### PR TITLE
fix(wasm): make update_check non-WASM only

### DIFF
--- a/crates/velesdb-core/Cargo.toml
+++ b/crates/velesdb-core/Cargo.toml
@@ -30,7 +30,8 @@ toml = { workspace = true }
 # HNSW: Native implementation only (v1.0+)
 # hnsw_rs dependency removed - native HNSW is 1.2x faster
 
-[dependencies.uuid]
+# UUID - target-specific for WASM compatibility
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies.uuid]
 version = "1.7"
 features = ["v4", "serde"]
 
@@ -276,17 +277,17 @@ optional = true
 workspace = true
 optional = true
 
-# Update check dependencies
-[dependencies.sha2]
+# Update check dependencies (non-WASM only)
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies.sha2]
 version = "0.10"
 
-[dependencies.hex]
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies.hex]
 version = "0.4"
 
-[dependencies.hostname]
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies.hostname]
 version = "0.4"
 
-[dependencies.whoami]
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies.whoami]
 version = "1.5"
 
 [dependencies.reqwest]

--- a/crates/velesdb-core/src/lib.rs
+++ b/crates/velesdb-core/src/lib.rs
@@ -180,14 +180,16 @@ mod simd_tests;
 #[cfg(feature = "persistence")]
 pub mod storage;
 pub mod sync;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod update_check;
 pub mod vector_ref;
 #[cfg(test)]
 mod vector_ref_tests;
 pub mod velesql;
 
-#[cfg(feature = "update-check")]
+#[cfg(all(not(target_arch = "wasm32"), feature = "update-check"))]
 pub use update_check::{check_for_updates, spawn_update_check};
+#[cfg(not(target_arch = "wasm32"))]
 pub use update_check::{compute_instance_hash, UpdateCheckConfig};
 
 #[cfg(feature = "persistence")]


### PR DESCRIPTION
Fixes WASM build failure caused by uuid/hostname crates incompatibility with wasm32-unknown-unknown target.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/168">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
