### PR TITLE
fix(ci): fix clippy and feature parity failures on main

### DIFF
--- a/crates/velesdb-core/src/database/mod.rs
+++ b/crates/velesdb-core/src/database/mod.rs
@@ -3,7 +3,7 @@
 //! This module is split into focused submodules:
 //!
 //! - [`collection_ops`] — Collection CRUD (create, delete, list, get)
-//! - [`query_engine`] — VelesQL query execution, plan caching, DML
+//! - [`query_engine`] — `VelesQL` query execution, plan caching, DML
 //! - [`persistence`] — Loading collections from disk at startup
 //! - [`training`] — `TRAIN QUANTIZER` statement execution
 //! - [`stats`] — Collection statistics (analyze, cache)

--- a/crates/velesdb-core/src/database/training.rs
+++ b/crates/velesdb-core/src/database/training.rs
@@ -1,4 +1,4 @@
-//! `TRAIN QUANTIZER` statement execution (PQ, OPQ, RaBitQ).
+//! `TRAIN QUANTIZER` statement execution (PQ, OPQ, `RaBitQ`).
 
 use crate::{Error, Result, SearchResult, StorageMode};
 
@@ -182,7 +182,7 @@ impl Database {
         )])
     }
 
-    /// Trains a RaBitQ quantizer and persists it.
+    /// Trains a `RaBitQ` quantizer and persists it.
     fn train_rabitq(
         collection: &crate::Collection,
         vectors: &[Vec<f32>],

--- a/crates/velesdb-core/src/index/hnsw/native/tests.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/tests.rs
@@ -961,7 +961,7 @@ fn test_prenormalized_search_distances_are_consistent() {
     // All distances should be in valid range [0, 2] for cosine
     for &(_, dist) in &results {
         assert!(
-            dist.is_finite() && dist >= -1e-6 && dist <= 2.0 + 1e-6,
+            dist.is_finite() && (-1e-6..=2.0 + 1e-6).contains(&dist),
             "Cosine distance {dist} out of valid range"
         );
     }

--- a/crates/velesdb-server/Cargo.toml
+++ b/crates/velesdb-server/Cargo.toml
@@ -42,6 +42,7 @@ utoipa-swagger-ui = { version = "9", features = ["axum"], optional = true }
 [features]
 default = ["velesdb-core/default"]
 gpu = ["velesdb-core/gpu"]
+internal-bench = ["velesdb-core/internal-bench"]
 loom = ["velesdb-core/loom"]
 persistence = ["velesdb-core/persistence"]
 prometheus = []


### PR DESCRIPTION
## Summary

Automated fix for CI #671 failures on `main` after merging PR #291.

**Clippy errors fixed (`cargo clippy --strict`):**
- `crates/velesdb-core/src/database/mod.rs:6` — added backticks around `VelesQL` in doc comment
- `crates/velesdb-core/src/database/training.rs:1` — added backticks around `RaBitQ` in module doc
- `crates/velesdb-core/src/database/training.rs:185` — added backticks around `RaBitQ` in fn doc
- `crates/velesdb-core/src/index/hnsw/native/tests.rs:964` — replaced manual range check with `(-1e-6..=2.0 + 1e-6).contains(&dist)`

**Test failure fixed (`server_exposes_all_core_features`):**
- Added `internal-bench = ["velesdb-core/internal-bench"]` to `crates/velesdb-server/Cargo.toml` so the server exposes all core features as required by the parity test.

Applied by VelesDB CI Watcher (Cowork automated task)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/292" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
