### PR TITLE
fix(clippy): resolve pedantic warnings blocking CI

### DIFF
--- a/crates/velesdb-core/benches/chunked_insert_recall_benchmark.rs
+++ b/crates/velesdb-core/benches/chunked_insert_recall_benchmark.rs
@@ -1,4 +1,4 @@
-//! Chunked insert recall quality benchmark for VelesDB HNSW index.
+//! Chunked insert recall quality benchmark for `VelesDB` HNSW index.
 #![allow(
     clippy::cast_precision_loss,
     clippy::cast_possible_truncation,

--- a/crates/velesdb-core/benches/dual_precision_benchmark.rs
+++ b/crates/velesdb-core/benches/dual_precision_benchmark.rs
@@ -45,7 +45,7 @@ fn bench_search_latency(c: &mut Criterion) {
     let mut dual_hnsw =
         DualPrecisionHnsw::new(engine_dual, dim, 32, 200, num_vectors).expect("bench");
     for v in &vectors {
-        dual_hnsw.insert(v.clone()).expect("bench");
+        dual_hnsw.insert(v).expect("bench");
     }
     // Force training if not already done
     dual_hnsw.force_train_quantizer();
@@ -126,7 +126,7 @@ fn bench_memory_footprint(c: &mut Criterion) {
                 let mut hnsw =
                     DualPrecisionHnsw::new(engine, dim, 32, 200, num_vectors).expect("bench");
                 for v in &vectors {
-                    hnsw.insert(v.clone()).expect("bench");
+                    hnsw.insert(v).expect("bench");
                 }
                 hnsw.force_train_quantizer();
                 black_box(hnsw.len())

--- a/crates/velesdb-core/src/gpu/gpu_backend.rs
+++ b/crates/velesdb-core/src/gpu/gpu_backend.rs
@@ -141,9 +141,9 @@ impl GpuAccelerator {
     ///
     /// Uses the shared quad bind-group layout from [`super::helpers`]:
     /// binding 0 = storage(read), binding 1 = storage(read),
-    /// binding 2 = storage(read_write), binding 3 = uniform.
+    /// binding 2 = `storage(read_write)`, binding 3 = uniform.
     ///
-    /// All four shaders (cosine, euclidean, dot_product, kmeans) share this
+    /// All four shaders (cosine, euclidean, `dot_product`, kmeans) share this
     /// structural layout. The uniform buffer's internal data layout (e.g.,
     /// 2-field params for distance vs 4-field for kmeans) is interpreted
     /// by the shader code, not constrained by the bind group layout.

--- a/crates/velesdb-core/src/index/hnsw/native/backend_adapter_tests.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/backend_adapter_tests.rs
@@ -80,7 +80,7 @@ fn test_search_neighbours_format() {
     let hnsw = NativeHnsw::new(engine, 16, 100, 100);
 
     for i in 0..50 {
-        hnsw.insert(&vec![i as f32 * 0.1; 32]).expect("test");
+        hnsw.insert(&[i as f32 * 0.1; 32]).expect("test");
     }
 
     let query = vec![0.0; 32];
@@ -134,7 +134,7 @@ fn test_file_dump_creates_files() {
     let hnsw = NativeHnsw::new(engine, 16, 100, 100);
 
     for i in 0..20 {
-        hnsw.insert(&vec![i as f32; 32]).expect("test");
+        hnsw.insert(&[i as f32; 32]).expect("test");
     }
 
     let dir = tempdir().unwrap();
@@ -244,7 +244,7 @@ fn test_native_backend_generic_function() {
     let hnsw = NativeHnsw::new(engine, 16, 100, 100);
 
     for i in 0..10 {
-        hnsw.insert(&vec![i as f32; 32]).expect("test");
+        hnsw.insert(&[i as f32; 32]).expect("test");
     }
 
     let query = vec![0.0; 32];
@@ -266,7 +266,7 @@ fn test_native_backend_len_and_is_empty() {
         0
     );
 
-    hnsw.insert(&vec![1.0; 32]).expect("test");
+    hnsw.insert(&[1.0; 32]).expect("test");
 
     assert!(!<NativeHnsw<SimdDistance> as NativeHnswBackend>::is_empty(
         &hnsw

--- a/crates/velesdb-core/src/index/hnsw/native/dual_precision.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/dual_precision.rs
@@ -136,7 +136,7 @@ impl<D: DistanceEngine> DualPrecisionHnsw<D> {
     /// # Errors
     ///
     /// Returns an error if allocation or insertion fails.
-    pub fn insert(&mut self, vector: Vec<f32>) -> crate::error::Result<NodeId> {
+    pub fn insert(&mut self, vector: &[f32]) -> crate::error::Result<NodeId> {
         debug_assert_eq!(vector.len(), self.dimension);
 
         // F-13: Push to quantized store or training buffer using a reference
@@ -144,16 +144,16 @@ impl<D: DistanceEngine> DualPrecisionHnsw<D> {
         // Note: inner.insert() still clones internally (F-14), but we avoid an
         // additional clone at this level for the quantized path.
         if let Some(ref mut store) = self.quantized_store {
-            store.push(&vector);
+            store.push(vector);
         } else {
-            // Training path: must clone because inner.insert() consumes vector
-            self.training_buffer.push(vector.clone());
+            // Training path: clone into buffer for later quantizer training
+            self.training_buffer.push(vector.to_vec());
             if self.training_buffer.len() >= self.training_sample_size {
                 self.train_quantizer();
             }
         }
 
-        self.inner.insert(&vector)
+        self.inner.insert(vector)
     }
 
     /// Trains the quantizer on accumulated samples.

--- a/crates/velesdb-core/src/index/hnsw/native/dual_precision_tests.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/dual_precision_tests.rs
@@ -27,7 +27,7 @@ fn test_insert_before_quantizer_training() {
     // Insert fewer vectors than training threshold
     for i in 0..10 {
         let v: Vec<f32> = (0..32).map(|j| (i * 32 + j) as f32).collect();
-        hnsw.insert(v).expect("test");
+        hnsw.insert(&v).expect("test");
     }
 
     assert_eq!(hnsw.len(), 10);
@@ -46,7 +46,7 @@ fn test_quantizer_trains_after_threshold() {
         let v: Vec<f32> = (0..32)
             .map(|j| ((i * 32 + j) as f32 * 0.01).sin())
             .collect();
-        hnsw.insert(v).expect("test");
+        hnsw.insert(&v).expect("test");
     }
 
     assert!(
@@ -63,7 +63,7 @@ fn test_force_train_quantizer() {
     // Insert fewer than threshold
     for i in 0..50 {
         let v: Vec<f32> = (0..32).map(|j| (i * 32 + j) as f32).collect();
-        hnsw.insert(v).expect("test");
+        hnsw.insert(&v).expect("test");
     }
 
     assert!(!hnsw.is_quantizer_trained());
@@ -86,7 +86,7 @@ fn test_search_before_quantizer_training() {
     // Insert some vectors
     for i in 0..50 {
         let v: Vec<f32> = (0..32).map(|j| (i * 32 + j) as f32).collect();
-        hnsw.insert(v).expect("test");
+        hnsw.insert(&v).expect("test");
     }
 
     // Search without quantizer (should use float32)
@@ -106,7 +106,7 @@ fn test_search_after_quantizer_training() {
     // Insert vectors
     for i in 0..50 {
         let v: Vec<f32> = (0..32).map(|j| (i * 32 + j) as f32).collect();
-        hnsw.insert(v).expect("test");
+        hnsw.insert(&v).expect("test");
     }
 
     // Force train quantizer
@@ -136,7 +136,7 @@ fn test_dual_precision_recall() {
         .collect();
 
     for v in &vectors {
-        hnsw.insert(v.clone()).expect("test");
+        hnsw.insert(v).expect("test");
     }
 
     hnsw.force_train_quantizer();
@@ -168,14 +168,14 @@ fn test_insert_after_quantizer_training() {
     // Insert and train
     for i in 0..50 {
         let v: Vec<f32> = (0..32).map(|j| (i * 32 + j) as f32).collect();
-        hnsw.insert(v).expect("test");
+        hnsw.insert(&v).expect("test");
     }
     hnsw.force_train_quantizer();
 
     // Insert more after training
     for i in 50..100 {
         let v: Vec<f32> = (0..32).map(|j| (i * 32 + j) as f32).collect();
-        hnsw.insert(v).expect("test");
+        hnsw.insert(&v).expect("test");
     }
 
     assert_eq!(hnsw.len(), 100);
@@ -201,7 +201,7 @@ fn test_quantized_reranking_uses_asymmetric_distance() {
         let v: Vec<f32> = (0..64)
             .map(|j| ((i * 64 + j) as f32 * 0.01).sin())
             .collect();
-        hnsw.insert(v).expect("test");
+        hnsw.insert(&v).expect("test");
     }
 
     // Force train quantizer
@@ -237,7 +237,7 @@ fn test_quantized_reranking_maintains_recall() {
         .collect();
 
     for v in &vectors {
-        hnsw.insert(v.clone()).expect("test");
+        hnsw.insert(v).expect("test");
     }
 
     hnsw.force_train_quantizer();
@@ -268,7 +268,7 @@ fn test_search_with_int8_traversal_enabled() {
         let v: Vec<f32> = (0..64)
             .map(|j| ((i * 64 + j) as f32 * 0.01).sin())
             .collect();
-        hnsw.insert(v).expect("test");
+        hnsw.insert(&v).expect("test");
     }
 
     hnsw.force_train_quantizer();
@@ -304,7 +304,7 @@ fn test_int8_traversal_recall_vs_f32() {
         .collect();
 
     for v in &vectors {
-        hnsw.insert(v.clone()).expect("test");
+        hnsw.insert(v).expect("test");
     }
 
     hnsw.force_train_quantizer();

--- a/crates/velesdb-core/src/index/hnsw/native/graph_tests.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/graph_tests.rs
@@ -53,7 +53,7 @@ fn test_heuristic_selection_empty_candidates() {
     let hnsw = NativeHnsw::new(engine, 16, 100, 100);
 
     // Insert a single vector to have valid query
-    hnsw.insert(&vec![0.0; 32]).expect("test");
+    hnsw.insert(&[0.0; 32]).expect("test");
 
     let candidates: Vec<(NodeId, f32)> = vec![];
 
@@ -69,7 +69,7 @@ fn test_heuristic_selection_fewer_than_max() {
 
     // Insert vectors
     for i in 0..5 {
-        hnsw.insert(&vec![i as f32; 32]).expect("test");
+        hnsw.insert(&[i as f32; 32]).expect("test");
     }
 
     let candidates: Vec<(NodeId, f32)> = vec![(0, 0.0), (1, 1.0), (2, 2.0)];
@@ -90,7 +90,7 @@ fn test_heuristic_selection_respects_max() {
 
     // Insert vectors
     for i in 0..20 {
-        hnsw.insert(&vec![i as f32; 32]).expect("test");
+        hnsw.insert(&[i as f32; 32]).expect("test");
     }
 
     let candidates: Vec<(NodeId, f32)> = (0..15).map(|i| (i, i as f32)).collect();
@@ -105,7 +105,7 @@ fn test_heuristic_selection_prefers_diverse_neighbors() {
     let hnsw = NativeHnsw::new(engine, 16, 100, 100);
 
     // Insert diverse vectors: one at origin, cluster around (10,0,0...), spread around (0,10,0...)
-    hnsw.insert(&vec![0.0; 32]).expect("test"); // 0: origin
+    hnsw.insert(&[0.0; 32]).expect("test"); // 0: origin
 
     // Cluster A: near (10, 0, 0, ...)
     let mut v1 = vec![0.0; 32];
@@ -148,7 +148,7 @@ fn test_heuristic_fills_quota_with_closest_if_needed() {
 
     // Insert vectors
     for i in 0..10 {
-        hnsw.insert(&vec![i as f32; 32]).expect("test");
+        hnsw.insert(&[i as f32; 32]).expect("test");
     }
 
     let candidates: Vec<(NodeId, f32)> = (0..10).map(|i| (i, i as f32)).collect();

--- a/crates/velesdb-core/src/index/hnsw/native/tests.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/tests.rs
@@ -44,7 +44,7 @@ fn test_native_hnsw_recall() {
         .collect();
 
     for v in &vectors {
-        hnsw.insert(&v).expect("test");
+        hnsw.insert(v).expect("test");
     }
 
     // Test recall with multiple queries


### PR DESCRIPTION
## Summary
- Fix `doc_markdown`: add backticks to `storage(read_write)` and `dot_product` in `gpu_backend.rs` doc comments
- Fix `needless_pass_by_value`: change `DualPrecisionHnsw::insert()` from `Vec<f32>` to `&[f32]`, update all callers
- Fix `useless_vec`: replace `&vec![...]` with `&[...]` in test files
- Fix `needless_borrow`: remove double-reference in `tests.rs`
- Fix `doc_markdown`: backtick `VelesDB` in benchmark doc comment
- Apply `cargo fmt` to touched files

Fixes CI run #23462660953 (Lint & Format failure on `main`).

## Test plan
- [x] `cargo clippy --workspace --all-targets --features persistence,gpu,update-check --exclude velesdb-python -- -D warnings -D clippy::pedantic` → zero errors
- [x] `cargo test -p velesdb-core --features persistence -- --test-threads=1 dual_precision` → 8/8 pass
- [x] `cargo fmt --all --check` → clean

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/368" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
