### PR TITLE
docs: add velesdb-core production readiness status and link in docs index

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -39,6 +39,7 @@ In-depth technical documentation:
 | [Performance SLO](./reference/PERFORMANCE_SLO.md) | CI-enforced performance objectives and budget gates |
 | [REST API](./reference/api-reference.md) | HTTP API endpoints |
 | [SIMD Performance](./reference/SIMD_PERFORMANCE.md) | SIMD optimizations and benchmarks |
+| [VelesDB Core Production Readiness](./reference/velesdb-core-production-readiness.md) | Current status, gaps, and production hardening plan for `velesdb-core` |
 
 ---
 

--- a/docs/reference/velesdb-core-production-readiness.md
+++ b/docs/reference/velesdb-core-production-readiness.md
@@ -1,0 +1,56 @@
+# VelesDB Core — Production Readiness Status
+
+Last updated: 2026-02-23.
+
+## 1) Branch synchronization check (before implementation work)
+
+Performed from local branch `work`:
+
+- `git fetch --all --prune`
+- `git branch -a --verbose --no-abbrev`
+
+Current result in this workspace: only branch `work` is present locally/remotely in the configured Git metadata, so a direct `develop` vs `work` diff cannot be computed here.
+
+## 2) Current implementation status of `velesdb-core`
+
+### Core capabilities already present
+
+`velesdb-core` already exposes the production-oriented building blocks expected by the main README and crate README:
+
+- Vector collections with configurable metric and persistence APIs (`Database`, `Collection`, `DistanceMetric`, bulk ingestion, quantization options in docs and public API examples).  
+- Hybrid retrieval stack (vector + text/BM25 + fusion) documented and covered by tests/benchmarks.  
+- VelesQL parser + execution path with SQL-like operations (`SELECT`, `WHERE`, `ORDER BY`, `LIMIT/OFFSET`, vector clauses, `MATCH`, `EXPLAIN`).  
+- Graph query and traversal execution components (`MATCH` planning/execution, traversal APIs).
+
+### Evidence of maturity already in repo
+
+- Extensive test suites dedicated to VelesQL conformance and integration use-cases.  
+- Dedicated EXPLAIN planner + strategy selection, including filter strategy and cost modeling.  
+- Dedicated performance benches for VelesQL execution and end-to-end search workloads.
+
+## 3) Gaps to close for a "full production promise"
+
+The codebase is strong, but the remaining work is mostly **production hardening and contract-proofing** rather than foundational missing features:
+
+1. **Cross-layer contract verification cadence**  
+   Keep runtime route/docs matrix continuously updated and checked in CI to prevent README/API drift.
+
+2. **VelesQL DX guardrails**  
+   Strengthen deterministic behavior and clearer diagnostics for edge cases (placeholder handling, strict validation messaging, execution plan predictability).
+
+3. **Production SLO proof-pack**  
+   Automate reproducible latency/recall/throughput reports from benchmark suites and publish results per release.
+
+4. **Release gates for production profile**  
+   Define mandatory checks before release: critical VelesQL conformance, crash recovery scenarios, and core performance regression thresholds.
+
+## 4) Recommended execution plan (short term)
+
+- **P0**: lock API/query contract truth matrix in release CI.  
+- **P0**: lock VelesQL conformance + alias/parameter regression packs as mandatory for release branches.  
+- **P1**: publish benchmark baselines and fail CI on defined regression budgets.  
+- **P1**: maintain a production-readiness checklist tied to each release tag.
+
+## 5) Practical conclusion
+
+At this point, `velesdb-core` is functionally broad and close to production-complete in scope. The remaining delta to the "velesdb.com + README promise" is primarily about **systematic production guarantees** (contract drift prevention, deterministic query UX, and hard release gates), not a missing core engine.


### PR DESCRIPTION
### Motivation
- Provide a concise production-readiness status for `velesdb-core` that documents current implementation coverage, gaps, and a short-term remediation plan. 
- Make the status discoverable by linking it from the main docs index so contributors and release owners can act on the recommendations.

### Description
- Add `docs/reference/velesdb-core-production-readiness.md` with branch-synchronization notes, current capability inventory, remaining hardening gaps, and a prioritized short-term plan (P0/P1).
- Update `docs/README.md` to include a reference link to the new production-readiness document under the Technical Reference section.
- Commit created on the current branch; changes are documentation-only and do not modify runtime code.

### Testing
- Ran formatting check `cargo fmt --all -- --check` which failed due to pre-existing formatting diffs in unrelated files (`join.rs`, `join_tests.rs`), not caused by this docs change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ce2e10900832abcc2d9242781285c)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/218" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
