### PR TITLE
fix(ci): coverage --test-threads=1, flaky streaming test, cargo fmt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -275,7 +275,8 @@ jobs:
           cargo llvm-cov --features persistence,gpu,update-check --workspace \
             --exclude velesdb-python \
             --fail-under-lines 70 \
-            --lcov --output-path lcov.info
+            --lcov --output-path lcov.info \
+            -- --test-threads=1
 
       - uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         continue-on-error: true

--- a/crates/velesdb-core/src/collection/graph_collection.rs
+++ b/crates/velesdb-core/src/collection/graph_collection.rs
@@ -370,8 +370,12 @@ impl GraphCollection {
         similarity_threshold: f32,
         params: &HashMap<String, serde_json::Value>,
     ) -> Result<Vec<crate::collection::search::query::match_exec::MatchResult>> {
-        self.inner
-            .execute_match_with_similarity(match_clause, query_vector, similarity_threshold, params)
+        self.inner.execute_match_with_similarity(
+            match_clause,
+            query_vector,
+            similarity_threshold,
+            params,
+        )
     }
 }
 
@@ -442,10 +446,16 @@ mod tests {
         .unwrap();
 
         // Store node payloads with labels
-        col.upsert_node_payload(10, &serde_json::json!({"_labels": ["Person"], "name": "Alice"}))
-            .unwrap();
-        col.upsert_node_payload(20, &serde_json::json!({"_labels": ["Person"], "name": "Bob"}))
-            .unwrap();
+        col.upsert_node_payload(
+            10,
+            &serde_json::json!({"_labels": ["Person"], "name": "Alice"}),
+        )
+        .unwrap();
+        col.upsert_node_payload(
+            20,
+            &serde_json::json!({"_labels": ["Person"], "name": "Bob"}),
+        )
+        .unwrap();
 
         // Add edge: Alice -> Bob
         let edge = crate::collection::graph::GraphEdge::new(1, 10, 20, "KNOWS").unwrap();
@@ -473,7 +483,10 @@ mod tests {
 
         let params = HashMap::new();
         let results = col.execute_match(&match_clause, &params).unwrap();
-        assert!(!results.is_empty(), "execute_match should find the KNOWS edge");
+        assert!(
+            !results.is_empty(),
+            "execute_match should find the KNOWS edge"
+        );
         assert_eq!(results[0].node_id, 20, "target should be Bob (id=20)");
     }
 }

--- a/crates/velesdb-core/src/collection/search/query/mod.rs
+++ b/crates/velesdb-core/src/collection/search/query/mod.rs
@@ -210,8 +210,7 @@ impl Collection {
         }
 
         // Main vector/similarity/metadata dispatch path.
-        let mut results =
-            self.dispatch_main_select(stmt, params, &extracted, fetch_limit, &ctx)?;
+        let mut results = self.dispatch_main_select(stmt, params, &extracted, fetch_limit, &ctx)?;
 
         // JOIN pushdown analysis (EPIC-031 US-006).
         self.analyze_join_pushdown(stmt);

--- a/crates/velesdb-core/src/collection/streaming/ingester_tests.rs
+++ b/crates/velesdb-core/src/collection/streaming/ingester_tests.rs
@@ -453,17 +453,24 @@ async fn test_stream_delta_rebuild_no_data_loss() {
         tokio::time::sleep(std::time::Duration::from_millis(25)).await;
     }
 
+    // Poll until all 10 points are indexed in HNSW and searchable (max 5s).
+    // Points visible via get() may not yet be in the HNSW index.
     let query = vec![10.0, 0.0, 0.0, 0.0];
-    let results = coll_clone
-        .search_ids(&query, 10)
-        .expect("search_ids should succeed");
-    let found_ids: std::collections::HashSet<u64> = results.iter().map(|sr| sr.id).collect();
-
-    for id in 1..=10 {
+    let search_deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
+    loop {
+        let results = coll_clone
+            .search_ids(&query, 10)
+            .expect("search_ids should succeed");
+        let found_ids: std::collections::HashSet<u64> = results.iter().map(|sr| sr.id).collect();
+        if (1..=10u64).all(|id| found_ids.contains(&id)) {
+            break;
+        }
         assert!(
-            found_ids.contains(&id),
-            "point id={id} should be in search results"
+            tokio::time::Instant::now() < search_deadline,
+            "timed out waiting for all 10 points in search results (found {}/10)",
+            found_ids.len()
         );
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
     }
 
     let drained = coll_clone.delta_buffer.deactivate_and_drain();

--- a/crates/velesdb-python/src/collection/query.rs
+++ b/crates/velesdb-python/src/collection/query.rs
@@ -46,7 +46,10 @@ pub(crate) fn parse_velesql(query_str: &str) -> PyResult<velesdb_core::velesql::
 }
 
 /// Builds an EXPLAIN dict from a parsed VelesQL query.
-pub(crate) fn build_explain_dict(py: Python<'_>, parsed: &velesdb_core::velesql::Query) -> PyObject {
+pub(crate) fn build_explain_dict(
+    py: Python<'_>,
+    parsed: &velesdb_core::velesql::Query,
+) -> PyObject {
     let plan = if let Some(match_clause) = parsed.match_clause.as_ref() {
         let stats =
             velesdb_core::collection::search::query::match_planner::CollectionStats::default();

--- a/crates/velesdb-python/src/graph_collection.rs
+++ b/crates/velesdb-python/src/graph_collection.rs
@@ -399,9 +399,7 @@ impl PyGraphCollection {
                 .map_err(core_err)
         })?;
 
-        Ok(crate::collection_helpers::search_results_to_multimodel_dicts(
-            py, results,
-        ))
+        Ok(crate::collection_helpers::search_results_to_multimodel_dicts(py, results))
     }
 
     /// Execute a MATCH graph traversal query.
@@ -435,9 +433,7 @@ impl PyGraphCollection {
         let match_clause = parsed
             .match_clause
             .as_ref()
-            .ok_or_else(|| {
-                pyo3::exceptions::PyValueError::new_err("Query is not a MATCH query")
-            })?
+            .ok_or_else(|| pyo3::exceptions::PyValueError::new_err("Query is not a MATCH query"))?
             .clone();
 
         let rust_params = convert_params(py, params)?;
@@ -446,12 +442,7 @@ impl PyGraphCollection {
         let results = py.allow_threads(|| {
             if let Some(ref qv) = query_vector {
                 self.inner
-                    .execute_match_with_similarity(
-                        &match_clause,
-                        qv,
-                        threshold,
-                        &rust_params,
-                    )
+                    .execute_match_with_similarity(&match_clause, qv, threshold, &rust_params)
                     .map_err(core_err)
             } else {
                 self.inner


### PR DESCRIPTION
## Summary

- Add `--test-threads=1` to `cargo llvm-cov` in CI coverage job (was running tests in parallel causing file system races in `test_stream_delta_rebuild_no_data_loss`)
- Fix flaky test: poll `search_ids` with deadline instead of single assertion (HNSW index may lag behind storage flush)
- Apply `cargo fmt` to files from v1.9.3 release

## Test plan

- [ ] CI Code Coverage job passes
- [ ] Lint & Format passes
- [ ] No test regressions

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/460" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
