### PR TITLE
fix: address post-refactor regressions from Devin review

### DIFF
--- a/crates/velesdb-core/src/quantization/rabitq.rs
+++ b/crates/velesdb-core/src/quantization/rabitq.rs
@@ -135,6 +135,8 @@ struct PreparedQuery {
     bits: Vec<u64>,
     /// Number of u64 words in the bit representation.
     num_words: usize,
+    /// Rotated normalized vector (used by encode for correction factors).
+    rotated: Vec<f32>,
 }
 
 impl RaBitQIndex {
@@ -165,6 +167,7 @@ impl RaBitQIndex {
             norm,
             bits,
             num_words,
+            rotated,
         })
     }
 
@@ -211,24 +214,13 @@ impl RaBitQIndex {
             });
         };
 
-        // Recompute the rotated normalized vector for correction factor calculation.
-        // prepare_query already does this work but only returns bits. We need the
-        // full rotated values for the quantization inner product computation.
-        let centered: Vec<f32> = vector
-            .iter()
-            .zip(self.centroid.iter())
-            .map(|(&v, &c)| v - c)
-            .collect();
-        let normalized: Vec<f32> = centered.iter().map(|&x| x / pq.norm).collect();
-        let rotated = apply_rotation_flat(&self.rotation, &normalized, self.dimension);
-
         // Compute correction factors
         // The binary reconstruction maps each sign bit to +1/-1, scaled by 1/sqrt(D).
         // quantization_inner_product = <binary_reconstruction, rotated_normalized>
         #[allow(clippy::cast_precision_loss)]
         let scale = 1.0 / (self.dimension as f32).sqrt();
         let mut qip: f32 = 0.0;
-        for (i, &rv) in rotated.iter().enumerate().take(self.dimension) {
+        for (i, &rv) in pq.rotated.iter().enumerate().take(self.dimension) {
             let word = i / 64;
             let bit = i % 64;
             let sign = if (pq.bits[word] >> bit) & 1 == 1 {

--- a/crates/velesdb-core/src/velesql/parser/helpers.rs
+++ b/crates/velesdb-core/src/velesql/parser/helpers.rs
@@ -39,7 +39,7 @@ pub(crate) fn compare_op_from_str(op: &str) -> Result<CompareOp, ParseError> {
 /// Returns [`ParseError`] if the input cannot be recognized as any value type.
 pub(crate) fn parse_value_from_str(input: &str) -> Result<Value, ParseError> {
     if input.len() >= 2 && input.starts_with('\'') && input.ends_with('\'') {
-        return Ok(Value::String(input.trim_matches('\'').to_string()));
+        return Ok(Value::String(input[1..input.len() - 1].to_string()));
     }
     if input.eq_ignore_ascii_case("true") {
         return Ok(Value::Boolean(true));

--- a/crates/velesdb-wasm/src/filter.rs
+++ b/crates/velesdb-wasm/src/filter.rs
@@ -52,11 +52,13 @@ pub fn evaluate_condition(payload: &Value, condition: &Value) -> bool {
         "neq" => match extract_field_pair(payload, condition) {
             Some((pv, v)) => pv != v,
             None => {
-                // neq is true when the field is missing entirely
-                condition
-                    .get("field")
-                    .and_then(|f| f.as_str())
-                    .is_some_and(|field| get_nested_field(payload, field).is_none())
+                // No condition value → neq always true (backward compat).
+                // Condition value present but field missing → also true.
+                condition.get("value").is_none()
+                    || condition
+                        .get("field")
+                        .and_then(|f| f.as_str())
+                        .is_some_and(|field| get_nested_field(payload, field).is_none())
             }
         },
         "gt" => compare_numeric(payload, condition, |pv, v| pv > v),

--- a/sdks/typescript/src/query-builder.ts
+++ b/sdks/typescript/src/query-builder.ts
@@ -20,6 +20,9 @@
 
 import type { FusionStrategy } from './types';
 
+/** Re-export FusionStrategy for backwards compatibility */
+export type { FusionStrategy } from './types';
+
 /** Direction for relationship traversal */
 export type RelDirection = 'outgoing' | 'incoming' | 'both';
 


### PR DESCRIPTION
## Summary

Fixes 4 regressions introduced by the code deduplication refactor (#345), identified by Devin code review:

- **VelesQL parser** (`helpers.rs`): `trim_matches('\'')` strips all leading/trailing quotes instead of exactly one from each end — replaced with slice `[1..len-1]`
- **RaBitQ encode** (`rabitq.rs`): `prepare_query` computed centered/normalized/rotated vectors but only returned bits, forcing `encode` to redo the same work — now stores `rotated` in `PreparedQuery` to eliminate redundant computation
- **WASM filter neq** (`filter.rs`): refactored `neq` condition returned `false` for malformed conditions missing a `"value"` key (old behavior: `true`) — restored backward-compatible semantics
- **TypeScript SDK** (`query-builder.ts`): `FusionStrategy` was imported from `types.ts` but no longer re-exported — added `export type { FusionStrategy }` for backward compatibility

## Test plan

- [x] `cargo check --workspace` passes
- [x] `cargo clippy --workspace --all-targets -D warnings -D clippy::pedantic` — 0 warnings
- [x] WASM tests: 87/87 + conformance OK
- [x] VelesQL parser helpers tests: 14/14 OK
- [x] Codacy CLI analysis: no new findings on modified files

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/346" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
