### PR TITLE
docs: update ERROR_CODES, api-reference, CONFIGURATION, STORAGE_FORMAT, ECOSYSTEM_PARITY, README badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
   <a href="https://pypi.org/project/velesdb/"><img src="https://img.shields.io/pypi/v/velesdb.svg" alt="PyPI"></a>
   <a href="https://www.npmjs.com/package/@wiscale/velesdb-sdk"><img src="https://img.shields.io/npm/v/@wiscale/velesdb-sdk.svg" alt="npm"></a>
   <a href="https://app.codacy.com/gh/cyberlife-coder/VelesDB/dashboard"><img src="https://app.codacy.com/project/badge/Coverage/58c73832dd294ba38144856ae69e9cf2" alt="Coverage"></a>
-  <img src="https://img.shields.io/badge/tests-6242_(incl._403_BDD)-brightgreen" alt="Tests">
+  <img src="https://img.shields.io/badge/tests-6562_(incl._606_BDD)-brightgreen" alt="Tests">
   <a href="https://github.com/cyberlife-coder/VelesDB/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-VelesDB_Core_1.0-blue" alt="License"></a>
   <a href="https://github.com/cyberlife-coder/VelesDB"><img src="https://img.shields.io/github/stars/cyberlife-coder/VelesDB?style=flat-square" alt="Stars"></a>
   <a href="https://img.shields.io/badge/contributors-welcome-brightgreen"><img src="https://img.shields.io/badge/contributors-welcome-brightgreen" alt="Contributors Welcome"></a>

--- a/docs/STORAGE_FORMAT.md
+++ b/docs/STORAGE_FORMAT.md
@@ -31,12 +31,35 @@ collection_directory/
 {
   "dimension": 128,
   "distance_metric": "cosine",
+  "schema_version": 1,
   "hnsw_config": {
     "m": 16,
     "ef_construction": 100
   }
 }
 ```
+
+### Fields
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `dimension` | u32 | — | Vector dimension |
+| `distance_metric` | string | `"cosine"` | Distance metric |
+| `schema_version` | u32 | `1` | On-disk format version (see below) |
+| `hnsw_config` | object | — | HNSW index parameters |
+
+### schema_version
+
+The `schema_version` field tracks the on-disk format version for forward-compatibility protection.
+
+| Value | Behavior |
+|-------|----------|
+| absent | Treated as `1` (backward compatibility with pre-versioned collections) |
+| `0` | Treated as `1` (backward compatibility) |
+| `1` | Current version -- normal operation |
+| `> CURRENT_SCHEMA_VERSION` | Rejected with `VELES-036 IncompatibleSchemaVersion` |
+
+This field is validated at collection load time (`Collection::open()`). When a newer VelesDB writes a collection with a higher schema version, older binaries refuse to open it rather than silently corrupting data. The current schema version is defined as `CURRENT_SCHEMA_VERSION = 1` in `crates/velesdb-core/src/collection/types.rs`.
 
 ## Vector Storage (vectors.bin)
 
@@ -222,7 +245,7 @@ All multi-byte integers are stored in **little-endian** format.
 
 ### Format Version
 
-Currently implicit (v1.0.0). Future versions will include explicit version headers.
+Explicit via `schema_version` in `config.json` (current: v1). See [schema_version](#schema_version) above.
 
 ### Compatibility Rules
 

--- a/docs/guides/CONFIGURATION.md
+++ b/docs/guides/CONFIGURATION.md
@@ -190,6 +190,10 @@ data_dir = "./velesdb_data"
 # Default: 30
 shutdown_timeout_secs = 30
 
+# Rate limit: requêtes max par seconde par IP (0 = désactivé)
+# Default: 100
+rate_limit = 100
+
 # Nombre de workers (threads)
 # Range: 1 - 256
 # Default: nombre de CPUs
@@ -320,6 +324,7 @@ All options can be set via environment variables with the `VELESDB_` prefix:
 | `VELESDB_HOST` | `server.host` | `0.0.0.0` |
 | `VELESDB_PORT` | `server.port` | `8080` |
 | `VELESDB_DATA_DIR` | `server.data_dir` | `/var/lib/velesdb` |
+| `VELESDB_RATE_LIMIT` | `server.rate_limit` | `100` |
 | `VELESDB_API_KEYS` | `auth.api_keys` | `key1,key2,key3` (comma-separated) |
 | `VELESDB_TLS_CERT` | `tls.cert` | `/etc/ssl/cert.pem` |
 | `VELESDB_TLS_KEY` | `tls.key` | `/etc/ssl/key.pem` |
@@ -441,6 +446,7 @@ SELECT * FROM docs WHERE vector NEAR $v WITH (ef_search = 512);
 | `shutdown_timeout_secs` | int | — | — | `30` | Connection drain timeout (seconds) |
 | `workers` | int | — | — | `0` | Workers (0=auto) |
 | `max_body_size` | int | — | — | `104857600` | Max body (bytes) |
+| `rate_limit` | int | `VELESDB_RATE_LIMIT` | `--rate-limit` | `100` | Max req/s per IP (0=disabled) |
 | `cors_enabled` | bool | — | — | `false` | Enable CORS |
 | `cors_origins` | array | — | — | `["*"]` | CORS origins |
 
@@ -636,6 +642,88 @@ velesdb config show
 
 # Générer un fichier de configuration par défaut
 velesdb config init > velesdb.toml
+```
+
+---
+
+## Rate Limiting
+
+VelesDB Server includes per-IP rate limiting backed by a token-bucket algorithm (`tower-governor`). The rate limiter uses `SmartIpKeyExtractor`, which inspects `x-forwarded-for`, `x-real-ip`, and `forwarded` headers before falling back to the peer IP, making it safe behind reverse proxies.
+
+### Configuration
+
+| Source | Setting | Example |
+|--------|---------|---------|
+| CLI | `--rate-limit N` | `velesdb-server --rate-limit 200` |
+| Environment | `VELESDB_RATE_LIMIT` | `VELESDB_RATE_LIMIT=200` |
+| TOML | `[server] rate_limit` | `rate_limit = 200` |
+
+- **Default**: `100` (requests per second per IP)
+- **Disable**: Set to `0` to disable rate limiting entirely
+
+### Behavior
+
+When a client exceeds the limit, the server responds with HTTP `429 Too Many Requests` and includes rate-limit headers:
+
+| Header | Description |
+|--------|-------------|
+| `x-ratelimit-limit` | Maximum requests allowed per second |
+| `x-ratelimit-remaining` | Remaining requests in the current window |
+| `x-ratelimit-after` | Seconds until the bucket refills |
+| `retry-after` | Seconds to wait before retrying (only on 429) |
+
+A background thread prunes stale IP entries from the rate limiter map every 60 seconds.
+
+### Examples
+
+```toml
+# Production: 200 req/s per IP
+[server]
+rate_limit = 200
+
+# Development: disabled
+[server]
+rate_limit = 0
+```
+
+```bash
+# CLI override
+velesdb-server --rate-limit 50
+
+# Environment override
+VELESDB_RATE_LIMIT=0 velesdb-server
+```
+
+---
+
+## Schema Versioning
+
+Each collection's `config.json` includes a `schema_version` field (type `u32`) that tracks the on-disk format version. This prevents a newer VelesDB from writing data that an older version cannot read.
+
+### Behavior
+
+| Condition | Result |
+|-----------|--------|
+| `schema_version` absent or `0` | Treated as `1` (backward compatibility with pre-versioned collections) |
+| `schema_version` equals current | Normal operation |
+| `schema_version` > current | Error `VELES-036 IncompatibleSchemaVersion` -- upgrade VelesDB to open this collection |
+
+- **Current version**: `1` (defined as `CURRENT_SCHEMA_VERSION` in `crates/velesdb-core/src/collection/types.rs`)
+- The version is validated at collection load time, before any data is read or modified
+- The `VELES-036` error is **not recoverable** -- the only resolution is to upgrade VelesDB
+
+### config.json Example
+
+```json
+{
+  "dimension": 768,
+  "distance_metric": "cosine",
+  "schema_version": 1,
+  "hnsw_config": {
+    "m": 16,
+    "ef_construction": 100
+  }
+}
 ```
 
 ---

--- a/docs/reference/ECOSYSTEM_PARITY.md
+++ b/docs/reference/ECOSYSTEM_PARITY.md
@@ -1,6 +1,6 @@
 # VelesQL Ecosystem Parity Matrix
 
-Last updated: 2026-04-04 (v1.11.1)
+Last updated: 2026-04-08 (v1.12.0)
 
 This matrix tracks runtime contract and feature parity across the VelesDB ecosystem.
 
@@ -87,6 +87,109 @@ Legend: ✅ full support | ⚠️ partial / limited | ❌ not supported | N/A no
 | CLI parser | `conformance/velesql_parser_cases.json` | `crates/velesdb-cli/tests/velesql_parser_conformance.rs` |
 | WASM parser | `conformance/velesql_parser_cases.json` | `crates/velesdb-wasm/tests/velesql_parser_conformance.rs` |
 
+## Enum Propagation Matrix
+
+Tracks whether core enums are fully propagated to each ecosystem component.
+
+Legend: ✅ full (all variants) | N/A not applicable (brute-force only, no HNSW)
+
+### DistanceMetric — 9/9 (100%)
+
+All 5 variants (`Cosine`, `Euclidean`, `DotProduct`, `Hamming`, `Jaccard`) are supported in all 9 components.
+
+| Component | Status |
+|-----------|--------|
+| Core | ✅ (source of truth) |
+| Server | ✅ |
+| Python | ✅ |
+| WASM | ✅ |
+| Mobile | ✅ |
+| CLI | ✅ |
+| TS SDK | ✅ |
+| Tauri | ✅ |
+| LangChain | ✅ |
+| LlamaIndex | ✅ |
+
+### StorageMode — 9/9 (100%)
+
+All 5 variants (`Full`, `SQ8`, `Binary`, `ProductQuantization`, `RaBitQ`) are supported in all 9 components.
+
+| Component | Status |
+|-----------|--------|
+| Core | ✅ (source of truth) |
+| Server | ✅ |
+| Python | ✅ |
+| WASM | ✅ |
+| Mobile | ✅ |
+| CLI | ✅ |
+| TS SDK | ✅ |
+| Tauri | ✅ |
+| LangChain | ✅ |
+| LlamaIndex | ✅ |
+
+### FusionStrategy — 9/9 (100%)
+
+All 4 strategies (`RRF`, `Weighted`, `Maximum`, `RSF`) plus `Average` are supported in all 9 components.
+
+| Component | Status |
+|-----------|--------|
+| Core | ✅ (source of truth) |
+| Server | ✅ |
+| Python | ✅ |
+| WASM | ✅ |
+| Mobile | ✅ |
+| CLI | ✅ |
+| TS SDK | ✅ |
+| Tauri | ✅ |
+| LangChain | ✅ |
+| LlamaIndex | ✅ |
+
+### SearchQuality — 6/9
+
+4 HNSW presets (`Fast`, `Balanced`, `Accurate`, `Perfect`) plus `Custom(usize)` and `Adaptive`. WASM, Mobile, and Tauri use brute-force search (no HNSW), so `SearchQuality` is not applicable.
+
+| Component | Status | Notes |
+|-----------|--------|-------|
+| Core | ✅ (source of truth) | |
+| Server | ✅ | |
+| Python | ✅ | |
+| WASM | N/A | Brute-force only, no HNSW index |
+| Mobile | N/A | Brute-force only, no HNSW index |
+| CLI | ✅ | |
+| TS SDK | ✅ | |
+| Tauri | N/A | Brute-force only, no HNSW index |
+| LangChain | ✅ | |
+| LlamaIndex | ✅ | |
+
+### CollectionType — 8/9
+
+3 types (`Vector`, `MetadataOnly`, `Graph`). Mobile does not expose graph collection creation.
+
+| Component | Status | Notes |
+|-----------|--------|-------|
+| Core | ✅ (source of truth) | |
+| Server | ✅ | |
+| Python | ✅ | |
+| WASM | ✅ | |
+| Mobile | ⚠️ 2/3 | `Vector` and `MetadataOnly` only -- graph collection creation not exposed |
+| CLI | ✅ | |
+| TS SDK | ✅ | |
+| Tauri | ✅ | |
+| LangChain | ✅ | |
+| LlamaIndex | ✅ | |
+
+### Propagation Summary
+
+| Enum | Coverage | Status |
+|------|----------|--------|
+| `DistanceMetric` | 9/9 | 100% |
+| `StorageMode` | 9/9 | 100% |
+| `FusionStrategy` | 9/9 | 100% |
+| `SearchQuality` | 6/9 | N/A for WASM/Mobile/Tauri (brute-force) |
+| `CollectionType` | 8/9 | Mobile missing graph creation |
+
+---
+
 ## Remaining Gaps and Action Items
 
 1. Add explicit CLI end-to-end assertions for REST error shape (`code/hint/details`) beyond parser conformance.
@@ -97,3 +200,4 @@ Legend: ✅ full support | ⚠️ partial / limited | ❌ not supported | N/A no
 6. Expose named sparse indexes in LangChain and LlamaIndex integrations.
 7. Propagate `@collection` cross-collection MATCH to WASM, Mobile, Tauri, LangChain, and LlamaIndex.
 8. Add cross-collection vector search (`similarity()` on `@collection`-annotated nodes).
+9. Expose graph collection creation in `velesdb-mobile` (`create_graph_collection`).

--- a/docs/reference/ERROR_CODES.md
+++ b/docs/reference/ERROR_CODES.md
@@ -15,8 +15,8 @@ All error types are defined in `crates/velesdb-core/src/error.rs` and derive fro
 ## Recoverability
 
 Most errors are recoverable (the caller can fix the input and retry). The following
-four error codes are **not recoverable** and indicate corruption, resource exhaustion,
-or internal bugs:
+five error codes are **not recoverable** and indicate corruption, resource exhaustion,
+version incompatibility, or internal bugs:
 
 | Code | Variant | Why |
 |------|---------|-----|
@@ -24,6 +24,7 @@ or internal bugs:
 | VELES-013 | `Internal` | Unexpected bug; please report |
 | VELES-026 | `EpochMismatch` | Stale mmap guard; re-acquire required |
 | VELES-033 | `AllocationFailed` | Out of memory; cannot continue |
+| VELES-036 | `IncompatibleSchemaVersion` | Collection created by a newer VelesDB; upgrade required |
 
 ---
 
@@ -307,6 +308,22 @@ or internal bugs:
 - **Resolution**: Rename the collection using only allowed characters. Use `velesdb_core::validate_collection_name()` to check names before creation.
 - **Recoverable**: Yes
 
+### VELES-035: SnapshotBuildFailed
+
+- **Variant**: `SnapshotBuildFailed(String)`
+- **Message**: `Snapshot build failed: {details}`
+- **Cause**: Building a CSR (Compressed Sparse Row) snapshot from the edge store failed. This can happen during graph snapshot rebuild if the system runs out of memory or an internal allocation fails.
+- **Resolution**: Check available system memory. Reduce the number of edges in the collection, or increase system RAM. If the problem persists after restart, report it as a bug.
+- **Recoverable**: Yes
+
+### VELES-036: IncompatibleSchemaVersion
+
+- **Variant**: `IncompatibleSchemaVersion { found: u32, supported: u32 }`
+- **Message**: `Collection created with newer schema version (v{found}), current VelesDB supports up to v{supported}`
+- **Cause**: The collection's `config.json` contains a `schema_version` higher than what the running VelesDB binary supports. This happens when opening a collection that was created or migrated by a newer version of VelesDB.
+- **Resolution**: Upgrade VelesDB to a version that supports schema version v{found} or higher. Do not attempt to manually edit `config.json` -- this will likely corrupt the collection.
+- **Recoverable**: **No** -- requires a VelesDB upgrade.
+
 ---
 
 ## Programmatic Usage
@@ -394,6 +411,8 @@ try {
 | VELES-032 | `InvalidDimension` | Yes | Validation |
 | VELES-033 | `AllocationFailed` | **No** | Resource |
 | VELES-034 | `InvalidCollectionName` | Yes | Validation |
+| VELES-035 | `SnapshotBuildFailed` | Yes | Graph |
+| VELES-036 | `IncompatibleSchemaVersion` | **No** | Schema |
 
 ## Python SDK Exception Hierarchy
 

--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -8,6 +8,39 @@ Complete REST API documentation for VelesDB.
 http://localhost:8080
 ```
 
+### API Versioning
+
+All routes are available under two prefixes:
+
+| Prefix | Status | Example |
+|--------|--------|---------|
+| `/v1/` | **Canonical** (recommended) | `POST /v1/collections` |
+| `/` (no prefix) | **Legacy** (deprecated) | `POST /collections` |
+
+Legacy (unversioned) routes return deprecation headers in every response:
+
+| Header | Value |
+|--------|-------|
+| `deprecation` | `true` |
+| `x-api-deprecated` | `Use /v1/ prefix` |
+
+New integrations should use the `/v1/` prefix exclusively. Legacy routes will be removed in a future major version.
+
+### Rate Limiting
+
+Per-IP rate limiting is enabled by default (100 requests/second per IP). When a client exceeds the limit, the server responds with `429 Too Many Requests`.
+
+**Rate-limit response headers** (present on every response when rate limiting is enabled):
+
+| Header | Type | Description |
+|--------|------|-------------|
+| `x-ratelimit-limit` | integer | Maximum requests allowed per second |
+| `x-ratelimit-remaining` | integer | Remaining requests in the current window |
+| `x-ratelimit-after` | integer | Seconds until the bucket refills |
+| `retry-after` | integer | Seconds to wait before retrying (only on 429 responses) |
+
+**Configuration**: See [CONFIGURATION.md](../guides/CONFIGURATION.md#rate-limiting) for CLI, environment variable, and TOML options.
+
 ---
 
 ## Health Check
@@ -334,7 +367,7 @@ For VelesQL semantic/runtime errors (`/query`, `/aggregate`, `/query/explain`), 
 | 201 | Created |
 | 400 | Bad Request (invalid input) |
 | 404 | Not Found |
-| 429 | Too Many Requests (streaming backpressure) |
+| 429 | Too Many Requests (rate limit exceeded or streaming backpressure) |
 | 500 | Internal Server Error |
 
 ---


### PR DESCRIPTION
## Summary
- README: test badge 6242 → 6562 (6138 Rust + 200 TS + 224 Python)
- ERROR_CODES: added VELES-035 (SnapshotBuildFailed) + VELES-036 (IncompatibleSchemaVersion)
- api-reference: /v1/ versioning section + rate limiting headers + HTTP 429
- CONFIGURATION: rate_limit config (CLI/env/TOML) + schema_version section
- STORAGE_FORMAT: schema_version in config.json with field table
- ECOSYSTEM_PARITY: full enum propagation matrix (5 enums × 9 crates)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/560" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
