### PR TITLE
fix(ci): remove target-cpu=native from .cargo/config.toml to prevent SIGILL crashes

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -15,40 +15,25 @@ test-all = "test --all-features"
 # | aarch64-unknown-linux| NEON    | cargo build --release --target aarch64-unknown-linux-gnu |
 # =============================================================================
 
-# x86_64 optimizations (Windows/Linux)
-[target.x86_64-pc-windows-msvc]
-rustflags = ["-C", "target-cpu=native", "-C", "opt-level=3"]
-
-[target.x86_64-pc-windows-gnu]
-rustflags = ["-C", "target-cpu=native", "-C", "opt-level=3"]
-
-[target.x86_64-unknown-linux-gnu]
-rustflags = ["-C", "target-cpu=native", "-C", "opt-level=3"]
-
-[target.x86_64-unknown-linux-musl]
-rustflags = ["-C", "target-cpu=native", "-C", "opt-level=3"]
-
-# macOS x86_64 (Intel Macs)
-[target.x86_64-apple-darwin]
-rustflags = ["-C", "target-cpu=native", "-C", "opt-level=3"]
-
-# ARM64/aarch64 optimizations (Apple Silicon, ARM servers)
-[target.aarch64-apple-darwin]
-rustflags = ["-C", "target-cpu=native", "-C", "opt-level=3"]
-
-[target.aarch64-unknown-linux-gnu]
-rustflags = ["-C", "target-cpu=native", "-C", "opt-level=3"]
-
-[target.aarch64-unknown-linux-musl]
-rustflags = ["-C", "target-cpu=native", "-C", "opt-level=3"]
-
 # =============================================================================
-# Portable builds (no native CPU detection, for distribution)
-# Use: RUSTFLAGS="-C target-cpu=x86-64-v3" cargo build --release
+# Per-target rustflags intentionally omitted.
+#
+# target-cpu=native must NOT be committed here: proc-macro dylibs are host
+# binaries executed by rustc during compilation. If they are compiled with
+# native CPU instructions and then restored from a CI cache on a runner with
+# a different CPU, rustc crashes with SIGILL/STATUS_ILLEGAL_INSTRUCTION.
+#
+# Performance flags are handled by [profile.release] and [profile.bench]
+# below (opt-level, lto, codegen-units).
+#
+# To benchmark with full native SIMD locally:
+#   RUSTFLAGS="-C target-cpu=native" cargo bench
+#
+# Portable baseline levels for distribution builds:
+#   x86-64-v2: SSE4.2 (2008+)
+#   x86-64-v3: AVX2 (2013+)  ← recommended
+#   x86-64-v4: AVX-512 (2017+)
 # =============================================================================
-# x86-64-v2: SSE4.2 (2008+)
-# x86-64-v3: AVX2 (2013+) - recommended baseline
-# x86-64-v4: AVX-512 (2017+)
 
 # Build profiles
 [profile.release]

--- a/.github/workflows/compat-matrix.yml
+++ b/.github/workflows/compat-matrix.yml
@@ -7,6 +7,7 @@ on:
       - 'crates/**'
       - 'Cargo.toml'
       - 'Cargo.lock'
+      - '.cargo/config.toml'
       - '.github/workflows/**'
   pull_request:
     branches: [main, develop]
@@ -14,6 +15,7 @@ on:
       - 'crates/**'
       - 'Cargo.toml'
       - 'Cargo.lock'
+      - '.cargo/config.toml'
       - '.github/workflows/**'
 
 env:

--- a/.github/workflows/propagation-guard.yml
+++ b/.github/workflows/propagation-guard.yml
@@ -14,6 +14,7 @@ on:
       - "scripts/**"
       - "Cargo.toml"
       - "Cargo.lock"
+      - ".cargo/config.toml"
       - ".github/workflows/propagation-guard.yml"
   pull_request:
     branches: [main, develop]
@@ -28,6 +29,7 @@ on:
       - "scripts/**"
       - "Cargo.toml"
       - "Cargo.lock"
+      - ".cargo/config.toml"
       - ".github/workflows/propagation-guard.yml"
 
 concurrency:


### PR DESCRIPTION
## Problème

Les jobs **Propagation Guard** (Linux) et **Compatibility Matrix** (Windows) crashaient de façon intermittente avec :
- `error: rustc interrupted by SIGILL` (Linux)
- `STATUS_ILLEGAL_INSTRUCTION` / exit code 101 (Windows)

## Cause racine (5 Pourquoi)

| # | Pourquoi ? | Réponse |
|---|------------|---------|
| 1 | Pourquoi rustc crashe avec SIGILL ? | Il exécute des instructions CPU non supportées sur ce runner |
| 2 | Pourquoi des instructions incompatibles ? | Les proc-macros (`.so`/`.dll`) compilés avec `target-cpu=native` d'un autre runner |
| 3 | Pourquoi ces dylibs sont chargés ? | `Swatinem/rust-cache` restaure le `target/` d'un run précédent |
| 4 | Pourquoi le cache contient des binaires CPU-spécifiques ? | `.cargo/config.toml` appliquait `target-cpu=native` globalement sans override dans ces workflows |
| 5 | Pourquoi `ci.yml` ne crashait pas ? | Il set `RUSTFLAGS: "-Dwarnings"` qui override config.toml — les autres workflows n'avaient pas cet override |

**Les proc-macros sont des host binaries exécutés par rustc, pas par le programme cible.** `target-cpu=native` ne doit jamais être dans un config.toml commité — il rend le cache inter-runners CPU-hétérogène.

## Fix

Suppression des 8 blocs `[target.*.rustflags]` de `.cargo/config.toml`. Les performances sont déjà couvertes par :
- `[profile.release]` : `lto = "thin"`, `codegen-units = 1`
- `[profile.bench]` : `opt-level = 3`

Note : `ci.yml` override déjà `RUSTFLAGS` → les benchmarks CI tournaient déjà **sans** `target-cpu=native`. Ce fix n'affecte pas les résultats de perf CI.

Pour les développeurs qui veulent le SIMD natif en local :
```
RUSTFLAGS="-C target-cpu=native" cargo bench
```

## Checks

- [ ] `Propagation Guard` — Rust Cross-Crate Check (plus de SIGILL)
- [ ] `Compatibility Matrix` — Windows all features (plus de STATUS_ILLEGAL_INSTRUCTION)
- [ ] `Compatibility Matrix` — Linux all features

## Relation avec PR #294

Ce fix est **prérequis** pour PR #294 : le Propagation Guard sur `fix/ci-perf-baseline-and-coverage-2026-03-12` crashait aussi à cause de ce SIGILL. Fusionner ce PR en premier permettra à PR #294 de passer tous ses checks.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/295" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
