### PR TITLE
fix(release): only dry-run root crate in pre-publish validation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,17 +95,15 @@ jobs:
             --exclude velesdb-python -- --test-threads=1
       - name: Verify publish readiness
         run: |
-          # Only dry-run velesdb-core (no workspace deps) — dependent crates
-          # cannot resolve velesdb-core from crates.io during dry-run since
-          # it hasn't been published yet (chicken-and-egg).
-          # For dependent crates, validate packaging only (--no-verify skips
-          # dependency resolution and build, but checks Cargo.toml and file inclusion).
+          # Only dry-run velesdb-core (root crate, no workspace deps).
+          # Dependent crates cannot be validated here because velesdb-core
+          # ^1.5.x isn't on crates.io yet (chicken-and-egg). They are
+          # validated at actual publish time (with retries) in the
+          # publish-crates job which publishes in dependency order.
           echo "📦 Full dry-run for velesdb-core..."
           cargo publish --dry-run -p velesdb-core
-          for crate in velesdb-server velesdb-cli velesdb-migrate velesdb-mobile tauri-plugin-velesdb; do
-            echo "📦 Package check for $crate..."
-            cargo package --no-verify -p "$crate"
-          done
+          echo "✅ velesdb-core packaging validated"
+          echo "ℹ️  Dependent crates skipped (validated at publish time)"
 
   # ===========================================================================
   # 2. Build Binaries (Linux, Windows, macOS)


### PR DESCRIPTION
## Summary
- `cargo package --no-verify` still resolves registry deps, so dependent crates still fail
- Simplify: only validate `velesdb-core` (root, no workspace deps) with full dry-run
- Dependent crates are validated at actual publish time in the `publish-crates` job (dependency order + retries)

## Context
Follow-up to PR #281. The `--no-verify` flag only skips compilation, not dependency resolution from crates.io.

## Test plan
- [ ] Release workflow `validate-all` job passes
- [ ] Publishing jobs are unblocked

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/282" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
