### PR TITLE
feat(persistence): add schema_version to collection config [WP-2I]

### DIFF
--- a/crates/velesdb-core/src/collection/core/lifecycle_create.rs
+++ b/crates/velesdb-core/src/collection/core/lifecycle_create.rs
@@ -3,7 +3,7 @@
 //! Extracted from `lifecycle.rs` to reduce NLOC below the 500 threshold.
 //! Contains all `create_*` public constructors and their shared helpers.
 
-use crate::collection::types::{Collection, CollectionConfig};
+use crate::collection::types::{Collection, CollectionConfig, CURRENT_SCHEMA_VERSION};
 use crate::distance::DistanceMetric;
 use crate::error::Result;
 use crate::quantization::StorageMode;
@@ -75,6 +75,7 @@ impl Collection {
             dimension,
             metric,
             point_count: 0,
+            schema_version: CURRENT_SCHEMA_VERSION,
             storage_mode,
             metadata_only: false,
             graph_schema: None,
@@ -109,6 +110,7 @@ impl Collection {
             dimension,
             metric,
             point_count: 0,
+            schema_version: CURRENT_SCHEMA_VERSION,
             storage_mode,
             metadata_only: false,
             graph_schema: None,
@@ -141,6 +143,7 @@ impl Collection {
             dimension,
             metric,
             point_count: 0,
+            schema_version: CURRENT_SCHEMA_VERSION,
             storage_mode: StorageMode::Full,
             metadata_only: false,
             graph_schema: None,
@@ -169,6 +172,7 @@ impl Collection {
             dimension: 0,
             metric: DistanceMetric::Cosine,
             point_count: 0,
+            schema_version: CURRENT_SCHEMA_VERSION,
             storage_mode: StorageMode::Full,
             metadata_only: true,
             graph_schema: None,
@@ -201,6 +205,7 @@ impl Collection {
             dimension: embedding_dim.unwrap_or(0),
             metric,
             point_count: 0,
+            schema_version: CURRENT_SCHEMA_VERSION,
             storage_mode: StorageMode::Full,
             metadata_only: false,
             graph_schema: Some(schema),

--- a/crates/velesdb-core/src/collection/core/lifecycle_tests.rs
+++ b/crates/velesdb-core/src/collection/core/lifecycle_tests.rs
@@ -451,3 +451,130 @@ fn test_open_without_edge_store_bin_recovers_gracefully() {
         "edge_store.bin should be re-created after flush"
     );
 }
+
+// ── WP-2I: Schema version tests ────────────────────────────────────
+
+/// New collections must have `schema_version == CURRENT_SCHEMA_VERSION`.
+#[test]
+fn test_schema_version_set_on_new_collection() {
+    use crate::collection::types::CURRENT_SCHEMA_VERSION;
+
+    let temp_dir = tempfile::tempdir().expect("temp dir should be created");
+    let collection = Collection::create(PathBuf::from(temp_dir.path()), 4, DistanceMetric::Cosine)
+        .expect("collection should be created");
+
+    let cfg = collection.config();
+    assert_eq!(
+        cfg.schema_version, CURRENT_SCHEMA_VERSION,
+        "new collection must carry the current schema version"
+    );
+}
+
+/// `schema_version` must survive a config.json round-trip.
+#[test]
+fn test_schema_version_persisted_in_config_json() {
+    use crate::collection::types::CURRENT_SCHEMA_VERSION;
+
+    let temp_dir = tempfile::tempdir().expect("temp dir should be created");
+    let _collection = Collection::create(PathBuf::from(temp_dir.path()), 4, DistanceMetric::Cosine)
+        .expect("collection should be created");
+
+    let raw = std::fs::read_to_string(temp_dir.path().join("config.json"))
+        .expect("config.json should exist");
+    let deserialized: CollectionConfig =
+        serde_json::from_str(&raw).expect("config.json should deserialize");
+    assert_eq!(deserialized.schema_version, CURRENT_SCHEMA_VERSION);
+}
+
+/// Old config.json files without `schema_version` must deserialize to 1.
+#[test]
+fn test_schema_version_defaults_to_1_for_legacy_config() {
+    let json = r#"{
+        "name": "legacy_no_version",
+        "dimension": 128,
+        "metric": "Cosine",
+        "point_count": 0,
+        "storage_mode": "full",
+        "metadata_only": false
+    }"#;
+
+    let cfg: CollectionConfig =
+        serde_json::from_str(json).expect("legacy config should deserialize");
+    assert_eq!(
+        cfg.schema_version, 1,
+        "missing schema_version must default to 1"
+    );
+}
+
+/// Opening a collection with a future schema version must return VELES-036.
+#[test]
+fn test_open_rejects_future_schema_version() {
+    let temp_dir = tempfile::tempdir().expect("temp dir should be created");
+
+    // 1. Create a valid collection so that storage files exist
+    let collection = Collection::create(PathBuf::from(temp_dir.path()), 4, DistanceMetric::Cosine)
+        .expect("collection should be created");
+    collection.flush().expect("flush should succeed");
+    drop(collection);
+
+    // 2. Tamper with config.json: set schema_version to 999
+    let config_path = temp_dir.path().join("config.json");
+    let raw = std::fs::read_to_string(&config_path).expect("read config");
+    let mut cfg: serde_json::Value = serde_json::from_str(&raw).expect("parse config");
+    cfg["schema_version"] = serde_json::Value::from(999);
+    std::fs::write(
+        &config_path,
+        serde_json::to_string_pretty(&cfg).expect("serialize"),
+    )
+    .expect("write tampered config");
+
+    // 3. Attempt to open — must fail with VELES-036
+    let result = Collection::open(PathBuf::from(temp_dir.path()));
+    let err = expect_err(result);
+    assert_eq!(err.code(), "VELES-036");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("999"),
+        "error must mention the found version: {msg}"
+    );
+}
+
+/// `schema_version == 0` must be treated as v1 (silent migration).
+#[test]
+fn test_schema_version_zero_treated_as_v1() {
+    let temp_dir = tempfile::tempdir().expect("temp dir should be created");
+
+    // Create a valid collection
+    let collection = Collection::create(PathBuf::from(temp_dir.path()), 4, DistanceMetric::Cosine)
+        .expect("collection should be created");
+    collection.flush().expect("flush should succeed");
+    drop(collection);
+
+    // Set schema_version to 0 in config.json
+    let config_path = temp_dir.path().join("config.json");
+    let raw = std::fs::read_to_string(&config_path).expect("read config");
+    let mut cfg: serde_json::Value = serde_json::from_str(&raw).expect("parse config");
+    cfg["schema_version"] = serde_json::Value::from(0);
+    std::fs::write(
+        &config_path,
+        serde_json::to_string_pretty(&cfg).expect("serialize"),
+    )
+    .expect("write config with version 0");
+
+    // Opening must succeed (0 is treated as v1)
+    let _reopened = Collection::open(PathBuf::from(temp_dir.path()))
+        .expect("collection with schema_version=0 should open");
+}
+
+/// `IncompatibleSchemaVersion` is not recoverable.
+#[test]
+fn test_incompatible_schema_version_is_not_recoverable() {
+    let err = crate::Error::IncompatibleSchemaVersion {
+        found: 99,
+        supported: 1,
+    };
+    assert!(
+        !err.is_recoverable(),
+        "IncompatibleSchemaVersion must not be recoverable"
+    );
+}

--- a/crates/velesdb-core/src/collection/core/recovery.rs
+++ b/crates/velesdb-core/src/collection/core/recovery.rs
@@ -128,7 +128,30 @@ use crate::storage::LogPayloadStorage;
 pub(super) fn load_config(path: &std::path::Path) -> Result<CollectionConfig> {
     let config_path = path.join("config.json");
     let config_data = std::fs::read_to_string(&config_path)?;
-    serde_json::from_str(&config_data).map_err(|e| Error::Serialization(e.to_string()))
+    let config: CollectionConfig =
+        serde_json::from_str(&config_data).map_err(|e| Error::Serialization(e.to_string()))?;
+    validate_schema_version(&config)?;
+    Ok(config)
+}
+
+/// Rejects collections written by a newer VelesDB with a higher schema
+/// version. Treats `schema_version == 0` as v1 (silent migration of
+/// pre-versioned collections).
+fn validate_schema_version(config: &CollectionConfig) -> Result<()> {
+    use crate::collection::types::CURRENT_SCHEMA_VERSION;
+
+    let version = if config.schema_version == 0 {
+        1
+    } else {
+        config.schema_version
+    };
+    if version > CURRENT_SCHEMA_VERSION {
+        return Err(Error::IncompatibleSchemaVersion {
+            found: version,
+            supported: CURRENT_SCHEMA_VERSION,
+        });
+    }
+    Ok(())
 }
 
 /// Reconciles `point_count` from the actual storage (config.json may be

--- a/crates/velesdb-core/src/collection/types.rs
+++ b/crates/velesdb-core/src/collection/types.rs
@@ -122,6 +122,21 @@ impl CollectionType {
     }
 }
 
+/// Current on-disk schema version for `config.json`.
+///
+/// Increment this constant when the persisted format changes in a way that
+/// older VelesDB versions cannot safely read. The `Collection::open()` path
+/// rejects any `schema_version > CURRENT_SCHEMA_VERSION` with a clear error.
+pub const CURRENT_SCHEMA_VERSION: u32 = 1;
+
+/// Returns the default schema version for backward-compatible deserialization.
+///
+/// Old `config.json` files written before schema versioning was introduced
+/// will deserialize with this default, which is equivalent to version 1.
+fn default_schema_version() -> u32 {
+    1
+}
+
 /// Metadata for a collection.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CollectionConfig {
@@ -136,6 +151,17 @@ pub struct CollectionConfig {
 
     /// Number of points in the collection.
     pub point_count: usize,
+
+    /// On-disk schema version for forward-compatibility detection.
+    ///
+    /// When a newer VelesDB version writes a `config.json` with a higher
+    /// schema version, older versions will refuse to open the collection
+    /// rather than silently corrupting data.
+    ///
+    /// Backward compatible: old `config.json` files without this field
+    /// deserialize to `1` (the initial version).
+    #[serde(default = "default_schema_version")]
+    pub schema_version: u32,
 
     /// Storage mode for vectors (Full, SQ8, Binary).
     #[serde(default)]
@@ -466,6 +492,7 @@ mod rescore_config_tests {
             dimension: 128,
             metric: DistanceMetric::Euclidean,
             point_count: 0,
+            schema_version: CURRENT_SCHEMA_VERSION,
             storage_mode: StorageMode::ProductQuantization,
             metadata_only: false,
             graph_schema: None,

--- a/crates/velesdb-core/src/error.rs
+++ b/crates/velesdb-core/src/error.rs
@@ -206,6 +206,21 @@ pub enum Error {
     /// (e.g., allocation failure during rebuild).
     #[error("[VELES-035] Snapshot build failed: {0}")]
     SnapshotBuildFailed(String),
+
+    /// Incompatible schema version (VELES-036).
+    ///
+    /// The collection was created with a newer `VelesDB` version that uses a
+    /// schema format this version cannot read. Upgrade `VelesDB` to open it.
+    #[error(
+        "[VELES-036] Collection created with newer schema version (v{found}), \
+         current VelesDB supports up to v{supported}"
+    )]
+    IncompatibleSchemaVersion {
+        /// The schema version found in `config.json`.
+        found: u32,
+        /// The maximum schema version this binary supports.
+        supported: u32,
+    },
 }
 
 impl Error {
@@ -248,6 +263,7 @@ impl Error {
             Self::AllocationFailed(_) => "VELES-033",
             Self::InvalidCollectionName { .. } => "VELES-034",
             Self::SnapshotBuildFailed(_) => "VELES-035",
+            Self::IncompatibleSchemaVersion { .. } => "VELES-036",
         }
     }
 
@@ -262,6 +278,7 @@ impl Error {
                 | Self::Internal(_)
                 | Self::EpochMismatch(_)
                 | Self::AllocationFailed(_)
+                | Self::IncompatibleSchemaVersion { .. }
         )
     }
 }

--- a/crates/velesdb-core/src/storage/wal_entry.rs
+++ b/crates/velesdb-core/src/storage/wal_entry.rs
@@ -1,6 +1,16 @@
 //! WAL entry domain type — separates parsing from application.
 //!
 //! Extracted from `log_payload.rs` to reduce NLOC.
+//!
+//! ## WAL versioning (WP-2I)
+//!
+//! The WAL format is implicitly versioned through its marker bytes. Legacy
+//! entries use `LEGACY_STORE_MARKER` / `LEGACY_DELETE_MARKER` (no CRC),
+//! while v2 entries use `CRC_STORE_MARKER` / `CRC_DELETE_MARKER` (with
+//! CRC32 integrity checking). Future format changes should introduce new
+//! marker values, preserving backward-compatible reading of older entries.
+//! No separate schema-version header is needed because the per-entry
+//! marker already encodes the wire format.
 
 use super::log_payload::{
     compute_delete_crc, compute_store_crc, CRC_DELETE_MARKER, CRC_STORE_MARKER,


### PR DESCRIPTION
## Summary
- Added `schema_version: u32` field to `CollectionConfig` with `serde(default)`
- `Collection::open()` rejects future schema versions (error VELES-036)
- Backward compat: v0 treated as v1
- 6 tests added

## Test plan
- [x] 4452 tests pass

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/542" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
