### PR TITLE
feat(tauri): add cross-platform AppData persistence [EPIC-015/US-003]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5605,6 +5605,7 @@ dependencies = [
 name = "tauri-plugin-velesdb"
 version = "1.3.1"
 dependencies = [
+ "dirs 5.0.1",
  "parking_lot",
  "serde",
  "serde_json",

--- a/crates/tauri-plugin-velesdb/Cargo.toml
+++ b/crates/tauri-plugin-velesdb/Cargo.toml
@@ -21,6 +21,7 @@ serde_json = "1.0"
 thiserror = "2.0"
 tracing = "0.1"
 parking_lot = "0.12"
+dirs = "5.0"
 
 # VelesDB core dependency (local path for development)
 velesdb-core = { path = "../../crates/velesdb-core", version = "1.1.2" }


### PR DESCRIPTION
Adds init_with_app_data() and get_app_data_dir() for cross-platform persistence. Uses dirs crate for Windows/macOS/Linux support. Includes 2 new tests.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/134">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
