### PR TITLE
fix: tauri test string ID + clippy pedantic + pq_gpu total_cmp

### DIFF
--- a/crates/tauri-plugin-velesdb/src/commands_tests.rs
+++ b/crates/tauri-plugin-velesdb/src/commands_tests.rs
@@ -137,7 +137,7 @@ fn test_search_result_serialize() {
     };
     let json = serde_json::to_string(&result).unwrap();
 
-    assert!(json.contains("\"id\":42"));
+    assert!(json.contains("\"id\":\"42\""));
     assert!(json.contains("\"score\":0.95"));
     assert!(json.contains("\"title\":\"Test\""));
 }

--- a/crates/velesdb-core/src/gpu/pq_gpu.rs
+++ b/crates/velesdb-core/src/gpu/pq_gpu.rs
@@ -321,7 +321,7 @@ mod tests {
                             v.iter().zip(c.iter()).map(|(a, b)| (a - b) * (a - b)).sum();
                         (idx, dist)
                     })
-                    .min_by(|a, b| a.1.partial_cmp(&b.1).unwrap())
+                    .min_by(|a, b| a.1.total_cmp(&b.1))
                     .map(|(idx, _)| idx)
                     .unwrap()
             })

--- a/crates/velesdb-core/src/index/hnsw/index_tests.rs
+++ b/crates/velesdb-core/src/index/hnsw/index_tests.rs
@@ -1772,10 +1772,10 @@ fn test_search_brute_force_gpu_fallback_to_none_without_gpu() {
     let query = vec![0.5; 64];
 
     // Should not panic, returns Ok(None) if GPU unavailable
-    let _result = index.search_brute_force_gpu(&query, 5).unwrap();
+    let result = index.search_brute_force_gpu(&query, 5).unwrap();
 
     #[cfg(not(feature = "gpu"))]
-    assert!(_result.is_none(), "Should return None without GPU feature");
+    assert!(result.is_none(), "Should return None without GPU feature");
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Tauri `test_search_result_serialize`: updated assertion for string ID serialization
- Clippy: renamed `_result` → `result` in index_tests.rs
- pq_gpu: `partial_cmp().unwrap()` → `total_cmp()` (NaN-safe)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/563" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
