### PR TITLE
fix(integrations): add upper bounds to external dependencies [WP-2D]

### DIFF
--- a/demos/rag-pdf-demo/pyproject.toml
+++ b/demos/rag-pdf-demo/pyproject.toml
@@ -11,23 +11,23 @@ authors = [
 keywords = ["rag", "velesdb", "pdf", "embeddings", "vector-search"]
 
 dependencies = [
-    "fastapi>=0.104.0",
-    "uvicorn[standard]>=0.24.0",
-    "python-multipart>=0.0.6",
-    "sentence-transformers>=2.2.0",
-    "pymupdf>=1.23.0",
-    "httpx>=0.25.0",
-    "pydantic>=2.5.0",
-    "pydantic-settings>=2.1.0",
-    "aiofiles>=23.0.0",
+    "fastapi>=0.104.0,<1.0.0",
+    "uvicorn[standard]>=0.24.0,<1.0.0",
+    "python-multipart>=0.0.6,<1.0.0",
+    "sentence-transformers>=2.2.0,<4.0.0",
+    "pymupdf>=1.23.0,<2.0.0",
+    "httpx>=0.25.0,<1.0.0",
+    "pydantic>=2.5.0,<3.0.0",
+    "pydantic-settings>=2.1.0,<3.0.0",
+    "aiofiles>=23.0.0,<25.0.0",
 ]
 
 [project.optional-dependencies]
 dev = [
-    "pytest>=7.4.0",
-    "pytest-asyncio>=0.21.0",
-    "pytest-cov>=4.1.0",
-    "httpx>=0.25.0",
+    "pytest>=7.4.0,<9.0",
+    "pytest-asyncio>=0.21.0,<1.0.0",
+    "pytest-cov>=4.1.0,<7.0.0",
+    "httpx>=0.25.0,<1.0.0",
 ]
 
 [build-system]

--- a/integrations/langchain/pyproject.toml
+++ b/integrations/langchain/pyproject.toml
@@ -25,16 +25,16 @@ classifiers = [
 ]
 requires-python = ">=3.9"
 dependencies = [
-    "langchain-core>=0.1.0",
+    "langchain-core>=0.1.0,<1.0.0",
     "velesdb>=1.9.0",
     "velesdb-common>=1.9.0",
 ]
 
 [project.optional-dependencies]
 dev = [
-    "pytest>=7.0",
-    "pytest-asyncio>=0.21",
-    "langchain>=0.1.0",
+    "pytest>=7.0,<9.0",
+    "pytest-asyncio>=0.21,<1.0.0",
+    "langchain>=0.1.0,<1.0.0",
 ]
 
 [project.urls]

--- a/integrations/llamaindex/pyproject.toml
+++ b/integrations/llamaindex/pyproject.toml
@@ -26,15 +26,15 @@ classifiers = [
 ]
 
 dependencies = [
-    "llama-index-core>=0.10.0",
+    "llama-index-core>=0.10.0,<1.0.0",
     "velesdb>=1.9.0",
     "velesdb-common>=1.9.0",
 ]
 
 [project.optional-dependencies]
 dev = [
-    "pytest>=7.0",
-    "pytest-asyncio>=0.21",
+    "pytest>=7.0,<9.0",
+    "pytest-asyncio>=0.21,<1.0.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
## Summary
- Added upper bounds to all external deps in 3 pyproject.toml files
- LangChain/LlamaIndex capped at <1.0.0, pytest <9.0, etc.
- VelesDB internal deps left uncapped

## Test plan
- [x] No code changes, dependency constraints only

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/538" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
