### PR TITLE
fix(cbo): remove unused update_histograms_on_upsert dead code [WP-0E]

### DIFF
--- a/crates/velesdb-core/src/collection/core/crud_histogram.rs
+++ b/crates/velesdb-core/src/collection/core/crud_histogram.rs
@@ -9,18 +9,6 @@ use crate::collection::stats::CollectionStats;
 use crate::collection::types::Collection;
 
 impl Collection {
-    /// Incrementally updates persisted histograms for upserted payloads.
-    ///
-    /// For each column that has a histogram in the persisted stats, converts
-    /// the payload value to `f64` and calls `increment_bucket`. Reads and
-    /// writes `collection.stats.json` only when the file exists.
-    ///
-    /// Called BEFORE `invalidate_caches_and_bump_generation()` in the upsert path.
-    #[allow(dead_code)]
-    pub(super) fn update_histograms_on_upsert(&self, payloads: &[Option<serde_json::Value>]) {
-        self.update_histograms_for_payloads(payloads, true);
-    }
-
     /// Incrementally updates persisted histograms for deleted payloads.
     ///
     /// For each column that has a histogram in the persisted stats, converts

--- a/crates/velesdb-core/src/velesql/explain/formatter.rs
+++ b/crates/velesdb-core/src/velesql/explain/formatter.rs
@@ -242,8 +242,9 @@ impl fmt::Display for QueryPlan {
 /// Formats a `WithValue` for human-readable EXPLAIN display.
 pub(super) fn format_with_value(v: &super::super::ast::WithValue) -> String {
     match v {
-        super::super::ast::WithValue::String(s)
-        | super::super::ast::WithValue::Identifier(s) => s.clone(),
+        super::super::ast::WithValue::String(s) | super::super::ast::WithValue::Identifier(s) => {
+            s.clone()
+        }
         super::super::ast::WithValue::Integer(i) => i.to_string(),
         super::super::ast::WithValue::Float(f) => f.to_string(),
         super::super::ast::WithValue::Boolean(b) => b.to_string(),

--- a/crates/velesdb-core/src/velesql/explain/node_stats.rs
+++ b/crates/velesdb-core/src/velesql/explain/node_stats.rs
@@ -18,9 +18,7 @@ pub(super) fn estimate_cost(root: &PlanNode, has_vector_search: bool) -> f64 {
     let base_cost = if has_vector_search { 0.05 } else { 1.0 };
 
     match root {
-        PlanNode::Sequence(nodes) => nodes
-            .iter()
-            .fold(base_cost, |acc, n| acc + node_cost(n)),
+        PlanNode::Sequence(nodes) => nodes.iter().fold(base_cost, |acc, n| acc + node_cost(n)),
         _ => base_cost + node_cost(root),
     }
 }


### PR DESCRIPTION
## Summary
- Removed `update_histograms_on_upsert` method (confirmed dead code, zero callers)
- Histograms maintained via `update_histograms_replace` in all upsert paths

## Test plan
- [x] 25 histogram tests pass

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/528" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
