### PR TITLE
fix(ecosystem): final pre-seed gaps — non_exhaustive, compaction docs, Python wrappers

### DIFF
--- a/.github/instructions/codacy.instructions.md
+++ b/.github/instructions/codacy.instructions.md
@@ -10,7 +10,7 @@ Configuration for AI behavior when interacting with Codacy's MCP Server
 - ALWAYS use:
  - provider: gh
  - organization: cyberlife-coder
- - repository: VelesDB
+ - repository: velesdb-private
 - Avoid calling `git remote -v` unless really necessary
 
 ## CRITICAL: After ANY successful `edit_file` or `reapply` operation

--- a/crates/velesdb-core/src/half_precision.rs
+++ b/crates/velesdb-core/src/half_precision.rs
@@ -33,6 +33,7 @@ use serde::{Deserialize, Serialize};
 
 /// Vector precision format.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[non_exhaustive]
 pub enum VectorPrecision {
     /// 32-bit floating point (4 bytes per dimension)
     #[default]
@@ -65,6 +66,7 @@ impl VectorPrecision {
 /// Stores vectors in their native precision format to minimize memory usage.
 /// Provides conversion methods for distance calculations.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
 pub enum VectorData {
     /// Full precision f32 vector
     F32(Vec<f32>),

--- a/crates/velesdb-core/src/simd_native/dispatch/mod.rs
+++ b/crates/velesdb-core/src/simd_native/dispatch/mod.rs
@@ -18,6 +18,7 @@ pub use hamming::{
 
 /// SIMD capability level detected at runtime.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum SimdLevel {
     /// AVX-512F available (x86_64 only).
     Avx512,

--- a/crates/velesdb-core/src/storage/hnsw_delta_wal.rs
+++ b/crates/velesdb-core/src/storage/hnsw_delta_wal.rs
@@ -31,6 +31,7 @@ const ENTRY_PAYLOAD_SIZE: usize = 1 + 4 + 1; // 6 bytes
 
 /// Operation codes for HNSW delta WAL entries.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 #[repr(u8)]
 pub enum DeltaOp {
     /// Directed edge addition.
@@ -43,6 +44,7 @@ pub enum DeltaOp {
 
 /// A single HNSW graph mutation.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum HnswDelta {
     /// Add a directed edge from `from` to `to` at `layer`.
     AddEdge {

--- a/crates/velesdb-core/src/velesql/ast/aggregation.rs
+++ b/crates/velesdb-core/src/velesql/ast/aggregation.rs
@@ -10,6 +10,7 @@ use super::values::Value;
 
 /// Aggregate function type.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub enum AggregateType {
     /// COUNT(*) or COUNT(column)
     Count,
@@ -27,6 +28,7 @@ pub enum AggregateType {
 
 /// Argument to an aggregate function.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub enum AggregateArg {
     /// Wildcard (*) - only valid for COUNT.
     Wildcard,
@@ -56,6 +58,7 @@ pub struct GroupByClause {
 
 /// Logical operator for combining HAVING conditions.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub enum LogicalOp {
     /// Logical AND.
     And,

--- a/crates/velesdb-core/src/velesql/ast/condition.rs
+++ b/crates/velesdb-core/src/velesql/ast/condition.rs
@@ -88,6 +88,7 @@ pub struct SparseVectorSearch {
 
 /// Expression representing a sparse vector value in a query.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub enum SparseVectorExpr {
     /// Inline sparse literal: `{12: 0.8, 45: 0.3}`
     Literal(SparseVector),
@@ -121,6 +122,7 @@ pub struct Comparison {
 
 /// Comparison operators.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub enum CompareOp {
     /// Equal (=)
     Eq,
@@ -203,6 +205,7 @@ pub struct ContainsTextCondition {
 
 /// Containment mode for array CONTAINS operations.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub enum ContainsMode {
     /// Single value: `column CONTAINS value`
     Single,

--- a/crates/velesdb-core/src/velesql/ast/ddl.rs
+++ b/crates/velesdb-core/src/velesql/ast/ddl.rs
@@ -35,6 +35,7 @@ pub struct CreateCollectionStatement {
 
 /// Kind of collection to create.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub enum CreateCollectionKind {
     /// Vector collection (default).
     Vector(VectorCollectionParams),
@@ -72,6 +73,7 @@ pub struct GraphCollectionParams {
 
 /// Graph schema mode.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub enum GraphSchemaMode {
     /// No schema enforcement.
     Schemaless,
@@ -81,6 +83,7 @@ pub enum GraphSchemaMode {
 
 /// A single schema definition (node type or edge type).
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub enum SchemaDefinition {
     /// Node type with properties.
     Node {

--- a/crates/velesdb-core/src/velesql/ast/join.rs
+++ b/crates/velesdb-core/src/velesql/ast/join.rs
@@ -21,6 +21,7 @@ pub struct JoinClause {
 
 /// Type of SQL JOIN operation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[non_exhaustive]
 pub enum JoinType {
     /// INNER JOIN.
     #[default]

--- a/crates/velesdb-core/src/velesql/ast/mod.rs
+++ b/crates/velesdb-core/src/velesql/ast/mod.rs
@@ -283,6 +283,7 @@ impl Query {
 
 /// SQL set operator for compound queries (EPIC-040 US-006).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub enum SetOperator {
     /// UNION - merge results, remove duplicates.
     Union,

--- a/crates/velesdb-core/src/velesql/ast/select.rs
+++ b/crates/velesdb-core/src/velesql/ast/select.rs
@@ -188,6 +188,7 @@ impl SelectOrderBy {
 
 /// Expression types supported in ORDER BY clause.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub enum OrderByExpr {
     /// Simple field reference.
     Field(String),
@@ -226,6 +227,7 @@ pub struct LetBinding {
 /// Supports binary operations (+, -, *, /) with numeric literals,
 /// variables (field references), and similarity() function calls.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub enum ArithmeticExpr {
     /// Numeric literal (e.g., `0.7`, `2`).
     Literal(f64),
@@ -246,6 +248,7 @@ pub enum ArithmeticExpr {
 
 /// Arithmetic operators for ORDER BY expressions (EPIC-042).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub enum ArithmeticOp {
     /// Addition (`+`).
     Add,

--- a/crates/velesdb-core/src/velesql/ast/with_clause.rs
+++ b/crates/velesdb-core/src/velesql/ast/with_clause.rs
@@ -9,6 +9,7 @@ use serde::{Deserialize, Serialize};
 ///
 /// Controls the precision/speed tradeoff for similarity search.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[non_exhaustive]
 pub enum QuantizationMode {
     /// Use full f32 precision (exact, slower).
     F32,
@@ -147,6 +148,7 @@ pub struct WithOption {
 
 /// Value type for WITH clause options.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub enum WithValue {
     /// String value.
     String(String),

--- a/crates/velesdb-core/src/velesql/graph_pattern.rs
+++ b/crates/velesdb-core/src/velesql/graph_pattern.rs
@@ -120,6 +120,7 @@ impl RelationshipPattern {
 
 /// Direction of a relationship.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub enum Direction {
     /// Outgoing: `-->`
     Outgoing,

--- a/crates/velesdb-core/src/velesql/json_path.rs
+++ b/crates/velesdb-core/src/velesql/json_path.rs
@@ -8,6 +8,7 @@ use serde_json::Value;
 
 /// Error type for JSON path parsing.
 #[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
 pub enum JsonPathError {
     /// Empty path provided.
     EmptyPath,
@@ -34,6 +35,7 @@ impl std::error::Error for JsonPathError {}
 
 /// A segment in a JSON path.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[non_exhaustive]
 pub enum PathSegment {
     /// Object property access: `.field`
     Property(String),

--- a/crates/velesdb-core/src/velesql/planner.rs
+++ b/crates/velesdb-core/src/velesql/planner.rs
@@ -36,6 +36,7 @@ pub use crate::velesql::query_stats::QueryStats;
 
 /// Execution strategy for hybrid queries.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum ExecutionStrategy {
     /// Execute vector search first, then filter by graph pattern.
     /// Best when graph filter is not very selective (>10% of data).

--- a/crates/velesdb-python/python/velesdb/__init__.py
+++ b/crates/velesdb-python/python/velesdb/__init__.py
@@ -159,6 +159,33 @@ class Collection:
             searches = [{"vector": list(v), "top_k": int(top_k)} for v in queries]
         return self._inner.batch_search(searches)
 
+    def multi_query_search(
+        self,
+        queries: list[list[float]],
+        top_k: int = 10,
+        fusion_strategy: str | None = None,
+        fusion_params: dict[str, Any] | None = None,
+    ) -> list[list[dict[str, Any]]]:
+        """Multi-query search with fusion strategy."""
+        return self._inner.multi_query_search(
+            queries,
+            top_k=top_k,
+            fusion_strategy=fusion_strategy,
+            fusion_params=fusion_params,
+        )
+
+    def stream_insert(self, points: list[dict[str, Any]]) -> int:
+        """Streaming insert for real-time ingestion."""
+        return self._inner.stream_insert(points)
+
+    def search_batch_parallel(
+        self,
+        vectors: list[list[float]],
+        top_k: int = 10,
+    ) -> list[list[dict[str, Any]]]:
+        """Parallel batch search using rayon."""
+        return self._inner.search_batch_parallel(vectors, top_k=top_k)
+
     def search_with_quality(
         self,
         vector: Any,

--- a/crates/velesdb-python/python/velesdb/__init__.py
+++ b/crates/velesdb-python/python/velesdb/__init__.py
@@ -161,17 +161,21 @@ class Collection:
 
     def multi_query_search(
         self,
-        queries: list[list[float]],
+        vectors: list[list[float]],
         top_k: int = 10,
-        fusion_strategy: str | None = None,
-        fusion_params: dict[str, Any] | None = None,
-    ) -> list[list[dict[str, Any]]]:
-        """Multi-query search with fusion strategy."""
+        fusion: Any = None,
+        filter: dict[str, Any] | None = None,
+    ) -> list[dict[str, Any]]:
+        """Multi-query search with result fusion.
+
+        Args:
+            vectors: List of query vectors.
+            top_k: Number of results per query (default: 10).
+            fusion: Optional FusionStrategy instance.
+            filter: Optional metadata filter dict.
+        """
         return self._inner.multi_query_search(
-            queries,
-            top_k=top_k,
-            fusion_strategy=fusion_strategy,
-            fusion_params=fusion_params,
+            vectors, top_k=top_k, fusion=fusion, filter=filter,
         )
 
     def stream_insert(self, points: list[dict[str, Any]]) -> int:

--- a/crates/velesdb-python/python/velesdb/__init__.pyi
+++ b/crates/velesdb-python/python/velesdb/__init__.pyi
@@ -306,18 +306,22 @@ class Collection:
 
     def multi_query_search(
         self,
-        vectors: List[Union[List[float], "np.ndarray"]],
+        queries: List[List[float]],
         top_k: int = 10,
-        fusion: Optional[FusionStrategy] = None,
-        filter: Optional[Dict[str, Any]] = None,
-    ) -> List[Dict[str, Any]]:
-        """Multi-query search with result fusion.
+        fusion_strategy: Optional[str] = None,
+        fusion_params: Optional[Dict[str, Any]] = None,
+    ) -> List[List[Dict[str, Any]]]:
+        """Multi-query search with fusion strategy.
 
         Args:
-            vectors: List of query vectors (max 10)
-            top_k: Number of results to return after fusion
-            fusion: Fusion strategy (default: RRF with k=60)
-            filter: Optional metadata filter applied to all queries
+            queries: List of query vectors
+            top_k: Number of results per fused output (default: 10)
+            fusion_strategy: Named fusion strategy (e.g. ``'rrf'``, ``'weighted'``).
+                Defaults to RRF when None.
+            fusion_params: Strategy-specific parameters (e.g. ``{'k': 60}`` for RRF).
+
+        Returns:
+            List of result lists, one per query vector (pre-fusion per-query results).
         """
         ...
 

--- a/crates/velesdb-python/python/velesdb/__init__.pyi
+++ b/crates/velesdb-python/python/velesdb/__init__.pyi
@@ -306,22 +306,21 @@ class Collection:
 
     def multi_query_search(
         self,
-        queries: List[List[float]],
+        vectors: List[Union[List[float], "np.ndarray"]],
         top_k: int = 10,
-        fusion_strategy: Optional[str] = None,
-        fusion_params: Optional[Dict[str, Any]] = None,
-    ) -> List[List[Dict[str, Any]]]:
-        """Multi-query search with fusion strategy.
+        fusion: Optional["FusionStrategy"] = None,
+        filter: Optional[Dict[str, Any]] = None,
+    ) -> List[Dict[str, Any]]:
+        """Multi-query search with result fusion.
 
         Args:
-            queries: List of query vectors
-            top_k: Number of results per fused output (default: 10)
-            fusion_strategy: Named fusion strategy (e.g. ``'rrf'``, ``'weighted'``).
-                Defaults to RRF when None.
-            fusion_params: Strategy-specific parameters (e.g. ``{'k': 60}`` for RRF).
+            vectors: List of query vectors.
+            top_k: Number of results (default: 10).
+            fusion: Optional FusionStrategy instance. Defaults to RRF.
+            filter: Optional metadata filter dict.
 
         Returns:
-            List of result lists, one per query vector (pre-fusion per-query results).
+            Fused search results as list of dicts.
         """
         ...
 

--- a/docs/CONCURRENCY_MODEL.md
+++ b/docs/CONCURRENCY_MODEL.md
@@ -50,6 +50,7 @@ VelesDB utilise un modèle de concurrence basé sur:
 | RaBitQ index | `parking_lot::RwLock` | None (after training) | Write-once then read-only |
 | RaBitQ store | `parking_lot::RwLock` | Low | Write per insert (~10ns hold) |
 | RaBitQ training buffer | `parking_lot::Mutex` | Low | Pre-training only |
+| MmapStorage (compaction) | `parking_lot::RwLock` | High (during compaction) | Exclusive write lock for full compaction duration |
 
 ## Thread Safety Guarantees
 
@@ -591,6 +592,69 @@ Recovery behavior is validated by the following test suite:
 | WAL replay tests | `wal_recovery_tests.rs` | CRC validation, legacy format detection, truncation |
 | HNSW delta WAL tests | `hnsw_delta_wal_tests.rs` | Delta entry serialization, CRC verification, crash boundary |
 
+## Storage Compaction Concurrency
+
+### Exclusive Lock Scope
+
+Storage compaction holds the `MmapStorage` write lock for the entire
+duration of the operation. This is enforced at two levels:
+
+1. **Synchronous path** (`MmapStorage::compact(&mut self)`): The method
+   takes `&mut self`, so the caller must already hold an exclusive
+   reference. No concurrent reads or writes are possible while compaction
+   runs.
+
+2. **Asynchronous path** (`compact_async(storage: Arc<RwLock<MmapStorage>>)`):
+   Acquires `storage.write()` inside a `spawn_blocking` task and holds
+   the write guard for the full compaction cycle. All readers and writers
+   on the same `RwLock` are blocked until the guard is dropped.
+
+```
+compact_async()
+├─ spawn_blocking
+│  ├─ storage.write()          ← exclusive lock acquired
+│  ├─ MmapStorage::compact()   ← rewrite active vectors to .tmp
+│  │   ├─ build temp file
+│  │   ├─ copy active vectors
+│  │   ├─ atomic_replace(.tmp → .dat)
+│  │   └─ rebuild index + flush
+│  └─ drop(guard)              ← exclusive lock released
+```
+
+### Latency Impact
+
+On large collections (>1M vectors), compaction rewrites the entire active
+vector set to a new file and atomically replaces the original. This can
+block all reads and writes for seconds, depending on disk throughput and
+vector dimensionality. This is an intentional correctness-over-performance
+trade-off: holding the exclusive lock prevents readers from observing a
+partially rewritten file and writers from appending to a file that is about
+to be replaced.
+
+### Crash Recovery
+
+`recover_compaction_artifacts()` runs automatically during
+`MmapStorage::new()` to repair any interrupted compaction. The recovery
+logic inspects leftover intermediate files:
+
+| State on Disk | Interpretation | Recovery Action |
+|---------------|---------------|-----------------|
+| `.bak` exists, original missing | Crash after rename-to-backup, before new file swap | Restore `.bak` as original |
+| `.bak` exists, original exists | Compaction completed, backup not yet cleaned up | Remove `.bak` |
+| `.tmp` exists | Incomplete compaction (temp file never swapped in) | Remove `.tmp` |
+
+This ensures the storage directory is always in a consistent state before
+the mmap file is opened, regardless of when the previous process crashed.
+
+**Module**: `crates/velesdb-core/src/storage/compaction.rs`
+(`recover_compaction_artifacts`, `atomic_replace`)
+
+### Future Roadmap
+
+Copy-on-write compaction that allows concurrent reads during the rewrite
+phase is planned for the enterprise edition. The current exclusive-lock
+design is the baseline for correctness validation.
+
 ## Testing Concurrency
 
 ### Running Loom Tests
@@ -624,4 +688,4 @@ invariants, see [SOUNDNESS.md: HNSW Batch Insertion Ordering](SOUNDNESS.md#hnsw-
 
 ---
 
-*Last updated: 2026-04-08 (WP-1F: HNSW crash recovery documentation)*
+*Last updated: 2026-04-09 (Storage compaction concurrency documentation)*


### PR DESCRIPTION
## Summary

Closes the 3 final gaps identified by the definitive architectural audit.

### 1. `#[non_exhaustive]` on 25 remaining public enums (HIGH)
All public enums in velesdb-core now have `#[non_exhaustive]`. This ensures adding a variant is never a semver-breaking change — critical for the enterprise version where third-party code will match on these types.

25 enums across 13 files: VelesQL AST types (AggregateType, CompareOp, JoinType, SetOperator, etc.), storage types (DeltaOp, HnswDelta), SIMD (SimdLevel), half precision (VectorPrecision, VectorData).

No downstream match-arm fixes needed — all matches are within the defining crate.

### 2. Compaction concurrency documentation (MEDIUM)
Added "Storage Compaction Concurrency" section to CONCURRENCY_MODEL.md:
- Exclusive lock scope (`compact(&mut self)`)
- Latency impact on large collections
- Crash recovery via `recover_compaction_artifacts()`
- Enterprise roadmap: copy-on-write compaction

### 3. Python wrapper methods (LOW)
Exposed 3 methods that existed in PyO3 bindings but were missing from the `Collection` wrapper:
- `multi_query_search` (fusion search)
- `stream_insert` (real-time ingestion)
- `search_batch_parallel` (rayon parallel)

Updated `__init__.pyi` type stubs.

## Test plan
- [x] `cargo check --workspace` + WASM + Python — all clean
- [x] `cargo clippy -- -D warnings` — 0 warnings
- [ ] CI full suite
- [ ] Devin review

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/578" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
