### PR TITLE
chore(release): harden crates.io publish workflow and add post-publish verification (v1.4.1)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,24 +148,15 @@ jobs:
   # 3. Publish to crates.io (each crate independently)
   # ===========================================================================
   publish-crates:
-    name: Publish ${{ matrix.crate }}
+    name: Publish crates.io
     runs-on: ubuntu-latest
     needs: validate
     if: |
       needs.validate.outputs.is_prerelease == 'false' &&
       (github.event_name == 'push' || inputs.publish_crates)
     environment: crates-io
-    strategy:
-      fail-fast: false
-      max-parallel: 1
-      matrix:
-        crate:
-          - velesdb-core
-          - velesdb-server
-          - velesdb-cli
-          - velesdb-migrate
-          - velesdb-mobile
-          - tauri-plugin-velesdb
+    env:
+      CRATES_TO_PUBLISH: "velesdb-core velesdb-server velesdb-cli velesdb-migrate velesdb-mobile tauri-plugin-velesdb"
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: dtolnay/rust-toolchain@stable # Intentionally unpinned - uses toolchain input
@@ -180,12 +171,48 @@ jobs:
         with:
           shared-key: "publish-crates"
 
-      - name: Publish ${{ matrix.crate }}
+      - name: Validate workspace version
+        run: |
+          WORKSPACE_VERSION=$(python - <<'PY'
+          import tomllib
+          with open('Cargo.toml', 'rb') as f:
+              data = tomllib.load(f)
+          print(data['workspace']['package']['version'])
+          PY
+          )
+          if [ "$WORKSPACE_VERSION" != "${{ needs.validate.outputs.version }}" ]; then
+            echo "❌ Workspace version ($WORKSPACE_VERSION) does not match release version (${{ needs.validate.outputs.version }})"
+            exit 1
+          fi
+          echo "✅ Workspace version: $WORKSPACE_VERSION"
+
+      - name: Publish crates in dependency order
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         run: |
-          echo "📦 Publishing ${{ matrix.crate }}..."
-          cargo publish -p ${{ matrix.crate }} --allow-dirty || echo "⏭️ ${{ matrix.crate }} already published or failed"
+          set -euo pipefail
+          for crate in $CRATES_TO_PUBLISH; do
+            echo "📦 Publishing $crate..."
+            success=0
+            for attempt in 1 2 3; do
+              if cargo publish --locked -p "$crate"; then
+                success=1
+                break
+              fi
+              echo "⚠️ Publish failed for $crate (attempt $attempt/3), retrying in 15s..."
+              sleep 15
+            done
+            if [ "$success" -ne 1 ]; then
+              echo "❌ Failed to publish $crate after 3 attempts"
+              exit 1
+            fi
+            echo "✅ Published $crate"
+          done
+
+      - name: Verify crates.io versions
+        run: |
+          chmod +x scripts/check-crates-io-versions.sh
+          scripts/check-crates-io-versions.sh "${{ needs.validate.outputs.version }}" $CRATES_TO_PUBLISH
 
   # ===========================================================================
   # 4. Publish to PyPI (each package independently)

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@
 </h3>
 
 <p align="center">
-  <strong>� v1.4.0 Released</strong> — VelesQL v2.0, MATCH queries, Multi-Score Fusion, 100% Ecosystem Complete<br/>
-  <a href="https://github.com/cyberlife-coder/VelesDB/releases/tag/v1.4.0">Download Now</a> • <a href="#-quick-start">Quick Start</a>
+  <strong>🚀 v1.4.1 Released</strong> — Ecosystem crates synced on crates.io + hardened release workflow<br/>
+  <a href="https://github.com/cyberlife-coder/VelesDB/releases/tag/v1.4.1">Download Now</a> • <a href="#-quick-start">Quick Start</a>
 </p>
 
 <p align="center">
@@ -29,6 +29,15 @@
   <img src="https://img.shields.io/badge/📊_Coverage-82.30%25-success?style=for-the-badge" alt="Coverage"/>
   <img src="https://img.shields.io/badge/🎯_Recall-100%25-success?style=for-the-badge" alt="Recall"/>
   <img src="https://img.shields.io/badge/⚡_Throughput-41Gelem/s-purple?style=for-the-badge" alt="Throughput"/>
+</p>
+
+<p align="center">
+  <a href="https://crates.io/crates/velesdb-core"><img src="https://img.shields.io/crates/v/velesdb-core?style=flat-square" alt="velesdb-core version"></a>
+  <a href="https://crates.io/crates/velesdb-server"><img src="https://img.shields.io/crates/v/velesdb-server?style=flat-square" alt="velesdb-server version"></a>
+  <a href="https://crates.io/crates/velesdb-cli"><img src="https://img.shields.io/crates/v/velesdb-cli?style=flat-square" alt="velesdb-cli version"></a>
+  <a href="https://crates.io/crates/velesdb-migrate"><img src="https://img.shields.io/crates/v/velesdb-migrate?style=flat-square" alt="velesdb-migrate version"></a>
+  <a href="https://crates.io/crates/velesdb-mobile"><img src="https://img.shields.io/crates/v/velesdb-mobile?style=flat-square" alt="velesdb-mobile version"></a>
+  <a href="https://crates.io/crates/tauri-plugin-velesdb"><img src="https://img.shields.io/crates/v/tauri-plugin-velesdb?style=flat-square" alt="tauri-plugin-velesdb version"></a>
 </p>
 
 [![Star History Chart](https://api.star-history.com/svg?repos=cyberlife-coder/velesdb&type=Date)](https://star-history.com/#cyberlife-coder/velesdb&Date)

--- a/scripts/check-crates-io-versions.sh
+++ b/scripts/check-crates-io-versions.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v curl >/dev/null 2>&1; then
+  echo "❌ curl is required"
+  exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "❌ jq is required"
+  exit 1
+fi
+
+EXPECTED_VERSION="${1:-}"
+shift || true
+
+if [ -z "$EXPECTED_VERSION" ]; then
+  echo "Usage: $0 <expected_version> <crate1> [crate2 ... crateN]"
+  exit 1
+fi
+
+if [ "$#" -eq 0 ]; then
+  echo "❌ At least one crate name must be provided"
+  exit 1
+fi
+
+failures=0
+
+for crate in "$@"; do
+  echo "🔎 Checking $crate"
+
+  response=$(curl -fsSL --retry 3 --retry-delay 2 --retry-connrefused \
+    -H "User-Agent: VelesDB-release-check/1.0" \
+    -H "Accept: application/json" \
+    "https://crates.io/api/v1/crates/${crate}")
+  max_version=$(printf '%s' "$response" | jq -r '.crate.max_version')
+
+  if [ "$max_version" != "$EXPECTED_VERSION" ]; then
+    echo "❌ $crate max_version=$max_version (expected $EXPECTED_VERSION)"
+    failures=$((failures + 1))
+  else
+    echo "✅ $crate max_version=$max_version"
+  fi
+done
+
+if [ "$failures" -gt 0 ]; then
+  echo "❌ Version check failed for $failures crate(s)."
+  exit 1
+fi
+
+echo "✅ All crates are published at version $EXPECTED_VERSION"


### PR DESCRIPTION
### Motivation
- Align all public workspace crates with the workspace version `1.4.1` and make the release publish step reliable. 
- The existing `publish-crates` step masked failures (`|| echo ...`) and published in parallel/matrix mode making troubleshooting difficult. 
- Add an automated, fail-fast verification against crates.io so regressions are detected immediately. 

### Description
- Replace the matrix publish with a deterministic sequential publish in `.github/workflows/release.yml` including retries (3 attempts) and failing the job on permanent errors. 
- Add a workspace-version consistency check that validates `Cargo.toml` `workspace.package.version` matches the release `version`. 
- Add `scripts/check-crates-io-versions.sh` which queries `https://crates.io/api/v1/crates/{crate}` (via `curl` + `jq`) and fails if any crate `max_version` does not equal the expected version. 
- Update `README.md` to show the `v1.4.1` release banner and add `shields.io` crates.io version badges for the public crates. 

### Testing
- Installed required system deps with `sudo apt-get install -y libglib2.0-dev libgtk-3-dev libwebkit2gtk-4.1-dev jq` and the install completed successfully. 
- Ran `PYTHONHOME= PYTHONPATH= cargo build --workspace` and the workspace built successfully after neutralizing a polluted Python environment. 
- Executed `scripts/check-crates-io-versions.sh 1.4.1 <crates...>` which correctly detected that crates.io currently reports older `1.1.x` versions (expected until the publish workflow runs); the script fails when any crate does not match the expected version. 
- Note: `gh` CLI / GitHub Actions UI could not be used from this environment so the `release.yml` run must be triggered manually via `workflow_dispatch` (e.g., `version=1.4.1` and `publish_crates=true`) to actually publish and then re-run the verification script.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e57003c50832aa311080e399e1783)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/236" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
