### PR TITLE
fix(integrations): use normalized search_quality value

### DIFF
--- a/integrations/langchain/src/langchain_velesdb/search_ops.py
+++ b/integrations/langchain/src/langchain_velesdb/search_ops.py
@@ -251,7 +251,7 @@ class SearchOpsMixin(MultiQueryOpsMixin):
         sparse_index_name = kwargs.get("sparse_index_name")
         quality = kwargs.get("search_quality", getattr(self, "_search_quality", None))
         if quality is not None:
-            validate_search_quality(quality)
+            quality = validate_search_quality(quality)
         query_embedding = self._embedding.embed_query(query)
         results = self._run_vector_search(
             query_embedding, k,

--- a/integrations/llamaindex/src/llamaindex_velesdb/search_ops.py
+++ b/integrations/llamaindex/src/llamaindex_velesdb/search_ops.py
@@ -98,7 +98,7 @@ class SearchOpsMixin:
 
         quality = kwargs.get("search_quality", getattr(self, "_search_quality", None))
         if quality is not None:
-            validate_search_quality(quality)
+            quality = validate_search_quality(quality)
 
         core_filter = self._metadata_filters_to_core_filter(query.filters)
 


### PR DESCRIPTION
## Summary

Devin found that `validate_search_quality()` returns the normalized (lowercase) quality string but both LangChain and LlamaIndex per-call overrides discarded the return value, sending the original mixed-case string to the core engine.

Example: user passes `"AutoTune"` → validation passes → but `"AutoTune"` (not `"autotune"`) is sent to core → core rejects or misparses.

Fix: `quality = validate_search_quality(quality)` — use the return value.

## Test plan
- [x] 2-line change, no compilation impact
- [ ] CI
- [ ] Devin

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/577" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
