### PR TITLE
Guardrails & robustness: LIKE/ILIKE DP rewrite, parser depth limit, mmap safety, and query-cache hardening

### DIFF
--- a/crates/velesdb-core/src/filter/matching.rs
+++ b/crates/velesdb-core/src/filter/matching.rs
@@ -1,7 +1,11 @@
 //! Condition matching logic and helper functions.
 
 use super::Condition;
+use crate::metrics::global_guardrails_metrics;
 use serde_json::Value;
+
+const LIKE_MAX_PATTERN_BYTES: usize = 4096;
+const LIKE_MAX_DYN_OPS: usize = 2_000_000;
 
 impl Condition {
     /// Evaluates the condition against a payload.
@@ -97,6 +101,16 @@ fn compare_values(a: &Value, b: &Value) -> i32 {
 /// * `pattern` - The SQL LIKE pattern
 /// * `case_insensitive` - If true, performs case-insensitive matching (ILIKE)
 fn like_match(text: &str, pattern: &str, case_insensitive: bool) -> bool {
+    if pattern.len() > LIKE_MAX_PATTERN_BYTES {
+        global_guardrails_metrics().record_like_guardrail_rejected();
+        return false;
+    }
+
+    if text.len().saturating_mul(pattern.len().max(1)) > LIKE_MAX_DYN_OPS {
+        global_guardrails_metrics().record_like_guardrail_rejected();
+        return false;
+    }
+
     let (text, pattern) = if case_insensitive {
         (text.to_lowercase(), pattern.to_lowercase())
     } else {
@@ -106,72 +120,68 @@ fn like_match(text: &str, pattern: &str, case_insensitive: bool) -> bool {
     like_match_impl(text.as_bytes(), pattern.as_bytes())
 }
 
-/// Recursive implementation of LIKE matching using dynamic programming approach.
-fn like_match_impl(text: &[u8], pattern: &[u8]) -> bool {
-    let m = text.len();
-    let n = pattern.len();
+#[derive(Clone, Copy)]
+enum Token {
+    AnySeq,
+    AnyOne,
+    Literal(u8),
+}
 
-    // dp[i][j] = true if text[0..i] matches pattern[0..j]
-    let mut dp = vec![vec![false; n + 1]; m + 1];
-
-    // Empty pattern matches empty text
-    dp[0][0] = true;
-
-    // Handle patterns starting with % (can match empty string)
-    let mut j = 0;
-    while j < n {
-        if pattern[j] == b'%' {
-            dp[0][j + 1] = dp[0][j];
-            j += 1;
-        } else if pattern[j] == b'\\' && j + 1 < n {
-            // Escaped character - skip both
-            break;
-        } else {
-            break;
-        }
-    }
-
-    let mut pi = 0;
-    while pi < n {
-        let (pat_char, pat_len) = if pattern[pi] == b'\\' && pi + 1 < n {
-            // Escaped character: \% or \_
-            (Some(pattern[pi + 1]), 2)
-        } else if pattern[pi] == b'%' {
-            (None, 1) // % wildcard
-        } else if pattern[pi] == b'_' {
-            (Some(0), 1) // _ wildcard (0 means "match any single char")
-        } else {
-            (Some(pattern[pi]), 1)
-        };
-
-        for ti in 0..=m {
-            match pat_char {
-                None => {
-                    // % matches zero or more characters
-                    // dp[ti][pi+1] is true if any dp[k][pi] is true for k <= ti
-                    if ti == 0 {
-                        dp[ti][pi + pat_len] = dp[ti][pi];
-                    } else {
-                        dp[ti][pi + pat_len] = dp[ti][pi] || dp[ti - 1][pi + pat_len];
-                    }
+fn tokenize_like_pattern(pattern: &[u8]) -> Vec<Token> {
+    let mut out = Vec::with_capacity(pattern.len());
+    let mut i = 0;
+    while i < pattern.len() {
+        match pattern[i] {
+            b'\\' if i + 1 < pattern.len() => {
+                out.push(Token::Literal(pattern[i + 1]));
+                i += 2;
+            }
+            b'%' => {
+                if !matches!(out.last(), Some(Token::AnySeq)) {
+                    out.push(Token::AnySeq);
                 }
-                Some(0) => {
-                    // _ matches exactly one character
-                    if ti > 0 {
-                        dp[ti][pi + pat_len] = dp[ti - 1][pi];
-                    }
-                }
-                Some(c) => {
-                    // Literal character match
-                    if ti > 0 && text[ti - 1] == c {
-                        dp[ti][pi + pat_len] = dp[ti - 1][pi];
-                    }
-                }
+                i += 1;
+            }
+            b'_' => {
+                out.push(Token::AnyOne);
+                i += 1;
+            }
+            c => {
+                out.push(Token::Literal(c));
+                i += 1;
             }
         }
+    }
+    out
+}
 
-        pi += pat_len;
+/// LIKE matching using rolling DP (O(text_len * token_len) time, O(token_len) memory).
+fn like_match_impl(text: &[u8], pattern: &[u8]) -> bool {
+    let tokens = tokenize_like_pattern(pattern);
+    let n = tokens.len();
+
+    let mut prev = vec![false; n + 1];
+    prev[0] = true;
+    for (j, tok) in tokens.iter().enumerate() {
+        if matches!(tok, Token::AnySeq) {
+            prev[j + 1] = prev[j];
+        } else {
+            break;
+        }
     }
 
-    dp[m][n]
+    let mut curr = vec![false; n + 1];
+    for &ch in text {
+        curr.fill(false);
+        for (j, tok) in tokens.iter().enumerate() {
+            curr[j + 1] = match tok {
+                Token::AnySeq => curr[j] || prev[j + 1],
+                Token::AnyOne => prev[j],
+                Token::Literal(c) => prev[j] && ch == *c,
+            };
+        }
+        std::mem::swap(&mut prev, &mut curr);
+    }
+
+    prev[n]
 }

--- a/crates/velesdb-core/src/filter_like_tests.rs
+++ b/crates/velesdb-core/src/filter_like_tests.rs
@@ -188,6 +188,15 @@ fn test_like_escaped_underscore() {
     assert!(condition.matches(&payload));
 }
 
+#[test]
+fn test_like_guardrail_rejects_too_large_complexity_budget() {
+    let text = "a".repeat(5_000);
+    let pattern = "%a%".repeat(600);
+    let payload = json!({"name": text});
+    let condition = Condition::like("name", &pattern);
+    assert!(!condition.matches(&payload));
+}
+
 // =============================================================================
 // AC4: Filter integration
 // =============================================================================

--- a/crates/velesdb-core/src/metrics/guardrails.rs
+++ b/crates/velesdb-core/src/metrics/guardrails.rs
@@ -6,6 +6,7 @@
 //! - Rate limiting decisions
 
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::OnceLock;
 
 /// Metrics specific to graph traversal operations.
 #[derive(Debug, Default)]
@@ -145,6 +146,14 @@ pub struct GuardRailsMetrics {
     pub rate_limit_allowed: AtomicU64,
     /// Rate limit requests rejected
     pub rate_limit_rejected: AtomicU64,
+    /// LIKE/ILIKE guardrail rejections
+    pub like_guardrail_rejected: AtomicU64,
+    /// Parser condition-depth limit rejections
+    pub parser_depth_limit_rejected: AtomicU64,
+    /// Invalid storage offset read errors
+    pub invalid_offset_read_errors: AtomicU64,
+    /// Query-cache collision fallback counter (reserved for hash-keyed implementations)
+    pub cache_collision_fallback_total: AtomicU64,
 }
 
 impl GuardRailsMetrics {
@@ -172,6 +181,29 @@ impl GuardRailsMetrics {
         } else {
             self.rate_limit_rejected.fetch_add(1, Ordering::Relaxed);
         }
+    }
+
+    /// Records a LIKE/ILIKE guardrail rejection.
+    pub fn record_like_guardrail_rejected(&self) {
+        self.like_guardrail_rejected.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Records a parser condition-depth rejection.
+    pub fn record_parser_depth_limit_rejected(&self) {
+        self.parser_depth_limit_rejected
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Records an invalid offset read error in storage.
+    pub fn record_invalid_offset_read_error(&self) {
+        self.invalid_offset_read_errors
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Records a cache collision fallback event.
+    pub fn record_cache_collision_fallback(&self) {
+        self.cache_collision_fallback_total
+            .fetch_add(1, Ordering::Relaxed);
     }
 
     /// Exports guard-rails metrics in Prometheus format.
@@ -223,8 +255,76 @@ impl GuardRailsMetrics {
             self.rate_limit_rejected.load(Ordering::Relaxed)
         );
 
+        let _ = writeln!(output);
+        let _ = writeln!(
+            output,
+            "# HELP velesdb_like_guardrail_rejected_total LIKE/ILIKE guardrail rejections"
+        );
+        let _ = writeln!(
+            output,
+            "# TYPE velesdb_like_guardrail_rejected_total counter"
+        );
+        let _ = writeln!(
+            output,
+            "velesdb_like_guardrail_rejected_total {}",
+            self.like_guardrail_rejected.load(Ordering::Relaxed)
+        );
+
+        let _ = writeln!(output);
+        let _ = writeln!(
+            output,
+            "# HELP velesdb_parser_depth_limit_rejected_total Parser depth-limit rejections"
+        );
+        let _ = writeln!(
+            output,
+            "# TYPE velesdb_parser_depth_limit_rejected_total counter"
+        );
+        let _ = writeln!(
+            output,
+            "velesdb_parser_depth_limit_rejected_total {}",
+            self.parser_depth_limit_rejected.load(Ordering::Relaxed)
+        );
+
+        let _ = writeln!(output);
+        let _ = writeln!(
+            output,
+            "# HELP velesdb_invalid_offset_read_errors_total Invalid storage offset read errors"
+        );
+        let _ = writeln!(
+            output,
+            "# TYPE velesdb_invalid_offset_read_errors_total counter"
+        );
+        let _ = writeln!(
+            output,
+            "velesdb_invalid_offset_read_errors_total {}",
+            self.invalid_offset_read_errors.load(Ordering::Relaxed)
+        );
+
+        let _ = writeln!(output);
+        let _ = writeln!(
+            output,
+            "# HELP velesdb_cache_collision_fallback_total Query-cache collision fallbacks"
+        );
+        let _ = writeln!(
+            output,
+            "# TYPE velesdb_cache_collision_fallback_total counter"
+        );
+        let _ = writeln!(
+            output,
+            "velesdb_cache_collision_fallback_total {}",
+            self.cache_collision_fallback_total.load(Ordering::Relaxed)
+        );
+
         output
     }
+}
+
+static GUARDRAILS_METRICS: OnceLock<GuardRailsMetrics> = OnceLock::new();
+
+/// Returns process-wide guardrail metrics instance used by runtime hardening paths.
+#[must_use]
+pub fn global_guardrails_metrics() -> &'static GuardRailsMetrics {
+    GUARDRAILS_METRICS.get_or_init(GuardRailsMetrics::default)
 }
 
 #[cfg(test)]
@@ -303,12 +403,20 @@ mod tests {
         let metrics = GuardRailsMetrics::new();
         metrics.record_limit_exceeded(LimitType::Timeout);
         metrics.record_rate_limit(false);
+        metrics.record_like_guardrail_rejected();
+        metrics.record_parser_depth_limit_rejected();
+        metrics.record_invalid_offset_read_error();
+        metrics.record_cache_collision_fallback();
 
         let output = metrics.export_prometheus();
 
         assert!(output.contains("velesdb_limits_exceeded_total"));
         assert!(output.contains("limit_type=\"timeout\""));
         assert!(output.contains("velesdb_rate_limit_requests_total"));
+        assert!(output.contains("velesdb_like_guardrail_rejected_total 1"));
+        assert!(output.contains("velesdb_parser_depth_limit_rejected_total 1"));
+        assert!(output.contains("velesdb_invalid_offset_read_errors_total 1"));
+        assert!(output.contains("velesdb_cache_collision_fallback_total 1"));
     }
 
     #[test]

--- a/crates/velesdb-core/src/metrics/mod.rs
+++ b/crates/velesdb-core/src/metrics/mod.rs
@@ -37,7 +37,7 @@ pub use latency::{compute_latency_percentiles, LatencyStats};
 pub use operational::{OperationalMetrics, DEPTH_BUCKETS, DURATION_BUCKETS, NODES_BUCKETS};
 
 // Re-export guard-rails and traversal metrics
-pub use guardrails::{GuardRailsMetrics, LimitType, TraversalMetrics};
+pub use guardrails::{global_guardrails_metrics, GuardRailsMetrics, LimitType, TraversalMetrics};
 
 // Re-export query diagnostics
 pub use query::{DurationHistogram, QueryPhase, QueryStats, SlowQueryLogger, SpanBuilder};

--- a/crates/velesdb-core/src/storage/mmap.rs
+++ b/crates/velesdb-core/src/storage/mmap.rs
@@ -25,6 +25,7 @@ use super::guard::VectorSliceGuard;
 use super::metrics::StorageMetrics;
 use super::sharded_index::ShardedIndex;
 use super::traits::VectorStorage;
+use crate::metrics::global_guardrails_metrics;
 
 use memmap2::MmapMut;
 use parking_lot::RwLock;
@@ -383,6 +384,7 @@ impl MmapStorage {
         let vector_size = self.dimension * std::mem::size_of::<f32>();
 
         if offset + vector_size > mmap.len() {
+            global_guardrails_metrics().record_invalid_offset_read_error();
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
                 "Offset out of bounds",
@@ -398,12 +400,16 @@ impl MmapStorage {
         // - Condition 4: All writes via store() use f32-aligned offsets.
         // Reason: Zero-copy vector access via memory mapping requires raw pointer operations.
         // P2 Audit 2026-01-29: Converted from debug_assert to assert for memory safety
-        assert!(
-            offset % std::mem::align_of::<f32>() == 0,
-            "EPIC-032/US-001: offset {} is not f32-aligned (must be multiple of {})",
-            offset,
-            std::mem::align_of::<f32>()
-        );
+        if offset % std::mem::align_of::<f32>() != 0 {
+            global_guardrails_metrics().record_invalid_offset_read_error();
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "EPIC-032/US-001: offset {offset} is not f32-aligned (must be multiple of {})",
+                    std::mem::align_of::<f32>()
+                ),
+            ));
+        }
         #[allow(clippy::cast_ptr_alignment)]
         let ptr = unsafe { mmap.as_ptr().add(offset).cast::<f32>() };
 

--- a/crates/velesdb-core/src/storage/tests.rs
+++ b/crates/velesdb-core/src/storage/tests.rs
@@ -313,6 +313,22 @@ fn test_retrieve_ref_large_dimension() {
     assert_eq!(guard.as_ref()[767], 767.0);
 }
 
+#[test]
+fn test_retrieve_ref_returns_invalid_data_on_misaligned_offset() {
+    let dir = tempdir().unwrap();
+    let mut storage = MmapStorage::new(dir.path(), 3).unwrap();
+    storage.store(1, &[1.0, 2.0, 3.0]).unwrap();
+
+    // Inject a corrupted, non-f32-aligned offset to ensure retrieve_ref is fallible.
+    storage.index.insert(42, 1);
+
+    let result = storage.retrieve_ref(42);
+    match result {
+        Err(err) => assert_eq!(err.kind(), std::io::ErrorKind::InvalidData),
+        Ok(_) => panic!("misaligned offset must not succeed"),
+    }
+}
+
 // =========================================================================
 // TS-CORE-004: Compaction Tests
 // =========================================================================

--- a/crates/velesdb-core/src/velesql/cache.rs
+++ b/crates/velesdb-core/src/velesql/cache.rs
@@ -6,7 +6,6 @@
 use parking_lot::RwLock;
 use rustc_hash::FxHashMap;
 use std::collections::VecDeque;
-use std::hash::{Hash, Hasher};
 
 use super::ast::Query;
 use super::error::ParseError;
@@ -54,10 +53,10 @@ impl CacheStats {
 /// assert!(cache.stats().hits >= 1);
 /// ```
 pub struct QueryCache {
-    /// Cache storage: hash -> Query
-    cache: RwLock<FxHashMap<u64, Query>>,
-    /// LRU order: front = oldest, back = newest
-    order: RwLock<VecDeque<u64>>,
+    /// Cache storage: full query string -> Query
+    cache: RwLock<FxHashMap<String, Query>>,
+    /// LRU order: front = oldest query string, back = newest
+    order: RwLock<VecDeque<String>>,
     /// Maximum cache size
     max_size: usize,
     /// Cache statistics
@@ -86,16 +85,25 @@ impl QueryCache {
     ///
     /// Returns `ParseError` if the query is invalid.
     pub fn parse(&self, query: &str) -> Result<Query, ParseError> {
-        let hash = Self::hash_query(query);
+        // Fast-path read
+        let cached = { self.cache.read().get(query).cloned() };
 
-        // Try cache read first
-        {
-            let cache = self.cache.read();
-            if let Some(cached) = cache.get(&hash) {
-                let mut stats = self.stats.write();
-                stats.hits += 1;
-                return Ok(cached.clone());
+        if let Some(cached) = cached {
+            let cache = self.cache.write();
+            let mut order = self.order.write();
+            let mut stats = self.stats.write();
+
+            stats.hits += 1;
+
+            // Keep strict LRU invariant (no duplicates + move-to-MRU)
+            if cache.contains_key(query) {
+                if let Some(pos) = order.iter().position(|q| q == query) {
+                    order.remove(pos);
+                }
+                order.push_back(query.to_string());
             }
+
+            return Ok(cached);
         }
 
         // Cache miss - parse the query
@@ -117,8 +125,13 @@ impl QueryCache {
                 }
             }
 
-            cache.insert(hash, parsed.clone());
-            order.push_back(hash);
+            // Prevent duplicate order entries for same query
+            if let Some(pos) = order.iter().position(|q| q == query) {
+                order.remove(pos);
+            }
+
+            cache.insert(query.to_string(), parsed.clone());
+            order.push_back(query.to_string());
         }
 
         Ok(parsed)
@@ -151,13 +164,6 @@ impl QueryCache {
         cache.clear();
         order.clear();
         *stats = CacheStats::default();
-    }
-
-    /// Computes a hash for the query string.
-    fn hash_query(query: &str) -> u64 {
-        let mut hasher = rustc_hash::FxHasher::default();
-        query.hash(&mut hasher);
-        hasher.finish()
     }
 }
 
@@ -252,6 +258,61 @@ mod tests {
         let _ = cache.parse("SELECT * FROM docs LIMIT 3");
         assert_eq!(cache.len(), 2);
         assert!(cache.stats().evictions >= 1);
+    }
+
+    #[test]
+    fn test_query_cache_hit_refreshes_mru_without_duplicates() {
+        let cache = QueryCache::new(3);
+        let q1 = "SELECT * FROM docs LIMIT 1";
+        let q2 = "SELECT * FROM docs LIMIT 2";
+        let q3 = "SELECT * FROM docs LIMIT 3";
+
+        let _ = cache.parse(q1);
+        let _ = cache.parse(q2);
+        let _ = cache.parse(q3);
+        let _ = cache.parse(q1); // refresh MRU
+
+        let order = cache.order.read();
+        assert_eq!(order.len(), cache.len());
+        assert_eq!(order.iter().filter(|v| v.as_str() == q1).count(), 1);
+        assert_eq!(order.back().map(std::string::String::as_str), Some(q1));
+    }
+
+    #[test]
+    fn test_query_cache_concurrent_invariant_no_order_duplicates() {
+        use std::sync::Arc;
+        use std::thread;
+
+        let cache = Arc::new(QueryCache::new(32));
+        let queries = [
+            "SELECT * FROM docs LIMIT 1",
+            "SELECT * FROM docs LIMIT 2",
+            "SELECT * FROM docs LIMIT 3",
+            "SELECT * FROM docs LIMIT 4",
+            "SELECT * FROM docs LIMIT 5",
+        ];
+
+        let mut handles = Vec::new();
+        for _ in 0..8 {
+            let cache = Arc::clone(&cache);
+            handles.push(thread::spawn(move || {
+                for i in 0..200 {
+                    let q = queries[i % queries.len()];
+                    let _ = cache.parse(q);
+                }
+            }));
+        }
+
+        for h in handles {
+            h.join().expect("thread must complete");
+        }
+
+        let order = cache.order.read();
+        let mut uniq = std::collections::HashSet::new();
+        for q in order.iter() {
+            assert!(uniq.insert(q.clone()), "duplicate query in LRU order: {q}");
+        }
+        assert_eq!(order.len(), cache.len());
     }
 
     #[test]

--- a/crates/velesdb-core/src/velesql/parser/conditions.rs
+++ b/crates/velesdb-core/src/velesql/parser/conditions.rs
@@ -1,6 +1,7 @@
 //! WHERE clause and condition parsing.
 
 use super::{extract_identifier, Rule};
+use crate::metrics::global_guardrails_metrics;
 use crate::velesql::ast::{
     BetweenCondition, CompareOp, Comparison, Condition, FusionConfig, InCondition, IsNullCondition,
     LikeCondition, MatchCondition, SimilarityCondition, VectorExpr, VectorFusedSearch,
@@ -10,6 +11,8 @@ use crate::velesql::error::ParseError;
 use crate::velesql::Parser;
 
 impl Parser {
+    const MAX_CONDITION_DEPTH: usize = 256;
+
     fn extract_column_name(pair: &pest::iterators::Pair<'_, Rule>) -> String {
         if pair.as_rule() != Rule::column_name && pair.as_rule() != Rule::where_column {
             return extract_identifier(pair);
@@ -37,50 +40,85 @@ impl Parser {
             .next()
             .ok_or_else(|| ParseError::syntax(0, "", "Expected condition"))?;
 
-        Self::parse_or_expr(or_expr)
+        Self::parse_or_expr_with_depth(or_expr, 0)
     }
 
+    #[allow(dead_code)]
     pub(crate) fn parse_or_expr(
         pair: pest::iterators::Pair<Rule>,
     ) -> Result<Condition, ParseError> {
+        Self::parse_or_expr_with_depth(pair, 0)
+    }
+
+    fn ensure_depth(depth: usize, input: &str) -> Result<(), ParseError> {
+        if depth > Self::MAX_CONDITION_DEPTH {
+            global_guardrails_metrics().record_parser_depth_limit_rejected();
+            return Err(ParseError::syntax(0, input, "Condition nesting too deep"));
+        }
+        Ok(())
+    }
+
+    fn parse_or_expr_with_depth(
+        pair: pest::iterators::Pair<Rule>,
+        depth: usize,
+    ) -> Result<Condition, ParseError> {
+        Self::ensure_depth(depth, pair.as_str())?;
         let mut inner = pair.into_inner().peekable();
 
         let first = inner
             .next()
             .ok_or_else(|| ParseError::syntax(0, "", "Expected condition"))?;
 
-        let mut result = Self::parse_and_expr(first)?;
+        let mut result = Self::parse_and_expr_with_depth(first, depth + 1)?;
 
         for and_expr in inner {
-            let right = Self::parse_and_expr(and_expr)?;
+            let right = Self::parse_and_expr_with_depth(and_expr, depth + 1)?;
             result = Condition::Or(Box::new(result), Box::new(right));
         }
 
         Ok(result)
     }
 
+    #[allow(dead_code)]
     pub(crate) fn parse_and_expr(
         pair: pest::iterators::Pair<Rule>,
     ) -> Result<Condition, ParseError> {
+        Self::parse_and_expr_with_depth(pair, 0)
+    }
+
+    fn parse_and_expr_with_depth(
+        pair: pest::iterators::Pair<Rule>,
+        depth: usize,
+    ) -> Result<Condition, ParseError> {
+        Self::ensure_depth(depth, pair.as_str())?;
         let mut inner = pair.into_inner().peekable();
 
         let first = inner
             .next()
             .ok_or_else(|| ParseError::syntax(0, "", "Expected condition"))?;
 
-        let mut result = Self::parse_primary_expr(first)?;
+        let mut result = Self::parse_primary_expr_with_depth(first, depth + 1)?;
 
         for primary in inner {
-            let right = Self::parse_primary_expr(primary)?;
+            let right = Self::parse_primary_expr_with_depth(primary, depth + 1)?;
             result = Condition::And(Box::new(result), Box::new(right));
         }
 
         Ok(result)
     }
 
+    #[allow(dead_code)]
     pub(crate) fn parse_primary_expr(
         pair: pest::iterators::Pair<Rule>,
     ) -> Result<Condition, ParseError> {
+        Self::parse_primary_expr_with_depth(pair, 0)
+    }
+
+    fn parse_primary_expr_with_depth(
+        pair: pest::iterators::Pair<Rule>,
+        depth: usize,
+    ) -> Result<Condition, ParseError> {
+        Self::ensure_depth(depth, pair.as_str())?;
         let inner = pair
             .into_inner()
             .next()
@@ -88,7 +126,7 @@ impl Parser {
 
         match inner.as_rule() {
             Rule::or_expr => {
-                let cond = Self::parse_or_expr(inner)?;
+                let cond = Self::parse_or_expr_with_depth(inner, depth + 1)?;
                 Ok(Condition::Group(Box::new(cond)))
             }
             Rule::not_expr => {
@@ -96,7 +134,7 @@ impl Parser {
                     .into_inner()
                     .next()
                     .ok_or_else(|| ParseError::syntax(0, "", "Expected expression after NOT"))?;
-                let cond = Self::parse_primary_expr(nested)?;
+                let cond = Self::parse_primary_expr_with_depth(nested, depth + 1)?;
                 Ok(Condition::Not(Box::new(cond)))
             }
             Rule::similarity_expr => Self::parse_similarity_expr(inner),

--- a/crates/velesdb-core/src/velesql/parser/robustness_tests.rs
+++ b/crates/velesdb-core/src/velesql/parser/robustness_tests.rs
@@ -22,3 +22,22 @@ fn parse_join_condition_handles_quoted_identifiers_with_dots() {
     assert_eq!(condition.right.table.as_deref(), Some("order.items"));
     assert_eq!(condition.right.column, "user\"id");
 }
+
+#[test]
+fn parse_rejects_excessive_condition_nesting_depth() {
+    let depth = 400;
+    let mut query = String::from("SELECT * FROM t WHERE ");
+    for _ in 0..depth {
+        query.push_str("NOT (");
+    }
+    query.push_str("x = 1");
+    for _ in 0..depth {
+        query.push(')');
+    }
+
+    let err = Parser::parse(&query).expect_err("deeply nested condition should be rejected");
+    assert!(
+        err.to_string().contains("Condition nesting too deep"),
+        "unexpected parser error: {err}"
+    );
+}

--- a/docs/reviews/velesdb-core-velesql-expert-review-2026-02-26.md
+++ b/docs/reviews/velesdb-core-velesql-expert-review-2026-02-26.md
@@ -1,0 +1,172 @@
+# Expert review Rust/Craftsman — `velesdb-core` + `VelesQL`
+
+Date: 2026-02-26  
+Scope: `crates/velesdb-core` (core runtime + `velesql` parser/cache/execution paths)
+
+## Executive summary
+
+I found **4 priority risks** that can create production incidents:
+
+1. **Query cache correctness/safety risk**: cache key uses only a 64-bit hash, so a collision can return the wrong AST for another query.
+2. **LRU implementation drift**: order queue is not updated on cache hit and can accumulate duplicates, causing non-LRU behavior and extra evictions.
+3. **Potential DoS via LIKE/ILIKE**: current matcher allocates `O(text_len * pattern_len)` boolean matrix, unbounded by guardrails.
+4. **Potential panic/DoS in mmap retrieval**: corrupted/untrusted index offset triggers `assert!` and can crash process.
+
+I also list one medium-risk hardening topic (parser recursion depth).
+
+---
+
+## Detailed findings
+
+## 1) Cache collision can return wrong parsed query (correctness + security)
+
+### Evidence
+- `QueryCache` stores entries as `FxHashMap<u64, Query>` where key is only `hash_query(query)` (no original SQL string check).  
+- On hit, `cache.get(&hash)` returns cached query directly.
+
+### Why this is dangerous
+A 64-bit hash collision (accidental or crafted) means query A can receive AST of query B. If the cache is used by shared clients, this is a **query confusion** bug and can become a security boundary issue.
+
+### Impact
+- Wrong filtering/authorization logic at query layer.
+- Hard-to-reproduce correctness bugs under load.
+
+### Recommended fix
+- Store `(original_query, parsed_query)` as value and validate full-string equality on hit.
+- Optionally use a keyed hasher (`ahash`/SipHash keyed) to reduce chosen-collision risk.
+
+---
+
+## 2) LRU behavior is not true LRU and can over-evict
+
+### Evidence
+- On cache hit, code increments stats and returns without moving key to MRU position.
+- On insert, code always `push_back(hash)` and never de-duplicates queue.
+
+### Why this is dangerous
+- Frequently used queries can still be evicted as “old”.
+- Duplicate hash entries in deque can trigger redundant pop/remove cycles and higher lock contention under churn.
+
+### Impact
+- Lower hit-rate than expected.
+- Latency regressions due to repeated parsing.
+
+### Recommended fix
+- Maintain explicit node/index for O(1) move-to-back on hit.
+- Prevent duplicate queue entries (remove old position before push).
+- Add invariant checks in tests: `order.len() == cache.len()` and no duplicates.
+
+---
+
+## 3) LIKE/ILIKE matcher can become memory/CPU amplification vector
+
+### Evidence
+- `like_match_impl` allocates a DP matrix: `vec![vec![false; n + 1]; m + 1]`.
+- Complexity is O(m*n) memory and CPU.
+
+### Why this is dangerous
+For long payload strings and patterns, this can consume large memory and CPU (DoS vector), especially in multi-tenant/server mode.
+
+### Impact
+- Request-level latency spikes.
+- Potential OOM for worst-case inputs.
+
+### Recommended fix
+- Replace full matrix with rolling 1D DP (`O(min(m,n))` memory).
+- Enforce guardrails: max pattern length and/or max `m*n` budget.
+- Add benchmark + adversarial tests for pathological patterns.
+
+---
+
+## 4) `retrieve_ref` uses `assert!` for data validation, can panic process
+
+### Evidence
+- `retrieve_ref` validates alignment with `assert!(offset % align_of::<f32>() == 0, ...)` before pointer cast.
+
+### Why this is dangerous
+If on-disk index is corrupted (or maliciously tampered), an assertion panic can terminate the process, turning data corruption into service outage.
+
+### Impact
+- Crash/DoS on read path.
+- Lower resilience for crash-recovery scenarios.
+
+### Recommended fix
+- Replace `assert!` with fallible error (`io::ErrorKind::InvalidData`) and quarantining logic.
+- Add corruption test that verifies graceful error, no panic.
+
+---
+
+## 5) Medium risk: parser recursion depth is unbounded
+
+### Evidence
+- `parse_primary_expr` recursively calls `parse_or_expr` / `parse_primary_expr` for nested groups/NOT.
+- No depth budget/guard.
+
+### Why this is dangerous
+Very deeply nested expressions can trigger stack overflow (DoS) and unpredictable failures.
+
+### Recommended fix
+- Thread a depth counter with max threshold (configurable), return parse error when exceeded.
+
+---
+
+## Action plan (prioritized)
+
+## P0 (this sprint)
+1. **Cache correctness hardening**
+   - Store full query text with parsed AST in cache value.
+   - Verify equality on hit; treat hash collision as miss.
+2. **Replace panic path in `retrieve_ref`**
+   - Convert alignment assert to recoverable error.
+3. **LIKE guardrails**
+   - Add max pattern/input budget and reject over-limit conditions.
+
+## P1
+4. **True LRU implementation**
+   - Move-to-back on hit, deduplicate order structure.
+5. **Parser depth limits**
+   - Add recursion depth guard in parser condition handling.
+
+## P2
+6. **Security/perf regression suite**
+   - Add fuzz corpus and adversarial perf tests for parser + LIKE + cache collisions.
+
+---
+
+## Acceptance criteria (complets)
+
+### AC-1 Cache correctness
+- Given two different queries with forced same hash bucket/path, cache never returns wrong AST.
+- Unit/integration tests cover collision scenario explicitly.
+- No regression in cache hit-rate benchmark beyond agreed tolerance (e.g. <= 2%).
+
+### AC-2 LRU invariants
+- On hit, key becomes MRU.
+- Internal order structure has no duplicates.
+- Invariant tests pass under concurrent parse workload.
+
+### AC-3 LIKE resilience
+- Memory usage scales linearly with input length (no 2D matrix allocation).
+- Requests exceeding configured budget fail fast with explicit error.
+- Adversarial test corpus (long wildcard patterns) passes within latency envelope.
+
+### AC-4 Storage robustness
+- Corrupted/misaligned offset returns structured `InvalidData` error, no panic.
+- Crash-recovery tests include tampered index case.
+
+### AC-5 Parser hardening
+- Deep nesting above limit returns deterministic parse error.
+- Fuzz tests show no stack overflow/panic across defined corpus/time budget.
+
+### AC-6 Observability
+- Metrics added for: cache collision fallback count, LIKE guardrail rejections, parser depth-limit rejections, invalid offset read errors.
+- Dashboards/alerts documented.
+
+---
+
+## Next priorities
+
+1. **Ship P0 hardening patch first** (cache correctness + panic removal + LIKE guardrails).
+2. **Run a focused perf baseline** before/after P0 and P1.
+3. **Add security review gate** in CI (fuzz smoke + adversarial tests).
+4. **Document operational limits** (max query complexity/pattern size) in public docs.


### PR DESCRIPTION
### Motivation
- Prevent DoS and excessive memory/CPU from pathological `LIKE`/`ILIKE` inputs by bounding complexity and avoiding a full 2D DP allocation.\
- Eliminate crash/panic on corrupted storage offsets and improve observability for runtime safety events.\
- Fix query-cache correctness and LRU behavior to avoid hash-collision surprises and duplicate order entries, and add parser nesting guard to avoid stack/DoS issues.

### Description
- Rewrote `LIKE` matcher to tokenize patterns and use a rolling 1D DP (`O(text_len * token_len)` time, `O(token_len)` memory) and added guardrails `LIKE_MAX_PATTERN_BYTES` and `LIKE_MAX_DYN_OPS` to reject extreme cases; rejections are recorded via metrics by calling `global_guardrails_metrics().record_like_guardrail_rejected()`.\
- Added new `GuardRailsMetrics` counters and a process-wide accessor `global_guardrails_metrics()`; exported the accessor from `metrics::mod`.\
- Threaded a condition-nesting depth budget through the parser with `MAX_CONDITION_DEPTH` and return a parse error while recording `parser_depth_limit_rejected` when exceeded.\
- Reworked `QueryCache` to key by full query string instead of a 64-bit hash, move a hit to MRU (remove any previous entry first), and prevent duplicate entries in the LRU order; added unit tests that validate MRU refresh and concurrent invariant.\
- Hardened `MmapStorage::retrieve_ref` to fail gracefully on out-of-bounds or misaligned offsets by returning `io::ErrorKind::InvalidData` and recording `invalid_offset_read_errors` instead of using `assert!`; added a test that injects a misaligned offset.\
- Added multiple unit tests covering `LIKE` guardrail, parser depth rejection, storage misalignment, cache behavior, and metrics Prometheus export; included an expert review document under `docs/reviews` summarizing the findings and rationale.

### Testing
- Ran `cargo test` for the crate suite; all unit tests completed successfully.\
- Exercised new `LIKE` guardrail test `test_like_guardrail_rejects_too_large_complexity_budget` which passed.\
- Exercised storage test `test_retrieve_ref_returns_invalid_data_on_misaligned_offset` and parser test `parse_rejects_excessive_condition_nesting_depth`, both of which passed.\
- Exercised cache invariants tests `test_query_cache_hit_refreshes_mru_without_duplicates` and `test_query_cache_concurrent_invariant_no_order_duplicates`, and the `GuardRailsMetrics` Prometheus export test, all of which passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a048c34078832abc187e70d8b6c1fe)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/245" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
