### PR TITLE
Add NDJSON streaming upsert endpoint with batching and tests

### DIFF
--- a/crates/velesdb-server/src/handlers/mod.rs
+++ b/crates/velesdb-server/src/handlers/mod.rs
@@ -28,7 +28,7 @@ pub use collections::{
 };
 pub use health::health_check;
 pub use indexes::{create_index, delete_index, list_indexes};
-pub use points::{delete_point, get_point, upsert_points};
+pub use points::{delete_point, get_point, stream_upsert_points, upsert_points};
 // EPIC-058 US-007: match_query handler for /collections/{name}/match
 pub use match_query::match_query;
 pub use query::{explain, query};

--- a/crates/velesdb-server/src/handlers/points.rs
+++ b/crates/velesdb-server/src/handlers/points.rs
@@ -1,16 +1,76 @@
 //! Point operations handlers.
 
 use axum::{
+    body::Body,
     extract::{Path, State},
     http::StatusCode,
     response::IntoResponse,
     Json,
 };
+use futures::StreamExt;
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 use crate::types::{ErrorResponse, UpsertPointsRequest};
 use crate::AppState;
-use velesdb_core::Point;
+use velesdb_core::{Collection, Point};
+
+const STREAM_BATCH_SIZE: usize = 100;
+const STREAM_BATCH_MAX_WAIT: Duration = Duration::from_millis(100);
+
+#[derive(Default)]
+struct StreamUpsertStats {
+    inserted: usize,
+    malformed: usize,
+    failed_upserts: usize,
+}
+
+fn parse_ndjson_line(line: &str, batch: &mut Vec<Point>, stats: &mut StreamUpsertStats) {
+    if line.is_empty() {
+        return;
+    }
+
+    match serde_json::from_str::<Point>(line) {
+        Ok(point) => batch.push(point),
+        Err(error) => {
+            stats.malformed += 1;
+            tracing::warn!(error = %error, "Skipping malformed NDJSON point");
+        }
+    }
+}
+
+async fn flush_point_batch(
+    collection: Collection,
+    batch: &mut Vec<Point>,
+    stats: &mut StreamUpsertStats,
+) {
+    if batch.is_empty() {
+        return;
+    }
+
+    let points = std::mem::take(batch);
+    let batch_size = points.len();
+
+    match tokio::task::spawn_blocking(move || collection.upsert_bulk(&points)).await {
+        Ok(Ok(inserted)) => stats.inserted += inserted,
+        Ok(Err(error)) => {
+            stats.failed_upserts += batch_size;
+            tracing::error!(
+                error = %error,
+                batch_size,
+                "Failed to upsert streamed batch"
+            );
+        }
+        Err(error) => {
+            stats.failed_upserts += batch_size;
+            tracing::error!(
+                error = %error,
+                batch_size,
+                "Stream upsert batch task panicked"
+            );
+        }
+    }
+}
 
 /// Upsert points to a collection.
 #[utoipa::path(
@@ -76,6 +136,84 @@ pub async fn upsert_points(
         )
             .into_response(),
     }
+}
+
+/// Stream upsert points using NDJSON.
+#[utoipa::path(
+    post,
+    path = "/collections/{name}/points/stream",
+    tag = "points",
+    params(
+        ("name" = String, Path, description = "Collection name")
+    ),
+    request_body(content = String, content_type = "application/x-ndjson", description = "NDJSON stream with one point per line"),
+    responses(
+        (status = 200, description = "Stream processed", body = Object),
+        (status = 404, description = "Collection not found", body = ErrorResponse)
+    )
+)]
+pub async fn stream_upsert_points(
+    State(state): State<Arc<AppState>>,
+    Path(name): Path<String>,
+    body: Body,
+) -> impl IntoResponse {
+    let collection = match state.db.get_collection(&name) {
+        Some(c) => c,
+        None => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(ErrorResponse {
+                    error: format!("Collection '{}' not found", name),
+                }),
+            )
+                .into_response()
+        }
+    };
+
+    let mut stream = body.into_data_stream();
+    let mut buffer = Vec::<u8>::new();
+    let mut batch = Vec::with_capacity(STREAM_BATCH_SIZE);
+    let mut stats = StreamUpsertStats::default();
+    let mut last_flush = Instant::now();
+
+    while let Some(chunk_result) = stream.next().await {
+        match chunk_result {
+            Ok(chunk) => {
+                buffer.extend_from_slice(&chunk);
+
+                while let Some(newline_pos) = buffer.iter().position(|byte| *byte == b'\n') {
+                    let line_bytes: Vec<u8> = buffer.drain(..=newline_pos).collect();
+                    let line = String::from_utf8_lossy(&line_bytes);
+                    parse_ndjson_line(line.trim(), &mut batch, &mut stats);
+
+                    if batch.len() >= STREAM_BATCH_SIZE
+                        || (!batch.is_empty() && last_flush.elapsed() >= STREAM_BATCH_MAX_WAIT)
+                    {
+                        flush_point_batch(collection.clone(), &mut batch, &mut stats).await;
+                        last_flush = Instant::now();
+                    }
+                }
+            }
+            Err(error) => {
+                tracing::warn!(error = %error, "Error while reading request body stream");
+            }
+        }
+    }
+
+    if !buffer.is_empty() {
+        let line = String::from_utf8_lossy(&buffer);
+        parse_ndjson_line(line.trim(), &mut batch, &mut stats);
+    }
+
+    flush_point_batch(collection, &mut batch, &mut stats).await;
+
+    Json(serde_json::json!({
+        "message": "Stream processed",
+        "inserted": stats.inserted,
+        "malformed": stats.malformed,
+        "failed_upserts": stats.failed_upserts
+    }))
+    .into_response()
 }
 
 /// Get a point by ID.

--- a/crates/velesdb-server/src/lib.rs
+++ b/crates/velesdb-server/src/lib.rs
@@ -35,8 +35,8 @@ pub use types::*;
 pub use handlers::{
     batch_search, create_collection, create_index, delete_collection, delete_index, delete_point,
     explain, flush_collection, get_collection, get_point, health_check, hybrid_search, is_empty,
-    list_collections, list_indexes, match_query, multi_query_search, query, search, text_search,
-    upsert_points,
+    list_collections, list_indexes, match_query, multi_query_search, query, search,
+    stream_upsert_points, text_search, upsert_points,
 };
 
 // FLAG-2 FIX: Re-export graph handlers for routing (EPIC-016/US-031, US-050)
@@ -83,6 +83,7 @@ pub use handlers::metrics::{health_metrics, prometheus_metrics};
         handlers::collections::get_collection,
         handlers::collections::delete_collection,
         handlers::points::upsert_points,
+        handlers::points::stream_upsert_points,
         handlers::points::get_point,
         handlers::points::delete_point,
         handlers::search::search,
@@ -171,6 +172,10 @@ mod tests {
             "Should document collections by name"
         );
         assert!(json.contains("/points"), "Should document points endpoint");
+        assert!(
+            json.contains(r"/collections/{name}/points/stream"),
+            "Should document points stream endpoint"
+        );
         assert!(json.contains("/search"), "Should document search endpoint");
         assert!(json.contains("/query"), "Should document /query");
     }

--- a/crates/velesdb-server/src/main.rs
+++ b/crates/velesdb-server/src/main.rs
@@ -19,8 +19,8 @@ use velesdb_server::{
     add_edge, batch_search, create_collection, create_index, delete_collection, delete_index,
     delete_point, flush_collection, get_collection, get_edges, get_node_degree, get_point,
     health_check, hybrid_search, is_empty, list_collections, list_indexes, match_query,
-    multi_query_search, query, search, text_search, traverse_graph, upsert_points, ApiDoc,
-    AppState, GraphService,
+    multi_query_search, query, search, stream_upsert_points, text_search, traverse_graph,
+    upsert_points, ApiDoc, AppState, GraphService,
 };
 
 /// VelesDB Server - A high-performance vector database
@@ -100,6 +100,10 @@ async fn main() -> anyhow::Result<()> {
         .route("/collections/{name}/flush", post(flush_collection))
         // 100MB limit for batch vector uploads (1000 vectors × 768D × 4 bytes = ~3MB typical)
         .route("/collections/{name}/points", post(upsert_points))
+        .route(
+            "/collections/{name}/points/stream",
+            post(stream_upsert_points),
+        )
         .layer(DefaultBodyLimit::max(100 * 1024 * 1024))
         .route(
             "/collections/{name}/points/{id}",

--- a/crates/velesdb-server/tests/api_integration.rs
+++ b/crates/velesdb-server/tests/api_integration.rs
@@ -8,6 +8,7 @@ use axum::{
     http::{Request, StatusCode},
 };
 use common::create_test_app;
+use futures::stream;
 use serde_json::{json, Value};
 use tempfile::TempDir;
 use tower::ServiceExt;
@@ -215,6 +216,168 @@ async fn test_upsert_and_search() {
     let json: Value = serde_json::from_slice(&body).expect("Invalid JSON");
 
     assert!(json["results"].is_array());
+}
+
+#[tokio::test]
+async fn test_stream_upsert_ndjson() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let app = create_test_app(&temp_dir);
+
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/collections")
+                .header("Content-Type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "name": "stream_vectors",
+                        "dimension": 3,
+                        "metric": "cosine"
+                    })
+                    .to_string(),
+                ))
+                .expect("Failed to build request"),
+        )
+        .await
+        .expect("Request failed");
+
+    assert_eq!(response.status(), StatusCode::CREATED);
+
+    let ndjson_lines = vec![
+        r#"{"id": 10, "vector": [1.0, 0.0, 0.0], "payload": {"source":"a"}}
+"#,
+        "not-a-json-line
+",
+        r#"{"id": 11, "vector": [0.0, 1.0, 0.0]}
+"#,
+        r#"{"id": 12, "vector": [0.0, 0.0, 1.0]}
+"#,
+    ];
+
+    let stream_body = Body::from_stream(stream::iter(
+        ndjson_lines
+            .into_iter()
+            .map(|line| Ok::<_, std::io::Error>(line.to_string())),
+    ));
+
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/collections/stream_vectors/points/stream")
+                .header("Content-Type", "application/x-ndjson")
+                .body(stream_body)
+                .expect("Failed to build request"),
+        )
+        .await
+        .expect("Request failed");
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("Failed to read body");
+    let json: Value = serde_json::from_slice(&body).expect("Invalid JSON");
+
+    assert_eq!(json["inserted"], 3);
+    assert_eq!(json["malformed"], 1);
+
+    for point_id in [10_u64, 11, 12] {
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/collections/stream_vectors/points/{point_id}"))
+                    .body(Body::empty())
+                    .expect("Failed to build request"),
+            )
+            .await
+            .expect("Request failed");
+
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+}
+
+#[tokio::test]
+async fn test_stream_upsert_ndjson_chunked_without_trailing_newline() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let app = create_test_app(&temp_dir);
+
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/collections")
+                .header("Content-Type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "name": "stream_chunked",
+                        "dimension": 2,
+                        "metric": "cosine"
+                    })
+                    .to_string(),
+                ))
+                .expect("Failed to build request"),
+        )
+        .await
+        .expect("Request failed");
+
+    assert_eq!(response.status(), StatusCode::CREATED);
+
+    let chunks = vec![
+        r#"{"id":101,"vector":[1.0,0.0]"#,
+        r#","payload":{"source":"chunk"}}
+{"id":102,"#,
+        r#""vector":[0.0,1.0]}"#,
+    ];
+
+    let stream_body = Body::from_stream(stream::iter(
+        chunks
+            .into_iter()
+            .map(|chunk| Ok::<_, std::io::Error>(chunk.to_string())),
+    ));
+
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/collections/stream_chunked/points/stream")
+                .header("Content-Type", "application/x-ndjson")
+                .body(stream_body)
+                .expect("Failed to build request"),
+        )
+        .await
+        .expect("Request failed");
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("Failed to read body");
+    let json: Value = serde_json::from_slice(&body).expect("Invalid JSON");
+
+    assert_eq!(json["inserted"], 2);
+    assert_eq!(json["malformed"], 0);
+
+    for point_id in [101_u64, 102] {
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/collections/stream_chunked/points/{point_id}"))
+                    .body(Body::empty())
+                    .expect("Failed to build request"),
+            )
+            .await
+            .expect("Request failed");
+
+        assert_eq!(response.status(), StatusCode::OK);
+    }
 }
 
 #[tokio::test]

--- a/crates/velesdb-server/tests/common/mod.rs
+++ b/crates/velesdb-server/tests/common/mod.rs
@@ -11,7 +11,8 @@ use velesdb_core::Database;
 use velesdb_server::{
     add_edge, batch_search, create_collection, delete_collection, delete_point, get_collection,
     get_edges, get_node_degree, get_point, health_check, hybrid_search, list_collections, query,
-    search, text_search, traverse_graph, upsert_points, AppState, GraphService,
+    search, stream_upsert_points, text_search, traverse_graph, upsert_points, AppState,
+    GraphService,
 };
 
 /// Helper to create test app with all routes
@@ -31,6 +32,10 @@ pub fn create_test_app(temp_dir: &TempDir) -> Router {
             get(get_collection).delete(delete_collection),
         )
         .route("/collections/{name}/points", post(upsert_points))
+        .route(
+            "/collections/{name}/points/stream",
+            post(stream_upsert_points),
+        )
         .route(
             "/collections/{name}/points/{id}",
             get(get_point).delete(delete_point),


### PR DESCRIPTION
### Motivation

- Support large or chunked point uploads without requiring the entire payload in memory by accepting NDJSON streaming uploads to `/collections/{name}/points/stream`.
- Improve robustness by parsing line-delimited JSON, skipping malformed lines, and reporting per-stream statistics.

### Description

- Implemented `stream_upsert_points` in `crates/velesdb-server/src/handlers/points.rs` which consumes an `application/x-ndjson` body, parses NDJSON lines, batches points, and flushes with `tokio::task::spawn_blocking` to `Collection::upsert_bulk`, while tracking `inserted`, `malformed`, and `failed_upserts` in `StreamUpsertStats`.
- Added helper functions and constants `STREAM_BATCH_SIZE` and `STREAM_BATCH_MAX_WAIT`, `parse_ndjson_line`, and `flush_point_batch` to support batching and timed flushes, and exported the handler via `handlers::mod.rs` and `lib.rs`.
- Registered the streaming route in `main.rs` and the test app in `tests/common/mod.rs`, and updated OpenAPI docs in `lib.rs` to include the new streaming path.
- Added integration tests in `crates/velesdb-server/tests/api_integration.rs` to validate NDJSON streaming behavior, chunked streams without trailing newline, and malformed-line handling.

### Testing

- Ran `cargo test` for the server crate which executed unit tests (including OpenAPI spec tests) and they passed.
- Ran integration tests in `crates/velesdb-server/tests/api_integration.rs` which include `test_stream_upsert_ndjson` and `test_stream_upsert_ndjson_chunked_without_trailing_newline`, and they passed.
- Verified the new endpoint is documented in the generated OpenAPI JSON via the existing OpenAPI tests which passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e56a67960832a878ef1b6df89f03f)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/231" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
