### PR TITLE
fix(integrations): widen ImportError catch + document scroll O(N²) limitation

### DIFF
--- a/integrations/langchain/src/langchain_velesdb/__init__.py
+++ b/integrations/langchain/src/langchain_velesdb/__init__.py
@@ -32,7 +32,9 @@ try:
         VelesDBProceduralMemory,
     )
     _HAS_MEMORY = True
-except ModuleNotFoundError:
+except ImportError as e:
+    import logging
+    logging.getLogger(__name__).debug("Optional import failed: %s", e)
     VelesDBChatMemory = None  # type: ignore
     VelesDBSemanticMemory = None  # type: ignore
     VelesDBProceduralMemory = None  # type: ignore

--- a/integrations/langchain/src/langchain_velesdb/scroll_ops.py
+++ b/integrations/langchain/src/langchain_velesdb/scroll_ops.py
@@ -21,10 +21,22 @@ def _scroll_one_batch(
 ) -> tuple:
     """Pull one batch from a velesdb Collection using its scroll iterator.
 
-    Drives the native ``collection.scroll()`` iterator from the beginning,
-    skipping batches whose highest point-ID does not exceed *cursor*.
-    Returns the first batch whose last point-ID is greater than *cursor*
-    (or the very first batch when *cursor* is ``None``).
+    Creates a fresh ``collection.scroll()`` iterator on every call and skips
+    batches until the one past *cursor* is found.
+
+    .. warning::
+        **Complexity: O(page_index * batch_size)** — this function re-scans
+        from the beginning of the collection on each call because the native
+        SDK does not yet expose a cursor-based ``scroll_batch`` method at the
+        Python level (the Rust ``VectorCollection.scroll_batch`` method is
+        internal to the ``ScrollIterator`` PyO3 class).  For large collections
+        with many pages, callers should either:
+
+        * keep the ``ScrollIterator`` alive across calls (use
+          ``collection.scroll(batch_size=N)`` as a Python generator and drive
+          it with ``next()``), or
+        * wait for a future ``Collection.scroll_batch(cursor, batch_size)``
+          Python binding that will provide true O(1) cursor seek.
 
     Args:
         collection: A ``velesdb.Collection`` instance.

--- a/integrations/llamaindex/src/llamaindex_velesdb/__init__.py
+++ b/integrations/llamaindex/src/llamaindex_velesdb/__init__.py
@@ -24,7 +24,9 @@ try:
         VelesDBProceduralMemory,
     )
     _HAS_MEMORY = True
-except ModuleNotFoundError:
+except ImportError as e:
+    import logging
+    logging.getLogger(__name__).debug("Optional import failed: %s", e)
     VelesDBSemanticMemory = None  # type: ignore
     VelesDBEpisodicMemory = None  # type: ignore
     VelesDBProceduralMemory = None  # type: ignore

--- a/integrations/llamaindex/src/llamaindex_velesdb/scroll_ops.py
+++ b/integrations/llamaindex/src/llamaindex_velesdb/scroll_ops.py
@@ -20,10 +20,22 @@ def _scroll_one_batch(
 ) -> tuple:
     """Pull one batch from a velesdb Collection using its scroll iterator.
 
-    Drives the native ``collection.scroll()`` iterator from the beginning,
-    skipping batches whose highest point-ID does not exceed *cursor*.
-    Returns the first batch whose last point-ID exceeds *cursor* (or the
-    very first batch when *cursor* is ``None``).
+    Creates a fresh ``collection.scroll()`` iterator on every call and skips
+    batches until the one past *cursor* is found.
+
+    .. warning::
+        **Complexity: O(page_index * batch_size)** — this function re-scans
+        from the beginning of the collection on each call because the native
+        SDK does not yet expose a cursor-based ``scroll_batch`` method at the
+        Python level (the Rust ``VectorCollection.scroll_batch`` method is
+        internal to the ``ScrollIterator`` PyO3 class).  For large collections
+        with many pages, callers should either:
+
+        * keep the ``ScrollIterator`` alive across calls (use
+          ``collection.scroll(batch_size=N)`` as a Python generator and drive
+          it with ``next()``), or
+        * wait for a future ``Collection.scroll_batch(cursor, batch_size)``
+          Python binding that will provide true O(1) cursor seek.
 
     Args:
         collection: A ``velesdb.Collection`` instance.


### PR DESCRIPTION
## Summary
- `except ModuleNotFoundError` → `except ImportError` with DEBUG logging (native extensions raise ImportError on ABI mismatch)
- scroll() O(N²) limitation documented (true fix requires PyO3 `scroll_batch` binding)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/555" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
