### PR TITLE
docs(sdks): update all SDK READMEs with scroll, relative_score, search_with_ef, py.typed

### DIFF
--- a/crates/velesdb-python/README.md
+++ b/crates/velesdb-python/README.md
@@ -285,6 +285,12 @@ count = collection.stream_insert([
     {"id": 100, "vector": [...], "payload": {"key": "value"}}
 ])
 
+# Scroll through all points in stable batches (no vector required)
+# Useful for export, reindexing, or full-collection inspection.
+for batch in collection.scroll(batch_size=100, filter=None):
+    for point in batch:
+        print(point["id"], point["payload"])
+
 # MATCH graph traversal query (VelesQL)
 results = collection.match_query(
     "MATCH (a:Person)-[:KNOWS]->(b:Person) RETURN a.name, b.name",

--- a/crates/velesdb-python/python/velesdb/__init__.py
+++ b/crates/velesdb-python/python/velesdb/__init__.py
@@ -166,7 +166,9 @@ class Collection:
 
         Args:
             vector: Query vector (list or numpy array).
-            quality: One of 'fast', 'balanced', 'accurate', 'perfect', 'autotune'.
+            quality: One of 'fast', 'balanced', 'accurate', 'perfect', 'autotune',
+                     'custom:<ef>' (e.g. 'custom:256'), or 'adaptive:<min>:<max>'
+                     (e.g. 'adaptive:32:512').
             top_k: Number of results (default: 10).
 
         Returns:

--- a/integrations/common/README.md
+++ b/integrations/common/README.md
@@ -16,6 +16,21 @@ Shared utilities for [VelesDB](https://github.com/cyberlife-coder/VelesDB) Pytho
 - **Graph helpers** — REST payload builders and native graph bindings
 - **Memory formatting** — procedural memory result formatting
 
+## Public Exports
+
+The following symbols form the stable internal API consumed by `langchain-velesdb`
+and `llama-index-vector-stores-velesdb`. They are not intended for direct use by
+end users.
+
+| Export | Type | Description |
+|--------|------|-------------|
+| `build_fusion_strategy` | function | Converts a strategy name + params dict into the native `FusionStrategy` object |
+| `validate_url` | function | Validates a server URL string; raises `ValueError` on malformed input |
+| `validate_text` | function | Sanitizes free-text query strings against injection patterns |
+| `validate_collection_name` | function | Ensures a collection name meets naming rules (alphanumeric + underscore, ≤ 64 chars) |
+| `CollectionAdminMixin` | class | Mixin providing shared admin operations (`flush`, `get_collection_info`, `is_empty`) |
+| `GraphOpsBase` | class | Base class for graph query helpers used by both integrations |
+
 ## License
 
 MIT License (this integration). See [LICENSE](https://github.com/cyberlife-coder/VelesDB/blob/main/integrations/common/LICENSE) for details.

--- a/integrations/langchain/README.md
+++ b/integrations/langchain/README.md
@@ -102,6 +102,7 @@ VelesDBVectorStore(
 - `from_texts(texts, embedding, ...)` - Create store from texts (class method)
 - `get_collection_info()` - Get collection metadata (name, dimension, point_count)
 - `is_empty()` - Check if collection is empty
+- `scroll(batch_size=100, filter=None)` - Iterate over all points in stable batches without a query vector
 
 ## Advanced Features
 
@@ -144,6 +145,39 @@ for doc, score in results_with_scores:
 - `"average"` - Mean score across all queries
 - `"maximum"` - Maximum score from any query
 - `"weighted"` - Custom combination of avg, max, and hit ratio
+- `"relative_score"` - Linear blend of dense and sparse scores
+
+```python
+# Relative Score Fusion — explicit control over dense vs sparse weight
+results = vectorstore.multi_query_search(
+    queries=["semantic search", "keyword retrieval"],
+    k=10,
+    fusion="relative_score",
+    fusion_params={"dense_weight": 0.7, "sparse_weight": 0.3}
+)
+```
+
+### Advanced Search
+
+#### `similarity_search_with_ef(query, ef_search, k)`
+
+Search with an explicit HNSW `ef_search` parameter to trade query latency for recall.
+Higher `ef_search` increases recall at the cost of slower search.
+
+```python
+# Use a high ef_search for maximum recall at query time
+results = vectorstore.similarity_search_with_ef(
+    query="machine learning",
+    ef_search=256,
+    k=10
+)
+```
+
+### Server Mode: URL Validation
+
+When connecting to a remote `velesdb-server` via the `url` parameter,
+`validate_url` is called automatically during initialization to reject
+malformed URLs before any network request is issued.
 
 ### Hybrid Search (Vector + BM25)
 

--- a/integrations/llamaindex/README.md
+++ b/integrations/llamaindex/README.md
@@ -102,6 +102,7 @@ VelesDBVectorStore(
 | **Utilities** | |
 | `get_collection_info()` | Get collection metadata |
 | `is_empty()` | Check if collection is empty |
+| `scroll(batch_size, filter)` | Iterate all points in stable batches without a query vector |
 
 ## Advanced Features
 
@@ -143,6 +144,48 @@ for node in results.nodes:
 - `"average"` - Mean score across all queries
 - `"maximum"` - Maximum score from any query
 - `"weighted"` - Custom combination of avg, max, and hit ratio
+- `"relative_score"` - Linear blend of dense and sparse scores
+
+```python
+# Relative Score Fusion
+results = vector_store.multi_query_search(
+    query_embeddings=[emb1, emb2],
+    similarity_top_k=10,
+    fusion="relative_score",
+    fusion_params={"dense_weight": 0.7, "sparse_weight": 0.3}
+)
+```
+
+### Advanced Search
+
+#### `query_with_ef(query_embedding, ef_search, top_k)`
+
+Search with an explicit HNSW `ef_search` parameter to trade query latency for recall.
+
+```python
+# Higher ef_search = better recall, slower query
+results = vector_store.query_with_ef(
+    query_embedding=embedding,
+    ef_search=256,
+    top_k=10
+)
+```
+
+#### `query_ids(query_embedding, top_k)`
+
+Search returning only node IDs and scores — no payloads transferred.
+Faster than `query()` when only IDs are needed (e.g., for post-processing pipelines).
+
+```python
+hits = vector_store.query_ids(query_embedding=embedding, top_k=50)
+# [{"id": "abc", "score": 0.92}, ...]
+```
+
+### Server Mode: URL Validation
+
+When connecting to a remote `velesdb-server` via the `path` parameter as a URL,
+`validate_url` is called automatically during initialization to reject
+malformed URLs before any network request is issued.
 
 ### Hybrid Search (Vector + BM25)
 

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -119,6 +119,11 @@ const results = await db.search('products', queryVector, { k: 10 });
 
 > **REST backend note:** Document IDs must be numeric integers in the range `0..Number.MAX_SAFE_INTEGER`. String IDs are only supported with the WASM backend.
 
+> **Versioned routes:** The REST backend uses `/v1/` as the canonical route prefix
+> (e.g. `POST /v1/collections/{name}/search`). Legacy routes without the prefix
+> are accepted for backward compatibility but are deprecated and will be removed
+> in a future major version. Always target `/v1/` in custom HTTP clients.
+
 ## API Reference
 
 ### Client
@@ -297,6 +302,39 @@ const hits = await db.searchIds('docs', queryVector, { k: 100 });
 // Returns: Array<{ id: number, score: number }>
 ```
 
+#### `db.scroll(collection, request)`
+
+Iterate over all points in a collection in stable, paginated batches without a
+query vector. Useful for export pipelines, re-embedding, and full-collection
+inspection. Pagination is cursor-based — pass the `nextOffset` from each
+`ScrollResponse` until it is `null`.
+
+```typescript
+import { ScrollRequest, ScrollResponse } from '@wiscale/velesdb-sdk';
+
+let offset: number | null = 0;
+while (offset !== null) {
+  const page: ScrollResponse = await db.scroll('docs', {
+    batchSize: 100,
+    offset,
+    filter: { category: 'tech' },  // optional payload filter
+    withVectors: false,             // set true to include raw vectors
+  } satisfies ScrollRequest);
+
+  for (const point of page.points) {
+    console.log(point.id, point.payload);
+  }
+  offset = page.nextOffset;
+}
+```
+
+| Field (`ScrollRequest`) | Type | Default | Description |
+|-------------------------|------|---------|-------------|
+| `batchSize` | `number` | `100` | Points per page |
+| `offset` | `number \| null` | `0` | Cursor from previous `ScrollResponse.nextOffset` |
+| `filter` | `object` | - | Optional payload filter expression |
+| `withVectors` | `boolean` | `false` | Include raw vectors in each point |
+
 #### `db.textSearch(collection, query, options?)`
 
 Full-text search using BM25 scoring.
@@ -325,7 +363,7 @@ Multi-query fusion search for RAG pipelines using Multiple Query Generation (MQG
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `k` | `number` | `10` | Number of results |
-| `fusion` | `'rrf' \| 'average' \| 'maximum' \| 'weighted'` | `'rrf'` | Fusion strategy |
+| `fusion` | `'rrf' \| 'average' \| 'maximum' \| 'weighted' \| 'relative_score'` | `'rrf'` | Fusion strategy |
 | `fusionParams` | `object` | `{ k: 60 }` | Strategy-specific parameters |
 | `filter` | `object` | - | Payload filter expression |
 
@@ -343,9 +381,16 @@ const results = await db.multiQuerySearch('docs', [emb1, emb2], {
   fusion: 'weighted',
   fusionParams: { avgWeight: 0.6, maxWeight: 0.3, hitWeight: 0.1 }
 });
+
+// Relative Score Fusion — linear blend of dense and sparse scores
+const results = await db.multiQuerySearch('docs', [emb1, emb2], {
+  k: 10,
+  fusion: 'relative_score',
+  fusionParams: { denseWeight: 0.7, sparseWeight: 0.3 }
+});
 ```
 
-> **Note:** WASM supports `rrf`, `average`, `maximum`. The `weighted` strategy is REST-only.
+> **Note:** WASM supports `rrf`, `average`, `maximum`. The `weighted` and `relative_score` strategies are REST-only.
 
 ---
 


### PR DESCRIPTION
## Summary
- Python SDK: `search_with_quality` docstring updated with custom/adaptive modes, scroll() added
- LangChain README: +scroll, +relative_score fusion, +similarity_search_with_ef, +validate_url note
- LlamaIndex README: +scroll, +relative_score, +query_with_ef, +query_ids, +validate_url
- Common README: public exports table (build_fusion_strategy, validators, mixins)
- TypeScript README: +scroll section, +relative_score in fusion table, +/v1/ prefix note

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/559" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
