### PR TITLE
fix: green CI — resolve all clippy/test errors + complete unsafe SAFETY documentation

### DIFF
--- a/crates/velesdb-core/benches/dual_precision_benchmark.rs
+++ b/crates/velesdb-core/benches/dual_precision_benchmark.rs
@@ -147,7 +147,7 @@ fn bench_quantized_distance(c: &mut Criterion) {
     let v1: Vec<f32> = (0..dim).map(|i| (i as f32 * 0.01).sin()).collect();
     let v2: Vec<f32> = (0..dim).map(|i| (i as f32 * 0.01).cos()).collect();
 
-    let quantizer = ScalarQuantizer::train(&[&v1, &v2]);
+    let quantizer = ScalarQuantizer::train(&[&v1, &v2]).expect("bench: train quantizer");
     let q1 = quantizer.quantize(&v1);
     let q2 = quantizer.quantize(&v2);
 

--- a/crates/velesdb-core/benches/pq_recall_benchmark.rs
+++ b/crates/velesdb-core/benches/pq_recall_benchmark.rs
@@ -11,7 +11,7 @@
 //! neighbors, enabling HNSW (M=24, `ef_construction=300`, `ef_search=128`) to
 //! achieve recall@10 above 0.92, satisfying PQ-07.
 
-#![allow(clippy::cast_precision_loss)]
+#![allow(clippy::cast_precision_loss, clippy::doc_markdown)]
 
 use std::collections::{HashMap, HashSet};
 

--- a/crates/velesdb-core/benches/pq_recall_multidist.rs
+++ b/crates/velesdb-core/benches/pq_recall_multidist.rs
@@ -7,7 +7,7 @@
 //! Extends the uniform random coverage in `pq_recall_benchmark.rs` to validate
 //! HNSW+PQ behavior on realistic distribution shapes.
 
-#![allow(clippy::cast_precision_loss)]
+#![allow(clippy::cast_precision_loss, clippy::doc_markdown)]
 
 use std::collections::{HashMap, HashSet};
 use std::time::Duration;

--- a/crates/velesdb-core/benches/trigram_benchmark.rs
+++ b/crates/velesdb-core/benches/trigram_benchmark.rs
@@ -36,7 +36,7 @@ fn bench_trigram_insert(c: &mut Criterion) {
             b.iter(|| {
                 let mut index = TrigramIndex::new();
                 for (i, doc) in docs.iter().enumerate() {
-                    index.insert(i as u64, doc);
+                    let _ = index.insert(i as u64, doc);
                 }
                 black_box(index)
             });
@@ -53,7 +53,7 @@ fn bench_trigram_search(c: &mut Criterion) {
         let docs = generate_documents(size);
         let mut index = TrigramIndex::new();
         for (i, doc) in docs.iter().enumerate() {
-            index.insert(i as u64, doc);
+            let _ = index.insert(i as u64, doc);
         }
 
         group.bench_with_input(BenchmarkId::new("search_like", size), &index, |b, index| {
@@ -78,7 +78,7 @@ fn bench_trigram_vs_linear(c: &mut Criterion) {
     let docs = generate_documents(10_000);
     let mut index = TrigramIndex::new();
     for (i, doc) in docs.iter().enumerate() {
-        index.insert(i as u64, doc);
+        let _ = index.insert(i as u64, doc);
     }
 
     // With trigram index

--- a/crates/velesdb-core/src/collection/stats/tests.rs
+++ b/crates/velesdb-core/src/collection/stats/tests.rs
@@ -434,7 +434,7 @@ fn test_builder_default_buckets_on_zero() {
     let h = builder.build(&mut values);
     // With 1000 values and 64 buckets, we get ceil(1000/64)=16 per chunk → ~63 buckets
     assert!(h.buckets.len() <= 64);
-    assert!(h.buckets.len() > 0);
+    assert!(!h.buckets.is_empty());
     assert_eq!(h.total_count, 1000);
 }
 
@@ -679,13 +679,13 @@ fn test_zero_width_merge_preserves_count() {
 
     // First bucket: original non-zero-width (count=10), unchanged.
     assert_eq!(merged[0].count, 10);
-    assert_eq!(merged[0].lower_bound, 0.0);
+    assert!((merged[0].lower_bound - 0.0).abs() < f64::EPSILON);
     assert!((merged[0].upper_bound - 5.0).abs() < f64::EPSILON);
 
     // Second bucket: original (count=15) + absorbed zero-width (count=20) = 35.
     // The zero-width bucket is merged forward into the next non-zero-width bucket.
     assert_eq!(merged[1].count, 35);
-    assert_eq!(merged[1].lower_bound, 5.0);
+    assert!((merged[1].lower_bound - 5.0).abs() < f64::EPSILON);
     assert!((merged[1].upper_bound - 10.0).abs() < f64::EPSILON);
 
     // Total count preserved.

--- a/crates/velesdb-core/src/index/hnsw/native/graph/neighbors.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/graph/neighbors.rs
@@ -167,6 +167,7 @@ impl<D: DistanceEngine> NativeHnsw<D> {
         vectors: &crate::perf_optimizations::ContiguousVectors,
     ) {
         // SAFETY: new_node was just inserted, so new_node < vectors.len().
+        // - Condition 1: `new_node` index is valid because it was just registered in vectors.
         // Reason: Finding the most redundant neighbor (closest to new_node).
         let new_vec = unsafe { vectors.get_unchecked(new_node) };
 

--- a/crates/velesdb-core/src/index/trigram/tests.rs
+++ b/crates/velesdb-core/src/index/trigram/tests.rs
@@ -223,7 +223,7 @@ fn test_trigram_search_performance_10k() {
     // Insert 10K documents
     for i in 0..10_000u64 {
         let text = format!("document number {i} with some content");
-        index.insert(i, &text);
+        index.insert(i, &text).expect("test: insert");
     }
 
     // Search should be fast
@@ -377,9 +377,13 @@ fn test_threshold_pruning_performance() {
     // Insert 1000 documents, only 10% should match
     for i in 0..1000u64 {
         if i % 10 == 0 {
-            index.insert(i, &format!("matching document number {i}"));
+            index
+                .insert(i, &format!("matching document number {i}"))
+                .expect("test: insert");
         } else {
-            index.insert(i, &format!("other content {i}"));
+            index
+                .insert(i, &format!("other content {i}"))
+                .expect("test: insert");
         }
     }
 

--- a/crates/velesdb-core/src/index/trigram/thread_safety_tests.rs
+++ b/crates/velesdb-core/src/index/trigram/thread_safety_tests.rs
@@ -26,6 +26,10 @@ impl ConcurrentTrigramIndex {
     }
 
     /// Insert a document (write lock).
+    ///
+    /// # Panics
+    ///
+    /// Panics if the underlying `TrigramIndex::insert` returns an error (test-only code).
     pub fn insert(&self, doc_id: u64, text: &str) {
         self.inner
             .write()

--- a/crates/velesdb-core/src/internal_bench.rs
+++ b/crates/velesdb-core/src/internal_bench.rs
@@ -36,6 +36,9 @@ pub fn detected_simd_level() -> SimdLevel {
 pub fn cosine_avx2_2acc(a: &[f32], b: &[f32]) -> Option<f32> {
     if std::arch::is_x86_feature_detected!("avx2") && std::arch::is_x86_feature_detected!("fma") {
         // SAFETY: Feature detection above guarantees AVX2+FMA availability.
+        // - Condition 1: `is_x86_feature_detected!("avx2")` confirms AVX2 support.
+        // - Condition 2: `is_x86_feature_detected!("fma")` confirms FMA support.
+        // Reason: Direct call to AVX2 2-accumulator cosine kernel for benchmarking.
         Some(unsafe { crate::simd_native::cosine_fused_avx2_2acc(a, b) })
     } else {
         None
@@ -48,6 +51,9 @@ pub fn cosine_avx2_2acc(a: &[f32], b: &[f32]) -> Option<f32> {
 pub fn cosine_avx2_4acc(a: &[f32], b: &[f32]) -> Option<f32> {
     if std::arch::is_x86_feature_detected!("avx2") && std::arch::is_x86_feature_detected!("fma") {
         // SAFETY: Feature detection above guarantees AVX2+FMA availability.
+        // - Condition 1: `is_x86_feature_detected!("avx2")` confirms AVX2 support.
+        // - Condition 2: `is_x86_feature_detected!("fma")` confirms FMA support.
+        // Reason: Direct call to AVX2 4-accumulator cosine kernel for benchmarking.
         Some(unsafe { crate::simd_native::cosine_fused_avx2(a, b) })
     } else {
         None
@@ -60,6 +66,8 @@ pub fn cosine_avx2_4acc(a: &[f32], b: &[f32]) -> Option<f32> {
 pub fn cosine_avx512(a: &[f32], b: &[f32]) -> Option<f32> {
     if std::arch::is_x86_feature_detected!("avx512f") {
         // SAFETY: Feature detection above guarantees AVX-512F availability.
+        // - Condition 1: `is_x86_feature_detected!("avx512f")` confirms AVX-512F support.
+        // Reason: Direct call to AVX-512 cosine kernel for benchmarking.
         Some(unsafe { crate::simd_native::cosine_fused_avx512(a, b) })
     } else {
         None

--- a/crates/velesdb-core/src/perf_optimizations.rs
+++ b/crates/velesdb-core/src/perf_optimizations.rs
@@ -191,6 +191,9 @@ impl ContiguousVectors {
         // (`alloc_zeroed`) and resize (`AllocGuard::new_zeroed`) zero-initialize the buffer.
         // `count * dimension <= capacity * dimension`, `data` is non-null per `NonNull`
         // invariant. Even sparse `insert_at` gaps contain valid 0.0 f32 values.
+        // - Condition 1: `data` is a valid, aligned `NonNull<f32>` pointer.
+        // - Condition 2: `total <= capacity * dimension` ensures the slice is within the allocation.
+        // - Condition 3: All bytes in the allocation are initialized (zeroed or written).
         // Reason: Zero-copy GPU upload requires a contiguous &[f32] view.
         unsafe { std::slice::from_raw_parts(self.data.as_ptr(), total) }
     }

--- a/crates/velesdb-core/src/simd_native/adc.rs
+++ b/crates/velesdb-core/src/simd_native/adc.rs
@@ -67,6 +67,9 @@ pub(crate) fn adc_distances_batch(lut: &[f32], codes: &[&[u16]], m: usize) -> Ve
                     if i + 1 < codes.len() {
                         super::prefetch::prefetch_vector_from_u16(codes[i + 1]);
                     }
+                    // SAFETY: NEON is available (checked by `simd_level()` in outer match).
+                    // - Condition 1: `simd_level()` selected `Neon`, confirming aarch64 NEON support.
+                    // Reason: Call per-code NEON ADC kernel for throughput inside the iterator.
                     unsafe { adc_single_neon(lut, c, m, k) }
                 })
                 .collect()

--- a/crates/velesdb-core/src/simd_native/dispatch/mod.rs
+++ b/crates/velesdb-core/src/simd_native/dispatch/mod.rs
@@ -195,8 +195,14 @@ impl std::fmt::Debug for DistanceEngine {
 }
 
 // SAFETY: `DistanceEngine` stores only plain function pointers and a `usize`.
+// - Condition 1: All fields are `fn(...)` pointers and `usize`, both inherently `Send`.
+// - Condition 2: No interior mutability or non-`Send` types like `Rc`, raw pointers, or thread-local refs.
+// Reason: Function pointers are safe to transfer across threads.
 unsafe impl Send for DistanceEngine {}
 // SAFETY: Function pointers are immutable references to static code.
+// - Condition 1: All fields are `fn(...)` pointers and `usize`, both inherently `Sync`.
+// - Condition 2: No mutable shared state; the struct is read-only after construction.
+// Reason: Multiple threads can safely share a `&DistanceEngine` for distance computation.
 unsafe impl Sync for DistanceEngine {}
 
 impl DistanceEngine {

--- a/crates/velesdb-core/src/simd_native/neon.rs
+++ b/crates/velesdb-core/src/simd_native/neon.rs
@@ -114,6 +114,7 @@ fn dot_product_neon_4acc(a: &[f32], b: &[f32]) -> f32 {
     };
 
     // SAFETY: `vaddvq_f32` reduces a 128-bit register to a scalar f32 on aarch64.
+    // - Condition 1: NEON is always present on aarch64; `vaddvq_f32` is guaranteed available.
     // Reason: Horizontal reduction of the combined SIMD accumulator to a scalar result.
     let mut result = unsafe { vaddvq_f32(combined) };
 
@@ -150,10 +151,13 @@ pub(crate) fn cosine_neon(a: &[f32], b: &[f32]) -> f32 {
     if a.len() >= 64 {
         // SAFETY: `cosine_fused_neon_4acc` requires NEON (guaranteed on aarch64)
         // and len >= 64 (checked above).
+        // - Condition 1: NEON is always present on aarch64.
+        // - Condition 2: `a.len() >= 64` satisfies the 4-acc kernel's minimum length.
         // Reason: Delegate to the 4-accumulator ILP variant for large vectors.
         return unsafe { cosine_fused_neon_4acc(a, b) };
     }
     // SAFETY: `cosine_fused_neon_1acc` requires NEON (guaranteed on aarch64).
+    // - Condition 1: NEON is always present on aarch64.
     // Reason: Single-accumulator variant for small/medium vectors.
     unsafe { cosine_fused_neon_1acc(a, b) }
 }
@@ -383,6 +387,7 @@ pub(crate) fn squared_l2_neon(a: &[f32], b: &[f32]) -> f32 {
         return squared_l2_neon_4acc(a, b);
     }
     // SAFETY: `squared_l2_neon_1acc` requires NEON (guaranteed on aarch64).
+    // - Condition 1: NEON is always present on aarch64.
     // Reason: Single-accumulator variant for small/medium vectors.
     unsafe { squared_l2_neon_1acc(a, b) }
 }
@@ -472,6 +477,7 @@ fn squared_l2_neon_4acc(a: &[f32], b: &[f32]) -> f32 {
     };
 
     // SAFETY: `vaddvq_f32` reduces a 128-bit register to a scalar f32 on aarch64.
+    // - Condition 1: NEON is always present on aarch64; `vaddvq_f32` is guaranteed available.
     // Reason: Horizontal reduction of the combined SIMD accumulator to a scalar result.
     let mut result = unsafe { vaddvq_f32(combined) };
 
@@ -507,10 +513,13 @@ pub(crate) fn hamming_neon(a: &[f32], b: &[f32]) -> f32 {
     if a.len() >= 64 {
         // SAFETY: `hamming_neon_4acc` requires NEON (guaranteed on aarch64)
         // and len >= 64 (checked above).
+        // - Condition 1: NEON is always present on aarch64.
+        // - Condition 2: `a.len() >= 64` satisfies the 4-acc kernel's minimum length.
         // Reason: Delegate to the 4-accumulator ILP variant for large vectors.
         return unsafe { hamming_neon_4acc(a, b) };
     }
     // SAFETY: `hamming_neon_1acc` requires NEON (guaranteed on aarch64).
+    // - Condition 1: NEON is always present on aarch64.
     // Reason: Single-accumulator variant for small/medium vectors.
     unsafe { hamming_neon_1acc(a, b) }
 }
@@ -729,10 +738,13 @@ pub(crate) fn jaccard_neon(a: &[f32], b: &[f32]) -> f32 {
     if a.len() >= 64 {
         // SAFETY: `jaccard_neon_4acc` requires NEON (guaranteed on aarch64)
         // and len >= 64 (checked above).
+        // - Condition 1: NEON is always present on aarch64.
+        // - Condition 2: `a.len() >= 64` satisfies the 4-acc kernel's minimum length.
         // Reason: Delegate to the 4-accumulator ILP variant for large vectors.
         return unsafe { jaccard_neon_4acc(a, b) };
     }
     // SAFETY: `jaccard_neon_1acc` requires NEON (guaranteed on aarch64).
+    // - Condition 1: NEON is always present on aarch64.
     // Reason: Single-accumulator variant for small/medium vectors.
     unsafe { jaccard_neon_1acc(a, b) }
 }

--- a/crates/velesdb-core/src/simd_native/prefetch.rs
+++ b/crates/velesdb-core/src/simd_native/prefetch.rs
@@ -217,18 +217,24 @@ fn prefetch_multi_arm64(vector: &[f32]) {
     // Line 1 → L1 (offset 128B)
     if vector_bytes > ARM_CL {
         // SAFETY: Prefetch is a non-faulting hint; offset < vector_bytes.
+        // - Condition 1: `vector_bytes > ARM_CL` ensures offset is within allocation.
+        // Reason: Prefetch next cache line into L1 for spatial locality.
         let ptr = unsafe { base.add(ARM_CL) };
         crate::simd_neon_prefetch::prefetch_read_l1(ptr);
     }
     // Line 2 → L2 (offset 256B)
     if vector_bytes > ARM_CL * 2 {
-        // SAFETY: Same; offset 256 < vector_bytes.
+        // SAFETY: Prefetch is a non-faulting hint; offset < vector_bytes.
+        // - Condition 1: `vector_bytes > ARM_CL * 2` ensures offset is within allocation.
+        // Reason: Prefetch farther cache line into L2 for streaming access.
         let ptr = unsafe { base.add(ARM_CL * 2) };
         crate::simd_neon_prefetch::prefetch_read_l2(ptr);
     }
     // Line 3 → L3 (offset 512B)
     if vector_bytes > ARM_CL * 4 {
-        // SAFETY: Same; offset 512 < vector_bytes.
+        // SAFETY: Prefetch is a non-faulting hint; offset < vector_bytes.
+        // - Condition 1: `vector_bytes > ARM_CL * 4` ensures offset is within allocation.
+        // Reason: Prefetch distant cache line into L3 for large vector lookahead.
         let ptr = unsafe { base.add(ARM_CL * 4) };
         crate::simd_neon_prefetch::prefetch_read_l3(ptr);
     }

--- a/crates/velesdb-core/tests/bdd.rs
+++ b/crates/velesdb-core/tests/bdd.rs
@@ -1,5 +1,9 @@
 #![cfg(feature = "persistence")]
-#![allow(clippy::cast_precision_loss, clippy::uninlined_format_args)]
+#![allow(
+    clippy::cast_precision_loss,
+    clippy::uninlined_format_args,
+    clippy::doc_markdown
+)]
 
 #[path = "bdd/admin_operations.rs"]
 mod admin_operations;

--- a/crates/velesdb-core/tests/histogram_selectivity_bdd.rs
+++ b/crates/velesdb-core/tests/histogram_selectivity_bdd.rs
@@ -10,7 +10,8 @@
     clippy::cast_precision_loss,
     clippy::cast_possible_truncation,
     clippy::cast_lossless,
-    clippy::uninlined_format_args
+    clippy::uninlined_format_args,
+    clippy::doc_markdown
 )]
 
 use serde_json::json;
@@ -189,7 +190,7 @@ fn histogram_nominal_flow_analyze_and_explain() {
 #[test]
 fn histogram_incremental_maintenance_on_upsert_and_delete() {
     // GIVEN a collection with 100 points, ANALYZE called
-    let (_dir, db) = temp_database();
+    let (dir, db) = temp_database();
     db.create_collection("incremental", 4, DistanceMetric::Cosine)
         .expect("create");
     insert_scored_points(&db, "incremental", 1, 100);
@@ -221,7 +222,7 @@ fn histogram_incremental_maintenance_on_upsert_and_delete() {
 
     // THEN histogram bucket counts are updated (read from persisted stats on disk)
     // Incremental updates are written to collection.stats.json, not the in-memory cache.
-    let stats_after = load_persisted_stats(&_dir, "incremental");
+    let stats_after = load_persisted_stats(&dir, "incremental");
 
     let hist_after = stats_after
         .field_stats
@@ -250,7 +251,7 @@ fn histogram_incremental_maintenance_on_upsert_and_delete() {
     coll.delete(&ids_to_delete).expect("delete");
 
     // THEN histogram bucket counts are decremented
-    let stats_post_delete = load_persisted_stats(&_dir, "incremental");
+    let stats_post_delete = load_persisted_stats(&dir, "incremental");
 
     let hist_post_delete = stats_post_delete
         .field_stats

--- a/crates/velesdb-migrate/src/connectors/redis_tests.rs
+++ b/crates/velesdb-migrate/src/connectors/redis_tests.rs
@@ -212,7 +212,7 @@ fn test_parse_ft_search_response_single_doc() {
 fn test_parse_ft_search_response_zero_vector() {
     // Regression: all-zero vectors are valid UTF-8 (null bytes), so the old
     // UTF-8 heuristic failed to decode them. Verify they are decoded correctly.
-    let vec_bytes: Vec<u8> = std::iter::repeat(0u8).take(12).collect(); // 3 × f32 zeros
+    let vec_bytes: Vec<u8> = vec![0u8; 12]; // 3 × f32 zeros
 
     let resp = redis::Value::Array(vec![
         redis::Value::Int(1),

--- a/crates/velesdb-server/src/main.rs
+++ b/crates/velesdb-server/src/main.rs
@@ -236,6 +236,7 @@ async fn deprecation_header(
     response
 }
 
+#[allow(clippy::similar_names)] // Reason: `routes` (handler tree) and `router` (final router) are distinct concepts.
 fn build_router(
     state: Arc<AppState>,
     auth_state: AuthState,


### PR DESCRIPTION
## Summary

### CI fixes (36+ errors resolved):
- `TrigramIndex::insert()` Result handling in tests + benchmarks
- `ScalarQuantizer::train()` Result handling in benchmark
- Clippy pedantic: `similar_names`, `len_zero`, `float_cmp`, `doc_markdown`, `missing_panics_doc`
- WASM build: already passing

### SAFETY documentation (19 violations fixed):
- `internal_bench.rs` — 3 AVX2/AVX-512 blocks
- `perf_optimizations.rs` — `as_flat_slice` unsafe
- `neighbors.rs` — `get_unchecked`
- `neon.rs` — 10 NEON kernel blocks
- `prefetch.rs` — 3 cache-line prefetch blocks
- `dispatch/mod.rs` — Send/Sync impls
- `adc.rs` — NEON ADC kernel
- `verify_unsafe_safety_template.py --strict`: 0 violations (361 files scanned)

## Verification
- [x] `cargo fmt --all -- --check` PASS
- [x] `cargo clippy --workspace --all-targets --features persistence -- -D warnings -D clippy::pedantic` PASS (0 errors)
- [x] `cargo test -p velesdb-core --features persistence -- --test-threads=1` PASS (4577+ tests)
- [x] `cargo check -p velesdb-wasm --no-default-features --target wasm32-unknown-unknown` PASS
- [x] SAFETY template verification: 0 violations

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/557" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
