### PR TITLE
test(python): add DataFrame schema consistency regression tests [Devin review]

### DIFF
--- a/crates/velesdb-python/tests/test_dataframe_converter.py
+++ b/crates/velesdb-python/tests/test_dataframe_converter.py
@@ -302,6 +302,31 @@ class TestScrollDataframeMixedBatch:
         assert df["vector"].iloc[0] == [1.0, 2.0]
         assert df["vector"].iloc[1] == [3.0, 4.0]
 
+    def test_all_non_dict_payloads_use_payload_column(self, pd):
+        """Non-None, non-dict payloads (e.g. strings) are stored under 'payload'."""
+        batch = [
+            _make_scroll_point(1, [0.1], payload="label-a"),
+            _make_scroll_point(2, [0.2], payload="label-b"),
+        ]
+        df = to_scroll_dataframe(batch, backend="pandas")
+        assert "payload" in df.columns
+        assert "id" in df.columns
+        assert list(df["payload"]) == ["label-a", "label-b"]
+
+    def test_mixed_dict_and_non_dict_non_none_payloads_use_flattening(self, pd):
+        """Mixed batch with dict + string: dict keys become columns, string rows are null."""
+        batch = [
+            _make_scroll_point(1, [0.1], payload={"category": "sport"}),
+            _make_scroll_point(2, [0.2], payload="raw-string"),
+        ]
+        df = to_scroll_dataframe(batch, backend="pandas")
+        # At least one dict payload triggers flattening; string payload is treated
+        # as non-dict and contributes no columns — its 'category' cell is NaN.
+        assert "category" in df.columns
+        assert "payload" not in df.columns
+        assert df["category"].iloc[0] == "sport"
+        assert pd.isna(df["category"].iloc[1])
+
 
 # ---------------------------------------------------------------------------
 # NaN vector guard — _row_to_point and dataframe_to_points (Issue 3)


### PR DESCRIPTION
## Summary
- Added 2 regression tests for DataFrame schema consistency
- `test_all_non_dict_payloads_use_payload_column` — non-dict payloads
- `test_mixed_dict_and_non_dict_non_none_payloads_use_flattening` — mixed batch schema
- 26/26 DataFrame converter tests pass

## Devin finding
PR #522 flagged schema inconsistency risk with mixed dict/None payloads — confirmed already handled, tests lock in the contract

## Test plan
- [x] 26/26 tests pass

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/545" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
