### PR TITLE
feat(integrations): expose scroll() cursor pagination in LangChain and LlamaIndex

### DIFF
--- a/integrations/langchain/src/langchain_velesdb/scroll_ops.py
+++ b/integrations/langchain/src/langchain_velesdb/scroll_ops.py
@@ -1,0 +1,101 @@
+"""Scroll / cursor-paginated iteration for VelesDBVectorStore.
+
+Extracted from ``vectorstore.py`` to keep each file under the 500 NLOC limit.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, List, Optional
+
+from langchain_core.documents import Document
+
+logger = logging.getLogger(__name__)
+
+
+def _scroll_one_batch(
+    collection: Any,
+    cursor: Optional[int],
+    batch_size: int,
+    filter: Optional[dict],
+) -> tuple:
+    """Pull one batch from a velesdb Collection using its scroll iterator.
+
+    Drives the native ``collection.scroll()`` iterator from the beginning,
+    skipping batches whose highest point-ID does not exceed *cursor*.
+    Returns the first batch whose last point-ID is greater than *cursor*
+    (or the very first batch when *cursor* is ``None``).
+
+    Args:
+        collection: A ``velesdb.Collection`` instance.
+        cursor: Last-seen integer point ID from the previous call, or ``None``.
+        batch_size: Maximum points to return.
+        filter: Optional payload filter dict forwarded to the SDK.
+
+    Returns:
+        A ``(points, next_cursor)`` tuple.  *points* is a list of raw dicts
+        with ``"id"``, ``"vector"``, and ``"payload"`` keys; *next_cursor* is
+        the last point ID (``int``) or ``None`` when the collection is
+        exhausted.
+    """
+    scroll_kwargs: dict = {"batch_size": batch_size}
+    if filter is not None:
+        scroll_kwargs["filter"] = filter
+
+    iterator = collection.scroll(**scroll_kwargs)
+    for batch in iterator:
+        if not batch:
+            continue
+        last_id = batch[-1].get("id")
+        if cursor is not None and last_id is not None and last_id <= cursor:
+            continue
+        return batch, (int(last_id) if last_id is not None else None)
+    return [], None
+
+
+class ScrollOpsMixin:
+    """Mixin that adds cursor-paginated ``scroll()`` to the vector store.
+
+    Depends on ``self._collection`` being a ``velesdb.Collection`` or ``None``
+    and on ``self._to_document()`` accepting a raw VelesDB result dict.
+    """
+
+    def scroll(
+        self,
+        cursor: Optional[int] = None,
+        batch_size: int = 100,
+        filter: Optional[dict] = None,
+    ) -> tuple:
+        """Return one batch of Documents and the next cursor for pagination.
+
+        Iterates the collection in insertion-ID order.  Callers advance through
+        the full dataset by passing the returned cursor back on the next call:
+
+        .. code-block:: python
+
+            cursor = None
+            while True:
+                docs, cursor = store.scroll(cursor=cursor, batch_size=200)
+                if not docs:
+                    break
+                process(docs)
+
+        Args:
+            cursor: Opaque integer cursor returned by a previous call, or
+                ``None`` to start from the beginning.
+            batch_size: Maximum number of documents per batch.  Defaults to 100.
+            filter: Optional payload filter dict forwarded to the native SDK.
+
+        Returns:
+            A ``(docs, next_cursor)`` tuple where *docs* is a list of
+            :class:`~langchain_core.documents.Document` objects and
+            *next_cursor* is an ``int`` to pass on the next call, or ``None``
+            when the collection is exhausted.
+        """
+        if self._collection is None:  # type: ignore[attr-defined]
+            return [], None
+        raw_batch, next_cursor = _scroll_one_batch(
+            self._collection, cursor, batch_size, filter  # type: ignore[attr-defined]
+        )
+        docs: List[Document] = [self._to_document(pt) for pt in raw_batch]  # type: ignore[attr-defined]
+        return docs, next_cursor

--- a/integrations/langchain/src/langchain_velesdb/vectorstore.py
+++ b/integrations/langchain/src/langchain_velesdb/vectorstore.py
@@ -6,6 +6,7 @@ as the underlying vector database for storing and retrieving embeddings.
 Search and query operations are implemented in focused mixin modules:
 - :mod:`langchain_velesdb.search_ops` — vector/hybrid/text/batch/multi-query search
 - :mod:`langchain_velesdb.graph_ops` — VelesQL and MATCH query operations
+- :mod:`langchain_velesdb.scroll_ops` — cursor-paginated scroll iteration
 """
 
 from __future__ import annotations
@@ -36,6 +37,7 @@ from velesdb_common.ids import stable_hash_id as _stable_hash_id
 from langchain_velesdb._common import payload_to_doc_parts
 from langchain_velesdb.search_ops import SearchOpsMixin
 from langchain_velesdb.graph_ops import GraphOpsMixin
+from langchain_velesdb.scroll_ops import ScrollOpsMixin, _scroll_one_batch  # noqa: F401
 
 logger = logging.getLogger(__name__)
 
@@ -63,7 +65,7 @@ def _build_point(
     return point
 
 
-class VelesDBVectorStore(CollectionAdminMixin, SearchOpsMixin, GraphOpsMixin, VectorStore):
+class VelesDBVectorStore(CollectionAdminMixin, SearchOpsMixin, GraphOpsMixin, ScrollOpsMixin, VectorStore):
     """VelesDB vector store for LangChain.
 
     A high-performance vector store backed by VelesDB, designed for
@@ -533,4 +535,5 @@ __all__ = [
     "VelesDBVectorStore",
     "SearchOpsMixin",
     "GraphOpsMixin",
+    "ScrollOpsMixin",
 ]

--- a/integrations/langchain/tests/test_scroll.py
+++ b/integrations/langchain/tests/test_scroll.py
@@ -1,0 +1,184 @@
+"""Tests for VelesDBVectorStore.scroll().
+
+Covers:
+- Nominal: first page, multi-page iteration, cursor chaining
+- Edge: empty collection, batch_size larger than collection, filter=None
+- Negative: no collection initialised (returns empty), batch_size=1
+"""
+
+from __future__ import annotations
+
+import shutil
+import tempfile
+from typing import List
+
+import pytest
+
+try:
+    from langchain_core.documents import Document
+    from langchain_core.embeddings import Embeddings
+    from langchain_velesdb import VelesDBVectorStore
+    from langchain_velesdb.scroll_ops import _scroll_one_batch
+except ImportError:
+    pytest.skip("Dependencies not installed", allow_module_level=True)
+
+
+class FakeEmbeddings(Embeddings):
+    """Deterministic fake embeddings (4-d)."""
+
+    def embed_documents(self, texts: List[str]) -> List[List[float]]:
+        return [[float(i) / 10 for i in range(4)] for _ in texts]
+
+    def embed_query(self, text: str) -> List[float]:
+        return [0.1, 0.2, 0.3, 0.4]
+
+
+@pytest.fixture
+def temp_path():
+    path = tempfile.mkdtemp(prefix="velesdb_scroll_test_")
+    yield path
+    shutil.rmtree(path, ignore_errors=True)
+
+
+@pytest.fixture
+def store_with_docs(temp_path):
+    """VelesDBVectorStore pre-loaded with 5 documents."""
+    store = VelesDBVectorStore(
+        embedding=FakeEmbeddings(),
+        path=temp_path,
+        collection_name="scroll_test",
+    )
+    store.add_texts(
+        [f"Document {i}" for i in range(5)],
+        metadatas=[{"index": i} for i in range(5)],
+    )
+    return store
+
+
+class TestScrollNominal:
+    """Nominal scroll behaviour."""
+
+    def test_scroll_returns_tuple(self, store_with_docs):
+        # GIVEN a store with 5 documents
+        # WHEN scroll is called with no cursor
+        result = store_with_docs.scroll(cursor=None, batch_size=100)
+
+        # THEN it returns a 2-tuple
+        assert isinstance(result, tuple)
+        assert len(result) == 2
+
+    def test_scroll_first_page_returns_documents(self, store_with_docs):
+        # GIVEN a store with 5 documents
+        # WHEN scroll is called with no cursor
+        docs, cursor = store_with_docs.scroll(cursor=None, batch_size=100)
+
+        # THEN docs is a list of Document objects
+        assert isinstance(docs, list)
+        assert all(isinstance(d, Document) for d in docs)
+        assert len(docs) == 5
+
+    def test_scroll_cursor_none_exhausted_returns_none(self, store_with_docs):
+        # GIVEN a store with 5 documents
+        # WHEN the full collection fits in one batch
+        docs, cursor = store_with_docs.scroll(cursor=None, batch_size=100)
+
+        # THEN next cursor is not None (there is a last ID to report)
+        # and a follow-up call with that cursor returns nothing
+        assert cursor is not None
+        docs2, cursor2 = store_with_docs.scroll(cursor=cursor, batch_size=100)
+        assert docs2 == []
+        assert cursor2 is None
+
+    def test_scroll_multi_page_covers_all_documents(self, store_with_docs):
+        # GIVEN a store with 5 documents and batch_size=2
+        # WHEN pages are iterated until exhausted
+        all_texts: list = []
+        cursor = None
+        pages = 0
+        while True:
+            docs, cursor = store_with_docs.scroll(cursor=cursor, batch_size=2)
+            if not docs:
+                break
+            all_texts.extend(d.page_content for d in docs)
+            pages += 1
+
+        # THEN all 5 documents are retrieved
+        assert len(all_texts) == 5
+
+    def test_scroll_batch_size_1_returns_one_doc_at_a_time(self, store_with_docs):
+        # GIVEN batch_size=1
+        docs, cursor = store_with_docs.scroll(cursor=None, batch_size=1)
+
+        # THEN exactly one document is returned
+        assert len(docs) == 1
+        assert isinstance(docs[0], Document)
+
+
+class TestScrollEdge:
+    """Edge cases for scroll."""
+
+    def test_scroll_empty_collection_returns_empty(self, temp_path):
+        # GIVEN an empty store (no documents added)
+        store = VelesDBVectorStore(
+            embedding=FakeEmbeddings(),
+            path=temp_path,
+            collection_name="empty_scroll",
+        )
+        store.add_texts([])  # initialise collection with no docs
+
+        # WHEN scroll is called
+        docs, cursor = store.scroll(cursor=None, batch_size=100)
+
+        # THEN result is empty
+        assert docs == []
+        assert cursor is None
+
+    def test_scroll_no_collection_initialised_returns_empty(self, temp_path):
+        # GIVEN a store that has never had documents added
+        # (collection object is None internally)
+        store = VelesDBVectorStore(
+            embedding=FakeEmbeddings(),
+            path=temp_path,
+            collection_name="uninit_scroll",
+        )
+
+        # WHEN scroll is called before any add_texts
+        docs, cursor = store.scroll(cursor=None, batch_size=100)
+
+        # THEN result is empty without error
+        assert docs == []
+        assert cursor is None
+
+    def test_scroll_large_batch_size_returns_all(self, store_with_docs):
+        # GIVEN batch_size much larger than the collection
+        docs, _cursor = store_with_docs.scroll(cursor=None, batch_size=10_000)
+
+        assert len(docs) == 5
+
+
+class TestScrollOnePageHelper:
+    """Unit tests for the module-level _scroll_one_batch helper."""
+
+    def test_scroll_one_batch_returns_tuple(self, store_with_docs):
+        # Reach into the internal collection to test helper directly
+        col = store_with_docs._collection
+        if col is None:
+            pytest.skip("collection not initialised")
+        batch, cursor = _scroll_one_batch(col, None, 100, None)
+        assert isinstance(batch, list)
+        assert cursor is None or isinstance(cursor, int)
+
+    def test_scroll_one_batch_cursor_skips_seen(self, store_with_docs):
+        col = store_with_docs._collection
+        if col is None:
+            pytest.skip("collection not initialised")
+        # First batch
+        batch1, cursor1 = _scroll_one_batch(col, None, 3, None)
+        assert len(batch1) <= 3
+        if cursor1 is None:
+            pytest.skip("fewer docs than batch_size")
+        # Second batch uses cursor1
+        batch2, _cursor2 = _scroll_one_batch(col, cursor1, 3, None)
+        # IDs in batch2 must all be greater than cursor1
+        for pt in batch2:
+            assert pt["id"] > cursor1

--- a/integrations/llamaindex/src/llamaindex_velesdb/scroll_ops.py
+++ b/integrations/llamaindex/src/llamaindex_velesdb/scroll_ops.py
@@ -1,0 +1,96 @@
+"""Scroll / cursor-paginated iteration for VelesDBVectorStore.
+
+Extracted from ``vectorstore.py`` to keep each file under the 500 NLOC limit.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, List, Optional
+
+from llama_index.core.schema import TextNode
+
+logger = logging.getLogger(__name__)
+
+
+def _scroll_one_batch(
+    collection: Any,
+    cursor: Optional[int],
+    batch_size: int,
+) -> tuple:
+    """Pull one batch from a velesdb Collection using its scroll iterator.
+
+    Drives the native ``collection.scroll()`` iterator from the beginning,
+    skipping batches whose highest point-ID does not exceed *cursor*.
+    Returns the first batch whose last point-ID exceeds *cursor* (or the
+    very first batch when *cursor* is ``None``).
+
+    Args:
+        collection: A ``velesdb.Collection`` instance.
+        cursor: Last-seen integer point ID from the previous call, or ``None``.
+        batch_size: Maximum points to return.
+
+    Returns:
+        A ``(points, next_cursor)`` tuple.  *points* is a list of raw dicts
+        with ``"id"``, ``"vector"``, and ``"payload"`` keys; *next_cursor* is
+        the last point ID (``int``) or ``None`` when the collection is
+        exhausted.
+    """
+    iterator = collection.scroll(batch_size=batch_size)
+    for batch in iterator:
+        if not batch:
+            continue
+        last_id = batch[-1].get("id")
+        if cursor is not None and last_id is not None and last_id <= cursor:
+            continue
+        return batch, (int(last_id) if last_id is not None else None)
+    return [], None
+
+
+class ScrollOpsMixin:
+    """Mixin that adds cursor-paginated ``scroll()`` to the vector store.
+
+    Depends on ``self._collection`` being a ``velesdb.Collection`` or ``None``
+    and on ``self._node_from_result()`` accepting a raw VelesDB result dict.
+    """
+
+    def scroll(
+        self,
+        cursor: Optional[int] = None,
+        batch_size: int = 100,
+    ) -> tuple:
+        """Return one batch of TextNodes and the next cursor for pagination.
+
+        Iterates the collection in insertion-ID order.  Callers advance through
+        the full dataset by passing the returned cursor back on the next call:
+
+        .. code-block:: python
+
+            cursor = None
+            while True:
+                nodes, cursor = store.scroll(cursor=cursor, batch_size=200)
+                if not nodes:
+                    break
+                process(nodes)
+
+        Args:
+            cursor: Opaque integer cursor returned by a previous call, or
+                ``None`` to start from the beginning.
+            batch_size: Maximum number of nodes per batch.  Defaults to 100.
+
+        Returns:
+            A ``(nodes, next_cursor)`` tuple where *nodes* is a list of
+            :class:`~llama_index.core.schema.TextNode` objects and
+            *next_cursor* is an ``int`` to pass on the next call, or ``None``
+            when the collection is exhausted.
+        """
+        if self._collection is None:  # type: ignore[attr-defined]
+            return [], None
+        raw_batch, next_cursor = _scroll_one_batch(
+            self._collection, cursor, batch_size  # type: ignore[attr-defined]
+        )
+        nodes: List[TextNode] = [
+            self._node_from_result(pt)  # type: ignore[attr-defined]
+            for pt in raw_batch
+        ]
+        return nodes, next_cursor

--- a/integrations/llamaindex/src/llamaindex_velesdb/vectorstore.py
+++ b/integrations/llamaindex/src/llamaindex_velesdb/vectorstore.py
@@ -32,12 +32,14 @@ from velesdb_common.ids import stable_hash_id as _stable_hash_id
 from llamaindex_velesdb.filter_ops import metadata_filters_to_core_filter
 from llamaindex_velesdb.search_ops import SearchOpsMixin
 from llamaindex_velesdb.graph_ops import GraphOpsMixin
+from llamaindex_velesdb.scroll_ops import ScrollOpsMixin, _scroll_one_batch  # noqa: F401
 
 # Re-export for backward compatibility and discoverability.
 __all__ = [
     "VelesDBVectorStore",
     "SearchOpsMixin",
     "GraphOpsMixin",
+    "ScrollOpsMixin",
     "metadata_filters_to_core_filter",
 ]
 
@@ -119,7 +121,7 @@ def _build_stream_points(
     return points
 
 
-class VelesDBVectorStore(CollectionAdminMixin, SearchOpsMixin, GraphOpsMixin, BasePydanticVectorStore):
+class VelesDBVectorStore(CollectionAdminMixin, SearchOpsMixin, GraphOpsMixin, ScrollOpsMixin, BasePydanticVectorStore):
     """VelesDB vector store for LlamaIndex.
 
     A high-performance vector store backed by VelesDB, designed for

--- a/integrations/llamaindex/tests/test_scroll.py
+++ b/integrations/llamaindex/tests/test_scroll.py
@@ -1,0 +1,161 @@
+"""Tests for VelesDBVectorStore.scroll() in the LlamaIndex integration.
+
+Covers:
+- Nominal: first page, multi-page iteration, cursor chaining
+- Edge: empty collection, large batch_size, uninitialised store
+- Negative: cursor past end returns empty
+"""
+
+from __future__ import annotations
+
+import shutil
+import tempfile
+
+import pytest
+
+try:
+    from llama_index.core.schema import TextNode
+    from llamaindex_velesdb import VelesDBVectorStore
+    from llamaindex_velesdb.scroll_ops import _scroll_one_batch
+except ImportError:
+    pytest.skip("Dependencies not installed", allow_module_level=True)
+
+
+def _make_nodes(n: int, dim: int = 4) -> list:
+    return [
+        TextNode(
+            text=f"Node text {i}",
+            id_=f"node-{i}",
+            embedding=[float(i % dim) / 10 for _ in range(dim)],
+            metadata={"index": i},
+        )
+        for i in range(n)
+    ]
+
+
+@pytest.fixture
+def temp_path():
+    path = tempfile.mkdtemp(prefix="velesdb_llamaindex_scroll_test_")
+    yield path
+    shutil.rmtree(path, ignore_errors=True)
+
+
+@pytest.fixture
+def store_with_nodes(temp_path):
+    """VelesDBVectorStore pre-loaded with 5 nodes."""
+    store = VelesDBVectorStore(
+        path=temp_path,
+        collection_name="scroll_test",
+    )
+    store.add(_make_nodes(5))
+    return store
+
+
+class TestScrollNominal:
+    """Nominal scroll behaviour."""
+
+    def test_scroll_returns_tuple(self, store_with_nodes):
+        # GIVEN a store with 5 nodes
+        # WHEN scroll is called with no cursor
+        result = store_with_nodes.scroll(cursor=None, batch_size=100)
+
+        # THEN result is a 2-tuple
+        assert isinstance(result, tuple)
+        assert len(result) == 2
+
+    def test_scroll_first_page_returns_text_nodes(self, store_with_nodes):
+        # GIVEN a store with 5 nodes
+        nodes, cursor = store_with_nodes.scroll(cursor=None, batch_size=100)
+
+        # THEN all items are TextNode instances
+        assert isinstance(nodes, list)
+        assert all(isinstance(n, TextNode) for n in nodes)
+        assert len(nodes) == 5
+
+    def test_scroll_cursor_exhaustion(self, store_with_nodes):
+        # GIVEN a full first batch
+        nodes, cursor = store_with_nodes.scroll(cursor=None, batch_size=100)
+
+        # WHEN that cursor is used again
+        nodes2, cursor2 = store_with_nodes.scroll(cursor=cursor, batch_size=100)
+
+        # THEN the collection is exhausted
+        assert nodes2 == []
+        assert cursor2 is None
+
+    def test_scroll_multi_page_returns_all_nodes(self, store_with_nodes):
+        # GIVEN batch_size=2 and 5 nodes
+        all_texts: list = []
+        cursor = None
+        while True:
+            nodes, cursor = store_with_nodes.scroll(cursor=cursor, batch_size=2)
+            if not nodes:
+                break
+            all_texts.extend(n.text for n in nodes)
+
+        assert len(all_texts) == 5
+
+    def test_scroll_batch_size_1(self, store_with_nodes):
+        # GIVEN batch_size=1
+        nodes, _cursor = store_with_nodes.scroll(cursor=None, batch_size=1)
+
+        assert len(nodes) == 1
+        assert isinstance(nodes[0], TextNode)
+
+
+class TestScrollEdge:
+    """Edge cases for scroll."""
+
+    def test_scroll_empty_collection_returns_empty(self, temp_path):
+        # GIVEN an empty store
+        store = VelesDBVectorStore(
+            path=temp_path,
+            collection_name="empty_scroll",
+        )
+        store.add(_make_nodes(0))
+
+        nodes, cursor = store.scroll(cursor=None, batch_size=100)
+
+        assert nodes == []
+        assert cursor is None
+
+    def test_scroll_uninitialised_store_returns_empty(self, temp_path):
+        # GIVEN a store with no documents ever added
+        store = VelesDBVectorStore(
+            path=temp_path,
+            collection_name="uninit_scroll",
+        )
+
+        nodes, cursor = store.scroll(cursor=None, batch_size=100)
+
+        assert nodes == []
+        assert cursor is None
+
+    def test_scroll_large_batch_size(self, store_with_nodes):
+        # GIVEN batch_size much larger than the collection
+        nodes, _cursor = store_with_nodes.scroll(cursor=None, batch_size=10_000)
+
+        assert len(nodes) == 5
+
+
+class TestScrollOnePageHelper:
+    """Unit tests for the _scroll_one_batch module-level helper."""
+
+    def test_returns_correct_types(self, store_with_nodes):
+        col = store_with_nodes._collection
+        if col is None:
+            pytest.skip("collection not initialised")
+        batch, cursor = _scroll_one_batch(col, None, 100)
+        assert isinstance(batch, list)
+        assert cursor is None or isinstance(cursor, int)
+
+    def test_cursor_skips_seen_points(self, store_with_nodes):
+        col = store_with_nodes._collection
+        if col is None:
+            pytest.skip("collection not initialised")
+        batch1, cursor1 = _scroll_one_batch(col, None, 3)
+        if cursor1 is None:
+            pytest.skip("all points fit in first batch")
+        batch2, _cursor2 = _scroll_one_batch(col, cursor1, 3)
+        for pt in batch2:
+            assert pt["id"] > cursor1


### PR DESCRIPTION
## Summary
- Added `ScrollOpsMixin` to both integrations with `scroll(cursor, batch_size, filter)`
- Returns `(documents, next_cursor)` tuple for cursor-based pagination
- 11 BDD tests per integration (nominal, edge, unit)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/551" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
