### PR TITLE
fix(gpu): unified version counter for snapshot + CSR cache invalidation

### DIFF
--- a/crates/velesdb-core/src/index/hnsw/native/backend_adapter.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/backend_adapter.rs
@@ -156,19 +156,12 @@ impl<D: DistanceEngine + Send + Sync> NativeHnsw<D> {
         // Invalidate GPU caches — topology and vectors both changed.
         // Single `insert()` does this per-call; batch path must do it once
         // after all nodes are connected to avoid stale CSR/vector snapshots.
-        //
         // `finalize_batch` has already released every `Vectors` write lock
-        // taken during the insert loop, so the `gpu_vectors_snapshot`
-        // acquisition below is a flat acquire (rank 5) with nothing on the
-        // lock stack — consistent with the declared global order.
+        // taken during the insert loop, so the helper's mutex acquisition
+        // is a flat acquire (rank 5) with nothing on the lock stack —
+        // consistent with the declared global order.
         #[cfg(feature = "gpu")]
-        {
-            use super::graph::locking::{record_lock_acquire, record_lock_release, LockRank};
-            self.gpu_csr_cache.invalidate();
-            record_lock_acquire(LockRank::GpuVectorsSnapshot);
-            *self.gpu_vectors_snapshot.lock() = None;
-            record_lock_release(LockRank::GpuVectorsSnapshot);
-        }
+        self.invalidate_gpu_caches();
 
         // Return the graph-assigned node IDs in input order
         let assigned_ids: Vec<usize> = assignments.iter().map(|(node_id, _)| *node_id).collect();

--- a/crates/velesdb-core/src/index/hnsw/native/graph/gpu_search.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/graph/gpu_search.rs
@@ -84,10 +84,13 @@ impl<D: DistanceEngine> NativeHnsw<D> {
         // Phase 3: Get flat vectors for GPU upload via cached snapshot.
         //
         // The snapshot is an `Arc<[f32]>` cached on the NativeHnsw instance.
-        // Only refreshed when the vector count changes (insert/delete).
+        // Only refreshed when `gpu_snapshot_version` moves past the recorded
+        // build version — any mutation (insert/parallel_insert, future
+        // delete) bumps that counter via `invalidate_gpu_caches`, so the
+        // cache self-invalidates without depending on `count` alone.
         // Subsequent queries clone the Arc (O(1) pointer bump) instead of
         // copying ~1.5GB of vector data per query.
-        let (dimension, vectors_arc) = self.get_or_refresh_vector_snapshot(count);
+        let (dimension, vectors_arc) = self.get_or_refresh_vector_snapshot();
 
         if dimension == 0 || vectors_arc.is_empty() {
             return None;
@@ -165,9 +168,22 @@ impl<D: DistanceEngine> NativeHnsw<D> {
         }
     }
 
-    /// Returns cached vector snapshot or refreshes it if the count changed.
+    /// Returns cached vector snapshot or refreshes it if the index version
+    /// moved past the recorded build version.
     ///
     /// Returns `(dimension, Arc<[f32]>)`. The Arc clone is O(1) on cache hit.
+    ///
+    /// # Cache validity
+    ///
+    /// The cache is valid iff the stored `version_at_build` equals
+    /// `gpu_snapshot_version` at read time. Every mutation (insert /
+    /// parallel_insert, future delete) goes through
+    /// [`NativeHnsw::invalidate_gpu_caches`] which bumps the version,
+    /// so the cache self-invalidates without relying on callers to
+    /// remember to clear the snapshot mutex. A delete-then-insert that
+    /// returns to the same count still bumps the version twice and is
+    /// therefore detected as stale — the previous count-keyed design
+    /// would have served the deleted vector.
     ///
     /// # Lock order
     ///
@@ -176,18 +192,20 @@ impl<D: DistanceEngine> NativeHnsw<D> {
     /// Instrumented with `record_lock_acquire/release` so the runtime
     /// lock-rank tracker (debug builds) catches any future caller that
     /// inverts the order.
-    fn get_or_refresh_vector_snapshot(
-        &self,
-        current_count: usize,
-    ) -> (usize, std::sync::Arc<[f32]>) {
+    fn get_or_refresh_vector_snapshot(&self) -> (usize, std::sync::Arc<[f32]>) {
         use super::locking::{record_lock_acquire, record_lock_release, LockRank};
+
+        // Acquire pairs with the Release fetch_add in
+        // `invalidate_gpu_caches` so this read observes every prior
+        // mutation.
+        let current_version = self.gpu_snapshot_version.load(Ordering::Acquire);
 
         record_lock_acquire(LockRank::GpuVectorsSnapshot);
         let mut snapshot = self.gpu_vectors_snapshot.lock();
 
-        // Check if cached snapshot is still valid
-        if let Some((cached_count, cached_dim, ref cached_vecs)) = *snapshot {
-            if cached_count == current_count {
+        // Check if cached snapshot is still valid against the version.
+        if let Some((cached_version, cached_dim, ref cached_vecs)) = *snapshot {
+            if cached_version == current_version {
                 let hit = (cached_dim, cached_vecs.clone());
                 drop(snapshot);
                 record_lock_release(LockRank::GpuVectorsSnapshot);
@@ -203,7 +221,7 @@ impl<D: DistanceEngine> NativeHnsw<D> {
             let arc: std::sync::Arc<[f32]> = vectors.as_flat_slice().to_vec().into();
             (d, arc)
         });
-        *snapshot = Some((current_count, dim, arc.clone()));
+        *snapshot = Some((current_version, dim, arc.clone()));
         drop(snapshot);
         record_lock_release(LockRank::GpuVectorsSnapshot);
         (dim, arc)

--- a/crates/velesdb-core/src/index/hnsw/native/graph/insert.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/graph/insert.rs
@@ -107,20 +107,14 @@ impl<D: DistanceEngine> NativeHnsw<D> {
         self.count.fetch_add(1, Ordering::Relaxed);
 
         // Invalidate GPU caches — topology and vectors both changed.
-        //
         // `vectors.write()` is already released at this point (the caller
         // chain `allocate_and_store_vector → with_vectors_write` drops it
         // before returning), so the `gpu_vectors_snapshot` acquisition
-        // below does not nest inside the vectors lock and respects the
-        // declared order (`GpuVectorsSnapshot` rank 5 → `Vectors` rank 10).
+        // inside the helper does not nest inside the vectors lock and
+        // respects the declared order
+        // (`GpuVectorsSnapshot` rank 5 → `Vectors` rank 10).
         #[cfg(feature = "gpu")]
-        {
-            use super::locking::{record_lock_acquire, record_lock_release, LockRank};
-            self.gpu_csr_cache.invalidate();
-            record_lock_acquire(LockRank::GpuVectorsSnapshot);
-            *self.gpu_vectors_snapshot.lock() = None;
-            record_lock_release(LockRank::GpuVectorsSnapshot);
-        }
+        self.invalidate_gpu_caches();
 
         Ok(node_id)
     }

--- a/crates/velesdb-core/src/index/hnsw/native/graph/mod.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/graph/mod.rs
@@ -108,25 +108,35 @@ pub struct NativeHnsw<D: DistanceEngine> {
     ///
     /// Each `NativeHnsw` instance owns its own cache, preventing cross-collection
     /// contamination when multiple indices exist in the same process.
-    /// Invalidated automatically on insert/delete via `CsrCache::invalidate()`.
+    /// Invalidated automatically on insert/delete via [`Self::invalidate_gpu_caches`].
     #[cfg(feature = "gpu")]
     pub(in crate::index::hnsw::native) gpu_csr_cache: crate::gpu::gpu_csr::CsrCache,
     /// Cached flat vector snapshot for GPU upload.
     ///
-    /// Stores `(count_at_snapshot, dimension, Arc<[f32]>)`. Only refreshed
-    /// when the vector count changes, eliminating the ~1.5GB per-query copy
-    /// at the 500K+ GPU activation threshold.
+    /// Stores `(version_at_snapshot, dimension, Arc<[f32]>)`. Validity is
+    /// checked against [`Self::gpu_snapshot_version`] rather than `count`
+    /// alone so that a hypothetical future delete+insert that returns to
+    /// the same count cannot silently serve stale vectors.
     #[cfg(feature = "gpu")]
     pub(in crate::index::hnsw::native) gpu_vectors_snapshot:
         parking_lot::Mutex<Option<GpuVectorsSnapshot>>,
+    /// Monotonic version counter bumped on every vectors / topology
+    /// mutation. Anchors GPU cache validity (snapshot + CSR) to a single
+    /// observable value — the snapshot compares its recorded version
+    /// against this counter on read, so the cache remains invalid after
+    /// any mutation even if a future code path forgets to explicitly
+    /// clear the snapshot mutex (belt-and-suspenders).
+    #[cfg(feature = "gpu")]
+    pub(in crate::index::hnsw::native) gpu_snapshot_version: AtomicU64,
 }
 
-/// Cached GPU vector snapshot: `(count, dimension, flat_vectors)`.
+/// Cached GPU vector snapshot: `(version, dimension, flat_vectors)`.
 ///
-/// Only refreshed when the vector count changes. Subsequent queries
-/// clone the `Arc` (O(1) pointer bump) instead of copying ~1.5GB.
+/// Only refreshed when [`NativeHnsw::gpu_snapshot_version`] moves past
+/// the value captured at build time. Subsequent queries clone the `Arc`
+/// (O(1) pointer bump) instead of copying ~1.5GB.
 #[cfg(feature = "gpu")]
-pub(in crate::index::hnsw::native) type GpuVectorsSnapshot = (usize, usize, std::sync::Arc<[f32]>);
+pub(in crate::index::hnsw::native) type GpuVectorsSnapshot = (u64, usize, std::sync::Arc<[f32]>);
 
 impl<D: DistanceEngine> NativeHnsw<D> {
     /// Creates a new native HNSW index with VAMANA diversification (`alpha = 1.2`).
@@ -257,6 +267,12 @@ impl<D: DistanceEngine> NativeHnsw<D> {
             gpu_csr_cache: crate::gpu::gpu_csr::CsrCache::new(),
             #[cfg(feature = "gpu")]
             gpu_vectors_snapshot: parking_lot::Mutex::new(None),
+            // Starts at 0. Snapshots built before any mutation store
+            // `0` as `version_at_build`; a fresh index therefore hits
+            // the cache on its first read, and any mutation bumps this
+            // counter to invalidate all subsequent reads.
+            #[cfg(feature = "gpu")]
+            gpu_snapshot_version: AtomicU64::new(0),
         }
     }
 
@@ -276,6 +292,34 @@ impl<D: DistanceEngine> NativeHnsw<D> {
     #[must_use]
     pub fn is_empty(&self) -> bool {
         self.len() == 0
+    }
+
+    /// Invalidates both GPU caches (CSR topology + vectors snapshot) as a
+    /// single atomic step.
+    ///
+    /// Call this **after every mutation** that changes the set of active
+    /// nodes or their vector data — currently insert and parallel insert;
+    /// a future delete path must call this too.
+    ///
+    /// Bumps [`Self::gpu_snapshot_version`] first (Release), then
+    /// invalidates the CSR cache, then clears the snapshot mutex. The
+    /// version bump is the canonical invalidation signal: even if a
+    /// hypothetical caller forgot the explicit `None`-clear, the next
+    /// snapshot read would still observe `stored_version !=
+    /// current_version` and rebuild from the fresh vectors. The explicit
+    /// clear is kept as belt-and-suspenders (frees the `Arc` promptly so
+    /// the old buffer can drop).
+    #[cfg(feature = "gpu")]
+    pub(in crate::index::hnsw::native) fn invalidate_gpu_caches(&self) {
+        use self::locking::{record_lock_acquire, record_lock_release, LockRank};
+        // Release ordering: any thread that subsequently loads the
+        // version with Acquire will observe every mutation that
+        // happened-before this fetch_add.
+        self.gpu_snapshot_version.fetch_add(1, Ordering::Release);
+        self.gpu_csr_cache.invalidate();
+        record_lock_acquire(LockRank::GpuVectorsSnapshot);
+        *self.gpu_vectors_snapshot.lock() = None;
+        record_lock_release(LockRank::GpuVectorsSnapshot);
     }
 
     /// Computes the raw distance between two vectors using this index's distance engine.

--- a/crates/velesdb-core/src/index/hnsw/native/graph/reorder.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/graph/reorder.rs
@@ -48,7 +48,21 @@ impl<D: DistanceEngine> NativeHnsw<D> {
             return Ok(());
         }
 
-        self.apply_permutation(&permutation)
+        self.apply_permutation(&permutation)?;
+
+        // Reordering rewrites both the vector buffer AND every neighbour
+        // list, so any cached CSR / flat-vector snapshot built from the
+        // pre-reorder topology is now stale. The contract on
+        // `invalidate_gpu_caches` is "call after every mutation that
+        // changes the set of active nodes or their vector data" — an
+        // in-place permutation qualifies. This was a pre-existing gap
+        // (PR #626 never invalidated here either); folding the fix into
+        // PR-B of #634 since the whole point of the unified version
+        // counter is to close this class of bug.
+        #[cfg(feature = "gpu")]
+        self.invalidate_gpu_caches();
+
+        Ok(())
     }
 
     /// Computes BFS traversal order starting from the entry point on layer 0.

--- a/crates/velesdb-core/src/index/hnsw/native/graph_io.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/graph_io.rs
@@ -244,6 +244,11 @@ impl<D: DistanceEngine + Send + Sync> NativeHnsw<D> {
             gpu_csr_cache: crate::gpu::gpu_csr::CsrCache::new(),
             #[cfg(feature = "gpu")]
             gpu_vectors_snapshot: parking_lot::Mutex::new(None),
+            // Fresh-from-disk index: no mutations since load → version 0.
+            // The snapshot cache treats any stored version != 0 as stale,
+            // which is fine because no snapshot exists yet after load.
+            #[cfg(feature = "gpu")]
+            gpu_snapshot_version: std::sync::atomic::AtomicU64::new(0),
         })
     }
 

--- a/crates/velesdb-core/src/index/hnsw/native/graph_tests.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/graph_tests.rs
@@ -499,6 +499,53 @@ fn test_gpu_snapshot_version_bumps_on_every_mutation() {
     assert!(v2 > v1, "parallel insert path must also bump the version");
 }
 
+/// `reorder_for_locality` rewrites both the vector buffer AND every
+/// neighbour list in place. Devin flagged on PR-B that the pre-existing
+/// reorder path never invalidated GPU caches, so any snapshot / CSR
+/// built from the pre-reorder topology would silently be served after
+/// reorder. This test locks in the contract: the snapshot version must
+/// bump once per reorder pass that actually runs (above the threshold).
+#[cfg(feature = "gpu")]
+#[test]
+fn test_reorder_for_locality_bumps_snapshot_version() {
+    use std::sync::atomic::Ordering;
+
+    // The reorder threshold is 1000 in reorder.rs; we need enough vectors
+    // for the code path to actually execute the permutation.
+    const N: usize = 1024;
+    const DIM: usize = 8;
+
+    let engine = CachedSimdDistance::new(DistanceMetric::Cosine, DIM);
+    let hnsw = NativeHnsw::new_with_dimension_and_alpha(engine, 16, 100, 2048, DIM, 1.2)
+        .expect("test: index creation");
+
+    let vectors: Vec<Vec<f32>> = (0..N)
+        .map(|i| (0..DIM).map(|j| (i * DIM + j) as f32 / 1000.0).collect())
+        .collect();
+    let refs: Vec<(&[f32], usize)> = vectors
+        .iter()
+        .enumerate()
+        .map(|(i, v)| (&v[..], i))
+        .collect();
+    hnsw.parallel_insert(&refs)
+        .expect("test: bulk insert for reorder");
+    let before = hnsw.gpu_snapshot_version.load(Ordering::Acquire);
+
+    hnsw.reorder_for_locality().expect("test: reorder succeeds");
+    let after = hnsw.gpu_snapshot_version.load(Ordering::Acquire);
+
+    assert!(
+        after > before,
+        "reorder_for_locality must bump the snapshot version \
+         (before={before}, after={after})"
+    );
+    // Snapshot mutex must be cleared too (belt-and-suspenders).
+    assert!(
+        hnsw.gpu_vectors_snapshot.lock().is_none(),
+        "reorder_for_locality must clear the snapshot mutex"
+    );
+}
+
 /// Regression for the snapshot-cache-keyed-on-count bug: a hypothetical
 /// delete-then-insert that returns to the same count must still
 /// invalidate the cache. With the version counter introduced by PR-B

--- a/crates/velesdb-core/src/index/hnsw/native/graph_tests.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/graph_tests.rs
@@ -462,3 +462,91 @@ fn test_no_mutex_field_exists() {
     let results = hnsw.search(&query, 10, 50);
     assert!(!results.is_empty(), "test: search must return results");
 }
+
+// ============================================================================
+// GPU snapshot invalidation version counter (PR-B of #634)
+// ============================================================================
+
+/// The snapshot version must bump once per insert (single and parallel
+/// paths alike) so GPU caches re-read fresh vectors after every mutation.
+#[cfg(feature = "gpu")]
+#[test]
+fn test_gpu_snapshot_version_bumps_on_every_mutation() {
+    use std::sync::atomic::Ordering;
+
+    let engine = CachedSimdDistance::new(DistanceMetric::Cosine, 8);
+    let hnsw = NativeHnsw::new_with_dimension_and_alpha(engine, 16, 100, 1000, 8, 1.2)
+        .expect("test: index creation should succeed");
+
+    let v0 = hnsw.gpu_snapshot_version.load(Ordering::Acquire);
+    assert_eq!(v0, 0, "fresh index starts at version 0");
+
+    let vec_a: Vec<f32> = (0..8).map(|i| i as f32 / 10.0).collect();
+    hnsw.insert(&vec_a).expect("test: insert succeeds");
+    let v1 = hnsw.gpu_snapshot_version.load(Ordering::Acquire);
+    assert!(v1 > v0, "single insert must bump the snapshot version");
+
+    // Parallel insert path (big enough batch to actually go parallel —
+    // `parallel_insert` falls back to sequential under 100 entries).
+    let batch: Vec<Vec<f32>> = (0..120)
+        .map(|seed| (0..8).map(|j| (seed + j) as f32 / 100.0).collect())
+        .collect();
+    let batch_refs: Vec<(&[f32], usize)> =
+        batch.iter().enumerate().map(|(i, v)| (&v[..], i)).collect();
+    hnsw.parallel_insert(&batch_refs)
+        .expect("test: parallel_insert succeeds");
+    let v2 = hnsw.gpu_snapshot_version.load(Ordering::Acquire);
+    assert!(v2 > v1, "parallel insert path must also bump the version");
+}
+
+/// Regression for the snapshot-cache-keyed-on-count bug: a hypothetical
+/// delete-then-insert that returns to the same count must still
+/// invalidate the cache. With the version counter introduced by PR-B
+/// (issue #634), any call to `invalidate_gpu_caches` bumps the version —
+/// so a future delete path that forgets the explicit `None`-clear is
+/// still safe.
+///
+/// We simulate the worst-case "future delete forgets to clear" by
+/// manually populating the snapshot with a stale entry keyed at the
+/// **current** version (mimicking a snapshot installed just before
+/// a delete), then calling `invalidate_gpu_caches` and checking that
+/// the next read observes staleness via the version.
+#[cfg(feature = "gpu")]
+#[test]
+fn test_snapshot_version_detects_staleness_without_explicit_clear() {
+    use std::sync::atomic::Ordering;
+
+    let engine = CachedSimdDistance::new(DistanceMetric::Cosine, 4);
+    let hnsw = NativeHnsw::new_with_dimension_and_alpha(engine, 16, 100, 1000, 4, 1.2)
+        .expect("test: index creation should succeed");
+
+    // Drive the index past its fresh state so there is a real snapshot
+    // to populate.
+    let v: Vec<f32> = vec![0.1, 0.2, 0.3, 0.4];
+    hnsw.insert(&v).expect("test: insert succeeds");
+
+    // Install a fake "stale" snapshot keyed at the current version.
+    let current_version = hnsw.gpu_snapshot_version.load(Ordering::Acquire);
+    let fake_arc: std::sync::Arc<[f32]> = vec![9.9_f32; 4].into();
+    *hnsw.gpu_vectors_snapshot.lock() = Some((current_version, 4, fake_arc.clone()));
+
+    // Invalidate via the helper but DO NOT touch the snapshot mutex
+    // manually — this mirrors a future delete path that forgets the
+    // explicit `None`-clear. The version bump inside the helper must be
+    // enough to detect staleness on the next read.
+    hnsw.invalidate_gpu_caches();
+
+    let post_version = hnsw.gpu_snapshot_version.load(Ordering::Acquire);
+    assert!(
+        post_version > current_version,
+        "invalidate_gpu_caches must bump the version"
+    );
+
+    // Belt-and-suspenders: the helper also clears the mutex. Verify both
+    // safety nets are in place — either one alone is sufficient for
+    // correctness, but both together fail-close.
+    assert!(
+        hnsw.gpu_vectors_snapshot.lock().is_none(),
+        "invalidate_gpu_caches must also clear the snapshot mutex (belt-and-suspenders)"
+    );
+}


### PR DESCRIPTION
## Summary

Addresses the last ANALYSIS finding from Devin on [PR #626](https://github.com/cyberlife-coder/VelesDB/pull/626), tracked in [issue #634 as PR-B](https://github.com/cyberlife-coder/VelesDB/issues/634).

Replaces the count-keyed snapshot cache with a monotonic version counter that any mutation bumps atomically. Prevents the delete-then-insert-back-to-same-count regression class.

Closes #634 for PR-B.

## Problem (from Devin)

> Vector snapshot cache keyed only on count may serve stale data after delete+insert. The GPU vector snapshot at gpu_search.rs:177-179 checks `cached_count == current_count` to decide if the cache is valid. If a vector is deleted and then a new one is inserted (count returns to the same value), the snapshot would serve stale data containing the deleted vector.

Today the `insert` path explicitly clears the snapshot mutex (belt-and-suspenders), so no stale-serve actually happens. But the safety **depends on every mutator remembering the clear ritual** — a hidden contract that a future delete path could easily break.

## Fix

- `NativeHnsw::gpu_snapshot_version: AtomicU64` — monotonic, starts at 0, initialised in both `new_with_options` and the `file_load` path.
- `GpuVectorsSnapshot` tuple: `(count, dim, Arc<[f32]>)` → `(version, dim, Arc<[f32]>)`.
- Consolidated the two scattered invalidation blocks (`insert.rs`, `backend_adapter.rs`) into a single `NativeHnsw::invalidate_gpu_caches` helper. It does three things in the declared lock order:
  1. `gpu_snapshot_version.fetch_add(1, Release)` — canonical signal.
  2. `gpu_csr_cache.invalidate()` — topology cache.
  3. clear `gpu_vectors_snapshot` mutex (belt-and-suspenders; frees the `Arc` promptly).
- `get_or_refresh_vector_snapshot` now loads the version with Acquire and compares it to the snapshot's recorded `version_at_build`. Any mutation → version mismatch → refresh.

## Belt-and-suspenders

The explicit `None`-clear stays in the helper. Either mechanism alone is sufficient for correctness, both together fail-close. A future mutator that forgets to call `invalidate_gpu_caches` and also forgets to clear the mutex would be the only way to serve stale data — and at that point the caller is manifestly ignoring the documented contract.

## Tests

- **`test_gpu_snapshot_version_bumps_on_every_mutation`** — single AND parallel insert paths both bump the counter. Parallel insert uses 120 elements to exceed the `< 100` sequential fallback.
- **`test_snapshot_version_detects_staleness_without_explicit_clear`** — simulates a future mutator that forgets the mutex clear: manually populates the snapshot, calls `invalidate_gpu_caches`, verifies the version bump alone detects staleness AND the mutex is cleared by the helper.

## Verification (CI-mirror, local)

| Check | Result |
|---|---|
| `cargo clippy --workspace --all-targets --features persistence,gpu,update-check --exclude velesdb-python -- -D warnings -D clippy::pedantic` | ✅ 0 errors |
| `cargo fmt --all --check` | ✅ |
| `cargo check -p velesdb-core --no-default-features` | ✅ |
| `cargo test -p velesdb-core --features gpu --lib index::hnsw::` | ✅ 538 pass, 0 fail |
| `cargo test -p velesdb-core --features persistence,gpu --test recall_validation` | ✅ 7 pass, 1 ignored |

## Out of scope for this PR (tracked in #634)

- PR-C (bench concurrent-insert + snapshot-stall; optional non-blocking refresh after measurement)
- PR-E (parallel `select_topk` after bench justifies it)
- Issue #639 (align `NativeHnswIndex::search_with_quality` on `ef_search_for_scale`)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/640" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
