### PR TITLE
Sprint 2 Waves 5+6+7: Tauri parity + CLI scroll/batch-search/stream-insert

### DIFF
--- a/crates/tauri-plugin-velesdb/build.rs
+++ b/crates/tauri-plugin-velesdb/build.rs
@@ -23,6 +23,7 @@ const COMMANDS: &[&str] = &[
     "get_collection",
     "is_empty",
     "flush",
+    "scroll_collection",
     // Point operations
     "upsert",
     "upsert_metadata",
@@ -35,15 +36,28 @@ const COMMANDS: &[&str] = &[
     "hybrid_search",
     "multi_query_search",
     "query",
-    // AgentMemory (semantic)
+    // AgentMemory (semantic, episodic, procedural)
     "semantic_store",
     "semantic_query",
+    "episodic_record",
+    "episodic_recent",
+    "procedural_learn",
+    "procedural_recall",
     // Knowledge Graph
+    "create_graph_collection",
     "add_edge",
     "get_edges",
     "traverse_graph",
     "get_node_degree",
     "traverse_graph_parallel",
+    // Sparse vector operations
+    "sparse_search",
+    "hybrid_sparse_search",
+    "sparse_upsert",
+    // PQ training
+    "train_pq",
+    // Streaming insert (persistence only)
+    "stream_insert",
     // Secondary Indexes
     "create_index",
     "drop_index",

--- a/crates/tauri-plugin-velesdb/guest-js/index.ts
+++ b/crates/tauri-plugin-velesdb/guest-js/index.ts
@@ -31,7 +31,11 @@ import { invoke } from '@tauri-apps/api/core';
 /** Distance metric for vector similarity. */
 export type DistanceMetric = 'cosine' | 'euclidean' | 'dot' | 'hamming' | 'jaccard';
 
-/** Request to create a new collection. */
+/** Storage mode for vector compression. */
+export type StorageMode = 'full' | 'sq8' | 'binary' | 'pq' | 'rabitq';
+
+
+/** Request to create a new vector collection. */
 export interface CreateCollectionRequest {
   /** Collection name (unique identifier). */
   name: string;
@@ -39,6 +43,30 @@ export interface CreateCollectionRequest {
   dimension: number;
   /** Distance metric for similarity calculations. Default: 'cosine'. */
   metric?: DistanceMetric;
+  /** Storage mode for vector compression. Default: 'full'. */
+  storageMode?: StorageMode;
+  /** HNSW M parameter (max connections per node). Auto-tuned if omitted. */
+  hnswM?: number;
+  /** HNSW ef_construction parameter. Auto-tuned if omitted. */
+  hnswEfConstruction?: number;
+  /** HNSW alpha for neighbor diversification. Default: 1.2. */
+  hnswAlpha?: number;
+  /** HNSW initial max elements capacity. Auto-tuned if omitted. */
+  hnswMaxElements?: number;
+  /** PQ rescore oversampling factor. Default: 4. */
+  pqRescoreOversampling?: number;
+}
+
+/** Request to create a graph collection with optional schema. */
+export interface CreateGraphCollectionRequest {
+  /** Collection name (unique identifier). */
+  name: string;
+  /** Optional vector dimension for node embeddings. */
+  dimension?: number;
+  /** Distance metric (when dimension is set). Default: 'cosine'. */
+  metric?: DistanceMetric;
+  /** Graph schema definition. Pass { schemaless: true } for schemaless mode. */
+  graphSchema?: Record<string, unknown>;
 }
 
 /** Request to create a metadata-only collection. */
@@ -73,6 +101,8 @@ export interface CollectionInfo {
   metric: string;
   /** Number of vectors in the collection. */
   count: number;
+  /** Storage mode (full, sq8, binary, pq, rabitq, graph, metadata_only). */
+  storageMode: string;
 }
 
 /** A point (vector with metadata) to insert. */
@@ -101,6 +131,10 @@ export interface SearchRequest {
   vector: number[];
   /** Number of results to return. Default: 10. */
   topK?: number;
+  /** Optional metadata filter. */
+  filter?: Record<string, unknown>;
+  /** Search quality: 'fast', 'balanced', 'accurate', 'perfect', 'auto', or 'custom:<ef>'. */
+  quality?: string;
 }
 
 /** Request for BM25 text search. */
@@ -111,6 +145,8 @@ export interface TextSearchRequest {
   query: string;
   /** Number of results to return. Default: 10. */
   topK?: number;
+  /** Optional metadata filter. */
+  filter?: Record<string, unknown>;
 }
 
 /** Request for hybrid (vector + text) search. */
@@ -125,6 +161,8 @@ export interface HybridSearchRequest {
   topK?: number;
   /** Weight for vector results (0.0-1.0). Default: 0.5. */
   vectorWeight?: number;
+  /** Optional metadata filter. */
+  filter?: Record<string, unknown>;
 }
 
 /** Request for VelesQL query. */
@@ -159,6 +197,8 @@ export interface IndividualSearchRequest {
   topK?: number;
   /** Optional metadata filter. */
   filter?: Record<string, unknown>;
+  /** Search quality: 'fast', 'balanced', 'accurate', 'perfect', 'auto', or 'custom:<ef>'. */
+  quality?: string;
 }
 
 /** Request for batch search. */
@@ -228,6 +268,30 @@ export interface SearchResult {
 export interface SearchResponse {
   /** Search results ordered by relevance. */
   results: SearchResult[];
+  /** Query execution time in milliseconds. */
+  timingMs: number;
+}
+
+/** Hybrid result from VelesQL queries (vector + graph + column data). */
+export interface HybridResult {
+  /** Node/point ID. */
+  nodeId: number;
+  /** Vector similarity score (if applicable). */
+  vectorScore?: number;
+  /** Graph traversal score (if applicable). */
+  graphScore?: number;
+  /** Fused score combining vector and graph components. */
+  fusedScore: number;
+  /** Payload/bindings from the query. */
+  bindings?: Record<string, unknown>;
+  /** Column data from aggregation queries. */
+  columnData?: Record<string, unknown>;
+}
+
+/** Response from VelesQL query operations. */
+export interface QueryResponse {
+  /** Query results. */
+  results: HybridResult[];
   /** Query execution time in milliseconds. */
   timingMs: number;
 }
@@ -454,22 +518,29 @@ export async function hybridSearch(request: HybridSearchRequest): Promise<Search
 }
 
 /**
- * Executes a VelesQL query.
- * 
+ * Executes a VelesQL query (SELECT, MATCH, DDL, DML).
+ *
  * @param request - Query request with VelesQL string
- * @returns Search response with results and timing
+ * @returns Query response with hybrid results and timing
  * @throws {CommandError} If query syntax is invalid or collection doesn't exist
- * 
+ *
  * @example
  * ```typescript
+ * // SELECT query
  * const response = await query({
- *   query: "SELECT * FROM documents WHERE content MATCH 'rust programming' LIMIT 10",
+ *   query: "SELECT * FROM documents WHERE vector NEAR $v LIMIT 10",
+ *   params: { v: queryEmbedding }
+ * });
+ *
+ * // MATCH (graph) query
+ * const response = await query({
+ *   query: "MATCH (d:Doc)-[:AUTHORED_BY]->(a:Person) RETURN a.name",
  *   params: {}
  * });
  * ```
  */
-export async function query(request: QueryRequest): Promise<SearchResponse> {
-  return invoke<SearchResponse>('plugin:velesdb|query', { request });
+export async function query(request: QueryRequest): Promise<QueryResponse> {
+  return invoke<QueryResponse>('plugin:velesdb|query', { request });
 }
 
 /**
@@ -631,10 +702,13 @@ export interface GetEdgesRequest {
 export interface TraverseGraphRequest {
   collection: string;
   source: number;
-  maxDepth: number;
+  /** Maximum traversal depth. Default: 3. */
+  maxDepth?: number;
   relTypes?: string[];
-  limit: number;
-  algorithm: 'bfs' | 'dfs';
+  /** Maximum results to return. Default: 100. */
+  limit?: number;
+  /** Traversal algorithm. Default: 'bfs'. */
+  algorithm?: 'bfs' | 'dfs';
 }
 
 /** Request to get the degree of a node. */
@@ -733,4 +807,240 @@ export async function traverseGraph(request: TraverseGraphRequest): Promise<Trav
  */
 export async function getNodeDegree(request: GetNodeDegreeRequest): Promise<NodeDegreeOutput> {
   return invoke<NodeDegreeOutput>('plugin:velesdb|get_node_degree', { request });
+}
+
+/**
+ * Creates a graph collection with optional schema.
+ *
+ * @param request - Graph collection configuration
+ * @returns Collection info
+ * @throws {CommandError} If collection already exists or parameters are invalid
+ *
+ * @example
+ * ```typescript
+ * // Schemaless graph (default)
+ * const info = await createGraphCollection({ name: 'knowledge' });
+ *
+ * // Graph with embeddings
+ * const info = await createGraphCollection({
+ *   name: 'knowledge', dimension: 768, metric: 'cosine',
+ *   graphSchema: { schemaless: true }
+ * });
+ * ```
+ */
+export async function createGraphCollection(request: CreateGraphCollectionRequest): Promise<CollectionInfo> {
+  return invoke<CollectionInfo>('plugin:velesdb|create_graph_collection', { request });
+}
+
+// ============================================================================
+// Scroll / Pagination
+// ============================================================================
+
+/** Request to scroll through collection points. */
+export interface ScrollRequest {
+  /** Target collection name. */
+  collection: string;
+  /** Cursor from a previous scroll (omit for the first batch). */
+  cursor?: number;
+  /** Number of points per batch. Default: 100. */
+  batchSize?: number;
+  /** Optional metadata filter. */
+  filter?: Record<string, unknown>;
+}
+
+/** Response from a scroll operation. */
+export interface ScrollResponse {
+  /** Points in this batch. */
+  points: PointOutput[];
+  /** Cursor for the next batch (absent when no more points). */
+  nextCursor?: number;
+}
+
+/**
+ * Scrolls through collection points with cursor-based pagination.
+ *
+ * @param request - Scroll parameters
+ * @returns Batch of points and optional next cursor
+ * @throws {CommandError} If collection doesn't exist
+ *
+ * @example
+ * ```typescript
+ * let cursor: number | undefined;
+ * do {
+ *   const batch = await scrollCollection({ collection: 'docs', cursor, batchSize: 50 });
+ *   batch.points.forEach(p => console.log(p.id));
+ *   cursor = batch.nextCursor;
+ * } while (cursor !== undefined);
+ * ```
+ */
+export async function scrollCollection(request: ScrollRequest): Promise<ScrollResponse> {
+  return invoke<ScrollResponse>('plugin:velesdb|scroll_collection', { request });
+}
+
+// ============================================================================
+// Agent Memory — Semantic
+// ============================================================================
+
+/** Request to store knowledge in semantic memory. */
+export interface SemanticStoreRequest {
+  /** Unique ID for this knowledge fact. */
+  id: number;
+  /** Text content of the knowledge. */
+  content: string;
+  /** Embedding vector for the content. */
+  embedding: number[];
+}
+
+/** Request to query semantic memory. */
+export interface SemanticQueryRequest {
+  /** Query embedding vector. */
+  embedding: number[];
+  /** Number of results to return. Default: 10. */
+  topK?: number;
+}
+
+/** Result from semantic memory query. */
+export interface SemanticQueryResult {
+  /** Knowledge fact ID. */
+  id: number;
+  /** Similarity score. */
+  score: number;
+  /** Knowledge content text. */
+  content: string;
+}
+
+/**
+ * Stores a knowledge fact in semantic memory.
+ *
+ * @param request - Semantic store request
+ * @throws {CommandError} On storage failure
+ */
+export async function semanticStore(request: SemanticStoreRequest): Promise<void> {
+  return invoke<void>('plugin:velesdb|semantic_store', { request });
+}
+
+/**
+ * Queries semantic memory by similarity search.
+ *
+ * @param request - Semantic query request
+ * @returns Array of matching knowledge facts
+ */
+export async function semanticQuery(request: SemanticQueryRequest): Promise<SemanticQueryResult[]> {
+  return invoke<SemanticQueryResult[]>('plugin:velesdb|semantic_query', { request });
+}
+
+// ============================================================================
+// Agent Memory — Episodic
+// ============================================================================
+
+/** Request to record an episode. */
+export interface EpisodicRecordRequest {
+  /** Episode event ID. */
+  eventId: number;
+  /** Episode description/content. */
+  content: string;
+  /** Timestamp (epoch seconds). */
+  timestamp: number;
+  /** Embedding vector for the episode. */
+  embedding: number[];
+}
+
+/** Request to query recent episodes. */
+export interface EpisodicRecentRequest {
+  /** Number of recent episodes to return. Default: 10. */
+  limit?: number;
+  /** Only return episodes since this timestamp (epoch seconds). */
+  sinceTimestamp?: number;
+}
+
+/** Result from episodic memory query. */
+export interface EpisodicResult {
+  /** Episode ID. */
+  id: number;
+  /** Episode content. */
+  content: string;
+  /** Timestamp (epoch seconds). */
+  timestamp: number;
+}
+
+/**
+ * Records an episode in episodic memory.
+ *
+ * @param request - Episode to record
+ * @throws {CommandError} On storage failure
+ */
+export async function episodicRecord(request: EpisodicRecordRequest): Promise<void> {
+  return invoke<void>('plugin:velesdb|episodic_record', { request });
+}
+
+/**
+ * Queries recent episodes from episodic memory.
+ *
+ * @param request - Query parameters (limit, since_timestamp)
+ * @returns Array of recent episodes
+ */
+export async function episodicRecent(request: EpisodicRecentRequest): Promise<EpisodicResult[]> {
+  return invoke<EpisodicResult[]>('plugin:velesdb|episodic_recent', { request });
+}
+
+// ============================================================================
+// Agent Memory — Procedural
+// ============================================================================
+
+/** Request to learn a procedure. */
+export interface ProceduralLearnRequest {
+  /** Procedure ID. */
+  procedureId: number;
+  /** Procedure name. */
+  name: string;
+  /** Steps to perform. */
+  steps: string[];
+  /** Embedding vector for the procedure. */
+  embedding: number[];
+  /** Confidence level (0.0-1.0). Default: 1.0. */
+  confidence?: number;
+}
+
+/** Request to recall procedures by similarity. */
+export interface ProceduralRecallRequest {
+  /** Query embedding vector. */
+  embedding: number[];
+  /** Number of results. Default: 10. */
+  topK?: number;
+  /** Minimum confidence threshold. Default: 0.0. */
+  minConfidence?: number;
+}
+
+/** Result from procedural memory recall. */
+export interface ProceduralMatchResult {
+  /** Procedure ID. */
+  id: number;
+  /** Procedure name. */
+  name: string;
+  /** Steps. */
+  steps: string[];
+  /** Confidence score. */
+  confidence: number;
+  /** Similarity score from vector search. */
+  score: number;
+}
+
+/**
+ * Learns a procedure in procedural memory.
+ *
+ * @param request - Procedure to learn
+ * @throws {CommandError} On storage failure
+ */
+export async function proceduralLearn(request: ProceduralLearnRequest): Promise<void> {
+  return invoke<void>('plugin:velesdb|procedural_learn', { request });
+}
+
+/**
+ * Recalls procedures by similarity from procedural memory.
+ *
+ * @param request - Recall parameters
+ * @returns Array of matching procedures
+ */
+export async function proceduralRecall(request: ProceduralRecallRequest): Promise<ProceduralMatchResult[]> {
+  return invoke<ProceduralMatchResult[]>('plugin:velesdb|procedural_recall', { request });
 }

--- a/crates/tauri-plugin-velesdb/permissions/autogenerated/commands/create_graph_collection.toml
+++ b/crates/tauri-plugin-velesdb/permissions/autogenerated/commands/create_graph_collection.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-create-graph-collection"
+description = "Enables the create_graph_collection command without any pre-configured scope."
+commands.allow = ["create_graph_collection"]
+
+[[permission]]
+identifier = "deny-create-graph-collection"
+description = "Denies the create_graph_collection command without any pre-configured scope."
+commands.deny = ["create_graph_collection"]

--- a/crates/tauri-plugin-velesdb/permissions/autogenerated/commands/episodic_recent.toml
+++ b/crates/tauri-plugin-velesdb/permissions/autogenerated/commands/episodic_recent.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-episodic-recent"
+description = "Enables the episodic_recent command without any pre-configured scope."
+commands.allow = ["episodic_recent"]
+
+[[permission]]
+identifier = "deny-episodic-recent"
+description = "Denies the episodic_recent command without any pre-configured scope."
+commands.deny = ["episodic_recent"]

--- a/crates/tauri-plugin-velesdb/permissions/autogenerated/commands/episodic_record.toml
+++ b/crates/tauri-plugin-velesdb/permissions/autogenerated/commands/episodic_record.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-episodic-record"
+description = "Enables the episodic_record command without any pre-configured scope."
+commands.allow = ["episodic_record"]
+
+[[permission]]
+identifier = "deny-episodic-record"
+description = "Denies the episodic_record command without any pre-configured scope."
+commands.deny = ["episodic_record"]

--- a/crates/tauri-plugin-velesdb/permissions/autogenerated/commands/hybrid_sparse_search.toml
+++ b/crates/tauri-plugin-velesdb/permissions/autogenerated/commands/hybrid_sparse_search.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-hybrid-sparse-search"
+description = "Enables the hybrid_sparse_search command without any pre-configured scope."
+commands.allow = ["hybrid_sparse_search"]
+
+[[permission]]
+identifier = "deny-hybrid-sparse-search"
+description = "Denies the hybrid_sparse_search command without any pre-configured scope."
+commands.deny = ["hybrid_sparse_search"]

--- a/crates/tauri-plugin-velesdb/permissions/autogenerated/commands/procedural_learn.toml
+++ b/crates/tauri-plugin-velesdb/permissions/autogenerated/commands/procedural_learn.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-procedural-learn"
+description = "Enables the procedural_learn command without any pre-configured scope."
+commands.allow = ["procedural_learn"]
+
+[[permission]]
+identifier = "deny-procedural-learn"
+description = "Denies the procedural_learn command without any pre-configured scope."
+commands.deny = ["procedural_learn"]

--- a/crates/tauri-plugin-velesdb/permissions/autogenerated/commands/procedural_recall.toml
+++ b/crates/tauri-plugin-velesdb/permissions/autogenerated/commands/procedural_recall.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-procedural-recall"
+description = "Enables the procedural_recall command without any pre-configured scope."
+commands.allow = ["procedural_recall"]
+
+[[permission]]
+identifier = "deny-procedural-recall"
+description = "Denies the procedural_recall command without any pre-configured scope."
+commands.deny = ["procedural_recall"]

--- a/crates/tauri-plugin-velesdb/permissions/autogenerated/commands/scroll_collection.toml
+++ b/crates/tauri-plugin-velesdb/permissions/autogenerated/commands/scroll_collection.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-scroll-collection"
+description = "Enables the scroll_collection command without any pre-configured scope."
+commands.allow = ["scroll_collection"]
+
+[[permission]]
+identifier = "deny-scroll-collection"
+description = "Denies the scroll_collection command without any pre-configured scope."
+commands.deny = ["scroll_collection"]

--- a/crates/tauri-plugin-velesdb/permissions/autogenerated/commands/sparse_search.toml
+++ b/crates/tauri-plugin-velesdb/permissions/autogenerated/commands/sparse_search.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-sparse-search"
+description = "Enables the sparse_search command without any pre-configured scope."
+commands.allow = ["sparse_search"]
+
+[[permission]]
+identifier = "deny-sparse-search"
+description = "Denies the sparse_search command without any pre-configured scope."
+commands.deny = ["sparse_search"]

--- a/crates/tauri-plugin-velesdb/permissions/autogenerated/commands/sparse_upsert.toml
+++ b/crates/tauri-plugin-velesdb/permissions/autogenerated/commands/sparse_upsert.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-sparse-upsert"
+description = "Enables the sparse_upsert command without any pre-configured scope."
+commands.allow = ["sparse_upsert"]
+
+[[permission]]
+identifier = "deny-sparse-upsert"
+description = "Denies the sparse_upsert command without any pre-configured scope."
+commands.deny = ["sparse_upsert"]

--- a/crates/tauri-plugin-velesdb/permissions/autogenerated/commands/stream_insert.toml
+++ b/crates/tauri-plugin-velesdb/permissions/autogenerated/commands/stream_insert.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-stream-insert"
+description = "Enables the stream_insert command without any pre-configured scope."
+commands.allow = ["stream_insert"]
+
+[[permission]]
+identifier = "deny-stream-insert"
+description = "Denies the stream_insert command without any pre-configured scope."
+commands.deny = ["stream_insert"]

--- a/crates/tauri-plugin-velesdb/permissions/autogenerated/commands/train_pq.toml
+++ b/crates/tauri-plugin-velesdb/permissions/autogenerated/commands/train_pq.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-train-pq"
+description = "Enables the train_pq command without any pre-configured scope."
+commands.allow = ["train_pq"]
+
+[[permission]]
+identifier = "deny-train-pq"
+description = "Denies the train_pq command without any pre-configured scope."
+commands.deny = ["train_pq"]

--- a/crates/tauri-plugin-velesdb/permissions/autogenerated/reference.md
+++ b/crates/tauri-plugin-velesdb/permissions/autogenerated/reference.md
@@ -11,6 +11,7 @@ Default permissions for VelesDB plugin - allows all database operations
 - `allow-get-collection`
 - `allow-is-empty`
 - `allow-flush`
+- `allow-scroll-collection`
 - `allow-upsert`
 - `allow-upsert-metadata`
 - `allow-get-points`
@@ -21,8 +22,18 @@ Default permissions for VelesDB plugin - allows all database operations
 - `allow-hybrid-search`
 - `allow-multi-query-search`
 - `allow-query`
+- `allow-sparse-search`
+- `allow-hybrid-sparse-search`
+- `allow-sparse-upsert`
+- `allow-train-pq`
+- `allow-stream-insert`
 - `allow-semantic-store`
 - `allow-semantic-query`
+- `allow-episodic-record`
+- `allow-episodic-recent`
+- `allow-procedural-learn`
+- `allow-procedural-recall`
+- `allow-create-graph-collection`
 - `allow-add-edge`
 - `allow-get-edges`
 - `allow-traverse-graph`
@@ -115,6 +126,32 @@ Enables the create_collection command without any pre-configured scope.
 <td>
 
 Denies the create_collection command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`velesdb:allow-create-graph-collection`
+
+</td>
+<td>
+
+Enables the create_graph_collection command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`velesdb:deny-create-graph-collection`
+
+</td>
+<td>
+
+Denies the create_graph_collection command without any pre-configured scope.
 
 </td>
 </tr>
@@ -245,6 +282,58 @@ Enables the drop_index command without any pre-configured scope.
 <td>
 
 Denies the drop_index command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`velesdb:allow-episodic-recent`
+
+</td>
+<td>
+
+Enables the episodic_recent command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`velesdb:deny-episodic-recent`
+
+</td>
+<td>
+
+Denies the episodic_recent command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`velesdb:allow-episodic-record`
+
+</td>
+<td>
+
+Enables the episodic_record command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`velesdb:deny-episodic-record`
+
+</td>
+<td>
+
+Denies the episodic_record command without any pre-configured scope.
 
 </td>
 </tr>
@@ -408,6 +497,32 @@ Denies the hybrid_search command without any pre-configured scope.
 <tr>
 <td>
 
+`velesdb:allow-hybrid-sparse-search`
+
+</td>
+<td>
+
+Enables the hybrid_sparse_search command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`velesdb:deny-hybrid-sparse-search`
+
+</td>
+<td>
+
+Denies the hybrid_sparse_search command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
 `velesdb:allow-is-empty`
 
 </td>
@@ -512,6 +627,58 @@ Denies the multi_query_search command without any pre-configured scope.
 <tr>
 <td>
 
+`velesdb:allow-procedural-learn`
+
+</td>
+<td>
+
+Enables the procedural_learn command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`velesdb:deny-procedural-learn`
+
+</td>
+<td>
+
+Denies the procedural_learn command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`velesdb:allow-procedural-recall`
+
+</td>
+<td>
+
+Enables the procedural_recall command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`velesdb:deny-procedural-recall`
+
+</td>
+<td>
+
+Denies the procedural_recall command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
 `velesdb:allow-query`
 
 </td>
@@ -531,6 +698,32 @@ Enables the query command without any pre-configured scope.
 <td>
 
 Denies the query command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`velesdb:allow-scroll-collection`
+
+</td>
+<td>
+
+Enables the scroll_collection command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`velesdb:deny-scroll-collection`
+
+</td>
+<td>
+
+Denies the scroll_collection command without any pre-configured scope.
 
 </td>
 </tr>
@@ -616,6 +809,84 @@ Denies the semantic_store command without any pre-configured scope.
 <tr>
 <td>
 
+`velesdb:allow-sparse-search`
+
+</td>
+<td>
+
+Enables the sparse_search command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`velesdb:deny-sparse-search`
+
+</td>
+<td>
+
+Denies the sparse_search command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`velesdb:allow-sparse-upsert`
+
+</td>
+<td>
+
+Enables the sparse_upsert command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`velesdb:deny-sparse-upsert`
+
+</td>
+<td>
+
+Denies the sparse_upsert command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`velesdb:allow-stream-insert`
+
+</td>
+<td>
+
+Enables the stream_insert command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`velesdb:deny-stream-insert`
+
+</td>
+<td>
+
+Denies the stream_insert command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
 `velesdb:allow-text-search`
 
 </td>
@@ -635,6 +906,32 @@ Enables the text_search command without any pre-configured scope.
 <td>
 
 Denies the text_search command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`velesdb:allow-train-pq`
+
+</td>
+<td>
+
+Enables the train_pq command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`velesdb:deny-train-pq`
+
+</td>
+<td>
+
+Denies the train_pq command without any pre-configured scope.
 
 </td>
 </tr>

--- a/crates/tauri-plugin-velesdb/permissions/default.toml
+++ b/crates/tauri-plugin-velesdb/permissions/default.toml
@@ -19,6 +19,7 @@ permissions = [
     "allow-get-collection",
     "allow-is-empty",
     "allow-flush",
+    "allow-scroll-collection",
     # Point operations
     "allow-upsert",
     "allow-upsert-metadata",
@@ -31,10 +32,23 @@ permissions = [
     "allow-hybrid-search",
     "allow-multi-query-search",
     "allow-query",
-    # AgentMemory (semantic)
+    # Sparse vector operations
+    "allow-sparse-search",
+    "allow-hybrid-sparse-search",
+    "allow-sparse-upsert",
+    # PQ training
+    "allow-train-pq",
+    # Streaming insert
+    "allow-stream-insert",
+    # AgentMemory (semantic, episodic, procedural)
     "allow-semantic-store",
     "allow-semantic-query",
+    "allow-episodic-record",
+    "allow-episodic-recent",
+    "allow-procedural-learn",
+    "allow-procedural-recall",
     # Knowledge Graph
+    "allow-create-graph-collection",
     "allow-add-edge",
     "allow-get-edges",
     "allow-traverse-graph",
@@ -54,6 +68,7 @@ permissions = [
     "allow-get-collection",
     "allow-is-empty",
     "allow-get-points",
+    "allow-scroll-collection",
     "allow-search",
     "allow-batch-search",
     "allow-text-search",
@@ -61,11 +76,15 @@ permissions = [
     "allow-multi-query-search",
     "allow-query",
     "allow-semantic-query",
+    "allow-episodic-recent",
+    "allow-procedural-recall",
     "allow-get-edges",
     "allow-traverse-graph",
     "allow-get-node-degree",
     "allow-traverse-graph-parallel",
     "allow-list-indexes",
+    "allow-sparse-search",
+    "allow-hybrid-sparse-search",
 ]
 
 # Search-only permission set

--- a/crates/tauri-plugin-velesdb/permissions/schemas/schema.json
+++ b/crates/tauri-plugin-velesdb/permissions/schemas/schema.json
@@ -331,6 +331,18 @@
           "markdownDescription": "Denies the create_collection command without any pre-configured scope."
         },
         {
+          "description": "Enables the create_graph_collection command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-create-graph-collection",
+          "markdownDescription": "Enables the create_graph_collection command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the create_graph_collection command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-create-graph-collection",
+          "markdownDescription": "Denies the create_graph_collection command without any pre-configured scope."
+        },
+        {
           "description": "Enables the create_index command without any pre-configured scope.",
           "type": "string",
           "const": "allow-create-index",
@@ -389,6 +401,30 @@
           "type": "string",
           "const": "deny-drop-index",
           "markdownDescription": "Denies the drop_index command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the episodic_recent command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-episodic-recent",
+          "markdownDescription": "Enables the episodic_recent command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the episodic_recent command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-episodic-recent",
+          "markdownDescription": "Denies the episodic_recent command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the episodic_record command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-episodic-record",
+          "markdownDescription": "Enables the episodic_record command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the episodic_record command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-episodic-record",
+          "markdownDescription": "Denies the episodic_record command without any pre-configured scope."
         },
         {
           "description": "Enables the flush command without any pre-configured scope.",
@@ -463,6 +499,18 @@
           "markdownDescription": "Denies the hybrid_search command without any pre-configured scope."
         },
         {
+          "description": "Enables the hybrid_sparse_search command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-hybrid-sparse-search",
+          "markdownDescription": "Enables the hybrid_sparse_search command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the hybrid_sparse_search command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-hybrid-sparse-search",
+          "markdownDescription": "Denies the hybrid_sparse_search command without any pre-configured scope."
+        },
+        {
           "description": "Enables the is_empty command without any pre-configured scope.",
           "type": "string",
           "const": "allow-is-empty",
@@ -511,6 +559,30 @@
           "markdownDescription": "Denies the multi_query_search command without any pre-configured scope."
         },
         {
+          "description": "Enables the procedural_learn command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-procedural-learn",
+          "markdownDescription": "Enables the procedural_learn command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the procedural_learn command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-procedural-learn",
+          "markdownDescription": "Denies the procedural_learn command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the procedural_recall command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-procedural-recall",
+          "markdownDescription": "Enables the procedural_recall command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the procedural_recall command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-procedural-recall",
+          "markdownDescription": "Denies the procedural_recall command without any pre-configured scope."
+        },
+        {
           "description": "Enables the query command without any pre-configured scope.",
           "type": "string",
           "const": "allow-query",
@@ -521,6 +593,18 @@
           "type": "string",
           "const": "deny-query",
           "markdownDescription": "Denies the query command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the scroll_collection command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-scroll-collection",
+          "markdownDescription": "Enables the scroll_collection command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the scroll_collection command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-scroll-collection",
+          "markdownDescription": "Denies the scroll_collection command without any pre-configured scope."
         },
         {
           "description": "Enables the search command without any pre-configured scope.",
@@ -559,6 +643,42 @@
           "markdownDescription": "Denies the semantic_store command without any pre-configured scope."
         },
         {
+          "description": "Enables the sparse_search command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-sparse-search",
+          "markdownDescription": "Enables the sparse_search command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the sparse_search command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-sparse-search",
+          "markdownDescription": "Denies the sparse_search command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the sparse_upsert command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-sparse-upsert",
+          "markdownDescription": "Enables the sparse_upsert command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the sparse_upsert command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-sparse-upsert",
+          "markdownDescription": "Denies the sparse_upsert command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the stream_insert command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-stream-insert",
+          "markdownDescription": "Enables the stream_insert command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the stream_insert command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-stream-insert",
+          "markdownDescription": "Denies the stream_insert command without any pre-configured scope."
+        },
+        {
           "description": "Enables the text_search command without any pre-configured scope.",
           "type": "string",
           "const": "allow-text-search",
@@ -569,6 +689,18 @@
           "type": "string",
           "const": "deny-text-search",
           "markdownDescription": "Denies the text_search command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the train_pq command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-train-pq",
+          "markdownDescription": "Enables the train_pq command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the train_pq command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-train-pq",
+          "markdownDescription": "Denies the train_pq command without any pre-configured scope."
         },
         {
           "description": "Enables the traverse_graph command without any pre-configured scope.",
@@ -619,10 +751,10 @@
           "markdownDescription": "Denies the upsert_metadata command without any pre-configured scope."
         },
         {
-          "description": "Default permissions for VelesDB plugin - allows all database operations\n#### This default permission set includes:\n\n- `allow-create-collection`\n- `allow-create-metadata-collection`\n- `allow-delete-collection`\n- `allow-list-collections`\n- `allow-get-collection`\n- `allow-is-empty`\n- `allow-flush`\n- `allow-upsert`\n- `allow-upsert-metadata`\n- `allow-get-points`\n- `allow-delete-points`\n- `allow-search`\n- `allow-batch-search`\n- `allow-text-search`\n- `allow-hybrid-search`\n- `allow-multi-query-search`\n- `allow-query`\n- `allow-semantic-store`\n- `allow-semantic-query`\n- `allow-add-edge`\n- `allow-get-edges`\n- `allow-traverse-graph`\n- `allow-get-node-degree`\n- `allow-traverse-graph-parallel`\n- `allow-create-index`\n- `allow-drop-index`\n- `allow-list-indexes`",
+          "description": "Default permissions for VelesDB plugin - allows all database operations\n#### This default permission set includes:\n\n- `allow-create-collection`\n- `allow-create-metadata-collection`\n- `allow-delete-collection`\n- `allow-list-collections`\n- `allow-get-collection`\n- `allow-is-empty`\n- `allow-flush`\n- `allow-scroll-collection`\n- `allow-upsert`\n- `allow-upsert-metadata`\n- `allow-get-points`\n- `allow-delete-points`\n- `allow-search`\n- `allow-batch-search`\n- `allow-text-search`\n- `allow-hybrid-search`\n- `allow-multi-query-search`\n- `allow-query`\n- `allow-sparse-search`\n- `allow-hybrid-sparse-search`\n- `allow-sparse-upsert`\n- `allow-train-pq`\n- `allow-stream-insert`\n- `allow-semantic-store`\n- `allow-semantic-query`\n- `allow-episodic-record`\n- `allow-episodic-recent`\n- `allow-procedural-learn`\n- `allow-procedural-recall`\n- `allow-create-graph-collection`\n- `allow-add-edge`\n- `allow-get-edges`\n- `allow-traverse-graph`\n- `allow-get-node-degree`\n- `allow-traverse-graph-parallel`\n- `allow-create-index`\n- `allow-drop-index`\n- `allow-list-indexes`",
           "type": "string",
           "const": "default",
-          "markdownDescription": "Default permissions for VelesDB plugin - allows all database operations\n#### This default permission set includes:\n\n- `allow-create-collection`\n- `allow-create-metadata-collection`\n- `allow-delete-collection`\n- `allow-list-collections`\n- `allow-get-collection`\n- `allow-is-empty`\n- `allow-flush`\n- `allow-upsert`\n- `allow-upsert-metadata`\n- `allow-get-points`\n- `allow-delete-points`\n- `allow-search`\n- `allow-batch-search`\n- `allow-text-search`\n- `allow-hybrid-search`\n- `allow-multi-query-search`\n- `allow-query`\n- `allow-semantic-store`\n- `allow-semantic-query`\n- `allow-add-edge`\n- `allow-get-edges`\n- `allow-traverse-graph`\n- `allow-get-node-degree`\n- `allow-traverse-graph-parallel`\n- `allow-create-index`\n- `allow-drop-index`\n- `allow-list-indexes`"
+          "markdownDescription": "Default permissions for VelesDB plugin - allows all database operations\n#### This default permission set includes:\n\n- `allow-create-collection`\n- `allow-create-metadata-collection`\n- `allow-delete-collection`\n- `allow-list-collections`\n- `allow-get-collection`\n- `allow-is-empty`\n- `allow-flush`\n- `allow-scroll-collection`\n- `allow-upsert`\n- `allow-upsert-metadata`\n- `allow-get-points`\n- `allow-delete-points`\n- `allow-search`\n- `allow-batch-search`\n- `allow-text-search`\n- `allow-hybrid-search`\n- `allow-multi-query-search`\n- `allow-query`\n- `allow-sparse-search`\n- `allow-hybrid-sparse-search`\n- `allow-sparse-upsert`\n- `allow-train-pq`\n- `allow-stream-insert`\n- `allow-semantic-store`\n- `allow-semantic-query`\n- `allow-episodic-record`\n- `allow-episodic-recent`\n- `allow-procedural-learn`\n- `allow-procedural-recall`\n- `allow-create-graph-collection`\n- `allow-add-edge`\n- `allow-get-edges`\n- `allow-traverse-graph`\n- `allow-get-node-degree`\n- `allow-traverse-graph-parallel`\n- `allow-create-index`\n- `allow-drop-index`\n- `allow-list-indexes`"
         }
       ]
     }

--- a/crates/tauri-plugin-velesdb/src/commands.rs
+++ b/crates/tauri-plugin-velesdb/src/commands.rs
@@ -3,12 +3,12 @@
 
 use crate::error::{CommandError, Error};
 use crate::events::{emit_collection_created, emit_collection_deleted, emit_collection_updated};
-#[cfg(feature = "persistence")]
-use crate::helpers::require_vector_collection;
 use crate::helpers::{
     map_core_results, metric_to_string, parse_filter, parse_fusion_strategy, parse_metric,
     parse_storage_mode, require_collection, storage_mode_to_string, timed_search_response,
 };
+#[cfg(feature = "persistence")]
+use crate::helpers::{parse_search_quality, require_vector_collection};
 use crate::state::VelesDbState;
 #[cfg(feature = "persistence")]
 use crate::types::StreamInsertRequest;
@@ -18,10 +18,37 @@ pub use crate::types::{
 use crate::types::{
     BatchSearchRequest, CollectionInfo, CreateCollectionRequest, CreateMetadataCollectionRequest,
     DeletePointsRequest, GetPointsRequest, HybridSearchRequest, MultiQuerySearchRequest,
-    PointOutput, SearchRequest, SearchResponse, TextSearchRequest, TrainPqRequest,
-    UpsertMetadataRequest, UpsertRequest,
+    PointOutput, ScrollRequest, ScrollResponse, SearchRequest, SearchResponse, TextSearchRequest,
+    TrainPqRequest, UpsertMetadataRequest, UpsertRequest,
 };
 use tauri::{command, AppHandle, Runtime, State};
+
+/// Builds [`velesdb_core::HnswParams`] from optional request fields, falling
+/// back to dimension-based auto-tuned defaults for any omitted parameter.
+#[cfg(feature = "persistence")]
+pub(crate) fn build_hnsw_params(
+    request: &CreateCollectionRequest,
+    storage_mode: velesdb_core::StorageMode,
+) -> velesdb_core::HnswParams {
+    let base = velesdb_core::HnswParams::auto(request.dimension);
+    velesdb_core::HnswParams {
+        max_connections: request.hnsw_m.unwrap_or(base.max_connections),
+        ef_construction: request.hnsw_ef_construction.unwrap_or(base.ef_construction),
+        max_elements: request.hnsw_max_elements.unwrap_or(base.max_elements),
+        storage_mode,
+        alpha: request.hnsw_alpha.unwrap_or(base.alpha),
+    }
+}
+
+/// Returns `true` when the request carries at least one advanced HNSW or PQ
+/// parameter, indicating that [`build_hnsw_params`] should be used.
+pub(crate) const fn has_advanced_params(request: &CreateCollectionRequest) -> bool {
+    request.hnsw_m.is_some()
+        || request.hnsw_ef_construction.is_some()
+        || request.hnsw_alpha.is_some()
+        || request.hnsw_max_elements.is_some()
+        || request.pq_rescore_oversampling.is_some()
+}
 
 /// Creates a new collection.
 #[command]
@@ -31,17 +58,28 @@ pub async fn create_collection<R: Runtime>(
     request: CreateCollectionRequest,
 ) -> std::result::Result<CollectionInfo, CommandError> {
     let metric = parse_metric(&request.metric).map_err(CommandError::from)?;
-
     let storage_mode = parse_storage_mode(&request.storage_mode).map_err(CommandError::from)?;
 
     let result = state
         .with_db(|db| {
-            db.create_vector_collection_with_options(
-                &request.name,
-                request.dimension,
-                metric,
-                storage_mode,
-            )?;
+            if has_advanced_params(&request) {
+                let hnsw_params = build_hnsw_params(&request, storage_mode);
+                db.create_vector_collection_with_params(
+                    &request.name,
+                    request.dimension,
+                    metric,
+                    storage_mode,
+                    hnsw_params,
+                    request.pq_rescore_oversampling,
+                )?;
+            } else {
+                db.create_vector_collection_with_options(
+                    &request.name,
+                    request.dimension,
+                    metric,
+                    storage_mode,
+                )?;
+            }
             Ok(CollectionInfo {
                 name: request.name.clone(),
                 dimension: request.dimension,
@@ -52,7 +90,6 @@ pub async fn create_collection<R: Runtime>(
         })
         .map_err(CommandError::from)?;
 
-    // Emit event
     emit_collection_created(&app, &request.name);
     Ok(result)
 }
@@ -247,7 +284,42 @@ pub async fn delete_points<R: Runtime>(
         .map_err(CommandError::from)
 }
 
+/// Dispatches a single search with optional quality mode.
+///
+/// When quality is `Some`, delegates to `search_with_quality`;
+/// otherwise falls back to the default `search`.
+#[cfg(feature = "persistence")]
+fn dispatch_quality_search(
+    coll: &velesdb_core::VectorCollection,
+    query: &[f32],
+    k: usize,
+    quality: Option<&velesdb_core::SearchQuality>,
+) -> crate::error::Result<Vec<velesdb_core::SearchResult>> {
+    if let Some(q) = quality {
+        coll.search_with_quality(query, k, *q)
+            .map_err(crate::error::Error::Database)
+    } else {
+        coll.search(query, k).map_err(crate::error::Error::Database)
+    }
+}
+
+/// Dispatches a single search (no quality support without `persistence`).
+#[cfg(not(feature = "persistence"))]
+fn dispatch_quality_search(
+    coll: &velesdb_core::VectorCollection,
+    query: &[f32],
+    k: usize,
+    _quality: Option<&()>,
+) -> crate::error::Result<Vec<velesdb_core::SearchResult>> {
+    coll.search(query, k).map_err(crate::error::Error::Database)
+}
+
 /// Searches for similar vectors.
+///
+/// Supports an optional `quality` mode (e.g. "fast", "balanced", "accurate",
+/// "perfect", "auto", "custom:\<ef\>", "adaptive:\<min\>:\<max\>").
+/// Known limitation (#457): when a filter is present, quality is ignored
+/// because `search_with_filter` does not accept a quality parameter yet.
 #[command]
 pub async fn search<R: Runtime>(
     _app: AppHandle<R>,
@@ -256,15 +328,26 @@ pub async fn search<R: Runtime>(
 ) -> std::result::Result<SearchResponse, CommandError> {
     let start = std::time::Instant::now();
     let parsed_filter = parse_filter(&request.filter).map_err(CommandError::from)?;
+    #[cfg(feature = "persistence")]
+    let parsed_quality = parse_search_quality(&request.quality).map_err(CommandError::from)?;
+    #[cfg(not(feature = "persistence"))]
+    let parsed_quality: Option<()> = None;
 
     let results = state
         .with_db(|db| {
             let coll = require_collection(&db, &request.collection)?;
 
+            // Filter takes precedence (known limitation #457: quality ignored
+            // when filter is present). Quality dispatch only when no filter.
             let search_results = if let Some(ref f) = parsed_filter {
                 coll.search_with_filter(&request.vector, request.top_k, f)?
             } else {
-                coll.search(&request.vector, request.top_k)?
+                dispatch_quality_search(
+                    &coll,
+                    &request.vector,
+                    request.top_k,
+                    parsed_quality.as_ref(),
+                )?
             };
             Ok(map_core_results(search_results))
         })
@@ -273,7 +356,11 @@ pub async fn search<R: Runtime>(
     Ok(timed_search_response(results, start))
 }
 
-/// Batch search for multiple query vectors in parallel.
+/// Batch search for multiple query vectors.
+///
+/// When any individual search specifies a `quality` mode, each search is
+/// dispatched individually (per-search quality). Otherwise the optimized
+/// `search_batch_with_filters` batch API is used.
 #[command]
 pub async fn batch_search<R: Runtime>(
     _app: AppHandle<R>,
@@ -281,8 +368,61 @@ pub async fn batch_search<R: Runtime>(
     request: BatchSearchRequest,
 ) -> std::result::Result<Vec<SearchResponse>, CommandError> {
     let start = std::time::Instant::now();
+    let has_quality = request.searches.iter().any(|s| s.quality.is_some());
 
-    let batch_results = state
+    let batch_results = if has_quality {
+        batch_search_per_query(&state, &request)?
+    } else {
+        batch_search_bulk(&state, &request)?
+    };
+
+    let timing_ms = start.elapsed().as_secs_f64() * 1000.0;
+    Ok(batch_results
+        .into_iter()
+        .map(|results| SearchResponse { results, timing_ms })
+        .collect())
+}
+
+/// Per-query batch search with per-search quality dispatch.
+fn batch_search_per_query(
+    state: &VelesDbState,
+    request: &BatchSearchRequest,
+) -> std::result::Result<Vec<Vec<crate::types::SearchResult>>, CommandError> {
+    state
+        .with_db(|db| {
+            let coll = require_collection(&db, &request.collection)?;
+            let mut all_results = Vec::with_capacity(request.searches.len());
+            for s in &request.searches {
+                let filter = parse_filter(&s.filter)?;
+                #[cfg(feature = "persistence")]
+                let quality = parse_search_quality(&s.quality)
+                    .map_err(|e| Error::InvalidConfig(e.to_string()))?;
+                #[cfg(not(feature = "persistence"))]
+                let quality: Option<()> = None;
+
+                let search_results = if let Some(ref f) = filter {
+                    coll.search_with_filter(&s.vector, s.top_k, f)?
+                } else {
+                    dispatch_quality_search(&coll, &s.vector, s.top_k, quality.as_ref())?
+                };
+                all_results.push(
+                    search_results
+                        .into_iter()
+                        .map(crate::helpers::map_core_result)
+                        .collect(),
+                );
+            }
+            Ok(all_results)
+        })
+        .map_err(CommandError::from)
+}
+
+/// Optimized bulk batch search (no per-query quality).
+fn batch_search_bulk(
+    state: &VelesDbState,
+    request: &BatchSearchRequest,
+) -> std::result::Result<Vec<Vec<crate::types::SearchResult>>, CommandError> {
+    state
         .with_db(|db| {
             let coll = require_collection(&db, &request.collection)?;
 
@@ -294,12 +434,8 @@ pub async fn batch_search<R: Runtime>(
             let filters: Vec<Option<velesdb_core::Filter>> = request
                 .searches
                 .iter()
-                .map(|s| {
-                    s.filter
-                        .as_ref()
-                        .and_then(|f_json| serde_json::from_value(f_json.clone()).ok())
-                })
-                .collect();
+                .map(|s| parse_filter(&s.filter))
+                .collect::<crate::error::Result<_>>()?;
 
             // Use the maximum top_k across all searches so that every individual
             // query retrieves enough candidates before per-query truncation.
@@ -318,13 +454,7 @@ pub async fn batch_search<R: Runtime>(
                 })
                 .collect::<Vec<_>>())
         })
-        .map_err(CommandError::from)?;
-
-    let timing_ms = start.elapsed().as_secs_f64() * 1000.0;
-    Ok(batch_results
-        .into_iter()
-        .map(|results| SearchResponse { results, timing_ms })
-        .collect())
+        .map_err(CommandError::from)
 }
 
 /// Searches by text using BM25.
@@ -420,6 +550,36 @@ pub async fn flush<R: Runtime>(
             let coll = require_collection(&db, &name)?;
             coll.flush()?;
             Ok(())
+        })
+        .map_err(CommandError::from)
+}
+
+/// Scrolls through collection points with cursor-based pagination.
+#[command]
+pub async fn scroll_collection<R: Runtime>(
+    _app: AppHandle<R>,
+    state: State<'_, VelesDbState>,
+    request: ScrollRequest,
+) -> std::result::Result<ScrollResponse, CommandError> {
+    let parsed_filter = parse_filter(&request.filter).map_err(CommandError::from)?;
+
+    state
+        .with_db(|db| {
+            let coll = require_collection(&db, &request.collection)?;
+            let batch =
+                coll.scroll_batch(request.cursor, request.batch_size, parsed_filter.as_ref())?;
+            Ok(ScrollResponse {
+                points: batch
+                    .points
+                    .into_iter()
+                    .map(|p| PointOutput {
+                        id: p.id,
+                        vector: p.vector,
+                        payload: p.payload,
+                    })
+                    .collect(),
+                next_cursor: batch.next_cursor,
+            })
         })
         .map_err(CommandError::from)
 }
@@ -541,14 +701,19 @@ pub async fn stream_insert<R: Runtime>(
 }
 
 // NOTE: AgentMemory Commands moved to commands_memory.rs (NLOC refactoring)
-pub use crate::commands_memory::{semantic_query, semantic_store};
+pub use crate::commands_memory::{
+    episodic_recent, episodic_record, procedural_learn, procedural_recall, semantic_query,
+    semantic_store,
+};
 
 // NOTE: Secondary Index Commands moved to commands_index.rs
 pub use crate::commands_index::{create_index, drop_index, list_indexes};
 
 // NOTE: Knowledge Graph Commands moved to commands_graph.rs (EPIC-061/US-008 refactoring)
 // Re-export graph commands for backwards compatibility
-pub use crate::commands_graph::{add_edge, get_edges, get_node_degree, traverse_graph};
+pub use crate::commands_graph::{
+    add_edge, create_graph_collection, get_edges, get_node_degree, traverse_graph,
+};
 
 #[cfg(test)]
 #[path = "commands_tests.rs"]

--- a/crates/tauri-plugin-velesdb/src/commands.rs
+++ b/crates/tauri-plugin-velesdb/src/commands.rs
@@ -25,7 +25,6 @@ use tauri::{command, AppHandle, Runtime, State};
 
 /// Builds [`velesdb_core::HnswParams`] from optional request fields, falling
 /// back to dimension-based auto-tuned defaults for any omitted parameter.
-#[cfg(feature = "persistence")]
 pub(crate) fn build_hnsw_params(
     request: &CreateCollectionRequest,
     storage_mode: velesdb_core::StorageMode,

--- a/crates/tauri-plugin-velesdb/src/commands_graph.rs
+++ b/crates/tauri-plugin-velesdb/src/commands_graph.rs
@@ -4,14 +4,56 @@
 #![allow(clippy::missing_errors_doc)]
 
 use crate::error::{CommandError, Error};
-use crate::helpers::require_graph_collection;
+use crate::events::emit_collection_created;
+use crate::helpers::{parse_metric, require_graph_collection};
 use crate::state::VelesDbState;
 use crate::types::{
-    AddEdgeRequest, EdgeOutput, GetEdgesRequest, GetNodeDegreeRequest, NodeDegreeOutput,
-    TraversalOutput, TraverseGraphParallelRequest, TraverseGraphRequest,
+    AddEdgeRequest, CollectionInfo, CreateGraphCollectionRequest, EdgeOutput, GetEdgesRequest,
+    GetNodeDegreeRequest, NodeDegreeOutput, TraversalOutput, TraverseGraphParallelRequest,
+    TraverseGraphRequest,
 };
 use tauri::{command, AppHandle, Runtime, State};
 use velesdb_core::collection::graph::TraversalConfig;
+use velesdb_core::GraphSchema;
+
+/// Creates a graph collection with optional schema and embeddings.
+///
+/// When `graph_schema` is provided, it is deserialized into a [`GraphSchema`].
+/// When omitted, a schemaless graph is created. If `dimension` is set, node
+/// embeddings are enabled with the given metric.
+#[command]
+pub async fn create_graph_collection<R: Runtime>(
+    app: AppHandle<R>,
+    state: State<'_, VelesDbState>,
+    request: CreateGraphCollectionRequest,
+) -> std::result::Result<CollectionInfo, CommandError> {
+    let schema = match &request.graph_schema {
+        Some(json_val) => serde_json::from_value::<GraphSchema>(json_val.clone())
+            .map_err(|e| Error::InvalidConfig(format!("Invalid graph schema: {e}")))?,
+        None => GraphSchema::schemaless(),
+    };
+
+    let result = state
+        .with_db(|db| {
+            if let Some(dim) = request.dimension {
+                let metric = parse_metric(&request.metric)?;
+                db.create_graph_collection_with_embeddings(&request.name, schema, dim, metric)?;
+            } else {
+                db.create_graph_collection(&request.name, schema)?;
+            }
+            Ok(CollectionInfo {
+                name: request.name.clone(),
+                dimension: request.dimension.unwrap_or(0),
+                metric: request.metric.clone(),
+                count: 0,
+                storage_mode: "graph".to_string(),
+            })
+        })
+        .map_err(CommandError::from)?;
+
+    emit_collection_created(&app, &request.name);
+    Ok(result)
+}
 
 /// Adds an edge to the knowledge graph.
 #[command]

--- a/crates/tauri-plugin-velesdb/src/commands_memory.rs
+++ b/crates/tauri-plugin-velesdb/src/commands_memory.rs
@@ -1,13 +1,17 @@
 //! `AgentMemory` Tauri commands extracted from `commands.rs` (EPIC-016 US-003).
 //!
-//! Contains semantic store and semantic query commands.
+//! Contains semantic, episodic, and procedural memory commands.
 #![allow(clippy::missing_errors_doc)]
 
 use crate::error::{CommandError, Error};
 use crate::state::VelesDbState;
-use crate::types::{SemanticQueryRequest, SemanticQueryResult, SemanticStoreRequest};
+use crate::types::{
+    EpisodicRecentRequest, EpisodicRecordRequest, EpisodicResult, ProceduralLearnRequest,
+    ProceduralMatchResult, ProceduralRecallRequest, SemanticQueryRequest, SemanticQueryResult,
+    SemanticStoreRequest,
+};
 use tauri::{command, AppHandle, Runtime, State};
-use velesdb_core::agent::SemanticMemory;
+use velesdb_core::agent::{EpisodicMemory, ProceduralMemory, SemanticMemory};
 
 /// Creates a `SemanticMemory` instance, converting agent errors to plugin errors.
 fn open_semantic_memory(
@@ -15,6 +19,22 @@ fn open_semantic_memory(
     dimension: usize,
 ) -> std::result::Result<SemanticMemory, Error> {
     SemanticMemory::new_from_db(db, dimension).map_err(|e| Error::InvalidConfig(e.to_string()))
+}
+
+/// Creates an `EpisodicMemory` instance, converting agent errors to plugin errors.
+fn open_episodic_memory(
+    db: std::sync::Arc<velesdb_core::Database>,
+    dimension: usize,
+) -> std::result::Result<EpisodicMemory, Error> {
+    EpisodicMemory::new_from_db(db, dimension).map_err(|e| Error::InvalidConfig(e.to_string()))
+}
+
+/// Creates a `ProceduralMemory` instance, converting agent errors to plugin errors.
+fn open_procedural_memory(
+    db: std::sync::Arc<velesdb_core::Database>,
+    dimension: usize,
+) -> std::result::Result<ProceduralMemory, Error> {
+    ProceduralMemory::new_from_db(db, dimension).map_err(|e| Error::InvalidConfig(e.to_string()))
 }
 
 /// Stores a knowledge fact in semantic memory.
@@ -51,6 +71,105 @@ pub async fn semantic_query<R: Runtime>(
             Ok(results
                 .into_iter()
                 .map(|(id, score, content)| SemanticQueryResult { id, score, content })
+                .collect())
+        })
+        .map_err(CommandError::from)
+}
+
+/// Records an episode in episodic memory.
+#[command]
+pub async fn episodic_record<R: Runtime>(
+    _app: AppHandle<R>,
+    state: State<'_, VelesDbState>,
+    request: EpisodicRecordRequest,
+) -> std::result::Result<(), CommandError> {
+    state
+        .with_db(|db| {
+            let memory = open_episodic_memory(db, request.embedding.len())?;
+            memory
+                .record(
+                    request.event_id,
+                    &request.content,
+                    request.timestamp,
+                    Some(&request.embedding),
+                )
+                .map_err(|e| Error::InvalidConfig(e.to_string()))?;
+            Ok(())
+        })
+        .map_err(CommandError::from)
+}
+
+/// Queries recent episodes from episodic memory.
+#[command]
+pub async fn episodic_recent<R: Runtime>(
+    _app: AppHandle<R>,
+    state: State<'_, VelesDbState>,
+    request: EpisodicRecentRequest,
+) -> std::result::Result<Vec<EpisodicResult>, CommandError> {
+    state
+        .with_db(|db| {
+            let memory = open_episodic_memory(db, crate::types::default_dimension())?;
+            let results = memory
+                .recent(request.limit, request.since_timestamp)
+                .map_err(|e| Error::InvalidConfig(e.to_string()))?;
+            Ok(results
+                .into_iter()
+                .map(|(id, content, timestamp)| EpisodicResult {
+                    id,
+                    content,
+                    timestamp,
+                })
+                .collect())
+        })
+        .map_err(CommandError::from)
+}
+
+/// Learns a procedure in procedural memory.
+#[command]
+pub async fn procedural_learn<R: Runtime>(
+    _app: AppHandle<R>,
+    state: State<'_, VelesDbState>,
+    request: ProceduralLearnRequest,
+) -> std::result::Result<(), CommandError> {
+    state
+        .with_db(|db| {
+            let memory = open_procedural_memory(db, request.embedding.len())?;
+            memory
+                .learn(
+                    request.procedure_id,
+                    &request.name,
+                    &request.steps,
+                    Some(&request.embedding),
+                    request.confidence,
+                )
+                .map_err(|e| Error::InvalidConfig(e.to_string()))?;
+            Ok(())
+        })
+        .map_err(CommandError::from)
+}
+
+/// Recalls procedures by similarity from procedural memory.
+#[command]
+pub async fn procedural_recall<R: Runtime>(
+    _app: AppHandle<R>,
+    state: State<'_, VelesDbState>,
+    request: ProceduralRecallRequest,
+) -> std::result::Result<Vec<ProceduralMatchResult>, CommandError> {
+    state
+        .with_db(|db| {
+            let memory = open_procedural_memory(db, request.embedding.len())?;
+            let results = memory
+                .recall(&request.embedding, request.top_k, request.min_confidence)
+                .map_err(|e| Error::InvalidConfig(e.to_string()))?;
+            Ok(results
+                .into_iter()
+                .map(|m| ProceduralMatchResult {
+                    id: m.id,
+                    name: m.name,
+                    steps: m.steps,
+                    confidence: m.confidence,
+                    score: m.score,
+                })
                 .collect())
         })
         .map_err(CommandError::from)

--- a/crates/tauri-plugin-velesdb/src/commands_query.rs
+++ b/crates/tauri-plugin-velesdb/src/commands_query.rs
@@ -39,11 +39,11 @@ fn is_aggregation_query(parsed: &velesdb_core::velesql::Query) -> bool {
 
 /// Executes a `VelesQL` query (EPIC-031 US-012).
 ///
-/// Supports SELECT-style `VelesQL` queries with vector similarity search.
-/// Aggregation queries (GROUP BY, COUNT, etc.) are auto-detected and routed
-/// to `execute_aggregate()`. DDL/DML/TRAIN queries are dispatched directly
-/// to `Database::execute_query`. MATCH queries are not yet supported through
-/// this endpoint. Returns results in `HybridResult` format.
+/// Supports SELECT-style and MATCH-style `VelesQL` queries with vector
+/// similarity search. Aggregation queries (GROUP BY, COUNT, etc.) are
+/// auto-detected and routed to `execute_aggregate()`. DDL/DML/TRAIN/MATCH
+/// queries are dispatched directly to `Database::execute_query`.
+/// Returns results in `HybridResult` format.
 #[command]
 pub async fn query<R: Runtime>(
     _app: AppHandle<R>,
@@ -55,15 +55,6 @@ pub async fn query<R: Runtime>(
     // Parse the VelesQL query
     let parsed = velesdb_core::velesql::Parser::parse(&request.query)
         .map_err(|e| Error::InvalidConfig(format!("VelesQL parse error: {}", e.message)))?;
-
-    // MATCH queries are not supported through this endpoint.
-    if parsed.is_match_query() {
-        return Err(CommandError::from(Error::InvalidConfig(
-            "MATCH queries are not supported through the query endpoint. \
-             Use graph-specific commands instead."
-                .to_string(),
-        )));
-    }
 
     let results = dispatch_tauri_query(&state, &parsed, &request)?;
 

--- a/crates/tauri-plugin-velesdb/src/commands_tests.rs
+++ b/crates/tauri-plugin-velesdb/src/commands_tests.rs
@@ -98,6 +98,99 @@ fn test_create_collection_request_deserialize() {
     assert_eq!(request.dimension, 768);
     assert_eq!(request.metric, "cosine");
     assert_eq!(request.storage_mode, "full");
+    // Advanced params default to None (backward compatibility)
+    assert!(request.hnsw_m.is_none());
+    assert!(request.hnsw_ef_construction.is_none());
+    assert!(request.hnsw_alpha.is_none());
+    assert!(request.hnsw_max_elements.is_none());
+    assert!(request.pq_rescore_oversampling.is_none());
+}
+
+#[test]
+fn test_create_collection_request_with_all_hnsw_params() {
+    let json = r#"{
+        "name": "custom",
+        "dimension": 384,
+        "metric": "euclidean",
+        "storageMode": "sq8",
+        "hnswM": 48,
+        "hnswEfConstruction": 600,
+        "hnswAlpha": 1.5,
+        "hnswMaxElements": 500000,
+        "pqRescoreOversampling": 8
+    }"#;
+    let request: CreateCollectionRequest = serde_json::from_str(json).unwrap();
+
+    assert_eq!(request.name, "custom");
+    assert_eq!(request.dimension, 384);
+    assert_eq!(request.metric, "euclidean");
+    assert_eq!(request.storage_mode, "sq8");
+    assert_eq!(request.hnsw_m, Some(48));
+    assert_eq!(request.hnsw_ef_construction, Some(600));
+    assert!((request.hnsw_alpha.unwrap() - 1.5).abs() < f32::EPSILON);
+    assert_eq!(request.hnsw_max_elements, Some(500_000));
+    assert_eq!(request.pq_rescore_oversampling, Some(8));
+}
+
+#[test]
+fn test_create_collection_request_with_partial_hnsw_params() {
+    let json = r#"{"name": "partial", "dimension": 128, "hnswM": 16}"#;
+    let request: CreateCollectionRequest = serde_json::from_str(json).unwrap();
+
+    assert_eq!(request.hnsw_m, Some(16));
+    assert!(request.hnsw_ef_construction.is_none());
+    assert!(request.hnsw_alpha.is_none());
+    assert!(request.hnsw_max_elements.is_none());
+    assert!(request.pq_rescore_oversampling.is_none());
+}
+
+#[test]
+fn test_build_hnsw_params_uses_auto_defaults() {
+    use crate::commands::build_hnsw_params;
+
+    let json = r#"{"name": "test", "dimension": 768}"#;
+    let request: CreateCollectionRequest = serde_json::from_str(json).unwrap();
+    let params = build_hnsw_params(&request, velesdb_core::StorageMode::Full);
+
+    let auto = velesdb_core::HnswParams::auto(768);
+    assert_eq!(params.max_connections, auto.max_connections);
+    assert_eq!(params.ef_construction, auto.ef_construction);
+    assert_eq!(params.max_elements, auto.max_elements);
+    assert!((params.alpha - auto.alpha).abs() < f32::EPSILON);
+}
+
+#[test]
+fn test_build_hnsw_params_overrides_selectively() {
+    use crate::commands::build_hnsw_params;
+
+    let json = r#"{"name": "test", "dimension": 128, "hnswM": 64, "hnswAlpha": 1.0}"#;
+    let request: CreateCollectionRequest = serde_json::from_str(json).unwrap();
+    let params = build_hnsw_params(&request, velesdb_core::StorageMode::SQ8);
+
+    let auto = velesdb_core::HnswParams::auto(128);
+    assert_eq!(params.max_connections, 64);
+    assert_eq!(params.ef_construction, auto.ef_construction);
+    assert_eq!(params.max_elements, auto.max_elements);
+    assert!((params.alpha - 1.0).abs() < f32::EPSILON);
+    assert_eq!(params.storage_mode, velesdb_core::StorageMode::SQ8);
+}
+
+#[test]
+fn test_has_advanced_params_false_when_all_none() {
+    use crate::commands::has_advanced_params;
+
+    let json = r#"{"name": "test", "dimension": 768}"#;
+    let request: CreateCollectionRequest = serde_json::from_str(json).unwrap();
+    assert!(!has_advanced_params(&request));
+}
+
+#[test]
+fn test_has_advanced_params_true_when_any_set() {
+    use crate::commands::has_advanced_params;
+
+    let json = r#"{"name": "test", "dimension": 768, "pqRescoreOversampling": 4}"#;
+    let request: CreateCollectionRequest = serde_json::from_str(json).unwrap();
+    assert!(has_advanced_params(&request));
 }
 
 #[test]
@@ -108,6 +201,45 @@ fn test_search_request_deserialize() {
     assert_eq!(request.collection, "docs");
     assert_eq!(request.vector, vec![0.1, 0.2, 0.3]);
     assert_eq!(request.top_k, 10);
+    assert!(request.quality.is_none(), "quality should default to None");
+}
+
+#[test]
+fn test_search_request_with_quality() {
+    let json = r#"{"collection": "docs", "vector": [0.1, 0.2], "quality": "fast"}"#;
+    let request: SearchRequest = serde_json::from_str(json).unwrap();
+
+    assert_eq!(request.quality, Some("fast".to_string()));
+}
+
+#[test]
+fn test_search_request_with_quality_camel_case() {
+    // Verify camelCase deserialization for the quality field
+    let json = r#"{"collection": "docs", "vector": [0.1], "topK": 5, "quality": "accurate"}"#;
+    let request: SearchRequest = serde_json::from_str(json).unwrap();
+
+    assert_eq!(request.top_k, 5);
+    assert_eq!(request.quality, Some("accurate".to_string()));
+}
+
+#[test]
+fn test_individual_search_request_with_quality() {
+    use crate::types::IndividualSearchRequest;
+
+    let json = r#"{"vector": [0.1, 0.2], "quality": "balanced"}"#;
+    let request: IndividualSearchRequest = serde_json::from_str(json).unwrap();
+
+    assert_eq!(request.quality, Some("balanced".to_string()));
+}
+
+#[test]
+fn test_individual_search_request_quality_defaults_none() {
+    use crate::types::IndividualSearchRequest;
+
+    let json = r#"{"vector": [0.1, 0.2]}"#;
+    let request: IndividualSearchRequest = serde_json::from_str(json).unwrap();
+
+    assert!(request.quality.is_none());
 }
 
 #[test]
@@ -417,6 +549,7 @@ const REGISTERED_COMMANDS: &[&str] = &[
     "get_collection",
     "is_empty",
     "flush",
+    "scroll_collection",
     // Point operations
     "upsert",
     "upsert_metadata",
@@ -429,15 +562,28 @@ const REGISTERED_COMMANDS: &[&str] = &[
     "hybrid_search",
     "multi_query_search",
     "query",
-    // AgentMemory (semantic)
+    // AgentMemory (semantic, episodic, procedural)
     "semantic_store",
     "semantic_query",
+    "episodic_record",
+    "episodic_recent",
+    "procedural_learn",
+    "procedural_recall",
     // Knowledge Graph
+    "create_graph_collection",
     "add_edge",
     "get_edges",
     "traverse_graph",
     "get_node_degree",
     "traverse_graph_parallel",
+    // Sparse vector operations
+    "sparse_search",
+    "hybrid_sparse_search",
+    "sparse_upsert",
+    // PQ training
+    "train_pq",
+    // Streaming insert (persistence only)
+    "stream_insert",
     // Secondary Indexes
     "create_index",
     "drop_index",
@@ -546,4 +692,158 @@ fn test_build_rs_commands_match_registered() {
              Add '\"{cmd}\"' to the COMMANDS array in build.rs to generate its permission file."
         );
     }
+}
+
+// ============================================================================
+// Scroll DTO Tests
+// ============================================================================
+
+#[test]
+fn test_scroll_request_deserialize() {
+    use crate::types::ScrollRequest;
+    let json = r#"{"collection": "docs"}"#;
+    let req: ScrollRequest = serde_json::from_str(json).unwrap();
+    assert_eq!(req.collection, "docs");
+    assert!(req.cursor.is_none());
+    assert_eq!(req.batch_size, 100); // default
+    assert!(req.filter.is_none());
+}
+
+#[test]
+fn test_scroll_request_with_cursor() {
+    use crate::types::ScrollRequest;
+    let json = r#"{"collection": "docs", "cursor": 42, "batchSize": 50}"#;
+    let req: ScrollRequest = serde_json::from_str(json).unwrap();
+    assert_eq!(req.cursor, Some(42));
+    assert_eq!(req.batch_size, 50);
+}
+
+#[test]
+fn test_scroll_response_serialize() {
+    use crate::types::{PointOutput, ScrollResponse};
+    let resp = ScrollResponse {
+        points: vec![PointOutput {
+            id: 1,
+            vector: vec![0.1, 0.2],
+            payload: None,
+        }],
+        next_cursor: Some(2),
+    };
+    let json = serde_json::to_string(&resp).unwrap();
+    assert!(json.contains("\"nextCursor\":2"));
+    assert!(json.contains("\"id\":1"));
+}
+
+// ============================================================================
+// AgentMemory DTO Deserialization Tests (episodic + procedural)
+// ============================================================================
+
+#[test]
+fn test_episodic_record_request_deserialize() {
+    use crate::types::EpisodicRecordRequest;
+    let json = r#"{"eventId": 42, "content": "found key", "timestamp": 1700000000, "embedding": [0.1, 0.2]}"#;
+    let req: EpisodicRecordRequest = serde_json::from_str(json).unwrap();
+    assert_eq!(req.event_id, 42);
+    assert_eq!(req.content, "found key");
+    assert_eq!(req.timestamp, 1_700_000_000);
+    assert_eq!(req.embedding.len(), 2);
+}
+
+#[test]
+fn test_episodic_recent_request_defaults() {
+    use crate::types::EpisodicRecentRequest;
+    let json = r#"{}"#;
+    let req: EpisodicRecentRequest = serde_json::from_str(json).unwrap();
+    assert_eq!(req.limit, 10); // default_top_k
+    assert!(req.since_timestamp.is_none());
+}
+
+#[test]
+fn test_episodic_recent_request_with_since_timestamp() {
+    use crate::types::EpisodicRecentRequest;
+    let json = r#"{"limit": 5, "sinceTimestamp": 1700000000}"#;
+    let req: EpisodicRecentRequest = serde_json::from_str(json).unwrap();
+    assert_eq!(req.limit, 5);
+    assert_eq!(req.since_timestamp, Some(1_700_000_000));
+}
+
+#[test]
+fn test_procedural_learn_request_deserialize() {
+    use crate::types::ProceduralLearnRequest;
+    let json = r#"{"procedureId": 1, "name": "login", "steps": ["open app", "enter creds"], "embedding": [0.5], "confidence": 0.9}"#;
+    let req: ProceduralLearnRequest = serde_json::from_str(json).unwrap();
+    assert_eq!(req.procedure_id, 1);
+    assert_eq!(req.name, "login");
+    assert_eq!(req.steps.len(), 2);
+    assert!((req.confidence - 0.9).abs() < f32::EPSILON);
+}
+
+#[test]
+fn test_procedural_learn_request_default_confidence() {
+    use crate::types::ProceduralLearnRequest;
+    let json = r#"{"procedureId": 1, "name": "test", "steps": [], "embedding": [0.1]}"#;
+    let req: ProceduralLearnRequest = serde_json::from_str(json).unwrap();
+    assert!((req.confidence - 1.0).abs() < f32::EPSILON);
+}
+
+#[test]
+fn test_procedural_recall_request_deserialize() {
+    use crate::types::ProceduralRecallRequest;
+    let json = r#"{"embedding": [0.1, 0.2], "topK": 5, "minConfidence": 0.5}"#;
+    let req: ProceduralRecallRequest = serde_json::from_str(json).unwrap();
+    assert_eq!(req.top_k, 5);
+    assert!((req.min_confidence - 0.5).abs() < f32::EPSILON);
+}
+
+#[test]
+fn test_procedural_recall_request_defaults() {
+    use crate::types::ProceduralRecallRequest;
+    let json = r#"{"embedding": [0.1]}"#;
+    let req: ProceduralRecallRequest = serde_json::from_str(json).unwrap();
+    assert_eq!(req.top_k, 10); // default_top_k
+    assert!((req.min_confidence - 0.0).abs() < f32::EPSILON);
+}
+
+#[test]
+fn test_episodic_result_serialize() {
+    use crate::types::EpisodicResult;
+    let result = EpisodicResult {
+        id: 42,
+        content: "found key".to_string(),
+        timestamp: 1_700_000_000,
+    };
+    let json = serde_json::to_string(&result).unwrap();
+    assert!(json.contains("\"id\":42"));
+    assert!(json.contains("\"content\":\"found key\""));
+    assert!(json.contains("\"timestamp\":1700000000"));
+}
+
+#[test]
+fn test_procedural_match_result_serialize() {
+    use crate::types::ProceduralMatchResult;
+    let result = ProceduralMatchResult {
+        id: 1,
+        name: "login".to_string(),
+        steps: vec!["open app".to_string(), "enter creds".to_string()],
+        confidence: 0.9,
+        score: 0.85,
+    };
+    let json = serde_json::to_string(&result).unwrap();
+    assert!(json.contains("\"id\":1"));
+    assert!(json.contains("\"name\":\"login\""));
+    assert!(json.contains("\"steps\""));
+    assert!(json.contains("\"confidence\":0.9"));
+    assert!(json.contains("\"score\":0.85"));
+}
+
+#[test]
+fn test_scroll_response_no_next_cursor() {
+    use crate::types::ScrollResponse;
+    let resp = ScrollResponse {
+        points: vec![],
+        next_cursor: None,
+    };
+    let json = serde_json::to_string(&resp).unwrap();
+    // next_cursor should be skipped when None
+    assert!(!json.contains("nextCursor"));
 }

--- a/crates/tauri-plugin-velesdb/src/commands_tests.rs
+++ b/crates/tauri-plugin-velesdb/src/commands_tests.rs
@@ -752,7 +752,7 @@ fn test_episodic_record_request_deserialize() {
 #[test]
 fn test_episodic_recent_request_defaults() {
     use crate::types::EpisodicRecentRequest;
-    let json = r#"{}"#;
+    let json = r"{}";
     let req: EpisodicRecentRequest = serde_json::from_str(json).unwrap();
     assert_eq!(req.limit, 10); // default_top_k
     assert!(req.since_timestamp.is_none());

--- a/crates/tauri-plugin-velesdb/src/events.rs
+++ b/crates/tauri-plugin-velesdb/src/events.rs
@@ -90,7 +90,9 @@ pub fn emit_collection_created<R: Runtime>(app: &AppHandle<R>, collection: &str)
         operation: "created".to_string(),
         count: None,
     };
-    let _ = app.emit(event_names::COLLECTION_CREATED, payload);
+    if let Err(e) = app.emit(event_names::COLLECTION_CREATED, payload) {
+        tracing::warn!(error = %e, "Failed to emit collection-created event");
+    }
 }
 
 /// Emits a collection deleted event.
@@ -100,7 +102,9 @@ pub fn emit_collection_deleted<R: Runtime>(app: &AppHandle<R>, collection: &str)
         operation: "deleted".to_string(),
         count: None,
     };
-    let _ = app.emit(event_names::COLLECTION_DELETED, payload);
+    if let Err(e) = app.emit(event_names::COLLECTION_DELETED, payload) {
+        tracing::warn!(error = %e, "Failed to emit collection-deleted event");
+    }
 }
 
 /// Emits a collection updated event (after upsert or delete).
@@ -115,7 +119,9 @@ pub fn emit_collection_updated<R: Runtime>(
         operation: operation.to_string(),
         count: Some(count),
     };
-    let _ = app.emit(event_names::COLLECTION_UPDATED, payload);
+    if let Err(e) = app.emit(event_names::COLLECTION_UPDATED, payload) {
+        tracing::warn!(error = %e, "Failed to emit collection-updated event");
+    }
 }
 
 /// Emits an operation progress event.
@@ -143,7 +149,9 @@ pub fn emit_progress<R: Runtime>(
         processed,
         message: message.map(String::from),
     };
-    let _ = app.emit(event_names::OPERATION_PROGRESS, payload);
+    if let Err(e) = app.emit(event_names::OPERATION_PROGRESS, payload) {
+        tracing::warn!(error = %e, "Failed to emit operation-progress event");
+    }
 }
 
 /// Emits an operation complete event.
@@ -160,7 +168,9 @@ pub fn emit_complete<R: Runtime>(
         error: error.map(String::from),
         duration_ms,
     };
-    let _ = app.emit(event_names::OPERATION_COMPLETE, payload);
+    if let Err(e) = app.emit(event_names::OPERATION_COMPLETE, payload) {
+        tracing::warn!(error = %e, "Failed to emit operation-complete event");
+    }
 }
 
 #[cfg(test)]

--- a/crates/tauri-plugin-velesdb/src/helpers.rs
+++ b/crates/tauri-plugin-velesdb/src/helpers.rs
@@ -184,6 +184,22 @@ pub fn parse_filter(filter: &Option<serde_json::Value>) -> Result<Option<velesdb
     }
 }
 
+/// Parses an optional search quality mode string into a [`SearchQuality`].
+///
+/// Delegates to [`velesdb_core::api_types::mode_to_search_quality`] to keep
+/// mode parsing in one place. Returns `Ok(None)` when the mode is absent.
+///
+/// [`SearchQuality`]: velesdb_core::SearchQuality
+#[cfg(feature = "persistence")]
+pub fn parse_search_quality(mode: &Option<String>) -> Result<Option<velesdb_core::SearchQuality>> {
+    match mode {
+        None => Ok(None),
+        Some(m) => velesdb_core::api_types::mode_to_search_quality(m)
+            .ok_or_else(|| Error::InvalidConfig(format!("Unknown search quality mode: '{m}'")))
+            .map(Some),
+    }
+}
+
 /// Wraps search results and a start instant into a `SearchResponse`.
 #[must_use]
 pub fn timed_search_response(
@@ -270,5 +286,53 @@ mod tests {
             let s = storage_mode_to_string(mode);
             assert_eq!(parse_storage_mode(s).unwrap(), mode);
         }
+    }
+
+    #[cfg(feature = "persistence")]
+    #[test]
+    fn test_parse_search_quality_none_returns_none() {
+        assert!(parse_search_quality(&None)
+            .expect("test: should succeed for None")
+            .is_none());
+    }
+
+    #[cfg(feature = "persistence")]
+    #[test]
+    fn test_parse_search_quality_named_modes() {
+        for mode in ["fast", "balanced", "accurate", "perfect", "auto"] {
+            assert!(
+                parse_search_quality(&Some(mode.to_string()))
+                    .expect("test: named mode should succeed")
+                    .is_some(),
+                "mode '{mode}' should parse successfully"
+            );
+        }
+    }
+
+    #[cfg(feature = "persistence")]
+    #[test]
+    fn test_parse_search_quality_custom_and_adaptive() {
+        let custom = parse_search_quality(&Some("custom:256".to_string()))
+            .expect("test: custom should succeed");
+        assert_eq!(custom, Some(velesdb_core::SearchQuality::Custom(256)));
+
+        let adaptive = parse_search_quality(&Some("adaptive:32:512".to_string()))
+            .expect("test: adaptive should succeed");
+        assert_eq!(
+            adaptive,
+            Some(velesdb_core::SearchQuality::Adaptive {
+                min_ef: 32,
+                max_ef: 512,
+            })
+        );
+    }
+
+    #[cfg(feature = "persistence")]
+    #[test]
+    fn test_parse_search_quality_invalid() {
+        assert!(parse_search_quality(&Some("nonexistent".to_string())).is_err());
+        assert!(parse_search_quality(&Some(String::new())).is_err());
+        assert!(parse_search_quality(&Some("custom:abc".to_string())).is_err());
+        assert!(parse_search_quality(&Some("adaptive:512:32".to_string())).is_err());
     }
 }

--- a/crates/tauri-plugin-velesdb/src/lib.rs
+++ b/crates/tauri-plugin-velesdb/src/lib.rs
@@ -335,6 +335,7 @@ pub fn init_with_path<R: Runtime, P: AsRef<Path>>(path: P) -> TauriPlugin<R> {
             commands_query::query,
             commands::is_empty,
             commands::flush,
+            commands::scroll_collection,
             // Sparse vector commands
             commands_sparse::sparse_search,
             commands_sparse::hybrid_sparse_search,
@@ -344,7 +345,12 @@ pub fn init_with_path<R: Runtime, P: AsRef<Path>>(path: P) -> TauriPlugin<R> {
             // AgentMemory commands (EPIC-016 US-003)
             commands_memory::semantic_store,
             commands_memory::semantic_query,
+            commands_memory::episodic_record,
+            commands_memory::episodic_recent,
+            commands_memory::procedural_learn,
+            commands_memory::procedural_recall,
             // Knowledge Graph commands (EPIC-015 US-001)
+            commands_graph::create_graph_collection,
             commands_graph::add_edge,
             commands_graph::get_edges,
             commands_graph::traverse_graph,
@@ -363,8 +369,10 @@ pub fn init_with_path<R: Runtime, P: AsRef<Path>>(path: P) -> TauriPlugin<R> {
         .setup(move |app, _api| {
             let state = VelesDbState::new(db_path.clone());
             app.manage(state);
-            // Initialize simple in-memory index for VelesDbExt trait (384 dimensions for AllMiniLML6V2)
-            let simple_index = SimpleIndexState(Arc::new(RwLock::new(SimpleVectorIndex::new(384))));
+            // Initialize simple in-memory index for VelesDbExt trait (default dimension for AllMiniLML6V2)
+            let simple_index = SimpleIndexState(Arc::new(RwLock::new(SimpleVectorIndex::new(
+                crate::types::default_dimension(),
+            ))));
             app.manage(simple_index);
             tracing::info!("VelesDB plugin initialized with path: {:?}", db_path);
             Ok(())

--- a/crates/tauri-plugin-velesdb/src/types.rs
+++ b/crates/tauri-plugin-velesdb/src/types.rs
@@ -48,9 +48,12 @@ pub use velesdb_core::api_types::{
 
 /// Request to create a new collection (Tauri IPC).
 ///
-/// Differs from [`velesdb_core::api_types::CreateCollectionRequest`]: simpler
-/// (no `collection_type`, `hnsw_m`, `hnsw_ef_construction` fields) and uses
-/// `camelCase` deserialization.
+/// Supports optional advanced HNSW tuning parameters (`hnswM`,
+/// `hnswEfConstruction`, `hnswAlpha`, `hnswMaxElements`) and PQ rescore
+/// oversampling (`pqRescoreOversampling`). When all advanced fields are
+/// omitted the collection uses dimension-based auto-tuned defaults.
+///
+/// Uses `camelCase` deserialization for JavaScript callers.
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CreateCollectionRequest {
@@ -64,6 +67,21 @@ pub struct CreateCollectionRequest {
     /// Storage mode: "full", "sq8", "binary".
     #[serde(default = "default_storage_mode")]
     pub storage_mode: String,
+    /// HNSW M parameter (max connections per node). Auto-tuned if omitted.
+    #[serde(default)]
+    pub hnsw_m: Option<usize>,
+    /// HNSW `ef_construction` parameter. Auto-tuned if omitted.
+    #[serde(default)]
+    pub hnsw_ef_construction: Option<usize>,
+    /// HNSW alpha for VAMANA neighbor diversification. Default: 1.2.
+    #[serde(default)]
+    pub hnsw_alpha: Option<f32>,
+    /// HNSW initial max elements capacity. Auto-tuned if omitted.
+    #[serde(default)]
+    pub hnsw_max_elements: Option<usize>,
+    /// PQ rescore oversampling factor. Default: 4.
+    #[serde(default)]
+    pub pq_rescore_oversampling: Option<u32>,
 }
 
 /// Request to create a metadata-only collection.
@@ -72,6 +90,31 @@ pub struct CreateCollectionRequest {
 pub struct CreateMetadataCollectionRequest {
     /// Collection name.
     pub name: String,
+}
+
+/// Request to create a graph collection with optional schema (Tauri IPC).
+///
+/// Supports two modes:
+/// - **Schemaless** (default): pass `graphSchema: { "schemaless": true }` or omit it entirely.
+/// - **Strict**: define `node_types` and `edge_types` in the `graphSchema` JSON object.
+///
+/// When `dimension` is set, node embeddings are enabled with the specified metric.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateGraphCollectionRequest {
+    /// Collection name.
+    pub name: String,
+    /// Optional vector dimension for node embeddings. If omitted, graph has no embeddings.
+    #[serde(default)]
+    pub dimension: Option<usize>,
+    /// Distance metric (when dimension is set). Default: "cosine".
+    #[serde(default = "default_metric")]
+    pub metric: String,
+    /// Graph schema definition as JSON.
+    /// Pass `{ "schemaless": true }` for schemaless mode (default),
+    /// or define `node_types` / `edge_types` for strict mode.
+    #[serde(default)]
+    pub graph_schema: Option<serde_json::Value>,
 }
 
 /// A metadata-only point to insert (no vector).
@@ -150,6 +193,10 @@ pub struct SearchRequest {
     /// Optional metadata filter.
     #[serde(default)]
     pub filter: Option<serde_json::Value>,
+    /// Search quality mode: "fast", "balanced", "accurate", "perfect", "auto",
+    /// "custom:\<ef\>", "adaptive:\<min\>:\<max\>".
+    #[serde(default)]
+    pub quality: Option<String>,
 }
 
 /// Individual search request within a batch.
@@ -164,6 +211,10 @@ pub struct IndividualSearchRequest {
     /// Optional metadata filter.
     #[serde(default)]
     pub filter: Option<serde_json::Value>,
+    /// Search quality mode: "fast", "balanced", "accurate", "perfect", "auto",
+    /// "custom:\<ef\>", "adaptive:\<min\>:\<max\>".
+    #[serde(default)]
+    pub quality: Option<String>,
 }
 
 /// Request for batch search.
@@ -480,17 +531,18 @@ pub struct SemanticQueryResult {
     pub content: String,
 }
 
-/// Request to record an episode.
+/// Request to record an episode in episodic memory.
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct EpisodicRecordRequest {
+    /// Episode event ID.
+    pub event_id: u64,
     /// Episode description/content.
     pub content: String,
+    /// Timestamp (epoch seconds).
+    pub timestamp: i64,
     /// Embedding vector for the episode.
     pub embedding: Vec<f32>,
-    /// Optional context metadata.
-    #[serde(default)]
-    pub context: Option<serde_json::Value>,
 }
 
 /// Request to query recent episodes.
@@ -500,6 +552,9 @@ pub struct EpisodicRecentRequest {
     /// Number of recent episodes to return.
     #[serde(default = "default_top_k")]
     pub limit: usize,
+    /// Only return episodes since this timestamp (epoch seconds).
+    #[serde(default)]
+    pub since_timestamp: Option<i64>,
 }
 
 /// Result from episodic memory query.
@@ -511,15 +566,112 @@ pub struct EpisodicResult {
     /// Episode content.
     pub content: String,
     /// Timestamp (epoch seconds).
-    pub timestamp: u64,
-    /// Optional context.
-    pub context: Option<serde_json::Value>,
+    pub timestamp: i64,
+}
+
+// ============================================================================
+// ProceduralMemory DTOs
+// ============================================================================
+
+/// Default confidence for procedural learning.
+#[must_use]
+pub const fn default_confidence() -> f32 {
+    1.0
+}
+
+/// Request to learn a procedure.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProceduralLearnRequest {
+    /// Procedure ID.
+    pub procedure_id: u64,
+    /// Procedure name.
+    pub name: String,
+    /// Steps to perform.
+    pub steps: Vec<String>,
+    /// Embedding vector for the procedure.
+    pub embedding: Vec<f32>,
+    /// Confidence level (0.0-1.0). Default: 1.0.
+    #[serde(default = "default_confidence")]
+    pub confidence: f32,
+}
+
+/// Request to recall procedures by similarity.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProceduralRecallRequest {
+    /// Query embedding vector.
+    pub embedding: Vec<f32>,
+    /// Number of results.
+    #[serde(default = "default_top_k")]
+    pub top_k: usize,
+    /// Minimum confidence threshold. Default: 0.0 (no filter).
+    #[serde(default)]
+    pub min_confidence: f32,
+}
+
+/// Result from procedural memory recall.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProceduralMatchResult {
+    /// Procedure ID.
+    pub id: u64,
+    /// Procedure name.
+    pub name: String,
+    /// Steps.
+    pub steps: Vec<String>,
+    /// Confidence score.
+    pub confidence: f32,
+    /// Similarity score from vector search.
+    pub score: f32,
 }
 
 // ============================================================================
 // Knowledge Graph Types (EPIC-015 US-001) — moved to types_graph.rs
 // ============================================================================
 pub use crate::types_graph::*;
+
+// ============================================================================
+// Scroll DTOs
+// ============================================================================
+
+/// Default batch size for scroll operations.
+#[must_use]
+pub const fn default_batch_size() -> usize {
+    100
+}
+
+/// Request to scroll through collection points.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ScrollRequest {
+    /// Collection name.
+    pub collection: String,
+    /// Cursor from a previous scroll (omit for the first batch).
+    #[serde(default)]
+    pub cursor: Option<u64>,
+    /// Number of points per batch. Default: 100.
+    #[serde(default = "default_batch_size")]
+    pub batch_size: usize,
+    /// Optional metadata filter.
+    #[serde(default)]
+    pub filter: Option<serde_json::Value>,
+}
+
+/// Response from a scroll operation.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ScrollResponse {
+    /// Points in this batch.
+    pub points: Vec<PointOutput>,
+    /// Cursor for the next batch (absent when no more points).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub next_cursor: Option<u64>,
+}
+
+// ============================================================================
+// Secondary Index DTOs
+// ============================================================================
 
 /// Request to create a secondary index on a metadata field.
 #[derive(Debug, Deserialize)]

--- a/crates/velesdb-cli/src/commands.rs
+++ b/crates/velesdb-cli/src/commands.rs
@@ -303,6 +303,27 @@ pub enum DataCommands {
         #[arg(required = true)]
         ids: Vec<u64>,
     },
+
+    /// Scroll through collection points with cursor-based pagination
+    Scroll {
+        /// Path to database directory
+        path: PathBuf,
+
+        /// Collection name
+        collection: String,
+
+        /// Batch size (number of points per page)
+        #[arg(short, long, default_value = "20")]
+        batch_size: usize,
+
+        /// Starting cursor (point ID to resume after). Omit for first page.
+        #[arg(long)]
+        cursor: Option<u64>,
+
+        /// Output format (table, json)
+        #[arg(short, long, default_value = "json")]
+        format: String,
+    },
 }
 
 // ---------------------------------------------------------------------------
@@ -349,6 +370,27 @@ pub enum QueryCommands {
         /// RRF k parameter (only for rrf strategy)
         #[arg(long, default_value = "60")]
         rrf_k: u32,
+
+        /// Output format (table, json)
+        #[arg(short, long, default_value = "table")]
+        format: String,
+    },
+
+    /// Perform batch search: multiple independent queries in parallel
+    #[command(name = "batch-search")]
+    BatchSearch {
+        /// Path to database directory
+        path: PathBuf,
+
+        /// Collection name
+        collection: String,
+
+        /// Query vectors as JSON array of arrays (e.g., '[[1.0, 0.0], [0.0, 1.0]]')
+        vectors: String,
+
+        /// Number of results per query
+        #[arg(short = 'k', long, default_value = "10")]
+        top_k: usize,
 
         /// Output format (table, json)
         #[arg(short, long, default_value = "table")]

--- a/crates/velesdb-cli/src/commands.rs
+++ b/crates/velesdb-cli/src/commands.rs
@@ -54,7 +54,7 @@ pub enum Commands {
         action: CollectionCommands,
     },
 
-    /// Data operations (import, export, upsert, get, delete)
+    /// Data operations (import, export, upsert, get, delete, stream-insert)
     Data {
         #[command(subcommand)]
         action: DataCommands,
@@ -323,6 +323,20 @@ pub enum DataCommands {
         /// Output format (table, json)
         #[arg(short, long, default_value = "json")]
         format: String,
+    },
+
+    /// Stream-insert points from stdin (one JSON object per line)
+    #[command(name = "stream-insert")]
+    StreamInsert {
+        /// Path to database directory
+        path: PathBuf,
+
+        /// Collection name
+        collection: String,
+
+        /// Batch size for micro-batching (points buffered before upsert)
+        #[arg(short, long, default_value = "100")]
+        batch_size: usize,
     },
 }
 

--- a/crates/velesdb-cli/src/handlers/data.rs
+++ b/crates/velesdb-cli/src/handlers/data.rs
@@ -1,4 +1,4 @@
-//! Handlers for data commands: `export`, `import`, `get`, `upsert`, `delete-points`.
+//! Handlers for data commands: `export`, `import`, `get`, `upsert`, `delete-points`, `stream-insert`.
 
 use std::path::{Path, PathBuf};
 
@@ -313,4 +313,119 @@ fn print_scroll_table(batch: &velesdb_core::ScrollBatch, collection: &str) {
     } else {
         println!("\n  {} End of collection", "\u{2713}".green());
     }
+}
+
+/// Handles the `stream-insert` subcommand: reads JSONL from stdin and upserts in micro-batches.
+///
+/// Each line must be a JSON object with `id` (number), `vector` (array of numbers),
+/// and optional `payload` (object). Example:
+/// ```json
+/// {"id": 1, "vector": [0.1, 0.2, 0.3], "payload": {"title": "Doc 1"}}
+/// ```
+pub fn handle_stream_insert(path: &Path, collection: &str, batch_size: usize) -> Result<()> {
+    use std::io::BufRead;
+
+    let db = velesdb_core::Database::open(path)?;
+    let col = db
+        .get_vector_collection(collection)
+        .ok_or_else(|| anyhow::anyhow!("Vector collection '{}' not found", collection))?;
+
+    let stdin = std::io::stdin();
+    let reader = stdin.lock();
+
+    let mut batch: Vec<velesdb_core::Point> = Vec::with_capacity(batch_size);
+    let mut total_inserted: usize = 0;
+    let mut total_errors: usize = 0;
+
+    for line_result in reader.lines() {
+        let line = line_result?;
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+
+        match parse_point_json(trimmed) {
+            Ok(point) => {
+                batch.push(point);
+                if batch.len() >= batch_size {
+                    let count = batch.len();
+                    flush_batch(&col, &mut batch)?;
+                    total_inserted += count;
+                    eprint!("\r  Inserted: {total_inserted}");
+                }
+            }
+            Err(e) => {
+                total_errors += 1;
+                eprintln!("\r  Skipping invalid line: {e}");
+            }
+        }
+    }
+
+    // Flush remaining batch
+    if !batch.is_empty() {
+        let count = batch.len();
+        flush_batch(&col, &mut batch)?;
+        total_inserted += count;
+    }
+
+    eprintln!();
+    println!(
+        "{} Stream insert complete: {} inserted, {} errors",
+        "\u{2705}".green(),
+        total_inserted.to_string().green(),
+        format_error_count(total_errors),
+    );
+    Ok(())
+}
+
+/// Upserts a batch of points and drains the buffer via `std::mem::take`.
+fn flush_batch(
+    col: &velesdb_core::VectorCollection,
+    batch: &mut Vec<velesdb_core::Point>,
+) -> Result<()> {
+    col.upsert(std::mem::take(batch))
+        .map_err(|e| anyhow::anyhow!("Upsert failed: {e}"))
+}
+
+/// Formats the error count: red if non-zero, plain "0" otherwise.
+fn format_error_count(count: usize) -> String {
+    if count > 0 {
+        count.to_string().red().to_string()
+    } else {
+        "0".to_string()
+    }
+}
+
+/// Parses a single JSONL line into a [`velesdb_core::Point`].
+///
+/// Expected format: `{"id": <u64>, "vector": [<f32>, ...], "payload": {...}}`
+fn parse_point_json(json_str: &str) -> Result<velesdb_core::Point> {
+    let v: serde_json::Value =
+        serde_json::from_str(json_str).map_err(|e| anyhow::anyhow!("JSON parse error: {e}"))?;
+
+    let id = v
+        .get("id")
+        .and_then(serde_json::Value::as_u64)
+        .ok_or_else(|| anyhow::anyhow!("Missing or invalid 'id' field"))?;
+
+    let vector = parse_vector_array(&v)?;
+    let payload = v.get("payload").cloned();
+
+    Ok(velesdb_core::Point::new(id, vector, payload))
+}
+
+/// Extracts the `"vector"` field from a JSON value as `Vec<f32>`.
+fn parse_vector_array(v: &serde_json::Value) -> Result<Vec<f32>> {
+    let arr = v
+        .get("vector")
+        .and_then(serde_json::Value::as_array)
+        .ok_or_else(|| anyhow::anyhow!("Missing or invalid 'vector' field"))?;
+
+    arr.iter()
+        .map(|n| {
+            n.as_f64()
+                .map(|f| f as f32)
+                .ok_or_else(|| anyhow::anyhow!("Non-numeric value in vector"))
+        })
+        .collect()
 }

--- a/crates/velesdb-cli/src/handlers/data.rs
+++ b/crates/velesdb-cli/src/handlers/data.rs
@@ -245,3 +245,72 @@ pub fn handle_delete_points(path: &Path, collection: &str, ids: &[u64]) -> Resul
     );
     Ok(())
 }
+
+/// Handles the `scroll` subcommand: cursor-based pagination through a collection.
+pub fn handle_scroll(
+    path: &Path,
+    collection: &str,
+    batch_size: usize,
+    cursor: Option<u64>,
+    format: &str,
+) -> Result<()> {
+    let db = velesdb_core::Database::open(path)?;
+    let col = db
+        .get_vector_collection(collection)
+        .ok_or_else(|| anyhow::anyhow!("Collection '{}' not found", collection))?;
+
+    let batch = col
+        .scroll_batch(cursor, batch_size, None)
+        .map_err(|e| anyhow::anyhow!("Scroll failed: {e}"))?;
+
+    if format == "json" {
+        print_scroll_json(&batch)
+    } else {
+        print_scroll_table(&batch, collection);
+        Ok(())
+    }
+}
+
+/// Prints scroll results as JSON (suitable for piping).
+fn print_scroll_json(batch: &velesdb_core::ScrollBatch) -> Result<()> {
+    let output = serde_json::json!({
+        "points": batch.points.iter().map(|p| {
+            serde_json::json!({
+                "id": p.id,
+                "vector": p.vector,
+                "payload": p.payload
+            })
+        }).collect::<Vec<_>>(),
+        "nextCursor": batch.next_cursor
+    });
+    println!("{}", serde_json::to_string_pretty(&output)?);
+    Ok(())
+}
+
+/// Prints scroll results as a colored table.
+fn print_scroll_table(batch: &velesdb_core::ScrollBatch, collection: &str) {
+    println!(
+        "\n{} ({} points)",
+        format!("Scroll: {collection}").bold().underline(),
+        batch.points.len()
+    );
+    for p in &batch.points {
+        println!(
+            "  ID: {} [{} dims]",
+            p.id.to_string().green(),
+            p.vector.len()
+        );
+        if let Some(payload) = &p.payload {
+            println!("    Payload: {payload}");
+        }
+    }
+    if let Some(next) = batch.next_cursor {
+        println!(
+            "\n  Next cursor: {} (pass --cursor {} to continue)",
+            next.to_string().cyan(),
+            next
+        );
+    } else {
+        println!("\n  {} End of collection", "\u{2713}".green());
+    }
+}

--- a/crates/velesdb-cli/src/handlers/mod.rs
+++ b/crates/velesdb-cli/src/handlers/mod.rs
@@ -14,8 +14,10 @@ pub use collections::{
     handle_create_graph_collection, handle_create_metadata_collection,
     handle_create_vector_collection, handle_delete_collection,
 };
-pub use data::{handle_delete_points, handle_export, handle_get, handle_import, handle_upsert};
+pub use data::{
+    handle_delete_points, handle_export, handle_get, handle_import, handle_scroll, handle_upsert,
+};
 pub use index::handle_index;
 pub use info::{handle_analyze, handle_info, handle_list, handle_show};
-pub use search::handle_multi_search;
+pub use search::{handle_batch_search, handle_multi_search};
 pub use tools::{handle_completions, handle_explain, handle_license, handle_simd};

--- a/crates/velesdb-cli/src/handlers/mod.rs
+++ b/crates/velesdb-cli/src/handlers/mod.rs
@@ -15,7 +15,8 @@ pub use collections::{
     handle_create_vector_collection, handle_delete_collection,
 };
 pub use data::{
-    handle_delete_points, handle_export, handle_get, handle_import, handle_scroll, handle_upsert,
+    handle_delete_points, handle_export, handle_get, handle_import, handle_scroll,
+    handle_stream_insert, handle_upsert,
 };
 pub use index::handle_index;
 pub use info::{handle_analyze, handle_info, handle_list, handle_show};

--- a/crates/velesdb-cli/src/handlers/search.rs
+++ b/crates/velesdb-cli/src/handlers/search.rs
@@ -131,3 +131,79 @@ fn print_search_table(results: &[velesdb_core::SearchResult], strategy: &str, ve
     }
     println!("\n  Total: {} result(s)\n", results.len());
 }
+
+/// Handles the `batch-search` subcommand: independent parallel searches.
+pub fn handle_batch_search(
+    path: &Path,
+    collection: &str,
+    vectors: &str,
+    top_k: usize,
+    format: &str,
+) -> Result<()> {
+    let col = open_vector_collection(path, collection)?;
+    let parsed_vectors = parse_query_vectors(vectors)?;
+
+    let query_refs: Vec<&[f32]> = parsed_vectors.iter().map(Vec::as_slice).collect();
+    let no_filters: Vec<Option<velesdb_core::Filter>> = vec![None; parsed_vectors.len()];
+
+    let batch_results = col
+        .search_batch_with_filters(&query_refs, top_k, &no_filters)
+        .map_err(|e| anyhow::anyhow!("Batch search failed: {e}"))?;
+
+    if format == "json" {
+        print_batch_json(&batch_results)
+    } else {
+        print_batch_table(&batch_results);
+        Ok(())
+    }
+}
+
+/// Prints batch search results as JSON.
+fn print_batch_json(batch: &[Vec<velesdb_core::SearchResult>]) -> Result<()> {
+    let output: Vec<_> = batch
+        .iter()
+        .enumerate()
+        .map(|(i, results)| {
+            serde_json::json!({
+                "query": i,
+                "results": results.iter().map(|r| {
+                    serde_json::json!({
+                        "id": r.point.id,
+                        "score": r.score,
+                        "payload": r.point.payload
+                    })
+                }).collect::<Vec<_>>()
+            })
+        })
+        .collect();
+    println!("{}", serde_json::to_string_pretty(&output)?);
+    Ok(())
+}
+
+/// Prints batch search results as a colored table.
+fn print_batch_table(batch: &[Vec<velesdb_core::SearchResult>]) {
+    for (i, results) in batch.iter().enumerate() {
+        println!(
+            "\n{} (query {})",
+            "Batch Search Results".bold().underline(),
+            (i + 1).to_string().cyan()
+        );
+        if results.is_empty() {
+            println!("  No results found.");
+            continue;
+        }
+        for (j, r) in results.iter().enumerate() {
+            println!(
+                "  {}. ID: {} (score: {:.4})",
+                j + 1,
+                r.point.id.to_string().green(),
+                r.score
+            );
+            if let Some(payload) = &r.point.payload {
+                println!("     Payload: {payload}");
+            }
+        }
+        println!("  Total: {} result(s)", results.len());
+    }
+    println!();
+}

--- a/crates/velesdb-cli/src/main.rs
+++ b/crates/velesdb-cli/src/main.rs
@@ -199,6 +199,13 @@ fn dispatch_data(action: DataCommands) -> anyhow::Result<()> {
             collection,
             ids,
         } => handlers::handle_delete_points(&path, &collection, &ids),
+        DataCommands::Scroll {
+            path,
+            collection,
+            batch_size,
+            cursor,
+            format,
+        } => handlers::handle_scroll(&path, &collection, batch_size, cursor, &format),
     }
 }
 
@@ -227,6 +234,13 @@ fn dispatch_query_cmd(action: QueryCommands) -> anyhow::Result<()> {
             rrf_k,
             &format,
         ),
+        QueryCommands::BatchSearch {
+            path,
+            collection,
+            vectors,
+            top_k,
+            format,
+        } => handlers::handle_batch_search(&path, &collection, &vectors, top_k, &format),
         QueryCommands::Explain {
             path,
             query,

--- a/crates/velesdb-cli/src/main.rs
+++ b/crates/velesdb-cli/src/main.rs
@@ -206,6 +206,11 @@ fn dispatch_data(action: DataCommands) -> anyhow::Result<()> {
             cursor,
             format,
         } => handlers::handle_scroll(&path, &collection, batch_size, cursor, &format),
+        DataCommands::StreamInsert {
+            path,
+            collection,
+            batch_size,
+        } => handlers::handle_stream_insert(&path, &collection, batch_size),
     }
 }
 


### PR DESCRIPTION
## Summary

Three waves delivering Tauri plugin parity and CLI feature completion:

### Wave 5 — Tauri plugin parity (58%→90%+, 7 items)
- **#25 PROP-SQ-TAURI**: SearchQuality in search DTOs → `search_with_quality()`
- **#26 PROP-VQL-TAURI-MATCH**: Unblock MATCH graph queries
- **#27 PROP-CONFIG-ADVANCED**: HNSW params in CreateCollectionRequest
- **#28 PROP-GRAPHSCHEMA**: `create_graph_collection` with schema + embeddings
- **S2-NEW-02 Scroll**: `scroll_collection` cursor-based pagination
- **S2-NEW-06 Agent Memory**: 4 new commands (episodic_record/recent + procedural_learn/recall)
- **#29 Quality pass**: Fix 384 hardcode, silent emits, registration gap (5 missing commands)

### Wave 6 — CLI block (2 items)
- **S2-NEW-01**: `velesdb data scroll` — cursor-based pagination with JSON/table output
- **S2-NEW-04**: `velesdb query batch-search` — independent parallel searches

### Wave 7 — stream_insert CLI (1 item)
- **S2-NEW-03**: `velesdb data stream-insert` — JSONL stdin micro-batching

### Expert review fixes (Wave 5)
- Runtime crash fix: `episodic_recent` dimension=1 → `default_dimension()`
- Silent error fix: `batch_search` filter `.ok()` → `parse_filter()` with `?`
- TypeScript fixes: CollectionInfo.storageMode, filter on text/hybrid, query() → QueryResponse

### Stats
- 30 files changed, ~2100 insertions
- 38 Tauri commands, 3 new CLI subcommands
- 90 Tauri tests + 324 CLI tests + 4546 core tests, 0 regressions

## Test plan
- [x] `cargo clippy --pedantic` (Tauri + CLI) — clean
- [x] `cargo test -p tauri-plugin-velesdb` — 90 tests
- [x] `cargo test -p velesdb-cli` — 324 tests  
- [x] `cargo test -p velesdb-core` — 4546 tests
- [x] Feature gate checks (no-default-features, WASM)
- [ ] CI pipeline (Codacy, Devin, Linux, Windows, WASM)
