### PR TITLE
fix(release): fix PyPI wheel publishing for all platforms

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -278,13 +278,23 @@ jobs:
         with:
           target: ${{ matrix.target }}
           working-directory: crates/velesdb-python
-          args: --release --out dist
+          args: --release --out dist -i python3.11
           manylinux: ${{ matrix.manylinux || '' }}
-      - uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # release/v1
+      # gh-action-pypi-publish only runs on Linux; upload wheel directly on other OSes
+      - name: Publish to PyPI (Linux)
+        if: runner.os == 'Linux'
+        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # release/v1
         with:
           packages-dir: crates/velesdb-python/dist/
           password: ${{ secrets.PYPI_API_TOKEN }}
           skip-existing: true
+      - name: Publish to PyPI (non-Linux)
+        if: runner.os != 'Linux'
+        env:
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+        run: |
+          pip install twine
+          twine upload --skip-existing -u __token__ crates/velesdb-python/dist/*
 
   # ===========================================================================
   # 4b. Publish to PyPI — Pure Python packages


### PR DESCRIPTION
## Summary
- Fix maturin "no python interpreter" in Docker/manylinux by adding `-i python3.11`
- Fix Windows publish: `gh-action-pypi-publish` only runs on Linux, use `twine` on other OSes
- langchain/llamaindex 403 is a token scope issue (needs separate PyPI tokens - not fixed here)

## Test plan
- [ ] Re-run Release workflow with `publish_pypi` enabled
- [ ] aarch64 Linux wheels build and publish
- [ ] Windows wheels build and publish via twine

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/283" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
