### PR TITLE
fix(velesql): normalize WITH option keys to lowercase

### DIFF
--- a/crates/velesdb-core/src/velesql/parser/values.rs
+++ b/crates/velesdb-core/src/velesql/parser/values.rs
@@ -218,7 +218,7 @@ impl Parser {
             .next()
             .ok_or_else(|| ParseError::syntax(0, "", "Expected option key"))?
             .as_str()
-            .to_string();
+            .to_ascii_lowercase();
 
         let value_pair = inner
             .next()


### PR DESCRIPTION
### Motivation
- Fix case-sensitivity gap where `WITH` clause option keys (e.g. `MAX_GROUPS`, `Max_Groups`) were parsed as-is and could be missed by consumers expecting case-insensitive keys.

### Description
- Normalize parsed `WITH` option keys to lowercase in `parse_with_option` by calling `.to_ascii_lowercase()` so keys are stored consistently (`crates/velesdb-core/src/velesql/parser/values.rs`).

### Testing
- Attempted to run the targeted test `cargo test -p velesdb-core test_bug_8_with_max_groups_case_insensitive --lib`, but the `velesdb-core` build/test in this environment did not complete within the execution window (compilation started but no completion output was produced).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ce8d76e94832a83efe16fce1b65e3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/219" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
