### PR TITLE
feat: add Product Quantization (PQ) mode with ADC-based search

### DIFF
--- a/crates/velesdb-core/Cargo.toml
+++ b/crates/velesdb-core/Cargo.toml
@@ -300,3 +300,7 @@ optional = true
 
 [lints]
 workspace = true
+
+[[bench]]
+name = "pq_hnsw_benchmark"
+harness = false

--- a/crates/velesdb-core/benches/pq_hnsw_benchmark.rs
+++ b/crates/velesdb-core/benches/pq_hnsw_benchmark.rs
@@ -1,0 +1,98 @@
+//! Benchmark HNSW search with Full vs SQ8 vs PQ storage modes.
+
+#![allow(clippy::cast_precision_loss)]
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use tempfile::tempdir;
+use velesdb_core::{Collection, DistanceMetric, Point, StorageMode};
+
+fn generate_vector(dimension: usize, seed: usize) -> Vec<f32> {
+    (0..dimension)
+        .map(|i| {
+            let x = ((seed * 31 + i * 17 + 11) % 1000) as f32 / 1000.0;
+            x * 2.0 - 1.0
+        })
+        .collect()
+}
+
+fn build_collection(storage_mode: StorageMode, n: usize, dimension: usize) -> Collection {
+    let dir = tempdir().expect("tempdir");
+    let path = dir.path().join(format!("bench_{storage_mode:?}"));
+    std::mem::forget(dir); // keep for bench duration
+
+    let collection =
+        Collection::create_with_options(path, dimension, DistanceMetric::Euclidean, storage_mode)
+            .expect("create collection");
+
+    let points: Vec<Point> = (0..n)
+        .map(|id| Point::new(id as u64, generate_vector(dimension, id), None))
+        .collect();
+    collection.upsert(points).expect("upsert");
+    collection
+}
+
+fn benchmark_hnsw_latency(c: &mut Criterion) {
+    let dimension = 64;
+    let n = 2000;
+    let query = generate_vector(dimension, 9999);
+
+    let full = build_collection(StorageMode::Full, n, dimension);
+    let sq8 = build_collection(StorageMode::SQ8, n, dimension);
+    let pq = build_collection(StorageMode::ProductQuantization, n, dimension);
+
+    let mut group = c.benchmark_group("hnsw_latency_full_sq8_pq");
+    group.bench_function("full", |b| {
+        b.iter(|| full.search_ids(black_box(&query), black_box(20)))
+    });
+    group.bench_function("sq8", |b| {
+        b.iter(|| sq8.search_ids(black_box(&query), black_box(20)))
+    });
+    group.bench_function("pq", |b| {
+        b.iter(|| pq.search_ids(black_box(&query), black_box(20)))
+    });
+    group.finish();
+}
+
+fn benchmark_hnsw_recall(c: &mut Criterion) {
+    let dimension = 64;
+    let n = 2000;
+    let query = generate_vector(dimension, 4242);
+
+    let full = build_collection(StorageMode::Full, n, dimension);
+    let sq8 = build_collection(StorageMode::SQ8, n, dimension);
+    let pq = build_collection(StorageMode::ProductQuantization, n, dimension);
+
+    let full_top: std::collections::HashSet<u64> = full
+        .search_ids(&query, 50)
+        .expect("full search")
+        .into_iter()
+        .map(|(id, _)| id)
+        .collect();
+
+    let sq8_recall = sq8
+        .search_ids(&query, 50)
+        .expect("sq8 search")
+        .into_iter()
+        .map(|(id, _)| id)
+        .filter(|id| full_top.contains(id))
+        .count() as f32
+        / 50.0;
+
+    let pq_recall = pq
+        .search_ids(&query, 50)
+        .expect("pq search")
+        .into_iter()
+        .map(|(id, _)| id)
+        .filter(|id| full_top.contains(id))
+        .count() as f32
+        / 50.0;
+
+    c.bench_function("hnsw_recall_report_full_sq8_pq", |b| {
+        b.iter(|| black_box((sq8_recall, pq_recall)))
+    });
+
+    println!("Recall@50 vs full: SQ8={sq8_recall:.3}, PQ={pq_recall:.3}");
+}
+
+criterion_group!(benches, benchmark_hnsw_latency, benchmark_hnsw_recall);
+criterion_main!(benches);

--- a/crates/velesdb-core/src/collection/core/crud.rs
+++ b/crates/velesdb-core/src/collection/core/crud.rs
@@ -5,7 +5,9 @@ use crate::error::{Error, Result};
 use crate::index::VectorIndex;
 use crate::index::{JsonValue, SecondaryIndex};
 use crate::point::Point;
-use crate::quantization::{BinaryQuantizedVector, QuantizedVector, StorageMode};
+use crate::quantization::{
+    BinaryQuantizedVector, PQVector, ProductQuantizer, QuantizedVector, StorageMode,
+};
 use crate::storage::{PayloadStorage, VectorStorage};
 
 impl Collection {
@@ -59,6 +61,10 @@ impl Collection {
             StorageMode::Binary => Some(self.binary_cache.write()),
             _ => None,
         };
+        let mut pq_cache = match storage_mode {
+            StorageMode::ProductQuantization => Some(self.pq_cache.write()),
+            _ => None,
+        };
 
         for point in points {
             let old_payload = payload_storage.retrieve(point.id).ok().flatten();
@@ -79,6 +85,39 @@ impl Collection {
                     if let Some(ref mut cache) = binary_cache {
                         let quantized = BinaryQuantizedVector::from_f32(&point.vector);
                         cache.insert(point.id, quantized);
+                    }
+                }
+                StorageMode::ProductQuantization => {
+                    let maybe_code: Option<PQVector> = {
+                        let mut quantizer_guard = self.pq_quantizer.write();
+                        if quantizer_guard.is_none() {
+                            let mut buffer = self.pq_training_buffer.write();
+                            buffer.push_back(point.vector.clone());
+                            const PQ_TRAINING_SAMPLES: usize = 128;
+                            if buffer.len() >= PQ_TRAINING_SAMPLES {
+                                let training: Vec<Vec<f32>> = buffer.iter().cloned().collect();
+                                let dimension = point.vector.len();
+                                let mut num_subspaces = 8usize;
+                                while num_subspaces > 1 && !dimension.is_multiple_of(num_subspaces)
+                                {
+                                    num_subspaces /= 2;
+                                }
+                                let num_centroids = 256usize.min(training.len().max(2));
+                                *quantizer_guard = Some(ProductQuantizer::train(
+                                    &training,
+                                    num_subspaces.max(1),
+                                    num_centroids,
+                                ));
+                            }
+                        }
+
+                        quantizer_guard
+                            .as_ref()
+                            .map(|quantizer| quantizer.quantize(&point.vector))
+                    };
+
+                    if let (Some(ref mut cache), Some(code)) = (&mut pq_cache, maybe_code) {
+                        cache.insert(point.id, code);
                     }
                 }
                 StorageMode::Full => {}
@@ -330,6 +369,9 @@ impl Collection {
                 vector_storage.delete(id).map_err(Error::Io)?;
                 payload_storage.delete(id).map_err(Error::Io)?;
                 self.index.remove(id);
+                self.sq8_cache.write().remove(&id);
+                self.binary_cache.write().remove(&id);
+                self.pq_cache.write().remove(&id);
                 self.text_index.remove_document(id);
                 self.update_secondary_indexes_on_delete(id, old_payload.as_ref());
             }

--- a/crates/velesdb-core/src/collection/core/lifecycle.rs
+++ b/crates/velesdb-core/src/collection/core/lifecycle.rs
@@ -8,7 +8,7 @@ use crate::index::{Bm25Index, HnswIndex};
 use crate::quantization::StorageMode;
 use crate::storage::{LogPayloadStorage, MmapStorage, PayloadStorage, VectorStorage};
 
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 
 use parking_lot::RwLock;
 use std::path::PathBuf;
@@ -83,6 +83,9 @@ impl Collection {
             text_index,
             sq8_cache: Arc::new(RwLock::new(HashMap::new())),
             binary_cache: Arc::new(RwLock::new(HashMap::new())),
+            pq_cache: Arc::new(RwLock::new(HashMap::new())),
+            pq_quantizer: Arc::new(RwLock::new(None)),
+            pq_training_buffer: Arc::new(RwLock::new(VecDeque::new())),
             property_index: Arc::new(RwLock::new(PropertyIndex::new())),
             range_index: Arc::new(RwLock::new(RangeIndex::new())),
             edge_store: Arc::new(RwLock::new(EdgeStore::new())),
@@ -171,6 +174,9 @@ impl Collection {
             text_index,
             sq8_cache: Arc::new(RwLock::new(HashMap::new())),
             binary_cache: Arc::new(RwLock::new(HashMap::new())),
+            pq_cache: Arc::new(RwLock::new(HashMap::new())),
+            pq_quantizer: Arc::new(RwLock::new(None)),
+            pq_training_buffer: Arc::new(RwLock::new(VecDeque::new())),
             property_index: Arc::new(RwLock::new(PropertyIndex::new())),
             range_index: Arc::new(RwLock::new(RangeIndex::new())),
             edge_store: Arc::new(RwLock::new(EdgeStore::new())),
@@ -281,6 +287,9 @@ impl Collection {
             text_index,
             sq8_cache: Arc::new(RwLock::new(HashMap::new())),
             binary_cache: Arc::new(RwLock::new(HashMap::new())),
+            pq_cache: Arc::new(RwLock::new(HashMap::new())),
+            pq_quantizer: Arc::new(RwLock::new(None)),
+            pq_training_buffer: Arc::new(RwLock::new(VecDeque::new())),
             property_index: Arc::new(RwLock::new(property_index)),
             range_index: Arc::new(RwLock::new(range_index)),
             edge_store: Arc::new(RwLock::new(EdgeStore::new())),

--- a/crates/velesdb-core/src/collection/search/vector.rs
+++ b/crates/velesdb-core/src/collection/search/vector.rs
@@ -4,7 +4,51 @@ use crate::collection::types::Collection;
 use crate::error::{Error, Result};
 use crate::index::VectorIndex;
 use crate::point::{Point, SearchResult};
+use crate::quantization::{distance_pq, StorageMode};
 use crate::storage::{PayloadStorage, VectorStorage};
+
+impl Collection {
+    fn search_ids_with_adc_if_pq(&self, query: &[f32], k: usize) -> Vec<(u64, f32)> {
+        let config = self.config.read();
+        let is_pq = matches!(config.storage_mode, StorageMode::ProductQuantization);
+        let higher_is_better = config.metric.higher_is_better();
+        drop(config);
+
+        if !is_pq {
+            return self.index.search(query, k);
+        }
+
+        let candidates_k = k.saturating_mul(8).max(k + 32);
+        let index_results = self.index.search(query, candidates_k);
+
+        let pq_cache = self.pq_cache.read();
+        let quantizer = self.pq_quantizer.read();
+        let Some(quantizer) = quantizer.as_ref() else {
+            return index_results.into_iter().take(k).collect();
+        };
+
+        let mut rescored: Vec<(u64, f32)> = index_results
+            .into_iter()
+            .map(|(id, fallback_score)| {
+                let score = pq_cache
+                    .get(&id)
+                    .map(|pq_vec| distance_pq(query, pq_vec, &quantizer.codebook))
+                    .unwrap_or(fallback_score);
+                (id, score)
+            })
+            .collect();
+
+        rescored.sort_by(|a, b| {
+            if higher_is_better {
+                b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal)
+            } else {
+                a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal)
+            }
+        });
+        rescored.truncate(k);
+        rescored
+    }
+}
 
 impl Collection {
     /// Searches for the k nearest neighbors of the query vector.
@@ -32,7 +76,7 @@ impl Collection {
         drop(config);
 
         // Use HNSW index for fast ANN search
-        let index_results = self.index.search(query, k);
+        let index_results = self.search_ids_with_adc_if_pq(query, k);
 
         let vector_storage = self.vector_storage.read();
         let payload_storage = self.payload_storage.read();
@@ -143,7 +187,7 @@ impl Collection {
         drop(config);
 
         // Perf: Direct HNSW search without vector/payload retrieval
-        let results = self.index.search(query, k);
+        let results = self.search_ids_with_adc_if_pq(query, k);
         Ok(results)
     }
 
@@ -180,7 +224,7 @@ impl Collection {
         // Post-filtering strategy: retrieve more candidates than k, then filter
         // Heuristic: retrieve 4x candidates to account for filtered-out results
         let candidates_k = k.saturating_mul(4).max(k + 10);
-        let index_results = self.index.search(query, candidates_k);
+        let index_results = self.search_ids_with_adc_if_pq(query, candidates_k);
 
         let vector_storage = self.vector_storage.read();
         let payload_storage = self.payload_storage.read();

--- a/crates/velesdb-core/src/collection/types.rs
+++ b/crates/velesdb-core/src/collection/types.rs
@@ -3,11 +3,13 @@
 use crate::collection::graph::{EdgeStore, GraphSchema, PropertyIndex, RangeIndex};
 use crate::distance::DistanceMetric;
 use crate::index::{Bm25Index, HnswIndex, SecondaryIndex};
-use crate::quantization::{BinaryQuantizedVector, QuantizedVector, StorageMode};
+use crate::quantization::{
+    BinaryQuantizedVector, PQVector, ProductQuantizer, QuantizedVector, StorageMode,
+};
 use crate::storage::{LogPayloadStorage, MmapStorage};
 use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -153,6 +155,15 @@ pub struct Collection {
 
     /// Binary quantized vectors cache (for Binary storage mode).
     pub(super) binary_cache: Arc<RwLock<HashMap<u64, BinaryQuantizedVector>>>,
+
+    /// PQ quantized vectors cache (for ProductQuantization storage mode).
+    pub(super) pq_cache: Arc<RwLock<HashMap<u64, PQVector>>>,
+
+    /// Trained ProductQuantizer (lazy-trained on first inserted vectors).
+    pub(super) pq_quantizer: Arc<RwLock<Option<ProductQuantizer>>>,
+
+    /// Buffer of first vectors used to train PQ codebooks.
+    pub(super) pq_training_buffer: Arc<RwLock<VecDeque<Vec<f32>>>>,
 
     /// Property index for O(1) equality lookups on graph nodes (EPIC-009).
     pub(super) property_index: Arc<RwLock<PropertyIndex>>,

--- a/crates/velesdb-core/src/lib.rs
+++ b/crates/velesdb-core/src/lib.rs
@@ -156,9 +156,10 @@ pub use error::{Error, Result};
 pub use filter::{Condition, Filter};
 pub use point::{Point, SearchResult};
 pub use quantization::{
-    cosine_similarity_quantized, cosine_similarity_quantized_simd, dot_product_quantized,
-    dot_product_quantized_simd, euclidean_squared_quantized, euclidean_squared_quantized_simd,
-    BinaryQuantizedVector, QuantizedVector, StorageMode,
+    cosine_similarity_quantized, cosine_similarity_quantized_simd, distance_pq,
+    dot_product_quantized, dot_product_quantized_simd, euclidean_squared_quantized,
+    euclidean_squared_quantized_simd, BinaryQuantizedVector, PQCodebook, PQVector,
+    ProductQuantizer, QuantizedVector, StorageMode,
 };
 
 #[cfg(feature = "persistence")]

--- a/crates/velesdb-core/src/quantization/mod.rs
+++ b/crates/velesdb-core/src/quantization/mod.rs
@@ -13,10 +13,12 @@
 use serde::{Deserialize, Serialize};
 
 mod binary;
+mod pq;
 mod scalar;
 
 // Re-export binary quantization
 pub use binary::BinaryQuantizedVector;
+pub use pq::{distance_pq, PQCodebook, PQVector, ProductQuantizer};
 
 // Re-export scalar quantization
 pub use scalar::{
@@ -37,4 +39,6 @@ pub enum StorageMode {
     /// 1-bit binary quantization for 32x memory reduction.
     /// Best for edge/IoT devices with limited RAM.
     Binary,
+    /// Product Quantization (PQ) for aggressive lossy compression (8x-16x typical).
+    ProductQuantization,
 }

--- a/crates/velesdb-core/src/quantization/pq.rs
+++ b/crates/velesdb-core/src/quantization/pq.rs
@@ -1,0 +1,284 @@
+//! Product Quantization (PQ) for aggressive lossy vector compression.
+//!
+//! PQ splits vectors into multiple subspaces and quantizes each subspace
+//! independently with its own codebook (k-means centroids).
+
+use serde::{Deserialize, Serialize};
+
+/// Per-subspace centroid tables learned with k-means.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PQCodebook {
+    /// Flattened centroids, indexed as `[subspace][centroid][subspace_dim]`.
+    pub centroids: Vec<Vec<Vec<f32>>>,
+    /// Full vector dimension.
+    pub dimension: usize,
+    /// Number of subspaces `m`.
+    pub num_subspaces: usize,
+    /// Number of centroids `k` per subspace.
+    pub num_centroids: usize,
+    /// Dimension of each subspace.
+    pub subspace_dim: usize,
+}
+
+/// Compressed representation of a vector: one centroid id per subspace.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PQVector {
+    /// Selected centroid ids for each subspace.
+    pub codes: Vec<u16>,
+}
+
+/// Product quantizer model and helpers for train/encode/decode.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProductQuantizer {
+    /// Trained codebook.
+    pub codebook: PQCodebook,
+}
+
+impl ProductQuantizer {
+    /// Train a PQ codebook using simplified k-means for each subspace.
+    #[must_use]
+    pub fn train(vectors: &[Vec<f32>], num_subspaces: usize, num_centroids: usize) -> Self {
+        assert!(!vectors.is_empty(), "Cannot train PQ with empty dataset");
+        assert!(num_subspaces > 0, "num_subspaces must be > 0");
+        assert!(num_centroids > 0, "num_centroids must be > 0");
+
+        let dimension = vectors[0].len();
+        assert!(
+            vectors.iter().all(|v| v.len() == dimension),
+            "All vectors must share the same dimension"
+        );
+        assert!(
+            dimension.is_multiple_of(num_subspaces),
+            "Dimension must be divisible by num_subspaces"
+        );
+
+        let subspace_dim = dimension / num_subspaces;
+        let mut centroids = Vec::with_capacity(num_subspaces);
+
+        for subspace in 0..num_subspaces {
+            let start = subspace * subspace_dim;
+            let end = start + subspace_dim;
+            let sub_vectors: Vec<Vec<f32>> =
+                vectors.iter().map(|v| v[start..end].to_vec()).collect();
+            centroids.push(kmeans_train(&sub_vectors, num_centroids, 25));
+        }
+
+        Self {
+            codebook: PQCodebook {
+                centroids,
+                dimension,
+                num_subspaces,
+                num_centroids,
+                subspace_dim,
+            },
+        }
+    }
+
+    /// Quantize a full-precision vector into PQ codes.
+    #[must_use]
+    pub fn quantize(&self, vector: &[f32]) -> PQVector {
+        assert_eq!(vector.len(), self.codebook.dimension);
+
+        let mut codes = Vec::with_capacity(self.codebook.num_subspaces);
+        for subspace in 0..self.codebook.num_subspaces {
+            let start = subspace * self.codebook.subspace_dim;
+            let end = start + self.codebook.subspace_dim;
+            let code = nearest_centroid(&vector[start..end], &self.codebook.centroids[subspace]);
+            codes.push(u16::try_from(code).expect("centroid index must fit u16"));
+        }
+
+        PQVector { codes }
+    }
+
+    /// Reconstruct an approximate vector from PQ codes.
+    #[must_use]
+    pub fn reconstruct(&self, pq_vector: &PQVector) -> Vec<f32> {
+        assert_eq!(pq_vector.codes.len(), self.codebook.num_subspaces);
+
+        let mut reconstructed = Vec::with_capacity(self.codebook.dimension);
+        for (subspace, &code) in pq_vector.codes.iter().enumerate() {
+            let centroid = &self.codebook.centroids[subspace][usize::from(code)];
+            reconstructed.extend_from_slice(centroid);
+        }
+
+        reconstructed
+    }
+}
+
+/// Asymmetric distance computation (ADC): query is f32, candidate is PQ-coded.
+#[must_use]
+pub fn distance_pq(query_vector: &[f32], pq_vector: &PQVector, codebook: &PQCodebook) -> f32 {
+    assert_eq!(query_vector.len(), codebook.dimension);
+    assert_eq!(pq_vector.codes.len(), codebook.num_subspaces);
+
+    let mut lookup_tables = Vec::with_capacity(codebook.num_subspaces);
+    for subspace in 0..codebook.num_subspaces {
+        let start = subspace * codebook.subspace_dim;
+        let end = start + codebook.subspace_dim;
+        let q_sub = &query_vector[start..end];
+
+        let table: Vec<f32> = codebook.centroids[subspace]
+            .iter()
+            .map(|centroid| l2_squared(q_sub, centroid))
+            .collect();
+        lookup_tables.push(table);
+    }
+
+    pq_vector
+        .codes
+        .iter()
+        .enumerate()
+        .map(|(subspace, &code)| lookup_tables[subspace][usize::from(code)])
+        .sum::<f32>()
+        .sqrt()
+}
+
+fn nearest_centroid(vector: &[f32], centroids: &[Vec<f32>]) -> usize {
+    let mut best_idx = 0;
+    let mut best_dist = f32::MAX;
+
+    for (idx, centroid) in centroids.iter().enumerate() {
+        let dist = l2_squared(vector, centroid);
+        if dist < best_dist {
+            best_dist = dist;
+            best_idx = idx;
+        }
+    }
+
+    best_idx
+}
+
+fn l2_squared(a: &[f32], b: &[f32]) -> f32 {
+    a.iter()
+        .zip(b.iter())
+        .map(|(x, y)| {
+            let d = x - y;
+            d * d
+        })
+        .sum()
+}
+
+fn kmeans_train(samples: &[Vec<f32>], k: usize, max_iters: usize) -> Vec<Vec<f32>> {
+    assert!(!samples.is_empty());
+    let dim = samples[0].len();
+
+    // Deterministic init: first k (cycled if needed).
+    let mut centroids: Vec<Vec<f32>> = (0..k).map(|i| samples[i % samples.len()].clone()).collect();
+
+    let mut assignments = vec![0usize; samples.len()];
+
+    for _ in 0..max_iters {
+        let mut changed = false;
+
+        // Assignment step
+        for (i, sample) in samples.iter().enumerate() {
+            let new_assignment = nearest_centroid(sample, &centroids);
+            if assignments[i] != new_assignment {
+                assignments[i] = new_assignment;
+                changed = true;
+            }
+        }
+
+        // Update step
+        let mut new_centroids = vec![vec![0.0; dim]; k];
+        let mut counts = vec![0usize; k];
+
+        for (sample, &cluster) in samples.iter().zip(assignments.iter()) {
+            counts[cluster] += 1;
+            for (d, &val) in sample.iter().enumerate() {
+                new_centroids[cluster][d] += val;
+            }
+        }
+
+        for cluster in 0..k {
+            if counts[cluster] == 0 {
+                // Re-seed empty cluster deterministically.
+                new_centroids[cluster] = samples[cluster % samples.len()].clone();
+            } else {
+                let inv = 1.0 / counts[cluster] as f32;
+                for d in 0..dim {
+                    new_centroids[cluster][d] *= inv;
+                }
+            }
+        }
+
+        centroids = new_centroids;
+
+        if !changed {
+            break;
+        }
+    }
+
+    centroids
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{distance_pq, ProductQuantizer};
+
+    #[test]
+    fn train_builds_expected_codebook_shape() {
+        let vectors = vec![
+            vec![0.0, 0.0, 10.0, 10.0],
+            vec![0.1, 0.0, 9.9, 10.1],
+            vec![8.0, 8.0, 1.0, 1.0],
+            vec![8.1, 7.9, 1.2, 0.8],
+        ];
+
+        let pq = ProductQuantizer::train(&vectors, 2, 2);
+        assert_eq!(pq.codebook.num_subspaces, 2);
+        assert_eq!(pq.codebook.num_centroids, 2);
+        assert_eq!(pq.codebook.subspace_dim, 2);
+        assert_eq!(pq.codebook.centroids.len(), 2);
+        assert_eq!(pq.codebook.centroids[0].len(), 2);
+    }
+
+    #[test]
+    fn quantize_and_reconstruct_roundtrip_is_reasonable() {
+        let vectors = vec![
+            vec![0.0, 0.0, 10.0, 10.0],
+            vec![0.1, -0.1, 10.1, 9.9],
+            vec![8.0, 8.0, 1.0, 1.0],
+            vec![8.1, 7.9, 1.2, 0.8],
+        ];
+        let pq = ProductQuantizer::train(&vectors, 2, 4);
+
+        let input = vec![8.05, 8.0, 1.1, 1.0];
+        let code = pq.quantize(&input);
+        let reconstructed = pq.reconstruct(&code);
+
+        assert_eq!(code.codes.len(), 2);
+        assert_eq!(reconstructed.len(), input.len());
+
+        let mse: f32 = input
+            .iter()
+            .zip(reconstructed.iter())
+            .map(|(a, b)| {
+                let d = a - b;
+                d * d
+            })
+            .sum::<f32>()
+            / input.len() as f32;
+        assert!(mse < 0.2, "reconstruction MSE too high: {mse}");
+    }
+
+    #[test]
+    fn adc_distance_prefers_closer_codes() {
+        let vectors = vec![
+            vec![0.0, 0.0, 0.0, 0.0],
+            vec![0.1, 0.1, 0.1, 0.1],
+            vec![5.0, 5.0, 5.0, 5.0],
+            vec![5.1, 4.9, 5.0, 5.2],
+        ];
+        let pq = ProductQuantizer::train(&vectors, 2, 2);
+
+        let near = pq.quantize(&[0.05, 0.05, 0.0, 0.1]);
+        let far = pq.quantize(&[5.0, 5.0, 5.0, 5.0]);
+        let query = [0.0, 0.0, 0.0, 0.0];
+
+        let d_near = distance_pq(&query, &near, &pq.codebook);
+        let d_far = distance_pq(&query, &far, &pq.codebook);
+
+        assert!(d_near < d_far, "ADC did not preserve proximity ordering");
+    }
+}

--- a/crates/velesdb-core/src/quantization_tests.rs
+++ b/crates/velesdb-core/src/quantization_tests.rs
@@ -360,15 +360,18 @@ fn test_storage_mode_enum() {
     let full = StorageMode::Full;
     let sq8 = StorageMode::SQ8;
     let binary = StorageMode::Binary;
+    let pq = StorageMode::ProductQuantization;
     let default = StorageMode::default();
 
     // Assert
     assert_eq!(full, StorageMode::Full);
     assert_eq!(sq8, StorageMode::SQ8);
     assert_eq!(binary, StorageMode::Binary);
+    assert_eq!(pq, StorageMode::ProductQuantization);
     assert_eq!(default, StorageMode::Full);
     assert_ne!(full, sq8);
     assert_ne!(sq8, binary);
+    assert_ne!(binary, pq);
 }
 
 // =========================================================================


### PR DESCRIPTION
### Motivation

- Fournir une option de compression avec perte plus aggressive que SQ8 afin de réduire significativement l’empreinte mémoire des vecteurs (objectif ~8x–16x) tout en conservant une qualité de recherche acceptable.
- Permettre un parcours HNSW plus rapide en utilisant la distance asymétrique (ADC) entre vecteurs de requête en float32 et vecteurs stockés en PQ codes sans reconstruction complète.

### Description

- Ajout d’un module PQ `crates/velesdb-core/src/quantization/pq.rs` contenant `ProductQuantizer`, `PQCodebook`, `PQVector`, une implémentation simplifiée de `kmeans_train`, `ProductQuantizer::train`, `quantize`, `reconstruct` et la fonction ADC `distance_pq`.
- Exposition des types/fonctions PQ depuis `quantization` et la racine du crate, et ajout de la variante `StorageMode::ProductQuantization` à l’enum `StorageMode`.
- Intégration dans `Collection`: ajout des champs `pq_cache`, `pq_quantizer`, `pq_training_buffer` et logique d’`upsert` qui bufferise les premiers vecteurs, entraîne paresseusement le `ProductQuantizer` et stocke ensuite les `PQVector` codes; suppression des caches PQ/SQ8/Binary sur `delete`.
- Recherche HNSW: ajout de `search_ids_with_adc_if_pq` qui applique ADC (re-scoring via lookup tables) pour les collections en mode PQ et utilisation de ce chemin dans `search`, `search_ids` et `search_with_filter` pour améliorer latence/qualité.
- Tests et benchmark: ajout de tests unitaires de validation (training/quantize/reconstruct/ADC ordering) dans `pq.rs` et d’un bench `benches/pq_hnsw_benchmark.rs` comparant Full vs SQ8 vs PQ.

### Testing

- `cargo check -p velesdb-core` a été exécuté et a réussi.
- `cargo check -p velesdb-core --benches` a été exécuté et a réussi, et le bench `pq_hnsw_benchmark` a été ajouté au manifest.
- Des tests unitaires pour PQ ont été ajoutés (`crates/velesdb-core/src/quantization/pq.rs::tests`) ; une tentative d’exécution ciblée (`cargo test -p velesdb-core quantization::pq`) a commencé mais la compilation/exécution longue a été interrompue dans cette session; les tests sont inclus et prêts à être lancés dans CI/localement.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e56c45b20832a8c933ae60cd90c3a)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/233" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
