### PR TITLE
docs(storage): document epoch overflow safety [EPIC-034/US-003]

### DIFF
--- a/crates/velesdb-core/src/storage/guard.rs
+++ b/crates/velesdb-core/src/storage/guard.rs
@@ -26,6 +26,14 @@ use std::sync::atomic::AtomicU64;
 /// Zero-copy guard for vector data from mmap storage.
 /// Holds a read-lock on the mmap and validates that the underlying mapping
 /// hasn't been remapped via an *epoch* counter.
+///
+/// # Epoch Validation
+///
+/// The guard captures the epoch at creation and validates it on each access.
+/// If the mmap was remapped (epoch changed), access panics to prevent UB.
+///
+/// The epoch uses wrapping `u64` arithmetic. Overflow is theoretically possible
+/// after 2^64 remaps (~584 years at 1B/sec) but practically irrelevant.
 pub struct VectorSliceGuard<'a> {
     /// Read guard holding the mmap lock – guarantees the mapping is pinned for the guard lifetime
     pub(super) _guard: RwLockReadGuard<'a, MmapMut>,

--- a/crates/velesdb-core/src/storage/mmap.rs
+++ b/crates/velesdb-core/src/storage/mmap.rs
@@ -59,6 +59,13 @@ pub struct MmapStorage {
     /// P0 Audit: Metrics for monitoring `ensure_capacity` latency
     metrics: Arc<StorageMetrics>,
     /// Epoch counter incremented every time the mmap is remapped.
+    ///
+    /// # Overflow Safety
+    ///
+    /// Uses wrapping arithmetic (guaranteed by `fetch_add`). Even at 1 billion
+    /// remaps/second, overflow would take ~584 years. The worst-case scenario
+    /// on wrap is a false-positive panic in `VectorSliceGuard::as_slice()`,
+    /// which is acceptable given the astronomical time required.
     remap_epoch: AtomicU64,
 }
 


### PR DESCRIPTION
Documents the overflow safety of the remap_epoch counter in MmapStorage and VectorSliceGuard. The u64 epoch uses wrapping arithmetic and would take ~584 years to overflow at 1B remaps/sec.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/135">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
