### PR TITLE
feat(cbo): wire choose_hybrid_strategy for ORDER BY similarity SELECTs (closes #467 scope-reduced)

### DIFF
--- a/crates/velesdb-core/src/collection/search/query/mod.rs
+++ b/crates/velesdb-core/src/collection/search/query/mod.rs
@@ -5,16 +5,27 @@
 //! - Condition extraction (`extraction.rs`)
 //! - ORDER BY processing (`ordering.rs`)
 //!
-//! # Future Enhancement: HybridExecutionPlan Integration
+//! # Cost-based optimization wiring (issue #467)
 //!
-//! The `HybridExecutionPlan` and `choose_hybrid_strategy()` in `planner.rs`
-//! are ready for integration to optimize query execution based on:
-//! - Query pattern (ORDER BY similarity, filters, etc.)
-//! - Runtime statistics (latency, selectivity)
-//! - Over-fetch factor for filtered queries
+//! `compute_cbo_strategy` in `select_dispatch.rs` routes between two planner
+//! entry points depending on query shape:
 //!
-//! Future: Integrate `QueryPlanner::choose_hybrid_strategy()` into `execute_query()`
-//! to leverage cost-based optimization for complex queries.
+//! - Queries carrying `ORDER BY similarity()` go through
+//!   [`QueryPlanner::choose_hybrid_strategy`], which forces `VectorFirst`
+//!   to preserve HNSW's natural similarity ordering and applies a
+//!   selectivity-aware over-fetch factor.
+//! - All other SELECT queries go through
+//!   [`QueryPlanner::choose_strategy_with_cbo_and_overfetch`], which
+//!   derives I/O / CPU weights from calibrated `OperationCostFactors`
+//!   (or defaults when the collection was never analyzed).
+//!
+//! Both entry points share the same return shape
+//! `(ExecutionStrategy, over_fetch: usize)` consumed by
+//! `dispatch_vector_query` in `execution_paths.rs`. The deeper
+//! multi-candidate `PlanGenerator` enumeration remains open
+//! (see `collection/query_cost/plan_generator.rs`); it is reserved for
+//! a future expansion that would supersede the current two-path routing
+//! with full cost-based enumeration.
 
 #![allow(clippy::uninlined_format_args)] // Prefer readability in query error paths.
 #![allow(clippy::implicit_hasher)] // HashSet hasher genericity adds noise for internal APIs.

--- a/crates/velesdb-core/src/collection/search/query/select_dispatch.rs
+++ b/crates/velesdb-core/src/collection/search/query/select_dispatch.rs
@@ -14,11 +14,30 @@ use super::{distinct, pushdown, ExtractedComponents, MAX_LIMIT};
 
 impl Collection {
     /// Computes the CBO execution strategy and over-fetch factor for the query.
+    ///
+    /// Routes between two planner entry points depending on query shape
+    /// (issue #467 closure):
+    ///
+    /// - **Queries with `ORDER BY similarity()`** must preserve HNSW's natural
+    ///   similarity ordering, so the planner forces `VectorFirst` via
+    ///   [`QueryPlanner::choose_hybrid_strategy`], which additionally computes
+    ///   a selectivity-aware over-fetch factor clamped to `[2.0, 10.0]` when
+    ///   a filter is present. A pure-cost comparison would occasionally pick
+    ///   `GraphFirst`/`Parallel` and lose the natural ordering — observable
+    ///   as scrambled top-k for `ORDER BY similarity() DESC LIMIT k` queries.
+    /// - **All other queries** use the calibrated
+    ///   [`QueryPlanner::choose_strategy_with_cbo_and_overfetch`] path, which
+    ///   derives I/O / CPU weights from `OperationCostFactors` (or defaults
+    ///   when the collection was never analyzed).
     pub(super) fn compute_cbo_strategy(
         &self,
+        stmt: &crate::velesql::SelectStatement,
         filter_condition: Option<&crate::velesql::Condition>,
         limit: usize,
     ) -> (crate::velesql::ExecutionStrategy, usize) {
+        if Self::has_order_by_similarity(stmt) {
+            return self.cbo_strategy_for_order_by_similarity(filter_condition, limit);
+        }
         let col_stats = self.get_stats();
         let result = self.query_planner.choose_strategy_with_cbo_and_overfetch(
             &col_stats,
@@ -27,9 +46,70 @@ impl Collection {
         );
         tracing::debug!(
             strategy = ?result.0, over_fetch = result.1,
-            "CBO selected execution strategy"
+            "CBO selected execution strategy (calibrated cost path)"
         );
         result
+    }
+
+    /// Returns `true` when the ORDER BY clause contains at least one
+    /// `similarity(...)` (or bare `similarity()`) expression. Detection is
+    /// purely syntactic — the planner uses this signal to preserve HNSW
+    /// natural ordering regardless of cost estimates.
+    fn has_order_by_similarity(stmt: &crate::velesql::SelectStatement) -> bool {
+        let Some(order_by) = stmt.order_by.as_ref() else {
+            return false;
+        };
+        order_by.iter().any(|item| {
+            matches!(
+                item.expr,
+                crate::velesql::OrderByExpr::Similarity(_)
+                    | crate::velesql::OrderByExpr::SimilarityBare
+            )
+        })
+    }
+
+    /// CBO path for queries that carry `ORDER BY similarity()` in their
+    /// projection. Delegates to [`QueryPlanner::choose_hybrid_strategy`] so
+    /// the returned `HybridExecutionPlan.strategy` is always `VectorFirst`
+    /// and the over-fetch factor reflects the calibrated selectivity.
+    fn cbo_strategy_for_order_by_similarity(
+        &self,
+        filter_condition: Option<&crate::velesql::Condition>,
+        limit: usize,
+    ) -> (crate::velesql::ExecutionStrategy, usize) {
+        let col_stats = self.get_stats();
+        let estimated_selectivity = filter_condition.map(|cond| {
+            crate::velesql::CostEstimator::new(&col_stats)
+                .estimate_condition_selectivity(cond)
+                .clamp(0.001, 1.0)
+        });
+        // Reason: execution limit already clamped upstream to `usize::MAX`
+        // equivalent values; `u64::try_from(usize)` never fails on 64-bit
+        // targets and saturates on 32-bit.
+        let limit_u64 = u64::try_from(limit).unwrap_or(u64::MAX);
+        let plan = self.query_planner.choose_hybrid_strategy(
+            true, // has_order_by_similarity
+            filter_condition.is_some(),
+            Some(limit_u64),
+            estimated_selectivity,
+        );
+        // Reason: over_fetch_factor is clamped upstream to [1.0, 64.0] so
+        // the ceil-to-usize cast is safe. `.max(1)` guards against a
+        // degenerate planner output (would be a bug, not a truncation).
+        #[allow(
+            clippy::cast_possible_truncation,
+            clippy::cast_sign_loss,
+            clippy::cast_precision_loss
+        )]
+        let over_fetch = (plan.over_fetch_factor.ceil() as usize).max(1);
+        tracing::debug!(
+            strategy = ?plan.strategy,
+            over_fetch,
+            use_early_termination = plan.use_early_termination,
+            recompute_scores = plan.recompute_scores,
+            "CBO selected execution strategy (ORDER BY similarity() path)"
+        );
+        (plan.strategy, over_fetch)
     }
 
     /// Dispatches the main SELECT query path (vector, similarity, metadata).
@@ -56,7 +136,7 @@ impl Collection {
             .with_fusion(stmt.fusion_clause.clone());
         let first_similarity = extracted.similarity_conditions.first().cloned();
         let (cbo_strategy, cbo_over_fetch) =
-            self.compute_cbo_strategy(extracted.filter_condition.as_ref(), limit);
+            self.compute_cbo_strategy(stmt, extracted.filter_condition.as_ref(), limit);
 
         let mut results = self
             .dispatch_vector_query(

--- a/crates/velesdb-core/src/collection/search/query/select_dispatch.rs
+++ b/crates/velesdb-core/src/collection/search/query/select_dispatch.rs
@@ -35,13 +35,21 @@ impl Collection {
         filter_condition: Option<&crate::velesql::Condition>,
         limit: usize,
     ) -> (crate::velesql::ExecutionStrategy, usize) {
+        // `filter_condition` is the WHERE clause AFTER `extract_vector_search`
+        // and similarity extraction — for pure `vector NEAR $v` queries the
+        // residual is a vector-only node that carries no selectivity signal.
+        // Strip the vector-family subtree so the CBO does not compute a
+        // spurious over-fetch (Devin PR #613 finding 3).
+        let meaningful_filter = filter_condition.and_then(crate::velesql::strip_vector_predicates);
+        let effective_filter = meaningful_filter.as_ref();
+
         if Self::has_order_by_similarity(stmt) {
-            return self.cbo_strategy_for_order_by_similarity(filter_condition, limit);
+            return self.cbo_strategy_for_order_by_similarity(effective_filter, limit);
         }
         let col_stats = self.get_stats();
         let result = self.query_planner.choose_strategy_with_cbo_and_overfetch(
             &col_stats,
-            filter_condition,
+            effective_filter,
             limit,
         );
         tracing::debug!(
@@ -52,20 +60,70 @@ impl Collection {
     }
 
     /// Returns `true` when the ORDER BY clause contains at least one
-    /// `similarity(...)` (or bare `similarity()`) expression. Detection is
-    /// purely syntactic — the planner uses this signal to preserve HNSW
-    /// natural ordering regardless of cost estimates.
+    /// expression whose final ordering reduces to `similarity()` under a
+    /// monotonic transform. This routes the query through
+    /// `choose_hybrid_strategy` so HNSW's natural similarity ordering is
+    /// preserved by the executor.
+    ///
+    /// Detected shapes:
+    /// - Top-level `OrderByExpr::Similarity(_)` / `OrderByExpr::SimilarityBare`.
+    /// - `OrderByExpr::Arithmetic(...)` whose expression tree contains a
+    ///   `Similarity` node and **no other `Variable` reference** — i.e.
+    ///   `similarity() * 2.0`, `0.5 * similarity() + 0.25`,
+    ///   `-similarity() + 1.0` are all monotonic (Devin PR #613 finding 1).
+    ///
+    /// Composite expressions such as `0.7 * similarity() + 0.3 * bm25_score`
+    /// carry a `Variable` node and are deliberately NOT detected — their
+    /// final ordering differs from pure similarity, so forcing VectorFirst
+    /// would trade correctness for an inconsequential optimisation.
     fn has_order_by_similarity(stmt: &crate::velesql::SelectStatement) -> bool {
         let Some(order_by) = stmt.order_by.as_ref() else {
             return false;
         };
-        order_by.iter().any(|item| {
-            matches!(
-                item.expr,
-                crate::velesql::OrderByExpr::Similarity(_)
-                    | crate::velesql::OrderByExpr::SimilarityBare
-            )
-        })
+        order_by
+            .iter()
+            .any(|item| Self::order_by_item_reduces_to_similarity(&item.expr))
+    }
+
+    /// Helper for [`has_order_by_similarity`]. Kept as an associated function
+    /// so the match arm can delegate to the arithmetic-expression walker
+    /// without inflating the outer method's cyclomatic complexity.
+    fn order_by_item_reduces_to_similarity(expr: &crate::velesql::OrderByExpr) -> bool {
+        use crate::velesql::OrderByExpr;
+        match expr {
+            OrderByExpr::Similarity(_) | OrderByExpr::SimilarityBare => true,
+            OrderByExpr::Arithmetic(arith) => {
+                Self::arith_contains_similarity(arith) && !Self::arith_contains_variable(arith)
+            }
+            _ => false,
+        }
+    }
+
+    /// Returns `true` if any node in the arithmetic expression tree is a
+    /// `Similarity` call.
+    fn arith_contains_similarity(expr: &crate::velesql::ArithmeticExpr) -> bool {
+        use crate::velesql::ArithmeticExpr;
+        match expr {
+            ArithmeticExpr::Similarity(_) => true,
+            ArithmeticExpr::BinaryOp { left, right, .. } => {
+                Self::arith_contains_similarity(left) || Self::arith_contains_similarity(right)
+            }
+            _ => false,
+        }
+    }
+
+    /// Returns `true` if any node in the arithmetic expression tree is a
+    /// `Variable` reference — used to reject composite scoring like
+    /// `similarity() + bm25_score`.
+    fn arith_contains_variable(expr: &crate::velesql::ArithmeticExpr) -> bool {
+        use crate::velesql::ArithmeticExpr;
+        match expr {
+            ArithmeticExpr::Variable(_) => true,
+            ArithmeticExpr::BinaryOp { left, right, .. } => {
+                Self::arith_contains_variable(left) || Self::arith_contains_variable(right)
+            }
+            _ => false,
+        }
     }
 
     /// CBO path for queries that carry `ORDER BY similarity()` in their
@@ -93,9 +151,12 @@ impl Collection {
             Some(limit_u64),
             estimated_selectivity,
         );
-        // Reason: over_fetch_factor is clamped upstream to [1.0, 64.0] so
-        // the ceil-to-usize cast is safe. `.max(1)` guards against a
-        // degenerate planner output (would be a bug, not a truncation).
+        // Reason: `choose_hybrid_strategy` with `has_order_by_similarity = true`
+        // produces `over_fetch_factor` in `[1.0, 10.0]` — either `1.0` when no
+        // filter is present, or `(1.0 / selectivity).clamp(2.0, 10.0)` with a
+        // filter (planner.rs:265-275). Ceil-to-usize is therefore safe and
+        // lossless. `.max(1)` guards against a degenerate planner output
+        // (would be a bug, not a truncation).
         #[allow(
             clippy::cast_possible_truncation,
             clippy::cast_sign_loss,

--- a/crates/velesdb-core/src/velesql/explain/filter_strategy.rs
+++ b/crates/velesdb-core/src/velesql/explain/filter_strategy.rs
@@ -161,7 +161,12 @@ pub(super) fn estimate_filter_stats(
 /// what drives the pre/post-filter decision.
 ///
 /// Returns `None` when every branch is vector-related (selectivity = 1.0).
-pub(super) fn strip_vector_predicates(condition: &Condition) -> Option<Condition> {
+///
+/// Exposed to `pub(crate)` so the CBO router in
+/// `collection/search/query/select_dispatch.rs` can reuse the same
+/// "meaningful filter" test when classifying a residual condition left
+/// behind by `extract_vector_search` (Devin PR #613 finding).
+pub(crate) fn strip_vector_predicates(condition: &Condition) -> Option<Condition> {
     match condition {
         Condition::VectorSearch(_)
         | Condition::VectorFusedSearch(_)

--- a/crates/velesdb-core/src/velesql/explain/mod.rs
+++ b/crates/velesdb-core/src/velesql/explain/mod.rs
@@ -18,6 +18,7 @@ mod node_stats;
 mod plan_builder;
 mod types;
 
+pub(crate) use filter_strategy::strip_vector_predicates;
 pub use filter_strategy::{
     fallback_selectivity_threshold, set_fallback_selectivity_threshold,
     DEFAULT_FALLBACK_SELECTIVITY_THRESHOLD,

--- a/crates/velesdb-core/src/velesql/mod.rs
+++ b/crates/velesdb-core/src/velesql/mod.rs
@@ -250,6 +250,8 @@ pub use graph_pattern::*;
 pub use cache::{CacheStats, QueryCache};
 pub use error::{ParseError, ParseErrorKind};
 #[cfg(feature = "persistence")]
+pub(crate) use explain::strip_vector_predicates;
+#[cfg(feature = "persistence")]
 pub use explain::{
     build_leaf_node_stats, fallback_selectivity_threshold, set_fallback_selectivity_threshold,
     ActualStats, ExplainOutput, FilterPlan, FilterStrategy, FusionInfo, IndexLookupPlan, IndexType,

--- a/crates/velesdb-core/tests/bdd/advanced.rs
+++ b/crates/velesdb-core/tests/bdd/advanced.rs
@@ -300,6 +300,99 @@ fn test_order_by_similarity_desc() {
     }
 }
 
+/// GIVEN a docs collection + a selective metadata filter that would normally
+///       nudge the CBO towards `GraphFirst`/`Parallel` execution,
+/// WHEN  the query carries `ORDER BY similarity() DESC`,
+/// THEN  result scores must still be in non-increasing order — proving the
+///       CBO forced `VectorFirst` to preserve HNSW natural ordering
+///       (issue #467 closure: `compute_cbo_strategy` routes
+///       `ORDER BY similarity()` queries through `choose_hybrid_strategy`).
+///
+/// Before the routing fix, a highly selective filter could flip the strategy
+/// to `Parallel` or `GraphFirst` and the merge step would break strict
+/// monotonicity of `similarity()` across the top-k.
+#[test]
+fn test_cbo_forces_vector_first_for_order_by_similarity_with_selective_filter() {
+    let (_dir, db) = create_test_db();
+    setup_similarity_collection(&db);
+    // ANALYZE so the calibrated CBO path has real statistics to work with
+    // — the regression would be invisible without it because the fallback
+    // path already prefers VectorFirst for non-selective predicates.
+    execute_sql(&db, "ANALYZE docs").expect("test: ANALYZE docs");
+
+    // category = 'science' matches 3 of 8 seeded points (~37% selectivity)
+    // plus the vector query targets science-cluster vectors — a naive
+    // cost-only CBO could pick Parallel/GraphFirst and lose the natural
+    // ordering. The routing fix must force VectorFirst here.
+    let sql = "SELECT * FROM docs WHERE vector NEAR $v AND category = 'science' \
+               ORDER BY similarity() DESC LIMIT 3";
+    let params = vector_param(&[1.0, 0.0, 0.0, 0.0]);
+    let results =
+        execute_sql_with_params(&db, sql, &params).expect("test: selective filter + ORDER BY sim");
+
+    assert!(
+        !results.is_empty(),
+        "filtered query must still yield results; collection seeded with 3 science rows"
+    );
+    for w in results.windows(2) {
+        assert!(
+            w[0].score >= w[1].score,
+            "ORDER BY similarity() DESC must stay monotone even with a selective filter: \
+             {} (id={}) should be >= {} (id={})",
+            w[0].score,
+            w[0].point.id,
+            w[1].score,
+            w[1].point.id
+        );
+    }
+}
+
+/// GIVEN a docs collection WITHOUT `ORDER BY similarity()` in the query,
+/// WHEN  a query with a metadata filter runs through the CBO,
+/// THEN  results are still returned correctly — verifying the calibrated
+///       (`choose_strategy_with_cbo_and_overfetch`) branch remains intact
+///       when the ORDER BY similarity routing does NOT kick in.
+///
+/// This is the negative counterpart to the ORDER BY similarity test above:
+/// the two branches of `compute_cbo_strategy` must both produce valid
+/// results; a regression that accidentally short-circuited the calibrated
+/// path would be caught here.
+#[test]
+fn test_cbo_calibrated_path_still_works_without_order_by_similarity() {
+    let (_dir, db) = create_test_db();
+    setup_similarity_collection(&db);
+    execute_sql(&db, "ANALYZE docs").expect("test: ANALYZE docs");
+
+    // NO ORDER BY similarity — routes through the calibrated CBO branch.
+    let sql = "SELECT * FROM docs WHERE vector NEAR $v AND category = 'science' LIMIT 3";
+    let params = vector_param(&[1.0, 0.0, 0.0, 0.0]);
+    let results = execute_sql_with_params(&db, sql, &params).expect("test: calibrated CBO path");
+
+    assert!(
+        !results.is_empty(),
+        "calibrated CBO path must still yield results"
+    );
+    assert!(
+        results.len() <= 3,
+        "LIMIT 3 must be honoured by the calibrated path too, got {} results",
+        results.len()
+    );
+    // Every surviving row must pass the predicate — proves the calibrated
+    // path wires the filter correctly even when it does not force
+    // VectorFirst via the ORDER BY similarity branch.
+    for r in &results {
+        let payload = r.point.payload.as_ref().expect("payload present");
+        let cat = payload.get("category").and_then(|v| v.as_str());
+        assert_eq!(
+            cat,
+            Some("science"),
+            "filter `category = 'science'` must survive the calibrated CBO path, \
+             got {cat:?} for id={}",
+            r.point.id
+        );
+    }
+}
+
 /// GIVEN a docs collection
 /// WHEN `ORDER BY similarity() ASC LIMIT 5`
 /// THEN scores are in non-decreasing order.

--- a/crates/velesdb-core/tests/bdd/advanced.rs
+++ b/crates/velesdb-core/tests/bdd/advanced.rs
@@ -347,6 +347,42 @@ fn test_cbo_forces_vector_first_for_order_by_similarity_with_selective_filter() 
     }
 }
 
+/// GIVEN a docs collection + a selective metadata filter,
+/// WHEN  the query carries `ORDER BY 2.0 * similarity() DESC` (pure
+///       monotonic arithmetic transform of similarity — no other variable),
+/// THEN  result scores must still be in non-increasing order. The CBO
+///       router detects similarity nested inside the arithmetic expression
+///       (as long as no other Variable is present) and forces VectorFirst
+///       to preserve HNSW natural ordering (Devin PR #613 finding 1).
+#[test]
+fn test_cbo_forces_vector_first_for_monotonic_arithmetic_similarity() {
+    let (_dir, db) = create_test_db();
+    setup_similarity_collection(&db);
+    execute_sql(&db, "ANALYZE docs").expect("test: ANALYZE docs");
+
+    let sql = "SELECT * FROM docs WHERE vector NEAR $v AND category = 'science' \
+               ORDER BY 2.0 * similarity() DESC LIMIT 3";
+    let params = vector_param(&[1.0, 0.0, 0.0, 0.0]);
+    let results =
+        execute_sql_with_params(&db, sql, &params).expect("test: monotonic arithmetic ORDER BY");
+
+    assert!(
+        !results.is_empty(),
+        "monotonic transform should still yield results"
+    );
+    for w in results.windows(2) {
+        assert!(
+            w[0].score >= w[1].score,
+            "ORDER BY 2.0 * similarity() DESC must stay monotone: \
+             {} (id={}) should be >= {} (id={})",
+            w[0].score,
+            w[0].point.id,
+            w[1].score,
+            w[1].point.id
+        );
+    }
+}
+
 /// GIVEN a docs collection WITHOUT `ORDER BY similarity()` in the query,
 /// WHEN  a query with a metadata filter runs through the CBO,
 /// THEN  results are still returned correctly — verifying the calibrated

--- a/docs/reference/KNOWN_LIMITATIONS.md
+++ b/docs/reference/KNOWN_LIMITATIONS.md
@@ -28,13 +28,20 @@ The ratio (~22×) is **not** a regression; it reflects that the calibrated path 
 
 **Resolution path**: pin `COST_UNIT_TO_MS` empirically via a micro-benchmark that times a known plan shape on reference hardware, then rescale the constant so pre/post-`ANALYZE` costs align at the same operating point. Not blocker for correctness — both paths rank the same plan shape consistently within their own range.
 
-### 2. CBO `choose_hybrid_strategy` not integrated for pure-`SELECT` hybrid queries
+### 2. Multi-candidate `PlanGenerator` enumeration not wired into `execute_query`
 
-**Status**: partial integration. Tracked by [issue #467](https://github.com/cyberlife-coder/VelesDB/issues/467) (scope-reduced). Source: `crates/velesdb-core/src/collection/search/query/mod.rs:16` (TODO comment).
+**Status**: partial integration (scope-reduced). Tracked by [issue #467](https://github.com/cyberlife-coder/VelesDB/issues/467). Source: `crates/velesdb-core/src/collection/query_cost/plan_generator.rs` (`PlanGenerator::CandidatePlan`).
 
-The calibrated CBO is fully wired for `MATCH` queries (via `MatchQueryPlanner::plan`). For pure-`SELECT` hybrid queries (vector + WHERE + optional text), `QueryPlanner::choose_hybrid_strategy` and `PlanGenerator` are defined but not called by `execute_query`. The `filter_strategy` reported in `EXPLAIN` is still driven by `resolve_filter_strategy` (the pipeline used by this PR series) and remains accurate; the missing piece is the deeper strategy-enumeration layer that compares multiple candidate plans (`PlanGenerator::CandidatePlan`).
+`compute_cbo_strategy` in `collection/search/query/select_dispatch.rs` now routes SELECT queries through two calibrated planner entry points:
 
-**User impact**: `MATCH` queries benefit from the full CBO; pure-`SELECT` hybrid queries benefit from calibrated filter-strategy selection but not from multi-candidate plan enumeration. Covered by `test_filter_strategy_switches_on_selectivity` + `test_prefilter_accounts_for_full_table_scan`.
+- `QueryPlanner::choose_hybrid_strategy` for queries carrying `ORDER BY similarity()` — forces `VectorFirst` to preserve HNSW natural ordering regardless of cost estimates.
+- `QueryPlanner::choose_strategy_with_cbo_and_overfetch` for all other SELECT queries — calibrated I/O / CPU cost comparison across `VectorFirst` / `GraphFirst` / `Parallel`.
+
+Both branches feed into the same `dispatch_vector_query` executor through the `(ExecutionStrategy, over_fetch: usize)` tuple.
+
+**What remains open**: the deeper `PlanGenerator::CandidatePlan` enumeration (SeqScan, IndexScan, VectorSearch, GraphTraversal, hybrid combinations) is still not consumed by `execute_query`. The current two-path routing covers the operationally common cases — full multi-candidate enumeration would only change the decision when the cost landscape is non-trivially multimodal.
+
+**User impact**: `MATCH` queries use the full CBO via `MatchQueryPlanner::plan`. SELECT queries (including ORDER BY similarity + filter) now use calibrated strategy and over-fetch selection. Covered by `test_cbo_forces_vector_first_for_order_by_similarity_with_selective_filter` + `test_cbo_calibrated_path_still_works_without_order_by_similarity` + `test_filter_strategy_switches_on_selectivity`.
 
 ### 3. Filter-strategy fallback threshold is runtime-tunable (default 0.1)
 


### PR DESCRIPTION
## Summary

Phase 2B of the pre-seed remediation plan. Closes the \`compute_cbo_strategy\` disconnect flagged by issue #467 (scope-reduced): the existing path delegated unconditionally to the pure-cost planner entry and bypassed \`QueryPlanner::choose_hybrid_strategy\` even for queries whose correctness depends on HNSW natural ordering (\`ORDER BY similarity()\`).

## The gap

- \`QueryPlanner::choose_hybrid_strategy\` — built in \`planner.rs\`, handles \`has_order_by_similarity\` by forcing \`VectorFirst\` and scaling over-fetch by selectivity. **Never called from \`execute_query\`.**
- \`QueryPlanner::choose_strategy_with_cbo_and_overfetch\` — calibrated cost comparison across \`VectorFirst\` / \`GraphFirst\` / \`Parallel\`. Called by \`compute_cbo_strategy\` for every SELECT query, including those with \`ORDER BY similarity()\`.
- A stale TODO in \`collection/search/query/mod.rs:16\` tracked this.

For \`ORDER BY similarity()\` queries with a selective non-vector filter, a pure-cost CBO could legitimately pick \`Parallel\` / \`GraphFirst\` and break the strict monotonicity of \`similarity()\` across the top-k — a correctness regression, not a perf issue.

## What this PR does

1. \`compute_cbo_strategy(stmt, filter, limit)\` now inspects \`stmt.order_by\` for \`OrderByExpr::Similarity(_)\` / \`OrderByExpr::SimilarityBare\` and routes:
   - **ORDER BY similarity() present** → \`choose_hybrid_strategy\` (forces \`VectorFirst\`, selectivity-aware over-fetch clamped to \`[2.0, 10.0]\`).
   - **Otherwise** → unchanged \`choose_strategy_with_cbo_and_overfetch\` (calibrated cost comparison).
2. Both branches return the same \`(ExecutionStrategy, over_fetch: usize)\` tuple consumed by \`dispatch_vector_query\` in \`execution_paths.rs\` — zero cascade on the executor side.
3. Private helpers \`has_order_by_similarity\` and \`cbo_strategy_for_order_by_similarity\` keep cyclomatic complexity ≤ 8 on the router and document the rationale inline.
4. Stale TODO in \`query/mod.rs\` replaced by a docstring describing both routing branches.
5. \`docs/reference/KNOWN_LIMITATIONS.md\` entry #2 rescoped from \"\`choose_hybrid_strategy\` never called\" to \"multi-candidate \`PlanGenerator\` enumeration not wired\" — the remaining deep-CBO gap tracked for a future expansion.

## Scope reduction rationale

Issue #467 originally asked for multi-candidate \`PlanGenerator::CandidatePlan\` enumeration. Post-analysis, the operationally-visible disconnect is the \`choose_hybrid_strategy\` bypass, not the plan-generator enumeration. Full enumeration would only change decisions when the cost landscape is non-trivially multimodal — a niche improvement with high architectural risk. This PR closes the correctness-impacting half of the issue and carries the deeper enumeration forward as a KNOWN_LIMITATIONS entry.

## Test coverage — 2 new BDD tests (379 total)

| Test | Verifies |
|---|---|
| \`test_cbo_forces_vector_first_for_order_by_similarity_with_selective_filter\` | Selective \`category = 'science'\` + \`ORDER BY similarity() DESC LIMIT 3\` → top-k stays monotone. |
| \`test_cbo_calibrated_path_still_works_without_order_by_similarity\` | Same filter without \`ORDER BY similarity()\` → calibrated branch still applies filter + LIMIT correctly. |

Pre-existing \`test_order_by_similarity_desc\` / \`_asc\` / \`hybrid_compositions\` suites all remain green (377 → 379 tests, 0 failures, 0 regressions).

## Gate results

- [x] \`cargo fmt --all\`
- [x] \`cargo clippy --workspace --all-targets --features persistence,gpu,update-check --exclude velesdb-python -- -D warnings -D clippy::pedantic\`
- [x] \`cargo test -p velesdb-core --features persistence --test bdd -- --test-threads=1\` — **379 BDD (+2 new), 0 failures**
- [x] \`cargo check -p velesdb-core --no-default-features\`
- [x] \`cargo check -p velesdb-wasm --no-default-features --target wasm32-unknown-unknown\`
- [x] Codacy CLI (WSL) — **0 code findings**
- [x] Recall gate — **skipped**, execution path changes only affect plan selection; the \`search_post_filter\` / \`filter_and_hydrate\` executor code is untouched and the two new BDD tests verify result-ordering invariants.

## Impact matrix

| Surface | Impact | Action |
|---|---|---|
| \`velesdb-core\` internal | \`Collection::compute_cbo_strategy\` signature gained \`stmt\` param (private, \`pub(super)\`) | Updated in-file |
| Public API | None (private helper) | N/A |
| \`velesdb-server\` / SDK / integrations | None (routing is transparent) | N/A |
| WASM / mobile / CLI | None | N/A |
| Docs | \`KNOWN_LIMITATIONS.md\` #2 rescoped, \`query/mod.rs\` docstring rewritten | Shipped |

## Test plan

- [x] Full BDD suite runs green locally (single-threaded).
- [x] Codacy CLI green in WSL.
- [ ] CI green on PR.
- [ ] Devin review green.
- [ ] Codacy Online green.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/613" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
