### PR TITLE
fix(integrations): call validate_url() in vectorstore __init__ [WP-2B]

### DIFF
--- a/integrations/langchain/src/langchain_velesdb/vectorstore.py
+++ b/integrations/langchain/src/langchain_velesdb/vectorstore.py
@@ -29,6 +29,7 @@ from langchain_velesdb.security import (
     validate_batch_size,
     validate_collection_name,
     validate_sparse_vector,
+    validate_url,
 )
 from velesdb_common.collection_admin import CollectionAdminMixin
 from velesdb_common.ids import stable_hash_id as _stable_hash_id
@@ -93,6 +94,7 @@ class VelesDBVectorStore(CollectionAdminMixin, SearchOpsMixin, GraphOpsMixin, Ve
         collection_name: str = "langchain",
         metric: str = "cosine",
         storage_mode: str = "full",
+        server_url: Optional[str] = None,
         **kwargs: Any,
     ) -> None:
         """Initialize VelesDB vector store.
@@ -118,6 +120,8 @@ class VelesDBVectorStore(CollectionAdminMixin, SearchOpsMixin, GraphOpsMixin, Ve
                 - "rabitq": RaBitQ with scalar correction (32x compression, good recall).
 
                 Examples: ``storage_mode="f32"`` is equivalent to ``storage_mode="full"``.
+            server_url: Optional URL of a VelesDB server for server mode. When
+                provided, must be a valid http:// or https:// URL.
             **kwargs: Additional arguments passed to the database.
 
         Raises:
@@ -127,6 +131,9 @@ class VelesDBVectorStore(CollectionAdminMixin, SearchOpsMixin, GraphOpsMixin, Ve
         self._collection_name = validate_collection_name(collection_name)
         self._metric = validate_metric(metric)
         self._storage_mode = validate_storage_mode(storage_mode)
+        if server_url is not None:
+            validate_url(server_url)
+        self.server_url = server_url
 
         self._embedding = embedding
         self._db: Optional[velesdb.Database] = None

--- a/integrations/langchain/tests/test_vectorstore.py
+++ b/integrations/langchain/tests/test_vectorstore.py
@@ -883,5 +883,74 @@ class TestV15Features:
         assert __version__ == "1.7.0"
 
 
+class TestServerUrlValidation:
+    """Tests for validate_url() call in server mode (WP-2B)."""
+
+    def test_valid_https_server_url_is_accepted(self, embeddings):
+        """A valid https:// server_url must not raise."""
+        store = VelesDBVectorStore(
+            embedding=embeddings,
+            path="./unused",
+            collection_name="url-test",
+            server_url="https://velesdb.example.com:8080",
+        )
+        assert store.server_url == "https://velesdb.example.com:8080"
+
+    def test_valid_http_server_url_is_accepted(self, embeddings):
+        """A valid http:// server_url must not raise."""
+        store = VelesDBVectorStore(
+            embedding=embeddings,
+            path="./unused",
+            collection_name="url-test-http",
+            server_url="http://localhost:8080",
+        )
+        assert store.server_url == "http://localhost:8080"
+
+    def test_no_server_url_is_accepted(self, embeddings):
+        """Omitting server_url (local mode) must not raise."""
+        store = VelesDBVectorStore(
+            embedding=embeddings,
+            path="./unused",
+            collection_name="url-test-none",
+        )
+        assert store.server_url is None
+
+    def test_invalid_scheme_raises_security_error(self, embeddings):
+        """A server_url without http/https scheme must raise SecurityError."""
+        from langchain_velesdb.security import SecurityError
+
+        with pytest.raises(SecurityError, match="http"):
+            VelesDBVectorStore(
+                embedding=embeddings,
+                path="./unused",
+                collection_name="url-test-bad",
+                server_url="ftp://velesdb.example.com",
+            )
+
+    def test_empty_server_url_raises_security_error(self, embeddings):
+        """An empty server_url string must raise SecurityError."""
+        from langchain_velesdb.security import SecurityError
+
+        with pytest.raises(SecurityError):
+            VelesDBVectorStore(
+                embedding=embeddings,
+                path="./unused",
+                collection_name="url-test-empty",
+                server_url="",
+            )
+
+    def test_server_url_with_newline_raises_security_error(self, embeddings):
+        """A server_url containing a newline must raise SecurityError."""
+        from langchain_velesdb.security import SecurityError
+
+        with pytest.raises(SecurityError):
+            VelesDBVectorStore(
+                embedding=embeddings,
+                path="./unused",
+                collection_name="url-test-injection",
+                server_url="https://ok.example.com\nX-Injected: evil",
+            )
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/integrations/llamaindex/src/llamaindex_velesdb/vectorstore.py
+++ b/integrations/llamaindex/src/llamaindex_velesdb/vectorstore.py
@@ -25,6 +25,7 @@ from llamaindex_velesdb.security import (
     validate_batch_size,
     validate_collection_name,
     validate_sparse_vector,
+    validate_url,
 )
 from velesdb_common.collection_admin import CollectionAdminMixin
 from velesdb_common.ids import stable_hash_id as _stable_hash_id
@@ -155,6 +156,7 @@ class VelesDBVectorStore(CollectionAdminMixin, SearchOpsMixin, GraphOpsMixin, Ba
     collection_name: str = "llamaindex"
     metric: str = "cosine"
     storage_mode: str = "full"
+    server_url: Optional[str] = None
 
     _db: Optional[velesdb.Database] = PrivateAttr(default=None)
     _collection: Optional[velesdb.Collection] = PrivateAttr(default=None)
@@ -168,6 +170,7 @@ class VelesDBVectorStore(CollectionAdminMixin, SearchOpsMixin, GraphOpsMixin, Ba
         collection_name: str = "llamaindex",
         metric: str = "cosine",
         storage_mode: str = "full",
+        server_url: Optional[str] = None,
         **kwargs: Any,
     ) -> None:
         """Initialize VelesDB vector store.
@@ -192,6 +195,8 @@ class VelesDBVectorStore(CollectionAdminMixin, SearchOpsMixin, GraphOpsMixin, Ba
                 - "rabitq": RaBitQ with scalar correction (32x compression, good recall).
 
                 Examples: ``storage_mode="int8"`` is equivalent to ``storage_mode="sq8"``.
+            server_url: Optional URL of a VelesDB server for server mode. When
+                provided, must be a valid http:// or https:// URL.
             **kwargs: Additional arguments.
 
         Raises:
@@ -202,12 +207,15 @@ class VelesDBVectorStore(CollectionAdminMixin, SearchOpsMixin, GraphOpsMixin, Ba
         validated_collection = validate_collection_name(collection_name)
         validated_metric = validate_metric(metric)
         validated_storage_mode = validate_storage_mode(storage_mode)
+        if server_url is not None:
+            validate_url(server_url)
 
         super().__init__(
             path=validated_path,
             storage_mode=validated_storage_mode,
             collection_name=validated_collection,
             metric=validated_metric,
+            server_url=server_url,
             **kwargs,
         )
 

--- a/integrations/llamaindex/tests/test_vectorstore.py
+++ b/integrations/llamaindex/tests/test_vectorstore.py
@@ -794,5 +794,72 @@ class TestV15Features:
         assert __version__ == "1.7.0"
 
 
+class TestServerUrlValidation:
+    """Tests for validate_url() call in server mode (WP-2B)."""
+
+    @pytest.fixture
+    def temp_dir(self):
+        """Create a temporary directory for tests."""
+        path = tempfile.mkdtemp()
+        yield path
+        shutil.rmtree(path, ignore_errors=True)
+
+    def test_valid_https_server_url_is_accepted(self, temp_dir):
+        """A valid https:// server_url must not raise."""
+        store = VelesDBVectorStore(
+            path=temp_dir,
+            collection_name="url-test",
+            server_url="https://velesdb.example.com:8080",
+        )
+        assert store.server_url == "https://velesdb.example.com:8080"
+
+    def test_valid_http_server_url_is_accepted(self, temp_dir):
+        """A valid http:// server_url must not raise."""
+        store = VelesDBVectorStore(
+            path=temp_dir,
+            collection_name="url-test-http",
+            server_url="http://localhost:8080",
+        )
+        assert store.server_url == "http://localhost:8080"
+
+    def test_no_server_url_is_accepted(self, temp_dir):
+        """Omitting server_url (local mode) must not raise."""
+        store = VelesDBVectorStore(path=temp_dir, collection_name="url-test-none")
+        assert store.server_url is None
+
+    def test_invalid_scheme_raises_security_error(self, temp_dir):
+        """A server_url without http/https scheme must raise SecurityError."""
+        from llamaindex_velesdb.security import SecurityError
+
+        with pytest.raises(SecurityError, match="http"):
+            VelesDBVectorStore(
+                path=temp_dir,
+                collection_name="url-test-bad",
+                server_url="ftp://velesdb.example.com",
+            )
+
+    def test_empty_server_url_raises_security_error(self, temp_dir):
+        """An empty server_url string must raise SecurityError."""
+        from llamaindex_velesdb.security import SecurityError
+
+        with pytest.raises(SecurityError):
+            VelesDBVectorStore(
+                path=temp_dir,
+                collection_name="url-test-empty",
+                server_url="",
+            )
+
+    def test_server_url_with_newline_raises_security_error(self, temp_dir):
+        """A server_url containing a newline must raise SecurityError."""
+        from llamaindex_velesdb.security import SecurityError
+
+        with pytest.raises(SecurityError):
+            VelesDBVectorStore(
+                path=temp_dir,
+                collection_name="url-test-injection",
+                server_url="https://ok.example.com\nX-Injected: evil",
+            )
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary
- Added `validate_url(server_url)` call in both LangChain and LlamaIndex vectorstore constructors
- 12 security tests added (6 per integration)

## Test plan
- [x] All 12 URL validation tests pass

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/536" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
