### PR TITLE
fix(migrate): use flush_full() to fix checkpoint resume test

### DIFF
--- a/crates/velesdb-migrate/src/pipeline.rs
+++ b/crates/velesdb-migrate/src/pipeline.rs
@@ -327,8 +327,10 @@ impl Pipeline {
                         stats.loaded += inserted as u64;
                     }
 
+                    // Use flush_full to persist HNSW graph + vectors.idx
+                    // so checkpoint resume finds all previously loaded points.
                     collection
-                        .flush()
+                        .flush_full()
                         .map_err(|e| Error::Loading(e.to_string()))?;
 
                     // Save checkpoint immediately after successful flush, BEFORE


### PR DESCRIPTION
Pipeline.flush() was changed to defer HNSW graph persistence in v1.8.0. This broke checkpoint resume which requires full state on disk. Switch to flush_full().
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/440" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
