### PR TITLE
Handle quoted dotted identifiers in JOIN conditions and add robustness tests

### DIFF
--- a/crates/velesdb-core/src/velesql/parser/mod.rs
+++ b/crates/velesdb-core/src/velesql/parser/mod.rs
@@ -13,6 +13,8 @@ mod match_clause_tests;
 #[cfg(test)]
 mod match_query_tests;
 #[cfg(test)]
+mod robustness_tests;
+#[cfg(test)]
 mod subquery_tests;
 #[cfg(test)]
 mod temporal_tests;

--- a/crates/velesdb-core/src/velesql/parser/robustness_tests.rs
+++ b/crates/velesdb-core/src/velesql/parser/robustness_tests.rs
@@ -1,0 +1,24 @@
+//! Robustness regression tests for parser panic-prone paths.
+
+use crate::velesql::Parser;
+
+#[test]
+fn parse_join_condition_handles_quoted_identifiers_with_dots() {
+    let query = r#"SELECT * FROM users AS u JOIN orders AS o ON `tenant.users`.id = "order.items"."user""id""#;
+
+    let parsed = Parser::parse(query).expect("query with quoted JOIN identifiers should parse");
+    let join = parsed
+        .select
+        .joins
+        .first()
+        .expect("expected one JOIN clause");
+    let condition = join
+        .condition
+        .as_ref()
+        .expect("expected JOIN condition in ON clause");
+
+    assert_eq!(condition.left.table.as_deref(), Some("tenant.users"));
+    assert_eq!(condition.left.column, "id");
+    assert_eq!(condition.right.table.as_deref(), Some("order.items"));
+    assert_eq!(condition.right.column, "user\"id");
+}

--- a/crates/velesdb-core/src/velesql/parser/select/clause_from_join.rs
+++ b/crates/velesdb-core/src/velesql/parser/select/clause_from_join.rs
@@ -2,7 +2,7 @@
 
 use super::super::{extract_identifier, Rule};
 use crate::velesql::ast::{ColumnRef, JoinClause, JoinCondition};
-use crate::velesql::error::ParseError;
+use crate::velesql::error::{ParseError, ParseErrorKind};
 use crate::velesql::Parser;
 
 impl Parser {
@@ -106,21 +106,40 @@ impl Parser {
     pub(crate) fn parse_join_condition(
         pair: pest::iterators::Pair<Rule>,
     ) -> Result<JoinCondition, ParseError> {
-        let mut refs: Vec<ColumnRef> = Vec::new();
-        for inner_pair in pair.into_inner() {
-            if inner_pair.as_rule() == Rule::column_ref {
-                refs.push(Self::parse_column_ref(&inner_pair)?);
-            }
-        }
-        if refs.len() != 2 {
-            return Err(ParseError::syntax(
-                0,
-                "",
-                "JOIN condition requires exactly two column references",
+        let pair_start = pair.as_span().start();
+        let pair_text = pair.as_str().to_string();
+        let mut refs = pair
+            .into_inner()
+            .filter(|inner_pair| inner_pair.as_rule() == Rule::column_ref)
+            .map(|inner_pair| Self::parse_column_ref(&inner_pair));
+
+        let left = refs.next().transpose()?.ok_or_else(|| {
+            ParseError::new(
+                ParseErrorKind::SyntaxError,
+                pair_start,
+                pair_text.clone(),
+                "Expected left-side column reference in JOIN condition.".to_string(),
+            )
+        })?;
+
+        let right = refs.next().transpose()?.ok_or_else(|| {
+            ParseError::new(
+                ParseErrorKind::SyntaxError,
+                pair_start,
+                pair_text.clone(),
+                "Expected right-side column reference in JOIN condition.".to_string(),
+            )
+        })?;
+
+        if refs.next().is_some() {
+            return Err(ParseError::new(
+                ParseErrorKind::SyntaxError,
+                pair_start,
+                pair_text,
+                "JOIN condition must contain exactly two column references.".to_string(),
             ));
         }
-        let right = refs.pop().expect("right ref validated by len check");
-        let left = refs.pop().expect("left ref validated by len check");
+
         Ok(JoinCondition { left, right })
     }
 
@@ -128,17 +147,85 @@ impl Parser {
         pair: &pest::iterators::Pair<Rule>,
     ) -> Result<ColumnRef, ParseError> {
         let s = pair.as_str();
-        let parts: Vec<&str> = s.split('.').collect();
-        if parts.len() != 2 {
-            return Err(ParseError::syntax(
-                0,
+        let (table, column) = Self::split_column_ref(s).ok_or_else(|| {
+            ParseError::new(
+                ParseErrorKind::SyntaxError,
+                pair.as_span().start(),
                 s,
-                "Column reference must be in format 'table.column'",
-            ));
-        }
+                "Column reference must be in format 'table.column'.".to_string(),
+            )
+        })?;
+
         Ok(ColumnRef {
-            table: Some(parts[0].to_string()),
-            column: parts[1].to_string(),
+            table: Some(table),
+            column,
         })
+    }
+
+    fn split_column_ref(input: &str) -> Option<(String, String)> {
+        let mut separator_index = None;
+        let mut chars = input.char_indices().peekable();
+        let mut in_backtick = false;
+        let mut in_double_quotes = false;
+
+        while let Some((index, ch)) = chars.next() {
+            if in_backtick {
+                if ch == '`' {
+                    in_backtick = false;
+                }
+                continue;
+            }
+
+            if in_double_quotes {
+                if ch == '"' {
+                    if matches!(chars.peek(), Some((_, '"'))) {
+                        chars.next();
+                    } else {
+                        in_double_quotes = false;
+                    }
+                }
+                continue;
+            }
+
+            match ch {
+                '`' => in_backtick = true,
+                '"' => in_double_quotes = true,
+                '.' => {
+                    if separator_index.replace(index).is_some() {
+                        return None;
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        if in_backtick || in_double_quotes {
+            return None;
+        }
+
+        let dot_index = separator_index?;
+        let (left, right_with_dot) = input.split_at(dot_index);
+        let right = right_with_dot.strip_prefix('.')?;
+
+        if left.is_empty() || right.is_empty() {
+            return None;
+        }
+
+        Some((
+            Self::normalize_identifier(left),
+            Self::normalize_identifier(right),
+        ))
+    }
+
+    fn normalize_identifier(identifier: &str) -> String {
+        if identifier.starts_with('`') && identifier.ends_with('`') && identifier.len() >= 2 {
+            return identifier[1..identifier.len() - 1].to_string();
+        }
+
+        if identifier.starts_with('"') && identifier.ends_with('"') && identifier.len() >= 2 {
+            return identifier[1..identifier.len() - 1].replace("\"\"", "\"");
+        }
+
+        identifier.to_string()
     }
 }


### PR DESCRIPTION
### Motivation

- The JOIN condition parsing previously split column references naively on '.' which caused panics or incorrect parsing when identifiers were quoted and contained dots or embedded quotes.

### Description

- Add `split_column_ref` and `normalize_identifier` helpers to correctly locate the separator dot while respecting backtick and double-quote quoting and to strip/unescape quoted identifiers. 
- Refactor `parse_join_condition` to use an iterator-based parse of exactly two `column_ref` entries and to return richer `ParseError` values using `ParseErrorKind` and span/text context. 
- Update `parse_column_ref` to call `split_column_ref` and construct `ColumnRef` from the normalized table and column parts. 
- Add a robustness test `parse_join_condition_handles_quoted_identifiers_with_dots` and register `robustness_tests` in the test modules to cover quoted identifiers containing dots and embedded double-quotes.

### Testing

- Ran unit tests with `cargo test` for the crate, and the new test `parse_join_condition_handles_quoted_identifiers_with_dots` passed. 
- Existing parser test suites (including `match_clause_tests`, `match_query_tests`, `subquery_tests`, and `temporal_tests`) were executed and remained green.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e27f412cc832a823a2b1a50580a10)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/229" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
