### PR TITLE
fix(ci): clippy useless_vec in Pinecone test

### DIFF
--- a/crates/velesdb-migrate/src/connectors/pinecone.rs
+++ b/crates/velesdb-migrate/src/connectors/pinecone.rs
@@ -373,7 +373,7 @@ mod tests {
 
     #[test]
     fn test_fetch_query_params_with_namespace() {
-        let ids = vec!["id-1".to_string(), "id-2".to_string(), "id-3".to_string()];
+        let ids = ["id-1".to_string(), "id-2".to_string(), "id-3".to_string()];
         let namespace: Option<String> = Some("ns1".to_string());
 
         let mut fetch_params: Vec<(&str, String)> =


### PR DESCRIPTION
## Summary

CI Clippy (Rust 1.83) flags `vec!["id-1"...]` as `clippy::useless_vec` when the vec is immediately borrowed via `.iter()`. Replace with array literal.

Fixes the Lint & Format failure on main push CI run.

## Test plan

- [x] 1-line change in test code only
- [x] `cargo clippy -p velesdb-migrate --all-targets -D warnings -D clippy::pedantic` clean locally

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/303" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
