### PR TITLE
fix(gpu): remove redundant count-check in CSR cache path (closes #634 PR-F)

### DIFF
--- a/crates/velesdb-core/src/index/hnsw/native/graph/gpu_search.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/graph/gpu_search.rs
@@ -66,17 +66,30 @@ impl<D: DistanceEngine> NativeHnsw<D> {
         //
         // Uses the per-instance `gpu_csr_cache` field — each NativeHnsw
         // owns its own cache, preventing cross-collection contamination.
-        // The CsrCache only rebuilds when invalidated (insert/delete) or
-        // when the node count changes.
+        //
+        // **Validity signal** — relies solely on the CsrCache dirty flag
+        // (`get_if_clean`), which is aligned with `gpu_snapshot_version`:
+        // every mutation that bumps `gpu_snapshot_version` also invalidates
+        // the CSR cache through `NativeHnsw::invalidate_gpu_caches`, so
+        // "cache clean" ⇔ "snapshot version unchanged" ⇔ "topology
+        // unchanged since last build".
+        //
+        // The historical secondary check `existing.num_nodes == count`
+        // (kept on develop until PR-F of #634) was a redundant race
+        // guard: it covered the tiny window where `count.fetch_add`
+        // completes before `invalidate_gpu_caches` runs on the same
+        // mutator thread. Removed as part of the version-counter
+        // consolidation — the remaining worst case is that one search
+        // serves a CSR with N-1 nodes against an index that just
+        // reached N: the newly-inserted node is missed by that single
+        // query (same behaviour any delete+insert race has always had)
+        // and the next search picks up the fresh rebuild.
         let csr = self.with_layers_read(|layers| {
             if layers.is_empty() {
                 return None;
             }
             if let Some(existing) = self.gpu_csr_cache.get_if_clean() {
-                if existing.num_nodes as usize == count {
-                    return Some(existing);
-                }
-                self.gpu_csr_cache.invalidate();
+                return Some(existing);
             }
             Some(self.gpu_csr_cache.get_or_rebuild(&layers[0], count))
         })?;


### PR DESCRIPTION
## Summary

Closes the last technical item in [#634](https://github.com/cyberlife-coder/VelesDB/issues/634) (PR-F). Addresses Devin 🚩 on [PR #640](https://github.com/cyberlife-coder/VelesDB/pull/640) about the intentional asymmetry between the version-counter-based snapshot cache and the count-based CSR cache secondary check.

Single-file, doc-heavy change — the diff is mostly comment that explains the correctness argument.

## Problem

Before this PR, `search_gpu` did:

\`\`\`rust
if let Some(existing) = self.gpu_csr_cache.get_if_clean() {
    if existing.num_nodes as usize == count {
        return Some(existing);
    }
    self.gpu_csr_cache.invalidate();
}
\`\`\`

- Primary signal: the CSR cache dirty flag via `get_if_clean()`.
- Secondary: a count-based check layered on top.

After PR-B in #640 unified the snapshot cache on `gpu_snapshot_version` (bumped atomically with the CSR dirty flag inside `NativeHnsw::invalidate_gpu_caches`), the count check became redundant defense and a code smell Devin kept pattern-matching against the old count-keyed-cache bug.

## Fix

Remove the count check. Rely on the dirty flag alone, which is in 1:1 correspondence with the version counter since every mutation bumps both through the helper.

## Race window analysis

The count check used to cover the tiny window between `count.fetch_add` and `invalidate_gpu_caches` on the same mutator thread. With the check removed:

- Worst case: one search serves a CSR with N-1 nodes against an index that just reached N. The newly-inserted node is missed by that one query.
- Subsequent searches observe the rebuilt CSR after `invalidate_gpu_caches` runs.
- Exactly the same observable behaviour concurrent insert+search already has on every other code path — new nodes become visible to search "eventually", never instantly.

Documented in the updated doc comment on the Phase 2 block.

## Net effect

- Symmetric design — both caches now key on the same signal.
- One fewer atomic load (`count`) per cache-hit search (micro-optimisation).
- Removes the code-smell Devin keeps flagging without changing correctness under concurrent load.

## Verification (CI-mirror, local)

| Check | Result |
|---|---|
| `cargo clippy --workspace --all-targets --features persistence,gpu,update-check --exclude velesdb-python -- -D warnings -D clippy::pedantic` | ✅ 0 errors |
| `cargo fmt --all --check` | ✅ |
| `cargo test --features gpu --lib gpu::gpu_csr` | ✅ 26 pass |
| `cargo test --features persistence,gpu --test recall_validation` | ✅ 7 pass, 1 ignored |

## Out of scope

- PR-C / PR-E / #639 remain as follow-ups in #634.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/641" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
