### PR TITLE
fix(migrate): fix Pinecone pagination, namespace, and fetch params

### DIFF
--- a/crates/velesdb-migrate/src/connectors/pinecone.rs
+++ b/crates/velesdb-migrate/src/connectors/pinecone.rs
@@ -1,7 +1,7 @@
 //! Pinecone vector database connector.
 
 use async_trait::async_trait;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use std::collections::HashMap;
 use tracing::{debug, info};
 
@@ -72,16 +72,6 @@ struct IndexStats {
     total_vector_count: u64,
 }
 
-#[derive(Debug, Serialize)]
-struct ListRequest {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    namespace: Option<String>,
-    limit: usize,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[serde(rename = "paginationToken")]
-    pagination_token: Option<String>,
-}
-
 #[derive(Debug, Deserialize)]
 struct ListResponse {
     vectors: Option<Vec<VectorInfo>>,
@@ -96,14 +86,6 @@ struct VectorInfo {
 #[derive(Debug, Deserialize)]
 struct Pagination {
     next: Option<String>,
-}
-
-#[derive(Debug, Serialize)]
-#[allow(dead_code)] // Reserved for future use in batch fetch
-struct FetchRequest {
-    ids: Vec<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    namespace: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -224,17 +206,20 @@ impl SourceConnector for PineconeConnector {
         // First, list vector IDs
         let base = self.data_plane_url();
         let list_url = format!("{base}/vectors/list");
-        let _list_req = ListRequest {
-            namespace: self.config.namespace.clone(),
-            limit: batch_size,
-            pagination_token,
-        };
+
+        let mut list_params: Vec<(&str, String)> = vec![("limit", batch_size.to_string())];
+        if let Some(ref token) = pagination_token {
+            list_params.push(("paginationToken", token.clone()));
+        }
+        if let Some(ref ns) = self.config.namespace {
+            list_params.push(("namespace", ns.clone()));
+        }
 
         debug!("Listing Pinecone vectors, limit={}", batch_size);
 
         let resp = self
             .api_request(reqwest::Method::GET, &list_url)
-            .query(&[("limit", batch_size.to_string())])
+            .query(&list_params)
             .send()
             .await?;
 
@@ -263,11 +248,16 @@ impl SourceConnector for PineconeConnector {
             });
         }
 
-        // Fetch full vectors
+        // Fetch full vectors — Pinecone expects repeated `ids` query params
         let fetch_url = format!("{base}/vectors/fetch");
+        let mut fetch_params: Vec<(&str, String)> =
+            ids.iter().map(|id| ("ids", id.clone())).collect();
+        if let Some(ref ns) = self.config.namespace {
+            fetch_params.push(("namespace", ns.clone()));
+        }
         let resp = self
             .api_request(reqwest::Method::GET, &fetch_url)
-            .query(&[("ids", ids.join(","))])
+            .query(&fetch_params)
             .send()
             .await?;
 
@@ -344,17 +334,59 @@ mod tests {
     }
 
     #[test]
-    fn test_list_request_serialization() {
-        let req = ListRequest {
-            namespace: Some("ns1".to_string()),
-            limit: 100,
-            pagination_token: None,
-        };
+    fn test_list_query_params_construction() {
+        let batch_size: usize = 100;
+        let pagination_token: Option<String> = Some("tok-abc".to_string());
+        let namespace: Option<String> = Some("ns1".to_string());
 
-        let json = serde_json::to_string(&req).unwrap();
-        assert!(json.contains("\"limit\":100"));
-        assert!(json.contains("\"namespace\":\"ns1\""));
-        assert!(!json.contains("paginationToken"));
+        let mut params: Vec<(&str, String)> = vec![("limit", batch_size.to_string())];
+        if let Some(ref token) = pagination_token {
+            params.push(("paginationToken", token.clone()));
+        }
+        if let Some(ref ns) = namespace {
+            params.push(("namespace", ns.clone()));
+        }
+
+        assert_eq!(params.len(), 3);
+        assert_eq!(params[0], ("limit", "100".to_string()));
+        assert_eq!(params[1], ("paginationToken", "tok-abc".to_string()));
+        assert_eq!(params[2], ("namespace", "ns1".to_string()));
+    }
+
+    #[test]
+    fn test_list_query_params_without_optional_fields() {
+        let batch_size: usize = 50;
+        let pagination_token: Option<String> = None;
+        let namespace: Option<String> = None;
+
+        let mut params: Vec<(&str, String)> = vec![("limit", batch_size.to_string())];
+        if let Some(ref token) = pagination_token {
+            params.push(("paginationToken", token.clone()));
+        }
+        if let Some(ref ns) = namespace {
+            params.push(("namespace", ns.clone()));
+        }
+
+        assert_eq!(params.len(), 1);
+        assert_eq!(params[0], ("limit", "50".to_string()));
+    }
+
+    #[test]
+    fn test_fetch_query_params_with_namespace() {
+        let ids = vec!["id-1".to_string(), "id-2".to_string(), "id-3".to_string()];
+        let namespace: Option<String> = Some("ns1".to_string());
+
+        let mut fetch_params: Vec<(&str, String)> =
+            ids.iter().map(|id| ("ids", id.clone())).collect();
+        if let Some(ref ns) = namespace {
+            fetch_params.push(("namespace", ns.clone()));
+        }
+
+        assert_eq!(fetch_params.len(), 4);
+        assert_eq!(fetch_params[0], ("ids", "id-1".to_string()));
+        assert_eq!(fetch_params[1], ("ids", "id-2".to_string()));
+        assert_eq!(fetch_params[2], ("ids", "id-3".to_string()));
+        assert_eq!(fetch_params[3], ("namespace", "ns1".to_string()));
     }
 
     #[test]

--- a/crates/velesdb-migrate/src/connectors/qdrant.rs
+++ b/crates/velesdb-migrate/src/connectors/qdrant.rs
@@ -3,7 +3,7 @@
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 
 use super::{ExtractedBatch, ExtractedPoint, SourceConnector, SourceSchema};
 use crate::config::QdrantConfig;
@@ -281,14 +281,23 @@ impl SourceConnector for QdrantConnector {
             .result
             .points
             .into_iter()
-            .map(|p| {
+            .filter_map(|p| {
                 let sparse = p.vector.extract_sparse();
-                ExtractedPoint {
+                let dense = p.vector.into_dense();
+                if dense.is_empty() {
+                    warn!(
+                        point_id = %p.id,
+                        "Skipping point with no dense vector \
+                         (sparse-only points are not supported)"
+                    );
+                    return None;
+                }
+                Some(ExtractedPoint {
                     id: p.id.to_string(),
-                    vector: p.vector.into_dense(),
+                    vector: dense,
                     payload: p.payload.unwrap_or_default(),
                     sparse_vector: sparse,
-                }
+                })
             })
             .collect();
 
@@ -397,5 +406,21 @@ mod tests {
         )]));
 
         assert!(named.extract_sparse().is_none());
+    }
+
+    #[test]
+    fn test_qdrant_sparse_only_into_dense_is_empty() {
+        let json = r#"{"sparse":{"indices":[1,2],"values":[0.5,0.3]}}"#;
+
+        let map: HashMap<String, QdrantNamedVectorValue> =
+            serde_json::from_str(json).expect("valid JSON");
+        let v = QdrantVector::Named(map);
+        assert!(v.extract_sparse().is_some());
+
+        // `into_dense` consumes, so test separately
+        let map2: HashMap<String, QdrantNamedVectorValue> =
+            serde_json::from_str(json).expect("valid JSON");
+        let v2 = QdrantVector::Named(map2);
+        assert!(v2.into_dense().is_empty());
     }
 }


### PR DESCRIPTION
## Summary

Fixes 3 pre-existing bugs in the Pinecone connector and 1 edge case in Qdrant.

### Pinecone (critical)

- **Pagination token never sent** — `_list_req` was dead code; `paginationToken` is now sent as a query parameter, fixing infinite loop on collections larger than `batch_size`
- **Namespace never sent** — list and fetch requests now include `namespace` when configured
- **Fetch IDs format** — changed from `ids=a,b,c` (single comma-separated param) to `ids=a&ids=b&ids=c` (repeated params per Pinecone API spec)
- Removed dead `ListRequest`/`FetchRequest` structs and unused `Serialize` import

### Qdrant (edge case)

- Sparse-only points (no dense vector) now skipped with `tracing::warn` instead of producing an `ExtractedPoint` with empty vector that fails at upsert

## Test plan

- [x] 145 unit tests pass (4 new: 3 Pinecone query param tests + 1 Qdrant sparse-only)
- [x] 14 e2e tests pass (including Pinecone pagination mock)
- [x] `cargo clippy -D warnings -D clippy::pedantic` clean

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/302" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
