### PR TITLE
hotfix(ci): build velesdb-python from source before Python integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -323,6 +323,24 @@ jobs:
           python-version: '3.11'
           cache: 'pip'
 
+      - name: Install stable Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Cargo registry and build artefacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            crates/velesdb-python/target
+          key: ${{ runner.os }}-integ-py-${{ hashFiles('Cargo.lock', 'crates/velesdb-python/Cargo.toml') }}
+
+      - name: Build velesdb-python from source (ensures integrations test the in-tree version, not a stale PyPI release)
+        run: |
+          pip install maturin
+          cd crates/velesdb-python
+          maturin develop --release --features persistence
+
       - name: Install velesdb-common (local shared package)
         run: pip install -e integrations/common
 


### PR DESCRIPTION
## Summary

Main CI is currently red after the v1.13.0 merge (#628) due to a **CI bootstrap flaw** that surfaces on every release cut:

- The `python-integrations` job (runs only on push-to-main) pip-installs `integrations/llamaindex` and `integrations/common`. Both declare `velesdb>=1.12.0` as dependency.
- pip resolves this to the LATEST PUBLISHED version on PyPI (currently v1.12.x).
- The integration test suite, however, references v1.13.0-only additions (`Collection.scroll`, `GraphLoader.add_edge` kwarg changes, `ParsedStatement.collection_name` rename).
- Result: **10 test failures on main post-#628 merge**, blocking the v1.13.0 tag push per `release-checklist.md` "CI green on main" requirement.

## Fix

Install the stable Rust toolchain and run `maturin develop --release --features persistence` against `crates/velesdb-python` before pip-installing the integrations. This makes the locally-built v1.13.0-dev wheel satisfy the `velesdb` dependency instead of pip pulling the stale PyPI release.

Added a cargo cache keyed on `Cargo.lock` to keep subsequent runs under ~2 minutes.

## Why this hotfix targets main directly

Per `.claude/rules/` gitflow convention: `hotfix/*` branches target `main` (not develop) for urgent fixes blocking a release. This PR is strictly additive to CI config (no code or dependency changes); zero risk of regression.

## Blocking for v1.13.0 tag

Merge this → main CI re-runs → once green, I push `v1.13.0` tag and the Release workflow publishes crates.io + PyPI + npm. After that first publish, future develop→main merges will not hit this problem because PyPI has the fresh version.

## Test plan

- [ ] CI green on this PR (including the fixed python-integrations job)
- [ ] Codacy Cloud clean
- [ ] Devin Review clean (trivial CI-config diff, should auto-pass)
- [ ] Merge → observe main CI pass
- [ ] Then tag v1.13.0
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/649" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
