### PR TITLE
fix(wasm): add --enable-bulk-memory to wasm-opt flags

### DIFF
--- a/crates/velesdb-wasm/Cargo.toml
+++ b/crates/velesdb-wasm/Cargo.toml
@@ -60,7 +60,8 @@ serde-wasm-bindgen = "0.6"
 
 [package.metadata.wasm-pack.profile.release]
 # Enable wasm-opt with size optimization (EPIC-053/US-006)
-wasm-opt = ["-Os", "--enable-simd"]
+# --enable-bulk-memory required for Rust's memory.copy/fill operations
+wasm-opt = ["-Os", "--enable-simd", "--enable-bulk-memory"]
 
 [package.metadata.wasm-pack.profile.profiling]
 wasm-opt = false


### PR DESCRIPTION
Fixes wasm-pack build failure caused by missing bulk memory feature flag for wasm-opt.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/170">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
