### PR TITLE
fix: align install scripts with actual release asset names

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -38,7 +38,7 @@ function Install-VelesDB {
     
     Write-Host "📦 Latest version: v$version" -ForegroundColor Green
     
-    $archiveName = "velesdb-windows-x86_64.zip"
+    $archiveName = "velesdb-x86_64-pc-windows-msvc.zip"
     $downloadUrl = "https://github.com/$Repo/releases/download/v$version/$archiveName"
     
     # Create install directory

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -72,11 +72,12 @@ install_velesdb() {
     
     echo -e "${GREEN}📦 Latest version: v${version}${NC}"
     
-    # Construct download URL
+    # Construct download URL (matches GitHub Release asset names)
     case "$platform" in
-        linux-x86_64)  archive_name="velesdb-linux-x86_64.tar.gz" ;;
-        macos-x86_64)  archive_name="velesdb-macos-x86_64.tar.gz" ;;
-        macos-aarch64) archive_name="velesdb-macos-aarch64.tar.gz" ;;
+        linux-x86_64)  archive_name="velesdb-x86_64-unknown-linux-gnu.tar.gz" ;;
+        macos-x86_64)  archive_name="velesdb-x86_64-apple-darwin.tar.gz" ;;
+        macos-aarch64) archive_name="velesdb-aarch64-apple-darwin.tar.gz" ;;
+        linux-aarch64) archive_name="velesdb-aarch64-unknown-linux-gnu.tar.gz" ;;
         *)             echo -e "${RED}❌ No binary available for ${platform}${NC}"; exit 1 ;;
     esac
     
@@ -100,6 +101,7 @@ install_velesdb() {
     echo -e "${YELLOW}🔗 Creating symlinks...${NC}"
     ln -sf "$INSTALL_DIR/velesdb" "$BIN_DIR/velesdb"
     ln -sf "$INSTALL_DIR/velesdb-server" "$BIN_DIR/velesdb-server"
+    [ -f "$INSTALL_DIR/velesdb-migrate" ] && ln -sf "$INSTALL_DIR/velesdb-migrate" "$BIN_DIR/velesdb-migrate"
     
     # Cleanup
     rm -rf "$tmp_dir"


### PR DESCRIPTION
## Summary
- Fix install.sh: archive names didn't match GitHub Release assets (scripts would 404)
- Fix install.ps1: same issue for Windows
- Add linux-aarch64 support and velesdb-migrate symlink
- Verified all 4 platform URLs resolve against v1.6.0 release

## Test plan
- [x] Verified HTTP 200/302 for all 4 download URLs
- [x] Verified tar.gz contents match expected binary names

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/339" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
