### PR TITLE
fix(cbo): filter zero-width buckets in equidepth histogram [WP-2A]

### DIFF
--- a/crates/velesdb-core/src/collection/stats/histogram.rs
+++ b/crates/velesdb-core/src/collection/stats/histogram.rs
@@ -387,6 +387,11 @@ fn build_per_distinct_buckets(sorted: &[f64], distinct: usize) -> Vec<HistogramB
 }
 
 /// Builds equi-depth buckets by splitting sorted values into equal-sized chunks.
+///
+/// After chunking, merges any zero-width buckets (`lower_bound == upper_bound`)
+/// into adjacent buckets. Zero-width buckets arise from duplicate-heavy data where
+/// a chunk boundary falls inside a run of identical values — their counts inflate
+/// `bucket_sum()` without contributing to any selectivity lookup.
 fn build_equidepth_buckets(sorted: &[f64], num_buckets: usize) -> Vec<HistogramBucket> {
     let chunk_size = sorted.len().div_ceil(num_buckets);
     let mut buckets = Vec::with_capacity(num_buckets);
@@ -400,7 +405,53 @@ fn build_equidepth_buckets(sorted: &[f64], num_buckets: usize) -> Vec<HistogramB
             distinct_count: slice_distinct_count(chunk),
         });
     }
-    buckets
+    merge_zero_width_buckets(buckets)
+}
+
+/// Merges zero-width buckets (`lower_bound == upper_bound`) into adjacent buckets.
+///
+/// Zero-width buckets are absorbed into the nearest **non-zero-width** neighbor.
+/// Leading zero-width buckets are merged forward into the first non-zero-width
+/// bucket; trailing ones are merged backward into the last non-zero-width bucket.
+///
+/// Counts and distinct counts are summed into the absorbing bucket. If every
+/// bucket is zero-width (all values identical), the input is returned unchanged —
+/// this case is already handled by `build_single_value_buckets` upstream.
+#[allow(clippy::float_cmp)]
+pub(crate) fn merge_zero_width_buckets(buckets: Vec<HistogramBucket>) -> Vec<HistogramBucket> {
+    if buckets.is_empty() {
+        return buckets;
+    }
+    // Accumulator for leading/pending zero-width bucket counts.
+    let mut pending_count: u64 = 0;
+    let mut pending_distinct: u64 = 0;
+    let mut result: Vec<HistogramBucket> = Vec::with_capacity(buckets.len());
+    for bucket in buckets {
+        // Reason: exact equality is intentional — zero-width means the chunk
+        // contained only identical values whose upper bound equals the next
+        // chunk's lower bound.
+        if bucket.lower_bound == bucket.upper_bound {
+            pending_count += bucket.count;
+            pending_distinct += bucket.distinct_count;
+        } else {
+            // Absorb any pending zero-width counts into this non-zero-width bucket.
+            let mut merged = bucket;
+            merged.count += pending_count;
+            merged.distinct_count += pending_distinct;
+            pending_count = 0;
+            pending_distinct = 0;
+            result.push(merged);
+        }
+    }
+    // Trailing zero-width buckets: merge into the last non-zero-width bucket.
+    if pending_count > 0 {
+        if let Some(last) = result.last_mut() {
+            last.count += pending_count;
+            last.distinct_count += pending_distinct;
+        }
+        // else: all buckets were zero-width — handled by build_single_value_buckets
+    }
+    result
 }
 
 /// Computes the upper bound for an equi-depth chunk.

--- a/crates/velesdb-core/src/collection/stats/tests.rs
+++ b/crates/velesdb-core/src/collection/stats/tests.rs
@@ -584,3 +584,111 @@ fn test_histogram_serde_default_metadata_fields() {
     assert_eq!(hist.buckets.len(), 1);
     assert_eq!(hist.buckets[0].distinct_count, 0);
 }
+
+// --- WP-2A: Zero-width bucket inflation regression tests ---
+
+#[test]
+fn test_no_zero_width_buckets_with_heavy_duplicates() {
+    // Regression test: duplicate-heavy data used to produce zero-width buckets
+    // whose counts inflated bucket_sum(), deflating selectivity estimates.
+    let builder = HistogramBuilder::new(4);
+    // 20 copies of 5.0 mixed with a few distinct values → forces chunk boundaries
+    // inside the 5.0 run, previously creating zero-width buckets.
+    let mut values = vec![5.0; 20];
+    values.extend_from_slice(&[1.0, 2.0, 3.0, 10.0, 20.0]);
+    let h = builder.build(&mut values);
+
+    // Every bucket must have non-zero width.
+    for (i, bucket) in h.buckets.iter().enumerate() {
+        assert!(
+            bucket.upper_bound > bucket.lower_bound,
+            "bucket {i} is zero-width: lower={}, upper={}",
+            bucket.lower_bound,
+            bucket.upper_bound,
+        );
+    }
+
+    // Total count across buckets must equal number of values.
+    let bucket_sum: u64 = h.buckets.iter().map(|b| b.count).sum();
+    assert_eq!(bucket_sum, 25, "bucket_sum must equal total input count");
+    assert_eq!(h.total_count, 25);
+}
+
+#[test]
+fn test_selectivity_not_inflated_by_duplicates() {
+    // Build a histogram from data with heavy duplicates and verify that
+    // bucket_sum() equals total_count (no inflation from zero-width ghosts).
+    let builder = HistogramBuilder::new(4);
+    let mut values: Vec<f64> = vec![1.0; 50];
+    values.extend_from_slice(&[2.0, 3.0, 4.0, 5.0]);
+    let h = builder.build(&mut values);
+
+    // Core invariant: bucket_sum must equal total_count — no inflation.
+    let bucket_sum: u64 = h.buckets.iter().map(|b| b.count).sum();
+    assert_eq!(
+        bucket_sum, h.total_count,
+        "bucket_sum ({bucket_sum}) != total_count ({}): zero-width inflation detected",
+        h.total_count
+    );
+
+    // No zero-width buckets should remain.
+    for (i, bucket) in h.buckets.iter().enumerate() {
+        assert!(
+            bucket.upper_bound > bucket.lower_bound,
+            "bucket {i} is zero-width after merge"
+        );
+    }
+
+    // Selectivity for 1.0 must be findable (not silently lost in a zero-width bucket).
+    let sel = h.estimate_eq_selectivity(1.0);
+    assert!(
+        sel > 0.0,
+        "selectivity for dominant value should be > 0, got {sel}"
+    );
+}
+
+#[test]
+fn test_zero_width_merge_preserves_count() {
+    // Directly test the merge helper: fabricate buckets including zero-width ones
+    // and verify counts are preserved after merging.
+    let buckets = vec![
+        HistogramBucket {
+            lower_bound: 0.0,
+            upper_bound: 5.0,
+            count: 10,
+            distinct_count: 5,
+        },
+        // Zero-width: lower == upper == 5.0
+        HistogramBucket {
+            lower_bound: 5.0,
+            upper_bound: 5.0,
+            count: 20,
+            distinct_count: 1,
+        },
+        HistogramBucket {
+            lower_bound: 5.0,
+            upper_bound: 10.0,
+            count: 15,
+            distinct_count: 5,
+        },
+    ];
+    let merged = histogram::merge_zero_width_buckets(buckets);
+
+    // The zero-width bucket should have been absorbed.
+    assert_eq!(merged.len(), 2, "zero-width bucket should be merged");
+
+    // First bucket: original non-zero-width (count=10), unchanged.
+    assert_eq!(merged[0].count, 10);
+    assert_eq!(merged[0].lower_bound, 0.0);
+    assert!((merged[0].upper_bound - 5.0).abs() < f64::EPSILON);
+
+    // Second bucket: original (count=15) + absorbed zero-width (count=20) = 35.
+    // The zero-width bucket is merged forward into the next non-zero-width bucket.
+    assert_eq!(merged[1].count, 35);
+    assert_eq!(merged[1].lower_bound, 5.0);
+    assert!((merged[1].upper_bound - 10.0).abs() < f64::EPSILON);
+
+    // Total count preserved.
+    let total: u64 = merged.iter().map(|b| b.count).sum();
+    assert_eq!(total, 45);
+}


### PR DESCRIPTION
## Summary
- Added `merge_zero_width_buckets()` post-processing step (CC=7, NLOC=34)
- Prevents selectivity denominator inflation from zero-width buckets
- 3 regression tests added

## Test plan
- [x] 45 stats tests pass

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/535" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
