### PR TITLE
Fix TOCTOU race in query-cache hit path LRU updates

### DIFF
--- a/crates/velesdb-core/src/velesql/cache.rs
+++ b/crates/velesdb-core/src/velesql/cache.rs
@@ -102,8 +102,8 @@ impl QueryCache {
         let canonical_query = canonicalize_query(query);
         let hash = (self.hash_fn)(&canonical_query);
 
-        let cached = {
-            self.cache.read().get(&hash).and_then(|entries| {
+        let cache = self.cache.read();
+        let cached = cache.get(&hash).and_then(|entries| {
                 entries
                     .iter()
                     .find(|entry| {
@@ -111,8 +111,7 @@ impl QueryCache {
                         entry.original_query == query && entry.canonical_query == canonical_query
                     })
                     .cloned()
-            })
-        };
+            });
 
         if let Some(cached) = cached {
             let mut order = self.order.write();
@@ -125,14 +124,19 @@ impl QueryCache {
                 original_query: query.to_string(),
             };
 
-            // Move to MRU, keeping order duplicate-free.
-            if let Some(pos) = order.iter().position(|existing| existing == &key) {
-                order.remove(pos);
+            // Keep order/cache synchronized while the cache read-lock is held.
+            if cache.get(&hash).is_some() {
+                // Move to MRU, keeping order duplicate-free.
+                if let Some(pos) = order.iter().position(|existing| existing == &key) {
+                    order.remove(pos);
+                }
+                order.push_back(key);
             }
-            order.push_back(key);
 
             return Ok(cached.parsed);
         }
+
+        drop(cache);
 
         let parsed = Parser::parse(query)?;
 


### PR DESCRIPTION
### Motivation
- A recent change released the `cache` read-lock before updating the LRU `order`, opening a TOCTOU window where a concurrent eviction could remove an entry from `cache` while the hit-path still pushed the same key into `order`.
- That race can desynchronize `order` from `cache` and break the invariant `entry_count(&cache) == order.len()`, causing phantom entries and incorrect evictions under concurrency.

### Description
- Hold the `self.cache.read()` guard in a local `cache` variable for the duration of the hit-path critical section so the entry cannot be evicted while updating MRU order.
- Reintroduce the presence check `if cache.get(&hash).is_some()` while the read-lock is held before mutating `order` to avoid pushing phantom keys.
- Call `drop(cache)` explicitly before entering the miss/insert path so the miss can acquire write locks without violating lock ordering.
- Changes are localized to `crates/velesdb-core/src/velesql/cache.rs` in `QueryCache::parse` and preserve the duplicate-free MRU move logic.

### Testing
- Ran `cargo test -p velesdb-core velesql::cache`, and all cache unit tests passed (24 passed; 0 failed).
- Ran the crate test suite for `velesdb-core` during development and observed the unit tests that exercised the cache pass (no failures related to the cache changes).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a104b553b0832a986747b4fb1e28d0)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/251" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
