### PR TITLE
feat(velesql): ORDER BY multi-expressions [EPIC-040/US-002]

### DIFF
--- a/crates/velesdb-core/src/collection/search/query/ordering.rs
+++ b/crates/velesdb-core/src/collection/search/query/ordering.rs
@@ -136,6 +136,11 @@ impl Collection {
                             .and_then(|p| p.get(field_name));
                         compare_json_values(val_i, val_j)
                     }
+                    OrderByExpr::Aggregate(_) => {
+                        // EPIC-040 US-002: ORDER BY aggregate requires pre-computed values
+                        // For raw results (not grouped), aggregates don't apply - skip
+                        Ordering::Equal
+                    }
                 };
 
                 // Apply direction (ASC/DESC)

--- a/crates/velesdb-core/src/velesql/ast.rs
+++ b/crates/velesdb-core/src/velesql/ast.rs
@@ -93,6 +93,8 @@ pub enum OrderByExpr {
     Field(String),
     /// Similarity function (e.g., `similarity(embedding, $v)`).
     Similarity(SimilarityOrderBy),
+    /// Aggregate function (e.g., `COUNT(*)`, `SUM(price)`).
+    Aggregate(AggregateFunction),
 }
 
 /// Similarity expression for ORDER BY.

--- a/crates/velesdb-core/src/velesql/grammar.pest
+++ b/crates/velesdb-core/src/velesql/grammar.pest
@@ -30,10 +30,10 @@ alias_clause = { ^"AS" ~ identifier }
 join_condition = { column_ref ~ "=" ~ column_ref }
 column_ref = @{ identifier ~ "." ~ identifier }
 
-// ORDER BY clause
+// ORDER BY clause (EPIC-040 US-002: supports columns, aggregates, similarity)
 order_by_clause = { ^"ORDER" ~ ^"BY" ~ order_by_item ~ ("," ~ order_by_item)* }
 order_by_item = { order_by_expr ~ sort_direction? }
-order_by_expr = { order_by_similarity | identifier }
+order_by_expr = { order_by_similarity | aggregate_function | identifier }
 order_by_similarity = { ^"similarity" ~ "(" ~ similarity_field ~ "," ~ vector_value ~ ")" }
 sort_direction = { ^"DESC" | ^"ASC" }
 

--- a/crates/velesdb-core/src/velesql/mod.rs
+++ b/crates/velesdb-core/src/velesql/mod.rs
@@ -46,6 +46,8 @@ mod groupby_tests;
 #[cfg(test)]
 mod having_tests;
 #[cfg(test)]
+mod orderby_multi_tests;
+#[cfg(test)]
 mod parallel_aggregation_tests;
 mod parser;
 #[cfg(test)]

--- a/crates/velesdb-core/src/velesql/orderby_multi_tests.rs
+++ b/crates/velesdb-core/src/velesql/orderby_multi_tests.rs
@@ -1,0 +1,108 @@
+//! Tests for ORDER BY multi-expression support (EPIC-040 US-002).
+//!
+//! Covers:
+//! - ORDER BY multiple columns
+//! - ORDER BY with aggregate functions
+//! - ORDER BY mixed (columns + aggregates)
+//! - Direction per column (ASC/DESC)
+
+use crate::velesql::{OrderByExpr, Parser};
+
+#[test]
+fn test_orderby_multiple_columns() {
+    let sql = "SELECT * FROM products ORDER BY category ASC, price DESC";
+    let result = Parser::parse(sql);
+    assert!(result.is_ok(), "Failed to parse: {:?}", result.err());
+
+    let query = result.unwrap();
+    let order_by = query.select.order_by.expect("ORDER BY should be present");
+
+    assert_eq!(order_by.len(), 2, "Should have 2 ORDER BY items");
+    // First: category ASC
+    assert!(matches!(&order_by[0].expr, OrderByExpr::Field(f) if f == "category"));
+    assert!(!order_by[0].descending, "category should be ASC");
+    // Second: price DESC
+    assert!(matches!(&order_by[1].expr, OrderByExpr::Field(f) if f == "price"));
+    assert!(order_by[1].descending, "price should be DESC");
+}
+
+#[test]
+fn test_orderby_with_aggregate() {
+    let sql = "SELECT category, COUNT(*) FROM products GROUP BY category ORDER BY COUNT(*) DESC";
+    let result = Parser::parse(sql);
+    assert!(result.is_ok(), "Failed to parse: {:?}", result.err());
+
+    let query = result.unwrap();
+    let order_by = query.select.order_by.expect("ORDER BY should be present");
+
+    assert_eq!(order_by.len(), 1);
+    assert!(order_by[0].descending, "Should be DESC");
+    // The expression should represent COUNT(*)
+    assert!(
+        matches!(&order_by[0].expr, OrderByExpr::Aggregate(_)),
+        "Should be Aggregate variant"
+    );
+}
+
+#[test]
+fn test_orderby_mixed_columns_and_aggregates() {
+    let sql = "SELECT category, COUNT(*), AVG(price) FROM products GROUP BY category ORDER BY COUNT(*) DESC, category ASC";
+    let result = Parser::parse(sql);
+    assert!(result.is_ok(), "Failed to parse: {:?}", result.err());
+
+    let query = result.unwrap();
+    let order_by = query.select.order_by.expect("ORDER BY should be present");
+
+    assert_eq!(order_by.len(), 2, "Should have 2 ORDER BY items");
+    // First: COUNT(*) DESC
+    assert!(order_by[0].descending);
+    // Second: category ASC
+    assert!(!order_by[1].descending);
+}
+
+#[test]
+fn test_orderby_aggregate_with_column_arg() {
+    let sql =
+        "SELECT category, SUM(price) FROM products GROUP BY category ORDER BY SUM(price) DESC";
+    let result = Parser::parse(sql);
+    assert!(result.is_ok(), "Failed to parse: {:?}", result.err());
+
+    let query = result.unwrap();
+    let order_by = query.select.order_by.expect("ORDER BY should be present");
+
+    assert_eq!(order_by.len(), 1);
+    assert!(order_by[0].descending);
+}
+
+#[test]
+fn test_orderby_default_direction_is_asc() {
+    let sql = "SELECT * FROM products ORDER BY price, category";
+    let result = Parser::parse(sql);
+    assert!(result.is_ok(), "Failed to parse: {:?}", result.err());
+
+    let query = result.unwrap();
+    let order_by = query.select.order_by.expect("ORDER BY should be present");
+
+    assert_eq!(order_by.len(), 2);
+    // Both should default to ASC (descending = false)
+    assert!(matches!(&order_by[0].expr, OrderByExpr::Field(f) if f == "price"));
+    assert!(!order_by[0].descending, "Default should be ASC");
+    assert!(matches!(&order_by[1].expr, OrderByExpr::Field(f) if f == "category"));
+    assert!(!order_by[1].descending, "Default should be ASC");
+}
+
+#[test]
+fn test_orderby_similarity_with_column() {
+    let sql = "SELECT * FROM products ORDER BY similarity(embedding, $query) DESC, price ASC";
+    let result = Parser::parse(sql);
+    assert!(result.is_ok(), "Failed to parse: {:?}", result.err());
+
+    let query = result.unwrap();
+    let order_by = query.select.order_by.expect("ORDER BY should be present");
+
+    assert_eq!(order_by.len(), 2);
+    assert!(matches!(&order_by[0].expr, OrderByExpr::Similarity(_)));
+    assert!(order_by[0].descending, "similarity should be DESC");
+    assert!(matches!(&order_by[1].expr, OrderByExpr::Field(f) if f == "price"));
+    assert!(!order_by[1].descending, "price should be ASC");
+}

--- a/crates/velesdb-core/src/velesql/parser/select.rs
+++ b/crates/velesdb-core/src/velesql/parser/select.rs
@@ -139,6 +139,11 @@ impl Parser {
                     let sim = Self::parse_order_by_similarity(inner_pair)?;
                     return Ok((OrderByExpr::Similarity(sim), true));
                 }
+                Rule::aggregate_function => {
+                    // EPIC-040 US-002: Support ORDER BY with aggregate functions
+                    let agg = Self::parse_aggregate_function_only(inner_pair)?;
+                    return Ok((OrderByExpr::Aggregate(agg), false));
+                }
                 Rule::identifier => {
                     return Ok((OrderByExpr::Field(inner_pair.as_str().to_string()), false));
                 }

--- a/crates/velesdb-core/src/velesql/similarity_tests.rs
+++ b/crates/velesdb-core/src/velesql/similarity_tests.rs
@@ -307,7 +307,9 @@ mod tests {
                 assert_eq!(sim.field, "embedding");
                 assert!(matches!(sim.vector, VectorExpr::Parameter(ref name) if name == "v"));
             }
-            crate::velesql::OrderByExpr::Field(_) => panic!("Expected OrderByExpr::Similarity"),
+            crate::velesql::OrderByExpr::Field(_) | crate::velesql::OrderByExpr::Aggregate(_) => {
+                panic!("Expected OrderByExpr::Similarity")
+            }
         }
     }
 
@@ -362,7 +364,8 @@ mod tests {
             crate::velesql::OrderByExpr::Field(name) => {
                 assert_eq!(name, "created_at");
             }
-            crate::velesql::OrderByExpr::Similarity(_) => panic!("Expected OrderByExpr::Field"),
+            crate::velesql::OrderByExpr::Similarity(_)
+            | crate::velesql::OrderByExpr::Aggregate(_) => panic!("Expected OrderByExpr::Field"),
         }
     }
 


### PR DESCRIPTION
## US-002: ORDER BY Multi-expressions

### Feature
Support ORDER BY avec colonnes multiples et similarity().

### Syntaxes
- ORDER BY column1, column2 DESC
- ORDER BY similarity(vector, query) DESC

### Changements
- Grammar: order_by_item, order_by_expr, sort_direction
- Parser: support multi-columns et similarity
- Tests de parsing

### Validation
- clippy clean
- Tests passent
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/112">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
