### PR TITLE
fix: TS SDK scroll cursor type + README scroll field names + LlamaIndex filter param

### DIFF
--- a/integrations/llamaindex/README.md
+++ b/integrations/llamaindex/README.md
@@ -102,7 +102,7 @@ VelesDBVectorStore(
 | **Utilities** | |
 | `get_collection_info()` | Get collection metadata |
 | `is_empty()` | Check if collection is empty |
-| `scroll(batch_size, filter)` | Iterate all points in stable batches without a query vector |
+| `scroll(batch_size)` | Iterate all points in stable batches without a query vector |
 
 ## Advanced Features
 

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -306,34 +306,35 @@ const hits = await db.searchIds('docs', queryVector, { k: 100 });
 
 Iterate over all points in a collection in stable, paginated batches without a
 query vector. Useful for export pipelines, re-embedding, and full-collection
-inspection. Pagination is cursor-based — pass the `nextOffset` from each
+inspection. Pagination is cursor-based — pass the `nextCursor` from each
 `ScrollResponse` until it is `null`.
 
 ```typescript
 import { ScrollRequest, ScrollResponse } from '@wiscale/velesdb-sdk';
 
-let offset: number | null = 0;
-while (offset !== null) {
-  const page: ScrollResponse = await db.scroll('docs', {
-    batchSize: 100,
-    offset,
-    filter: { category: 'tech' },  // optional payload filter
-    withVectors: false,             // set true to include raw vectors
-  } satisfies ScrollRequest);
+let cursor: string | number | null = null;
+let hasMore = true;
+while (hasMore) {
+  const req: ScrollRequest = { batchSize: 100 };
+  if (cursor !== null) {
+    req.cursor = cursor;
+  }
+
+  const page: ScrollResponse = await db.scroll('docs', req);
 
   for (const point of page.points) {
     console.log(point.id, point.payload);
   }
-  offset = page.nextOffset;
+  cursor = page.nextCursor;
+  hasMore = cursor !== null;
 }
 ```
 
 | Field (`ScrollRequest`) | Type | Default | Description |
 |-------------------------|------|---------|-------------|
+| `cursor` | `string \| number` | - | Cursor from previous `ScrollResponse.nextCursor` |
 | `batchSize` | `number` | `100` | Points per page |
-| `offset` | `number \| null` | `0` | Cursor from previous `ScrollResponse.nextOffset` |
 | `filter` | `object` | - | Optional payload filter expression |
-| `withVectors` | `boolean` | `false` | Include raw vectors in each point |
 
 #### `db.textSearch(collection, query, options?)`
 

--- a/sdks/typescript/src/backends/scroll-backend.ts
+++ b/sdks/typescript/src/backends/scroll-backend.ts
@@ -18,7 +18,7 @@ interface ScrollApiResponse {
     vector?: number[];
     payload?: Record<string, unknown>;
   }>;
-  next_cursor: number | null;
+  next_cursor: string | number | null;
 }
 
 /**

--- a/sdks/typescript/src/types.ts
+++ b/sdks/typescript/src/types.ts
@@ -325,7 +325,7 @@ export interface AgentMemoryConfig {
 /** Request parameters for cursor-based scroll pagination. */
 export interface ScrollRequest {
   /** Cursor position to resume from. Omit to start from beginning. */
-  cursor?: number;
+  cursor?: string | number;
   /** Number of points per page (1–10000, default 100). */
   batchSize?: number;
   /** Optional filter object. */
@@ -341,7 +341,7 @@ export interface ScrollResponse {
     payload?: Record<string, unknown>;
   }>;
   /** Cursor for next page, or null if no more results. */
-  nextCursor: number | null;
+  nextCursor: string | number | null;
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary
3 Devin review bugs from PRs #558 and #559:

1. **TS SDK**: `ScrollRequest.cursor` and `ScrollResponse.nextCursor` widened to `string | number` to match server's string serialization
2. **TS README**: scroll example corrected — `offset`/`nextOffset`/`withVectors` → `cursor`/`nextCursor`/`batchSize`
3. **LlamaIndex README**: removed nonexistent `filter` parameter from `scroll()` signature

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/561" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
