### PR TITLE
Fix security evidence script when ripgrep returns no matches

### DIFF
--- a/scripts/generate-security-evidence-pack.sh
+++ b/scripts/generate-security-evidence-pack.sh
@@ -13,8 +13,8 @@ if command -v cargo >/dev/null 2>&1 && cargo deny --version >/dev/null 2>&1; the
   fi
 fi
 
-UNSAFE_COUNT="$(rg -n "\bunsafe\b" crates/velesdb-core/src | wc -l | tr -d ' ')"
-FUZZ_TARGETS="$(rg --files fuzz | wc -l | tr -d ' ')"
+UNSAFE_COUNT="$( (rg -n "\bunsafe\b" crates/velesdb-core/src 2>/dev/null || true) | wc -l | tr -d ' ' )"
+FUZZ_TARGETS="$( (rg --files fuzz 2>/dev/null || true) | wc -l | tr -d ' ' )"
 
 cat > "$OUT" <<MD
 # Security Evidence Pack


### PR DESCRIPTION
### Motivation
- The security evidence generator aborted under `set -euo pipefail` when `rg` returned non-zero (no matches or missing directory), causing the script to fail instead of reporting `0` counts.

### Description
- Guarded both `rg` invocations in `scripts/generate-security-evidence-pack.sh` with `2>/dev/null || true` inside the counting pipeline so the substitutions yield `0` instead of causing the script to exit.

### Testing
- Ran `bash -n scripts/generate-security-evidence-pack.sh` (syntax check), executed `bash scripts/generate-security-evidence-pack.sh` to generate the output file, and ran a `set -euo pipefail` reproduction that simulates missing directories which printed `0,0`; all checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e2c74c298832a9b75aea4a6314300)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/227" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
