### PR TITLE
fix(simd): remove unstable aarch64 prefetch (darwin CI fix)

### DIFF
--- a/crates/velesdb-core/src/simd_native.rs
+++ b/crates/velesdb-core/src/simd_native.rs
@@ -404,13 +404,8 @@ pub fn batch_dot_product_native(candidates: &[&[f32]], query: &[f32]) -> Vec<f32
             }
         }
 
-        #[cfg(target_arch = "aarch64")]
-        if i + 4 < candidates.len() {
-            unsafe {
-                use std::arch::aarch64::_prefetch;
-                _prefetch(candidates[i + 4].as_ptr().cast::<i8>(), 0, 3);
-            }
-        }
+        // Note: aarch64 prefetch requires unstable feature, skipped for now
+        // See: https://github.com/rust-lang/rust/issues/117217
 
         results.push(dot_product_native(candidate, query));
     }


### PR DESCRIPTION
Fixes CI failure on macOS ARM64 runners.

The \_prefetch\ intrinsic on aarch64 requires the unstable feature \stdarch_aarch64_prefetch\ (rust-lang/rust#117217).

Prefetch is now only enabled on x86_64 until the feature stabilizes.