### PR TITLE
fix(release): fix pre-publish validation for workspace crates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,8 +95,16 @@ jobs:
             --exclude velesdb-python -- --test-threads=1
       - name: Verify publish readiness
         run: |
-          for crate in velesdb-core velesdb-server velesdb-cli velesdb-migrate velesdb-mobile tauri-plugin-velesdb; do
-            cargo publish --dry-run -p "$crate"
+          # Only dry-run velesdb-core (no workspace deps) — dependent crates
+          # cannot resolve velesdb-core from crates.io during dry-run since
+          # it hasn't been published yet (chicken-and-egg).
+          # For dependent crates, validate packaging only (--no-verify skips
+          # dependency resolution and build, but checks Cargo.toml and file inclusion).
+          echo "📦 Full dry-run for velesdb-core..."
+          cargo publish --dry-run -p velesdb-core
+          for crate in velesdb-server velesdb-cli velesdb-migrate velesdb-mobile tauri-plugin-velesdb; do
+            echo "📦 Package check for $crate..."
+            cargo package --no-verify -p "$crate"
           done
 
   # ===========================================================================


### PR DESCRIPTION
## Summary
- Fix the chicken-and-egg problem in pre-publish validation where `cargo publish --dry-run` fails for dependent crates because `velesdb-core` isn't yet on crates.io
- Full dry-run only for `velesdb-core` (no workspace deps); `cargo package --no-verify` for dependent crates to validate packaging without registry resolution
- This unblocks crates.io/PyPI/npm publishing in the Release workflow

## Context
The v1.5.1 Release workflow passed all builds and GitHub Release, but the pre-publish validation gate failed, blocking all publishing jobs.

## Test plan
- [ ] Release workflow `validate-all` job passes
- [ ] Publishing jobs are unblocked and execute

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/281" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
