### PR TITLE
feat(wasm): Playwright E2E browser tests [EPIC-011/US-004]

### DIFF
--- a/crates/velesdb-wasm/e2e/.gitignore
+++ b/crates/velesdb-wasm/e2e/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+pkg/
+test-results/
+playwright-report/
+playwright/.cache/

--- a/crates/velesdb-wasm/e2e/README.md
+++ b/crates/velesdb-wasm/e2e/README.md
@@ -1,0 +1,73 @@
+# VelesDB WASM E2E Browser Tests
+
+End-to-end browser tests for VelesDB WASM using Playwright.
+
+## Prerequisites
+
+- Node.js 18+
+- wasm-pack (`cargo install wasm-pack`)
+
+## Setup
+
+```bash
+# Install dependencies
+npm install
+
+# Install Playwright browsers
+npx playwright install
+
+# Build WASM module
+npm run build:wasm
+```
+
+## Running Tests
+
+```bash
+# Run all tests (headless)
+npm test
+
+# Run with browser visible
+npm run test:headed
+
+# Run with Playwright UI
+npm run test:ui
+```
+
+## Test Coverage
+
+| Test | Description |
+|------|-------------|
+| Load WASM module | Verifies WASM initializes correctly |
+| Create VectorStore | Tests cosine, euclidean, dot metrics |
+| Insert & Search | Vector CRUD operations |
+| Batch insert | Performance with 100 vectors |
+| Error handling | Invalid metric, dimension mismatch |
+| Remove/Clear | Vector deletion operations |
+| Large vectors | 1536-dim (OpenAI embeddings) |
+
+## CI Integration
+
+Add to `.github/workflows/ci.yml`:
+
+```yaml
+wasm-e2e:
+  runs-on: ubuntu-latest
+  steps:
+    - uses: actions/checkout@v4
+    - uses: dtolnay/rust-toolchain@stable
+    - uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+    - name: Install wasm-pack
+      run: cargo install wasm-pack
+    - name: Build WASM
+      run: |
+        cd crates/velesdb-wasm
+        wasm-pack build --target web --out-dir e2e/pkg
+    - name: Install & Test
+      run: |
+        cd crates/velesdb-wasm/e2e
+        npm ci
+        npx playwright install --with-deps chromium
+        npm test -- --project=chromium
+```

--- a/crates/velesdb-wasm/e2e/index.html
+++ b/crates/velesdb-wasm/e2e/index.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>VelesDB WASM E2E Tests</title>
+    <style>
+        body { font-family: system-ui, sans-serif; padding: 20px; }
+        #status { padding: 10px; margin: 10px 0; border-radius: 4px; }
+        .success { background: #d4edda; color: #155724; }
+        .error { background: #f8d7da; color: #721c24; }
+        .pending { background: #fff3cd; color: #856404; }
+        pre { background: #f4f4f4; padding: 10px; overflow-x: auto; }
+    </style>
+</head>
+<body>
+    <h1>VelesDB WASM E2E Tests</h1>
+    <div id="status" class="pending">Loading WASM module...</div>
+    <div id="results"></div>
+
+    <script type="module">
+        import init, { VectorStore } from './pkg/velesdb_wasm.js';
+
+        // Expose to window for Playwright tests
+        window.VelesDB = { ready: false, VectorStore: null, error: null };
+
+        async function initWasm() {
+            const status = document.getElementById('status');
+            const results = document.getElementById('results');
+
+            try {
+                await init();
+                window.VelesDB.VectorStore = VectorStore;
+                window.VelesDB.ready = true;
+                status.className = 'success';
+                status.textContent = 'WASM module loaded successfully!';
+
+                // Run basic smoke test
+                const store = VectorStore.new(4, 'cosine');
+                store.insert(1, new Float32Array([1.0, 0.0, 0.0, 0.0]));
+                store.insert(2, new Float32Array([0.9, 0.1, 0.0, 0.0]));
+                store.insert(3, new Float32Array([0.0, 1.0, 0.0, 0.0]));
+
+                const searchResults = store.search(new Float32Array([1.0, 0.0, 0.0, 0.0]), 2);
+                
+                results.innerHTML = `
+                    <h2>Smoke Test Results</h2>
+                    <p><strong>Store dimension:</strong> ${store.dimension()}</p>
+                    <p><strong>Store size:</strong> ${store.len()}</p>
+                    <p><strong>Search results:</strong></p>
+                    <pre>${JSON.stringify(searchResults, null, 2)}</pre>
+                `;
+            } catch (e) {
+                window.VelesDB.error = e.message;
+                status.className = 'error';
+                status.textContent = `Error: ${e.message}`;
+                results.innerHTML = `<pre>${e.stack}</pre>`;
+            }
+        }
+
+        initWasm();
+    </script>
+</body>
+</html>

--- a/crates/velesdb-wasm/e2e/package.json
+++ b/crates/velesdb-wasm/e2e/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "velesdb-wasm-e2e",
+  "version": "1.0.0",
+  "description": "E2E browser tests for VelesDB WASM",
+  "private": true,
+  "scripts": {
+    "build:wasm": "cd .. && wasm-pack build --target web --out-dir e2e/pkg",
+    "test": "npx playwright test",
+    "test:headed": "npx playwright test --headed",
+    "test:ui": "npx playwright test --ui"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.40.0"
+  }
+}

--- a/crates/velesdb-wasm/e2e/playwright.config.ts
+++ b/crates/velesdb-wasm/e2e/playwright.config.ts
@@ -1,0 +1,33 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: 'html',
+  use: {
+    baseURL: 'http://localhost:8080',
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+    {
+      name: 'firefox',
+      use: { ...devices['Desktop Firefox'] },
+    },
+    {
+      name: 'webkit',
+      use: { ...devices['Desktop Safari'] },
+    },
+  ],
+  webServer: {
+    command: 'npx serve . -l 8080',
+    url: 'http://localhost:8080',
+    reuseExistingServer: !process.env.CI,
+  },
+});

--- a/crates/velesdb-wasm/e2e/tests/vectorstore.spec.ts
+++ b/crates/velesdb-wasm/e2e/tests/vectorstore.spec.ts
@@ -1,0 +1,188 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('VelesDB WASM VectorStore', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    // Wait for WASM to load
+    await page.waitForFunction(() => window['VelesDB']?.ready === true, { timeout: 10000 });
+  });
+
+  test('should load WASM module successfully', async ({ page }) => {
+    const ready = await page.evaluate(() => window['VelesDB'].ready);
+    expect(ready).toBe(true);
+  });
+
+  test('should create VectorStore with cosine metric', async ({ page }) => {
+    const result = await page.evaluate(() => {
+      const { VectorStore } = window['VelesDB'];
+      const store = VectorStore.new(128, 'cosine');
+      return {
+        dimension: store.dimension(),
+        len: store.len(),
+        isEmpty: store.is_empty(),
+      };
+    });
+
+    expect(result.dimension).toBe(128);
+    expect(result.len).toBe(0);
+    expect(result.isEmpty).toBe(true);
+  });
+
+  test('should create VectorStore with euclidean metric', async ({ page }) => {
+    const result = await page.evaluate(() => {
+      const { VectorStore } = window['VelesDB'];
+      const store = VectorStore.new(768, 'euclidean');
+      return { dimension: store.dimension() };
+    });
+
+    expect(result.dimension).toBe(768);
+  });
+
+  test('should insert and search vectors', async ({ page }) => {
+    const results = await page.evaluate(() => {
+      const { VectorStore } = window['VelesDB'];
+      const store = VectorStore.new(4, 'cosine');
+
+      // Insert vectors
+      store.insert(1, new Float32Array([1.0, 0.0, 0.0, 0.0]));
+      store.insert(2, new Float32Array([0.9, 0.1, 0.0, 0.0]));
+      store.insert(3, new Float32Array([0.5, 0.5, 0.0, 0.0]));
+      store.insert(4, new Float32Array([0.0, 1.0, 0.0, 0.0]));
+
+      // Search
+      const query = new Float32Array([1.0, 0.0, 0.0, 0.0]);
+      const searchResults = store.search(query, 3);
+
+      return {
+        storeLen: store.len(),
+        results: searchResults,
+      };
+    });
+
+    expect(results.storeLen).toBe(4);
+    expect(results.results).toHaveLength(3);
+    // First result should be exact match (id=1)
+    expect(results.results[0].id).toBe(1);
+  });
+
+  test('should handle batch insert', async ({ page }) => {
+    const result = await page.evaluate(() => {
+      const { VectorStore } = window['VelesDB'];
+      const store = VectorStore.new(4, 'cosine');
+
+      // Batch insert 100 vectors
+      for (let i = 0; i < 100; i++) {
+        store.insert(i, new Float32Array([i / 100, 0.0, 0.0, 0.0]));
+      }
+
+      return { len: store.len() };
+    });
+
+    expect(result.len).toBe(100);
+  });
+
+  test('should reject invalid metric', async ({ page }) => {
+    const error = await page.evaluate(() => {
+      const { VectorStore } = window['VelesDB'];
+      try {
+        VectorStore.new(128, 'invalid_metric');
+        return null;
+      } catch (e) {
+        return e.message;
+      }
+    });
+
+    expect(error).toBeTruthy();
+    expect(error).toContain('metric');
+  });
+
+  test('should reject dimension mismatch on insert', async ({ page }) => {
+    const error = await page.evaluate(() => {
+      const { VectorStore } = window['VelesDB'];
+      const store = VectorStore.new(4, 'cosine');
+      try {
+        store.insert(1, new Float32Array([1.0, 0.0, 0.0])); // Wrong dimension
+        return null;
+      } catch (e) {
+        return e.message;
+      }
+    });
+
+    expect(error).toBeTruthy();
+  });
+
+  test('should remove vectors', async ({ page }) => {
+    const result = await page.evaluate(() => {
+      const { VectorStore } = window['VelesDB'];
+      const store = VectorStore.new(4, 'cosine');
+
+      store.insert(1, new Float32Array([1.0, 0.0, 0.0, 0.0]));
+      store.insert(2, new Float32Array([0.0, 1.0, 0.0, 0.0]));
+
+      const lenBefore = store.len();
+      store.remove(1);
+      const lenAfter = store.len();
+
+      return { lenBefore, lenAfter };
+    });
+
+    expect(result.lenBefore).toBe(2);
+    expect(result.lenAfter).toBe(1);
+  });
+
+  test('should clear all vectors', async ({ page }) => {
+    const result = await page.evaluate(() => {
+      const { VectorStore } = window['VelesDB'];
+      const store = VectorStore.new(4, 'cosine');
+
+      for (let i = 0; i < 10; i++) {
+        store.insert(i, new Float32Array([i, 0, 0, 0]));
+      }
+
+      const lenBefore = store.len();
+      store.clear();
+      const lenAfter = store.len();
+
+      return { lenBefore, lenAfter };
+    });
+
+    expect(result.lenBefore).toBe(10);
+    expect(result.lenAfter).toBe(0);
+  });
+
+  test('should support dot product metric', async ({ page }) => {
+    const results = await page.evaluate(() => {
+      const { VectorStore } = window['VelesDB'];
+      const store = VectorStore.new(4, 'dot');
+
+      store.insert(1, new Float32Array([1.0, 0.0, 0.0, 0.0]));
+      store.insert(2, new Float32Array([0.5, 0.5, 0.0, 0.0]));
+
+      return store.search(new Float32Array([1.0, 0.0, 0.0, 0.0]), 2);
+    });
+
+    expect(results).toHaveLength(2);
+  });
+
+  test('should handle large vectors (1536 dim - OpenAI embeddings)', async ({ page }) => {
+    const result = await page.evaluate(() => {
+      const { VectorStore } = window['VelesDB'];
+      const store = VectorStore.new(1536, 'cosine');
+
+      // Create random 1536-dim vectors
+      const vec1 = new Float32Array(1536).fill(0.1);
+      const vec2 = new Float32Array(1536).fill(0.2);
+
+      store.insert(1, vec1);
+      store.insert(2, vec2);
+
+      return {
+        dimension: store.dimension(),
+        len: store.len(),
+      };
+    });
+
+    expect(result.dimension).toBe(1536);
+    expect(result.len).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary

Adds Playwright E2E browser tests for VelesDB WASM module.

### Files Added

- \2e/package.json\ - Node.js project with Playwright dependency
- \2e/playwright.config.ts\ - Multi-browser config (Chromium, Firefox, WebKit)
- \2e/index.html\ - Test page that loads WASM module
- \2e/tests/vectorstore.spec.ts\ - 11 E2E test cases
- \2e/README.md\ - Setup and CI integration guide

### Test Coverage

| Test | Description |
|------|-------------|
| Load WASM module | Verifies WASM initializes correctly |
| Create VectorStore (cosine) | Basic store creation |
| Create VectorStore (euclidean) | Alternative metric |
| Insert & Search | Vector CRUD + search |
| Batch insert | 100 vectors performance |
| Invalid metric | Error handling |
| Dimension mismatch | Error handling |
| Remove vectors | Deletion operation |
| Clear all | Reset operation |
| Dot product metric | Alternative metric |
| Large vectors (1536-dim) | OpenAI embeddings size |

### Running Tests

\\\ash
cd crates/velesdb-wasm/e2e
npm install
npm run build:wasm
npx playwright install
npm test
\\\

### CI Integration

See README for GitHub Actions workflow snippet.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/104">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
