### PR TITLE
Sprint 4 Phase C Vague 1+2: BDD tests + Python E2E

### DIFF
--- a/crates/velesdb-core/tests/bdd.rs
+++ b/crates/velesdb-core/tests/bdd.rs
@@ -45,6 +45,8 @@ mod hybrid_compositions;
 mod index_management;
 #[path = "bdd/introspection.rs"]
 mod introspection;
+#[path = "bdd/match_graph_first.rs"]
+mod match_graph_first;
 #[path = "bdd/match_vector_first.rs"]
 mod match_vector_first;
 #[path = "bdd/operators.rs"]

--- a/crates/velesdb-core/tests/bdd/hybrid_compositions.rs
+++ b/crates/velesdb-core/tests/bdd/hybrid_compositions.rs
@@ -666,3 +666,305 @@ fn test_delete_then_near_excludes_deleted() {
         );
     }
 }
+
+// =========================================================================
+// S4-16: BM25 + vector RRF pure fusion BDD
+// -------------------------------------------------------------------------
+// DESIGN: "Pure" hybrid = RRF fusion of BM25 text search and vector kNN
+// with no graph pattern. VelesQL exposes this pattern via the public
+// `VectorCollection::hybrid_search` API, which is the canonical entry
+// point for BM25+vector fusion. The surface-level alternative
+// `NEAR $v AND column MATCH 'term'` routes through the same fusion
+// pipeline (see `search/query/execution_paths.rs::dispatch_near_with_filter`)
+// and is covered separately by `test_near_match_bm25_with_vector_affinity`.
+//
+// We assert against the public engine API because it yields fully
+// deterministic input to the RRF formula and lets us hand-compute the
+// expected fused scores from the two branch rank orders. Formula:
+//   score(doc) = w_v * 1/(rank_v + k)  +  w_t * 1/(rank_t + k)
+// with defaults w_v = w_t = 0.5 and k = 60 (per FusionStrategy::rrf_default).
+// =========================================================================
+
+/// Populates a "hybrid_pure" collection with 4 documents having distinct
+/// vector directions and distinct text content. Vectors are aligned on the
+/// unit axes so cosine ranks are unambiguous.
+fn setup_hybrid_pure_collection(db: &Database) {
+    db.create_vector_collection("hybrid_pure", 4, velesdb_core::DistanceMetric::Cosine)
+        .expect("test: create hybrid_pure collection");
+    let vc = db
+        .get_vector_collection("hybrid_pure")
+        .expect("test: get hybrid_pure collection");
+
+    vc.upsert(vec![
+        Point::new(
+            1,
+            vec![1.0, 0.0, 0.0, 0.0],
+            Some(json!({"title": "rust programming language"})),
+        ),
+        Point::new(
+            2,
+            vec![0.0, 1.0, 0.0, 0.0],
+            Some(json!({"title": "programming programming guide"})),
+        ),
+        Point::new(
+            3,
+            vec![0.0, 0.0, 1.0, 0.0],
+            Some(json!({"title": "cooking recipes"})),
+        ),
+        Point::new(
+            4,
+            vec![0.0, 0.0, 0.0, 1.0],
+            Some(json!({"title": "garden flowers"})),
+        ),
+    ])
+    .expect("test: upsert hybrid_pure corpus");
+}
+
+/// Computes the expected RRF fused score for a given document ID from the
+/// empirical rank orders of the vector and text branches.
+///
+/// Returns 0.0 for branches where the doc does not appear.
+fn rrf_score(vector_rank: Option<usize>, text_rank: Option<usize>) -> f32 {
+    const VECTOR_WEIGHT: f32 = 0.5;
+    const TEXT_WEIGHT: f32 = 0.5;
+    const RRF_K: f32 = 60.0;
+
+    // Reason: empirical ranks from test fixtures are < 16; usize->f32 exact.
+    #[allow(clippy::cast_precision_loss)]
+    let v_term = vector_rank.map_or(0.0, |r| VECTOR_WEIGHT / (r as f32 + RRF_K));
+    #[allow(clippy::cast_precision_loss)]
+    let t_term = text_rank.map_or(0.0, |r| TEXT_WEIGHT / (r as f32 + RRF_K));
+    v_term + t_term
+}
+
+/// Returns the position (0-indexed rank) of `id` in `ranking`, or `None`.
+fn rank_of(ranking: &[u64], id: u64) -> Option<usize> {
+    ranking.iter().position(|&x| x == id)
+}
+
+/// GIVEN a collection of 4 documents with distinct vectors and text payloads
+/// WHEN `hybrid_search` runs with the canonical RRF settings (alpha=None =>
+///      0.5/0.5 weights, rrf_k=60) for top-5
+/// THEN the fused score for every returned document matches the hand-computed
+///      formula `0.5/(rv+60) + 0.5/(rt+60)` using the empirical ranks from
+///      each branch, and the order is fused-score descending.
+///
+/// This validates that k=60 and the `1/(k+rank+1)` (0-indexed +1 internally,
+/// which matches `rank_as_f32 + rrf_k`) formula are actually applied.
+#[test]
+fn test_hybrid_rrf_fused_score_matches_hand_computed_formula() {
+    let (_dir, db) = create_test_db();
+    setup_hybrid_pure_collection(&db);
+    let vc = db
+        .get_vector_collection("hybrid_pure")
+        .expect("test: get hybrid_pure");
+
+    let query_vec = [1.0, 0.0, 0.0, 0.0];
+    let query_text = "programming";
+
+    // Snapshot per-branch ranks to derive expected RRF scores.
+    // Over-fetch (k * 2) matches the hybrid_search internal gate.
+    let vector_only = vc.search(&query_vec, 10).expect("test: vector-only search");
+    let vector_ranking: Vec<u64> = vector_only.iter().map(|r| r.point.id).collect();
+
+    let text_only = vc
+        .text_search(query_text, 10)
+        .expect("test: text-only search");
+    let text_ranking: Vec<u64> = text_only.iter().map(|r| r.point.id).collect();
+
+    // Sanity: the corpus contains the query tokens on known ids.
+    assert!(
+        !text_ranking.is_empty(),
+        "text branch must find at least one match for 'programming'"
+    );
+
+    let fused = vc
+        .hybrid_search(&query_vec, query_text, 5, None)
+        .expect("test: hybrid_search should succeed");
+
+    assert!(!fused.is_empty(), "hybrid search must return fused results");
+
+    // Verify every fused score equals the hand-computed RRF formula.
+    for hit in &fused {
+        let expected = rrf_score(
+            rank_of(&vector_ranking, hit.point.id),
+            rank_of(&text_ranking, hit.point.id),
+        );
+        assert!(
+            (hit.score - expected).abs() < 1e-6,
+            "RRF fused score mismatch for id={}: actual={}, expected={} \
+             (vector_rank={:?}, text_rank={:?})",
+            hit.point.id,
+            hit.score,
+            expected,
+            rank_of(&vector_ranking, hit.point.id),
+            rank_of(&text_ranking, hit.point.id),
+        );
+    }
+
+    // Verify the results are sorted by fused score descending.
+    for w in fused.windows(2) {
+        assert!(
+            w[0].score >= w[1].score,
+            "fused scores must be non-increasing: {} >= {} (ids {} vs {})",
+            w[0].score,
+            w[1].score,
+            w[0].point.id,
+            w[1].point.id
+        );
+    }
+}
+
+/// GIVEN a corpus where two docs have rank assignments that are a
+///       permutation of each other across the two branches:
+///       doc A: vector rank 0, text rank 1
+///       doc B: vector rank 1, text rank 0
+/// WHEN `hybrid_search` fuses the branches with equal weights
+/// THEN both docs receive identical fused scores
+///      (`0.5/60 + 0.5/61 = 0.5/61 + 0.5/60`), and both appear in the
+///      final top-k with fused-score ties broken deterministically.
+#[test]
+fn test_hybrid_rrf_permuted_ranks_produce_identical_fused_scores() {
+    let (_dir, db) = create_test_db();
+    db.create_vector_collection("tied", 4, velesdb_core::DistanceMetric::Cosine)
+        .expect("test: create tied collection");
+    let vc = db.get_vector_collection("tied").expect("test: get tied");
+
+    // Two docs, both matching the text query at TF=1. The vector ranking
+    // is determined by cosine to [1, 0, 0, 0]: id=1 (exact) ranks above
+    // id=2 (orthogonal, similarity 0). BM25 ranks: id=2's payload is
+    // shorter, so it ranks above id=1.
+    vc.upsert(vec![
+        Point::new(
+            1,
+            vec![1.0, 0.0, 0.0, 0.0],
+            Some(json!({"title": "programming rust language guide book"})),
+        ),
+        Point::new(
+            2,
+            vec![0.0, 0.0, 0.0, 1.0],
+            Some(json!({"title": "programming"})),
+        ),
+    ])
+    .expect("test: upsert tied corpus");
+
+    let query_vec = [1.0, 0.0, 0.0, 0.0];
+    let query_text = "programming";
+
+    // Snapshot empirical per-branch ranks so the test stays robust to the
+    // exact BM25 parameters used by the index.
+    let vector_only = vc.search(&query_vec, 10).expect("test: vector-only search");
+    let text_only = vc
+        .text_search(query_text, 10)
+        .expect("test: text-only search");
+    let vector_rank_1 = rank_of(
+        &vector_only.iter().map(|r| r.point.id).collect::<Vec<_>>(),
+        1,
+    );
+    let vector_rank_2 = rank_of(
+        &vector_only.iter().map(|r| r.point.id).collect::<Vec<_>>(),
+        2,
+    );
+    let text_rank_1 = rank_of(&text_only.iter().map(|r| r.point.id).collect::<Vec<_>>(), 1);
+    let text_rank_2 = rank_of(&text_only.iter().map(|r| r.point.id).collect::<Vec<_>>(), 2);
+
+    // Precondition: ranks must be a permutation (swap pattern) for the
+    // fused scores to tie. If BM25 tuning ever changes this, the test
+    // diagnoses the setup issue instead of failing cryptically.
+    assert_eq!(
+        (vector_rank_1, text_rank_1),
+        (Some(0), Some(1)),
+        "fixture precondition: id=1 must rank top in vector, second in text"
+    );
+    assert_eq!(
+        (vector_rank_2, text_rank_2),
+        (Some(1), Some(0)),
+        "fixture precondition: id=2 must rank second in vector, top in text"
+    );
+
+    let fused = vc
+        .hybrid_search(&query_vec, query_text, 10, None)
+        .expect("test: hybrid_search should succeed");
+    let fused_map: std::collections::HashMap<u64, f32> =
+        fused.iter().map(|r| (r.point.id, r.score)).collect();
+
+    let score_1 = fused_map
+        .get(&1)
+        .copied()
+        .expect("test: id=1 must be in fused results");
+    let score_2 = fused_map
+        .get(&2)
+        .copied()
+        .expect("test: id=2 must be in fused results");
+
+    let expected = 0.5_f32 / 60.0 + 0.5_f32 / 61.0;
+    assert!(
+        (score_1 - expected).abs() < 1e-6,
+        "id=1 permuted-rank RRF score mismatch: {} != {}",
+        score_1,
+        expected
+    );
+    assert!(
+        (score_2 - expected).abs() < 1e-6,
+        "id=2 permuted-rank RRF score mismatch: {} != {}",
+        score_2,
+        expected
+    );
+    assert!(
+        (score_1 - score_2).abs() < f32::EPSILON,
+        "permuted rank pair must yield identical fused scores: {score_1} vs {score_2}"
+    );
+}
+
+/// GIVEN a corpus where the text query matches zero documents
+/// WHEN `hybrid_search` runs
+/// THEN RRF collapses to the pure vector ranking: fused scores equal
+///      `0.5 / (rank + 60)` for each doc in vector order, and the result
+///      order matches the vector-only ranking exactly.
+#[test]
+fn test_hybrid_rrf_empty_text_side_collapses_to_vector_ranking() {
+    let (_dir, db) = create_test_db();
+    setup_hybrid_pure_collection(&db);
+    let vc = db
+        .get_vector_collection("hybrid_pure")
+        .expect("test: get hybrid_pure");
+
+    let query_vec = [1.0, 0.0, 0.0, 0.0];
+    // This term does not appear in any payload.
+    let query_text = "zzzzzzzzzzzzzzzz_no_match";
+
+    let vector_only = vc.search(&query_vec, 10).expect("test: vector-only search");
+    let fused = vc
+        .hybrid_search(&query_vec, query_text, 4, None)
+        .expect("test: hybrid_search should succeed");
+
+    assert!(
+        !fused.is_empty(),
+        "empty text side must not zero out the vector branch"
+    );
+
+    // Order must match the vector-only ranking for the prefix of length |fused|.
+    let fused_ids: Vec<u64> = fused.iter().map(|r| r.point.id).collect();
+    let vector_prefix: Vec<u64> = vector_only
+        .iter()
+        .take(fused_ids.len())
+        .map(|r| r.point.id)
+        .collect();
+    assert_eq!(
+        fused_ids, vector_prefix,
+        "empty BM25 side must collapse to vector ranking"
+    );
+
+    // Every fused score must equal 0.5 / (rank + 60) with no text contribution.
+    for (rank, hit) in fused.iter().enumerate() {
+        let expected = rrf_score(Some(rank), None);
+        assert!(
+            (hit.score - expected).abs() < 1e-6,
+            "rank {} id {} fused score {} != expected vector-only {}",
+            rank,
+            hit.point.id,
+            hit.score,
+            expected,
+        );
+    }
+}

--- a/crates/velesdb-core/tests/bdd/match_graph_first.rs
+++ b/crates/velesdb-core/tests/bdd/match_graph_first.rs
@@ -1,0 +1,360 @@
+//! BDD tests for the GraphFirst MATCH execution strategy (S4-17).
+//!
+//! The MATCH query planner (`MatchQueryPlanner::plan`) selects
+//! `MatchExecutionStrategy::GraphFirst` when the WHERE clause contains
+//! **no** `similarity()` predicate. GraphFirst traverses the graph from the
+//! start node (optionally filtered by labels + property index), then
+//! evaluates the remaining WHERE conditions. It is the default strategy for
+//! pure-graph queries and queries whose WHERE clause only touches scalar
+//! properties.
+//!
+//! These tests exercise the **full pipeline**: SQL string -> parse ->
+//! planner strategy selection -> execute -> verify bindings.
+//!
+//! Two complementary assertion strategies are used:
+//!
+//! 1. **Planner-level**: call `MatchQueryPlanner::plan` directly on the
+//!    parsed `MatchClause` with a representative `CollectionStats` to assert
+//!    that `GraphFirst` is the strategy the planner would pick. This gives
+//!    deterministic coverage of strategy selection without depending on
+//!    execution side-effects.
+//! 2. **Behavior-level**: execute the same query through
+//!    `Database::execute_query` and verify the returned node bindings match
+//!    what a correct GraphFirst execution must yield.
+//!
+//! Coverage breakdown (per `.claude/rules/bdd-testing.md`):
+//!
+//! | Category | Count | Share |
+//! |----------|-------|-------|
+//! | Nominal  |   3   |  50%  |
+//! | Edge     |   2   |  33%  |
+//! | Negative |   1   |  17%  |
+
+use std::collections::HashMap;
+
+use serde_json::json;
+use velesdb_core::collection::search::query::match_planner::{
+    CollectionStats, MatchExecutionStrategy, MatchQueryPlanner,
+};
+use velesdb_core::{Database, GraphEdge, Point};
+
+use super::helpers::create_test_db;
+
+// =========================================================================
+// Module-specific setup
+// =========================================================================
+
+/// Creates a `VectorCollection` with 5 labeled nodes and a single CITES
+/// edge, yielding a lopsided graph so GraphFirst traversal is clearly
+/// cheaper than vector scan.
+///
+/// Graph topology:
+/// ```text
+///   (1:Document {category:"science"})--[:CITES]-->(2:Reference {category:"science"})
+///   (3:Document {category:"tech"})     (no outgoing edge)
+///   (4:Document {category:"tech"})     (no outgoing edge)
+///   (5:Reference {category:"history"}) (isolated)
+/// ```
+fn setup_graph_first_collection(db: &Database) {
+    db.create_vector_collection("papers", 4, velesdb_core::DistanceMetric::Cosine)
+        .expect("test: create papers collection");
+    let vc = db
+        .get_vector_collection("papers")
+        .expect("test: get papers collection");
+
+    vc.upsert(vec![
+        Point::new(
+            1,
+            vec![1.0, 0.0, 0.0, 0.0],
+            Some(json!({
+                "_labels": ["Document"],
+                "title": "Physics 101",
+                "category": "science"
+            })),
+        ),
+        Point::new(
+            2,
+            vec![0.9, 0.1, 0.0, 0.0],
+            Some(json!({
+                "_labels": ["Reference"],
+                "title": "Newton's Laws",
+                "category": "science"
+            })),
+        ),
+        Point::new(
+            3,
+            vec![0.0, 1.0, 0.0, 0.0],
+            Some(json!({
+                "_labels": ["Document"],
+                "title": "Rust Handbook",
+                "category": "tech"
+            })),
+        ),
+        Point::new(
+            4,
+            vec![0.05, 0.95, 0.0, 0.0],
+            Some(json!({
+                "_labels": ["Document"],
+                "title": "Python Guide",
+                "category": "tech"
+            })),
+        ),
+        Point::new(
+            5,
+            vec![0.0, 0.0, 1.0, 0.0],
+            Some(json!({
+                "_labels": ["Reference"],
+                "title": "Ancient Rome",
+                "category": "history"
+            })),
+        ),
+    ])
+    .expect("test: upsert corpus");
+
+    let edge = GraphEdge::new(100, 1, 2, "CITES").expect("test: create edge 1->2");
+    vc.add_edge(edge).expect("test: add edge 1->2 CITES");
+}
+
+/// Builds a params map with only the `_collection` routing key.
+fn collection_param(collection: &str) -> HashMap<String, serde_json::Value> {
+    let mut params = HashMap::new();
+    params.insert(
+        "_collection".to_string(),
+        serde_json::Value::String(collection.to_string()),
+    );
+    params
+}
+
+/// Stats representative of the seeded collection: 5 nodes, 1 edge, 2 labels.
+fn seeded_stats() -> CollectionStats {
+    CollectionStats {
+        total_nodes: 5,
+        total_edges: 1,
+        avg_degree: 0.2,
+        label_count: 2,
+        label_selectivity: 0.5,
+    }
+}
+
+/// Parses `sql` and asserts that `MatchQueryPlanner::plan` selects
+/// `GraphFirst` for the representative stats.
+fn assert_graph_first_planned(sql: &str) {
+    let query = velesdb_core::velesql::Parser::parse(sql).expect("test: parse MATCH query");
+    let match_clause = query
+        .match_clause
+        .as_ref()
+        .expect("test: query must have a MATCH clause");
+    let strategy = MatchQueryPlanner::plan(match_clause, &seeded_stats());
+    assert!(
+        matches!(strategy, MatchExecutionStrategy::GraphFirst { .. }),
+        "planner must select GraphFirst for '{sql}', got: {strategy:?}"
+    );
+}
+
+// =========================================================================
+// A. Nominal tests (~50%)
+// =========================================================================
+
+/// GIVEN a collection with Documents linked to References via CITES edges
+/// WHEN a MATCH query traverses `(doc:Document)-[:CITES]->(ref)` with NO
+///      `similarity()` predicate
+/// THEN the planner picks GraphFirst and execution returns the traversal
+///      endpoint (ref = node 2) reached from the only Document that has
+///      an outgoing CITES edge (doc = node 1).
+///
+/// Note: per the MATCH execution contract,
+/// `SearchResult.point.id == traversal_result.target_id`, i.e. the terminal
+/// node of each traversal branch. The start node is exposed via the
+/// `bindings` map on `MatchResult`, not via `SearchResult.point.id`.
+#[test]
+fn test_match_graph_first_basic_traversal_returns_connected_pair() {
+    let (_dir, db) = create_test_db();
+    setup_graph_first_collection(&db);
+
+    let sql = "MATCH (doc:Document)-[:CITES]->(ref) RETURN doc, ref LIMIT 10";
+    assert_graph_first_planned(sql);
+
+    let query = velesdb_core::velesql::Parser::parse(sql).expect("test: parse MATCH");
+    let params = collection_param("papers");
+    let results = db
+        .execute_query(&query, &params)
+        .expect("test: GraphFirst MATCH should succeed");
+
+    let ids: Vec<u64> = results.iter().map(|r| r.point.id).collect();
+    // The only CITES edge is 1 -> 2. Node 2 is the unique traversal target.
+    assert_eq!(
+        ids,
+        vec![2],
+        "only reachable target node is 2 (Reference via CITES), got: {ids:?}"
+    );
+    // Isolated Documents (3, 4) have no CITES edge and must NOT appear.
+    assert!(
+        !ids.contains(&3) && !ids.contains(&4),
+        "isolated Documents 3 and 4 must not appear as traversal targets, got: {ids:?}"
+    );
+}
+
+/// GIVEN the same graph
+/// WHEN a MATCH query adds a scalar property predicate on the start node
+///      (`WHERE doc.category = 'science'`) with NO similarity predicate
+/// THEN the planner still picks GraphFirst (property index prefilter +
+///      traversal). Only node 1 (science Document) satisfies the prefilter
+///      and has an outgoing CITES edge, so node 2 appears as the unique
+///      traversal target.
+#[test]
+fn test_match_graph_first_with_start_property_predicate() {
+    let (_dir, db) = create_test_db();
+    setup_graph_first_collection(&db);
+
+    let sql = "MATCH (doc:Document)-[:CITES]->(ref) \
+               WHERE doc.category = 'science' \
+               RETURN doc, ref LIMIT 10";
+    assert_graph_first_planned(sql);
+
+    let query = velesdb_core::velesql::Parser::parse(sql).expect("test: parse MATCH");
+    let params = collection_param("papers");
+    let results = db
+        .execute_query(&query, &params)
+        .expect("test: GraphFirst with predicate should succeed");
+
+    let ids: Vec<u64> = results.iter().map(|r| r.point.id).collect();
+    // Only doc=1 (science, has CITES edge) passes the predicate -> target = 2.
+    assert_eq!(
+        ids,
+        vec![2],
+        "only traversal target from a science Document is node 2, got: {ids:?}"
+    );
+    // Tech Documents (3, 4) have no CITES edge AND wrong category -- excluded.
+    assert!(
+        !ids.contains(&3) && !ids.contains(&4),
+        "tech Documents must not appear as targets, got: {ids:?}"
+    );
+}
+
+/// GIVEN the same graph
+/// WHEN a MATCH query with no relationship pattern filters by label +
+///      property (`MATCH (n:Document) WHERE n.category = 'tech'`)
+/// THEN the planner picks GraphFirst (no similarity) and returns every
+///      Document matching the property predicate (nodes 3 and 4).
+#[test]
+fn test_match_graph_first_label_only_pattern_returns_all_matches() {
+    let (_dir, db) = create_test_db();
+    setup_graph_first_collection(&db);
+
+    let sql = "MATCH (n:Document) WHERE n.category = 'tech' RETURN n LIMIT 10";
+    assert_graph_first_planned(sql);
+
+    let query = velesdb_core::velesql::Parser::parse(sql).expect("test: parse MATCH");
+    let params = collection_param("papers");
+    let results = db
+        .execute_query(&query, &params)
+        .expect("test: GraphFirst single-node MATCH should succeed");
+
+    let ids: std::collections::HashSet<u64> = results.iter().map(|r| r.point.id).collect();
+    let expected: std::collections::HashSet<u64> = [3, 4].into_iter().collect();
+    assert_eq!(
+        ids, expected,
+        "GraphFirst must return exactly the tech Documents"
+    );
+}
+
+// =========================================================================
+// B. Edge tests (~33%)
+// =========================================================================
+
+/// GIVEN the seeded graph (only one CITES edge exists: 1->2)
+/// WHEN a MATCH query requests an unknown relationship type
+///      `[:AUTHORED_BY]` that no edge uses
+/// THEN the planner picks GraphFirst and execution returns an empty set
+///      (no panic, no error).
+#[test]
+fn test_match_graph_first_no_matching_relationship_returns_empty() {
+    let (_dir, db) = create_test_db();
+    setup_graph_first_collection(&db);
+
+    let sql = "MATCH (doc:Document)-[:AUTHORED_BY]->(a) RETURN doc, a LIMIT 10";
+    assert_graph_first_planned(sql);
+
+    let query = velesdb_core::velesql::Parser::parse(sql).expect("test: parse MATCH");
+    let params = collection_param("papers");
+    let results = db
+        .execute_query(&query, &params)
+        .expect("test: unknown relationship should not error");
+
+    assert!(
+        results.is_empty(),
+        "no edges match AUTHORED_BY, expected empty result, got {} rows",
+        results.len()
+    );
+}
+
+/// GIVEN a collection populated with nodes but zero edges
+/// WHEN a MATCH query requires a relationship traversal
+/// THEN the planner picks GraphFirst and execution returns an empty set.
+#[test]
+fn test_match_graph_first_empty_edge_store_returns_empty() {
+    let (_dir, db) = create_test_db();
+    db.create_vector_collection("isolates", 4, velesdb_core::DistanceMetric::Cosine)
+        .expect("test: create isolates collection");
+    let vc = db
+        .get_vector_collection("isolates")
+        .expect("test: get isolates");
+    vc.upsert(vec![
+        Point::new(
+            1,
+            vec![1.0, 0.0, 0.0, 0.0],
+            Some(json!({"_labels": ["Document"], "title": "A"})),
+        ),
+        Point::new(
+            2,
+            vec![0.0, 1.0, 0.0, 0.0],
+            Some(json!({"_labels": ["Document"], "title": "B"})),
+        ),
+    ])
+    .expect("test: upsert isolates");
+
+    let sql = "MATCH (d:Document)-[:CITES]->(r) RETURN d LIMIT 10";
+    assert_graph_first_planned(sql);
+
+    let query = velesdb_core::velesql::Parser::parse(sql).expect("test: parse MATCH");
+    let params = collection_param("isolates");
+    let results = db
+        .execute_query(&query, &params)
+        .expect("test: traversal on isolate-only graph should not error");
+
+    assert!(
+        results.is_empty(),
+        "no edges exist, expected empty result, got {} rows",
+        results.len()
+    );
+}
+
+// =========================================================================
+// C. Negative tests (>= 17%)
+// =========================================================================
+
+/// GIVEN a MATCH query referencing a collection that does not exist
+/// WHEN the query is executed
+/// THEN an explicit error is returned (not a panic, not empty results).
+#[test]
+fn test_match_graph_first_missing_collection_errors() {
+    let (_dir, db) = create_test_db();
+
+    let sql = "MATCH (doc:Document)-[:CITES]->(ref) RETURN doc LIMIT 10";
+    // Planner selection is independent of collection existence -- still
+    // GraphFirst because there is no similarity() predicate.
+    assert_graph_first_planned(sql);
+
+    let query = velesdb_core::velesql::Parser::parse(sql).expect("test: parse MATCH");
+    let params = collection_param("does_not_exist");
+
+    let err = db
+        .execute_query(&query, &params)
+        .expect_err("test: missing collection must produce a clean error");
+
+    let msg = err.to_string().to_lowercase();
+    assert!(
+        msg.contains("not found") || msg.contains("collection") || msg.contains("does_not_exist"),
+        "error should reference the missing collection, got: {err}"
+    );
+}

--- a/integrations/langchain/tests/test_e2e_velesdb.py
+++ b/integrations/langchain/tests/test_e2e_velesdb.py
@@ -15,6 +15,7 @@ import math
 
 try:
     import velesdb  # noqa: F401  # pylint: disable=unused-import
+
     VELESDB_AVAILABLE = True
 except ImportError:
     VELESDB_AVAILABLE = False
@@ -22,6 +23,7 @@ except ImportError:
 try:
     from langchain_velesdb import VelesDBVectorStore
     from langchain_core.documents import Document
+
     LANGCHAIN_AVAILABLE = True
 except ImportError:
     LANGCHAIN_AVAILABLE = False
@@ -154,3 +156,264 @@ class TestE2EVelesDB:
         # Directory exists during test
         assert os.path.isdir(temp_dir)
         # Cleanup happens via fixture teardown
+
+
+class TestE2EVelesDBAdvanced:
+    """Advanced E2E tests: hybrid search, metadata filtering, isolation, and edge cases.
+
+    All tests use real VelesDB engine (no mocks). GIVEN/WHEN/THEN structure is
+    documented inline. Tests are deterministic via seeded embeddings.
+    """
+
+    @pytest.fixture()
+    def embeddings(self):
+        """64-dim deterministic embeddings (no API calls)."""
+        return DeterministicEmbeddings(dimension=64)
+
+    @pytest.fixture()
+    def temp_dir(self):
+        """Create and cleanup a temporary directory per test."""
+        d = tempfile.mkdtemp(prefix="velesdb_adv_e2e_")
+        yield d
+        shutil.rmtree(d, ignore_errors=True)
+
+    @pytest.fixture()
+    def temp_dir_b(self):
+        """Second isolated temp directory for multi-collection tests."""
+        d = tempfile.mkdtemp(prefix="velesdb_adv_e2e_b_")
+        yield d
+        shutil.rmtree(d, ignore_errors=True)
+
+    # ------------------------------------------------------------------
+    # Nominal tests
+    # ------------------------------------------------------------------
+
+    def test_hybrid_search_text_plus_vector_scores(self, temp_dir, embeddings):
+        """Hybrid search returns (Document, score) tuples with plausible ranking.
+
+        GIVEN: 8 docs with distinct text and deterministic embeddings.
+        WHEN: hybrid_search is called with a query matching one doc closely.
+        THEN: top-3 results are returned as (Document, float) pairs; all
+              scores are non-negative floats; no exception is raised.
+        """
+        texts = [
+            "vector database high performance search engine",
+            "machine learning neural network deep learning",
+            "python programming language data science",
+            "vector similarity cosine distance embeddings",
+            "distributed systems cloud computing architecture",
+            "natural language processing transformer model",
+            "graph database knowledge representation query",
+            "reinforcement learning policy optimization agent",
+        ]
+        # GIVEN: insert 8 docs
+        ids = embeddings.embed_documents(texts)
+        store = VelesDBVectorStore(
+            embedding=embeddings,
+            path=temp_dir,
+            collection_name="hybrid_adv",
+            metric="cosine",
+            storage_mode="full",
+        )
+        store.add_texts(texts)
+
+        # WHEN: hybrid search combining text relevance + vector similarity
+        results = store.hybrid_search(
+            "vector database search",
+            k=3,
+            vector_weight=0.7,
+        )
+
+        # THEN: exactly 3 (Document, float) tuples, all scores non-negative
+        assert len(results) == 3
+        for doc, score in results:
+            assert isinstance(doc, Document)
+            assert isinstance(score, float)
+            assert score >= 0.0
+
+    def test_metadata_filter_on_similarity_search(self, temp_dir, embeddings):
+        """similarity_search_with_filter returns only docs matching the filter.
+
+        GIVEN: 6 docs split evenly between two metadata categories.
+        WHEN: similarity_search_with_filter is called filtering on 'tech'.
+        THEN: every returned document has category == 'tech'.
+        """
+        tech_docs = [
+            Document(
+                page_content="Rust systems programming language",
+                metadata={"category": "tech"},
+            ),
+            Document(
+                page_content="VelesDB vector database engine",
+                metadata={"category": "tech"},
+            ),
+            Document(
+                page_content="PyO3 Python Rust bindings",
+                metadata={"category": "tech"},
+            ),
+        ]
+        art_docs = [
+            Document(
+                page_content="Impressionist painting oil on canvas",
+                metadata={"category": "art"},
+            ),
+            Document(
+                page_content="Baroque music harpsichord composition",
+                metadata={"category": "art"},
+            ),
+            Document(
+                page_content="Sculpture marble Renaissance masterpiece",
+                metadata={"category": "art"},
+            ),
+        ]
+        # GIVEN: insert 6 docs across two categories
+        store = VelesDBVectorStore(
+            embedding=embeddings,
+            path=temp_dir,
+            collection_name="filter_adv",
+        )
+        store.add_documents(tech_docs + art_docs)
+
+        # WHEN: search with category == 'tech' filter
+        core_filter = {
+            "condition": {"type": "eq", "field": "category", "value": "tech"}
+        }
+        results = store.similarity_search_with_filter(
+            "programming database",
+            k=10,
+            metadata_filter=core_filter,
+        )
+
+        # THEN: all returned docs are in the 'tech' category
+        assert len(results) > 0
+        for doc in results:
+            assert (
+                doc.metadata.get("category") == "tech"
+            ), f"Expected category 'tech', got {doc.metadata.get('category')!r}"
+
+    def test_delete_then_search_excludes_deleted(self, temp_dir, embeddings):
+        """Deleted documents are excluded from subsequent search results.
+
+        GIVEN: 5 docs inserted with explicit IDs.
+        WHEN: 2 docs are deleted, then a similarity_search is run with k=5.
+        THEN: neither deleted doc appears in the results.
+        """
+        texts = [
+            "document alpha stays",
+            "document beta deleted",
+            "document gamma stays",
+            "document delta deleted",
+            "document epsilon stays",
+        ]
+        doc_ids = ["id_alpha", "id_beta", "id_gamma", "id_delta", "id_epsilon"]
+
+        # GIVEN: insert 5 docs
+        store = VelesDBVectorStore(
+            embedding=embeddings,
+            path=temp_dir,
+            collection_name="delete_adv",
+        )
+        store.add_texts(texts, ids=doc_ids)
+
+        # WHEN: delete beta and delta
+        store.delete(["id_beta", "id_delta"])
+        results = store.similarity_search("document", k=5)
+
+        # THEN: deleted docs not in results
+        contents = {doc.page_content for doc in results}
+        assert "document beta deleted" not in contents
+        assert "document delta deleted" not in contents
+
+    # ------------------------------------------------------------------
+    # Edge tests
+    # ------------------------------------------------------------------
+
+    def test_multi_collection_isolation(self, temp_dir, temp_dir_b, embeddings):
+        """Two collections in separate directories do not share documents.
+
+        GIVEN: collection A in temp_dir, collection B in temp_dir_b.
+        WHEN: each has a distinct document and we search in each.
+        THEN: A's search never returns B's document and vice-versa.
+        """
+        # GIVEN: insert different docs in each collection
+        store_a = VelesDBVectorStore(
+            embedding=embeddings,
+            path=temp_dir,
+            collection_name="isolation_a",
+        )
+        store_b = VelesDBVectorStore(
+            embedding=embeddings,
+            path=temp_dir_b,
+            collection_name="isolation_b",
+        )
+        store_a.add_texts(["document exclusive to collection A"])
+        store_b.add_texts(["document exclusive to collection B"])
+
+        # WHEN: search in each
+        results_a = store_a.similarity_search("document", k=5)
+        results_b = store_b.similarity_search("document", k=5)
+
+        # THEN: no cross-contamination
+        contents_a = {doc.page_content for doc in results_a}
+        contents_b = {doc.page_content for doc in results_b}
+        assert "document exclusive to collection B" not in contents_a
+        assert "document exclusive to collection A" not in contents_b
+
+    def test_search_with_k_larger_than_corpus(self, temp_dir, embeddings):
+        """Querying with k > corpus size returns all docs without error or duplicates.
+
+        GIVEN: only 3 documents in the store.
+        WHEN: similarity_search is called with k=10.
+        THEN: at most 3 results are returned, no duplicates.
+        """
+        # GIVEN: 3 documents
+        store = VelesDBVectorStore(
+            embedding=embeddings,
+            path=temp_dir,
+            collection_name="small_corpus",
+        )
+        store.add_texts(["alpha", "beta", "gamma"])
+
+        # WHEN: request more than the corpus size
+        results = store.similarity_search("anything", k=10)
+
+        # THEN: at most 3 results, no page_content duplicates
+        assert len(results) <= 3
+        contents = [doc.page_content for doc in results]
+        assert len(contents) == len(set(contents)), "Duplicate documents returned"
+
+    # ------------------------------------------------------------------
+    # Negative tests
+    # ------------------------------------------------------------------
+
+    def test_invalid_collection_raises_clear_error(self, temp_dir, embeddings):
+        """Searching with a dimension mismatch raises DimensionMismatchError.
+
+        GIVEN: a store with 64-dim embeddings already populated.
+        WHEN: the embedding model is swapped to produce 3-dim vectors.
+        THEN: similarity_search raises velesdb.DimensionMismatchError with a
+              clear message — not a generic Exception.
+        """
+        import velesdb as _velesdb
+
+        # GIVEN: insert one doc with 64-dim embeddings
+        store = VelesDBVectorStore(
+            embedding=embeddings,
+            path=temp_dir,
+            collection_name="dim_mismatch",
+        )
+        store.add_texts(["hello vector database"])
+
+        # WHEN: swap to a 3-dim embedder and search
+        class WrongDimEmbeddings:
+            def embed_documents(self, texts):
+                return [[0.1, 0.2, 0.3] for _ in texts]
+
+            def embed_query(self, text):
+                return [0.1, 0.2, 0.3]
+
+        store._embedding = WrongDimEmbeddings()  # type: ignore[assignment]
+
+        # THEN: a typed DimensionMismatchError is raised
+        with pytest.raises(_velesdb.DimensionMismatchError):
+            store.similarity_search("hello", k=1)

--- a/integrations/langchain/tests/test_e2e_velesdb.py
+++ b/integrations/langchain/tests/test_e2e_velesdb.py
@@ -207,7 +207,7 @@ class TestE2EVelesDBAdvanced:
             "reinforcement learning policy optimization agent",
         ]
         # GIVEN: insert 8 docs
-        ids = embeddings.embed_documents(texts)
+        _embeddings_cache = embeddings.embed_documents(texts)
         store = VelesDBVectorStore(
             embedding=embeddings,
             path=temp_dir,

--- a/integrations/llamaindex/tests/test_e2e_advanced.py
+++ b/integrations/llamaindex/tests/test_e2e_advanced.py
@@ -1,0 +1,281 @@
+#!/usr/bin/env python3
+"""
+Advanced E2E Tests for VelesDB LlamaIndex Integration — S4-15
+
+Covers the query scenarios not present in the existing test suite:
+- Metadata-predicate filtering on VectorStoreQuery
+- Hybrid query (text + vector) with graceful capability fallback
+- Delete by node ID removing all targeted nodes
+- Persist → reload preserving the full index
+
+Tests use the correct ``llamaindex_velesdb`` package (not the legacy
+``llama_index.vector_stores.velesdb`` shim). Each test creates an isolated
+temp directory via fixture, uses seeded numpy RNG for deterministic vectors,
+and follows the GIVEN/WHEN/THEN BDD structure.
+
+Run with: pytest tests/test_e2e_advanced.py -v
+"""
+
+import gc
+import shutil
+import tempfile
+
+import numpy as np
+import pytest
+
+try:
+    from llamaindex_velesdb import VelesDBVectorStore
+    from llama_index.core.schema import TextNode
+    from llama_index.core.vector_stores.types import (
+        MetadataFilter,
+        MetadataFilters,
+        VectorStoreQuery,
+        VectorStoreQueryResult,
+    )
+    from llamaindex_velesdb.errors import VelesDBCapabilityError
+
+    VELESDB_LLAMAINDEX_AVAILABLE = True
+except ImportError:
+    VELESDB_LLAMAINDEX_AVAILABLE = False
+
+
+pytestmark = pytest.mark.skipif(
+    not VELESDB_LLAMAINDEX_AVAILABLE,
+    reason="llamaindex-velesdb not installed",
+)
+
+_DIM = 64
+
+
+def _make_vec(seed: int, dim: int = _DIM) -> list:
+    """Deterministic unit vector from seed using numpy default_rng."""
+    rng = np.random.default_rng(seed)
+    v = rng.standard_normal(dim).astype(np.float32)
+    v = v / np.linalg.norm(v)
+    return v.tolist()
+
+
+@pytest.fixture()
+def temp_dir():
+    """Per-test isolated temp directory."""
+    d = tempfile.mkdtemp(prefix="velesdb_lli_adv_")
+    yield d
+    shutil.rmtree(d, ignore_errors=True)
+
+
+class TestE2EAdvancedQueries:
+    """Advanced E2E tests for LlamaIndex VelesDB integration.
+
+    Covers metadata filtering, hybrid query, delete-by-ref-doc-id, and
+    persistence across reopen. All tests use the real VelesDB engine (no mocks).
+    """
+
+    # ------------------------------------------------------------------
+    # Nominal tests
+    # ------------------------------------------------------------------
+
+    def test_filter_by_metadata_on_query(self, temp_dir):
+        """VectorStoreQuery with MetadataFilters returns only matching nodes.
+
+        GIVEN: 6 nodes split between two categories ('science', 'history').
+        WHEN: a query with filters=[category == 'science'] is executed.
+        THEN: every returned node has metadata['category'] == 'science'.
+        """
+        store = VelesDBVectorStore(
+            path=temp_dir,
+            collection_name="meta_filter_adv",
+            dimension=_DIM,
+            metric="cosine",
+        )
+
+        # GIVEN: 6 nodes in two categories
+        science_nodes = [
+            TextNode(
+                text=f"Science article {i}",
+                id_=f"sci_{i}",
+                embedding=_make_vec(i),
+                metadata={"category": "science"},
+            )
+            for i in range(3)
+        ]
+        history_nodes = [
+            TextNode(
+                text=f"History article {i}",
+                id_=f"hist_{i}",
+                embedding=_make_vec(i + 10),
+                metadata={"category": "history"},
+            )
+            for i in range(3)
+        ]
+        store.add(science_nodes + history_nodes)
+
+        # WHEN: query with metadata filter on category
+        query = VectorStoreQuery(
+            query_embedding=_make_vec(0),
+            similarity_top_k=6,
+            filters=MetadataFilters(
+                filters=[MetadataFilter(key="category", value="science")]
+            ),
+        )
+        results = store.query(query)
+
+        # THEN: all returned nodes are 'science'
+        assert len(results.nodes) > 0
+        for node in results.nodes:
+            assert (
+                node.metadata.get("category") == "science"
+            ), f"Expected 'science', got {node.metadata.get('category')!r}"
+
+    def test_delete_by_ref_doc_id_removes_all_nodes(self, temp_dir):
+        """Deleting nodes by their IDs removes all of them from the index.
+
+        GIVEN: 3 nodes sharing a logical parent doc, plus 2 unrelated nodes.
+        WHEN: each of the 3 parent-doc nodes is deleted by its node ID.
+        THEN: a subsequent query returns only the 2 unrelated nodes; the
+              deleted nodes are absent.
+        """
+        store = VelesDBVectorStore(
+            path=temp_dir,
+            collection_name="del_ref_adv",
+            dimension=_DIM,
+        )
+
+        # GIVEN: 3 'parent doc' chunks + 2 unrelated
+        parent_nodes = [
+            TextNode(
+                text=f"Parent chunk {i}",
+                id_=f"parent_{i}",
+                embedding=_make_vec(i + 20),
+                metadata={"doc_id": "parent_doc"},
+            )
+            for i in range(3)
+        ]
+        other_nodes = [
+            TextNode(
+                text="Unrelated node A",
+                id_="other_a",
+                embedding=_make_vec(50),
+                metadata={"doc_id": "other_doc"},
+            ),
+            TextNode(
+                text="Unrelated node B",
+                id_="other_b",
+                embedding=_make_vec(51),
+                metadata={"doc_id": "other_doc"},
+            ),
+        ]
+        store.add(parent_nodes + other_nodes)
+
+        # WHEN: delete all 3 parent nodes by their IDs
+        for node in parent_nodes:
+            store.delete(node.id_)
+
+        # THEN: deleted nodes are absent; at least one unrelated node remains
+        query = VectorStoreQuery(
+            query_embedding=_make_vec(20),
+            similarity_top_k=10,
+        )
+        results = store.query(query)
+        returned_ids = {n.id_ for n in results.nodes}
+        for node in parent_nodes:
+            assert (
+                node.id_ not in returned_ids
+            ), f"Deleted node {node.id_!r} unexpectedly returned in results"
+        assert "other_a" in returned_ids or "other_b" in returned_ids
+
+    def test_persist_and_reload_preserves_index(self, temp_dir):
+        """Reopening the store after flush returns the same documents.
+
+        GIVEN: 3 nodes inserted and the store flushed to disk.
+        WHEN: a new VelesDBVectorStore is opened on the same directory.
+        THEN: querying the reloaded store returns all 3 original node IDs.
+        """
+
+        def _insert_and_flush(path: str, vecs: list) -> None:
+            """Insert 3 nodes and flush in an isolated scope to release the lock."""
+            from llama_index.core.schema import BaseNode
+
+            s = VelesDBVectorStore(
+                path=path,
+                collection_name="persist_test",
+                dimension=_DIM,
+            )
+            nodes: list[BaseNode] = [
+                TextNode(
+                    text=f"persistent_node_{i}",
+                    id_=f"p_{i}",
+                    embedding=vecs[i],
+                )
+                for i in range(3)
+            ]
+            s.add(nodes)
+            s.flush()
+            # s goes out of scope here, releasing the VelesDB database lock
+
+        # GIVEN: 3 deterministic vectors
+        vecs = [_make_vec(i + 100) for i in range(3)]
+        _insert_and_flush(temp_dir, vecs)
+
+        # WHEN: reopen the store (new object, same path + collection)
+        gc.collect()
+        reloaded = VelesDBVectorStore(
+            path=temp_dir,
+            collection_name="persist_test",
+            dimension=_DIM,
+        )
+        query = VectorStoreQuery(
+            query_embedding=vecs[0],
+            similarity_top_k=3,
+        )
+        results = reloaded.query(query)
+
+        # THEN: all 3 nodes are recovered with matching IDs
+        assert len(results.nodes) == 3
+        returned_ids = {n.id_ for n in results.nodes}
+        assert returned_ids == {"p_0", "p_1", "p_2"}
+
+    # ------------------------------------------------------------------
+    # Edge tests
+    # ------------------------------------------------------------------
+
+    def test_query_with_hybrid_mode_falls_back_gracefully(self, temp_dir):
+        """hybrid_query does not raise a bare Exception; shape is always valid.
+
+        GIVEN: a store with 3 nodes.
+        WHEN: hybrid_query is called.
+        THEN: if hybrid is supported, returns a valid VectorStoreQueryResult
+              with matching nodes/similarities/ids lengths.
+              If hybrid is NOT supported, raises VelesDBCapabilityError, which
+              is a subclass of NotImplementedError — never a bare Exception.
+        """
+        store = VelesDBVectorStore(
+            path=temp_dir,
+            collection_name="hybrid_fallback_adv",
+            dimension=_DIM,
+        )
+        nodes = [
+            TextNode(
+                text=f"hybrid test doc {i}",
+                id_=f"h_{i}",
+                embedding=_make_vec(i + 30),
+            )
+            for i in range(3)
+        ]
+        store.add(nodes)
+
+        # WHEN: attempt hybrid query
+        try:
+            result = store.hybrid_query(
+                query_str="hybrid test",
+                query_embedding=_make_vec(30),
+                similarity_top_k=3,
+                vector_weight=0.6,
+            )
+            # THEN (hybrid supported): result shape is correct
+            assert isinstance(result, VectorStoreQueryResult)
+            assert len(result.similarities) == len(result.nodes)
+            assert len(result.ids) == len(result.nodes)
+        except VelesDBCapabilityError as exc:
+            # THEN (hybrid not supported): typed error, not a bare Exception
+            assert isinstance(exc, NotImplementedError)
+            assert exc.capability  # capability attribute must be non-empty


### PR DESCRIPTION
## Summary

Sprint 4 Phase C quick wins — 19 new tests across 3 domains:

- **S4-17** (6 tests): Explicit `GraphFirst` MATCH strategy BDD — verifies planner selection + graph traversal execution via `MatchQueryPlanner::plan()` deterministic assertions. Nominal/edge/negative coverage.
- **S4-16** (3 tests): BM25 + vector RRF pure fusion BDD — hand-computes expected RRF formula `0.5/(rv+60) + 0.5/(rt+60)` and verifies scores match. Tests public `VectorCollection::hybrid_search` API (VelesQL grammar doesn't support explicit `rrf()` syntax; design documented in DESIGN comment).
- **S4-15** (10 tests): LangChain (6) + LlamaIndex (4) advanced E2E — hybrid search, metadata filter, multi-collection isolation, delete-then-search, persist-and-reload, capability error handling. All against real VelesDB engine.

## Files changed

| File | Change |
|------|--------|
| `crates/velesdb-core/tests/bdd/match_graph_first.rs` | NEW — 360 lines, 6 BDD tests |
| `crates/velesdb-core/tests/bdd/hybrid_compositions.rs` | +302 lines, 3 BDD tests appended |
| `crates/velesdb-core/tests/bdd.rs` | Wire `mod match_graph_first` |
| `integrations/langchain/tests/test_e2e_velesdb.py` | +263 lines, 6 E2E tests |
| `integrations/llamaindex/tests/test_e2e_advanced.py` | NEW — 281 lines, 4 E2E tests |

No production code changes. Tests only.

## Quality gates

- cargo fmt + clippy pedantic workspace: PASS
- cargo test -p velesdb-core --features persistence (BDD): 359 passed, 0 failed
- Codacy CLI (opengrep + pylint): 0 findings
- LangChain pytest: 12/12 PASS
- LlamaIndex pytest: 4/4 PASS

## Test plan

- [x] All new BDD tests pass single-threaded
- [x] All existing 350 BDD tests still pass (no regression)
- [x] Python E2E tests use real VelesDB engine (not mocks)
- [x] Codacy CLI pre-push gate clean

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/592" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
