### PR TITLE
fix(mobile): add ProductQuantization variant to StorageMode [WP-1C]

### DIFF
--- a/crates/velesdb-mobile/src/types.rs
+++ b/crates/velesdb-mobile/src/types.rs
@@ -89,6 +89,8 @@ pub enum StorageMode {
     Sq8,
     /// Binary: 1-bit quantization (1 bit/dimension). 32x compression, ~5-10% recall loss.
     Binary,
+    /// Product Quantization (PQ): aggressive lossy compression (8x-16x typical).
+    ProductQuantization,
     /// `RaBitQ`: 1-bit with rotation + scalar correction. 32x compression, ~1-2% recall loss.
     Rabitq,
 }
@@ -99,6 +101,7 @@ impl From<StorageMode> for velesdb_core::StorageMode {
             StorageMode::Full => velesdb_core::StorageMode::Full,
             StorageMode::Sq8 => velesdb_core::StorageMode::SQ8,
             StorageMode::Binary => velesdb_core::StorageMode::Binary,
+            StorageMode::ProductQuantization => velesdb_core::StorageMode::ProductQuantization,
             StorageMode::Rabitq => velesdb_core::StorageMode::RaBitQ,
         }
     }


### PR DESCRIPTION
## Summary
- Added `ProductQuantization` to mobile `StorageMode` enum
- Updated `From<StorageMode>` conversion

## Test plan
- [x] `cargo check -p velesdb-mobile` passes

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/531" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
