### PR TITLE
feat(examples): Add GraphRAG examples for LangChain and LlamaIndex [EPIC-013/US-006]

### DIFF
--- a/examples/python/graphrag_langchain.py
+++ b/examples/python/graphrag_langchain.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""
+VelesDB GraphRAG Example with LangChain
+
+Demonstrates the "Seed + Expand" pattern for Graph-enhanced RAG:
+1. Vector search to find initial seed documents
+2. Graph traversal to expand context to related documents
+3. Combined context for LLM generation
+
+Requirements:
+    pip install langchain-velesdb langchain-openai
+
+Usage:
+    export OPENAI_API_KEY=your-key
+    python graphrag_langchain.py
+"""
+
+import os
+from typing import List
+
+# LangChain imports
+from langchain_core.documents import Document
+from langchain_core.prompts import ChatPromptTemplate
+from langchain_openai import ChatOpenAI, OpenAIEmbeddings
+
+# VelesDB LangChain integration
+from langchain_velesdb import VelesDBVectorStore, GraphRetriever
+
+
+def create_sample_knowledge_base() -> VelesDBVectorStore:
+    """Create a sample knowledge base with documents and relations."""
+    
+    embeddings = OpenAIEmbeddings()
+    
+    # Initialize VelesDB with local storage
+    vectorstore = VelesDBVectorStore.from_texts(
+        texts=[
+            "Machine learning is a subset of artificial intelligence.",
+            "Deep learning uses neural networks with many layers.",
+            "Natural language processing enables computers to understand text.",
+            "Transformers revolutionized NLP with attention mechanisms.",
+            "GPT models are based on the transformer architecture.",
+            "BERT is a bidirectional transformer for language understanding.",
+            "Vector databases store embeddings for similarity search.",
+            "VelesDB combines vector search with graph traversal.",
+        ],
+        embedding=embeddings,
+        metadatas=[
+            {"id": 1, "topic": "ML", "category": "fundamentals"},
+            {"id": 2, "topic": "DL", "category": "fundamentals"},
+            {"id": 3, "topic": "NLP", "category": "fundamentals"},
+            {"id": 4, "topic": "Transformers", "category": "architecture"},
+            {"id": 5, "topic": "GPT", "category": "models"},
+            {"id": 6, "topic": "BERT", "category": "models"},
+            {"id": 7, "topic": "VectorDB", "category": "infrastructure"},
+            {"id": 8, "topic": "VelesDB", "category": "infrastructure"},
+        ],
+        path="./graphrag_demo",
+        collection_name="knowledge_base",
+    )
+    
+    # Add graph edges (concept relationships)
+    collection = vectorstore._get_collection()
+    
+    # ML → DL (ML includes DL)
+    collection.add_edge(id=1, source=1, target=2, label="INCLUDES")
+    # ML → NLP (ML includes NLP)
+    collection.add_edge(id=2, source=1, target=3, label="INCLUDES")
+    # NLP → Transformers (NLP uses Transformers)
+    collection.add_edge(id=3, source=3, target=4, label="USES")
+    # Transformers → GPT (Transformers basis for GPT)
+    collection.add_edge(id=4, source=4, target=5, label="BASIS_FOR")
+    # Transformers → BERT (Transformers basis for BERT)
+    collection.add_edge(id=5, source=4, target=6, label="BASIS_FOR")
+    # VelesDB → VectorDB (VelesDB is a VectorDB)
+    collection.add_edge(id=6, source=8, target=7, label="IS_A")
+    
+    print("✅ Knowledge base created with 8 documents and 6 relationships")
+    return vectorstore
+
+
+def graphrag_query(
+    vectorstore: VelesDBVectorStore,
+    query: str,
+    use_graph: bool = True,
+) -> str:
+    """
+    Execute a GraphRAG query.
+    
+    Args:
+        vectorstore: VelesDB vector store with graph layer
+        query: User question
+        use_graph: Whether to use graph expansion (True) or vector-only (False)
+    
+    Returns:
+        LLM-generated answer
+    """
+    
+    # Create retriever (with or without graph expansion)
+    if use_graph:
+        retriever = GraphRetriever(
+            vectorstore=vectorstore,
+            seed_k=2,      # Initial vector search results
+            expand_k=5,    # Max results after graph expansion
+            max_depth=2,   # Graph traversal depth
+        )
+        mode = "GraphRAG (vector + graph)"
+    else:
+        retriever = vectorstore.as_retriever(search_kwargs={"k": 5})
+        mode = "Standard RAG (vector only)"
+    
+    # Retrieve relevant documents
+    docs: List[Document] = retriever.invoke(query)
+    
+    print(f"\n📚 Retrieved {len(docs)} documents using {mode}:")
+    for i, doc in enumerate(docs):
+        depth = doc.metadata.get("graph_depth", 0)
+        marker = "🎯" if depth == 0 else "🔗"
+        print(f"  {marker} [{i+1}] {doc.page_content[:60]}...")
+    
+    # Create prompt with retrieved context
+    context = "\n".join([doc.page_content for doc in docs])
+    
+    prompt = ChatPromptTemplate.from_messages([
+        ("system", "You are a helpful AI assistant. Answer based on the context provided."),
+        ("human", "Context:\n{context}\n\nQuestion: {question}\n\nAnswer:"),
+    ])
+    
+    # Generate answer with LLM
+    llm = ChatOpenAI(model="gpt-4o-mini", temperature=0)
+    chain = prompt | llm
+    
+    response = chain.invoke({"context": context, "question": query})
+    return response.content
+
+
+def main():
+    """Run GraphRAG demonstration."""
+    
+    print("=" * 60)
+    print("VelesDB GraphRAG Demo")
+    print("=" * 60)
+    
+    # Check for API key
+    if not os.getenv("OPENAI_API_KEY"):
+        print("⚠️  Set OPENAI_API_KEY environment variable")
+        print("   For demo without LLM, the retrieval still works.")
+        return
+    
+    # Create knowledge base
+    vectorstore = create_sample_knowledge_base()
+    
+    # Query examples
+    queries = [
+        "What is the relationship between transformers and GPT?",
+        "How does VelesDB differ from other vector databases?",
+    ]
+    
+    for query in queries:
+        print(f"\n{'=' * 60}")
+        print(f"❓ Question: {query}")
+        print("=" * 60)
+        
+        # Compare GraphRAG vs Standard RAG
+        print("\n--- GraphRAG Mode ---")
+        answer_graph = graphrag_query(vectorstore, query, use_graph=True)
+        print(f"\n💡 Answer: {answer_graph}")
+        
+        print("\n--- Standard RAG Mode ---")
+        answer_vector = graphrag_query(vectorstore, query, use_graph=False)
+        print(f"\n💡 Answer: {answer_vector}")
+    
+    print("\n" + "=" * 60)
+    print("✅ Demo complete!")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/python/graphrag_llamaindex.py
+++ b/examples/python/graphrag_llamaindex.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""
+VelesDB GraphRAG Example with LlamaIndex
+
+Demonstrates Graph-enhanced RAG using LlamaIndex's query engine:
+1. Build a knowledge graph from documents
+2. Use GraphRetriever for context expansion
+3. Generate answers with expanded context
+
+Requirements:
+    pip install llama-index-vector-stores-velesdb llama-index-llms-openai
+
+Usage:
+    export OPENAI_API_KEY=your-key
+    python graphrag_llamaindex.py
+"""
+
+import os
+from typing import List
+
+# LlamaIndex imports
+from llama_index.core import VectorStoreIndex, Settings
+from llama_index.core.schema import TextNode, NodeRelationship, RelatedNodeInfo
+from llama_index.llms.openai import OpenAI
+from llama_index.embeddings.openai import OpenAIEmbedding
+
+# VelesDB LlamaIndex integration
+from llamaindex_velesdb import VelesDBVectorStore, GraphLoader, GraphRetriever
+
+
+def create_knowledge_graph() -> tuple[VelesDBVectorStore, VectorStoreIndex]:
+    """Create a knowledge graph with documents and relationships."""
+    
+    # Configure LlamaIndex settings
+    Settings.llm = OpenAI(model="gpt-4o-mini", temperature=0)
+    Settings.embed_model = OpenAIEmbedding()
+    
+    # Create VelesDB vector store
+    vector_store = VelesDBVectorStore(
+        path="./graphrag_llamaindex_demo",
+        collection_name="research_papers",
+        dimension=1536,
+    )
+    
+    # Create sample research paper nodes
+    nodes = [
+        TextNode(
+            text="Attention Is All You Need introduced the Transformer architecture, "
+                 "replacing recurrence with self-attention mechanisms.",
+            id_="paper_1",
+            metadata={"title": "Attention Is All You Need", "year": 2017, "topic": "transformers"},
+        ),
+        TextNode(
+            text="BERT: Pre-training of Deep Bidirectional Transformers showed that "
+                 "bidirectional pre-training improves language understanding.",
+            id_="paper_2",
+            metadata={"title": "BERT", "year": 2018, "topic": "nlp"},
+        ),
+        TextNode(
+            text="GPT-3: Language Models are Few-Shot Learners demonstrated that "
+                 "scaling up language models enables few-shot learning.",
+            id_="paper_3",
+            metadata={"title": "GPT-3", "year": 2020, "topic": "llm"},
+        ),
+        TextNode(
+            text="Retrieval-Augmented Generation combines retrieval with generation "
+                 "to reduce hallucinations and improve factuality.",
+            id_="paper_4",
+            metadata={"title": "RAG", "year": 2020, "topic": "rag"},
+        ),
+        TextNode(
+            text="GraphRAG: Unlocking LLM discovery on narrative private data uses "
+                 "knowledge graphs to enhance retrieval for complex queries.",
+            id_="paper_5",
+            metadata={"title": "GraphRAG", "year": 2024, "topic": "graphrag"},
+        ),
+    ]
+    
+    # Add relationships between papers (citations)
+    nodes[1].relationships[NodeRelationship.PARENT] = RelatedNodeInfo(
+        node_id="paper_1", metadata={"relation": "cites"}
+    )
+    nodes[2].relationships[NodeRelationship.PARENT] = RelatedNodeInfo(
+        node_id="paper_1", metadata={"relation": "cites"}
+    )
+    nodes[3].relationships[NodeRelationship.PARENT] = RelatedNodeInfo(
+        node_id="paper_2", metadata={"relation": "extends"}
+    )
+    nodes[4].relationships[NodeRelationship.PARENT] = RelatedNodeInfo(
+        node_id="paper_4", metadata={"relation": "extends"}
+    )
+    
+    # Build index from nodes
+    index = VectorStoreIndex.from_vector_store(vector_store)
+    
+    # Add nodes to index
+    for node in nodes:
+        vector_store.add([node])
+    
+    # Load graph relationships
+    loader = GraphLoader(vector_store)
+    
+    # Add edges based on citations
+    loader.add_edge(id=1, source=2, target=1, label="CITES")  # BERT cites Transformer
+    loader.add_edge(id=2, source=3, target=1, label="CITES")  # GPT-3 cites Transformer
+    loader.add_edge(id=3, source=4, target=2, label="EXTENDS")  # RAG extends BERT ideas
+    loader.add_edge(id=4, source=5, target=4, label="EXTENDS")  # GraphRAG extends RAG
+    
+    print("✅ Knowledge graph created: 5 papers, 4 citation relationships")
+    return vector_store, index
+
+
+def query_with_graph_expansion(
+    index: VectorStoreIndex,
+    vector_store: VelesDBVectorStore,
+    query: str,
+) -> str:
+    """Query using GraphRetriever for context expansion."""
+    
+    # Create graph-enhanced retriever
+    retriever = GraphRetriever(
+        index=index,
+        server_url="http://localhost:8080",  # VelesDB server for graph ops
+        seed_k=2,
+        expand_k=4,
+        max_depth=2,
+        low_latency=False,  # Enable graph expansion
+    )
+    
+    # Retrieve with graph expansion
+    nodes = retriever.retrieve(query)
+    
+    print(f"\n📚 Retrieved {len(nodes)} nodes:")
+    for i, node_with_score in enumerate(nodes):
+        node = node_with_score.node
+        depth = node.metadata.get("graph_depth", 0)
+        mode = node.metadata.get("retrieval_mode", "unknown")
+        marker = "🎯" if depth == 0 else "🔗"
+        title = node.metadata.get("title", "Unknown")
+        print(f"  {marker} [{i+1}] {title} (depth={depth}, mode={mode})")
+    
+    # Create query engine and generate answer
+    query_engine = index.as_query_engine(
+        retriever=retriever,
+        response_mode="compact",
+    )
+    
+    response = query_engine.query(query)
+    return str(response)
+
+
+def query_vector_only(index: VectorStoreIndex, query: str) -> str:
+    """Query using standard vector search only."""
+    
+    query_engine = index.as_query_engine(
+        similarity_top_k=4,
+        response_mode="compact",
+    )
+    
+    response = query_engine.query(query)
+    return str(response)
+
+
+def main():
+    """Run LlamaIndex GraphRAG demonstration."""
+    
+    print("=" * 60)
+    print("VelesDB GraphRAG Demo (LlamaIndex)")
+    print("=" * 60)
+    
+    # Check for API key
+    if not os.getenv("OPENAI_API_KEY"):
+        print("⚠️  Set OPENAI_API_KEY environment variable")
+        return
+    
+    # Create knowledge graph
+    vector_store, index = create_knowledge_graph()
+    
+    # Example queries
+    queries = [
+        "What papers built upon the Transformer architecture?",
+        "How does GraphRAG improve upon traditional RAG?",
+    ]
+    
+    for query in queries:
+        print(f"\n{'=' * 60}")
+        print(f"❓ Question: {query}")
+        print("=" * 60)
+        
+        print("\n--- GraphRAG Mode (with citation graph) ---")
+        try:
+            answer = query_with_graph_expansion(index, vector_store, query)
+            print(f"\n💡 Answer: {answer}")
+        except Exception as e:
+            print(f"⚠️  Graph expansion requires VelesDB server: {e}")
+            print("   Falling back to vector-only mode...")
+            answer = query_vector_only(index, query)
+            print(f"\n💡 Answer: {answer}")
+    
+    print("\n" + "=" * 60)
+    print("✅ Demo complete!")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds production-ready GraphRAG examples demonstrating the 'Seed + Expand' pattern.

## Files Added

- xamples/python/graphrag_langchain.py - LangChain integration demo
- xamples/python/graphrag_llamaindex.py - LlamaIndex integration demo

## Features Demonstrated

- Knowledge graph construction from documents
- Graph-enhanced retrieval vs vector-only comparison
- Citation graph traversal
- LLM answer generation with expanded context

## EPIC-013 Status

This completes EPIC-013: LangChain & LlamaIndex Integrations (7/7 US = 100%)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/102">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
