### PR TITLE
fix: PR #307 review findings — security + crash guard

### DIFF
--- a/integrations/langchain/src/langchain_velesdb/search_ops.py
+++ b/integrations/langchain/src/langchain_velesdb/search_ops.py
@@ -502,6 +502,11 @@ class SearchOpsMixin:
         if not queries:
             return []
 
+        validate_k(k)
+        validate_batch_size(len(queries))
+        for q in queries:
+            validate_text(q)
+
         query_embeddings = [self._embedding.embed_query(q) for q in queries]
         collection = self._get_collection(len(query_embeddings[0]))
         fusion_strategy = self._build_fusion_strategy(fusion, fusion_params)

--- a/integrations/langchain/src/langchain_velesdb/search_ops.py
+++ b/integrations/langchain/src/langchain_velesdb/search_ops.py
@@ -387,6 +387,10 @@ class SearchOpsMixin:
         """
         if not queries:
             return []
+        validate_k(k)
+        validate_batch_size(len(queries))
+        for q in queries:
+            validate_text(q)
         query_embeddings = [self._embedding.embed_query(q) for q in queries]
         collection = self._get_collection(len(query_embeddings[0]))
         searches = [{"vector": emb, "top_k": k} for emb in query_embeddings]
@@ -411,6 +415,10 @@ class SearchOpsMixin:
         """
         if not queries:
             return []
+        validate_k(k)
+        validate_batch_size(len(queries))
+        for q in queries:
+            validate_text(q)
         query_embeddings = [self._embedding.embed_query(q) for q in queries]
         collection = self._get_collection(len(query_embeddings[0]))
         searches = [{"vector": emb, "top_k": k} for emb in query_embeddings]

--- a/integrations/langchain/src/langchain_velesdb/search_ops.py
+++ b/integrations/langchain/src/langchain_velesdb/search_ops.py
@@ -385,6 +385,8 @@ class SearchOpsMixin:
         Returns:
             List of Document lists, one per query.
         """
+        if not queries:
+            return []
         query_embeddings = [self._embedding.embed_query(q) for q in queries]
         collection = self._get_collection(len(query_embeddings[0]))
         searches = [{"vector": emb, "top_k": k} for emb in query_embeddings]
@@ -407,6 +409,8 @@ class SearchOpsMixin:
         Returns:
             List of (Document, score) tuple lists, one per query.
         """
+        if not queries:
+            return []
         query_embeddings = [self._embedding.embed_query(q) for q in queries]
         collection = self._get_collection(len(query_embeddings[0]))
         searches = [{"vector": emb, "top_k": k} for emb in query_embeddings]

--- a/integrations/llamaindex/src/llamaindex_velesdb/graph_ops.py
+++ b/integrations/llamaindex/src/llamaindex_velesdb/graph_ops.py
@@ -36,7 +36,11 @@ class GraphOpsMixin:
 
         Returns:
             Query result with nodes and similarities.
+
+        Raises:
+            SecurityError: If query fails validation.
         """
+        validate_query(query_str)
         if self._collection is None:
             return VectorStoreQueryResult(nodes=[], similarities=[], ids=[])
         results = self._collection.query(query_str, params)


### PR DESCRIPTION
## Summary
- Add `validate_query()` to LlamaIndex `velesql()` method — security parity with `explain()`, `match_query()`, and LangChain `query()`
- Add empty list guard to LangChain `batch_search()` and `batch_search_with_score()` — prevents `IndexError` on empty queries list

Both were pre-existing bugs surfaced by Devin Review on PR #307.

## Test plan
- [x] `pytest` (LangChain) — verify batch_search([]) returns []
- [x] `pytest` (LlamaIndex) — verify velesql validates input

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/309" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
