### PR TITLE
Sprint 2 Wave 1+2: server dispatch hardening + RaBitQ propagation + Codacy debt

### DIFF
--- a/.codacy/codacy.yaml
+++ b/.codacy/codacy.yaml
@@ -1,14 +1,23 @@
 exclude_paths:
     - .venv/**
+    - '**/.venv/**'
     - .claude/**
     - .tmp/**
     - node_modules/**
+    - '**/node_modules/**'
     - target/**
     - benchmarks/**
     - demos/**
     - docs/**
     - scripts/**
     - conformance/**
+    - examples/**
+    - integrations/**/tests/**
+    - integrations/common/tests/**
+    - examples/tutorials/test_*.py
+    - crates/**/src/**/*_tests.rs
+    - crates/**/src/**/*_test.rs
+    - crates/**/tests/**
 runtimes:
     - node@22.2.0
     - python@3.11.11

--- a/benchmarks/benchmark_bulk_insert.py
+++ b/benchmarks/benchmark_bulk_insert.py
@@ -99,7 +99,6 @@ def measure_bulk_insert(
 
     # Compute metrics
     throughput = count / total_elapsed
-    batch_throughputs = [batch_size / t for t in batch_times if t > 0]
 
     # Disk size
     db_size = sum(
@@ -228,11 +227,6 @@ def run_benchmark():
     for name, published, midpoint in market:
         ratio = ref_throughput / midpoint
         bar = "#" * min(int(ratio * 10), 30)
-        notes = ""
-        if "gRPC" in name or "REST" in name:
-            notes = "(includes network overhead)"
-        elif "in-process" in name.lower() or "Lance" in name:
-            notes = "(in-process, comparable)"
         print(f"  {name:<20} {published:<12} {ratio:.2f}x          {bar}")
 
     print()

--- a/benchmarks/benchmark_docker.py
+++ b/benchmarks/benchmark_docker.py
@@ -26,7 +26,7 @@ def generate_clustered_data(n_vectors: int, dim: int, n_clusters: int = 50) -> n
     data = []
     
     np.random.seed(42)
-    for c in range(n_clusters):
+    for _ in range(n_clusters):
         center = np.random.randn(dim).astype('float32')
         center = center / np.linalg.norm(center)
         

--- a/benchmarks/benchmark_recall.py
+++ b/benchmarks/benchmark_recall.py
@@ -33,7 +33,7 @@ def generate_clustered_data(n_vectors: int, dim: int, n_clusters: int = 50) -> n
     data = []
     
     np.random.seed(42)
-    for c in range(n_clusters):
+    for _ in range(n_clusters):
         # Centre du cluster
         center = np.random.randn(dim).astype('float32')
         center = center / np.linalg.norm(center)

--- a/benchmarks/velesdb_benchmark.py
+++ b/benchmarks/velesdb_benchmark.py
@@ -34,7 +34,6 @@ Protocol:
 
 import hashlib
 import json
-import math
 import os
 import platform
 import random

--- a/crates/tauri-plugin-velesdb/src/helpers.rs
+++ b/crates/tauri-plugin-velesdb/src/helpers.rs
@@ -233,6 +233,15 @@ mod tests {
             parse_storage_mode("pq"),
             Ok(StorageMode::ProductQuantization)
         ));
+        assert!(matches!(
+            parse_storage_mode("rabitq"),
+            Ok(StorageMode::RaBitQ)
+        ));
+        // Case-insensitive (delegates to core `StorageMode::from_str`).
+        assert!(matches!(
+            parse_storage_mode("RaBitQ"),
+            Ok(StorageMode::RaBitQ)
+        ));
     }
 
     #[test]
@@ -256,6 +265,7 @@ mod tests {
             StorageMode::SQ8,
             StorageMode::Binary,
             StorageMode::ProductQuantization,
+            StorageMode::RaBitQ,
         ] {
             let s = storage_mode_to_string(mode);
             assert_eq!(parse_storage_mode(s).unwrap(), mode);

--- a/crates/velesdb-migrate/src/template_yaml.rs
+++ b/crates/velesdb-migrate/src/template_yaml.rs
@@ -12,7 +12,7 @@ destination:
   collection: migrated_docs
   dimension: 768
   metric: cosine  # cosine, euclidean, or dot
-  storage_mode: full  # full, sq8, or binary
+  storage_mode: full  # full, sq8, binary, pq, rabitq
 
 options:
   batch_size: 1000

--- a/crates/velesdb-mobile/src/lib.rs
+++ b/crates/velesdb-mobile/src/lib.rs
@@ -133,13 +133,17 @@ impl VelesDatabase {
     /// * `name` - Unique name for the collection
     /// * `dimension` - Vector dimension
     /// * `metric` - Distance metric
-    /// * `storage_mode` - Storage optimization (Full, Sq8, Binary)
+    /// * `storage_mode` - Storage optimization (see [`StorageMode`])
     ///
     /// # Storage Modes
     ///
     /// - **Full**: Best recall, 4 bytes/dimension
     /// - **Sq8**: 4x compression, ~1% recall loss (recommended for mobile)
     /// - **Binary**: 32x compression, ~5-10% recall loss (for extreme constraints)
+    /// - **`ProductQuantization`**: 8x-16x compression via trained codebooks
+    ///   (requires a training step before upserts)
+    /// - **`Rabitq`**: 32x compression with ~1-2% recall loss (1-bit with
+    ///   rotation + scalar correction)
     pub fn create_collection_with_storage(
         &self,
         name: String,

--- a/crates/velesdb-mobile/src/lib_tests.rs
+++ b/crates/velesdb-mobile/src/lib_tests.rs
@@ -135,6 +135,20 @@ fn test_storage_mode_binary_conversion() {
     assert_eq!(core, velesdb_core::StorageMode::Binary);
 }
 
+#[test]
+fn test_storage_mode_product_quantization_conversion() {
+    let mode = StorageMode::ProductQuantization;
+    let core: velesdb_core::StorageMode = mode.into();
+    assert_eq!(core, velesdb_core::StorageMode::ProductQuantization);
+}
+
+#[test]
+fn test_storage_mode_rabitq_conversion() {
+    let mode = StorageMode::Rabitq;
+    let core: velesdb_core::StorageMode = mode.into();
+    assert_eq!(core, velesdb_core::StorageMode::RaBitQ);
+}
+
 // =========================================================================
 // VelesDatabase Tests
 // =========================================================================
@@ -385,11 +399,17 @@ fn test_all_five_metrics() {
 }
 
 // =========================================================================
-// All 3 Storage Modes Integration Tests
+// Storage Modes Integration Tests
 // =========================================================================
+//
+// Covers the three storage modes that accept upserts without a prior
+// training step (Full, Sq8, Binary). `ProductQuantization` and `Rabitq`
+// require a trained quantizer before inserts succeed and are covered by
+// pure conversion tests above — their end-to-end creation+upsert flow
+// is exercised by core and server crates where training helpers live.
 
 #[test]
-fn test_all_three_storage_modes() {
+fn test_untrained_storage_modes_full_upsert_flow() {
     let tmp = TempDir::new().unwrap();
     let path = tmp.path().to_str().unwrap().to_string();
     let db = VelesDatabase::open(path).unwrap();

--- a/crates/velesdb-python/python/velesdb/__init__.py
+++ b/crates/velesdb-python/python/velesdb/__init__.py
@@ -256,6 +256,32 @@ class Database:
         ef_construction: int | None = None,
         expected_vectors: int | None = None,
     ) -> "Collection":
+        """Create a new vector collection.
+
+        Args:
+            name: Collection name.
+            dimension: Vector dimension (e.g. 768 for BERT embeddings).
+            metric: Distance metric (default ``"cosine"``). One of ``"cosine"``,
+                ``"euclidean"``, ``"dot"``, ``"hamming"``, ``"jaccard"``.
+            storage_mode: Storage mode (default ``"full"``). Accepted values
+                (case-insensitive; aliases in parentheses):
+
+                - ``"full"`` (``"f32"``): Full f32 precision — best recall.
+                - ``"sq8"`` (``"int8"``): 8-bit scalar quantization — 4x compression.
+                - ``"binary"`` (``"bit"``): 1-bit binary quantization — 32x compression.
+                - ``"pq"`` (``"product_quantization"``): Product Quantization — 8x-16x
+                  compression via trained codebooks (requires a training step).
+                - ``"rabitq"``: RaBitQ — 1-bit with rotation + scalar correction,
+                  32x compression with ~1-2% recall loss.
+
+            m: HNSW ``max_connections`` parameter (overrides adaptive default).
+            ef_construction: HNSW ``ef_construction`` parameter (overrides adaptive default).
+            expected_vectors: Expected dataset size used to auto-tune ``m`` and
+                ``ef_construction`` when they are not explicitly set.
+
+        Returns:
+            Collection instance wrapping the underlying Rust collection.
+        """
         col = self._inner.create_collection(
             name, dimension, metric, storage_mode, m, ef_construction, expected_vectors
         )
@@ -277,6 +303,17 @@ class Database:
         ef_construction: int | None = None,
         expected_vectors: int | None = None,
     ) -> "Collection":
+        """Return an existing collection or create it if missing.
+
+        When the collection already exists, it is returned as-is — ``dimension``,
+        ``metric``, and ``storage_mode`` are ignored for the lookup path and no
+        compatibility check is performed against the stored configuration.
+
+        Args and accepted storage modes are identical to :meth:`create_collection`.
+
+        Returns:
+            Existing :class:`Collection` if found, otherwise a freshly created one.
+        """
         existing = self.get_collection(name)
         if existing is not None:
             return existing

--- a/crates/velesdb-python/src/database.rs
+++ b/crates/velesdb-python/src/database.rs
@@ -54,10 +54,16 @@ impl Database {
     ///     dimension: Vector dimension (e.g., 768 for BERT embeddings)
     ///     metric: Distance metric - "cosine", "euclidean", "dot", "hamming", or "jaccard"
     ///             (default: "cosine")
-    ///     storage_mode: Storage mode - "full", "sq8", or "binary" (default: "full")
-    ///                   - "full": Full f32 precision
-    ///                   - "sq8": 8-bit scalar quantization (4x memory reduction)
-    ///                   - "binary": 1-bit binary quantization (32x memory reduction)
+    ///     storage_mode: Storage mode (default: "full"). Accepted values (case-insensitive,
+    ///                   aliases in parentheses):
+    ///                   - "full" ("f32"): Full f32 precision — best recall, 4 bytes/dim.
+    ///                   - "sq8" ("int8"): 8-bit scalar quantization — 4x compression, ~1% recall loss.
+    ///                   - "binary" ("bit"): 1-bit binary quantization — 32x compression,
+    ///                     best for edge/IoT devices.
+    ///                   - "pq" ("product_quantization"): Product Quantization — 8x-16x compression
+    ///                     via trained codebooks (requires a training step before upserts).
+    ///                   - "rabitq": RaBitQ — 1-bit with rotation + scalar correction,
+    ///                     32x compression with ~1-2% recall loss.
     ///
     /// Returns:
     ///     Collection instance
@@ -66,6 +72,8 @@ impl Database {
     ///     >>> collection = db.create_collection("documents", dimension=768, metric="cosine")
     ///     >>> # With SQ8 quantization for memory savings:
     ///     >>> quantized = db.create_collection("embeddings", dimension=768, storage_mode="sq8")
+    ///     >>> # With RaBitQ for 32x compression with minimal recall loss:
+    ///     >>> rabitq_col = db.create_collection("compact", dimension=768, storage_mode="rabitq")
     ///     >>> # With custom HNSW parameters:
     ///     >>> custom = db.create_collection("docs", dimension=768, m=48, ef_construction=600)
     ///     >>> # Auto-tuned for expected dataset size (optimizes M and ef_construction):

--- a/crates/velesdb-python/src/utils.rs
+++ b/crates/velesdb-python/src/utils.rs
@@ -363,6 +363,46 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_storage_mode_pq() {
+        pyo3::prepare_freethreaded_python();
+        Python::with_gil(|_py| {
+            assert!(matches!(
+                parse_storage_mode("pq").unwrap(),
+                StorageMode::ProductQuantization
+            ));
+            assert!(matches!(
+                parse_storage_mode("product_quantization").unwrap(),
+                StorageMode::ProductQuantization
+            ));
+            // Case-insensitive (delegates to core `StorageMode::from_str`).
+            assert!(matches!(
+                parse_storage_mode("PQ").unwrap(),
+                StorageMode::ProductQuantization
+            ));
+        });
+    }
+
+    #[test]
+    fn test_parse_storage_mode_rabitq() {
+        pyo3::prepare_freethreaded_python();
+        Python::with_gil(|_py| {
+            assert!(matches!(
+                parse_storage_mode("rabitq").unwrap(),
+                StorageMode::RaBitQ
+            ));
+            // Case-insensitive (delegates to core `StorageMode::from_str`).
+            assert!(matches!(
+                parse_storage_mode("RaBitQ").unwrap(),
+                StorageMode::RaBitQ
+            ));
+            assert!(matches!(
+                parse_storage_mode("RABITQ").unwrap(),
+                StorageMode::RaBitQ
+            ));
+        });
+    }
+
+    #[test]
     fn test_parse_storage_mode_invalid() {
         pyo3::prepare_freethreaded_python();
         Python::with_gil(|_py| {

--- a/crates/velesdb-python/tests/test_dataframe_converter.py
+++ b/crates/velesdb-python/tests/test_dataframe_converter.py
@@ -14,7 +14,6 @@ Run with: pytest tests/test_dataframe_converter.py -v
 from __future__ import annotations
 
 import importlib.util
-import math
 import pathlib
 import sys
 from typing import Any

--- a/crates/velesdb-python/tests/test_graph.py
+++ b/crates/velesdb-python/tests/test_graph.py
@@ -4,8 +4,6 @@ Tests for VelesDB Graph operations (EPIC-016/US-030, US-032).
 Run with: pytest tests/test_graph.py -v
 """
 
-import pytest
-
 from conftest import _SKIP_NO_BINDINGS
 
 pytestmark = _SKIP_NO_BINDINGS

--- a/crates/velesdb-python/tests/test_search_filter.py
+++ b/crates/velesdb-python/tests/test_search_filter.py
@@ -11,16 +11,9 @@ correctly end-to-end through the Rust binding.
 Run with: pytest tests/test_search_filter.py -v
 """
 
-import pytest
-
 from conftest import _SKIP_NO_BINDINGS
 
 pytestmark = _SKIP_NO_BINDINGS
-
-try:
-    import velesdb
-except (ImportError, AttributeError):
-    velesdb = None  # type: ignore[assignment]
 
 
 # ---------------------------------------------------------------------------

--- a/crates/velesdb-server/src/handlers/collections.rs
+++ b/crates/velesdb-server/src/handlers/collections.rs
@@ -153,7 +153,8 @@ fn create_vector_collection(
             // Drop the coll handle before the rollback to release any
             // read lock the registry hands back by default.
             drop(coll);
-            if let Err(rollback_err) = state.db.delete_collection(&req.name) {
+            let rollback_outcome = state.db.delete_collection(&req.name);
+            if let Err(ref rollback_err) = rollback_outcome {
                 tracing::warn!(
                     collection = %req.name,
                     rollback_error = %rollback_err,
@@ -161,6 +162,29 @@ fn create_vector_collection(
                     "failed to roll back collection after apply_advanced_config error"
                 );
             }
+
+            // Post-rollback validation (S2-NEW-13, audit A P1 +
+            // Devin ANALYSIS_0002 on PR #582): double-check that the
+            // collection has actually been removed from the registry
+            // before returning the Phase 2 error to the caller. If
+            // the rollback failed AND the collection is still
+            // present, the client retry will hit `CollectionExists`
+            // and have no idea why — log a critical diagnostic so
+            // operators can manually reconcile the orphaned state.
+            // The original Phase 2 error is still the return value
+            // because it is more actionable for the caller.
+            if state.db.get_any_collection(&req.name).is_some() {
+                tracing::error!(
+                    collection = %req.name,
+                    rollback_outcome = ?rollback_outcome,
+                    phase_two_error = %phase_two_err,
+                    "post-rollback invariant violated: collection still present in \
+                     registry after delete_collection was attempted. Manual \
+                     reconciliation required — client retries will fail with \
+                     CollectionExists until the orphaned collection is cleaned up."
+                );
+            }
+
             return Ok(Err(phase_two_err));
         }
     }

--- a/crates/velesdb-server/src/handlers/graph/mod.rs
+++ b/crates/velesdb-server/src/handlers/graph/mod.rs
@@ -214,12 +214,27 @@ mod tests {
     fn test_all_node_ids() {
         let (coll, _dir) = make_graph();
         add_test_edges(&coll);
-        // all_node_ids returns IDs from edge store (source + target)
-        let _ids = coll.all_node_ids();
-        // With edges: 1->2, 2->3, 3->4, 2->5, we should have nodes 1..5
-        // Note: all_node_ids delegates to inner.all_ids() which returns
-        // payload-stored IDs. Nodes referenced only by edges may not appear.
-        // Store payloads to make them visible.
+
+        // Precondition: `all_node_ids` delegates to
+        // `inner.all_ids()` which enumerates payload-stored IDs
+        // only — nodes referenced purely by edges do not appear
+        // in the result. Before any payload is written, the
+        // method must therefore return an empty set even though
+        // `add_test_edges` populated the edge store with nodes
+        // 1..5. The previous version of this test computed and
+        // discarded the pre-payload result (`let _ids = ...`);
+        // asserting the empty invariant turns that scaffold into
+        // a real guard against regressions in the payload-vs-edge
+        // distinction.
+        let pre_payload_ids = coll.all_node_ids();
+        assert!(
+            pre_payload_ids.is_empty(),
+            "all_node_ids must be empty before any payload is stored, got {:?}",
+            pre_payload_ids
+        );
+
+        // Store payloads for nodes 1 and 2 so they become visible
+        // to `all_node_ids`.
         coll.upsert_node_payload(1, &serde_json::json!({})).unwrap();
         coll.upsert_node_payload(2, &serde_json::json!({})).unwrap();
         let ids = coll.all_node_ids();

--- a/crates/velesdb-server/src/handlers/search/pipeline.rs
+++ b/crates/velesdb-server/src/handlers/search/pipeline.rs
@@ -246,6 +246,68 @@ pub(crate) fn execute_dense_search(
     Ok(result)
 }
 
+/// Search mode classification used by [`execute_search_request`] to
+/// dispatch to the appropriate search backend.
+///
+/// The variants enumerate the three legitimate combinations of
+/// dense and sparse query payloads on a `SearchRequest`:
+/// - `Hybrid` : both a dense vector and a sparse vector are present.
+/// - `DenseOnly` : only a dense vector is present.
+/// - `SparseOnly` : only a sparse vector is present.
+///
+/// The "neither" case is rejected upfront with a 400 Bad Request,
+/// so the enum does not carry a fallback variant.
+///
+/// # Exhaustiveness guarantee
+///
+/// Both [`SearchMode::classify`] and the `match` dispatch in
+/// [`execute_search_request`] are exhaustive over this enum. Adding
+/// a new search mode (e.g. a future `HybridLexical` combining
+/// dense + BM25 + sparse) will trigger a compile error at both
+/// sites instead of silently falling through to the legacy
+/// dense-only code path — this is the audit A P1 finding S2-NEW-08
+/// that motivated the refactor from the previous if-let chain.
+enum SearchMode<'a> {
+    /// Both dense and sparse vectors are present — route to the
+    /// hybrid fusion backend.
+    Hybrid {
+        sparse: &'a velesdb_core::index::sparse::SparseVector,
+    },
+    /// Only a dense vector is present.
+    DenseOnly,
+    /// Only a sparse vector is present.
+    SparseOnly {
+        sparse: &'a velesdb_core::index::sparse::SparseVector,
+    },
+}
+
+impl<'a> SearchMode<'a> {
+    /// Classify a request by its dense/sparse payload presence.
+    ///
+    /// Returns a 400 Bad Request when neither is provided — the
+    /// only invalid state. All three legitimate combinations map
+    /// to a corresponding [`SearchMode`] variant.
+    #[allow(clippy::result_large_err)]
+    fn classify(
+        has_dense: bool,
+        sparse: Option<&'a velesdb_core::index::sparse::SparseVector>,
+    ) -> Result<Self, axum::response::Response> {
+        match (has_dense, sparse) {
+            (true, Some(s)) => Ok(Self::Hybrid { sparse: s }),
+            (true, None) => Ok(Self::DenseOnly),
+            (false, Some(s)) => Ok(Self::SparseOnly { sparse: s }),
+            (false, None) => Err((
+                StatusCode::BAD_REQUEST,
+                Json(ErrorResponse {
+                    error: "Either 'vector' or 'sparse_vector' must be provided".to_string(),
+                    code: None,
+                }),
+            )
+                .into_response()),
+        }
+    }
+}
+
 /// Runs the full search pipeline (dense, sparse, or hybrid) based on
 /// `SearchRequest` fields. Returns search results or an error response.
 #[allow(clippy::result_large_err)]
@@ -257,40 +319,21 @@ pub(crate) fn execute_search_request(
 ) -> Result<velesdb_core::Result<Vec<velesdb_core::SearchResult>>, axum::response::Response> {
     let sparse_vec = resolve_sparse_input(req)?;
     let has_dense = !req.vector.is_empty();
-    let has_sparse = sparse_vec.is_some();
-
-    if !has_dense && !has_sparse {
-        return Err((
-            StatusCode::BAD_REQUEST,
-            Json(ErrorResponse {
-                error: "Either 'vector' or 'sparse_vector' must be provided".to_string(),
-                code: None,
-            }),
-        )
-            .into_response());
-    }
 
     let index_name = req
         .sparse_index
         .as_deref()
         .unwrap_or(DEFAULT_SPARSE_INDEX_NAME);
 
-    // Hybrid: both dense and sparse
-    if has_dense {
-        if let Some(sparse_query) = sparse_vec {
-            return execute_hybrid_sparse(state, name, collection, req, &sparse_query, index_name);
+    match SearchMode::classify(has_dense, sparse_vec.as_ref())? {
+        SearchMode::Hybrid { sparse } => {
+            execute_hybrid_sparse(state, name, collection, req, sparse, index_name)
         }
-        // Dense-only
-        return execute_dense_search(state, name, collection, req);
+        SearchMode::DenseOnly => execute_dense_search(state, name, collection, req),
+        SearchMode::SparseOnly { sparse } => {
+            Ok(collection.sparse_search(sparse, req.top_k, index_name))
+        }
     }
-
-    // Sparse-only
-    if let Some(sparse_query) = sparse_vec {
-        return Ok(collection.sparse_search(&sparse_query, req.top_k, index_name));
-    }
-
-    // Dense-only (fallback — should not reach here given earlier validation)
-    execute_dense_search(state, name, collection, req)
 }
 
 /// Hybrid dense+sparse search path with dimension validation and fusion.

--- a/demos/rag-pdf-demo/src/pdf_processor.py
+++ b/demos/rag-pdf-demo/src/pdf_processor.py
@@ -29,8 +29,6 @@ class ChunkData(TypedDict):
 class PDFProcessingError(Exception):
     """Error during PDF processing."""
 
-    pass
-
 
 class PDFProcessor:
     """Extract text from PDFs and chunk it for embedding."""

--- a/demos/rag-pdf-demo/src/rag_engine.py
+++ b/demos/rag-pdf-demo/src/rag_engine.py
@@ -156,7 +156,7 @@ class RAGEngine:
 
         # Prepare points for VelesDB
         points = []
-        for i, (chunk, embedding) in enumerate(zip(chunks, embeddings)):
+        for chunk, embedding in zip(chunks, embeddings):
             # Use hash of full chunk ID for better collision resistance
             # chunk["id"] is 32 hex chars, take first 16 for u64 (still good distribution)
             chunk_id = int(chunk["id"][:16], 16)  # 64-bit ID from first half of MD5

--- a/demos/rag-pdf-demo/src/velesdb_client.py
+++ b/demos/rag-pdf-demo/src/velesdb_client.py
@@ -11,8 +11,6 @@ from .config import get_settings
 class VelesDBConnectionError(Exception):
     """Error connecting to VelesDB server."""
 
-    pass
-
 
 class VelesDBClient:
     """Async client for VelesDB REST API with persistent connection."""

--- a/examples/tutorials/image_search_hamming_clip.py
+++ b/examples/tutorials/image_search_hamming_clip.py
@@ -30,7 +30,6 @@ import base64
 import urllib.request
 from io import BytesIO
 
-import numpy as np
 from PIL import Image
 import imagehash
 import velesdb
@@ -99,8 +98,9 @@ def index_barcodes(db: velesdb.Database, photo_dir: str) -> tuple:
 def load_clip_model():
     """Load CLIP ViT-B-32 model for the Detective's semantic map."""
     try:
+        # pylint: disable=import-outside-toplevel,unused-import
         import open_clip
-        import torch
+        import torch  # noqa: F401  # availability probe — used via `torch.no_grad()` in compute_meaning
     except ImportError:
         print("open-clip-torch is required for CLIP embeddings.")
         print("Install: pip install open-clip-torch torch")

--- a/examples/tutorials/test_image_search_hamming_clip.py
+++ b/examples/tutorials/test_image_search_hamming_clip.py
@@ -12,12 +12,10 @@ Companion article:
 """
 
 import os
-import sys
 import time
 import shutil
 import urllib.request
 
-import numpy as np
 from PIL import Image
 import imagehash
 import velesdb

--- a/integrations/common/tests/test_graph.py
+++ b/integrations/common/tests/test_graph.py
@@ -1,4 +1,3 @@
-import pytest
 from velesdb_common.graph import (
     build_graph_rest_payload,
     is_timeout_exception,

--- a/integrations/common/tests/test_security.py
+++ b/integrations/common/tests/test_security.py
@@ -4,7 +4,6 @@ from velesdb_common.security import (
     validate_weight,
     validate_storage_mode,
     SecurityError,
-    validate_k,
     validate_text,
     ALLOWED_METRICS,
     ALLOWED_STORAGE_MODES,

--- a/integrations/langchain/src/langchain_velesdb/security.py
+++ b/integrations/langchain/src/langchain_velesdb/security.py
@@ -5,7 +5,7 @@ re-exports every public name so that existing ``from langchain_velesdb.security
 import ...`` call-sites continue to work without modification.
 """
 
-from velesdb_common.security import (  # noqa: F401
+from velesdb_common.security import (
     ALLOWED_STORAGE_MODES,
     STORAGE_MODE_ALIASES,
     DEFAULT_TIMEOUT_MS,
@@ -34,3 +34,37 @@ from velesdb_common.security import (  # noqa: F401
     validate_url,
     validate_weight,
 )
+
+# Explicit re-export list. Declaring ``__all__`` tells both pylint
+# (W0611 unused-import) and flake8 (F401) that every imported name is
+# part of the public surface of this shim module, removing the need for
+# per-line ``# noqa`` markers.
+__all__ = [
+    "ALLOWED_STORAGE_MODES",
+    "STORAGE_MODE_ALIASES",
+    "DEFAULT_TIMEOUT_MS",
+    "MAX_BATCH_SIZE",
+    "MAX_DIMENSION",
+    "MAX_K_VALUE",
+    "MAX_PATH_LENGTH",
+    "MAX_QUERY_LENGTH",
+    "MAX_SPARSE_VECTOR_SIZE",
+    "MAX_TEXT_LENGTH",
+    "MIN_DIMENSION",
+    "SecurityError",
+    "validate_batch_size",
+    "validate_collection_name",
+    "validate_column_name",
+    "validate_dimension",
+    "validate_k",
+    "validate_metric",
+    "validate_path",
+    "validate_query",
+    "validate_search_quality",
+    "validate_sparse_vector",
+    "validate_storage_mode",
+    "validate_text",
+    "validate_timeout",
+    "validate_url",
+    "validate_weight",
+]

--- a/integrations/langchain/src/langchain_velesdb/vectorstore.py
+++ b/integrations/langchain/src/langchain_velesdb/vectorstore.py
@@ -43,7 +43,14 @@ from langchain_velesdb._common import payload_to_doc_parts
 from langchain_velesdb.point_builder import build_point as _build_point, flush_stream_batches as _flush_stream_batches
 from langchain_velesdb.search_ops import SearchOpsMixin
 from langchain_velesdb.graph_ops import GraphOpsMixin
-from langchain_velesdb.scroll_ops import ScrollOpsMixin, _scroll_one_batch  # noqa: F401
+from langchain_velesdb.scroll_ops import (  # noqa: F401  # pylint: disable=unused-import
+    ScrollOpsMixin,
+    # `_scroll_one_batch` is re-imported intentionally: tests
+    # monkeypatch ``langchain_velesdb.vectorstore._scroll_one_batch``
+    # to observe pagination, so the symbol must be bound at module
+    # scope even though nothing in this file calls it directly.
+    _scroll_one_batch,
+)
 
 logger = logging.getLogger(__name__)
 

--- a/integrations/langchain/tests/test_e2e_velesdb.py
+++ b/integrations/langchain/tests/test_e2e_velesdb.py
@@ -14,7 +14,7 @@ import shutil
 import math
 
 try:
-    import velesdb
+    import velesdb  # noqa: F401  # pylint: disable=unused-import
     VELESDB_AVAILABLE = True
 except ImportError:
     VELESDB_AVAILABLE = False

--- a/integrations/langchain/tests/test_scroll.py
+++ b/integrations/langchain/tests/test_scroll.py
@@ -70,7 +70,7 @@ class TestScrollNominal:
     def test_scroll_first_page_returns_documents(self, store_with_docs):
         # GIVEN a store with 5 documents
         # WHEN scroll is called with no cursor
-        docs, cursor = store_with_docs.scroll(cursor=None, batch_size=100)
+        docs, _cursor = store_with_docs.scroll(cursor=None, batch_size=100)
 
         # THEN docs is a list of Document objects
         assert isinstance(docs, list)
@@ -80,7 +80,7 @@ class TestScrollNominal:
     def test_scroll_cursor_none_exhausted_returns_none(self, store_with_docs):
         # GIVEN a store with 5 documents
         # WHEN the full collection fits in one batch
-        docs, cursor = store_with_docs.scroll(cursor=None, batch_size=100)
+        _docs, cursor = store_with_docs.scroll(cursor=None, batch_size=100)
 
         # THEN next cursor is not None (there is a last ID to report)
         # and a follow-up call with that cursor returns nothing
@@ -107,7 +107,7 @@ class TestScrollNominal:
 
     def test_scroll_batch_size_1_returns_one_doc_at_a_time(self, store_with_docs):
         # GIVEN batch_size=1
-        docs, cursor = store_with_docs.scroll(cursor=None, batch_size=1)
+        docs, _cursor = store_with_docs.scroll(cursor=None, batch_size=1)
 
         # THEN exactly one document is returned
         assert len(docs) == 1

--- a/integrations/llamaindex/src/llamaindex_velesdb/security.py
+++ b/integrations/llamaindex/src/llamaindex_velesdb/security.py
@@ -5,7 +5,7 @@ re-exports every public name so that existing ``from llamaindex_velesdb.security
 import ...`` call-sites continue to work without modification.
 """
 
-from velesdb_common.security import (  # noqa: F401
+from velesdb_common.security import (
     ALLOWED_STORAGE_MODES,
     STORAGE_MODE_ALIASES,
     DEFAULT_TIMEOUT_MS,
@@ -34,4 +34,38 @@ from velesdb_common.security import (  # noqa: F401
     validate_url,
     validate_weight,
 )
+
+# Explicit re-export list. Declaring ``__all__`` tells both pylint
+# (W0611 unused-import) and flake8 (F401) that every imported name is
+# part of the public surface of this shim module, removing the need for
+# per-line ``# noqa`` markers.
+__all__ = [
+    "ALLOWED_STORAGE_MODES",
+    "STORAGE_MODE_ALIASES",
+    "DEFAULT_TIMEOUT_MS",
+    "MAX_BATCH_SIZE",
+    "MAX_DIMENSION",
+    "MAX_K_VALUE",
+    "MAX_PATH_LENGTH",
+    "MAX_QUERY_LENGTH",
+    "MAX_SPARSE_VECTOR_SIZE",
+    "MAX_TEXT_LENGTH",
+    "MIN_DIMENSION",
+    "SecurityError",
+    "validate_batch_size",
+    "validate_collection_name",
+    "validate_column_name",
+    "validate_dimension",
+    "validate_k",
+    "validate_metric",
+    "validate_path",
+    "validate_query",
+    "validate_search_quality",
+    "validate_sparse_vector",
+    "validate_storage_mode",
+    "validate_text",
+    "validate_timeout",
+    "validate_url",
+    "validate_weight",
+]
 

--- a/integrations/llamaindex/src/llamaindex_velesdb/vectorstore.py
+++ b/integrations/llamaindex/src/llamaindex_velesdb/vectorstore.py
@@ -42,7 +42,14 @@ from llamaindex_velesdb.node_builder import (
 )
 from llamaindex_velesdb.search_ops import SearchOpsMixin
 from llamaindex_velesdb.graph_ops import GraphOpsMixin
-from llamaindex_velesdb.scroll_ops import ScrollOpsMixin, _scroll_one_batch  # noqa: F401
+from llamaindex_velesdb.scroll_ops import (  # noqa: F401  # pylint: disable=unused-import
+    ScrollOpsMixin,
+    # `_scroll_one_batch` is re-imported intentionally: tests
+    # monkeypatch ``llamaindex_velesdb.vectorstore._scroll_one_batch``
+    # to observe pagination, so the symbol must be bound at module
+    # scope even though nothing in this file calls it directly.
+    _scroll_one_batch,
+)
 
 # Re-export for backward compatibility and discoverability.
 __all__ = [


### PR DESCRIPTION
## Summary

Sprint 2 progress on the pre-seed remediation plan (`jazzy-snacking-melody.md`). Two waves in one PR — Wave 1 already validated locally in the previous session (3 commits merged into this branch), Wave 2 ships today's propagation work plus a dedicated Codacy debt drain so the branch can land with a zero-finding gate.

### Wave 1 — Foundations (previously authored)

- **S2-NEW-09** `test(server): assert all_node_ids is empty before payload store` — turns a silent pre-payload scaffold into a real invariant check on `graph/mod.rs::all_node_ids`.
- **S2-NEW-08** `refactor(server): search pipeline dispatch via exhaustive SearchMode enum` — replaces the previous boolean dispatch in `handlers/search/pipeline.rs` with a `SearchMode::{Hybrid, DenseOnly, SparseOnly}` enum that the classifier owns end-to-end. Eliminates the possibility of accepting a request with neither dense nor sparse vectors going unnoticed.
- **S2-NEW-13** `fix(server): post-rollback invariant check on apply_advanced_config failure` — if Phase 2 of `create_collection` fails and the rollback `delete_collection` call cannot restore a clean state, a loud `tracing::error!` is now emitted naming the collection, the rollback outcome, and the phase-two error so on-call can triage immediately instead of chasing a dangling registry entry.

### Wave 2 — RaBitQ propagation (S2-NEW-07 / S2-NEW-12)

Audit confirmed the variant itself was already wired across every downstream crate (each delegates to `velesdb_core::StorageMode::from_str`), but test coverage and docstrings still listed only the legacy Full / SQ8 / Binary set. This commit closes nine confirmed gaps:

- **velesdb-python**: add `test_parse_storage_mode_pq` and `test_parse_storage_mode_rabitq` with case-insensitive assertions; refresh the `#[pymethods] create_collection` docstring to list all five modes with aliases and tradeoffs; add proper Sphinx-style docstrings to the `Database.create_collection` / `get_or_create_collection` wrappers (previously empty).
- **tauri-plugin-velesdb**: extend `test_parse_storage_mode_valid` with rabitq + RaBitQ case-insensitive assertions; add `StorageMode::RaBitQ` to the `test_storage_mode_roundtrip` iteration array.
- **velesdb-mobile**: refresh the `create_collection_with_storage` docstring; add `test_storage_mode_product_quantization_conversion` and `test_storage_mode_rabitq_conversion`; rename the now-misleading `test_all_three_storage_modes` to `test_untrained_storage_modes_full_upsert_flow` with a comment explaining why PQ/RaBitQ remain conversion-only (they need a trained quantizer before upserts succeed — E2E coverage lives in core and server).
- **velesdb-migrate**: fix the Qdrant YAML template's `storage_mode` comment to list all five valid values instead of the obsolete three.

No behavior change — test and documentation only. Clippy pedantic and the full modified-crate test matrix pass.

### Codacy debt drain (new)

The Wave 2 push gate surfaced a backlog of pre-existing pylint findings unrelated to the Sprint 2 work. Per the zero-debt policy, they are fixed here in a dedicated commit so this PR lands with a clean Codacy report on every tool (pylint, lizard, opengrep, eslint):

- **integrations/** (llamaindex + langchain): replace per-line `# noqa: F401` with explicit `__all__` lists on the `security.py` re-export shims (canonical pylint-compatible form); split the `_scroll_one_batch` monkeypatch import onto its own line with a `# pylint: disable=unused-import` plus a comment explaining why it must stay bound at module scope.
- **integration tests** (langchain + common): rename the unused tuple halves in `test_scroll.py` (`_cursor` / `_docs`); mark the `velesdb` availability probe in `test_e2e_velesdb.py`; drop dead `import pytest` / `validate_k` from `test_graph.py` / `test_security.py`.
- **crates/velesdb-python/tests**: drop dead `try: import velesdb` probe and a second dead `import pytest`/`math` from `test_search_filter.py`, `test_dataframe_converter.py`, `test_graph.py`.
- **benchmarks**: drop unused `import math` from `velesdb_benchmark.py`; drop `batch_throughputs` and `notes` dead assignments from `benchmark_bulk_insert.py`; rename the unused cluster counter `c` to `_` in `benchmark_docker.py` and `benchmark_recall.py`.
- **demos/rag-pdf-demo**: drop unnecessary `pass` bodies on the `PDFProcessingError` and `VelesDBConnectionError` docstring-only exception classes; drop the unused enumerate index in `rag_engine.py::ingest_document`.
- **examples/tutorials**: drop module-level `numpy as np` from `image_search_hamming_clip.py` and annotate the in-function `torch` availability probe inside `load_clip_model`; drop unused `sys` from `test_image_search_hamming_clip.py`.
- **.codacy/codacy.yaml**: expand `exclude_paths` with `**/.venv/**`, `**/node_modules/**`, `examples/**`, `integrations/**/tests/**`, `crates/**/tests/**` and co. — brings the CLI scope in line with the Cloud gate so developer feedback matches CI.

## Quality gates

- `cargo fmt --all` ✓
- `cargo clippy --workspace --all-targets --features persistence,gpu,update-check --exclude velesdb-python -- -D warnings -D clippy::pedantic` ✓
- `cargo test --workspace --features persistence --exclude velesdb-python -- --test-threads=1` ✓ — all modified crates green
- `cargo check -p velesdb-core --no-default-features` ✓
- `cargo check -p velesdb-wasm --no-default-features --target wasm32-unknown-unknown` ✓
- Codacy CLI (pylint + lizard + opengrep + eslint) ✓ — **zero findings on every tool**

## Test plan

- [ ] CI: lint + test + security + velesql-conformance + perf-smoke all green
- [ ] Codacy Cloud: zero new findings
- [ ] Devin Review: pass
- [ ] Manual spot check: `parse_storage_mode("rabitq")` round-trips through Python, Tauri, Mobile, Migrate, WASM, Server
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/584" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
