### PR TITLE
feat(bm25): snapshot + WAL persistence — O(N) → O(1) cold-start (closes #389)

### DIFF
--- a/crates/velesdb-core/src/collection/core/bulk_import.rs
+++ b/crates/velesdb-core/src/collection/core/bulk_import.rs
@@ -93,31 +93,45 @@ impl Collection {
         let inserted = self.bulk_index_or_defer(vector_refs);
         self.config.write().point_count = self.vector_storage.read().len();
 
-        // Incremental histogram maintenance: decrement old values, increment new.
-        // Bug #47: only the last occurrence per ID is counted for new payloads
-        // to match last-writer-wins storage semantics.
-        if let Some(ps) = payloads {
-            let mut dedup_map: HashMap<u64, usize> = HashMap::with_capacity(ids.len());
-            for (i, &id) in ids.iter().enumerate() {
-                dedup_map.insert(id, i);
-            }
-            let owned: Vec<Option<serde_json::Value>> = ps
-                .iter()
-                .enumerate()
-                .map(|(i, opt)| {
-                    if dedup_map.get(&ids[i]) == Some(&i) {
-                        opt.clone()
-                    } else {
-                        None
-                    }
-                })
-                .collect();
-            self.update_histograms_replace(&old_payloads, &owned);
-        }
+        self.maintain_histograms_for_raw(ids, payloads, &old_payloads);
 
         self.invalidate_caches_and_bump_generation();
 
         Ok(inserted)
+    }
+
+    /// Incremental histogram maintenance for a raw-slices bulk upsert.
+    ///
+    /// Decrements old values and increments new values in a single atomic
+    /// read/modify/write cycle (Bug #49). Bug #47: only the last occurrence
+    /// per ID is counted for new payloads to match last-writer-wins storage
+    /// semantics.
+    ///
+    /// Extracted from `upsert_bulk_from_raw` to keep its CC under the
+    /// Codacy limit after adding the BM25 WAL propagation (#389).
+    fn maintain_histograms_for_raw(
+        &self,
+        ids: &[u64],
+        payloads: Option<&[Option<serde_json::Value>]>,
+        old_payloads: &[Option<serde_json::Value>],
+    ) {
+        let Some(ps) = payloads else { return };
+        let mut dedup_map: HashMap<u64, usize> = HashMap::with_capacity(ids.len());
+        for (i, &id) in ids.iter().enumerate() {
+            dedup_map.insert(id, i);
+        }
+        let owned: Vec<Option<serde_json::Value>> = ps
+            .iter()
+            .enumerate()
+            .map(|(i, opt)| {
+                if dedup_map.get(&ids[i]) == Some(&i) {
+                    opt.clone()
+                } else {
+                    None
+                }
+            })
+            .collect();
+        self.update_histograms_replace(old_payloads, &owned);
     }
 
     /// Validates raw bulk-insert inputs before any state mutation.

--- a/crates/velesdb-core/src/collection/core/bulk_import.rs
+++ b/crates/velesdb-core/src/collection/core/bulk_import.rs
@@ -86,7 +86,7 @@ impl Collection {
 
         self.store_vectors_and_payload_entries(&vector_refs, &payload_entries)?;
 
-        self.update_text_index_from_raw(ids, payloads);
+        self.update_text_index_from_raw(ids, payloads)?;
         self.update_label_index_from_raw(ids, payloads);
         self.update_secondary_indexes_from_raw(ids, payloads);
 
@@ -242,27 +242,38 @@ impl Collection {
         }
     }
 
-    /// Updates BM25 text index from raw payload slices.
+    /// Updates BM25 text index from raw payload slices (WAL-then-apply).
     ///
-    /// Points with `Some(payload)` get their text indexed.
-    /// Points with `None` payload get their stale BM25 entry removed
-    /// (consistent with `update_text_index` in `crud.rs`).
+    /// Points with `Some(payload)` get their text indexed; points with
+    /// `None` payload get their stale BM25 entry removed. Mirrors the
+    /// contract of `update_text_index` in `crud.rs`.
+    ///
+    /// Issue #389: each mutation is appended to the BM25 WAL BEFORE it
+    /// is applied in-memory so that a crash between the two replays
+    /// the mutation on next open. WAL append errors propagate and the
+    /// in-memory mutation is skipped, so in-memory and WAL state never
+    /// diverge.
     fn update_text_index_from_raw(
         &self,
         ids: &[u64],
         payloads: Option<&[Option<serde_json::Value>]>,
-    ) {
-        let Some(ps) = payloads else { return };
+    ) -> Result<()> {
+        let Some(ps) = payloads else { return Ok(()) };
         for (i, opt) in ps.iter().enumerate() {
             if let Some(payload) = opt {
                 let text = Self::extract_text_from_payload(payload);
                 if !text.is_empty() {
+                    #[cfg(feature = "persistence")]
+                    self.append_bm25_wal_add(ids[i], &text)?;
                     self.text_index.add_document(ids[i], &text);
                 }
             } else {
+                #[cfg(feature = "persistence")]
+                self.append_bm25_wal_remove(ids[i])?;
                 self.text_index.remove_document(ids[i]);
             }
         }
+        Ok(())
     }
 
     /// Batch-updates the label index from raw payload slices.

--- a/crates/velesdb-core/src/collection/core/crud.rs
+++ b/crates/velesdb-core/src/collection/core/crud.rs
@@ -86,7 +86,7 @@ impl Collection {
         let old_payloads = self.batch_store_all(points)?;
 
         // Phase 2: Per-point updates (no storage locks held)
-        let sparse_batch = self.per_point_updates(points, &old_payloads, storage_mode);
+        let sparse_batch = self.per_point_updates(points, &old_payloads, storage_mode)?;
 
         // Phase 3: Batch HNSW insert
         let vector_refs: Vec<(u64, &[f32])> =
@@ -318,12 +318,12 @@ impl Collection {
         points: &[Point],
         old_payloads: &[Option<serde_json::Value>],
         storage_mode: StorageMode,
-    ) -> Vec<(u64, BTreeMap<String, crate::index::sparse::SparseVector>)> {
+    ) -> Result<Vec<(u64, BTreeMap<String, crate::index::sparse::SparseVector>)>> {
         // Issue #425: Fast-path — skip Phase 2 entirely when no secondary
         // processing is needed. Avoids lock acquisition, HashMap allocation,
         // and the per-point loop for the common StorageMode::Full case.
         if self.can_skip_phase2(points, storage_mode) {
-            return Vec::new();
+            return Ok(Vec::new());
         }
 
         // Issue #486: Parallel quantization for SQ8/Binary — compute all
@@ -358,7 +358,7 @@ impl Collection {
         storage_mode: StorageMode,
         quant_guards: &mut QuantizationGuards<'_>,
         quant_done: bool,
-    ) -> Vec<(u64, BTreeMap<String, crate::index::sparse::SparseVector>)> {
+    ) -> Result<Vec<(u64, BTreeMap<String, crate::index::sparse::SparseVector>)>> {
         let mut sparse_batch = Vec::new();
         let mut seen_payloads: HashMap<u64, Option<&serde_json::Value>> = HashMap::new();
         let skip_bm25 = self.text_index.is_empty() && !points.iter().any(|p| p.payload.is_some());
@@ -375,7 +375,9 @@ impl Collection {
                 point.payload.as_ref(),
             );
             if !skip_bm25 {
-                Self::update_text_index(&self.text_index, point);
+                // Issue #389: WAL-before-apply — failure propagates so
+                // in-memory BM25 and on-disk WAL never diverge.
+                self.update_text_index(point)?;
             }
             Self::collect_sparse_vectors(point, &mut sparse_batch);
             if needs_label_updates {
@@ -385,7 +387,7 @@ impl Collection {
         }
 
         Self::apply_label_updates(&self.label_index, &label_updates);
-        sparse_batch
+        Ok(sparse_batch)
     }
 
     /// Inserts or updates metadata-only points (no vectors).
@@ -416,7 +418,7 @@ impl Collection {
             } else {
                 let _ = payload_storage.delete(point.id);
             }
-            Self::update_text_index(&self.text_index, point);
+            self.update_text_index(point)?;
             self.update_secondary_indexes_on_upsert(
                 point.id,
                 old_payload.as_ref(),

--- a/crates/velesdb-core/src/collection/core/crud_bulk.rs
+++ b/crates/velesdb-core/src/collection/core/crud_bulk.rs
@@ -289,7 +289,7 @@ impl Collection {
         // body would be a no-op for every point.
         if !entries.is_empty() || !self.text_index.is_empty() {
             for point in points {
-                Self::update_text_index(&self.text_index, point);
+                self.update_text_index(point)?;
             }
         }
 

--- a/crates/velesdb-core/src/collection/core/crud_indexing.rs
+++ b/crates/velesdb-core/src/collection/core/crud_indexing.rs
@@ -135,16 +135,47 @@ impl Collection {
         }
     }
 
-    /// Updates the BM25 text index for a single point.
-    pub(super) fn update_text_index(text_index: &crate::index::Bm25Index, point: &Point) {
+    /// Updates the BM25 text index for a single point (WAL-then-apply).
+    ///
+    /// Issue #389: appends the mutation to `bm25.wal` BEFORE calling
+    /// `add_document` / `remove_document` on the in-memory index so
+    /// that a crash between the two replays the mutation on next
+    /// open. WAL append errors propagate; the in-memory mutation is
+    /// skipped so in-memory and WAL state never diverge.
+    pub(super) fn update_text_index(&self, point: &Point) -> Result<()> {
         if let Some(payload) = &point.payload {
             let text = Self::extract_text_from_payload(payload);
             if !text.is_empty() {
-                text_index.add_document(point.id, &text);
+                #[cfg(feature = "persistence")]
+                self.append_bm25_wal_add(point.id, &text)?;
+                self.text_index.add_document(point.id, &text);
             }
         } else {
-            text_index.remove_document(point.id);
+            #[cfg(feature = "persistence")]
+            self.append_bm25_wal_remove(point.id)?;
+            self.text_index.remove_document(point.id);
         }
+        Ok(())
+    }
+
+    /// Appends an `add_document` mutation to the BM25 WAL.
+    ///
+    /// Feature-gated — non-persistence builds have no on-disk WAL.
+    /// Callers already gate on `feature = "persistence"` when they
+    /// need crash-safety ordering.
+    #[cfg(feature = "persistence")]
+    #[inline]
+    pub(super) fn append_bm25_wal_add(&self, id: u64, text: &str) -> Result<()> {
+        let wal_path = crate::index::bm25_persistence_wal::wal_path_for_bm25(&self.path);
+        crate::index::bm25_persistence_wal::wal_append_add_document(&wal_path, id, text)
+    }
+
+    /// Appends a `remove_document` mutation to the BM25 WAL.
+    #[cfg(feature = "persistence")]
+    #[inline]
+    pub(super) fn append_bm25_wal_remove(&self, id: u64) -> Result<()> {
+        let wal_path = crate::index::bm25_persistence_wal::wal_path_for_bm25(&self.path);
+        crate::index::bm25_persistence_wal::wal_append_remove_document(&wal_path, id)
     }
 
     /// Appends `(name, point_id, sparse_vector)` triples to the per-index

--- a/crates/velesdb-core/src/collection/core/crud_read_delete.rs
+++ b/crates/velesdb-core/src/collection/core/crud_read_delete.rs
@@ -89,6 +89,10 @@ impl Collection {
         for &id in ids {
             let old_payload = payload_storage.retrieve(id).ok().flatten();
             payload_storage.delete(id)?;
+            // Issue #389: WAL-before-apply for BM25 removes so crash
+            // recovery replays the remove.
+            #[cfg(feature = "persistence")]
+            self.append_bm25_wal_remove(id)?;
             self.text_index.remove_document(id);
             self.update_secondary_indexes_on_delete(id, old_payload.as_ref());
             if let Some(ref old) = old_payload {
@@ -128,6 +132,10 @@ impl Collection {
             sq8_cache.remove(&id);
             binary_cache.remove(&id);
             pq_cache.remove(&id);
+            // Issue #389: WAL-before-apply for BM25 removes so crash
+            // recovery replays the remove.
+            #[cfg(feature = "persistence")]
+            self.append_bm25_wal_remove(id)?;
             self.text_index.remove_document(id);
             self.update_secondary_indexes_on_delete(id, old_payload.as_ref());
             if let Some(ref old) = old_payload {

--- a/crates/velesdb-core/src/collection/core/flush.rs
+++ b/crates/velesdb-core/src/collection/core/flush.rs
@@ -63,6 +63,18 @@ impl Collection {
     ///
     /// Returns an error if storage operations fail.
     pub fn flush_full(&self) -> Result<()> {
+        self.flush_core_storage()?;
+        self.flush_derived_indexes()?;
+        // Write the deferred vectors.idx AFTER all other flush steps.
+        self.vector_storage.read().flush_index()?;
+        Ok(())
+    }
+
+    /// Flushes config + vector/payload storage + drains + HNSW save.
+    ///
+    /// Extracted from `flush_full` to keep its CC under the Codacy limit
+    /// after adding the BM25 snapshot/WAL step (#389).
+    fn flush_core_storage(&self) -> Result<()> {
         self.save_config()?;
         self.vector_storage.write().flush()?;
         self.payload_storage.write().flush()?;
@@ -73,15 +85,17 @@ impl Collection {
         self.index.save(&self.path)?;
         self.inserts_since_last_hnsw_save
             .store(0, std::sync::atomic::Ordering::Relaxed);
+        Ok(())
+    }
+
+    /// Persists all derived indexes (secondary, sparse, BM25) in order.
+    ///
+    /// BM25 (issue #389) is ordered AFTER sparse so the collection-level
+    /// flush semantics remain "durable → truncate WAL" uniformly for both.
+    fn flush_derived_indexes(&self) -> Result<()> {
         self.flush_secondary_indexes()?;
         self.flush_sparse_indexes()?;
-        // Issue #389: persist BM25 index as a snapshot + truncate WAL.
-        // Ordered AFTER sparse indexes so the collection-level flush
-        // semantics remain "durable → truncate WAL" for both BM25 and
-        // sparse.
         self.flush_bm25_index()?;
-        // Write the deferred vectors.idx after all other flush steps.
-        self.vector_storage.read().flush_index()?;
         Ok(())
     }
 

--- a/crates/velesdb-core/src/collection/core/flush.rs
+++ b/crates/velesdb-core/src/collection/core/flush.rs
@@ -75,8 +75,29 @@ impl Collection {
             .store(0, std::sync::atomic::Ordering::Relaxed);
         self.flush_secondary_indexes()?;
         self.flush_sparse_indexes()?;
+        // Issue #389: persist BM25 index as a snapshot + truncate WAL.
+        // Ordered AFTER sparse indexes so the collection-level flush
+        // semantics remain "durable → truncate WAL" for both BM25 and
+        // sparse.
+        self.flush_bm25_index()?;
         // Write the deferred vectors.idx after all other flush steps.
         self.vector_storage.read().flush_index()?;
+        Ok(())
+    }
+
+    /// Persists the BM25 index as an atomic snapshot and truncates its
+    /// WAL on success (issue #389).
+    ///
+    /// Skipped entirely when the index is empty: no snapshot file is
+    /// created, so a pre-existing (non-BM25) collection reopened by
+    /// newer code does not gain a spurious empty snapshot.
+    fn flush_bm25_index(&self) -> Result<()> {
+        if self.text_index.is_empty() {
+            return Ok(());
+        }
+        crate::index::bm25_persistence::save_snapshot(&self.path, &self.text_index)?;
+        let wal_path = crate::index::bm25_persistence_wal::wal_path_for_bm25(&self.path);
+        crate::index::bm25_persistence_wal::wal_truncate(&wal_path)?;
         Ok(())
     }
 

--- a/crates/velesdb-core/src/collection/core/lifecycle.rs
+++ b/crates/velesdb-core/src/collection/core/lifecycle.rs
@@ -1,19 +1,17 @@
 //! Collection lifecycle methods (create, open, flush).
 
+use crate::collection::graph::property_index::{
+    CompositeIndexManager, IndexAdvisor, QueryPatternTracker,
+};
 use crate::collection::graph::{ConcurrentEdgeStore, LabelIndex, PropertyIndex, RangeIndex};
 use crate::collection::types::{Collection, CollectionConfig};
 use crate::error::Result;
 use crate::guardrails::GuardRails;
+use crate::index::sparse::SparseInvertedIndex;
 use crate::index::{Bm25Index, HnswIndex};
 use crate::sparse_index::DEFAULT_SPARSE_INDEX_NAME;
 use crate::storage::{LogPayloadStorage, MmapStorage, PayloadStorage};
 use crate::velesql::{QueryCache, QueryPlanner};
-
-use crate::index::sparse::SparseInvertedIndex;
-
-use crate::collection::graph::property_index::{
-    CompositeIndexManager, IndexAdvisor, QueryPatternTracker,
-};
 
 use std::collections::{BTreeMap, HashMap, VecDeque};
 
@@ -203,6 +201,43 @@ impl Collection {
         }
     }
 
+    /// Loads the BM25 index from its snapshot + WAL if present, falling
+    /// back to the payload-scan rebuild otherwise.
+    ///
+    /// Issue #389: O(N) cold-start rebuild → O(1) snapshot load + O(WAL
+    /// delta) replay.
+    ///
+    /// # Contract
+    ///
+    /// - Snapshot present → load + replay WAL on top.
+    /// - Snapshot absent → fall back to the legacy payload rebuild
+    ///   (backward-compat for DBs written before this feature).
+    /// - Snapshot corrupt → propagate the error (fail-fast, per #618
+    ///   learning: silent fallback masks data loss).
+    fn load_bm25_index(
+        path: &std::path::Path,
+        payload_storage: &Arc<RwLock<LogPayloadStorage>>,
+    ) -> Result<Arc<Bm25Index>> {
+        if let Some(loaded) = crate::index::bm25_persistence::load_snapshot(path)? {
+            let index = Arc::new(loaded);
+            let wal_path = crate::index::bm25_persistence_wal::wal_path_for_bm25(path);
+            let replayed = crate::index::bm25_persistence_wal::wal_replay(&wal_path, &index)?;
+            tracing::debug!(
+                "BM25 restored from snapshot + {replayed} WAL entries ({} docs)",
+                index.len()
+            );
+            Ok(index)
+        } else {
+            let index = Arc::new(Bm25Index::new());
+            Self::rebuild_bm25_index(payload_storage, &index);
+            tracing::debug!(
+                "BM25 snapshot absent; rebuilt from payload storage ({} docs)",
+                index.len()
+            );
+            Ok(index)
+        }
+    }
+
     // Create constructors are in lifecycle_create.rs
 
     /// Returns true if this is a metadata-only collection.
@@ -240,9 +275,9 @@ impl Collection {
         let vector_storage = Arc::new(RwLock::new(MmapStorage::new(&path, config.dimension)?));
         let payload_storage = Arc::new(RwLock::new(LogPayloadStorage::new(&path)?));
         let index = Self::load_or_create_hnsw(&path, &config)?;
-        let text_index = Arc::new(Bm25Index::new());
-
-        Self::rebuild_bm25_index(&payload_storage, &text_index);
+        // Issue #389: try snapshot + WAL first, fall back to payload
+        // rebuild if no snapshot exists (backward-compat).
+        let text_index = Self::load_bm25_index(&path, &payload_storage)?;
 
         let property_index = Self::load_property_index(&path);
         let label_index = Self::rebuild_label_index(&payload_storage);

--- a/crates/velesdb-core/src/index/bm25.rs
+++ b/crates/velesdb-core/src/index/bm25.rs
@@ -74,7 +74,6 @@ pub(crate) struct Document {
 /// rebuilt from `documents` + `point_to_doc` on
 /// [`Bm25Index::from_snapshot`], which keeps the wire format compact
 /// and avoids adding `Serialize` to the adaptive `PostingList` enum.
-#[allow(dead_code)] // TODO(US-389): commit 4 wires this into Collection::flush.
 #[derive(Debug, Serialize, Deserialize)]
 pub(crate) struct Bm25Snapshot {
     /// Schema version for forward-compat (bump on breaking changes).
@@ -475,7 +474,6 @@ impl Default for Bm25Index {
 // Snapshot serialization (for `bm25_persistence` module)
 // ---------------------------------------------------------------------------
 
-#[allow(dead_code)] // TODO(US-389): commit 4 wires these into Collection::flush.
 impl Bm25Index {
     /// Captures the current index state as a [`Bm25Snapshot`].
     ///

--- a/crates/velesdb-core/src/index/bm25.rs
+++ b/crates/velesdb-core/src/index/bm25.rs
@@ -479,34 +479,98 @@ impl Default for Bm25Index {
 impl Bm25Index {
     /// Captures the current index state as a [`Bm25Snapshot`].
     ///
-    /// STUB — returns an empty/default snapshot. The real implementation
-    /// lands in commit 2; this stub exists so the TDD tests (commit 1)
-    /// compile while still failing at runtime.
+    /// Takes a snapshot under read locks — callers that need a
+    /// coherent picture across mutations must serialise writes
+    /// externally (the intended caller is `Collection::flush_full`,
+    /// which already holds the collection-level write lock when it
+    /// snapshots the BM25 index).
+    ///
+    /// ## Wire format
+    ///
+    /// Only the primary state (documents, mapping tables, counters)
+    /// is serialised. The `inverted_index` is rebuilt from
+    /// `documents` on [`Self::from_snapshot`]. This keeps the wire
+    /// format compact and avoids adding `Serialize` to the adaptive
+    /// `PostingList` enum (which would fix its internal representation
+    /// and block future tuning).
     #[must_use]
     pub(crate) fn to_snapshot(&self) -> Bm25Snapshot {
-        // TODO(US-389): commit 2 will read the actual internal state.
+        // Lock acquisition order (stable across to_snapshot / load paths):
+        //   documents → point_to_doc → doc_to_point → free_doc_ids
+        //   → next_doc_id → doc_count → total_doc_length.
+        // Holding multiple read locks simultaneously is safe: parking_lot
+        // RwLock reads never block each other, and no code path takes a
+        // write lock *after* a read lock on a lower-positioned field.
+        let documents = self.documents.read();
+        let point_to_doc = self.point_to_doc.read();
+        let doc_to_point = self.doc_to_point.read();
+        let free_doc_ids = self.free_doc_ids.read();
+        let next_doc_id = *self.next_doc_id.read();
+        let doc_count = *self.doc_count.read();
+        let total_doc_length = *self.total_doc_length.read();
         Bm25Snapshot {
             version: BM25_SNAPSHOT_VERSION,
             params: self.params,
-            documents: FxHashMap::default(),
-            point_to_doc: FxHashMap::default(),
-            doc_to_point: FxHashMap::default(),
-            free_doc_ids: Vec::new(),
-            next_doc_id: 0,
-            doc_count: 0,
-            total_doc_length: 0,
+            documents: documents.clone(),
+            point_to_doc: point_to_doc.clone(),
+            doc_to_point: doc_to_point.clone(),
+            free_doc_ids: free_doc_ids.clone(),
+            next_doc_id,
+            doc_count,
+            total_doc_length,
         }
     }
 
     /// Rebuilds an index from a [`Bm25Snapshot`].
     ///
-    /// STUB — ignores the snapshot contents and returns an empty index.
-    /// The real implementation lands in commit 2.
+    /// The inverted index is reconstructed from `snapshot.documents`
+    /// and `snapshot.point_to_doc` — iterating each document's
+    /// `term_freqs` keys and inserting the internal doc-id into the
+    /// corresponding posting list. This mirrors exactly what
+    /// `add_document` does for the inverted-index update, so the
+    /// rebuilt postings are bitwise-identical to the original for
+    /// any fixed insertion order.
+    ///
+    /// # Errors
+    ///
+    /// Silently skips documents missing from `point_to_doc`. Such a
+    /// mismatch would indicate a corrupt snapshot and is logged
+    /// rather than raised, matching the existing BM25
+    /// `remove_document_internal` tolerance for unknown ids.
     #[must_use]
-    #[allow(clippy::needless_pass_by_value)] // TODO(US-389): commit 2 consumes `snapshot`
     pub(crate) fn from_snapshot(snapshot: Bm25Snapshot) -> Self {
-        // TODO(US-389): commit 2 will restore the full state.
-        let _ = snapshot;
-        Self::new()
+        let index = Self::with_params(snapshot.params);
+
+        // Rebuild inverted index from `documents` + `point_to_doc`.
+        // We use a single write-lock scope on `inverted_index` for
+        // efficiency — there is no other reader during construction.
+        {
+            let mut inv_idx = index.inverted_index.write();
+            for (point_id, doc) in &snapshot.documents {
+                let Some(&doc_id_u32) = snapshot.point_to_doc.get(point_id) else {
+                    tracing::warn!(
+                        "BM25 snapshot: document for point_id {point_id} missing from point_to_doc — skipping inverted-index reconstruction for this doc"
+                    );
+                    continue;
+                };
+                for term in doc.term_freqs.keys() {
+                    inv_idx
+                        .entry(term.clone())
+                        .or_insert_with(PostingList::new)
+                        .insert(doc_id_u32);
+                }
+            }
+        }
+
+        // Install primary state under the same lock order as to_snapshot.
+        *index.documents.write() = snapshot.documents;
+        *index.point_to_doc.write() = snapshot.point_to_doc;
+        *index.doc_to_point.write() = snapshot.doc_to_point;
+        *index.free_doc_ids.write() = snapshot.free_doc_ids;
+        *index.next_doc_id.write() = snapshot.next_doc_id;
+        *index.doc_count.write() = snapshot.doc_count;
+        *index.total_doc_length.write() = snapshot.total_doc_length;
+
+        index
     }
 }

--- a/crates/velesdb-core/src/index/bm25.rs
+++ b/crates/velesdb-core/src/index/bm25.rs
@@ -41,9 +41,10 @@
 use super::posting_list::PostingList;
 use parking_lot::RwLock;
 use rustc_hash::FxHashMap;
+use serde::{Deserialize, Serialize};
 
 /// BM25 tuning parameters.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 pub struct Bm25Params {
     /// Term frequency saturation parameter (default: 1.2)
     pub k1: f32,
@@ -58,13 +59,38 @@ impl Default for Bm25Params {
 }
 
 /// A document stored in the BM25 index.
-#[derive(Debug, Clone)]
-struct Document {
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct Document {
     /// Term frequencies in this document
-    term_freqs: FxHashMap<String, u32>,
+    pub(crate) term_freqs: FxHashMap<String, u32>,
     /// Total number of terms in the document
-    length: u32,
+    pub(crate) length: u32,
 }
+
+/// Serializable full-state snapshot of a [`Bm25Index`].
+///
+/// Captures the in-memory state in a form that round-trips through
+/// postcard. The `inverted_index` is not stored explicitly — it is
+/// rebuilt from `documents` + `point_to_doc` on
+/// [`Bm25Index::from_snapshot`], which keeps the wire format compact
+/// and avoids adding `Serialize` to the adaptive `PostingList` enum.
+#[allow(dead_code)] // TODO(US-389): commit 4 wires this into Collection::flush.
+#[derive(Debug, Serialize, Deserialize)]
+pub(crate) struct Bm25Snapshot {
+    /// Schema version for forward-compat (bump on breaking changes).
+    pub(crate) version: u32,
+    pub(crate) params: Bm25Params,
+    pub(crate) documents: FxHashMap<u64, Document>,
+    pub(crate) point_to_doc: FxHashMap<u64, u32>,
+    pub(crate) doc_to_point: FxHashMap<u32, u64>,
+    pub(crate) free_doc_ids: Vec<u32>,
+    pub(crate) next_doc_id: u32,
+    pub(crate) doc_count: usize,
+    pub(crate) total_doc_length: u64,
+}
+
+/// Current [`Bm25Snapshot`] schema version. Bump on breaking changes.
+pub(crate) const BM25_SNAPSHOT_VERSION: u32 = 1;
 
 /// BM25 full-text search index.
 ///
@@ -441,6 +467,46 @@ impl Bm25Index {
 
 impl Default for Bm25Index {
     fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Snapshot serialization (for `bm25_persistence` module)
+// ---------------------------------------------------------------------------
+
+#[allow(dead_code)] // TODO(US-389): commit 4 wires these into Collection::flush.
+impl Bm25Index {
+    /// Captures the current index state as a [`Bm25Snapshot`].
+    ///
+    /// STUB — returns an empty/default snapshot. The real implementation
+    /// lands in commit 2; this stub exists so the TDD tests (commit 1)
+    /// compile while still failing at runtime.
+    #[must_use]
+    pub(crate) fn to_snapshot(&self) -> Bm25Snapshot {
+        // TODO(US-389): commit 2 will read the actual internal state.
+        Bm25Snapshot {
+            version: BM25_SNAPSHOT_VERSION,
+            params: self.params,
+            documents: FxHashMap::default(),
+            point_to_doc: FxHashMap::default(),
+            doc_to_point: FxHashMap::default(),
+            free_doc_ids: Vec::new(),
+            next_doc_id: 0,
+            doc_count: 0,
+            total_doc_length: 0,
+        }
+    }
+
+    /// Rebuilds an index from a [`Bm25Snapshot`].
+    ///
+    /// STUB — ignores the snapshot contents and returns an empty index.
+    /// The real implementation lands in commit 2.
+    #[must_use]
+    #[allow(clippy::needless_pass_by_value)] // TODO(US-389): commit 2 consumes `snapshot`
+    pub(crate) fn from_snapshot(snapshot: Bm25Snapshot) -> Self {
+        // TODO(US-389): commit 2 will restore the full state.
+        let _ = snapshot;
         Self::new()
     }
 }

--- a/crates/velesdb-core/src/index/bm25_persistence.rs
+++ b/crates/velesdb-core/src/index/bm25_persistence.rs
@@ -1,8 +1,3 @@
-// TODO(US-389): remove `dead_code` allow after commit 4 wires the
-// lifecycle integration. Until then these helpers are used only by the
-// persistence tests, which do not count as lib-side references.
-#![allow(dead_code)]
-
 //! BM25 index persistence: atomic snapshot save/load.
 //!
 //! All types and functions in this module are gated behind

--- a/crates/velesdb-core/src/index/bm25_persistence.rs
+++ b/crates/velesdb-core/src/index/bm25_persistence.rs
@@ -1,0 +1,131 @@
+// TODO(US-389): remove `dead_code` allow after commit 4 wires the
+// lifecycle integration. Until then these helpers are used only by the
+// persistence tests, which do not count as lib-side references.
+#![allow(dead_code)]
+
+//! BM25 index persistence: atomic snapshot save/load.
+//!
+//! All types and functions in this module are gated behind
+//! `#[cfg(feature = "persistence")]`.
+//!
+//! ## On-disk layout
+//!
+//! ```text
+//! <collection_dir>/
+//!   bm25.snapshot    # Postcard-serialized [`Bm25Snapshot`]
+//!   bm25.wal         # Write-ahead log (see [`bm25_persistence_wal`])
+//! ```
+//!
+//! The snapshot captures the full in-memory state of the BM25 index
+//! (documents, term frequencies, point/doc-id mappings, doc-count and
+//! total length). The WAL captures mutations made after the most recent
+//! snapshot. `load_snapshot` + `wal_replay` together restore the index
+//! to its pre-shutdown state in O(snapshot) + O(WAL delta) time, which
+//! replaces the prior O(N) payload-scan rebuild.
+//!
+//! ## Corruption handling
+//!
+//! `load_snapshot` returns `Ok(None)` only when the snapshot file is
+//! absent (`NotFound`). Any other read error — including corrupt
+//! bytes that fail postcard deserialization — surfaces as `Err`.
+//! Silent fallback to the payload-rebuild path must be triggered by
+//! the caller checking for `Ok(None)`; never by swallowing an `Err`.
+//! See issue #618 for the Devin learning that motivates this
+//! fail-fast contract.
+
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use crate::error::{Error, Result};
+use crate::index::bm25::{Bm25Index, Bm25Snapshot};
+
+/// Snapshot filename under a collection directory.
+pub(crate) const BM25_SNAPSHOT_FILENAME: &str = "bm25.snapshot";
+
+/// Returns the absolute path to the BM25 snapshot file under `dir`.
+#[must_use]
+pub(crate) fn snapshot_path(dir: &Path) -> PathBuf {
+    dir.join(BM25_SNAPSHOT_FILENAME)
+}
+
+/// Saves the BM25 index as an atomic snapshot under `dir/bm25.snapshot`.
+///
+/// Uses the `write-tmp-fsync-rename` pattern to guarantee that a crash
+/// mid-save never leaves a torn snapshot file observable by the next
+/// startup.
+///
+/// # Errors
+///
+/// Returns [`Error::Index`] if serialization or disk I/O fails.
+pub(crate) fn save_snapshot(dir: &Path, index: &Bm25Index) -> Result<()> {
+    let snapshot = index.to_snapshot();
+    let bytes = postcard::to_allocvec(&snapshot)
+        .map_err(|e| Error::Index(format!("BM25 snapshot serialize: {e}")))?;
+    let final_path = snapshot_path(dir);
+    atomic_write(&final_path, &bytes).map_err(|e| Error::Index(format!("BM25 snapshot write: {e}")))
+}
+
+/// Loads the BM25 index from `dir/bm25.snapshot` if present.
+///
+/// - Returns `Ok(None)` when the snapshot file does not exist (backward
+///   compat: the caller should fall back to the payload-rebuild path).
+/// - Returns `Err(Error::Index(..))` when the file exists but cannot
+///   be read or deserialized (corruption must surface loudly — never
+///   silently fall back to rebuild, per issue #618 learning).
+///
+/// # Errors
+///
+/// Returns [`Error::Index`] when the file exists but is unreadable or
+/// contains corrupt bytes that fail postcard deserialization.
+pub(crate) fn load_snapshot(dir: &Path) -> Result<Option<Bm25Index>> {
+    let path = snapshot_path(dir);
+    let bytes = match std::fs::read(&path) {
+        Ok(b) => b,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => return Err(Error::Index(format!("BM25 snapshot read: {e}"))),
+    };
+    let snapshot: Bm25Snapshot = postcard::from_bytes(&bytes)
+        .map_err(|e| Error::Index(format!("BM25 snapshot deserialize: {e}")))?;
+    Ok(Some(Bm25Index::from_snapshot(snapshot)))
+}
+
+// ---------------------------------------------------------------------------
+// Atomic write (write-tmp-fsync-rename)
+// ---------------------------------------------------------------------------
+
+/// Process-wide counter to produce unique tmp suffixes even when two
+/// threads race to save the same snapshot.
+static TMP_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+/// Writes `data` to `final_path` atomically: stage to a uniquely-named
+/// tmp file in the same directory, flush + fsync, then rename over.
+///
+/// Mirrors the pattern in `index::hnsw::persistence::atomic_write`. The
+/// tmp suffix combines PID, thread ID and a monotonically-increasing
+/// counter to avoid collisions under concurrent saves.
+fn atomic_write(final_path: &Path, data: &[u8]) -> std::io::Result<()> {
+    let seq = TMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let pid = std::process::id();
+    let tid = std::thread::current().id();
+
+    let file_name = final_path.file_name().unwrap_or_default().to_string_lossy();
+    let tmp_name = format!("{file_name}.tmp.{pid}.{tid:?}.{seq}");
+    let tmp_path = final_path.with_file_name(&tmp_name);
+
+    let result = atomic_write_inner(&tmp_path, final_path, data);
+    if result.is_err() {
+        // Best-effort cleanup — ignore any follow-up error.
+        let _ = std::fs::remove_file(&tmp_path);
+    }
+    result
+}
+
+fn atomic_write_inner(tmp_path: &Path, final_path: &Path, data: &[u8]) -> std::io::Result<()> {
+    let file = std::fs::File::create(tmp_path)?;
+    let mut writer = std::io::BufWriter::new(file);
+    writer.write_all(data)?;
+    writer.flush()?;
+    writer.get_ref().sync_all()?;
+    std::fs::rename(tmp_path, final_path)
+}

--- a/crates/velesdb-core/src/index/bm25_persistence_tests.rs
+++ b/crates/velesdb-core/src/index/bm25_persistence_tests.rs
@@ -1,0 +1,360 @@
+//! TDD tests for BM25 snapshot + WAL persistence (issue #389).
+//!
+//! These tests define the behavioural contract for the hybrid
+//! snapshot/WAL persistence path:
+//!
+//! 1. Full state round-trips bitwise through `save_snapshot` /
+//!    `load_snapshot` (no silent recall loss).
+//! 2. WAL append + replay preserves incremental mutations on crash.
+//! 3. Corrupted snapshot surfaces an error — never a silent fallback.
+//! 4. Absent snapshot falls back to the payload-rebuild path without
+//!    raising an error (backward-compat with pre-persistence DBs).
+//! 5. `wal_truncate` after snapshot guarantees zero replay on next open.
+//! 6. Concurrent adds serialise correctly through the WAL.
+//!
+//! All tests run single-threaded by repo convention (`--test-threads=1`).
+
+#![allow(clippy::unwrap_used)] // tests: .unwrap()/.expect() is idiomatic
+
+use std::sync::{Arc, Barrier};
+use std::thread;
+
+use tempfile::tempdir;
+
+use super::bm25::Bm25Index;
+use super::bm25_persistence::{load_snapshot, save_snapshot, snapshot_path};
+use super::bm25_persistence_wal::{
+    wal_append_add_document, wal_append_remove_document, wal_path_for_bm25, wal_replay,
+    wal_truncate,
+};
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+/// Fixed corpus used by several tests — all documents share enough
+/// overlap to exercise the inverted index.
+fn sample_corpus() -> Vec<(u64, &'static str)> {
+    vec![
+        (1, "rust programming language systems"),
+        (2, "python programming data science"),
+        (3, "java programming enterprise"),
+        (4, "rust memory safety concurrency"),
+        (5, "typescript programming web frontend"),
+    ]
+}
+
+/// Convenience: sorts a query result by `doc_id` so that comparisons
+/// are deterministic under stable-sort.
+fn sort_by_id(mut results: Vec<(u64, f32)>) -> Vec<(u64, f32)> {
+    results.sort_by_key(|(id, _)| *id);
+    results
+}
+
+/// Bitwise float equality via `to_bits` — BM25 scores must round-trip
+/// exactly through serialization, not just within an epsilon.
+fn assert_bitwise_eq(a: &[(u64, f32)], b: &[(u64, f32)]) {
+    assert_eq!(a.len(), b.len(), "result lengths differ: {a:?} vs {b:?}");
+    for (lhs, rhs) in a.iter().zip(b.iter()) {
+        assert_eq!(lhs.0, rhs.0, "ids differ: {a:?} vs {b:?}");
+        assert_eq!(
+            lhs.1.to_bits(),
+            rhs.1.to_bits(),
+            "score bits differ for id {}: {:?} vs {:?}",
+            lhs.0,
+            lhs.1,
+            rhs.1
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Test 1 — snapshot round-trip
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_save_load_snapshot_roundtrip() {
+    let dir = tempdir().unwrap();
+    let index = Bm25Index::new();
+    for (id, text) in sample_corpus() {
+        index.add_document(id, text);
+    }
+
+    save_snapshot(dir.path(), &index).expect("save_snapshot");
+
+    let loaded = load_snapshot(dir.path())
+        .expect("load_snapshot")
+        .expect("snapshot file should exist");
+
+    assert_eq!(loaded.len(), index.len(), "doc_count should match");
+    for query in ["rust", "programming", "python", "web"] {
+        let original = sort_by_id(index.search(query, 10));
+        let round_trip = sort_by_id(loaded.search(query, 10));
+        assert_bitwise_eq(&original, &round_trip);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Test 2 — WAL append `add_document` + replay
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_wal_append_add_document_replay() {
+    let dir = tempdir().unwrap();
+    let wal_path = wal_path_for_bm25(dir.path());
+
+    // Reference index — in-memory truth we replay against.
+    let reference = Bm25Index::new();
+    for i in 0u64..10 {
+        let text = format!("document number {i} rust persistence");
+        wal_append_add_document(&wal_path, i, &text).unwrap();
+        reference.add_document(i, &text);
+    }
+
+    let replayed = Bm25Index::new();
+    let count = wal_replay(&wal_path, &replayed).expect("wal_replay");
+    assert_eq!(count, 10, "replay should apply all 10 entries");
+    assert_eq!(replayed.len(), reference.len());
+
+    for query in ["rust", "persistence", "number"] {
+        let expected = sort_by_id(reference.search(query, 10));
+        let actual = sort_by_id(replayed.search(query, 10));
+        assert_bitwise_eq(&expected, &actual);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Test 3 — WAL append `remove_document` + replay
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_wal_append_remove_document_replay() {
+    let dir = tempdir().unwrap();
+    let wal_path = wal_path_for_bm25(dir.path());
+
+    let reference = Bm25Index::new();
+    for (id, text) in sample_corpus() {
+        wal_append_add_document(&wal_path, id, text).unwrap();
+        reference.add_document(id, text);
+    }
+    // Now remove ids 2 and 4 via WAL.
+    wal_append_remove_document(&wal_path, 2).unwrap();
+    wal_append_remove_document(&wal_path, 4).unwrap();
+    reference.remove_document(2);
+    reference.remove_document(4);
+
+    let replayed = Bm25Index::new();
+    let count = wal_replay(&wal_path, &replayed).expect("wal_replay");
+    let expected_count = u64::try_from(sample_corpus().len() + 2).expect("sample corpus is small");
+    assert_eq!(count, expected_count, "adds + removes must be counted");
+    assert_eq!(replayed.len(), reference.len());
+
+    let expected = sort_by_id(reference.search("programming", 10));
+    let actual = sort_by_id(replayed.search("programming", 10));
+    assert_bitwise_eq(&expected, &actual);
+}
+
+// ---------------------------------------------------------------------------
+// Test 4 — snapshot + WAL replay preserves top-k queries
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_snapshot_plus_wal_replay_preserves_query_topk() {
+    let dir = tempdir().unwrap();
+    let wal_path = wal_path_for_bm25(dir.path());
+
+    // Phase A: build an index, snapshot it.
+    let initial = Bm25Index::new();
+    for (id, text) in sample_corpus() {
+        initial.add_document(id, text);
+    }
+    save_snapshot(dir.path(), &initial).unwrap();
+    // After snapshot, WAL should be truncated by the caller — here we
+    // simulate that ordering explicitly.
+    wal_truncate(&wal_path).unwrap();
+
+    // Phase B: apply additional mutations directly and via WAL.
+    let mutations: &[(u64, &str)] = &[
+        (10, "rust async runtime tokio"),
+        (11, "data science machine learning python"),
+        (12, "web assembly rust performance"),
+    ];
+    for (id, text) in mutations {
+        wal_append_add_document(&wal_path, *id, text).unwrap();
+        initial.add_document(*id, text);
+    }
+    wal_append_remove_document(&wal_path, 3).unwrap();
+    initial.remove_document(3);
+
+    // Phase C: reload from snapshot + replay WAL.
+    let mut reloaded = load_snapshot(dir.path())
+        .unwrap()
+        .expect("snapshot should exist");
+    let replayed_count = wal_replay(&wal_path, &reloaded).unwrap();
+    let expected_replay = u64::try_from(mutations.len() + 1).expect("mutations is small");
+    assert_eq!(replayed_count, expected_replay);
+    assert_eq!(reloaded.len(), initial.len());
+
+    for query in ["rust", "python", "web", "programming"] {
+        let expected = sort_by_id(initial.search(query, 10));
+        let actual = sort_by_id(reloaded.search(query, 10));
+        assert_bitwise_eq(&expected, &actual);
+    }
+
+    // Silence unused_mut on platforms where `reloaded` is only read
+    // after `wal_replay` — the mutability is required by the API.
+    let _ = &mut reloaded;
+}
+
+// ---------------------------------------------------------------------------
+// Test 5 — absent snapshot returns Ok(None) (backward-compat)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_no_snapshot_falls_back_to_payload_rebuild() {
+    let dir = tempdir().unwrap();
+    // No files at all in `dir`.
+    let result = load_snapshot(dir.path()).expect("load_snapshot should not error on missing file");
+    assert!(
+        result.is_none(),
+        "absent snapshot must signal the caller to run the legacy rebuild path"
+    );
+
+    // WAL-only also loads cleanly (zero entries).
+    let wal_path = wal_path_for_bm25(dir.path());
+    let idx = Bm25Index::new();
+    let count = wal_replay(&wal_path, &idx).expect("wal_replay");
+    assert_eq!(count, 0);
+    assert!(idx.is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// Test 6 — corrupt snapshot surfaces Err (no silent data loss)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_corrupted_snapshot_surfaces_error_without_silent_data_loss() {
+    let dir = tempdir().unwrap();
+    let path = snapshot_path(dir.path());
+
+    // Write garbage bytes — no legitimate postcard payload begins with
+    // these high-value byte sequences.
+    std::fs::write(&path, b"\xFF\x00\xAA\xBB\xCC\xDE\xAD\xBE\xEF\x42\x17").unwrap();
+
+    let result = load_snapshot(dir.path());
+    match result {
+        Err(err) => {
+            let msg = err.to_string().to_lowercase();
+            assert!(
+                msg.contains("bm25") || msg.contains("snapshot"),
+                "error message should identify BM25 or snapshot context: {msg}"
+            );
+        }
+        Ok(_) => {
+            panic!("corrupt snapshot MUST surface as Err, never Ok(None) (issue #618 learning)")
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Test 7 — snapshot truncates WAL so next open replays zero entries
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_wal_append_then_save_snapshot_truncates_wal() {
+    let dir = tempdir().unwrap();
+    let wal_path = wal_path_for_bm25(dir.path());
+
+    let index = Bm25Index::new();
+    for (id, text) in sample_corpus() {
+        wal_append_add_document(&wal_path, id, text).unwrap();
+        index.add_document(id, text);
+    }
+    assert!(wal_path.exists(), "WAL file should exist after appends");
+    let wal_len_before = std::fs::metadata(&wal_path).unwrap().len();
+    assert!(
+        wal_len_before > 0,
+        "WAL should be non-empty before snapshot"
+    );
+
+    save_snapshot(dir.path(), &index).unwrap();
+    wal_truncate(&wal_path).unwrap();
+
+    let wal_len_after = std::fs::metadata(&wal_path).unwrap().len();
+    assert_eq!(
+        wal_len_after, 0,
+        "wal_truncate must reduce WAL to zero bytes"
+    );
+
+    // Next open: reload + replay → zero replayed entries, state intact.
+    let reloaded = load_snapshot(dir.path()).unwrap().expect("snapshot exists");
+    let replayed = wal_replay(&wal_path, &reloaded).unwrap();
+    assert_eq!(replayed, 0, "truncated WAL must replay zero entries");
+    assert_eq!(reloaded.len(), index.len());
+}
+
+// ---------------------------------------------------------------------------
+// Test 8 — concurrent WAL append preserves every mutation
+// ---------------------------------------------------------------------------
+
+const CONCURRENT_THREADS: u64 = 4;
+const CONCURRENT_PER_THREAD: u64 = 25;
+
+#[test]
+fn test_concurrent_add_document_safe_with_wal_append() {
+    let dir = tempdir().unwrap();
+    let wal_path = Arc::new(wal_path_for_bm25(dir.path()));
+
+    let thread_count =
+        usize::try_from(CONCURRENT_THREADS).expect("CONCURRENT_THREADS fits in usize");
+    let barrier = Arc::new(Barrier::new(thread_count));
+
+    let mut handles = Vec::with_capacity(thread_count);
+    for t in 0..CONCURRENT_THREADS {
+        let wal = Arc::clone(&wal_path);
+        let bar = Arc::clone(&barrier);
+        handles.push(thread::spawn(move || {
+            bar.wait();
+            for i in 0..CONCURRENT_PER_THREAD {
+                let id = t * CONCURRENT_PER_THREAD + i;
+                // Unique-per-doc marker ensures we can spot-check
+                // every id after replay without relying on top-k
+                // ranking across a shared vocabulary. The tokenizer
+                // splits on non-alphanumeric and drops single-char
+                // tokens, so we embed the id directly in a single
+                // alphanumeric token (e.g. `markerXX123`).
+                let marker = format!("marker{id:05}");
+                let text = format!("concurrent thread{t} doc{i} {marker}");
+                wal_append_add_document(&wal, id, &text).expect("wal append");
+            }
+        }));
+    }
+    for h in handles {
+        h.join().expect("thread join");
+    }
+
+    let replayed_index = Bm25Index::new();
+    let count = wal_replay(&wal_path, &replayed_index).expect("wal_replay");
+    let expected = CONCURRENT_THREADS * CONCURRENT_PER_THREAD;
+    assert_eq!(
+        count, expected,
+        "all {expected} concurrent appends must survive replay"
+    );
+    let expected_usize = usize::try_from(expected).expect("expected fits in usize");
+    assert_eq!(replayed_index.len(), expected_usize);
+
+    // Every id must be present — each doc has a unique `markerXXXXX`
+    // token (0-padded), so search for that token returns exactly one
+    // hit.
+    for t in 0..CONCURRENT_THREADS {
+        for i in 0..CONCURRENT_PER_THREAD {
+            let id = t * CONCURRENT_PER_THREAD + i;
+            let needle = format!("marker{id:05}");
+            let hits = replayed_index.search(&needle, 2);
+            assert!(
+                hits.iter().any(|(hid, _)| *hid == id),
+                "id {id} missing after concurrent replay (hits: {hits:?})"
+            );
+        }
+    }
+}

--- a/crates/velesdb-core/src/index/bm25_persistence_wal.rs
+++ b/crates/velesdb-core/src/index/bm25_persistence_wal.rs
@@ -1,0 +1,89 @@
+// TODO(US-389): remove these allows after commit 3 implements the WAL
+// bodies (bringing them out of stub state) and commit 4 wires the
+// lifecycle integration. Until then the stubs are infallible, which
+// confuses `clippy::unnecessary_wraps` and `must_use_candidate`.
+#![allow(dead_code)]
+#![allow(clippy::unnecessary_wraps)]
+
+//! BM25 index WAL: append + replay for incremental persistence.
+//!
+//! The WAL captures `add_document` / `remove_document` mutations applied
+//! after the most recent snapshot. On collection open, the snapshot is
+//! loaded first and the WAL is replayed on top to bring the index
+//! up-to-date. After a successful `save_snapshot`, the WAL must be
+//! truncated via [`wal_truncate`] so the next open replays zero entries.
+//!
+//! All functions here are gated behind `#[cfg(feature = "persistence")]`.
+//!
+//! ## Implementation status
+//!
+//! Commit 1 (this file) ships only signatures — the WAL body is
+//! implemented in commit 3. The persistence tests therefore fail until
+//! commit 3 lands, which is the intended TDD red/green transition.
+
+use std::path::{Path, PathBuf};
+
+use crate::error::Result;
+use crate::index::bm25::Bm25Index;
+
+/// WAL filename under a collection directory.
+const BM25_WAL_FILENAME: &str = "bm25.wal";
+
+/// Returns the absolute path to the BM25 WAL file under `dir`.
+#[must_use]
+pub(crate) fn wal_path_for_bm25(dir: &Path) -> PathBuf {
+    dir.join(BM25_WAL_FILENAME)
+}
+
+/// Appends an `add_document(id, text)` mutation to the BM25 WAL.
+///
+/// STUB — commit 3 implements the body. Currently a no-op so the
+/// TDD test suite fails the replay assertions (red anchor).
+///
+/// # Errors
+///
+/// Infallible in the stub; commit 3 will return I/O errors.
+#[inline]
+pub(crate) fn wal_append_add_document(wal_path: &Path, id: u64, text: &str) -> Result<()> {
+    let _ = (wal_path, id, text);
+    Ok(())
+}
+
+/// Appends a `remove_document(id)` mutation to the BM25 WAL.
+///
+/// STUB — commit 3 implements the body.
+///
+/// # Errors
+///
+/// Infallible in the stub; commit 3 will return I/O errors.
+#[inline]
+pub(crate) fn wal_append_remove_document(wal_path: &Path, id: u64) -> Result<()> {
+    let _ = (wal_path, id);
+    Ok(())
+}
+
+/// Truncates the BM25 WAL file to zero length.
+///
+/// STUB — commit 3 implements the body.
+///
+/// # Errors
+///
+/// Infallible in the stub.
+pub(crate) fn wal_truncate(wal_path: &Path) -> Result<()> {
+    let _ = wal_path;
+    Ok(())
+}
+
+/// Replays the BM25 WAL against the provided `index`, returning the
+/// number of entries applied.
+///
+/// STUB — commit 3 implements the body. Returns 0 so the TDD tests
+/// fail the replay count assertions (red anchor).
+///
+/// # Errors
+///
+/// Infallible in the stub.
+pub(crate) fn wal_replay(wal_path: &Path, index: &Bm25Index) -> Result<u64> {
+    let _ = (wal_path, index);
+    Ok(0)
+}

--- a/crates/velesdb-core/src/index/bm25_persistence_wal.rs
+++ b/crates/velesdb-core/src/index/bm25_persistence_wal.rs
@@ -68,30 +68,56 @@ pub(crate) fn wal_path_for_bm25(dir: &Path) -> PathBuf {
 #[inline]
 pub(crate) fn wal_append_add_document(wal_path: &Path, id: u64, text: &str) -> Result<()> {
     let text_bytes = text.as_bytes();
-    let text_len = u32::try_from(text_bytes.len()).map_err(|_| {
+    let text_len = encode_text_len(text_bytes)?;
+    let body_len = add_entry_body_len(text_len)?;
+
+    let mut w = open_wal_writer(wal_path)?;
+    wal_write(&mut w, &body_len.to_le_bytes())?;
+    write_add_entry_body(&mut w, id, text_len, text_bytes)?;
+    flush_wal(&mut w)
+}
+
+/// Validates that `text_bytes.len()` fits in a `u32` and returns the cast.
+///
+/// Extracted from [`wal_append_add_document`] to keep its CC under the
+/// Codacy limit (#389).
+#[inline]
+fn encode_text_len(text_bytes: &[u8]) -> Result<u32> {
+    u32::try_from(text_bytes.len()).map_err(|_| {
         Error::Index(format!(
             "BM25 WAL: text too large ({} bytes) to encode",
             text_bytes.len()
         ))
-    })?;
+    })
+}
 
-    // body = op(1) + point_id(8) + text_len(4) + text_bytes
-    let body_len = u32::try_from(ADD_ENTRY_HEADER)
-        .ok()
-        .and_then(|h| h.checked_add(text_len))
-        .ok_or_else(|| {
-            Error::Index(format!(
-                "BM25 WAL: entry too large (text_len={text_len}) to fit in u32 prefix"
-            ))
-        })?;
+/// Computes the `u32` body length for an `Add` entry = `op(1)` +
+/// `point_id(8)` + `text_len(4)` + `text_bytes`. Fails if the sum
+/// overflows `u32`.
+#[inline]
+fn add_entry_body_len(text_len: u32) -> Result<u32> {
+    let header =
+        u32::try_from(ADD_ENTRY_HEADER).expect("ADD_ENTRY_HEADER fits in u32 (compile-time)");
+    header.checked_add(text_len).ok_or_else(|| {
+        Error::Index(format!(
+            "BM25 WAL: entry too large (text_len={text_len}) to fit in u32 prefix"
+        ))
+    })
+}
 
-    let mut w = open_wal_writer(wal_path)?;
-    wal_write(&mut w, &body_len.to_le_bytes())?;
-    wal_write(&mut w, &[WAL_OP_ADD])?;
-    wal_write(&mut w, &id.to_le_bytes())?;
-    wal_write(&mut w, &text_len.to_le_bytes())?;
-    wal_write(&mut w, text_bytes)?;
-    flush_wal(&mut w)
+/// Writes the body of an `Add` entry (op byte + `point_id` + `text_len`
+/// + text) into an already-prefixed WAL writer.
+#[inline]
+fn write_add_entry_body(
+    w: &mut std::io::BufWriter<std::fs::File>,
+    id: u64,
+    text_len: u32,
+    text_bytes: &[u8],
+) -> Result<()> {
+    wal_write(w, &[WAL_OP_ADD])?;
+    wal_write(w, &id.to_le_bytes())?;
+    wal_write(w, &text_len.to_le_bytes())?;
+    wal_write(w, text_bytes)
 }
 
 /// Appends a `remove_document(id)` mutation to the BM25 WAL.

--- a/crates/velesdb-core/src/index/bm25_persistence_wal.rs
+++ b/crates/velesdb-core/src/index/bm25_persistence_wal.rs
@@ -1,9 +1,7 @@
-// TODO(US-389): remove these allows after commit 3 implements the WAL
-// bodies (bringing them out of stub state) and commit 4 wires the
-// lifecycle integration. Until then the stubs are infallible, which
-// confuses `clippy::unnecessary_wraps` and `must_use_candidate`.
+// TODO(US-389): remove the `dead_code` allow after commit 4 wires the
+// lifecycle integration. Until then these helpers are used only by the
+// persistence tests, which do not count as lib-side references.
 #![allow(dead_code)]
-#![allow(clippy::unnecessary_wraps)]
 
 //! BM25 index WAL: append + replay for incremental persistence.
 //!
@@ -13,21 +11,43 @@
 //! up-to-date. After a successful `save_snapshot`, the WAL must be
 //! truncated via [`wal_truncate`] so the next open replays zero entries.
 //!
+//! ## On-disk entry layout (length-prefixed, little-endian)
+//!
+//! ```text
+//! Add:    [u32 body_len][u8 0x01][u64 point_id][u32 text_len][text bytes]
+//! Remove: [u32 body_len][u8 0x02][u64 point_id]
+//! ```
+//!
+//! `body_len` is the byte count *after* the prefix — it lets the replay
+//! loop skip unknown / corrupt entries without aborting the whole
+//! recovery. A truncated final entry (common on crash) is logged at
+//! `warn` level and skipped rather than surfacing as an error.
+//!
+//! ## Crash-safety ordering
+//!
+//! Callers MUST invoke `wal_append_*` BEFORE applying the corresponding
+//! in-memory mutation. If the process crashes between the two, replay
+//! reconstructs the mutation on next open. The WAL is fsynced on every
+//! append so that a power-cut after append but before any subsequent
+//! write still replays the entry correctly.
+//!
 //! All functions here are gated behind `#[cfg(feature = "persistence")]`.
-//!
-//! ## Implementation status
-//!
-//! Commit 1 (this file) ships only signatures — the WAL body is
-//! implemented in commit 3. The persistence tests therefore fail until
-//! commit 3 lands, which is the intended TDD red/green transition.
 
+use std::io::{BufWriter, Write};
 use std::path::{Path, PathBuf};
 
-use crate::error::Result;
+use crate::error::{Error, Result};
 use crate::index::bm25::Bm25Index;
+
+const WAL_OP_ADD: u8 = 0x01;
+const WAL_OP_REMOVE: u8 = 0x02;
 
 /// WAL filename under a collection directory.
 const BM25_WAL_FILENAME: &str = "bm25.wal";
+
+/// Header sizes used to validate truncated entries during replay.
+const ADD_ENTRY_HEADER: usize = 1 + 8 + 4; // op + point_id + text_len
+const REMOVE_ENTRY_HEADER: usize = 1 + 8; // op + point_id
 
 /// Returns the absolute path to the BM25 WAL file under `dir`.
 #[must_use]
@@ -35,55 +55,250 @@ pub(crate) fn wal_path_for_bm25(dir: &Path) -> PathBuf {
     dir.join(BM25_WAL_FILENAME)
 }
 
+// ---------------------------------------------------------------------------
+// Append operations (hot path — keep `#[inline]`)
+// ---------------------------------------------------------------------------
+
 /// Appends an `add_document(id, text)` mutation to the BM25 WAL.
 ///
-/// STUB — commit 3 implements the body. Currently a no-op so the
-/// TDD test suite fails the replay assertions (red anchor).
+/// Callers MUST invoke this BEFORE applying the mutation in-memory so
+/// that a crash between WAL append and in-memory apply replays the
+/// mutation on next open (WAL-before-apply crash-safety ordering).
 ///
 /// # Errors
 ///
-/// Infallible in the stub; commit 3 will return I/O errors.
+/// Returns [`Error::Index`] if the WAL file cannot be opened or
+/// written, or if the text is too large to encode in a `u32`-prefixed
+/// entry.
 #[inline]
 pub(crate) fn wal_append_add_document(wal_path: &Path, id: u64, text: &str) -> Result<()> {
-    let _ = (wal_path, id, text);
-    Ok(())
+    let text_bytes = text.as_bytes();
+    let text_len = u32::try_from(text_bytes.len()).map_err(|_| {
+        Error::Index(format!(
+            "BM25 WAL: text too large ({} bytes) to encode",
+            text_bytes.len()
+        ))
+    })?;
+
+    // body = op(1) + point_id(8) + text_len(4) + text_bytes
+    let body_len = u32::try_from(ADD_ENTRY_HEADER)
+        .ok()
+        .and_then(|h| h.checked_add(text_len))
+        .ok_or_else(|| {
+            Error::Index(format!(
+                "BM25 WAL: entry too large (text_len={text_len}) to fit in u32 prefix"
+            ))
+        })?;
+
+    let mut w = open_wal_writer(wal_path)?;
+    wal_write(&mut w, &body_len.to_le_bytes())?;
+    wal_write(&mut w, &[WAL_OP_ADD])?;
+    wal_write(&mut w, &id.to_le_bytes())?;
+    wal_write(&mut w, &text_len.to_le_bytes())?;
+    wal_write(&mut w, text_bytes)?;
+    flush_wal(&mut w)
 }
 
 /// Appends a `remove_document(id)` mutation to the BM25 WAL.
 ///
-/// STUB — commit 3 implements the body.
+/// Callers MUST invoke this BEFORE applying the mutation in-memory
+/// (WAL-before-apply crash-safety ordering).
 ///
 /// # Errors
 ///
-/// Infallible in the stub; commit 3 will return I/O errors.
+/// Returns [`Error::Index`] if the WAL file cannot be opened or
+/// written.
 #[inline]
 pub(crate) fn wal_append_remove_document(wal_path: &Path, id: u64) -> Result<()> {
-    let _ = (wal_path, id);
-    Ok(())
+    // Fits in a `u32` by construction — constant header size = 9.
+    let body_len = u32::try_from(REMOVE_ENTRY_HEADER).expect("REMOVE_ENTRY_HEADER <= u32::MAX");
+    let mut w = open_wal_writer(wal_path)?;
+    wal_write(&mut w, &body_len.to_le_bytes())?;
+    wal_write(&mut w, &[WAL_OP_REMOVE])?;
+    wal_write(&mut w, &id.to_le_bytes())?;
+    flush_wal(&mut w)
 }
 
 /// Truncates the BM25 WAL file to zero length.
 ///
-/// STUB — commit 3 implements the body.
+/// Called after a successful `save_snapshot` to guarantee that the next
+/// open replays zero WAL entries. A missing WAL file is a no-op.
 ///
 /// # Errors
 ///
-/// Infallible in the stub.
+/// Returns [`Error::Index`] if the WAL file exists but cannot be
+/// truncated.
 pub(crate) fn wal_truncate(wal_path: &Path) -> Result<()> {
-    let _ = wal_path;
-    Ok(())
+    if !wal_path.exists() {
+        return Ok(());
+    }
+    let file = std::fs::OpenOptions::new()
+        .write(true)
+        .open(wal_path)
+        .map_err(|e| Error::Index(format!("BM25 WAL truncate open: {e}")))?;
+    file.set_len(0)
+        .map_err(|e| Error::Index(format!("BM25 WAL truncate: {e}")))
 }
+
+// ---------------------------------------------------------------------------
+// Replay
+// ---------------------------------------------------------------------------
 
 /// Replays the BM25 WAL against the provided `index`, returning the
 /// number of entries applied.
 ///
-/// STUB — commit 3 implements the body. Returns 0 so the TDD tests
-/// fail the replay count assertions (red anchor).
+/// Missing WAL file returns `Ok(0)`. A truncated final entry (partial
+/// crash during append) is logged at `warn` level and skipped. Unknown
+/// opcodes are logged and skipped without aborting replay.
 ///
 /// # Errors
 ///
-/// Infallible in the stub.
+/// Returns [`Error::Index`] if the WAL file exists but cannot be read,
+/// or if a complete entry contains corrupt byte sequences that cannot
+/// be decoded.
 pub(crate) fn wal_replay(wal_path: &Path, index: &Bm25Index) -> Result<u64> {
-    let _ = (wal_path, index);
-    Ok(0)
+    let data = match std::fs::read(wal_path) {
+        Ok(d) => d,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(0),
+        Err(e) => return Err(Error::Index(format!("BM25 WAL read: {e}"))),
+    };
+
+    let mut pos = 0usize;
+    let mut count = 0u64;
+
+    while pos < data.len() {
+        let Some((body_start, body_len)) = read_entry_header(&data, pos) else {
+            break;
+        };
+        pos = body_start;
+        if pos + body_len > data.len() {
+            tracing::warn!(
+                "BM25 WAL truncated at offset {body_start}: declared {body_len} bytes but only {} remain",
+                data.len() - pos
+            );
+            break;
+        }
+        let op = data[pos];
+        pos += 1;
+        let applied = replay_single_entry(&data, op, &mut pos, body_start, body_len, index)?;
+        count += applied;
+        // Defensive: align `pos` to the entry boundary even when a
+        // replayer short-circuited (e.g. skipped a malformed entry).
+        if pos < body_start + body_len {
+            pos = body_start + body_len;
+        }
+    }
+
+    Ok(count)
+}
+
+/// Reads the `u32` length prefix, returning `(body_start, body_len)`.
+fn read_entry_header(data: &[u8], pos: usize) -> Option<(usize, usize)> {
+    if pos + 4 > data.len() {
+        tracing::warn!("BM25 WAL truncated at offset {pos}: not enough bytes for length prefix");
+        return None;
+    }
+    let bytes: [u8; 4] = data[pos..pos + 4].try_into().ok()?;
+    let body_len = u32::from_le_bytes(bytes) as usize;
+    Some((pos + 4, body_len))
+}
+
+/// Dispatches a single WAL entry to the appropriate in-memory mutation.
+fn replay_single_entry(
+    data: &[u8],
+    op: u8,
+    pos: &mut usize,
+    body_start: usize,
+    body_len: usize,
+    index: &Bm25Index,
+) -> Result<u64> {
+    match op {
+        WAL_OP_ADD => replay_add_entry(data, pos, body_start, body_len, index),
+        WAL_OP_REMOVE => replay_remove_entry(data, pos, index),
+        unknown => {
+            tracing::warn!("BM25 WAL unknown op 0x{unknown:02x} at offset {body_start}");
+            *pos = body_start + body_len;
+            Ok(0)
+        }
+    }
+}
+
+/// Replays a single `add_document` entry.
+fn replay_add_entry(
+    data: &[u8],
+    pos: &mut usize,
+    body_start: usize,
+    body_len: usize,
+    index: &Bm25Index,
+) -> Result<u64> {
+    if body_len < ADD_ENTRY_HEADER {
+        tracing::warn!("BM25 WAL add entry too short at offset {body_start}");
+        *pos = body_start + body_len;
+        return Ok(0);
+    }
+    let id = read_le_u64(data, *pos)?;
+    *pos += 8;
+    let text_len = read_le_u32(data, *pos)? as usize;
+    *pos += 4;
+    let text_end = *pos + text_len;
+    if text_end > body_start + body_len || text_end > data.len() {
+        tracing::warn!("BM25 WAL add entry truncated at offset {body_start}");
+        *pos = body_start + body_len;
+        return Ok(0);
+    }
+    let text = std::str::from_utf8(&data[*pos..text_end])
+        .map_err(|e| Error::Index(format!("BM25 WAL add: invalid utf8 at {body_start}: {e}")))?;
+    index.add_document(id, text);
+    *pos = text_end;
+    Ok(1)
+}
+
+/// Replays a single `remove_document` entry.
+fn replay_remove_entry(data: &[u8], pos: &mut usize, index: &Bm25Index) -> Result<u64> {
+    let id = read_le_u64(data, *pos)?;
+    *pos += 8;
+    index.remove_document(id);
+    Ok(1)
+}
+
+#[inline]
+fn read_le_u64(data: &[u8], pos: usize) -> Result<u64> {
+    data[pos..pos + 8]
+        .try_into()
+        .map(u64::from_le_bytes)
+        .map_err(|_| Error::Index(format!("BM25 WAL: corrupt u64 at offset {pos}")))
+}
+
+#[inline]
+fn read_le_u32(data: &[u8], pos: usize) -> Result<u32> {
+    data[pos..pos + 4]
+        .try_into()
+        .map(u32::from_le_bytes)
+        .map_err(|_| Error::Index(format!("BM25 WAL: corrupt u32 at offset {pos}")))
+}
+
+// ---------------------------------------------------------------------------
+// File-open helpers
+// ---------------------------------------------------------------------------
+
+fn open_wal_writer(wal_path: &Path) -> Result<BufWriter<std::fs::File>> {
+    let file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(wal_path)
+        .map_err(|e| Error::Index(format!("BM25 WAL open: {e}")))?;
+    Ok(BufWriter::new(file))
+}
+
+fn wal_write(w: &mut BufWriter<std::fs::File>, bytes: &[u8]) -> Result<()> {
+    w.write_all(bytes)
+        .map_err(|e| Error::Index(format!("BM25 WAL write: {e}")))
+}
+
+fn flush_wal(w: &mut BufWriter<std::fs::File>) -> Result<()> {
+    w.flush()
+        .map_err(|e| Error::Index(format!("BM25 WAL flush: {e}")))?;
+    w.get_ref()
+        .sync_all()
+        .map_err(|e| Error::Index(format!("BM25 WAL fsync: {e}")))
 }

--- a/crates/velesdb-core/src/index/bm25_persistence_wal.rs
+++ b/crates/velesdb-core/src/index/bm25_persistence_wal.rs
@@ -1,8 +1,3 @@
-// TODO(US-389): remove the `dead_code` allow after commit 4 wires the
-// lifecycle integration. Until then these helpers are used only by the
-// persistence tests, which do not count as lib-side references.
-#![allow(dead_code)]
-
 //! BM25 index WAL: append + replay for incremental persistence.
 //!
 //! The WAL captures `add_document` / `remove_document` mutations applied

--- a/crates/velesdb-core/src/index/mod.rs
+++ b/crates/velesdb-core/src/index/mod.rs
@@ -4,6 +4,13 @@
 //! nearest neighbor (ANN) search and full-text search.
 
 mod bm25;
+#[cfg(feature = "persistence")]
+pub(crate) mod bm25_persistence;
+#[cfg(feature = "persistence")]
+#[cfg(test)]
+mod bm25_persistence_tests;
+#[cfg(feature = "persistence")]
+pub(crate) mod bm25_persistence_wal;
 #[cfg(test)]
 mod bm25_tests;
 pub mod hnsw;


### PR DESCRIPTION
## Summary

Closes [#389](https://github.com/cyberlife-coder/VelesDB/issues/389) — BM25 cold-start was O(N) rebuild-from-payloads. Adds on-disk persistence via **snapshot + WAL hybrid** matching the existing `index/sparse/persistence.rs` pattern.

Cold-start : **O(N) rebuild → O(1) snapshot load + O(delta) WAL replay**. Closes KNOWN_LIMITATIONS #4 ("BM25 cold-start O(N) rebuild") after merge.

## Commits atomiques (4)

| # | SHA | Scope |
|---|---|---|
| 1 | `d8e9f401` | `test(bm25/persistence): TDD tests before impl (#389 TDD)` — 8 tests RED anchor |
| 2 | `f2df766b` | `feat(bm25/persistence): Bm25Snapshot + atomic save/load_snapshot via postcard (#389 schema)` |
| 3 | `042800a4` | `feat(bm25/persistence): WAL append + replay for BM25 mutations (#389 WAL)` |
| 4 | `51932772` | `feat(bm25/persistence): integrate snapshot+WAL into Collection lifecycle and text writes (#389 integration)` |

## Design

Même pattern que `index/sparse/persistence.rs` (snapshot) + `persistence_wal.rs` (WAL), déjà validé en prod.

- **Snapshot** : `bm25.snapshot` écrit atomiquement (`atomic_write` tmp+fsync+rename).
- **WAL** : `bm25.wal` append-only (`Add`/`Remove` entries postcard-encoded).
- **Load** : snapshot first → WAL replay → zero rebuild. Fallback to `rebuild_bm25_index` si snapshot absent (backward-compat).
- **Crash-safe ordering** : WAL append **AVANT** in-memory mutation dans `update_text_index`.
- **Fail-fast sur corruption** (leçon Devin #618) : garbage bytes dans snapshot → `Err` clair, pas de `.ok()` silencieux.

### Schéma disque

```
<data_dir>/<collection>/
├── ...existing files...
├── bm25.snapshot      # serialized full BM25 state (postcard)
└── bm25.wal           # append-only mutation log
```

## Tests (9/9 PASS)

8 TDD tests prévus + 1 bonus d'intégration :

1. `test_save_load_snapshot_roundtrip` — add N docs → save → fresh load → queries identiques
2. `test_wal_append_add_document_replay`
3. `test_wal_append_remove_document_replay`
4. `test_snapshot_plus_wal_replay_preserves_query_topk` — top-k invariant sur state hybrid
5. `test_no_snapshot_falls_back_to_payload_rebuild` — backward-compat
6. `test_corrupted_snapshot_surfaces_error_without_silent_data_loss` — fail-fast
7. `test_wal_append_then_save_snapshot_truncates_wal` — WAL reset sur flush_full
8. `test_concurrent_add_document_safe_with_wal_append` — multi-thread ordering
9. `test_bm25_persistence_on_reopen` (bonus) — end-to-end `Collection::open` path

**9/9 PASS** (FAIL avant impl TDD-style, GREEN après).

## Gates locaux — tous PASS ✅

- [x] `cargo fmt --all --check` — clean
- [x] `cargo check -p velesdb-core --no-default-features` — OK
- [x] `cargo check -p velesdb-wasm --no-default-features --target wasm32-unknown-unknown` — OK
- [x] `cargo clippy -p velesdb-core --features persistence --all-targets -- -D warnings -D clippy::pedantic` — 0 warnings
- [x] `cargo test --features persistence --lib bm25_persistence` → **9/9 PASS**
- [x] `cargo test --features persistence --test recall_validation` → **7/7 PASS** (non-négociable)
- [x] `cargo test --features persistence --test hnsw_dedup_parity_tests` → 7/7 PASS (regression lock)
- [x] Full suite → 0 régression
- [x] **Local perf gate — exit 0 PASS**
- [x] Codacy WSL — **0 findings** sur fichiers modifiés (opengrep + lizard clean)

## Design rationale (alternatives écartées)

- ❌ **Snapshot seul** — perd les writes entre snapshots sur crash. Pas acceptable pour un index qui reflète les payloads (qui ont leur propre WAL).
- ❌ **WAL seul** — delta grandit sans bound → O(delta) cold-start dégénère. Mauvaise scalabilité.
- ✅ **Hybrid (retenu)** — pattern éprouvé, même structure que sparse index.

## Impact matrix

Feature interne (`pub(crate)` helpers + schema disque privé). Aucune API publique modifiée.

| Component | Status |
|---|---|
| velesdb-core | ✅ MODIFIED (12 fichiers : 3 nouveaux modules + 9 intégration) |
| velesdb-server / -python / -wasm / -mobile / -cli / -migrate / tauri-plugin | ❌ NONE |
| TypeScript SDK / docs / promise-contract.json | ❌ NONE |
| `docs/reference/KNOWN_LIMITATIONS.md` | ⏭️ TODO post-merge (retirer entrée #4 BM25 cold-start) |

**REQUIRED items completed: 1/1 (100 %)**

## Test plan

- [x] `cargo test --features persistence --lib bm25_persistence` → 9/9 PASS
- [x] `cargo test --features persistence --test recall_validation` → 7/7 PASS
- [x] Perf gate local exit 0
- [ ] CI verte (Linux / Windows / WASM / no-default-features / conformance / Codacy Cloud / Devin / perf-smoke)
- [ ] **Manual IRL** : charger une DB produite par develop (pré-fix, sans snapshot) → doit loader via fallback rebuild sans erreur

Closes #389.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/619" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
