### PR TITLE
fix: ScrollResponse cursor as string + WASM fusion normalization alignment

### DIFF
--- a/crates/velesdb-core/src/api_types/responses.rs
+++ b/crates/velesdb-core/src/api_types/responses.rs
@@ -463,7 +463,10 @@ pub struct ListIndexesResponse {
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 pub struct ScrollRequest {
     /// Resume after this point ID (exclusive). Omit to start from beginning.
-    #[serde(default)]
+    #[serde(
+        default,
+        deserialize_with = "serde_id::deserialize_option_id_from_string_or_number"
+    )]
     pub cursor: Option<u64>,
     /// Maximum points per batch (1–10 000, default 100).
     #[serde(default = "default_scroll_batch_size")]
@@ -479,21 +482,28 @@ fn default_scroll_batch_size() -> u32 {
 }
 
 /// Response from the scroll endpoint.
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 pub struct ScrollResponse {
     /// Points in this batch (ascending ID order).
     pub points: Vec<ScrollPoint>,
     /// Cursor for the next batch. Null when iteration is complete.
+    #[serde(
+        serialize_with = "serde_id::serialize_option_id_as_string",
+        deserialize_with = "serde_id::deserialize_option_id_from_string_or_number"
+    )]
     pub next_cursor: Option<u64>,
 }
 
 /// A single point in a scroll response.
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 pub struct ScrollPoint {
     /// Point ID.
-    #[serde(serialize_with = "serde_id::serialize_id_as_string")]
+    #[serde(
+        serialize_with = "serde_id::serialize_id_as_string",
+        deserialize_with = "serde_id::deserialize_id_from_string_or_number"
+    )]
     pub id: u64,
     /// Vector data.
     pub vector: Vec<f32>,

--- a/crates/velesdb-core/src/api_types/serde_id.rs
+++ b/crates/velesdb-core/src/api_types/serde_id.rs
@@ -54,6 +54,38 @@ pub fn deserialize_id_from_string_or_number<'de, D: Deserializer<'de>>(
     deserializer.deserialize_any(IdVisitor)
 }
 
+/// Serializes an `Option<u64>` as a JSON string when `Some`, or `null` when `None`.
+///
+/// Emits `"12345"` for `Some(12345)` and `null` for `None`.
+///
+/// # Errors
+///
+/// Returns `S::Error` if the serializer rejects the value.
+pub fn serialize_option_id_as_string<S: Serializer>(
+    value: &Option<u64>,
+    serializer: S,
+) -> Result<S::Ok, S::Error> {
+    match value {
+        Some(id) => serializer.serialize_str(&id.to_string()),
+        None => serializer.serialize_none(),
+    }
+}
+
+/// Deserializes an `Option<u64>` from a JSON string, number, or null.
+///
+/// Accepts `"12345"` (string), `12345` (number), and `null` for backward
+/// compatibility with clients that have not yet migrated to string IDs.
+///
+/// # Errors
+///
+/// Returns `D::Error` if the input is present but not a valid u64 string
+/// or non-negative integer.
+pub fn deserialize_option_id_from_string_or_number<'de, D: Deserializer<'de>>(
+    deserializer: D,
+) -> Result<Option<u64>, D::Error> {
+    deserializer.deserialize_option(OptionIdVisitor)
+}
+
 /// Visitor that accepts either a JSON string or a JSON number as a `u64`.
 struct IdVisitor;
 
@@ -78,5 +110,28 @@ impl Visitor<'_> for IdVisitor {
         value
             .parse::<u64>()
             .map_err(|_| de::Error::invalid_value(Unexpected::Str(value), &"a u64 string"))
+    }
+}
+
+/// Visitor for `Option<u64>` that delegates to `IdVisitor` for `Some` values.
+struct OptionIdVisitor;
+
+impl<'de> Visitor<'de> for OptionIdVisitor {
+    type Value = Option<u64>;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("null, a u64 string, or a u64 number")
+    }
+
+    fn visit_none<E: de::Error>(self) -> Result<Self::Value, E> {
+        Ok(None)
+    }
+
+    fn visit_some<D: Deserializer<'de>>(self, deserializer: D) -> Result<Self::Value, D::Error> {
+        deserializer.deserialize_any(IdVisitor).map(Some)
+    }
+
+    fn visit_unit<E: de::Error>(self) -> Result<Self::Value, E> {
+        Ok(None)
     }
 }

--- a/crates/velesdb-core/src/api_types/tests.rs
+++ b/crates/velesdb-core/src/api_types/tests.rs
@@ -839,3 +839,85 @@ fn scroll_point_small_id_serialized_as_string() {
     let json = serde_json::to_value(&point).unwrap();
     assert_eq!(json["id"], json!("42"));
 }
+
+// ============================================================================
+// G. ScrollResponse::next_cursor serialization as string [BUG PR #554]
+// ============================================================================
+
+/// `next_cursor` above 2^53 must serialize as a JSON string, not a number.
+#[test]
+fn scroll_response_next_cursor_serialized_as_string() {
+    let above_safe = (1_u64 << 53) + 1; // 9_007_199_254_740_993
+    let resp = ScrollResponse {
+        points: vec![],
+        next_cursor: Some(above_safe),
+    };
+    let json = serde_json::to_value(&resp).unwrap();
+    assert_eq!(
+        json["next_cursor"],
+        json!("9007199254740993"),
+        "next_cursor must serialize as a JSON string for JS precision safety"
+    );
+}
+
+/// `next_cursor: None` serializes as JSON null.
+#[test]
+fn scroll_response_next_cursor_none_serialized_as_null() {
+    let resp = ScrollResponse {
+        points: vec![],
+        next_cursor: None,
+    };
+    let json = serde_json::to_value(&resp).unwrap();
+    assert!(json["next_cursor"].is_null());
+}
+
+/// Round-trip: `ScrollResponse` with cursor = 2^53 + 1 preserves exact value.
+#[test]
+fn scroll_response_cursor_round_trip_above_max_safe_integer() {
+    let above_safe = (1_u64 << 53) + 1;
+    let original = ScrollResponse {
+        points: vec![ScrollPoint {
+            id: 1,
+            vector: vec![0.1],
+            payload: None,
+        }],
+        next_cursor: Some(above_safe),
+    };
+    let serialized = serde_json::to_value(&original).unwrap();
+    assert_eq!(serialized["next_cursor"], json!("9007199254740993"));
+
+    let deserialized: ScrollResponse = serde_json::from_value(serialized).unwrap();
+    assert_eq!(deserialized.next_cursor, Some(above_safe));
+    assert_eq!(deserialized.points.len(), 1);
+    assert_eq!(deserialized.points[0].id, 1);
+}
+
+/// `ScrollRequest::cursor` accepts a string ID from JS clients.
+#[test]
+fn scroll_request_cursor_accepts_string_id() {
+    let input = json!({
+        "cursor": "9007199254740993",
+        "batch_size": 50
+    });
+    let req: ScrollRequest = serde_json::from_value(input).unwrap();
+    assert_eq!(req.cursor, Some((1_u64 << 53) + 1));
+    assert_eq!(req.batch_size, 50);
+}
+
+/// `ScrollRequest::cursor` accepts a numeric ID (backward compat).
+#[test]
+fn scroll_request_cursor_accepts_number_id() {
+    let input = json!({
+        "cursor": 42
+    });
+    let req: ScrollRequest = serde_json::from_value(input).unwrap();
+    assert_eq!(req.cursor, Some(42));
+}
+
+/// `ScrollRequest::cursor` accepts null / absent (start from beginning).
+#[test]
+fn scroll_request_cursor_accepts_null() {
+    let input = json!({});
+    let req: ScrollRequest = serde_json::from_value(input).unwrap();
+    assert_eq!(req.cursor, None);
+}

--- a/crates/velesdb-wasm/src/fusion.rs
+++ b/crates/velesdb-wasm/src/fusion.rs
@@ -87,6 +87,14 @@ fn fuse_weighted(scores: &HashMap<u64, Vec<f32>>, total_queries: usize) -> Vec<(
 /// Relative Score Fusion: min-max normalizes each query independently.
 ///
 /// Each query's scores are normalized to `[0, 1]`, then averaged per document.
+/// When all scores in a branch are equal (range < epsilon), the normalized
+/// value defaults to 0.5 — consistent with the core engine's
+/// `min_max_normalize` in `crates/velesdb-core/src/fusion/strategy.rs`.
+///
+/// **Note:** This WASM implementation is a simplified approximation of the
+/// core `RelativeScore` strategy. The core version is designed for exactly
+/// two branches (dense + sparse) with explicit weights. This WASM version
+/// averages across N branches with equal weights.
 fn fuse_relative_score(all_results: &[Vec<(u64, f32)>]) -> Vec<(u64, f32)> {
     let mut normalized: HashMap<u64, Vec<f32>> = HashMap::new();
     for results in all_results {
@@ -96,7 +104,7 @@ fn fuse_relative_score(all_results: &[Vec<(u64, f32)>]) -> Vec<(u64, f32)> {
             let norm = if range > f32::EPSILON {
                 (score - min_s) / range
             } else {
-                1.0
+                0.5
             };
             normalized.entry(id).or_default().push(norm);
         }
@@ -210,13 +218,13 @@ mod tests {
         let fused = fuse_results(&results, "relative_score", 60);
 
         // Query 0: range=0.8, ID 1 norm=(0.9-0.1)/0.8=1.0, ID 2 norm=0.0
-        // Query 1: range=0, both get 1.0 (default when range==0)
-        // ID 1: avg(1.0, 1.0)=1.0;  ID 2: avg(0.0, 1.0)=0.5
+        // Query 1: range=0, both get 0.5 (default when range==0, matches core)
+        // ID 1: avg(1.0, 0.5)=0.75;  ID 2: avg(0.0, 0.5)=0.25
         assert_eq!(fused.len(), 2);
         assert_eq!(fused[0].0, 1);
-        assert!((fused[0].1 - 1.0).abs() < 0.01);
+        assert!((fused[0].1 - 0.75).abs() < 0.01);
         assert_eq!(fused[1].0, 2);
-        assert!((fused[1].1 - 0.5).abs() < 0.01);
+        assert!((fused[1].1 - 0.25).abs() < 0.01);
     }
 
     #[test]
@@ -225,5 +233,25 @@ mod tests {
         let fused = fuse_results(&results, "rsf", 60);
         // "rsf" should behave like "relative_score"
         assert_eq!(fused.len(), 2);
+    }
+
+    /// BUG regression (PR #556): when all scores in a branch are equal
+    /// (range ~ 0), the normalized value must be 0.5 — consistent with
+    /// the core engine's `min_max_normalize`.
+    #[test]
+    fn test_fuse_relative_score_equal_scores_default_half() {
+        // All scores identical within each branch → range ≈ 0
+        let results = vec![vec![(1, 0.7), (2, 0.7)], vec![(1, 0.3), (2, 0.3)]];
+
+        let fused = fuse_results(&results, "relative_score", 60);
+
+        // Both branches collapse to 0.5 per document → avg = 0.5
+        assert_eq!(fused.len(), 2);
+        for (_, score) in &fused {
+            assert!(
+                (score - 0.5).abs() < 0.01,
+                "equal-score branch must normalize to 0.5, got {score}"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary
3 real bugs from Devin review on PRs #554 and #556:

1. **ScrollResponse::next_cursor** not serialized as string — added `serialize_option_id_as_string` + `deserialize_option_id_from_string_or_number` helpers, annotated cursor fields. 7 tests.
2. **WASM fuse_relative_score** equal-score default 1.0 → 0.5 — aligned with core `min_max_normalize` behavior
3. **WASM RelativeScore** documented as simplified N-branch approximation of core's 2-branch weighted strategy

## Test plan
- [x] 13 scroll tests pass
- [x] 10 WASM fusion tests pass
- [x] clippy clean

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/558" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
