### PR TITLE
fix(ci): ignore performance tests in CI

### DIFF
--- a/crates/velesdb-core/src/simd_native/cosine_fused_tests.rs
+++ b/crates/velesdb-core/src/simd_native/cosine_fused_tests.rs
@@ -107,6 +107,7 @@ fn test_fused_cosine_opposite_vectors() {
 }
 
 #[test]
+#[ignore = "Performance test - run locally with: cargo test -- --ignored"]
 fn test_fused_cosine_performance() {
     // Verify performance is acceptable for 768D
     // This is a smoke test - actual benchmarks in benches/

--- a/crates/velesdb-core/src/simd_native/harley_seal_tests.rs
+++ b/crates/velesdb-core/src/simd_native/harley_seal_tests.rs
@@ -141,6 +141,7 @@ fn test_harley_seal_jaccard_disjoint() {
 }
 
 #[test]
+#[ignore = "Performance test - run locally with: cargo test -- --ignored"]
 fn test_harley_seal_jaccard_performance() {
     // Performance test for 768D
     let size = 768;


### PR DESCRIPTION
## Problem\n\nPerformance tests fail consistently on CI runners because they are much slower than local development machines.\n\n## Solution\n\nMark performance tests with \#[ignore]\ so they:\n- Skip in normal CI runs\n- Can still be run locally with: \cargo test -- --ignored\\n\n## Changes\n\n- \simd_native/cosine_fused_tests.rs\: Added #[ignore] to test_fused_cosine_performance\n- \simd_native/harley_seal_tests.rs\: Added #[ignore] to test_harley_seal_jaccard_performance
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/190">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
