### PR TITLE
chore(release): bump workspace version to 1.4.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5752,7 +5752,7 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-velesdb"
-version = "1.4.1"
+version = "1.4.2"
 dependencies = [
  "dirs 5.0.1",
  "parking_lot",
@@ -6674,7 +6674,7 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "velesdb-cli"
-version = "1.4.1"
+version = "1.4.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -6699,7 +6699,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-core"
-version = "1.4.1"
+version = "1.4.2"
 dependencies = [
  "arc-swap",
  "bincode",
@@ -6744,7 +6744,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-migrate"
-version = "1.4.1"
+version = "1.4.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6771,7 +6771,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-mobile"
-version = "1.4.1"
+version = "1.4.2"
 dependencies = [
  "serde_json",
  "tempfile",
@@ -6783,7 +6783,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-python"
-version = "1.4.1"
+version = "1.4.2"
 dependencies = [
  "numpy",
  "pyo3",
@@ -6794,7 +6794,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-server"
-version = "1.4.1"
+version = "1.4.2"
 dependencies = [
  "anyhow",
  "axum",
@@ -6817,7 +6817,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-wasm"
-version = "1.4.1"
+version = "1.4.2"
 dependencies = [
  "js-sys",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "1.4.1"
+version = "1.4.2"
 edition = "2021"
 rust-version = "1.83"
 license-file = "LICENSE"


### PR DESCRIPTION
## Release v1.4.2

### Changes since v1.4.1

| PR | Type | Description |
|---|---|---|
| #237 | feat | SSE streaming graph traversal endpoint |
| #238 | refactor | Split 7 files >500 lines into focused modules |
| #239 | fix | Eliminate all 3 expect() from production code |

### Housekeeping
- Closed 5 stale PRs (#221, #224, #228, #229, #232)
- 0 open PRs remaining

### Release Process
After merge, tag `v1.4.2` will be created on main to trigger the `release.yml` workflow which publishes to:
- crates.io (velesdb-core, velesdb-server, velesdb-cli, velesdb-migrate, velesdb-mobile, tauri-plugin-velesdb)
- PyPI
- npm (WASM, TypeScript SDK, Tauri plugin)
- GitHub Releases (binaries for Linux, Windows, macOS)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/240" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
