### PR TITLE
fix(api): add #[non_exhaustive] to FusionStrategyType

### DIFF
--- a/crates/velesdb-core/src/velesql/ast/fusion.rs
+++ b/crates/velesdb-core/src/velesql/ast/fusion.rs
@@ -6,6 +6,7 @@
 use serde::{Deserialize, Serialize};
 
 /// Fusion strategy type for hybrid search (EPIC-040 US-005).
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub enum FusionStrategyType {
     /// Reciprocal Rank Fusion (default).


### PR DESCRIPTION
Devin finding: FusionStrategyType was the only fusion-related public enum without #[non_exhaustive]. 🤖 Claude Code