### PR TITLE
ci: add skip-existing to PyPI publish action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -180,6 +180,7 @@ jobs:
         with:
           packages-dir: crates/velesdb-python/dist/
           password: ${{ secrets.PYPI_API_TOKEN }}
+          skip-existing: true
 
   # ===========================================================================
   # 5. Publish to npm (WASM + SDK)


### PR DESCRIPTION
Prevents PyPI publish failures when version already exists on PyPI.

This was causing the v1.1.1 release workflow to fail.