### PR TITLE
refactor: align tutorial naming with article (Bouncer/Detective)

### DIFF
--- a/examples/tutorials/image_search_hamming_clip.py
+++ b/examples/tutorials/image_search_hamming_clip.py
@@ -1,9 +1,11 @@
 """
 VelesDB Tutorial: Two-Pass Image Search with Hamming + CLIP
 
-Find duplicate and similar photos in 0.3ms using a combined pipeline:
-  Pass 1 - Perceptual hashing (dHash) + Hamming distance for fast shortlisting
-  Pass 2 - CLIP embeddings + Euclidean distance for semantic re-ranking
+The Bouncer and the Detective:
+  Pass 1 - The Bouncer (dHash barcodes + Hamming distance) for fast shortlisting
+  Pass 2 - The Detective (CLIP meaning + Euclidean distance) for semantic re-ranking
+
+Find duplicate and similar photos in 0.3ms using a combined pipeline.
 
 Requirements:
     pip install velesdb Pillow imagehash numpy open-clip-torch torch
@@ -39,36 +41,36 @@ import velesdb
 
 PHOTO_DIR = os.environ.get("PHOTO_DIR", "./demo_photos")
 DB_DIR = os.environ.get("DB_DIR", "./velesdb_image_search")
-HASH_SIZE = 16  # dHash dimension: 16x16 = 256-bit vector
+HASH_SIZE = 16  # dHash dimension: 16x16 = 256-bit barcode
 CLIP_DIM = 512  # ViT-B-32 output dimension
 SHORTLIST_K = 10  # Pass 1 candidates
 FINAL_K = 5  # Final results
 
 
 # ---------------------------------------------------------------------------
-# Step 1: Perceptual hashing (dHash) - binary fingerprint per image
+# Step 1: The Bouncer - perceptual hashing (dHash) as binary barcodes
 # ---------------------------------------------------------------------------
 
-def dhash_vector(img_path: str, hash_size: int = HASH_SIZE) -> list[float]:
-    """Compute a dHash perceptual hash and return it as a binary vector.
+def compute_barcode(img_path: str, hash_size: int = HASH_SIZE) -> list[float]:
+    """Turn an image into a binary barcode for the Bouncer.
 
     dHash (difference hash) works by:
-      1. Resizing the image to (hash_size+1) x hash_size grayscale
-      2. Comparing adjacent pixel intensities left-to-right
-      3. Producing a binary vector: 1 if left > right, else 0
+      1. Shrinking the image to a (hash_size+1) x hash_size grayscale grid
+      2. Comparing each square to its right neighbor: darker = 1, else 0
+      3. Producing a 256-bit barcode: [1, 0, 1, 1, 0, 0, 1, ...]
 
-    The result is invariant to resizing, minor cropping, and compression.
+    The barcode barely changes when you resize, crop slightly, or compress.
     """
     img = Image.open(img_path)
     h = imagehash.dhash(img, hash_size=hash_size)
     return [float(b) for b in h.hash.flatten()]
 
 
-def index_hashes(db: velesdb.Database, photo_dir: str) -> tuple:
-    """Index all images in photo_dir with dHash into a Hamming collection."""
-    hash_dim = HASH_SIZE * HASH_SIZE  # 256
-    hash_col = db.get_or_create_collection(
-        "perceptual_hashes", dimension=hash_dim, metric="hamming"
+def index_barcodes(db: velesdb.Database, photo_dir: str) -> tuple:
+    """Index all images with dHash barcodes into the Bouncer's Hamming collection."""
+    barcode_dim = HASH_SIZE * HASH_SIZE  # 256
+    bouncer = db.get_or_create_collection(
+        "perceptual_hashes", dimension=barcode_dim, metric="hamming"
     )
 
     files = sorted(
@@ -82,20 +84,20 @@ def index_hashes(db: velesdb.Database, photo_dir: str) -> tuple:
     t0 = time.time()
     for i, fname in enumerate(files):
         path = os.path.join(photo_dir, fname)
-        vec = dhash_vector(path)
-        hash_col.upsert(i + 1, vector=vec, payload={"filename": fname, "path": path})
+        vec = compute_barcode(path)
+        bouncer.upsert(i + 1, vector=vec, payload={"filename": fname, "path": path})
     elapsed_ms = (time.time() - t0) * 1000
 
-    print(f"  Indexed {len(files)} perceptual hashes in {elapsed_ms:.1f}ms")
-    return hash_col, files
+    print(f"  Indexed {len(files)} barcodes in {elapsed_ms:.1f}ms")
+    return bouncer, files
 
 
 # ---------------------------------------------------------------------------
-# Step 2: CLIP embeddings - semantic understanding per image
+# Step 2: The Detective - CLIP embeddings as a map of meaning
 # ---------------------------------------------------------------------------
 
 def load_clip_model():
-    """Load CLIP ViT-B-32 model for image embedding."""
+    """Load CLIP ViT-B-32 model for the Detective's semantic map."""
     try:
         import open_clip
         import torch
@@ -111,12 +113,12 @@ def load_clip_model():
     return model, preprocess
 
 
-def clip_embedding(img_path: str, model, preprocess) -> list[float]:
-    """Compute a normalized CLIP embedding for an image.
+def compute_meaning(img_path: str, model, preprocess) -> list[float]:
+    """Place an image on the Detective's map of meaning.
 
     CLIP (Contrastive Language-Image Pre-training) encodes images and text
-    into a shared 512-dimensional space. Two images with similar semantic
-    content will have embeddings close together, even if their pixels differ.
+    into a shared 512-dimensional semantic space. Two images with similar
+    meaning will be close together, even if their pixels are completely different.
     """
     import torch
 
@@ -128,81 +130,80 @@ def clip_embedding(img_path: str, model, preprocess) -> list[float]:
         return features.squeeze().numpy().tolist()
 
 
-def index_clip(db: velesdb.Database, photo_dir: str, files: list, model, preprocess) -> tuple:
-    """Index all images with CLIP embeddings into a Euclidean collection."""
-    clip_col = db.get_or_create_collection(
+def index_meanings(db: velesdb.Database, photo_dir: str, files: list, model, preprocess) -> tuple:
+    """Index all images with CLIP embeddings into the Detective's Euclidean collection."""
+    detective = db.get_or_create_collection(
         "clip_features", dimension=CLIP_DIM, metric="euclidean"
     )
 
     t0 = time.time()
     for i, fname in enumerate(files):
         path = os.path.join(photo_dir, fname)
-        emb = clip_embedding(path, model, preprocess)
-        clip_col.upsert(i + 1, vector=emb, payload={"filename": fname, "path": path})
+        emb = compute_meaning(path, model, preprocess)
+        detective.upsert(i + 1, vector=emb, payload={"filename": fname, "path": path})
     elapsed = time.time() - t0
 
-    print(f"  Indexed {len(files)} CLIP embeddings in {elapsed:.1f}s")
-    return clip_col
+    print(f"  Indexed {len(files)} meanings in {elapsed:.1f}s")
+    return detective
 
 
 # ---------------------------------------------------------------------------
-# Step 3: Two-pass search pipeline
+# Step 3: Two-pass search - Bouncer filters, Detective re-ranks
 # ---------------------------------------------------------------------------
 
-def two_pass_search(
+def find_similar(
     query_path: str,
-    hash_col,
-    clip_col,
+    bouncer,
+    detective,
     model,
     preprocess,
     shortlist_k: int = SHORTLIST_K,
     final_k: int = FINAL_K,
 ) -> dict:
-    """Execute a two-pass image similarity search.
+    """Two-pass search: Bouncer filters, Detective re-ranks.
 
-    Pass 1 (Hamming): ultra-fast shortlisting using perceptual hashes.
-        Finds visually similar images by counting differing bits.
-        Typical latency: < 0.1ms.
+    Pass 1 (Hamming): The Bouncer looks at barcodes for one second.
+        Catches obvious fakes instantly. Ultra-fast (< 0.1ms).
 
-    Pass 2 (CLIP + Euclidean): semantic re-ranking of shortlist.
-        Re-scores candidates by semantic similarity using neural embeddings.
-        Euclidean distance on normalized vectors is equivalent to cosine ranking.
-        Typical latency: < 0.5ms (search only, not encoding).
+    Pass 2 (CLIP + Euclidean): The Detective runs a thorough investigation.
+        ONE single CLIP query, then joins scores. Not N queries.
+        This is what makes it scale.
 
     Returns a dict with timings and results for each pass.
     """
-    # -- Pass 1: Hamming shortlist --
-    query_hash = dhash_vector(query_path)
+    # --- Pass 1: The Bouncer (instant) ---
+    query_barcode = compute_barcode(query_path)
     t0 = time.time()
-    candidates = hash_col.search(vector=query_hash, top_k=shortlist_k)
-    pass1_ms = (time.time() - t0) * 1000
+    fast_candidates = bouncer.search(vector=query_barcode, top_k=shortlist_k)
+    bouncer_ms = (time.time() - t0) * 1000
 
-    # -- Pass 2: CLIP re-ranking --
-    query_clip = clip_embedding(query_path, model, preprocess)
+    # --- Pass 2: The Detective (thorough) ---
+    # ONE single CLIP query. Not N. This is what makes it scale.
+    query_meaning = compute_meaning(query_path, model, preprocess)
     t0 = time.time()
-    candidate_ids = {c["id"] for c in candidates}
-    clip_results = clip_col.search(vector=query_clip, top_k=shortlist_k * 2)
-    clip_scores = {r["id"]: r["score"] for r in clip_results}
+    all_meanings = detective.search(vector=query_meaning, top_k=shortlist_k * 2)
+    meaning_scores = {r["id"]: r["score"] for r in all_meanings}
 
+    # Re-rank the Bouncer's shortlist with the Detective's scores
     reranked = []
-    for c in candidates:
+    for c in fast_candidates:
         reranked.append({
             "id": c["id"],
             "filename": c["payload"]["filename"],
-            "hamming_distance": c["score"],
-            "clip_distance": clip_scores.get(c["id"], float("inf")),
+            "bouncer": c["score"],
+            "detective": meaning_scores.get(c["id"], float("inf")),
         })
-    reranked.sort(key=lambda x: x["clip_distance"])
-    pass2_ms = (time.time() - t0) * 1000
+    reranked.sort(key=lambda x: x["detective"])
+    detective_ms = (time.time() - t0) * 1000
 
     return {
         "query": os.path.basename(query_path),
-        "pass1_ms": pass1_ms,
-        "pass2_ms": pass2_ms,
-        "total_ms": pass1_ms + pass2_ms,
-        "hamming_results": [
+        "bouncer_ms": bouncer_ms,
+        "detective_ms": detective_ms,
+        "total_ms": bouncer_ms + detective_ms,
+        "bouncer_results": [
             {"filename": c["payload"]["filename"], "distance": c["score"]}
-            for c in candidates[:final_k]
+            for c in fast_candidates[:final_k]
         ],
         "combined_results": reranked[:final_k],
     }
@@ -233,8 +234,8 @@ def generate_html_report(results: dict, photo_dir: str, output_path: str):
                 <img src="data:image/jpeg;base64,{b64}"
                      style="border-radius:6px;max-width:150px;" /><br/>
                 <b style="color:#cdd6f4;">{r['filename']}</b><br/>
-                <span style="color:#89b4fa;">Hamming: {r['hamming_distance']}</span><br/>
-                <span style="color:#a6e3a1;">CLIP L2: {r['clip_distance']:.4f}</span>
+                <span style="color:#89b4fa;">Bouncer: {r['bouncer']}</span><br/>
+                <span style="color:#a6e3a1;">Detective: {r['detective']:.4f}</span>
             </div>"""
 
     html = f"""<!DOCTYPE html>
@@ -254,10 +255,10 @@ def generate_html_report(results: dict, photo_dir: str, output_path: str):
 <body>
     <h1>Two-Pass Image Search Results</h1>
     <p>Query: <b>{results['query']}</b></p>
-    <span class="badge fast">Pass 1 (Hamming): {results['pass1_ms']:.2f}ms</span>
-    <span class="badge fast">Pass 2 (CLIP): {results['pass2_ms']:.2f}ms</span>
+    <span class="badge fast">Bouncer (Hamming): {results['bouncer_ms']:.2f}ms</span>
+    <span class="badge fast">Detective (CLIP): {results['detective_ms']:.2f}ms</span>
     <span class="badge info">Total: {results['total_ms']:.2f}ms</span>
-    <h2 style="color:#f9e2af;">Combined Results (re-ranked by CLIP)</h2>
+    <h2 style="color:#f9e2af;">Combined Results (re-ranked by Detective)</h2>
     {cards_html}
     <hr style="border-color:#313244;margin-top:2rem;"/>
     <p style="color:#6c7086;font-size:0.8rem;">
@@ -301,7 +302,7 @@ def download_demo_images(photo_dir: str):
 
 def main():
     print("\n" + "=" * 60)
-    print("VelesDB Two-Pass Image Search Pipeline")
+    print("VelesDB Two-Pass Image Search: The Bouncer and the Detective")
     print("=" * 60)
 
     # Use demo images or point PHOTO_DIR to your own photos
@@ -313,31 +314,31 @@ def main():
     shutil.rmtree(DB_DIR, ignore_errors=True)
     db = velesdb.Database(DB_DIR)
 
-    # Step 1: Index perceptual hashes
-    print("\nStep 1: Indexing perceptual hashes (dHash + Hamming)")
-    hash_col, files = index_hashes(db, PHOTO_DIR)
+    # Step 1: Give the Bouncer his barcodes
+    print("\nStep 1: The Bouncer indexes barcodes (dHash + Hamming)")
+    bouncer, files = index_barcodes(db, PHOTO_DIR)
 
-    # Step 2: Index CLIP embeddings
-    print("\nStep 2: Indexing CLIP embeddings (ViT-B-32 + Euclidean)")
+    # Step 2: Give the Detective his map
+    print("\nStep 2: The Detective builds his map of meaning (CLIP + Euclidean)")
     model, preprocess = load_clip_model()
-    clip_col = index_clip(db, PHOTO_DIR, files, model, preprocess)
+    detective = index_meanings(db, PHOTO_DIR, files, model, preprocess)
 
     # Step 3: Two-pass search
     query = os.path.join(PHOTO_DIR, "beach_1.jpg")
     print(f"\nStep 3: Two-pass search for '{os.path.basename(query)}'")
-    results = two_pass_search(query, hash_col, clip_col, model, preprocess)
+    results = find_similar(query, bouncer, detective, model, preprocess)
 
     # Display results
-    print(f"\n  Pass 1 (Hamming shortlist): {results['pass1_ms']:.2f}ms")
-    for r in results["hamming_results"]:
+    print(f"\n  Bouncer (Hamming shortlist): {results['bouncer_ms']:.2f}ms")
+    for r in results["bouncer_results"]:
         print(f"    {r['filename']:25s}  distance={r['distance']}")
 
-    print(f"\n  Pass 2 (CLIP re-ranked):    {results['pass2_ms']:.2f}ms")
+    print(f"\n  Detective (CLIP re-ranked):  {results['detective_ms']:.2f}ms")
     for r in results["combined_results"]:
         print(
             f"    {r['filename']:25s}  "
-            f"hamming={r['hamming_distance']}  "
-            f"clip_l2={r['clip_distance']:.4f}"
+            f"bouncer={r['bouncer']}  "
+            f"detective={r['detective']:.4f}"
         )
 
     print(f"\n  Total pipeline: {results['total_ms']:.2f}ms")

--- a/examples/tutorials/test_image_search_hamming_clip.py
+++ b/examples/tutorials/test_image_search_hamming_clip.py
@@ -59,37 +59,38 @@ def cleanup():
     shutil.rmtree(PHOTO_DIR, ignore_errors=True)
 
 
-def dhash_vector(img_path, hash_size=HASH_SIZE):
+def compute_barcode(img_path, hash_size=HASH_SIZE):
+    """Turn an image into a binary barcode for the Bouncer."""
     img = Image.open(img_path)
     h = imagehash.dhash(img, hash_size=hash_size)
     return [float(b) for b in h.hash.flatten()]
 
 
 # ---------------------------------------------------------------------------
-# Test 1: dHash + Hamming collection
+# Test 1: Bouncer - dHash barcodes + Hamming collection
 # ---------------------------------------------------------------------------
 
-def test_dhash_hamming():
-    """Perceptual hash indexing and Hamming search produce correct results."""
+def test_bouncer_hamming():
+    """The Bouncer indexes barcodes and Hamming search finds near-duplicates."""
     shutil.rmtree(DB_DIR, ignore_errors=True)
     files = setup_test_images()
     db = velesdb.Database(DB_DIR)
 
-    hash_dim = HASH_SIZE * HASH_SIZE
-    hash_col = db.get_or_create_collection(
-        "perceptual_hashes", dimension=hash_dim, metric="hamming"
+    barcode_dim = HASH_SIZE * HASH_SIZE
+    bouncer = db.get_or_create_collection(
+        "perceptual_hashes", dimension=barcode_dim, metric="hamming"
     )
 
     for i, fname in enumerate(files):
         path = os.path.join(PHOTO_DIR, fname)
-        vec = dhash_vector(path)
-        assert len(vec) == hash_dim
-        assert all(v in (0.0, 1.0) for v in vec), "Hash must be binary"
-        hash_col.upsert(i + 1, vector=vec, payload={"filename": fname, "path": path})
+        vec = compute_barcode(path)
+        assert len(vec) == barcode_dim
+        assert all(v in (0.0, 1.0) for v in vec), "Barcode must be binary"
+        bouncer.upsert(i + 1, vector=vec, payload={"filename": fname, "path": path})
 
     # Search for beach_1
     query_path = os.path.join(PHOTO_DIR, "beach_1.jpg")
-    results = hash_col.search(vector=dhash_vector(query_path), top_k=5)
+    results = bouncer.search(vector=compute_barcode(query_path), top_k=5)
 
     assert len(results) == 5
     assert results[0]["payload"]["filename"] == "beach_1.jpg"
@@ -98,16 +99,16 @@ def test_dhash_hamming():
     top3 = [r["payload"]["filename"] for r in results[:3]]
     assert "beach_1_small.jpg" in top3, f"Near-duplicate not found in top 3: {top3}"
 
-    print("  [PASS] dHash + Hamming: correct indexing and search")
-    return db, hash_col, files
+    print("  [PASS] Bouncer (dHash + Hamming): correct indexing and search")
+    return db, bouncer, files
 
 
 # ---------------------------------------------------------------------------
-# Test 2: CLIP + Euclidean collection
+# Test 2: Detective - CLIP meanings + Euclidean collection
 # ---------------------------------------------------------------------------
 
-def test_clip_euclidean(db, files):
-    """CLIP embedding indexing and Euclidean search produce correct results."""
+def test_detective_euclidean(db, files):
+    """The Detective indexes meanings and Euclidean search ranks semantically."""
     try:
         import open_clip
         import torch
@@ -120,7 +121,8 @@ def test_clip_euclidean(db, files):
     )
     model.eval()
 
-    def clip_emb(img_path):
+    def compute_meaning(img_path):
+        """Place an image on the Detective's map of meaning."""
         img = Image.open(img_path).convert("RGB")
         with torch.no_grad():
             t = preprocess(img).unsqueeze(0)
@@ -128,18 +130,18 @@ def test_clip_euclidean(db, files):
             f /= f.norm(dim=-1, keepdim=True)
             return f.squeeze().numpy().tolist()
 
-    clip_col = db.get_or_create_collection(
+    detective = db.get_or_create_collection(
         "clip_features", dimension=512, metric="euclidean"
     )
 
     for i, fname in enumerate(files):
         path = os.path.join(PHOTO_DIR, fname)
-        emb = clip_emb(path)
+        emb = compute_meaning(path)
         assert len(emb) == 512
-        clip_col.upsert(i + 1, vector=emb, payload={"filename": fname, "path": path})
+        detective.upsert(i + 1, vector=emb, payload={"filename": fname, "path": path})
 
     query_path = os.path.join(PHOTO_DIR, "beach_1.jpg")
-    results = clip_col.search(vector=clip_emb(query_path), top_k=5)
+    results = detective.search(vector=compute_meaning(query_path), top_k=5)
 
     assert len(results) == 5
     assert results[0]["payload"]["filename"] == "beach_1.jpg"
@@ -148,48 +150,48 @@ def test_clip_euclidean(db, files):
     top3 = [r["payload"]["filename"] for r in results[:3]]
     assert "beach_1_square.jpg" in top3, f"Semantic match not in top 3: {top3}"
 
-    print("  [PASS] CLIP + Euclidean: correct semantic ranking")
-    return clip_col, clip_emb
+    print("  [PASS] Detective (CLIP + Euclidean): correct semantic ranking")
+    return detective, compute_meaning
 
 
 # ---------------------------------------------------------------------------
-# Test 3: Combined two-pass pipeline
+# Test 3: Combined two-pass pipeline (Bouncer + Detective)
 # ---------------------------------------------------------------------------
 
-def test_combined_pipeline(hash_col, clip_col, clip_emb_fn, files):
+def test_combined_pipeline(bouncer, detective, compute_meaning_fn, files):
     """Two-pass pipeline completes under 100ms and produces valid re-ranking."""
     query_path = os.path.join(PHOTO_DIR, "beach_1.jpg")
 
-    # Pass 1: Hamming
+    # Pass 1: The Bouncer
     t0 = time.time()
-    candidates = hash_col.search(vector=dhash_vector(query_path), top_k=8)
-    pass1_ms = (time.time() - t0) * 1000
+    fast_candidates = bouncer.search(vector=compute_barcode(query_path), top_k=8)
+    bouncer_ms = (time.time() - t0) * 1000
 
-    # Pass 2: CLIP re-ranking
-    query_clip = clip_emb_fn(query_path)
+    # Pass 2: The Detective re-ranks
+    query_meaning = compute_meaning_fn(query_path)
     t0 = time.time()
-    clip_all = clip_col.search(vector=query_clip, top_k=len(files))
-    clip_by_id = {r["id"]: r["score"] for r in clip_all}
+    all_meanings = detective.search(vector=query_meaning, top_k=len(files))
+    meaning_scores = {r["id"]: r["score"] for r in all_meanings}
 
     reranked = sorted(
         [
             {
                 "id": c["id"],
                 "filename": c["payload"]["filename"],
-                "hamming": c["score"],
-                "clip_dist": clip_by_id.get(c["id"], float("inf")),
+                "bouncer": c["score"],
+                "detective": meaning_scores.get(c["id"], float("inf")),
             }
-            for c in candidates
+            for c in fast_candidates
         ],
-        key=lambda x: x["clip_dist"],
+        key=lambda x: x["detective"],
     )
-    pass2_ms = (time.time() - t0) * 1000
+    detective_ms = (time.time() - t0) * 1000
 
-    total = pass1_ms + pass2_ms
+    total = bouncer_ms + detective_ms
     assert total < 100, f"Pipeline too slow: {total:.1f}ms"
     assert reranked[0]["filename"] == "beach_1.jpg"
 
-    print(f"  [PASS] Combined pipeline: {total:.2f}ms (p1={pass1_ms:.2f}, p2={pass2_ms:.2f})")
+    print(f"  [PASS] Combined pipeline: {total:.2f}ms (bouncer={bouncer_ms:.2f}, detective={detective_ms:.2f})")
 
 
 # ---------------------------------------------------------------------------
@@ -246,16 +248,16 @@ if __name__ == "__main__":
     files = setup_test_images()
     print(f"  {len(files)} images ready\n")
 
-    print("Test 1: dHash + Hamming")
-    db, hash_col, files = test_dhash_hamming()
+    print("Test 1: Bouncer (dHash + Hamming)")
+    db, bouncer, files = test_bouncer_hamming()
 
-    print("\nTest 2: CLIP + Euclidean")
-    result = test_clip_euclidean(db, files)
+    print("\nTest 2: Detective (CLIP + Euclidean)")
+    result = test_detective_euclidean(db, files)
 
     if result:
-        clip_col, clip_fn = result
-        print("\nTest 3: Two-pass pipeline")
-        test_combined_pipeline(hash_col, clip_col, clip_fn, files)
+        detective, compute_meaning_fn = result
+        print("\nTest 3: Two-pass pipeline (Bouncer + Detective)")
+        test_combined_pipeline(bouncer, detective, compute_meaning_fn, files)
 
     print("\nTest 4: All article metrics")
     test_all_metrics()


### PR DESCRIPTION
Align tutorial code with the published Dev.to article naming convention.

Renames:
- `dhash_vector` -> `compute_barcode`
- `index_hashes` -> `index_barcodes`
- `hash_col` -> `bouncer`
- `clip_embedding` -> `compute_meaning`
- `index_clip` -> `index_meanings`
- `clip_col` -> `detective`
- `two_pass_search` -> `find_similar`
- `candidates` -> `fast_candidates`
- `clip_scores` -> `meaning_scores`

All 5 tests pass against VelesDB v1.11.0.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/507" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
