### PR TITLE
docs(changelog): add GPU HNSW traversal to v1.13.0 entry (#626)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.13.0] — 2026-04-22
+## [1.13.0] — 2026-04-23
 
 ### Summary
 
@@ -21,6 +21,15 @@ reproducer commands next to every performance claim, a dedicated
 "Known Limitations" section for scope transparency, and a refreshed
 test-count badge (7634 tests across Rust, TypeScript, Python).
 
+**GPU-accelerated HNSW layer-0 traversal** (`#626`, closes `#502`) —
+new SONG 3-stage compute pipeline (Expand → Distance → Select) runs
+layer-0 BFS on the GPU via wgpu compute shaders. CPU still handles
+upper-layer greedy descent; the GPU kicks in only when
+`num_vectors > 500_000` AND `num_vectors * dim ≤ u32::MAX` (WGSL has
+no u64 — correctness gate). Graceful fallback to the CPU SIMD path
+on any GPU error. 77 new GPU tests, zero new dependencies, zero
+`unsafe`. Credit @SBALAVIGNESH123 for the original implementation.
+
 **Pre-seed remediation (Option D)** — 10 phases merged across
 `#611`–`#623`: BM25 persistence cold-start dropped from O(N) to O(1),
 sparse search speed-up of 16× on 10K-doc corpora via k-way merge +
@@ -32,6 +41,31 @@ search layers (cumulative across all phases: jscpd `collection/`
 Zero regression cumulatively —
 recall gate (Fast 0.90 / Balanced 0.95 / Accurate 0.99 / Perfect 1.00)
 passes on every phase.
+
+### Added — GPU acceleration
+
+- **GPU HNSW layer-0 traversal** (`#626`, closes `#502`): SONG paper
+  3-stage pipeline on wgpu. New modules:
+  - `crates/velesdb-core/src/gpu/gpu_traversal.rs` — pipeline
+    orchestration (CSR snapshot cache, generation-based invalidation,
+    double-buffered frontier, adaptive 10–20 iterations based on
+    `ef_search`).
+  - `crates/velesdb-core/src/gpu/gpu_traversal_buffers.rs` — GPU
+    buffer management.
+  - `crates/velesdb-core/src/gpu/gpu_traversal_pipelines.rs` —
+    compute-shader pipeline setup (EXPAND_FRONTIER, TRAVERSAL_*
+    distance kernels for Euclidean-squared / Cosine / DotProduct,
+    SELECT_TOPK with workgroup-local bitonic sort).
+  - `crates/velesdb-core/src/index/hnsw/native/graph/gpu_search.rs`
+    — search entry point with correctness-gate guard
+    (`should_traverse_gpu`) and CPU fallback.
+
+  All iterations dispatched in a single command buffer (no per-iter
+  CPU↔GPU sync), activated behind the existing `--features gpu` flag.
+  Gate: `num_vectors > 500_000` AND `num_vectors * dim ≤ u32::MAX`.
+  Below either threshold, or on any GPU error, returns `None` so the
+  caller falls back to the CPU SIMD path — no behavior change for
+  workloads outside the GPU activation range.
 
 ### Added — Pre-seed remediation
 

--- a/docs/reference/promise-contract.json
+++ b/docs/reference/promise-contract.json
@@ -1,5 +1,5 @@
 {
-  "last_updated": "2026-04-22",
+  "last_updated": "2026-04-23",
   "claims": [
     {
       "id": "root_readme_hnsw_latency_microseconds",


### PR DESCRIPTION
## Summary

PR #626 (SONG 3-stage GPU HNSW layer-0 traversal) landed on develop at 2026-04-22 21:30 UTC, **after** #627 had already finalized the v1.13.0 CHANGELOG entry. This docs-only PR closes the gap so the release tag carries an accurate changelog.

## Changes

- `CHANGELOG.md`:
  - `[1.13.0]` date bumped 2026-04-22 → 2026-04-23 (actual tag date, CEST).
  - Summary section: GPU HNSW callout inserted ahead of the Pre-seed remediation block.
  - New `### Added — GPU acceleration` subsection:
    - Lists the four new modules (`gpu_traversal.rs`, `gpu_traversal_buffers.rs`, `gpu_traversal_pipelines.rs`, `gpu_search.rs`).
    - Documents the activation gate (`>500K vectors AND num_vectors * dim ≤ u32::MAX` — WGSL has no `u64`).
    - Notes the graceful CPU fallback on any GPU error.
    - Credits @SBALAVIGNESH123 for the original implementation.
- `docs/reference/promise-contract.json`: `last_updated` bumped 2026-04-22 → 2026-04-23.

No code touched. No test or feature change. Still 15 promise-contract claims.

## Validation

- `cargo fmt --all -- --check`: clean
- `python scripts/check-promise-contract.py`: 15 claims PASS

## Impact matrix

| Component | Changed | Action |
|---|---|---|
| `CHANGELOG.md` | Yes | +1 subsection, +1 summary paragraph, date bumped |
| `docs/reference/promise-contract.json` | Yes | `last_updated` bumped only |
| All crates / SDKs / integrations | No | Docs-only |

## Post-merge

1. PR #628 (develop→main) auto-updates with this commit.
2. Wait CI green on #628 (full matrix + Codacy Cloud + Devin).
3. Merge #628 to main.
4. Tag `v1.13.0` on main, `git push --tags` → Release workflow publishes to crates.io / PyPI / npm.
5. Smoke install test.

## Test plan

- [x] Fmt + promise-contract local checks
- [ ] CI green on this PR
- [ ] Devin + Codacy Cloud review
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/635" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
