### PR TITLE
feat(ts-sdk): add TypeScript parity for query EXPLAIN and collection sanity endpoints

### DIFF
--- a/sdks/typescript/src/backends/rest.ts
+++ b/sdks/typescript/src/backends/rest.ts
@@ -22,6 +22,8 @@ import type {
   DegreeResponse,
   QueryOptions,
   QueryResponse,
+  ExplainResponse,
+  CollectionSanityResponse,
 } from '../types';
 import { ConnectionError, NotFoundError, VelesDBError } from '../types';
 
@@ -37,6 +39,50 @@ interface ApiResponse<T> {
 /** Batch search response structure */
 interface BatchSearchResponse {
   results: Array<{ results: SearchResult[] }>;
+}
+
+interface QueryExplainApiResponse {
+  query: string;
+  query_type: string;
+  collection: string;
+  plan: Array<{ step: number; operation: string; description: string; estimated_rows: number | null }>;
+  estimated_cost: {
+    uses_index: boolean;
+    index_name: string | null;
+    selectivity: number;
+    complexity: string;
+  };
+  features: {
+    has_vector_search: boolean;
+    has_filter: boolean;
+    has_order_by: boolean;
+    has_group_by: boolean;
+    has_aggregation: boolean;
+    has_join: boolean;
+    has_fusion: boolean;
+    limit: number | null;
+    offset: number | null;
+  };
+}
+
+interface CollectionSanityApiResponse {
+  collection: string;
+  dimension: number;
+  metric: string;
+  point_count: number;
+  is_empty: boolean;
+  checks: {
+    has_vectors: boolean;
+    search_ready: boolean;
+    dimension_configured: boolean;
+  };
+  diagnostics: {
+    search_requests_total: number;
+    dimension_mismatch_total: number;
+    empty_search_results_total: number;
+    filter_parse_errors_total: number;
+  };
+  hints: string[];
 }
 
 /**
@@ -537,6 +583,91 @@ export class RestBackend implements IVelesDBBackend {
         strategy: 'select',
         scannedNodes: rawData?.rows_returned ?? 0,
       },
+    };
+  }
+
+
+  async queryExplain(queryString: string, params?: Record<string, unknown>): Promise<ExplainResponse> {
+    this.ensureInitialized();
+
+    const response = await this.request<QueryExplainApiResponse>(
+      'POST',
+      '/query/explain',
+      {
+        query: queryString,
+        params: params ?? {},
+      }
+    );
+
+    if (response.error) {
+      throw new VelesDBError(response.error.message, response.error.code);
+    }
+
+    const data = response.data!;
+    return {
+      query: data.query,
+      queryType: data.query_type,
+      collection: data.collection,
+      plan: data.plan.map(step => ({
+        step: step.step,
+        operation: step.operation,
+        description: step.description,
+        estimatedRows: step.estimated_rows,
+      })),
+      estimatedCost: {
+        usesIndex: data.estimated_cost.uses_index,
+        indexName: data.estimated_cost.index_name,
+        selectivity: data.estimated_cost.selectivity,
+        complexity: data.estimated_cost.complexity,
+      },
+      features: {
+        hasVectorSearch: data.features.has_vector_search,
+        hasFilter: data.features.has_filter,
+        hasOrderBy: data.features.has_order_by,
+        hasGroupBy: data.features.has_group_by,
+        hasAggregation: data.features.has_aggregation,
+        hasJoin: data.features.has_join,
+        hasFusion: data.features.has_fusion,
+        limit: data.features.limit,
+        offset: data.features.offset,
+      },
+    };
+  }
+
+  async collectionSanity(collection: string): Promise<CollectionSanityResponse> {
+    this.ensureInitialized();
+
+    const response = await this.request<CollectionSanityApiResponse>(
+      'GET',
+      `/collections/${encodeURIComponent(collection)}/sanity`
+    );
+
+    if (response.error) {
+      if (response.error.code === 'NOT_FOUND') {
+        throw new NotFoundError(`Collection '${collection}'`);
+      }
+      throw new VelesDBError(response.error.message, response.error.code);
+    }
+
+    const data = response.data!;
+    return {
+      collection: data.collection,
+      dimension: data.dimension,
+      metric: data.metric,
+      pointCount: data.point_count,
+      isEmpty: data.is_empty,
+      checks: {
+        hasVectors: data.checks.has_vectors,
+        searchReady: data.checks.search_ready,
+        dimensionConfigured: data.checks.dimension_configured,
+      },
+      diagnostics: {
+        searchRequestsTotal: data.diagnostics.search_requests_total,
+        dimensionMismatchTotal: data.diagnostics.dimension_mismatch_total,
+        emptySearchResultsTotal: data.diagnostics.empty_search_results_total,
+        filterParseErrorsTotal: data.diagnostics.filter_parse_errors_total,
+      },
+      hints: data.hints ?? [],
     };
   }
 

--- a/sdks/typescript/src/backends/wasm.ts
+++ b/sdks/typescript/src/backends/wasm.ts
@@ -22,6 +22,8 @@ import type {
   DegreeResponse,
   QueryOptions,
   QueryResponse,
+  ExplainResponse,
+  CollectionSanityResponse,
 } from '../types';
 import { ConnectionError, NotFoundError, VelesDBError } from '../types';
 
@@ -370,6 +372,23 @@ export class WasmBackend implements IVelesDBBackend {
     // Use REST backend for MQF capabilities
     throw new VelesDBError(
       'Multi-query fusion is not supported in WASM backend. Use REST backend for MQF search.',
+      'NOT_SUPPORTED'
+    );
+  }
+
+
+  async queryExplain(_queryString: string, _params?: Record<string, unknown>): Promise<ExplainResponse> {
+    this.ensureInitialized();
+    throw new VelesDBError(
+      'Query explain is not supported in WASM backend. Use REST backend for EXPLAIN support.',
+      'NOT_SUPPORTED'
+    );
+  }
+
+  async collectionSanity(_collection: string): Promise<CollectionSanityResponse> {
+    this.ensureInitialized();
+    throw new VelesDBError(
+      'Collection sanity endpoint is not supported in WASM backend. Use REST backend for diagnostics.',
       'NOT_SUPPORTED'
     );
   }

--- a/sdks/typescript/src/client.ts
+++ b/sdks/typescript/src/client.ts
@@ -21,6 +21,8 @@ import type {
   DegreeResponse,
   QueryOptions,
   QueryResponse,
+  ExplainResponse,
+  CollectionSanityResponse,
 } from './types';
 import { ValidationError } from './types';
 import { WasmBackend } from './backends/wasm';
@@ -426,6 +428,27 @@ export class VelesDB {
    * });
    * ```
    */
+
+  async queryExplain(queryString: string, params?: Record<string, unknown>): Promise<ExplainResponse> {
+    this.ensureInitialized();
+
+    if (!queryString || typeof queryString !== 'string') {
+      throw new ValidationError('Query string must be a non-empty string');
+    }
+
+    return this.backend.queryExplain(queryString, params);
+  }
+
+  async collectionSanity(collection: string): Promise<CollectionSanityResponse> {
+    this.ensureInitialized();
+
+    if (!collection || typeof collection !== 'string') {
+      throw new ValidationError('Collection name must be a non-empty string');
+    }
+
+    return this.backend.collectionSanity(collection);
+  }
+
   async multiQuerySearch(
     collection: string,
     vectors: Array<number[] | Float32Array>,

--- a/sdks/typescript/src/types.ts
+++ b/sdks/typescript/src/types.ts
@@ -267,6 +267,68 @@ export interface QueryResponse {
 // Index Management Types (EPIC-009)
 // ============================================================================
 
+
+
+/** Query explain request/response metadata */
+export interface ExplainPlanStep {
+  step: number;
+  operation: string;
+  description: string;
+  estimatedRows: number | null;
+}
+
+export interface ExplainCost {
+  usesIndex: boolean;
+  indexName: string | null;
+  selectivity: number;
+  complexity: string;
+}
+
+export interface ExplainFeatures {
+  hasVectorSearch: boolean;
+  hasFilter: boolean;
+  hasOrderBy: boolean;
+  hasGroupBy: boolean;
+  hasAggregation: boolean;
+  hasJoin: boolean;
+  hasFusion: boolean;
+  limit: number | null;
+  offset: number | null;
+}
+
+export interface ExplainResponse {
+  query: string;
+  queryType: string;
+  collection: string;
+  plan: ExplainPlanStep[];
+  estimatedCost: ExplainCost;
+  features: ExplainFeatures;
+}
+
+export interface CollectionSanityChecks {
+  hasVectors: boolean;
+  searchReady: boolean;
+  dimensionConfigured: boolean;
+}
+
+export interface CollectionSanityDiagnostics {
+  searchRequestsTotal: number;
+  dimensionMismatchTotal: number;
+  emptySearchResultsTotal: number;
+  filterParseErrorsTotal: number;
+}
+
+export interface CollectionSanityResponse {
+  collection: string;
+  dimension: number;
+  metric: string;
+  pointCount: number;
+  isEmpty: boolean;
+  checks: CollectionSanityChecks;
+  diagnostics: CollectionSanityDiagnostics;
+  hints: string[];
+}
+
 /** Index type for property indexes */
 export type IndexType = 'hash' | 'range';
 
@@ -365,6 +427,12 @@ export interface IVelesDBBackend {
     params?: Record<string, unknown>,
     options?: QueryOptions
   ): Promise<QueryResponse>;
+
+  /** Explain a VelesQL query without executing it */
+  queryExplain(queryString: string, params?: Record<string, unknown>): Promise<ExplainResponse>;
+
+  /** Run collection sanity checks */
+  collectionSanity(collection: string): Promise<CollectionSanityResponse>;
 
   /** Multi-query fusion search */
   multiQuerySearch(

--- a/sdks/typescript/tests/client.test.ts
+++ b/sdks/typescript/tests/client.test.ts
@@ -207,6 +207,42 @@ describe('VelesDB Client', () => {
     });
   });
 
+
+  describe('query diagnostics', () => {
+    let db: VelesDB;
+    let mockBackend: any;
+
+    beforeEach(() => {
+      db = new VelesDB({ backend: 'wasm' });
+      mockBackend = {
+        queryExplain: vi.fn(),
+        collectionSanity: vi.fn(),
+      };
+      (db as any).backend = mockBackend;
+      (db as any).initialized = true;
+    });
+
+    it('should validate queryExplain input', async () => {
+      await expect(db.queryExplain('')).rejects.toThrow(ValidationError);
+    });
+
+    it('should call backend queryExplain', async () => {
+      mockBackend.queryExplain.mockResolvedValue({ queryType: 'SELECT', plan: [] });
+      await db.queryExplain('SELECT * FROM docs', {});
+      expect(mockBackend.queryExplain).toHaveBeenCalledWith('SELECT * FROM docs', {});
+    });
+
+    it('should validate collectionSanity input', async () => {
+      await expect(db.collectionSanity('')).rejects.toThrow(ValidationError);
+    });
+
+    it('should call backend collectionSanity', async () => {
+      mockBackend.collectionSanity.mockResolvedValue({ collection: 'docs' });
+      await db.collectionSanity('docs');
+      expect(mockBackend.collectionSanity).toHaveBeenCalledWith('docs');
+    });
+  });
+
   describe('multiQuerySearch', () => {
     let db: VelesDB;
     let mockBackend: any;

--- a/sdks/typescript/tests/rest-backend.test.ts
+++ b/sdks/typescript/tests/rest-backend.test.ts
@@ -449,5 +449,84 @@ describe('RestBackend', () => {
         })
       );
     });
+
+    it('should call /query/explain and return explain payload', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({
+          query: 'SELECT * FROM docs LIMIT 10',
+          query_type: 'SELECT',
+          collection: 'docs',
+          plan: [{ step: 1, operation: 'FullScan', description: 'Scan collection', estimated_rows: null }],
+          estimated_cost: {
+            uses_index: false,
+            index_name: null,
+            selectivity: 1,
+            complexity: 'O(n)',
+          },
+          features: {
+            has_vector_search: false,
+            has_filter: false,
+            has_order_by: false,
+            has_group_by: false,
+            has_aggregation: false,
+            has_join: false,
+            has_fusion: false,
+            limit: 10,
+            offset: null,
+          },
+        }),
+      });
+
+      const explain = await backend.queryExplain('SELECT * FROM docs LIMIT 10', {});
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:8080/query/explain',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({
+            query: 'SELECT * FROM docs LIMIT 10',
+            params: {},
+          }),
+        })
+      );
+      expect(explain.queryType).toBe('SELECT');
+      expect(explain.plan[0]?.operation).toBe('FullScan');
+    });
+
+    it('should call /collections/{name}/sanity and map response', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({
+          collection: 'docs',
+          dimension: 768,
+          metric: 'cosine',
+          point_count: 42,
+          is_empty: false,
+          checks: {
+            has_vectors: true,
+            search_ready: true,
+            dimension_configured: true,
+          },
+          diagnostics: {
+            search_requests_total: 3,
+            dimension_mismatch_total: 0,
+            empty_search_results_total: 1,
+            filter_parse_errors_total: 0,
+          },
+          hints: ['hint-1'],
+        }),
+      });
+
+      const sanity = await backend.collectionSanity('docs');
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:8080/collections/docs/sanity',
+        expect.objectContaining({ method: 'GET' })
+      );
+      expect(sanity.pointCount).toBe(42);
+      expect(sanity.checks.searchReady).toBe(true);
+      expect(sanity.diagnostics.searchRequestsTotal).toBe(3);
+    });
   });
 });


### PR DESCRIPTION
### Motivation
- Provide feature parity between the TypeScript SDK and server/velesdb-core for query diagnostics and onboarding diagnostics by surfacing `POST /query/explain` and `GET /collections/{name}/sanity` in the SDK.

### Description
- Added typed response models (`ExplainResponse`, `ExplainPlanStep`, `ExplainCost`, `ExplainFeatures`, `CollectionSanityResponse`, etc.) to `sdks/typescript/src/types.ts` and extended `IVelesDBBackend` with `queryExplain(...)` and `collectionSanity(...)`.
- Implemented `queryExplain` and `collectionSanity` in the REST backend (`sdks/typescript/src/backends/rest.ts`) with snake_case → camelCase mapping and robust error handling consistent with existing patterns.
- Exposed `queryExplain(...)` and `collectionSanity(...)` on the high-level `VelesDB` client (`sdks/typescript/src/client.ts`) with input validation.
- Added explicit `NOT_SUPPORTED` stubs in the WASM backend (`sdks/typescript/src/backends/wasm.ts`) to make server-only capabilities fail fast and document the limitation.
- Added TDD coverage and tests for the new surface: updated `sdks/typescript/tests/rest-backend.test.ts` and `sdks/typescript/tests/client.test.ts` to cover forwarding, explain mapping and sanity mapping.

### Testing
- Ran targeted tests: `cd sdks/typescript && npm test -- --run tests/rest-backend.test.ts` and `cd sdks/typescript && npm test -- --run tests/client.test.ts tests/rest-backend.test.ts`; both succeeded.
- Ran full test suite: `cd sdks/typescript && npm test`; all TypeScript tests passed (152 tests across the SDK passed).
- Built the SDK: `cd sdks/typescript && npm run build`; build and DTS generation completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a38c9cb45c832a9fd163da92de576c)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/255" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
