### PR TITLE
feat(cli): add shell completions command [EPIC-014/US-007]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -678,6 +678,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.5.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "430b4dc2b5e3861848de79627b2bedc9f3342c7da5173a14eaa5d0f8dc18ae5d"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.5.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6523,6 +6532,7 @@ dependencies = [
  "base64 0.22.1",
  "chrono",
  "clap",
+ "clap_complete",
  "colored",
  "comfy-table",
  "csv",

--- a/crates/velesdb-cli/Cargo.toml
+++ b/crates/velesdb-cli/Cargo.toml
@@ -21,6 +21,7 @@ velesdb-core = { path = "../velesdb-core", version = "1.1.2" }
 
 # CLI
 clap = { version = "4.5", features = ["derive", "env"] }
+clap_complete = "4.5"
 
 # REPL
 rustyline = { version = "14.0", features = ["derive"] }

--- a/crates/velesdb-cli/src/main.rs
+++ b/crates/velesdb-cli/src/main.rs
@@ -16,7 +16,9 @@ mod license;
 mod repl;
 mod session;
 
-use clap::{Parser, Subcommand, ValueEnum};
+use clap::{CommandFactory, Parser, Subcommand, ValueEnum};
+use clap_complete::{generate, Shell};
+use std::io;
 use std::path::PathBuf;
 use velesdb_core::{DistanceMetric, StorageMode};
 
@@ -252,6 +254,13 @@ enum Commands {
     Graph {
         #[command(subcommand)]
         action: graph::GraphAction,
+    },
+
+    /// Generate shell completions (EPIC-014 US-007)
+    Completions {
+        /// Shell type (bash, zsh, fish, powershell, elvish)
+        #[arg(value_enum)]
+        shell: Shell,
     },
 }
 
@@ -739,6 +748,10 @@ fn main() -> anyhow::Result<()> {
         }
         Commands::Graph { action } => {
             graph::handle(action);
+        }
+        Commands::Completions { shell } => {
+            let mut cmd = Cli::command();
+            generate(shell, &mut cmd, "velesdb", &mut io::stdout());
         }
     }
 


### PR DESCRIPTION
## Summary

Adds shell completion generation for velesdb CLI.

### Usage

`ash
# Bash
velesdb completions bash > ~/.bash_completion.d/velesdb

# Zsh  
velesdb completions zsh > ~/.zfunc/_velesdb

# Fish
velesdb completions fish > ~/.config/fish/completions/velesdb.fish

# PowerShell
velesdb completions powershell >> C:\Users\Nicolas\Documents\PowerShell\Microsoft.PowerShell_profile.ps1
`

### Changes

- Added clap_complete dependency
- Added Completions subcommand with shell type argument
- Supports: bash, zsh, fish, powershell, elvish

### Validation

- cargo clippy: No warnings
- cargo test: All tests pass

### Related

- EPIC-014: CLI Enhancements
- US-007: Shell completions
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/132">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
