### PR TITLE
feat(velesql): Parser JOIN cross-store [EPIC-031/US-004]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5594,7 +5594,7 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-velesdb"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "parking_lot",
  "serde",
@@ -6517,7 +6517,7 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "velesdb-cli"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -6540,7 +6540,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-core"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -6578,7 +6578,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-migrate"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6606,7 +6606,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-mobile"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "serde_json",
  "tempfile",
@@ -6618,7 +6618,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-python"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "numpy",
  "pyo3",
@@ -6629,7 +6629,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-server"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -6653,7 +6653,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-wasm"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "half",
  "js-sys",

--- a/crates/velesdb-core/src/velesql/ast.rs
+++ b/crates/velesdb-core/src/velesql/ast.rs
@@ -18,6 +18,9 @@ pub struct SelectStatement {
     pub columns: SelectColumns,
     /// Collection name (FROM clause).
     pub from: String,
+    /// JOIN clauses for cross-store queries (EPIC-031 US-004).
+    #[serde(default)]
+    pub joins: Vec<JoinClause>,
     /// WHERE conditions (optional).
     pub where_clause: Option<Condition>,
     /// ORDER BY clause (optional).
@@ -28,6 +31,44 @@ pub struct SelectStatement {
     pub offset: Option<u64>,
     /// WITH clause for query-time configuration (optional).
     pub with_clause: Option<WithClause>,
+}
+
+/// JOIN clause for cross-store queries (EPIC-031 US-004).
+///
+/// Allows joining graph traversal results with ColumnStore data.
+///
+/// # Example
+/// ```sql
+/// MATCH (p:Product)
+/// JOIN prices AS pr ON pr.product_id = p.id
+/// WHERE pr.available = true
+/// ```
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct JoinClause {
+    /// Table/store name to join.
+    pub table: String,
+    /// Optional alias for the joined table.
+    pub alias: Option<String>,
+    /// Join condition (ON clause).
+    pub condition: JoinCondition,
+}
+
+/// Join condition specifying how to link tables.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct JoinCondition {
+    /// Left side of the join (table.column).
+    pub left: ColumnRef,
+    /// Right side of the join (match_var.property).
+    pub right: ColumnRef,
+}
+
+/// Column reference with optional table/alias prefix.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ColumnRef {
+    /// Optional table or alias prefix.
+    pub table: Option<String>,
+    /// Column or property name.
+    pub column: String,
 }
 
 /// ORDER BY item for sorting SELECT results.

--- a/crates/velesdb-core/src/velesql/ast_tests.rs
+++ b/crates/velesdb-core/src/velesql/ast_tests.rs
@@ -46,6 +46,7 @@ fn test_query_serialization() {
         select: SelectStatement {
             columns: SelectColumns::All,
             from: "documents".to_string(),
+            joins: vec![],
             where_clause: None,
             order_by: None,
             limit: Some(10),

--- a/crates/velesdb-core/src/velesql/explain_tests.rs
+++ b/crates/velesdb-core/src/velesql/explain_tests.rs
@@ -12,6 +12,7 @@ fn test_plan_from_simple_select() {
     let stmt = SelectStatement {
         columns: SelectColumns::All,
         from: "documents".to_string(),
+        joins: vec![],
         where_clause: None,
         order_by: None,
         limit: Some(10),
@@ -34,6 +35,7 @@ fn test_plan_from_vector_search() {
     let stmt = SelectStatement {
         columns: SelectColumns::All,
         from: "embeddings".to_string(),
+        joins: vec![],
         where_clause: Some(Condition::VectorSearch(VsCondition {
             vector: VectorExpr::Parameter("query".to_string()),
         })),
@@ -57,6 +59,7 @@ fn test_plan_with_filter() {
     let stmt = SelectStatement {
         columns: SelectColumns::All,
         from: "docs".to_string(),
+        joins: vec![],
         where_clause: Some(Condition::And(
             Box::new(Condition::VectorSearch(VsCondition {
                 vector: VectorExpr::Parameter("v".to_string()),
@@ -87,6 +90,7 @@ fn test_plan_to_tree_format() {
     let stmt = SelectStatement {
         columns: SelectColumns::All,
         from: "documents".to_string(),
+        joins: vec![],
         where_clause: Some(Condition::VectorSearch(VsCondition {
             vector: VectorExpr::Parameter("q".to_string()),
         })),
@@ -113,6 +117,7 @@ fn test_plan_to_json() {
     let stmt = SelectStatement {
         columns: SelectColumns::All,
         from: "test".to_string(),
+        joins: vec![],
         where_clause: None,
         order_by: None,
         limit: Some(5),
@@ -135,6 +140,7 @@ fn test_plan_with_offset() {
     let stmt = SelectStatement {
         columns: SelectColumns::All,
         from: "items".to_string(),
+        joins: vec![],
         where_clause: None,
         order_by: None,
         limit: Some(10),
@@ -157,6 +163,7 @@ fn test_filter_strategy_post_filter_default() {
     let stmt = SelectStatement {
         columns: SelectColumns::All,
         from: "docs".to_string(),
+        joins: vec![],
         where_clause: Some(Condition::And(
             Box::new(Condition::VectorSearch(VsCondition {
                 vector: VectorExpr::Parameter("v".to_string()),
@@ -203,6 +210,7 @@ fn test_plan_display_impl() {
     let stmt = SelectStatement {
         columns: SelectColumns::All,
         from: "test".to_string(),
+        joins: vec![],
         where_clause: None,
         order_by: None,
         limit: Some(5),

--- a/crates/velesdb-core/src/velesql/grammar.pest
+++ b/crates/velesdb-core/src/velesql/grammar.pest
@@ -8,11 +8,17 @@ COMMENT = _{ "--" ~ (!"\n" ~ ANY)* }
 // Main entry point
 query = { SOI ~ select_stmt ~ ";"? ~ EOI }
 
-// SELECT statement with optional WITH clause
+// SELECT statement with optional JOIN, WHERE, ORDER BY, LIMIT, OFFSET, WITH clauses
 select_stmt = { 
     ^"SELECT" ~ select_list ~ ^"FROM" ~ identifier ~
-    where_clause? ~ order_by_clause? ~ limit_clause? ~ offset_clause? ~ with_clause?
+    join_clause* ~ where_clause? ~ order_by_clause? ~ limit_clause? ~ offset_clause? ~ with_clause?
 }
+
+// JOIN clause for cross-store queries (EPIC-031 US-004)
+join_clause = { ^"JOIN" ~ identifier ~ alias_clause? ~ ^"ON" ~ join_condition }
+alias_clause = { ^"AS" ~ identifier }
+join_condition = { column_ref ~ "=" ~ column_ref }
+column_ref = @{ identifier ~ "." ~ identifier }
 
 // ORDER BY clause
 order_by_clause = { ^"ORDER" ~ ^"BY" ~ order_by_item ~ ("," ~ order_by_item)* }


### PR DESCRIPTION
## Summary

Implements JOIN clause parsing for cross-store queries (ColumnStore + Graph).

### Changes
- **AST**: Add \JoinClause\, \JoinCondition\, \ColumnRef\ structures
- **Grammar**: Add \join_clause\, \lias_clause\, \join_condition\, \column_ref\ rules
- **Parser**: Implement \parse_join_clause\, \parse_join_condition\, \parse_column_ref\
- **SelectStatement**: Add \joins: Vec<JoinClause>\ field

### Syntax Supported
\\\sql
-- Simple JOIN
SELECT * FROM products JOIN prices ON prices.product_id = products.id

-- With alias
SELECT * FROM products JOIN prices AS pr ON pr.product_id = products.id

-- Multiple JOINs
SELECT * FROM trips 
JOIN prices ON prices.trip_id = trips.id 
JOIN availability ON availability.trip_id = trips.id
\\\

### Tests
- 5 new JOIN parsing tests
- 1400+ total tests pass
- Clippy clean

### Next Steps
- US-005: Executor JOIN adaptive batch
- US-006: Filter pushdown auto
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/84">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
