### PR TITLE
Add SSE streaming graph traversal endpoint and integration test

### DIFF
--- a/crates/velesdb-server/src/handlers/graph/stream.rs
+++ b/crates/velesdb-server/src/handlers/graph/stream.rs
@@ -8,7 +8,6 @@ use axum::{
 };
 use futures::stream::{self, Stream};
 use std::convert::Infallible;
-use std::sync::Arc;
 use std::time::Instant;
 
 use super::service::GraphService;
@@ -25,7 +24,7 @@ use super::types::{
 /// - `error`: If an error occurs
 #[allow(clippy::unused_async)]
 pub async fn stream_traverse(
-    State(graph_service): State<Arc<GraphService>>,
+    State(graph_service): State<GraphService>,
     Path(collection): Path<String>,
     Query(params): Query<StreamTraverseParams>,
 ) -> Sse<impl Stream<Item = Result<Event, Infallible>>> {

--- a/crates/velesdb-server/src/main.rs
+++ b/crates/velesdb-server/src/main.rs
@@ -19,8 +19,8 @@ use velesdb_server::{
     add_edge, batch_search, create_collection, create_index, delete_collection, delete_index,
     delete_point, flush_collection, get_collection, get_edges, get_node_degree, get_point,
     health_check, hybrid_search, is_empty, list_collections, list_indexes, match_query,
-    multi_query_search, query, search, text_search, traverse_graph, upsert_points, ApiDoc,
-    AppState, GraphService,
+    multi_query_search, query, search, stream_traverse, text_search, traverse_graph, upsert_points,
+    ApiDoc, AppState, GraphService,
 };
 
 /// VelesDB Server - A high-performance vector database
@@ -79,6 +79,10 @@ async fn main() -> anyhow::Result<()> {
             get(get_edges).post(add_edge),
         )
         .route("/collections/{name}/graph/traverse", post(traverse_graph))
+        .route(
+            "/collections/{name}/graph/traverse/stream",
+            get(stream_traverse),
+        )
         .route(
             "/collections/{name}/graph/nodes/{node_id}/degree",
             get(get_node_degree),

--- a/crates/velesdb-server/tests/api_integration.rs
+++ b/crates/velesdb-server/tests/api_integration.rs
@@ -8,6 +8,7 @@ use axum::{
     http::{Request, StatusCode},
 };
 use common::create_test_app;
+use reqwest::header::CONTENT_TYPE;
 use serde_json::{json, Value};
 use tempfile::TempDir;
 use tower::ServiceExt;
@@ -1988,6 +1989,66 @@ async fn test_graph_traverse_invalid_strategy() {
         .expect("Request failed");
 
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn test_graph_traverse_stream_sse() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let (base_url, shutdown_tx) = common::spawn_test_server(&temp_dir).await;
+
+    let client = reqwest::Client::builder()
+        .no_proxy()
+        .build()
+        .expect("Failed to build HTTP client");
+
+    // Build a graph: 1 -> 2 -> 3
+    for (id, src, tgt) in [(1, 1, 2), (2, 2, 3)] {
+        let response = client
+            .post(format!("{base_url}/collections/stream_test/graph/edges"))
+            .json(&json!({
+                "id": id,
+                "source": src,
+                "target": tgt,
+                "label": "KNOWS"
+            }))
+            .send()
+            .await
+            .expect("Request failed");
+        assert_eq!(response.status(), reqwest::StatusCode::CREATED);
+    }
+
+    let mut response = client
+        .get(format!(
+            "{base_url}/collections/stream_test/graph/traverse/stream?start_node=1&algorithm=bfs&max_depth=5&limit=10"
+        ))
+        .send()
+        .await
+        .expect("SSE request failed");
+
+    assert_eq!(response.status(), reqwest::StatusCode::OK);
+    assert_eq!(
+        response
+            .headers()
+            .get(CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok()),
+        Some("text/event-stream")
+    );
+
+    let mut payload = String::new();
+    while let Some(chunk) = response.chunk().await.expect("SSE chunk read failed") {
+        payload.push_str(&String::from_utf8_lossy(&chunk));
+        if payload.contains("event: done") {
+            break;
+        }
+    }
+
+    let _ = shutdown_tx.send(());
+
+    assert!(payload.contains("event: node"));
+    assert!(payload.contains("\"id\":2"));
+    assert!(payload.contains("\"id\":3"));
+    assert!(payload.contains("event: done"));
+    assert!(payload.contains("\"total_nodes\":2"));
 }
 
 #[tokio::test]

--- a/crates/velesdb-server/tests/common/mod.rs
+++ b/crates/velesdb-server/tests/common/mod.rs
@@ -6,12 +6,13 @@ use axum::{
 };
 use std::sync::Arc;
 use tempfile::TempDir;
+use tokio::sync::oneshot;
 
 use velesdb_core::Database;
 use velesdb_server::{
     add_edge, batch_search, create_collection, delete_collection, delete_point, get_collection,
     get_edges, get_node_degree, get_point, health_check, hybrid_search, list_collections, query,
-    search, text_search, traverse_graph, upsert_points, AppState, GraphService,
+    search, stream_traverse, text_search, traverse_graph, upsert_points, AppState, GraphService,
 };
 
 /// Helper to create test app with all routes
@@ -47,8 +48,37 @@ pub fn create_test_app(temp_dir: &TempDir) -> Router {
         )
         .route("/collections/{name}/graph/traverse", post(traverse_graph))
         .route(
+            "/collections/{name}/graph/traverse/stream",
+            get(stream_traverse),
+        )
+        .route(
             "/collections/{name}/graph/nodes/{node_id}/degree",
             get(get_node_degree),
         )
         .with_state(graph_service)
+}
+
+/// Spawn a test HTTP server on an ephemeral port and return its base URL.
+#[allow(dead_code)]
+pub async fn spawn_test_server(temp_dir: &TempDir) -> (String, oneshot::Sender<()>) {
+    let app = create_test_app(temp_dir);
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("Failed to bind test listener");
+    let addr = listener
+        .local_addr()
+        .expect("Failed to read local listener addr");
+
+    let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+
+    tokio::spawn(async move {
+        axum::serve(listener, app)
+            .with_graceful_shutdown(async move {
+                let _ = shutdown_rx.await;
+            })
+            .await
+            .expect("Test server failed");
+    });
+
+    (format!("http://{addr}"), shutdown_tx)
 }


### PR DESCRIPTION
### Motivation
- Provide a Server-Sent Events (SSE) endpoint to stream graph traversal results for large traversals without buffering the whole result in memory.
- Add integration coverage for the streaming endpoint to ensure correct SSE framing and event emission.
- Simplify state handling for `GraphService` in the SSE handler by removing an unnecessary `Arc` wrapper.

### Description
- Introduces a new SSE route `GET /collections/{name}/graph/traverse/stream` and wires it into both the main server router and the test app via `stream_traverse`.
- Adjusts the SSE handler signature to take `State<GraphService>` instead of `State<Arc<GraphService>>` and removes the unused `Arc` import in `stream.rs`.
- Adds an integration test `test_graph_traverse_stream_sse` which spawns a test server, constructs a small graph, connects to the SSE endpoint, and asserts presence of `node`, `done`, and `stats` information in the stream payload.
- Adds test helper `spawn_test_server` to `tests/common/mod.rs` to run an ephemeral HTTP server and return its base URL and a shutdown channel.

### Testing
- Ran the integration test suite in `crates/velesdb-server/tests`, including the new `test_graph_traverse_stream_sse`, which exercised the SSE endpoint and assertions on event payloads; tests completed successfully.
- Existing API integration tests were executed as part of the same test run and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e56b461bc832a842e46c9bb10efc7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/232" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
