### PR TITLE
feat(llamaindex): align storage mode parity with velesdb-core

### DIFF
--- a/integrations/llamaindex/src/llamaindex_velesdb/security.py
+++ b/integrations/llamaindex/src/llamaindex_velesdb/security.py
@@ -16,6 +16,7 @@ MAX_DIMENSION = 65_536  # Max vector dimension (reasonable for any model)
 MIN_DIMENSION = 1
 MAX_PATH_LENGTH = 4096  # Max path length
 ALLOWED_METRICS = {"cosine", "euclidean", "dot", "hamming", "jaccard"}
+ALLOWED_STORAGE_MODES = {"full", "sq8", "binary"}
 DEFAULT_TIMEOUT_MS = 30_000  # 30 seconds max timeout
 
 
@@ -186,6 +187,30 @@ def validate_metric(metric: str) -> str:
         )
     
     return metric_lower
+
+
+def validate_storage_mode(mode: str) -> str:
+    """Validate vector storage mode.
+
+    Args:
+        mode: Storage mode name.
+
+    Returns:
+        Validated storage mode (lowercase).
+
+    Raises:
+        SecurityError: If storage mode is not allowed.
+    """
+    if not isinstance(mode, str):
+        raise SecurityError(f"Storage mode must be a string, got {type(mode).__name__}")
+
+    mode_lower = mode.lower()
+    if mode_lower not in ALLOWED_STORAGE_MODES:
+        raise SecurityError(
+            f"Invalid storage mode '{mode}'. Allowed: {', '.join(sorted(ALLOWED_STORAGE_MODES))}"
+        )
+
+    return mode_lower
 
 
 def validate_batch_size(size: int) -> int:

--- a/integrations/llamaindex/src/llamaindex_velesdb/vectorstore.py
+++ b/integrations/llamaindex/src/llamaindex_velesdb/vectorstore.py
@@ -26,6 +26,7 @@ from llamaindex_velesdb.security import (
     validate_text,
     validate_query,
     validate_metric,
+    validate_storage_mode,
     validate_batch_size,
     validate_collection_name,
     validate_weight,
@@ -132,14 +133,50 @@ class VelesDBVectorStore(BasePydanticVectorStore):
         validated_path = validate_path(path)
         validated_collection = validate_collection_name(collection_name)
         validated_metric = validate_metric(metric)
+        validated_storage_mode = validate_storage_mode(storage_mode)
         
         super().__init__(
             path=validated_path,
-            storage_mode=storage_mode,
+            storage_mode=validated_storage_mode,
             collection_name=validated_collection,
             metric=validated_metric,
             **kwargs,
         )
+
+    @staticmethod
+    def _metadata_from_payload(payload: dict) -> dict:
+        """Extract metadata from a VelesDB payload."""
+        return {k: v for k, v in payload.items() if k not in ("text", "node_id")}
+
+    @classmethod
+    def _node_from_result(cls, result: dict) -> TextNode:
+        """Convert a VelesDB search result to a TextNode."""
+        payload = result.get("payload", {})
+        text = payload.get("text", "")
+        node_id = payload.get("node_id", str(result.get("id", "")))
+        metadata = cls._metadata_from_payload(payload)
+        return TextNode(text=text, id_=node_id, metadata=metadata)
+
+    @classmethod
+    def _result_to_parts(cls, result: dict) -> tuple[TextNode, float, str]:
+        """Convert a VelesDB result into (node, score, node_id)."""
+        node = cls._node_from_result(result)
+        return node, result.get("score", 0.0), node.node_id
+
+    @classmethod
+    def _build_query_result(cls, results: list[dict]) -> VectorStoreQueryResult:
+        """Build a VectorStoreQueryResult from raw VelesDB result dictionaries."""
+        nodes: List[TextNode] = []
+        similarities: List[float] = []
+        ids: List[str] = []
+
+        for result in results:
+            node, score, node_id = cls._result_to_parts(result)
+            nodes.append(node)
+            similarities.append(score)
+            ids.append(node_id)
+
+        return VectorStoreQueryResult(nodes=nodes, similarities=similarities, ids=ids)
 
     def _get_db(self) -> velesdb.Database:
         """Get or create the database connection."""
@@ -167,6 +204,7 @@ class VelesDBVectorStore(BasePydanticVectorStore):
                     self.collection_name,
                     dimension=dimension,
                     metric=self.metric,
+                    storage_mode=self.storage_mode,
                 )
                 self._collection = db.get_collection(self.collection_name)
             else:
@@ -298,37 +336,7 @@ class VelesDBVectorStore(BasePydanticVectorStore):
 
         results = collection.search(query.query_embedding, top_k=k)
 
-        nodes: List[TextNode] = []
-        similarities: List[float] = []
-        ids: List[str] = []
-
-        for result in results:
-            payload = result.get("payload", {})
-            text = payload.get("text", "")
-            node_id = payload.get("node_id", str(result.get("id", "")))
-            score = result.get("score", 0.0)
-
-            # Build metadata from remaining payload
-            metadata = {
-                k: v for k, v in payload.items()
-                if k not in ("text", "node_id")
-            }
-
-            node = TextNode(
-                text=text,
-                id_=node_id,
-                metadata=metadata,
-            )
-
-            nodes.append(node)
-            similarities.append(score)
-            ids.append(node_id)
-
-        return VectorStoreQueryResult(
-            nodes=nodes,
-            similarities=similarities,
-            ids=ids,
-        )
+        return self._build_query_result(results)
 
     def query_with_score_threshold(
         self,
@@ -415,36 +423,7 @@ class VelesDBVectorStore(BasePydanticVectorStore):
             vector_weight=vector_weight,
         )
 
-        nodes: List[TextNode] = []
-        similarities: List[float] = []
-        ids: List[str] = []
-
-        for result in results:
-            payload = result.get("payload", {})
-            text = payload.get("text", "")
-            node_id = payload.get("node_id", str(result.get("id", "")))
-            score = result.get("score", 0.0)
-
-            metadata = {
-                k: v for k, v in payload.items()
-                if k not in ("text", "node_id")
-            }
-
-            node = TextNode(
-                text=text,
-                id_=node_id,
-                metadata=metadata,
-            )
-
-            nodes.append(node)
-            similarities.append(score)
-            ids.append(node_id)
-
-        return VectorStoreQueryResult(
-            nodes=nodes,
-            similarities=similarities,
-            ids=ids,
-        )
+        return self._build_query_result(results)
 
     def text_query(
         self,
@@ -474,36 +453,7 @@ class VelesDBVectorStore(BasePydanticVectorStore):
 
         results = self._collection.text_search(query_str, top_k=similarity_top_k)
 
-        nodes: List[TextNode] = []
-        similarities: List[float] = []
-        ids: List[str] = []
-
-        for result in results:
-            payload = result.get("payload", {})
-            text = payload.get("text", "")
-            node_id = payload.get("node_id", str(result.get("id", "")))
-            score = result.get("score", 0.0)
-
-            metadata = {
-                k: v for k, v in payload.items()
-                if k not in ("text", "node_id")
-            }
-
-            node = TextNode(
-                text=text,
-                id_=node_id,
-                metadata=metadata,
-            )
-
-            nodes.append(node)
-            similarities.append(score)
-            ids.append(node_id)
-
-        return VectorStoreQueryResult(
-            nodes=nodes,
-            similarities=similarities,
-            ids=ids,
-        )
+        return self._build_query_result(results)
 
     def batch_query(
         self,
@@ -534,18 +484,7 @@ class VelesDBVectorStore(BasePydanticVectorStore):
 
         batch_results = collection.batch_search(searches)
 
-        all_results: List[VectorStoreQueryResult] = []
-        for res_list in batch_results:
-            n_list, s_list, i_list = [], [], []
-            for r in res_list:
-                p = r.get("payload", {})
-                nid = p.get("node_id", str(r.get("id", "")))
-                n_list.append(TextNode(text=p.get("text", ""), id_=nid,
-                    metadata={k: v for k, v in p.items() if k not in ("text", "node_id")}))
-                s_list.append(r.get("score", 0.0))
-                i_list.append(nid)
-            all_results.append(VectorStoreQueryResult(nodes=n_list, similarities=s_list, ids=i_list))
-        return all_results
+        return [self._build_query_result(res_list) for res_list in batch_results]
 
     def add_bulk(self, nodes: List[BaseNode], **add_kwargs: Any) -> List[str]:
         """Bulk insert optimized for large batches.
@@ -590,8 +529,13 @@ class VelesDBVectorStore(BasePydanticVectorStore):
         for pt in points:
             if pt:
                 p = pt.get("payload", {})
-                result.append(TextNode(text=p.get("text", ""), id_=p.get("node_id", ""),
-                    metadata={k: v for k, v in p.items() if k not in ("text", "node_id")}))
+                result.append(
+                    TextNode(
+                        text=p.get("text", ""),
+                        id_=p.get("node_id", ""),
+                        metadata=self._metadata_from_payload(p),
+                    )
+                )
         return result
 
     def get_collection_info(self) -> dict:
@@ -636,15 +580,7 @@ class VelesDBVectorStore(BasePydanticVectorStore):
         if self._collection is None:
             return VectorStoreQueryResult(nodes=[], similarities=[], ids=[])
         results = self._collection.query(query_str, params)
-        n_list, s_list, i_list = [], [], []
-        for r in results:
-            p = r.get("payload", {})
-            nid = p.get("node_id", str(r.get("id", "")))
-            n_list.append(TextNode(text=p.get("text", ""), id_=nid,
-                metadata={k: v for k, v in p.items() if k not in ("text", "node_id")}))
-            s_list.append(r.get("score", 0.0))
-            i_list.append(nid)
-        return VectorStoreQueryResult(nodes=n_list, similarities=s_list, ids=i_list)
+        return self._build_query_result(results)
 
     def multi_query_search(
         self,
@@ -710,36 +646,7 @@ class VelesDBVectorStore(BasePydanticVectorStore):
             fusion=fusion_strategy,
         )
 
-        nodes: List[TextNode] = []
-        similarities: List[float] = []
-        ids: List[str] = []
-
-        for result in results:
-            payload = result.get("payload", {})
-            text = payload.get("text", "")
-            node_id = payload.get("node_id", str(result.get("id", "")))
-            score = result.get("score", 0.0)
-
-            metadata = {
-                k: v for k, v in payload.items()
-                if k not in ("text", "node_id")
-            }
-
-            node = TextNode(
-                text=text,
-                id_=node_id,
-                metadata=metadata,
-            )
-
-            nodes.append(node)
-            similarities.append(score)
-            ids.append(node_id)
-
-        return VectorStoreQueryResult(
-            nodes=nodes,
-            similarities=similarities,
-            ids=ids,
-        )
+        return self._build_query_result(results)
 
     def explain(
         self,

--- a/integrations/llamaindex/tests/test_core_parity.py
+++ b/integrations/llamaindex/tests/test_core_parity.py
@@ -1,0 +1,83 @@
+"""Parity-focused tests between llamaindex integration and velesdb-core exposed API."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+
+import pytest
+from llama_index.core.schema import TextNode
+
+
+@pytest.fixture
+def vectorstore_module(monkeypatch):
+    """Import vectorstore with a fake velesdb module for isolated unit testing."""
+
+    class FakeCollection:
+        def __init__(self):
+            self.upsert_calls = []
+
+        def info(self):
+            return {"dimension": 3}
+
+        def upsert(self, points):
+            self.upsert_calls.append(points)
+
+    class FakeDatabase:
+        def __init__(self, _path):
+            self.collection = None
+            self.created_with = None
+
+        def get_collection(self, _name):
+            return self.collection
+
+        def create_collection(self, name, dimension, metric, storage_mode="full"):
+            self.created_with = {
+                "name": name,
+                "dimension": dimension,
+                "metric": metric,
+                "storage_mode": storage_mode,
+            }
+            self.collection = FakeCollection()
+            return self.collection
+
+    fake_velesdb = types.SimpleNamespace(Database=FakeDatabase, Collection=FakeCollection)
+    monkeypatch.setitem(sys.modules, "velesdb", fake_velesdb)
+
+    sys.path.insert(0, "integrations/llamaindex/src")
+    sys.modules.pop("llamaindex_velesdb.vectorstore", None)
+    return importlib.import_module("llamaindex_velesdb.vectorstore")
+
+
+def test_storage_mode_validation_accepts_all_core_modes(vectorstore_module):
+    VelesDBVectorStore = vectorstore_module.VelesDBVectorStore
+
+    for mode in ("full", "sq8", "binary"):
+        store = VelesDBVectorStore(path="/tmp/veles", collection_name="t", storage_mode=mode)
+        assert store.storage_mode == mode
+
+
+def test_storage_mode_validation_rejects_invalid_mode(vectorstore_module):
+    VelesDBVectorStore = vectorstore_module.VelesDBVectorStore
+    SecurityError = importlib.import_module("llamaindex_velesdb.security").SecurityError
+
+    with pytest.raises(SecurityError):
+        VelesDBVectorStore(path="/tmp/veles", collection_name="t", storage_mode="invalid")
+
+
+def test_collection_creation_propagates_storage_mode(vectorstore_module):
+    VelesDBVectorStore = vectorstore_module.VelesDBVectorStore
+
+    store = VelesDBVectorStore(
+        path="/tmp/veles",
+        collection_name="t",
+        metric="cosine",
+        storage_mode="sq8",
+    )
+
+    store.add([TextNode(text="doc", id_="n1", embedding=[0.1, 0.2, 0.3])])
+
+    created = store.client.created_with
+    assert created is not None
+    assert created["storage_mode"] == "sq8"


### PR DESCRIPTION
### Motivation
- Ensure the LlamaIndex integration exposes the same storage-mode surface as `velesdb-core` so users can request `full`, `sq8`, or `binary` storage modes and have them applied at collection creation. 
- Reduce duplicated result-conversion logic so there is a single modular conversion path from raw VelesDB responses into LlamaIndex `VectorStoreQueryResult` objects. 
- Follow TDD/parity practices by adding unit tests that validate parity behaviors with a mocked `velesdb` to keep `velesdb-core` as the single source of truth.

### Description
- Added `ALLOWED_STORAGE_MODES` and `validate_storage_mode()` in `integrations/llamaindex/src/llamaindex_velesdb/security.py` to validate `storage_mode` values. 
- Wire `validate_storage_mode()` into `VelesDBVectorStore.__init__` and propagate the validated `storage_mode` to `db.create_collection(...)` so collection creation uses the requested core storage mode. 
- Consolidated repeated result-to-node conversion into helper methods in `integrations/llamaindex/src/llamaindex_velesdb/vectorstore.py`: `_metadata_from_payload`, `_node_from_result`, `_result_to_parts`, and `_build_query_result`, and updated `query`, `hybrid_query`, `text_query`, `batch_query`, `velesql`, and `multi_query_search` to use them. 
- Added parity-focused tests `integrations/llamaindex/tests/test_core_parity.py` that mock `velesdb` to assert acceptance of valid modes, rejection of invalid modes, and that `storage_mode` is propagated on collection creation.

### Testing
- Ran `python -m pytest integrations/llamaindex/tests/test_core_parity.py -q`, which passed (`3 passed`).
- Attempted `python -m pytest integrations/llamaindex/tests/test_vectorstore.py -q`, but collection-level integration tests were blocked during collection due to missing build/install of the local `velesdb` Python package. 
- Attempted to install local packages via `pip install -e integrations/llamaindex` and `pip install -e crates/velesdb-python`, but both installs failed in this environment due to Rust/Python `maturin` build constraints; installing `llama-index-core` succeeded.
- The new parity tests are isolated and deterministic by mocking `velesdb`, so they validate the behavioral changes despite local build limitations.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a38d382a88832aa6e67c24692f6917)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/261" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
