### PR TITLE
fix(safety): Eliminate unwrap() in production code [EPIC-035/US-001]

### DIFF
--- a/crates/velesdb-core/src/velesql/parser/select.rs
+++ b/crates/velesdb-core/src/velesql/parser/select.rs
@@ -267,8 +267,9 @@ impl Parser {
             ));
         }
 
-        let right = refs.pop().unwrap();
-        let left = refs.pop().unwrap();
+        // SAFETY: refs.len() == 2 is validated above, pop() cannot fail
+        let right = refs.pop().expect("right ref validated by len check");
+        let left = refs.pop().expect("left ref validated by len check");
 
         Ok(JoinCondition { left, right })
     }


### PR DESCRIPTION
## Summary

Eliminates unwrap() calls in production (non-test) code as part of EPIC-035 safety audit.

## Changes

- File: crates/velesdb-core/src/velesql/parser/select.rs:270-271
- Fix: Replace unwrap() with expect() + safety comment
- The code was already safe (guarded by refs.len() == 2 check), but now has explicit documentation

## Validation

- cargo clippy with -W clippy::unwrap_used: 0 warnings (was 2)
- cargo test: 1492 tests passing

## Related

- EPIC-035: Fou Furieux Audit
- US-001: Eliminate unwrap() in production
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/98">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
