### PR TITLE
fix(doctest): remove extra arg from hybrid_search example

### DIFF
--- a/crates/velesdb-core/src/lib.rs
+++ b/crates/velesdb-core/src/lib.rs
@@ -39,7 +39,7 @@
 //!     let results = collection.search(&query_vector, 10)?;
 //!
 //!     // Hybrid search (vector + text)
-//!     let hybrid = collection.hybrid_search(&query_vector, "hello", 5, Some(0.7), None)?;
+//!     let hybrid = collection.hybrid_search(&query_vector, "hello", 5, Some(0.7))?;
 //!     # Ok(())
 //! }
 //! ```


### PR DESCRIPTION
## Summary
lib.rs doctest called `hybrid_search` with 5 args but `VectorCollection::hybrid_search` takes 4 (rrf_k is not exposed in the typed API). Removed the extra `None`.

Fixes Release pre-publish validation failure.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/481" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
