### PR TITLE
feat(velesql): finalize JOIN/MATCH runtime contract and validation [EPIC-045/US-003]

### DIFF
--- a/crates/velesdb-core/src/collection/search/query/mod.rs
+++ b/crates/velesdb-core/src/collection/search/query/mod.rs
@@ -91,17 +91,16 @@ impl Collection {
         query: &crate::velesql::Query,
         params: &std::collections::HashMap<String, serde_json::Value>,
     ) -> Result<Vec<SearchResult>> {
+        crate::velesql::QueryValidator::validate(query)
+            .map_err(|e| crate::error::Error::Query(e.to_string()))?;
+
         // Unified VelesQL dispatch: allow Collection::execute_query() to run top-level MATCH queries.
         if let Some(match_clause) = query.match_clause.as_ref() {
             let mut match_results = self.execute_match(match_clause, params)?;
 
             if let Some(order_by) = match_clause.return_clause.order_by.as_ref() {
                 for item in order_by.iter().rev() {
-                    Self::order_match_results(
-                        &mut match_results,
-                        &item.expression,
-                        item.descending,
-                    );
+                    self.order_match_results(&mut match_results, &item.expression, item.descending);
                 }
             }
 

--- a/crates/velesdb-core/src/velesql/grammar.pest
+++ b/crates/velesdb-core/src/velesql/grammar.pest
@@ -108,7 +108,7 @@ column_ref = @{ identifier ~ "." ~ identifier }
 // ORDER BY clause (EPIC-040 US-002: supports columns, aggregates, similarity)
 order_by_clause = { ^"ORDER" ~ ^"BY" ~ order_by_item ~ ("," ~ order_by_item)* }
 order_by_item = { order_by_expr ~ sort_direction? }
-order_by_expr = { order_by_similarity | aggregate_function | identifier }
+order_by_expr = { order_by_similarity | aggregate_function | property_access | identifier }
 order_by_similarity = { ^"similarity" ~ "(" ~ similarity_field ~ "," ~ vector_value ~ ")" }
 sort_direction = { ^"DESC" | ^"ASC" }
 

--- a/crates/velesdb-core/src/velesql/parser/select/clause_group_order.rs
+++ b/crates/velesdb-core/src/velesql/parser/select/clause_group_order.rs
@@ -147,6 +147,9 @@ impl Parser {
                         false,
                     ));
                 }
+                Rule::property_access => {
+                    return Ok((OrderByExpr::Field(inner_pair.as_str().to_string()), false))
+                }
                 Rule::identifier => {
                     return Ok((OrderByExpr::Field(extract_identifier(&inner_pair)), false))
                 }

--- a/crates/velesdb-server/src/handlers/query.rs
+++ b/crates/velesdb-server/src/handlers/query.rs
@@ -53,6 +53,21 @@ pub async fn query(
         }
     };
 
+    if let Err(e) = velesql::QueryValidator::validate(&parsed) {
+        return (
+            StatusCode::UNPROCESSABLE_ENTITY,
+            Json(VelesqlErrorResponse {
+                error: VelesqlErrorDetail {
+                    code: "VELESQL_VALIDATION_ERROR".to_string(),
+                    message: e.to_string(),
+                    hint: e.suggestion,
+                    details: None,
+                },
+            }),
+        )
+            .into_response();
+    }
+
     let select = &parsed.select;
     let collection_name = if parsed.is_match_query() {
         match req.collection.as_ref().filter(|name| !name.is_empty()) {
@@ -131,9 +146,39 @@ pub async fn query(
         return Json(AggregationResponse { result, timing_ms }).into_response();
     }
 
-    // Standard query execution (database-level for cross-collection JOIN support)
-    let results = match state.db.execute_query(&parsed, &req.params) {
+    // Standard query execution:
+    // - top-level MATCH executes in requested collection context
+    // - SELECT executes through database-level dispatcher for cross-collection JOIN support
+    let execute_result = if parsed.is_match_query() {
+        match state.db.get_collection(&collection_name) {
+            Some(c) => c.execute_query(&parsed, &req.params),
+            None => Err(velesdb_core::Error::CollectionNotFound(
+                collection_name.clone(),
+            )),
+        }
+    } else {
+        state.db.execute_query(&parsed, &req.params)
+    };
+
+    let results = match execute_result {
         Ok(r) => r,
+        Err(velesdb_core::Error::CollectionNotFound(name)) => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(VelesqlErrorResponse {
+                    error: VelesqlErrorDetail {
+                        code: "VELESQL_COLLECTION_NOT_FOUND".to_string(),
+                        message: format!("Collection '{}' not found", name),
+                        hint: "Create the collection first or correct the collection name"
+                            .to_string(),
+                        details: Some(serde_json::json!({
+                            "collection": name
+                        })),
+                    },
+                }),
+            )
+                .into_response()
+        }
         Err(e) => return (
             StatusCode::UNPROCESSABLE_ENTITY,
             Json(VelesqlErrorResponse {

--- a/docs/VELESQL_SPEC.md
+++ b/docs/VELESQL_SPEC.md
@@ -20,8 +20,8 @@ VelesQL is a SQL-inspired query language designed specifically for vector simila
 | ORDER BY | ✅ Stable | 2.0 |
 | GROUP BY, HAVING | ✅ Stable | 2.0 |
 | JOIN (INNER ... ON) | ✅ Stable | 2.0 |
-| JOIN (LEFT, RIGHT, FULL) | ⚠️ Partial (parser/spec) | 2.0 |
-| JOIN USING | ⚠️ Parsed, runtime pending | 2.0 |
+| JOIN (LEFT, RIGHT, FULL) | ⚠️ Parsed + explicit runtime error | 2.0 |
+| JOIN USING | ⚠️ Experimental (single-column runtime support) | 2.0 |
 | Set Operations (UNION, INTERSECT, EXCEPT) | ✅ Stable | 2.0 |
 | USING FUSION | ✅ Stable | 2.0 |
 | NOW() / INTERVAL temporal | ✅ Stable | 2.1 |

--- a/docs/reference/VELESQL_CONTRACT.md
+++ b/docs/reference/VELESQL_CONTRACT.md
@@ -124,8 +124,8 @@ Reference grammar:
 | top-level `MATCH (...) RETURN ...` | Stable | Stable |
 | top-level `MATCH` via `/query` with body `collection` | Stable | Stable |
 | `JOIN ... ON` | Stable | Stable |
-| `JOIN ... USING (...)` | Experimental | Parser only |
-| `LEFT/RIGHT/FULL JOIN` | Experimental | Not runtime-ready |
+| `JOIN ... USING (...)` | Experimental | Stable for single-column USING |
+| `LEFT/RIGHT/FULL JOIN` | Experimental | Explicit runtime error (`Unsupported`) |
 | `GROUP BY` / `HAVING` | Stable | Stable |
 | `UNION/INTERSECT/EXCEPT` | Stable | Stable |
 
@@ -142,8 +142,8 @@ Each invalid case maps to an expected HTTP status and an expected error shape.
 | Feature | Parser | Executor |
 |---------|--------|----------|
 | `JOIN ... ON` | Supported | Supported (inner join) |
-| `JOIN ... USING (...)` | Supported | Not supported |
-| `LEFT/RIGHT/FULL JOIN` | Parsed in spec variants | Not supported in runtime |
+| `JOIN ... USING (...)` | Supported | Supported for single-column USING |
+| `LEFT/RIGHT/FULL JOIN` | Parsed in spec variants | Rejected with explicit runtime error |
 | `GROUP BY`, `HAVING` | Supported | Supported |
 | `ORDER BY similarity()` | Supported | Supported |
 | `UNION/INTERSECT/EXCEPT` | Supported | Supported |

--- a/docs/reference/VELESQL_SPEC.md
+++ b/docs/reference/VELESQL_SPEC.md
@@ -726,7 +726,7 @@ LIMIT 10
 
 | Feature | Status | Workaround |
 |---------|--------|------------|
-| `LEFT/RIGHT/FULL JOIN` | ❌ Not supported | Use basic `JOIN` |
+| `LEFT/RIGHT/FULL JOIN` | ❌ Not supported in executor | Runtime returns explicit error; use `JOIN`/`INNER JOIN` |
 | Subqueries | ❌ Not supported | Use multiple queries |
 | `ORDER BY` aggregates | ❌ Not supported | Sort in application |
 | Nested `GROUP BY` fields | ❌ Not supported | Use simple column names |
@@ -736,7 +736,7 @@ LIMIT 10
 | Feature | Status | Notes |
 |---------|--------|-------|
 | `JOIN ... ON` | ✅ Supported | Basic inner join |
-| `JOIN ... USING (...)` | ⚠️ Partial | Parser support; runtime execution not yet supported |
+| `JOIN ... USING (...)` | ⚠️ Partial | Runtime supports single-column USING only |
 | `GROUP BY` | ✅ Supported | With aggregates |
 | `HAVING` | ✅ Supported | AND/OR operators |
 | `ORDER BY` | ✅ Supported | Columns, similarity() |
@@ -748,7 +748,7 @@ LIMIT 10
 ### Planned Features (Roadmap)
 
 - `LEFT/RIGHT/FULL OUTER JOIN`
-- Full runtime execution for `JOIN USING (column)`
+- Multi-column and composite-key runtime execution for `JOIN USING (...)`
 - `ORDER BY` with aggregates
 - `EXPLAIN` for query analysis
 - Prepared query caching


### PR DESCRIPTION
## Summary
- enforce explicit runtime errors for unsupported/invalid JOIN semantics
- add query validation in collection/database execution paths
- support ORDER BY alias.property parsing/execution for MATCH
- align server /query error mapping and top-level MATCH collection execution
- update VelesQL spec/contract docs with actual runtime support boundaries

## Verification
- cargo fmt --all
- cargo clippy -p velesdb-core -p velesdb-server -- -D warnings
- cargo test -p velesdb-core join_tests -- --nocapture
- cargo test -p velesdb-core test_collection_execute_query_match_order_by_property -- --nocapture
- cargo test -p velesdb-core test_database_execute_query_rejects_left_join_runtime -- --nocapture
- cargo test -p velesdb-core test_database_execute_query_rejects_join_using_multi_column -- --nocapture
- cargo test -p velesdb-server --test api_integration test_velesql_collection_not_found -- --nocapture
- cargo test -p velesdb-server --test api_integration test_query_match_top_level_with_collection -- --nocapture
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/210" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
