### PR TITLE
fix(ci): gate persistence-dependent code for no-default-features builds

### DIFF
--- a/crates/velesdb-core/Cargo.toml
+++ b/crates/velesdb-core/Cargo.toml
@@ -129,6 +129,7 @@ optional = true
 [[example]]
 name = "crash_driver"
 path = "examples/crash_driver.rs"
+required-features = ["persistence"]
 
 [[bench]]
 name = "search_benchmark"

--- a/crates/velesdb-core/src/lib.rs
+++ b/crates/velesdb-core/src/lib.rs
@@ -110,7 +110,7 @@ pub mod perf_optimizations;
 #[cfg(test)]
 mod perf_optimizations_tests;
 pub mod point;
-#[cfg(test)]
+#[cfg(all(test, feature = "persistence"))]
 mod point_tests;
 pub mod quantization;
 #[cfg(test)]

--- a/crates/velesdb-core/src/lib.rs
+++ b/crates/velesdb-core/src/lib.rs
@@ -110,7 +110,7 @@ pub mod perf_optimizations;
 #[cfg(test)]
 mod perf_optimizations_tests;
 pub mod point;
-#[cfg(all(test, feature = "persistence"))]
+#[cfg(test)]
 mod point_tests;
 pub mod quantization;
 #[cfg(test)]

--- a/crates/velesdb-core/src/point_tests.rs
+++ b/crates/velesdb-core/src/point_tests.rs
@@ -3,7 +3,7 @@
 use std::collections::BTreeMap;
 
 use super::point::*;
-use crate::index::sparse::SparseVector;
+use crate::sparse_index::SparseVector;
 use serde_json::json;
 
 #[test]

--- a/crates/velesdb-core/src/velesql/mod.rs
+++ b/crates/velesdb-core/src/velesql/mod.rs
@@ -33,7 +33,7 @@ mod ast_tests;
 mod cache;
 #[cfg(test)]
 mod cache_tests;
-#[cfg(test)]
+#[cfg(all(test, feature = "persistence"))]
 mod cbo_tests;
 #[cfg(test)]
 mod complex_parser_tests;

--- a/crates/velesdb-core/tests/crash_recovery_tests.rs
+++ b/crates/velesdb-core/tests/crash_recovery_tests.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "persistence")]
 //! Crash recovery integration tests for `VelesDB`.
 //!
 //! These tests verify that `VelesDB` survives abrupt shutdowns without logical corruption.

--- a/crates/velesdb-core/tests/epic_features_integration_tests.rs
+++ b/crates/velesdb-core/tests/epic_features_integration_tests.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "persistence")]
 //! Integration tests for completed EPICs features.
 //!
 //! These tests verify end-to-end functionality of features marked as DONE in EPICs.

--- a/crates/velesdb-core/tests/hybrid_credibility_tests.rs
+++ b/crates/velesdb-core/tests/hybrid_credibility_tests.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "persistence")]
 //! Integration tests proving `VelesDB`'s hybrid query value proposition.
 //!
 //! HYB-01: `VelesQL` NEAR + scalar filter with ranking identity assertions

--- a/crates/velesdb-core/tests/integration_scenarios.rs
+++ b/crates/velesdb-core/tests/integration_scenarios.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "persistence")]
 //! Integration tests for `VelesDB` real-world usage scenarios.
 #![allow(
     clippy::cast_precision_loss,

--- a/crates/velesdb-core/tests/match_similarity_dimension_guard.rs
+++ b/crates/velesdb-core/tests/match_similarity_dimension_guard.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "persistence")]
+
 use std::collections::HashMap;
 
 use serde_json::json;

--- a/crates/velesdb-core/tests/match_where_alias_property.rs
+++ b/crates/velesdb-core/tests/match_where_alias_property.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "persistence")]
+
 use std::collections::HashMap;
 
 use serde_json::json;

--- a/crates/velesdb-core/tests/stress_concurrency_tests.rs
+++ b/crates/velesdb-core/tests/stress_concurrency_tests.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "persistence")]
 //! Stress tests for concurrent Collection operations.
 //!
 //! # Design Decision

--- a/crates/velesdb-core/tests/use_cases_integration_tests.rs
+++ b/crates/velesdb-core/tests/use_cases_integration_tests.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "persistence")]
 //! Integration tests for the 10 hybrid use cases documented in `docs/guides/USE_CASES.md`.
 //!
 //! These tests verify that all documented `VelesQL` queries work correctly and serve


### PR DESCRIPTION
## Summary
- Quality Deep (Miri + Careful) failed for 3 consecutive weeks because tests and examples referenced persistence-gated modules without proper `cfg` attributes
- Gate `cbo_tests` and `point_tests` behind `cfg(feature = "persistence")`
- Add `required-features = ["persistence"]` to `crash_driver` example
- Add `#![cfg(feature = "persistence")]` to 8 integration test files

## Test plan
- [x] `cargo check --no-default-features -p velesdb-core` passes
- [x] `cargo test --no-default-features -p velesdb-core --no-run` passes (no compilation errors)
- [x] `cargo check --features persistence -p velesdb-core` passes
- [x] `cargo test --features persistence -p velesdb-core --no-run` passes
- [x] `cargo clippy --workspace --all-targets --features persistence,gpu,update-check --exclude velesdb-python -- -D warnings -D clippy::pedantic` passes
- [x] `cargo fmt --all -- --check` passes

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/304" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
