### PR TITLE
test(core): cover NOT condition support in query validation

### DIFF
--- a/crates/velesdb-core/src/collection/search/query_validation_tests.rs
+++ b/crates/velesdb-core/src/collection/search/query_validation_tests.rs
@@ -4,9 +4,8 @@
 //! - `validate_similarity_query_structure()` - Rejects unsupported patterns
 //! - NEAR + similarity() combination - Supported pattern for agentic memory
 //!
-//! Note: NOT similarity() tests are commented out because VelesQL parser
-//! does not yet support `NOT condition` syntax (only `IS NOT NULL`).
-//! The validation code exists for future parser extension.
+//! NOTE: `NOT <condition>` is now supported by the parser and execution path.
+//! Keep explicit tests here to prevent regressions in NOT handling.
 
 #[cfg(test)]
 mod tests {
@@ -25,15 +24,46 @@ mod tests {
     }
 
     // =========================================================================
-    // Tests for NOT similarity() rejection
-    // NOTE: VelesQL parser does not support `NOT condition` syntax yet.
-    // These tests are disabled until parser is extended (see EPIC-005).
-    // The validation code in query.rs is ready for when parser supports NOT.
+    // Tests for NOT support with similarity and metadata predicates.
     // =========================================================================
 
-    // TODO: Enable when parser supports NOT condition
-    // #[test]
-    // fn test_not_similarity_is_rejected() { ... }
+    #[test]
+    fn test_not_similarity_is_supported() {
+        let (collection, _temp) = create_test_collection();
+
+        let points = vec![
+            crate::Point {
+                id: 1,
+                vector: vec![1.0, 0.0, 0.0, 0.0],
+                payload: Some(serde_json::json!({"category": "tech"})),
+            },
+            crate::Point {
+                id: 2,
+                vector: vec![0.0, 1.0, 0.0, 0.0],
+                payload: Some(serde_json::json!({"category": "science"})),
+            },
+        ];
+        collection.upsert(points).unwrap();
+
+        let query = "SELECT * FROM test WHERE NOT similarity(vector, $v) > 0.8 LIMIT 10";
+        let parsed = Parser::parse(query).unwrap();
+
+        let mut params = HashMap::new();
+        params.insert("v".to_string(), serde_json::json!([1.0, 0.0, 0.0, 0.0]));
+
+        let result = collection.execute_query(&parsed, &params);
+        assert!(
+            result.is_ok(),
+            "NOT similarity() should be supported: {:?}",
+            result.err()
+        );
+
+        let results = result.unwrap();
+        assert!(
+            results.iter().all(|r| r.point.id != 1),
+            "Vector too close to query should be excluded by NOT similarity()"
+        );
+    }
 
     // =========================================================================
     // Tests for NEAR + similarity() combination (should work)
@@ -128,10 +158,37 @@ mod tests {
     }
 
     // =========================================================================
-    // Tests for NOT with metadata
-    // NOTE: VelesQL parser does not support `NOT condition` syntax yet.
-    // Use != operator instead for negation.
+    // Tests for NOT with metadata.
     // =========================================================================
+
+    #[test]
+    fn test_not_metadata_equality_is_supported() {
+        let (collection, _temp) = create_test_collection();
+
+        let points = vec![
+            crate::Point {
+                id: 1,
+                vector: vec![1.0, 0.0, 0.0, 0.0],
+                payload: Some(serde_json::json!({"category": "tech"})),
+            },
+            crate::Point {
+                id: 2,
+                vector: vec![0.9, 0.1, 0.0, 0.0],
+                payload: Some(serde_json::json!({"category": "science"})),
+            },
+        ];
+        collection.upsert(points).unwrap();
+
+        let query = "SELECT * FROM test WHERE NOT category = 'tech' LIMIT 10";
+        let parsed = Parser::parse(query).unwrap();
+
+        let result = collection.execute_query(&parsed, &HashMap::new());
+        assert!(
+            result.is_ok(),
+            "NOT metadata equality should be supported: {:?}",
+            result.err()
+        );
+    }
 
     #[test]
     fn test_not_equal_metadata_is_supported() {
@@ -151,7 +208,7 @@ mod tests {
         ];
         collection.upsert(points).unwrap();
 
-        // Use != instead of NOT for negation (parser supported)
+        // `!=` remains supported and should behave like a metadata negation shortcut.
         let query = "SELECT * FROM test WHERE category != 'tech' LIMIT 10";
         let parsed = Parser::parse(query).unwrap();
 


### PR DESCRIPTION
### Motivation

- Ensure `velesdb-core` correctly supports generic `NOT <condition>` patterns (including `similarity()` and metadata equality) and prevent regressions in VelesQL handling.

### Description

- Update test module header to reflect that `NOT <condition>` is supported and add focused regression tests in `crates/velesdb-core/src/collection/search/query_validation_tests.rs`.
- Add `test_not_similarity_is_supported` to validate `NOT similarity(vector, $v) > ...` is parsed and executed and assert results exclude near vectors using `r.point.id` access.
- Add `test_not_metadata_equality_is_supported` to validate `NOT category = '...'` metadata negation, and clarify that `!=` remains supported.
- Small test assertion fix to use the correct `SearchResult` structure field (`r.point.id`) and adjust comments for intent clarity.

### Testing

- Ran targeted test attempts with `cargo test -p velesdb-core test_not_similarity_is_supported -- --exact` and `cargo test -p velesdb-core test_not_metadata_equality_is_supported -- --exact`, and iterated on a failing assertion to correct `r.id` -> `r.point.id` (fix applied and committed).
- Compilation and test execution were started for the targeted tests in this environment but full test completion could not be captured due to long compile times and artifact locks in the runner.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699cdd136d98832a8e7141a37adeba1c)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/217" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
