### PR TITLE
fix(ecosystem): propagate FusionStrategy::RelativeScore to mobile, server, tauri

### DIFF
--- a/crates/tauri-plugin-velesdb/guest-js/index.ts
+++ b/crates/tauri-plugin-velesdb/guest-js/index.ts
@@ -170,7 +170,7 @@ export interface BatchSearchRequest {
 }
 
 /** Fusion strategy for multi-query search. */
-export type FusionStrategy = 'rrf' | 'average' | 'maximum' | 'weighted';
+export type FusionStrategy = 'rrf' | 'average' | 'maximum' | 'weighted' | 'relative_score';
 
 /** Fusion parameters for multi-query search. */
 export interface FusionParams {
@@ -182,6 +182,10 @@ export interface FusionParams {
   maxWeight?: number;
   /** Weighted fusion: hit weight (default: 0.1). */
   hitWeight?: number;
+  /** Relative score fusion: dense branch weight (default: 0.5). */
+  denseWeight?: number;
+  /** Relative score fusion: sparse branch weight (default: 0.5). */
+  sparseWeight?: number;
 }
 
 /** Request for multi-query fusion search. */
@@ -192,7 +196,7 @@ export interface MultiQuerySearchRequest {
   vectors: number[][];
   /** Number of results to return. Default: 10. */
   topK?: number;
-  /** Fusion strategy: 'rrf', 'average', 'maximum', 'weighted'. Default: 'rrf'. */
+  /** Fusion strategy: 'rrf', 'average', 'maximum', 'weighted', 'relative_score'. Default: 'rrf'. */
   fusion?: FusionStrategy;
   /** Fusion parameters. */
   fusionParams?: FusionParams;

--- a/crates/tauri-plugin-velesdb/src/helpers.rs
+++ b/crates/tauri-plugin-velesdb/src/helpers.rs
@@ -41,10 +41,25 @@ pub fn storage_mode_to_string(mode: velesdb_core::StorageMode) -> &'static str {
     mode.canonical_name()
 }
 
+/// Extracts a named f64 param from JSON, accepting both `camelCase` and `snake_case` keys.
+#[allow(clippy::cast_possible_truncation)]
+// Reason: JSON f64 → f32 for weights; values are small config numbers (0.0-1.0).
+fn extract_weight(
+    params: Option<&serde_json::Value>,
+    camel: &str,
+    snake: &str,
+    default: f64,
+) -> f32 {
+    params
+        .and_then(|p| p.get(camel).or_else(|| p.get(snake)))
+        .and_then(serde_json::Value::as_f64)
+        .unwrap_or(default) as f32
+}
+
 /// Parses fusion strategy from string and optional params.
 #[must_use]
-// Reason: JSON f64 → f32 for weights, u64 → u32 for k; values are small config numbers.
 #[allow(clippy::cast_possible_truncation)]
+// Reason: JSON u64 → u32 for k; value is a small config number (typically 60).
 pub fn parse_fusion_strategy(
     fusion: &str,
     params: Option<&serde_json::Value>,
@@ -60,25 +75,15 @@ pub fn parse_fusion_strategy(
         }
         "average" => FusionStrategy::Average,
         "maximum" => FusionStrategy::Maximum,
-        "weighted" => {
-            let avg_weight = params
-                .and_then(|p| p.get("avgWeight").or_else(|| p.get("avg_weight")))
-                .and_then(serde_json::Value::as_f64)
-                .unwrap_or(0.6) as f32;
-            let max_weight = params
-                .and_then(|p| p.get("maxWeight").or_else(|| p.get("max_weight")))
-                .and_then(serde_json::Value::as_f64)
-                .unwrap_or(0.3) as f32;
-            let hit_weight = params
-                .and_then(|p| p.get("hitWeight").or_else(|| p.get("hit_weight")))
-                .and_then(serde_json::Value::as_f64)
-                .unwrap_or(0.1) as f32;
-            FusionStrategy::Weighted {
-                avg_weight,
-                max_weight,
-                hit_weight,
-            }
-        }
+        "weighted" => FusionStrategy::Weighted {
+            avg_weight: extract_weight(params, "avgWeight", "avg_weight", 0.6),
+            max_weight: extract_weight(params, "maxWeight", "max_weight", 0.3),
+            hit_weight: extract_weight(params, "hitWeight", "hit_weight", 0.1),
+        },
+        "relative_score" | "rsf" => FusionStrategy::RelativeScore {
+            dense_weight: extract_weight(params, "denseWeight", "dense_weight", 0.5),
+            sparse_weight: extract_weight(params, "sparseWeight", "sparse_weight", 0.5),
+        },
         unknown => {
             tracing::warn!(
                 strategy = unknown,

--- a/crates/velesdb-core/src/api_types/mod.rs
+++ b/crates/velesdb-core/src/api_types/mod.rs
@@ -80,6 +80,18 @@ pub const fn default_hit_weight() -> f32 {
     0.2
 }
 
+/// Default dense weight for relative score fusion.
+#[must_use]
+pub const fn default_dense_weight() -> f32 {
+    0.5
+}
+
+/// Default sparse weight for relative score fusion.
+#[must_use]
+pub const fn default_sparse_weight() -> f32 {
+    0.5
+}
+
 /// Default index type: hash.
 #[must_use]
 pub fn default_index_type() -> String {

--- a/crates/velesdb-core/src/api_types/requests.rs
+++ b/crates/velesdb-core/src/api_types/requests.rs
@@ -8,9 +8,9 @@ use serde::Deserialize;
 use utoipa::ToSchema;
 
 use super::{
-    default_avg_weight, default_collection_type, default_fusion_strategy, default_hit_weight,
-    default_index_type, default_max_weight, default_metric, default_rrf_k, default_storage_mode,
-    default_top_k, default_vector_weight, serde_id,
+    default_avg_weight, default_collection_type, default_dense_weight, default_fusion_strategy,
+    default_hit_weight, default_index_type, default_max_weight, default_metric, default_rrf_k,
+    default_sparse_weight, default_storage_mode, default_top_k, default_vector_weight, serde_id,
 };
 
 // ============================================================================
@@ -289,7 +289,7 @@ pub struct MultiQuerySearchRequest {
     #[serde(default = "default_top_k")]
     #[cfg_attr(feature = "openapi", schema(example = 10))]
     pub top_k: usize,
-    /// Fusion strategy: "average", "maximum", "rrf", "weighted".
+    /// Fusion strategy: "average", "maximum", "rrf", "weighted", "relative_score".
     #[serde(default = "default_fusion_strategy")]
     #[cfg_attr(feature = "openapi", schema(example = "rrf"))]
     pub strategy: String,
@@ -309,6 +309,14 @@ pub struct MultiQuerySearchRequest {
     #[serde(default = "default_hit_weight")]
     #[cfg_attr(feature = "openapi", schema(example = 0.2))]
     pub hit_weight: f32,
+    /// Relative score fusion: weight for the dense (vector) branch.
+    #[serde(default = "default_dense_weight")]
+    #[cfg_attr(feature = "openapi", schema(example = 0.5))]
+    pub dense_weight: f32,
+    /// Relative score fusion: weight for the sparse branch.
+    #[serde(default = "default_sparse_weight")]
+    #[cfg_attr(feature = "openapi", schema(example = 0.5))]
+    pub sparse_weight: f32,
     /// Optional metadata filter.
     #[serde(default)]
     pub filter: Option<serde_json::Value>,

--- a/crates/velesdb-mobile/src/types.rs
+++ b/crates/velesdb-mobile/src/types.rs
@@ -128,6 +128,13 @@ pub enum FusionStrategy {
         /// Weight for hit ratio (0.0-1.0).
         hit_weight: f32,
     },
+    /// Relative Score Fusion for dense + sparse hybrid search.
+    RelativeScore {
+        /// Weight for the dense (vector) branch (0.0-1.0).
+        dense_weight: f32,
+        /// Weight for the sparse branch (0.0-1.0).
+        sparse_weight: f32,
+    },
 }
 
 impl From<FusionStrategy> for CoreFusionStrategy {
@@ -144,6 +151,13 @@ impl From<FusionStrategy> for CoreFusionStrategy {
                 avg_weight,
                 max_weight,
                 hit_weight,
+            },
+            FusionStrategy::RelativeScore {
+                dense_weight,
+                sparse_weight,
+            } => CoreFusionStrategy::RelativeScore {
+                dense_weight,
+                sparse_weight,
             },
         }
     }

--- a/crates/velesdb-server/src/handlers/search/multi.rs
+++ b/crates/velesdb-server/src/handlers/search/multi.rs
@@ -57,12 +57,17 @@ pub async fn multi_query_search(
             max_weight: req.max_weight,
             hit_weight: req.hit_weight,
         },
+        "relative_score" | "rsf" => FusionStrategy::RelativeScore {
+            dense_weight: req.dense_weight,
+            sparse_weight: req.sparse_weight,
+        },
         _ => {
             return (
                 StatusCode::BAD_REQUEST,
                 Json(ErrorResponse {
                     error: format!(
-                        "Invalid strategy: {}. Valid: average, maximum, rrf, weighted",
+                        "Invalid strategy: {}. Valid: average, maximum, rrf, weighted, \
+                         relative_score",
                         req.strategy
                     ),
                     code: None,

--- a/crates/velesdb-server/tests/api_versioning_tests.rs
+++ b/crates/velesdb-server/tests/api_versioning_tests.rs
@@ -161,8 +161,7 @@ async fn v1_and_legacy_health_return_same_body() {
     let body_legacy = axum::body::to_bytes(resp_legacy.into_body(), usize::MAX)
         .await
         .expect("test: read body");
-    let json_legacy: Value =
-        serde_json::from_slice(&body_legacy).expect("test: parse JSON");
+    let json_legacy: Value = serde_json::from_slice(&body_legacy).expect("test: parse JSON");
 
     assert_eq!(
         json_v1["status"], json_legacy["status"],

--- a/crates/velesdb-server/tests/common/mod.rs
+++ b/crates/velesdb-server/tests/common/mod.rs
@@ -101,10 +101,15 @@ async fn deprecation_header(
 ) -> axum::response::Response {
     let mut response = next.run(request).await;
     let headers = response.headers_mut();
-    headers.insert("deprecation", "true".parse().expect("test: static header value"));
+    headers.insert(
+        "deprecation",
+        "true".parse().expect("test: static header value"),
+    );
     headers.insert(
         "x-api-deprecated",
-        "Use /v1/ prefix".parse().expect("test: static header value"),
+        "Use /v1/ prefix"
+            .parse()
+            .expect("test: static header value"),
     );
     response
 }


### PR DESCRIPTION
## Summary
- Added `RelativeScore` variant to mobile `FusionStrategy` enum + `From` impl
- Added `"relative_score"/"rsf"` match arm in server `multi_query_search()`
- Added parsing in tauri `parse_fusion_strategy()` + guest-js type union
- Added `dense_weight`/`sparse_weight` fields to `MultiQuerySearchRequest`

## Severity: CRITICAL — missing variant causes error/crash

## Test plan
- [x] `cargo check --workspace --exclude velesdb-python`
- [x] `cargo clippy` clean on all 3 crates

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/546" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
