### PR TITLE
Align LangChain vectorstore with velesdb-core search features

### DIFF
--- a/integrations/langchain/src/langchain_velesdb/vectorstore.py
+++ b/integrations/langchain/src/langchain_velesdb/vectorstore.py
@@ -149,6 +149,7 @@ class VelesDBVectorStore(VectorStore):
                     self._collection_name,
                     dimension=dimension,
                     metric=self._metric,
+                    storage_mode=self._storage_mode,
                 )
                 # Reload to get the collection object
                 self._collection = db.get_collection(self._collection_name)
@@ -159,6 +160,45 @@ class VelesDBVectorStore(VectorStore):
         id_val = self._next_id
         self._next_id += 1
         return id_val
+
+    def _to_document(self, result: dict) -> Document:
+        """Convert a VelesDB search result into a LangChain Document."""
+        payload = result.get("payload", {})
+        text = payload.get("text", "")
+        metadata = {k: v for k, v in payload.items() if k != "text"}
+        return Document(page_content=text, metadata=metadata)
+
+    def _run_vector_search(
+        self,
+        query_embedding: List[float],
+        k: int,
+        *,
+        filter: Optional[dict] = None,
+        ef_search: Optional[int] = None,
+        ids_only: bool = False,
+    ) -> List[dict]:
+        """Run the appropriate core vector search variant."""
+        dimension = len(query_embedding)
+        collection = self._get_collection(dimension)
+
+        if ids_only:
+            if filter is not None:
+                return collection.search_ids(query_embedding, top_k=k, filter=filter)
+            return collection.search_ids(query_embedding, top_k=k)
+
+        if ef_search is not None:
+            if filter is not None:
+                return collection.search_with_ef(
+                    query_embedding,
+                    top_k=k,
+                    ef_search=ef_search,
+                    filter=filter,
+                )
+            return collection.search_with_ef(query_embedding, top_k=k, ef_search=ef_search)
+
+        if filter is not None:
+            return collection.search_with_filter(query_embedding, top_k=k, filter=filter)
+        return collection.search(query_embedding, top_k=k)
 
     def add_texts(
         self,
@@ -270,27 +310,10 @@ class VelesDBVectorStore(VectorStore):
         Returns:
             List of (Document, score) tuples.
         """
-        # Generate query embedding
         query_embedding = self._embedding.embed_query(query)
-        dimension = len(query_embedding)
+        results = self._run_vector_search(query_embedding, k)
 
-        # Get collection
-        collection = self._get_collection(dimension)
-
-        # Search
-        results = collection.search(query_embedding, top_k=k)
-
-        # Convert to Documents
-        documents: List[Tuple[Document, float]] = []
-        for result in results:
-            payload = result.get("payload", {})
-            text = payload.get("text", "")
-            metadata = {k: v for k, v in payload.items() if k != "text"}
-            doc = Document(page_content=text, metadata=metadata)
-            score = result.get("score", 0.0)
-            documents.append((doc, score))
-
-        return documents
+        return [(self._to_document(result), result.get("score", 0.0)) for result in results]
 
     def similarity_search_with_relevance_scores(
         self,
@@ -346,29 +369,9 @@ class VelesDBVectorStore(VectorStore):
         Returns:
             List of Documents matching the query and filter.
         """
-        # Generate query embedding
         query_embedding = self._embedding.embed_query(query)
-        dimension = len(query_embedding)
-
-        # Get collection
-        collection = self._get_collection(dimension)
-
-        # Search with filter if provided
-        if filter:
-            results = collection.search_with_filter(query_embedding, top_k=k, filter=filter)
-        else:
-            results = collection.search(query_embedding, top_k=k)
-
-        # Convert to Documents
-        documents: List[Document] = []
-        for result in results:
-            payload = result.get("payload", {})
-            text = payload.get("text", "")
-            metadata = {k: v for k, v in payload.items() if k != "text"}
-            doc = Document(page_content=text, metadata=metadata)
-            documents.append(doc)
-
-        return documents
+        results = self._run_vector_search(query_embedding, k, filter=filter)
+        return [self._to_document(result) for result in results]
 
     def hybrid_search(
         self,
@@ -482,6 +485,41 @@ class VelesDBVectorStore(VectorStore):
             documents.append((doc, score))
 
         return documents
+
+    def similarity_search_with_ef(
+        self,
+        query: str,
+        k: int = 4,
+        ef_search: int = 64,
+        filter: Optional[dict] = None,
+        **kwargs: Any,
+    ) -> List[Document]:
+        """Search using the core HNSW ef_search tuning parameter."""
+        validate_text(query)
+        validate_k(k)
+
+        query_embedding = self._embedding.embed_query(query)
+        results = self._run_vector_search(
+            query_embedding,
+            k,
+            ef_search=ef_search,
+            filter=filter,
+        )
+        return [self._to_document(result) for result in results]
+
+    def similarity_search_ids(
+        self,
+        query: str,
+        k: int = 4,
+        filter: Optional[dict] = None,
+        **kwargs: Any,
+    ) -> List[dict]:
+        """Search returning only {id, score} for parity with velesdb-core."""
+        validate_text(query)
+        validate_k(k)
+
+        query_embedding = self._embedding.embed_query(query)
+        return self._run_vector_search(query_embedding, k, filter=filter, ids_only=True)
 
     def delete(self, ids: Optional[List[str]] = None, **kwargs: Any) -> Optional[bool]:
         """Delete documents by ID.

--- a/integrations/langchain/tests/test_core_feature_parity.py
+++ b/integrations/langchain/tests/test_core_feature_parity.py
@@ -1,0 +1,139 @@
+"""Unit tests enforcing LangChain parity with velesdb-core search features."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+from langchain_core.embeddings import Embeddings
+
+
+class _FakeEmbeddings(Embeddings):
+    def embed_documents(self, texts):
+        return [[0.1, 0.2, 0.3, 0.4] for _ in texts]
+
+    def embed_query(self, text):
+        return [0.1, 0.2, 0.3, 0.4]
+
+
+class _FakeFusionStrategy:
+    @staticmethod
+    def average():
+        return {"strategy": "average"}
+
+    @staticmethod
+    def maximum():
+        return {"strategy": "maximum"}
+
+    @staticmethod
+    def rrf(k=60):
+        return {"strategy": "rrf", "k": k}
+
+    @staticmethod
+    def weighted(avg_weight, max_weight, hit_weight):
+        return {
+            "strategy": "weighted",
+            "avg_weight": avg_weight,
+            "max_weight": max_weight,
+            "hit_weight": hit_weight,
+        }
+
+
+class _FakeCollection:
+    def __init__(self):
+        self.create_args = None
+        self.search_with_ef_calls = []
+        self.search_ids_calls = []
+
+    def upsert(self, points):
+        return len(points)
+
+    def search(self, vector, top_k=10):
+        return [{"id": 1, "score": 0.95, "payload": {"text": "doc"}}]
+
+    def search_with_ef(self, vector, top_k=10, ef_search=64, filter=None):
+        self.search_with_ef_calls.append(
+            {"vector": vector, "top_k": top_k, "ef_search": ef_search, "filter": filter}
+        )
+        return [{"id": 1, "score": 0.95, "payload": {"text": "doc-ef"}}]
+
+    def search_ids(self, vector, top_k=10, filter=None):
+        self.search_ids_calls.append({"vector": vector, "top_k": top_k, "filter": filter})
+        return [{"id": 1, "score": 0.95}]
+
+
+class _FakeDatabase:
+    def __init__(self, path):
+        self.path = path
+        self.collection = None
+
+    def get_collection(self, name):
+        return self.collection
+
+    def create_collection(self, name, dimension, metric, storage_mode="full"):
+        self.collection = _FakeCollection()
+        self.collection.create_args = {
+            "name": name,
+            "dimension": dimension,
+            "metric": metric,
+            "storage_mode": storage_mode,
+        }
+        return self.collection
+
+
+def _load_vectorstore_module():
+    root = Path(__file__).resolve().parents[1] / "src" / "langchain_velesdb"
+    pkg = types.ModuleType("langchain_velesdb")
+    pkg.__path__ = [str(root)]
+    sys.modules["langchain_velesdb"] = pkg
+
+    fake_velesdb = types.SimpleNamespace(Database=_FakeDatabase, FusionStrategy=_FakeFusionStrategy)
+    sys.modules["velesdb"] = fake_velesdb
+
+    sec_spec = importlib.util.spec_from_file_location("langchain_velesdb.security", root / "security.py")
+    sec_mod = importlib.util.module_from_spec(sec_spec)
+    sys.modules["langchain_velesdb.security"] = sec_mod
+    sec_spec.loader.exec_module(sec_mod)
+
+    vs_spec = importlib.util.spec_from_file_location("langchain_velesdb.vectorstore", root / "vectorstore.py")
+    vs_mod = importlib.util.module_from_spec(vs_spec)
+    sys.modules["langchain_velesdb.vectorstore"] = vs_mod
+    vs_spec.loader.exec_module(vs_mod)
+    return vs_mod
+
+
+def test_collection_creation_propagates_storage_mode():
+    module = _load_vectorstore_module()
+    store = module.VelesDBVectorStore(
+        embedding=_FakeEmbeddings(),
+        path="/tmp/velesdb_test",
+        collection_name="parity_storage_mode",
+        storage_mode="sq8",
+    )
+
+    store.add_texts(["hello"])
+    assert store._collection.create_args["storage_mode"] == "sq8"
+
+
+def test_similarity_search_with_ef_uses_core_search_variant():
+    module = _load_vectorstore_module()
+    store = module.VelesDBVectorStore(embedding=_FakeEmbeddings(), path="/tmp/velesdb_test", collection_name="ef")
+    store.add_texts(["hello"])
+
+    docs = store.similarity_search_with_ef("query", k=2, ef_search=96)
+
+    assert len(docs) == 1
+    assert store._collection.search_with_ef_calls[0]["ef_search"] == 96
+
+
+def test_similarity_search_ids_returns_core_shape():
+    module = _load_vectorstore_module()
+    store = module.VelesDBVectorStore(embedding=_FakeEmbeddings(), path="/tmp/velesdb_test", collection_name="ids")
+    store.add_texts(["hello"])
+
+    results = store.similarity_search_ids("query", k=2)
+
+    assert results == [{"id": 1, "score": 0.95}]
+    assert store._collection.search_ids_calls[0]["top_k"] == 2


### PR DESCRIPTION
### Motivation
- Ensure the LangChain integration exposes the same search capabilities and configuration as `velesdb-core`, avoiding duplicated logic and mismatches in behavior.
- Surface core tuning and result-shape features (HNSW `ef_search`, `search_ids`, and `storage_mode`) so LangChain users can rely on the core as the single source of truth.

### Description
- Propagate `storage_mode` when creating collections by passing `storage_mode=self._storage_mode` to `db.create_collection` in `_get_collection` so the integration honors core storage configuration.
- Add modular helpers `_to_document(...)` and `_run_vector_search(...)` to centralize result conversion and routing to core search variants (`search`, `search_with_filter`, `search_with_ef`, `search_ids`) and remove duplicated conversion/search code.
- Add parity APIs `similarity_search_with_ef(...)` and `similarity_search_ids(...)` that delegate to the appropriate core search variant and return core-shaped results or `Document` conversions as required.
- Add `integrations/langchain/tests/test_core_feature_parity.py` to lock expected behavior and drive the implementation via TDD.

### Testing
- Ran `cd integrations/langchain && pytest -q tests/test_core_feature_parity.py` before implementation to validate the TDD failure mode (initial run produced failing tests as expected).
- Ran `cd integrations/langchain && pytest -q tests/test_core_feature_parity.py` after the changes and the suite passed with `3 passed`.
- Unit tests exercise storage-mode propagation, routing to `search_with_ef`, and the `search_ids` return shape, and they all succeeded after the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a38cb9abf0832a888c32112b672355)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/256" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
