### PR TITLE
fix(hnsw/persistence): atomic save_sidecars via generation counter (closes #617)

### DIFF
--- a/crates/velesdb-core/src/index/hnsw/index/constructors.rs
+++ b/crates/velesdb-core/src/index/hnsw/index/constructors.rs
@@ -260,8 +260,10 @@ impl HnswIndex {
 
         // #617: stamp every on-disk artefact with the same monotonic generation
         // so that a crash between any two renames (graph, mappings, vectors,
-        // meta) is detectable on reload.
-        let new_gen = persistence::next_generation(path);
+        // meta) is detectable on reload. Errors are propagated rather than
+        // silently resetting to generation 1 on corrupted meta (Devin #618
+        // follow-up).
+        let new_gen = persistence::next_generation(path)?;
 
         // Dump the HNSW graph itself (caller-specific — see persistence::save_sidecars).
         self.inner.read().file_dump(path, "native_hnsw")?;

--- a/crates/velesdb-core/src/index/hnsw/index/constructors.rs
+++ b/crates/velesdb-core/src/index/hnsw/index/constructors.rs
@@ -258,8 +258,19 @@ impl HnswIndex {
         let path = path.as_ref();
         std::fs::create_dir_all(path)?;
 
+        // #617: stamp every on-disk artefact with the same monotonic generation
+        // so that a crash between any two renames (graph, mappings, vectors,
+        // meta) is detectable on reload.
+        let new_gen = persistence::next_generation(path);
+
         // Dump the HNSW graph itself (caller-specific — see persistence::save_sidecars).
         self.inner.read().file_dump(path, "native_hnsw")?;
+
+        // Graph-generation marker is written IMMEDIATELY after the graph dump
+        // and BEFORE the sidecars, so any crash after the graph rename leaves
+        // the marker at the new generation while the sidecars still stamp the
+        // old one — `load_sidecars` detects the mismatch.
+        persistence::save_graph_generation(path, new_gen)?;
 
         // Mappings + vectors + meta in one shared call (RF-DEDUP #448 Group C).
         // NativeHnsw exclusively uses StorageMode::Full for backward compat.
@@ -272,9 +283,10 @@ impl HnswIndex {
                 metric: self.metric,
                 enable_vector_storage: self.enable_vector_storage,
                 storage_mode: crate::StorageMode::Full,
-                // `save_sidecars` overwrites this with the bumped generation (#617).
+                // `save_sidecars` overwrites this with `new_gen` (#617).
                 generation: 0,
             },
+            new_gen,
         )
     }
 

--- a/crates/velesdb-core/src/index/hnsw/index/constructors.rs
+++ b/crates/velesdb-core/src/index/hnsw/index/constructors.rs
@@ -272,6 +272,8 @@ impl HnswIndex {
                 metric: self.metric,
                 enable_vector_storage: self.enable_vector_storage,
                 storage_mode: crate::StorageMode::Full,
+                // `save_sidecars` overwrites this with the bumped generation (#617).
+                generation: 0,
             },
         )
     }

--- a/crates/velesdb-core/src/index/hnsw/mod.rs
+++ b/crates/velesdb-core/src/index/hnsw/mod.rs
@@ -47,6 +47,8 @@ mod index_tests;
 #[cfg(test)]
 mod params_tests;
 #[cfg(test)]
+mod persistence_atomicity_tests;
+#[cfg(test)]
 mod sharded_mappings_tests;
 #[cfg(test)]
 mod sharded_vectors_tests;

--- a/crates/velesdb-core/src/index/hnsw/native_index_io.rs
+++ b/crates/velesdb-core/src/index/hnsw/native_index_io.rs
@@ -23,8 +23,10 @@ impl NativeHnswIndex {
 
         // #617: stamp every on-disk artefact with the same monotonic generation
         // so that a crash between any two renames (graph, mappings, vectors,
-        // meta) is detectable on reload.
-        let new_gen = persistence::next_generation(path);
+        // meta) is detectable on reload. Errors are propagated rather than
+        // silently resetting to generation 1 on corrupted meta (Devin #618
+        // follow-up).
+        let new_gen = persistence::next_generation(path)?;
 
         // Dump the HNSW graph itself (caller-specific — see persistence::save_sidecars).
         let storage_mode = {

--- a/crates/velesdb-core/src/index/hnsw/native_index_io.rs
+++ b/crates/velesdb-core/src/index/hnsw/native_index_io.rs
@@ -38,6 +38,8 @@ impl NativeHnswIndex {
                 metric: self.metric,
                 enable_vector_storage: self.enable_vector_storage,
                 storage_mode,
+                // `save_sidecars` overwrites this with the bumped generation (#617).
+                generation: 0,
             },
         )
     }

--- a/crates/velesdb-core/src/index/hnsw/native_index_io.rs
+++ b/crates/velesdb-core/src/index/hnsw/native_index_io.rs
@@ -21,12 +21,22 @@ impl NativeHnswIndex {
         let path = path.as_ref();
         std::fs::create_dir_all(path)?;
 
+        // #617: stamp every on-disk artefact with the same monotonic generation
+        // so that a crash between any two renames (graph, mappings, vectors,
+        // meta) is detectable on reload.
+        let new_gen = persistence::next_generation(path);
+
         // Dump the HNSW graph itself (caller-specific — see persistence::save_sidecars).
         let storage_mode = {
             let inner = self.inner.read();
             inner.file_dump(path, "native_hnsw")?;
             inner.storage_mode()
         };
+
+        // Graph-generation marker is written IMMEDIATELY after the graph dump
+        // and BEFORE the sidecars — see comment in `HnswIndex::save` for the
+        // full rationale (#617 Devin follow-up).
+        persistence::save_graph_generation(path, new_gen)?;
 
         // Mappings + vectors + meta in one shared call (RF-DEDUP #448 Group C).
         persistence::save_sidecars(
@@ -38,9 +48,10 @@ impl NativeHnswIndex {
                 metric: self.metric,
                 enable_vector_storage: self.enable_vector_storage,
                 storage_mode,
-                // `save_sidecars` overwrites this with the bumped generation (#617).
+                // `save_sidecars` overwrites this with `new_gen` (#617).
                 generation: 0,
             },
+            new_gen,
         )
     }
 

--- a/crates/velesdb-core/src/index/hnsw/persistence.rs
+++ b/crates/velesdb-core/src/index/hnsw/persistence.rs
@@ -347,6 +347,54 @@ fn read_current_generation(path: &Path) -> Option<u64> {
     load_meta(path).ok().map(|meta| meta.generation)
 }
 
+/// Returns the generation number to stamp on the next save at `path`.
+///
+/// Callers that write artefacts outside the sidecar trio (e.g. the HNSW
+/// graph file via `file_dump`) must call this once, then pass the returned
+/// value to both [`save_graph_generation`] and [`save_sidecars`] so every
+/// artefact is stamped with the same monotonic counter.
+pub(crate) fn next_generation(path: &Path) -> u64 {
+    read_current_generation(path).unwrap_or(0).saturating_add(1)
+}
+
+/// Writes the HNSW graph generation marker (`native_hnsw.gen`) atomically.
+///
+/// Complements the graph file (`native_hnsw`) dumped by the caller before
+/// invoking [`save_sidecars`]. Closes the atomicity gap between graph dump
+/// and sidecar writes (issue #617 Devin follow-up): any crash after graph
+/// dump but before sidecar writes leaves `native_hnsw.gen` at the new
+/// generation while the sidecars remain at the old one, so [`load_sidecars`]
+/// detects the mismatch.
+///
+/// # Errors
+///
+/// Returns `io::Error` if serialization or the atomic write fails.
+pub(crate) fn save_graph_generation(path: &Path, generation: u64) -> std::io::Result<()> {
+    let marker_path = path.join("native_hnsw.gen");
+    let bytes = postcard::to_allocvec(&generation).map_err(std::io::Error::other)?;
+    atomic_write(&marker_path, &bytes)
+}
+
+/// Reads the HNSW graph generation marker, returning `0` when the file is
+/// missing for backward compatibility with pre-#617 databases.
+///
+/// Pre-#617 saves did not write `native_hnsw.gen`, so legacy DBs carry gen 0
+/// everywhere — the consistency check in [`load_sidecars`] passes trivially
+/// (0 == 0 == 0 == 0).
+///
+/// # Errors
+///
+/// Returns `io::Error` only when the file exists but is unreadable /
+/// corrupt. A missing file is not an error (returns `Ok(0)`).
+pub(crate) fn load_graph_generation(path: &Path) -> std::io::Result<u64> {
+    let marker_path = path.join("native_hnsw.gen");
+    match std::fs::read(&marker_path) {
+        Ok(bytes) => postcard::from_bytes::<u64>(&bytes).map_err(std::io::Error::other),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(0),
+        Err(err) => Err(err),
+    }
+}
+
 /// Persists every non-graph sidecar (mappings, vectors, meta) for an HNSW
 /// index in one call.
 ///
@@ -364,14 +412,19 @@ fn read_current_generation(path: &Path) -> Option<u64> {
 /// Individual file writes are atomic (via [`atomic_write`]), but the 3-file
 /// sequence is not — a crash between two renames leaves the on-disk state
 /// inconsistent. To detect such a crash on reload, every sidecar is stamped
-/// with the same monotonic `generation: u64`, computed as
-/// `current_on_disk_generation + 1` at the start of this call. `meta` is
-/// written LAST: its generation is the authoritative commit point. On load,
-/// [`load_sidecars`] verifies that mappings and vectors carry the same
-/// generation as meta — any mismatch is reported as `InvalidData`.
+/// with the same monotonic `new_gen: u64`, computed by the caller via
+/// [`next_generation`] BEFORE dumping the HNSW graph. `meta` is written
+/// LAST: its generation is the authoritative commit point. On load,
+/// [`load_sidecars`] verifies that mappings, vectors, and the graph marker
+/// all carry the same generation as meta — any mismatch is reported as
+/// `InvalidData`.
+///
+/// The caller must pre-compute `new_gen = next_generation(path)` once and
+/// pass the same value to [`save_graph_generation`] and this function, so
+/// the graph file and the sidecars land on the same generation stamp.
 ///
 /// The caller-provided [`HnswMeta::generation`] is ignored; this function
-/// overwrites it with the freshly bumped value.
+/// overwrites it with `new_gen`.
 ///
 /// # Errors
 ///
@@ -381,12 +434,8 @@ pub(crate) fn save_sidecars(
     mappings: &super::sharded_mappings::ShardedMappings,
     vectors: &super::sharded_vectors::ShardedVectors,
     meta: &HnswMeta,
+    new_gen: u64,
 ) -> std::io::Result<()> {
-    // Bump off the current on-disk generation (not the caller-supplied one)
-    // so that repeated saves keep the counter strictly monotonic even when
-    // the in-memory `HnswMeta` is freshly constructed each time.
-    let new_gen = read_current_generation(path).unwrap_or(0).saturating_add(1);
-
     let (id_to_idx, idx_to_id, next_idx) = mappings.as_parts();
     save_mappings(
         path,
@@ -400,7 +449,7 @@ pub(crate) fn save_sidecars(
     save_or_cleanup_vectors(path, meta.enable_vector_storage, vectors, new_gen)?;
 
     // `meta` is written LAST — its generation is the authoritative commit
-    // point that `load_sidecars` checks the two other sidecars against.
+    // point that `load_sidecars` checks the other artefacts against.
     let stamped_meta = HnswMeta {
         generation: new_gen,
         ..*meta
@@ -416,15 +465,18 @@ pub(crate) fn save_sidecars(
 ///
 /// # Atomicity check (issue #617)
 ///
-/// Every sidecar carries a `generation: u64` stamp written by
-/// [`save_sidecars`]. `meta.generation` is the authoritative commit
-/// point. If mappings or vectors carry a stale or mismatched generation,
-/// the database is proven to be in an inconsistent state (crash between
-/// two file renames during the previous save) and this function returns
-/// `InvalidData` rather than silently loading a torn state.
+/// Every persisted artefact (graph marker, mappings, vectors) carries a
+/// `generation: u64` stamp written by the pair
+/// [`save_graph_generation`] + [`save_sidecars`]. `meta.generation` is the
+/// authoritative commit point. If any artefact carries a stale or
+/// mismatched generation, the database is proven to be in an inconsistent
+/// state (crash between file renames during the previous save) and this
+/// function returns `InvalidData` rather than silently loading a torn
+/// state.
 ///
-/// Legacy DBs written by pre-#617 binaries have generation=0 everywhere,
-/// so the consistency check passes trivially (0 == 0 == 0).
+/// Legacy DBs written by pre-#617 binaries have generation=0 everywhere
+/// and no `native_hnsw.gen` marker — [`load_graph_generation`] returns 0
+/// for missing markers, so the consistency check passes trivially.
 ///
 /// # Errors
 ///
@@ -440,6 +492,18 @@ pub(crate) fn load_sidecars(
     super::sharded_vectors::ShardedVectors,
     bool,
 )> {
+    let graph_generation = load_graph_generation(path)?;
+    if graph_generation != meta.generation {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!(
+                "incomplete save detected: graph generation {} but meta generation {} \
+                 (crash between graph dump and sidecar writes, database state inconsistent)",
+                graph_generation, meta.generation,
+            ),
+        ));
+    }
+
     let mappings_data = load_mappings(path)?;
     if mappings_data.generation != meta.generation {
         return Err(std::io::Error::new(

--- a/crates/velesdb-core/src/index/hnsw/persistence.rs
+++ b/crates/velesdb-core/src/index/hnsw/persistence.rs
@@ -13,7 +13,7 @@
 //! - `native_meta.bin`: 5-tuple `(dimension: usize, metric: u8,
 //!   enable_vector_storage: bool, storage_mode: u8, generation: u64)`.
 //!   Backward-compat: 4-tuple (v1.7.2+, generation=0) and 3-tuple
-//!   (pre-v1.7.2, generation=0, storage_mode=Full) are still accepted on
+//!   (pre-v1.7.2, generation=0, `storage_mode=Full`) are still accepted on
 //!   load.
 //! - `native_mappings.bin`: 4-tuple `(id_to_idx: HashMap<u64, usize>,
 //!   idx_to_id: HashMap<usize, u64>, next_idx: usize, generation: u64)`.
@@ -272,30 +272,35 @@ fn atomic_write_inner(tmp_path: &Path, final_path: &Path, data: &[u8]) -> std::i
 /// RF-DEDUP: This pattern was duplicated in `HnswIndex::load` and
 /// `NativeHnswIndex::load`. Now both delegate here.
 ///
+/// Returns `(vectors, enable_vector_storage, vectors_generation)`. The
+/// third element is the on-disk generation stamp (see #617); it is only
+/// meaningful when `enable_vector_storage` is `true`. When vectors are
+/// disabled or the file is absent, the returned generation is `0`.
+///
 /// # Errors
 ///
 /// Returns `io::Error` if the vectors file exists but cannot be read/deserialized.
 pub(crate) fn load_vectors_or_disable(
     path: &Path,
     meta: &HnswMeta,
-) -> std::io::Result<(super::sharded_vectors::ShardedVectors, bool)> {
+) -> std::io::Result<(super::sharded_vectors::ShardedVectors, bool, u64)> {
     use super::sharded_vectors::ShardedVectors;
 
     if !meta.enable_vector_storage {
-        return Ok((ShardedVectors::new(meta.dimension), false));
+        return Ok((ShardedVectors::new(meta.dimension), false, 0));
     }
 
     match load_vectors(path) {
         Ok(vectors_data) => {
             let vectors = ShardedVectors::new(meta.dimension);
             vectors.insert_batch(vectors_data.vectors);
-            Ok((vectors, true))
+            Ok((vectors, true, vectors_data.generation))
         }
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
             tracing::debug!(
                 "native_vectors.bin missing during HNSW load; disabling vector storage for safety"
             );
-            Ok((ShardedVectors::new(meta.dimension), false))
+            Ok((ShardedVectors::new(meta.dimension), false, 0))
         }
         Err(err) => Err(err),
     }
@@ -332,6 +337,16 @@ pub(crate) fn save_or_cleanup_vectors(
     }
 }
 
+/// Reads the current on-disk generation from `native_meta.bin`, if any.
+///
+/// Returns `None` when meta is missing or unreadable — the caller then
+/// treats the directory as fresh and starts at generation 0. Legacy DBs
+/// (pre-#617 format) return `Some(0)` via [`load_meta`]'s backward-compat
+/// fallback, so the next save lands at generation 1 regardless.
+fn read_current_generation(path: &Path) -> Option<u64> {
+    load_meta(path).ok().map(|meta| meta.generation)
+}
+
 /// Persists every non-graph sidecar (mappings, vectors, meta) for an HNSW
 /// index in one call.
 ///
@@ -344,6 +359,20 @@ pub(crate) fn save_or_cleanup_vectors(
 /// types use different inner types (`NativeHnswInner` directly vs
 /// `ManuallyDrop<HnswInner>`) that would otherwise require a trait object.
 ///
+/// # Atomicity (issue #617)
+///
+/// Individual file writes are atomic (via [`atomic_write`]), but the 3-file
+/// sequence is not — a crash between two renames leaves the on-disk state
+/// inconsistent. To detect such a crash on reload, every sidecar is stamped
+/// with the same monotonic `generation: u64`, computed as
+/// `current_on_disk_generation + 1` at the start of this call. `meta` is
+/// written LAST: its generation is the authoritative commit point. On load,
+/// [`load_sidecars`] verifies that mappings and vectors carry the same
+/// generation as meta — any mismatch is reported as `InvalidData`.
+///
+/// The caller-provided [`HnswMeta::generation`] is ignored; this function
+/// overwrites it with the freshly bumped value.
+///
 /// # Errors
 ///
 /// Returns `io::Error` if any of the three file operations fail.
@@ -353,6 +382,11 @@ pub(crate) fn save_sidecars(
     vectors: &super::sharded_vectors::ShardedVectors,
     meta: &HnswMeta,
 ) -> std::io::Result<()> {
+    // Bump off the current on-disk generation (not the caller-supplied one)
+    // so that repeated saves keep the counter strictly monotonic even when
+    // the in-memory `HnswMeta` is freshly constructed each time.
+    let new_gen = read_current_generation(path).unwrap_or(0).saturating_add(1);
+
     let (id_to_idx, idx_to_id, next_idx) = mappings.as_parts();
     save_mappings(
         path,
@@ -360,11 +394,18 @@ pub(crate) fn save_sidecars(
             id_to_idx,
             idx_to_id,
             next_idx,
-            generation: meta.generation,
+            generation: new_gen,
         },
     )?;
-    save_or_cleanup_vectors(path, meta.enable_vector_storage, vectors, meta.generation)?;
-    save_meta(path, meta)
+    save_or_cleanup_vectors(path, meta.enable_vector_storage, vectors, new_gen)?;
+
+    // `meta` is written LAST — its generation is the authoritative commit
+    // point that `load_sidecars` checks the two other sidecars against.
+    let stamped_meta = HnswMeta {
+        generation: new_gen,
+        ..*meta
+    };
+    save_meta(path, &stamped_meta)
 }
 
 /// Loads non-graph sidecars (mappings + vectors) for an HNSW index given a
@@ -373,11 +414,24 @@ pub(crate) fn save_sidecars(
 /// Complements [`save_sidecars`]. The HNSW graph itself is loaded by the
 /// caller (different inner types, see [`save_sidecars`]).
 ///
+/// # Atomicity check (issue #617)
+///
+/// Every sidecar carries a `generation: u64` stamp written by
+/// [`save_sidecars`]. `meta.generation` is the authoritative commit
+/// point. If mappings or vectors carry a stale or mismatched generation,
+/// the database is proven to be in an inconsistent state (crash between
+/// two file renames during the previous save) and this function returns
+/// `InvalidData` rather than silently loading a torn state.
+///
+/// Legacy DBs written by pre-#617 binaries have generation=0 everywhere,
+/// so the consistency check passes trivially (0 == 0 == 0).
+///
 /// # Errors
 ///
-/// Returns `io::Error` if the mappings file is missing or corrupt. Missing
-/// vectors files are tolerated and gracefully disable vector storage — see
-/// [`load_vectors_or_disable`].
+/// Returns `io::Error::InvalidData` if the on-disk generations disagree
+/// with `meta.generation`. Also returns `io::Error` if the mappings file
+/// is missing or corrupt. Missing vectors files are tolerated and
+/// gracefully disable vector storage — see [`load_vectors_or_disable`].
 pub(crate) fn load_sidecars(
     path: &Path,
     meta: &HnswMeta,
@@ -387,12 +441,34 @@ pub(crate) fn load_sidecars(
     bool,
 )> {
     let mappings_data = load_mappings(path)?;
+    if mappings_data.generation != meta.generation {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!(
+                "incomplete save detected: mappings generation {} but meta generation {} \
+                 (crash between sidecar writes, database state inconsistent)",
+                mappings_data.generation, meta.generation,
+            ),
+        ));
+    }
+
+    let (vectors, enable_vector_storage, vectors_generation) = load_vectors_or_disable(path, meta)?;
+    if enable_vector_storage && vectors_generation != meta.generation {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!(
+                "incomplete save detected: vectors generation {} but meta generation {} \
+                 (crash between sidecar writes, database state inconsistent)",
+                vectors_generation, meta.generation,
+            ),
+        ));
+    }
+
     let mappings = super::sharded_mappings::ShardedMappings::from_parts(
         mappings_data.id_to_idx,
         mappings_data.idx_to_id,
         mappings_data.next_idx,
     );
-    let (vectors, enable_vector_storage) = load_vectors_or_disable(path, meta)?;
     Ok((mappings, vectors, enable_vector_storage))
 }
 

--- a/crates/velesdb-core/src/index/hnsw/persistence.rs
+++ b/crates/velesdb-core/src/index/hnsw/persistence.rs
@@ -337,14 +337,24 @@ pub(crate) fn save_or_cleanup_vectors(
     }
 }
 
-/// Reads the current on-disk generation from `native_meta.bin`, if any.
+/// Reads the current on-disk generation from `native_meta.bin` with
+/// fail-fast semantics on real I/O or corruption errors.
 ///
-/// Returns `None` when meta is missing or unreadable — the caller then
-/// treats the directory as fresh and starts at generation 0. Legacy DBs
-/// (pre-#617 format) return `Some(0)` via [`load_meta`]'s backward-compat
-/// fallback, so the next save lands at generation 1 regardless.
-fn read_current_generation(path: &Path) -> Option<u64> {
-    load_meta(path).ok().map(|meta| meta.generation)
+/// Returns:
+/// - `Ok(Some(gen))` when meta exists and was parseable (incl. legacy
+///   backward-compat fallbacks, which yield `gen=0`).
+/// - `Ok(None)` only when meta does NOT exist — the caller then treats
+///   the directory as fresh and starts at generation 1.
+/// - `Err(err)` on any other I/O or deserialization failure (corrupted
+///   meta, permission denied, etc.). Callers MUST NOT paper over this —
+///   proceeding with a fresh generation=1 save would overwrite potentially
+///   recoverable corrupted state (Devin #618 follow-up).
+fn read_current_generation(path: &Path) -> std::io::Result<Option<u64>> {
+    match load_meta(path) {
+        Ok(meta) => Ok(Some(meta.generation)),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(err) => Err(err),
+    }
 }
 
 /// Returns the generation number to stamp on the next save at `path`.
@@ -353,8 +363,18 @@ fn read_current_generation(path: &Path) -> Option<u64> {
 /// graph file via `file_dump`) must call this once, then pass the returned
 /// value to both [`save_graph_generation`] and [`save_sidecars`] so every
 /// artefact is stamped with the same monotonic counter.
-pub(crate) fn next_generation(path: &Path) -> u64 {
-    read_current_generation(path).unwrap_or(0).saturating_add(1)
+///
+/// # Errors
+///
+/// Returns `io::Error` when meta exists but is unreadable or corrupted —
+/// the caller must propagate rather than silently starting at generation
+/// 1, which would overwrite potentially recoverable state (Devin #618
+/// follow-up). A missing meta is not an error (returns `Ok(1)` for fresh
+/// directories).
+pub(crate) fn next_generation(path: &Path) -> std::io::Result<u64> {
+    Ok(read_current_generation(path)?
+        .unwrap_or(0)
+        .saturating_add(1))
 }
 
 /// Writes the HNSW graph generation marker (`native_hnsw.gen`) atomically.

--- a/crates/velesdb-core/src/index/hnsw/persistence.rs
+++ b/crates/velesdb-core/src/index/hnsw/persistence.rs
@@ -5,10 +5,22 @@
 //!
 //! # On-Disk Format
 //!
-//! Both index types share the same binary format:
-//! - `native_meta.bin`: `(dimension: usize, metric: u8, enable_vector_storage: bool)`
-//! - `native_mappings.bin`: `(id_to_idx: HashMap<u64, usize>, idx_to_id: HashMap<usize, u64>, next_idx: usize)`
-//! - `native_vectors.bin`: `Vec<(internal_idx: usize, vector: Vec<f32>)>`
+//! Both index types share the same binary format. Every sidecar carries a
+//! `generation: u64` stamp so that [`load_sidecars`] can detect a partial
+//! save (see issue #617 — the 3-file sequence is not itself atomic even
+//! though each individual file is written atomically).
+//!
+//! - `native_meta.bin`: 5-tuple `(dimension: usize, metric: u8,
+//!   enable_vector_storage: bool, storage_mode: u8, generation: u64)`.
+//!   Backward-compat: 4-tuple (v1.7.2+, generation=0) and 3-tuple
+//!   (pre-v1.7.2, generation=0, storage_mode=Full) are still accepted on
+//!   load.
+//! - `native_mappings.bin`: 4-tuple `(id_to_idx: HashMap<u64, usize>,
+//!   idx_to_id: HashMap<usize, u64>, next_idx: usize, generation: u64)`.
+//!   Backward-compat: 3-tuple (generation=0) accepted on load.
+//! - `native_vectors.bin`: 2-tuple `(Vec<(internal_idx: usize, vector:
+//!   Vec<f32>)>, generation: u64)`. Backward-compat: plain `Vec`
+//!   (generation=0) accepted on load.
 
 use crate::distance::DistanceMetric;
 use std::collections::HashMap;
@@ -17,12 +29,19 @@ use std::path::Path;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 /// HNSW index metadata as stored on disk.
+///
+/// The `generation` field is the authoritative commit stamp used to
+/// detect partial `save_sidecars` writes (see [`save_sidecars`] and
+/// issue #617). `meta` is written last during save, so its generation is
+/// the ground truth that the other two sidecars must match on load.
 pub(crate) struct HnswMeta {
     pub dimension: usize,
     pub metric: DistanceMetric,
     pub enable_vector_storage: bool,
     /// Storage mode for the HNSW backend (defaults to `Full` for backward compat).
     pub storage_mode: crate::StorageMode,
+    /// Monotonic save generation. `0` for DBs written by pre-fix binaries.
+    pub generation: u64,
 }
 
 /// HNSW mappings data as stored on disk.
@@ -30,11 +49,15 @@ pub(crate) struct HnswMappingsData {
     pub id_to_idx: HashMap<u64, usize>,
     pub idx_to_id: HashMap<usize, u64>,
     pub next_idx: usize,
+    /// Must match [`HnswMeta::generation`] on load — mismatch = partial save.
+    pub generation: u64,
 }
 
 /// HNSW vectors payload as stored on disk.
 pub(crate) struct HnswVectorsData {
     pub vectors: Vec<(usize, Vec<f32>)>,
+    /// Must match [`HnswMeta::generation`] on load — mismatch = partial save.
+    pub generation: u64,
 }
 
 /// Saves HNSW metadata to `native_meta.bin` in the given directory.
@@ -51,6 +74,7 @@ pub(crate) fn save_meta(path: &Path, meta: &HnswMeta) -> std::io::Result<()> {
         meta.metric as u8,
         meta.enable_vector_storage,
         storage_mode_to_u8(meta.storage_mode),
+        meta.generation,
     ))
     .map_err(std::io::Error::other)?;
     atomic_write(&meta_path, &bytes)
@@ -66,7 +90,22 @@ pub(crate) fn load_meta(path: &Path) -> std::io::Result<HnswMeta> {
     let meta_path = path.join("native_meta.bin");
     let bytes = std::fs::read(meta_path)?;
 
-    // Try 4-tuple format first (v1.7.2+), fall back to 3-tuple (pre-v1.7.2)
+    // Try 5-tuple (post-#617, with generation) first.
+    if let Ok((dimension, metric_u8, enable_vector_storage, storage_mode_u8, generation)) =
+        postcard::from_bytes::<(usize, u8, bool, u8, u64)>(&bytes)
+    {
+        let metric = metric_from_u8(metric_u8)?;
+        let storage_mode = storage_mode_from_u8(storage_mode_u8);
+        return Ok(HnswMeta {
+            dimension,
+            metric,
+            enable_vector_storage,
+            storage_mode,
+            generation,
+        });
+    }
+
+    // Backward-compat: 4-tuple format (v1.7.2+) — no generation stamp.
     if let Ok((dimension, metric_u8, enable_vector_storage, storage_mode_u8)) =
         postcard::from_bytes::<(usize, u8, bool, u8)>(&bytes)
     {
@@ -77,10 +116,11 @@ pub(crate) fn load_meta(path: &Path) -> std::io::Result<HnswMeta> {
             metric,
             enable_vector_storage,
             storage_mode,
+            generation: 0,
         });
     }
 
-    // Backward-compat: 3-tuple format (pre-v1.7.2) defaults to Full
+    // Backward-compat: 3-tuple format (pre-v1.7.2) defaults to Full.
     let (dimension, metric_u8, enable_vector_storage): (usize, u8, bool) =
         postcard::from_bytes(&bytes).map_err(std::io::Error::other)?;
     let metric = metric_from_u8(metric_u8)?;
@@ -90,6 +130,7 @@ pub(crate) fn load_meta(path: &Path) -> std::io::Result<HnswMeta> {
         metric,
         enable_vector_storage,
         storage_mode: crate::StorageMode::Full,
+        generation: 0,
     })
 }
 
@@ -102,8 +143,13 @@ pub(crate) fn load_meta(path: &Path) -> std::io::Result<HnswMeta> {
 /// Returns `io::Error` if file creation or serialization fails.
 pub(crate) fn save_mappings(path: &Path, data: &HnswMappingsData) -> std::io::Result<()> {
     let mappings_path = path.join("native_mappings.bin");
-    let bytes = postcard::to_allocvec(&(&data.id_to_idx, &data.idx_to_id, data.next_idx))
-        .map_err(std::io::Error::other)?;
+    let bytes = postcard::to_allocvec(&(
+        &data.id_to_idx,
+        &data.idx_to_id,
+        data.next_idx,
+        data.generation,
+    ))
+    .map_err(std::io::Error::other)?;
     atomic_write(&mappings_path, &bytes)
 }
 
@@ -116,6 +162,19 @@ pub(crate) fn load_mappings(path: &Path) -> std::io::Result<HnswMappingsData> {
     let mappings_path = path.join("native_mappings.bin");
     let bytes = std::fs::read(mappings_path)?;
 
+    // Try 4-tuple (post-#617, with generation) first.
+    if let Ok((id_to_idx, idx_to_id, next_idx, generation)) =
+        postcard::from_bytes::<(HashMap<u64, usize>, HashMap<usize, u64>, usize, u64)>(&bytes)
+    {
+        return Ok(HnswMappingsData {
+            id_to_idx,
+            idx_to_id,
+            next_idx,
+            generation,
+        });
+    }
+
+    // Backward-compat: 3-tuple format (pre-#617) — no generation stamp.
     let (id_to_idx, idx_to_id, next_idx): (HashMap<u64, usize>, HashMap<usize, u64>, usize) =
         postcard::from_bytes(&bytes).map_err(std::io::Error::other)?;
 
@@ -123,6 +182,7 @@ pub(crate) fn load_mappings(path: &Path) -> std::io::Result<HnswMappingsData> {
         id_to_idx,
         idx_to_id,
         next_idx,
+        generation: 0,
     })
 }
 
@@ -135,7 +195,8 @@ pub(crate) fn load_mappings(path: &Path) -> std::io::Result<HnswMappingsData> {
 /// Returns `io::Error` if file creation or serialization fails.
 pub(crate) fn save_vectors(path: &Path, data: &HnswVectorsData) -> std::io::Result<()> {
     let vectors_path = path.join("native_vectors.bin");
-    let bytes = postcard::to_allocvec(&data.vectors).map_err(std::io::Error::other)?;
+    let bytes =
+        postcard::to_allocvec(&(&data.vectors, data.generation)).map_err(std::io::Error::other)?;
     atomic_write(&vectors_path, &bytes)
 }
 
@@ -147,9 +208,23 @@ pub(crate) fn save_vectors(path: &Path, data: &HnswVectorsData) -> std::io::Resu
 pub(crate) fn load_vectors(path: &Path) -> std::io::Result<HnswVectorsData> {
     let vectors_path = path.join("native_vectors.bin");
     let bytes = std::fs::read(vectors_path)?;
+
+    // Try 2-tuple (post-#617, with generation) first.
+    if let Ok((vectors, generation)) = postcard::from_bytes::<(Vec<(usize, Vec<f32>)>, u64)>(&bytes)
+    {
+        return Ok(HnswVectorsData {
+            vectors,
+            generation,
+        });
+    }
+
+    // Backward-compat: plain `Vec` payload (pre-#617) — no generation stamp.
     let vectors: Vec<(usize, Vec<f32>)> =
         postcard::from_bytes(&bytes).map_err(std::io::Error::other)?;
-    Ok(HnswVectorsData { vectors })
+    Ok(HnswVectorsData {
+        vectors,
+        generation: 0,
+    })
 }
 
 /// Writes `data` to a unique temp file, fsyncs, then renames to `final_path`.
@@ -238,12 +313,14 @@ pub(crate) fn save_or_cleanup_vectors(
     path: &Path,
     enable_vector_storage: bool,
     vectors: &super::sharded_vectors::ShardedVectors,
+    generation: u64,
 ) -> std::io::Result<()> {
     if enable_vector_storage {
         save_vectors(
             path,
             &HnswVectorsData {
                 vectors: vectors.collect_for_parallel(),
+                generation,
             },
         )
     } else {
@@ -283,9 +360,10 @@ pub(crate) fn save_sidecars(
             id_to_idx,
             idx_to_id,
             next_idx,
+            generation: meta.generation,
         },
     )?;
-    save_or_cleanup_vectors(path, meta.enable_vector_storage, vectors)?;
+    save_or_cleanup_vectors(path, meta.enable_vector_storage, vectors, meta.generation)?;
     save_meta(path, meta)
 }
 

--- a/crates/velesdb-core/src/index/hnsw/persistence_atomicity_tests.rs
+++ b/crates/velesdb-core/src/index/hnsw/persistence_atomicity_tests.rs
@@ -145,9 +145,30 @@ fn test_save_sidecars_stamps_monotonic_generation() {
     let vectors = build_vectors();
     let meta = build_meta(0);
 
-    save_sidecars(path, &mappings, &vectors, &meta).expect("test: first save");
-    save_sidecars(path, &mappings, &vectors, &meta).expect("test: second save");
-    save_sidecars(path, &mappings, &vectors, &meta).expect("test: third save");
+    save_sidecars(
+        path,
+        &mappings,
+        &vectors,
+        &meta,
+        persistence::next_generation(path),
+    )
+    .expect("test: first save");
+    save_sidecars(
+        path,
+        &mappings,
+        &vectors,
+        &meta,
+        persistence::next_generation(path),
+    )
+    .expect("test: second save");
+    save_sidecars(
+        path,
+        &mappings,
+        &vectors,
+        &meta,
+        persistence::next_generation(path),
+    )
+    .expect("test: third save");
 
     let loaded_meta = persistence::load_meta(path).expect("test: load meta");
     assert_eq!(
@@ -179,8 +200,10 @@ fn test_load_sidecars_detects_stale_mappings() {
     let mappings = build_mappings();
     let vectors = build_vectors();
 
-    // Simulate a save at generation 4 (all three files consistent).
+    // Simulate a save at generation 4 (all four artefacts consistent:
+    // graph marker, mappings, vectors, meta).
     let meta_4 = build_meta(4);
+    persistence::save_graph_generation(path, 4).expect("test: graph gen 4");
     persistence::save_mappings(path, &mappings_data(&mappings, 4)).expect("test: save mappings 4");
     persistence::save_vectors(path, &vectors_data(&vectors, 4)).expect("test: save vectors 4");
     persistence::save_meta(path, &meta_4).expect("test: save meta 4");
@@ -209,13 +232,15 @@ fn test_load_sidecars_detects_stale_vectors() {
     let mappings = build_mappings();
     let vectors = build_vectors();
 
-    // Consistent state at generation 4.
+    // Consistent state at generation 4 (graph + mappings + vectors + meta).
+    persistence::save_graph_generation(path, 4).expect("test: graph gen 4");
     persistence::save_mappings(path, &mappings_data(&mappings, 4)).expect("test: save mappings 4");
     persistence::save_vectors(path, &vectors_data(&vectors, 4)).expect("test: save vectors 4");
     persistence::save_meta(path, &build_meta(4)).expect("test: save meta 4");
 
-    // Simulate a crash at generation 5 that only rewrote mappings + meta,
+    // Simulate a crash at generation 5 that rewrote graph + mappings + meta,
     // leaving vectors at gen 4.
+    persistence::save_graph_generation(path, 5).expect("test: graph gen 5");
     persistence::save_mappings(path, &mappings_data(&mappings, 5)).expect("test: save mappings 5");
     persistence::save_meta(path, &build_meta(5)).expect("test: save meta 5");
 
@@ -241,6 +266,8 @@ fn test_load_sidecars_detects_newer_mappings_than_meta() {
     let vectors = build_vectors();
 
     // Meta is older (gen 5) than mappings (gen 10) — `meta` is authoritative.
+    // Graph marker aligned with meta to isolate the mappings check.
+    persistence::save_graph_generation(path, 5).expect("test: graph gen 5");
     persistence::save_mappings(path, &mappings_data(&mappings, 10))
         .expect("test: save mappings 10");
     persistence::save_vectors(path, &vectors_data(&vectors, 5)).expect("test: save vectors 5");
@@ -336,10 +363,12 @@ fn test_save_then_load_roundtrip_gen_bumped() {
     persistence::save_vectors(path, &vectors_data(&vectors, 7)).expect("test: seed vectors");
     persistence::save_meta(path, &build_meta(7)).expect("test: seed meta");
 
-    // `save_sidecars` must read the current on-disk generation and bump
-    // to 8, regardless of what the caller put in the `HnswMeta` struct.
+    // Callers are expected to compute `next_generation(path)` and pass it
+    // explicitly; this must read the current on-disk generation and bump to 8.
     let meta_in = build_meta(0); // caller-provided generation ignored
-    save_sidecars(path, &mappings, &vectors, &meta_in).expect("test: save bumps gen");
+    let new_gen = persistence::next_generation(path);
+    assert_eq!(new_gen, 8, "next_generation must bump from 7 to 8");
+    save_sidecars(path, &mappings, &vectors, &meta_in, new_gen).expect("test: save bumps gen");
 
     let loaded_meta = persistence::load_meta(path).expect("test: reload meta");
     assert_eq!(
@@ -361,11 +390,89 @@ fn test_save_when_no_prior_state_starts_at_gen_1() {
 
     // Fresh directory, no prior meta. Caller passes generation=0 (ignored).
     let meta_in = build_meta(0);
-    save_sidecars(path, &mappings, &vectors, &meta_in).expect("test: first save");
+    let new_gen = persistence::next_generation(path);
+    assert_eq!(
+        new_gen, 1,
+        "next_generation on a fresh directory must return 1"
+    );
+    save_sidecars(path, &mappings, &vectors, &meta_in, new_gen).expect("test: first save");
 
     let loaded_meta = persistence::load_meta(path).expect("test: reload meta");
     assert_eq!(
         loaded_meta.generation, 1,
         "first save on a fresh directory must land at generation 1"
     );
+}
+
+// -----------------------------------------------------------------------
+// Test 9 (Devin follow-up) — load_sidecars detects stale HNSW graph
+// -----------------------------------------------------------------------
+
+#[test]
+fn test_load_sidecars_detects_stale_graph_generation() {
+    let dir = TempDir::new().expect("test: temp dir");
+    let path = dir.path();
+    let mappings = build_mappings();
+    let vectors = build_vectors();
+
+    // Consistent state at generation 4 across all four artefacts.
+    persistence::save_graph_generation(path, 4).expect("test: graph gen 4");
+    persistence::save_mappings(path, &mappings_data(&mappings, 4)).expect("test: save mappings 4");
+    persistence::save_vectors(path, &vectors_data(&vectors, 4)).expect("test: save vectors 4");
+    persistence::save_meta(path, &build_meta(4)).expect("test: save meta 4");
+
+    // Simulate a crash after the graph dump (new graph + new marker at gen=5)
+    // but BEFORE any sidecar was rewritten — mappings / vectors / meta still
+    // at gen=4.
+    persistence::save_graph_generation(path, 5).expect("test: graph gen 5 only");
+
+    let loaded_meta = persistence::load_meta(path).expect("test: reload meta");
+    let err =
+        load_sidecars(path, &loaded_meta).expect_err("test: stale graph must trigger InvalidData");
+    assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+    assert!(
+        err.to_string().contains("graph generation"),
+        "error should mention graph generation, got: {err}"
+    );
+}
+
+// -----------------------------------------------------------------------
+// Test 10 (Devin follow-up) — backward compat without graph marker
+// -----------------------------------------------------------------------
+
+#[test]
+fn test_backward_compat_no_graph_generation_marker_loads_as_zero() {
+    let dir = TempDir::new().expect("test: temp dir");
+    let path = dir.path();
+
+    // Fresh directory: no native_hnsw.gen exists → must read as 0 rather
+    // than surfacing a NotFound error. This is what makes legacy DBs (all
+    // sidecars at gen=0 by backward-compat default) pass the atomicity
+    // check trivially.
+    let observed = persistence::load_graph_generation(path)
+        .expect("test: missing graph marker must not be an error");
+    assert_eq!(
+        observed, 0,
+        "missing native_hnsw.gen must be treated as generation 0"
+    );
+}
+
+// -----------------------------------------------------------------------
+// Test 11 (Devin follow-up) — save_graph_generation round-trip
+// -----------------------------------------------------------------------
+
+#[test]
+fn test_save_graph_generation_roundtrip() {
+    let dir = TempDir::new().expect("test: temp dir");
+    let path = dir.path();
+
+    persistence::save_graph_generation(path, 42).expect("test: save marker");
+    let observed = persistence::load_graph_generation(path).expect("test: reload marker");
+    assert_eq!(observed, 42, "graph generation marker must round-trip");
+
+    // Overwriting with a larger generation also round-trips (atomic_write
+    // handles replacement).
+    persistence::save_graph_generation(path, 9999).expect("test: overwrite marker");
+    let observed = persistence::load_graph_generation(path).expect("test: reload marker 2");
+    assert_eq!(observed, 9999, "overwritten marker must round-trip");
 }

--- a/crates/velesdb-core/src/index/hnsw/persistence_atomicity_tests.rs
+++ b/crates/velesdb-core/src/index/hnsw/persistence_atomicity_tests.rs
@@ -1,0 +1,371 @@
+//! Crash-simulation tests for `save_sidecars` / `load_sidecars` atomicity
+//! (issue #617).
+//!
+//! `save_sidecars` writes three sidecar files sequentially
+//! (`native_mappings.bin`, `native_vectors.bin`, `native_meta.bin`). Each
+//! individual file uses atomic write-tmp-fsync-rename, but the 3-file
+//! sequence itself is not atomic. A crash between two renames leaves
+//! the on-disk state inconsistent, which can silently corrupt search or
+//! panic at load time.
+//!
+//! To detect a crashed save we stamp every sidecar with a monotonic
+//! `generation: u64`. `meta` (written last) is the authoritative commit
+//! point. Any file with a stale generation is proof of an incomplete
+//! prior save, and `load_sidecars` must reject the database with
+//! `io::ErrorKind::InvalidData` rather than silently return a torn state.
+//!
+//! These tests simulate the crashed states by manually rewriting the
+//! sidecar files with mismatched generations, no real crash is needed.
+//! Backward-compat cases (legacy DBs without the generation counter)
+//! must keep loading unchanged.
+//!
+//! NOTE: this module is an internal `#[cfg(test)]` sibling of
+//! [`super::persistence`], which means every `pub(crate)` helper in
+//! `persistence.rs` is reachable from here.
+
+use super::persistence::{
+    self, load_sidecars, save_sidecars, HnswMappingsData, HnswMeta, HnswVectorsData,
+};
+use super::sharded_mappings::ShardedMappings;
+use super::sharded_vectors::ShardedVectors;
+use crate::distance::DistanceMetric;
+use crate::StorageMode;
+use std::collections::HashMap;
+use std::path::Path;
+use tempfile::TempDir;
+
+// -----------------------------------------------------------------------
+// Helpers
+// -----------------------------------------------------------------------
+
+/// Builds a minimal `HnswMeta` for the atomicity tests.
+fn build_meta(generation: u64) -> HnswMeta {
+    HnswMeta {
+        dimension: 4,
+        metric: DistanceMetric::Cosine,
+        enable_vector_storage: true,
+        storage_mode: StorageMode::Full,
+        generation,
+    }
+}
+
+/// Builds a populated `ShardedMappings` containing two id→idx pairs.
+fn build_mappings() -> ShardedMappings {
+    let mut id_to_idx = HashMap::new();
+    id_to_idx.insert(1_u64, 0_usize);
+    id_to_idx.insert(2_u64, 1_usize);
+    let mut idx_to_id = HashMap::new();
+    idx_to_id.insert(0_usize, 1_u64);
+    idx_to_id.insert(1_usize, 2_u64);
+    ShardedMappings::from_parts(id_to_idx, idx_to_id, 2)
+}
+
+/// Builds a populated `ShardedVectors` containing two 4-d vectors.
+fn build_vectors() -> ShardedVectors {
+    let vectors = ShardedVectors::new(4);
+    vectors.insert_batch(vec![
+        (0_usize, vec![1.0_f32, 0.0, 0.0, 0.0]),
+        (1_usize, vec![0.0_f32, 1.0, 0.0, 0.0]),
+    ]);
+    vectors
+}
+
+/// Writes the legacy 4-tuple meta format (v1.7.2+, without the generation
+/// field) directly via postcard, bypassing `save_meta` so the file ends
+/// up at a real pre-fix format.
+fn write_legacy_4tuple_meta(path: &Path, meta: &HnswMeta) -> std::io::Result<()> {
+    let metric_u8 = meta.metric as u8;
+    let storage_mode_u8 = match meta.storage_mode {
+        StorageMode::Full => 0u8,
+        StorageMode::SQ8 => 1,
+        StorageMode::Binary => 2,
+        StorageMode::ProductQuantization => 3,
+        StorageMode::RaBitQ => 4,
+    };
+    let bytes = postcard::to_allocvec(&(
+        meta.dimension,
+        metric_u8,
+        meta.enable_vector_storage,
+        storage_mode_u8,
+    ))
+    .map_err(std::io::Error::other)?;
+    std::fs::write(path.join("native_meta.bin"), bytes)
+}
+
+/// Writes the legacy 3-tuple meta format (pre-v1.7.2, without storage mode
+/// or generation) directly via postcard.
+fn write_legacy_3tuple_meta(path: &Path, meta: &HnswMeta) -> std::io::Result<()> {
+    let metric_u8 = meta.metric as u8;
+    let bytes = postcard::to_allocvec(&(meta.dimension, metric_u8, meta.enable_vector_storage))
+        .map_err(std::io::Error::other)?;
+    std::fs::write(path.join("native_meta.bin"), bytes)
+}
+
+/// Writes the legacy 3-tuple mappings format (pre-generation) directly.
+fn write_legacy_3tuple_mappings(path: &Path, data: &HnswMappingsData) -> std::io::Result<()> {
+    let bytes = postcard::to_allocvec(&(&data.id_to_idx, &data.idx_to_id, data.next_idx))
+        .map_err(std::io::Error::other)?;
+    std::fs::write(path.join("native_mappings.bin"), bytes)
+}
+
+/// Writes the legacy plain-`Vec` vectors format (pre-generation) directly.
+fn write_legacy_plain_vectors(path: &Path, data: &HnswVectorsData) -> std::io::Result<()> {
+    let bytes = postcard::to_allocvec(&data.vectors).map_err(std::io::Error::other)?;
+    std::fs::write(path.join("native_vectors.bin"), bytes)
+}
+
+/// Returns the `HnswMappingsData` in the same shape `save_sidecars` expects.
+fn mappings_data(mappings: &ShardedMappings, generation: u64) -> HnswMappingsData {
+    let (id_to_idx, idx_to_id, next_idx) = mappings.as_parts();
+    HnswMappingsData {
+        id_to_idx,
+        idx_to_id,
+        next_idx,
+        generation,
+    }
+}
+
+/// Returns the `HnswVectorsData` in the same shape `save_sidecars` expects.
+fn vectors_data(vectors: &ShardedVectors, generation: u64) -> HnswVectorsData {
+    HnswVectorsData {
+        vectors: vectors.collect_for_parallel(),
+        generation,
+    }
+}
+
+// -----------------------------------------------------------------------
+// Test 1 — save_sidecars stamps a monotonically increasing generation
+// -----------------------------------------------------------------------
+
+#[test]
+fn test_save_sidecars_stamps_monotonic_generation() {
+    let dir = TempDir::new().expect("test: temp dir");
+    let path = dir.path();
+    let mappings = build_mappings();
+    let vectors = build_vectors();
+    let meta = build_meta(0);
+
+    save_sidecars(path, &mappings, &vectors, &meta).expect("test: first save");
+    save_sidecars(path, &mappings, &vectors, &meta).expect("test: second save");
+    save_sidecars(path, &mappings, &vectors, &meta).expect("test: third save");
+
+    let loaded_meta = persistence::load_meta(path).expect("test: load meta");
+    assert_eq!(
+        loaded_meta.generation, 3,
+        "meta generation should be bumped once per save"
+    );
+
+    let loaded_mappings = persistence::load_mappings(path).expect("test: load mappings");
+    assert_eq!(
+        loaded_mappings.generation, 3,
+        "mappings generation must match meta"
+    );
+
+    let loaded_vectors = persistence::load_vectors(path).expect("test: load vectors");
+    assert_eq!(
+        loaded_vectors.generation, 3,
+        "vectors generation must match meta"
+    );
+}
+
+// -----------------------------------------------------------------------
+// Test 2 — load_sidecars detects stale mappings
+// -----------------------------------------------------------------------
+
+#[test]
+fn test_load_sidecars_detects_stale_mappings() {
+    let dir = TempDir::new().expect("test: temp dir");
+    let path = dir.path();
+    let mappings = build_mappings();
+    let vectors = build_vectors();
+
+    // Simulate a save at generation 4 (all three files consistent).
+    let meta_4 = build_meta(4);
+    persistence::save_mappings(path, &mappings_data(&mappings, 4)).expect("test: save mappings 4");
+    persistence::save_vectors(path, &vectors_data(&vectors, 4)).expect("test: save vectors 4");
+    persistence::save_meta(path, &meta_4).expect("test: save meta 4");
+
+    // Now simulate a crash at generation 5 that only rewrote mappings.
+    persistence::save_mappings(path, &mappings_data(&mappings, 5)).expect("test: save mappings 5");
+
+    let loaded_meta = persistence::load_meta(path).expect("test: reload meta");
+    let err = load_sidecars(path, &loaded_meta)
+        .expect_err("test: stale mappings must trigger InvalidData");
+    assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+    assert!(
+        err.to_string().contains("mappings generation"),
+        "error should mention mappings generation, got: {err}"
+    );
+}
+
+// -----------------------------------------------------------------------
+// Test 3 — load_sidecars detects stale vectors
+// -----------------------------------------------------------------------
+
+#[test]
+fn test_load_sidecars_detects_stale_vectors() {
+    let dir = TempDir::new().expect("test: temp dir");
+    let path = dir.path();
+    let mappings = build_mappings();
+    let vectors = build_vectors();
+
+    // Consistent state at generation 4.
+    persistence::save_mappings(path, &mappings_data(&mappings, 4)).expect("test: save mappings 4");
+    persistence::save_vectors(path, &vectors_data(&vectors, 4)).expect("test: save vectors 4");
+    persistence::save_meta(path, &build_meta(4)).expect("test: save meta 4");
+
+    // Simulate a crash at generation 5 that only rewrote mappings + meta,
+    // leaving vectors at gen 4.
+    persistence::save_mappings(path, &mappings_data(&mappings, 5)).expect("test: save mappings 5");
+    persistence::save_meta(path, &build_meta(5)).expect("test: save meta 5");
+
+    let loaded_meta = persistence::load_meta(path).expect("test: reload meta");
+    let err = load_sidecars(path, &loaded_meta)
+        .expect_err("test: stale vectors must trigger InvalidData");
+    assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+    assert!(
+        err.to_string().contains("vectors generation"),
+        "error should mention vectors generation, got: {err}"
+    );
+}
+
+// -----------------------------------------------------------------------
+// Test 4 — load_sidecars detects mappings newer than meta
+// -----------------------------------------------------------------------
+
+#[test]
+fn test_load_sidecars_detects_newer_mappings_than_meta() {
+    let dir = TempDir::new().expect("test: temp dir");
+    let path = dir.path();
+    let mappings = build_mappings();
+    let vectors = build_vectors();
+
+    // Meta is older (gen 5) than mappings (gen 10) — `meta` is authoritative.
+    persistence::save_mappings(path, &mappings_data(&mappings, 10))
+        .expect("test: save mappings 10");
+    persistence::save_vectors(path, &vectors_data(&vectors, 5)).expect("test: save vectors 5");
+    persistence::save_meta(path, &build_meta(5)).expect("test: save meta 5");
+
+    let loaded_meta = persistence::load_meta(path).expect("test: reload meta");
+    let err = load_sidecars(path, &loaded_meta)
+        .expect_err("test: newer mappings than meta must trigger InvalidData");
+    assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+    assert!(
+        err.to_string().contains("mappings generation"),
+        "error should mention mappings generation, got: {err}"
+    );
+}
+
+// -----------------------------------------------------------------------
+// Test 5 — backward compat: legacy 4-tuple meta + plain sidecars load
+// -----------------------------------------------------------------------
+
+#[test]
+fn test_backward_compat_legacy_meta_without_generation_loads() {
+    let dir = TempDir::new().expect("test: temp dir");
+    let path = dir.path();
+    let mappings = build_mappings();
+    let vectors = build_vectors();
+
+    // Pretend the database was written by a pre-fix binary: legacy 4-tuple
+    // meta (v1.7.2+ storage mode, no generation), legacy 3-tuple mappings,
+    // plain-Vec vectors.
+    let meta = build_meta(0); // generation ignored by legacy writer
+    write_legacy_4tuple_meta(path, &meta).expect("test: legacy meta");
+    write_legacy_3tuple_mappings(path, &mappings_data(&mappings, 0))
+        .expect("test: legacy mappings");
+    write_legacy_plain_vectors(path, &vectors_data(&vectors, 0)).expect("test: legacy vectors");
+
+    let loaded_meta = persistence::load_meta(path).expect("test: legacy meta loads");
+    assert_eq!(
+        loaded_meta.generation, 0,
+        "legacy meta must default to generation 0"
+    );
+
+    let (_mappings, _vectors, enable_vs) =
+        load_sidecars(path, &loaded_meta).expect("test: legacy sidecars load");
+    assert!(enable_vs, "enable_vector_storage must round-trip from meta");
+}
+
+// -----------------------------------------------------------------------
+// Test 6 — backward compat: pre-v1.7.2 3-tuple meta + legacy sidecars load
+// -----------------------------------------------------------------------
+
+#[test]
+fn test_backward_compat_legacy_3tuple_meta_loads() {
+    let dir = TempDir::new().expect("test: temp dir");
+    let path = dir.path();
+    let mappings = build_mappings();
+    let vectors = build_vectors();
+
+    // Pre-v1.7.2 meta: only (dim, metric, enable_vs) — no storage_mode, no
+    // generation. Paired with legacy 3-tuple mappings + plain vectors.
+    let meta = build_meta(0);
+    write_legacy_3tuple_meta(path, &meta).expect("test: 3-tuple meta");
+    write_legacy_3tuple_mappings(path, &mappings_data(&mappings, 0))
+        .expect("test: legacy mappings");
+    write_legacy_plain_vectors(path, &vectors_data(&vectors, 0)).expect("test: legacy vectors");
+
+    let loaded_meta = persistence::load_meta(path).expect("test: 3-tuple meta loads");
+    assert_eq!(
+        loaded_meta.generation, 0,
+        "3-tuple meta must default to generation 0"
+    );
+    assert_eq!(
+        loaded_meta.storage_mode,
+        StorageMode::Full,
+        "3-tuple meta must default storage_mode to Full"
+    );
+
+    load_sidecars(path, &loaded_meta).expect("test: legacy sidecars load cleanly");
+}
+
+// -----------------------------------------------------------------------
+// Test 7 — existing DB at generation 7 → save → load → generation 8
+// -----------------------------------------------------------------------
+
+#[test]
+fn test_save_then_load_roundtrip_gen_bumped() {
+    let dir = TempDir::new().expect("test: temp dir");
+    let path = dir.path();
+    let mappings = build_mappings();
+    let vectors = build_vectors();
+
+    // Prime the directory with a consistent state at generation 7.
+    persistence::save_mappings(path, &mappings_data(&mappings, 7)).expect("test: seed mappings");
+    persistence::save_vectors(path, &vectors_data(&vectors, 7)).expect("test: seed vectors");
+    persistence::save_meta(path, &build_meta(7)).expect("test: seed meta");
+
+    // `save_sidecars` must read the current on-disk generation and bump
+    // to 8, regardless of what the caller put in the `HnswMeta` struct.
+    let meta_in = build_meta(0); // caller-provided generation ignored
+    save_sidecars(path, &mappings, &vectors, &meta_in).expect("test: save bumps gen");
+
+    let loaded_meta = persistence::load_meta(path).expect("test: reload meta");
+    assert_eq!(
+        loaded_meta.generation, 8,
+        "save_sidecars must bump to next generation"
+    );
+}
+
+// -----------------------------------------------------------------------
+// Test 8 — fresh directory: first save starts at generation 1
+// -----------------------------------------------------------------------
+
+#[test]
+fn test_save_when_no_prior_state_starts_at_gen_1() {
+    let dir = TempDir::new().expect("test: temp dir");
+    let path = dir.path();
+    let mappings = build_mappings();
+    let vectors = build_vectors();
+
+    // Fresh directory, no prior meta. Caller passes generation=0 (ignored).
+    let meta_in = build_meta(0);
+    save_sidecars(path, &mappings, &vectors, &meta_in).expect("test: first save");
+
+    let loaded_meta = persistence::load_meta(path).expect("test: reload meta");
+    assert_eq!(
+        loaded_meta.generation, 1,
+        "first save on a fresh directory must land at generation 1"
+    );
+}

--- a/crates/velesdb-core/src/index/hnsw/persistence_atomicity_tests.rs
+++ b/crates/velesdb-core/src/index/hnsw/persistence_atomicity_tests.rs
@@ -150,7 +150,7 @@ fn test_save_sidecars_stamps_monotonic_generation() {
         &mappings,
         &vectors,
         &meta,
-        persistence::next_generation(path),
+        persistence::next_generation(path).expect("test: next_generation"),
     )
     .expect("test: first save");
     save_sidecars(
@@ -158,7 +158,7 @@ fn test_save_sidecars_stamps_monotonic_generation() {
         &mappings,
         &vectors,
         &meta,
-        persistence::next_generation(path),
+        persistence::next_generation(path).expect("test: next_generation"),
     )
     .expect("test: second save");
     save_sidecars(
@@ -166,7 +166,7 @@ fn test_save_sidecars_stamps_monotonic_generation() {
         &mappings,
         &vectors,
         &meta,
-        persistence::next_generation(path),
+        persistence::next_generation(path).expect("test: next_generation"),
     )
     .expect("test: third save");
 
@@ -366,7 +366,7 @@ fn test_save_then_load_roundtrip_gen_bumped() {
     // Callers are expected to compute `next_generation(path)` and pass it
     // explicitly; this must read the current on-disk generation and bump to 8.
     let meta_in = build_meta(0); // caller-provided generation ignored
-    let new_gen = persistence::next_generation(path);
+    let new_gen = persistence::next_generation(path).expect("test: next_generation");
     assert_eq!(new_gen, 8, "next_generation must bump from 7 to 8");
     save_sidecars(path, &mappings, &vectors, &meta_in, new_gen).expect("test: save bumps gen");
 
@@ -390,7 +390,7 @@ fn test_save_when_no_prior_state_starts_at_gen_1() {
 
     // Fresh directory, no prior meta. Caller passes generation=0 (ignored).
     let meta_in = build_meta(0);
-    let new_gen = persistence::next_generation(path);
+    let new_gen = persistence::next_generation(path).expect("test: next_generation");
     assert_eq!(
         new_gen, 1,
         "next_generation on a fresh directory must return 1"
@@ -475,4 +475,35 @@ fn test_save_graph_generation_roundtrip() {
     persistence::save_graph_generation(path, 9999).expect("test: overwrite marker");
     let observed = persistence::load_graph_generation(path).expect("test: reload marker 2");
     assert_eq!(observed, 9999, "overwritten marker must round-trip");
+}
+
+// -----------------------------------------------------------------------
+// Test 12 (Devin follow-up #2) — corrupted meta must abort next save,
+// not silently reset generation to 1
+// -----------------------------------------------------------------------
+
+#[test]
+fn test_next_generation_propagates_corrupted_meta_error() {
+    let dir = TempDir::new().expect("test: temp dir");
+    let path = dir.path();
+
+    // Write garbage bytes that postcard cannot parse as any of the 3/4/5
+    // tuple shapes accepted by `load_meta`.
+    std::fs::write(path.join("native_meta.bin"), [0xFF_u8; 32]).expect("test: seed corrupted meta");
+
+    let result = persistence::next_generation(path);
+    assert!(
+        result.is_err(),
+        "corrupted meta must propagate, not silently reset to gen 1 (got {result:?})"
+    );
+
+    // Missing meta (fresh directory) must NOT be an error — it is the
+    // legitimate "start at generation 1" case.
+    let fresh = TempDir::new().expect("test: fresh dir");
+    let gen =
+        persistence::next_generation(fresh.path()).expect("test: missing meta is not an error");
+    assert_eq!(
+        gen, 1,
+        "missing meta must yield generation 1, not propagate NotFound"
+    );
 }


### PR DESCRIPTION
## Summary

Fixes issue [#617](https://github.com/cyberlife-coder/VelesDB/issues/617) — HIGH risk persistence atomicity bug surfaced by Devin post-merge review of PR #615.

`save_sidecars` écrivait 3 fichiers séquentiellement (`native_mappings.bin` → `native_vectors.bin` → `native_meta.bin`). Chacun atomique individuellement, **mais la séquence globale ne l'était pas** → crash entre 2 renames = état disque incohérent silencieusement chargé.

Fix : **generation counter stampé dans les 3 fichiers**, `meta` (écrit en dernier) = authoritative source, `load_sidecars` vérifie consistance → `io::Error::InvalidData` si mismatch. Backward-compat complète : legacy DBs (pre-fix) loadent avec `generation=0` partout, consistency check passe trivialement.

## Commits atomiques (3)

| # | SHA | Scope |
|---|---|---|
| 1 | `5939f48c` | `test(hnsw/persistence): TDD crash-simulation tests for save_sidecars atomicity (#617 TDD)` — 8 tests RED anchor |
| 2 | `04d16c2c` | `fix(hnsw/persistence): add generation counter with backward-compat deserialization (#617 schema)` |
| 3 | `1d29f672` | `fix(hnsw/persistence): write generation-stamped sidecars atomically and verify on load (#617 logic)` |

## TDD (8/8 PASS)

Tests dans `crates/velesdb-core/src/index/hnsw/persistence_atomicity_tests.rs` :

1. `test_save_sidecars_stamps_monotonic_generation` — 3 saves → gen=3 sur les 3 fichiers
2. `test_load_sidecars_detects_stale_mappings` — crash-sim : mappings=5, vectors/meta=4 → `InvalidData`
3. `test_load_sidecars_detects_stale_vectors` — crash-sim : vectors stale → `InvalidData`
4. `test_load_sidecars_detects_newer_mappings_than_meta` — mappings=10, meta=5 → `InvalidData`
5. `test_backward_compat_legacy_meta_without_generation_loads` — 4-tuple legacy → OK avec gen=0
6. `test_backward_compat_legacy_3tuple_meta_loads` — 3-tuple pre-v1.7.2 → OK, storage=Full default
7. `test_save_then_load_roundtrip_gen_bumped` — gen=7 → save → gen=8
8. `test_save_when_no_prior_state_starts_at_gen_1` — fresh dir → gen=1

## Schema changes (backward-compat)

| File | Before | After |
|---|---|---|
| `native_meta.bin` | 4-tuple `(dim, metric, enable_vs, storage_mode)` | 5-tuple + `generation` |
| `native_mappings.bin` | 3-tuple `(id_to_idx, idx_to_id, next_idx)` | 4-tuple + `generation` |
| `native_vectors.bin` | `Vec<(usize, Vec<f32>)>` | 2-tuple `(Vec, generation)` |

Les `load_*` tentent le nouveau format d'abord, fallback sur l'ancien avec `generation=0`. Aucune DB existante ne casse.

## Gates locaux — tous PASS ✅

- [x] `cargo fmt --all --check` — clean
- [x] `cargo check -p velesdb-core --no-default-features` — OK
- [x] `cargo check -p velesdb-wasm --no-default-features --target wasm32-unknown-unknown` — OK
- [x] `cargo clippy -p velesdb-core --features persistence --all-targets -- -D warnings -D clippy::pedantic` — 0 warnings
- [x] `cargo test --features persistence` full suite — 0 régressions
- [x] **`persistence_atomicity_tests` — 8/8 PASS**
- [x] **`recall_validation` — 7/7 PASS** (non-négociable)
- [x] `hnsw_dedup_parity_tests` — 7/7 PASS (regression lock Phase 3.2)
- [x] **Local perf gate — exit 0 PASS** (machine stable)
- [x] Codacy WSL — 0 findings sur fichiers modifiés (opengrep + lizard clean)
- [x] CC ≤ 8 / NLOC ≤ 50 sur toutes les fonctions modifiées

## Design rationale (alternatives écartées)

- ❌ **Separate `sidecars.manifest.json` with SHA-256** — extra I/O on load, new file to version, no backward-compat pattern match.
- ❌ **Double-write meta (in-progress/committed)** — doubles meta I/O, no advantage over generation counter.
- ❌ **Do nothing, document, wait for real crash** — HIGH risk severity justifies fix now.

Le pattern retenu (generation counter + tuple widening) réutilise le pattern backward-compat déjà présent pour `HnswMeta` (3→4 tuple v1.7.2), extension naturelle.

## Impact matrix

Fix 100 % interne (`pub(crate)` helpers + postcard schema privé). Aucune API publique modifiée.

| Component | Status |
|---|---|
| velesdb-core | ✅ MODIFIED (persistence.rs schema + logic, 1 test file nouveau, 2 call sites avec champ placeholder) |
| velesdb-server / -python / -wasm / -mobile / -cli / -migrate / tauri-plugin | ❌ NONE (signature `save_sidecars`/`load_sidecars` inchangée) |
| TypeScript SDK / docs / README / promise-contract.json | ❌ NONE |

**REQUIRED items completed: 1/1 (100 %)**

## Test plan

- [x] `cargo test --features persistence --lib persistence_atomicity` → 8/8 PASS
- [x] `cargo test --features persistence --test recall_validation` → 7/7 PASS
- [x] `cargo test --features persistence --test hnsw_dedup_parity_tests` → 7/7 PASS
- [x] Perf gate local exit 0
- [ ] CI verte (Linux / Windows / WASM / no-default-features / conformance / Codacy Cloud / Devin / perf-smoke)
- [ ] **Manual IRL backward compat** : charger une DB produite par develop pré-fix → doit loader sans erreur

Closes #617.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/618" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
