### PR TITLE
docs(safety): add missing SAFETY comments to unsafe blocks [EPIC-032/US-003]

### DIFF
--- a/crates/velesdb-core/src/index/hnsw/index/vacuum.rs
+++ b/crates/velesdb-core/src/index/hnsw/index/vacuum.rs
@@ -157,7 +157,10 @@ impl HnswIndex {
         // 6. Atomic swap (replace old with new)
         {
             let mut inner_guard = self.inner.write();
-            // Drop old inner safely
+            // SAFETY (EPIC-032/US-003): ManuallyDrop::drop is safe here because:
+            // 1. We hold exclusive write lock on inner_guard
+            // 2. This is called exactly once before replacement
+            // 3. The old value is immediately replaced with new_inner
             unsafe {
                 ManuallyDrop::drop(&mut *inner_guard);
             }

--- a/crates/velesdb-core/src/index/hnsw/vector_store.rs
+++ b/crates/velesdb-core/src/index/hnsw/vector_store.rs
@@ -236,6 +236,9 @@ impl VectorStore {
 
         if offset < buffer.len() {
             #[cfg(target_arch = "x86_64")]
+            // SAFETY (EPIC-032/US-003): _mm_prefetch is safe when:
+            // 1. Target has x86_64 architecture (cfg guard)
+            // 2. Pointer is within bounds (offset < buffer.len() check above)
             unsafe {
                 use std::arch::x86_64::{_mm_prefetch, _MM_HINT_T0};
                 let ptr = buffer.as_ptr().add(offset);

--- a/crates/velesdb-core/src/velesql/log_payload.rs
+++ b/crates/velesdb-core/src/velesql/log_payload.rs
@@ -409,6 +409,9 @@ pub fn batch_cosine_normalized(candidates: &[&[f32]], query: &[f32]) -> Vec<f32>
         // Prefetch next vectors
         if i + 4 < candidates.len() {
             #[cfg(target_arch = "x86_64")]
+            // SAFETY (EPIC-032/US-003): _mm_prefetch is safe when:
+            // 1. Target has x86_64 architecture (cfg guard)
+            // 2. Index is valid (i + 4 < candidates.len() check above)
             unsafe {
                 use std::arch::x86_64::{_mm_prefetch, _MM_HINT_T0};
                 _mm_prefetch(candidates[i + 4].as_ptr().cast::<i8>(), _MM_HINT_T0);


### PR DESCRIPTION
## Summary

Adds missing SAFETY documentation to unsafe blocks that were missing explicit justification.

### Files Updated

1. **vector_store.rs**: prefetch with bounds check justification
2. **vacuum.rs**: ManuallyDrop::drop with lock/uniqueness justification  
3. **log_payload.rs**: prefetch with bounds check justification

### Validation

- cargo clippy: No warnings
- cargo test: All tests pass

### Related

- EPIC-032: Safety Hardening
- US-003: Add missing SAFETY docs
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/131">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
