### PR TITLE
feat(tauri-plugin): mirror velesdb-core feature flags

### DIFF
--- a/crates/tauri-plugin-velesdb/Cargo.toml
+++ b/crates/tauri-plugin-velesdb/Cargo.toml
@@ -31,7 +31,11 @@ tempfile = "3.14"
 toml = "0.8"
 
 [features]
-default = []
+default = ["velesdb-core/default"]
+gpu = ["velesdb-core/gpu"]
+persistence = ["velesdb-core/persistence"]
+update-check = ["velesdb-core/update-check"]
+loom = ["velesdb-core/loom"]
 
 [lints]
 workspace = true

--- a/crates/tauri-plugin-velesdb/tests/feature_parity.rs
+++ b/crates/tauri-plugin-velesdb/tests/feature_parity.rs
@@ -1,0 +1,107 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::path::Path;
+
+use toml::Value;
+
+fn cargo_features(path: &Path) -> BTreeMap<String, Vec<String>> {
+    let content = fs::read_to_string(path)
+        .unwrap_or_else(|err| panic!("failed to read {}: {err}", path.display()));
+    let parsed: Value = toml::from_str(&content)
+        .unwrap_or_else(|err| panic!("failed to parse {}: {err}", path.display()));
+
+    let feature_table = parsed
+        .get("features")
+        .and_then(Value::as_table)
+        .unwrap_or_else(|| panic!("missing [features] table in {}", path.display()));
+
+    feature_table
+        .iter()
+        .map(|(feature, values)| {
+            let values = values
+                .as_array()
+                .map(|items| {
+                    items
+                        .iter()
+                        .filter_map(Value::as_str)
+                        .map(ToOwned::to_owned)
+                        .collect::<Vec<_>>()
+                })
+                .unwrap_or_default();
+            (feature.clone(), values)
+        })
+        .collect()
+}
+
+fn core_features_without_default(
+    core_features: &BTreeMap<String, Vec<String>>,
+) -> BTreeSet<String> {
+    core_features
+        .keys()
+        .filter(|name| name.as_str() != "default")
+        .cloned()
+        .collect()
+}
+
+#[test]
+fn tauri_plugin_exposes_all_velesdb_core_features() {
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let core_manifest = manifest_dir.join("../velesdb-core/Cargo.toml");
+    let plugin_manifest = manifest_dir.join("Cargo.toml");
+
+    let core_features = cargo_features(&core_manifest);
+    let plugin_features = cargo_features(&plugin_manifest);
+
+    let expected = core_features_without_default(&core_features);
+    let actual = plugin_features
+        .keys()
+        .filter(|name| name.as_str() != "default")
+        .cloned()
+        .collect::<BTreeSet<_>>();
+
+    assert_eq!(
+        actual, expected,
+        "tauri-plugin-velesdb must expose every non-default velesdb-core feature"
+    );
+}
+
+#[test]
+fn tauri_plugin_features_forward_to_velesdb_core() {
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let core_manifest = manifest_dir.join("../velesdb-core/Cargo.toml");
+    let plugin_manifest = manifest_dir.join("Cargo.toml");
+
+    let core_features = cargo_features(&core_manifest);
+    let plugin_features = cargo_features(&plugin_manifest);
+
+    for feature in core_features.keys() {
+        if feature == "default" {
+            continue;
+        }
+
+        let forwarded = plugin_features
+            .get(feature)
+            .unwrap_or_else(|| panic!("missing feature '{feature}' in tauri plugin"));
+
+        assert!(
+            forwarded.contains(&format!("velesdb-core/{feature}")),
+            "feature '{feature}' in tauri plugin must forward to velesdb-core/{feature}"
+        );
+    }
+}
+
+#[test]
+fn tauri_plugin_default_feature_forwards_to_velesdb_core_default() {
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let plugin_manifest = manifest_dir.join("Cargo.toml");
+    let plugin_features = cargo_features(&plugin_manifest);
+
+    let default_features = plugin_features
+        .get("default")
+        .unwrap_or_else(|| panic!("missing default feature in tauri plugin"));
+
+    assert!(
+        default_features.contains(&"velesdb-core/default".to_string()),
+        "tauri plugin default feature must include velesdb-core/default"
+    );
+}


### PR DESCRIPTION
### Motivation

- Garantir que le plugin Tauri expose et forwarde exactement les features définies dans `velesdb-core`, en faisant de `velesdb-core` la seule source de vérité pour les options compilatoires.
- Ajouter des tests TDD pour verrouiller la parité des features et prévenir les régressions futures.

### Description

- Expose et forwarde les features du core dans `crates/tauri-plugin-velesdb/Cargo.toml` en ajoutant `default = ["velesdb-core/default"]` et les mappings `gpu`, `persistence`, `update-check`, `loom` vers `velesdb-core/<feature>`.
- Ajout d'un test d'intégration TDD `crates/tauri-plugin-velesdb/tests/feature_parity.rs` qui parse les manifests TOML et vérifie que toutes les features non-default du core sont exposées par le plugin.
- Le test vérifie aussi que chaque feature du plugin forwarde vers `velesdb-core/<feature>` et que le `default` du plugin inclut `velesdb-core/default`.

### Testing

- Exécuté `cargo test -p tauri-plugin-velesdb --test feature_parity`, qui a échoué pour des raisons environnementales liées à l'absence de la bibliothèque système `glib-2.0` (dépendance native requise par certaines crates tauri). (échec)
- Exécuté `cargo test -p tauri-plugin-velesdb --test feature_parity --no-default-features`, qui a échoué pour la même raison d'environnement (`glib-2.0` manquant). (échec)
- Exécuté `rustfmt --check crates/tauri-plugin-velesdb/tests/feature_parity.rs`, qui a réussi.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a38cd0b994832aa2542364232fb558)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/257" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
