### PR TITLE
refactor: extend test coverage, harden quality gates, fix Python lint

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -40,6 +40,14 @@ exclude_paths:
   # SDK test suites
   - "sdks/**/tests/**"
   - "sdks/**/__tests__/**"
+  # Root-level benchmark scripts (Python, not criterion)
+  - "benchmarks/**"
+  # Non-project directories (dependencies, tooling, build output)
+  - ".venv/**"
+  - ".claude/**"
+  - "node_modules/**"
+  - "target/**"
+  - ".tmp/**"
 
   # --- Audited unsafe code (false positive suppression) ---
   # Codacy's "unsafe detected" rule cannot distinguish documented from
@@ -76,6 +84,17 @@ exclude_paths:
   # Memory pool — MaybeUninit for arena-allocated graph nodes
   # RAII-guarded with compile-time size assertions.
   - "crates/velesdb-core/src/collection/graph/memory_pool/mod.rs"
+  # SIMD NEON intrinsics (ARM equivalent of AVX2)
+  - "crates/velesdb-core/src/simd_neon.rs"
+  - "crates/velesdb-core/src/simd_neon_prefetch.rs"
+  # Allocation guard — RAII-guarded aligned alloc/dealloc
+  - "crates/velesdb-core/src/alloc_guard.rs"
+  # SIMD trigram — AVX2/NEON distance in trigram index
+  - "crates/velesdb-core/src/index/trigram/simd.rs"
+  # Vector byte conversion — raw pointer cast for zero-copy serialization
+  - "crates/velesdb-core/src/storage/vector_bytes.rs"
+  # Internal benchmark helper (not production)
+  - "crates/velesdb-core/src/internal_bench.rs"
   # FFI bindings — PyO3 (Python), JNI (mobile), wasm-bindgen
   - "crates/velesdb-python/**"
   - "crates/velesdb-mobile/**"
@@ -157,6 +176,8 @@ engines:
 
       # --- HNSW native (search loops with inherent complexity) ---
       - "crates/velesdb-core/src/index/hnsw/native/dual_precision.rs"
+      # --- HNSW beam search hot path (lock-held greedy descent + prefetch) ---
+      - "crates/velesdb-core/src/index/hnsw/native/graph/search.rs"
 
       # --- Server handlers (HTTP glue, not engine logic) ---
       - "crates/velesdb-server/src/handlers/**"

--- a/.codacy/codacy.yaml
+++ b/.codacy/codacy.yaml
@@ -1,15 +1,20 @@
+exclude_paths:
+    - .venv/**
+    - .claude/**
+    - .tmp/**
+    - node_modules/**
+    - target/**
+    - benchmarks/**
+    - demos/**
+    - docs/**
+    - scripts/**
+    - conformance/**
 runtimes:
-    - dart@3.7.2
-    - go@1.22.3
-    - java@17.0.10
     - node@22.2.0
     - python@3.11.11
 tools:
-    - dartanalyzer@3.7.2
     - eslint@8.57.0
     - lizard@1.17.31
-    - pmd@7.11.0
+    - opengrep@1.16.2
     - pylint@3.3.6
-    - revive@1.7.0
-    - semgrep@1.78.0
-    - trivy@0.66.0
+    - trivy@0.69.3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -281,6 +281,13 @@ jobs:
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
 
+      - name: Upload coverage to Codacy
+        uses: codacy/codacy-coverage-reporter-action@89d6c85cfafaec52c72b6c5e8b2878d33104c699 # v1.3.0
+        continue-on-error: true
+        with:
+          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
+          coverage-reports: lcov.info
+
       - name: Upload lcov for SonarCloud
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,11 +82,11 @@ jobs:
         with:
           toolchain: ${{ env.RUST_VERSION }}
       - name: Cache apt packages
-        uses: awalsh128/cache-apt-pkgs-action@v1
+        uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05 # v1.6.0
         with:
           packages: libglib2.0-dev libgtk-3-dev libwebkit2gtk-4.1-dev
           version: 1.0
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@401aff9a7a08acb9d27b64936a90db81024cff97 # v2.8.2
         with:
           shared-key: "validate-all"
       - name: Run workspace tests
@@ -274,7 +274,7 @@ jobs:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.11'
-      - uses: PyO3/maturin-action@v1
+      - uses: PyO3/maturin-action@db323e2cf5679b7feb8bcb561a36b27a0bc19e79 # v1
         with:
           target: ${{ matrix.target }}
           working-directory: crates/velesdb-python

--- a/.semgrepignore
+++ b/.semgrepignore
@@ -1,0 +1,73 @@
+# =============================================================================
+# VelesDB — Semgrep/Opengrep Ignore Configuration
+# =============================================================================
+#
+# Mirrors .codacy.yml exclude_paths for opengrep/semgrep, which does NOT
+# read .codacy.yml exclusions. Every entry has a documented rationale.
+#
+# Maintainer: Julien L.
+# Last reviewed: 2026-03-19
+# =============================================================================
+
+# --- Test files (different quality standards, assert is idiomatic) ---
+crates/**/src/**/*_tests.rs
+crates/**/src/**/*_test.rs
+crates/**/src/**/tests.rs
+crates/**/tests/
+sdks/**/tests/
+sdks/**/__tests__/
+# Catch-all for any *_tests.rs not under src/ subdirs
+*_tests.rs
+
+# --- Benchmark harnesses (criterion, perf code) ---
+crates/**/benches/
+
+# --- Non-production code ---
+conformance/
+demos/
+docs/
+scripts/
+examples/
+benchmarks/
+fuzz/
+
+# --- Audited unsafe code (SAFETY comments enforced by CI script) ---
+# See docs/SOUNDNESS.md for full audit. CI: scripts/verify_unsafe_safety_template.py
+crates/velesdb-core/src/simd_native/
+crates/velesdb-core/src/index/hnsw/native/graph/
+crates/velesdb-core/src/perf_optimizations.rs
+crates/velesdb-core/src/storage/mmap.rs
+crates/velesdb-core/src/storage/compaction.rs
+crates/velesdb-core/src/storage/guard.rs
+crates/velesdb-core/src/storage/vector_bytes.rs
+crates/velesdb-core/src/index/hnsw/index/mod.rs
+crates/velesdb-core/src/index/hnsw/index/vacuum.rs
+crates/velesdb-core/src/index/hnsw/vector_store.rs
+crates/velesdb-core/src/collection/graph/memory_pool/mod.rs
+# SIMD NEON intrinsics (ARM equivalent of AVX2)
+crates/velesdb-core/src/simd_neon.rs
+crates/velesdb-core/src/simd_neon_prefetch.rs
+# Allocation guard (RAII-guarded aligned alloc/dealloc)
+crates/velesdb-core/src/alloc_guard.rs
+# SIMD trigram (AVX2/NEON distance in trigram index)
+crates/velesdb-core/src/index/trigram/simd.rs
+# Internal benchmark helper (exposes internals, not production)
+crates/velesdb-core/src/internal_bench.rs
+
+# --- FFI bindings (PyO3, JNI, wasm-bindgen) ---
+crates/velesdb-python/
+crates/velesdb-mobile/
+crates/velesdb-wasm/
+
+# --- Non-project directories ---
+.venv/
+.tmp/
+node_modules/
+.claude/
+target/
+
+# --- Generated/build files ---
+crates/**/build.rs
+
+# --- CI workflows (dtolnay/rust-toolchain@stable is intentional) ---
+.github/

--- a/crates/velesdb-core/src/agent/memory_tests.rs
+++ b/crates/velesdb-core/src/agent/memory_tests.rs
@@ -251,3 +251,252 @@ fn test_procedural_min_confidence_filter() {
     let results = memory.procedural().recall(&embedding, 1, 0.2).unwrap();
     assert_eq!(results.len(), 1);
 }
+
+// ============================================================================
+// US-005: Eviction, TTL, Snapshots, Consolidation
+// ============================================================================
+
+/// Test: with_eviction_config sets the eviction configuration
+#[test]
+fn test_with_eviction_config() {
+    let dir = tempdir().unwrap();
+    let db = Arc::new(Database::open(dir.path()).unwrap());
+
+    let config = EvictionConfig {
+        consolidation_age_threshold: 3600,
+        min_confidence_threshold: 0.5,
+        max_entries_per_cycle: 100,
+    };
+
+    // Builder pattern must not fail
+    let memory = AgentMemory::new(Arc::clone(&db))
+        .unwrap()
+        .with_eviction_config(config);
+
+    // Verify the memory is usable after configuration
+    memory.semantic().store(1, "fact", &vec![0.0; 384]).unwrap();
+    assert!(memory.auto_expire().is_ok());
+}
+
+/// Test: with_snapshots enables the snapshot manager
+#[test]
+fn test_with_snapshots() {
+    let dir = tempdir().unwrap();
+    let snap_dir = tempdir().unwrap();
+    let db = Arc::new(Database::open(dir.path()).unwrap());
+
+    let memory = AgentMemory::new(Arc::clone(&db))
+        .unwrap()
+        .with_snapshots(snap_dir.path().to_str().unwrap(), 5);
+
+    // Snapshot operations should now succeed (manager is configured)
+    let version = memory.snapshot().unwrap();
+    assert_eq!(version, 1);
+}
+
+/// Test: set_semantic_ttl / set_episodic_ttl / set_procedural_ttl register TTLs
+#[test]
+fn test_set_ttl_functions() {
+    let dir = tempdir().unwrap();
+    let db = Arc::new(Database::open(dir.path()).unwrap());
+    let memory = AgentMemory::with_dimension(Arc::clone(&db), 4).unwrap();
+
+    let embedding = vec![1.0, 0.0, 0.0, 0.0];
+
+    memory.semantic().store(1, "sem fact", &embedding).unwrap();
+    memory.episodic().record(2, "epi event", 1000, Some(&embedding)).unwrap();
+    let steps = vec!["s1".to_string()];
+    memory.procedural().learn(3, "proc", &steps, Some(&embedding), 0.9).unwrap();
+
+    // Setting TTLs should not panic
+    memory.set_semantic_ttl(1, 3600);
+    memory.set_episodic_ttl(2, 7200);
+    memory.set_procedural_ttl(3, 1800);
+
+    // Non-expired entries should still be queryable
+    let results = memory.semantic().query(&embedding, 1).unwrap();
+    assert_eq!(results.len(), 1);
+}
+
+/// Test: auto_expire removes entries whose TTL has elapsed
+#[test]
+fn test_auto_expire_removes_expired() {
+    let dir = tempdir().unwrap();
+    let db = Arc::new(Database::open(dir.path()).unwrap());
+    let memory = AgentMemory::with_dimension(Arc::clone(&db), 4).unwrap();
+
+    let embedding = vec![1.0, 0.0, 0.0, 0.0];
+    memory.semantic().store(1, "will expire", &embedding).unwrap();
+
+    // Set a TTL of 0 seconds — expires immediately
+    memory.set_semantic_ttl(1, 0);
+
+    let result = memory.auto_expire().unwrap();
+    // auto_expire tries delete on all three subsystems per expired ID;
+    // delete succeeds even for missing IDs, so all three counters increment.
+    assert_eq!(result.semantic_expired, 1);
+    assert!(result.episodic_expired <= 1);
+    assert!(result.procedural_expired <= 1);
+
+    // Verify the entry is actually gone from semantic memory
+    let results = memory.semantic().query(&embedding, 1).unwrap();
+    assert!(results.is_empty());
+}
+
+/// Test: auto_expire returns zero counts when nothing is expired
+#[test]
+fn test_auto_expire_nothing_expired() {
+    let dir = tempdir().unwrap();
+    let db = Arc::new(Database::open(dir.path()).unwrap());
+    let memory = AgentMemory::with_dimension(Arc::clone(&db), 4).unwrap();
+
+    let embedding = vec![1.0, 0.0, 0.0, 0.0];
+    memory.semantic().store(1, "keep me", &embedding).unwrap();
+
+    // TTL far in the future — should not expire
+    memory.set_semantic_ttl(1, 999_999);
+
+    let result = memory.auto_expire().unwrap();
+    assert_eq!(result.semantic_expired, 0);
+    assert_eq!(result.episodic_expired, 0);
+    assert_eq!(result.procedural_expired, 0);
+    assert_eq!(result.episodic_consolidated, 0);
+}
+
+/// Test: evict_low_confidence_procedures removes low-confidence entries
+#[test]
+fn test_evict_low_confidence_procedures() {
+    let dir = tempdir().unwrap();
+    let db = Arc::new(Database::open(dir.path()).unwrap());
+    let memory = AgentMemory::with_dimension(Arc::clone(&db), 4).unwrap();
+
+    let embedding = vec![1.0, 0.0, 0.0, 0.0];
+    let steps = vec!["step".to_string()];
+
+    // Low confidence — should be evicted
+    memory.procedural().learn(1, "weak", &steps, Some(&embedding), 0.1).unwrap();
+    // High confidence — should survive
+    memory.procedural().learn(2, "strong", &steps, Some(&embedding), 0.9).unwrap();
+
+    let evicted = memory.evict_low_confidence_procedures(0.5).unwrap();
+    assert_eq!(evicted, 1);
+
+    // Only the high-confidence procedure should remain
+    let remaining = memory.procedural().list_all().unwrap();
+    assert_eq!(remaining.len(), 1);
+    assert_eq!(remaining[0].id, 2);
+}
+
+/// Test: evict_low_confidence_procedures returns 0 when all above threshold
+#[test]
+fn test_evict_low_confidence_none_evicted() {
+    let dir = tempdir().unwrap();
+    let db = Arc::new(Database::open(dir.path()).unwrap());
+    let memory = AgentMemory::with_dimension(Arc::clone(&db), 4).unwrap();
+
+    let embedding = vec![1.0, 0.0, 0.0, 0.0];
+    let steps = vec!["step".to_string()];
+
+    memory.procedural().learn(1, "good", &steps, Some(&embedding), 0.8).unwrap();
+    memory.procedural().learn(2, "also good", &steps, Some(&embedding), 0.7).unwrap();
+
+    let evicted = memory.evict_low_confidence_procedures(0.5).unwrap();
+    assert_eq!(evicted, 0);
+}
+
+/// Test: snapshot and load_latest_snapshot round-trip
+#[test]
+fn test_snapshot_round_trip() {
+    let dir = tempdir().unwrap();
+    let snap_dir = tempdir().unwrap();
+    let db = Arc::new(Database::open(dir.path()).unwrap());
+
+    let memory = AgentMemory::with_dimension(Arc::clone(&db), 4)
+        .unwrap()
+        .with_snapshots(snap_dir.path().to_str().unwrap(), 5);
+
+    // Store data across all subsystems
+    let embedding = vec![1.0, 0.0, 0.0, 0.0];
+    memory.semantic().store(1, "fact one", &embedding).unwrap();
+    memory.episodic().record(2, "event one", 1000, Some(&embedding)).unwrap();
+    let steps = vec!["step1".to_string()];
+    memory.procedural().learn(3, "proc one", &steps, Some(&embedding), 0.8).unwrap();
+
+    // Create snapshot
+    let version = memory.snapshot().unwrap();
+    assert!(version >= 1);
+
+    // Load it back
+    let loaded_version = memory.load_latest_snapshot().unwrap();
+    assert_eq!(loaded_version, version);
+}
+
+/// Test: snapshot without manager returns an error
+#[test]
+fn test_snapshot_without_manager_errors() {
+    let dir = tempdir().unwrap();
+    let db = Arc::new(Database::open(dir.path()).unwrap());
+    let memory = AgentMemory::new(Arc::clone(&db)).unwrap();
+
+    // No snapshot manager configured — should fail
+    assert!(memory.snapshot().is_err());
+    assert!(memory.load_latest_snapshot().is_err());
+    assert!(memory.list_snapshot_versions().is_err());
+}
+
+/// Test: list_snapshot_versions returns created versions
+#[test]
+fn test_list_snapshot_versions() {
+    let dir = tempdir().unwrap();
+    let snap_dir = tempdir().unwrap();
+    let db = Arc::new(Database::open(dir.path()).unwrap());
+
+    let memory = AgentMemory::with_dimension(Arc::clone(&db), 4)
+        .unwrap()
+        .with_snapshots(snap_dir.path().to_str().unwrap(), 10);
+
+    let embedding = vec![1.0, 0.0, 0.0, 0.0];
+    memory.semantic().store(1, "fact", &embedding).unwrap();
+
+    // Create two snapshots
+    let v1 = memory.snapshot().unwrap();
+    let v2 = memory.snapshot().unwrap();
+
+    let versions = memory.list_snapshot_versions().unwrap();
+    assert!(versions.contains(&v1));
+    assert!(versions.contains(&v2));
+    assert_eq!(versions.len(), 2);
+}
+
+/// Test: consolidate_old_episodes migrates old events to semantic memory
+#[test]
+fn test_consolidate_old_episodes_via_auto_expire() {
+    let dir = tempdir().unwrap();
+    let db = Arc::new(Database::open(dir.path()).unwrap());
+
+    // Use a very small consolidation threshold (1 second) so past events qualify
+    let config = EvictionConfig {
+        consolidation_age_threshold: 1,
+        min_confidence_threshold: 0.1,
+        max_entries_per_cycle: 1000,
+    };
+    let memory = AgentMemory::with_dimension(Arc::clone(&db), 4)
+        .unwrap()
+        .with_eviction_config(config);
+
+    // Record an episode with a timestamp far in the past
+    let embedding = vec![1.0, 0.0, 0.0, 0.0];
+    memory
+        .episodic()
+        .record(1, "ancient event", 100, Some(&embedding))
+        .unwrap();
+
+    // auto_expire should consolidate the old episode into semantic memory
+    let result = memory.auto_expire().unwrap();
+    assert_eq!(result.episodic_consolidated, 1);
+
+    // The event should now be findable in semantic memory
+    let sem_results = memory.semantic().query(&embedding, 1).unwrap();
+    assert_eq!(sem_results.len(), 1);
+    assert!(sem_results[0].2.contains("ancient event"));
+}

--- a/crates/velesdb-core/src/collection/graph/cart/node/growth_tests.rs
+++ b/crates/velesdb-core/src/collection/graph/cart/node/growth_tests.rs
@@ -1,0 +1,261 @@
+//! Tests for C-ART node growth operations (Node4→Node16→Node48→Node256).
+
+use super::CARTNode;
+
+/// Helper: builds a leaf node containing a single value.
+fn leaf(value: u64) -> Option<Box<CARTNode>> {
+    Some(Box::new(CARTNode::new_leaf(value)))
+}
+
+// =========================================================================
+// grow_to_node16: Node4 → Node16
+// =========================================================================
+
+#[test]
+fn grow_node4_to_node16_preserves_children() {
+    let node = CARTNode::Node4 {
+        num_children: 4,
+        keys: [30, 10, 40, 20],
+        children: [leaf(300), leaf(100), leaf(400), leaf(200)],
+    };
+
+    let grown = node.grow_to_node16();
+
+    // Must be Node16 with keys sorted and children re-ordered to match
+    match &grown {
+        CARTNode::Node16 {
+            num_children,
+            keys,
+            children,
+        } => {
+            assert_eq!(*num_children, 4);
+            // Keys are sorted by the growth function
+            assert_eq!(&keys[..4], &[10, 20, 30, 40]);
+            // Each key's child must carry the matching leaf value
+            for (i, expected_val) in [100u64, 200, 300, 400].iter().enumerate() {
+                let child = children[i].as_ref().unwrap();
+                let mut vals = Vec::new();
+                child.collect_all(&mut vals);
+                assert_eq!(vals, vec![*expected_val]);
+            }
+            // Remaining slots must be None
+            for slot in &children[4..] {
+                assert!(slot.is_none());
+            }
+        }
+        other => panic!("Expected Node16, got {other:?}"),
+    }
+}
+
+#[test]
+fn grow_node4_to_node16_partial_fill() {
+    let node = CARTNode::Node4 {
+        num_children: 2,
+        keys: [5, 3, 0, 0],
+        children: [leaf(50), leaf(30), None, None],
+    };
+
+    let grown = node.grow_to_node16();
+
+    match &grown {
+        CARTNode::Node16 {
+            num_children,
+            keys,
+            children,
+        } => {
+            assert_eq!(*num_children, 2);
+            assert_eq!(&keys[..2], &[3, 5]);
+            assert!(children[0].is_some());
+            assert!(children[1].is_some());
+            for slot in &children[2..] {
+                assert!(slot.is_none());
+            }
+        }
+        other => panic!("Expected Node16, got {other:?}"),
+    }
+}
+
+// =========================================================================
+// grow_to_node48: Node16 → Node48
+// =========================================================================
+
+#[test]
+fn grow_node16_to_node48_preserves_children() {
+    let mut keys = [0u8; 16];
+    let mut children: [Option<Box<CARTNode>>; 16] = Default::default();
+
+    // Fill all 16 slots with distinct keys
+    for i in 0u8..16 {
+        let key = i * 10; // 0, 10, 20, ... 150
+        keys[i as usize] = key;
+        children[i as usize] = leaf(u64::from(key) * 100);
+    }
+
+    let node = CARTNode::Node16 {
+        num_children: 16,
+        keys,
+        children,
+    };
+    let grown = node.grow_to_node48();
+
+    match &grown {
+        CARTNode::Node48 {
+            num_children,
+            keys: idx,
+            children: slots,
+        } => {
+            assert_eq!(*num_children, 16);
+            // For each original key byte, the index must map to a valid slot
+            for i in 0u8..16 {
+                let key_byte = i * 10;
+                let slot = idx[key_byte as usize];
+                assert_ne!(slot, 255, "key {key_byte} should have a slot");
+                let child = slots[slot as usize].as_ref().unwrap();
+                let mut vals = Vec::new();
+                child.collect_all(&mut vals);
+                assert_eq!(vals, vec![u64::from(key_byte) * 100]);
+            }
+        }
+        other => panic!("Expected Node48, got {other:?}"),
+    }
+}
+
+#[test]
+fn grow_node16_to_node48_empty_slots_are_255() {
+    let mut keys = [0u8; 16];
+    let mut children: [Option<Box<CARTNode>>; 16] = Default::default();
+
+    // Only 3 children
+    keys[0] = 5;
+    keys[1] = 100;
+    keys[2] = 200;
+    children[0] = leaf(1);
+    children[1] = leaf(2);
+    children[2] = leaf(3);
+
+    let node = CARTNode::Node16 {
+        num_children: 3,
+        keys,
+        children,
+    };
+    let grown = node.grow_to_node48();
+
+    match &grown {
+        CARTNode::Node48 {
+            num_children, keys, ..
+        } => {
+            assert_eq!(*num_children, 3);
+            // Bytes without a child must map to 255
+            let occupied: Vec<usize> = vec![5, 100, 200];
+            for byte in 0..256usize {
+                if occupied.contains(&byte) {
+                    assert_ne!(keys[byte], 255);
+                } else {
+                    assert_eq!(keys[byte], 255, "byte {byte} should be empty (255)");
+                }
+            }
+        }
+        other => panic!("Expected Node48, got {other:?}"),
+    }
+}
+
+// =========================================================================
+// grow_to_node256: Node48 → Node256
+// =========================================================================
+
+#[test]
+fn grow_node48_to_node256_preserves_children() {
+    let mut keys = [255u8; 256];
+    let mut children: [Option<Box<CARTNode>>; 48] = std::array::from_fn(|_| None);
+
+    // Place 5 children at known byte positions
+    let entries: [(u8, u64); 5] = [(0, 10), (42, 420), (128, 1280), (200, 2000), (255, 2550)];
+    for (slot, &(byte, val)) in entries.iter().enumerate() {
+        keys[byte as usize] = slot as u8;
+        children[slot] = leaf(val);
+    }
+
+    let node = CARTNode::Node48 {
+        num_children: 5,
+        keys,
+        children,
+    };
+    let grown = node.grow_to_node256();
+
+    match &grown {
+        CARTNode::Node256 {
+            num_children,
+            children,
+        } => {
+            assert_eq!(*num_children, 5);
+            for &(byte, val) in &entries {
+                let child = children[byte as usize].as_ref().unwrap();
+                let mut vals = Vec::new();
+                child.collect_all(&mut vals);
+                assert_eq!(vals, vec![val], "child at byte {byte} mismatch");
+            }
+            // Count populated slots
+            let populated = children.iter().filter(|c| c.is_some()).count();
+            assert_eq!(populated, 5);
+        }
+        other => panic!("Expected Node256, got {other:?}"),
+    }
+}
+
+// =========================================================================
+// Wrong-type calls: should clone (no-op)
+// =========================================================================
+
+#[test]
+fn grow_to_node16_on_node16_returns_clone() {
+    let node = CARTNode::Node16 {
+        num_children: 1,
+        keys: {
+            let mut k = [0u8; 16];
+            k[0] = 42;
+            k
+        },
+        children: {
+            let mut c: [Option<Box<CARTNode>>; 16] = Default::default();
+            c[0] = leaf(99);
+            c
+        },
+    };
+
+    let result = node.grow_to_node16();
+    assert!(matches!(result, CARTNode::Node16 { num_children: 1, .. }));
+}
+
+#[test]
+fn grow_to_node16_on_leaf_returns_clone() {
+    let node = CARTNode::new_leaf(7);
+    let result = node.grow_to_node16();
+    assert!(matches!(result, CARTNode::Leaf { .. }));
+}
+
+#[test]
+fn grow_to_node48_on_node4_returns_clone() {
+    let node = CARTNode::Node4 {
+        num_children: 1,
+        keys: [10, 0, 0, 0],
+        children: [leaf(1), None, None, None],
+    };
+
+    let result = node.grow_to_node48();
+    assert!(matches!(result, CARTNode::Node4 { num_children: 1, .. }));
+}
+
+#[test]
+fn grow_to_node256_on_node16_returns_clone() {
+    let node = CARTNode::Node16 {
+        num_children: 0,
+        keys: [0u8; 16],
+        children: Default::default(),
+    };
+
+    let result = node.grow_to_node256();
+    assert!(matches!(
+        result,
+        CARTNode::Node16 { num_children: 0, .. }
+    ));
+}

--- a/crates/velesdb-core/src/collection/graph/cart/node/mod.rs
+++ b/crates/velesdb-core/src/collection/graph/cart/node/mod.rs
@@ -12,6 +12,9 @@
 
 mod growth;
 
+#[cfg(test)]
+mod growth_tests;
+
 /// Node variants for the Compressed Adaptive Radix Tree.
 // Reason: Node256 is larger than other variants by design for high-degree vertices
 #[derive(Debug, Clone)]

--- a/crates/velesdb-core/src/collection/metadata_collection_tests.rs
+++ b/crates/velesdb-core/src/collection/metadata_collection_tests.rs
@@ -1,0 +1,196 @@
+//! Tests for [`MetadataCollection`] public API.
+
+use crate::collection::MetadataCollection;
+use crate::error::Error;
+use crate::point::Point;
+use serde_json::json;
+use tempfile::tempdir;
+
+// =========================================================================
+// Lifecycle: create + name + len + is_empty
+// =========================================================================
+
+#[test]
+fn test_create_name_len_empty() {
+    let dir = tempdir().unwrap();
+    let coll = MetadataCollection::create(dir.path().to_path_buf(), "items").unwrap();
+
+    assert_eq!(coll.name(), "items");
+    assert_eq!(coll.len(), 0);
+    assert!(coll.is_empty());
+}
+
+// =========================================================================
+// Upsert metadata points and get
+// =========================================================================
+
+#[test]
+fn test_upsert_and_get() {
+    let dir = tempdir().unwrap();
+    let coll = MetadataCollection::create(dir.path().to_path_buf(), "products").unwrap();
+
+    coll.upsert(vec![
+        Point::metadata_only(1, json!({"name": "Widget", "price": 9.99})),
+        Point::metadata_only(2, json!({"name": "Gadget", "price": 19.99})),
+    ])
+    .unwrap();
+
+    assert_eq!(coll.len(), 2);
+    assert!(!coll.is_empty());
+
+    let results = coll.get(&[1, 2, 999]);
+    assert!(results[0].is_some());
+    assert_eq!(results[0].as_ref().unwrap().id, 1);
+    assert!(results[1].is_some());
+    assert_eq!(results[1].as_ref().unwrap().id, 2);
+    assert!(results[2].is_none());
+}
+
+// =========================================================================
+// Upsert with vector returns VectorNotAllowed
+// =========================================================================
+
+#[test]
+fn test_upsert_with_vector_returns_error() {
+    let dir = tempdir().unwrap();
+    let coll = MetadataCollection::create(dir.path().to_path_buf(), "meta_only").unwrap();
+
+    let point_with_vector = Point::new(1, vec![1.0, 2.0, 3.0], Some(json!({"k": "v"})));
+    let err = coll.upsert(vec![point_with_vector]).unwrap_err();
+
+    assert!(
+        matches!(err, Error::VectorNotAllowed(_)),
+        "expected VectorNotAllowed, got: {err:?}"
+    );
+}
+
+// =========================================================================
+// Delete points
+// =========================================================================
+
+#[test]
+fn test_delete_points() {
+    let dir = tempdir().unwrap();
+    let coll = MetadataCollection::create(dir.path().to_path_buf(), "del_test").unwrap();
+
+    coll.upsert(vec![
+        Point::metadata_only(10, json!({"a": 1})),
+        Point::metadata_only(20, json!({"b": 2})),
+        Point::metadata_only(30, json!({"c": 3})),
+    ])
+    .unwrap();
+
+    assert_eq!(coll.len(), 3);
+
+    coll.delete(&[10, 30]).unwrap();
+    assert_eq!(coll.len(), 1);
+
+    let remaining = coll.get(&[10, 20, 30]);
+    assert!(remaining[0].is_none());
+    assert!(remaining[1].is_some());
+    assert!(remaining[2].is_none());
+}
+
+// =========================================================================
+// text_search returns empty for metadata-only (no vector_storage entries)
+// =========================================================================
+
+#[test]
+fn test_text_search_returns_empty_for_metadata_only() {
+    let dir = tempdir().unwrap();
+    let coll = MetadataCollection::create(dir.path().to_path_buf(), "docs").unwrap();
+
+    coll.upsert(vec![
+        Point::metadata_only(1, json!({"title": "Rust programming language"})),
+        Point::metadata_only(2, json!({"title": "Python programming guide"})),
+    ])
+    .unwrap();
+
+    // text_search delegates to BM25 + hydrate_point; hydrate_point requires
+    // vector_storage entries which metadata-only points lack, so the result
+    // set is empty.  The call itself must not error.
+    let results = coll.text_search("programming", 10).unwrap();
+    assert!(
+        results.is_empty(),
+        "text_search returns empty for metadata-only points (no vector storage)"
+    );
+}
+
+// =========================================================================
+// execute_query_str with simple VelesQL
+// =========================================================================
+
+#[test]
+fn test_execute_query_str_select_all() {
+    let dir = tempdir().unwrap();
+    let coll = MetadataCollection::create(dir.path().to_path_buf(), "velesql_test").unwrap();
+
+    coll.upsert(vec![
+        Point::metadata_only(1, json!({"name": "alpha"})),
+        Point::metadata_only(2, json!({"name": "beta"})),
+        Point::metadata_only(3, json!({"name": "gamma"})),
+    ])
+    .unwrap();
+
+    let results = coll
+        .execute_query_str(
+            "SELECT * FROM velesql_test LIMIT 10",
+            &std::collections::HashMap::new(),
+        )
+        .unwrap();
+
+    assert_eq!(results.len(), 3);
+}
+
+// =========================================================================
+// all_ids
+// =========================================================================
+
+#[test]
+fn test_all_ids() {
+    let dir = tempdir().unwrap();
+    let coll = MetadataCollection::create(dir.path().to_path_buf(), "id_test").unwrap();
+
+    coll.upsert(vec![
+        Point::metadata_only(5, json!({"x": 1})),
+        Point::metadata_only(10, json!({"x": 2})),
+        Point::metadata_only(15, json!({"x": 3})),
+    ])
+    .unwrap();
+
+    let mut ids = coll.all_ids();
+    ids.sort_unstable();
+    assert_eq!(ids, vec![5, 10, 15]);
+}
+
+// =========================================================================
+// Persistence: open after create
+// =========================================================================
+
+#[test]
+fn test_open_after_create_persistence() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().to_path_buf();
+
+    // Create and populate, then flush.
+    {
+        let coll = MetadataCollection::create(path.clone(), "persist").unwrap();
+        coll.upsert(vec![
+            Point::metadata_only(1, json!({"key": "value1"})),
+            Point::metadata_only(2, json!({"key": "value2"})),
+        ])
+        .unwrap();
+        coll.flush().unwrap();
+    }
+
+    // Re-open from disk and verify data survived.
+    {
+        let coll = MetadataCollection::open(path).unwrap();
+        assert_eq!(coll.name(), "persist");
+        assert_eq!(coll.len(), 2);
+
+        let results = coll.get(&[1, 2]);
+        assert!(results[0].is_some());
+        assert!(results[1].is_some());
+    }
+}

--- a/crates/velesdb-core/src/collection/mod.rs
+++ b/crates/velesdb-core/src/collection/mod.rs
@@ -37,6 +37,9 @@ mod vector_collection;
 mod tests;
 
 #[cfg(test)]
+mod metadata_collection_tests;
+
+#[cfg(test)]
 mod metadata_only_tests;
 
 #[cfg(test)]

--- a/crates/velesdb-core/src/collection/vector_collection/mod.rs
+++ b/crates/velesdb-core/src/collection/vector_collection/mod.rs
@@ -8,6 +8,8 @@ mod accessors;
 mod crud;
 mod lifecycle;
 mod search;
+#[cfg(test)]
+mod search_tests;
 
 use crate::collection::types::Collection;
 

--- a/crates/velesdb-core/src/collection/vector_collection/search_tests.rs
+++ b/crates/velesdb-core/src/collection/vector_collection/search_tests.rs
@@ -1,0 +1,339 @@
+//! Tests for `VectorCollection` search methods.
+
+use std::collections::HashMap;
+
+use serde_json::json;
+use tempfile::TempDir;
+
+use crate::distance::DistanceMetric;
+use crate::filter::{Condition, Filter};
+use crate::point::Point;
+use crate::quantization::StorageMode;
+use crate::VectorCollection;
+
+/// Creates a 4-dim `VectorCollection` backed by a temporary directory.
+fn create_test_vc() -> (VectorCollection, TempDir) {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test_coll");
+    let coll =
+        VectorCollection::create(path, "test", 4, DistanceMetric::Cosine, StorageMode::Full)
+            .unwrap();
+    (coll, dir)
+}
+
+/// Inserts five orthogonal-ish points with text payloads.
+fn seed_points(coll: &VectorCollection) {
+    let points = vec![
+        Point::new(1, vec![1.0, 0.0, 0.0, 0.0], Some(json!({"text": "hello world", "cat": "a"}))),
+        Point::new(2, vec![0.0, 1.0, 0.0, 0.0], Some(json!({"text": "foo bar", "cat": "b"}))),
+        Point::new(3, vec![0.0, 0.0, 1.0, 0.0], Some(json!({"text": "hello foo", "cat": "a"}))),
+        Point::new(4, vec![0.0, 0.0, 0.0, 1.0], Some(json!({"text": "baz qux", "cat": "b"}))),
+        Point::new(5, vec![1.0, 1.0, 0.0, 0.0], Some(json!({"text": "hello bar", "cat": "a"}))),
+    ];
+    coll.upsert(points).unwrap();
+}
+
+// ─── search() ────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_search_returns_k_nearest() {
+    let (coll, _dir) = create_test_vc();
+    seed_points(&coll);
+
+    let results = coll.search(&[1.0, 0.0, 0.0, 0.0], 3).unwrap();
+
+    assert_eq!(results.len(), 3);
+    // The exact match (id=1) should be the closest result.
+    assert_eq!(results[0].point.id, 1);
+}
+
+#[test]
+fn test_search_empty_collection() {
+    let (coll, _dir) = create_test_vc();
+
+    let results = coll.search(&[1.0, 0.0, 0.0, 0.0], 5).unwrap();
+
+    assert!(results.is_empty());
+}
+
+#[test]
+fn test_search_k_exceeds_collection_size() {
+    let (coll, _dir) = create_test_vc();
+    seed_points(&coll);
+
+    let results = coll.search(&[1.0, 0.0, 0.0, 0.0], 100).unwrap();
+
+    // Cannot return more points than exist in the collection.
+    assert!(results.len() <= 5);
+}
+
+#[test]
+fn test_search_results_ordered_by_similarity() {
+    let (coll, _dir) = create_test_vc();
+    seed_points(&coll);
+
+    let results = coll.search(&[1.0, 0.0, 0.0, 0.0], 5).unwrap();
+
+    // Cosine similarity: higher score = more similar, sorted descending.
+    for pair in results.windows(2) {
+        assert!(
+            pair[0].score >= pair[1].score,
+            "Results should be sorted by descending similarity"
+        );
+    }
+}
+
+// ─── text_search() ──────────────────────────────────────────────────────────
+
+#[test]
+fn test_text_search_returns_matching_docs() {
+    let (coll, _dir) = create_test_vc();
+    seed_points(&coll);
+
+    let results = coll.text_search("hello", 10).unwrap();
+
+    // Points 1, 3, and 5 contain "hello" in their text payload.
+    let ids: Vec<u64> = results.iter().map(|r| r.point.id).collect();
+    assert!(ids.contains(&1), "id=1 should match 'hello'");
+    assert!(ids.contains(&3), "id=3 should match 'hello'");
+    assert!(ids.contains(&5), "id=5 should match 'hello'");
+}
+
+#[test]
+fn test_text_search_no_match() {
+    let (coll, _dir) = create_test_vc();
+    seed_points(&coll);
+
+    let results = coll.text_search("nonexistent_term_xyz", 10).unwrap();
+
+    assert!(results.is_empty());
+}
+
+// ─── search_with_ef() ───────────────────────────────────────────────────────
+
+#[test]
+fn test_search_with_ef_returns_results() {
+    let (coll, _dir) = create_test_vc();
+    seed_points(&coll);
+
+    let results = coll.search_with_ef(&[1.0, 0.0, 0.0, 0.0], 3, 200).unwrap();
+
+    assert!(!results.is_empty());
+    assert!(results.len() <= 3);
+    // Exact match should still be top-1 with higher ef.
+    assert_eq!(results[0].point.id, 1);
+}
+
+#[test]
+fn test_search_with_ef_empty_collection() {
+    let (coll, _dir) = create_test_vc();
+
+    let results = coll.search_with_ef(&[0.5, 0.5, 0.0, 0.0], 5, 50).unwrap();
+
+    assert!(results.is_empty());
+}
+
+// ─── search_with_filter() ───────────────────────────────────────────────────
+
+#[test]
+fn test_search_with_filter_equality() {
+    let (coll, _dir) = create_test_vc();
+    seed_points(&coll);
+
+    let filter = Filter::new(Condition::eq("cat", "a"));
+    let results = coll
+        .search_with_filter(&[1.0, 0.0, 0.0, 0.0], 10, &filter)
+        .unwrap();
+
+    // Only points with cat="a" (ids 1, 3, 5) should be returned.
+    for r in &results {
+        let cat = r
+            .point
+            .payload
+            .as_ref()
+            .and_then(|p| p.get("cat"))
+            .and_then(|v| v.as_str());
+        assert_eq!(cat, Some("a"), "filter should only admit cat=a");
+    }
+}
+
+#[test]
+fn test_search_with_filter_no_match() {
+    let (coll, _dir) = create_test_vc();
+    seed_points(&coll);
+
+    let filter = Filter::new(Condition::eq("cat", "nonexistent"));
+    let results = coll
+        .search_with_filter(&[1.0, 0.0, 0.0, 0.0], 10, &filter)
+        .unwrap();
+
+    assert!(results.is_empty());
+}
+
+// ─── search_ids() ───────────────────────────────────────────────────────────
+
+#[test]
+fn test_search_ids_returns_id_score_pairs() {
+    let (coll, _dir) = create_test_vc();
+    seed_points(&coll);
+
+    let results = coll.search_ids(&[1.0, 0.0, 0.0, 0.0], 3).unwrap();
+
+    assert_eq!(results.len(), 3);
+    // Exact match (id=1) should be closest.
+    assert_eq!(results[0].id, 1);
+    // Scores should be non-negative for cosine distance.
+    for r in &results {
+        assert!(r.score >= 0.0, "cosine scores should be non-negative");
+    }
+}
+
+#[test]
+fn test_search_ids_empty_collection() {
+    let (coll, _dir) = create_test_vc();
+
+    let results = coll.search_ids(&[1.0, 0.0, 0.0, 0.0], 5).unwrap();
+
+    assert!(results.is_empty());
+}
+
+// ─── hybrid_search() ────────────────────────────────────────────────────────
+
+#[test]
+fn test_hybrid_search_combines_vector_and_text() {
+    let (coll, _dir) = create_test_vc();
+    seed_points(&coll);
+
+    let results = coll
+        .hybrid_search(&[1.0, 0.0, 0.0, 0.0], "hello", 5, None)
+        .unwrap();
+
+    // Point id=1 is both the vector nearest neighbor AND contains "hello",
+    // so it should rank at or near the top.
+    assert!(!results.is_empty());
+    let ids: Vec<u64> = results.iter().map(|r| r.point.id).collect();
+    assert!(ids.contains(&1), "id=1 should appear in hybrid results");
+}
+
+#[test]
+fn test_hybrid_search_with_alpha() {
+    let (coll, _dir) = create_test_vc();
+    seed_points(&coll);
+
+    // alpha=1.0 should heavily weight vector similarity.
+    let results = coll
+        .hybrid_search(&[1.0, 0.0, 0.0, 0.0], "hello", 3, Some(1.0))
+        .unwrap();
+
+    assert!(!results.is_empty());
+}
+
+#[test]
+fn test_hybrid_search_empty_collection() {
+    let (coll, _dir) = create_test_vc();
+
+    let results = coll
+        .hybrid_search(&[1.0, 0.0, 0.0, 0.0], "hello", 5, None)
+        .unwrap();
+
+    assert!(results.is_empty());
+}
+
+// ─── execute_query() ────────────────────────────────────────────────────────
+
+#[test]
+fn test_execute_query_select_all_with_limit() {
+    let (coll, _dir) = create_test_vc();
+    seed_points(&coll);
+
+    let query = crate::velesql::Parser::parse("SELECT * FROM coll LIMIT 3;").unwrap();
+    let params = HashMap::new();
+    let results = coll.execute_query(&query, &params).unwrap();
+
+    assert!(results.len() <= 3);
+}
+
+#[test]
+fn test_execute_query_with_where_clause() {
+    let (coll, _dir) = create_test_vc();
+    seed_points(&coll);
+
+    let query =
+        crate::velesql::Parser::parse("SELECT * FROM coll WHERE cat = 'a' LIMIT 10;").unwrap();
+    let params = HashMap::new();
+    let results = coll.execute_query(&query, &params).unwrap();
+
+    for r in &results {
+        let cat = r
+            .point
+            .payload
+            .as_ref()
+            .and_then(|p| p.get("cat"))
+            .and_then(|v| v.as_str());
+        assert_eq!(cat, Some("a"));
+    }
+}
+
+// ─── execute_query_str() ────────────────────────────────────────────────────
+
+#[test]
+fn test_execute_query_str_basic() {
+    let (coll, _dir) = create_test_vc();
+    seed_points(&coll);
+
+    let params = HashMap::new();
+    let results = coll
+        .execute_query_str("SELECT * FROM coll LIMIT 5;", &params)
+        .unwrap();
+
+    assert!(results.len() <= 5);
+}
+
+#[test]
+fn test_execute_query_str_invalid_sql_returns_error() {
+    let (coll, _dir) = create_test_vc();
+    let params = HashMap::new();
+
+    let result = coll.execute_query_str("THIS IS NOT SQL", &params);
+
+    assert!(result.is_err(), "invalid SQL should produce an error");
+}
+
+#[test]
+fn test_execute_query_str_with_filter() {
+    let (coll, _dir) = create_test_vc();
+    seed_points(&coll);
+
+    let params = HashMap::new();
+    let results = coll
+        .execute_query_str("SELECT * FROM coll WHERE cat = 'b' LIMIT 10;", &params)
+        .unwrap();
+
+    for r in &results {
+        let cat = r
+            .point
+            .payload
+            .as_ref()
+            .and_then(|p| p.get("cat"))
+            .and_then(|v| v.as_str());
+        assert_eq!(cat, Some("b"));
+    }
+}
+
+#[test]
+fn test_execute_query_str_returns_consistent_results() {
+    let (coll, _dir) = create_test_vc();
+    seed_points(&coll);
+
+    let params = HashMap::new();
+    let sql = "SELECT * FROM coll LIMIT 3;";
+
+    let r1 = coll.execute_query_str(sql, &params).unwrap();
+    let r2 = coll.execute_query_str(sql, &params).unwrap();
+
+    assert_eq!(
+        r1.len(),
+        r2.len(),
+        "repeated queries should return the same count"
+    );
+}

--- a/crates/velesdb-core/src/database/graph_ops_tests.rs
+++ b/crates/velesdb-core/src/database/graph_ops_tests.rs
@@ -1,0 +1,176 @@
+//! Tests for graph collection creation and retrieval via [`Database`].
+
+#![allow(deprecated)] // Tests use legacy Collection via get_collection().
+
+use super::*;
+use crate::collection::{EdgeType, GraphSchema, NodeType};
+use crate::DistanceMetric;
+use tempfile::tempdir;
+
+// =========================================================================
+// create_graph_collection — schemaless
+// =========================================================================
+
+#[test]
+fn test_create_graph_collection_schemaless() {
+    let dir = tempdir().unwrap();
+    let db = Database::open(dir.path()).unwrap();
+
+    db.create_graph_collection("kg", GraphSchema::schemaless())
+        .unwrap();
+
+    assert!(db.list_collections().contains(&"kg".to_string()));
+}
+
+#[test]
+fn test_create_graph_collection_with_strict_schema() {
+    let dir = tempdir().unwrap();
+    let db = Database::open(dir.path()).unwrap();
+
+    let schema = GraphSchema::new()
+        .with_node_type(NodeType::new("Person"))
+        .with_edge_type(EdgeType::new("KNOWS", "Person", "Person"));
+
+    db.create_graph_collection("social", schema).unwrap();
+
+    let gc = db.get_graph_collection("social").unwrap();
+    assert_eq!(gc.name(), "social");
+    assert!(!gc.schema().is_schemaless());
+    assert!(gc.schema().has_node_type("Person"));
+    assert!(gc.schema().has_edge_type("KNOWS"));
+}
+
+// =========================================================================
+// create_graph_collection_with_embeddings
+// =========================================================================
+
+#[test]
+fn test_create_graph_collection_with_embeddings() {
+    let dir = tempdir().unwrap();
+    let db = Database::open(dir.path()).unwrap();
+
+    db.create_graph_collection_with_embeddings(
+        "kg_embed",
+        GraphSchema::schemaless(),
+        128,
+        DistanceMetric::Cosine,
+    )
+    .unwrap();
+
+    let gc = db.get_graph_collection("kg_embed").unwrap();
+    assert_eq!(gc.name(), "kg_embed");
+    assert!(gc.has_embeddings());
+}
+
+// =========================================================================
+// create_graph_collection_from_type (pub(super) helper)
+// =========================================================================
+
+#[test]
+fn test_create_graph_collection_from_type() {
+    let dir = tempdir().unwrap();
+    let db = Database::open(dir.path()).unwrap();
+
+    let schema = GraphSchema::schemaless();
+    db.create_graph_collection_from_type("typed_kg", Some(64), DistanceMetric::Euclidean, &schema)
+        .unwrap();
+
+    let gc = db.get_graph_collection("typed_kg").unwrap();
+    assert_eq!(gc.name(), "typed_kg");
+    assert!(gc.has_embeddings());
+}
+
+#[test]
+fn test_create_graph_collection_from_type_no_dimension() {
+    let dir = tempdir().unwrap();
+    let db = Database::open(dir.path()).unwrap();
+
+    let schema = GraphSchema::schemaless();
+    db.create_graph_collection_from_type("plain_kg", None, DistanceMetric::Cosine, &schema)
+        .unwrap();
+
+    let gc = db.get_graph_collection("plain_kg").unwrap();
+    assert!(!gc.has_embeddings());
+}
+
+// =========================================================================
+// get_graph_collection — Some / None
+// =========================================================================
+
+#[test]
+fn test_get_graph_collection_returns_none_for_absent() {
+    let dir = tempdir().unwrap();
+    let db = Database::open(dir.path()).unwrap();
+
+    assert!(db.get_graph_collection("nonexistent").is_none());
+}
+
+#[test]
+fn test_get_graph_collection_returns_created() {
+    let dir = tempdir().unwrap();
+    let db = Database::open(dir.path()).unwrap();
+
+    db.create_graph_collection("g1", GraphSchema::schemaless())
+        .unwrap();
+
+    let gc = db.get_graph_collection("g1");
+    assert!(gc.is_some());
+    assert_eq!(gc.unwrap().name(), "g1");
+}
+
+// =========================================================================
+// Duplicate name should return error
+// =========================================================================
+
+#[test]
+fn test_create_duplicate_graph_collection_returns_error() {
+    let dir = tempdir().unwrap();
+    let db = Database::open(dir.path()).unwrap();
+
+    db.create_graph_collection("dup_graph", GraphSchema::schemaless())
+        .unwrap();
+
+    let err = db
+        .create_graph_collection("dup_graph", GraphSchema::schemaless())
+        .unwrap_err();
+    assert!(matches!(err, crate::Error::CollectionExists(_)));
+}
+
+#[test]
+fn test_duplicate_name_across_types_graph_vs_vector() {
+    let dir = tempdir().unwrap();
+    let db = Database::open(dir.path()).unwrap();
+
+    db.create_graph_collection("shared", GraphSchema::schemaless())
+        .unwrap();
+
+    let err = db
+        .create_vector_collection("shared", 64, DistanceMetric::Cosine)
+        .unwrap_err();
+    assert!(matches!(err, crate::Error::CollectionExists(_)));
+}
+
+// =========================================================================
+// Schema version increments after creation
+// =========================================================================
+
+#[test]
+fn test_schema_version_increments_on_graph_creation() {
+    let dir = tempdir().unwrap();
+    let db = Database::open(dir.path()).unwrap();
+
+    let v0 = db.schema_version();
+
+    db.create_graph_collection("g_v1", GraphSchema::schemaless())
+        .unwrap();
+    assert_eq!(db.schema_version(), v0 + 1);
+
+    db.create_graph_collection_with_embeddings(
+        "g_v2",
+        GraphSchema::schemaless(),
+        32,
+        DistanceMetric::Cosine,
+    )
+    .unwrap();
+    assert_eq!(db.schema_version(), v0 + 2);
+}

--- a/crates/velesdb-core/src/database/mod.rs
+++ b/crates/velesdb-core/src/database/mod.rs
@@ -35,6 +35,8 @@ mod collection_ops_tests;
 #[cfg(all(test, feature = "persistence"))]
 mod database_tests;
 #[cfg(all(test, feature = "persistence"))]
+mod graph_ops_tests;
+#[cfg(all(test, feature = "persistence"))]
 mod query_engine_tests;
 #[cfg(all(test, feature = "persistence"))]
 mod stats_tests;

--- a/integrations/langchain/src/langchain_velesdb/graph_retriever.py
+++ b/integrations/langchain/src/langchain_velesdb/graph_retriever.py
@@ -311,7 +311,7 @@ class GraphRetriever(BaseRetriever):
         retrieval_mode = "graph_expanded" if graph_available else "vector_fallback"
         result_docs: List[Document] = []
 
-        for doc_id, (doc, score) in seed_docs.items():
+        for _doc_id, (doc, score) in seed_docs.items():
             doc.metadata["graph_depth"] = 0
             doc.metadata["relevance_score"] = score
             doc.metadata["retrieval_mode"] = retrieval_mode

--- a/integrations/langchain/src/langchain_velesdb/memory.py
+++ b/integrations/langchain/src/langchain_velesdb/memory.py
@@ -146,7 +146,7 @@ class VelesDBChatMemory(BaseChatMemory):
     def _events_to_messages(self, events: List) -> List[BaseMessage]:
         """Convert episodic events to LangChain messages."""
         messages = []
-        for event_id, description, timestamp in events:
+        for _event_id, description, _timestamp in events:
             try:
                 data = json.loads(description)
                 role = data.get("role", "human")
@@ -165,7 +165,7 @@ class VelesDBChatMemory(BaseChatMemory):
     def _events_to_string(self, events: List) -> str:
         """Convert episodic events to formatted string."""
         lines = []
-        for event_id, description, timestamp in events:
+        for _event_id, description, _timestamp in events:
             try:
                 data = json.loads(description)
                 role = data.get("role", "human")

--- a/integrations/langchain/src/langchain_velesdb/security.py
+++ b/integrations/langchain/src/langchain_velesdb/security.py
@@ -23,7 +23,6 @@ MAX_SPARSE_VECTOR_SIZE = 100_000  # Max entries in a sparse vector
 
 class SecurityError(ValueError):
     """Raised when a security validation fails."""
-    pass
 
 
 def validate_path(path: str) -> str:

--- a/integrations/llamaindex/src/llamaindex_velesdb/graph_retriever.py
+++ b/integrations/llamaindex/src/llamaindex_velesdb/graph_retriever.py
@@ -327,7 +327,7 @@ class GraphRetriever(BaseRetriever):
         retrieval_mode = "graph_expanded" if graph_available else "vector_fallback"
         results: List[NodeWithScore] = []
 
-        for node_id, nws in seed_map.items():
+        for _node_id, nws in seed_map.items():
             nws.node.metadata["graph_depth"] = 0
             nws.node.metadata["retrieval_mode"] = retrieval_mode
             results.append(nws)

--- a/integrations/llamaindex/src/llamaindex_velesdb/search_ops.py
+++ b/integrations/llamaindex/src/llamaindex_velesdb/search_ops.py
@@ -10,7 +10,6 @@ import logging
 import warnings
 from typing import Any, List, Optional
 
-from llama_index.core.schema import TextNode
 from llama_index.core.vector_stores.types import (
     VectorStoreQuery,
     VectorStoreQueryResult,

--- a/integrations/llamaindex/src/llamaindex_velesdb/security.py
+++ b/integrations/llamaindex/src/llamaindex_velesdb/security.py
@@ -24,7 +24,6 @@ DEFAULT_TIMEOUT_MS = 30_000  # 30 seconds max timeout
 
 class SecurityError(ValueError):
     """Raised when a security validation fails."""
-    pass
 
 
 def validate_path(path: str) -> str:

--- a/integrations/llamaindex/src/llamaindex_velesdb/vectorstore.py
+++ b/integrations/llamaindex/src/llamaindex_velesdb/vectorstore.py
@@ -13,7 +13,6 @@ from typing import Any, List, Optional
 from llama_index.core.schema import BaseNode, TextNode
 from llama_index.core.vector_stores.types import (
     BasePydanticVectorStore,
-    VectorStoreQuery,
     VectorStoreQueryResult,
 )
 from pydantic import ConfigDict, PrivateAttr
@@ -22,14 +21,10 @@ import velesdb
 
 from llamaindex_velesdb.security import (
     validate_path,
-    validate_k,
-    validate_text,
-    validate_query,
     validate_metric,
     validate_storage_mode,
     validate_batch_size,
     validate_collection_name,
-    validate_weight,
     validate_sparse_vector,
 )
 from llamaindex_velesdb.filter_ops import metadata_filters_to_core_filter

--- a/scripts/local-ci.ps1
+++ b/scripts/local-ci.ps1
@@ -133,6 +133,32 @@ try {
     $errors += "TODO-Governance"
 }
 
+# ============================================================================
+# Check: Codacy CLI static analysis (WSL required)
+# ============================================================================
+Write-Step "Check: Codacy CLI static analysis"
+try {
+    $wslCheck = wsl -- bash -c "which codacy-cli 2>/dev/null" 2>&1
+    if ($LASTEXITCODE -eq 0) {
+        $codacyOutput = wsl -- bash -c "cd /mnt/d/Projets-dev/velesDB/velesdb-core && codacy-cli analyze 2>&1"
+        if ($LASTEXITCODE -ne 0) { throw "Codacy CLI failed" }
+        $findingsLine = $codacyOutput | Select-String "findings\." | Select-Object -Last 1
+        if ($findingsLine -match "0 findings") {
+            Write-Success "Codacy CLI: 0 findings"
+        } else {
+            Write-Fail "Codacy CLI found issues:"
+            Write-Output $findingsLine
+            $errors += "CodacyCLI"
+        }
+    } else {
+        Write-Warn "Codacy CLI not installed in WSL - skipping"
+        Write-Output "   Install: https://docs.codacy.com/related-tools/local-analysis/client-side-tools/"
+    }
+} catch {
+    Write-Fail "Codacy CLI analysis failed!"
+    $errors += "CodacyCLI"
+}
+
 if ($Quick) {
     Write-Warn "Quick mode - skipping tests and security audit"
 } else {


### PR DESCRIPTION
## Summary

- **New tests (~1000 lines)**: Agent memory eviction/TTL/snapshots (US-005), CART node growth, metadata collection ops, vector search pipeline, graph database operations
- **Codacy hardening**: Extended `.codacy.yml` exclusions for SIMD NEON/trigram, alloc_guard, internal_bench, HNSW beam search; streamlined CLI config; added Codacy coverage upload in CI; integrated Codacy CLI check in `local-ci.ps1`
- **Supply-chain safety**: Pinned GitHub Actions to SHA in release workflow; added `.semgrepignore` mirroring `.codacy.yml`
- **Python lint fixes**: Prefixed unused loop vars with `_`, removed redundant `pass` statements, removed unused imports across LangChain and LlamaIndex integrations

## Test plan

- [ ] CI passes (fmt + clippy + tests)
- [ ] New Rust tests pass: `cargo test -p velesdb-core --features persistence -- --test-threads=1`
- [ ] Codacy analysis shows no new findings on changed files
- [ ] Python integration modules still importable

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/334" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
