### PR TITLE
fix(quality): resolve clippy pedantic errors — split long functions + fix docs

### DIFF
--- a/crates/velesdb-core/src/collection/search/query/mod.rs
+++ b/crates/velesdb-core/src/collection/search/query/mod.rs
@@ -525,6 +525,7 @@ impl Collection {
     ///
     /// Extracts aggregation functions from the SELECT columns and delegates
     /// to [`vector_group_by::group_search_results`].
+    #[allow(clippy::unused_self)] // Instance method for consistency with other query pipeline stages.
     fn apply_vector_group_by(
         &self,
         stmt: &crate::velesql::SelectStatement,

--- a/crates/velesdb-core/src/collection/search/query/vector_group_by.rs
+++ b/crates/velesdb-core/src/collection/search/query/vector_group_by.rs
@@ -138,16 +138,14 @@ pub(crate) fn group_search_results(
 
     // Single-pass accumulation.
     for (idx, result) in results.iter().enumerate() {
-        let key = match extract_group_key(result.point.payload.as_ref(), config.group_by_columns) {
-            Some(k) => k,
-            None => {
-                tracing::debug!(
-                    id = result.point.id,
-                    fields = ?config.group_by_columns,
-                    "Skipping chunk: missing group-by field"
-                );
-                continue;
-            }
+        let Some(key) = extract_group_key(result.point.payload.as_ref(), config.group_by_columns)
+        else {
+            tracing::debug!(
+                id = result.point.id,
+                fields = ?config.group_by_columns,
+                "Skipping chunk: missing group-by field"
+            );
+            continue;
         };
         groups
             .entry(key)

--- a/crates/velesdb-core/src/database/query_engine.rs
+++ b/crates/velesdb-core/src/database/query_engine.rs
@@ -519,7 +519,7 @@ impl Database {
     /// Orchestrates filter pushdown and join strategy selection:
     /// 1. Analyze WHERE for pushdown-eligible conditions
     /// 2. Strip pushed conditions from base query
-    /// 3. For each JOIN: lookup, filtered, or full ColumnStore path
+    /// 3. For each JOIN: lookup, filtered, or full `ColumnStore` path
     fn execute_single_select(
         &self,
         query: &crate::velesql::Query,

--- a/crates/velesdb-core/src/filter/conversion.rs
+++ b/crates/velesdb-core/src/filter/conversion.rs
@@ -68,25 +68,78 @@ fn convert_comparison(
     }
 }
 
+/// Converts an IN condition, optionally negated via NOT.
+fn convert_in(inc: crate::velesql::InCondition) -> Condition {
+    let in_cond = Condition::In {
+        field: inc.column,
+        values: inc.values.into_iter().map(velesql_value_to_json).collect(),
+    };
+    if inc.negated {
+        Condition::Not {
+            condition: Box::new(in_cond),
+        }
+    } else {
+        in_cond
+    }
+}
+
+/// Converts a BETWEEN condition into `Gte AND Lte`.
+fn convert_between(btw: crate::velesql::BetweenCondition) -> Condition {
+    Condition::And {
+        conditions: vec![
+            Condition::Gte {
+                field: btw.column.clone(),
+                value: velesql_numeric_to_json(&btw.low),
+            },
+            Condition::Lte {
+                field: btw.column,
+                value: velesql_numeric_to_json(&btw.high),
+            },
+        ],
+    }
+}
+
+/// Converts a LIKE/ILIKE condition based on case-sensitivity.
+fn convert_like(lk: crate::velesql::LikeCondition) -> Condition {
+    if lk.case_insensitive {
+        Condition::ILike {
+            field: lk.column,
+            pattern: lk.pattern,
+        }
+    } else {
+        Condition::Like {
+            field: lk.column,
+            pattern: lk.pattern,
+        }
+    }
+}
+
+/// Converts CONTAINS (single/any/all) array conditions.
+fn convert_contains(cc: crate::velesql::ContainsCondition) -> Condition {
+    let json_values: Vec<Value> = cc.values.into_iter().map(velesql_value_to_json).collect();
+    match cc.mode {
+        crate::velesql::ContainsMode::Single => Condition::ArrayContains {
+            field: cc.column,
+            value: json_values.into_iter().next().unwrap_or(Value::Null),
+        },
+        crate::velesql::ContainsMode::Any => Condition::ArrayContainsAny {
+            field: cc.column,
+            values: json_values,
+        },
+        crate::velesql::ContainsMode::All => Condition::ArrayContainsAll {
+            field: cc.column,
+            values: json_values,
+        },
+    }
+}
+
 impl From<crate::velesql::Condition> for Condition {
     fn from(cond: crate::velesql::Condition) -> Self {
         match cond {
             crate::velesql::Condition::Comparison(cmp) => {
                 convert_comparison(cmp.column, cmp.operator, cmp.value)
             }
-            crate::velesql::Condition::In(inc) => {
-                let in_cond = Self::In {
-                    field: inc.column,
-                    values: inc.values.into_iter().map(velesql_value_to_json).collect(),
-                };
-                if inc.negated {
-                    Self::Not {
-                        condition: Box::new(in_cond),
-                    }
-                } else {
-                    in_cond
-                }
-            }
+            crate::velesql::Condition::In(inc) => convert_in(inc),
             crate::velesql::Condition::IsNull(isn) => {
                 if isn.is_null {
                     Self::IsNull { field: isn.column }
@@ -117,49 +170,9 @@ impl From<crate::velesql::Condition> for Condition {
                 field: ct.column,
                 value: ct.query,
             },
-            crate::velesql::Condition::Between(btw) => Self::And {
-                conditions: vec![
-                    Self::Gte {
-                        field: btw.column.clone(),
-                        value: velesql_numeric_to_json(&btw.low),
-                    },
-                    Self::Lte {
-                        field: btw.column,
-                        value: velesql_numeric_to_json(&btw.high),
-                    },
-                ],
-            },
-            crate::velesql::Condition::Like(lk) => {
-                if lk.case_insensitive {
-                    Self::ILike {
-                        field: lk.column,
-                        pattern: lk.pattern,
-                    }
-                } else {
-                    Self::Like {
-                        field: lk.column,
-                        pattern: lk.pattern,
-                    }
-                }
-            }
-            crate::velesql::Condition::Contains(cc) => {
-                let json_values: Vec<Value> =
-                    cc.values.into_iter().map(velesql_value_to_json).collect();
-                match cc.mode {
-                    crate::velesql::ContainsMode::Single => Self::ArrayContains {
-                        field: cc.column,
-                        value: json_values.into_iter().next().unwrap_or(Value::Null),
-                    },
-                    crate::velesql::ContainsMode::Any => Self::ArrayContainsAny {
-                        field: cc.column,
-                        values: json_values,
-                    },
-                    crate::velesql::ContainsMode::All => Self::ArrayContainsAll {
-                        field: cc.column,
-                        values: json_values,
-                    },
-                }
-            }
+            crate::velesql::Condition::Between(btw) => convert_between(btw),
+            crate::velesql::Condition::Like(lk) => convert_like(lk),
+            crate::velesql::Condition::Contains(cc) => convert_contains(cc),
             crate::velesql::Condition::GeoDistance(gd) => Self::GeoDistance {
                 field: gd.column,
                 lat: gd.lat,

--- a/crates/velesdb-core/src/filter/matching.rs
+++ b/crates/velesdb-core/src/filter/matching.rs
@@ -7,6 +7,72 @@ use serde_json::Value;
 const LIKE_MAX_PATTERN_BYTES: usize = 4096;
 const LIKE_MAX_DYN_OPS: usize = 2_000_000;
 
+/// Evaluates array-level conditions (single, any, all).
+fn match_array_condition(payload: &Value, field: &str, values: &[Value], mode: ArrayMode) -> bool {
+    get_field(payload, field).is_some_and(|v| match v {
+        Value::Array(arr) => match mode {
+            ArrayMode::Single => values
+                .first()
+                .is_some_and(|val| arr.iter().any(|e| values_equal(e, val))),
+            ArrayMode::Any => values
+                .iter()
+                .any(|val| arr.iter().any(|e| values_equal(e, val))),
+            ArrayMode::All => values
+                .iter()
+                .all(|val| arr.iter().any(|e| values_equal(e, val))),
+        },
+        _ => false,
+    })
+}
+
+/// Array condition matching mode.
+#[derive(Clone, Copy)]
+enum ArrayMode {
+    Single,
+    Any,
+    All,
+}
+
+/// Evaluates geospatial conditions (distance, bounding box).
+fn match_geo_distance(
+    payload: &Value,
+    field: &str,
+    lat: f64,
+    lng: f64,
+    operator: crate::velesql::CompareOp,
+    threshold: f64,
+) -> bool {
+    get_field(payload, field).is_some_and(|v| {
+        extract_geo_point(v).is_some_and(|(plat, plng)| {
+            let dist = haversine_distance_m(plat, plng, lat, lng);
+            compare_geo_distance(dist, threshold, operator)
+        })
+    })
+}
+
+/// Evaluates a geospatial bounding box check.
+fn match_geo_bbox(
+    payload: &Value,
+    field: &str,
+    lat_min: f64,
+    lng_min: f64,
+    lat_max: f64,
+    lng_max: f64,
+) -> bool {
+    get_field(payload, field).is_some_and(|v| {
+        extract_geo_point(v).is_some_and(|(plat, plng)| {
+            plat >= lat_min && plat <= lat_max && plng >= lng_min && plng <= lng_max
+        })
+    })
+}
+
+/// Extracts `(lat, lng)` from a JSON object with `"lat"` and `"lng"` keys.
+fn extract_geo_point(v: &Value) -> Option<(f64, f64)> {
+    let lat = v.get("lat").and_then(Value::as_f64)?;
+    let lng = v.get("lng").and_then(Value::as_f64)?;
+    Some((lat, lng))
+}
+
 impl Condition {
     /// Evaluates the condition against a payload.
     #[must_use]
@@ -43,27 +109,17 @@ impl Condition {
                 .is_some_and(|v| v.as_str().is_some_and(|s| like_match(s, pattern, false))),
             Self::ILike { field, pattern } => get_field(payload, field)
                 .is_some_and(|v| v.as_str().is_some_and(|s| like_match(s, pattern, true))),
-            Self::ArrayContains { field, value } => {
-                get_field(payload, field).is_some_and(|v| match v {
-                    Value::Array(arr) => arr.iter().any(|e| values_equal(e, value)),
-                    _ => false,
-                })
-            }
+            Self::ArrayContains { field, value } => match_array_condition(
+                payload,
+                field,
+                std::slice::from_ref(value),
+                ArrayMode::Single,
+            ),
             Self::ArrayContainsAny { field, values } => {
-                get_field(payload, field).is_some_and(|v| match v {
-                    Value::Array(arr) => values
-                        .iter()
-                        .any(|val| arr.iter().any(|e| values_equal(e, val))),
-                    _ => false,
-                })
+                match_array_condition(payload, field, values, ArrayMode::Any)
             }
             Self::ArrayContainsAll { field, values } => {
-                get_field(payload, field).is_some_and(|v| match v {
-                    Value::Array(arr) => values
-                        .iter()
-                        .all(|val| arr.iter().any(|e| values_equal(e, val))),
-                    _ => false,
-                })
+                match_array_condition(payload, field, values, ArrayMode::All)
             }
             Self::GeoDistance {
                 field,
@@ -71,33 +127,14 @@ impl Condition {
                 lng,
                 operator,
                 threshold,
-            } => get_field(payload, field).is_some_and(|v| {
-                let point_lat = v.get("lat").and_then(Value::as_f64);
-                let point_lng = v.get("lng").and_then(Value::as_f64);
-                match (point_lat, point_lng) {
-                    (Some(plat), Some(plng)) => {
-                        let dist = haversine_distance_m(plat, plng, *lat, *lng);
-                        compare_geo_distance(dist, *threshold, *operator)
-                    }
-                    _ => false,
-                }
-            }),
+            } => match_geo_distance(payload, field, *lat, *lng, *operator, *threshold),
             Self::GeoBbox {
                 field,
                 lat_min,
                 lng_min,
                 lat_max,
                 lng_max,
-            } => get_field(payload, field).is_some_and(|v| {
-                let point_lat = v.get("lat").and_then(Value::as_f64);
-                let point_lng = v.get("lng").and_then(Value::as_f64);
-                match (point_lat, point_lng) {
-                    (Some(plat), Some(plng)) => {
-                        plat >= *lat_min && plat <= *lat_max && plng >= *lng_min && plng <= *lng_max
-                    }
-                    _ => false,
-                }
-            }),
+            } => match_geo_bbox(payload, field, *lat_min, *lng_min, *lat_max, *lng_max),
         }
     }
 }

--- a/crates/velesdb-core/src/filter/mod.rs
+++ b/crates/velesdb-core/src/filter/mod.rs
@@ -191,7 +191,7 @@ pub enum Condition {
     },
     /// Geospatial distance filter: Haversine distance comparison.
     GeoDistance {
-        /// Field name containing GeoPoint data
+        /// Field name containing `GeoPoint` data
         field: String,
         /// Reference latitude in degrees
         lat: f64,
@@ -204,7 +204,7 @@ pub enum Condition {
     },
     /// Geospatial bounding box filter: coordinate containment check.
     GeoBbox {
-        /// Field name containing GeoPoint data
+        /// Field name containing `GeoPoint` data
         field: String,
         /// Minimum latitude
         lat_min: f64,


### PR DESCRIPTION
## Summary
- Split `filter/conversion.rs:from()` 107→50 NLOC (4 helpers extracted)
- Split `filter/matching.rs:matches()` 90→40 NLOC (4 helpers extracted)
- Fixed 3 `doc_markdown` warnings (GeoPoint, ColumnStore)
- Fixed `manual_let_else` in vector_group_by.rs
- 0 clippy pedantic errors remaining

## Severity: HIGH — CI-blocking with -D warnings

## Test plan
- [x] 4572 tests pass
- [x] `cargo clippy --workspace -- -D warnings -D clippy::pedantic` clean

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/547" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
