### PR TITLE
fix(wasm): add --enable-nontrapping-float-to-int to wasm-opt

### DIFF
--- a/crates/velesdb-wasm/Cargo.toml
+++ b/crates/velesdb-wasm/Cargo.toml
@@ -60,8 +60,10 @@ serde-wasm-bindgen = "0.6"
 
 [package.metadata.wasm-pack.profile.release]
 # Enable wasm-opt with size optimization (EPIC-053/US-006)
-# --enable-bulk-memory required for Rust's memory.copy/fill operations
-wasm-opt = ["-Os", "--enable-simd", "--enable-bulk-memory"]
+# Required features for Rust-generated WASM:
+# - bulk-memory: memory.copy/fill operations
+# - nontrapping-float-to-int: i32.trunc_sat_f32_u etc.
+wasm-opt = ["-Os", "--enable-simd", "--enable-bulk-memory", "--enable-nontrapping-float-to-int"]
 
 [package.metadata.wasm-pack.profile.profiling]
 wasm-opt = false


### PR DESCRIPTION
Fixes wasm-opt validation errors for i32.trunc_sat_f32_u and i64.trunc_sat_f64_s instructions.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/171">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
