### PR TITLE
Fix missing preflight warnings when `collection_type` is empty

### DIFF
--- a/crates/velesdb-server/src/handlers/collections.rs
+++ b/crates/velesdb-server/src/handlers/collections.rs
@@ -121,7 +121,8 @@ pub async fn create_collection(
     match result {
         Ok(()) => {
             let mut warnings = Vec::new();
-            if req.collection_type.eq_ignore_ascii_case("vector") {
+            let is_vector = matches!(req.collection_type.to_lowercase().as_str(), "vector" | "");
+            if is_vector {
                 warnings.push("Collection dimension and metric are immutable after creation. If your embedding model changes, create a new collection and reindex data.");
                 warnings.push("For first queries, start without strict filters/thresholds, then tighten progressively.");
             }

--- a/crates/velesdb-server/tests/api_integration.rs
+++ b/crates/velesdb-server/tests/api_integration.rs
@@ -2300,6 +2300,46 @@ async fn test_create_collection_returns_preflight_warnings() {
 }
 
 #[tokio::test]
+async fn test_create_collection_with_empty_type_returns_preflight_warnings() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let app = create_test_app(&temp_dir);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/collections")
+                .header("Content-Type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "name": "warn_collection_empty_type",
+                        "collection_type": "",
+                        "dimension": 128,
+                        "metric": "cosine"
+                    })
+                    .to_string(),
+                ))
+                .expect("Failed to build request"),
+        )
+        .await
+        .expect("Request failed");
+
+    assert_eq!(response.status(), StatusCode::CREATED);
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("Failed to read body");
+    let json: Value = serde_json::from_slice(&body).expect("Invalid JSON");
+
+    assert!(json["warnings"].is_array());
+    assert_eq!(
+        json["warnings"]
+            .as_array()
+            .map_or(0, |warnings| warnings.len()),
+        2
+    );
+}
+
+#[tokio::test]
 async fn test_collection_sanity_reports_empty_collection() {
     let temp_dir = TempDir::new().expect("Failed to create temp dir");
     let app = create_test_app(&temp_dir);


### PR DESCRIPTION
### Motivation
- Creating a vector collection already accepts `"vector" | ""`, but the preflight warning gate only checked for `"vector"`, so clients explicitly passing `collection_type: ""` did not receive onboarding warnings.
- This could cause users to miss important guidance about immutable dimension/metric and initial query tuning when they intentionally send an empty string.

### Description
- Treat an explicit empty `collection_type` as a vector when deciding to emit preflight warnings by adding `let is_vector = matches!(req.collection_type.to_lowercase().as_str(), "vector" | "");` and using `if is_vector { ... }` in `create_collection`.
- Added an integration test `test_create_collection_with_empty_type_returns_preflight_warnings` that posts `"collection_type": ""` and asserts the `warnings` array is present and has length 2.
- Changes are in `crates/velesdb-server/src/handlers/collections.rs` and `crates/velesdb-server/tests/api_integration.rs`.

### Testing
- Ran `cargo test -p velesdb-server preflight_warnings` which executed the relevant integration tests and passed (`2 passed; 0 failed`).
- Ran `cargo test -p velesdb-server test_create_collection_with_empty_type_returns_preflight_warnings` and it passed (`1 passed; 0 failed`).
- Ran `cargo test -p velesdb-server test_create_collection_returns_preflight_warnings` and it passed (`1 passed; 0 failed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a34dfa9e54832ab5f50ed2e87c8dc3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/254" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
