### PR TITLE
feat(velesql): implement window functions ROW_NUMBER, RANK, DENSE_RANK (#386)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,73 @@ Zero regression cumulatively —
 recall gate (Fast 0.90 / Balanced 0.95 / Accurate 0.99 / Perfect 1.00)
 passes on every phase.
 
+### Added — VelesQL window functions
+
+- **`ROW_NUMBER()`, `RANK()`, `DENSE_RANK()` with `OVER (PARTITION BY … ORDER BY …)`**
+  (`#629`, closes `#386`). Credit @SBALAVIGNESH123 for the original
+  implementation; the landed form includes a complete zero-tech-debt
+  hardening pass.
+
+  Grammar additions in `velesql/grammar.pest`: `window_item`,
+  `window_function_call`, `over_clause`, `partition_by_clause`,
+  `window_order_by_clause`. The evaluator lives in
+  `velesql/window_evaluator.rs` and runs after DISTINCT and before
+  ORDER BY / LIMIT in the query pipeline (see the design note on
+  `apply_select_postprocessing` for why the order deviates from the SQL
+  standard — vector-search survivors get a dense `1..N` numbering).
+
+  Implementation highlights (all pinned by regression tests):
+
+  - **Global snapshot-first evaluation** prevents three classes of
+    payload corruption — intra-function (alias collides with own
+    ORDER BY column), inter-function via ORDER BY, inter-function via
+    PARTITION BY. `evaluate` pre-captures every window function's
+    ORDER BY values and PARTITION BY keys **before** any injection,
+    so sequential window evaluation cannot read another function's
+    injected ranks.
+  - **Dispatch-by-variant** for rank computation (`compute_row_numbers`,
+    `compute_rank`, `compute_dense_rank`) with a shared `is_new_group`
+    tie-detection predicate — no dead state.
+  - **Canonical-JSON partition keys** preserve JSON type
+    discriminators, eliminating collisions between `Number(1)` and
+    `String("1")` and between `Null` and a literal payload string
+    `"__null__"`.
+
+### Changed — correctness fixes with visible effects
+
+These corrections resolve pre-existing bugs that were silently wrong.
+Each is pinned by regression tests; callers who depended on the buggy
+output must update.
+
+- **`SelectColumns::to_display_names` returns every SELECT-list item.**
+  Previous releases silently dropped `similarity()` expressions and
+  qualified wildcards from the Mixed SELECT variant, shortening the
+  list returned by the Python `VelesQL.parse(...).columns` getter and
+  the WASM `parsed.columns` getter. v1.13.0 returns the complete list
+  in grammar order (columns → aggregations → similarity scores →
+  qualified wildcards → window functions).
+
+  *Migration*: callers that hard-coded an expected list length or
+  `columns[n]` offsets against the buggy output will now see
+  additional entries. Update the expected length / offsets, or
+  switch to dict-style lookup by name. The complete contract is
+  pinned by
+  `velesql::ast_tests::test_display_names_mixed_includes_all_variants`.
+
+- **`DISTINCT` dedup key now includes qualified-wildcard-expanded
+  fields.** `SELECT DISTINCT ctx.*, title FROM docs` previously
+  deduped by `title` only, silently collapsing rows that differed
+  only on a wildcard-expanded field. v1.13.0 deduplicates by the full
+  payload when any qualified wildcard is in the SELECT list, matching
+  SQL's "DISTINCT considers the whole projected row" semantics.
+
+  *Migration*: queries of the shape
+  `SELECT DISTINCT alias.*, col, …` may return more rows than before.
+  If the pre-v1.13.0 behavior is required, replace `alias.*` with the
+  specific columns that should participate in the dedup key. Pinned
+  by
+  `collection::search::query::distinct_tests::tests::test_distinct_mixed_with_qualified_wildcard_dedupes_by_full_payload`.
+
 ### Added — GPU acceleration
 
 - **GPU HNSW layer-0 traversal** (`#626`, closes `#502`): SONG paper

--- a/crates/velesdb-core/src/collection/search/query/distinct.rs
+++ b/crates/velesdb-core/src/collection/search/query/distinct.rs
@@ -198,6 +198,7 @@ mod tests {
                 alias: Some("score".to_string()),
             }],
             qualified_wildcards: vec![],
+            window_functions: vec![],
         };
 
         let distinct = apply_distinct(results, &columns);
@@ -220,6 +221,7 @@ mod tests {
             aggregations: vec![],
             similarity_scores: vec![],
             qualified_wildcards: vec![],
+            window_functions: vec![],
         };
 
         let distinct = apply_distinct(results, &columns);

--- a/crates/velesdb-core/src/collection/search/query/distinct.rs
+++ b/crates/velesdb-core/src/collection/search/query/distinct.rs
@@ -9,20 +9,55 @@ use rustc_hash::FxHashSet;
 /// Apply DISTINCT deduplication to results based on selected columns (EPIC-052 US-001).
 ///
 /// Uses HashSet for O(n) complexity and preserves insertion order.
+///
+/// # Dedup-key contract
+///
+/// The SELECT-list variants drive the dedup key as follows:
+///
+/// - `Columns(cols)` → dedup by the listed payload fields only.
+/// - `Mixed { columns, qualified_wildcards, similarity_scores, .. }`:
+///   - if `qualified_wildcards` is **empty**, dedup by the listed `columns`;
+///   - if `qualified_wildcards` is **non-empty**, dedup by the **full payload**
+///     (same semantics as `SELECT *`) because a qualified wildcard expands
+///     to every payload field — those fields are part of the projected row
+///     and must participate in the dedup key, otherwise
+///     `SELECT DISTINCT ctx.*, title FROM docs` would collapse rows that
+///     differ only by non-title wildcard fields.
+///   - `similarity_scores` presence appends the similarity score to the key
+///     so rows differing only by score are not collapsed.
+///   - `aggregations` are handled by a separate aggregation pipeline and
+///     are not part of the DISTINCT key (they don't reach this path).
+///   - `window_functions` are deliberately excluded — DISTINCT runs BEFORE
+///     window evaluation per the VelesQL pipeline order (see the contract
+///     on `apply_select_postprocessing`), so any window-injected field
+///     doesn't exist on the payload yet.
+/// - `SimilarityScore(_)` → dedup by score only.
+/// - `All` / `QualifiedWildcard(_)` → dedup by full payload.
+/// - `Aggregations(_)` → no dedup (aggregations collapse rows themselves).
 pub fn apply_distinct(results: Vec<SearchResult>, columns: &SelectColumns) -> Vec<SearchResult> {
-    // If SELECT *, deduplicate by all payload fields
     let (column_names, include_score) = match columns {
         SelectColumns::Columns(cols) => (cols.iter().map(|c| c.name.clone()).collect(), false),
         SelectColumns::Mixed {
             columns: cols,
             similarity_scores,
+            qualified_wildcards,
             ..
-        } => (
-            cols.iter().map(|c| c.name.clone()).collect(),
-            !similarity_scores.is_empty(),
-        ),
+        } => {
+            // Qualified wildcards expand to every payload field; fall back
+            // to "dedup by full payload" (empty column list) so those
+            // fields participate in the key.
+            let cols_for_dedup = if qualified_wildcards.is_empty() {
+                cols.iter().map(|c| c.name.clone()).collect()
+            } else {
+                Vec::new()
+            };
+            (cols_for_dedup, !similarity_scores.is_empty())
+        }
         SelectColumns::SimilarityScore(_) => (Vec::new(), true),
-        // All, Aggregations, QualifiedWildcard: use full payload or no dedup
+        // All / QualifiedWildcard → full payload; Aggregations → no dedup
+        // (the empty-column path below gives the same "full payload" key,
+        // which is harmless for Aggregations since that path never reaches
+        // this function in practice).
         SelectColumns::All
         | SelectColumns::Aggregations(_)
         | SelectColumns::QualifiedWildcard(_) => (Vec::new(), false),

--- a/crates/velesdb-core/src/collection/search/query/distinct_tests.rs
+++ b/crates/velesdb-core/src/collection/search/query/distinct_tests.rs
@@ -101,4 +101,86 @@ mod tests {
         // Number 42 vs string "42" should be distinct (different JSON repr).
         assert_eq!(distinct.len(), 2, "number vs string should be distinct");
     }
+
+    // -----------------------------------------------------------------------
+    // Mixed with qualified_wildcards must dedup by FULL payload, not just
+    // the explicit `columns` list. Regression for the Devin finding:
+    // `SELECT DISTINCT ctx.*, title FROM docs` must collapse rows only when
+    // ALL payload fields match, not only when `title` matches.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_distinct_mixed_with_qualified_wildcard_dedupes_by_full_payload() {
+        // Two rows share `title` but differ in a wildcard-expanded field
+        // (`author`). Without the fix, dedup would collapse them (only
+        // `title` considered). With the fix, dedup uses the full payload,
+        // so both survive.
+        let results = vec![
+            make_result(
+                1,
+                Some(serde_json::json!({"title": "T1", "author": "Alice"})),
+            ),
+            make_result(2, Some(serde_json::json!({"title": "T1", "author": "Bob"}))),
+            // Third row is an exact duplicate of row 1 → should collapse.
+            make_result(
+                3,
+                Some(serde_json::json!({"title": "T1", "author": "Alice"})),
+            ),
+        ];
+
+        let columns = SelectColumns::Mixed {
+            columns: vec![Column {
+                name: "title".to_string(),
+                alias: None,
+            }],
+            aggregations: Vec::new(),
+            similarity_scores: Vec::new(),
+            qualified_wildcards: vec!["ctx".to_string()],
+            window_functions: Vec::new(),
+        };
+
+        let distinct = apply_distinct(results, &columns);
+        assert_eq!(
+            distinct.len(),
+            2,
+            "rows 1 and 2 differ (Alice vs Bob) so both survive; row 3 is an \
+             exact duplicate of row 1 and is dropped"
+        );
+        // Preserves insertion order: row 1 and row 2 survive.
+        assert_eq!(distinct[0].point.id, 1);
+        assert_eq!(distinct[1].point.id, 2);
+    }
+
+    /// Control case: same query shape but WITHOUT qualified_wildcards —
+    /// dedup must still use only the explicit `columns` list (current
+    /// behaviour preserved for backward compatibility).
+    #[test]
+    fn test_distinct_mixed_without_qualified_wildcard_dedupes_by_columns_only() {
+        let results = vec![
+            make_result(
+                1,
+                Some(serde_json::json!({"title": "T1", "author": "Alice"})),
+            ),
+            make_result(2, Some(serde_json::json!({"title": "T1", "author": "Bob"}))),
+        ];
+
+        let columns = SelectColumns::Mixed {
+            columns: vec![Column {
+                name: "title".to_string(),
+                alias: None,
+            }],
+            aggregations: Vec::new(),
+            similarity_scores: Vec::new(),
+            qualified_wildcards: Vec::new(),
+            window_functions: Vec::new(),
+        };
+
+        let distinct = apply_distinct(results, &columns);
+        assert_eq!(
+            distinct.len(),
+            1,
+            "no wildcard → dedup by `title` only → both rows collapse"
+        );
+        assert_eq!(distinct[0].point.id, 1);
+    }
 }

--- a/crates/velesdb-core/src/collection/search/query/projection.rs
+++ b/crates/velesdb-core/src/collection/search/query/projection.rs
@@ -37,6 +37,7 @@ fn project_single(result: &SearchResult, select_exprs: &SelectColumns) -> serde_
             aggregations: _,
             similarity_scores,
             qualified_wildcards,
+            ..
         } => project_mixed(result, columns, similarity_scores, qualified_wildcards),
     }
 }
@@ -268,6 +269,7 @@ mod tests {
                 alias: Some("score".to_string()),
             }],
             qualified_wildcards: vec![],
+            window_functions: vec![],
         };
         let projected = project_single(&result, &columns);
         let obj = projected.as_object().unwrap();
@@ -291,6 +293,7 @@ mod tests {
                 alias: Some("relevance".to_string()),
             }],
             qualified_wildcards: vec!["ctx".to_string()],
+            window_functions: vec![],
         };
         let projected = project_single(&result, &columns);
         let obj = projected.as_object().unwrap();

--- a/crates/velesdb-core/src/collection/search/query/projection.rs
+++ b/crates/velesdb-core/src/collection/search/query/projection.rs
@@ -38,7 +38,13 @@ fn project_single(result: &SearchResult, select_exprs: &SelectColumns) -> serde_
             similarity_scores,
             qualified_wildcards,
             window_functions,
-        } => project_mixed(result, columns, similarity_scores, qualified_wildcards, window_functions),
+        } => project_mixed(
+            result,
+            columns,
+            similarity_scores,
+            qualified_wildcards,
+            window_functions,
+        ),
     }
 }
 

--- a/crates/velesdb-core/src/collection/search/query/projection.rs
+++ b/crates/velesdb-core/src/collection/search/query/projection.rs
@@ -37,8 +37,8 @@ fn project_single(result: &SearchResult, select_exprs: &SelectColumns) -> serde_
             aggregations: _,
             similarity_scores,
             qualified_wildcards,
-            ..
-        } => project_mixed(result, columns, similarity_scores, qualified_wildcards),
+            window_functions,
+        } => project_mixed(result, columns, similarity_scores, qualified_wildcards, window_functions),
     }
 }
 
@@ -85,12 +85,13 @@ fn project_similarity_only(result: &SearchResult, expr: &SimilarityScoreExpr) ->
     serde_json::Value::Object(map)
 }
 
-/// Mixed projection: columns + similarity scores + qualified wildcards.
+/// Mixed projection: columns + similarity scores + qualified wildcards + window functions.
 fn project_mixed(
     result: &SearchResult,
     columns: &[crate::velesql::Column],
     similarity_scores: &[SimilarityScoreExpr],
     qualified_wildcards: &[String],
+    window_functions: &[crate::velesql::WindowFunction],
 ) -> serde_json::Value {
     let mut map = serde_json::Map::new();
 
@@ -120,6 +121,22 @@ fn project_mixed(
             key.to_string(),
             serde_json::Value::from(f64::from(result.score)),
         );
+    }
+
+    // Window function values (injected into payload by window_evaluator)
+    for wf in window_functions {
+        let alias = wf
+            .alias
+            .as_deref()
+            .unwrap_or(wf.function_type.default_alias());
+        let value = result
+            .point
+            .payload
+            .as_ref()
+            .and_then(|p| p.get(alias))
+            .cloned()
+            .unwrap_or(serde_json::Value::Null);
+        map.insert(alias.to_string(), value);
     }
 
     serde_json::Value::Object(map)

--- a/crates/velesdb-core/src/collection/search/query/projection.rs
+++ b/crates/velesdb-core/src/collection/search/query/projection.rs
@@ -92,6 +92,14 @@ fn project_similarity_only(result: &SearchResult, expr: &SimilarityScoreExpr) ->
 }
 
 /// Mixed projection: columns + similarity scores + qualified wildcards + window functions.
+///
+/// Window function values were injected into the row's payload by
+/// [`crate::velesql::window_evaluator`]. The wildcard-expansion step below
+/// therefore must skip keys that correspond to window-function aliases —
+/// otherwise those values would be read from the payload twice (once by
+/// wildcard expansion, once by the explicit window-function loop). The final
+/// value would still be correct (the explicit loop wins), but the extra
+/// copy is pointless and mis-signals in reviews as suspicious dedup.
 fn project_mixed(
     result: &SearchResult,
     columns: &[crate::velesql::Column],
@@ -101,26 +109,37 @@ fn project_mixed(
 ) -> serde_json::Value {
     let mut map = serde_json::Map::new();
 
-    // Qualified wildcards expand to all payload fields + id
+    // Pre-compute the set of window-function aliases so wildcard expansion
+    // can skip them in O(1) per payload key.
+    let window_aliases: rustc_hash::FxHashSet<&str> = window_functions
+        .iter()
+        .map(|wf| {
+            wf.alias
+                .as_deref()
+                .unwrap_or(wf.function_type.default_alias())
+        })
+        .collect();
+
+    // Qualified wildcards expand to all payload fields + id.
     if !qualified_wildcards.is_empty() {
         map.insert("id".to_string(), serde_json::Value::from(result.point.id));
         if let Some(serde_json::Value::Object(payload_map)) = result.point.payload.as_ref() {
             for (k, v) in payload_map {
-                if k != "id" {
+                if k != "id" && !window_aliases.contains(k.as_str()) {
                     map.insert(k.clone(), v.clone());
                 }
             }
         }
     }
 
-    // Named columns
+    // Named columns.
     for col in columns {
         let output_key = col.alias.as_deref().unwrap_or(&col.name);
         let value = extract_field_value(result, &col.name);
         map.insert(output_key.to_string(), value);
     }
 
-    // Similarity scores
+    // Similarity scores.
     for expr in similarity_scores {
         let key = expr.alias.as_deref().unwrap_or("similarity");
         map.insert(
@@ -129,7 +148,9 @@ fn project_mixed(
         );
     }
 
-    // Window function values (injected into payload by window_evaluator)
+    // Window function values (injected into payload by window_evaluator).
+    // This is the single source of truth for window aliases — wildcard
+    // expansion above deliberately skipped them.
     for wf in window_functions {
         let alias = wf
             .alias

--- a/crates/velesdb-core/src/collection/search/query/select_dispatch.rs
+++ b/crates/velesdb-core/src/collection/search/query/select_dispatch.rs
@@ -256,6 +256,26 @@ impl Collection {
 
     /// Applies DISTINCT, window functions, ORDER BY (with LET bindings), OFFSET, LIMIT, and
     /// LET payload injection (Issue #473).
+    ///
+    /// # Pipeline order and its SQL-standard deviation
+    ///
+    /// VelesQL runs `DISTINCT → window functions → ORDER BY → OFFSET/LIMIT`.
+    /// Standard SQL runs window functions **before** DISTINCT (logical order
+    /// `SELECT → DISTINCT → ORDER BY`). This is an **intentional deviation**
+    /// tailored to the vector-search use case:
+    ///
+    /// - "Give me the top-N distinct titles, ranked by similarity" (the
+    ///   common vector-search pattern) wants DISTINCT to collapse rows
+    ///   **before** ROW_NUMBER / RANK assigns positions, so survivors get
+    ///   a dense `1..N` numbering. Running window functions first would
+    ///   leave gaps in the numbering after DISTINCT drops rows.
+    /// - No VelesQL query currently uses the standard-SQL contract, so no
+    ///   existing user code depends on the reverse order.
+    ///
+    /// If the standard order becomes necessary in the future (e.g., SQL
+    /// compatibility mode), swap step 1 and step 2 and wrap behind a feature
+    /// flag. Regression coverage is in
+    /// `window_function_tests::test_distinct_runs_before_window_functions`.
     pub(super) fn apply_select_postprocessing(
         &self,
         stmt: &crate::velesql::SelectStatement,
@@ -264,7 +284,8 @@ impl Collection {
         limit: usize,
         let_bindings: &[crate::velesql::LetBinding],
     ) -> Result<Vec<SearchResult>> {
-        // Step 1: DISTINCT — deduplication before any ranking.
+        // Step 1: DISTINCT — deduplication before any ranking (see pipeline
+        // order contract in the doc comment above).
         if stmt.distinct == crate::velesql::DistinctMode::All {
             results = distinct::apply_distinct(results, &stmt.columns);
         }

--- a/crates/velesdb-core/src/collection/search/query/select_dispatch.rs
+++ b/crates/velesdb-core/src/collection/search/query/select_dispatch.rs
@@ -254,7 +254,7 @@ impl Collection {
         analysis
     }
 
-    /// Applies DISTINCT, ORDER BY (with LET bindings), OFFSET, LIMIT, and
+    /// Applies DISTINCT, window functions, ORDER BY (with LET bindings), OFFSET, LIMIT, and
     /// LET payload injection (Issue #473).
     pub(super) fn apply_select_postprocessing(
         &self,
@@ -264,9 +264,15 @@ impl Collection {
         limit: usize,
         let_bindings: &[crate::velesql::LetBinding],
     ) -> Result<Vec<SearchResult>> {
+        // Step 1: DISTINCT — deduplication before any ranking.
         if stmt.distinct == crate::velesql::DistinctMode::All {
             results = distinct::apply_distinct(results, &stmt.columns);
         }
+        // Step 2: Window functions — after DISTINCT, before ORDER BY/LIMIT.
+        if let Some(wfs) = Self::extract_window_functions(&stmt.columns) {
+            crate::velesql::window_evaluator::evaluate(&mut results, wfs)?;
+        }
+        // Step 3: ORDER BY (with optional LET bindings).
         if let Some(ref order_by) = stmt.order_by {
             if let_bindings.is_empty() {
                 self.apply_order_by(&mut results, order_by, params)?;
@@ -308,6 +314,18 @@ impl Collection {
                 )
             })
             .collect()
+    }
+
+    /// Extracts window functions from `SelectColumns`, if any are present.
+    fn extract_window_functions(
+        columns: &crate::velesql::SelectColumns,
+    ) -> Option<&[crate::velesql::WindowFunction]> {
+        match columns {
+            crate::velesql::SelectColumns::Mixed {
+                window_functions, ..
+            } if !window_functions.is_empty() => Some(window_functions),
+            _ => None,
+        }
     }
 }
 

--- a/crates/velesdb-core/src/velesql/ast/mod.rs
+++ b/crates/velesdb-core/src/velesql/ast/mod.rs
@@ -13,6 +13,7 @@ mod join;
 mod select;
 mod train;
 mod values;
+mod window;
 mod with_clause;
 
 use serde::{Deserialize, Serialize};
@@ -51,6 +52,7 @@ pub use values::{
     CorrelatedColumn, IntervalUnit, IntervalValue, Subquery, TemporalExpr, Value, VectorExpr,
 };
 pub use with_clause::{QuantizationMode, WithClause, WithOption, WithValue};
+pub use window::{OverClause, WindowFunction, WindowFunctionType, WindowOrderBy};
 
 /// A complete VelesQL query.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/crates/velesdb-core/src/velesql/ast/mod.rs
+++ b/crates/velesdb-core/src/velesql/ast/mod.rs
@@ -51,8 +51,8 @@ pub use train::TrainStatement;
 pub use values::{
     CorrelatedColumn, IntervalUnit, IntervalValue, Subquery, TemporalExpr, Value, VectorExpr,
 };
-pub use with_clause::{QuantizationMode, WithClause, WithOption, WithValue};
 pub use window::{OverClause, WindowFunction, WindowFunctionType, WindowOrderBy};
+pub use with_clause::{QuantizationMode, WithClause, WithOption, WithValue};
 
 /// A complete VelesQL query.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/crates/velesdb-core/src/velesql/ast/select.rs
+++ b/crates/velesdb-core/src/velesql/ast/select.rs
@@ -93,9 +93,25 @@ pub enum SelectColumns {
 }
 
 impl SelectColumns {
-    /// Returns human-readable column names for display.
+    /// Returns human-readable column names for display, one per SELECT-list
+    /// item in grammar order.
     ///
-    /// Used by Python/WASM bindings to expose column metadata.
+    /// Used by Python/WASM bindings to expose the column-metadata contract.
+    ///
+    /// # Completeness
+    ///
+    /// Every SELECT-list variant must contribute exactly one entry per item
+    /// it contains. Historically the `Mixed` arm dropped `similarity_scores`
+    /// and `qualified_wildcards` via a `..` pattern, which silently shortened
+    /// the column list for queries that combined them with regular columns —
+    /// a correctness bug that was observable through Python/WASM callers
+    /// reading the column count or iterating the list. That bug is now
+    /// fixed; the returned list reflects the *complete* SELECT projection.
+    ///
+    /// **Compatibility note**: callers that previously relied on the
+    /// incomplete list (e.g. hard-coded `len() == columns.len()`) will now
+    /// see additional entries. The new contract is pinned by
+    /// `ast_tests::test_display_names_mixed_includes_all_variants`.
     #[must_use]
     pub fn to_display_names(&self) -> Vec<String> {
         match self {

--- a/crates/velesdb-core/src/velesql/ast/select.rs
+++ b/crates/velesdb-core/src/velesql/ast/select.rs
@@ -70,7 +70,7 @@ pub enum SelectColumns {
     Columns(Vec<Column>),
     /// Select aggregate functions.
     Aggregations(Vec<AggregateFunction>),
-    /// Mixed: columns + aggregations + similarity scores + qualified wildcards.
+    /// Mixed: columns + aggregations + similarity scores + qualified wildcards + window functions.
     Mixed {
         /// Regular columns.
         columns: Vec<Column>,
@@ -82,6 +82,9 @@ pub enum SelectColumns {
         /// Qualified wildcards (e.g., `ctx.*`).
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
         qualified_wildcards: Vec<String>,
+        /// Window function expressions (Issue #386).
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        window_functions: Vec<super::window::WindowFunction>,
     },
     /// Select similarity() score only (zero-arg form).
     SimilarityScore(SimilarityScoreExpr),
@@ -105,6 +108,7 @@ impl SelectColumns {
             Self::Mixed {
                 columns,
                 aggregations,
+                window_functions,
                 ..
             } => {
                 let mut result: Vec<String> = columns.iter().map(|c| c.name.clone()).collect();
@@ -113,6 +117,11 @@ impl SelectColumns {
                         .iter()
                         .map(|a| format!("{:?}", a.function_type)),
                 );
+                result.extend(window_functions.iter().map(|wf| {
+                    wf.alias
+                        .clone()
+                        .unwrap_or_else(|| wf.function_type.default_alias().to_string())
+                }));
                 result
             }
             Self::SimilarityScore(expr) => {

--- a/crates/velesdb-core/src/velesql/ast/select.rs
+++ b/crates/velesdb-core/src/velesql/ast/select.rs
@@ -108,15 +108,27 @@ impl SelectColumns {
             Self::Mixed {
                 columns,
                 aggregations,
+                similarity_scores,
+                qualified_wildcards,
                 window_functions,
-                ..
             } => {
+                // Order mirrors the SELECT-list grammar: columns, aggregates,
+                // similarity(), qualified wildcards (`alias.*`), window
+                // functions. Python/WASM bindings consume this list to expose
+                // the column metadata contract, so every SELECT-list variant
+                // must contribute a display name.
                 let mut result: Vec<String> = columns.iter().map(|c| c.name.clone()).collect();
                 result.extend(
                     aggregations
                         .iter()
                         .map(|a| format!("{:?}", a.function_type)),
                 );
+                result.extend(similarity_scores.iter().map(|expr| {
+                    expr.alias
+                        .clone()
+                        .unwrap_or_else(|| "similarity".to_string())
+                }));
+                result.extend(qualified_wildcards.iter().map(|alias| format!("{alias}.*")));
                 result.extend(window_functions.iter().map(|wf| {
                     wf.alias
                         .clone()

--- a/crates/velesdb-core/src/velesql/ast/window.rs
+++ b/crates/velesdb-core/src/velesql/ast/window.rs
@@ -1,0 +1,61 @@
+//! Window function types for VelesQL (Issue #386).
+//!
+//! Phase 1: `ROW_NUMBER`, `RANK`, `DENSE_RANK` with `PARTITION BY` + `ORDER BY`.
+
+use serde::{Deserialize, Serialize};
+
+/// Window function type (Phase 1: ranking functions).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum WindowFunctionType {
+    /// `ROW_NUMBER()` — sequential numbering 1..N within each partition.
+    RowNumber,
+    /// `RANK()` — ranking with gaps on ties (e.g., 1, 2, 2, 4).
+    Rank,
+    /// `DENSE_RANK()` — ranking without gaps on ties (e.g., 1, 2, 2, 3).
+    DenseRank,
+}
+
+impl WindowFunctionType {
+    /// Returns the default column alias for this function type.
+    #[must_use]
+    pub fn default_alias(&self) -> &'static str {
+        match self {
+            Self::RowNumber => "row_number",
+            Self::Rank => "rank",
+            Self::DenseRank => "dense_rank",
+        }
+    }
+}
+
+/// `ORDER BY` item inside a window `OVER` clause.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct WindowOrderBy {
+    /// Column to sort by within the partition.
+    pub column: String,
+    /// Sort direction (`true` = DESC).
+    pub descending: bool,
+}
+
+/// The `OVER` clause defining the window specification.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct OverClause {
+    /// `PARTITION BY` columns (empty = entire result set is one partition).
+    #[serde(default)]
+    pub partition_by: Vec<String>,
+    /// `ORDER BY` within each partition.
+    #[serde(default)]
+    pub order_by: Vec<WindowOrderBy>,
+}
+
+/// A window function expression in the SELECT list.
+///
+/// Example: `ROW_NUMBER() OVER (PARTITION BY source ORDER BY score DESC) AS rn`
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct WindowFunction {
+    /// Type of window function.
+    pub function_type: WindowFunctionType,
+    /// `OVER` clause specification.
+    pub over_clause: OverClause,
+    /// Optional alias (`AS` clause). Defaults to function name.
+    pub alias: Option<String>,
+}

--- a/crates/velesdb-core/src/velesql/ast_tests.rs
+++ b/crates/velesdb-core/src/velesql/ast_tests.rs
@@ -195,3 +195,101 @@ fn test_value_unsigned_integer_serialization_roundtrip() {
     let parsed: Value = serde_json::from_str(&json_str).expect("test: deserialize");
     assert_eq!(v, parsed);
 }
+
+// ---------------------------------------------------------------------------
+// `SelectColumns::to_display_names` — every SELECT-list variant must
+// contribute a display name. The Python/WASM bindings consume this list as
+// the column-metadata contract, so omitting a variant silently drops columns
+// from their returned schema. These tests pin the full contract.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_display_names_all_wildcard() {
+    let sc = SelectColumns::All;
+    assert_eq!(sc.to_display_names(), vec!["*".to_string()]);
+}
+
+#[test]
+fn test_display_names_columns_only() {
+    let sc = SelectColumns::Columns(vec![Column::new("title"), Column::new("score")]);
+    assert_eq!(
+        sc.to_display_names(),
+        vec!["title".to_string(), "score".to_string()]
+    );
+}
+
+#[test]
+fn test_display_names_similarity_score_with_alias() {
+    let sc = SelectColumns::SimilarityScore(SimilarityScoreExpr {
+        alias: Some("relevance".to_string()),
+    });
+    assert_eq!(sc.to_display_names(), vec!["relevance".to_string()]);
+}
+
+#[test]
+fn test_display_names_similarity_score_no_alias() {
+    let sc = SelectColumns::SimilarityScore(SimilarityScoreExpr { alias: None });
+    assert_eq!(sc.to_display_names(), vec!["similarity".to_string()]);
+}
+
+#[test]
+fn test_display_names_qualified_wildcard() {
+    let sc = SelectColumns::QualifiedWildcard("ctx".to_string());
+    assert_eq!(sc.to_display_names(), vec!["ctx.*".to_string()]);
+}
+
+/// Zero-tech-debt regression: the `Mixed` variant used to silently drop
+/// `similarity_scores` and `qualified_wildcards` from its display names,
+/// so bindings showed incomplete column lists for queries that combined
+/// those features with regular columns.
+#[test]
+fn test_display_names_mixed_includes_all_variants() {
+    let sc = SelectColumns::Mixed {
+        columns: vec![Column::new("title"), Column::new("author")],
+        aggregations: Vec::new(),
+        similarity_scores: vec![SimilarityScoreExpr {
+            alias: Some("score".to_string()),
+        }],
+        qualified_wildcards: vec!["ctx".to_string()],
+        window_functions: vec![WindowFunction {
+            function_type: WindowFunctionType::RowNumber,
+            over_clause: OverClause {
+                partition_by: Vec::new(),
+                order_by: Vec::new(),
+            },
+            alias: Some("rn".to_string()),
+        }],
+    };
+
+    // Expected order (mirrors the SELECT-list grammar):
+    //   columns → aggregations → similarity_scores → qualified_wildcards → windows
+    assert_eq!(
+        sc.to_display_names(),
+        vec![
+            "title".to_string(),
+            "author".to_string(),
+            "score".to_string(),
+            "ctx.*".to_string(),
+            "rn".to_string(),
+        ]
+    );
+}
+
+/// Edge case: Mixed with only a similarity score and a qualified wildcard
+/// (no regular columns). Pre-fix, this would return an empty `Vec`,
+/// completely hiding the SELECT list from bindings.
+#[test]
+fn test_display_names_mixed_without_columns_still_exposes_score_and_wildcard() {
+    let sc = SelectColumns::Mixed {
+        columns: Vec::new(),
+        aggregations: Vec::new(),
+        similarity_scores: vec![SimilarityScoreExpr { alias: None }],
+        qualified_wildcards: vec!["docs".to_string()],
+        window_functions: Vec::new(),
+    };
+
+    assert_eq!(
+        sc.to_display_names(),
+        vec!["similarity".to_string(), "docs.*".to_string()]
+    );
+}

--- a/crates/velesdb-core/src/velesql/grammar.pest
+++ b/crates/velesdb-core/src/velesql/grammar.pest
@@ -295,7 +295,7 @@ select_list = { "*" | select_item_list }
 
 // Mixed select items: columns, aggregations, similarity(), and qualified wildcards
 select_item_list = { select_item ~ ("," ~ select_item)* }
-select_item = { similarity_select | aggregation_item | qualified_wildcard | column }
+select_item = { similarity_select | window_item | aggregation_item | qualified_wildcard | column }
 
 // similarity() zero-arg in SELECT: SELECT similarity() [AS alias]
 similarity_select = { ^"similarity" ~ "(" ~ ")" ~ (^"AS" ~ identifier)? }
@@ -308,6 +308,30 @@ aggregation_item = { aggregate_function ~ (^"AS" ~ identifier)? }
 aggregate_function = { aggregate_type ~ "(" ~ aggregate_arg ~ ")" }
 aggregate_type = { ^"FIRST" | ^"COUNT" | ^"SUM" | ^"AVG" | ^"MIN" | ^"MAX" }
 aggregate_arg = { "*" | ^"score" | column_name }
+
+// ──────────────────────────────────────────────────────────────
+// Window functions (Issue #386 Phase 1)
+// ──────────────────────────────────────────────────────────────
+
+// Window function expression in SELECT list
+// Example: ROW_NUMBER() OVER (PARTITION BY source ORDER BY score DESC) AS rn
+window_item = { window_function_call ~ ^"OVER" ~ "(" ~ over_clause ~ ")" ~ (^"AS" ~ identifier)? }
+
+// Window function call (zero-arg for Phase 1 ranking functions)
+window_function_call = { window_function_name ~ "(" ~ ")" }
+window_function_name = { ^"ROW_NUMBER" | ^"DENSE_RANK" | ^"RANK" }
+
+// OVER clause: optional PARTITION BY + optional ORDER BY
+over_clause = { partition_by_clause? ~ window_order_by_clause? }
+
+// PARTITION BY: one or more columns
+partition_by_clause = { ^"PARTITION" ~ ^"BY" ~ partition_by_list }
+partition_by_list = { column_name ~ ("," ~ column_name)* }
+
+// ORDER BY inside OVER(): separate rule to avoid ambiguity with outer ORDER BY
+window_order_by_clause = { ^"ORDER" ~ ^"BY" ~ window_order_by_item ~ ("," ~ window_order_by_item)* }
+window_order_by_item = { window_order_by_expr ~ sort_direction? }
+window_order_by_expr = { order_by_similarity_bare | column_name }
 
 column = { column_name ~ (^"AS" ~ identifier)? }
 // EPIC-052 US-005: Support nested field paths like metadata.source or profile.address.city

--- a/crates/velesdb-core/src/velesql/mod.rs
+++ b/crates/velesdb-core/src/velesql/mod.rs
@@ -218,6 +218,8 @@ pub use ast::{
     LogicalOp,
     MatchCondition,
     OrderByExpr,
+    // Window functions (Issue #386)
+    OverClause,
     // WITH clause
     QuantizationMode,
     Query,
@@ -244,14 +246,12 @@ pub use ast::{
     VectorExpr,
     VectorFusedSearch,
     VectorSearch,
-    WithClause,
-    WithOption,
-    WithValue,
-    // Window functions (Issue #386)
-    OverClause,
     WindowFunction,
     WindowFunctionType,
     WindowOrderBy,
+    WithClause,
+    WithOption,
+    WithValue,
 };
 pub use graph_pattern::*;
 // Re-export match_clause parser functions for benchmarks

--- a/crates/velesdb-core/src/velesql/mod.rs
+++ b/crates/velesdb-core/src/velesql/mod.rs
@@ -85,6 +85,9 @@ mod validation_parity_tests;
 #[cfg(test)]
 mod validation_tests;
 mod validation_types;
+pub mod window_evaluator;
+#[cfg(test)]
+mod window_function_tests;
 
 #[cfg(test)]
 mod aggregation_params_tests;
@@ -244,6 +247,11 @@ pub use ast::{
     WithClause,
     WithOption,
     WithValue,
+    // Window functions (Issue #386)
+    OverClause,
+    WindowFunction,
+    WindowFunctionType,
+    WindowOrderBy,
 };
 pub use graph_pattern::*;
 // Re-export match_clause parser functions for benchmarks

--- a/crates/velesdb-core/src/velesql/parser/select/clause_projection.rs
+++ b/crates/velesdb-core/src/velesql/parser/select/clause_projection.rs
@@ -292,6 +292,21 @@ impl Parser {
     pub(crate) fn parse_window_item(
         pair: pest::iterators::Pair<Rule>,
     ) -> Result<WindowFunction, ParseError> {
+        let (function_type, over_clause, alias) = Self::parse_window_item_parts(pair)?;
+
+        Ok(WindowFunction {
+            function_type: function_type
+                .ok_or_else(|| ParseError::syntax(0, "", "Expected window function"))?,
+            over_clause: over_clause
+                .ok_or_else(|| ParseError::syntax(0, "", "Expected OVER clause"))?,
+            alias,
+        })
+    }
+
+    /// Extracts the constituent parts from a `window_item` pair.
+    fn parse_window_item_parts(
+        pair: pest::iterators::Pair<Rule>,
+    ) -> Result<(Option<WindowFunctionType>, Option<OverClause>, Option<String>), ParseError> {
         let mut function_type = None;
         let mut over_clause = None;
         let mut alias = None;
@@ -311,13 +326,7 @@ impl Parser {
             }
         }
 
-        Ok(WindowFunction {
-            function_type: function_type
-                .ok_or_else(|| ParseError::syntax(0, "", "Expected window function"))?,
-            over_clause: over_clause
-                .ok_or_else(|| ParseError::syntax(0, "", "Expected OVER clause"))?,
-            alias,
-        })
+        Ok((function_type, over_clause, alias))
     }
 
     /// Parses `window_function_name ~ "(" ~ ")"`.

--- a/crates/velesdb-core/src/velesql/parser/select/clause_projection.rs
+++ b/crates/velesdb-core/src/velesql/parser/select/clause_projection.rs
@@ -3,13 +3,22 @@
 use super::super::helpers::strip_identifier_quotes;
 use super::super::{extract_identifier, Rule};
 use super::validation;
+use crate::velesql::ast::OverClause;
 use crate::velesql::ast::{
     AggregateArg, AggregateFunction, AggregateType, Column, SelectColumns, SimilarityScoreExpr,
     WindowFunction, WindowFunctionType, WindowOrderBy,
 };
-use crate::velesql::ast::OverClause;
 use crate::velesql::error::ParseError;
 use crate::velesql::Parser;
+
+/// Intermediate tuple returned by `parse_window_item_parts`. Named via a
+/// type alias so the `clippy::type_complexity` lint does not fire on the
+/// bare `Option<...>, Option<...>, Option<String>` trio.
+type WindowItemParts = (
+    Option<WindowFunctionType>,
+    Option<OverClause>,
+    Option<String>,
+);
 
 /// Accumulator for parsed SELECT items before building `SelectColumns`.
 struct SelectItemAccumulator {
@@ -123,8 +132,7 @@ impl Parser {
                                 .push(Self::parse_similarity_select(item));
                         }
                         Rule::window_item => {
-                            acc.window_functions
-                                .push(Self::parse_window_item(item)?);
+                            acc.window_functions.push(Self::parse_window_item(item)?);
                         }
                         Rule::aggregation_item => {
                             acc.aggregations.push(Self::parse_aggregation_item(item)?);
@@ -306,7 +314,7 @@ impl Parser {
     /// Extracts the constituent parts from a `window_item` pair.
     fn parse_window_item_parts(
         pair: pest::iterators::Pair<Rule>,
-    ) -> Result<(Option<WindowFunctionType>, Option<OverClause>, Option<String>), ParseError> {
+    ) -> Result<WindowItemParts, ParseError> {
         let mut function_type = None;
         let mut over_clause = None;
         let mut alias = None;
@@ -339,11 +347,7 @@ impl Parser {
                     "ROW_NUMBER" => Ok(WindowFunctionType::RowNumber),
                     "RANK" => Ok(WindowFunctionType::Rank),
                     "DENSE_RANK" => Ok(WindowFunctionType::DenseRank),
-                    other => Err(ParseError::syntax(
-                        0,
-                        other,
-                        "Unknown window function",
-                    )),
+                    other => Err(ParseError::syntax(0, other, "Unknown window function")),
                 };
             }
         }
@@ -351,9 +355,7 @@ impl Parser {
     }
 
     /// Parses `partition_by_clause? ~ window_order_by_clause?`.
-    fn parse_over_clause(
-        pair: pest::iterators::Pair<Rule>,
-    ) -> Result<OverClause, ParseError> {
+    fn parse_over_clause(pair: pest::iterators::Pair<Rule>) -> Result<OverClause, ParseError> {
         let mut partition_by = Vec::new();
         let mut order_by = Vec::new();
 

--- a/crates/velesdb-core/src/velesql/parser/select/clause_projection.rs
+++ b/crates/velesdb-core/src/velesql/parser/select/clause_projection.rs
@@ -5,7 +5,9 @@ use super::super::{extract_identifier, Rule};
 use super::validation;
 use crate::velesql::ast::{
     AggregateArg, AggregateFunction, AggregateType, Column, SelectColumns, SimilarityScoreExpr,
+    WindowFunction, WindowFunctionType, WindowOrderBy,
 };
+use crate::velesql::ast::OverClause;
 use crate::velesql::error::ParseError;
 use crate::velesql::Parser;
 
@@ -15,6 +17,7 @@ struct SelectItemAccumulator {
     aggregations: Vec<AggregateFunction>,
     similarity_scores: Vec<SimilarityScoreExpr>,
     qualified_wildcards: Vec<String>,
+    window_functions: Vec<WindowFunction>,
 }
 
 impl SelectItemAccumulator {
@@ -24,6 +27,7 @@ impl SelectItemAccumulator {
             aggregations: Vec::new(),
             similarity_scores: Vec::new(),
             qualified_wildcards: Vec::new(),
+            window_functions: Vec::new(),
         }
     }
 
@@ -41,6 +45,7 @@ impl SelectItemAccumulator {
             aggregations: self.aggregations,
             similarity_scores: self.similarity_scores,
             qualified_wildcards: self.qualified_wildcards,
+            window_functions: self.window_functions,
         }
     }
 
@@ -51,6 +56,7 @@ impl SelectItemAccumulator {
             !self.aggregations.is_empty(),
             !self.similarity_scores.is_empty(),
             !self.qualified_wildcards.is_empty(),
+            !self.window_functions.is_empty(),
         ]
         .iter()
         .filter(|&&b| b)
@@ -82,12 +88,13 @@ impl SelectItemAccumulator {
                     .expect("checked len==1"),
             );
         }
-        // Multiple similarity scores or wildcards without other types -> Mixed
+        // Multiple similarity scores, wildcards, or window functions without other types -> Mixed
         SelectColumns::Mixed {
             columns: self.columns,
             aggregations: self.aggregations,
             similarity_scores: self.similarity_scores,
             qualified_wildcards: self.qualified_wildcards,
+            window_functions: self.window_functions,
         }
     }
 }
@@ -114,6 +121,10 @@ impl Parser {
                         Rule::similarity_select => {
                             acc.similarity_scores
                                 .push(Self::parse_similarity_select(item));
+                        }
+                        Rule::window_item => {
+                            acc.window_functions
+                                .push(Self::parse_window_item(item)?);
                         }
                         Rule::aggregation_item => {
                             acc.aggregations.push(Self::parse_aggregation_item(item)?);
@@ -271,5 +282,153 @@ impl Parser {
         } else {
             strip_identifier_quotes(raw)
         }
+    }
+
+    // ────────────────────────────────────────────────────────────
+    // Window function parsing (Issue #386 Phase 1)
+    // ────────────────────────────────────────────────────────────
+
+    /// Parses a `window_item`: `window_function_call OVER (over_clause) [AS alias]`.
+    pub(crate) fn parse_window_item(
+        pair: pest::iterators::Pair<Rule>,
+    ) -> Result<WindowFunction, ParseError> {
+        let mut function_type = None;
+        let mut over_clause = None;
+        let mut alias = None;
+
+        for inner_pair in pair.into_inner() {
+            match inner_pair.as_rule() {
+                Rule::window_function_call => {
+                    function_type = Some(Self::parse_window_function_call(inner_pair)?);
+                }
+                Rule::over_clause => {
+                    over_clause = Some(Self::parse_over_clause(inner_pair)?);
+                }
+                Rule::identifier => {
+                    alias = Some(extract_identifier(&inner_pair));
+                }
+                _ => {}
+            }
+        }
+
+        Ok(WindowFunction {
+            function_type: function_type
+                .ok_or_else(|| ParseError::syntax(0, "", "Expected window function"))?,
+            over_clause: over_clause
+                .ok_or_else(|| ParseError::syntax(0, "", "Expected OVER clause"))?,
+            alias,
+        })
+    }
+
+    /// Parses `window_function_name ~ "(" ~ ")"`.
+    fn parse_window_function_call(
+        pair: pest::iterators::Pair<Rule>,
+    ) -> Result<WindowFunctionType, ParseError> {
+        for inner in pair.into_inner() {
+            if inner.as_rule() == Rule::window_function_name {
+                return match inner.as_str().to_uppercase().as_str() {
+                    "ROW_NUMBER" => Ok(WindowFunctionType::RowNumber),
+                    "RANK" => Ok(WindowFunctionType::Rank),
+                    "DENSE_RANK" => Ok(WindowFunctionType::DenseRank),
+                    other => Err(ParseError::syntax(
+                        0,
+                        other,
+                        "Unknown window function",
+                    )),
+                };
+            }
+        }
+        Err(ParseError::syntax(0, "", "Expected window function name"))
+    }
+
+    /// Parses `partition_by_clause? ~ window_order_by_clause?`.
+    fn parse_over_clause(
+        pair: pest::iterators::Pair<Rule>,
+    ) -> Result<OverClause, ParseError> {
+        let mut partition_by = Vec::new();
+        let mut order_by = Vec::new();
+
+        for inner in pair.into_inner() {
+            match inner.as_rule() {
+                Rule::partition_by_clause => {
+                    partition_by = Self::parse_partition_by_list(inner);
+                }
+                Rule::window_order_by_clause => {
+                    order_by = Self::parse_window_order_by(inner)?;
+                }
+                _ => {}
+            }
+        }
+
+        Ok(OverClause {
+            partition_by,
+            order_by,
+        })
+    }
+
+    /// Extracts column names from `partition_by_clause`.
+    fn parse_partition_by_list(pair: pest::iterators::Pair<Rule>) -> Vec<String> {
+        let mut cols = Vec::new();
+        for inner in pair.into_inner() {
+            if inner.as_rule() == Rule::partition_by_list {
+                for col in inner.into_inner() {
+                    if col.as_rule() == Rule::column_name {
+                        cols.push(Self::parse_column_name(&col));
+                    }
+                }
+            }
+        }
+        cols
+    }
+
+    /// Parses `window_order_by_clause` into a list of `WindowOrderBy`.
+    fn parse_window_order_by(
+        pair: pest::iterators::Pair<Rule>,
+    ) -> Result<Vec<WindowOrderBy>, ParseError> {
+        let mut items = Vec::new();
+        for inner in pair.into_inner() {
+            if inner.as_rule() == Rule::window_order_by_item {
+                items.push(Self::parse_window_order_by_item(inner)?);
+            }
+        }
+        Ok(items)
+    }
+
+    /// Parses a single `window_order_by_item`.
+    fn parse_window_order_by_item(
+        pair: pest::iterators::Pair<Rule>,
+    ) -> Result<WindowOrderBy, ParseError> {
+        let mut column = None;
+        let mut descending = false;
+
+        for inner in pair.into_inner() {
+            match inner.as_rule() {
+                Rule::window_order_by_expr => {
+                    // The expression can be column_name or order_by_similarity_bare
+                    for expr_inner in inner.into_inner() {
+                        match expr_inner.as_rule() {
+                            Rule::column_name => {
+                                column = Some(Self::parse_column_name(&expr_inner));
+                            }
+                            Rule::order_by_similarity_bare => {
+                                column = Some("similarity".to_string());
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+                Rule::sort_direction => {
+                    descending = inner.as_str().to_uppercase() == "DESC";
+                }
+                _ => {}
+            }
+        }
+
+        Ok(WindowOrderBy {
+            column: column.ok_or_else(|| {
+                ParseError::syntax(0, "", "Expected column name in window ORDER BY")
+            })?,
+            descending,
+        })
     }
 }

--- a/crates/velesdb-core/src/velesql/window_evaluator.rs
+++ b/crates/velesdb-core/src/velesql/window_evaluator.rs
@@ -6,27 +6,77 @@
 //! Window evaluation happens **after** DISTINCT but **before** ORDER BY/LIMIT
 //! in the query pipeline, matching SQL standard semantics.
 //!
-//! ## Design: Snapshot-based evaluation
+//! ## Design: Global snapshot-first evaluation
 //!
-//! Rankings are computed using a **snapshot** of ORDER BY values taken before
-//! any payload mutation. This prevents two classes of corruption:
+//! Rankings are computed from snapshots of ORDER BY values AND PARTITION BY
+//! keys taken **up-front for every window function**, before any single
+//! injection runs. This prevents three classes of corruption:
 //!
 //! 1. **Intra-function**: If the window alias matches an ORDER BY column
 //!    (e.g., `RANK() OVER (ORDER BY score DESC) AS score`), injecting the
-//!    rank mid-loop would overwrite the original sort value.
+//!    rank mid-loop would overwrite the original sort value. Fixed by the
+//!    per-function three-phase (snapshot → compute → inject) path.
 //!
-//! 2. **Inter-function**: When multiple window functions are evaluated
-//!    sequentially, each snapshots independently so a prior function's
-//!    injected values cannot contaminate the next function's comparisons.
+//! 2. **Inter-function on ORDER BY**: When multiple window functions are
+//!    evaluated sequentially and an earlier function's alias collides with
+//!    a later function's ORDER BY column (e.g.
+//!    `ROW_NUMBER() ... AS score, RANK() OVER (ORDER BY score DESC) AS rnk`),
+//!    the later function would read the injected ranks instead of the
+//!    original payload. Fixed by snapshotting ORDER BY values for **every**
+//!    window function before any injection.
+//!
+//! 3. **Inter-function on PARTITION BY**: Same contamination path but via
+//!    a partition key rather than a sort key. Fixed by snapshotting partition
+//!    keys alongside ORDER BY values, up-front.
 
-use crate::velesql::{OverClause, WindowFunction, WindowFunctionType, WindowOrderBy};
+use crate::velesql::{WindowFunction, WindowFunctionType, WindowOrderBy};
 use crate::SearchResult;
 use std::collections::BTreeMap;
 
+/// Pre-computed per-row snapshot of the inputs a single window function
+/// reads from the result set.
+///
+/// Captured in [`evaluate`] **before any window function injects values**
+/// so sequential injection cannot contaminate later functions' inputs.
+struct WindowSnapshot {
+    /// For each row (parallel index to `results`), the value of each
+    /// ORDER BY column in the `OVER` clause, in declaration order.
+    order_by_values: Vec<Vec<serde_json::Value>>,
+    /// For each row, the pre-computed PARTITION BY key string.
+    partition_keys: Vec<String>,
+}
+
+impl WindowSnapshot {
+    fn capture(results: &[SearchResult], wf: &WindowFunction) -> Self {
+        let order_by_values = results
+            .iter()
+            .map(|r| {
+                wf.over_clause
+                    .order_by
+                    .iter()
+                    .map(|ob| extract_sort_value(r, &ob.column))
+                    .collect()
+            })
+            .collect();
+        let partition_keys = results
+            .iter()
+            .map(|r| partition_key(r, &wf.over_clause.partition_by))
+            .collect();
+        Self {
+            order_by_values,
+            partition_keys,
+        }
+    }
+}
+
 /// Evaluates window functions on a mutable result set.
 ///
-/// For each window function, snapshots ORDER BY values, computes rankings
-/// from the snapshots, then injects results into payloads in a separate pass.
+/// Pre-snapshots every window function's ORDER BY values and PARTITION BY
+/// keys **before** any injection, then computes rankings and injects
+/// results one function at a time. This prevents both intra-function
+/// corruption (alias collides with its own ORDER BY column) and
+/// inter-function contamination (an earlier function's alias collides
+/// with a later function's ORDER BY or PARTITION BY column).
 ///
 /// Returns `Ok(())` unconditionally; the `Result` signature is kept for
 /// pipeline consistency with the execution engine.
@@ -41,19 +91,33 @@ pub fn evaluate(
     results: &mut [SearchResult],
     window_functions: &[WindowFunction],
 ) -> crate::Result<()> {
-    for wf in window_functions {
-        apply_single_window(results, wf);
+    // Phase 0: snapshot EVERY window function's inputs before any injection.
+    // This is the fix for inter-function contamination — once any window
+    // function injects values into payloads, later snapshots would read the
+    // injected values instead of the originals.
+    let snapshots: Vec<WindowSnapshot> = window_functions
+        .iter()
+        .map(|wf| WindowSnapshot::capture(results, wf))
+        .collect();
+
+    for (wf, snapshot) in window_functions.iter().zip(snapshots.iter()) {
+        apply_single_window(results, wf, snapshot);
     }
     Ok(())
 }
 
-/// Applies a single window function across all partitions.
+/// Applies a single window function across all partitions, using a
+/// pre-captured snapshot of its inputs.
 ///
 /// Uses a three-phase approach to prevent payload corruption:
-/// 1. **Snapshot** all ORDER BY values before any mutation.
-/// 2. **Compute** rankings from snapshots (read-only).
+/// 1. **Snapshot** captured up-front by [`evaluate`] (read-only from here).
+/// 2. **Compute** rankings from the snapshot.
 /// 3. **Inject** ranking values into payloads (write-only).
-fn apply_single_window(results: &mut [SearchResult], wf: &WindowFunction) {
+fn apply_single_window(
+    results: &mut [SearchResult],
+    wf: &WindowFunction,
+    snapshot: &WindowSnapshot,
+) {
     let alias = wf
         .alias
         .as_deref()
@@ -67,28 +131,20 @@ fn apply_single_window(results: &mut [SearchResult], wf: &WindowFunction) {
         );
     }
 
-    // Phase 1: Snapshot ORDER BY values before any mutation.
-    let sort_snapshots: Vec<Vec<serde_json::Value>> = results
-        .iter()
-        .map(|r| {
-            wf.over_clause
-                .order_by
-                .iter()
-                .map(|ob| extract_sort_value(r, &ob.column))
-                .collect()
-        })
-        .collect();
-
-    // Phase 2: Build partitions and compute rankings (read-only from snapshots).
-    let partitions = build_partitions(results, &wf.over_clause);
+    // Phase 2: Build partitions from the pre-snapshotted partition keys
+    // and compute rankings (read-only from snapshots).
+    let partitions = build_partitions_from_snapshot(&snapshot.partition_keys);
     let mut all_rankings: Vec<(usize, u64)> = Vec::new();
 
     for indices in partitions.values() {
-        let sorted =
-            sort_partition_from_snapshots(indices, &sort_snapshots, &wf.over_clause.order_by);
+        let sorted = sort_partition_from_snapshots(
+            indices,
+            &snapshot.order_by_values,
+            &wf.over_clause.order_by,
+        );
         let rankings = compute_rankings(
             &sorted,
-            &sort_snapshots,
+            &snapshot.order_by_values,
             &wf.over_clause.order_by,
             wf.function_type,
         );
@@ -101,18 +157,15 @@ fn apply_single_window(results: &mut [SearchResult], wf: &WindowFunction) {
     }
 }
 
-/// Groups result indices by their `PARTITION BY` key values.
+/// Groups row indices by their pre-computed `PARTITION BY` key.
 ///
 /// Uses `BTreeMap` for deterministic partition ordering in tests.
-/// Empty `partition_by` → single partition containing all indices.
-fn build_partitions(
-    results: &[SearchResult],
-    over_clause: &OverClause,
-) -> BTreeMap<String, Vec<usize>> {
+/// An empty `PARTITION BY` clause maps every row to the same key (`""`),
+/// producing a single partition that covers the whole result set.
+fn build_partitions_from_snapshot(partition_keys: &[String]) -> BTreeMap<String, Vec<usize>> {
     let mut partitions: BTreeMap<String, Vec<usize>> = BTreeMap::new();
-    for (i, result) in results.iter().enumerate() {
-        let key = partition_key(result, &over_clause.partition_by);
-        partitions.entry(key).or_default().push(i);
+    for (i, key) in partition_keys.iter().enumerate() {
+        partitions.entry(key.clone()).or_default().push(i);
     }
     partitions
 }

--- a/crates/velesdb-core/src/velesql/window_evaluator.rs
+++ b/crates/velesdb-core/src/velesql/window_evaluator.rs
@@ -196,23 +196,19 @@ fn assign_rankings(
     let mut dense_rank: u64 = 1;
 
     for (position, &idx) in sorted_indices.iter().enumerate() {
+        let is_new_group = is_new_ranking_group(results, sorted_indices, position, order_by);
+
         let value = match fn_type {
             WindowFunctionType::RowNumber => (position + 1) as u64,
             WindowFunctionType::Rank => {
-                if position > 0 {
-                    let prev_idx = sorted_indices[position - 1];
-                    if !rows_tied(results, idx, prev_idx, order_by) {
-                        rank = (position + 1) as u64;
-                    }
+                if is_new_group {
+                    rank = (position + 1) as u64;
                 }
                 rank
             }
             WindowFunctionType::DenseRank => {
-                if position > 0 {
-                    let prev_idx = sorted_indices[position - 1];
-                    if !rows_tied(results, idx, prev_idx, order_by) {
-                        dense_rank += 1;
-                    }
+                if is_new_group {
+                    dense_rank += 1;
                 }
                 dense_rank
             }
@@ -220,6 +216,23 @@ fn assign_rankings(
 
         inject_ranking(&mut results[idx], alias, value);
     }
+}
+
+/// Returns `true` if this position starts a new ranking group (not tied with predecessor).
+///
+/// The first position (0) is never a "new group" — it starts at rank 1 by default.
+fn is_new_ranking_group(
+    results: &[SearchResult],
+    sorted_indices: &[usize],
+    position: usize,
+    order_by: &[WindowOrderBy],
+) -> bool {
+    if position == 0 {
+        return false;
+    }
+    let idx = sorted_indices[position];
+    let prev_idx = sorted_indices[position - 1];
+    !rows_tied(results, idx, prev_idx, order_by)
 }
 
 /// Returns `true` if two rows have identical values for all ORDER BY columns.

--- a/crates/velesdb-core/src/velesql/window_evaluator.rs
+++ b/crates/velesdb-core/src/velesql/window_evaluator.rs
@@ -5,6 +5,19 @@
 //!
 //! Window evaluation happens **after** DISTINCT but **before** ORDER BY/LIMIT
 //! in the query pipeline, matching SQL standard semantics.
+//!
+//! ## Design: Snapshot-based evaluation
+//!
+//! Rankings are computed using a **snapshot** of ORDER BY values taken before
+//! any payload mutation. This prevents two classes of corruption:
+//!
+//! 1. **Intra-function**: If the window alias matches an ORDER BY column
+//!    (e.g., `RANK() OVER (ORDER BY score DESC) AS score`), injecting the
+//!    rank mid-loop would overwrite the original sort value.
+//!
+//! 2. **Inter-function**: When multiple window functions are evaluated
+//!    sequentially, each snapshots independently so a prior function's
+//!    injected values cannot contaminate the next function's comparisons.
 
 use crate::velesql::{OverClause, WindowFunction, WindowFunctionType, WindowOrderBy};
 use crate::SearchResult;
@@ -12,9 +25,8 @@ use std::collections::BTreeMap;
 
 /// Evaluates window functions on a mutable result set.
 ///
-/// For each window function, partitions the results, sorts within each
-/// partition, computes the ranking value, and injects it into the
-/// `SearchResult`'s payload as a new JSON field.
+/// For each window function, snapshots ORDER BY values, computes rankings
+/// from the snapshots, then injects results into payloads in a separate pass.
 ///
 /// Returns `Ok(())` unconditionally; the `Result` signature is kept for
 /// pipeline consistency with the execution engine.
@@ -29,6 +41,11 @@ pub fn evaluate(
 }
 
 /// Applies a single window function across all partitions.
+///
+/// Uses a three-phase approach to prevent payload corruption:
+/// 1. **Snapshot** all ORDER BY values before any mutation.
+/// 2. **Compute** rankings from snapshots (read-only).
+/// 3. **Inject** ranking values into payloads (write-only).
 fn apply_single_window(
     results: &mut [SearchResult],
     wf: &WindowFunction,
@@ -46,13 +63,31 @@ fn apply_single_window(
         );
     }
 
-    // Step 1: Build partition groups (row indices grouped by partition key).
-    let partitions = build_partitions(results, &wf.over_clause);
+    // Phase 1: Snapshot ORDER BY values before any mutation.
+    let sort_snapshots: Vec<Vec<serde_json::Value>> = results
+        .iter()
+        .map(|r| {
+            wf.over_clause
+                .order_by
+                .iter()
+                .map(|ob| extract_sort_value(r, &ob.column))
+                .collect()
+        })
+        .collect();
 
-    // Step 2: For each partition, sort indices and assign rankings.
+    // Phase 2: Build partitions and compute rankings (read-only from snapshots).
+    let partitions = build_partitions(results, &wf.over_clause);
+    let mut all_rankings: Vec<(usize, u64)> = Vec::new();
+
     for indices in partitions.values() {
-        let sorted = sort_partition(results, indices, &wf.over_clause.order_by);
-        assign_rankings(results, &sorted, &wf.over_clause.order_by, wf.function_type, alias);
+        let sorted = sort_partition_from_snapshots(indices, &sort_snapshots, &wf.over_clause.order_by);
+        let rankings = compute_rankings(&sorted, &sort_snapshots, &wf.over_clause.order_by, wf.function_type);
+        all_rankings.extend(rankings);
+    }
+
+    // Phase 3: Inject all rankings (write-only, no more reads).
+    for (idx, value) in all_rankings {
+        inject_ranking(&mut results[idx], alias, value);
     }
 }
 
@@ -88,34 +123,85 @@ fn partition_key(result: &SearchResult, columns: &[String]) -> String {
         .join("\x1F")
 }
 
-/// Sorts indices within a partition according to the window `ORDER BY` spec.
-fn sort_partition(
-    results: &[SearchResult],
+/// Sorts indices within a partition using pre-snapshotted sort values.
+///
+/// This avoids reading from payloads during sorting, preventing any
+/// corruption from prior injections.
+fn sort_partition_from_snapshots(
     indices: &[usize],
+    snapshots: &[Vec<serde_json::Value>],
     order_by: &[WindowOrderBy],
 ) -> Vec<usize> {
     let mut sorted = indices.to_vec();
-    sorted.sort_by(|&a, &b| compare_rows(results, a, b, order_by));
+    sorted.sort_by(|&a, &b| {
+        for (col_idx, ob) in order_by.iter().enumerate() {
+            let cmp = compare_json_values(&snapshots[a][col_idx], &snapshots[b][col_idx]);
+            let cmp = if ob.descending { cmp.reverse() } else { cmp };
+            if cmp != std::cmp::Ordering::Equal {
+                return cmp;
+            }
+        }
+        std::cmp::Ordering::Equal
+    });
     sorted
 }
 
-/// Compares two result rows by the window `ORDER BY` columns.
-fn compare_rows(
-    results: &[SearchResult],
-    a: usize,
-    b: usize,
+/// Computes ranking values from pre-snapshotted sort values.
+///
+/// Returns a list of `(result_index, ranking_value)` pairs.
+/// Uses snapshots for tie detection to prevent payload corruption.
+fn compute_rankings(
+    sorted_indices: &[usize],
+    snapshots: &[Vec<serde_json::Value>],
     order_by: &[WindowOrderBy],
-) -> std::cmp::Ordering {
-    for ob in order_by {
-        let val_a = extract_sort_value(&results[a], &ob.column);
-        let val_b = extract_sort_value(&results[b], &ob.column);
-        let cmp = compare_json_values(&val_a, &val_b);
-        let cmp = if ob.descending { cmp.reverse() } else { cmp };
-        if cmp != std::cmp::Ordering::Equal {
-            return cmp;
+    fn_type: WindowFunctionType,
+) -> Vec<(usize, u64)> {
+    let mut rankings = Vec::with_capacity(sorted_indices.len());
+    let mut rank: u64 = 1;
+    let mut dense_rank: u64 = 1;
+
+    for (position, &idx) in sorted_indices.iter().enumerate() {
+        let is_new_group = if position == 0 {
+            false
+        } else {
+            let prev_idx = sorted_indices[position - 1];
+            !snapshots_tied(&snapshots[idx], &snapshots[prev_idx], order_by)
+        };
+
+        let value = match fn_type {
+            WindowFunctionType::RowNumber => (position + 1) as u64,
+            WindowFunctionType::Rank => {
+                if is_new_group {
+                    rank = (position + 1) as u64;
+                }
+                rank
+            }
+            WindowFunctionType::DenseRank => {
+                if is_new_group {
+                    dense_rank += 1;
+                }
+                dense_rank
+            }
+        };
+
+        rankings.push((idx, value));
+    }
+
+    rankings
+}
+
+/// Returns `true` if two snapshot rows have identical ORDER BY values.
+fn snapshots_tied(
+    snap_a: &[serde_json::Value],
+    snap_b: &[serde_json::Value],
+    order_by: &[WindowOrderBy],
+) -> bool {
+    for (col_idx, _ob) in order_by.iter().enumerate() {
+        if compare_json_values(&snap_a[col_idx], &snap_b[col_idx]) != std::cmp::Ordering::Equal {
+            return false;
         }
     }
-    std::cmp::Ordering::Equal
+    true
 }
 
 /// Extracts a sortable value from a result for comparison.
@@ -179,78 +265,6 @@ fn compare_json_values(a: &serde_json::Value, b: &serde_json::Value) -> std::cmp
             _ => a.to_string().cmp(&b.to_string()),
         },
     }
-}
-
-/// Assigns ranking values to each result in the sorted partition.
-///
-/// - `ROW_NUMBER`: sequential 1..N, no ties.
-/// - `RANK`: same rank for ties, gaps after ties (1, 2, 2, 4).
-/// - `DENSE_RANK`: same rank for ties, no gaps (1, 2, 2, 3).
-fn assign_rankings(
-    results: &mut [SearchResult],
-    sorted_indices: &[usize],
-    order_by: &[WindowOrderBy],
-    fn_type: WindowFunctionType,
-    alias: &str,
-) {
-    let mut rank: u64 = 1;
-    let mut dense_rank: u64 = 1;
-
-    for (position, &idx) in sorted_indices.iter().enumerate() {
-        let is_new_group = is_new_ranking_group(results, sorted_indices, position, order_by);
-
-        let value = match fn_type {
-            WindowFunctionType::RowNumber => (position + 1) as u64,
-            WindowFunctionType::Rank => {
-                if is_new_group {
-                    rank = (position + 1) as u64;
-                }
-                rank
-            }
-            WindowFunctionType::DenseRank => {
-                if is_new_group {
-                    dense_rank += 1;
-                }
-                dense_rank
-            }
-        };
-
-        inject_ranking(&mut results[idx], alias, value);
-    }
-}
-
-/// Returns `true` if this position starts a new ranking group (not tied with predecessor).
-///
-/// The first position (0) is never a "new group" — it starts at rank 1 by default.
-fn is_new_ranking_group(
-    results: &[SearchResult],
-    sorted_indices: &[usize],
-    position: usize,
-    order_by: &[WindowOrderBy],
-) -> bool {
-    if position == 0 {
-        return false;
-    }
-    let idx = sorted_indices[position];
-    let prev_idx = sorted_indices[position - 1];
-    !rows_tied(results, idx, prev_idx, order_by)
-}
-
-/// Returns `true` if two rows have identical values for all ORDER BY columns.
-fn rows_tied(
-    results: &[SearchResult],
-    a: usize,
-    b: usize,
-    order_by: &[WindowOrderBy],
-) -> bool {
-    for ob in order_by {
-        let val_a = extract_sort_value(&results[a], &ob.column);
-        let val_b = extract_sort_value(&results[b], &ob.column);
-        if compare_json_values(&val_a, &val_b) != std::cmp::Ordering::Equal {
-            return false;
-        }
-    }
-    true
 }
 
 /// Injects a ranking value into the result's payload as a new JSON field.

--- a/crates/velesdb-core/src/velesql/window_evaluator.rs
+++ b/crates/velesdb-core/src/velesql/window_evaluator.rs
@@ -30,6 +30,13 @@ use std::collections::BTreeMap;
 ///
 /// Returns `Ok(())` unconditionally; the `Result` signature is kept for
 /// pipeline consistency with the execution engine.
+///
+/// # Errors
+///
+/// Currently infallible — the signature keeps `Result` so future window
+/// functions that can fail (e.g. numeric overflow in `ROW_NUMBER` past
+/// `u64::MAX`, or a user-provided ORDER BY reference that cannot be
+/// resolved) can propagate errors without rippling through every caller.
 pub fn evaluate(
     results: &mut [SearchResult],
     window_functions: &[WindowFunction],
@@ -46,10 +53,7 @@ pub fn evaluate(
 /// 1. **Snapshot** all ORDER BY values before any mutation.
 /// 2. **Compute** rankings from snapshots (read-only).
 /// 3. **Inject** ranking values into payloads (write-only).
-fn apply_single_window(
-    results: &mut [SearchResult],
-    wf: &WindowFunction,
-) {
+fn apply_single_window(results: &mut [SearchResult], wf: &WindowFunction) {
     let alias = wf
         .alias
         .as_deref()
@@ -80,8 +84,14 @@ fn apply_single_window(
     let mut all_rankings: Vec<(usize, u64)> = Vec::new();
 
     for indices in partitions.values() {
-        let sorted = sort_partition_from_snapshots(indices, &sort_snapshots, &wf.over_clause.order_by);
-        let rankings = compute_rankings(&sorted, &sort_snapshots, &wf.over_clause.order_by, wf.function_type);
+        let sorted =
+            sort_partition_from_snapshots(indices, &sort_snapshots, &wf.over_clause.order_by);
+        let rankings = compute_rankings(
+            &sorted,
+            &sort_snapshots,
+            &wf.over_clause.order_by,
+            wf.function_type,
+        );
         all_rankings.extend(rankings);
     }
 
@@ -217,9 +227,8 @@ fn extract_sort_value(result: &SearchResult, column: &str) -> serde_json::Value 
 
 /// Extracts a potentially nested payload value (e.g., `"metadata.source"`).
 fn extract_nested_value(result: &SearchResult, column: &str) -> serde_json::Value {
-    let payload = match result.point.payload.as_ref() {
-        Some(p) => p,
-        None => return serde_json::Value::Null,
+    let Some(payload) = result.point.payload.as_ref() else {
+        return serde_json::Value::Null;
     };
 
     if column.contains('.') {

--- a/crates/velesdb-core/src/velesql/window_evaluator.rs
+++ b/crates/velesdb-core/src/velesql/window_evaluator.rs
@@ -120,9 +120,10 @@ fn compare_rows(
 
 /// Extracts a sortable value from a result for comparison.
 ///
-/// Special-cases `"similarity"` and `"score"` to use the search score.
+/// Special-cases `"similarity"` to use the search score, consistent with
+/// the main ORDER BY system in `ordering.rs`.
 fn extract_sort_value(result: &SearchResult, column: &str) -> serde_json::Value {
-    if column == "similarity" || column == "score" {
+    if column == "similarity" {
         return serde_json::Value::from(f64::from(result.score));
     }
     extract_nested_value(result, column)

--- a/crates/velesdb-core/src/velesql/window_evaluator.rs
+++ b/crates/velesdb-core/src/velesql/window_evaluator.rs
@@ -38,6 +38,14 @@ fn apply_single_window(
         .as_deref()
         .unwrap_or(wf.function_type.default_alias());
 
+    // Warn when ORDER BY is empty — ranking is non-deterministic without it.
+    if wf.over_clause.order_by.is_empty() {
+        tracing::warn!(
+            function = alias,
+            "Window function OVER clause has no ORDER BY; ranking order is non-deterministic"
+        );
+    }
+
     // Step 1: Build partition groups (row indices grouped by partition key).
     let partitions = build_partitions(results, &wf.over_clause);
 
@@ -67,7 +75,8 @@ fn build_partitions(
 /// Computes a partition key from the result's payload fields.
 ///
 /// Empty `columns` → single partition key (`""`).
-/// Multiple columns are joined with `|` as separator.
+/// Multiple columns are joined with `\x1F` (ASCII Unit Separator) to avoid
+/// collisions when values contain common delimiters.
 fn partition_key(result: &SearchResult, columns: &[String]) -> String {
     if columns.is_empty() {
         return String::new();
@@ -76,7 +85,7 @@ fn partition_key(result: &SearchResult, columns: &[String]) -> String {
         .iter()
         .map(|col| extract_payload_value(result, col))
         .collect::<Vec<_>>()
-        .join("|")
+        .join("\x1F")
 }
 
 /// Sorts indices within a partition according to the window `ORDER BY` spec.

--- a/crates/velesdb-core/src/velesql/window_evaluator.rs
+++ b/crates/velesdb-core/src/velesql/window_evaluator.rs
@@ -1,0 +1,242 @@
+//! Window function evaluation engine (Issue #386).
+//!
+//! Evaluates window functions (`ROW_NUMBER`, `RANK`, `DENSE_RANK`) over
+//! a result set, partitioning and sorting as specified by the `OVER` clause.
+//!
+//! Window evaluation happens **after** DISTINCT but **before** ORDER BY/LIMIT
+//! in the query pipeline, matching SQL standard semantics.
+
+use crate::velesql::{OverClause, WindowFunction, WindowFunctionType, WindowOrderBy};
+use crate::SearchResult;
+use std::collections::BTreeMap;
+
+/// Evaluates window functions on a mutable result set.
+///
+/// For each window function, partitions the results, sorts within each
+/// partition, computes the ranking value, and injects it into the
+/// `SearchResult`'s payload as a new JSON field.
+///
+/// Returns `Ok(())` unconditionally; the `Result` signature is kept for
+/// pipeline consistency with the execution engine.
+pub fn evaluate(
+    results: &mut [SearchResult],
+    window_functions: &[WindowFunction],
+) -> crate::Result<()> {
+    for wf in window_functions {
+        apply_single_window(results, wf);
+    }
+    Ok(())
+}
+
+/// Applies a single window function across all partitions.
+fn apply_single_window(
+    results: &mut [SearchResult],
+    wf: &WindowFunction,
+) {
+    let alias = wf
+        .alias
+        .as_deref()
+        .unwrap_or(wf.function_type.default_alias());
+
+    // Step 1: Build partition groups (row indices grouped by partition key).
+    let partitions = build_partitions(results, &wf.over_clause);
+
+    // Step 2: For each partition, sort indices and assign rankings.
+    for indices in partitions.values() {
+        let sorted = sort_partition(results, indices, &wf.over_clause.order_by);
+        assign_rankings(results, &sorted, &wf.over_clause.order_by, wf.function_type, alias);
+    }
+}
+
+/// Groups result indices by their `PARTITION BY` key values.
+///
+/// Uses `BTreeMap` for deterministic partition ordering in tests.
+/// Empty `partition_by` → single partition containing all indices.
+fn build_partitions(
+    results: &[SearchResult],
+    over_clause: &OverClause,
+) -> BTreeMap<String, Vec<usize>> {
+    let mut partitions: BTreeMap<String, Vec<usize>> = BTreeMap::new();
+    for (i, result) in results.iter().enumerate() {
+        let key = partition_key(result, &over_clause.partition_by);
+        partitions.entry(key).or_default().push(i);
+    }
+    partitions
+}
+
+/// Computes a partition key from the result's payload fields.
+///
+/// Empty `columns` → single partition key (`""`).
+/// Multiple columns are joined with `|` as separator.
+fn partition_key(result: &SearchResult, columns: &[String]) -> String {
+    if columns.is_empty() {
+        return String::new();
+    }
+    columns
+        .iter()
+        .map(|col| extract_payload_value(result, col))
+        .collect::<Vec<_>>()
+        .join("|")
+}
+
+/// Sorts indices within a partition according to the window `ORDER BY` spec.
+fn sort_partition(
+    results: &[SearchResult],
+    indices: &[usize],
+    order_by: &[WindowOrderBy],
+) -> Vec<usize> {
+    let mut sorted = indices.to_vec();
+    sorted.sort_by(|&a, &b| compare_rows(results, a, b, order_by));
+    sorted
+}
+
+/// Compares two result rows by the window `ORDER BY` columns.
+fn compare_rows(
+    results: &[SearchResult],
+    a: usize,
+    b: usize,
+    order_by: &[WindowOrderBy],
+) -> std::cmp::Ordering {
+    for ob in order_by {
+        let val_a = extract_sort_value(&results[a], &ob.column);
+        let val_b = extract_sort_value(&results[b], &ob.column);
+        let cmp = compare_json_values(&val_a, &val_b);
+        let cmp = if ob.descending { cmp.reverse() } else { cmp };
+        if cmp != std::cmp::Ordering::Equal {
+            return cmp;
+        }
+    }
+    std::cmp::Ordering::Equal
+}
+
+/// Extracts a sortable value from a result for comparison.
+///
+/// Special-cases `"similarity"` and `"score"` to use the search score.
+fn extract_sort_value(result: &SearchResult, column: &str) -> serde_json::Value {
+    if column == "similarity" || column == "score" {
+        return serde_json::Value::from(f64::from(result.score));
+    }
+    extract_nested_value(result, column)
+}
+
+/// Extracts a potentially nested payload value (e.g., `"metadata.source"`).
+fn extract_nested_value(result: &SearchResult, column: &str) -> serde_json::Value {
+    let payload = match result.point.payload.as_ref() {
+        Some(p) => p,
+        None => return serde_json::Value::Null,
+    };
+
+    if column.contains('.') {
+        // Navigate nested path: "metadata.source" → payload["metadata"]["source"]
+        let parts: Vec<&str> = column.split('.').collect();
+        let mut current = payload;
+        for part in &parts {
+            match current.get(*part) {
+                Some(v) => current = v,
+                None => return serde_json::Value::Null,
+            }
+        }
+        current.clone()
+    } else {
+        payload
+            .get(column)
+            .cloned()
+            .unwrap_or(serde_json::Value::Null)
+    }
+}
+
+/// Extracts a string representation of a payload value for partition keys.
+fn extract_payload_value(result: &SearchResult, column: &str) -> String {
+    let value = extract_nested_value(result, column);
+    match value {
+        serde_json::Value::Null => "__null__".to_string(),
+        serde_json::Value::String(s) => s,
+        other => other.to_string(),
+    }
+}
+
+/// Compares two JSON values for sorting.
+///
+/// Numeric values are compared numerically; everything else is compared
+/// as strings. `Null` sorts last (after all non-null values).
+fn compare_json_values(a: &serde_json::Value, b: &serde_json::Value) -> std::cmp::Ordering {
+    match (a, b) {
+        (serde_json::Value::Null, serde_json::Value::Null) => std::cmp::Ordering::Equal,
+        (serde_json::Value::Null, _) => std::cmp::Ordering::Greater, // NULLs sort last
+        (_, serde_json::Value::Null) => std::cmp::Ordering::Less,
+        _ => match (a.as_f64(), b.as_f64()) {
+            (Some(fa), Some(fb)) => fa.partial_cmp(&fb).unwrap_or(std::cmp::Ordering::Equal),
+            _ => a.to_string().cmp(&b.to_string()),
+        },
+    }
+}
+
+/// Assigns ranking values to each result in the sorted partition.
+///
+/// - `ROW_NUMBER`: sequential 1..N, no ties.
+/// - `RANK`: same rank for ties, gaps after ties (1, 2, 2, 4).
+/// - `DENSE_RANK`: same rank for ties, no gaps (1, 2, 2, 3).
+fn assign_rankings(
+    results: &mut [SearchResult],
+    sorted_indices: &[usize],
+    order_by: &[WindowOrderBy],
+    fn_type: WindowFunctionType,
+    alias: &str,
+) {
+    let mut rank: u64 = 1;
+    let mut dense_rank: u64 = 1;
+
+    for (position, &idx) in sorted_indices.iter().enumerate() {
+        let value = match fn_type {
+            WindowFunctionType::RowNumber => (position + 1) as u64,
+            WindowFunctionType::Rank => {
+                if position > 0 {
+                    let prev_idx = sorted_indices[position - 1];
+                    if !rows_tied(results, idx, prev_idx, order_by) {
+                        rank = (position + 1) as u64;
+                    }
+                }
+                rank
+            }
+            WindowFunctionType::DenseRank => {
+                if position > 0 {
+                    let prev_idx = sorted_indices[position - 1];
+                    if !rows_tied(results, idx, prev_idx, order_by) {
+                        dense_rank += 1;
+                    }
+                }
+                dense_rank
+            }
+        };
+
+        inject_ranking(&mut results[idx], alias, value);
+    }
+}
+
+/// Returns `true` if two rows have identical values for all ORDER BY columns.
+fn rows_tied(
+    results: &[SearchResult],
+    a: usize,
+    b: usize,
+    order_by: &[WindowOrderBy],
+) -> bool {
+    for ob in order_by {
+        let val_a = extract_sort_value(&results[a], &ob.column);
+        let val_b = extract_sort_value(&results[b], &ob.column);
+        if compare_json_values(&val_a, &val_b) != std::cmp::Ordering::Equal {
+            return false;
+        }
+    }
+    true
+}
+
+/// Injects a ranking value into the result's payload as a new JSON field.
+fn inject_ranking(result: &mut SearchResult, alias: &str, value: u64) {
+    let payload = result
+        .point
+        .payload
+        .get_or_insert_with(|| serde_json::Value::Object(serde_json::Map::new()));
+    if let serde_json::Value::Object(map) = payload {
+        map.insert(alias.to_string(), serde_json::json!(value));
+    }
+}

--- a/crates/velesdb-core/src/velesql/window_evaluator.rs
+++ b/crates/velesdb-core/src/velesql/window_evaluator.rs
@@ -3,8 +3,13 @@
 //! Evaluates window functions (`ROW_NUMBER`, `RANK`, `DENSE_RANK`) over
 //! a result set, partitioning and sorting as specified by the `OVER` clause.
 //!
-//! Window evaluation happens **after** DISTINCT but **before** ORDER BY/LIMIT
-//! in the query pipeline, matching SQL standard semantics.
+//! ## Pipeline position
+//!
+//! Window evaluation happens **after** DISTINCT and **before** ORDER BY/LIMIT.
+//! This is an intentional deviation from SQL standard (which runs windows
+//! before DISTINCT) tailored to the vector-search use case; see the design
+//! note on [`crate::collection::search::query::select_dispatch::QueryExecutor::apply_select_postprocessing`]
+//! for the full rationale.
 //!
 //! ## Design: Global snapshot-first evaluation
 //!
@@ -211,46 +216,85 @@ fn sort_partition_from_snapshots(
 
 /// Computes ranking values from pre-snapshotted sort values.
 ///
+/// Dispatches to a variant-specific helper so each helper only maintains
+/// the state its ranking function actually uses (no dead `rank` / `dense_rank`
+/// initialisation when the other variant is selected).
+///
 /// Returns a list of `(result_index, ranking_value)` pairs.
-/// Uses snapshots for tie detection to prevent payload corruption.
 fn compute_rankings(
     sorted_indices: &[usize],
     snapshots: &[Vec<serde_json::Value>],
     order_by: &[WindowOrderBy],
     fn_type: WindowFunctionType,
 ) -> Vec<(usize, u64)> {
+    match fn_type {
+        WindowFunctionType::RowNumber => compute_row_numbers(sorted_indices),
+        WindowFunctionType::Rank => compute_rank(sorted_indices, snapshots, order_by),
+        WindowFunctionType::DenseRank => compute_dense_rank(sorted_indices, snapshots, order_by),
+    }
+}
+
+/// `ROW_NUMBER()`: assign `1..=n` by sort position, ignoring ties.
+fn compute_row_numbers(sorted_indices: &[usize]) -> Vec<(usize, u64)> {
+    sorted_indices
+        .iter()
+        .enumerate()
+        .map(|(position, &idx)| (idx, (position as u64) + 1))
+        .collect()
+}
+
+/// `RANK()`: gaps after ties (1, 2, 2, 4).
+///
+/// When the current row's snapshot ties with the previous row's, the rank
+/// is carried forward; otherwise it jumps to `position + 1`.
+fn compute_rank(
+    sorted_indices: &[usize],
+    snapshots: &[Vec<serde_json::Value>],
+    order_by: &[WindowOrderBy],
+) -> Vec<(usize, u64)> {
     let mut rankings = Vec::with_capacity(sorted_indices.len());
     let mut rank: u64 = 1;
-    let mut dense_rank: u64 = 1;
-
     for (position, &idx) in sorted_indices.iter().enumerate() {
-        let is_new_group = if position == 0 {
-            false
-        } else {
-            let prev_idx = sorted_indices[position - 1];
-            !snapshots_tied(&snapshots[idx], &snapshots[prev_idx], order_by)
-        };
-
-        let value = match fn_type {
-            WindowFunctionType::RowNumber => (position + 1) as u64,
-            WindowFunctionType::Rank => {
-                if is_new_group {
-                    rank = (position + 1) as u64;
-                }
-                rank
-            }
-            WindowFunctionType::DenseRank => {
-                if is_new_group {
-                    dense_rank += 1;
-                }
-                dense_rank
-            }
-        };
-
-        rankings.push((idx, value));
+        if is_new_group(position, sorted_indices, snapshots, order_by, idx) {
+            rank = (position as u64) + 1;
+        }
+        rankings.push((idx, rank));
     }
-
     rankings
+}
+
+/// `DENSE_RANK()`: no gaps after ties (1, 2, 2, 3).
+fn compute_dense_rank(
+    sorted_indices: &[usize],
+    snapshots: &[Vec<serde_json::Value>],
+    order_by: &[WindowOrderBy],
+) -> Vec<(usize, u64)> {
+    let mut rankings = Vec::with_capacity(sorted_indices.len());
+    let mut dense_rank: u64 = 1;
+    for (position, &idx) in sorted_indices.iter().enumerate() {
+        if is_new_group(position, sorted_indices, snapshots, order_by, idx) {
+            dense_rank += 1;
+        }
+        rankings.push((idx, dense_rank));
+    }
+    rankings
+}
+
+/// Returns `true` if the row at `position` starts a new tie group, i.e.
+/// its ORDER BY snapshot differs from the previous row's. The first row
+/// (`position == 0`) is never "new" — it anchors the initial group.
+fn is_new_group(
+    position: usize,
+    sorted_indices: &[usize],
+    snapshots: &[Vec<serde_json::Value>],
+    order_by: &[WindowOrderBy],
+    idx: usize,
+) -> bool {
+    if position == 0 {
+        return false;
+    }
+    let prev_idx = sorted_indices[position - 1];
+    !snapshots_tied(&snapshots[idx], &snapshots[prev_idx], order_by)
 }
 
 /// Returns `true` if two snapshot rows have identical ORDER BY values.
@@ -303,14 +347,24 @@ fn extract_nested_value(result: &SearchResult, column: &str) -> serde_json::Valu
     }
 }
 
-/// Extracts a string representation of a payload value for partition keys.
+/// Extracts a canonical-JSON string representation of a payload value for
+/// partition keys.
+///
+/// Uses `serde_json`'s `Display` (`value.to_string()`) rather than extracting
+/// the inner string for `Value::String`. This preserves the JSON type
+/// discriminator (quotes around strings, bare digits for numbers, `null`
+/// literal for NULL) so rows with different types cannot collide into the
+/// same partition.
+///
+/// Examples of collisions that this prevents:
+/// - `Value::Null` vs `Value::String("null")` → `null` vs `"null"` (distinct)
+/// - `Value::Number(1)` vs `Value::String("1")` → `1` vs `"1"` (distinct)
+/// - `Value::Bool(true)` vs `Value::String("true")` → `true` vs `"true"`
+///
+/// Consistent with `distinct::canonical_json_string` which applies the same
+/// rule for DISTINCT deduplication keys.
 fn extract_payload_value(result: &SearchResult, column: &str) -> String {
-    let value = extract_nested_value(result, column);
-    match value {
-        serde_json::Value::Null => "__null__".to_string(),
-        serde_json::Value::String(s) => s,
-        other => other.to_string(),
-    }
+    extract_nested_value(result, column).to_string()
 }
 
 /// Compares two JSON values for sorting.

--- a/crates/velesdb-core/src/velesql/window_function_tests.rs
+++ b/crates/velesdb-core/src/velesql/window_function_tests.rs
@@ -697,6 +697,182 @@ mod tests {
         );
     }
 
+    /// Bug #4 regression: **inter-function contamination via ORDER BY**.
+    ///
+    /// Before the fix, `evaluate` snapshotted ORDER BY values inside
+    /// `apply_single_window`, so each function's snapshot was taken **after**
+    /// all earlier functions had already injected their rank values into the
+    /// payload. Two window functions with a colliding alias/column pair
+    /// would corrupt each other's inputs.
+    ///
+    /// Scenario: `ROW_NUMBER() OVER (ORDER BY score DESC) AS score,
+    /// RANK()       OVER (ORDER BY score DESC) AS rnk` with payload scores
+    /// `[100, 90, 90, 80]` and similarity `0.5` for every row.
+    ///
+    /// - ROW_NUMBER ranks by original payload `score` DESC → `[1, 2, 3, 4]`
+    ///   and injects those values into `payload["score"]`.
+    /// - RANK must ALSO see the original `[100, 90, 90, 80]` and produce
+    ///   `[1, 2, 2, 4]`. The pre-fix code read the corrupted
+    ///   `payload["score"]` values (now `1,2,3,4`, all distinct) and
+    ///   produced `[1, 2, 3, 4]` with no tie detection.
+    #[test]
+    fn test_inter_function_contamination_via_order_by_column() {
+        let mut results = vec![
+            make_result(1, serde_json::json!({"score": 100}), 0.5),
+            make_result(2, serde_json::json!({"score": 90}), 0.5),
+            make_result(3, serde_json::json!({"score": 90}), 0.5),
+            make_result(4, serde_json::json!({"score": 80}), 0.5),
+        ];
+
+        // First window function: ROW_NUMBER aliased to "score" (collides with
+        // the payload column AND with the second function's ORDER BY key).
+        let wf_row_number = WindowFunction {
+            function_type: WindowFunctionType::RowNumber,
+            over_clause: OverClause {
+                partition_by: vec![],
+                order_by: vec![WindowOrderBy {
+                    column: "score".to_string(),
+                    descending: true,
+                }],
+            },
+            alias: Some("score".to_string()),
+        };
+
+        // Second window function: RANK, ORDER BY "score" — which the first
+        // function has just overwritten. If snapshots are not taken up-front,
+        // this reads the injected row-numbers instead of the original scores.
+        let wf_rank = WindowFunction {
+            function_type: WindowFunctionType::Rank,
+            over_clause: OverClause {
+                partition_by: vec![],
+                order_by: vec![WindowOrderBy {
+                    column: "score".to_string(),
+                    descending: true,
+                }],
+            },
+            alias: Some("rnk".to_string()),
+        };
+
+        window_evaluator::evaluate(&mut results, &[wf_row_number, wf_rank]).expect("evaluate");
+
+        // ROW_NUMBER on original [100, 90, 90, 80] DESC → [1, 2, 3, 4]
+        // (stable order: ids 1, 2, 3, 4 respectively). The alias "score"
+        // overwrites the payload.
+        assert_eq!(get_payload_u64(&results[0], "score"), Some(1));
+        assert_eq!(get_payload_u64(&results[1], "score"), Some(2));
+        assert_eq!(get_payload_u64(&results[2], "score"), Some(3));
+        assert_eq!(get_payload_u64(&results[3], "score"), Some(4));
+
+        // RANK on the ORIGINAL [100, 90, 90, 80] DESC must be [1, 2, 2, 4].
+        // Pre-fix, RANK saw [1, 2, 3, 4] (all distinct) and produced
+        // [1, 2, 3, 4] — no tie was detected, breaking SQL semantics.
+        assert_eq!(
+            get_payload_u64(&results[0], "rnk"),
+            Some(1),
+            "id 1 (original score=100) must rank 1"
+        );
+        assert_eq!(
+            get_payload_u64(&results[1], "rnk"),
+            Some(2),
+            "id 2 (original score=90) must rank 2 (tie)"
+        );
+        assert_eq!(
+            get_payload_u64(&results[2], "rnk"),
+            Some(2),
+            "id 3 (original score=90) must rank 2 (tie)"
+        );
+        assert_eq!(
+            get_payload_u64(&results[3], "rnk"),
+            Some(4),
+            "id 4 (original score=80) must rank 4 (gap after ties)"
+        );
+    }
+
+    /// Bug #4 regression: **inter-function contamination via PARTITION BY**.
+    ///
+    /// Same contamination mechanism as the ORDER BY variant above, but via
+    /// a partition key. The first window function writes its rank into a
+    /// column that the second function uses as its `PARTITION BY`.
+    ///
+    /// Scenario: four rows split across two original `group` values
+    /// (`"A"` and `"B"`), each row also has its own `val`.
+    /// - First WF: `ROW_NUMBER() OVER (ORDER BY val) AS group` — overwrites
+    ///   `payload["group"]` with `1..4` (all distinct, so every row would
+    ///   become its own partition if the second function reads the injected
+    ///   value).
+    /// - Second WF: `RANK() OVER (PARTITION BY group ORDER BY val) AS rnk`
+    ///   must still see the ORIGINAL `"A"` / `"B"` grouping.
+    ///
+    /// With the fix, `RANK` sees 2 partitions (2 rows each). Pre-fix, it
+    /// would see 4 partitions of 1 row each and every row would rank 1.
+    #[test]
+    fn test_inter_function_contamination_via_partition_by_column() {
+        let mut results = vec![
+            make_result(1, serde_json::json!({"group": "A", "val": 10}), 0.5),
+            make_result(2, serde_json::json!({"group": "B", "val": 20}), 0.5),
+            make_result(3, serde_json::json!({"group": "A", "val": 30}), 0.5),
+            make_result(4, serde_json::json!({"group": "B", "val": 40}), 0.5),
+        ];
+
+        let wf_row_number = WindowFunction {
+            function_type: WindowFunctionType::RowNumber,
+            over_clause: OverClause {
+                partition_by: vec![],
+                order_by: vec![WindowOrderBy {
+                    column: "val".to_string(),
+                    descending: false,
+                }],
+            },
+            // Alias collides with the second function's PARTITION BY column.
+            alias: Some("group".to_string()),
+        };
+
+        let wf_rank = WindowFunction {
+            function_type: WindowFunctionType::Rank,
+            over_clause: OverClause {
+                partition_by: vec!["group".to_string()],
+                order_by: vec![WindowOrderBy {
+                    column: "val".to_string(),
+                    descending: false,
+                }],
+            },
+            alias: Some("rnk".to_string()),
+        };
+
+        window_evaluator::evaluate(&mut results, &[wf_row_number, wf_rank]).expect("evaluate");
+
+        // ROW_NUMBER over val ASC → 10→1, 20→2, 30→3, 40→4.
+        assert_eq!(get_payload_u64(&results[0], "group"), Some(1));
+        assert_eq!(get_payload_u64(&results[1], "group"), Some(2));
+        assert_eq!(get_payload_u64(&results[2], "group"), Some(3));
+        assert_eq!(get_payload_u64(&results[3], "group"), Some(4));
+
+        // RANK inside ORIGINAL partition "A" (ids 1, 3) by val ASC → 1, 2.
+        // RANK inside ORIGINAL partition "B" (ids 2, 4) by val ASC → 1, 2.
+        // Pre-fix, each row would be its own partition (because the "group"
+        // column now holds unique values 1..4) and every rnk would be 1.
+        assert_eq!(
+            get_payload_u64(&results[0], "rnk"),
+            Some(1),
+            "id 1 in partition A, val=10 → rank 1"
+        );
+        assert_eq!(
+            get_payload_u64(&results[2], "rnk"),
+            Some(2),
+            "id 3 in partition A, val=30 → rank 2"
+        );
+        assert_eq!(
+            get_payload_u64(&results[1], "rnk"),
+            Some(1),
+            "id 2 in partition B, val=20 → rank 1"
+        );
+        assert_eq!(
+            get_payload_u64(&results[3], "rnk"),
+            Some(2),
+            "id 4 in partition B, val=40 → rank 2"
+        );
+    }
+
     /// Bug #3 regression with the *default* alias. `RANK()` without an
     /// explicit `AS` uses `WindowFunctionType::default_alias() == "rank"`,
     /// and a user who happens to have a `rank` payload field and sorts by

--- a/crates/velesdb-core/src/velesql/window_function_tests.rs
+++ b/crates/velesdb-core/src/velesql/window_function_tests.rs
@@ -873,6 +873,140 @@ mod tests {
         );
     }
 
+    // =====================================================================
+    // Zero-tech-debt pass: regressions for the 🚩 informational findings
+    // that were resolved in the hardening commit.
+    // =====================================================================
+
+    /// Partition-key collision regression: typed JSON values that render to
+    /// the same bytes via naive `to_string()` must still produce distinct
+    /// partition keys.
+    ///
+    /// Before the fix, `extract_payload_value` returned the inner string for
+    /// `Value::String(s)` (stripping the JSON quotes) and `"__null__"` for
+    /// `Value::Null`. Consequences:
+    /// - `Value::Number(1)` and `Value::String("1")` both rendered as `"1"`
+    ///   and collided into the same partition.
+    /// - `Value::Null` and a literal payload string `"__null__"` both rendered
+    ///   as `"__null__"` and collided into the same partition.
+    ///
+    /// The fix uses `serde_json`'s canonical `Display` (`Value::to_string`),
+    /// which preserves the JSON type discriminator (bare `1`, quoted `"1"`,
+    /// literal `null`, quoted `"null"`).
+    #[test]
+    fn test_partition_key_does_not_collide_int_and_string_of_same_digits() {
+        // Two rows with the SAME `val` but DIFFERENT payload types for the
+        // partition column `"cat"`. Before the fix they'd end up in the same
+        // partition and rank 1, 2. After the fix they're in separate
+        // partitions and both rank 1.
+        let mut results = vec![
+            make_result(1, serde_json::json!({"cat": 1, "val": 10}), 0.5),
+            make_result(2, serde_json::json!({"cat": "1", "val": 20}), 0.5),
+        ];
+
+        let wf = WindowFunction {
+            function_type: WindowFunctionType::RowNumber,
+            over_clause: OverClause {
+                partition_by: vec!["cat".to_string()],
+                order_by: vec![WindowOrderBy {
+                    column: "val".to_string(),
+                    descending: false,
+                }],
+            },
+            alias: Some("rn".to_string()),
+        };
+
+        window_evaluator::evaluate(&mut results, &[wf]).expect("evaluate");
+
+        // Each row is the sole member of its own partition → both rank 1.
+        assert_eq!(get_payload_u64(&results[0], "rn"), Some(1), "cat=int(1)");
+        assert_eq!(
+            get_payload_u64(&results[1], "rn"),
+            Some(1),
+            "cat=str(\"1\")"
+        );
+    }
+
+    /// Partition-key NULL-sentinel regression: a payload string literally
+    /// equal to `"__null__"` must not collide with a missing/Null field.
+    #[test]
+    fn test_partition_key_distinguishes_null_from_literal_sentinel() {
+        let mut results = vec![
+            // Row 1: actual JSON null for "cat".
+            make_result(1, serde_json::json!({"cat": null, "val": 10}), 0.5),
+            // Row 2: literal string "__null__" for "cat".
+            make_result(2, serde_json::json!({"cat": "__null__", "val": 20}), 0.5),
+        ];
+
+        let wf = WindowFunction {
+            function_type: WindowFunctionType::RowNumber,
+            over_clause: OverClause {
+                partition_by: vec!["cat".to_string()],
+                order_by: vec![WindowOrderBy {
+                    column: "val".to_string(),
+                    descending: false,
+                }],
+            },
+            alias: Some("rn".to_string()),
+        };
+
+        window_evaluator::evaluate(&mut results, &[wf]).expect("evaluate");
+
+        // Distinct partitions → both rank 1.
+        assert_eq!(get_payload_u64(&results[0], "rn"), Some(1), "cat=null");
+        assert_eq!(
+            get_payload_u64(&results[1], "rn"),
+            Some(1),
+            "cat=\"__null__\""
+        );
+    }
+
+    /// Design-intent regression: DISTINCT runs BEFORE window functions.
+    ///
+    /// VelesQL deliberately deviates from the SQL-standard logical order
+    /// (which is `SELECT (windows) → DISTINCT`) so that `ROW_NUMBER` /
+    /// `RANK` over a DISTINCT set produces a dense `1..N` without gaps,
+    /// matching the "top-N distinct titles ranked by similarity" vector
+    /// search pattern. This evaluator contract drives that behaviour: when
+    /// evaluate is called, DISTINCT has already reduced the row set.
+    ///
+    /// This test verifies the *evaluator's* invariant: given a row set that
+    /// has already been deduped (as the pipeline would hand it over), the
+    /// window function numbers the survivors contiguously. If the pipeline
+    /// order were ever flipped, this test would still pass (because it
+    /// feeds a pre-deduped slice directly) — its purpose is to pin the
+    /// evaluator semantics, while the pipeline order contract is pinned by
+    /// the doc comment on `apply_select_postprocessing`.
+    #[test]
+    fn test_row_number_numbers_deduped_rows_contiguously() {
+        // Simulate what the pipeline hands to the evaluator after DISTINCT:
+        // three survivors with unique titles, sorted by similarity.
+        let mut results = vec![
+            make_result(10, serde_json::json!({"title": "A"}), 0.9),
+            make_result(20, serde_json::json!({"title": "B"}), 0.7),
+            make_result(30, serde_json::json!({"title": "C"}), 0.5),
+        ];
+
+        let wf = WindowFunction {
+            function_type: WindowFunctionType::RowNumber,
+            over_clause: OverClause {
+                partition_by: vec![],
+                order_by: vec![WindowOrderBy {
+                    column: "similarity".to_string(),
+                    descending: true,
+                }],
+            },
+            alias: Some("rn".to_string()),
+        };
+
+        window_evaluator::evaluate(&mut results, &[wf]).expect("evaluate");
+
+        // Contiguous 1, 2, 3 — no gaps, matching vector-search expectation.
+        assert_eq!(get_payload_u64(&results[0], "rn"), Some(1));
+        assert_eq!(get_payload_u64(&results[1], "rn"), Some(2));
+        assert_eq!(get_payload_u64(&results[2], "rn"), Some(3));
+    }
+
     /// Bug #3 regression with the *default* alias. `RANK()` without an
     /// explicit `AS` uses `WindowFunctionType::default_alias() == "rank"`,
     /// and a user who happens to have a `rank` payload field and sorts by

--- a/crates/velesdb-core/src/velesql/window_function_tests.rs
+++ b/crates/velesdb-core/src/velesql/window_function_tests.rs
@@ -33,7 +33,7 @@ mod tests {
             .payload
             .as_ref()
             .and_then(|p| p.get(field))
-            .and_then(|v| v.as_u64())
+            .and_then(serde_json::Value::as_u64)
     }
 
     // ================================================================
@@ -72,10 +72,8 @@ mod tests {
 
     #[test]
     fn test_parse_rank_desc() {
-        let query = Parser::parse(
-            "SELECT RANK() OVER (ORDER BY score DESC) AS rnk FROM docs",
-        )
-        .unwrap();
+        let query =
+            Parser::parse("SELECT RANK() OVER (ORDER BY score DESC) AS rnk FROM docs").unwrap();
 
         match &query.select.columns {
             SelectColumns::Mixed {
@@ -201,7 +199,10 @@ mod tests {
             SelectColumns::Mixed {
                 window_functions, ..
             } => {
-                assert_eq!(window_functions[0].function_type, WindowFunctionType::RowNumber);
+                assert_eq!(
+                    window_functions[0].function_type,
+                    WindowFunctionType::RowNumber
+                );
             }
             other => panic!("Expected Mixed, got: {:?}", other),
         }
@@ -354,11 +355,7 @@ mod tests {
 
     #[test]
     fn test_single_result() {
-        let mut results = vec![make_result(
-            1,
-            serde_json::json!({"val": 42}),
-            0.5,
-        )];
+        let mut results = vec![make_result(1, serde_json::json!({"val": 42}), 0.5)];
 
         let wf = WindowFunction {
             function_type: WindowFunctionType::RowNumber,
@@ -408,11 +405,7 @@ mod tests {
 
     #[test]
     fn test_default_alias() {
-        let mut results = vec![make_result(
-            1,
-            serde_json::json!({"val": 1}),
-            0.5,
-        )];
+        let mut results = vec![make_result(1, serde_json::json!({"val": 1}), 0.5)];
 
         // No alias → uses function_type.default_alias()
         let wf = WindowFunction {
@@ -589,5 +582,153 @@ mod tests {
         assert_eq!(get_payload_u64(&results[1], "rn"), Some(1)); // val=30 (id=2)
         assert_eq!(get_payload_u64(&results[2], "rn"), Some(2)); // val=20 (id=3)
         assert_eq!(get_payload_u64(&results[0], "rn"), Some(3)); // val=10 (id=1)
+    }
+
+    // =====================================================================
+    // Regression tests — the three 🔴 critical bugs flagged by Devin on
+    // the original #629 and fixed before merge.
+    // =====================================================================
+
+    /// Bug #2 regression: `extract_sort_value` used to special-case the
+    /// column name `"score"` and return `result.score` (the search
+    /// similarity score) instead of the user's payload field. Any payload
+    /// with its own `score` column would silently order by the search
+    /// score instead of the column value — hidden until a user's payload
+    /// score distribution diverges from the similarity ranking.
+    ///
+    /// This test constructs that exact mismatch: similarity scores are in
+    /// `[0.1, 0.3, 0.5, 0.2]` order but payload scores are
+    /// `[100, 50, 75, 200]`. Ordering by payload `score` DESC must yield
+    /// id 4 (200) first, not id 3 (similarity 0.5) first.
+    #[test]
+    fn test_order_by_payload_score_is_not_hijacked_by_similarity() {
+        let mut results = vec![
+            make_result(1, serde_json::json!({"score": 100}), 0.1),
+            make_result(2, serde_json::json!({"score": 50}), 0.3),
+            make_result(3, serde_json::json!({"score": 75}), 0.5),
+            make_result(4, serde_json::json!({"score": 200}), 0.2),
+        ];
+
+        let wf = WindowFunction {
+            function_type: WindowFunctionType::RowNumber,
+            over_clause: OverClause {
+                partition_by: vec![],
+                order_by: vec![WindowOrderBy {
+                    column: "score".to_string(),
+                    descending: true,
+                }],
+            },
+            alias: Some("rn".to_string()),
+        };
+
+        window_evaluator::evaluate(&mut results, &[wf]).expect("evaluate");
+
+        // Expected order by payload.score DESC: 200, 100, 75, 50 → ids 4, 1, 3, 2.
+        assert_eq!(
+            get_payload_u64(&results[3], "rn"),
+            Some(1),
+            "id 4 payload=200 should rank 1"
+        );
+        assert_eq!(
+            get_payload_u64(&results[0], "rn"),
+            Some(2),
+            "id 1 payload=100 should rank 2"
+        );
+        assert_eq!(
+            get_payload_u64(&results[2], "rn"),
+            Some(3),
+            "id 3 payload=75 should rank 3"
+        );
+        assert_eq!(
+            get_payload_u64(&results[1], "rn"),
+            Some(4),
+            "id 2 payload=50 should rank 4"
+        );
+    }
+
+    /// Bug #3 regression: `RANK() OVER (ORDER BY score DESC) AS score` used
+    /// to corrupt its own input. The old loop wrote the rank value back
+    /// into `payload["score"]` after each iteration; the next iteration's
+    /// tie-detection read this corrupted value instead of the original
+    /// sort key. For input `[100, 90, 90, 80]` it produced `[1, 2, 3, 4]`
+    /// instead of the SQL-correct `[1, 2, 2, 4]`.
+    #[test]
+    fn test_rank_alias_collides_with_order_by_column_preserves_ties() {
+        let mut results = vec![
+            make_result(1, serde_json::json!({"score": 100}), 0.5),
+            make_result(2, serde_json::json!({"score": 90}), 0.5),
+            make_result(3, serde_json::json!({"score": 90}), 0.5),
+            make_result(4, serde_json::json!({"score": 80}), 0.5),
+        ];
+
+        let wf = WindowFunction {
+            function_type: WindowFunctionType::Rank,
+            over_clause: OverClause {
+                partition_by: vec![],
+                order_by: vec![WindowOrderBy {
+                    column: "score".to_string(),
+                    descending: true,
+                }],
+            },
+            // Alias deliberately collides with the ORDER BY column.
+            alias: Some("score".to_string()),
+        };
+
+        window_evaluator::evaluate(&mut results, &[wf]).expect("evaluate");
+
+        // SQL-correct RANK() for [100, 90, 90, 80] DESC is [1, 2, 2, 4].
+        // The pre-fix implementation produced [1, 2, 3, 4] because the
+        // "score" alias overwrote the sort key used by tie detection.
+        assert_eq!(get_payload_u64(&results[0], "score"), Some(1), "100 → 1");
+        assert_eq!(
+            get_payload_u64(&results[1], "score"),
+            Some(2),
+            "90 → 2 (tie)"
+        );
+        assert_eq!(
+            get_payload_u64(&results[2], "score"),
+            Some(2),
+            "90 → 2 (tie)"
+        );
+        assert_eq!(
+            get_payload_u64(&results[3], "score"),
+            Some(4),
+            "80 → 4 (gap after ties)"
+        );
+    }
+
+    /// Bug #3 regression with the *default* alias. `RANK()` without an
+    /// explicit `AS` uses `WindowFunctionType::default_alias() == "rank"`,
+    /// and a user who happens to have a `rank` payload field and sorts by
+    /// it would hit the same corruption path.
+    #[test]
+    fn test_rank_default_alias_collides_with_payload_field_preserves_ties() {
+        let mut results = vec![
+            make_result(1, serde_json::json!({"rank": 10}), 0.5),
+            make_result(2, serde_json::json!({"rank": 5}), 0.5),
+            make_result(3, serde_json::json!({"rank": 5}), 0.5),
+            make_result(4, serde_json::json!({"rank": 1}), 0.5),
+        ];
+
+        let wf = WindowFunction {
+            function_type: WindowFunctionType::Rank,
+            over_clause: OverClause {
+                partition_by: vec![],
+                order_by: vec![WindowOrderBy {
+                    column: "rank".to_string(),
+                    descending: true,
+                }],
+            },
+            // No explicit alias → default_alias() is "rank", collides.
+            alias: None,
+        };
+
+        window_evaluator::evaluate(&mut results, &[wf]).expect("evaluate");
+
+        // Same pattern as the explicit-alias test: [10, 5, 5, 1] → [1, 2, 2, 4].
+        assert_eq!(get_payload_u64(&results[0], "rank"), Some(1));
+        assert_eq!(get_payload_u64(&results[1], "rank"), Some(2));
+        assert_eq!(get_payload_u64(&results[2], "rank"), Some(2));
+        assert_eq!(get_payload_u64(&results[3], "rank"), Some(4));
     }
 }

--- a/crates/velesdb-core/src/velesql/window_function_tests.rs
+++ b/crates/velesdb-core/src/velesql/window_function_tests.rs
@@ -1,0 +1,593 @@
+//! Tests for window functions (Issue #386 Phase 1).
+//!
+//! Covers: grammar parsing, AST construction, evaluator logic,
+//! edge cases (ties, empty partitions, NULL values, no PARTITION BY).
+
+#[cfg(test)]
+mod tests {
+    use crate::point::{Point, SearchResult};
+    use crate::velesql::{
+        window_evaluator, OverClause, Parser, SelectColumns, WindowFunction, WindowFunctionType,
+        WindowOrderBy,
+    };
+
+    // ================================================================
+    // Helper functions
+    // ================================================================
+
+    fn make_result(id: u64, payload: serde_json::Value, score: f32) -> SearchResult {
+        SearchResult::new(
+            Point {
+                id,
+                vector: vec![0.0; 4],
+                payload: Some(payload),
+                sparse_vectors: None,
+            },
+            score,
+        )
+    }
+
+    fn get_payload_u64(result: &SearchResult, field: &str) -> Option<u64> {
+        result
+            .point
+            .payload
+            .as_ref()
+            .and_then(|p| p.get(field))
+            .and_then(|v| v.as_u64())
+    }
+
+    // ================================================================
+    // Parser tests — grammar → AST
+    // ================================================================
+
+    #[test]
+    fn test_parse_row_number_with_partition_and_order() {
+        let query = Parser::parse(
+            "SELECT name, ROW_NUMBER() OVER (PARTITION BY category ORDER BY price ASC) AS rn FROM products",
+        )
+        .unwrap();
+
+        match &query.select.columns {
+            SelectColumns::Mixed {
+                columns,
+                window_functions,
+                ..
+            } => {
+                assert_eq!(columns.len(), 1);
+                assert_eq!(columns[0].name, "name");
+
+                assert_eq!(window_functions.len(), 1);
+                let wf = &window_functions[0];
+                assert_eq!(wf.function_type, WindowFunctionType::RowNumber);
+                assert_eq!(wf.alias, Some("rn".to_string()));
+
+                assert_eq!(wf.over_clause.partition_by, vec!["category".to_string()]);
+                assert_eq!(wf.over_clause.order_by.len(), 1);
+                assert_eq!(wf.over_clause.order_by[0].column, "price");
+                assert!(!wf.over_clause.order_by[0].descending);
+            }
+            other => panic!("Expected Mixed, got: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_parse_rank_desc() {
+        let query = Parser::parse(
+            "SELECT RANK() OVER (ORDER BY score DESC) AS rnk FROM docs",
+        )
+        .unwrap();
+
+        match &query.select.columns {
+            SelectColumns::Mixed {
+                window_functions, ..
+            } => {
+                assert_eq!(window_functions.len(), 1);
+                let wf = &window_functions[0];
+                assert_eq!(wf.function_type, WindowFunctionType::Rank);
+                assert_eq!(wf.alias, Some("rnk".to_string()));
+                assert!(wf.over_clause.partition_by.is_empty());
+                assert_eq!(wf.over_clause.order_by[0].column, "score");
+                assert!(wf.over_clause.order_by[0].descending);
+            }
+            other => panic!("Expected Mixed, got: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_parse_dense_rank_no_alias() {
+        let query = Parser::parse(
+            "SELECT DENSE_RANK() OVER (PARTITION BY dept ORDER BY salary DESC) FROM employees",
+        )
+        .unwrap();
+
+        match &query.select.columns {
+            SelectColumns::Mixed {
+                window_functions, ..
+            } => {
+                assert_eq!(window_functions.len(), 1);
+                let wf = &window_functions[0];
+                assert_eq!(wf.function_type, WindowFunctionType::DenseRank);
+                assert!(wf.alias.is_none());
+                assert_eq!(wf.over_clause.partition_by, vec!["dept".to_string()]);
+            }
+            other => panic!("Expected Mixed, got: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_parse_multiple_partition_columns() {
+        let query = Parser::parse(
+            "SELECT ROW_NUMBER() OVER (PARTITION BY region, department ORDER BY hire_date ASC) AS rn FROM emp",
+        )
+        .unwrap();
+
+        match &query.select.columns {
+            SelectColumns::Mixed {
+                window_functions, ..
+            } => {
+                let wf = &window_functions[0];
+                assert_eq!(
+                    wf.over_clause.partition_by,
+                    vec!["region".to_string(), "department".to_string()]
+                );
+            }
+            other => panic!("Expected Mixed, got: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_parse_window_with_similarity_order() {
+        let query = Parser::parse(
+            "SELECT ROW_NUMBER() OVER (PARTITION BY source ORDER BY similarity() DESC) AS rn FROM docs",
+        )
+        .unwrap();
+
+        match &query.select.columns {
+            SelectColumns::Mixed {
+                window_functions, ..
+            } => {
+                let wf = &window_functions[0];
+                assert_eq!(wf.over_clause.order_by[0].column, "similarity");
+                assert!(wf.over_clause.order_by[0].descending);
+            }
+            other => panic!("Expected Mixed, got: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_parse_rank_as_column_name_no_ambiguity() {
+        // "rank" without parens should parse as a regular column, not a window function
+        let query = Parser::parse("SELECT rank FROM docs").unwrap();
+        match &query.select.columns {
+            SelectColumns::Columns(cols) => {
+                assert_eq!(cols.len(), 1);
+                assert_eq!(cols[0].name, "rank");
+            }
+            other => panic!("Expected Columns, got: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_parse_multiple_order_by_in_over() {
+        let query = Parser::parse(
+            "SELECT ROW_NUMBER() OVER (PARTITION BY dept ORDER BY salary DESC, name ASC) AS rn FROM emp",
+        )
+        .unwrap();
+
+        match &query.select.columns {
+            SelectColumns::Mixed {
+                window_functions, ..
+            } => {
+                let wf = &window_functions[0];
+                assert_eq!(wf.over_clause.order_by.len(), 2);
+                assert_eq!(wf.over_clause.order_by[0].column, "salary");
+                assert!(wf.over_clause.order_by[0].descending);
+                assert_eq!(wf.over_clause.order_by[1].column, "name");
+                assert!(!wf.over_clause.order_by[1].descending);
+            }
+            other => panic!("Expected Mixed, got: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_parse_case_insensitive_keywords() {
+        // Verify case-insensitive parsing for all window keywords
+        let query = Parser::parse(
+            "SELECT row_number() over (partition by cat order by val desc) AS rn FROM t",
+        )
+        .unwrap();
+
+        match &query.select.columns {
+            SelectColumns::Mixed {
+                window_functions, ..
+            } => {
+                assert_eq!(window_functions[0].function_type, WindowFunctionType::RowNumber);
+            }
+            other => panic!("Expected Mixed, got: {:?}", other),
+        }
+    }
+
+    // ================================================================
+    // Evaluator tests — window function computation
+    // ================================================================
+
+    #[test]
+    fn test_row_number_single_partition() {
+        let mut results = vec![
+            make_result(1, serde_json::json!({"name": "C", "score": 30}), 0.3),
+            make_result(2, serde_json::json!({"name": "A", "score": 10}), 0.1),
+            make_result(3, serde_json::json!({"name": "B", "score": 20}), 0.2),
+        ];
+
+        let wf = WindowFunction {
+            function_type: WindowFunctionType::RowNumber,
+            over_clause: OverClause {
+                partition_by: vec![],
+                order_by: vec![WindowOrderBy {
+                    column: "score".to_string(),
+                    descending: false,
+                }],
+            },
+            alias: Some("rn".to_string()),
+        };
+
+        window_evaluator::evaluate(&mut results, &[wf]).unwrap();
+
+        // Sorted by score ASC: A(10)=1, B(20)=2, C(30)=3
+        assert_eq!(get_payload_u64(&results[1], "rn"), Some(1)); // A (id=2)
+        assert_eq!(get_payload_u64(&results[2], "rn"), Some(2)); // B (id=3)
+        assert_eq!(get_payload_u64(&results[0], "rn"), Some(3)); // C (id=1)
+    }
+
+    #[test]
+    fn test_row_number_multiple_partitions() {
+        let mut results = vec![
+            make_result(1, serde_json::json!({"cat": "A", "val": 10}), 0.1),
+            make_result(2, serde_json::json!({"cat": "B", "val": 20}), 0.2),
+            make_result(3, serde_json::json!({"cat": "A", "val": 30}), 0.3),
+            make_result(4, serde_json::json!({"cat": "B", "val": 40}), 0.4),
+        ];
+
+        let wf = WindowFunction {
+            function_type: WindowFunctionType::RowNumber,
+            over_clause: OverClause {
+                partition_by: vec!["cat".to_string()],
+                order_by: vec![WindowOrderBy {
+                    column: "val".to_string(),
+                    descending: false,
+                }],
+            },
+            alias: Some("rn".to_string()),
+        };
+
+        window_evaluator::evaluate(&mut results, &[wf]).unwrap();
+
+        // Partition A: id=1(val=10)→1, id=3(val=30)→2
+        assert_eq!(get_payload_u64(&results[0], "rn"), Some(1));
+        assert_eq!(get_payload_u64(&results[2], "rn"), Some(2));
+
+        // Partition B: id=2(val=20)→1, id=4(val=40)→2
+        assert_eq!(get_payload_u64(&results[1], "rn"), Some(1));
+        assert_eq!(get_payload_u64(&results[3], "rn"), Some(2));
+    }
+
+    #[test]
+    fn test_rank_with_ties() {
+        let mut results = vec![
+            make_result(1, serde_json::json!({"score": 100}), 1.0),
+            make_result(2, serde_json::json!({"score": 90}), 0.9),
+            make_result(3, serde_json::json!({"score": 90}), 0.9),
+            make_result(4, serde_json::json!({"score": 80}), 0.8),
+        ];
+
+        let wf = WindowFunction {
+            function_type: WindowFunctionType::Rank,
+            over_clause: OverClause {
+                partition_by: vec![],
+                order_by: vec![WindowOrderBy {
+                    column: "score".to_string(),
+                    descending: true,
+                }],
+            },
+            alias: Some("rnk".to_string()),
+        };
+
+        window_evaluator::evaluate(&mut results, &[wf]).unwrap();
+
+        // 100→1, 90→2, 90→2, 80→4 (gap after tie)
+        assert_eq!(get_payload_u64(&results[0], "rnk"), Some(1)); // 100
+        assert_eq!(get_payload_u64(&results[1], "rnk"), Some(2)); // 90
+        assert_eq!(get_payload_u64(&results[2], "rnk"), Some(2)); // 90
+        assert_eq!(get_payload_u64(&results[3], "rnk"), Some(4)); // 80
+    }
+
+    #[test]
+    fn test_dense_rank_with_ties() {
+        let mut results = vec![
+            make_result(1, serde_json::json!({"score": 100}), 1.0),
+            make_result(2, serde_json::json!({"score": 90}), 0.9),
+            make_result(3, serde_json::json!({"score": 90}), 0.9),
+            make_result(4, serde_json::json!({"score": 80}), 0.8),
+        ];
+
+        let wf = WindowFunction {
+            function_type: WindowFunctionType::DenseRank,
+            over_clause: OverClause {
+                partition_by: vec![],
+                order_by: vec![WindowOrderBy {
+                    column: "score".to_string(),
+                    descending: true,
+                }],
+            },
+            alias: Some("drnk".to_string()),
+        };
+
+        window_evaluator::evaluate(&mut results, &[wf]).unwrap();
+
+        // 100→1, 90→2, 90→2, 80→3 (no gap)
+        assert_eq!(get_payload_u64(&results[0], "drnk"), Some(1));
+        assert_eq!(get_payload_u64(&results[1], "drnk"), Some(2));
+        assert_eq!(get_payload_u64(&results[2], "drnk"), Some(2));
+        assert_eq!(get_payload_u64(&results[3], "drnk"), Some(3));
+    }
+
+    #[test]
+    fn test_empty_result_set() {
+        let mut results: Vec<SearchResult> = vec![];
+
+        let wf = WindowFunction {
+            function_type: WindowFunctionType::RowNumber,
+            over_clause: OverClause {
+                partition_by: vec![],
+                order_by: vec![WindowOrderBy {
+                    column: "score".to_string(),
+                    descending: false,
+                }],
+            },
+            alias: Some("rn".to_string()),
+        };
+
+        // Should succeed with no crash
+        window_evaluator::evaluate(&mut results, &[wf]).unwrap();
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn test_single_result() {
+        let mut results = vec![make_result(
+            1,
+            serde_json::json!({"val": 42}),
+            0.5,
+        )];
+
+        let wf = WindowFunction {
+            function_type: WindowFunctionType::RowNumber,
+            over_clause: OverClause {
+                partition_by: vec![],
+                order_by: vec![WindowOrderBy {
+                    column: "val".to_string(),
+                    descending: false,
+                }],
+            },
+            alias: Some("rn".to_string()),
+        };
+
+        window_evaluator::evaluate(&mut results, &[wf]).unwrap();
+        assert_eq!(get_payload_u64(&results[0], "rn"), Some(1));
+    }
+
+    #[test]
+    fn test_null_partition_values() {
+        let mut results = vec![
+            make_result(1, serde_json::json!({"cat": "A", "val": 1}), 0.1),
+            make_result(2, serde_json::json!({"val": 2}), 0.2), // No "cat" field → null partition
+            make_result(3, serde_json::json!({"cat": "A", "val": 3}), 0.3),
+        ];
+
+        let wf = WindowFunction {
+            function_type: WindowFunctionType::RowNumber,
+            over_clause: OverClause {
+                partition_by: vec!["cat".to_string()],
+                order_by: vec![WindowOrderBy {
+                    column: "val".to_string(),
+                    descending: false,
+                }],
+            },
+            alias: Some("rn".to_string()),
+        };
+
+        window_evaluator::evaluate(&mut results, &[wf]).unwrap();
+
+        // Partition A: id=1(val=1)→1, id=3(val=3)→2
+        assert_eq!(get_payload_u64(&results[0], "rn"), Some(1));
+        assert_eq!(get_payload_u64(&results[2], "rn"), Some(2));
+
+        // Null partition: id=2→1
+        assert_eq!(get_payload_u64(&results[1], "rn"), Some(1));
+    }
+
+    #[test]
+    fn test_default_alias() {
+        let mut results = vec![make_result(
+            1,
+            serde_json::json!({"val": 1}),
+            0.5,
+        )];
+
+        // No alias → uses function_type.default_alias()
+        let wf = WindowFunction {
+            function_type: WindowFunctionType::RowNumber,
+            over_clause: OverClause {
+                partition_by: vec![],
+                order_by: vec![WindowOrderBy {
+                    column: "val".to_string(),
+                    descending: false,
+                }],
+            },
+            alias: None,
+        };
+
+        window_evaluator::evaluate(&mut results, &[wf]).unwrap();
+        assert_eq!(get_payload_u64(&results[0], "row_number"), Some(1));
+    }
+
+    #[test]
+    fn test_sort_by_similarity_score() {
+        let mut results = vec![
+            make_result(1, serde_json::json!({"source": "web"}), 0.95),
+            make_result(2, serde_json::json!({"source": "web"}), 0.80),
+            make_result(3, serde_json::json!({"source": "web"}), 0.90),
+        ];
+
+        let wf = WindowFunction {
+            function_type: WindowFunctionType::RowNumber,
+            over_clause: OverClause {
+                partition_by: vec!["source".to_string()],
+                order_by: vec![WindowOrderBy {
+                    column: "similarity".to_string(),
+                    descending: true,
+                }],
+            },
+            alias: Some("rn".to_string()),
+        };
+
+        window_evaluator::evaluate(&mut results, &[wf]).unwrap();
+
+        // Sorted by similarity DESC: 0.95→1, 0.90→2, 0.80→3
+        assert_eq!(get_payload_u64(&results[0], "rn"), Some(1)); // score=0.95
+        assert_eq!(get_payload_u64(&results[2], "rn"), Some(2)); // score=0.90
+        assert_eq!(get_payload_u64(&results[1], "rn"), Some(3)); // score=0.80
+    }
+
+    #[test]
+    fn test_all_same_values_rank() {
+        let mut results = vec![
+            make_result(1, serde_json::json!({"score": 50}), 0.5),
+            make_result(2, serde_json::json!({"score": 50}), 0.5),
+            make_result(3, serde_json::json!({"score": 50}), 0.5),
+        ];
+
+        let wf = WindowFunction {
+            function_type: WindowFunctionType::Rank,
+            over_clause: OverClause {
+                partition_by: vec![],
+                order_by: vec![WindowOrderBy {
+                    column: "score".to_string(),
+                    descending: false,
+                }],
+            },
+            alias: Some("rnk".to_string()),
+        };
+
+        window_evaluator::evaluate(&mut results, &[wf]).unwrap();
+
+        // All tied → all rank 1
+        for r in &results {
+            assert_eq!(get_payload_u64(r, "rnk"), Some(1));
+        }
+    }
+
+    #[test]
+    fn test_all_same_values_dense_rank() {
+        let mut results = vec![
+            make_result(1, serde_json::json!({"score": 50}), 0.5),
+            make_result(2, serde_json::json!({"score": 50}), 0.5),
+        ];
+
+        let wf = WindowFunction {
+            function_type: WindowFunctionType::DenseRank,
+            over_clause: OverClause {
+                partition_by: vec![],
+                order_by: vec![WindowOrderBy {
+                    column: "score".to_string(),
+                    descending: false,
+                }],
+            },
+            alias: Some("drnk".to_string()),
+        };
+
+        window_evaluator::evaluate(&mut results, &[wf]).unwrap();
+
+        // All tied → all dense_rank 1
+        for r in &results {
+            assert_eq!(get_payload_u64(r, "drnk"), Some(1));
+        }
+    }
+
+    #[test]
+    fn test_window_function_type_default_alias() {
+        assert_eq!(WindowFunctionType::RowNumber.default_alias(), "row_number");
+        assert_eq!(WindowFunctionType::Rank.default_alias(), "rank");
+        assert_eq!(WindowFunctionType::DenseRank.default_alias(), "dense_rank");
+    }
+
+    #[test]
+    fn test_nested_partition_column() {
+        let mut results = vec![
+            make_result(
+                1,
+                serde_json::json!({"metadata": {"source": "web"}, "val": 10}),
+                0.1,
+            ),
+            make_result(
+                2,
+                serde_json::json!({"metadata": {"source": "api"}, "val": 20}),
+                0.2,
+            ),
+            make_result(
+                3,
+                serde_json::json!({"metadata": {"source": "web"}, "val": 30}),
+                0.3,
+            ),
+        ];
+
+        let wf = WindowFunction {
+            function_type: WindowFunctionType::RowNumber,
+            over_clause: OverClause {
+                partition_by: vec!["metadata.source".to_string()],
+                order_by: vec![WindowOrderBy {
+                    column: "val".to_string(),
+                    descending: false,
+                }],
+            },
+            alias: Some("rn".to_string()),
+        };
+
+        window_evaluator::evaluate(&mut results, &[wf]).unwrap();
+
+        // Web partition: id=1(val=10)→1, id=3(val=30)→2
+        assert_eq!(get_payload_u64(&results[0], "rn"), Some(1));
+        assert_eq!(get_payload_u64(&results[2], "rn"), Some(2));
+
+        // API partition: id=2→1
+        assert_eq!(get_payload_u64(&results[1], "rn"), Some(1));
+    }
+
+    #[test]
+    fn test_desc_order_row_number() {
+        let mut results = vec![
+            make_result(1, serde_json::json!({"val": 10}), 0.1),
+            make_result(2, serde_json::json!({"val": 30}), 0.3),
+            make_result(3, serde_json::json!({"val": 20}), 0.2),
+        ];
+
+        let wf = WindowFunction {
+            function_type: WindowFunctionType::RowNumber,
+            over_clause: OverClause {
+                partition_by: vec![],
+                order_by: vec![WindowOrderBy {
+                    column: "val".to_string(),
+                    descending: true,
+                }],
+            },
+            alias: Some("rn".to_string()),
+        };
+
+        window_evaluator::evaluate(&mut results, &[wf]).unwrap();
+
+        // DESC: val=30→1, val=20→2, val=10→3
+        assert_eq!(get_payload_u64(&results[1], "rn"), Some(1)); // val=30 (id=2)
+        assert_eq!(get_payload_u64(&results[2], "rn"), Some(2)); // val=20 (id=3)
+        assert_eq!(get_payload_u64(&results[0], "rn"), Some(3)); // val=10 (id=1)
+    }
+}

--- a/crates/velesdb-core/tests/bdd.rs
+++ b/crates/velesdb-core/tests/bdd.rs
@@ -69,3 +69,5 @@ mod vector_group_by;
 mod vector_search;
 #[path = "bdd/where_filters.rs"]
 mod where_filters;
+#[path = "bdd/window_functions.rs"]
+mod window_functions;

--- a/crates/velesdb-core/tests/bdd/window_functions.rs
+++ b/crates/velesdb-core/tests/bdd/window_functions.rs
@@ -1,0 +1,367 @@
+//! BDD-style end-to-end tests for `VelesQL` window functions
+//! (`ROW_NUMBER`, `RANK`, `DENSE_RANK`) and their interactions with
+//! DISTINCT + qualified wildcards.
+//!
+//! These tests exercise the **full pipeline** from the user's perspective:
+//! SQL string -> `Parser::parse()` -> `Database::execute_query()` -> verify
+//! the injected window values appear in the result payloads and the
+//! DISTINCT-then-window ordering produces a contiguous `1..N` numbering.
+
+use velesdb_core::{Database, Point};
+
+use super::helpers::{create_test_db, execute_sql};
+
+// =========================================================================
+// Shared fixture: 6 "docs" rows across 3 sources with varying scores.
+// =========================================================================
+
+/// Seed a small `docs` collection suitable for window + DISTINCT tests.
+///
+/// | id | source | title    | score |
+/// |----|--------|----------|-------|
+/// |  1 | web    | Alpha    | 100.0 |
+/// |  2 | web    | Bravo    |  90.0 |
+/// |  3 | api    | Alpha    |  90.0 |  (same title as id=1 but different source)
+/// |  4 | api    | Charlie  |  80.0 |
+/// |  5 | kb     | Alpha    |  80.0 |  (same title as id=1 and id=3, third source)
+/// |  6 | kb     | Bravo    |  70.0 |
+fn setup_docs_collection(db: &Database) {
+    execute_sql(
+        db,
+        "CREATE COLLECTION docs (dimension = 4, metric = 'cosine')",
+    )
+    .expect("test: create docs");
+
+    let vc = db.get_vector_collection("docs").expect("test: get docs");
+    vc.upsert(vec![
+        Point::new(
+            1,
+            vec![1.0, 0.0, 0.0, 0.0],
+            Some(serde_json::json!({"source": "web", "title": "Alpha", "score": 100.0})),
+        ),
+        Point::new(
+            2,
+            vec![1.0, 0.0, 0.0, 0.0],
+            Some(serde_json::json!({"source": "web", "title": "Bravo", "score": 90.0})),
+        ),
+        Point::new(
+            3,
+            vec![1.0, 0.0, 0.0, 0.0],
+            Some(serde_json::json!({"source": "api", "title": "Alpha", "score": 90.0})),
+        ),
+        Point::new(
+            4,
+            vec![1.0, 0.0, 0.0, 0.0],
+            Some(serde_json::json!({"source": "api", "title": "Charlie", "score": 80.0})),
+        ),
+        Point::new(
+            5,
+            vec![1.0, 0.0, 0.0, 0.0],
+            Some(serde_json::json!({"source": "kb", "title": "Alpha", "score": 80.0})),
+        ),
+        Point::new(
+            6,
+            vec![1.0, 0.0, 0.0, 0.0],
+            Some(serde_json::json!({"source": "kb", "title": "Bravo", "score": 70.0})),
+        ),
+    ])
+    .expect("test: upsert docs");
+}
+
+fn payload_u64(result: &velesdb_core::SearchResult, field: &str) -> Option<u64> {
+    result
+        .point
+        .payload
+        .as_ref()
+        .and_then(|p| p.get(field))
+        .and_then(serde_json::Value::as_u64)
+}
+
+// =========================================================================
+// ROW_NUMBER — simple case, verifies the full pipeline wires window values
+// into the returned payloads.
+// =========================================================================
+
+#[test]
+fn test_row_number_over_order_by_score_desc() {
+    let (_dir, db) = create_test_db();
+    setup_docs_collection(&db);
+
+    // GIVEN: 6 docs with known scores.
+    // WHEN: project ROW_NUMBER() OVER (ORDER BY score DESC) AS rn
+    let results = execute_sql(
+        &db,
+        "SELECT id, score, ROW_NUMBER() OVER (ORDER BY score DESC) AS rn FROM docs LIMIT 10",
+    )
+    .expect("test: query");
+
+    // THEN: every result carries a dense rn in payload. Sorted scores:
+    //   100 (id=1), 90 (id=2), 90 (id=3), 80 (id=4), 80 (id=5), 70 (id=6)
+    //   → rn = 1, 2, 3, 4, 5, 6 respectively.
+    assert_eq!(results.len(), 6);
+    let by_id: std::collections::HashMap<u64, u64> = results
+        .iter()
+        .map(|r| (r.point.id, payload_u64(r, "rn").expect("rn present")))
+        .collect();
+
+    assert_eq!(by_id[&1], 1, "score=100 → rn 1");
+    assert_eq!(by_id[&6], 6, "score=70 → rn 6");
+    // id 2 and 3 share score=90 — both get distinct row numbers (ROW_NUMBER
+    // doesn't handle ties). Same for id 4 and 5 at score=80.
+    let rns_for_tie_90: Vec<u64> = [2, 3].iter().map(|id| by_id[id]).collect();
+    assert!(rns_for_tie_90.contains(&2) && rns_for_tie_90.contains(&3));
+    let rns_for_tie_80: Vec<u64> = [4, 5].iter().map(|id| by_id[id]).collect();
+    assert!(rns_for_tie_80.contains(&4) && rns_for_tie_80.contains(&5));
+}
+
+// =========================================================================
+// RANK with PARTITION BY — per-source ranking with ties.
+// =========================================================================
+
+#[test]
+fn test_rank_partition_by_source_order_by_score_desc() {
+    let (_dir, db) = create_test_db();
+    setup_docs_collection(&db);
+
+    let results = execute_sql(
+        &db,
+        "SELECT id, source, score, \
+              RANK() OVER (PARTITION BY source ORDER BY score DESC) AS rnk \
+              FROM docs LIMIT 10",
+    )
+    .expect("test: query");
+
+    assert_eq!(results.len(), 6);
+
+    // Partition "web": id=1 (100) → 1, id=2 (90) → 2
+    // Partition "api": id=3 (90) → 1, id=4 (80) → 2
+    // Partition "kb":  id=5 (80) → 1, id=6 (70) → 2
+    let by_id: std::collections::HashMap<u64, u64> = results
+        .iter()
+        .map(|r| (r.point.id, payload_u64(r, "rnk").expect("rnk present")))
+        .collect();
+    assert_eq!(by_id[&1], 1);
+    assert_eq!(by_id[&2], 2);
+    assert_eq!(by_id[&3], 1);
+    assert_eq!(by_id[&4], 2);
+    assert_eq!(by_id[&5], 1);
+    assert_eq!(by_id[&6], 2);
+}
+
+// =========================================================================
+// DENSE_RANK with ties — no gaps after tie groups.
+// =========================================================================
+
+#[test]
+fn test_dense_rank_single_partition_with_ties_has_no_gaps() {
+    let (_dir, db) = create_test_db();
+    setup_docs_collection(&db);
+
+    let results = execute_sql(
+        &db,
+        "SELECT id, score, DENSE_RANK() OVER (ORDER BY score DESC) AS drnk FROM docs LIMIT 10",
+    )
+    .expect("test: query");
+
+    // Sorted by score DESC:
+    //   100         → drnk 1
+    //   90, 90      → drnk 2 (tie, no gap after)
+    //   80, 80      → drnk 3 (tie, no gap after)
+    //   70          → drnk 4
+    assert_eq!(results.len(), 6);
+    let by_id: std::collections::HashMap<u64, u64> = results
+        .iter()
+        .map(|r| (r.point.id, payload_u64(r, "drnk").expect("drnk present")))
+        .collect();
+    assert_eq!(by_id[&1], 1); // 100
+    assert_eq!(by_id[&2], 2); // 90
+    assert_eq!(by_id[&3], 2); // 90 tie
+    assert_eq!(by_id[&4], 3); // 80
+    assert_eq!(by_id[&5], 3); // 80 tie
+    assert_eq!(by_id[&6], 4); // 70 (no gap)
+}
+
+// =========================================================================
+// Pipeline regression: DISTINCT runs BEFORE window functions, so
+// `SELECT DISTINCT title, ROW_NUMBER() ...` numbers DEDUPED survivors
+// contiguously, without gaps.
+//
+// This pins the VelesQL-intentional-deviation from SQL standard order.
+// =========================================================================
+
+#[test]
+fn test_distinct_then_window_numbers_survivors_contiguously() {
+    let (_dir, db) = create_test_db();
+    setup_docs_collection(&db);
+
+    // 3 distinct titles: Alpha, Bravo, Charlie.
+    let results = execute_sql(
+        &db,
+        "SELECT DISTINCT title, ROW_NUMBER() OVER (ORDER BY title ASC) AS rn \
+              FROM docs LIMIT 10",
+    )
+    .expect("test: query");
+
+    // THEN: exactly 3 survivors (DISTINCT dedup by title) and rn is 1, 2, 3
+    // (contiguous — window function numbers DEDUPED rows).
+    assert_eq!(
+        results.len(),
+        3,
+        "DISTINCT collapses 6 rows down to 3 unique titles"
+    );
+
+    let mut rns: Vec<u64> = results
+        .iter()
+        .map(|r| payload_u64(r, "rn").expect("rn present"))
+        .collect();
+    rns.sort_unstable();
+    assert_eq!(
+        rns,
+        vec![1, 2, 3],
+        "window function numbers the 3 survivors 1..3, no gaps"
+    );
+}
+
+// =========================================================================
+// Pipeline regression: DISTINCT dedup key now includes qualified-wildcard
+// fields. Rows that differ only on a wildcard-expanded field must survive.
+//
+// This pins the zero-tech-debt fix for the Devin finding on
+// `apply_distinct` + `qualified_wildcards`.
+// =========================================================================
+
+#[test]
+fn test_distinct_with_qualified_wildcard_dedupes_by_full_payload() {
+    let (_dir, db) = create_test_db();
+    setup_docs_collection(&db);
+
+    // Three rows share title="Alpha" but differ on source/score:
+    //   id=1 web 100, id=3 api 90, id=5 kb 80.
+    // Without the fix, `DISTINCT docs.*, title` deduped by `title` only
+    // and collapsed these three into one. With the fix, every wildcard
+    // field participates in the dedup key → all three survive.
+    let results = execute_sql(
+        &db,
+        "SELECT DISTINCT docs.*, title FROM docs WHERE title = 'Alpha' LIMIT 10",
+    )
+    .expect("test: query");
+
+    assert_eq!(
+        results.len(),
+        3,
+        "rows differ on source + score (wildcard-expanded) so all three survive"
+    );
+
+    // All three must have title=\"Alpha\" and unique source values.
+    let mut sources: Vec<String> = results
+        .iter()
+        .map(|r| {
+            r.point
+                .payload
+                .as_ref()
+                .and_then(|p| p.get("source"))
+                .and_then(serde_json::Value::as_str)
+                .expect("source present")
+                .to_string()
+        })
+        .collect();
+    sources.sort();
+    assert_eq!(sources, vec!["api", "kb", "web"]);
+}
+
+// =========================================================================
+// Alias-collision regression: RANK() AS score on a column named `score`
+// must NOT use the injected ranks for tie detection (the bug Devin flagged
+// on the first review pass). Executed here through the full pipeline to
+// confirm the evaluator guards against corruption end-to-end, not just in
+// isolation.
+// =========================================================================
+
+#[test]
+fn test_rank_alias_collides_with_payload_score_end_to_end() {
+    let (_dir, db) = create_test_db();
+    setup_docs_collection(&db);
+
+    // Alias `score` collides with the ORDER BY column. Pre-fix, RANK
+    // would write [1,2,3,4,5,6] into `payload.score` and destroy ties.
+    let results = execute_sql(
+        &db,
+        "SELECT id, RANK() OVER (ORDER BY score DESC) AS score FROM docs LIMIT 10",
+    )
+    .expect("test: query");
+
+    assert_eq!(results.len(), 6);
+
+    // Expected ranks for sorted score [100, 90, 90, 80, 80, 70]: [1, 2, 2, 4, 4, 6].
+    // The `score` alias overwrites the payload, so we read from `payload.score`.
+    let ranks_by_id: std::collections::HashMap<u64, u64> = results
+        .iter()
+        .map(|r| (r.point.id, payload_u64(r, "score").expect("score present")))
+        .collect();
+
+    assert_eq!(ranks_by_id[&1], 1, "id=1 score=100 rank 1");
+    // ids 2 and 3 tie at score=90 → both rank 2 (gap after tie):
+    assert_eq!(ranks_by_id[&2], 2);
+    assert_eq!(ranks_by_id[&3], 2);
+    // ids 4 and 5 tie at score=80 → both rank 4:
+    assert_eq!(ranks_by_id[&4], 4);
+    assert_eq!(ranks_by_id[&5], 4);
+    // id 6 at score=70 → rank 6 (gap preserved):
+    assert_eq!(ranks_by_id[&6], 6);
+}
+
+// =========================================================================
+// Negative-path: a SELECT with a window function on an empty result set
+// must not panic and must produce no rows.
+// =========================================================================
+
+#[test]
+fn test_window_function_on_empty_result_returns_no_rows() {
+    let (_dir, db) = create_test_db();
+    setup_docs_collection(&db);
+
+    let results = execute_sql(
+        &db,
+        "SELECT id, ROW_NUMBER() OVER (ORDER BY score DESC) AS rn \
+              FROM docs WHERE score > 99999 LIMIT 10",
+    )
+    .expect("test: query");
+
+    assert!(results.is_empty(), "filter selects nothing → 0 rows");
+}
+
+// =========================================================================
+// Sanity: window functions coexist with existing similarity() projection.
+// =========================================================================
+
+#[test]
+fn test_window_function_coexists_with_vector_search_near() {
+    use super::helpers::{execute_sql_with_params, vector_param};
+
+    let (_dir, db) = create_test_db();
+    setup_docs_collection(&db);
+
+    // Vector search context (NEAR) + window function — verifies the
+    // window pipeline slot runs on NEAR-ranked results and injects its
+    // alias into every row's payload.
+    let params = vector_param(&[1.0, 0.0, 0.0, 0.0]);
+    let results = execute_sql_with_params(
+        &db,
+        "SELECT id, ROW_NUMBER() OVER (ORDER BY score DESC) AS rn \
+              FROM docs WHERE vector NEAR $v LIMIT 10",
+        &params,
+    )
+    .expect("test: query");
+
+    assert_eq!(
+        results.len(),
+        6,
+        "all 6 docs returned by NEAR (k=10 but only 6 exist)"
+    );
+    for r in &results {
+        assert!(
+            payload_u64(r, "rn").is_some(),
+            "window alias `rn` in payload even when NEAR runs first"
+        );
+    }
+}

--- a/crates/velesdb-python/src/velesql.rs
+++ b/crates/velesdb-python/src/velesql.rs
@@ -213,15 +213,35 @@ impl ParsedStatement {
         self.inner.select.from_alias.clone()
     }
 
-    /// Get the list of selected columns.
+    /// Get the list of selected columns — one entry per SELECT-list item.
+    ///
+    /// The returned list covers every item in the SELECT list, in grammar
+    /// order: regular columns, aggregate calls, `similarity()` expressions,
+    /// qualified wildcards (`alias.*`), and window functions.
     ///
     /// Returns:
-    ///     list[str] or '*': List of column names, or ['*'] for SELECT *
+    ///     list[str]: Column identifiers, one per SELECT-list item. Use
+    ///     the literal `'*'` for `SELECT *`. Qualified wildcards appear as
+    ///     `'alias.*'`. Aliased expressions use the alias (or the bare
+    ///     default for un-aliased similarity / window calls).
     ///
     /// Example:
     ///     >>> parsed = VelesQL.parse("SELECT id, name FROM users")
-    ///     >>> print(parsed.columns)
+    ///     >>> parsed.columns
     ///     ['id', 'name']
+    ///
+    ///     >>> parsed = VelesQL.parse(
+    ///     ...     "SELECT title, similarity() AS score, "
+    ///     ...     "ROW_NUMBER() OVER (ORDER BY score DESC) AS rn FROM docs"
+    ///     ... )
+    ///     >>> parsed.columns
+    ///     ['title', 'score', 'rn']
+    ///
+    /// Note (v1.13.0 contract completion):
+    ///     Versions prior to v1.13.0 silently omitted `similarity()`
+    ///     expressions and qualified wildcards from this list for mixed
+    ///     SELECT statements. The full list is now returned. Callers that
+    ///     relied on the shorter length must update their expectations.
     #[getter]
     fn columns(&self) -> Vec<String> {
         self.inner.select.columns.to_display_names()

--- a/crates/velesdb-wasm/src/velesql.rs
+++ b/crates/velesdb-wasm/src/velesql.rs
@@ -113,7 +113,17 @@ impl ParsedQuery {
         self.collection_name()
     }
 
-    /// Get the list of selected columns as JSON array.
+    /// Get the list of selected columns — one entry per SELECT-list item.
+    ///
+    /// Returns a JSON array with every item in the SELECT list, in grammar
+    /// order: regular columns, aggregate calls, `similarity()` expressions,
+    /// qualified wildcards (`alias.*`), and window functions. `SELECT *`
+    /// returns `["*"]`.
+    ///
+    /// Note (v1.13.0 contract completion): versions prior to v1.13.0
+    /// silently omitted `similarity()` expressions and qualified wildcards
+    /// from this list for mixed SELECT statements. The full list is now
+    /// returned. Callers that hard-coded the shorter length must update.
     #[wasm_bindgen(getter)]
     pub fn columns(&self) -> JsValue {
         let cols = self.inner.select.columns.to_display_names();


### PR DESCRIPTION
## Summary

Implements SQL window functions `ROW_NUMBER()`, `RANK()`, `DENSE_RANK()` with `PARTITION BY` and `ORDER BY` support in VelesQL.

Closes #386

## Changes

### Grammar (`grammar.pest`)
- 11 new PEG rules: `window_item`, `window_function_call`, `window_function_name`, `over_clause`, `partition_by_clause`, `partition_by_list`, `window_order_by_clause`, `window_order_by_item`, `window_order_by_expr`
- Window rules placed **before** `aggregation_item` to prevent PEG ambiguity

### AST (`ast/window.rs`) - NEW
- `WindowFunctionType` enum (`RowNumber`, `Rank`, `DenseRank`)
- `WindowOrderBy`, `OverClause`, `WindowFunction` structs
- All types derive `Serialize`/`Deserialize` with `serde(default)` for backward compatibility

### Parser (`clause_projection.rs`)
- Extended `SelectItemAccumulator` with `window_functions` tracking
- 4 new parsing methods: `parse_window_item`, `parse_window_function_call`, `parse_over_clause`, `parse_window_order_by_item`

### Executor (`window_evaluator.rs`) - NEW
- Partition-sort-rank pipeline with `BTreeMap` for deterministic ordering
- Handles nested field paths, `similarity`/`score` sorting, NULL partitions
- Integrated into `select_dispatch.rs` postprocessing (after DISTINCT, before ORDER BY)
- Injects ranking values into result payload JSON

### Tests (`window_function_tests.rs`) - NEW
- **22 tests**: 8 parser + 14 evaluator
- Edge cases: empty sets, single result, all-tied values, NULL partitions, nested fields, DESC ordering, case-insensitive keywords, similarity score sorting

## Verification

| Check | Result |
|---|---|
| `cargo check` (core, server, tauri) | All 3 crates compile |
| Clippy (new code) | Zero warnings |
| Window function tests | 22/22 pass |
| Parser regression tests | 18/18 pass |
| Validation regression tests | 75/75 pass |
| TODOs/FIXMEs/hallucinations | None found |

## Example Usage

```sql
-- Top-2 documents per source by similarity
SELECT name, source,
       ROW_NUMBER() OVER (PARTITION BY source ORDER BY similarity() DESC) AS rn
FROM documents
WHERE vector NEAR 
LIMIT 100

-- Rank with tie handling
SELECT title,
       RANK() OVER (ORDER BY score DESC) AS rnk,
       DENSE_RANK() OVER (ORDER BY score DESC) AS drnk
FROM results
```

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/629" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
