### PR TITLE
docs(api): clarify per-node stats are estimated, not measured [Devin review]

### DIFF
--- a/crates/velesdb-core/src/api_types/responses.rs
+++ b/crates/velesdb-core/src/api_types/responses.rs
@@ -317,19 +317,26 @@ impl From<&crate::velesql::ActualStats> for ActualStatsResponse {
     }
 }
 
-/// Per-plan-node actual execution statistics for EXPLAIN ANALYZE responses.
+/// Per-plan-node **estimated** execution statistics for EXPLAIN ANALYZE responses.
+///
+/// All values are synthetic heuristics derived from the plan-global
+/// `actual_time_ms` — they are **not** individually measured per node.
+/// Field names keep the `actual_` prefix for API stability; check the
+/// `estimated` flag to distinguish heuristic values from future
+/// instrumented measurements (#467).
 #[derive(Debug, Serialize)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 pub struct NodeStatsResponse {
     /// Node label (e.g. `VectorSearch`, `Filter`, `Limit`).
     pub node_label: String,
-    /// Heuristic estimate of wall-clock time for this node in milliseconds.
-    /// Derived from total execution time using fixed fractions, not real
-    /// per-node instrumentation. Will be replaced by measured timing (#467).
+    /// Estimated wall-clock time for this node in milliseconds.
+    /// Derived from total execution time using normalized weight fractions,
+    /// not real per-node instrumentation. Will be replaced by measured
+    /// timing (#467).
     pub actual_time_ms: f64,
-    /// Rows entering this node (heuristic approximation).
+    /// Estimated rows entering this node (heuristic approximation).
     pub actual_rows_in: u64,
-    /// Rows leaving this node (heuristic approximation).
+    /// Estimated rows leaving this node (heuristic approximation).
     pub actual_rows_out: u64,
     /// Number of loop iterations (1 for non-looping nodes).
     pub loops: u64,

--- a/crates/velesdb-core/src/velesql/explain.rs
+++ b/crates/velesdb-core/src/velesql/explain.rs
@@ -259,19 +259,30 @@ pub struct ActualStats {
     pub edges_traversed: u64,
 }
 
-/// Per-plan-node actual execution statistics.
+/// Per-plan-node **estimated** execution statistics.
+///
+/// All values in this struct are synthetic heuristics derived from the
+/// plan-global `ActualStats::actual_time_ms` using fixed weight fractions
+/// — they are **not** individually measured per node.  The `estimated`
+/// field is always `true` until real per-node instrumentation lands
+/// (#467–#469).
+///
+/// Field names use the `actual_` prefix for forward-compatibility with
+/// the future instrumented variant; the `estimated` flag distinguishes
+/// the two modes at runtime.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct NodeStats {
     /// Node label (e.g. "VectorSearch", "Filter", "Limit").
     pub node_label: String,
-    /// Heuristic estimate of wall-clock time for this node in milliseconds.
+    /// Estimated wall-clock time for this node in milliseconds.
     /// Derived by distributing the total `actual_time_ms` across nodes using
-    /// fixed fractions — NOT a real per-node measurement. Foundational for the
-    /// CBO feedback loop; will be replaced by instrumented timing (#467–#469).
+    /// normalized weight fractions — NOT a real per-node measurement.
+    /// Foundational for the CBO feedback loop; will be replaced by
+    /// instrumented timing (#467–#469).
     pub actual_time_ms: f64,
-    /// Rows entering this node (heuristic: set to top-level actual_rows).
+    /// Estimated rows entering this node (heuristic approximation).
     pub actual_rows_in: u64,
-    /// Rows leaving this node (heuristic: set to top-level actual_rows).
+    /// Estimated rows leaving this node (heuristic approximation).
     pub actual_rows_out: u64,
     /// Number of loop iterations (1 for non-looping nodes).
     pub loops: u64,

--- a/crates/velesdb-core/src/velesql/explain/formatter.rs
+++ b/crates/velesdb-core/src/velesql/explain/formatter.rs
@@ -242,8 +242,9 @@ impl fmt::Display for QueryPlan {
 /// Formats a `WithValue` for human-readable EXPLAIN display.
 pub(super) fn format_with_value(v: &super::super::ast::WithValue) -> String {
     match v {
-        super::super::ast::WithValue::String(s)
-        | super::super::ast::WithValue::Identifier(s) => s.clone(),
+        super::super::ast::WithValue::String(s) | super::super::ast::WithValue::Identifier(s) => {
+            s.clone()
+        }
         super::super::ast::WithValue::Integer(i) => i.to_string(),
         super::super::ast::WithValue::Float(f) => f.to_string(),
         super::super::ast::WithValue::Boolean(b) => b.to_string(),

--- a/crates/velesdb-core/src/velesql/explain/node_stats.rs
+++ b/crates/velesdb-core/src/velesql/explain/node_stats.rs
@@ -18,9 +18,7 @@ pub(super) fn estimate_cost(root: &PlanNode, has_vector_search: bool) -> f64 {
     let base_cost = if has_vector_search { 0.05 } else { 1.0 };
 
     match root {
-        PlanNode::Sequence(nodes) => nodes
-            .iter()
-            .fold(base_cost, |acc, n| acc + node_cost(n)),
+        PlanNode::Sequence(nodes) => nodes.iter().fold(base_cost, |acc, n| acc + node_cost(n)),
         _ => base_cost + node_cost(root),
     }
 }

--- a/crates/velesdb-python/python/velesdb/__init__.pyi
+++ b/crates/velesdb-python/python/velesdb/__init__.pyi
@@ -413,8 +413,10 @@ class Collection:
                 - ``actual_stats`` (dict or None): Execution statistics with
                   ``actual_rows``, ``actual_time_ms``, ``loops``,
                   ``nodes_visited``, ``edges_traversed``.
-                - ``node_stats`` (list[dict] or None): Per-node statistics
-                  with ``node_label``, ``actual_time_ms``, ``actual_rows``.
+                - ``node_stats`` (list[dict] or None): Per-node **estimated**
+                  statistics (heuristic, not measured) with ``node_label``,
+                  ``actual_time_ms``, ``actual_rows``. Check ``estimated``
+                  flag to distinguish heuristic values from future measured ones.
 
         Raises:
             RuntimeError: If the query is invalid or execution fails.
@@ -1019,8 +1021,10 @@ class PyGraphCollection:
                 - ``actual_stats`` (dict or None): Execution statistics with
                   ``actual_rows``, ``actual_time_ms``, ``loops``,
                   ``nodes_visited``, ``edges_traversed``.
-                - ``node_stats`` (list[dict] or None): Per-node statistics
-                  with ``node_label``, ``actual_time_ms``, ``actual_rows``.
+                - ``node_stats`` (list[dict] or None): Per-node **estimated**
+                  statistics (heuristic, not measured) with ``node_label``,
+                  ``actual_time_ms``, ``actual_rows``. Check ``estimated``
+                  flag to distinguish heuristic values from future measured ones.
 
         Raises:
             RuntimeError: If the query is invalid or execution fails.

--- a/crates/velesdb-python/src/collection/query.rs
+++ b/crates/velesdb-python/src/collection/query.rs
@@ -82,8 +82,9 @@ pub(crate) fn build_explain_dict(
 ///
 /// Returns a Python dict with keys: `plan`, `actual_stats`, `node_stats`.
 /// The `plan` sub-dict mirrors `build_explain_dict` output.
-/// `actual_stats` is a dict with actual execution metrics (or `None`).
-/// `node_stats` is a list of per-node statistic dicts.
+/// `actual_stats` is a dict with measured execution metrics (or `None`).
+/// `node_stats` is a list of per-node **estimated** statistic dicts
+/// (heuristic values derived from `actual_stats`, not individually measured).
 pub(crate) fn build_explain_analyze_dict(
     py: Python<'_>,
     output: &velesdb_core::velesql::ExplainOutput,

--- a/sdks/typescript/src/types.ts
+++ b/sdks/typescript/src/types.ts
@@ -373,13 +373,25 @@ export interface ActualStats {
   edgesTraversed: number;
 }
 
-/** Per-node execution statistics from EXPLAIN ANALYZE. */
+/**
+ * Per-node **estimated** execution statistics from EXPLAIN ANALYZE.
+ *
+ * All values are synthetic heuristics derived from the plan-global
+ * `actualTimeMs` — they are NOT individually measured per node.
+ * Field names keep the `actual` prefix for API stability; check
+ * the `estimated` flag to distinguish heuristic values from future
+ * instrumented measurements.
+ */
 export interface NodeStats {
   nodeLabel: string;
+  /** Estimated wall-clock time for this node (ms). */
   actualTimeMs: number;
+  /** Estimated rows entering this node. */
   actualRowsIn: number;
+  /** Estimated rows leaving this node. */
   actualRowsOut: number;
   loops: number;
+  /** When true, all values are heuristic estimates, not measured. */
   estimated: boolean;
 }
 


### PR DESCRIPTION
## Summary
- Harmonized wording across 7 files: per-node stats described as "estimated" (not "actual")
- Plan-global `ActualStats` (truly measured) left unchanged
- No field name changes (API stability preserved)
- Covers: core explain.rs, responses.rs, TS SDK types.ts, Python stubs, PyO3 bindings

## Devin finding
PRs #520/#522 flagged inconsistency between "Actual wall-clock time" (responses.rs) and "Estimated wall-clock time" (explain.rs)

## Test plan
- [x] `cargo check --workspace` passes
- [x] Documentation-only changes

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/544" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
