### PR TITLE
fix: add missing SAFETY comments for clippy 1.94

### DIFF
--- a/crates/velesdb-core/benches/scalability_benchmark.rs
+++ b/crates/velesdb-core/benches/scalability_benchmark.rs
@@ -76,6 +76,7 @@ fn get_memory_usage() -> usize {
         fn GetCurrentProcess() -> isize;
     }
 
+    // SAFETY: FFI call to Windows GetProcessMemoryInfo — struct is zeroed and cb is set correctly.
     unsafe {
         let mut pmc = MaybeUninit::<ProcessMemoryCounters>::zeroed().assume_init();
         pmc.cb = std::mem::size_of::<ProcessMemoryCounters>() as u32;

--- a/crates/velesdb-core/src/perf_optimizations_tests.rs
+++ b/crates/velesdb-core/src/perf_optimizations_tests.rs
@@ -283,6 +283,7 @@ fn test_get_unchecked_valid_index() {
     // - Condition 1: Two vectors were pushed above, so indices 0 and 1 are valid.
     // Reason: Verify that `get_unchecked` returns correct data for in-bounds access.
     let v0 = unsafe { cv.get_unchecked(0) };
+    // SAFETY: index 1 is valid — two vectors were pushed above.
     let v1 = unsafe { cv.get_unchecked(1) };
 
     // Assert

--- a/crates/velesdb-core/src/simd_native/adc.rs
+++ b/crates/velesdb-core/src/simd_native/adc.rs
@@ -49,6 +49,7 @@ pub(crate) fn adc_distances_batch(lut: &[f32], codes: &[&[u16]], m: usize) -> Ve
                     if i + 1 < codes.len() {
                         super::prefetch::prefetch_vector_from_u16(codes[i + 1]);
                     }
+                    // SAFETY: AVX2 ADC gather kernel — `simd_level()` confirmed Avx2/Avx512 above.
                     unsafe { adc_single_avx2(lut, c, m, k) }
                 })
                 .collect()


### PR DESCRIPTION
## Summary

- Add `// SAFETY:` comment directly above `unsafe` block in `simd_native/adc.rs` (AVX2 ADC kernel)
- Add `// SAFETY:` comment for second `get_unchecked` call in `perf_optimizations_tests.rs`
- Add `// SAFETY:` comment for FFI `GetProcessMemoryInfo` call in `scalability_benchmark.rs`

Clippy 1.94 enforces `undocumented_unsafe_blocks` — each `unsafe` block needs its own SAFETY comment on the immediately preceding line, not just on a parent scope.

## Test plan

- [x] `cargo clippy -p velesdb-core --all-targets -D clippy::undocumented-unsafe-blocks` passes

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/353" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
