### PR TITLE
feat(server): align velesdb-server features with velesdb-core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6849,6 +6849,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-test",
+ "toml 0.8.23",
  "tower",
  "tower-http",
  "tracing",

--- a/crates/velesdb-server/Cargo.toml
+++ b/crates/velesdb-server/Cargo.toml
@@ -21,7 +21,7 @@ name = "velesdb-server"
 path = "src/main.rs"
 
 [dependencies]
-velesdb-core = { path = "../velesdb-core", version = "1.4.0" }
+velesdb-core = { path = "../velesdb-core", version = "1.4.0", default-features = false }
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -39,8 +39,12 @@ utoipa = { version = "5", features = ["axum_extras"] }
 utoipa-swagger-ui = { version = "9", features = ["axum"] }
 
 [features]
-default = []
+default = ["velesdb-core/default"]
+gpu = ["velesdb-core/gpu"]
+loom = ["velesdb-core/loom"]
+persistence = ["velesdb-core/persistence"]
 prometheus = []
+update-check = ["velesdb-core/update-check"]
 
 [dev-dependencies]
 # Use native-tls to avoid ring compilation issues on aarch64-apple-darwin
@@ -48,6 +52,7 @@ reqwest = { version = "0.12", default-features = false, features = ["json", "nat
 tokio-test = "0.4"
 tempfile = { workspace = true }
 tower = { workspace = true }
+toml = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/velesdb-server/tests/core_feature_parity_tests.rs
+++ b/crates/velesdb-server/tests/core_feature_parity_tests.rs
@@ -1,0 +1,101 @@
+use std::{collections::{BTreeMap, BTreeSet}, fs, path::Path};
+
+use toml::Value;
+
+fn parse_features(manifest_path: &Path) -> BTreeMap<String, Vec<String>> {
+    let manifest = fs::read_to_string(manifest_path)
+        .unwrap_or_else(|e| panic!("failed to read {}: {e}", manifest_path.display()));
+
+    let parsed: Value = manifest
+        .parse()
+        .unwrap_or_else(|e| panic!("failed to parse {} as TOML: {e}", manifest_path.display()));
+
+    let features = parsed
+        .get("features")
+        .and_then(Value::as_table)
+        .unwrap_or_else(|| panic!("missing [features] in {}", manifest_path.display()));
+
+    features
+        .iter()
+        .map(|(feature, entries)| {
+            let values = entries
+                .as_array()
+                .map(|arr| {
+                    arr.iter()
+                        .filter_map(Value::as_str)
+                        .map(ToString::to_string)
+                        .collect::<Vec<_>>()
+                })
+                .unwrap_or_default();
+
+            (feature.clone(), values)
+        })
+        .collect()
+}
+
+#[test]
+fn server_exposes_all_core_features() {
+    let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let core_manifest = workspace_root.join("crates/velesdb-core/Cargo.toml");
+    let server_manifest = workspace_root.join("crates/velesdb-server/Cargo.toml");
+
+    let core_features = parse_features(&core_manifest);
+    let server_features = parse_features(&server_manifest);
+
+    let missing: Vec<_> = core_features
+        .keys()
+        .filter(|feature| !server_features.contains_key(*feature))
+        .cloned()
+        .collect();
+
+    assert!(
+        missing.is_empty(),
+        "velesdb-server is missing core features: {missing:?}"
+    );
+
+    for feature in core_features.keys() {
+        if let Some(entries) = server_features.get(feature) {
+            let expected = format!("velesdb-core/{feature}");
+            assert!(
+                entries.iter().any(|entry| entry == &expected),
+                "server feature `{feature}` must forward to `{expected}`"
+            );
+        }
+    }
+}
+
+#[test]
+fn server_default_feature_matches_core_default() {
+    let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let core_manifest = workspace_root.join("crates/velesdb-core/Cargo.toml");
+    let server_manifest = workspace_root.join("crates/velesdb-server/Cargo.toml");
+
+    let core_features = parse_features(&core_manifest);
+    let server_features = parse_features(&server_manifest);
+
+    let core_default: BTreeSet<_> = core_features
+        .get("default")
+        .into_iter()
+        .flatten()
+        .cloned()
+        .collect();
+
+    let server_default: BTreeSet<_> = server_features
+        .get("default")
+        .into_iter()
+        .flatten()
+        .cloned()
+        .collect();
+
+    let forwards_core_default_directly = server_default.contains("velesdb-core/default");
+
+    if !forwards_core_default_directly {
+        for core_default_feature in core_default {
+            let expected = format!("velesdb-core/{core_default_feature}");
+            assert!(
+                server_default.contains(&expected),
+                "server default feature set must include `{expected}`"
+            );
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Garantir que `velesdb-server` n duplique pas la logique de feature et que la seule source de vérité reste `velesdb-core` afin d'éviter une dérive lors d'évolution du core. 
- Fournir une vérification TDD automatique qui alerte si le serveur cesse d'exposer ou de forwarder les features du core.

### Description
- Désactive les `default-features` de la dépendance `velesdb-core` côté serveur en ajoutant `default-features = false` dans `crates/velesdb-server/Cargo.toml`. 
- Expose côté serveur les flags de feature du core (`default`, `persistence`, `gpu`, `loom`, `update-check`) et les forwarde vers `velesdb-core/<feature>` pour conserver un point unique de contrôle. 
- Ajoute `toml` en `dev-dependency` et crée le test TDD `crates/velesdb-server/tests/core_feature_parity_tests.rs` qui lit les deux manifests et vérifie l'existence des features, le forwarding vers `velesdb-core/<feature>` et la correspondance des valeurs par défaut. 
- Met à jour le `Cargo.lock` pour inclure la dépendance de développement ajoutée.

### Testing
- Exécution du test de parité avec `cargo test -p velesdb-server --test core_feature_parity_tests -- --nocapture` et résultat : réussite (`2 passed; 0 failed`).
- Exécution de la suite de tests du package serveur avec `cargo test -p velesdb-server` et résultat : réussite complète (tous les tests unitaires et d'intégration du crate sont passés).
- Le `Cargo.lock` a été régénéré automatiquement lors de la validation des tests et inclus dans la modification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a38c818554832ab03059ae851b6722)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/258" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
