### PR TITLE
Refactor planner cost model and correct query cache hit-rate and LRU handling

### DIFF
--- a/crates/velesdb-core/src/velesql/cache.rs
+++ b/crates/velesdb-core/src/velesql/cache.rs
@@ -31,9 +31,7 @@ impl CacheStats {
         if total == 0 {
             0.0
         } else {
-            (self.hits.to_string().parse::<f64>().unwrap_or(0.0)
-                / total.to_string().parse::<f64>().unwrap_or(1.0))
-                * 100.0
+            (self.hits as f64 / total as f64) * 100.0
         }
     }
 }
@@ -117,7 +115,6 @@ impl QueryCache {
         };
 
         if let Some(cached) = cached {
-            let cache = self.cache.read();
             let mut order = self.order.write();
             let mut stats = self.stats.write();
 
@@ -129,12 +126,10 @@ impl QueryCache {
             };
 
             // Move to MRU, keeping order duplicate-free.
-            if cache.get(&hash).is_some() {
-                if let Some(pos) = order.iter().position(|existing| existing == &key) {
-                    order.remove(pos);
-                }
-                order.push_back(key);
+            if let Some(pos) = order.iter().position(|existing| existing == &key) {
+                order.remove(pos);
             }
+            order.push_back(key);
 
             return Ok(cached.parsed);
         }

--- a/crates/velesdb-core/src/velesql/planner.rs
+++ b/crates/velesdb-core/src/velesql/planner.rs
@@ -46,6 +46,14 @@ pub struct Cost {
     pub cpu_cost: f64,
 }
 
+const FILTER_SCAN_IO_WEIGHT: f64 = 0.2;
+const FILTER_SCAN_CPU_WEIGHT: f64 = 0.8;
+const HNSW_IO_WEIGHT: f64 = 0.5;
+const HNSW_CPU_WEIGHT: f64 = 1.0;
+const VECTOR_FIRST_FILTER_PENALTY: f64 = 1.5;
+const PARALLEL_MERGE_OVERHEAD: f64 = 25.0;
+const GRAPH_TO_VECTOR_SCALING: f64 = 100.0;
+
 impl Cost {
     #[must_use]
     /// Creates a new cost value from I/O and CPU components.
@@ -79,7 +87,10 @@ impl<'a> CostEstimator<'a> {
         let selectivity = self.estimate_condition_selectivity(filter).clamp(0.0, 1.0);
         let total = self.stats.total_points.max(self.stats.row_count) as f64;
         let scan_rows = (total * selectivity).max(1.0);
-        Cost::new(scan_rows * 0.2, scan_rows * 0.8)
+        Cost::new(
+            scan_rows * FILTER_SCAN_IO_WEIGHT,
+            scan_rows * FILTER_SCAN_CPU_WEIGHT,
+        )
     }
 
     #[must_use]
@@ -87,7 +98,7 @@ impl<'a> CostEstimator<'a> {
     pub fn estimate_hnsw_search_cost(&self, k: usize) -> Cost {
         let total = self.stats.total_points.max(self.stats.row_count).max(1) as f64;
         let probe = (k.max(1) as f64) * total.log2().max(1.0);
-        Cost::new(probe * 0.5, probe)
+        Cost::new(probe * HNSW_IO_WEIGHT, probe * HNSW_CPU_WEIGHT)
     }
 
     #[must_use]
@@ -312,18 +323,22 @@ impl QueryPlanner {
         let filter_cost = filter.map_or(Cost::new(0.0, 0.0), |f| estimator.estimate_filter_cost(f));
         let vector_cost = estimator.estimate_hnsw_search_cost(k.max(1));
 
-        let vector_first = vector_cost.total() + (filter_cost.total() * 1.5);
-        let graph_first =
-            filter_cost.total() + (vector_cost.total() * filter_cost.io_cost.max(1.0) / 100.0);
-        let parallel = vector_cost.total().max(filter_cost.total()) + 25.0;
+        let vector_first =
+            vector_cost.total() + (filter_cost.total() * VECTOR_FIRST_FILTER_PENALTY);
+        let graph_first = filter_cost.total()
+            + (vector_cost.total() * filter_cost.io_cost.max(1.0) / GRAPH_TO_VECTOR_SCALING);
+        let parallel = vector_cost.total().max(filter_cost.total()) + PARALLEL_MERGE_OVERHEAD;
 
-        let mut plans = [
+        let candidates = [
             (ExecutionStrategy::VectorFirst, vector_first),
             (ExecutionStrategy::GraphFirst, graph_first),
             (ExecutionStrategy::Parallel, parallel),
         ];
-        plans.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal));
-        plans[0].0
+
+        candidates
+            .into_iter()
+            .min_by(|a, b| a.1.total_cmp(&b.1))
+            .map_or(ExecutionStrategy::Parallel, |(strategy, _)| strategy)
     }
 
     /// Returns a reference to the query statistics.


### PR DESCRIPTION
### Motivation
- Fix incorrect floating-point calculation in `CacheStats::hit_rate` that relied on string parsing and simplify the logic.
- Correct and simplify LRU update logic in `QueryCache::parse` to avoid an unnecessary read lock and ensure MRU movement is duplicate-free.
- Replace magic numbers in the planner's cost model with named constants and adjust cost formulas to make the cost-based optimizer clearer and more tunable.

### Description
- Replace string-based conversion in `CacheStats::hit_rate` with direct numeric division using `as f64` to compute hit rate precisely.
- Simplify LRU MRU update in `QueryCache::parse` by removing an unused read lock and always removing any existing key from `order` before pushing it to the back.
- Add named constants in `planner.rs` (`FILTER_SCAN_IO_WEIGHT`, `FILTER_SCAN_CPU_WEIGHT`, `HNSW_IO_WEIGHT`, `HNSW_CPU_WEIGHT`, `VECTOR_FIRST_FILTER_PENALTY`, `PARALLEL_MERGE_OVERHEAD`, `GRAPH_TO_VECTOR_SCALING`) and update `CostEstimator` to use these constants in `estimate_filter_cost` and `estimate_hnsw_search_cost`.
- Adjust `choose_strategy_with_cbo` to compute `vector_first`, `graph_first`, and `parallel` costs with the new constants, and select the minimum-cost strategy using `min_by` with `total_cmp`, falling back to `ExecutionStrategy::Parallel` if comparison fails.

### Testing
- Ran the workspace unit test suite with `cargo test` and the `velesdb-core` package tests with `cargo test -p velesdb-core` and observed all tests succeed.
- Verified basic cache behavior and planner cost-choice logic through the existing unit tests exercising `QueryCache::parse` and the planner CBO routines.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0e6a93c04832ab2b99668bddf150e)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/250" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
