### PR TITLE
Sprint 1 — Core to server REST propagation + spawn_blocking sweep (partial)

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,7 +469,7 @@ The container runs as a non-root `velesdb` user. Data persists via the named vol
 | **Points** | `/collections/{name}/points`, `/collections/{name}/points/scroll`, `/collections/{name}/stream/insert` |
 | **Search** | `/collections/{name}/search`, `/collections/{name}/search/batch`, `/collections/{name}/search/hybrid`, `/collections/{name}/search/text`, `/collections/{name}/search/multi`, `/collections/{name}/search/ids`, `/collections/{name}/match` |
 | **Graph** | `/collections/{name}/graph/edges`, `/collections/{name}/graph/edges/{id}`, `/collections/{name}/graph/edges/count`, `/collections/{name}/graph/traverse`, `/collections/{name}/graph/traverse/stream`, `/collections/{name}/graph/traverse/parallel`, `/collections/{name}/graph/nodes`, `/collections/{name}/graph/nodes/{id}/degree`, `/collections/{name}/graph/nodes/{id}/edges`, `/collections/{name}/graph/nodes/{id}/payload`, `/collections/{name}/graph/search` |
-| **Indexes** | `GET/POST /collections/{name}/indexes`, `DELETE /collections/{name}/indexes/{label}/{property}` |
+| **Indexes** | `GET/POST /collections/{name}/indexes`, `DELETE /collections/{name}/indexes/{label}/{property}`, `/collections/{name}/index/rebuild` |
 | **VelesQL** | `/query`, `/aggregate`, `/query/explain` |
 | **Admin** | `/health`, `/ready`, `/metrics`, `/guardrails`, `/collections/{name}/stats`, `/collections/{name}/config`, `/collections/{name}/flush`, `/collections/{name}/analyze`, `/collections/{name}/empty`, `/collections/{name}/sanity` |
 

--- a/crates/tauri-plugin-velesdb/src/helpers.rs
+++ b/crates/tauri-plugin-velesdb/src/helpers.rs
@@ -136,15 +136,19 @@ pub fn map_core_results(
 
 /// Looks up a collection by name, returning a typed error on miss.
 ///
-/// Returns a `VectorCollection` for any collection type (vector, graph, or metadata)
-/// by using `get_any_collection` and converting via `into_vector_collection`.
-/// This ensures graph and metadata collections are accessible through Tauri commands.
+/// Returns a `VectorCollection` for any collection type (vector, graph,
+/// or metadata) by using `get_any_collection` and the unchecked cast
+/// `AnyCollection::as_vector_collection_unchecked`. Callers that
+/// invoke vector-specific methods on a collection produced from a
+/// graph or metadata variant may observe empty or nonsensical
+/// results — a proper typed split is tracked as the F2.2 post-seed
+/// EPIC (see `docs/ARCHITECTURE.md`).
 pub fn require_collection(
     db: &velesdb_core::Database,
     name: &str,
 ) -> Result<velesdb_core::VectorCollection> {
     db.get_any_collection(name)
-        .map(velesdb_core::AnyCollection::into_vector_collection)
+        .map(velesdb_core::AnyCollection::as_vector_collection_unchecked)
         .ok_or_else(|| Error::CollectionNotFound(name.to_string()))
 }
 

--- a/crates/velesdb-core/src/api_types/requests.rs
+++ b/crates/velesdb-core/src/api_types/requests.rs
@@ -47,6 +47,38 @@ pub struct CreateCollectionRequest {
     #[serde(default)]
     #[cfg_attr(feature = "openapi", schema(example = 400, nullable))]
     pub hnsw_ef_construction: Option<usize>,
+    /// PQ rescore oversampling factor (default 4).
+    ///
+    /// The search pipeline fetches `max(k * factor, k + 32)` candidates
+    /// from HNSW and rescores them with full-precision ADC. Only
+    /// meaningful for quantised storage modes (SQ8, PQ). `Some(0)` is
+    /// treated as "disabled".
+    #[serde(default)]
+    #[cfg_attr(feature = "openapi", schema(example = 4, nullable))]
+    pub pq_rescore_oversampling: Option<u32>,
+    /// Deferred indexing configuration (`US-366`).
+    ///
+    /// When present, inserts are buffered in memory and batch-merged
+    /// into the HNSW index when the buffer reaches `merge_threshold`.
+    /// Accepted as a free-form JSON object matching
+    /// `velesdb_core::collection::streaming::DeferredIndexerConfig`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub deferred_indexing: Option<serde_json::Value>,
+    /// Async index builder configuration (Issue `#488` — Bulk Insert V2).
+    ///
+    /// When present, enables the `AsyncIndexBuilder` for deferred HNSW
+    /// insertion during bulk import. Accepted as a free-form JSON object
+    /// matching
+    /// `velesdb_core::collection::streaming::AsyncIndexBuilderConfig`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub async_index_builder: Option<serde_json::Value>,
+    /// Graph schema (only for `collection_type = "graph"`).
+    ///
+    /// Accepted as a free-form JSON object matching
+    /// `velesdb_core::GraphSchema`. `GraphSchema::schemaless()` is
+    /// used when the field is absent.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub graph_schema: Option<serde_json::Value>,
 }
 
 // ============================================================================

--- a/crates/velesdb-core/src/api_types/requests.rs
+++ b/crates/velesdb-core/src/api_types/requests.rs
@@ -132,7 +132,8 @@ impl SparseVectorInput {
 #[derive(Debug, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 pub struct FusionRequest {
-    /// Fusion strategy: "rrf" or "rsf".
+    /// Fusion strategy: "rrf", "rsf" (alias "`relative_score`"),
+    /// "average" (alias "avg"), "maximum" (alias "max"), or "weighted".
     #[cfg_attr(feature = "openapi", schema(example = "rrf"))]
     pub strategy: String,
     /// RRF k parameter (only for strategy = "rrf", default 60).
@@ -144,6 +145,18 @@ pub struct FusionRequest {
     /// Sparse weight (only for strategy = "rsf", default 0.5).
     #[serde(default)]
     pub sparse_w: Option<f32>,
+    /// Weighted fusion: weight applied to the average score component
+    /// (only for strategy = "weighted", default 0.5).
+    #[serde(default)]
+    pub avg_w: Option<f32>,
+    /// Weighted fusion: weight applied to the maximum score component
+    /// (only for strategy = "weighted", default 0.3).
+    #[serde(default)]
+    pub max_w: Option<f32>,
+    /// Weighted fusion: weight applied to the hit-ratio component
+    /// (only for strategy = "weighted", default 0.2).
+    #[serde(default)]
+    pub hit_w: Option<f32>,
 }
 
 // ============================================================================

--- a/crates/velesdb-core/src/api_types/responses.rs
+++ b/crates/velesdb-core/src/api_types/responses.rs
@@ -52,6 +52,28 @@ pub struct CollectionConfigResponse {
     /// Embedding dimension for graph node vectors.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub embedding_dimension: Option<usize>,
+    /// On-disk schema version. Increments when the persisted
+    /// `config.json` format changes in a way older `VelesDB` versions
+    /// cannot safely read.
+    #[serde(default)]
+    pub schema_version: u32,
+    /// PQ rescore oversampling factor. See `CollectionConfig` for
+    /// the semantics of `None`, `Some(0)`, and `Some(n > 0)`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pq_rescore_oversampling: Option<u32>,
+    /// Persisted HNSW parameters (M, `ef_construction`, etc.) when
+    /// customised at create time. `None` means the defaults inferred
+    /// from the collection dimension are in use.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub hnsw_params: Option<serde_json::Value>,
+    /// Deferred indexing configuration (`US-366`) — `None` when the
+    /// feature is disabled for this collection.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub deferred_indexing: Option<serde_json::Value>,
+    /// Async index builder configuration (Issue `#488`) — `None` when
+    /// the feature is disabled for this collection.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub async_index_builder: Option<serde_json::Value>,
 }
 
 // ============================================================================

--- a/crates/velesdb-core/src/api_types/tests.rs
+++ b/crates/velesdb-core/src/api_types/tests.rs
@@ -214,6 +214,11 @@ fn round_trip_collection_config_response() {
         metadata_only: false,
         graph_schema: Some(json!({"labels": ["Person"]})),
         embedding_dimension: Some(128),
+        schema_version: 1,
+        pq_rescore_oversampling: Some(4),
+        hnsw_params: None,
+        deferred_indexing: None,
+        async_index_builder: None,
     };
     let serialized = serde_json::to_value(&resp).unwrap();
     let deserialized: CollectionConfigResponse = serde_json::from_value(serialized).unwrap();
@@ -222,6 +227,8 @@ fn round_trip_collection_config_response() {
     assert_eq!(deserialized.metric, "cosine");
     assert_eq!(deserialized.storage_mode, "full");
     assert_eq!(deserialized.point_count, 1000);
+    assert_eq!(deserialized.schema_version, 1);
+    assert_eq!(deserialized.pq_rescore_oversampling, Some(4));
     assert!(!deserialized.metadata_only);
     assert!(deserialized.graph_schema.is_some());
     assert_eq!(deserialized.embedding_dimension, Some(128));
@@ -577,14 +584,23 @@ fn serialize_collection_config_skips_none_graph_schema() {
         metadata_only: true,
         graph_schema: None,
         embedding_dimension: None,
+        schema_version: 1,
+        pq_rescore_oversampling: None,
+        hnsw_params: None,
+        deferred_indexing: None,
+        async_index_builder: None,
     };
     let json = serde_json::to_value(&resp).unwrap();
     // `skip_serializing_if = "Option::is_none"` omits the key entirely
-    assert!(!json.as_object().unwrap().contains_key("graph_schema"));
-    assert!(!json
-        .as_object()
-        .unwrap()
-        .contains_key("embedding_dimension"));
+    let obj = json.as_object().unwrap();
+    assert!(!obj.contains_key("graph_schema"));
+    assert!(!obj.contains_key("embedding_dimension"));
+    assert!(!obj.contains_key("pq_rescore_oversampling"));
+    assert!(!obj.contains_key("hnsw_params"));
+    assert!(!obj.contains_key("deferred_indexing"));
+    assert!(!obj.contains_key("async_index_builder"));
+    // `schema_version` is not an Option — always serialised.
+    assert_eq!(obj["schema_version"], 1);
 }
 
 #[test]

--- a/crates/velesdb-core/src/collection/any_collection.rs
+++ b/crates/velesdb-core/src/collection/any_collection.rs
@@ -123,23 +123,72 @@ impl AnyCollection {
         }
     }
 
-    /// Converts this `AnyCollection` into a `VectorCollection`.
+    /// Consumes this `AnyCollection` and returns a `VectorCollection`
+    /// wrapping the same inner state.
     ///
-    /// For `Vector` variants, returns the inner `VectorCollection` directly.
-    /// For `Graph` and `Metadata` variants, wraps the inner `Collection` in a
-    /// `VectorCollection` newtype. This is safe because `VectorCollection` is a
-    /// pure newtype over `Collection` — all operations delegate to the same
-    /// `Arc`-wrapped state.
+    /// For the `Vector` variant this is a straightforward move. For
+    /// the `Graph` and `Metadata` variants this function re-wraps the
+    /// inner `Arc<Collection>` in the `VectorCollection` newtype
+    /// without changing the underlying runtime type — downstream code
+    /// that then invokes vector-specific methods on the result (for
+    /// example `search`, `upsert`, `config().dimension > 0`) may
+    /// therefore hit an error or nonsensical state at runtime. The
+    /// method is still useful for SDK bindings (Python, Mobile, Tauri)
+    /// that expose a single `Collection` type to users and only call
+    /// shared methods (config, flush, diagnostics, point_count) on
+    /// the result.
     ///
-    /// This is primarily useful for SDK bindings (Python, Mobile, Tauri) that
-    /// expose a single `Collection` type to users regardless of the underlying
-    /// collection kind.
+    /// # Safety
+    ///
+    /// Calling vector-specific methods on a `VectorCollection` that
+    /// was produced from a `Graph` or `Metadata` variant is **not**
+    /// memory-unsafe, but the result is logically unsound: the
+    /// underlying storage does not hold a homogeneous vector index,
+    /// and the returned `SearchResult` objects are either empty or
+    /// reflect internal state that was not intended for public
+    /// consumption. Callers must either:
+    ///
+    /// * branch on [`AnyCollection::is_vector`] first and only
+    ///   invoke vector-specific methods on the `Vector` variant, or
+    /// * restrict themselves to the methods that all three collection
+    ///   kinds share (`config`, `flush`, `diagnostics`, `name`,
+    ///   `point_count`).
+    ///
+    /// This method is retained to support the existing SDK surface
+    /// but is flagged as `unchecked` to make the caller obligation
+    /// explicit. A proper type-safe refactor is tracked under the
+    /// post-seed EPIC documented in `docs/ARCHITECTURE.md` (finding
+    /// F2.2 of the pre-seed audit).
     #[must_use]
-    pub fn into_vector_collection(self) -> VectorCollection {
+    pub fn as_vector_collection_unchecked(self) -> VectorCollection {
         match self {
             Self::Vector(c) => c,
             Self::Graph(c) => VectorCollection { inner: c.inner },
             Self::Metadata(c) => VectorCollection { inner: c.inner },
         }
+    }
+
+    /// Deprecated alias for [`Self::as_vector_collection_unchecked`].
+    ///
+    /// The old name is retained so external consumers do not break at
+    /// compile time; it emits a deprecation warning that points at
+    /// the safer replacement. Internal call sites have been migrated.
+    #[must_use]
+    #[deprecated(
+        since = "1.13.0",
+        note = "Renamed to `as_vector_collection_unchecked`. See the rustdoc for the unchecked-cast contract and finding F2.2 in docs/ARCHITECTURE.md."
+    )]
+    pub fn into_vector_collection(self) -> VectorCollection {
+        self.as_vector_collection_unchecked()
+    }
+
+    /// Returns `true` if this collection is a `Vector` variant.
+    ///
+    /// Intended for callers that use
+    /// [`Self::as_vector_collection_unchecked`] and need to branch on
+    /// the underlying kind before invoking vector-specific methods.
+    #[must_use]
+    pub fn is_vector(&self) -> bool {
+        matches!(self, Self::Vector(_))
     }
 }

--- a/crates/velesdb-core/src/collection/core/flush.rs
+++ b/crates/velesdb-core/src/collection/core/flush.rs
@@ -270,6 +270,25 @@ impl Collection {
         Ok(())
     }
 
+    /// Vacuums the HNSW index of this collection, rebuilding the
+    /// graph from the current vector storage and reclaiming memory
+    /// occupied by tombstoned entries. Returns the number of entries
+    /// compacted.
+    ///
+    /// This is the collection-level wrapper around
+    /// [`HnswIndex::vacuum`] used by the server admin endpoint
+    /// `POST /collections/{name}/index/rebuild` (finding F-21).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the underlying HNSW vacuum fails (for
+    /// instance, when vector storage is disabled on the index).
+    pub(crate) fn vacuum_hnsw_index(&self) -> Result<usize> {
+        self.index
+            .vacuum()
+            .map_err(|e| Error::Index(format!("HNSW vacuum failed: {e}")))
+    }
+
     /// Applies post-creation overrides to the advanced configuration
     /// fields and persists the updated `config.json` atomically.
     ///

--- a/crates/velesdb-core/src/collection/core/flush.rs
+++ b/crates/velesdb-core/src/collection/core/flush.rs
@@ -315,9 +315,7 @@ impl Collection {
         #[cfg(feature = "persistence")] deferred_indexing: Option<
             Option<crate::collection::streaming::DeferredIndexerConfig>,
         >,
-        async_index_builder: Option<
-            Option<crate::collection::streaming::AsyncIndexBuilderConfig>,
-        >,
+        async_index_builder: Option<Option<crate::collection::streaming::AsyncIndexBuilderConfig>>,
     ) -> Result<()> {
         {
             let mut config = self.config.write();

--- a/crates/velesdb-core/src/collection/core/flush.rs
+++ b/crates/velesdb-core/src/collection/core/flush.rs
@@ -269,4 +269,50 @@ impl Collection {
         std::fs::rename(&tmp_path, &config_path)?;
         Ok(())
     }
+
+    /// Applies post-creation overrides to the advanced configuration
+    /// fields and persists the updated `config.json` atomically.
+    ///
+    /// This is used by the server `POST /collections` handler to wire
+    /// `pq_rescore_oversampling`, `deferred_indexing`, and
+    /// `async_index_builder` from the REST payload after the collection
+    /// has been created with its base options (HNSW, storage mode).
+    /// Passing `None` leaves the corresponding field unchanged — callers
+    /// that need to clear a field should pass `Some(None)` via the
+    /// nested `Option`.
+    ///
+    /// The `Option<Option<T>>` pattern encodes three states:
+    /// `None` (leave unchanged), `Some(None)` (clear the field), and
+    /// `Some(Some(v))` (set the field to `v`). A clippy allow is
+    /// applied locally because that is exactly what we need here.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the updated config cannot be written to disk.
+    #[allow(clippy::option_option)]
+    pub(crate) fn apply_advanced_config(
+        &self,
+        pq_rescore_oversampling: Option<Option<u32>>,
+        #[cfg(feature = "persistence")] deferred_indexing: Option<
+            Option<crate::collection::streaming::DeferredIndexerConfig>,
+        >,
+        async_index_builder: Option<
+            Option<crate::collection::streaming::AsyncIndexBuilderConfig>,
+        >,
+    ) -> Result<()> {
+        {
+            let mut config = self.config.write();
+            if let Some(rescore) = pq_rescore_oversampling {
+                config.pq_rescore_oversampling = rescore;
+            }
+            #[cfg(feature = "persistence")]
+            if let Some(deferred) = deferred_indexing {
+                config.deferred_indexing = deferred;
+            }
+            if let Some(aib) = async_index_builder {
+                config.async_index_builder = aib;
+            }
+        }
+        self.save_config()
+    }
 }

--- a/crates/velesdb-core/src/collection/vector_collection/accessors.rs
+++ b/crates/velesdb-core/src/collection/vector_collection/accessors.rs
@@ -77,6 +77,21 @@ impl VectorCollection {
         self.inner.config()
     }
 
+    /// Rebuilds the HNSW index of this collection from the vector
+    /// storage, reclaiming memory occupied by tombstoned entries.
+    /// Returns the number of entries compacted.
+    ///
+    /// Used by the server admin endpoint
+    /// `POST /collections/{name}/index/rebuild` (finding F-21).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the vacuum fails (for instance, when
+    /// vector storage is disabled on the HNSW index).
+    pub fn rebuild_index(&self) -> crate::error::Result<usize> {
+        self.inner.vacuum_hnsw_index()
+    }
+
     /// Applies post-creation overrides to the advanced configuration
     /// fields (`pq_rescore_oversampling`, `deferred_indexing`,
     /// `async_index_builder`) and persists the updated `config.json`.

--- a/crates/velesdb-core/src/collection/vector_collection/accessors.rs
+++ b/crates/velesdb-core/src/collection/vector_collection/accessors.rs
@@ -77,6 +77,38 @@ impl VectorCollection {
         self.inner.config()
     }
 
+    /// Applies post-creation overrides to the advanced configuration
+    /// fields (`pq_rescore_oversampling`, `deferred_indexing`,
+    /// `async_index_builder`) and persists the updated `config.json`.
+    ///
+    /// Each parameter is wrapped in an outer `Option` that expresses
+    /// "leave unchanged" (`None`) versus "set to this value" (`Some(_)`).
+    /// Passing `Some(None)` explicitly clears the inner field. A local
+    /// clippy allow is applied because the three-state semantics are
+    /// the intended contract here.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the updated config cannot be written to disk.
+    #[allow(clippy::option_option)]
+    pub fn apply_advanced_config(
+        &self,
+        pq_rescore_oversampling: Option<Option<u32>>,
+        #[cfg(feature = "persistence")] deferred_indexing: Option<
+            Option<crate::collection::streaming::DeferredIndexerConfig>,
+        >,
+        async_index_builder: Option<
+            Option<crate::collection::streaming::AsyncIndexBuilderConfig>,
+        >,
+    ) -> crate::error::Result<()> {
+        self.inner.apply_advanced_config(
+            pq_rescore_oversampling,
+            #[cfg(feature = "persistence")]
+            deferred_indexing,
+            async_index_builder,
+        )
+    }
+
     /// Returns CBO statistics.
     #[must_use]
     pub fn get_stats(&self) -> crate::collection::stats::CollectionStats {

--- a/crates/velesdb-core/src/collection/vector_collection/accessors.rs
+++ b/crates/velesdb-core/src/collection/vector_collection/accessors.rs
@@ -112,9 +112,7 @@ impl VectorCollection {
         #[cfg(feature = "persistence")] deferred_indexing: Option<
             Option<crate::collection::streaming::DeferredIndexerConfig>,
         >,
-        async_index_builder: Option<
-            Option<crate::collection::streaming::AsyncIndexBuilderConfig>,
-        >,
+        async_index_builder: Option<Option<crate::collection::streaming::AsyncIndexBuilderConfig>>,
     ) -> crate::error::Result<()> {
         self.inner.apply_advanced_config(
             pq_rescore_oversampling,

--- a/crates/velesdb-migrate/src/config.rs
+++ b/crates/velesdb-migrate/src/config.rs
@@ -285,6 +285,14 @@ pub struct MigrationOptions {
     /// Continue on errors.
     #[serde(default)]
     pub continue_on_error: bool,
+    /// Allow the pipeline to proceed even when the source reports a
+    /// distance metric that differs from the destination
+    /// configuration (finding M-P0-3). Defaults to `false`: a
+    /// mismatch aborts the migration with an error that names both
+    /// metrics. Set to `true` for controlled migrations where the
+    /// operator knows the semantic difference is acceptable.
+    #[serde(default)]
+    pub allow_metric_mismatch: bool,
 }
 
 impl Default for MigrationOptions {
@@ -297,6 +305,7 @@ impl Default for MigrationOptions {
             dry_run: false,
             field_mappings: HashMap::new(),
             continue_on_error: false,
+            allow_metric_mismatch: false,
         }
     }
 }

--- a/crates/velesdb-migrate/src/connectors/csv_file.rs
+++ b/crates/velesdb-migrate/src/connectors/csv_file.rs
@@ -239,6 +239,8 @@ impl SourceConnector for CsvFileConnector {
                 fields,
                 vector_column: Some(self.config.vector_column.clone()),
                 id_column: Some(self.config.id_column.clone()),
+                // File-backed connectors cannot introspect the metric.
+                metric: None,
             });
         }
         Ok(())

--- a/crates/velesdb-migrate/src/connectors/elasticsearch.rs
+++ b/crates/velesdb-migrate/src/connectors/elasticsearch.rs
@@ -260,6 +260,8 @@ impl SourceConnector for ElasticsearchConnector {
             fields,
             vector_column: Some(self.config.vector_field.clone()),
             id_column: Some(self.config.id_field.clone()),
+            // TODO(S2): parse similarity from _mapping response.
+            metric: None,
         });
 
         Ok(())

--- a/crates/velesdb-migrate/src/connectors/elasticsearch.rs
+++ b/crates/velesdb-migrate/src/connectors/elasticsearch.rs
@@ -260,7 +260,7 @@ impl SourceConnector for ElasticsearchConnector {
             fields,
             vector_column: Some(self.config.vector_field.clone()),
             id_column: Some(self.config.id_field.clone()),
-            // TODO(S2): parse similarity from _mapping response.
+            // TODO(MIGRATE-METRIC-ES): parse similarity from _mapping response.
             metric: None,
         });
 

--- a/crates/velesdb-migrate/src/connectors/json_file.rs
+++ b/crates/velesdb-migrate/src/connectors/json_file.rs
@@ -168,6 +168,8 @@ impl SourceConnector for JsonFileConnector {
                 fields,
                 vector_column: Some(self.config.vector_field.clone()),
                 id_column: Some(self.config.id_field.clone()),
+                // File-backed connectors cannot introspect the metric.
+                metric: None,
             });
         }
         Ok(())

--- a/crates/velesdb-migrate/src/connectors/mod.rs
+++ b/crates/velesdb-migrate/src/connectors/mod.rs
@@ -66,6 +66,19 @@ pub struct SourceSchema {
     /// Detected ID column name (for SQL-based sources).
     #[serde(default)]
     pub id_column: Option<String>,
+    /// Distance metric reported by the source, when the connector
+    /// can introspect it (Qdrant, Pinecone, Weaviate, Milvus,
+    /// ChromaDB, Supabase, Elasticsearch, Redis). File-backed
+    /// connectors (JSON, CSV) leave this field empty because the
+    /// source format does not carry a metric annotation.
+    ///
+    /// Values are normalised to the lowercase core identifiers
+    /// (`"cosine"`, `"euclidean"`, `"dot"`, `"hamming"`,
+    /// `"jaccard"`). Unrecognised source values are preserved
+    /// verbatim so `Pipeline::check_metric_fidelity` can report
+    /// them honestly in the mismatch error.
+    #[serde(default)]
+    pub metric: Option<String>,
 }
 
 /// Information about a payload field.

--- a/crates/velesdb-migrate/src/connectors/pinecone.rs
+++ b/crates/velesdb-migrate/src/connectors/pinecone.rs
@@ -15,6 +15,13 @@ pub struct PineconeConnector {
     config: PineconeConfig,
     client: reqwest::Client,
     host: Option<String>,
+    /// Distance metric reported by the Pinecone `describe_index` call,
+    /// normalised to VelesDB core identifiers (`cosine`, `euclidean`,
+    /// `dot`). Captured in [`SourceConnector::connect`] and forwarded
+    /// to [`SourceSchema::metric`] in [`SourceConnector::get_schema`]
+    /// so `Pipeline::check_metric_fidelity` can detect mismatches
+    /// against the destination collection.
+    metric: Option<String>,
 }
 
 impl PineconeConnector {
@@ -25,6 +32,21 @@ impl PineconeConnector {
             config,
             client: create_http_client(),
             host: None,
+            metric: None,
+        }
+    }
+
+    /// Normalise a Pinecone metric string to the VelesDB core
+    /// identifier vocabulary. Pinecone exposes `cosine`, `euclidean`,
+    /// and `dotproduct`; VelesDB uses `dot` for the inner-product
+    /// metric. Unknown values are returned lowercased so
+    /// `check_metric_fidelity` can surface them verbatim in the
+    /// mismatch error instead of swallowing them.
+    fn normalise_pinecone_metric(raw: &str) -> String {
+        let lower = raw.to_ascii_lowercase();
+        match lower.as_str() {
+            "dotproduct" => "dot".to_string(),
+            _ => lower,
         }
     }
 
@@ -200,6 +222,7 @@ impl SourceConnector for PineconeConnector {
         }
 
         self.host = Some(desc.host);
+        self.metric = Some(Self::normalise_pinecone_metric(&desc.metric));
         info!(
             "Connected to Pinecone index: {} ({}D, {})",
             self.config.index, desc.dimension, desc.metric
@@ -240,6 +263,7 @@ impl SourceConnector for PineconeConnector {
             dimension: stats.dimension,
             total_count: count,
             fields: vec![],
+            metric: self.metric.clone(),
             ..Default::default()
         })
     }
@@ -316,6 +340,51 @@ mod tests {
         let connector = PineconeConnector::new(config);
         assert_eq!(connector.source_type(), "pinecone");
         assert!(connector.host.is_none());
+        assert!(connector.metric.is_none());
+    }
+
+    #[test]
+    fn test_normalise_pinecone_metric_maps_dotproduct_to_dot() {
+        // Pinecone reports `dotproduct` for inner-product indexes but
+        // VelesDB core identifies the same metric as `dot`. The
+        // normalisation layer is what makes
+        // `Pipeline::check_metric_fidelity` able to match Pinecone
+        // sources against a destination collection created with
+        // `metric: "dot"`.
+        assert_eq!(
+            PineconeConnector::normalise_pinecone_metric("dotproduct"),
+            "dot"
+        );
+        assert_eq!(
+            PineconeConnector::normalise_pinecone_metric("DotProduct"),
+            "dot"
+        );
+    }
+
+    #[test]
+    fn test_normalise_pinecone_metric_lowercases_known_values() {
+        // Already-compatible values are lowercased so
+        // `check_metric_fidelity` compares them against the core
+        // identifier vocabulary verbatim without surprise.
+        assert_eq!(
+            PineconeConnector::normalise_pinecone_metric("Cosine"),
+            "cosine"
+        );
+        assert_eq!(
+            PineconeConnector::normalise_pinecone_metric("EUCLIDEAN"),
+            "euclidean"
+        );
+    }
+
+    #[test]
+    fn test_normalise_pinecone_metric_preserves_unknown_values() {
+        // Unknown metric names are preserved (lowercased) rather than
+        // silently normalised to `None` — this keeps mismatch errors
+        // actionable instead of masking them behind a no-op schema.
+        assert_eq!(
+            PineconeConnector::normalise_pinecone_metric("manhattan"),
+            "manhattan"
+        );
     }
 
     #[test]

--- a/crates/velesdb-migrate/src/connectors/redis.rs
+++ b/crates/velesdb-migrate/src/connectors/redis.rs
@@ -194,7 +194,7 @@ impl SourceConnector for RedisConnector {
             fields,
             vector_column: Some(self.config.vector_field.clone()),
             id_column: None,
-            // TODO(S2): parse DISTANCE_METRIC from FT.INFO response.
+            // TODO(MIGRATE-METRIC-REDIS): parse DISTANCE_METRIC from FT.INFO response.
             metric: None,
         });
         self.connection = Some(Arc::new(Mutex::new(con)));

--- a/crates/velesdb-migrate/src/connectors/redis.rs
+++ b/crates/velesdb-migrate/src/connectors/redis.rs
@@ -194,6 +194,8 @@ impl SourceConnector for RedisConnector {
             fields,
             vector_column: Some(self.config.vector_field.clone()),
             id_column: None,
+            // TODO(S2): parse DISTANCE_METRIC from FT.INFO response.
+            metric: None,
         });
         self.connection = Some(Arc::new(Mutex::new(con)));
 

--- a/crates/velesdb-migrate/src/connectors/supabase.rs
+++ b/crates/velesdb-migrate/src/connectors/supabase.rs
@@ -119,8 +119,8 @@ impl SourceConnector for SupabaseConnector {
             fields,
             vector_column: detected_vector_col,
             id_column: Some(self.config.id_column.clone()),
-            // TODO(S2): introspect operator class of the pgvector
-            // index (vector_cosine_ops, vector_l2_ops, etc.).
+            // TODO(MIGRATE-METRIC-SUPABASE): introspect operator class of the
+            // pgvector index (vector_cosine_ops, vector_l2_ops, etc.).
             metric: None,
         })
     }

--- a/crates/velesdb-migrate/src/connectors/supabase.rs
+++ b/crates/velesdb-migrate/src/connectors/supabase.rs
@@ -119,6 +119,9 @@ impl SourceConnector for SupabaseConnector {
             fields,
             vector_column: detected_vector_col,
             id_column: Some(self.config.id_column.clone()),
+            // TODO(S2): introspect operator class of the pgvector
+            // index (vector_cosine_ops, vector_l2_ops, etc.).
+            metric: None,
         })
     }
 

--- a/crates/velesdb-migrate/src/pipeline.rs
+++ b/crates/velesdb-migrate/src/pipeline.rs
@@ -209,6 +209,12 @@ impl Pipeline {
             )));
         }
 
+        check_metric_fidelity(
+            schema.metric.as_deref(),
+            self.config.destination.metric,
+            self.config.options.allow_metric_mismatch,
+        )?;
+
         if let Some(ctx) = &checkpoint_ctx {
             if let Some(state) = ctx.load().await? {
                 offset = state.next_offset;
@@ -483,6 +489,102 @@ pub(crate) fn fnv1a64(bytes: &[u8]) -> u64 {
     hash
 }
 
+/// Normalises a source-reported metric label into its canonical lowercase
+/// identifier (matches `velesdb_core::DistanceMetric::from_str` aliases).
+///
+/// Returns `None` when the label is empty or unknown — unknown values are
+/// intentionally preserved verbatim to [`check_metric_fidelity`] so the
+/// mismatch error carries the original string for diagnostics.
+fn canonicalise_source_metric(raw: &str) -> Option<&'static str> {
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "cosine" | "cos" | "cosinesimilarity" => Some("cosine"),
+        "euclidean" | "euclid" | "l2" | "l2_distance" => Some("euclidean"),
+        "dot" | "dotproduct" | "ip" | "inner_product" => Some("dot"),
+        "hamming" => Some("hamming"),
+        "jaccard" => Some("jaccard"),
+        _ => None,
+    }
+}
+
+/// Returns the canonical lowercase string for a destination
+/// `DistanceMetric` selected in `MigrationConfig`.
+fn canonicalise_dest_metric(metric: crate::config::DistanceMetric) -> &'static str {
+    match metric {
+        crate::config::DistanceMetric::Cosine => "cosine",
+        crate::config::DistanceMetric::Euclidean => "euclidean",
+        crate::config::DistanceMetric::Dot => "dot",
+        crate::config::DistanceMetric::Hamming => "hamming",
+        crate::config::DistanceMetric::Jaccard => "jaccard",
+    }
+}
+
+/// Verifies that the metric reported by the source (when present)
+/// matches the one configured on the destination. A mismatch returns
+/// [`Error::SchemaMismatch`] with both metrics named, unless the
+/// caller opted into `allow_metric_mismatch` in `MigrationOptions`.
+///
+/// Finding M-P0-3 of the pre-seed audit.
+fn check_metric_fidelity(
+    source_metric: Option<&str>,
+    dest_metric: crate::config::DistanceMetric,
+    allow_mismatch: bool,
+) -> Result<()> {
+    let Some(raw) = source_metric else {
+        // The connector did not introspect a metric. This is
+        // expected for file-backed connectors (JSON, CSV) and for
+        // connectors that have not yet been extended to populate the
+        // field. Nothing to verify.
+        return Ok(());
+    };
+
+    let canonical_dest = canonicalise_dest_metric(dest_metric);
+
+    match canonicalise_source_metric(raw) {
+        Some(canonical_source) if canonical_source == canonical_dest => Ok(()),
+        Some(canonical_source) => {
+            if allow_mismatch {
+                warn!(
+                    source = canonical_source,
+                    destination = canonical_dest,
+                    "metric mismatch allowed by allow_metric_mismatch escape hatch"
+                );
+                Ok(())
+            } else {
+                Err(Error::SchemaMismatch(format!(
+                    "Source metric '{canonical_source}' does not match \
+                     destination metric '{canonical_dest}'. Migration \
+                     aborted to preserve search quality. Set \
+                     `options.allow_metric_mismatch = true` in the \
+                     migration config if the semantic difference is \
+                     acceptable."
+                )))
+            }
+        }
+        None => {
+            // Source reported a label we do not recognise. Preserve
+            // the raw string in the error message so operators can
+            // diagnose the connector output without additional logs.
+            if allow_mismatch {
+                warn!(
+                    source = %raw,
+                    destination = canonical_dest,
+                    "unknown source metric; proceeding because \
+                     allow_metric_mismatch is set"
+                );
+                Ok(())
+            } else {
+                Err(Error::SchemaMismatch(format!(
+                    "Source reported unknown metric '{raw}' which \
+                     cannot be mapped to a core DistanceMetric. \
+                     Expected '{canonical_dest}'. Set \
+                     `options.allow_metric_mismatch = true` to bypass \
+                     this check."
+                )))
+            }
+        }
+    }
+}
+
 fn create_progress_bar(total: u64) -> ProgressBar {
     let pb = if total > 0 {
         ProgressBar::new(total)
@@ -505,6 +607,91 @@ fn create_progress_bar(total: u64) -> ProgressBar {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::DistanceMetric;
+
+    // ─────────────────────────────────────────────────────────────
+    // M-P0-3: metric fidelity check
+    // ─────────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_check_metric_fidelity_passes_when_source_is_none() {
+        // File-backed connectors (JSON/CSV) and legacy connectors
+        // that have not been extended yet report `None`. The check
+        // must never fail in that case.
+        assert!(check_metric_fidelity(None, DistanceMetric::Cosine, false).is_ok());
+    }
+
+    #[test]
+    fn test_check_metric_fidelity_passes_on_exact_match() {
+        assert!(check_metric_fidelity(Some("cosine"), DistanceMetric::Cosine, false).is_ok());
+        assert!(check_metric_fidelity(Some("euclidean"), DistanceMetric::Euclidean, false).is_ok());
+        assert!(check_metric_fidelity(Some("dot"), DistanceMetric::Dot, false).is_ok());
+    }
+
+    #[test]
+    fn test_check_metric_fidelity_passes_on_alias_match() {
+        // Source reports "l2" which canonicalises to "euclidean".
+        assert!(check_metric_fidelity(Some("l2"), DistanceMetric::Euclidean, false).is_ok());
+        // Source reports "ip" (inner product) which canonicalises to "dot".
+        assert!(check_metric_fidelity(Some("ip"), DistanceMetric::Dot, false).is_ok());
+        // Case-insensitive.
+        assert!(check_metric_fidelity(Some("COSINE"), DistanceMetric::Cosine, false).is_ok());
+    }
+
+    #[test]
+    fn test_check_metric_fidelity_rejects_known_mismatch() {
+        let result = check_metric_fidelity(Some("cosine"), DistanceMetric::Euclidean, false);
+        assert!(result.is_err(), "cosine vs euclidean must fail");
+
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("cosine") && err.contains("euclidean"),
+            "error must name both metrics, got: {err}"
+        );
+        assert!(
+            err.contains("allow_metric_mismatch"),
+            "error must point at the escape hatch, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_check_metric_fidelity_rejects_unknown_label() {
+        let result =
+            check_metric_fidelity(Some("some_weird_metric"), DistanceMetric::Cosine, false);
+        assert!(result.is_err(), "unknown metric must fail by default");
+
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("some_weird_metric"),
+            "error must preserve the raw source label for diagnostics, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_check_metric_fidelity_allows_mismatch_when_opted_in() {
+        // Explicit opt-in via allow_metric_mismatch bypasses the
+        // hard error for both recognised-but-mismatching and
+        // unrecognised source labels.
+        assert!(
+            check_metric_fidelity(Some("cosine"), DistanceMetric::Euclidean, true).is_ok(),
+            "allow_metric_mismatch must permit known mismatches"
+        );
+        assert!(
+            check_metric_fidelity(Some("weird"), DistanceMetric::Cosine, true).is_ok(),
+            "allow_metric_mismatch must permit unknown source labels"
+        );
+    }
+
+    #[test]
+    fn test_check_metric_fidelity_hamming_and_jaccard() {
+        assert!(check_metric_fidelity(Some("hamming"), DistanceMetric::Hamming, false).is_ok());
+        assert!(check_metric_fidelity(Some("jaccard"), DistanceMetric::Jaccard, false).is_ok());
+        // Cross-metric mismatch.
+        assert!(
+            check_metric_fidelity(Some("hamming"), DistanceMetric::Jaccard, false).is_err(),
+            "hamming vs jaccard must fail"
+        );
+    }
 
     #[test]
     fn test_migration_stats_throughput() {

--- a/crates/velesdb-migrate/src/templates.rs
+++ b/crates/velesdb-migrate/src/templates.rs
@@ -252,6 +252,7 @@ mod tests {
             fields,
             vector_column: None,
             id_column: None,
+            metric: None,
         }
     }
 
@@ -310,6 +311,7 @@ mod tests {
             ],
             vector_column: Some("embedding".to_string()),
             id_column: Some("doc_id".to_string()),
+            metric: None,
         };
         let params = AutoConfigParams {
             source_type: "supabase",
@@ -360,6 +362,7 @@ mod tests {
             fields: vec![],
             vector_column: None,
             id_column: None,
+            metric: None,
         };
         let params = make_params("milvus", &schema);
         let yaml = generate_auto_config(&params);
@@ -410,6 +413,7 @@ mod tests {
             ],
             vector_column: None,
             id_column: None,
+            metric: None,
         };
         let col = detect_vector_column(&schema);
         assert_eq!(col, "content_embedding");
@@ -436,6 +440,7 @@ mod tests {
             ],
             vector_column: None,
             id_column: None,
+            metric: None,
         };
         let col = detect_id_column(&schema);
         assert_eq!(col, "doc_id");
@@ -472,6 +477,7 @@ mod tests {
             ],
             vector_column: None,
             id_column: None,
+            metric: None,
         };
         let list = build_fields_list(&schema, "id", "embedding");
         assert!(list.contains("- title"));

--- a/crates/velesdb-migrate/src/wizard/migration_builder.rs
+++ b/crates/velesdb-migrate/src/wizard/migration_builder.rs
@@ -44,6 +44,7 @@ pub(crate) fn build_migration_config(
         checkpoint_enabled: true,
         checkpoint_path: None,
         field_mappings: std::collections::HashMap::new(),
+        allow_metric_mismatch: false,
     };
 
     Ok(MigrationConfig {

--- a/crates/velesdb-migrate/src/wizard/mod.rs
+++ b/crates/velesdb-migrate/src/wizard/mod.rs
@@ -451,6 +451,7 @@ mod tests {
             fields: vec![],
             vector_column: None,
             id_column: None,
+            metric: None,
         };
 
         // Act
@@ -491,6 +492,7 @@ mod tests {
             fields: vec![],
             vector_column: None,
             id_column: None,
+            metric: None,
         };
 
         // Act
@@ -526,6 +528,7 @@ mod tests {
             fields: vec![],
             vector_column: None,
             id_column: None,
+            metric: None,
         };
 
         // Act

--- a/crates/velesdb-mobile/src/lib.rs
+++ b/crates/velesdb-mobile/src/lib.rs
@@ -176,7 +176,13 @@ impl VelesDatabase {
     pub fn get_collection(&self, name: String) -> Result<Option<Arc<VelesCollection>>, VelesError> {
         match self.inner.get_any_collection(&name) {
             Some(any_coll) => {
-                let vc = any_coll.into_vector_collection();
+                // F2.2 mitigation: the mobile surface exposes a single
+                // `VelesCollection` type, so we use the unchecked cast
+                // here. Callers that invoke vector-specific methods on
+                // a graph or metadata collection will observe empty
+                // results at runtime. A proper typed split is tracked
+                // as the F2.2 post-seed EPIC.
+                let vc = any_coll.as_vector_collection_unchecked();
                 Ok(Some(Arc::new(VelesCollection { inner: vc })))
             }
             None => Ok(None),

--- a/crates/velesdb-python/src/database.rs
+++ b/crates/velesdb-python/src/database.rs
@@ -170,7 +170,12 @@ impl Database {
     fn get_collection(&self, name: &str) -> PyResult<Option<Collection>> {
         match self.inner.get_any_collection(name) {
             Some(any_coll) => {
-                let vc = any_coll.into_vector_collection();
+                // F2.2 mitigation: Python SDK exposes a single Collection
+                // type. Invoking vector-specific methods on a graph or
+                // metadata collection returns empty results rather than
+                // raising — the typed split is tracked as a post-seed
+                // EPIC in docs/ARCHITECTURE.md.
+                let vc = any_coll.as_vector_collection_unchecked();
                 Ok(Some(Collection::new(vc, name.to_string())))
             }
             None => Ok(None),
@@ -230,7 +235,7 @@ impl Database {
         let collection = self
             .inner
             .get_any_collection(name)
-            .map(|c| c.into_vector_collection())
+            .map(velesdb_core::AnyCollection::as_vector_collection_unchecked)
             .ok_or_else(|| PyRuntimeError::new_err("Collection not found after creation"))?;
 
         Ok(Collection::new(collection, name.to_string()))

--- a/crates/velesdb-server/Cargo.toml
+++ b/crates/velesdb-server/Cargo.toml
@@ -52,7 +52,7 @@ utoipa = { version = "5", features = ["axum_extras"] }
 utoipa-swagger-ui = { version = "9", features = ["axum"], optional = true }
 
 [features]
-default = ["velesdb-core/default", "update-check"]
+default = ["velesdb-core/default", "persistence", "update-check"]
 gpu = ["velesdb-core/gpu"]
 internal-bench = ["velesdb-core/internal-bench"]
 loom = ["velesdb-core/loom"]

--- a/crates/velesdb-server/src/auth.rs
+++ b/crates/velesdb-server/src/auth.rs
@@ -75,11 +75,24 @@ impl AuthState {
 }
 
 /// Paths that bypass authentication (both legacy and `/v1/` versioned).
+///
+/// `/health` and `/ready` are the only genuinely public endpoints — they
+/// expose no internal state beyond liveness booleans and are needed by
+/// container orchestrators that cannot carry authentication headers.
+///
+/// `/metrics` is **not** in this list. The Prometheus metrics endpoint
+/// returns detailed operational data (collection counts, cache hit
+/// rates, query latencies, per-collection sizes, WAL depths) that
+/// constitutes an information leak when the surrounding REST API is
+/// protected by API keys. The fix for F-02 moves `/metrics` behind the
+/// same API key gate as the rest of the REST surface: scrapers must
+/// present `Authorization: Bearer <key>` like any other client.
+///
+/// Operators who need a dedicated scraping credential can provision a
+/// distinct API key for the Prometheus scraper and rotate it
+/// independently.
 fn is_public_path(path: &str) -> bool {
-    matches!(
-        path,
-        "/health" | "/ready" | "/metrics" | "/v1/health" | "/v1/ready" | "/v1/metrics"
-    )
+    matches!(path, "/health" | "/ready" | "/v1/health" | "/v1/ready")
 }
 
 /// Extract the Bearer token from the Authorization header value.
@@ -176,8 +189,11 @@ mod tests {
     }
 
     #[test]
-    fn test_is_public_path_metrics() {
-        assert!(is_public_path("/metrics"));
+    fn test_is_public_path_metrics_is_protected() {
+        // F-02: /metrics must not bypass authentication — it leaks
+        // operational details about the running database.
+        assert!(!is_public_path("/metrics"));
+        assert!(!is_public_path("/v1/metrics"));
     }
 
     #[test]
@@ -188,11 +204,6 @@ mod tests {
     #[test]
     fn test_is_public_path_versioned_ready() {
         assert!(is_public_path("/v1/ready"));
-    }
-
-    #[test]
-    fn test_is_public_path_versioned_metrics() {
-        assert!(is_public_path("/v1/metrics"));
     }
 
     #[test]

--- a/crates/velesdb-server/src/handlers/admin.rs
+++ b/crates/velesdb-server/src/handlers/admin.rs
@@ -43,6 +43,25 @@ pub async fn get_collection_config(
         .graph_schema
         .as_ref()
         .and_then(|gs| serde_json::to_value(gs).ok());
+    let hnsw_params = config
+        .hnsw_params
+        .as_ref()
+        .and_then(|p| serde_json::to_value(p).ok());
+
+    // `deferred_indexing` is only populated under the `persistence`
+    // feature because the core config field is gated the same way.
+    #[cfg(feature = "persistence")]
+    let deferred_indexing = config
+        .deferred_indexing
+        .as_ref()
+        .and_then(|d| serde_json::to_value(d).ok());
+    #[cfg(not(feature = "persistence"))]
+    let deferred_indexing = None;
+
+    let async_index_builder = config
+        .async_index_builder
+        .as_ref()
+        .and_then(|a| serde_json::to_value(a).ok());
 
     Json(CollectionConfigResponse {
         name: config.name,
@@ -53,6 +72,11 @@ pub async fn get_collection_config(
         metadata_only: config.metadata_only,
         graph_schema,
         embedding_dimension: config.embedding_dimension,
+        schema_version: config.schema_version,
+        pq_rescore_oversampling: config.pq_rescore_oversampling,
+        hnsw_params,
+        deferred_indexing,
+        async_index_builder,
     })
     .into_response()
 }

--- a/crates/velesdb-server/src/handlers/admin.rs
+++ b/crates/velesdb-server/src/handlers/admin.rs
@@ -14,7 +14,9 @@ use crate::types::{
 };
 use crate::AppState;
 
-use super::helpers::{core_error_response, error_response, get_collection_or_404};
+use super::helpers::{
+    core_error_response, error_response, get_collection_or_404, get_vector_collection_or_404,
+};
 
 /// Get detailed collection configuration (HNSW params, storage mode, schema, etc.).
 #[utoipa::path(
@@ -79,6 +81,49 @@ pub async fn get_collection_config(
         async_index_builder,
     })
     .into_response()
+}
+
+/// Rebuilds the HNSW index of a vector collection, reclaiming memory
+/// occupied by tombstoned entries and producing a fresh graph from
+/// the current vector storage.
+///
+/// This is a blocking operation: for large collections it may take
+/// several seconds. The response includes the number of entries that
+/// were compacted during the rebuild.
+#[utoipa::path(
+    post,
+    path = "/collections/{name}/index/rebuild",
+    tag = "collections",
+    params(
+        ("name" = String, Path, description = "Collection name")
+    ),
+    responses(
+        (status = 200, description = "Index rebuilt", body = Object),
+        (status = 404, description = "Collection not found", body = ErrorResponse),
+        (status = 500, description = "Rebuild failed", body = ErrorResponse)
+    )
+)]
+pub async fn rebuild_index(
+    State(state): State<Arc<AppState>>,
+    Path(name): Path<String>,
+) -> impl IntoResponse {
+    let collection = match get_vector_collection_or_404(&state, &name) {
+        Ok(c) => c,
+        Err(resp) => return resp,
+    };
+
+    match collection.rebuild_index() {
+        Ok(compacted) => (
+            StatusCode::OK,
+            Json(serde_json::json!({
+                "message": "Index rebuilt",
+                "collection": name,
+                "compacted_entries": compacted
+            })),
+        )
+            .into_response(),
+        Err(e) => core_error_response(StatusCode::INTERNAL_SERVER_ERROR, &e),
+    }
 }
 
 /// Analyze a collection, computing and persisting statistics.

--- a/crates/velesdb-server/src/handlers/collections.rs
+++ b/crates/velesdb-server/src/handlers/collections.rs
@@ -83,6 +83,14 @@ fn parse_storage_mode(raw: &str) -> Result<StorageMode, axum::response::Response
 }
 
 /// Create a vector collection, requiring a dimension in the request.
+///
+/// Applies advanced configuration overrides (pq_rescore_oversampling,
+/// deferred_indexing, async_index_builder) in a second pass via
+/// `VectorCollection::apply_advanced_config` once the base collection
+/// has been registered. This two-step approach keeps the core
+/// `Database::create_vector_collection_*` API stable while still
+/// honouring the full PROP-CONFIG-ADVANCED field set on the REST
+/// surface.
 #[allow(clippy::result_large_err)]
 fn create_vector_collection(
     state: &AppState,
@@ -96,22 +104,139 @@ fn create_vector_collection(
             "dimension is required for vector collections".to_string(),
         )
     })?;
-    if req.hnsw_m.is_some() || req.hnsw_ef_construction.is_some() {
-        Ok(state.db.create_vector_collection_with_hnsw(
+
+    // Parse the advanced override fields up-front so a malformed JSON
+    // payload fails the request before any collection is created on
+    // disk. This avoids the half-initialised state where the base
+    // collection exists but the advanced fields are missing.
+    let advanced = parse_advanced_config(req)?;
+
+    // Phase 1: create the base collection with HNSW params.
+    let base_result = if req.hnsw_m.is_some() || req.hnsw_ef_construction.is_some() {
+        state.db.create_vector_collection_with_hnsw(
             &req.name,
             dimension,
             metric,
             storage_mode,
             req.hnsw_m,
             req.hnsw_ef_construction,
-        ))
+        )
     } else {
-        Ok(state.db.create_vector_collection_with_options(
+        state.db.create_vector_collection_with_options(
             &req.name,
             dimension,
             metric,
             storage_mode,
-        ))
+        )
+    };
+    if let Err(e) = base_result {
+        return Ok(Err(e));
+    }
+
+    // Phase 2: persist advanced overrides if any were requested.
+    if advanced.has_any() {
+        let Some(coll) = state.db.get_vector_collection(&req.name) else {
+            return Ok(Err(velesdb_core::error::Error::CollectionNotFound(
+                req.name.clone(),
+            )));
+        };
+        if let Err(e) = coll.apply_advanced_config(
+            advanced.pq_rescore_oversampling,
+            #[cfg(feature = "persistence")]
+            advanced.deferred_indexing,
+            advanced.async_index_builder,
+        ) {
+            return Ok(Err(e));
+        }
+    }
+
+    Ok(Ok(()))
+}
+
+/// Parsed advanced override fields for the create-collection pipeline.
+///
+/// The outer `Option` signals whether the field was present in the
+/// request body; the inner `Option` carries the value the caller
+/// wanted to persist (including explicit `null` → `Some(None)`).
+/// A local clippy allow is applied because the three-state semantics
+/// are the intended contract here.
+#[allow(clippy::option_option)]
+#[derive(Default)]
+struct AdvancedCreateOverrides {
+    pq_rescore_oversampling: Option<Option<u32>>,
+    #[cfg(feature = "persistence")]
+    deferred_indexing: Option<Option<velesdb_core::collection::streaming::DeferredIndexerConfig>>,
+    async_index_builder: Option<Option<velesdb_core::collection::streaming::AsyncIndexBuilderConfig>>,
+}
+
+impl AdvancedCreateOverrides {
+    #[cfg(feature = "persistence")]
+    fn has_any(&self) -> bool {
+        self.pq_rescore_oversampling.is_some()
+            || self.deferred_indexing.is_some()
+            || self.async_index_builder.is_some()
+    }
+
+    #[cfg(not(feature = "persistence"))]
+    fn has_any(&self) -> bool {
+        self.pq_rescore_oversampling.is_some() || self.async_index_builder.is_some()
+    }
+}
+
+/// Parses the advanced override JSON fields on `CreateCollectionRequest`
+/// into typed `CollectionConfig` fragments. A malformed JSON payload
+/// becomes a 400 response.
+#[allow(clippy::result_large_err)]
+fn parse_advanced_config(
+    req: &CreateCollectionRequest,
+) -> Result<AdvancedCreateOverrides, axum::response::Response> {
+    let mut overrides = AdvancedCreateOverrides {
+        pq_rescore_oversampling: req.pq_rescore_oversampling.map(Some),
+        ..Default::default()
+    };
+
+    #[cfg(feature = "persistence")]
+    if let Some(ref value) = req.deferred_indexing {
+        let parsed: velesdb_core::collection::streaming::DeferredIndexerConfig =
+            serde_json::from_value(value.clone()).map_err(|e| {
+                error_response(
+                    StatusCode::BAD_REQUEST,
+                    format!("Invalid 'deferred_indexing' configuration: {e}"),
+                )
+            })?;
+        overrides.deferred_indexing = Some(Some(parsed));
+    }
+
+    if let Some(ref value) = req.async_index_builder {
+        let parsed: velesdb_core::collection::streaming::AsyncIndexBuilderConfig =
+            serde_json::from_value(value.clone()).map_err(|e| {
+                error_response(
+                    StatusCode::BAD_REQUEST,
+                    format!("Invalid 'async_index_builder' configuration: {e}"),
+                )
+            })?;
+        overrides.async_index_builder = Some(Some(parsed));
+    }
+
+    Ok(overrides)
+}
+
+/// Parses the optional `graph_schema` JSON field on
+/// `CreateCollectionRequest` into a typed `GraphSchema`. When the field
+/// is absent the schemaless default is returned, preserving backward
+/// compatibility with callers that relied on the previous behaviour.
+#[allow(clippy::result_large_err)]
+fn parse_graph_schema(
+    req: &CreateCollectionRequest,
+) -> Result<velesdb_core::GraphSchema, axum::response::Response> {
+    match req.graph_schema.as_ref() {
+        Some(value) => serde_json::from_value(value.clone()).map_err(|e| {
+            error_response(
+                StatusCode::BAD_REQUEST,
+                format!("Invalid 'graph_schema' payload: {e}"),
+            )
+        }),
+        None => Ok(velesdb_core::GraphSchema::schemaless()),
     }
 }
 
@@ -128,10 +253,8 @@ fn dispatch_create(
             Ok(state.db.create_metadata_collection(&req.name))
         }
         "graph" | "knowledge_graph" | "kg" => {
-            use velesdb_core::GraphSchema;
-            Ok(state
-                .db
-                .create_graph_collection(&req.name, GraphSchema::schemaless()))
+            let schema = parse_graph_schema(req)?;
+            Ok(state.db.create_graph_collection(&req.name, schema))
         }
         "vector" | "" => create_vector_collection(state, req, metric, storage_mode),
         _ => Err(error_response(

--- a/crates/velesdb-server/src/handlers/collections.rs
+++ b/crates/velesdb-server/src/handlers/collections.rs
@@ -122,12 +122,9 @@ fn create_vector_collection(
             req.hnsw_ef_construction,
         )
     } else {
-        state.db.create_vector_collection_with_options(
-            &req.name,
-            dimension,
-            metric,
-            storage_mode,
-        )
+        state
+            .db
+            .create_vector_collection_with_options(&req.name, dimension, metric, storage_mode)
     };
     if let Err(e) = base_result {
         return Ok(Err(e));
@@ -166,7 +163,8 @@ struct AdvancedCreateOverrides {
     pq_rescore_oversampling: Option<Option<u32>>,
     #[cfg(feature = "persistence")]
     deferred_indexing: Option<Option<velesdb_core::collection::streaming::DeferredIndexerConfig>>,
-    async_index_builder: Option<Option<velesdb_core::collection::streaming::AsyncIndexBuilderConfig>>,
+    async_index_builder:
+        Option<Option<velesdb_core::collection::streaming::AsyncIndexBuilderConfig>>,
 }
 
 impl AdvancedCreateOverrides {

--- a/crates/velesdb-server/src/handlers/collections.rs
+++ b/crates/velesdb-server/src/handlers/collections.rs
@@ -131,19 +131,37 @@ fn create_vector_collection(
     }
 
     // Phase 2: persist advanced overrides if any were requested.
+    //
+    // If this phase fails, we MUST roll back the Phase 1 collection
+    // creation so callers do not end up with a half-initialised
+    // collection on disk that would subsequently fail every retry
+    // with `CollectionExists`. Any delete error during rollback is
+    // logged but we still surface the original Phase 2 error to the
+    // caller because it is more actionable.
     if advanced.has_any() {
         let Some(coll) = state.db.get_vector_collection(&req.name) else {
             return Ok(Err(velesdb_core::error::Error::CollectionNotFound(
                 req.name.clone(),
             )));
         };
-        if let Err(e) = coll.apply_advanced_config(
+        if let Err(phase_two_err) = coll.apply_advanced_config(
             advanced.pq_rescore_oversampling,
             #[cfg(feature = "persistence")]
             advanced.deferred_indexing,
             advanced.async_index_builder,
         ) {
-            return Ok(Err(e));
+            // Drop the coll handle before the rollback to release any
+            // read lock the registry hands back by default.
+            drop(coll);
+            if let Err(rollback_err) = state.db.delete_collection(&req.name) {
+                tracing::warn!(
+                    collection = %req.name,
+                    rollback_error = %rollback_err,
+                    phase_two_error = %phase_two_err,
+                    "failed to roll back collection after apply_advanced_config error"
+                );
+            }
+            return Ok(Err(phase_two_err));
         }
     }
 

--- a/crates/velesdb-server/src/handlers/graph/handlers.rs
+++ b/crates/velesdb-server/src/handlers/graph/handlers.rs
@@ -24,11 +24,20 @@ use super::types::{
 
 /// Resolves a `GraphCollection` by name.
 ///
-/// Returns 404 if no collection with that name exists at all.
-/// Returns 409 if a collection exists but is not a graph collection (type mismatch).
-/// Auto-creates a schemaless graph collection on first use if no collection exists yet,
-/// preserving backward compatibility with workflows that drive graph ops without
-/// an explicit `create_graph_collection` call.
+/// # Returns
+///
+/// * `Ok(collection)` if a graph collection with this name exists.
+/// * `Err(404 Not Found)` if no collection with this name exists.
+/// * `Err(409 Conflict)` if a collection exists with this name but is not
+///   a graph collection (type mismatch with vector or metadata collection).
+///
+/// # Contract
+///
+/// This function previously auto-created a schemaless graph collection
+/// on first use. That behaviour is retired (F-05): a missing graph
+/// collection now yields a 404 response instead of being created
+/// silently. Callers must issue `POST /collections` with
+/// `collection_type = "graph"` before targeting graph endpoints.
 pub(super) fn get_graph_collection_or_404(
     state: &AppState,
     name: &str,
@@ -45,38 +54,24 @@ pub(super) fn get_graph_collection_or_404(
             StatusCode::CONFLICT,
             Json(ErrorResponse {
                 error: format!(
-                    "Collection '{}' exists but is not a graph collection. \
-                     Use /collections/{}/graph only on graph-typed collections.",
-                    name, name
+                    "Collection '{name}' exists but is not a graph collection. \
+                     Use /collections/{name}/graph only on graph-typed collections.",
                 ),
                 code: None,
             }),
         ));
     }
 
-    use velesdb_core::GraphSchema;
-    state
-        .db
-        .create_graph_collection(name, GraphSchema::schemaless())
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse {
-                    error: format!("Failed to auto-create graph collection '{}': {e}", name),
-                    code: None,
-                }),
-            )
-        })?;
-
-    state.db.get_graph_collection(name).ok_or_else(|| {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(ErrorResponse {
-                error: format!("Graph collection '{}' not found after creation.", name),
-                code: None,
-            }),
-        )
-    })
+    Err((
+        StatusCode::NOT_FOUND,
+        Json(ErrorResponse {
+            error: format!(
+                "Graph collection '{name}' not found. Create it first with \
+                 POST /collections and collection_type = \"graph\".",
+            ),
+            code: None,
+        }),
+    ))
 }
 
 /// Get edges from a collection's graph filtered by label.

--- a/crates/velesdb-server/src/handlers/graph/stream.rs
+++ b/crates/velesdb-server/src/handlers/graph/stream.rs
@@ -79,8 +79,7 @@ pub async fn stream_traverse(
     // wrapper as a lazy iterator, so individual events are still
     // pushed to the wire progressively under back-pressure.
     let events = tokio::task::spawn_blocking(move || {
-        let traversal_result =
-            run_traversal_blocking(coll_handle, collection.as_str(), &params);
+        let traversal_result = run_traversal_blocking(coll_handle, collection.as_str(), &params);
         build_sse_events(traversal_result, start_time)
     })
     .await

--- a/crates/velesdb-server/src/handlers/graph/stream.rs
+++ b/crates/velesdb-server/src/handlers/graph/stream.rs
@@ -1,7 +1,27 @@
 //! SSE streaming graph traversal handler (EPIC-058 US-003).
 //!
-//! Provides a Server-Sent Events endpoint for streaming graph traversal
-//! results incrementally, avoiding full buffering for large traversals.
+//! Provides a Server-Sent Events endpoint for graph traversal results.
+//!
+//! # Streaming contract (finding F-17)
+//!
+//! The server-side traversal produced by `velesdb_core::GraphCollection::
+//! traverse_bfs` / `traverse_dfs` is a synchronous call that returns a
+//! fully materialised `Vec<TraversalResult>`. That means the "streaming"
+//! semantics of this endpoint currently apply to the **wire level**
+//! only — every node event is delivered to the client as an individual
+//! SSE record (with back-pressure handled by axum's SSE wrapper), but
+//! the traversal itself runs to completion before the first node
+//! reaches the wire.
+//!
+//! F-17 of the pre-seed audit flagged this as a "fake SSE" problem.
+//! Sprint 1 addresses the most damaging half of that finding: the
+//! synchronous traversal is now executed on a `spawn_blocking` worker
+//! so the async runtime stays responsive for concurrent requests,
+//! and the SSE events are built off the runtime thread. True
+//! incremental streaming — where each node is emitted to the wire
+//! as soon as the traversal visits it — requires a new callback-based
+//! core method (`traverse_bfs_stream(config, cb)`) and is tracked as
+//! a post-seed EPIC in `docs/ARCHITECTURE.md`.
 
 use axum::{
     extract::{Path, Query, State},
@@ -42,50 +62,80 @@ const STATS_INTERVAL: usize = 100;
         (status = 200, description = "SSE stream of traversal events (node, stats, done, error)")
     )
 )]
-#[allow(clippy::unused_async)]
 pub async fn stream_traverse(
     State(state): State<Arc<AppState>>,
     Path(collection): Path<String>,
     Query(params): Query<StreamTraverseParams>,
 ) -> Sse<impl Stream<Item = Result<Event, Infallible>>> {
+    let start_time = Instant::now();
+
+    // Snapshot the parameters and state needed by the blocking worker.
+    let coll_handle = state.db.get_graph_collection(&collection);
+
+    // F-17 fix: execute the synchronous traversal and event
+    // construction on a blocking worker so the Tokio async runtime
+    // stays responsive to other requests. The completed Vec<Event>
+    // is then handed back to the async handler and fed to the SSE
+    // wrapper as a lazy iterator, so individual events are still
+    // pushed to the wire progressively under back-pressure.
+    let events = tokio::task::spawn_blocking(move || {
+        let traversal_result =
+            run_traversal_blocking(coll_handle, collection.as_str(), &params);
+        build_sse_events(traversal_result, start_time)
+    })
+    .await
+    .unwrap_or_else(|e| {
+        // JoinError: panic or cancellation inside the blocking task.
+        // Report it as an SSE error event so the client receives a
+        // well-formed SSE frame instead of an aborted connection.
+        build_error_events(format!(
+            "Graph traversal worker failed: {e}. This is an internal \
+             server error; please retry or contact the operator."
+        ))
+    });
+
+    Sse::new(stream::iter(events)).keep_alive(KeepAlive::default())
+}
+
+/// Runs the graph traversal synchronously on the calling (blocking)
+/// thread. Factored out of the handler so it can be invoked from
+/// `tokio::task::spawn_blocking` without leaking async internals.
+fn run_traversal_blocking(
+    coll_handle: Option<velesdb_core::GraphCollection>,
+    collection_name: &str,
+    params: &StreamTraverseParams,
+) -> Result<Vec<TraversalResultItem>, String> {
     use velesdb_core::collection::graph::TraversalConfig;
 
-    let start_time = Instant::now();
+    let Some(coll) = coll_handle else {
+        return Err(format!(
+            "Collection '{collection_name}' not found or is not a graph collection."
+        ));
+    };
 
     let rel_types: Vec<String> = params
         .relationship_types
+        .as_ref()
         .map(|s| s.split(',').map(|t| t.trim().to_string()).collect())
         .unwrap_or_default();
 
-    let traversal_result: Result<Vec<TraversalResultItem>, String> =
-        match state.db.get_graph_collection(&collection) {
-            None => Err(format!(
-                "Collection '{}' not found or is not a graph collection.",
-                collection
-            )),
-            Some(coll) => {
-                let config = TraversalConfig::with_range(1, params.max_depth)
-                    .with_limit(params.limit)
-                    .with_rel_types(rel_types);
+    let config = TraversalConfig::with_range(1, params.max_depth)
+        .with_limit(params.limit)
+        .with_rel_types(rel_types);
 
-                let raw = match params.algorithm.to_lowercase().as_str() {
-                    "dfs" => coll.traverse_dfs(params.start_node, &config),
-                    _ => coll.traverse_bfs(params.start_node, &config),
-                };
+    let raw = match params.algorithm.to_lowercase().as_str() {
+        "dfs" => coll.traverse_dfs(params.start_node, &config),
+        _ => coll.traverse_bfs(params.start_node, &config),
+    };
 
-                Ok(raw
-                    .into_iter()
-                    .map(|r| TraversalResultItem {
-                        target_id: r.target_id,
-                        depth: r.depth,
-                        path: r.path,
-                    })
-                    .collect())
-            }
-        };
-
-    let events = build_sse_events(traversal_result, start_time);
-    Sse::new(stream::iter(events)).keep_alive(KeepAlive::default())
+    Ok(raw
+        .into_iter()
+        .map(|r| TraversalResultItem {
+            target_id: r.target_id,
+            depth: r.depth,
+            path: r.path,
+        })
+        .collect())
 }
 
 /// Converts a traversal result into a sequence of SSE events.

--- a/crates/velesdb-server/src/handlers/mod.rs
+++ b/crates/velesdb-server/src/handlers/mod.rs
@@ -26,7 +26,7 @@ pub mod search;
 pub mod metrics;
 
 pub use admin::{
-    analyze_collection, get_collection_config, get_collection_stats, get_guardrails,
+    analyze_collection, get_collection_config, get_collection_stats, get_guardrails, rebuild_index,
     update_guardrails,
 };
 pub use collections::{

--- a/crates/velesdb-server/src/handlers/search/mod.rs
+++ b/crates/velesdb-server/src/handlers/search/mod.rs
@@ -311,12 +311,12 @@ pub async fn hybrid_search(
         (status = 400, description = "Invalid request", body = crate::types::ErrorResponse)
     )
 )]
-#[allow(clippy::unused_async)]
+#[allow(clippy::result_large_err)]
 pub async fn search_ids(
     State(state): State<Arc<AppState>>,
     headers: axum::http::HeaderMap,
     Path(name): Path<String>,
-    Json(mut req): Json<SearchRequest>,
+    Json(req): Json<SearchRequest>,
 ) -> impl IntoResponse {
     let start = std::time::Instant::now();
 
@@ -325,9 +325,34 @@ pub async fn search_ids(
         Err(resp) => return resp,
     };
 
-    let search_result = match execute_with_cb(&state, &name, &collection, &mut req) {
-        Ok(r) => r,
-        Err(resp) => return resp,
+    // F-03: honour the per-request `timeout_ms` budget and run the
+    // CPU-bound search on a blocking worker so the async runtime stays
+    // responsive. Mirrors the pattern used by `search` so both endpoints
+    // share the same timeout semantics for the same `SearchRequest` type.
+    let timeout_ms = req.timeout_ms;
+    let state_for_work = Arc::clone(&state);
+    let name_for_work = name.clone();
+    let collection_for_work = collection.clone();
+
+    let execution = run_search_with_optional_timeout(timeout_ms, move || {
+        let mut owned_req = req;
+        execute_search_with_cb_owned(
+            &state_for_work,
+            &name_for_work,
+            &collection_for_work,
+            &mut owned_req,
+        )
+    })
+    .await;
+
+    let search_result = match execution {
+        Ok(Ok(inner)) => inner,
+        Ok(Err(resp)) => return resp,
+        Err(pipeline::TimeoutElapsed) => {
+            collection.guard_rails().circuit_breaker.record_failure();
+            let ms = timeout_ms.unwrap_or_default();
+            return timeout_response(&name, ms);
+        }
     };
 
     finish_search_ids_with_cb(&state, &name, start, &collection, search_result)

--- a/crates/velesdb-server/src/handlers/search/mod.rs
+++ b/crates/velesdb-server/src/handlers/search/mod.rs
@@ -21,7 +21,8 @@ use crate::AppState;
 use super::helpers::{apply_pre_check, extract_client_id, get_vector_collection_or_404};
 use pipeline::{
     execute_search_request, finish_search_ids_with_cb, finish_search_with_cb,
-    finish_search_with_status, parse_filter_or_400, validate_query_dimension,
+    finish_search_with_status, parse_filter_or_400, run_search_with_optional_timeout,
+    timeout_response, validate_query_dimension,
 };
 
 #[allow(unused_imports)]
@@ -82,12 +83,12 @@ fn execute_with_cb(
         (status = 400, description = "Invalid request", body = crate::types::ErrorResponse)
     )
 )]
-#[allow(clippy::unused_async)]
+#[allow(clippy::result_large_err)]
 pub async fn search(
     State(state): State<Arc<AppState>>,
     headers: axum::http::HeaderMap,
     Path(name): Path<String>,
-    Json(mut req): Json<SearchRequest>,
+    Json(req): Json<SearchRequest>,
 ) -> impl IntoResponse {
     let start = std::time::Instant::now();
 
@@ -96,12 +97,53 @@ pub async fn search(
         Err(resp) => return resp,
     };
 
-    let search_result = match execute_with_cb(&state, &name, &collection, &mut req) {
-        Ok(r) => r,
-        Err(resp) => return resp,
+    // F-03: honour the per-request `timeout_ms` budget. The synchronous
+    // search runs on a blocking worker so the async runtime stays
+    // responsive and the timer can actually fire. See
+    // `run_search_with_optional_timeout` for the cancellation contract.
+    let timeout_ms = req.timeout_ms;
+    let state_for_work = Arc::clone(&state);
+    let name_for_work = name.clone();
+    let collection_for_work = collection.clone();
+
+    let execution = run_search_with_optional_timeout(timeout_ms, move || {
+        let mut owned_req = req;
+        execute_search_with_cb_owned(
+            &state_for_work,
+            &name_for_work,
+            &collection_for_work,
+            &mut owned_req,
+        )
+    })
+    .await;
+
+    let search_result = match execution {
+        Ok(Ok(inner)) => inner,
+        Ok(Err(resp)) => return resp,
+        Err(pipeline::TimeoutElapsed) => {
+            // Timeout elapsed: record the circuit-breaker failure and
+            // return a 408 with the budget echoed back to the caller.
+            collection.guard_rails().circuit_breaker.record_failure();
+            let ms = timeout_ms.unwrap_or_default();
+            return timeout_response(&name, ms);
+        }
     };
 
     finish_search_with_cb(&state, &name, start, &collection, search_result)
+}
+
+/// Owned-request wrapper around [`execute_with_cb`] used by the
+/// `run_search_with_optional_timeout` spawn_blocking closure. Having a
+/// dedicated function keeps the move-semantics inside the closure
+/// explicit and avoids lifetime juggling in the handler body.
+#[allow(clippy::result_large_err)]
+fn execute_search_with_cb_owned(
+    state: &AppState,
+    name: &str,
+    collection: &VectorCollection,
+    req: &mut SearchRequest,
+) -> Result<velesdb_core::Result<Vec<velesdb_core::SearchResult>>, axum::response::Response> {
+    execute_with_cb(state, name, collection, req)
 }
 
 /// Search using BM25 full-text search.

--- a/crates/velesdb-server/src/handlers/search/mod.rs
+++ b/crates/velesdb-server/src/handlers/search/mod.rs
@@ -21,8 +21,8 @@ use crate::AppState;
 use super::helpers::{apply_pre_check, extract_client_id, get_vector_collection_or_404};
 use pipeline::{
     execute_search_request, finish_search_ids_with_cb, finish_search_with_cb,
-    finish_search_with_status, parse_filter_or_400, run_search_with_optional_timeout,
-    timeout_response, validate_query_dimension,
+    finish_search_with_status, parse_filter_or_400, run_blocking_search,
+    run_search_with_optional_timeout, timeout_response, validate_query_dimension,
 };
 
 #[allow(unused_imports)]
@@ -160,7 +160,7 @@ fn execute_search_with_cb_owned(
         (status = 404, description = "Collection not found", body = crate::types::ErrorResponse)
     )
 )]
-#[allow(clippy::unused_async)]
+#[allow(clippy::result_large_err)]
 pub async fn text_search(
     State(state): State<Arc<AppState>>,
     headers: axum::http::HeaderMap,
@@ -174,14 +174,34 @@ pub async fn text_search(
 
     let start = std::time::Instant::now();
 
-    let search_result = if let Some(ref filter_json) = req.filter {
-        let filter = match parse_filter_or_400(filter_json, &state.onboarding_metrics) {
-            Ok(f) => f,
-            Err(resp) => return resp,
+    // F-01 / F-03 sweep: the BM25 text search is CPU-bound and was
+    // previously executed on the async runtime thread. Move it to a
+    // blocking worker so concurrent requests do not stall.
+    let filter_json = req.filter.clone();
+    let query = req.query.clone();
+    let top_k = req.top_k;
+    let collection_for_work = collection.clone();
+    let onboarding_for_work = Arc::clone(&state);
+
+    let work_result = run_blocking_search(move || {
+        let filter = match filter_json.as_ref() {
+            Some(fj) => match parse_filter_or_400(fj, &onboarding_for_work.onboarding_metrics) {
+                Ok(f) => Some(f),
+                Err(resp) => return Err(resp),
+            },
+            None => None,
         };
-        collection.text_search_with_filter(&req.query, req.top_k, &filter)
-    } else {
-        collection.text_search(&req.query, req.top_k)
+        Ok(if let Some(f) = filter {
+            collection_for_work.text_search_with_filter(&query, top_k, &f)
+        } else {
+            collection_for_work.text_search(&query, top_k)
+        })
+    })
+    .await;
+
+    let search_result = match work_result {
+        Ok(inner) => inner,
+        Err(resp) => return resp,
     };
 
     finish_search_with_status(
@@ -209,7 +229,7 @@ pub async fn text_search(
         (status = 400, description = "Invalid request", body = crate::types::ErrorResponse)
     )
 )]
-#[allow(clippy::unused_async)]
+#[allow(clippy::result_large_err)]
 pub async fn hybrid_search(
     State(state): State<Arc<AppState>>,
     headers: axum::http::HeaderMap,
@@ -228,20 +248,45 @@ pub async fn hybrid_search(
         return (StatusCode::BAD_REQUEST, Json(error)).into_response();
     }
 
-    let search_result = if let Some(ref filter_json) = req.filter {
-        let filter = match parse_filter_or_400(filter_json, &state.onboarding_metrics) {
-            Ok(f) => f,
-            Err(resp) => return resp,
+    // F-01 / F-03 sweep: the hybrid BM25 + dense path is CPU-bound
+    // (filter parsing, text index lookup, dense HNSW search, fusion).
+    // Move the whole closure to a blocking worker so the async
+    // runtime stays responsive.
+    let collection_for_work = collection.clone();
+    let state_for_work = Arc::clone(&state);
+    let HybridSearchRequest {
+        vector,
+        query,
+        top_k,
+        vector_weight,
+        filter,
+    } = req;
+
+    let work_result = run_blocking_search(move || {
+        let filter = match filter.as_ref() {
+            Some(fj) => match parse_filter_or_400(fj, &state_for_work.onboarding_metrics) {
+                Ok(f) => Some(f),
+                Err(resp) => return Err(resp),
+            },
+            None => None,
         };
-        collection.hybrid_search_with_filter(
-            &req.vector,
-            &req.query,
-            req.top_k,
-            Some(req.vector_weight),
-            &filter,
-        )
-    } else {
-        collection.hybrid_search(&req.vector, &req.query, req.top_k, Some(req.vector_weight))
+        Ok(if let Some(f) = filter {
+            collection_for_work.hybrid_search_with_filter(
+                &vector,
+                &query,
+                top_k,
+                Some(vector_weight),
+                &f,
+            )
+        } else {
+            collection_for_work.hybrid_search(&vector, &query, top_k, Some(vector_weight))
+        })
+    })
+    .await;
+
+    let search_result = match work_result {
+        Ok(inner) => inner,
+        Err(resp) => return resp,
     };
 
     finish_search_with_cb(&state, &name, start, &collection, search_result)

--- a/crates/velesdb-server/src/handlers/search/multi.rs
+++ b/crates/velesdb-server/src/handlers/search/multi.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 use crate::types::{ErrorResponse, MultiQuerySearchRequest, SearchResponse};
 use crate::AppState;
 
-use super::pipeline::{finish_search_with_cb, validate_query_dimension};
+use super::pipeline::{finish_search_with_cb, parse_filter_or_400, validate_query_dimension};
 use crate::handlers::helpers::{apply_pre_check, extract_client_id, get_vector_collection_or_404};
 
 /// Multi-query search with fusion strategies.
@@ -91,10 +91,26 @@ pub async fn multi_query_search(
         }
     }
 
+    // Parse the optional metadata filter. We need to materialise the
+    // `Filter` before starting the stopwatch so that a malformed filter
+    // yields a 400 response instead of a misleading 200 with unfiltered
+    // results. Regression guard: see
+    // `test_multi_query_search_with_filter_excludes_nonmatching_points`
+    // and `test_multi_query_search_with_invalid_filter_returns_400`
+    // (F-04).
+    let filter = match req.filter.as_ref() {
+        Some(filter_json) => match parse_filter_or_400(filter_json, &state.onboarding_metrics) {
+            Ok(f) => Some(f),
+            Err(resp) => return resp,
+        },
+        None => None,
+    };
+
     let start = std::time::Instant::now();
     let query_refs: Vec<&[f32]> = req.vectors.iter().map(Vec::as_slice).collect();
 
-    let search_result = collection.multi_query_search(&query_refs, req.top_k, strategy, None);
+    let search_result =
+        collection.multi_query_search(&query_refs, req.top_k, strategy, filter.as_ref());
 
     finish_search_with_cb(&state, &name, start, &collection, search_result)
 }

--- a/crates/velesdb-server/src/handlers/search/multi.rs
+++ b/crates/velesdb-server/src/handlers/search/multi.rs
@@ -11,7 +11,9 @@ use std::sync::Arc;
 use crate::types::{ErrorResponse, MultiQuerySearchRequest, SearchResponse};
 use crate::AppState;
 
-use super::pipeline::{finish_search_with_cb, parse_filter_or_400, validate_query_dimension};
+use super::pipeline::{
+    finish_search_with_cb, parse_filter_or_400, run_blocking_search, validate_query_dimension,
+};
 use crate::handlers::helpers::{apply_pre_check, extract_client_id, get_vector_collection_or_404};
 
 /// Multi-query search with fusion strategies.
@@ -27,7 +29,7 @@ use crate::handlers::helpers::{apply_pre_check, extract_client_id, get_vector_co
         (status = 500, description = "Internal server error", body = ErrorResponse)
     )
 )]
-#[allow(clippy::unused_async, clippy::too_many_lines)]
+#[allow(clippy::too_many_lines, clippy::result_large_err)]
 pub async fn multi_query_search(
     State(state): State<Arc<AppState>>,
     headers: axum::http::HeaderMap,
@@ -107,10 +109,28 @@ pub async fn multi_query_search(
     };
 
     let start = std::time::Instant::now();
-    let query_refs: Vec<&[f32]> = req.vectors.iter().map(Vec::as_slice).collect();
 
-    let search_result =
-        collection.multi_query_search(&query_refs, req.top_k, strategy, filter.as_ref());
+    // F-01 sweep: multi-vector fusion is CPU-bound (multiple HNSW
+    // passes plus a fusion step) and was previously executed on the
+    // async runtime thread. Move it to a blocking worker so concurrent
+    // requests stay responsive. We move `vectors` (owned
+    // `Vec<Vec<f32>>`) into the closure and rebuild the `&[f32]` slice
+    // view inside, because `spawn_blocking` requires a 'static closure
+    // and borrowed slice references cannot cross the boundary.
+    let collection_for_work = collection.clone();
+    let vectors = req.vectors;
+    let top_k = req.top_k;
+
+    let work_result = run_blocking_search(move || {
+        let query_refs: Vec<&[f32]> = vectors.iter().map(Vec::as_slice).collect();
+        Ok(collection_for_work.multi_query_search(&query_refs, top_k, strategy, filter.as_ref()))
+    })
+    .await;
+
+    let search_result = match work_result {
+        Ok(inner) => inner,
+        Err(resp) => return resp,
+    };
 
     finish_search_with_cb(&state, &name, start, &collection, search_result)
 }

--- a/crates/velesdb-server/src/handlers/search/pipeline.rs
+++ b/crates/velesdb-server/src/handlers/search/pipeline.rs
@@ -540,6 +540,27 @@ where
 /// the per-request timeout elapses before the blocking worker finishes.
 pub(crate) struct TimeoutElapsed;
 
+/// Executes a synchronous search closure on a `spawn_blocking` worker,
+/// without a timeout budget. This is the lighter-weight sibling of
+/// [`run_search_with_optional_timeout`] used by handlers that do not
+/// currently expose a per-request timeout (text search, hybrid
+/// search, batch search) but still need to keep CPU-bound work off
+/// the async runtime.
+///
+/// Finding F-01 of the pre-seed audit (spawn_blocking sweep).
+#[allow(clippy::result_large_err)]
+pub(crate) async fn run_blocking_search<F>(
+    work: F,
+) -> Result<velesdb_core::Result<Vec<velesdb_core::SearchResult>>, axum::response::Response>
+where
+    F: FnOnce()
+            -> Result<velesdb_core::Result<Vec<velesdb_core::SearchResult>>, axum::response::Response>
+        + Send
+        + 'static,
+{
+    unwrap_join(tokio::task::spawn_blocking(work).await)
+}
+
 /// Converts a `JoinHandle` result into the same shape expected by
 /// callers of the synchronous search pipeline. A panic or cancellation
 /// of the blocking task is reported as a 500 Internal Server Error.

--- a/crates/velesdb-server/src/handlers/search/pipeline.rs
+++ b/crates/velesdb-server/src/handlers/search/pipeline.rs
@@ -146,6 +146,20 @@ pub(crate) fn resolve_sparse_input(
 /// Parses fusion configuration into a core `FusionStrategy`.
 ///
 /// Defaults to RRF k=60 when no fusion config is provided.
+///
+/// Supported strategy strings (case-insensitive):
+///
+/// | Strategy | Aliases | Parameters |
+/// |---|---|---|
+/// | RRF | `rrf` | `k` (default 60) |
+/// | Relative Score | `rsf`, `relative_score` | `dense_w`, `sparse_w` (default 0.5 / 0.5) |
+/// | Average | `average`, `avg` | — |
+/// | Maximum | `maximum`, `max` | — |
+/// | Weighted | `weighted` | `avg_w`, `max_w`, `hit_w` (default 0.5 / 0.3 / 0.2) |
+///
+/// Unknown strategies yield a 400 Bad Request response listing the
+/// supported values. This propagates the full `velesdb_core::FusionStrategy`
+/// enum to the REST surface (findings PROP-FUS-HYBRID / PROP-FUS-SPARSE).
 #[allow(clippy::result_large_err)]
 pub(crate) fn parse_fusion_strategy(
     fusion: Option<&crate::types::FusionRequest>,
@@ -176,12 +190,21 @@ pub(crate) fn parse_fusion_strategy(
                     .into_response()
             })
         }
+        "average" | "avg" => Ok(velesdb_core::FusionStrategy::Average),
+        "maximum" | "max" => Ok(velesdb_core::FusionStrategy::Maximum),
+        "weighted" => Ok(velesdb_core::FusionStrategy::Weighted {
+            avg_weight: f.avg_w.unwrap_or(0.5),
+            max_weight: f.max_w.unwrap_or(0.3),
+            hit_weight: f.hit_w.unwrap_or(0.2),
+        }),
         other => Err((
             StatusCode::BAD_REQUEST,
             Json(ErrorResponse {
                 error: format!(
-                    "Invalid fusion strategy: '{other}'. \
-                     Valid values: 'rrf', 'rsf' (alias: 'relative_score')"
+                    "Invalid fusion strategy: '{other}'. Valid values: \
+                     'rrf', 'rsf' (alias: 'relative_score'), \
+                     'average' (alias: 'avg'), \
+                     'maximum' (alias: 'max'), 'weighted'"
                 ),
                 code: None,
             }),
@@ -540,5 +563,149 @@ fn unwrap_join(
             }),
         )
             .into_response()),
+    }
+}
+
+#[cfg(test)]
+mod parse_fusion_strategy_tests {
+    use super::parse_fusion_strategy;
+    use crate::types::FusionRequest;
+
+    fn strat(name: &str) -> FusionRequest {
+        FusionRequest {
+            strategy: name.to_string(),
+            k: None,
+            dense_w: None,
+            sparse_w: None,
+            avg_w: None,
+            max_w: None,
+            hit_w: None,
+        }
+    }
+
+    #[test]
+    fn test_default_is_rrf_k60() {
+        let result = parse_fusion_strategy(None).expect("None must default to RRF");
+        match result {
+            velesdb_core::FusionStrategy::RRF { k } => assert_eq!(k, 60),
+            other => panic!("expected RRF, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_rrf_with_custom_k() {
+        let mut req = strat("rrf");
+        req.k = Some(120);
+        let result = parse_fusion_strategy(Some(&req)).expect("rrf must parse");
+        match result {
+            velesdb_core::FusionStrategy::RRF { k } => assert_eq!(k, 120),
+            other => panic!("expected RRF, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_average_no_params() {
+        for alias in ["average", "avg", "AVG"] {
+            let req = strat(alias);
+            let result = parse_fusion_strategy(Some(&req))
+                .unwrap_or_else(|_| panic!("'{alias}' must parse"));
+            assert!(matches!(result, velesdb_core::FusionStrategy::Average));
+        }
+    }
+
+    #[test]
+    fn test_maximum_no_params() {
+        for alias in ["maximum", "max", "MAX"] {
+            let req = strat(alias);
+            let result = parse_fusion_strategy(Some(&req))
+                .unwrap_or_else(|_| panic!("'{alias}' must parse"));
+            assert!(matches!(result, velesdb_core::FusionStrategy::Maximum));
+        }
+    }
+
+    #[test]
+    fn test_weighted_with_defaults() {
+        let req = strat("weighted");
+        let result = parse_fusion_strategy(Some(&req)).expect("weighted must parse");
+        match result {
+            velesdb_core::FusionStrategy::Weighted {
+                avg_weight,
+                max_weight,
+                hit_weight,
+            } => {
+                assert!((avg_weight - 0.5).abs() < f32::EPSILON);
+                assert!((max_weight - 0.3).abs() < f32::EPSILON);
+                assert!((hit_weight - 0.2).abs() < f32::EPSILON);
+            }
+            other => panic!("expected Weighted, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_weighted_with_explicit_weights() {
+        let mut req = strat("weighted");
+        req.avg_w = Some(0.7);
+        req.max_w = Some(0.2);
+        req.hit_w = Some(0.1);
+        let result = parse_fusion_strategy(Some(&req)).expect("weighted must parse");
+        match result {
+            velesdb_core::FusionStrategy::Weighted {
+                avg_weight,
+                max_weight,
+                hit_weight,
+            } => {
+                assert!((avg_weight - 0.7).abs() < f32::EPSILON);
+                assert!((max_weight - 0.2).abs() < f32::EPSILON);
+                assert!((hit_weight - 0.1).abs() < f32::EPSILON);
+            }
+            other => panic!("expected Weighted, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_rsf_with_dense_weight_only() {
+        let mut req = strat("rsf");
+        req.dense_w = Some(0.7);
+        let result = parse_fusion_strategy(Some(&req)).expect("rsf must parse");
+        match result {
+            velesdb_core::FusionStrategy::RelativeScore {
+                dense_weight,
+                sparse_weight,
+            } => {
+                assert!((dense_weight - 0.7).abs() < f32::EPSILON);
+                assert!((sparse_weight - 0.3).abs() < f32::EPSILON);
+            }
+            other => panic!("expected RelativeScore, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_relative_score_alias() {
+        let req = strat("relative_score");
+        let result = parse_fusion_strategy(Some(&req)).expect("relative_score must parse");
+        assert!(matches!(
+            result,
+            velesdb_core::FusionStrategy::RelativeScore { .. }
+        ));
+    }
+
+    #[test]
+    fn test_unknown_strategy_returns_error() {
+        let req = strat("nonexistent");
+        let result = parse_fusion_strategy(Some(&req));
+        assert!(
+            result.is_err(),
+            "unknown strategy must return Err (400 response)"
+        );
+    }
+
+    #[test]
+    fn test_rrf_alias_case_insensitive() {
+        for alias in ["rrf", "RRF", "Rrf"] {
+            let req = strat(alias);
+            let result = parse_fusion_strategy(Some(&req))
+                .unwrap_or_else(|_| panic!("'{alias}' must parse"));
+            assert!(matches!(result, velesdb_core::FusionStrategy::RRF { .. }));
+        }
     }
 }

--- a/crates/velesdb-server/src/handlers/search/pipeline.rs
+++ b/crates/velesdb-server/src/handlers/search/pipeline.rs
@@ -454,10 +454,7 @@ pub(crate) fn finish_search_with_status(
 /// exceeds the per-request `timeout_ms` budget. Includes the collection
 /// name and the budget in milliseconds so that clients can log
 /// actionable diagnostics.
-pub(crate) fn timeout_response(
-    collection_name: &str,
-    timeout_ms: u64,
-) -> axum::response::Response {
+pub(crate) fn timeout_response(collection_name: &str, timeout_ms: u64) -> axum::response::Response {
     (
         StatusCode::REQUEST_TIMEOUT,
         Json(ErrorResponse {
@@ -506,9 +503,10 @@ pub(crate) async fn run_search_with_optional_timeout<F>(
     TimeoutElapsed,
 >
 where
-    F: FnOnce()
-            -> Result<velesdb_core::Result<Vec<velesdb_core::SearchResult>>, axum::response::Response>
-        + Send
+    F: FnOnce() -> Result<
+            velesdb_core::Result<Vec<velesdb_core::SearchResult>>,
+            axum::response::Response,
+        > + Send
         + 'static,
 {
     // A zero-millisecond budget is treated as an immediate short-circuit:
@@ -553,9 +551,10 @@ pub(crate) async fn run_blocking_search<F>(
     work: F,
 ) -> Result<velesdb_core::Result<Vec<velesdb_core::SearchResult>>, axum::response::Response>
 where
-    F: FnOnce()
-            -> Result<velesdb_core::Result<Vec<velesdb_core::SearchResult>>, axum::response::Response>
-        + Send
+    F: FnOnce() -> Result<
+            velesdb_core::Result<Vec<velesdb_core::SearchResult>>,
+            axum::response::Response,
+        > + Send
         + 'static,
 {
     unwrap_join(tokio::task::spawn_blocking(work).await)
@@ -567,10 +566,7 @@ where
 #[allow(clippy::result_large_err)]
 fn unwrap_join(
     join_result: Result<
-        Result<
-            velesdb_core::Result<Vec<velesdb_core::SearchResult>>,
-            axum::response::Response,
-        >,
+        Result<velesdb_core::Result<Vec<velesdb_core::SearchResult>>, axum::response::Response>,
         tokio::task::JoinError,
     >,
 ) -> Result<velesdb_core::Result<Vec<velesdb_core::SearchResult>>, axum::response::Response> {

--- a/crates/velesdb-server/src/handlers/search/pipeline.rs
+++ b/crates/velesdb-server/src/handlers/search/pipeline.rs
@@ -426,3 +426,119 @@ pub(crate) fn finish_search_with_status(
         Json(build_search_response(results)).into_response()
     })
 }
+
+/// Builds the 408 Request Timeout response returned when a search
+/// exceeds the per-request `timeout_ms` budget. Includes the collection
+/// name and the budget in milliseconds so that clients can log
+/// actionable diagnostics.
+pub(crate) fn timeout_response(
+    collection_name: &str,
+    timeout_ms: u64,
+) -> axum::response::Response {
+    (
+        StatusCode::REQUEST_TIMEOUT,
+        Json(ErrorResponse {
+            error: format!(
+                "Search on collection '{collection_name}' exceeded the \
+                 requested timeout of {timeout_ms}ms. The server returned \
+                 early; the in-flight query may continue in the background \
+                 until completion.",
+            ),
+            code: Some("VELES-QUERY-TIMEOUT".to_string()),
+        }),
+    )
+        .into_response()
+}
+
+/// Executes the synchronous search pipeline on a `spawn_blocking` worker
+/// with an optional per-request timeout.
+///
+/// # Contract
+///
+/// * When `timeout_ms` is `None`, the search runs on a blocking worker
+///   and the future simply awaits its completion. No artificial timeout
+///   is applied; the only bound is whatever the collection-level guard
+///   rails enforce.
+/// * When `timeout_ms` is `Some`, the blocking join handle is wrapped
+///   in `tokio::time::timeout`. If the budget elapses first, the helper
+///   returns `Err(TimeoutElapsed)` and the caller is expected to emit a
+///   408 response via [`timeout_response`]. The spawned blocking task
+///   is **not** cancelled — synchronous Rust code cannot be interrupted
+///   mid-flight by Tokio — and will continue to execute until completion
+///   (its result is then discarded). This is the standard Tokio pattern
+///   for bounding the latency observed by clients while keeping the
+///   async runtime responsive.
+///
+/// # Parameters
+///
+/// The closure is given ownership of the [`SearchRequest`] because the
+/// inner pipeline takes `&mut SearchRequest` to drain sparse vector
+/// fields via `Option::take()`.
+#[allow(clippy::result_large_err)]
+pub(crate) async fn run_search_with_optional_timeout<F>(
+    timeout_ms: Option<u64>,
+    work: F,
+) -> Result<
+    Result<velesdb_core::Result<Vec<velesdb_core::SearchResult>>, axum::response::Response>,
+    TimeoutElapsed,
+>
+where
+    F: FnOnce()
+            -> Result<velesdb_core::Result<Vec<velesdb_core::SearchResult>>, axum::response::Response>
+        + Send
+        + 'static,
+{
+    // A zero-millisecond budget is treated as an immediate short-circuit:
+    // we do not even spawn the blocking worker before returning the
+    // timeout signal. This guarantees deterministic behaviour for test
+    // fixtures that want to exercise the 408 path without depending on
+    // the runtime scheduler to win a race against `Duration::ZERO`, and
+    // matches the intuitive semantic that "zero budget" means "no budget
+    // to spend".
+    if matches!(timeout_ms, Some(0)) {
+        return Err(TimeoutElapsed);
+    }
+
+    let handle = tokio::task::spawn_blocking(work);
+
+    match timeout_ms {
+        Some(ms) => {
+            let duration = std::time::Duration::from_millis(ms);
+            match tokio::time::timeout(duration, handle).await {
+                Ok(join_result) => Ok(unwrap_join(join_result)),
+                Err(_elapsed) => Err(TimeoutElapsed),
+            }
+        }
+        None => Ok(unwrap_join(handle.await)),
+    }
+}
+
+/// Marker error returned by [`run_search_with_optional_timeout`] when
+/// the per-request timeout elapses before the blocking worker finishes.
+pub(crate) struct TimeoutElapsed;
+
+/// Converts a `JoinHandle` result into the same shape expected by
+/// callers of the synchronous search pipeline. A panic or cancellation
+/// of the blocking task is reported as a 500 Internal Server Error.
+#[allow(clippy::result_large_err)]
+fn unwrap_join(
+    join_result: Result<
+        Result<
+            velesdb_core::Result<Vec<velesdb_core::SearchResult>>,
+            axum::response::Response,
+        >,
+        tokio::task::JoinError,
+    >,
+) -> Result<velesdb_core::Result<Vec<velesdb_core::SearchResult>>, axum::response::Response> {
+    match join_result {
+        Ok(inner) => inner,
+        Err(join_err) => Err((
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse {
+                error: format!("Search worker task failed: {join_err}"),
+                code: Some("VELES-INTERNAL-WORKER-FAILURE".to_string()),
+            }),
+        )
+            .into_response()),
+    }
+}

--- a/crates/velesdb-server/src/lib.rs
+++ b/crates/velesdb-server/src/lib.rs
@@ -46,8 +46,8 @@ pub use handlers::{
     create_index, delete_collection, delete_index, delete_point, explain, flush_collection,
     get_collection, get_collection_config, get_collection_stats, get_guardrails, get_point,
     health_check, hybrid_search, is_empty, list_collections, list_indexes, match_query,
-    multi_query_search, query, readiness_check, scroll_points, search, search_ids, stream_insert,
-    stream_upsert_points, text_search, update_guardrails, upsert_points,
+    multi_query_search, query, readiness_check, rebuild_index, scroll_points, search, search_ids,
+    stream_insert, stream_upsert_points, text_search, update_guardrails, upsert_points,
 };
 
 pub use handlers::graph::{

--- a/crates/velesdb-server/src/main.rs
+++ b/crates/velesdb-server/src/main.rs
@@ -36,9 +36,8 @@ use velesdb_server::{
     graph_search, health_check, hybrid_search, is_empty, list_collections, list_indexes,
     list_nodes, match_query, multi_query_search, query, readiness_check, rebuild_index,
     remove_edge, scroll_points, search, search_ids, stream_insert, stream_traverse,
-    stream_upsert_points,
-    text_search, traverse_graph, traverse_parallel, update_guardrails, upsert_node_payload,
-    upsert_points, AppState, OnboardingMetrics,
+    stream_upsert_points, text_search, traverse_graph, traverse_parallel, update_guardrails,
+    upsert_node_payload, upsert_points, AppState, OnboardingMetrics,
 };
 
 /// VelesDB Server - A high-performance vector database

--- a/crates/velesdb-server/src/main.rs
+++ b/crates/velesdb-server/src/main.rs
@@ -34,8 +34,9 @@ use velesdb_server::{
     flush_collection, get_collection, get_collection_config, get_collection_stats, get_edge_count,
     get_edges, get_guardrails, get_node_degree, get_node_edges, get_node_payload, get_point,
     graph_search, health_check, hybrid_search, is_empty, list_collections, list_indexes,
-    list_nodes, match_query, multi_query_search, query, readiness_check, remove_edge,
-    scroll_points, search, search_ids, stream_insert, stream_traverse, stream_upsert_points,
+    list_nodes, match_query, multi_query_search, query, readiness_check, rebuild_index,
+    remove_edge, scroll_points, search, search_ids, stream_insert, stream_traverse,
+    stream_upsert_points,
     text_search, traverse_graph, traverse_parallel, update_guardrails, upsert_node_payload,
     upsert_points, AppState, OnboardingMetrics,
 };
@@ -137,6 +138,7 @@ fn core_routes() -> Router<Arc<AppState>> {
         .route("/collections/{name}/sanity", get(collection_sanity))
         .route("/collections/{name}/flush", post(flush_collection))
         .route("/collections/{name}/analyze", post(analyze_collection))
+        .route("/collections/{name}/index/rebuild", post(rebuild_index))
         .route("/collections/{name}/stats", get(get_collection_stats))
         .route("/guardrails", get(get_guardrails).put(update_guardrails))
         // 100MB limit scoped to batch vector upload routes only

--- a/crates/velesdb-server/tests/api_integration.rs
+++ b/crates/velesdb-server/tests/api_integration.rs
@@ -3649,6 +3649,181 @@ async fn test_graph_endpoint_works_after_explicit_creation() {
     assert_eq!(response.status(), StatusCode::CREATED);
 }
 
+// ────────────────────────────────────────────────────────────────────────────
+// Per-request timeout_ms — honoured by /search (Sprint 1 / F-03)
+// ────────────────────────────────────────────────────────────────────────────
+
+/// Helper: seed a small vector collection for timeout tests.
+async fn seed_timeout_collection(app: &axum::Router, name: &str) {
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/collections")
+                .header("Content-Type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "name": name,
+                        "dimension": 4,
+                        "metric": "cosine"
+                    })
+                    .to_string(),
+                ))
+                .expect("test: build create collection request"),
+        )
+        .await
+        .expect("test: create collection request failed");
+    assert_eq!(response.status(), StatusCode::CREATED);
+
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/collections/{name}/points"))
+                .header("Content-Type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "points": [
+                            {"id": 1, "vector": [1.0, 0.0, 0.0, 0.0]},
+                            {"id": 2, "vector": [0.0, 1.0, 0.0, 0.0]},
+                            {"id": 3, "vector": [0.0, 0.0, 1.0, 0.0]}
+                        ]
+                    })
+                    .to_string(),
+                ))
+                .expect("test: build upsert request"),
+        )
+        .await
+        .expect("test: upsert request failed");
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+/// Nominal: a search without `timeout_ms` must behave exactly as before
+/// and return 200 with the expected result set. This locks in the
+/// baseline so the F-03 wrapping does not introduce latency or break
+/// the no-timeout path.
+#[tokio::test]
+async fn test_search_without_timeout_returns_200() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let app = create_test_app(&temp_dir);
+    seed_timeout_collection(&app, "timeout_ok").await;
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/collections/timeout_ok/search")
+                .header("Content-Type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "vector": [1.0, 0.0, 0.0, 0.0],
+                        "top_k": 3
+                    })
+                    .to_string(),
+                ))
+                .expect("test: build search request"),
+        )
+        .await
+        .expect("test: search request failed");
+
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+/// Nominal: a search with a generous `timeout_ms` (30 seconds) must
+/// return 200. This verifies the new wrapping code path behaves like
+/// the pass-through code path for any realistic query.
+#[tokio::test]
+async fn test_search_with_generous_timeout_returns_200() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let app = create_test_app(&temp_dir);
+    seed_timeout_collection(&app, "timeout_generous").await;
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/collections/timeout_generous/search")
+                .header("Content-Type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "vector": [1.0, 0.0, 0.0, 0.0],
+                        "top_k": 3,
+                        "timeout_ms": 30000
+                    })
+                    .to_string(),
+                ))
+                .expect("test: build search request"),
+        )
+        .await
+        .expect("test: search request failed");
+
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+/// Negative: a search with `timeout_ms: 0` yields an immediate timeout.
+/// The handler must return 408 Request Timeout with a VELES-QUERY-TIMEOUT
+/// error code, not 200 with the results. The `tokio::time::timeout`
+/// wrapper fires on the very next runtime tick after the worker is
+/// spawned, so this deterministic test will always see the elapsed
+/// path regardless of how fast the underlying HNSW search is.
+#[tokio::test]
+async fn test_search_with_zero_timeout_returns_408() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let app = create_test_app(&temp_dir);
+    seed_timeout_collection(&app, "timeout_zero").await;
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/collections/timeout_zero/search")
+                .header("Content-Type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "vector": [1.0, 0.0, 0.0, 0.0],
+                        "top_k": 3,
+                        "timeout_ms": 0
+                    })
+                    .to_string(),
+                ))
+                .expect("test: build search request"),
+        )
+        .await
+        .expect("test: search request failed");
+
+    assert_eq!(
+        response.status(),
+        StatusCode::REQUEST_TIMEOUT,
+        "F-03: timeout_ms=0 must return 408 Request Timeout"
+    );
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("test: read body");
+    let json: Value = serde_json::from_slice(&body).expect("test: parse json");
+    assert_eq!(
+        json["code"].as_str(),
+        Some("VELES-QUERY-TIMEOUT"),
+        "error code must be VELES-QUERY-TIMEOUT, got: {}",
+        json["code"]
+    );
+    let error_msg = json["error"].as_str().expect("error field");
+    assert!(
+        error_msg.contains("timeout_zero"),
+        "error must include collection name, got: {error_msg}"
+    );
+    assert!(
+        error_msg.contains("0ms"),
+        "error must echo the budget, got: {error_msg}"
+    );
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Type-mismatch branch for F-05 (retained from the previous section)
+// ────────────────────────────────────────────────────────────────────────────
+
 /// Type-mismatch: a vector collection already exists with the target
 /// name, but the caller targets a graph endpoint. The handler must
 /// return 409 Conflict (already the case before F-05, but we lock it

--- a/crates/velesdb-server/tests/api_integration.rs
+++ b/crates/velesdb-server/tests/api_integration.rs
@@ -3555,9 +3555,7 @@ async fn test_graph_endpoint_on_missing_collection_returns_404() {
         .await
         .expect("Failed to read body");
     let json: Value = serde_json::from_slice(&body).expect("Invalid JSON");
-    let error_msg = json["error"]
-        .as_str()
-        .expect("error field must be present");
+    let error_msg = json["error"].as_str().expect("error field must be present");
     assert!(
         error_msg.contains("never_created"),
         "error message must include the collection name, got: {error_msg}"
@@ -3961,8 +3959,7 @@ async fn test_create_without_advanced_config_describe_returns_defaults() {
         "pq_rescore_oversampling must default to 4"
     );
     assert!(
-        json.get("async_index_builder").is_none()
-            || json["async_index_builder"].is_null(),
+        json.get("async_index_builder").is_none() || json["async_index_builder"].is_null(),
         "async_index_builder must be absent or null when not set"
     );
 }

--- a/crates/velesdb-server/tests/api_integration.rs
+++ b/crates/velesdb-server/tests/api_integration.rs
@@ -4120,6 +4120,113 @@ async fn test_create_graph_collection_with_invalid_schema_returns_400() {
     );
 }
 
+// ────────────────────────────────────────────────────────────────────────────
+// F-21: POST /collections/{name}/index/rebuild — HNSW vacuum endpoint
+// ────────────────────────────────────────────────────────────────────────────
+
+/// Nominal: `POST /collections/{name}/index/rebuild` on a populated
+/// vector collection must return 200 with `compacted_entries` in the
+/// body. For a collection that has not had any deletions, the compacted
+/// count is expected to be 0 — the important contract is that the
+/// endpoint succeeds and surfaces the count honestly.
+#[tokio::test]
+async fn test_rebuild_index_on_populated_collection_returns_200() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let app = create_test_app(&temp_dir);
+
+    // Seed a small collection with three points.
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/collections")
+                .header("Content-Type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "name": "rebuild_ok",
+                        "dimension": 4,
+                        "metric": "cosine"
+                    })
+                    .to_string(),
+                ))
+                .expect("test: build create request"),
+        )
+        .await
+        .expect("test: create request failed");
+    assert_eq!(response.status(), StatusCode::CREATED);
+
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/collections/rebuild_ok/points")
+                .header("Content-Type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "points": [
+                            {"id": 1, "vector": [1.0, 0.0, 0.0, 0.0]},
+                            {"id": 2, "vector": [0.0, 1.0, 0.0, 0.0]},
+                            {"id": 3, "vector": [0.0, 0.0, 1.0, 0.0]}
+                        ]
+                    })
+                    .to_string(),
+                ))
+                .expect("test: build upsert request"),
+        )
+        .await
+        .expect("test: upsert request failed");
+    assert_eq!(response.status(), StatusCode::OK);
+
+    // Rebuild the index.
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/collections/rebuild_ok/index/rebuild")
+                .body(Body::empty())
+                .expect("test: build rebuild request"),
+        )
+        .await
+        .expect("test: rebuild request failed");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("test: read body");
+    let json: Value = serde_json::from_slice(&body).expect("test: parse json");
+
+    assert_eq!(json["message"], "Index rebuilt");
+    assert_eq!(json["collection"], "rebuild_ok");
+    assert!(
+        json["compacted_entries"].as_u64().is_some(),
+        "compacted_entries must be a number, got: {}",
+        json["compacted_entries"]
+    );
+}
+
+/// Negative: `POST /collections/{name}/index/rebuild` on a missing
+/// collection must return 404.
+#[tokio::test]
+async fn test_rebuild_index_on_missing_collection_returns_404() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let app = create_test_app(&temp_dir);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/collections/never_created/index/rebuild")
+                .body(Body::empty())
+                .expect("test: build rebuild request"),
+        )
+        .await
+        .expect("test: rebuild request failed");
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
 /// Type-mismatch: a vector collection already exists with the target
 /// name, but the caller targets a graph endpoint. The handler must
 /// return 409 Conflict (already the case before F-05, but we lock it

--- a/crates/velesdb-server/tests/api_integration.rs
+++ b/crates/velesdb-server/tests/api_integration.rs
@@ -3824,6 +3824,302 @@ async fn test_search_with_zero_timeout_returns_408() {
 // Type-mismatch branch for F-05 (retained from the previous section)
 // ────────────────────────────────────────────────────────────────────────────
 
+// ────────────────────────────────────────────────────────────────────────────
+// PROP-CONFIG-ADVANCED: CreateCollectionRequest accepts pq_rescore_oversampling,
+// deferred_indexing, async_index_builder; GET /collections/{name}/config
+// echoes them back (Sprint 1 / S1-07).
+// ────────────────────────────────────────────────────────────────────────────
+
+/// Nominal round-trip: create a collection with pq_rescore_oversampling
+/// and async_index_builder, then GET /config and verify the values are
+/// persisted and echoed.
+#[tokio::test]
+async fn test_create_with_pq_rescore_and_async_builder_round_trip() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let app = create_test_app(&temp_dir);
+
+    // Create with advanced config.
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/collections")
+                .header("Content-Type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "name": "advanced_cfg",
+                        "dimension": 16,
+                        "metric": "cosine",
+                        "pq_rescore_oversampling": 8,
+                        "async_index_builder": {
+                            "merge_threshold": 5000,
+                            "segment_count": 4
+                        }
+                    })
+                    .to_string(),
+                ))
+                .expect("test: build create request"),
+        )
+        .await
+        .expect("test: create request failed");
+    assert_eq!(response.status(), StatusCode::CREATED);
+
+    // Describe: GET /collections/{name}/config.
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/collections/advanced_cfg/config")
+                .body(Body::empty())
+                .expect("test: build describe request"),
+        )
+        .await
+        .expect("test: describe request failed");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("test: read body");
+    let json: Value = serde_json::from_slice(&body).expect("test: parse json");
+
+    assert_eq!(json["name"], "advanced_cfg");
+    assert_eq!(json["dimension"], 16);
+    assert_eq!(
+        json["pq_rescore_oversampling"], 8,
+        "pq_rescore_oversampling must round-trip through describe, got: {}",
+        json["pq_rescore_oversampling"]
+    );
+
+    let aib = &json["async_index_builder"];
+    assert!(
+        aib.is_object(),
+        "async_index_builder must be populated in describe response, got: {aib}"
+    );
+    assert_eq!(
+        aib["merge_threshold"], 5000,
+        "async_index_builder.merge_threshold must round-trip"
+    );
+    assert_eq!(
+        aib["segment_count"], 4,
+        "async_index_builder.segment_count must round-trip"
+    );
+
+    // schema_version is always populated (non-optional in the response).
+    assert!(
+        json["schema_version"].as_u64().is_some(),
+        "schema_version must be present"
+    );
+}
+
+/// Edge: a collection created WITHOUT advanced overrides must still
+/// describe cleanly. pq_rescore_oversampling defaults to 4 (the core
+/// default); async_index_builder and deferred_indexing are absent.
+#[tokio::test]
+async fn test_create_without_advanced_config_describe_returns_defaults() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let app = create_test_app(&temp_dir);
+
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/collections")
+                .header("Content-Type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "name": "minimal_cfg",
+                        "dimension": 8,
+                        "metric": "cosine"
+                    })
+                    .to_string(),
+                ))
+                .expect("test: build create request"),
+        )
+        .await
+        .expect("test: create request failed");
+    assert_eq!(response.status(), StatusCode::CREATED);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/collections/minimal_cfg/config")
+                .body(Body::empty())
+                .expect("test: build describe request"),
+        )
+        .await
+        .expect("test: describe request failed");
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("test: read body");
+    let json: Value = serde_json::from_slice(&body).expect("test: parse json");
+
+    assert_eq!(
+        json["pq_rescore_oversampling"], 4,
+        "pq_rescore_oversampling must default to 4"
+    );
+    assert!(
+        json.get("async_index_builder").is_none()
+            || json["async_index_builder"].is_null(),
+        "async_index_builder must be absent or null when not set"
+    );
+}
+
+/// Negative: a malformed `async_index_builder` payload must return
+/// 400 Bad Request with a message that identifies the offending field.
+#[tokio::test]
+async fn test_create_with_invalid_async_index_builder_returns_400() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let app = create_test_app(&temp_dir);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/collections")
+                .header("Content-Type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "name": "bad_aib",
+                        "dimension": 8,
+                        "metric": "cosine",
+                        "async_index_builder": {
+                            "merge_threshold": "this is not a number"
+                        }
+                    })
+                    .to_string(),
+                ))
+                .expect("test: build create request"),
+        )
+        .await
+        .expect("test: create request failed");
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("test: read body");
+    let json: Value = serde_json::from_slice(&body).expect("test: parse json");
+    let error_msg = json["error"].as_str().expect("error field");
+    assert!(
+        error_msg.contains("async_index_builder"),
+        "error must name the offending field, got: {error_msg}"
+    );
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// PROP-GRAPHSCHEMA-SERVER: CreateCollectionRequest accepts a typed
+// graph_schema payload instead of hard-coding GraphSchema::schemaless()
+// (Sprint 1 / S1-08).
+// ────────────────────────────────────────────────────────────────────────────
+
+/// Nominal: creating a graph collection with a typed `graph_schema`
+/// payload must succeed with 201 and the schema must persist through
+/// GET /config. The shape matches `velesdb_core::GraphSchema`: a
+/// `schemaless` boolean plus `node_types` / `edge_types` arrays.
+#[tokio::test]
+async fn test_create_graph_collection_with_typed_schema() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let app = create_test_app(&temp_dir);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/collections")
+                .header("Content-Type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "name": "typed_graph",
+                        "collection_type": "graph",
+                        "graph_schema": {
+                            "schemaless": false,
+                            "node_types": [],
+                            "edge_types": []
+                        }
+                    })
+                    .to_string(),
+                ))
+                .expect("test: build create request"),
+        )
+        .await
+        .expect("test: create request failed");
+
+    assert_eq!(
+        response.status(),
+        StatusCode::CREATED,
+        "typed graph schema must be accepted"
+    );
+}
+
+/// Edge: a graph collection created without a `graph_schema` field must
+/// continue to work and fall back to `GraphSchema::schemaless()`. This
+/// locks in the backward-compatibility promise.
+#[tokio::test]
+async fn test_create_graph_collection_without_schema_uses_schemaless() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let app = create_test_app(&temp_dir);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/collections")
+                .header("Content-Type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "name": "implicit_schemaless",
+                        "collection_type": "graph"
+                    })
+                    .to_string(),
+                ))
+                .expect("test: build create request"),
+        )
+        .await
+        .expect("test: create request failed");
+
+    assert_eq!(response.status(), StatusCode::CREATED);
+}
+
+/// Negative: a malformed `graph_schema` payload must return 400 Bad
+/// Request with a message that identifies the offending field.
+#[tokio::test]
+async fn test_create_graph_collection_with_invalid_schema_returns_400() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let app = create_test_app(&temp_dir);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/collections")
+                .header("Content-Type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "name": "bad_schema",
+                        "collection_type": "graph",
+                        "graph_schema": "not an object"
+                    })
+                    .to_string(),
+                ))
+                .expect("test: build create request"),
+        )
+        .await
+        .expect("test: create request failed");
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("test: read body");
+    let json: Value = serde_json::from_slice(&body).expect("test: parse json");
+    let error_msg = json["error"].as_str().expect("error field");
+    assert!(
+        error_msg.contains("graph_schema"),
+        "error must name the offending field, got: {error_msg}"
+    );
+}
+
 /// Type-mismatch: a vector collection already exists with the target
 /// name, but the caller targets a graph endpoint. The handler must
 /// return 409 Conflict (already the case before F-05, but we lock it

--- a/crates/velesdb-server/tests/api_integration.rs
+++ b/crates/velesdb-server/tests/api_integration.rs
@@ -7,7 +7,7 @@ use axum::{
     body::Body,
     http::{Request, StatusCode},
 };
-use common::{create_test_app, create_test_app_with_state};
+use common::{create_graph_collection, create_test_app, create_test_app_with_state};
 use futures::stream;
 use serde_json::{json, Value};
 use tempfile::TempDir;
@@ -1926,6 +1926,9 @@ async fn test_graph_add_edge() {
     let temp_dir = TempDir::new().expect("Failed to create temp dir");
     let app = create_test_app(&temp_dir);
 
+    // Graph collections must be explicitly created since F-05 (Sprint 1).
+    create_graph_collection(&app, "test").await;
+
     // Add edge
     let response = app
         .oneshot(
@@ -1955,6 +1958,7 @@ async fn test_graph_add_edge() {
 async fn test_graph_get_edges_by_label() {
     let temp_dir = TempDir::new().expect("Failed to create temp dir");
     let app = create_test_app(&temp_dir);
+    create_graph_collection(&app, "test").await;
 
     // Add edges
     let response = app
@@ -2048,6 +2052,7 @@ async fn test_graph_get_edges_missing_label() {
 async fn test_graph_traverse_bfs() {
     let temp_dir = TempDir::new().expect("Failed to create temp dir");
     let app = create_test_app(&temp_dir);
+    create_graph_collection(&app, "graph_test").await;
 
     // Build a graph: 1 -> 2 -> 3 -> 4
     for (id, src, tgt) in [(1, 1, 2), (2, 2, 3), (3, 3, 4)] {
@@ -2115,6 +2120,7 @@ async fn test_graph_traverse_bfs() {
 async fn test_graph_traverse_dfs() {
     let temp_dir = TempDir::new().expect("Failed to create temp dir");
     let app = create_test_app(&temp_dir);
+    create_graph_collection(&app, "dfs_test").await;
 
     // Build graph
     for (id, src, tgt) in [(1, 1, 2), (2, 2, 3)] {
@@ -2177,6 +2183,7 @@ async fn test_graph_traverse_dfs() {
 async fn test_graph_traverse_with_rel_type_filter() {
     let temp_dir = TempDir::new().expect("Failed to create temp dir");
     let app = create_test_app(&temp_dir);
+    create_graph_collection(&app, "filter_test").await;
 
     // Build graph with mixed edge types: 1 -KNOWS-> 2 -WROTE-> 3
     let edges = [(1, 1, 2, "KNOWS"), (2, 2, 3, "WROTE")];
@@ -2243,6 +2250,7 @@ async fn test_graph_traverse_with_rel_type_filter() {
 async fn test_graph_traverse_invalid_strategy() {
     let temp_dir = TempDir::new().expect("Failed to create temp dir");
     let app = create_test_app(&temp_dir);
+    create_graph_collection(&app, "test").await;
 
     let response = app
         .oneshot(
@@ -2270,6 +2278,7 @@ async fn test_graph_traverse_invalid_strategy() {
 async fn test_graph_node_degree() {
     let temp_dir = TempDir::new().expect("Failed to create temp dir");
     let app = create_test_app(&temp_dir);
+    create_graph_collection(&app, "degree_test").await;
 
     // Build graph: 1 -> 2, 3 -> 2, 2 -> 4
     // Node 2 has in_degree=2, out_degree=1
@@ -3502,4 +3511,195 @@ async fn test_multi_query_search_with_invalid_filter_returns_400() {
         StatusCode::BAD_REQUEST,
         "invalid filter must be rejected with 400"
     );
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Graph collection resolution — no auto-create (Sprint 1 / F-05 regression)
+// ────────────────────────────────────────────────────────────────────────────
+
+/// Nominal negative: calling a graph endpoint on a collection that was
+/// never created must return 404 Not Found, not silently create a
+/// schemaless graph collection. This is the F-05 regression guard.
+#[tokio::test]
+async fn test_graph_endpoint_on_missing_collection_returns_404() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let app = create_test_app(&temp_dir);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/collections/never_created/graph/edges")
+                .header("Content-Type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "id": 1,
+                        "source": 100,
+                        "target": 200,
+                        "label": "KNOWS"
+                    })
+                    .to_string(),
+                ))
+                .expect("Failed to build request"),
+        )
+        .await
+        .expect("Request failed");
+
+    assert_eq!(
+        response.status(),
+        StatusCode::NOT_FOUND,
+        "graph endpoints must return 404 when the collection does not exist"
+    );
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("Failed to read body");
+    let json: Value = serde_json::from_slice(&body).expect("Invalid JSON");
+    let error_msg = json["error"]
+        .as_str()
+        .expect("error field must be present");
+    assert!(
+        error_msg.contains("never_created"),
+        "error message must include the collection name, got: {error_msg}"
+    );
+    assert!(
+        error_msg.contains("collection_type"),
+        "error message must guide callers to create the collection explicitly, got: {error_msg}"
+    );
+}
+
+/// GET /collections/{name}/graph/edges?label=... on a missing graph
+/// collection must return 404 (not auto-create and not 500).
+#[tokio::test]
+async fn test_graph_get_edges_on_missing_collection_returns_404() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let app = create_test_app(&temp_dir);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/collections/ghost/graph/edges?label=KNOWS")
+                .body(Body::empty())
+                .expect("Failed to build request"),
+        )
+        .await
+        .expect("Request failed");
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+/// POST /collections/{name}/graph/traverse on a missing graph collection
+/// must return 404 (regression: auto-create previously hid this path).
+#[tokio::test]
+async fn test_graph_traverse_on_missing_collection_returns_404() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let app = create_test_app(&temp_dir);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/collections/absent/graph/traverse")
+                .header("Content-Type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "source": 1,
+                        "strategy": "bfs",
+                        "max_depth": 3
+                    })
+                    .to_string(),
+                ))
+                .expect("Failed to build request"),
+        )
+        .await
+        .expect("Request failed");
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+/// After an explicit `POST /collections` with `collection_type = "graph"`,
+/// graph endpoints must succeed as before — this is the happy path that
+/// validates the new explicit-creation contract.
+#[tokio::test]
+async fn test_graph_endpoint_works_after_explicit_creation() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let app = create_test_app(&temp_dir);
+    create_graph_collection(&app, "explicit").await;
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/collections/explicit/graph/edges")
+                .header("Content-Type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "id": 1,
+                        "source": 100,
+                        "target": 200,
+                        "label": "KNOWS"
+                    })
+                    .to_string(),
+                ))
+                .expect("Failed to build request"),
+        )
+        .await
+        .expect("Request failed");
+
+    assert_eq!(response.status(), StatusCode::CREATED);
+}
+
+/// Type-mismatch: a vector collection already exists with the target
+/// name, but the caller targets a graph endpoint. The handler must
+/// return 409 Conflict (already the case before F-05, but we lock it
+/// in with an explicit test so the fix cannot regress the branch).
+#[tokio::test]
+async fn test_graph_endpoint_on_vector_collection_returns_409() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let app = create_test_app(&temp_dir);
+
+    // Create a vector collection (not a graph collection).
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/collections")
+                .header("Content-Type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "name": "type_mismatch",
+                        "dimension": 4,
+                        "metric": "cosine"
+                    })
+                    .to_string(),
+                ))
+                .expect("Failed to build create collection request"),
+        )
+        .await
+        .expect("Create collection request failed");
+    assert_eq!(response.status(), StatusCode::CREATED);
+
+    // Now POST to its graph/edges endpoint → must be 409, not 404 or 500.
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/collections/type_mismatch/graph/edges")
+                .header("Content-Type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "id": 1,
+                        "source": 1,
+                        "target": 2,
+                        "label": "X"
+                    })
+                    .to_string(),
+                ))
+                .expect("Failed to build graph edge request"),
+        )
+        .await
+        .expect("Graph edge request failed");
+
+    assert_eq!(response.status(), StatusCode::CONFLICT);
 }

--- a/crates/velesdb-server/tests/api_integration.rs
+++ b/crates/velesdb-server/tests/api_integration.rs
@@ -3292,3 +3292,214 @@ async fn test_delete_point_by_id() {
         .unwrap();
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
 }
+
+// ────────────────────────────────────────────────────────────────────────────
+// Multi-query search — filter forwarding (Sprint 1 / F-04 regression tests)
+// ────────────────────────────────────────────────────────────────────────────
+
+/// Helper: seed a collection named `multi_filter` with three categorised points.
+async fn seed_multi_query_filter_collection(app: &axum::Router) {
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/collections")
+                .header("Content-Type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "name": "multi_filter",
+                        "dimension": 4,
+                        "metric": "cosine"
+                    })
+                    .to_string(),
+                ))
+                .expect("Failed to build create collection request"),
+        )
+        .await
+        .expect("Create collection request failed");
+    assert_eq!(response.status(), StatusCode::CREATED);
+
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/collections/multi_filter/points")
+                .header("Content-Type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "points": [
+                            {"id": 1, "vector": [1.0, 0.0, 0.0, 0.0], "payload": {"category": "a"}},
+                            {"id": 2, "vector": [0.9, 0.1, 0.0, 0.0], "payload": {"category": "b"}},
+                            {"id": 3, "vector": [0.8, 0.2, 0.0, 0.0], "payload": {"category": "a"}}
+                        ]
+                    })
+                    .to_string(),
+                ))
+                .expect("Failed to build upsert request"),
+        )
+        .await
+        .expect("Upsert request failed");
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+/// Nominal: `/search/multi` must apply a metadata filter and exclude rows
+/// that do not match. With three points (ids 1, 2, 3) and a filter
+/// `category = "a"`, the result set must be `{1, 3}` — id 2 belongs to
+/// category "b" and must be excluded.
+///
+/// Regression test for F-04: `MultiQuerySearchRequest.filter` was previously
+/// deserialized by the handler but never forwarded to
+/// `VectorCollection::multi_query_search`, so all rows were returned.
+#[tokio::test]
+async fn test_multi_query_search_with_filter_excludes_nonmatching_points() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let app = create_test_app(&temp_dir);
+    seed_multi_query_filter_collection(&app).await;
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/collections/multi_filter/search/multi")
+                .header("Content-Type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "vectors": [
+                            [1.0, 0.0, 0.0, 0.0],
+                            [0.95, 0.05, 0.0, 0.0]
+                        ],
+                        "top_k": 10,
+                        "strategy": "rrf",
+                        "rrf_k": 60,
+                        "filter": {
+                            "condition": {
+                                "type": "eq",
+                                "field": "category",
+                                "value": "a"
+                            }
+                        }
+                    })
+                    .to_string(),
+                ))
+                .expect("Failed to build multi search request"),
+        )
+        .await
+        .expect("Multi search request failed");
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("Failed to read body");
+    let json: Value = serde_json::from_slice(&body).expect("Invalid JSON");
+    let results = json["results"].as_array().expect("results is an array");
+
+    let ids: Vec<u64> = results
+        .iter()
+        .filter_map(|r| {
+            r["id"]
+                .as_str()
+                .and_then(|s| s.parse::<u64>().ok())
+                .or_else(|| r["id"].as_u64())
+        })
+        .collect();
+
+    assert!(
+        ids.contains(&1),
+        "expected id=1 (category=a) in filtered results, got {ids:?}"
+    );
+    assert!(
+        ids.contains(&3),
+        "expected id=3 (category=a) in filtered results, got {ids:?}"
+    );
+    assert!(
+        !ids.contains(&2),
+        "id=2 (category=b) must be excluded by the filter, got {ids:?}"
+    );
+}
+
+/// Without a filter, `/search/multi` must return all three points (verifies
+/// that the filter fix does not break the baseline behaviour).
+#[tokio::test]
+async fn test_multi_query_search_without_filter_returns_all_points() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let app = create_test_app(&temp_dir);
+    seed_multi_query_filter_collection(&app).await;
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/collections/multi_filter/search/multi")
+                .header("Content-Type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "vectors": [[1.0, 0.0, 0.0, 0.0]],
+                        "top_k": 10,
+                        "strategy": "rrf",
+                        "rrf_k": 60
+                    })
+                    .to_string(),
+                ))
+                .expect("Failed to build multi search request"),
+        )
+        .await
+        .expect("Multi search request failed");
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("Failed to read body");
+    let json: Value = serde_json::from_slice(&body).expect("Invalid JSON");
+    let results = json["results"].as_array().expect("results is an array");
+    assert_eq!(
+        results.len(),
+        3,
+        "without filter, all three points must be returned"
+    );
+}
+
+/// Negative: an invalid filter expression must produce a 400 response
+/// (not a 500 and not silently dropped).
+#[tokio::test]
+async fn test_multi_query_search_with_invalid_filter_returns_400() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let app = create_test_app(&temp_dir);
+    seed_multi_query_filter_collection(&app).await;
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/collections/multi_filter/search/multi")
+                .header("Content-Type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "vectors": [[1.0, 0.0, 0.0, 0.0]],
+                        "top_k": 10,
+                        "strategy": "rrf",
+                        "rrf_k": 60,
+                        "filter": {
+                            "condition": {
+                                "type": "nonexistent_operator",
+                                "field": "category",
+                                "value": "a"
+                            }
+                        }
+                    })
+                    .to_string(),
+                ))
+                .expect("Failed to build multi search request"),
+        )
+        .await
+        .expect("Multi search request failed");
+
+    assert_eq!(
+        response.status(),
+        StatusCode::BAD_REQUEST,
+        "invalid filter must be rejected with 400"
+    );
+}

--- a/crates/velesdb-server/tests/api_integration.rs
+++ b/crates/velesdb-server/tests/api_integration.rs
@@ -4005,6 +4005,53 @@ async fn test_create_with_invalid_async_index_builder_returns_400() {
     );
 }
 
+/// Regression: when Phase 2 (`apply_advanced_config`) fails after
+/// Phase 1 created the base collection, the handler must roll back
+/// the collection via `Database::delete_collection` so the client can
+/// retry without hitting `CollectionExists`. The only realistic failure
+/// mode of `apply_advanced_config` is `save_config()` I/O, which we
+/// cannot inject from the outside without a mockable filesystem trait.
+///
+/// This test documents the invariant and is kept ignored until a
+/// fault-injection hook is introduced (tracked alongside Sprint 2
+/// server polish). Re-enable once `VectorCollection` exposes a test
+/// seam that can force a write failure on `save_config()`.
+#[tokio::test]
+#[ignore = "needs disk fault-injection seam — see finding ANALYSIS_0002 on PR #582"]
+async fn test_advanced_config_failure_rolls_back_collection() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let app = create_test_app(&temp_dir);
+
+    // Precondition: POST a collection with advanced config and inject
+    // a `save_config()` failure between Phase 1 and Phase 2. Until the
+    // test seam exists, the scaffolding below documents the expected
+    // shape so the first engineer to wire the hook has a ready body.
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/collections")
+                .header("Content-Type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "name": "rollback_cfg",
+                        "dimension": 16,
+                        "metric": "cosine",
+                        "pq_rescore_oversampling": 8
+                    })
+                    .to_string(),
+                ))
+                .expect("test: build create request"),
+        )
+        .await
+        .expect("test: create request failed");
+
+    // Expected (post-seam): 500 with a diagnostic error body AND the
+    // collection must be absent from the registry so retrying with a
+    // valid payload succeeds instead of returning `CollectionExists`.
+    assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+}
+
 // ────────────────────────────────────────────────────────────────────────────
 // PROP-GRAPHSCHEMA-SERVER: CreateCollectionRequest accepts a typed
 // graph_schema payload instead of hard-coding GraphSchema::schemaless()

--- a/crates/velesdb-server/tests/auth_integration.rs
+++ b/crates/velesdb-server/tests/auth_integration.rs
@@ -196,3 +196,85 @@ async fn test_auth_basic_scheme_rejected() {
 
     assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
 }
+
+// ============================================================================
+// F-02: /metrics must not bypass auth — Prometheus endpoint leaks operational
+// details about the running database (collection counts, query latencies, WAL
+// depths, cache hit rates). When auth is enabled, scrapers must present an
+// API key like any other REST client.
+// ============================================================================
+
+/// Nominal negative: `/metrics` without an Authorization header must be
+/// rejected with 401 when auth is enabled, not bypassed as a public path.
+#[tokio::test]
+async fn test_metrics_endpoint_requires_auth_when_enabled() {
+    let temp_dir = TempDir::new().unwrap();
+    let app = create_test_app_with_auth(&temp_dir, vec!["secret-key".to_string()]);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/metrics")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        response.status(),
+        StatusCode::UNAUTHORIZED,
+        "F-02: /metrics must require an API key when auth is enabled"
+    );
+}
+
+/// Same guard for the versioned path `/v1/metrics`.
+#[tokio::test]
+async fn test_metrics_versioned_endpoint_requires_auth_when_enabled() {
+    let temp_dir = TempDir::new().unwrap();
+    let app = create_test_app_with_auth(&temp_dir, vec!["secret-key".to_string()]);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/v1/metrics")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        response.status(),
+        StatusCode::UNAUTHORIZED,
+        "F-02: /v1/metrics must require an API key when auth is enabled"
+    );
+}
+
+/// `/health` and `/ready` remain public — they are needed by container
+/// orchestrators (Kubernetes, Nomad, systemd) that cannot carry
+/// authentication headers on probes.
+#[tokio::test]
+async fn test_health_and_ready_remain_public_after_f02_fix() {
+    let temp_dir = TempDir::new().unwrap();
+    let app = create_test_app_with_auth(&temp_dir, vec!["secret-key".to_string()]);
+
+    for path in ["/health", "/ready"] {
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri(path)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            response.status(),
+            StatusCode::OK,
+            "{path} must remain public for container orchestrators"
+        );
+    }
+}

--- a/crates/velesdb-server/tests/auth_integration.rs
+++ b/crates/velesdb-server/tests/auth_integration.rs
@@ -262,12 +262,7 @@ async fn test_health_and_ready_remain_public_after_f02_fix() {
     for path in ["/health", "/ready"] {
         let response = app
             .clone()
-            .oneshot(
-                Request::builder()
-                    .uri(path)
-                    .body(Body::empty())
-                    .unwrap(),
-            )
+            .oneshot(Request::builder().uri(path).body(Body::empty()).unwrap())
             .await
             .unwrap();
 

--- a/crates/velesdb-server/tests/common/mod.rs
+++ b/crates/velesdb-server/tests/common/mod.rs
@@ -130,3 +130,43 @@ pub fn create_versioned_test_app(temp_dir: &TempDir) -> Router {
 
     versioned.merge(legacy).with_state(state)
 }
+
+/// Seeds a graph collection via `POST /collections` with
+/// `collection_type = "graph"`. Returns after asserting the 201 status.
+///
+/// Since F-05 (Sprint 1), graph collections must be created explicitly
+/// before any `/collections/{name}/graph/*` endpoint can be called.
+/// Previously, `get_graph_collection_or_404` auto-created a schemaless
+/// graph collection on first use, which made tests appear to work
+/// without an explicit creation step but hid a feature-lie from
+/// real API consumers.
+pub async fn create_graph_collection(app: &Router, name: &str) {
+    use axum::body::Body;
+    use axum::http::Request;
+    use tower::ServiceExt;
+
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/collections")
+                .header("Content-Type", "application/json")
+                .body(Body::from(
+                    serde_json::json!({
+                        "name": name,
+                        "collection_type": "graph"
+                    })
+                    .to_string(),
+                ))
+                .expect("test: build create graph collection request"),
+        )
+        .await
+        .expect("test: create graph collection request failed");
+
+    assert_eq!(
+        response.status(),
+        axum::http::StatusCode::CREATED,
+        "test: failed to create graph collection '{name}'"
+    );
+}

--- a/crates/velesdb-server/tests/common/mod.rs
+++ b/crates/velesdb-server/tests/common/mod.rs
@@ -14,8 +14,8 @@ use velesdb_server::{
     auth::{auth_middleware, AuthState},
     batch_search, collection_sanity, create_collection, delete_collection, delete_point, explain,
     get_collection, get_edges, get_node_degree, get_point, health_check, hybrid_search,
-    list_collections, query, readiness_check, search, search_ids, stream_upsert_points,
-    text_search, traverse_graph, upsert_points, AppState, OnboardingMetrics,
+    list_collections, multi_query_search, query, readiness_check, search, search_ids,
+    stream_upsert_points, text_search, traverse_graph, upsert_points, AppState, OnboardingMetrics,
 };
 
 fn base_routes() -> Router<Arc<AppState>> {
@@ -42,6 +42,7 @@ fn base_routes() -> Router<Arc<AppState>> {
         )
         .route("/collections/{name}/search", post(search))
         .route("/collections/{name}/search/batch", post(batch_search))
+        .route("/collections/{name}/search/multi", post(multi_query_search))
         .route("/collections/{name}/search/text", post(text_search))
         .route("/collections/{name}/search/hybrid", post(hybrid_search))
         .route("/collections/{name}/search/ids", post(search_ids))

--- a/crates/velesdb-server/tests/common/mod.rs
+++ b/crates/velesdb-server/tests/common/mod.rs
@@ -13,9 +13,10 @@ use velesdb_server::{
     add_edge, aggregate,
     auth::{auth_middleware, AuthState},
     batch_search, collection_sanity, create_collection, delete_collection, delete_point, explain,
-    get_collection, get_edges, get_node_degree, get_point, health_check, hybrid_search,
-    list_collections, multi_query_search, query, readiness_check, search, search_ids,
-    stream_upsert_points, text_search, traverse_graph, upsert_points, AppState, OnboardingMetrics,
+    get_collection, get_collection_config, get_edges, get_node_degree, get_point, health_check,
+    hybrid_search, list_collections, multi_query_search, query, readiness_check, search,
+    search_ids, stream_upsert_points, text_search, traverse_graph, upsert_points, AppState,
+    OnboardingMetrics,
 };
 
 fn base_routes() -> Router<Arc<AppState>> {
@@ -30,6 +31,7 @@ fn base_routes() -> Router<Arc<AppState>> {
             "/collections/{name}",
             get(get_collection).delete(delete_collection),
         )
+        .route("/collections/{name}/config", get(get_collection_config))
         .route("/collections/{name}/sanity", get(collection_sanity))
         .route("/collections/{name}/points", post(upsert_points))
         .route(

--- a/crates/velesdb-server/tests/common/mod.rs
+++ b/crates/velesdb-server/tests/common/mod.rs
@@ -15,8 +15,8 @@ use velesdb_server::{
     batch_search, collection_sanity, create_collection, delete_collection, delete_point, explain,
     get_collection, get_collection_config, get_edges, get_node_degree, get_point, health_check,
     hybrid_search, list_collections, multi_query_search, query, readiness_check, rebuild_index,
-    search, search_ids, stream_upsert_points, text_search, traverse_graph, upsert_points,
-    AppState, OnboardingMetrics,
+    search, search_ids, stream_upsert_points, text_search, traverse_graph, upsert_points, AppState,
+    OnboardingMetrics,
 };
 
 fn base_routes() -> Router<Arc<AppState>> {

--- a/crates/velesdb-server/tests/common/mod.rs
+++ b/crates/velesdb-server/tests/common/mod.rs
@@ -14,9 +14,9 @@ use velesdb_server::{
     auth::{auth_middleware, AuthState},
     batch_search, collection_sanity, create_collection, delete_collection, delete_point, explain,
     get_collection, get_collection_config, get_edges, get_node_degree, get_point, health_check,
-    hybrid_search, list_collections, multi_query_search, query, readiness_check, search,
-    search_ids, stream_upsert_points, text_search, traverse_graph, upsert_points, AppState,
-    OnboardingMetrics,
+    hybrid_search, list_collections, multi_query_search, query, readiness_check, rebuild_index,
+    search, search_ids, stream_upsert_points, text_search, traverse_graph, upsert_points,
+    AppState, OnboardingMetrics,
 };
 
 fn base_routes() -> Router<Arc<AppState>> {
@@ -32,6 +32,7 @@ fn base_routes() -> Router<Arc<AppState>> {
             get(get_collection).delete(delete_collection),
         )
         .route("/collections/{name}/config", get(get_collection_config))
+        .route("/collections/{name}/index/rebuild", post(rebuild_index))
         .route("/collections/{name}/sanity", get(collection_sanity))
         .route("/collections/{name}/points", post(upsert_points))
         .route(

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,78 @@
+# Architecture — Open decisions and known tech debt
+
+This document tracks architectural decisions that are deliberately
+deferred and known tech-debt items that the codebase is aware of but
+has not yet resolved. Each entry links the related audit finding, the
+mitigation currently in place, and the post-seed remediation plan.
+
+> **Note**: this is **not** a comprehensive architecture overview. For
+> the current module layout and data flow, see `CLAUDE.md` and the
+> per-crate `README.md` files. This document is a registry of
+> intentional open items.
+
+---
+
+## F2.2 — `AnyCollection::as_vector_collection_unchecked` (god-object cross-cast)
+
+**Audit finding**: F2.2 of the pre-seed audit (`AUDIT_VELESDB_CORE.md`).
+
+**Summary**: the `AnyCollection` enum exposes a method that consumes
+the enum and returns a `VectorCollection` newtype regardless of the
+actual variant. For `AnyCollection::Vector(c)` this is a genuine move
+of the inner `VectorCollection`. For `AnyCollection::Graph(c)` and
+`AnyCollection::Metadata(c)` the method re-wraps the inner
+`Arc<Collection>` in a `VectorCollection { inner }` newtype without
+any runtime check. Downstream code that then invokes a vector-specific
+method (`search`, `upsert`, `search_with_quality`, etc.) on the
+result observes either empty results or state that was not intended
+for public consumption. The operation is not memory-unsafe, but it is
+logically unsound.
+
+**Why this shape exists**: the three downstream SDK bindings (Python,
+Mobile, Tauri) expose a single `Collection` type to end users. Having
+separate `VectorCollection`, `GraphCollection`, and `MetadataCollection`
+types at the binding surface would triple the number of exported
+classes and require a discriminator enum in the public API. The
+unchecked cast was introduced as a short-term convenience so those
+bindings could share a single type.
+
+**Sprint 1 mitigation** (shipped):
+
+1. The method has been renamed from `into_vector_collection` to
+   `as_vector_collection_unchecked` to make the unchecked contract
+   explicit at the call site.
+2. The rustdoc of the new method carries a `# Safety` section that
+   documents the caller's obligation to either branch on
+   [`AnyCollection::is_vector`] first, or restrict themselves to the
+   methods that all three collection kinds share (`config`, `flush`,
+   `diagnostics`, `name`, `point_count`).
+3. The old `into_vector_collection` name is retained as a
+   `#[deprecated]` alias that delegates to the new method so external
+   consumers do not break at compile time.
+4. The four internal call sites (velesdb-mobile, velesdb-python,
+   tauri-plugin-velesdb, any_collection.rs itself) have been migrated
+   to the new name and each carries an explanatory comment referring
+   to this section.
+5. A new accessor `AnyCollection::is_vector()` is provided so callers
+   can branch defensively before the unchecked cast.
+
+**Post-seed resolution** (tracked as the F2.2 EPIC):
+
+The correct long-term fix is to split the `Collection` god-object
+into three genuinely distinct types with distinct public APIs:
+
+1. `VectorCollection` retains the vector search surface.
+2. `GraphCollection` exposes only graph operations (traversal, edge
+   CRUD, node CRUD, BFS/DFS, graph schema).
+3. `MetadataCollection` exposes only payload CRUD and VelesQL query
+   execution, with no vector or graph surface.
+
+The SDK bindings would then expose a sum type (enum) or union
+interface that forces callers to discriminate the kind before
+invoking any operation. This is estimated at 2-4 weeks of core
+refactoring and is deliberately out of scope for the pre-seed
+remediation cycle. The `as_vector_collection_unchecked` method will
+be removed in full as part of the EPIC.
+
+**When to revisit**: post-seed, within the first 4 weeks of the
+architecture cleanup milestone.

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3339,6 +3339,14 @@
           "strategy"
         ],
         "properties": {
+          "avg_w": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "format": "float",
+            "description": "Weighted fusion: weight applied to the average score component\n(only for strategy = \"weighted\", default 0.5)."
+          },
           "dense_w": {
             "type": [
               "number",
@@ -3346,6 +3354,14 @@
             ],
             "format": "float",
             "description": "Dense weight (only for strategy = \"rsf\", default 0.5)."
+          },
+          "hit_w": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "format": "float",
+            "description": "Weighted fusion: weight applied to the hit-ratio component\n(only for strategy = \"weighted\", default 0.2)."
           },
           "k": {
             "type": [
@@ -3355,6 +3371,14 @@
             "format": "int32",
             "description": "RRF k parameter (only for strategy = \"rrf\", default 60).",
             "minimum": 0
+          },
+          "max_w": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "format": "float",
+            "description": "Weighted fusion: weight applied to the maximum score component\n(only for strategy = \"weighted\", default 0.3)."
           },
           "sparse_w": {
             "type": [
@@ -3366,7 +3390,7 @@
           },
           "strategy": {
             "type": "string",
-            "description": "Fusion strategy: \"rrf\" or \"rsf\".",
+            "description": "Fusion strategy: \"rrf\", \"rsf\" (alias \"`relative_score`\"),\n\"average\" (alias \"avg\"), \"maximum\" (alias \"max\"), or \"weighted\".",
             "example": "rrf"
           }
         }

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -2728,7 +2728,7 @@
           "schema_version": {
             "type": "integer",
             "format": "int32",
-            "description": "On-disk schema version. Increments when the persisted\n`config.json` format changes in a way older VelesDB versions\ncannot safely read.",
+            "description": "On-disk schema version. Increments when the persisted\n`config.json` format changes in a way older `VelesDB` versions\ncannot safely read.",
             "minimum": 0
           },
           "storage_mode": {

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -2674,6 +2674,12 @@
           "metadata_only"
         ],
         "properties": {
+          "async_index_builder": {
+            "description": "Async index builder configuration (Issue `#488`) — `None` when\nthe feature is disabled for this collection."
+          },
+          "deferred_indexing": {
+            "description": "Deferred indexing configuration (`US-366`) — `None` when the\nfeature is disabled for this collection."
+          },
           "dimension": {
             "type": "integer",
             "description": "Vector dimension (0 for metadata-only collections).",
@@ -2690,6 +2696,9 @@
           "graph_schema": {
             "description": "Graph schema (if this is a graph collection)."
           },
+          "hnsw_params": {
+            "description": "Persisted HNSW parameters (M, `ef_construction`, etc.) when\ncustomised at create time. `None` means the defaults inferred\nfrom the collection dimension are in use."
+          },
           "metadata_only": {
             "type": "boolean",
             "description": "Whether this is a metadata-only collection."
@@ -2705,6 +2714,21 @@
           "point_count": {
             "type": "integer",
             "description": "Number of points in the collection.",
+            "minimum": 0
+          },
+          "pq_rescore_oversampling": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int32",
+            "description": "PQ rescore oversampling factor. See `CollectionConfig` for\nthe semantics of `None`, `Some(0)`, and `Some(n > 0)`.",
+            "minimum": 0
+          },
+          "schema_version": {
+            "type": "integer",
+            "format": "int32",
+            "description": "On-disk schema version. Increments when the persisted\n`config.json` format changes in a way older VelesDB versions\ncannot safely read.",
             "minimum": 0
           },
           "storage_mode": {
@@ -2893,10 +2917,16 @@
           "name"
         ],
         "properties": {
+          "async_index_builder": {
+            "description": "Async index builder configuration (Issue `#488` — Bulk Insert V2).\n\nWhen present, enables the `AsyncIndexBuilder` for deferred HNSW\ninsertion during bulk import. Accepted as a free-form JSON object\nmatching\n`velesdb_core::collection::streaming::AsyncIndexBuilderConfig`."
+          },
           "collection_type": {
             "type": "string",
             "description": "Collection type: \"vector\" (default) or \"`metadata_only`\".",
             "example": "vector"
+          },
+          "deferred_indexing": {
+            "description": "Deferred indexing configuration (`US-366`).\n\nWhen present, inserts are buffered in memory and batch-merged\ninto the HNSW index when the buffer reaches `merge_threshold`.\nAccepted as a free-form JSON object matching\n`velesdb_core::collection::streaming::DeferredIndexerConfig`."
           },
           "dimension": {
             "type": [
@@ -2906,6 +2936,9 @@
             "description": "Vector dimension (required for vector collections, ignored for `metadata_only`).",
             "example": 768,
             "minimum": 0
+          },
+          "graph_schema": {
+            "description": "Graph schema (only for `collection_type = \"graph\"`).\n\nAccepted as a free-form JSON object matching\n`velesdb_core::GraphSchema`. `GraphSchema::schemaless()` is\nused when the field is absent."
           },
           "hnsw_ef_construction": {
             "type": [
@@ -2934,6 +2967,16 @@
             "type": "string",
             "description": "Collection name.",
             "example": "documents"
+          },
+          "pq_rescore_oversampling": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int32",
+            "description": "PQ rescore oversampling factor (default 4).\n\nThe search pipeline fetches `max(k * factor, k + 32)` candidates\nfrom HNSW and rescores them with full-precision ADC. Only\nmeaningful for quantised storage modes (SQ8, PQ). `Some(0)` is\ntreated as \"disabled\".",
+            "example": 4,
+            "minimum": 0
           },
           "storage_mode": {
             "type": "string",

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2247,12 +2247,28 @@ components:
       required:
       - strategy
       properties:
+        avg_w:
+          type:
+          - number
+          - 'null'
+          format: float
+          description: |-
+            Weighted fusion: weight applied to the average score component
+            (only for strategy = "weighted", default 0.5).
         dense_w:
           type:
           - number
           - 'null'
           format: float
           description: Dense weight (only for strategy = "rsf", default 0.5).
+        hit_w:
+          type:
+          - number
+          - 'null'
+          format: float
+          description: |-
+            Weighted fusion: weight applied to the hit-ratio component
+            (only for strategy = "weighted", default 0.2).
         k:
           type:
           - integer
@@ -2260,6 +2276,14 @@ components:
           format: int32
           description: RRF k parameter (only for strategy = "rrf", default 60).
           minimum: 0
+        max_w:
+          type:
+          - number
+          - 'null'
+          format: float
+          description: |-
+            Weighted fusion: weight applied to the maximum score component
+            (only for strategy = "weighted", default 0.3).
         sparse_w:
           type:
           - number
@@ -2268,7 +2292,9 @@ components:
           description: Sparse weight (only for strategy = "rsf", default 0.5).
         strategy:
           type: string
-          description: 'Fusion strategy: "rrf" or "rsf".'
+          description: |-
+            Fusion strategy: "rrf", "rsf" (alias "`relative_score`"),
+            "average" (alias "avg"), "maximum" (alias "max"), or "weighted".
           example: rrf
     GraphSearchRequest:
       type: object

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1744,6 +1744,14 @@ components:
       - point_count
       - metadata_only
       properties:
+        async_index_builder:
+          description: |-
+            Async index builder configuration (Issue `#488`) — `None` when
+            the feature is disabled for this collection.
+        deferred_indexing:
+          description: |-
+            Deferred indexing configuration (`US-366`) — `None` when the
+            feature is disabled for this collection.
         dimension:
           type: integer
           description: Vector dimension (0 for metadata-only collections).
@@ -1756,6 +1764,11 @@ components:
           minimum: 0
         graph_schema:
           description: Graph schema (if this is a graph collection).
+        hnsw_params:
+          description: |-
+            Persisted HNSW parameters (M, `ef_construction`, etc.) when
+            customised at create time. `None` means the defaults inferred
+            from the collection dimension are in use.
         metadata_only:
           type: boolean
           description: Whether this is a metadata-only collection.
@@ -1768,6 +1781,23 @@ components:
         point_count:
           type: integer
           description: Number of points in the collection.
+          minimum: 0
+        pq_rescore_oversampling:
+          type:
+          - integer
+          - 'null'
+          format: int32
+          description: |-
+            PQ rescore oversampling factor. See `CollectionConfig` for
+            the semantics of `None`, `Some(0)`, and `Some(n > 0)`.
+          minimum: 0
+        schema_version:
+          type: integer
+          format: int32
+          description: |-
+            On-disk schema version. Increments when the persisted
+            `config.json` format changes in a way older VelesDB versions
+            cannot safely read.
           minimum: 0
         storage_mode:
           type: string
@@ -1915,10 +1945,26 @@ components:
       required:
       - name
       properties:
+        async_index_builder:
+          description: |-
+            Async index builder configuration (Issue `#488` — Bulk Insert V2).
+
+            When present, enables the `AsyncIndexBuilder` for deferred HNSW
+            insertion during bulk import. Accepted as a free-form JSON object
+            matching
+            `velesdb_core::collection::streaming::AsyncIndexBuilderConfig`.
         collection_type:
           type: string
           description: 'Collection type: "vector" (default) or "`metadata_only`".'
           example: vector
+        deferred_indexing:
+          description: |-
+            Deferred indexing configuration (`US-366`).
+
+            When present, inserts are buffered in memory and batch-merged
+            into the HNSW index when the buffer reaches `merge_threshold`.
+            Accepted as a free-form JSON object matching
+            `velesdb_core::collection::streaming::DeferredIndexerConfig`.
         dimension:
           type:
           - integer
@@ -1926,6 +1972,13 @@ components:
           description: Vector dimension (required for vector collections, ignored for `metadata_only`).
           example: 768
           minimum: 0
+        graph_schema:
+          description: |-
+            Graph schema (only for `collection_type = "graph"`).
+
+            Accepted as a free-form JSON object matching
+            `velesdb_core::GraphSchema`. `GraphSchema::schemaless()` is
+            used when the field is absent.
         hnsw_ef_construction:
           type:
           - integer
@@ -1948,6 +2001,20 @@ components:
           type: string
           description: Collection name.
           example: documents
+        pq_rescore_oversampling:
+          type:
+          - integer
+          - 'null'
+          format: int32
+          description: |-
+            PQ rescore oversampling factor (default 4).
+
+            The search pipeline fetches `max(k * factor, k + 32)` candidates
+            from HNSW and rescores them with full-precision ADC. Only
+            meaningful for quantised storage modes (SQ8, PQ). `Some(0)` is
+            treated as "disabled".
+          example: 4
+          minimum: 0
         storage_mode:
           type: string
           description: Storage mode (full, sq8, binary). Defaults to full.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1796,7 +1796,7 @@ components:
           format: int32
           description: |-
             On-disk schema version. Increments when the persisted
-            `config.json` format changes in a way older VelesDB versions
+            `config.json` format changes in a way older `VelesDB` versions
             cannot safely read.
           minimum: 0
         storage_mode:


### PR DESCRIPTION
## Summary

Sprint 1 of the pre-seed remediation plan. Closes the 13 Sprint 1
items from `.planning/jazzy-snacking-melody.md` by propagating the
core REST contract to every handler that was previously lying
about its capabilities, and by moving the most commonly used
search handlers off the async runtime thread via `spawn_blocking`.

**Delta: 13 commits, ~1 800 insertions / ~200 deletions.**

Philosophy (per the Sprint 1 plan revision): **implement rather
than delete**. Features that the core already supports but that
were not wired through the REST surface are now wired; nothing
was removed.

## Findings closed

### Core -> Server REST API propagation

| Finding | Scope | Commit |
|---|---|---|
| F-04 | `POST /collections/{name}/search/multi` discarded `filter`. Handler now calls `parse_filter_or_400` and forwards `Option<&Filter>` to `multi_query_search`. Three BDD tests (nominal with filter, edge without filter, negative invalid filter). | `232241a6` |
| F-05 | `get_graph_collection_or_404` silently auto-created a schemaless graph collection on first use. Now returns 404 with an error message pointing at `POST /collections` with `collection_type = "graph"`. Eight existing graph tests migrated to create collections explicitly; five new regression tests lock in the 404/409/201 branches. | `b00b9075` |
| F-02 | `/metrics` and `/v1/metrics` were listed as public paths and bypassed the API key middleware. Removed from `is_public_path`; three integration tests confirm 401 on missing key and 200 on `/health` / `/ready` (which remain public for container orchestrators). | `3bf60964` |
| F-03 | `SearchRequest.timeout_ms` was declared in the API type but never consumed. New helper `run_search_with_optional_timeout` wraps the synchronous search in `spawn_blocking` + `tokio::time::timeout`, returns 408 with a `VELES-QUERY-TIMEOUT` error code on elapse. `timeout_ms: 0` short-circuits deterministically for test fixtures. Three BDD tests. | `431c70a2` |
| PROP-FUS-HYBRID / PROP-FUS-SPARSE | `parse_fusion_strategy` only recognised RRF and RSF. Extended to `average`, `maximum`, `weighted`, plus their aliases. `FusionRequest` gets `avg_w` / `max_w` / `hit_w` weight fields. Ten unit tests covering every variant, every alias, case-insensitive matching, and the unknown-strategy negative path. | `53630ed1` |
| PROP-CONFIG-ADVANCED / PROP-GRAPHSCHEMA-SERVER | `CreateCollectionRequest` was missing `pq_rescore_oversampling`, `deferred_indexing`, `async_index_builder`, and `graph_schema`. `CollectionConfigResponse` was missing `schema_version`, `pq_rescore_oversampling`, `hnsw_params`, `deferred_indexing`, `async_index_builder`. Added all nine fields on both sides. New core method `Collection::apply_advanced_config` (Option<Option<T>> tri-state) persists post-creation overrides atomically. Six BDD tests covering round-trip + typed GraphSchema. | `4e5fbba2` |
| F-21 | New `POST /collections/{name}/index/rebuild` endpoint wraps the core `HnswIndex::vacuum` path to reclaim memory from tombstoned entries. Response carries `compacted_entries` count. Two BDD tests (populated collection, missing collection). | `cbea89fc` |
| F2.2 mitigation | `AnyCollection::into_vector_collection` flagged as a cross-cast trap. Renamed to `as_vector_collection_unchecked` with a `# Safety` section explaining the three-variant contract. Old name retained as `#[deprecated]` alias. All four internal call sites migrated. `docs/ARCHITECTURE.md` documents the debt and the post-seed EPIC scope. | `9a337be3` |
| M-P0-3 | `SourceSchema.metric: Option<String>` added. New `Pipeline::check_metric_fidelity` helper compares source and destination metrics (with alias canonicalisation: l2 -> euclidean, ip -> dot, etc.) and aborts with `SchemaMismatch` on conflict, unless `MigrationOptions.allow_metric_mismatch` is set. Seven unit tests covering exact match, aliases, known mismatch, unknown label, and the escape hatch. | `2e2992bc` |
| F-17 (partial) | `stream_traverse` moved to `spawn_blocking`. The synchronous graph traversal no longer blocks the Tokio runtime. JoinError is translated to a well-formed SSE `error` event. True node-by-node streaming still requires a core callback-based API and is documented as a post-seed EPIC in the module rustdoc. | `f6a60e2b` |
| F-01 (partial) | New helper `pipeline::run_blocking_search` applied to `text_search` and `hybrid_search`. `/search` was already migrated as part of F-03. Remaining handlers (batch, multi, ids, graph, admin) are mechanically similar and tracked for Sprint 2. | `56d177b4` |

## Verification (all single-threaded per --test-threads=1)

- `cargo fmt --all -- --check` -- clean
- `cargo clippy --workspace --all-targets --features persistence,gpu,update-check --exclude velesdb-python -- -D warnings -D clippy::pedantic` -- clean
- `cargo test -p velesdb-core --features persistence -- --test-threads=1` -- 4533 unit + 344 integration + all suites pass
- `cargo test -p velesdb-server --features persistence -- --test-threads=1` -- 124 lib + 73 api_integration + 10 auth_integration + all suites pass
- `cargo test -p velesdb-migrate -- --test-threads=1` -- 210 unit + 13 integration + 15 pipeline E2E pass
- `cargo test -p velesdb-core --features persistence test_recall_contract -- --test-threads=1` -- all four contracts (accurate >=0.99, balanced >=0.95, fast >=0.90, perfect =1.00) pass
- `cargo check -p velesdb-core --no-default-features` -- clean
- `cargo check -p velesdb-wasm --target wasm32-unknown-unknown` -- clean

## Out of scope (tracked for later sprints)

- **Sprint 2**: remaining spawn_blocking migrations for `batch_search`, `multi_query_search`, `search_ids`, graph, and admin handlers. The helper (`run_blocking_search`) is shipped in this PR so the migration is purely mechanical.
- **Sprint 2**: PATCH `/collections/{name}/index/params` endpoint for live tuning of `m` / `ef_construction` / `ef_search`. Requires a core refactor to support reconstruction with new parameters and is deliberately deferred.
- **Sprint 2**: populate `SourceSchema.metric` from connector-specific introspection responses (Qdrant `/collections/{name}`, Pinecone `describe_index`, Weaviate `/schema`, Milvus `describe_collection`, ChromaDB `/collections/{name}`). The pipeline check and the escape hatch are shipped; connectors that do not yet populate the field simply opt out of the check.
- **Post-seed EPIC**: true incremental streaming for `stream_traverse` (callback-based core API) and the full god-object split (F2.2 proper resolution). Both documented in `docs/ARCHITECTURE.md`.

## Test plan

- [x] Workspace builds under `persistence,gpu,update-check` (excluding velesdb-python)
- [x] Workspace builds under `--no-default-features`
- [x] WASM target builds clean
- [x] velesdb-core, velesdb-server, velesdb-migrate test suites all pass
- [x] Recall contracts hold across all four modes
- [x] `cargo fmt` and `cargo clippy -D pedantic` clean on the whole workspace
- [ ] CI green
- [ ] Devin Review returns no findings
- [ ] Codacy online returns no new findings

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/582" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
