### PR TITLE
Add multi-query fusion tutorial (5 strategies, quality modes)

### DIFF
--- a/examples/tutorials/multi_query_fusion_demo.py
+++ b/examples/tutorials/multi_query_fusion_demo.py
@@ -15,9 +15,11 @@ Article: "One query is never enough: why top RAG systems search three times"
 Requirements:
     pip install velesdb sentence-transformers
 """
-import velesdb
+import atexit
 import shutil
 import os
+
+import velesdb
 from sentence_transformers import SentenceTransformer
 
 # ============================================================
@@ -27,6 +29,9 @@ DB_PATH = "./multi_query_demo"
 
 if os.path.exists(DB_PATH):
     shutil.rmtree(DB_PATH)
+
+# Ensure cleanup even if the script crashes mid-way
+atexit.register(lambda: shutil.rmtree(DB_PATH, ignore_errors=True))
 
 db = velesdb.Database(DB_PATH)
 model = SentenceTransformer("all-MiniLM-L6-v2")
@@ -166,18 +171,18 @@ for r in results:
 # 4. Compare all fusion strategies
 # ============================================================
 print(f"\n{'=' * 60}")
-print("STEP 4: Five fusion strategies compared")
+print("STEP 4: Fusion strategies compared")
 print("=" * 60)
 
-strategies = {
+# These 4 strategies support N vectors (multi-query dense fusion)
+multi_query_strategies = {
     "rrf": velesdb.FusionStrategy.rrf(),
     "average": velesdb.FusionStrategy.average(),
     "maximum": velesdb.FusionStrategy.maximum(),
-    "relative_score": velesdb.FusionStrategy.relative_score(0.7, 0.3),
     "weighted": velesdb.FusionStrategy.weighted(0.6, 0.3, 0.1),
 }
 
-for name, strategy in strategies.items():
+for name, strategy in multi_query_strategies.items():
     results = collection.multi_query_search(
         vectors=[q1, q2, q3],
         top_k=3,
@@ -190,6 +195,19 @@ for name, strategy in strategies.items():
     print(f"\n  {name}:")
     for t in titles:
         print(f"    - {t}")
+
+# RelativeScore is designed for exactly 2 branches (dense + sparse).
+# With 3+ vectors, branches beyond index 1 are silently discarded.
+# Demo it separately with 2 vectors to show correct usage.
+print("\n  relative_score (2 vectors — dense+sparse design):")
+results = collection.multi_query_search(
+    vectors=[q1, q2],
+    top_k=3,
+    fusion=velesdb.FusionStrategy.relative_score(0.7, 0.3),
+)
+for r in results:
+    title = r.get("payload", r.get("bindings", {}))["title"][:50]
+    print(f"    - {title}")
 
 
 # ============================================================


### PR DESCRIPTION
## Description

Companion script for the Dev.to article **"One query is never enough: why top RAG systems search three times"**.

Demonstrates single-query blind spots in vector retrieval and how multi-query fusion fixes them using a 12-doc technical documentation corpus (Flask, database, performance domains).

## Type of Change

- [x] Documentation update

## How Has This Been Tested?

- [x] Integration tests (test_article_multi_query_fusion.py)
- [x] Manual testing with VelesDB v1.10.0 + sentence-transformers

**Test Configuration:**
- OS: Windows
- Python: 3.11
- VelesDB: 1.10.0
- sentence-transformers: all-MiniLM-L6-v2

## Features demonstrated

- `collection.search()` single-query retrieval
- `collection.multi_query_search()` with 5 FusionStrategy (rrf, average, maximum, relative_score, weighted)
- `collection.search_with_quality()` with fast/balanced/accurate modes

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/484" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
