### PR TITLE
refactor(search): rename internal FusionStrategy to ScoreFusionMethod [WP-1E]

### DIFF
--- a/crates/velesdb-core/src/collection/search/query/score_fusion/explanation.rs
+++ b/crates/velesdb-core/src/collection/search/query/score_fusion/explanation.rs
@@ -2,7 +2,7 @@
 //!
 //! Provides detailed human-readable explanations of score computations.
 
-use super::{FusionStrategy, ScoreBreakdown};
+use super::{ScoreBreakdown, ScoreFusionMethod};
 use serde::{Deserialize, Serialize};
 
 /// Detailed explanation of a score's components.
@@ -37,7 +37,7 @@ pub struct ComponentExplanation {
 impl ScoreBreakdown {
     /// Generates a detailed explanation of the score breakdown.
     #[must_use]
-    pub fn explain(&self, strategy: &FusionStrategy) -> ScoreExplanation {
+    pub fn explain(&self, strategy: &ScoreFusionMethod) -> ScoreExplanation {
         let total_components = self.count_components();
         let default_weight = if total_components > 0 {
             1.0 / total_components as f32

--- a/crates/velesdb-core/src/collection/search/query/score_fusion/mod.rs
+++ b/crates/velesdb-core/src/collection/search/query/score_fusion/mod.rs
@@ -151,7 +151,7 @@ impl ScoreBreakdown {
     }
 
     /// Compute final score using the specified strategy.
-    pub fn compute_final(&mut self, strategy: &FusionStrategy) {
+    pub fn compute_final(&mut self, strategy: &ScoreFusionMethod) {
         self.final_score = strategy.combine(self);
     }
 
@@ -184,8 +184,11 @@ impl ScoreBreakdown {
 }
 
 /// Strategy for combining multiple scores (EPIC-049 US-004).
+///
+/// Named `ScoreFusionMethod` to distinguish from the public
+/// [`crate::fusion::FusionStrategy`] enum used for multi-query result fusion.
 #[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
-pub enum FusionStrategy {
+pub enum ScoreFusionMethod {
     /// Reciprocal Rank Fusion (RRF) - good for combining ranked lists.
     #[default]
     Rrf,
@@ -206,7 +209,7 @@ pub enum FusionStrategy {
     Average,
 }
 
-impl FusionStrategy {
+impl ScoreFusionMethod {
     /// Combine scores from a breakdown using this strategy.
     #[must_use]
     pub fn combine(&self, breakdown: &ScoreBreakdown) -> f32 {

--- a/crates/velesdb-core/src/collection/search/query/score_fusion_tests.rs
+++ b/crates/velesdb-core/src/collection/search/query/score_fusion_tests.rs
@@ -51,7 +51,7 @@ fn test_score_breakdown_components() {
 fn test_fusion_strategy_average() {
     let mut breakdown = ScoreBreakdown::new().with_vector(0.9).with_graph(0.7);
 
-    breakdown.compute_final(&FusionStrategy::Average);
+    breakdown.compute_final(&ScoreFusionMethod::Average);
     assert!((breakdown.final_score - 0.8).abs() < 0.001);
 }
 
@@ -59,7 +59,7 @@ fn test_fusion_strategy_average() {
 fn test_fusion_strategy_maximum() {
     let mut breakdown = ScoreBreakdown::new().with_vector(0.9).with_graph(0.7);
 
-    breakdown.compute_final(&FusionStrategy::Maximum);
+    breakdown.compute_final(&ScoreFusionMethod::Maximum);
     assert!((breakdown.final_score - 0.9).abs() < 0.001);
 }
 
@@ -67,7 +67,7 @@ fn test_fusion_strategy_maximum() {
 fn test_fusion_strategy_minimum() {
     let mut breakdown = ScoreBreakdown::new().with_vector(0.9).with_graph(0.7);
 
-    breakdown.compute_final(&FusionStrategy::Minimum);
+    breakdown.compute_final(&ScoreFusionMethod::Minimum);
     assert!((breakdown.final_score - 0.7).abs() < 0.001);
 }
 
@@ -75,7 +75,7 @@ fn test_fusion_strategy_minimum() {
 fn test_fusion_strategy_product() {
     let mut breakdown = ScoreBreakdown::new().with_vector(0.9).with_graph(0.8);
 
-    breakdown.compute_final(&FusionStrategy::Product);
+    breakdown.compute_final(&ScoreFusionMethod::Product);
     assert!((breakdown.final_score - 0.72).abs() < 0.001);
 }
 
@@ -85,7 +85,7 @@ fn test_fusion_with_metadata_boost() {
         .with_vector(0.8)
         .with_metadata_boost(1.5);
 
-    breakdown.compute_final(&FusionStrategy::Average);
+    breakdown.compute_final(&ScoreFusionMethod::Average);
     assert!((breakdown.final_score - 1.2).abs() < 0.001);
 }
 
@@ -96,7 +96,7 @@ fn test_fusion_with_multiple_boosts() {
         .with_metadata_boost(1.2)
         .with_recency_boost(1.1);
 
-    breakdown.compute_final(&FusionStrategy::Average);
+    breakdown.compute_final(&ScoreFusionMethod::Average);
     assert!((breakdown.final_score - 1.056).abs() < 0.01);
 }
 
@@ -106,7 +106,7 @@ fn test_fusion_with_custom_boost() {
         .with_vector(0.5)
         .with_custom_boost("popularity", 2.0);
 
-    breakdown.compute_final(&FusionStrategy::Average);
+    breakdown.compute_final(&ScoreFusionMethod::Average);
     assert!((breakdown.final_score - 1.0).abs() < 0.001);
 }
 
@@ -123,7 +123,7 @@ fn test_scored_result_with_breakdown() {
     let breakdown = ScoreBreakdown::new().with_vector(0.9).with_graph(0.8);
 
     let mut bd = breakdown.clone();
-    bd.compute_final(&FusionStrategy::Average);
+    bd.compute_final(&ScoreFusionMethod::Average);
 
     let result = ScoredResult::with_breakdown(1, bd);
     assert_eq!(result.id, 1);
@@ -132,10 +132,10 @@ fn test_scored_result_with_breakdown() {
 
 #[test]
 fn test_fusion_strategy_as_str() {
-    assert_eq!(FusionStrategy::Rrf.as_str(), "rrf");
-    assert_eq!(FusionStrategy::Weighted.as_str(), "weighted");
-    assert_eq!(FusionStrategy::Maximum.as_str(), "maximum");
-    assert_eq!(FusionStrategy::Average.as_str(), "average");
+    assert_eq!(ScoreFusionMethod::Rrf.as_str(), "rrf");
+    assert_eq!(ScoreFusionMethod::Weighted.as_str(), "weighted");
+    assert_eq!(ScoreFusionMethod::Maximum.as_str(), "maximum");
+    assert_eq!(ScoreFusionMethod::Average.as_str(), "average");
 }
 
 #[test]
@@ -151,7 +151,7 @@ fn test_score_breakdown_json_serialization() {
 #[test]
 fn test_scored_result_json_serialization() {
     let mut breakdown = ScoreBreakdown::new().with_vector(0.9);
-    breakdown.compute_final(&FusionStrategy::Average);
+    breakdown.compute_final(&ScoreFusionMethod::Average);
 
     let result = ScoredResult::with_breakdown(42, breakdown)
         .with_payload(serde_json::json!({"title": "Test"}));
@@ -260,7 +260,7 @@ fn test_path_scorer_combined_with_breakdown() {
 
     let mut breakdown = ScoreBreakdown::new().with_vector(0.9).with_path(path_score);
 
-    breakdown.compute_final(&FusionStrategy::Average);
+    breakdown.compute_final(&ScoreFusionMethod::Average);
 
     // Average of 0.9 and 0.64 = 0.77
     assert!((breakdown.final_score - 0.77).abs() < 0.01);
@@ -420,9 +420,9 @@ fn test_boost_function_names() {
 #[test]
 fn test_explain_vector_only() {
     let mut breakdown = ScoreBreakdown::new().with_vector(0.85);
-    breakdown.compute_final(&FusionStrategy::Average);
+    breakdown.compute_final(&ScoreFusionMethod::Average);
 
-    let explanation = breakdown.explain(&FusionStrategy::Average);
+    let explanation = breakdown.explain(&ScoreFusionMethod::Average);
 
     assert!((explanation.final_score - 0.85).abs() < f32::EPSILON);
     assert_eq!(explanation.strategy, "average");
@@ -437,9 +437,9 @@ fn test_explain_hybrid_query() {
         .with_vector(0.9)
         .with_graph(0.7)
         .with_path(0.8);
-    breakdown.compute_final(&FusionStrategy::Average);
+    breakdown.compute_final(&ScoreFusionMethod::Average);
 
-    let explanation = breakdown.explain(&FusionStrategy::Average);
+    let explanation = breakdown.explain(&ScoreFusionMethod::Average);
 
     // 3 weighted components + none for boosts
     assert_eq!(explanation.components.len(), 3);
@@ -458,9 +458,9 @@ fn test_explain_with_boosts() {
         .with_vector(0.9)
         .with_metadata_boost(1.2)
         .with_recency_boost(1.1);
-    breakdown.compute_final(&FusionStrategy::Average);
+    breakdown.compute_final(&ScoreFusionMethod::Average);
 
-    let explanation = breakdown.explain(&FusionStrategy::Average);
+    let explanation = breakdown.explain(&ScoreFusionMethod::Average);
 
     // 1 weighted component (vector) + 2 multipliers
     assert_eq!(explanation.components.len(), 3);
@@ -477,9 +477,9 @@ fn test_explain_with_boosts() {
 #[test]
 fn test_explain_human_readable_format() {
     let mut breakdown = ScoreBreakdown::new().with_vector(0.92).with_graph(0.75);
-    breakdown.compute_final(&FusionStrategy::Average);
+    breakdown.compute_final(&ScoreFusionMethod::Average);
 
-    let explanation = breakdown.explain(&FusionStrategy::Average);
+    let explanation = breakdown.explain(&ScoreFusionMethod::Average);
 
     // Should contain final score line
     assert!(explanation.human_readable.contains("Final score:"));
@@ -495,9 +495,9 @@ fn test_explain_custom_boosts() {
     let mut breakdown = ScoreBreakdown::new()
         .with_vector(0.8)
         .with_custom_boost("popularity", 1.5);
-    breakdown.compute_final(&FusionStrategy::Average);
+    breakdown.compute_final(&ScoreFusionMethod::Average);
 
-    let explanation = breakdown.explain(&FusionStrategy::Average);
+    let explanation = breakdown.explain(&ScoreFusionMethod::Average);
 
     // Should include custom boost
     let custom = explanation
@@ -511,9 +511,9 @@ fn test_explain_custom_boosts() {
 #[test]
 fn test_explanation_json_serialization() {
     let mut breakdown = ScoreBreakdown::new().with_vector(0.9).with_graph(0.8);
-    breakdown.compute_final(&FusionStrategy::Average);
+    breakdown.compute_final(&ScoreFusionMethod::Average);
 
-    let explanation = breakdown.explain(&FusionStrategy::Average);
+    let explanation = breakdown.explain(&ScoreFusionMethod::Average);
     let json = serde_json::to_string(&explanation).unwrap();
 
     assert!(json.contains("final_score"));


### PR DESCRIPTION
## Summary
- Renamed internal `FusionStrategy` enum to `ScoreFusionMethod` in score_fusion module
- Eliminates naming confusion with the public API `FusionStrategy` enum
- Pure rename, no logic changes

## Test plan
- [x] 84 fusion tests pass
- [x] 40 score_fusion tests pass

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/533" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
