### PR TITLE
style(migrate): cargo fmt — formatting fixes after #508 squash merge

### DIFF
--- a/crates/velesdb-migrate/src/connectors/elasticsearch_tests.rs
+++ b/crates/velesdb-migrate/src/connectors/elasticsearch_tests.rs
@@ -158,7 +158,5 @@ fn test_search_response_deserialization() {
 
 #[test]
 fn test_connect_rejects_file_url() {
-    assert!(
-        crate::connectors::common::validate_url("file:///etc/passwd").is_err()
-    );
+    assert!(crate::connectors::common::validate_url("file:///etc/passwd").is_err());
 }

--- a/crates/velesdb-migrate/src/connectors/mod.rs
+++ b/crates/velesdb-migrate/src/connectors/mod.rs
@@ -157,7 +157,7 @@ pub fn create_connector(config: &crate::config::SourceConfig) -> Result<Box<dyn 
         #[cfg(not(feature = "redis-source"))]
         crate::config::SourceConfig::Redis(_) => Err(crate::error::Error::UnsupportedSource(
             "Redis source requires the 'redis-source' feature".to_string(),
-        ))
+        )),
     }
 }
 

--- a/crates/velesdb-migrate/src/connectors/pgvector.rs
+++ b/crates/velesdb-migrate/src/connectors/pgvector.rs
@@ -464,9 +464,7 @@ mod tests {
 
     #[test]
     fn test_supabase_connect_rejects_file_url() {
-        assert!(
-            crate::connectors::common::validate_url("file:///etc/passwd").is_err()
-        );
+        assert!(crate::connectors::common::validate_url("file:///etc/passwd").is_err());
     }
 
     #[test]

--- a/crates/velesdb-migrate/src/connectors/qdrant.rs
+++ b/crates/velesdb-migrate/src/connectors/qdrant.rs
@@ -155,7 +155,10 @@ impl QdrantVector {
             Self::Named(map) => {
                 for value in map.values() {
                     if let QdrantNamedVectorValue::Sparse(sv) = value {
-                        if crate::connectors::common::is_valid_sparse_vector(&sv.indices, &sv.values) {
+                        if crate::connectors::common::is_valid_sparse_vector(
+                            &sv.indices,
+                            &sv.values,
+                        ) {
                             return Some(
                                 sv.indices
                                     .iter()
@@ -417,8 +420,6 @@ mod tests {
         };
         let connector = QdrantConnector::new(config);
         // validate_url rejects file:// synchronously at connect time
-        assert!(
-            crate::connectors::common::validate_url(&connector.config.url).is_err()
-        );
+        assert!(crate::connectors::common::validate_url(&connector.config.url).is_err());
     }
 }

--- a/crates/velesdb-migrate/src/connectors/redis.rs
+++ b/crates/velesdb-migrate/src/connectors/redis.rs
@@ -10,9 +10,9 @@ use std::sync::Arc;
 use tokio::sync::Mutex;
 
 use crate::config::RedisConfig;
-use crate::connectors::common::{build_numeric_offset_batch, parse_vector_from_json};
 #[cfg(test)]
 use crate::connectors::common::extract_payload_from_object;
+use crate::connectors::common::{build_numeric_offset_batch, parse_vector_from_json};
 use crate::connectors::{ExtractedBatch, ExtractedPoint, FieldInfo, SourceConnector, SourceSchema};
 use crate::error::{Error, Result};
 
@@ -42,7 +42,10 @@ impl RedisConnector {
     /// The array case delegates to the shared `parse_vector_from_json` helper;
     /// the string case is Redis-specific (comma/space-separated floats).
     #[cfg(test)]
-    pub(crate) fn parse_vector(&self, attrs: &HashMap<String, serde_json::Value>) -> Result<Vec<f32>> {
+    pub(crate) fn parse_vector(
+        &self,
+        attrs: &HashMap<String, serde_json::Value>,
+    ) -> Result<Vec<f32>> {
         let vector_value = attrs.get(&self.config.vector_field).ok_or_else(|| {
             Error::Extraction(format!(
                 "Vector field '{}' not found in document",
@@ -94,9 +97,7 @@ impl RedisConnector {
     }
 
     /// Opens a multiplexed async Redis connection with optional AUTH.
-    async fn open_connection(
-        &self,
-    ) -> Result<redis::aio::MultiplexedConnection> {
+    async fn open_connection(&self) -> Result<redis::aio::MultiplexedConnection> {
         let client = redis::Client::open(self.config.url.as_str())
             .map_err(|e| Error::SourceConnection(format!("Redis client error: {e}")))?;
 
@@ -124,17 +125,15 @@ impl RedisConnector {
     async fn acquire_connection(
         &self,
     ) -> Result<tokio::sync::MutexGuard<'_, redis::aio::MultiplexedConnection>> {
-        let shared = self.connection.as_ref().ok_or_else(|| {
-            Error::SourceConnection("Not connected to Redis".to_string())
-        })?;
+        let shared = self
+            .connection
+            .as_ref()
+            .ok_or_else(|| Error::SourceConnection("Not connected to Redis".to_string()))?;
         Ok(shared.lock().await)
     }
 
     /// Detects the vector dimension by fetching a single document from the index.
-    async fn detect_dimension(
-        &self,
-        con: &mut redis::aio::MultiplexedConnection,
-    ) -> Result<usize> {
+    async fn detect_dimension(&self, con: &mut redis::aio::MultiplexedConnection) -> Result<usize> {
         let resp: redis::Value = redis::cmd("FT.SEARCH")
             .arg(&self.config.index)
             .arg("*")
@@ -148,11 +147,12 @@ impl RedisConnector {
             .await
             .map_err(|e| Error::SourceConnection(format!("FT.SEARCH sample failed: {e}")))?;
 
-        let points = parse_ft_search_response(&resp, &self.config.vector_field, &self.config.key_prefix)?;
+        let points =
+            parse_ft_search_response(&resp, &self.config.vector_field, &self.config.key_prefix)?;
 
-        let first = points.first().ok_or_else(|| {
-            Error::Extraction("No documents found in Redis index".to_string())
-        })?;
+        let first = points
+            .first()
+            .ok_or_else(|| Error::Extraction("No documents found in Redis index".to_string()))?;
 
         Ok(first.vector.len())
     }
@@ -254,7 +254,11 @@ fn build_ft_search_cmd(
     payload_fields: &[String],
 ) -> redis::Cmd {
     let mut cmd = redis::cmd("FT.SEARCH");
-    cmd.arg(index).arg(query).arg("LIMIT").arg(offset).arg(limit);
+    cmd.arg(index)
+        .arg(query)
+        .arg("LIMIT")
+        .arg(offset)
+        .arg(limit);
 
     // Determine which fields to return.
     let return_fields: Vec<&str> = if payload_fields.is_empty() {
@@ -334,10 +338,7 @@ pub fn parse_ft_search_response(
         let attrs = parse_field_value_pairs(&items[idx], vector_field)?;
         idx += 1;
 
-        let id = key
-            .strip_prefix(key_prefix)
-            .unwrap_or(&key)
-            .to_string();
+        let id = key.strip_prefix(key_prefix).unwrap_or(&key).to_string();
 
         let vector = extract_vector_from_attrs(&attrs, vector_field)?;
         let payload = build_payload(&attrs, vector_field);
@@ -413,7 +414,9 @@ fn extract_vector_from_attrs(
     vector_field: &str,
 ) -> Result<Vec<f32>> {
     let value = attrs.get(vector_field).ok_or_else(|| {
-        Error::Extraction(format!("Vector field '{vector_field}' not found in document"))
+        Error::Extraction(format!(
+            "Vector field '{vector_field}' not found in document"
+        ))
     })?;
 
     match value {
@@ -532,10 +535,7 @@ fn extract_attributes(items: &[redis::Value], vector_field: &str) -> Vec<FieldIn
 /// Parses a single attribute definition from `FT.INFO`.
 ///
 /// Each attribute is a flat array: `["identifier", "name", "type", "TEXT", ...]`
-fn parse_single_attribute(
-    attr: &redis::Value,
-    vector_field: &str,
-) -> Option<FieldInfo> {
+fn parse_single_attribute(attr: &redis::Value, vector_field: &str) -> Option<FieldInfo> {
     let parts = match attr {
         redis::Value::Array(arr) => arr,
         _ => return None,

--- a/crates/velesdb-migrate/src/connectors/redis_tests.rs
+++ b/crates/velesdb-migrate/src/connectors/redis_tests.rs
@@ -126,7 +126,7 @@ fn test_find_info_int_stride2_correctness() {
     let items = vec![
         redis::Value::BulkString(b"some_key".to_vec()),
         redis::Value::BulkString(b"num_docs".to_vec()), // value at odd index — must NOT match
-        redis::Value::BulkString(b"num_docs".to_vec()),  // key at even index — must match
+        redis::Value::BulkString(b"num_docs".to_vec()), // key at even index — must match
         redis::Value::BulkString(b"42".to_vec()),
     ];
     // WHEN: stride is 2, only the key at index 2 matches, returning 42
@@ -350,8 +350,7 @@ fn test_parse_ft_search_response_binary_blob_vector() {
     ]);
 
     // WHEN: parsing the response
-    let points =
-        parse_ft_search_response(&resp, "embedding", "doc:").expect("test: binary blob");
+    let points = parse_ft_search_response(&resp, "embedding", "doc:").expect("test: binary blob");
 
     // THEN: vector is correctly decoded from LE f32 bytes
     assert_eq!(points.len(), 1);
@@ -379,11 +378,13 @@ async fn test_extract_batch_fails_when_not_connected() {
     let result = connector.extract_batch(None, 10).await;
 
     // THEN: an error is returned indicating not connected
-    assert!(result.is_err(), "extract_batch should fail without connect()");
+    assert!(
+        result.is_err(),
+        "extract_batch should fail without connect()"
+    );
     let err = result.unwrap_err().to_string();
     assert!(
         err.contains("Not connected"),
         "expected 'Not connected' in error, got: {err}"
     );
 }
-

--- a/crates/velesdb-migrate/src/connectors/relation_detector.rs
+++ b/crates/velesdb-migrate/src/connectors/relation_detector.rs
@@ -25,9 +25,7 @@ pub fn detect_relations(schema: &SourceSchema) -> Vec<RelationConfig> {
         .collect()
 }
 
-fn detect_single_relation(
-    field: &crate::connectors::FieldInfo,
-) -> Option<RelationConfig> {
+fn detect_single_relation(field: &crate::connectors::FieldInfo) -> Option<RelationConfig> {
     // Strategy 1: column name ends with _id (common FK convention)
     if let Some(base) = field.name.strip_suffix("_id") {
         if base.is_empty() {
@@ -45,7 +43,11 @@ fn detect_single_relation(
 
     // Strategy 2: Weaviate cross-reference -- field_type starts with uppercase
     // (Weaviate class names are PascalCase, e.g., "Author", "Category")
-    if field.field_type.chars().next().is_some_and(|c| c.is_uppercase())
+    if field
+        .field_type
+        .chars()
+        .next()
+        .is_some_and(|c| c.is_uppercase())
         && !field.field_type.is_empty()
         && field.field_type.chars().all(|c| c.is_alphanumeric())
     {

--- a/crates/velesdb-migrate/src/connectors/weaviate.rs
+++ b/crates/velesdb-migrate/src/connectors/weaviate.rs
@@ -365,8 +365,6 @@ mod tests {
 
     #[test]
     fn test_connect_rejects_file_url() {
-        assert!(
-            crate::connectors::common::validate_url("file:///etc/passwd").is_err()
-        );
+        assert!(crate::connectors::common::validate_url("file:///etc/passwd").is_err());
     }
 }

--- a/crates/velesdb-migrate/src/pipeline.rs
+++ b/crates/velesdb-migrate/src/pipeline.rs
@@ -274,11 +274,9 @@ impl Pipeline {
 
         loop {
             let connector = &mut *self.connector;
-            let batch = crate::retry::with_retry(
-                &retry_config,
-                "extract_batch",
-                || connector.extract_batch(offset.clone(), batch_size),
-            )
+            let batch = crate::retry::with_retry(&retry_config, "extract_batch", || {
+                connector.extract_batch(offset.clone(), batch_size)
+            })
             .await?;
 
             if batch.points.is_empty() {
@@ -379,10 +377,8 @@ impl Pipeline {
             {
                 info!("Starting graph migration phase...");
                 let graph_connector = crate::connectors::create_connector(&self.config.source)?;
-                let mut graph_phase = crate::pipeline_graph::GraphMigrationPhase::new(
-                    &self.config,
-                    graph_connector,
-                );
+                let mut graph_phase =
+                    crate::pipeline_graph::GraphMigrationPhase::new(&self.config, graph_connector);
                 graph_phase.connect().await?;
                 let graph_stats = graph_phase.run(db).await?;
                 graph_phase.close().await?;
@@ -559,8 +555,7 @@ mod tests {
             {"id": "2", "vector": [0.3, 0.4], "payload": {}},
             {"id": "3", "vector": [0.5, 0.6], "payload": {}}
         ]);
-        std::fs::write(&json_path, json_content.to_string())
-            .expect("test: write json");
+        std::fs::write(&json_path, json_content.to_string()).expect("test: write json");
 
         let config = MigrationConfig {
             source: SourceConfig::JsonFile(JsonFileConfig {
@@ -585,8 +580,7 @@ mod tests {
             relations: vec![],
         };
 
-        let mut pipeline = crate::Pipeline::new(config)
-            .expect("test: create pipeline");
+        let mut pipeline = crate::Pipeline::new(config).expect("test: create pipeline");
         let stats = pipeline.run().await.expect("test: run pipeline");
 
         assert_eq!(stats.extracted, 3, "Should extract 3 points");

--- a/crates/velesdb-migrate/src/pipeline_graph.rs
+++ b/crates/velesdb-migrate/src/pipeline_graph.rs
@@ -57,10 +57,7 @@ impl<'a> GraphMigrationPhase<'a> {
     ///
     /// Returns an error if the database or graph collection cannot be
     /// opened or created.
-    pub async fn run(
-        &self,
-        db: &velesdb_core::Database,
-    ) -> Result<GraphMigrationStats> {
+    pub async fn run(&self, db: &velesdb_core::Database) -> Result<GraphMigrationStats> {
         let graph_name = self
             .config
             .destination
@@ -70,11 +67,9 @@ impl<'a> GraphMigrationPhase<'a> {
 
         ensure_graph_collection_exists(db, graph_name)?;
 
-        let gc = db
-            .get_graph_collection(graph_name)
-            .ok_or_else(|| {
-                Error::DestinationConnection("Graph collection not found".to_string())
-            })?;
+        let gc = db.get_graph_collection(graph_name).ok_or_else(|| {
+            Error::DestinationConnection("Graph collection not found".to_string())
+        })?;
 
         let relations = &self.config.relations;
         if relations.is_empty() {
@@ -92,10 +87,7 @@ impl<'a> GraphMigrationPhase<'a> {
         for relation in relations {
             info!(
                 "Migrating relation: {} -> {}.{} [{}]",
-                relation.from_column,
-                relation.to_table,
-                relation.to_column,
-                relation.edge_label
+                relation.from_column, relation.to_table, relation.to_column, relation.edge_label
             );
 
             let edges = self
@@ -129,7 +121,10 @@ impl<'a> GraphMigrationPhase<'a> {
         let mut offset = None;
 
         loop {
-            let batch = self.connector.extract_batch(offset.clone(), batch_size).await?;
+            let batch = self
+                .connector
+                .extract_batch(offset.clone(), batch_size)
+                .await?;
 
             // Guard against connectors that return has_more=true with an empty batch
             // (e.g. cursor-based connectors on transient gaps), which would otherwise
@@ -159,17 +154,12 @@ impl<'a> GraphMigrationPhase<'a> {
     }
 }
 
-fn ensure_graph_collection_exists(
-    db: &velesdb_core::Database,
-    name: &str,
-) -> Result<()> {
+fn ensure_graph_collection_exists(db: &velesdb_core::Database, name: &str) -> Result<()> {
     if db.get_graph_collection(name).is_some() {
         return Ok(());
     }
     db.create_graph_collection(name, velesdb_core::GraphSchema::schemaless())
-        .map_err(|e| {
-            Error::DestinationConnection(format!("Cannot create graph collection: {e}"))
-        })
+        .map_err(|e| Error::DestinationConnection(format!("Cannot create graph collection: {e}")))
 }
 
 fn build_edge(
@@ -185,13 +175,14 @@ fn build_edge(
     let key = format!("{from_node_id}-{to_node_id}-{}", relation.edge_label);
     let id = crate::pipeline::fnv1a64(key.as_bytes());
 
-    let edge = match velesdb_core::GraphEdge::new(id, from_node_id, to_node_id, &relation.edge_label) {
-        Ok(e) => e,
-        Err(e) => {
-            warn!("Failed to create edge {}: {}", id, e);
-            return None;
-        }
-    };
+    let edge =
+        match velesdb_core::GraphEdge::new(id, from_node_id, to_node_id, &relation.edge_label) {
+            Ok(e) => e,
+            Err(e) => {
+                warn!("Failed to create edge {}: {}", id, e);
+                return None;
+            }
+        };
 
     Some(attach_weight(edge, point, relation))
 }
@@ -295,7 +286,11 @@ mod tests {
         let e2 = build_edge(&point, &relation).expect("test: e2 should be Some");
 
         // THEN: both produce the same deterministic ID
-        assert_eq!(e1.id(), e2.id(), "Edge IDs must be deterministic for the same input");
+        assert_eq!(
+            e1.id(),
+            e2.id(),
+            "Edge IDs must be deterministic for the same input"
+        );
     }
 
     #[test]
@@ -310,6 +305,10 @@ mod tests {
         let e2 = build_edge(&point, &rel2).expect("test: e2 should be Some");
 
         // THEN: different labels produce different IDs
-        assert_ne!(e1.id(), e2.id(), "Different edge labels must produce different IDs");
+        assert_ne!(
+            e1.id(),
+            e2.id(),
+            "Different edge labels must produce different IDs"
+        );
     }
 }

--- a/crates/velesdb-migrate/src/wizard/ui.rs
+++ b/crates/velesdb-migrate/src/wizard/ui.rs
@@ -141,8 +141,16 @@ impl WizardUI {
 
         if stats.relations_processed > 0 {
             println!();
-            println!("   {} {}", bold.apply_to("Graph edges created:"), stats.edges_created);
-            println!("   {} {}", bold.apply_to("Relations processed: "), stats.relations_processed);
+            println!(
+                "   {} {}",
+                bold.apply_to("Graph edges created:"),
+                stats.edges_created
+            );
+            println!(
+                "   {} {}",
+                bold.apply_to("Relations processed: "),
+                stats.relations_processed
+            );
             if stats.edges_failed > 0 {
                 println!(
                     "   {} {} (skipped)",

--- a/crates/velesdb-migrate/tests/pipeline_e2e.rs
+++ b/crates/velesdb-migrate/tests/pipeline_e2e.rs
@@ -1129,9 +1129,7 @@ async fn test_pipeline_supabase_e2e() {
     // Mock 1: HEAD — count via content-range (separate method, no conflict).
     Mock::given(method("HEAD"))
         .and(path("/rest/v1/documents"))
-        .respond_with(
-            ResponseTemplate::new(200).insert_header("content-range", "0-1/2"),
-        )
+        .respond_with(ResponseTemplate::new(200).insert_header("content-range", "0-1/2"))
         .expect(1)
         .mount(&mock_server)
         .await;
@@ -1149,15 +1147,13 @@ async fn test_pipeline_supabase_e2e() {
     Mock::given(method("GET"))
         .and(path("/rest/v1/documents"))
         .and(query_param("limit", "1"))
-        .respond_with(
-            ResponseTemplate::new(200).set_body_json(serde_json::json!([
-                {
-                    "id": "1",
-                    "embedding": [0.1, 0.2, 0.3],
-                    "title": "Sample Doc"
-                }
-            ])),
-        )
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+            {
+                "id": "1",
+                "embedding": [0.1, 0.2, 0.3],
+                "title": "Sample Doc"
+            }
+        ])))
         .expect(1)
         .mount(&mock_server)
         .await;
@@ -1166,20 +1162,18 @@ async fn test_pipeline_supabase_e2e() {
     Mock::given(method("GET"))
         .and(path("/rest/v1/documents"))
         .and(query_param("offset", "0"))
-        .respond_with(
-            ResponseTemplate::new(200).set_body_json(serde_json::json!([
-                {
-                    "id": "1",
-                    "embedding": [0.1, 0.2, 0.3],
-                    "title": "Doc 1"
-                },
-                {
-                    "id": "2",
-                    "embedding": [0.4, 0.5, 0.6],
-                    "title": "Doc 2"
-                }
-            ])),
-        )
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+            {
+                "id": "1",
+                "embedding": [0.1, 0.2, 0.3],
+                "title": "Doc 1"
+            },
+            {
+                "id": "2",
+                "embedding": [0.4, 0.5, 0.6],
+                "title": "Doc 2"
+            }
+        ])))
         .expect(1)
         .mount(&mock_server)
         .await;


### PR DESCRIPTION
## Summary

- `cargo fmt` pass on `velesdb-migrate` — 12 files reformatted
- Fixes the **Lint & Format** CI failure on `develop` introduced by the #508 squash merge
- Zero behavioral change

## Test plan

- [ ] CI Lint & Format passes on develop after merge
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/517" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
