### PR TITLE
fix(simd): suppress unused variable warnings on aarch64

### DIFF
--- a/crates/velesdb-core/src/simd_native/dispatch/dot.rs
+++ b/crates/velesdb-core/src/simd_native/dispatch/dot.rs
@@ -57,8 +57,9 @@ pub fn dot_product_native(a: &[f32], b: &[f32]) -> f32 {
 #[must_use]
 pub fn batch_dot_product_native(candidates: &[&[f32]], query: &[f32]) -> Vec<f32> {
     let mut results = Vec::with_capacity(candidates.len());
+
+    #[cfg(target_arch = "x86_64")]
     for (i, candidate) in candidates.iter().enumerate() {
-        #[cfg(target_arch = "x86_64")]
         if i + 4 < candidates.len() {
             // SAFETY: `_mm_prefetch` is a non-faulting cache hint.
             // - Condition 1: pointer originates from a valid slice in `candidates`.
@@ -70,6 +71,12 @@ pub fn batch_dot_product_native(candidates: &[&[f32]], query: &[f32]) -> Vec<f32
         }
         results.push(dot_product_native(candidate, query));
     }
+
+    #[cfg(not(target_arch = "x86_64"))]
+    for candidate in candidates {
+        results.push(dot_product_native(candidate, query));
+    }
+
     results
 }
 

--- a/crates/velesdb-core/src/simd_native/dispatch/hamming.rs
+++ b/crates/velesdb-core/src/simd_native/dispatch/hamming.rs
@@ -76,10 +76,10 @@ fn jaccard_simd(a: &[f32], b: &[f32]) -> f32 {
     crate::simd_native::scalar::jaccard_scalar(a, b)
 }
 
-pub(super) fn resolve_hamming(level: SimdLevel, dim: usize) -> fn(&[f32], &[f32]) -> f32 {
-    match level {
+pub(super) fn resolve_hamming(_level: SimdLevel, _dim: usize) -> fn(&[f32], &[f32]) -> f32 {
+    match _level {
         #[cfg(target_arch = "x86_64")]
-        SimdLevel::Avx512 if dim >= 16 => {
+        SimdLevel::Avx512 if _dim >= 16 => {
             |a, b| {
                 // SAFETY: Resolver emitted AVX-512 implementation for this dimension.
                 // - Condition 1: caller chose this function pointer via `resolve_hamming`.
@@ -88,7 +88,7 @@ pub(super) fn resolve_hamming(level: SimdLevel, dim: usize) -> fn(&[f32], &[f32]
             }
         }
         #[cfg(target_arch = "x86_64")]
-        SimdLevel::Avx2 if dim >= 8 => |a, b| {
+        SimdLevel::Avx2 if _dim >= 8 => |a, b| {
             // SAFETY: Resolver emitted AVX2 implementation for this dimension.
             // - Condition 1: caller chose this function pointer via `resolve_hamming`.
             // Reason: execute AVX2 specialized hamming implementation.
@@ -98,10 +98,10 @@ pub(super) fn resolve_hamming(level: SimdLevel, dim: usize) -> fn(&[f32], &[f32]
     }
 }
 
-pub(super) fn resolve_jaccard(level: SimdLevel, dim: usize) -> fn(&[f32], &[f32]) -> f32 {
-    match level {
+pub(super) fn resolve_jaccard(_level: SimdLevel, _dim: usize) -> fn(&[f32], &[f32]) -> f32 {
+    match _level {
         #[cfg(target_arch = "x86_64")]
-        SimdLevel::Avx512 if dim >= 16 => {
+        SimdLevel::Avx512 if _dim >= 16 => {
             |a, b| {
                 // SAFETY: Resolver emitted AVX-512 implementation for this dimension.
                 // - Condition 1: caller chose this function pointer via `resolve_jaccard`.
@@ -110,7 +110,7 @@ pub(super) fn resolve_jaccard(level: SimdLevel, dim: usize) -> fn(&[f32], &[f32]
             }
         }
         #[cfg(target_arch = "x86_64")]
-        SimdLevel::Avx2 if dim >= 8 => |a, b| {
+        SimdLevel::Avx2 if _dim >= 8 => |a, b| {
             // SAFETY: Resolver emitted AVX2 implementation for this dimension.
             // - Condition 1: caller chose this function pointer via `resolve_jaccard`.
             // Reason: execute AVX2 specialized jaccard implementation.

--- a/crates/velesdb-core/src/simd_native/prefetch.rs
+++ b/crates/velesdb-core/src/simd_native/prefetch.rs
@@ -83,11 +83,11 @@ pub fn prefetch_vector_multi_cache_line(vector: &[f32]) {
         return;
     }
 
-    let vector_bytes = std::mem::size_of_val(vector);
-
     #[cfg(target_arch = "x86_64")]
     {
         use std::arch::x86_64::{_mm_prefetch, _MM_HINT_T0, _MM_HINT_T1, _MM_HINT_T2};
+
+        let vector_bytes = std::mem::size_of_val(vector);
 
         // SAFETY: _mm_prefetch is a hint instruction that cannot cause memory faults.
         // - Condition 1: All pointers are derived from a valid slice reference (non-empty check above)
@@ -123,6 +123,5 @@ pub fn prefetch_vector_multi_cache_line(vector: &[f32]) {
     #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
     {
         let _ = vector;
-        let _ = vector_bytes;
     }
 }


### PR DESCRIPTION
## Summary
- Move `vector_bytes` binding inside `#[cfg(x86_64)]` block in `prefetch.rs` (only used there)
- Split prefetch loop into two cfg-gated loops in `dot.rs` (x86_64 with `i` index vs non-x86_64 without)
- Prefix conditionally-used params with underscore (`_level`, `_dim`) in `hamming.rs` resolvers

Fixes compilation warnings on `aarch64-apple-darwin` that become errors with `-D warnings`.

## Test plan
- [x] `cargo check` passes locally
- [x] `cargo clippy -D warnings` passes locally
- [x] Full test suite passes (pre-push hook)
- [ ] CI validates on aarch64-apple-darwin

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/278" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
