### PR TITLE
fix: v1.7.1 patch — security, crash recovery, VelesQL grammar, spec gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Security**: Validate collection names against path traversal — reject `../`, backslashes, special characters, and Windows reserved names. New error code VELES-034 (`InvalidCollectionName`). (#381)
 - **Core**: Crash recovery gap detection for deferred HNSW indexer — vectors written to storage but not yet indexed in HNSW are automatically re-indexed on `Collection::open()`. (#382)
+- **VelesQL**: Grammar bugs — `''` string escaping, N-ary compound queries (UNION/INTERSECT/EXCEPT chaining), vector literal integers `[1, 2, 3]`, `NOT IN` operator, version number alignment. (#383)
 
 ## [1.7.0] - 2026-03-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Security**: Validate collection names against path traversal — reject `../`, backslashes, special characters, and Windows reserved names. New error code VELES-034 (`InvalidCollectionName`). (#381)
 - **Core**: Crash recovery gap detection for deferred HNSW indexer — vectors written to storage but not yet indexed in HNSW are automatically re-indexed on `Collection::open()`. (#382)
-- **VelesQL**: Grammar bugs — `''` string escaping, N-ary compound queries (UNION/INTERSECT/EXCEPT chaining), vector literal integers `[1, 2, 3]`, `NOT IN` operator, version number alignment. (#383)
+- **VelesQL**: Grammar bugs — `''` string escaping, N-ary compound queries (UNION/INTERSECT/EXCEPT chaining), vector literal integers `[1, 2, 3]`, `NOT IN` operator, version number alignment. **Note:** `CompoundQuery` AST struct shape changed (serde-breaking for external consumers serializing query ASTs; plan cache is unaffected). (#383)
+- **VelesQL**: Fix plan cache invalidation for compound queries — `referenced_collection_names` now includes collection names from all UNION/INTERSECT/EXCEPT operands.
 - **Docs**: VelesQL spec gaps — document `NEAR_FUSED` syntax and fusion strategies, fix FAQ INSERT/UPDATE/DELETE claims, correct API reference `FUSE BY` → `USING FUSION`, add conformance test cases. (#387)
 
 ## [1.7.0] - 2026-03-24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Security**: Validate collection names against path traversal — reject `../`, backslashes, special characters, and Windows reserved names. New error code VELES-034 (`InvalidCollectionName`). (#381)
 - **Core**: Crash recovery gap detection for deferred HNSW indexer — vectors written to storage but not yet indexed in HNSW are automatically re-indexed on `Collection::open()`. (#382)
 - **VelesQL**: Grammar bugs — `''` string escaping, N-ary compound queries (UNION/INTERSECT/EXCEPT chaining), vector literal integers `[1, 2, 3]`, `NOT IN` operator, version number alignment. (#383)
+- **Docs**: VelesQL spec gaps — document `NEAR_FUSED` syntax and fusion strategies, fix FAQ INSERT/UPDATE/DELETE claims, correct API reference `FUSE BY` → `USING FUSION`, add conformance test cases. (#387)
 
 ## [1.7.0] - 2026-03-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Security**: Validate collection names against path traversal — reject `../`, backslashes, special characters, and Windows reserved names. New error code VELES-034 (`InvalidCollectionName`). (#381)
+- **Core**: Crash recovery gap detection for deferred HNSW indexer — vectors written to storage but not yet indexed in HNSW are automatically re-indexed on `Collection::open()`. (#382)
+
 ## [1.7.0] - 2026-03-24
 
 ### Highlights

--- a/conformance/velesql_parser_cases.json
+++ b/conformance/velesql_parser_cases.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.3.0",
+  "version": "3.1.0",
   "cases": [
     {
       "id": "P001",
@@ -170,6 +170,51 @@
     {
       "id": "P033",
       "query": "SELECT * FROM t WHERE vector NEAR $v ORDER BY similarity() DESC, created_at ASC LIMIT 10",
+      "should_parse": true
+    },
+    {
+      "id": "P034",
+      "query": "SELECT * FROM docs WHERE name = 'O''Brien'",
+      "should_parse": true
+    },
+    {
+      "id": "P035",
+      "query": "SELECT * FROM docs WHERE name = 'It''s a ''test'''",
+      "should_parse": true
+    },
+    {
+      "id": "P036",
+      "query": "SELECT * FROM docs WHERE name = ''",
+      "should_parse": true
+    },
+    {
+      "id": "P037",
+      "query": "SELECT * FROM docs WHERE vector NEAR [1, 2, 3] LIMIT 5",
+      "should_parse": true
+    },
+    {
+      "id": "P038",
+      "query": "SELECT * FROM docs WHERE vector NEAR [1, 0.5, 2] LIMIT 5",
+      "should_parse": true
+    },
+    {
+      "id": "P039",
+      "query": "SELECT * FROM docs WHERE category NOT IN ('draft', 'deleted')",
+      "should_parse": true
+    },
+    {
+      "id": "P040",
+      "query": "SELECT * FROM docs WHERE id NOT IN (1, 2, 3)",
+      "should_parse": true
+    },
+    {
+      "id": "P041",
+      "query": "SELECT * FROM a UNION SELECT * FROM b UNION SELECT * FROM c",
+      "should_parse": true
+    },
+    {
+      "id": "P042",
+      "query": "SELECT * FROM a UNION SELECT * FROM b INTERSECT SELECT * FROM c",
       "should_parse": true
     }
   ]

--- a/conformance/velesql_parser_cases.json
+++ b/conformance/velesql_parser_cases.json
@@ -216,6 +216,21 @@
       "id": "P042",
       "query": "SELECT * FROM a UNION SELECT * FROM b INTERSECT SELECT * FROM c",
       "should_parse": true
+    },
+    {
+      "id": "P043",
+      "query": "SELECT * FROM docs WHERE vector NEAR_FUSED [$v1, $v2] LIMIT 10",
+      "should_parse": true
+    },
+    {
+      "id": "P044",
+      "query": "SELECT * FROM docs WHERE vector NEAR_FUSED [$v1, $v2] USING FUSION 'rrf' (k=60) LIMIT 10",
+      "should_parse": true
+    },
+    {
+      "id": "P045",
+      "query": "SELECT * FROM docs WHERE vector NEAR_FUSED [$v1] LIMIT 10",
+      "should_parse": true
     }
   ]
 }

--- a/crates/velesdb-core/src/collection/core/lifecycle.rs
+++ b/crates/velesdb-core/src/collection/core/lifecycle.rs
@@ -413,11 +413,22 @@ impl Collection {
         let mut config = config;
         config.point_count = actual_count;
 
-        // TODO #370: implement crash recovery gap detection for deferred indexer.
-        // After loading HNSW and vector storage, detect vectors in storage but
-        // not in HNSW (gap vectors from a crash during deferred merge) and
-        // re-index them. This requires comparing storage IDs against HNSW IDs
-        // which may be expensive for large collections.
+        // Crash recovery: detect vectors in storage but not in HNSW (gap from
+        // crash during deferred merge, delta drain, or normal insert).
+        if !config.metadata_only && config.dimension > 0 {
+            let recovered = super::recovery::recover_hnsw_gap(
+                &vector_storage,
+                &index,
+                config.dimension,
+            )?;
+            if recovered > 0 {
+                tracing::info!(
+                    collection = %config.name,
+                    recovered,
+                    "Collection gap recovery completed on open"
+                );
+            }
+        }
 
         Ok(Self::assemble(CollectionParts {
             path,

--- a/crates/velesdb-core/src/collection/core/lifecycle.rs
+++ b/crates/velesdb-core/src/collection/core/lifecycle.rs
@@ -415,6 +415,7 @@ impl Collection {
 
         // Crash recovery: detect vectors in storage but not in HNSW (gap from
         // crash during deferred merge, delta drain, or normal insert).
+        #[cfg(feature = "persistence")]
         if !config.metadata_only && config.dimension > 0 {
             let recovered = super::recovery::recover_hnsw_gap(
                 &vector_storage,

--- a/crates/velesdb-core/src/collection/core/mod.rs
+++ b/crates/velesdb-core/src/collection/core/mod.rs
@@ -19,6 +19,10 @@ mod index_management_tests;
 mod lifecycle;
 #[cfg(test)]
 mod lifecycle_tests;
+#[cfg(feature = "persistence")]
+mod recovery;
+#[cfg(all(test, feature = "persistence"))]
+mod recovery_tests;
 mod statistics;
 
 pub use crate::validation::{MAX_DIMENSION, MIN_DIMENSION};

--- a/crates/velesdb-core/src/collection/core/recovery.rs
+++ b/crates/velesdb-core/src/collection/core/recovery.rs
@@ -29,6 +29,10 @@ use std::sync::Arc;
 /// # Early exit
 ///
 /// Returns `0` immediately if storage is empty or its count matches HNSW.
+/// This heuristic may miss gaps in the theoretical case where a gap and an
+/// HNSW orphan cancel out (e.g., one inserted + one deleted during the same
+/// crash). This scenario requires two complementary failure modes and is
+/// extremely unlikely in practice.
 ///
 /// # Errors
 ///

--- a/crates/velesdb-core/src/collection/core/recovery.rs
+++ b/crates/velesdb-core/src/collection/core/recovery.rs
@@ -1,0 +1,105 @@
+//! Crash recovery: gap detection between vector storage and HNSW index.
+//!
+//! On [`Collection::open()`](super::super::Collection::open), vectors may
+//! exist in storage but not in HNSW if a crash occurred between the storage
+//! write and the HNSW batch insert (deferred indexer gap, delta buffer gap,
+//! or normal insert gap).
+//!
+//! This module detects such gaps and re-indexes the missing vectors.
+
+use crate::index::HnswIndex;
+use crate::storage::{MmapStorage, VectorStorage};
+use parking_lot::RwLock;
+use std::sync::Arc;
+
+/// Detects vectors in storage that are missing from the HNSW index and
+/// re-indexes them.
+///
+/// Returns the number of recovered (re-indexed) vectors.
+///
+/// # Early exit
+///
+/// Returns `0` immediately if storage is empty or its count matches HNSW.
+///
+/// # Errors
+///
+/// Returns an error if vector retrieval from storage fails.
+pub(crate) fn recover_hnsw_gap(
+    vector_storage: &Arc<RwLock<MmapStorage>>,
+    index: &Arc<HnswIndex>,
+    dimension: usize,
+) -> crate::error::Result<usize> {
+    let storage = vector_storage.read();
+    let storage_count = storage.len();
+    let hnsw_count = index.len();
+
+    if storage_count == 0 || storage_count == hnsw_count {
+        return Ok(0);
+    }
+
+    let gap_ids = find_gap_ids(&storage, index);
+    if gap_ids.is_empty() {
+        return Ok(0);
+    }
+
+    let vectors = retrieve_valid_vectors(&storage, &gap_ids, dimension)?;
+    let gap_total = gap_ids.len();
+    drop(storage);
+
+    let recovered = reindex_vectors(index, &vectors);
+    tracing::warn!(
+        recovered,
+        gap_total,
+        "Crash recovery: re-indexed gap vectors into HNSW"
+    );
+    Ok(recovered)
+}
+
+/// Returns storage IDs not present in the HNSW index.
+fn find_gap_ids(storage: &MmapStorage, index: &HnswIndex) -> Vec<u64> {
+    storage
+        .ids()
+        .into_iter()
+        .filter(|id| !index.mappings.contains(*id))
+        .collect()
+}
+
+/// Retrieves vectors for gap IDs, propagating IO errors.
+///
+/// Skips vectors with wrong dimension (corruption) or missing data
+/// (concurrent deletion between `ids()` and `retrieve()`).
+fn retrieve_valid_vectors(
+    storage: &MmapStorage,
+    gap_ids: &[u64],
+    dimension: usize,
+) -> crate::error::Result<Vec<(u64, Vec<f32>)>> {
+    let mut vectors = Vec::with_capacity(gap_ids.len());
+    for &id in gap_ids {
+        match storage.retrieve(id) {
+            Ok(Some(v)) if v.len() == dimension => vectors.push((id, v)),
+            Ok(Some(v)) => tracing::warn!(
+                id,
+                expected = dimension,
+                actual = v.len(),
+                "Skipping gap vector with mismatched dimension"
+            ),
+            Ok(None) => {} // Deleted between ids() and retrieve()
+            Err(e) => return Err(crate::error::Error::Storage(format!(
+                "failed to retrieve gap vector {id}: {e}"
+            ))),
+        }
+    }
+    Ok(vectors)
+}
+
+/// Batch-inserts recovered vectors into the HNSW index.
+fn reindex_vectors(index: &HnswIndex, vectors: &[(u64, Vec<f32>)]) -> usize {
+    if vectors.is_empty() {
+        return 0;
+    }
+    let refs: Vec<(u64, &[f32])> = vectors
+        .iter()
+        .map(|(id, v)| (*id, v.as_slice()))
+        .collect();
+    index.insert_batch_parallel(refs)
+}

--- a/crates/velesdb-core/src/collection/core/recovery.rs
+++ b/crates/velesdb-core/src/collection/core/recovery.rs
@@ -6,6 +6,15 @@
 //! or normal insert gap).
 //!
 //! This module detects such gaps and re-indexes the missing vectors.
+//!
+//! ## Known limitation
+//!
+//! If a crash occurs between the HNSW delete and the storage delete being
+//! persisted, a previously deleted vector may appear in storage but not in
+//! HNSW — indistinguishable from an insert gap. Recovery will re-index the
+//! deleted vector. This is an inherent trade-off without two-phase commit
+//! and is acceptable because (a) the window is very small, and (b) a
+//! resurrected vector is preferable to a silently lost one.
 
 use crate::index::HnswIndex;
 use crate::storage::{MmapStorage, VectorStorage};

--- a/crates/velesdb-core/src/collection/core/recovery_tests.rs
+++ b/crates/velesdb-core/src/collection/core/recovery_tests.rs
@@ -1,0 +1,148 @@
+#![allow(deprecated)] // Tests use legacy Collection via field access.
+
+use super::recovery;
+use crate::distance::DistanceMetric;
+use crate::index::VectorIndex;
+use crate::point::Point;
+use crate::storage::VectorStorage;
+use crate::Collection;
+use std::path::PathBuf;
+
+/// Creates N distinct 4-dim points with IDs 0..n.
+fn make_points(n: u64) -> Vec<Point> {
+    (0..n)
+        .map(|i| {
+            let v = f32::from(u16::try_from(i).expect("test ID fits u16"));
+            Point::without_payload(i, vec![v, v + 1.0, v + 2.0, v + 3.0])
+        })
+        .collect()
+}
+
+// =========================================================================
+// Happy path — no gap
+// =========================================================================
+
+#[test]
+fn test_no_gap_returns_zero() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    let coll =
+        Collection::create(PathBuf::from(temp.path()), 4, DistanceMetric::Cosine).expect("create");
+
+    coll.upsert(make_points(5)).expect("upsert");
+
+    let recovered =
+        recovery::recover_hnsw_gap(&coll.vector_storage, &coll.index, 4).expect("recovery");
+    assert_eq!(recovered, 0);
+}
+
+#[test]
+fn test_empty_collection_no_recovery() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    let coll =
+        Collection::create(PathBuf::from(temp.path()), 4, DistanceMetric::Cosine).expect("create");
+
+    let recovered =
+        recovery::recover_hnsw_gap(&coll.vector_storage, &coll.index, 4).expect("recovery");
+    assert_eq!(recovered, 0);
+}
+
+// =========================================================================
+// Simulated crash gap — vectors in storage but not in HNSW
+// =========================================================================
+
+#[test]
+fn test_crash_gap_detected_and_recovered() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    let coll =
+        Collection::create(PathBuf::from(temp.path()), 4, DistanceMetric::Cosine).expect("create");
+
+    coll.upsert(make_points(3)).expect("upsert");
+
+    // Simulate crash gap: write 2 vectors to storage ONLY, bypassing HNSW.
+    // Use orthogonal directions to avoid cosine ambiguity with existing points.
+    {
+        let mut vs = coll.vector_storage.write();
+        vs.store(100, &[0.0, 0.0, 1.0, 0.0]).expect("store 100");
+        vs.store(101, &[0.0, 0.0, 0.0, 1.0]).expect("store 101");
+    }
+
+    assert_eq!(coll.vector_storage.read().len(), 5);
+    assert_eq!(coll.index.len(), 3);
+
+    let recovered =
+        recovery::recover_hnsw_gap(&coll.vector_storage, &coll.index, 4).expect("recovery");
+
+    assert_eq!(recovered, 2);
+    assert_eq!(coll.index.len(), 5);
+
+    // Verify recovered vectors are searchable via HNSW.
+    let results = coll.index.search(&[0.0, 0.0, 1.0, 0.0], 1);
+    assert_eq!(results[0].id, 100, "recovered vector should be searchable");
+}
+
+// =========================================================================
+// End-to-end: create → gap → flush → drop → reopen → verify
+// =========================================================================
+
+#[test]
+fn test_gap_recovery_on_collection_reopen() {
+    let temp = tempfile::tempdir().expect("temp dir");
+
+    // Phase 1: Create, populate, and simulate gap.
+    {
+        let coll = Collection::create(PathBuf::from(temp.path()), 4, DistanceMetric::Cosine)
+            .expect("create");
+
+        coll.upsert(make_points(3)).expect("upsert");
+        coll.flush().expect("flush");
+
+        // Simulate gap: store vectors directly without HNSW indexing.
+        // Use orthogonal directions to avoid cosine ambiguity.
+        {
+            let mut vs = coll.vector_storage.write();
+            vs.store(100, &[0.0, 0.0, 1.0, 0.0]).expect("store 100");
+            vs.store(101, &[0.0, 0.0, 0.0, 1.0]).expect("store 101");
+            vs.flush().expect("flush storage");
+        }
+
+        // Persist HNSW WITHOUT gap vectors (simulates crash state).
+        coll.flush().expect("flush hnsw");
+    }
+
+    // Phase 2: Reopen — should auto-recover gap vectors.
+    let reopened = Collection::open(PathBuf::from(temp.path())).expect("reopen");
+    assert_eq!(
+        reopened.index.len(),
+        5,
+        "HNSW should include 3 original + 2 recovered vectors"
+    );
+
+    // Verify search finds the recovered vector (orthogonal direction).
+    let results = reopened
+        .search(&[0.0, 0.0, 1.0, 0.0], 1)
+        .expect("search");
+    assert!(!results.is_empty(), "search should return results");
+    assert_eq!(
+        results[0].point.id, 100,
+        "recovered vector should be found by search"
+    );
+}
+
+// =========================================================================
+// Metadata-only collection — no recovery needed
+// =========================================================================
+
+#[test]
+fn test_metadata_only_skips_recovery() {
+    let temp = tempfile::tempdir().expect("temp dir");
+
+    // Create metadata-only, drop, reopen — should succeed without crash.
+    {
+        let _coll =
+            Collection::create_metadata_only(PathBuf::from(temp.path()), "meta").expect("create");
+    }
+    let reopened = Collection::open(PathBuf::from(temp.path())).expect("reopen");
+
+    // Metadata-only has dimension 0, no vectors, no HNSW content.
+    assert_eq!(reopened.config.read().dimension, 0);
+}

--- a/crates/velesdb-core/src/collection/search/query/aggregation/having.rs
+++ b/crates/velesdb-core/src/collection/search/query/aggregation/having.rs
@@ -243,6 +243,7 @@ impl Collection {
                 Condition::In(crate::velesql::InCondition {
                     column: in_cond.column.clone(),
                     values: resolved_values,
+                    negated: in_cond.negated,
                 })
             }
             Condition::Between(btw) => {

--- a/crates/velesdb-core/src/collection/search/query/mod.rs
+++ b/crates/velesdb-core/src/collection/search/query/mod.rs
@@ -135,16 +135,19 @@ impl Collection {
 
         // compound is guaranteed Some here (non-compound returns above).
         if let Some(ref compound) = query.compound {
-            let mut right_query = crate::velesql::Query::new_select(*compound.right.clone());
-            right_query.select.limit = compound_limit;
-            let right_results = self.execute_query_with_client(&right_query, params, "default")?;
-            let mut merged =
-                set_operations::apply_set_operation(left_results, right_results, compound.operator);
+            let mut accumulated = left_results;
+            for (operator, right_select) in &compound.operations {
+                let mut right_query = crate::velesql::Query::new_select(right_select.clone());
+                right_query.select.limit = compound_limit;
+                let right_results = self.execute_query_with_client(&right_query, params, "default")?;
+                accumulated =
+                    set_operations::apply_set_operation(accumulated, right_results, *operator);
+            }
             // SQL-standard: LIMIT from the left (outer) SELECT applies to the final result.
             if let Some(limit) = query.select.limit {
-                merged.truncate(usize::try_from(limit).unwrap_or(usize::MAX));
+                accumulated.truncate(usize::try_from(limit).unwrap_or(usize::MAX));
             }
-            return Ok(merged);
+            return Ok(accumulated);
         }
 
         Ok(left_results)

--- a/crates/velesdb-core/src/database/collection_ops.rs
+++ b/crates/velesdb-core/src/database/collection_ops.rs
@@ -14,11 +14,14 @@ use super::Database;
 // so `#[allow(deprecated)]` is applied at impl-block level rather than per-method.
 #[allow(deprecated)]
 impl Database {
-    /// Ensures a collection name is free in memory and on disk.
+    /// Ensures a collection name is valid, free in memory, and free on disk.
     ///
-    /// This prevents re-creating over a skipped/corrupted on-disk collection
-    /// that was not loaded into registries.
+    /// Validates the name against path traversal and forbidden characters
+    /// **before** any filesystem operation, then checks that no collection
+    /// with the same name already exists in any registry or on disk.
     pub(super) fn ensure_collection_name_available(&self, name: &str) -> Result<()> {
+        crate::validation::validate_collection_name(name)?;
+
         let exists_in_registry = self.collections.read().contains_key(name)
             || self.vector_colls.read().contains_key(name)
             || self.graph_colls.read().contains_key(name)
@@ -131,8 +134,11 @@ impl Database {
     ///
     /// # Errors
     ///
-    /// Returns an error if the collection does not exist in any registry.
+    /// Returns an error if the name is invalid or the collection does not
+    /// exist in any registry.
     pub fn delete_collection(&self, name: &str) -> Result<()> {
+        crate::validation::validate_collection_name(name)?;
+
         let exists = self.collections.read().contains_key(name)
             || self.vector_colls.read().contains_key(name)
             || self.graph_colls.read().contains_key(name)
@@ -192,11 +198,15 @@ impl Database {
 
     /// Reads and parses `config.json` from a collection directory.
     ///
-    /// Returns `None` if the config file does not exist or cannot be parsed.
+    /// Returns `None` if the name is invalid, the config file does not exist,
+    /// or the config cannot be parsed.
     pub(super) fn read_collection_config(
         &self,
         name: &str,
     ) -> Option<crate::collection::CollectionConfig> {
+        if crate::validation::validate_collection_name(name).is_err() {
+            return None;
+        }
         let path = self.data_dir.join(name);
         let config_path = path.join("config.json");
         if !config_path.exists() {

--- a/crates/velesdb-core/src/database/collection_ops_tests.rs
+++ b/crates/velesdb-core/src/database/collection_ops_tests.rs
@@ -213,3 +213,229 @@ fn test_name_collision_across_collection_types() {
         .unwrap_err();
     assert!(matches!(err, crate::Error::CollectionExists(_)));
 }
+
+// =========================================================================
+// Collection name validation — path traversal prevention (issue #381)
+// =========================================================================
+
+/// Helper: asserts that creating a collection with the given name produces
+/// `InvalidCollectionName`.
+fn assert_name_rejected(db: &Database, name: &str) {
+    let err = db
+        .create_collection(name, 4, DistanceMetric::Cosine)
+        .unwrap_err();
+    assert!(
+        matches!(err, crate::Error::InvalidCollectionName { .. }),
+        "Expected InvalidCollectionName for {:?}, got: {err}",
+        name,
+    );
+}
+
+#[test]
+fn test_reject_empty_name() {
+    let dir = tempdir().unwrap();
+    let db = Database::open(dir.path()).unwrap();
+    assert_name_rejected(&db, "");
+}
+
+#[test]
+fn test_reject_dot_names() {
+    let dir = tempdir().unwrap();
+    let db = Database::open(dir.path()).unwrap();
+    assert_name_rejected(&db, ".");
+    assert_name_rejected(&db, "..");
+}
+
+#[test]
+fn test_reject_path_traversal_unix() {
+    let dir = tempdir().unwrap();
+    let db = Database::open(dir.path()).unwrap();
+    assert_name_rejected(&db, "../etc/evil");
+    assert_name_rejected(&db, "../../passwd");
+    assert_name_rejected(&db, "foo/bar");
+    assert_name_rejected(&db, "a/b/c");
+}
+
+#[test]
+fn test_reject_path_traversal_windows() {
+    let dir = tempdir().unwrap();
+    let db = Database::open(dir.path()).unwrap();
+    assert_name_rejected(&db, r"..\evil");
+    assert_name_rejected(&db, r"foo\bar");
+    assert_name_rejected(&db, r"C:\Windows");
+}
+
+#[test]
+fn test_reject_path_separators() {
+    let dir = tempdir().unwrap();
+    let db = Database::open(dir.path()).unwrap();
+    assert_name_rejected(&db, "name/with/slash");
+    assert_name_rejected(&db, "name\\with\\backslash");
+}
+
+#[test]
+fn test_reject_special_characters() {
+    let dir = tempdir().unwrap();
+    let db = Database::open(dir.path()).unwrap();
+    assert_name_rejected(&db, "name with spaces");
+    assert_name_rejected(&db, "name@special");
+    assert_name_rejected(&db, "name.dot");
+    assert_name_rejected(&db, "name#hash");
+    assert_name_rejected(&db, "name$dollar");
+    assert_name_rejected(&db, "name:colon");
+    assert_name_rejected(&db, "name*star");
+    assert_name_rejected(&db, "name?question");
+    assert_name_rejected(&db, "name<angle>");
+    assert_name_rejected(&db, "name|pipe");
+    assert_name_rejected(&db, "name\"quote");
+}
+
+#[test]
+fn test_reject_unicode() {
+    let dir = tempdir().unwrap();
+    let db = Database::open(dir.path()).unwrap();
+    assert_name_rejected(&db, "café");
+    assert_name_rejected(&db, "日本語");
+    assert_name_rejected(&db, "коллекция");
+}
+
+#[test]
+fn test_reject_leading_hyphen() {
+    let dir = tempdir().unwrap();
+    let db = Database::open(dir.path()).unwrap();
+    assert_name_rejected(&db, "-leading");
+    assert_name_rejected(&db, "--double");
+}
+
+#[test]
+fn test_reject_too_long_name() {
+    let dir = tempdir().unwrap();
+    let db = Database::open(dir.path()).unwrap();
+    let long_name = "a".repeat(129);
+    assert_name_rejected(&db, &long_name);
+}
+
+#[test]
+fn test_reject_windows_reserved_names() {
+    let dir = tempdir().unwrap();
+    let db = Database::open(dir.path()).unwrap();
+    for reserved in &[
+        "CON", "PRN", "AUX", "NUL", "COM1", "COM9", "LPT1", "LPT9", "con", "Con", "aux",
+    ] {
+        assert_name_rejected(&db, reserved);
+    }
+}
+
+// =========================================================================
+// Valid collection names — positive cases
+// =========================================================================
+
+#[test]
+fn test_accept_valid_names() {
+    let dir = tempdir().unwrap();
+    let db = Database::open(dir.path()).unwrap();
+    for name in &[
+        "simple",
+        "with_underscore",
+        "with-hyphen",
+        "CamelCase",
+        "UPPERCASE",
+        "a",
+        "a1",
+        "collection_v2",
+        "test-123",
+        &"a".repeat(128), // exactly at the limit
+    ] {
+        db.create_collection(name, 4, DistanceMetric::Cosine)
+            .unwrap_or_else(|e| panic!("Expected name {:?} to be valid, got: {e}", name));
+    }
+}
+
+// =========================================================================
+// Validation on all collection types (vector, graph, metadata)
+// =========================================================================
+
+#[test]
+fn test_reject_invalid_name_on_vector_collection() {
+    let dir = tempdir().unwrap();
+    let db = Database::open(dir.path()).unwrap();
+    let err = db
+        .create_vector_collection("../evil", 4, DistanceMetric::Cosine)
+        .unwrap_err();
+    assert!(matches!(err, crate::Error::InvalidCollectionName { .. }));
+}
+
+#[test]
+fn test_reject_invalid_name_on_graph_collection() {
+    let dir = tempdir().unwrap();
+    let db = Database::open(dir.path()).unwrap();
+    let err = db
+        .create_graph_collection(
+            "../evil",
+            crate::collection::GraphSchema::schemaless(),
+        )
+        .unwrap_err();
+    assert!(matches!(err, crate::Error::InvalidCollectionName { .. }));
+}
+
+#[test]
+fn test_reject_invalid_name_on_metadata_collection() {
+    let dir = tempdir().unwrap();
+    let db = Database::open(dir.path()).unwrap();
+    let err = db.create_metadata_collection("../evil").unwrap_err();
+    assert!(matches!(err, crate::Error::InvalidCollectionName { .. }));
+}
+
+// =========================================================================
+// Validation on delete and stats paths
+// =========================================================================
+
+#[test]
+fn test_reject_invalid_name_on_delete() {
+    let dir = tempdir().unwrap();
+    let db = Database::open(dir.path()).unwrap();
+    let err = db.delete_collection("../evil").unwrap_err();
+    assert!(matches!(err, crate::Error::InvalidCollectionName { .. }));
+}
+
+#[test]
+fn test_reject_invalid_name_on_get_stats() {
+    let dir = tempdir().unwrap();
+    let db = Database::open(dir.path()).unwrap();
+    let err = db.get_collection_stats("../evil").unwrap_err();
+    assert!(matches!(err, crate::Error::InvalidCollectionName { .. }));
+}
+
+#[test]
+fn test_reject_invalid_name_on_analyze() {
+    let dir = tempdir().unwrap();
+    let db = Database::open(dir.path()).unwrap();
+    let err = db.analyze_collection("../evil").unwrap_err();
+    assert!(matches!(err, crate::Error::InvalidCollectionName { .. }));
+}
+
+// =========================================================================
+// Disk fallback read paths reject invalid names
+// =========================================================================
+
+#[test]
+fn test_get_vector_collection_rejects_traversal() {
+    let dir = tempdir().unwrap();
+    let db = Database::open(dir.path()).unwrap();
+    // Should return None rather than attempting filesystem access.
+    assert!(db.get_vector_collection("../evil").is_none());
+}
+
+#[test]
+fn test_get_graph_collection_rejects_traversal() {
+    let dir = tempdir().unwrap();
+    let db = Database::open(dir.path()).unwrap();
+    assert!(db.get_graph_collection("../evil").is_none());
+}
+
+#[test]
+fn test_get_metadata_collection_rejects_traversal() {
+    let dir = tempdir().unwrap();
+    let db = Database::open(dir.path()).unwrap();
+    assert!(db.get_metadata_collection("../evil").is_none());
+}

--- a/crates/velesdb-core/src/database/persistence.rs
+++ b/crates/velesdb-core/src/database/persistence.rs
@@ -45,8 +45,9 @@ impl Database {
 
     /// Returns the collection name if the directory entry is a loadable collection.
     ///
-    /// A directory is loadable when it contains `config.json` and is not
-    /// already registered in the legacy collections map.
+    /// A directory is loadable when it contains `config.json`, has a valid
+    /// collection name, and is not already registered in the legacy collections
+    /// map. Directories with invalid names are skipped with a warning.
     fn loadable_collection_name(&self, entry: &std::fs::DirEntry) -> Option<String> {
         let path = entry.path();
         if !path.is_dir() {
@@ -55,7 +56,15 @@ impl Database {
         if !path.join("config.json").exists() {
             return None;
         }
-        let name = path.file_name()?.to_str().unwrap_or("unknown").to_string();
+        let name = path.file_name()?.to_str()?.to_string();
+        if crate::validation::validate_collection_name(&name).is_err() {
+            tracing::warn!(
+                name = %name,
+                path = %path.display(),
+                "Skipping directory with invalid collection name"
+            );
+            return None;
+        }
         if self.collections.read().contains_key(&name) {
             return None;
         }

--- a/crates/velesdb-core/src/database/query_engine.rs
+++ b/crates/velesdb-core/src/database/query_engine.rs
@@ -230,7 +230,8 @@ impl Database {
         Ok(left_results)
     }
 
-    /// Collects sorted, deduplicated collection names referenced by a query.
+    /// Collects sorted, deduplicated collection names referenced by a query,
+    /// including all compound operands (UNION, INTERSECT, EXCEPT).
     ///
     /// RF-DEDUP: Shared by `build_plan_key` and `populate_plan_cache`, which
     /// both need the same sorted collection-name list from the query AST.
@@ -238,6 +239,14 @@ impl Database {
         let mut names = vec![query.select.from.clone()];
         for join in &query.select.joins {
             names.push(join.table.clone());
+        }
+        if let Some(ref compound) = query.compound {
+            for (_, right_select) in &compound.operations {
+                names.push(right_select.from.clone());
+                for join in &right_select.joins {
+                    names.push(join.table.clone());
+                }
+            }
         }
         names.sort();
         names.dedup();

--- a/crates/velesdb-core/src/database/query_engine.rs
+++ b/crates/velesdb-core/src/database/query_engine.rs
@@ -209,19 +209,22 @@ impl Database {
 
         // compound is guaranteed Some here (non-compound returns above).
         if let Some(ref compound) = query.compound {
-            let mut right_query = crate::velesql::Query::new_select(*compound.right.clone());
-            right_query.select.limit = compound_limit;
-            let right_results = self.execute_single_select(&right_query, params)?;
-            let mut merged = crate::collection::search::query::set_operations::apply_set_operation(
-                left_results,
-                right_results,
-                compound.operator,
-            );
+            let mut accumulated = left_results;
+            for (operator, right_select) in &compound.operations {
+                let mut right_query = crate::velesql::Query::new_select(right_select.clone());
+                right_query.select.limit = compound_limit;
+                let right_results = self.execute_single_select(&right_query, params)?;
+                accumulated = crate::collection::search::query::set_operations::apply_set_operation(
+                    accumulated,
+                    right_results,
+                    *operator,
+                );
+            }
             // SQL-standard: LIMIT from the left (outer) SELECT applies to the final result.
             if let Some(limit) = query.select.limit {
-                merged.truncate(usize::try_from(limit).unwrap_or(usize::MAX));
+                accumulated.truncate(usize::try_from(limit).unwrap_or(usize::MAX));
             }
-            return Ok(merged);
+            return Ok(accumulated);
         }
 
         Ok(left_results)

--- a/crates/velesdb-core/src/database/stats.rs
+++ b/crates/velesdb-core/src/database/stats.rs
@@ -9,13 +9,15 @@ impl Database {
     ///
     /// # Errors
     ///
-    /// Returns an error if the collection does not exist, analysis fails, or
-    /// stats cannot be serialized and written to disk.
+    /// Returns an error if the name is invalid, the collection does not exist,
+    /// analysis fails, or stats cannot be serialized and written to disk.
     #[allow(deprecated)]
     pub fn analyze_collection(
         &self,
         name: &str,
     ) -> Result<crate::collection::stats::CollectionStats> {
+        crate::validation::validate_collection_name(name)?;
+
         let collection = self
             .get_collection(name)
             .ok_or_else(|| Error::CollectionNotFound(name.to_string()))?;
@@ -37,12 +39,14 @@ impl Database {
     ///
     /// # Errors
     ///
-    /// Returns an error if the on-disk stats file exists but cannot be read or
-    /// deserialized.
+    /// Returns an error if the name is invalid, or the on-disk stats file
+    /// exists but cannot be read or deserialized.
     pub fn get_collection_stats(
         &self,
         name: &str,
     ) -> Result<Option<crate::collection::stats::CollectionStats>> {
+        crate::validation::validate_collection_name(name)?;
+
         if let Some(stats) = self.collection_stats.read().get(name).cloned() {
             return Ok(Some(stats));
         }

--- a/crates/velesdb-core/src/error.rs
+++ b/crates/velesdb-core/src/error.rs
@@ -187,6 +187,18 @@ pub enum Error {
     /// Indicates a memory allocation failure (out of memory or invalid layout).
     #[error("[VELES-033] Allocation failed: {0}")]
     AllocationFailed(String),
+
+    /// Invalid collection name (VELES-034).
+    ///
+    /// The collection name contains forbidden characters, path separators,
+    /// or is otherwise unsafe for use as a filesystem directory name.
+    #[error("[VELES-034] Invalid collection name '{name}': {reason}")]
+    InvalidCollectionName {
+        /// The rejected name.
+        name: String,
+        /// Human-readable explanation of why it was rejected.
+        reason: String,
+    },
 }
 
 impl Error {
@@ -227,6 +239,7 @@ impl Error {
             Self::DatabaseLocked(_) => "VELES-031",
             Self::InvalidDimension { .. } => "VELES-032",
             Self::AllocationFailed(_) => "VELES-033",
+            Self::InvalidCollectionName { .. } => "VELES-034",
         }
     }
 

--- a/crates/velesdb-core/src/filter/conversion.rs
+++ b/crates/velesdb-core/src/filter/conversion.rs
@@ -72,10 +72,19 @@ impl From<crate::velesql::Condition> for Condition {
             crate::velesql::Condition::Comparison(cmp) => {
                 convert_comparison(cmp.column, cmp.operator, cmp.value)
             }
-            crate::velesql::Condition::In(inc) => Self::In {
-                field: inc.column,
-                values: inc.values.into_iter().map(velesql_value_to_json).collect(),
-            },
+            crate::velesql::Condition::In(inc) => {
+                let in_cond = Self::In {
+                    field: inc.column,
+                    values: inc.values.into_iter().map(velesql_value_to_json).collect(),
+                };
+                if inc.negated {
+                    Self::Not {
+                        condition: Box::new(in_cond),
+                    }
+                } else {
+                    in_cond
+                }
+            }
             crate::velesql::Condition::IsNull(isn) => {
                 if isn.is_null {
                     Self::IsNull { field: isn.column }

--- a/crates/velesdb-core/src/filter/conversion_tests.rs
+++ b/crates/velesdb-core/src/filter/conversion_tests.rs
@@ -126,6 +126,24 @@ fn test_in_condition() {
 }
 
 #[test]
+fn test_not_in_condition() {
+    let inc = InCondition {
+        column: "status".to_string(),
+        values: vec![
+            VelesValue::String("draft".to_string()),
+            VelesValue::String("deleted".to_string()),
+        ],
+        negated: true,
+    };
+    let cond = crate::velesql::Condition::In(inc);
+    let result: Condition = cond.into();
+    assert!(
+        matches!(result, Condition::Not { ref condition } if matches!(**condition, Condition::In { ref field, .. } if field == "status")),
+        "NOT IN should convert to Not(In(...))"
+    );
+}
+
+#[test]
 fn test_is_null_true() {
     let isn = IsNullCondition {
         column: "optional".to_string(),

--- a/crates/velesdb-core/src/filter/conversion_tests.rs
+++ b/crates/velesdb-core/src/filter/conversion_tests.rs
@@ -116,6 +116,7 @@ fn test_in_condition() {
             VelesValue::String("a".to_string()),
             VelesValue::String("b".to_string()),
         ],
+        negated: false,
     };
     let cond = crate::velesql::Condition::In(inc);
     let result: Condition = cond.into();

--- a/crates/velesdb-core/src/index/hnsw/sharded_mappings.rs
+++ b/crates/velesdb-core/src/index/hnsw/sharded_mappings.rs
@@ -202,7 +202,6 @@ impl ShardedMappings {
 
     /// Checks if an ID is registered.
     #[must_use]
-    #[allow(dead_code)] // API completeness
     pub fn contains(&self, id: u64) -> bool {
         self.id_to_idx.contains_key(&id)
     }

--- a/crates/velesdb-core/src/lib.rs
+++ b/crates/velesdb-core/src/lib.rs
@@ -199,7 +199,10 @@ pub use quantization::{
     BinaryQuantizedVector, QuantizationCodec, QuantizedVector, StorageMode,
 };
 pub use scored_result::ScoredResult;
-pub use validation::{validate_dimension, validate_dimension_match, MAX_DIMENSION, MIN_DIMENSION};
+pub use validation::{
+    validate_collection_name, validate_dimension, validate_dimension_match,
+    MAX_COLLECTION_NAME_LENGTH, MAX_DIMENSION, MIN_DIMENSION,
+};
 
 #[cfg(feature = "persistence")]
 pub use column_store::{

--- a/crates/velesdb-core/src/validation.rs
+++ b/crates/velesdb-core/src/validation.rs
@@ -1,9 +1,12 @@
-//! Unified dimension validation helpers.
+//! Unified validation helpers.
 //!
-//! Centralizes dimension range checks and mismatch validation used across
-//! collection creation, CRUD, and search paths.
+//! Centralizes dimension range checks, collection name validation, and
+//! mismatch validation used across collection creation, CRUD, and search paths.
 
 use crate::error::{Error, Result};
+
+/// Maximum allowed length for a collection name.
+pub const MAX_COLLECTION_NAME_LENGTH: usize = 128;
 
 /// Minimum valid vector dimension.
 pub const MIN_DIMENSION: usize = 1;
@@ -38,4 +41,201 @@ pub fn validate_dimension_match(expected: usize, actual: usize) -> Result<()> {
         return Err(Error::DimensionMismatch { expected, actual });
     }
     Ok(())
+}
+
+/// Validates that a collection name is safe for use as a filesystem directory.
+///
+/// # Rules
+///
+/// - Must not be empty.
+/// - Must not exceed [`MAX_COLLECTION_NAME_LENGTH`] characters.
+/// - Must contain only ASCII alphanumeric characters, underscores, or hyphens
+///   (`[a-zA-Z0-9_-]`).
+/// - Must not be `.` or `..` (path traversal).
+/// - Must not start with a hyphen (avoids CLI flag confusion).
+/// - Must not be a Windows reserved device name (`CON`, `PRN`, `AUX`, `NUL`,
+///   `COM1`–`COM9`, `LPT1`–`LPT9`).
+///
+/// # Errors
+///
+/// Returns [`Error::InvalidCollectionName`] with a human-readable reason.
+///
+/// # Examples
+///
+/// ```
+/// use velesdb_core::validate_collection_name;
+///
+/// assert!(validate_collection_name("my_collection").is_ok());
+/// assert!(validate_collection_name("docs-v2").is_ok());
+/// assert!(validate_collection_name("").is_err());
+/// assert!(validate_collection_name("../evil").is_err());
+/// assert!(validate_collection_name("a/b").is_err());
+/// ```
+pub fn validate_collection_name(name: &str) -> Result<()> {
+    if name.is_empty() {
+        return Err(invalid_name(name, "must not be empty"));
+    }
+
+    if name.len() > MAX_COLLECTION_NAME_LENGTH {
+        return Err(invalid_name(
+            name,
+            &format!("exceeds maximum length of {MAX_COLLECTION_NAME_LENGTH} characters"),
+        ));
+    }
+
+    if name == "." || name == ".." {
+        return Err(invalid_name(name, "path traversal is not allowed"));
+    }
+
+    if name.starts_with('-') {
+        return Err(invalid_name(name, "must not start with a hyphen"));
+    }
+
+    if let Some(bad) = name.chars().find(|c| !is_valid_name_char(*c)) {
+        return Err(invalid_name(
+            name,
+            &format!(
+                "contains forbidden character '{bad}'; \
+                 only ASCII letters, digits, underscores, and hyphens are allowed"
+            ),
+        ));
+    }
+
+    if is_windows_reserved(name) {
+        return Err(invalid_name(
+            name,
+            "is a Windows reserved device name",
+        ));
+    }
+
+    Ok(())
+}
+
+/// Returns `true` if `c` is allowed in a collection name.
+fn is_valid_name_char(c: char) -> bool {
+    c.is_ascii_alphanumeric() || c == '_' || c == '-'
+}
+
+/// Returns `true` if `name` matches a Windows reserved device name
+/// (case-insensitive).
+fn is_windows_reserved(name: &str) -> bool {
+    let upper = name.to_ascii_uppercase();
+    matches!(
+        upper.as_str(),
+        "CON" | "PRN" | "AUX" | "NUL"
+            | "COM1" | "COM2" | "COM3" | "COM4" | "COM5"
+            | "COM6" | "COM7" | "COM8" | "COM9"
+            | "LPT1" | "LPT2" | "LPT3" | "LPT4" | "LPT5"
+            | "LPT6" | "LPT7" | "LPT8" | "LPT9"
+    )
+}
+
+/// Convenience constructor for [`Error::InvalidCollectionName`].
+fn invalid_name(name: &str, reason: &str) -> Error {
+    Error::InvalidCollectionName {
+        name: name.to_string(),
+        reason: reason.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_simple_ascii_names() {
+        for name in ["a", "abc", "my_coll", "docs-v2", "A1_b2-C3"] {
+            validate_collection_name(name).unwrap();
+        }
+    }
+
+    #[test]
+    fn accepts_max_length() {
+        let name = "x".repeat(MAX_COLLECTION_NAME_LENGTH);
+        validate_collection_name(&name).unwrap();
+    }
+
+    #[test]
+    fn rejects_empty() {
+        assert!(validate_collection_name("").is_err());
+    }
+
+    #[test]
+    fn rejects_over_max_length() {
+        let name = "x".repeat(MAX_COLLECTION_NAME_LENGTH + 1);
+        assert!(validate_collection_name(&name).is_err());
+    }
+
+    #[test]
+    fn rejects_dot_and_dotdot() {
+        assert!(validate_collection_name(".").is_err());
+        assert!(validate_collection_name("..").is_err());
+    }
+
+    #[test]
+    fn rejects_path_separators() {
+        assert!(validate_collection_name("a/b").is_err());
+        assert!(validate_collection_name("a\\b").is_err());
+        assert!(validate_collection_name("../x").is_err());
+    }
+
+    #[test]
+    fn rejects_leading_hyphen() {
+        assert!(validate_collection_name("-bad").is_err());
+        assert!(validate_collection_name("--bad").is_err());
+    }
+
+    #[test]
+    fn allows_interior_hyphens() {
+        validate_collection_name("a-b").unwrap();
+        validate_collection_name("a-b-c").unwrap();
+    }
+
+    #[test]
+    fn rejects_special_chars() {
+        for name in ["a b", "a@b", "a.b", "a#b", "a$b", "a:b", "a*b"] {
+            assert!(
+                validate_collection_name(name).is_err(),
+                "Should reject {:?}",
+                name
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_unicode() {
+        assert!(validate_collection_name("café").is_err());
+        assert!(validate_collection_name("日本").is_err());
+    }
+
+    #[test]
+    fn rejects_windows_reserved_case_insensitive() {
+        for name in ["CON", "con", "Con", "PRN", "AUX", "NUL", "COM1", "LPT9"] {
+            assert!(
+                validate_collection_name(name).is_err(),
+                "Should reject {:?}",
+                name
+            );
+        }
+    }
+
+    #[test]
+    fn allows_names_containing_reserved_as_substring() {
+        // "connection" contains "con" but is not the reserved name "CON"
+        validate_collection_name("connection").unwrap();
+        validate_collection_name("my_aux_data").unwrap();
+        validate_collection_name("com10").unwrap();
+    }
+
+    #[test]
+    fn error_code_is_veles_034() {
+        let err = validate_collection_name("").unwrap_err();
+        assert_eq!(err.code(), "VELES-034");
+    }
+
+    #[test]
+    fn error_is_recoverable() {
+        let err = validate_collection_name("").unwrap_err();
+        assert!(err.is_recoverable());
+    }
 }

--- a/crates/velesdb-core/src/velesql/ast/condition.rs
+++ b/crates/velesdb-core/src/velesql/ast/condition.rs
@@ -127,13 +127,16 @@ pub enum CompareOp {
     Lte,
 }
 
-/// IN condition: column IN (value1, value2, ...)
+/// IN / NOT IN condition: column [NOT] IN (value1, value2, ...)
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct InCondition {
     /// Column name.
     pub column: String,
     /// List of values.
     pub values: Vec<Value>,
+    /// `true` when this is a `NOT IN` condition.
+    #[serde(default)]
+    pub negated: bool,
 }
 
 /// BETWEEN condition: column BETWEEN low AND high

--- a/crates/velesdb-core/src/velesql/ast/mod.rs
+++ b/crates/velesdb-core/src/velesql/ast/mod.rs
@@ -146,13 +146,14 @@ pub enum SetOperator {
     Except,
 }
 
-/// Compound query combining two queries with a set operator.
+/// Compound query combining queries with set operators (UNION/INTERSECT/EXCEPT).
+///
+/// Supports N-ary chaining: `SELECT ... UNION SELECT ... INTERSECT SELECT ...`
+/// is represented as `operations: [(Union, B), (Intersect, C)]`, applied left-to-right.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct CompoundQuery {
-    /// The set operator.
-    pub operator: SetOperator,
-    /// The second query.
-    pub right: Box<SelectStatement>,
+    /// Chained set operations: `(operator, right_select)` pairs, applied left-to-right.
+    pub operations: Vec<(SetOperator, SelectStatement)>,
 }
 
 #[cfg(test)]

--- a/crates/velesdb-core/src/velesql/cost_estimator.rs
+++ b/crates/velesdb-core/src/velesql/cost_estimator.rs
@@ -75,7 +75,8 @@ impl<'a> CostEstimator<'a> {
             Condition::Comparison(cmp) => self.estimate_comparison_selectivity(cmp.column.as_str()),
             Condition::In(cond) => {
                 let base = self.stats.estimate_selectivity(cond.column.as_str());
-                (base * cond.values.len() as f64).clamp(0.0, 1.0)
+                let sel = (base * cond.values.len() as f64).clamp(0.0, 1.0);
+                if cond.negated { 1.0 - sel } else { sel }
             }
             Condition::Between(cond) => self.estimate_range_selectivity(cond.column.as_str()),
             Condition::Like(cond) => {

--- a/crates/velesdb-core/src/velesql/explain.rs
+++ b/crates/velesdb-core/src/velesql/explain.rs
@@ -321,7 +321,8 @@ impl QueryPlan {
                 filter_conditions.push(format!("{} {} ?", cmp.column, cmp.operator.as_str()));
             }
             Condition::In(inc) => {
-                filter_conditions.push(format!("{} IN (...)", inc.column));
+                let op = if inc.negated { "NOT IN" } else { "IN" };
+                filter_conditions.push(format!("{} {op} (...)", inc.column));
             }
             Condition::Between(btw) => {
                 filter_conditions.push(format!("{} BETWEEN ? AND ?", btw.column));

--- a/crates/velesdb-core/src/velesql/grammar.pest
+++ b/crates/velesdb-core/src/velesql/grammar.pest
@@ -239,7 +239,7 @@ vector_literal = { "[" ~ vector_component ~ ("," ~ vector_component)* ~ "]" }
 match_expr = { where_column ~ ^"MATCH" ~ string }
 
 // IN / NOT IN expression: column [NOT] IN (value, ...)
-in_expr = { where_column ~ (^"NOT" ~ ^"IN" | ^"IN") ~ "(" ~ value_list ~ ")" }
+in_expr = { where_column ~ (not_kw ~ ^"IN" | ^"IN") ~ "(" ~ value_list ~ ")" }
 value_list = { value ~ ("," ~ value)* }
 
 // BETWEEN expression: column BETWEEN value AND value

--- a/crates/velesdb-core/src/velesql/grammar.pest
+++ b/crates/velesdb-core/src/velesql/grammar.pest
@@ -1,5 +1,5 @@
 // VelesQL Grammar - SQL-like query language for VelesDB
-// Version 0.2.0 - WITH clause support
+// Version 3.1.0 — string escaping, NOT IN, vector literal integers, N-ary compound queries
 
 // Whitespace and comments
 WHITESPACE = _{ " " | "\t" | "\r" | "\n" }
@@ -52,8 +52,8 @@ return_expr = { similarity_return | property_access | identifier | "*" }
 similarity_return = { ^"similarity" ~ "(" ~ ")" }
 property_access = @{ identifier ~ "." ~ identifier }
 
-// Compound query: SELECT with optional UNION/INTERSECT/EXCEPT
-compound_query = { select_stmt ~ (set_operator ~ select_stmt)? }
+// Compound query: SELECT with zero or more UNION/INTERSECT/EXCEPT
+compound_query = { select_stmt ~ (set_operator ~ select_stmt)* }
 set_operator = { ^"UNION" ~ ^"ALL" | ^"UNION" | ^"INTERSECT" | ^"EXCEPT" }
 
 // INSERT statement: INSERT INTO table (col1, col2) VALUES (v1, v2)
@@ -232,13 +232,14 @@ fusion_param = { identifier ~ "=" ~ fusion_param_value }
 fusion_param_value = { float | integer }
 
 vector_value = { vector_literal | parameter }
-vector_literal = { "[" ~ float ~ ("," ~ float)* ~ "]" }
+vector_component = { float | integer }
+vector_literal = { "[" ~ vector_component ~ ("," ~ vector_component)* ~ "]" }
 
 // Full-text search: column MATCH 'query'
 match_expr = { where_column ~ ^"MATCH" ~ string }
 
-// IN expression: column IN (value, ...)
-in_expr = { where_column ~ ^"IN" ~ "(" ~ value_list ~ ")" }
+// IN / NOT IN expression: column [NOT] IN (value, ...)
+in_expr = { where_column ~ (^"NOT" ~ ^"IN" | ^"IN") ~ "(" ~ value_list ~ ")" }
 value_list = { value ~ ("," ~ value)* }
 
 // BETWEEN expression: column BETWEEN value AND value
@@ -277,7 +278,7 @@ now_function = { ^"NOW" ~ "(" ~ ")" }
 interval_expr = { ^"INTERVAL" ~ string }
 
 // Literals
-string = @{ "'" ~ (!"'" ~ ANY)* ~ "'" }
+string = @{ "'" ~ (!"'" ~ ANY | "''")* ~ "'" }
 integer = @{ "-"? ~ ASCII_DIGIT+ }
 float = @{ "-"? ~ ASCII_DIGIT+ ~ "." ~ ASCII_DIGIT+ }
 

--- a/crates/velesdb-core/src/velesql/parser/condition_vectors.rs
+++ b/crates/velesdb-core/src/velesql/parser/condition_vectors.rs
@@ -39,18 +39,8 @@ impl Parser {
                 }
                 Rule::string => {
                     // USING clause: string value is the index name.
-                    //
-                    // The `string` grammar rule is defined as an atomic rule:
-                    //   string = @{ "'" ~ (!"'" ~ ANY)* ~ "'" }
-                    // `pair.as_str()` therefore includes the surrounding single
-                    // quotes (e.g. `'my-index'`), so `trim_matches('\'')` is
-                    // required and correct — it is not a no-op.
-                    //
-                    // Only single-quoted strings are accepted by the grammar.
-                    // Double-quoted identifiers (e.g. `USING "body"`) are NOT
-                    // supported and will fail at the pest parse stage before
-                    // reaching this branch.
-                    index_name = Some(inner.as_str().trim_matches('\'').to_string());
+                    // Strips surrounding quotes and unescapes '' → '.
+                    index_name = Some(crate::velesql::parser::helpers::unescape_string_literal(inner.as_str()));
                 }
                 _ => {}
             }
@@ -186,7 +176,7 @@ impl Parser {
                 Rule::fusion_strategy => {
                     strategy = inner.into_inner().next().map_or_else(
                         || "rrf".to_string(),
-                        |s| s.as_str().trim_matches('\'').to_string(),
+                        |s| crate::velesql::parser::helpers::unescape_string_literal(s.as_str()),
                     );
                 }
                 Rule::fusion_params => {
@@ -211,11 +201,15 @@ impl Parser {
             Rule::vector_literal => {
                 let values: Result<Vec<f32>, _> = inner
                     .into_inner()
-                    .filter(|p| p.as_rule() == Rule::float)
+                    .filter(|p| p.as_rule() == Rule::vector_component)
                     .map(|p| {
-                        p.as_str()
+                        let child = p.into_inner().next().ok_or_else(|| {
+                            ParseError::syntax(0, "", "Expected numeric value in vector")
+                        })?;
+                        child
+                            .as_str()
                             .parse::<f32>()
-                            .map_err(|_| ParseError::syntax(0, p.as_str(), "Invalid float value"))
+                            .map_err(|_| ParseError::syntax(0, child.as_str(), "Invalid vector component"))
                     })
                     .collect();
                 Ok(VectorExpr::Literal(values?))

--- a/crates/velesdb-core/src/velesql/parser/conditions.rs
+++ b/crates/velesdb-core/src/velesql/parser/conditions.rs
@@ -255,15 +255,16 @@ impl Parser {
     pub(crate) fn parse_in_expr(
         pair: pest::iterators::Pair<Rule>,
     ) -> Result<Condition, ParseError> {
-        let raw = pair.as_str();
         let mut inner = pair.into_inner();
         let column = Self::extract_leading_column(&mut inner)?;
 
-        // Detect NOT IN vs IN by checking the text AFTER the column name.
-        // Strip the column prefix so "not IN (...)" → " IN (...)" (not negated)
-        // while "status NOT IN (...)" → " NOT IN (...)" (negated).
-        let after_column = &raw[column.len()..].to_uppercase();
-        let negated = after_column.contains("NOT IN");
+        // Detect NOT IN via the named `not_kw` rule in the pest parse tree.
+        // This is immune to false positives from column names or string values
+        // containing "NOT IN" (e.g. 'NOT IN STOCK').
+        let negated = inner.peek().is_some_and(|p| p.as_rule() == Rule::not_kw);
+        if negated {
+            inner.next(); // consume the not_kw token
+        }
 
         let value_list = inner
             .find(|p| p.as_rule() == Rule::value_list)

--- a/crates/velesdb-core/src/velesql/parser/conditions.rs
+++ b/crates/velesdb-core/src/velesql/parser/conditions.rs
@@ -259,10 +259,11 @@ impl Parser {
         let mut inner = pair.into_inner();
         let column = Self::extract_leading_column(&mut inner)?;
 
-        // Detect NOT IN vs IN: the grammar `(^"NOT" ~ ^"IN" | ^"IN")` puts
-        // "NOT IN" or "IN" literally between column and "(". We check for
-        // " NOT IN " to avoid false positives on column names like "notification".
-        let negated = raw.to_uppercase().contains("NOT IN");
+        // Detect NOT IN vs IN by checking the text AFTER the column name.
+        // Strip the column prefix so "not IN (...)" → " IN (...)" (not negated)
+        // while "status NOT IN (...)" → " NOT IN (...)" (negated).
+        let after_column = &raw[column.len()..].to_uppercase();
+        let negated = after_column.contains("NOT IN");
 
         let value_list = inner
             .find(|p| p.as_rule() == Rule::value_list)

--- a/crates/velesdb-core/src/velesql/parser/conditions.rs
+++ b/crates/velesdb-core/src/velesql/parser/conditions.rs
@@ -225,12 +225,12 @@ impl Parser {
         let mut inner = pair.into_inner();
         let column = Self::extract_leading_column(&mut inner)?;
 
-        let query = inner
-            .next()
-            .ok_or_else(|| ParseError::syntax(0, "", "Expected match query"))?
-            .as_str()
-            .trim_matches('\'')
-            .to_string();
+        let query = crate::velesql::parser::helpers::unescape_string_literal(
+            inner
+                .next()
+                .ok_or_else(|| ParseError::syntax(0, "", "Expected match query"))?
+                .as_str(),
+        );
 
         Ok(Condition::Match(MatchCondition { column, query }))
     }
@@ -255,11 +255,17 @@ impl Parser {
     pub(crate) fn parse_in_expr(
         pair: pest::iterators::Pair<Rule>,
     ) -> Result<Condition, ParseError> {
+        let raw = pair.as_str();
         let mut inner = pair.into_inner();
         let column = Self::extract_leading_column(&mut inner)?;
 
+        // Detect NOT IN vs IN: the grammar `(^"NOT" ~ ^"IN" | ^"IN")` puts
+        // "NOT IN" or "IN" literally between column and "(". We check for
+        // " NOT IN " to avoid false positives on column names like "notification".
+        let negated = raw.to_uppercase().contains("NOT IN");
+
         let value_list = inner
-            .next()
+            .find(|p| p.as_rule() == Rule::value_list)
             .ok_or_else(|| ParseError::syntax(0, "", "Expected value list"))?;
 
         let values: Result<Vec<_>, _> = value_list
@@ -271,6 +277,7 @@ impl Parser {
         Ok(Condition::In(InCondition {
             column,
             values: values?,
+            negated,
         }))
     }
 
@@ -311,12 +318,12 @@ impl Parser {
             .to_uppercase();
         let case_insensitive = like_op == "ILIKE";
 
-        let pattern = inner
-            .next()
-            .ok_or_else(|| ParseError::syntax(0, "", "Expected pattern"))?
-            .as_str()
-            .trim_matches('\'')
-            .to_string();
+        let pattern = crate::velesql::parser::helpers::unescape_string_literal(
+            inner
+                .next()
+                .ok_or_else(|| ParseError::syntax(0, "", "Expected pattern"))?
+                .as_str(),
+        );
 
         Ok(Condition::Like(LikeCondition {
             column,

--- a/crates/velesdb-core/src/velesql/parser/helpers.rs
+++ b/crates/velesdb-core/src/velesql/parser/helpers.rs
@@ -39,7 +39,7 @@ pub(crate) fn compare_op_from_str(op: &str) -> Result<CompareOp, ParseError> {
 /// Returns [`ParseError`] if the input cannot be recognized as any value type.
 pub(crate) fn parse_value_from_str(input: &str) -> Result<Value, ParseError> {
     if input.len() >= 2 && input.starts_with('\'') && input.ends_with('\'') {
-        return Ok(Value::String(input[1..input.len() - 1].to_string()));
+        return Ok(Value::String(unescape_string_literal(input)));
     }
     if input.eq_ignore_ascii_case("true") {
         return Ok(Value::Boolean(true));
@@ -95,8 +95,7 @@ pub(crate) fn parse_scalar_from_rule(
             Ok(Value::Float(v))
         }
         Rule::string => {
-            let s = pair.as_str().trim_matches('\'').to_string();
-            Ok(Value::String(s))
+            Ok(Value::String(unescape_string_literal(pair.as_str())))
         }
         Rule::boolean => {
             let b = pair.as_str().to_uppercase() == "TRUE";
@@ -130,6 +129,14 @@ pub(crate) fn parse_u64_clause(
     int_pair.as_str().parse::<u64>().map_err(|_| {
         ParseError::syntax(0, int_pair.as_str(), format!("Invalid {clause_name} value"))
     })
+}
+
+/// Strips surrounding single quotes and unescapes SQL-style doubled quotes.
+///
+/// `'O''Brien'` becomes `O'Brien`. The grammar guarantees the string starts
+/// and ends with `'` and is at least 2 chars long (atomic rule).
+pub(crate) fn unescape_string_literal(raw: &str) -> String {
+    raw[1..raw.len() - 1].replace("''", "'")
 }
 
 /// Strips surrounding backticks or double-quotes from an identifier segment.
@@ -237,5 +244,25 @@ mod tests {
     #[test]
     fn test_strip_identifier_quotes_trimmed() {
         assert_eq!(strip_identifier_quotes("  `spaced`  "), "spaced");
+    }
+
+    #[test]
+    fn test_unescape_string_literal_simple() {
+        assert_eq!(unescape_string_literal("'hello'"), "hello");
+    }
+
+    #[test]
+    fn test_unescape_string_literal_escaped_quote() {
+        assert_eq!(unescape_string_literal("'O''Brien'"), "O'Brien");
+    }
+
+    #[test]
+    fn test_unescape_string_literal_multiple_escapes() {
+        assert_eq!(unescape_string_literal("'It''s a ''test'''"), "It's a 'test'");
+    }
+
+    #[test]
+    fn test_unescape_string_literal_empty() {
+        assert_eq!(unescape_string_literal("''"), "");
     }
 }

--- a/crates/velesdb-core/src/velesql/parser/select/clause_compound.rs
+++ b/crates/velesdb-core/src/velesql/parser/select/clause_compound.rs
@@ -10,26 +10,35 @@ impl Parser {
         pair: pest::iterators::Pair<Rule>,
     ) -> Result<Query, ParseError> {
         let mut select_stmts = Vec::new();
-        let mut set_op = None;
+        let mut set_ops = Vec::new();
+
         for inner_pair in pair.into_inner() {
             match inner_pair.as_rule() {
                 Rule::select_stmt => select_stmts.push(Self::parse_select_stmt(inner_pair)?),
-                Rule::set_operator => set_op = Some(Self::parse_set_operator(inner_pair.as_str())),
+                Rule::set_operator => set_ops.push(Self::parse_set_operator(inner_pair.as_str())),
                 _ => {}
             }
         }
+
         let select = select_stmts
             .first()
             .cloned()
             .ok_or_else(|| ParseError::syntax(0, "", "Expected SELECT statement"))?;
-        let compound = if let (Some(op), Some(right)) = (set_op, select_stmts.get(1).cloned()) {
-            Some(CompoundQuery {
-                operator: op,
-                right: Box::new(right),
-            })
-        } else {
+
+        let compound = if set_ops.is_empty() {
             None
+        } else {
+            let operations: Vec<(SetOperator, _)> = set_ops
+                .into_iter()
+                .zip(select_stmts.into_iter().skip(1))
+                .collect();
+            if operations.is_empty() {
+                None
+            } else {
+                Some(CompoundQuery { operations })
+            }
         };
+
         Ok(Query {
             select,
             compound,

--- a/crates/velesdb-core/src/velesql/parser/select/clause_limit_with.rs
+++ b/crates/velesdb-core/src/velesql/parser/select/clause_limit_with.rs
@@ -52,7 +52,17 @@ impl Parser {
         for part in option.into_inner() {
             match part.as_rule() {
                 Rule::identifier => key = extract_identifier(&part).to_lowercase(),
-                Rule::fusion_value => value_str = part.as_str().trim_matches('\'').to_string(),
+                Rule::fusion_value => {
+                    // fusion_value = { string | float | integer }
+                    // Only unescape if the inner child is a string literal.
+                    if let Some(child) = part.into_inner().next() {
+                        value_str = if child.as_rule() == Rule::string {
+                            crate::velesql::parser::helpers::unescape_string_literal(child.as_str())
+                        } else {
+                            child.as_str().to_string()
+                        };
+                    }
+                }
                 _ => {}
             }
         }

--- a/crates/velesdb-core/src/velesql/parser/values.rs
+++ b/crates/velesdb-core/src/velesql/parser/values.rs
@@ -73,8 +73,8 @@ impl Parser {
             .find(|p| p.as_rule() == Rule::string)
             .ok_or_else(|| ParseError::syntax(0, "", "Expected interval string"))?;
 
-        let interval_str = string_pair.as_str().trim_matches('\'');
-        let interval_value = Self::parse_interval_string(interval_str)?;
+        let interval_str = crate::velesql::parser::helpers::unescape_string_literal(string_pair.as_str());
+        let interval_value = Self::parse_interval_string(&interval_str)?;
         Ok(TemporalExpr::Interval(interval_value))
     }
 

--- a/crates/velesdb-core/src/velesql/parser_tests.rs
+++ b/crates/velesdb-core/src/velesql/parser_tests.rs
@@ -220,8 +220,48 @@ fn test_parse_in_condition() {
         Some(Condition::In(c)) => {
             assert_eq!(c.column, "category");
             assert_eq!(c.values.len(), 2);
+            assert!(!c.negated, "IN should not be negated");
         }
         _ => panic!("Expected IN condition"),
+    }
+}
+
+#[test]
+fn test_parse_not_in_condition() {
+    let query =
+        Parser::parse("SELECT * FROM docs WHERE status NOT IN ('draft', 'deleted')").unwrap();
+    match query.select.where_clause {
+        Some(Condition::In(c)) => {
+            assert_eq!(c.column, "status");
+            assert_eq!(c.values.len(), 2);
+            assert!(c.negated, "NOT IN should be negated");
+        }
+        _ => panic!("Expected NOT IN condition"),
+    }
+}
+
+#[test]
+fn test_parse_in_column_named_not_is_not_negated() {
+    // Column named "not" with regular IN — must NOT be a false positive for NOT IN.
+    // Grammar: where_column greedily matches "not" as identifier, then "IN" follows.
+    let result = Parser::parse("SELECT * FROM docs WHERE not IN (1, 2)");
+    // If the grammar allows this, verify negated is false. If it fails to parse
+    // (because NOT is consumed as a keyword), that's also acceptable.
+    if let Ok(query) = result {
+        if let Some(Condition::In(c)) = query.select.where_clause {
+            assert!(!c.negated, "column named 'not' with IN must not be negated");
+        }
+    }
+}
+
+#[test]
+fn test_parse_string_with_escaped_quote() {
+    let query = Parser::parse("SELECT * FROM docs WHERE name = 'O''Brien'").unwrap();
+    match query.select.where_clause {
+        Some(Condition::Comparison(c)) => {
+            assert_eq!(c.value, Value::String("O'Brien".to_string()));
+        }
+        _ => panic!("Expected Comparison condition with escaped string"),
     }
 }
 

--- a/crates/velesdb-core/src/velesql/parser_tests.rs
+++ b/crates/velesdb-core/src/velesql/parser_tests.rs
@@ -255,6 +255,22 @@ fn test_parse_in_column_named_not_is_not_negated() {
 }
 
 #[test]
+fn test_parse_in_with_not_in_string_value() {
+    // Value containing "NOT IN" must NOT cause the IN to be treated as NOT IN.
+    // Regression test for Devin review finding: `status IN ('NOT IN STOCK')`.
+    let query =
+        Parser::parse("SELECT * FROM docs WHERE status IN ('NOT IN STOCK', 'AVAILABLE')").unwrap();
+    match query.select.where_clause {
+        Some(Condition::In(c)) => {
+            assert_eq!(c.column, "status");
+            assert!(!c.negated, "IN with 'NOT IN STOCK' value must not be negated");
+            assert_eq!(c.values.len(), 2);
+        }
+        _ => panic!("Expected IN condition"),
+    }
+}
+
+#[test]
 fn test_parse_string_with_escaped_quote() {
     let query = Parser::parse("SELECT * FROM docs WHERE name = 'O''Brien'").unwrap();
     match query.select.where_clause {

--- a/crates/velesdb-core/src/velesql/set_operations_tests.rs
+++ b/crates/velesdb-core/src/velesql/set_operations_tests.rs
@@ -4,7 +4,7 @@
 //! - UNION / UNION ALL
 //! - INTERSECT
 //! - EXCEPT
-//! - Chained operations
+//! - Chained N-ary operations
 
 use crate::velesql::Parser;
 
@@ -20,7 +20,8 @@ fn test_union_basic() {
         .as_ref()
         .expect("Compound query should be present");
 
-    assert_eq!(compound.operator, crate::velesql::SetOperator::Union);
+    assert_eq!(compound.operations.len(), 1);
+    assert_eq!(compound.operations[0].0, crate::velesql::SetOperator::Union);
 }
 
 #[test]
@@ -39,7 +40,11 @@ fn test_union_all() {
         .as_ref()
         .expect("Compound query should be present");
 
-    assert_eq!(compound.operator, crate::velesql::SetOperator::UnionAll);
+    assert_eq!(compound.operations.len(), 1);
+    assert_eq!(
+        compound.operations[0].0,
+        crate::velesql::SetOperator::UnionAll
+    );
 }
 
 #[test]
@@ -58,7 +63,11 @@ fn test_intersect() {
         .as_ref()
         .expect("Compound query should be present");
 
-    assert_eq!(compound.operator, crate::velesql::SetOperator::Intersect);
+    assert_eq!(compound.operations.len(), 1);
+    assert_eq!(
+        compound.operations[0].0,
+        crate::velesql::SetOperator::Intersect
+    );
 }
 
 #[test]
@@ -73,16 +82,50 @@ fn test_except() {
         .as_ref()
         .expect("Compound query should be present");
 
-    assert_eq!(compound.operator, crate::velesql::SetOperator::Except);
+    assert_eq!(compound.operations.len(), 1);
+    assert_eq!(
+        compound.operations[0].0,
+        crate::velesql::SetOperator::Except
+    );
 }
 
 #[test]
 fn test_simple_select_no_compound() {
-    // Ensure simple SELECT still works and has no compound
     let sql = "SELECT * FROM docs";
     let result = Parser::parse(sql);
     assert!(result.is_ok());
 
     let query = result.unwrap();
     assert!(query.compound.is_none());
+}
+
+// =========================================================================
+// N-ary compound queries (Bug 2, issue #383)
+// =========================================================================
+
+#[test]
+fn test_chained_three_way_union() {
+    let sql = "SELECT * FROM a UNION SELECT * FROM b UNION SELECT * FROM c";
+    let query = Parser::parse(sql).expect("should parse 3-way UNION");
+
+    let compound = query.compound.as_ref().expect("compound should be present");
+    assert_eq!(compound.operations.len(), 2);
+    assert_eq!(compound.operations[0].0, crate::velesql::SetOperator::Union);
+    assert_eq!(compound.operations[1].0, crate::velesql::SetOperator::Union);
+    assert_eq!(compound.operations[0].1.from, "b");
+    assert_eq!(compound.operations[1].1.from, "c");
+}
+
+#[test]
+fn test_chained_mixed_operators() {
+    let sql = "SELECT * FROM a UNION SELECT * FROM b INTERSECT SELECT * FROM c";
+    let query = Parser::parse(sql).expect("should parse mixed operators");
+
+    let compound = query.compound.as_ref().expect("compound should be present");
+    assert_eq!(compound.operations.len(), 2);
+    assert_eq!(compound.operations[0].0, crate::velesql::SetOperator::Union);
+    assert_eq!(
+        compound.operations[1].0,
+        crate::velesql::SetOperator::Intersect
+    );
 }

--- a/crates/velesdb-core/src/velesql/validation.rs
+++ b/crates/velesdb-core/src/velesql/validation.rs
@@ -234,8 +234,10 @@ impl QueryValidator {
             Self::validate_condition(condition, query.select.limit, config)?;
         }
         if let Some(ref compound) = query.compound {
-            if let Some(ref condition) = compound.right.where_clause {
-                Self::validate_condition(condition, compound.right.limit, config)?;
+            for (_, right_select) in &compound.operations {
+                if let Some(ref condition) = right_select.where_clause {
+                    Self::validate_condition(condition, right_select.limit, config)?;
+                }
             }
         }
 
@@ -243,8 +245,10 @@ impl QueryValidator {
         Self::validate_qualified_wildcards(&query.select)?;
 
         if let Some(ref compound) = query.compound {
-            Self::validate_similarity_context(&compound.right)?;
-            Self::validate_qualified_wildcards(&compound.right)?;
+            for (_, right_select) in &compound.operations {
+                Self::validate_similarity_context(right_select)?;
+                Self::validate_qualified_wildcards(right_select)?;
+            }
         }
 
         Ok(())
@@ -413,10 +417,12 @@ impl QueryValidator {
         }
 
         if let Some(ref compound) = query.compound {
-            if let Some(ref condition) = compound.right.where_clause {
-                let (depth, like_count) = Self::analyze_condition(condition);
-                stats.ast_depth = stats.ast_depth.max(depth);
-                stats.like_ilike_terms += like_count;
+            for (_, right_select) in &compound.operations {
+                if let Some(ref condition) = right_select.where_clause {
+                    let (depth, like_count) = Self::analyze_condition(condition);
+                    stats.ast_depth = stats.ast_depth.max(depth);
+                    stats.like_ilike_terms += like_count;
+                }
             }
         }
 

--- a/crates/velesdb-core/src/velesql/validation_tests.rs
+++ b/crates/velesdb-core/src/velesql/validation_tests.rs
@@ -560,8 +560,7 @@ fn test_validate_compound_query_where_clause() {
             fusion_clause: None,
         },
         compound: Some(CompoundQuery {
-            operator: SetOperator::Union,
-            right: Box::new(SelectStatement {
+            operations: vec![(SetOperator::Union, SelectStatement {
                 distinct: crate::velesql::DistinctMode::None,
                 columns: SelectColumns::All,
                 from: "docs".to_string(),
@@ -575,7 +574,7 @@ fn test_validate_compound_query_where_clause() {
                 group_by: None,
                 having: None,
                 fusion_clause: None,
-            }),
+            })],
         }),
         match_clause: None,
         dml: None,

--- a/crates/velesdb-core/src/velesql/velesql_v2_integration_tests.rs
+++ b/crates/velesdb-core/src/velesql/velesql_v2_integration_tests.rs
@@ -199,7 +199,7 @@ fn test_union_basic() {
     let query = result.unwrap();
     assert!(query.compound.is_some());
     let compound = query.compound.unwrap();
-    assert_eq!(compound.operator, SetOperator::Union);
+    assert_eq!(compound.operations[0].0, SetOperator::Union);
 }
 
 #[test]
@@ -210,7 +210,7 @@ fn test_union_all() {
 
     let query = result.unwrap();
     let compound = query.compound.unwrap();
-    assert_eq!(compound.operator, SetOperator::UnionAll);
+    assert_eq!(compound.operations[0].0, SetOperator::UnionAll);
 }
 
 #[test]
@@ -221,7 +221,7 @@ fn test_intersect() {
 
     let query = result.unwrap();
     let compound = query.compound.unwrap();
-    assert_eq!(compound.operator, SetOperator::Intersect);
+    assert_eq!(compound.operations[0].0, SetOperator::Intersect);
 }
 
 #[test]
@@ -232,7 +232,7 @@ fn test_except() {
 
     let query = result.unwrap();
     let compound = query.compound.unwrap();
-    assert_eq!(compound.operator, SetOperator::Except);
+    assert_eq!(compound.operations[0].0, SetOperator::Except);
 }
 
 #[test]

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -170,7 +170,7 @@ coll.stream_insert([
 ### Query limitations
 
 - VelesQL parses subqueries but does not execute them yet. CTEs are not supported.
-- `UPDATE` and `DELETE ... WHERE` statements are not supported in VelesQL (use the programmatic API).
+- `INSERT` and `UPDATE` are parsed by VelesQL but runtime execution is not yet implemented (use the programmatic API). `DELETE` is planned.
 - Graph traversal in VelesQL is limited to `MATCH` patterns; recursive CTEs are not available.
 
 ---
@@ -194,9 +194,12 @@ VelesQL is a SQL-like query language with vector and graph extensions. It suppor
 | `vector NEAR $v` (similarity search) | Yes | No |
 | `MATCH` (graph traversal) | Yes | No |
 | `USING FUSION` (hybrid search) | Yes | No |
+| `NEAR_FUSED` (multi-vector fusion) | Yes | No |
+| `SPARSE_NEAR` (sparse vector search) | Yes | No |
 | `TRAIN QUANTIZER ON ...` | Yes | No |
 | Subqueries / CTEs | No | Yes |
-| `INSERT` / `UPDATE` / `DELETE` | No | Yes |
+| `INSERT` / `UPDATE` | Parsed (no runtime execution) | Yes |
+| `DELETE` | Planned | Yes |
 | `CREATE TABLE` / DDL | No | Yes |
 | Window functions | No | Yes |
 | Stored procedures | No | Yes |

--- a/docs/STORAGE_FORMAT.md
+++ b/docs/STORAGE_FORMAT.md
@@ -206,6 +206,14 @@ All multi-byte integers are stored in **little-endian** format.
 │     │                                                            │
 │     ▼                                                            │
 │  5. Load/rebuild HNSW index                                      │
+│     │                                                            │
+│     ▼                                                            │
+│  6. Gap detection: compare storage IDs vs HNSW IDs               │
+│     │                                                            │
+│     ├─── Counts match ──► No gap (O(1) fast path)                │
+│     │                                                            │
+│     └─── Gap found ────► Re-index missing vectors into HNSW      │
+│                          (crash during deferred merge recovery)   │
 │                                                                  │
 └─────────────────────────────────────────────────────────────────┘
 ```

--- a/docs/VELESQL_SPEC.md
+++ b/docs/VELESQL_SPEC.md
@@ -2,7 +2,7 @@
 
 > SQL-like query language for vector search in VelesDB.
 
-**Version**: 3.0.0 | **Last Updated**: 2026-03-07
+**Version**: 3.1.0 | **Last Updated**: 2026-03-25
 
 ## Overview
 

--- a/docs/VELESQL_SPEC.md
+++ b/docs/VELESQL_SPEC.md
@@ -505,7 +505,16 @@ JOIN products p ON o.product_id = p.id
 
 ## Set Operations (v2.0+)
 
-Combine results from multiple queries.
+Combine results from multiple queries. N-ary chaining is supported:
+
+```sql
+SELECT * FROM a UNION SELECT * FROM b INTERSECT SELECT * FROM c
+```
+
+> **Precedence note:** VelesQL evaluates set operators strictly **left-to-right**,
+> unlike standard SQL where `INTERSECT` binds tighter than `UNION`. The query
+> above is evaluated as `(A UNION B) INTERSECT C`. Use parenthesized subqueries
+> if different evaluation order is needed (when subquery execution is supported).
 
 ### UNION
 

--- a/docs/VELESQL_SPEC.md
+++ b/docs/VELESQL_SPEC.md
@@ -27,7 +27,8 @@ VelesQL is a SQL-inspired query language designed specifically for vector simila
 | NOW() / INTERVAL temporal | ✅ Stable | 2.1 |
 | MATCH graph traversal | ✅ Stable | 2.1 |
 | SPARSE_NEAR sparse vector search | ✅ Stable | 2.2 |
-| FUSE BY fusion clause | 🔜 Planned | 2.2 |
+| NEAR_FUSED multi-vector fusion | ✅ Stable | 2.2 |
+| FUSE BY fusion clause | 🔜 Planned | - |
 | TRAIN QUANTIZER command | ✅ Stable | 2.2 |
 | Table aliases | 🔜 Planned | - |
 
@@ -259,6 +260,53 @@ LIMIT 10
 ```
 
 > **Note:** The `FUSE BY` syntax is planned but not yet implemented in the grammar. Use `USING FUSION(...)` for hybrid search. See the [FUSE BY clause (planned)](#fuse-by-clause-v22-planned-syntax) section below for the planned syntax.
+
+### Multi-Vector Fusion with NEAR_FUSED (v2.2+)
+
+`NEAR_FUSED` combines multiple embedding vectors into a single similarity search using a fusion strategy. This is useful for multi-modal search (text + image embeddings) or ensemble approaches.
+
+#### Syntax
+
+```sql
+SELECT * FROM docs
+WHERE vector NEAR_FUSED [$text_embedding, $image_embedding]
+USING FUSION 'rrf' (k=60)
+LIMIT 10
+```
+
+#### Vector Array
+
+The `NEAR_FUSED` clause accepts a vector array `[v1, v2, ...]` where each element is either a parameter (`$name`) or a vector literal (`[0.1, 0.2, ...]`).
+
+#### Fusion Strategies
+
+| Strategy | Description |
+|----------|-------------|
+| `'rrf'` | Reciprocal Rank Fusion (default). Parameter: `k` (default 60). |
+| `'weighted'` | Weighted average of scores. Parameters: per-vector weights. |
+| `'maximum'` | Takes the maximum score across vectors. |
+| `'rsf'` | Relative Score Fusion. |
+
+#### Examples
+
+```sql
+-- Two-vector fusion with RRF
+SELECT * FROM products
+WHERE vector NEAR_FUSED [$text_emb, $image_emb]
+USING FUSION 'rrf' (k=60)
+LIMIT 20
+
+-- Three-vector ensemble
+SELECT * FROM docs
+WHERE vector NEAR_FUSED [$query_v1, $query_v2, $query_v3]
+USING FUSION 'maximum'
+LIMIT 10
+
+-- Without explicit fusion (defaults to RRF)
+SELECT * FROM docs
+WHERE vector NEAR_FUSED [$v1, $v2]
+LIMIT 5
+```
 
 ### Similarity Function (v1.3+)
 
@@ -827,7 +875,7 @@ SELECT id AS `select` FROM docs
 | `ORDER`, `BY`, `ASC`, `DESC` | Sorting |
 | `GROUP`, `HAVING` | Aggregation |
 | `WITH`, `AS` | Options and aliases |
-| `NEAR`, `SPARSE_NEAR`, `SIMILARITY` | Vector operations |
+| `NEAR`, `NEAR_FUSED`, `SPARSE_NEAR`, `SIMILARITY` | Vector operations |
 | `FUSE`, `TRAIN`, `QUANTIZER` | v2.2 extensions (`FUSE` reserved for planned syntax) |
 
 ## Grammar (EBNF) - v2.2
@@ -871,14 +919,19 @@ join_type       = "INNER" | "LEFT" ["OUTER"] | "RIGHT" ["OUTER"] | "FULL" ["OUTE
 where_clause    = "WHERE" or_expr ;
 or_expr         = and_expr { "OR" and_expr } ;
 and_expr        = condition { "AND" condition } ;
-condition       = comparison | vector_search | sparse_search | similarity_cond | in_cond
-                | between_cond | like_cond | is_null_cond | "(" or_expr ")" ;
+condition       = comparison | vector_search | fused_search | sparse_search
+                | similarity_cond | in_cond | between_cond | like_cond
+                | is_null_cond | "(" or_expr ")" ;
 
 (* Vector operations *)
 vector_search   = identifier "NEAR" vector_expr ;
+fused_search    = identifier "NEAR_FUSED" vector_array [ fusion_clause ] ;
 sparse_search   = identifier "SPARSE_NEAR" sparse_vector_expr ;
 similarity_cond = "similarity" "(" identifier "," vector_expr ")" compare_op number ;
 vector_expr     = "$" identifier | "[" number { "," number } "]" ;
+vector_array    = "[" vector_expr { "," vector_expr } "]" ;
+fusion_clause   = "USING" "FUSION" string [ "(" fusion_params ")" ] ;
+fusion_params   = identifier "=" value { "," identifier "=" value } ;
 sparse_vector_expr = "$" identifier ;
 
 (* Comparisons *)
@@ -886,7 +939,7 @@ comparison      = column compare_op value ;
 compare_op      = "=" | "!=" | "<>" | ">" | ">=" | "<" | "<=" ;
 
 (* Special conditions *)
-in_cond         = column "IN" "(" value { "," value } ")" ;
+in_cond         = column [ "NOT" ] "IN" "(" value { "," value } ")" ;
 between_cond    = column "BETWEEN" value "AND" value ;
 like_cond       = column ("LIKE" | "ILIKE") string ;
 is_null_cond    = column "IS" ["NOT"] "NULL" ;
@@ -929,7 +982,7 @@ train_param     = identifier "=" integer ;
 (* Values *)
 value           = string | number | boolean | "NULL" | vector_literal ;
 vector_literal  = "[" number { "," number } "]" ;
-string          = "'" { char } "'" | '"' { char } '"' ;
+string          = "'" { char | "''" } "'" ;   (* '' escapes a single quote *)
 number          = ["-"] digit { digit } ["." digit { digit }] ;
 boolean         = "true" | "false" ;
 integer         = digit { digit } ;

--- a/docs/contributing/CRASH_RECOVERY_TESTING.md
+++ b/docs/contributing/CRASH_RECOVERY_TESTING.md
@@ -158,6 +158,22 @@ For fast recovery, `LogPayloadStorage` supports snapshots:
 - Recovery loads snapshot + replays WAL delta
 - CRC32 checksum validates snapshot integrity
 
+### HNSW Gap Detection (Issue #382)
+
+After WAL replay and HNSW load, `Collection::open()` runs gap detection:
+1. Compares `storage.ids()` vs `index.mappings.contains()` (lock-free)
+2. Re-indexes gap vectors via `insert_batch_parallel()`
+3. Skips vectors with mismatched dimensions (corruption defense)
+
+This recovers vectors that were written to storage but not yet indexed
+in HNSW due to a crash during deferred merge or delta buffer drain.
+
+Unit tests in `collection/core/recovery_tests.rs` cover:
+- No-gap fast path (O(1) count comparison)
+- Simulated gap (direct storage write bypassing HNSW)
+- Full reopen cycle (create → gap → drop → reopen → verify search)
+- Metadata-only skip (no false positives)
+
 ## Future Work (EPIC-024)
 
 - **US-002**: Corruption tests (truncation, bitflip)

--- a/docs/reference/API_REFERENCE.md
+++ b/docs/reference/API_REFERENCE.md
@@ -116,6 +116,11 @@ SELECT * FROM active UNION SELECT * FROM archived
 
 ### Create Collection
 
+**Collection naming rules:** Names must be 1--128 characters, containing only ASCII
+letters, digits, underscores, and hyphens (`[a-zA-Z0-9_-]`). Names must not start
+with a hyphen, must not be `.` or `..`, and must not be Windows reserved device names
+(CON, PRN, etc.). Invalid names return HTTP 400 with error code `VELES-034`.
+
 ```bash
 curl -X POST http://localhost:8080/collections \
   -H "Content-Type: application/json" \

--- a/docs/reference/API_REFERENCE.md
+++ b/docs/reference/API_REFERENCE.md
@@ -76,8 +76,10 @@ Complete REST API documentation for `velesdb-server`. All endpoints are served f
 - `UNION` / `INTERSECT` / `EXCEPT` set operations
 - `USING FUSION(strategy='rrf')` hybrid search
 - `SPARSE_NEAR` clause for sparse vector similarity search
+- `NEAR_FUSED` multi-vector fusion with RRF/weighted/maximum/RSF strategies
 - `TRAIN QUANTIZER ON <collection> WITH (m=8, k=256)` for explicit PQ training
-- `FUSE BY` / `USING FUSION` with `dense_weight`/`sparse_weight` for RSF fusion
+- `USING FUSION` with `dense_weight`/`sparse_weight` for RSF fusion
+- `NOT IN` operator for negative filtering
 - `WITH (max_groups=100)` query-time config
 
 ```sql

--- a/docs/reference/ERROR_CODES.md
+++ b/docs/reference/ERROR_CODES.md
@@ -293,6 +293,20 @@ or internal bugs:
 - **Resolution**: Reduce memory usage (e.g., use quantization, reduce dataset size, increase system RAM). Consider using `StorageMode::SQ8` or `StorageMode::Binary` to reduce memory footprint.
 - **Recoverable**: **No** -- indicates resource exhaustion.
 
+### VELES-034: InvalidCollectionName
+
+- **Variant**: `InvalidCollectionName { name: String, reason: String }`
+- **Message**: `Invalid collection name '{name}': {reason}`
+- **Cause**: The collection name is unsafe for use as a filesystem directory. This check prevents path traversal attacks and filesystem errors.
+- **Naming rules**:
+  - 1--128 characters
+  - ASCII letters, digits, underscores, and hyphens only (`[a-zA-Z0-9_-]`)
+  - Must not start with a hyphen
+  - Must not be `.` or `..`
+  - Must not be a Windows reserved device name (`CON`, `PRN`, `AUX`, `NUL`, `COM1`--`COM9`, `LPT1`--`LPT9`)
+- **Resolution**: Rename the collection using only allowed characters. Use `velesdb_core::validate_collection_name()` to check names before creation.
+- **Recoverable**: Yes
+
 ---
 
 ## Programmatic Usage
@@ -352,3 +366,4 @@ fn handle_error(err: &Error) {
 | VELES-031 | `DatabaseLocked` | Yes | Database |
 | VELES-032 | `InvalidDimension` | Yes | Validation |
 | VELES-033 | `AllocationFailed` | **No** | Resource |
+| VELES-034 | `InvalidCollectionName` | Yes | Validation |

--- a/docs/reference/VELESQL_SPEC.md
+++ b/docs/reference/VELESQL_SPEC.md
@@ -114,13 +114,16 @@ VelesQL is a query language that combines familiar SQL syntax with vector simila
                   | <compare_expr>
 
 <vector_search> ::= "vector" "NEAR" [<metric>] <vector_value>
+<fused_search>  ::= "vector" "NEAR_FUSED" <vector_array> [<fusion_clause>]
+<vector_array>  ::= "[" <vector_value> ("," <vector_value>)* "]"
+<fusion_clause> ::= "USING" "FUSION" <string> ["(" <fusion_params> ")"]
 <metric>        ::= "COSINE" | "EUCLIDEAN" | "DOT" | "HAMMING" | "JACCARD"
 <vector_value>  ::= <vector_literal> | <parameter>
 <vector_literal>::= "[" <float> ("," <float>)* "]"
 
 <match_expr>    ::= <identifier> "MATCH" <string>
 
-<in_expr>       ::= <identifier> "IN" "(" <value_list> ")"
+<in_expr>       ::= <identifier> ["NOT"] "IN" "(" <value_list> ")"
 <value_list>    ::= <value> ("," <value>)*
 
 <between_expr>  ::= <identifier> "BETWEEN" <value> "AND" <value>

--- a/docs/reference/VELESQL_SPEC.md
+++ b/docs/reference/VELESQL_SPEC.md
@@ -2,7 +2,7 @@
 
 > **Canonical spec:** [docs/VELESQL_SPEC.md](../VELESQL_SPEC.md) is the authoritative version. This file provides a reference summary.
 
-*Version 3.0.0 — February 2026*
+*Version 3.1.0 — March 2026*
 
 VelesQL is a **SQL-like query language** designed specifically for vector search operations. If you know SQL, you already know VelesQL.
 


### PR DESCRIPTION
## Summary

Post-release audit and patch fixes for v1.7.1:

- **#381** fix(security): validate collection names against path traversal — new `validate_collection_name()` with allowlist `[a-zA-Z0-9_-]`, error VELES-034, defense-in-depth on all 16 `data_dir.join(name)` sites
- **#382** fix(core): crash recovery gap detection for deferred HNSW indexer — auto-recovers vectors in storage but missing from HNSW on `Collection::open()`
- **#383** fix(velesql): 5 grammar bugs — `''` string escaping, N-ary compound queries, vector literal integers, `NOT IN` operator, version alignment to 3.1.0
- **#387** fix(docs): VelesQL spec gaps — document `NEAR_FUSED`, fix FAQ INSERT/UPDATE/DELETE claims, correct API reference FUSE BY → USING FUSION

Fixes #381, fixes #382, fixes #383, fixes #387

## Changes

- **59 files changed**, +1500 / -240
- **45 conformance test cases** (P001-P045)
- **~50 new regression tests** across validation, recovery, parser, conversion
- All versions aligned: grammar, spec, reference, conformance → 3.1.0

## Validation

- `cargo clippy --workspace --all-targets` → **0 warnings**
- `cargo test --workspace` → **0 failures** (3520+ tests)
- Expert code review (rust-elite-architect): **PASS** on all 4 issues
- Devin review: **8/8 findings addressed** (including critical NOT IN false-positive fix)

## Test plan

- [x] Clippy pedantic workspace: 0 warnings
- [x] Full test suite: 0 failures
- [x] Conformance tests: 45/45 pass
- [x] Recovery tests: gap detection + reopen cycle
- [x] Security tests: path traversal, Unicode, Windows reserved names
- [x] NOT IN false positive regression tests (column named 'not', value 'NOT IN STOCK')
- [x] String escaping round-trip (O''Brien → O'Brien)
- [x] Plan cache includes compound query collection names
