### PR TITLE
fix(velesql): add Average to FusionStrategyType + clean property_index dead code

### DIFF
--- a/crates/velesdb-core/src/collection/graph/property_index/advisor.rs
+++ b/crates/velesdb-core/src/collection/graph/property_index/advisor.rs
@@ -7,6 +7,9 @@
 // - u64/usize->f64 for statistics: precision loss acceptable for query planning
 // - All values are bounded by collection sizes and query counts
 // - Used for index selection heuristics, not financial calculations
+// Reason: EPIC-047 US-005 — all types in this module are scaffolded for the
+// auto-index-advisor feature and will be wired once the query planner integrates.
+#![allow(dead_code)]
 #![allow(clippy::cast_precision_loss)]
 #![allow(clippy::cast_possible_truncation)]
 
@@ -14,7 +17,6 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 /// Predicate types for query pattern tracking.
-#[allow(dead_code)]
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum PredicateType {
     /// Equality check (=)
@@ -28,7 +30,6 @@ pub enum PredicateType {
 }
 
 /// A query pattern for index suggestion analysis.
-#[allow(dead_code)]
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct QueryPattern {
     /// Labels involved
@@ -40,7 +41,6 @@ pub struct QueryPattern {
 }
 
 /// Statistics for a query pattern.
-#[allow(dead_code)]
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct PatternStats {
     /// Number of times this pattern was seen
@@ -54,7 +54,6 @@ pub struct PatternStats {
 }
 
 /// Tracks query patterns for index suggestion.
-#[allow(dead_code)]
 #[derive(Debug, Default, Serialize, Deserialize)]
 pub struct QueryPatternTracker {
     /// Pattern -> stats mapping
@@ -63,7 +62,6 @@ pub struct QueryPatternTracker {
     slow_query_threshold_ms: u64,
 }
 
-#[allow(dead_code)]
 impl QueryPatternTracker {
     /// Creates a new tracker with default threshold (100ms).
     #[must_use]
@@ -115,7 +113,6 @@ impl QueryPatternTracker {
 }
 
 /// An index suggestion.
-#[allow(dead_code)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct IndexSuggestion {
     /// DDL statement to create the index
@@ -131,14 +128,12 @@ pub struct IndexSuggestion {
 }
 
 /// Advisor that suggests indexes based on query patterns.
-#[allow(dead_code)]
 #[derive(Debug, Default)]
 pub struct IndexAdvisor {
     /// Existing index names (to avoid duplicates)
     existing_indexes: std::collections::HashSet<String>,
 }
 
-#[allow(dead_code)]
 impl IndexAdvisor {
     /// Creates a new advisor.
     #[must_use]

--- a/crates/velesdb-core/src/collection/graph/property_index/composite.rs
+++ b/crates/velesdb-core/src/collection/graph/property_index/composite.rs
@@ -2,6 +2,10 @@
 //!
 //! Provides O(1) hash-based lookups on (label, property1, property2, ...) combinations.
 
+// Reason: EPIC-047 US-001 — all types in this module are scaffolded for the
+// composite graph index feature and will be wired once the query planner integrates.
+#![allow(dead_code)]
+
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::hash_map::DefaultHasher;
@@ -9,8 +13,11 @@ use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
 
 /// Index type for composite indexes.
+<<<<<<< HEAD
 // SAFETY: CompositeIndexType part of EPIC-047 composite graph index feature
 #[allow(dead_code)]
+=======
+>>>>>>> 64264b17 (fix(velesql): add Average to FusionStrategyType and clean property_index dead code)
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum CompositeIndexType {
     /// Hash index for equality lookups (O(1))
@@ -23,8 +30,11 @@ pub enum CompositeIndexType {
 ///
 /// Provides O(1) lookups for nodes matching a label and specific property values.
 /// Useful for queries like `MATCH (n:Person {name: 'Alice', city: 'Paris'})`.
+<<<<<<< HEAD
 // SAFETY: CompositeGraphIndex part of EPIC-047 composite graph index feature
 #[allow(dead_code)]
+=======
+>>>>>>> 64264b17 (fix(velesql): add Average to FusionStrategyType and clean property_index dead code)
 #[derive(Debug, Serialize, Deserialize)]
 pub struct CompositeGraphIndex {
     /// Label this index covers
@@ -37,8 +47,11 @@ pub struct CompositeGraphIndex {
     hash_index: HashMap<u64, Vec<u64>>,
 }
 
+<<<<<<< HEAD
 // SAFETY: CompositeGraphIndex impl part of EPIC-047 composite graph index feature
 #[allow(dead_code)]
+=======
+>>>>>>> 64264b17 (fix(velesql): add Average to FusionStrategyType and clean property_index dead code)
 impl CompositeGraphIndex {
     /// Creates a new composite index.
     #[must_use]
@@ -174,16 +187,22 @@ impl CompositeGraphIndex {
 }
 
 /// Manager for multiple composite indexes.
+<<<<<<< HEAD
 // SAFETY: CompositeIndexManager part of EPIC-047 composite graph index feature
 #[allow(dead_code)]
+=======
+>>>>>>> 64264b17 (fix(velesql): add Average to FusionStrategyType and clean property_index dead code)
 #[derive(Debug, Default, Serialize, Deserialize)]
 pub struct CompositeIndexManager {
     /// All composite indexes, keyed by index name
     indexes: HashMap<String, CompositeGraphIndex>,
 }
 
+<<<<<<< HEAD
 // SAFETY: CompositeIndexManager impl part of EPIC-047 composite graph index feature
 #[allow(dead_code)]
+=======
+>>>>>>> 64264b17 (fix(velesql): add Average to FusionStrategyType and clean property_index dead code)
 impl CompositeIndexManager {
     /// Creates a new index manager.
     #[must_use]

--- a/crates/velesdb-core/src/collection/graph/property_index/mod.rs
+++ b/crates/velesdb-core/src/collection/graph/property_index/mod.rs
@@ -15,7 +15,8 @@ mod advisor;
 mod composite;
 mod range;
 
-// SAFETY: EPIC-047 types are dead_code (not yet used externally), suppress unused import warnings
+// Reason: EPIC-047 types are scaffolded but not yet wired to the query planner.
+// Re-exports are used by property_index_tests; suppress unused-import warnings.
 #[allow(unused_imports)]
 pub use advisor::{
     IndexAdvisor, IndexSuggestion, PatternStats, PredicateType, QueryPattern, QueryPatternTracker,

--- a/crates/velesdb-core/src/collection/graph/property_index/range.rs
+++ b/crates/velesdb-core/src/collection/graph/property_index/range.rs
@@ -6,6 +6,10 @@
 //! B-tree storage via [`BTreeOrderedIndex`], differing only in their metadata
 //! (label vs relationship-type) and public API surface.
 
+// Reason: EPIC-047 US-002/US-003/US-004 — all types in this module are scaffolded
+// for range indexes and edge property indexes, will be wired once the query planner integrates.
+#![allow(dead_code)]
+
 use roaring::RoaringBitmap;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -16,8 +20,6 @@ use std::ops::Bound;
 // =============================================================================
 
 /// Wrapper for total ordering on JSON values.
-// SAFETY: OrderedValue part of EPIC-047 range index feature
-#[allow(dead_code)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct OrderedValue(pub(crate) Value);
 
@@ -65,13 +67,11 @@ impl Ord for OrderedValue {
 /// Both [`CompositeRangeIndex`] (node properties) and [`EdgePropertyIndex`]
 /// (edge properties) delegate to this type for all insert/remove/lookup
 /// operations, eliminating code duplication.
-#[allow(dead_code)]
 #[derive(Debug, Serialize, Deserialize)]
 struct BTreeOrderedIndex {
     entries: std::collections::BTreeMap<OrderedValue, Vec<u64>>,
 }
 
-#[allow(dead_code)]
 impl BTreeOrderedIndex {
     fn new() -> Self {
         Self {
@@ -145,7 +145,6 @@ impl BTreeOrderedIndex {
 // =============================================================================
 
 /// B-tree based range index for ordered queries on node properties.
-#[allow(dead_code)]
 #[derive(Debug, Serialize, Deserialize)]
 pub struct CompositeRangeIndex {
     /// Label this index covers
@@ -156,7 +155,6 @@ pub struct CompositeRangeIndex {
     index: BTreeOrderedIndex,
 }
 
-#[allow(dead_code)]
 impl CompositeRangeIndex {
     /// Creates a new range index.
     #[must_use]
@@ -217,7 +215,6 @@ impl CompositeRangeIndex {
 // =============================================================================
 
 /// Index for edge/relationship properties.
-#[allow(dead_code)]
 #[derive(Debug, Serialize, Deserialize)]
 pub struct EdgePropertyIndex {
     /// Relationship type this index covers
@@ -228,7 +225,6 @@ pub struct EdgePropertyIndex {
     index: BTreeOrderedIndex,
 }
 
-#[allow(dead_code)]
 impl EdgePropertyIndex {
     /// Creates a new edge property index.
     #[must_use]
@@ -279,10 +275,8 @@ impl EdgePropertyIndex {
 // =============================================================================
 
 /// Utilities for intersecting index results.
-#[allow(dead_code)]
 pub struct IndexIntersection;
 
-#[allow(dead_code)]
 impl IndexIntersection {
     /// Intersects multiple node ID sets using RoaringBitmap for efficiency.
     #[must_use]

--- a/crates/velesdb-core/src/collection/search/query/sparse_dispatch.rs
+++ b/crates/velesdb-core/src/collection/search/query/sparse_dispatch.rs
@@ -125,7 +125,9 @@ impl Collection {
                     FusionStrategyType::Rrf => crate::fusion::FusionStrategy::RRF {
                         k: fc.k.unwrap_or(60),
                     },
-                    _ => crate::fusion::FusionStrategy::rrf_default(),
+                    FusionStrategyType::Average => crate::fusion::FusionStrategy::Average,
+                    FusionStrategyType::Maximum => crate::fusion::FusionStrategy::Maximum,
+                    FusionStrategyType::Weighted => crate::fusion::FusionStrategy::rrf_default(),
                 }
             })
     }

--- a/crates/velesdb-core/src/velesql/ast/fusion.rs
+++ b/crates/velesdb-core/src/velesql/ast/fusion.rs
@@ -17,12 +17,14 @@ pub enum FusionStrategyType {
     Maximum,
     /// Reciprocal Sparse Fusion for dense + sparse hybrid search.
     Rsf,
+    /// Average score across all queries where the document appears.
+    Average,
 }
 
 /// USING FUSION clause for hybrid search (EPIC-040 US-005).
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct FusionClause {
-    /// Fusion strategy (rrf, weighted, maximum, rsf).
+    /// Fusion strategy (rrf, weighted, maximum, rsf, average).
     pub strategy: FusionStrategyType,
     /// RRF k parameter (default 60).
     pub k: Option<u32>,

--- a/crates/velesdb-core/src/velesql/explain.rs
+++ b/crates/velesdb-core/src/velesql/explain.rs
@@ -449,6 +449,7 @@ impl QueryPlan {
             super::ast::FusionStrategyType::Weighted => "Weighted",
             super::ast::FusionStrategyType::Maximum => "Maximum",
             super::ast::FusionStrategyType::Rsf => "RSF",
+            super::ast::FusionStrategyType::Average => "Average",
         };
         let weights = Self::format_fusion_weights(fc);
         Some(FusionInfo {

--- a/crates/velesdb-core/src/velesql/fusion_clause_tests.rs
+++ b/crates/velesdb-core/src/velesql/fusion_clause_tests.rs
@@ -96,6 +96,26 @@ fn test_using_fusion_maximum() {
 }
 
 #[test]
+fn test_using_fusion_average() {
+    let sql = "SELECT * FROM docs USING FUSION(strategy = 'average')";
+    let result = Parser::parse(sql);
+    assert!(
+        result.is_ok(),
+        "Failed to parse FUSION average: {:?}",
+        result.err()
+    );
+
+    let query = result.unwrap();
+    let fusion = query
+        .select
+        .fusion_clause
+        .as_ref()
+        .expect("FUSION clause should be present");
+
+    assert_eq!(fusion.strategy, crate::velesql::FusionStrategyType::Average);
+}
+
+#[test]
 fn test_fusion_with_where_clause() {
     // USING FUSION combined with WHERE clause
     let sql = "SELECT * FROM docs WHERE category = 'tech' USING FUSION(strategy = 'rrf', k = 60)";

--- a/crates/velesdb-core/src/velesql/parser/select/clause_limit_with.rs
+++ b/crates/velesdb-core/src/velesql/parser/select/clause_limit_with.rs
@@ -84,6 +84,7 @@ impl Parser {
             "weighted" => crate::velesql::FusionStrategyType::Weighted,
             "maximum" => crate::velesql::FusionStrategyType::Maximum,
             "rsf" => crate::velesql::FusionStrategyType::Rsf,
+            "average" => crate::velesql::FusionStrategyType::Average,
             _ => crate::velesql::FusionStrategyType::Rrf,
         }
     }


### PR DESCRIPTION
## Summary
- Added `Average` variant to `FusionStrategyType` (VelesQL AST)
- Parser, EXPLAIN, and sparse_dispatch updated
- Test: `USING FUSION(strategy = 'average')` parses correctly
- property_index: 22 per-item `#[allow(dead_code)]` → 3 module-level with EPIC-047 rationale

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/565" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
