### PR TITLE
feat(velesql): add NOW() and INTERVAL temporal functions [EPIC-038/US-001]

### DIFF
--- a/crates/velesdb-core/src/filter/conversion.rs
+++ b/crates/velesdb-core/src/filter/conversion.rs
@@ -16,6 +16,10 @@ impl From<crate::velesql::Condition> for Condition {
                     crate::velesql::Value::Null | crate::velesql::Value::Parameter(_) => {
                         Value::Null
                     }
+                    crate::velesql::Value::Temporal(t) => {
+                        // Convert temporal to epoch seconds for comparison
+                        Value::Number(t.to_epoch_seconds().into())
+                    }
                 };
                 match cmp.operator {
                     crate::velesql::CompareOp::Eq => Self::eq(cmp.column, value),
@@ -49,6 +53,9 @@ impl From<crate::velesql::Condition> for Condition {
                         crate::velesql::Value::Boolean(b) => Value::Bool(b),
                         crate::velesql::Value::Null | crate::velesql::Value::Parameter(_) => {
                             Value::Null
+                        }
+                        crate::velesql::Value::Temporal(t) => {
+                            Value::Number(t.to_epoch_seconds().into())
                         }
                     })
                     .collect();

--- a/crates/velesdb-core/src/velesql/grammar.pest
+++ b/crates/velesdb-core/src/velesql/grammar.pest
@@ -152,11 +152,18 @@ compare_op = { ">=" | "<=" | "<>" | "!=" | "=" | ">" | "<" }
 limit_clause = { ^"LIMIT" ~ integer }
 offset_clause = { ^"OFFSET" ~ integer }
 
-// Values
-value = { float | integer | string | boolean | null_value | parameter }
+// Values - EPIC-038: Added temporal expressions (NOW, INTERVAL)
+value = { temporal_expr | float | integer | string | boolean | null_value | parameter }
 parameter = @{ "$" ~ identifier }
 null_value = { ^"NULL" }
 boolean = { ^"TRUE" | ^"FALSE" }
+
+// Temporal expressions (EPIC-038)
+temporal_expr = { temporal_arithmetic | now_function | interval_expr }
+temporal_arithmetic = { (now_function | interval_expr) ~ temporal_op ~ (now_function | interval_expr) }
+temporal_op = { "+" | "-" }
+now_function = { ^"NOW" ~ "(" ~ ")" }
+interval_expr = { ^"INTERVAL" ~ string }
 
 // Literals
 string = @{ "'" ~ (!"'" ~ ANY)* ~ "'" }

--- a/crates/velesdb-core/src/velesql/parser/mod.rs
+++ b/crates/velesdb-core/src/velesql/parser/mod.rs
@@ -8,6 +8,8 @@ mod values;
 pub mod match_clause;
 #[cfg(test)]
 mod match_clause_tests;
+#[cfg(test)]
+mod temporal_tests;
 
 use pest::iterators::Pair;
 use pest::Parser as PestParser;

--- a/crates/velesdb-core/src/velesql/parser/temporal_tests.rs
+++ b/crates/velesdb-core/src/velesql/parser/temporal_tests.rs
@@ -1,0 +1,139 @@
+//! Tests for temporal expression parsing (EPIC-038).
+
+use crate::velesql::ast::{IntervalUnit, TemporalExpr, Value};
+use crate::velesql::Parser;
+
+#[test]
+fn test_parse_now_function() {
+    let query = "SELECT * FROM events WHERE timestamp > NOW()";
+    let result = Parser::parse(query);
+    assert!(result.is_ok(), "Failed to parse NOW(): {:?}", result.err());
+}
+
+#[test]
+fn test_parse_interval_days() {
+    let query = "SELECT * FROM events WHERE timestamp > INTERVAL '7 days'";
+    let result = Parser::parse(query);
+    assert!(
+        result.is_ok(),
+        "Failed to parse INTERVAL: {:?}",
+        result.err()
+    );
+}
+
+#[test]
+fn test_parse_now_minus_interval() {
+    let query = "SELECT * FROM logs WHERE created_at > NOW() - INTERVAL '24 hours'";
+    let result = Parser::parse(query);
+    assert!(
+        result.is_ok(),
+        "Failed to parse NOW() - INTERVAL: {:?}",
+        result.err()
+    );
+}
+
+#[test]
+fn test_parse_now_plus_interval() {
+    let query = "SELECT * FROM tasks WHERE due_date < NOW() + INTERVAL '7 days'";
+    let result = Parser::parse(query);
+    assert!(
+        result.is_ok(),
+        "Failed to parse NOW() + INTERVAL: {:?}",
+        result.err()
+    );
+}
+
+#[test]
+fn test_interval_units() {
+    let units = [
+        ("1 second", IntervalUnit::Seconds),
+        ("30 seconds", IntervalUnit::Seconds),
+        ("5 minutes", IntervalUnit::Minutes),
+        ("2 hours", IntervalUnit::Hours),
+        ("7 days", IntervalUnit::Days),
+        ("2 weeks", IntervalUnit::Weeks),
+        ("1 month", IntervalUnit::Months),
+    ];
+
+    for (interval_str, expected_unit) in units {
+        let query = format!(
+            "SELECT * FROM events WHERE ts > INTERVAL '{}'",
+            interval_str
+        );
+        let result = Parser::parse(&query);
+        assert!(
+            result.is_ok(),
+            "Failed to parse interval '{}': {:?}",
+            interval_str,
+            result.err()
+        );
+
+        let parsed = result.unwrap();
+        if let Some(crate::velesql::Condition::Comparison(cmp)) =
+            parsed.select.where_clause.as_ref()
+        {
+            if let Value::Temporal(TemporalExpr::Interval(iv)) = &cmp.value {
+                assert_eq!(
+                    iv.unit, expected_unit,
+                    "Wrong unit for '{}': expected {:?}, got {:?}",
+                    interval_str, expected_unit, iv.unit
+                );
+            } else {
+                panic!("Expected Temporal(Interval), got {:?}", cmp.value);
+            }
+        } else {
+            panic!("Expected Comparison condition");
+        }
+    }
+}
+
+#[test]
+fn test_temporal_expr_to_epoch_seconds() {
+    use crate::velesql::ast::IntervalValue;
+
+    // Test interval conversions
+    let one_day = IntervalValue {
+        magnitude: 1,
+        unit: IntervalUnit::Days,
+    };
+    assert_eq!(one_day.to_seconds(), 86400);
+
+    let one_week = IntervalValue {
+        magnitude: 1,
+        unit: IntervalUnit::Weeks,
+    };
+    assert_eq!(one_week.to_seconds(), 604_800);
+
+    // Test NOW() returns a reasonable timestamp
+    let now_expr = TemporalExpr::Now;
+    let now_secs = now_expr.to_epoch_seconds();
+    // Should be after Jan 1, 2020 (1577836800)
+    assert!(now_secs > 1_577_836_800, "NOW() should return current time");
+
+    // Test subtraction
+    let week_ago = TemporalExpr::Subtract(
+        Box::new(TemporalExpr::Now),
+        Box::new(TemporalExpr::Interval(one_week.clone())),
+    );
+    let week_ago_secs = week_ago.to_epoch_seconds();
+    assert!(
+        now_secs - week_ago_secs >= 604_799 && now_secs - week_ago_secs <= 604_801,
+        "NOW() - 1 week should be ~604800 seconds ago"
+    );
+}
+
+#[test]
+fn test_interval_shorthand_units() {
+    let shorthands = ["1 s", "30 sec", "5 min", "2 h", "7 d", "2 w"];
+
+    for shorthand in shorthands {
+        let query = format!("SELECT * FROM events WHERE ts > INTERVAL '{}'", shorthand);
+        let result = Parser::parse(&query);
+        assert!(
+            result.is_ok(),
+            "Failed to parse shorthand interval '{}': {:?}",
+            shorthand,
+            result.err()
+        );
+    }
+}

--- a/crates/velesdb-core/src/velesql/parser/values.rs
+++ b/crates/velesdb-core/src/velesql/parser/values.rs
@@ -1,7 +1,9 @@
 //! Value parsing (literals, parameters, WITH clause).
 
 use super::Rule;
-use crate::velesql::ast::{Value, WithClause, WithOption, WithValue};
+use crate::velesql::ast::{
+    IntervalUnit, IntervalValue, TemporalExpr, Value, WithClause, WithOption, WithValue,
+};
 use crate::velesql::error::ParseError;
 use crate::velesql::Parser;
 
@@ -40,7 +42,121 @@ impl Parser {
                 let name = inner.as_str().trim_start_matches('$').to_string();
                 Ok(Value::Parameter(name))
             }
+            Rule::temporal_expr => {
+                let temporal = Self::parse_temporal_expr(inner)?;
+                Ok(Value::Temporal(temporal))
+            }
             _ => Err(ParseError::syntax(0, inner.as_str(), "Unknown value type")),
+        }
+    }
+
+    /// Parses a temporal expression (NOW(), INTERVAL, arithmetic).
+    pub(crate) fn parse_temporal_expr(
+        pair: pest::iterators::Pair<Rule>,
+    ) -> Result<TemporalExpr, ParseError> {
+        let inner = pair
+            .into_inner()
+            .next()
+            .ok_or_else(|| ParseError::syntax(0, "", "Expected temporal expression"))?;
+
+        match inner.as_rule() {
+            Rule::now_function => Ok(TemporalExpr::Now),
+            Rule::interval_expr => Self::parse_interval_expr(inner),
+            Rule::temporal_arithmetic => Self::parse_temporal_arithmetic(inner),
+            _ => Err(ParseError::syntax(
+                0,
+                inner.as_str(),
+                "Unknown temporal expression",
+            )),
+        }
+    }
+
+    /// Parses an INTERVAL expression like `INTERVAL '7 days'`.
+    fn parse_interval_expr(pair: pest::iterators::Pair<Rule>) -> Result<TemporalExpr, ParseError> {
+        let string_pair = pair
+            .into_inner()
+            .find(|p| p.as_rule() == Rule::string)
+            .ok_or_else(|| ParseError::syntax(0, "", "Expected interval string"))?;
+
+        let interval_str = string_pair.as_str().trim_matches('\'');
+        let interval_value = Self::parse_interval_string(interval_str)?;
+        Ok(TemporalExpr::Interval(interval_value))
+    }
+
+    /// Parses interval string like "7 days" or "1 hour".
+    fn parse_interval_string(s: &str) -> Result<IntervalValue, ParseError> {
+        let parts: Vec<&str> = s.split_whitespace().collect();
+        if parts.len() != 2 {
+            return Err(ParseError::syntax(
+                0,
+                s,
+                "INTERVAL format: '<number> <unit>' (e.g., '7 days')",
+            ));
+        }
+
+        let magnitude = parts[0]
+            .parse::<i64>()
+            .map_err(|_| ParseError::syntax(0, parts[0], "Invalid interval magnitude"))?;
+
+        let unit = match parts[1].to_lowercase().as_str() {
+            "s" | "sec" | "second" | "seconds" => IntervalUnit::Seconds,
+            "m" | "min" | "minute" | "minutes" => IntervalUnit::Minutes,
+            "h" | "hour" | "hours" => IntervalUnit::Hours,
+            "d" | "day" | "days" => IntervalUnit::Days,
+            "w" | "week" | "weeks" => IntervalUnit::Weeks,
+            "month" | "months" => IntervalUnit::Months,
+            _ => {
+                return Err(ParseError::syntax(
+                    0,
+                    parts[1],
+                    "Unknown interval unit (use: seconds, minutes, hours, days, weeks, months)",
+                ))
+            }
+        };
+
+        Ok(IntervalValue { magnitude, unit })
+    }
+
+    /// Parses temporal arithmetic like `NOW() - INTERVAL '7 days'`.
+    fn parse_temporal_arithmetic(
+        pair: pest::iterators::Pair<Rule>,
+    ) -> Result<TemporalExpr, ParseError> {
+        let mut inner = pair.into_inner();
+
+        let left_pair = inner
+            .next()
+            .ok_or_else(|| ParseError::syntax(0, "", "Expected left operand"))?;
+        let left = Self::parse_temporal_operand(left_pair)?;
+
+        let op_pair = inner
+            .next()
+            .ok_or_else(|| ParseError::syntax(0, "", "Expected temporal operator"))?;
+        let is_subtract = op_pair.as_str() == "-";
+
+        let right_pair = inner
+            .next()
+            .ok_or_else(|| ParseError::syntax(0, "", "Expected right operand"))?;
+        let right = Self::parse_temporal_operand(right_pair)?;
+
+        if is_subtract {
+            Ok(TemporalExpr::Subtract(Box::new(left), Box::new(right)))
+        } else {
+            Ok(TemporalExpr::Add(Box::new(left), Box::new(right)))
+        }
+    }
+
+    /// Parses a single temporal operand (NOW or INTERVAL).
+    fn parse_temporal_operand(
+        pair: pest::iterators::Pair<Rule>,
+    ) -> Result<TemporalExpr, ParseError> {
+        match pair.as_rule() {
+            Rule::now_function => Ok(TemporalExpr::Now),
+            Rule::interval_expr => Self::parse_interval_expr(pair),
+            _ => Err(ParseError::syntax(
+                0,
+                pair.as_str(),
+                "Expected NOW() or INTERVAL",
+            )),
         }
     }
 


### PR DESCRIPTION
Adds temporal expression support to VelesQL parser:

- **NOW()** function returns current Unix timestamp
- **INTERVAL 'N unit'** expressions (seconds, minutes, hours, days, weeks, months)
- Arithmetic: **NOW() - INTERVAL '7 days'**, **NOW() + INTERVAL '1 hour'**
- 7 new tests covering all functionality

Example queries:
\\\sql
SELECT * FROM events WHERE timestamp > NOW()
SELECT * FROM logs WHERE created_at > NOW() - INTERVAL '24 hours'
\\\" --base main

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/136">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
