### PR TITLE
ci(tests): free ~40GB on runner before linking — fix Bus error SIGBUS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,6 +171,24 @@ jobs:
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
+      # Free ~40 GB of disk space by dropping pre-installed tooling we do
+      # not use (Android SDK, .NET, Haskell/GHC, cached Docker images,
+      # heavy apt packages). Without this the full test matrix link phase
+      # runs out of space — `ld` dies with SIGBUS when it cannot mmap more
+      # pages. Observed on PR #633 (two consecutive runs, warning:
+      # "Free space left: 80 MB"). Keep `tool-cache: false` so rustup and
+      # the Rust toolchain restored by `Swatinem/rust-cache` stay put.
+      - name: Free disk space on runner
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: false
+
       - uses: dtolnay/rust-toolchain@stable # Intentionally unpinned - uses toolchain input
         with:
           toolchain: ${{ env.RUST_VERSION }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,13 +171,22 @@ jobs:
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
-      # Free ~40 GB of disk space by dropping pre-installed tooling we do
-      # not use (Android SDK, .NET, Haskell/GHC, cached Docker images,
-      # heavy apt packages). Without this the full test matrix link phase
-      # runs out of space — `ld` dies with SIGBUS when it cannot mmap more
-      # pages. Observed on PR #633 (two consecutive runs, warning:
-      # "Free space left: 80 MB"). Keep `tool-cache: false` so rustup and
-      # the Rust toolchain restored by `Swatinem/rust-cache` stay put.
+      # Free ~35 GB of disk space by dropping pre-installed tooling we do
+      # not use (Android SDK, .NET, Haskell/GHC, cached Docker images).
+      # Without this the full test matrix link phase runs out of space —
+      # `ld` dies with SIGBUS when it cannot mmap more pages. Observed on
+      # PR #633 (two consecutive runs, warning: "Free space left: 80 MB").
+      #
+      # Flag rationale:
+      # * `tool-cache: false` — keeps rustup + the toolchain restored by
+      #   `Swatinem/rust-cache`.
+      # * `large-packages: false` — intentionally OFF. The action's
+      #   `large-packages` flag runs `apt-get autoremove -y` which
+      #   cascade-removes `libgl1-mesa-dri` and its reverse-dependencies,
+      #   including `glib-2.0-dev` / `gtk-3-dev` that `glib-sys` / Tauri
+      #   transitive deps need. Pulling those back in via
+      #   `awalsh128/cache-apt-pkgs-action` below is unreliable once
+      #   autoremove has touched them, so we simply keep them installed.
       - name: Free disk space on runner
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
         with:
@@ -185,7 +194,7 @@ jobs:
           android: true
           dotnet: true
           haskell: true
-          large-packages: true
+          large-packages: false
           docker-images: true
           swap-storage: false
 


### PR DESCRIPTION
## Problem

The \`Tests\` job in \`.github/workflows/ci.yml\` has been dying on [PR #633](https://github.com/cyberlife-coder/VelesDB/pull/633) (openssl security bump) with:

\`\`\`
collect2: fatal error: ld terminated with signal 7 [Bus error], core dumped
##[warning]You are running out of disk space. Free space left: 80 MB
\`\`\`

Two consecutive re-runs of the same commit both hit the wall at different test binaries (\`scale_recall_100k\`, \`pq_adc_e2e_tests\`, \`stress_concurrency_tests\`). Zero code change between runs — the variance in which binary crashes is the tell: it's disk exhaustion during the link phase, not a test bug.

## Root cause

\`ubuntu-latest\` ships ~40 GB of pre-installed tooling we never use:
- Android SDK
- .NET SDK
- Haskell / GHC
- CodeQL
- Pre-pulled Docker images
- Heavy apt packages (\`dotnet-*\`, \`google-cloud-sdk\`, \`azure-cli\`, ...)

Combined with ~800 MB of rust-cache restore and an in-flight debug build of 200+ workspace crates + 20+ test binaries (each ~200–500 MB in debug with symbols), the workspace hits the ~14 GB free ceiling before \`ld\` can finish mmap-ing.

## Fix

Add \`jlumbroso/free-disk-space@v1.3.1\` step right after checkout on the \`Tests\` job. Drops the unused tooling categories in ~30 s, frees ~40 GB, well before the first \`cargo\` invocation.

\`tool-cache: false\` is **kept** — that is where \`rustup\` lives. The \`Swatinem/rust-cache\` restore that follows needs the Rust toolchain to already be on disk, so evicting \`tool-cache\` would undo itself.

## Why scoped to the \`Tests\` job

- The \`Tests\` job is the only one that crashed today.
- The Coverage / Quality Deep jobs run the same monster compile and will eventually want the same fix, but I kept this PR minimal so it is trivially reviewable.
- If either future job starts hitting the same error, the fix is a copy-paste of these 14 lines.

## Immediate unblock

Merging this PR unblocks [PR #633 (openssl 0.10.78 security bump)](https://github.com/cyberlife-coder/VelesDB/pull/633) and every future full-test CI run on this repo.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/644" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
