### PR TITLE
feat(mobile): expose core collection stats, index, and flush APIs

### DIFF
--- a/crates/velesdb-mobile/src/lib.rs
+++ b/crates/velesdb-mobile/src/lib.rs
@@ -41,8 +41,8 @@ mod types;
 
 pub use graph::{MobileGraphEdge, MobileGraphNode, MobileGraphStore, TraversalResult};
 pub use types::{
-    DistanceMetric, FusionStrategy, IndividualSearchRequest, SearchResult, StorageMode, VelesError,
-    VelesPoint,
+    DistanceMetric, FusionStrategy, IndividualSearchRequest, MobileCollectionStats,
+    MobileIndexInfo, SearchResult, StorageMode, VelesError, VelesPoint,
 };
 
 use std::sync::Arc;
@@ -706,6 +706,79 @@ impl VelesCollection {
                 score: r.score,
             })
             .collect())
+    }
+
+    /// Flushes collection data to durable storage.
+    pub fn flush(&self) -> Result<(), VelesError> {
+        self.inner.flush()?;
+        Ok(())
+    }
+
+    /// Returns all point IDs currently present in the collection.
+    pub fn all_ids(&self) -> Vec<u64> {
+        self.inner.all_ids()
+    }
+
+    /// Creates a secondary metadata index for a payload field.
+    pub fn create_index(&self, field_name: String) -> Result<(), VelesError> {
+        self.inner.create_index(&field_name)?;
+        Ok(())
+    }
+
+    /// Checks whether a secondary metadata index exists for a field.
+    pub fn has_secondary_index(&self, field_name: String) -> bool {
+        self.inner.has_secondary_index(&field_name)
+    }
+
+    /// Creates a graph/property index for equality lookups.
+    pub fn create_property_index(&self, label: String, property: String) -> Result<(), VelesError> {
+        self.inner.create_property_index(&label, &property)?;
+        Ok(())
+    }
+
+    /// Creates a graph/range index for range queries.
+    pub fn create_range_index(&self, label: String, property: String) -> Result<(), VelesError> {
+        self.inner.create_range_index(&label, &property)?;
+        Ok(())
+    }
+
+    /// Checks if a property index exists.
+    pub fn has_property_index(&self, label: String, property: String) -> bool {
+        self.inner.has_property_index(&label, &property)
+    }
+
+    /// Checks if a range index exists.
+    pub fn has_range_index(&self, label: String, property: String) -> bool {
+        self.inner.has_range_index(&label, &property)
+    }
+
+    /// Lists all index definitions on this collection.
+    pub fn list_indexes(&self) -> Vec<MobileIndexInfo> {
+        self.inner
+            .list_indexes()
+            .into_iter()
+            .map(MobileIndexInfo::from)
+            .collect()
+    }
+
+    /// Drops an index and returns true when something was removed.
+    pub fn drop_index(&self, label: String, property: String) -> Result<bool, VelesError> {
+        Ok(self.inner.drop_index(&label, &property)?)
+    }
+
+    /// Returns total memory usage used by indexes.
+    pub fn indexes_memory_usage(&self) -> u64 {
+        u64::try_from(self.inner.indexes_memory_usage()).unwrap_or(u64::MAX)
+    }
+
+    /// Runs ANALYZE and returns fresh statistics for this collection.
+    pub fn analyze(&self) -> Result<MobileCollectionStats, VelesError> {
+        Ok(self.inner.analyze()?.into())
+    }
+
+    /// Returns the latest known collection statistics snapshot.
+    pub fn get_stats(&self) -> MobileCollectionStats {
+        self.inner.get_stats().into()
     }
 }
 

--- a/crates/velesdb-mobile/src/lib_tests.rs
+++ b/crates/velesdb-mobile/src/lib_tests.rs
@@ -575,3 +575,128 @@ fn test_get_multiple_ids() {
     let results = col.get(vec![1, 2, 999]); // 999 doesn't exist
     assert_eq!(results.len(), 2); // Only 2 found
 }
+
+// =========================================================================
+// Core parity tests: stats/index/flush/all_ids
+// =========================================================================
+
+#[test]
+fn test_collection_flush_and_all_ids() {
+    let tmp = TempDir::new().unwrap();
+    let path = tmp.path().to_str().unwrap().to_string();
+
+    let db = VelesDatabase::open(path).unwrap();
+    db.create_collection("flush_ids".to_string(), 4, DistanceMetric::Cosine)
+        .unwrap();
+
+    let col = db.get_collection("flush_ids".to_string()).unwrap().unwrap();
+    col.upsert_batch(vec![
+        VelesPoint {
+            id: 9,
+            vector: vec![1.0, 0.0, 0.0, 0.0],
+            payload: Some(r#"{"v":1}"#.to_string()),
+        },
+        VelesPoint {
+            id: 4,
+            vector: vec![0.0, 1.0, 0.0, 0.0],
+            payload: Some(r#"{"v":2}"#.to_string()),
+        },
+    ])
+    .unwrap();
+
+    col.flush().unwrap();
+
+    let mut ids = col.all_ids();
+    ids.sort_unstable();
+    assert_eq!(ids, vec![4, 9]);
+}
+
+#[test]
+fn test_collection_secondary_index_lifecycle() {
+    let tmp = TempDir::new().unwrap();
+    let path = tmp.path().to_str().unwrap().to_string();
+
+    let db = VelesDatabase::open(path).unwrap();
+    db.create_collection("secondary_index".to_string(), 4, DistanceMetric::Cosine)
+        .unwrap();
+
+    let col = db
+        .get_collection("secondary_index".to_string())
+        .unwrap()
+        .unwrap();
+
+    assert!(!col.has_secondary_index("category".to_string()));
+    col.create_index("category".to_string()).unwrap();
+    assert!(col.has_secondary_index("category".to_string()));
+}
+
+#[test]
+fn test_collection_property_and_range_index_lifecycle() {
+    let tmp = TempDir::new().unwrap();
+    let path = tmp.path().to_str().unwrap().to_string();
+
+    let db = VelesDatabase::open(path).unwrap();
+    db.create_collection("graph_indexes".to_string(), 4, DistanceMetric::Cosine)
+        .unwrap();
+
+    let col = db
+        .get_collection("graph_indexes".to_string())
+        .unwrap()
+        .unwrap();
+
+    col.create_property_index("Doc".to_string(), "title".to_string())
+        .unwrap();
+    col.create_range_index("Doc".to_string(), "year".to_string())
+        .unwrap();
+
+    assert!(col.has_property_index("Doc".to_string(), "title".to_string()));
+    assert!(col.has_range_index("Doc".to_string(), "year".to_string()));
+
+    let indexes = col.list_indexes();
+    assert!(indexes
+        .iter()
+        .any(|idx| idx.label == "Doc" && idx.property == "title" && idx.index_type == "hash"));
+    assert!(indexes
+        .iter()
+        .any(|idx| idx.label == "Doc" && idx.property == "year" && idx.index_type == "range"));
+
+    let usage = col.indexes_memory_usage();
+    assert!(usage > 0);
+
+    assert!(col
+        .drop_index("Doc".to_string(), "title".to_string())
+        .unwrap());
+    assert!(!col.has_property_index("Doc".to_string(), "title".to_string()));
+}
+
+#[test]
+fn test_collection_analyze_and_get_stats() {
+    let tmp = TempDir::new().unwrap();
+    let path = tmp.path().to_str().unwrap().to_string();
+
+    let db = VelesDatabase::open(path).unwrap();
+    db.create_collection("stats".to_string(), 4, DistanceMetric::Cosine)
+        .unwrap();
+
+    let col = db.get_collection("stats".to_string()).unwrap().unwrap();
+    col.upsert_batch(vec![
+        VelesPoint {
+            id: 1,
+            vector: vec![1.0, 0.0, 0.0, 0.0],
+            payload: Some(r#"{"category":"a"}"#.to_string()),
+        },
+        VelesPoint {
+            id: 2,
+            vector: vec![0.0, 1.0, 0.0, 0.0],
+            payload: Some(r#"{"category":"b"}"#.to_string()),
+        },
+    ])
+    .unwrap();
+
+    let analyzed = col.analyze().unwrap();
+    assert!(analyzed.total_points >= 2);
+
+    let snapshot = col.get_stats();
+    assert!(snapshot.total_points >= 2);
+    assert!(snapshot.field_stats_count >= 1 || snapshot.column_stats_count >= 1);
+}

--- a/crates/velesdb-mobile/src/types.rs
+++ b/crates/velesdb-mobile/src/types.rs
@@ -183,3 +183,69 @@ pub struct IndividualSearchRequest {
     /// Optional metadata filter as JSON string.
     pub filter: Option<String>,
 }
+
+/// Public statistics snapshot for a collection.
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct MobileCollectionStats {
+    /// Total number of points currently stored.
+    pub total_points: u64,
+    /// Total payload footprint in bytes.
+    pub payload_size_bytes: u64,
+    /// Number of rows in storage.
+    pub row_count: u64,
+    /// Number of deleted/tombstoned rows.
+    pub deleted_count: u64,
+    /// Mean row size estimate in bytes.
+    pub avg_row_size_bytes: u64,
+    /// Total collection size estimate in bytes.
+    pub total_size_bytes: u64,
+    /// Number of tracked fields.
+    pub field_stats_count: u32,
+    /// Number of tracked columns.
+    pub column_stats_count: u32,
+    /// Number of tracked indexes.
+    pub index_stats_count: u32,
+}
+
+impl From<velesdb_core::collection::stats::CollectionStats> for MobileCollectionStats {
+    fn from(stats: velesdb_core::collection::stats::CollectionStats) -> Self {
+        Self {
+            total_points: stats.total_points,
+            payload_size_bytes: stats.payload_size_bytes,
+            row_count: stats.row_count,
+            deleted_count: stats.deleted_count,
+            avg_row_size_bytes: stats.avg_row_size_bytes,
+            total_size_bytes: stats.total_size_bytes,
+            field_stats_count: u32::try_from(stats.field_stats.len()).unwrap_or(u32::MAX),
+            column_stats_count: u32::try_from(stats.column_stats.len()).unwrap_or(u32::MAX),
+            index_stats_count: u32::try_from(stats.index_stats.len()).unwrap_or(u32::MAX),
+        }
+    }
+}
+
+/// Metadata and graph index details.
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct MobileIndexInfo {
+    /// Node label.
+    pub label: String,
+    /// Property name.
+    pub property: String,
+    /// Index type name.
+    pub index_type: String,
+    /// Number of distinct values.
+    pub cardinality: u64,
+    /// Approximate memory usage in bytes.
+    pub memory_bytes: u64,
+}
+
+impl From<velesdb_core::IndexInfo> for MobileIndexInfo {
+    fn from(value: velesdb_core::IndexInfo) -> Self {
+        Self {
+            label: value.label,
+            property: value.property,
+            index_type: value.index_type,
+            cardinality: u64::try_from(value.cardinality).unwrap_or(u64::MAX),
+            memory_bytes: u64::try_from(value.memory_bytes).unwrap_or(u64::MAX),
+        }
+    }
+}


### PR DESCRIPTION
### Motivation

- Align `velesdb-mobile` feature parity with `velesdb-core` so mobile bindings can access collection-level operations (indexes, stats, flush, ids) without duplicating core logic.
- Keep `velesdb-core` as the single source of truth and provide thin, modular UniFFI-friendly wrappers on top of core APIs.
- Make these capabilities available to mobile SDK consumers (Swift/Kotlin) for on-device index management, diagnostics, and analytics.

### Description

- Added thin wrappers on `VelesCollection` in `crates/velesdb-mobile/src/lib.rs` to expose `flush`, `all_ids`, `create_index`, `has_secondary_index`, `create_property_index`, `create_range_index`, `has_property_index`, `has_range_index`, `list_indexes`, `drop_index`, `indexes_memory_usage`, `analyze`, and `get_stats` that delegate to `velesdb-core`.
- Introduced mobile DTOs `MobileCollectionStats` and `MobileIndexInfo` in `crates/velesdb-mobile/src/types.rs` with `From` conversions from core types to avoid duplicating business logic and to provide UniFFI-compatible records.
- Exported the new types from the mobile crate API so they are available to bindings (updated public `use` in `lib.rs`).
- Added TDD-style unit tests in `crates/velesdb-mobile/src/lib_tests.rs` to validate flush/all_ids behavior, secondary index lifecycle, property/range index lifecycle, index listing/drop/memory usage, and `analyze`/`get_stats` end-to-end against the core implementation.

### Testing

- Ran unit tests with `cargo test -p velesdb-mobile` and all mobile tests passed (`44 passed; 0 failed`).
- Ran code formatting with `cargo fmt --all` and the workspace formatted successfully.
- New tests added in `crates/velesdb-mobile/src/lib_tests.rs` exercise the newly exposed APIs and are included in the above test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a38d38f420832a81720522181266ce)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/262" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
