### PR TITLE
docs: fix stale v1.7.2 references in crate READMEs

### DIFF
--- a/crates/velesdb-python/README.md
+++ b/crates/velesdb-python/README.md
@@ -3,9 +3,9 @@
 [![PyPI](https://img.shields.io/pypi/v/velesdb)](https://pypi.org/project/velesdb/)
 [![Python](https://img.shields.io/pypi/pyversions/velesdb)](https://pypi.org/project/velesdb/)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
-[![Version](https://img.shields.io/badge/version-1.7.2-blue)](https://github.com/cyberlife-coder/VelesDB/releases)
+[![Version](https://img.shields.io/badge/version-1.8.0-blue)](https://github.com/cyberlife-coder/VelesDB/releases)
 
-Python bindings for [VelesDB](https://github.com/cyberlife-coder/VelesDB) v1.7.2 - a high-performance vector database for AI applications.
+Python bindings for [VelesDB](https://github.com/cyberlife-coder/VelesDB) v1.8.0 - a high-performance vector database for AI applications.
 
 ## Features
 
@@ -586,7 +586,7 @@ print(graph.edge_count())  # total edges in the graph
 
 ### VelesQL Parser API
 
-VelesDB v1.7.2 exposes the VelesQL parser as a standalone Python API for query
+VelesDB (since v1.7.2) exposes the VelesQL parser as a standalone Python API for query
 introspection, validation, and tooling integration. Parse any VelesQL statement
 into a `ParsedStatement` object and inspect its structure without executing it.
 

--- a/crates/velesdb-server/README.md
+++ b/crates/velesdb-server/README.md
@@ -440,7 +440,7 @@ curl http://localhost:8080/health
 Response:
 
 ```json
-{"status": "ok", "version": "1.7.2"}
+{"status": "ok", "version": "1.8.0"}
 ```
 
 ### `GET /ready` -- Readiness Probe
@@ -454,13 +454,13 @@ curl http://localhost:8080/ready
 Response (ready):
 
 ```json
-{"status": "ready", "version": "1.7.2"}
+{"status": "ready", "version": "1.8.0"}
 ```
 
 Response (not ready):
 
 ```json
-{"status": "not_ready", "version": "1.7.2"}
+{"status": "not_ready", "version": "1.8.0"}
 ```
 
 ### Kubernetes Example

--- a/docs/guides/AGENT_MEMORY.md
+++ b/docs/guides/AGENT_MEMORY.md
@@ -1,6 +1,6 @@
 # Agent Memory SDK - Complete Guide
 
-*Version 1.7.2 -- March 2026*
+*Version 1.8.0 -- March 2026*
 
 Complete guide for using VelesDB's Agent Memory SDK. Covers the three memory subsystems (semantic, episodic, procedural), embedding generation, TTL configuration, snapshots, and production best practices.
 


### PR DESCRIPTION
Pre-release fix: update version badges and examples to v1.8.0 in Python, Server, and Agent Memory docs.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/438" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
