### PR TITLE
feat(tauri): add AgentMemory commands (semantic_store, semantic_query) [EPIC-016/US-003]

### DIFF
--- a/crates/tauri-plugin-velesdb/src/lib.rs
+++ b/crates/tauri-plugin-velesdb/src/lib.rs
@@ -317,6 +317,9 @@ pub fn init_with_path<R: Runtime, P: AsRef<Path>>(path: P) -> TauriPlugin<R> {
             commands::query,
             commands::is_empty,
             commands::flush,
+            // AgentMemory commands (EPIC-016 US-003)
+            commands::semantic_store,
+            commands::semantic_query,
         ])
         .setup(move |app, _api| {
             let state = VelesDbState::new(db_path.clone());

--- a/crates/tauri-plugin-velesdb/src/types.rs
+++ b/crates/tauri-plugin-velesdb/src/types.rs
@@ -315,3 +315,84 @@ pub const fn default_vector_weight() -> f32 {
 pub fn default_fusion() -> String {
     "rrf".to_string()
 }
+
+// ============================================================================
+// AgentMemory DTOs (EPIC-016 US-003)
+// ============================================================================
+
+/// Request to store knowledge in semantic memory.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SemanticStoreRequest {
+    /// Unique ID for this knowledge fact.
+    pub id: u64,
+    /// Text content of the knowledge.
+    pub content: String,
+    /// Embedding vector for the content.
+    pub embedding: Vec<f32>,
+}
+
+/// Request to query semantic memory.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SemanticQueryRequest {
+    /// Query embedding vector.
+    pub embedding: Vec<f32>,
+    /// Number of results to return.
+    #[serde(default = "default_top_k")]
+    pub top_k: usize,
+}
+
+/// Result from semantic memory query.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SemanticQueryResult {
+    /// Knowledge fact ID.
+    pub id: u64,
+    /// Similarity score.
+    pub score: f32,
+    /// Knowledge content text.
+    pub content: String,
+}
+
+/// Request to record an episode.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EpisodicRecordRequest {
+    /// Episode description/content.
+    pub content: String,
+    /// Embedding vector for the episode.
+    pub embedding: Vec<f32>,
+    /// Optional context metadata.
+    #[serde(default)]
+    pub context: Option<serde_json::Value>,
+}
+
+/// Request to query recent episodes.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EpisodicRecentRequest {
+    /// Number of recent episodes to return.
+    #[serde(default = "default_top_k")]
+    pub limit: usize,
+}
+
+/// Result from episodic memory query.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EpisodicResult {
+    /// Episode ID.
+    pub id: u64,
+    /// Episode content.
+    pub content: String,
+    /// Timestamp (epoch seconds).
+    pub timestamp: u64,
+    /// Optional context.
+    pub context: Option<serde_json::Value>,
+}
+
+/// Default dimension for agent memory (384 for typical sentence transformers).
+#[must_use]
+pub const fn default_dimension() -> usize {
+    384
+}


### PR DESCRIPTION
Adds AgentMemory support to the Tauri plugin, enabling desktop apps to use semantic memory for AI agents.

## New Commands

- **semantic_store**: Store knowledge facts with embeddings
- **semantic_query**: Query semantic memory by similarity search

## Usage (JavaScript)

\\\javascript
// Store knowledge
await invoke('plugin:velesdb|semantic_store', {
  request: { id: 1, content: 'Paris is the capital of France', embedding: [...] }
});

// Query knowledge
const results = await invoke('plugin:velesdb|semantic_query', {
  request: { embedding: [...], topK: 5 }
});
\\\

## Files Changed

- \	ypes.rs\: Added SemanticStoreRequest, SemanticQueryRequest, SemanticQueryResult
- \commands.rs\: Added semantic_store, semantic_query commands
- \lib.rs\: Registered new commands in plugin

Part of EPIC-016 (SDK Ecosystem Sync) - propagating EPIC-010 AgentMemory to Tauri.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/138">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
