### PR TITLE
docs(reference): remove KNOWN_LIMITATIONS #4 BM25 cold-start (resolved by #619)

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ VelesDB is honest about its boundaries. The following are current scope limits o
 
 None of the above is a correctness gap — the Community Edition is production-ready for single-node, local-first deployments. The items above are feature-scope boundaries, not bugs.
 
-For **internal technical limitations** (query-planner approximations, plan cache semantics around `ANALYZE`, BM25 cold-start, CBO integration status), see [`docs/reference/KNOWN_LIMITATIONS.md`](docs/reference/KNOWN_LIMITATIONS.md) — each entry is tracked by a GitHub issue or documented as an explicit approximation with regression tests.
+For **internal technical limitations** (query-planner approximations, plan cache semantics around `ANALYZE`, CBO integration status), see [`docs/reference/KNOWN_LIMITATIONS.md`](docs/reference/KNOWN_LIMITATIONS.md) — each entry is tracked by a GitHub issue or documented as an explicit approximation with regression tests.
 
 ---
 

--- a/docs/reference/KNOWN_LIMITATIONS.md
+++ b/docs/reference/KNOWN_LIMITATIONS.md
@@ -53,20 +53,6 @@ When no calibrated `CollectionStats` is available (collection never analyzed, SD
 
 ---
 
-## Full-text search
-
-### 4. BM25 cold-start triggers an O(N) rebuild
-
-**Status**: open. Tracked by [issue #389](https://github.com/cyberlife-coder/VelesDB/issues/389). Source: `crates/velesdb-core/src/collection/core/lifecycle.rs:189-244` (`rebuild_bm25_index()` invoked on every `Database::open`).
-
-The BM25 inverted index is not persisted. On `Database::open` it is rebuilt in-memory by scanning every document in the collection. For a 100 K-document corpus this adds a few hundred milliseconds at startup; for multi-million-document corpora the cold-start penalty is proportionally larger.
-
-**User impact**: higher-than-expected latency on the first query after process start for text-heavy workloads. Steady-state query latency is unaffected.
-
-**Resolution path**: implement `Bm25Snapshot` with `save()` / `load()` mirroring the HNSW graph persistence pattern (`hnsw.bin`), plus an incremental update layer that keeps the on-disk snapshot in sync with write operations.
-
----
-
 ## Reading this document
 
 Each entry states:


### PR DESCRIPTION
## Summary

Removes KNOWN_LIMITATIONS entry #4 ("BM25 cold-start triggers an O(N) rebuild") now that PR #619 (#389) landed BM25 persistence via snapshot + WAL hybrid.

Promised in PR #619 description as post-merge follow-up. Zero code change, docs-only.

## Test plan

- [x] `grep "BM25.*cold" docs/reference/KNOWN_LIMITATIONS.md` → no matches
- [x] Rendered doc reads coherently without the entry (was the only item in "Full-text search" section which is now removed too)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/620" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
