### PR TITLE
chore(gpu): enforce lock-ordering for gpu_vectors_snapshot + CsrCache caller contract

### DIFF
--- a/crates/velesdb-core/src/gpu/gpu_csr.rs
+++ b/crates/velesdb-core/src/gpu/gpu_csr.rs
@@ -296,12 +296,46 @@ impl CsrCache {
     ///
     /// This method is designed for the GPU dispatch hot path:
     /// - If the cache is fresh, returns the existing CSR (fast path).
-    /// - If stale, rebuilds from the Layer (slow path, ~50ms for 1M nodes).
+    /// - If stale, rebuilds from the `layer` argument (slow path, ~50 ms
+    ///   for 1 M nodes).
     ///
-    /// The rebuild is generation-safe: if a concurrent `invalidate()` occurs
-    /// during the rebuild, the stale CSR is still stored but the generation
-    /// check ensures the *next* query will re-trigger a rebuild.
+    /// # Caller contract — must hold `layers` read lock
+    ///
+    /// **The rebuild from `layer` is only race-free while the caller holds
+    /// the `layers` read lock** (rank 20 in `locking::LockRank`) for the
+    /// entire duration of this call. Layer mutations require the write
+    /// lock, so as long as the read lock is held, every concurrent
+    /// rebuilder sees the same layer topology and produces an identical
+    /// CSR. The `gen_before`/`gen_after` check under `self.csr.write()`
+    /// then discards any rebuild that raced with an `invalidate()`.
+    ///
+    /// If a future caller ever invokes `get_or_rebuild` **without** the
+    /// layers read lock held, two rebuilders could observe different
+    /// layer states, and one might commit a stale CSR while the
+    /// generation counter indicates fresh — a silent correctness bug.
+    /// Debug builds assert the precondition via `holds_lock(Layers)`.
+    ///
+    /// # Generation protocol (NOT a CAS)
+    ///
+    /// The rebuild is **not** a compare-and-swap. It is a
+    /// load-before-rebuild (`gen_before`) / re-check-under-write-lock
+    /// (`gen_after`) sequence: we store the new CSR and bump
+    /// `built_generation` only when the generation has not moved during
+    /// the rebuild. Correctness depends on the caller contract above —
+    /// without the shared layer snapshot, the write would still be
+    /// atomic but the data committed could be stale.
     pub fn get_or_rebuild(&self, layer: &Layer, num_nodes: usize) -> CsrGraph {
+        // Caller contract: the layers read lock must be held so concurrent
+        // rebuilders observe the same layer topology. In release builds
+        // `hnsw_holds_lock` returns `true` unconditionally (thread-local
+        // stack is not maintained), so the assert is a debug-only tripwire.
+        debug_assert!(
+            crate::index::hnsw::native::hnsw_holds_lock(
+                crate::index::hnsw::native::HnswLockRank::Layers
+            ),
+            "CsrCache::get_or_rebuild must be called while holding the layers read lock"
+        );
+
         // Fast path: check if cache is fresh
         if !self.is_stale() {
             let guard = self.csr.read();
@@ -313,7 +347,9 @@ impl CsrCache {
         // Snapshot generation before rebuild
         let gen_before = self.generation.load(Ordering::Acquire);
 
-        // Slow path: rebuild outside of any lock.
+        // Slow path: rebuild outside of any lock on `self.csr`. Safe
+        // against concurrent rebuilders because they all observe the
+        // same layer state (see caller contract above).
         let new_csr = CsrGraph::from_layer(layer, num_nodes);
 
         // Commit is atomic under the write lock: we only store our CSR
@@ -368,7 +404,21 @@ impl Default for CsrCache {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::index::hnsw::native::NodeId;
+    use crate::index::hnsw::native::{
+        hnsw_holds_lock, hnsw_record_lock_acquire, hnsw_record_lock_release, HnswLockRank, NodeId,
+    };
+
+    /// Runs `f` with the layers rank recorded as held — the caller contract
+    /// of [`CsrCache::get_or_rebuild`]. Abstracts away the record/release
+    /// dance so tests read linearly and do not accidentally break the
+    /// contract by forgetting the release.
+    fn with_layers_rank<R>(f: impl FnOnce() -> R) -> R {
+        hnsw_record_lock_acquire(HnswLockRank::Layers);
+        debug_assert!(hnsw_holds_lock(HnswLockRank::Layers));
+        let result = f();
+        hnsw_record_lock_release(HnswLockRank::Layers);
+        result
+    }
 
     #[test]
     fn test_csr_from_empty_layer() {
@@ -432,19 +482,20 @@ mod tests {
         layer.set_neighbors(0, vec![1]);
         layer.set_neighbors(1, vec![0]);
 
-        // First build
-        let csr = cache.get_or_rebuild(&layer, 2);
+        // First build — tests model the production caller contract
+        // (`with_layers_read → get_or_rebuild`) via `with_layers_rank`.
+        let csr = with_layers_rank(|| cache.get_or_rebuild(&layer, 2));
         assert_eq!(csr.num_nodes, 2);
         assert_eq!(cache.version(), 1);
 
         // Should return cached (not rebuild)
-        let csr2 = cache.get_or_rebuild(&layer, 2);
+        let csr2 = with_layers_rank(|| cache.get_or_rebuild(&layer, 2));
         assert_eq!(csr2.num_nodes, 2);
         assert_eq!(cache.version(), 1); // Same version
 
         // Invalidate and rebuild
         cache.invalidate();
-        let csr3 = cache.get_or_rebuild(&layer, 2);
+        let csr3 = with_layers_rank(|| cache.get_or_rebuild(&layer, 2));
         assert_eq!(csr3.num_nodes, 2);
         assert_eq!(cache.version(), 2); // Incremented
     }
@@ -484,7 +535,7 @@ mod tests {
         assert!(cache.get_if_clean().is_none()); // Starts dirty
 
         let layer = Layer::new(1);
-        cache.get_or_rebuild(&layer, 1); // Build it
+        with_layers_rank(|| cache.get_or_rebuild(&layer, 1)); // Build it
         assert!(cache.get_if_clean().is_some()); // Now clean
 
         cache.invalidate();

--- a/crates/velesdb-core/src/gpu/gpu_csr_tests.rs
+++ b/crates/velesdb-core/src/gpu/gpu_csr_tests.rs
@@ -7,6 +7,19 @@
 
 use crate::gpu::gpu_csr::{CsrCache, CsrGraph};
 use crate::index::hnsw::native::layer::{Layer, NodeId};
+use crate::index::hnsw::native::{
+    hnsw_record_lock_acquire, hnsw_record_lock_release, HnswLockRank,
+};
+
+/// Runs `f` with the layers rank recorded as held — the caller contract
+/// of [`CsrCache::get_or_rebuild`]. Mirrors the helper in `gpu_csr::tests`
+/// so concurrent tests spread across threads keep their rank stack clean.
+fn with_layers_rank<R>(f: impl FnOnce() -> R) -> R {
+    hnsw_record_lock_acquire(HnswLockRank::Layers);
+    let result = f();
+    hnsw_record_lock_release(HnswLockRank::Layers);
+    result
+}
 
 #[test]
 fn test_csr_validate_valid_graph() {
@@ -228,7 +241,7 @@ fn test_csr_cache_concurrent_rebuild_safety() {
             let c = Arc::clone(&cache);
             let l = Arc::clone(&layer);
             thread::spawn(move || {
-                let csr = c.get_or_rebuild(&l, 100);
+                let csr = with_layers_rank(|| c.get_or_rebuild(&l, 100));
                 assert_eq!(csr.num_nodes, 100);
                 assert!(csr.validate().is_ok());
             })
@@ -273,7 +286,7 @@ fn test_csr_cache_no_stale_commit_under_concurrent_invalidate() {
             let l = Arc::clone(&layer);
             thread::spawn(move || {
                 for _ in 0..100 {
-                    let csr = c.get_or_rebuild(&l, 64);
+                    let csr = with_layers_rank(|| c.get_or_rebuild(&l, 64));
                     // Whatever we observe, it must always validate:
                     // a corrupt CSR would indicate a torn write.
                     assert!(csr.validate().is_ok());
@@ -302,7 +315,7 @@ fn test_csr_cache_no_stale_commit_under_concurrent_invalidate() {
     }
 
     // One final rebuild converges the cache. Must produce a valid CSR.
-    let final_csr = cache.get_or_rebuild(&layer, 64);
+    let final_csr = with_layers_rank(|| cache.get_or_rebuild(&layer, 64));
     assert_eq!(final_csr.num_nodes, 64);
     assert!(final_csr.validate().is_ok());
 }
@@ -315,9 +328,33 @@ fn test_csr_cache_invalidate_rebuild_cycle() {
     }
     let cache = CsrCache::new();
     for round in 0..5_u64 {
-        let csr = cache.get_or_rebuild(&layer, 10);
+        let csr = with_layers_rank(|| cache.get_or_rebuild(&layer, 10));
         assert_eq!(csr.num_nodes, 10);
         assert_eq!(cache.version(), round + 1);
         cache.invalidate();
     }
+}
+
+/// Regression for the caller contract documented on
+/// [`CsrCache::get_or_rebuild`]. Debug builds must panic when the
+/// function is invoked without the layers read lock held — see the
+/// race described by Devin on PR #626 where a rebuilder without the
+/// shared layer snapshot can commit stale data under a fresh
+/// generation counter. Release builds compile the assert out and have
+/// to rely on the caller audit; this test guards the invariant at
+/// least during CI / local debug runs.
+#[cfg(debug_assertions)]
+#[test]
+#[should_panic(expected = "layers read lock")]
+fn test_csr_cache_get_or_rebuild_panics_without_layers_lock() {
+    let layer = Layer::new(4);
+    layer.set_neighbors(0, vec![1, 2]);
+    layer.set_neighbors(1, vec![0, 3]);
+    layer.set_neighbors(2, vec![0, 1, 3]);
+    layer.set_neighbors(3, vec![1, 2]);
+
+    let cache = CsrCache::new();
+    // Deliberately DO NOT wrap in `with_layers_rank` — this simulates a
+    // future caller that forgets the contract.
+    let _ = cache.get_or_rebuild(&layer, 4);
 }

--- a/crates/velesdb-core/src/index/hnsw/native/backend_adapter.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/backend_adapter.rs
@@ -156,10 +156,18 @@ impl<D: DistanceEngine + Send + Sync> NativeHnsw<D> {
         // Invalidate GPU caches — topology and vectors both changed.
         // Single `insert()` does this per-call; batch path must do it once
         // after all nodes are connected to avoid stale CSR/vector snapshots.
+        //
+        // `finalize_batch` has already released every `Vectors` write lock
+        // taken during the insert loop, so the `gpu_vectors_snapshot`
+        // acquisition below is a flat acquire (rank 5) with nothing on the
+        // lock stack — consistent with the declared global order.
         #[cfg(feature = "gpu")]
         {
+            use super::graph::locking::{record_lock_acquire, record_lock_release, LockRank};
             self.gpu_csr_cache.invalidate();
+            record_lock_acquire(LockRank::GpuVectorsSnapshot);
             *self.gpu_vectors_snapshot.lock() = None;
+            record_lock_release(LockRank::GpuVectorsSnapshot);
         }
 
         // Return the graph-assigned node IDs in input order

--- a/crates/velesdb-core/src/index/hnsw/native/graph/gpu_search.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/graph/gpu_search.rs
@@ -168,26 +168,44 @@ impl<D: DistanceEngine> NativeHnsw<D> {
     /// Returns cached vector snapshot or refreshes it if the count changed.
     ///
     /// Returns `(dimension, Arc<[f32]>)`. The Arc clone is O(1) on cache hit.
+    ///
+    /// # Lock order
+    ///
+    /// Acquires `gpu_vectors_snapshot` (rank 5) first, then nests
+    /// `vectors` (rank 10) via `with_vectors_read` when the cache is stale.
+    /// Instrumented with `record_lock_acquire/release` so the runtime
+    /// lock-rank tracker (debug builds) catches any future caller that
+    /// inverts the order.
     fn get_or_refresh_vector_snapshot(
         &self,
         current_count: usize,
     ) -> (usize, std::sync::Arc<[f32]>) {
+        use super::locking::{record_lock_acquire, record_lock_release, LockRank};
+
+        record_lock_acquire(LockRank::GpuVectorsSnapshot);
         let mut snapshot = self.gpu_vectors_snapshot.lock();
 
         // Check if cached snapshot is still valid
         if let Some((cached_count, cached_dim, ref cached_vecs)) = *snapshot {
             if cached_count == current_count {
-                return (cached_dim, cached_vecs.clone());
+                let hit = (cached_dim, cached_vecs.clone());
+                drop(snapshot);
+                record_lock_release(LockRank::GpuVectorsSnapshot);
+                return hit;
             }
         }
 
-        // Cache miss or stale — refresh
+        // Cache miss or stale — refresh. `with_vectors_read` nests
+        // `Vectors` (rank 10) inside the snapshot mutex (rank 5), which
+        // is the declared lock order.
         let (dim, arc) = self.with_vectors_read(|vectors| {
             let d = vectors.dimension();
             let arc: std::sync::Arc<[f32]> = vectors.as_flat_slice().to_vec().into();
             (d, arc)
         });
         *snapshot = Some((current_count, dim, arc.clone()));
+        drop(snapshot);
+        record_lock_release(LockRank::GpuVectorsSnapshot);
         (dim, arc)
     }
 

--- a/crates/velesdb-core/src/index/hnsw/native/graph/insert.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/graph/insert.rs
@@ -107,10 +107,19 @@ impl<D: DistanceEngine> NativeHnsw<D> {
         self.count.fetch_add(1, Ordering::Relaxed);
 
         // Invalidate GPU caches — topology and vectors both changed.
+        //
+        // `vectors.write()` is already released at this point (the caller
+        // chain `allocate_and_store_vector → with_vectors_write` drops it
+        // before returning), so the `gpu_vectors_snapshot` acquisition
+        // below does not nest inside the vectors lock and respects the
+        // declared order (`GpuVectorsSnapshot` rank 5 → `Vectors` rank 10).
         #[cfg(feature = "gpu")]
         {
+            use super::locking::{record_lock_acquire, record_lock_release, LockRank};
             self.gpu_csr_cache.invalidate();
+            record_lock_acquire(LockRank::GpuVectorsSnapshot);
             *self.gpu_vectors_snapshot.lock() = None;
+            record_lock_release(LockRank::GpuVectorsSnapshot);
         }
 
         Ok(node_id)

--- a/crates/velesdb-core/src/index/hnsw/native/graph/locking.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/graph/locking.rs
@@ -139,8 +139,15 @@ pub(crate) fn lock_depth() -> usize {
 /// cache rebuild helpers that must run under a parent lock — e.g. a
 /// GPU CSR rebuild is only race-free while the layers read lock is held.
 ///
-/// Returns `false` in release builds (the thread-local stack is not
-/// maintained there, so any runtime assertion is a no-op).
+/// Returns `true` in release builds (the thread-local stack is not
+/// maintained there, so any runtime assertion is a no-op). Callers
+/// should always wrap the invocation in `debug_assert!` so the entire
+/// check compiles out of release binaries.
+// Only reachable via `debug_assert!` in `gpu_csr` (feature-gated) and
+// via the locking test module; outside those contexts rustc treats the
+// function as dead code. Keep it visible at the crate level so future
+// callers can reuse it.
+#[cfg_attr(not(any(feature = "gpu", test)), allow(dead_code))]
 #[cfg(debug_assertions)]
 pub(crate) fn holds_lock(rank: LockRank) -> bool {
     LOCK_RANK_STACK.with(|stack| stack.borrow().contains(&rank))
@@ -148,6 +155,7 @@ pub(crate) fn holds_lock(rank: LockRank) -> bool {
 
 /// Release build stub — never panics, but callers should only invoke this
 /// behind `debug_assert!` so the call is compiled out entirely.
+#[cfg_attr(not(any(feature = "gpu", test)), allow(dead_code))]
 #[cfg(not(debug_assertions))]
 #[inline]
 pub(crate) fn holds_lock(_rank: LockRank) -> bool {

--- a/crates/velesdb-core/src/index/hnsw/native/graph/locking.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/graph/locking.rs
@@ -4,8 +4,15 @@
 //! checking to prevent deadlocks. The rank system encodes the rule:
 //!
 //! ```text
-//! vectors (rank 10) → columnar (rank 15) → layers (rank 20) → neighbors (rank 30)
+//! gpu_vectors_snapshot (rank 5) → vectors (rank 10) → columnar (rank 15)
+//!     → layers (rank 20) → neighbors (rank 30)
 //! ```
+//!
+//! The `gpu_vectors_snapshot` mutex is acquired before `vectors` in the
+//! GPU path (`get_or_refresh_vector_snapshot` takes the mutex first, then
+//! calls `with_vectors_read` which takes `vectors`). Writers release
+//! `vectors` before reacquiring `gpu_vectors_snapshot` to invalidate, so
+//! both call sites observe the same order.
 //!
 //! Acquiring a lock with lower-or-equal rank than the highest currently
 //! held rank is a violation that gets recorded in safety counters.
@@ -22,13 +29,23 @@ use super::safety_counters::HNSW_COUNTERS;
 
 /// Lock rank values — monotonically increasing acquisition order.
 ///
-/// The global lock order is: vectors → columnar → layers → neighbors.
+/// The global lock order is:
+/// `gpu_vectors_snapshot → vectors → columnar → layers → neighbors`.
 /// Any code path that acquires multiple locks must acquire them
 /// in strictly increasing rank order.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(u8)]
 pub(crate) enum LockRank {
-    /// `vectors` RwLock — rank 10 (acquired first)
+    /// `gpu_vectors_snapshot` Mutex — rank 5 (acquired before `Vectors`).
+    ///
+    /// Caches the flat vector buffer for GPU upload. The snapshot refresh
+    /// path acquires this mutex, then calls `with_vectors_read` which takes
+    /// `Vectors`, so the rank must be strictly lower than `Vectors`.
+    // Only exercised when the `gpu` feature is active; stays in the enum so
+    // lock-ordering logic is the same across feature configurations.
+    #[cfg_attr(not(feature = "gpu"), allow(dead_code))]
+    GpuVectorsSnapshot = 5,
+    /// `vectors` RwLock — rank 10 (acquired first among the core HNSW locks)
     Vectors = 10,
     /// `columnar` RwLock — rank 15 (PDX block-columnar layout)
     #[allow(dead_code)] // Reason: PDX columnar lock rank — used when PDX search is wired
@@ -113,4 +130,71 @@ pub(crate) fn record_lock_release(rank: LockRank) {
 #[cfg(all(test, debug_assertions))]
 pub(crate) fn lock_depth() -> usize {
     LOCK_RANK_STACK.with(|stack| stack.borrow().len())
+}
+
+/// Returns `true` if the current thread is currently holding a lock at `rank`.
+///
+/// Debug-builds only: callers guarded by `debug_assert!` will compile to
+/// nothing in release builds. Use this to encode caller contracts for
+/// cache rebuild helpers that must run under a parent lock — e.g. a
+/// GPU CSR rebuild is only race-free while the layers read lock is held.
+///
+/// Returns `false` in release builds (the thread-local stack is not
+/// maintained there, so any runtime assertion is a no-op).
+#[cfg(debug_assertions)]
+pub(crate) fn holds_lock(rank: LockRank) -> bool {
+    LOCK_RANK_STACK.with(|stack| stack.borrow().contains(&rank))
+}
+
+/// Release build stub — never panics, but callers should only invoke this
+/// behind `debug_assert!` so the call is compiled out entirely.
+#[cfg(not(debug_assertions))]
+#[inline]
+pub(crate) fn holds_lock(_rank: LockRank) -> bool {
+    true
+}
+
+#[cfg(all(test, debug_assertions))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn holds_lock_reports_currently_held_rank() {
+        // Empty stack — nothing held.
+        assert!(!holds_lock(LockRank::Layers));
+        assert!(!holds_lock(LockRank::Vectors));
+
+        record_lock_acquire(LockRank::Layers);
+        assert!(holds_lock(LockRank::Layers));
+        assert!(!holds_lock(LockRank::Vectors));
+
+        record_lock_release(LockRank::Layers);
+        assert!(!holds_lock(LockRank::Layers));
+    }
+
+    #[test]
+    fn gpu_vectors_snapshot_rank_sorts_before_vectors() {
+        // Monotone rank check — the core invariant of the enum.
+        assert!(LockRank::GpuVectorsSnapshot < LockRank::Vectors);
+        assert!(LockRank::Vectors < LockRank::Columnar);
+        assert!(LockRank::Columnar < LockRank::Layers);
+        assert!(LockRank::Layers < LockRank::Neighbors);
+    }
+
+    #[test]
+    fn nested_acquire_in_declared_order_reports_both_held() {
+        // Simulate `get_or_refresh_vector_snapshot`: snapshot then vectors.
+        record_lock_acquire(LockRank::GpuVectorsSnapshot);
+        record_lock_acquire(LockRank::Vectors);
+
+        assert!(holds_lock(LockRank::GpuVectorsSnapshot));
+        assert!(holds_lock(LockRank::Vectors));
+
+        record_lock_release(LockRank::Vectors);
+        record_lock_release(LockRank::GpuVectorsSnapshot);
+
+        // Stack back to empty.
+        assert!(!holds_lock(LockRank::GpuVectorsSnapshot));
+        assert!(!holds_lock(LockRank::Vectors));
+    }
 }

--- a/crates/velesdb-core/src/index/hnsw/native/mod.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/mod.rs
@@ -54,6 +54,20 @@ pub use backend_adapter::{NativeHnswBackend, NativeNeighbour};
 pub use distance::{CachedSimdDistance, CpuDistance, DistanceEngine};
 pub use dual_precision::{DualPrecisionConfig, DualPrecisionHnsw};
 pub use graph::{NativeHnsw, DEFAULT_ALPHA, NO_ENTRY_POINT};
+// Re-exported so sibling modules (notably `crate::gpu::gpu_csr` and its
+// tests) can document and assert the caller contract of rebuilders that
+// depend on a held layers lock, without widening `mod graph` itself to
+// `pub(crate)`.
+#[cfg(feature = "gpu")]
+pub(crate) use graph::locking::{holds_lock as hnsw_holds_lock, LockRank as HnswLockRank};
+// Test-only re-exports: only `gpu_csr` tests need to synthesise a held
+// layers rank. Production code inside `native/` acquires ranks through
+// the `with_*` helpers, never via these symbols directly.
+#[cfg(all(test, feature = "gpu"))]
+pub(crate) use graph::locking::{
+    record_lock_acquire as hnsw_record_lock_acquire,
+    record_lock_release as hnsw_record_lock_release,
+};
 pub use layer::{Layer, NodeId};
 pub use quantization::{QuantizedVector, QuantizedVectorStore, ScalarQuantizer};
 pub use rabitq_precision::{RaBitQPrecisionConfig, RaBitQPrecisionHnsw};


### PR DESCRIPTION
## Summary

Addresses the first two 🚩 ANALYSIS findings from Devin on [PR #626](https://github.com/cyberlife-coder/VelesDB/pull/626), tracked in [issue #634 as PR-A](https://github.com/cyberlife-coder/VelesDB/issues/634).

No behaviour change in production — pure invariant instrumentation + doc contract tightening.

Closes #634 for PR-A.

## What's inside

### Finding 1 — `gpu_vectors_snapshot` lock ordering was implicit

Devin:
> Lock ordering between gpu_vectors_snapshot and vectors is safe but fragile ... the ordering is implicit — there's no LockRank entry for gpu_vectors_snapshot in the locking framework.

Fix:
- Add `LockRank::GpuVectorsSnapshot = 5` (strictly lower than `Vectors = 10`).
- Instrument the three acquisition sites with `record_lock_acquire` / `record_lock_release`:
  - `gpu_search.rs::get_or_refresh_vector_snapshot`
  - `insert.rs` (post-vectors-write invalidation)
  - `backend_adapter.rs::parallel_insert` (same invalidation)
- Debug builds now catch ordering violations via the existing thread-local stack; release builds keep the F-25 zero-overhead path.
- Module-level doc in `locking.rs` updated to show the new rank in the ordering diagram.

### Finding E — `CsrCache::get_or_rebuild` "CAS on generation" was misleading

Devin:
> The doc comment at line 326 claims "CAS on generation" protects against this, but no CAS is used — it's a load-compare-store sequence with the cache write already committed. ... if `get_or_rebuild` were ever called WITHOUT holding the layers read lock, a thread could write a stale CSR after another thread writes a fresh one.

Fix:
- Rewrite the doc to describe the actual mechanism (check-then-write under `self.csr.write()` guarded by `gen_before`/`gen_after`).
- Document the caller contract explicitly: must hold `LockRank::Layers`.
- Add a `debug_assert!(holds_lock(Layers))` tripwire via a new crate-internal `holds_lock` helper in `locking.rs`.
- New `hnsw_holds_lock` / `HnswLockRank` re-exports through `native/mod.rs` keep `mod graph` private while letting `crate::gpu::gpu_csr` assert the contract.

### Tests

- `locking.rs`: 3 new unit tests cover `holds_lock` behaviour, rank monotonicity, nested acquire/release round-trips.
- `gpu_csr.rs::tests`: existing cache tests wrapped in a `with_layers_rank` helper that models the production caller contract (`with_layers_read → get_or_rebuild`).
- `gpu_csr_tests.rs`: same helper applied to the 4 concurrent/regression tests + new `#[should_panic(expected = "layers read lock")]` test guards the contract itself.

## Verification (CI-mirror, local)

| Check | Result |
|---|---|
| `cargo clippy --workspace --all-targets --features persistence,gpu,update-check --exclude velesdb-python -- -D warnings -D clippy::pedantic` | ✅ 0 errors |
| `cargo fmt --all --check` | ✅ |
| `cargo check -p velesdb-core --no-default-features` | ✅ |
| `cargo test -p velesdb-core --features gpu --lib gpu::` | ✅ 79 pass, 0 fail |
| `cargo test -p velesdb-core --features persistence,gpu --test recall_validation` | ✅ 7 pass, 1 ignored (manual) |

## Out of scope for this PR

Tracked in #634:
- PR-B (version counter unifying snapshot + CSR invalidation) — next up
- PR-C (bench concurrent-insert stall, then optional non-blocking refresh)
- PR-D (wire `search_auto` into production pipeline) — running in parallel right now
- PR-E (parallel `select_topk` after bench)

Issue #634 is updated with the full plan.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/637" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
