### PR TITLE
fix(concurrency): drop label_idx before stats_io_mutex in upsert_metadata [WP-0A]

### DIFF
--- a/crates/velesdb-core/src/collection/core/crud.rs
+++ b/crates/velesdb-core/src/collection/core/crud.rs
@@ -481,12 +481,15 @@ impl Collection {
             }
         }
 
+        // LOCK ORDER: drop label_index(7) before acquiring config(1) and stats_io_mutex(12).
+        drop(label_idx);
+
         // LOCK ORDER: flush while payload_storage(3) still held, then drop before acquiring config(1).
         let point_count = payload_storage.ids().len();
         payload_storage.flush()?;
         drop(payload_storage);
 
-        // config(1) only — all higher-numbered locks released above.
+        // config(1) only — payload_storage(3) and label_index(7) both released above.
         self.config.write().point_count = point_count;
 
         // Incremental histogram maintenance for metadata-only collections:


### PR DESCRIPTION
## Summary
- Fix lock ordering violation: `label_idx` (lock #7) was held when acquiring `stats_io_mutex` (lock #12), violating the "no other lock held" invariant
- Added explicit `drop(label_idx)` after label update loop
- Corrected misleading comment about released locks

## Severity: CRITICAL — potential deadlock in production

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p velesdb-core --features persistence -- -D warnings -D clippy::pedantic`
- [x] `cargo test -p velesdb-core --features persistence -- --test-threads=1`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/524" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
