### PR TITLE
fix(deps): align thiserror to v2 [SEC-1]

### DIFF
--- a/demos/tauri-rag-app/src-tauri/Cargo.toml
+++ b/demos/tauri-rag-app/src-tauri/Cargo.toml
@@ -15,7 +15,7 @@ tauri-plugin-shell = "2"
 tauri-plugin-velesdb = { path = "../../../crates/tauri-plugin-velesdb" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-thiserror = "1"
+thiserror = "2"
 # ML embeddings for semantic search
 fastembed = "4"
 tokio = { version = "1", features = ["sync"] }


### PR DESCRIPTION
## SEC-1: Dependency Alignment

Aligns \	hiserror\ version across all crates to v2.0.

### Changes
- \demos/tauri-rag-app/src-tauri/Cargo.toml\: thiserror 1 → 2

### Risk Mitigated
- ABI mismatch between thiserror 1.0 and 2.0 trait implementations
- Duplicate crate in binary

Ref: .audit/2026-01-25-audit.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/105">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
