### PR TITLE
chore(ci): surface Git Flow base rules in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,11 @@
+## ⚠️ Target branch (Git Flow)
+
+> Enforced by the `PR Governance` workflow — the PR will be rejected if these rules are not respected.
+
+- `feat/*`, `feature/*`, `fix/*`, `bugfix/*`, `chore/*`, `docs/*`, `perf/*`, `refactor/*`, `test/*`, `ci/*`, `build/*`, `style/*` → **target `develop`**
+- `release/*`, `hotfix/*`, `support/*`, or `develop` itself → **target `main`**
+- Any other combination is rejected. See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full Git Flow model.
+
 ## Description
 
 Please include a summary of the changes and the related issue. Include relevant motivation and context.


### PR DESCRIPTION
## Summary

Add a Git Flow enforcement notice at the top of `.github/PULL_REQUEST_TEMPLATE.md` so contributors see the base/head branch policy **before** opening a PR, rather than discovering it via a failed `PR Governance` check after the fact.

## Context

The `PR Governance` workflow (on `develop`) already enforces Git Flow:
- `feat/*`, `fix/*`, `chore/*`, ... → must target `develop`
- `develop`, `release/*`, `hotfix/*`, `support/*` → may target `main`

But the PR template gave zero hint, so external contributors were learning the rule the hard way (cf. PR #622, initially opened against `main`, retargeted to `develop` manually).

## Changes

- `.github/PULL_REQUEST_TEMPLATE.md`: prepend a concise Git Flow section that links to `CONTRIBUTING.md` for the full model.

No workflow or behaviour change — documentation surfacing only.

## Test plan

- [x] Lint: markdown renders correctly in GitHub preview.
- [x] `PR Governance` check passes on this PR (`chore/*` → `develop` is allowed).
- [ ] Reviewer confirms wording is accurate.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/624" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
