### PR TITLE
feat(server): add /v1/ API versioning prefix [WP-2H]

### DIFF
--- a/crates/velesdb-server/src/main.rs
+++ b/crates/velesdb-server/src/main.rs
@@ -3,6 +3,7 @@
 
 use axum::{
     extract::DefaultBodyLimit,
+    middleware::Next,
     routing::{delete, get, post},
     Router,
 };
@@ -209,8 +210,35 @@ fn api_routes() -> Router<Arc<AppState>> {
     core_routes().merge(search_routes()).merge(graph_routes())
 }
 
+/// Middleware that adds deprecation headers to responses served on
+/// unversioned (legacy) routes. Clients should migrate to `/v1/` prefix.
+async fn deprecation_header(
+    request: axum::extract::Request,
+    next: Next,
+) -> axum::response::Response {
+    let mut response = next.run(request).await;
+    let headers = response.headers_mut();
+    // SAFETY rationale: these are compile-time constant ASCII strings;
+    // `parse()` cannot fail, but we use `expect` to satisfy no-unwrap policy
+    // with an explanation (this is binary code, not library).
+    headers.insert("deprecation", "true".parse().expect("static header value"));
+    headers.insert(
+        "x-api-deprecated",
+        "Use /v1/ prefix".parse().expect("static header value"),
+    );
+    response
+}
+
 fn build_router(state: Arc<AppState>, auth_state: AuthState) -> Router {
-    let api_router = api_routes();
+    let routes = api_routes();
+
+    // Canonical versioned API under /v1/
+    let versioned = Router::new().nest("/v1", routes.clone());
+
+    // Legacy unversioned routes with deprecation headers for backward compat
+    let legacy = routes.layer(axum::middleware::from_fn(deprecation_header));
+
+    let api_router = versioned.merge(legacy);
 
     #[cfg(feature = "prometheus")]
     let api_router = {

--- a/crates/velesdb-server/tests/api_versioning_tests.rs
+++ b/crates/velesdb-server/tests/api_versioning_tests.rs
@@ -1,0 +1,171 @@
+//! Integration tests for API versioning (WP-2H).
+//!
+//! Verifies that:
+//! - `/v1/` prefixed routes return responses without deprecation headers.
+//! - Legacy (unprefixed) routes still work but include deprecation headers.
+
+mod common;
+
+use axum::{
+    body::Body,
+    http::{Request, StatusCode},
+};
+use serde_json::Value;
+use tower::ServiceExt;
+
+// ============================================================================
+// Versioned routes (/v1/) — no deprecation headers
+// ============================================================================
+
+#[tokio::test]
+async fn v1_health_returns_200_without_deprecation() {
+    let temp_dir = tempfile::tempdir().expect("test: temp dir");
+    let app = common::create_versioned_test_app(&temp_dir);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/v1/health")
+                .body(Body::empty())
+                .expect("test: build request"),
+        )
+        .await
+        .expect("test: request failed");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert!(
+        response.headers().get("deprecation").is_none(),
+        "/v1/ routes must not carry deprecation header"
+    );
+    assert!(
+        response.headers().get("x-api-deprecated").is_none(),
+        "/v1/ routes must not carry x-api-deprecated header"
+    );
+}
+
+#[tokio::test]
+async fn v1_collections_returns_200_without_deprecation() {
+    let temp_dir = tempfile::tempdir().expect("test: temp dir");
+    let app = common::create_versioned_test_app(&temp_dir);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/v1/collections")
+                .body(Body::empty())
+                .expect("test: build request"),
+        )
+        .await
+        .expect("test: request failed");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert!(
+        response.headers().get("deprecation").is_none(),
+        "/v1/collections must not carry deprecation header"
+    );
+}
+
+// ============================================================================
+// Legacy routes (no prefix) — must include deprecation headers
+// ============================================================================
+
+#[tokio::test]
+async fn legacy_health_returns_200_with_deprecation_headers() {
+    let temp_dir = tempfile::tempdir().expect("test: temp dir");
+    let app = common::create_versioned_test_app(&temp_dir);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/health")
+                .body(Body::empty())
+                .expect("test: build request"),
+        )
+        .await
+        .expect("test: request failed");
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let deprecation = response
+        .headers()
+        .get("deprecation")
+        .expect("test: deprecation header missing on legacy route");
+    assert_eq!(deprecation, "true");
+
+    let api_deprecated = response
+        .headers()
+        .get("x-api-deprecated")
+        .expect("test: x-api-deprecated header missing on legacy route");
+    assert_eq!(api_deprecated, "Use /v1/ prefix");
+}
+
+#[tokio::test]
+async fn legacy_collections_returns_200_with_deprecation_headers() {
+    let temp_dir = tempfile::tempdir().expect("test: temp dir");
+    let app = common::create_versioned_test_app(&temp_dir);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/collections")
+                .body(Body::empty())
+                .expect("test: build request"),
+        )
+        .await
+        .expect("test: request failed");
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let deprecation = response
+        .headers()
+        .get("deprecation")
+        .expect("test: deprecation header missing on legacy /collections");
+    assert_eq!(deprecation, "true");
+}
+
+// ============================================================================
+// Response body parity — both routes return identical payloads
+// ============================================================================
+
+#[tokio::test]
+async fn v1_and_legacy_health_return_same_body() {
+    let temp_dir = tempfile::tempdir().expect("test: temp dir");
+
+    // Request /v1/health
+    let app_v1 = common::create_versioned_test_app(&temp_dir);
+    let resp_v1 = app_v1
+        .oneshot(
+            Request::builder()
+                .uri("/v1/health")
+                .body(Body::empty())
+                .expect("test: build request"),
+        )
+        .await
+        .expect("test: request failed");
+    let body_v1 = axum::body::to_bytes(resp_v1.into_body(), usize::MAX)
+        .await
+        .expect("test: read body");
+    let json_v1: Value = serde_json::from_slice(&body_v1).expect("test: parse JSON");
+
+    // Request /health (legacy)
+    let app_legacy = common::create_versioned_test_app(&temp_dir);
+    let resp_legacy = app_legacy
+        .oneshot(
+            Request::builder()
+                .uri("/health")
+                .body(Body::empty())
+                .expect("test: build request"),
+        )
+        .await
+        .expect("test: request failed");
+    let body_legacy = axum::body::to_bytes(resp_legacy.into_body(), usize::MAX)
+        .await
+        .expect("test: read body");
+    let json_legacy: Value =
+        serde_json::from_slice(&body_legacy).expect("test: parse JSON");
+
+    assert_eq!(
+        json_v1["status"], json_legacy["status"],
+        "v1 and legacy must return the same status"
+    );
+}

--- a/crates/velesdb-server/tests/common/mod.rs
+++ b/crates/velesdb-server/tests/common/mod.rs
@@ -92,3 +92,35 @@ pub fn create_test_app_with_auth(temp_dir: &TempDir, api_keys: Vec<String>) -> R
             auth_middleware,
         ))
 }
+
+/// Middleware that adds deprecation headers for unversioned legacy routes.
+/// Mirrors the production middleware in `main.rs`.
+async fn deprecation_header(
+    request: axum::extract::Request,
+    next: axum::middleware::Next,
+) -> axum::response::Response {
+    let mut response = next.run(request).await;
+    let headers = response.headers_mut();
+    headers.insert("deprecation", "true".parse().expect("test: static header value"));
+    headers.insert(
+        "x-api-deprecated",
+        "Use /v1/ prefix".parse().expect("test: static header value"),
+    );
+    response
+}
+
+/// Helper to create test app with `/v1/` versioned routes and legacy
+/// unversioned routes (with deprecation headers). Mirrors `build_router()`
+/// from the production binary.
+pub fn create_versioned_test_app(temp_dir: &TempDir) -> Router {
+    let state = create_app_state(temp_dir);
+    let routes = base_routes();
+
+    // Canonical versioned API under /v1/
+    let versioned = Router::new().nest("/v1", routes.clone());
+
+    // Legacy unversioned routes with deprecation headers
+    let legacy = routes.layer(axum::middleware::from_fn(deprecation_header));
+
+    versioned.merge(legacy).with_state(state)
+}


### PR DESCRIPTION
## Summary
- Routes served under `/v1/` (canonical) and `/` (legacy with deprecation headers)
- `Deprecation: true` + `X-API-Deprecated` headers on legacy routes
- 5 integration tests + 209 server tests pass

## Test plan
- [x] 209 server tests pass

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/541" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
