### PR TITLE
feat(core): latency-aware two-stage ANN rerank adaptation in velesdb-core

### DIFF
--- a/crates/velesdb-core/src/index/hnsw/index/constructors.rs
+++ b/crates/velesdb-core/src/index/hnsw/index/constructors.rs
@@ -8,6 +8,7 @@ use crate::index::hnsw::sharded_vectors::ShardedVectors;
 use parking_lot::RwLock;
 use std::mem::ManuallyDrop;
 use std::path::Path;
+use std::sync::atomic::AtomicU64;
 
 impl HnswIndex {
     /// Creates a new HNSW index with auto-tuned parameters based on dimension.
@@ -141,6 +142,8 @@ impl HnswIndex {
             mappings,
             vectors: ShardedVectors::new(dimension),
             enable_vector_storage,
+            rerank_latency_target_us: AtomicU64::new(0),
+            rerank_latency_ema_us: AtomicU64::new(0),
             io_holder: None,
         }
     }
@@ -217,6 +220,8 @@ impl HnswIndex {
             mappings,
             vectors: ShardedVectors::new(meta.dimension),
             enable_vector_storage: meta.enable_vector_storage,
+            rerank_latency_target_us: AtomicU64::new(0),
+            rerank_latency_ema_us: AtomicU64::new(0),
             io_holder: None,
         })
     }

--- a/crates/velesdb-core/src/index/hnsw/index/mod.rs
+++ b/crates/velesdb-core/src/index/hnsw/index/mod.rs
@@ -36,6 +36,7 @@ use super::sharded_vectors::ShardedVectors;
 use crate::distance::DistanceMetric;
 use parking_lot::RwLock;
 use std::mem::ManuallyDrop;
+use std::sync::atomic::AtomicU64;
 
 // Native persistence - no HnswIo needed (v1.0+)
 type HnswIo = ();
@@ -117,6 +118,12 @@ pub struct HnswIndex {
     ///
     /// Default: `true` (full functionality)
     pub(crate) enable_vector_storage: bool,
+    /// Optional soft latency target for two-stage reranking (microseconds).
+    ///
+    /// `0` disables latency-aware rerank adaptation.
+    pub(crate) rerank_latency_target_us: AtomicU64,
+    /// Exponential moving average of two-stage rerank latency (microseconds).
+    pub(crate) rerank_latency_ema_us: AtomicU64,
     /// Holds the `HnswIo` for loaded indices.
     ///
     /// # Safety

--- a/crates/velesdb-core/src/index/hnsw/index/search.rs
+++ b/crates/velesdb-core/src/index/hnsw/index/search.rs
@@ -3,8 +3,30 @@
 use super::HnswIndex;
 use crate::distance::DistanceMetric;
 use crate::index::hnsw::params::SearchQuality;
+use std::sync::atomic::Ordering;
+use std::time::Instant;
 
 impl HnswIndex {
+    /// Sets a soft latency target (microseconds) for two-stage reranking adaptation.
+    ///
+    /// A value of `0` disables latency-aware adaptation.
+    pub fn set_rerank_latency_target_us(&self, target_us: u64) {
+        self.rerank_latency_target_us
+            .store(target_us, Ordering::Relaxed);
+    }
+
+    /// Returns the configured soft latency target for reranking (microseconds).
+    #[must_use]
+    pub fn rerank_latency_target_us(&self) -> u64 {
+        self.rerank_latency_target_us.load(Ordering::Relaxed)
+    }
+
+    /// Returns the exponential moving average of reranking latency (microseconds).
+    #[must_use]
+    pub fn rerank_latency_ema_us(&self) -> u64 {
+        self.rerank_latency_ema_us.load(Ordering::Relaxed)
+    }
+
     /// Validates that the query/vector dimension matches the index dimension.
     ///
     /// RF-2.7: Helper to eliminate 7x duplicated validation pattern.
@@ -90,7 +112,43 @@ impl HnswIndex {
             _ => return None,
         };
 
-        Some(rerank_k.min(len.max(k)))
+        let bounded = rerank_k.min(len.max(k));
+        Some(self.adapt_rerank_k_to_latency(bounded, k))
+    }
+
+    #[inline]
+    fn adapt_rerank_k_to_latency(&self, rerank_k: usize, k: usize) -> usize {
+        let target_us = self.rerank_latency_target_us.load(Ordering::Relaxed);
+        if target_us == 0 || rerank_k <= k {
+            return rerank_k;
+        }
+
+        let ema_us = self.rerank_latency_ema_us.load(Ordering::Relaxed);
+        if ema_us == 0 {
+            return rerank_k;
+        }
+
+        if ema_us > target_us + (target_us / 4) {
+            ((rerank_k * 3) / 4).max(k)
+        } else if ema_us + (target_us / 5) < target_us {
+            (rerank_k + (rerank_k / 5)).max(k)
+        } else {
+            rerank_k
+        }
+    }
+
+    #[inline]
+    fn update_rerank_latency_ema(&self, sample_us: u64) {
+        const ALPHA_NUM: u64 = 1;
+        const ALPHA_DEN: u64 = 8;
+
+        let current = self.rerank_latency_ema_us.load(Ordering::Relaxed);
+        let next = if current == 0 {
+            sample_us
+        } else {
+            ((ALPHA_DEN - ALPHA_NUM) * current + (ALPHA_NUM * sample_us)) / ALPHA_DEN
+        };
+        self.rerank_latency_ema_us.store(next, Ordering::Relaxed);
     }
 
     /// Searches for the k nearest neighbors with a specific quality profile.
@@ -188,6 +246,8 @@ impl HnswIndex {
             return Vec::new();
         }
 
+        let rerank_start = Instant::now();
+
         // 2. Re-rank using SIMD-optimized exact distance computation
         // EPIC-A.2: Collect candidate vectors from ShardedVectors for re-ranking
         let candidate_vectors: Vec<(u64, usize, Vec<f32>)> = candidates
@@ -219,6 +279,9 @@ impl HnswIndex {
         self.metric.sort_results(&mut reranked);
 
         reranked.truncate(k);
+        let elapsed_micros = rerank_start.elapsed().as_micros();
+        let elapsed = u64::try_from(elapsed_micros).unwrap_or(u64::MAX);
+        self.update_rerank_latency_ema(elapsed);
         reranked
     }
 
@@ -383,6 +446,8 @@ impl HnswIndex {
             return Vec::new();
         }
 
+        let rerank_start = Instant::now();
+
         // 2. Re-rank using SIMD-optimized exact distance computation
         // EPIC-A.2: Collect candidate vectors from ShardedVectors
         let candidate_vectors: Vec<(u64, usize, Vec<f32>)> = candidates
@@ -413,6 +478,9 @@ impl HnswIndex {
         self.metric.sort_results(&mut reranked);
 
         reranked.truncate(k);
+        let elapsed_micros = rerank_start.elapsed().as_micros();
+        let elapsed = u64::try_from(elapsed_micros).unwrap_or(u64::MAX);
+        self.update_rerank_latency_ema(elapsed);
         reranked
     }
 

--- a/crates/velesdb-core/src/index/hnsw/index_tests.rs
+++ b/crates/velesdb-core/src/index/hnsw/index_tests.rs
@@ -1158,6 +1158,33 @@ fn test_recall_quality_minimum_threshold() {
 }
 
 #[test]
+fn test_rerank_latency_target_configuration_roundtrip() {
+    let index = HnswIndex::new(32, DistanceMetric::Cosine);
+    assert_eq!(index.rerank_latency_target_us(), 0);
+
+    index.set_rerank_latency_target_us(250);
+    assert_eq!(index.rerank_latency_target_us(), 250);
+}
+
+#[test]
+fn test_rerank_latency_ema_updates_after_two_stage_search() {
+    let index = HnswIndex::new(64, DistanceMetric::Cosine);
+    index.set_rerank_latency_target_us(1);
+
+    for i in 0u64..1500 {
+        let v: Vec<f32> = (0..64)
+            .map(|j| ((i * 5 + j as u64) as f32 * 0.0013).sin())
+            .collect();
+        index.insert(i, &v);
+    }
+
+    let query: Vec<f32> = (0..64).map(|j| (j as f32 * 0.009).cos()).collect();
+    let _ = index.search_with_quality(&query, 20, SearchQuality::Accurate);
+
+    assert!(index.rerank_latency_ema_us() > 0);
+}
+
+#[test]
 fn test_search_with_quality_custom_ef_uses_high_recall_path_without_regression() {
     let index = HnswIndex::new(64, DistanceMetric::Cosine);
 


### PR DESCRIPTION
### Motivation
- Continue ANN SOTA audit P1 work by making two-stage SIMD reranking adaptive to observed latency so query-time quality policies respect soft latency targets.
- Reduce risk of long-tail latency spikes during large candidate re-ranking by tracking rerank costs and shrinking/expanding the candidate count (`rerank_k`) automatically.

### Description
- Added two atomic fields to `HnswIndex`: `rerank_latency_target_us` and `rerank_latency_ema_us` to store a soft latency SLO (microseconds) and an EMA of observed rerank latency.
- Initialized the new fields in all constructors and load paths so newly created and loaded indices start with sane defaults (`0` = disabled).
- Exposed a small public API to configure/read the target via `set_rerank_latency_target_us()` and the getters `rerank_latency_target_us()` and `rerank_latency_ema_us()`.
- Implemented `adapt_rerank_k_to_latency()` and `update_rerank_latency_ema()` and wired sampling around the SIMD re-rank phases (`search_with_rerank_with_ef` and `search_with_rerank_quality`) using `Instant` to measure rerank time and adapt `rerank_k` when appropriate.
- Added unit tests `test_rerank_latency_target_configuration_roundtrip` and `test_rerank_latency_ema_updates_after_two_stage_search` to validate configuration and EMA update behavior.

### Testing
- Ran `cargo fmt --all` successfully to format the changes.
- Ran `cargo test -p velesdb-core rerank_latency_target_configuration_roundtrip` and it passed.
- Ran `cargo test -p velesdb-core rerank_latency_ema_updates_after_two_stage_search` and it passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e2440d69c832aa9f44759d998dcec)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/222" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
