### PR TITLE
fix(v1.13.0): zero technical debt — AnyCollection idiomatic API + #[non_exhaustive] + CsrCache rename + invariant docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,38 @@ output must update.
   by
   `collection::search::query::distinct_tests::tests::test_distinct_mixed_with_qualified_wildcard_dedupes_by_full_payload`.
 
+### Changed — API hardening (v1.13.0 pre-release)
+
+Five HIGH findings from a triple Rust-expert review landed as zero-tech-debt
+fixes during the develop→main rebase window. Public API only; no runtime
+behaviour change.
+
+- **`AnyCollection` variant access redesign.** The previous
+  `as_vector_collection_unchecked(self) -> VectorCollection` (plus its
+  deprecated alias `into_vector_collection`) is replaced by a full std-style
+  matrix: `as_vector / as_vector_mut / into_vector(…) -> Result<…, Self>`
+  (plus `as_graph*`, `as_metadata*`, `into_graph`, `into_metadata`). The
+  unchecked cross-cast survives only as `unsafe fn into_vector_unchecked`
+  so the logical-soundness contract is explicit at every call site. The
+  velesdb-mobile and tauri-plugin-velesdb bindings migrated to the safe
+  `into_vector()` API; the Python SDK keeps `into_vector_unchecked` under
+  a documented `// SAFETY:` block. See
+  [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) — F2.2.
+
+- **`CsrCache::get_if_clean` renamed to `clean_snapshot`.** Aligns with
+  VelesDB's existing `Snapshot` terminology (`Bm25Snapshot`, `HnswSnapshot`,
+  `to_snapshot`, `from_snapshot`). Option semantics unchanged.
+
+- **`WindowFunctionType` marked `#[non_exhaustive]`.** Future window
+  functions (`LAG`, `LEAD`, `NTILE`, aggregate windows, …) can now be
+  added without a semver break. Downstream crates matching on the enum
+  must include a `_ =>` wildcard arm.
+
+- **`ConcurrentEdgeStore::rebuild_snapshot` locking contract documented.**
+  The `# Note` docstring now explicitly forbids callers from holding an
+  `edge_ids` write lock or any `shards[*]` write lock when invoking this
+  method, and cross-references `docs/CONCURRENCY_MODEL.md`.
+
 ### Added — GPU acceleration
 
 - **GPU HNSW layer-0 traversal** (`#626`, closes `#502`): SONG paper
@@ -199,7 +231,8 @@ stale caches.
 - **CSR cache count-check cleanup** (`#641`, PR-F). Removes the
   redundant `existing.num_nodes == count` secondary check in
   `search_gpu`. Every mutation bumps `gpu_snapshot_version` AND calls
-  `gpu_csr_cache.invalidate()` through the helper, so `get_if_clean`
+  `gpu_csr_cache.invalidate()` through the helper, so `clean_snapshot`
+  (renamed from `get_if_clean` in the v1.13.0 API-hardening pass)
   alone is the authoritative validity signal — "cache clean" ⇔
   "snapshot version unchanged" ⇔ "topology unchanged since last
   build". Removes the code-smell that kept pattern-matching against

--- a/crates/tauri-plugin-velesdb/src/helpers.rs
+++ b/crates/tauri-plugin-velesdb/src/helpers.rs
@@ -148,12 +148,9 @@ pub fn require_collection(
     let any_coll = db
         .get_any_collection(name)
         .ok_or_else(|| Error::CollectionNotFound(name.to_string()))?;
-    if !any_coll.is_vector() {
-        return Err(Error::InvalidConfig(format!(
-            "Collection '{name}' is not a vector collection"
-        )));
-    }
-    Ok(any_coll.as_vector_collection_unchecked())
+    any_coll.into_vector().map_err(|_other_variant| {
+        Error::InvalidConfig(format!("Collection '{name}' is not a vector collection"))
+    })
 }
 
 /// Looks up a `VectorCollection` by name, returning a typed error on miss.

--- a/crates/velesdb-core/src/collection/any_collection.rs
+++ b/crates/velesdb-core/src/collection/any_collection.rs
@@ -2,6 +2,25 @@
 //!
 //! `AnyCollection` wraps the three typed collections in an enum, dispatching
 //! common operations via match arms. Zero-cost: no heap allocation, no vtable.
+//!
+//! # Variant access
+//!
+//! Three complementary APIs follow the std `Result` / `Option` / `Any` idiom:
+//!
+//! | Need                              | Method                               | Returns                            |
+//! |-----------------------------------|--------------------------------------|------------------------------------|
+//! | Check variant                     | [`is_vector`], [`is_graph`], …       | `bool`                             |
+//! | Borrow variant (shared)           | [`as_vector`], [`as_graph`], …       | `Option<&T>`                       |
+//! | Borrow variant (exclusive)        | [`as_vector_mut`], …                 | `Option<&mut T>`                   |
+//! | Consume with recovery on miss     | [`into_vector`], [`into_graph`], …   | `Result<T, Self>`                  |
+//!
+//! [`is_vector`]: AnyCollection::is_vector
+//! [`is_graph`]: AnyCollection::is_graph
+//! [`as_vector`]: AnyCollection::as_vector
+//! [`as_graph`]: AnyCollection::as_graph
+//! [`as_vector_mut`]: AnyCollection::as_vector_mut
+//! [`into_vector`]: AnyCollection::into_vector
+//! [`into_graph`]: AnyCollection::into_graph
 
 use std::collections::HashMap;
 
@@ -16,6 +35,28 @@ use crate::point::SearchResult;
 ///
 /// Dispatches common operations to the inner typed collection via enum match.
 /// Zero-cost: no heap allocation, no vtable — just a match arm per variant.
+///
+/// # Examples
+///
+/// ```rust,no_run
+/// use velesdb_core::{AnyCollection, Database};
+///
+/// let db = Database::open("./data")?;
+/// if let Some(any) = db.get_any_collection("docs") {
+///     // `config()`, `flush()`, `point_count()`, `name()`, `execute_query_str()`
+///     // dispatch across all variants — safe on every kind.
+///     println!("{}: {} pts", any.name(), any.point_count());
+///
+///     // Pattern-match when a variant-specific method is needed.
+///     match &any {
+///         AnyCollection::Vector(_) => println!("vector collection"),
+///         AnyCollection::Graph(_)  => println!("graph collection"),
+///         AnyCollection::Metadata(_) => println!("metadata collection"),
+///         _ => println!("unknown variant"),
+///     }
+/// }
+/// # Ok::<(), velesdb_core::Error>(())
+/// ```
 #[derive(Clone)]
 #[non_exhaustive]
 pub enum AnyCollection {
@@ -28,6 +69,10 @@ pub enum AnyCollection {
 }
 
 impl AnyCollection {
+    // -------------------------------------------------------------------------
+    // Shared operations (dispatch on variant)
+    // -------------------------------------------------------------------------
+
     /// Returns the collection configuration.
     #[must_use]
     pub fn config(&self) -> CollectionConfig {
@@ -68,6 +113,9 @@ impl AnyCollection {
     }
 
     /// Returns `true` if this is a metadata-only collection.
+    ///
+    /// Equivalent to [`is_metadata`](Self::is_metadata) — kept for backward
+    /// compatibility with older call sites.
     #[must_use]
     pub fn is_metadata_only(&self) -> bool {
         matches!(self, Self::Metadata(_))
@@ -123,72 +171,248 @@ impl AnyCollection {
         }
     }
 
-    /// Consumes this `AnyCollection` and returns a `VectorCollection`
-    /// wrapping the same inner state.
+    // -------------------------------------------------------------------------
+    // Variant discriminants (`is_*`)
+    // -------------------------------------------------------------------------
+
+    /// Returns `true` if this collection is the [`Vector`](Self::Vector) variant.
     ///
-    /// For the `Vector` variant this is a straightforward move. For
-    /// the `Graph` and `Metadata` variants this function re-wraps the
-    /// inner `Arc<Collection>` in the `VectorCollection` newtype
-    /// without changing the underlying runtime type — downstream code
-    /// that then invokes vector-specific methods on the result (for
-    /// example `search`, `upsert`, `config().dimension > 0`) may
-    /// therefore hit an error or nonsensical state at runtime. The
-    /// method is still useful for SDK bindings (Python, Mobile, Tauri)
-    /// that expose a single `Collection` type to users and only call
-    /// shared methods (config, flush, diagnostics, point_count) on
-    /// the result.
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// use velesdb_core::{AnyCollection, Database, DistanceMetric};
+    ///
+    /// let db = Database::open("./data")?;
+    /// db.create_collection("docs", 768, DistanceMetric::Cosine)?;
+    /// let any = db.get_any_collection("docs").expect("exists");
+    /// assert!(any.is_vector());
+    /// assert!(!any.is_graph());
+    /// # Ok::<(), velesdb_core::Error>(())
+    /// ```
+    #[must_use]
+    pub fn is_vector(&self) -> bool {
+        matches!(self, Self::Vector(_))
+    }
+
+    /// Returns `true` if this collection is the [`Graph`](Self::Graph) variant.
+    #[must_use]
+    pub fn is_graph(&self) -> bool {
+        matches!(self, Self::Graph(_))
+    }
+
+    /// Returns `true` if this collection is the [`Metadata`](Self::Metadata) variant.
+    #[must_use]
+    pub fn is_metadata(&self) -> bool {
+        matches!(self, Self::Metadata(_))
+    }
+
+    // -------------------------------------------------------------------------
+    // Shared borrows (`as_*`) — zero-cost, return `Option<&T>`
+    // -------------------------------------------------------------------------
+
+    /// Returns a shared reference to the inner [`VectorCollection`] if this is
+    /// the [`Vector`](Self::Vector) variant, or `None` otherwise.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// use velesdb_core::{Database, DistanceMetric};
+    ///
+    /// let db = Database::open("./data")?;
+    /// db.create_collection("docs", 768, DistanceMetric::Cosine)?;
+    /// let any = db.get_any_collection("docs").expect("exists");
+    /// if let Some(v) = any.as_vector() {
+    ///     let _ = v.config().dimension;
+    /// }
+    /// # Ok::<(), velesdb_core::Error>(())
+    /// ```
+    #[must_use]
+    pub fn as_vector(&self) -> Option<&VectorCollection> {
+        match self {
+            Self::Vector(c) => Some(c),
+            _ => None,
+        }
+    }
+
+    /// Returns an exclusive reference to the inner [`VectorCollection`] if
+    /// this is the [`Vector`](Self::Vector) variant, or `None` otherwise.
+    #[must_use]
+    pub fn as_vector_mut(&mut self) -> Option<&mut VectorCollection> {
+        match self {
+            Self::Vector(c) => Some(c),
+            _ => None,
+        }
+    }
+
+    /// Returns a shared reference to the inner [`GraphCollection`] if this is
+    /// the [`Graph`](Self::Graph) variant, or `None` otherwise.
+    #[must_use]
+    pub fn as_graph(&self) -> Option<&GraphCollection> {
+        match self {
+            Self::Graph(c) => Some(c),
+            _ => None,
+        }
+    }
+
+    /// Returns an exclusive reference to the inner [`GraphCollection`] if
+    /// this is the [`Graph`](Self::Graph) variant, or `None` otherwise.
+    #[must_use]
+    pub fn as_graph_mut(&mut self) -> Option<&mut GraphCollection> {
+        match self {
+            Self::Graph(c) => Some(c),
+            _ => None,
+        }
+    }
+
+    /// Returns a shared reference to the inner [`MetadataCollection`] if this
+    /// is the [`Metadata`](Self::Metadata) variant, or `None` otherwise.
+    #[must_use]
+    pub fn as_metadata(&self) -> Option<&MetadataCollection> {
+        match self {
+            Self::Metadata(c) => Some(c),
+            _ => None,
+        }
+    }
+
+    /// Returns an exclusive reference to the inner [`MetadataCollection`] if
+    /// this is the [`Metadata`](Self::Metadata) variant, or `None` otherwise.
+    #[must_use]
+    pub fn as_metadata_mut(&mut self) -> Option<&mut MetadataCollection> {
+        match self {
+            Self::Metadata(c) => Some(c),
+            _ => None,
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Consuming conversions (`into_*`) — return `Result<T, Self>` for recovery
+    // -------------------------------------------------------------------------
+
+    /// Consumes `self` and returns the inner [`VectorCollection`] if this is
+    /// the [`Vector`](Self::Vector) variant.
+    ///
+    /// On the wrong variant, returns `Err(self)` so callers can recover
+    /// ownership — mirroring the std [`Result`] / [`TryFrom`] idiom.
+    ///
+    /// # Errors
+    ///
+    /// Returns the original `AnyCollection` unchanged when the variant is
+    /// [`Graph`](Self::Graph) or [`Metadata`](Self::Metadata).
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// use velesdb_core::{Database, DistanceMetric};
+    ///
+    /// let db = Database::open("./data")?;
+    /// db.create_collection("docs", 768, DistanceMetric::Cosine)?;
+    /// let any = db.get_any_collection("docs").expect("exists");
+    /// match any.into_vector() {
+    ///     Ok(v) => { let _ = v.config().dimension; }
+    ///     Err(original) => {
+    ///         // wrong variant; `original` still valid
+    ///         assert!(!original.is_vector());
+    ///     }
+    /// }
+    /// # Ok::<(), velesdb_core::Error>(())
+    /// ```
+    // `Err`-variant is `Self` by design — mirrors std `TryFrom` so callers
+    // recover ownership on the wrong variant. Box-wrapping would defeat the
+    // purpose and forces an allocation on every miss.
+    #[allow(clippy::result_large_err)]
+    pub fn into_vector(self) -> core::result::Result<VectorCollection, Self> {
+        match self {
+            Self::Vector(c) => Ok(c),
+            other => Err(other),
+        }
+    }
+
+    /// Consumes `self` and returns the inner [`GraphCollection`] if this is
+    /// the [`Graph`](Self::Graph) variant.
+    ///
+    /// # Errors
+    ///
+    /// Returns the original `AnyCollection` unchanged when the variant is
+    /// [`Vector`](Self::Vector) or [`Metadata`](Self::Metadata).
+    #[allow(clippy::result_large_err)]
+    pub fn into_graph(self) -> core::result::Result<GraphCollection, Self> {
+        match self {
+            Self::Graph(c) => Ok(c),
+            other => Err(other),
+        }
+    }
+
+    /// Consumes `self` and returns the inner [`MetadataCollection`] if this
+    /// is the [`Metadata`](Self::Metadata) variant.
+    ///
+    /// # Errors
+    ///
+    /// Returns the original `AnyCollection` unchanged when the variant is
+    /// [`Vector`](Self::Vector) or [`Graph`](Self::Graph).
+    #[allow(clippy::result_large_err)]
+    pub fn into_metadata(self) -> core::result::Result<MetadataCollection, Self> {
+        match self {
+            Self::Metadata(c) => Ok(c),
+            other => Err(other),
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Unchecked cross-cast (escape hatch for SDK bindings)
+    // -------------------------------------------------------------------------
+
+    /// Consumes `self` and returns a [`VectorCollection`] regardless of the
+    /// underlying variant, re-wrapping the shared inner state.
+    ///
+    /// For the [`Vector`](Self::Vector) variant this is a straightforward
+    /// move. For the [`Graph`](Self::Graph) and [`Metadata`](Self::Metadata)
+    /// variants this re-wraps the shared `Arc<Collection>` in the
+    /// `VectorCollection` newtype **without changing the underlying runtime
+    /// type** — downstream code that invokes vector-specific methods on the
+    /// result (for example [`search`](VectorCollection::search),
+    /// [`upsert`](VectorCollection::upsert),
+    /// `config().dimension > 0`) may therefore return empty results or
+    /// misleading state.
+    ///
+    /// This method exists to support the Python / Mobile / Tauri SDK bindings
+    /// that expose a single `Collection` type to users and only invoke the
+    /// shared surface (`config`, `flush`, `diagnostics`, `point_count`,
+    /// `execute_query_str`) on the result.
     ///
     /// # Safety
     ///
-    /// Calling vector-specific methods on a `VectorCollection` that
-    /// was produced from a `Graph` or `Metadata` variant is **not**
-    /// memory-unsafe, but the result is logically unsound: the
-    /// underlying storage does not hold a homogeneous vector index,
-    /// and the returned `SearchResult` objects are either empty or
-    /// reflect internal state that was not intended for public
-    /// consumption. Callers must either:
+    /// Calling vector-specific methods on a `VectorCollection` obtained from
+    /// a `Graph` or `Metadata` variant is **not** memory-unsafe, but the
+    /// result is logically unsound: the underlying storage does not hold a
+    /// homogeneous vector index, and the returned search results are either
+    /// empty or reflect internal state that was not intended for public
+    /// consumption.
     ///
-    /// * branch on [`AnyCollection::is_vector`] first and only
-    ///   invoke vector-specific methods on the `Vector` variant, or
+    /// Callers must either:
+    ///
+    /// * branch on [`is_vector`](Self::is_vector) first and only invoke
+    ///   vector-specific methods on the `Vector` variant, or
     /// * restrict themselves to the methods that all three collection
     ///   kinds share (`config`, `flush`, `diagnostics`, `name`,
-    ///   `point_count`).
+    ///   `point_count`, `execute_query_str`).
     ///
-    /// This method is retained to support the existing SDK surface
-    /// but is flagged as `unchecked` to make the caller obligation
-    /// explicit. A proper type-safe refactor is tracked under the
-    /// post-seed EPIC documented in `docs/ARCHITECTURE.md` (finding
-    /// F2.2 of the pre-seed audit).
+    /// Prefer the safe [`into_vector`](Self::into_vector) (variant-checked,
+    /// returns `Result`) when the caller can branch. A proper type-safe
+    /// refactor that eliminates this method entirely is tracked under the
+    /// post-seed EPIC documented in `docs/ARCHITECTURE.md` (finding F2.2 of
+    /// the pre-seed audit).
+    ///
+    /// # Violation of invariants
+    ///
+    /// The `unsafe` marker flags the caller contract (only invoke the
+    /// shared surface on non-`Vector` variants) even though violating it
+    /// does not cause undefined behaviour.
     #[must_use]
-    pub fn as_vector_collection_unchecked(self) -> VectorCollection {
+    pub unsafe fn into_vector_unchecked(self) -> VectorCollection {
         match self {
             Self::Vector(c) => c,
             Self::Graph(c) => VectorCollection { inner: c.inner },
             Self::Metadata(c) => VectorCollection { inner: c.inner },
         }
-    }
-
-    /// Deprecated alias for [`Self::as_vector_collection_unchecked`].
-    ///
-    /// The old name is retained so external consumers do not break at
-    /// compile time; it emits a deprecation warning that points at
-    /// the safer replacement. Internal call sites have been migrated.
-    #[must_use]
-    #[deprecated(
-        since = "1.13.0",
-        note = "Renamed to `as_vector_collection_unchecked`. See the rustdoc for the unchecked-cast contract and finding F2.2 in docs/ARCHITECTURE.md."
-    )]
-    pub fn into_vector_collection(self) -> VectorCollection {
-        self.as_vector_collection_unchecked()
-    }
-
-    /// Returns `true` if this collection is a `Vector` variant.
-    ///
-    /// Intended for callers that use
-    /// [`Self::as_vector_collection_unchecked`] and need to branch on
-    /// the underlying kind before invoking vector-specific methods.
-    #[must_use]
-    pub fn is_vector(&self) -> bool {
-        matches!(self, Self::Vector(_))
     }
 }

--- a/crates/velesdb-core/src/collection/any_collection.rs
+++ b/crates/velesdb-core/src/collection/any_collection.rs
@@ -195,12 +195,36 @@ impl AnyCollection {
     }
 
     /// Returns `true` if this collection is the [`Graph`](Self::Graph) variant.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// use velesdb_core::{Database, GraphSchema};
+    ///
+    /// let db = Database::open("./data")?;
+    /// db.create_graph_collection("edges", GraphSchema::schemaless())?;
+    /// let any = db.get_any_collection("edges").expect("exists");
+    /// assert!(any.is_graph());
+    /// # Ok::<(), velesdb_core::Error>(())
+    /// ```
     #[must_use]
     pub fn is_graph(&self) -> bool {
         matches!(self, Self::Graph(_))
     }
 
     /// Returns `true` if this collection is the [`Metadata`](Self::Metadata) variant.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// use velesdb_core::Database;
+    ///
+    /// let db = Database::open("./data")?;
+    /// db.create_metadata_collection("catalog")?;
+    /// let any = db.get_any_collection("catalog").expect("exists");
+    /// assert!(any.is_metadata());
+    /// # Ok::<(), velesdb_core::Error>(())
+    /// ```
     #[must_use]
     pub fn is_metadata(&self) -> bool {
         matches!(self, Self::Metadata(_))
@@ -246,6 +270,20 @@ impl AnyCollection {
 
     /// Returns a shared reference to the inner [`GraphCollection`] if this is
     /// the [`Graph`](Self::Graph) variant, or `None` otherwise.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// use velesdb_core::{Database, GraphSchema};
+    ///
+    /// let db = Database::open("./data")?;
+    /// db.create_graph_collection("edges", GraphSchema::schemaless())?;
+    /// let any = db.get_any_collection("edges").expect("exists");
+    /// if let Some(g) = any.as_graph() {
+    ///     let _ = g.edge_count();
+    /// }
+    /// # Ok::<(), velesdb_core::Error>(())
+    /// ```
     #[must_use]
     pub fn as_graph(&self) -> Option<&GraphCollection> {
         match self {
@@ -266,6 +304,20 @@ impl AnyCollection {
 
     /// Returns a shared reference to the inner [`MetadataCollection`] if this
     /// is the [`Metadata`](Self::Metadata) variant, or `None` otherwise.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// use velesdb_core::Database;
+    ///
+    /// let db = Database::open("./data")?;
+    /// db.create_metadata_collection("catalog")?;
+    /// let any = db.get_any_collection("catalog").expect("exists");
+    /// if let Some(m) = any.as_metadata() {
+    ///     let _ = m.is_empty();
+    /// }
+    /// # Ok::<(), velesdb_core::Error>(())
+    /// ```
     #[must_use]
     pub fn as_metadata(&self) -> Option<&MetadataCollection> {
         match self {
@@ -330,10 +382,28 @@ impl AnyCollection {
     /// Consumes `self` and returns the inner [`GraphCollection`] if this is
     /// the [`Graph`](Self::Graph) variant.
     ///
+    /// On the wrong variant, returns `Err(self)` so callers can recover
+    /// ownership.
+    ///
     /// # Errors
     ///
     /// Returns the original `AnyCollection` unchanged when the variant is
     /// [`Vector`](Self::Vector) or [`Metadata`](Self::Metadata).
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// use velesdb_core::{Database, GraphSchema};
+    ///
+    /// let db = Database::open("./data")?;
+    /// db.create_graph_collection("edges", GraphSchema::schemaless())?;
+    /// let any = db.get_any_collection("edges").expect("exists");
+    /// match any.into_graph() {
+    ///     Ok(graph) => { let _ = graph.edge_count(); }
+    ///     Err(_wrong_variant) => unreachable!("edges is a graph collection"),
+    /// }
+    /// # Ok::<(), velesdb_core::Error>(())
+    /// ```
     #[allow(clippy::result_large_err)]
     pub fn into_graph(self) -> core::result::Result<GraphCollection, Self> {
         match self {
@@ -345,10 +415,28 @@ impl AnyCollection {
     /// Consumes `self` and returns the inner [`MetadataCollection`] if this
     /// is the [`Metadata`](Self::Metadata) variant.
     ///
+    /// On the wrong variant, returns `Err(self)` so callers can recover
+    /// ownership.
+    ///
     /// # Errors
     ///
     /// Returns the original `AnyCollection` unchanged when the variant is
     /// [`Vector`](Self::Vector) or [`Graph`](Self::Graph).
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// use velesdb_core::Database;
+    ///
+    /// let db = Database::open("./data")?;
+    /// db.create_metadata_collection("catalog")?;
+    /// let any = db.get_any_collection("catalog").expect("exists");
+    /// match any.into_metadata() {
+    ///     Ok(meta) => assert!(meta.is_empty()),
+    ///     Err(_wrong_variant) => unreachable!("catalog is a metadata collection"),
+    /// }
+    /// # Ok::<(), velesdb_core::Error>(())
+    /// ```
     #[allow(clippy::result_large_err)]
     pub fn into_metadata(self) -> core::result::Result<MetadataCollection, Self> {
         match self {

--- a/crates/velesdb-core/src/collection/graph/edge_concurrent/snapshot.rs
+++ b/crates/velesdb-core/src/collection/graph/edge_concurrent/snapshot.rs
@@ -47,11 +47,31 @@ impl ConcurrentEdgeStore {
     /// On failure the previous snapshot is retained (readers see stale but
     /// structurally valid data).
     ///
-    /// # Note
+    /// # Locking contract (must-read)
     ///
-    /// This method does NOT acquire `edge_ids` — it reads directly from
-    /// shard `EdgeStore`s. This avoids deadlock when called from mutation
-    /// methods that already hold the `edge_ids` write lock.
+    /// The caller **must not** hold a write lock on `edge_ids` **or** any
+    /// `shards[*]` lock (read or write) when invoking this method. The
+    /// method walks every shard and takes a read lock on each one in turn;
+    /// holding a same-shard write lock deadlocks against the reader, and
+    /// holding an `edge_ids` write lock deadlocks against the downstream
+    /// `label_table` / snapshot consumers in the same lock-order chain.
+    ///
+    /// The only two supported call sites are:
+    ///
+    /// * [`build_read_snapshot`](Self::build_read_snapshot) (this file) —
+    ///   acquires `edge_ids` as **read-only** and releases per-shard read
+    ///   locks between loop iterations.
+    /// * The lazy-rebuild path in
+    ///   `collection/graph/edge_concurrent/query.rs::ensure_csr_fresh`
+    ///   (reachable from `get_csr_snapshot`) — runs with no outer locks
+    ///   held.
+    ///
+    /// Mutation methods (`add_edge`, `remove_edge`, `flush`, …) must
+    /// instead call
+    /// [`rebuild_snapshot_best_effort`](Self::rebuild_snapshot_best_effort)
+    /// which only flips the dirty flag and defers the actual rebuild to
+    /// the next reader. Cross-reference: `docs/CONCURRENCY_MODEL.md`
+    /// (graph collection lock-ordering section).
     ///
     /// # Errors
     ///

--- a/crates/velesdb-core/src/gpu/gpu_csr.rs
+++ b/crates/velesdb-core/src/gpu/gpu_csr.rs
@@ -378,12 +378,16 @@ impl CsrCache {
         new_csr
     }
 
-    /// Returns a clone of the cached CSR if available and fresh.
+    /// Returns a clone of the cached CSR if it is available and fresh.
     ///
-    /// Returns `None` if the cache is stale or not yet built.
-    /// Used by non-critical paths that don't want to pay the rebuild cost.
+    /// Returns `None` if the cache is stale or has not been built yet. Used
+    /// by non-critical paths that do not want to pay the rebuild cost.
+    ///
+    /// Aligns with the existing `Snapshot` terminology used throughout
+    /// `velesdb-core` (`Bm25Snapshot`, `HnswSnapshot`, `to_snapshot`,
+    /// `from_snapshot`).
     #[must_use]
-    pub fn get_if_clean(&self) -> Option<CsrGraph> {
+    pub fn clean_snapshot(&self) -> Option<CsrGraph> {
         if self.is_stale() {
             return None;
         }
@@ -530,15 +534,15 @@ mod tests {
     }
 
     #[test]
-    fn test_get_if_clean_returns_none_when_dirty() {
+    fn test_clean_snapshot_returns_none_when_dirty() {
         let cache = CsrCache::new();
-        assert!(cache.get_if_clean().is_none()); // Starts dirty
+        assert!(cache.clean_snapshot().is_none()); // Starts dirty
 
         let layer = Layer::new(1);
         with_layers_rank(|| cache.get_or_rebuild(&layer, 1)); // Build it
-        assert!(cache.get_if_clean().is_some()); // Now clean
+        assert!(cache.clean_snapshot().is_some()); // Now clean
 
         cache.invalidate();
-        assert!(cache.get_if_clean().is_none()); // Dirty again
+        assert!(cache.clean_snapshot().is_none()); // Dirty again
     }
 }

--- a/crates/velesdb-core/src/index/hnsw/native/graph/gpu_search.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/graph/gpu_search.rs
@@ -68,7 +68,7 @@ impl<D: DistanceEngine> NativeHnsw<D> {
         // owns its own cache, preventing cross-collection contamination.
         //
         // **Validity signal** — relies solely on the CsrCache dirty flag
-        // (`get_if_clean`), which is aligned with `gpu_snapshot_version`:
+        // (`clean_snapshot`), which is aligned with `gpu_snapshot_version`:
         // every mutation that bumps `gpu_snapshot_version` also invalidates
         // the CSR cache through `NativeHnsw::invalidate_gpu_caches`, so
         // "cache clean" ⇔ "snapshot version unchanged" ⇔ "topology
@@ -88,7 +88,7 @@ impl<D: DistanceEngine> NativeHnsw<D> {
             if layers.is_empty() {
                 return None;
             }
-            if let Some(existing) = self.gpu_csr_cache.get_if_clean() {
+            if let Some(existing) = self.gpu_csr_cache.clean_snapshot() {
                 return Some(existing);
             }
             Some(self.gpu_csr_cache.get_or_rebuild(&layers[0], count))

--- a/crates/velesdb-core/src/velesql/ast/window.rs
+++ b/crates/velesdb-core/src/velesql/ast/window.rs
@@ -5,7 +5,13 @@
 use serde::{Deserialize, Serialize};
 
 /// Window function type (Phase 1: ranking functions).
+///
+/// Marked `#[non_exhaustive]` so future phases (`LAG`, `LEAD`,
+/// `FIRST_VALUE`, `NTILE`, aggregate windows, …) can be added
+/// without a semver break. Downstream crates must include a
+/// wildcard (`_ =>`) arm when matching on this enum.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub enum WindowFunctionType {
     /// `ROW_NUMBER()` — sequential numbering 1..N within each partition.
     RowNumber,

--- a/crates/velesdb-mobile/src/lib.rs
+++ b/crates/velesdb-mobile/src/lib.rs
@@ -222,19 +222,15 @@ impl VelesDatabase {
     /// (use [`get_graph_collection`](Self::get_graph_collection) for graph collections).
     pub fn get_collection(&self, name: String) -> Result<Option<Arc<VelesCollection>>, VelesError> {
         match self.inner.get_any_collection(&name) {
-            Some(any_coll) => {
-                if !any_coll.is_vector() {
-                    return Err(VelesError::Collection {
-                        message: format!(
-                            "Collection '{}' is not a vector collection. \
-                             Use get_graph_collection() for graph collections.",
-                            name
-                        ),
-                    });
-                }
-                let vc = any_coll.as_vector_collection_unchecked();
-                Ok(Some(Arc::new(VelesCollection { inner: vc })))
-            }
+            Some(any_coll) => match any_coll.into_vector() {
+                Ok(vc) => Ok(Some(Arc::new(VelesCollection { inner: vc }))),
+                Err(_other_variant) => Err(VelesError::Collection {
+                    message: format!(
+                        "Collection '{name}' is not a vector collection. \
+                         Use get_graph_collection() for graph collections."
+                    ),
+                }),
+            },
             None => Ok(None),
         }
     }

--- a/crates/velesdb-python/src/database.rs
+++ b/crates/velesdb-python/src/database.rs
@@ -255,7 +255,15 @@ impl Database {
                 // metadata collection returns empty results rather than
                 // raising — the typed split is tracked as a post-seed
                 // EPIC in docs/ARCHITECTURE.md.
-                let vc = any_coll.as_vector_collection_unchecked();
+                //
+                // SAFETY: Python SDK intentionally exposes a single
+                // Collection facade over all variants. Only the shared
+                // surface (config, flush, diagnostics, execute_query_str,
+                // etc.) is guaranteed correct on non-Vector variants; the
+                // Python wrapper and BDD tests cover that contract. See
+                // `AnyCollection::into_vector_unchecked` for full caller
+                // obligations.
+                let vc = unsafe { any_coll.into_vector_unchecked() };
                 Ok(Some(Collection::new(vc, name.to_string())))
             }
             None => Ok(None),
@@ -320,11 +328,15 @@ impl Database {
             .map_err(core_err)?;
 
         // Use get_any_collection to get the registered instance (not a disconnected copy).
-        let collection = self
+        let any = self
             .inner
             .get_any_collection(&name_owned)
-            .map(velesdb_core::AnyCollection::as_vector_collection_unchecked)
             .ok_or_else(|| PyRuntimeError::new_err("Collection not found after creation"))?;
+        // SAFETY: Python SDK intentionally wraps the freshly-created metadata
+        // collection in the single `Collection` facade. Only the shared
+        // surface is exercised on metadata variants. See
+        // `AnyCollection::into_vector_unchecked` for full caller obligations.
+        let collection = unsafe { any.into_vector_unchecked() };
 
         Ok(Collection::new(collection, name_owned))
     }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -12,7 +12,7 @@ mitigation currently in place, and the post-seed remediation plan.
 
 ---
 
-## F2.2 — `AnyCollection::as_vector_collection_unchecked` (god-object cross-cast)
+## F2.2 — `AnyCollection` variant-access API & unchecked cross-cast
 
 **Audit finding**: F2.2 of the pre-seed audit (`AUDIT_VELESDB_CORE.md`).
 
@@ -36,25 +36,31 @@ classes and require a discriminator enum in the public API. The
 unchecked cast was introduced as a short-term convenience so those
 bindings could share a single type.
 
-**Sprint 1 mitigation** (shipped):
+**v1.13.0 resolution** (shipped):
 
-1. The method has been renamed from `into_vector_collection` to
-   `as_vector_collection_unchecked` to make the unchecked contract
-   explicit at the call site.
-2. The rustdoc of the new method carries a `# Safety` section that
-   documents the caller's obligation to either branch on
-   [`AnyCollection::is_vector`] first, or restrict themselves to the
-   methods that all three collection kinds share (`config`, `flush`,
-   `diagnostics`, `name`, `point_count`).
-3. The old `into_vector_collection` name is retained as a
-   `#[deprecated]` alias that delegates to the new method so external
-   consumers do not break at compile time.
-4. The four internal call sites (velesdb-mobile, velesdb-python,
-   tauri-plugin-velesdb, any_collection.rs itself) have been migrated
-   to the new name and each carries an explanatory comment referring
-   to this section.
-5. A new accessor `AnyCollection::is_vector()` is provided so callers
-   can branch defensively before the unchecked cast.
+The API was redesigned to match the std `Result` / `Option` / `Any`
+idiom for enum-variant access:
+
+1. **Safe borrows** — `as_vector(&self) -> Option<&VectorCollection>`,
+   `as_vector_mut(&mut self)`, plus `as_graph*` and `as_metadata*`
+   counterparts. Zero-cost: match + reference, no allocation.
+2. **Safe consuming** — `into_vector(self) -> Result<VectorCollection, Self>`,
+   plus `into_graph` and `into_metadata`. Wrong variant returns
+   `Err(self)` so the caller recovers ownership.
+3. **Variant discriminants** — `is_vector`, `is_graph`, `is_metadata`
+   round out the matrix.
+4. **Unchecked escape hatch** — the previous
+   `as_vector_collection_unchecked` (and its deprecated alias
+   `into_vector_collection`) was replaced by
+   `unsafe fn into_vector_unchecked(self) -> VectorCollection`. The
+   `unsafe` marker makes the logical-soundness contract explicit at
+   every call site, even though violating it does not cause
+   undefined behaviour. Only the Python SDK binding retains this
+   escape hatch (twice), each with a mandatory `// SAFETY:` comment
+   documenting why the shared-surface-only contract holds.
+5. The velesdb-mobile and tauri-plugin-velesdb bindings migrated to
+   the safe `into_vector()` API — the Rust error path already
+   existed in both bindings, so the variant check became free.
 
 **Post-seed resolution** (tracked as the F2.2 EPIC):
 
@@ -71,8 +77,8 @@ The SDK bindings would then expose a sum type (enum) or union
 interface that forces callers to discriminate the kind before
 invoking any operation. This is estimated at 2-4 weeks of core
 refactoring and is deliberately out of scope for the pre-seed
-remediation cycle. The `as_vector_collection_unchecked` method will
-be removed in full as part of the EPIC.
+remediation cycle. The `into_vector_unchecked` method will be
+removed in full as part of the EPIC.
 
 **When to revisit**: post-seed, within the first 4 weeks of the
 architecture cleanup milestone.


### PR DESCRIPTION
## Summary

Follow-up to PR #646 (pre-seed review). After a **triple Rust-expert code review** (idiomaticity / safety-concurrency / API-surface angles) against the v1.12.0 → v1.13.0 delta (163 commits, 902 files), 5 HIGH findings surfaced. Per the "zero technical debt introduced by develop → main" mandate, this PR lands the **true idiomatic fixes** — not just rule-compliant renames.

## Fixes (6 atomic commits)

### 1. `WindowFunctionType` missing `#[non_exhaustive]` (#629 follow-up)
`crates/velesdb-core/src/velesql/ast/window.rs` — adding future variants (LEAD/LAG/NTILE) without `#[non_exhaustive]` would semver-break downstream exhaustive matches. `#[non_exhaustive]` is a no-op intra-crate, so the internal `match` at `window_evaluator.rs:230` stays clean.

### 2. `AnyCollection` variant-access API redesign (true idiom)
The previous `as_vector_collection_unchecked(self)` violated C-CONV (`as_` consuming `self`) AND forced every caller to opt into panic-on-wrong-variant. Redesign to the full **Rust std `Result`/`Option`/`Any` idiom** per variant:

```rust
// Safe borrow (C-CONV: as_ returns reference)
fn as_vector(&self) -> Option<&VectorCollection>
fn as_vector_mut(&mut self) -> Option<&mut VectorCollection>

// Safe consume (C-CONV: into_ takes self)
fn into_vector(self) -> Result<VectorCollection, Self>

// Plus is_vector/is_graph/is_metadata discriminants (C-BOOL)
// Plus unsafe fn into_vector_unchecked(self) → VectorCollection
//   (kept ONLY because Python SDK's facade intentionally cross-casts
//    Graph→Vector via inner field; marked unsafe to surface the
//    logical-soundness contract at every call site)
```

Mirror for `graph` and `metadata` variants. Python callers at `database.rs:258,326` now use `unsafe { any.into_vector_unchecked() }` with inline `// SAFETY:` blocks documenting the cross-cast contract.

### 3. Doc-tests on all new `AnyCollection` methods
10 doc-tests added covering enum match pattern, `is_*`, `as_*`, `into_*`. `cargo test --doc`: **46 pass**.

### 4. `CsrCache::get_if_clean` → `clean_snapshot`
C-GETTER violation (no key parameter). New name aligns with the codebase's existing Snapshot terminology (`Bm25Snapshot`, `HnswSnapshot`, `to_snapshot`, `from_snapshot`). 2 callers + 1 test migrated.

### 5. `ConcurrentEdgeStore::rebuild_snapshot` locking-contract doc
3-line `# Note` replaced with a 19-line `# Locking contract (must-read)` block stating explicit lock prohibitions, naming the two supported call sites, and cross-referencing `docs/CONCURRENCY_MODEL.md`.

### 6. CHANGELOG update
Consolidated "API hardening (v1.13.0 pre-release)" section.

## Quality gates (all green locally)

- `cargo fmt --all -- --check`: PASS
- `cargo clippy --workspace --all-targets --features persistence,gpu,update-check --exclude velesdb-python -- -D warnings -D clippy::pedantic`: **PASS (0 warnings)**
- `cargo test --doc -p velesdb-core --features persistence`: PASS (46 passed)
- `cargo test -p velesdb-core --features persistence test_recall`: **23 pass / 0 fail**
- `cargo test -p velesdb-core --test velesql_parser_conformance`: PASS (127 window-fn cases)
- `cargo check -p velesdb-core --no-default-features`: PASS
- `cargo check -p velesdb-wasm --no-default-features --target wasm32-unknown-unknown`: PASS
- `python scripts/check-promise-contract.py`: PASS (15 claims)

## Cross-crate propagation verified

- `crates/velesdb-mobile/src/lib.rs` — safe `into_vector()` with `Err` arm
- `crates/tauri-plugin-velesdb/src/helpers.rs` — safe `into_vector()` with `Err` arm
- `crates/velesdb-python/src/database.rs` — `unsafe { into_vector_unchecked() }` with documented SAFETY contract (2 sites)
- `docs/ARCHITECTURE.md` F2.2 — rewritten to reflect v1.13.0 resolved state

## Test plan

- [x] Local gates all green (fmt, clippy pedantic, doc-tests, recall, parser conformance, feature-gate hygiene)
- [ ] CI green on this PR
- [ ] Codacy Cloud clean
- [ ] Devin Review (expected pass — diff is only 10 files)
- [ ] Merge into develop → PR #628 picks up automatically
- [ ] Tag v1.13.0 post main merge
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/647" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
