### PR TITLE
ci(governance): enforce PR base + freshness guardrails [EPIC-077/US-001]

### DIFF
--- a/.github/workflows/pr-governance.yml
+++ b/.github/workflows/pr-governance.yml
@@ -1,0 +1,42 @@
+name: PR Governance
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  governance:
+    name: PR Base & Freshness Checks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Block archive branches as PR source
+        if: ${{ startsWith(github.event.pull_request.head.ref, 'archive/') }}
+        run: |
+          echo "::error::PR source branch '${{ github.event.pull_request.head.ref }}' is archived and cannot be merged."
+          exit 1
+
+      - name: Ensure PR targets main
+        if: ${{ github.event.pull_request.base.ref != 'main' }}
+        run: |
+          echo "::error::PR base must be 'main'. Current base: '${{ github.event.pull_request.base.ref }}'."
+          exit 1
+
+      - name: Checkout head branch
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - name: Verify branch includes latest origin/main
+        run: |
+          git fetch origin main --depth=1
+          if git merge-base --is-ancestor origin/main HEAD; then
+            echo "OK: HEAD contains latest origin/main."
+          else
+            echo "::error::Branch is behind origin/main. Rebase/merge main before merging."
+            exit 1
+          fi


### PR DESCRIPTION
## Summary\n- add PR governance workflow to enforce GitFlow safety\n- block PRs not targeting main\n- block PRs from rchive/* branches\n- block PRs whose head does not include latest origin/main\n\n## Why\nRecent branch divergence incidents came from stale bases and archive branch reuse.\nThese checks fail fast before merge and keep release flow deterministic.\n\n## Validation\n- pre-push local validation passed (fmt, clippy, tests, deny)\n\n## Impact\n- CI-only change\n- no runtime or API impact\n
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/208" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
