### PR TITLE
fix(ecosystem): complete FusionStrategy/SearchQuality propagation + TS graph type + badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
   <a href="https://pypi.org/project/velesdb/"><img src="https://img.shields.io/pypi/v/velesdb.svg" alt="PyPI"></a>
   <a href="https://www.npmjs.com/package/@wiscale/velesdb-sdk"><img src="https://img.shields.io/npm/v/@wiscale/velesdb-sdk.svg" alt="npm"></a>
   <a href="https://app.codacy.com/gh/cyberlife-coder/VelesDB/dashboard"><img src="https://app.codacy.com/project/badge/Coverage/58c73832dd294ba38144856ae69e9cf2" alt="Coverage"></a>
-  <img src="https://img.shields.io/badge/tests-4685_(incl._238_BDD)-brightgreen" alt="Tests">
+  <img src="https://img.shields.io/badge/tests-6242_(incl._403_BDD)-brightgreen" alt="Tests">
   <a href="https://github.com/cyberlife-coder/VelesDB/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-VelesDB_Core_1.0-blue" alt="License"></a>
   <a href="https://github.com/cyberlife-coder/VelesDB"><img src="https://img.shields.io/github/stars/cyberlife-coder/VelesDB?style=flat-square" alt="Stars"></a>
   <a href="https://img.shields.io/badge/contributors-welcome-brightgreen"><img src="https://img.shields.io/badge/contributors-welcome-brightgreen" alt="Contributors Welcome"></a>

--- a/crates/velesdb-cli/src/handlers/search.rs
+++ b/crates/velesdb-cli/src/handlers/search.rs
@@ -64,8 +64,12 @@ fn parse_fusion_strategy(strategy: &str, rrf_k: u32) -> Result<FusionStrategy> {
             max_weight: 0.3,
             hit_weight: 0.2,
         }),
+        "relative_score" | "rsf" => Ok(FusionStrategy::RelativeScore {
+            dense_weight: 0.5,
+            sparse_weight: 0.5,
+        }),
         _ => anyhow::bail!(
-            "Invalid strategy '{}'. Valid: average, maximum, rrf, weighted",
+            "Invalid strategy '{}'. Valid: average, maximum, rrf, weighted, relative_score",
             strategy
         ),
     }

--- a/crates/velesdb-cli/src/repl_search_cmds.rs
+++ b/crates/velesdb-cli/src/repl_search_cmds.rs
@@ -116,9 +116,19 @@ pub(crate) fn cmd_hybrid_sparse(db: &Database, parts: &[&str]) -> CommandResult 
         "rrf" => velesdb_core::FusionStrategy::rrf_default(),
         "average" => velesdb_core::FusionStrategy::Average,
         "max" | "maximum" => velesdb_core::FusionStrategy::Maximum,
+        "weighted" => velesdb_core::FusionStrategy::Weighted {
+            avg_weight: 0.5,
+            max_weight: 0.3,
+            hit_weight: 0.2,
+        },
+        "relative_score" | "rsf" => velesdb_core::FusionStrategy::RelativeScore {
+            dense_weight: 0.5,
+            sparse_weight: 0.5,
+        },
         other => {
             return CommandResult::Error(format!(
-                "Unknown fusion strategy: '{other}'. Use rrf, average, or max."
+                "Unknown fusion strategy: '{other}'. \
+                 Use rrf, average, max, weighted, or relative_score."
             ));
         }
     };

--- a/crates/velesdb-cli/src/session.rs
+++ b/crates/velesdb-cli/src/session.rs
@@ -3,13 +3,13 @@
 //! Manages session-level settings that can be modified with `\set` and viewed with `\show`.
 
 use std::collections::HashMap;
-use velesdb_core::config::SearchMode;
+use velesdb_core::SearchQuality;
 
 /// Session settings for the REPL.
 #[derive(Debug, Clone)]
 pub struct SessionSettings {
     /// Current search mode.
-    mode: SearchMode,
+    mode: SearchQuality,
     /// Override ef_search (None = use mode default).
     ef_search: Option<usize>,
     /// Query timeout in milliseconds.
@@ -27,7 +27,7 @@ pub struct SessionSettings {
 impl Default for SessionSettings {
     fn default() -> Self {
         Self {
-            mode: SearchMode::Balanced,
+            mode: SearchQuality::Balanced,
             ef_search: None,
             timeout_ms: 30000,
             rerank: true,
@@ -47,15 +47,17 @@ impl SessionSettings {
 
     /// Gets the current search mode.
     #[must_use]
-    pub fn mode(&self) -> SearchMode {
+    pub fn mode(&self) -> SearchQuality {
         self.mode
     }
 
     /// Gets the effective ef_search value.
+    ///
+    /// Uses a default `k=10` for the quality profile's ef calculation.
     #[must_use]
     #[allow(dead_code)] // Reason: public API for session-aware query execution (used in tests)
     pub fn effective_ef_search(&self) -> usize {
-        self.ef_search.unwrap_or_else(|| self.mode.ef_search())
+        self.ef_search.unwrap_or_else(|| self.mode.ef_search(10))
     }
 
     /// Gets the query timeout in milliseconds.
@@ -150,7 +152,7 @@ impl SessionSettings {
                 *self = Self::default();
             }
             Some(k) => match k.to_lowercase().as_str() {
-                "mode" => self.mode = SearchMode::Balanced,
+                "mode" => self.mode = SearchQuality::Balanced,
                 "ef_search" => self.ef_search = None,
                 "timeout_ms" | "timeout" => self.timeout_ms = 30000,
                 "rerank" => self.rerank = true,
@@ -167,14 +169,11 @@ impl SessionSettings {
     #[must_use]
     pub fn all_settings(&self) -> Vec<(String, String)> {
         let mut settings = vec![
-            (
-                "mode".to_string(),
-                format!("{:?}", self.mode).to_lowercase(),
-            ),
+            ("mode".to_string(), format_quality(self.mode)),
             (
                 "ef_search".to_string(),
                 self.ef_search.map_or_else(
-                    || format!("auto ({})", self.mode.ef_search()),
+                    || format!("auto ({})", self.mode.ef_search(10)),
                     |v| v.to_string(),
                 ),
             ),
@@ -200,9 +199,9 @@ impl SessionSettings {
     #[must_use]
     pub fn get(&self, key: &str) -> Option<String> {
         match key.to_lowercase().as_str() {
-            "mode" => Some(format!("{:?}", self.mode).to_lowercase()),
+            "mode" => Some(format_quality(self.mode)),
             "ef_search" => Some(self.ef_search.map_or_else(
-                || format!("auto ({})", self.mode.ef_search()),
+                || format!("auto ({})", self.mode.ef_search(10)),
                 |v| v.to_string(),
             )),
             "timeout_ms" | "timeout" => Some(self.timeout_ms.to_string()),
@@ -218,17 +217,59 @@ impl SessionSettings {
     }
 }
 
-fn parse_mode(value: &str) -> Result<SearchMode, String> {
-    match value.to_lowercase().as_str() {
-        "fast" => Ok(SearchMode::Fast),
-        "balanced" => Ok(SearchMode::Balanced),
-        "accurate" => Ok(SearchMode::Accurate),
-        "perfect" => Ok(SearchMode::Perfect),
-        _ => Err(format!(
-            "Invalid mode '{}'. Valid: fast, balanced, accurate, perfect",
-            value
-        )),
+/// Formats a `SearchQuality` for display in session settings.
+fn format_quality(q: SearchQuality) -> String {
+    match q {
+        SearchQuality::Fast => "fast".to_string(),
+        SearchQuality::Balanced => "balanced".to_string(),
+        SearchQuality::Accurate => "accurate".to_string(),
+        SearchQuality::Perfect => "perfect".to_string(),
+        SearchQuality::AutoTune => "autotune".to_string(),
+        SearchQuality::Custom(ef) => format!("custom:{ef}"),
+        SearchQuality::Adaptive { min_ef, max_ef } => {
+            format!("adaptive:{min_ef}:{max_ef}")
+        }
+        _ => format!("{q:?}").to_lowercase(),
     }
+}
+
+fn parse_mode(value: &str) -> Result<SearchQuality, String> {
+    let lower = value.to_lowercase();
+    match lower.as_str() {
+        "fast" => Ok(SearchQuality::Fast),
+        "balanced" => Ok(SearchQuality::Balanced),
+        "accurate" => Ok(SearchQuality::Accurate),
+        "perfect" => Ok(SearchQuality::Perfect),
+        "autotune" => Ok(SearchQuality::AutoTune),
+        _ => parse_parameterized_mode(&lower),
+    }
+}
+
+/// Parses `custom:<ef>` and `adaptive:<min>:<max>` mode strings.
+fn parse_parameterized_mode(value: &str) -> Result<SearchQuality, String> {
+    if let Some(ef_str) = value.strip_prefix("custom:") {
+        let ef = ef_str
+            .parse::<usize>()
+            .map_err(|_| format!("Invalid ef value in 'custom:{ef_str}'"))?;
+        return Ok(SearchQuality::Custom(ef));
+    }
+    if let Some(rest) = value.strip_prefix("adaptive:") {
+        let parts: Vec<&str> = rest.splitn(2, ':').collect();
+        if parts.len() != 2 {
+            return Err("adaptive format: adaptive:<min_ef>:<max_ef>".to_string());
+        }
+        let min_ef = parts[0]
+            .parse::<usize>()
+            .map_err(|_| format!("Invalid min_ef in '{value}'"))?;
+        let max_ef = parts[1]
+            .parse::<usize>()
+            .map_err(|_| format!("Invalid max_ef in '{value}'"))?;
+        return Ok(SearchQuality::Adaptive { min_ef, max_ef });
+    }
+    Err(format!(
+        "Invalid mode '{value}'. Valid: fast, balanced, accurate, \
+         perfect, autotune, custom:<ef>, adaptive:<min>:<max>"
+    ))
 }
 
 fn parse_bool(value: &str) -> Result<bool, String> {
@@ -249,7 +290,7 @@ mod tests {
     #[test]
     fn test_session_defaults() {
         let session = SessionSettings::new();
-        assert_eq!(session.mode(), SearchMode::Balanced);
+        assert_eq!(session.mode(), SearchQuality::Balanced);
         assert_eq!(session.effective_ef_search(), 160);
         assert_eq!(session.timeout_ms(), 30000);
         assert!(session.rerank());
@@ -261,7 +302,7 @@ mod tests {
     fn test_set_mode() {
         let mut session = SessionSettings::new();
         session.set("mode", "fast").unwrap();
-        assert_eq!(session.mode(), SearchMode::Fast);
+        assert_eq!(session.mode(), SearchQuality::Fast);
         assert_eq!(session.effective_ef_search(), 96);
     }
 
@@ -307,7 +348,7 @@ mod tests {
         let mut session = SessionSettings::new();
         session.set("mode", "fast").unwrap();
         session.reset(Some("mode"));
-        assert_eq!(session.mode(), SearchMode::Balanced);
+        assert_eq!(session.mode(), SearchQuality::Balanced);
     }
 
     #[test]
@@ -316,7 +357,7 @@ mod tests {
         session.set("mode", "fast").unwrap();
         session.set("ef_search", "512").unwrap();
         session.reset(None);
-        assert_eq!(session.mode(), SearchMode::Balanced);
+        assert_eq!(session.mode(), SearchQuality::Balanced);
         assert!(session.ef_search.is_none());
     }
 
@@ -340,5 +381,41 @@ mod tests {
         let mut session = SessionSettings::new();
         session.set("custom_key", "custom_value").unwrap();
         assert_eq!(session.get("custom_key"), Some("custom_value".to_string()));
+    }
+
+    #[test]
+    fn test_set_mode_autotune() {
+        let mut session = SessionSettings::new();
+        session.set("mode", "autotune").unwrap();
+        assert_eq!(session.mode(), SearchQuality::AutoTune);
+    }
+
+    #[test]
+    fn test_set_mode_custom() {
+        let mut session = SessionSettings::new();
+        session.set("mode", "custom:256").unwrap();
+        assert_eq!(session.mode(), SearchQuality::Custom(256));
+        assert_eq!(session.effective_ef_search(), 256);
+    }
+
+    #[test]
+    fn test_set_mode_adaptive() {
+        let mut session = SessionSettings::new();
+        session.set("mode", "adaptive:32:512").unwrap();
+        assert_eq!(
+            session.mode(),
+            SearchQuality::Adaptive {
+                min_ef: 32,
+                max_ef: 512
+            }
+        );
+    }
+
+    #[test]
+    fn test_set_mode_invalid() {
+        let mut session = SessionSettings::new();
+        assert!(session.set("mode", "nonexistent").is_err());
+        assert!(session.set("mode", "custom:abc").is_err());
+        assert!(session.set("mode", "adaptive:32").is_err());
     }
 }

--- a/crates/velesdb-wasm/src/fusion.rs
+++ b/crates/velesdb-wasm/src/fusion.rs
@@ -38,6 +38,8 @@ pub fn fuse_results(
     let mut fused: Vec<(u64, f32)> = match strategy.to_lowercase().as_str() {
         "average" | "avg" => fuse_average(&scores),
         "maximum" | "max" => fuse_maximum(&scores),
+        "weighted" => fuse_weighted(&scores, all_results.len()),
+        "relative_score" | "rsf" => fuse_relative_score(all_results),
         _ => fuse_rrf(&ranks, rrf_k),
     };
 
@@ -65,6 +67,50 @@ fn fuse_maximum(scores: &HashMap<u64, Vec<f32>>) -> Vec<(u64, f32)> {
             (*id, max)
         })
         .collect()
+}
+
+/// Weighted fusion: combines average score, max score, and hit ratio.
+///
+/// `score = 0.5 * avg + 0.3 * max + 0.2 * (hits / total_queries)`
+fn fuse_weighted(scores: &HashMap<u64, Vec<f32>>, total_queries: usize) -> Vec<(u64, f32)> {
+    scores
+        .iter()
+        .map(|(id, s)| {
+            let avg = s.iter().sum::<f32>() / s.len() as f32;
+            let max = s.iter().copied().fold(f32::NEG_INFINITY, f32::max);
+            let hit_ratio = s.len() as f32 / total_queries.max(1) as f32;
+            (*id, 0.5 * avg + 0.3 * max + 0.2 * hit_ratio)
+        })
+        .collect()
+}
+
+/// Relative Score Fusion: min-max normalizes each query independently.
+///
+/// Each query's scores are normalized to `[0, 1]`, then averaged per document.
+fn fuse_relative_score(all_results: &[Vec<(u64, f32)>]) -> Vec<(u64, f32)> {
+    let mut normalized: HashMap<u64, Vec<f32>> = HashMap::new();
+    for results in all_results {
+        let (min_s, max_s) = min_max_scores(results);
+        let range = max_s - min_s;
+        for &(id, score) in results {
+            let norm = if range > f32::EPSILON {
+                (score - min_s) / range
+            } else {
+                1.0
+            };
+            normalized.entry(id).or_default().push(norm);
+        }
+    }
+    fuse_average(&normalized)
+}
+
+/// Returns `(min, max)` scores from a result set.
+fn min_max_scores(results: &[(u64, f32)]) -> (f32, f32) {
+    results
+        .iter()
+        .fold((f32::INFINITY, f32::NEG_INFINITY), |(min, max), &(_, s)| {
+            (min.min(s), max.max(s))
+        })
 }
 
 /// Reciprocal Rank Fusion: position-based scoring.
@@ -140,5 +186,44 @@ mod tests {
 
         assert_eq!(fused.len(), 2);
         assert_eq!(fused[0].0, 1); // Higher RRF score (rank 0)
+    }
+
+    #[test]
+    fn test_fuse_weighted() {
+        let results = vec![vec![(1, 0.8), (2, 0.6)], vec![(1, 0.6), (2, 0.8)]];
+
+        let fused = fuse_results(&results, "weighted", 60);
+
+        // Both docs appear in 2/2 queries => hit_ratio = 1.0
+        // ID 1: avg=0.7, max=0.8 => 0.5*0.7 + 0.3*0.8 + 0.2*1.0 = 0.79
+        // ID 2: avg=0.7, max=0.8 => same
+        assert_eq!(fused.len(), 2);
+        for (_, score) in &fused {
+            assert!((score - 0.79).abs() < 0.01);
+        }
+    }
+
+    #[test]
+    fn test_fuse_relative_score() {
+        let results = vec![vec![(1, 0.9), (2, 0.1)], vec![(1, 0.5), (2, 0.5)]];
+
+        let fused = fuse_results(&results, "relative_score", 60);
+
+        // Query 0: range=0.8, ID 1 norm=(0.9-0.1)/0.8=1.0, ID 2 norm=0.0
+        // Query 1: range=0, both get 1.0 (default when range==0)
+        // ID 1: avg(1.0, 1.0)=1.0;  ID 2: avg(0.0, 1.0)=0.5
+        assert_eq!(fused.len(), 2);
+        assert_eq!(fused[0].0, 1);
+        assert!((fused[0].1 - 1.0).abs() < 0.01);
+        assert_eq!(fused[1].0, 2);
+        assert!((fused[1].1 - 0.5).abs() < 0.01);
+    }
+
+    #[test]
+    fn test_fuse_rsf_alias() {
+        let results = vec![vec![(1, 0.9), (2, 0.1)]];
+        let fused = fuse_results(&results, "rsf", 60);
+        // "rsf" should behave like "relative_score"
+        assert_eq!(fused.len(), 2);
     }
 }

--- a/sdks/typescript/src/types.ts
+++ b/sdks/typescript/src/types.ts
@@ -31,7 +31,7 @@ export interface VelesDBConfig {
 }
 
 /** Collection type */
-export type CollectionType = 'vector' | 'metadata_only';
+export type CollectionType = 'vector' | 'metadata_only' | 'graph';
 
 /** HNSW index parameters for collection creation */
 export interface HnswParams {


### PR DESCRIPTION
## Summary
- WASM: added Weighted + RelativeScore fusion with `fuse_weighted`, `fuse_relative_score` helpers + 3 tests
- CLI: added RelativeScore to `parse_fusion_strategy`, migrated SearchMode to SearchQuality (7 modes: fast/balanced/accurate/perfect/autotune/custom/adaptive) + 4 tests
- TS SDK: added `'graph'` to `CollectionType` union
- README: badge updated 4685 → 6242 tests (incl. 403 BDD)

## Audit finding
Resolves all propagation gaps from the final architecture audit

## Test plan
- [x] 7 new tests pass
- [x] `cargo check --workspace --exclude velesdb-python`
- [x] clippy clean on cli + wasm

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/556" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
