### PR TITLE
fix(agent): prevent ID collision in consolidate_old_episodes

### DIFF
--- a/crates/velesdb-core/src/agent/memory.rs
+++ b/crates/velesdb-core/src/agent/memory.rs
@@ -205,7 +205,14 @@ impl<'a> AgentMemory<'a> {
 
         // Fallback: use random-ish ID based on current time + counter
         let fallback_id = base_id ^ 0xDEAD_BEEF_CAFE_BABE;
-        Ok(fallback_id)
+        if !self.semantic.exists(fallback_id)? {
+            return Ok(fallback_id);
+        }
+
+        // If even the fallback collides, return an error
+        Err(AgentMemoryError::CollectionError(
+            "Unable to generate unique semantic ID after exhausting all candidates".to_string(),
+        ))
     }
 }
 


### PR DESCRIPTION
## Description

Fixes ID collision issue where consolidating episodic events to semantic memory could silently overwrite existing semantic memory entries when they share the same ID.

When `consolidate_old_episodes` moves old episodic events to semantic memory, it now checks if a semantic memory entry with the same ID already exists. If so, it generates a new unique ID to prevent data loss.

**Link to Devin run:** https://app.devin.ai/sessions/ec6ead0df2634e459488878fbda51848
**Requested by:** Julien L (@cyberlife-coder)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)

## Changes

Added to `AgentMemory`:
- `auto_expire(retention_seconds)` - Convenience method for time-based expiration
- `consolidate_old_episodes(cutoff_timestamp)` - Core consolidation with ID collision prevention
- `generate_unique_semantic_id()` - Private helper for unique ID generation

Added to `SemanticMemory`:
- `exists(id)` - Check if an entry with given ID exists

Added to `EpisodicMemory`:
- `get_events_before(cutoff_timestamp)` - Retrieve events older than cutoff
- `delete(event_id)` - Remove an event from episodic memory

## How Has This Been Tested?

- [x] Unit tests (existing tests pass)
- [ ] Integration tests
- [ ] Manual testing

**Test Configuration:**
- OS: Linux
- Rust version: stable

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] My changes generate no new warnings (except one expected `dead_code` warning for the public constant)

## Human Review Checklist

- [ ] Verify ID collision detection logic in `consolidate_old_episodes` is correct
- [ ] Review `generate_unique_semantic_id()` fallback strategy (XOR with magic constant)
- [ ] Note: `get_events_before` scans IDs 0..10000 (same limitation as existing `recent()` method)
- [ ] Note: Consolidated events receive zero-vector embeddings

## Additional Notes

- The `DEFAULT_RETENTION_SECONDS` constant generates a `dead_code` warning since it's a public API constant for users to reference when calling `auto_expire()`
- No unit tests were added for the new consolidation logic - this should be addressed in a follow-up
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/177">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
