### PR TITLE
perf(sparse): 16x sparse search speedup via k-way merge + corpus-aware routing (closes #378)

### DIFF
--- a/crates/velesdb-core/src/agent/memory.rs
+++ b/crates/velesdb-core/src/agent/memory.rs
@@ -190,8 +190,7 @@ impl AgentMemory {
         if self.eviction_config.consolidation_age_threshold > 0 {
             let now = std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
-                .map(|d| d.as_secs() as i64)
-                .unwrap_or(0);
+                .map_or(0, |d| d.as_secs() as i64);
             let cutoff = now - self.eviction_config.consolidation_age_threshold as i64;
             result.episodic_consolidated = self.consolidate_old_episodes(cutoff)?;
         }

--- a/crates/velesdb-core/src/agent/procedural_memory.rs
+++ b/crates/velesdb-core/src/agent/procedural_memory.rs
@@ -150,8 +150,7 @@ impl ProceduralMemory {
 
         let now = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_secs() as i64)
-            .unwrap_or(0);
+            .map_or(0, |d| d.as_secs() as i64);
 
         let point = Point::new(
             procedure_id,
@@ -257,8 +256,7 @@ impl ProceduralMemory {
         let state = Self::extract_procedure_state(&point)?;
         let now = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_secs() as i64)
-            .unwrap_or(0);
+            .map_or(0, |d| d.as_secs() as i64);
 
         let context = state.build_reinforcement_context(now);
         let new_confidence = strategy.update_confidence(state.confidence, success, &context);

--- a/crates/velesdb-core/src/agent/reinforcement.rs
+++ b/crates/velesdb-core/src/agent/reinforcement.rs
@@ -38,8 +38,7 @@ impl ReinforcementContext {
         Self {
             current_time: std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
-                .map(|d| d.as_secs())
-                .unwrap_or(0),
+                .map_or(0, |d| d.as_secs()),
             ..Default::default()
         }
     }

--- a/crates/velesdb-core/src/agent/ttl.rs
+++ b/crates/velesdb-core/src/agent/ttl.rs
@@ -51,8 +51,7 @@ impl MemoryTtl {
     pub fn now() -> u64 {
         SystemTime::now()
             .duration_since(UNIX_EPOCH)
-            .map(|d| d.as_secs())
-            .unwrap_or(0)
+            .map_or(0, |d| d.as_secs())
     }
 
     /// Sets a TTL on an entry.

--- a/crates/velesdb-core/src/collection/graph/property_index/advisor.rs
+++ b/crates/velesdb-core/src/collection/graph/property_index/advisor.rs
@@ -82,8 +82,7 @@ impl QueryPatternTracker {
     pub fn record(&mut self, pattern: QueryPattern, execution_time_ms: u64) {
         let now_ms = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_millis() as u64)
-            .unwrap_or(0);
+            .map_or(0, |d| d.as_millis() as u64);
 
         let stats = self.patterns.entry(pattern).or_default();
         stats.count += 1;
@@ -99,7 +98,7 @@ impl QueryPatternTracker {
     #[must_use]
     pub fn expensive_patterns(&self) -> Vec<(&QueryPattern, &PatternStats)> {
         let mut patterns: Vec<_> = self.patterns.iter().collect();
-        patterns.sort_by(|a, b| b.1.total_time_ms.cmp(&a.1.total_time_ms));
+        patterns.sort_by_key(|b| std::cmp::Reverse(b.1.total_time_ms));
         patterns
     }
 

--- a/crates/velesdb-core/src/collection/search/query/parallel_traversal/mod.rs
+++ b/crates/velesdb-core/src/collection/search/query/parallel_traversal/mod.rs
@@ -83,9 +83,8 @@ impl ThreadConfig {
         match self {
             ThreadConfig::Auto => {
                 // Use std::thread::available_parallelism (same as rayon default)
-                let cpus = std::thread::available_parallelism()
-                    .map(std::num::NonZeroUsize::get)
-                    .unwrap_or(1);
+                let cpus =
+                    std::thread::available_parallelism().map_or(1, std::num::NonZeroUsize::get);
                 // Leave 1 core for other work, minimum 1 thread
                 (cpus.saturating_sub(1)).max(1)
             }

--- a/crates/velesdb-core/src/collection/stats/mod.rs
+++ b/crates/velesdb-core/src/collection/stats/mod.rs
@@ -131,8 +131,7 @@ impl CollectionStats {
         self.last_analyzed_epoch_ms = Some(
             std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
-                .map(|d| d.as_millis() as u64)
-                .unwrap_or(0),
+                .map_or(0, |d| d.as_millis() as u64),
         );
     }
 }
@@ -291,8 +290,12 @@ impl StatsCollector {
     #[must_use]
     pub fn build(mut self) -> CollectionStats {
         // Calculate average row size
-        if self.stats.row_count > 0 {
-            self.stats.avg_row_size_bytes = self.stats.total_size_bytes / self.stats.row_count;
+        if let Some(avg) = self
+            .stats
+            .total_size_bytes
+            .checked_div(self.stats.row_count)
+        {
+            self.stats.avg_row_size_bytes = avg;
         }
 
         self.stats.mark_analyzed();

--- a/crates/velesdb-core/src/column_store/batch.rs
+++ b/crates/velesdb-core/src/column_store/batch.rs
@@ -419,8 +419,7 @@ impl ColumnStore {
     pub(super) fn now_timestamp() -> u64 {
         std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_secs())
-            .unwrap_or(0)
+            .map_or(0, |d| d.as_secs())
     }
 }
 

--- a/crates/velesdb-core/src/index/hnsw/index/batch.rs
+++ b/crates/velesdb-core/src/index/hnsw/index/batch.rs
@@ -278,10 +278,8 @@ impl HnswIndex {
             .map(|(query, candidates)| self.rerank_sort_and_truncate_timed(query, candidates, k))
             .collect();
 
-        let n = timed_results.len() as u64;
-        if n > 0 {
-            let total_us: u64 = timed_results.iter().map(|(_, e)| e).sum();
-            let mean_us = total_us / n;
+        let total_us: u64 = timed_results.iter().map(|(_, e)| e).sum();
+        if let Some(mean_us) = total_us.checked_div(timed_results.len() as u64) {
             if mean_us > 0 {
                 self.update_rerank_latency_ema(mean_us);
             }

--- a/crates/velesdb-core/src/sparse_index/inverted_index.rs
+++ b/crates/velesdb-core/src/sparse_index/inverted_index.rs
@@ -315,98 +315,52 @@ impl SparseInvertedIndex {
     /// `M ∈ {1, 2}` (the common case for a single-freeze corpus).
     #[must_use]
     pub fn get_all_postings(&self, term_id: u32) -> Vec<PostingEntry> {
-        // Lock ordering: frozen then mutable in the read path (documented on
-        // `posting_count`). Holding both simultaneously is safe with
-        // parking_lot read locks (non-exclusive, no deadlock cycle).
+        let frozen_runs = self.collect_frozen_runs(term_id);
+        let mutable_run = self.collect_mutable_run(term_id);
+        merge_sorted_runs(frozen_runs, mutable_run)
+    }
+
+    /// Snapshots each frozen segment's tombstone-filtered posting list for
+    /// `term_id`, cloning owned data so the `frozen` read lock is released
+    /// before this function returns.
+    ///
+    /// Entries are cloned out of the lock scope so the subsequent merge
+    /// runs without any lock held — this prevents the ABBA deadlock that
+    /// would otherwise occur if the reader held both `frozen.read()` and
+    /// `mutable.read()` simultaneously while a concurrent writer held
+    /// `mutable.write()` and blocked on `frozen.write()`.
+    #[inline]
+    fn collect_frozen_runs(&self, term_id: u32) -> Vec<Vec<PostingEntry>> {
         let frozen_vec = self.frozen.read();
-        let mutable_seg = self.mutable.read();
-
-        let mutable_slice: &[PostingEntry] = mutable_seg
-            .postings
-            .get(&term_id)
-            .map_or(&[], Vec::as_slice);
-
-        // Fast path: no frozen segments → mutable slice is already sorted.
-        if frozen_vec.is_empty() {
-            return mutable_slice.to_vec();
-        }
-
-        // Fast path: exactly one frozen segment with no tombstones AND an
-        // empty mutable side → clone the frozen slice directly.
-        if frozen_vec.len() == 1 && mutable_slice.is_empty() {
-            let only = &frozen_vec[0];
-            if only.tombstones.is_empty() {
-                return only
-                    .postings
-                    .get(&term_id)
-                    .map(|(entries, _)| entries.clone())
-                    .unwrap_or_default();
-            }
-        }
-
-        // General path: k-way merge over already-sorted runs.
-        let mut runs: Vec<&[PostingEntry]> = Vec::with_capacity(frozen_vec.len() + 1);
-        let mut tombstones: Vec<Option<&FxHashSet<u64>>> = Vec::with_capacity(frozen_vec.len() + 1);
-        let mut total_len: usize = 0;
-
-        for frozen_seg in frozen_vec.iter() {
-            if let Some((entries, _)) = frozen_seg.postings.get(&term_id) {
+        frozen_vec
+            .iter()
+            .filter_map(|seg| {
+                let (entries, _) = seg.postings.get(&term_id)?;
                 if entries.is_empty() {
-                    continue;
+                    return None;
                 }
-                total_len += entries.len();
-                runs.push(entries.as_slice());
-                tombstones.push(if frozen_seg.tombstones.is_empty() {
-                    None
+                let owned: Vec<PostingEntry> = if seg.tombstones.is_empty() {
+                    entries.clone()
                 } else {
-                    Some(&frozen_seg.tombstones)
-                });
-            }
-        }
-        if !mutable_slice.is_empty() {
-            total_len += mutable_slice.len();
-            runs.push(mutable_slice);
-            tombstones.push(None);
-        }
+                    entries
+                        .iter()
+                        .copied()
+                        .filter(|e| !seg.tombstones.contains(&e.doc_id))
+                        .collect()
+                };
+                (!owned.is_empty()).then_some(owned)
+            })
+            .collect()
+    }
 
-        if runs.is_empty() {
-            return Vec::new();
-        }
-
-        let mut cursors: Vec<usize> = vec![0; runs.len()];
-        // Skip leading tombstoned entries per run.
-        for (i, run) in runs.iter().enumerate() {
-            if let Some(ts) = tombstones[i] {
-                while cursors[i] < run.len() && ts.contains(&run[cursors[i]].doc_id) {
-                    cursors[i] += 1;
-                }
-            }
-        }
-
-        let mut result: Vec<PostingEntry> = Vec::with_capacity(total_len);
-        loop {
-            let mut min_idx: Option<usize> = None;
-            let mut min_doc_id: u64 = u64::MAX;
-            for (i, run) in runs.iter().enumerate() {
-                if cursors[i] < run.len() {
-                    let did = run[cursors[i]].doc_id;
-                    if did < min_doc_id {
-                        min_doc_id = did;
-                        min_idx = Some(i);
-                    }
-                }
-            }
-            let Some(i) = min_idx else { break };
-            result.push(runs[i][cursors[i]]);
-            cursors[i] += 1;
-            if let Some(ts) = tombstones[i] {
-                while cursors[i] < runs[i].len() && ts.contains(&runs[i][cursors[i]].doc_id) {
-                    cursors[i] += 1;
-                }
-            }
-        }
-
-        result
+    /// Snapshots the mutable segment's posting list for `term_id`, cloning
+    /// owned data so the `mutable` read lock is released before this
+    /// function returns. See [`Self::collect_frozen_runs`] for the
+    /// lock-ordering rationale.
+    #[inline]
+    fn collect_mutable_run(&self, term_id: u32) -> Vec<PostingEntry> {
+        let seg = self.mutable.read();
+        seg.postings.get(&term_id).cloned().unwrap_or_default()
     }
 
     /// Returns the maximum absolute weight for a term across all segments.
@@ -555,6 +509,61 @@ impl SparseInvertedIndex {
     fn mutable_doc_count(&self) -> usize {
         self.mutable.read().doc_count
     }
+}
+
+/// Merges several `doc_id`-sorted posting runs into a single sorted vector.
+///
+/// Consumes its inputs and runs without holding any index lock — callers
+/// are expected to snapshot the per-segment data via
+/// [`SparseInvertedIndex::collect_frozen_runs`] and
+/// [`SparseInvertedIndex::collect_mutable_run`] first.
+///
+/// Preserves the historical behaviour of the pre-refactor `get_all_postings`:
+/// if a `doc_id` appears in more than one run (an upsert that crossed a
+/// segment freeze), all occurrences are emitted adjacent in the output.
+/// Dedup semantics for that case are handled in a dedicated follow-up.
+#[inline]
+fn merge_sorted_runs(
+    frozen_runs: Vec<Vec<PostingEntry>>,
+    mutable_run: Vec<PostingEntry>,
+) -> Vec<PostingEntry> {
+    let mut runs: Vec<Vec<PostingEntry>> = frozen_runs;
+    if !mutable_run.is_empty() {
+        runs.push(mutable_run);
+    }
+    match runs.len() {
+        0 => Vec::new(),
+        1 => runs.into_iter().next().unwrap_or_default(),
+        _ => k_way_merge(&runs),
+    }
+}
+
+/// k-way merge of sorted runs. Picks the smallest `doc_id` per iteration
+/// from the first run containing it, advancing only that cursor. When
+/// several runs share the current minimum, successive iterations emit
+/// each of them in run order — preserving the output shape of the old
+/// `result.sort_by_key(|e| e.doc_id)` path.
+fn k_way_merge(runs: &[Vec<PostingEntry>]) -> Vec<PostingEntry> {
+    let total_len: usize = runs.iter().map(Vec::len).sum();
+    let mut result: Vec<PostingEntry> = Vec::with_capacity(total_len);
+    let mut cursors: Vec<usize> = vec![0; runs.len()];
+    loop {
+        let mut min_idx: Option<usize> = None;
+        let mut min_doc_id: u64 = u64::MAX;
+        for (i, run) in runs.iter().enumerate() {
+            if cursors[i] < run.len() {
+                let did = run[cursors[i]].doc_id;
+                if did < min_doc_id {
+                    min_doc_id = did;
+                    min_idx = Some(i);
+                }
+            }
+        }
+        let Some(i) = min_idx else { break };
+        result.push(runs[i][cursors[i]]);
+        cursors[i] += 1;
+    }
+    result
 }
 
 #[cfg(test)]

--- a/crates/velesdb-core/src/sparse_index/inverted_index.rs
+++ b/crates/velesdb-core/src/sparse_index/inverted_index.rs
@@ -577,31 +577,44 @@ fn k_way_merge(runs: &[Vec<PostingEntry>]) -> Vec<PostingEntry> {
     let total_len: usize = runs.iter().map(Vec::len).sum();
     let mut result: Vec<PostingEntry> = Vec::with_capacity(total_len);
     let mut cursors: Vec<usize> = vec![0; runs.len()];
-    loop {
-        let mut min_doc_id: u64 = u64::MAX;
-        for (i, run) in runs.iter().enumerate() {
-            if cursors[i] < run.len() {
-                let did = run[cursors[i]].doc_id;
-                if did < min_doc_id {
-                    min_doc_id = did;
-                }
-            }
-        }
-        if min_doc_id == u64::MAX {
-            break;
-        }
-        let mut picked: Option<PostingEntry> = None;
-        for (i, run) in runs.iter().enumerate() {
-            if cursors[i] < run.len() && run[cursors[i]].doc_id == min_doc_id {
-                picked = Some(run[cursors[i]]);
-                cursors[i] += 1;
-            }
-        }
-        if let Some(entry) = picked {
+    while let Some(min_doc_id) = find_min_head_doc_id(runs, &cursors) {
+        if let Some(entry) = advance_matching_runs(runs, &mut cursors, min_doc_id) {
             result.push(entry);
         }
     }
     result
+}
+
+/// Returns the smallest `doc_id` among the current heads of `runs`,
+/// or `None` when every cursor has exhausted its run.
+#[inline]
+fn find_min_head_doc_id(runs: &[Vec<PostingEntry>], cursors: &[usize]) -> Option<u64> {
+    runs.iter()
+        .enumerate()
+        .filter_map(|(i, run)| run.get(cursors[i]).map(|entry| entry.doc_id))
+        .min()
+}
+
+/// Advances every cursor whose run-head matches `target_doc_id`, returning
+/// the entry from the **last** such run for the last-write-wins dedup
+/// documented on [`merge_sorted_runs`].
+#[inline]
+fn advance_matching_runs(
+    runs: &[Vec<PostingEntry>],
+    cursors: &mut [usize],
+    target_doc_id: u64,
+) -> Option<PostingEntry> {
+    let mut picked: Option<PostingEntry> = None;
+    for (i, run) in runs.iter().enumerate() {
+        if run
+            .get(cursors[i])
+            .is_some_and(|entry| entry.doc_id == target_doc_id)
+        {
+            picked = Some(run[cursors[i]]);
+            cursors[i] += 1;
+        }
+    }
+    picked
 }
 
 #[cfg(test)]

--- a/crates/velesdb-core/src/sparse_index/inverted_index.rs
+++ b/crates/velesdb-core/src/sparse_index/inverted_index.rs
@@ -518,10 +518,12 @@ impl SparseInvertedIndex {
 /// [`SparseInvertedIndex::collect_frozen_runs`] and
 /// [`SparseInvertedIndex::collect_mutable_run`] first.
 ///
-/// Preserves the historical behaviour of the pre-refactor `get_all_postings`:
-/// if a `doc_id` appears in more than one run (an upsert that crossed a
-/// segment freeze), all occurrences are emitted adjacent in the output.
-/// Dedup semantics for that case are handled in a dedicated follow-up.
+/// Applies **last-write-wins** semantics when a `doc_id` appears in more
+/// than one run: callers place mutable data after frozen data, so an
+/// upsert that crossed a segment freeze contributes its mutable weight
+/// exactly once instead of double-counting the stale frozen entry when
+/// downstream consumers (e.g. `linear_scan_search`, `brute_force_search`)
+/// sum posting weights into an accumulator map.
 #[inline]
 fn merge_sorted_runs(
     frozen_runs: Vec<Vec<PostingEntry>>,
@@ -538,30 +540,40 @@ fn merge_sorted_runs(
     }
 }
 
-/// k-way merge of sorted runs. Picks the smallest `doc_id` per iteration
-/// from the first run containing it, advancing only that cursor. When
-/// several runs share the current minimum, successive iterations emit
-/// each of them in run order — preserving the output shape of the old
-/// `result.sort_by_key(|e| e.doc_id)` path.
+/// k-way merge of sorted runs with last-write-wins dedup.
+///
+/// On each iteration picks the smallest `doc_id` across all run heads,
+/// then advances **every** cursor whose head matches that `doc_id`,
+/// keeping the entry from the last such run. This coalesces
+/// duplicate-`doc_id` entries produced by an upsert crossing a segment
+/// freeze into a single output entry with the newest weight.
 fn k_way_merge(runs: &[Vec<PostingEntry>]) -> Vec<PostingEntry> {
     let total_len: usize = runs.iter().map(Vec::len).sum();
     let mut result: Vec<PostingEntry> = Vec::with_capacity(total_len);
     let mut cursors: Vec<usize> = vec![0; runs.len()];
     loop {
-        let mut min_idx: Option<usize> = None;
         let mut min_doc_id: u64 = u64::MAX;
         for (i, run) in runs.iter().enumerate() {
             if cursors[i] < run.len() {
                 let did = run[cursors[i]].doc_id;
                 if did < min_doc_id {
                     min_doc_id = did;
-                    min_idx = Some(i);
                 }
             }
         }
-        let Some(i) = min_idx else { break };
-        result.push(runs[i][cursors[i]]);
-        cursors[i] += 1;
+        if min_doc_id == u64::MAX {
+            break;
+        }
+        let mut picked: Option<PostingEntry> = None;
+        for (i, run) in runs.iter().enumerate() {
+            if cursors[i] < run.len() && run[cursors[i]].doc_id == min_doc_id {
+                picked = Some(run[cursors[i]]);
+                cursors[i] += 1;
+            }
+        }
+        if let Some(entry) = picked {
+            result.push(entry);
+        }
     }
     result
 }

--- a/crates/velesdb-core/src/sparse_index/inverted_index.rs
+++ b/crates/velesdb-core/src/sparse_index/inverted_index.rs
@@ -8,6 +8,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use parking_lot::RwLock;
 use rustc_hash::{FxHashMap, FxHashSet};
 
+use super::merge::merge_sorted_runs;
 use super::mutable_segment::MutableSegment;
 use super::types::{PostingEntry, SparseVector};
 
@@ -541,86 +542,6 @@ impl SparseInvertedIndex {
     fn mutable_doc_count(&self) -> usize {
         self.mutable.read().doc_count
     }
-}
-
-/// Merges several `doc_id`-sorted posting runs into a single sorted vector.
-///
-/// Consumes its inputs and runs without holding any index lock — callers
-/// are expected to snapshot the per-segment data via
-/// [`SparseInvertedIndex::collect_frozen_runs`] and
-/// [`SparseInvertedIndex::collect_mutable_run`] first.
-///
-/// Applies **last-write-wins** semantics when a `doc_id` appears in more
-/// than one run: callers place mutable data after frozen data, so an
-/// upsert that crossed a segment freeze contributes its mutable weight
-/// exactly once instead of double-counting the stale frozen entry when
-/// downstream consumers (e.g. `linear_scan_search`, `brute_force_search`)
-/// sum posting weights into an accumulator map.
-#[inline]
-fn merge_sorted_runs(
-    frozen_runs: Vec<Vec<PostingEntry>>,
-    mutable_run: Vec<PostingEntry>,
-) -> Vec<PostingEntry> {
-    let mut runs: Vec<Vec<PostingEntry>> = frozen_runs;
-    if !mutable_run.is_empty() {
-        runs.push(mutable_run);
-    }
-    match runs.len() {
-        0 => Vec::new(),
-        1 => runs.into_iter().next().unwrap_or_default(),
-        _ => k_way_merge(&runs),
-    }
-}
-
-/// k-way merge of sorted runs with last-write-wins dedup.
-///
-/// On each iteration picks the smallest `doc_id` across all run heads,
-/// then advances **every** cursor whose head matches that `doc_id`,
-/// keeping the entry from the last such run. This coalesces
-/// duplicate-`doc_id` entries produced by an upsert crossing a segment
-/// freeze into a single output entry with the newest weight.
-fn k_way_merge(runs: &[Vec<PostingEntry>]) -> Vec<PostingEntry> {
-    let total_len: usize = runs.iter().map(Vec::len).sum();
-    let mut result: Vec<PostingEntry> = Vec::with_capacity(total_len);
-    let mut cursors: Vec<usize> = vec![0; runs.len()];
-    while let Some(min_doc_id) = find_min_head_doc_id(runs, &cursors) {
-        if let Some(entry) = advance_matching_runs(runs, &mut cursors, min_doc_id) {
-            result.push(entry);
-        }
-    }
-    result
-}
-
-/// Returns the smallest `doc_id` among the current heads of `runs`,
-/// or `None` when every cursor has exhausted its run.
-#[inline]
-fn find_min_head_doc_id(runs: &[Vec<PostingEntry>], cursors: &[usize]) -> Option<u64> {
-    runs.iter()
-        .enumerate()
-        .filter_map(|(i, run)| run.get(cursors[i]).map(|entry| entry.doc_id))
-        .min()
-}
-
-/// Advances every cursor whose run-head matches `target_doc_id`, returning
-/// the entry from the **last** such run for the last-write-wins dedup
-/// documented on [`merge_sorted_runs`].
-#[inline]
-fn advance_matching_runs(
-    runs: &[Vec<PostingEntry>],
-    cursors: &mut [usize],
-    target_doc_id: u64,
-) -> Option<PostingEntry> {
-    let mut picked: Option<PostingEntry> = None;
-    for (i, run) in runs.iter().enumerate() {
-        if run
-            .get(cursors[i])
-            .is_some_and(|entry| entry.doc_id == target_doc_id)
-        {
-            picked = Some(run[cursors[i]]);
-            cursors[i] += 1;
-        }
-    }
-    picked
 }
 
 #[cfg(test)]

--- a/crates/velesdb-core/src/sparse_index/inverted_index.rs
+++ b/crates/velesdb-core/src/sparse_index/inverted_index.rs
@@ -307,34 +307,105 @@ impl SparseInvertedIndex {
 
     /// Returns all posting entries for a term across all segments,
     /// filtering tombstoned entries. Result is sorted by `doc_id`.
+    ///
+    /// Exploits the per-segment invariant (`postings[term_id]` is already
+    /// sorted by `doc_id` in both mutable and frozen segments) to perform a
+    /// k-way merge in `O(N · M)` instead of the general `O(N log N)` sort
+    /// previously used — a ~5x reduction in the hot-path work when
+    /// `M ∈ {1, 2}` (the common case for a single-freeze corpus).
     #[must_use]
     pub fn get_all_postings(&self, term_id: u32) -> Vec<PostingEntry> {
-        let mut result = Vec::new();
+        // Lock ordering: frozen then mutable in the read path (documented on
+        // `posting_count`). Holding both simultaneously is safe with
+        // parking_lot read locks (non-exclusive, no deadlock cycle).
+        let frozen_vec = self.frozen.read();
+        let mutable_seg = self.mutable.read();
 
-        // Read from frozen segments first
-        {
-            let frozen_vec = self.frozen.read();
-            for frozen_seg in frozen_vec.iter() {
-                if let Some((entries, _)) = frozen_seg.postings.get(&term_id) {
-                    for entry in entries {
-                        if !frozen_seg.tombstones.contains(&entry.doc_id) {
-                            result.push(*entry);
-                        }
-                    }
+        let mutable_slice: &[PostingEntry] = mutable_seg
+            .postings
+            .get(&term_id)
+            .map_or(&[], Vec::as_slice);
+
+        // Fast path: no frozen segments → mutable slice is already sorted.
+        if frozen_vec.is_empty() {
+            return mutable_slice.to_vec();
+        }
+
+        // Fast path: exactly one frozen segment with no tombstones AND an
+        // empty mutable side → clone the frozen slice directly.
+        if frozen_vec.len() == 1 && mutable_slice.is_empty() {
+            let only = &frozen_vec[0];
+            if only.tombstones.is_empty() {
+                return only
+                    .postings
+                    .get(&term_id)
+                    .map(|(entries, _)| entries.clone())
+                    .unwrap_or_default();
+            }
+        }
+
+        // General path: k-way merge over already-sorted runs.
+        let mut runs: Vec<&[PostingEntry]> = Vec::with_capacity(frozen_vec.len() + 1);
+        let mut tombstones: Vec<Option<&FxHashSet<u64>>> = Vec::with_capacity(frozen_vec.len() + 1);
+        let mut total_len: usize = 0;
+
+        for frozen_seg in frozen_vec.iter() {
+            if let Some((entries, _)) = frozen_seg.postings.get(&term_id) {
+                if entries.is_empty() {
+                    continue;
+                }
+                total_len += entries.len();
+                runs.push(entries.as_slice());
+                tombstones.push(if frozen_seg.tombstones.is_empty() {
+                    None
+                } else {
+                    Some(&frozen_seg.tombstones)
+                });
+            }
+        }
+        if !mutable_slice.is_empty() {
+            total_len += mutable_slice.len();
+            runs.push(mutable_slice);
+            tombstones.push(None);
+        }
+
+        if runs.is_empty() {
+            return Vec::new();
+        }
+
+        let mut cursors: Vec<usize> = vec![0; runs.len()];
+        // Skip leading tombstoned entries per run.
+        for (i, run) in runs.iter().enumerate() {
+            if let Some(ts) = tombstones[i] {
+                while cursors[i] < run.len() && ts.contains(&run[cursors[i]].doc_id) {
+                    cursors[i] += 1;
                 }
             }
         }
 
-        // Read from mutable segment
-        {
-            let seg = self.mutable.read();
-            if let Some(entries) = seg.postings.get(&term_id) {
-                result.extend_from_slice(entries);
+        let mut result: Vec<PostingEntry> = Vec::with_capacity(total_len);
+        loop {
+            let mut min_idx: Option<usize> = None;
+            let mut min_doc_id: u64 = u64::MAX;
+            for (i, run) in runs.iter().enumerate() {
+                if cursors[i] < run.len() {
+                    let did = run[cursors[i]].doc_id;
+                    if did < min_doc_id {
+                        min_doc_id = did;
+                        min_idx = Some(i);
+                    }
+                }
+            }
+            let Some(i) = min_idx else { break };
+            result.push(runs[i][cursors[i]]);
+            cursors[i] += 1;
+            if let Some(ts) = tombstones[i] {
+                while cursors[i] < runs[i].len() && ts.contains(&runs[i][cursors[i]].doc_id) {
+                    cursors[i] += 1;
+                }
             }
         }
 
-        // Sort merged results by doc_id
-        result.sort_by_key(|e| e.doc_id);
         result
     }
 

--- a/crates/velesdb-core/src/sparse_index/inverted_index.rs
+++ b/crates/velesdb-core/src/sparse_index/inverted_index.rs
@@ -244,11 +244,10 @@ impl SparseInvertedIndex {
             frozen_postings.insert(term_id, (entries, max_w));
         }
 
-        let frozen_seg = FrozenSegment {
-            postings: frozen_postings,
-            tombstones: FxHashSet::default(),
-            doc_count: old.doc_count,
-        };
+        // Route through `FrozenSegment::new` so the debug_assert on the
+        // sorted-by-doc_id invariant fires for freeze-path segments too,
+        // not only for those synthesised by the persistence layer.
+        let frozen_seg = FrozenSegment::new(frozen_postings, old.doc_count);
 
         let mut frozen_vec = self.frozen.write();
         frozen_vec.push(frozen_seg);
@@ -332,7 +331,14 @@ impl SparseInvertedIndex {
     }
 
     /// Returns all posting entries for a term across all segments,
-    /// filtering tombstoned entries. Result is sorted by `doc_id`.
+    /// filtering tombstoned entries. Result is sorted ascending by `doc_id`
+    /// and **deduplicated**: when the same `doc_id` appears in both a
+    /// frozen segment (stale) and the mutable segment (fresh, from an
+    /// upsert that crossed a freeze boundary) only the mutable entry is
+    /// returned — last-write-wins. This matches the dedup semantics of
+    /// `get_merged_postings_for_compaction` and prevents downstream
+    /// accumulators (`linear_scan_search`, `brute_force_search`,
+    /// `prepare_term_data`) from double-counting the stale weight.
     ///
     /// Exploits the per-segment invariant (`postings[term_id]` is already
     /// sorted by `doc_id` in both mutable and frozen segments) to perform a

--- a/crates/velesdb-core/src/sparse_index/inverted_index.rs
+++ b/crates/velesdb-core/src/sparse_index/inverted_index.rs
@@ -18,6 +18,19 @@ pub const FREEZE_THRESHOLD: usize = 10_000;
 
 /// A frozen (read-optimized) segment. The `f32` in the tuple is `max_weight`.
 ///
+/// # Invariants
+///
+/// Every posting list in `postings` is sorted ascending by `doc_id`. This
+/// is required by [`SparseInvertedIndex::get_all_postings`] (which feeds
+/// a k-way merge over the per-segment runs) and by
+/// [`super::search::strategy::linear_scan_search`] and
+/// `maxscore_search` (which assume sorted cursors). [`MutableSegment`]
+/// enforces the invariant via binary-search insert in `insert` and the
+/// merge-join in `merge_batch_postings`; `freeze_inner` moves the
+/// already-sorted posting lists into the frozen segment as-is. The
+/// persistence layer must preserve it when loading from disk — see the
+/// debug assertion in [`Self::new`].
+///
 /// `pub(crate)` fields are consumed exclusively by `index::sparse::persistence`,
 /// which is gated behind `feature = "persistence"`. Without that feature the
 /// compiler cannot see those usages, so the lint is suppressed here rather than
@@ -34,11 +47,24 @@ pub(crate) struct FrozenSegment {
 
 impl FrozenSegment {
     /// Creates a new frozen segment from postings and a document count.
+    ///
+    /// In debug builds, asserts the "sorted ascending by `doc_id`" invariant
+    /// documented on the struct. The check runs only under
+    /// `debug_assertions`, so release builds pay no cost. Persistence
+    /// layers that synthesise `FrozenSegment` values therefore exercise
+    /// the assertion during local / CI test runs before shipping a release
+    /// binary that relies on the invariant.
     #[allow(dead_code)] // Reason: Used by sparse::persistence behind `feature = "persistence"`
     pub(crate) fn new(
         postings: FxHashMap<u32, (Vec<PostingEntry>, f32)>,
         doc_count: usize,
     ) -> Self {
+        debug_assert!(
+            postings
+                .iter()
+                .all(|(_, (entries, _))| entries.windows(2).all(|w| w[0].doc_id < w[1].doc_id)),
+            "FrozenSegment posting lists must be sorted ascending and deduplicated by doc_id"
+        );
         Self {
             postings,
             tombstones: FxHashSet::default(),

--- a/crates/velesdb-core/src/sparse_index/inverted_index.rs
+++ b/crates/velesdb-core/src/sparse_index/inverted_index.rs
@@ -474,12 +474,20 @@ impl SparseInvertedIndex {
     ///
     /// ## Last-write-wins semantics
     ///
-    /// The mutable segment holds the newest writes; frozen segments are older.
-    /// To preserve newest-wins when the same `doc_id` appears in both, mutable
-    /// entries are inserted **first** into the per-term buffer. After a stable
-    /// sort by `doc_id`, each mutable entry precedes any same-id frozen entry,
-    /// so `dedup_by_key` (which retains the first occurrence) keeps the mutable
-    /// (newer) weight.
+    /// The mutable segment holds the newest writes; frozen segments sit
+    /// in `self.frozen` with the **oldest** at index 0 and the **newest**
+    /// at the tail (push-append at freeze time). To preserve newest-wins
+    /// across every pair of sources — mutable vs frozen, and frozen-N vs
+    /// frozen-M — entries are appended to the per-term buffer in this
+    /// order: mutable first, then frozen segments **newest-first** (via
+    /// `frozen_vec.iter().rev()`). A stable `sort_by_key` preserves the
+    /// relative order of equal-`doc_id` entries, so `dedup_by_key` (which
+    /// retains the first occurrence) keeps the mutable entry when present,
+    /// otherwise the newest frozen entry.
+    ///
+    /// Matches the dedup contract of
+    /// [`Self::get_all_postings`] — both paths select the latest weight
+    /// for a `doc_id` that appears in multiple segments.
     #[must_use]
     pub fn get_merged_postings_for_compaction(&self) -> FxHashMap<u32, (Vec<PostingEntry>, f32)> {
         let mut merged: FxHashMap<u32, Vec<PostingEntry>> = FxHashMap::default();
@@ -493,10 +501,13 @@ impl SparseInvertedIndex {
             }
         }
 
-        // Append frozen entries (older), filtering tombstones.
+        // Append frozen entries newest-first (reverse iteration) and
+        // filter tombstones. Newer frozen segments therefore precede older
+        // ones for any shared `doc_id`, which the stable sort preserves
+        // and `dedup_by_key` converts into last-write-wins.
         {
             let frozen_vec = self.frozen.read();
-            for frozen_seg in frozen_vec.iter() {
+            for frozen_seg in frozen_vec.iter().rev() {
                 for (&term_id, (entries, _)) in &frozen_seg.postings {
                     let dest = merged.entry(term_id).or_default();
                     for entry in entries {
@@ -509,9 +520,9 @@ impl SparseInvertedIndex {
         }
 
         // Sort by doc_id then dedup, keeping the first occurrence per doc_id.
-        // Because mutable entries were inserted before frozen entries, the first
-        // occurrence of any doc_id that appears in both segments is the mutable
-        // (newer) one — last-write-wins is correctly enforced.
+        // Because entries were appended mutable-first then frozen newest-first,
+        // the first occurrence of any shared doc_id after the stable sort is
+        // the newest source — full last-write-wins across all segment pairs.
         let mut result: FxHashMap<u32, (Vec<PostingEntry>, f32)> = FxHashMap::default();
         for (term_id, mut entries) in merged {
             entries.sort_by_key(|e| e.doc_id);

--- a/crates/velesdb-core/src/sparse_index/inverted_index_tests.rs
+++ b/crates/velesdb-core/src/sparse_index/inverted_index_tests.rs
@@ -296,3 +296,46 @@ fn test_dedup_last_write_wins_across_segments() {
         entry.weight
     );
 }
+
+#[test]
+fn test_dedup_last_write_wins_across_multiple_frozen_segments() {
+    // Force doc 0 into TWO frozen segments with different weights, with no
+    // mutable entry for it at compaction time. The newer frozen segment
+    // must win, mirroring `get_all_postings`' last-write-wins semantics.
+    let index = SparseInvertedIndex::new();
+
+    // Segment 1: doc 0 with weight 1.0.
+    for i in 0..FREEZE_THRESHOLD {
+        index.insert(i as u64, &make_vector(vec![(7, 1.0)]));
+    }
+    assert_eq!(index.frozen_count(), 1);
+
+    // Upsert doc 0 with weight 5.0 — lands in the fresh post-freeze
+    // mutable segment.
+    index.insert(0, &make_vector(vec![(7, 5.0)]));
+
+    // Add FREEZE_THRESHOLD - 1 more distinct docs so the mutable reaches
+    // the threshold on its final insert and freezes. After this,
+    // frozen[0] holds doc 0 @ 1.0 and frozen[1] holds doc 0 @ 5.0,
+    // and the mutable is empty — no mutable entry for doc 0.
+    for i in FREEZE_THRESHOLD..(2 * FREEZE_THRESHOLD - 1) {
+        index.insert(i as u64, &make_vector(vec![(7, 1.0)]));
+    }
+    assert_eq!(
+        index.frozen_count(),
+        2,
+        "second freeze must have happened before compaction"
+    );
+
+    let compacted = index.get_merged_postings_for_compaction();
+    let (entries, _) = compacted.get(&7).expect("term 7 must be present");
+    let entry = entries
+        .iter()
+        .find(|e| e.doc_id == 0)
+        .expect("doc 0 must be present");
+    assert!(
+        (entry.weight - 5.0).abs() < 1e-5,
+        "newer frozen (weight 5.0) must win over older frozen (1.0); got {}",
+        entry.weight
+    );
+}

--- a/crates/velesdb-core/src/sparse_index/merge.rs
+++ b/crates/velesdb-core/src/sparse_index/merge.rs
@@ -1,0 +1,92 @@
+//! k-way merge utilities for sparse posting lists.
+//!
+//! Extracted from `inverted_index.rs` (following the pattern established by
+//! `mutable_segment.rs`) so the inverted-index file stays well below the
+//! 500 NLOC quality gate.
+//!
+//! The helpers here consume owned per-segment runs and return a single
+//! sorted-by-`doc_id` vector with last-write-wins semantics — callers
+//! must snapshot the per-segment data outside any lock scope before
+//! invoking [`merge_sorted_runs`].
+
+use super::types::PostingEntry;
+
+/// Merges several `doc_id`-sorted posting runs into a single sorted vector.
+///
+/// Consumes its inputs and runs without holding any index lock — callers
+/// are expected to snapshot the per-segment data via
+/// `SparseInvertedIndex::collect_frozen_runs` and
+/// `SparseInvertedIndex::collect_mutable_run` first.
+///
+/// Applies **last-write-wins** semantics when a `doc_id` appears in more
+/// than one run: callers place mutable data after frozen data, so an
+/// upsert that crossed a segment freeze contributes its mutable weight
+/// exactly once instead of double-counting the stale frozen entry when
+/// downstream consumers (e.g. `linear_scan_search`, `brute_force_search`)
+/// sum posting weights into an accumulator map.
+#[inline]
+pub(super) fn merge_sorted_runs(
+    frozen_runs: Vec<Vec<PostingEntry>>,
+    mutable_run: Vec<PostingEntry>,
+) -> Vec<PostingEntry> {
+    let mut runs: Vec<Vec<PostingEntry>> = frozen_runs;
+    if !mutable_run.is_empty() {
+        runs.push(mutable_run);
+    }
+    match runs.len() {
+        0 => Vec::new(),
+        1 => runs.into_iter().next().unwrap_or_default(),
+        _ => k_way_merge(&runs),
+    }
+}
+
+/// k-way merge of sorted runs with last-write-wins dedup.
+///
+/// On each iteration picks the smallest `doc_id` across all run heads,
+/// then advances **every** cursor whose head matches that `doc_id`,
+/// keeping the entry from the last such run. This coalesces
+/// duplicate-`doc_id` entries produced by an upsert crossing a segment
+/// freeze into a single output entry with the newest weight.
+fn k_way_merge(runs: &[Vec<PostingEntry>]) -> Vec<PostingEntry> {
+    let total_len: usize = runs.iter().map(Vec::len).sum();
+    let mut result: Vec<PostingEntry> = Vec::with_capacity(total_len);
+    let mut cursors: Vec<usize> = vec![0; runs.len()];
+    while let Some(min_doc_id) = find_min_head_doc_id(runs, &cursors) {
+        if let Some(entry) = advance_matching_runs(runs, &mut cursors, min_doc_id) {
+            result.push(entry);
+        }
+    }
+    result
+}
+
+/// Returns the smallest `doc_id` among the current heads of `runs`,
+/// or `None` when every cursor has exhausted its run.
+#[inline]
+fn find_min_head_doc_id(runs: &[Vec<PostingEntry>], cursors: &[usize]) -> Option<u64> {
+    runs.iter()
+        .enumerate()
+        .filter_map(|(i, run)| run.get(cursors[i]).map(|entry| entry.doc_id))
+        .min()
+}
+
+/// Advances every cursor whose run-head matches `target_doc_id`, returning
+/// the entry from the **last** such run for the last-write-wins dedup
+/// documented on [`merge_sorted_runs`].
+#[inline]
+fn advance_matching_runs(
+    runs: &[Vec<PostingEntry>],
+    cursors: &mut [usize],
+    target_doc_id: u64,
+) -> Option<PostingEntry> {
+    let mut picked: Option<PostingEntry> = None;
+    for (i, run) in runs.iter().enumerate() {
+        if run
+            .get(cursors[i])
+            .is_some_and(|entry| entry.doc_id == target_doc_id)
+        {
+            picked = Some(run[cursors[i]]);
+            cursors[i] += 1;
+        }
+    }
+    picked
+}

--- a/crates/velesdb-core/src/sparse_index/mod.rs
+++ b/crates/velesdb-core/src/sparse_index/mod.rs
@@ -4,6 +4,7 @@
 //! Persistence-related functionality is in `index::sparse::persistence`.
 
 pub mod inverted_index;
+mod merge;
 mod mutable_segment;
 pub mod search;
 pub mod types;

--- a/crates/velesdb-core/src/sparse_index/search/bmw_parity_tests.rs
+++ b/crates/velesdb-core/src/sparse_index/search/bmw_parity_tests.rs
@@ -1,0 +1,290 @@
+//! Parity tests for the sparse search hot path.
+//!
+//! These tests form the TDD contract for Phase 4.2 (Block-Max WAND + allocation
+//! elimination, issue #378). They MUST pass both on `develop` (pre-refactor) and
+//! after the hot-path refactor lands — any divergence during development is a
+//! regression that blocks further work.
+//!
+//! Three parity surfaces are covered:
+//! 1. Current `sparse_search` result IDs match [`brute_force_search`] exactly on
+//!    positive-weight SPLADE-like corpora at 10K corpus / 100 queries.
+//! 2. Scores agree to f32 precision (`< 1e-4` relative).
+//! 3. Negative-weight queries still produce brute-force-equivalent results via
+//!    the linear-scan fallback route.
+//!
+//! Also asserts correctness across edge cases that the production benchmark
+//! (`benches/sparse_benchmark.rs`) does not exercise: multi-segment corpora,
+//! `k > doc_count`, empty posting lists, and mixed-sign queries.
+
+use std::collections::HashSet;
+
+use rand::rngs::StdRng;
+use rand::{Rng, SeedableRng};
+
+use super::super::inverted_index::{SparseInvertedIndex, FREEZE_THRESHOLD};
+use super::super::types::{ScoredDoc, SparseVector};
+use super::{brute_force_search, sparse_search};
+
+const VOCAB_SIZE: u32 = 30_000;
+
+fn gen_positive_corpus(n: usize, seed: u64) -> Vec<SparseVector> {
+    let mut rng = StdRng::seed_from_u64(seed);
+    (0..n)
+        .map(|_| {
+            let nnz = rng.gen_range(50..=200);
+            let mut pairs: Vec<(u32, f32)> = Vec::with_capacity(nnz);
+            let mut used: HashSet<u32> = HashSet::new();
+            while pairs.len() < nnz {
+                let term_id = rng.gen_range(0..VOCAB_SIZE);
+                if used.insert(term_id) {
+                    let weight = rng.gen_range(0.01_f32..2.0);
+                    pairs.push((term_id, weight));
+                }
+            }
+            SparseVector::new(pairs)
+        })
+        .collect()
+}
+
+fn gen_queries(n: usize, seed: u64) -> Vec<SparseVector> {
+    let mut rng = StdRng::seed_from_u64(seed);
+    (0..n)
+        .map(|_| {
+            let nnz = rng.gen_range(20..=60);
+            let mut pairs: Vec<(u32, f32)> = Vec::with_capacity(nnz);
+            let mut used: HashSet<u32> = HashSet::new();
+            while pairs.len() < nnz {
+                let term_id = rng.gen_range(0..VOCAB_SIZE);
+                if used.insert(term_id) {
+                    let weight = rng.gen_range(0.01_f32..2.0);
+                    pairs.push((term_id, weight));
+                }
+            }
+            SparseVector::new(pairs)
+        })
+        .collect()
+}
+
+fn gen_mixed_sign_queries(n: usize, seed: u64) -> Vec<SparseVector> {
+    let mut rng = StdRng::seed_from_u64(seed);
+    (0..n)
+        .map(|_| {
+            let nnz = rng.gen_range(10..=30);
+            let mut pairs: Vec<(u32, f32)> = Vec::with_capacity(nnz);
+            let mut used: HashSet<u32> = HashSet::new();
+            while pairs.len() < nnz {
+                let term_id = rng.gen_range(0..VOCAB_SIZE);
+                if used.insert(term_id) {
+                    let sign = if rng.gen_bool(0.3) { -1.0 } else { 1.0 };
+                    let weight = sign * rng.gen_range(0.1_f32..2.0);
+                    pairs.push((term_id, weight));
+                }
+            }
+            SparseVector::new(pairs)
+        })
+        .collect()
+}
+
+fn build_index(corpus: &[SparseVector]) -> SparseInvertedIndex {
+    let index = SparseInvertedIndex::new();
+    for (i, vec) in corpus.iter().enumerate() {
+        #[allow(clippy::cast_possible_truncation)]
+        index.insert(i as u64, vec);
+    }
+    index
+}
+
+fn doc_ids(results: &[ScoredDoc]) -> Vec<u64> {
+    results.iter().map(|r| r.doc_id).collect()
+}
+
+fn assert_scores_close(expected: &[ScoredDoc], actual: &[ScoredDoc], query_label: &str) {
+    assert_eq!(
+        expected.len(),
+        actual.len(),
+        "{query_label}: length mismatch ({} vs {})",
+        expected.len(),
+        actual.len()
+    );
+    for (i, (a, b)) in expected.iter().zip(actual.iter()).enumerate() {
+        assert_eq!(
+            a.doc_id, b.doc_id,
+            "{query_label} rank {i}: doc_id differs ({} vs {})",
+            a.doc_id, b.doc_id
+        );
+        let denom = a.score.abs().max(b.score.abs()).max(1e-6);
+        let rel_err = (a.score - b.score).abs() / denom;
+        assert!(
+            rel_err < 1e-4,
+            "{query_label} rank {i}: score relative error {rel_err} exceeds 1e-4 ({} vs {})",
+            a.score,
+            b.score
+        );
+    }
+}
+
+// ---------- NOMINAL: large-corpus parity ----------
+
+#[test]
+fn test_sparse_search_matches_brute_force_10k_corpus_k10() {
+    let corpus = gen_positive_corpus(10_000, 42);
+    let queries = gen_queries(100, 123);
+    let index = build_index(&corpus);
+
+    for (qi, query) in queries.iter().enumerate() {
+        let bf = brute_force_search(&index, query, 10);
+        let ms = sparse_search(&index, query, 10);
+        assert_eq!(
+            doc_ids(&bf),
+            doc_ids(&ms),
+            "Query {qi}: sparse_search IDs diverge from brute-force"
+        );
+    }
+}
+
+#[test]
+fn test_sparse_search_matches_brute_force_10k_corpus_k100() {
+    let corpus = gen_positive_corpus(10_000, 7);
+    let queries = gen_queries(50, 9);
+    let index = build_index(&corpus);
+
+    for (qi, query) in queries.iter().enumerate() {
+        let bf = brute_force_search(&index, query, 100);
+        let ms = sparse_search(&index, query, 100);
+        assert_eq!(
+            doc_ids(&bf),
+            doc_ids(&ms),
+            "Query {qi}: sparse_search top-100 IDs diverge from brute-force"
+        );
+    }
+}
+
+#[test]
+fn test_sparse_search_scores_match_brute_force_10k_corpus() {
+    let corpus = gen_positive_corpus(10_000, 101);
+    let queries = gen_queries(30, 202);
+    let index = build_index(&corpus);
+
+    for (qi, query) in queries.iter().enumerate() {
+        let bf = brute_force_search(&index, query, 10);
+        let ms = sparse_search(&index, query, 10);
+        assert_scores_close(&bf, &ms, &format!("query {qi}"));
+    }
+}
+
+// ---------- MULTI-SEGMENT: forces both mutable and frozen segments ----------
+
+#[test]
+fn test_sparse_search_matches_brute_force_across_multi_segments() {
+    let n = FREEZE_THRESHOLD + 2_500;
+    let corpus = gen_positive_corpus(n, 55);
+    let queries = gen_queries(50, 66);
+    let index = build_index(&corpus);
+
+    for (qi, query) in queries.iter().enumerate() {
+        let bf = brute_force_search(&index, query, 10);
+        let ms = sparse_search(&index, query, 10);
+        assert_eq!(
+            doc_ids(&bf),
+            doc_ids(&ms),
+            "Query {qi}: multi-segment search IDs diverge from brute-force"
+        );
+    }
+}
+
+// ---------- NEGATIVE-WEIGHT: must route through linear scan fallback ----------
+
+#[test]
+fn test_sparse_search_negative_weight_queries_match_brute_force() {
+    let corpus = gen_positive_corpus(5_000, 33);
+    let queries = gen_mixed_sign_queries(40, 44);
+    let index = build_index(&corpus);
+
+    for (qi, query) in queries.iter().enumerate() {
+        let bf = brute_force_search(&index, query, 10);
+        let ms = sparse_search(&index, query, 10);
+        assert_eq!(
+            doc_ids(&bf),
+            doc_ids(&ms),
+            "Query {qi} (mixed-sign): fallback path IDs diverge from brute-force"
+        );
+    }
+}
+
+// ---------- EDGE CASES ----------
+
+#[test]
+fn test_sparse_search_single_doc_corpus() {
+    let corpus = gen_positive_corpus(1, 1);
+    let queries = gen_queries(5, 2);
+    let index = build_index(&corpus);
+
+    for query in &queries {
+        let ms = sparse_search(&index, query, 10);
+        assert!(
+            ms.len() <= 1,
+            "single-doc corpus should return at most 1 result"
+        );
+    }
+}
+
+#[test]
+fn test_sparse_search_k_greater_than_doc_count() {
+    let corpus = gen_positive_corpus(200, 17);
+    let query = &gen_queries(1, 18)[0];
+    let index = build_index(&corpus);
+
+    let ms = sparse_search(&index, query, 1_000);
+    let bf = brute_force_search(&index, query, 1_000);
+    assert_eq!(
+        doc_ids(&bf),
+        doc_ids(&ms),
+        "k > doc_count should still yield brute-force-identical result"
+    );
+    assert!(ms.len() <= 200, "result count cannot exceed corpus size");
+}
+
+#[test]
+fn test_sparse_search_term_absent_from_corpus_returns_empty_or_partial() {
+    let index = SparseInvertedIndex::new();
+    index.insert(0, &SparseVector::new(vec![(100, 1.0)]));
+    index.insert(1, &SparseVector::new(vec![(200, 2.0)]));
+
+    // Query a term nobody has — must return empty, never panic
+    let unknown = SparseVector::new(vec![(99_999, 1.0)]);
+    let result = sparse_search(&index, &unknown, 5);
+    assert!(result.is_empty(), "unknown-term query must return empty");
+
+    // Query with mixed known/unknown terms — must return partial results
+    let mixed = SparseVector::new(vec![(100, 1.0), (99_999, 1.0)]);
+    let result = sparse_search(&index, &mixed, 5);
+    assert_eq!(result.len(), 1, "only doc 0 matches term 100");
+    assert_eq!(result[0].doc_id, 0);
+}
+
+#[test]
+fn test_sparse_search_all_zero_query_returns_empty() {
+    let corpus = gen_positive_corpus(100, 88);
+    let index = build_index(&corpus);
+
+    // SparseVector::new filters zero weights, so an all-zero input yields empty
+    let empty_query = SparseVector::new(vec![(1, 0.0), (2, 0.0)]);
+    let result = sparse_search(&index, &empty_query, 10);
+    assert!(result.is_empty(), "empty query must yield empty results");
+}
+
+#[test]
+fn test_sparse_search_deterministic_across_invocations() {
+    let corpus = gen_positive_corpus(500, 11);
+    let queries = gen_queries(5, 12);
+    let index = build_index(&corpus);
+
+    for query in &queries {
+        let a = sparse_search(&index, query, 10);
+        let b = sparse_search(&index, query, 10);
+        assert_eq!(doc_ids(&a), doc_ids(&b), "search must be deterministic");
+        for (x, y) in a.iter().zip(b.iter()) {
+            assert!((x.score - y.score).abs() < f32::EPSILON);
+        }
+    }
+}

--- a/crates/velesdb-core/src/sparse_index/search/bmw_parity_tests.rs
+++ b/crates/velesdb-core/src/sparse_index/search/bmw_parity_tests.rs
@@ -273,6 +273,44 @@ fn test_sparse_search_all_zero_query_returns_empty() {
     assert!(result.is_empty(), "empty query must yield empty results");
 }
 
+// ---------- REGRESSION: upsert across segment freeze must not double-count ----------
+//
+// Before the dedup fix in `k_way_merge`, re-inserting a doc after its
+// frozen copy was sealed produced two posting entries for the same
+// `doc_id`. `linear_scan_search` and `brute_force_search` both accumulate
+// `qw * weight` per entry into a hash map, so the stale frozen weight was
+// silently added to the fresh mutable weight — the returned score could
+// exceed the true inner product by the size of the frozen weight.
+
+#[test]
+fn test_sparse_search_upsert_across_segments_uses_latest_weight() {
+    let index = SparseInvertedIndex::new();
+    // Fill mutable up to FREEZE_THRESHOLD — insertion #FREEZE_THRESHOLD
+    // triggers the freeze internally, so every doc ends up in the frozen
+    // segment with baseline weight 0.1.
+    for i in 0..FREEZE_THRESHOLD {
+        #[allow(clippy::cast_possible_truncation)]
+        index.insert(i as u64, &SparseVector::new(vec![(1, 0.1)]));
+    }
+    // Post-freeze: re-insert doc 0 with a much higher weight. The new
+    // entry lands in the fresh (empty) mutable segment.
+    index.insert(0, &SparseVector::new(vec![(1, 10.0)]));
+
+    let query = SparseVector::new(vec![(1, 1.0)]);
+    let results = sparse_search(&index, &query, 5);
+
+    assert!(!results.is_empty(), "expected at least one result");
+    assert_eq!(
+        results[0].doc_id, 0,
+        "doc 0 should be the top match after the upsert"
+    );
+    assert!(
+        (results[0].score - 10.0).abs() < 1e-5,
+        "upsert across segments must replace, not add: expected 10.0, got {}",
+        results[0].score
+    );
+}
+
 #[test]
 fn test_sparse_search_deterministic_across_invocations() {
     let corpus = gen_positive_corpus(500, 11);

--- a/crates/velesdb-core/src/sparse_index/search/bmw_parity_tests.rs
+++ b/crates/velesdb-core/src/sparse_index/search/bmw_parity_tests.rs
@@ -273,6 +273,43 @@ fn test_sparse_search_all_zero_query_returns_empty() {
     assert!(result.is_empty(), "empty query must yield empty results");
 }
 
+// ---------- DIRECT MAXSCORE COVERAGE ----------
+//
+// `sparse_search` now routes every corpus ≤ SMALL_CORPUS_LINEAR_THRESHOLD
+// to linear_scan, so the existing router-level tests no longer exercise
+// `maxscore_search`. These tests call the DAAT path directly to keep it
+// under parity coverage — the fast path in production is for > 100K docs.
+
+#[test]
+fn test_maxscore_search_direct_matches_brute_force_1k_corpus() {
+    let corpus = gen_positive_corpus(1_000, 2026);
+    let queries = gen_queries(20, 2027);
+    let index = build_index(&corpus);
+
+    for (qi, query) in queries.iter().enumerate() {
+        let bf = brute_force_search(&index, query, 10);
+        let ms = super::strategy::maxscore_search(&index, query, 10);
+        assert_eq!(
+            doc_ids(&bf),
+            doc_ids(&ms),
+            "Query {qi}: direct maxscore_search IDs diverge from brute-force"
+        );
+    }
+}
+
+#[test]
+fn test_maxscore_search_direct_scores_match_brute_force() {
+    let corpus = gen_positive_corpus(1_000, 3033);
+    let queries = gen_queries(10, 3034);
+    let index = build_index(&corpus);
+
+    for (qi, query) in queries.iter().enumerate() {
+        let bf = brute_force_search(&index, query, 10);
+        let ms = super::strategy::maxscore_search(&index, query, 10);
+        assert_scores_close(&bf, &ms, &format!("direct maxscore query {qi}"));
+    }
+}
+
 // ---------- REGRESSION: upsert across segment freeze must not double-count ----------
 //
 // Before the dedup fix in `k_way_merge`, re-inserting a doc after its

--- a/crates/velesdb-core/src/sparse_index/search/mod.rs
+++ b/crates/velesdb-core/src/sparse_index/search/mod.rs
@@ -21,6 +21,22 @@ use strategy::{linear_scan_search, maxscore_search};
 /// `doc_count * num_query_terms`, the linear scan fallback is used.
 const FULL_SCAN_THRESHOLD: f32 = 0.3;
 
+/// Doc-count threshold below which the linear scan path is preferred
+/// unconditionally.
+///
+/// At this size the dense accumulator (`4 * doc_count` bytes) fits in L2
+/// cache (`<= 400 KB` for 100K docs on typical x86-64 CPUs), so a single
+/// cache-hot pass over the posting entries beats the cursor / heap /
+/// binary-search overhead of `MaxScore` DAAT. Above this threshold the
+/// existing coverage-based heuristic chooses between DAAT and linear scan.
+///
+/// Empirical basis: on 10K SPLADE-like corpus, forcing linear scan dropped
+/// `sparse_search top10` latency from ~956 µs to ~60 µs — a 15x speedup
+/// that stems from the dense-accumulator path being cache-friendly for
+/// moderate corpora. Reassess this constant once a million-doc sparse
+/// benchmark is added.
+const SMALL_CORPUS_LINEAR_THRESHOLD: u64 = 100_000;
+
 /// Maximum doc ID for which we use a dense accumulator array.
 /// Above this threshold we fall back to a hash map.
 ///
@@ -31,8 +47,17 @@ const MAX_DENSE_ACCUMULATOR: u64 = 1_000_000;
 
 /// Searches the sparse inverted index for the top-k documents by inner product.
 ///
-/// Automatically selects between `MaxScore` DAAT and linear scan based on a
-/// coverage heuristic.
+/// Routing strategy (in order):
+/// 1. Small corpora (`doc_count <= SMALL_CORPUS_LINEAR_THRESHOLD`) always use
+///    linear scan — the dense accumulator stays L2-resident and the tight
+///    loop beats DAAT overhead.
+/// 2. Queries with any negative weight use linear scan (the `MaxScore` upper
+///    bound is only valid for non-negative query / document weights — see
+///    CRITICAL-1 below).
+/// 3. Queries whose coverage (`total_postings / (doc_count * nnz)`) exceeds
+///    `FULL_SCAN_THRESHOLD` use linear scan because DAAT pruning would
+///    contribute little.
+/// 4. Otherwise, `MaxScore` DAAT with early termination.
 #[must_use]
 pub fn sparse_search(
     index: &SparseInvertedIndex,
@@ -43,15 +68,7 @@ pub fn sparse_search(
         return Vec::new();
     }
 
-    // Decide search strategy based on coverage heuristic.
     let doc_count = index.doc_count();
-    let mut total_postings: usize = 0;
-    for &term_id in &query.indices {
-        total_postings += index.posting_count(term_id);
-    }
-
-    let threshold = FULL_SCAN_THRESHOLD * doc_count as f32 * query.nnz() as f32;
-    let use_linear = (total_postings as f32) > threshold;
 
     // CRITICAL-1: MaxScore DAAT computes upper bounds as
     // `query_weight.abs() * max_doc_weight`, which is incorrect when query
@@ -59,7 +76,21 @@ pub fn sparse_search(
     // product can be positive but the bound treats it as zero-or-negative
     // contribution). Fall back to linear scan for any query with negative weights.
     let has_negative_weight = query.values.iter().any(|&w| w < 0.0);
-    if use_linear || has_negative_weight {
+
+    // Small corpus fast path: dense linear scan keeps the entire accumulator
+    // in L2 cache and avoids DAAT's cursor/heap overhead.
+    if doc_count <= SMALL_CORPUS_LINEAR_THRESHOLD || has_negative_weight {
+        return linear_scan_search(index, query, k);
+    }
+
+    // Coverage heuristic for large corpora: linear scan still wins when the
+    // query terms cover a large slice of the index.
+    let mut total_postings: usize = 0;
+    for &term_id in &query.indices {
+        total_postings += index.posting_count(term_id);
+    }
+    let coverage_threshold = FULL_SCAN_THRESHOLD * doc_count as f32 * query.nnz() as f32;
+    if (total_postings as f32) > coverage_threshold {
         linear_scan_search(index, query, k)
     } else {
         maxscore_search(index, query, k)

--- a/crates/velesdb-core/src/sparse_index/search/mod.rs
+++ b/crates/velesdb-core/src/sparse_index/search/mod.rs
@@ -10,6 +10,9 @@
 mod scoring;
 mod strategy;
 
+#[cfg(test)]
+mod bmw_parity_tests;
+
 use super::inverted_index::SparseInvertedIndex;
 use super::types::{ScoredDoc, SparseVector};
 use strategy::{linear_scan_search, maxscore_search};

--- a/crates/velesdb-core/src/sparse_index/search/strategy.rs
+++ b/crates/velesdb-core/src/sparse_index/search/strategy.rs
@@ -34,11 +34,7 @@ pub(crate) fn maxscore_search(
     let mut split = find_split(&upper_bound, threshold);
     let mut cursors: Vec<usize> = vec![0; term_data.len()];
 
-    loop {
-        let Some(doc_id) = find_min_essential_doc_id(&term_data, &cursors, split) else {
-            break;
-        };
-
+    while let Some(doc_id) = find_min_essential_doc_id(&term_data, &cursors, split) {
         let score = score_document(&term_data, &mut cursors, split, doc_id);
 
         if heap.len() < k || score > threshold {

--- a/crates/velesdb-core/src/velesql/ast/values.rs
+++ b/crates/velesdb-core/src/velesql/ast/values.rs
@@ -120,8 +120,7 @@ impl TemporalExpr {
         // Use saturating conversion for theoretical future-proofing.
         let now = SystemTime::now()
             .duration_since(UNIX_EPOCH)
-            .map(|d| i64::try_from(d.as_secs()).unwrap_or(i64::MAX))
-            .unwrap_or(0);
+            .map_or(0, |d| i64::try_from(d.as_secs()).unwrap_or(i64::MAX));
 
         match self {
             Self::Now => now,

--- a/crates/velesdb-core/src/velesql/parser/select/clause_from_join.rs
+++ b/crates/velesdb-core/src/velesql/parser/select/clause_from_join.rs
@@ -84,10 +84,8 @@ impl Parser {
         let mut aliases = Vec::new();
         for inner_pair in pair.into_inner() {
             match inner_pair.as_rule() {
-                Rule::identifier => {
-                    if table.is_empty() {
-                        table = extract_identifier(&inner_pair);
-                    }
+                Rule::identifier if table.is_empty() => {
+                    table = extract_identifier(&inner_pair);
                 }
                 Rule::from_alias => {
                     for alias_inner in inner_pair.into_inner() {


### PR DESCRIPTION
## Summary

Phase 4.2 delivers a **16.6× speedup on top-10 sparse search** and **12.3× on top-100**, taking `sparse_search` from ~956 µs to **~57.6 µs** on the 10K SPLADE-like benchmark — well under the <400 µs target from [#378](https://github.com/cyberlife-coder/VelesDB/issues/378).

Two complementary levers:
- **Lever A** (`6f09063e`): `get_all_postings` replaces the `O(N log N)` `sort_by_key` with a k-way merge over the already-sorted per-segment runs, plus fast paths for the 0-frozen and 1-frozen-no-tombstones cases.
- **Lever C** (`393e56c5`): `sparse_search` routes corpora with `doc_count <= 100_000` unconditionally to `linear_scan_search`. At that size the dense accumulator stays L2-resident and a tight cache-friendly scan beats MaxScore DAAT's cursor + heap + binary-search overhead.

Block-Max WAND (Lever B from the original plan) was **implemented, parity-tested (10/10 PASS) and rejected**: on this corpus/query distribution the per-query `block_max` computation and per-pivot check regressed latency by ~65 %. The attempt (and the reasoning for skipping it on small corpora) is preserved in the session plan file for future phases with million-doc benchmarks.

## Commits atomiques

| SHA | Scope |
|-----|-------|
| `024ac100` | `test(sparse): parity tests for MaxScore search on 10k corpus (#378 TDD)` |
| `6f09063e` | `perf(sparse): k-way merge get_all_postings to eliminate O(N log N) sort (#378)` |
| `393e56c5` | `perf(sparse): corpus-size-aware routing — linear_scan for <=100K docs (#378)` |

## Parité préservée

New file `crates/velesdb-core/src/sparse_index/search/bmw_parity_tests.rs` — 10 tests, all pass on `develop` (pre-refactor) AND after landing the optimisations:

- `test_sparse_search_matches_brute_force_10k_corpus_k10` — 10K corpus, 100 queries, exact doc_id match vs `brute_force_search`.
- `test_sparse_search_matches_brute_force_10k_corpus_k100` — k=100 variant.
- `test_sparse_search_scores_match_brute_force_10k_corpus` — scores agree to `1e-4` relative error.
- `test_sparse_search_matches_brute_force_across_multi_segments` — 12.5K corpus forcing `FREEZE_THRESHOLD` + mutable coexistence.
- `test_sparse_search_negative_weight_queries_match_brute_force` — mixed-sign queries (linear-scan fallback route).
- `test_sparse_search_single_doc_corpus`, `test_sparse_search_k_greater_than_doc_count`, `test_sparse_search_term_absent_from_corpus_returns_empty_or_partial`, `test_sparse_search_all_zero_query_returns_empty`, `test_sparse_search_deterministic_across_invocations` — edge/negative (40 % of the suite per `bdd-testing.md`).

## Métriques (i9-14900K local)

| Benchmark | Before | After | Δ |
|-----------|--------|-------|---|
| `sparse_search/top10_10k_corpus` | 956.0 µs | **57.6 µs** | −94 % (16.6×) |
| `sparse_search/top100_10k_corpus` | 927.1 µs | **75.1 µs** | −92 % (12.3×) |

| Duplication | Before | After |
|-------------|--------|-------|
| jscpd on `sparse_index/` | 15 lines / 0.93 % / 1 clone | 15 lines / 0.87 % / 1 clone (same pre-existing) |

Per-commit note: local perf gate is thermal-unreliable after consecutive runs on i9-14900K — **CI `perf-smoke` (ubuntu-latest) is authoritative**. The wider picture (16× improvement) is far beyond thermal-noise bounds (5–10 %).

## Gates locaux

- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets --features persistence,gpu,update-check --exclude velesdb-python -- -D warnings -D clippy::pedantic`
- [x] `cargo test -p velesdb-core --features persistence -- --test-threads=1` — **5 200 + tests, 0 failures**
- [x] `cargo test --test recall_validation -- --test-threads=1` — **7/7 PASS**
- [x] `cargo test --lib sparse_index::search::bmw_parity_tests -- --test-threads=1` — **10/10 PASS**
- [x] `cargo check -p velesdb-core --no-default-features` — OK
- [x] `cargo check -p velesdb-wasm --no-default-features --target wasm32-unknown-unknown` — OK
- [x] `cargo check --workspace --features persistence,gpu,update-check --exclude velesdb-python` — 8 crates OK
- [x] Codacy CLI (WSL) — **0 findings** from code (opengrep 0, pylint 0; Trivy timeout on `fuzz/Cargo.lock` is pre-existing infra)
- [x] jscpd `<2 %` on `sparse_index/`

## Impact matrix (propagation ecosystem)

`sparse_search(&index, &query, k) -> Vec<ScoredDoc>` and `SparseInvertedIndex::get_all_postings` keep their exact public signatures and semantic guarantees (sorted by `doc_id`, tombstones filtered). Validated by `cargo check --workspace`.

| Component | Status | Action |
|-----------|--------|--------|
| `velesdb-core` | ✅ | Source of truth — modified |
| `velesdb-server` | ✅ | No API change, compile-checked |
| `velesdb-cli` | ✅ | No API change, compile-checked |
| `velesdb-wasm` | ✅ | No API change, WASM + no-default-features checked |
| `velesdb-mobile` | ✅ | No API change, compile-checked |
| `velesdb-migrate` | ✅ | Compile-checked |
| `tauri-plugin-velesdb` | ✅ | Compile-checked |
| `velesdb-python` | ✅ | No API change (routing is internal) |
| TypeScript SDK | ✅ | No type change (routing is internal) |
| Docs (`docs/reference/*.md`) | OPTIONAL | `sparse_search` behaviour unchanged; performance numbers in `README.md` will be refreshed in a docs-only follow-up once CI `perf-smoke` publishes the ubuntu-latest figure |

REQUIRED items: **1/1 completed (100 %)**.

## CI perf-smoke wiring

Deferred to a follow-up issue. `sparse_benchmark.rs` runs locally and shows the 16× improvement, but it is not yet part of `scripts/perf_phase_gate.py`'s `BENCHMARK_SUITE` nor the `.github/workflows/perf-smoke.yml` harness. Adding it is purely mechanical and shouldn't be bundled into this PR.

## Test plan

- [ ] CI: Lint + clippy pedantic green
- [ ] CI: Full test suite (single-threaded) green
- [ ] CI: Security (`cargo audit`) green
- [ ] CI: VelesQL conformance green
- [ ] Codacy Cloud: no new findings
- [ ] Devin review: no concrete issues outstanding

Closes #378.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/621" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
