### PR TITLE
fix: storage reliability — atomic index swap, WAL replay, Windows crash recovery

### DIFF
--- a/crates/velesdb-core/src/storage/compaction.rs
+++ b/crates/velesdb-core/src/storage/compaction.rs
@@ -198,6 +198,41 @@ fn punch_hole_fallback(file: &File, offset: u64, len: u64) -> io::Result<bool> {
     Ok(false) // No disk space reclaimed, only zeroed
 }
 
+/// Recovers from interrupted compaction on startup.
+///
+/// Issue #318: On Windows, `atomic_replace()` uses a two-step rename
+/// (dst -> `.bak`, src -> dst). A crash between the two leaves either
+/// a `.bak` or `.new` file on disk. This function detects and repairs
+/// such states before the mmap file is opened.
+///
+/// # Recovery Rules
+///
+/// - `.bak` exists, original missing -> restore from `.bak`
+/// - `.bak` exists, original exists -> remove `.bak` (compaction completed)
+/// - `.new` exists -> remove it (incomplete compaction)
+pub fn recover_compaction_artifacts(data_path: &Path) -> io::Result<()> {
+    let bak_path = data_path.with_extension("dat.bak");
+    let new_path = data_path.with_extension("dat.tmp");
+
+    // Handle .bak file
+    if bak_path.exists() {
+        if data_path.exists() {
+            // Both exist: previous compaction completed, clean up backup
+            std::fs::remove_file(&bak_path)?;
+        } else {
+            // Only backup exists: compaction crashed after rename-to-backup
+            std::fs::rename(&bak_path, data_path)?;
+        }
+    }
+
+    // Handle incomplete .tmp file (new data that was never swapped in)
+    if new_path.exists() {
+        std::fs::remove_file(&new_path)?;
+    }
+
+    Ok(())
+}
+
 /// Cross-platform atomic file replacement.
 ///
 /// On Unix, `rename()` atomically replaces the destination.
@@ -353,12 +388,11 @@ impl CompactionContext<'_> {
         // Reason: Reloading mmap is required to switch storage to compacted bytes.
         let new_mmap = unsafe { MmapMut::map_mut(&new_data_file)? };
 
-        // 7. Update internal state (EPIC-033/US-004: Clear and repopulate ShardedIndex)
+        // 7. Update internal state
+        // Issue #316: Atomic index swap — replace mmap and index without
+        // an intermediate empty state visible to concurrent readers.
         *self.mmap.write() = new_mmap;
-        self.index.clear();
-        for (id, offset) in new_index {
-            self.index.insert(id, offset);
-        }
+        self.index.replace_all(new_index);
         self.next_offset.store(new_offset, Ordering::Relaxed);
 
         // 8. Write compaction marker to WAL

--- a/crates/velesdb-core/src/storage/log_payload.rs
+++ b/crates/velesdb-core/src/storage/log_payload.rs
@@ -46,7 +46,7 @@ const DEFAULT_SNAPSHOT_THRESHOLD: u64 = 10 * 1024 * 1024;
 /// Used for snapshot integrity validation.
 #[inline]
 #[allow(clippy::cast_possible_truncation)] // Table index always 0-255
-fn crc32_hash(data: &[u8]) -> u32 {
+pub(crate) fn crc32_hash(data: &[u8]) -> u32 {
     const CRC32_TABLE: [u32; 256] = {
         let mut table = [0u32; 256];
         let mut i = 0;

--- a/crates/velesdb-core/src/storage/mmap.rs
+++ b/crates/velesdb-core/src/storage/mmap.rs
@@ -19,8 +19,9 @@
 //! - Explicit `reserve_capacity()` for bulk imports
 
 mod vector_io;
+mod wal_replay;
 
-use super::compaction::CompactionContext;
+use super::compaction::{self, CompactionContext};
 use super::guard::VectorSliceGuard;
 use super::metrics::StorageMetrics;
 use super::sharded_index::ShardedIndex;
@@ -99,8 +100,12 @@ impl MmapStorage {
         let path = path.as_ref().to_path_buf();
         std::fs::create_dir_all(&path)?;
 
-        // 1. Open/Create Data File
+        // Issue #318: Recover from interrupted compaction artifacts
+        // (.bak/.tmp files) before opening the data file.
         let data_path = path.join("vectors.dat");
+        compaction::recover_compaction_artifacts(&data_path)?;
+
+        // 1. Open/Create Data File
         let data_file = OpenOptions::new()
             .read(true)
             .write(true)
@@ -149,6 +154,21 @@ impl MmapStorage {
         } else {
             (ShardedIndex::new(), 0)
         };
+
+        // Issue #317: Replay WAL to recover writes since last flush.
+        // `mmap` is still a plain MmapMut here (not yet wrapped in RwLock).
+        let mut next_offset = next_offset;
+        let mut mmap = mmap;
+        let replayed = wal_replay::replay_wal_to_index(
+            &wal_path,
+            &index,
+            dimension,
+            &mut mmap,
+            &mut next_offset,
+        )?;
+        if replayed > 0 {
+            mmap.flush()?;
+        }
 
         Ok(Self {
             path,

--- a/crates/velesdb-core/src/storage/mmap/vector_io.rs
+++ b/crates/velesdb-core/src/storage/mmap/vector_io.rs
@@ -10,6 +10,7 @@
 //! `Drop` only performs best-effort sync and must not be relied on as a commit point.
 
 use super::MmapStorage;
+use crate::storage::log_payload::crc32_hash;
 use crate::storage::traits::VectorStorage;
 use crate::storage::vector_bytes::{bytes_to_vector, vector_to_bytes};
 
@@ -17,6 +18,40 @@ use rustc_hash::FxHashMap;
 use std::fs::File;
 use std::io::{self, Write};
 use std::sync::atomic::Ordering;
+
+/// Writes a CRC32-framed store entry to the WAL.
+///
+/// Format: `[op:1][id:8][len:4][data:N][crc32:4]`
+///
+/// The CRC32 covers `op + id + len + data`.
+fn write_wal_store_entry(wal: &mut io::BufWriter<File>, id: u64, data: &[u8]) -> io::Result<()> {
+    let mut frame = Vec::with_capacity(1 + 8 + 4 + data.len());
+    frame.push(1u8);
+    frame.extend_from_slice(&id.to_le_bytes());
+    // Reason: Vector byte length is dimension * 4. With max dimension 65536,
+    // max bytes = 262144 which fits in u32 (max 4,294,967,295).
+    #[allow(clippy::cast_possible_truncation)]
+    let len_u32 = data.len() as u32;
+    frame.extend_from_slice(&len_u32.to_le_bytes());
+    frame.extend_from_slice(data);
+    let crc = crc32_hash(&frame);
+    wal.write_all(&frame)?;
+    wal.write_all(&crc.to_le_bytes())
+}
+
+/// Writes a CRC32-framed delete entry to the WAL.
+///
+/// Format: `[op:1][id:8][crc32:4]`
+///
+/// The CRC32 covers `op + id`.
+fn write_wal_delete_entry(wal: &mut io::BufWriter<File>, id: u64) -> io::Result<()> {
+    let mut frame = Vec::with_capacity(1 + 8);
+    frame.push(2u8);
+    frame.extend_from_slice(&id.to_le_bytes());
+    let crc = crc32_hash(&frame);
+    wal.write_all(&frame)?;
+    wal.write_all(&crc.to_le_bytes())
+}
 
 impl VectorStorage for MmapStorage {
     fn store(&mut self, id: u64, vector: &[f32]) -> io::Result<()> {
@@ -33,18 +68,10 @@ impl VectorStorage for MmapStorage {
 
         let vector_bytes = vector_to_bytes(vector);
 
-        // 1. Write to WAL (append only; durability barrier is `flush()`)
+        // 1. Write to WAL with CRC32 framing (Issue #317)
         {
             let mut wal = self.wal.write();
-            // Op: Store (1) | ID | Len | Data
-            wal.write_all(&[1u8])?;
-            wal.write_all(&id.to_le_bytes())?;
-            // SAFETY: Vector byte length is dimension * 4 bytes. With max dimension 65536,
-            // max bytes = 262144 which fits in u32 (max 4,294,967,295)
-            #[allow(clippy::cast_possible_truncation)]
-            let len_u32 = vector_bytes.len() as u32;
-            wal.write_all(&len_u32.to_le_bytes())?;
-            wal.write_all(vector_bytes)?;
+            write_wal_store_entry(&mut wal, id, vector_bytes)?;
         }
 
         // 2. Determine offset (EPIC-033/US-004: Use sharded index)
@@ -118,27 +145,12 @@ impl VectorStorage for MmapStorage {
                 .fetch_add(total_new_size, Ordering::Relaxed);
         }
 
-        // 3. Single WAL append for entire batch (Op: BatchStore = 3)
+        // 3. WAL append with CRC32 framing per entry (Issue #317)
         {
             let mut wal = self.wal.write();
-            // Batch header: Op(1) | Count(4)
-            wal.write_all(&[3u8])?;
-            // SAFETY: Batch size is limited by memory constraints. In practice, batches
-            // are < 100K vectors which fits in u32 (max 4,294,967,295)
-            #[allow(clippy::cast_possible_truncation)]
-            let count = vectors.len() as u32;
-            wal.write_all(&count.to_le_bytes())?;
-
-            // Write all vectors contiguously
             for &(id, vector) in vectors {
                 let vector_bytes = vector_to_bytes(vector);
-                wal.write_all(&id.to_le_bytes())?;
-                // SAFETY: Vector byte length is dimension * 4 bytes. With max dimension 65536,
-                // max bytes = 262144 which fits in u32 (max 4,294,967,295)
-                #[allow(clippy::cast_possible_truncation)]
-                let len_u32 = vector_bytes.len() as u32;
-                wal.write_all(&len_u32.to_le_bytes())?;
-                wal.write_all(vector_bytes)?;
+                write_wal_store_entry(&mut wal, id, vector_bytes)?;
             }
             // Note: no fsync here, caller controls durability via `flush()`.
         }
@@ -201,12 +213,10 @@ impl VectorStorage for MmapStorage {
     }
 
     fn delete(&mut self, id: u64) -> io::Result<()> {
-        // 1. Write to WAL (durability barrier remains `flush()`)
+        // 1. Write to WAL with CRC32 framing (Issue #317)
         {
             let mut wal = self.wal.write();
-            // Op: Delete (2) | ID
-            wal.write_all(&[2u8])?;
-            wal.write_all(&id.to_le_bytes())?;
+            write_wal_delete_entry(&mut wal, id)?;
         }
 
         // 2. Get offset before removing from index (for hole-punch)

--- a/crates/velesdb-core/src/storage/mmap/wal_replay.rs
+++ b/crates/velesdb-core/src/storage/mmap/wal_replay.rs
@@ -45,39 +45,65 @@ pub(crate) fn replay_wal_to_index(
     mmap_data: &mut [u8],
     next_offset: &mut usize,
 ) -> io::Result<usize> {
-    if !wal_path.exists() {
+    let Some((mut reader, file_len)) = open_crc_wal(wal_path)? else {
         return Ok(0);
-    }
+    };
 
-    let file_len = File::open(wal_path)?.metadata()?.len();
-    if file_len == 0 {
-        return Ok(0);
-    }
-
-    if !is_crc_framed_wal(wal_path, file_len)? {
-        return Ok(0);
-    }
-
-    let mut reader = BufReader::new(File::open(wal_path)?);
     let vector_size = dimension * std::mem::size_of::<f32>();
-    let mut replayed = 0usize;
-
-    while let Ok(true) = replay_one_entry(
+    let replayed = drain_wal_entries(
         &mut reader,
         file_len,
         index,
         mmap_data,
         next_offset,
         vector_size,
-    ) {
-        replayed += 1;
-    }
+    );
 
     if replayed > 0 {
         truncate_wal(wal_path)?;
     }
 
     Ok(replayed)
+}
+
+/// Opens the WAL file and validates it uses CRC32-framed format.
+///
+/// Returns `None` if the file is missing, empty, or uses the legacy format.
+fn open_crc_wal(wal_path: &Path) -> io::Result<Option<(BufReader<File>, u64)>> {
+    if !wal_path.exists() {
+        return Ok(None);
+    }
+
+    let file = File::open(wal_path)?;
+    let file_len = file.metadata()?.len();
+    if file_len == 0 {
+        return Ok(None);
+    }
+
+    if !is_crc_framed_wal(wal_path, file_len)? {
+        return Ok(None);
+    }
+
+    let reader = BufReader::new(File::open(wal_path)?);
+    Ok(Some((reader, file_len)))
+}
+
+/// Replays all valid entries from the WAL, returning the count.
+fn drain_wal_entries(
+    reader: &mut BufReader<File>,
+    file_len: u64,
+    index: &ShardedIndex,
+    mmap_data: &mut [u8],
+    next_offset: &mut usize,
+    vector_size: usize,
+) -> usize {
+    let mut replayed = 0usize;
+    while let Ok(true) = replay_one_entry(
+        reader, file_len, index, mmap_data, next_offset, vector_size,
+    ) {
+        replayed += 1;
+    }
+    replayed
 }
 
 // ---------------------------------------------------------------------------
@@ -182,21 +208,15 @@ fn replay_one_entry(
     }
 }
 
-/// Replays a store entry: validates CRC, writes data to mmap, updates index.
-#[allow(clippy::cast_possible_truncation)]
-fn replay_store(
-    reader: &mut BufReader<File>,
-    index: &ShardedIndex,
-    mmap_data: &mut [u8],
-    next_offset: &mut usize,
-    vector_size: usize,
-) -> io::Result<bool> {
+/// Reads and CRC-validates a store entry from the WAL.
+///
+/// Returns `(id, data)` on success.
+fn read_store_entry(reader: &mut BufReader<File>) -> io::Result<(u64, Vec<u8>)> {
     let mut id_bytes = [0u8; 8];
     let mut len_bytes = [0u8; 4];
     reader.read_exact(&mut id_bytes)?;
     reader.read_exact(&mut len_bytes)?;
 
-    let id = u64::from_le_bytes(id_bytes);
     let data_len = usize::try_from(u32::from_le_bytes(len_bytes))
         .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "data_len overflow"))?;
 
@@ -206,33 +226,68 @@ fn replay_store(
     let mut stored_crc = [0u8; 4];
     reader.read_exact(&mut stored_crc)?;
 
-    // Validate CRC
-    let mut frame = Vec::with_capacity(1 + 8 + 4 + data_len);
+    verify_store_crc(id_bytes, len_bytes, &data, stored_crc)?;
+
+    Ok((u64::from_le_bytes(id_bytes), data))
+}
+
+/// Verifies the CRC32 of a store WAL frame.
+fn verify_store_crc(
+    id_bytes: [u8; 8],
+    len_bytes: [u8; 4],
+    data: &[u8],
+    stored_crc: [u8; 4],
+) -> io::Result<()> {
+    let mut frame = Vec::with_capacity(1 + 8 + 4 + data.len());
     frame.push(1u8);
     frame.extend_from_slice(&id_bytes);
     frame.extend_from_slice(&len_bytes);
-    frame.extend_from_slice(&data);
+    frame.extend_from_slice(data);
 
-    if crc32_hash(&frame) != u32::from_le_bytes(stored_crc) {
-        return Err(io::Error::new(io::ErrorKind::InvalidData, "CRC mismatch"));
+    if crc32_hash(&frame) == u32::from_le_bytes(stored_crc) {
+        Ok(())
+    } else {
+        Err(io::Error::new(io::ErrorKind::InvalidData, "CRC mismatch"))
     }
+}
 
-    // Apply: only if data matches expected vector size
-    if data_len == vector_size {
-        let offset = index.get(id).unwrap_or_else(|| {
-            let off = *next_offset;
-            *next_offset += vector_size;
-            off
-        });
+/// Replays a store entry: validates CRC, writes data to mmap, updates index.
+fn replay_store(
+    reader: &mut BufReader<File>,
+    index: &ShardedIndex,
+    mmap_data: &mut [u8],
+    next_offset: &mut usize,
+    vector_size: usize,
+) -> io::Result<bool> {
+    let (id, data) = read_store_entry(reader)?;
 
-        let end = offset + vector_size;
-        if end <= mmap_data.len() {
-            mmap_data[offset..end].copy_from_slice(&data);
-            index.insert(id, offset);
-        }
+    if data.len() == vector_size {
+        apply_store_to_mmap(id, &data, index, mmap_data, next_offset, vector_size);
     }
 
     Ok(true)
+}
+
+/// Writes vector data into the mmap region and updates the index.
+fn apply_store_to_mmap(
+    id: u64,
+    data: &[u8],
+    index: &ShardedIndex,
+    mmap_data: &mut [u8],
+    next_offset: &mut usize,
+    vector_size: usize,
+) {
+    let offset = index.get(id).unwrap_or_else(|| {
+        let off = *next_offset;
+        *next_offset += vector_size;
+        off
+    });
+
+    let end = offset + vector_size;
+    if end <= mmap_data.len() {
+        mmap_data[offset..end].copy_from_slice(data);
+        index.insert(id, offset);
+    }
 }
 
 /// Replays a delete entry: validates CRC, removes id from index.

--- a/crates/velesdb-core/src/storage/mmap/wal_replay.rs
+++ b/crates/velesdb-core/src/storage/mmap/wal_replay.rs
@@ -1,0 +1,265 @@
+//! WAL replay for `MmapStorage` crash recovery.
+//!
+//! Issue #317: On crash, WAL data written since the last `flush()` would be
+//! lost because the index file (`vectors.idx`) only reflects the last
+//! flushed state. This module replays WAL entries to recover those writes.
+//!
+//! # WAL Format (CRC32-framed, Issue #317)
+//!
+//! ```text
+//! Store:  [op=1: 1B] [id: 8B LE] [len: 4B LE] [data: len B] [crc32: 4B LE]
+//! Delete: [op=2: 1B] [id: 8B LE] [crc32: 4B LE]
+//! ```
+//!
+//! # Legacy WAL Format (pre-#317, no CRC)
+//!
+//! Detected by validating the CRC of the first entry. If validation fails,
+//! the file is legacy format and replay is skipped (the persisted index is
+//! authoritative for legacy data).
+
+use crate::storage::log_payload::crc32_hash;
+use crate::storage::sharded_index::ShardedIndex;
+
+use std::fs::{File, OpenOptions};
+use std::io::{self, BufReader, Read, Seek};
+use std::path::Path;
+
+/// Minimum store entry size: op(1) + id(8) + len(4) + crc(4) = 17.
+const MIN_STORE_ENTRY: usize = 17;
+/// Delete entry size: op(1) + id(8) + crc(4) = 13.
+const DELETE_ENTRY_SIZE: usize = 13;
+
+/// Replays CRC32-framed WAL entries into the sharded index and mmap.
+///
+/// Skips legacy (non-CRC) WAL files. Truncates the WAL after a
+/// successful replay so entries are not replayed twice.
+///
+/// # Returns
+///
+/// Number of WAL entries successfully replayed.
+#[allow(clippy::module_name_repetitions)]
+pub(crate) fn replay_wal_to_index(
+    wal_path: &Path,
+    index: &ShardedIndex,
+    dimension: usize,
+    mmap_data: &mut [u8],
+    next_offset: &mut usize,
+) -> io::Result<usize> {
+    if !wal_path.exists() {
+        return Ok(0);
+    }
+
+    let file_len = File::open(wal_path)?.metadata()?.len();
+    if file_len == 0 {
+        return Ok(0);
+    }
+
+    if !is_crc_framed_wal(wal_path, file_len)? {
+        return Ok(0);
+    }
+
+    let mut reader = BufReader::new(File::open(wal_path)?);
+    let vector_size = dimension * std::mem::size_of::<f32>();
+    let mut replayed = 0usize;
+
+    while let Ok(true) = replay_one_entry(
+        &mut reader,
+        file_len,
+        index,
+        mmap_data,
+        next_offset,
+        vector_size,
+    ) {
+        replayed += 1;
+    }
+
+    if replayed > 0 {
+        truncate_wal(wal_path)?;
+    }
+
+    Ok(replayed)
+}
+
+// ---------------------------------------------------------------------------
+// Format Detection
+// ---------------------------------------------------------------------------
+
+/// Returns `true` if the WAL uses CRC32-framed entries.
+fn is_crc_framed_wal(wal_path: &Path, file_len: u64) -> io::Result<bool> {
+    let min_size = MIN_STORE_ENTRY.min(DELETE_ENTRY_SIZE) as u64;
+    if file_len < min_size {
+        return Ok(false);
+    }
+
+    let mut reader = BufReader::new(File::open(wal_path)?);
+    let mut op = [0u8; 1];
+    if reader.read_exact(&mut op).is_err() {
+        return Ok(false);
+    }
+
+    match op[0] {
+        1 => validate_first_store_crc(&mut reader),
+        2 => Ok(validate_first_delete_crc(&mut reader)),
+        _ => Ok(false),
+    }
+}
+
+/// Validates the CRC of the first store entry.
+fn validate_first_store_crc(reader: &mut BufReader<File>) -> io::Result<bool> {
+    let mut id_bytes = [0u8; 8];
+    let mut len_bytes = [0u8; 4];
+    if reader.read_exact(&mut id_bytes).is_err() || reader.read_exact(&mut len_bytes).is_err() {
+        return Ok(false);
+    }
+
+    let data_len = usize::try_from(u32::from_le_bytes(len_bytes))
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "data_len overflow"))?;
+
+    let mut data = vec![0u8; data_len];
+    if reader.read_exact(&mut data).is_err() {
+        return Ok(false);
+    }
+
+    let mut stored_crc = [0u8; 4];
+    if reader.read_exact(&mut stored_crc).is_err() {
+        return Ok(false);
+    }
+
+    let mut frame = Vec::with_capacity(1 + 8 + 4 + data_len);
+    frame.push(1u8);
+    frame.extend_from_slice(&id_bytes);
+    frame.extend_from_slice(&len_bytes);
+    frame.extend_from_slice(&data);
+
+    Ok(crc32_hash(&frame) == u32::from_le_bytes(stored_crc))
+}
+
+/// Validates the CRC of the first delete entry.
+fn validate_first_delete_crc(reader: &mut BufReader<File>) -> bool {
+    let mut id_bytes = [0u8; 8];
+    if reader.read_exact(&mut id_bytes).is_err() {
+        return false;
+    }
+
+    let mut stored_crc = [0u8; 4];
+    if reader.read_exact(&mut stored_crc).is_err() {
+        return false;
+    }
+
+    let mut frame = Vec::with_capacity(1 + 8);
+    frame.push(2u8);
+    frame.extend_from_slice(&id_bytes);
+
+    crc32_hash(&frame) == u32::from_le_bytes(stored_crc)
+}
+
+// ---------------------------------------------------------------------------
+// Entry Replay
+// ---------------------------------------------------------------------------
+
+/// Replays one WAL entry. Returns `Ok(true)` on success, `Ok(false)` at EOF.
+fn replay_one_entry(
+    reader: &mut BufReader<File>,
+    file_len: u64,
+    index: &ShardedIndex,
+    mmap_data: &mut [u8],
+    next_offset: &mut usize,
+    vector_size: usize,
+) -> io::Result<bool> {
+    if reader.stream_position()? >= file_len {
+        return Ok(false);
+    }
+
+    let mut op = [0u8; 1];
+    if reader.read_exact(&mut op).is_err() {
+        return Ok(false);
+    }
+
+    match op[0] {
+        1 => replay_store(reader, index, mmap_data, next_offset, vector_size),
+        2 => replay_delete(reader, index),
+        _ => Err(io::Error::new(io::ErrorKind::InvalidData, "unknown WAL op")),
+    }
+}
+
+/// Replays a store entry: validates CRC, writes data to mmap, updates index.
+#[allow(clippy::cast_possible_truncation)]
+fn replay_store(
+    reader: &mut BufReader<File>,
+    index: &ShardedIndex,
+    mmap_data: &mut [u8],
+    next_offset: &mut usize,
+    vector_size: usize,
+) -> io::Result<bool> {
+    let mut id_bytes = [0u8; 8];
+    let mut len_bytes = [0u8; 4];
+    reader.read_exact(&mut id_bytes)?;
+    reader.read_exact(&mut len_bytes)?;
+
+    let id = u64::from_le_bytes(id_bytes);
+    let data_len = usize::try_from(u32::from_le_bytes(len_bytes))
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "data_len overflow"))?;
+
+    let mut data = vec![0u8; data_len];
+    reader.read_exact(&mut data)?;
+
+    let mut stored_crc = [0u8; 4];
+    reader.read_exact(&mut stored_crc)?;
+
+    // Validate CRC
+    let mut frame = Vec::with_capacity(1 + 8 + 4 + data_len);
+    frame.push(1u8);
+    frame.extend_from_slice(&id_bytes);
+    frame.extend_from_slice(&len_bytes);
+    frame.extend_from_slice(&data);
+
+    if crc32_hash(&frame) != u32::from_le_bytes(stored_crc) {
+        return Err(io::Error::new(io::ErrorKind::InvalidData, "CRC mismatch"));
+    }
+
+    // Apply: only if data matches expected vector size
+    if data_len == vector_size {
+        let offset = index.get(id).unwrap_or_else(|| {
+            let off = *next_offset;
+            *next_offset += vector_size;
+            off
+        });
+
+        let end = offset + vector_size;
+        if end <= mmap_data.len() {
+            mmap_data[offset..end].copy_from_slice(&data);
+            index.insert(id, offset);
+        }
+    }
+
+    Ok(true)
+}
+
+/// Replays a delete entry: validates CRC, removes id from index.
+fn replay_delete(reader: &mut BufReader<File>, index: &ShardedIndex) -> io::Result<bool> {
+    let mut id_bytes = [0u8; 8];
+    reader.read_exact(&mut id_bytes)?;
+
+    let mut stored_crc = [0u8; 4];
+    reader.read_exact(&mut stored_crc)?;
+
+    // Validate CRC
+    let mut frame = Vec::with_capacity(1 + 8);
+    frame.push(2u8);
+    frame.extend_from_slice(&id_bytes);
+
+    if crc32_hash(&frame) != u32::from_le_bytes(stored_crc) {
+        return Err(io::Error::new(io::ErrorKind::InvalidData, "CRC mismatch"));
+    }
+
+    let id = u64::from_le_bytes(id_bytes);
+    index.remove(id);
+    Ok(true)
+}
+
+/// Truncates WAL after successful replay.
+fn truncate_wal(wal_path: &Path) -> io::Result<()> {
+    let file = OpenOptions::new().write(true).open(wal_path)?;
+    file.set_len(0)?;
+    file.sync_all()
+}

--- a/crates/velesdb-core/src/storage/mod.rs
+++ b/crates/velesdb-core/src/storage/mod.rs
@@ -37,6 +37,8 @@ mod loom_tests;
 #[cfg(test)]
 mod metrics_tests;
 #[cfg(test)]
+mod storage_reliability_tests;
+#[cfg(test)]
 mod tests;
 #[cfg(test)]
 mod wal_recovery_tests;

--- a/crates/velesdb-core/src/storage/sharded_index.rs
+++ b/crates/velesdb-core/src/storage/sharded_index.rs
@@ -120,10 +120,39 @@ impl ShardedIndex {
     }
 
     /// Clears all entries from all shards.
+    #[allow(dead_code)] // API completeness; production code uses replace_all()
     pub fn clear(&self) {
         for shard in &self.shards {
             shard.write().entries.clear();
         }
+    }
+
+    /// Atomically replaces all entries in the index.
+    ///
+    /// Locks all 16 shards simultaneously in deterministic order (0..15),
+    /// clears them, and repopulates from the provided map in a single
+    /// critical section. This prevents concurrent readers from seeing an
+    /// intermediate empty state during compaction.
+    ///
+    /// # Issue #316
+    ///
+    /// Without this, `clear()` + per-entry `insert()` creates a window
+    /// where readers see `None` for valid IDs.
+    pub fn replace_all(&self, new_entries: FxHashMap<u64, usize>) {
+        // Lock all shards in deterministic order to prevent deadlocks
+        let mut guards: Vec<_> = self.shards.iter().map(RwLock::write).collect();
+
+        // Clear all shards under the combined lock
+        for guard in &mut guards {
+            guard.entries.clear();
+        }
+
+        // Repopulate from new entries
+        for (id, offset) in new_entries {
+            let shard_idx = Self::shard_index(id);
+            guards[shard_idx].entries.insert(id, offset);
+        }
+        // All guards dropped here, releasing locks simultaneously
     }
 
     /// Collects all IDs from all shards.

--- a/crates/velesdb-core/src/storage/storage_reliability_tests.rs
+++ b/crates/velesdb-core/src/storage/storage_reliability_tests.rs
@@ -1,0 +1,354 @@
+#![allow(
+    clippy::cast_precision_loss,
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    clippy::float_cmp
+)]
+//! Tests for storage reliability fixes (Issues #316, #317, #318).
+
+use super::sharded_index::ShardedIndex;
+use super::*;
+use rustc_hash::FxHashMap;
+use std::io::Write as _;
+use std::sync::Arc;
+use tempfile::tempdir;
+
+// ===========================================================================
+// Issue #316: Atomic index swap during compaction
+// ===========================================================================
+
+#[test]
+fn test_replace_all_atomic_no_intermediate_empty() {
+    // Verify that replace_all swaps all entries atomically:
+    // a concurrent reader should never see an empty index while
+    // replace_all is in progress.
+    let index = Arc::new(ShardedIndex::new());
+
+    // Populate initial state
+    for i in 0..100u64 {
+        index.insert(i, i as usize * 16);
+    }
+
+    // Build replacement map
+    let mut new_entries: FxHashMap<u64, usize> = FxHashMap::default();
+    for i in 0..100u64 {
+        new_entries.insert(i, i as usize * 32);
+    }
+
+    // Perform atomic replace
+    index.replace_all(new_entries);
+
+    // After replace_all, all entries should have new offsets
+    for i in 0..100u64 {
+        assert_eq!(
+            index.get(i),
+            Some(i as usize * 32),
+            "ID {i} should have updated offset after replace_all"
+        );
+    }
+    assert_eq!(index.len(), 100);
+}
+
+#[test]
+fn test_replace_all_with_empty_map_clears_index() {
+    let index = ShardedIndex::new();
+    for i in 0..50u64 {
+        index.insert(i, i as usize * 8);
+    }
+
+    index.replace_all(FxHashMap::default());
+    assert!(
+        index.is_empty(),
+        "replace_all with empty map should clear index"
+    );
+}
+
+#[test]
+fn test_replace_all_concurrent_reader_sees_consistent_state() {
+    // Spawn a reader thread that continuously checks index consistency
+    // (either all old values or all new values, never a mix with empty).
+    let index = Arc::new(ShardedIndex::new());
+    for i in 0..64u64 {
+        index.insert(i, i as usize * 10);
+    }
+
+    let reader_index = Arc::clone(&index);
+    let reader = std::thread::spawn(move || {
+        for _ in 0..10_000 {
+            let mut found = 0usize;
+            let mut missing = 0usize;
+            for i in 0..64u64 {
+                if reader_index.get(i).is_some() {
+                    found += 1;
+                } else {
+                    missing += 1;
+                }
+            }
+            // With atomic replace_all, we should never see a partially
+            // empty state — either all found or (transiently) all missing
+            // during the swap. In practice, the reader should always see
+            // all 64 entries because replace_all holds all shard locks.
+            assert!(
+                found == 64 || found == 0,
+                "Inconsistent state: found={found}, missing={missing}"
+            );
+        }
+    });
+
+    // Meanwhile, do many replace_all cycles
+    for cycle in 0..100u64 {
+        let mut new_entries: FxHashMap<u64, usize> = FxHashMap::default();
+        for i in 0..64u64 {
+            new_entries.insert(i, (cycle * 64 + i) as usize);
+        }
+        index.replace_all(new_entries);
+    }
+
+    reader.join().expect("reader thread should not panic");
+}
+
+#[test]
+fn test_compaction_uses_atomic_swap() {
+    // End-to-end: store, delete, compact — verify no data loss.
+    let dir = tempdir().unwrap();
+    let dim = 4;
+    let mut storage = MmapStorage::new(dir.path(), dim).unwrap();
+
+    for i in 0u64..20 {
+        storage.store(i, &[i as f32; 4]).unwrap();
+    }
+    for i in 0u64..10 {
+        storage.delete(i).unwrap();
+    }
+
+    let reclaimed = storage.compact().unwrap();
+    assert!(reclaimed > 0);
+
+    // All surviving vectors accessible
+    for i in 10u64..20 {
+        let v = storage.retrieve(i).unwrap();
+        assert_eq!(v, Some(vec![i as f32; 4]));
+    }
+}
+
+// ===========================================================================
+// Issue #317: WAL replay for MmapStorage crash recovery
+// ===========================================================================
+
+#[test]
+fn test_wal_replay_recovers_unflushed_stores() {
+    // Simulate crash: store vectors, do NOT call flush(), drop, reopen.
+    // The new CRC-framed WAL should allow recovery.
+    let dir = tempdir().unwrap();
+    let path = dir.path().to_path_buf();
+    let dim = 3;
+
+    {
+        let mut storage = MmapStorage::new(&path, dim).unwrap();
+        storage.store(1, &[1.0, 2.0, 3.0]).unwrap();
+        storage.store(2, &[4.0, 5.0, 6.0]).unwrap();
+
+        // Flush WAL to disk but do NOT call storage.flush() (which persists index)
+        storage.wal.write().flush().unwrap();
+        storage.wal.write().get_ref().sync_all().unwrap();
+        // Flush mmap too so vector bytes are on disk
+        storage.mmap.write().flush().unwrap();
+
+        // Do NOT call storage.flush() — simulates crash before index persistence
+    }
+
+    // Reopen — WAL replay should recover vectors
+    let storage = MmapStorage::new(&path, dim).unwrap();
+    let v1 = storage.retrieve(1).unwrap();
+    let v2 = storage.retrieve(2).unwrap();
+    assert_eq!(
+        v1,
+        Some(vec![1.0, 2.0, 3.0]),
+        "Vector 1 should be recovered from WAL"
+    );
+    assert_eq!(
+        v2,
+        Some(vec![4.0, 5.0, 6.0]),
+        "Vector 2 should be recovered from WAL"
+    );
+}
+
+#[test]
+fn test_wal_replay_recovers_deletes() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().to_path_buf();
+    let dim = 3;
+
+    {
+        let mut storage = MmapStorage::new(&path, dim).unwrap();
+        storage.store(1, &[1.0, 2.0, 3.0]).unwrap();
+        storage.store(2, &[4.0, 5.0, 6.0]).unwrap();
+        storage.flush().unwrap(); // Persist both to index
+
+        // Now delete one — written to WAL but NOT flushed to index
+        storage.delete(1).unwrap();
+        storage.wal.write().flush().unwrap();
+        storage.wal.write().get_ref().sync_all().unwrap();
+        // Do NOT call storage.flush() — crash
+    }
+
+    let storage = MmapStorage::new(&path, dim).unwrap();
+    assert!(
+        storage.retrieve(1).unwrap().is_none(),
+        "Deleted vector should not be recoverable"
+    );
+    assert_eq!(
+        storage.retrieve(2).unwrap(),
+        Some(vec![4.0, 5.0, 6.0]),
+        "Non-deleted vector should survive"
+    );
+}
+
+#[test]
+fn test_wal_replay_skips_legacy_format() {
+    // Write a legacy-format WAL (no CRC) and verify replay skips it.
+    let dir = tempdir().unwrap();
+    let path = dir.path().to_path_buf();
+    std::fs::create_dir_all(&path).unwrap();
+
+    // Create an index with one entry
+    let mut index: FxHashMap<u64, usize> = FxHashMap::default();
+    index.insert(1, 0);
+    let index_bytes = postcard::to_allocvec(&index).unwrap();
+    std::fs::write(path.join("vectors.idx"), &index_bytes).unwrap();
+
+    // Create data file with a vector at offset 0
+    let data_path = path.join("vectors.dat");
+    let dim = 3;
+    let vector_bytes: Vec<u8> = [1.0f32, 2.0, 3.0]
+        .iter()
+        .flat_map(|f| f.to_le_bytes())
+        .collect();
+    let mut data = vec![0u8; 16 * 1024 * 1024]; // 16MB initial
+    data[..vector_bytes.len()].copy_from_slice(&vector_bytes);
+    std::fs::write(&data_path, &data).unwrap();
+
+    // Write legacy WAL (no CRC): op=1, id=2, len, data
+    let mut wal = Vec::new();
+    wal.push(1u8);
+    wal.extend_from_slice(&2u64.to_le_bytes());
+    let vec_bytes: Vec<u8> = [7.0f32, 8.0, 9.0]
+        .iter()
+        .flat_map(|f| f.to_le_bytes())
+        .collect();
+    wal.extend_from_slice(&(vec_bytes.len() as u32).to_le_bytes());
+    wal.extend_from_slice(&vec_bytes);
+    // No CRC appended — legacy format
+    std::fs::write(path.join("vectors.wal"), &wal).unwrap();
+
+    // Open storage — legacy WAL should be skipped, only index data survives
+    let storage = MmapStorage::new(&path, dim).unwrap();
+    assert_eq!(storage.len(), 1, "Only indexed entry should exist");
+    assert!(
+        storage.retrieve(2).unwrap().is_none(),
+        "Legacy WAL entry should not be replayed"
+    );
+}
+
+#[test]
+fn test_wal_replay_truncates_after_success() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().to_path_buf();
+    let dim = 3;
+
+    {
+        let mut storage = MmapStorage::new(&path, dim).unwrap();
+        storage.store(1, &[1.0, 2.0, 3.0]).unwrap();
+        storage.wal.write().flush().unwrap();
+        storage.wal.write().get_ref().sync_all().unwrap();
+        storage.mmap.write().flush().unwrap();
+    }
+
+    // Reopen triggers replay
+    let _storage = MmapStorage::new(&path, dim).unwrap();
+
+    // WAL should be truncated after replay
+    let wal_len = std::fs::metadata(path.join("vectors.wal")).unwrap().len();
+    assert_eq!(
+        wal_len, 0,
+        "WAL should be truncated after successful replay"
+    );
+}
+
+// ===========================================================================
+// Issue #318: Windows atomic_replace crash-safety (.bak recovery)
+// ===========================================================================
+
+#[test]
+fn test_bak_recovery_restores_from_backup() {
+    // Simulate: original gone, .bak exists -> restore from .bak
+    let dir = tempdir().unwrap();
+    let path = dir.path().to_path_buf();
+    std::fs::create_dir_all(&path).unwrap();
+
+    let data_path = path.join("vectors.dat");
+    let bak_path = path.join("vectors.dat.bak");
+
+    // Create a valid data file as the backup
+    let dim = 3;
+    let data = vec![0u8; 16 * 1024 * 1024];
+    std::fs::write(&bak_path, &data).unwrap();
+
+    // Create empty index and WAL
+    std::fs::write(path.join("vectors.wal"), b"").unwrap();
+
+    // No vectors.dat exists — should be restored from .bak
+    assert!(!data_path.exists());
+    assert!(bak_path.exists());
+
+    let storage = MmapStorage::new(&path, dim).unwrap();
+    assert_eq!(storage.len(), 0); // Empty but opened successfully
+    assert!(
+        data_path.exists(),
+        "vectors.dat should be restored from .bak"
+    );
+    assert!(!bak_path.exists(), ".bak should be cleaned up");
+}
+
+#[test]
+fn test_bak_recovery_removes_stale_backup() {
+    // Simulate: both original and .bak exist -> remove .bak
+    let dir = tempdir().unwrap();
+    let path = dir.path().to_path_buf();
+    std::fs::create_dir_all(&path).unwrap();
+
+    let data_path = path.join("vectors.dat");
+    let bak_path = path.join("vectors.dat.bak");
+
+    let data = vec![0u8; 16 * 1024 * 1024];
+    std::fs::write(&data_path, &data).unwrap();
+    std::fs::write(&bak_path, &data).unwrap();
+
+    // Create empty WAL
+    std::fs::write(path.join("vectors.wal"), b"").unwrap();
+
+    let _storage = MmapStorage::new(&path, 3).unwrap();
+    assert!(
+        !bak_path.exists(),
+        ".bak should be removed when original exists"
+    );
+}
+
+#[test]
+fn test_tmp_recovery_removes_incomplete_compaction() {
+    // Simulate: .tmp file from incomplete compaction -> remove it
+    let dir = tempdir().unwrap();
+    let path = dir.path().to_path_buf();
+    std::fs::create_dir_all(&path).unwrap();
+
+    let data_path = path.join("vectors.dat");
+    let tmp_path = path.join("vectors.dat.tmp");
+
+    let data = vec![0u8; 16 * 1024 * 1024];
+    std::fs::write(&data_path, &data).unwrap();
+    std::fs::write(&tmp_path, b"incomplete compaction data").unwrap();
+    std::fs::write(path.join("vectors.wal"), b"").unwrap();
+
+    let _storage = MmapStorage::new(&path, 3).unwrap();
+    assert!(!tmp_path.exists(), ".tmp should be removed on startup");
+}


### PR DESCRIPTION
## Summary

Implements 3 storage reliability improvements identified during the concurrency audit (PR #315).

- **Closes #316**: Add `ShardedIndex::replace_all()` for atomic compaction index swap — locks all 16 shards in deterministic order, clears and repopulates in one critical section. Concurrent readers never see an intermediate empty state.
- **Closes #317**: Implement WAL replay with CRC32 framing for `MmapStorage` crash recovery — store/delete WAL entries now include CRC32 checksums. On startup, `MmapStorage::new()` replays unflushed WAL entries to recover data after crash. Legacy (non-CRC) WAL files are detected and skipped for backward compatibility.
- **Closes #318**: Add `.bak` file recovery in `MmapStorage::new()` for Windows crash safety — handles 3 crash states: restore from `.bak`, cleanup stale `.bak`, cleanup incomplete `.tmp`.

## Files changed

- `storage/sharded_index.rs` — `replace_all()` method
- `storage/compaction.rs` — atomic swap + `recover_compaction_artifacts()`
- `storage/mmap/vector_io.rs` — CRC32-framed WAL entries
- `storage/mmap/wal_replay.rs` — NEW: WAL replay engine
- `storage/mmap.rs` — startup recovery calls
- `storage/log_payload.rs` — `crc32_hash()` made `pub(crate)`
- `storage/storage_reliability_tests.rs` — 11 new tests

## Test plan

- [x] `cargo check --workspace` passes
- [x] `cargo clippy --pedantic` passes
- [x] 156 storage tests pass (11 new + 145 existing)
- [x] WAL replay backward compat with legacy format
- [ ] Linux CI (GitHub Actions on push to main)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/319" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
