### PR TITLE
fix: Address 7 critical bugs reported by Devin AI

### DIFF
--- a/crates/velesdb-core/src/column_store/batch.rs
+++ b/crates/velesdb-core/src/column_store/batch.rs
@@ -132,6 +132,10 @@ impl ColumnStore {
         for row_idx in expired_rows {
             if let Some(&pk) = self.row_idx_to_pk.get(&row_idx) {
                 self.deleted_rows.insert(row_idx);
+                // BUG-2 FIX: Also update RoaringBitmap to keep both in sync
+                if let Ok(idx) = u32::try_from(row_idx) {
+                    self.deletion_bitmap.insert(idx);
+                }
                 self.row_expiry.remove(&row_idx);
                 result.pks.push(pk);
                 result.expired_count += 1;

--- a/crates/velesdb-wasm/Cargo.toml
+++ b/crates/velesdb-wasm/Cargo.toml
@@ -44,6 +44,7 @@ features = [
     "IdbRequest",
     "IdbOpenDbRequest",
     "IdbVersionChangeEvent",
+    "IdbKeyRange",
     "DomException",
 ]
 


### PR DESCRIPTION
## Summary

Fixes 7 bugs identified by Devin AI code review.

### 🔴 Critical Bugs Fixed

| Bug | Root Cause | Fix |
|-----|-----------|-----|
| **BUG-1: MemoryPool UB** | Drop assumed non-free = initialized | Track initialization with HashSet |
| **BUG-6: IndexedDB load()** | get_all() loads all graphs | Use IDBKeyRange.bound() for prefix filtering |
| **BUG-7: IndexedDB delete()** | Only deleted metadata | Delete nodes/edges with prefix before metadata |

### 🟡 Medium Bugs Fixed

| Bug | Root Cause | Fix |
|-----|-----------|-----|
| **BUG-2: Tombstone sync** | expire_rows() didn't update deletion_bitmap | Add bitmap insert in batch.rs |
| **BUG-3: Connection underflow** | fetch_sub(1) wraps at 0 | CAS loop saturating at 0 |
| **BUG-4: Prometheus success** | Exported total as success | success = total.saturating_sub(errors) |
| **BUG-5: Subquery false positives** | Value::String treated as column ref | Remove string literal check, add dedup |

### Tests

- [x] cargo test --workspace ✅
- [x] cargo clippy -- -D warnings ✅
- [x] cargo fmt --all --check ✅
- [x] cargo deny check ✅

### Regression Tests Added

- test_allocate_without_store_no_ub
- test_deallocate_uninitialized_slot
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/164">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
