### PR TITLE
fix(tauri): add missing permissions including delete_points (#169)

### DIFF
--- a/crates/tauri-plugin-velesdb/permissions/default.toml
+++ b/crates/tauri-plugin-velesdb/permissions/default.toml
@@ -6,15 +6,34 @@
 [default]
 description = "Default permissions for VelesDB plugin - allows all database operations"
 permissions = [
+    # Collection management
     "allow-create-collection",
+    "allow-create-metadata-collection",
     "allow-delete-collection",
     "allow-list-collections",
     "allow-get-collection",
+    "allow-is-empty",
+    "allow-flush",
+    # Point operations
     "allow-upsert",
+    "allow-upsert-metadata",
+    "allow-get-points",
+    "allow-delete-points",
+    # Search operations
     "allow-search",
+    "allow-batch-search",
     "allow-text-search",
     "allow-hybrid-search",
+    "allow-multi-query-search",
     "allow-query",
+    # AgentMemory (semantic)
+    "allow-semantic-store",
+    "allow-semantic-query",
+    # Knowledge Graph
+    "allow-add-edge",
+    "allow-get-edges",
+    "allow-traverse-graph",
+    "allow-get-node-degree",
 ]
 
 # Read-only permission set
@@ -23,10 +42,18 @@ description = "Read-only permissions - search and list operations only"
 permissions = [
     "allow-list-collections",
     "allow-get-collection",
+    "allow-is-empty",
+    "allow-get-points",
     "allow-search",
+    "allow-batch-search",
     "allow-text-search",
     "allow-hybrid-search",
+    "allow-multi-query-search",
     "allow-query",
+    "allow-semantic-query",
+    "allow-get-edges",
+    "allow-traverse-graph",
+    "allow-get-node-degree",
 ]
 
 # Search-only permission set


### PR DESCRIPTION
Hotfix for Issue #169 - Command delete_points not found in Tauri plugin.

Adds all missing permissions to default.toml and regression tests.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/173">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
