### PR TITLE
fix(migrate): add Hamming and Jaccard distance metrics [WP-1B]

### DIFF
--- a/crates/velesdb-migrate/src/config.rs
+++ b/crates/velesdb-migrate/src/config.rs
@@ -261,7 +261,12 @@ pub enum DistanceMetric {
     /// Euclidean distance. Best for unnormalized embeddings.
     Euclidean,
     /// Dot product. Fast but requires normalized vectors.
+    #[serde(alias = "DotProduct", alias = "dot_product")]
     Dot,
+    /// Hamming distance for binary vectors.
+    Hamming,
+    /// Jaccard similarity for set-like vectors.
+    Jaccard,
 }
 
 /// Storage mode for `VelesDB`.

--- a/crates/velesdb-migrate/src/pipeline.rs
+++ b/crates/velesdb-migrate/src/pipeline.rs
@@ -243,6 +243,8 @@ impl Pipeline {
                 crate::config::DistanceMetric::Cosine => velesdb_core::DistanceMetric::Cosine,
                 crate::config::DistanceMetric::Euclidean => velesdb_core::DistanceMetric::Euclidean,
                 crate::config::DistanceMetric::Dot => velesdb_core::DistanceMetric::DotProduct,
+                crate::config::DistanceMetric::Hamming => velesdb_core::DistanceMetric::Hamming,
+                crate::config::DistanceMetric::Jaccard => velesdb_core::DistanceMetric::Jaccard,
             };
 
             let storage_mode = match self.config.destination.storage_mode {


### PR DESCRIPTION
## Summary
- Added `Hamming` and `Jaccard` variants to migrate's `DistanceMetric`
- Added serde aliases for `DotProduct`/`dot_product` on `Dot` variant
- Updated conversion in `pipeline.rs`

## Test plan
- [x] 230 migrate tests pass

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/530" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
