### PR TITLE
fix(api): add #[non_exhaustive] to FusionStrategy and SearchQuality [WP-1D]

### DIFF
--- a/crates/velesdb-core/benches/recall_benchmark.rs
+++ b/crates/velesdb-core/benches/recall_benchmark.rs
@@ -122,6 +122,7 @@ fn bench_hnsw_recall(c: &mut Criterion) {
                     SearchQuality::Custom(_) => "custom",
                     SearchQuality::Adaptive { .. } => "adaptive",
                     SearchQuality::AutoTune => "autotune",
+                    _ => "unknown",
                 };
 
                 group.bench_function(

--- a/crates/velesdb-core/benches/recall_comprehensive.rs
+++ b/crates/velesdb-core/benches/recall_comprehensive.rs
@@ -112,6 +112,7 @@ fn bench_comprehensive(c: &mut Criterion) {
                 SearchQuality::Custom(e) => ("Custom", e),
                 SearchQuality::Adaptive { min_ef, .. } => ("Adaptive", min_ef),
                 SearchQuality::AutoTune => ("AutoTune", 128),
+                _ => ("Unknown", 128),
             };
 
             // Measure latencies

--- a/crates/velesdb-core/src/fusion/strategy.rs
+++ b/crates/velesdb-core/src/fusion/strategy.rs
@@ -42,6 +42,7 @@ impl std::error::Error for FusionError {}
 /// - `RRF`: Position-based fusion, robust to score scale differences
 /// - `Weighted`: Custom combination with explicit control over factors
 #[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
 pub enum FusionStrategy {
     /// Average score across all queries where the document appears.
     ///

--- a/crates/velesdb-core/src/index/hnsw/params.rs
+++ b/crates/velesdb-core/src/index/hnsw/params.rs
@@ -289,6 +289,7 @@ impl HnswParams {
 
 /// Search quality profile controlling the recall/latency tradeoff.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[non_exhaustive]
 pub enum SearchQuality {
     /// Fast search with `ef_search=96`. ~95% recall, lowest latency.
     Fast,

--- a/crates/velesdb-core/src/velesql/explain/formatter.rs
+++ b/crates/velesdb-core/src/velesql/explain/formatter.rs
@@ -242,8 +242,9 @@ impl fmt::Display for QueryPlan {
 /// Formats a `WithValue` for human-readable EXPLAIN display.
 pub(super) fn format_with_value(v: &super::super::ast::WithValue) -> String {
     match v {
-        super::super::ast::WithValue::String(s)
-        | super::super::ast::WithValue::Identifier(s) => s.clone(),
+        super::super::ast::WithValue::String(s) | super::super::ast::WithValue::Identifier(s) => {
+            s.clone()
+        }
         super::super::ast::WithValue::Integer(i) => i.to_string(),
         super::super::ast::WithValue::Float(f) => f.to_string(),
         super::super::ast::WithValue::Boolean(b) => b.to_string(),

--- a/crates/velesdb-core/src/velesql/explain/node_stats.rs
+++ b/crates/velesdb-core/src/velesql/explain/node_stats.rs
@@ -18,9 +18,7 @@ pub(super) fn estimate_cost(root: &PlanNode, has_vector_search: bool) -> f64 {
     let base_cost = if has_vector_search { 0.05 } else { 1.0 };
 
     match root {
-        PlanNode::Sequence(nodes) => nodes
-            .iter()
-            .fold(base_cost, |acc, n| acc + node_cost(n)),
+        PlanNode::Sequence(nodes) => nodes.iter().fold(base_cost, |acc, n| acc + node_cost(n)),
         _ => base_cost + node_cost(root),
     }
 }

--- a/crates/velesdb-python/src/fusion.rs
+++ b/crates/velesdb-python/src/fusion.rs
@@ -149,6 +149,8 @@ impl FusionStrategy {
             } => format!(
                 "FusionStrategy.relative_score(dense_weight={dense_weight}, sparse_weight={sparse_weight})"
             ),
+            // Forward-compat: future variants added behind #[non_exhaustive].
+            _ => format!("FusionStrategy(<unknown variant: {:?}>)", self.inner),
         }
     }
 }


### PR DESCRIPTION
## Summary
- Added `#[non_exhaustive]` to `FusionStrategy` and `SearchQuality` public enums
- Added wildcard arm in `velesdb-python` `__repr__` match

## Test plan
- [x] 4550 tests pass
- [x] Workspace check passes

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/532" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
