### PR TITLE
fix(ci): fix fmt ordering and tauri feature parity

### DIFF
--- a/crates/tauri-plugin-velesdb/Cargo.toml
+++ b/crates/tauri-plugin-velesdb/Cargo.toml
@@ -35,6 +35,7 @@ default = ["velesdb-core/default"]
 gpu = ["velesdb-core/gpu"]
 persistence = ["velesdb-core/persistence"]
 update-check = ["velesdb-core/update-check"]
+internal-bench = ["velesdb-core/internal-bench"]
 loom = ["velesdb-core/loom"]
 
 [lints]

--- a/crates/velesdb-core/benches/simd_benchmark.rs
+++ b/crates/velesdb-core/benches/simd_benchmark.rs
@@ -8,12 +8,12 @@
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
 #[cfg(feature = "internal-bench")]
 use velesdb_core::internal_bench;
+#[cfg(feature = "internal-bench")]
+use velesdb_core::simd_native::SimdLevel;
 use velesdb_core::simd_native::{
     cosine_similarity_native, dot_product_native, euclidean_native, hamming_distance_native,
     jaccard_similarity_native, DistanceEngine,
 };
-#[cfg(feature = "internal-bench")]
-use velesdb_core::simd_native::SimdLevel;
 
 fn generate_vector(dim: usize, seed: f32) -> Vec<f32> {
     #[allow(clippy::cast_precision_loss)]


### PR DESCRIPTION
## Fixes CI failures on main (CI #670)

Two unrelated CI failures detected and fixed automatically by VelesDB CI Watcher.

### 1. `cargo fmt` failure — `crates/velesdb-core/benches/simd_benchmark.rs`

Rustfmt requires `#[cfg]`-annotated imports to be ordered consistently. The `use velesdb_core::simd_native::SimdLevel` (with `#[cfg(feature = "internal-bench")]`) was placed **after** the multi-item `use velesdb_core::simd_native::{...}` block. Moved it before to satisfy `cargo fmt --all -- --check`.

### 2. Feature parity test failure — `crates/tauri-plugin-velesdb`

The `internal-bench` feature exists in `velesdb-core` but was not forwarded in `tauri-plugin-velesdb/Cargo.toml`. The feature parity tests (`tauri_plugin_exposes_all_velesdb_core_features`, `tauri_plugin_features_forward_to_velesdb_core`) check that all features are mirrored. Added: `internal-bench = ["velesdb-core/internal-bench"]`.

---
🤖 Applied by **VelesDB CI Watcher** (Cowork automated task)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/291" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
