### PR TITLE
Add onboarding diagnostics, dimension validation, actionable search errors and sanity endpoint

### DIFF
--- a/crates/velesdb-server/src/handlers/collections.rs
+++ b/crates/velesdb-server/src/handlers/collections.rs
@@ -119,15 +119,24 @@ pub async fn create_collection(
     };
 
     match result {
-        Ok(()) => (
-            StatusCode::CREATED,
-            Json(serde_json::json!({
-                "message": "Collection created",
-                "name": req.name,
-                "type": req.collection_type
-            })),
-        )
-            .into_response(),
+        Ok(()) => {
+            let mut warnings = Vec::new();
+            if req.collection_type.eq_ignore_ascii_case("vector") {
+                warnings.push("Collection dimension and metric are immutable after creation. If your embedding model changes, create a new collection and reindex data.");
+                warnings.push("For first queries, start without strict filters/thresholds, then tighten progressively.");
+            }
+
+            (
+                StatusCode::CREATED,
+                Json(serde_json::json!({
+                    "message": "Collection created",
+                    "name": req.name,
+                    "type": req.collection_type,
+                    "warnings": warnings
+                })),
+            )
+                .into_response()
+        }
         Err(e) => (
             StatusCode::BAD_REQUEST,
             Json(ErrorResponse {
@@ -165,6 +174,67 @@ pub async fn get_collection(
                 point_count: config.point_count,
                 storage_mode: format!("{:?}", config.storage_mode).to_lowercase(),
             })
+            .into_response()
+        }
+        None => (
+            StatusCode::NOT_FOUND,
+            Json(ErrorResponse {
+                error: format!("Collection '{}' not found", name),
+            }),
+        )
+            .into_response(),
+    }
+}
+
+/// Run a quick sanity check for onboarding and troubleshooting.
+#[utoipa::path(
+    get,
+    path = "/collections/{name}/sanity",
+    tag = "collections",
+    params(
+        ("name" = String, Path, description = "Collection name")
+    ),
+    responses(
+        (status = 200, description = "Collection sanity status", body = Object),
+        (status = 404, description = "Collection not found", body = ErrorResponse)
+    )
+)]
+pub async fn collection_sanity(
+    State(state): State<Arc<AppState>>,
+    Path(name): Path<String>,
+) -> impl IntoResponse {
+    match state.db.get_collection(&name) {
+        Some(collection) => {
+            let config = collection.config();
+            let has_data = config.point_count > 0;
+            Json(serde_json::json!({
+                "collection": config.name,
+                "dimension": config.dimension,
+                "metric": format!("{:?}", config.metric).to_lowercase(),
+                "point_count": config.point_count,
+                "is_empty": collection.is_empty(),
+                "checks": {
+                    "has_vectors": has_data,
+                    "search_ready": has_data,
+                    "dimension_configured": config.dimension > 0
+                },
+                "diagnostics": {
+                    "search_requests_total": state.onboarding_metrics.search_requests_total.load(std::sync::atomic::Ordering::Relaxed),
+                    "dimension_mismatch_total": state.onboarding_metrics.dimension_mismatch_total.load(std::sync::atomic::Ordering::Relaxed),
+                    "empty_search_results_total": state.onboarding_metrics.empty_search_results_total.load(std::sync::atomic::Ordering::Relaxed),
+                    "filter_parse_errors_total": state.onboarding_metrics.filter_parse_errors_total.load(std::sync::atomic::Ordering::Relaxed)
+                },
+                "hints": if has_data {
+                    vec![
+                        "Run a search without strict filters first, then tighten filters progressively."
+                    ]
+                } else {
+                    vec![
+                        "Insert at least one known vector before evaluating search quality.",
+                        "Verify you are querying the intended collection."
+                    ]
+                }
+            }))
             .into_response()
         }
         None => (

--- a/crates/velesdb-server/src/handlers/mod.rs
+++ b/crates/velesdb-server/src/handlers/mod.rs
@@ -23,8 +23,8 @@ pub mod search;
 pub mod metrics;
 
 pub use collections::{
-    create_collection, delete_collection, flush_collection, get_collection, is_empty,
-    list_collections,
+    collection_sanity, create_collection, delete_collection, flush_collection, get_collection,
+    is_empty, list_collections,
 };
 pub use health::health_check;
 pub use indexes::{create_index, delete_index, list_indexes};

--- a/crates/velesdb-server/src/handlers/search.rs
+++ b/crates/velesdb-server/src/handlers/search.rs
@@ -15,6 +15,54 @@ use crate::types::{
 };
 use crate::AppState;
 
+fn dimension_mismatch_error(
+    collection_name: &str,
+    expected: usize,
+    actual: usize,
+) -> ErrorResponse {
+    ErrorResponse {
+        error: format!(
+            "Vector dimension mismatch for collection '{collection_name}': expected {expected}, got {actual}. Hint: use embeddings with the same dimension as the collection or create a new collection with the target dimension."
+        ),
+    }
+}
+
+fn validate_query_dimension(
+    state: &AppState,
+    collection_name: &str,
+    expected: usize,
+    query_vector: &[f32],
+) -> Result<(), ErrorResponse> {
+    let actual = query_vector.len();
+    if actual == expected {
+        return Ok(());
+    }
+    state.onboarding_metrics.record_dimension_mismatch();
+    tracing::warn!(
+        collection = %collection_name,
+        expected_dimension = expected,
+        actual_dimension = actual,
+        "Search rejected due to vector dimension mismatch"
+    );
+    Err(dimension_mismatch_error(collection_name, expected, actual))
+}
+
+fn actionable_search_error(error: &dyn std::fmt::Display) -> ErrorResponse {
+    let base_error = error.to_string();
+    let lower = base_error.to_lowercase();
+    let hint = if lower.contains("dimension") {
+        " Hint: check that query vector dimension matches collection dimension."
+    } else if lower.contains("filter") {
+        " Hint: validate filter syntax and start with a broader query before reintroducing strict filters."
+    } else {
+        " Hint: if you get empty results, retry without strict filters/thresholds, then tighten progressively."
+    };
+
+    ErrorResponse {
+        error: format!("{base_error}{hint}"),
+    }
+}
+
 /// Search for similar vectors.
 #[utoipa::path(
     post,
@@ -36,6 +84,8 @@ pub async fn search(
     Path(name): Path<String>,
     Json(req): Json<SearchRequest>,
 ) -> impl IntoResponse {
+    state.onboarding_metrics.record_search_request();
+
     let collection = match state.db.get_collection(&name) {
         Some(c) => c,
         None => {
@@ -49,6 +99,11 @@ pub async fn search(
         }
     };
 
+    let expected_dimension = collection.config().dimension;
+    if let Err(error) = validate_query_dimension(&state, &name, expected_dimension, &req.vector) {
+        return (StatusCode::BAD_REQUEST, Json(error)).into_response();
+    }
+
     let effective_ef = req
         .ef_search
         .or_else(|| req.mode.as_ref().and_then(|m| mode_to_ef_search(m)));
@@ -57,13 +112,14 @@ pub async fn search(
         let filter: velesdb_core::Filter = match serde_json::from_value(filter_json.clone()) {
             Ok(f) => f,
             Err(e) => {
+                state.onboarding_metrics.record_filter_parse_error();
                 return (
                     StatusCode::BAD_REQUEST,
                     Json(ErrorResponse {
                         error: format!("Invalid filter: {}", e),
                     }),
                 )
-                    .into_response()
+                    .into_response();
             }
         };
         collection.search_with_filter(&req.vector, req.top_k, &filter)
@@ -75,6 +131,10 @@ pub async fn search(
 
     match search_result {
         Ok(results) => {
+            if results.is_empty() {
+                state.onboarding_metrics.record_empty_search_results();
+            }
+
             let response = SearchResponse {
                 results: results
                     .into_iter()
@@ -87,13 +147,7 @@ pub async fn search(
             };
             Json(response).into_response()
         }
-        Err(e) => (
-            StatusCode::BAD_REQUEST,
-            Json(ErrorResponse {
-                error: e.to_string(),
-            }),
-        )
-            .into_response(),
+        Err(e) => (StatusCode::BAD_REQUEST, Json(actionable_search_error(&e))).into_response(),
     }
 }
 
@@ -119,6 +173,7 @@ pub async fn batch_search(
     Json(req): Json<BatchSearchRequest>,
 ) -> impl IntoResponse {
     let start = std::time::Instant::now();
+    state.onboarding_metrics.record_search_request();
 
     let collection = match state.db.get_collection(&name) {
         Some(c) => c,
@@ -133,42 +188,73 @@ pub async fn batch_search(
         }
     };
 
+    let expected_dimension = collection.config().dimension;
+    for (idx, search) in req.searches.iter().enumerate() {
+        if let Err(error) =
+            validate_query_dimension(&state, &name, expected_dimension, &search.vector)
+        {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(ErrorResponse {
+                    error: format!("Invalid query at index {idx}: {}", error.error),
+                }),
+            )
+                .into_response();
+        }
+    }
+
     let queries: Vec<&[f32]> = req.searches.iter().map(|s| s.vector.as_slice()).collect();
 
-    let filters: Vec<Option<velesdb_core::Filter>> = req
-        .searches
-        .iter()
-        .map(|s| {
-            s.filter
-                .as_ref()
-                .and_then(|f_json| serde_json::from_value(f_json.clone()).ok())
-        })
-        .collect();
+    let mut filters: Vec<Option<velesdb_core::Filter>> = Vec::with_capacity(req.searches.len());
+    for (idx, search) in req.searches.iter().enumerate() {
+        if let Some(filter_json) = &search.filter {
+            match serde_json::from_value(filter_json.clone()) {
+                Ok(filter) => filters.push(Some(filter)),
+                Err(e) => {
+                    state.onboarding_metrics.record_filter_parse_error();
+                    return (
+                        StatusCode::BAD_REQUEST,
+                        Json(ErrorResponse {
+                            error: format!(
+                                "Invalid filter at index {idx}: {e}. Hint: validate filter syntax and start with a broader query before reintroducing strict filters."
+                            ),
+                        }),
+                    )
+                        .into_response();
+                }
+            }
+        } else {
+            filters.push(None);
+        }
+    }
 
     let top_k = req.searches.first().map_or(10, |s| s.top_k);
 
     let all_results = match collection.search_batch_with_filters(&queries, top_k, &filters) {
-        Ok(batch_results) => batch_results
-            .into_iter()
-            .map(|results| SearchResponse {
-                results: results
-                    .into_iter()
-                    .map(|r| SearchResultResponse {
-                        id: r.point.id,
-                        score: r.score,
-                        payload: r.point.payload,
-                    })
-                    .collect(),
-            })
-            .collect(),
+        Ok(batch_results) => {
+            let empty_count = batch_results
+                .iter()
+                .filter(|results| results.is_empty())
+                .count();
+            for _ in 0..empty_count {
+                state.onboarding_metrics.record_empty_search_results();
+            }
+            batch_results
+                .into_iter()
+                .map(|results| SearchResponse {
+                    results: results
+                        .into_iter()
+                        .map(|r| SearchResultResponse {
+                            id: r.point.id,
+                            score: r.score,
+                            payload: r.point.payload,
+                        })
+                        .collect(),
+                })
+                .collect()
+        }
         Err(e) => {
-            return (
-                StatusCode::BAD_REQUEST,
-                Json(ErrorResponse {
-                    error: e.to_string(),
-                }),
-            )
-                .into_response()
+            return (StatusCode::BAD_REQUEST, Json(actionable_search_error(&e))).into_response()
         }
     };
 
@@ -189,6 +275,7 @@ pub async fn multi_query_search(
     Json(req): Json<MultiQuerySearchRequest>,
 ) -> impl IntoResponse {
     use velesdb_core::FusionStrategy;
+    state.onboarding_metrics.record_search_request();
 
     let collection = match state.db.get_collection(&name) {
         Some(c) => c,
@@ -226,20 +313,31 @@ pub async fn multi_query_search(
         }
     };
 
+    let expected_dimension = collection.config().dimension;
+    for (idx, vector) in req.vectors.iter().enumerate() {
+        if let Err(error) = validate_query_dimension(&state, &name, expected_dimension, vector) {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(ErrorResponse {
+                    error: format!("Invalid query vector at index {idx}: {}", error.error),
+                }),
+            )
+                .into_response();
+        }
+    }
+
     let query_refs: Vec<&[f32]> = req.vectors.iter().map(Vec::as_slice).collect();
 
     let results = match collection.multi_query_search(&query_refs, req.top_k, strategy, None) {
         Ok(r) => r,
         Err(e) => {
-            return (
-                StatusCode::BAD_REQUEST,
-                Json(ErrorResponse {
-                    error: e.to_string(),
-                }),
-            )
-                .into_response()
+            return (StatusCode::BAD_REQUEST, Json(actionable_search_error(&e))).into_response()
         }
     };
+
+    if results.is_empty() {
+        state.onboarding_metrics.record_empty_search_results();
+    }
 
     let response = SearchResponse {
         results: results
@@ -275,6 +373,8 @@ pub async fn text_search(
     Path(name): Path<String>,
     Json(req): Json<TextSearchRequest>,
 ) -> impl IntoResponse {
+    state.onboarding_metrics.record_search_request();
+
     let collection = match state.db.get_collection(&name) {
         Some(c) => c,
         None => {
@@ -292,13 +392,14 @@ pub async fn text_search(
         let filter: velesdb_core::Filter = match serde_json::from_value(filter_json.clone()) {
             Ok(f) => f,
             Err(e) => {
+                state.onboarding_metrics.record_filter_parse_error();
                 return (
                     StatusCode::BAD_REQUEST,
                     Json(ErrorResponse {
                         error: format!("Invalid filter: {}", e),
                     }),
                 )
-                    .into_response()
+                    .into_response();
             }
         };
         collection.text_search_with_filter(&req.query, req.top_k, &filter)
@@ -341,6 +442,8 @@ pub async fn hybrid_search(
     Path(name): Path<String>,
     Json(req): Json<HybridSearchRequest>,
 ) -> impl IntoResponse {
+    state.onboarding_metrics.record_search_request();
+
     let collection = match state.db.get_collection(&name) {
         Some(c) => c,
         None => {
@@ -354,17 +457,23 @@ pub async fn hybrid_search(
         }
     };
 
+    let expected_dimension = collection.config().dimension;
+    if let Err(error) = validate_query_dimension(&state, &name, expected_dimension, &req.vector) {
+        return (StatusCode::BAD_REQUEST, Json(error)).into_response();
+    }
+
     let search_result = if let Some(ref filter_json) = req.filter {
         let filter: velesdb_core::Filter = match serde_json::from_value(filter_json.clone()) {
             Ok(f) => f,
             Err(e) => {
+                state.onboarding_metrics.record_filter_parse_error();
                 return (
                     StatusCode::BAD_REQUEST,
                     Json(ErrorResponse {
                         error: format!("Invalid filter: {}", e),
                     }),
                 )
-                    .into_response()
+                    .into_response();
             }
         };
         collection.hybrid_search_with_filter(
@@ -380,6 +489,9 @@ pub async fn hybrid_search(
 
     match search_result {
         Ok(results) => {
+            if results.is_empty() {
+                state.onboarding_metrics.record_empty_search_results();
+            }
             let response = SearchResponse {
                 results: results
                     .into_iter()
@@ -392,12 +504,6 @@ pub async fn hybrid_search(
             };
             Json(response).into_response()
         }
-        Err(e) => (
-            StatusCode::BAD_REQUEST,
-            Json(ErrorResponse {
-                error: e.to_string(),
-            }),
-        )
-            .into_response(),
+        Err(e) => (StatusCode::BAD_REQUEST, Json(actionable_search_error(&e))).into_response(),
     }
 }

--- a/crates/velesdb-server/src/lib.rs
+++ b/crates/velesdb-server/src/lib.rs
@@ -25,6 +25,7 @@
 mod handlers;
 mod types;
 
+use std::sync::atomic::{AtomicU64, Ordering};
 use utoipa::OpenApi;
 use velesdb_core::Database;
 
@@ -33,10 +34,10 @@ pub use types::*;
 
 // Re-export handlers for routing
 pub use handlers::{
-    batch_search, create_collection, create_index, delete_collection, delete_index, delete_point,
-    explain, flush_collection, get_collection, get_point, health_check, hybrid_search, is_empty,
-    list_collections, list_indexes, match_query, multi_query_search, query, search,
-    stream_upsert_points, text_search, upsert_points,
+    batch_search, collection_sanity, create_collection, create_index, delete_collection,
+    delete_index, delete_point, explain, flush_collection, get_collection, get_point, health_check,
+    hybrid_search, is_empty, list_collections, list_indexes, match_query, multi_query_search,
+    query, search, stream_upsert_points, text_search, upsert_points,
 };
 
 // FLAG-2 FIX: Re-export graph handlers for routing (EPIC-016/US-031, US-050)
@@ -82,6 +83,7 @@ pub use handlers::metrics::{health_metrics, prometheus_metrics};
         handlers::collections::create_collection,
         handlers::collections::get_collection,
         handlers::collections::delete_collection,
+        handlers::collections::collection_sanity,
         handlers::points::upsert_points,
         handlers::points::stream_upsert_points,
         handlers::points::get_point,
@@ -138,6 +140,38 @@ pub struct ApiDoc;
 pub struct AppState {
     /// The `VelesDB` database instance.
     pub db: Database,
+    /// New-user onboarding diagnostics counters.
+    pub onboarding_metrics: OnboardingMetrics,
+}
+
+/// Lightweight counters for first-hour troubleshooting diagnostics.
+#[derive(Default)]
+pub struct OnboardingMetrics {
+    pub search_requests_total: AtomicU64,
+    pub dimension_mismatch_total: AtomicU64,
+    pub empty_search_results_total: AtomicU64,
+    pub filter_parse_errors_total: AtomicU64,
+}
+
+impl OnboardingMetrics {
+    pub fn record_search_request(&self) {
+        self.search_requests_total.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn record_dimension_mismatch(&self) {
+        self.dimension_mismatch_total
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn record_empty_search_results(&self) {
+        self.empty_search_results_total
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn record_filter_parse_error(&self) {
+        self.filter_parse_errors_total
+            .fetch_add(1, Ordering::Relaxed);
+    }
 }
 
 // ============================================================================

--- a/crates/velesdb-server/src/main.rs
+++ b/crates/velesdb-server/src/main.rs
@@ -16,11 +16,11 @@ use utoipa::OpenApi;
 use utoipa_swagger_ui::SwaggerUi;
 use velesdb_core::Database;
 use velesdb_server::{
-    add_edge, batch_search, create_collection, create_index, delete_collection, delete_index,
-    delete_point, flush_collection, get_collection, get_edges, get_node_degree, get_point,
-    health_check, hybrid_search, is_empty, list_collections, list_indexes, match_query,
+    add_edge, batch_search, collection_sanity, create_collection, create_index, delete_collection,
+    delete_index, delete_point, flush_collection, get_collection, get_edges, get_node_degree,
+    get_point, health_check, hybrid_search, is_empty, list_collections, list_indexes, match_query,
     multi_query_search, query, search, stream_traverse, stream_upsert_points, text_search,
-    traverse_graph, upsert_points, ApiDoc, AppState, GraphService,
+    traverse_graph, upsert_points, ApiDoc, AppState, GraphService, OnboardingMetrics,
 };
 
 /// VelesDB Server - A high-performance vector database
@@ -59,7 +59,10 @@ async fn main() -> anyhow::Result<()> {
 
     // Initialize database
     let db = Database::open(&args.data_dir)?;
-    let state = Arc::new(AppState { db });
+    let state = Arc::new(AppState {
+        db,
+        onboarding_metrics: OnboardingMetrics::default(),
+    });
 
     // Initialize graph service (FLAG-2 FIX: EPIC-016/US-031)
     // WARNING: GraphService is in-memory only and NOT persisted to disk.
@@ -101,6 +104,7 @@ async fn main() -> anyhow::Result<()> {
             get(get_collection).delete(delete_collection),
         )
         .route("/collections/{name}/empty", get(is_empty))
+        .route("/collections/{name}/sanity", get(collection_sanity))
         .route("/collections/{name}/flush", post(flush_collection))
         // 100MB limit for batch vector uploads (1000 vectors × 768D × 4 bytes = ~3MB typical)
         .route("/collections/{name}/points", post(upsert_points))

--- a/crates/velesdb-server/tests/api_integration.rs
+++ b/crates/velesdb-server/tests/api_integration.rs
@@ -2206,3 +2206,284 @@ async fn test_graph_node_degree() {
     assert_eq!(json["in_degree"], 2);
     assert_eq!(json["out_degree"], 1);
 }
+
+#[tokio::test]
+async fn test_search_dimension_mismatch_returns_actionable_error() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let app = create_test_app(&temp_dir);
+
+    let create_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/collections")
+                .header("Content-Type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "name": "dim_guard",
+                        "dimension": 4,
+                        "metric": "cosine"
+                    })
+                    .to_string(),
+                ))
+                .expect("Failed to build request"),
+        )
+        .await
+        .expect("Request failed");
+
+    assert_eq!(create_response.status(), StatusCode::CREATED);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/collections/dim_guard/search")
+                .header("Content-Type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "vector": [1.0, 0.0],
+                        "top_k": 2
+                    })
+                    .to_string(),
+                ))
+                .expect("Failed to build request"),
+        )
+        .await
+        .expect("Request failed");
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("Failed to read body");
+    let json: Value = serde_json::from_slice(&body).expect("Invalid JSON");
+    let error = json["error"].as_str().unwrap_or_default();
+    assert!(error.contains("expected 4, got 2"));
+    assert!(error.contains("Hint"));
+}
+
+#[tokio::test]
+async fn test_create_collection_returns_preflight_warnings() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let app = create_test_app(&temp_dir);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/collections")
+                .header("Content-Type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "name": "warn_collection",
+                        "dimension": 128,
+                        "metric": "cosine"
+                    })
+                    .to_string(),
+                ))
+                .expect("Failed to build request"),
+        )
+        .await
+        .expect("Request failed");
+
+    assert_eq!(response.status(), StatusCode::CREATED);
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("Failed to read body");
+    let json: Value = serde_json::from_slice(&body).expect("Invalid JSON");
+
+    assert!(json["warnings"].is_array());
+    assert!(!json["warnings"]
+        .as_array()
+        .expect("warnings array")
+        .is_empty());
+}
+
+#[tokio::test]
+async fn test_collection_sanity_reports_empty_collection() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let app = create_test_app(&temp_dir);
+
+    let create_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/collections")
+                .header("Content-Type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "name": "sanity_collection",
+                        "dimension": 3,
+                        "metric": "cosine"
+                    })
+                    .to_string(),
+                ))
+                .expect("Failed to build request"),
+        )
+        .await
+        .expect("Request failed");
+
+    assert_eq!(create_response.status(), StatusCode::CREATED);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/collections/sanity_collection/sanity")
+                .body(Body::empty())
+                .expect("Failed to build request"),
+        )
+        .await
+        .expect("Request failed");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("Failed to read body");
+    let json: Value = serde_json::from_slice(&body).expect("Invalid JSON");
+
+    assert_eq!(json["checks"]["has_vectors"], false);
+    assert_eq!(json["is_empty"], true);
+}
+
+#[tokio::test]
+async fn test_collection_sanity_includes_diagnostics_counters() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let app = create_test_app(&temp_dir);
+
+    let create_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/collections")
+                .header("Content-Type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "name": "diag_collection",
+                        "dimension": 4,
+                        "metric": "cosine"
+                    })
+                    .to_string(),
+                ))
+                .expect("Failed to build request"),
+        )
+        .await
+        .expect("Request failed");
+    assert_eq!(create_response.status(), StatusCode::CREATED);
+
+    // Trigger one dimension mismatch
+    let mismatch_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/collections/diag_collection/search")
+                .header("Content-Type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "vector": [1.0, 0.0],
+                        "top_k": 1
+                    })
+                    .to_string(),
+                ))
+                .expect("Failed to build request"),
+        )
+        .await
+        .expect("Request failed");
+    assert_eq!(mismatch_response.status(), StatusCode::BAD_REQUEST);
+
+    let sanity_response = app
+        .oneshot(
+            Request::builder()
+                .uri("/collections/diag_collection/sanity")
+                .body(Body::empty())
+                .expect("Failed to build request"),
+        )
+        .await
+        .expect("Request failed");
+    assert_eq!(sanity_response.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(sanity_response.into_body(), usize::MAX)
+        .await
+        .expect("Failed to read body");
+    let json: Value = serde_json::from_slice(&body).expect("Invalid JSON");
+
+    assert!(
+        json["diagnostics"]["search_requests_total"]
+            .as_u64()
+            .unwrap_or(0)
+            >= 1
+    );
+    assert!(
+        json["diagnostics"]["dimension_mismatch_total"]
+            .as_u64()
+            .unwrap_or(0)
+            >= 1
+    );
+}
+
+#[tokio::test]
+async fn test_batch_search_invalid_filter_returns_bad_request() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let app = create_test_app(&temp_dir);
+
+    let create_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/collections")
+                .header("Content-Type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "name": "batch_filter_validation",
+                        "dimension": 4,
+                        "metric": "cosine"
+                    })
+                    .to_string(),
+                ))
+                .expect("Failed to build request"),
+        )
+        .await
+        .expect("Request failed");
+
+    assert_eq!(create_response.status(), StatusCode::CREATED);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/collections/batch_filter_validation/search/batch")
+                .header("Content-Type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "searches": [
+                            {
+                                "vector": [1.0, 0.0, 0.0, 0.0],
+                                "top_k": 2,
+                                "filter": {
+                                    "type": "eq",
+                                    "field": "category"
+                                }
+                            }
+                        ]
+                    })
+                    .to_string(),
+                ))
+                .expect("Failed to build request"),
+        )
+        .await
+        .expect("Request failed");
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("Failed to read body");
+    let json: Value = serde_json::from_slice(&body).expect("Invalid JSON");
+    let error = json["error"].as_str().unwrap_or_default();
+
+    assert!(error.contains("Invalid filter at index 0"));
+    assert!(error.contains("Hint"));
+}

--- a/crates/velesdb-server/tests/common/mod.rs
+++ b/crates/velesdb-server/tests/common/mod.rs
@@ -9,16 +9,19 @@ use tempfile::TempDir;
 
 use velesdb_core::Database;
 use velesdb_server::{
-    add_edge, batch_search, create_collection, delete_collection, delete_point, get_collection,
-    get_edges, get_node_degree, get_point, health_check, hybrid_search, list_collections, query,
-    search, stream_upsert_points, text_search, traverse_graph, upsert_points, AppState,
-    GraphService,
+    add_edge, batch_search, collection_sanity, create_collection, delete_collection, delete_point,
+    get_collection, get_edges, get_node_degree, get_point, health_check, hybrid_search,
+    list_collections, query, search, stream_upsert_points, text_search, traverse_graph,
+    upsert_points, AppState, GraphService, OnboardingMetrics,
 };
 
 /// Helper to create test app with all routes
 pub fn create_test_app(temp_dir: &TempDir) -> Router {
     let db = Database::open(temp_dir.path()).expect("Failed to open database");
-    let state = Arc::new(AppState { db });
+    let state = Arc::new(AppState {
+        db,
+        onboarding_metrics: OnboardingMetrics::default(),
+    });
     let graph_service = GraphService::new();
 
     Router::new()
@@ -31,6 +34,7 @@ pub fn create_test_app(temp_dir: &TempDir) -> Router {
             "/collections/{name}",
             get(get_collection).delete(delete_collection),
         )
+        .route("/collections/{name}/sanity", get(collection_sanity))
         .route("/collections/{name}/points", post(upsert_points))
         .route(
             "/collections/{name}/points/stream",

--- a/docs/NEW_USER_TROUBLESHOOTING.md
+++ b/docs/NEW_USER_TROUBLESHOOTING.md
@@ -93,3 +93,45 @@ Normal : dépend du CPU, de `ef_search`, des filtres/payloads et du dataset.
 - [ ] At least one known vector is inserted and retrievable
 - [ ] Query works without strict filters first
 - [ ] Thresholds/filters are added progressively
+
+---
+
+## Priorités d'amélioration code (basées sur les incidents "first-hour")
+
+### P0 — Réduire les erreurs silencieuses et les "empty results" incompris
+
+1. **Validation explicite de dimension dans les handlers HTTP/CLI avant exécution de recherche**
+   - Problème visé: requêtes qui retournent 0 résultat alors que la vraie cause est un mismatch de dimension.
+   - Amélioration: vérifier `query.len()` vs dimension collection et renvoyer une erreur guidée avec suggestion corrective.
+2. **Messages d'erreur actionnables pour seuil/filtre trop strict**
+   - Problème visé: "0 résultat" sans feedback.
+   - Amélioration: enrichir les erreurs/réponses avec hints (ex: "testez sans threshold", "élargissez filter").
+3. **Endpoint/check de diagnostic rapide pour nouvelle collection**
+   - Problème visé: données absentes ou mauvaise collection ciblée.
+   - Amélioration: endpoint "sanity" (dimension, metric, point_count, exemple de recherche simple).
+
+### P1 — Mieux guider la configuration figée (dimension/métrique)
+
+1. **Préflight au `create_collection` avec avertissements orientés usage**
+   - Problème visé: incompréhension du caractère immuable dimension/métrique.
+   - Amélioration: warnings/documentation inline à la création + conseils de migration/reindex.
+2. **Commande/outillage de reindex simplifié**
+   - Problème visé: friction quand l'utilisateur change de modèle d'embedding.
+   - Amélioration: utilitaire guidé pour copier payloads + recalcul embeddings + création nouvelle collection.
+
+### P2 — Observabilité et onboarding
+
+1. **Logs/metrics orientés "new user"**
+   - Compteurs pour: mismatch dimension, recherches sans données, seuils éliminant tous les hits.
+2. **Exemples exécutables "de zéro à premier résultat"**
+   - Script unique: create → insert known vector → search sans filtre → search avec filtre.
+3. **Messages d'installation plus explicites entre core/server/cli**
+   - Clarifier plus tôt que `velesdb-core` n'expose ni HTTP API ni REPL.
+
+### Ordre d'implémentation recommandé
+
+1. P0.1 + P0.2 (impact immédiat sur DX)
+2. P0.3 (diagnostic automatique)
+3. P1.1 (prévention)
+4. P1.2 (workflow de migration)
+5. P2.* (observabilité et docs onboarding)


### PR DESCRIPTION
### Motivation

- Reduce first‑hour user confusion by surfacing actionable errors (dimension mismatches, filter parse issues) instead of silent empty results.
- Provide lightweight onboarding diagnostics to help troubleshoot common misconfigurations (wrong embedding dimension, strict filters, empty collections).
- Guide users at collection creation with preflight warnings about immutable properties (dimension/metric) to avoid costly mistakes.

### Description

- Added `OnboardingMetrics` to `AppState` with atomic counters and helper methods for `search_requests_total`, `dimension_mismatch_total`, `empty_search_results_total`, and `filter_parse_errors_total`.
- Enhanced search handlers (`search`, `batch_search`, `multi_query_search`, `hybrid_search`, `text_search`) to record onboarding metrics, validate query vector dimensions before executing searches, and attach actionable hints to errors (dimension/filter/empty-result guidance).
- Introduced `collection_sanity` endpoint at `GET /collections/{name}/sanity` that returns collection info, basic checks (`has_vectors`, `search_ready`, `dimension_configured`), diagnostics counters and contextual hints for onboarding/troubleshooting.
- Updated `create_collection` to include preflight `warnings` in the response for vector collections advising that dimension/metric are immutable and recommending progressive filter tightening on first queries.
- Added routing/exports changes across handlers, `lib.rs`, `main.rs`, and test bootstrap to expose the new endpoint and types, and updated documentation with `docs/NEW_USER_TROUBLESHOOTING.md` improvements.
- Added multiple integration tests covering dimension mismatch errors, create collection warnings, `collection_sanity` behavior and diagnostics, and batch search invalid filter handling.

### Testing

- Ran the test suite with `cargo test`, including unit tests and the updated integration tests in `crates/velesdb-server/tests`, and all tests passed.
- Included integration tests: `test_search_dimension_mismatch_returns_actionable_error`, `test_create_collection_returns_preflight_warnings`, `test_collection_sanity_reports_empty_collection`, `test_collection_sanity_includes_diagnostics_counters`, and `test_batch_search_invalid_filter_returns_bad_request`, which succeeded during the run.
- Verified OpenAPI generation test `test_openapi_spec_generation` still passes after adding the new endpoint to the API doc.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2ed252420832a9148c16449e77543)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/253" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
