### PR TITLE
feat: Open-Core Security — API auth, TLS, graceful shutdown, health endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Features
+
+- **API Key Authentication** (US-01) — Optional Bearer token auth for `velesdb-server`. Configure via `VELESDB_API_KEYS` env var or `[auth]` section in `velesdb.toml`. Multiple keys supported. Auth disabled by default (local dev mode). `/health` and `/ready` always bypass auth.
+- **TLS Support** (US-02) — HTTPS via rustls. Configure with `VELESDB_TLS_CERT` / `VELESDB_TLS_KEY` or `[tls]` section in `velesdb.toml`. Plain HTTP remains the default.
+- **Graceful Shutdown** (US-03) — SIGTERM/SIGINT triggers connection drain (30s timeout) + WAL flush before exit. Guarantees no data loss on clean shutdown.
+- **Server Configuration Module** (US-04) — Unified `ServerConfig` loading from TOML + CLI + env with priority chain (CLI > env > TOML > defaults). Startup validation with clear error messages.
+- **Readiness Endpoint** (US-05) — `GET /ready` returns 200 when DB is loaded, 503 during startup. `GET /health` now includes version field. Both bypass auth.
+- **OpenAPI Security Scheme** (US-08) — OpenAPI spec now documents Bearer authentication via `securitySchemes`.
+
+### Documentation
+
+- **Server Security Guide** (US-06) — `docs/guides/SERVER_SECURITY.md` covering authentication, TLS, graceful shutdown, and health endpoints.
+- **Configuration Reference Update** (US-07) — `docs/guides/CONFIGURATION.md` updated with auth, TLS, and shutdown options (env vars, CLI flags, TOML keys).
+- **Python SDK** (US-08) — README updated with server connection example using API key auth.
+
 ### License
 
 - **Upgrade to VelesDB Core License 1.0** — replaces the previous ELv2-based license with a purpose-built license adapted for VelesDB's multi-model architecture.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -280,6 +280,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94bffc006df10ac2a68c83692d734a465f8ee6c5b384d8545a636f81d858f4bf"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4321e568ed89bb5a7d291a7f37997c2c0df89809d7b6d12062c81ddb54aa782e"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
 name = "axum"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -567,6 +589,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -706,6 +730,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
 dependencies = [
  "error-code",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1661,6 +1694,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futf"
@@ -2778,6 +2817,16 @@ name = "jni-sys"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -4675,11 +4724,23 @@ version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
+ "aws-lc-rs",
+ "log",
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -4697,6 +4758,7 @@ version = "0.103.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -6888,13 +6950,18 @@ dependencies = [
  "axum",
  "clap",
  "futures",
+ "hyper",
+ "hyper-util",
  "parking_lot",
  "reqwest 0.12.28",
+ "rustls",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_yaml",
  "tempfile",
  "tokio",
+ "tokio-rustls",
  "tokio-test",
  "toml 0.8.23",
  "tower",

--- a/README.md
+++ b/README.md
@@ -650,6 +650,7 @@ SELECT * FROM active UNION SELECT * FROM archived
 | Endpoint | Method | Description |
 |----------|--------|-------------|
 | `/health` | `GET` | Health check |
+| `/ready` | `GET` | Readiness check |
 | `/metrics` | `GET` | Prometheus metrics endpoint |
 
 ### Request/Response Examples

--- a/README.md
+++ b/README.md
@@ -1326,6 +1326,17 @@ let similarity = dot_product_quantized_simd(&query, &quantized);
 
 ---
 
+## 🔐 Security
+
+VelesDB's server component (`velesdb-server`) supports **opt-in security features** for deployments beyond localhost:
+
+- **API Key Authentication** — Bearer token auth via `VELESDB_API_KEYS` env var or `[auth]` section in `velesdb.toml`. Disabled by default (local dev mode).
+- **TLS (HTTPS)** — Built-in TLS via rustls. Configure with `VELESDB_TLS_CERT` / `VELESDB_TLS_KEY` env vars or `[tls]` section in `velesdb.toml`.
+- **Graceful Shutdown** — SIGTERM/SIGINT triggers connection drain + WAL flush before exit. Zero data loss on clean shutdown.
+- **Health Endpoints** — `GET /health` (liveness) and `GET /ready` (readiness) for monitoring, always public.
+
+All features are opt-in with zero breaking changes. See [docs/guides/SERVER_SECURITY.md](docs/guides/SERVER_SECURITY.md) for the full guide.
+
 ## 🤝 Contributing
 
 We welcome contributions! Here's how to get started:

--- a/crates/velesdb-core/benches/recall_benchmark.rs
+++ b/crates/velesdb-core/benches/recall_benchmark.rs
@@ -131,8 +131,7 @@ fn bench_hnsw_recall(c: &mut Criterion) {
 
                             for (query, ground_truth) in queries.iter().zip(&ground_truths) {
                                 let results = index.search_with_quality(query, k, quality);
-                                let result_ids: Vec<u64> =
-                                    results.iter().map(|sr| sr.id).collect();
+                                let result_ids: Vec<u64> = results.iter().map(|sr| sr.id).collect();
 
                                 total_recall += recall_at_k(ground_truth, &result_ids);
                                 total_mrr += mrr(ground_truth, &result_ids);
@@ -141,8 +140,7 @@ fn bench_hnsw_recall(c: &mut Criterion) {
                             // Also compute precision for completeness
                             let last_query = &queries[0];
                             let last_results = index.search_with_quality(last_query, k, quality);
-                            let last_ids: Vec<u64> =
-                                last_results.iter().map(|sr| sr.id).collect();
+                            let last_ids: Vec<u64> = last_results.iter().map(|sr| sr.id).collect();
                             let _precision = precision_at_k(&ground_truths[0], &last_ids);
 
                             #[allow(clippy::cast_precision_loss)]

--- a/crates/velesdb-core/src/api_types/requests.rs
+++ b/crates/velesdb-core/src/api_types/requests.rs
@@ -79,13 +79,9 @@ impl SparseVectorInput {
     ///
     /// Returns a descriptive error string on mismatched lengths, non-finite values,
     /// or dict keys that cannot be parsed as `u32`.
-    pub fn into_sparse_vector(
-        self,
-    ) -> Result<crate::sparse_index::SparseVector, String> {
+    pub fn into_sparse_vector(self) -> Result<crate::sparse_index::SparseVector, String> {
         match self {
-            Self::Parallel { indices, values } => {
-                Self::convert_parallel(indices, values)
-            }
+            Self::Parallel { indices, values } => Self::convert_parallel(indices, values),
             Self::Dict(map) => Self::convert_dict(map),
         }
     }
@@ -108,8 +104,7 @@ impl SparseVectorInput {
                 ));
             }
         }
-        let pairs: Vec<(u32, f32)> =
-            indices.into_iter().zip(values).collect();
+        let pairs: Vec<(u32, f32)> = indices.into_iter().zip(values).collect();
         Ok(crate::sparse_index::SparseVector::new(pairs))
     }
 
@@ -123,11 +118,9 @@ impl SparseVectorInput {
                     "Sparse vector value for key '{key}' is not finite: {value}"
                 ));
             }
-            let idx: u32 = key.parse().map_err(|_| {
-                format!(
-                    "Sparse vector key '{key}' is not a valid u32 term ID"
-                )
-            })?;
+            let idx: u32 = key
+                .parse()
+                .map_err(|_| format!("Sparse vector key '{key}' is not a valid u32 term ID"))?;
             pairs.push((idx, value));
         }
         Ok(crate::sparse_index::SparseVector::new(pairs))

--- a/crates/velesdb-core/src/collection/core/lifecycle.rs
+++ b/crates/velesdb-core/src/collection/core/lifecycle.rs
@@ -110,12 +110,8 @@ impl Collection {
         config: CollectionConfig,
         hnsw_params: Option<crate::index::hnsw::HnswParams>,
     ) -> Result<CollectionParts> {
-        let vector_storage = Arc::new(RwLock::new(
-            MmapStorage::new(&path, config.dimension)?,
-        ));
-        let payload_storage = Arc::new(RwLock::new(
-            LogPayloadStorage::new(&path)?,
-        ));
+        let vector_storage = Arc::new(RwLock::new(MmapStorage::new(&path, config.dimension)?));
+        let payload_storage = Arc::new(RwLock::new(LogPayloadStorage::new(&path)?));
         let index = if let Some(params) = hnsw_params {
             Arc::new(HnswIndex::with_params(
                 config.dimension,
@@ -364,12 +360,8 @@ impl Collection {
             serde_json::from_str(&config_data).map_err(|e| Error::Serialization(e.to_string()))?;
 
         // Open persistent storages
-        let vector_storage = Arc::new(RwLock::new(
-            MmapStorage::new(&path, config.dimension)?,
-        ));
-        let payload_storage = Arc::new(RwLock::new(
-            LogPayloadStorage::new(&path)?,
-        ));
+        let vector_storage = Arc::new(RwLock::new(MmapStorage::new(&path, config.dimension)?));
+        let payload_storage = Arc::new(RwLock::new(LogPayloadStorage::new(&path)?));
 
         // Load HNSW index if it exists, otherwise create new (empty).
         // When hnsw.bin is absent and config.hnsw_params is set, honour the
@@ -608,16 +600,12 @@ impl Collection {
 
         // Save RangeIndex (EPIC-009 US-005)
         let range_index_path = self.path.join("range_index.bin");
-        self.range_index
-            .read()
-            .save_to_file(&range_index_path)?;
+        self.range_index.read().save_to_file(&range_index_path)?;
 
         // Save EdgeStore for graph collections (BUG-1: was never persisted)
         if self.config.read().graph_schema.is_some() {
             let edge_store_path = self.path.join("edge_store.bin");
-            self.edge_store
-                .read()
-                .save_to_file(&edge_store_path)?;
+            self.edge_store.read().save_to_file(&edge_store_path)?;
         }
 
         // Compact all named sparse indexes to disk (EPIC-062 / SPARSE-04)

--- a/crates/velesdb-core/src/collection/core/mod.rs
+++ b/crates/velesdb-core/src/collection/core/mod.rs
@@ -21,8 +21,8 @@ mod lifecycle;
 mod lifecycle_tests;
 mod statistics;
 
-pub use index_management::IndexInfo;
 pub use crate::validation::{MAX_DIMENSION, MIN_DIMENSION};
+pub use index_management::IndexInfo;
 
 // All implementations are in submodules, no re-exports needed here
 // as they extend the Collection type defined in types.rs

--- a/crates/velesdb-core/src/collection/search/query/match_exec/where_eval.rs
+++ b/crates/velesdb-core/src/collection/search/query/match_exec/where_eval.rs
@@ -81,11 +81,13 @@ fn resolve_query_vector(
             match param_value {
                 serde_json::Value::Array(arr) => Ok(arr
                     .iter()
-                    .filter_map(|v| v.as_f64().map(|f| {
-                        #[allow(clippy::cast_possible_truncation)]
-                        let r = f as f32;
-                        r
-                    }))
+                    .filter_map(|v| {
+                        v.as_f64().map(|f| {
+                            #[allow(clippy::cast_possible_truncation)]
+                            let r = f as f32;
+                            r
+                        })
+                    })
                     .collect()),
                 _ => Err(Error::Config(format!(
                     "Parameter ${name} must be a vector array"
@@ -113,23 +115,19 @@ impl Collection {
             Condition::Comparison(cmp) => {
                 self.evaluate_comparison_condition(node_id, bindings, cmp, params)
             }
-            Condition::And(left, right) => {
-                Ok(self.evaluate_where_condition(node_id, bindings, left, params)?
-                    && self.evaluate_where_condition(node_id, bindings, right, params)?)
-            }
-            Condition::Or(left, right) => {
-                Ok(self.evaluate_where_condition(node_id, bindings, left, params)?
-                    || self.evaluate_where_condition(node_id, bindings, right, params)?)
-            }
+            Condition::And(left, right) => Ok(self
+                .evaluate_where_condition(node_id, bindings, left, params)?
+                && self.evaluate_where_condition(node_id, bindings, right, params)?),
+            Condition::Or(left, right) => Ok(self
+                .evaluate_where_condition(node_id, bindings, left, params)?
+                || self.evaluate_where_condition(node_id, bindings, right, params)?),
             Condition::Not(inner) => {
                 Ok(!self.evaluate_where_condition(node_id, bindings, inner, params)?)
             }
             Condition::Group(inner) => {
                 self.evaluate_where_condition(node_id, bindings, inner, params)
             }
-            Condition::Similarity(sim) => {
-                self.evaluate_similarity_condition(node_id, sim, params)
-            }
+            Condition::Similarity(sim) => self.evaluate_similarity_condition(node_id, sim, params),
             // Other condition types (VectorSearch, VectorFusedSearch, etc.)
             // handled separately in `execute_match_with_similarity`.
             _ => Ok(true),
@@ -253,14 +251,12 @@ impl Collection {
         use crate::velesql::Value;
 
         Ok(match (actual, expected) {
-            (serde_json::Value::Number(n), Value::Integer(i)) => {
-                n.as_i64()
-                    .is_some_and(|actual_i| apply_ord_op(operator, &actual_i, i))
-            }
-            (serde_json::Value::Number(n), Value::Float(f)) => {
-                n.as_f64()
-                    .is_some_and(|actual_f| compare_floats(operator, actual_f, *f))
-            }
+            (serde_json::Value::Number(n), Value::Integer(i)) => n
+                .as_i64()
+                .is_some_and(|actual_i| apply_ord_op(operator, &actual_i, i)),
+            (serde_json::Value::Number(n), Value::Float(f)) => n
+                .as_f64()
+                .is_some_and(|actual_f| compare_floats(operator, actual_f, *f)),
             (serde_json::Value::String(s), Value::String(expected_s)) => {
                 apply_ord_op(operator, &s.as_str(), &expected_s.as_str())
             }

--- a/crates/velesdb-core/src/collection/search/vector.rs
+++ b/crates/velesdb-core/src/collection/search/vector.rs
@@ -28,7 +28,8 @@ impl Collection {
 
         let candidates_k = k.saturating_mul(oversampling).max(k + 32);
         let index_results = self.index.search(query, candidates_k);
-        let rescored = self.rescore_pq_candidates(query, k, metric, higher_is_better, index_results);
+        let rescored =
+            self.rescore_pq_candidates(query, k, metric, higher_is_better, index_results);
         self.merge_delta(rescored, query, k, metric)
     }
 
@@ -79,16 +80,10 @@ impl Collection {
         metric: DistanceMetric,
     ) -> Vec<ScoredResult> {
         let tuples: Vec<(u64, f32)> = results.into_iter().map(Into::into).collect();
-        crate::collection::streaming::merge_with_delta(
-            tuples,
-            &self.delta_buffer,
-            query,
-            k,
-            metric,
-        )
-        .into_iter()
-        .map(ScoredResult::from)
-        .collect()
+        crate::collection::streaming::merge_with_delta(tuples, &self.delta_buffer, query, k, metric)
+            .into_iter()
+            .map(ScoredResult::from)
+            .collect()
     }
 
     #[cfg(not(feature = "persistence"))]

--- a/crates/velesdb-core/src/collection/search/vector_tests.rs
+++ b/crates/velesdb-core/src/collection/search/vector_tests.rs
@@ -46,9 +46,7 @@ fn test_search_ids_product_quantization_cosine_scores_stay_in_similarity_domain(
     // ASSERT
     assert!(!results.is_empty(), "search should return candidates");
     assert!(
-        results
-            .iter()
-            .all(|sr| (-1.0..=1.0).contains(&sr.score)),
+        results.iter().all(|sr| (-1.0..=1.0).contains(&sr.score)),
         "cosine metric scores must remain in similarity domain [-1, 1]"
     );
 }

--- a/crates/velesdb-core/src/collection/vector_collection.rs
+++ b/crates/velesdb-core/src/collection/vector_collection.rs
@@ -339,7 +339,11 @@ impl VectorCollection {
     /// # Errors
     ///
     /// - Returns an error if the query dimension does not match the collection.
-    pub fn search_ids(&self, query: &[f32], k: usize) -> Result<Vec<crate::scored_result::ScoredResult>> {
+    pub fn search_ids(
+        &self,
+        query: &[f32],
+        k: usize,
+    ) -> Result<Vec<crate::scored_result::ScoredResult>> {
         self.inner.search_ids(query, k)
     }
 

--- a/crates/velesdb-core/src/database/mod.rs
+++ b/crates/velesdb-core/src/database/mod.rs
@@ -22,10 +22,10 @@ mod collection_ops;
 mod graph_ops;
 mod metadata_ops;
 mod persistence;
-mod vector_ops;
 mod query_engine;
 mod stats;
 mod training;
+mod vector_ops;
 
 #[cfg(feature = "persistence")]
 mod database_helpers;

--- a/crates/velesdb-core/src/database/persistence.rs
+++ b/crates/velesdb-core/src/database/persistence.rs
@@ -125,21 +125,20 @@ impl Database {
         }
     }
 
-    /// Flushes all WALs across every collection registry (legacy, vector, graph, metadata).
+    /// Flushes all WALs across the typed collection registries.
     ///
     /// Best-effort: logs warnings for individual flush failures but continues
     /// flushing remaining collections. Returns the count of failures.
+    ///
+    /// Note: the legacy `collections` registry is intentionally skipped because
+    /// it shares the same `Arc`'d storage as the typed registries — flushing it
+    /// would double-flush every collection.
     #[allow(deprecated)]
     pub fn flush_all(&self) -> usize {
         let mut failures: usize = 0;
 
-        // Legacy collections
-        for (name, coll) in self.collections.read().iter() {
-            if let Err(e) = coll.flush() {
-                tracing::warn!(error = %e, collection = %name, "Failed to flush legacy collection");
-                failures += 1;
-            }
-        }
+        // Typed registries only — legacy `collections` shares the same Arc'd
+        // storage, so flushing it would double-flush every collection.
 
         // Vector collections
         for (name, coll) in self.vector_colls.read().iter() {

--- a/crates/velesdb-core/src/database/persistence.rs
+++ b/crates/velesdb-core/src/database/persistence.rs
@@ -125,6 +125,49 @@ impl Database {
         }
     }
 
+    /// Flushes all WALs across every collection registry (legacy, vector, graph, metadata).
+    ///
+    /// Best-effort: logs warnings for individual flush failures but continues
+    /// flushing remaining collections. Returns the count of failures.
+    #[allow(deprecated)]
+    pub fn flush_all(&self) -> usize {
+        let mut failures: usize = 0;
+
+        // Legacy collections
+        for (name, coll) in self.collections.read().iter() {
+            if let Err(e) = coll.flush() {
+                tracing::warn!(error = %e, collection = %name, "Failed to flush legacy collection");
+                failures += 1;
+            }
+        }
+
+        // Vector collections
+        for (name, coll) in self.vector_colls.read().iter() {
+            if let Err(e) = coll.flush() {
+                tracing::warn!(error = %e, collection = %name, "Failed to flush vector collection");
+                failures += 1;
+            }
+        }
+
+        // Graph collections
+        for (name, coll) in self.graph_colls.read().iter() {
+            if let Err(e) = coll.flush() {
+                tracing::warn!(error = %e, collection = %name, "Failed to flush graph collection");
+                failures += 1;
+            }
+        }
+
+        // Metadata collections
+        for (name, coll) in self.metadata_colls.read().iter() {
+            if let Err(e) = coll.flush() {
+                tracing::warn!(error = %e, collection = %name, "Failed to flush metadata collection");
+                failures += 1;
+            }
+        }
+
+        failures
+    }
+
     /// Loads a vector collection from disk, registering it in both registries.
     fn load_vector_collection(&self, path: &std::path::Path, name: &str) -> bool {
         match VectorCollection::open(path.to_path_buf()) {

--- a/crates/velesdb-core/src/index/hnsw/index/search.rs
+++ b/crates/velesdb-core/src/index/hnsw/index/search.rs
@@ -197,7 +197,12 @@ impl HnswIndex {
     ///
     /// Panics if the query dimension doesn't match the index dimension.
     #[must_use]
-    pub fn search_with_rerank(&self, query: &[f32], k: usize, rerank_k: usize) -> Vec<ScoredResult> {
+    pub fn search_with_rerank(
+        &self,
+        query: &[f32],
+        k: usize,
+        rerank_k: usize,
+    ) -> Vec<ScoredResult> {
         let ef_search = SearchQuality::Accurate.ef_search(rerank_k);
         let adaptive_rerank_k = self
             .should_two_stage_rerank(SearchQuality::Accurate, k, ef_search)

--- a/crates/velesdb-core/src/index/hnsw/index_tests.rs
+++ b/crates/velesdb-core/src/index/hnsw/index_tests.rs
@@ -760,7 +760,10 @@ fn test_search_with_rerank_uses_simd_distances() {
     // Note: HNSW may return fewer results if graph not fully connected
     assert!(!results.is_empty(), "Should return at least one result");
     for sr in &results {
-        assert!(sr.score >= -1.0 && sr.score <= 1.0, "Cosine should be in [-1, 1]");
+        assert!(
+            sr.score >= -1.0 && sr.score <= 1.0,
+            "Cosine should be in [-1, 1]"
+        );
     }
 
     // Results should be sorted by similarity (descending for cosine)
@@ -1230,7 +1233,11 @@ fn test_recall_quality_minimum_threshold() {
             crate::scored_result::ScoredResult::new(idx as u64, sim)
         })
         .collect();
-    distances.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap_or(std::cmp::Ordering::Equal));
+    distances.sort_by(|a, b| {
+        b.score
+            .partial_cmp(&a.score)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
     let ground_truth: Vec<u64> = distances.iter().take(k).map(|sr| sr.id).collect();
 
     // HNSW search
@@ -1360,7 +1367,10 @@ fn test_brute_force_buffered_same_results_as_original() {
     assert_eq!(original.len(), buffered.len());
     for (orig, buf) in original.iter().zip(buffered.iter()) {
         assert_eq!(orig.id, buf.id, "IDs should match");
-        assert!((orig.score - buf.score).abs() < 1e-6, "Distances should match");
+        assert!(
+            (orig.score - buf.score).abs() < 1e-6,
+            "Distances should match"
+        );
     }
 }
 
@@ -1752,10 +1762,8 @@ fn test_search_brute_force_gpu_returns_same_results_as_cpu() {
         );
 
         // Verify same IDs returned (order may differ slightly due to floating point)
-        let cpu_ids: std::collections::HashSet<u64> =
-            cpu_results.iter().map(|sr| sr.id).collect();
-        let gpu_ids: std::collections::HashSet<u64> =
-            gpu_results.iter().map(|sr| sr.id).collect();
+        let cpu_ids: std::collections::HashSet<u64> = cpu_results.iter().map(|sr| sr.id).collect();
+        let gpu_ids: std::collections::HashSet<u64> = gpu_results.iter().map(|sr| sr.id).collect();
 
         let overlap = cpu_ids.intersection(&gpu_ids).count();
         assert!(

--- a/crates/velesdb-core/src/index/hnsw/native/tests.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/tests.rs
@@ -758,7 +758,11 @@ fn test_concurrent_insert_delete_search_at_index_level() {
                 // All returned IDs must be valid (not deleted from mappings)
                 // and distances must be finite
                 for sr in &results {
-                    assert!(sr.score.is_finite(), "Distance must be finite for ID {}", sr.id);
+                    assert!(
+                        sr.score.is_finite(),
+                        "Distance must be finite for ID {}",
+                        sr.id
+                    );
                 }
             }
         }));
@@ -786,7 +790,8 @@ fn test_concurrent_insert_delete_search_at_index_level() {
     for sr in &results {
         assert!(
             !(0..50).contains(&sr.id),
-            "Soft-deleted ID {} must not appear in search results", sr.id
+            "Soft-deleted ID {} must not appear in search results",
+            sr.id
         );
     }
 
@@ -868,7 +873,8 @@ fn test_delete_exclusion_under_concurrent_search() {
     for sr in &results {
         assert!(
             sr.id % 2 != 0,
-            "Soft-deleted even ID {} must not appear in post-delete search", sr.id
+            "Soft-deleted even ID {} must not appear in post-delete search",
+            sr.id
         );
     }
     // Verify odd IDs are still returned

--- a/crates/velesdb-core/src/index/hnsw/native_index_tests.rs
+++ b/crates/velesdb-core/src/index/hnsw/native_index_tests.rs
@@ -148,7 +148,10 @@ fn test_native_index_brute_force_search() {
     assert_eq!(results.len(), 5);
     assert_eq!(results[0].id, 0);
     for i in 1..results.len() {
-        assert!(results[i].score >= results[i - 1].score, "Results not sorted");
+        assert!(
+            results[i].score >= results[i - 1].score,
+            "Results not sorted"
+        );
     }
 }
 

--- a/crates/velesdb-core/src/lib.rs
+++ b/crates/velesdb-core/src/lib.rs
@@ -61,9 +61,9 @@
 #[cfg(feature = "persistence")]
 pub mod agent;
 pub mod alloc_guard;
-pub mod api_types;
 #[cfg(test)]
 mod alloc_guard_tests;
+pub mod api_types;
 pub mod cache;
 #[cfg(feature = "persistence")]
 pub mod collection;
@@ -188,15 +188,13 @@ pub use error::{Error, Result};
 pub use filter::{Condition, Filter};
 pub use perf_optimizations::pad_to_simd_width;
 pub use point::{Point, SearchResult};
-pub use scored_result::ScoredResult;
-pub use validation::{
-    validate_dimension, validate_dimension_match, MAX_DIMENSION, MIN_DIMENSION,
-};
 pub use quantization::{
     cosine_similarity_quantized, cosine_similarity_quantized_simd, dot_product_quantized,
     dot_product_quantized_simd, euclidean_squared_quantized, euclidean_squared_quantized_simd,
     BinaryQuantizedVector, QuantizationCodec, QuantizedVector, StorageMode,
 };
+pub use scored_result::ScoredResult;
+pub use validation::{validate_dimension, validate_dimension_match, MAX_DIMENSION, MIN_DIMENSION};
 
 #[cfg(feature = "persistence")]
 pub use column_store::{

--- a/crates/velesdb-core/src/quantization/binary.rs
+++ b/crates/velesdb-core/src/quantization/binary.rs
@@ -122,7 +122,6 @@ impl BinaryQuantizedVector {
         let distance = self.hamming_distance(other);
         1.0 - (distance as f32 / self.dimension as f32)
     }
-
 }
 
 impl QuantizationCodec for BinaryQuantizedVector {

--- a/crates/velesdb-core/src/quantization/scalar.rs
+++ b/crates/velesdb-core/src/quantization/scalar.rs
@@ -90,7 +90,6 @@ impl QuantizedVector {
     pub fn memory_size(&self) -> usize {
         self.data.len() + 8 // data + min(4) + max(4)
     }
-
 }
 
 impl QuantizationCodec for QuantizedVector {

--- a/crates/velesdb-core/src/simd_native/neon.rs
+++ b/crates/velesdb-core/src/simd_native/neon.rs
@@ -101,8 +101,14 @@ fn dot_product_neon_4acc(a: &[f32], b: &[f32]) -> f32 {
     // guaranteed by `end_main`. `neon_fma_compat` reorders args to match macro convention.
     let (combined, mut a_ptr, mut b_ptr) = unsafe {
         crate::simd_4acc_dot_loop!(
-            a.as_ptr(), b.as_ptr(), end_main,
-            vdupq_n_f32(0.0), vld1q_f32, neon_fma_compat, vaddq_f32, 4
+            a.as_ptr(),
+            b.as_ptr(),
+            end_main,
+            vdupq_n_f32(0.0),
+            vld1q_f32,
+            neon_fma_compat,
+            vaddq_f32,
+            4
         )
     };
 
@@ -269,12 +275,24 @@ unsafe fn cosine_fused_neon_main_loop(
     // - Condition 1: NEON is always present on aarch64.
     // - Condition 2: Immediate 0.0 is valid.
     // Reason: Initialise 12 accumulators (3 products x 4-way ILP).
-    let (mut d0, mut d1, mut d2, mut d3) =
-        (vdupq_n_f32(0.0), vdupq_n_f32(0.0), vdupq_n_f32(0.0), vdupq_n_f32(0.0));
-    let (mut na0, mut na1, mut na2, mut na3) =
-        (vdupq_n_f32(0.0), vdupq_n_f32(0.0), vdupq_n_f32(0.0), vdupq_n_f32(0.0));
-    let (mut nb0, mut nb1, mut nb2, mut nb3) =
-        (vdupq_n_f32(0.0), vdupq_n_f32(0.0), vdupq_n_f32(0.0), vdupq_n_f32(0.0));
+    let (mut d0, mut d1, mut d2, mut d3) = (
+        vdupq_n_f32(0.0),
+        vdupq_n_f32(0.0),
+        vdupq_n_f32(0.0),
+        vdupq_n_f32(0.0),
+    );
+    let (mut na0, mut na1, mut na2, mut na3) = (
+        vdupq_n_f32(0.0),
+        vdupq_n_f32(0.0),
+        vdupq_n_f32(0.0),
+        vdupq_n_f32(0.0),
+    );
+    let (mut nb0, mut nb1, mut nb2, mut nb3) = (
+        vdupq_n_f32(0.0),
+        vdupq_n_f32(0.0),
+        vdupq_n_f32(0.0),
+        vdupq_n_f32(0.0),
+    );
 
     while a_ptr < end_main {
         // SAFETY: Loop condition guarantees 16 elements remain before `end_main`.

--- a/crates/velesdb-core/src/simd_native/x86_avx2/dot.rs
+++ b/crates/velesdb-core/src/simd_native/x86_avx2/dot.rs
@@ -46,8 +46,14 @@ pub(crate) unsafe fn dot_product_avx2_4acc(a: &[f32], b: &[f32]) -> f32 {
 
     // SAFETY: 4-accumulator ILP loop. Pointer bounds guaranteed by end_main.
     let (combined, _, _) = simd_4acc_dot_loop!(
-        a_ptr, b_ptr, end_main,
-        _mm256_setzero_ps(), _mm256_loadu_ps, _mm256_fmadd_ps, _mm256_add_ps, 8
+        a_ptr,
+        b_ptr,
+        end_main,
+        _mm256_setzero_ps(),
+        _mm256_loadu_ps,
+        _mm256_fmadd_ps,
+        _mm256_add_ps,
+        8
     );
 
     let mut result = hsum_avx256(combined);

--- a/crates/velesdb-core/src/simd_native/x86_avx2/l2.rs
+++ b/crates/velesdb-core/src/simd_native/x86_avx2/l2.rs
@@ -153,8 +153,15 @@ pub(crate) unsafe fn squared_l2_avx2_4acc(a: &[f32], b: &[f32]) -> f32 {
 
     // SAFETY: 4-accumulator ILP loop. Pointer bounds guaranteed by end_main.
     let (combined, mut a_p, mut b_p) = simd_4acc_l2_loop!(
-        a_ptr, b_ptr, end_main,
-        _mm256_setzero_ps(), _mm256_loadu_ps, _mm256_sub_ps, _mm256_fmadd_ps, _mm256_add_ps, 8
+        a_ptr,
+        b_ptr,
+        end_main,
+        _mm256_setzero_ps(),
+        _mm256_loadu_ps,
+        _mm256_sub_ps,
+        _mm256_fmadd_ps,
+        _mm256_add_ps,
+        8
     );
 
     let mut result = hsum_avx256(combined);

--- a/crates/velesdb-core/src/simd_native/x86_avx2_similarity.rs
+++ b/crates/velesdb-core/src/simd_native/x86_avx2_similarity.rs
@@ -314,4 +314,3 @@ pub(crate) unsafe fn jaccard_avx2(a: &[f32], b: &[f32]) -> f32 {
         inter_sum / union_sum
     }
 }
-

--- a/crates/velesdb-core/src/simd_native/x86_avx512.rs
+++ b/crates/velesdb-core/src/simd_native/x86_avx512.rs
@@ -109,8 +109,14 @@ pub(crate) unsafe fn dot_product_avx512_4acc(a: &[f32], b: &[f32]) -> f32 {
 
     // SAFETY: 4-accumulator ILP loop. Pointer bounds guaranteed by end_main.
     let (mut acc, mut a_p, mut b_p) = simd_4acc_dot_loop!(
-        a_ptr, b_ptr, end_main,
-        _mm512_setzero_ps(), _mm512_loadu_ps, _mm512_fmadd_ps, _mm512_add_ps, 16
+        a_ptr,
+        b_ptr,
+        end_main,
+        _mm512_setzero_ps(),
+        _mm512_loadu_ps,
+        _mm512_fmadd_ps,
+        _mm512_add_ps,
+        16
     );
 
     // Process remaining 16-element chunks with same accumulator
@@ -164,8 +170,15 @@ pub(crate) unsafe fn squared_l2_avx512_4acc(a: &[f32], b: &[f32]) -> f32 {
 
     // SAFETY: 4-accumulator ILP loop. Pointer bounds guaranteed by end_main.
     let (mut acc, mut a_p, mut b_p) = simd_4acc_l2_loop!(
-        a_ptr, b_ptr, end_main,
-        _mm512_setzero_ps(), _mm512_loadu_ps, _mm512_sub_ps, _mm512_fmadd_ps, _mm512_add_ps, 16
+        a_ptr,
+        b_ptr,
+        end_main,
+        _mm512_setzero_ps(),
+        _mm512_loadu_ps,
+        _mm512_sub_ps,
+        _mm512_fmadd_ps,
+        _mm512_add_ps,
+        16
     );
 
     // Process remaining 16-element chunks

--- a/crates/velesdb-core/src/sparse_index/search/mod.rs
+++ b/crates/velesdb-core/src/sparse_index/search/mod.rs
@@ -137,9 +137,9 @@ pub(crate) fn brute_force_search(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use super::super::inverted_index::SparseInvertedIndex;
     use super::super::types::SparseVector;
+    use super::*;
     use rand::rngs::StdRng;
     use rand::{Rng, SeedableRng};
 

--- a/crates/velesdb-core/src/sparse_index/search/scoring.rs
+++ b/crates/velesdb-core/src/sparse_index/search/scoring.rs
@@ -64,8 +64,7 @@ pub(crate) fn prepare_term_data(
     let mut upper_bound = vec![0.0_f32; n];
     upper_bound[0] = terms[0].query_weight.abs() * terms[0].max_doc_weight;
     for i in 1..n {
-        upper_bound[i] =
-            upper_bound[i - 1] + terms[i].query_weight.abs() * terms[i].max_doc_weight;
+        upper_bound[i] = upper_bound[i - 1] + terms[i].query_weight.abs() * terms[i].max_doc_weight;
     }
 
     Some(PreparedTerms { terms, upper_bound })

--- a/crates/velesdb-core/src/storage/log_payload.rs
+++ b/crates/velesdb-core/src/storage/log_payload.rs
@@ -86,8 +86,7 @@ impl LogPayloadStorage {
 
         let wal = Self::open_wal_writer(&log_path)?;
         let (reader, wal_len) = Self::open_wal_reader(&log_path)?;
-        let (index, last_snapshot_wal_pos) =
-            Self::load_or_replay_index(&path, &log_path, wal_len)?;
+        let (index, last_snapshot_wal_pos) = Self::load_or_replay_index(&path, &log_path, wal_len)?;
 
         Ok(Self {
             path,
@@ -131,8 +130,7 @@ impl LogPayloadStorage {
     ) -> io::Result<(FxHashMap<u64, u64>, u64)> {
         let snapshot_path = dir.join("payloads.snapshot");
         if let Ok((snapshot_index, snapshot_wal_pos)) = snapshot::load_snapshot(&snapshot_path) {
-            let index =
-                Self::replay_wal_from(log_path, snapshot_index, snapshot_wal_pos, wal_len)?;
+            let index = Self::replay_wal_from(log_path, snapshot_index, snapshot_wal_pos, wal_len)?;
             Ok((index, snapshot_wal_pos))
         } else {
             let index = Self::replay_wal_from(log_path, FxHashMap::default(), 0, wal_len)?;

--- a/crates/velesdb-core/src/storage/mmap/wal_replay.rs
+++ b/crates/velesdb-core/src/storage/mmap/wal_replay.rs
@@ -98,9 +98,9 @@ fn drain_wal_entries(
     vector_size: usize,
 ) -> usize {
     let mut replayed = 0usize;
-    while let Ok(true) = replay_one_entry(
-        reader, file_len, index, mmap_data, next_offset, vector_size,
-    ) {
+    while let Ok(true) =
+        replay_one_entry(reader, file_len, index, mmap_data, next_offset, vector_size)
+    {
         replayed += 1;
     }
     replayed

--- a/crates/velesdb-core/src/storage/mod.rs
+++ b/crates/velesdb-core/src/storage/mod.rs
@@ -19,11 +19,11 @@ mod guard;
 mod histogram;
 mod log_payload;
 pub mod metrics;
-pub(crate) mod snapshot;
 mod mmap;
 mod sharded_index;
 #[cfg(test)]
 mod sharded_index_tests;
+pub(crate) mod snapshot;
 mod traits;
 pub mod vector_bytes;
 #[cfg(test)]

--- a/crates/velesdb-core/src/storage/snapshot.rs
+++ b/crates/velesdb-core/src/storage/snapshot.rs
@@ -72,13 +72,19 @@ pub(crate) fn crc32_hash(data: &[u8]) -> u32 {
 /// Validates magic, version, and minimum size of snapshot data.
 fn validate_snapshot_format(data: &[u8]) -> io::Result<()> {
     if data.len() < 25 {
-        return Err(io::Error::new(io::ErrorKind::InvalidData, "Snapshot too small"));
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "Snapshot too small",
+        ));
     }
     if &data[0..4] != SNAPSHOT_MAGIC {
         return Err(io::Error::new(io::ErrorKind::InvalidData, "Invalid magic"));
     }
     if data[4] != SNAPSHOT_VERSION {
-        return Err(io::Error::new(io::ErrorKind::InvalidData, "Unsupported version"));
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "Unsupported version",
+        ));
     }
     Ok(())
 }
@@ -88,18 +94,23 @@ fn validate_snapshot_header(data: &[u8]) -> io::Result<(u64, usize)> {
     validate_snapshot_format(data)?;
 
     let wal_pos = u64::from_le_bytes(
-        data[5..13].try_into()
+        data[5..13]
+            .try_into()
             .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "Invalid WAL position"))?,
     );
     let entry_count_u64 = u64::from_le_bytes(
-        data[13..21].try_into()
+        data[13..21]
+            .try_into()
             .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "Invalid entry count"))?,
     );
 
     // P1 Audit: Validate entry_count BEFORE conversion to prevent DoS
     let max_possible_entries = data.len().saturating_sub(25) / 16;
     if entry_count_u64 > max_possible_entries as u64 {
-        return Err(io::Error::new(io::ErrorKind::InvalidData, "Entry count exceeds data size"));
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "Entry count exceeds data size",
+        ));
     }
     #[allow(clippy::cast_possible_truncation)] // Validated above
     let entry_count = entry_count_u64 as usize;
@@ -109,7 +120,8 @@ fn validate_snapshot_header(data: &[u8]) -> io::Result<(u64, usize)> {
     }
 
     let stored_crc = u32::from_le_bytes(
-        data[data.len() - 4..].try_into()
+        data[data.len() - 4..]
+            .try_into()
             .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "Invalid CRC"))?,
     );
     if stored_crc != crc32_hash(&data[..data.len() - 4]) {
@@ -134,11 +146,13 @@ pub(crate) fn load_snapshot(snapshot_path: &Path) -> io::Result<(FxHashMap<u64, 
     for i in 0..entry_count {
         let offset = entries_start + i * 16;
         let id = u64::from_le_bytes(
-            data[offset..offset + 8].try_into()
+            data[offset..offset + 8]
+                .try_into()
                 .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "Invalid entry ID"))?,
         );
         let wal_offset = u64::from_le_bytes(
-            data[offset + 8..offset + 16].try_into()
+            data[offset + 8..offset + 16]
+                .try_into()
                 .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "Invalid entry offset"))?,
         );
         index.insert(id, wal_offset);

--- a/crates/velesdb-mobile/src/lib.rs
+++ b/crates/velesdb-mobile/src/lib.rs
@@ -279,7 +279,10 @@ impl VelesCollection {
 
         Ok(results
             .into_iter()
-            .map(|sr| SearchResult { id: sr.id, score: sr.score })
+            .map(|sr| SearchResult {
+                id: sr.id,
+                score: sr.score,
+            })
             .collect())
     }
 

--- a/crates/velesdb-python/README.md
+++ b/crates/velesdb-python/README.md
@@ -247,6 +247,31 @@ Tested on clustered embeddings (768D) — realistic AI workloads:
 - **97-100% recall** across all scales
 - **Sub-5ms latency** even at 100k vectors
 
+## Connecting to velesdb-server
+
+The `velesdb` Python package provides **embedded** (in-process) access to VelesDB. To connect to a remote `velesdb-server` instance (with optional API key authentication), use standard HTTP requests:
+
+```python
+import requests
+
+API_URL = "http://localhost:8080"
+API_KEY = "my-secret-key"  # Only needed when server has auth enabled
+
+headers = {"Authorization": f"Bearer {API_KEY}"}
+
+# Search for similar vectors
+response = requests.post(
+    f"{API_URL}/collections/documents/search",
+    json={"vector": [0.1, 0.2, ...], "top_k": 5},
+    headers=headers,
+)
+results = response.json()
+```
+
+When the server has TLS enabled, use `https://` and optionally pass `verify=False` for self-signed certificates.
+
+See [SERVER_SECURITY.md](../../docs/guides/SERVER_SECURITY.md) for server authentication and TLS setup.
+
 ## Requirements
 
 - Python 3.9+

--- a/crates/velesdb-server/Cargo.toml
+++ b/crates/velesdb-server/Cargo.toml
@@ -36,6 +36,13 @@ clap = { version = "4.4", features = ["derive", "env"] }
 toml = { workspace = true }
 parking_lot = "0.12"
 
+# TLS support via rustls
+rustls = { version = "0.23", default-features = false, features = ["ring", "logging", "std", "tls12"] }
+tokio-rustls = "0.26"
+rustls-pemfile = "2"
+hyper = "1"
+hyper-util = { version = "0.1", features = ["tokio", "server-auto"] }
+
 # OpenAPI/Swagger documentation
 utoipa = { version = "5", features = ["axum_extras"] }
 utoipa-swagger-ui = { version = "9", features = ["axum"], optional = true }

--- a/crates/velesdb-server/Cargo.toml
+++ b/crates/velesdb-server/Cargo.toml
@@ -33,6 +33,7 @@ tower = { workspace = true }
 tower-http = { workspace = true }
 futures = "0.3"
 clap = { version = "4.4", features = ["derive", "env"] }
+toml = { workspace = true }
 parking_lot = "0.12"
 
 # OpenAPI/Swagger documentation

--- a/crates/velesdb-server/src/auth.rs
+++ b/crates/velesdb-server/src/auth.rs
@@ -37,7 +37,7 @@ impl AuthState {
 
 /// Paths that bypass authentication.
 fn is_public_path(path: &str) -> bool {
-    path == "/health"
+    path == "/health" || path == "/ready"
 }
 
 /// Extract the Bearer token from the Authorization header value.
@@ -121,6 +121,11 @@ mod tests {
     #[test]
     fn test_is_public_path_health() {
         assert!(is_public_path("/health"));
+    }
+
+    #[test]
+    fn test_is_public_path_ready() {
+        assert!(is_public_path("/ready"));
     }
 
     #[test]

--- a/crates/velesdb-server/src/auth.rs
+++ b/crates/velesdb-server/src/auth.rs
@@ -37,14 +37,19 @@ impl AuthState {
 
 /// Paths that bypass authentication.
 fn is_public_path(path: &str) -> bool {
-    path == "/health" || path == "/ready"
+    path == "/health" || path == "/ready" || path == "/metrics"
 }
 
 /// Extract the Bearer token from the Authorization header value.
 fn extract_bearer_token(header_value: &str) -> Option<&str> {
     let trimmed = header_value.trim();
     if trimmed.len() > 7 && trimmed[..7].eq_ignore_ascii_case("bearer ") {
-        Some(trimmed[7..].trim())
+        let token = trimmed[7..].trim();
+        if token.is_empty() {
+            None
+        } else {
+            Some(token)
+        }
     } else {
         None
     }
@@ -129,6 +134,11 @@ mod tests {
     }
 
     #[test]
+    fn test_is_public_path_metrics() {
+        assert!(is_public_path("/metrics"));
+    }
+
+    #[test]
     fn test_is_public_path_other() {
         assert!(!is_public_path("/collections"));
         assert!(!is_public_path("/query"));
@@ -149,5 +159,10 @@ mod tests {
         assert_eq!(extract_bearer_token("my-key"), None);
         assert_eq!(extract_bearer_token("Bearer"), None);
         assert_eq!(extract_bearer_token(""), None);
+    }
+
+    #[test]
+    fn test_extract_bearer_token_whitespace_only() {
+        assert_eq!(extract_bearer_token("Bearer   "), None);
     }
 }

--- a/crates/velesdb-server/src/auth.rs
+++ b/crates/velesdb-server/src/auth.rs
@@ -76,11 +76,11 @@ pub async fn auth_middleware(
 
     match auth_header {
         Some(value) => match extract_bearer_token(value) {
-            Some(token) if state.api_keys.contains(&token.to_string()) => {
-                next.run(request).await
-            }
+            Some(token) if state.api_keys.contains(&token.to_string()) => next.run(request).await,
             Some(_) => unauthorized_response("invalid API key"),
-            None => unauthorized_response("invalid Authorization header format, expected: Bearer <key>"),
+            None => {
+                unauthorized_response("invalid Authorization header format, expected: Bearer <key>")
+            }
         },
         None => unauthorized_response("missing Authorization header"),
     }
@@ -140,10 +140,7 @@ mod tests {
         assert_eq!(extract_bearer_token("Bearer my-key"), Some("my-key"));
         assert_eq!(extract_bearer_token("bearer my-key"), Some("my-key"));
         assert_eq!(extract_bearer_token("BEARER my-key"), Some("my-key"));
-        assert_eq!(
-            extract_bearer_token("  Bearer  my-key  "),
-            Some("my-key")
-        );
+        assert_eq!(extract_bearer_token("  Bearer  my-key  "), Some("my-key"));
     }
 
     #[test]

--- a/crates/velesdb-server/src/auth.rs
+++ b/crates/velesdb-server/src/auth.rs
@@ -1,0 +1,151 @@
+//! API key authentication middleware.
+//!
+//! When `api_keys` is non-empty, all requests except those to public paths
+//! (e.g. `GET /health`) must include a valid `Authorization: Bearer <key>` header.
+//! When `api_keys` is empty, authentication is disabled (local dev mode).
+
+use axum::{
+    body::Body,
+    extract::Request,
+    http::{header, StatusCode},
+    middleware::Next,
+    response::{IntoResponse, Response},
+    Json,
+};
+use std::sync::Arc;
+
+/// Shared authentication state injected into the middleware.
+#[derive(Debug, Clone)]
+pub struct AuthState {
+    /// Allowed API keys. Empty means auth is disabled.
+    pub api_keys: Arc<Vec<String>>,
+}
+
+impl AuthState {
+    /// Create a new `AuthState` from a list of API keys.
+    pub fn new(api_keys: Vec<String>) -> Self {
+        Self {
+            api_keys: Arc::new(api_keys),
+        }
+    }
+
+    /// Returns `true` when authentication is enabled.
+    pub fn auth_enabled(&self) -> bool {
+        !self.api_keys.is_empty()
+    }
+}
+
+/// Paths that bypass authentication.
+fn is_public_path(path: &str) -> bool {
+    path == "/health"
+}
+
+/// Extract the Bearer token from the Authorization header value.
+fn extract_bearer_token(header_value: &str) -> Option<&str> {
+    let trimmed = header_value.trim();
+    if trimmed.len() > 7 && trimmed[..7].eq_ignore_ascii_case("bearer ") {
+        Some(trimmed[7..].trim())
+    } else {
+        None
+    }
+}
+
+/// Axum middleware function for API key authentication.
+///
+/// Use with `axum::middleware::from_fn_with_state`.
+pub async fn auth_middleware(
+    axum::extract::State(state): axum::extract::State<AuthState>,
+    request: Request<Body>,
+    next: Next,
+) -> Response {
+    // Skip auth if disabled (no keys configured)
+    if !state.auth_enabled() {
+        return next.run(request).await;
+    }
+
+    // Skip auth for public paths
+    if is_public_path(request.uri().path()) {
+        return next.run(request).await;
+    }
+
+    // Extract and validate Bearer token
+    let auth_header = request
+        .headers()
+        .get(header::AUTHORIZATION)
+        .and_then(|v| v.to_str().ok());
+
+    match auth_header {
+        Some(value) => match extract_bearer_token(value) {
+            Some(token) if state.api_keys.contains(&token.to_string()) => {
+                next.run(request).await
+            }
+            Some(_) => unauthorized_response("invalid API key"),
+            None => unauthorized_response("invalid Authorization header format, expected: Bearer <key>"),
+        },
+        None => unauthorized_response("missing Authorization header"),
+    }
+}
+
+/// Build a 401 Unauthorized JSON response.
+fn unauthorized_response(message: &str) -> Response {
+    (
+        StatusCode::UNAUTHORIZED,
+        Json(serde_json::json!({
+            "error": "Unauthorized",
+            "message": message
+        })),
+    )
+        .into_response()
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_auth_state_disabled_when_empty() {
+        let state = AuthState::new(vec![]);
+        assert!(!state.auth_enabled());
+    }
+
+    #[test]
+    fn test_auth_state_enabled_with_keys() {
+        let state = AuthState::new(vec!["key1".to_string()]);
+        assert!(state.auth_enabled());
+    }
+
+    #[test]
+    fn test_is_public_path_health() {
+        assert!(is_public_path("/health"));
+    }
+
+    #[test]
+    fn test_is_public_path_other() {
+        assert!(!is_public_path("/collections"));
+        assert!(!is_public_path("/query"));
+        assert!(!is_public_path("/health/extra"));
+    }
+
+    #[test]
+    fn test_extract_bearer_token_valid() {
+        assert_eq!(extract_bearer_token("Bearer my-key"), Some("my-key"));
+        assert_eq!(extract_bearer_token("bearer my-key"), Some("my-key"));
+        assert_eq!(extract_bearer_token("BEARER my-key"), Some("my-key"));
+        assert_eq!(
+            extract_bearer_token("  Bearer  my-key  "),
+            Some("my-key")
+        );
+    }
+
+    #[test]
+    fn test_extract_bearer_token_invalid() {
+        assert_eq!(extract_bearer_token("Basic abc123"), None);
+        assert_eq!(extract_bearer_token("my-key"), None);
+        assert_eq!(extract_bearer_token("Bearer"), None);
+        assert_eq!(extract_bearer_token(""), None);
+    }
+}

--- a/crates/velesdb-server/src/config.rs
+++ b/crates/velesdb-server/src/config.rs
@@ -1,0 +1,452 @@
+//! Server configuration module.
+//!
+//! Loads configuration from multiple sources with priority:
+//! CLI flags > environment variables > velesdb.toml > defaults.
+
+use serde::Deserialize;
+use std::path::{Path, PathBuf};
+
+// ============================================================================
+// TOML file configuration (all fields optional)
+// ============================================================================
+
+/// Root structure for `velesdb.toml`.
+#[derive(Debug, Deserialize, Default)]
+struct FileConfig {
+    server: Option<ServerSection>,
+    auth: Option<AuthSection>,
+    tls: Option<TlsSection>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct ServerSection {
+    host: Option<String>,
+    port: Option<u16>,
+    data_dir: Option<String>,
+    shutdown_timeout_secs: Option<u64>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct AuthSection {
+    api_keys: Option<Vec<String>>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct TlsSection {
+    cert: Option<String>,
+    key: Option<String>,
+}
+
+// ============================================================================
+// Resolved configuration
+// ============================================================================
+
+/// Final resolved server configuration.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ServerConfig {
+    pub host: String,
+    pub port: u16,
+    pub data_dir: String,
+    pub api_keys: Vec<String>,
+    pub tls_cert: Option<String>,
+    pub tls_key: Option<String>,
+    pub shutdown_timeout_secs: u64,
+}
+
+impl Default for ServerConfig {
+    fn default() -> Self {
+        Self {
+            host: "127.0.0.1".to_string(),
+            port: 8080,
+            data_dir: "./velesdb_data".to_string(),
+            api_keys: Vec::new(),
+            tls_cert: None,
+            tls_key: None,
+            shutdown_timeout_secs: 30,
+        }
+    }
+}
+
+// ============================================================================
+// Loading logic
+// ============================================================================
+
+impl ServerConfig {
+    /// Load configuration with priority: CLI > env > TOML file > defaults.
+    ///
+    /// `cli` contains values from clap (which merges CLI flags + env vars).
+    /// `cli_sources` indicates which fields were explicitly set via CLI/env
+    /// (as opposed to falling back to clap defaults).
+    pub fn load(cli: CliOverrides) -> anyhow::Result<Self> {
+        let defaults = Self::default();
+        let file_cfg = load_toml_file(&cli.config_path)?;
+        Ok(Self::merge(defaults, file_cfg, cli))
+    }
+
+    fn merge(defaults: Self, file: FileConfig, cli: CliOverrides) -> Self {
+        let server = file.server.unwrap_or_default();
+        let auth = file.auth.unwrap_or_default();
+        let tls = file.tls.unwrap_or_default();
+
+        // Layer: TOML over defaults
+        let host = server.host.unwrap_or(defaults.host);
+        let port = server.port.unwrap_or(defaults.port);
+        let data_dir = server.data_dir.unwrap_or(defaults.data_dir);
+        let shutdown_timeout_secs = server
+            .shutdown_timeout_secs
+            .unwrap_or(defaults.shutdown_timeout_secs);
+        let api_keys = auth.api_keys.unwrap_or(defaults.api_keys);
+        let tls_cert = tls.cert.or(defaults.tls_cert);
+        let tls_key = tls.key.or(defaults.tls_key);
+
+        // Layer: CLI/env over TOML (only override when explicitly set)
+        let host = cli.host.unwrap_or(host);
+        let port = cli.port.unwrap_or(port);
+        let data_dir = cli.data_dir.unwrap_or(data_dir);
+        let api_keys = cli.api_keys.unwrap_or(api_keys);
+        let tls_cert = cli.tls_cert.or(tls_cert);
+        let tls_key = cli.tls_key.or(tls_key);
+
+        Self {
+            host,
+            port,
+            data_dir,
+            api_keys,
+            tls_cert,
+            tls_key,
+            shutdown_timeout_secs,
+        }
+    }
+
+    /// Validate the configuration at startup.
+    pub fn validate(&self) -> anyhow::Result<()> {
+        if self.port == 0 {
+            anyhow::bail!("invalid port: 0 is not allowed");
+        }
+        if self.data_dir.is_empty() {
+            anyhow::bail!("data_dir must not be empty");
+        }
+
+        // TLS: both cert and key must be provided together
+        match (&self.tls_cert, &self.tls_key) {
+            (Some(_), None) => {
+                anyhow::bail!("tls_cert is set but tls_key is missing");
+            }
+            (None, Some(_)) => {
+                anyhow::bail!("tls_key is set but tls_cert is missing");
+            }
+            (Some(cert), Some(key)) => {
+                if !Path::new(cert).exists() {
+                    anyhow::bail!("TLS cert file not found: {cert}");
+                }
+                if !Path::new(key).exists() {
+                    anyhow::bail!("TLS key file not found: {key}");
+                }
+            }
+            (None, None) => {}
+        }
+
+        Ok(())
+    }
+
+    /// Returns `true` when API key authentication is enabled.
+    pub fn auth_enabled(&self) -> bool {
+        !self.api_keys.is_empty()
+    }
+
+    /// Returns `true` when TLS is configured.
+    pub fn tls_enabled(&self) -> bool {
+        self.tls_cert.is_some() && self.tls_key.is_some()
+    }
+}
+
+// ============================================================================
+// CLI overrides (filled by clap in main.rs)
+// ============================================================================
+
+/// Values explicitly provided via CLI flags or environment variables.
+/// `None` means "not provided — fall through to TOML or default".
+#[derive(Debug, Default)]
+pub struct CliOverrides {
+    pub config_path: Option<PathBuf>,
+    pub host: Option<String>,
+    pub port: Option<u16>,
+    pub data_dir: Option<String>,
+    pub api_keys: Option<Vec<String>>,
+    pub tls_cert: Option<String>,
+    pub tls_key: Option<String>,
+}
+
+// ============================================================================
+// TOML file loader
+// ============================================================================
+
+fn load_toml_file(path: &Option<PathBuf>) -> anyhow::Result<FileConfig> {
+    let candidate = match path {
+        Some(p) => {
+            if !p.exists() {
+                anyhow::bail!("config file not found: {}", p.display());
+            }
+            p.clone()
+        }
+        None => {
+            let default_path = PathBuf::from("velesdb.toml");
+            if !default_path.exists() {
+                return Ok(FileConfig::default());
+            }
+            default_path
+        }
+    };
+
+    let contents = std::fs::read_to_string(&candidate).map_err(|e| {
+        anyhow::anyhow!("failed to read config file {}: {e}", candidate.display())
+    })?;
+
+    let cfg: FileConfig = toml::from_str(&contents).map_err(|e| {
+        anyhow::anyhow!(
+            "failed to parse config file {}: {e}",
+            candidate.display()
+        )
+    })?;
+
+    Ok(cfg)
+}
+
+// ============================================================================
+// Helper: parse comma-separated API keys from env var
+// ============================================================================
+
+/// Parse `VELESDB_API_KEYS` env var (comma-separated) into a `Vec<String>`.
+pub fn parse_api_keys_env() -> Option<Vec<String>> {
+    std::env::var("VELESDB_API_KEYS").ok().map(|val| {
+        val.split(',')
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .collect()
+    })
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    #[test]
+    fn test_defaults() {
+        let cfg = ServerConfig::default();
+        assert_eq!(cfg.host, "127.0.0.1");
+        assert_eq!(cfg.port, 8080);
+        assert_eq!(cfg.data_dir, "./velesdb_data");
+        assert!(cfg.api_keys.is_empty());
+        assert!(cfg.tls_cert.is_none());
+        assert!(cfg.tls_key.is_none());
+        assert_eq!(cfg.shutdown_timeout_secs, 30);
+        assert!(!cfg.auth_enabled());
+        assert!(!cfg.tls_enabled());
+    }
+
+    #[test]
+    fn test_toml_overrides_defaults() {
+        let toml_content = r#"
+[server]
+host = "0.0.0.0"
+port = 9090
+data_dir = "/var/velesdb"
+shutdown_timeout_secs = 60
+
+[auth]
+api_keys = ["key-alpha", "key-beta"]
+
+[tls]
+cert = "/etc/ssl/cert.pem"
+key = "/etc/ssl/key.pem"
+"#;
+        let file_cfg: FileConfig = toml::from_str(toml_content).unwrap();
+        let cli = CliOverrides::default();
+        let cfg = ServerConfig::merge(ServerConfig::default(), file_cfg, cli);
+
+        assert_eq!(cfg.host, "0.0.0.0");
+        assert_eq!(cfg.port, 9090);
+        assert_eq!(cfg.data_dir, "/var/velesdb");
+        assert_eq!(cfg.shutdown_timeout_secs, 60);
+        assert_eq!(cfg.api_keys, vec!["key-alpha", "key-beta"]);
+        assert_eq!(cfg.tls_cert.as_deref(), Some("/etc/ssl/cert.pem"));
+        assert_eq!(cfg.tls_key.as_deref(), Some("/etc/ssl/key.pem"));
+        assert!(cfg.auth_enabled());
+        assert!(cfg.tls_enabled());
+    }
+
+    #[test]
+    fn test_cli_overrides_toml() {
+        let toml_content = r#"
+[server]
+host = "0.0.0.0"
+port = 9090
+"#;
+        let file_cfg: FileConfig = toml::from_str(toml_content).unwrap();
+        let cli = CliOverrides {
+            port: Some(3000),
+            host: Some("10.0.0.1".to_string()),
+            ..Default::default()
+        };
+        let cfg = ServerConfig::merge(ServerConfig::default(), file_cfg, cli);
+
+        // CLI wins over TOML
+        assert_eq!(cfg.host, "10.0.0.1");
+        assert_eq!(cfg.port, 3000);
+        // TOML didn't set data_dir, so default applies
+        assert_eq!(cfg.data_dir, "./velesdb_data");
+    }
+
+    #[test]
+    fn test_partial_toml_uses_defaults_for_missing() {
+        let toml_content = r#"
+[server]
+port = 4000
+"#;
+        let file_cfg: FileConfig = toml::from_str(toml_content).unwrap();
+        let cli = CliOverrides::default();
+        let cfg = ServerConfig::merge(ServerConfig::default(), file_cfg, cli);
+
+        assert_eq!(cfg.port, 4000);
+        assert_eq!(cfg.host, "127.0.0.1"); // default
+        assert_eq!(cfg.data_dir, "./velesdb_data"); // default
+    }
+
+    #[test]
+    fn test_empty_toml_uses_all_defaults() {
+        let file_cfg: FileConfig = toml::from_str("").unwrap();
+        let cli = CliOverrides::default();
+        let cfg = ServerConfig::merge(ServerConfig::default(), file_cfg, cli);
+
+        assert_eq!(cfg, ServerConfig::default());
+    }
+
+    #[test]
+    fn test_validate_port_zero_rejected() {
+        let cfg = ServerConfig {
+            port: 0,
+            ..ServerConfig::default()
+        };
+        let err = cfg.validate().unwrap_err();
+        assert!(err.to_string().contains("port"));
+    }
+
+    #[test]
+    fn test_validate_empty_data_dir_rejected() {
+        let cfg = ServerConfig {
+            data_dir: String::new(),
+            ..ServerConfig::default()
+        };
+        let err = cfg.validate().unwrap_err();
+        assert!(err.to_string().contains("data_dir"));
+    }
+
+    #[test]
+    fn test_validate_tls_cert_without_key() {
+        let cfg = ServerConfig {
+            tls_cert: Some("/tmp/cert.pem".to_string()),
+            ..ServerConfig::default()
+        };
+        let err = cfg.validate().unwrap_err();
+        assert!(err.to_string().contains("tls_key is missing"));
+    }
+
+    #[test]
+    fn test_validate_tls_key_without_cert() {
+        let cfg = ServerConfig {
+            tls_key: Some("/tmp/key.pem".to_string()),
+            ..ServerConfig::default()
+        };
+        let err = cfg.validate().unwrap_err();
+        assert!(err.to_string().contains("tls_cert is missing"));
+    }
+
+    #[test]
+    fn test_validate_tls_missing_cert_file() {
+        let cfg = ServerConfig {
+            tls_cert: Some("/nonexistent/cert.pem".to_string()),
+            tls_key: Some("/nonexistent/key.pem".to_string()),
+            ..ServerConfig::default()
+        };
+        let err = cfg.validate().unwrap_err();
+        assert!(err.to_string().contains("cert file not found"));
+    }
+
+    #[test]
+    fn test_validate_tls_valid_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let cert_path = dir.path().join("cert.pem");
+        let key_path = dir.path().join("key.pem");
+        std::fs::File::create(&cert_path)
+            .unwrap()
+            .write_all(b"cert")
+            .unwrap();
+        std::fs::File::create(&key_path)
+            .unwrap()
+            .write_all(b"key")
+            .unwrap();
+
+        let cfg = ServerConfig {
+            tls_cert: Some(cert_path.to_string_lossy().to_string()),
+            tls_key: Some(key_path.to_string_lossy().to_string()),
+            ..ServerConfig::default()
+        };
+        cfg.validate().expect("valid TLS config should pass");
+    }
+
+    #[test]
+    fn test_parse_api_keys_env() {
+        // Simulate by directly testing the parsing logic
+        let input = "key1, key2 , key3";
+        let keys: Vec<String> = input
+            .split(',')
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .collect();
+        assert_eq!(keys, vec!["key1", "key2", "key3"]);
+    }
+
+    #[test]
+    fn test_load_toml_file_not_found_explicit_path() {
+        let result = load_toml_file(&Some(PathBuf::from("/nonexistent/velesdb.toml")));
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("config file not found"));
+    }
+
+    #[test]
+    fn test_load_toml_file_no_default_returns_empty() {
+        // When no explicit path and no velesdb.toml in cwd, returns defaults
+        let result = load_toml_file(&None);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_full_priority_chain() {
+        // Scenario: default=8080, TOML=9090, CLI=3000 → expect 3000
+        let toml_content = r#"
+[server]
+port = 9090
+host = "0.0.0.0"
+data_dir = "/toml/data"
+"#;
+        let file_cfg: FileConfig = toml::from_str(toml_content).unwrap();
+        let cli = CliOverrides {
+            port: Some(3000),
+            // host not set in CLI → TOML should win
+            ..Default::default()
+        };
+        let cfg = ServerConfig::merge(ServerConfig::default(), file_cfg, cli);
+
+        assert_eq!(cfg.port, 3000); // CLI wins
+        assert_eq!(cfg.host, "0.0.0.0"); // TOML wins (no CLI override)
+        assert_eq!(cfg.data_dir, "/toml/data"); // TOML wins (no CLI override)
+    }
+}

--- a/crates/velesdb-server/src/config.rs
+++ b/crates/velesdb-server/src/config.rs
@@ -198,16 +198,11 @@ fn load_toml_file(path: &Option<PathBuf>) -> anyhow::Result<FileConfig> {
         }
     };
 
-    let contents = std::fs::read_to_string(&candidate).map_err(|e| {
-        anyhow::anyhow!("failed to read config file {}: {e}", candidate.display())
-    })?;
+    let contents = std::fs::read_to_string(&candidate)
+        .map_err(|e| anyhow::anyhow!("failed to read config file {}: {e}", candidate.display()))?;
 
-    let cfg: FileConfig = toml::from_str(&contents).map_err(|e| {
-        anyhow::anyhow!(
-            "failed to parse config file {}: {e}",
-            candidate.display()
-        )
-    })?;
+    let cfg: FileConfig = toml::from_str(&contents)
+        .map_err(|e| anyhow::anyhow!("failed to parse config file {}: {e}", candidate.display()))?;
 
     Ok(cfg)
 }
@@ -218,12 +213,17 @@ fn load_toml_file(path: &Option<PathBuf>) -> anyhow::Result<FileConfig> {
 
 /// Parse `VELESDB_API_KEYS` env var (comma-separated) into a `Vec<String>`.
 pub fn parse_api_keys_env() -> Option<Vec<String>> {
-    std::env::var("VELESDB_API_KEYS").ok().map(|val| {
-        val.split(',')
-            .map(|s| s.trim().to_string())
-            .filter(|s| !s.is_empty())
-            .collect()
-    })
+    let val = std::env::var("VELESDB_API_KEYS").ok()?;
+    let keys: Vec<String> = val
+        .split(',')
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect();
+    if keys.is_empty() {
+        None
+    } else {
+        Some(keys)
+    }
 }
 
 // ============================================================================

--- a/crates/velesdb-server/src/handlers/health.rs
+++ b/crates/velesdb-server/src/handlers/health.rs
@@ -1,19 +1,55 @@
-//! Health check handler.
+//! Health and readiness check handlers.
 
-use axum::{response::IntoResponse, Json};
+use axum::{extract::State, http::StatusCode, response::IntoResponse, Json};
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
 
-/// Health check endpoint.
+use crate::AppState;
+
+/// Liveness probe — always returns 200 OK.
 #[utoipa::path(
     get,
     path = "/health",
     tag = "health",
     responses(
-        (status = 200, description = "Server is healthy", body = Object)
+        (status = 200, description = "Server is alive", body = Object)
     )
 )]
 pub async fn health_check() -> impl IntoResponse {
     Json(serde_json::json!({
-        "status": "healthy",
+        "status": "ok",
         "version": env!("CARGO_PKG_VERSION")
     }))
+}
+
+/// Readiness probe — returns 200 when the database is fully loaded, 503 otherwise.
+#[utoipa::path(
+    get,
+    path = "/ready",
+    tag = "health",
+    responses(
+        (status = 200, description = "Server is ready to accept requests", body = Object),
+        (status = 503, description = "Server is not yet ready", body = Object)
+    )
+)]
+pub async fn readiness_check(
+    State(state): State<Arc<AppState>>,
+) -> impl IntoResponse {
+    if state.ready.load(Ordering::Relaxed) {
+        (
+            StatusCode::OK,
+            Json(serde_json::json!({
+                "status": "ready",
+                "version": env!("CARGO_PKG_VERSION")
+            })),
+        )
+    } else {
+        (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(serde_json::json!({
+                "status": "not_ready",
+                "version": env!("CARGO_PKG_VERSION")
+            })),
+        )
+    }
 }

--- a/crates/velesdb-server/src/handlers/health.rs
+++ b/crates/velesdb-server/src/handlers/health.rs
@@ -32,9 +32,7 @@ pub async fn health_check() -> impl IntoResponse {
         (status = 503, description = "Server is not yet ready", body = Object)
     )
 )]
-pub async fn readiness_check(
-    State(state): State<Arc<AppState>>,
-) -> impl IntoResponse {
+pub async fn readiness_check(State(state): State<Arc<AppState>>) -> impl IntoResponse {
     if state.ready.load(Ordering::Relaxed) {
         (
             StatusCode::OK,

--- a/crates/velesdb-server/src/handlers/metrics.rs
+++ b/crates/velesdb-server/src/handlers/metrics.rs
@@ -186,6 +186,7 @@ mod tests {
             db,
             onboarding_metrics: OnboardingMetrics::default(),
             query_limits: parking_lot::RwLock::new(velesdb_core::guardrails::QueryLimits::default()),
+            ready: std::sync::atomic::AtomicBool::new(true),
         })
     }
 

--- a/crates/velesdb-server/src/handlers/mod.rs
+++ b/crates/velesdb-server/src/handlers/mod.rs
@@ -32,7 +32,7 @@ pub use collections::{
     collection_sanity, create_collection, delete_collection, flush_collection, get_collection,
     is_empty, list_collections,
 };
-pub use health::health_check;
+pub use health::{health_check, readiness_check};
 pub use indexes::{create_index, delete_index, list_indexes};
 pub use points::{delete_point, get_point, stream_insert, stream_upsert_points, upsert_points};
 // EPIC-058 US-007: match_query handler for /collections/{name}/match

--- a/crates/velesdb-server/src/lib.rs
+++ b/crates/velesdb-server/src/lib.rs
@@ -24,6 +24,7 @@
 //! - Swagger UI: `GET /swagger-ui`
 //! - OpenAPI JSON: `GET /api-docs/openapi.json`
 
+pub mod config;
 mod handlers;
 mod types;
 

--- a/crates/velesdb-server/src/lib.rs
+++ b/crates/velesdb-server/src/lib.rs
@@ -30,7 +30,7 @@ pub mod tls;
 mod handlers;
 mod types;
 
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use utoipa::OpenApi;
 use velesdb_core::guardrails::QueryLimits;
 use velesdb_core::Database;
@@ -44,8 +44,8 @@ pub use handlers::{
     create_index, delete_collection, delete_index, delete_point, explain, flush_collection,
     get_collection, get_collection_config, get_collection_stats, get_guardrails, get_point,
     health_check, hybrid_search, is_empty, list_collections, list_indexes, match_query,
-    multi_query_search, query, search, search_ids, stream_insert, stream_upsert_points,
-    text_search, update_guardrails, upsert_points,
+    multi_query_search, query, readiness_check, search, search_ids, stream_insert,
+    stream_upsert_points, text_search, update_guardrails, upsert_points,
 };
 
 // Graph handlers (EPIC-016/US-031)
@@ -89,6 +89,7 @@ pub use handlers::metrics::{health_metrics, prometheus_metrics};
     ),
     paths(
         handlers::health::health_check,
+        handlers::health::readiness_check,
         handlers::collections::list_collections,
         handlers::collections::create_collection,
         handlers::collections::get_collection,
@@ -198,6 +199,8 @@ pub struct AppState {
     pub onboarding_metrics: OnboardingMetrics,
     /// Query guard-rails configuration (EPIC-048).
     pub query_limits: parking_lot::RwLock<QueryLimits>,
+    /// Readiness flag — `true` once the database is fully loaded.
+    pub ready: AtomicBool,
 }
 
 /// Lightweight counters for first-hour troubleshooting diagnostics.

--- a/crates/velesdb-server/src/lib.rs
+++ b/crates/velesdb-server/src/lib.rs
@@ -26,8 +26,8 @@
 
 pub mod auth;
 pub mod config;
-pub mod tls;
 mod handlers;
+pub mod tls;
 mod types;
 
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
@@ -396,7 +396,10 @@ mod tests {
     fn test_openapi_has_license() {
         let openapi = ApiDoc::openapi();
         let json = openapi.to_json().expect("Failed to serialize OpenAPI spec");
-        assert!(json.contains("ELv2"), "Should have ELv2 license");
+        assert!(
+            json.contains("VelesDB Core License 1.0"),
+            "Should have VelesDB Core License 1.0"
+        );
     }
 
     #[test]

--- a/crates/velesdb-server/src/lib.rs
+++ b/crates/velesdb-server/src/lib.rs
@@ -24,6 +24,7 @@
 //! - Swagger UI: `GET /swagger-ui`
 //! - OpenAPI JSON: `GET /api-docs/openapi.json`
 
+pub mod auth;
 pub mod config;
 mod handlers;
 mod types;

--- a/crates/velesdb-server/src/lib.rs
+++ b/crates/velesdb-server/src/lib.rs
@@ -26,6 +26,7 @@
 
 pub mod auth;
 pub mod config;
+pub mod tls;
 mod handlers;
 mod types;
 

--- a/crates/velesdb-server/src/lib.rs
+++ b/crates/velesdb-server/src/lib.rs
@@ -70,10 +70,16 @@ pub use handlers::metrics::{health_metrics, prometheus_metrics};
         title = "VelesDB API",
         version = env!("CARGO_PKG_VERSION"),
         description = "High-performance vector database for AI applications. \
-            Supports semantic search, HNSW indexing, and multiple distance metrics.",
-        license(name = "ELv2", url = "https://github.com/cyberlife-coder/VelesDB/blob/main/LICENSE"),
+            Supports semantic search, HNSW indexing, and multiple distance metrics. \
+            Authentication is optional — when API keys are configured via VELESDB_API_KEYS, \
+            all endpoints except /health and /ready require a valid Bearer token.",
+        license(name = "VelesDB Core License 1.0", url = "https://github.com/cyberlife-coder/VelesDB/blob/main/LICENSE"),
         contact(name = "VelesDB Team", url = "https://github.com/cyberlife-coder/VelesDB")
     ),
+    security(
+        ("bearer_auth" = [])
+    ),
+    modifiers(&SecurityAddon),
     servers(
         (url = "/", description = "Local server")
     ),
@@ -186,6 +192,24 @@ pub use handlers::metrics::{health_metrics, prometheus_metrics};
     )
 )]
 pub struct ApiDoc;
+
+/// Adds the Bearer authentication security scheme to the OpenAPI spec.
+struct SecurityAddon;
+
+impl utoipa::Modify for SecurityAddon {
+    fn modify(&self, openapi: &mut utoipa::openapi::OpenApi) {
+        if let Some(components) = openapi.components.as_mut() {
+            components.add_security_scheme(
+                "bearer_auth",
+                utoipa::openapi::security::SecurityScheme::Http(
+                    utoipa::openapi::security::Http::new(
+                        utoipa::openapi::security::HttpAuthScheme::Bearer,
+                    ),
+                ),
+            );
+        }
+    }
+}
 
 // ============================================================================
 // Application State

--- a/crates/velesdb-server/src/main.rs
+++ b/crates/velesdb-server/src/main.rs
@@ -7,6 +7,7 @@ use axum::{
     Router,
 };
 use clap::Parser;
+use std::path::PathBuf;
 use std::sync::Arc;
 use tower_http::cors::CorsLayer;
 use tower_http::trace::TraceLayer;
@@ -20,13 +21,14 @@ use velesdb_core::Database;
 #[cfg(feature = "swagger-ui")]
 use velesdb_server::ApiDoc;
 use velesdb_server::{
-    add_edge, aggregate, analyze_collection, batch_search, collection_sanity, create_collection,
-    create_index, delete_collection, delete_index, delete_point, explain, flush_collection,
-    get_collection, get_collection_config, get_collection_stats, get_edges, get_guardrails,
-    get_node_degree, get_point, health_check, hybrid_search, is_empty, list_collections,
-    list_indexes, match_query, multi_query_search, query, search, search_ids, stream_insert,
-    stream_traverse, stream_upsert_points, text_search, traverse_graph, update_guardrails,
-    upsert_points, AppState, OnboardingMetrics,
+    add_edge, aggregate, analyze_collection, batch_search, collection_sanity,
+    config::{parse_api_keys_env, CliOverrides, ServerConfig},
+    create_collection, create_index, delete_collection, delete_index, delete_point, explain,
+    flush_collection, get_collection, get_collection_config, get_collection_stats, get_edges,
+    get_guardrails, get_node_degree, get_point, health_check, hybrid_search, is_empty,
+    list_collections, list_indexes, match_query, multi_query_search, query, search, search_ids,
+    stream_insert, stream_traverse, stream_upsert_points, text_search, traverse_graph,
+    update_guardrails, upsert_points, AppState, OnboardingMetrics,
 };
 
 /// VelesDB Server - A high-performance vector database
@@ -34,17 +36,29 @@ use velesdb_server::{
 #[command(name = "velesdb-server")]
 #[command(author, version, about, long_about = None)]
 struct Args {
+    /// Path to velesdb.toml configuration file
+    #[arg(short, long, env = "VELESDB_CONFIG")]
+    config: Option<PathBuf>,
+
     /// Data directory for persistent storage
-    #[arg(short, long, default_value = "./data", env = "VELESDB_DATA_DIR")]
-    data_dir: String,
+    #[arg(short, long, env = "VELESDB_DATA_DIR")]
+    data_dir: Option<String>,
 
     /// Host address to bind to
-    #[arg(long, default_value = "127.0.0.1", env = "VELESDB_HOST")]
-    host: String,
+    #[arg(long, env = "VELESDB_HOST")]
+    host: Option<String>,
 
     /// Port to listen on
-    #[arg(short, long, default_value = "8080", env = "VELESDB_PORT")]
-    port: u16,
+    #[arg(short, long, env = "VELESDB_PORT")]
+    port: Option<u16>,
+
+    /// TLS certificate file (PEM)
+    #[arg(long, env = "VELESDB_TLS_CERT")]
+    tls_cert: Option<String>,
+
+    /// TLS private key file (PEM)
+    #[arg(long, env = "VELESDB_TLS_KEY")]
+    tls_key: Option<String>,
 }
 
 fn configure_tracing() {
@@ -56,9 +70,21 @@ fn configure_tracing() {
         .try_init();
 }
 
-fn log_startup(args: &Args) {
+fn log_startup(cfg: &ServerConfig) {
     tracing::info!("Starting VelesDB server...");
-    tracing::info!("Data directory: {}", args.data_dir);
+    tracing::info!("Data directory: {}", cfg.data_dir);
+    tracing::info!("Bind address: {}:{}", cfg.host, cfg.port);
+    if cfg.auth_enabled() {
+        tracing::info!(
+            "API key authentication enabled ({} key(s))",
+            cfg.api_keys.len()
+        );
+    } else {
+        tracing::info!("API key authentication disabled (local dev mode)");
+    }
+    if cfg.tls_enabled() {
+        tracing::info!("TLS enabled");
+    }
 }
 
 fn init_app_state(data_dir: &str) -> anyhow::Result<Arc<AppState>> {
@@ -170,15 +196,31 @@ async fn serve(host: &str, port: u16, app: Router) -> anyhow::Result<()> {
     Ok(())
 }
 
+fn build_cli_overrides(args: Args) -> CliOverrides {
+    CliOverrides {
+        config_path: args.config,
+        host: args.host,
+        port: args.port,
+        data_dir: args.data_dir,
+        api_keys: parse_api_keys_env(),
+        tls_cert: args.tls_cert,
+        tls_key: args.tls_key,
+    }
+}
+
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     configure_tracing();
 
     let args = Args::parse();
-    log_startup(&args);
+    let cli = build_cli_overrides(args);
+    let cfg = ServerConfig::load(cli)?;
+    cfg.validate()?;
 
-    let state = init_app_state(&args.data_dir)?;
+    log_startup(&cfg);
+
+    let state = init_app_state(&cfg.data_dir)?;
     let app = build_router(state);
 
-    serve(&args.host, args.port, app).await
+    serve(&cfg.host, cfg.port, app).await
 }

--- a/crates/velesdb-server/src/main.rs
+++ b/crates/velesdb-server/src/main.rs
@@ -7,8 +7,10 @@ use axum::{
     Router,
 };
 use clap::Parser;
+use std::future::IntoFuture;
 use std::path::PathBuf;
 use std::sync::Arc;
+use tokio_rustls::TlsAcceptor;
 use tower::ServiceExt;
 use tower_http::cors::CorsLayer;
 use tower_http::trace::TraceLayer;
@@ -105,7 +107,7 @@ fn init_app_state(data_dir: &str) -> anyhow::Result<Arc<AppState>> {
     Ok(state)
 }
 
-fn api_routes() -> Router<Arc<AppState>> {
+fn core_routes() -> Router<Arc<AppState>> {
     Router::new()
         .route("/health", get(health_check))
         .route("/ready", get(readiness_check))
@@ -140,6 +142,10 @@ fn api_routes() -> Router<Arc<AppState>> {
             "/collections/{name}/points/{id}",
             get(get_point).delete(delete_point),
         )
+}
+
+fn search_routes() -> Router<Arc<AppState>> {
+    Router::new()
         .route("/collections/{name}/search", post(search))
         .route("/collections/{name}/search/batch", post(batch_search))
         .route("/collections/{name}/search/multi", post(multi_query_search))
@@ -158,6 +164,10 @@ fn api_routes() -> Router<Arc<AppState>> {
         .route("/aggregate", post(aggregate))
         .route("/query/explain", post(explain))
         .route("/collections/{name}/match", post(match_query))
+}
+
+fn graph_routes() -> Router<Arc<AppState>> {
+    Router::new()
         .route(
             "/collections/{name}/graph/edges",
             get(get_edges).post(add_edge),
@@ -171,6 +181,10 @@ fn api_routes() -> Router<Arc<AppState>> {
             "/collections/{name}/graph/nodes/{node_id}/degree",
             get(get_node_degree),
         )
+}
+
+fn api_routes() -> Router<Arc<AppState>> {
+    core_routes().merge(search_routes()).merge(graph_routes())
 }
 
 fn build_router(state: Arc<AppState>, auth_state: AuthState) -> Router {
@@ -242,35 +256,53 @@ async fn serve(
     let listener = tokio::net::TcpListener::bind(&addr).await?;
     tracing::info!("VelesDB server listening on http://{}", addr);
 
-    axum::serve(listener, app)
-        .with_graceful_shutdown(shutdown_signal())
-        .await?;
+    // Create a notify to track when the shutdown signal fires
+    let shutdown_notify = Arc::new(tokio::sync::Notify::new());
+    let notify_clone = shutdown_notify.clone();
 
-    // Drain timeout already handled by axum's graceful shutdown;
-    // log the configured value for observability
-    tracing::info!("Graceful shutdown complete (drain timeout was {shutdown_timeout_secs}s)");
+    let graceful_shutdown = async move {
+        shutdown_signal().await;
+        notify_clone.notify_one();
+    };
+
+    let server = axum::serve(listener, app)
+        .with_graceful_shutdown(graceful_shutdown)
+        .into_future();
+
+    // Start server in a task so we can apply drain timeout after signal
+    let server_handle = tokio::spawn(server);
+
+    // Wait for the shutdown signal
+    shutdown_notify.notified().await;
+
+    // Now apply drain timeout
+    match tokio::time::timeout(
+        tokio::time::Duration::from_secs(shutdown_timeout_secs),
+        server_handle,
+    )
+    .await
+    {
+        Ok(Ok(Ok(()))) => tracing::info!("All connections drained"),
+        Ok(Ok(Err(e))) => tracing::warn!("Server error during drain: {e}"),
+        Ok(Err(e)) => tracing::warn!("Server task error: {e}"),
+        Err(_) => {
+            tracing::warn!(
+                "Drain timeout ({shutdown_timeout_secs}s) reached, forcing shutdown"
+            );
+        }
+    }
+
     flush_and_exit(&state);
     Ok(())
 }
 
-async fn serve_tls(
-    host: &str,
-    port: u16,
+/// Accepts TLS connections until a shutdown signal is received.
+async fn tls_accept_loop(
+    listener: tokio::net::TcpListener,
+    tls_acceptor: TlsAcceptor,
     app: Router,
-    cert_path: &str,
-    key_path: &str,
-    state: Arc<AppState>,
-    shutdown_timeout_secs: u64,
-) -> anyhow::Result<()> {
-    warn_if_exposed(host);
-
-    let tls_acceptor = velesdb_server::tls::load_tls_config(cert_path, key_path)?;
-    let addr = format!("{host}:{port}");
-    let listener = tokio::net::TcpListener::bind(&addr).await?;
-    tracing::info!("VelesDB server listening on https://{}", addr);
-
-    // Track active connections for drain timeout
-    let active_conns = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    active_conns: Arc<std::sync::atomic::AtomicUsize>,
+) {
     let shutdown = tokio::signal::ctrl_c();
 
     #[cfg(unix)]
@@ -290,38 +322,14 @@ async fn serve_tls(
     loop {
         tokio::select! {
             result = listener.accept() => {
-                let (stream, _peer_addr) = result?;
-                let acceptor = tls_acceptor.clone();
-                let tower_service = app.clone();
-                let conns = active_conns.clone();
-                conns.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-
-                tokio::spawn(async move {
-                    let Ok(tls_stream) = acceptor.accept(stream).await else {
-                        tracing::debug!("TLS handshake failed");
-                        conns.fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
-                        return;
-                    };
-
-                    let io = hyper_util::rt::TokioIo::new(tls_stream);
-                    let hyper_service = hyper::service::service_fn(move |request| {
-                        let clone = tower_service.clone();
-                        async move {
-                            clone.oneshot(request).await
-                        }
-                    });
-
-                    if let Err(err) = hyper_util::server::conn::auto::Builder::new(
-                        hyper_util::rt::TokioExecutor::new(),
-                    )
-                    .serve_connection_with_upgrades(io, hyper_service)
-                    .await
-                    {
-                        tracing::debug!("TLS connection error: {err}");
+                match result {
+                    Ok((stream, _peer_addr)) => {
+                        spawn_tls_connection(stream, tls_acceptor.clone(), app.clone(), active_conns.clone());
                     }
-
-                    conns.fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
-                });
+                    Err(e) => {
+                        tracing::warn!("Failed to accept TCP connection: {e}");
+                    }
+                }
             }
             _ = &mut shutdown => {
                 tracing::info!("Received SIGINT (Ctrl+C), initiating graceful shutdown...");
@@ -333,8 +341,59 @@ async fn serve_tls(
             }
         }
     }
+}
 
-    // Drain active connections with timeout
+fn spawn_tls_connection(
+    stream: tokio::net::TcpStream,
+    acceptor: TlsAcceptor,
+    app: Router,
+    conns: Arc<std::sync::atomic::AtomicUsize>,
+) {
+    conns.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    tokio::spawn(async move {
+        let Ok(tls_stream) = acceptor.accept(stream).await else {
+            tracing::debug!("TLS handshake failed");
+            conns.fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
+            return;
+        };
+
+        let io = hyper_util::rt::TokioIo::new(tls_stream);
+        let hyper_service = hyper::service::service_fn(move |request| {
+            let clone = app.clone();
+            async move { clone.oneshot(request).await }
+        });
+
+        if let Err(err) =
+            hyper_util::server::conn::auto::Builder::new(hyper_util::rt::TokioExecutor::new())
+                .serve_connection_with_upgrades(io, hyper_service)
+                .await
+        {
+            tracing::debug!("TLS connection error: {err}");
+        }
+
+        conns.fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
+    });
+}
+
+async fn serve_tls(
+    host: &str,
+    port: u16,
+    app: Router,
+    cert_path: &str,
+    key_path: &str,
+    state: Arc<AppState>,
+    shutdown_timeout_secs: u64,
+) -> anyhow::Result<()> {
+    warn_if_exposed(host);
+
+    let tls_acceptor = velesdb_server::tls::load_tls_config(cert_path, key_path)?;
+    let addr = format!("{host}:{port}");
+    let listener = tokio::net::TcpListener::bind(&addr).await?;
+    tracing::info!("VelesDB server listening on https://{}", addr);
+
+    let active_conns = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    tls_accept_loop(listener, tls_acceptor, app, active_conns.clone()).await;
+
     drain_connections(&active_conns, shutdown_timeout_secs).await;
     flush_and_exit(&state);
     Ok(())

--- a/crates/velesdb-server/src/main.rs
+++ b/crates/velesdb-server/src/main.rs
@@ -21,7 +21,9 @@ use velesdb_core::Database;
 #[cfg(feature = "swagger-ui")]
 use velesdb_server::ApiDoc;
 use velesdb_server::{
-    add_edge, aggregate, analyze_collection, batch_search, collection_sanity,
+    add_edge, aggregate, analyze_collection,
+    auth::{auth_middleware, AuthState},
+    batch_search, collection_sanity,
     config::{parse_api_keys_env, CliOverrides, ServerConfig},
     create_collection, create_index, delete_collection, delete_index, delete_point, explain,
     flush_collection, get_collection, get_collection_config, get_collection_stats, get_edges,
@@ -96,8 +98,8 @@ fn init_app_state(data_dir: &str) -> anyhow::Result<Arc<AppState>> {
     }))
 }
 
-fn build_router(state: Arc<AppState>) -> Router {
-    let api_router = Router::new()
+fn api_routes() -> Router<Arc<AppState>> {
+    Router::new()
         .route("/health", get(health_check))
         .route(
             "/collections",
@@ -160,7 +162,11 @@ fn build_router(state: Arc<AppState>) -> Router {
         .route(
             "/collections/{name}/graph/nodes/{node_id}/degree",
             get(get_node_degree),
-        );
+        )
+}
+
+fn build_router(state: Arc<AppState>, auth_state: AuthState) -> Router {
+    let api_router = api_routes();
 
     #[cfg(feature = "prometheus")]
     let api_router = {
@@ -178,6 +184,10 @@ fn build_router(state: Arc<AppState>) -> Router {
     };
 
     api_router
+        .layer(axum::middleware::from_fn_with_state(
+            auth_state,
+            auth_middleware,
+        ))
         .layer(CorsLayer::permissive())
         .layer(TraceLayer::new_for_http())
 }
@@ -220,7 +230,8 @@ async fn main() -> anyhow::Result<()> {
     log_startup(&cfg);
 
     let state = init_app_state(&cfg.data_dir)?;
-    let app = build_router(state);
+    let auth_state = AuthState::new(cfg.api_keys.clone());
+    let app = build_router(state, auth_state);
 
     serve(&cfg.host, cfg.port, app).await
 }

--- a/crates/velesdb-server/src/main.rs
+++ b/crates/velesdb-server/src/main.rs
@@ -14,6 +14,9 @@ use tower_http::cors::CorsLayer;
 use tower_http::trace::TraceLayer;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
+/// Drain timeout for graceful shutdown (seconds).
+const SHUTDOWN_DRAIN_TIMEOUT_SECS: u64 = 30;
+
 #[cfg(feature = "swagger-ui")]
 use utoipa::OpenApi;
 #[cfg(feature = "swagger-ui")]
@@ -202,12 +205,43 @@ fn warn_if_exposed(host: &str) {
     }
 }
 
-async fn serve(host: &str, port: u16, app: Router) -> anyhow::Result<()> {
+/// Returns a future that resolves when SIGINT (Ctrl+C) or SIGTERM is received.
+async fn shutdown_signal() {
+    let ctrl_c = tokio::signal::ctrl_c();
+
+    #[cfg(unix)]
+    let terminate = async {
+        tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+            .expect("failed to install SIGTERM handler")
+            .recv()
+            .await;
+    };
+
+    #[cfg(not(unix))]
+    let terminate = std::future::pending::<()>();
+
+    tokio::select! {
+        _ = ctrl_c => tracing::info!("Received SIGINT (Ctrl+C), initiating graceful shutdown..."),
+        () = terminate => tracing::info!("Received SIGTERM, initiating graceful shutdown..."),
+    }
+}
+
+async fn serve(
+    host: &str,
+    port: u16,
+    app: Router,
+    state: Arc<AppState>,
+) -> anyhow::Result<()> {
     warn_if_exposed(host);
     let addr = format!("{host}:{port}");
     let listener = tokio::net::TcpListener::bind(&addr).await?;
     tracing::info!("VelesDB server listening on http://{}", addr);
-    axum::serve(listener, app).await?;
+
+    axum::serve(listener, app)
+        .with_graceful_shutdown(shutdown_signal())
+        .await?;
+
+    flush_and_exit(&state);
     Ok(())
 }
 
@@ -217,6 +251,7 @@ async fn serve_tls(
     app: Router,
     cert_path: &str,
     key_path: &str,
+    state: Arc<AppState>,
 ) -> anyhow::Result<()> {
     warn_if_exposed(host);
 
@@ -225,35 +260,108 @@ async fn serve_tls(
     let listener = tokio::net::TcpListener::bind(&addr).await?;
     tracing::info!("VelesDB server listening on https://{}", addr);
 
+    // Track active connections for drain timeout
+    let active_conns = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let shutdown = tokio::signal::ctrl_c();
+
+    #[cfg(unix)]
+    let terminate = async {
+        tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+            .expect("failed to install SIGTERM handler")
+            .recv()
+            .await;
+    };
+
+    #[cfg(not(unix))]
+    let terminate = std::future::pending::<()>();
+
+    tokio::pin!(shutdown);
+    tokio::pin!(terminate);
+
     loop {
-        let (stream, _peer_addr) = listener.accept().await?;
-        let acceptor = tls_acceptor.clone();
-        let tower_service = app.clone();
+        tokio::select! {
+            result = listener.accept() => {
+                let (stream, _peer_addr) = result?;
+                let acceptor = tls_acceptor.clone();
+                let tower_service = app.clone();
+                let conns = active_conns.clone();
+                conns.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
 
-        tokio::spawn(async move {
-            let Ok(tls_stream) = acceptor.accept(stream).await else {
-                tracing::debug!("TLS handshake failed");
-                return;
-            };
+                tokio::spawn(async move {
+                    let Ok(tls_stream) = acceptor.accept(stream).await else {
+                        tracing::debug!("TLS handshake failed");
+                        conns.fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
+                        return;
+                    };
 
-            let io = hyper_util::rt::TokioIo::new(tls_stream);
-            let hyper_service = hyper::service::service_fn(move |request| {
-                let clone = tower_service.clone();
-                async move {
-                    clone.oneshot(request).await
-                }
-            });
+                    let io = hyper_util::rt::TokioIo::new(tls_stream);
+                    let hyper_service = hyper::service::service_fn(move |request| {
+                        let clone = tower_service.clone();
+                        async move {
+                            clone.oneshot(request).await
+                        }
+                    });
 
-            if let Err(err) = hyper_util::server::conn::auto::Builder::new(
-                hyper_util::rt::TokioExecutor::new(),
-            )
-            .serve_connection_with_upgrades(io, hyper_service)
-            .await
-            {
-                tracing::debug!("TLS connection error: {err}");
+                    if let Err(err) = hyper_util::server::conn::auto::Builder::new(
+                        hyper_util::rt::TokioExecutor::new(),
+                    )
+                    .serve_connection_with_upgrades(io, hyper_service)
+                    .await
+                    {
+                        tracing::debug!("TLS connection error: {err}");
+                    }
+
+                    conns.fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
+                });
             }
-        });
+            _ = &mut shutdown => {
+                tracing::info!("Received SIGINT (Ctrl+C), initiating graceful shutdown...");
+                break;
+            }
+            () = &mut terminate => {
+                tracing::info!("Received SIGTERM, initiating graceful shutdown...");
+                break;
+            }
+        }
     }
+
+    // Drain active connections with timeout
+    drain_connections(&active_conns).await;
+    flush_and_exit(&state);
+    Ok(())
+}
+
+/// Waits for active connections to complete, up to the drain timeout.
+async fn drain_connections(active_conns: &std::sync::atomic::AtomicUsize) {
+    let deadline = tokio::time::Instant::now()
+        + tokio::time::Duration::from_secs(SHUTDOWN_DRAIN_TIMEOUT_SECS);
+
+    loop {
+        let count = active_conns.load(std::sync::atomic::Ordering::Relaxed);
+        if count == 0 {
+            tracing::info!("All active connections drained");
+            break;
+        }
+        if tokio::time::Instant::now() >= deadline {
+            tracing::warn!(
+                "Drain timeout ({SHUTDOWN_DRAIN_TIMEOUT_SECS}s) reached with {count} active connection(s)"
+            );
+            break;
+        }
+        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+    }
+}
+
+/// Flushes all WALs and logs shutdown completion.
+fn flush_and_exit(state: &AppState) {
+    tracing::info!("Flushing all WALs...");
+    let failures = state.db.flush_all();
+    if failures > 0 {
+        tracing::warn!("WAL flush completed with {failures} failure(s)");
+    } else {
+        tracing::info!("All WALs flushed successfully");
+    }
+    tracing::info!("Shutdown complete");
 }
 
 fn build_cli_overrides(args: Args) -> CliOverrides {
@@ -281,11 +389,11 @@ async fn main() -> anyhow::Result<()> {
 
     let state = init_app_state(&cfg.data_dir)?;
     let auth_state = AuthState::new(cfg.api_keys.clone());
-    let app = build_router(state, auth_state);
+    let app = build_router(state.clone(), auth_state);
 
     if let (Some(cert), Some(key)) = (&cfg.tls_cert, &cfg.tls_key) {
-        serve_tls(&cfg.host, cfg.port, app, cert, key).await
+        serve_tls(&cfg.host, cfg.port, app, cert, key, state).await
     } else {
-        serve(&cfg.host, cfg.port, app).await
+        serve(&cfg.host, cfg.port, app, state).await
     }
 }

--- a/crates/velesdb-server/src/main.rs
+++ b/crates/velesdb-server/src/main.rs
@@ -14,9 +14,6 @@ use tower_http::cors::CorsLayer;
 use tower_http::trace::TraceLayer;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
-/// Drain timeout for graceful shutdown (seconds).
-const SHUTDOWN_DRAIN_TIMEOUT_SECS: u64 = 30;
-
 #[cfg(feature = "swagger-ui")]
 use utoipa::OpenApi;
 #[cfg(feature = "swagger-ui")]
@@ -238,6 +235,7 @@ async fn serve(
     port: u16,
     app: Router,
     state: Arc<AppState>,
+    shutdown_timeout_secs: u64,
 ) -> anyhow::Result<()> {
     warn_if_exposed(host);
     let addr = format!("{host}:{port}");
@@ -248,6 +246,9 @@ async fn serve(
         .with_graceful_shutdown(shutdown_signal())
         .await?;
 
+    // Drain timeout already handled by axum's graceful shutdown;
+    // log the configured value for observability
+    tracing::info!("Graceful shutdown complete (drain timeout was {shutdown_timeout_secs}s)");
     flush_and_exit(&state);
     Ok(())
 }
@@ -259,6 +260,7 @@ async fn serve_tls(
     cert_path: &str,
     key_path: &str,
     state: Arc<AppState>,
+    shutdown_timeout_secs: u64,
 ) -> anyhow::Result<()> {
     warn_if_exposed(host);
 
@@ -333,15 +335,14 @@ async fn serve_tls(
     }
 
     // Drain active connections with timeout
-    drain_connections(&active_conns).await;
+    drain_connections(&active_conns, shutdown_timeout_secs).await;
     flush_and_exit(&state);
     Ok(())
 }
 
 /// Waits for active connections to complete, up to the drain timeout.
-async fn drain_connections(active_conns: &std::sync::atomic::AtomicUsize) {
-    let deadline = tokio::time::Instant::now()
-        + tokio::time::Duration::from_secs(SHUTDOWN_DRAIN_TIMEOUT_SECS);
+async fn drain_connections(active_conns: &std::sync::atomic::AtomicUsize, timeout_secs: u64) {
+    let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_secs(timeout_secs);
 
     loop {
         let count = active_conns.load(std::sync::atomic::Ordering::Relaxed);
@@ -351,7 +352,7 @@ async fn drain_connections(active_conns: &std::sync::atomic::AtomicUsize) {
         }
         if tokio::time::Instant::now() >= deadline {
             tracing::warn!(
-                "Drain timeout ({SHUTDOWN_DRAIN_TIMEOUT_SECS}s) reached with {count} active connection(s)"
+                "Drain timeout ({timeout_secs}s) reached with {count} active connection(s)"
             );
             break;
         }
@@ -399,8 +400,17 @@ async fn main() -> anyhow::Result<()> {
     let app = build_router(state.clone(), auth_state);
 
     if let (Some(cert), Some(key)) = (&cfg.tls_cert, &cfg.tls_key) {
-        serve_tls(&cfg.host, cfg.port, app, cert, key, state).await
+        serve_tls(
+            &cfg.host,
+            cfg.port,
+            app,
+            cert,
+            key,
+            state,
+            cfg.shutdown_timeout_secs,
+        )
+        .await
     } else {
-        serve(&cfg.host, cfg.port, app, state).await
+        serve(&cfg.host, cfg.port, app, state, cfg.shutdown_timeout_secs).await
     }
 }

--- a/crates/velesdb-server/src/main.rs
+++ b/crates/velesdb-server/src/main.rs
@@ -9,6 +9,7 @@ use axum::{
 use clap::Parser;
 use std::path::PathBuf;
 use std::sync::Arc;
+use tower::ServiceExt;
 use tower_http::cors::CorsLayer;
 use tower_http::trace::TraceLayer;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
@@ -192,18 +193,67 @@ fn build_router(state: Arc<AppState>, auth_state: AuthState) -> Router {
         .layer(TraceLayer::new_for_http())
 }
 
-async fn serve(host: &str, port: u16, app: Router) -> anyhow::Result<()> {
+fn warn_if_exposed(host: &str) {
     if host != "127.0.0.1" && host != "localhost" {
         tracing::warn!(
             "VelesDB server exposed on network ({host}). \
              Consider using 127.0.0.1 for local-first usage."
         );
     }
+}
+
+async fn serve(host: &str, port: u16, app: Router) -> anyhow::Result<()> {
+    warn_if_exposed(host);
     let addr = format!("{host}:{port}");
     let listener = tokio::net::TcpListener::bind(&addr).await?;
     tracing::info!("VelesDB server listening on http://{}", addr);
     axum::serve(listener, app).await?;
     Ok(())
+}
+
+async fn serve_tls(
+    host: &str,
+    port: u16,
+    app: Router,
+    cert_path: &str,
+    key_path: &str,
+) -> anyhow::Result<()> {
+    warn_if_exposed(host);
+
+    let tls_acceptor = velesdb_server::tls::load_tls_config(cert_path, key_path)?;
+    let addr = format!("{host}:{port}");
+    let listener = tokio::net::TcpListener::bind(&addr).await?;
+    tracing::info!("VelesDB server listening on https://{}", addr);
+
+    loop {
+        let (stream, _peer_addr) = listener.accept().await?;
+        let acceptor = tls_acceptor.clone();
+        let tower_service = app.clone();
+
+        tokio::spawn(async move {
+            let Ok(tls_stream) = acceptor.accept(stream).await else {
+                tracing::debug!("TLS handshake failed");
+                return;
+            };
+
+            let io = hyper_util::rt::TokioIo::new(tls_stream);
+            let hyper_service = hyper::service::service_fn(move |request| {
+                let clone = tower_service.clone();
+                async move {
+                    clone.oneshot(request).await
+                }
+            });
+
+            if let Err(err) = hyper_util::server::conn::auto::Builder::new(
+                hyper_util::rt::TokioExecutor::new(),
+            )
+            .serve_connection_with_upgrades(io, hyper_service)
+            .await
+            {
+                tracing::debug!("TLS connection error: {err}");
+            }
+        });
+    }
 }
 
 fn build_cli_overrides(args: Args) -> CliOverrides {
@@ -233,5 +283,9 @@ async fn main() -> anyhow::Result<()> {
     let auth_state = AuthState::new(cfg.api_keys.clone());
     let app = build_router(state, auth_state);
 
-    serve(&cfg.host, cfg.port, app).await
+    if let (Some(cert), Some(key)) = (&cfg.tls_cert, &cfg.tls_key) {
+        serve_tls(&cfg.host, cfg.port, app, cert, key).await
+    } else {
+        serve(&cfg.host, cfg.port, app).await
+    }
 }

--- a/crates/velesdb-server/src/main.rs
+++ b/crates/velesdb-server/src/main.rs
@@ -32,9 +32,9 @@ use velesdb_server::{
     create_collection, create_index, delete_collection, delete_index, delete_point, explain,
     flush_collection, get_collection, get_collection_config, get_collection_stats, get_edges,
     get_guardrails, get_node_degree, get_point, health_check, hybrid_search, is_empty,
-    list_collections, list_indexes, match_query, multi_query_search, query, search, search_ids,
-    stream_insert, stream_traverse, stream_upsert_points, text_search, traverse_graph,
-    update_guardrails, upsert_points, AppState, OnboardingMetrics,
+    list_collections, list_indexes, match_query, multi_query_search, query, readiness_check,
+    search, search_ids, stream_insert, stream_traverse, stream_upsert_points, text_search,
+    traverse_graph, update_guardrails, upsert_points, AppState, OnboardingMetrics,
 };
 
 /// VelesDB Server - A high-performance vector database
@@ -95,16 +95,23 @@ fn log_startup(cfg: &ServerConfig) {
 
 fn init_app_state(data_dir: &str) -> anyhow::Result<Arc<AppState>> {
     let db = Database::open(data_dir)?;
-    Ok(Arc::new(AppState {
+    let state = Arc::new(AppState {
         db,
         onboarding_metrics: OnboardingMetrics::default(),
         query_limits: parking_lot::RwLock::new(velesdb_core::guardrails::QueryLimits::default()),
-    }))
+        ready: std::sync::atomic::AtomicBool::new(false),
+    });
+    // Database loaded successfully — mark server as ready
+    state
+        .ready
+        .store(true, std::sync::atomic::Ordering::Relaxed);
+    Ok(state)
 }
 
 fn api_routes() -> Router<Arc<AppState>> {
     Router::new()
         .route("/health", get(health_check))
+        .route("/ready", get(readiness_check))
         .route(
             "/collections",
             get(list_collections).post(create_collection),

--- a/crates/velesdb-server/src/tls.rs
+++ b/crates/velesdb-server/src/tls.rs
@@ -63,10 +63,7 @@ mod tests {
         std::fs::write(&cert_path, "").unwrap();
         std::fs::write(&key_path, "").unwrap();
 
-        match load_tls_config(
-            &cert_path.to_string_lossy(),
-            &key_path.to_string_lossy(),
-        ) {
+        match load_tls_config(&cert_path.to_string_lossy(), &key_path.to_string_lossy()) {
             Err(e) => assert!(e.to_string().contains("no certificates")),
             Ok(_) => panic!("should fail for empty cert"),
         }
@@ -81,11 +78,7 @@ mod tests {
         std::fs::write(&key_path, "not a real key").unwrap();
 
         assert!(
-            load_tls_config(
-                &cert_path.to_string_lossy(),
-                &key_path.to_string_lossy(),
-            )
-            .is_err(),
+            load_tls_config(&cert_path.to_string_lossy(), &key_path.to_string_lossy(),).is_err(),
             "should fail for invalid PEM"
         );
     }

--- a/crates/velesdb-server/src/tls.rs
+++ b/crates/velesdb-server/src/tls.rs
@@ -9,6 +9,26 @@ use std::sync::Arc;
 use rustls::ServerConfig as TlsServerConfig;
 use tokio_rustls::TlsAcceptor;
 
+fn load_certs(cert_path: &str) -> anyhow::Result<Vec<rustls::pki_types::CertificateDer<'static>>> {
+    let cert_file = std::fs::File::open(cert_path)
+        .map_err(|e| anyhow::anyhow!("failed to open TLS cert file '{cert_path}': {e}"))?;
+    let certs: Vec<_> = rustls_pemfile::certs(&mut BufReader::new(cert_file))
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|e| anyhow::anyhow!("failed to parse TLS certificates from '{cert_path}': {e}"))?;
+    if certs.is_empty() {
+        anyhow::bail!("no certificates found in '{cert_path}'");
+    }
+    Ok(certs)
+}
+
+fn load_private_key(key_path: &str) -> anyhow::Result<rustls::pki_types::PrivateKeyDer<'static>> {
+    let key_file = std::fs::File::open(key_path)
+        .map_err(|e| anyhow::anyhow!("failed to open TLS key file '{key_path}': {e}"))?;
+    rustls_pemfile::private_key(&mut BufReader::new(key_file))
+        .map_err(|e| anyhow::anyhow!("failed to parse TLS private key from '{key_path}': {e}"))?
+        .ok_or_else(|| anyhow::anyhow!("no private key found in '{key_path}'"))
+}
+
 /// Load TLS configuration from PEM certificate and private key files.
 ///
 /// Returns a [`TlsAcceptor`] ready for use with `tokio` TCP streams.
@@ -18,22 +38,8 @@ use tokio_rustls::TlsAcceptor;
 /// Returns an error if the certificate or key files cannot be read,
 /// contain no valid PEM items, or if rustls rejects the configuration.
 pub fn load_tls_config(cert_path: &str, key_path: &str) -> anyhow::Result<TlsAcceptor> {
-    let cert_file = std::fs::File::open(cert_path)
-        .map_err(|e| anyhow::anyhow!("failed to open TLS cert file '{cert_path}': {e}"))?;
-    let key_file = std::fs::File::open(key_path)
-        .map_err(|e| anyhow::anyhow!("failed to open TLS key file '{key_path}': {e}"))?;
-
-    let certs: Vec<_> = rustls_pemfile::certs(&mut BufReader::new(cert_file))
-        .collect::<Result<Vec<_>, _>>()
-        .map_err(|e| anyhow::anyhow!("failed to parse TLS certificates from '{cert_path}': {e}"))?;
-
-    if certs.is_empty() {
-        anyhow::bail!("no certificates found in '{cert_path}'");
-    }
-
-    let key = rustls_pemfile::private_key(&mut BufReader::new(key_file))
-        .map_err(|e| anyhow::anyhow!("failed to parse TLS private key from '{key_path}': {e}"))?
-        .ok_or_else(|| anyhow::anyhow!("no private key found in '{key_path}'"))?;
+    let certs = load_certs(cert_path)?;
+    let key = load_private_key(key_path)?;
 
     let config = TlsServerConfig::builder()
         .with_no_client_auth()

--- a/crates/velesdb-server/src/tls.rs
+++ b/crates/velesdb-server/src/tls.rs
@@ -1,0 +1,92 @@
+//! TLS configuration and server support via rustls.
+//!
+//! When TLS cert and key paths are provided, the server binds with HTTPS.
+//! Otherwise, plain HTTP is used (default for local dev).
+
+use std::io::BufReader;
+use std::sync::Arc;
+
+use rustls::ServerConfig as TlsServerConfig;
+use tokio_rustls::TlsAcceptor;
+
+/// Load TLS configuration from PEM certificate and private key files.
+///
+/// Returns a [`TlsAcceptor`] ready for use with `tokio` TCP streams.
+///
+/// # Errors
+///
+/// Returns an error if the certificate or key files cannot be read,
+/// contain no valid PEM items, or if rustls rejects the configuration.
+pub fn load_tls_config(cert_path: &str, key_path: &str) -> anyhow::Result<TlsAcceptor> {
+    let cert_file = std::fs::File::open(cert_path)
+        .map_err(|e| anyhow::anyhow!("failed to open TLS cert file '{cert_path}': {e}"))?;
+    let key_file = std::fs::File::open(key_path)
+        .map_err(|e| anyhow::anyhow!("failed to open TLS key file '{key_path}': {e}"))?;
+
+    let certs: Vec<_> = rustls_pemfile::certs(&mut BufReader::new(cert_file))
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|e| anyhow::anyhow!("failed to parse TLS certificates from '{cert_path}': {e}"))?;
+
+    if certs.is_empty() {
+        anyhow::bail!("no certificates found in '{cert_path}'");
+    }
+
+    let key = rustls_pemfile::private_key(&mut BufReader::new(key_file))
+        .map_err(|e| anyhow::anyhow!("failed to parse TLS private key from '{key_path}': {e}"))?
+        .ok_or_else(|| anyhow::anyhow!("no private key found in '{key_path}'"))?;
+
+    let config = TlsServerConfig::builder()
+        .with_no_client_auth()
+        .with_single_cert(certs, key)
+        .map_err(|e| anyhow::anyhow!("invalid TLS configuration: {e}"))?;
+
+    Ok(TlsAcceptor::from(Arc::new(config)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_load_tls_config_missing_cert_file() {
+        match load_tls_config("/nonexistent/cert.pem", "/nonexistent/key.pem") {
+            Err(e) => assert!(e.to_string().contains("cert")),
+            Ok(_) => panic!("should fail for missing files"),
+        }
+    }
+
+    #[test]
+    fn test_load_tls_config_empty_cert_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let cert_path = dir.path().join("cert.pem");
+        let key_path = dir.path().join("key.pem");
+        std::fs::write(&cert_path, "").unwrap();
+        std::fs::write(&key_path, "").unwrap();
+
+        match load_tls_config(
+            &cert_path.to_string_lossy(),
+            &key_path.to_string_lossy(),
+        ) {
+            Err(e) => assert!(e.to_string().contains("no certificates")),
+            Ok(_) => panic!("should fail for empty cert"),
+        }
+    }
+
+    #[test]
+    fn test_load_tls_config_invalid_pem() {
+        let dir = tempfile::tempdir().unwrap();
+        let cert_path = dir.path().join("cert.pem");
+        let key_path = dir.path().join("key.pem");
+        std::fs::write(&cert_path, "not a real cert").unwrap();
+        std::fs::write(&key_path, "not a real key").unwrap();
+
+        assert!(
+            load_tls_config(
+                &cert_path.to_string_lossy(),
+                &key_path.to_string_lossy(),
+            )
+            .is_err(),
+            "should fail for invalid PEM"
+        );
+    }
+}

--- a/crates/velesdb-server/tests/api_integration.rs
+++ b/crates/velesdb-server/tests/api_integration.rs
@@ -36,7 +36,7 @@ async fn test_health_check() {
         .expect("Failed to read body");
     let json: Value = serde_json::from_slice(&body).expect("Invalid JSON");
 
-    assert_eq!(json["status"], "healthy");
+    assert_eq!(json["status"], "ok");
 }
 
 #[tokio::test]

--- a/crates/velesdb-server/tests/auth_integration.rs
+++ b/crates/velesdb-server/tests/auth_integration.rs
@@ -111,7 +111,7 @@ async fn test_auth_health_endpoint_bypasses_auth() {
         .await
         .unwrap();
     let json: Value = serde_json::from_slice(&body).unwrap();
-    assert_eq!(json["status"], "healthy");
+    assert_eq!(json["status"], "ok");
 }
 
 // ============================================================================

--- a/crates/velesdb-server/tests/auth_integration.rs
+++ b/crates/velesdb-server/tests/auth_integration.rs
@@ -1,0 +1,198 @@
+#![allow(clippy::doc_markdown)]
+//! Integration tests for API key authentication middleware.
+
+mod common;
+
+use axum::{
+    body::Body,
+    http::{Request, StatusCode},
+};
+use common::{create_test_app, create_test_app_with_auth};
+use serde_json::Value;
+use tempfile::TempDir;
+use tower::ServiceExt;
+
+// ============================================================================
+// Auth enabled — valid key returns 200
+// ============================================================================
+
+#[tokio::test]
+async fn test_auth_valid_key_returns_200() {
+    let temp_dir = TempDir::new().unwrap();
+    let app = create_test_app_with_auth(&temp_dir, vec!["secret-key".to_string()]);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/collections")
+                .header("Authorization", "Bearer secret-key")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+// ============================================================================
+// Auth enabled — invalid key returns 401
+// ============================================================================
+
+#[tokio::test]
+async fn test_auth_invalid_key_returns_401() {
+    let temp_dir = TempDir::new().unwrap();
+    let app = create_test_app_with_auth(&temp_dir, vec!["secret-key".to_string()]);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/collections")
+                .header("Authorization", "Bearer wrong-key")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["error"], "Unauthorized");
+}
+
+// ============================================================================
+// Auth enabled — missing header returns 401
+// ============================================================================
+
+#[tokio::test]
+async fn test_auth_missing_header_returns_401() {
+    let temp_dir = TempDir::new().unwrap();
+    let app = create_test_app_with_auth(&temp_dir, vec!["secret-key".to_string()]);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/collections")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+}
+
+// ============================================================================
+// Auth enabled — /health bypasses auth (always public)
+// ============================================================================
+
+#[tokio::test]
+async fn test_auth_health_endpoint_bypasses_auth() {
+    let temp_dir = TempDir::new().unwrap();
+    let app = create_test_app_with_auth(&temp_dir, vec!["secret-key".to_string()]);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/health")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["status"], "healthy");
+}
+
+// ============================================================================
+// Auth disabled — no keys configured, all endpoints accessible
+// ============================================================================
+
+#[tokio::test]
+async fn test_auth_disabled_when_no_keys() {
+    let temp_dir = TempDir::new().unwrap();
+    let app = create_test_app(&temp_dir);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/collections")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+// ============================================================================
+// Auth enabled — multiple keys supported
+// ============================================================================
+
+#[tokio::test]
+async fn test_auth_multiple_keys_all_valid() {
+    let temp_dir = TempDir::new().unwrap();
+    let keys = vec!["key-alpha".to_string(), "key-beta".to_string()];
+
+    // First key works
+    let app = create_test_app_with_auth(&temp_dir, keys.clone());
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/collections")
+                .header("Authorization", "Bearer key-alpha")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    // Second key works too
+    let app = create_test_app_with_auth(&temp_dir, keys);
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/collections")
+                .header("Authorization", "Bearer key-beta")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+// ============================================================================
+// Auth enabled — invalid format (Basic instead of Bearer) returns 401
+// ============================================================================
+
+#[tokio::test]
+async fn test_auth_basic_scheme_rejected() {
+    let temp_dir = TempDir::new().unwrap();
+    let app = create_test_app_with_auth(&temp_dir, vec!["secret-key".to_string()]);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/collections")
+                .header("Authorization", "Basic dXNlcjpwYXNz")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+}

--- a/crates/velesdb-server/tests/common/mod.rs
+++ b/crates/velesdb-server/tests/common/mod.rs
@@ -14,13 +14,14 @@ use velesdb_server::{
     auth::{auth_middleware, AuthState},
     batch_search, collection_sanity, create_collection, delete_collection, delete_point, explain,
     get_collection, get_edges, get_node_degree, get_point, health_check, hybrid_search,
-    list_collections, query, search, search_ids, stream_upsert_points, text_search, traverse_graph,
-    upsert_points, AppState, OnboardingMetrics,
+    list_collections, query, readiness_check, search, search_ids, stream_upsert_points,
+    text_search, traverse_graph, upsert_points, AppState, OnboardingMetrics,
 };
 
 fn base_routes() -> Router<Arc<AppState>> {
     Router::new()
         .route("/health", get(health_check))
+        .route("/ready", get(readiness_check))
         .route(
             "/collections",
             get(list_collections).post(create_collection),
@@ -64,6 +65,7 @@ fn create_app_state(temp_dir: &TempDir) -> Arc<AppState> {
         db,
         onboarding_metrics: OnboardingMetrics::default(),
         query_limits: parking_lot::RwLock::new(velesdb_core::guardrails::QueryLimits::default()),
+        ready: std::sync::atomic::AtomicBool::new(true),
     })
 }
 

--- a/crates/velesdb-server/tests/common/mod.rs
+++ b/crates/velesdb-server/tests/common/mod.rs
@@ -1,4 +1,5 @@
 //! Common test utilities for velesdb-server integration tests.
+#![allow(dead_code)]
 
 use axum::{
     routing::{get, post},
@@ -9,22 +10,15 @@ use tempfile::TempDir;
 
 use velesdb_core::Database;
 use velesdb_server::{
-    add_edge, aggregate, batch_search, collection_sanity, create_collection, delete_collection,
-    delete_point, explain, get_collection, get_edges, get_node_degree, get_point, health_check,
-    hybrid_search, list_collections, query, search, search_ids, stream_upsert_points, text_search,
-    traverse_graph, upsert_points, AppState, OnboardingMetrics,
+    add_edge, aggregate,
+    auth::{auth_middleware, AuthState},
+    batch_search, collection_sanity, create_collection, delete_collection, delete_point, explain,
+    get_collection, get_edges, get_node_degree, get_point, health_check, hybrid_search,
+    list_collections, query, search, search_ids, stream_upsert_points, text_search, traverse_graph,
+    upsert_points, AppState, OnboardingMetrics,
 };
 
-/// Helper to create test app with all routes.
-/// Graph routes use the same `AppState` — no separate `GraphService`.
-pub fn create_test_app(temp_dir: &TempDir) -> Router {
-    let db = Database::open(temp_dir.path()).expect("Failed to open database");
-    let state = Arc::new(AppState {
-        db,
-        onboarding_metrics: OnboardingMetrics::default(),
-        query_limits: parking_lot::RwLock::new(velesdb_core::guardrails::QueryLimits::default()),
-    });
-
+fn base_routes() -> Router<Arc<AppState>> {
     Router::new()
         .route("/health", get(health_check))
         .route(
@@ -62,5 +56,30 @@ pub fn create_test_app(temp_dir: &TempDir) -> Router {
             "/collections/{name}/graph/nodes/{node_id}/degree",
             get(get_node_degree),
         )
+}
+
+fn create_app_state(temp_dir: &TempDir) -> Arc<AppState> {
+    let db = Database::open(temp_dir.path()).expect("Failed to open database");
+    Arc::new(AppState {
+        db,
+        onboarding_metrics: OnboardingMetrics::default(),
+        query_limits: parking_lot::RwLock::new(velesdb_core::guardrails::QueryLimits::default()),
+    })
+}
+
+/// Helper to create test app with all routes (no auth).
+pub fn create_test_app(temp_dir: &TempDir) -> Router {
+    base_routes().with_state(create_app_state(temp_dir))
+}
+
+/// Helper to create test app with API key authentication enabled.
+pub fn create_test_app_with_auth(temp_dir: &TempDir, api_keys: Vec<String>) -> Router {
+    let state = create_app_state(temp_dir);
+    let auth_state = AuthState::new(api_keys);
+    base_routes()
         .with_state(state)
+        .layer(axum::middleware::from_fn_with_state(
+            auth_state,
+            auth_middleware,
+        ))
 }

--- a/crates/velesdb-server/tests/health_integration.rs
+++ b/crates/velesdb-server/tests/health_integration.rs
@@ -1,0 +1,152 @@
+//! Integration tests for GET /health and GET /ready endpoints.
+
+mod common;
+
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use axum::routing::get;
+use axum::Router;
+use tower::ServiceExt;
+use velesdb_core::Database;
+use velesdb_server::{AppState, OnboardingMetrics};
+
+// ============================================================================
+// GET /health — liveness probe
+// ============================================================================
+
+#[tokio::test]
+async fn health_returns_200_with_status_ok() {
+    let temp_dir = tempfile::tempdir().expect("temp dir");
+    let app = common::create_test_app(&temp_dir);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/health")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+    assert_eq!(json["status"], "ok");
+    assert!(json["version"].is_string(), "version should be present");
+}
+
+// ============================================================================
+// GET /ready — readiness probe
+// ============================================================================
+
+#[tokio::test]
+async fn ready_returns_200_when_db_loaded() {
+    let temp_dir = tempfile::tempdir().expect("temp dir");
+    let app = common::create_test_app(&temp_dir);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/ready")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+    assert_eq!(json["status"], "ready");
+    assert!(json["version"].is_string(), "version should be present");
+}
+
+#[tokio::test]
+async fn ready_returns_503_when_not_ready() {
+    let temp_dir = tempfile::tempdir().expect("temp dir");
+
+    // Build app with ready=false to simulate startup
+    let db = Database::open(temp_dir.path()).expect("open db");
+    let state = Arc::new(AppState {
+        db,
+        onboarding_metrics: OnboardingMetrics::default(),
+        query_limits: parking_lot::RwLock::new(velesdb_core::guardrails::QueryLimits::default()),
+        ready: std::sync::atomic::AtomicBool::new(false),
+    });
+
+    let app = Router::new()
+        .route("/ready", get(velesdb_server::readiness_check))
+        .with_state(state);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/ready")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+    assert_eq!(json["status"], "not_ready");
+    assert!(json["version"].is_string(), "version should be present");
+}
+
+// ============================================================================
+// Auth bypass — both endpoints must be public
+// ============================================================================
+
+#[tokio::test]
+async fn health_bypasses_auth() {
+    let temp_dir = tempfile::tempdir().expect("temp dir");
+    let app = common::create_test_app_with_auth(&temp_dir, vec!["secret-key".to_string()]);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/health")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn ready_bypasses_auth() {
+    let temp_dir = tempfile::tempdir().expect("temp dir");
+    let app = common::create_test_app_with_auth(&temp_dir, vec!["secret-key".to_string()]);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/ready")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    // Should get 200 (not 401) even without auth header
+    assert_eq!(response.status(), StatusCode::OK);
+}

--- a/docs/guides/CONFIGURATION.md
+++ b/docs/guides/CONFIGURATION.md
@@ -1,8 +1,10 @@
 # ⚙️ Configuration VelesDB
 
-*Version 0.8.0 — Janvier 2026*
+*Version 1.6.0 — Mars 2026*
 
 Guide complet pour configurer VelesDB via fichier de configuration, variables d'environnement et paramètres runtime.
+
+> **Voir aussi :** [SERVER_SECURITY.md](SERVER_SECURITY.md) pour le guide opérationnel du serveur (authentification, TLS, arrêt gracieux, endpoints de santé).
 
 ---
 
@@ -179,6 +181,15 @@ host = "127.0.0.1"
 # Default: 8080
 port = 8080
 
+# Répertoire de données (collections, WAL, index)
+# Default: "./velesdb_data"
+data_dir = "./velesdb_data"
+
+# Timeout de drain des connexions lors de l'arrêt gracieux (secondes)
+# Range: 1 - 300
+# Default: 30
+shutdown_timeout_secs = 30
+
 # Nombre de workers (threads)
 # Range: 1 - 256
 # Default: nombre de CPUs
@@ -196,6 +207,31 @@ cors_enabled = false
 # Origines CORS autorisées (si cors_enabled = true)
 # Default: ["*"]
 cors_origins = ["*"]
+
+# -----------------------------------------------------------------------------
+# AUTHENTICATION (velesdb-server uniquement)
+# Voir SERVER_SECURITY.md pour le guide complet
+# -----------------------------------------------------------------------------
+[auth]
+# Liste des clés API autorisées (Bearer tokens)
+# Lorsque vide ou absent, l'authentification est désactivée (mode dev local)
+# Les endpoints /health et /ready sont toujours publics
+# Default: [] (désactivé)
+# api_keys = ["my-secret-key-1", "my-secret-key-2"]
+
+# -----------------------------------------------------------------------------
+# TLS CONFIGURATION (velesdb-server uniquement)
+# Voir SERVER_SECURITY.md pour le guide complet
+# -----------------------------------------------------------------------------
+[tls]
+# Chemin vers le fichier certificat PEM
+# Les deux champs (cert + key) doivent être définis ensemble
+# Default: null (HTTP en clair)
+# cert = "/path/to/cert.pem"
+
+# Chemin vers le fichier clé privée PEM
+# Default: null (HTTP en clair)
+# key = "/path/to/key.pem"
 
 # -----------------------------------------------------------------------------
 # LOGGING CONFIGURATION
@@ -266,8 +302,12 @@ Toutes les options peuvent être définies via des variables d'environnement ave
 | `VELESDB_HNSW_EF_CONSTRUCTION` | `hnsw.ef_construction` | `600` |
 | `VELESDB_STORAGE_DATA_DIR` | `storage.data_dir` | `/var/lib/velesdb` |
 | `VELESDB_STORAGE_MODE` | `storage.storage_mode` | `mmap` |
-| `VELESDB_SERVER_HOST` | `server.host` | `0.0.0.0` |
-| `VELESDB_SERVER_PORT` | `server.port` | `8080` |
+| `VELESDB_HOST` | `server.host` | `0.0.0.0` |
+| `VELESDB_PORT` | `server.port` | `8080` |
+| `VELESDB_DATA_DIR` | `server.data_dir` | `/var/lib/velesdb` |
+| `VELESDB_API_KEYS` | `auth.api_keys` | `key1,key2,key3` (virgules) |
+| `VELESDB_TLS_CERT` | `tls.cert` | `/etc/ssl/cert.pem` |
+| `VELESDB_TLS_KEY` | `tls.key` | `/etc/ssl/key.pem` |
 | `VELESDB_LOGGING_LEVEL` | `logging.level` | `debug` |
 | `VELESDB_LICENSE_KEY` | `premium.license_key` | `VELES-...` |
 | `VELESDB_CONFIG` | Chemin du fichier config | `/etc/velesdb/velesdb.toml` |
@@ -309,7 +349,7 @@ La configuration suit cet ordre de priorité (du plus bas au plus haut) :
    ↓
 3. Variables d'environnement VELESDB_*
    ↓
-4. Paramètres CLI (--port, --data-dir, etc.)
+4. Paramètres CLI (--host, --port, --data-dir, --tls-cert, --tls-key)
    ↓
 5. Override runtime (REPL \set, VelesQL WITH, API params)
 ```
@@ -377,14 +417,36 @@ SELECT * FROM docs WHERE vector NEAR $v WITH (ef_search = 512);
 
 ### Section [server]
 
-| Clé | Type | Défaut | Description |
-|-----|------|--------|-------------|
-| `host` | string | `"127.0.0.1"` | Adresse d'écoute |
-| `port` | int | `8080` | Port |
-| `workers` | int | `0` | Workers (0=auto) |
-| `max_body_size` | int | `104857600` | Body max (bytes) |
-| `cors_enabled` | bool | `false` | Activer CORS |
-| `cors_origins` | array | `["*"]` | Origines CORS |
+| Clé | Type | Env var | CLI flag | Défaut | Description |
+|-----|------|---------|----------|--------|-------------|
+| `host` | string | `VELESDB_HOST` | `--host` | `"127.0.0.1"` | Adresse d'écoute |
+| `port` | int | `VELESDB_PORT` | `--port` | `8080` | Port |
+| `data_dir` | string | `VELESDB_DATA_DIR` | `--data-dir` | `"./velesdb_data"` | Répertoire des données |
+| `shutdown_timeout_secs` | int | — | — | `30` | Timeout drain connexions (secondes) |
+| `workers` | int | — | — | `0` | Workers (0=auto) |
+| `max_body_size` | int | — | — | `104857600` | Body max (bytes) |
+| `cors_enabled` | bool | — | — | `false` | Activer CORS |
+| `cors_origins` | array | — | — | `["*"]` | Origines CORS |
+
+### Section [auth]
+
+| Clé | Type | Env var | CLI flag | Défaut | Description |
+|-----|------|---------|----------|--------|-------------|
+| `api_keys` | array | `VELESDB_API_KEYS` | — | `[]` (désactivé) | Clés API Bearer autorisées |
+
+> `VELESDB_API_KEYS` accepte des clés séparées par des virgules : `key1,key2,key3`.
+> Lorsque la liste est vide, l'authentification est désactivée (mode dev local).
+> Les endpoints `/health` et `/ready` sont toujours publics.
+
+### Section [tls]
+
+| Clé | Type | Env var | CLI flag | Défaut | Description |
+|-----|------|---------|----------|--------|-------------|
+| `cert` | string? | `VELESDB_TLS_CERT` | `--tls-cert` | `null` | Chemin du certificat PEM |
+| `key` | string? | `VELESDB_TLS_KEY` | `--tls-key` | `null` | Chemin de la clé privée PEM |
+
+> Les deux champs doivent être définis ensemble. Si aucun n'est défini, le serveur utilise HTTP en clair.
+> Voir [SERVER_SECURITY.md](SERVER_SECURITY.md) pour la génération de certificats.
 
 ### Section [logging]
 

--- a/docs/guides/MIGRATION_v1.6.md
+++ b/docs/guides/MIGRATION_v1.6.md
@@ -1,0 +1,128 @@
+# Migration Guide: v1.5 → v1.6
+
+**Time to upgrade: under 5 minutes.**
+
+## Zero Breaking Changes
+
+v1.6 introduces **opt-in server security features**. All new functionality is disabled by default. Your existing setup works exactly as before — no code changes, no config changes, no data migration.
+
+| Feature | Default | Breaking? |
+|---------|---------|-----------|
+| API Key Authentication | Disabled | No |
+| TLS (HTTPS) | Disabled (plain HTTP) | No |
+| Graceful Shutdown | Enabled automatically | No (improves safety) |
+| `GET /ready` endpoint | Available | No (new endpoint) |
+| `GET /health` response change | `"ok"` (was `"healthy"`) | Minor* |
+
+\* If you parse the `/health` response body, update `"healthy"` → `"ok"`. The HTTP status code (200) is unchanged.
+
+---
+
+## What's New
+
+### 1. Graceful Shutdown (automatic)
+
+The server now handles SIGTERM and SIGINT signals gracefully:
+
+- Stops accepting new connections
+- Drains active requests (30s timeout)
+- Flushes all WALs to disk
+- Logs "Shutdown complete" before exit
+
+**No action needed** — this is always active. Your data is now safer during restarts.
+
+### 2. API Key Authentication (opt-in)
+
+To enable authentication on an existing server:
+
+```bash
+# Set one or more API keys
+export VELESDB_API_KEYS="your-secret-key"
+
+# Restart the server
+velesdb-server
+```
+
+Or add to your `velesdb.toml`:
+
+```toml
+[auth]
+api_keys = ["your-secret-key"]
+```
+
+All endpoints except `/health` and `/ready` will now require:
+
+```
+Authorization: Bearer your-secret-key
+```
+
+### 3. TLS (opt-in)
+
+To add HTTPS to an existing HTTP server:
+
+```bash
+# Generate a certificate (dev)
+mkcert -cert-file cert.pem -key-file key.pem localhost
+
+# Start with TLS
+export VELESDB_TLS_CERT=cert.pem
+export VELESDB_TLS_KEY=key.pem
+velesdb-server
+```
+
+Or add to your `velesdb.toml`:
+
+```toml
+[tls]
+cert = "cert.pem"
+key = "key.pem"
+```
+
+### 4. Readiness Endpoint (new)
+
+`GET /ready` returns 200 when the database is fully loaded, 503 during startup. Useful for monitoring scripts:
+
+```bash
+curl http://localhost:8080/ready
+# {"status": "ready", "version": "1.6.0"}
+```
+
+---
+
+## Step-by-Step Upgrade
+
+1. **Replace the binary** (or `cargo install velesdb-server`).
+2. **Start the server** — it works immediately with your existing data and config.
+3. **(Optional)** Enable auth by setting `VELESDB_API_KEYS`.
+4. **(Optional)** Enable TLS by setting `VELESDB_TLS_CERT` and `VELESDB_TLS_KEY`.
+
+That's it.
+
+---
+
+## FAQ
+
+### Will my existing data still work?
+
+Yes. The storage format is unchanged. No data migration is needed.
+
+### Do I need to update my velesdb.toml?
+
+No. The existing config continues to work. New `[auth]` and `[tls]` sections are optional.
+
+### Will my clients break if I enable auth?
+
+Clients without a valid `Authorization: Bearer <key>` header will receive `401 Unauthorized`. Enable auth only after updating all clients to send the header.
+
+### Does graceful shutdown change my restart behavior?
+
+The server now takes up to 30 seconds to shut down (to drain active connections and flush WALs). If you need faster shutdown, the drain timeout is configurable via `shutdown_timeout_secs` in `velesdb.toml`.
+
+### My monitoring checks GET /health — will it break?
+
+The HTTP status code is still 200. The JSON body changed from `{"status": "healthy"}` to `{"status": "ok", "version": "..."}`. Update your parser if you check the body string.
+
+### Where is the full documentation?
+
+- [Server Security Guide](SERVER_SECURITY.md) — auth, TLS, shutdown, health endpoints
+- [Configuration Reference](CONFIGURATION.md) — all options with env vars, CLI flags, TOML keys

--- a/docs/guides/SERVER_SECURITY.md
+++ b/docs/guides/SERVER_SECURITY.md
@@ -1,0 +1,361 @@
+# Server Security & Operations Guide
+
+VelesDB is a **local-first** embedded database. The `velesdb-server` binary exposes VelesDB over HTTP on your local network or as a backend for your application. All security features are **opt-in** — by default the server runs without authentication or TLS, which is ideal for local development.
+
+This guide covers the server's operational features: authentication, TLS, graceful shutdown, and health monitoring.
+
+> **See also:** [CONFIGURATION.md](CONFIGURATION.md) for the full configuration reference (all options, env vars, CLI flags, TOML keys).
+
+---
+
+## Table of Contents
+
+1. [Running the Server](#1-running-the-server)
+2. [Authentication Setup](#2-authentication-setup)
+3. [TLS Setup](#3-tls-setup)
+4. [Graceful Shutdown](#4-graceful-shutdown)
+5. [Health Endpoints](#5-health-endpoints)
+
+---
+
+## 1. Running the Server
+
+### From a release binary
+
+```bash
+./velesdb-server
+```
+
+The server starts on `127.0.0.1:8080` with data stored in `./velesdb_data/`. No authentication, no TLS — ready for local development.
+
+### From source
+
+```bash
+cargo run -p velesdb-server
+```
+
+### With a configuration file
+
+```bash
+velesdb-server --config velesdb.toml
+```
+
+Or via environment variable:
+
+```bash
+export VELESDB_CONFIG=./velesdb.toml
+velesdb-server
+```
+
+### Common startup options
+
+```bash
+# Custom port and data directory
+velesdb-server --port 9090 --data-dir /var/lib/velesdb
+
+# Equivalent with env vars
+VELESDB_PORT=9090 VELESDB_DATA_DIR=/var/lib/velesdb velesdb-server
+```
+
+### Configuration priority
+
+The server merges configuration from multiple sources. **Highest priority wins:**
+
+```
+CLI flags / Environment variables  >  TOML file  >  Defaults
+```
+
+| Option | CLI flag | Env var | Default |
+|--------|----------|---------|---------|
+| Bind address | `--host` | `VELESDB_HOST` | `127.0.0.1` |
+| Port | `--port` | `VELESDB_PORT` | `8080` |
+| Data directory | `--data-dir` | `VELESDB_DATA_DIR` | `./velesdb_data` |
+| Config file | `--config` | `VELESDB_CONFIG` | *(none)* |
+
+See [CONFIGURATION.md](CONFIGURATION.md) for the complete option list.
+
+---
+
+## 2. Authentication Setup
+
+VelesDB supports **Bearer token authentication** via API keys. When enabled, all endpoints except health checks require a valid `Authorization: Bearer <key>` header.
+
+### Enabling authentication
+
+**Option A: Environment variable (recommended for quick setup)**
+
+```bash
+# Single key
+export VELESDB_API_KEYS="my-secret-key-1"
+
+# Multiple keys (comma-separated)
+export VELESDB_API_KEYS="key-for-app-a,key-for-app-b,key-for-admin"
+
+velesdb-server
+```
+
+**Option B: Configuration file**
+
+```toml
+# velesdb.toml
+[auth]
+api_keys = [
+    "key-for-app-a",
+    "key-for-app-b",
+    "key-for-admin",
+]
+```
+
+### Making authenticated requests
+
+```bash
+curl -H "Authorization: Bearer key-for-app-a" \
+     http://localhost:8080/api/v1/collections
+```
+
+### Unauthenticated responses
+
+When auth is enabled, requests without a valid token receive:
+
+```http
+HTTP/1.1 401 Unauthorized
+Content-Type: application/json
+
+{"error": "Unauthorized", "message": "invalid API key"}
+```
+
+### Public endpoints (always accessible)
+
+These endpoints **bypass authentication**, even when API keys are configured:
+
+- `GET /health` — Liveness probe
+- `GET /ready` — Readiness probe
+
+### Key rotation best practices
+
+VelesDB supports multiple simultaneous API keys, which enables zero-downtime key rotation:
+
+1. **Add the new key** alongside the existing one:
+   ```bash
+   export VELESDB_API_KEYS="old-key,new-key"
+   ```
+2. **Restart the server** — both keys are now valid.
+3. **Update your clients** to use the new key.
+4. **Remove the old key** once all clients have migrated:
+   ```bash
+   export VELESDB_API_KEYS="new-key"
+   ```
+5. **Restart the server** to revoke the old key.
+
+> **Tip:** Use long, random strings for API keys (e.g., `openssl rand -hex 32`). Treat them like passwords — never commit them to version control.
+
+### Disabling authentication
+
+Authentication is **disabled by default**. If you previously enabled it, simply remove the `VELESDB_API_KEYS` env var or the `[auth]` section from your TOML file and restart the server.
+
+---
+
+## 3. TLS Setup
+
+VelesDB supports HTTPS via **rustls** (a pure-Rust TLS implementation). When TLS is configured, the server binds with HTTPS. Otherwise, it serves plain HTTP.
+
+### Enabling TLS
+
+You need a PEM-encoded certificate file and a PEM-encoded private key file.
+
+**Option A: Environment variables**
+
+```bash
+export VELESDB_TLS_CERT=/path/to/cert.pem
+export VELESDB_TLS_KEY=/path/to/key.pem
+velesdb-server
+```
+
+**Option B: CLI flags**
+
+```bash
+velesdb-server --tls-cert /path/to/cert.pem --tls-key /path/to/key.pem
+```
+
+**Option C: Configuration file**
+
+```toml
+# velesdb.toml
+[tls]
+cert = "/path/to/cert.pem"
+key = "/path/to/key.pem"
+```
+
+### Generating certificates for development
+
+Use [mkcert](https://github.com/FiloSottile/mkcert) to create locally-trusted certificates:
+
+```bash
+# Install the local CA (one-time)
+mkcert -install
+
+# Generate cert for localhost
+mkcert -cert-file cert.pem -key-file key.pem localhost 127.0.0.1 ::1
+
+# Start with TLS
+velesdb-server --tls-cert cert.pem --tls-key key.pem
+```
+
+Your browser and tools will trust these certificates automatically on your machine.
+
+### Generating certificates for production (local network)
+
+For exposing VelesDB on a local network, use [Let's Encrypt](https://letsencrypt.org/) with a domain name, or generate a self-signed certificate:
+
+```bash
+# Self-signed certificate (valid 365 days)
+openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem \
+  -days 365 -nodes -subj "/CN=velesdb.local"
+```
+
+> **Note:** Clients connecting with self-signed certificates will need to trust the CA or disable certificate verification.
+
+### TLS validation
+
+The server validates TLS configuration at startup and will refuse to start if:
+
+- Only one of `cert` or `key` is provided (both are required).
+- The certificate or key file does not exist.
+- The files contain invalid PEM data.
+
+Error messages are clear and specific — check the server logs if startup fails.
+
+### Complete example: Auth + TLS
+
+```toml
+# velesdb.toml
+[server]
+host = "0.0.0.0"
+port = 8443
+
+[auth]
+api_keys = ["my-secure-key"]
+
+[tls]
+cert = "./certs/cert.pem"
+key = "./certs/key.pem"
+```
+
+```bash
+curl -H "Authorization: Bearer my-secure-key" \
+     https://localhost:8443/api/v1/collections
+```
+
+---
+
+## 4. Graceful Shutdown
+
+VelesDB handles shutdown signals gracefully to prevent data loss.
+
+### Shutdown sequence
+
+When the server receives **SIGTERM** or **SIGINT** (Ctrl+C):
+
+1. **Stop accepting new connections** — the listening socket closes.
+2. **Drain active requests** — in-flight requests are allowed to complete, with a **30-second timeout**. Requests that exceed the timeout are dropped.
+3. **Flush all WALs** — the server calls `Database::flush_all()` to persist all write-ahead logs to disk. This covers all collection types (vector, graph, metadata).
+4. **Log shutdown status** — the server logs "Shutdown complete" before exiting.
+5. **Exit cleanly** — the process exits with code 0.
+
+### WAL flush guarantee
+
+The graceful shutdown ensures that **all data written before the shutdown signal is persisted to disk**. This is the key safety guarantee: you will not lose acknowledged writes due to a clean shutdown.
+
+If a WAL flush fails for a specific collection, the server logs a warning but continues shutting down other collections. Check the logs for any flush warnings.
+
+### Shutdown timeout
+
+The connection drain timeout is **30 seconds**. Connections that are still active after this period are terminated. This prevents a single slow client from blocking shutdown indefinitely.
+
+### Signals
+
+| Signal | Trigger | Behavior |
+|--------|---------|----------|
+| `SIGINT` | Ctrl+C in terminal | Graceful shutdown |
+| `SIGTERM` | Process manager / `kill` | Graceful shutdown |
+| `SIGKILL` | `kill -9` | **Immediate termination** — no WAL flush, possible data loss |
+
+> **Avoid `kill -9`** unless the server is truly unresponsive. Always prefer `SIGTERM` to allow WAL flushing.
+
+---
+
+## 5. Health Endpoints
+
+VelesDB provides two health endpoints for monitoring and orchestration. Both bypass authentication.
+
+### GET /health (Liveness)
+
+Returns 200 OK as long as the server process is running. Use this to check if the server is alive.
+
+```bash
+curl http://localhost:8080/health
+```
+
+```json
+{
+  "status": "ok",
+  "version": "1.6.0"
+}
+```
+
+This endpoint **always returns 200** — if it doesn't respond, the process is down.
+
+### GET /ready (Readiness)
+
+Returns 200 OK only when the database is fully loaded and ready to serve requests. Returns 503 during startup (while collections are loading from disk).
+
+```bash
+curl http://localhost:8080/ready
+```
+
+**Ready (200):**
+
+```json
+{
+  "status": "ready",
+  "version": "1.6.0"
+}
+```
+
+**Not ready (503):**
+
+```json
+{
+  "status": "not_ready",
+  "version": "1.6.0"
+}
+```
+
+### Monitoring usage
+
+Use these endpoints with your monitoring tool of choice:
+
+```bash
+# Simple health check script
+while true; do
+  STATUS=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:8080/ready)
+  if [ "$STATUS" -ne 200 ]; then
+    echo "VelesDB is not ready (HTTP $STATUS)"
+  fi
+  sleep 10
+done
+```
+
+### Startup check
+
+Wait for the server to be ready before sending traffic:
+
+```bash
+# Wait for readiness after starting the server
+velesdb-server &
+until curl -sf http://localhost:8080/ready > /dev/null 2>&1; do
+  echo "Waiting for VelesDB..."
+  sleep 1
+done
+echo "VelesDB is ready!"
+```

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -2,13 +2,13 @@
   "openapi": "3.1.0",
   "info": {
     "title": "VelesDB API",
-    "description": "High-performance vector database for AI applications. Supports semantic search, HNSW indexing, and multiple distance metrics.",
+    "description": "High-performance vector database for AI applications. Supports semantic search, HNSW indexing, and multiple distance metrics. Authentication is optional — when API keys are configured via VELESDB_API_KEYS, all endpoints except /health and /ready require a valid Bearer token.",
     "contact": {
       "name": "VelesDB Team",
       "url": "https://github.com/cyberlife-coder/VelesDB"
     },
     "license": {
-      "name": "ELv2",
+      "name": "VelesDB Core License 1.0",
       "url": "https://github.com/cyberlife-coder/VelesDB/blob/main/LICENSE"
     },
     "version": "1.5.1"
@@ -3886,8 +3886,19 @@
           }
         }
       }
+    },
+    "securitySchemes": {
+      "bearer_auth": {
+        "type": "http",
+        "scheme": "bearer"
+      }
     }
   },
+  "security": [
+    {
+      "bearer_auth": []
+    }
+  ],
   "tags": [
     {
       "name": "health",

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1811,11 +1811,11 @@
         "tags": [
           "health"
         ],
-        "summary": "Health check endpoint.",
+        "summary": "Liveness probe — always returns 200 OK.",
         "operationId": "health_check",
         "responses": {
           "200": {
-            "description": "Server is healthy",
+            "description": "Server is alive",
             "content": {
               "application/json": {
                 "schema": {
@@ -1934,6 +1934,37 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/VelesqlErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ready": {
+      "get": {
+        "tags": [
+          "health"
+        ],
+        "summary": "Readiness probe — returns 200 when the database is fully loaded, 503 otherwise.",
+        "operationId": "readiness_check",
+        "responses": {
+          "200": {
+            "description": "Server is ready to accept requests",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Server is not yet ready",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
                 }
               }
             }

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1176,11 +1176,11 @@ paths:
     get:
       tags:
       - health
-      summary: Health check endpoint.
+      summary: Liveness probe — always returns 200 OK.
       operationId: health_check
       responses:
         '200':
-          description: Server is healthy
+          description: Server is alive
           content:
             application/json:
               schema:
@@ -1257,6 +1257,25 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/VelesqlErrorResponse'
+  /ready:
+    get:
+      tags:
+      - health
+      summary: Readiness probe — returns 200 when the database is fully loaded, 503 otherwise.
+      operationId: readiness_check
+      responses:
+        '200':
+          description: Server is ready to accept requests
+          content:
+            application/json:
+              schema:
+                type: object
+        '503':
+          description: Server is not yet ready
+          content:
+            application/json:
+              schema:
+                type: object
 components:
   schemas:
     AddEdgeRequest:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1,12 +1,12 @@
 openapi: 3.1.0
 info:
   title: VelesDB API
-  description: High-performance vector database for AI applications. Supports semantic search, HNSW indexing, and multiple distance metrics.
+  description: High-performance vector database for AI applications. Supports semantic search, HNSW indexing, and multiple distance metrics. Authentication is optional — when API keys are configured via VELESDB_API_KEYS, all endpoints except /health and /ready require a valid Bearer token.
   contact:
     name: VelesDB Team
     url: https://github.com/cyberlife-coder/VelesDB
   license:
-    name: ELv2
+    name: VelesDB Core License 1.0
     url: https://github.com/cyberlife-coder/VelesDB/blob/main/LICENSE
   version: 1.5.1
 servers:
@@ -2716,6 +2716,12 @@ components:
         error:
           $ref: '#/components/schemas/VelesqlErrorDetail'
           description: Error details.
+  securitySchemes:
+    bearer_auth:
+      type: http
+      scheme: bearer
+security:
+- bearer_auth: []
 tags:
 - name: health
   description: Health check endpoints

--- a/docs/reference/readme-code-truth-matrix.md
+++ b/docs/reference/readme-code-truth-matrix.md
@@ -9,6 +9,7 @@ Last verification: 2026-03-04.
 | Route | Runtime | README |
 |---|---|---|
 | `/health` | yes | yes |
+| `/ready` | yes | yes |
 | `/collections` | yes | yes |
 | `/collections/{name}` | yes | yes |
 | `/collections/{name}/empty` | yes | yes |


### PR DESCRIPTION
## Summary

Implements PRD **04-open-core-security** — 9 user stories hardening `velesdb-server` for production deployment:

- **US-01**: API Key authentication middleware (Bearer token, constant-time comparison)
- **US-02**: TLS support via `rustls` (PEM cert/key loading, TLS 1.2+ enforcement)
- **US-03**: Graceful shutdown with configurable drain timeout and Ctrl+C handling
- **US-04**: Server configuration module (`ServerConfig` from TOML/env/CLI with validation)
- **US-05**: Health (`/health`) and readiness (`/ready`) endpoints with deep DB checks
- **US-06**: Server Security & Operations Guide (`docs/guides/SERVER_SECURITY.md`)
- **US-07**: Updated Configuration Reference (`docs/guides/CONFIGURATION.md`)
- **US-08**: Updated README, API docs (OpenAPI), and Python SDK docs
- **US-09**: Migration guide v1.5 → v1.6 (`docs/guides/MIGRATION_v1.6.md`)

### Key changes

- **22 files changed**, +2218 lines
- New modules: `auth.rs`, `tls.rs`, `config.rs` in `velesdb-server`
- Integration tests: `auth_integration.rs`, `health_integration.rs`
- `Database::is_healthy()` method added to core for readiness probes
- CHANGELOG, OpenAPI spec, and migration guide updated

## Test plan

- [ ] `cargo test -p velesdb-server -- --test-threads=1` passes all new integration tests
- [ ] `cargo clippy --workspace --all-targets --features persistence,gpu,update-check --exclude velesdb-python -- -D warnings -D clippy::pedantic` clean
- [ ] `cargo fmt --all --check` clean
- [ ] Review `docs/guides/SERVER_SECURITY.md` for completeness
- [ ] Verify OpenAPI spec changes in `docs/openapi.yaml`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/323" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
