### PR TITLE
fix(ecosystem): pre-seed audit v4 — 43 fixes across 6 sprints

### DIFF
--- a/.github/workflows/bench-arm64.yml
+++ b/.github/workflows/bench-arm64.yml
@@ -4,13 +4,13 @@ on:
   push:
     branches: [main]
     paths:
-      - 'crates/velesdb-core/src/simd/**'
+      - 'crates/velesdb-core/src/simd_native/**'
       - 'crates/velesdb-core/src/index/**'
       - 'crates/velesdb-core/benches/**'
   pull_request:
     types: [opened, reopened, synchronize, labeled, unlabeled]
     paths:
-      - 'crates/velesdb-core/src/simd/**'
+      - 'crates/velesdb-core/src/simd_native/**'
       - 'crates/velesdb-core/src/index/**'
       - 'crates/velesdb-core/benches/**'
   workflow_dispatch:

--- a/.github/workflows/bench-scalability.yml
+++ b/.github/workflows/bench-scalability.yml
@@ -24,7 +24,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  RUST_VERSION: "1.83"
+  RUST_VERSION: "1.86"
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,6 +161,7 @@ jobs:
 
   # ===========================================================================
   # Tests unitaires (parallèle avec lint et security)
+  # TODO(S1-05): Add Windows and macOS test matrix for cross-platform coverage
   # ===========================================================================
   test:
     name: Tests
@@ -266,7 +267,7 @@ jobs:
         run: |
           cd integrations/llamaindex
           pip install -e ".[dev]" 2>/dev/null || pip install pytest pytest-asyncio
-          python -m pytest tests/ -v --tb=short 2>/dev/null || echo "Tests skipped"
+          python -m pytest tests/ -v --tb=short
 
   # ===========================================================================
   # Coverage (main seulement)
@@ -300,12 +301,13 @@ jobs:
       - name: Generate coverage report and enforce threshold
         run: |
           # Run tests with coverage instrumentation and emit lcov report.
-          # Threshold is 70%: the gpu/update-check features add code paths that
+          # Threshold is 78%: closer to the 80% project target, with a small
+          # margin for variance. The gpu/update-check features add code paths that
           # are not exercisable in CI (no GPU hardware), lowering measured coverage
           # vs the local 82.30% badge which was measured without those features.
           cargo llvm-cov --features persistence,gpu,update-check --workspace \
             --exclude velesdb-python \
-            --fail-under-lines 70 \
+            --fail-under-lines 78 \
             --lcov --output-path lcov.info \
             -- --test-threads=1
 

--- a/.github/workflows/propagation-guard.yml
+++ b/.github/workflows/propagation-guard.yml
@@ -48,7 +48,7 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - uses: dtolnay/rust-toolchain@f7ccc83f9ed1e5b9c81d8a67d7ad1a747e22a561 # stable
         with:
-          toolchain: "1.83"
+          toolchain: "1.86"
       - name: Install Linux build deps
         uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05
         with:
@@ -73,7 +73,7 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - uses: dtolnay/rust-toolchain@f7ccc83f9ed1e5b9c81d8a67d7ad1a747e22a561 # stable
         with:
-          toolchain: "1.83"
+          toolchain: "1.86"
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.11"
@@ -144,7 +144,7 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - uses: dtolnay/rust-toolchain@f7ccc83f9ed1e5b9c81d8a67d7ad1a747e22a561 # stable
         with:
-          toolchain: "1.83"
+          toolchain: "1.86"
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.11"
@@ -190,7 +190,7 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - uses: dtolnay/rust-toolchain@f7ccc83f9ed1e5b9c81d8a67d7ad1a747e22a561 # stable
         with:
-          toolchain: "1.83"
+          toolchain: "1.86"
       - uses: Swatinem/rust-cache@401aff9a7a08acb9d27b64936a90db81024cff97 # v2.8.2
         with:
           shared-key: "propagation-regressions"

--- a/.github/workflows/quality-deep.yml
+++ b/.github/workflows/quality-deep.yml
@@ -88,7 +88,6 @@ jobs:
             storage::vector_bytes:: --test-threads=1
         env:
           MIRIFLAGS: "-Zmiri-disable-isolation -Zmiri-symbolic-alignment-check"
-        continue-on-error: true
 
   # ===========================================================================
   # Loom Concurrency Tests - Détecte deadlocks et data races
@@ -136,7 +135,6 @@ jobs:
         env:
           RUSTFLAGS: "--cfg loom"
           LOOM_MAX_PREEMPTIONS: 3
-        continue-on-error: true
 
   # ===========================================================================
   # Fuzzing - Robustesse des parsers et APIs exposées
@@ -167,7 +165,7 @@ jobs:
           cd fuzz
           cargo +nightly fuzz run fuzz_velesql_parser \
             -- -max_total_time=${{ inputs.fuzz_duration || 300 }}
-        continue-on-error: true
+        continue-on-error: true  # Fuzz may timeout without finding bugs; not a failure
 
       # Distance metrics - données vectorielles
       - name: Fuzz distance metrics
@@ -175,7 +173,7 @@ jobs:
           cd fuzz
           cargo +nightly fuzz run fuzz_distance_metrics \
             -- -max_total_time=${{ inputs.fuzz_duration || 300 }}
-        continue-on-error: true
+        continue-on-error: true  # Fuzz may timeout without finding bugs; not a failure
 
       # Snapshot parser - fichiers de persistance
       - name: Fuzz snapshot parser
@@ -183,7 +181,7 @@ jobs:
           cd fuzz
           cargo +nightly fuzz run fuzz_snapshot_parser \
             -- -max_total_time=${{ inputs.fuzz_duration || 300 }}
-        continue-on-error: true
+        continue-on-error: true  # Fuzz may timeout without finding bugs; not a failure
 
       # Upload crash artifacts si trouvés
       - name: Upload crash artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,7 @@
+# WARNING: This workflow does not verify that CI has passed on the tagged commit.
+# Always ensure CI is green before pushing a tag.
+# A proper fix would use workflow_run trigger to gate on CI completion,
+# but that requires significant refactoring of the release pipeline.
 name: Release
 
 on:
@@ -39,7 +43,7 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
-  RUST_VERSION: '1.83'
+  RUST_VERSION: '1.86'
 
 jobs:
   # ===========================================================================

--- a/crates/tauri-plugin-velesdb/guest-js/package.json
+++ b/crates/tauri-plugin-velesdb/guest-js/package.json
@@ -37,7 +37,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/cyberlife-coder/VelesDB.git",
-    "directory": "integrations/tauri-plugin-velesdb/guest-js"
+    "directory": "crates/tauri-plugin-velesdb/guest-js"
   },
   "bugs": {
     "url": "https://github.com/cyberlife-coder/VelesDB/issues"

--- a/crates/velesdb-core/src/api_types/mod.rs
+++ b/crates/velesdb-core/src/api_types/mod.rs
@@ -98,18 +98,6 @@ pub fn default_index_type() -> String {
     "hash".to_string()
 }
 
-/// Convert search mode string to `ef_search` value.
-#[must_use]
-pub fn mode_to_ef_search(mode: &str) -> Option<usize> {
-    match mode.to_lowercase().as_str() {
-        "fast" => Some(64),
-        "balanced" => Some(128),
-        "accurate" => Some(512),
-        "perfect" => Some(usize::MAX),
-        _ => None,
-    }
-}
-
 /// Convert search mode string to [`SearchQuality`].
 ///
 /// Supports all named modes including `"autotune"` which adapts ef

--- a/crates/velesdb-core/src/api_types/tests.rs
+++ b/crates/velesdb-core/src/api_types/tests.rs
@@ -300,16 +300,6 @@ fn test_default_rrf_k() {
     assert_eq!(default_rrf_k(), 60);
 }
 
-#[test]
-fn test_mode_to_ef_search_all_modes() {
-    assert_eq!(mode_to_ef_search("fast"), Some(64));
-    assert_eq!(mode_to_ef_search("balanced"), Some(128));
-    assert_eq!(mode_to_ef_search("accurate"), Some(512));
-    assert_eq!(mode_to_ef_search("perfect"), Some(usize::MAX));
-    assert_eq!(mode_to_ef_search("unknown_mode"), None);
-    assert_eq!(mode_to_ef_search(""), None);
-}
-
 // ============================================================================
 // C. Edge case tests (~10)
 // ============================================================================
@@ -449,14 +439,6 @@ fn filter_with_nested_conditions() {
 // ============================================================================
 // D. Utility function / constant tests (~3+)
 // ============================================================================
-
-#[test]
-fn test_mode_to_ef_search_case_insensitive() {
-    assert_eq!(mode_to_ef_search("FAST"), Some(64));
-    assert_eq!(mode_to_ef_search("Balanced"), Some(128));
-    assert_eq!(mode_to_ef_search("ACCURATE"), Some(512));
-    assert_eq!(mode_to_ef_search("Perfect"), Some(usize::MAX));
-}
 
 #[test]
 fn test_default_index_type() {

--- a/crates/velesdb-core/src/collection/types.rs
+++ b/crates/velesdb-core/src/collection/types.rs
@@ -386,7 +386,6 @@ pub(crate) struct Collection {
     /// construction via `HnswSegmentBuilder` for high-throughput bulk import.
     ///
     /// Lock order position: **11** (same tier as `deferred_indexer`).
-    #[allow(dead_code)] // Read by future upsert_bulk_v2 path
     pub(crate) async_index_builder: Option<Arc<AsyncIndexBuilder>>,
 }
 

--- a/crates/velesdb-core/src/simd_native/adc.rs
+++ b/crates/velesdb-core/src/simd_native/adc.rs
@@ -10,6 +10,7 @@
 // the PQ rescoring pipeline. Remove this allow when Phase 03 integration is complete.
 #![allow(dead_code)]
 
+#[allow(unused_imports)] // simd_level/SimdLevel used only on x86_64/aarch64 targets
 use super::dispatch::{simd_level, SimdLevel};
 #[cfg(target_arch = "x86_64")]
 use super::reduction::hsum_avx256;

--- a/crates/velesdb-core/src/simd_native/dispatch/cosine.rs
+++ b/crates/velesdb-core/src/simd_native/dispatch/cosine.rs
@@ -1,4 +1,6 @@
-use super::{dot::dot_product_native, simd_level, SimdLevel};
+use super::dot::dot_product_native;
+#[allow(unused_imports)] // simd_level used only on x86_64/aarch64 targets
+use super::{simd_level, SimdLevel};
 
 /// Cosine for pre-normalized vectors with runtime SIMD dispatch.
 #[allow(clippy::inline_always)]
@@ -72,6 +74,7 @@ pub fn batch_cosine_native(candidates: &[&[f32]], query: &[f32]) -> Vec<f32> {
     super::batch_with_prefetch(candidates, query, cosine_similarity_native)
 }
 
+#[allow(unused_variables)] // dim used only on x86_64 for dimension-based dispatch
 pub(super) fn resolve_cosine(level: SimdLevel, dim: usize) -> fn(&[f32], &[f32]) -> f32 {
     match level {
         #[cfg(target_arch = "x86_64")]

--- a/crates/velesdb-core/src/simd_native/dispatch/dot.rs
+++ b/crates/velesdb-core/src/simd_native/dispatch/dot.rs
@@ -1,3 +1,4 @@
+#[allow(unused_imports)] // simd_level used only on x86_64/aarch64 targets
 use super::{simd_level, SimdLevel};
 
 /// Dot product with runtime SIMD dispatch.
@@ -83,6 +84,7 @@ pub(super) fn batch_prefetch_candidate(candidates: &[&[f32]], i: usize) {
     }
 }
 
+#[allow(unused_variables)] // dim used only on x86_64 for dimension-based dispatch
 pub(super) fn resolve_dot_product(level: SimdLevel, dim: usize) -> fn(&[f32], &[f32]) -> f32 {
     match level {
         #[cfg(target_arch = "x86_64")]

--- a/crates/velesdb-core/src/simd_native/dispatch/euclidean.rs
+++ b/crates/velesdb-core/src/simd_native/dispatch/euclidean.rs
@@ -1,3 +1,4 @@
+#[allow(unused_imports)] // simd_level used only on x86_64/aarch64 targets
 use super::{dot::dot_product_native, simd_level, SimdLevel};
 
 /// Squared L2 distance with runtime SIMD dispatch.
@@ -163,6 +164,7 @@ pub fn batch_euclidean_native(candidates: &[&[f32]], query: &[f32]) -> Vec<f32> 
     super::batch_with_prefetch(candidates, query, euclidean_native)
 }
 
+#[allow(unused_variables)] // dim used only on x86_64 for dimension-based dispatch
 pub(super) fn resolve_squared_l2(level: SimdLevel, dim: usize) -> fn(&[f32], &[f32]) -> f32 {
     match level {
         #[cfg(target_arch = "x86_64")]

--- a/crates/velesdb-core/src/simd_native/scalar.rs
+++ b/crates/velesdb-core/src/simd_native/scalar.rs
@@ -48,6 +48,7 @@ pub fn fast_rsqrt(x: f32) -> f32 {
 /// Algebraic identity: `dot / (sqrt(na²) × sqrt(nb²)) = dot / sqrt(na² × nb²)`.
 /// Saves one `sqrtss` (~3 cycles throughput on modern x86), exact precision.
 /// Used by all SIMD cosine kernels (AVX2, AVX-512, NEON) as the final step.
+#[allow(dead_code)] // Used by AVX2/AVX-512/NEON cosine kernels, not on WASM
 #[inline]
 #[must_use]
 pub(crate) fn cosine_finish_fast(dot: f32, norm_a_sq: f32, norm_b_sq: f32) -> f32 {

--- a/crates/velesdb-core/src/velesql/ast/values.rs
+++ b/crates/velesdb-core/src/velesql/ast/values.rs
@@ -6,6 +6,7 @@
 use serde::{Deserialize, Serialize};
 
 /// Vector expression in a NEAR clause.
+#[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum VectorExpr {
     /// Literal vector: [0.1, 0.2, ...]
@@ -96,6 +97,7 @@ pub struct CorrelatedColumn {
 }
 
 /// Temporal expression for date/time operations (EPIC-038).
+#[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum TemporalExpr {
     /// Current timestamp: `NOW()`
@@ -177,6 +179,7 @@ impl Value {
 }
 
 /// Time unit for INTERVAL expressions (EPIC-038).
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum IntervalUnit {
     /// Seconds.

--- a/crates/velesdb-python/python/velesdb/__init__.py
+++ b/crates/velesdb-python/python/velesdb/__init__.py
@@ -181,6 +181,23 @@ class Collection:
         return int(info.get("point_count", 0))
 
     def get_graph_store(self) -> GraphStore:
+        """Return a standalone in-memory graph store.
+
+        Warning:
+            This graph store is **independent** of this collection's data.
+            Edges and nodes added here are NOT persisted to the collection.
+            For persistent graph operations, use
+            ``Database.get_graph_collection()`` instead.
+        """
+        import warnings
+
+        warnings.warn(
+            "Collection.get_graph_store() returns a standalone in-memory "
+            "graph not connected to this collection. Use "
+            "Database.get_graph_collection() for persistent graph operations.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         if self._graph_store is None:
             self._graph_store = GraphStore()
         return self._graph_store

--- a/crates/velesdb-python/python/velesdb/dataframe_converter.py
+++ b/crates/velesdb-python/python/velesdb/dataframe_converter.py
@@ -3,16 +3,13 @@
 Converts between VelesDB result types (list[dict]) and Pandas/Polars
 DataFrames. All pandas/polars imports are deferred to first use.
 
-.. warning:: Reserved column names
+.. note:: Reserved column names
 
    The structural columns ``id``, ``score`` (search results) and
-   ``vector`` (scroll batches) always take precedence over identically
-   named payload keys.  If a payload contains a field called ``id``,
-   ``score``, or ``vector``, it will be **silently overwritten** by the
-   structural value in the resulting DataFrame.  A subsequent
-   ``upsert_from_dataframe`` round-trip would therefore **lose** those
-   payload fields.  Avoid using reserved names as payload keys, or
-   rename them before converting to a DataFrame.
+   ``vector`` (scroll batches) are always present in the output DataFrame.
+   If a payload contains a field with one of these names, it is renamed to
+   ``payload_<name>`` (e.g. ``payload_id``, ``payload_score``) so the data
+   is preserved rather than silently overwritten.
 """
 
 from __future__ import annotations
@@ -63,8 +60,9 @@ def to_dataframe(results: list[dict], backend: str = "pandas") -> Any:
     Each dict should have 'id', 'score', and optional payload keys.
     Missing payload fields are represented as None/NaN/null.
 
-    .. note:: Payload keys named ``id`` or ``score`` are overwritten by
-       the structural search-result values (see module-level warning).
+    .. note:: Payload keys named ``id`` or ``score`` are renamed to
+       ``payload_id`` / ``payload_score`` to avoid collision with
+       structural columns (see module-level note).
 
     Args:
         results: List of search result dicts.
@@ -74,6 +72,8 @@ def to_dataframe(results: list[dict], backend: str = "pandas") -> Any:
         A pandas.DataFrame or polars.DataFrame.
     """
     lib = _get_backend(backend)
+
+    _SEARCH_RESERVED = frozenset({"id", "score"})
 
     if not results:
         if backend == "pandas":
@@ -85,7 +85,9 @@ def to_dataframe(results: list[dict], backend: str = "pandas") -> Any:
         row: dict[str, Any] = {}
         payload = r.get("payload")
         if isinstance(payload, dict):
-            row.update(payload)
+            for k, v in payload.items():
+                safe_key = f"payload_{k}" if k in _SEARCH_RESERVED else k
+                row[safe_key] = v
         row["id"] = r.get("id")
         row["score"] = r.get("score")
         rows.append(row)
@@ -120,8 +122,9 @@ def to_scroll_dataframe(batch: list[dict], backend: str = "pandas") -> Any:
 
     Each dict has 'id', 'vector', and 'payload' keys.
 
-    .. note:: Payload keys named ``id`` or ``vector`` are overwritten
-       by the structural point values (see module-level warning).
+    .. note:: Payload keys named ``id`` or ``vector`` are renamed to
+       ``payload_id`` / ``payload_vector`` to avoid collision with
+       structural columns (see module-level note).
 
     Args:
         batch: List of point dicts from scroll.
@@ -149,18 +152,21 @@ def to_scroll_dataframe(batch: list[dict], backend: str = "pandas") -> Any:
     # This guarantees a consistent schema regardless of per-point payload type.
     has_dict_payload = any(isinstance(p.get("payload"), dict) for p in batch)
 
+    _SCROLL_RESERVED = frozenset({"id", "vector"})
+
     rows = []
     for p in batch:
         row: dict[str, Any] = {}
         payload = p.get("payload")
         if has_dict_payload:
             if isinstance(payload, dict):
-                row.update(payload)
+                for k, v in payload.items():
+                    safe_key = f"payload_{k}" if k in _SCROLL_RESERVED else k
+                    row[safe_key] = v
             # Non-dict payloads in a mixed batch are silently skipped;
             # their columns will be NaN/null in the final DataFrame.
         else:
             row["payload"] = payload
-        # Special columns are written last so payload keys cannot overwrite them.
         row["id"] = p.get("id")
         row["vector"] = list(p.get("vector", []))
         rows.append(row)

--- a/crates/velesdb-python/python/velesdb/dataframe_converter.py
+++ b/crates/velesdb-python/python/velesdb/dataframe_converter.py
@@ -86,7 +86,12 @@ def to_dataframe(results: list[dict], backend: str = "pandas") -> Any:
         payload = r.get("payload")
         if isinstance(payload, dict):
             for k, v in payload.items():
-                safe_key = f"payload_{k}" if k in _SEARCH_RESERVED else k
+                if k in _SEARCH_RESERVED:
+                    safe_key = f"payload_{k}"
+                    while safe_key in payload:
+                        safe_key = f"_{safe_key}"
+                else:
+                    safe_key = k
                 row[safe_key] = v
         row["id"] = r.get("id")
         row["score"] = r.get("score")
@@ -161,7 +166,12 @@ def to_scroll_dataframe(batch: list[dict], backend: str = "pandas") -> Any:
         if has_dict_payload:
             if isinstance(payload, dict):
                 for k, v in payload.items():
-                    safe_key = f"payload_{k}" if k in _SCROLL_RESERVED else k
+                    if k in _SCROLL_RESERVED:
+                        safe_key = f"payload_{k}"
+                        while safe_key in payload:
+                            safe_key = f"_{safe_key}"
+                    else:
+                        safe_key = k
                     row[safe_key] = v
             # Non-dict payloads in a mixed batch are silently skipped;
             # their columns will be NaN/null in the final DataFrame.

--- a/crates/velesdb-python/src/collection/search.rs
+++ b/crates/velesdb-python/src/collection/search.rs
@@ -406,11 +406,17 @@ impl Collection {
         }
 
         // Invariant: every query index was assigned to exactly one group.
-        debug_assert!(
-            output.iter().all(Option::is_some),
-            "batch dispatch left unassigned slots"
-        );
-        Ok(output.into_iter().map(|o| o.unwrap_or_default()).collect())
+        output
+            .into_iter()
+            .enumerate()
+            .map(|(i, slot)| {
+                slot.ok_or_else(|| {
+                    core_err(velesdb_core::error::Error::Query(format!(
+                        "batch dispatch left slot {i} unassigned"
+                    )))
+                })
+            })
+            .collect::<PyResult<Vec<_>>>()
     }
 
     /// Converts core `SearchResult` vectors to Python dicts.

--- a/crates/velesdb-python/src/database.rs
+++ b/crates/velesdb-python/src/database.rs
@@ -494,10 +494,13 @@ impl Database {
             .inner
             .get_collection_stats(name)
             .map_err(|e| PyRuntimeError::new_err(format!("Failed to read stats: {e}")))?;
-        Ok(maybe_stats.map(|stats| {
-            let json = serde_json::to_value(&stats).unwrap_or(serde_json::Value::Null);
-            utils::json_to_python(py, &json)
-        }))
+        maybe_stats
+            .map(|stats| {
+                let json = serde_json::to_value(&stats)
+                    .map_err(|e| PyRuntimeError::new_err(format!("stats serialization failed: {e}")))?;
+                Ok(utils::json_to_python(py, &json))
+            })
+            .transpose()
     }
 }
 

--- a/crates/velesdb-python/src/database.rs
+++ b/crates/velesdb-python/src/database.rs
@@ -496,8 +496,9 @@ impl Database {
             .map_err(|e| PyRuntimeError::new_err(format!("Failed to read stats: {e}")))?;
         maybe_stats
             .map(|stats| {
-                let json = serde_json::to_value(&stats)
-                    .map_err(|e| PyRuntimeError::new_err(format!("stats serialization failed: {e}")))?;
+                let json = serde_json::to_value(&stats).map_err(|e| {
+                    PyRuntimeError::new_err(format!("stats serialization failed: {e}"))
+                })?;
                 Ok(utils::json_to_python(py, &json))
             })
             .transpose()

--- a/crates/velesdb-python/src/utils.rs
+++ b/crates/velesdb-python/src/utils.rs
@@ -146,13 +146,17 @@ pub fn python_to_json(py: Python<'_>, obj: &PyObject) -> PyResult<serde_json::Va
 /// Helper to convert a value to `PyObject` using the `IntoPyObject` trait.
 ///
 /// Returns `py.None()` on conversion failure instead of panicking,
-/// which preserves the existing `-> PyObject` signature for 50+ callers.
+/// which preserves the existing `-> PyObject` signature for 18 callers.
+/// Failures are logged to help diagnose unexpected `None` values in results.
 #[inline]
 pub fn to_pyobject<'py, T>(py: Python<'py>, value: T) -> PyObject
 where
     T: IntoPyObjectExt<'py>,
 {
-    value.into_py_any(py).unwrap_or_else(|_| py.None())
+    value.into_py_any(py).unwrap_or_else(|e| {
+        eprintln!("[velesdb] to_pyobject conversion failed, returning None: {e}");
+        py.None()
+    })
 }
 
 /// Convert a `serde_json::Value` to a Python object.

--- a/crates/velesdb-server/src/handlers/query/mod.rs
+++ b/crates/velesdb-server/src/handlers/query/mod.rs
@@ -137,6 +137,7 @@ fn extract_mutation_collection_name(parsed: &Query) -> String {
             IntrospectionStatement::ShowCollections | IntrospectionStatement::Explain(_) => {
                 "_system".to_string()
             }
+            // FIXME(PRE-SEED): New IntrospectionStatement variants silently map to _system. Update when core adds variants.
             _ => "_system".to_string(),
         };
     }
@@ -146,6 +147,7 @@ fn extract_mutation_collection_name(parsed: &Query) -> String {
                 .collection
                 .clone()
                 .unwrap_or_else(|| "_system".to_string()),
+            // FIXME(PRE-SEED): New AdminStatement variants silently map to _system. Update when core adds variants.
             _ => "_system".to_string(),
         };
     }
@@ -157,29 +159,29 @@ fn extract_mutation_collection_name(parsed: &Query) -> String {
 
 /// Extract collection name from a DDL statement.
 fn extract_ddl_collection(parsed: &Query) -> Option<String> {
-    parsed.ddl.as_ref().map(|ddl| match ddl {
-        DdlStatement::CreateCollection(s) => s.name.clone(),
-        DdlStatement::DropCollection(s) => s.name.clone(),
-        DdlStatement::CreateIndex(s) => s.collection.clone(),
-        DdlStatement::DropIndex(s) => s.collection.clone(),
-        DdlStatement::Analyze(s) => s.collection.clone(),
-        DdlStatement::Truncate(s) => s.collection.clone(),
-        DdlStatement::AlterCollection(s) => s.collection.clone(),
-        _ => format!("<unknown DDL {:?}>", ddl),
+    parsed.ddl.as_ref().and_then(|ddl| match ddl {
+        DdlStatement::CreateCollection(s) => Some(s.name.clone()),
+        DdlStatement::DropCollection(s) => Some(s.name.clone()),
+        DdlStatement::CreateIndex(s) => Some(s.collection.clone()),
+        DdlStatement::DropIndex(s) => Some(s.collection.clone()),
+        DdlStatement::Analyze(s) => Some(s.collection.clone()),
+        DdlStatement::Truncate(s) => Some(s.collection.clone()),
+        DdlStatement::AlterCollection(s) => Some(s.collection.clone()),
+        _ => None,
     })
 }
 
 /// Extract collection name from a DML statement.
 fn extract_dml_collection(parsed: &Query) -> Option<String> {
-    parsed.dml.as_ref().map(|dml| match dml {
-        DmlStatement::Insert(s) | DmlStatement::Upsert(s) => s.table.clone(),
-        DmlStatement::Update(s) => s.table.clone(),
-        DmlStatement::InsertEdge(s) => s.collection.clone(),
-        DmlStatement::Delete(s) => s.table.clone(),
-        DmlStatement::DeleteEdge(s) => s.collection.clone(),
-        DmlStatement::SelectEdges(s) => s.collection.clone(),
-        DmlStatement::InsertNode(s) => s.collection.clone(),
-        _ => format!("<unknown DML {:?}>", dml),
+    parsed.dml.as_ref().and_then(|dml| match dml {
+        DmlStatement::Insert(s) | DmlStatement::Upsert(s) => Some(s.table.clone()),
+        DmlStatement::Update(s) => Some(s.table.clone()),
+        DmlStatement::InsertEdge(s) => Some(s.collection.clone()),
+        DmlStatement::Delete(s) => Some(s.table.clone()),
+        DmlStatement::DeleteEdge(s) => Some(s.collection.clone()),
+        DmlStatement::SelectEdges(s) => Some(s.collection.clone()),
+        DmlStatement::InsertNode(s) => Some(s.collection.clone()),
+        _ => None,
     })
 }
 

--- a/crates/velesdb-server/tests/api_integration.rs
+++ b/crates/velesdb-server/tests/api_integration.rs
@@ -857,7 +857,10 @@ async fn test_hybrid_search() {
     let results = json["results"].as_array().expect("Not an array");
     assert!(!results.is_empty());
     // Results should contain docs matching "rust" (ids 1 and 3)
-    let ids: Vec<i64> = results.iter().filter_map(|r| r["id"].as_i64()).collect();
+    let ids: Vec<i64> = results
+        .iter()
+        .filter_map(|r| r["id"].as_str().and_then(|s| s.parse::<i64>().ok()))
+        .collect();
     assert!(
         ids.contains(&1) || ids.contains(&3),
         "Should find rust-related docs"
@@ -1230,7 +1233,7 @@ async fn test_sq8_collection_upsert_and_search() {
     let results = json["results"].as_array().expect("Not an array");
     assert_eq!(results.len(), 3);
     // First result should be exact match
-    assert_eq!(results[0]["id"], 1);
+    assert_eq!(results[0]["id"], "1");
 }
 
 // =============================================================================
@@ -2018,8 +2021,8 @@ async fn test_graph_get_edges_by_label() {
 
     assert_eq!(json["count"], 1);
     assert_eq!(json["edges"][0]["label"], "KNOWS");
-    assert_eq!(json["edges"][0]["source"], 100);
-    assert_eq!(json["edges"][0]["target"], 200);
+    assert_eq!(json["edges"][0]["source"], "100");
+    assert_eq!(json["edges"][0]["target"], "200");
 }
 
 #[tokio::test]
@@ -2233,7 +2236,7 @@ async fn test_graph_traverse_with_rel_type_filter() {
     // Should only find node 2 (KNOWS), not node 3 (WROTE)
     let results = json["results"].as_array().expect("Not an array");
     assert_eq!(results.len(), 1);
-    assert_eq!(results[0]["target_id"], 2);
+    assert_eq!(results[0]["target_id"], "2");
 }
 
 #[tokio::test]
@@ -2720,7 +2723,10 @@ async fn test_search_ids_with_filter() {
     let results = json["results"].as_array().expect("results is array");
 
     // Only IDs 1 and 3 have category="a"
-    let ids: Vec<u64> = results.iter().filter_map(|r| r["id"].as_u64()).collect();
+    let ids: Vec<u64> = results
+        .iter()
+        .filter_map(|r| r["id"].as_str().and_then(|s| s.parse::<u64>().ok()))
+        .collect();
     assert!(ids.contains(&1));
     assert!(ids.contains(&3));
     assert!(!ids.contains(&2));
@@ -2812,7 +2818,7 @@ async fn test_search_ids_with_mode() {
     assert!(!results.is_empty());
     // Verify id and score fields exist, but no payload
     for r in results {
-        assert!(r["id"].is_u64());
+        assert!(r["id"].is_string());
         assert!(r["score"].is_number());
         assert!(r.get("payload").is_none());
     }
@@ -2905,7 +2911,7 @@ async fn test_search_ids_sparse() {
 
     // Should return results as id+score only
     for r in results {
-        assert!(r["id"].is_u64());
+        assert!(r["id"].is_string());
         assert!(r["score"].is_number());
         assert!(r.get("payload").is_none());
     }

--- a/crates/velesdb-wasm/src/fusion.rs
+++ b/crates/velesdb-wasm/src/fusion.rs
@@ -18,11 +18,16 @@ use std::collections::HashMap;
 /// # Returns
 ///
 /// Fused results sorted by combined score (descending).
+/// # Errors
+///
+/// Returns an error if `strategy` is not one of the recognised names:
+/// `"average"` / `"avg"`, `"maximum"` / `"max"`, `"weighted"`,
+/// `"relative_score"` / `"rsf"`, `"rrf"`.
 pub fn fuse_results(
     all_results: &[Vec<(u64, f32)>],
     strategy: &str,
     rrf_k: u32,
-) -> Vec<(u64, f32)> {
+) -> Result<Vec<(u64, f32)>, String> {
     let mut scores: HashMap<u64, Vec<f32>> = HashMap::new();
     let mut ranks: HashMap<u64, Vec<usize>> = HashMap::new();
 
@@ -40,11 +45,19 @@ pub fn fuse_results(
         "maximum" | "max" => fuse_maximum(&scores),
         "weighted" => fuse_weighted(&scores, all_results.len()),
         "relative_score" | "rsf" => fuse_relative_score(all_results),
-        _ => fuse_rrf(&ranks, rrf_k),
+        "rrf" => fuse_rrf(&ranks, rrf_k),
+        // FIXME(PRE-SEED): New fusion strategies must be added here explicitly.
+        _ => {
+            return Err(format!(
+                "Unknown fusion strategy '{strategy}'. \
+                 Expected one of: average, avg, maximum, max, weighted, \
+                 relative_score, rsf, rrf"
+            ));
+        }
     };
 
     fused.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
-    fused
+    Ok(fused)
 }
 
 /// Average fusion: mean score across all queries.
@@ -147,7 +160,7 @@ mod tests {
             vec![(2, 1.0), (1, 0.5), (4, 0.3)],
         ];
 
-        let fused = fuse_results(&results, "rrf", 60);
+        let fused = fuse_results(&results, "rrf", 60).unwrap();
 
         // ID 1 and 2 should be at top (appear in both lists)
         assert!(fused.len() >= 2);
@@ -159,7 +172,7 @@ mod tests {
     fn test_fuse_average() {
         let results = vec![vec![(1, 0.8), (2, 0.6)], vec![(1, 0.6), (2, 0.8)]];
 
-        let fused = fuse_results(&results, "average", 60);
+        let fused = fuse_results(&results, "average", 60).unwrap();
 
         // Both should have average 0.7
         for (_, score) in &fused {
@@ -171,7 +184,7 @@ mod tests {
     fn test_fuse_maximum() {
         let results = vec![vec![(1, 0.9), (2, 0.5)], vec![(1, 0.3), (2, 0.8)]];
 
-        let fused = fuse_results(&results, "maximum", 60);
+        let fused = fuse_results(&results, "maximum", 60).unwrap();
 
         let id1_score = fused.iter().find(|(id, _)| *id == 1).map(|(_, s)| *s);
         let id2_score = fused.iter().find(|(id, _)| *id == 2).map(|(_, s)| *s);
@@ -183,14 +196,14 @@ mod tests {
     #[test]
     fn test_fuse_empty() {
         let results: Vec<Vec<(u64, f32)>> = vec![];
-        let fused = fuse_results(&results, "rrf", 60);
+        let fused = fuse_results(&results, "rrf", 60).unwrap();
         assert!(fused.is_empty());
     }
 
     #[test]
     fn test_fuse_single_query() {
         let results = vec![vec![(1, 0.9), (2, 0.8)]];
-        let fused = fuse_results(&results, "rrf", 60);
+        let fused = fuse_results(&results, "rrf", 60).unwrap();
 
         assert_eq!(fused.len(), 2);
         assert_eq!(fused[0].0, 1); // Higher RRF score (rank 0)
@@ -200,7 +213,7 @@ mod tests {
     fn test_fuse_weighted() {
         let results = vec![vec![(1, 0.8), (2, 0.6)], vec![(1, 0.6), (2, 0.8)]];
 
-        let fused = fuse_results(&results, "weighted", 60);
+        let fused = fuse_results(&results, "weighted", 60).unwrap();
 
         // Both docs appear in 2/2 queries => hit_ratio = 1.0
         // ID 1: avg=0.7, max=0.8 => 0.5*0.7 + 0.3*0.8 + 0.2*1.0 = 0.79
@@ -215,7 +228,7 @@ mod tests {
     fn test_fuse_relative_score() {
         let results = vec![vec![(1, 0.9), (2, 0.1)], vec![(1, 0.5), (2, 0.5)]];
 
-        let fused = fuse_results(&results, "relative_score", 60);
+        let fused = fuse_results(&results, "relative_score", 60).unwrap();
 
         // Query 0: range=0.8, ID 1 norm=(0.9-0.1)/0.8=1.0, ID 2 norm=0.0
         // Query 1: range=0, both get 0.5 (default when range==0, matches core)
@@ -230,7 +243,7 @@ mod tests {
     #[test]
     fn test_fuse_rsf_alias() {
         let results = vec![vec![(1, 0.9), (2, 0.1)]];
-        let fused = fuse_results(&results, "rsf", 60);
+        let fused = fuse_results(&results, "rsf", 60).unwrap();
         // "rsf" should behave like "relative_score"
         assert_eq!(fused.len(), 2);
     }
@@ -243,7 +256,7 @@ mod tests {
         // All scores identical within each branch → range ≈ 0
         let results = vec![vec![(1, 0.7), (2, 0.7)], vec![(1, 0.3), (2, 0.3)]];
 
-        let fused = fuse_results(&results, "relative_score", 60);
+        let fused = fuse_results(&results, "relative_score", 60).unwrap();
 
         // Both branches collapse to 0.5 per document → avg = 0.5
         assert_eq!(fused.len(), 2);
@@ -253,5 +266,15 @@ mod tests {
                 "equal-score branch must normalize to 0.5, got {score}"
             );
         }
+    }
+
+    #[test]
+    fn test_fuse_unknown_strategy_returns_error() {
+        let results = vec![vec![(1, 0.9), (2, 0.8)]];
+        let err = fuse_results(&results, "typo_strategy", 60).unwrap_err();
+        assert!(
+            err.contains("Unknown fusion strategy"),
+            "expected descriptive error, got: {err}"
+        );
     }
 }

--- a/crates/velesdb-wasm/src/lib_tests.rs
+++ b/crates/velesdb-wasm/src/lib_tests.rs
@@ -212,7 +212,7 @@ fn test_fuse_results_rrf() {
     let results2 = vec![(2, 0.95), (1, 0.85), (4, 0.6)];
     let all_results = vec![results1, results2];
 
-    let fused = fusion::fuse_results(&all_results, "rrf", 60);
+    let fused = fusion::fuse_results(&all_results, "rrf", 60).unwrap();
     assert!(!fused.is_empty());
     // ID 2 appears in rank 0 and rank 1, should have high RRF score
     // ID 1 appears in rank 0 and rank 1, should also be high
@@ -224,7 +224,7 @@ fn test_fuse_results_average() {
     let results2 = vec![(1, 0.7), (2, 0.6)];
     let all_results = vec![results1, results2];
 
-    let fused = fusion::fuse_results(&all_results, "average", 60);
+    let fused = fusion::fuse_results(&all_results, "average", 60).unwrap();
     assert_eq!(fused.len(), 2);
     // ID 1: (0.9 + 0.7) / 2 = 0.8
     // ID 2: (0.8 + 0.6) / 2 = 0.7
@@ -238,7 +238,7 @@ fn test_fuse_results_maximum() {
     let results2 = vec![(1, 0.7), (2, 0.8)];
     let all_results = vec![results1, results2];
 
-    let fused = fusion::fuse_results(&all_results, "maximum", 60);
+    let fused = fusion::fuse_results(&all_results, "maximum", 60).unwrap();
     // ID 1: max(0.9, 0.7) = 0.9
     // ID 2: max(0.5, 0.8) = 0.8
     let id1_score = fused.iter().find(|(id, _)| *id == 1).map(|(_, s)| *s);
@@ -250,7 +250,7 @@ fn test_fuse_results_maximum() {
 #[test]
 fn test_fuse_results_empty() {
     let all_results: Vec<Vec<(u64, f32)>> = vec![];
-    let fused = fusion::fuse_results(&all_results, "rrf", 60);
+    let fused = fusion::fuse_results(&all_results, "rrf", 60).unwrap();
     assert!(fused.is_empty());
 }
 

--- a/crates/velesdb-wasm/src/parsing.rs
+++ b/crates/velesdb-wasm/src/parsing.rs
@@ -57,7 +57,7 @@ const fn core_to_wasm_storage_mode(core: velesdb_core::StorageMode) -> StorageMo
         velesdb_core::StorageMode::Binary => StorageMode::Binary,
         velesdb_core::StorageMode::ProductQuantization => StorageMode::ProductQuantization,
         velesdb_core::StorageMode::RaBitQ => StorageMode::RaBitQ,
-        // Reason: StorageMode is #[non_exhaustive] — future variants default to Full.
+        // FIXME(PRE-SEED): New StorageMode variants silently map to Full. Update when core adds variants.
         _ => StorageMode::Full,
     }
 }

--- a/crates/velesdb-wasm/src/store_search.rs
+++ b/crates/velesdb-wasm/src/store_search.rs
@@ -227,7 +227,8 @@ pub fn multi_query_search_impl(
         all_results.push(results);
     }
 
-    let fused = fusion::fuse_results(&all_results, strategy, rrf_k.unwrap_or(60));
+    let fused = fusion::fuse_results(&all_results, strategy, rrf_k.unwrap_or(60))
+        .map_err(|e| JsValue::from_str(&e))?;
     let fused: Vec<(u64, f32)> = fused.into_iter().take(k).collect();
 
     to_js(&fused)

--- a/integrations/common/pyproject.toml
+++ b/integrations/common/pyproject.toml
@@ -12,8 +12,9 @@ authors = [
     {name = "VelesDB Team", email = "contact@wiscale.fr"}
 ]
 requires-python = ">=3.9"
-# No runtime dependencies beyond the stdlib — kept deliberately lean.
-dependencies = []
+dependencies = [
+    "velesdb>=1.12.0",
+]
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/integrations/langchain/pyproject.toml
+++ b/integrations/langchain/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 requires-python = ">=3.9"
 dependencies = [
     "langchain-core>=0.1.0,<1.0.0",
-    "velesdb>=1.9.0",
+    "velesdb>=1.12.0",
     "velesdb-common>=1.12.0",
 ]
 

--- a/integrations/langchain/src/langchain_velesdb/memory.py
+++ b/integrations/langchain/src/langchain_velesdb/memory.py
@@ -147,7 +147,8 @@ class VelesDBChatMemory(BaseChatMemory):
     def _events_to_messages(self, events: List) -> List[BaseMessage]:
         """Convert episodic events to LangChain messages."""
         messages = []
-        for _event_id, description, _timestamp in events:
+        for event in events:
+            description = event["description"]
             role, content = parse_event_entry(description)
             if role == "human":
                 messages.append(HumanMessage(content=content))
@@ -158,7 +159,8 @@ class VelesDBChatMemory(BaseChatMemory):
     def _events_to_string(self, events: List) -> str:
         """Convert episodic events to formatted string."""
         lines = []
-        for _event_id, description, _timestamp in events:
+        for event in events:
+            description = event["description"]
             role, content = parse_event_entry(description)
             prefix = self.human_prefix if role == "human" else self.ai_prefix
             lines.append(f"{prefix}: {content}")

--- a/integrations/langchain/src/langchain_velesdb/multi_query_ops.py
+++ b/integrations/langchain/src/langchain_velesdb/multi_query_ops.py
@@ -1,0 +1,237 @@
+"""Batch and multi-query search mixin for VelesDBVectorStore.
+
+Contains batch_search, batch_search_with_score, multi_query_search,
+multi_query_search_with_score, and related internal helpers, extracted
+from search_ops.py to keep each module under the 500 NLOC limit.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, List, Optional, Tuple
+
+from langchain_core.documents import Document
+
+from langchain_velesdb._common import payload_to_doc_parts, validate_queries_batch
+from velesdb_common.fusion import build_fusion_strategy as _build_fusion_strategy_fn
+from langchain_velesdb.security import (
+    validate_k,
+    validate_text,
+    validate_batch_size,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _payload_to_doc(result: dict) -> Document:
+    """Convert a single search result dict to a LangChain Document."""
+    text, metadata = payload_to_doc_parts(result)
+    return Document(page_content=text, metadata=metadata)
+
+
+def _results_to_docs(results: List[dict]) -> List[Document]:
+    """Convert a list of search result dicts to Documents."""
+    return [_payload_to_doc(r) for r in results]
+
+
+def _results_to_docs_with_score(results: List[dict]) -> List[Tuple[Document, float]]:
+    """Convert a list of search result dicts to (Document, score) tuples."""
+    return [(_payload_to_doc(r), r.get("score", 0.0)) for r in results]
+
+
+class MultiQueryOpsMixin:
+    """Mixin providing batch and multi-query search operations.
+
+    Expects the host class to provide:
+        - ``self._embedding``: Embeddings model
+        - ``self._get_collection(dimension)``: Returns or creates the collection
+    """
+
+    def _validate_and_embed_queries(
+        self,
+        queries: List[str],
+        k: int,
+    ) -> tuple[List[List[float]], Any]:
+        """Validate query batch, embed all queries, and return the collection.
+
+        Centralises the validate → embed → get_collection steps shared by
+        ``_run_batch_search`` and ``_run_multi_query``.
+
+        Args:
+            queries: Non-empty list of query strings.
+            k: Top-k value to validate.
+
+        Returns:
+            A ``(query_embeddings, collection)`` tuple.
+        """
+        validate_queries_batch(
+            queries,
+            validate_k_fn=validate_k,
+            validate_batch_size_fn=validate_batch_size,
+            validate_text_fn=validate_text,
+            k=k,
+        )
+        query_embeddings = [self._embedding.embed_query(q) for q in queries]
+        collection = self._get_collection(len(query_embeddings[0]))
+        return query_embeddings, collection
+
+    def _run_batch_search(self, queries: List[str], k: int) -> List[List[dict]]:
+        """Validate, embed, and execute a batch search, returning raw results.
+
+        Args:
+            queries: Non-empty list of query strings (caller guarantees non-empty).
+            k: Number of results per query.
+
+        Returns:
+            Raw list-of-lists of result dicts from the collection.
+        """
+        query_embeddings, collection = self._validate_and_embed_queries(queries, k)
+        searches = [{"vector": emb, "top_k": k} for emb in query_embeddings]
+        return collection.batch_search(searches)
+
+    def batch_search(
+        self,
+        queries: List[str],
+        k: int = 4,
+        **kwargs: Any,
+    ) -> List[List[Document]]:
+        """Batch search for multiple queries in parallel.
+
+        Optimized for high throughput when searching with multiple queries.
+
+        Args:
+            queries: List of query strings.
+            k: Number of results per query. Defaults to 4.
+            **kwargs: Additional arguments.
+
+        Returns:
+            List of Document lists, one per query.
+        """
+        if not queries:
+            return []
+        return [_results_to_docs(r) for r in self._run_batch_search(queries, k)]
+
+    def batch_search_with_score(
+        self,
+        queries: List[str],
+        k: int = 4,
+        **kwargs: Any,
+    ) -> List[List[Tuple[Document, float]]]:
+        """Batch search with scores for multiple queries.
+
+        Args:
+            queries: List of query strings.
+            k: Number of results per query. Defaults to 4.
+            **kwargs: Additional arguments.
+
+        Returns:
+            List of (Document, score) tuple lists, one per query.
+        """
+        if not queries:
+            return []
+        return [_results_to_docs_with_score(r) for r in self._run_batch_search(queries, k)]
+
+    def _run_multi_query(
+        self,
+        queries: List[str],
+        k: int,
+        fusion: str,
+        fusion_params: Optional[dict],
+        query_filter: Optional[dict],
+    ) -> List[dict]:
+        """Validate inputs and execute a multi-query search, returning raw results.
+
+        Args:
+            queries: Non-empty list of query strings.
+            k: Number of results to return after fusion.
+            fusion: Fusion strategy name.
+            fusion_params: Optional fusion strategy parameters.
+            query_filter: Optional metadata filter dict.
+
+        Returns:
+            Raw list of search result dicts from the collection.
+        """
+        query_embeddings, collection = self._validate_and_embed_queries(queries, k)
+        fusion_strategy = self._build_fusion_strategy(fusion, fusion_params)
+        return collection.multi_query_search(
+            vectors=query_embeddings,
+            top_k=k,
+            fusion=fusion_strategy,
+            filter=query_filter,
+        )
+
+    def multi_query_search(
+        self,
+        queries: List[str],
+        k: int = 4,
+        fusion: str = "rrf",
+        fusion_params: Optional[dict] = None,
+        filter: Optional[dict] = None,
+        **kwargs: Any,
+    ) -> List[Document]:
+        """Multi-query search with result fusion.
+
+        Executes parallel searches for multiple query strings and fuses
+        the results using the specified fusion strategy. Ideal for
+        Multiple Query Generation (MQG) pipelines.
+
+        Args:
+            queries: List of query strings (reformulations of user query).
+            k: Number of results to return after fusion. Defaults to 4.
+            fusion: Fusion strategy - "average", "maximum", "rrf", or "weighted".
+                Defaults to "rrf".
+            fusion_params: Optional parameters for fusion strategy:
+                - For "rrf": {"k": 60} (ranking constant)
+                - For "weighted": {"avg_weight": 0.6, "max_weight": 0.3, "hit_weight": 0.1}
+            filter: Optional metadata filter dict.
+            **kwargs: Additional arguments.
+
+        Returns:
+            List of Documents with fused ranking.
+
+        Raises:
+            SecurityError: If parameters fail validation.
+        """
+        if not queries:
+            return []
+        results = self._run_multi_query(queries, k, fusion, fusion_params, query_filter=filter)
+        return _results_to_docs(results)
+
+    def multi_query_search_with_score(
+        self,
+        queries: List[str],
+        k: int = 4,
+        fusion: str = "rrf",
+        fusion_params: Optional[dict] = None,
+        filter: Optional[dict] = None,
+        **kwargs: Any,
+    ) -> List[Tuple[Document, float]]:
+        """Multi-query search with fused scores.
+
+        Args:
+            queries: List of query strings.
+            k: Number of results. Defaults to 4.
+            fusion: Fusion strategy. Defaults to "rrf".
+            fusion_params: Optional fusion parameters.
+            filter: Optional metadata filter.
+            **kwargs: Additional arguments.
+
+        Returns:
+            List of (Document, fused_score) tuples.
+        """
+        if not queries:
+            return []
+        results = self._run_multi_query(queries, k, fusion, fusion_params, query_filter=filter)
+        return _results_to_docs_with_score(results)
+
+    def _build_fusion_strategy(
+        self,
+        fusion: str,
+        fusion_params: Optional[dict] = None,
+    ) -> object:
+        """Build a FusionStrategy from string name and params.
+
+        Delegates to :func:`velesdb_common.fusion.build_fusion_strategy`
+        to avoid duplication with the LlamaIndex integration.
+        """
+        return _build_fusion_strategy_fn(fusion, fusion_params)

--- a/integrations/langchain/src/langchain_velesdb/point_builder.py
+++ b/integrations/langchain/src/langchain_velesdb/point_builder.py
@@ -1,0 +1,50 @@
+"""Point construction helpers for LangChain VelesDB VectorStore.
+
+Extracted from vectorstore.py to keep each module under the 500 NLOC
+limit. Contains functions for building VelesDB point dicts and flushing
+batches through the streaming insertion channel.
+"""
+
+from __future__ import annotations
+
+from typing import Any, List, Optional
+
+
+def build_point(
+    int_id: int,
+    text: str,
+    embedding: List[float],
+    metadata: Optional[dict] = None,
+    sparse_vector: Optional[dict] = None,
+) -> dict:
+    """Build a single VelesDB point dict.
+
+    Args:
+        int_id: Numeric point identifier.
+        text: Document text for the payload.
+        embedding: Dense embedding vector.
+        metadata: Optional metadata to merge into the payload.
+        sparse_vector: Optional sparse vector dict for hybrid search.
+
+    Returns:
+        A VelesDB point dict ready for upsert or stream_insert.
+    """
+    payload: dict = {"text": text}
+    if metadata is not None:
+        payload.update(metadata)
+    point: dict = {"id": int_id, "vector": embedding, "payload": payload}
+    if sparse_vector is not None:
+        point["sparse_vector"] = sparse_vector
+    return point
+
+
+def flush_stream_batches(collection: Any, points: list, batch_size: int) -> None:
+    """Send points to a collection in batches via stream_insert.
+
+    Args:
+        collection: VelesDB collection with a ``stream_insert`` method.
+        points: List of point dicts to insert.
+        batch_size: Maximum number of points per streaming batch.
+    """
+    for start in range(0, len(points), batch_size):
+        collection.stream_insert(points[start : start + batch_size])

--- a/integrations/langchain/src/langchain_velesdb/search_ops.py
+++ b/integrations/langchain/src/langchain_velesdb/search_ops.py
@@ -1,7 +1,10 @@
 """Search operation mixins for VelesDBVectorStore.
 
-Contains all search/query methods extracted from vectorstore.py to keep
-file size under the 500 NLOC limit (US-005).
+Contains vector/hybrid/text/sparse search methods extracted from
+vectorstore.py to keep each file under the 500 NLOC limit (US-005).
+
+Batch and multi-query search methods live in:
+- :mod:`langchain_velesdb.multi_query_ops` — batch_search, multi_query_search
 """
 
 from __future__ import annotations
@@ -11,13 +14,12 @@ from typing import Any, List, Optional, Tuple
 
 from langchain_core.documents import Document
 
-from langchain_velesdb._common import payload_to_doc_parts, validate_queries_batch
-from velesdb_common.fusion import build_fusion_strategy as _build_fusion_strategy_fn
+from langchain_velesdb._common import payload_to_doc_parts
+from langchain_velesdb.multi_query_ops import MultiQueryOpsMixin
 from langchain_velesdb.security import (
     validate_k,
     validate_text,
     validate_weight,
-    validate_batch_size,
     validate_sparse_vector,
     validate_query,
     validate_collection_name,
@@ -43,7 +45,7 @@ def _results_to_docs_with_score(results: List[dict]) -> List[Tuple[Document, flo
     return [(_payload_to_doc(r), r.get("score", 0.0)) for r in results]
 
 
-class SearchOpsMixin:
+class SearchOpsMixin(MultiQueryOpsMixin):
     """Mixin providing all search and query operations for VelesDBVectorStore.
 
     Expects the host class to provide:
@@ -51,6 +53,9 @@ class SearchOpsMixin:
         - ``self._collection``: Optional VelesDB collection (may be None)
         - ``self._get_collection(dimension)``: Returns or creates the collection
         - ``self._to_document(result)``: Converts a result dict to a Document
+
+    Batch and multi-query methods are inherited from
+    :class:`~langchain_velesdb.multi_query_ops.MultiQueryOpsMixin`.
     """
 
     def _run_vector_search(
@@ -90,7 +95,10 @@ class SearchOpsMixin:
 
         if ids_only:
             if filter is not None:
-                return collection.search_ids(query_embedding, top_k=k, filter=filter)
+                results = collection.search_with_filter(
+                    query_embedding, top_k=k, filter=filter,
+                )
+                return [{"id": r["id"], "score": r["score"]} for r in results]
             return collection.search_ids(query_embedding, top_k=k)
 
         if ef_search is not None:
@@ -420,192 +428,3 @@ class SearchOpsMixin:
             text, metadata = payload_to_doc_parts(result)
             documents.append(Document(page_content=text, metadata=metadata))
         return documents
-
-    def _validate_and_embed_queries(
-        self,
-        queries: List[str],
-        k: int,
-    ) -> tuple[List[List[float]], Any]:
-        """Validate query batch, embed all queries, and return the collection.
-
-        Centralises the validate → embed → get_collection steps shared by
-        ``_run_batch_search`` and ``_run_multi_query``.
-
-        Args:
-            queries: Non-empty list of query strings.
-            k: Top-k value to validate.
-
-        Returns:
-            A ``(query_embeddings, collection)`` tuple.
-        """
-        validate_queries_batch(
-            queries,
-            validate_k_fn=validate_k,
-            validate_batch_size_fn=validate_batch_size,
-            validate_text_fn=validate_text,
-            k=k,
-        )
-        query_embeddings = [self._embedding.embed_query(q) for q in queries]
-        collection = self._get_collection(len(query_embeddings[0]))
-        return query_embeddings, collection
-
-    def _run_batch_search(self, queries: List[str], k: int) -> List[List[dict]]:
-        """Validate, embed, and execute a batch search, returning raw results.
-
-        Args:
-            queries: Non-empty list of query strings (caller guarantees non-empty).
-            k: Number of results per query.
-
-        Returns:
-            Raw list-of-lists of result dicts from the collection.
-        """
-        query_embeddings, collection = self._validate_and_embed_queries(queries, k)
-        searches = [{"vector": emb, "top_k": k} for emb in query_embeddings]
-        return collection.batch_search(searches)
-
-    def batch_search(
-        self,
-        queries: List[str],
-        k: int = 4,
-        **kwargs: Any,
-    ) -> List[List[Document]]:
-        """Batch search for multiple queries in parallel.
-
-        Optimized for high throughput when searching with multiple queries.
-
-        Args:
-            queries: List of query strings.
-            k: Number of results per query. Defaults to 4.
-            **kwargs: Additional arguments.
-
-        Returns:
-            List of Document lists, one per query.
-        """
-        if not queries:
-            return []
-        return [_results_to_docs(r) for r in self._run_batch_search(queries, k)]
-
-    def batch_search_with_score(
-        self,
-        queries: List[str],
-        k: int = 4,
-        **kwargs: Any,
-    ) -> List[List[Tuple[Document, float]]]:
-        """Batch search with scores for multiple queries.
-
-        Args:
-            queries: List of query strings.
-            k: Number of results per query. Defaults to 4.
-            **kwargs: Additional arguments.
-
-        Returns:
-            List of (Document, score) tuple lists, one per query.
-        """
-        if not queries:
-            return []
-        return [_results_to_docs_with_score(r) for r in self._run_batch_search(queries, k)]
-
-    def _run_multi_query(
-        self,
-        queries: List[str],
-        k: int,
-        fusion: str,
-        fusion_params: Optional[dict],
-        query_filter: Optional[dict],
-    ) -> List[dict]:
-        """Validate inputs and execute a multi-query search, returning raw results.
-
-        Args:
-            queries: Non-empty list of query strings.
-            k: Number of results to return after fusion.
-            fusion: Fusion strategy name.
-            fusion_params: Optional fusion strategy parameters.
-            query_filter: Optional metadata filter dict.
-
-        Returns:
-            Raw list of search result dicts from the collection.
-        """
-        query_embeddings, collection = self._validate_and_embed_queries(queries, k)
-        fusion_strategy = self._build_fusion_strategy(fusion, fusion_params)
-        return collection.multi_query_search(
-            vectors=query_embeddings,
-            top_k=k,
-            fusion=fusion_strategy,
-            filter=query_filter,
-        )
-
-    def multi_query_search(
-        self,
-        queries: List[str],
-        k: int = 4,
-        fusion: str = "rrf",
-        fusion_params: Optional[dict] = None,
-        filter: Optional[dict] = None,
-        **kwargs: Any,
-    ) -> List[Document]:
-        """Multi-query search with result fusion.
-
-        Executes parallel searches for multiple query strings and fuses
-        the results using the specified fusion strategy. Ideal for
-        Multiple Query Generation (MQG) pipelines.
-
-        Args:
-            queries: List of query strings (reformulations of user query).
-            k: Number of results to return after fusion. Defaults to 4.
-            fusion: Fusion strategy - "average", "maximum", "rrf", or "weighted".
-                Defaults to "rrf".
-            fusion_params: Optional parameters for fusion strategy:
-                - For "rrf": {"k": 60} (ranking constant)
-                - For "weighted": {"avg_weight": 0.6, "max_weight": 0.3, "hit_weight": 0.1}
-            filter: Optional metadata filter dict.
-            **kwargs: Additional arguments.
-
-        Returns:
-            List of Documents with fused ranking.
-
-        Raises:
-            SecurityError: If parameters fail validation.
-        """
-        if not queries:
-            return []
-        results = self._run_multi_query(queries, k, fusion, fusion_params, query_filter=filter)
-        return _results_to_docs(results)
-
-    def multi_query_search_with_score(
-        self,
-        queries: List[str],
-        k: int = 4,
-        fusion: str = "rrf",
-        fusion_params: Optional[dict] = None,
-        filter: Optional[dict] = None,
-        **kwargs: Any,
-    ) -> List[Tuple[Document, float]]:
-        """Multi-query search with fused scores.
-
-        Args:
-            queries: List of query strings.
-            k: Number of results. Defaults to 4.
-            fusion: Fusion strategy. Defaults to "rrf".
-            fusion_params: Optional fusion parameters.
-            filter: Optional metadata filter.
-            **kwargs: Additional arguments.
-
-        Returns:
-            List of (Document, fused_score) tuples.
-        """
-        if not queries:
-            return []
-        results = self._run_multi_query(queries, k, fusion, fusion_params, query_filter=filter)
-        return _results_to_docs_with_score(results)
-
-    def _build_fusion_strategy(
-        self,
-        fusion: str,
-        fusion_params: Optional[dict] = None,
-    ) -> object:
-        """Build a FusionStrategy from string name and params.
-
-        Delegates to :func:`velesdb_common.fusion.build_fusion_strategy`
-        to avoid duplication with the LlamaIndex integration.
-        """
-        return _build_fusion_strategy_fn(fusion, fusion_params)

--- a/integrations/langchain/src/langchain_velesdb/vectorstore.py
+++ b/integrations/langchain/src/langchain_velesdb/vectorstore.py
@@ -5,8 +5,12 @@ as the underlying vector database for storing and retrieving embeddings.
 
 Search and query operations are implemented in focused mixin modules:
 - :mod:`langchain_velesdb.search_ops` — vector/hybrid/text/batch/multi-query search
+- :mod:`langchain_velesdb.multi_query_ops` — batch and multi-query search
 - :mod:`langchain_velesdb.graph_ops` — VelesQL and MATCH query operations
 - :mod:`langchain_velesdb.scroll_ops` — cursor-paginated scroll iteration
+
+Point construction and streaming helpers live in:
+- :mod:`langchain_velesdb.point_builder` — build_point, flush_stream_batches
 """
 
 from __future__ import annotations
@@ -35,34 +39,12 @@ from langchain_velesdb.security import (
 from velesdb_common.collection_admin import CollectionAdminMixin
 from velesdb_common.ids import stable_hash_id as _stable_hash_id
 from langchain_velesdb._common import payload_to_doc_parts
+from langchain_velesdb.point_builder import build_point as _build_point, flush_stream_batches as _flush_stream_batches
 from langchain_velesdb.search_ops import SearchOpsMixin
 from langchain_velesdb.graph_ops import GraphOpsMixin
 from langchain_velesdb.scroll_ops import ScrollOpsMixin, _scroll_one_batch  # noqa: F401
 
 logger = logging.getLogger(__name__)
-
-
-def _flush_stream_batches(collection: Any, points: list, batch_size: int) -> None:
-    """Send points to a collection in batches via stream_insert."""
-    for start in range(0, len(points), batch_size):
-        collection.stream_insert(points[start : start + batch_size])
-
-
-def _build_point(
-    int_id: int,
-    text: str,
-    embedding: List[float],
-    metadata: Optional[dict] = None,
-    sparse_vector: Optional[dict] = None,
-) -> dict:
-    """Build a single VelesDB point dict."""
-    payload: dict = {"text": text}
-    if metadata is not None:
-        payload.update(metadata)
-    point: dict = {"id": int_id, "vector": embedding, "payload": payload}
-    if sparse_vector is not None:
-        point["sparse_vector"] = sparse_vector
-    return point
 
 
 class VelesDBVectorStore(CollectionAdminMixin, SearchOpsMixin, GraphOpsMixin, ScrollOpsMixin, VectorStore):
@@ -512,6 +494,7 @@ class VelesDBVectorStore(CollectionAdminMixin, SearchOpsMixin, GraphOpsMixin, Sc
         if not texts_list:
             return []
 
+        validate_batch_size(len(texts_list))
         for text in texts_list:
             validate_text(text)
 

--- a/integrations/langchain/tests/test_vectorstore.py
+++ b/integrations/langchain/tests/test_vectorstore.py
@@ -876,11 +876,11 @@ class TestV15Features:
         with pytest.raises(SecurityError):
             validate_sparse_vector({True: 1.0})
 
-    def test_version_is_1_7_0(self):
-        """Test that package version is 1.7.0."""
+    def test_version_is_current(self):
+        """Test that package version matches workspace version."""
         from langchain_velesdb import __version__
 
-        assert __version__ == "1.7.0"
+        assert __version__ == "1.12.0"
 
 
 class TestServerUrlValidation:

--- a/integrations/llamaindex/pyproject.toml
+++ b/integrations/llamaindex/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 
 dependencies = [
     "llama-index-core>=0.10.0,<1.0.0",
-    "velesdb>=1.9.0",
+    "velesdb>=1.12.0",
     "velesdb-common>=1.12.0",
 ]
 

--- a/integrations/llamaindex/src/llamaindex_velesdb/node_builder.py
+++ b/integrations/llamaindex/src/llamaindex_velesdb/node_builder.py
@@ -1,0 +1,136 @@
+"""Node construction helpers for LlamaIndex VelesDB VectorStore.
+
+Extracted from vectorstore.py to keep each module under the 500 NLOC
+limit. Contains functions for building VelesDB point dicts from
+LlamaIndex nodes and flushing batches through the streaming channel.
+"""
+
+from __future__ import annotations
+
+from typing import Any, List, Optional
+
+from llama_index.core.schema import BaseNode
+
+from velesdb_common.ids import stable_hash_id as _stable_hash_id
+
+
+def validate_all_embeddings(nodes: List[BaseNode]) -> None:
+    """Validate that every node has an embedding (required for sparse alignment).
+
+    Args:
+        nodes: List of LlamaIndex nodes to check.
+
+    Raises:
+        ValueError: If any node is missing an embedding.
+    """
+    for i, node in enumerate(nodes):
+        if node.get_embedding() is None:
+            raise ValueError(
+                f"Node at index {i} has no embedding. All nodes must have embeddings "
+                f"when sparse_vectors are provided to preserve index alignment."
+            )
+
+
+def build_node_payload(node: BaseNode) -> dict:
+    """Build a VelesDB payload dict from a LlamaIndex node.
+
+    Args:
+        node: A LlamaIndex node with optional metadata.
+
+    Returns:
+        Dict with ``text`` and ``node_id`` keys, plus scalar metadata fields.
+    """
+    node_id = node.node_id
+    payload: dict = {"text": node.get_content(), "node_id": node_id}
+    if hasattr(node, "metadata") and node.metadata:
+        for key, value in node.metadata.items():
+            if isinstance(value, (str, int, float, bool)):
+                payload[key] = value
+    return payload
+
+
+def build_points_with_ids(
+    nodes: List[BaseNode],
+    sparse_vectors: Optional[list] = None,
+) -> tuple[list, List[str]]:
+    """Convert nodes to VelesDB points and collect node IDs.
+
+    Nodes without embeddings are skipped silently (use
+    :func:`validate_all_embeddings` first if you need strict enforcement).
+
+    Args:
+        nodes: List of LlamaIndex nodes with optional embeddings.
+        sparse_vectors: Optional list of sparse vector dicts aligned with nodes.
+
+    Returns:
+        A ``(points, ids)`` tuple where ``points`` is the VelesDB point list
+        and ``ids`` is the list of node ID strings.
+    """
+    points: list = []
+    ids: List[str] = []
+    for idx, node in enumerate(nodes):
+        embedding = node.get_embedding()
+        if embedding is None:
+            continue
+        node_id = node.node_id
+        ids.append(node_id)
+        point: dict = {
+            "id": _stable_hash_id(node_id),
+            "vector": embedding,
+            "payload": build_node_payload(node),
+        }
+        if sparse_vectors is not None and idx < len(sparse_vectors):
+            point["sparse_vector"] = sparse_vectors[idx]
+        points.append(point)
+    return points, ids
+
+
+def flush_in_batches(collection: Any, points: list, batch_size: int) -> None:
+    """Send points to a collection in batches via stream_insert.
+
+    Args:
+        collection: VelesDB collection with a ``stream_insert`` method.
+        points: List of point dicts to insert.
+        batch_size: Maximum number of points per streaming batch.
+    """
+    for start in range(0, len(points), batch_size):
+        collection.stream_insert(points[start : start + batch_size])
+
+
+def build_stream_points(
+    nodes: List[BaseNode],
+    sparse_vectors: Optional[list] = None,
+) -> list:
+    """Convert nodes to VelesDB points, requiring all nodes have embeddings.
+
+    Unlike :func:`build_points_with_ids`, this raises immediately if any
+    node is missing an embedding, making it safe for streaming workflows
+    that must not silently drop data.
+
+    Args:
+        nodes: List of LlamaIndex nodes — all must have embeddings.
+        sparse_vectors: Optional list of sparse vector dicts aligned with nodes.
+
+    Returns:
+        List of VelesDB point dicts.
+
+    Raises:
+        ValueError: If any node is missing an embedding.
+    """
+    points: list = []
+    for idx, node in enumerate(nodes):
+        embedding = node.get_embedding()
+        if embedding is None:
+            raise ValueError(
+                f"Node at index {idx} (id={node.node_id!r}) has no embedding. "
+                f"All nodes passed to stream_insert must have embeddings."
+            )
+        point: dict = {
+            "id": _stable_hash_id(node.node_id),
+            "vector": embedding,
+            "payload": build_node_payload(node),
+        }
+        if sparse_vectors is not None and idx < len(sparse_vectors):
+            point["sparse_vector"] = sparse_vectors[idx]
+        points.append(point)
+    return points

--- a/integrations/llamaindex/src/llamaindex_velesdb/search_ops.py
+++ b/integrations/llamaindex/src/llamaindex_velesdb/search_ops.py
@@ -350,16 +350,18 @@ class SearchOpsMixin:
         # Security: Validate batch size
         validate_batch_size(len(queries))
 
-        first_emb = queries[0].query_embedding
-        if first_emb is None:
-            return [VectorStoreQueryResult(nodes=[], similarities=[], ids=[])
-                    for _ in queries]
+        missing = [i for i, q in enumerate(queries) if q.query_embedding is None]
+        if missing:
+            raise ValueError(
+                f"Queries at indices {missing} have no embedding. "
+                "All queries in a batch must have a query_embedding set."
+            )
 
-        dimension = len(first_emb)
+        dimension = len(queries[0].query_embedding)  # type: ignore[arg-type]
         collection = self._get_collection(dimension)
 
         searches = [{"vector": q.query_embedding, "top_k": q.similarity_top_k or 10}
-                    for q in queries if q.query_embedding is not None]
+                    for q in queries]
 
         batch_results = collection.batch_search(searches)
 
@@ -478,14 +480,5 @@ class SearchOpsMixin:
         dimension = len(query_embedding)
         collection = self._get_collection(dimension)
         raw = collection.search_ids(query_embedding, top_k=top_k)
-        # search_ids returns [{id, score}, ...]; extract the node_id string
-        # stored in the payload, falling back to the numeric point ID.
-        ids: List[str] = []
-        for entry in raw:
-            payload = entry.get("payload", {})
-            node_id = payload.get("node_id")
-            if node_id is not None:
-                ids.append(str(node_id))
-            else:
-                ids.append(str(entry.get("id", "")))
-        return ids
+        # search_ids returns [{id, score}, ...] — no payload.
+        return [str(entry["id"]) for entry in raw]

--- a/integrations/llamaindex/src/llamaindex_velesdb/vectorstore.py
+++ b/integrations/llamaindex/src/llamaindex_velesdb/vectorstore.py
@@ -2,6 +2,9 @@
 
 This module provides a LlamaIndex-compatible VectorStore that uses VelesDB
 as the underlying vector database for storing and retrieving embeddings.
+
+Node construction and streaming helpers live in a dedicated module:
+- :mod:`llamaindex_velesdb.node_builder` — build_points_with_ids, flush_in_batches, etc.
 """
 
 from __future__ import annotations
@@ -30,6 +33,12 @@ from llamaindex_velesdb.security import (
 from velesdb_common.collection_admin import CollectionAdminMixin
 from velesdb_common.ids import stable_hash_id as _stable_hash_id
 from llamaindex_velesdb.filter_ops import metadata_filters_to_core_filter
+from llamaindex_velesdb.node_builder import (
+    validate_all_embeddings as _validate_all_embeddings,
+    build_points_with_ids as _build_points_with_ids,
+    flush_in_batches as _flush_in_batches,
+    build_stream_points as _build_stream_points,
+)
 from llamaindex_velesdb.search_ops import SearchOpsMixin
 from llamaindex_velesdb.graph_ops import GraphOpsMixin
 from llamaindex_velesdb.scroll_ops import ScrollOpsMixin, _scroll_one_batch  # noqa: F401
@@ -44,81 +53,6 @@ __all__ = [
 ]
 
 logger = logging.getLogger(__name__)
-
-
-def _validate_all_embeddings(nodes: List[BaseNode]) -> None:
-    """Validate that every node has an embedding (required for sparse alignment)."""
-    for i, node in enumerate(nodes):
-        if node.get_embedding() is None:
-            raise ValueError(
-                f"Node at index {i} has no embedding. All nodes must have embeddings "
-                f"when sparse_vectors are provided to preserve index alignment."
-            )
-
-
-def _build_node_payload(node: BaseNode) -> dict:
-    """Build a VelesDB payload dict from a LlamaIndex node."""
-    node_id = node.node_id
-    payload: dict = {"text": node.get_content(), "node_id": node_id}
-    if hasattr(node, "metadata") and node.metadata:
-        for key, value in node.metadata.items():
-            if isinstance(value, (str, int, float, bool)):
-                payload[key] = value
-    return payload
-
-
-def _build_points_with_ids(
-    nodes: List[BaseNode],
-    sparse_vectors: Optional[list] = None,
-) -> tuple[list, List[str]]:
-    """Convert nodes to VelesDB points and collect node IDs."""
-    points: list = []
-    ids: List[str] = []
-    for idx, node in enumerate(nodes):
-        embedding = node.get_embedding()
-        if embedding is None:
-            continue
-        node_id = node.node_id
-        ids.append(node_id)
-        point: dict = {
-            "id": _stable_hash_id(node_id),
-            "vector": embedding,
-            "payload": _build_node_payload(node),
-        }
-        if sparse_vectors is not None and idx < len(sparse_vectors):
-            point["sparse_vector"] = sparse_vectors[idx]
-        points.append(point)
-    return points, ids
-
-
-def _flush_in_batches(collection: Any, points: list, batch_size: int) -> None:
-    """Send points to a collection in batches via stream_insert."""
-    for start in range(0, len(points), batch_size):
-        collection.stream_insert(points[start : start + batch_size])
-
-
-def _build_stream_points(
-    nodes: List[BaseNode],
-    sparse_vectors: Optional[list] = None,
-) -> list:
-    """Convert nodes to VelesDB points, requiring all nodes have embeddings."""
-    points: list = []
-    for idx, node in enumerate(nodes):
-        embedding = node.get_embedding()
-        if embedding is None:
-            raise ValueError(
-                f"Node at index {idx} (id={node.node_id!r}) has no embedding. "
-                f"All nodes passed to stream_insert must have embeddings."
-            )
-        point: dict = {
-            "id": _stable_hash_id(node.node_id),
-            "vector": embedding,
-            "payload": _build_node_payload(node),
-        }
-        if sparse_vectors is not None and idx < len(sparse_vectors):
-            point["sparse_vector"] = sparse_vectors[idx]
-        points.append(point)
-    return points
 
 
 class VelesDBVectorStore(CollectionAdminMixin, SearchOpsMixin, GraphOpsMixin, ScrollOpsMixin, BasePydanticVectorStore):

--- a/integrations/llamaindex/tests/test_vectorstore.py
+++ b/integrations/llamaindex/tests/test_vectorstore.py
@@ -787,11 +787,11 @@ class TestV15Features:
         with pytest.raises(SecurityError):
             validate_sparse_vector({True: 1.0})
 
-    def test_version_is_1_7_0(self):
-        """Test that __version__ is 1.7.0."""
+    def test_version_is_current(self):
+        """Test that __version__ matches workspace version."""
         from llamaindex_velesdb import __version__
 
-        assert __version__ == "1.7.0"
+        assert __version__ == "1.12.0"
 
 
 class TestServerUrlValidation:

--- a/scripts/check-todo-annotations.py
+++ b/scripts/check-todo-annotations.py
@@ -8,7 +8,7 @@ Rule:
   - #<number>
   - #issue
 
-By default, checks `crates/velesdb-core/src/**/*.rs` excluding test/bench-like files.
+By default, checks all workspace crate `src/**/*.rs` excluding test/bench-like files.
 """
 
 from __future__ import annotations
@@ -21,7 +21,12 @@ from pathlib import Path
 
 ANNOTATION_RE = re.compile(r"\b(TODO|FIXME|HACK)\b")
 TAG_RE = re.compile(
-    r"(?:\[EPIC-[A-Za-z0-9.-]+/US-[A-Za-z0-9.-]+\]|#\d+|#issue)",
+    r"(?:"
+    r"\[EPIC-[A-Za-z0-9.-]+/US-[A-Za-z0-9.-]+\]"  # [EPIC-XXX/US-YYY]
+    r"|\([A-Z][A-Z0-9]*(?:-[A-Z0-9]+)+\)"  # (EPIC-001), (US-GRAPH-01), (PRE-SEED), (MIGRATE-01), etc.
+    r"|#\d+"  # #123
+    r"|#issue"  # #issue
+    r")",
     re.IGNORECASE,
 )
 
@@ -39,10 +44,21 @@ def is_production_file(path: Path) -> bool:
 
 
 def iter_default_files() -> list[Path]:
-    root = Path("crates/velesdb-core/src")
-    if not root.exists():
-        return []
-    return [p for p in root.rglob("*.rs") if is_production_file(p)]
+    roots = [
+        Path("crates/velesdb-core/src"),
+        Path("crates/velesdb-server/src"),
+        Path("crates/velesdb-cli/src"),
+        Path("crates/velesdb-migrate/src"),
+        Path("crates/velesdb-mobile/src"),
+        Path("crates/velesdb-wasm/src"),
+        Path("crates/tauri-plugin-velesdb/src"),
+    ]
+    files: list[Path] = []
+    for root in roots:
+        if not root.exists():
+            continue
+        files.extend(p for p in root.rglob("*.rs") if is_production_file(p))
+    return files
 
 
 def check_files(files: list[Path]) -> list[str]:

--- a/scripts/check_prod_unwraps.py
+++ b/scripts/check_prod_unwraps.py
@@ -2,8 +2,8 @@
 """
 Detect `.unwrap()` calls in production Rust code.
 
-Scans `crates/velesdb-core/src/` and `crates/velesdb-server/src/` for `.unwrap()`
-in production code. Skips test code, comments, and doc examples.
+Scans all workspace crate `src/` directories for `.unwrap()` in production code.
+Skips test code, comments, and doc examples.
 
 Exit code 0 = clean, 1 = violations found.
 """
@@ -19,6 +19,11 @@ UNWRAP_RE = re.compile(r"\.unwrap\(\)")
 SCAN_DIRS = [
     Path("crates/velesdb-core/src"),
     Path("crates/velesdb-server/src"),
+    Path("crates/velesdb-cli/src"),
+    Path("crates/velesdb-migrate/src"),
+    Path("crates/velesdb-mobile/src"),
+    Path("crates/velesdb-wasm/src"),
+    Path("crates/tauri-plugin-velesdb/src"),
 ]
 
 

--- a/sdks/typescript/.eslintrc.json
+++ b/sdks/typescript/.eslintrc.json
@@ -13,12 +13,14 @@
   },
   "parserOptions": {
     "ecmaVersion": 2020,
-    "sourceType": "module"
+    "sourceType": "module",
+    "project": "./tsconfig.json"
   },
   "rules": {
     "@typescript-eslint/explicit-function-return-type": "off",
     "@typescript-eslint/no-explicit-any": "warn",
     "@typescript-eslint/no-unused-vars": ["error", { "argsIgnorePattern": "^_" }],
-    "no-console": "warn"
+    "no-console": "warn",
+    "@typescript-eslint/no-floating-promises": "error"
   }
 }

--- a/sdks/typescript/src/backends/admin-backend.ts
+++ b/sdks/typescript/src/backends/admin-backend.ts
@@ -9,6 +9,8 @@ import type {
   CollectionStatsResponse,
   CollectionConfigResponse,
   ColumnStatsDetail,
+  DistanceMetric,
+  StorageMode,
 } from '../types';
 import type { BaseTransport } from './shared';
 import { throwOnError, returnNullOnNotFound, collectionPath } from './shared';
@@ -119,8 +121,8 @@ export async function getCollectionConfig(
   return {
     name: data.name,
     dimension: data.dimension,
-    metric: data.metric,
-    storageMode: data.storage_mode,
+    metric: data.metric as DistanceMetric,
+    storageMode: data.storage_mode as StorageMode,
     pointCount: data.point_count,
     metadataOnly: data.metadata_only,
     graphSchema: data.graph_schema,

--- a/sdks/typescript/src/backends/wasm-search.ts
+++ b/sdks/typescript/src/backends/wasm-search.ts
@@ -1,0 +1,314 @@
+/**
+ * WASM Backend — Search & Query Operations
+ *
+ * Extracted from wasm.ts to keep file NLOC under 500.
+ * All functions receive a WasmContext to access collections and the WASM module.
+ */
+
+import type {
+  SearchOptions,
+  SearchResult,
+  MultiQuerySearchOptions,
+  QueryOptions,
+  QueryApiResponse,
+} from '../types';
+import { NotFoundError, VelesDBError } from '../types';
+import type { WasmContext } from './wasm-types';
+
+// ---------------------------------------------------------------------------
+// Dense search (optionally with sparse/hybrid/filter)
+// ---------------------------------------------------------------------------
+
+function searchSparseOnly(
+  ctx: WasmContext,
+  collection: ReturnType<WasmContext['getCollection']>,
+  indices: number[],
+  values: number[],
+  k: number
+): SearchResult[] {
+  const sparseResults = collection!.store.sparse_search(
+    new Uint32Array(indices),
+    new Float32Array(values),
+    k
+  ) as Array<{ doc_id: bigint | number; score: number }>;
+
+  return sparseResults.map(r => ({
+    id: String(r.doc_id),
+    score: r.score,
+    payload: collection!.payloads.get(ctx.canonicalPayloadKeyFromResultId(r.doc_id)),
+  }));
+}
+
+function searchHybridFusion(
+  ctx: WasmContext,
+  collection: ReturnType<WasmContext['getCollection']>,
+  queryVector: Float32Array,
+  indices: number[],
+  values: number[],
+  k: number
+): SearchResult[] {
+  const denseResults = collection!.store.search(queryVector, k) as Array<[bigint, number]>;
+  const sparseResults = collection!.store.sparse_search(
+    new Uint32Array(indices),
+    new Float32Array(values),
+    k
+  ) as Array<{ doc_id: bigint | number; score: number }>;
+
+  const denseForFuse = denseResults.map(([id, score]: [bigint, number]) => [Number(id), score]);
+  const sparseForFuse = sparseResults.map(
+    (r: { doc_id: bigint | number; score: number }) => [Number(r.doc_id), r.score]
+  );
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const fused = (ctx.wasmModule as any).hybrid_search_fuse(
+    denseForFuse, sparseForFuse, 60
+  ) as Array<{ doc_id: bigint | number; score: number }>;
+
+  return fused.slice(0, k).map(r => ({
+    id: String(r.doc_id),
+    score: r.score,
+    payload: collection!.payloads.get(ctx.canonicalPayloadKeyFromResultId(r.doc_id)),
+  }));
+}
+
+function searchWithFilter(
+  ctx: WasmContext,
+  collection: ReturnType<WasmContext['getCollection']>,
+  queryVector: Float32Array,
+  k: number,
+  filter: Record<string, unknown>
+): SearchResult[] {
+  const results = collection!.store.search_with_filter(queryVector, k, filter) as Array<{
+    id: bigint;
+    score: number;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    payload: any;
+  }>;
+
+  return results.map(r => ({
+    id: String(r.id),
+    score: r.score,
+    payload: r.payload || collection!.payloads.get(ctx.canonicalPayloadKeyFromResultId(r.id)),
+  }));
+}
+
+function searchDenseOnly(
+  ctx: WasmContext,
+  collection: ReturnType<WasmContext['getCollection']>,
+  queryVector: Float32Array,
+  k: number
+): SearchResult[] {
+  const rawResults = collection!.store.search(queryVector, k) as Array<[bigint, number]>;
+
+  return rawResults.map(([id, score]: [bigint, number]) => {
+    const result: SearchResult = { id: String(id), score };
+    const payload = collection!.payloads.get(ctx.canonicalPayloadKeyFromResultId(id));
+    if (payload) {
+      result.payload = payload;
+    }
+    return result;
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Exported search functions
+// ---------------------------------------------------------------------------
+
+export async function wasmSearch(
+  ctx: WasmContext,
+  collectionName: string,
+  query: number[] | Float32Array,
+  options?: SearchOptions
+): Promise<SearchResult[]> {
+  const collection = ctx.getCollection(collectionName);
+  if (!collection) {
+    throw new NotFoundError(`Collection '${collectionName}'`);
+  }
+
+  const queryVector = query instanceof Float32Array ? query : new Float32Array(query);
+  if (queryVector.length !== collection.config.dimension) {
+    throw new VelesDBError(
+      `Query dimension mismatch: expected ${collection.config.dimension}, got ${queryVector.length}`,
+      'DIMENSION_MISMATCH'
+    );
+  }
+
+  const k = options?.k ?? 10;
+
+  if (options?.sparseVector) {
+    const { indices, values } = ctx.sparseVectorToArrays(options.sparseVector);
+    const hasDense = queryVector.length > 0
+      && collection.config.dimension !== undefined
+      && collection.config.dimension > 0;
+
+    return hasDense
+      ? searchHybridFusion(ctx, collection, queryVector, indices, values, k)
+      : searchSparseOnly(ctx, collection, indices, values, k);
+  }
+
+  if (options?.filter) {
+    return searchWithFilter(ctx, collection, queryVector, k, options.filter);
+  }
+
+  return searchDenseOnly(ctx, collection, queryVector, k);
+}
+
+export async function wasmSearchBatch(
+  ctx: WasmContext,
+  collectionName: string,
+  searches: Array<{
+    vector: number[] | Float32Array;
+    k?: number;
+    filter?: Record<string, unknown>;
+  }>
+): Promise<SearchResult[][]> {
+  const results: SearchResult[][] = [];
+  for (const s of searches) {
+    results.push(await wasmSearch(ctx, collectionName, s.vector, { k: s.k, filter: s.filter }));
+  }
+  return results;
+}
+
+// ---------------------------------------------------------------------------
+// Text / Hybrid search
+// ---------------------------------------------------------------------------
+
+/** Map a WASM search result (tuple or object) to a SearchResult. */
+function mapWasmResult(
+  ctx: WasmContext,
+  collection: ReturnType<WasmContext['getCollection']>,
+  r: [bigint | number, number] | { id: bigint | number; score: number; payload?: Record<string, unknown> }
+): SearchResult {
+  if (Array.isArray(r)) {
+    const key = ctx.canonicalPayloadKeyFromResultId(r[0]);
+    return { id: String(r[0]), score: r[1], payload: collection!.payloads.get(key) };
+  }
+  const key = ctx.canonicalPayloadKeyFromResultId(r.id);
+  return { id: String(r.id), score: r.score, payload: r.payload ?? collection!.payloads.get(key) };
+}
+
+export async function wasmTextSearch(
+  ctx: WasmContext,
+  collectionName: string,
+  query: string,
+  options?: { k?: number; filter?: Record<string, unknown> }
+): Promise<SearchResult[]> {
+  const collection = ctx.getCollection(collectionName);
+  if (!collection) {
+    throw new NotFoundError(`Collection '${collectionName}'`);
+  }
+  const k = options?.k ?? 10;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const raw = collection.store.text_search(query, k, undefined) as Array<any>;
+  return raw.map(r => mapWasmResult(ctx, collection, r));
+}
+
+export async function wasmHybridSearch(
+  ctx: WasmContext,
+  collectionName: string,
+  vector: number[] | Float32Array,
+  textQuery: string,
+  options?: { k?: number; vectorWeight?: number; filter?: Record<string, unknown> }
+): Promise<SearchResult[]> {
+  const collection = ctx.getCollection(collectionName);
+  if (!collection) {
+    throw new NotFoundError(`Collection '${collectionName}'`);
+  }
+  const queryVector = vector instanceof Float32Array ? vector : new Float32Array(vector);
+  const k = options?.k ?? 10;
+  const vectorWeight = options?.vectorWeight ?? 0.5;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const raw = collection.store.hybrid_search(queryVector, textQuery, k, vectorWeight) as Array<any>;
+  return raw.map((r: { id: bigint | number; score: number; payload?: Record<string, unknown> }) => {
+    const key = ctx.canonicalPayloadKeyFromResultId(r.id);
+    return { id: String(r.id), score: r.score, payload: r.payload ?? collection.payloads.get(key) };
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Multi-query search
+// ---------------------------------------------------------------------------
+
+export async function wasmMultiQuerySearch(
+  ctx: WasmContext,
+  collectionName: string,
+  vectors: Array<number[] | Float32Array>,
+  options?: MultiQuerySearchOptions
+): Promise<SearchResult[]> {
+  const collection = ctx.getCollection(collectionName);
+  if (!collection) {
+    throw new NotFoundError(`Collection '${collectionName}'`);
+  }
+  if (vectors.length === 0) {
+    return [];
+  }
+
+  const numVectors = vectors.length;
+  const dimension = collection.config.dimension ?? 0;
+  const flat = new Float32Array(numVectors * dimension);
+  vectors.forEach((vector, idx) => {
+    const src = vector instanceof Float32Array ? vector : new Float32Array(vector);
+    flat.set(src, idx * dimension);
+  });
+
+  const strategy = options?.fusion ?? 'rrf';
+  if (strategy === 'weighted') {
+    throw new VelesDBError(
+      "Fusion strategy 'weighted' is not supported in WASM backend.",
+      'NOT_SUPPORTED'
+    );
+  }
+  const raw = collection.store.multi_query_search(
+    flat,
+    numVectors,
+    options?.k ?? 10,
+    strategy,
+    options?.fusionParams?.k ?? 60
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ) as Array<any>;
+
+  return raw.map(r => mapWasmResult(ctx, collection, r));
+}
+
+// ---------------------------------------------------------------------------
+// Query (VelesQL over WASM)
+// ---------------------------------------------------------------------------
+
+export async function wasmQuery(
+  ctx: WasmContext,
+  collectionName: string,
+  _queryString: string,
+  params?: Record<string, unknown>,
+  _options?: QueryOptions
+): Promise<QueryApiResponse> {
+  const collection = ctx.getCollection(collectionName);
+  if (!collection) {
+    throw new NotFoundError(`Collection '${collectionName}'`);
+  }
+  const paramsVector = params?.q;
+  if (!Array.isArray(paramsVector) && !(paramsVector instanceof Float32Array)) {
+    throw new VelesDBError(
+      'WASM query() expects params.q to contain the query embedding vector.',
+      'BAD_REQUEST'
+    );
+  }
+  const requestedK = params?.k;
+  const k =
+    typeof requestedK === 'number' && Number.isInteger(requestedK) && requestedK > 0
+      ? requestedK
+      : 10;
+  const raw = collection.store.query(
+    paramsVector instanceof Float32Array ? paramsVector : new Float32Array(paramsVector),
+    k
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ) as Array<any>;
+
+  return {
+    results: raw as Record<string, unknown>[],
+    stats: {
+      executionTimeMs: 0,
+      strategy: 'wasm-query',
+      scannedNodes: raw.length,
+    },
+  };
+}

--- a/sdks/typescript/src/backends/wasm-search.ts
+++ b/sdks/typescript/src/backends/wasm-search.ts
@@ -252,12 +252,6 @@ export async function wasmMultiQuerySearch(
   });
 
   const strategy = options?.fusion ?? 'rrf';
-  if (strategy === 'weighted') {
-    throw new VelesDBError(
-      "Fusion strategy 'weighted' is not supported in WASM backend.",
-      'NOT_SUPPORTED'
-    );
-  }
   const raw = collection.store.multi_query_search(
     flat,
     numVectors,

--- a/sdks/typescript/src/backends/wasm-stubs.ts
+++ b/sdks/typescript/src/backends/wasm-stubs.ts
@@ -1,0 +1,213 @@
+/**
+ * WASM Backend — Unsupported Feature Stubs
+ *
+ * Extracted from wasm.ts to keep file NLOC under 500.
+ * Groups all methods that throw "not supported" for operations
+ * requiring server-side infrastructure (graph, index, streaming,
+ * admin, agent memory).
+ */
+
+import type {
+  CreateIndexOptions,
+  IndexInfo,
+  AddEdgeRequest,
+  GetEdgesOptions,
+  GraphEdge,
+  TraverseRequest,
+  TraverseParallelRequest,
+  TraverseResponse,
+  DegreeResponse,
+  ExplainResponse,
+  CollectionSanityResponse,
+  PqTrainOptions,
+  GraphCollectionConfig,
+  CollectionStatsResponse,
+  CollectionConfigResponse,
+  SemanticEntry,
+  EpisodicEvent,
+  ProceduralPattern,
+  SearchResult,
+  VectorDocument,
+  SearchOptions,
+  ScrollRequest,
+  ScrollResponse,
+} from '../types';
+import { wasmNotSupported } from './shared';
+
+// ---------------------------------------------------------------------------
+// Index Management (EPIC-009)
+// ---------------------------------------------------------------------------
+
+export async function wasmCreateIndex(
+  _collection: string, _options: CreateIndexOptions
+): Promise<void> {
+  throw new Error(
+    'WasmBackend: createIndex is not yet supported. ' +
+    'Index operations require the REST backend with velesdb-server.'
+  );
+}
+
+export async function wasmListIndexes(_collection: string): Promise<IndexInfo[]> {
+  return [];
+}
+
+export async function wasmHasIndex(
+  _collection: string, _label: string, _property: string
+): Promise<boolean> {
+  return false;
+}
+
+export async function wasmDropIndex(
+  _collection: string, _label: string, _property: string
+): Promise<boolean> {
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Knowledge Graph (EPIC-016 US-041)
+// ---------------------------------------------------------------------------
+
+export async function wasmAddEdge(
+  _collection: string, _edge: AddEdgeRequest
+): Promise<void> {
+  wasmNotSupported('Knowledge Graph operations');
+}
+
+export async function wasmGetEdges(
+  _collection: string, _options?: GetEdgesOptions
+): Promise<GraphEdge[]> {
+  wasmNotSupported('Knowledge Graph operations');
+}
+
+export async function wasmTraverseGraph(
+  _collection: string, _request: TraverseRequest
+): Promise<TraverseResponse> {
+  wasmNotSupported('Graph traversal');
+}
+
+export async function wasmTraverseParallel(
+  _collection: string, _request: TraverseParallelRequest
+): Promise<TraverseResponse> {
+  wasmNotSupported('Graph parallel traversal');
+}
+
+export async function wasmGetNodeDegree(
+  _collection: string, _nodeId: number
+): Promise<DegreeResponse> {
+  wasmNotSupported('Graph degree query');
+}
+
+// ---------------------------------------------------------------------------
+// Query explain / Sanity / Scroll
+// ---------------------------------------------------------------------------
+
+export async function wasmQueryExplain(
+  _queryString: string,
+  _params?: Record<string, unknown>,
+  _options?: { analyze?: boolean }
+): Promise<ExplainResponse> {
+  if (_options?.analyze) {
+    wasmNotSupported('EXPLAIN ANALYZE');
+  }
+  wasmNotSupported('Query explain');
+}
+
+export async function wasmCollectionSanity(
+  _collection: string
+): Promise<CollectionSanityResponse> {
+  wasmNotSupported('Collection sanity endpoint');
+}
+
+export async function wasmScroll(
+  _collection: string, _request?: ScrollRequest
+): Promise<ScrollResponse> {
+  wasmNotSupported('scroll');
+}
+
+// ---------------------------------------------------------------------------
+// Sparse / PQ / Streaming (v1.5)
+// ---------------------------------------------------------------------------
+
+export async function wasmTrainPq(
+  _collection: string, _options?: PqTrainOptions
+): Promise<string> {
+  wasmNotSupported('PQ training');
+}
+
+export async function wasmStreamInsert(
+  _collection: string, _docs: VectorDocument[]
+): Promise<void> {
+  wasmNotSupported('Streaming insert');
+}
+
+// ---------------------------------------------------------------------------
+// Graph Collection / Stats / Agent Memory (Phase 8)
+// ---------------------------------------------------------------------------
+
+export async function wasmCreateGraphCollection(
+  _name: string, _config?: GraphCollectionConfig
+): Promise<void> {
+  wasmNotSupported('Graph collections');
+}
+
+export async function wasmGetCollectionStats(
+  _collection: string
+): Promise<CollectionStatsResponse | null> {
+  wasmNotSupported('Collection stats');
+}
+
+export async function wasmAnalyzeCollection(
+  _collection: string
+): Promise<CollectionStatsResponse> {
+  wasmNotSupported('Collection analyze');
+}
+
+export async function wasmGetCollectionConfig(
+  _collection: string
+): Promise<CollectionConfigResponse> {
+  wasmNotSupported('Collection config');
+}
+
+export async function wasmSearchIds(
+  _collection: string,
+  _query: number[] | Float32Array,
+  _options?: SearchOptions
+): Promise<Array<{ id: number; score: number }>> {
+  wasmNotSupported('searchIds');
+}
+
+export async function wasmStoreSemanticFact(
+  _collection: string, _entry: SemanticEntry
+): Promise<void> {
+  wasmNotSupported('Agent memory');
+}
+
+export async function wasmSearchSemanticMemory(
+  _collection: string, _embedding: number[], _k?: number
+): Promise<SearchResult[]> {
+  wasmNotSupported('Agent memory');
+}
+
+export async function wasmRecordEpisodicEvent(
+  _collection: string, _event: EpisodicEvent
+): Promise<void> {
+  wasmNotSupported('Agent memory');
+}
+
+export async function wasmRecallEpisodicEvents(
+  _collection: string, _embedding: number[], _k?: number
+): Promise<SearchResult[]> {
+  wasmNotSupported('Agent memory');
+}
+
+export async function wasmStoreProceduralPattern(
+  _collection: string, _pattern: ProceduralPattern
+): Promise<void> {
+  wasmNotSupported('Agent memory');
+}
+
+export async function wasmMatchProceduralPatterns(
+  _collection: string, _embedding: number[], _k?: number
+): Promise<SearchResult[]> {
+  wasmNotSupported('Agent memory');
+}

--- a/sdks/typescript/src/backends/wasm-types.ts
+++ b/sdks/typescript/src/backends/wasm-types.ts
@@ -1,0 +1,36 @@
+/**
+ * WASM Backend — Shared type definitions
+ *
+ * Internal context interface used by wasm-search.ts and wasm-stubs.ts
+ * to access WasmBackend internals without circular dependencies.
+ */
+
+import type { CollectionConfig } from '../types';
+import type { SparseVector } from '../types';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type WasmModule = any;
+
+/** In-memory collection storage */
+export interface CollectionData {
+  config: CollectionConfig;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  store: any;
+  payloads: Map<string, Record<string, unknown>>;
+  createdAt: Date;
+}
+
+/**
+ * Internal context passed from WasmBackend to extracted search/stub modules.
+ *
+ * Exposes the minimum surface needed by helper functions without leaking the
+ * full class. All methods mirror private WasmBackend helpers.
+ */
+export interface WasmContext {
+  wasmModule: WasmModule;
+  getCollection(name: string): CollectionData | undefined;
+  canonicalPayloadKeyFromResultId(id: bigint | number | string): string;
+  canonicalPayloadKey(id: string | number): string;
+  sparseVectorToArrays(sv: SparseVector): { indices: number[]; values: number[] };
+  toNumericId(id: string | number): number;
+}

--- a/sdks/typescript/src/backends/wasm.ts
+++ b/sdks/typescript/src/backends/wasm.ts
@@ -1,7 +1,9 @@
 /**
  * WASM Backend for VelesDB
- * 
- * Uses velesdb-wasm for in-browser/Node.js vector operations
+ *
+ * Uses velesdb-wasm for in-browser/Node.js vector operations.
+ * Search/query logic lives in wasm-search.ts; unsupported-feature
+ * stubs live in wasm-stubs.ts.
  */
 
 import type {
@@ -37,24 +39,50 @@ import type {
 } from '../types';
 import { ConnectionError, NotFoundError, VelesDBError } from '../types';
 import type { SparseVector } from '../types';
-import { wasmNotSupported } from './shared';
+import type { WasmModule, CollectionData, WasmContext } from './wasm-types';
 
-// Type definitions are loose to avoid strict type checking issues with dynamic WASM imports
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type WasmModule = any;
+// Search & query delegates
+import {
+  wasmSearch,
+  wasmSearchBatch,
+  wasmTextSearch,
+  wasmHybridSearch,
+  wasmMultiQuerySearch,
+  wasmQuery,
+} from './wasm-search';
 
-/** In-memory collection storage */
-interface CollectionData {
-  config: CollectionConfig;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  store: any;
-  payloads: Map<string, Record<string, unknown>>;
-  createdAt: Date;
-}
+// Unsupported-feature stubs
+import {
+  wasmCreateIndex,
+  wasmListIndexes,
+  wasmHasIndex,
+  wasmDropIndex,
+  wasmAddEdge,
+  wasmGetEdges,
+  wasmTraverseGraph,
+  wasmTraverseParallel,
+  wasmGetNodeDegree,
+  wasmQueryExplain,
+  wasmCollectionSanity,
+  wasmScroll,
+  wasmTrainPq,
+  wasmStreamInsert,
+  wasmCreateGraphCollection,
+  wasmGetCollectionStats,
+  wasmAnalyzeCollection,
+  wasmGetCollectionConfig,
+  wasmSearchIds,
+  wasmStoreSemanticFact,
+  wasmSearchSemanticMemory,
+  wasmRecordEpisodicEvent,
+  wasmRecallEpisodicEvents,
+  wasmStoreProceduralPattern,
+  wasmMatchProceduralPatterns,
+} from './wasm-stubs';
 
 /**
  * WASM Backend
- * 
+ *
  * Provides vector storage using WebAssembly for optimal performance
  * in browser and Node.js environments.
  */
@@ -63,13 +91,16 @@ export class WasmBackend implements IVelesDBBackend {
   private collections: Map<string, CollectionData> = new Map();
   private _initialized = false;
 
+  // ========================================================================
+  // Lifecycle
+  // ========================================================================
+
   async init(): Promise<void> {
     if (this._initialized) {
       return;
     }
 
     try {
-      // Dynamic import for WASM module
       this.wasmModule = await import('@wiscale/velesdb-wasm') as WasmModule;
       await this.wasmModule.default();
       this._initialized = true;
@@ -84,6 +115,18 @@ export class WasmBackend implements IVelesDBBackend {
   isInitialized(): boolean {
     return this._initialized;
   }
+
+  async close(): Promise<void> {
+    for (const [, data] of this.collections) {
+      data.store.free();
+    }
+    this.collections.clear();
+    this._initialized = false;
+  }
+
+  // ========================================================================
+  // Internal helpers
+  // ========================================================================
 
   private ensureInitialized(): void {
     if (!this._initialized || !this.wasmModule) {
@@ -120,6 +163,52 @@ export class WasmBackend implements IVelesDBBackend {
     }
     return String(this.toNumericId(id));
   }
+
+  private sparseVectorToArrays(sv: SparseVector): { indices: number[]; values: number[] } {
+    const indices: number[] = [];
+    const values: number[] = [];
+    for (const [k, v] of Object.entries(sv)) {
+      indices.push(Number(k));
+      values.push(v);
+    }
+    return { indices, values };
+  }
+
+  private toNumericId(id: string | number): number {
+    if (typeof id === 'number') {
+      return id;
+    }
+    const normalized = this.normalizeIdString(id);
+    if (normalized !== null) {
+      const parsed = Number(normalized);
+      if (Number.isSafeInteger(parsed)) {
+        return parsed;
+      }
+    }
+    let hash = 0;
+    for (let i = 0; i < id.length; i++) {
+      const char = id.charCodeAt(i);
+      hash = ((hash << 5) - hash) + char;
+      hash = hash & hash;
+    }
+    return Math.abs(hash);
+  }
+
+  /** Build a WasmContext for the extracted search/query modules. */
+  private context(): WasmContext {
+    return {
+      wasmModule: this.wasmModule!,
+      getCollection: (name: string) => this.collections.get(name),
+      canonicalPayloadKeyFromResultId: (id) => this.canonicalPayloadKeyFromResultId(id),
+      canonicalPayloadKey: (id) => this.canonicalPayloadKey(id),
+      sparseVectorToArrays: (sv) => this.sparseVectorToArrays(sv),
+      toNumericId: (id) => this.toNumericId(id),
+    };
+  }
+
+  // ========================================================================
+  // Collection management
+  // ========================================================================
 
   async createCollection(name: string, config: CollectionConfig): Promise<void> {
     this.ensureInitialized();
@@ -184,6 +273,10 @@ export class WasmBackend implements IVelesDBBackend {
     return result;
   }
 
+  // ========================================================================
+  // Point CRUD
+  // ========================================================================
+
   async insert(collectionName: string, doc: VectorDocument): Promise<void> {
     this.ensureInitialized();
 
@@ -193,8 +286,8 @@ export class WasmBackend implements IVelesDBBackend {
     }
 
     const id = this.toNumericId(doc.id);
-    const vector = doc.vector instanceof Float32Array 
-      ? doc.vector 
+    const vector = doc.vector instanceof Float32Array
+      ? doc.vector
       : new Float32Array(doc.vector);
 
     if (vector.length !== collection.config.dimension) {
@@ -223,21 +316,17 @@ export class WasmBackend implements IVelesDBBackend {
       throw new NotFoundError(`Collection '${collectionName}'`);
     }
 
-    // Validate all documents first
     for (const doc of docs) {
-      const vectorLen = doc.vector.length;
-      if (vectorLen !== collection.config.dimension) {
+      if (doc.vector.length !== collection.config.dimension) {
         throw new VelesDBError(
-          `Vector dimension mismatch for doc ${doc.id}: expected ${collection.config.dimension}, got ${vectorLen}`,
+          `Vector dimension mismatch for doc ${doc.id}: expected ${collection.config.dimension}, got ${doc.vector.length}`,
           'DIMENSION_MISMATCH'
         );
       }
     }
 
-    // Reserve capacity
     collection.store.reserve(docs.length);
 
-    // Batch insert docs without payload; payload-bearing docs use insert_with_payload.
     const batch: Array<[bigint, number[]]> = [];
     for (const doc of docs) {
       const id = BigInt(this.toNumericId(doc.id));
@@ -256,131 +345,11 @@ export class WasmBackend implements IVelesDBBackend {
       collection.store.insert_batch(batch);
     }
 
-    // Store payloads
     for (const doc of docs) {
       if (doc.payload) {
         collection.payloads.set(this.canonicalPayloadKey(doc.id), doc.payload);
       }
     }
-  }
-
-  async search(
-    collectionName: string,
-    query: number[] | Float32Array,
-    options?: SearchOptions
-  ): Promise<SearchResult[]> {
-    this.ensureInitialized();
-
-    const collection = this.collections.get(collectionName);
-    if (!collection) {
-      throw new NotFoundError(`Collection '${collectionName}'`);
-    }
-
-    const queryVector = query instanceof Float32Array 
-      ? query 
-      : new Float32Array(query);
-
-    if (queryVector.length !== collection.config.dimension) {
-      throw new VelesDBError(
-        `Query dimension mismatch: expected ${collection.config.dimension}, got ${queryVector.length}`,
-        'DIMENSION_MISMATCH'
-      );
-    }
-
-    const k = options?.k ?? 10;
-
-    // Sparse/hybrid search handling
-    if (options?.sparseVector) {
-      const { indices, values } = this.sparseVectorToArrays(options.sparseVector);
-
-      if (queryVector.length > 0 && collection.config.dimension && collection.config.dimension > 0) {
-        // Hybrid: dense + sparse → use RRF fusion
-        const denseResults = collection.store.search(queryVector, k) as Array<[bigint, number]>;
-        const sparseResults = collection.store.sparse_search(
-          new Uint32Array(indices),
-          new Float32Array(values),
-          k
-        );
-
-        // Parse sparse results
-        const sparseArray = (sparseResults as Array<{ doc_id: bigint | number; score: number }>);
-
-        // Format for hybrid_search_fuse: arrays of [doc_id, score]
-        const denseForFuse = denseResults.map(([id, score]: [bigint, number]) => [Number(id), score]);
-        const sparseForFuse = sparseArray.map((r: { doc_id: bigint | number; score: number }) => [Number(r.doc_id), r.score]);
-
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const fused = (this.wasmModule as any).hybrid_search_fuse(denseForFuse, sparseForFuse, 60) as Array<{ doc_id: bigint | number; score: number }>;
-
-        return fused.slice(0, k).map(r => ({
-          id: String(r.doc_id),
-          score: r.score,
-          payload: collection.payloads.get(this.canonicalPayloadKeyFromResultId(r.doc_id)),
-        }));
-      } else {
-        // Sparse-only search
-        const sparseResults = collection.store.sparse_search(
-          new Uint32Array(indices),
-          new Float32Array(values),
-          k
-        ) as Array<{ doc_id: bigint | number; score: number }>;
-
-        return sparseResults.map(r => ({
-          id: String(r.doc_id),
-          score: r.score,
-          payload: collection.payloads.get(this.canonicalPayloadKeyFromResultId(r.doc_id)),
-        }));
-      }
-    }
-
-    if (options?.filter) {
-      // Use the new search_with_filter method
-      const results = collection.store.search_with_filter(queryVector, k, options.filter) as Array<{
-        id: bigint;
-        score: number;
-        payload: any;
-      }>;
-
-      return results.map(r => ({
-        id: String(r.id),
-        score: r.score,
-        payload: r.payload || collection.payloads.get(this.canonicalPayloadKeyFromResultId(r.id)),
-      }));
-    }
-
-    const rawResults = collection.store.search(queryVector, k) as Array<[bigint, number]>;
-
-    return rawResults.map(([id, score]: [bigint, number]) => {
-      const stringId = String(id);
-      const result: SearchResult = {
-        id: stringId,
-        score,
-      };
-
-      const payload = collection.payloads.get(this.canonicalPayloadKeyFromResultId(id));
-      if (payload) {
-        result.payload = payload;
-      }
-
-      return result;
-    });
-  }
-
-  async searchBatch(
-    collectionName: string,
-    searches: Array<{
-      vector: number[] | Float32Array;
-      k?: number;
-      filter?: Record<string, unknown>;
-    }>
-  ): Promise<SearchResult[][]> {
-    this.ensureInitialized();
-
-    const results: SearchResult[][] = [];
-    for (const s of searches) {
-      results.push(await this.search(collectionName, s.vector, { k: s.k, filter: s.filter }));
-    }
-    return results;
   }
 
   async delete(collectionName: string, id: string | number): Promise<boolean> {
@@ -393,7 +362,7 @@ export class WasmBackend implements IVelesDBBackend {
 
     const numericId = this.toNumericId(id);
     const removed = collection.store.remove(BigInt(numericId));
-    
+
     if (removed) {
       collection.payloads.delete(this.canonicalPayloadKey(id));
     }
@@ -428,162 +397,9 @@ export class WasmBackend implements IVelesDBBackend {
     };
   }
 
-  async textSearch(
-    _collection: string,
-    _query: string,
-    _options?: { k?: number; filter?: Record<string, unknown> }
-  ): Promise<SearchResult[]> {
-    this.ensureInitialized();
-    const collection = this.collections.get(_collection);
-    if (!collection) {
-      throw new NotFoundError(`Collection '${_collection}'`);
-    }
-    const k = _options?.k ?? 10;
-    const field = undefined;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const raw = collection.store.text_search(_query, k, field) as Array<any>;
-    return raw.map((r: [bigint | number, number] | { id: bigint | number; score: number; payload?: Record<string, unknown> }) => {
-      if (Array.isArray(r)) {
-        const key = this.canonicalPayloadKeyFromResultId(r[0]);
-        return { id: String(r[0]), score: r[1], payload: collection.payloads.get(key) };
-      }
-      const key = this.canonicalPayloadKeyFromResultId(r.id);
-      return { id: String(r.id), score: r.score, payload: r.payload ?? collection.payloads.get(key) };
-    });
-  }
-
-  async hybridSearch(
-    _collection: string,
-    _vector: number[] | Float32Array,
-    _textQuery: string,
-    _options?: { k?: number; vectorWeight?: number; filter?: Record<string, unknown> }
-  ): Promise<SearchResult[]> {
-    this.ensureInitialized();
-    const collection = this.collections.get(_collection);
-    if (!collection) {
-      throw new NotFoundError(`Collection '${_collection}'`);
-    }
-    const queryVector = _vector instanceof Float32Array ? _vector : new Float32Array(_vector);
-    const k = _options?.k ?? 10;
-    const vectorWeight = _options?.vectorWeight ?? 0.5;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const raw = collection.store.hybrid_search(queryVector, _textQuery, k, vectorWeight) as Array<any>;
-    return raw.map((r: { id: bigint | number; score: number; payload?: Record<string, unknown> }) => {
-      const key = this.canonicalPayloadKeyFromResultId(r.id);
-      return {
-        id: String(r.id),
-        score: r.score,
-        payload: r.payload ?? collection.payloads.get(key),
-      };
-    });
-  }
-
-  async query(
-    _collection: string,
-    _queryString: string,
-    _params?: Record<string, unknown>,
-    _options?: QueryOptions
-  ): Promise<QueryApiResponse> {
-    this.ensureInitialized();
-    const collection = this.collections.get(_collection);
-    if (!collection) {
-      throw new NotFoundError(`Collection '${_collection}'`);
-    }
-    const paramsVector = _params?.q;
-    if (!Array.isArray(paramsVector) && !(paramsVector instanceof Float32Array)) {
-      throw new VelesDBError(
-        'WASM query() expects params.q to contain the query embedding vector.',
-        'BAD_REQUEST'
-      );
-    }
-    const requestedK = _params?.k;
-    const k =
-      typeof requestedK === 'number' && Number.isInteger(requestedK) && requestedK > 0
-        ? requestedK
-        : 10;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const raw = collection.store.query(
-      paramsVector instanceof Float32Array ? paramsVector : new Float32Array(paramsVector),
-      k
-    ) as Array<any>;
-
-    // v3.0.0: WASM query returns projected rows directly.
-    return {
-      results: raw as Record<string, unknown>[],
-      stats: {
-        executionTimeMs: 0,
-        strategy: 'wasm-query',
-        scannedNodes: raw.length,
-      },
-    };
-  }
-
-  async multiQuerySearch(
-    _collection: string,
-    _vectors: Array<number[] | Float32Array>,
-    _options?: MultiQuerySearchOptions
-  ): Promise<SearchResult[]> {
-    this.ensureInitialized();
-    const collection = this.collections.get(_collection);
-    if (!collection) {
-      throw new NotFoundError(`Collection '${_collection}'`);
-    }
-    if (_vectors.length === 0) {
-      return [];
-    }
-
-    const numVectors = _vectors.length;
-    const dimension = collection.config.dimension ?? 0;
-    const flat = new Float32Array(numVectors * dimension);
-    _vectors.forEach((vector, idx) => {
-      const src = vector instanceof Float32Array ? vector : new Float32Array(vector);
-      flat.set(src, idx * dimension);
-    });
-
-    const strategy = _options?.fusion ?? 'rrf';
-    if (strategy === 'weighted') {
-      throw new VelesDBError(
-        "Fusion strategy 'weighted' is not supported in WASM backend.",
-        'NOT_SUPPORTED'
-      );
-    }
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const raw = collection.store.multi_query_search(
-      flat,
-      numVectors,
-      _options?.k ?? 10,
-      strategy,
-      _options?.fusionParams?.k ?? 60
-    ) as Array<any>;
-
-    return raw.map((r: [bigint | number, number] | { id: bigint | number; score: number; payload?: Record<string, unknown> }) => {
-      if (Array.isArray(r)) {
-        const key = this.canonicalPayloadKeyFromResultId(r[0]);
-        return { id: String(r[0]), score: r[1], payload: collection.payloads.get(key) };
-      }
-      const key = this.canonicalPayloadKeyFromResultId(r.id);
-      return { id: String(r.id), score: r.score, payload: r.payload ?? collection.payloads.get(key) };
-    });
-  }
-
-
-  async queryExplain(_queryString: string, _params?: Record<string, unknown>, _options?: { analyze?: boolean }): Promise<ExplainResponse> {
-    this.ensureInitialized();
-    if (_options?.analyze) {
-      wasmNotSupported('EXPLAIN ANALYZE');
-    }
-    wasmNotSupported('Query explain');
-  }
-
-  async collectionSanity(_collection: string): Promise<CollectionSanityResponse> {
-    this.ensureInitialized();
-    wasmNotSupported('Collection sanity endpoint');
-  }
-
-  async scroll(_collection: string, _request?: ScrollRequest): Promise<ScrollResponse> {
-    this.ensureInitialized();
-    wasmNotSupported('scroll');
-  }
+  // ========================================================================
+  // Collection utilities
+  // ========================================================================
 
   async isEmpty(collectionName: string): Promise<boolean> {
     this.ensureInitialized();
@@ -605,203 +421,192 @@ export class WasmBackend implements IVelesDBBackend {
     }
 
     // WASM runs in-memory, flush is a no-op
-    // Real persistence would require IndexedDB or similar
-  }
-
-  async close(): Promise<void> {
-    for (const [, data] of this.collections) {
-      data.store.free();
-    }
-    this.collections.clear();
-    this._initialized = false;
-  }
-
-  private sparseVectorToArrays(sv: SparseVector): { indices: number[]; values: number[] } {
-    const indices: number[] = [];
-    const values: number[] = [];
-    for (const [k, v] of Object.entries(sv)) {
-      indices.push(Number(k));
-      values.push(v);
-    }
-    return { indices, values };
-  }
-
-  private toNumericId(id: string | number): number {
-    if (typeof id === 'number') {
-      return id;
-    }
-    // Parse only canonical numeric strings, avoid parseInt partial parsing ("123abc" -> 123)
-    const normalized = this.normalizeIdString(id);
-    if (normalized !== null) {
-      const parsed = Number(normalized);
-      if (Number.isSafeInteger(parsed)) {
-        return parsed;
-      }
-    }
-    // Simple string hash for non-numeric IDs
-    let hash = 0;
-    for (let i = 0; i < id.length; i++) {
-      const char = id.charCodeAt(i);
-      hash = ((hash << 5) - hash) + char;
-      hash = hash & hash; // Convert to 32bit integer
-    }
-    return Math.abs(hash);
   }
 
   // ========================================================================
-  // Index Management (EPIC-009) - Stubs for WASM backend
-  // Note: Full implementation requires velesdb-wasm support
+  // Search & Query — delegates to wasm-search.ts
   // ========================================================================
 
-  async createIndex(_collection: string, _options: CreateIndexOptions): Promise<void> {
+  async search(
+    collectionName: string, query: number[] | Float32Array, options?: SearchOptions
+  ): Promise<SearchResult[]> {
     this.ensureInitialized();
-    // FIX: Throw error instead of silent warning for fail-fast behavior
-    // This prevents confusion when switching between REST and WASM backends
-    throw new Error(
-      'WasmBackend: createIndex is not yet supported. ' +
-      'Index operations require the REST backend with velesdb-server.'
-    );
+    return wasmSearch(this.context(), collectionName, query, options);
   }
 
-  async listIndexes(_collection: string): Promise<IndexInfo[]> {
+  async searchBatch(
+    collectionName: string,
+    searches: Array<{ vector: number[] | Float32Array; k?: number; filter?: Record<string, unknown> }>
+  ): Promise<SearchResult[][]> {
     this.ensureInitialized();
-    // Return empty list - WASM backend has no indexes
-    // This is acceptable since an empty list is semantically correct (no indexes exist)
-    return [];
+    return wasmSearchBatch(this.context(), collectionName, searches);
   }
 
-  async hasIndex(_collection: string, _label: string, _property: string): Promise<boolean> {
+  async textSearch(
+    collection: string, query: string, options?: { k?: number; filter?: Record<string, unknown> }
+  ): Promise<SearchResult[]> {
     this.ensureInitialized();
-    // Return false - WASM backend has no indexes
-    // This is semantically correct (no index exists)
-    return false;
+    return wasmTextSearch(this.context(), collection, query, options);
   }
 
-  async dropIndex(_collection: string, _label: string, _property: string): Promise<boolean> {
+  async hybridSearch(
+    collection: string, vector: number[] | Float32Array, textQuery: string,
+    options?: { k?: number; vectorWeight?: number; filter?: Record<string, unknown> }
+  ): Promise<SearchResult[]> {
     this.ensureInitialized();
-    // Return false - nothing to drop since no indexes exist in WASM backend
-    return false;
+    return wasmHybridSearch(this.context(), collection, vector, textQuery, options);
   }
 
-  // ========================================================================
-  // Knowledge Graph (EPIC-016 US-041) - Stubs for WASM backend
-  // Note: Graph operations require server-side EdgeStore
-  // ========================================================================
-
-  async addEdge(_collection: string, _edge: AddEdgeRequest): Promise<void> {
+  async query(
+    collection: string, queryString: string,
+    params?: Record<string, unknown>, options?: QueryOptions
+  ): Promise<QueryApiResponse> {
     this.ensureInitialized();
-    wasmNotSupported('Knowledge Graph operations');
+    return wasmQuery(this.context(), collection, queryString, params, options);
   }
 
-  async getEdges(_collection: string, _options?: GetEdgesOptions): Promise<GraphEdge[]> {
+  async multiQuerySearch(
+    collection: string, vectors: Array<number[] | Float32Array>,
+    options?: MultiQuerySearchOptions
+  ): Promise<SearchResult[]> {
     this.ensureInitialized();
-    wasmNotSupported('Knowledge Graph operations');
-  }
-
-  async traverseGraph(_collection: string, _request: TraverseRequest): Promise<TraverseResponse> {
-    this.ensureInitialized();
-    wasmNotSupported('Graph traversal');
-  }
-
-  async traverseParallel(_collection: string, _request: TraverseParallelRequest): Promise<TraverseResponse> {
-    this.ensureInitialized();
-    wasmNotSupported('Graph parallel traversal');
-  }
-
-  async getNodeDegree(_collection: string, _nodeId: number): Promise<DegreeResponse> {
-    this.ensureInitialized();
-    wasmNotSupported('Graph degree query');
+    return wasmMultiQuerySearch(this.context(), collection, vectors, options);
   }
 
   // ========================================================================
-  // Sparse / PQ / Streaming (v1.5)
+  // Stubs — delegates to wasm-stubs.ts
   // ========================================================================
 
-  async trainPq(_collection: string, _options?: PqTrainOptions): Promise<string> {
+  async queryExplain(q: string, p?: Record<string, unknown>, o?: { analyze?: boolean }): Promise<ExplainResponse> {
     this.ensureInitialized();
-    wasmNotSupported('PQ training');
+    return wasmQueryExplain(q, p, o);
   }
 
-  async streamInsert(_collection: string, _docs: VectorDocument[]): Promise<void> {
+  async collectionSanity(collection: string): Promise<CollectionSanityResponse> {
     this.ensureInitialized();
-    wasmNotSupported('Streaming insert');
+    return wasmCollectionSanity(collection);
   }
 
-  // ========================================================================
-  // Graph Collection / Stats / Agent Memory (Phase 8) - WASM stubs
-  // ========================================================================
-
-  async createGraphCollection(_name: string, _config?: GraphCollectionConfig): Promise<void> {
+  async scroll(collection: string, request?: ScrollRequest): Promise<ScrollResponse> {
     this.ensureInitialized();
-    wasmNotSupported('Graph collections');
+    return wasmScroll(collection, request);
   }
 
-  async getCollectionStats(_collection: string): Promise<CollectionStatsResponse | null> {
+  async createIndex(collection: string, options: CreateIndexOptions): Promise<void> {
     this.ensureInitialized();
-    wasmNotSupported('Collection stats');
+    return wasmCreateIndex(collection, options);
   }
 
-  async analyzeCollection(_collection: string): Promise<CollectionStatsResponse> {
+  async listIndexes(collection: string): Promise<IndexInfo[]> {
     this.ensureInitialized();
-    wasmNotSupported('Collection analyze');
+    return wasmListIndexes(collection);
   }
 
-  async getCollectionConfig(_collection: string): Promise<CollectionConfigResponse> {
+  async hasIndex(collection: string, label: string, property: string): Promise<boolean> {
     this.ensureInitialized();
-    wasmNotSupported('Collection config');
+    return wasmHasIndex(collection, label, property);
+  }
+
+  async dropIndex(collection: string, label: string, property: string): Promise<boolean> {
+    this.ensureInitialized();
+    return wasmDropIndex(collection, label, property);
+  }
+
+  async addEdge(collection: string, edge: AddEdgeRequest): Promise<void> {
+    this.ensureInitialized();
+    return wasmAddEdge(collection, edge);
+  }
+
+  async getEdges(collection: string, options?: GetEdgesOptions): Promise<GraphEdge[]> {
+    this.ensureInitialized();
+    return wasmGetEdges(collection, options);
+  }
+
+  async traverseGraph(collection: string, request: TraverseRequest): Promise<TraverseResponse> {
+    this.ensureInitialized();
+    return wasmTraverseGraph(collection, request);
+  }
+
+  async traverseParallel(collection: string, request: TraverseParallelRequest): Promise<TraverseResponse> {
+    this.ensureInitialized();
+    return wasmTraverseParallel(collection, request);
+  }
+
+  async getNodeDegree(collection: string, nodeId: number): Promise<DegreeResponse> {
+    this.ensureInitialized();
+    return wasmGetNodeDegree(collection, nodeId);
+  }
+
+  async trainPq(collection: string, options?: PqTrainOptions): Promise<string> {
+    this.ensureInitialized();
+    return wasmTrainPq(collection, options);
+  }
+
+  async streamInsert(collection: string, docs: VectorDocument[]): Promise<void> {
+    this.ensureInitialized();
+    return wasmStreamInsert(collection, docs);
+  }
+
+  async createGraphCollection(name: string, config?: GraphCollectionConfig): Promise<void> {
+    this.ensureInitialized();
+    return wasmCreateGraphCollection(name, config);
+  }
+
+  async getCollectionStats(collection: string): Promise<CollectionStatsResponse | null> {
+    this.ensureInitialized();
+    return wasmGetCollectionStats(collection);
+  }
+
+  async analyzeCollection(collection: string): Promise<CollectionStatsResponse> {
+    this.ensureInitialized();
+    return wasmAnalyzeCollection(collection);
+  }
+
+  async getCollectionConfig(collection: string): Promise<CollectionConfigResponse> {
+    this.ensureInitialized();
+    return wasmGetCollectionConfig(collection);
   }
 
   async searchIds(
-    _collection: string,
-    _query: number[] | Float32Array,
-    _options?: SearchOptions
+    collection: string, query: number[] | Float32Array, options?: SearchOptions
   ): Promise<Array<{ id: number; score: number }>> {
     this.ensureInitialized();
-    wasmNotSupported('searchIds');
+    return wasmSearchIds(collection, query, options);
   }
 
-  async storeSemanticFact(_collection: string, _entry: SemanticEntry): Promise<void> {
+  async storeSemanticFact(collection: string, entry: SemanticEntry): Promise<void> {
     this.ensureInitialized();
-    wasmNotSupported('Agent memory');
+    return wasmStoreSemanticFact(collection, entry);
   }
 
   async searchSemanticMemory(
-    _collection: string,
-    _embedding: number[],
-    _k?: number
+    collection: string, embedding: number[], k?: number
   ): Promise<SearchResult[]> {
     this.ensureInitialized();
-    wasmNotSupported('Agent memory');
+    return wasmSearchSemanticMemory(collection, embedding, k);
   }
 
-  async recordEpisodicEvent(_collection: string, _event: EpisodicEvent): Promise<void> {
+  async recordEpisodicEvent(collection: string, event: EpisodicEvent): Promise<void> {
     this.ensureInitialized();
-    wasmNotSupported('Agent memory');
+    return wasmRecordEpisodicEvent(collection, event);
   }
 
   async recallEpisodicEvents(
-    _collection: string,
-    _embedding: number[],
-    _k?: number
+    collection: string, embedding: number[], k?: number
   ): Promise<SearchResult[]> {
     this.ensureInitialized();
-    wasmNotSupported('Agent memory');
+    return wasmRecallEpisodicEvents(collection, embedding, k);
   }
 
-  async storeProceduralPattern(
-    _collection: string,
-    _pattern: ProceduralPattern
-  ): Promise<void> {
+  async storeProceduralPattern(collection: string, pattern: ProceduralPattern): Promise<void> {
     this.ensureInitialized();
-    wasmNotSupported('Agent memory');
+    return wasmStoreProceduralPattern(collection, pattern);
   }
 
   async matchProceduralPatterns(
-    _collection: string,
-    _embedding: number[],
-    _k?: number
+    collection: string, embedding: number[], k?: number
   ): Promise<SearchResult[]> {
     this.ensureInitialized();
-    wasmNotSupported('Agent memory');
+    return wasmMatchProceduralPatterns(collection, embedding, k);
   }
 }

--- a/sdks/typescript/src/types.ts
+++ b/sdks/typescript/src/types.ts
@@ -39,6 +39,12 @@ export interface HnswParams {
   m?: number;
   /** Size of dynamic candidate list during construction */
   efConstruction?: number;
+  /** Maximum number of elements in the index */
+  maxElements?: number;
+  /** Storage mode for vector quantization */
+  storageMode?: StorageMode;
+  /** Alpha parameter for HNSW construction */
+  alpha?: number;
 }
 
 /** Collection configuration */
@@ -135,6 +141,10 @@ export interface MultiQuerySearchOptions {
     maxWeight?: number;
     /** Weighted fusion: hit weight (default: 0.1) */
     hitWeight?: number;
+    /** Relative score fusion: dense vector weight (default: 0.5) */
+    denseWeight?: number;
+    /** Relative score fusion: sparse vector weight (default: 0.5) */
+    sparseWeight?: number;
   };
   /** Filter expression (optional) */
   filter?: Record<string, unknown>;
@@ -411,8 +421,8 @@ export interface CollectionStatsResponse {
 export interface CollectionConfigResponse {
   name: string;
   dimension: number;
-  metric: string;
-  storageMode: string;
+  metric: DistanceMetric;
+  storageMode: StorageMode;
   pointCount: number;
   metadataOnly: boolean;
   graphSchema?: Record<string, unknown>;

--- a/sdks/typescript/tests/wasm-backend.test.ts
+++ b/sdks/typescript/tests/wasm-backend.test.ts
@@ -219,13 +219,12 @@ describe('WasmBackend', () => {
       expect(results[0].score).toBe(0.95);
     });
 
-    it('should reject weighted fusion strategy', async () => {
-      await expect(
-        backend.multiQuerySearch('vectors', [[0.1, 0.2, 0.3, 0.4]], {
-          fusion: 'weighted',
-          fusionParams: { avgWeight: 0.6, maxWeight: 0.3, hitWeight: 0.1 },
-        }),
-      ).rejects.toThrow("Fusion strategy 'weighted' is not supported in WASM backend.");
+    it('should accept weighted fusion strategy', async () => {
+      const results = await backend.multiQuerySearch('vectors', [[0.1, 0.2, 0.3, 0.4]], {
+        fusion: 'weighted',
+        fusionParams: { avgWeight: 0.6, maxWeight: 0.3, hitWeight: 0.1 },
+      });
+      expect(Array.isArray(results)).toBe(true);
     });
   });
 


### PR DESCRIPTION
## Summary

Comprehensive pre-seed architectural audit (5 independent agents) identified 68 deduplicated findings. This PR implements 43 fixes across 6 sprints + addresses all 10 Devin review bugs and 3 ANALYSIS flags.

### Sprint 0 — Ship-Blockers (6 fixes)
- **LangChain chat memory broken** — dict iteration yielded keys instead of values
- **search_ids TypeError** — filter param routed to search_with_filter
- **Batch dispatch silent empty results** — debug_assert → Result::Err in release builds
- **GraphStore disconnected** — DeprecationWarning + documentation
- **to_pyobject error swallowing** — eprintln diagnostic added
- **Version assertions stale** — 1.7.0 → 1.12.0

### Sprint 1 — CI/Release Safety (7 fixes)
- Rust version aligned to 1.86 across all workflows
- Miri/Loom continue-on-error removed (safety findings no longer silent)
- Coverage gate 70% → 78%
- bench-arm64 simd path updated, Python test error suppression removed

### Sprint 2 — Python Quality (7 fixes + 3 file splits)
- `py.typed` PEP 561 marker created
- `velesdb-common` runtime dependency declared
- Version floors bumped to >=1.12.0
- `batch_query` raises ValueError for None embeddings
- `dataframe_converter` renames collision keys instead of silent overwrite
- `search_ops.py` split: extracted `multi_query_ops.py` (614→430 NLOC)
- `vectorstore.py` splits: extracted `point_builder.py` and `node_builder.py`

### Sprint 3 — TypeScript/WASM (6 fixes + wasm.ts split)
- HnswParams completed (5/5 fields), FusionParams with denseWeight/sparseWeight
- ESLint typed linting activated with no-floating-promises
- `wasm.ts` split into 4 files (807→479 NLOC)

### Sprint 4 — Rust Core (6 fixes)
- WASM fusion: unknown strategy returns error (not silent RRF fallback)
- Dead code `mode_to_ef_search` removed
- Quality scripts extended to all 7 workspace crates
- DDL/DML wildcard extract → None (Devin bug fix)

### Devin Review
- 10/10 bugs addressed (9 already fixed by prior PRs, 1 corrected here)
- 3/10 ANALYSIS flags with real implementation fixes

## Test plan
- [x] `cargo check --workspace` passes (all 8 crates)
- [x] `cargo check -p velesdb-python` passes
- [ ] CI lint + test suite
- [ ] Codacy static analysis — zero NLOC violations expected
- [ ] Devin review — expect clean or advisory-only

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/573" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
