### PR TITLE
feat: P1-P2 production-ready — coverage 80%+, API, docs, Python SDK, SIMD

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -1,0 +1,70 @@
+---
+# =============================================================================
+# VelesDB — Codacy Repository Configuration
+# =============================================================================
+#
+# This file configures Codacy static analysis exclusions to eliminate
+# known false positives while preserving all legitimate quality checks.
+#
+# Policy: Every exclusion must have a documented rationale.
+# Review this file when adding new modules that use unsafe code.
+#
+# Maintainer: Tech Lead
+# Last reviewed: 2026-03-16
+# =============================================================================
+
+# ---------------------------------------------------------------------------
+# Global exclusions — files excluded from ALL Codacy tools
+# ---------------------------------------------------------------------------
+# Rationale: Test files, benchmarks, and generated code follow different
+# quality standards (complexity, line count, unsafe usage in test harnesses).
+# Test quality is enforced by CI (`cargo test`) not static analysis.
+exclude_paths:
+  # Test files (Rust naming convention: *_tests.rs)
+  - "crates/**/src/**/*_tests.rs"
+  # Integration test directories
+  - "crates/**/tests/**"
+  # Benchmark harnesses (criterion)
+  - "crates/**/benches/**"
+  # Generated code (pest parser, build scripts)
+  - "crates/**/build.rs"
+  # Conformance test data
+  - "conformance/**"
+  # Demo/example apps (not production code)
+  - "demos/**"
+  # Documentation assets
+  - "docs/**"
+  # Scripts (CI, tooling — validated by shellcheck separately)
+  - "scripts/**"
+  # SDK tests
+  - "sdks/**/tests/**"
+  - "sdks/**/__tests__/**"
+
+# ---------------------------------------------------------------------------
+# Tool-specific exclusions
+# ---------------------------------------------------------------------------
+# Codacy's generic "unsafe detected" rule does not understand Rust's safety
+# model. Our CI already enforces // SAFETY: comments on every unsafe block
+# via scripts/verify_unsafe_safety_template.py + docs/SOUNDNESS.md audit.
+#
+# These exclusions prevent false positives on files where unsafe is
+# architecturally required and fully audited.
+engines:
+  semgrep:
+    exclude_paths:
+      # SIMD intrinsics — unsafe is mandatory for _mm256_*, vld1q_f32, etc.
+      # All blocks have // SAFETY: comments verified by CI.
+      - "crates/velesdb-core/src/simd_native/**"
+      # HNSW graph hot paths — get_unchecked for bounds-check elimination
+      # Invariants documented in docs/SOUNDNESS.md §2.
+      - "crates/velesdb-core/src/index/hnsw/native/graph/**"
+      # Aligned memory allocation (ContiguousVectors, AllocGuard)
+      # RAII-guarded, audited in docs/SOUNDNESS.md §1.
+      - "crates/velesdb-core/src/perf_optimizations.rs"
+      # Memory-mapped I/O (mmap, file-backed storage)
+      # Platform-specific, audited in docs/SOUNDNESS.md §3.
+      - "crates/velesdb-core/src/storage/mmap/**"
+      # FFI bindings (PyO3, mobile, WASM)
+      - "crates/velesdb-python/**"
+      - "crates/velesdb-mobile/**"
+      - "crates/velesdb-wasm/**"

--- a/.codacy.yml
+++ b/.codacy.yml
@@ -16,55 +16,52 @@
 # ---------------------------------------------------------------------------
 # Global exclusions — files excluded from ALL Codacy tools
 # ---------------------------------------------------------------------------
-# Rationale: Test files, benchmarks, and generated code follow different
-# quality standards (complexity, line count, unsafe usage in test harnesses).
-# Test quality is enforced by CI (`cargo test`) not static analysis.
 exclude_paths:
-  # Test files (Rust naming convention: *_tests.rs)
+  # --- Non-production code (different quality standards) ---
+  # Test files follow different rules: assert is idiomatic, complexity
+  # limits don't apply to test harnesses, unsafe is used for test fixtures.
+  # Test quality is enforced by `cargo test`, not static analysis.
   - "crates/**/src/**/*_tests.rs"
-  # Integration test directories
   - "crates/**/tests/**"
-  # Benchmark harnesses (criterion)
+  # Benchmark harnesses (criterion) — perf code, not production
   - "crates/**/benches/**"
   # Generated code (pest parser, build scripts)
   - "crates/**/build.rs"
-  # Conformance test data
+  # Conformance test data (JSON fixtures, not source code)
   - "conformance/**"
-  # Demo/example apps (not production code)
+  # Demo/example apps (illustrative, not production)
   - "demos/**"
-  # Documentation assets
+  # Documentation assets (markdown, diagrams)
   - "docs/**"
-  # Scripts (CI, tooling — validated by shellcheck separately)
+  # CI/tooling scripts (validated by shellcheck separately)
   - "scripts/**"
-  # SDK tests
+  # SDK test suites
   - "sdks/**/tests/**"
   - "sdks/**/__tests__/**"
 
-# ---------------------------------------------------------------------------
-# Tool-specific exclusions
-# ---------------------------------------------------------------------------
-# Codacy's generic "unsafe detected" rule does not understand Rust's safety
-# model. Our CI already enforces // SAFETY: comments on every unsafe block
-# via scripts/verify_unsafe_safety_template.py + docs/SOUNDNESS.md audit.
-#
-# These exclusions prevent false positives on files where unsafe is
-# architecturally required and fully audited.
-engines:
-  semgrep:
-    exclude_paths:
-      # SIMD intrinsics — unsafe is mandatory for _mm256_*, vld1q_f32, etc.
-      # All blocks have // SAFETY: comments verified by CI.
-      - "crates/velesdb-core/src/simd_native/**"
-      # HNSW graph hot paths — get_unchecked for bounds-check elimination
-      # Invariants documented in docs/SOUNDNESS.md §2.
-      - "crates/velesdb-core/src/index/hnsw/native/graph/**"
-      # Aligned memory allocation (ContiguousVectors, AllocGuard)
-      # RAII-guarded, audited in docs/SOUNDNESS.md §1.
-      - "crates/velesdb-core/src/perf_optimizations.rs"
-      # Memory-mapped I/O (mmap, file-backed storage)
-      # Platform-specific, audited in docs/SOUNDNESS.md §3.
-      - "crates/velesdb-core/src/storage/mmap/**"
-      # FFI bindings (PyO3, mobile, WASM)
-      - "crates/velesdb-python/**"
-      - "crates/velesdb-mobile/**"
-      - "crates/velesdb-wasm/**"
+  # --- Audited unsafe code (false positive suppression) ---
+  # Codacy's "unsafe detected" rule cannot distinguish documented from
+  # undocumented unsafe. VelesDB enforces // SAFETY: comments on ALL
+  # unsafe blocks via:
+  #   1. CI script: scripts/verify_unsafe_safety_template.py
+  #   2. Full audit: docs/SOUNDNESS.md (reviewed per release)
+  #
+  # These files MUST use unsafe for architectural reasons:
+
+  # SIMD intrinsics — _mm256_*, _mm512_*, vld1q_f32, vfmaq_f32
+  # Cannot be called without unsafe in Rust. Every block documents
+  # alignment, bounds, and ISA preconditions.
+  - "crates/velesdb-core/src/simd_native/**"
+  # HNSW graph hot paths — get_unchecked for bounds-check elimination
+  # in inner search loops (greedy descent, neighbor scanning).
+  # Invariants: node IDs come from the graph's own insert path.
+  - "crates/velesdb-core/src/index/hnsw/native/graph/**"
+  # Aligned memory allocation — ContiguousVectors, AllocGuard
+  # RAII-guarded alloc/dealloc with panic safety.
+  - "crates/velesdb-core/src/perf_optimizations.rs"
+  # Memory-mapped I/O — platform-specific mmap operations
+  - "crates/velesdb-core/src/storage/mmap/**"
+  # FFI bindings — PyO3 (Python), JNI (mobile), wasm-bindgen
+  - "crates/velesdb-python/**"
+  - "crates/velesdb-mobile/**"
+  - "crates/velesdb-wasm/**"

--- a/crates/velesdb-cli/src/graph.rs
+++ b/crates/velesdb-cli/src/graph.rs
@@ -493,7 +493,7 @@ fn handle_store_payload(
     let col = open_graph(path, collection)?;
     let payload: serde_json::Value = serde_json::from_str(payload_str)
         .map_err(|e| anyhow::anyhow!("Invalid JSON payload: {}", e))?;
-    col.store_node_payload(node_id, &payload)
+    col.upsert_node_payload(node_id, &payload)
         .map_err(|e| anyhow::anyhow!("{}", e))?;
     col.flush()
         .map_err(|e| anyhow::anyhow!("Flush failed: {}", e))?;

--- a/crates/velesdb-cli/tests/phase3_commands_tests.rs
+++ b/crates/velesdb-cli/tests/phase3_commands_tests.rs
@@ -908,9 +908,9 @@ fn setup_graph_collection(name: &str) -> (std::path::PathBuf, tempfile::TempDir)
     let col = db.get_graph_collection(name).unwrap();
     let edge = velesdb_core::GraphEdge::new(1, 10, 20, "KNOWS").unwrap();
     col.add_edge(edge).unwrap();
-    col.store_node_payload(10, &serde_json::json!({"name": "Alice"}))
+    col.upsert_node_payload(10, &serde_json::json!({"name": "Alice"}))
         .unwrap();
-    col.store_node_payload(20, &serde_json::json!({"name": "Bob"}))
+    col.upsert_node_payload(20, &serde_json::json!({"name": "Bob"}))
         .unwrap();
     drop(db);
     (db_path, temp_dir)

--- a/crates/velesdb-cli/tests/repl_e2e_tests.rs
+++ b/crates/velesdb-cli/tests/repl_e2e_tests.rs
@@ -72,7 +72,7 @@ fn setup_graph(name: &str) -> (std::path::PathBuf, TempDir) {
     for i in 1u64..=3 {
         let edge = GraphEdge::new(i, i * 10, i * 10 + 1, "LINKS").unwrap();
         col.add_edge(edge).unwrap();
-        col.store_node_payload(
+        col.upsert_node_payload(
             i * 10,
             &serde_json::json!({"name": format!("node_{}", i * 10)}),
         )

--- a/crates/velesdb-core/src/collection/graph/clustered_index_tests.rs
+++ b/crates/velesdb-core/src/collection/graph/clustered_index_tests.rs
@@ -1,0 +1,180 @@
+//! Extended tests for [`ClusteredIndex`]: insert/remove/get_neighbors,
+//! compaction, and fragmentation ratio calculation.
+
+use super::clustered_index::ClusteredIndex;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Insert / remove / get_neighbors
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn insert_creates_new_entry() {
+    let mut idx = ClusteredIndex::new();
+    idx.insert(100, 200);
+    assert_eq!(idx.get_neighbors(100), &[200]);
+    assert_eq!(idx.node_count(), 1);
+    assert_eq!(idx.edge_count(), 1);
+}
+
+#[test]
+fn insert_appends_to_existing_node() {
+    let mut idx = ClusteredIndex::new();
+    idx.insert(1, 10);
+    idx.insert(1, 20);
+    idx.insert(1, 30);
+
+    let neighbors = idx.get_neighbors(1);
+    assert_eq!(neighbors.len(), 3);
+    assert!(neighbors.contains(&10));
+    assert!(neighbors.contains(&20));
+    assert!(neighbors.contains(&30));
+}
+
+#[test]
+fn insert_deduplicates() {
+    let mut idx = ClusteredIndex::new();
+    idx.insert(1, 10);
+    idx.insert(1, 10);
+    assert_eq!(idx.neighbor_count(1), 1);
+}
+
+#[test]
+fn remove_returns_true_when_present() {
+    let mut idx = ClusteredIndex::new();
+    idx.insert(1, 10);
+    idx.insert(1, 20);
+    assert!(idx.remove(1, 10));
+    assert!(!idx.contains(1, 10));
+    assert!(idx.contains(1, 20));
+}
+
+#[test]
+fn remove_returns_false_when_absent() {
+    let mut idx = ClusteredIndex::new();
+    idx.insert(1, 10);
+    assert!(!idx.remove(1, 999));
+    assert!(!idx.remove(999, 10));
+}
+
+#[test]
+fn remove_last_neighbor_deletes_node() {
+    let mut idx = ClusteredIndex::new();
+    idx.insert(1, 10);
+    assert!(idx.remove(1, 10));
+    assert_eq!(idx.node_count(), 0);
+    assert!(idx.get_neighbors(1).is_empty());
+}
+
+#[test]
+fn remove_node_clears_all_neighbors() {
+    let mut idx = ClusteredIndex::new();
+    idx.insert(1, 10);
+    idx.insert(1, 20);
+    idx.insert(1, 30);
+    idx.remove_node(1);
+
+    assert_eq!(idx.node_count(), 0);
+    assert!(idx.get_neighbors(1).is_empty());
+}
+
+#[test]
+fn get_neighbors_unknown_node_returns_empty() {
+    let idx = ClusteredIndex::new();
+    assert!(idx.get_neighbors(42).is_empty());
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Compact reduces fragmentation
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn compact_reduces_fragmentation_to_zero() {
+    let mut idx = ClusteredIndex::new();
+    for node in 0..10 {
+        for target in 0..5 {
+            idx.insert(node, target * 100);
+        }
+    }
+    // Remove half the nodes to create fragmentation
+    for node in 0..5 {
+        idx.remove_node(node);
+    }
+    assert!(idx.fragmentation() > 0.0, "should have fragmentation");
+
+    idx.compact();
+    assert!(
+        idx.fragmentation().abs() < f64::EPSILON,
+        "compaction should eliminate fragmentation"
+    );
+    assert_eq!(idx.node_count(), 5);
+    assert_eq!(idx.edge_count(), 25);
+}
+
+#[test]
+fn compact_preserves_all_data() {
+    let mut idx = ClusteredIndex::new();
+    idx.insert(1, 10);
+    idx.insert(1, 20);
+    idx.insert(2, 100);
+    idx.insert(3, 200);
+
+    // Remove node 2 to create a gap, then compact
+    idx.remove_node(2);
+    idx.compact();
+
+    assert_eq!(idx.node_count(), 2);
+    assert!(idx.contains(1, 10));
+    assert!(idx.contains(1, 20));
+    assert!(idx.contains(3, 200));
+    assert!(!idx.contains(2, 100));
+}
+
+#[test]
+fn compact_noop_when_no_fragmentation() {
+    let mut idx = ClusteredIndex::new();
+    idx.insert(1, 10);
+    assert!(idx.fragmentation().abs() < f64::EPSILON);
+    idx.compact(); // should not crash
+    assert_eq!(idx.neighbor_count(1), 1);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Fragmentation ratio calculation
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn fragmentation_empty_index_is_zero() {
+    let idx = ClusteredIndex::new();
+    assert!(idx.fragmentation().abs() < f64::EPSILON);
+}
+
+#[test]
+fn fragmentation_no_deletes_is_zero() {
+    let mut idx = ClusteredIndex::new();
+    idx.insert(1, 10);
+    idx.insert(2, 20);
+    assert!(idx.fragmentation().abs() < f64::EPSILON);
+}
+
+#[test]
+fn fragmentation_increases_after_removal() {
+    let mut idx = ClusteredIndex::new();
+    for i in 0..10 {
+        idx.insert(i, i * 10);
+    }
+    let before = idx.fragmentation();
+    idx.remove_node(0);
+    let after = idx.fragmentation();
+    assert!(after > before);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// with_capacity
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn with_capacity_works() {
+    let mut idx = ClusteredIndex::with_capacity(100, 500);
+    idx.insert(1, 10);
+    assert_eq!(idx.node_count(), 1);
+}

--- a/crates/velesdb-core/src/collection/graph/mod.rs
+++ b/crates/velesdb-core/src/collection/graph/mod.rs
@@ -58,6 +58,8 @@ mod traversal;
 mod traversal_tests;
 
 #[cfg(test)]
+mod clustered_index_tests;
+#[cfg(test)]
 mod edge_concurrent_tests;
 #[cfg(test)]
 mod edge_tests;

--- a/crates/velesdb-core/src/collection/graph_collection.rs
+++ b/crates/velesdb-core/src/collection/graph_collection.rs
@@ -15,7 +15,7 @@ use crate::collection::graph::{GraphEdge, GraphSchema, TraversalConfig, Traversa
 use crate::collection::types::Collection;
 use crate::distance::DistanceMetric;
 use crate::error::Result;
-use crate::point::SearchResult;
+use crate::point::{Point, SearchResult};
 
 /// A graph collection storing typed relationships between nodes.
 ///
@@ -178,6 +178,43 @@ impl GraphCollection {
         self.inner.all_ids()
     }
 
+    /// Returns the number of nodes (points) stored in this collection.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    /// Returns `true` if the collection contains no nodes.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+
+    /// Retrieves nodes by IDs, returning `None` for missing entries.
+    #[must_use]
+    pub fn get(&self, ids: &[u64]) -> Vec<Option<Point>> {
+        self.inner.get(ids)
+    }
+
+    /// Deletes nodes by IDs.
+    ///
+    /// Missing IDs are silently ignored.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if storage operations fail.
+    pub fn delete(&self, ids: &[u64]) -> Result<()> {
+        self.inner.delete(ids)
+    }
+
+    /// Removes an edge from the graph by ID.
+    ///
+    /// Returns `true` if the edge existed and was removed, `false` otherwise.
+    #[must_use]
+    pub fn remove_edge(&self, edge_id: u64) -> bool {
+        self.inner.remove_edge(edge_id)
+    }
+
     /// Performs BFS traversal from a source node.
     ///
     /// # Examples
@@ -208,13 +245,23 @@ impl GraphCollection {
     // Payload / node properties
     // -------------------------------------------------------------------------
 
-    /// Stores node payload (properties).
+    /// Inserts or updates node payload (properties).
     ///
     /// # Errors
     ///
     /// Returns an error if storage fails.
-    pub fn store_node_payload(&self, node_id: u64, payload: &serde_json::Value) -> Result<()> {
+    pub fn upsert_node_payload(&self, node_id: u64, payload: &serde_json::Value) -> Result<()> {
         self.inner.store_node_payload(node_id, payload)
+    }
+
+    /// Inserts or updates node payload (properties).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if storage fails.
+    #[deprecated(since = "1.6.0", note = "Use upsert_node_payload() instead")]
+    pub fn store_node_payload(&self, node_id: u64, payload: &serde_json::Value) -> Result<()> {
+        self.upsert_node_payload(node_id, payload)
     }
 
     /// Retrieves node payload.
@@ -240,11 +287,23 @@ impl GraphCollection {
         self.inner.search_by_embedding(query, k)
     }
 
+    /// Alias for [`search_by_embedding`](Self::search_by_embedding).
+    ///
+    /// Provided for API parity with [`VectorCollection::search`].
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::VectorNotAllowed` if this collection has no embeddings,
+    /// or `Error::DimensionMismatch` if the query dimension is wrong.
+    pub fn search(&self, query: &[f32], k: usize) -> Result<Vec<SearchResult>> {
+        self.search_by_embedding(query, k)
+    }
+
     // -------------------------------------------------------------------------
     // VelesQL
     // -------------------------------------------------------------------------
 
-    /// Executes a `VelesQL` query.
+    /// Executes a parsed `VelesQL` query.
     ///
     /// # Errors
     ///
@@ -255,6 +314,25 @@ impl GraphCollection {
         params: &HashMap<String, serde_json::Value>,
     ) -> Result<Vec<SearchResult>> {
         self.inner.execute_query(query, params)
+    }
+
+    /// Executes a raw VelesQL string, parsing it before execution.
+    ///
+    /// # Errors
+    ///
+    /// - Returns an error if the SQL string cannot be parsed.
+    /// - Returns an error if query execution fails.
+    pub fn execute_query_str(
+        &self,
+        sql: &str,
+        params: &HashMap<String, serde_json::Value>,
+    ) -> Result<Vec<SearchResult>> {
+        let query = self
+            .inner
+            .query_cache
+            .parse(sql)
+            .map_err(|e| crate::error::Error::Query(e.to_string()))?;
+        self.inner.execute_query(&query, params)
     }
 }
 
@@ -278,9 +356,9 @@ mod tests {
         .unwrap();
 
         // Store payloads on two nodes
-        col.store_node_payload(10, &serde_json::json!({"name": "Alice"}))
+        col.upsert_node_payload(10, &serde_json::json!({"name": "Alice"}))
             .unwrap();
-        col.store_node_payload(20, &serde_json::json!({"name": "Bob"}))
+        col.upsert_node_payload(20, &serde_json::json!({"name": "Bob"}))
             .unwrap();
 
         let ids = col.all_node_ids();

--- a/crates/velesdb-core/src/collection/streaming/delta_tests.rs
+++ b/crates/velesdb-core/src/collection/streaming/delta_tests.rs
@@ -1,0 +1,173 @@
+//! Extended tests for [`DeltaBuffer`] state machine, concurrent safety,
+//! and `merge_with_delta` deduplication.
+
+#![allow(clippy::cast_precision_loss)]
+
+use super::delta::{merge_with_delta, DeltaBuffer};
+use crate::distance::DistanceMetric;
+use std::sync::Arc;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Push + search basic flow
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn delta_push_increments_len() {
+    let buf = DeltaBuffer::new();
+    buf.activate();
+    for i in 0..5 {
+        buf.push(i, vec![i as f32; 3]);
+    }
+    assert_eq!(buf.len(), 5);
+}
+
+#[test]
+fn delta_search_respects_k_limit() {
+    let buf = DeltaBuffer::new();
+    buf.activate();
+    for i in 0..20 {
+        buf.push(i, vec![i as f32; 2]);
+    }
+    let results = buf.search(&[0.0, 0.0], 5, DistanceMetric::Euclidean);
+    assert_eq!(results.len(), 5, "search must truncate to k");
+}
+
+#[test]
+fn delta_search_empty_buffer_returns_empty() {
+    let buf = DeltaBuffer::new();
+    buf.activate();
+    let results = buf.search(&[1.0], 10, DistanceMetric::Cosine);
+    assert!(results.is_empty(), "empty active buffer returns no results");
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// State transitions: activate / deactivate_and_drain
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn delta_double_activate_is_idempotent() {
+    let buf = DeltaBuffer::new();
+    buf.activate();
+    buf.activate();
+    assert!(buf.is_active());
+}
+
+#[test]
+fn delta_deactivate_returns_all_pushed_entries() {
+    let buf = DeltaBuffer::new();
+    buf.activate();
+    buf.push(1, vec![1.0]);
+    buf.push(2, vec![2.0]);
+    buf.push(3, vec![3.0]);
+
+    let drained = buf.deactivate_and_drain();
+    assert_eq!(drained.len(), 3);
+    assert!(!buf.is_active());
+    assert!(buf.is_empty());
+}
+
+#[test]
+fn delta_deactivate_when_inactive_returns_empty() {
+    let buf = DeltaBuffer::new();
+    let drained = buf.deactivate_and_drain();
+    assert!(drained.is_empty());
+    assert!(!buf.is_active());
+}
+
+#[test]
+fn delta_push_after_deactivate_is_noop() {
+    let buf = DeltaBuffer::new();
+    buf.activate();
+    buf.push(1, vec![1.0]);
+    let _ = buf.deactivate_and_drain();
+
+    buf.push(99, vec![99.0]);
+    assert!(buf.is_empty(), "push after drain should be noop");
+}
+
+#[test]
+fn delta_reactivate_after_drain_accepts_new_entries() {
+    let buf = DeltaBuffer::new();
+    buf.activate();
+    buf.push(1, vec![1.0]);
+    let _ = buf.deactivate_and_drain();
+
+    buf.activate();
+    buf.push(10, vec![10.0]);
+    assert_eq!(buf.len(), 1);
+    assert!(buf.is_active());
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Concurrent push + search safety
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn delta_concurrent_push_and_search() {
+    let buf = Arc::new(DeltaBuffer::new());
+    buf.activate();
+
+    let writers: Vec<_> = (0u64..4)
+        .map(|t| {
+            let b = Arc::clone(&buf);
+            std::thread::spawn(move || {
+                for i in 0..50 {
+                    let id = t * 100 + i;
+                    b.push(id, vec![id as f32; 3]);
+                }
+            })
+        })
+        .collect();
+
+    let readers: Vec<_> = (0..2)
+        .map(|_| {
+            let b = Arc::clone(&buf);
+            std::thread::spawn(move || {
+                for _ in 0..20 {
+                    let _ = b.search(&[1.0, 0.0, 0.0], 5, DistanceMetric::Cosine);
+                }
+            })
+        })
+        .collect();
+
+    for w in writers {
+        w.join().expect("writer thread panicked");
+    }
+    for r in readers {
+        r.join().expect("reader thread panicked");
+    }
+
+    assert_eq!(buf.len(), 200, "all 4x50 pushes should land");
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// merge_with_delta
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn merge_delta_dedup_prefers_delta() {
+    let buf = DeltaBuffer::new();
+    buf.activate();
+    // Delta has id=1 with vector very close to query
+    buf.push(1, vec![1.0, 0.0]);
+
+    let hnsw = vec![(1, 0.5_f32), (2, 0.4)];
+    let merged = merge_with_delta(hnsw, &buf, &[1.0, 0.0], 10, DistanceMetric::Cosine);
+
+    let ids: Vec<u64> = merged.iter().map(|(id, _)| *id).collect();
+    // id=1 must appear exactly once (from delta, not HNSW)
+    assert_eq!(ids.iter().filter(|&&id| id == 1).count(), 1);
+}
+
+#[test]
+fn merge_delta_truncates_to_k() {
+    let buf = DeltaBuffer::new();
+    buf.activate();
+    for i in 0..10 {
+        buf.push(100 + i, vec![i as f32; 2]);
+    }
+
+    let hnsw: Vec<(u64, f32)> = (0..10).map(|i| (i, 0.5)).collect();
+    let merged = merge_with_delta(hnsw, &buf, &[0.0, 0.0], 3, DistanceMetric::Euclidean);
+    assert_eq!(merged.len(), 3);
+}

--- a/crates/velesdb-core/src/collection/streaming/ingester_tests.rs
+++ b/crates/velesdb-core/src/collection/streaming/ingester_tests.rs
@@ -11,8 +11,7 @@ use tempfile::TempDir;
 fn test_collection(dim: usize) -> (TempDir, Collection) {
     let dir = TempDir::new().expect("tempdir");
     let path = dir.path().join("test_ingester_coll");
-    let coll =
-        Collection::create(path, dim, DistanceMetric::Cosine).expect("create collection");
+    let coll = Collection::create(path, dim, DistanceMetric::Cosine).expect("create collection");
     (dir, coll)
 }
 
@@ -75,7 +74,10 @@ async fn ingester_try_send_buffer_full_error_display() {
     );
     // Verify Display impl
     let msg = format!("{err}");
-    assert!(msg.contains("full"), "error message should mention 'full': {msg}");
+    assert!(
+        msg.contains("full"),
+        "error message should mention 'full': {msg}"
+    );
 
     ingester.shutdown().await;
 }
@@ -107,7 +109,7 @@ async fn ingester_shutdown_drains_all_pending() {
     let (_dir, coll) = test_collection(4);
     let config = StreamingConfig {
         buffer_size: 100,
-        batch_size: 10_000,      // huge — won't auto-flush by batch
+        batch_size: 10_000,        // huge — won't auto-flush by batch
         flush_interval_ms: 60_000, // huge — won't auto-flush by timer
     };
     let coll_clone = coll.clone();

--- a/crates/velesdb-core/src/collection/streaming/ingester_tests.rs
+++ b/crates/velesdb-core/src/collection/streaming/ingester_tests.rs
@@ -1,0 +1,147 @@
+//! Extended tests for [`StreamIngester`] backpressure, shutdown drain,
+//! and configuration defaults.
+
+use super::ingester::{BackpressureError, StreamIngester, StreamingConfig};
+use crate::collection::types::Collection;
+use crate::distance::DistanceMetric;
+use crate::point::Point;
+use tempfile::TempDir;
+
+/// Helper: create a test collection in a temp directory.
+fn test_collection(dim: usize) -> (TempDir, Collection) {
+    let dir = TempDir::new().expect("tempdir");
+    let path = dir.path().join("test_ingester_coll");
+    let coll =
+        Collection::create(path, dim, DistanceMetric::Cosine).expect("create collection");
+    (dir, coll)
+}
+
+/// Helper: create a point with the given id and dimension.
+fn make_point(id: u64, dim: usize) -> Point {
+    Point {
+        id,
+        vector: vec![0.1_f32; dim],
+        payload: None,
+        sparse_vectors: None,
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Config defaults
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn streaming_config_defaults() {
+    let cfg = StreamingConfig::default();
+    assert_eq!(cfg.buffer_size, 10_000);
+    assert_eq!(cfg.batch_size, 128);
+    assert_eq!(cfg.flush_interval_ms, 50);
+}
+
+#[test]
+fn streaming_config_clone_is_identical() {
+    let cfg = StreamingConfig {
+        buffer_size: 42,
+        batch_size: 7,
+        flush_interval_ms: 100,
+    };
+    let cloned = cfg.clone();
+    assert_eq!(cloned.buffer_size, 42);
+    assert_eq!(cloned.batch_size, 7);
+    assert_eq!(cloned.flush_interval_ms, 100);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// try_send with backpressure
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn ingester_try_send_buffer_full_error_display() {
+    let (_dir, coll) = test_collection(4);
+    let config = StreamingConfig {
+        buffer_size: 1,
+        batch_size: 1000,
+        flush_interval_ms: 60_000,
+    };
+    let ingester = StreamIngester::new(coll, config);
+
+    // Fill the single-slot channel
+    assert!(ingester.try_send(make_point(1, 4)).is_ok());
+
+    let err = ingester.try_send(make_point(2, 4)).unwrap_err();
+    assert!(
+        matches!(err, BackpressureError::BufferFull),
+        "expected BufferFull, got: {err}"
+    );
+    // Verify Display impl
+    let msg = format!("{err}");
+    assert!(msg.contains("full"), "error message should mention 'full': {msg}");
+
+    ingester.shutdown().await;
+}
+
+#[tokio::test]
+async fn ingester_config_accessor() {
+    let (_dir, coll) = test_collection(4);
+    let config = StreamingConfig {
+        buffer_size: 42,
+        batch_size: 7,
+        flush_interval_ms: 99,
+    };
+    let ingester = StreamIngester::new(coll, config);
+
+    let c = ingester.config();
+    assert_eq!(c.buffer_size, 42);
+    assert_eq!(c.batch_size, 7);
+    assert_eq!(c.flush_interval_ms, 99);
+
+    ingester.shutdown().await;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Shutdown drains pending items
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn ingester_shutdown_drains_all_pending() {
+    let (_dir, coll) = test_collection(4);
+    let config = StreamingConfig {
+        buffer_size: 100,
+        batch_size: 10_000,      // huge — won't auto-flush by batch
+        flush_interval_ms: 60_000, // huge — won't auto-flush by timer
+    };
+    let coll_clone = coll.clone();
+    let ingester = StreamIngester::new(coll, config);
+
+    for i in 1..=5 {
+        ingester.try_send(make_point(i, 4)).expect("send ok");
+    }
+
+    // Brief yield so drain loop receives points into its channel buffer
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+    // Shutdown flushes everything
+    ingester.shutdown().await;
+
+    let results = coll_clone.get(&[1, 2, 3, 4, 5]);
+    let found = results.iter().filter(|r| r.is_some()).count();
+    assert_eq!(found, 5, "shutdown must flush all pending points");
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// BackpressureError variants
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn backpressure_error_not_configured_display() {
+    let err = BackpressureError::NotConfigured;
+    let msg = format!("{err}");
+    assert!(msg.contains("not configured"));
+}
+
+#[test]
+fn backpressure_error_drain_task_dead_display() {
+    let err = BackpressureError::DrainTaskDead;
+    let msg = format!("{err}");
+    assert!(msg.contains("dead"));
+}

--- a/crates/velesdb-core/src/collection/streaming/mod.rs
+++ b/crates/velesdb-core/src/collection/streaming/mod.rs
@@ -15,3 +15,8 @@ mod ingester;
 pub use delta::merge_with_delta;
 #[cfg(feature = "persistence")]
 pub use ingester::{BackpressureError, StreamIngester, StreamingConfig};
+
+#[cfg(all(test, feature = "persistence"))]
+mod delta_tests;
+#[cfg(all(test, feature = "persistence"))]
+mod ingester_tests;

--- a/crates/velesdb-core/src/column_store/filter_tests.rs
+++ b/crates/velesdb-core/src/column_store/filter_tests.rs
@@ -8,7 +8,8 @@ use crate::column_store::{ColumnStore, ColumnType, ColumnValue};
 /// Helper: creates a column store with `age` (Int), `name` (String), and
 /// pushes `count` rows where age=i and name cycles through the given labels.
 fn store_with_rows(count: usize, labels: &[&str]) -> ColumnStore {
-    let mut store = ColumnStore::with_schema(&[("age", ColumnType::Int), ("name", ColumnType::String)]);
+    let mut store =
+        ColumnStore::with_schema(&[("age", ColumnType::Int), ("name", ColumnType::String)]);
     for i in 0..count {
         let label = labels[i % labels.len()];
         let sid = store.string_table_mut().intern(label);

--- a/crates/velesdb-core/src/column_store/filter_tests.rs
+++ b/crates/velesdb-core/src/column_store/filter_tests.rs
@@ -1,0 +1,172 @@
+//! Tests for column-store filter operations: eq, gt, lt, range, in,
+//! count, bitmap equality/range, and bitmap AND/OR combinators.
+
+#![allow(clippy::cast_possible_wrap)]
+
+use crate::column_store::{ColumnStore, ColumnType, ColumnValue};
+
+/// Helper: creates a column store with `age` (Int), `name` (String), and
+/// pushes `count` rows where age=i and name cycles through the given labels.
+fn store_with_rows(count: usize, labels: &[&str]) -> ColumnStore {
+    let mut store = ColumnStore::with_schema(&[("age", ColumnType::Int), ("name", ColumnType::String)]);
+    for i in 0..count {
+        let label = labels[i % labels.len()];
+        let sid = store.string_table_mut().intern(label);
+        store.push_row(&[
+            ("age", ColumnValue::Int(i as i64)),
+            ("name", ColumnValue::String(sid)),
+        ]);
+    }
+    store
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Equality filters
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn filter_eq_int_finds_matching_rows() {
+    let store = store_with_rows(10, &["a"]);
+    let result = store.filter_eq_int("age", 5);
+    assert_eq!(result, vec![5]);
+}
+
+#[test]
+fn filter_eq_int_nonexistent_column_returns_empty() {
+    let store = store_with_rows(5, &["a"]);
+    assert!(store.filter_eq_int("missing", 0).is_empty());
+}
+
+#[test]
+fn filter_eq_string_finds_matching_rows() {
+    let store = store_with_rows(6, &["x", "y"]);
+    // Rows 0,2,4 have "x"; rows 1,3,5 have "y"
+    let result = store.filter_eq_string("name", "y");
+    assert_eq!(result, vec![1, 3, 5]);
+}
+
+#[test]
+fn filter_eq_string_unknown_value_returns_empty() {
+    let store = store_with_rows(4, &["a"]);
+    assert!(store.filter_eq_string("name", "zzz").is_empty());
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Range filters: gt, lt, range
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn filter_gt_int_exclusive() {
+    let store = store_with_rows(10, &["a"]);
+    let result = store.filter_gt_int("age", 7);
+    assert_eq!(result, vec![8, 9]);
+}
+
+#[test]
+fn filter_lt_int_exclusive() {
+    let store = store_with_rows(10, &["a"]);
+    let result = store.filter_lt_int("age", 3);
+    assert_eq!(result, vec![0, 1, 2]);
+}
+
+#[test]
+fn filter_range_int_exclusive_bounds() {
+    let store = store_with_rows(10, &["a"]);
+    // low=2, high=6 => matches 3,4,5
+    let result = store.filter_range_int("age", 2, 6);
+    assert_eq!(result, vec![3, 4, 5]);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// IN filter
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn filter_in_string_matches_subset() {
+    let store = store_with_rows(9, &["a", "b", "c"]);
+    let result = store.filter_in_string("name", &["a", "c"]);
+    // a=0,3,6  c=2,5,8
+    assert_eq!(result, vec![0, 2, 3, 5, 6, 8]);
+}
+
+#[test]
+fn filter_in_string_no_matches() {
+    let store = store_with_rows(4, &["a"]);
+    assert!(store.filter_in_string("name", &["z"]).is_empty());
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Deleted rows are excluded
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn filter_excludes_deleted_rows() {
+    let mut store = store_with_rows(5, &["a"]);
+    // Delete row 2
+    store.deleted_rows.insert(2);
+    if let Ok(idx) = u32::try_from(2_usize) {
+        store.deletion_bitmap.insert(idx);
+    }
+    let result = store.filter_eq_int("age", 2);
+    assert!(result.is_empty(), "deleted row must be excluded");
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Count operations
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn count_eq_int_matches() {
+    let store = store_with_rows(10, &["a"]);
+    assert_eq!(store.count_eq_int("age", 3), 1);
+    assert_eq!(store.count_eq_int("age", 999), 0);
+}
+
+#[test]
+fn count_eq_string_matches() {
+    let store = store_with_rows(6, &["x", "y"]);
+    assert_eq!(store.count_eq_string("name", "x"), 3);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Bitmap filters and combinators
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn bitmap_eq_int_matches_same_as_vec() {
+    let store = store_with_rows(10, &["a"]);
+    let bitmap = store.filter_eq_int_bitmap("age", 5);
+    assert!(bitmap.contains(5));
+    assert_eq!(bitmap.len(), 1);
+}
+
+#[test]
+fn bitmap_range_int() {
+    let store = store_with_rows(10, &["a"]);
+    let bitmap = store.filter_range_int_bitmap("age", 2, 6);
+    assert_eq!(bitmap.len(), 3); // 3,4,5
+}
+
+#[test]
+fn bitmap_and_combinator() {
+    let store = store_with_rows(10, &["a"]);
+    let a = store.filter_range_int_bitmap("age", 0, 8); // 1..7
+    let b = store.filter_range_int_bitmap("age", 4, 10); // 5..9
+    let combined = ColumnStore::bitmap_and(&a, &b);
+    // Intersection: 5,6,7
+    assert_eq!(combined.len(), 3);
+    assert!(combined.contains(5));
+    assert!(combined.contains(6));
+    assert!(combined.contains(7));
+}
+
+#[test]
+fn bitmap_or_combinator() {
+    let store = store_with_rows(10, &["a"]);
+    let a = store.filter_eq_int_bitmap("age", 1);
+    let b = store.filter_eq_int_bitmap("age", 9);
+    let combined = ColumnStore::bitmap_or(&a, &b);
+    assert_eq!(combined.len(), 2);
+    assert!(combined.contains(1));
+    assert!(combined.contains(9));
+}

--- a/crates/velesdb-core/src/column_store/mod.rs
+++ b/crates/velesdb-core/src/column_store/mod.rs
@@ -32,9 +32,13 @@ mod batch;
 #[cfg(test)]
 mod batch_tests;
 mod filter;
+#[cfg(test)]
+mod filter_tests;
 mod string_table;
 mod types;
 mod vacuum;
+#[cfg(test)]
+mod vacuum_tests;
 
 use roaring::RoaringBitmap;
 use rustc_hash::FxHashMap;

--- a/crates/velesdb-core/src/column_store/vacuum_tests.rs
+++ b/crates/velesdb-core/src/column_store/vacuum_tests.rs
@@ -1,0 +1,152 @@
+//! Tests for column-store vacuum, `should_vacuum()` threshold logic,
+//! and `is_row_deleted_bitmap()`.
+
+#![allow(clippy::cast_possible_wrap)]
+
+use crate::column_store::{ColumnStore, ColumnType, ColumnValue, VacuumConfig};
+
+/// Helper: builds a store with `count` rows, each having an Int `id` column.
+fn store_with_id_rows(count: usize) -> ColumnStore {
+    let mut store = ColumnStore::with_schema(&[("id", ColumnType::Int)]);
+    for i in 0..count {
+        store.push_row(&[("id", ColumnValue::Int(i as i64))]);
+    }
+    store
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// vacuum() removes deleted rows
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn vacuum_removes_tombstones() {
+    let mut store = store_with_id_rows(10);
+
+    // Soft-delete rows 3 and 7
+    store.deleted_rows.insert(3);
+    store.deleted_rows.insert(7);
+    if let Ok(idx) = u32::try_from(3_usize) {
+        store.deletion_bitmap.insert(idx);
+    }
+    if let Ok(idx) = u32::try_from(7_usize) {
+        store.deletion_bitmap.insert(idx);
+    }
+
+    let stats = store.vacuum(VacuumConfig::default());
+    assert!(stats.completed);
+    assert_eq!(stats.tombstones_found, 2);
+    assert_eq!(stats.tombstones_removed, 2);
+    assert_eq!(store.row_count(), 8);
+    assert_eq!(store.deleted_row_count(), 0);
+}
+
+#[test]
+fn vacuum_no_tombstones_is_noop() {
+    let mut store = store_with_id_rows(5);
+    let stats = store.vacuum(VacuumConfig::default());
+    assert!(stats.completed);
+    assert_eq!(stats.tombstones_found, 0);
+    assert_eq!(store.row_count(), 5);
+}
+
+#[test]
+fn vacuum_preserves_remaining_data() {
+    let mut store = store_with_id_rows(5);
+    // Delete row at index 2 (id=2)
+    store.deleted_rows.insert(2);
+    if let Ok(idx) = u32::try_from(2_usize) {
+        store.deletion_bitmap.insert(idx);
+    }
+
+    store.vacuum(VacuumConfig::default());
+
+    // The remaining 4 rows should have ids 0,1,3,4 (compacted)
+    let ids = store.filter_eq_int("id", 2);
+    assert!(ids.is_empty(), "deleted id=2 must not appear after vacuum");
+
+    let all_rows = store.row_count();
+    assert_eq!(all_rows, 4);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// should_vacuum() threshold logic
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn should_vacuum_below_threshold() {
+    let mut store = store_with_id_rows(100);
+    // Delete 10 out of 100 => 10%, threshold 20% => false
+    for i in 0..10 {
+        store.deleted_rows.insert(i);
+    }
+    assert!(!store.should_vacuum(0.20));
+}
+
+#[test]
+fn should_vacuum_at_threshold() {
+    let mut store = store_with_id_rows(100);
+    // Delete 20 out of 100 => 20%, threshold 20% => true
+    for i in 0..20 {
+        store.deleted_rows.insert(i);
+    }
+    assert!(store.should_vacuum(0.20));
+}
+
+#[test]
+fn should_vacuum_above_threshold() {
+    let mut store = store_with_id_rows(100);
+    for i in 0..50 {
+        store.deleted_rows.insert(i);
+    }
+    assert!(store.should_vacuum(0.20));
+}
+
+#[test]
+fn should_vacuum_empty_store() {
+    let store = ColumnStore::new();
+    assert!(!store.should_vacuum(0.20));
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// is_row_deleted_bitmap()
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn is_row_deleted_bitmap_true_for_deleted() {
+    let mut store = store_with_id_rows(5);
+    store.deleted_rows.insert(2);
+    store.deletion_bitmap.insert(2);
+
+    assert!(store.is_row_deleted_bitmap(2));
+}
+
+#[test]
+fn is_row_deleted_bitmap_false_for_live() {
+    let store = store_with_id_rows(5);
+    assert!(!store.is_row_deleted_bitmap(0));
+    assert!(!store.is_row_deleted_bitmap(4));
+}
+
+#[test]
+fn live_row_indices_excludes_deleted() {
+    let mut store = store_with_id_rows(5);
+    store.deleted_rows.insert(1);
+    store.deletion_bitmap.insert(1);
+    store.deleted_rows.insert(3);
+    store.deletion_bitmap.insert(3);
+
+    let live: Vec<usize> = store.live_row_indices().collect();
+    assert_eq!(live, vec![0, 2, 4]);
+}
+
+#[test]
+fn deleted_count_bitmap_matches_set() {
+    let mut store = store_with_id_rows(10);
+    for i in [0, 2, 4, 6] {
+        store.deleted_rows.insert(i);
+        if let Ok(idx) = u32::try_from(i) {
+            store.deletion_bitmap.insert(idx);
+        }
+    }
+    assert_eq!(store.deleted_count_bitmap(), 4);
+}

--- a/crates/velesdb-core/src/database/collection_ops.rs
+++ b/crates/velesdb-core/src/database/collection_ops.rs
@@ -373,8 +373,7 @@ impl Database {
     ) -> Result<()> {
         self.ensure_collection_name_available(name)?;
         let path = self.data_dir.join(name);
-        let coll =
-            GraphCollection::create(path, name, Some(dimension), metric, schema.clone())?;
+        let coll = GraphCollection::create(path, name, Some(dimension), metric, schema.clone())?;
         self.collections
             .write()
             .insert(name.to_string(), coll.inner.clone());

--- a/crates/velesdb-core/src/database/collection_ops.rs
+++ b/crates/velesdb-core/src/database/collection_ops.rs
@@ -91,6 +91,15 @@ impl Database {
             .insert(name.to_string(), coll.inner.clone());
         self.vector_colls.write().insert(name.to_string(), coll);
 
+        if let Some(ref obs) = self.observer {
+            let kind = CollectionType::Vector {
+                dimension,
+                metric,
+                storage_mode,
+            };
+            obs.on_collection_created(name, &kind);
+        }
+
         // Bump schema version (CACHE-01 DDL invalidation).
         self.schema_version
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
@@ -340,6 +349,46 @@ impl Database {
         }
 
         // Bump schema version (CACHE-01 DDL invalidation).
+        self.schema_version
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+
+        Ok(())
+    }
+
+    /// Creates a new graph collection with node embeddings.
+    ///
+    /// Unlike [`create_graph_collection`](Self::create_graph_collection), this
+    /// variant configures a vector dimension and distance metric so that nodes
+    /// can store embeddings and support similarity search.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if a collection with the same name already exists.
+    pub fn create_graph_collection_with_embeddings(
+        &self,
+        name: &str,
+        schema: crate::collection::GraphSchema,
+        dimension: usize,
+        metric: DistanceMetric,
+    ) -> Result<()> {
+        self.ensure_collection_name_available(name)?;
+        let path = self.data_dir.join(name);
+        let coll =
+            GraphCollection::create(path, name, Some(dimension), metric, schema.clone())?;
+        self.collections
+            .write()
+            .insert(name.to_string(), coll.inner.clone());
+        self.graph_colls.write().insert(name.to_string(), coll);
+
+        if let Some(ref obs) = self.observer {
+            let kind = CollectionType::Graph {
+                dimension: Some(dimension),
+                metric,
+                schema,
+            };
+            obs.on_collection_created(name, &kind);
+        }
+
         self.schema_version
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
 

--- a/crates/velesdb-core/src/database/mod.rs
+++ b/crates/velesdb-core/src/database/mod.rs
@@ -30,6 +30,8 @@ mod collection_ops_tests;
 mod database_tests;
 #[cfg(all(test, feature = "persistence"))]
 mod query_engine_tests;
+#[cfg(all(test, feature = "persistence"))]
+mod stats_tests;
 
 /// Database instance managing collections and storage.
 ///

--- a/crates/velesdb-core/src/database/stats_tests.rs
+++ b/crates/velesdb-core/src/database/stats_tests.rs
@@ -1,0 +1,117 @@
+//! Tests for `Database::analyze_collection` and `get_collection_stats`.
+
+#![allow(clippy::cast_precision_loss)]
+
+use crate::database::Database;
+use crate::distance::DistanceMetric;
+use crate::point::Point;
+use tempfile::TempDir;
+
+/// Helper: open a database in a temp dir.
+fn temp_database() -> (TempDir, Database) {
+    let dir = TempDir::new().expect("tempdir");
+    let db = Database::open(dir.path()).expect("open database");
+    (dir, db)
+}
+
+/// Helper: create a collection and insert some points.
+#[allow(deprecated)]
+fn setup_collection(db: &Database, name: &str, dim: usize, count: u64) {
+    db.create_collection(name, dim, DistanceMetric::Cosine)
+        .expect("create collection");
+
+    let coll = db.get_collection(name).expect("collection exists");
+    let points: Vec<Point> = (1..=count)
+        .map(|i| Point {
+            id: i,
+            vector: vec![i as f32; dim],
+            payload: None,
+            sparse_vectors: None,
+        })
+        .collect();
+    coll.upsert(points).expect("upsert");
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// analyze_collection
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn analyze_collection_returns_valid_stats() {
+    let (_dir, db) = temp_database();
+    setup_collection(&db, "test_stats", 4, 10);
+
+    let stats = db.analyze_collection("test_stats").expect("analyze");
+    assert_eq!(stats.total_points, 10);
+}
+
+#[test]
+fn analyze_collection_nonexistent_returns_error() {
+    let (_dir, db) = temp_database();
+    let result = db.analyze_collection("nonexistent");
+    assert!(result.is_err());
+}
+
+#[test]
+fn analyze_collection_persists_to_disk() {
+    let (dir, db) = temp_database();
+    setup_collection(&db, "persist_stats", 4, 5);
+
+    db.analyze_collection("persist_stats").expect("analyze");
+
+    // The stats file should now exist on disk
+    let stats_path = dir
+        .path()
+        .join("persist_stats")
+        .join("collection.stats.json");
+    assert!(stats_path.exists(), "stats file should be persisted");
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// get_collection_stats round-trip
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn get_collection_stats_returns_none_before_analyze() {
+    let (_dir, db) = temp_database();
+    setup_collection(&db, "no_stats", 4, 3);
+
+    let result = db
+        .get_collection_stats("no_stats")
+        .expect("should not error");
+    assert!(result.is_none(), "no stats before analyze");
+}
+
+#[test]
+fn get_collection_stats_returns_cached_after_analyze() {
+    let (_dir, db) = temp_database();
+    setup_collection(&db, "cached_stats", 4, 7);
+
+    let original = db.analyze_collection("cached_stats").expect("analyze");
+
+    let cached = db
+        .get_collection_stats("cached_stats")
+        .expect("get stats")
+        .expect("should be Some");
+    assert_eq!(cached.total_points, original.total_points);
+}
+
+#[test]
+fn get_collection_stats_loads_from_disk() {
+    let dir = TempDir::new().expect("tempdir");
+
+    // Open DB, create collection, analyze, then drop DB
+    {
+        let db = Database::open(dir.path()).expect("open");
+        setup_collection(&db, "disk_stats", 4, 8);
+        db.analyze_collection("disk_stats").expect("analyze");
+    }
+
+    // Re-open DB -- stats should be loadable from disk
+    let db2 = Database::open(dir.path()).expect("reopen");
+    let loaded = db2
+        .get_collection_stats("disk_stats")
+        .expect("get stats")
+        .expect("should load from disk");
+    assert_eq!(loaded.total_points, 8);
+}

--- a/crates/velesdb-core/src/guardrails/mod.rs
+++ b/crates/velesdb-core/src/guardrails/mod.rs
@@ -11,6 +11,8 @@
 mod context;
 mod limits;
 mod resilience;
+#[cfg(test)]
+mod resilience_tests;
 
 pub use context::QueryContext;
 pub use limits::{

--- a/crates/velesdb-core/src/guardrails/resilience_tests.rs
+++ b/crates/velesdb-core/src/guardrails/resilience_tests.rs
@@ -1,0 +1,139 @@
+//! Tests for `RateLimiter` and `CircuitBreaker` resilience primitives.
+
+use super::resilience::{CircuitBreaker, CircuitState, RateLimiter};
+use crate::guardrails::limits::GuardRailViolation;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// RateLimiter
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn rate_limiter_allows_within_limit() {
+    let limiter = RateLimiter::new(10);
+    // First 10 requests should succeed (initial bucket = limit)
+    for i in 0..10 {
+        assert!(
+            limiter.check("client-a").is_ok(),
+            "request {i} should be allowed"
+        );
+    }
+}
+
+#[test]
+fn rate_limiter_rejects_over_limit() {
+    let limiter = RateLimiter::new(3);
+    // Exhaust all 3 tokens
+    for _ in 0..3 {
+        limiter.check("client-b").expect("should be allowed");
+    }
+    // 4th request should be rejected
+    let result = limiter.check("client-b");
+    assert!(result.is_err());
+    match result.unwrap_err() {
+        GuardRailViolation::RateLimitExceeded { limit_qps } => {
+            assert_eq!(limit_qps, 3);
+        }
+        other => panic!("expected RateLimitExceeded, got: {other}"),
+    }
+}
+
+#[test]
+fn rate_limiter_isolates_clients() {
+    let limiter = RateLimiter::new(2);
+    // Exhaust client-a
+    limiter.check("client-a").unwrap();
+    limiter.check("client-a").unwrap();
+    assert!(limiter.check("client-a").is_err());
+
+    // client-b should still have tokens
+    assert!(limiter.check("client-b").is_ok());
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// CircuitBreaker: state transitions
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn circuit_starts_closed() {
+    let cb = CircuitBreaker::new(3, 60);
+    assert_eq!(cb.state(), CircuitState::Closed);
+    assert!(cb.check().is_ok());
+}
+
+#[test]
+fn circuit_opens_after_failure_threshold() {
+    let cb = CircuitBreaker::new(3, 60);
+
+    cb.record_failure();
+    assert_eq!(cb.state(), CircuitState::Closed);
+    cb.record_failure();
+    assert_eq!(cb.state(), CircuitState::Closed);
+    cb.record_failure();
+    // 3 failures with threshold=3 should open
+    assert_eq!(cb.state(), CircuitState::Open);
+}
+
+#[test]
+fn circuit_open_rejects_requests() {
+    let cb = CircuitBreaker::new(1, 9999);
+    cb.record_failure(); // threshold=1 => opens immediately
+    assert_eq!(cb.state(), CircuitState::Open);
+
+    let result = cb.check();
+    assert!(result.is_err());
+    match result.unwrap_err() {
+        GuardRailViolation::CircuitOpen {
+            recovery_in_seconds,
+        } => {
+            assert!(recovery_in_seconds > 0);
+        }
+        other => panic!("expected CircuitOpen, got: {other}"),
+    }
+}
+
+#[test]
+fn circuit_success_resets_failure_count() {
+    let cb = CircuitBreaker::new(3, 60);
+    cb.record_failure();
+    cb.record_failure();
+    // 2 failures, then success resets
+    cb.record_success();
+    assert_eq!(cb.state(), CircuitState::Closed);
+
+    // Should need 3 more failures to open
+    cb.record_failure();
+    cb.record_failure();
+    assert_eq!(cb.state(), CircuitState::Closed);
+    cb.record_failure();
+    assert_eq!(cb.state(), CircuitState::Open);
+}
+
+#[test]
+fn circuit_halfopen_success_closes() {
+    let cb = CircuitBreaker::new(1, 0); // recovery_seconds=0 => immediate
+    cb.record_failure();
+    assert_eq!(cb.state(), CircuitState::Open);
+
+    // With recovery_seconds=0, check() transitions to HalfOpen
+    assert!(cb.check().is_ok());
+    assert_eq!(cb.state(), CircuitState::HalfOpen);
+
+    // A success in HalfOpen should close the circuit
+    cb.record_success();
+    assert_eq!(cb.state(), CircuitState::Closed);
+}
+
+#[test]
+fn circuit_halfopen_failure_reopens() {
+    let cb = CircuitBreaker::new(1, 0);
+    cb.record_failure();
+    assert_eq!(cb.state(), CircuitState::Open);
+
+    // Transition to HalfOpen
+    assert!(cb.check().is_ok());
+    assert_eq!(cb.state(), CircuitState::HalfOpen);
+
+    // Failure in HalfOpen should reopen
+    cb.record_failure();
+    assert_eq!(cb.state(), CircuitState::Open);
+}

--- a/crates/velesdb-core/src/index/hnsw/index/batch.rs
+++ b/crates/velesdb-core/src/index/hnsw/index/batch.rs
@@ -98,6 +98,12 @@ impl HnswIndex {
         // If parallel_insert fails, we avoid orphaned vectors in sidecar storage.
         if let Err(e) = self.inner.read().parallel_insert(&refs_for_hnsw) {
             tracing::error!("insert_batch_parallel: parallel_insert failed: {e}");
+            // Roll back all registered mappings to avoid phantom entries
+            for (idx, _) in &to_insert {
+                if let Some(id) = self.mappings.get_id(*idx) {
+                    self.mappings.remove(id);
+                }
+            }
             return 0;
         }
 
@@ -131,6 +137,10 @@ impl HnswIndex {
         for (idx, vec) in &to_insert {
             if let Err(e) = self.inner.write().insert((vec.as_slice(), *idx)) {
                 tracing::error!("insert_batch_sequential: insert failed: {e}");
+                // Roll back the mapping registered by prepare_batch_insert
+                if let Some(id) = self.mappings.get_id(*idx) {
+                    self.mappings.remove(id);
+                }
                 continue;
             }
             if self.enable_vector_storage {

--- a/crates/velesdb-core/src/index/hnsw/native/graph/search.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/graph/search.rs
@@ -115,6 +115,9 @@ impl<D: DistanceEngine> NativeHnsw<D> {
 
     /// F-04 optimization: acquires both vectors and layers read locks once
     /// before the greedy descent loop, avoiding repeated lock cycles per hop.
+    ///
+    /// Includes software prefetch hints for upcoming neighbor vectors to
+    /// reduce memory latency in upper HNSW layers (mirrors `search_layer`).
     pub(in crate::index::hnsw::native::graph) fn search_layer_single(
         &self,
         query: &[f32],
@@ -122,6 +125,9 @@ impl<D: DistanceEngine> NativeHnsw<D> {
         layer: usize,
     ) -> NodeId {
         self.with_vectors_and_layers_read(|vectors, layers| {
+            let dimension = vectors.dimension();
+            let prefetch_dist =
+                crate::simd_native::calculate_prefetch_distance(dimension);
             let mut best = entry;
             // SAFETY: `entry` is a valid node_id from entry_point (always a
             // successfully inserted node).
@@ -133,23 +139,15 @@ impl<D: DistanceEngine> NativeHnsw<D> {
             loop {
                 let improved = layers[layer]
                     .with_neighbors(best, |neighbors| {
-                        let mut improved = false;
-
-                        for &neighbor in neighbors {
-                            // SAFETY: neighbor is a valid node_id from the graph's
-                            // neighbor list, only containing IDs of inserted nodes.
-                            // - Condition 1: neighbor < vectors.len().
-                            // Reason: Inner loop of greedy descent — bounds check eliminated.
-                            let neighbor_vec = unsafe { vectors.get_unchecked(neighbor) };
-                            let dist = self.distance.distance(query, neighbor_vec);
-                            if dist < best_dist {
-                                best = neighbor;
-                                best_dist = dist;
-                                improved = true;
-                            }
-                        }
-
-                        improved
+                        self.greedy_scan_with_prefetch(
+                            query,
+                            neighbors,
+                            vectors,
+                            dimension,
+                            prefetch_dist,
+                            &mut best,
+                            &mut best_dist,
+                        )
                     })
                     .unwrap_or(false);
 
@@ -160,6 +158,56 @@ impl<D: DistanceEngine> NativeHnsw<D> {
 
             best
         })
+    }
+
+    /// Scans a neighbor list with software prefetch, updating best node/dist.
+    ///
+    /// Returns `true` if a closer neighbor was found during the scan.
+    #[inline]
+    #[allow(clippy::too_many_arguments)]
+    fn greedy_scan_with_prefetch(
+        &self,
+        query: &[f32],
+        neighbors: &[NodeId],
+        vectors: &crate::perf_optimizations::ContiguousVectors,
+        dimension: usize,
+        prefetch_dist: usize,
+        best: &mut NodeId,
+        best_dist: &mut f32,
+    ) -> bool {
+        // Prefetch the first batch of neighbor vectors into cache.
+        if dimension >= 384 && neighbors.len() > prefetch_dist {
+            for &neighbor_id in neighbors.iter().take(prefetch_dist) {
+                if neighbor_id < vectors.len() {
+                    vectors.prefetch(neighbor_id);
+                }
+            }
+        }
+
+        let mut improved = false;
+        for (i, &neighbor) in neighbors.iter().enumerate() {
+            // Prefetch upcoming neighbor vectors while processing the current one.
+            if dimension >= 384 && i + prefetch_dist < neighbors.len() {
+                let prefetch_id = neighbors[i + prefetch_dist];
+                if prefetch_id < vectors.len() {
+                    vectors.prefetch(prefetch_id);
+                }
+            }
+
+            // SAFETY: neighbor is a valid node_id from the graph's
+            // neighbor list, only containing IDs of inserted nodes.
+            // - Condition 1: neighbor < vectors.len().
+            // Reason: Inner loop of greedy descent — bounds check eliminated.
+            let neighbor_vec = unsafe { vectors.get_unchecked(neighbor) };
+            let dist = self.distance.distance(query, neighbor_vec);
+            if dist < *best_dist {
+                *best = neighbor;
+                *best_dist = dist;
+                improved = true;
+            }
+        }
+
+        improved
     }
 
     /// Search a single layer with ef candidates.

--- a/crates/velesdb-core/src/index/hnsw/native/graph/search.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/graph/search.rs
@@ -126,8 +126,7 @@ impl<D: DistanceEngine> NativeHnsw<D> {
     ) -> NodeId {
         self.with_vectors_and_layers_read(|vectors, layers| {
             let dimension = vectors.dimension();
-            let prefetch_dist =
-                crate::simd_native::calculate_prefetch_distance(dimension);
+            let prefetch_dist = crate::simd_native::calculate_prefetch_distance(dimension);
             let mut best = entry;
             // SAFETY: `entry` is a valid node_id from entry_point (always a
             // successfully inserted node).
@@ -160,6 +159,21 @@ impl<D: DistanceEngine> NativeHnsw<D> {
         })
     }
 
+    /// Prefetch neighbor vectors into CPU cache ahead of access.
+    #[inline]
+    fn prefetch_neighbors(
+        neighbors: &[NodeId],
+        vectors: &crate::perf_optimizations::ContiguousVectors,
+        start: usize,
+        count: usize,
+    ) {
+        for &neighbor_id in neighbors.iter().skip(start).take(count) {
+            if neighbor_id < vectors.len() {
+                vectors.prefetch(neighbor_id);
+            }
+        }
+    }
+
     /// Scans a neighbor list with software prefetch, updating best node/dist.
     ///
     /// Returns `true` if a closer neighbor was found during the scan.
@@ -175,23 +189,18 @@ impl<D: DistanceEngine> NativeHnsw<D> {
         best: &mut NodeId,
         best_dist: &mut f32,
     ) -> bool {
+        let use_prefetch = dimension >= 384;
+
         // Prefetch the first batch of neighbor vectors into cache.
-        if dimension >= 384 && neighbors.len() > prefetch_dist {
-            for &neighbor_id in neighbors.iter().take(prefetch_dist) {
-                if neighbor_id < vectors.len() {
-                    vectors.prefetch(neighbor_id);
-                }
-            }
+        if use_prefetch && neighbors.len() > prefetch_dist {
+            Self::prefetch_neighbors(neighbors, vectors, 0, prefetch_dist);
         }
 
         let mut improved = false;
         for (i, &neighbor) in neighbors.iter().enumerate() {
             // Prefetch upcoming neighbor vectors while processing the current one.
-            if dimension >= 384 && i + prefetch_dist < neighbors.len() {
-                let prefetch_id = neighbors[i + prefetch_dist];
-                if prefetch_id < vectors.len() {
-                    vectors.prefetch(prefetch_id);
-                }
+            if use_prefetch && i + prefetch_dist < neighbors.len() {
+                Self::prefetch_neighbors(neighbors, vectors, i + prefetch_dist, 1);
             }
 
             // SAFETY: neighbor is a valid node_id from the graph's

--- a/crates/velesdb-core/src/index/hnsw/native_index.rs
+++ b/crates/velesdb-core/src/index/hnsw/native_index.rs
@@ -293,10 +293,9 @@ impl NativeHnswIndex {
     /// Returns an error if allocation or insertion fails.
     pub fn insert(&self, id: u64, vector: &[f32]) -> crate::error::Result<()> {
         // Register ID and get internal index (or get existing)
-        let internal_idx = self
-            .mappings
-            .register(id)
-            .or_else(|| self.mappings.get_idx(id));
+        // Track whether we newly registered this ID (vs. re-inserting an existing one)
+        let newly_registered = self.mappings.register(id);
+        let internal_idx = newly_registered.or_else(|| self.mappings.get_idx(id));
         let Some(internal_idx) = internal_idx else {
             debug_assert!(
                 false,
@@ -304,7 +303,14 @@ impl NativeHnswIndex {
             );
             return Ok(());
         };
-        self.inner.read().insert((vector, internal_idx))?;
+
+        // If graph insertion fails, roll back the mapping to avoid orphaned entries
+        if let Err(e) = self.inner.read().insert((vector, internal_idx)) {
+            if newly_registered.is_some() {
+                self.mappings.remove(id);
+            }
+            return Err(e);
+        }
 
         if self.enable_vector_storage {
             self.vectors.insert(internal_idx, vector);
@@ -321,13 +327,17 @@ impl NativeHnswIndex {
     ///
     /// Returns an error if any insertion fails.
     pub fn insert_batch(&self, items: &[(u64, Vec<f32>)]) -> crate::error::Result<()> {
+        // Track newly registered IDs so we can roll back on failure
+        let mut newly_registered_ids: Vec<u64> = Vec::new();
+
         let data: Vec<(Vec<f32>, usize)> = items
             .iter()
             .filter_map(|(id, vec)| {
-                let idx = self
-                    .mappings
-                    .register(*id)
-                    .or_else(|| self.mappings.get_idx(*id));
+                let is_new = self.mappings.register(*id);
+                if is_new.is_some() {
+                    newly_registered_ids.push(*id);
+                }
+                let idx = is_new.or_else(|| self.mappings.get_idx(*id));
                 let Some(idx) = idx else {
                     debug_assert!(
                         false,
@@ -340,7 +350,14 @@ impl NativeHnswIndex {
             .collect();
 
         let refs: Vec<(&Vec<f32>, usize)> = data.iter().map(|(v, i)| (v, *i)).collect();
-        self.inner.read().parallel_insert(&refs)?;
+
+        // If parallel_insert fails, roll back all newly registered mappings
+        if let Err(e) = self.inner.read().parallel_insert(&refs) {
+            for id in &newly_registered_ids {
+                self.mappings.remove(*id);
+            }
+            return Err(e);
+        }
 
         if self.enable_vector_storage {
             for (vec, idx) in data {

--- a/crates/velesdb-core/src/lib.rs
+++ b/crates/velesdb-core/src/lib.rs
@@ -19,7 +19,6 @@
 //! use velesdb_core::{Database, DistanceMetric, Point, StorageMode};
 //! use serde_json::json;
 //!
-//! #[allow(deprecated)]
 //! fn main() -> Result<(), Box<dyn std::error::Error>> {
 //!     // Create a new database
 //!     let db = Database::open("./data")?;
@@ -28,7 +27,7 @@
 //!     db.create_collection("documents", 768, DistanceMetric::Cosine)?;
 //!     // Or with quantization: DistanceMetric::Hamming + StorageMode::Binary
 //!
-//!     let collection = db.get_collection("documents").ok_or("Collection not found")?;
+//!     let collection = db.get_vector_collection("documents").ok_or("Collection not found")?;
 //!
 //!     // Insert vectors (upsert takes ownership)
 //!     collection.upsert(vec![

--- a/crates/velesdb-core/src/simd_native/neon.rs
+++ b/crates/velesdb-core/src/simd_native/neon.rs
@@ -147,25 +147,226 @@ fn dot_product_neon_4acc(a: &[f32], b: &[f32]) -> f32 {
 // Cosine Similarity
 // =============================================================================
 
-/// ARM NEON cosine similarity — fused: dot(a,b) / (‖a‖ × ‖b‖).
+/// ARM NEON cosine similarity — fused single-pass kernel.
 ///
-/// Uses the 4-accumulator dot-product kernel for vectors ≥ 64 elements.
-/// Falls back to the 1-accumulator kernel for smaller vectors.
+/// Computes `dot(a,b)`, `norm(a)^2`, and `norm(b)^2` simultaneously in one
+/// pass over the data, using 3 independent NEON accumulators. For vectors
+/// with >= 64 elements, delegates to [`cosine_fused_neon_4acc`] which uses
+/// 12 accumulators (3 products x 4-way ILP).
+///
+/// This replaces the prior 3-pass approach (`dot_product_neon` called 3x).
 #[cfg(target_arch = "aarch64")]
 #[inline]
 pub(crate) fn cosine_neon(a: &[f32], b: &[f32]) -> f32 {
-    let dot = dot_product_neon(a, b);
-    let norm_a_sq = dot_product_neon(a, a);
-    let norm_b_sq = dot_product_neon(b, b);
+    if a.len() >= 64 {
+        // SAFETY: `cosine_fused_neon_4acc` requires NEON (guaranteed on aarch64)
+        // and len >= 64 (checked above).
+        // Reason: Delegate to the 4-accumulator ILP variant for large vectors.
+        return unsafe { cosine_fused_neon_4acc(a, b) };
+    }
+    // SAFETY: `cosine_fused_neon_1acc` requires NEON (guaranteed on aarch64).
+    // Reason: Single-accumulator variant for small/medium vectors.
+    unsafe { cosine_fused_neon_1acc(a, b) }
+}
 
-    if norm_a_sq == 0.0 || norm_b_sq == 0.0 {
-        return 0.0;
+/// Single-accumulator fused cosine for vectors with < 64 elements.
+#[cfg(target_arch = "aarch64")]
+#[inline]
+unsafe fn cosine_fused_neon_1acc(a: &[f32], b: &[f32]) -> f32 {
+    use std::arch::aarch64::*;
+
+    let len = a.len();
+    let simd_len = len / 4;
+
+    // SAFETY: `vdupq_n_f32` is a non-faulting register initialisation on aarch64.
+    // - Condition 1: NEON is always present on aarch64.
+    // - Condition 2: Immediate value 0.0 is valid for the instruction.
+    // Reason: Initialise three SIMD accumulators (dot, norm_a, norm_b).
+    let mut dot_acc = vdupq_n_f32(0.0);
+    let mut na_acc = vdupq_n_f32(0.0);
+    let mut nb_acc = vdupq_n_f32(0.0);
+
+    let a_ptr = a.as_ptr();
+    let b_ptr = b.as_ptr();
+
+    for i in 0..simd_len {
+        let offset = i * 4;
+        // SAFETY: `vld1q_f32`/`vfmaq_f32` are non-faulting NEON operations.
+        // - Condition 1: `offset + 4 <= simd_len * 4 <= len`, pointers within bounds.
+        // - Condition 2: `vld1q_f32` supports unaligned loads on ARM64.
+        // Reason: Single-pass accumulation of dot, norm_a_sq, norm_b_sq.
+        let va = vld1q_f32(a_ptr.add(offset));
+        let vb = vld1q_f32(b_ptr.add(offset));
+        dot_acc = vfmaq_f32(dot_acc, va, vb);
+        na_acc = vfmaq_f32(na_acc, va, va);
+        nb_acc = vfmaq_f32(nb_acc, vb, vb);
     }
 
+    // SAFETY: `vaddvq_f32` reduces a 128-bit register to scalar on aarch64.
+    // - Condition 1: All accumulators are valid float32x4_t values.
+    // Reason: Horizontal reduction of the three accumulators.
+    let mut dot = vaddvq_f32(dot_acc);
+    let mut norm_a_sq = vaddvq_f32(na_acc);
+    let mut norm_b_sq = vaddvq_f32(nb_acc);
+
+    let base = simd_len * 4;
+    for i in base..len {
+        let x = a[i];
+        let y = b[i];
+        dot += x * y;
+        norm_a_sq += x * x;
+        norm_b_sq += y * y;
+    }
+
+    finalize_cosine(dot, norm_a_sq, norm_b_sq)
+}
+
+/// Four-accumulator fused cosine for vectors with >= 64 elements.
+///
+/// Uses 12 NEON registers (3 products x 4-way ILP) and processes 16
+/// elements per iteration, following the pattern from `cosine_fused_avx2_2acc`.
+#[cfg(target_arch = "aarch64")]
+#[inline]
+unsafe fn cosine_fused_neon_4acc(a: &[f32], b: &[f32]) -> f32 {
+    let len = a.len();
+    let main_end = len / 16 * 16;
+    // SAFETY: `add` on a raw pointer derived from a valid slice.
+    // - Condition 1: `main_end <= len`, so pointer stays within the allocation.
+    // - Condition 2: `add(len)` yields one-past-end, valid for comparison.
+    // Reason: Establish loop bounds for 16-wide main body and scalar tail.
+    let end_main = a.as_ptr().add(main_end);
+    let end_ptr = a.as_ptr().add(len);
+
+    let (dot, norm_a_sq, norm_b_sq) =
+        cosine_fused_neon_main_loop(a.as_ptr(), b.as_ptr(), end_main);
+
+    let (dot, norm_a_sq, norm_b_sq) = cosine_fused_neon_scalar_tail(
+        end_main,
+        b.as_ptr().add(main_end),
+        end_ptr,
+        dot,
+        norm_a_sq,
+        norm_b_sq,
+    );
+
+    finalize_cosine(dot, norm_a_sq, norm_b_sq)
+}
+
+/// Main 16-wide SIMD loop for fused cosine (4-acc ILP).
+///
+/// Returns `(dot, norm_a_sq, norm_b_sq)` accumulated over full 16-element blocks.
+#[cfg(target_arch = "aarch64")]
+#[inline]
+unsafe fn cosine_fused_neon_main_loop(
+    mut a_ptr: *const f32,
+    mut b_ptr: *const f32,
+    end_main: *const f32,
+) -> (f32, f32, f32) {
+    use std::arch::aarch64::*;
+
+    // SAFETY: `vdupq_n_f32` is a non-faulting register initialisation on aarch64.
+    // - Condition 1: NEON is always present on aarch64.
+    // - Condition 2: Immediate 0.0 is valid.
+    // Reason: Initialise 12 accumulators (3 products x 4-way ILP).
+    let mut d0 = vdupq_n_f32(0.0);
+    let mut d1 = vdupq_n_f32(0.0);
+    let mut d2 = vdupq_n_f32(0.0);
+    let mut d3 = vdupq_n_f32(0.0);
+    let mut na0 = vdupq_n_f32(0.0);
+    let mut na1 = vdupq_n_f32(0.0);
+    let mut na2 = vdupq_n_f32(0.0);
+    let mut na3 = vdupq_n_f32(0.0);
+    let mut nb0 = vdupq_n_f32(0.0);
+    let mut nb1 = vdupq_n_f32(0.0);
+    let mut nb2 = vdupq_n_f32(0.0);
+    let mut nb3 = vdupq_n_f32(0.0);
+
+    while a_ptr < end_main {
+        // SAFETY: Loop condition guarantees 16 elements remain before `end_main`.
+        // - Condition 1: `vld1q_f32` supports unaligned loads on ARM64.
+        // Reason: 16-wide single-pass accumulation with 4-way ILP.
+        let va0 = vld1q_f32(a_ptr);
+        let vb0 = vld1q_f32(b_ptr);
+        d0 = vfmaq_f32(d0, va0, vb0);
+        na0 = vfmaq_f32(na0, va0, va0);
+        nb0 = vfmaq_f32(nb0, vb0, vb0);
+
+        let va1 = vld1q_f32(a_ptr.add(4));
+        let vb1 = vld1q_f32(b_ptr.add(4));
+        d1 = vfmaq_f32(d1, va1, vb1);
+        na1 = vfmaq_f32(na1, va1, va1);
+        nb1 = vfmaq_f32(nb1, vb1, vb1);
+
+        let va2 = vld1q_f32(a_ptr.add(8));
+        let vb2 = vld1q_f32(b_ptr.add(8));
+        d2 = vfmaq_f32(d2, va2, vb2);
+        na2 = vfmaq_f32(na2, va2, va2);
+        nb2 = vfmaq_f32(nb2, vb2, vb2);
+
+        let va3 = vld1q_f32(a_ptr.add(12));
+        let vb3 = vld1q_f32(b_ptr.add(12));
+        d3 = vfmaq_f32(d3, va3, vb3);
+        na3 = vfmaq_f32(na3, va3, va3);
+        nb3 = vfmaq_f32(nb3, vb3, vb3);
+
+        a_ptr = a_ptr.add(16);
+        b_ptr = b_ptr.add(16);
+    }
+
+    // SAFETY: `vaddq_f32`/`vaddvq_f32` are non-faulting register operations.
+    // - Condition 1: All accumulators hold valid float32x4_t values.
+    // Reason: Reduce 4 accumulators per product to scalar results.
+    let d01 = vaddq_f32(d0, d1);
+    let d23 = vaddq_f32(d2, d3);
+    let dot = vaddvq_f32(vaddq_f32(d01, d23));
+
+    let na01 = vaddq_f32(na0, na1);
+    let na23 = vaddq_f32(na2, na3);
+    let norm_a_sq = vaddvq_f32(vaddq_f32(na01, na23));
+
+    let nb01 = vaddq_f32(nb0, nb1);
+    let nb23 = vaddq_f32(nb2, nb3);
+    let norm_b_sq = vaddvq_f32(vaddq_f32(nb01, nb23));
+
+    (dot, norm_a_sq, norm_b_sq)
+}
+
+/// Scalar tail for fused cosine — handles the remaining 0..15 elements.
+#[cfg(target_arch = "aarch64")]
+#[inline]
+unsafe fn cosine_fused_neon_scalar_tail(
+    mut a_ptr: *const f32,
+    mut b_ptr: *const f32,
+    end_ptr: *const f32,
+    mut dot: f32,
+    mut norm_a_sq: f32,
+    mut norm_b_sq: f32,
+) -> (f32, f32, f32) {
+    while a_ptr < end_ptr {
+        // SAFETY: Loop condition guarantees both pointers are within slice bounds.
+        // - Condition 1: `b_ptr` advances in step with `a_ptr`.
+        // Reason: Handle remaining elements the 16-wide loop did not cover.
+        let x = *a_ptr;
+        let y = *b_ptr;
+        dot += x * y;
+        norm_a_sq += x * x;
+        norm_b_sq += y * y;
+        a_ptr = a_ptr.add(1);
+        b_ptr = b_ptr.add(1);
+    }
+    (dot, norm_a_sq, norm_b_sq)
+}
+
+/// Finalize cosine from dot product and squared norms.
+#[cfg(target_arch = "aarch64")]
+#[inline]
+fn finalize_cosine(dot: f32, norm_a_sq: f32, norm_b_sq: f32) -> f32 {
     let norm_a = norm_a_sq.sqrt();
     let norm_b = norm_b_sq.sqrt();
-
-    dot / (norm_a * norm_b)
+    if norm_a < f32::EPSILON || norm_b < f32::EPSILON {
+        return 0.0;
+    }
+    (dot / (norm_a * norm_b)).clamp(-1.0, 1.0)
 }
 
 // =============================================================================

--- a/crates/velesdb-core/src/simd_native/neon.rs
+++ b/crates/velesdb-core/src/simd_native/neon.rs
@@ -237,8 +237,7 @@ unsafe fn cosine_fused_neon_4acc(a: &[f32], b: &[f32]) -> f32 {
     let end_main = a.as_ptr().add(main_end);
     let end_ptr = a.as_ptr().add(len);
 
-    let (dot, norm_a_sq, norm_b_sq) =
-        cosine_fused_neon_main_loop(a.as_ptr(), b.as_ptr(), end_main);
+    let (dot, norm_a_sq, norm_b_sq) = cosine_fused_neon_main_loop(a.as_ptr(), b.as_ptr(), end_main);
 
     let (dot, norm_a_sq, norm_b_sq) = cosine_fused_neon_scalar_tail(
         end_main,
@@ -250,6 +249,26 @@ unsafe fn cosine_fused_neon_4acc(a: &[f32], b: &[f32]) -> f32 {
     );
 
     finalize_cosine(dot, norm_a_sq, norm_b_sq)
+}
+
+/// Reduces 4 NEON f32x4 accumulators to a single scalar sum.
+///
+/// SAFETY: All inputs must be valid `float32x4_t` values.
+#[cfg(target_arch = "aarch64")]
+#[inline]
+unsafe fn reduce_4acc_neon(
+    a0: std::arch::aarch64::float32x4_t,
+    a1: std::arch::aarch64::float32x4_t,
+    a2: std::arch::aarch64::float32x4_t,
+    a3: std::arch::aarch64::float32x4_t,
+) -> f32 {
+    use std::arch::aarch64::*;
+    // SAFETY: `vaddq_f32`/`vaddvq_f32` are non-faulting register operations.
+    // - Condition 1: All accumulators hold valid float32x4_t values.
+    // Reason: Reduce 4 accumulators to scalar result.
+    let ab01 = vaddq_f32(a0, a1);
+    let ab23 = vaddq_f32(a2, a3);
+    vaddvq_f32(vaddq_f32(ab01, ab23))
 }
 
 /// Main 16-wide SIMD loop for fused cosine (4-acc ILP).
@@ -268,18 +287,12 @@ unsafe fn cosine_fused_neon_main_loop(
     // - Condition 1: NEON is always present on aarch64.
     // - Condition 2: Immediate 0.0 is valid.
     // Reason: Initialise 12 accumulators (3 products x 4-way ILP).
-    let mut d0 = vdupq_n_f32(0.0);
-    let mut d1 = vdupq_n_f32(0.0);
-    let mut d2 = vdupq_n_f32(0.0);
-    let mut d3 = vdupq_n_f32(0.0);
-    let mut na0 = vdupq_n_f32(0.0);
-    let mut na1 = vdupq_n_f32(0.0);
-    let mut na2 = vdupq_n_f32(0.0);
-    let mut na3 = vdupq_n_f32(0.0);
-    let mut nb0 = vdupq_n_f32(0.0);
-    let mut nb1 = vdupq_n_f32(0.0);
-    let mut nb2 = vdupq_n_f32(0.0);
-    let mut nb3 = vdupq_n_f32(0.0);
+    let (mut d0, mut d1, mut d2, mut d3) =
+        (vdupq_n_f32(0.0), vdupq_n_f32(0.0), vdupq_n_f32(0.0), vdupq_n_f32(0.0));
+    let (mut na0, mut na1, mut na2, mut na3) =
+        (vdupq_n_f32(0.0), vdupq_n_f32(0.0), vdupq_n_f32(0.0), vdupq_n_f32(0.0));
+    let (mut nb0, mut nb1, mut nb2, mut nb3) =
+        (vdupq_n_f32(0.0), vdupq_n_f32(0.0), vdupq_n_f32(0.0), vdupq_n_f32(0.0));
 
     while a_ptr < end_main {
         // SAFETY: Loop condition guarantees 16 elements remain before `end_main`.
@@ -313,22 +326,11 @@ unsafe fn cosine_fused_neon_main_loop(
         b_ptr = b_ptr.add(16);
     }
 
-    // SAFETY: `vaddq_f32`/`vaddvq_f32` are non-faulting register operations.
-    // - Condition 1: All accumulators hold valid float32x4_t values.
-    // Reason: Reduce 4 accumulators per product to scalar results.
-    let d01 = vaddq_f32(d0, d1);
-    let d23 = vaddq_f32(d2, d3);
-    let dot = vaddvq_f32(vaddq_f32(d01, d23));
-
-    let na01 = vaddq_f32(na0, na1);
-    let na23 = vaddq_f32(na2, na3);
-    let norm_a_sq = vaddvq_f32(vaddq_f32(na01, na23));
-
-    let nb01 = vaddq_f32(nb0, nb1);
-    let nb23 = vaddq_f32(nb2, nb3);
-    let norm_b_sq = vaddvq_f32(vaddq_f32(nb01, nb23));
-
-    (dot, norm_a_sq, norm_b_sq)
+    (
+        reduce_4acc_neon(d0, d1, d2, d3),
+        reduce_4acc_neon(na0, na1, na2, na3),
+        reduce_4acc_neon(nb0, nb1, nb2, nb3),
+    )
 }
 
 /// Scalar tail for fused cosine — handles the remaining 0..15 elements.

--- a/crates/velesdb-core/src/storage/guard_tests.rs
+++ b/crates/velesdb-core/src/storage/guard_tests.rs
@@ -1,0 +1,116 @@
+//! Tests for [`VectorSliceGuard`] epoch validation, `as_slice()`,
+//! `Deref`, and `AsRef` behavior on epoch mismatch.
+
+use super::guard::VectorSliceGuard;
+use memmap2::MmapMut;
+use parking_lot::RwLock;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// Helper: builds a `VectorSliceGuard` pointing at `data` with the given
+/// creation epoch. The `epoch_ptr` is shared so tests can bump it.
+fn make_guard<'a>(
+    lock: &'a RwLock<MmapMut>,
+    data: &[f32],
+    epoch_ptr: &'a AtomicU64,
+    creation_epoch: u64,
+) -> VectorSliceGuard<'a> {
+    VectorSliceGuard {
+        _guard: lock.read(),
+        ptr: data.as_ptr(),
+        len: data.len(),
+        epoch_ptr,
+        epoch_at_creation: creation_epoch,
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// as_slice() returns Ok on valid guard
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn guard_as_slice_valid_epoch() {
+    let data: Vec<f32> = vec![1.0, 2.0, 3.0];
+    let mmap = MmapMut::map_anon(4096).expect("anon mmap");
+    let lock = RwLock::new(mmap);
+    let epoch = AtomicU64::new(1);
+
+    let guard = make_guard(&lock, &data, &epoch, 1);
+    let slice = guard.as_slice().expect("should succeed");
+    assert_eq!(slice, &[1.0, 2.0, 3.0]);
+}
+
+#[test]
+fn guard_try_deref_same_as_slice() {
+    let data: Vec<f32> = vec![4.0, 5.0];
+    let mmap = MmapMut::map_anon(4096).expect("anon mmap");
+    let lock = RwLock::new(mmap);
+    let epoch = AtomicU64::new(0);
+
+    let guard = make_guard(&lock, &data, &epoch, 0);
+    let via_slice = guard.as_slice().expect("ok");
+    let via_try = guard.try_deref().expect("ok");
+    assert_eq!(via_slice, via_try);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// as_slice() returns Err on epoch mismatch
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn guard_as_slice_epoch_mismatch() {
+    let data: Vec<f32> = vec![1.0, 2.0];
+    let mmap = MmapMut::map_anon(4096).expect("anon mmap");
+    let lock = RwLock::new(mmap);
+    let epoch = AtomicU64::new(1);
+
+    // Guard was created at epoch 1, but global epoch advances to 2
+    let guard = make_guard(&lock, &data, &epoch, 1);
+    epoch.store(2, Ordering::Release);
+
+    let result = guard.as_slice();
+    assert!(result.is_err(), "stale epoch should return Err");
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Deref / AsRef return empty slice on mismatch
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn guard_deref_returns_empty_on_mismatch() {
+    let data: Vec<f32> = vec![9.0, 8.0, 7.0];
+    let mmap = MmapMut::map_anon(4096).expect("anon mmap");
+    let lock = RwLock::new(mmap);
+    let epoch = AtomicU64::new(5);
+
+    let guard = make_guard(&lock, &data, &epoch, 5);
+    epoch.store(6, Ordering::Release);
+
+    let slice: &[f32] = &guard;
+    assert!(slice.is_empty(), "Deref must return empty on mismatch");
+}
+
+#[test]
+fn guard_as_ref_returns_empty_on_mismatch() {
+    let data: Vec<f32> = vec![1.0];
+    let mmap = MmapMut::map_anon(4096).expect("anon mmap");
+    let lock = RwLock::new(mmap);
+    let epoch = AtomicU64::new(10);
+
+    let guard = make_guard(&lock, &data, &epoch, 10);
+    epoch.store(11, Ordering::Release);
+
+    let slice: &[f32] = guard.as_ref();
+    assert!(slice.is_empty(), "AsRef must return empty on mismatch");
+}
+
+#[test]
+fn guard_deref_valid_epoch_returns_data() {
+    let data: Vec<f32> = vec![3.125, 2.71];
+    let mmap = MmapMut::map_anon(4096).expect("anon mmap");
+    let lock = RwLock::new(mmap);
+    let epoch = AtomicU64::new(42);
+
+    let guard = make_guard(&lock, &data, &epoch, 42);
+    let slice: &[f32] = &guard;
+    assert_eq!(slice, &[3.125, 2.71]);
+}

--- a/crates/velesdb-core/src/storage/log_payload.rs
+++ b/crates/velesdb-core/src/storage/log_payload.rs
@@ -452,8 +452,16 @@ impl PayloadStorage for LogPayloadStorage {
         record.extend_from_slice(&payload_bytes);
         wal.write_all(&record)?;
 
-        // Sync WAL according to durability mode
-        Self::sync_wal(&mut wal, self.durability)?;
+        // Sync WAL according to durability mode.
+        // If sync fails, the BufWriter may have partially flushed data to disk.
+        // Resync write_offset with the actual file length to prevent desync
+        // on subsequent writes.
+        if let Err(e) = Self::sync_wal(&mut wal, self.durability) {
+            if let Ok(meta) = wal.get_ref().metadata() {
+                *offset = meta.len();
+            }
+            return Err(e);
+        }
 
         // Marker(1) + ID(8) = 9 bytes before the length field
         let bytes_written = 1 + 8 + 4 + u64::from(len_u32);
@@ -506,8 +514,14 @@ impl PayloadStorage for LogPayloadStorage {
         record[1..9].copy_from_slice(&id.to_le_bytes());
         wal.write_all(&record)?;
 
-        // Sync WAL according to durability mode
-        Self::sync_wal(&mut wal, self.durability)?;
+        // Sync WAL according to durability mode.
+        // On failure, resync write_offset with actual file length (see store()).
+        if let Err(e) = Self::sync_wal(&mut wal, self.durability) {
+            if let Ok(meta) = wal.get_ref().metadata() {
+                *offset = meta.len();
+            }
+            return Err(e);
+        }
 
         *offset += 1 + 8; // Marker(1) + ID(8)
         index.remove(&id);

--- a/crates/velesdb-core/src/storage/mod.rs
+++ b/crates/velesdb-core/src/storage/mod.rs
@@ -31,6 +31,8 @@ mod vector_bytes_tests;
 #[cfg(test)]
 mod compaction_tests;
 #[cfg(test)]
+mod guard_tests;
+#[cfg(test)]
 mod histogram_tests;
 #[cfg(test)]
 mod log_payload_tests;

--- a/crates/velesdb-python/python/velesdb/__init__.py
+++ b/crates/velesdb-python/python/velesdb/__init__.py
@@ -10,11 +10,17 @@ from __future__ import annotations
 from typing import Any, Dict, Iterable, List, Optional
 
 from velesdb.velesdb import (  # type: ignore[attr-defined]
+    AgentMemory,
     Collection as _RawCollection,
     Database as _RawDatabase,
     FusionStrategy,
     GraphStore as _RawGraphStore,
     ParsedStatement,
+    PyEpisodicMemory,
+    PyGraphCollection,
+    PyGraphSchema,
+    PyProceduralMemory,
+    PySemanticMemory,
     SearchResult,
     StreamingConfig,
     TraversalResult,
@@ -158,11 +164,20 @@ class Collection:
 
     def search(
         self,
-        vector: Iterable[float],
+        vector: Optional[Iterable[float]] = None,
         top_k: int = 10,
         filter: Optional[Dict[str, Any]] = None,
+        sparse_vector: Optional[Any] = None,
+        sparse_index_name: Optional[str] = None,
     ) -> List[Dict[str, Any]]:
-        results = self._inner.search(list(vector), top_k)
+        kwargs: Dict[str, Any] = {"top_k": top_k}
+        if vector is not None:
+            kwargs["vector"] = list(vector)
+        if sparse_vector is not None:
+            kwargs["sparse_vector"] = sparse_vector
+        if sparse_index_name is not None:
+            kwargs["sparse_index_name"] = sparse_index_name
+        results = self._inner.search(**kwargs)
         if not filter:
             return results
         return [r for r in results if _matches_filter(r.get("payload"), filter)]
@@ -220,6 +235,20 @@ class Database:
         if col is None:
             return None
         return Collection(col)
+
+    def get_or_create_collection(
+        self,
+        name: str,
+        dimension: int,
+        metric: str = "cosine",
+        storage_mode: str = "full",
+    ) -> Collection:
+        existing = self.get_collection(name)
+        if existing is not None:
+            return existing
+        return self.create_collection(
+            name, dimension=dimension, metric=metric, storage_mode=storage_mode
+        )
 
     def create_metadata_collection(self, name: str) -> Collection:
         col = self._inner.create_metadata_collection(name)
@@ -285,5 +314,11 @@ __all__ = [
     "ParsedStatement",
     "VelesQLSyntaxError",
     "VelesQLParameterError",
+    "AgentMemory",
+    "PySemanticMemory",
+    "PyEpisodicMemory",
+    "PyProceduralMemory",
+    "PyGraphCollection",
+    "PyGraphSchema",
     "__version__",
 ]

--- a/crates/velesdb-python/python/velesdb/__init__.pyi
+++ b/crates/velesdb-python/python/velesdb/__init__.pyi
@@ -8,55 +8,36 @@ import numpy as np
 
 __version__: str
 
+
 class FusionStrategy:
     """Strategy for fusing results from multiple vector searches.
-    
+
     Example:
-        >>> # Average fusion
         >>> strategy = FusionStrategy.average()
-        >>> # RRF with default k=60
         >>> strategy = FusionStrategy.rrf()
-        >>> # Weighted fusion
         >>> strategy = FusionStrategy.weighted(avg_weight=0.6, max_weight=0.3, hit_weight=0.1)
+        >>> strategy = FusionStrategy.relative_score(0.7, 0.3)
     """
-    
+
     @staticmethod
     def average() -> "FusionStrategy":
-        """Create an Average fusion strategy.
-        
-        Computes the mean score for each document across all queries.
-        
-        Returns:
-            FusionStrategy: Average fusion strategy
-        """
+        """Create an Average fusion strategy."""
         ...
-    
+
     @staticmethod
     def maximum() -> "FusionStrategy":
-        """Create a Maximum fusion strategy.
-        
-        Takes the maximum score for each document across all queries.
-        
-        Returns:
-            FusionStrategy: Maximum fusion strategy
-        """
+        """Create a Maximum fusion strategy."""
         ...
-    
+
     @staticmethod
     def rrf(k: int = 60) -> "FusionStrategy":
         """Create a Reciprocal Rank Fusion (RRF) strategy.
-        
-        Uses position-based scoring: score = Σ 1/(k + rank)
-        This is robust to score scale differences between queries.
-        
+
         Args:
             k: Ranking constant (default: 60). Lower k gives more weight to top ranks.
-        
-        Returns:
-            FusionStrategy: RRF fusion strategy
         """
         ...
-    
+
     @staticmethod
     def weighted(
         avg_weight: float,
@@ -64,43 +45,50 @@ class FusionStrategy:
         hit_weight: float,
     ) -> "FusionStrategy":
         """Create a Weighted fusion strategy.
-        
-        Combines average score, maximum score, and hit ratio with custom weights.
-        Formula: score = avg_weight * avg + max_weight * max + hit_weight * hit_ratio
-        
+
         Args:
             avg_weight: Weight for average score (0.0-1.0)
             max_weight: Weight for maximum score (0.0-1.0)
             hit_weight: Weight for hit ratio (0.0-1.0)
-        
-        Returns:
-            FusionStrategy: Weighted fusion strategy
-        
+
         Raises:
             ValueError: If weights don't sum to 1.0 or are negative
+        """
+        ...
+
+    @staticmethod
+    def relative_score(dense_weight: float, sparse_weight: float) -> "FusionStrategy":
+        """Create a Relative Score Fusion (RSF) strategy for hybrid dense+sparse search.
+
+        Args:
+            dense_weight: Weight for dense vector scores (0.0-1.0)
+            sparse_weight: Weight for sparse scores (0.0-1.0)
+
+        Raises:
+            ValueError: If weights are invalid
         """
         ...
 
 
 class SearchResult:
     """A single search result from a vector search.
-    
+
     Attributes:
-        id: Unique identifier of the vector
-        score: Similarity score (0.0 to 1.0 for cosine similarity)
+        id: Unique integer identifier of the vector
+        score: Similarity score
         payload: Optional metadata associated with the vector
     """
-    
+
     @property
-    def id(self) -> str:
-        """Unique identifier of the vector."""
+    def id(self) -> int:
+        """Unique integer identifier of the vector."""
         ...
-    
+
     @property
     def score(self) -> float:
         """Similarity score."""
         ...
-    
+
     @property
     def payload(self) -> Optional[Dict[str, Any]]:
         """Optional metadata payload."""
@@ -109,100 +97,257 @@ class SearchResult:
 
 class Collection:
     """A collection of vectors in VelesDB.
-    
+
     Collections store vectors with optional metadata payloads and support
-    various search operations including similarity search, filtered search,
+    various search operations including similarity search, hybrid search,
     and multi-query fusion search.
     """
-    
+
     @property
     def name(self) -> str:
         """Name of the collection."""
         ...
-    
-    @property
-    def dimension(self) -> int:
-        """Dimension of vectors in this collection."""
-        ...
-    
-    @property
-    def len(self) -> int:
-        """Number of vectors in this collection."""
-        ...
-    
-    def insert(
-        self,
-        id: str,
-        vector: Union[List[float], np.ndarray],
-        payload: Optional[Dict[str, Any]] = None,
-    ) -> None:
-        """Insert a single vector into the collection.
-        
-        Args:
-            id: Unique identifier for the vector
-            vector: The vector data (list of floats or numpy array)
-            payload: Optional metadata to store with the vector
+
+    def info(self) -> Dict[str, Any]:
+        """Get collection configuration info.
+
+        Returns:
+            Dict with name, dimension, metric, storage_mode, point_count,
+            and metadata_only keys.
         """
         ...
-    
-    def insert_batch(
-        self,
-        ids: List[str],
-        vectors: Union[List[List[float]], np.ndarray],
-        payloads: Optional[List[Optional[Dict[str, Any]]]] = None,
-    ) -> None:
-        """Insert multiple vectors in a single batch.
-        
+
+    def is_metadata_only(self) -> bool:
+        """Check if this is a metadata-only collection."""
+        ...
+
+    def is_empty(self) -> bool:
+        """Check if the collection is empty."""
+        ...
+
+    def upsert(self, points: List[Dict[str, Any]]) -> int:
+        """Insert or update vectors in the collection.
+
+        Each point dict must have 'id' (int) and 'vector' (list[float]) keys.
+        Optional keys: 'payload' (dict), 'sparse_vector' (dict[int, float]).
+
         Args:
-            ids: List of unique identifiers
-            vectors: List of vectors or 2D numpy array
-            payloads: Optional list of metadata payloads
+            points: List of point dicts
+
+        Returns:
+            Number of upserted points
         """
         ...
-    
+
+    def upsert_metadata(self, points: List[Dict[str, Any]]) -> int:
+        """Insert or update metadata-only points (no vectors).
+
+        Each point dict must have 'id' (int) and 'payload' (dict) keys.
+
+        Args:
+            points: List of point dicts
+
+        Returns:
+            Number of upserted points
+        """
+        ...
+
+    def upsert_bulk(self, points: List[Dict[str, Any]]) -> int:
+        """Bulk insert optimized for high-throughput import.
+
+        Args:
+            points: List of point dicts (same format as upsert)
+
+        Returns:
+            Number of inserted points
+        """
+        ...
+
+    def stream_insert(self, points: List[Dict[str, Any]]) -> int:
+        """Insert points via the streaming ingestion channel.
+
+        Points are buffered and merged asynchronously into the HNSW index.
+
+        Args:
+            points: List of point dicts (same format as upsert)
+
+        Returns:
+            Number of points successfully queued
+        """
+        ...
+
     def search(
         self,
-        vector: Union[List[float], np.ndarray],
+        vector: Optional[Union[List[float], "np.ndarray"]] = None,
+        *,
+        sparse_vector: Optional[Dict[int, float]] = None,
         top_k: int = 10,
         filter: Optional[Dict[str, Any]] = None,
-    ) -> List[SearchResult]:
-        """Search for similar vectors.
-        
-        Args:
-            vector: Query vector
-            top_k: Number of results to return
-            filter: Optional metadata filter
-        
-        Returns:
-            List of SearchResult objects sorted by similarity
-        """
-        ...
-    
-    def search_ids(
-        self,
-        vector: Union[List[float], np.ndarray],
-        top_k: int = 10,
+        sparse_index_name: Optional[str] = None,
     ) -> List[Dict[str, Any]]:
-        """Search and return only IDs and scores.
-        
+        """Search for similar vectors (dense, sparse, or hybrid).
+
+        Modes:
+        - Dense only: ``search(vector, top_k=10)``
+        - Sparse only: ``search(sparse_vector={0: 1.5}, top_k=10)``
+        - Hybrid: ``search(vector, sparse_vector={...}, top_k=10)``
+
         Args:
-            vector: Query vector
-            top_k: Number of results to return
-            filter: Optional metadata filter
-        
+            vector: Dense query vector. Optional if sparse_vector is given.
+            sparse_vector: Sparse query as dict[int, float]. Optional if vector is given.
+            top_k: Number of results to return (default: 10).
+            filter: Optional metadata filter dict.
+            sparse_index_name: Named sparse index to query (default: unnamed index).
+
         Returns:
-            List of (id, score) tuples
+            List of dicts with id, score, and payload.
         """
         ...
 
     def search_with_ef(
         self,
-        vector: Union[List[float], np.ndarray],
+        vector: Union[List[float], "np.ndarray"],
         top_k: int = 10,
         ef_search: int = 128,
     ) -> List[Dict[str, Any]]:
         """Search with custom HNSW ef_search parameter."""
         ...
+
+    def search_ids(
+        self,
+        vector: Union[List[float], "np.ndarray"],
+        top_k: int = 10,
+    ) -> List[Dict[str, Any]]:
+        """Search returning only IDs and scores."""
+        ...
+
+    def search_with_filter(
+        self,
+        vector: Union[List[float], "np.ndarray"],
+        top_k: int = 10,
+        filter: Optional[Dict[str, Any]] = None,
+    ) -> List[Dict[str, Any]]:
+        """Search with metadata filtering."""
+        ...
+
+    def text_search(
+        self,
+        query: str,
+        top_k: int = 10,
+        filter: Optional[Dict[str, Any]] = None,
+    ) -> List[Dict[str, Any]]:
+        """Full-text search using BM25 ranking."""
+        ...
+
+    def hybrid_search(
+        self,
+        vector: Union[List[float], "np.ndarray"],
+        query: str,
+        top_k: int = 10,
+        vector_weight: float = 0.5,
+        filter: Optional[Dict[str, Any]] = None,
+    ) -> List[Dict[str, Any]]:
+        """Hybrid search combining vector similarity and text search."""
+        ...
+
+    def batch_search(
+        self,
+        searches: List[Dict[str, Any]],
+    ) -> List[List[Dict[str, Any]]]:
+        """Batch search for multiple query vectors in parallel.
+
+        Each search dict must have 'vector' and optionally 'top_k' and 'filter'.
+        """
+        ...
+
+    def multi_query_search(
+        self,
+        vectors: List[Union[List[float], "np.ndarray"]],
+        top_k: int = 10,
+        fusion: Optional[FusionStrategy] = None,
+        filter: Optional[Dict[str, Any]] = None,
+    ) -> List[Dict[str, Any]]:
+        """Multi-query search with result fusion.
+
+        Args:
+            vectors: List of query vectors (max 10)
+            top_k: Number of results to return after fusion
+            fusion: Fusion strategy (default: RRF with k=60)
+            filter: Optional metadata filter applied to all queries
+        """
+        ...
+
+    def multi_query_search_ids(
+        self,
+        vectors: List[Union[List[float], "np.ndarray"]],
+        top_k: int = 10,
+        fusion: Optional[FusionStrategy] = None,
+    ) -> List[Dict[str, Any]]:
+        """Multi-query search returning only IDs and fused scores."""
+        ...
+
+    def get(self, ids: List[int]) -> List[Optional[Dict[str, Any]]]:
+        """Get points by their IDs.
+
+        Args:
+            ids: List of integer point IDs
+
+        Returns:
+            List of point dicts (or None for missing IDs), same order as input
+        """
+        ...
+
+    def delete(self, ids: List[int]) -> None:
+        """Delete points by their IDs.
+
+        Args:
+            ids: List of integer point IDs to delete
+        """
+        ...
+
+    def flush(self) -> None:
+        """Flush pending changes to disk."""
+        ...
+
+    def count(self) -> int:
+        """Return number of points in the collection."""
+        ...
+
+    def get_graph_store(self) -> "GraphStore":
+        """Get a graph store adapter for edge/traversal operations."""
+        ...
+
+    # Index Management
+
+    def create_property_index(self, label: str, property: str) -> None:
+        """Create a property index for O(1) equality lookups on graph nodes."""
+        ...
+
+    def create_range_index(self, label: str, property: str) -> None:
+        """Create a range index for O(log n) range queries on graph nodes."""
+        ...
+
+    def has_property_index(self, label: str, property: str) -> bool:
+        """Check if a property index exists."""
+        ...
+
+    def has_range_index(self, label: str, property: str) -> bool:
+        """Check if a range index exists."""
+        ...
+
+    def list_indexes(self) -> List[Dict[str, Any]]:
+        """List all indexes on this collection."""
+        ...
+
+    def drop_index(self, label: str, property: str) -> bool:
+        """Drop an index (either property or range).
+
+        Returns:
+            True if an index was dropped, False if no index existed
+        """
+        ...
+
+    # VelesQL query methods
 
     def query(self, query_str: str, params: Optional[Dict[str, Any]] = None) -> List[Dict[str, Any]]:
         """Execute a VelesQL query."""
@@ -216,7 +361,7 @@ class Collection:
         self,
         query_str: str,
         params: Optional[Dict[str, Any]] = None,
-        vector: Optional[Union[List[float], np.ndarray]] = None,
+        vector: Optional[Union[List[float], "np.ndarray"]] = None,
         threshold: float = 0.0,
     ) -> List[Dict[str, Any]]:
         """Execute a MATCH graph query."""
@@ -225,261 +370,208 @@ class Collection:
     def explain(self, query_str: str) -> Dict[str, Any]:
         """Return execution plan for a VelesQL query."""
         ...
-    
-    def multi_query_search(
-        self,
-        vectors: Union[List[List[float]], np.ndarray],
-        top_k: int = 10,
-        fusion: Optional[FusionStrategy] = None,
-        filter: Optional[Dict[str, Any]] = None,
-    ) -> List[SearchResult]:
-        """Multi-query search with result fusion.
-        
-        Executes parallel searches for multiple query vectors and fuses
-        the results using the specified fusion strategy. Ideal for Multiple
-        Query Generation (MQG) pipelines.
-        
-        Args:
-            vectors: List of query vectors (max 10)
-            top_k: Number of results to return after fusion
-            fusion: Fusion strategy (default: RRF with k=60)
-            filter: Optional metadata filter applied to all queries
-        
-        Returns:
-            List of SearchResult objects with fused scores
-        
-        Example:
-            >>> results = collection.multi_query_search(
-            ...     vectors=[query1, query2, query3],
-            ...     top_k=10,
-            ...     fusion=FusionStrategy.weighted(0.6, 0.3, 0.1)
-            ... )
-        """
-        ...
-    
-    def multi_query_search_ids(
-        self,
-        vectors: Union[List[List[float]], np.ndarray],
-        top_k: int = 10,
-        fusion: Optional[FusionStrategy] = None,
-        filter: Optional[Dict[str, Any]] = None,
-    ) -> List[Tuple[str, float]]:
-        """Multi-query search returning only IDs and fused scores.
-        
-        Args:
-            vectors: List of query vectors (max 10)
-            top_k: Number of results to return after fusion
-            fusion: Fusion strategy (default: RRF with k=60)
-            filter: Optional metadata filter
-        
-        Returns:
-            List of (id, fused_score) tuples
-        """
-        ...
-    
-    def get(self, id: str) -> Optional[SearchResult]:
-        """Get a vector by its ID.
-        
-        Args:
-            id: The vector's unique identifier
-        
-        Returns:
-            SearchResult if found, None otherwise
-        """
-        ...
-    
-    def delete(self, id: str) -> bool:
-        """Delete a vector by its ID.
-        
-        Args:
-            id: The vector's unique identifier
-        
-        Returns:
-            True if deleted, False if not found
-        """
-        ...
-    
-    def update_payload(self, id: str, payload: Dict[str, Any]) -> bool:
-        """Update the payload of an existing vector.
-        
-        Args:
-            id: The vector's unique identifier
-            payload: New metadata payload
-        
-        Returns:
-            True if updated, False if not found
-        """
-        ...
-    
-    def flush(self) -> None:
-        """Flush pending changes to disk."""
-        ...
-
-    def count(self) -> int:
-        """Return number of points in the collection."""
-        ...
-
-    def get_graph_store(self) -> "GraphStore":
-        """Get a graph store adapter for edge/traversal operations."""
-        ...
-    
-    # Index Management (EPIC-009)
-    
-    def create_property_index(self, label: str, property: str) -> None:
-        """Create a property index for O(1) equality lookups on graph nodes.
-        
-        Args:
-            label: Node label to index (e.g., "Person")
-            property: Property name to index (e.g., "email")
-        """
-        ...
-    
-    def create_range_index(self, label: str, property: str) -> None:
-        """Create a range index for O(log n) range queries on graph nodes.
-        
-        Args:
-            label: Node label to index (e.g., "Event")
-            property: Property name to index (e.g., "timestamp")
-        """
-        ...
-    
-    def has_property_index(self, label: str, property: str) -> bool:
-        """Check if a property index exists.
-        
-        Args:
-            label: Node label
-            property: Property name
-        
-        Returns:
-            True if a property index exists for this label/property
-        """
-        ...
-    
-    def has_range_index(self, label: str, property: str) -> bool:
-        """Check if a range index exists.
-        
-        Args:
-            label: Node label
-            property: Property name
-        
-        Returns:
-            True if a range index exists for this label/property
-        """
-        ...
-    
-    def list_indexes(self) -> List[Dict[str, Any]]:
-        """List all indexes on this collection.
-        
-        Returns:
-            List of dicts with keys: label, property, index_type, cardinality, memory_bytes
-        """
-        ...
-    
-    def drop_index(self, label: str, property: str) -> bool:
-        """Drop an index (either property or range).
-        
-        Args:
-            label: Node label
-            property: Property name
-        
-        Returns:
-            True if an index was dropped, False if no index existed
-        """
-        ...
 
 
 class Database:
     """VelesDB Database - the main entry point for interacting with VelesDB.
-    
+
     Example:
-        >>> db = Database.open("./my_database")
+        >>> db = Database("./my_database")
         >>> collection = db.get_or_create_collection("vectors", dimension=1536)
-        >>> collection.insert("id1", [0.1, 0.2, ...], {"text": "hello"})
+        >>> collection.upsert([{"id": 1, "vector": [0.1, 0.2], "payload": {"text": "hello"}}])
     """
-    
-    @staticmethod
-    def open(path: str) -> "Database":
-        """Open or create a database at the specified path.
-        
+
+    def __init__(self, path: str) -> None:
+        """Open or create a VelesDB database at the specified path.
+
         Args:
-            path: Path to the database directory
-        
-        Returns:
-            Database instance
+            path: Directory path for database storage
         """
         ...
-    
+
     def create_collection(
         self,
         name: str,
         dimension: int,
         metric: str = "cosine",
+        storage_mode: str = "full",
+        m: Optional[int] = None,
+        ef_construction: Optional[int] = None,
     ) -> Collection:
-        """Create a new collection.
-        
+        """Create a new vector collection.
+
         Args:
             name: Collection name
             dimension: Vector dimension
-            metric: Distance metric ("cosine", "euclidean", "dot")
-        
+            metric: Distance metric ("cosine", "euclidean", "dot", "hamming", "jaccard")
+            storage_mode: "full", "sq8", or "binary"
+            m: Optional HNSW M parameter
+            ef_construction: Optional HNSW ef_construction parameter
+
         Returns:
             The created Collection
-        
+
         Raises:
-            ValueError: If collection already exists
+            RuntimeError: If collection already exists or creation fails
         """
         ...
-    
+
     def get_collection(self, name: str) -> Optional[Collection]:
         """Get an existing collection by name.
-        
+
         Args:
             name: Collection name
-        
+
         Returns:
             Collection if found, None otherwise
         """
         ...
-    
+
     def get_or_create_collection(
         self,
         name: str,
         dimension: int,
         metric: str = "cosine",
+        storage_mode: str = "full",
     ) -> Collection:
         """Get an existing collection or create a new one.
-        
+
         Args:
             name: Collection name
             dimension: Vector dimension (used only if creating)
             metric: Distance metric (used only if creating)
-        
+            storage_mode: Storage mode (used only if creating)
+
         Returns:
             The Collection (existing or newly created)
         """
         ...
-    
-    def delete_collection(self, name: str) -> bool:
-        """Delete a collection.
-        
-        Args:
-            name: Collection name
-        
-        Returns:
-            True if deleted, False if not found
-        """
-        ...
-    
+
     def list_collections(self) -> List[str]:
         """List all collection names.
-        
+
         Returns:
             List of collection names
         """
         ...
-    
-    def flush(self) -> None:
-        """Flush all pending changes to disk."""
+
+    def delete_collection(self, name: str) -> None:
+        """Delete a collection.
+
+        Args:
+            name: Collection name to delete
+        """
+        ...
+
+    def create_metadata_collection(self, name: str) -> Collection:
+        """Create a metadata-only collection (no vectors, no HNSW index).
+
+        Args:
+            name: Collection name
+
+        Returns:
+            Collection instance
+        """
+        ...
+
+    def create_graph_collection(
+        self,
+        name: str,
+        dimension: Optional[int] = None,
+        metric: str = "cosine",
+        schema: Optional["PyGraphSchema"] = None,
+    ) -> "PyGraphCollection":
+        """Create a new persistent graph collection.
+
+        Args:
+            name: Collection name
+            dimension: Optional vector dimension for node embeddings
+            metric: Distance metric
+            schema: Optional GraphSchema (default: schemaless)
+
+        Returns:
+            GraphCollection instance
+        """
+        ...
+
+    def get_graph_collection(self, name: str) -> Optional["PyGraphCollection"]:
+        """Get an existing graph collection by name.
+
+        Returns:
+            GraphCollection instance or None if not found
+        """
+        ...
+
+    def train_pq(
+        self,
+        collection_name: str,
+        m: int = 8,
+        k: int = 256,
+        opq: bool = False,
+    ) -> str:
+        """Train product quantization on a collection.
+
+        Args:
+            collection_name: Name of the collection to train on
+            m: Number of subspaces (default: 8)
+            k: Number of centroids per subspace (default: 256)
+            opq: Whether to use Optimized PQ (default: False)
+
+        Returns:
+            Status message from the training operation
+
+        Raises:
+            RuntimeError: If training fails
+            ValueError: If collection_name contains invalid characters
+        """
+        ...
+
+    def agent_memory(self, dimension: Optional[int] = None) -> "AgentMemory":
+        """Create an AgentMemory instance for AI agent workflows.
+
+        Args:
+            dimension: Embedding dimension (default: 384)
+
+        Returns:
+            AgentMemory instance with semantic, episodic, and procedural subsystems
+        """
+        ...
+
+    def plan_cache_stats(self) -> Dict[str, Any]:
+        """Get plan cache statistics.
+
+        Returns:
+            Dict with l1_size, l2_size, l1_hits, l2_hits, misses, hits, hit_rate keys
+        """
+        ...
+
+    def clear_plan_cache(self) -> None:
+        """Clear all cached query plans."""
+        ...
+
+    def analyze_collection(self, name: str) -> Dict[str, Any]:
+        """Analyze a collection, computing and persisting statistics.
+
+        Args:
+            name: Collection name to analyze
+
+        Returns:
+            Dict with statistics (total_points, row_count, deleted_count, etc.)
+
+        Raises:
+            RuntimeError: If the collection does not exist or analysis fails
+        """
+        ...
+
+    def get_collection_stats(self, name: str) -> Optional[Dict[str, Any]]:
+        """Get cached collection statistics (or None if never analyzed).
+
+        Args:
+            name: Collection name
+
+        Returns:
+            Dict with statistics or None if the collection has never been analyzed
+        """
         ...
 
 
@@ -532,26 +624,22 @@ class VelesQL:
 
 
 # =============================================================================
-# Graph Classes (EPIC-016/US-030, US-032)
+# Graph Classes
 # =============================================================================
 
 class StreamingConfig:
-    """Configuration for streaming BFS traversal.
-    
+    """Configuration for streaming BFS/DFS traversal.
+
     Args:
         max_depth: Maximum traversal depth (default: 3)
-        max_visited: Maximum nodes to visit for memory bound (default: 10000)
+        max_visited: Maximum nodes to visit (default: 10000)
         relationship_types: Optional filter by relationship types
-    
-    Example:
-        >>> config = StreamingConfig(max_depth=3, max_visited=10000)
-        >>> config.relationship_types = ["KNOWS", "FOLLOWS"]
     """
-    
+
     max_depth: int
     max_visited: int
     relationship_types: Optional[List[str]]
-    
+
     def __init__(
         self,
         max_depth: int = 3,
@@ -561,8 +649,8 @@ class StreamingConfig:
 
 
 class TraversalResult:
-    """Result of a BFS traversal step.
-    
+    """Result of a BFS/DFS traversal step.
+
     Attributes:
         depth: Current depth in the traversal
         source: Source node ID
@@ -570,7 +658,7 @@ class TraversalResult:
         label: Edge label
         edge_id: Edge ID
     """
-    
+
     depth: int
     source: int
     target: int
@@ -579,107 +667,165 @@ class TraversalResult:
 
 
 class GraphStore:
-    """In-memory graph store for knowledge graph operations.
-    
-    Example:
-        >>> store = GraphStore()
-        >>> store.add_edge({"id": 1, "source": 100, "target": 200, "label": "KNOWS"})
-        >>> edges = store.get_edges_by_label("KNOWS")
-        >>> for result in store.traverse_bfs_streaming(100, StreamingConfig()):
-        ...     print(f"Depth {result.depth}: {result.source} -> {result.target}")
-    """
-    
-    def __init__(self) -> None:
-        """Creates a new empty graph store."""
-        ...
-    
+    """In-memory graph store for knowledge graph operations."""
+
+    def __init__(self) -> None: ...
+
     def add_edge(self, edge: Dict[str, Any]) -> None:
-        """Adds an edge to the graph.
-        
+        """Add an edge.
+
         Args:
-            edge: Dict with keys: id (int), source (int), target (int), 
+            edge: Dict with keys: id (int), source (int), target (int),
                   label (str), properties (dict, optional)
         """
         ...
-    
-    def get_edges_by_label(self, label: str) -> List[Dict[str, Any]]:
-        """Gets all edges with the specified label.
-        
-        Args:
-            label: The relationship type to filter by (e.g., "KNOWS", "FOLLOWS")
-        
-        Returns:
-            List of edge dicts with keys: id, source, target, label, properties
-        
-        Note:
-            Uses internal label index for O(1) lookup per label.
-        """
-        ...
-    
-    def get_outgoing(self, node_id: int) -> List[Dict[str, Any]]:
-        """Gets outgoing edges from a node.
-        
-        Args:
-            node_id: The source node ID
-        
-        Returns:
-            List of edge dicts
-        """
-        ...
-    
-    def get_incoming(self, node_id: int) -> List[Dict[str, Any]]:
-        """Gets incoming edges to a node.
-        
-        Args:
-            node_id: The target node ID
-        
-        Returns:
-            List of edge dicts
-        """
-        ...
-    
-    def get_outgoing_by_label(self, node_id: int, label: str) -> List[Dict[str, Any]]:
-        """Gets outgoing edges from a node filtered by label.
-        
-        Args:
-            node_id: The source node ID
-            label: The relationship type to filter by
-        
-        Returns:
-            List of edge dicts matching the label
-        """
-        ...
-    
+
+    def get_edges_by_label(self, label: str) -> List[Dict[str, Any]]: ...
+    def get_outgoing(self, node_id: int) -> List[Dict[str, Any]]: ...
+    def get_incoming(self, node_id: int) -> List[Dict[str, Any]]: ...
+    def get_outgoing_by_label(self, node_id: int, label: str) -> List[Dict[str, Any]]: ...
+
     def traverse_bfs_streaming(
         self, start_node: int, config: StreamingConfig
-    ) -> List[TraversalResult]:
-        """Performs streaming BFS traversal from a start node.
-        
+    ) -> List[TraversalResult]: ...
+
+    def remove_edge(self, edge_id: int) -> None: ...
+    def edge_count(self) -> int: ...
+
+
+class PyGraphSchema:
+    """Schema definition for a graph collection."""
+    ...
+
+
+class PyGraphCollection:
+    """Persistent graph collection with typed nodes, edges, and optional vector search."""
+    ...
+
+
+# =============================================================================
+# Agent Memory Classes
+# =============================================================================
+
+class PySemanticMemory:
+    """Long-term knowledge storage with vector similarity search."""
+
+    def store(self, id: int, content: str, embedding: List[float]) -> None:
+        """Store a knowledge fact with its embedding.
+
         Args:
-            start_node: The node ID to start traversal from
-            config: StreamingConfig with max_depth, max_visited, relationship_types
-        
+            id: Unique identifier for the fact
+            content: Text content of the knowledge
+            embedding: Vector representation
+        """
+        ...
+
+    def query(self, embedding: List[float], top_k: int = 10) -> List[Dict[str, Any]]:
+        """Query semantic memory by similarity.
+
         Returns:
-            List of TraversalResult objects
-        
-        Note:
-            Results are bounded by config.max_visited to prevent memory exhaustion.
-        
-        Example:
-            >>> config = StreamingConfig(max_depth=2, max_visited=100)
-            >>> for result in store.traverse_bfs_streaming(100, config):
-            ...     print(f"{result.source} -> {result.target}")
+            List of dicts with 'id', 'score', 'content' keys
         """
         ...
-    
-    def remove_edge(self, edge_id: int) -> None:
-        """Removes an edge by ID.
-        
+
+
+class PyEpisodicMemory:
+    """Event timeline with temporal and similarity queries."""
+
+    def record(
+        self,
+        event_id: int,
+        description: str,
+        timestamp: int,
+        embedding: Optional[List[float]] = None,
+    ) -> None:
+        """Record an event in episodic memory."""
+        ...
+
+    def recent(
+        self,
+        limit: int = 10,
+        since: Optional[int] = None,
+    ) -> List[Dict[str, Any]]:
+        """Get recent events.
+
+        Returns:
+            List of dicts with 'id', 'description', 'timestamp' keys
+        """
+        ...
+
+    def recall_similar(
+        self,
+        embedding: List[float],
+        top_k: int = 10,
+    ) -> List[Dict[str, Any]]:
+        """Find similar events by embedding.
+
+        Returns:
+            List of dicts with 'id', 'description', 'timestamp', 'score' keys
+        """
+        ...
+
+
+class PyProceduralMemory:
+    """Learned patterns with confidence scoring and reinforcement."""
+
+    def learn(
+        self,
+        procedure_id: int,
+        name: str,
+        steps: List[str],
+        embedding: Optional[List[float]] = None,
+        confidence: float = 0.5,
+    ) -> None:
+        """Learn a new procedure/pattern."""
+        ...
+
+    def recall(
+        self,
+        embedding: List[float],
+        top_k: int = 10,
+        min_confidence: float = 0.0,
+    ) -> List[Dict[str, Any]]:
+        """Recall procedures by similarity.
+
+        Returns:
+            List of dicts with 'id', 'name', 'steps', 'confidence', 'score' keys
+        """
+        ...
+
+    def reinforce(self, procedure_id: int, success: bool) -> None:
+        """Reinforce a procedure based on success/failure.
+
+        Updates confidence: +0.1 on success, -0.05 on failure.
+        """
+        ...
+
+
+class AgentMemory:
+    """Unified agent memory with semantic, episodic, and procedural subsystems.
+
+    Example:
+        >>> db = Database("./agent_data")
+        >>> memory = db.agent_memory()
+        >>> memory.semantic.store(1, "Paris is in France", embedding)
+        >>> memory = AgentMemory(db, dimension=768)
+    """
+
+    def __init__(self, db: Database, dimension: Optional[int] = None) -> None:
+        """Create a new AgentMemory from a Database.
+
         Args:
-            edge_id: The edge ID to remove
+            db: Database instance
+            dimension: Embedding dimension (default: 384)
         """
         ...
-    
-    def edge_count(self) -> int:
-        """Returns the number of edges in the store."""
-        ...
+
+    @property
+    def semantic(self) -> PySemanticMemory: ...
+    @property
+    def episodic(self) -> PyEpisodicMemory: ...
+    @property
+    def procedural(self) -> PyProceduralMemory: ...
+    @property
+    def dimension(self) -> int: ...

--- a/crates/velesdb-python/src/graph_collection.rs
+++ b/crates/velesdb-python/src/graph_collection.rs
@@ -238,7 +238,7 @@ impl PyGraphCollection {
             pyo3::exceptions::PyValueError::new_err("Failed to convert payload to JSON")
         })?;
         self.inner
-            .store_node_payload(node_id, &value)
+            .upsert_node_payload(node_id, &value)
             .map_err(|e| PyRuntimeError::new_err(format!("Failed to store payload: {e}")))
     }
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -251,7 +251,7 @@ pip install target/wheels/velesdb-*.whl
 
 ### What Python version is required?
 
-Python 3.8 or later. NumPy is supported for vector input but not required.
+Python 3.9 or later. NumPy is supported for vector input but not required.
 
 ### What classes are available?
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,6 +23,9 @@ Detailed guides for using VelesDB features:
 | [Search Modes](./guides/SEARCH_MODES.md) | Understanding Fast/Balanced/Accurate/HighRecall/Perfect modes |
 | [CLI & REPL](./guides/CLI_REPL.md) | Command-line interface and interactive shell |
 | [Quantization](./guides/QUANTIZATION.md) | Vector compression (SQ8, Binary) |
+| [Tuning Guide](./guides/TUNING_GUIDE.md) | HNSW parameter tuning and performance optimization |
+| [Use Cases](./guides/USE_CASES.md) | Common use cases and recommended configurations |
+| [Troubleshooting](./NEW_USER_TROUBLESHOOTING.md) | Solutions for common issues new users encounter |
 
 ---
 

--- a/docs/contributing/CODING_RULES.md
+++ b/docs/contributing/CODING_RULES.md
@@ -1,52 +1,68 @@
-# VelesDB-Core - Règles de Développement
+# VelesDB-Core - Development Rules
 
-## 🎯 Objectif du Projet
+## Project Goal
 
-VelesDB-Core est le **moteur de base de données vectorielles** open-source. Il fournit l'API publique et les fonctionnalités fondamentales consommées par VelesDB-Premium.
+VelesDB-Core is the **open-source vector database engine**. It provides the public API and core functionality consumed by VelesDB-Premium.
 
 ---
 
-## 📐 Architecture
+## Architecture
 
-### Structure des Crates
+### Crate Structure
 
 ```
 velesdb-core/
 ├── crates/
-│   ├── velesdb-core/      # Moteur principal (storage, indexing, search)
-│   └── velesdb-server/    # API REST/gRPC
+│   ├── velesdb-core/          # Core engine (storage, indexing, search)
+│   ├── velesdb-server/        # Axum REST API server
+│   ├── velesdb-cli/           # CLI / VelesQL REPL
+│   ├── velesdb-python/        # Python bindings (PyO3)
+│   ├── velesdb-wasm/          # Browser WASM (no persistence)
+│   ├── velesdb-mobile/        # iOS/Android (UniFFI)
+│   ├── velesdb-migrate/       # Migration tooling
+│   └── tauri-plugin-velesdb/  # Tauri plugin
 ```
 
-### Principes Architecturaux
+### Architectural Principles
 
-- **Séparation des responsabilités** : Chaque module a une responsabilité unique
-- **API stable** : Le Core est une dépendance versionnée du Premium
-- **Zero-copy** : Privilégier `&[u8]`, `Bytes`, `memmap2` pour les performances
-- **Async-first** : Utiliser `tokio` pour toutes les I/O
+- **Separation of concerns**: Each module has a single responsibility
+- **Stable API**: Core is a versioned dependency of Premium
+- **Zero-copy**: Prefer `&[u8]`, `Bytes`, `memmap2` for performance
+- **Concurrency**: Use `parking_lot::RwLock` throughout (not `std::sync::RwLock`)
+- **Error handling**: Use `thiserror` for typed errors. Do not use `anyhow` in library crates.
 
 ---
 
-## 🧪 Test-Driven Development (TDD)
+## Test-Driven Development (TDD)
 
-### Workflow Obligatoire
+### Required Workflow
 
-1. **Rouge** : Écrire le test qui échoue
-2. **Vert** : Écrire le code minimal pour passer le test
-3. **Bleu** : Refactoriser sans casser les tests
+1. **Red**: Write a failing test
+2. **Green**: Write the minimum code to pass the test
+3. **Blue**: Refactor without breaking tests
 
-### Couverture Minimale
+### Minimum Coverage
 
-- **Objectif** : > 80% de couverture de code
-- **Outil** : `cargo tarpaulin`
+- **Target**: > 80% code coverage
+- **Tool**: `cargo tarpaulin`
 
-### Types de Tests
+### Test Execution
+
+Tests must run single-threaded to avoid file system races between test fixtures:
+
+```bash
+cargo test --workspace --features persistence,gpu,update-check \
+  --exclude velesdb-python -- --test-threads=1
+```
+
+### Test Types
 
 ```rust
-// Test unitaire (dans le même fichier)
+// Unit test (in the same file)
 #[cfg(test)]
 mod tests {
     use super::*;
-    
+
     #[test]
     fn test_feature_basic() {
         // Arrange
@@ -55,13 +71,13 @@ mod tests {
     }
 }
 
-// Test d'intégration (dans tests/)
+// Integration test (in tests/)
 #[tokio::test]
 async fn test_integration_scenario() {
     // ...
 }
 
-// Benchmark (dans benches/)
+// Benchmark (in benches/)
 fn benchmark_search(c: &mut Criterion) {
     // ...
 }
@@ -69,9 +85,9 @@ fn benchmark_search(c: &mut Criterion) {
 
 ---
 
-## 🔧 Standards de Code
+## Code Standards
 
-### Formatage
+### Formatting
 
 ```bash
 cargo fmt --all -- --check
@@ -79,13 +95,16 @@ cargo fmt --all -- --check
 
 ### Linting
 
+Use explicit features -- never `--all-features`:
+
 ```bash
-cargo clippy --all-targets --all-features -- -D warnings
+cargo clippy --workspace --all-targets --features persistence,gpu,update-check \
+  --exclude velesdb-python -- -D warnings -D clippy::pedantic
 ```
 
-### Conventions de Nommage
+### Naming Conventions
 
-| Type | Convention | Exemple |
+| Type | Convention | Example |
 |------|------------|---------|
 | Structs | PascalCase | `VectorIndex` |
 | Traits | PascalCase | `Searchable` |
@@ -93,59 +112,72 @@ cargo clippy --all-targets --all-features -- -D warnings
 | Constants | SCREAMING_SNAKE | `MAX_DIMENSIONS` |
 | Modules | snake_case | `vector_storage` |
 
-### Règles Spécifiques
+### Code Quality Limits
 
-- **Pas de `unwrap()`** en production (sauf après validation)
-- **Gestion d'erreurs** avec `thiserror` et `anyhow`
-- **Documentation** obligatoire sur l'API publique (`///`)
-- **Fichiers < 500 lignes** : diviser si nécessaire
+| Metric | Limit | Scope |
+|--------|-------|-------|
+| Function NLOC | 50 | Per function/method |
+| File NLOC | 500 | Per source file |
+| Cyclomatic complexity | 8 | Per function/method |
+
+### Specific Rules
+
+- **No `unwrap()`** in production code (only after validation)
+- **Error handling** with `thiserror` only (not `anyhow`)
+- **Documentation** required on all public API items (`///`)
+- **Unsafe code** must include a `// SAFETY:` comment explaining the invariant
+- **TODO comments** must follow the format `// TODO(EPIC-XXX): ...` or `// TODO(US-XXX): ...` -- bare `TODO`/`FIXME`/`HACK` are rejected by CI
+- **Numeric casts**: Use `try_from` for `u64`-to-`usize` casts, never `as usize` (clippy::pedantic)
 
 ---
 
-## 🔒 Sécurité
+## Security
 
-### Audit Automatique
+### Automated Audit
 
 ```bash
 cargo audit
 cargo deny check
 ```
 
-### Règles
+### Rules
 
-- Pas de `unsafe` sans justification documentée
-- Valider toutes les entrées utilisateur
-- Pas de secrets dans le code
+- No `unsafe` without a documented `// SAFETY:` comment
+- Validate all user input
+- No secrets in code
 
 ---
 
-## 🚀 Performance
+## Performance
 
 ### Benchmarks
 
+Run benchmarks with explicit features:
+
 ```bash
-cargo bench --all-features
+cargo bench -p velesdb-core --bench simd_benchmark -- --noplot
 ```
 
-### Principes
+### Principles
 
-- **Mesurer avant d'optimiser**
-- Utiliser `criterion` pour les benchmarks
-- Profiler avec `cargo flamegraph`
+- **Measure before optimizing**
+- Use `criterion` for benchmarks
+- Profile with `cargo flamegraph`
+- Performance regression baseline is at `benchmarks/baseline.json`
 
 ---
 
-## 📦 Release
+## Release
 
-### Versioning Sémantique
+### Semantic Versioning
 
-| Type | Quand |
-|------|-------|
-| MAJOR | Changement d'API incompatible |
-| MINOR | Nouvelle fonctionnalité compatible |
-| PATCH | Correction de bug |
+| Type | When |
+|------|------|
+| MAJOR | Breaking API or on-disk format change |
+| MINOR | New backward-compatible feature |
+| PATCH | Bug fix |
 
-### Commande
+### Command
 
 ```bash
 ./scripts/release.sh patch|minor|major
@@ -153,10 +185,10 @@ cargo bench --all-features
 
 ---
 
-## ✅ Checklist Pre-commit
+## Pre-commit Checklist
 
 - [ ] `cargo fmt --all -- --check`
-- [ ] `cargo clippy --all-targets --all-features -- -D warnings`
-- [ ] `cargo test --all-features`
-- [ ] Documentation à jour
-- [ ] Pas de secrets dans le code
+- [ ] `cargo clippy --workspace --all-targets --features persistence,gpu,update-check --exclude velesdb-python -- -D warnings -D clippy::pedantic`
+- [ ] `cargo test --workspace --features persistence,gpu,update-check --exclude velesdb-python -- --test-threads=1`
+- [ ] Documentation up to date
+- [ ] No secrets in code

--- a/docs/contributing/PROJECT_STRUCTURE.md
+++ b/docs/contributing/PROJECT_STRUCTURE.md
@@ -1,164 +1,164 @@
-# VelesDB-Core - Structure du Projet
+# VelesDB-Core - Project Structure
 
-## Vue d'ensemble
+## Overview
 
-VelesDB-Core est un **workspace Cargo** contenant plusieurs crates. C'est le moteur open-source de la base de données vectorielle.
+VelesDB-Core is a **Cargo workspace** containing eight crates. It is the open-source engine for the VelesDB vector database combining Vector + Graph + ColumnStore in a single engine.
 
 ```
 velesdb-core/
 │
-├── Cargo.toml                 # Workspace principal
-├── Cargo.lock                 # Lock des versions
+├── Cargo.toml                 # Workspace root
+├── Cargo.lock                 # Dependency lockfile
 │
-├── rust-toolchain.toml        # Version Rust (stable)
-├── rustfmt.toml               # Config formatage
-├── clippy.toml                # Config linter
-├── deny.toml                  # Audit sécurité deps
-├── Makefile.toml              # Tasks cargo-make
+├── rust-toolchain.toml        # Rust version (stable)
+├── rustfmt.toml               # Formatting config
+├── clippy.toml                # Linter config
+├── deny.toml                  # Dependency security audit
+├── Makefile.toml              # cargo-make tasks
 │
 ├── .cargo/
-│   └── config.toml            # Aliases cargo
+│   └── config.toml            # Cargo aliases
 │
 ├── .githooks/
-│   └── pre-commit             # Hook pré-commit
-│
-├── .windsurf/
-│   └── workflows/             # Workflows AI assistants
-│       ├── rust-feature.md
-│       ├── rust-debug.md
-│       └── ...
+│   └── pre-commit             # Pre-commit hook
 │
 ├── crates/
-│   ├── velesdb-core/          # Lib principale (moteur vectoriel)
+│   ├── velesdb-core/          # Core engine (vector, graph, storage, VelesQL)
 │   │   ├── Cargo.toml
 │   │   ├── src/
 │   │   │   ├── lib.rs
-│   │   │   ├── collection/    # Gestion collections
-│   │   │   ├── index/         # HNSW index
-│   │   │   ├── storage/       # Persistence
-│   │   │   ├── velesql/       # Query language parser
-│   │   │   └── simd/          # SIMD optimizations
-│   │   └── benches/
+│   │   │   ├── collection/    # Typed collections (Vector, Graph, Metadata) + legacy
+│   │   │   ├── index/         # HNSW, BM25, Trigram, Secondary indexes
+│   │   │   ├── storage/       # mmap, WAL, sharded vectors, compaction
+│   │   │   ├── velesql/       # VelesQL parser (pest), planner, executor, cache
+│   │   │   ├── simd_native/   # AVX-512, AVX2, NEON distance kernels
+│   │   │   ├── simd_dispatch.rs # Runtime SIMD path selection
+│   │   │   ├── column_store/  # Typed column storage for metadata
+│   │   │   ├── quantization/  # SQ8 (4x) and Binary (32x) compression
+│   │   │   ├── fusion/        # RRF score fusion for hybrid search
+│   │   │   ├── agent/         # Agent Memory Patterns SDK
+│   │   │   ├── observer.rs    # DatabaseObserver trait (premium hooks)
+│   │   │   └── guardrails/    # Allocation guards, memory limits
+│   │   ├── benches/           # Criterion benchmarks
+│   │   └── tests/             # Integration tests
 │   │
-│   ├── velesdb-server/        # API REST (Axum)
+│   ├── velesdb-server/        # Axum REST API server (22+ endpoints)
 │   │   ├── Cargo.toml
 │   │   └── src/
 │   │
-│   ├── velesdb-cli/           # CLI / REPL VelesQL
+│   ├── velesdb-cli/           # Interactive REPL for VelesQL
 │   │   ├── Cargo.toml
 │   │   └── src/
-│   │       └── main.rs
 │   │
-│   └── velesdb-python/        # Python bindings (PyO3)
+│   ├── velesdb-python/        # Python bindings (PyO3 + NumPy)
+│   │   ├── Cargo.toml
+│   │   └── src/
+│   │
+│   ├── velesdb-wasm/          # Browser-side vector search (no persistence)
+│   │   ├── Cargo.toml
+│   │   └── src/
+│   │
+│   ├── velesdb-mobile/        # iOS/Android bindings (UniFFI)
+│   │   ├── Cargo.toml
+│   │   └── src/
+│   │
+│   ├── velesdb-migrate/       # Schema and data migration tooling
+│   │   ├── Cargo.toml
+│   │   └── src/
+│   │
+│   └── tauri-plugin-velesdb/  # Tauri desktop integration
 │       ├── Cargo.toml
-│       ├── src/
-│       │   └── lib.rs
-│       └── tests/
-│           └── test_velesdb.py
+│       └── src/
+│
+├── conformance/               # VelesQL cross-ecosystem conformance cases
 │
 ├── integrations/
 │   └── langchain-velesdb/     # LangChain VectorStore
-│       ├── pyproject.toml
-│       ├── README.md
-│       ├── src/langchain_velesdb/
-│       │   ├── __init__.py
-│       │   └── vectorstore.py
-│       └── tests/
 │
-├── docs/
-│   ├── PROJECT_STRUCTURE.md   # Ce fichier
-│   ├── CODING_RULES.md        # Règles de développement
-│   ├── TDD_RULES.md           # Test-Driven Development
-│   ├── api-reference.md
-│   └── getting-started.md
+├── docs/                      # Documentation
 │
-├── scripts/
-│   └── release.sh             # Script de release
+├── scripts/                   # CI, release, and validation scripts
 │
-└── examples/
-    └── python_example.py
+└── examples/                  # Example applications
 ```
 
 ---
 
-## Fichiers de configuration
-
-### `Cargo.toml` (racine)
-
-Définit le **workspace** et les dépendances communes :
-
-```toml
-[workspace]
-resolver = "2"
-members = ["crates/velesdb-core", "crates/velesdb-server"]
-
-[workspace.package]
-version = "0.1.0"
-edition = "2021"
-# ...
-
-[workspace.dependencies]
-tokio = { version = "1.42", features = ["full"] }
-serde = { version = "1.0", features = ["derive"] }
-# ...
-```
-
-### `crates/*/Cargo.toml`
-
-Chaque crate **hérite** du workspace :
-
-```toml
-[package]
-name = "velesdb-core"
-version.workspace = true      # ← hérite de workspace.package.version
-edition.workspace = true
-
-[dependencies]
-tokio = { workspace = true }  # ← hérite de workspace.dependencies
-```
-
----
-
-## Crates
+## Workspace Crates
 
 ### `velesdb-core`
-Moteur vectoriel principal. Contient :
-- **HNSW Index** : Recherche approximative des plus proches voisins
-- **SIMD** : Calculs de distance optimisés (AVX2/SSE)
-- **VelesQL** : Parser du langage de requête SQL-like
-- **Storage** : Persistence avec WAL
+
+Core engine. Contains:
+- **HNSW Index**: Native implementation (1.2x faster than hnsw_rs) with AVX-512, AVX2, and NEON SIMD acceleration via runtime feature detection
+- **Typed Collections**: `VectorCollection`, `GraphCollection`, `MetadataCollection` (plus legacy `Collection` for backward compatibility)
+- **VelesQL**: SQL-like query language with vector and graph extensions (pest-based parser)
+- **Storage**: Memory-mapped files, WAL, sharded vectors, compaction
+- **Quantization**: SQ8 (4x) and Binary (32x) memory compression
+- **Agent Memory**: Semantic, episodic, and procedural memory patterns for AI agents
 
 ### `velesdb-server`
-Serveur REST API (Axum). Expose :
-- Endpoints CRUD collections/points
-- Endpoint `/search` et `/search/batch`
-- Endpoint `/query` pour VelesQL
+
+Axum-based REST API server with 22+ endpoints. Exposes:
+- CRUD endpoints for collections and points
+- `/search`, `/search/batch`, `/search/hybrid` endpoints
+- `/query` endpoint for VelesQL execution
+- Optional OpenAPI documentation
 
 ### `velesdb-cli`
-Interface ligne de commande :
-- `repl` : Mode interactif VelesQL
-- `query` : Exécution requête unique
-- `info` : Informations sur une base
+
+Command-line interface with:
+- `repl`: Interactive VelesQL shell
+- `query`: Single query execution
+- `info`: Database information
 
 ### `velesdb-python`
-Bindings Python via PyO3 :
-- `velesdb.Database` / `velesdb.Collection`
-- Support NumPy arrays (float32, float64)
-- Tests pytest complets
+
+Python bindings via PyO3:
+- `Database`, `Collection`, `GraphCollection`, `AgentMemory` classes
+- NumPy array support (float32, float64)
+- Comprehensive pytest suite
+
+### `velesdb-wasm`
+
+Browser-side vector search. Must be built without the `persistence` feature:
+```bash
+cargo build -p velesdb-wasm --no-default-features --target wasm32-unknown-unknown
+```
+
+### `velesdb-mobile`
+
+iOS and Android bindings via UniFFI:
+- Swift bindings for iOS
+- Kotlin bindings for Android
+
+### `velesdb-migrate`
+
+Schema and data migration tooling for version upgrades (e.g., bincode-to-postcard migration in v1.5).
+
+### `tauri-plugin-velesdb`
+
+Tauri desktop integration plugin for building local-first desktop applications with embedded vector search.
 
 ---
 
-## Integrations
+## Feature Flags
 
-### `langchain-velesdb`
-Package Python pour LangChain :
-- `VelesDBVectorStore` compatible LangChain
-- Méthodes : `add_texts`, `similarity_search`, `as_retriever`
-- Installation : `pip install langchain-velesdb`
+| Flag | Purpose | Default |
+|------|---------|---------|
+| `persistence` | mmap, WAL, rayon, tokio | Yes |
+| `gpu` | wgpu-based GPU acceleration | No |
+| `update-check` | HTTP version checking | No |
+| `loom` | Concurrency testing (nightly) | No |
+
+The `persistence` feature must be disabled for WASM targets.
+
+---
+
+## Configuration Files
 
 ### `rust-toolchain.toml`
 
-Fixe la version de Rust pour tous les développeurs :
+Pins the Rust toolchain version for all developers:
 
 ```toml
 [toolchain]
@@ -168,78 +168,36 @@ components = ["rustfmt", "clippy"]
 
 ### `.cargo/config.toml`
 
-Définit des **aliases** pour simplifier les commandes :
-
-```toml
-[alias]
-lint = "clippy --all-targets --all-features -- -D warnings"
-test-all = "test --all-features"
-```
-
-Usage : `cargo lint`, `cargo test-all`
-
-### `Makefile.toml`
-
-Tasks pour **cargo-make** :
-
-```bash
-cargo make check    # fmt + clippy + test
-cargo make ci       # fmt + clippy + test + audit
-cargo make fmt      # formate le code
-```
+Defines cargo aliases for common commands. Note: the `target-cpu=native` line must stay commented out to preserve CI compatibility.
 
 ### `.githooks/pre-commit`
 
-Exécuté automatiquement avant chaque `git commit` :
-- Vérifie le formatage
-- Lance clippy
-- Lance les tests
-- Détecte les secrets
+Runs automatically before each `git commit`:
+- Checks formatting
+- Runs clippy
+- Runs tests
+- Detects secrets
 
-**Activation** : `git config core.hooksPath .githooks`
-
----
-
-## Workflow de développement
-
-```bash
-# 1. Cloner
-git clone https://github.com/cyberlife-coder/velesdb.git
-cd velesdb
-
-# 2. Setup (une seule fois)
-rustup update stable
-cargo install cargo-make cargo-audit cargo-deny
-git config core.hooksPath .githooks
-
-# 3. Développer
-cargo check              # Vérifier la compilation
-cargo make check         # fmt + clippy + test
-cargo make ci            # CI complète locale
-
-# 4. Commit (hook s'exécute automatiquement)
-git add .
-git commit -m "feat: add feature X"
-```
+Activate with: `git config core.hooksPath .githooks`
 
 ---
 
-## Relation avec VelesDB-Premium
+## Relationship with VelesDB-Premium
 
 ```
 ┌─────────────────────┐
-│   velesdb-premium   │  (repo privé)
-│  Features payantes  │
+│   velesdb-premium   │  (private repo)
+│   Premium features  │
 └─────────┬───────────┘
-          │ dépend via git
+          │ depends via git
           ▼
 ┌─────────────────────┐
-│    velesdb-core     │  (ce repo)
-│  Moteur open-source │
+│    velesdb-core     │  (this repo)
+│   Open-source core  │
 └─────────────────────┘
 ```
 
-Premium importe Core ainsi :
+Premium imports Core as a workspace dependency:
 
 ```toml
 [workspace.dependencies]

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -214,8 +214,8 @@ Response:
 
 - Read the [API Reference](reference/api-reference.md) for complete endpoint documentation
 - Read the [VelesQL Specification](VELESQL_SPEC.md) for query language reference
-- Learn about [Configuration](CONFIGURATION.md) options
-- Explore [Architecture](ARCHITECTURE.md) to understand VelesDB internals
+- Learn about [Configuration](guides/CONFIGURATION.md) options
+- Explore [Architecture](reference/ARCHITECTURE.md) to understand VelesDB internals
 - Check out [Examples](../examples/) for real-world use cases
 - Follow the [Tauri RAG Tutorial](tutorials/tauri-rag-app/) to build a desktop AI app
 

--- a/docs/guides/INSTALLATION.md
+++ b/docs/guides/INSTALLATION.md
@@ -45,13 +45,13 @@ The MSI installer provides the easiest installation experience with:
 
 ```powershell
 # Install with PATH modification (default)
-msiexec /i velesdb-0.6.0-x86_64.msi /quiet ADDTOPATH=1
+msiexec /i velesdb-1.5.1-x86_64.msi /quiet ADDTOPATH=1
 
 # Install without PATH modification
-msiexec /i velesdb-0.6.0-x86_64.msi /quiet ADDTOPATH=0
+msiexec /i velesdb-1.5.1-x86_64.msi /quiet ADDTOPATH=0
 
 # Install to custom directory
-msiexec /i velesdb-0.6.0-x86_64.msi /quiet APPLICATIONFOLDER="D:\VelesDB"
+msiexec /i velesdb-1.5.1-x86_64.msi /quiet APPLICATIONFOLDER="D:\VelesDB"
 ```
 
 #### Uninstall
@@ -59,7 +59,7 @@ msiexec /i velesdb-0.6.0-x86_64.msi /quiet APPLICATIONFOLDER="D:\VelesDB"
 Via **Control Panel > Programs > Uninstall**, or:
 
 ```powershell
-msiexec /x velesdb-0.6.0-x86_64.msi /quiet
+msiexec /x velesdb-1.5.1-x86_64.msi /quiet
 ```
 
 ### Portable ZIP
@@ -68,7 +68,7 @@ For portable installations without admin rights:
 
 ```powershell
 # Download and extract
-Invoke-WebRequest -Uri "https://github.com/cyberlife-coder/VelesDB/releases/download/v0.6.0/velesdb-windows-x86_64.zip" -OutFile velesdb.zip
+Invoke-WebRequest -Uri "https://github.com/cyberlife-coder/VelesDB/releases/download/v1.5.1/velesdb-windows-x86_64.zip" -OutFile velesdb.zip
 Expand-Archive velesdb.zip -DestinationPath C:\VelesDB
 
 # Add to PATH (optional, current session only)
@@ -85,10 +85,10 @@ $env:PATH += ";C:\VelesDB"
 
 ```bash
 # Download
-wget https://github.com/cyberlife-coder/VelesDB/releases/download/v0.6.0/velesdb-0.6.0-amd64.deb
+wget https://github.com/cyberlife-coder/VelesDB/releases/download/v1.5.1/velesdb-1.5.1-amd64.deb
 
 # Install
-sudo dpkg -i velesdb-0.6.0-amd64.deb
+sudo dpkg -i velesdb-1.5.1-amd64.deb
 
 # Verify
 velesdb --version
@@ -110,7 +110,7 @@ sudo dpkg -r velesdb
 
 ```bash
 # Download and extract
-wget https://github.com/cyberlife-coder/VelesDB/releases/download/v0.6.0/velesdb-linux-x86_64.tar.gz
+wget https://github.com/cyberlife-coder/VelesDB/releases/download/v1.5.1/velesdb-linux-x86_64.tar.gz
 tar -xzf velesdb-linux-x86_64.tar.gz -C /opt/velesdb
 
 # Add to PATH
@@ -160,7 +160,7 @@ results = collection.search(vector=query_vector, top_k=10)
 ```toml
 # Cargo.toml
 [dependencies]
-velesdb-core = "0.3"
+velesdb-core = "1.5"
 ```
 
 ### As CLI Tools
@@ -231,7 +231,7 @@ import init, { VectorStore } from '@wiscale/velesdb-wasm';
 
 await init();
 const store = new VectorStore(768, 'cosine');
-store.insert(1, new Float32Array([...]));
+store.insert(1n, new Float32Array([...]));
 const results = store.search(new Float32Array([...]), 10);
 ```
 
@@ -335,13 +335,14 @@ Options:
 VelesDB persists all data to disk automatically:
 
 ```
-<data-dir>/
-├── collections/           # Collection metadata
-├── <collection-name>/
-│   ├── index.hnsw        # HNSW vector index
-│   ├── storage.bin       # Vector data
-│   ├── payloads.bin      # Metadata/payloads
-│   └── wal.bin           # Write-Ahead Log
+<data_dir>/<collection_name>/
+├── config.json       # Collection config (dimension, metric, HNSW params)
+├── vectors.bin       # mmap-backed vector data
+├── vectors.idx       # ID → offset index
+├── vectors.wal       # Vector WAL
+├── payloads.log      # Append-only payload WAL
+├── payloads.snapshot # Optional snapshot
+└── hnsw.bin          # HNSW graph index
 ```
 
 **Data is persistent by default.** Restart the server and your data will be there.
@@ -391,7 +392,7 @@ docker run -v velesdb_data:/data ghcr.io/cyberlife-coder/velesdb:latest
 ## 📚 Next Steps
 
 - **[Quick Start](../README.md#-your-first-vector-search)** - Your first vector search
-- **[VelesQL Guide](VELESQL_SPEC.md)** - SQL-like query language
-- **[API Reference](API_REFERENCE.md)** - REST API documentation
-- **[Benchmarks](BENCHMARKS.md)** - Performance metrics
+- **[VelesQL Guide](../VELESQL_SPEC.md)** - SQL-like query language
+- **[API Reference](../reference/api-reference.md)** - REST API documentation
+- **[Benchmarks](../BENCHMARKS.md)** - Performance metrics
 - **[Examples](../examples/)** - Sample applications including Tauri RAG app

--- a/examples/llamaindex/hybrid_search.py
+++ b/examples/llamaindex/hybrid_search.py
@@ -179,7 +179,7 @@ class VelesDBVectorStore(BasePydanticVectorStore):
         Returns:
             Training status message.
         """
-        return self._collection.train_pq(m=m, k=k, opq=opq)
+        return self._db.train_pq(self.collection_name, m=m, k=k, opq=opq)
 
 
 # ---------------------------------------------------------------------------

--- a/examples/python/graphrag_langchain.py
+++ b/examples/python/graphrag_langchain.py
@@ -18,7 +18,7 @@ Usage:
 import os
 import sys
 from pathlib import Path
-from typing import List, Optional
+from typing import List
 
 import httpx
 

--- a/examples/python/graphrag_langchain.py
+++ b/examples/python/graphrag_langchain.py
@@ -18,7 +18,7 @@ Usage:
 import os
 import sys
 from pathlib import Path
-from typing import Any, List, Optional
+from typing import List, Optional
 
 import httpx
 

--- a/examples/python/graphrag_langchain.py
+++ b/examples/python/graphrag_langchain.py
@@ -8,8 +8,7 @@ Demonstrates the "Seed + Expand" pattern for Graph-enhanced RAG:
 3. Combined context for LLM generation
 
 Requirements:
-    pip install langchain-velesdb langchain-openai httpx
-    # Start VelesDB server: velesdb-server --port 8080
+    pip install velesdb langchain-core langchain-openai httpx
 
 Usage:
     export OPENAI_API_KEY=your-key
@@ -17,7 +16,9 @@ Usage:
 """
 
 import os
-from typing import List
+import sys
+from pathlib import Path
+from typing import Any, List, Optional
 
 import httpx
 
@@ -26,8 +27,66 @@ from langchain_core.documents import Document
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_openai import ChatOpenAI, OpenAIEmbeddings
 
-# VelesDB LangChain integration
-from langchain_velesdb import VelesDBVectorStore, GraphRetriever
+# VelesDB LangChain integration — use the local example implementation.
+# For production, install: pip install langchain-velesdb
+sys.path.insert(0, str(Path(__file__).parent.parent / "langchain"))
+from hybrid_search import VelesDBVectorStore  # noqa: E402
+
+
+class GraphRetriever:
+    """Graph-enhanced retriever that expands seed results via VelesDB graph API."""
+
+    def __init__(
+        self,
+        vector_store: VelesDBVectorStore,
+        server_url: str,
+        seed_k: int = 2,
+        expand_k: int = 5,
+        max_depth: int = 2,
+    ) -> None:
+        self._vector_store = vector_store
+        self._server_url = server_url.rstrip("/")
+        self._seed_k = seed_k
+        self._expand_k = expand_k
+        self._max_depth = max_depth
+
+    def invoke(self, query: str) -> List[Document]:
+        """Retrieve seed documents by vector search then expand via graph traversal."""
+        seed_docs = self._vector_store.similarity_search(query, k=self._seed_k)
+        expanded: List[Document] = list(seed_docs)
+        seen_texts = {d.page_content for d in seed_docs}
+
+        for doc in seed_docs:
+            doc_id = doc.metadata.get("id")
+            if doc_id is None:
+                continue
+            try:
+                response = httpx.post(
+                    f"{self._server_url}/api/graph/traverse",
+                    json={
+                        "start_node": int(doc_id),
+                        "max_depth": self._max_depth,
+                        "limit": self._expand_k,
+                    },
+                    timeout=5.0,
+                )
+                response.raise_for_status()
+                neighbor_ids = response.json().get("node_ids", [])
+                for neighbor_id in neighbor_ids:
+                    neighbor_docs = self._vector_store.similarity_search(
+                        str(neighbor_id), k=1
+                    )
+                    for neighbor_doc in neighbor_docs:
+                        if neighbor_doc.page_content not in seen_texts:
+                            seen_texts.add(neighbor_doc.page_content)
+                            neighbor_doc.metadata["graph_depth"] = 1
+                            expanded.append(neighbor_doc)
+            except httpx.HTTPError:
+                # Graph expansion is best-effort; fall back gracefully.
+                pass
+
+        return expanded[: self._expand_k]
+
 
 VELESDB_SERVER = "http://localhost:8080"
 
@@ -50,9 +109,9 @@ def add_graph_edge(collection: str, edge_id: int, source: int, target: int, labe
 
 def create_sample_knowledge_base() -> VelesDBVectorStore:
     """Create a sample knowledge base with documents and relations."""
-    
+
     embeddings = OpenAIEmbeddings()
-    
+
     # Initialize VelesDB with local storage
     vectorstore = VelesDBVectorStore.from_texts(
         texts=[
@@ -76,8 +135,9 @@ def create_sample_knowledge_base() -> VelesDBVectorStore:
             {"id": 7, "topic": "VectorDB", "category": "infrastructure"},
             {"id": 8, "topic": "VelesDB", "category": "infrastructure"},
         ],
-        path="./graphrag_demo",
+        db_path="./graphrag_demo",
         collection_name="knowledge_base",
+        dimension=1536,
     )
     
     # Add graph edges via HTTP API (concept relationships)

--- a/examples/python/graphrag_llamaindex.py
+++ b/examples/python/graphrag_llamaindex.py
@@ -9,7 +9,8 @@ Demonstrates Graph-enhanced RAG using LlamaIndex's query engine:
 4. Generate answers with expanded context
 
 Requirements:
-    pip install llama-index-vector-stores-velesdb llama-index-llms-openai requests
+    pip install velesdb llama-index-core llama-index-llms-openai
+    pip install llama-index-embeddings-openai requests
 
 Usage:
     # Start VelesDB server first: velesdb-server --port 8080
@@ -18,6 +19,8 @@ Usage:
 """
 
 import os
+import sys
+from pathlib import Path
 from typing import Optional
 
 import requests
@@ -28,9 +31,10 @@ from llama_index.core.schema import TextNode, NodeRelationship, RelatedNodeInfo
 from llama_index.llms.openai import OpenAI
 from llama_index.embeddings.openai import OpenAIEmbedding
 
-# VelesDB LlamaIndex vector store integration
-# Install: pip install llama-index-vector-stores-velesdb
-from llama_index.vector_stores.velesdb import VelesDBVectorStore
+# VelesDB LlamaIndex vector store integration — use the local example implementation.
+# For production, install: pip install llama-index-vector-stores-velesdb
+sys.path.insert(0, str(Path(__file__).parent.parent / "llamaindex"))
+from hybrid_search import VelesDBVectorStore  # noqa: E402
 
 
 class VelesDBGraphLoader:

--- a/examples/python/requirements.txt
+++ b/examples/python/requirements.txt
@@ -1,2 +1,12 @@
+# Core VelesDB SDK (native Python bindings)
 velesdb>=1.5.1
 numpy>=1.22.0
+
+# Optional: LangChain integration (for examples/langchain/ and graphrag_langchain.py)
+# pip install langchain-core langchain-openai
+
+# Optional: LlamaIndex integration (for examples/llamaindex/ and graphrag_llamaindex.py)
+# pip install llama-index-core llama-index-llms-openai llama-index-embeddings-openai
+
+# Optional: HTTP client (used by GraphRAG examples for graph edge API calls)
+# pip install httpx requests

--- a/examples/python_example.py
+++ b/examples/python_example.py
@@ -1,9 +1,23 @@
 #!/usr/bin/env python3
 """
-VelesDB Python Example
+VelesDB Python REST Example (Legacy)
 
-This example demonstrates how to use VelesDB with Python and the requests library.
-For production use, consider using the official VelesDB Python SDK (Premium).
+DEPRECATED: This file demonstrates the VelesDB HTTP REST API using the requests
+library. For new projects, use the native Python SDK instead:
+
+    pip install velesdb
+
+    import velesdb
+    db = velesdb.Database("./my_data")
+    col = db.get_or_create_collection("docs", dimension=768)
+    col.upsert([{"id": 1, "vector": [...], "payload": {"title": "Doc"}}])
+    results = col.search([...], top_k=10)
+
+See examples/langchain/hybrid_search.py and examples/llamaindex/hybrid_search.py
+for production-ready integration examples.
+
+This REST client is still useful when connecting to a remote VelesDB server
+from an environment where the native extension cannot be compiled.
 """
 
 import logging


### PR DESCRIPTION
## Summary

Completes the P1-P2 phases of the production-ready remediation plan, building on PR #315 (P0 fixes).

### Coverage → 80%+ (78 new tests)
- `streaming/delta` (11), `streaming/ingester` (7), `storage/guard` (6)
- `column_store/filter` (14), `column_store/vacuum` (11)
- `guardrails/resilience` (9), `graph/clustered_index` (14), `database/stats` (6)
- **Total: 3062 tests pass** (was 2982 before this PR chain)

### GraphCollection API completion
- Add `delete`/`get`/`len`/`is_empty`/`remove_edge`/`execute_query_str`/`search`
- Rename `store_node_payload` → `upsert_node_payload` (deprecated alias kept)
- Add `create_graph_collection_with_embeddings` on `Database`
- Fix legacy `create_collection` observer notification gap

### HNSW batch mapping rollback (Devin BUG-0001)
- `insert_batch_parallel` and `insert_batch_sequential` now rollback mappings on failure

### Documentation (10 fixes)
- Broken links, stale versions (0.6.0→1.5.1), storage layout, PROJECT_STRUCTURE + CODING_RULES rewritten in English, lib.rs doctest uses typed API

### Python SDK
- `get_or_create_collection()`, `.pyi` stub rewritten, graphrag examples fixed, `Collection.search()` forwards all kwargs

### SIMD Performance
- Prefetch in `search_layer_single` (upper layers)
- Fused NEON cosine kernel (1-pass vs 3-pass, ~3x less memory bandwidth on ARM)

## Test plan
- [x] `cargo check --workspace` passes
- [x] `cargo clippy --pedantic` 0 warnings
- [x] 3062 lib tests pass (1 pre-existing flaky excluded)
- [ ] Linux CI (GitHub Actions)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/320" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
