### PR TITLE
feat(velesql): USING FUSION hybrid search [EPIC-040/US-005]

### DIFF
--- a/crates/velesdb-core/src/velesql/ast.rs
+++ b/crates/velesdb-core/src/velesql/ast.rs
@@ -37,6 +37,9 @@ pub struct SelectStatement {
     /// HAVING clause for filtering groups (optional).
     #[serde(default)]
     pub having: Option<HavingClause>,
+    /// USING FUSION clause for hybrid search (EPIC-040 US-005).
+    #[serde(default)]
+    pub fusion_clause: Option<FusionClause>,
 }
 
 /// JOIN clause for cross-store queries (EPIC-031 US-004).
@@ -242,6 +245,52 @@ impl WithValue {
         match self {
             Self::Boolean(b) => Some(*b),
             _ => None,
+        }
+    }
+}
+
+/// Fusion strategy type for hybrid search (EPIC-040 US-005).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub enum FusionStrategyType {
+    /// Reciprocal Rank Fusion (default) - position-based fusion.
+    #[default]
+    Rrf,
+    /// Weighted sum of normalized scores.
+    Weighted,
+    /// Take maximum score from either source.
+    Maximum,
+}
+
+/// USING FUSION clause for hybrid vector+graph search (EPIC-040 US-005).
+///
+/// Combines results from NEAR (vector) and MATCH (graph) queries.
+///
+/// # Example
+/// ```sql
+/// SELECT * FROM docs
+/// NEAR([0.1, 0.2], 10)
+/// MATCH (d)-[:CITES]->(ref)
+/// USING FUSION(strategy = 'rrf', k = 60)
+/// ```
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct FusionClause {
+    /// Fusion strategy (rrf, weighted, maximum).
+    pub strategy: FusionStrategyType,
+    /// RRF k parameter (default 60).
+    pub k: Option<u32>,
+    /// Vector weight for weighted fusion (0.0-1.0).
+    pub vector_weight: Option<f64>,
+    /// Graph weight for weighted fusion (0.0-1.0).
+    pub graph_weight: Option<f64>,
+}
+
+impl Default for FusionClause {
+    fn default() -> Self {
+        Self {
+            strategy: FusionStrategyType::Rrf,
+            k: Some(60),
+            vector_weight: None,
+            graph_weight: None,
         }
     }
 }

--- a/crates/velesdb-core/src/velesql/ast_tests.rs
+++ b/crates/velesdb-core/src/velesql/ast_tests.rs
@@ -54,6 +54,7 @@ fn test_query_serialization() {
             with_clause: None,
             group_by: None,
             having: None,
+            fusion_clause: None,
         },
     };
 

--- a/crates/velesdb-core/src/velesql/explain_tests.rs
+++ b/crates/velesdb-core/src/velesql/explain_tests.rs
@@ -20,6 +20,7 @@ fn test_plan_from_simple_select() {
         with_clause: None,
         group_by: None,
         having: None,
+        fusion_clause: None,
     };
 
     // Act
@@ -47,6 +48,7 @@ fn test_plan_from_vector_search() {
         with_clause: None,
         group_by: None,
         having: None,
+        fusion_clause: None,
     };
 
     // Act
@@ -80,6 +82,7 @@ fn test_plan_with_filter() {
         with_clause: None,
         group_by: None,
         having: None,
+        fusion_clause: None,
     };
 
     // Act
@@ -106,6 +109,7 @@ fn test_plan_to_tree_format() {
         with_clause: None,
         group_by: None,
         having: None,
+        fusion_clause: None,
     };
 
     // Act
@@ -133,6 +137,7 @@ fn test_plan_to_json() {
         with_clause: None,
         group_by: None,
         having: None,
+        fusion_clause: None,
     };
 
     // Act
@@ -158,6 +163,7 @@ fn test_plan_with_offset() {
         with_clause: None,
         group_by: None,
         having: None,
+        fusion_clause: None,
     };
 
     // Act
@@ -192,6 +198,7 @@ fn test_filter_strategy_post_filter_default() {
         with_clause: None,
         group_by: None,
         having: None,
+        fusion_clause: None,
     };
 
     // Act
@@ -232,6 +239,7 @@ fn test_plan_display_impl() {
         with_clause: None,
         group_by: None,
         having: None,
+        fusion_clause: None,
     };
 
     // Act

--- a/crates/velesdb-core/src/velesql/fusion_clause_tests.rs
+++ b/crates/velesdb-core/src/velesql/fusion_clause_tests.rs
@@ -1,0 +1,112 @@
+//! Tests for USING FUSION clause (EPIC-040 US-005).
+//!
+//! Covers:
+//! - USING FUSION parsing with default RRF
+//! - USING FUSION with explicit strategy (rrf, weighted, maximum)
+//! - USING FUSION with parameters (k, weights)
+
+use crate::velesql::Parser;
+
+#[test]
+fn test_using_fusion_default() {
+    // USING FUSION without parameters - default RRF strategy
+    let sql = "SELECT * FROM docs USING FUSION";
+    let result = Parser::parse(sql);
+    assert!(
+        result.is_ok(),
+        "Failed to parse USING FUSION: {:?}",
+        result.err()
+    );
+
+    let query = result.unwrap();
+    let fusion = query
+        .select
+        .fusion_clause
+        .as_ref()
+        .expect("FUSION clause should be present");
+
+    // Default strategy is RRF
+    assert_eq!(fusion.strategy, crate::velesql::FusionStrategyType::Rrf);
+}
+
+#[test]
+fn test_using_fusion_rrf_with_k() {
+    let sql = "SELECT * FROM docs USING FUSION(strategy = 'rrf', k = 30)";
+    let result = Parser::parse(sql);
+    assert!(
+        result.is_ok(),
+        "Failed to parse FUSION with k: {:?}",
+        result.err()
+    );
+
+    let query = result.unwrap();
+    let fusion = query
+        .select
+        .fusion_clause
+        .as_ref()
+        .expect("FUSION clause should be present");
+
+    assert_eq!(fusion.strategy, crate::velesql::FusionStrategyType::Rrf);
+    assert_eq!(fusion.k, Some(30));
+}
+
+#[test]
+fn test_using_fusion_weighted() {
+    let sql = "SELECT * FROM docs USING FUSION(strategy = 'weighted', vector_weight = 0.7, graph_weight = 0.3)";
+    let result = Parser::parse(sql);
+    assert!(
+        result.is_ok(),
+        "Failed to parse FUSION weighted: {:?}",
+        result.err()
+    );
+
+    let query = result.unwrap();
+    let fusion = query
+        .select
+        .fusion_clause
+        .as_ref()
+        .expect("FUSION clause should be present");
+
+    assert_eq!(
+        fusion.strategy,
+        crate::velesql::FusionStrategyType::Weighted
+    );
+    assert!((fusion.vector_weight.unwrap_or(0.0) - 0.7).abs() < 0.01);
+    assert!((fusion.graph_weight.unwrap_or(0.0) - 0.3).abs() < 0.01);
+}
+
+#[test]
+fn test_using_fusion_maximum() {
+    let sql = "SELECT * FROM docs USING FUSION(strategy = 'maximum')";
+    let result = Parser::parse(sql);
+    assert!(
+        result.is_ok(),
+        "Failed to parse FUSION maximum: {:?}",
+        result.err()
+    );
+
+    let query = result.unwrap();
+    let fusion = query
+        .select
+        .fusion_clause
+        .as_ref()
+        .expect("FUSION clause should be present");
+
+    assert_eq!(fusion.strategy, crate::velesql::FusionStrategyType::Maximum);
+}
+
+#[test]
+fn test_fusion_with_where_clause() {
+    // USING FUSION combined with WHERE clause
+    let sql = "SELECT * FROM docs WHERE category = 'tech' USING FUSION(strategy = 'rrf', k = 60)";
+    let result = Parser::parse(sql);
+    assert!(
+        result.is_ok(),
+        "Failed to parse FUSION with WHERE: {:?}",
+        result.err()
+    );
+
+    let query = result.unwrap();
+    assert!(query.select.where_clause.is_some());
+    assert!(query.select.fusion_clause.is_some());
+}

--- a/crates/velesdb-core/src/velesql/grammar.pest
+++ b/crates/velesdb-core/src/velesql/grammar.pest
@@ -8,11 +8,18 @@ COMMENT = _{ "--" ~ (!"\n" ~ ANY)* }
 // Main entry point
 query = { SOI ~ select_stmt ~ ";"? ~ EOI }
 
-// SELECT statement with optional JOIN, WHERE, GROUP BY, HAVING, ORDER BY, LIMIT, OFFSET, WITH clauses
+// SELECT statement with optional JOIN, WHERE, GROUP BY, HAVING, ORDER BY, LIMIT, OFFSET, WITH, FUSION clauses
 select_stmt = { 
     ^"SELECT" ~ select_list ~ ^"FROM" ~ identifier ~
-    join_clause* ~ where_clause? ~ group_by_clause? ~ having_clause? ~ order_by_clause? ~ limit_clause? ~ offset_clause? ~ with_clause?
+    join_clause* ~ where_clause? ~ group_by_clause? ~ having_clause? ~ order_by_clause? ~ limit_clause? ~ offset_clause? ~ with_clause? ~ using_fusion_clause?
 }
+
+// USING FUSION clause for hybrid search (EPIC-040 US-005)
+using_fusion_clause = { ^"USING" ~ ^"FUSION" ~ fusion_options? }
+fusion_options = { "(" ~ fusion_option_list ~ ")" }
+fusion_option_list = { fusion_option ~ ("," ~ fusion_option)* }
+fusion_option = { identifier ~ "=" ~ fusion_value }
+fusion_value = { string | float | integer }
 
 // GROUP BY clause (EPIC-017 US-003)
 group_by_clause = { ^"GROUP" ~ ^"BY" ~ group_by_list }

--- a/crates/velesdb-core/src/velesql/mod.rs
+++ b/crates/velesdb-core/src/velesql/mod.rs
@@ -53,6 +53,8 @@ mod parser_tests;
 mod planner;
 
 #[cfg(test)]
+mod fusion_clause_tests;
+#[cfg(test)]
 mod similarity_tests;
 
 pub use aggregator::{AggregateResult, Aggregator};

--- a/crates/velesdb-core/src/velesql/parser/select.rs
+++ b/crates/velesdb-core/src/velesql/parser/select.rs
@@ -35,6 +35,7 @@ impl Parser {
         let mut with_clause = None;
         let mut group_by = None;
         let mut having = None;
+        let mut fusion_clause = None;
 
         for inner_pair in pair.into_inner() {
             match inner_pair.as_rule() {
@@ -68,6 +69,9 @@ impl Parser {
                 Rule::with_clause => {
                     with_clause = Some(Self::parse_with_clause(inner_pair)?);
                 }
+                Rule::using_fusion_clause => {
+                    fusion_clause = Some(Self::parse_using_fusion_clause(inner_pair));
+                }
                 _ => {}
             }
         }
@@ -83,6 +87,7 @@ impl Parser {
             with_clause,
             group_by,
             having,
+            fusion_clause,
         })
     }
 
@@ -549,6 +554,73 @@ impl Parser {
             "<" => Ok(CompareOp::Lt),
             "<=" => Ok(CompareOp::Lte),
             other => Err(ParseError::syntax(0, other, "Unknown comparison operator")),
+        }
+    }
+
+    /// Parse USING FUSION clause (EPIC-040 US-005).
+    fn parse_using_fusion_clause(
+        pair: pest::iterators::Pair<Rule>,
+    ) -> crate::velesql::FusionClause {
+        let mut strategy = crate::velesql::FusionStrategyType::Rrf;
+        let mut k = None;
+        let mut vector_weight = None;
+        let mut graph_weight = None;
+
+        for inner_pair in pair.into_inner() {
+            if inner_pair.as_rule() == Rule::fusion_options {
+                for opt_pair in inner_pair.into_inner() {
+                    if opt_pair.as_rule() == Rule::fusion_option_list {
+                        for option in opt_pair.into_inner() {
+                            if option.as_rule() == Rule::fusion_option {
+                                let mut key = String::new();
+                                let mut value_str = String::new();
+
+                                for part in option.into_inner() {
+                                    match part.as_rule() {
+                                        Rule::identifier => key = part.as_str().to_lowercase(),
+                                        Rule::fusion_value => {
+                                            value_str =
+                                                part.as_str().trim_matches('\'').to_string();
+                                        }
+                                        _ => {}
+                                    }
+                                }
+
+                                match key.as_str() {
+                                    "strategy" => {
+                                        strategy = match value_str.to_lowercase().as_str() {
+                                            "weighted" => {
+                                                crate::velesql::FusionStrategyType::Weighted
+                                            }
+                                            "maximum" => {
+                                                crate::velesql::FusionStrategyType::Maximum
+                                            }
+                                            _ => crate::velesql::FusionStrategyType::Rrf, // rrf is default
+                                        };
+                                    }
+                                    "k" => {
+                                        k = value_str.parse().ok();
+                                    }
+                                    "vector_weight" => {
+                                        vector_weight = value_str.parse().ok();
+                                    }
+                                    "graph_weight" => {
+                                        graph_weight = value_str.parse().ok();
+                                    }
+                                    _ => {}
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        crate::velesql::FusionClause {
+            strategy,
+            k,
+            vector_weight,
+            graph_weight,
         }
     }
 }


### PR DESCRIPTION
## US-005: USING FUSION Hybrid Search

### Feature
Clause USING FUSION pour combiner recherche vectorielle et graph.

### Syntaxes supportees
- USING FUSION (default RRF k=60)
- USING FUSION(strategy = 'rrf', k = 100)
- USING FUSION(strategy = 'weighted', vector_weight = 0.7, graph_weight = 0.3)
- USING FUSION(strategy = 'maximum')

### Changements
- FusionStrategyType enum
- FusionClause struct dans AST
- Grammar: using_fusion_clause
- Parser: parse_using_fusion_clause()
- 5 tests de parsing

### Validation
- clippy clean
- Tests passent
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/109">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
