### PR TITLE
Use parking_lot RwLock, add Layer.with_neighbors, refactor HNSW search paths, and harden metrics/QueryCache paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6843,6 +6843,7 @@ dependencies = [
  "axum",
  "clap",
  "futures",
+ "parking_lot",
  "reqwest 0.12.28",
  "serde",
  "serde_json",

--- a/crates/velesdb-core/src/collection/auto_reindex/mod.rs
+++ b/crates/velesdb-core/src/collection/auto_reindex/mod.rs
@@ -33,7 +33,9 @@
 #![allow(clippy::cast_possible_truncation)]
 
 use std::sync::atomic::{AtomicU8, Ordering};
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+
+use parking_lot::RwLock;
 use std::time::Duration;
 
 use crate::index::hnsw::HnswParams;
@@ -90,56 +92,43 @@ impl AutoReindexManager {
 
     /// Returns whether auto-reindex is enabled
     ///
-    /// Returns `false` if the lock is poisoned (fail-safe).
     #[must_use]
     pub fn is_enabled(&self) -> bool {
-        self.config.read().map(|c| c.enabled).unwrap_or(false)
+        self.config.read().enabled
     }
 
     /// Enables or disables auto-reindex
     ///
-    /// Silently fails if the lock is poisoned.
     pub fn set_enabled(&self, enabled: bool) {
-        if let Ok(mut guard) = self.config.write() {
-            guard.enabled = enabled;
-        }
+        self.config.write().enabled = enabled;
     }
 
     /// Updates the configuration
     ///
-    /// Silently fails if the lock is poisoned.
     pub fn set_config(&self, config: AutoReindexConfig) {
-        if let Ok(mut guard) = self.config.write() {
-            *guard = config;
-        }
+        *self.config.write() = config;
     }
 
     /// Gets the current configuration
     ///
-    /// Returns default config if the lock is poisoned.
     #[must_use]
     pub fn config(&self) -> AutoReindexConfig {
-        self.config.read().map(|c| c.clone()).unwrap_or_default()
+        self.config.read().clone()
     }
 
     /// Sets the event callback for reindex lifecycle events
     ///
-    /// Silently fails if the lock is poisoned.
     pub fn on_event<F>(&self, callback: F)
     where
         F: Fn(ReindexEvent) + Send + Sync + 'static,
     {
-        if let Ok(mut guard) = self.event_callback.write() {
-            *guard = Some(Arc::new(callback));
-        }
+        *self.event_callback.write() = Some(Arc::new(callback));
     }
 
     /// Emits an event to the registered callback
     fn emit_event(&self, event: ReindexEvent) {
-        if let Ok(guard) = self.event_callback.read() {
-            if let Some(ref callback) = *guard {
-                callback(event);
-            }
+        if let Some(ref callback) = *self.event_callback.read() {
+            callback(event);
         }
     }
 
@@ -155,7 +144,6 @@ impl AutoReindexManager {
     ///
     /// `DivergenceCheck` with recommendation and details
     ///
-    /// Returns a no-reindex recommendation if the lock is poisoned.
     #[must_use]
     pub fn check_divergence(
         &self,
@@ -163,15 +151,7 @@ impl AutoReindexManager {
         current_size: usize,
         dimension: usize,
     ) -> DivergenceCheck {
-        let Ok(config) = self.config.read() else {
-            return DivergenceCheck {
-                should_reindex: false,
-                current_m: current_params.max_connections,
-                optimal_m: current_params.max_connections,
-                ratio: 1.0,
-                reason: None,
-            };
-        };
+        let config = self.config.read();
 
         // Check minimum size
         if current_size < config.min_size_for_reindex {
@@ -219,7 +199,6 @@ impl AutoReindexManager {
 
     /// Checks if reindex should be triggered (convenience method)
     ///
-    /// Returns `false` if locks are poisoned (fail-safe).
     #[must_use]
     pub fn should_reindex(
         &self,
@@ -228,14 +207,10 @@ impl AutoReindexManager {
         dimension: usize,
     ) -> bool {
         // Check cooldown
-        if let Ok(guard) = self.last_reindex_timestamp.read() {
-            if let Some(last) = *guard {
-                let Ok(config) = self.config.read() else {
-                    return false;
-                };
-                if last.elapsed() < config.cooldown {
-                    return false;
-                }
+        if let Some(last) = *self.last_reindex_timestamp.read() {
+            let config = self.config.read();
+            if last.elapsed() < config.cooldown {
+                return false;
             }
         }
 
@@ -252,21 +227,16 @@ impl AutoReindexManager {
     ///
     /// Returns `Ok(())` if validation passes, `Err(reason)` if rollback needed
     ///
-    /// Returns `Err` if the lock is poisoned.
-    ///
     /// # Errors
     ///
-    /// Returns an error message when lock access fails or when latency/recall
+    /// Returns an error message when latency/recall
     /// regressions exceed configured thresholds.
     pub fn validate_benchmark(
         &self,
         old_benchmark: &BenchmarkResult,
         new_benchmark: &BenchmarkResult,
     ) -> Result<(), String> {
-        let config = self
-            .config
-            .read()
-            .map_err(|_| "Config lock poisoned".to_string())?;
+        let config = self.config.read();
 
         // Check latency regression
         if old_benchmark.latency_p99_us > 0 {
@@ -383,17 +353,13 @@ impl AutoReindexManager {
 
     /// Completes the reindex successfully
     ///
-    /// Returns `false` if the lock is poisoned.
     pub fn complete_reindex(&self, duration: Duration) -> bool {
         if self.state() != ReindexState::Validating && self.state() != ReindexState::Swapping {
             return false;
         }
 
         // Update last reindex timestamp
-        let Ok(mut guard) = self.last_reindex_timestamp.write() else {
-            return false;
-        };
-        *guard = Some(std::time::Instant::now());
+        *self.last_reindex_timestamp.write() = Some(std::time::Instant::now());
 
         self.state
             .store(ReindexState::Idle as u8, Ordering::Release);

--- a/crates/velesdb-core/src/index/hnsw/native/dual_precision.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/dual_precision.rs
@@ -382,26 +382,27 @@ impl<D: DistanceEngine> DualPrecisionHnsw<D> {
                 break;
             }
 
-            let neighbors = self.inner.layers.read()[0].get_neighbors(c_node);
+            let layers = self.inner.layers.read();
+            let _ = layers[0].with_neighbors(c_node, |neighbors| {
+                for &neighbor in neighbors {
+                    if visited.insert(neighbor) {
+                        if let Some(neighbor_slice) = store.get_slice(neighbor) {
+                            let dist =
+                                quantizer.distance_l2_quantized_slice(query_int8, neighbor_slice);
+                            let furthest = results.peek().map_or(u32::MAX, |r| r.0);
 
-            for neighbor in neighbors {
-                if visited.insert(neighbor) {
-                    if let Some(neighbor_slice) = store.get_slice(neighbor) {
-                        let dist =
-                            quantizer.distance_l2_quantized_slice(query_int8, neighbor_slice);
-                        let furthest = results.peek().map_or(u32::MAX, |r| r.0);
+                            if dist < furthest || results.len() < ef {
+                                candidates.push(Reverse((dist, neighbor)));
+                                results.push((dist, neighbor));
 
-                        if dist < furthest || results.len() < ef {
-                            candidates.push(Reverse((dist, neighbor)));
-                            results.push((dist, neighbor));
-
-                            if results.len() > ef {
-                                results.pop();
+                                if results.len() > ef {
+                                    results.pop();
+                                }
                             }
                         }
                     }
                 }
-            }
+            });
         }
 
         // Convert to sorted vec
@@ -426,19 +427,21 @@ impl<D: DistanceEngine> DualPrecisionHnsw<D> {
         });
 
         loop {
-            let neighbors = self.inner.layers.read()[layer].get_neighbors(current);
             let mut improved = false;
-
-            for neighbor in neighbors {
-                if let Some(neighbor_slice) = store.get_slice(neighbor) {
-                    let dist = quantizer.distance_l2_quantized_slice(query_int8, neighbor_slice);
-                    if dist < current_dist {
-                        current = neighbor;
-                        current_dist = dist;
-                        improved = true;
+            let layers = self.inner.layers.read();
+            let _ = layers[layer].with_neighbors(current, |neighbors| {
+                for &neighbor in neighbors {
+                    if let Some(neighbor_slice) = store.get_slice(neighbor) {
+                        let dist =
+                            quantizer.distance_l2_quantized_slice(query_int8, neighbor_slice);
+                        if dist < current_dist {
+                            current = neighbor;
+                            current_dist = dist;
+                            improved = true;
+                        }
                     }
                 }
-            }
+            });
 
             if !improved {
                 break;

--- a/crates/velesdb-core/src/index/hnsw/native/graph/search.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/graph/search.rs
@@ -120,17 +120,24 @@ impl<D: DistanceEngine> NativeHnsw<D> {
             let mut best_dist = self.distance.distance(query, &vectors[entry]);
 
             loop {
-                let neighbors = self.with_layers_read(|layers| layers[layer].get_neighbors(best));
-                let mut improved = false;
+                let improved = self.with_layers_read(|layers| {
+                    layers[layer]
+                        .with_neighbors(best, |neighbors| {
+                            let mut improved = false;
 
-                for neighbor in neighbors {
-                    let dist = self.distance.distance(query, &vectors[neighbor]);
-                    if dist < best_dist {
-                        best = neighbor;
-                        best_dist = dist;
-                        improved = true;
-                    }
-                }
+                            for &neighbor in neighbors {
+                                let dist = self.distance.distance(query, &vectors[neighbor]);
+                                if dist < best_dist {
+                                    best = neighbor;
+                                    best_dist = dist;
+                                    improved = true;
+                                }
+                            }
+
+                            improved
+                        })
+                        .unwrap_or(false)
+                });
 
                 if !improved {
                     break;
@@ -178,38 +185,40 @@ impl<D: DistanceEngine> NativeHnsw<D> {
                     break;
                 }
 
-                let neighbors = self.with_layers_read(|layers| layers[layer].get_neighbors(c_node));
-
-                if dimension >= 384 && neighbors.len() > prefetch_distance {
-                    for &neighbor_id in neighbors.iter().take(prefetch_distance) {
-                        if neighbor_id < vectors.len() {
-                            crate::simd_native::prefetch_vector(&vectors[neighbor_id]);
-                        }
-                    }
-                }
-
-                for (i, neighbor) in neighbors.iter().enumerate() {
-                    if dimension >= 384 && i + prefetch_distance < neighbors.len() {
-                        let prefetch_id = neighbors[i + prefetch_distance];
-                        if prefetch_id < vectors.len() {
-                            crate::simd_native::prefetch_vector(&vectors[prefetch_id]);
-                        }
-                    }
-
-                    if visited.insert(*neighbor) {
-                        let dist = self.distance.distance(query, &vectors[*neighbor]);
-                        let furthest = results.peek().map_or(f32::MAX, |r| r.0 .0);
-
-                        if dist < furthest || results.len() < ef {
-                            candidates.push(Reverse((OrderedFloat(dist), *neighbor)));
-                            results.push((OrderedFloat(dist), *neighbor));
-
-                            if results.len() > ef {
-                                results.pop();
+                self.with_layers_read(|layers| {
+                    let _ = layers[layer].with_neighbors(c_node, |neighbors| {
+                        if dimension >= 384 && neighbors.len() > prefetch_distance {
+                            for &neighbor_id in neighbors.iter().take(prefetch_distance) {
+                                if neighbor_id < vectors.len() {
+                                    crate::simd_native::prefetch_vector(&vectors[neighbor_id]);
+                                }
                             }
                         }
-                    }
-                }
+
+                        for (i, neighbor) in neighbors.iter().enumerate() {
+                            if dimension >= 384 && i + prefetch_distance < neighbors.len() {
+                                let prefetch_id = neighbors[i + prefetch_distance];
+                                if prefetch_id < vectors.len() {
+                                    crate::simd_native::prefetch_vector(&vectors[prefetch_id]);
+                                }
+                            }
+
+                            if visited.insert(*neighbor) {
+                                let dist = self.distance.distance(query, &vectors[*neighbor]);
+                                let furthest = results.peek().map_or(f32::MAX, |r| r.0 .0);
+
+                                if dist < furthest || results.len() < ef {
+                                    candidates.push(Reverse((OrderedFloat(dist), *neighbor)));
+                                    results.push((OrderedFloat(dist), *neighbor));
+
+                                    if results.len() > ef {
+                                        results.pop();
+                                    }
+                                }
+                            }
+                        }
+                    });
+                });
             }
         });
 

--- a/crates/velesdb-core/src/index/hnsw/native/layer.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/layer.rs
@@ -38,6 +38,20 @@ impl Layer {
         }
     }
 
+    /// Runs a closure with immutable access to a node's adjacency list under a read lock.
+    pub(crate) fn with_neighbors<R>(
+        &self,
+        node_id: NodeId,
+        f: impl FnOnce(&[NodeId]) -> R,
+    ) -> Option<R> {
+        if node_id < self.neighbors.len() {
+            let guard = self.neighbors[node_id].read();
+            Some(f(&guard))
+        } else {
+            None
+        }
+    }
+
     /// Sets the neighbors for a node.
     pub(crate) fn set_neighbors(&self, node_id: NodeId, neighbors: Vec<NodeId>) {
         if node_id < self.neighbors.len() {

--- a/crates/velesdb-core/src/index/hnsw/native/layer_tests.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/layer_tests.rs
@@ -94,3 +94,22 @@ fn test_layer_empty_neighbors() {
 
     assert!(layer.get_neighbors(0).is_empty());
 }
+
+#[test]
+fn test_layer_with_neighbors_reads_slice() {
+    let layer = Layer::new(4);
+    layer.set_neighbors(2, vec![7, 8, 9]);
+
+    let len = layer.with_neighbors(2, |neighbors| neighbors.len());
+    assert_eq!(len, Some(3));
+
+    let sum = layer.with_neighbors(2, |neighbors| neighbors.iter().sum::<usize>());
+    assert_eq!(sum, Some(24));
+}
+
+#[test]
+fn test_layer_with_neighbors_out_of_bounds_returns_none() {
+    let layer = Layer::new(1);
+    let result = layer.with_neighbors(99, |neighbors| neighbors.len());
+    assert_eq!(result, None);
+}

--- a/crates/velesdb-core/src/velesql/cache.rs
+++ b/crates/velesdb-core/src/velesql/cache.rs
@@ -102,8 +102,9 @@ impl QueryCache {
         let canonical_query = canonicalize_query(query);
         let hash = (self.hash_fn)(&canonical_query);
 
-        let cache = self.cache.read();
-        let cached = cache.get(&hash).and_then(|entries| {
+        let cached = {
+            let cache = self.cache.read();
+            cache.get(&hash).and_then(|entries| {
                 entries
                     .iter()
                     .find(|entry| {
@@ -111,32 +112,26 @@ impl QueryCache {
                         entry.original_query == query && entry.canonical_query == canonical_query
                     })
                     .cloned()
-            });
+            })
+        };
 
         if let Some(cached) = cached {
-            let mut order = self.order.write();
-            let mut stats = self.stats.write();
-
-            stats.hits += 1;
-
             let key = CacheKey {
                 hash,
                 original_query: query.to_string(),
             };
 
-            // Keep order/cache synchronized while the cache read-lock is held.
-            if cache.get(&hash).is_some() {
-                // Move to MRU, keeping order duplicate-free.
+            {
+                let mut order = self.order.write();
                 if let Some(pos) = order.iter().position(|existing| existing == &key) {
                     order.remove(pos);
                 }
                 order.push_back(key);
             }
 
+            self.stats.write().hits += 1;
             return Ok(cached.parsed);
         }
-
-        drop(cache);
 
         let parsed = Parser::parse(query)?;
 

--- a/crates/velesdb-server/Cargo.toml
+++ b/crates/velesdb-server/Cargo.toml
@@ -33,6 +33,7 @@ tower = { workspace = true }
 tower-http = { workspace = true }
 futures = "0.3"
 clap = { version = "4.4", features = ["derive", "env"] }
+parking_lot = "0.12"
 
 # OpenAPI/Swagger documentation
 utoipa = { version = "5", features = ["axum_extras"] }

--- a/crates/velesdb-server/src/handlers/graph/service.rs
+++ b/crates/velesdb-server/src/handlers/graph/service.rs
@@ -3,7 +3,9 @@
 //! Manages per-collection edge stores for graph operations.
 
 use std::collections::{HashMap, HashSet, VecDeque};
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+
+use parking_lot::RwLock;
 use velesdb_core::collection::graph::{EdgeStore, GraphEdge};
 
 use super::types::TraversalResultItem;
@@ -25,15 +27,11 @@ impl GraphService {
     ///
     /// # Errors
     ///
-    /// Returns an error if the internal lock is poisoned.
     pub fn get_or_create_store(
         &self,
         collection_name: &str,
     ) -> Result<Arc<RwLock<EdgeStore>>, String> {
-        let mut stores = self
-            .stores
-            .write()
-            .map_err(|e| format!("Lock poisoned: {e}"))?;
+        let mut stores = self.stores.write();
         Ok(stores
             .entry(collection_name.to_string())
             .or_insert_with(|| Arc::new(RwLock::new(EdgeStore::new())))
@@ -44,10 +42,10 @@ impl GraphService {
     ///
     /// # Errors
     ///
-    /// Returns an error if the lock is poisoned or if adding the edge fails.
+    /// Returns an error if adding the edge fails.
     pub fn add_edge(&self, collection_name: &str, edge: GraphEdge) -> Result<(), String> {
         let store = self.get_or_create_store(collection_name)?;
-        let mut guard = store.write().map_err(|e| format!("Lock error: {e}"))?;
+        let mut guard = store.write();
         guard.add_edge(edge).map_err(|e| e.to_string())
     }
 
@@ -55,14 +53,13 @@ impl GraphService {
     ///
     /// # Errors
     ///
-    /// Returns an error if the internal lock is poisoned.
     pub fn get_edges_by_label(
         &self,
         collection_name: &str,
         label: &str,
     ) -> Result<Vec<GraphEdge>, String> {
         let store = self.get_or_create_store(collection_name)?;
-        let guard = store.read().map_err(|e| format!("Lock poisoned: {e}"))?;
+        let guard = store.read();
         Ok(guard
             .get_edges_by_label(label)
             .into_iter()
@@ -74,13 +71,9 @@ impl GraphService {
     ///
     /// # Errors
     ///
-    /// Returns an error if the internal lock is poisoned.
     #[allow(clippy::type_complexity)]
     pub fn list_stores(&self) -> Result<Vec<(String, Arc<RwLock<EdgeStore>>)>, String> {
-        let stores = self
-            .stores
-            .read()
-            .map_err(|e| format!("Lock poisoned: {e}"))?;
+        let stores = self.stores.read();
         Ok(stores.iter().map(|(k, v)| (k.clone(), v.clone())).collect())
     }
 
@@ -88,7 +81,6 @@ impl GraphService {
     ///
     /// # Errors
     ///
-    /// Returns an error if the internal lock is poisoned.
     pub fn traverse_bfs(
         &self,
         collection_name: &str,
@@ -98,7 +90,7 @@ impl GraphService {
         rel_types: &[String],
     ) -> Result<Vec<TraversalResultItem>, String> {
         let store = self.get_or_create_store(collection_name)?;
-        let guard = store.read().map_err(|e| format!("Lock error: {e}"))?;
+        let guard = store.read();
 
         // PERF: Convert rel_types to HashSet for O(1) lookup instead of O(k)
         let rel_filter: HashSet<&str> = rel_types.iter().map(String::as_str).collect();
@@ -155,7 +147,6 @@ impl GraphService {
     ///
     /// # Errors
     ///
-    /// Returns an error if the internal lock is poisoned.
     pub fn traverse_dfs(
         &self,
         collection_name: &str,
@@ -165,7 +156,7 @@ impl GraphService {
         rel_types: &[String],
     ) -> Result<Vec<TraversalResultItem>, String> {
         let store = self.get_or_create_store(collection_name)?;
-        let guard = store.read().map_err(|e| format!("Lock error: {e}"))?;
+        let guard = store.read();
 
         // PERF: Convert rel_types to HashSet for O(1) lookup instead of O(k)
         let rel_filter: HashSet<&str> = rel_types.iter().map(String::as_str).collect();
@@ -219,14 +210,13 @@ impl GraphService {
     ///
     /// # Errors
     ///
-    /// Returns an error if the internal lock is poisoned.
     pub fn get_node_degree(
         &self,
         collection_name: &str,
         node_id: u64,
     ) -> Result<(usize, usize), String> {
         let store = self.get_or_create_store(collection_name)?;
-        let guard = store.read().map_err(|e| format!("Lock error: {e}"))?;
+        let guard = store.read();
 
         let in_degree = guard.get_incoming(node_id).len();
         let out_degree = guard.get_outgoing(node_id).len();

--- a/crates/velesdb-server/src/handlers/metrics.rs
+++ b/crates/velesdb-server/src/handlers/metrics.rs
@@ -10,8 +10,20 @@
 
 #![allow(dead_code)] // Functions exposed via feature flag, used when prometheus feature enabled
 
-use axum::{http::StatusCode, response::IntoResponse};
+use axum::{
+    http::StatusCode,
+    response::{IntoResponse, Response},
+};
 use std::fmt::Write;
+
+fn formatting_error_response() -> Response {
+    (
+        StatusCode::INTERNAL_SERVER_ERROR,
+        [("content-type", "text/plain; version=0.0.4; charset=utf-8")],
+        "Failed to format metrics".to_string(),
+    )
+        .into_response()
+}
 /// Prometheus text format metrics response.
 ///
 /// Returns metrics in Prometheus exposition format.
@@ -28,56 +40,90 @@ pub async fn prometheus_metrics() -> impl IntoResponse {
     let mut output = String::new();
 
     // Write header comments
-    writeln!(output, "# VelesDB Prometheus Metrics").unwrap();
-    writeln!(output).unwrap();
+    if writeln!(output, "# VelesDB Prometheus Metrics").is_err() || writeln!(output).is_err() {
+        return formatting_error_response();
+    }
 
     // Server info
-    writeln!(output, "# HELP velesdb_info VelesDB server information").unwrap();
-    writeln!(output, "# TYPE velesdb_info gauge").unwrap();
-    writeln!(
-        output,
-        "velesdb_info{{version=\"{}\"}} 1",
-        env!("CARGO_PKG_VERSION")
-    )
-    .unwrap();
-    writeln!(output).unwrap();
+    if writeln!(output, "# HELP velesdb_info VelesDB server information").is_err()
+        || writeln!(output, "# TYPE velesdb_info gauge").is_err()
+        || writeln!(
+            output,
+            "velesdb_info{{version=\"{}\"}} 1",
+            env!("CARGO_PKG_VERSION")
+        )
+        .is_err()
+        || writeln!(output).is_err()
+    {
+        return formatting_error_response();
+    }
 
     // velesdb_up gauge
-    writeln!(output, "# HELP velesdb_up VelesDB server is up and running").unwrap();
-    writeln!(output, "# TYPE velesdb_up gauge").unwrap();
-    writeln!(output, "velesdb_up 1").unwrap();
+    if writeln!(output, "# HELP velesdb_up VelesDB server is up and running").is_err()
+        || writeln!(output, "# TYPE velesdb_up gauge").is_err()
+        || writeln!(output, "velesdb_up 1").is_err()
+    {
+        return formatting_error_response();
+    }
 
     (
         StatusCode::OK,
         [("content-type", "text/plain; version=0.0.4; charset=utf-8")],
         output,
     )
+        .into_response()
 }
 
 /// Simple health metrics for lightweight monitoring.
 pub async fn health_metrics() -> impl IntoResponse {
     let mut output = String::new();
 
-    writeln!(output, "# HELP velesdb_up VelesDB server is up").unwrap();
-    writeln!(output, "# TYPE velesdb_up gauge").unwrap();
-    writeln!(output, "velesdb_up 1").unwrap();
+    if writeln!(output, "# HELP velesdb_up VelesDB server is up").is_err()
+        || writeln!(output, "# TYPE velesdb_up gauge").is_err()
+        || writeln!(output, "velesdb_up 1").is_err()
+    {
+        return formatting_error_response();
+    }
 
     (
         StatusCode::OK,
         [("content-type", "text/plain; version=0.0.4; charset=utf-8")],
         output,
     )
+        .into_response()
 }
 
 #[cfg(test)]
 mod tests {
-    #[test]
-    fn test_health_metrics_format() {
-        // Verify the format is valid Prometheus text format
-        let output =
-            "# HELP velesdb_up VelesDB server is up\n# TYPE velesdb_up gauge\nvelesdb_up 1\n";
-        assert!(output.contains("velesdb_up 1"));
-        assert!(output.contains("# TYPE"));
-        assert!(output.contains("# HELP"));
+    use super::*;
+
+    #[tokio::test]
+    async fn test_prometheus_metrics_response_shape() {
+        let response = prometheus_metrics().await.into_response();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let content_type = response
+            .headers()
+            .get("content-type")
+            .and_then(|h| h.to_str().ok());
+        assert_eq!(
+            content_type,
+            Some("text/plain; version=0.0.4; charset=utf-8")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_health_metrics_response_shape() {
+        let response = health_metrics().await.into_response();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let content_type = response
+            .headers()
+            .get("content-type")
+            .and_then(|h| h.to_str().ok());
+        assert_eq!(
+            content_type,
+            Some("text/plain; version=0.0.4; charset=utf-8")
+        );
     }
 }


### PR DESCRIPTION
### Motivation

- Replace use of `std::sync::RwLock` with `parking_lot::RwLock` to simplify locking behavior and avoid poisoned-lock handling paths. 
- Provide a safe, efficient way to access adjacency slices without cloning via a new `Layer::with_neighbors` helper to reduce allocations and lock churn. 
- Refactor HNSW search code to use the new neighbor accessor and reduce lock scope while preserving correctness. 
- Harden Prometheus metrics formatting code to handle formatting failures and improve testability, and tighten `QueryCache::parse` locking to reduce contention.

### Description

- Switched several modules from `std::sync::RwLock` to `parking_lot::RwLock` (notably `auto_reindex`, graph service, and server crate dependency), and added `parking_lot = "0.12"` to `crates/velesdb-server/Cargo.toml` and `Cargo.lock` updates. 
- Added `Layer::with_neighbors<R>(&self, node_id: NodeId, f: impl FnOnce(&[NodeId]) -> R) -> Option<R>` to `native/layer.rs` and two unit tests (`test_layer_with_neighbors_reads_slice` and `test_layer_with_neighbors_out_of_bounds_returns_none`). 
- Refactored HNSW search paths in `native/graph/search.rs` and `native/dual_precision.rs` to call the new `with_neighbors` accessor and reduce cloned neighbor vectors and lock hold times. 
- Simplified `AutoReindexManager` locking logic using `parking_lot::RwLock` and removed many poisoned-lock fail-safe branches, reducing `Result` handling around config/last-reindex access and streamlining methods like `is_enabled`, `set_enabled`, `config`, `should_reindex`, `check_divergence`, `validate_benchmark`, and `complete_reindex`. 
- Optimized `QueryCache::parse` to minimize time holding the cache read lock, update MRU order and stats correctly, and avoid holding a read lock while mutating order. 
- Hardened Prometheus endpoints in `handlers/metrics.rs` by checking `writeln!` results and returning an internal error `Response` on formatting failures, and replaced tests with async `tokio` tests that assert response shape and headers.

### Testing

- Ran unit tests for core and server crates using `cargo test -p velesdb-core` and `cargo test -p velesdb-server`; all tests passed including the new layer and metrics tests. 
- Exercised the modified HNSW search code paths via existing HNSW tests during `cargo test` and observed no regressions. 
- Ran `cargo check` across the workspace to verify dependency and compilation updates, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a42cc0ea64832aab9bd251bf8dc21b)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/264" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
