### PR TITLE
feat(server): observability & ops — Prometheus metrics, bulk delete, vacuum/compact (#388)

### DIFF
--- a/crates/velesdb-core/src/collection/core/flush.rs
+++ b/crates/velesdb-core/src/collection/core/flush.rs
@@ -343,6 +343,21 @@ impl Collection {
             .map_err(|e| Error::Index(format!("HNSW vacuum failed: {e}")))
     }
 
+    /// Compacts the vector storage, rewriting active vectors into a
+    /// contiguous layout and reclaiming disk space from deleted entries.
+    ///
+    /// Returns the number of bytes reclaimed.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the compaction I/O fails.
+    pub(crate) fn compact_vector_storage(&self) -> Result<usize> {
+        self.vector_storage
+            .write()
+            .compact()
+            .map_err(|e| Error::Storage(format!("storage compaction failed: {e}")))
+    }
+
     /// Applies post-creation overrides to the advanced configuration
     /// fields and persists the updated `config.json` atomically.
     ///

--- a/crates/velesdb-core/src/collection/vector_collection/accessors.rs
+++ b/crates/velesdb-core/src/collection/vector_collection/accessors.rs
@@ -94,6 +94,23 @@ impl VectorCollection {
         self.inner.vacuum_hnsw_index()
     }
 
+    /// Compacts the underlying vector storage, rewriting active vectors
+    /// into a contiguous layout and reclaiming disk space occupied by
+    /// deleted entries.
+    ///
+    /// Returns the number of bytes reclaimed.
+    ///
+    /// Used by the server admin endpoint
+    /// `POST /collections/{name}/compact`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the compaction I/O fails (e.g. disk full,
+    /// file lock contention).
+    pub fn compact_storage(&self) -> crate::error::Result<usize> {
+        self.inner.compact_vector_storage()
+    }
+
     /// Applies post-creation overrides to the advanced configuration
     /// fields (`pq_rescore_oversampling`, `deferred_indexing`,
     /// `async_index_builder`) and persists the updated `config.json`.

--- a/crates/velesdb-core/src/metrics/operational.rs
+++ b/crates/velesdb-core/src/metrics/operational.rs
@@ -49,9 +49,16 @@ impl OperationalMetrics {
         Self::default()
     }
 
-    /// Creates a shared metrics instance.
+    /// Creates a fresh metrics instance wrapped in an `Arc` for shared
+    /// ownership across handlers.
+    ///
+    /// This is a constructor convenience — every call returns a brand-new
+    /// counter set. Callers that want a single workspace-wide instance
+    /// must hold the returned `Arc` themselves (e.g. in `AppState`) and
+    /// clone it where needed; this method does NOT back the instance with
+    /// a global cache.
     #[must_use]
-    pub fn shared() -> Arc<Self> {
+    pub fn new_arc() -> Arc<Self> {
         Arc::new(Self::new())
     }
 
@@ -266,8 +273,8 @@ mod tests {
     }
 
     #[test]
-    fn test_operational_metrics_shared() {
-        let metrics = OperationalMetrics::shared();
+    fn test_operational_metrics_new_arc() {
+        let metrics = OperationalMetrics::new_arc();
         metrics.record_vector_query();
 
         // Clone Arc and verify shared state

--- a/crates/velesdb-core/src/metrics/operational.rs
+++ b/crates/velesdb-core/src/metrics/operational.rs
@@ -26,6 +26,8 @@ pub struct OperationalMetrics {
     pub queries_total: AtomicU64,
     /// Total query errors
     pub query_errors: AtomicU64,
+    /// Queries rejected by guard rails (rate limiting, circuit breaker)
+    pub query_rate_limited: AtomicU64,
     /// Vector search queries
     pub vector_queries: AtomicU64,
     /// Graph traversal queries
@@ -61,6 +63,11 @@ impl OperationalMetrics {
     /// Increments the query error counter.
     pub fn inc_errors(&self) {
         self.query_errors.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Increments the rate-limited/rejected counter.
+    pub fn inc_rate_limited(&self) {
+        self.query_rate_limited.fetch_add(1, Ordering::Relaxed);
     }
 
     /// Records a vector search query.
@@ -125,7 +132,8 @@ impl OperationalMetrics {
 
         let total = self.queries_total.load(Ordering::Relaxed);
         let errors = self.query_errors.load(Ordering::Relaxed);
-        let success = total.saturating_sub(errors);
+        let rate_limited = self.query_rate_limited.load(Ordering::Relaxed);
+        let success = total.saturating_sub(errors).saturating_sub(rate_limited);
 
         Self::write_metric_header(
             &mut output,
@@ -137,9 +145,10 @@ impl OperationalMetrics {
             output,
             "velesdb_queries_total{{status=\"success\"}} {success}"
         );
+        let _ = writeln!(output, "velesdb_queries_total{{status=\"error\"}} {errors}");
         let _ = writeln!(
             output,
-            "velesdb_queries_total{{status=\"error\"}} {errors}\n"
+            "velesdb_queries_total{{status=\"rate_limited\"}} {rate_limited}\n"
         );
 
         Self::write_metric_header(
@@ -266,5 +275,37 @@ mod tests {
         metrics2.record_vector_query();
 
         assert_eq!(metrics.queries_total.load(Ordering::Relaxed), 2);
+    }
+
+    #[test]
+    fn test_rate_limited_request_increments_status_rate_limited() {
+        let metrics = OperationalMetrics::new();
+
+        // Simulate 3 queries: 1 succeeds, 1 errors, 1 rate-limited
+        metrics.record_vector_query(); // queries_total = 1
+        metrics.record_vector_query(); // queries_total = 2
+        metrics.record_vector_query(); // queries_total = 3
+        metrics.inc_errors(); // 1 error
+        metrics.inc_rate_limited(); // 1 rate-limited
+
+        assert_eq!(metrics.queries_total.load(Ordering::Relaxed), 3);
+        assert_eq!(metrics.query_errors.load(Ordering::Relaxed), 1);
+        assert_eq!(metrics.query_rate_limited.load(Ordering::Relaxed), 1);
+
+        let output = metrics.export_prometheus();
+
+        // success = total - errors - rate_limited = 3 - 1 - 1 = 1
+        assert!(
+            output.contains("velesdb_queries_total{status=\"success\"} 1"),
+            "expected success=1 in:\n{output}"
+        );
+        assert!(
+            output.contains("velesdb_queries_total{status=\"error\"} 1"),
+            "expected error=1 in:\n{output}"
+        );
+        assert!(
+            output.contains("velesdb_queries_total{status=\"rate_limited\"} 1"),
+            "expected rate_limited=1 in:\n{output}"
+        );
     }
 }

--- a/crates/velesdb-core/src/metrics/query.rs
+++ b/crates/velesdb-core/src/metrics/query.rs
@@ -262,8 +262,11 @@ impl DurationHistogram {
                 return;
             }
         }
-        // Value exceeds all buckets - count in last bucket
-        self.buckets[7].fetch_add(1, Ordering::Relaxed);
+        // Value exceeds all buckets — only the +Inf bucket (derived from
+        // `count`) captures it.  Do NOT increment buckets[7] here: the
+        // Prometheus export accumulates buckets cumulatively, so adding to
+        // the last named bucket would make le="5.0" include observations
+        // >5.0s, violating histogram semantics.
     }
 
     /// Exports histogram in Prometheus format.

--- a/crates/velesdb-server/src/handlers/admin.rs
+++ b/crates/velesdb-server/src/handlers/admin.rs
@@ -131,6 +131,101 @@ pub async fn rebuild_index(
     }
 }
 
+/// Vacuums the HNSW index of a vector collection, removing tombstoned
+/// entries and rebuilding the graph from current vectors.
+///
+/// Semantically equivalent to `POST /collections/{name}/index/rebuild`
+/// but exposed under a more intuitive maintenance-oriented name.
+///
+/// This is a blocking operation: for large collections it may take
+/// several seconds.
+#[utoipa::path(
+    post,
+    path = "/collections/{name}/vacuum",
+    tag = "collections",
+    params(
+        ("name" = String, Path, description = "Collection name")
+    ),
+    responses(
+        (status = 200, description = "Index vacuumed", body = Object),
+        (status = 404, description = "Collection not found", body = ErrorResponse),
+        (status = 500, description = "Vacuum failed", body = ErrorResponse)
+    )
+)]
+pub async fn vacuum_collection(
+    State(state): State<Arc<AppState>>,
+    Path(name): Path<String>,
+) -> impl IntoResponse {
+    let collection = match get_vector_collection_or_404(&state, &name) {
+        Ok(c) => c,
+        Err(resp) => return resp,
+    };
+
+    let result = tokio::task::spawn_blocking(move || collection.rebuild_index()).await;
+    match result {
+        Ok(Ok(compacted)) => (
+            StatusCode::OK,
+            Json(serde_json::json!({
+                "message": "Index vacuumed",
+                "collection": name,
+                "compacted_entries": compacted
+            })),
+        )
+            .into_response(),
+        Ok(Err(e)) => auto_core_error_response(&e),
+        Err(join_err) => error_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("vacuum task panicked: {join_err}"),
+        ),
+    }
+}
+
+/// Compacts the vector storage of a collection, rewriting active vectors
+/// into a contiguous layout and reclaiming disk space from deleted entries.
+///
+/// This is a blocking operation that may involve significant I/O for
+/// large, fragmented collections.
+#[utoipa::path(
+    post,
+    path = "/collections/{name}/compact",
+    tag = "collections",
+    params(
+        ("name" = String, Path, description = "Collection name")
+    ),
+    responses(
+        (status = 200, description = "Storage compacted", body = Object),
+        (status = 404, description = "Collection not found", body = ErrorResponse),
+        (status = 500, description = "Compaction failed", body = ErrorResponse)
+    )
+)]
+pub async fn compact_collection(
+    State(state): State<Arc<AppState>>,
+    Path(name): Path<String>,
+) -> impl IntoResponse {
+    let collection = match get_vector_collection_or_404(&state, &name) {
+        Ok(c) => c,
+        Err(resp) => return resp,
+    };
+
+    let result = tokio::task::spawn_blocking(move || collection.compact_storage()).await;
+    match result {
+        Ok(Ok(bytes_reclaimed)) => (
+            StatusCode::OK,
+            Json(serde_json::json!({
+                "message": "Storage compacted",
+                "collection": name,
+                "bytes_reclaimed": bytes_reclaimed
+            })),
+        )
+            .into_response(),
+        Ok(Err(e)) => auto_core_error_response(&e),
+        Err(join_err) => error_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("compact task panicked: {join_err}"),
+        ),
+    }
+}
+
 /// Analyze a collection, computing and persisting statistics.
 #[utoipa::path(
     post,

--- a/crates/velesdb-server/src/handlers/metrics.rs
+++ b/crates/velesdb-server/src/handlers/metrics.rs
@@ -57,6 +57,10 @@ pub async fn prometheus_metrics(State(state): State<Arc<AppState>>) -> impl Into
 }
 
 /// Writes all Prometheus metrics to the output buffer.
+///
+/// Aggregates server-level metrics (info, uptime, plan cache) with
+/// core operational metrics (query throughput, connections, guardrails,
+/// traversal stats, query duration histogram).
 fn write_metrics(output: &mut String, state: &AppState) -> std::fmt::Result {
     writeln!(output, "# VelesDB Prometheus Metrics")?;
     writeln!(output)?;
@@ -66,7 +70,25 @@ fn write_metrics(output: &mut String, state: &AppState) -> std::fmt::Result {
 
     let cache_metrics = state.db.plan_cache().metrics();
     let cache_stats = state.db.plan_cache().stats();
-    write_cache_metrics(output, cache_metrics, &cache_stats)
+    write_cache_metrics(output, cache_metrics, &cache_stats)?;
+
+    // Core operational metrics: query throughput, connections, doc counts.
+    output.push_str(&state.operational_metrics.export_prometheus());
+
+    // Guard-rails metrics: rate limiting, resource limits, error counters.
+    // Uses the process-wide singleton (OnceLock) — always available.
+    output.push_str(&velesdb_core::metrics::global_guardrails_metrics().export_prometheus());
+
+    // Graph traversal metrics: nodes visited, depth, edges scanned.
+    output.push_str(&state.traversal_metrics.export_prometheus());
+
+    // Query duration histogram (8-bucket + sum + count).
+    output.push_str(&state.query_duration_histogram.export_prometheus(
+        "velesdb_query_duration_seconds",
+        "Query execution duration in seconds",
+    ));
+
+    Ok(())
 }
 
 /// Writes server version info metric.
@@ -200,6 +222,11 @@ mod tests {
             onboarding_metrics: OnboardingMetrics::default(),
             query_limits: parking_lot::RwLock::new(velesdb_core::guardrails::QueryLimits::default()),
             ready: std::sync::atomic::AtomicBool::new(true),
+            operational_metrics: velesdb_core::metrics::OperationalMetrics::shared(),
+            traversal_metrics: std::sync::Arc::new(velesdb_core::metrics::TraversalMetrics::new()),
+            query_duration_histogram: std::sync::Arc::new(
+                velesdb_core::metrics::DurationHistogram::new(),
+            ),
         })
     }
 

--- a/crates/velesdb-server/src/handlers/metrics.rs
+++ b/crates/velesdb-server/src/handlers/metrics.rs
@@ -222,7 +222,7 @@ mod tests {
             onboarding_metrics: OnboardingMetrics::default(),
             query_limits: parking_lot::RwLock::new(velesdb_core::guardrails::QueryLimits::default()),
             ready: std::sync::atomic::AtomicBool::new(true),
-            operational_metrics: velesdb_core::metrics::OperationalMetrics::shared(),
+            operational_metrics: velesdb_core::metrics::OperationalMetrics::new_arc(),
             traversal_metrics: std::sync::Arc::new(velesdb_core::metrics::TraversalMetrics::new()),
             query_duration_histogram: std::sync::Arc::new(
                 velesdb_core::metrics::DurationHistogram::new(),

--- a/crates/velesdb-server/src/handlers/mod.rs
+++ b/crates/velesdb-server/src/handlers/mod.rs
@@ -26,8 +26,8 @@ pub mod search;
 pub mod metrics;
 
 pub use admin::{
-    analyze_collection, get_collection_config, get_collection_stats, get_guardrails, rebuild_index,
-    update_guardrails,
+    analyze_collection, compact_collection, get_collection_config, get_collection_stats,
+    get_guardrails, rebuild_index, update_guardrails, vacuum_collection,
 };
 pub use collections::{
     collection_sanity, create_collection, delete_collection, flush_collection, get_collection,
@@ -36,7 +36,8 @@ pub use collections::{
 pub use health::{health_check, readiness_check};
 pub use indexes::{create_index, delete_index, list_indexes};
 pub use points::{
-    delete_point, get_point, scroll_points, stream_insert, stream_upsert_points, upsert_points,
+    bulk_delete_points, delete_point, get_point, scroll_points, stream_insert,
+    stream_upsert_points, upsert_points,
 };
 // EPIC-058 US-007: match_query handler for /collections/{name}/match
 pub use match_query::match_query;

--- a/crates/velesdb-server/src/handlers/points/mod.rs
+++ b/crates/velesdb-server/src/handlers/points/mod.rs
@@ -313,7 +313,19 @@ pub struct BulkDeleteRequest {
 /// more efficient than individual deletions.
 ///
 /// Returns the number of points that were requested for deletion.
-/// Points that do not exist are silently skipped.
+/// Points that do not exist are silently skipped (idempotent delete).
+///
+/// # Empty payload semantics
+///
+/// `{ "ids": [] }` is treated as a successful no-op: the response is
+/// `200 OK` with `deleted_count = 0`. This matches Kubernetes-style
+/// idempotent batch APIs and lets callers send empty batches without
+/// special-casing on the client side.
+///
+/// # Limits
+///
+/// Batches larger than `MAX_BULK_DELETE_SIZE` (10000) are rejected with
+/// `400 BAD_REQUEST`.
 #[utoipa::path(
     post,
     path = "/collections/{name}/points/delete",

--- a/crates/velesdb-server/src/handlers/points/mod.rs
+++ b/crates/velesdb-server/src/handlers/points/mod.rs
@@ -295,3 +295,85 @@ fn build_scroll_response(batch: velesdb_core::ScrollBatch) -> axum::response::Re
     })
     .into_response()
 }
+
+/// Maximum number of IDs in a single bulk delete request.
+const MAX_BULK_DELETE_SIZE: usize = 10_000;
+
+/// Request body for bulk point deletion.
+#[derive(serde::Deserialize, utoipa::ToSchema)]
+pub struct BulkDeleteRequest {
+    /// List of point IDs to delete.
+    pub ids: Vec<u64>,
+}
+
+/// Deletes multiple points by ID in a single request.
+///
+/// Accepts a JSON body with a list of point IDs. All IDs are passed to
+/// the underlying `Collection::delete(&[u64])` in one call, which is
+/// more efficient than individual deletions.
+///
+/// Returns the number of points that were requested for deletion.
+/// Points that do not exist are silently skipped.
+#[utoipa::path(
+    post,
+    path = "/collections/{name}/points/delete",
+    tag = "points",
+    params(
+        ("name" = String, Path, description = "Collection name")
+    ),
+    request_body = BulkDeleteRequest,
+    responses(
+        (status = 200, description = "Points deleted", body = Object),
+        (status = 400, description = "Batch too large", body = ErrorResponse),
+        (status = 404, description = "Collection not found", body = ErrorResponse),
+        (status = 500, description = "Delete failed", body = ErrorResponse)
+    )
+)]
+pub async fn bulk_delete_points(
+    State(state): State<Arc<AppState>>,
+    Path(name): Path<String>,
+    Json(req): Json<BulkDeleteRequest>,
+) -> impl IntoResponse {
+    if req.ids.is_empty() {
+        return Json(serde_json::json!({
+            "message": "No points to delete",
+            "collection": name,
+            "deleted_count": 0
+        }))
+        .into_response();
+    }
+
+    if req.ids.len() > MAX_BULK_DELETE_SIZE {
+        return error_response(
+            StatusCode::BAD_REQUEST,
+            format!(
+                "Batch too large: {} IDs (max {MAX_BULK_DELETE_SIZE})",
+                req.ids.len()
+            ),
+        );
+    }
+
+    let collection = match get_vector_collection_or_404(&state, &name) {
+        Ok(c) => c,
+        Err(resp) => return resp,
+    };
+
+    let ids = req.ids;
+    let count = ids.len();
+    let coll_name = name.clone();
+
+    let result = tokio::task::spawn_blocking(move || collection.delete(&ids)).await;
+    match result {
+        Ok(Ok(())) => Json(serde_json::json!({
+            "message": "Points deleted",
+            "collection": coll_name,
+            "deleted_count": count
+        }))
+        .into_response(),
+        Ok(Err(e)) => auto_core_error_response(&e),
+        Err(join_err) => error_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("bulk_delete task panicked: {join_err}"),
+        ),
+    }
+}

--- a/crates/velesdb-server/src/handlers/query/aggregation.rs
+++ b/crates/velesdb-server/src/handlers/query/aggregation.rs
@@ -62,24 +62,30 @@ pub(crate) fn execute_aggregation_query(
     } else if let Some(any) = state.db.get_any_collection(collection_name) {
         any.execute_aggregate(parsed, params)
     } else {
+        state.operational_metrics.inc_errors();
         return velesql_collection_not_found(collection_name);
     };
 
     let result = match result {
         Ok(r) => r,
         Err(e) => {
+            state.operational_metrics.inc_errors();
             return velesql_error(
                 StatusCode::UNPROCESSABLE_ENTITY,
                 "VELESQL_AGGREGATION_ERROR",
                 &e.to_string(),
                 "Verify GROUP BY/HAVING clauses and aggregate function arguments",
                 None,
-            )
+            );
         }
     };
 
-    let timing_ms = start.elapsed().as_secs_f64() * 1000.0;
+    let elapsed = start.elapsed();
+    let timing_ms = elapsed.as_secs_f64() * 1000.0;
     notify_query_timing(state, collection_name, start);
+    state
+        .query_duration_histogram
+        .observe(elapsed.as_secs_f64());
     let count = aggregation_result_count(&result);
 
     Json(AggregationResponse {
@@ -141,13 +147,18 @@ pub async fn aggregate(
     Json(req): Json<QueryRequest>,
 ) -> impl IntoResponse {
     let start = std::time::Instant::now();
+    state.operational_metrics.inc_queries();
 
     let parsed = match parse_and_validate(&req.query) {
         Ok(q) => q,
-        Err(resp) => return resp,
+        Err(resp) => {
+            state.operational_metrics.inc_errors();
+            return resp;
+        }
     };
 
     if parsed.is_match_query() || !is_aggregation_query(&parsed.select) {
+        state.operational_metrics.inc_errors();
         return velesql_error(
             StatusCode::UNPROCESSABLE_ENTITY,
             "VELESQL_AGGREGATION_ERROR",
@@ -160,7 +171,10 @@ pub async fn aggregate(
     let collection_name = resolve_aggregate_collection(&parsed, &req);
     let collection_name = match collection_name {
         Ok(name) => name,
-        Err(resp) => return resp,
+        Err(resp) => {
+            state.operational_metrics.inc_errors();
+            return resp;
+        }
     };
 
     execute_aggregation_query(&state, &collection_name, &parsed, &req.params, start)

--- a/crates/velesdb-server/src/handlers/query/mod.rs
+++ b/crates/velesdb-server/src/handlers/query/mod.rs
@@ -83,10 +83,14 @@ pub async fn query(
     Json(req): Json<QueryRequest>,
 ) -> impl IntoResponse {
     let start = std::time::Instant::now();
+    state.operational_metrics.inc_queries();
 
     let parsed = match parse_and_validate(&req.query) {
         Ok(q) => q,
-        Err(resp) => return resp,
+        Err(resp) => {
+            state.operational_metrics.inc_errors();
+            return resp;
+        }
     };
 
     // DDL/Introspection/Admin/graph-mutation bypass: these extract collection from
@@ -98,7 +102,10 @@ pub async fn query(
 
     let collection_name = match resolve_collection_name(&parsed, &req) {
         Ok(name) => name,
-        Err(resp) => return resp,
+        Err(resp) => {
+            state.operational_metrics.inc_errors();
+            return resp;
+        }
     };
 
     // BUG-1 FIX: Detect aggregation queries and route to execute_aggregate
@@ -108,7 +115,10 @@ pub async fn query(
 
     let results = match execute_standard_query(&state, &parsed, &collection_name, &req) {
         Ok(r) => r,
-        Err(resp) => return resp,
+        Err(resp) => {
+            state.operational_metrics.inc_errors();
+            return resp;
+        }
     };
 
     build_query_response(
@@ -246,10 +256,14 @@ fn execute_mutation_query(
         Ok(results) => {
             let coll_name = extract_mutation_collection_name(parsed);
             notify_query_timing(state, &coll_name, start);
-            let timing_ms = start.elapsed().as_secs_f64() * 1000.0;
+            let elapsed = start.elapsed();
+            let timing_ms = elapsed.as_secs_f64() * 1000.0;
             #[allow(clippy::cast_possible_truncation)]
             // Reason: timing_ms is always < u64::MAX (query durations < 585 millennia)
             let took_ms = timing_ms.round() as u64;
+            state
+                .query_duration_histogram
+                .observe(elapsed.as_secs_f64());
             let projected = projection::project_results(&results, &parsed.select.columns);
             let rows_returned = projected.len();
             Json(QueryResponse {
@@ -264,13 +278,16 @@ fn execute_mutation_query(
             })
             .into_response()
         }
-        Err(e) => velesql_error(
-            StatusCode::UNPROCESSABLE_ENTITY,
-            "VELESQL_MUTATION_ERROR",
-            &e.to_string(),
-            "Check collection name, statement syntax, and target existence",
-            None,
-        ),
+        Err(e) => {
+            state.operational_metrics.inc_errors();
+            velesql_error(
+                StatusCode::UNPROCESSABLE_ENTITY,
+                "VELESQL_MUTATION_ERROR",
+                &e.to_string(),
+                "Check collection name, statement syntax, and target existence",
+                None,
+            )
+        }
     }
 }
 
@@ -349,11 +366,15 @@ fn build_query_response(
     results: Vec<velesdb_core::SearchResult>,
     select_columns: &SelectColumns,
 ) -> axum::response::Response {
-    let timing_ms = start.elapsed().as_secs_f64() * 1000.0;
+    let elapsed = start.elapsed();
+    let timing_ms = elapsed.as_secs_f64() * 1000.0;
     #[allow(clippy::cast_possible_truncation)]
     // Reason: timing_ms is always < u64::MAX (query durations < 585 millennia)
     let took_ms = timing_ms.round() as u64;
     notify_query_timing(state, collection_name, start);
+    state
+        .query_duration_histogram
+        .observe(elapsed.as_secs_f64());
     let projected = projection::project_results(&results, select_columns);
     let rows_returned = projected.len();
 

--- a/crates/velesdb-server/src/handlers/search/batch.rs
+++ b/crates/velesdb-server/src/handlers/search/batch.rs
@@ -48,18 +48,27 @@ pub async fn batch_search(
         Err(resp) => return resp,
     };
 
+    // Record query type only after confirming the collection exists, so
+    // 404s do not inflate queries_total or vector_queries.
+    state.operational_metrics.record_vector_query();
+
     let client_id = extract_client_id(&headers);
     if let Err(resp) = apply_pre_check(collection.guard_rails(), &client_id) {
+        state.operational_metrics.inc_rate_limited();
         return resp;
     }
 
     if let Err(resp) = validate_batch_dimensions(&state, &name, &collection, &req) {
+        state.operational_metrics.inc_errors();
         return resp;
     }
 
     let filters = match parse_batch_filters(&state, &req) {
         Ok(f) => f,
-        Err(resp) => return resp,
+        Err(resp) => {
+            state.operational_metrics.inc_errors();
+            return resp;
+        }
     };
 
     let queries: Vec<&[f32]> = req.searches.iter().map(|s| s.vector.as_slice()).collect();
@@ -71,12 +80,17 @@ pub async fn batch_search(
     let all_results = match batch_result {
         Ok(batch_results) => build_batch_responses(&state, batch_results, &req),
         Err(e) => {
+            state.operational_metrics.inc_errors();
             return (StatusCode::BAD_REQUEST, Json(actionable_search_error(&e))).into_response();
         }
     };
 
-    let timing_ms = start.elapsed().as_secs_f64() * 1000.0;
+    let elapsed = start.elapsed();
+    let timing_ms = elapsed.as_secs_f64() * 1000.0;
     notify_query_timing(&state, &name, start);
+    state
+        .query_duration_histogram
+        .observe(elapsed.as_secs_f64());
 
     Json(BatchSearchResponse {
         results: all_results,

--- a/crates/velesdb-server/src/handlers/search/mod.rs
+++ b/crates/velesdb-server/src/handlers/search/mod.rs
@@ -33,20 +33,24 @@ pub use batch::batch_search;
 pub use multi::__path_multi_query_search;
 pub use multi::multi_query_search;
 
-/// Shared search preamble: record metric, resolve collection, check guard rails.
+/// Shared search preamble: record onboarding metric and resolve collection.
+///
+/// Does NOT check guard rails — each handler inlines `apply_pre_check`
+/// after recording its query-type counter so that rate-limited requests
+/// are visible in metrics with `status="rate_limited"`.
+///
+/// Does NOT record the query-type counter (vector / hybrid / text) — each
+/// handler calls the appropriate `record_*_query()` method itself so that
+/// BM25 text searches are not miscounted as vector queries.
 ///
 /// Returns `Ok(collection)` or `Err(response)` on failure.
 #[allow(clippy::result_large_err)]
 fn search_preamble(
     state: &AppState,
     name: &str,
-    headers: &axum::http::HeaderMap,
 ) -> Result<VectorCollection, axum::response::Response> {
     state.onboarding_metrics.record_search_request();
-    let collection = get_vector_collection_or_404(state, name)?;
-    let client_id = extract_client_id(headers);
-    apply_pre_check(collection.guard_rails(), &client_id)?;
-    Ok(collection)
+    get_vector_collection_or_404(state, name)
 }
 
 /// Executes the full search pipeline and records circuit-breaker on failure.
@@ -93,10 +97,17 @@ pub async fn search(
 ) -> impl IntoResponse {
     let start = std::time::Instant::now();
 
-    let collection = match search_preamble(&state, &name, &headers) {
+    let collection = match search_preamble(&state, &name) {
         Ok(c) => c,
         Err(resp) => return resp,
     };
+    state.operational_metrics.record_vector_query();
+
+    let client_id = extract_client_id(&headers);
+    if let Err(resp) = apply_pre_check(collection.guard_rails(), &client_id) {
+        state.operational_metrics.inc_rate_limited();
+        return resp;
+    }
 
     // F-03: honour the per-request `timeout_ms` budget. The synchronous
     // search runs on a blocking worker so the async runtime stays
@@ -120,8 +131,12 @@ pub async fn search(
 
     let search_result = match execution {
         Ok(Ok(inner)) => inner,
-        Ok(Err(resp)) => return resp,
+        Ok(Err(resp)) => {
+            state.operational_metrics.inc_errors();
+            return resp;
+        }
         Err(workers::TimeoutElapsed) => {
+            state.operational_metrics.inc_errors();
             // Timeout elapsed: record the circuit-breaker failure and
             // return a 408 with the budget echoed back to the caller.
             collection.guard_rails().circuit_breaker.record_failure();
@@ -168,10 +183,18 @@ pub async fn text_search(
     Path(name): Path<String>,
     Json(req): Json<TextSearchRequest>,
 ) -> impl IntoResponse {
-    let collection = match search_preamble(&state, &name, &headers) {
+    let collection = match search_preamble(&state, &name) {
         Ok(c) => c,
         Err(resp) => return resp,
     };
+    // BM25 text search is not a vector query — only count in queries_total.
+    state.operational_metrics.inc_queries();
+
+    let client_id = extract_client_id(&headers);
+    if let Err(resp) = apply_pre_check(collection.guard_rails(), &client_id) {
+        state.operational_metrics.inc_rate_limited();
+        return resp;
+    }
 
     let start = std::time::Instant::now();
 
@@ -202,7 +225,10 @@ pub async fn text_search(
 
     let search_result = match work_result {
         Ok(inner) => inner,
-        Err(resp) => return resp,
+        Err(resp) => {
+            state.operational_metrics.inc_errors();
+            return resp;
+        }
     };
 
     finish_search_with_status(
@@ -237,15 +263,23 @@ pub async fn hybrid_search(
     Path(name): Path<String>,
     Json(req): Json<HybridSearchRequest>,
 ) -> impl IntoResponse {
-    let collection = match search_preamble(&state, &name, &headers) {
+    let collection = match search_preamble(&state, &name) {
         Ok(c) => c,
         Err(resp) => return resp,
     };
+    state.operational_metrics.record_hybrid_query();
+
+    let client_id = extract_client_id(&headers);
+    if let Err(resp) = apply_pre_check(collection.guard_rails(), &client_id) {
+        state.operational_metrics.inc_rate_limited();
+        return resp;
+    }
 
     let start = std::time::Instant::now();
 
     let expected_dimension = collection.config().dimension;
     if let Err(error) = validate_query_dimension(&state, &name, expected_dimension, &req.vector) {
+        state.operational_metrics.inc_errors();
         return (StatusCode::BAD_REQUEST, Json(error)).into_response();
     }
 
@@ -287,7 +321,10 @@ pub async fn hybrid_search(
 
     let search_result = match work_result {
         Ok(inner) => inner,
-        Err(resp) => return resp,
+        Err(resp) => {
+            state.operational_metrics.inc_errors();
+            return resp;
+        }
     };
 
     finish_search_with_cb(&state, &name, start, &collection, search_result)
@@ -321,10 +358,17 @@ pub async fn search_ids(
 ) -> impl IntoResponse {
     let start = std::time::Instant::now();
 
-    let collection = match search_preamble(&state, &name, &headers) {
+    let collection = match search_preamble(&state, &name) {
         Ok(c) => c,
         Err(resp) => return resp,
     };
+    state.operational_metrics.record_vector_query();
+
+    let client_id = extract_client_id(&headers);
+    if let Err(resp) = apply_pre_check(collection.guard_rails(), &client_id) {
+        state.operational_metrics.inc_rate_limited();
+        return resp;
+    }
 
     // F-03: honour the per-request `timeout_ms` budget and run the
     // CPU-bound search on a blocking worker so the async runtime stays
@@ -348,8 +392,12 @@ pub async fn search_ids(
 
     let search_result = match execution {
         Ok(Ok(inner)) => inner,
-        Ok(Err(resp)) => return resp,
+        Ok(Err(resp)) => {
+            state.operational_metrics.inc_errors();
+            return resp;
+        }
         Err(workers::TimeoutElapsed) => {
+            state.operational_metrics.inc_errors();
             collection.guard_rails().circuit_breaker.record_failure();
             let ms = timeout_ms.unwrap_or_default();
             return timeout_response(&name, ms);

--- a/crates/velesdb-server/src/handlers/search/multi.rs
+++ b/crates/velesdb-server/src/handlers/search/multi.rs
@@ -44,8 +44,13 @@ pub async fn multi_query_search(
             Err(resp) => return resp,
         };
 
+    // Record query type only after confirming the collection exists, so
+    // 404s do not inflate queries_total or vector_queries.
+    state.operational_metrics.record_vector_query();
+
     let client_id = extract_client_id(&headers);
     if let Err(resp) = apply_pre_check(collection.guard_rails(), &client_id) {
+        state.operational_metrics.inc_rate_limited();
         return resp;
     }
 
@@ -63,6 +68,7 @@ pub async fn multi_query_search(
             sparse_weight: req.sparse_weight,
         },
         _ => {
+            state.operational_metrics.inc_errors();
             return (
                 StatusCode::BAD_REQUEST,
                 Json(ErrorResponse {
@@ -74,13 +80,14 @@ pub async fn multi_query_search(
                     code: None,
                 }),
             )
-                .into_response()
+                .into_response();
         }
     };
 
     let expected_dimension = collection.config().dimension;
     for (idx, vector) in req.vectors.iter().enumerate() {
         if let Err(error) = validate_query_dimension(&state, &name, expected_dimension, vector) {
+            state.operational_metrics.inc_errors();
             return (
                 StatusCode::BAD_REQUEST,
                 Json(ErrorResponse {
@@ -102,7 +109,10 @@ pub async fn multi_query_search(
     let filter = match req.filter.as_ref() {
         Some(filter_json) => match parse_filter_or_400(filter_json, &state.onboarding_metrics) {
             Ok(f) => Some(f),
-            Err(resp) => return resp,
+            Err(resp) => {
+                state.operational_metrics.inc_errors();
+                return resp;
+            }
         },
         None => None,
     };
@@ -128,7 +138,10 @@ pub async fn multi_query_search(
 
     let search_result = match work_result {
         Ok(inner) => inner,
-        Err(resp) => return resp,
+        Err(resp) => {
+            state.operational_metrics.inc_errors();
+            return resp;
+        }
     };
 
     finish_search_with_cb(&state, &name, start, &collection, search_result)

--- a/crates/velesdb-server/src/handlers/search/pipeline.rs
+++ b/crates/velesdb-server/src/handlers/search/pipeline.rs
@@ -367,12 +367,17 @@ fn record_search_metrics(state: &AppState, name: &str, start: std::time::Instant
     if is_empty {
         state.onboarding_metrics.record_empty_search_results();
     }
-    let duration_us = start.elapsed().as_micros();
+    let elapsed = start.elapsed();
+    let duration_us = elapsed.as_micros();
     #[allow(clippy::cast_possible_truncation)]
     // Reason: value is clamped to u64::MAX above, so the truncation is lossless.
     state
         .db
         .notify_query(name, duration_us.min(u128::from(u64::MAX)) as u64);
+    // Record into Prometheus histogram (seconds).
+    state
+        .query_duration_histogram
+        .observe(elapsed.as_secs_f64());
 }
 
 /// Core search result handler: records metrics, delegates success to `on_ok`,
@@ -390,7 +395,10 @@ fn finish_search_core(
             record_search_metrics(state, name, start, results.is_empty());
             on_ok(results)
         }
-        Err(e) => (error_status, Json(actionable_search_error(&e))).into_response(),
+        Err(e) => {
+            state.operational_metrics.inc_errors();
+            (error_status, Json(actionable_search_error(&e))).into_response()
+        }
     }
 }
 

--- a/crates/velesdb-server/src/lib.rs
+++ b/crates/velesdb-server/src/lib.rs
@@ -45,20 +45,23 @@ mod types;
 
 use security_addon::SecurityAddon;
 use std::sync::atomic::AtomicBool;
+use std::sync::Arc;
 use utoipa::OpenApi;
 use velesdb_core::guardrails::QueryLimits;
+use velesdb_core::metrics::{DurationHistogram, OperationalMetrics, TraversalMetrics};
 use velesdb_core::Database;
 
 pub use onboarding::OnboardingMetrics;
 pub use types::*;
 
 pub use handlers::{
-    aggregate, analyze_collection, batch_search, collection_sanity, create_collection,
-    create_index, delete_collection, delete_index, delete_point, explain, flush_collection,
-    get_collection, get_collection_config, get_collection_stats, get_guardrails, get_point,
-    health_check, hybrid_search, is_empty, list_collections, list_indexes, match_query,
-    multi_query_search, query, readiness_check, rebuild_index, scroll_points, search, search_ids,
-    stream_insert, stream_upsert_points, text_search, update_guardrails, upsert_points,
+    aggregate, analyze_collection, batch_search, bulk_delete_points, collection_sanity,
+    compact_collection, create_collection, create_index, delete_collection, delete_index,
+    delete_point, explain, flush_collection, get_collection, get_collection_config,
+    get_collection_stats, get_guardrails, get_point, health_check, hybrid_search, is_empty,
+    list_collections, list_indexes, match_query, multi_query_search, query, readiness_check,
+    rebuild_index, scroll_points, search, search_ids, stream_insert, stream_upsert_points,
+    text_search, update_guardrails, upsert_points, vacuum_collection,
 };
 
 pub use handlers::graph::{
@@ -153,7 +156,11 @@ pub use handlers::metrics::{health_metrics, prometheus_metrics};
         handlers::graph::handlers::get_node_degree,
         handlers::graph::handlers_extended::graph_search,
         handlers::graph::stream::stream_traverse,
-        handlers::match_query::match_query
+        handlers::match_query::match_query,
+        handlers::admin::rebuild_index,
+        handlers::admin::vacuum_collection,
+        handlers::admin::compact_collection,
+        handlers::points::bulk_delete_points
     ),
     components(
         schemas(
@@ -223,7 +230,8 @@ pub use handlers::metrics::{health_metrics, prometheus_metrics};
             handlers::match_query::MatchQueryResponse,
             handlers::match_query::MatchQueryResultItem,
             handlers::match_query::MatchQueryMeta,
-            handlers::match_query::MatchQueryError
+            handlers::match_query::MatchQueryError,
+            handlers::points::BulkDeleteRequest
         )
     )
 )]
@@ -242,6 +250,12 @@ pub struct AppState {
     pub query_limits: parking_lot::RwLock<QueryLimits>,
     /// Readiness flag — `true` once the database is fully loaded.
     pub ready: AtomicBool,
+    /// Operational metrics: query throughput, connections, doc counts (EPIC-050).
+    pub operational_metrics: Arc<OperationalMetrics>,
+    /// Graph traversal metrics: nodes visited, depth, edges scanned.
+    pub traversal_metrics: Arc<TraversalMetrics>,
+    /// Query duration histogram for Prometheus export.
+    pub query_duration_histogram: Arc<DurationHistogram>,
 }
 
 // ============================================================================
@@ -605,6 +619,9 @@ mod tests {
             onboarding_metrics: OnboardingMetrics::default(),
             query_limits: parking_lot::RwLock::new(QueryLimits::default()),
             ready: AtomicBool::new(true),
+            operational_metrics: velesdb_core::metrics::OperationalMetrics::shared(),
+            traversal_metrics: Arc::new(velesdb_core::metrics::TraversalMetrics::new()),
+            query_duration_histogram: Arc::new(velesdb_core::metrics::DurationHistogram::new()),
         });
         (state, dir)
     }

--- a/crates/velesdb-server/src/lib.rs
+++ b/crates/velesdb-server/src/lib.rs
@@ -619,7 +619,7 @@ mod tests {
             onboarding_metrics: OnboardingMetrics::default(),
             query_limits: parking_lot::RwLock::new(QueryLimits::default()),
             ready: AtomicBool::new(true),
-            operational_metrics: velesdb_core::metrics::OperationalMetrics::shared(),
+            operational_metrics: velesdb_core::metrics::OperationalMetrics::new_arc(),
             traversal_metrics: Arc::new(velesdb_core::metrics::TraversalMetrics::new()),
             query_duration_histogram: Arc::new(velesdb_core::metrics::DurationHistogram::new()),
         });

--- a/crates/velesdb-server/src/main.rs
+++ b/crates/velesdb-server/src/main.rs
@@ -113,7 +113,7 @@ fn init_app_state(data_dir: &str) -> anyhow::Result<Arc<AppState>> {
         onboarding_metrics: OnboardingMetrics::default(),
         query_limits: parking_lot::RwLock::new(velesdb_core::guardrails::QueryLimits::default()),
         ready: std::sync::atomic::AtomicBool::new(false),
-        operational_metrics: velesdb_core::metrics::OperationalMetrics::shared(),
+        operational_metrics: velesdb_core::metrics::OperationalMetrics::new_arc(),
         traversal_metrics: std::sync::Arc::new(velesdb_core::metrics::TraversalMetrics::new()),
         query_duration_histogram: std::sync::Arc::new(
             velesdb_core::metrics::DurationHistogram::new(),

--- a/crates/velesdb-server/src/main.rs
+++ b/crates/velesdb-server/src/main.rs
@@ -113,6 +113,11 @@ fn init_app_state(data_dir: &str) -> anyhow::Result<Arc<AppState>> {
         onboarding_metrics: OnboardingMetrics::default(),
         query_limits: parking_lot::RwLock::new(velesdb_core::guardrails::QueryLimits::default()),
         ready: std::sync::atomic::AtomicBool::new(false),
+        operational_metrics: velesdb_core::metrics::OperationalMetrics::shared(),
+        traversal_metrics: std::sync::Arc::new(velesdb_core::metrics::TraversalMetrics::new()),
+        query_duration_histogram: std::sync::Arc::new(
+            velesdb_core::metrics::DurationHistogram::new(),
+        ),
     });
     // Database loaded successfully — mark server as ready
     state

--- a/crates/velesdb-server/src/routes.rs
+++ b/crates/velesdb-server/src/routes.rs
@@ -12,14 +12,15 @@ use axum::{
 };
 
 use crate::{
-    add_edge, aggregate, analyze_collection, batch_search, collection_sanity, create_collection,
-    create_index, delete_collection, delete_index, delete_point, explain, flush_collection,
-    get_collection, get_collection_config, get_collection_stats, get_edge_count, get_edges,
-    get_guardrails, get_node_degree, get_node_edges, get_node_payload, get_point, graph_search,
-    health_check, hybrid_search, is_empty, list_collections, list_indexes, list_nodes, match_query,
-    multi_query_search, query, readiness_check, rebuild_index, remove_edge, scroll_points, search,
-    search_ids, stream_insert, stream_traverse, stream_upsert_points, text_search, traverse_graph,
-    traverse_parallel, update_guardrails, upsert_node_payload, upsert_points, AppState,
+    add_edge, aggregate, analyze_collection, batch_search, bulk_delete_points, collection_sanity,
+    compact_collection, create_collection, create_index, delete_collection, delete_index,
+    delete_point, explain, flush_collection, get_collection, get_collection_config,
+    get_collection_stats, get_edge_count, get_edges, get_guardrails, get_node_degree,
+    get_node_edges, get_node_payload, get_point, graph_search, health_check, hybrid_search,
+    is_empty, list_collections, list_indexes, list_nodes, match_query, multi_query_search, query,
+    readiness_check, rebuild_index, remove_edge, scroll_points, search, search_ids, stream_insert,
+    stream_traverse, stream_upsert_points, text_search, traverse_graph, traverse_parallel,
+    update_guardrails, upsert_node_payload, upsert_points, vacuum_collection, AppState,
 };
 
 /// Core CRUD and admin routes.
@@ -60,6 +61,14 @@ fn core_routes() -> Router<Arc<AppState>> {
             get(get_point).delete(delete_point),
         )
         .route("/collections/{name}/points/scroll", post(scroll_points))
+        // Bulk operations
+        .route(
+            "/collections/{name}/points/delete",
+            post(bulk_delete_points),
+        )
+        // Maintenance endpoints
+        .route("/collections/{name}/vacuum", post(vacuum_collection))
+        .route("/collections/{name}/compact", post(compact_collection))
 }
 
 /// Search, text, hybrid, and index routes.

--- a/crates/velesdb-server/tests/admin_endpoints_bdd_tests.rs
+++ b/crates/velesdb-server/tests/admin_endpoints_bdd_tests.rs
@@ -1,0 +1,436 @@
+#![allow(clippy::doc_markdown)]
+//! BDD tests for the maintenance and bulk-ops endpoints introduced in
+//! PR #648:
+//!
+//! - `POST /collections/{name}/points/delete` — bulk delete by id
+//! - `POST /collections/{name}/vacuum`         — HNSW index vacuum
+//! - `POST /collections/{name}/compact`        — storage compaction
+//!
+//! Coverage per `.claude/rules/bdd-testing.md`:
+//! - Nominal (~60%): happy paths, end-to-end behaviour observable from
+//!   the REST surface.
+//! - Edge (~20%): boundary conditions (empty payload, max-batch size,
+//!   collection with no deletions to compact).
+//! - Negative (~20%): unknown collection, oversized batch, malformed
+//!   JSON. Each must produce the documented HTTP status code.
+//!
+//! Tests build a router via `common::create_test_app` and exercise the
+//! endpoints with `tower::ServiceExt::oneshot` requests, asserting
+//! status codes and JSON response shape — no internal state inspection.
+
+mod common;
+
+use axum::{
+    body::Body,
+    http::{Request, StatusCode},
+};
+use common::create_test_app;
+use serde_json::{json, Value};
+use tempfile::TempDir;
+use tower::ServiceExt;
+
+const TEST_COLLECTION: &str = "admin_endpoints_bdd";
+const DIM: usize = 4;
+
+/// Bootstrap a vector collection and seed it with `n` deterministic points.
+async fn seed_collection(app: axum::Router, n: usize) {
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/collections")
+                .header("Content-Type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "name": TEST_COLLECTION,
+                        "dimension": DIM,
+                        "metric": "cosine"
+                    })
+                    .to_string(),
+                ))
+                .expect("test: build create request"),
+        )
+        .await
+        .expect("test: collection create request");
+    assert_eq!(
+        response.status(),
+        StatusCode::CREATED,
+        "test setup: failed to create collection"
+    );
+
+    if n == 0 {
+        return;
+    }
+    let points: Vec<Value> = (0..n)
+        .map(|i| {
+            #[allow(clippy::cast_precision_loss)]
+            let v = (i as f32) / 100.0;
+            json!({
+                "id": u64::try_from(i).expect("test: idx fits in u64") + 1,
+                "vector": vec![v; DIM],
+                "payload": { "idx": i }
+            })
+        })
+        .collect();
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/collections/{TEST_COLLECTION}/points"))
+                .header("Content-Type", "application/json")
+                .body(Body::from(json!({ "points": points }).to_string()))
+                .expect("test: build upsert request"),
+        )
+        .await
+        .expect("test: upsert request");
+    assert_eq!(
+        response.status(),
+        StatusCode::OK,
+        "test setup: failed to seed points"
+    );
+}
+
+async fn read_json(response: axum::response::Response) -> Value {
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("test: read body");
+    serde_json::from_slice(&body).expect("test: response is valid JSON")
+}
+
+// ---------------------------------------------------------------------
+// /points/delete — bulk_delete_points
+// ---------------------------------------------------------------------
+
+#[tokio::test]
+async fn bulk_delete_nominal_returns_200_with_deleted_count() {
+    let temp_dir = TempDir::new().expect("test: temp dir");
+    let app = create_test_app(&temp_dir);
+    seed_collection(app.clone(), 5).await;
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/collections/{TEST_COLLECTION}/points/delete"))
+                .header("Content-Type", "application/json")
+                .body(Body::from(json!({ "ids": [1, 2, 3] }).to_string()))
+                .expect("test: build delete request"),
+        )
+        .await
+        .expect("test: delete request");
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let json = read_json(response).await;
+    assert_eq!(json["deleted_count"], 3);
+    assert_eq!(json["collection"], TEST_COLLECTION);
+}
+
+#[tokio::test]
+async fn bulk_delete_empty_payload_returns_200_noop() {
+    // Documented behaviour: empty `ids: []` is a no-op (200, count=0).
+    // See `bulk_delete_points` rustdoc — idempotent batch semantics.
+    let temp_dir = TempDir::new().expect("test: temp dir");
+    let app = create_test_app(&temp_dir);
+    seed_collection(app.clone(), 3).await;
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/collections/{TEST_COLLECTION}/points/delete"))
+                .header("Content-Type", "application/json")
+                .body(Body::from(json!({ "ids": [] }).to_string()))
+                .expect("test: build delete request"),
+        )
+        .await
+        .expect("test: delete request");
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let json = read_json(response).await;
+    assert_eq!(json["deleted_count"], 0);
+}
+
+#[tokio::test]
+async fn bulk_delete_unknown_ids_silently_skipped() {
+    // Idempotent: deleting non-existent IDs returns 200, count = batch size.
+    let temp_dir = TempDir::new().expect("test: temp dir");
+    let app = create_test_app(&temp_dir);
+    seed_collection(app.clone(), 2).await;
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/collections/{TEST_COLLECTION}/points/delete"))
+                .header("Content-Type", "application/json")
+                .body(Body::from(json!({ "ids": [999, 1000] }).to_string()))
+                .expect("test: build delete request"),
+        )
+        .await
+        .expect("test: delete request");
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = read_json(response).await;
+    assert_eq!(json["deleted_count"], 2);
+}
+
+#[tokio::test]
+async fn bulk_delete_oversized_batch_returns_400() {
+    // Negative: > MAX_BULK_DELETE_SIZE (10_000) must be 400.
+    let temp_dir = TempDir::new().expect("test: temp dir");
+    let app = create_test_app(&temp_dir);
+    seed_collection(app.clone(), 1).await;
+
+    let oversized: Vec<u64> = (1..=10_001).collect();
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/collections/{TEST_COLLECTION}/points/delete"))
+                .header("Content-Type", "application/json")
+                .body(Body::from(json!({ "ids": oversized }).to_string()))
+                .expect("test: build delete request"),
+        )
+        .await
+        .expect("test: delete request");
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn bulk_delete_unknown_collection_returns_404() {
+    // Negative: ghost collection must be 404.
+    let temp_dir = TempDir::new().expect("test: temp dir");
+    let app = create_test_app(&temp_dir);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/collections/ghost_collection/points/delete")
+                .header("Content-Type", "application/json")
+                .body(Body::from(json!({ "ids": [1, 2] }).to_string()))
+                .expect("test: build delete request"),
+        )
+        .await
+        .expect("test: delete request");
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn bulk_delete_malformed_payload_returns_400() {
+    // Negative: missing `ids` field must be a deserialisation failure (4xx).
+    let temp_dir = TempDir::new().expect("test: temp dir");
+    let app = create_test_app(&temp_dir);
+    seed_collection(app.clone(), 1).await;
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/collections/{TEST_COLLECTION}/points/delete"))
+                .header("Content-Type", "application/json")
+                .body(Body::from(json!({ "wrong_field": [1, 2] }).to_string()))
+                .expect("test: build delete request"),
+        )
+        .await
+        .expect("test: delete request");
+    assert!(
+        response.status().is_client_error(),
+        "expected 4xx for malformed payload, got {}",
+        response.status()
+    );
+}
+
+// ---------------------------------------------------------------------
+// /vacuum — vacuum_collection (alias of /index/rebuild, by design)
+// ---------------------------------------------------------------------
+
+#[tokio::test]
+async fn vacuum_nominal_returns_200_with_compacted_count() {
+    let temp_dir = TempDir::new().expect("test: temp dir");
+    let app = create_test_app(&temp_dir);
+    seed_collection(app.clone(), 4).await;
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/collections/{TEST_COLLECTION}/vacuum"))
+                .header("Content-Type", "application/json")
+                .body(Body::empty())
+                .expect("test: build vacuum request"),
+        )
+        .await
+        .expect("test: vacuum request");
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let json = read_json(response).await;
+    assert_eq!(json["message"], "Index vacuumed");
+    assert_eq!(json["collection"], TEST_COLLECTION);
+    assert!(
+        json["compacted_entries"].is_number(),
+        "compacted_entries must be a number, got {:?}",
+        json["compacted_entries"]
+    );
+}
+
+#[tokio::test]
+async fn vacuum_empty_collection_returns_200() {
+    // Edge: vacuuming a collection with 0 vectors must succeed (no-op).
+    let temp_dir = TempDir::new().expect("test: temp dir");
+    let app = create_test_app(&temp_dir);
+    seed_collection(app.clone(), 0).await;
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/collections/{TEST_COLLECTION}/vacuum"))
+                .body(Body::empty())
+                .expect("test: build vacuum request"),
+        )
+        .await
+        .expect("test: vacuum request");
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn vacuum_unknown_collection_returns_404() {
+    let temp_dir = TempDir::new().expect("test: temp dir");
+    let app = create_test_app(&temp_dir);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/collections/ghost_collection/vacuum")
+                .body(Body::empty())
+                .expect("test: build vacuum request"),
+        )
+        .await
+        .expect("test: vacuum request");
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+// ---------------------------------------------------------------------
+// /compact — compact_collection
+// ---------------------------------------------------------------------
+
+#[tokio::test]
+async fn compact_nominal_returns_200_with_bytes_reclaimed() {
+    let temp_dir = TempDir::new().expect("test: temp dir");
+    let app = create_test_app(&temp_dir);
+    seed_collection(app.clone(), 6).await;
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/collections/{TEST_COLLECTION}/compact"))
+                .body(Body::empty())
+                .expect("test: build compact request"),
+        )
+        .await
+        .expect("test: compact request");
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let json = read_json(response).await;
+    assert_eq!(json["message"], "Storage compacted");
+    assert_eq!(json["collection"], TEST_COLLECTION);
+    assert!(
+        json["bytes_reclaimed"].is_number(),
+        "bytes_reclaimed must be a number, got {:?}",
+        json["bytes_reclaimed"]
+    );
+}
+
+#[tokio::test]
+async fn compact_empty_collection_returns_200() {
+    // Edge: compacting an empty collection is a valid no-op.
+    let temp_dir = TempDir::new().expect("test: temp dir");
+    let app = create_test_app(&temp_dir);
+    seed_collection(app.clone(), 0).await;
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/collections/{TEST_COLLECTION}/compact"))
+                .body(Body::empty())
+                .expect("test: build compact request"),
+        )
+        .await
+        .expect("test: compact request");
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn compact_unknown_collection_returns_404() {
+    let temp_dir = TempDir::new().expect("test: temp dir");
+    let app = create_test_app(&temp_dir);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/collections/ghost_collection/compact")
+                .body(Body::empty())
+                .expect("test: build compact request"),
+        )
+        .await
+        .expect("test: compact request");
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+// ---------------------------------------------------------------------
+// Cross-endpoint sanity: delete -> vacuum -> compact lifecycle
+// ---------------------------------------------------------------------
+
+#[tokio::test]
+async fn lifecycle_delete_then_vacuum_then_compact_succeeds() {
+    let temp_dir = TempDir::new().expect("test: temp dir");
+    let app = create_test_app(&temp_dir);
+    seed_collection(app.clone(), 8).await;
+
+    // Delete half the points.
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/collections/{TEST_COLLECTION}/points/delete"))
+                .header("Content-Type", "application/json")
+                .body(Body::from(json!({ "ids": [1, 2, 3, 4] }).to_string()))
+                .expect("test: build delete request"),
+        )
+        .await
+        .expect("test: delete request");
+    assert_eq!(response.status(), StatusCode::OK);
+
+    // Vacuum the (now half-empty) index.
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/collections/{TEST_COLLECTION}/vacuum"))
+                .body(Body::empty())
+                .expect("test: build vacuum request"),
+        )
+        .await
+        .expect("test: vacuum request");
+    assert_eq!(response.status(), StatusCode::OK);
+
+    // Compact the storage.
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/collections/{TEST_COLLECTION}/compact"))
+                .body(Body::empty())
+                .expect("test: build compact request"),
+        )
+        .await
+        .expect("test: compact request");
+    assert_eq!(response.status(), StatusCode::OK);
+}

--- a/crates/velesdb-server/tests/common/mod.rs
+++ b/crates/velesdb-server/tests/common/mod.rs
@@ -12,11 +12,11 @@ use velesdb_core::Database;
 use velesdb_server::{
     add_edge, aggregate,
     auth::{auth_middleware, AuthState},
-    batch_search, collection_sanity, create_collection, delete_collection, delete_point, explain,
-    get_collection, get_collection_config, get_edges, get_node_degree, get_point, health_check,
-    hybrid_search, list_collections, multi_query_search, query, readiness_check, rebuild_index,
-    search, search_ids, stream_upsert_points, text_search, traverse_graph, upsert_points, AppState,
-    OnboardingMetrics,
+    batch_search, bulk_delete_points, collection_sanity, compact_collection, create_collection,
+    delete_collection, delete_point, explain, get_collection, get_collection_config, get_edges,
+    get_node_degree, get_point, health_check, hybrid_search, list_collections, multi_query_search,
+    query, readiness_check, rebuild_index, search, search_ids, stream_upsert_points, text_search,
+    traverse_graph, upsert_points, vacuum_collection, AppState, OnboardingMetrics,
 };
 
 fn base_routes() -> Router<Arc<AppState>> {
@@ -61,6 +61,13 @@ fn base_routes() -> Router<Arc<AppState>> {
             "/collections/{name}/graph/nodes/{node_id}/degree",
             get(get_node_degree),
         )
+        // Maintenance + bulk endpoints (PR #648)
+        .route(
+            "/collections/{name}/points/delete",
+            post(bulk_delete_points),
+        )
+        .route("/collections/{name}/vacuum", post(vacuum_collection))
+        .route("/collections/{name}/compact", post(compact_collection))
 }
 
 fn create_app_state(temp_dir: &TempDir) -> Arc<AppState> {
@@ -70,7 +77,7 @@ fn create_app_state(temp_dir: &TempDir) -> Arc<AppState> {
         onboarding_metrics: OnboardingMetrics::default(),
         query_limits: parking_lot::RwLock::new(velesdb_core::guardrails::QueryLimits::default()),
         ready: std::sync::atomic::AtomicBool::new(true),
-        operational_metrics: velesdb_core::metrics::OperationalMetrics::shared(),
+        operational_metrics: velesdb_core::metrics::OperationalMetrics::new_arc(),
         traversal_metrics: std::sync::Arc::new(velesdb_core::metrics::TraversalMetrics::new()),
         query_duration_histogram: std::sync::Arc::new(
             velesdb_core::metrics::DurationHistogram::new(),

--- a/crates/velesdb-server/tests/common/mod.rs
+++ b/crates/velesdb-server/tests/common/mod.rs
@@ -70,6 +70,11 @@ fn create_app_state(temp_dir: &TempDir) -> Arc<AppState> {
         onboarding_metrics: OnboardingMetrics::default(),
         query_limits: parking_lot::RwLock::new(velesdb_core::guardrails::QueryLimits::default()),
         ready: std::sync::atomic::AtomicBool::new(true),
+        operational_metrics: velesdb_core::metrics::OperationalMetrics::shared(),
+        traversal_metrics: std::sync::Arc::new(velesdb_core::metrics::TraversalMetrics::new()),
+        query_duration_histogram: std::sync::Arc::new(
+            velesdb_core::metrics::DurationHistogram::new(),
+        ),
     })
 }
 

--- a/crates/velesdb-server/tests/health_integration.rs
+++ b/crates/velesdb-server/tests/health_integration.rs
@@ -83,6 +83,11 @@ async fn ready_returns_503_when_not_ready() {
         onboarding_metrics: OnboardingMetrics::default(),
         query_limits: parking_lot::RwLock::new(velesdb_core::guardrails::QueryLimits::default()),
         ready: std::sync::atomic::AtomicBool::new(false),
+        operational_metrics: velesdb_core::metrics::OperationalMetrics::shared(),
+        traversal_metrics: std::sync::Arc::new(velesdb_core::metrics::TraversalMetrics::new()),
+        query_duration_histogram: std::sync::Arc::new(
+            velesdb_core::metrics::DurationHistogram::new(),
+        ),
     });
 
     let app = Router::new()

--- a/crates/velesdb-server/tests/health_integration.rs
+++ b/crates/velesdb-server/tests/health_integration.rs
@@ -83,7 +83,7 @@ async fn ready_returns_503_when_not_ready() {
         onboarding_metrics: OnboardingMetrics::default(),
         query_limits: parking_lot::RwLock::new(velesdb_core::guardrails::QueryLimits::default()),
         ready: std::sync::atomic::AtomicBool::new(false),
-        operational_metrics: velesdb_core::metrics::OperationalMetrics::shared(),
+        operational_metrics: velesdb_core::metrics::OperationalMetrics::new_arc(),
         traversal_metrics: std::sync::Arc::new(velesdb_core::metrics::TraversalMetrics::new()),
         query_duration_histogram: std::sync::Arc::new(
             velesdb_core::metrics::DurationHistogram::new(),

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -276,6 +276,59 @@
         }
       }
     },
+    "/collections/{name}/compact": {
+      "post": {
+        "tags": [
+          "collections"
+        ],
+        "summary": "Compacts the vector storage of a collection, rewriting active vectors\ninto a contiguous layout and reclaiming disk space from deleted entries.",
+        "description": "This is a blocking operation that may involve significant I/O for\nlarge, fragmented collections.",
+        "operationId": "compact_collection",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "description": "Collection name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Storage compacted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Collection not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Compaction failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/collections/{name}/config": {
       "get": {
         "tags": [
@@ -1242,6 +1295,59 @@
         }
       }
     },
+    "/collections/{name}/index/rebuild": {
+      "post": {
+        "tags": [
+          "collections"
+        ],
+        "summary": "Rebuilds the HNSW index of a vector collection, reclaiming memory\noccupied by tombstoned entries and producing a fresh graph from\nthe current vector storage.",
+        "description": "This is a blocking operation: for large collections it may take\nseveral seconds. The response includes the number of entries that\nwere compacted during the rebuild.",
+        "operationId": "rebuild_index",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "description": "Collection name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Index rebuilt",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Collection not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Rebuild failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/collections/{name}/indexes": {
       "get": {
         "tags": [
@@ -1528,6 +1634,79 @@
           },
           "404": {
             "description": "Collection not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/collections/{name}/points/delete": {
+      "post": {
+        "tags": [
+          "points"
+        ],
+        "summary": "Deletes multiple points by ID in a single request.",
+        "description": "Accepts a JSON body with a list of point IDs. All IDs are passed to\nthe underlying `Collection::delete(&[u64])` in one call, which is\nmore efficient than individual deletions.\n\nReturns the number of points that were requested for deletion.\nPoints that do not exist are silently skipped.",
+        "operationId": "bulk_delete_points",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "description": "Collection name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BulkDeleteRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Points deleted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Batch too large",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Collection not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Delete failed",
             "content": {
               "application/json": {
                 "schema": {
@@ -2293,6 +2472,59 @@
         }
       }
     },
+    "/collections/{name}/vacuum": {
+      "post": {
+        "tags": [
+          "collections"
+        ],
+        "summary": "Vacuums the HNSW index of a vector collection, removing tombstoned\nentries and rebuilding the graph from current vectors.",
+        "description": "Semantically equivalent to `POST /collections/{name}/index/rebuild`\nbut exposed under a more intuitive maintenance-oriented name.\n\nThis is a blocking operation: for large collections it may take\nseveral seconds.",
+        "operationId": "vacuum_collection",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "description": "Collection name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Index vacuumed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Collection not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Vacuum failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/guardrails": {
       "get": {
         "tags": [
@@ -2659,6 +2891,24 @@
             "type": "number",
             "format": "double",
             "description": "Total time in milliseconds."
+          }
+        }
+      },
+      "BulkDeleteRequest": {
+        "type": "object",
+        "description": "Request body for bulk point deletion.",
+        "required": [
+          "ids"
+        ],
+        "properties": {
+          "ids": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int64",
+              "minimum": 0
+            },
+            "description": "List of point IDs to delete."
           }
         }
       },

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -11,7 +11,7 @@
       "name": "VelesDB Core License 1.0",
       "url": "https://github.com/cyberlife-coder/VelesDB/blob/main/LICENSE"
     },
-    "version": "1.13.0"
+    "version": "1.13.1"
   },
   "servers": [
     {
@@ -1651,7 +1651,7 @@
           "points"
         ],
         "summary": "Deletes multiple points by ID in a single request.",
-        "description": "Accepts a JSON body with a list of point IDs. All IDs are passed to\nthe underlying `Collection::delete(&[u64])` in one call, which is\nmore efficient than individual deletions.\n\nReturns the number of points that were requested for deletion.\nPoints that do not exist are silently skipped.",
+        "description": "Accepts a JSON body with a list of point IDs. All IDs are passed to\nthe underlying `Collection::delete(&[u64])` in one call, which is\nmore efficient than individual deletions.\n\nReturns the number of points that were requested for deletion.\nPoints that do not exist are silently skipped (idempotent delete).\n\n# Empty payload semantics\n\n`{ \"ids\": [] }` is treated as a successful no-op: the response is\n`200 OK` with `deleted_count = 0`. This matches Kubernetes-style\nidempotent batch APIs and lets callers send empty batches without\nspecial-casing on the client side.\n\n# Limits\n\nBatches larger than `MAX_BULK_DELETE_SIZE` (10000) are rejected with\n`400 BAD_REQUEST`.",
         "operationId": "bulk_delete_points",
         "parameters": [
           {

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -8,7 +8,7 @@ info:
   license:
     name: VelesDB Core License 1.0
     url: https://github.com/cyberlife-coder/VelesDB/blob/main/LICENSE
-  version: 1.13.0
+  version: 1.13.1
 servers:
 - url: /
   description: Local server
@@ -1078,7 +1078,19 @@ paths:
         more efficient than individual deletions.
 
         Returns the number of points that were requested for deletion.
-        Points that do not exist are silently skipped.
+        Points that do not exist are silently skipped (idempotent delete).
+
+        # Empty payload semantics
+
+        `{ "ids": [] }` is treated as a successful no-op: the response is
+        `200 OK` with `deleted_count = 0`. This matches Kubernetes-style
+        idempotent batch APIs and lets callers send empty batches without
+        special-casing on the client side.
+
+        # Limits
+
+        Batches larger than `MAX_BULK_DELETE_SIZE` (10000) are rejected with
+        `400 BAD_REQUEST`.
       operationId: bulk_delete_points
       parameters:
       - name: name

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -171,6 +171,43 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+  /collections/{name}/compact:
+    post:
+      tags:
+      - collections
+      summary: |-
+        Compacts the vector storage of a collection, rewriting active vectors
+        into a contiguous layout and reclaiming disk space from deleted entries.
+      description: |-
+        This is a blocking operation that may involve significant I/O for
+        large, fragmented collections.
+      operationId: compact_collection
+      parameters:
+      - name: name
+        in: path
+        description: Collection name
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Storage compacted
+          content:
+            application/json:
+              schema:
+                type: object
+        '404':
+          description: Collection not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Compaction failed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
   /collections/{name}/config:
     get:
       tags:
@@ -786,6 +823,45 @@ paths:
       responses:
         '200':
           description: SSE stream of traversal events (node, stats, done, error)
+  /collections/{name}/index/rebuild:
+    post:
+      tags:
+      - collections
+      summary: |-
+        Rebuilds the HNSW index of a vector collection, reclaiming memory
+        occupied by tombstoned entries and producing a fresh graph from
+        the current vector storage.
+      description: |-
+        This is a blocking operation: for large collections it may take
+        several seconds. The response includes the number of entries that
+        were compacted during the rebuild.
+      operationId: rebuild_index
+      parameters:
+      - name: name
+        in: path
+        description: Collection name
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Index rebuilt
+          content:
+            application/json:
+              schema:
+                type: object
+        '404':
+          description: Collection not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Rebuild failed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
   /collections/{name}/indexes:
     get:
       tags:
@@ -987,6 +1063,57 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
         '404':
           description: Collection not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /collections/{name}/points/delete:
+    post:
+      tags:
+      - points
+      summary: Deletes multiple points by ID in a single request.
+      description: |-
+        Accepts a JSON body with a list of point IDs. All IDs are passed to
+        the underlying `Collection::delete(&[u64])` in one call, which is
+        more efficient than individual deletions.
+
+        Returns the number of points that were requested for deletion.
+        Points that do not exist are silently skipped.
+      operationId: bulk_delete_points
+      parameters:
+      - name: name
+        in: path
+        description: Collection name
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BulkDeleteRequest'
+        required: true
+      responses:
+        '200':
+          description: Points deleted
+          content:
+            application/json:
+              schema:
+                type: object
+        '400':
+          description: Batch too large
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Collection not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Delete failed
           content:
             application/json:
               schema:
@@ -1478,6 +1605,46 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+  /collections/{name}/vacuum:
+    post:
+      tags:
+      - collections
+      summary: |-
+        Vacuums the HNSW index of a vector collection, removing tombstoned
+        entries and rebuilding the graph from current vectors.
+      description: |-
+        Semantically equivalent to `POST /collections/{name}/index/rebuild`
+        but exposed under a more intuitive maintenance-oriented name.
+
+        This is a blocking operation: for large collections it may take
+        several seconds.
+      operationId: vacuum_collection
+      parameters:
+      - name: name
+        in: path
+        description: Collection name
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Index vacuumed
+          content:
+            application/json:
+              schema:
+                type: object
+        '404':
+          description: Collection not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Vacuum failed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
   /guardrails:
     get:
       tags:
@@ -1733,6 +1900,19 @@ components:
           type: number
           format: double
           description: Total time in milliseconds.
+    BulkDeleteRequest:
+      type: object
+      description: Request body for bulk point deletion.
+      required:
+      - ids
+      properties:
+        ids:
+          type: array
+          items:
+            type: integer
+            format: int64
+            minimum: 0
+          description: List of point IDs to delete.
     CollectionConfigResponse:
       type: object
       description: Response with detailed collection configuration.


### PR DESCRIPTION
## Summary

Implements production-grade observability and maintenance endpoints for VelesDB.

Closes #388

## What Changed

### Prometheus Metrics Wiring (Deliverable 1)
- Wire `OperationalMetrics` (query throughput, connections, doc counts) into `/metrics`
- Wire `GuardRailsMetrics` (rate limiting, resource limits, error counters) via global singleton
- Wire `TraversalMetrics` (nodes visited, depth, edges scanned) into `/metrics`
- Wire `DurationHistogram` (8-bucket query latency) into `/metrics`
- Add `operational_metrics`, `traversal_metrics`, `query_duration_histogram` to `AppState`
- ~32 new Prometheus time-series exposed

### Bulk Delete Endpoint (Deliverable 2)
- `POST /collections/{name}/points/delete` — accepts JSON `{"ids": [u64]}`
- 10,000 ID batch limit matching existing `MAX_SCROLL_BATCH_SIZE`
- Uses `spawn_blocking` for non-blocking async execution
- Empty/oversized batch validation with proper error responses

### Vacuum & Compact Maintenance Endpoints (Deliverable 3)
- `POST /collections/{name}/vacuum` — HNSW index vacuum (rebuild from live vectors)
- `POST /collections/{name}/compact` — storage compaction (rewrite active vectors, reclaim disk)
- Add `compact_storage()` to `VectorCollection`, `compact_vector_storage()` to `Collection`
- Both use `spawn_blocking`, consistent with existing `rebuild_index` pattern

### Wiring
- Register 3 new routes in `core_routes()`
- Add OpenAPI paths + `BulkDeleteRequest` schema
- Update all `AppState` construction sites (main.rs, metrics test, conformance test)

## Files Changed (9 files, +288/-20)

| File | Change |
|------|--------|
| `velesdb-core/.../flush.rs` | Add `compact_vector_storage()` to `Collection` |
| `velesdb-core/.../accessors.rs` | Add `compact_storage()` to `VectorCollection` |
| `velesdb-server/.../admin.rs` | Add `vacuum_collection` + `compact_collection` handlers |
| `velesdb-server/.../metrics.rs` | Extend `write_metrics()` to aggregate 4 core metric sources |
| `velesdb-server/.../mod.rs` | Re-export new handlers |
| `velesdb-server/.../points/mod.rs` | Add `BulkDeleteRequest` + `bulk_delete_points` handler |
| `velesdb-server/src/lib.rs` | `AppState` fields + OpenAPI paths + schemas |
| `velesdb-server/src/main.rs` | Instantiate metrics in `init_app_state()` |
| `velesdb-server/src/routes.rs` | Register 3 new routes |

## Verification

| Check | Result |
|-------|--------|
| `cargo check --features prometheus` | ✅ EXIT 0 |
| `cargo clippy --features prometheus -- -D warnings` | ✅ EXIT 0 |
| `cargo test --features prometheus --lib` | ✅ 139/139 passed |
| `test_openapi_routes_match_router` | ✅ All routes match OpenAPI |

## Design Decisions
- **Sync endpoints** — All new endpoints use `spawn_blocking` following the existing `rebuild_index` pattern
- **No trait changes** — `vector_storage` is concrete `MmapStorage`, so `compact()` is called directly through the write lock
- **Batch limit** — 10,000 IDs for bulk delete matches `MAX_SCROLL_BATCH_SIZE`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/648" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
