### PR TITLE
feat(migrate): SSRF protection, Redis RESP natif, migration graph, corrections review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **BDD tests** — 14 new BDD tests for `AnyCollection` dispatch, persistence round-trip,
   typed registry integrity, and edge cases.
 
+### Added (migrate)
+- **Graph migration stats surfaced** — `MigrationStats` now includes `edges_created`,
+  `edges_failed`, and `relations_processed` from the graph migration phase. The wizard
+  success output displays these fields when a graph phase ran.
+- **`GraphMigrationPhase::close()`** — explicit connector close method; called after
+  `run()` in the pipeline for proper resource cleanup.
+- **Empty-batch guard in graph extraction loop** — prevents infinite loop when a
+  cursor-based connector returns `has_more=true` with an empty batch.
+- **Milvus `usize::try_from()` cast** — consistent with ChromaDB, replaces `as usize`
+  truncating cast with an explicit `try_from().unwrap_or(usize::MAX)`.
+
 ### Fixed
 - **LET bindings in SELECT projection (Issue #473)** — LET binding values now injected into
   result payloads during post-processing. LET bindings take precedence over payload fields

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -774,7 +774,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
+ "futures-core",
  "memchr",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -2481,7 +2485,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.3",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -3329,6 +3333,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -4431,6 +4445,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "redis"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e902a69d09078829137b4a5d9d082e0490393537badd7c91a3d69d14639e115f"
+dependencies = [
+ "arc-swap",
+ "async-trait",
+ "bytes",
+ "combine",
+ "futures-util",
+ "itoa",
+ "num-bigint",
+ "percent-encoding",
+ "pin-project-lite",
+ "ryu",
+ "sha1_smol",
+ "socket2 0.5.10",
+ "tokio",
+ "tokio-util",
+ "url",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5235,6 +5272,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1_smol"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5333,6 +5376,16 @@ name = "smawk"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
+
+[[package]]
+name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "socket2"
@@ -6136,7 +6189,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.3",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -6895,6 +6948,7 @@ dependencies = [
  "criterion",
  "dialoguer",
  "indicatif",
+ "redis",
  "reqwest 0.12.28",
  "serde",
  "serde_json",

--- a/crates/velesdb-core/src/filter/matching.rs
+++ b/crates/velesdb-core/src/filter/matching.rs
@@ -76,9 +76,7 @@ impl Condition {
                 let point_lng = v.get("lng").and_then(Value::as_f64);
                 match (point_lat, point_lng) {
                     (Some(plat), Some(plng)) => {
-                        let dist = crate::column_store::haversine::haversine_distance(
-                            plat, plng, *lat, *lng,
-                        );
+                        let dist = haversine_distance_km(plat, plng, *lat, *lng);
                         compare_geo_distance(dist, *threshold, *operator)
                     }
                     _ => false,
@@ -241,6 +239,20 @@ fn like_match_impl(text: &[u8], pattern: &[u8]) -> bool {
     }
 
     prev[n]
+}
+
+/// Haversine great-circle distance. Returns distance in meters (WGS-84 mean radius).
+///
+/// Kept local so this module compiles without the `persistence` feature
+/// (which gates `column_store::haversine`).
+fn haversine_distance_km(lat1: f64, lng1: f64, lat2: f64, lng2: f64) -> f64 {
+    const EARTH_RADIUS_M: f64 = 6_371_000.0;
+    let (lat1, lng1) = (lat1.to_radians(), lng1.to_radians());
+    let (lat2, lng2) = (lat2.to_radians(), lng2.to_radians());
+    let dlat = lat2 - lat1;
+    let dlng = lng2 - lng1;
+    let a = (dlat / 2.0).sin().powi(2) + lat1.cos() * lat2.cos() * (dlng / 2.0).sin().powi(2);
+    EARTH_RADIUS_M * 2.0 * a.sqrt().atan2((1.0 - a).sqrt())
 }
 
 /// Applies a comparison operator to a geo-distance value and threshold.

--- a/crates/velesdb-core/src/filter/matching.rs
+++ b/crates/velesdb-core/src/filter/matching.rs
@@ -76,7 +76,7 @@ impl Condition {
                 let point_lng = v.get("lng").and_then(Value::as_f64);
                 match (point_lat, point_lng) {
                     (Some(plat), Some(plng)) => {
-                        let dist = haversine_distance_km(plat, plng, *lat, *lng);
+                        let dist = haversine_distance_m(plat, plng, *lat, *lng);
                         compare_geo_distance(dist, *threshold, *operator)
                     }
                     _ => false,
@@ -241,11 +241,11 @@ fn like_match_impl(text: &[u8], pattern: &[u8]) -> bool {
     prev[n]
 }
 
-/// Haversine great-circle distance. Returns distance in meters (WGS-84 mean radius).
+/// Haversine great-circle distance. Returns distance in **meters** (WGS-84 mean radius).
 ///
 /// Kept local so this module compiles without the `persistence` feature
 /// (which gates `column_store::haversine`).
-fn haversine_distance_km(lat1: f64, lng1: f64, lat2: f64, lng2: f64) -> f64 {
+fn haversine_distance_m(lat1: f64, lng1: f64, lat2: f64, lng2: f64) -> f64 {
     const EARTH_RADIUS_M: f64 = 6_371_000.0;
     let (lat1, lng1) = (lat1.to_radians(), lng1.to_radians());
     let (lat2, lng2) = (lat2.to_radians(), lng2.to_radians());

--- a/crates/velesdb-migrate/Cargo.toml
+++ b/crates/velesdb-migrate/Cargo.toml
@@ -40,6 +40,9 @@ reqwest = { version = "0.12", features = ["json", "native-tls"], default-feature
 # Database clients
 sqlx = { version = "0.8", features = ["runtime-tokio", "postgres", "json"], default-features = false, optional = true }
 
+# Native RESP client for Redis Stack / RediSearch
+redis = { version = "0.26", features = ["tokio-comp", "aio"], optional = true }
+
 # Config parsing
 serde_yaml = "0.9"
 
@@ -70,14 +73,15 @@ name = "migration_benchmark"
 harness = false
 
 [features]
-default = ["postgres", "velesdb-core/default"]
+default = ["postgres", "redis-source", "velesdb-core/default"]
 postgres = ["sqlx"]
-all-sources = ["postgres"]
+redis-source = ["dep:redis"]
+all-sources = ["postgres", "redis-source"]
 loom = ["velesdb-core/loom"]
 
 # sqlx is optional behind "postgres" feature flag — cargo-machete can't detect it
 [package.metadata.cargo-machete]
-ignored = ["sqlx"]
+ignored = ["sqlx", "redis"]
 
 [lints]
 workspace = true

--- a/crates/velesdb-migrate/src/config.rs
+++ b/crates/velesdb-migrate/src/config.rs
@@ -14,6 +14,9 @@ pub struct MigrationConfig {
     /// Migration options.
     #[serde(default)]
     pub options: MigrationOptions,
+    /// Relations to migrate as graph edges (optional).
+    #[serde(default)]
+    pub relations: Vec<RelationConfig>,
 }
 
 /// Source database configuration.
@@ -207,6 +210,27 @@ pub struct ChromaDBConfig {
     pub database: Option<String>,
 }
 
+/// Configuration of a source relation to migrate as graph edges.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RelationConfig {
+    /// Column/field in the source containing the FK (e.g., "author_id").
+    pub from_column: String,
+    /// Target table/collection (e.g., "authors").
+    pub to_table: String,
+    /// ID column in the target (e.g., "id"). Defaults to "id".
+    #[serde(default = "default_relation_id_column")]
+    pub to_column: String,
+    /// Edge label in `VelesDB` (e.g., "AUTHORED_BY").
+    pub edge_label: String,
+    /// Optional column for a numeric edge weight.
+    #[serde(default)]
+    pub weight_column: Option<String>,
+}
+
+fn default_relation_id_column() -> String {
+    "id".to_string()
+}
+
 /// Destination `VelesDB` configuration.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DestinationConfig {
@@ -222,6 +246,9 @@ pub struct DestinationConfig {
     /// Storage mode.
     #[serde(default)]
     pub storage_mode: StorageMode,
+    /// Name of the `GraphCollection` for graph edges (optional).
+    #[serde(default)]
+    pub graph_collection: Option<String>,
 }
 
 /// Distance metric for `VelesDB`.
@@ -385,8 +412,10 @@ mod tests {
                 dimension: 0,
                 metric: DistanceMetric::Cosine,
                 storage_mode: StorageMode::Full,
+                graph_collection: None,
             },
             options: MigrationOptions::default(),
+            relations: vec![],
         };
 
         let result = config.validate();
@@ -408,11 +437,13 @@ mod tests {
                 dimension: 8,
                 metric: DistanceMetric::Cosine,
                 storage_mode: StorageMode::Full,
+                graph_collection: None,
             },
             options: MigrationOptions {
                 batch_size: 0,
                 ..MigrationOptions::default()
             },
+            relations: vec![],
         };
 
         let result = config.validate();
@@ -434,11 +465,13 @@ mod tests {
                 dimension: 8,
                 metric: DistanceMetric::Cosine,
                 storage_mode: StorageMode::Full,
+                graph_collection: None,
             },
             options: MigrationOptions {
                 workers: 0,
                 ..MigrationOptions::default()
             },
+            relations: vec![],
         };
 
         let result = config.validate();

--- a/crates/velesdb-migrate/src/config.rs
+++ b/crates/velesdb-migrate/src/config.rs
@@ -113,11 +113,18 @@ pub struct QdrantConfig {
 }
 
 /// Pinecone configuration.
+#[allow(deprecated)]
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct PineconeConfig {
     /// Pinecone API key.
     pub api_key: String,
-    /// Environment (e.g., "us-east-1-aws").
+    /// Deprecated: Pinecone serverless (2024+) discovers the host dynamically
+    /// via `GET /indexes/{name}`. Kept for backward compatibility with existing YAML configs.
+    #[serde(default)]
+    #[deprecated(
+        since = "1.12.0",
+        note = "Pinecone serverless ignores environments; host is discovered via the API"
+    )]
     pub environment: String,
     /// Index name.
     pub index: String,

--- a/crates/velesdb-migrate/src/config.rs
+++ b/crates/velesdb-migrate/src/config.rs
@@ -55,7 +55,39 @@ pub enum SourceConfig {
     Elasticsearch(crate::connectors::elasticsearch::ElasticsearchConfig),
     /// Redis Vector Search (Redis Stack).
     #[serde(rename = "redis")]
-    Redis(crate::connectors::redis::RedisConfig),
+    Redis(RedisConfig),
+}
+
+/// Configuration for Redis Vector Search.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RedisConfig {
+    /// Redis URL (e.g., `redis://localhost:6379` or `rediss://...` for TLS).
+    pub url: String,
+    /// Redis password (optional).
+    #[serde(default)]
+    pub password: Option<String>,
+    /// Index name created with `FT.CREATE`.
+    pub index: String,
+    /// Field name containing the vector embedding.
+    #[serde(default = "default_redis_vector_field")]
+    pub vector_field: String,
+    /// Prefix for document keys (e.g., "doc:").
+    #[serde(default = "default_redis_key_prefix")]
+    pub key_prefix: String,
+    /// Fields to include in payload (empty = all).
+    #[serde(default)]
+    pub payload_fields: Vec<String>,
+    /// Optional filter query (RediSearch syntax).
+    #[serde(default)]
+    pub filter: Option<String>,
+}
+
+fn default_redis_vector_field() -> String {
+    "embedding".to_string()
+}
+
+fn default_redis_key_prefix() -> String {
+    "doc:".to_string()
 }
 
 /// `PostgreSQL` pgvector configuration.

--- a/crates/velesdb-migrate/src/connectors/chromadb.rs
+++ b/crates/velesdb-migrate/src/connectors/chromadb.rs
@@ -164,14 +164,15 @@ impl SourceConnector for ChromaDBConnector {
         let current_offset = offset
             .as_ref()
             .and_then(serde_json::Value::as_u64)
-            .unwrap_or(0) as usize;
+            .unwrap_or(0);
+        let offset_usize = usize::try_from(current_offset).unwrap_or(usize::MAX);
 
         let url = format!("{}/collections/{}/get", self.base_url(), collection_id);
 
         let req = GetRequest {
             ids: None,
             limit: Some(batch_size),
-            offset: Some(current_offset),
+            offset: Some(offset_usize),
             include: vec![
                 "embeddings".to_string(),
                 "metadatas".to_string(),
@@ -223,7 +224,7 @@ impl SourceConnector for ChromaDBConnector {
         Ok(super::common::build_numeric_offset_batch(
             points,
             batch_size,
-            current_offset as u64,
+            current_offset,
         ))
     }
 

--- a/crates/velesdb-migrate/src/connectors/chromadb.rs
+++ b/crates/velesdb-migrate/src/connectors/chromadb.rs
@@ -64,12 +64,6 @@ struct GetResponse {
     documents: Option<Vec<Option<String>>>,
 }
 
-#[derive(Debug, Deserialize)]
-#[allow(dead_code)] // Reserved for future count endpoint
-struct CountResponse {
-    count: u64,
-}
-
 #[async_trait]
 impl SourceConnector for ChromaDBConnector {
     fn source_type(&self) -> &'static str {

--- a/crates/velesdb-migrate/src/connectors/common.rs
+++ b/crates/velesdb-migrate/src/connectors/common.rs
@@ -59,6 +59,12 @@ pub fn validate_url(url: &str) -> Result<()> {
     Ok(())
 }
 
+/// Returns `true` if the sparse vector is non-empty and has matching indices/values lengths.
+#[must_use]
+pub fn is_valid_sparse_vector(indices: &[u32], values: &[f32]) -> bool {
+    !indices.is_empty() && indices.len() == values.len()
+}
+
 /// Parses a vector from a JSON value.
 ///
 /// Expects the value to be a JSON array of numbers.

--- a/crates/velesdb-migrate/src/connectors/elasticsearch.rs
+++ b/crates/velesdb-migrate/src/connectors/elasticsearch.rs
@@ -206,6 +206,8 @@ impl SourceConnector for ElasticsearchConnector {
     }
 
     async fn connect(&mut self) -> Result<()> {
+        crate::connectors::common::validate_url(&self.config.url)?;
+
         // Fetch a sample document to detect schema
         let url = self.build_search_url();
         let body = SearchRequest {

--- a/crates/velesdb-migrate/src/connectors/elasticsearch_tests.rs
+++ b/crates/velesdb-migrate/src/connectors/elasticsearch_tests.rs
@@ -155,3 +155,10 @@ fn test_search_response_deserialization() {
     assert_eq!(response.hits.hits.len(), 1);
     assert_eq!(response.hits.hits[0].id, "doc1");
 }
+
+#[test]
+fn test_connect_rejects_file_url() {
+    assert!(
+        crate::connectors::common::validate_url("file:///etc/passwd").is_err()
+    );
+}

--- a/crates/velesdb-migrate/src/connectors/milvus.rs
+++ b/crates/velesdb-migrate/src/connectors/milvus.rs
@@ -16,6 +16,8 @@ use crate::error::{Error, Result};
 pub struct MilvusConnector {
     config: MilvusConfig,
     client: reqwest::Client,
+    vector_field: Option<String>,
+    cached_schema: Option<SourceSchema>,
 }
 
 impl MilvusConnector {
@@ -25,6 +27,8 @@ impl MilvusConnector {
         Self {
             config,
             client: create_http_client(),
+            vector_field: None,
+            cached_schema: None,
         }
     }
 
@@ -141,65 +145,13 @@ impl SourceConnector for MilvusConnector {
         }
 
         info!("Connected to Milvus collection: {}", self.config.collection);
+
+        self.fetch_and_cache_schema().await?;
         Ok(())
     }
 
     async fn get_schema(&self) -> Result<SourceSchema> {
-        // Get collection schema
-        let resp = self
-            .request(reqwest::Method::GET, "/collections/describe")
-            .query(&[("collectionName", &self.config.collection)])
-            .send()
-            .await?;
-
-        let resp = check_response(resp, "Milvus", "describe").await?;
-
-        let result: MilvusResponse<CollectionSchema> = resp.json().await?;
-
-        let schema = result
-            .data
-            .ok_or_else(|| Error::Extraction("No schema data returned".to_string()))?;
-
-        let (vector_field, dimension) = Self::find_vector_field(&schema)?;
-
-        let fields: Vec<FieldInfo> = schema
-            .fields
-            .iter()
-            .filter(|f| f.name != vector_field)
-            .map(|f| FieldInfo {
-                name: f.name.clone(),
-                field_type: f.field_type.clone(),
-                indexed: f.is_primary_key.unwrap_or(false),
-            })
-            .collect();
-
-        // Get stats for count
-        let resp = self
-            .request(reqwest::Method::GET, "/collections/stats")
-            .query(&[("collectionName", &self.config.collection)])
-            .send()
-            .await?;
-
-        let total_count = if resp.status().is_success() {
-            let stats: MilvusResponse<StatsResponse> = resp.json().await?;
-            stats.data.map(|s| s.row_count)
-        } else {
-            None
-        };
-
-        info!(
-            "Milvus collection '{}': {}D vectors, {:?} rows",
-            self.config.collection, dimension, total_count
-        );
-
-        Ok(SourceSchema {
-            source_type: "milvus".to_string(),
-            collection: self.config.collection.clone(),
-            dimension,
-            total_count,
-            fields,
-            ..Default::default()
-        })
+        crate::connectors::common::cached_schema(&self.cached_schema)
     }
 
     async fn extract_batch(
@@ -212,9 +164,13 @@ impl SourceConnector for MilvusConnector {
             .and_then(serde_json::Value::as_u64)
             .unwrap_or(0) as usize;
 
-        let schema = self.get_schema().await?;
-        let (vector_field, _) = Self::find_vector_field_from_schema(&schema)?;
+        let vector_field = self
+            .vector_field
+            .as_deref()
+            .ok_or_else(|| Error::SourceConnection("Not connected to Milvus".to_string()))?
+            .to_owned();
 
+        let schema = self.get_schema().await?;
         let mut output_fields: Vec<String> = schema.fields.iter().map(|f| f.name.clone()).collect();
         output_fields.push(vector_field.clone());
 
@@ -282,9 +238,11 @@ impl SourceConnector for MilvusConnector {
 }
 
 impl MilvusConnector {
+    /// Detect the first vector-typed field in the Milvus collection schema.
     fn find_vector_field(schema: &CollectionSchema) -> Result<(String, usize)> {
         for field in &schema.fields {
-            if field.field_type.contains("Vector") || field.field_type.contains("FLOAT_VECTOR") {
+            let ft = field.field_type.to_ascii_uppercase();
+            if ft.contains("VECTOR") {
                 let dim = field.params.as_ref().and_then(|p| p.dim).unwrap_or(0);
                 return Ok((field.name.clone(), dim));
             }
@@ -292,9 +250,63 @@ impl MilvusConnector {
         Err(Error::SchemaMismatch("No vector field found".to_string()))
     }
 
-    fn find_vector_field_from_schema(schema: &SourceSchema) -> Result<(String, usize)> {
-        // Return default vector field name and dimension from schema
-        Ok(("vector".to_string(), schema.dimension))
+    /// Fetch the collection schema from Milvus and cache it locally.
+    async fn fetch_and_cache_schema(&mut self) -> Result<()> {
+        let resp = self
+            .request(reqwest::Method::GET, "/collections/describe")
+            .query(&[("collectionName", &self.config.collection)])
+            .send()
+            .await?;
+
+        let resp = check_response(resp, "Milvus", "describe").await?;
+        let result: MilvusResponse<CollectionSchema> = resp.json().await?;
+
+        let schema = result
+            .data
+            .ok_or_else(|| Error::Extraction("No schema data returned".to_string()))?;
+
+        let (vector_field, dimension) = Self::find_vector_field(&schema)?;
+
+        let fields: Vec<FieldInfo> = schema
+            .fields
+            .iter()
+            .filter(|f| f.name != vector_field)
+            .map(|f| FieldInfo {
+                name: f.name.clone(),
+                field_type: f.field_type.clone(),
+                indexed: f.is_primary_key.unwrap_or(false),
+            })
+            .collect();
+
+        let resp = self
+            .request(reqwest::Method::GET, "/collections/stats")
+            .query(&[("collectionName", &self.config.collection)])
+            .send()
+            .await?;
+
+        let total_count = if resp.status().is_success() {
+            let stats: MilvusResponse<StatsResponse> = resp.json().await?;
+            stats.data.map(|s| s.row_count)
+        } else {
+            None
+        };
+
+        info!(
+            "Milvus collection '{}': {}D vectors, {:?} rows",
+            self.config.collection, dimension, total_count
+        );
+
+        self.vector_field = Some(vector_field);
+        self.cached_schema = Some(SourceSchema {
+            source_type: "milvus".to_string(),
+            collection: self.config.collection.clone(),
+            dimension,
+            total_count,
+            fields,
+            ..Default::default()
+        });
+
+        Ok(())
     }
 }
 
@@ -332,8 +344,67 @@ mod tests {
 
     #[test]
     fn test_connect_rejects_file_url() {
-        assert!(
-            crate::connectors::common::validate_url("file:///etc/passwd").is_err()
-        );
+        assert!(crate::connectors::common::validate_url("file:///etc/passwd").is_err());
+    }
+
+    #[test]
+    fn test_find_vector_field_detects_float_vector() {
+        let schema = CollectionSchema {
+            fields: vec![
+                FieldSchema {
+                    name: "id".to_string(),
+                    field_type: "Int64".to_string(),
+                    is_primary_key: Some(true),
+                    params: None,
+                },
+                FieldSchema {
+                    name: "embedding".to_string(),
+                    field_type: "FloatVector".to_string(),
+                    is_primary_key: None,
+                    params: Some(FieldParams { dim: Some(128) }),
+                },
+            ],
+        };
+        let (name, dim) =
+            MilvusConnector::find_vector_field(&schema).expect("test: should detect FloatVector");
+        assert_eq!(name, "embedding");
+        assert_eq!(dim, 128);
+    }
+
+    #[test]
+    fn test_find_vector_field_detects_float_vector_uppercase() {
+        let schema = CollectionSchema {
+            fields: vec![FieldSchema {
+                name: "vec".to_string(),
+                field_type: "FLOAT_VECTOR".to_string(),
+                is_primary_key: None,
+                params: Some(FieldParams { dim: Some(768) }),
+            }],
+        };
+        let (name, dim) =
+            MilvusConnector::find_vector_field(&schema).expect("test: FLOAT_VECTOR uppercase");
+        assert_eq!(name, "vec");
+        assert_eq!(dim, 768);
+    }
+
+    #[test]
+    fn test_find_vector_field_returns_error_when_no_vector_field() {
+        let schema = CollectionSchema {
+            fields: vec![
+                FieldSchema {
+                    name: "id".to_string(),
+                    field_type: "Int64".to_string(),
+                    is_primary_key: Some(true),
+                    params: None,
+                },
+                FieldSchema {
+                    name: "name".to_string(),
+                    field_type: "VarChar".to_string(),
+                    is_primary_key: None,
+                    params: None,
+                },
+            ],
+        };
+        assert!(MilvusConnector::find_vector_field(&schema).is_err());
     }
 }

--- a/crates/velesdb-migrate/src/connectors/milvus.rs
+++ b/crates/velesdb-migrate/src/connectors/milvus.rs
@@ -159,10 +159,13 @@ impl SourceConnector for MilvusConnector {
         offset: Option<serde_json::Value>,
         batch_size: usize,
     ) -> Result<ExtractedBatch> {
-        let current_offset = offset
-            .as_ref()
-            .and_then(serde_json::Value::as_u64)
-            .unwrap_or(0) as usize;
+        let current_offset = usize::try_from(
+            offset
+                .as_ref()
+                .and_then(serde_json::Value::as_u64)
+                .unwrap_or(0),
+        )
+        .unwrap_or(usize::MAX);
 
         let vector_field = self
             .vector_field

--- a/crates/velesdb-migrate/src/connectors/milvus.rs
+++ b/crates/velesdb-migrate/src/connectors/milvus.rs
@@ -111,6 +111,8 @@ impl SourceConnector for MilvusConnector {
     }
 
     async fn connect(&mut self) -> Result<()> {
+        crate::connectors::common::validate_url(&self.config.url)?;
+
         info!("Connecting to Milvus at {}", self.config.url);
 
         let resp = self
@@ -326,5 +328,12 @@ mod tests {
         let json = serde_json::to_string(&req).unwrap();
         assert!(json.contains("\"collectionName\":\"test\""));
         assert!(json.contains("\"limit\":100"));
+    }
+
+    #[test]
+    fn test_connect_rejects_file_url() {
+        assert!(
+            crate::connectors::common::validate_url("file:///etc/passwd").is_err()
+        );
     }
 }

--- a/crates/velesdb-migrate/src/connectors/mod.rs
+++ b/crates/velesdb-migrate/src/connectors/mod.rs
@@ -10,6 +10,7 @@ pub mod mongodb;
 pub mod pgvector;
 pub mod pinecone;
 pub mod qdrant;
+#[cfg(feature = "redis-source")]
 pub mod redis;
 pub mod weaviate;
 
@@ -148,9 +149,14 @@ pub fn create_connector(config: &crate::config::SourceConfig) -> Result<Box<dyn 
         crate::config::SourceConfig::Elasticsearch(cfg) => Ok(Box::new(
             elasticsearch::ElasticsearchConnector::new(cfg.clone()),
         )),
+        #[cfg(feature = "redis-source")]
         crate::config::SourceConfig::Redis(cfg) => {
             Ok(Box::new(redis::RedisConnector::new(cfg.clone())))
         }
+        #[cfg(not(feature = "redis-source"))]
+        crate::config::SourceConfig::Redis(_) => Err(crate::error::Error::UnsupportedSource(
+            "Redis source requires the 'redis-source' feature".to_string(),
+        ))
     }
 }
 

--- a/crates/velesdb-migrate/src/connectors/mod.rs
+++ b/crates/velesdb-migrate/src/connectors/mod.rs
@@ -12,6 +12,7 @@ pub mod pinecone;
 pub mod qdrant;
 #[cfg(feature = "redis-source")]
 pub mod redis;
+pub mod relation_detector;
 pub mod weaviate;
 
 use async_trait::async_trait;

--- a/crates/velesdb-migrate/src/connectors/mongodb.rs
+++ b/crates/velesdb-migrate/src/connectors/mongodb.rs
@@ -39,6 +39,10 @@ pub struct MongoDBConfig {
     /// Optional filter query (MongoDB query syntax as JSON).
     #[serde(default)]
     pub filter: Option<serde_json::Value>,
+    /// Data source name for the MongoDB Data API.
+    /// Defaults to "mongodb-atlas". Adjust if using a different cluster configuration.
+    #[serde(default = "default_mongo_data_source")]
+    pub data_source: String,
 }
 
 fn default_vector_field() -> String {
@@ -47,6 +51,10 @@ fn default_vector_field() -> String {
 
 fn default_id_field() -> String {
     "_id".to_string()
+}
+
+fn default_mongo_data_source() -> String {
+    "mongodb-atlas".to_string()
 }
 
 /// Request body for MongoDB Data API find operation.
@@ -93,7 +101,6 @@ pub struct MongoDBConnector {
     config: MongoDBConfig,
     client: Client,
     schema: Option<SourceSchema>,
-    data_source: String,
 }
 
 impl MongoDBConnector {
@@ -103,7 +110,6 @@ impl MongoDBConnector {
             config,
             client: create_http_client(),
             schema: None,
-            data_source: "mongodb-atlas".to_string(),
         }
     }
 
@@ -153,7 +159,7 @@ impl MongoDBConnector {
         pipeline.push(serde_json::json!({ "$count": "total" }));
 
         let request = AggregateRequest {
-            data_source: self.data_source.clone(),
+            data_source: self.config.data_source.clone(),
             database: self.config.database.clone(),
             collection: self.config.collection.clone(),
             pipeline,
@@ -219,7 +225,7 @@ impl SourceConnector for MongoDBConnector {
 
         // Fetch a sample document to detect schema
         let request = FindRequest {
-            data_source: self.data_source.clone(),
+            data_source: self.config.data_source.clone(),
             database: self.config.database.clone(),
             collection: self.config.collection.clone(),
             filter: self.config.filter.clone(),
@@ -272,7 +278,7 @@ impl SourceConnector for MongoDBConnector {
         let skip = offset.and_then(|v| v.as_u64()).unwrap_or(0);
 
         let request = FindRequest {
-            data_source: self.data_source.clone(),
+            data_source: self.config.data_source.clone(),
             database: self.config.database.clone(),
             collection: self.config.collection.clone(),
             filter: self.config.filter.clone(),

--- a/crates/velesdb-migrate/src/connectors/mongodb_tests.rs
+++ b/crates/velesdb-migrate/src/connectors/mongodb_tests.rs
@@ -13,6 +13,7 @@ fn test_config() -> MongoDBConfig {
         id_field: "_id".to_string(),
         payload_fields: vec![],
         filter: None,
+        data_source: "mongodb-atlas".to_string(),
     }
 }
 
@@ -119,4 +120,18 @@ fn test_aggregate_request_serialization() {
     };
     let json = serde_json::to_value(&req).unwrap();
     assert_eq!(json["pipeline"].as_array().unwrap().len(), 1);
+}
+
+#[test]
+fn test_mongodb_config_default_data_source() {
+    let json = r#"{"data_api_url":"https://data.mongodb-api.com/v1","api_key":"key","database":"db","collection":"col"}"#;
+    let config: MongoDBConfig = serde_json::from_str(json).unwrap();
+    assert_eq!(config.data_source, "mongodb-atlas");
+}
+
+#[test]
+fn test_mongodb_config_custom_data_source() {
+    let json = r#"{"data_api_url":"https://data.mongodb-api.com/v1","api_key":"key","database":"db","collection":"col","data_source":"my-cluster"}"#;
+    let config: MongoDBConfig = serde_json::from_str(json).unwrap();
+    assert_eq!(config.data_source, "my-cluster");
 }

--- a/crates/velesdb-migrate/src/connectors/pgvector.rs
+++ b/crates/velesdb-migrate/src/connectors/pgvector.rs
@@ -1,7 +1,6 @@
 //! `PostgreSQL` pgvector and Supabase connectors.
 
 use async_trait::async_trait;
-use serde::Deserialize;
 use std::collections::HashMap;
 use tracing::{debug, info};
 
@@ -40,6 +39,8 @@ impl SourceConnector for PgVectorConnector {
     }
 
     async fn connect(&mut self) -> Result<()> {
+        crate::connectors::common::validate_url(&self.config.connection_string)?;
+
         info!("pgvector connector requires 'postgres' feature");
 
         #[cfg(feature = "postgres")]
@@ -149,13 +150,6 @@ impl SupabaseConnector {
     }
 }
 
-#[derive(Debug, Deserialize)]
-#[allow(dead_code)] // Reserved for typed row deserialization
-struct SupabaseRow {
-    #[serde(flatten)]
-    data: HashMap<String, serde_json::Value>,
-}
-
 #[async_trait]
 impl SourceConnector for SupabaseConnector {
     fn source_type(&self) -> &'static str {
@@ -163,6 +157,8 @@ impl SourceConnector for SupabaseConnector {
     }
 
     async fn connect(&mut self) -> Result<()> {
+        crate::connectors::common::validate_url(&self.config.url)?;
+
         info!("Connecting to Supabase: {}", self.config.url);
 
         // Test connection by fetching schema
@@ -480,5 +476,12 @@ mod tests {
 
         let connector = SupabaseConnector::new(config);
         assert_eq!(connector.source_type(), "supabase");
+    }
+
+    #[test]
+    fn test_supabase_connect_rejects_file_url() {
+        assert!(
+            crate::connectors::common::validate_url("file:///etc/passwd").is_err()
+        );
     }
 }

--- a/crates/velesdb-migrate/src/connectors/pgvector.rs
+++ b/crates/velesdb-migrate/src/connectors/pgvector.rs
@@ -63,25 +63,11 @@ impl SourceConnector for PgVectorConnector {
     async fn get_schema(&self) -> Result<SourceSchema> {
         #[cfg(feature = "postgres")]
         {
-            // Would query pg_catalog for column info
-            Ok(SourceSchema {
-                source_type: "pgvector".to_string(),
-                collection: self.config.table.clone(),
-                dimension: 0, // Would be determined from vector column
-                total_count: None,
-                fields: self
-                    .config
-                    .payload_columns
-                    .iter()
-                    .map(|c| FieldInfo {
-                        name: c.clone(),
-                        field_type: "unknown".to_string(),
-                        indexed: false,
-                    })
-                    .collect(),
-                vector_column: Some(self.config.vector_column.clone()),
-                id_column: Some(self.config.id_column.clone()),
-            })
+            Err(crate::error::Error::UnsupportedSource(
+                "pgvector SQL extraction is not yet implemented. \
+                 Use the 'supabase' connector for Supabase projects (PostgREST API)."
+                    .to_string(),
+            ))
         }
 
         #[cfg(not(feature = "postgres"))]
@@ -99,13 +85,11 @@ impl SourceConnector for PgVectorConnector {
     ) -> Result<ExtractedBatch> {
         #[cfg(feature = "postgres")]
         {
-            // Would execute:
-            // SELECT id, vector, col1, col2 FROM table LIMIT batch_size OFFSET offset
-            Ok(ExtractedBatch {
-                points: vec![],
-                next_offset: None,
-                has_more: false,
-            })
+            Err(crate::error::Error::UnsupportedSource(
+                "pgvector SQL extraction is not yet implemented. \
+                 Use the 'supabase' connector for Supabase projects (PostgREST API)."
+                    .to_string(),
+            ))
         }
 
         #[cfg(not(feature = "postgres"))]
@@ -482,6 +466,34 @@ mod tests {
     fn test_supabase_connect_rejects_file_url() {
         assert!(
             crate::connectors::common::validate_url("file:///etc/passwd").is_err()
+        );
+    }
+
+    #[test]
+    fn test_pgvector_get_schema_returns_explicit_error() {
+        use crate::config::PgVectorConfig;
+
+        let config = PgVectorConfig {
+            connection_string: "postgres://localhost/test".to_string(),
+            table: "items".to_string(),
+            vector_column: "embedding".to_string(),
+            id_column: "id".to_string(),
+            payload_columns: vec![],
+            filter: None,
+        };
+        let connector = super::PgVectorConnector::new(config);
+
+        // get_schema() should fail with UnsupportedSource — not compile-time, but runtime.
+        let rt = tokio::runtime::Runtime::new().expect("test: tokio runtime");
+        let result = rt.block_on(connector.get_schema());
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("not yet implemented")
+                || err_msg.contains("Unsupported source")
+                || err_msg.contains("supabase")
+                || err_msg.contains("postgres"),
+            "Error should mention the issue: {err_msg}"
         );
     }
 }

--- a/crates/velesdb-migrate/src/connectors/pinecone.rs
+++ b/crates/velesdb-migrate/src/connectors/pinecone.rs
@@ -48,6 +48,8 @@ impl PineconeConnector {
         if let Some(base) = &self.config.base_url {
             return base.clone();
         }
+        // Invariant: callers (get_schema, extract_batch) always guard with
+        // `self.host.is_some()` before calling this method; "localhost" is unreachable.
         let host = self.host.as_deref().unwrap_or("localhost");
         format!("https://{host}")
     }

--- a/crates/velesdb-migrate/src/connectors/pinecone.rs
+++ b/crates/velesdb-migrate/src/connectors/pinecone.rs
@@ -102,7 +102,7 @@ impl PineconeConnector {
 /// Converts a Pinecone vector response into an `ExtractedPoint`.
 fn pinecone_vec_to_point(v: PineconeVector) -> ExtractedPoint {
     let sparse = v.sparse_values.and_then(|sv| {
-        if sv.indices.len() == sv.values.len() && !sv.indices.is_empty() {
+        if crate::connectors::common::is_valid_sparse_vector(&sv.indices, &sv.values) {
             Some(sv.indices.into_iter().zip(sv.values).collect())
         } else {
             None
@@ -301,6 +301,7 @@ mod tests {
     use super::*;
 
     #[test]
+    #[allow(deprecated)]
     fn test_pinecone_connector_new() {
         let config = PineconeConfig {
             api_key: "test-key".to_string(),
@@ -416,7 +417,7 @@ mod tests {
         };
 
         let sparse = v.sparse_values.and_then(|sv| {
-            if sv.indices.len() == sv.values.len() && !sv.indices.is_empty() {
+            if crate::connectors::common::is_valid_sparse_vector(&sv.indices, &sv.values) {
                 Some(sv.indices.into_iter().zip(sv.values).collect::<Vec<_>>())
             } else {
                 None

--- a/crates/velesdb-migrate/src/connectors/qdrant.rs
+++ b/crates/velesdb-migrate/src/connectors/qdrant.rs
@@ -155,7 +155,7 @@ impl QdrantVector {
             Self::Named(map) => {
                 for value in map.values() {
                     if let QdrantNamedVectorValue::Sparse(sv) = value {
-                        if sv.indices.len() == sv.values.len() && !sv.indices.is_empty() {
+                        if crate::connectors::common::is_valid_sparse_vector(&sv.indices, &sv.values) {
                             return Some(
                                 sv.indices
                                     .iter()
@@ -197,6 +197,8 @@ impl SourceConnector for QdrantConnector {
     }
 
     async fn connect(&mut self) -> Result<()> {
+        crate::connectors::common::validate_url(&self.config.url)?;
+
         info!("Connecting to Qdrant at {}", self.config.url);
 
         let resp = self.request(reqwest::Method::GET, "").send().await?;
@@ -403,5 +405,20 @@ mod tests {
             serde_json::from_str(json).expect("valid JSON");
         let v2 = QdrantVector::Named(map2);
         assert!(v2.into_dense().is_empty());
+    }
+
+    #[test]
+    fn test_connect_rejects_file_url() {
+        let config = QdrantConfig {
+            url: "file:///etc/passwd".to_string(),
+            collection: "test".to_string(),
+            api_key: None,
+            payload_fields: vec![],
+        };
+        let connector = QdrantConnector::new(config);
+        // validate_url rejects file:// synchronously at connect time
+        assert!(
+            crate::connectors::common::validate_url(&connector.config.url).is_err()
+        );
     }
 }

--- a/crates/velesdb-migrate/src/connectors/redis.rs
+++ b/crates/velesdb-migrate/src/connectors/redis.rs
@@ -354,9 +354,12 @@ pub fn parse_ft_search_response(
 }
 
 /// Parses field-value pairs from a RESP Array into a `HashMap`.
+///
+/// The `vector_field` name is used to intercept raw binary blobs before
+/// `resp_value_to_json` converts them into unusable `<binary:N bytes>` placeholders.
 fn parse_field_value_pairs(
     value: &redis::Value,
-    _vector_field: &str,
+    vector_field: &str,
 ) -> Result<HashMap<String, serde_json::Value>> {
     let pairs = match value {
         redis::Value::Array(arr) => arr,
@@ -371,11 +374,35 @@ fn parse_field_value_pairs(
     let mut i = 0;
     while i + 1 < pairs.len() {
         let field_name = extract_bulk_string(&pairs[i]).unwrap_or_default();
-        let field_value = resp_value_to_json(&pairs[i + 1]);
+        let field_value = decode_resp_field(&pairs[i + 1], &field_name, vector_field);
         attrs.insert(field_name, field_value);
         i += 2;
     }
     Ok(attrs)
+}
+
+/// Converts a RESP field value to JSON, intercepting binary vector blobs.
+///
+/// RediSearch stores VECTOR fields as raw little-endian f32 bytes by default.
+/// When the vector field contains a non-UTF-8 `BulkString`, this calls
+/// `decode_vector_blob` and returns a JSON array instead of an unusable
+/// `<binary:N bytes>` placeholder.
+fn decode_resp_field(
+    value: &redis::Value,
+    field_name: &str,
+    vector_field: &str,
+) -> serde_json::Value {
+    if field_name == vector_field {
+        if let redis::Value::BulkString(bytes) = value {
+            if String::from_utf8(bytes.clone()).is_err() {
+                let floats = decode_vector_blob(bytes);
+                return serde_json::Value::Array(
+                    floats.into_iter().map(|f| serde_json::json!(f)).collect(),
+                );
+            }
+        }
+    }
+    resp_value_to_json(value)
 }
 
 /// Extracts a vector from document attributes.

--- a/crates/velesdb-migrate/src/connectors/redis.rs
+++ b/crates/velesdb-migrate/src/connectors/redis.rs
@@ -6,6 +6,8 @@
 
 use async_trait::async_trait;
 use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::Mutex;
 
 use crate::config::RedisConfig;
 use crate::connectors::common::{
@@ -14,10 +16,13 @@ use crate::connectors::common::{
 use crate::connectors::{ExtractedBatch, ExtractedPoint, FieldInfo, SourceConnector, SourceSchema};
 use crate::error::{Error, Result};
 
+type SharedConnection = Arc<Mutex<redis::aio::MultiplexedConnection>>;
+
 /// Redis Vector Search connector.
 pub struct RedisConnector {
     config: RedisConfig,
     schema: Option<SourceSchema>,
+    connection: Option<SharedConnection>,
 }
 
 impl RedisConnector {
@@ -27,6 +32,7 @@ impl RedisConnector {
         Self {
             config,
             schema: None,
+            connection: None,
         }
     }
 
@@ -107,6 +113,20 @@ impl RedisConnector {
         Ok(con)
     }
 
+    /// Returns a lock guard for the cached multiplexed connection.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::SourceConnection` if `connect()` has not been called.
+    async fn acquire_connection(
+        &self,
+    ) -> Result<tokio::sync::MutexGuard<'_, redis::aio::MultiplexedConnection>> {
+        let shared = self.connection.as_ref().ok_or_else(|| {
+            Error::SourceConnection("Not connected to Redis".to_string())
+        })?;
+        Ok(shared.lock().await)
+    }
+
     /// Detects the vector dimension by fetching a single document from the index.
     async fn detect_dimension(
         &self,
@@ -172,6 +192,7 @@ impl SourceConnector for RedisConnector {
             vector_column: Some(self.config.vector_field.clone()),
             id_column: None,
         });
+        self.connection = Some(Arc::new(Mutex::new(con)));
 
         Ok(())
     }
@@ -188,7 +209,7 @@ impl SourceConnector for RedisConnector {
         let offset_num = offset.and_then(|v| v.as_u64()).unwrap_or(0);
         let query = self.config.filter.as_deref().unwrap_or("*");
 
-        let mut con = self.open_connection().await?;
+        let mut con = self.acquire_connection().await?;
 
         let resp: redis::Value = build_ft_search_cmd(
             &self.config.index,
@@ -198,9 +219,10 @@ impl SourceConnector for RedisConnector {
             &self.config.vector_field,
             &self.config.payload_fields,
         )
-        .query_async(&mut con)
+        .query_async(&mut *con)
         .await
         .map_err(|e| Error::Extraction(format!("FT.SEARCH batch failed: {e}")))?;
+        drop(con);
 
         let points =
             parse_ft_search_response(&resp, &self.config.vector_field, &self.config.key_prefix)?;
@@ -209,6 +231,7 @@ impl SourceConnector for RedisConnector {
     }
 
     async fn close(&mut self) -> Result<()> {
+        self.connection = None;
         self.schema = None;
         Ok(())
     }

--- a/crates/velesdb-migrate/src/connectors/redis.rs
+++ b/crates/velesdb-migrate/src/connectors/redis.rs
@@ -10,9 +10,9 @@ use std::sync::Arc;
 use tokio::sync::Mutex;
 
 use crate::config::RedisConfig;
-use crate::connectors::common::{
-    build_numeric_offset_batch, extract_payload_from_object, parse_vector_from_json,
-};
+use crate::connectors::common::{build_numeric_offset_batch, parse_vector_from_json};
+#[cfg(test)]
+use crate::connectors::common::extract_payload_from_object;
 use crate::connectors::{ExtractedBatch, ExtractedPoint, FieldInfo, SourceConnector, SourceSchema};
 use crate::error::{Error, Result};
 
@@ -41,7 +41,8 @@ impl RedisConnector {
     /// Redis stores vectors as JSON arrays or delimited strings.
     /// The array case delegates to the shared `parse_vector_from_json` helper;
     /// the string case is Redis-specific (comma/space-separated floats).
-    pub fn parse_vector(&self, attrs: &HashMap<String, serde_json::Value>) -> Result<Vec<f32>> {
+    #[cfg(test)]
+    pub(crate) fn parse_vector(&self, attrs: &HashMap<String, serde_json::Value>) -> Result<Vec<f32>> {
         let vector_value = attrs.get(&self.config.vector_field).ok_or_else(|| {
             Error::Extraction(format!(
                 "Vector field '{}' not found in document",
@@ -70,14 +71,16 @@ impl RedisConnector {
     }
 
     /// Extracts ID from Redis document key by stripping the configured prefix.
-    pub fn extract_id(&self, key: &str) -> String {
+    #[cfg(test)]
+    pub(crate) fn extract_id(&self, key: &str) -> String {
         key.strip_prefix(&self.config.key_prefix)
             .unwrap_or(key)
             .to_string()
     }
 
     /// Extracts payload from Redis document attributes, excluding the vector field.
-    pub fn extract_payload(
+    #[cfg(test)]
+    pub(crate) fn extract_payload(
         &self,
         attrs: &HashMap<String, serde_json::Value>,
     ) -> HashMap<String, serde_json::Value> {

--- a/crates/velesdb-migrate/src/connectors/redis.rs
+++ b/crates/velesdb-migrate/src/connectors/redis.rs
@@ -392,14 +392,14 @@ fn decode_resp_field(
     field_name: &str,
     vector_field: &str,
 ) -> serde_json::Value {
+    // Use field name, not byte content, to identify vector fields.
+    // The UTF-8 heuristic failed for zero-vectors (valid UTF-8 bytes).
     if field_name == vector_field {
         if let redis::Value::BulkString(bytes) = value {
-            if String::from_utf8(bytes.clone()).is_err() {
-                let floats = decode_vector_blob(bytes);
-                return serde_json::Value::Array(
-                    floats.into_iter().map(|f| serde_json::json!(f)).collect(),
-                );
-            }
+            let floats = decode_vector_blob(bytes);
+            return serde_json::Value::Array(
+                floats.into_iter().map(|f| serde_json::json!(f)).collect(),
+            );
         }
     }
     resp_value_to_json(value)
@@ -598,12 +598,10 @@ fn extract_int(value: &redis::Value) -> Option<u64> {
 fn resp_value_to_json(value: &redis::Value) -> serde_json::Value {
     match value {
         redis::Value::BulkString(bytes) => {
-            // Try UTF-8 string first; fall back to base64-ish representation.
+            // Preserve the original string type — do not coerce "42" to 42 or
+            // "true" to true, as that would silently corrupt metadata (e.g. zip codes).
             match String::from_utf8(bytes.clone()) {
-                Ok(s) => {
-                    // Attempt to parse as JSON (number, bool, array, object).
-                    serde_json::from_str(&s).unwrap_or(serde_json::Value::String(s))
-                }
+                Ok(s) => serde_json::Value::String(s),
                 Err(_) => serde_json::Value::String(format!("<binary:{} bytes>", bytes.len())),
             }
         }

--- a/crates/velesdb-migrate/src/connectors/redis.rs
+++ b/crates/velesdb-migrate/src/connectors/redis.rs
@@ -485,6 +485,9 @@ fn parse_ft_info_response(
 }
 
 /// Finds a numeric value by key in a flat key-value RESP list.
+///
+/// `FT.INFO` returns alternating `[key, value, key, value, ...]` pairs,
+/// so we advance by 2 to stay on key positions.
 fn find_info_int(items: &[redis::Value], key: &str) -> Option<u64> {
     let mut i = 0;
     while i + 1 < items.len() {
@@ -497,7 +500,7 @@ fn find_info_int(items: &[redis::Value], key: &str) -> Option<u64> {
                 return s.parse().ok();
             }
         }
-        i += 1;
+        i += 2;
     }
     None
 }
@@ -507,6 +510,7 @@ fn extract_attributes(items: &[redis::Value], vector_field: &str) -> Vec<FieldIn
     let mut fields = Vec::new();
 
     // Find the "attributes" key in the flat list.
+    // FT.INFO returns alternating [key, value, ...] — advance by 2 to stay on keys.
     let mut i = 0;
     while i + 1 < items.len() {
         if extract_bulk_string(&items[i]).as_deref() == Some("attributes") {
@@ -519,7 +523,7 @@ fn extract_attributes(items: &[redis::Value], vector_field: &str) -> Vec<FieldIn
             }
             break;
         }
-        i += 1;
+        i += 2;
     }
 
     fields
@@ -553,14 +557,17 @@ fn parse_single_attribute(
     })
 }
 
-/// Finds the string value immediately after a given key in a flat array.
+/// Finds the string value immediately after a given key in a flat key-value array.
+///
+/// Attribute arrays use the same alternating `[key, value, ...]` layout as `FT.INFO`,
+/// so we advance by 2 to stay on key positions.
 fn find_string_after(parts: &[redis::Value], key: &str) -> Option<String> {
     let mut j = 0;
     while j + 1 < parts.len() {
         if extract_bulk_string(&parts[j]).as_deref() == Some(key) {
             return extract_bulk_string(&parts[j + 1]);
         }
-        j += 1;
+        j += 2;
     }
     None
 }

--- a/crates/velesdb-migrate/src/connectors/redis.rs
+++ b/crates/velesdb-migrate/src/connectors/redis.rs
@@ -1,173 +1,36 @@
-//! Redis Vector Search connector.
+//! Redis Vector Search connector (native RESP protocol).
 //!
 //! This module provides a connector for importing vectors from Redis Stack
-//! with RediSearch module (FT.SEARCH). Supports both Redis Cloud and self-hosted.
+//! with RediSearch module (`FT.SEARCH`). Uses the native RESP protocol via the
+//! `redis` crate instead of HTTP. Supports both Redis Cloud and self-hosted.
 
 use async_trait::async_trait;
-use reqwest::Client;
-use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
+use crate::config::RedisConfig;
 use crate::connectors::common::{
-    build_numeric_offset_batch, check_response, create_http_client, extract_payload_from_object,
-    parse_vector_from_json,
+    build_numeric_offset_batch, extract_payload_from_object, parse_vector_from_json,
 };
 use crate::connectors::{ExtractedBatch, ExtractedPoint, FieldInfo, SourceConnector, SourceSchema};
 use crate::error::{Error, Result};
 
-/// Configuration for Redis Vector Search.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct RedisConfig {
-    /// Redis URL (e.g., redis://localhost:6379 or rediss://... for TLS).
-    pub url: String,
-    /// Redis password (optional).
-    #[serde(default)]
-    pub password: Option<String>,
-    /// Index name created with FT.CREATE.
-    pub index: String,
-    /// Field name containing the vector embedding.
-    #[serde(default = "default_vector_field")]
-    pub vector_field: String,
-    /// Prefix for document keys (e.g., "doc:").
-    #[serde(default = "default_key_prefix")]
-    pub key_prefix: String,
-    /// Fields to include in payload (empty = all).
-    #[serde(default)]
-    pub payload_fields: Vec<String>,
-    /// Optional filter query (RediSearch syntax).
-    #[serde(default)]
-    pub filter: Option<String>,
-}
-
-fn default_vector_field() -> String {
-    "embedding".to_string()
-}
-
-fn default_key_prefix() -> String {
-    "doc:".to_string()
-}
-
-/// Redis REST API response for FT.SEARCH.
-#[derive(Debug, Deserialize)]
-struct SearchResponse {
-    results: Vec<SearchResult>,
-    #[serde(default)]
-    #[allow(dead_code)]
-    total: u64,
-}
-
-#[derive(Debug, Deserialize)]
-struct SearchResult {
-    id: String,
-    #[serde(default)]
-    extra_attributes: HashMap<String, serde_json::Value>,
-}
-
-/// Redis REST API response for FT.INFO.
-#[derive(Debug, Deserialize)]
-struct IndexInfo {
-    num_docs: u64,
-    #[serde(default)]
-    attributes: Vec<AttributeInfo>,
-}
-
-#[derive(Debug, Deserialize)]
-struct AttributeInfo {
-    identifier: String,
-    #[serde(rename = "type")]
-    attr_type: String,
-}
-
 /// Redis Vector Search connector.
 pub struct RedisConnector {
     config: RedisConfig,
-    client: Client,
     schema: Option<SourceSchema>,
-    api_url: String,
 }
 
 impl RedisConnector {
-    /// Creates a new Redis connector with configured HTTP client.
+    /// Creates a new Redis connector.
+    #[must_use]
     pub fn new(config: RedisConfig) -> Self {
-        let api_url = Self::build_api_url(&config.url);
         Self {
             config,
-            client: create_http_client(),
             schema: None,
-            api_url,
         }
     }
 
-    /// Builds the REST API URL from Redis URL.
-    fn build_api_url(redis_url: &str) -> String {
-        // Convert redis:// to http:// for REST API
-        let url = redis_url
-            .replace("redis://", "http://")
-            .replace("rediss://", "https://");
-        url.trim_end_matches('/').to_string()
-    }
-
-    /// Executes a Redis command via REST API.
-    async fn execute_command<T: for<'de> Deserialize<'de>>(
-        &self,
-        command: &str,
-        args: &[&str],
-    ) -> Result<T> {
-        let url = format!("{}/{}", self.api_url, command);
-
-        let mut request = self.client.post(&url);
-
-        if let Some(password) = &self.config.password {
-            request = request.header("Authorization", format!("Bearer {}", password));
-        }
-
-        let body = serde_json::json!({ "args": args });
-
-        let response = request
-            .json(&body)
-            .send()
-            .await
-            .map_err(|e| Error::SourceConnection(format!("Redis request failed: {}", e)))?;
-
-        let checked = check_response(response, "Redis", command).await?;
-
-        checked
-            .json()
-            .await
-            .map_err(|e| Error::Extraction(format!("Failed to parse Redis response: {}", e)))
-    }
-
-    /// Gets index information.
-    async fn get_index_info(&self) -> Result<IndexInfo> {
-        self.execute_command("FT.INFO", &[&self.config.index]).await
-    }
-
-    /// Searches the index.
-    async fn search(&self, query: &str, offset: u64, limit: u64) -> Result<SearchResponse> {
-        let offset_str = offset.to_string();
-        let limit_str = limit.to_string();
-
-        let mut args = vec![
-            self.config.index.as_str(),
-            query,
-            "LIMIT",
-            &offset_str,
-            &limit_str,
-            "RETURN",
-            "10", // Return up to 10 fields
-        ];
-
-        // Add specific fields to return
-        if !self.config.payload_fields.is_empty() {
-            for field in &self.config.payload_fields {
-                args.push(field.as_str());
-            }
-        }
-
-        self.execute_command("FT.SEARCH", &args).await
-    }
-
-    /// Parses a vector from Redis document.
+    /// Parses a vector from Redis document attributes.
     ///
     /// Redis stores vectors as JSON arrays or delimited strings.
     /// The array case delegates to the shared `parse_vector_from_json` helper;
@@ -200,20 +63,18 @@ impl RedisConnector {
         }
     }
 
-    /// Extracts ID from Redis document key.
+    /// Extracts ID from Redis document key by stripping the configured prefix.
     pub fn extract_id(&self, key: &str) -> String {
-        // Remove prefix if present
         key.strip_prefix(&self.config.key_prefix)
             .unwrap_or(key)
             .to_string()
     }
 
-    /// Extracts payload from Redis document.
+    /// Extracts payload from Redis document attributes, excluding the vector field.
     pub fn extract_payload(
         &self,
         attrs: &HashMap<String, serde_json::Value>,
     ) -> HashMap<String, serde_json::Value> {
-        // Redis attrs is a HashMap — wrap as JSON object to use the shared helper.
         let obj =
             serde_json::Value::Object(attrs.iter().map(|(k, v)| (k.clone(), v.clone())).collect());
         extract_payload_from_object(
@@ -221,6 +82,70 @@ impl RedisConnector {
             &[&self.config.vector_field],
             &self.config.payload_fields,
         )
+    }
+
+    /// Opens a multiplexed async Redis connection with optional AUTH.
+    async fn open_connection(
+        &self,
+    ) -> Result<redis::aio::MultiplexedConnection> {
+        let client = redis::Client::open(self.config.url.as_str())
+            .map_err(|e| Error::SourceConnection(format!("Redis client error: {e}")))?;
+
+        let mut con = client
+            .get_multiplexed_async_connection()
+            .await
+            .map_err(|e| Error::SourceConnection(format!("Redis connect failed: {e}")))?;
+
+        if let Some(password) = &self.config.password {
+            redis::cmd("AUTH")
+                .arg(password.as_str())
+                .query_async::<()>(&mut con)
+                .await
+                .map_err(|e| Error::SourceConnection(format!("Redis auth failed: {e}")))?;
+        }
+
+        Ok(con)
+    }
+
+    /// Detects the vector dimension by fetching a single document from the index.
+    async fn detect_dimension(
+        &self,
+        con: &mut redis::aio::MultiplexedConnection,
+    ) -> Result<usize> {
+        let resp: redis::Value = redis::cmd("FT.SEARCH")
+            .arg(&self.config.index)
+            .arg("*")
+            .arg("LIMIT")
+            .arg(0_u64)
+            .arg(1_u64)
+            .arg("RETURN")
+            .arg(1_u32)
+            .arg(&self.config.vector_field)
+            .query_async(con)
+            .await
+            .map_err(|e| Error::SourceConnection(format!("FT.SEARCH sample failed: {e}")))?;
+
+        let points = parse_ft_search_response(&resp, &self.config.vector_field, &self.config.key_prefix)?;
+
+        let first = points.first().ok_or_else(|| {
+            Error::Extraction("No documents found in Redis index".to_string())
+        })?;
+
+        Ok(first.vector.len())
+    }
+
+    /// Fetches index metadata via `FT.INFO`: total document count and field definitions.
+    async fn fetch_index_info(
+        &self,
+        con: &mut redis::aio::MultiplexedConnection,
+    ) -> Result<(u64, Vec<FieldInfo>)> {
+        let resp: redis::Value = redis::cmd("FT.INFO")
+            .arg(&self.config.index)
+            .query_async(con)
+            .await
+            .map_err(|e| Error::SourceConnection(format!("FT.INFO failed: {e}")))?;
+
+        parse_ft_info_response(&resp, &self.config.vector_field)
     }
 }
 
@@ -231,44 +156,18 @@ impl SourceConnector for RedisConnector {
     }
 
     async fn connect(&mut self) -> Result<()> {
-        // Get index info to detect schema
-        let info = self.get_index_info().await?;
+        crate::connectors::common::validate_url(&self.config.url)?;
 
-        // Search for a sample document
-        let query = self
-            .config
-            .filter
-            .clone()
-            .unwrap_or_else(|| "*".to_string());
-        let sample = self.search(&query, 0, 1).await?;
+        let mut con = self.open_connection().await?;
 
-        if sample.results.is_empty() {
-            return Err(Error::Extraction(
-                "No documents found in Redis index".to_string(),
-            ));
-        }
-
-        let doc = &sample.results[0];
-        let vector = self.parse_vector(&doc.extra_attributes)?;
-        let dimension = vector.len();
-
-        // Detect fields from index info
-        let fields: Vec<FieldInfo> = info
-            .attributes
-            .iter()
-            .filter(|a| a.identifier != self.config.vector_field)
-            .map(|a| FieldInfo {
-                name: a.identifier.clone(),
-                field_type: a.attr_type.clone(),
-                indexed: true,
-            })
-            .collect();
+        let dimension = self.detect_dimension(&mut con).await?;
+        let (num_docs, fields) = self.fetch_index_info(&mut con).await?;
 
         self.schema = Some(SourceSchema {
             source_type: "redis".to_string(),
             collection: self.config.index.clone(),
             dimension,
-            total_count: Some(info.num_docs),
+            total_count: Some(num_docs),
             fields,
             vector_column: Some(self.config.vector_field.clone()),
             id_column: None,
@@ -287,30 +186,24 @@ impl SourceConnector for RedisConnector {
         batch_size: usize,
     ) -> Result<ExtractedBatch> {
         let offset_num = offset.and_then(|v| v.as_u64()).unwrap_or(0);
+        let query = self.config.filter.as_deref().unwrap_or("*");
 
-        let query = self
-            .config
-            .filter
-            .clone()
-            .unwrap_or_else(|| "*".to_string());
+        let mut con = self.open_connection().await?;
 
-        #[allow(clippy::cast_possible_truncation)]
-        let response = self.search(&query, offset_num, batch_size as u64).await?;
+        let resp: redis::Value = build_ft_search_cmd(
+            &self.config.index,
+            query,
+            offset_num,
+            batch_size,
+            &self.config.vector_field,
+            &self.config.payload_fields,
+        )
+        .query_async(&mut con)
+        .await
+        .map_err(|e| Error::Extraction(format!("FT.SEARCH batch failed: {e}")))?;
 
-        let mut points = Vec::with_capacity(response.results.len());
-
-        for doc in &response.results {
-            let id = self.extract_id(&doc.id);
-            let vector = self.parse_vector(&doc.extra_attributes)?;
-            let payload = self.extract_payload(&doc.extra_attributes);
-
-            points.push(ExtractedPoint {
-                id,
-                vector,
-                payload,
-                sparse_vector: None,
-            });
-        }
+        let points =
+            parse_ft_search_response(&resp, &self.config.vector_field, &self.config.key_prefix)?;
 
         Ok(build_numeric_offset_batch(points, batch_size, offset_num))
     }
@@ -318,6 +211,349 @@ impl SourceConnector for RedisConnector {
     async fn close(&mut self) -> Result<()> {
         self.schema = None;
         Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// RESP helpers
+// ---------------------------------------------------------------------------
+
+/// Builds a `FT.SEARCH` command with the requested fields.
+fn build_ft_search_cmd(
+    index: &str,
+    query: &str,
+    offset: u64,
+    limit: usize,
+    vector_field: &str,
+    payload_fields: &[String],
+) -> redis::Cmd {
+    let mut cmd = redis::cmd("FT.SEARCH");
+    cmd.arg(index).arg(query).arg("LIMIT").arg(offset).arg(limit);
+
+    // Determine which fields to return.
+    let return_fields: Vec<&str> = if payload_fields.is_empty() {
+        // Return everything -- omit RETURN clause entirely so Redis returns all.
+        return cmd;
+    } else {
+        let mut fields: Vec<&str> = payload_fields.iter().map(String::as_str).collect();
+        if !fields.contains(&vector_field) {
+            fields.push(vector_field);
+        }
+        fields
+    };
+
+    cmd.arg("RETURN")
+        .arg(return_fields.len())
+        .arg(&return_fields);
+    cmd
+}
+
+/// Decodes a Redis little-endian float32 vector blob.
+///
+/// RediSearch stores VECTOR fields as raw bytes (LE f32 sequence).
+pub fn decode_vector_blob(bytes: &[u8]) -> Vec<f32> {
+    bytes
+        .chunks_exact(4)
+        .map(|b| {
+            let arr: [u8; 4] = b.try_into().unwrap_or([0; 4]);
+            f32::from_le_bytes(arr)
+        })
+        .collect()
+}
+
+/// Parses a `FT.SEARCH` RESP response into extracted points.
+///
+/// The RESP format returned by `FT.SEARCH` is:
+/// ```text
+/// [total: Int, key: BulkStr, [field, val, field, val, ...], key, [...], ...]
+/// ```
+///
+/// # Errors
+///
+/// Returns `Error::Extraction` if the response structure is unexpected.
+pub fn parse_ft_search_response(
+    resp: &redis::Value,
+    vector_field: &str,
+    key_prefix: &str,
+) -> Result<Vec<ExtractedPoint>> {
+    let items = match resp {
+        redis::Value::Array(arr) => arr,
+        _ => {
+            return Err(Error::Extraction(
+                "FT.SEARCH: expected Array response".to_string(),
+            ));
+        }
+    };
+
+    // First element is the total count.
+    if items.is_empty() {
+        return Err(Error::Extraction(
+            "FT.SEARCH: empty response array".to_string(),
+        ));
+    }
+
+    // items[0] = total count (Int). If total is 0, return empty.
+    let total = extract_int(&items[0]).unwrap_or(0);
+    if total == 0 {
+        return Ok(Vec::new());
+    }
+
+    // Remaining elements alternate: key (BulkString), field-values (Array).
+    let mut points = Vec::new();
+    let mut idx = 1;
+    while idx + 1 < items.len() {
+        let key = extract_bulk_string(&items[idx]).unwrap_or_default();
+        idx += 1;
+
+        let attrs = parse_field_value_pairs(&items[idx], vector_field)?;
+        idx += 1;
+
+        let id = key
+            .strip_prefix(key_prefix)
+            .unwrap_or(&key)
+            .to_string();
+
+        let vector = extract_vector_from_attrs(&attrs, vector_field)?;
+        let payload = build_payload(&attrs, vector_field);
+
+        points.push(ExtractedPoint {
+            id,
+            vector,
+            payload,
+            sparse_vector: None,
+        });
+    }
+
+    Ok(points)
+}
+
+/// Parses field-value pairs from a RESP Array into a `HashMap`.
+fn parse_field_value_pairs(
+    value: &redis::Value,
+    _vector_field: &str,
+) -> Result<HashMap<String, serde_json::Value>> {
+    let pairs = match value {
+        redis::Value::Array(arr) => arr,
+        _ => {
+            return Err(Error::Extraction(
+                "FT.SEARCH: expected Array for field-value pairs".to_string(),
+            ));
+        }
+    };
+
+    let mut attrs = HashMap::new();
+    let mut i = 0;
+    while i + 1 < pairs.len() {
+        let field_name = extract_bulk_string(&pairs[i]).unwrap_or_default();
+        let field_value = resp_value_to_json(&pairs[i + 1]);
+        attrs.insert(field_name, field_value);
+        i += 2;
+    }
+    Ok(attrs)
+}
+
+/// Extracts a vector from document attributes.
+///
+/// Handles three formats: JSON array, comma/space-separated string, and raw LE f32 blob.
+fn extract_vector_from_attrs(
+    attrs: &HashMap<String, serde_json::Value>,
+    vector_field: &str,
+) -> Result<Vec<f32>> {
+    let value = attrs.get(vector_field).ok_or_else(|| {
+        Error::Extraction(format!("Vector field '{vector_field}' not found in document"))
+    })?;
+
+    match value {
+        serde_json::Value::Array(_) => parse_vector_from_json(value, vector_field),
+        serde_json::Value::String(s) => {
+            // Try JSON array parse first (e.g., "[1.0, 2.0]").
+            if let Ok(parsed) = serde_json::from_str::<Vec<f32>>(s) {
+                return Ok(parsed);
+            }
+            // Try comma/space-separated floats.
+            parse_delimited_vector(s)
+        }
+        // Binary blob stored as raw bytes (from RESP BulkString decoded as latin-1).
+        _ => Err(Error::Extraction(format!(
+            "Vector field '{vector_field}' has unsupported JSON format"
+        ))),
+    }
+}
+
+/// Parses a comma-or-space-separated float string into a vector.
+fn parse_delimited_vector(s: &str) -> Result<Vec<f32>> {
+    s.split([',', ' '])
+        .filter(|part| !part.is_empty())
+        .map(|part| {
+            part.trim()
+                .parse::<f32>()
+                .map_err(|_| Error::Extraction("Invalid vector element".to_string()))
+        })
+        .collect()
+}
+
+/// Builds the payload `HashMap`, excluding the vector field.
+fn build_payload(
+    attrs: &HashMap<String, serde_json::Value>,
+    vector_field: &str,
+) -> HashMap<String, serde_json::Value> {
+    attrs
+        .iter()
+        .filter(|(k, _)| k.as_str() != vector_field)
+        .map(|(k, v)| (k.clone(), v.clone()))
+        .collect()
+}
+
+/// Parses a `FT.INFO` RESP response to extract `num_docs` and field definitions.
+///
+/// `FT.INFO` returns a flat alternating key/value list:
+/// `["index_name", "...", "num_docs", "42", ..., "attributes", [...], ...]`
+///
+/// # Errors
+///
+/// Returns `Error::Extraction` if the response cannot be parsed.
+fn parse_ft_info_response(
+    resp: &redis::Value,
+    vector_field: &str,
+) -> Result<(u64, Vec<FieldInfo>)> {
+    let items = match resp {
+        redis::Value::Array(arr) => arr,
+        _ => {
+            return Err(Error::Extraction(
+                "FT.INFO: expected Array response".to_string(),
+            ));
+        }
+    };
+
+    let num_docs = find_info_int(items, "num_docs").unwrap_or(0);
+    let fields = extract_attributes(items, vector_field);
+
+    Ok((num_docs, fields))
+}
+
+/// Finds a numeric value by key in a flat key-value RESP list.
+fn find_info_int(items: &[redis::Value], key: &str) -> Option<u64> {
+    let mut i = 0;
+    while i + 1 < items.len() {
+        if extract_bulk_string(&items[i]).as_deref() == Some(key) {
+            // Value can be Int or BulkString (stringified number).
+            if let Some(n) = extract_int(&items[i + 1]) {
+                return Some(n);
+            }
+            if let Some(s) = extract_bulk_string(&items[i + 1]) {
+                return s.parse().ok();
+            }
+        }
+        i += 1;
+    }
+    None
+}
+
+/// Extracts attribute/field definitions from the `FT.INFO` response.
+fn extract_attributes(items: &[redis::Value], vector_field: &str) -> Vec<FieldInfo> {
+    let mut fields = Vec::new();
+
+    // Find the "attributes" key in the flat list.
+    let mut i = 0;
+    while i + 1 < items.len() {
+        if extract_bulk_string(&items[i]).as_deref() == Some("attributes") {
+            if let redis::Value::Array(attrs_array) = &items[i + 1] {
+                for attr in attrs_array {
+                    if let Some(info) = parse_single_attribute(attr, vector_field) {
+                        fields.push(info);
+                    }
+                }
+            }
+            break;
+        }
+        i += 1;
+    }
+
+    fields
+}
+
+/// Parses a single attribute definition from `FT.INFO`.
+///
+/// Each attribute is a flat array: `["identifier", "name", "type", "TEXT", ...]`
+fn parse_single_attribute(
+    attr: &redis::Value,
+    vector_field: &str,
+) -> Option<FieldInfo> {
+    let parts = match attr {
+        redis::Value::Array(arr) => arr,
+        _ => return None,
+    };
+
+    let identifier = find_string_after(parts, "identifier")?;
+
+    // Skip the vector field itself.
+    if identifier == vector_field {
+        return None;
+    }
+
+    let attr_type = find_string_after(parts, "type").unwrap_or_else(|| "unknown".to_string());
+
+    Some(FieldInfo {
+        name: identifier,
+        field_type: attr_type,
+        indexed: true,
+    })
+}
+
+/// Finds the string value immediately after a given key in a flat array.
+fn find_string_after(parts: &[redis::Value], key: &str) -> Option<String> {
+    let mut j = 0;
+    while j + 1 < parts.len() {
+        if extract_bulk_string(&parts[j]).as_deref() == Some(key) {
+            return extract_bulk_string(&parts[j + 1]);
+        }
+        j += 1;
+    }
+    None
+}
+
+// ---------------------------------------------------------------------------
+// Low-level RESP value extractors
+// ---------------------------------------------------------------------------
+
+/// Extracts a `String` from a `redis::Value::BulkString`.
+fn extract_bulk_string(value: &redis::Value) -> Option<String> {
+    match value {
+        redis::Value::BulkString(bytes) => String::from_utf8(bytes.clone()).ok(),
+        redis::Value::SimpleString(s) => Some(s.clone()),
+        // Some Redis versions return status strings.
+        _ => None,
+    }
+}
+
+/// Extracts a `u64` from a `redis::Value::Int`.
+fn extract_int(value: &redis::Value) -> Option<u64> {
+    match value {
+        redis::Value::Int(n) => u64::try_from(*n).ok(),
+        _ => None,
+    }
+}
+
+/// Converts a `redis::Value` to a `serde_json::Value` for payload storage.
+fn resp_value_to_json(value: &redis::Value) -> serde_json::Value {
+    match value {
+        redis::Value::BulkString(bytes) => {
+            // Try UTF-8 string first; fall back to base64-ish representation.
+            match String::from_utf8(bytes.clone()) {
+                Ok(s) => {
+                    // Attempt to parse as JSON (number, bool, array, object).
+                    serde_json::from_str(&s).unwrap_or(serde_json::Value::String(s))
+                }
+                Err(_) => serde_json::Value::String(format!("<binary:{} bytes>", bytes.len())),
+            }
+        }
+        redis::Value::SimpleString(s) => serde_json::Value::String(s.clone()),
+        redis::Value::Int(n) => serde_json::json!(n),
+        redis::Value::Array(arr) => {
+            serde_json::Value::Array(arr.iter().map(resp_value_to_json).collect())
+        }
+        redis::Value::Nil => serde_json::Value::Null,
+        _ => serde_json::Value::Null,
     }
 }
 

--- a/crates/velesdb-migrate/src/connectors/redis_tests.rs
+++ b/crates/velesdb-migrate/src/connectors/redis_tests.rs
@@ -268,6 +268,46 @@ fn test_build_ft_search_cmd_with_payload_fields() {
     assert!(cmd_str.contains("embedding"));
 }
 
+#[test]
+fn test_parse_ft_search_response_binary_blob_vector() {
+    // GIVEN: a FT.SEARCH response where the vector field is a raw LE f32 blob
+    // (this is the default RediSearch storage format for VECTOR fields).
+    let mut blob = Vec::new();
+    blob.extend_from_slice(&f32::to_le_bytes(1.0_f32));
+    blob.extend_from_slice(&f32::to_le_bytes(2.5_f32));
+
+    let resp = redis::Value::Array(vec![
+        redis::Value::Int(1),
+        redis::Value::BulkString(b"doc:7".to_vec()),
+        redis::Value::Array(vec![
+            redis::Value::BulkString(b"embedding".to_vec()),
+            redis::Value::BulkString(blob),
+            redis::Value::BulkString(b"title".to_vec()),
+            redis::Value::BulkString(b"Hello".to_vec()),
+        ]),
+    ]);
+
+    // WHEN: parsing the response
+    let points =
+        parse_ft_search_response(&resp, "embedding", "doc:").expect("test: binary blob");
+
+    // THEN: vector is correctly decoded from LE f32 bytes
+    assert_eq!(points.len(), 1);
+    assert_eq!(points[0].id, "7");
+    assert_eq!(points[0].vector.len(), 2);
+    assert!(
+        (points[0].vector[0] - 1.0).abs() < 1e-6,
+        "expected 1.0, got {}",
+        points[0].vector[0]
+    );
+    assert!(
+        (points[0].vector[1] - 2.5).abs() < 1e-6,
+        "expected 2.5, got {}",
+        points[0].vector[1]
+    );
+    assert!(points[0].payload.contains_key("title"));
+}
+
 #[tokio::test]
 async fn test_extract_batch_fails_when_not_connected() {
     // GIVEN: a connector that has not been connected

--- a/crates/velesdb-migrate/src/connectors/redis_tests.rs
+++ b/crates/velesdb-migrate/src/connectors/redis_tests.rs
@@ -267,3 +267,21 @@ fn test_build_ft_search_cmd_with_payload_fields() {
     // Vector field should be auto-added.
     assert!(cmd_str.contains("embedding"));
 }
+
+#[tokio::test]
+async fn test_extract_batch_fails_when_not_connected() {
+    // GIVEN: a connector that has not been connected
+    let connector = RedisConnector::new(test_config());
+
+    // WHEN: extract_batch is called without connect()
+    let result = connector.extract_batch(None, 10).await;
+
+    // THEN: an error is returned indicating not connected
+    assert!(result.is_err(), "extract_batch should fail without connect()");
+    let err = result.unwrap_err().to_string();
+    assert!(
+        err.contains("Not connected"),
+        "expected 'Not connected' in error, got: {err}"
+    );
+}
+

--- a/crates/velesdb-migrate/src/connectors/redis_tests.rs
+++ b/crates/velesdb-migrate/src/connectors/redis_tests.rs
@@ -178,7 +178,13 @@ fn test_parse_ft_search_response_empty() {
 
 #[test]
 fn test_parse_ft_search_response_single_doc() {
-    // Simulate: FT.SEARCH returns 1 document with a JSON-array vector.
+    // Simulate: FT.SEARCH returns 1 document.
+    // RediSearch returns VECTOR fields as raw LE f32 binary blobs.
+    let mut vec_bytes = Vec::new();
+    vec_bytes.extend_from_slice(&0.1_f32.to_le_bytes());
+    vec_bytes.extend_from_slice(&0.2_f32.to_le_bytes());
+    vec_bytes.extend_from_slice(&0.3_f32.to_le_bytes());
+
     let resp = redis::Value::Array(vec![
         redis::Value::Int(1),
         // Document key
@@ -186,9 +192,9 @@ fn test_parse_ft_search_response_single_doc() {
         // Field-value pairs
         redis::Value::Array(vec![
             redis::Value::BulkString(b"embedding".to_vec()),
-            redis::Value::BulkString(b"[0.1, 0.2, 0.3]".to_vec()),
+            redis::Value::BulkString(vec_bytes),
             redis::Value::BulkString(b"title".to_vec()),
-            redis::Value::BulkString(b"\"Hello World\"".to_vec()),
+            redis::Value::BulkString(b"Hello World".to_vec()),
         ]),
     ]);
 
@@ -203,18 +209,48 @@ fn test_parse_ft_search_response_single_doc() {
 }
 
 #[test]
+fn test_parse_ft_search_response_zero_vector() {
+    // Regression: all-zero vectors are valid UTF-8 (null bytes), so the old
+    // UTF-8 heuristic failed to decode them. Verify they are decoded correctly.
+    let vec_bytes: Vec<u8> = std::iter::repeat(0u8).take(12).collect(); // 3 × f32 zeros
+
+    let resp = redis::Value::Array(vec![
+        redis::Value::Int(1),
+        redis::Value::BulkString(b"doc:zero".to_vec()),
+        redis::Value::Array(vec![
+            redis::Value::BulkString(b"embedding".to_vec()),
+            redis::Value::BulkString(vec_bytes),
+        ]),
+    ]);
+
+    let points =
+        parse_ft_search_response(&resp, "embedding", "doc:").expect("test: zero vector parse");
+
+    assert_eq!(points.len(), 1);
+    assert_eq!(points[0].vector, vec![0.0_f32, 0.0, 0.0]);
+}
+
+#[test]
 fn test_parse_ft_search_response_multiple_docs() {
+    let mut vec1 = Vec::new();
+    vec1.extend_from_slice(&1.0_f32.to_le_bytes());
+    vec1.extend_from_slice(&2.0_f32.to_le_bytes());
+
+    let mut vec2 = Vec::new();
+    vec2.extend_from_slice(&3.0_f32.to_le_bytes());
+    vec2.extend_from_slice(&4.0_f32.to_le_bytes());
+
     let resp = redis::Value::Array(vec![
         redis::Value::Int(2),
         redis::Value::BulkString(b"doc:1".to_vec()),
         redis::Value::Array(vec![
             redis::Value::BulkString(b"embedding".to_vec()),
-            redis::Value::BulkString(b"[1.0, 2.0]".to_vec()),
+            redis::Value::BulkString(vec1),
         ]),
         redis::Value::BulkString(b"doc:2".to_vec()),
         redis::Value::Array(vec![
             redis::Value::BulkString(b"embedding".to_vec()),
-            redis::Value::BulkString(b"[3.0, 4.0]".to_vec()),
+            redis::Value::BulkString(vec2),
         ]),
     ]);
 
@@ -231,12 +267,13 @@ fn test_parse_ft_search_response_multiple_docs() {
 #[test]
 fn test_parse_ft_search_response_no_prefix_match() {
     // Document key doesn't start with the configured prefix.
+    let vec_bytes = 5.0_f32.to_le_bytes().to_vec();
     let resp = redis::Value::Array(vec![
         redis::Value::Int(1),
         redis::Value::BulkString(b"other:99".to_vec()),
         redis::Value::Array(vec![
             redis::Value::BulkString(b"embedding".to_vec()),
-            redis::Value::BulkString(b"[5.0]".to_vec()),
+            redis::Value::BulkString(vec_bytes),
         ]),
     ]);
 
@@ -250,9 +287,10 @@ fn test_parse_ft_search_response_no_prefix_match() {
 
 #[test]
 fn test_resp_value_to_json_types() {
-    // BulkString containing a number string parses to JSON number.
+    // BulkString always preserved as string — no type coercion.
+    // "42" must not silently become 42 (would corrupt zip codes, string IDs, etc.).
     let val = resp_value_to_json(&redis::Value::BulkString(b"42".to_vec()));
-    assert_eq!(val, serde_json::json!(42));
+    assert_eq!(val, serde_json::json!("42"));
 
     // BulkString containing a plain string stays as string.
     let val = resp_value_to_json(&redis::Value::BulkString(b"hello".to_vec()));

--- a/crates/velesdb-migrate/src/connectors/redis_tests.rs
+++ b/crates/velesdb-migrate/src/connectors/redis_tests.rs
@@ -120,6 +120,30 @@ fn test_redis_extract_payload_filtered() {
 // ---------------------------------------------------------------------------
 
 #[test]
+fn test_find_info_int_stride2_correctness() {
+    // GIVEN: a flat FT.INFO-style key-value list where a value is "num_docs"
+    // (if stride were 1, the value at index 1 would be checked as a key)
+    let items = vec![
+        redis::Value::BulkString(b"some_key".to_vec()),
+        redis::Value::BulkString(b"num_docs".to_vec()), // value at odd index — must NOT match
+        redis::Value::BulkString(b"num_docs".to_vec()),  // key at even index — must match
+        redis::Value::BulkString(b"42".to_vec()),
+    ];
+    // WHEN: stride is 2, only the key at index 2 matches, returning 42
+    let result = find_info_int(&items, "num_docs");
+    assert_eq!(result, Some(42), "stride-1 bug: matched value as key");
+}
+
+#[test]
+fn test_find_info_int_returns_none_when_missing() {
+    let items = vec![
+        redis::Value::BulkString(b"index_name".to_vec()),
+        redis::Value::BulkString(b"myidx".to_vec()),
+    ];
+    assert_eq!(find_info_int(&items, "num_docs"), None);
+}
+
+#[test]
 fn test_decode_vector_blob_le_bytes() {
     // 2 floats: 1.0 (0x3F800000 LE) and -2.5 (0xC0200000 LE)
     let bytes = [0x00u8, 0x00, 0x80, 0x3F, 0x00, 0x00, 0x20, 0xC0];

--- a/crates/velesdb-migrate/src/connectors/redis_tests.rs
+++ b/crates/velesdb-migrate/src/connectors/redis_tests.rs
@@ -1,7 +1,9 @@
 //! Tests for Redis Vector Search connector.
 
 use super::*;
+use crate::config::RedisConfig;
 use crate::connectors::SourceConnector;
+use std::collections::HashMap;
 
 fn test_config() -> RedisConfig {
     RedisConfig {
@@ -42,18 +44,6 @@ fn test_redis_config_with_filter() {
 fn test_redis_connector_new() {
     let connector = RedisConnector::new(test_config());
     assert_eq!(connector.source_type(), "redis");
-}
-
-#[test]
-fn test_redis_build_api_url() {
-    assert_eq!(
-        RedisConnector::build_api_url("redis://localhost:6379"),
-        "http://localhost:6379"
-    );
-    assert_eq!(
-        RedisConnector::build_api_url("rediss://cloud.redis.io:6380/"),
-        "https://cloud.redis.io:6380"
-    );
 }
 
 #[test]
@@ -123,4 +113,157 @@ fn test_redis_extract_payload_filtered() {
     assert_eq!(payload.len(), 1);
     assert!(payload.contains_key("title"));
     assert!(!payload.contains_key("count"));
+}
+
+// ---------------------------------------------------------------------------
+// RESP helper tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_decode_vector_blob_le_bytes() {
+    // 2 floats: 1.0 (0x3F800000 LE) and -2.5 (0xC0200000 LE)
+    let bytes = [0x00u8, 0x00, 0x80, 0x3F, 0x00, 0x00, 0x20, 0xC0];
+    let v = decode_vector_blob(&bytes);
+    assert_eq!(v.len(), 2);
+    assert!(
+        (v[0] - 1.0).abs() < 1e-6,
+        "v[0] should be 1.0, got {}",
+        v[0]
+    );
+    assert!(
+        (v[1] - (-2.5)).abs() < 1e-6,
+        "v[1] should be -2.5, got {}",
+        v[1]
+    );
+}
+
+#[test]
+fn test_decode_vector_blob_empty() {
+    let v = decode_vector_blob(&[]);
+    assert!(v.is_empty());
+}
+
+#[test]
+fn test_parse_ft_search_response_empty() {
+    // FT.SEARCH returns [0] when no results match.
+    let resp = redis::Value::Array(vec![redis::Value::Int(0)]);
+    let points =
+        parse_ft_search_response(&resp, "embedding", "doc:").expect("test: empty response");
+    assert!(points.is_empty());
+}
+
+#[test]
+fn test_parse_ft_search_response_single_doc() {
+    // Simulate: FT.SEARCH returns 1 document with a JSON-array vector.
+    let resp = redis::Value::Array(vec![
+        redis::Value::Int(1),
+        // Document key
+        redis::Value::BulkString(b"doc:42".to_vec()),
+        // Field-value pairs
+        redis::Value::Array(vec![
+            redis::Value::BulkString(b"embedding".to_vec()),
+            redis::Value::BulkString(b"[0.1, 0.2, 0.3]".to_vec()),
+            redis::Value::BulkString(b"title".to_vec()),
+            redis::Value::BulkString(b"\"Hello World\"".to_vec()),
+        ]),
+    ]);
+
+    let points =
+        parse_ft_search_response(&resp, "embedding", "doc:").expect("test: single doc parse");
+
+    assert_eq!(points.len(), 1);
+    assert_eq!(points[0].id, "42");
+    assert_eq!(points[0].vector, vec![0.1, 0.2, 0.3]);
+    assert!(points[0].payload.contains_key("title"));
+    assert!(!points[0].payload.contains_key("embedding"));
+}
+
+#[test]
+fn test_parse_ft_search_response_multiple_docs() {
+    let resp = redis::Value::Array(vec![
+        redis::Value::Int(2),
+        redis::Value::BulkString(b"doc:1".to_vec()),
+        redis::Value::Array(vec![
+            redis::Value::BulkString(b"embedding".to_vec()),
+            redis::Value::BulkString(b"[1.0, 2.0]".to_vec()),
+        ]),
+        redis::Value::BulkString(b"doc:2".to_vec()),
+        redis::Value::Array(vec![
+            redis::Value::BulkString(b"embedding".to_vec()),
+            redis::Value::BulkString(b"[3.0, 4.0]".to_vec()),
+        ]),
+    ]);
+
+    let points =
+        parse_ft_search_response(&resp, "embedding", "doc:").expect("test: multiple docs parse");
+
+    assert_eq!(points.len(), 2);
+    assert_eq!(points[0].id, "1");
+    assert_eq!(points[0].vector, vec![1.0, 2.0]);
+    assert_eq!(points[1].id, "2");
+    assert_eq!(points[1].vector, vec![3.0, 4.0]);
+}
+
+#[test]
+fn test_parse_ft_search_response_no_prefix_match() {
+    // Document key doesn't start with the configured prefix.
+    let resp = redis::Value::Array(vec![
+        redis::Value::Int(1),
+        redis::Value::BulkString(b"other:99".to_vec()),
+        redis::Value::Array(vec![
+            redis::Value::BulkString(b"embedding".to_vec()),
+            redis::Value::BulkString(b"[5.0]".to_vec()),
+        ]),
+    ]);
+
+    let points =
+        parse_ft_search_response(&resp, "embedding", "doc:").expect("test: no prefix match");
+
+    assert_eq!(points.len(), 1);
+    // Full key is used as ID when prefix doesn't match.
+    assert_eq!(points[0].id, "other:99");
+}
+
+#[test]
+fn test_resp_value_to_json_types() {
+    // BulkString containing a number string parses to JSON number.
+    let val = resp_value_to_json(&redis::Value::BulkString(b"42".to_vec()));
+    assert_eq!(val, serde_json::json!(42));
+
+    // BulkString containing a plain string stays as string.
+    let val = resp_value_to_json(&redis::Value::BulkString(b"hello".to_vec()));
+    assert_eq!(val, serde_json::json!("hello"));
+
+    // Int maps to JSON number.
+    let val = resp_value_to_json(&redis::Value::Int(7));
+    assert_eq!(val, serde_json::json!(7));
+
+    // Nil maps to JSON null.
+    let val = resp_value_to_json(&redis::Value::Nil);
+    assert!(val.is_null());
+}
+
+#[test]
+fn test_build_ft_search_cmd_no_payload_fields() {
+    // When payload_fields is empty, no RETURN clause is added.
+    let cmd = build_ft_search_cmd("myidx", "*", 0, 10, "embedding", &[]);
+    let packed = cmd.get_packed_command();
+    let cmd_str = String::from_utf8_lossy(&packed);
+    // Should contain FT.SEARCH, index, query, LIMIT but no RETURN.
+    assert!(cmd_str.contains("FT.SEARCH"));
+    assert!(cmd_str.contains("myidx"));
+    assert!(!cmd_str.contains("RETURN"));
+}
+
+#[test]
+fn test_build_ft_search_cmd_with_payload_fields() {
+    let fields = vec!["title".to_string(), "score".to_string()];
+    let cmd = build_ft_search_cmd("myidx", "*", 5, 20, "embedding", &fields);
+    let packed = cmd.get_packed_command();
+    let cmd_str = String::from_utf8_lossy(&packed);
+    assert!(cmd_str.contains("RETURN"));
+    assert!(cmd_str.contains("title"));
+    assert!(cmd_str.contains("score"));
+    // Vector field should be auto-added.
+    assert!(cmd_str.contains("embedding"));
 }

--- a/crates/velesdb-migrate/src/connectors/relation_detector.rs
+++ b/crates/velesdb-migrate/src/connectors/relation_detector.rs
@@ -1,0 +1,122 @@
+//! Auto-detection of source relations for graph migration.
+//!
+//! Analyses the source schema to infer FK-like relationships
+//! using naming conventions and source-specific signals.
+
+use crate::config::RelationConfig;
+use crate::connectors::SourceSchema;
+
+/// Detects probable relations from a source schema using naming heuristics.
+///
+/// Rules:
+/// - A field whose name ends with `_id` is treated as a FK to another table.
+///   The target table name is inferred by removing the `_id` suffix.
+///   Edge label is `HAS_<UPPERCASED_BASE>`.
+///
+/// - For Weaviate: a field whose type starts with an uppercase letter
+///   (cross-reference to a class) and is fully alphanumeric is detected
+///   as a relation.
+#[must_use]
+pub fn detect_relations(schema: &SourceSchema) -> Vec<RelationConfig> {
+    schema
+        .fields
+        .iter()
+        .filter_map(detect_single_relation)
+        .collect()
+}
+
+fn detect_single_relation(
+    field: &crate::connectors::FieldInfo,
+) -> Option<RelationConfig> {
+    // Strategy 1: column name ends with _id (common FK convention)
+    if let Some(base) = field.name.strip_suffix("_id") {
+        if base.is_empty() {
+            return None;
+        }
+        let edge_label = format!("HAS_{}", base.to_uppercase());
+        return Some(RelationConfig {
+            from_column: field.name.clone(),
+            to_table: base.to_string(),
+            to_column: "id".to_string(),
+            edge_label,
+            weight_column: None,
+        });
+    }
+
+    // Strategy 2: Weaviate cross-reference -- field_type starts with uppercase
+    // (Weaviate class names are PascalCase, e.g., "Author", "Category")
+    if field.field_type.chars().next().is_some_and(|c| c.is_uppercase())
+        && !field.field_type.is_empty()
+        && field.field_type.chars().all(|c| c.is_alphanumeric())
+    {
+        let edge_label = format!("HAS_{}", field.name.to_uppercase());
+        return Some(RelationConfig {
+            from_column: field.name.clone(),
+            to_table: field.field_type.to_lowercase(),
+            to_column: "id".to_string(),
+            edge_label,
+            weight_column: None,
+        });
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::connectors::{FieldInfo, SourceSchema};
+
+    fn make_schema(fields: Vec<(&str, &str)>) -> SourceSchema {
+        SourceSchema {
+            source_type: "test".to_string(),
+            collection: "items".to_string(),
+            dimension: 4,
+            total_count: None,
+            fields: fields
+                .into_iter()
+                .map(|(name, ft)| FieldInfo {
+                    name: name.to_string(),
+                    field_type: ft.to_string(),
+                    indexed: false,
+                })
+                .collect(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn test_detect_author_id_relation() {
+        let schema = make_schema(vec![("author_id", "integer")]);
+        let relations = detect_relations(&schema);
+        assert_eq!(relations.len(), 1);
+        assert_eq!(relations[0].from_column, "author_id");
+        assert_eq!(relations[0].to_table, "author");
+        assert_eq!(relations[0].edge_label, "HAS_AUTHOR");
+    }
+
+    #[test]
+    fn test_detect_weaviate_crossref() {
+        let schema = make_schema(vec![("author", "Author")]);
+        let relations = detect_relations(&schema);
+        assert_eq!(relations.len(), 1);
+        assert_eq!(relations[0].from_column, "author");
+        assert_eq!(relations[0].to_table, "author");
+        assert_eq!(relations[0].edge_label, "HAS_AUTHOR");
+    }
+
+    #[test]
+    fn test_no_relations_for_normal_fields() {
+        let schema = make_schema(vec![("title", "string"), ("price", "float")]);
+        let relations = detect_relations(&schema);
+        assert!(relations.is_empty());
+    }
+
+    #[test]
+    fn test_bare_id_field_not_detected() {
+        // "_id" with empty base should be ignored
+        let schema = make_schema(vec![("_id", "ObjectId")]);
+        let relations = detect_relations(&schema);
+        assert!(relations.is_empty());
+    }
+}

--- a/crates/velesdb-migrate/src/connectors/weaviate.rs
+++ b/crates/velesdb-migrate/src/connectors/weaviate.rs
@@ -120,6 +120,8 @@ impl SourceConnector for WeaviateConnector {
     }
 
     async fn connect(&mut self) -> Result<()> {
+        crate::connectors::common::validate_url(&self.config.url)?;
+
         info!("Connecting to Weaviate at {}", self.config.url);
 
         let resp = self
@@ -359,5 +361,12 @@ mod tests {
 
         let json = serde_json::to_string(&query).unwrap();
         assert!(json.contains("Get"));
+    }
+
+    #[test]
+    fn test_connect_rejects_file_url() {
+        assert!(
+            crate::connectors::common::validate_url("file:///etc/passwd").is_err()
+        );
     }
 }

--- a/crates/velesdb-migrate/src/lib.rs
+++ b/crates/velesdb-migrate/src/lib.rs
@@ -69,6 +69,8 @@ pub mod error;
 #[allow(clippy::pedantic)]
 pub mod pipeline;
 #[allow(clippy::pedantic)]
+pub mod pipeline_graph;
+#[allow(clippy::pedantic)]
 pub(crate) mod pipeline_points;
 #[allow(clippy::pedantic)]
 pub mod retry;

--- a/crates/velesdb-migrate/src/pipeline.rs
+++ b/crates/velesdb-migrate/src/pipeline.rs
@@ -365,6 +365,22 @@ impl Pipeline {
 
         progress.finish_with_message("Migration complete");
 
+        // Graph migration phase: migrate FK relations as graph edges.
+        if let Some(ref db) = db {
+            if self.config.destination.graph_collection.is_some()
+                && !self.config.relations.is_empty()
+            {
+                info!("Starting graph migration phase...");
+                let graph_connector = crate::connectors::create_connector(&self.config.source)?;
+                let mut graph_phase = crate::pipeline_graph::GraphMigrationPhase::new(
+                    &self.config,
+                    graph_connector,
+                );
+                graph_phase.connect().await?;
+                let _graph_stats = graph_phase.run(db).await?;
+            }
+        }
+
         self.connector.close().await?;
 
         stats.duration_secs = resumed_duration_secs + start.elapsed().as_secs_f64();
@@ -546,11 +562,13 @@ mod tests {
                 dimension: 2,
                 metric: DistanceMetric::Cosine,
                 storage_mode: StorageMode::Full,
+                graph_collection: None,
             },
             options: MigrationOptions {
                 dry_run: true,
                 ..MigrationOptions::default()
             },
+            relations: vec![],
         };
 
         let mut pipeline = crate::Pipeline::new(config)
@@ -576,11 +594,13 @@ mod tests {
                 dimension: 3,
                 metric: crate::config::DistanceMetric::Cosine,
                 storage_mode: crate::config::StorageMode::Full,
+                graph_collection: None,
             },
             options: crate::config::MigrationOptions {
                 checkpoint_path: Some(std::path::PathBuf::from("./custom-checkpoint.json")),
                 ..crate::config::MigrationOptions::default()
             },
+            relations: vec![],
         };
 
         assert_eq!(

--- a/crates/velesdb-migrate/src/pipeline.rs
+++ b/crates/velesdb-migrate/src/pipeline.rs
@@ -24,6 +24,12 @@ pub struct MigrationStats {
     pub batches: u64,
     /// Duration in seconds.
     pub duration_secs: f64,
+    /// Graph edges created (0 if no graph migration phase ran).
+    pub edges_created: u64,
+    /// Graph edges that failed to create.
+    pub edges_failed: u64,
+    /// FK relations processed during graph migration.
+    pub relations_processed: usize,
 }
 
 impl MigrationStats {
@@ -377,11 +383,11 @@ impl Pipeline {
                     graph_connector,
                 );
                 graph_phase.connect().await?;
-                // Stats discarded here; graph phase runs for side effects only
-                // (edge insertion + graph collection flush). Surfacing these stats
-                // to MigrationStats is tracked in TODO(US-GRAPH-02).
-                let _graph_stats = graph_phase.run(db).await?;
+                let graph_stats = graph_phase.run(db).await?;
                 graph_phase.close().await?;
+                stats.edges_created = graph_stats.edges_created;
+                stats.edges_failed = graph_stats.edges_failed;
+                stats.relations_processed = graph_stats.relations_processed;
             }
         }
 

--- a/crates/velesdb-migrate/src/pipeline.rs
+++ b/crates/velesdb-migrate/src/pipeline.rs
@@ -266,10 +266,13 @@ impl Pipeline {
         let batch_size = self.config.options.batch_size;
 
         loop {
-            let batch = self
-                .connector
-                .extract_batch(offset.clone(), batch_size)
-                .await?;
+            let connector = &mut *self.connector;
+            let batch = crate::retry::with_retry(
+                &crate::retry::RetryConfig::for_transient_errors(),
+                "extract_batch",
+                || connector.extract_batch(offset.clone(), batch_size),
+            )
+            .await?;
 
             if batch.points.is_empty() {
                 break;
@@ -281,6 +284,7 @@ impl Pipeline {
             let transformed = self.transformer.transform_batch(batch.points);
 
             if let Some(ref db) = db {
+                #[allow(deprecated)] // TODO(MIGRATE-01): migrate to get_vector_collection()
                 let collection = db
                     .get_vector_collection(&self.config.destination.collection)
                     .ok_or_else(|| {
@@ -347,7 +351,7 @@ impl Pipeline {
                     }
                 }
             } else {
-                stats.loaded += transformed.len() as u64;
+                // dry_run: nothing loaded, stats.loaded stays 0
             }
 
             progress.set_position(stats.loaded.min(total));
@@ -506,6 +510,55 @@ mod tests {
 
         assert_eq!(first, second);
         assert_ne!(first, other);
+    }
+
+    #[tokio::test]
+    async fn test_pipeline_dry_run_loaded_stays_zero() {
+        use crate::config::{
+            DestinationConfig, DistanceMetric, MigrationConfig, MigrationOptions, SourceConfig,
+            StorageMode,
+        };
+        use crate::connectors::json_file::JsonFileConfig;
+        use tempfile::TempDir;
+
+        let dir = TempDir::new().expect("test: create tempdir");
+        let json_path = dir.path().join("test_data.json");
+        // 3 points with 2-dimensional vectors
+        let json_content = serde_json::json!([
+            {"id": "1", "vector": [0.1, 0.2], "payload": {}},
+            {"id": "2", "vector": [0.3, 0.4], "payload": {}},
+            {"id": "3", "vector": [0.5, 0.6], "payload": {}}
+        ]);
+        std::fs::write(&json_path, json_content.to_string())
+            .expect("test: write json");
+
+        let config = MigrationConfig {
+            source: SourceConfig::JsonFile(JsonFileConfig {
+                path: json_path,
+                array_path: String::new(),
+                id_field: "id".to_string(),
+                vector_field: "vector".to_string(),
+                payload_fields: vec![],
+            }),
+            destination: DestinationConfig {
+                path: dir.path().to_path_buf(),
+                collection: "dry_run_test".to_string(),
+                dimension: 2,
+                metric: DistanceMetric::Cosine,
+                storage_mode: StorageMode::Full,
+            },
+            options: MigrationOptions {
+                dry_run: true,
+                ..MigrationOptions::default()
+            },
+        };
+
+        let mut pipeline = crate::Pipeline::new(config)
+            .expect("test: create pipeline");
+        let stats = pipeline.run().await.expect("test: run pipeline");
+
+        assert_eq!(stats.extracted, 3, "Should extract 3 points");
+        assert_eq!(stats.loaded, 0, "dry_run must not increment loaded");
     }
 
     #[test]

--- a/crates/velesdb-migrate/src/pipeline.rs
+++ b/crates/velesdb-migrate/src/pipeline.rs
@@ -270,11 +270,12 @@ impl Pipeline {
         };
 
         let batch_size = self.config.options.batch_size;
+        let retry_config = crate::retry::RetryConfig::for_transient_errors();
 
         loop {
             let connector = &mut *self.connector;
             let batch = crate::retry::with_retry(
-                &crate::retry::RetryConfig::for_transient_errors(),
+                &retry_config,
                 "extract_batch",
                 || connector.extract_batch(offset.clone(), batch_size),
             )
@@ -517,6 +518,9 @@ mod tests {
             failed: 0,
             batches: 10,
             duration_secs: 2.0,
+            edges_created: 0,
+            edges_failed: 0,
+            relations_processed: 0,
         };
 
         assert!((stats.throughput() - 500.0).abs() < 0.001);

--- a/crates/velesdb-migrate/src/pipeline.rs
+++ b/crates/velesdb-migrate/src/pipeline.rs
@@ -377,6 +377,9 @@ impl Pipeline {
                     graph_connector,
                 );
                 graph_phase.connect().await?;
+                // Stats discarded here; graph phase runs for side effects only
+                // (edge insertion + graph collection flush). Surfacing these stats
+                // to MigrationStats is tracked in TODO(US-GRAPH-02).
                 let _graph_stats = graph_phase.run(db).await?;
                 graph_phase.close().await?;
             }

--- a/crates/velesdb-migrate/src/pipeline.rs
+++ b/crates/velesdb-migrate/src/pipeline.rs
@@ -378,6 +378,7 @@ impl Pipeline {
                 );
                 graph_phase.connect().await?;
                 let _graph_stats = graph_phase.run(db).await?;
+                graph_phase.close().await?;
             }
         }
 

--- a/crates/velesdb-migrate/src/pipeline_graph.rs
+++ b/crates/velesdb-migrate/src/pipeline_graph.rs
@@ -73,9 +73,12 @@ impl<'a> GraphMigrationPhase<'a> {
             return Ok(GraphMigrationStats::default());
         }
 
+        // TODO(US-GRAPH-01): single-pass extraction — currently opens a second
+        // connector and scans the entire source again for graph edges. This doubles
+        // I/O for large sources. Future improvement: extract edges inline during
+        // the main vector pipeline pass.
         let mut stats = GraphMigrationStats::default();
         let batch_size = self.config.options.batch_size;
-        let mut edge_id_counter: u64 = 0;
 
         for relation in relations {
             info!(
@@ -87,7 +90,7 @@ impl<'a> GraphMigrationPhase<'a> {
             );
 
             let edges = self
-                .extract_edges_for_relation(relation, batch_size, &mut edge_id_counter)
+                .extract_edges_for_relation(relation, batch_size)
                 .await?;
 
             let total = edges.len() as u64;
@@ -112,7 +115,6 @@ impl<'a> GraphMigrationPhase<'a> {
         &self,
         relation: &RelationConfig,
         batch_size: usize,
-        edge_id: &mut u64,
     ) -> Result<Vec<velesdb_core::GraphEdge>> {
         let mut edges = Vec::new();
         let mut offset = None;
@@ -121,11 +123,11 @@ impl<'a> GraphMigrationPhase<'a> {
             let batch = self.connector.extract_batch(offset.clone(), batch_size).await?;
 
             for point in &batch.points {
-                if let Some(edge) = build_edge(point, relation, edge_id) {
+                if let Some(edge) = build_edge(point, relation) {
                     edges.push(edge);
                 } else {
                     debug!(
-                        "Skipping point '{}': missing column '{}'",
+                        "Skipping point '{}': unsupported type or missing column '{}'",
                         point.id, relation.from_column
                     );
                 }
@@ -157,7 +159,6 @@ fn ensure_graph_collection_exists(
 fn build_edge(
     point: &crate::connectors::ExtractedPoint,
     relation: &RelationConfig,
-    edge_id: &mut u64,
 ) -> Option<velesdb_core::GraphEdge> {
     let from_node_id = stable_point_id(&point.id);
 
@@ -165,8 +166,8 @@ fn build_edge(
     let fk_str = value_to_id_str(fk_value)?;
     let to_node_id = stable_point_id(&fk_str);
 
-    let id = *edge_id;
-    *edge_id += 1;
+    let key = format!("{from_node_id}-{to_node_id}-{}", relation.edge_label);
+    let id = crate::pipeline::fnv1a64(key.as_bytes());
 
     let edge = match velesdb_core::GraphEdge::new(id, from_node_id, to_node_id, &relation.edge_label) {
         Ok(e) => e,
@@ -241,21 +242,18 @@ mod tests {
     fn test_build_edge_string_fk() {
         let point = make_point("doc-1", serde_json::json!({"author_id": "auth-42"}));
         let relation = make_relation("author_id", "AUTHORED_BY");
-        let mut edge_id = 0u64;
-        let edge = build_edge(&point, &relation, &mut edge_id);
+        let edge = build_edge(&point, &relation);
         assert!(edge.is_some());
         let e = edge.expect("test: edge should be Some");
         assert_eq!(e.source(), stable_point_id("doc-1"));
         assert_eq!(e.target(), stable_point_id("auth-42"));
-        assert_eq!(edge_id, 1);
     }
 
     #[test]
     fn test_build_edge_numeric_fk() {
         let point = make_point("99", serde_json::json!({"category_id": 7}));
         let relation = make_relation("category_id", "BELONGS_TO");
-        let mut edge_id = 0u64;
-        let edge = build_edge(&point, &relation, &mut edge_id);
+        let edge = build_edge(&point, &relation);
         assert!(edge.is_some());
         assert_eq!(
             edge.expect("test: edge should be Some").source(),
@@ -267,8 +265,35 @@ mod tests {
     fn test_build_edge_missing_fk_returns_none() {
         let point = make_point("1", serde_json::json!({}));
         let relation = make_relation("author_id", "AUTHORED_BY");
-        let mut edge_id = 0u64;
-        assert!(build_edge(&point, &relation, &mut edge_id).is_none());
-        assert_eq!(edge_id, 0); // counter not incremented on skip
+        assert!(build_edge(&point, &relation).is_none());
+    }
+
+    #[test]
+    fn test_build_edge_string_fk_deterministic_id() {
+        // GIVEN: same point and relation
+        let point = make_point("doc-1", serde_json::json!({"author_id": "auth-42"}));
+        let relation = make_relation("author_id", "AUTHORED_BY");
+
+        // WHEN: build_edge is called twice
+        let e1 = build_edge(&point, &relation).expect("test: e1 should be Some");
+        let e2 = build_edge(&point, &relation).expect("test: e2 should be Some");
+
+        // THEN: both produce the same deterministic ID
+        assert_eq!(e1.id(), e2.id(), "Edge IDs must be deterministic for the same input");
+    }
+
+    #[test]
+    fn test_build_edge_different_labels_produce_different_ids() {
+        // GIVEN: same point but different edge labels
+        let point = make_point("doc-1", serde_json::json!({"author_id": "auth-42"}));
+        let rel1 = make_relation("author_id", "AUTHORED_BY");
+        let rel2 = make_relation("author_id", "EDITED_BY");
+
+        // WHEN: build_edge is called with each relation
+        let e1 = build_edge(&point, &rel1).expect("test: e1 should be Some");
+        let e2 = build_edge(&point, &rel2).expect("test: e2 should be Some");
+
+        // THEN: different labels produce different IDs
+        assert_ne!(e1.id(), e2.id(), "Different edge labels must produce different IDs");
     }
 }

--- a/crates/velesdb-migrate/src/pipeline_graph.rs
+++ b/crates/velesdb-migrate/src/pipeline_graph.rs
@@ -1,0 +1,274 @@
+//! Graph migration phase -- migrates FK relations as graph edges.
+
+use tracing::{debug, info, warn};
+
+use crate::config::{MigrationConfig, RelationConfig};
+use crate::connectors::SourceConnector;
+use crate::error::{Error, Result};
+use crate::pipeline_points::stable_point_id;
+
+/// Statistics from graph migration.
+#[derive(Debug, Default, Clone)]
+pub struct GraphMigrationStats {
+    /// Total relations processed.
+    pub relations_processed: usize,
+    /// Total edges successfully created.
+    pub edges_created: u64,
+    /// Total edges that failed to create.
+    pub edges_failed: u64,
+}
+
+/// Graph migration phase: migrates FK relations as edges in a `GraphCollection`.
+pub struct GraphMigrationPhase<'a> {
+    config: &'a MigrationConfig,
+    connector: Box<dyn SourceConnector>,
+}
+
+impl<'a> GraphMigrationPhase<'a> {
+    /// Creates a new graph migration phase.
+    pub fn new(config: &'a MigrationConfig, connector: Box<dyn SourceConnector>) -> Self {
+        Self { config, connector }
+    }
+
+    /// Connects the underlying source connector.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the source connection fails.
+    pub async fn connect(&mut self) -> Result<()> {
+        self.connector.connect().await
+    }
+
+    /// Runs the graph migration.
+    ///
+    /// Iterates over all configured relations, extracts FK columns from the
+    /// source, and inserts edges into the `VelesDB` `GraphCollection`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the database or graph collection cannot be
+    /// opened or created.
+    pub async fn run(
+        &self,
+        db: &velesdb_core::Database,
+    ) -> Result<GraphMigrationStats> {
+        let graph_name = self
+            .config
+            .destination
+            .graph_collection
+            .as_deref()
+            .ok_or_else(|| Error::Config("graph_collection not configured".to_string()))?;
+
+        ensure_graph_collection_exists(db, graph_name)?;
+
+        let gc = db
+            .get_graph_collection(graph_name)
+            .ok_or_else(|| {
+                Error::DestinationConnection("Graph collection not found".to_string())
+            })?;
+
+        let relations = &self.config.relations;
+        if relations.is_empty() {
+            info!("No relations configured, skipping graph phase");
+            return Ok(GraphMigrationStats::default());
+        }
+
+        let mut stats = GraphMigrationStats::default();
+        let batch_size = self.config.options.batch_size;
+        let mut edge_id_counter: u64 = 0;
+
+        for relation in relations {
+            info!(
+                "Migrating relation: {} -> {}.{} [{}]",
+                relation.from_column,
+                relation.to_table,
+                relation.to_column,
+                relation.edge_label
+            );
+
+            let edges = self
+                .extract_edges_for_relation(relation, batch_size, &mut edge_id_counter)
+                .await?;
+
+            let total = edges.len() as u64;
+            let inserted = gc.add_edges_batch(edges) as u64;
+            stats.edges_created += inserted;
+            stats.edges_failed += total.saturating_sub(inserted);
+            stats.relations_processed += 1;
+        }
+
+        gc.flush_full()
+            .map_err(|e| Error::DestinationConnection(format!("Graph flush failed: {e}")))?;
+
+        info!(
+            "Graph migration complete: {} edges created, {} failed",
+            stats.edges_created, stats.edges_failed
+        );
+
+        Ok(stats)
+    }
+
+    async fn extract_edges_for_relation(
+        &self,
+        relation: &RelationConfig,
+        batch_size: usize,
+        edge_id: &mut u64,
+    ) -> Result<Vec<velesdb_core::GraphEdge>> {
+        let mut edges = Vec::new();
+        let mut offset = None;
+
+        loop {
+            let batch = self.connector.extract_batch(offset.clone(), batch_size).await?;
+
+            for point in &batch.points {
+                if let Some(edge) = build_edge(point, relation, edge_id) {
+                    edges.push(edge);
+                } else {
+                    debug!(
+                        "Skipping point '{}': missing column '{}'",
+                        point.id, relation.from_column
+                    );
+                }
+            }
+
+            if !batch.has_more {
+                break;
+            }
+            offset = batch.next_offset;
+        }
+
+        Ok(edges)
+    }
+}
+
+fn ensure_graph_collection_exists(
+    db: &velesdb_core::Database,
+    name: &str,
+) -> Result<()> {
+    if db.get_graph_collection(name).is_some() {
+        return Ok(());
+    }
+    db.create_graph_collection(name, velesdb_core::GraphSchema::schemaless())
+        .map_err(|e| {
+            Error::DestinationConnection(format!("Cannot create graph collection: {e}"))
+        })
+}
+
+fn build_edge(
+    point: &crate::connectors::ExtractedPoint,
+    relation: &RelationConfig,
+    edge_id: &mut u64,
+) -> Option<velesdb_core::GraphEdge> {
+    let from_node_id = stable_point_id(&point.id);
+
+    let fk_value = point.payload.get(&relation.from_column)?;
+    let fk_str = value_to_id_str(fk_value)?;
+    let to_node_id = stable_point_id(&fk_str);
+
+    let id = *edge_id;
+    *edge_id += 1;
+
+    let edge = match velesdb_core::GraphEdge::new(id, from_node_id, to_node_id, &relation.edge_label) {
+        Ok(e) => e,
+        Err(e) => {
+            warn!("Failed to create edge {}: {}", id, e);
+            return None;
+        }
+    };
+
+    Some(attach_weight(edge, point, relation))
+}
+
+fn attach_weight(
+    edge: velesdb_core::GraphEdge,
+    point: &crate::connectors::ExtractedPoint,
+    relation: &RelationConfig,
+) -> velesdb_core::GraphEdge {
+    let weight_col = match relation.weight_column {
+        Some(ref col) => col,
+        None => return edge,
+    };
+
+    let weight = match point.payload.get(weight_col).and_then(|v| v.as_f64()) {
+        Some(w) => w,
+        None => return edge,
+    };
+
+    let mut props = std::collections::HashMap::new();
+    props.insert("weight".to_string(), serde_json::json!(weight));
+    edge.with_properties(props)
+}
+
+fn value_to_id_str(value: &serde_json::Value) -> Option<String> {
+    match value {
+        serde_json::Value::String(s) => Some(s.clone()),
+        serde_json::Value::Number(n) => Some(n.to_string()),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::connectors::ExtractedPoint;
+
+    fn make_point(id: &str, payload: serde_json::Value) -> ExtractedPoint {
+        let payload_map = payload
+            .as_object()
+            .cloned()
+            .unwrap_or_default()
+            .into_iter()
+            .collect();
+        ExtractedPoint {
+            id: id.to_string(),
+            vector: vec![],
+            payload: payload_map,
+            sparse_vector: None,
+        }
+    }
+
+    fn make_relation(from: &str, label: &str) -> RelationConfig {
+        RelationConfig {
+            from_column: from.to_string(),
+            to_table: "target".to_string(),
+            to_column: "id".to_string(),
+            edge_label: label.to_string(),
+            weight_column: None,
+        }
+    }
+
+    #[test]
+    fn test_build_edge_string_fk() {
+        let point = make_point("doc-1", serde_json::json!({"author_id": "auth-42"}));
+        let relation = make_relation("author_id", "AUTHORED_BY");
+        let mut edge_id = 0u64;
+        let edge = build_edge(&point, &relation, &mut edge_id);
+        assert!(edge.is_some());
+        let e = edge.expect("test: edge should be Some");
+        assert_eq!(e.source(), stable_point_id("doc-1"));
+        assert_eq!(e.target(), stable_point_id("auth-42"));
+        assert_eq!(edge_id, 1);
+    }
+
+    #[test]
+    fn test_build_edge_numeric_fk() {
+        let point = make_point("99", serde_json::json!({"category_id": 7}));
+        let relation = make_relation("category_id", "BELONGS_TO");
+        let mut edge_id = 0u64;
+        let edge = build_edge(&point, &relation, &mut edge_id);
+        assert!(edge.is_some());
+        assert_eq!(
+            edge.expect("test: edge should be Some").source(),
+            stable_point_id("99")
+        );
+    }
+
+    #[test]
+    fn test_build_edge_missing_fk_returns_none() {
+        let point = make_point("1", serde_json::json!({}));
+        let relation = make_relation("author_id", "AUTHORED_BY");
+        let mut edge_id = 0u64;
+        assert!(build_edge(&point, &relation, &mut edge_id).is_none());
+        assert_eq!(edge_id, 0); // counter not incremented on skip
+    }
+}

--- a/crates/velesdb-migrate/src/pipeline_graph.rs
+++ b/crates/velesdb-migrate/src/pipeline_graph.rs
@@ -39,6 +39,15 @@ impl<'a> GraphMigrationPhase<'a> {
         self.connector.connect().await
     }
 
+    /// Closes the underlying source connector, releasing any held resources.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the connector close fails.
+    pub async fn close(&mut self) -> Result<()> {
+        self.connector.close().await
+    }
+
     /// Runs the graph migration.
     ///
     /// Iterates over all configured relations, extracts FK columns from the
@@ -121,6 +130,13 @@ impl<'a> GraphMigrationPhase<'a> {
 
         loop {
             let batch = self.connector.extract_batch(offset.clone(), batch_size).await?;
+
+            // Guard against connectors that return has_more=true with an empty batch
+            // (e.g. cursor-based connectors on transient gaps), which would otherwise
+            // cause an infinite loop restarting from offset=None.
+            if batch.points.is_empty() {
+                break;
+            }
 
             for point in &batch.points {
                 if let Some(edge) = build_edge(point, relation) {

--- a/crates/velesdb-migrate/src/source_builders.rs
+++ b/crates/velesdb-migrate/src/source_builders.rs
@@ -30,6 +30,7 @@ pub(crate) fn build_qdrant(params: &SourceParams<'_>) -> SourceConfig {
     })
 }
 
+#[allow(deprecated)]
 pub(crate) fn build_pinecone(params: &SourceParams<'_>) -> Result<SourceConfig> {
     let api_key = require_api_key(params, "Pinecone")?;
     Ok(SourceConfig::Pinecone(crate::config::PineconeConfig {
@@ -123,6 +124,7 @@ pub(crate) fn build_mongodb(params: &SourceParams<'_>) -> Result<SourceConfig> {
             id_field: "_id".to_string(),
             payload_fields: vec![],
             filter: None,
+            data_source: "mongodb-atlas".to_string(),
         },
     ))
 }

--- a/crates/velesdb-migrate/src/source_builders.rs
+++ b/crates/velesdb-migrate/src/source_builders.rs
@@ -144,7 +144,7 @@ pub(crate) fn build_elasticsearch(params: &SourceParams<'_>) -> SourceConfig {
 }
 
 pub(crate) fn build_redis(params: &SourceParams<'_>) -> SourceConfig {
-    SourceConfig::Redis(crate::connectors::redis::RedisConfig {
+    SourceConfig::Redis(crate::config::RedisConfig {
         url: params.url.to_string(),
         password: params.api_key.map(String::from),
         index: params.collection.to_string(),

--- a/crates/velesdb-migrate/src/wizard/migration_builder.rs
+++ b/crates/velesdb-migrate/src/wizard/migration_builder.rs
@@ -33,6 +33,7 @@ pub(crate) fn build_migration_config(
         dimension: schema.dimension,
         metric: DistanceMetric::Cosine,
         storage_mode,
+        graph_collection: None,
     };
 
     let options = MigrationOptions {
@@ -49,5 +50,6 @@ pub(crate) fn build_migration_config(
         source,
         destination,
         options,
+        relations: vec![],
     })
 }

--- a/crates/velesdb-migrate/src/wizard/ui.rs
+++ b/crates/velesdb-migrate/src/wizard/ui.rs
@@ -139,6 +139,19 @@ impl WizardUI {
             );
         }
 
+        if stats.relations_processed > 0 {
+            println!();
+            println!("   {} {}", bold.apply_to("Graph edges created:"), stats.edges_created);
+            println!("   {} {}", bold.apply_to("Relations processed: "), stats.relations_processed);
+            if stats.edges_failed > 0 {
+                println!(
+                    "   {} {} (skipped)",
+                    style("Edges failed:").yellow(),
+                    stats.edges_failed
+                );
+            }
+        }
+
         println!();
         println!("{}", bold.apply_to("💡 Quick start:"));
         println!(

--- a/crates/velesdb-migrate/tests/pipeline_e2e.rs
+++ b/crates/velesdb-migrate/tests/pipeline_e2e.rs
@@ -51,12 +51,14 @@ fn json_config(source_path: &Path, destination_path: &Path, collection: &str) ->
             dimension: 2,
             metric: DistanceMetric::Cosine,
             storage_mode: StorageMode::Full,
+            graph_collection: None,
         },
         options: MigrationOptions {
             batch_size: 2,
             workers: 1,
             ..MigrationOptions::default()
         },
+        relations: vec![],
     }
 }
 
@@ -77,12 +79,14 @@ fn csv_config(source_path: &Path, destination_path: &Path, collection: &str) -> 
             dimension: 2,
             metric: DistanceMetric::Cosine,
             storage_mode: StorageMode::Full,
+            graph_collection: None,
         },
         options: MigrationOptions {
             batch_size: 2,
             workers: 1,
             ..MigrationOptions::default()
         },
+        relations: vec![],
     }
 }
 
@@ -375,12 +379,14 @@ async fn test_pipeline_qdrant_sparse_vectors_e2e() {
             dimension: 3,
             metric: DistanceMetric::Cosine,
             storage_mode: StorageMode::Full,
+            graph_collection: None,
         },
         options: MigrationOptions {
             batch_size: 10,
             workers: 1,
             ..MigrationOptions::default()
         },
+        relations: vec![],
     };
 
     let mut pipeline = Pipeline::new(config).expect("pipeline");
@@ -458,12 +464,14 @@ async fn test_pipeline_qdrant_500_fails_pipeline() {
             dimension: 3,
             metric: DistanceMetric::Cosine,
             storage_mode: StorageMode::Full,
+            graph_collection: None,
         },
         options: MigrationOptions {
             batch_size: 10,
             workers: 1,
             ..MigrationOptions::default()
         },
+        relations: vec![],
     };
 
     let mut pipeline = Pipeline::new(config).expect("pipeline");
@@ -529,12 +537,14 @@ async fn test_pipeline_qdrant_429_fails_pipeline() {
             dimension: 3,
             metric: DistanceMetric::Cosine,
             storage_mode: StorageMode::Full,
+            graph_collection: None,
         },
         options: MigrationOptions {
             batch_size: 10,
             workers: 1,
             ..MigrationOptions::default()
         },
+        relations: vec![],
     };
 
     let mut pipeline = Pipeline::new(config).expect("pipeline");
@@ -591,12 +601,14 @@ async fn test_pipeline_qdrant_schema_mismatch() {
             dimension: 3, // mismatch with source=5
             metric: DistanceMetric::Cosine,
             storage_mode: StorageMode::Full,
+            graph_collection: None,
         },
         options: MigrationOptions {
             batch_size: 10,
             workers: 1,
             ..MigrationOptions::default()
         },
+        relations: vec![],
     };
 
     let mut pipeline = Pipeline::new(config).expect("pipeline");
@@ -707,12 +719,14 @@ async fn test_pipeline_pinecone_sparse_vectors_e2e() {
             dimension: 3,
             metric: DistanceMetric::Cosine,
             storage_mode: StorageMode::Full,
+            graph_collection: None,
         },
         options: MigrationOptions {
             batch_size: 10,
             workers: 1,
             ..MigrationOptions::default()
         },
+        relations: vec![],
     };
 
     let mut pipeline = Pipeline::new(config).expect("pipeline");
@@ -840,12 +854,14 @@ async fn test_pipeline_elasticsearch_e2e() {
             dimension: 3,
             metric: DistanceMetric::Cosine,
             storage_mode: StorageMode::Full,
+            graph_collection: None,
         },
         options: MigrationOptions {
             batch_size: 2,
             workers: 1,
             ..MigrationOptions::default()
         },
+        relations: vec![],
     };
 
     let mut pipeline = Pipeline::new(config).expect("pipeline");
@@ -951,12 +967,14 @@ async fn test_pipeline_qdrant_pagination_multi_page() {
             dimension: 2,
             metric: DistanceMetric::Cosine,
             storage_mode: StorageMode::Full,
+            graph_collection: None,
         },
         options: MigrationOptions {
             batch_size: 2,
             workers: 1,
             ..MigrationOptions::default()
         },
+        relations: vec![],
     };
 
     let mut pipeline = Pipeline::new(config).expect("pipeline");
@@ -1082,12 +1100,14 @@ async fn test_pipeline_pinecone_pagination_multi_page() {
             dimension: 2,
             metric: DistanceMetric::Cosine,
             storage_mode: StorageMode::Full,
+            graph_collection: None,
         },
         options: MigrationOptions {
             batch_size: 2,
             workers: 1,
             ..MigrationOptions::default()
         },
+        relations: vec![],
     };
 
     let mut pipeline = Pipeline::new(config).expect("pipeline");

--- a/crates/velesdb-migrate/tests/pipeline_e2e.rs
+++ b/crates/velesdb-migrate/tests/pipeline_e2e.rs
@@ -182,7 +182,7 @@ async fn test_pipeline_dry_run_does_not_create_collection() {
     let mut pipeline = Pipeline::new(config).expect("pipeline");
     let stats = pipeline.run().await.expect("dry run");
 
-    assert_eq!(stats.loaded, 1);
+    assert_eq!(stats.loaded, 0, "dry_run must not increment loaded");
     assert!(Database::open(destination.path())
         .expect("open database")
         .get_any_collection("dry_run_docs")
@@ -439,7 +439,7 @@ async fn test_pipeline_qdrant_500_fails_pipeline() {
     Mock::given(method("POST"))
         .and(path("/collections/test_err/points/scroll"))
         .respond_with(ResponseTemplate::new(500).set_body_string("Internal Server Error"))
-        .expect(1) // proves no retry
+        .expect(4) // 1 initial + 3 retries (RetryConfig::for_transient_errors)
         .mount(&mock_server)
         .await;
 
@@ -478,8 +478,8 @@ async fn test_pipeline_qdrant_500_fails_pipeline() {
 }
 
 /// Verify that an HTTP 429 on the Qdrant scroll endpoint fails the pipeline
-/// immediately. The connector does not implement `with_retry`; this test
-/// documents that behavior and ensures no accidental retry loop is introduced.
+/// after exhausting retries. The pipeline wraps `extract_batch` in
+/// `with_retry(RetryConfig::for_transient_errors())` (3 retries).
 #[tokio::test]
 async fn test_pipeline_qdrant_429_fails_pipeline() {
     let mock_server = MockServer::start().await;
@@ -510,7 +510,7 @@ async fn test_pipeline_qdrant_429_fails_pipeline() {
                 .insert_header("Retry-After", "1")
                 .set_body_string("Too Many Requests"),
         )
-        .expect(1) // proves no retry
+        .expect(4) // 1 initial + 3 retries (RetryConfig::for_transient_errors)
         .mount(&mock_server)
         .await;
 

--- a/crates/velesdb-migrate/tests/pipeline_e2e.rs
+++ b/crates/velesdb-migrate/tests/pipeline_e2e.rs
@@ -8,12 +8,12 @@ use tempfile::{NamedTempFile, TempDir};
 use velesdb_core::Database;
 use velesdb_migrate::config::{
     DestinationConfig, DistanceMetric, MigrationConfig, MigrationOptions, PineconeConfig,
-    QdrantConfig, SourceConfig, StorageMode,
+    QdrantConfig, SourceConfig, StorageMode, SupabaseConfig,
 };
 use velesdb_migrate::connectors::elasticsearch::ElasticsearchConfig;
 use velesdb_migrate::connectors::{csv_file::CsvFileConfig, json_file::JsonFileConfig};
 use velesdb_migrate::Pipeline;
-use wiremock::matchers::{body_partial_json, method, path};
+use wiremock::matchers::{body_partial_json, method, path, query_param};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 fn write_json_source(file: &mut NamedTempFile, rows: &[serde_json::Value]) {
@@ -1119,4 +1119,103 @@ async fn test_pipeline_pinecone_pagination_multi_page() {
 
     let collection = open_collection(destination.path(), "pinecone_pag_docs");
     assert_eq!(collection.len(), 4);
+}
+
+#[tokio::test]
+async fn test_pipeline_supabase_e2e() {
+    let mock_server = MockServer::start().await;
+    let destination = TempDir::new().expect("destination dir");
+
+    // Mock 1: HEAD — count via content-range (separate method, no conflict).
+    Mock::given(method("HEAD"))
+        .and(path("/rest/v1/documents"))
+        .respond_with(
+            ResponseTemplate::new(200).insert_header("content-range", "0-1/2"),
+        )
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+
+    // Mock 2: connect() — GET /rest/v1/documents?limit=0
+    Mock::given(method("GET"))
+        .and(path("/rest/v1/documents"))
+        .and(query_param("limit", "0"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+
+    // Mock 3: get_schema() sample — GET with limit=1
+    Mock::given(method("GET"))
+        .and(path("/rest/v1/documents"))
+        .and(query_param("limit", "1"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                {
+                    "id": "1",
+                    "embedding": [0.1, 0.2, 0.3],
+                    "title": "Sample Doc"
+                }
+            ])),
+        )
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+
+    // Mock 4: extract_batch() — GET with offset=0
+    Mock::given(method("GET"))
+        .and(path("/rest/v1/documents"))
+        .and(query_param("offset", "0"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                {
+                    "id": "1",
+                    "embedding": [0.1, 0.2, 0.3],
+                    "title": "Doc 1"
+                },
+                {
+                    "id": "2",
+                    "embedding": [0.4, 0.5, 0.6],
+                    "title": "Doc 2"
+                }
+            ])),
+        )
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+
+    let config = MigrationConfig {
+        source: SourceConfig::Supabase(SupabaseConfig {
+            url: mock_server.uri(),
+            api_key: "test_key".to_string(),
+            table: "documents".to_string(),
+            vector_column: "embedding".to_string(),
+            id_column: "id".to_string(),
+            payload_columns: vec![],
+        }),
+        destination: DestinationConfig {
+            path: destination.path().to_path_buf(),
+            collection: "supabase_docs".to_string(),
+            dimension: 3,
+            metric: DistanceMetric::Cosine,
+            storage_mode: StorageMode::Full,
+            graph_collection: None,
+        },
+        options: MigrationOptions {
+            batch_size: 10,
+            workers: 1,
+            ..MigrationOptions::default()
+        },
+        relations: vec![],
+    };
+
+    let mut pipeline = Pipeline::new(config).expect("pipeline");
+    let stats = pipeline.run().await.expect("pipeline run");
+
+    assert_eq!(stats.extracted, 2, "Should extract 2 rows from Supabase");
+    assert_eq!(stats.loaded, 2, "Should load 2 points into VelesDB");
+    assert_eq!(stats.failed, 0, "No failures expected");
+
+    let collection = open_collection(destination.path(), "supabase_docs");
+    assert_eq!(collection.len(), 2, "Collection should contain 2 points");
 }


### PR DESCRIPTION
## Summary

- **Wave 1 — Fondations** : protection SSRF (`validate_url`) sur les 8 connecteurs HTTP, helper `is_valid_sparse_vector` partagé (dedup qdrant/pinecone), suppression code mort (`SupabaseRow`, `CountResponse`), retry intégré dans le pipeline, `dry_run` ne comptabilise plus `loaded`, `PineconeConfig.environment` déprécié, `MongoDBConfig.data_source` déplacé vers la config
- **Wave 2+3 — Correctifs connecteurs** : Milvus — cache du vrai champ vectoriel via `FT.INFO` (au lieu du stub `"vector"` codé en dur) + `cached_schema` pattern ; pgvector — erreur explicite sur le stub SQL (plus de résultats silencieusement vides)
- **Wave 4 — Redis RESP natif** : réécriture complète du connecteur Redis en protocole RESP via le crate `redis` (feature `redis-source`) — suppression de la fausse API REST, support `FT.SEARCH` / `FT.INFO`, décodage blob LE f32, pagination numérique
- **Wave 5 — Migration graphe** : nouveau `pipeline_graph.rs` (`GraphMigrationPhase`) — migre les relations FK comme arêtes dans une `GraphCollection` VelesDB ; `relation_detector.rs` — détection automatique heuristique des FK (`*_id`, Weaviate cross-references) ; intégration dans `pipeline.rs` conditionnelle sur `graph_collection`
- **Wave 6 — Tests E2E** : tests d'intégration wiremock pour Milvus (champ vectoriel custom) et Supabase (pagination multi-page)
- **Corrections code review** : cache connexion Redis via `Arc<Mutex<MultiplexedConnection>>`, IDs d'arêtes déterministes (FNV-1a hash), TODO(US-GRAPH-01/02), `#[cfg(test)]` sur helpers Redis, `try_from` sur cast usize, commentaire invariant pinecone

## Impact matrix

| Composant | Statut | Action |
|-----------|--------|--------|
| `velesdb-migrate` | ✅ Modifié | Toutes les waves |
| `velesdb-core` | ✅ Inchangé | Aucune propagation requise |
| Autres crates (server, python, wasm, cli...) | ✅ Inchangés | Aucune propagation requise |
| `Cargo.lock` | ✅ MAJ | Ajout `redis = "0.26"` (feature-gated) |

## Test plan

- [x] `cargo clippy -p velesdb-migrate --all-targets -- -D warnings -D clippy::pedantic` → clean
- [x] `cargo test -p velesdb-migrate -- --test-threads=1` → 226 tests verts (198 unit + 13 bin + 15 e2e)
- [x] `cargo check -p velesdb-migrate --no-default-features` → compilation sans features optionnelles
- [x] Codacy CLI (lizard + opengrep) → aucun finding sur `velesdb-migrate`
- [ ] Test manuel migration Supabase → VelesDB (vecteurs seuls)
- [ ] Test manuel migration Supabase → VelesDB (vecteurs + graph avec `relations` + `graph_collection`)
- [ ] Test manuel Redis Stack local (`redis://localhost:6379`, index RediSearch)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/508" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
