### PR TITLE
feat(hnsw): support vector update/replace with upsert semantics

### DIFF
--- a/crates/velesdb-core/src/index/hnsw/index/batch.rs
+++ b/crates/velesdb-core/src/index/hnsw/index/batch.rs
@@ -2,33 +2,46 @@
 
 use super::HnswIndex;
 use crate::index::hnsw::params::SearchQuality;
+use crate::index::hnsw::upsert::UpsertResult;
 use crate::scored_result::ScoredResult;
 use rayon::prelude::*;
+
+/// Prepared batch of vectors ready for HNSW graph insertion.
+///
+/// Contains both the data needed for `parallel_insert` and the rollback
+/// information needed to restore mappings on failure.
+pub(crate) struct PreparedBatch<'a> {
+    /// `(internal_idx, vector_slice)` pairs for HNSW insertion.
+    pub to_insert: Vec<(usize, &'a [f32])>,
+    /// `(external_id, upsert_result)` pairs for rollback on failure.
+    pub rollback_info: Vec<(u64, UpsertResult)>,
+}
 
 impl HnswIndex {
     /// Prepares vectors for batch insertion: validates dimensions and registers IDs.
     ///
-    /// Returns a vector of (`internal_index`, vector slice) pairs ready for insertion.
-    /// Duplicates are automatically skipped.
+    /// Returns a [`PreparedBatch`] containing insertion data and rollback
+    /// information. Existing IDs are replaced (upsert semantics): the old
+    /// mapping is updated and stale vector data is removed.
     ///
     /// # Performance
     ///
     /// - Single pass over input (no intermediate collection)
-    /// - Pre-allocated output vector
+    /// - Pre-allocated output vectors
     /// - Inline dimension validation
     /// - Zero-copy: stores borrowed slices, no cloning
     #[inline]
-    pub(crate) fn prepare_batch_insert<'a, I>(&self, vectors: I) -> Vec<(usize, &'a [f32])>
+    pub(crate) fn prepare_batch_insert<'a, I>(&self, vectors: I) -> PreparedBatch<'a>
     where
         I: IntoIterator<Item = (u64, &'a [f32])>,
     {
         let iter = vectors.into_iter();
         let (lower, upper) = iter.size_hint();
         let capacity = upper.unwrap_or(lower);
-        let mut to_insert: Vec<(usize, &'a [f32])> = Vec::with_capacity(capacity);
+        let mut to_insert = Vec::with_capacity(capacity);
+        let mut rollback_info = Vec::with_capacity(capacity);
 
         for (id, vector) in iter {
-            // Inline validation for hot path
             assert_eq!(
                 vector.len(),
                 self.dimension,
@@ -36,12 +49,16 @@ impl HnswIndex {
                 self.dimension,
                 vector.len()
             );
-            if let Some(idx) = self.mappings.register(id) {
-                to_insert.push((idx, vector));
-            }
+
+            let result = self.upsert_mapping(id);
+            to_insert.push((result.idx, vector));
+            rollback_info.push((id, result));
         }
 
-        to_insert
+        PreparedBatch {
+            to_insert,
+            rollback_info,
+        }
     }
 
     /// Inserts multiple vectors in parallel using rayon.
@@ -55,7 +72,7 @@ impl HnswIndex {
     ///
     /// # Returns
     ///
-    /// Number of vectors successfully inserted (duplicates are skipped).
+    /// Number of vectors successfully inserted or updated (upsert semantics).
     ///
     /// # Panics
     ///
@@ -85,33 +102,30 @@ impl HnswIndex {
     where
         I: IntoIterator<Item = (u64, &'a [f32])>,
     {
-        let to_insert = self.prepare_batch_insert(vectors);
-        let count = to_insert.len();
+        let batch = self.prepare_batch_insert(vectors);
+        let count = batch.to_insert.len();
 
         if count == 0 {
             return 0;
         }
 
-        // Prepare references for HNSW batch insertion
-        let refs_for_hnsw: Vec<(&[f32], usize)> =
-            to_insert.iter().map(|(idx, vec)| (*vec, *idx)).collect();
+        let refs_for_hnsw: Vec<(&[f32], usize)> = batch
+            .to_insert
+            .iter()
+            .map(|(idx, vec)| (*vec, *idx))
+            .collect();
 
-        // RF-1: Insert into HNSW graph BEFORE storing vectors.
-        // If parallel_insert fails, we avoid orphaned vectors in sidecar storage.
+        // Insert into HNSW graph before storing vectors to avoid orphaned sidecar data.
         if let Err(e) = self.inner.read().parallel_insert(&refs_for_hnsw) {
             tracing::error!("insert_batch_parallel: parallel_insert failed: {e}");
-            // Roll back all registered mappings to avoid phantom entries
-            for (idx, _) in &to_insert {
-                if let Some(id) = self.mappings.get_id(*idx) {
-                    self.mappings.remove(id);
-                }
+            for (id, result) in &batch.rollback_info {
+                self.rollback_upsert(*id, result);
             }
             return 0;
         }
 
-        // Perf: Store vectors after successful HNSW insertion (parallel-friendly)
         if self.enable_vector_storage {
-            to_insert.par_iter().for_each(|(idx, vec)| {
+            batch.to_insert.par_iter().for_each(|(idx, vec)| {
                 self.vectors.insert(*idx, vec);
             });
         }
@@ -133,16 +147,14 @@ impl HnswIndex {
     where
         I: IntoIterator<Item = (u64, &'a [f32])>,
     {
-        let to_insert = self.prepare_batch_insert(vectors);
+        let batch = self.prepare_batch_insert(vectors);
         let mut inserted = 0;
 
-        for (idx, vec) in &to_insert {
+        for (i, (idx, vec)) in batch.to_insert.iter().enumerate() {
             if let Err(e) = self.inner.write().insert((*vec, *idx)) {
                 tracing::error!("insert_batch_sequential: insert failed: {e}");
-                // Roll back the mapping registered by prepare_batch_insert
-                if let Some(id) = self.mappings.get_id(*idx) {
-                    self.mappings.remove(id);
-                }
+                let (id, result) = &batch.rollback_info[i];
+                self.rollback_upsert(*id, result);
                 continue;
             }
             if self.enable_vector_storage {
@@ -247,21 +259,18 @@ impl HnswIndex {
         rerank_k: usize,
         ef_search: usize,
     ) -> Vec<Vec<ScoredResult>> {
-        // Phase 1: HNSW search for all queries with oversampled candidate pool
         let all_candidates: Vec<Vec<ScoredResult>> = queries
             .par_iter()
             .map(|query| self.search_hnsw_only(query, rerank_k, ef_search))
             .collect();
 
-        // Phase 2: Rerank in parallel, collecting per-query latencies to avoid
-        // EMA race (concurrent Relaxed store would lose ~N-1 samples).
+        // Rerank in parallel, collecting per-query latencies for aggregated EMA update.
         let timed_results: Vec<(Vec<ScoredResult>, u64)> = queries
             .par_iter()
             .zip(all_candidates.par_iter())
             .map(|(query, candidates)| self.rerank_sort_and_truncate_timed(query, candidates, k))
             .collect();
 
-        // Update EMA once with mean latency from the entire batch
         let n = timed_results.len() as u64;
         if n > 0 {
             let total_us: u64 = timed_results.iter().map(|(_, e)| e).sum();
@@ -314,9 +323,8 @@ impl HnswIndex {
 
     /// GPU brute-force dispatch accessible from tests.
     ///
-    /// RF-DEDUP: delegates to `search_brute_force_gpu_inner` in `brute_force.rs`
-    /// without the 100K threshold gate, so tests can exercise the GPU path
-    /// with smaller datasets.
+    /// Delegates to `search_brute_force_gpu_inner` without the 100K threshold
+    /// gate, so tests can exercise the GPU path with smaller datasets.
     ///
     /// Returns `None` if GPU is unavailable.
     #[cfg(all(test, feature = "gpu"))]
@@ -334,10 +342,8 @@ impl HnswIndex {
     /// Extracted from `brute_force_search_parallel` so the GPU gate in that
     /// method stays compact.
     fn brute_force_search_rayon(&self, query: &[f32], k: usize) -> Vec<ScoredResult> {
-        // EPIC-A.2: Use collect_for_parallel for rayon par_iter support
         let vectors_snapshot = self.vectors.collect_for_parallel();
 
-        // Compute distances in parallel using rayon
         let mut results: Vec<ScoredResult> = vectors_snapshot
             .par_iter()
             .filter_map(|(idx, vec)| {
@@ -347,7 +353,6 @@ impl HnswIndex {
             })
             .collect();
 
-        // Sort by distance (metric-dependent ordering)
         self.metric.sort_scored_results(&mut results);
 
         results.truncate(k);

--- a/crates/velesdb-core/src/index/hnsw/index/batch.rs
+++ b/crates/velesdb-core/src/index/hnsw/index/batch.rs
@@ -118,7 +118,9 @@ impl HnswIndex {
         // Insert into HNSW graph before storing vectors to avoid orphaned sidecar data.
         if let Err(e) = self.inner.read().parallel_insert(&refs_for_hnsw) {
             tracing::error!("insert_batch_parallel: parallel_insert failed: {e}");
-            for (id, result) in &batch.rollback_info {
+            // Reverse order: undo last upsert first so duplicate-ID chains
+            // restore correctly (each rollback depends on the previous state).
+            for (id, result) in batch.rollback_info.iter().rev() {
                 self.rollback_upsert(*id, result);
             }
             return 0;

--- a/crates/velesdb-core/src/index/hnsw/index/batch.rs
+++ b/crates/velesdb-core/src/index/hnsw/index/batch.rs
@@ -140,6 +140,14 @@ impl HnswIndex {
 
     /// Sequential batch insertion (deprecated in favor of `insert_batch_parallel`).
     ///
+    /// Each item is processed individually (upsert_mapping + graph insert +
+    /// rollback), identical to calling `VectorIndex::insert` in a loop.
+    /// This avoids the eager-batch-mapping issues that arise with duplicate IDs.
+    ///
+    /// # Panics
+    ///
+    /// Panics if any vector has a dimension different from the index dimension.
+    ///
     /// # Performance
     ///
     /// Significantly slower than `insert_batch_parallel`. Use only if you need
@@ -152,18 +160,26 @@ impl HnswIndex {
     where
         I: IntoIterator<Item = (u64, &'a [f32])>,
     {
-        let batch = self.prepare_batch_insert(vectors);
         let mut inserted = 0;
 
-        for (i, (idx, vec)) in batch.to_insert.iter().enumerate() {
-            if let Err(e) = self.inner.write().insert((*vec, *idx)) {
-                tracing::error!("insert_batch_sequential: insert failed: {e}");
-                let (id, result) = &batch.rollback_info[i];
-                self.rollback_upsert(*id, result);
+        for (id, vector) in vectors {
+            assert_eq!(
+                vector.len(),
+                self.dimension,
+                "Vector dimension mismatch: expected {}, got {}",
+                self.dimension,
+                vector.len()
+            );
+
+            let result = self.upsert_mapping(id);
+
+            if let Err(e) = self.inner.write().insert((vector, result.idx)) {
+                tracing::error!("insert_batch_sequential: insert failed for id={id}: {e}");
+                self.rollback_upsert(id, &result);
                 continue;
             }
             if self.enable_vector_storage {
-                self.vectors.insert(*idx, vec);
+                self.vectors.insert(result.idx, vector);
             }
             inserted += 1;
         }

--- a/crates/velesdb-core/src/index/hnsw/index/batch.rs
+++ b/crates/velesdb-core/src/index/hnsw/index/batch.rs
@@ -35,13 +35,11 @@ impl HnswIndex {
     where
         I: IntoIterator<Item = (u64, &'a [f32])>,
     {
-        let iter = vectors.into_iter();
-        let (lower, upper) = iter.size_hint();
-        let capacity = upper.unwrap_or(lower);
-        let mut to_insert = Vec::with_capacity(capacity);
-        let mut rollback_info = Vec::with_capacity(capacity);
+        let items: Vec<(u64, &'a [f32])> = vectors.into_iter().collect();
 
-        for (id, vector) in iter {
+        // Validate ALL dimensions upfront before any destructive upsert_mapping
+        // calls. A panic after partial upsert_mapping would leave orphaned mappings.
+        for (_, vector) in &items {
             assert_eq!(
                 vector.len(),
                 self.dimension,
@@ -49,7 +47,12 @@ impl HnswIndex {
                 self.dimension,
                 vector.len()
             );
+        }
 
+        let mut to_insert = Vec::with_capacity(items.len());
+        let mut rollback_info = Vec::with_capacity(items.len());
+
+        for (id, vector) in items {
             let result = self.upsert_mapping(id);
             to_insert.push((result.idx, vector));
             rollback_info.push((id, result));

--- a/crates/velesdb-core/src/index/hnsw/index/mod.rs
+++ b/crates/velesdb-core/src/index/hnsw/index/mod.rs
@@ -27,19 +27,18 @@ mod search;
 mod trait_impl;
 mod vacuum;
 
-// Re-export VacuumError for public API
-#[allow(unused_imports)]
+#[allow(unused_imports)] // Re-export for downstream consumers; not directly used in this module
 pub use vacuum::VacuumError;
 
 use super::native_inner::NativeHnswInner as HnswInner;
 use super::sharded_mappings::ShardedMappings;
 use super::sharded_vectors::ShardedVectors;
+use super::upsert::{self, UpsertResult};
 use crate::distance::DistanceMetric;
 use parking_lot::RwLock;
 use std::mem::ManuallyDrop;
 use std::sync::atomic::AtomicU64;
 
-// Native persistence - no HnswIo needed (v1.0+)
 type HnswIo = ();
 
 /// HNSW index for efficient approximate nearest neighbor search.
@@ -54,7 +53,6 @@ type HnswIo = ();
 /// index.insert(1, &vec![0.1; 768]);
 /// let results = index.search(&vec![0.1; 768], 10);
 /// ```
-/// HNSW index for efficient approximate nearest neighbor search.
 ///
 /// # Implementation Notes (v1.0+)
 ///
@@ -112,6 +110,31 @@ pub struct HnswIndex {
     /// invariant is already structurally enforced.
     #[allow(dead_code)] // Retained for field-layout invariant; dropped after inner
     pub(crate) io_holder: Option<Box<HnswIo>>,
+}
+
+impl HnswIndex {
+    /// Registers an ID with upsert semantics and cleans up stale vector data.
+    ///
+    /// Returns an [`UpsertResult`] with the new internal index and optional
+    /// old index for rollback. If the ID already existed, the old mapping is
+    /// replaced and the stale sidecar vector is removed.
+    #[must_use]
+    pub(crate) fn upsert_mapping(&self, id: u64) -> UpsertResult {
+        upsert::upsert_mapping(
+            &self.mappings,
+            &self.vectors,
+            self.enable_vector_storage,
+            id,
+        )
+    }
+
+    /// Rolls back a mapping upsert after a failed graph insertion.
+    ///
+    /// Delegates to [`upsert::rollback_upsert`] to restore the previous
+    /// mapping state so the point remains searchable.
+    pub(crate) fn rollback_upsert(&self, id: u64, result: &UpsertResult) {
+        upsert::rollback_upsert(&self.mappings, id, result);
+    }
 }
 
 impl Drop for HnswIndex {

--- a/crates/velesdb-core/src/index/hnsw/index/search.rs
+++ b/crates/velesdb-core/src/index/hnsw/index/search.rs
@@ -32,8 +32,6 @@ impl HnswIndex {
 
     /// Validates that the query/vector dimension matches the index dimension.
     ///
-    /// RF-2.7: Helper to eliminate 7x duplicated validation pattern.
-    ///
     /// # Panics
     ///
     /// Panics if the dimension doesn't match.
@@ -292,8 +290,6 @@ impl HnswIndex {
         ef_search: usize,
     ) -> Vec<ScoredResult> {
         self.validate_dimension(query, "Query");
-
-        // 1. Get candidates from HNSW (fast approximate search)
         let candidates = self.search_hnsw_only(query, rerank_k, ef_search);
 
         self.rerank_sort_and_truncate(query, &candidates, k)
@@ -314,7 +310,6 @@ impl HnswIndex {
     ) -> Vec<ScoredResult> {
         self.validate_dimension(query, "Query");
 
-        // 1. Get candidates from HNSW with specified quality
         // Avoid recursion if initial_quality is Perfect
         let actual_quality = if matches!(initial_quality, SearchQuality::Perfect) {
             SearchQuality::Accurate
@@ -328,9 +323,8 @@ impl HnswIndex {
 
     /// Reranks candidates with SIMD, sorts, truncates, and updates latency EMA.
     ///
-    /// RF-2: Shared rerank pipeline used by `search_with_rerank_with_ef`,
-    /// `search_with_rerank_quality`. The batch path in `batch.rs` uses
-    /// `rerank_sort_and_truncate_timed` directly for aggregated EMA updates.
+    /// The batch path in `batch.rs` uses `rerank_sort_and_truncate_timed`
+    /// directly for aggregated EMA updates.
     pub(super) fn rerank_sort_and_truncate(
         &self,
         query: &[f32],
@@ -481,10 +475,8 @@ impl HnswIndex {
 
     /// Re-ranks candidates using SIMD-optimized exact distance computation.
     ///
-    /// F-05: Zero-copy reranking -- reads vector slices directly from
-    /// `ContiguousVectors` (64-byte aligned, cache-friendly) instead of
-    /// cloning via `ShardedVectors::get()`. Eliminates ~600KB of allocations
-    /// per search for k=100 x dim=1536.
+    /// Reads vector slices directly from `ContiguousVectors` (64-byte aligned,
+    /// cache-friendly) instead of cloning via `ShardedVectors::get()`.
     pub(crate) fn rerank_candidates_simd(
         &self,
         query: &[f32],
@@ -521,7 +513,6 @@ impl HnswIndex {
     /// correct search results. Call this after finishing all insertions
     /// and before performing searches.
     pub fn set_searching_mode(&self) {
-        // RF-1: Using HnswInner method
         let mut inner = self.inner.write();
         inner.set_searching_mode(true);
     }

--- a/crates/velesdb-core/src/index/hnsw/index/trait_impl.rs
+++ b/crates/velesdb-core/src/index/hnsw/index/trait_impl.rs
@@ -9,7 +9,6 @@ use crate::scored_result::ScoredResult;
 impl VectorIndex for HnswIndex {
     #[inline]
     fn insert(&self, id: u64, vector: &[f32]) {
-        // Inline validation for hot path performance
         assert_eq!(
             vector.len(),
             self.dimension,
@@ -18,49 +17,39 @@ impl VectorIndex for HnswIndex {
             vector.len()
         );
 
-        // Register the ID and get internal index with ShardedMappings
-        // Check if ID already exists - hnsw_rs doesn't support updates!
-        // register() returns None if ID already exists
-        let Some(idx) = self.mappings.register(id) else {
-            return; // ID already exists, skip insertion
-        };
+        let result = self.upsert_mapping(id);
 
-        // Insert into HNSW index (RF-1: using HnswInner method)
-        // Perf: Minimize lock hold time by not explicitly dropping
-        if let Err(e) = self.inner.write().insert((vector, idx)) {
-            // Roll back the mapping to avoid orphaned entries
-            self.mappings.remove(id);
+        if let Err(e) = self.inner.write().insert((vector, result.idx)) {
+            self.rollback_upsert(id, &result);
             tracing::error!("HnswIndex::insert failed for id={id}: {e}");
             return;
         }
 
-        // Perf: Conditionally store vector for SIMD re-ranking
-        // When disabled, saves ~50% memory and ~2x insert speed
         if self.enable_vector_storage {
-            self.vectors.insert(idx, vector);
+            self.vectors.insert(result.idx, vector);
         }
     }
 
     fn search(&self, query: &[f32], k: usize) -> Vec<ScoredResult> {
-        // Perf: Use Balanced quality for best latency/recall tradeoff
-        // ef_search=128 provides ~95% recall with minimal latency
         self.search_with_quality(query, k, SearchQuality::Balanced)
     }
 
     /// Performs a **soft delete** of the vector.
     ///
-    /// # Important
+    /// Removes the ID from mappings and cleans up stored vector data.
+    /// The HNSW graph node becomes a tombstone, filtered out during search.
     ///
-    /// This removes the ID from the mappings but **does NOT remove the vector
-    /// from the HNSW graph** (`hnsw_rs` doesn't support true deletion).
-    /// The vector will no longer appear in search results, but memory is not freed.
-    ///
-    /// For workloads with many deletions, consider periodic index rebuilding
-    /// to reclaim memory and maintain optimal graph structure.
+    /// For workloads with many deletions, consider periodic `vacuum()` to
+    /// rebuild the graph and reclaim memory.
     fn remove(&self, id: u64) -> bool {
-        // EPIC-A.1: Lock-free removal with ShardedMappings
-        // Soft delete: vector remains in HNSW graph but is excluded from results
-        self.mappings.remove(id).is_some()
+        if let Some(old_idx) = self.mappings.remove(id) {
+            if self.enable_vector_storage {
+                self.vectors.remove(old_idx);
+            }
+            true
+        } else {
+            false
+        }
     }
 
     fn len(&self) -> usize {

--- a/crates/velesdb-core/src/index/hnsw/index/vacuum.rs
+++ b/crates/velesdb-core/src/index/hnsw/index/vacuum.rs
@@ -2,33 +2,18 @@
 
 use super::{HnswIndex, HnswInner};
 use crate::index::hnsw::params::HnswParams;
-use crate::index::hnsw::sharded_mappings::ShardedMappings;
-use crate::index::hnsw::sharded_vectors::ShardedVectors;
 use std::mem::ManuallyDrop;
 
 /// Errors that can occur during vacuum operations.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum VacuumError {
     /// Vector storage is disabled, cannot rebuild index.
+    #[error("Cannot vacuum: vector storage is disabled (use new() instead of new_fast_insert())")]
     VectorStorageDisabled,
     /// Index rebuild failed (allocation or insertion error).
+    #[error("Vacuum rebuild failed: {0}")]
     RebuildFailed(String),
 }
-
-impl std::fmt::Display for VacuumError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::VectorStorageDisabled => {
-                write!(f, "Cannot vacuum: vector storage is disabled (use new() instead of new_fast_insert())")
-            }
-            Self::RebuildFailed(msg) => {
-                write!(f, "Vacuum rebuild failed: {msg}")
-            }
-        }
-    }
-}
-
-impl std::error::Error for VacuumError {}
 
 impl HnswIndex {
     /// Returns the number of tombstones (soft-deleted entries) in the index.
@@ -88,7 +73,9 @@ impl HnswIndex {
     /// # Important
     ///
     /// - This operation is **blocking** and may take significant time for large indices
-    /// - The index remains readable during rebuild (copy-on-write pattern)
+    /// - **Consistency**: between the graph swap and mappings rebuild, concurrent
+    ///   searches may return incomplete results. Callers should avoid concurrent
+    ///   queries during vacuum or accept transient result gaps.
     /// - Requires `enable_vector_storage = true` (vectors must be stored)
     ///
     /// # Returns
@@ -141,33 +128,19 @@ impl HnswIndex {
         )
         .map_err(|e| VacuumError::RebuildFailed(e.to_string()))?;
 
-        // 3. Create new mappings and vectors
-        let new_mappings = ShardedMappings::with_capacity(count);
-        let new_vectors = ShardedVectors::new(self.dimension);
-
-        // 4. Bulk insert into new structures
+        // 3. Build HNSW insertion references (idx = sequential, matches graph allocation)
         let refs_for_hnsw: Vec<(&[f32], usize)> = active_vectors
             .iter()
             .enumerate()
-            .map(|(idx, (id, vec))| {
-                // Register in new mappings
-                let mapped = new_mappings.register(*id);
-                debug_assert!(
-                    mapped.is_some(),
-                    "Vacuum invariant violated: active_vectors contains duplicate id {id}"
-                );
-                // Store in new vectors
-                new_vectors.insert(idx, vec);
-                (vec.as_slice(), idx)
-            })
+            .map(|(idx, (_id, vec))| (vec.as_slice(), idx))
             .collect();
 
-        // 5. Parallel insert into new HNSW
+        // 4. Parallel insert into new HNSW
         new_inner
             .parallel_insert(&refs_for_hnsw)
             .map_err(|e| VacuumError::RebuildFailed(e.to_string()))?;
 
-        // 6. Atomic swap (replace old with new)
+        // 5. Atomic swap (replace old with new)
         {
             let mut inner_guard = self.inner.write();
             // SAFETY: ManuallyDrop::drop is safe when exclusive ownership is guaranteed.
@@ -182,7 +155,7 @@ impl HnswIndex {
             *inner_guard = ManuallyDrop::new(new_inner);
         }
 
-        // 7. Swap mappings and vectors
+        // 6. Swap mappings and vectors
         // Note: ShardedMappings/ShardedVectors use interior mutability,
         // so we need to clear and repopulate
         self.mappings.clear();

--- a/crates/velesdb-core/src/index/hnsw/index_tests.rs
+++ b/crates/velesdb-core/src/index/hnsw/index_tests.rs
@@ -2573,6 +2573,40 @@ fn test_upsert_entry_point_vector() {
 // Upsert Rollback + Edge Case Tests (Issue #371)
 // -------------------------------------------------------------------------
 
+/// Verifies that batch insert with within-batch duplicate IDs correctly
+/// deduplicates: only the last occurrence is reachable, and the count
+/// reflects unique IDs (not raw entries). Within-batch duplicates are an
+/// unusual pattern but must not corrupt mapping state.
+#[test]
+fn test_batch_upsert_within_batch_duplicates() {
+    let dim = 4;
+    let index = HnswIndex::new(dim, DistanceMetric::Cosine).unwrap();
+
+    // Batch with id=1 appearing twice: first [1,0,0,0], then [0,1,0,0]
+    let vec_a = vec![1.0_f32, 0.0, 0.0, 0.0];
+    let vec_b = vec![0.0_f32, 1.0, 0.0, 0.0];
+    let batch: Vec<(u64, &[f32])> = vec![(1, &vec_a), (1, &vec_b), (2, &vec_a)];
+
+    let inserted = index.insert_batch_parallel(batch);
+    // Count may include both entries for id=1, but len() must reflect unique IDs
+    assert!(inserted >= 2, "At least 2 entries processed, got {inserted}");
+    assert_eq!(index.len(), 2, "Only 2 unique IDs should be mapped");
+
+    // id=1 must be searchable and point to vec_b (last wins)
+    let results = index.search(&vec_b, 1);
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].id, 1, "id=1 must be findable after within-batch upsert");
+    assert!(
+        results[0].score > 0.9,
+        "id=1 should match vec_b, got score {}",
+        results[0].score,
+    );
+
+    // id=2 must also be searchable
+    let results2 = index.search(&vec_a, 1);
+    assert_eq!(results2[0].id, 2, "id=2 must be findable");
+}
+
 /// Creates a deterministic vector where dimension `dominant_dim` has a
 /// large component, making it easily distinguishable in cosine search.
 ///

--- a/crates/velesdb-core/src/index/hnsw/index_tests.rs
+++ b/crates/velesdb-core/src/index/hnsw/index_tests.rs
@@ -2,6 +2,7 @@
 #![allow(
     clippy::cast_precision_loss,
     clippy::cast_sign_loss,
+    clippy::cast_possible_truncation,
     clippy::redundant_closure_for_method_calls
 )]
 
@@ -386,26 +387,26 @@ fn test_hnsw_search_wrong_dimension_panics() {
 }
 
 #[test]
-fn test_hnsw_duplicate_insert_is_skipped() {
+fn test_hnsw_duplicate_insert_upserts_vector() {
     // Arrange
     let index = HnswIndex::new(3, DistanceMetric::Cosine).unwrap();
     index.insert(1, &[1.0, 0.0, 0.0]);
 
-    // Act - Insert with same ID should be SKIPPED (not updated)
-    // hnsw_rs doesn't support updates; inserting same idx creates ghosts
+    // Act - Insert with same ID performs upsert (replaces the vector)
     index.insert(1, &[0.0, 1.0, 0.0]);
 
     // Assert
     assert_eq!(index.len(), 1); // Still only one entry
 
-    // Verify the ORIGINAL vector is still there (not updated)
-    let results = index.search(&[1.0, 0.0, 0.0], 1);
+    // Verify the UPDATED vector is indexed (not the original)
+    let results = index.search(&[0.0, 1.0, 0.0], 1);
     assert_eq!(results.len(), 1);
     assert_eq!(results[0].id, 1);
-    // Score should be ~1.0 (exact match with original vector)
+    // Score should be ~1.0 (only 1 vector in index, exact match expected)
     assert!(
-        results[0].score > 0.99,
-        "Original vector should still be indexed"
+        results[0].score > 0.9,
+        "Updated vector should be indexed, got score {}",
+        results[0].score,
     );
 }
 
@@ -557,23 +558,23 @@ fn test_hnsw_insert_batch_parallel() {
 }
 
 #[test]
-fn test_hnsw_insert_batch_parallel_skips_duplicates() {
+fn test_hnsw_insert_batch_parallel_upserts_duplicates() {
     // Arrange
     let index = HnswIndex::new(3, DistanceMetric::Cosine).unwrap();
 
     // Insert one vector first
     index.insert(1, &[1.0, 0.0, 0.0]);
 
-    // Act - Try to insert batch with duplicate ID
+    // Act - Insert batch with existing ID (upsert) + new ID
     let vectors: Vec<(u64, Vec<f32>)> = vec![
-        (1, vec![0.0, 1.0, 0.0]), // Duplicate ID
+        (1, vec![0.0, 1.0, 0.0]), // Upsert: updates existing id=1
         (2, vec![0.0, 0.0, 1.0]), // New
     ];
     let inserted = index.insert_batch_parallel(vectors.iter().map(|(id, v)| (*id, v.as_slice())));
     index.set_searching_mode();
 
-    // Assert - Only 1 new vector should be inserted
-    assert_eq!(inserted, 1);
+    // Assert - Both vectors processed (1 upserted + 1 new)
+    assert_eq!(inserted, 2);
     assert_eq!(index.len(), 2);
 }
 
@@ -610,20 +611,20 @@ fn test_hnsw_insert_batch_sequential() {
 
 #[test]
 #[allow(deprecated)]
-fn test_hnsw_insert_batch_sequential_skips_duplicates() {
+fn test_hnsw_insert_batch_sequential_upserts_duplicates() {
     // Arrange
     let index = HnswIndex::new(3, DistanceMetric::Cosine).unwrap();
     index.insert(1, &[1.0, 0.0, 0.0]);
 
-    // Act - Try to insert batch with duplicate ID
+    // Act - Insert batch with existing ID (upsert) + new ID
     let vectors: Vec<(u64, Vec<f32>)> = vec![
-        (1, vec![0.0, 1.0, 0.0]), // Duplicate ID
+        (1, vec![0.0, 1.0, 0.0]), // Upsert: updates existing id=1
         (2, vec![0.0, 0.0, 1.0]), // New
     ];
     let inserted = index.insert_batch_sequential(vectors.iter().map(|(id, v)| (*id, v.as_slice())));
 
-    // Assert - Only 1 new vector should be inserted
-    assert_eq!(inserted, 1);
+    // Assert - Both vectors processed (1 upserted + 1 new)
+    assert_eq!(inserted, 2);
     assert_eq!(index.len(), 2);
 }
 
@@ -2224,4 +2225,425 @@ fn test_adaptive_search_spread_works_for_similarity_metrics() {
             pair[1].score,
         );
     }
+}
+
+// -------------------------------------------------------------------------
+// Upsert Semantics Tests (Issue #371)
+// -------------------------------------------------------------------------
+
+#[test]
+fn test_insert_same_id_updates_vector() {
+    // Arrange: create index with vector storage enabled (default)
+    let index = HnswIndex::new(4, DistanceMetric::Cosine).unwrap();
+
+    // Insert id=1 with vector A (pointing along x-axis)
+    let vector_a = [1.0, 0.0, 0.0, 0.0];
+    index.insert(1, &vector_a);
+
+    // Act: insert id=1 again with vector B (pointing along y-axis, orthogonal to A)
+    let vector_b = [0.0, 1.0, 0.0, 0.0];
+    index.insert(1, &vector_b);
+
+    // Assert 1: index length must still be 1 (not 2)
+    assert_eq!(index.len(), 1, "Upsert must not create duplicate entries");
+
+    // Assert 2: search with query=B should return id=1 with high similarity
+    let results = index.search(&vector_b, 1);
+    assert_eq!(results.len(), 1, "Should find exactly one result");
+    assert_eq!(results[0].id, 1, "Result must be id=1");
+    assert!(
+        results[0].score > 0.9,
+        "Similarity to updated vector B should be > 0.9, got {}",
+        results[0].score,
+    );
+}
+
+// -------------------------------------------------------------------------
+// Upsert + Tombstone / Vacuum TDD Cycle 3 Tests
+// -------------------------------------------------------------------------
+
+#[test]
+fn test_upsert_tombstone_accumulation() {
+    // Arrange: 10-dim index so each of 10 IDs gets a unique dominant dimension
+    let dim = 10;
+    let index = HnswIndex::new(dim, DistanceMetric::Cosine).unwrap();
+
+    // Insert 10 vectors (generation 0)
+    for i in 0..10_usize {
+        index.insert(i as u64, &make_dominant_vector(dim, i, 0));
+    }
+
+    // Assert: no tombstones, 10 active entries
+    assert_eq!(
+        index.tombstone_count(),
+        0,
+        "Fresh index should have 0 tombstones"
+    );
+    assert_eq!(index.len(), 10, "Should have 10 active vectors");
+
+    // Act: update all 10 vectors with new values (generation 1)
+    for i in 0..10_usize {
+        index.insert(i as u64, &make_dominant_vector(dim, i, 1));
+    }
+
+    // Assert: 10 tombstones (old slots are dead), still 10 active
+    assert_eq!(
+        index.tombstone_count(),
+        10,
+        "Updating 10 vectors should leave 10 tombstones",
+    );
+    assert_eq!(index.len(), 10, "Active count must remain 10 after upserts");
+
+    // Tombstone ratio = 10 / 20 = 0.50 => needs_vacuum (threshold 0.20)
+    assert!(
+        index.needs_vacuum(),
+        "Tombstone ratio {:.2} should exceed 0.20 threshold",
+        index.tombstone_ratio(),
+    );
+}
+
+#[test]
+fn test_upsert_then_vacuum_cleans() {
+    // Arrange: 10-dim index so each of 10 IDs has a unique dominant dimension
+    let dim = 10;
+    let index = HnswIndex::new(dim, DistanceMetric::Cosine).unwrap();
+
+    // Insert 10 vectors (generation 0)
+    for i in 0..10_usize {
+        index.insert(i as u64, &make_dominant_vector(dim, i, 0));
+    }
+
+    // Update only the first 5 (id=0..4) with generation 1
+    for i in 0..5_usize {
+        index.insert(i as u64, &make_dominant_vector(dim, i, 1));
+    }
+
+    // Pre-vacuum assertions
+    assert_eq!(
+        index.tombstone_count(),
+        5,
+        "Updating 5 vectors should create 5 tombstones",
+    );
+    assert_eq!(index.len(), 10);
+
+    // Act: vacuum
+    let rebuilt = index.vacuum().expect("vacuum should succeed");
+    assert_eq!(rebuilt, 10, "Vacuum should report 10 active vectors");
+
+    // Post-vacuum: tombstones cleared
+    assert_eq!(
+        index.tombstone_count(),
+        0,
+        "Vacuum must eliminate all tombstones",
+    );
+    assert_eq!(index.len(), 10, "All 10 vectors must survive vacuum");
+
+    // Verify search correctness: each id appears in its own top-1 result
+    // Use the *current* generation vector as query
+    for i in 0..10_usize {
+        let gen = u8::from(i < 5);
+        let query = make_dominant_vector(dim, i, gen);
+        let results = index.search(&query, 1);
+        assert!(
+            !results.is_empty(),
+            "Search for id={i} returned no results after vacuum",
+        );
+        assert_eq!(
+            results[0].id, i as u64,
+            "Top-1 for id={i} should be itself, got id={}",
+            results[0].id,
+        );
+    }
+}
+
+#[test]
+fn test_batch_upsert_updates_existing() {
+    // Arrange: 10-dim index so each of 10 IDs gets a unique dominant dimension
+    let dim = 10;
+    let index = HnswIndex::new(dim, DistanceMetric::Cosine).unwrap();
+
+    // Insert 10 vectors (generation 0) via batch
+    let original_vectors: Vec<(u64, Vec<f32>)> = (0..10)
+        .map(|id| (id, make_dominant_vector(dim, id as usize, 0)))
+        .collect();
+
+    let refs: Vec<(u64, &[f32])> = original_vectors
+        .iter()
+        .map(|(id, v)| (*id, v.as_slice()))
+        .collect();
+
+    let inserted = index.insert_batch_parallel(refs);
+    assert_eq!(inserted, 10, "Should insert all 10 vectors");
+    assert_eq!(index.len(), 10, "Index should contain 10 entries");
+
+    // Act: update first 5 (id=0..4) with generation 1 via batch
+    let updated_vectors: Vec<(u64, Vec<f32>)> = (0..5)
+        .map(|id| (id, make_dominant_vector(dim, id as usize, 1)))
+        .collect();
+
+    let update_refs: Vec<(u64, &[f32])> = updated_vectors
+        .iter()
+        .map(|(id, v)| (*id, v.as_slice()))
+        .collect();
+
+    let upserted = index.insert_batch_parallel(update_refs);
+    assert_eq!(upserted, 5, "Should upsert all 5 vectors");
+
+    // Assert 1: index length must still be 10 (not 15)
+    assert_eq!(
+        index.len(),
+        10,
+        "Batch upsert must not create duplicate entries: expected 10, got {}",
+        index.len(),
+    );
+
+    // Assert 2: for each updated id (0..4), search with generation 1 vector
+    for id in 0..5_u64 {
+        let query = make_dominant_vector(dim, id as usize, 1);
+        let results = index.search(&query, 1);
+        assert_eq!(
+            results.len(),
+            1,
+            "Updated id={id}: should find exactly one result"
+        );
+        assert_eq!(
+            results[0].id, id,
+            "Updated id={id}: top-1 result should be the updated vector"
+        );
+        assert!(
+            results[0].score > 0.9,
+            "Updated id={id}: similarity to updated vector should be > 0.9, got {}",
+            results[0].score,
+        );
+    }
+
+    // Assert 3: for each non-updated id (5..9), search with generation 0 vector
+    for id in 5..10_u64 {
+        let query = make_dominant_vector(dim, id as usize, 0);
+        let results = index.search(&query, 1);
+        assert!(
+            !results.is_empty(),
+            "Non-updated id={id}: should find results"
+        );
+        assert_eq!(
+            results[0].id, id,
+            "Non-updated id={id}: top-1 result should be the original vector"
+        );
+    }
+}
+
+// -------------------------------------------------------------------------
+// Upsert TDD Cycle 5: Recall Verification + Edge Cases
+// -------------------------------------------------------------------------
+
+/// Verifies that after updating a vector to a different cluster, search
+/// finds it in the NEW location and no longer returns it from the OLD cluster.
+#[allow(clippy::similar_names)] // origin/target are semantically distinct cluster labels
+#[test]
+fn test_upsert_search_recall() {
+    let index = HnswIndex::new(8, DistanceMetric::Cosine).unwrap();
+
+    // Origin cluster center: dominant component at dim 0
+    let origin_center: Vec<f32> = vec![1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0];
+    // Target cluster center: dominant component at dim 4
+    let target_center: Vec<f32> = vec![0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0];
+
+    // Build deterministic vectors with small perturbation per id.
+    // Origin cluster: ids 0..49, base near origin_center
+    let origin_vectors: Vec<(u64, Vec<f32>)> = (0..50)
+        .map(|i| {
+            let mut v = origin_center.clone();
+            for (d, component) in v.iter_mut().enumerate() {
+                *component += 0.01 * (i * 8 + d) as f32;
+            }
+            (i as u64, v)
+        })
+        .collect();
+
+    // Target cluster: ids 50..99, base near target_center
+    let target_vectors: Vec<(u64, Vec<f32>)> = (0..50)
+        .map(|i| {
+            let mut v = target_center.clone();
+            for (d, component) in v.iter_mut().enumerate() {
+                *component += 0.01 * (i * 8 + d) as f32;
+            }
+            (i as u64 + 50, v)
+        })
+        .collect();
+
+    // Insert all 100 vectors via batch
+    let all_vectors: Vec<(u64, Vec<f32>)> = origin_vectors
+        .iter()
+        .chain(target_vectors.iter())
+        .map(|(id, v)| (*id, v.clone()))
+        .collect();
+
+    let refs: Vec<(u64, &[f32])> = all_vectors
+        .iter()
+        .map(|(id, v)| (*id, v.as_slice()))
+        .collect();
+
+    let inserted = index.insert_batch_parallel(refs);
+    assert_eq!(inserted, 100, "Should insert all 100 vectors");
+
+    // Update id=25 (origin cluster) to a target cluster vector
+    let moved_vector: Vec<f32> = vec![0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0];
+    index.insert(25, &moved_vector);
+
+    assert_eq!(index.len(), 100, "Length must remain 100 after upsert");
+
+    // Search near target cluster center: id=25 should appear (it moved there)
+    let results_target = index.search(&target_center, 10);
+    let found_in_target = results_target.iter().any(|r| r.id == 25);
+    assert!(
+        found_in_target,
+        "id=25 should appear in target cluster results after upsert, got ids: {:?}",
+        results_target.iter().map(|r| r.id).collect::<Vec<_>>(),
+    );
+
+    // Search near origin cluster center: id=25 should NOT appear (it left)
+    let results_origin = index.search(&origin_center, 10);
+    let found_in_origin = results_origin.iter().any(|r| r.id == 25);
+    assert!(
+        !found_in_origin,
+        "id=25 should NOT appear in origin cluster results after upsert, got ids: {:?}",
+        results_origin.iter().map(|r| r.id).collect::<Vec<_>>(),
+    );
+}
+
+/// Verifies that updating the very first vector (likely the HNSW entry point)
+/// does not break search for any vector in the index.
+#[test]
+fn test_upsert_entry_point_vector() {
+    let index = HnswIndex::new(4, DistanceMetric::Cosine).unwrap();
+
+    // Insert id=0 first — this becomes the HNSW entry point
+    let ep_original = vec![1.0, 0.0, 0.0, 0.0];
+    index.insert(0, &ep_original);
+
+    // Update id=0 to a completely different direction
+    let ep_updated = vec![0.0, 0.0, 0.0, 1.0];
+    index.insert(0, &ep_updated);
+
+    // Insert 20 more vectors with varied, well-separated values.
+    // Each vector has a dominant component determined by (id % 4).
+    let additional_vectors: Vec<(u64, Vec<f32>)> = (1..=20)
+        .map(|i| {
+            let dominant_dim = (i as usize) % 4;
+            let mut v = vec![0.1_f32; 4];
+            v[dominant_dim] += 1.0 + 0.05 * i as f32;
+            (i as u64, v)
+        })
+        .collect();
+
+    let refs: Vec<(u64, &[f32])> = additional_vectors
+        .iter()
+        .map(|(id, v)| (*id, v.as_slice()))
+        .collect();
+
+    let inserted = index.insert_batch_parallel(refs);
+    assert_eq!(inserted, 20, "Should insert all 20 vectors");
+    assert_eq!(index.len(), 21, "Index should contain 21 entries");
+
+    // Verify: searching for the updated id=0 vector returns id=0 as top-1
+    let results_ep = index.search(&ep_updated, 1);
+    assert_eq!(results_ep.len(), 1, "Should find at least 1 result for EP");
+    assert_eq!(
+        results_ep[0].id, 0,
+        "Top-1 for updated entry point should be id=0, got id={}",
+        results_ep[0].id,
+    );
+
+    // Verify: each of the 20 additional vectors is findable as top-1
+    for (id, vec) in &additional_vectors {
+        let results = index.search(vec.as_slice(), 1);
+        assert!(
+            !results.is_empty(),
+            "Search for id={id} should return results",
+        );
+        assert_eq!(
+            results[0].id, *id,
+            "Top-1 for id={id} should be itself, got id={}",
+            results[0].id,
+        );
+    }
+}
+
+// -------------------------------------------------------------------------
+// Upsert Rollback + Edge Case Tests (Issue #371)
+// -------------------------------------------------------------------------
+
+/// Creates a deterministic vector where dimension `dominant_dim` has a
+/// large component, making it easily distinguishable in cosine search.
+///
+/// Shared helper to avoid duplicating the same closure across tests.
+fn make_dominant_vector(dim: usize, dominant_dim: usize, gen: u8) -> Vec<f32> {
+    let mut v = vec![0.1_f32; dim];
+    v[dominant_dim % dim] += 1.0 + f32::from(gen) * 0.5;
+    v
+}
+
+/// Verifies that insert(id) after remove(id) correctly re-inserts
+/// the vector and returns it in search results.
+#[test]
+fn test_upsert_after_delete() {
+    let dim = 8;
+    let index = HnswIndex::new(dim, DistanceMetric::Cosine).unwrap();
+
+    // Insert id=1 with dominant dim 0
+    let vec_a = make_dominant_vector(dim, 0, 0);
+    index.insert(1, &vec_a);
+    assert_eq!(index.len(), 1);
+
+    // Remove id=1
+    assert!(index.remove(1));
+    assert_eq!(index.len(), 0);
+
+    // Re-insert id=1 with dominant dim 4
+    let vec_b = make_dominant_vector(dim, 4, 1);
+    index.insert(1, &vec_b);
+    assert_eq!(index.len(), 1, "Re-inserted id should count as 1 vector");
+
+    // Search should find id=1 near vec_b
+    let results = index.search(&vec_b, 1);
+    assert_eq!(results.len(), 1);
+    assert_eq!(
+        results[0].id, 1,
+        "After delete + re-insert, search must find re-inserted id=1"
+    );
+}
+
+/// Verifies that upserting the same id N times leaves exactly N-1
+/// tombstones and the index still contains exactly 1 live vector
+/// that matches the latest version.
+#[test]
+fn test_repeated_upsert_accumulates_tombstones() {
+    let dim = 8;
+    let index = HnswIndex::new(dim, DistanceMetric::Cosine).unwrap();
+    let num_upserts: usize = 20;
+
+    for gen in 0..num_upserts {
+        let v = make_dominant_vector(dim, gen % dim, gen as u8);
+        index.insert(1, &v);
+    }
+
+    assert_eq!(
+        index.len(),
+        1,
+        "Repeated upserts must not duplicate entries"
+    );
+    assert_eq!(
+        index.tombstone_count(),
+        num_upserts - 1,
+        "Each upsert after the first should leave one tombstone"
+    );
+
+    // Search must return the latest vector (dominant dim = (num_upserts-1) % dim)
+    let latest = make_dominant_vector(dim, (num_upserts - 1) % dim, (num_upserts - 1) as u8);
+    let results = index.search(&latest, 1);
+    assert_eq!(results.len(), 1);
+    assert_eq!(
+        results[0].id, 1,
+        "Search must return the latest upserted vector"
+    );
 }

--- a/crates/velesdb-core/src/index/hnsw/mod.rs
+++ b/crates/velesdb-core/src/index/hnsw/mod.rs
@@ -31,6 +31,7 @@ mod params;
 pub(crate) mod persistence;
 mod sharded_mappings;
 mod sharded_vectors;
+pub(crate) mod upsert;
 mod vector_store;
 
 // ============================================================================

--- a/crates/velesdb-core/src/index/hnsw/native/tests.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/tests.rs
@@ -775,12 +775,12 @@ fn test_concurrent_insert_delete_search_at_index_level() {
     }
 
     // Post-conditions:
-    // NativeHnswIndex::len() returns graph size (soft-deletes don't shrink it).
-    // Graph size = 100 initial + 100 new inserts = 200
-    let graph_len = index.len();
+    // NativeHnswIndex::len() returns live mapping count (excluding soft-deletes).
+    // Live count = 100 initial + 100 new inserts - 50 deleted = 150
+    let live_len = index.len();
     assert_eq!(
-        graph_len, 200,
-        "Graph size must reflect all inserts: got {graph_len}"
+        live_len, 150,
+        "Live count must reflect inserts minus deletes: got {live_len}"
     );
 
     // Verify deleted IDs (0..49) are excluded from search results.
@@ -863,9 +863,10 @@ fn test_delete_exclusion_under_concurrent_search() {
         "No non-finite distances should appear during concurrent delete+search"
     );
 
-    // After all deletes complete, graph size remains 200 (soft-delete keeps nodes).
-    let graph_len = index.len();
-    assert_eq!(graph_len, 200, "Graph size unchanged by soft-deletes");
+    // After all deletes complete, live count reflects removed mappings.
+    // 200 initial - 100 even IDs deleted = 100 remaining.
+    let live_len = index.len();
+    assert_eq!(live_len, 100, "Live count must exclude soft-deleted IDs");
 
     // All even IDs must be gone from search results (soft-delete exclusion).
     let query: Vec<f32> = (0..16).map(|j| (j as f32 * 0.01).sin()).collect();

--- a/crates/velesdb-core/src/index/hnsw/native_index.rs
+++ b/crates/velesdb-core/src/index/hnsw/native_index.rs
@@ -329,7 +329,9 @@ impl NativeHnswIndex {
             .collect();
 
         if let Err(e) = self.inner.read().parallel_insert(&data) {
-            for (id, result) in &rollback_info {
+            // Reverse order: undo last upsert first so duplicate-ID chains
+            // restore correctly (each rollback depends on the previous state).
+            for (id, result) in rollback_info.iter().rev() {
                 self.rollback_upsert(*id, result);
             }
             return Err(e);

--- a/crates/velesdb-core/src/index/hnsw/native_index.rs
+++ b/crates/velesdb-core/src/index/hnsw/native_index.rs
@@ -290,6 +290,15 @@ impl NativeHnswIndex {
     ///
     /// Returns an error if allocation or graph insertion fails.
     pub fn insert(&self, id: u64, vector: &[f32]) -> crate::error::Result<()> {
+        // Validate dimension BEFORE upsert_mapping to avoid destroying the old
+        // mapping for an invalid vector (Devin review finding).
+        if vector.len() != self.dimension {
+            return Err(crate::error::Error::DimensionMismatch {
+                expected: self.dimension,
+                actual: vector.len(),
+            });
+        }
+
         let result = self.upsert_mapping(id);
 
         if let Err(e) = self.inner.read().insert((vector, result.idx)) {
@@ -316,6 +325,16 @@ impl NativeHnswIndex {
     ///
     /// Returns an error if any insertion fails.
     pub fn insert_batch(&self, items: &[(u64, Vec<f32>)]) -> crate::error::Result<()> {
+        // Validate all dimensions upfront before any upsert_mapping side effects.
+        for (_id, vec) in items {
+            if vec.len() != self.dimension {
+                return Err(crate::error::Error::DimensionMismatch {
+                    expected: self.dimension,
+                    actual: vec.len(),
+                });
+            }
+        }
+
         let mut rollback_info: Vec<(u64, UpsertResult)> = Vec::with_capacity(items.len());
 
         let data: Vec<(&[f32], usize)> = items

--- a/crates/velesdb-core/src/index/hnsw/native_index.rs
+++ b/crates/velesdb-core/src/index/hnsw/native_index.rs
@@ -12,13 +12,11 @@
 //! velesdb-core = { version = "0.8", features = ["native-hnsw"] }
 //! ```
 
-#![allow(dead_code)] // Will be used when feature flag is enabled
-#![allow(clippy::cast_precision_loss)] // Test code uses simple casts
-
 use super::native_inner::NativeHnswInner;
 use super::params::{HnswParams, SearchQuality};
 use super::sharded_mappings::ShardedMappings;
 use super::sharded_vectors::ShardedVectors;
+use super::upsert::{self, UpsertResult};
 use crate::distance::DistanceMetric;
 use crate::index::VectorIndex;
 use crate::scored_result::ScoredResult;
@@ -43,6 +41,7 @@ pub struct NativeHnswIndex {
     mappings: ShardedMappings,
     vectors: ShardedVectors,
     enable_vector_storage: bool,
+    #[allow(dead_code)] // Retained for future vacuum/rebuild operations
     params: HnswParams,
 }
 
@@ -208,18 +207,21 @@ impl NativeHnswIndex {
         self.metric
     }
 
-    /// Returns the number of vectors in the index.
+    /// Returns the number of live vectors in the index.
+    ///
+    /// This reflects the mapping count (excluding tombstones), consistent
+    /// with `HnswIndex::len()`.
     #[inline]
     #[must_use]
     pub fn len(&self) -> usize {
-        self.inner.read().len()
+        self.mappings.len()
     }
 
-    /// Returns true if the index is empty.
+    /// Returns true if the index contains no live vectors.
     #[inline]
     #[must_use]
     pub fn is_empty(&self) -> bool {
-        self.inner.read().is_empty()
+        self.mappings.is_empty()
     }
 
     /// Returns whether vector storage is enabled.
@@ -230,11 +232,13 @@ impl NativeHnswIndex {
     }
 
     /// Searches for the k nearest neighbors.
+    #[must_use]
     pub fn search(&self, query: &[f32], k: usize) -> Vec<ScoredResult> {
         self.search_with_quality(query, k, SearchQuality::Balanced)
     }
 
     /// Searches with a specific quality profile.
+    #[must_use]
     pub fn search_with_quality(
         &self,
         query: &[f32],
@@ -256,76 +260,77 @@ impl NativeHnswIndex {
             .collect()
     }
 
-    /// Inserts a single vector.
+    /// Registers an ID with upsert semantics and cleans up stale vector data.
     ///
-    /// Internal mapping races are handled defensively: if a concurrent
-    /// registration race violates the mapping invariant, insertion is skipped.
+    /// Returns an [`UpsertResult`] with the new internal index and optional
+    /// old index for rollback. If the ID already existed, the old mapping is
+    /// replaced and the stale sidecar vector is removed.
+    #[must_use]
+    fn upsert_mapping(&self, id: u64) -> UpsertResult {
+        upsert::upsert_mapping(
+            &self.mappings,
+            &self.vectors,
+            self.enable_vector_storage,
+            id,
+        )
+    }
+
+    /// Rolls back a mapping upsert after a failed graph insertion.
+    fn rollback_upsert(&self, id: u64, result: &UpsertResult) {
+        upsert::rollback_upsert(&self.mappings, id, result);
+    }
+
+    /// Inserts or updates a single vector (upsert semantics).
+    ///
+    /// If `id` already exists, the old mapping is atomically replaced and
+    /// stale vector data is cleaned up. The old HNSW graph node becomes a
+    /// tombstone, filtered out during search via the reverse mapping.
     ///
     /// # Errors
     ///
-    /// Returns an error if allocation or insertion fails.
+    /// Returns an error if allocation or graph insertion fails.
     pub fn insert(&self, id: u64, vector: &[f32]) -> crate::error::Result<()> {
-        // Register ID and get internal index (or get existing)
-        // Track whether we newly registered this ID (vs. re-inserting an existing one)
-        let newly_registered = self.mappings.register(id);
-        let internal_idx = newly_registered.or_else(|| self.mappings.get_idx(id));
-        let Some(internal_idx) = internal_idx else {
-            debug_assert!(
-                false,
-                "Invariant violated: register returned None but ID missing from mappings"
-            );
-            return Ok(());
-        };
+        let result = self.upsert_mapping(id);
 
-        // If graph insertion fails, roll back the mapping to avoid orphaned entries
-        if let Err(e) = self.inner.read().insert((vector, internal_idx)) {
-            if newly_registered.is_some() {
-                self.mappings.remove(id);
-            }
+        if let Err(e) = self.inner.read().insert((vector, result.idx)) {
+            self.rollback_upsert(id, &result);
             return Err(e);
         }
 
         if self.enable_vector_storage {
-            self.vectors.insert(internal_idx, vector);
+            self.vectors.insert(result.idx, vector);
         }
         Ok(())
     }
 
-    /// Batch insert multiple vectors.
+    /// Batch insert or update multiple vectors (upsert semantics).
     ///
-    /// Internal mapping races are handled defensively: if a concurrent
-    /// registration race violates the mapping invariant, insertion is skipped.
+    /// For each item, the mapping is atomically replaced if the ID already
+    /// exists. Stale vector data is cleaned up before the graph insertion.
+    ///
+    /// On graph insertion failure, all IDs in this batch are removed from
+    /// mappings. For replaced IDs, the old mapping is already gone — the
+    /// caller should retry the full batch.
     ///
     /// # Errors
     ///
     /// Returns an error if any insertion fails.
     pub fn insert_batch(&self, items: &[(u64, Vec<f32>)]) -> crate::error::Result<()> {
-        // Track newly registered IDs so we can roll back on failure
-        let mut newly_registered_ids: Vec<u64> = Vec::new();
+        let mut rollback_info: Vec<(u64, UpsertResult)> = Vec::with_capacity(items.len());
 
         let data: Vec<(&[f32], usize)> = items
             .iter()
-            .filter_map(|(id, vec)| {
-                let is_new = self.mappings.register(*id);
-                if is_new.is_some() {
-                    newly_registered_ids.push(*id);
-                }
-                let idx = is_new.or_else(|| self.mappings.get_idx(*id));
-                let Some(idx) = idx else {
-                    debug_assert!(
-                        false,
-                        "Invariant violated: register returned None but ID missing from mappings"
-                    );
-                    return None;
-                };
-                Some((vec.as_slice(), idx))
+            .map(|(id, vec)| {
+                let result = self.upsert_mapping(*id);
+                let idx = result.idx;
+                rollback_info.push((*id, result));
+                (vec.as_slice(), idx)
             })
             .collect();
 
-        // If parallel_insert fails, roll back all newly registered mappings
         if let Err(e) = self.inner.read().parallel_insert(&data) {
-            for id in &newly_registered_ids {
-                self.mappings.remove(*id);
+            for (id, result) in &rollback_info {
+                self.rollback_upsert(*id, result);
             }
             return Err(e);
         }
@@ -338,9 +343,19 @@ impl NativeHnswIndex {
         Ok(())
     }
 
-    /// Removes a vector by ID (marks as deleted in mappings).
+    /// Removes a vector by ID (soft delete).
+    ///
+    /// Removes the ID from mappings and cleans up stored vector data.
+    /// The HNSW graph node becomes a tombstone, filtered out during search.
     pub fn remove(&self, id: u64) -> bool {
-        self.mappings.remove(id).is_some()
+        if let Some(old_idx) = self.mappings.remove(id) {
+            if self.enable_vector_storage {
+                self.vectors.remove(old_idx);
+            }
+            true
+        } else {
+            false
+        }
     }
 
     /// Sets searching mode (no-op for native implementation).
@@ -348,9 +363,7 @@ impl NativeHnswIndex {
     /// This method exists for API compatibility with `HnswIndex`.
     /// The native implementation doesn't require mode switching.
     #[allow(clippy::unused_self)]
-    pub fn set_searching_mode(&self) {
-        // No-op - native implementation doesn't need this
-    }
+    pub fn set_searching_mode(&self) {}
 
     /// Parallel batch insert - API compatible with `HnswIndex`.
     ///
@@ -382,6 +395,7 @@ impl NativeHnswIndex {
     /// # Returns
     ///
     /// Vector of results for each query.
+    #[must_use]
     pub fn search_batch_parallel(
         &self,
         queries: &[&[f32]],
@@ -419,17 +433,14 @@ impl NativeHnswIndex {
     pub fn brute_force_search_parallel(&self, query: &[f32], k: usize) -> Vec<ScoredResult> {
         use rayon::prelude::*;
 
-        // Collect all vectors for parallel iteration
         let vectors_snapshot = self.vectors.collect_for_parallel();
 
         if vectors_snapshot.is_empty() {
             return Vec::new();
         }
 
-        // Get distance calculator from inner
         let inner = self.inner.read();
 
-        // Compute distances in parallel
         let mut results: Vec<ScoredResult> = vectors_snapshot
             .par_iter()
             .filter_map(|(idx, vec)| {
@@ -439,7 +450,6 @@ impl NativeHnswIndex {
             })
             .collect();
 
-        // Sort by distance (ascending for most metrics)
         self.metric.sort_scored_results(&mut results);
 
         results.truncate(k);

--- a/crates/velesdb-core/src/index/hnsw/native_index_tests.rs
+++ b/crates/velesdb-core/src/index/hnsw/native_index_tests.rs
@@ -172,3 +172,93 @@ fn test_native_index_brute_force_k_larger_than_size() {
     let results = index.brute_force_search_parallel(&vec![0.0; 32], 10);
     assert_eq!(results.len(), 2);
 }
+
+// -------------------------------------------------------------------------
+// Upsert Semantics Tests (Issue #371 — TDD Cycle 4)
+// -------------------------------------------------------------------------
+
+#[test]
+fn test_native_insert_same_id_updates_vector() {
+    // Arrange: create index with vector storage enabled (default)
+    let index = NativeHnswIndex::new(4, DistanceMetric::Cosine).expect("test");
+
+    // Insert id=1 with vector A (pointing along x-axis)
+    let vector_a = [1.0, 0.0, 0.0, 0.0];
+    index.insert(1, &vector_a).expect("test");
+
+    // Act: insert id=1 again with vector B (pointing along y-axis, orthogonal to A)
+    let vector_b = [0.0, 1.0, 0.0, 0.0];
+    index.insert(1, &vector_b).expect("test");
+
+    // Assert 1: index length must still be 1 (not 2)
+    assert_eq!(index.len(), 1, "Upsert must not create duplicate entries");
+
+    // Assert 2: search with query=B should return id=1 with high similarity
+    let results = index.search(&vector_b, 1);
+    assert_eq!(results.len(), 1, "Should find exactly one result");
+    assert_eq!(results[0].id, 1, "Result must be id=1");
+    assert!(
+        results[0].score > 0.9,
+        "Similarity to updated vector B should be > 0.9, got {}",
+        results[0].score,
+    );
+}
+
+#[test]
+fn test_native_batch_upsert_updates_existing() {
+    // Arrange: create index and insert 10 vectors via batch
+    let index = NativeHnswIndex::new(4, DistanceMetric::Cosine).expect("test");
+
+    let initial: Vec<(u64, Vec<f32>)> = (0..10).map(|i| (i, vec![1.0, 0.0, 0.0, 0.0])).collect();
+    index.insert_batch(&initial).expect("test");
+    assert_eq!(
+        index.len(),
+        10,
+        "Should have 10 vectors after initial batch"
+    );
+
+    // Act: update 5 vectors (ids 0..5) with a different direction
+    let updates: Vec<(u64, Vec<f32>)> = (0..5).map(|i| (i, vec![0.0, 1.0, 0.0, 0.0])).collect();
+    index.insert_batch(&updates).expect("test");
+
+    // Assert 1: total count must still be 10 (not 15)
+    assert_eq!(index.len(), 10, "Upsert batch must not inflate count");
+
+    // Assert 2: searching with the updated direction should find updated vectors
+    let query = [0.0, 1.0, 0.0, 0.0];
+    let results = index.search(&query, 5);
+    assert!(!results.is_empty(), "Search must return results");
+    // The top result should be one of the updated ids (0..5) with high similarity
+    assert!(
+        results[0].id < 5,
+        "Top result should be an updated vector (id < 5), got id={}",
+        results[0].id,
+    );
+    assert!(
+        results[0].score > 0.9,
+        "Updated vector similarity should be > 0.9, got {}",
+        results[0].score,
+    );
+}
+
+#[test]
+fn test_native_remove_cleans_up_vector_storage() {
+    // Arrange: insert a vector with storage enabled
+    let index = NativeHnswIndex::new(4, DistanceMetric::Cosine).expect("test");
+    index.insert(1, &[1.0, 0.0, 0.0, 0.0]).expect("test");
+
+    // Verify vector exists in brute-force (uses ShardedVectors)
+    let before = index.brute_force_search_parallel(&[1.0, 0.0, 0.0, 0.0], 1);
+    assert_eq!(before.len(), 1, "Should find vector before removal");
+
+    // Act: remove the vector
+    assert!(index.remove(1), "Remove should return true for existing ID");
+
+    // Assert: brute-force search should find nothing (vector storage cleaned up)
+    let after = index.brute_force_search_parallel(&[1.0, 0.0, 0.0, 0.0], 1);
+    assert!(
+        after.is_empty(),
+        "Brute-force should find nothing after removal, got {} results",
+        after.len(),
+    );
+}

--- a/crates/velesdb-core/src/index/hnsw/sharded_mappings.rs
+++ b/crates/velesdb-core/src/index/hnsw/sharded_mappings.rs
@@ -59,7 +59,6 @@ impl ShardedMappings {
     ///
     /// Use this when the expected number of vectors is known upfront.
     #[must_use]
-    #[allow(dead_code)] // API completeness - useful for batch operations
     pub fn with_capacity(capacity: usize) -> Self {
         Self {
             id_to_idx: DashMap::with_capacity(capacity),
@@ -77,19 +76,55 @@ impl ShardedMappings {
     /// This operation is atomic - concurrent calls with the same ID will
     /// return `Some` for exactly one caller and `None` for others.
     pub fn register(&self, id: u64) -> Option<usize> {
-        // Use entry API for atomic check-and-insert
         use dashmap::mapref::entry::Entry;
 
         match self.id_to_idx.entry(id) {
-            Entry::Occupied(_) => None, // ID already exists
-            Entry::Vacant(entry) => {
-                // Atomically get next index
-                let idx = self.next_idx.fetch_add(1, Ordering::SeqCst);
-                entry.insert(idx);
-                self.idx_to_id.insert(idx, id);
-                Some(idx)
-            }
+            Entry::Occupied(_) => None,
+            Entry::Vacant(entry) => Some(self.allocate_and_map(entry, id)),
         }
+    }
+
+    /// Registers an ID, replacing the existing mapping if present.
+    ///
+    /// Returns `(new_internal_idx, Option<old_internal_idx>)`:
+    /// - If the ID is new: `(idx, None)`
+    /// - If the ID existed: `(new_idx, Some(old_idx))`
+    ///
+    /// The old internal index is removed from the reverse mapping so that
+    /// stale HNSW graph nodes are filtered out during search.
+    ///
+    /// # Thread Safety
+    ///
+    /// Uses `DashMap::entry()` for atomic check-and-replace. Concurrent
+    /// calls with the same ID are serialised by the entry lock.
+    pub fn register_or_replace(&self, id: u64) -> (usize, Option<usize>) {
+        use dashmap::mapref::entry::Entry;
+
+        match self.id_to_idx.entry(id) {
+            Entry::Occupied(mut entry) => {
+                let old_idx = *entry.get();
+                let new_idx = self.next_idx.fetch_add(1, Ordering::Relaxed);
+                entry.insert(new_idx);
+                self.idx_to_id.remove(&old_idx);
+                self.idx_to_id.insert(new_idx, id);
+                (new_idx, Some(old_idx))
+            }
+            Entry::Vacant(entry) => (self.allocate_and_map(entry, id), None),
+        }
+    }
+
+    /// Allocates a new internal index and inserts bidirectional mappings.
+    ///
+    /// Shared by `register` and `register_or_replace` for the new-ID path.
+    fn allocate_and_map(
+        &self,
+        entry: dashmap::mapref::entry::VacantEntry<'_, u64, usize>,
+        id: u64,
+    ) -> usize {
+        let idx = self.next_idx.fetch_add(1, Ordering::Relaxed);
+        entry.insert(idx);
+        self.idx_to_id.insert(idx, id);
+        idx
     }
 
     /// Registers multiple IDs in a batch, returning their indices.
@@ -109,6 +144,22 @@ impl ShardedMappings {
         }
 
         results
+    }
+
+    /// Restores a specific mapping (`id` -> `idx`) without allocating a new index.
+    ///
+    /// Used for rollback after a failed graph insertion: re-links the external
+    /// ID to a previously-allocated internal index that was removed by
+    /// `register_or_replace` or `remove`.
+    ///
+    /// # Correctness
+    ///
+    /// The caller must ensure `idx` was previously returned by `register` or
+    /// `register_or_replace` for this `id`. Passing an arbitrary `idx` will
+    /// corrupt the bidirectional mapping.
+    pub fn restore(&self, id: u64, idx: usize) {
+        self.id_to_idx.insert(id, idx);
+        self.idx_to_id.insert(idx, id);
     }
 
     /// Removes an ID and returns its internal index if it existed.
@@ -139,14 +190,12 @@ impl ShardedMappings {
 
     /// Returns the number of registered IDs.
     #[must_use]
-    #[allow(dead_code)] // Used by NativeHnswIndex
     pub fn len(&self) -> usize {
         self.id_to_idx.len()
     }
 
     /// Returns true if no IDs are registered.
     #[must_use]
-    #[allow(dead_code)] // API completeness
     pub fn is_empty(&self) -> bool {
         self.id_to_idx.is_empty()
     }
@@ -161,7 +210,6 @@ impl ShardedMappings {
     /// Returns an iterator over all (id, idx) pairs.
     ///
     /// Note: This acquires read locks on shards during iteration.
-    #[allow(dead_code)] // API completeness - useful for debugging
     pub fn iter(&self) -> impl Iterator<Item = (u64, usize)> + '_ {
         self.id_to_idx.iter().map(|r| (*r.key(), *r.value()))
     }
@@ -171,13 +219,11 @@ impl ShardedMappings {
     /// This is a monotonic counter that never decreases, even after removals.
     /// Useful for calculating tombstone count.
     #[must_use]
-    #[allow(dead_code)] // API completeness
     pub fn next_idx(&self) -> usize {
         self.next_idx.load(std::sync::atomic::Ordering::Relaxed)
     }
 
     /// Clears all mappings and resets the index counter.
-    #[allow(dead_code)] // API completeness
     pub fn clear(&self) {
         self.id_to_idx.clear();
         self.idx_to_id.clear();

--- a/crates/velesdb-core/src/index/hnsw/sharded_mappings_tests.rs
+++ b/crates/velesdb-core/src/index/hnsw/sharded_mappings_tests.rs
@@ -254,6 +254,74 @@ fn test_sharded_mappings_no_data_race() {
 }
 
 // -------------------------------------------------------------------------
+// register_or_replace tests
+// -------------------------------------------------------------------------
+
+#[test]
+fn test_register_or_replace_new_id() {
+    let mappings = ShardedMappings::new();
+    let (idx, old) = mappings.register_or_replace(42);
+    assert_eq!(idx, 0);
+    assert_eq!(old, None);
+    assert_eq!(mappings.get_idx(42), Some(0));
+    assert_eq!(mappings.get_id(0), Some(42));
+    assert_eq!(mappings.len(), 1);
+}
+
+#[test]
+fn test_register_or_replace_existing_id() {
+    let mappings = ShardedMappings::new();
+    let first_idx = mappings.register(42).expect("first register");
+    let (new_idx, old_idx) = mappings.register_or_replace(42);
+
+    assert_eq!(old_idx, Some(first_idx));
+    assert_ne!(new_idx, first_idx);
+    // Old reverse mapping removed
+    assert_eq!(mappings.get_id(first_idx), None);
+    // New mapping present
+    assert_eq!(mappings.get_idx(42), Some(new_idx));
+    assert_eq!(mappings.get_id(new_idx), Some(42));
+    // Length is still 1 (replaced, not duplicated)
+    assert_eq!(mappings.len(), 1);
+}
+
+// -------------------------------------------------------------------------
+// restore tests (rollback support)
+// -------------------------------------------------------------------------
+
+#[test]
+fn test_restore_after_remove() {
+    let mappings = ShardedMappings::new();
+    let old_idx = mappings.register(42).expect("register");
+    mappings.remove(42);
+    assert_eq!(mappings.get_idx(42), None);
+
+    mappings.restore(42, old_idx);
+    assert_eq!(mappings.get_idx(42), Some(old_idx));
+    assert_eq!(mappings.get_id(old_idx), Some(42));
+    assert_eq!(mappings.len(), 1);
+}
+
+#[test]
+fn test_restore_after_register_or_replace_rollback() {
+    let mappings = ShardedMappings::new();
+    let first_idx = mappings.register(42).expect("register");
+
+    // Simulate upsert: register_or_replace allocates a new idx
+    let (new_idx, old_idx) = mappings.register_or_replace(42);
+    assert_eq!(old_idx, Some(first_idx));
+
+    // Simulate failure: remove new mapping, restore old one
+    mappings.remove(42);
+    assert_eq!(mappings.get_id(new_idx), None);
+
+    mappings.restore(42, first_idx);
+    assert_eq!(mappings.get_idx(42), Some(first_idx));
+    assert_eq!(mappings.get_id(first_idx), Some(42));
+    assert_eq!(mappings.len(), 1);
+}
+
+// -------------------------------------------------------------------------
 // Serialization tests (TDD for HnswIndex migration)
 // -------------------------------------------------------------------------
 

--- a/crates/velesdb-core/src/index/hnsw/upsert.rs
+++ b/crates/velesdb-core/src/index/hnsw/upsert.rs
@@ -1,0 +1,68 @@
+//! Shared upsert-mapping logic for HNSW index variants.
+//!
+//! Both `HnswIndex` and `NativeHnswIndex` use identical mapping upsert
+//! semantics. This module provides a single implementation to avoid
+//! duplication.
+
+use super::sharded_mappings::ShardedMappings;
+use super::sharded_vectors::ShardedVectors;
+
+/// Result of an upsert mapping operation, carrying rollback information.
+///
+/// On success the caller uses `idx` as the internal HNSW index for the new
+/// graph node. On graph-insert failure, the caller passes this struct to
+/// [`rollback_upsert`] to restore the previous state.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct UpsertResult {
+    /// Newly allocated internal index for the vector.
+    pub idx: usize,
+    /// Previous internal index if this was an update (not a fresh insert).
+    pub old_idx: Option<usize>,
+}
+
+/// Registers an ID with upsert semantics and cleans up stale vector data.
+///
+/// If the ID already existed, the old mapping is replaced and the stale
+/// sidecar vector (if stored) is removed from `ShardedVectors`.
+///
+/// Returns an [`UpsertResult`] containing the new index and optional old
+/// index for rollback purposes.
+#[must_use]
+pub(crate) fn upsert_mapping(
+    mappings: &ShardedMappings,
+    vectors: &ShardedVectors,
+    enable_vector_storage: bool,
+    id: u64,
+) -> UpsertResult {
+    let (idx, old_idx) = mappings.register_or_replace(id);
+    if let Some(old) = old_idx {
+        if enable_vector_storage {
+            vectors.remove(old);
+        }
+    }
+    UpsertResult { idx, old_idx }
+}
+
+/// Rolls back mapping state after a failed graph insertion.
+///
+/// Removes the newly-allocated mapping and, if this was an update,
+/// restores the previous mapping so the point remains searchable
+/// through its old graph node.
+///
+/// **Transient gap**: Between `remove` and `restore`, the ID has no
+/// mapping for a brief window (nanoseconds). A concurrent search during
+/// this window will not find the point. This only occurs on graph-insert
+/// failure, which is rare (allocation error).
+///
+/// **Sidecar loss**: The old sidecar vector (in `ShardedVectors`) was
+/// already removed by [`upsert_mapping`] and cannot be cheaply restored.
+/// The HNSW graph still holds the vector data in `ContiguousVectors` for
+/// traversal, so the point remains searchable -- only sidecar reranking
+/// precision is lost for the affected point until the next successful
+/// upsert.
+pub(crate) fn rollback_upsert(mappings: &ShardedMappings, id: u64, result: &UpsertResult) {
+    mappings.remove(id);
+    if let Some(old_idx) = result.old_idx {
+        mappings.restore(id, old_idx);
+    }
+}

--- a/crates/velesdb-core/src/index/hnsw/upsert.rs
+++ b/crates/velesdb-core/src/index/hnsw/upsert.rs
@@ -61,8 +61,14 @@ pub(crate) fn upsert_mapping(
 /// precision is lost for the affected point until the next successful
 /// upsert.
 pub(crate) fn rollback_upsert(mappings: &ShardedMappings, id: u64, result: &UpsertResult) {
-    mappings.remove(id);
-    if let Some(old_idx) = result.old_idx {
-        mappings.restore(id, old_idx);
+    // Only remove if the current mapping still points to our index.
+    // A within-batch duplicate may have already overwritten the mapping
+    // with a newer index — removing it would corrupt that later entry.
+    let current_idx = mappings.get_idx(id);
+    if current_idx == Some(result.idx) {
+        mappings.remove(id);
+        if let Some(old_idx) = result.old_idx {
+            mappings.restore(id, old_idx);
+        }
     }
 }


### PR DESCRIPTION
## Summary

- **Fix**: `HnswIndex::insert()` now performs true upsert instead of silently skipping existing IDs. Old HNSW graph node becomes a tombstone with fresh neighborhood connections for the new vector.
- **Fix**: `NativeHnswIndex::insert()` broken `register().or_else(get_idx())` pattern replaced with `register_or_replace()`.
- **Fix**: `remove()` now cleans up `ShardedVectors` (previously leaving orphaned entries).
- **Rollback safety**: Failed graph insert restores previous mapping state via `ShardedMappings::restore()`.
- **Zero duplication**: Shared upsert logic extracted into `upsert.rs` module.
- **Vacuum optimized**: Removed wasted `new_mappings`/`new_vectors` allocation, migrated `VacuumError` to `thiserror`.

## Impact

| Workload | Before | After |
|----------|--------|-------|
| Insert-only (new IDs) | Normal | **0% overhead** (same code path) |
| Upsert (existing IDs) | Silent skip (bug: stale graph) | **True upsert** (remove + reinsert) |
| Search after upsert | Degraded recall (stale neighborhoods) | **Correct recall** (fresh neighborhoods) |

## Performance (i9-14900k, before/after)

| Benchmark | Change |
|-----------|--------|
| Insert 10k/128d | -0.7% (no regression) |
| Search 10k k10 | 0% (no regression) |
| Hybrid search | -7.3% (faster) |

## Test plan

- [x] 15 new regression tests: single upsert, batch upsert, tombstone accumulation, vacuum after upsert, search recall verification, entry-point mutation, upsert-after-delete, repeated upsert (20x same ID), `register_or_replace` unit tests, `restore` rollback tests
- [x] 3403 tests pass, 0 fail
- [x] Clippy pedantic clean (workspace)
- [x] Codacy CLI: 0 findings
- [x] CC max = 5 (limit: 8), NLOC max = 23 (limit: 50)

Closes #371

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/372" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
