### PR TITLE
fix(integrations): ImportError, search_with_ef LlamaIndex, fusion common, streamInsert doc

### DIFF
--- a/integrations/common/src/velesdb_common/__init__.py
+++ b/integrations/common/src/velesdb_common/__init__.py
@@ -38,6 +38,7 @@ from velesdb_common.security import (
     validate_url,
     validate_weight,
 )
+from velesdb_common.fusion import build_fusion_strategy
 from velesdb_common.graph import (
     build_graph_rest_payload,
     is_timeout_exception,
@@ -46,6 +47,8 @@ from velesdb_common.graph import (
 )
 
 __all__ = [
+    # fusion
+    "build_fusion_strategy",
     # collection admin
     "CollectionAdminMixin",
     # graph ops

--- a/integrations/common/src/velesdb_common/fusion.py
+++ b/integrations/common/src/velesdb_common/fusion.py
@@ -1,0 +1,65 @@
+"""Shared fusion strategy builder for VelesDB integrations.
+
+Centralises ``build_fusion_strategy`` so that both the LangChain and
+LlamaIndex integration packages can import from a single source instead
+of maintaining identical copies (US-018 — no duplication < 2%).
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import velesdb
+
+
+def build_fusion_strategy(
+    fusion: str,
+    fusion_params: Optional[dict] = None,
+) -> velesdb.FusionStrategy:
+    """Build a :class:`velesdb.FusionStrategy` from a string name and params.
+
+    Args:
+        fusion: Fusion strategy name.  One of ``"average"``, ``"maximum"``,
+            ``"rrf"``, ``"weighted"``, ``"relative_score"``, or ``"rsf"``
+            (alias for ``"relative_score"``).
+        fusion_params: Optional parameters for the chosen strategy:
+
+            - ``"rrf"``: ``{"k": 60}`` (default k=60)
+            - ``"weighted"``: ``{"avg_weight": 0.6, "max_weight": 0.3,
+              "hit_weight": 0.1}``
+            - ``"relative_score"`` / ``"rsf"``: ``{"dense_weight": 0.5,
+              "sparse_weight": 0.5}``
+
+    Returns:
+        A configured :class:`velesdb.FusionStrategy` instance.
+
+    Raises:
+        ValueError: If *fusion* is not one of the supported strategy names.
+    """
+    params = fusion_params or {}
+
+    if fusion == "average":
+        return velesdb.FusionStrategy.average()
+    if fusion == "maximum":
+        return velesdb.FusionStrategy.maximum()
+    if fusion == "rrf":
+        k = params.get("k", 60)
+        return velesdb.FusionStrategy.rrf(k=k)
+    if fusion == "weighted":
+        avg_weight = params.get("avg_weight", 0.6)
+        max_weight = params.get("max_weight", 0.3)
+        hit_weight = params.get("hit_weight", 0.1)
+        return velesdb.FusionStrategy.weighted(
+            avg_weight=avg_weight,
+            max_weight=max_weight,
+            hit_weight=hit_weight,
+        )
+    if fusion in ("relative_score", "rsf"):
+        dense_weight = params.get("dense_weight", 0.5)
+        sparse_weight = params.get("sparse_weight", 0.5)
+        return velesdb.FusionStrategy.relative_score(dense_weight, sparse_weight)
+
+    raise ValueError(
+        f"Unknown fusion strategy '{fusion}'. "
+        "Supported: 'average', 'maximum', 'rrf', 'weighted', 'relative_score'."
+    )

--- a/integrations/langchain/src/langchain_velesdb/__init__.py
+++ b/integrations/langchain/src/langchain_velesdb/__init__.py
@@ -32,7 +32,7 @@ try:
         VelesDBProceduralMemory,
     )
     _HAS_MEMORY = True
-except ImportError:
+except ModuleNotFoundError:
     VelesDBChatMemory = None  # type: ignore
     VelesDBSemanticMemory = None  # type: ignore
     VelesDBProceduralMemory = None  # type: ignore

--- a/integrations/langchain/src/langchain_velesdb/search_ops.py
+++ b/integrations/langchain/src/langchain_velesdb/search_ops.py
@@ -11,9 +11,8 @@ from typing import Any, List, Optional, Tuple
 
 from langchain_core.documents import Document
 
-import velesdb
-
 from langchain_velesdb._common import payload_to_doc_parts, validate_queries_batch
+from velesdb_common.fusion import build_fusion_strategy as _build_fusion_strategy_fn
 from langchain_velesdb.security import (
     validate_k,
     validate_text,
@@ -603,32 +602,10 @@ class SearchOpsMixin:
         self,
         fusion: str,
         fusion_params: Optional[dict] = None,
-    ) -> "velesdb.FusionStrategy":
-        """Build a FusionStrategy from string name and params."""
-        params = fusion_params or {}
+    ) -> object:
+        """Build a FusionStrategy from string name and params.
 
-        if fusion == "average":
-            return velesdb.FusionStrategy.average()
-        elif fusion == "maximum":
-            return velesdb.FusionStrategy.maximum()
-        elif fusion == "rrf":
-            k = params.get("k", 60)
-            return velesdb.FusionStrategy.rrf(k=k)
-        elif fusion == "weighted":
-            avg_weight = params.get("avg_weight", 0.6)
-            max_weight = params.get("max_weight", 0.3)
-            hit_weight = params.get("hit_weight", 0.1)
-            return velesdb.FusionStrategy.weighted(
-                avg_weight=avg_weight,
-                max_weight=max_weight,
-                hit_weight=hit_weight,
-            )
-        elif fusion in ("relative_score", "rsf"):
-            dense_weight = params.get("dense_weight", 0.5)
-            sparse_weight = params.get("sparse_weight", 0.5)
-            return velesdb.FusionStrategy.relative_score(dense_weight, sparse_weight)
-        else:
-            raise ValueError(
-                f"Unknown fusion strategy '{fusion}'. "
-                "Use 'average', 'maximum', 'rrf', 'weighted', or 'relative_score'."
-            )
+        Delegates to :func:`velesdb_common.fusion.build_fusion_strategy`
+        to avoid duplication with the LlamaIndex integration.
+        """
+        return _build_fusion_strategy_fn(fusion, fusion_params)

--- a/integrations/llamaindex/src/llamaindex_velesdb/__init__.py
+++ b/integrations/llamaindex/src/llamaindex_velesdb/__init__.py
@@ -24,7 +24,7 @@ try:
         VelesDBProceduralMemory,
     )
     _HAS_MEMORY = True
-except ImportError:
+except ModuleNotFoundError:
     VelesDBSemanticMemory = None  # type: ignore
     VelesDBEpisodicMemory = None  # type: ignore
     VelesDBProceduralMemory = None  # type: ignore

--- a/integrations/llamaindex/src/llamaindex_velesdb/search_ops.py
+++ b/integrations/llamaindex/src/llamaindex_velesdb/search_ops.py
@@ -15,7 +15,7 @@ from llama_index.core.vector_stores.types import (
     VectorStoreQueryResult,
 )
 
-import velesdb
+from velesdb_common.fusion import build_fusion_strategy as _build_fusion_strategy_fn
 
 from llamaindex_velesdb.security import (
     validate_k,
@@ -409,35 +409,83 @@ class SearchOpsMixin:
         self,
         fusion: str,
         fusion_params: Optional[dict] = None,
-    ) -> "velesdb.FusionStrategy":
+    ) -> object:
         """Build a FusionStrategy from string name and params.
 
+        Delegates to :func:`velesdb_common.fusion.build_fusion_strategy`
+        to avoid duplication with the LangChain integration.
+        """
+        return _build_fusion_strategy_fn(fusion, fusion_params)
+
+    def query_with_ef(
+        self,
+        query_embedding: List[float],
+        ef_search: int,
+        top_k: int = 10,
+        **kwargs: Any,
+    ) -> VectorStoreQueryResult:
+        """Query with a custom HNSW ``ef_search`` parameter.
+
+        Exposes the same capability as LangChain's
+        ``similarity_search_with_ef``, allowing callers to trade recall for
+        latency by controlling the HNSW search beam width at query time.
+
         Args:
-            fusion: Fusion strategy name ("rrf", "average", "maximum", "weighted").
-            fusion_params: Optional parameters for the strategy.
+            query_embedding: Dense query vector.
+            ef_search: HNSW ``ef`` value for this query.  Larger values
+                increase recall at the cost of higher latency.
+            top_k: Number of results to return.  Defaults to 10.
+            **kwargs: Additional arguments (reserved for future use).
 
         Returns:
-            A velesdb.FusionStrategy instance.
+            Query result with nodes and similarities.
+
+        Raises:
+            SecurityError: If ``top_k`` fails validation.
         """
-        params = fusion_params or {}
+        validate_k(top_k)
+        dimension = len(query_embedding)
+        collection = self._get_collection(dimension)
+        results = collection.search_with_ef(
+            query_embedding, top_k=top_k, ef_search=ef_search,
+        )
+        return self._build_query_result(results)
 
-        if fusion == "rrf":
-            k = params.get("k", 60)
-            return velesdb.FusionStrategy.rrf(k=k)
-        if fusion == "average":
-            return velesdb.FusionStrategy.average()
-        if fusion == "maximum":
-            return velesdb.FusionStrategy.maximum()
-        if fusion == "weighted":
-            avg_w = params.get("avg_weight", 0.6)
-            max_w = params.get("max_weight", 0.3)
-            hit_w = params.get("hit_weight", 0.1)
-            return velesdb.FusionStrategy.weighted(
-                avg_weight=avg_w, max_weight=max_w, hit_weight=hit_w,
-            )
-        if fusion in ("relative_score", "rsf"):
-            dense_weight = params.get("dense_weight", 0.5)
-            sparse_weight = params.get("sparse_weight", 0.5)
-            return velesdb.FusionStrategy.relative_score(dense_weight, sparse_weight)
+    def query_ids(
+        self,
+        query_embedding: List[float],
+        top_k: int = 10,
+        **kwargs: Any,
+    ) -> List[str]:
+        """Query returning only node IDs (no payloads fetched).
 
-        raise ValueError(f"Unknown fusion strategy: {fusion}")
+        Mirrors LangChain's ``similarity_search_ids`` — useful for
+        re-ranking pipelines that need candidate IDs before fetching full
+        payloads, keeping the round-trip cheap.
+
+        Args:
+            query_embedding: Dense query vector.
+            top_k: Number of IDs to return.  Defaults to 10.
+            **kwargs: Additional arguments (reserved for future use).
+
+        Returns:
+            List of node ID strings, ordered by descending similarity.
+
+        Raises:
+            SecurityError: If ``top_k`` fails validation.
+        """
+        validate_k(top_k)
+        dimension = len(query_embedding)
+        collection = self._get_collection(dimension)
+        raw = collection.search_ids(query_embedding, top_k=top_k)
+        # search_ids returns [{id, score}, ...]; extract the node_id string
+        # stored in the payload, falling back to the numeric point ID.
+        ids: List[str] = []
+        for entry in raw:
+            payload = entry.get("payload", {})
+            node_id = payload.get("node_id")
+            if node_id is not None:
+                ids.append(str(node_id))
+            else:
+                ids.append(str(entry.get("id", "")))
+        return ids

--- a/sdks/typescript/src/backends/streaming-backend.ts
+++ b/sdks/typescript/src/backends/streaming-backend.ts
@@ -50,6 +50,23 @@ export async function trainPq(
   return response.data?.message ?? 'PQ training initiated';
 }
 
+/**
+ * Why streamInsert does NOT use transport.requestJson:
+ *
+ * 1. **Backpressure signalling** — the streaming endpoint returns HTTP 429 to
+ *    signal backpressure (the ingestion channel is full), which is semantically
+ *    different from a rate-limit 429.  requestJson maps every non-2xx status to
+ *    a generic VelesDBError; here we must catch 429 *before* that mapping and
+ *    raise BackpressureError so callers can react with back-off logic.
+ *
+ * 2. **Custom endpoint** — the target URL is
+ *    `<collection>/stream/insert`, not the shared `/query` endpoint used by
+ *    requestJson, so the helper's URL construction does not apply.
+ *
+ * 3. **202 Accepted** — the endpoint may return 202 (enqueued, not yet
+ *    persisted) as a success code; requestJson treats only 2xx as success
+ *    but does not special-case 202 vs 200 for streaming semantics.
+ */
 export async function streamInsert(
   transport: StreamingTransport,
   collection: string,


### PR DESCRIPTION
## Summary
- `ImportError` → `ModuleNotFoundError` in both `__init__.py`
- `query_with_ef` + `query_ids` added to LlamaIndex (feature parity)
- `build_fusion_strategy` extracted to `velesdb_common.fusion` (DRY)
- `streamInsert` justification comment added in TS SDK

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/553" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
