### PR TITLE
perf(hnsw): parallelize Phase 2 reranking in batch search

### DIFF
--- a/crates/velesdb-core/src/index/hnsw/index/batch.rs
+++ b/crates/velesdb-core/src/index/hnsw/index/batch.rs
@@ -250,11 +250,13 @@ impl HnswIndex {
             })
             .collect();
 
-        // Update EMA once with mean latency from the entire batch
-        let n = timed_results.len() as u64;
-        if n > 0 {
-            let total_us: u64 = timed_results.iter().map(|(_, e)| e).sum();
-            self.update_rerank_latency_ema(total_us / n);
+        // Update EMA once with mean latency from non-empty reranks only.
+        // Skip elapsed == 0 entries (empty candidates) to avoid diluting the
+        // EMA toward zero, consistent with the single-query guard.
+        let non_zero: Vec<u64> = timed_results.iter().map(|(_, e)| *e).filter(|&e| e > 0).collect();
+        if !non_zero.is_empty() {
+            let mean = non_zero.iter().copied().sum::<u64>() / non_zero.len() as u64;
+            self.update_rerank_latency_ema(mean);
         }
 
         timed_results.into_iter().map(|(r, _)| r).collect()

--- a/crates/velesdb-core/src/index/hnsw/index/batch.rs
+++ b/crates/velesdb-core/src/index/hnsw/index/batch.rs
@@ -240,12 +240,24 @@ impl HnswIndex {
             .map(|query| self.search_hnsw_only(query, rerank_k, ef_search))
             .collect();
 
-        // Phase 2: Rerank each query's candidates and truncate to k
-        queries
-            .iter()
-            .zip(all_candidates.iter())
-            .map(|(query, candidates)| self.rerank_sort_and_truncate(query, candidates, k))
-            .collect()
+        // Phase 2: Rerank in parallel, collecting per-query latencies to avoid
+        // EMA race (concurrent Relaxed store would lose ~N-1 samples).
+        let timed_results: Vec<(Vec<ScoredResult>, u64)> = queries
+            .par_iter()
+            .zip(all_candidates.par_iter())
+            .map(|(query, candidates)| {
+                self.rerank_sort_and_truncate_timed(query, candidates, k)
+            })
+            .collect();
+
+        // Update EMA once with mean latency from the entire batch
+        let n = timed_results.len() as u64;
+        if n > 0 {
+            let total_us: u64 = timed_results.iter().map(|(_, e)| e).sum();
+            self.update_rerank_latency_ema(total_us / n);
+        }
+
+        timed_results.into_iter().map(|(r, _)| r).collect()
     }
 
     /// Performs exact brute-force search in parallel using rayon.

--- a/crates/velesdb-core/src/index/hnsw/index/search.rs
+++ b/crates/velesdb-core/src/index/hnsw/index/search.rs
@@ -154,7 +154,7 @@ impl HnswIndex {
     /// This is acceptable because the EMA is a best-effort heuristic for latency
     /// adaptation -- occasional lost samples do not affect search correctness and
     /// the overhead of a CAS retry loop is not justified for an advisory metric.
-    fn update_rerank_latency_ema(&self, sample_us: u64) {
+    pub(super) fn update_rerank_latency_ema(&self, sample_us: u64) {
         let current = self.rerank_latency_ema_us.load(Ordering::Relaxed);
         if current == 0 {
             self.rerank_latency_ema_us
@@ -336,8 +336,25 @@ impl HnswIndex {
         candidates: &[ScoredResult],
         k: usize,
     ) -> Vec<ScoredResult> {
+        let (results, elapsed) = self.rerank_sort_and_truncate_timed(query, candidates, k);
+        if elapsed > 0 {
+            self.update_rerank_latency_ema(elapsed);
+        }
+        results
+    }
+
+    /// Reranks, sorts, and truncates without updating the EMA.
+    ///
+    /// Returns `(results, elapsed_us)` so the caller can aggregate latencies
+    /// from a parallel batch and update the EMA once (avoiding lost samples).
+    pub(super) fn rerank_sort_and_truncate_timed(
+        &self,
+        query: &[f32],
+        candidates: &[ScoredResult],
+        k: usize,
+    ) -> (Vec<ScoredResult>, u64) {
         if candidates.is_empty() {
-            return Vec::new();
+            return (Vec::new(), 0);
         }
 
         let rerank_start = Instant::now();
@@ -349,8 +366,7 @@ impl HnswIndex {
 
         let elapsed_micros = rerank_start.elapsed().as_micros();
         let elapsed = u64::try_from(elapsed_micros).unwrap_or(u64::MAX);
-        self.update_rerank_latency_ema(elapsed);
-        reranked
+        (reranked, elapsed)
     }
 
     /// Re-ranks candidates using the best available compute path.


### PR DESCRIPTION
## Summary

- Phase 2 of `search_batch_with_rerank` used sequential `.iter()` while Phase 1 already used `par_iter()`. Now both phases are parallel.
- `rerank_sort_and_truncate` is `&self` (read-only via `parking_lot::RwLock`), safe for concurrent execution.
- GPU dispatch internally serializes on the device queue — no contention risk.

## Impact

- **SIMD-only reranking** (common case below GPU threshold): ~Nx speedup where N = min(num_queries, num_cores)
- **GPU reranking**: no change (GPU serializes internally)

## Quality checks

- `cargo check --workspace` — OK
- `cargo clippy -p velesdb-core --features persistence,gpu -D warnings -D clippy::pedantic` — 0 warnings
- 141 batch-related tests — 0 failures (1 pre-existing flaky perf test excluded)

## Test plan

- [x] All 141 batch search tests pass
- [x] GPU rerank tests pass (`test_batch_search_gpu_rerank_matches_cpu`)
- [x] Flaky `test_batch_product_indexing_performance` confirmed pre-existing (fails without change too)

Closes #360

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/361" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
