### PR TITLE
perf(hnsw): search_layer batch SIMD + deferred indexing (#366)

### DIFF
--- a/crates/velesdb-core/Cargo.toml
+++ b/crates/velesdb-core/Cargo.toml
@@ -358,3 +358,7 @@ required-features = ["internal-bench"]
 [[bench]]
 name = "chunked_insert_recall_benchmark"
 harness = false
+
+[[bench]]
+name = "search_layer_benchmark"
+harness = false

--- a/crates/velesdb-core/benches/search_layer_benchmark.rs
+++ b/crates/velesdb-core/benches/search_layer_benchmark.rs
@@ -1,0 +1,109 @@
+//! Phase A.0 (#366): Baseline micro-benchmark for HNSW `search_layer` performance.
+//!
+//! Measures per-query `search()` latency on a pre-built `NativeHnsw` index.
+//! `search()` is the public entry point that internally calls `search_layer`
+//! (the hot path for both search and insert). By sweeping `ef_search` values
+//! we isolate the search-layer traversal cost at different recall budgets.
+//!
+//! # Run
+//!
+//! ```bash
+//! cargo bench -p velesdb-core --bench search_layer_benchmark -- --noplot
+//! ```
+
+#![allow(clippy::cast_precision_loss)]
+
+mod bench_helpers;
+
+use criterion::{
+    black_box, criterion_group, criterion_main, measurement::Measurement, BenchmarkGroup,
+    BenchmarkId, Criterion, Throughput,
+};
+use velesdb_core::index::hnsw::native::{CachedSimdDistance, NativeHnsw};
+use velesdb_core::DistanceMetric;
+
+/// Number of vectors pre-inserted into the index before benchmarking.
+const DATASET_SIZE: usize = 5_000;
+
+/// Number of distinct query vectors (rotated round-robin inside the bench loop).
+const NUM_QUERIES: usize = 100;
+
+/// Top-k results requested per search call.
+const K: usize = 10;
+
+/// HNSW construction parameters (`M`, `ef_construction`).
+const MAX_CONNECTIONS: usize = 16;
+const EF_CONSTRUCTION: usize = 200;
+
+/// `ef_search` values to sweep — from lean (50) to generous (256).
+const EF_SEARCH_VALUES: &[usize] = &[50, 128, 256];
+
+/// Builds a `NativeHnsw` index pre-populated with `DATASET_SIZE` vectors.
+///
+/// Uses `CachedSimdDistance` (the non-deprecated, production engine) so the
+/// benchmark measures the same code path as real queries.
+fn build_index(dim: usize) -> NativeHnsw<CachedSimdDistance> {
+    let distance = CachedSimdDistance::new(DistanceMetric::Euclidean, dim);
+    let hnsw = NativeHnsw::new(distance, MAX_CONNECTIONS, EF_CONSTRUCTION, DATASET_SIZE);
+
+    for seed in 0..DATASET_SIZE {
+        #[allow(clippy::cast_possible_truncation)]
+        let v = bench_helpers::generate_vector(dim, seed as u64);
+        hnsw.insert(&v).expect("insert during index build");
+    }
+    hnsw
+}
+
+/// Generates `NUM_QUERIES` query vectors for the given dimension.
+fn build_queries(dim: usize) -> Vec<Vec<f32>> {
+    let base_seed = DATASET_SIZE as u64 + 1; // disjoint from dataset seeds
+    (0..NUM_QUERIES)
+        .map(|i| {
+            #[allow(clippy::cast_possible_truncation)]
+            let seed = base_seed + i as u64;
+            bench_helpers::generate_vector(dim, seed)
+        })
+        .collect()
+}
+
+/// Benchmarks `NativeHnsw::search()` for a single dimension, sweeping `ef_search`.
+fn bench_search_for_dim<M: Measurement>(group: &mut BenchmarkGroup<'_, M>, dim: usize) {
+    let index = build_index(dim);
+    let queries = build_queries(dim);
+
+    // Throughput = 1 search call per iteration (we measure single-query latency).
+    group.throughput(Throughput::Elements(1));
+
+    for &ef_search in EF_SEARCH_VALUES {
+        group.bench_with_input(
+            BenchmarkId::new(format!("ef{ef_search}"), dim),
+            &ef_search,
+            |b, &ef| {
+                let mut qi = 0_usize;
+                b.iter(|| {
+                    let q = &queries[qi % NUM_QUERIES];
+                    qi = qi.wrapping_add(1);
+                    let results = index.search(black_box(q), K, ef);
+                    black_box(results);
+                });
+            },
+        );
+    }
+}
+
+/// Benchmark group: `search_layer/128d` — low-dimension fast path.
+fn bench_search_128d(c: &mut Criterion) {
+    let mut group = c.benchmark_group("search_layer/128d");
+    bench_search_for_dim(&mut group, 128);
+    group.finish();
+}
+
+/// Benchmark group: `search_layer/768d` — BERT-class dimension.
+fn bench_search_768d(c: &mut Criterion) {
+    let mut group = c.benchmark_group("search_layer/768d");
+    bench_search_for_dim(&mut group, 768);
+    group.finish();
+}
+
+criterion_group!(benches, bench_search_128d, bench_search_768d);
+criterion_main!(benches);

--- a/crates/velesdb-core/src/collection/core/crud.rs
+++ b/crates/velesdb-core/src/collection/core/crud.rs
@@ -105,7 +105,7 @@ impl Collection {
                 old_payload.as_ref(),
                 point.payload.as_ref(),
             );
-            self.index.insert(point.id, &point.vector);
+            self.insert_or_defer(point.id, &point.vector);
             Self::update_text_index(&self.text_index, point);
             Self::collect_sparse_vectors(point, &mut sparse_batch);
         }
@@ -117,9 +117,7 @@ impl Collection {
         drop(payload_storage);
 
         self.config.write().point_count = point_count;
-        // NOTE: index.save() removed — atomic_write fsyncs are too slow on CI
-        // runners and production batch workloads. The WAL + payload log ensure
-        // data durability; call collection.flush() to persist the HNSW index.
+        self.maybe_merge_deferred();
 
         Ok(sparse_batch)
     }
@@ -194,6 +192,46 @@ impl Collection {
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     }
 
+    /// Inserts into HNSW directly, or buffers in the deferred indexer.
+    ///
+    /// When deferred indexing is enabled, the vector is pushed into the
+    /// deferred buffer instead of the HNSW graph. Otherwise falls through
+    /// to `VectorIndex::insert`.
+    fn insert_or_defer(&self, id: u64, vector: &[f32]) {
+        #[cfg(feature = "persistence")]
+        if let Some(ref di) = self.deferred_indexer {
+            if di.is_enabled() {
+                di.push(id, vector.to_vec());
+                return;
+            }
+        }
+        self.index.insert(id, vector);
+    }
+
+    /// Triggers a deferred merge if the buffer has reached threshold.
+    ///
+    /// Drains buffered vectors and batch-inserts them into HNSW.
+    /// No-op when deferred indexing is not configured.
+    fn maybe_merge_deferred(&self) {
+        #[cfg(feature = "persistence")]
+        if let Some(ref di) = self.deferred_indexer {
+            if di.should_merge() {
+                self.merge_deferred_batch(di);
+            }
+        }
+    }
+
+    /// Drains the deferred indexer and batch-inserts into HNSW.
+    #[cfg(feature = "persistence")]
+    fn merge_deferred_batch(&self, di: &crate::collection::streaming::DeferredIndexer) {
+        let drained = di.swap_and_drain();
+        if drained.is_empty() {
+            return;
+        }
+        let refs: Vec<(u64, &[f32])> = drained.iter().map(|(id, v)| (*id, v.as_slice())).collect();
+        self.index.insert_batch_parallel(refs);
+    }
+
     /// Inserts or updates metadata-only points (no vectors).
     ///
     /// This method is for metadata-only collections. Points should have
@@ -265,15 +303,33 @@ impl Collection {
         self.bulk_store_vectors(&vector_refs)?;
         self.bulk_store_payloads(points)?;
 
-        let inserted = self.index.insert_batch_parallel(vector_refs);
-        self.index.set_searching_mode();
-
+        let inserted = self.bulk_index_or_defer(vector_refs);
         self.config.write().point_count = self.vector_storage.read().len();
 
         self.apply_sparse_batch_bulk(&sparse_batch)?;
         self.invalidate_caches_and_bump_generation();
 
         Ok(inserted)
+    }
+
+    /// Batch-inserts into HNSW or defers into the deferred indexer.
+    ///
+    /// Returns the number of vectors that reached the HNSW index (0 when
+    /// deferred indexing absorbs the entire batch).
+    fn bulk_index_or_defer(&self, vector_refs: Vec<(u64, &[f32])>) -> usize {
+        #[cfg(feature = "persistence")]
+        if let Some(ref di) = self.deferred_indexer {
+            if di.is_enabled() {
+                di.extend(vector_refs.iter().map(|(id, v)| (*id, v.to_vec())));
+                if di.should_merge() {
+                    self.merge_deferred_batch(di);
+                }
+                return vector_refs.len();
+            }
+        }
+        let inserted = self.index.insert_batch_parallel(vector_refs);
+        self.index.set_searching_mode();
+        inserted
     }
 
     /// Collects sparse vectors grouped by index name for batch insert.
@@ -452,6 +508,14 @@ impl Collection {
         #[cfg(feature = "persistence")]
         for &id in ids {
             self.delta_buffer.remove(id);
+        }
+
+        // Lock order: deferred_indexer(11) acquired after delta_buffer(10).
+        #[cfg(feature = "persistence")]
+        if let Some(ref di) = self.deferred_indexer {
+            for &id in ids {
+                di.remove(id);
+            }
         }
 
         Ok(())

--- a/crates/velesdb-core/src/collection/core/crud.rs
+++ b/crates/velesdb-core/src/collection/core/crud.rs
@@ -418,7 +418,7 @@ impl Collection {
         Ok(())
     }
 
-    /// Deletes vector points from all stores (vector, payload, index, caches, sparse).
+    /// Deletes vector points from all stores (vector, payload, index, caches, sparse, delta).
     fn delete_vector_points(&self, ids: &[u64]) -> Result<()> {
         let mut payload_storage = self.payload_storage.write();
         let mut vector_storage = self.vector_storage.write();
@@ -446,7 +446,15 @@ impl Collection {
         drop(pq_cache);
         self.config.write().point_count = point_count;
 
-        self.delete_from_sparse_indexes(ids)
+        self.delete_from_sparse_indexes(ids)?;
+
+        // Lock order: delta_buffer(10) acquired after sparse_indexes(9) released.
+        #[cfg(feature = "persistence")]
+        for &id in ids {
+            self.delta_buffer.remove(id);
+        }
+
+        Ok(())
     }
 
     /// Deletes IDs from sparse indexes with WAL-before-apply.

--- a/crates/velesdb-core/src/collection/core/crud.rs
+++ b/crates/velesdb-core/src/collection/core/crud.rs
@@ -39,14 +39,6 @@ impl Collection {
     ///
     /// Returns an error if any point has a mismatched dimension, or if
     /// attempting to insert vectors into a metadata-only collection.
-    /// Inserts or updates points in the collection.
-    ///
-    /// Accepts any iterator of points (Vec, slice, array, etc.)
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if any point has a mismatched dimension, or if
-    /// attempting to insert vectors into a metadata-only collection.
     pub fn upsert(&self, points: impl IntoIterator<Item = Point>) -> Result<()> {
         let points: Vec<Point> = points.into_iter().collect();
         let config = self.config.read();
@@ -194,16 +186,18 @@ impl Collection {
 
     /// Inserts into HNSW directly, or buffers in the deferred indexer.
     ///
-    /// When deferred indexing is enabled, the vector is pushed into the
+    /// When a deferred indexer is present, the vector is pushed into the
     /// deferred buffer instead of the HNSW graph. Otherwise falls through
     /// to `VectorIndex::insert`.
+    ///
+    /// Invariant: `self.deferred_indexer` is `Some` only when enabled
+    /// (`build_deferred_indexer` filters on `cfg.enabled`), so no
+    /// redundant `is_enabled()` check is needed here.
     fn insert_or_defer(&self, id: u64, vector: &[f32]) {
         #[cfg(feature = "persistence")]
         if let Some(ref di) = self.deferred_indexer {
-            if di.is_enabled() {
-                di.push(id, vector.to_vec());
-                return;
-            }
+            di.push(id, vector.to_vec());
+            return;
         }
         self.index.insert(id, vector);
     }
@@ -222,14 +216,24 @@ impl Collection {
     }
 
     /// Drains the deferred indexer and batch-inserts into HNSW.
+    ///
+    /// Logs a warning if fewer vectors were inserted than drained, which
+    /// indicates a partial failure (e.g., duplicate IDs filtered out or
+    /// graph insertion error). The drained vectors are not retried.
     #[cfg(feature = "persistence")]
     fn merge_deferred_batch(&self, di: &crate::collection::streaming::DeferredIndexer) {
         let drained = di.swap_and_drain();
         if drained.is_empty() {
             return;
         }
+        let expected = drained.len();
         let refs: Vec<(u64, &[f32])> = drained.iter().map(|(id, v)| (*id, v.as_slice())).collect();
-        self.index.insert_batch_parallel(refs);
+        let inserted = self.index.insert_batch_parallel(refs);
+        if inserted < expected {
+            tracing::warn!(
+                "merge_deferred_batch: inserted {inserted}/{expected} vectors"
+            );
+        }
     }
 
     /// Inserts or updates metadata-only points (no vectors).
@@ -281,11 +285,6 @@ impl Collection {
     /// # Errors
     ///
     /// Returns an error if any point has a mismatched dimension.
-    /// Bulk insert optimized for high-throughput import.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if any point has a mismatched dimension.
     pub fn upsert_bulk(&self, points: &[Point]) -> Result<usize> {
         if points.is_empty() {
             return Ok(0);
@@ -316,16 +315,18 @@ impl Collection {
     ///
     /// Returns the number of vectors that reached the HNSW index (0 when
     /// deferred indexing absorbs the entire batch).
+    ///
+    /// Invariant: `self.deferred_indexer` is `Some` only when enabled
+    /// (`build_deferred_indexer` filters on `cfg.enabled`), so no
+    /// redundant `is_enabled()` check is needed here.
     fn bulk_index_or_defer(&self, vector_refs: Vec<(u64, &[f32])>) -> usize {
         #[cfg(feature = "persistence")]
         if let Some(ref di) = self.deferred_indexer {
-            if di.is_enabled() {
-                di.extend(vector_refs.iter().map(|(id, v)| (*id, v.to_vec())));
-                if di.should_merge() {
-                    self.merge_deferred_batch(di);
-                }
-                return vector_refs.len();
+            di.extend(vector_refs.iter().map(|(id, v)| (*id, v.to_vec())));
+            if di.should_merge() {
+                self.merge_deferred_batch(di);
             }
+            return vector_refs.len();
         }
         let inserted = self.index.insert_batch_parallel(vector_refs);
         self.index.set_searching_mode();

--- a/crates/velesdb-core/src/collection/core/crud.rs
+++ b/crates/velesdb-core/src/collection/core/crud.rs
@@ -217,22 +217,36 @@ impl Collection {
 
     /// Drains the deferred indexer and batch-inserts into HNSW.
     ///
-    /// Logs a warning if fewer vectors were inserted than drained, which
-    /// indicates a partial failure (e.g., duplicate IDs filtered out or
-    /// graph insertion error). The drained vectors are not retried.
+    /// Filters out IDs that have been deleted from vector storage since they
+    /// were buffered, preventing ghost vectors from being re-inserted into
+    /// HNSW after a concurrent delete.
+    ///
+    /// Logs a warning if fewer vectors were inserted than expected, which
+    /// indicates a partial failure (e.g., duplicate IDs filtered out,
+    /// ghost-vector filtering, or graph insertion error). The drained
+    /// vectors are not retried.
     #[cfg(feature = "persistence")]
     fn merge_deferred_batch(&self, di: &crate::collection::streaming::DeferredIndexer) {
         let drained = di.swap_and_drain();
         if drained.is_empty() {
             return;
         }
-        let expected = drained.len();
-        let refs: Vec<(u64, &[f32])> = drained.iter().map(|(id, v)| (*id, v.as_slice())).collect();
-        let inserted = self.index.insert_batch_parallel(refs);
+        // Filter out vectors deleted from storage during the buffer's
+        // lifetime to prevent ghost re-insertion into HNSW.
+        let storage = self.vector_storage.read();
+        let valid: Vec<(u64, &[f32])> = drained
+            .iter()
+            .filter(|(id, _)| storage.retrieve(*id).ok().flatten().is_some())
+            .map(|(id, v)| (*id, v.as_slice()))
+            .collect();
+        drop(storage); // Release read lock before batch insert
+        let expected = valid.len();
+        if valid.is_empty() {
+            return;
+        }
+        let inserted = self.index.insert_batch_parallel(valid);
         if inserted < expected {
-            tracing::warn!(
-                "merge_deferred_batch: inserted {inserted}/{expected} vectors"
-            );
+            tracing::warn!("merge_deferred_batch: inserted {inserted}/{expected} vectors");
         }
     }
 

--- a/crates/velesdb-core/src/collection/core/crud.rs
+++ b/crates/velesdb-core/src/collection/core/crud.rs
@@ -313,8 +313,8 @@ impl Collection {
 
     /// Batch-inserts into HNSW or defers into the deferred indexer.
     ///
-    /// Returns the number of vectors that reached the HNSW index (0 when
-    /// deferred indexing absorbs the entire batch).
+    /// Returns the number of vectors processed (whether indexed directly
+    /// or deferred for later merge).
     ///
     /// Invariant: `self.deferred_indexer` is `Some` only when enabled
     /// (`build_deferred_indexer` filters on `cfg.enabled`), so no

--- a/crates/velesdb-core/src/collection/core/lifecycle.rs
+++ b/crates/velesdb-core/src/collection/core/lifecycle.rs
@@ -5,7 +5,7 @@ use crate::collection::types::{Collection, CollectionConfig, CollectionType};
 use crate::distance::DistanceMetric;
 use crate::error::{Error, Result};
 use crate::guardrails::GuardRails;
-use crate::index::{Bm25Index, HnswIndex, VectorIndex};
+use crate::index::{Bm25Index, HnswIndex};
 use crate::quantization::StorageMode;
 use crate::sparse_index::DEFAULT_SPARSE_INDEX_NAME;
 use crate::storage::{LogPayloadStorage, MmapStorage, PayloadStorage, VectorStorage};
@@ -660,18 +660,22 @@ impl Collection {
     /// No-op when the delta buffer is inactive (no rebuild in progress).
     /// After draining, the buffer is empty and inactive.
     ///
+    /// Uses `insert_batch_parallel` for consistent batch insert performance
+    /// (same strategy as `merge_deferred_batch` in crud.rs).
+    ///
     /// # Lock ordering
     ///
     /// Acquires only `delta_buffer` (position 10). The caller must NOT hold
     /// any lower-numbered lock when calling this method.
     #[cfg(feature = "persistence")]
     fn drain_delta_into_index(&self) {
-        use crate::index::VectorIndex;
-
         let drained = self.delta_buffer.deactivate_and_drain();
-        for (id, vector) in &drained {
-            self.index.insert(*id, vector);
+        if drained.is_empty() {
+            return;
         }
+        let refs: Vec<(u64, &[f32])> =
+            drained.iter().map(|(id, v)| (*id, v.as_slice())).collect();
+        self.index.insert_batch_parallel(refs);
     }
 
     /// No-op stub when persistence is disabled.
@@ -683,6 +687,9 @@ impl Collection {
     /// No-op when deferred indexing is not configured or disabled.
     /// After draining, both buffers are empty and inactive.
     ///
+    /// Uses `insert_batch_parallel` for consistent batch insert performance
+    /// (same strategy as `merge_deferred_batch` in crud.rs).
+    ///
     /// # Lock ordering
     ///
     /// Acquires only `deferred_indexer` internal locks (position 11).
@@ -691,9 +698,12 @@ impl Collection {
     fn drain_deferred_into_index(&self) {
         if let Some(ref di) = self.deferred_indexer {
             let drained = di.drain_all();
-            for (id, vector) in &drained {
-                self.index.insert(*id, vector);
+            if drained.is_empty() {
+                return;
             }
+            let refs: Vec<(u64, &[f32])> =
+                drained.iter().map(|(id, v)| (*id, v.as_slice())).collect();
+            self.index.insert_batch_parallel(refs);
         }
     }
 

--- a/crates/velesdb-core/src/collection/core/lifecycle.rs
+++ b/crates/velesdb-core/src/collection/core/lifecycle.rs
@@ -5,7 +5,7 @@ use crate::collection::types::{Collection, CollectionConfig, CollectionType};
 use crate::distance::DistanceMetric;
 use crate::error::{Error, Result};
 use crate::guardrails::GuardRails;
-use crate::index::{Bm25Index, HnswIndex};
+use crate::index::{Bm25Index, HnswIndex, VectorIndex};
 use crate::quantization::StorageMode;
 use crate::sparse_index::DEFAULT_SPARSE_INDEX_NAME;
 use crate::storage::{LogPayloadStorage, MmapStorage, PayloadStorage, VectorStorage};
@@ -72,6 +72,9 @@ impl Collection {
     /// This is the single point of truth for the `Self { .. }` struct literal,
     /// eliminating duplication across the five public constructors.
     fn assemble(parts: CollectionParts) -> Self {
+        #[cfg(feature = "persistence")]
+        let deferred_indexer = Self::build_deferred_indexer(&parts.config);
+
         Self {
             path: parts.path,
             config: Arc::new(RwLock::new(parts.config)),
@@ -98,7 +101,28 @@ impl Collection {
             stream_ingester: Arc::new(RwLock::new(None)),
             #[cfg(feature = "persistence")]
             delta_buffer: Arc::new(crate::collection::streaming::delta::DeltaBuffer::new()),
+            #[cfg(feature = "persistence")]
+            deferred_indexer,
         }
+    }
+
+    /// Builds the optional `DeferredIndexer` from config.
+    ///
+    /// Returns `Some(Arc<DeferredIndexer>)` when `deferred_indexing` is
+    /// configured and enabled; `None` otherwise.
+    #[cfg(feature = "persistence")]
+    fn build_deferred_indexer(
+        config: &CollectionConfig,
+    ) -> Option<Arc<crate::collection::streaming::DeferredIndexer>> {
+        config
+            .deferred_indexing
+            .as_ref()
+            .filter(|cfg| cfg.enabled)
+            .map(|cfg| {
+                Arc::new(crate::collection::streaming::DeferredIndexer::new(
+                    cfg.clone(),
+                ))
+            })
     }
 
     /// Initialises persistent storages and indexes for a new collection.
@@ -218,6 +242,8 @@ impl Collection {
             embedding_dimension: None,
             pq_rescore_oversampling: Some(4),
             hnsw_params: None,
+            #[cfg(feature = "persistence")]
+            deferred_indexing: None,
         };
         Self::create_from_config(path, config, None)
     }
@@ -257,6 +283,8 @@ impl Collection {
             embedding_dimension: None,
             pq_rescore_oversampling: Some(4),
             hnsw_params: Some(hnsw_params),
+            #[cfg(feature = "persistence")]
+            deferred_indexing: None,
         };
         Self::create_from_config(path, config, Some(hnsw_params))
     }
@@ -315,6 +343,8 @@ impl Collection {
             embedding_dimension: None,
             pq_rescore_oversampling: Some(4),
             hnsw_params: None,
+            #[cfg(feature = "persistence")]
+            deferred_indexing: None,
         };
         Self::create_from_config(path, config, None)
     }
@@ -383,6 +413,12 @@ impl Collection {
         let mut config = config;
         config.point_count = actual_count;
 
+        // TODO(US-366): implement crash recovery gap detection for deferred indexer.
+        // After loading HNSW and vector storage, detect vectors in storage but
+        // not in HNSW (gap vectors from a crash during deferred merge) and
+        // re-index them. This requires comparing storage IDs against HNSW IDs
+        // which may be expensive for large collections.
+
         Ok(Self::assemble(CollectionParts {
             path,
             config,
@@ -422,6 +458,8 @@ impl Collection {
             embedding_dimension: embedding_dim,
             pq_rescore_oversampling: Some(4),
             hnsw_params: None,
+            #[cfg(feature = "persistence")]
+            deferred_indexing: None,
         };
         // NOTE: create_from_config validates dimension only when > 0,
         // so embedding_dim=None (dimension=0) skips validation correctly.
@@ -610,6 +648,8 @@ impl Collection {
         // Lock order: delta_buffer(10) is acquired after vector_storage(2)
         // and payload_storage(3) — both already released above.
         self.drain_delta_into_index();
+        // Drain deferred indexer into HNSW (position 11, after delta at 10).
+        self.drain_deferred_into_index();
         self.index.save(&self.path)?;
         self.flush_secondary_indexes()?;
         self.flush_sparse_indexes()
@@ -637,6 +677,29 @@ impl Collection {
     /// No-op stub when persistence is disabled.
     #[cfg(not(feature = "persistence"))]
     fn drain_delta_into_index(&self) {}
+
+    /// Drains the deferred indexer into the HNSW index (if configured).
+    ///
+    /// No-op when deferred indexing is not configured or disabled.
+    /// After draining, both buffers are empty and inactive.
+    ///
+    /// # Lock ordering
+    ///
+    /// Acquires only `deferred_indexer` internal locks (position 11).
+    /// The caller must NOT hold any lower-numbered lock.
+    #[cfg(feature = "persistence")]
+    fn drain_deferred_into_index(&self) {
+        if let Some(ref di) = self.deferred_indexer {
+            let drained = di.drain_all();
+            for (id, vector) in &drained {
+                self.index.insert(*id, vector);
+            }
+        }
+    }
+
+    /// No-op stub when persistence is disabled.
+    #[cfg(not(feature = "persistence"))]
+    fn drain_deferred_into_index(&self) {}
 
     /// Persists property index, range index, and edge store (EPIC-009 US-005).
     fn flush_secondary_indexes(&self) -> Result<()> {

--- a/crates/velesdb-core/src/collection/core/lifecycle.rs
+++ b/crates/velesdb-core/src/collection/core/lifecycle.rs
@@ -594,6 +594,11 @@ impl Collection {
 
     /// Saves the collection configuration and index to disk.
     ///
+    /// If the delta buffer is active (HNSW rebuild in progress), drains
+    /// buffered vectors into the HNSW index before persisting it. This
+    /// ensures graceful shutdown does not lose vectors that were accepted
+    /// during the rebuild window.
+    ///
     /// # Errors
     ///
     /// Returns an error if storage operations fail.
@@ -601,10 +606,37 @@ impl Collection {
         self.save_config()?;
         self.vector_storage.write().flush()?;
         self.payload_storage.write().flush()?;
+        // Drain delta buffer into HNSW before persisting the index.
+        // Lock order: delta_buffer(10) is acquired after vector_storage(2)
+        // and payload_storage(3) — both already released above.
+        self.drain_delta_into_index();
         self.index.save(&self.path)?;
         self.flush_secondary_indexes()?;
         self.flush_sparse_indexes()
     }
+
+    /// Drains the delta buffer into the HNSW index (if active).
+    ///
+    /// No-op when the delta buffer is inactive (no rebuild in progress).
+    /// After draining, the buffer is empty and inactive.
+    ///
+    /// # Lock ordering
+    ///
+    /// Acquires only `delta_buffer` (position 10). The caller must NOT hold
+    /// any lower-numbered lock when calling this method.
+    #[cfg(feature = "persistence")]
+    fn drain_delta_into_index(&self) {
+        use crate::index::VectorIndex;
+
+        let drained = self.delta_buffer.deactivate_and_drain();
+        for (id, vector) in &drained {
+            self.index.insert(*id, vector);
+        }
+    }
+
+    /// No-op stub when persistence is disabled.
+    #[cfg(not(feature = "persistence"))]
+    fn drain_delta_into_index(&self) {}
 
     /// Persists property index, range index, and edge store (EPIC-009 US-005).
     fn flush_secondary_indexes(&self) -> Result<()> {

--- a/crates/velesdb-core/src/collection/core/lifecycle.rs
+++ b/crates/velesdb-core/src/collection/core/lifecycle.rs
@@ -660,22 +660,37 @@ impl Collection {
     /// No-op when the delta buffer is inactive (no rebuild in progress).
     /// After draining, the buffer is empty and inactive.
     ///
+    /// Filters out IDs that have been deleted from vector storage since they
+    /// were buffered, preventing ghost vectors from being re-inserted into
+    /// HNSW after a concurrent delete.
+    ///
     /// Uses `insert_batch_parallel` for consistent batch insert performance
     /// (same strategy as `merge_deferred_batch` in crud.rs).
     ///
     /// # Lock ordering
     ///
-    /// Acquires only `delta_buffer` (position 10). The caller must NOT hold
-    /// any lower-numbered lock when calling this method.
+    /// Acquires `vector_storage` (position 2) briefly for the validity
+    /// check, releases it, then inserts into the index (no lock).
+    /// `delta_buffer` (position 10) is acquired first via `deactivate_and_drain`.
+    /// The caller must NOT hold any lower-numbered lock when calling this method.
     #[cfg(feature = "persistence")]
     fn drain_delta_into_index(&self) {
         let drained = self.delta_buffer.deactivate_and_drain();
         if drained.is_empty() {
             return;
         }
-        let refs: Vec<(u64, &[f32])> =
-            drained.iter().map(|(id, v)| (*id, v.as_slice())).collect();
-        self.index.insert_batch_parallel(refs);
+        // Filter out vectors deleted from storage during the buffer's
+        // lifetime to prevent ghost re-insertion into HNSW.
+        let storage = self.vector_storage.read();
+        let valid: Vec<(u64, &[f32])> = drained
+            .iter()
+            .filter(|(id, _)| storage.retrieve(*id).ok().flatten().is_some())
+            .map(|(id, v)| (*id, v.as_slice()))
+            .collect();
+        drop(storage); // Release read lock before batch insert
+        if !valid.is_empty() {
+            self.index.insert_batch_parallel(valid);
+        }
     }
 
     /// No-op stub when persistence is disabled.
@@ -687,12 +702,18 @@ impl Collection {
     /// No-op when deferred indexing is not configured or disabled.
     /// After draining, both buffers are empty and inactive.
     ///
+    /// Filters out IDs that have been deleted from vector storage since they
+    /// were buffered, preventing ghost vectors from being re-inserted into
+    /// HNSW after a concurrent delete.
+    ///
     /// Uses `insert_batch_parallel` for consistent batch insert performance
     /// (same strategy as `merge_deferred_batch` in crud.rs).
     ///
     /// # Lock ordering
     ///
-    /// Acquires only `deferred_indexer` internal locks (position 11).
+    /// Acquires `vector_storage` (position 2) briefly for the validity
+    /// check, releases it, then inserts into the index (no lock).
+    /// `deferred_indexer` (position 11) is acquired first via `drain_all`.
     /// The caller must NOT hold any lower-numbered lock.
     #[cfg(feature = "persistence")]
     fn drain_deferred_into_index(&self) {
@@ -701,9 +722,18 @@ impl Collection {
             if drained.is_empty() {
                 return;
             }
-            let refs: Vec<(u64, &[f32])> =
-                drained.iter().map(|(id, v)| (*id, v.as_slice())).collect();
-            self.index.insert_batch_parallel(refs);
+            // Filter out vectors deleted from storage during the buffer's
+            // lifetime to prevent ghost re-insertion into HNSW.
+            let storage = self.vector_storage.read();
+            let valid: Vec<(u64, &[f32])> = drained
+                .iter()
+                .filter(|(id, _)| storage.retrieve(*id).ok().flatten().is_some())
+                .map(|(id, v)| (*id, v.as_slice()))
+                .collect();
+            drop(storage); // Release read lock before batch insert
+            if !valid.is_empty() {
+                self.index.insert_batch_parallel(valid);
+            }
         }
     }
 

--- a/crates/velesdb-core/src/collection/core/lifecycle.rs
+++ b/crates/velesdb-core/src/collection/core/lifecycle.rs
@@ -413,7 +413,7 @@ impl Collection {
         let mut config = config;
         config.point_count = actual_count;
 
-        // TODO(US-366): implement crash recovery gap detection for deferred indexer.
+        // TODO #370: implement crash recovery gap detection for deferred indexer.
         // After loading HNSW and vector storage, detect vectors in storage but
         // not in HNSW (gap vectors from a crash during deferred merge) and
         // re-index them. This requires comparing storage IDs against HNSW IDs

--- a/crates/velesdb-core/src/collection/core/lifecycle_tests.rs
+++ b/crates/velesdb-core/src/collection/core/lifecycle_tests.rs
@@ -273,3 +273,92 @@ fn test_reopen_collection_reconciles_point_count_from_storage() {
         "len() must reflect actual vector count after reopen"
     );
 }
+
+// ── Bug B0.3: flush() must drain delta buffer ────────────────────────
+
+/// Regression test: `flush()` must drain the delta buffer into HNSW before
+/// persisting the index. Without this, a graceful shutdown during an active
+/// rebuild loses buffered vectors — they exist in vector storage but are
+/// absent from the persisted HNSW graph.
+#[test]
+fn test_flush_drains_delta_buffer_into_hnsw() {
+    use crate::index::VectorIndex;
+    use crate::point::Point;
+
+    let temp_dir = tempfile::tempdir().expect("temp dir should be created");
+    let collection = Collection::create(PathBuf::from(temp_dir.path()), 4, DistanceMetric::Cosine)
+        .expect("collection should be created");
+
+    // 1. Insert initial points so the HNSW index has some content
+    let initial_points = vec![
+        Point::without_payload(1, vec![1.0, 0.0, 0.0, 0.0]),
+        Point::without_payload(2, vec![0.0, 1.0, 0.0, 0.0]),
+    ];
+    collection.upsert(initial_points).expect("initial upsert");
+
+    // 2. Activate delta buffer (simulates an HNSW rebuild starting)
+    collection.delta_buffer.activate();
+    assert!(
+        collection.delta_buffer.is_active(),
+        "delta should be active"
+    );
+
+    // 3. Push vectors into the delta buffer (simulates upserts during rebuild)
+    collection.delta_buffer.push(10, vec![0.5, 0.5, 0.0, 0.0]);
+    collection.delta_buffer.push(11, vec![0.0, 0.0, 0.5, 0.5]);
+    assert_eq!(
+        collection.delta_buffer.len(),
+        2,
+        "delta should hold 2 entries"
+    );
+
+    // 4. Call flush — this should drain the delta buffer into HNSW
+    collection.flush().expect("flush should succeed");
+
+    // 5. Verify: delta buffer is now empty and inactive
+    assert!(
+        !collection.delta_buffer.is_active(),
+        "delta buffer must be inactive after flush"
+    );
+    assert!(
+        collection.delta_buffer.is_empty(),
+        "delta buffer must be empty after flush"
+    );
+
+    // 6. Verify: the drained vectors are now in the HNSW index (searchable)
+    let results = collection.index.search(&[0.5, 0.5, 0.0, 0.0], 5);
+    let result_ids: Vec<u64> = results.iter().map(|r| r.id).collect();
+    assert!(
+        result_ids.contains(&10),
+        "id=10 should be in HNSW after flush (was: {result_ids:?})"
+    );
+    assert!(
+        result_ids.contains(&11),
+        "id=11 should be in HNSW after flush (was: {result_ids:?})"
+    );
+}
+
+/// Regression test: `flush()` on a collection with an inactive (empty) delta
+/// buffer must succeed without errors and behave identically to before.
+#[test]
+fn test_flush_with_inactive_delta_buffer_is_noop() {
+    use crate::point::Point;
+
+    let temp_dir = tempfile::tempdir().expect("temp dir should be created");
+    let collection = Collection::create(PathBuf::from(temp_dir.path()), 4, DistanceMetric::Cosine)
+        .expect("collection should be created");
+
+    let points = vec![Point::without_payload(1, vec![1.0, 0.0, 0.0, 0.0])];
+    collection.upsert(points).expect("upsert");
+
+    // Delta buffer is NOT active — flush should behave normally
+    assert!(!collection.delta_buffer.is_active());
+
+    collection
+        .flush()
+        .expect("flush with inactive delta should succeed");
+
+    // Verify the collection is still functional
+    let results = collection.search(&[1.0, 0.0, 0.0, 0.0], 1).expect("search");
+    assert_eq!(results.len(), 1, "search should still work after flush");
+}

--- a/crates/velesdb-core/src/collection/core/lifecycle_tests.rs
+++ b/crates/velesdb-core/src/collection/core/lifecycle_tests.rs
@@ -296,14 +296,23 @@ fn test_flush_drains_delta_buffer_into_hnsw() {
     ];
     collection.upsert(initial_points).expect("initial upsert");
 
-    // 2. Activate delta buffer (simulates an HNSW rebuild starting)
+    // 2. Store vectors in MmapStorage first (real application flow: vectors
+    //    are persisted to storage before being delta-buffered).
+    {
+        use crate::storage::VectorStorage;
+        let mut vs = collection.vector_storage.write();
+        vs.store(10, &[0.5, 0.5, 0.0, 0.0]).expect("store 10");
+        vs.store(11, &[0.0, 0.0, 0.5, 0.5]).expect("store 11");
+    }
+
+    // 3. Activate delta buffer (simulates an HNSW rebuild starting)
     collection.delta_buffer.activate();
     assert!(
         collection.delta_buffer.is_active(),
         "delta should be active"
     );
 
-    // 3. Push vectors into the delta buffer (simulates upserts during rebuild)
+    // 4. Push vectors into the delta buffer (simulates upserts during rebuild)
     collection.delta_buffer.push(10, vec![0.5, 0.5, 0.0, 0.0]);
     collection.delta_buffer.push(11, vec![0.0, 0.0, 0.5, 0.5]);
     assert_eq!(
@@ -312,10 +321,10 @@ fn test_flush_drains_delta_buffer_into_hnsw() {
         "delta should hold 2 entries"
     );
 
-    // 4. Call flush — this should drain the delta buffer into HNSW
+    // 5. Call flush — this should drain the delta buffer into HNSW
     collection.flush().expect("flush should succeed");
 
-    // 5. Verify: delta buffer is now empty and inactive
+    // 6. Verify: delta buffer is now empty and inactive
     assert!(
         !collection.delta_buffer.is_active(),
         "delta buffer must be inactive after flush"
@@ -325,7 +334,7 @@ fn test_flush_drains_delta_buffer_into_hnsw() {
         "delta buffer must be empty after flush"
     );
 
-    // 6. Verify: the drained vectors are now in the HNSW index (searchable)
+    // 7. Verify: the drained vectors are now in the HNSW index (searchable)
     let results = collection.index.search(&[0.5, 0.5, 0.0, 0.0], 5);
     let result_ids: Vec<u64> = results.iter().map(|r| r.id).collect();
     assert!(

--- a/crates/velesdb-core/src/collection/search/vector.rs
+++ b/crates/velesdb-core/src/collection/search/vector.rs
@@ -67,9 +67,9 @@ impl Collection {
         rescored
     }
 
-    /// Merges HNSW results with the delta buffer (if active).
+    /// Merges HNSW results with delta buffer and deferred indexer (if active).
     ///
-    /// When the delta buffer is inactive (no rebuild in progress), this is
+    /// When both the delta buffer and deferred indexer are inactive, this is
     /// a no-op that returns results unchanged.
     #[cfg(feature = "persistence")]
     #[inline]
@@ -80,13 +80,36 @@ impl Collection {
         k: usize,
         metric: DistanceMetric,
     ) -> Vec<ScoredResult> {
-        crate::collection::streaming::merge_with_delta_scored(
+        let after_delta = crate::collection::streaming::merge_with_delta_scored(
             results,
             &self.delta_buffer,
             query,
             k,
             metric,
-        )
+        );
+        self.merge_deferred_search(after_delta, query, k, metric)
+    }
+
+    /// Merges search results with the deferred indexer buffer.
+    ///
+    /// No-op when deferred indexing is not configured or has no searchable data.
+    #[cfg(feature = "persistence")]
+    fn merge_deferred_search(
+        &self,
+        results: Vec<ScoredResult>,
+        query: &[f32],
+        k: usize,
+        metric: DistanceMetric,
+    ) -> Vec<ScoredResult> {
+        let Some(ref di) = self.deferred_indexer else {
+            return results;
+        };
+        if !di.is_searchable() {
+            return results;
+        }
+        let hnsw_tuples: Vec<(u64, f32)> = results.into_iter().map(Into::into).collect();
+        let merged = di.merge_with_hnsw(hnsw_tuples, query, k, metric);
+        merged.into_iter().map(ScoredResult::from).collect()
     }
 
     #[cfg(not(feature = "persistence"))]

--- a/crates/velesdb-core/src/collection/streaming/deferred.rs
+++ b/crates/velesdb-core/src/collection/streaming/deferred.rs
@@ -1,0 +1,565 @@
+//! Deferred indexer for high-throughput sequential vector inserts.
+//!
+//! The [`DeferredIndexer`] buffers incoming vectors in memory and exposes them
+//! to search via brute-force scan while they await insertion into the HNSW
+//! graph. This decouples the write path (fast, O(1) per point) from the index
+//! path (slower, O(log n) per point) and enables background merge.
+//!
+//! # Double-buffering
+//!
+//! Internally the indexer holds a *front* buffer that accepts writes and a
+//! *back* buffer used during drain. [`swap_and_drain`](DeferredIndexer::swap_and_drain)
+//! rotates front to back, drains the old front, and returns the vectors for
+//! the caller to insert into HNSW.
+//!
+//! # Deleted IDs
+//!
+//! When a point is deleted while buffered, its ID is recorded in a
+//! `deleted_ids` set. Search results are filtered against this set so that
+//! deleted vectors never surface. The set is cleared on drain (the HNSW
+//! tombstone system takes over after merge).
+//!
+//! # Lock ordering
+//!
+//! `DeferredIndexer` is above `DeltaBuffer` (position 10) in the lock order.
+//! The `swap_lock` (position 10.1) must never be held while acquiring any
+//! lower-numbered lock.
+
+use super::delta::DeltaBuffer;
+use crate::distance::DistanceMetric;
+use parking_lot::{Mutex, RwLock};
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+use std::sync::Arc;
+
+// ── Constants ────────────────────────────────────────────────────────────────
+
+/// Default number of buffered vectors before a merge is triggered.
+const DEFAULT_MERGE_THRESHOLD: usize = 1024;
+
+/// Default maximum age of buffered data before a time-based merge (ms).
+const DEFAULT_MAX_BUFFER_AGE_MS: u64 = 5000;
+
+// ── Configuration ────────────────────────────────────────────────────────────
+
+/// Configuration for the [`DeferredIndexer`].
+///
+/// Controls whether deferred indexing is enabled, how many vectors to
+/// buffer before triggering a merge, and the maximum age of buffered data.
+///
+/// # Examples
+///
+/// ```
+/// use velesdb_core::collection::streaming::DeferredIndexerConfig;
+///
+/// let config = DeferredIndexerConfig::default();
+/// assert!(!config.enabled);
+/// assert_eq!(config.merge_threshold, 1024);
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DeferredIndexerConfig {
+    /// Whether deferred indexing is enabled (default: `false`).
+    #[serde(default)]
+    pub enabled: bool,
+
+    /// Number of buffered vectors that triggers a merge into HNSW.
+    #[serde(default = "default_merge_threshold")]
+    pub merge_threshold: usize,
+
+    /// Maximum age (milliseconds) of the oldest buffered vector before a
+    /// time-based merge is triggered.
+    #[serde(default = "default_max_buffer_age_ms")]
+    pub max_buffer_age_ms: u64,
+}
+
+fn default_merge_threshold() -> usize {
+    DEFAULT_MERGE_THRESHOLD
+}
+
+fn default_max_buffer_age_ms() -> u64 {
+    DEFAULT_MAX_BUFFER_AGE_MS
+}
+
+impl Default for DeferredIndexerConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            merge_threshold: DEFAULT_MERGE_THRESHOLD,
+            max_buffer_age_ms: DEFAULT_MAX_BUFFER_AGE_MS,
+        }
+    }
+}
+
+// ── DeferredIndexer ──────────────────────────────────────────────────────────
+
+/// Buffers vectors for deferred HNSW insertion with brute-force searchability.
+///
+/// See the [module-level docs](self) for design details.
+pub struct DeferredIndexer {
+    /// Front buffer — accepts writes.
+    front: Arc<DeltaBuffer>,
+
+    /// Back buffer — used during swap-and-drain.
+    back: Arc<DeltaBuffer>,
+
+    /// Serializes swap-and-drain operations so only one drain runs at a time.
+    swap_lock: Mutex<()>,
+
+    /// IDs deleted while in the buffer. Filtered out of search results.
+    deleted_ids: RwLock<HashSet<u64>>,
+
+    /// Configuration (immutable after construction).
+    config: DeferredIndexerConfig,
+}
+
+impl DeferredIndexer {
+    /// Creates a new `DeferredIndexer` with the given configuration.
+    ///
+    /// Both buffers start inactive. If `config.enabled` is `false`, all
+    /// write operations are no-ops.
+    #[must_use]
+    pub fn new(config: DeferredIndexerConfig) -> Self {
+        Self {
+            front: Arc::new(DeltaBuffer::new()),
+            back: Arc::new(DeltaBuffer::new()),
+            swap_lock: Mutex::new(()),
+            deleted_ids: RwLock::new(HashSet::new()),
+            config,
+        }
+    }
+
+    /// Whether deferred indexing is enabled.
+    #[must_use]
+    pub fn is_enabled(&self) -> bool {
+        self.config.enabled
+    }
+
+    /// Pushes a vector into the front buffer.
+    ///
+    /// Activates the front buffer lazily on first write. Returns `true` if
+    /// the front buffer has reached `merge_threshold`, signaling the caller
+    /// to trigger a merge.
+    ///
+    /// No-op if deferred indexing is disabled.
+    pub fn push(&self, id: u64, vector: Vec<f32>) -> bool {
+        if !self.config.enabled {
+            return false;
+        }
+        self.ensure_front_active();
+        self.front.push(id, vector);
+        self.front.len() >= self.config.merge_threshold
+    }
+
+    /// Batch-pushes vectors into the front buffer.
+    ///
+    /// Returns `true` if the front buffer has reached `merge_threshold`.
+    /// No-op if deferred indexing is disabled.
+    pub fn extend(
+        &self,
+        entries: impl IntoIterator<Item = (u64, Vec<f32>)>,
+    ) -> bool {
+        if !self.config.enabled {
+            return false;
+        }
+        self.ensure_front_active();
+        self.front.extend(entries);
+        self.front.len() >= self.config.merge_threshold
+    }
+
+    /// Marks `id` as deleted, removing it from both buffers.
+    ///
+    /// The ID is added to `deleted_ids` so that search results are filtered
+    /// even if the vector was already snapshot for a concurrent search.
+    pub fn remove(&self, id: u64) {
+        self.front.remove(id);
+        self.back.remove(id);
+        self.deleted_ids.write().insert(id);
+    }
+
+    /// Brute-force searches both buffers, filtering deleted IDs.
+    ///
+    /// Results are deduplicated by ID (best score wins), sorted by the
+    /// metric ordering, and truncated to `k`.
+    #[must_use]
+    pub fn search(
+        &self,
+        query: &[f32],
+        k: usize,
+        metric: DistanceMetric,
+    ) -> Vec<(u64, f32)> {
+        let front_results = self.front.search(query, k, metric);
+        let back_results = self.back.search(query, k, metric);
+
+        let deleted = self.deleted_ids.read();
+        let merged = merge_and_dedup(
+            front_results,
+            back_results,
+            &deleted,
+            metric,
+        );
+        truncated(merged, k)
+    }
+
+    /// Merges HNSW results with deferred buffer results.
+    ///
+    /// HNSW is authoritative: if the same ID appears in both HNSW and the
+    /// buffer, the HNSW score is kept (the indexed position is canonical).
+    /// Deleted IDs are filtered from buffer results but not from HNSW
+    /// results (HNSW has its own tombstone system).
+    #[must_use]
+    pub fn merge_with_hnsw(
+        &self,
+        hnsw_results: Vec<(u64, f32)>,
+        query: &[f32],
+        k: usize,
+        metric: DistanceMetric,
+    ) -> Vec<(u64, f32)> {
+        let buffer_results = self.search(query, k, metric);
+        if buffer_results.is_empty() {
+            return hnsw_results;
+        }
+        let hnsw_ids: HashSet<u64> =
+            hnsw_results.iter().map(|(id, _)| *id).collect();
+        let mut combined: Vec<(u64, f32)> = hnsw_results;
+        combined.extend(
+            buffer_results
+                .into_iter()
+                .filter(|(id, _)| !hnsw_ids.contains(id)),
+        );
+        metric.sort_results(&mut combined);
+        combined.truncate(k);
+        combined
+    }
+
+    /// Drains the front buffer and returns vectors for HNSW insertion.
+    ///
+    /// After this call the front buffer is empty and inactive (a subsequent
+    /// `push` will re-activate it). The `deleted_ids` set is cleared because
+    /// the caller is expected to apply deletions to HNSW after merge.
+    ///
+    /// Serialized by an internal mutex so concurrent calls are safe (the
+    /// second caller gets an empty drain).
+    pub fn swap_and_drain(&self) -> Vec<(u64, Vec<f32>)> {
+        let _guard = self.swap_lock.lock();
+        let drained = self.front.deactivate_and_drain();
+        self.deleted_ids.write().clear();
+        drained
+    }
+
+    /// Total number of pending (not yet indexed) vectors across both buffers.
+    #[must_use]
+    pub fn pending_count(&self) -> usize {
+        self.front.len() + self.back.len()
+    }
+
+    /// Returns `true` if the front buffer has reached `merge_threshold`.
+    #[must_use]
+    pub fn should_merge(&self) -> bool {
+        self.front.len() >= self.config.merge_threshold
+    }
+
+    /// Returns `true` if deferred indexing is enabled and either buffer has
+    /// searchable data.
+    #[must_use]
+    pub fn is_searchable(&self) -> bool {
+        self.config.enabled
+            && (self.front.is_searchable() || self.back.is_searchable())
+    }
+
+    /// Drains all vectors from both buffers (for shutdown / flush).
+    ///
+    /// Clears `deleted_ids`. After this call both buffers are empty and
+    /// inactive.
+    pub fn drain_all(&self) -> Vec<(u64, Vec<f32>)> {
+        let _guard = self.swap_lock.lock();
+        let mut all = self.front.deactivate_and_drain();
+        all.extend(self.back.deactivate_and_drain());
+        self.deleted_ids.write().clear();
+        all
+    }
+
+    /// Lazily activates the front buffer if it is not already active.
+    fn ensure_front_active(&self) {
+        if !self.front.is_active() {
+            self.front.activate();
+        }
+    }
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/// Merges two result sets, deduplicating by ID (best score wins) and
+/// filtering deleted IDs.
+fn merge_and_dedup(
+    a: Vec<(u64, f32)>,
+    b: Vec<(u64, f32)>,
+    deleted: &HashSet<u64>,
+    metric: DistanceMetric,
+) -> Vec<(u64, f32)> {
+    let mut seen: HashSet<u64> = HashSet::with_capacity(a.len() + b.len());
+    let mut merged: Vec<(u64, f32)> =
+        Vec::with_capacity(a.len() + b.len());
+
+    for (id, score) in a.into_iter().chain(b) {
+        if deleted.contains(&id) {
+            continue;
+        }
+        if seen.insert(id) {
+            merged.push((id, score));
+        } else {
+            update_best_score(&mut merged, id, score, metric);
+        }
+    }
+
+    metric.sort_results(&mut merged);
+    merged
+}
+
+/// Updates the score for `id` in `results` if `new_score` is better
+/// according to the metric ordering.
+fn update_best_score(
+    results: &mut [(u64, f32)],
+    id: u64,
+    new_score: f32,
+    metric: DistanceMetric,
+) {
+    for entry in results.iter_mut() {
+        if entry.0 == id {
+            let keep_new = if metric.higher_is_better() {
+                new_score > entry.1
+            } else {
+                new_score < entry.1
+            };
+            if keep_new {
+                entry.1 = new_score;
+            }
+            return;
+        }
+    }
+}
+
+/// Truncates a result vector to at most `k` elements.
+fn truncated(mut v: Vec<(u64, f32)>, k: usize) -> Vec<(u64, f32)> {
+    v.truncate(k);
+    v
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Helper: builds an enabled config with a custom threshold.
+    fn enabled_config(threshold: usize) -> DeferredIndexerConfig {
+        DeferredIndexerConfig {
+            enabled: true,
+            merge_threshold: threshold,
+            ..DeferredIndexerConfig::default()
+        }
+    }
+
+    // ── Push tests ───────────────────────────────────────────────────────
+
+    #[test]
+    fn test_deferred_push_when_enabled() {
+        let idx = DeferredIndexer::new(enabled_config(1024));
+        idx.push(1, vec![1.0, 0.0, 0.0]);
+        idx.push(2, vec![0.0, 1.0, 0.0]);
+        assert_eq!(idx.pending_count(), 2);
+    }
+
+    #[test]
+    fn test_deferred_push_returns_true_at_threshold() {
+        let idx = DeferredIndexer::new(enabled_config(3));
+        assert!(!idx.push(1, vec![1.0]));
+        assert!(!idx.push(2, vec![2.0]));
+        assert!(idx.push(3, vec![3.0]), "third push should hit threshold");
+    }
+
+    #[test]
+    fn test_deferred_push_noop_when_disabled() {
+        let config = DeferredIndexerConfig::default(); // enabled=false
+        let idx = DeferredIndexer::new(config);
+        let triggered = idx.push(1, vec![1.0, 2.0]);
+        assert!(!triggered);
+        assert_eq!(idx.pending_count(), 0);
+    }
+
+    #[test]
+    fn test_deferred_extend_returns_true_at_threshold() {
+        let idx = DeferredIndexer::new(enabled_config(3));
+        let entries = vec![
+            (1, vec![1.0]),
+            (2, vec![2.0]),
+            (3, vec![3.0]),
+        ];
+        assert!(idx.extend(entries), "batch should hit threshold");
+    }
+
+    // ── Search tests ─────────────────────────────────────────────────────
+
+    #[test]
+    fn test_deferred_search_finds_buffered_vectors() {
+        let idx = DeferredIndexer::new(enabled_config(1024));
+        idx.push(1, vec![1.0, 0.0]);
+        idx.push(2, vec![0.0, 1.0]);
+
+        let results = idx.search(&[1.0, 0.0], 2, DistanceMetric::Cosine);
+        assert_eq!(results.len(), 2);
+        // Cosine: id=1 (identical to query) should be first
+        assert_eq!(results[0].0, 1);
+    }
+
+    #[test]
+    fn test_deferred_search_filters_deleted_ids() {
+        let idx = DeferredIndexer::new(enabled_config(1024));
+        idx.push(1, vec![1.0, 0.0, 0.0]);
+        idx.push(2, vec![0.0, 1.0, 0.0]);
+        idx.push(3, vec![0.0, 0.0, 1.0]);
+        idx.remove(2);
+
+        let results =
+            idx.search(&[1.0, 0.0, 0.0], 10, DistanceMetric::Euclidean);
+        let ids: Vec<u64> = results.iter().map(|(id, _)| *id).collect();
+        assert!(
+            !ids.contains(&2),
+            "deleted ID 2 must not appear in results"
+        );
+        assert_eq!(ids.len(), 2);
+    }
+
+    // ── Swap and drain tests ─────────────────────────────────────────────
+
+    #[test]
+    fn test_deferred_swap_and_drain() {
+        let idx = DeferredIndexer::new(enabled_config(1024));
+        idx.push(1, vec![1.0]);
+        idx.push(2, vec![2.0]);
+
+        let drained = idx.swap_and_drain();
+        assert_eq!(drained.len(), 2);
+        assert_eq!(idx.pending_count(), 0, "front should be empty after drain");
+    }
+
+    #[test]
+    fn test_deferred_swap_and_drain_clears_deleted_ids() {
+        let idx = DeferredIndexer::new(enabled_config(1024));
+        idx.push(1, vec![1.0]);
+        idx.remove(1);
+        let _drained = idx.swap_and_drain();
+        // After drain, deleted_ids should be cleared
+        assert!(idx.deleted_ids.read().is_empty());
+    }
+
+    // ── Merge with HNSW tests ────────────────────────────────────────────
+
+    #[test]
+    fn test_deferred_merge_with_hnsw() {
+        let idx = DeferredIndexer::new(enabled_config(1024));
+        idx.push(10, vec![0.9, 0.1]);
+        idx.push(30, vec![0.5, 0.5]);
+
+        // HNSW results: id=10 (also in buffer) and id=20 (only in HNSW)
+        let hnsw = vec![(10, 0.95_f32), (20, 0.80_f32)];
+        let merged = idx.merge_with_hnsw(
+            hnsw,
+            &[1.0, 0.0],
+            3,
+            DistanceMetric::Cosine,
+        );
+
+        // No duplicate IDs
+        let ids: Vec<u64> = merged.iter().map(|(id, _)| *id).collect();
+        let unique: HashSet<u64> = ids.iter().copied().collect();
+        assert_eq!(ids.len(), unique.len(), "no duplicate IDs");
+
+        // All three IDs should be present (10 from HNSW, 20 from HNSW, 30 from buffer)
+        assert_eq!(merged.len(), 3);
+        assert!(ids.contains(&10));
+        assert!(ids.contains(&20));
+        assert!(ids.contains(&30));
+
+        // HNSW score for id=10 should be kept (0.95), not buffer score
+        let id10_score = merged.iter().find(|(id, _)| *id == 10).map(|(_, s)| *s);
+        assert!(
+            (id10_score.unwrap_or(0.0) - 0.95).abs() < f32::EPSILON,
+            "HNSW score should be authoritative for id=10"
+        );
+    }
+
+    #[test]
+    fn test_deferred_merge_with_hnsw_empty_buffer() {
+        let idx = DeferredIndexer::new(enabled_config(1024));
+        // Buffer is empty — merge should return HNSW results unchanged
+        let hnsw = vec![(1, 0.9_f32), (2, 0.8_f32)];
+        let merged = idx.merge_with_hnsw(
+            hnsw.clone(),
+            &[1.0, 0.0],
+            5,
+            DistanceMetric::Cosine,
+        );
+        assert_eq!(merged, hnsw);
+    }
+
+    // ── Drain-all test ───────────────────────────────────────────────────
+
+    #[test]
+    fn test_deferred_drain_all() {
+        let idx = DeferredIndexer::new(enabled_config(1024));
+        idx.push(1, vec![1.0]);
+        idx.push(2, vec![2.0]);
+
+        let all = idx.drain_all();
+        assert_eq!(all.len(), 2);
+        assert_eq!(idx.pending_count(), 0);
+        assert!(!idx.is_searchable(), "not searchable after drain_all");
+    }
+
+    // ── Config serde test ────────────────────────────────────────────────
+
+    #[test]
+    fn test_deferred_config_serde() {
+        let config = DeferredIndexerConfig {
+            enabled: true,
+            merge_threshold: 512,
+            max_buffer_age_ms: 3000,
+        };
+        let json = serde_json::to_string(&config).expect("serialize");
+        let restored: DeferredIndexerConfig =
+            serde_json::from_str(&json).expect("deserialize");
+        assert!(restored.enabled);
+        assert_eq!(restored.merge_threshold, 512);
+        assert_eq!(restored.max_buffer_age_ms, 3000);
+    }
+
+    #[test]
+    fn test_deferred_config_serde_defaults() {
+        let json = "{}";
+        let config: DeferredIndexerConfig =
+            serde_json::from_str(json).expect("deserialize empty");
+        assert!(!config.enabled);
+        assert_eq!(config.merge_threshold, DEFAULT_MERGE_THRESHOLD);
+        assert_eq!(config.max_buffer_age_ms, DEFAULT_MAX_BUFFER_AGE_MS);
+    }
+
+    // ── Edge cases ───────────────────────────────────────────────────────
+
+    #[test]
+    fn test_deferred_should_merge_reflects_threshold() {
+        let idx = DeferredIndexer::new(enabled_config(2));
+        assert!(!idx.should_merge());
+        idx.push(1, vec![1.0]);
+        assert!(!idx.should_merge());
+        idx.push(2, vec![2.0]);
+        assert!(idx.should_merge());
+    }
+
+    #[test]
+    fn test_deferred_is_enabled_reflects_config() {
+        let enabled = DeferredIndexer::new(enabled_config(1024));
+        assert!(enabled.is_enabled());
+        let disabled = DeferredIndexer::new(DeferredIndexerConfig::default());
+        assert!(!disabled.is_enabled());
+    }
+}

--- a/crates/velesdb-core/src/collection/streaming/deferred.rs
+++ b/crates/velesdb-core/src/collection/streaming/deferred.rs
@@ -1,16 +1,16 @@
 //! Deferred indexer for high-throughput sequential vector inserts.
 //!
-//! The [`DeferredIndexer`] buffers incoming vectors in memory and exposes them
-//! to search via brute-force scan while they await insertion into the HNSW
-//! graph. This decouples the write path (fast, O(1) per point) from the index
-//! path (slower, O(log n) per point) and enables background merge.
+//! The [`DeferredIndexer`] buffers incoming vectors in a single write buffer
+//! and exposes them to search via brute-force scan while they await insertion
+//! into the HNSW graph. This decouples the write path (fast, O(1) per point)
+//! from the index path (slower, O(log n) per point) and enables
+//! threshold-triggered merge.
 //!
-//! # Double-buffering
+//! # Single-buffer with threshold-triggered merge
 //!
-//! Internally the indexer holds a *front* buffer that accepts writes and a
-//! *back* buffer used during drain. [`swap_and_drain`](DeferredIndexer::swap_and_drain)
-//! rotates front to back, drains the old front, and returns the vectors for
-//! the caller to insert into HNSW.
+//! The indexer holds one buffer that accepts writes. When the buffer reaches
+//! `merge_threshold`, [`swap_and_drain`](DeferredIndexer::swap_and_drain)
+//! drains it and returns the vectors for the caller to batch-insert into HNSW.
 //!
 //! # Deleted IDs
 //!
@@ -28,8 +28,8 @@
 use super::delta::DeltaBuffer;
 use crate::distance::DistanceMetric;
 use parking_lot::{Mutex, RwLock};
+use rustc_hash::FxHashSet;
 use serde::{Deserialize, Serialize};
-use std::collections::HashSet;
 use std::sync::Arc;
 
 // ── Constants ────────────────────────────────────────────────────────────────
@@ -96,17 +96,15 @@ impl Default for DeferredIndexerConfig {
 ///
 /// See the [module-level docs](self) for design details.
 pub struct DeferredIndexer {
-    /// Front buffer — accepts writes.
-    front: Arc<DeltaBuffer>,
-
-    /// Back buffer — used during swap-and-drain.
-    back: Arc<DeltaBuffer>,
+    /// Write buffer — accepts pushes and is drained on merge.
+    buffer: Arc<DeltaBuffer>,
 
     /// Serializes swap-and-drain operations so only one drain runs at a time.
     swap_lock: Mutex<()>,
 
     /// IDs deleted while in the buffer. Filtered out of search results.
-    deleted_ids: RwLock<HashSet<u64>>,
+    /// Uses `FxHashSet` for faster integer hashing on the hot search path.
+    deleted_ids: RwLock<FxHashSet<u64>>,
 
     /// Configuration (immutable after construction).
     config: DeferredIndexerConfig,
@@ -115,15 +113,14 @@ pub struct DeferredIndexer {
 impl DeferredIndexer {
     /// Creates a new `DeferredIndexer` with the given configuration.
     ///
-    /// Both buffers start inactive. If `config.enabled` is `false`, all
+    /// The buffer starts inactive. If `config.enabled` is `false`, all
     /// write operations are no-ops.
     #[must_use]
     pub fn new(config: DeferredIndexerConfig) -> Self {
         Self {
-            front: Arc::new(DeltaBuffer::new()),
-            back: Arc::new(DeltaBuffer::new()),
+            buffer: Arc::new(DeltaBuffer::new()),
             swap_lock: Mutex::new(()),
-            deleted_ids: RwLock::new(HashSet::new()),
+            deleted_ids: RwLock::new(FxHashSet::default()),
             config,
         }
     }
@@ -134,57 +131,69 @@ impl DeferredIndexer {
         self.config.enabled
     }
 
-    /// Pushes a vector into the front buffer.
+    /// Pushes a vector into the write buffer.
     ///
-    /// Activates the front buffer lazily on first write. Returns `true` if
-    /// the front buffer has reached `merge_threshold`, signaling the caller
+    /// Activates the buffer lazily on first write. Returns `true` if
+    /// the buffer has reached `merge_threshold`, signaling the caller
     /// to trigger a merge.
     ///
     /// No-op if deferred indexing is disabled.
+    ///
+    /// # TOCTOU note
+    ///
+    /// The `enabled` check and `len() >= threshold` read are not atomic with
+    /// the push. This is benign: a concurrent drain may reset the count
+    /// between push and the threshold check, causing a missed merge signal.
+    /// The next push will re-trigger.
     pub fn push(&self, id: u64, vector: Vec<f32>) -> bool {
         if !self.config.enabled {
             return false;
         }
-        self.ensure_front_active();
-        self.front.push(id, vector);
-        self.front.len() >= self.config.merge_threshold
+        self.ensure_buffer_active();
+        self.buffer.push(id, vector);
+        self.buffer.len() >= self.config.merge_threshold
     }
 
-    /// Batch-pushes vectors into the front buffer.
+    /// Batch-pushes vectors into the write buffer.
     ///
-    /// Returns `true` if the front buffer has reached `merge_threshold`.
+    /// Returns `true` if the buffer has reached `merge_threshold`.
     /// No-op if deferred indexing is disabled.
     pub fn extend(&self, entries: impl IntoIterator<Item = (u64, Vec<f32>)>) -> bool {
         if !self.config.enabled {
             return false;
         }
-        self.ensure_front_active();
-        self.front.extend(entries);
-        self.front.len() >= self.config.merge_threshold
+        self.ensure_buffer_active();
+        self.buffer.extend(entries);
+        self.buffer.len() >= self.config.merge_threshold
     }
 
-    /// Marks `id` as deleted, removing it from both buffers.
+    /// Marks `id` as deleted, removing it from the buffer.
     ///
     /// The ID is added to `deleted_ids` so that search results are filtered
     /// even if the vector was already snapshot for a concurrent search.
     pub fn remove(&self, id: u64) {
-        self.front.remove(id);
-        self.back.remove(id);
+        self.buffer.remove(id);
         self.deleted_ids.write().insert(id);
     }
 
-    /// Brute-force searches both buffers, filtering deleted IDs.
+    /// Brute-force searches the buffer, filtering deleted IDs.
     ///
-    /// Results are deduplicated by ID (best score wins), sorted by the
-    /// metric ordering, and truncated to `k`.
+    /// Results are sorted by the metric ordering and truncated to `k`.
+    ///
+    /// # TOCTOU note
+    ///
+    /// The `deleted_ids` snapshot is read under a separate lock from the
+    /// buffer search. A concurrent delete between the buffer snapshot and the
+    /// `deleted_ids` read is benign: the ID will be filtered on the next
+    /// search after the delete completes.
     #[must_use]
     pub fn search(&self, query: &[f32], k: usize, metric: DistanceMetric) -> Vec<(u64, f32)> {
-        let front_results = self.front.search(query, k, metric);
-        let back_results = self.back.search(query, k, metric);
-
+        let buffer_results = self.buffer.search(query, k, metric);
         let deleted = self.deleted_ids.read();
-        let merged = merge_and_dedup(front_results, back_results, &deleted, metric);
-        truncated(merged, k)
+        let mut filtered = filter_deleted(buffer_results, &deleted);
+        metric.sort_results(&mut filtered);
+        filtered.truncate(k);
+        filtered
     }
 
     /// Merges HNSW results with deferred buffer results.
@@ -205,7 +214,7 @@ impl DeferredIndexer {
         if buffer_results.is_empty() {
             return hnsw_results;
         }
-        let hnsw_ids: HashSet<u64> = hnsw_results.iter().map(|(id, _)| *id).collect();
+        let hnsw_ids: FxHashSet<u64> = hnsw_results.iter().map(|(id, _)| *id).collect();
         let mut combined: Vec<(u64, f32)> = hnsw_results;
         combined.extend(
             buffer_results
@@ -217,9 +226,9 @@ impl DeferredIndexer {
         combined
     }
 
-    /// Drains the front buffer and returns vectors for HNSW insertion.
+    /// Drains the buffer and returns vectors for HNSW insertion.
     ///
-    /// After this call the front buffer is empty and inactive (a subsequent
+    /// After this call the buffer is empty and inactive (a subsequent
     /// `push` will re-activate it). The `deleted_ids` set is cleared because
     /// the caller is expected to apply deletions to HNSW after merge.
     ///
@@ -227,100 +236,60 @@ impl DeferredIndexer {
     /// second caller gets an empty drain).
     pub fn swap_and_drain(&self) -> Vec<(u64, Vec<f32>)> {
         let _guard = self.swap_lock.lock();
-        let drained = self.front.deactivate_and_drain();
+        let drained = self.buffer.deactivate_and_drain();
         self.deleted_ids.write().clear();
         drained
     }
 
-    /// Total number of pending (not yet indexed) vectors across both buffers.
+    /// Total number of pending (not yet indexed) vectors in the buffer.
     #[must_use]
     pub fn pending_count(&self) -> usize {
-        self.front.len() + self.back.len()
+        self.buffer.len()
     }
 
-    /// Returns `true` if the front buffer has reached `merge_threshold`.
+    /// Returns `true` if the buffer has reached `merge_threshold`.
     #[must_use]
     pub fn should_merge(&self) -> bool {
-        self.front.len() >= self.config.merge_threshold
+        self.buffer.len() >= self.config.merge_threshold
     }
 
-    /// Returns `true` if deferred indexing is enabled and either buffer has
+    /// Returns `true` if deferred indexing is enabled and the buffer has
     /// searchable data.
     #[must_use]
     pub fn is_searchable(&self) -> bool {
-        self.config.enabled && (self.front.is_searchable() || self.back.is_searchable())
+        self.config.enabled && self.buffer.is_searchable()
     }
 
-    /// Drains all vectors from both buffers (for shutdown / flush).
+    /// Drains all vectors from the buffer (for shutdown / flush).
     ///
-    /// Clears `deleted_ids`. After this call both buffers are empty and
+    /// Clears `deleted_ids`. After this call the buffer is empty and
     /// inactive.
     pub fn drain_all(&self) -> Vec<(u64, Vec<f32>)> {
         let _guard = self.swap_lock.lock();
-        let mut all = self.front.deactivate_and_drain();
-        all.extend(self.back.deactivate_and_drain());
+        let all = self.buffer.deactivate_and_drain();
         self.deleted_ids.write().clear();
         all
     }
 
-    /// Lazily activates the front buffer if it is not already active.
-    fn ensure_front_active(&self) {
-        if !self.front.is_active() {
-            self.front.activate();
+    /// Lazily activates the buffer if it is not already active.
+    fn ensure_buffer_active(&self) {
+        if !self.buffer.is_active() {
+            self.buffer.activate();
         }
     }
 }
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
-/// Merges two result sets, deduplicating by ID (best score wins) and
-/// filtering deleted IDs.
-fn merge_and_dedup(
-    a: Vec<(u64, f32)>,
-    b: Vec<(u64, f32)>,
-    deleted: &HashSet<u64>,
-    metric: DistanceMetric,
-) -> Vec<(u64, f32)> {
-    let mut seen: HashSet<u64> = HashSet::with_capacity(a.len() + b.len());
-    let mut merged: Vec<(u64, f32)> = Vec::with_capacity(a.len() + b.len());
-
-    for (id, score) in a.into_iter().chain(b) {
-        if deleted.contains(&id) {
-            continue;
-        }
-        if seen.insert(id) {
-            merged.push((id, score));
-        } else {
-            update_best_score(&mut merged, id, score, metric);
-        }
+/// Filters out deleted IDs from a result set.
+fn filter_deleted(results: Vec<(u64, f32)>, deleted: &FxHashSet<u64>) -> Vec<(u64, f32)> {
+    if deleted.is_empty() {
+        return results;
     }
-
-    metric.sort_results(&mut merged);
-    merged
-}
-
-/// Updates the score for `id` in `results` if `new_score` is better
-/// according to the metric ordering.
-fn update_best_score(results: &mut [(u64, f32)], id: u64, new_score: f32, metric: DistanceMetric) {
-    for entry in results.iter_mut() {
-        if entry.0 == id {
-            let keep_new = if metric.higher_is_better() {
-                new_score > entry.1
-            } else {
-                new_score < entry.1
-            };
-            if keep_new {
-                entry.1 = new_score;
-            }
-            return;
-        }
-    }
-}
-
-/// Truncates a result vector to at most `k` elements.
-fn truncated(mut v: Vec<(u64, f32)>, k: usize) -> Vec<(u64, f32)> {
-    v.truncate(k);
-    v
+    results
+        .into_iter()
+        .filter(|(id, _)| !deleted.contains(id))
+        .collect()
 }
 
 // ── Tests ────────────────────────────────────────────────────────────────────
@@ -328,6 +297,7 @@ fn truncated(mut v: Vec<(u64, f32)>, k: usize) -> Vec<(u64, f32)> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::HashSet;
 
     /// Helper: builds an enabled config with a custom threshold.
     fn enabled_config(threshold: usize) -> DeferredIndexerConfig {
@@ -410,7 +380,7 @@ mod tests {
 
         let drained = idx.swap_and_drain();
         assert_eq!(drained.len(), 2);
-        assert_eq!(idx.pending_count(), 0, "front should be empty after drain");
+        assert_eq!(idx.pending_count(), 0, "buffer should be empty after drain");
     }
 
     #[test]

--- a/crates/velesdb-core/src/collection/streaming/deferred.rs
+++ b/crates/velesdb-core/src/collection/streaming/deferred.rs
@@ -180,6 +180,10 @@ impl DeferredIndexer {
     ///
     /// Results are sorted by the metric ordering and truncated to `k`.
     ///
+    /// To compensate for post-filter attrition, the buffer is queried with
+    /// `k + deleted_ids.len()` candidates. This is bounded: `deleted_ids`
+    /// never exceeds `merge_threshold` entries (cleared on every drain).
+    ///
     /// # TOCTOU note
     ///
     /// The `deleted_ids` snapshot is read under a separate lock from the
@@ -188,9 +192,11 @@ impl DeferredIndexer {
     /// search after the delete completes.
     #[must_use]
     pub fn search(&self, query: &[f32], k: usize, metric: DistanceMetric) -> Vec<(u64, f32)> {
-        let buffer_results = self.buffer.search(query, k, metric);
         let deleted = self.deleted_ids.read();
+        let overfetch = k.saturating_add(deleted.len());
+        let buffer_results = self.buffer.search(query, overfetch, metric);
         let mut filtered = filter_deleted(buffer_results, &deleted);
+        drop(deleted);
         metric.sort_results(&mut filtered);
         filtered.truncate(k);
         filtered

--- a/crates/velesdb-core/src/collection/streaming/deferred.rs
+++ b/crates/velesdb-core/src/collection/streaming/deferred.rs
@@ -145,6 +145,12 @@ impl DeferredIndexer {
     /// the push. This is benign: a concurrent drain may reset the count
     /// between push and the threshold check, causing a missed merge signal.
     /// The next push will re-trigger.
+    ///
+    /// A previous TOCTOU window existed where `swap_and_drain` could
+    /// deactivate the buffer between `ensure_buffer_active` and the
+    /// underlying `buffer.push`, causing the vector to be silently dropped.
+    /// This is fixed: `swap_and_drain` now re-activates the buffer after
+    /// draining so pushes between drain and the next merge succeed.
     pub fn push(&self, id: u64, vector: Vec<f32>) -> bool {
         if !self.config.enabled {
             return false;
@@ -204,8 +210,12 @@ impl DeferredIndexer {
 
     /// Merges HNSW results with deferred buffer results.
     ///
-    /// HNSW is authoritative: if the same ID appears in both HNSW and the
-    /// buffer, the HNSW score is kept (the indexed position is canonical).
+    /// Buffer is authoritative on duplicate IDs (more recent data): when a
+    /// point is upserted while deferred indexing is active, the new vector
+    /// goes to the buffer while HNSW still holds the stale vector. On ID
+    /// conflict the buffer score is kept, mirroring `merge_with_delta` in
+    /// `delta.rs`.
+    ///
     /// Deleted IDs are filtered from buffer results but not from HNSW
     /// results (HNSW has its own tombstone system).
     #[must_use]
@@ -220,13 +230,14 @@ impl DeferredIndexer {
         if buffer_results.is_empty() {
             return hnsw_results;
         }
-        let hnsw_ids: FxHashSet<u64> = hnsw_results.iter().map(|(id, _)| *id).collect();
-        let mut combined: Vec<(u64, f32)> = hnsw_results;
-        combined.extend(
-            buffer_results
-                .into_iter()
-                .filter(|(id, _)| !hnsw_ids.contains(id)),
-        );
+        // Buffer holds more-recent data (upserts route through buffer, not HNSW).
+        // On ID conflict, keep the buffer score.
+        let buffer_ids: FxHashSet<u64> = buffer_results.iter().map(|(id, _)| *id).collect();
+        let mut combined: Vec<(u64, f32)> = hnsw_results
+            .into_iter()
+            .filter(|(id, _)| !buffer_ids.contains(id))
+            .collect();
+        combined.extend(buffer_results);
         metric.sort_results(&mut combined);
         combined.truncate(k);
         combined
@@ -234,9 +245,10 @@ impl DeferredIndexer {
 
     /// Drains the buffer and returns vectors for HNSW insertion.
     ///
-    /// After this call the buffer is empty and inactive (a subsequent
-    /// `push` will re-activate it). The `deleted_ids` set is cleared because
-    /// the caller is expected to apply deletions to HNSW after merge.
+    /// After this call the buffer is empty but **re-activated** so that
+    /// pushes arriving between drain and the next merge are not silently
+    /// dropped. The `deleted_ids` set is cleared because the caller is
+    /// expected to apply deletions to HNSW after merge.
     ///
     /// Serialized by an internal mutex so concurrent calls are safe (the
     /// second caller gets an empty drain).
@@ -244,6 +256,9 @@ impl DeferredIndexer {
         let _guard = self.swap_lock.lock();
         let drained = self.buffer.deactivate_and_drain();
         self.deleted_ids.write().clear();
+        // Re-activate the buffer so pushes between drain and next merge
+        // are not silently dropped (fixes TOCTOU race with concurrent push).
+        self.buffer.activate();
         drained
     }
 
@@ -399,6 +414,45 @@ mod tests {
         assert!(idx.deleted_ids.read().is_empty());
     }
 
+    #[test]
+    fn test_deferred_swap_and_drain_reactivates_buffer() {
+        // Regression: swap_and_drain must re-activate the buffer so that
+        // pushes between drain and the next merge are not silently dropped.
+        let idx = DeferredIndexer::new(enabled_config(1024));
+        idx.push(1, vec![1.0]);
+        let _ = idx.swap_and_drain();
+
+        // After drain, the buffer should be re-activated and accept pushes.
+        idx.push(2, vec![2.0]);
+        assert_eq!(idx.pending_count(), 1, "push after drain must succeed");
+        assert!(
+            idx.is_searchable(),
+            "buffer should be searchable after push"
+        );
+    }
+
+    #[test]
+    fn test_deferred_drain_all_leaves_buffer_inactive() {
+        // drain_all is for shutdown — buffer is left inactive (not
+        // re-activated like swap_and_drain). A subsequent push *will*
+        // re-activate via ensure_buffer_active, but there is a window
+        // where the buffer is inactive immediately after drain_all.
+        let idx = DeferredIndexer::new(enabled_config(1024));
+        idx.push(1, vec![1.0]);
+        let _ = idx.drain_all();
+
+        // Immediately after drain_all the buffer is inactive.
+        assert!(
+            !idx.is_searchable(),
+            "buffer must not be searchable immediately after drain_all"
+        );
+        assert_eq!(
+            idx.pending_count(),
+            0,
+            "buffer should be empty after drain_all"
+        );
+    }
+
     // ── Merge with HNSW tests ────────────────────────────────────────────
 
     #[test]
@@ -416,17 +470,18 @@ mod tests {
         let unique: HashSet<u64> = ids.iter().copied().collect();
         assert_eq!(ids.len(), unique.len(), "no duplicate IDs");
 
-        // All three IDs should be present (10 from HNSW, 20 from HNSW, 30 from buffer)
+        // All three IDs should be present (10 from buffer, 20 from HNSW, 30 from buffer)
         assert_eq!(merged.len(), 3);
         assert!(ids.contains(&10));
         assert!(ids.contains(&20));
         assert!(ids.contains(&30));
 
-        // HNSW score for id=10 should be kept (0.95), not buffer score
+        // Buffer score for id=10 should be kept (not the HNSW score of 0.95),
+        // because the buffer holds more-recent data (upserts route there).
         let id10_score = merged.iter().find(|(id, _)| *id == 10).map(|(_, s)| *s);
         assert!(
-            (id10_score.unwrap_or(0.0) - 0.95).abs() < f32::EPSILON,
-            "HNSW score should be authoritative for id=10"
+            (id10_score.unwrap_or(0.0) - 0.95).abs() > f32::EPSILON,
+            "buffer score should be authoritative for id=10, not HNSW"
         );
     }
 

--- a/crates/velesdb-core/src/collection/streaming/deferred.rs
+++ b/crates/velesdb-core/src/collection/streaming/deferred.rs
@@ -154,10 +154,7 @@ impl DeferredIndexer {
     ///
     /// Returns `true` if the front buffer has reached `merge_threshold`.
     /// No-op if deferred indexing is disabled.
-    pub fn extend(
-        &self,
-        entries: impl IntoIterator<Item = (u64, Vec<f32>)>,
-    ) -> bool {
+    pub fn extend(&self, entries: impl IntoIterator<Item = (u64, Vec<f32>)>) -> bool {
         if !self.config.enabled {
             return false;
         }
@@ -181,22 +178,12 @@ impl DeferredIndexer {
     /// Results are deduplicated by ID (best score wins), sorted by the
     /// metric ordering, and truncated to `k`.
     #[must_use]
-    pub fn search(
-        &self,
-        query: &[f32],
-        k: usize,
-        metric: DistanceMetric,
-    ) -> Vec<(u64, f32)> {
+    pub fn search(&self, query: &[f32], k: usize, metric: DistanceMetric) -> Vec<(u64, f32)> {
         let front_results = self.front.search(query, k, metric);
         let back_results = self.back.search(query, k, metric);
 
         let deleted = self.deleted_ids.read();
-        let merged = merge_and_dedup(
-            front_results,
-            back_results,
-            &deleted,
-            metric,
-        );
+        let merged = merge_and_dedup(front_results, back_results, &deleted, metric);
         truncated(merged, k)
     }
 
@@ -218,8 +205,7 @@ impl DeferredIndexer {
         if buffer_results.is_empty() {
             return hnsw_results;
         }
-        let hnsw_ids: HashSet<u64> =
-            hnsw_results.iter().map(|(id, _)| *id).collect();
+        let hnsw_ids: HashSet<u64> = hnsw_results.iter().map(|(id, _)| *id).collect();
         let mut combined: Vec<(u64, f32)> = hnsw_results;
         combined.extend(
             buffer_results
@@ -262,8 +248,7 @@ impl DeferredIndexer {
     /// searchable data.
     #[must_use]
     pub fn is_searchable(&self) -> bool {
-        self.config.enabled
-            && (self.front.is_searchable() || self.back.is_searchable())
+        self.config.enabled && (self.front.is_searchable() || self.back.is_searchable())
     }
 
     /// Drains all vectors from both buffers (for shutdown / flush).
@@ -297,8 +282,7 @@ fn merge_and_dedup(
     metric: DistanceMetric,
 ) -> Vec<(u64, f32)> {
     let mut seen: HashSet<u64> = HashSet::with_capacity(a.len() + b.len());
-    let mut merged: Vec<(u64, f32)> =
-        Vec::with_capacity(a.len() + b.len());
+    let mut merged: Vec<(u64, f32)> = Vec::with_capacity(a.len() + b.len());
 
     for (id, score) in a.into_iter().chain(b) {
         if deleted.contains(&id) {
@@ -317,12 +301,7 @@ fn merge_and_dedup(
 
 /// Updates the score for `id` in `results` if `new_score` is better
 /// according to the metric ordering.
-fn update_best_score(
-    results: &mut [(u64, f32)],
-    id: u64,
-    new_score: f32,
-    metric: DistanceMetric,
-) {
+fn update_best_score(results: &mut [(u64, f32)], id: u64, new_score: f32, metric: DistanceMetric) {
     for entry in results.iter_mut() {
         if entry.0 == id {
             let keep_new = if metric.higher_is_better() {
@@ -389,11 +368,7 @@ mod tests {
     #[test]
     fn test_deferred_extend_returns_true_at_threshold() {
         let idx = DeferredIndexer::new(enabled_config(3));
-        let entries = vec![
-            (1, vec![1.0]),
-            (2, vec![2.0]),
-            (3, vec![3.0]),
-        ];
+        let entries = vec![(1, vec![1.0]), (2, vec![2.0]), (3, vec![3.0])];
         assert!(idx.extend(entries), "batch should hit threshold");
     }
 
@@ -419,13 +394,9 @@ mod tests {
         idx.push(3, vec![0.0, 0.0, 1.0]);
         idx.remove(2);
 
-        let results =
-            idx.search(&[1.0, 0.0, 0.0], 10, DistanceMetric::Euclidean);
+        let results = idx.search(&[1.0, 0.0, 0.0], 10, DistanceMetric::Euclidean);
         let ids: Vec<u64> = results.iter().map(|(id, _)| *id).collect();
-        assert!(
-            !ids.contains(&2),
-            "deleted ID 2 must not appear in results"
-        );
+        assert!(!ids.contains(&2), "deleted ID 2 must not appear in results");
         assert_eq!(ids.len(), 2);
     }
 
@@ -462,12 +433,7 @@ mod tests {
 
         // HNSW results: id=10 (also in buffer) and id=20 (only in HNSW)
         let hnsw = vec![(10, 0.95_f32), (20, 0.80_f32)];
-        let merged = idx.merge_with_hnsw(
-            hnsw,
-            &[1.0, 0.0],
-            3,
-            DistanceMetric::Cosine,
-        );
+        let merged = idx.merge_with_hnsw(hnsw, &[1.0, 0.0], 3, DistanceMetric::Cosine);
 
         // No duplicate IDs
         let ids: Vec<u64> = merged.iter().map(|(id, _)| *id).collect();
@@ -493,12 +459,7 @@ mod tests {
         let idx = DeferredIndexer::new(enabled_config(1024));
         // Buffer is empty — merge should return HNSW results unchanged
         let hnsw = vec![(1, 0.9_f32), (2, 0.8_f32)];
-        let merged = idx.merge_with_hnsw(
-            hnsw.clone(),
-            &[1.0, 0.0],
-            5,
-            DistanceMetric::Cosine,
-        );
+        let merged = idx.merge_with_hnsw(hnsw.clone(), &[1.0, 0.0], 5, DistanceMetric::Cosine);
         assert_eq!(merged, hnsw);
     }
 
@@ -526,8 +487,7 @@ mod tests {
             max_buffer_age_ms: 3000,
         };
         let json = serde_json::to_string(&config).expect("serialize");
-        let restored: DeferredIndexerConfig =
-            serde_json::from_str(&json).expect("deserialize");
+        let restored: DeferredIndexerConfig = serde_json::from_str(&json).expect("deserialize");
         assert!(restored.enabled);
         assert_eq!(restored.merge_threshold, 512);
         assert_eq!(restored.max_buffer_age_ms, 3000);
@@ -536,8 +496,7 @@ mod tests {
     #[test]
     fn test_deferred_config_serde_defaults() {
         let json = "{}";
-        let config: DeferredIndexerConfig =
-            serde_json::from_str(json).expect("deserialize empty");
+        let config: DeferredIndexerConfig = serde_json::from_str(json).expect("deserialize empty");
         assert!(!config.enabled);
         assert_eq!(config.merge_threshold, DEFAULT_MERGE_THRESHOLD);
         assert_eq!(config.max_buffer_age_ms, DEFAULT_MAX_BUFFER_AGE_MS);

--- a/crates/velesdb-core/src/collection/streaming/delta.rs
+++ b/crates/velesdb-core/src/collection/streaming/delta.rs
@@ -123,7 +123,14 @@ impl DeltaBuffer {
         drained
     }
 
-    /// Pushes a single entry into the delta buffer.
+    /// Pushes a single entry into the delta buffer (upsert semantics).
+    ///
+    /// If an entry with the same `id` already exists, it is replaced.
+    /// This prevents duplicate IDs from accumulating when the same point
+    /// is inserted multiple times during an HNSW rebuild.
+    ///
+    /// The retain-then-push is O(n) but acceptable: the buffer is bounded
+    /// by `merge_threshold` (typically 1024-4096 entries).
     ///
     /// No-op if the buffer is not in `ACTIVE` state. The check is performed
     /// **inside** the write lock to close the TOCTOU window between `is_active()`
@@ -131,11 +138,15 @@ impl DeltaBuffer {
     pub fn push(&self, id: u64, vector: Vec<f32>) {
         let mut points = self.points.write();
         if self.state.load(Ordering::Acquire) == ACTIVE {
+            points.retain(|(existing_id, _)| *existing_id != id);
             points.push((id, vector));
         }
     }
 
-    /// Extends the delta buffer with multiple entries.
+    /// Extends the delta buffer with multiple entries (upsert semantics).
+    ///
+    /// For each entry, any existing entry with the same ID is replaced.
+    /// This prevents duplicate IDs from accumulating in the buffer.
     ///
     /// No-op if the buffer is not in `ACTIVE` state. The check is performed
     /// **inside** the write lock to close the TOCTOU window between `is_active()`
@@ -143,8 +154,21 @@ impl DeltaBuffer {
     pub fn extend(&self, entries: impl IntoIterator<Item = (u64, Vec<f32>)>) {
         let mut points = self.points.write();
         if self.state.load(Ordering::Acquire) == ACTIVE {
-            points.extend(entries);
+            let new_entries: Vec<(u64, Vec<f32>)> = entries.into_iter().collect();
+            let new_ids: HashSet<u64> = new_entries.iter().map(|(id, _)| *id).collect();
+            points.retain(|(existing_id, _)| !new_ids.contains(existing_id));
+            points.extend(new_entries);
         }
+    }
+
+    /// Removes all entries matching the given point ID from the buffer.
+    ///
+    /// Works in any state (`ACTIVE`, `DRAINING`, or `INACTIVE`): a delete
+    /// must always purge stale data regardless of the buffer lifecycle.
+    /// This prevents ghost results where a deleted vector is still returned
+    /// by the delta brute-force scan.
+    pub fn remove(&self, id: u64) {
+        self.points.write().retain(|(eid, _)| *eid != id);
     }
 
     /// Returns the number of buffered entries.
@@ -464,5 +488,78 @@ mod tests {
         let (len, is_empty) = buf.stats();
         assert_eq!(len, 1);
         assert!(!is_empty);
+    }
+
+    // ── Bug B0.1: remove() filters deleted points from search ──────────
+
+    #[test]
+    fn test_delta_remove_filters_deleted_point() {
+        let buf = DeltaBuffer::new();
+        buf.activate();
+        buf.push(1, vec![1.0, 2.0, 3.0]);
+        buf.push(2, vec![4.0, 5.0, 6.0]);
+        buf.remove(1);
+        let results = buf.search(&[1.0, 2.0, 3.0], 10, DistanceMetric::Euclidean);
+        assert!(
+            results.iter().all(|(id, _)| *id != 1),
+            "Deleted point should not appear in search results"
+        );
+        assert_eq!(results.len(), 1, "Only point 2 should remain");
+    }
+
+    #[test]
+    fn test_delta_remove_nonexistent_id_is_noop() {
+        let buf = DeltaBuffer::new();
+        buf.activate();
+        buf.push(1, vec![1.0, 2.0]);
+        buf.remove(999);
+        assert_eq!(buf.len(), 1, "Removing absent ID should not change length");
+    }
+
+    #[test]
+    fn test_delta_remove_works_in_draining_state() {
+        let buf = DeltaBuffer::new();
+        buf.activate();
+        buf.push(1, vec![1.0]);
+        buf.push(2, vec![2.0]);
+        // remove() works unconditionally (any state) — a delete must always
+        // purge stale data regardless of buffer lifecycle.
+        buf.remove(1);
+        assert_eq!(buf.len(), 1);
+    }
+
+    // ── Bug B0.4: push() deduplicates on same ID (upsert semantics) ───
+
+    #[test]
+    fn test_delta_push_deduplicates_on_same_id() {
+        let buf = DeltaBuffer::new();
+        buf.activate();
+        buf.push(1, vec![1.0, 2.0, 3.0]);
+        buf.push(1, vec![4.0, 5.0, 6.0]); // Same ID, different vector
+        assert_eq!(buf.len(), 1, "Should have deduplicated");
+        let results = buf.search(&[4.0, 5.0, 6.0], 1, DistanceMetric::Euclidean);
+        assert_eq!(results[0].0, 1);
+        // Distance should be ~0 since query matches the updated vector
+        assert!(
+            results[0].1 < 0.01,
+            "Updated vector should match query closely"
+        );
+    }
+
+    #[test]
+    fn test_delta_extend_deduplicates_on_same_id() {
+        let buf = DeltaBuffer::new();
+        buf.activate();
+        buf.push(1, vec![1.0, 0.0]);
+        buf.push(2, vec![0.0, 1.0]);
+        // Extend with updates for id=1 and a new id=3
+        buf.extend(vec![(1, vec![0.5, 0.5]), (3, vec![0.0, 0.0])]);
+        assert_eq!(buf.len(), 3, "Should have ids 1, 2, 3");
+        let results = buf.search(&[0.5, 0.5], 1, DistanceMetric::Euclidean);
+        assert_eq!(
+            results[0].0, 1,
+            "ID 1 should have updated vector [0.5, 0.5]"
+        );
+        assert!(results[0].1 < 0.01, "Updated vector should match query");
     }
 }

--- a/crates/velesdb-core/src/collection/streaming/mod.rs
+++ b/crates/velesdb-core/src/collection/streaming/mod.rs
@@ -9,8 +9,13 @@
 pub mod delta;
 
 #[cfg(feature = "persistence")]
+pub mod deferred;
+
+#[cfg(feature = "persistence")]
 mod ingester;
 
+#[cfg(feature = "persistence")]
+pub use deferred::{DeferredIndexer, DeferredIndexerConfig};
 #[cfg(feature = "persistence")]
 pub use delta::{merge_with_delta, merge_with_delta_scored};
 #[cfg(feature = "persistence")]

--- a/crates/velesdb-core/src/collection/types.rs
+++ b/crates/velesdb-core/src/collection/types.rs
@@ -5,7 +5,7 @@ use crate::collection::stats::CollectionStats;
 #[cfg(feature = "persistence")]
 use crate::collection::streaming::delta::DeltaBuffer;
 #[cfg(feature = "persistence")]
-use crate::collection::streaming::{BackpressureError, StreamIngester};
+use crate::collection::streaming::{BackpressureError, DeferredIndexer, StreamIngester};
 use crate::distance::DistanceMetric;
 use crate::guardrails::GuardRails;
 use crate::index::hnsw::HnswParams;
@@ -174,6 +174,18 @@ pub struct CollectionConfig {
     /// deserialize to `None`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub hnsw_params: Option<HnswParams>,
+
+    /// Deferred indexing configuration (US-366).
+    ///
+    /// When `Some` and `enabled`, inserts are buffered in memory and
+    /// batch-merged into the HNSW index when the buffer reaches
+    /// `merge_threshold`. This decouples write latency from index cost.
+    ///
+    /// Backward compatible: old `config.json` files without this field
+    /// deserialize to `None` (disabled).
+    #[cfg(feature = "persistence")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub deferred_indexing: Option<crate::collection::streaming::DeferredIndexerConfig>,
 }
 
 /// Returns `Some(4)` as the default PQ rescore oversampling factor.
@@ -198,6 +210,7 @@ fn default_pq_rescore_oversampling() -> Option<u32> {
 //   8. edge_store
 //   9. sparse_indexes
 //  10. delta_buffer
+//  11. deferred_indexer (internal locks)
 
 /// A collection of vectors with associated metadata.
 #[deprecated(
@@ -292,6 +305,15 @@ pub struct Collection {
     /// Lock order position: **10** (after `sparse_indexes` at 9).
     #[cfg(feature = "persistence")]
     pub(crate) delta_buffer: Arc<DeltaBuffer>,
+
+    /// Deferred indexer for high-throughput sequential inserts (US-366).
+    ///
+    /// `None` when deferred indexing is not configured. When `Some`, inserts
+    /// are buffered and batch-merged into the HNSW index at threshold.
+    ///
+    /// Lock order position: **11** (after `delta_buffer` at 10).
+    #[cfg(feature = "persistence")]
+    pub(crate) deferred_indexer: Option<Arc<DeferredIndexer>>,
 }
 
 impl Collection {
@@ -382,6 +404,8 @@ mod rescore_config_tests {
             embedding_dimension: None,
             pq_rescore_oversampling: oversampling,
             hnsw_params: None,
+            #[cfg(feature = "persistence")]
+            deferred_indexing: None,
         }
     }
 

--- a/crates/velesdb-core/src/index/hnsw/native/dual_precision.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/dual_precision.rs
@@ -139,10 +139,9 @@ impl<D: DistanceEngine> DualPrecisionHnsw<D> {
     pub fn insert(&mut self, vector: &[f32]) -> crate::error::Result<NodeId> {
         debug_assert_eq!(vector.len(), self.dimension);
 
-        // F-13: Push to quantized store or training buffer using a reference
-        // BEFORE passing ownership to inner.insert().
-        // Note: inner.insert() still clones internally (F-14), but we avoid an
-        // additional clone at this level for the quantized path.
+        // F-13: Push the borrowed slice to the quantized store or copy into the
+        // training buffer before forwarding to inner.insert(). The quantized
+        // path is zero-copy; only the training path allocates via to_vec().
         if let Some(ref mut store) = self.quantized_store {
             store.push(vector);
         } else {

--- a/crates/velesdb-core/src/index/hnsw/native/graph/search.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/graph/search.rs
@@ -4,9 +4,12 @@ use super::super::distance::DistanceEngine;
 use super::super::layer::NodeId;
 use super::super::ordered_float::OrderedFloat;
 use super::NativeHnsw;
+use crate::perf_optimizations::ContiguousVectors;
 use rustc_hash::FxHashSet;
+use smallvec::SmallVec;
 use std::borrow::Cow;
 use std::cell::RefCell;
+use std::cmp::Reverse;
 use std::collections::BinaryHeap;
 use std::sync::atomic::Ordering;
 
@@ -43,6 +46,130 @@ fn release_visited_set(mut set: FxHashSet<usize>) {
             pool.push(set);
         }
     });
+}
+
+// =============================================================================
+// Extracted search helpers (Issue #366, Phase A.1 GREEN)
+// =============================================================================
+
+/// Encapsulates the mutable state of a `search_layer` traversal.
+///
+/// Bundles the candidate/result heaps, visited set, and stagnation
+/// counter into a single struct to reduce argument counts and keep
+/// helper functions under the Codacy complexity limit.
+struct SearchState {
+    candidates: BinaryHeap<Reverse<(OrderedFloat, NodeId)>>,
+    results: BinaryHeap<(OrderedFloat, NodeId)>,
+    visited: FxHashSet<usize>,
+    stagnation_count: usize,
+}
+
+impl SearchState {
+    /// Creates a fresh search state, acquiring a visited set from the pool.
+    fn new() -> Self {
+        Self {
+            candidates: BinaryHeap::new(),
+            results: BinaryHeap::new(),
+            visited: acquire_visited_set(),
+            stagnation_count: 0,
+        }
+    }
+
+    /// Pushes a candidate node into both heaps and marks it visited.
+    #[inline]
+    fn push_candidate(&mut self, node: NodeId, dist: f32) {
+        self.candidates
+            .push(Reverse((OrderedFloat(dist), node)));
+        self.results.push((OrderedFloat(dist), node));
+        self.visited.insert(node);
+    }
+
+    /// Returns `true` if the search should terminate.
+    ///
+    /// Termination conditions:
+    /// 1. The current candidate distance exceeds the furthest result and
+    ///    the result set has reached `ef` capacity.
+    /// 2. Stagnation limit is enabled and the counter has reached it.
+    #[inline]
+    fn should_terminate(&self, c_dist: f32, ef: usize, stagnation_limit: usize) -> bool {
+        let furthest = self.results.peek().map_or(f32::MAX, |r| r.0 .0);
+        if c_dist > furthest && self.results.len() >= ef {
+            return true;
+        }
+        stagnation_limit > 0 && self.stagnation_count >= stagnation_limit
+    }
+
+    /// Updates the stagnation counter: resets on improvement, increments otherwise.
+    #[inline]
+    fn update_stagnation(&mut self, improved: bool) {
+        if improved {
+            self.stagnation_count = 0;
+        } else {
+            self.stagnation_count += 1;
+        }
+    }
+
+    /// Consumes the state and returns results sorted by distance ascending.
+    ///
+    /// Releases the visited set back to the thread-local pool.
+    fn into_sorted_results(self) -> Vec<(NodeId, f32)> {
+        release_visited_set(self.visited);
+        let mut result_vec: Vec<(NodeId, f32)> = self
+            .results
+            .into_iter()
+            .map(|(d, n)| (n, d.0))
+            .collect();
+        result_vec.sort_by(|a, b| a.1.total_cmp(&b.1));
+        result_vec
+    }
+}
+
+/// Gathers vector slices for unvisited neighbors, marking them visited.
+#[inline]
+fn gather_unvisited_neighbors<'a>(
+    neighbors: &[NodeId],
+    visited: &mut FxHashSet<usize>,
+    vectors: &'a ContiguousVectors,
+) -> SmallVec<[(NodeId, &'a [f32]); 32]> {
+    let mut batch = SmallVec::new();
+    for &neighbor in neighbors {
+        if visited.insert(neighbor) {
+            // SAFETY: neighbor is a valid node_id from the graph's neighbor list,
+            // only containing IDs of successfully inserted nodes.
+            // - Condition 1: neighbor < vectors.len().
+            // Reason: Batch gathering of unvisited neighbor vectors.
+            let vec = unsafe { vectors.get_unchecked(neighbor) };
+            batch.push((neighbor, vec));
+        }
+    }
+    batch
+}
+
+/// Processes batch distance results into the search state heaps.
+///
+/// Returns `true` if any neighbor improved the result set.
+#[inline]
+fn process_batch_results(
+    batch: &[(NodeId, &[f32])],
+    distances: &[f32],
+    ef: usize,
+    state: &mut SearchState,
+) -> bool {
+    let mut improved = false;
+    for (&(node_id, _), &dist) in batch.iter().zip(distances.iter()) {
+        let furthest = state.results.peek().map_or(f32::MAX, |r| r.0 .0);
+        if dist < furthest || state.results.len() < ef {
+            state
+                .candidates
+                .push(Reverse((OrderedFloat(dist), node_id)));
+            state.results.push((OrderedFloat(dist), node_id));
+            if state.results.len() > ef {
+                state.results.pop();
+            }
+            improved = true;
+        }
+    }
+    improved
 }
 
 impl<D: DistanceEngine> NativeHnsw<D> {
@@ -263,6 +390,10 @@ impl<D: DistanceEngine> NativeHnsw<D> {
 
     /// Search a single layer with ef candidates.
     ///
+    /// Delegates to [`SearchState`], [`gather_unvisited_neighbors`], and
+    /// [`process_batch_results`] to keep each helper under Codacy limits
+    /// (CC <= 8, NLOC <= 50).
+    ///
     /// F-03 optimization: acquires both vectors and layers read locks once
     /// before the search loop, avoiding ~ef lock acquire/release cycles.
     ///
@@ -278,17 +409,10 @@ impl<D: DistanceEngine> NativeHnsw<D> {
         layer: usize,
         stagnation_limit: usize,
     ) -> Vec<(NodeId, f32)> {
-        use std::cmp::Reverse;
-
-        let mut visited = acquire_visited_set();
-        let mut candidates: BinaryHeap<Reverse<(OrderedFloat, NodeId)>> = BinaryHeap::new();
-        let mut results: BinaryHeap<(OrderedFloat, NodeId)> = BinaryHeap::new();
+        let mut state = SearchState::new();
 
         self.with_vectors_and_layers_read(|vectors, layers| {
-            let dimension = vectors.dimension();
-            let prefetch_distance = crate::simd_native::calculate_prefetch_distance(dimension);
-            let mut stagnation_count: usize = 0;
-
+            // Initialize entry points
             for &ep in entry_points {
                 // SAFETY: ep is a valid node_id from entry_point or random probe,
                 // always IDs of successfully inserted nodes.
@@ -296,84 +420,37 @@ impl<D: DistanceEngine> NativeHnsw<D> {
                 // Reason: Entry-point initialization in search hot path.
                 let ep_vec = unsafe { vectors.get_unchecked(ep) };
                 let dist = self.distance.distance(query, ep_vec);
-                candidates.push(Reverse((OrderedFloat(dist), ep)));
-                results.push((OrderedFloat(dist), ep));
-                visited.insert(ep);
+                state.push_candidate(ep, dist);
             }
 
-            while let Some(Reverse((OrderedFloat(c_dist), c_node))) = candidates.pop() {
-                let furthest_dist = results.peek().map_or(f32::MAX, |r| r.0 .0);
-
-                if c_dist > furthest_dist && results.len() >= ef {
-                    break;
-                }
-
-                // Early termination on stagnation: if many consecutive candidates
-                // fail to improve the result set, the search region is exhausted.
-                if stagnation_limit > 0 && stagnation_count >= stagnation_limit {
+            // Main search loop
+            while let Some(Reverse((OrderedFloat(c_dist), c_node))) = state.candidates.pop() {
+                if state.should_terminate(c_dist, ef, stagnation_limit) {
                     break;
                 }
 
                 let improved = layers[layer]
                     .with_neighbors(c_node, |neighbors| {
-                        let mut improved_this_round = false;
-
-                        if should_prefetch(dimension) && neighbors.len() > prefetch_distance {
-                            for &neighbor_id in neighbors.iter().take(prefetch_distance) {
-                                if neighbor_id < vectors.len() {
-                                    vectors.prefetch(neighbor_id);
-                                }
-                            }
+                        let batch = gather_unvisited_neighbors(
+                            neighbors,
+                            &mut state.visited,
+                            vectors,
+                        );
+                        if batch.is_empty() {
+                            return false;
                         }
-
-                        for (i, neighbor) in neighbors.iter().enumerate() {
-                            if should_prefetch(dimension) && i + prefetch_distance < neighbors.len()
-                            {
-                                let prefetch_id = neighbors[i + prefetch_distance];
-                                if prefetch_id < vectors.len() {
-                                    vectors.prefetch(prefetch_id);
-                                }
-                            }
-
-                            if visited.insert(*neighbor) {
-                                // SAFETY: *neighbor is a valid node_id from the graph's
-                                // neighbor list, only containing IDs of inserted nodes.
-                                // - Condition 1: *neighbor < vectors.len().
-                                // Reason: Inner search loop — bounds check eliminated.
-                                let n_vec = unsafe { vectors.get_unchecked(*neighbor) };
-                                let dist = self.distance.distance(query, n_vec);
-                                let furthest = results.peek().map_or(f32::MAX, |r| r.0 .0);
-
-                                if dist < furthest || results.len() < ef {
-                                    candidates.push(Reverse((OrderedFloat(dist), *neighbor)));
-                                    results.push((OrderedFloat(dist), *neighbor));
-
-                                    if results.len() > ef {
-                                        results.pop();
-                                    }
-                                    improved_this_round = true;
-                                }
-                            }
-                        }
-
-                        improved_this_round
+                        let vecs: SmallVec<[&[f32]; 32]> =
+                            batch.iter().map(|(_, v)| *v).collect();
+                        let distances = self.distance.batch_distance(query, &vecs);
+                        process_batch_results(&batch, &distances, ef, &mut state)
                     })
                     .unwrap_or(false);
 
-                if improved {
-                    stagnation_count = 0;
-                } else {
-                    stagnation_count += 1;
-                }
+                state.update_stagnation(improved);
             }
         });
 
-        release_visited_set(visited);
-
-        let mut result_vec: Vec<(NodeId, f32)> =
-            results.into_iter().map(|(d, n)| (n, d.0)).collect();
-        result_vec.sort_by(|a, b| a.1.total_cmp(&b.1));
-        result_vec
+        state.into_sorted_results()
     }
 
     /// Prepares a query vector for search or insertion. Returns `Cow::Borrowed`
@@ -407,17 +484,13 @@ impl<D: DistanceEngine> NativeHnsw<D> {
 
 #[cfg(test)]
 mod search_refactor_tests {
-    #![allow(unused_imports)] // RED phase: imports needed once TODO(US-366) code is uncommented
-
     use super::super::super::distance::SimdDistance;
     use super::super::super::layer::NodeId;
     use super::super::super::ordered_float::OrderedFloat;
     use super::super::NativeHnsw;
+    use super::SearchState;
+    use super::{gather_unvisited_neighbors, process_batch_results};
     use crate::distance::DistanceMetric;
-    // TODO(US-366): uncomment after SearchState is implemented
-    // use super::SearchState;
-    // use super::gather_unvisited_neighbors;
-    // use super::process_batch_results;
     use rustc_hash::FxHashSet;
     use smallvec::SmallVec;
     use std::cmp::Reverse;
@@ -428,6 +501,7 @@ mod search_refactor_tests {
     // =========================================================================
 
     /// Brute-force cosine distance for ground-truth computation.
+    #[allow(dead_code)]
     fn cosine_distance(a: &[f32], b: &[f32]) -> f32 {
         let dot: f32 = a.iter().zip(b.iter()).map(|(x, y)| x * y).sum();
         let norm_a: f32 = a.iter().map(|x| x * x).sum::<f32>().sqrt();
@@ -444,34 +518,37 @@ mod search_refactor_tests {
     // =========================================================================
 
     #[test]
-    #[ignore = "RED: SearchState does not exist yet"]
     fn test_search_state_new_and_push() {
-        // TODO(US-366): uncomment after SearchState is implemented
-        // let mut state = SearchState::new();
-        //
-        // // Push three candidates with known distances
-        // state.push_candidate(10, 0.5);
-        // state.push_candidate(20, 0.1);
-        // state.push_candidate(30, 0.9);
-        //
-        // // Candidates min-heap: closest first (0.1 at top)
-        // let (OrderedFloat(top_dist), top_node) = state.candidates.peek()
-        //     .map(|Reverse(item)| item)
-        //     .copied()
-        //     .expect("candidates should not be empty");
-        // assert_eq!(top_node, 20, "min-heap should surface closest candidate");
-        // assert!((top_dist - 0.1).abs() < f32::EPSILON);
-        //
-        // // Results max-heap: furthest first (0.9 at top)
-        // let &(OrderedFloat(furthest_dist), furthest_node) = state.results.peek()
-        //     .expect("results should not be empty");
-        // assert_eq!(furthest_node, 30, "max-heap should surface furthest result");
-        // assert!((furthest_dist - 0.9).abs() < f32::EPSILON);
-        //
-        // // Visited set should contain all three
-        // assert!(state.visited.contains(&10));
-        // assert!(state.visited.contains(&20));
-        // assert!(state.visited.contains(&30));
+        let mut state = SearchState::new();
+
+        // Push three candidates with known distances
+        state.push_candidate(10, 0.5);
+        state.push_candidate(20, 0.1);
+        state.push_candidate(30, 0.9);
+
+        // Candidates min-heap: closest first (0.1 at top)
+        let (OrderedFloat(top_dist), top_node) = state
+            .candidates
+            .peek()
+            .map(|Reverse(item)| item)
+            .copied()
+            .expect("candidates should not be empty");
+        assert_eq!(top_node, 20, "min-heap should surface closest candidate");
+        assert!((top_dist - 0.1).abs() < f32::EPSILON);
+
+        // Results max-heap: furthest first (0.9 at top)
+        let &(OrderedFloat(furthest_dist), furthest_node) =
+            state.results.peek().expect("results should not be empty");
+        assert_eq!(
+            furthest_node, 30,
+            "max-heap should surface furthest result"
+        );
+        assert!((furthest_dist - 0.9).abs() < f32::EPSILON);
+
+        // Visited set should contain all three
+        assert!(state.visited.contains(&10));
+        assert!(state.visited.contains(&20));
+        assert!(state.visited.contains(&30));
     }
 
     // =========================================================================
@@ -479,40 +556,38 @@ mod search_refactor_tests {
     // =========================================================================
 
     #[test]
-    #[ignore = "RED: SearchState does not exist yet"]
     fn test_search_state_should_terminate() {
-        // TODO(US-366): uncomment after SearchState is implemented
-        // let mut state = SearchState::new();
-        //
-        // // Fill ef=3 results with distances 0.1, 0.3, 0.5
-        // state.push_candidate(1, 0.1);
-        // state.push_candidate(2, 0.3);
-        // state.push_candidate(3, 0.5);
-        //
-        // let ef = 3;
-        // let stagnation_limit = 10;
-        //
-        // // c_dist=0.6 > furthest(0.5) AND results.len()>=ef => should terminate
-        // assert!(
-        //     state.should_terminate(0.6, ef, stagnation_limit),
-        //     "should terminate: c_dist > furthest and results full"
-        // );
-        //
-        // // c_dist=0.4 < furthest(0.5) => should NOT terminate
-        // assert!(
-        //     !state.should_terminate(0.4, ef, stagnation_limit),
-        //     "should not terminate: c_dist < furthest"
-        // );
-        //
-        // // c_dist=0.6 > furthest but results.len() < ef => should NOT terminate
-        // // (simulate by creating state with only 2 results)
-        // let mut state2 = SearchState::new();
-        // state2.push_candidate(1, 0.1);
-        // state2.push_candidate(2, 0.3);
-        // assert!(
-        //     !state2.should_terminate(0.6, ef, stagnation_limit),
-        //     "should not terminate: results not yet full"
-        // );
+        let mut state = SearchState::new();
+
+        // Fill ef=3 results with distances 0.1, 0.3, 0.5
+        state.push_candidate(1, 0.1);
+        state.push_candidate(2, 0.3);
+        state.push_candidate(3, 0.5);
+
+        let ef = 3;
+        let stagnation_limit = 10;
+
+        // c_dist=0.6 > furthest(0.5) AND results.len()>=ef => should terminate
+        assert!(
+            state.should_terminate(0.6, ef, stagnation_limit),
+            "should terminate: c_dist > furthest and results full"
+        );
+
+        // c_dist=0.4 < furthest(0.5) => should NOT terminate
+        assert!(
+            !state.should_terminate(0.4, ef, stagnation_limit),
+            "should not terminate: c_dist < furthest"
+        );
+
+        // c_dist=0.6 > furthest but results.len() < ef => should NOT terminate
+        // (simulate by creating state with only 2 results)
+        let mut state2 = SearchState::new();
+        state2.push_candidate(1, 0.1);
+        state2.push_candidate(2, 0.3);
+        assert!(
+            !state2.should_terminate(0.6, ef, stagnation_limit),
+            "should not terminate: results not yet full"
+        );
     }
 
     // =========================================================================
@@ -520,41 +595,39 @@ mod search_refactor_tests {
     // =========================================================================
 
     #[test]
-    #[ignore = "RED: SearchState does not exist yet"]
     fn test_search_state_stagnation() {
-        // TODO(US-366): uncomment after SearchState is implemented
-        // let mut state = SearchState::new();
-        //
-        // // Fill ef=2 results
-        // state.push_candidate(1, 0.1);
-        // state.push_candidate(2, 0.3);
-        //
-        // let ef = 2;
-        // let stagnation_limit = 3;
-        //
-        // // Initial stagnation count is 0
-        // assert_eq!(state.stagnation_count, 0);
-        //
-        // // Three rounds without improvement
-        // state.update_stagnation(false); // count -> 1
-        // assert_eq!(state.stagnation_count, 1);
-        // assert!(!state.should_terminate(0.0, ef, stagnation_limit));
-        //
-        // state.update_stagnation(false); // count -> 2
-        // assert_eq!(state.stagnation_count, 2);
-        // assert!(!state.should_terminate(0.0, ef, stagnation_limit));
-        //
-        // state.update_stagnation(false); // count -> 3 >= limit
-        // assert_eq!(state.stagnation_count, 3);
-        // assert!(
-        //     state.should_terminate(0.0, ef, stagnation_limit),
-        //     "should terminate after reaching stagnation limit"
-        // );
-        //
-        // // Improvement resets stagnation
-        // state.update_stagnation(true); // count -> 0
-        // assert_eq!(state.stagnation_count, 0);
-        // assert!(!state.should_terminate(0.0, ef, stagnation_limit));
+        let mut state = SearchState::new();
+
+        // Fill ef=2 results
+        state.push_candidate(1, 0.1);
+        state.push_candidate(2, 0.3);
+
+        let ef = 2;
+        let stagnation_limit = 3;
+
+        // Initial stagnation count is 0
+        assert_eq!(state.stagnation_count, 0);
+
+        // Three rounds without improvement
+        state.update_stagnation(false); // count -> 1
+        assert_eq!(state.stagnation_count, 1);
+        assert!(!state.should_terminate(0.0, ef, stagnation_limit));
+
+        state.update_stagnation(false); // count -> 2
+        assert_eq!(state.stagnation_count, 2);
+        assert!(!state.should_terminate(0.0, ef, stagnation_limit));
+
+        state.update_stagnation(false); // count -> 3 >= limit
+        assert_eq!(state.stagnation_count, 3);
+        assert!(
+            state.should_terminate(0.0, ef, stagnation_limit),
+            "should terminate after reaching stagnation limit"
+        );
+
+        // Improvement resets stagnation
+        state.update_stagnation(true); // count -> 0
+        assert_eq!(state.stagnation_count, 0);
+        assert!(!state.should_terminate(0.0, ef, stagnation_limit));
     }
 
     // =========================================================================
@@ -562,37 +635,35 @@ mod search_refactor_tests {
     // =========================================================================
 
     #[test]
-    #[ignore = "RED: SearchState does not exist yet"]
     fn test_search_state_into_sorted_results() {
-        // TODO(US-366): uncomment after SearchState is implemented
-        // let mut state = SearchState::new();
-        //
-        // // Insert results in non-sorted order
-        // state.push_candidate(10, 0.7);
-        // state.push_candidate(20, 0.2);
-        // state.push_candidate(30, 0.5);
-        // state.push_candidate(40, 0.1);
-        // state.push_candidate(50, 0.9);
-        //
-        // let sorted = state.into_sorted_results();
-        //
-        // // Should be sorted ascending by distance
-        // assert_eq!(sorted.len(), 5);
-        // assert_eq!(sorted[0].0, 40); // dist 0.1
-        // assert_eq!(sorted[1].0, 20); // dist 0.2
-        // assert_eq!(sorted[2].0, 30); // dist 0.5
-        // assert_eq!(sorted[3].0, 10); // dist 0.7
-        // assert_eq!(sorted[4].0, 50); // dist 0.9
-        //
-        // // Verify distances are monotonically non-decreasing
-        // for window in sorted.windows(2) {
-        //     assert!(
-        //         window[0].1 <= window[1].1,
-        //         "results must be sorted by distance ascending: {} <= {}",
-        //         window[0].1,
-        //         window[1].1,
-        //     );
-        // }
+        let mut state = SearchState::new();
+
+        // Insert results in non-sorted order
+        state.push_candidate(10, 0.7);
+        state.push_candidate(20, 0.2);
+        state.push_candidate(30, 0.5);
+        state.push_candidate(40, 0.1);
+        state.push_candidate(50, 0.9);
+
+        let sorted = state.into_sorted_results();
+
+        // Should be sorted ascending by distance
+        assert_eq!(sorted.len(), 5);
+        assert_eq!(sorted[0].0, 40); // dist 0.1
+        assert_eq!(sorted[1].0, 20); // dist 0.2
+        assert_eq!(sorted[2].0, 30); // dist 0.5
+        assert_eq!(sorted[3].0, 10); // dist 0.7
+        assert_eq!(sorted[4].0, 50); // dist 0.9
+
+        // Verify distances are monotonically non-decreasing
+        for window in sorted.windows(2) {
+            assert!(
+                window[0].1 <= window[1].1,
+                "results must be sorted by distance ascending: {} <= {}",
+                window[0].1,
+                window[1].1,
+            );
+        }
     }
 
     // =========================================================================
@@ -600,33 +671,32 @@ mod search_refactor_tests {
     // =========================================================================
 
     #[test]
-    #[ignore = "RED: gather_unvisited_neighbors does not exist yet"]
     fn test_gather_unvisited_neighbors_filters_visited() {
-        // TODO(US-366): uncomment after gather_unvisited_neighbors is implemented
-        // let dim = 4;
-        // let mut vectors = crate::perf_optimizations::ContiguousVectors::new(dim, 10)
-        //     .expect("alloc should succeed");
-        // for i in 0..5_usize {
-        //     let v: Vec<f32> = (0..dim).map(|j| (i * dim + j) as f32).collect();
-        //     vectors.push(&v).expect("push should succeed");
-        // }
-        //
-        // let neighbors: Vec<NodeId> = vec![0, 1, 2, 3, 4];
-        // let mut visited = FxHashSet::default();
-        // // Pre-mark nodes 1 and 3 as visited
-        // visited.insert(1);
-        // visited.insert(3);
-        //
-        // let unvisited: SmallVec<[(NodeId, &[f32]); 32]> =
-        //     gather_unvisited_neighbors(&neighbors, &mut visited, &vectors);
-        //
-        // let ids: Vec<NodeId> = unvisited.iter().map(|(id, _)| *id).collect();
-        // assert_eq!(ids.len(), 3, "should exclude 2 visited nodes");
-        // assert!(ids.contains(&0));
-        // assert!(ids.contains(&2));
-        // assert!(ids.contains(&4));
-        // assert!(!ids.contains(&1), "visited node 1 must be excluded");
-        // assert!(!ids.contains(&3), "visited node 3 must be excluded");
+        let dim = 4;
+        let mut vectors = crate::perf_optimizations::ContiguousVectors::new(dim, 10)
+            .expect("alloc should succeed");
+        for i in 0..5_usize {
+            #[allow(clippy::cast_precision_loss)]
+            let v: Vec<f32> = (0..dim).map(|j| (i * dim + j) as f32).collect();
+            vectors.push(&v).expect("push should succeed");
+        }
+
+        let neighbors: Vec<NodeId> = vec![0, 1, 2, 3, 4];
+        let mut visited = FxHashSet::default();
+        // Pre-mark nodes 1 and 3 as visited
+        visited.insert(1);
+        visited.insert(3);
+
+        let unvisited: SmallVec<[(NodeId, &[f32]); 32]> =
+            gather_unvisited_neighbors(&neighbors, &mut visited, &vectors);
+
+        let ids: Vec<NodeId> = unvisited.iter().map(|(id, _)| *id).collect();
+        assert_eq!(ids.len(), 3, "should exclude 2 visited nodes");
+        assert!(ids.contains(&0));
+        assert!(ids.contains(&2));
+        assert!(ids.contains(&4));
+        assert!(!ids.contains(&1), "visited node 1 must be excluded");
+        assert!(!ids.contains(&3), "visited node 3 must be excluded");
     }
 
     // =========================================================================
@@ -634,26 +704,25 @@ mod search_refactor_tests {
     // =========================================================================
 
     #[test]
-    #[ignore = "RED: gather_unvisited_neighbors does not exist yet"]
     fn test_gather_unvisited_neighbors_marks_visited() {
-        // TODO(US-366): uncomment after gather_unvisited_neighbors is implemented
-        // let dim = 4;
-        // let mut vectors = crate::perf_optimizations::ContiguousVectors::new(dim, 10)
-        //     .expect("alloc should succeed");
-        // for i in 0..3_usize {
-        //     let v: Vec<f32> = (0..dim).map(|j| (i * dim + j) as f32).collect();
-        //     vectors.push(&v).expect("push should succeed");
-        // }
-        //
-        // let neighbors: Vec<NodeId> = vec![0, 1, 2];
-        // let mut visited = FxHashSet::default();
-        //
-        // let _unvisited = gather_unvisited_neighbors(&neighbors, &mut visited, &vectors);
-        //
-        // // All returned neighbors should now be in the visited set
-        // assert!(visited.contains(&0), "node 0 should be marked visited");
-        // assert!(visited.contains(&1), "node 1 should be marked visited");
-        // assert!(visited.contains(&2), "node 2 should be marked visited");
+        let dim = 4;
+        let mut vectors = crate::perf_optimizations::ContiguousVectors::new(dim, 10)
+            .expect("alloc should succeed");
+        for i in 0..3_usize {
+            #[allow(clippy::cast_precision_loss)]
+            let v: Vec<f32> = (0..dim).map(|j| (i * dim + j) as f32).collect();
+            vectors.push(&v).expect("push should succeed");
+        }
+
+        let neighbors: Vec<NodeId> = vec![0, 1, 2];
+        let mut visited = FxHashSet::default();
+
+        let _unvisited = gather_unvisited_neighbors(&neighbors, &mut visited, &vectors);
+
+        // All returned neighbors should now be in the visited set
+        assert!(visited.contains(&0), "node 0 should be marked visited");
+        assert!(visited.contains(&1), "node 1 should be marked visited");
+        assert!(visited.contains(&2), "node 2 should be marked visited");
     }
 
     // =========================================================================
@@ -661,39 +730,37 @@ mod search_refactor_tests {
     // =========================================================================
 
     #[test]
-    #[ignore = "RED: SearchState / process_batch_results do not exist yet"]
     fn test_process_batch_results_updates_heaps() {
-        // TODO(US-366): uncomment after SearchState + process_batch_results
-        // let mut state = SearchState::new();
-        // let ef = 10;
-        //
-        // // Simulate a batch of 3 neighbors with their pre-computed distances
-        // let dim = 4;
-        // let vecs: Vec<Vec<f32>> = (0..3)
-        //     .map(|i| (0..dim).map(|j| (i * dim + j) as f32).collect())
-        //     .collect();
-        // let batch: Vec<(NodeId, &[f32])> = vecs
-        //     .iter()
-        //     .enumerate()
-        //     .map(|(i, v)| (i, v.as_slice()))
-        //     .collect();
-        // let distances = vec![0.3_f32, 0.1, 0.5];
-        //
-        // let improved = process_batch_results(&batch, &distances, ef, &mut state);
-        //
-        // assert!(improved, "first batch should improve empty state");
-        //
-        // // Candidates should contain all 3
-        // assert_eq!(state.candidates.len(), 3);
-        //
-        // // Results should contain all 3
-        // assert_eq!(state.results.len(), 3);
-        //
-        // // Min-candidate should be node 1 (dist 0.1)
-        // let Reverse((OrderedFloat(min_dist), min_node)) =
-        //     *state.candidates.peek().expect("non-empty");
-        // assert_eq!(min_node, 1);
-        // assert!((min_dist - 0.1).abs() < f32::EPSILON);
+        let mut state = SearchState::new();
+        let ef = 10;
+
+        // Simulate a batch of 3 neighbors with their pre-computed distances
+        let dim = 4;
+        let vecs: Vec<Vec<f32>> = (0..3)
+            .map(|i| (0..dim).map(|j| (i * dim + j) as f32).collect())
+            .collect();
+        let batch: Vec<(NodeId, &[f32])> = vecs
+            .iter()
+            .enumerate()
+            .map(|(i, v)| (i, v.as_slice()))
+            .collect();
+        let distances = vec![0.3_f32, 0.1, 0.5];
+
+        let improved = process_batch_results(&batch, &distances, ef, &mut state);
+
+        assert!(improved, "first batch should improve empty state");
+
+        // Candidates should contain all 3
+        assert_eq!(state.candidates.len(), 3);
+
+        // Results should contain all 3
+        assert_eq!(state.results.len(), 3);
+
+        // Min-candidate should be node 1 (dist 0.1)
+        let Reverse((OrderedFloat(min_dist), min_node)) =
+            *state.candidates.peek().expect("non-empty");
+        assert_eq!(min_node, 1);
+        assert!((min_dist - 0.1).abs() < f32::EPSILON);
     }
 
     // =========================================================================
@@ -701,50 +768,42 @@ mod search_refactor_tests {
     // =========================================================================
 
     #[test]
-    #[ignore = "RED: SearchState / process_batch_results do not exist yet"]
     fn test_process_batch_results_evicts_furthest_when_full() {
-        // TODO(US-366): uncomment after SearchState + process_batch_results
-        // let mut state = SearchState::new();
-        // let ef = 3;
-        //
-        // // Pre-fill with 3 results (ef is full)
-        // state.push_candidate(10, 0.2);
-        // state.push_candidate(20, 0.4);
-        // state.push_candidate(30, 0.6);
-        //
-        // // New batch: one candidate closer than the furthest (0.6), one farther
-        // let dim = 4;
-        // let v_close: Vec<f32> = vec![1.0; dim];
-        // let v_far: Vec<f32> = vec![2.0; dim];
-        // let batch: Vec<(NodeId, &[f32])> = vec![
-        //     (40, v_close.as_slice()),
-        //     (50, v_far.as_slice()),
-        // ];
-        // let distances = vec![0.3_f32, 0.8];
-        //
-        // let improved = process_batch_results(&batch, &distances, ef, &mut state);
-        //
-        // assert!(improved, "batch with closer candidate should improve results");
-        //
-        // // Results should still be capped at ef=3
-        // assert_eq!(
-        //     state.results.len(),
-        //     ef,
-        //     "results must not exceed ef"
-        // );
-        //
-        // // The furthest result should now be 0.4 (node 20), since:
-        // //   - 0.6 was evicted when 0.3 was inserted
-        // //   - 0.8 was rejected (> furthest after eviction)
-        // let result_ids: Vec<NodeId> = state.results.iter().map(|(_, id)| *id).collect();
-        // assert!(
-        //     !result_ids.contains(&30),
-        //     "node 30 (dist 0.6) should have been evicted"
-        // );
-        // assert!(
-        //     result_ids.contains(&40),
-        //     "node 40 (dist 0.3) should have been admitted"
-        // );
+        let mut state = SearchState::new();
+        let ef = 3;
+
+        // Pre-fill with 3 results (ef is full)
+        state.push_candidate(10, 0.2);
+        state.push_candidate(20, 0.4);
+        state.push_candidate(30, 0.6);
+
+        // New batch: one candidate closer than the furthest (0.6), one farther
+        let dim = 4;
+        let v_close: Vec<f32> = vec![1.0; dim];
+        let v_far: Vec<f32> = vec![2.0; dim];
+        let batch: Vec<(NodeId, &[f32])> =
+            vec![(40, v_close.as_slice()), (50, v_far.as_slice())];
+        let distances = vec![0.3_f32, 0.8];
+
+        let improved = process_batch_results(&batch, &distances, ef, &mut state);
+
+        assert!(improved, "batch with closer candidate should improve results");
+
+        // Results should still be capped at ef=3
+        assert_eq!(state.results.len(), ef, "results must not exceed ef");
+
+        // The furthest result should now be 0.4 (node 20), since:
+        //   - 0.6 was evicted when 0.3 was inserted
+        //   - 0.8 was rejected (> furthest after eviction)
+        let result_ids: Vec<NodeId> = state.results.iter().map(|(_, id)| *id).collect();
+        assert!(
+            !result_ids.contains(&30),
+            "node 30 (dist 0.6) should have been evicted"
+        );
+        assert!(
+            result_ids.contains(&40),
+            "node 40 (dist 0.3) should have been admitted"
+        );
     }
 
     // =========================================================================

--- a/crates/velesdb-core/src/index/hnsw/native/graph/search.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/graph/search.rs
@@ -395,3 +395,436 @@ impl<D: DistanceEngine> NativeHnsw<D> {
         }
     }
 }
+
+// =============================================================================
+// Phase A.1 RED tests — search_layer refactoring (Issue #366)
+//
+// These tests define the contract for the extracted SearchState struct and
+// helper functions. They are written BEFORE the implementation exists (TDD RED
+// phase). Tests that reference not-yet-existing types are #[ignore]d with the
+// concrete assertions commented out behind TODO(US-366) markers.
+// =============================================================================
+
+#[cfg(test)]
+mod search_refactor_tests {
+    #![allow(unused_imports)] // RED phase: imports needed once TODO(US-366) code is uncommented
+
+    use super::super::super::distance::SimdDistance;
+    use super::super::super::layer::NodeId;
+    use super::super::super::ordered_float::OrderedFloat;
+    use super::super::NativeHnsw;
+    use crate::distance::DistanceMetric;
+    // TODO(US-366): uncomment after SearchState is implemented
+    // use super::SearchState;
+    // use super::gather_unvisited_neighbors;
+    // use super::process_batch_results;
+    use rustc_hash::FxHashSet;
+    use smallvec::SmallVec;
+    use std::cmp::Reverse;
+    use std::collections::BinaryHeap;
+
+    // =========================================================================
+    // Helpers
+    // =========================================================================
+
+    /// Brute-force cosine distance for ground-truth computation.
+    fn cosine_distance(a: &[f32], b: &[f32]) -> f32 {
+        let dot: f32 = a.iter().zip(b.iter()).map(|(x, y)| x * y).sum();
+        let norm_a: f32 = a.iter().map(|x| x * x).sum::<f32>().sqrt();
+        let norm_b: f32 = b.iter().map(|x| x * x).sum::<f32>().sqrt();
+        if norm_a == 0.0 || norm_b == 0.0 {
+            1.0
+        } else {
+            1.0 - (dot / (norm_a * norm_b))
+        }
+    }
+
+    // =========================================================================
+    // 1. SearchState::new + push_candidate
+    // =========================================================================
+
+    #[test]
+    #[ignore = "RED: SearchState does not exist yet"]
+    fn test_search_state_new_and_push() {
+        // TODO(US-366): uncomment after SearchState is implemented
+        // let mut state = SearchState::new();
+        //
+        // // Push three candidates with known distances
+        // state.push_candidate(10, 0.5);
+        // state.push_candidate(20, 0.1);
+        // state.push_candidate(30, 0.9);
+        //
+        // // Candidates min-heap: closest first (0.1 at top)
+        // let (OrderedFloat(top_dist), top_node) = state.candidates.peek()
+        //     .map(|Reverse(item)| item)
+        //     .copied()
+        //     .expect("candidates should not be empty");
+        // assert_eq!(top_node, 20, "min-heap should surface closest candidate");
+        // assert!((top_dist - 0.1).abs() < f32::EPSILON);
+        //
+        // // Results max-heap: furthest first (0.9 at top)
+        // let &(OrderedFloat(furthest_dist), furthest_node) = state.results.peek()
+        //     .expect("results should not be empty");
+        // assert_eq!(furthest_node, 30, "max-heap should surface furthest result");
+        // assert!((furthest_dist - 0.9).abs() < f32::EPSILON);
+        //
+        // // Visited set should contain all three
+        // assert!(state.visited.contains(&10));
+        // assert!(state.visited.contains(&20));
+        // assert!(state.visited.contains(&30));
+    }
+
+    // =========================================================================
+    // 2. SearchState::should_terminate
+    // =========================================================================
+
+    #[test]
+    #[ignore = "RED: SearchState does not exist yet"]
+    fn test_search_state_should_terminate() {
+        // TODO(US-366): uncomment after SearchState is implemented
+        // let mut state = SearchState::new();
+        //
+        // // Fill ef=3 results with distances 0.1, 0.3, 0.5
+        // state.push_candidate(1, 0.1);
+        // state.push_candidate(2, 0.3);
+        // state.push_candidate(3, 0.5);
+        //
+        // let ef = 3;
+        // let stagnation_limit = 10;
+        //
+        // // c_dist=0.6 > furthest(0.5) AND results.len()>=ef => should terminate
+        // assert!(
+        //     state.should_terminate(0.6, ef, stagnation_limit),
+        //     "should terminate: c_dist > furthest and results full"
+        // );
+        //
+        // // c_dist=0.4 < furthest(0.5) => should NOT terminate
+        // assert!(
+        //     !state.should_terminate(0.4, ef, stagnation_limit),
+        //     "should not terminate: c_dist < furthest"
+        // );
+        //
+        // // c_dist=0.6 > furthest but results.len() < ef => should NOT terminate
+        // // (simulate by creating state with only 2 results)
+        // let mut state2 = SearchState::new();
+        // state2.push_candidate(1, 0.1);
+        // state2.push_candidate(2, 0.3);
+        // assert!(
+        //     !state2.should_terminate(0.6, ef, stagnation_limit),
+        //     "should not terminate: results not yet full"
+        // );
+    }
+
+    // =========================================================================
+    // 3. SearchState stagnation tracking
+    // =========================================================================
+
+    #[test]
+    #[ignore = "RED: SearchState does not exist yet"]
+    fn test_search_state_stagnation() {
+        // TODO(US-366): uncomment after SearchState is implemented
+        // let mut state = SearchState::new();
+        //
+        // // Fill ef=2 results
+        // state.push_candidate(1, 0.1);
+        // state.push_candidate(2, 0.3);
+        //
+        // let ef = 2;
+        // let stagnation_limit = 3;
+        //
+        // // Initial stagnation count is 0
+        // assert_eq!(state.stagnation_count, 0);
+        //
+        // // Three rounds without improvement
+        // state.update_stagnation(false); // count -> 1
+        // assert_eq!(state.stagnation_count, 1);
+        // assert!(!state.should_terminate(0.0, ef, stagnation_limit));
+        //
+        // state.update_stagnation(false); // count -> 2
+        // assert_eq!(state.stagnation_count, 2);
+        // assert!(!state.should_terminate(0.0, ef, stagnation_limit));
+        //
+        // state.update_stagnation(false); // count -> 3 >= limit
+        // assert_eq!(state.stagnation_count, 3);
+        // assert!(
+        //     state.should_terminate(0.0, ef, stagnation_limit),
+        //     "should terminate after reaching stagnation limit"
+        // );
+        //
+        // // Improvement resets stagnation
+        // state.update_stagnation(true); // count -> 0
+        // assert_eq!(state.stagnation_count, 0);
+        // assert!(!state.should_terminate(0.0, ef, stagnation_limit));
+    }
+
+    // =========================================================================
+    // 4. SearchState::into_sorted_results
+    // =========================================================================
+
+    #[test]
+    #[ignore = "RED: SearchState does not exist yet"]
+    fn test_search_state_into_sorted_results() {
+        // TODO(US-366): uncomment after SearchState is implemented
+        // let mut state = SearchState::new();
+        //
+        // // Insert results in non-sorted order
+        // state.push_candidate(10, 0.7);
+        // state.push_candidate(20, 0.2);
+        // state.push_candidate(30, 0.5);
+        // state.push_candidate(40, 0.1);
+        // state.push_candidate(50, 0.9);
+        //
+        // let sorted = state.into_sorted_results();
+        //
+        // // Should be sorted ascending by distance
+        // assert_eq!(sorted.len(), 5);
+        // assert_eq!(sorted[0].0, 40); // dist 0.1
+        // assert_eq!(sorted[1].0, 20); // dist 0.2
+        // assert_eq!(sorted[2].0, 30); // dist 0.5
+        // assert_eq!(sorted[3].0, 10); // dist 0.7
+        // assert_eq!(sorted[4].0, 50); // dist 0.9
+        //
+        // // Verify distances are monotonically non-decreasing
+        // for window in sorted.windows(2) {
+        //     assert!(
+        //         window[0].1 <= window[1].1,
+        //         "results must be sorted by distance ascending: {} <= {}",
+        //         window[0].1,
+        //         window[1].1,
+        //     );
+        // }
+    }
+
+    // =========================================================================
+    // 5. gather_unvisited_neighbors filters visited nodes
+    // =========================================================================
+
+    #[test]
+    #[ignore = "RED: gather_unvisited_neighbors does not exist yet"]
+    fn test_gather_unvisited_neighbors_filters_visited() {
+        // TODO(US-366): uncomment after gather_unvisited_neighbors is implemented
+        // let dim = 4;
+        // let mut vectors = crate::perf_optimizations::ContiguousVectors::new(dim, 10)
+        //     .expect("alloc should succeed");
+        // for i in 0..5_usize {
+        //     let v: Vec<f32> = (0..dim).map(|j| (i * dim + j) as f32).collect();
+        //     vectors.push(&v).expect("push should succeed");
+        // }
+        //
+        // let neighbors: Vec<NodeId> = vec![0, 1, 2, 3, 4];
+        // let mut visited = FxHashSet::default();
+        // // Pre-mark nodes 1 and 3 as visited
+        // visited.insert(1);
+        // visited.insert(3);
+        //
+        // let unvisited: SmallVec<[(NodeId, &[f32]); 32]> =
+        //     gather_unvisited_neighbors(&neighbors, &mut visited, &vectors);
+        //
+        // let ids: Vec<NodeId> = unvisited.iter().map(|(id, _)| *id).collect();
+        // assert_eq!(ids.len(), 3, "should exclude 2 visited nodes");
+        // assert!(ids.contains(&0));
+        // assert!(ids.contains(&2));
+        // assert!(ids.contains(&4));
+        // assert!(!ids.contains(&1), "visited node 1 must be excluded");
+        // assert!(!ids.contains(&3), "visited node 3 must be excluded");
+    }
+
+    // =========================================================================
+    // 6. gather_unvisited_neighbors marks returned nodes as visited
+    // =========================================================================
+
+    #[test]
+    #[ignore = "RED: gather_unvisited_neighbors does not exist yet"]
+    fn test_gather_unvisited_neighbors_marks_visited() {
+        // TODO(US-366): uncomment after gather_unvisited_neighbors is implemented
+        // let dim = 4;
+        // let mut vectors = crate::perf_optimizations::ContiguousVectors::new(dim, 10)
+        //     .expect("alloc should succeed");
+        // for i in 0..3_usize {
+        //     let v: Vec<f32> = (0..dim).map(|j| (i * dim + j) as f32).collect();
+        //     vectors.push(&v).expect("push should succeed");
+        // }
+        //
+        // let neighbors: Vec<NodeId> = vec![0, 1, 2];
+        // let mut visited = FxHashSet::default();
+        //
+        // let _unvisited = gather_unvisited_neighbors(&neighbors, &mut visited, &vectors);
+        //
+        // // All returned neighbors should now be in the visited set
+        // assert!(visited.contains(&0), "node 0 should be marked visited");
+        // assert!(visited.contains(&1), "node 1 should be marked visited");
+        // assert!(visited.contains(&2), "node 2 should be marked visited");
+    }
+
+    // =========================================================================
+    // 7. process_batch_results updates candidate and result heaps
+    // =========================================================================
+
+    #[test]
+    #[ignore = "RED: SearchState / process_batch_results do not exist yet"]
+    fn test_process_batch_results_updates_heaps() {
+        // TODO(US-366): uncomment after SearchState + process_batch_results
+        // let mut state = SearchState::new();
+        // let ef = 10;
+        //
+        // // Simulate a batch of 3 neighbors with their pre-computed distances
+        // let dim = 4;
+        // let vecs: Vec<Vec<f32>> = (0..3)
+        //     .map(|i| (0..dim).map(|j| (i * dim + j) as f32).collect())
+        //     .collect();
+        // let batch: Vec<(NodeId, &[f32])> = vecs
+        //     .iter()
+        //     .enumerate()
+        //     .map(|(i, v)| (i, v.as_slice()))
+        //     .collect();
+        // let distances = vec![0.3_f32, 0.1, 0.5];
+        //
+        // let improved = process_batch_results(&batch, &distances, ef, &mut state);
+        //
+        // assert!(improved, "first batch should improve empty state");
+        //
+        // // Candidates should contain all 3
+        // assert_eq!(state.candidates.len(), 3);
+        //
+        // // Results should contain all 3
+        // assert_eq!(state.results.len(), 3);
+        //
+        // // Min-candidate should be node 1 (dist 0.1)
+        // let Reverse((OrderedFloat(min_dist), min_node)) =
+        //     *state.candidates.peek().expect("non-empty");
+        // assert_eq!(min_node, 1);
+        // assert!((min_dist - 0.1).abs() < f32::EPSILON);
+    }
+
+    // =========================================================================
+    // 8. process_batch_results evicts furthest when results exceed ef
+    // =========================================================================
+
+    #[test]
+    #[ignore = "RED: SearchState / process_batch_results do not exist yet"]
+    fn test_process_batch_results_evicts_furthest_when_full() {
+        // TODO(US-366): uncomment after SearchState + process_batch_results
+        // let mut state = SearchState::new();
+        // let ef = 3;
+        //
+        // // Pre-fill with 3 results (ef is full)
+        // state.push_candidate(10, 0.2);
+        // state.push_candidate(20, 0.4);
+        // state.push_candidate(30, 0.6);
+        //
+        // // New batch: one candidate closer than the furthest (0.6), one farther
+        // let dim = 4;
+        // let v_close: Vec<f32> = vec![1.0; dim];
+        // let v_far: Vec<f32> = vec![2.0; dim];
+        // let batch: Vec<(NodeId, &[f32])> = vec![
+        //     (40, v_close.as_slice()),
+        //     (50, v_far.as_slice()),
+        // ];
+        // let distances = vec![0.3_f32, 0.8];
+        //
+        // let improved = process_batch_results(&batch, &distances, ef, &mut state);
+        //
+        // assert!(improved, "batch with closer candidate should improve results");
+        //
+        // // Results should still be capped at ef=3
+        // assert_eq!(
+        //     state.results.len(),
+        //     ef,
+        //     "results must not exceed ef"
+        // );
+        //
+        // // The furthest result should now be 0.4 (node 20), since:
+        // //   - 0.6 was evicted when 0.3 was inserted
+        // //   - 0.8 was rejected (> furthest after eviction)
+        // let result_ids: Vec<NodeId> = state.results.iter().map(|(_, id)| *id).collect();
+        // assert!(
+        //     !result_ids.contains(&30),
+        //     "node 30 (dist 0.6) should have been evicted"
+        // );
+        // assert!(
+        //     result_ids.contains(&40),
+        //     "node 40 (dist 0.3) should have been admitted"
+        // );
+    }
+
+    // =========================================================================
+    // 9. Refactored search recall matches original (regression guard)
+    //
+    // This test uses only the existing public API and compiles TODAY.
+    // After the refactoring, search results must remain identical.
+    // =========================================================================
+
+    #[test]
+    fn test_refactored_search_recall_matches_original() {
+        let dim = 32;
+        let n = 200;
+        let k = 10;
+        let ef_search = 64;
+        let n_queries = 10;
+
+        // Build index
+        let engine = SimdDistance::new(DistanceMetric::Euclidean);
+        let hnsw = NativeHnsw::new(engine, 16, 100, n);
+
+        let vectors: Vec<Vec<f32>> = (0..n)
+            .map(|i| {
+                (0..dim)
+                    .map(|j| ((i * dim + j) as f32 * 0.001).sin())
+                    .collect()
+            })
+            .collect();
+
+        for v in &vectors {
+            hnsw.insert(v).expect("insert should succeed in test");
+        }
+
+        // Verify recall against brute-force ground truth
+        let mut total_recall = 0.0_f64;
+
+        for q_idx in 0..n_queries {
+            let query = &vectors[q_idx * (n / n_queries)];
+
+            let hnsw_results: Vec<NodeId> = hnsw
+                .search(query, k, ef_search)
+                .iter()
+                .map(|(id, _)| *id)
+                .collect();
+
+            // Brute-force ground truth (euclidean)
+            let mut brute: Vec<(NodeId, f32)> = vectors
+                .iter()
+                .enumerate()
+                .map(|(i, v)| {
+                    let dist: f32 = v
+                        .iter()
+                        .zip(query.iter())
+                        .map(|(a, b)| (a - b) * (a - b))
+                        .sum();
+                    (i, dist)
+                })
+                .collect();
+            brute.sort_by(|a, b| a.1.total_cmp(&b.1));
+            let ground_truth: Vec<NodeId> = brute.iter().take(k).map(|(id, _)| *id).collect();
+
+            let hits = hnsw_results
+                .iter()
+                .filter(|id| ground_truth.contains(id))
+                .count();
+
+            #[allow(clippy::cast_precision_loss)]
+            {
+                total_recall += hits as f64 / k as f64;
+            }
+        }
+
+        #[allow(clippy::cast_precision_loss)]
+        let avg_recall = total_recall / n_queries as f64;
+
+        assert!(
+            avg_recall >= 0.90,
+            "search recall must be >= 90% (got {:.1}%); \
+             if this fails after refactoring, the extraction broke correctness",
+            avg_recall * 100.0,
+        );
+    }
+}

--- a/crates/velesdb-core/src/index/hnsw/native/graph/search.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/graph/search.rs
@@ -78,8 +78,7 @@ impl SearchState {
     /// Pushes a candidate node into both heaps and marks it visited.
     #[inline]
     fn push_candidate(&mut self, node: NodeId, dist: f32) {
-        self.candidates
-            .push(Reverse((OrderedFloat(dist), node)));
+        self.candidates.push(Reverse((OrderedFloat(dist), node)));
         self.results.push((OrderedFloat(dist), node));
         self.visited.insert(node);
     }
@@ -114,11 +113,8 @@ impl SearchState {
     /// Releases the visited set back to the thread-local pool.
     fn into_sorted_results(self) -> Vec<(NodeId, f32)> {
         release_visited_set(self.visited);
-        let mut result_vec: Vec<(NodeId, f32)> = self
-            .results
-            .into_iter()
-            .map(|(d, n)| (n, d.0))
-            .collect();
+        let mut result_vec: Vec<(NodeId, f32)> =
+            self.results.into_iter().map(|(d, n)| (n, d.0)).collect();
         result_vec.sort_by(|a, b| a.1.total_cmp(&b.1));
         result_vec
     }
@@ -431,16 +427,12 @@ impl<D: DistanceEngine> NativeHnsw<D> {
 
                 let improved = layers[layer]
                     .with_neighbors(c_node, |neighbors| {
-                        let batch = gather_unvisited_neighbors(
-                            neighbors,
-                            &mut state.visited,
-                            vectors,
-                        );
+                        let batch =
+                            gather_unvisited_neighbors(neighbors, &mut state.visited, vectors);
                         if batch.is_empty() {
                             return false;
                         }
-                        let vecs: SmallVec<[&[f32]; 32]> =
-                            batch.iter().map(|(_, v)| *v).collect();
+                        let vecs: SmallVec<[&[f32]; 32]> = batch.iter().map(|(_, v)| *v).collect();
                         let distances = self.distance.batch_distance(query, &vecs);
                         process_batch_results(&batch, &distances, ef, &mut state)
                     })
@@ -539,10 +531,7 @@ mod search_refactor_tests {
         // Results max-heap: furthest first (0.9 at top)
         let &(OrderedFloat(furthest_dist), furthest_node) =
             state.results.peek().expect("results should not be empty");
-        assert_eq!(
-            furthest_node, 30,
-            "max-heap should surface furthest result"
-        );
+        assert_eq!(furthest_node, 30, "max-heap should surface furthest result");
         assert!((furthest_dist - 0.9).abs() < f32::EPSILON);
 
         // Visited set should contain all three
@@ -781,13 +770,15 @@ mod search_refactor_tests {
         let dim = 4;
         let v_close: Vec<f32> = vec![1.0; dim];
         let v_far: Vec<f32> = vec![2.0; dim];
-        let batch: Vec<(NodeId, &[f32])> =
-            vec![(40, v_close.as_slice()), (50, v_far.as_slice())];
+        let batch: Vec<(NodeId, &[f32])> = vec![(40, v_close.as_slice()), (50, v_far.as_slice())];
         let distances = vec![0.3_f32, 0.8];
 
         let improved = process_batch_results(&batch, &distances, ef, &mut state);
 
-        assert!(improved, "batch with closer candidate should improve results");
+        assert!(
+            improved,
+            "batch with closer candidate should improve results"
+        );
 
         // Results should still be capped at ef=3
         assert_eq!(state.results.len(), ef, "results must not exceed ef");

--- a/crates/velesdb-core/src/index/hnsw/native/graph/search.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/graph/search.rs
@@ -466,12 +466,8 @@ impl<D: DistanceEngine> NativeHnsw<D> {
 }
 
 // =============================================================================
-// Phase A.1 RED tests — search_layer refactoring (Issue #366)
-//
-// These tests define the contract for the extracted SearchState struct and
-// helper functions. They are written BEFORE the implementation exists (TDD RED
-// phase). Tests that reference not-yet-existing types are #[ignore]d with the
-// concrete assertions commented out behind TODO(US-366) markers.
+// Contract tests for SearchState, gather_unvisited_neighbors, and
+// process_batch_results helpers extracted from search_layer (Issue #366).
 // =============================================================================
 
 #[cfg(test)]

--- a/crates/velesdb-core/tests/deferred_indexer_integration.rs
+++ b/crates/velesdb-core/tests/deferred_indexer_integration.rs
@@ -1,0 +1,244 @@
+#![cfg(feature = "persistence")]
+//! Integration tests for the deferred indexer (US-366 Phase B.3).
+//!
+//! Verifies that vectors are buffered, searchable via brute-force scan,
+//! and correctly merged into HNSW on flush.
+
+#![allow(
+    clippy::cast_precision_loss,
+    clippy::cast_possible_truncation,
+    deprecated
+)]
+
+use serde_json::json;
+use std::io::Write;
+use tempfile::TempDir;
+use velesdb_core::collection::streaming::DeferredIndexerConfig;
+use velesdb_core::collection::CollectionConfig;
+use velesdb_core::distance::DistanceMetric;
+use velesdb_core::quantization::StorageMode;
+use velesdb_core::Point;
+
+/// Creates a collection directory with a config.json that has deferred
+/// indexing enabled, then opens it via `Collection::open`.
+#[allow(deprecated)]
+fn create_deferred_collection(
+    dir: &std::path::Path,
+    dimension: usize,
+    metric: DistanceMetric,
+    merge_threshold: usize,
+) -> velesdb_core::collection::Collection {
+    use velesdb_core::collection::Collection;
+
+    // First create a normal collection so all storage files are initialized.
+    let coll =
+        Collection::create_with_options(dir.to_path_buf(), dimension, metric, StorageMode::Full)
+            .expect("create collection");
+    coll.flush().expect("flush after create");
+    drop(coll);
+
+    // Now patch config.json to enable deferred indexing.
+    let config_path = dir.join("config.json");
+    let config_data = std::fs::read_to_string(&config_path).expect("read config");
+    let mut config: serde_json::Value = serde_json::from_str(&config_data).expect("parse config");
+    config["deferred_indexing"] = json!({
+        "enabled": true,
+        "merge_threshold": merge_threshold,
+        "max_buffer_age_ms": 5000
+    });
+    let patched = serde_json::to_string_pretty(&config).expect("serialize config");
+    let mut f = std::fs::File::create(&config_path).expect("open config for write");
+    f.write_all(patched.as_bytes()).expect("write config");
+    f.sync_all().expect("sync config");
+
+    // Reopen with deferred indexing enabled.
+    Collection::open(dir.to_path_buf()).expect("reopen collection")
+}
+
+/// Generates a deterministic vector with a known pattern.
+fn make_vector(seed: u64, dim: usize) -> Vec<f32> {
+    (0..dim)
+        .map(|i| ((seed as f32) * 0.3 + (i as f32) * 0.1).sin())
+        .collect()
+}
+
+// ── Upsert + search via buffer ──────────────────────────────────────────
+
+#[test]
+fn deferred_upsert_is_searchable_before_merge() {
+    let tmp = TempDir::new().expect("temp dir");
+    let coll_dir = tmp.path().join("test_deferred");
+    let coll = create_deferred_collection(&coll_dir, 4, DistanceMetric::Cosine, 1000);
+
+    // Insert fewer vectors than merge_threshold so they stay in the buffer.
+    let points: Vec<Point> = (0..5)
+        .map(|i| Point::new(i, make_vector(i, 4), None))
+        .collect();
+    coll.upsert(points).expect("upsert");
+
+    // Search should find them via deferred buffer brute-force.
+    let results = coll.search(&make_vector(0, 4), 3).expect("search");
+    assert!(
+        !results.is_empty(),
+        "deferred buffer must be searchable before merge"
+    );
+    // The closest vector should be id=0 (identical query).
+    assert_eq!(results[0].point.id, 0);
+}
+
+// ── Upsert + flush merges into HNSW ────────────────────────────────────
+
+#[test]
+fn deferred_flush_drains_buffer_into_hnsw() {
+    let tmp = TempDir::new().expect("temp dir");
+    let coll_dir = tmp.path().join("test_deferred_flush");
+    let coll = create_deferred_collection(&coll_dir, 4, DistanceMetric::Euclidean, 1000);
+
+    let points: Vec<Point> = (0..10)
+        .map(|i| Point::new(i, make_vector(i, 4), None))
+        .collect();
+    coll.upsert(points).expect("upsert");
+
+    // Before flush: vectors are searchable via deferred buffer brute-force.
+    let pre_flush = coll
+        .search(&make_vector(0, 4), 5)
+        .expect("search before flush");
+    assert!(
+        !pre_flush.is_empty(),
+        "buffer search must work before flush"
+    );
+
+    // Flush drains the deferred buffer into HNSW.
+    coll.flush().expect("flush");
+
+    // After flush: vectors should still be searchable (now via HNSW index).
+    let post_flush = coll
+        .search(&make_vector(0, 4), 5)
+        .expect("search after flush");
+    assert!(
+        !post_flush.is_empty(),
+        "vectors must be in HNSW after flush"
+    );
+    assert_eq!(coll.len(), 10, "point count must be 10 after upsert");
+}
+
+// ── Bulk upsert through deferred path ──────────────────────────────────
+
+#[test]
+fn deferred_upsert_bulk_is_searchable() {
+    let tmp = TempDir::new().expect("temp dir");
+    let coll_dir = tmp.path().join("test_deferred_bulk");
+    let coll = create_deferred_collection(&coll_dir, 4, DistanceMetric::Cosine, 1000);
+
+    let points: Vec<Point> = (0..20)
+        .map(|i| Point::new(i, make_vector(i, 4), None))
+        .collect();
+    let inserted = coll.upsert_bulk(&points).expect("upsert_bulk");
+    assert_eq!(inserted, 20);
+
+    let results = coll.search(&make_vector(0, 4), 5).expect("search");
+    assert!(
+        !results.is_empty(),
+        "bulk-upserted vectors must be searchable via deferred buffer"
+    );
+}
+
+// ── Merge threshold triggers automatic HNSW insertion ──────────────────
+
+#[test]
+fn deferred_merge_triggered_at_threshold() {
+    let tmp = TempDir::new().expect("temp dir");
+    let coll_dir = tmp.path().join("test_deferred_threshold");
+    // Low threshold = 5 so the merge triggers within our test.
+    let coll = create_deferred_collection(&coll_dir, 4, DistanceMetric::Cosine, 5);
+
+    // Insert exactly threshold vectors — should trigger merge.
+    let points: Vec<Point> = (0..5)
+        .map(|i| Point::new(i, make_vector(i, 4), None))
+        .collect();
+    coll.upsert(points).expect("upsert");
+
+    // Insert one more to push over threshold in upsert path.
+    coll.upsert(vec![Point::new(99, make_vector(99, 4), None)])
+        .expect("upsert extra");
+
+    // After the merge, search should still find results.
+    let results = coll.search(&make_vector(0, 4), 3).expect("search");
+    assert!(
+        !results.is_empty(),
+        "results must be available after threshold-triggered merge"
+    );
+}
+
+// ── Delete from deferred buffer ────────────────────────────────────────
+
+#[test]
+fn deferred_delete_removes_from_buffer() {
+    let tmp = TempDir::new().expect("temp dir");
+    let coll_dir = tmp.path().join("test_deferred_delete");
+    let coll = create_deferred_collection(&coll_dir, 4, DistanceMetric::Euclidean, 1000);
+
+    let points: Vec<Point> = (0..5)
+        .map(|i| Point::new(i, make_vector(i, 4), None))
+        .collect();
+    coll.upsert(points).expect("upsert");
+
+    // Delete id=0 while it is still in the deferred buffer.
+    coll.delete(&[0]).expect("delete");
+
+    let results = coll.search(&make_vector(0, 4), 10).expect("search");
+    let ids: Vec<u64> = results.iter().map(|r| r.point.id).collect();
+    assert!(
+        !ids.contains(&0),
+        "deleted ID 0 must not appear in deferred search results"
+    );
+}
+
+// ── Config serde round-trip ────────────────────────────────────────────
+
+#[test]
+fn deferred_config_serde_backward_compat() {
+    // Old config.json without deferred_indexing field should deserialize OK.
+    let json = r#"{
+        "name": "old_collection",
+        "dimension": 128,
+        "metric": "Euclidean",
+        "point_count": 100,
+        "storage_mode": "full"
+    }"#;
+    let config: CollectionConfig = serde_json::from_str(json).expect("deserialize");
+    assert!(
+        config.deferred_indexing.is_none(),
+        "missing field must deserialize to None"
+    );
+}
+
+#[test]
+fn deferred_config_serde_enabled() {
+    let json = r#"{
+        "name": "new_collection",
+        "dimension": 128,
+        "metric": "Cosine",
+        "point_count": 0,
+        "storage_mode": "full",
+        "deferred_indexing": {
+            "enabled": true,
+            "merge_threshold": 512,
+            "max_buffer_age_ms": 3000
+        }
+    }"#;
+    let config: CollectionConfig = serde_json::from_str(json).expect("deserialize");
+    let di = config
+        .deferred_indexing
+        .expect("deferred_indexing must be Some");
+    assert!(di.enabled);
+    assert_eq!(di.merge_threshold, 512);
+    assert_eq!(di.max_buffer_age_ms, 3000);
+}
+
+#[test]
+fn deferred_config_default_is_disabled() {
+    let config = DeferredIndexerConfig::default();
+    assert!(!config.enabled);
+    assert_eq!(config.merge_threshold, 1024);
+}


### PR DESCRIPTION
## Summary

Implements P2 (SIMD batch neighbor selection) and P1 (deferred indexing) from issue #366. P3 (parallel graph construction) is deferred to a separate research issue.

### Phase A — search_layer refactoring + batch SIMD distance
- Extract `SearchState`, `gather_unvisited_neighbors`, `process_batch_results` helpers (CC<=8, NLOC<=50)
- Replace per-neighbor distance with `DistanceEngine::batch_distance()` (prefetch-accelerated pipeline)
- **Measured gains**: -15% to -42% search latency, +29% sequential insert throughput

### Phase B — DeferredIndexer
- Fix 3 pre-existing DeltaBuffer bugs (delete ghost, flush drain, dedup)
- New `DeferredIndexer` with single-buffer architecture + threshold-triggered merge
- Integrated into Collection: insert/search/delete/flush paths
- `DeferredIndexerConfig` with `serde(default)` for backward compat (disabled by default)

### Double code review applied
- Clean code: removed 6 HIGH + 12 MEDIUM findings (dead code, duplicate docs, vestigial back buffer, redundant checks)
- Safety: documented TOCTOU races, added merge failure logging, verified lock ordering

## Benchmark results (i9-14900KF, 64GB, Windows 11)

| Scenario | Before | After | Change |
|----------|--------|-------|--------|
| Sequential insert 1K×768d | 300 ms | 232 ms | **+29% throughput** |
| Parallel insert 10K×768d | 281 ms | 270 ms | **+5%** |
| Search 128d ef=256 | 10.23 μs | 5.94 μs | **-42% latency** |
| Search 128d ef=128 | 6.91 μs | 5.61 μs | **-19% latency** |
| Search 768d ef=256 | 8.95 μs | 7.24 μs | **-19% latency** |

Zero regression on any path. Recall >= 90% maintained.

## Test plan
- [x] 50+ new unit tests (SearchState, gather, process, DeferredIndexer, DeltaBuffer fixes)
- [x] 8 integration tests (upsert/search/flush/delete/bulk/serde/backward-compat)
- [x] `cargo clippy --workspace --all-targets -D warnings -D clippy::pedantic` → clean
- [x] `cargo test -p velesdb-core --features persistence -- --test-threads=1` → all green
- [x] `cargo bench --bench hnsw_benchmark` → no regressions
- [x] `cargo bench --bench search_layer_benchmark` → baseline captured + gains measured
- [ ] Codacy gate (post-push)

Closes #366 (P1+P2). P3 tracked in separate research issue.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/369" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
