### PR TITLE
fix(ci): gate RaBitQ re-exports behind persistence + fix fmt

### DIFF
--- a/crates/velesdb-core/src/quantization/mod.rs
+++ b/crates/velesdb-core/src/quantization/mod.rs
@@ -31,8 +31,10 @@ pub use pq::{PQCodebook, PQVector, ProductQuantizer};
 pub use pq_opq::train_opq;
 
 // Re-export RaBitQ quantization
+#[cfg(feature = "persistence")]
 pub(crate) use rabitq::PreparedQuery;
 pub use rabitq::{RaBitQCorrection, RaBitQIndex, RaBitQVector};
+#[cfg(feature = "persistence")]
 pub(crate) use rabitq_store::RaBitQVectorStore;
 
 // Re-export scalar quantization

--- a/crates/velesdb-server/src/handlers/search/pipeline.rs
+++ b/crates/velesdb-server/src/handlers/search/pipeline.rs
@@ -6,8 +6,8 @@ use velesdb_core::collection::VectorCollection;
 use velesdb_core::index::sparse::DEFAULT_SPARSE_INDEX_NAME;
 
 use crate::types::{
-    mode_to_search_quality, ErrorResponse, IdScoreResult, SearchIdsResponse,
-    SearchRequest, SearchResponse, SearchResultResponse,
+    mode_to_search_quality, ErrorResponse, IdScoreResult, SearchIdsResponse, SearchRequest,
+    SearchResponse, SearchResultResponse,
 };
 use crate::AppState;
 


### PR DESCRIPTION
## Summary
- Gate `PreparedQuery` and `RaBitQVectorStore` re-exports behind `#[cfg(feature = "persistence")]` to fix unused-import errors in WASM conformance CI job
- Fix `cargo fmt` divergence in `pipeline.rs` import ordering

## Test plan
- [x] `cargo check -p velesdb-core --no-default-features` with `-Dwarnings`: 0 errors
- [x] `cargo check -p velesdb-core --features persistence` with `-Dwarnings`: 0 errors
- [x] `cargo check -p velesdb-wasm --no-default-features`: pass
- [x] `cargo fmt --all -- --check`: pass
- [x] `cargo clippy --workspace --all-targets`: 0 warnings
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/441" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
