### PR TITLE
fix(release): reduce keywords to 5 (crates.io limit) and bump to v1.4.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,14 +17,14 @@ exclude = [
 ]
 
 [workspace.package]
-version = "1.4.2"
+version = "1.4.3"
 edition = "2021"
 rust-version = "1.83"
 license-file = "LICENSE"
 repository = "https://github.com/cyberlife-coder/velesdb"
 homepage = "https://velesdb.com"
 documentation = "https://deepwiki.com/cyberlife-coder/VelesDB"
-keywords = ["vector-database", "embeddings", "rag", "local-first", "ai-memory", "semantic-search", "hnsw", "sqlite-alternative"]
+keywords = ["vector-database", "embeddings", "rag", "local-first", "semantic-search"]
 categories = ["database", "data-structures", "algorithms", "science"]
 description = "VelesDB: The Local Vector Database for Rust & AI. Microsecond semantic search, zero network latency, runs anywhere."
 authors = ["Julien Lange <contact@wiscale.fr>"]


### PR DESCRIPTION
## Fix crates.io Publication

### Problem
crates.io rejects packages with more than 5 keywords. The workspace had 8.

### Solution
Reduced keywords from 8 to 5, keeping the most relevant:
`vector-database`, `embeddings`, `rag`, `local-first`, `semantic-search`

### Version Bump
- v1.4.2 → v1.4.3 (v1.4.2 tag already exists but failed to publish)

### After Merge
Tag `v1.4.3` will be created to trigger the release workflow.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/242" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
