### PR TITLE
hotfix(v1.13.0): docs adherence to velesdb-core API + CI maturin fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -339,7 +339,10 @@ jobs:
         run: |
           pip install maturin
           cd crates/velesdb-python
-          maturin develop --release --features persistence
+          # Use `build` + `pip install` — `maturin develop` requires an active virtualenv
+          # which setup-python does not provide on GitHub runners.
+          maturin build --release --features persistence --out dist
+          pip install dist/*.whl --force-reinstall
 
       - name: Install velesdb-common (local shared package)
         run: pip install -e integrations/common

--- a/crates/velesdb-core/README.md
+++ b/crates/velesdb-core/README.md
@@ -505,7 +505,7 @@ flushing and backpressure signaling.
 ### Basic usage
 
 ```rust,no_run
-use velesdb_core::collection::streaming::{StreamIngester, StreamingConfig};
+use velesdb_core::collection::streaming::StreamingConfig;
 use velesdb_core::Point;
 
 // Configure the pipeline
@@ -515,18 +515,18 @@ let config = StreamingConfig {
     flush_interval_ms: 50,   // or every 50ms, whichever comes first
 };
 
-// `collection` is a Collection obtained from db.get_vector_collection(...)
-let ingester = StreamIngester::new(collection, config);
+// `collection` is a `VectorCollection` obtained from
+// `db.get_vector_collection(name).expect("collection exists")` — the handle
+// is cheap to clone (Arc-backed inside). Activate the streaming pipeline:
+collection.enable_streaming(config);
 
-// Send points — returns immediately
+// Send points — returns immediately. `BackpressureError::BufferFull` signals
+// the bounded channel is saturated; retry or drop.
 let point = Point::new(1, vec![0.1; 384], None);
-match ingester.try_send(point) {
+match collection.stream_insert(point) {
     Ok(()) => { /* accepted */ }
     Err(e) => eprintln!("Backpressure: {e}"),
 }
-
-// Gracefully drain remaining points before shutdown
-ingester.shutdown().await;
 ```
 
 ### Backpressure
@@ -762,14 +762,18 @@ println!("Hits: {}, Misses: {}", metrics.hits(), metrics.misses());
 ## Public API Reference
 
 ```rust
-// Core types
+// Core types — v1.13: typed collection split (Collection is `pub(crate)`,
+// use one of VectorCollection / GraphCollection / MetadataCollection instead)
 use velesdb_core::{
-    Database,           // Database instance
-    Collection,         // Vector collection
-    Point,              // Vector with metadata
-    DistanceMetric,     // Cosine, Euclidean, DotProduct, Hamming, Jaccard
-    StorageMode,        // Full, SQ8, Binary, ProductQuantization, RaBitQ
-    Error, Result,      // Error types
+    Database,            // Database instance
+    VectorCollection,    // Vector collection (typed handle)
+    GraphCollection,     // Graph collection (typed handle)
+    MetadataCollection,  // Metadata-only collection (typed handle)
+    AnyCollection,       // Type-erased handle returned by Database::get_any_collection
+    Point,               // Vector with metadata
+    DistanceMetric,      // Cosine, Euclidean, DotProduct, Hamming, Jaccard
+    StorageMode,         // Full, SQ8, Binary, ProductQuantization, RaBitQ
+    Error, Result,       // Error types
 };
 
 // Sparse vectors and fusion

--- a/crates/velesdb-core/src/api_types/mod.rs
+++ b/crates/velesdb-core/src/api_types/mod.rs
@@ -99,7 +99,7 @@ pub fn default_index_type() -> String {
     "hash".to_string()
 }
 
-/// Convert search mode string to [`SearchQuality`].
+/// Convert search mode string to [`crate::SearchQuality`].
 ///
 /// Supports all named modes including `"autotune"` which adapts ef
 /// automatically based on collection statistics, plus advanced modes:

--- a/crates/velesdb-core/src/collection/graph_collection.rs
+++ b/crates/velesdb-core/src/collection/graph_collection.rs
@@ -213,7 +213,8 @@ impl GraphCollection {
 
     /// Returns the next batch of points for scroll iteration.
     ///
-    /// Delegates to [`Collection::scroll_batch`].
+    /// Delegates to the inner collection's `scroll_batch` (parallel
+    /// implementation to [`VectorCollection::scroll_batch`](crate::VectorCollection::scroll_batch)).
     ///
     /// # Errors
     ///
@@ -366,7 +367,7 @@ impl GraphCollection {
 
     /// Alias for [`search_by_embedding`](Self::search_by_embedding).
     ///
-    /// Provided for API parity with [`VectorCollection::search`].
+    /// Provided for API parity with [`crate::VectorCollection::search`].
     ///
     /// # Errors
     ///

--- a/crates/velesdb-core/src/collection/graph_collection_query.rs
+++ b/crates/velesdb-core/src/collection/graph_collection_query.rs
@@ -24,7 +24,7 @@ impl GraphCollection {
 
     /// Executes a query with instrumentation and returns plan + actual stats.
     ///
-    /// Delegates to [`Database::explain_analyze_query`].
+    /// Delegates to [`crate::Database::explain_analyze_query`].
     ///
     /// # Errors
     ///

--- a/crates/velesdb-core/src/collection/metadata_collection.rs
+++ b/crates/velesdb-core/src/collection/metadata_collection.rs
@@ -139,7 +139,8 @@ impl MetadataCollection {
 
     /// Returns the next batch of points for scroll iteration.
     ///
-    /// Delegates to [`Collection::scroll_batch`].
+    /// Delegates to the inner collection's `scroll_batch` (parallel
+    /// implementation to [`VectorCollection::scroll_batch`](crate::VectorCollection::scroll_batch)).
     ///
     /// # Errors
     ///

--- a/crates/velesdb-core/src/collection/query_cost/cost_factors.rs
+++ b/crates/velesdb-core/src/collection/query_cost/cost_factors.rs
@@ -2,9 +2,9 @@
 //!
 //! Defines [`OperationCostFactors`] — the per-operation weights used by the
 //! CBO — along with hardware-profile constructors (`ssd_optimized`,
-//! `in_memory`, `hdd_optimized`), safety bounds ([`CostFactorBounds`]), and
-//! the [`clamp_with_log`] utility. Extracted from `cost_model.rs` to keep
-//! each file under the 500-NLOC limit.
+//! `in_memory`, `hdd_optimized`), safety bounds (`CostFactorBounds`, private),
+//! and the `clamp_with_log` (private) utility. Extracted from `cost_model.rs`
+//! to keep each file under the 500-NLOC limit.
 
 // Reason: Numeric casts in cost model are intentional:
 // - All casts are for cost estimation/statistics (not user data)
@@ -26,7 +26,7 @@ use tracing::debug;
 /// # Bornes de sécurité
 ///
 /// Chaque facteur est borné dans un intervalle pour éviter les estimations
-/// dégénérées (voir [`CostFactorBounds`]).
+/// dégénérées (voir `CostFactorBounds`, privé au crate).
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct OperationCostFactors {
     /// Coût par accès séquentiel de page (8 KB). Borné dans \[0.01, 10.0\].
@@ -166,7 +166,7 @@ impl OperationCostFactors {
     /// Applies safety bounds to all cost factors.
     ///
     /// Each factor is clamped into its allowed interval defined by
-    /// [`CostFactorBounds`]. Emits a `debug!` log for every clamped field.
+    /// `CostFactorBounds` (private). Emits a `debug!` log for every clamped field.
     #[must_use]
     pub fn clamped(self) -> Self {
         Self {

--- a/crates/velesdb-core/src/collection/query_cost/cost_model.rs
+++ b/crates/velesdb-core/src/collection/query_cost/cost_model.rs
@@ -7,9 +7,10 @@
 //!
 //! `OperationCostFactors` holds the per-operation weights used by the CBO.
 //! Since Issue #467, these factors are **calibrated dynamically** from
-//! [`CollectionStats`] during `analyze()` via [`calibrate_cost_factors()`],
-//! replacing the former hard-coded constants. The calibration pipeline
-//! adjusts each factor based on observed collection characteristics:
+//! [`CollectionStats`] during `analyze()` via `calibrate_cost_factors()`
+//! (private to the crate), replacing the former hard-coded constants. The
+//! calibration pipeline adjusts each factor based on observed collection
+//! characteristics:
 //!
 //! - **`seq_page_cost`** — scaled by the page ratio (`total_size_bytes / 8 KB`)
 //! - **`cpu_tuple_cost`** — scaled by average row size (`avg_row_size_bytes / 256`)
@@ -17,9 +18,10 @@
 //! - **`random_page_cost`** — scaled by histogram skew (bucket imbalance)
 //! - **stale penalty** — all factors inflated by 1.2× when any histogram is stale
 //!
-//! All calibrated values are clamped within [`CostFactorBounds`] to prevent
-//! degenerate estimates. Hardware profiles (`ssd_optimized`, `in_memory`,
-//! `hdd_optimized`) serve as the base before calibration adjustments.
+//! All calibrated values are clamped within `CostFactorBounds` (private) to
+//! prevent degenerate estimates. Hardware profiles (`ssd_optimized`,
+//! `in_memory`, `hdd_optimized`) serve as the base before calibration
+//! adjustments.
 
 // Reason: Numeric casts in cost model are intentional:
 // - All casts are for cost estimation/statistics (not user data)

--- a/crates/velesdb-core/src/collection/search/query/match_exec/mod.rs
+++ b/crates/velesdb-core/src/collection/search/query/match_exec/mod.rs
@@ -99,9 +99,9 @@ pub enum ProjectionItem<'a> {
 ///
 /// Handles four patterns:
 /// - `"*"` → [`ProjectionItem::Wildcard`]
-/// - `"similarity()"` → [`ProjectionItem::FunctionCall("similarity")`]
-/// - `"n.name"` → [`ProjectionItem::PropertyPath { alias: "n", property: "name" }`]
-/// - `"n"` → [`ProjectionItem::BareAlias("n")`]
+/// - `"similarity()"` → `ProjectionItem::FunctionCall("similarity")`
+/// - `"n.name"` → `ProjectionItem::PropertyPath { alias: "n", property: "name" }`
+/// - `"n"` → `ProjectionItem::BareAlias("n")`
 #[must_use]
 pub fn parse_projection_item(expression: &str) -> ProjectionItem<'_> {
     if expression == "*" {

--- a/crates/velesdb-core/src/collection/search/query/mod.rs
+++ b/crates/velesdb-core/src/collection/search/query/mod.rs
@@ -11,12 +11,12 @@
 //! entry points depending on query shape:
 //!
 //! - Queries carrying `ORDER BY similarity()` go through
-//!   [`QueryPlanner::choose_hybrid_strategy`], which forces `VectorFirst`
-//!   to preserve HNSW's natural similarity ordering and applies a
-//!   selectivity-aware over-fetch factor.
+//!   [`crate::velesql::QueryPlanner::choose_hybrid_strategy`], which forces
+//!   `VectorFirst` to preserve HNSW's natural similarity ordering and applies
+//!   a selectivity-aware over-fetch factor.
 //! - All other SELECT queries go through
-//!   [`QueryPlanner::choose_strategy_with_cbo_and_overfetch`], which
-//!   derives I/O / CPU weights from calibrated `OperationCostFactors`
+//!   [`crate::velesql::QueryPlanner::choose_strategy_with_cbo_and_overfetch`],
+//!   which derives I/O / CPU weights from calibrated `OperationCostFactors`
 //!   (or defaults when the collection was never analyzed).
 //!
 //! Both entry points share the same return shape

--- a/crates/velesdb-core/src/collection/streaming/delta.rs
+++ b/crates/velesdb-core/src/collection/streaming/delta.rs
@@ -3,7 +3,8 @@
 //! The [`DeltaBuffer`] holds recently inserted vectors that have not yet been
 //! indexed into the HNSW graph (e.g., because a rebuild is in progress).
 //! The search pipeline brute-force scans this buffer and merges results with
-//! HNSW results for immediate searchability via [`merge_with_delta`].
+//! HNSW results for immediate searchability via
+//! [`super::delta_merge::merge_with_delta`].
 //!
 //! # State machine
 //!
@@ -45,7 +46,8 @@ const DRAINING: u8 = 2;
 ///
 /// Accumulates `(point_id, vector)` pairs that are in storage but not yet in
 /// the HNSW index. When active, search methods brute-force scan the buffer
-/// and merge results with HNSW results via [`merge_with_delta`].
+/// and merge results with HNSW results via
+/// [`super::delta_merge::merge_with_delta`].
 pub struct DeltaBuffer {
     /// Buffered `(point_id, vector)` pairs awaiting index insertion.
     points: RwLock<Vec<(u64, Vec<f32>)>>,

--- a/crates/velesdb-core/src/collection/streaming/delta_merge.rs
+++ b/crates/velesdb-core/src/collection/streaming/delta_merge.rs
@@ -45,7 +45,8 @@ pub fn merge_with_delta(
     merged
 }
 
-/// Merges HNSW search results (as [`ScoredResult`]) with delta buffer results.
+/// Merges HNSW search results (as [`crate::ScoredResult`]) with delta buffer
+/// results.
 ///
 /// Zero-allocation variant that avoids the `ScoredResult` → `(u64, f32)` →
 /// `ScoredResult` round-trip in the search pipeline.

--- a/crates/velesdb-core/src/collection/vector_collection/accessors.rs
+++ b/crates/velesdb-core/src/collection/vector_collection/accessors.rs
@@ -57,7 +57,9 @@ impl VectorCollection {
 
     /// Returns the next batch of points for scroll iteration.
     ///
-    /// Delegates to [`Collection::scroll_batch`].
+    /// Delegates to the inner collection's scroll implementation; see also
+    /// the parallel `scroll_batch` on [`crate::GraphCollection`] and
+    /// [`crate::MetadataCollection`].
     ///
     /// # Errors
     ///
@@ -195,8 +197,9 @@ impl VectorCollection {
     /// — that decision is left to the caller.
     ///
     /// External consumers can register their own reindex pipeline via
-    /// the manager's event callback ([`AutoReindexManager::on_event`]) or
-    /// poll the divergence state via
+    /// the manager's event callback
+    /// ([`crate::collection::auto_reindex::AutoReindexManager::on_event`])
+    /// or poll the divergence state via
     /// [`Self::check_auto_reindex_divergence`].
     ///
     /// # Example

--- a/crates/velesdb-core/src/collection/vector_collection/search.rs
+++ b/crates/velesdb-core/src/collection/vector_collection/search.rs
@@ -68,10 +68,11 @@ impl VectorCollection {
         self.inner.search_with_ef(query, k, ef_search)
     }
 
-    /// Performs kNN search with a specific [`SearchQuality`] profile.
+    /// Performs kNN search with a specific [`crate::SearchQuality`] profile.
     ///
-    /// Use this instead of [`search_with_ef`] when you want named quality
-    /// modes like [`SearchQuality::AutoTune`] that compute ef dynamically.
+    /// Use this instead of [`Self::search_with_ef`] when you want named
+    /// quality modes like [`crate::SearchQuality::AutoTune`] that compute ef
+    /// dynamically.
     ///
     /// # Errors
     ///
@@ -100,7 +101,7 @@ impl VectorCollection {
         self.inner.search_with_filter(query, k, filter)
     }
 
-    /// Returns [`ScoredResult`] pairs without payload hydration.
+    /// Returns [`crate::ScoredResult`] pairs without payload hydration.
     ///
     /// Faster than [`search`](Self::search) when only IDs and scores are needed.
     ///
@@ -404,7 +405,7 @@ impl VectorCollection {
 
     /// Executes a query with instrumentation and returns plan + actual stats.
     ///
-    /// Delegates to [`Database::explain_analyze_query`].
+    /// Delegates to [`crate::Database::explain_analyze_query`].
     ///
     /// # Errors
     ///
@@ -438,7 +439,7 @@ impl VectorCollection {
     ///
     /// Acquires the ingester lock once for the entire batch, eliminating
     /// per-point lock overhead. Returns the number of points successfully
-    /// queued. See [`Collection::stream_insert_batch`] for details.
+    /// queued. Companion to [`Self::stream_insert`] for single-point sends.
     ///
     /// # Errors
     ///

--- a/crates/velesdb-core/src/contiguous_resize.rs
+++ b/crates/velesdb-core/src/contiguous_resize.rs
@@ -38,6 +38,8 @@ impl ContiguousVectors {
     /// # Errors
     ///
     /// Returns [`Error::AllocationFailed`] if reallocation fails.
+    ///
+    /// [`Error::AllocationFailed`]: crate::error::Error::AllocationFailed
     pub fn reserve_additional(&mut self, additional: usize) -> crate::error::Result<()> {
         let required = self.count.saturating_add(additional);
         self.ensure_capacity(required)

--- a/crates/velesdb-core/src/database/collection_ops.rs
+++ b/crates/velesdb-core/src/database/collection_ops.rs
@@ -190,7 +190,7 @@ impl Database {
     /// Returns the analyze generation for a named collection, if it exists
     /// (issue #608).
     ///
-    /// Parallel to [`collection_write_generation`], but tracks `ANALYZE`
+    /// Parallel to [`Self::collection_write_generation`], but tracks `ANALYZE`
     /// invocations instead of data mutations. Threaded into the compiled plan
     /// cache key so that an `ANALYZE` run alone invalidates cached plans whose
     /// cost estimates pre-date the fresh calibrated statistics.

--- a/crates/velesdb-core/src/database/mod.rs
+++ b/crates/velesdb-core/src/database/mod.rs
@@ -168,8 +168,8 @@ impl Database {
         Self::open_impl(path, Some(observer), None)
     }
 
-    /// Opens a database with both an explicit [`VelesConfig`] and a
-    /// [`DatabaseObserver`]. Used by the premium shell that layers
+    /// Opens a database with both an explicit [`crate::VelesConfig`] and a
+    /// [`crate::DatabaseObserver`]. Used by the premium shell that layers
     /// RBAC/audit on top of a tenant-specific config file.
     ///
     /// # Errors

--- a/crates/velesdb-core/src/index/hnsw/index/mod.rs
+++ b/crates/velesdb-core/src/index/hnsw/index/mod.rs
@@ -187,7 +187,7 @@ impl HnswIndex {
     ///
     /// This is the single inherent implementation shared by the
     /// [`VectorIndex::remove`](crate::index::VectorIndex::remove) trait impl
-    /// and delegates to [`upsert::soft_delete`] (also used by
+    /// and delegates to `upsert::soft_delete` (private; also used by
     /// `NativeHnswIndex::remove`).
     pub fn remove(&self, id: u64) -> bool {
         upsert::soft_delete(

--- a/crates/velesdb-core/src/index/hnsw/native/graph/mod.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/graph/mod.rs
@@ -32,7 +32,8 @@ use locking::{record_lock_acquire, record_lock_release, LockRank};
 use parking_lot::RwLock;
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 
-/// Sentinel value for [`NativeHnsw::entry_point`]: indicates no entry point exists.
+/// Sentinel value for `NativeHnsw::entry_point` (private field): indicates no
+/// entry point exists.
 ///
 /// Using `usize::MAX` instead of `Option<NodeId>` behind an `RwLock` allows
 /// lock-free reads on the search hot path (`Ordering::Acquire` load) while
@@ -325,10 +326,9 @@ impl<D: DistanceEngine> NativeHnsw<D> {
     /// Computes the raw distance between two vectors using this index's distance engine.
     ///
     /// **Note:** For `CachedSimdDistance` with Euclidean metric, this returns
-    /// **squared L2** (no sqrt). Pass the result through [`transform_score`]
-    /// to obtain actual Euclidean distance.
-    ///
-    /// [`transform_score`]: super::backend_adapter::NativeHnsw::transform_score
+    /// **squared L2** (no sqrt). Pass the result through
+    /// `NativeHnsw::transform_score` (private) to obtain actual Euclidean
+    /// distance.
     #[inline]
     #[must_use]
     pub fn compute_distance(&self, a: &[f32], b: &[f32]) -> f32 {

--- a/crates/velesdb-core/src/index/hnsw/native/graph/search.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/graph/search.rs
@@ -30,9 +30,8 @@ impl<D: DistanceEngine> NativeHnsw<D> {
     /// Returned distances are **raw engine distances** from `D::distance()`.
     /// When `D = CachedSimdDistance`, Euclidean values are squared L2 (no
     /// sqrt). Callers that expose results to users must apply
-    /// [`transform_score()`] to convert to the user-visible metric.
-    ///
-    /// [`transform_score()`]: super::backend_adapter::NativeHnsw::transform_score
+    /// `NativeHnsw::transform_score` (private) to convert to the
+    /// user-visible metric.
     #[inline]
     #[must_use]
     pub fn search(&self, query: &[f32], k: usize, ef_search: usize) -> Vec<(NodeId, f32)> {
@@ -97,8 +96,8 @@ impl<D: DistanceEngine> NativeHnsw<D> {
     /// Multi-entry point search for improved recall on hard queries.
     ///
     /// Normalizes the query for cosine metric before searching. If the query
-    /// is already prepared (e.g., from [`search`]), use
-    /// [`search_multi_entry_prepared`] to avoid double normalization.
+    /// is already prepared (e.g., from [`Self::search`]), use the private
+    /// `search_multi_entry_prepared` companion to avoid double normalization.
     #[must_use]
     pub fn search_multi_entry(
         &self,
@@ -116,7 +115,7 @@ impl<D: DistanceEngine> NativeHnsw<D> {
     /// Multi-entry point search on an already-prepared query vector.
     ///
     /// Skips the `prepare_query` step — the caller is responsible for
-    /// normalization (cosine). Called internally by [`search`] which
+    /// normalization (cosine). Called internally by [`Self::search`] which
     /// prepares the query once at the top level.
     #[must_use]
     fn search_multi_entry_prepared(

--- a/crates/velesdb-core/src/index/hnsw/native_index.rs
+++ b/crates/velesdb-core/src/index/hnsw/native_index.rs
@@ -152,9 +152,10 @@ impl NativeHnswIndex {
 
     /// Searches with a specific quality profile.
     ///
-    /// Uses [`NativeHnswInner::search_auto`] so that when the `gpu` feature is
-    /// enabled and the index is large enough (> 500K vectors, Standard backend),
-    /// layer-0 traversal is offloaded to the GPU. Falls back to CPU otherwise.
+    /// Uses `NativeHnswInner::search_auto` (private) so that when the `gpu`
+    /// feature is enabled and the index is large enough (> 500K vectors,
+    /// Standard backend), layer-0 traversal is offloaded to the GPU. Falls
+    /// back to CPU otherwise.
     #[must_use]
     pub fn search_with_quality(
         &self,
@@ -286,8 +287,8 @@ impl NativeHnswIndex {
     /// Removes the ID from mappings and cleans up stored vector data.
     /// The HNSW graph node becomes a tombstone, filtered out during search.
     ///
-    /// Delegates to [`upsert::soft_delete`], shared with `HnswIndex::remove`
-    /// (#448 Group F).
+    /// Delegates to `upsert::soft_delete` (private), shared with
+    /// `HnswIndex::remove` (#448 Group F).
     pub fn remove(&self, id: u64) -> bool {
         upsert::soft_delete(
             &self.mappings,

--- a/crates/velesdb-core/src/quantization/mod.rs
+++ b/crates/velesdb-core/src/quantization/mod.rs
@@ -88,7 +88,7 @@ impl StorageMode {
     /// Returns the canonical lowercase name for this storage mode.
     ///
     /// This is the single source of truth for string representations,
-    /// used by [`Display`], [`FromStr`], and downstream crates.
+    /// used by [`std::fmt::Display`], [`std::str::FromStr`], and downstream crates.
     #[must_use]
     pub const fn canonical_name(self) -> &'static str {
         match self {

--- a/crates/velesdb-core/src/simd_native/adc.rs
+++ b/crates/velesdb-core/src/simd_native/adc.rs
@@ -3,8 +3,8 @@
 //! Provides SIMD-accelerated distance computation using precomputed lookup tables.
 //! Dispatches to AVX2 gather, NEON, or scalar path based on runtime detection.
 //!
-//! The public-crate API ([`adc_distances_batch`]) is called from the PQ
-//! rescoring pipeline in [`crate::quantization::pq::pq_adc_batch_rescore`].
+//! The crate-private API (`adc_distances_batch`) is called from the PQ
+//! rescoring pipeline in `crate::quantization::pq::pq_adc_batch_rescore`.
 
 // The sole caller (`pq_adc_batch_rescore`) is persistence-gated, so all items
 // in this module are dead when persistence is disabled.

--- a/crates/velesdb-core/src/velesql/ast/condition.rs
+++ b/crates/velesdb-core/src/velesql/ast/condition.rs
@@ -138,7 +138,7 @@ pub enum CompareOp {
     Lte,
 }
 
-/// IN / NOT IN condition: column [NOT] IN (value1, value2, ...)
+/// IN / NOT IN condition: `column [NOT] IN (value1, value2, ...)`
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct InCondition {
     /// Column name.

--- a/crates/velesdb-core/src/velesql/ast/ddl.rs
+++ b/crates/velesdb-core/src/velesql/ast/ddl.rs
@@ -16,9 +16,9 @@ pub enum DdlStatement {
     CreateIndex(CreateIndexStatement),
     /// DROP INDEX ON collection (field) -- remove secondary metadata index.
     DropIndex(DropIndexStatement),
-    /// ANALYZE [COLLECTION] name -- compute CBO statistics.
+    /// `ANALYZE [COLLECTION] name` — compute CBO statistics.
     Analyze(AnalyzeStatement),
-    /// TRUNCATE [COLLECTION] name -- delete all rows.
+    /// `TRUNCATE [COLLECTION] name` — delete all rows.
     Truncate(TruncateStatement),
     /// ALTER COLLECTION name SET (options) -- modify collection settings.
     AlterCollection(AlterCollectionStatement),

--- a/crates/velesdb-core/src/velesql/ast/select.rs
+++ b/crates/velesdb-core/src/velesql/ast/select.rs
@@ -340,8 +340,10 @@ pub struct SimilarityOrderBy {
 impl SelectStatement {
     /// Returns an empty `SelectStatement` with all fields at their defaults.
     ///
-    /// Used by [`Query::new_dml`], [`Query::new_train`], and [`Query::new_match`]
-    /// to avoid repeating the 14-field struct literal.
+    /// Used by [`crate::velesql::Query::new_dml`],
+    /// [`crate::velesql::Query::new_train`], and
+    /// [`crate::velesql::Query::new_match`] to avoid repeating the 14-field
+    /// struct literal.
     #[must_use]
     pub fn empty() -> Self {
         Self {

--- a/crates/velesdb-core/src/velesql/cost_estimator/mod.rs
+++ b/crates/velesdb-core/src/velesql/cost_estimator/mod.rs
@@ -281,7 +281,7 @@ impl<'a> CostEstimator<'a> {
     /// finding 4.
     ///
     /// Uses the same `(ef + k) * log2(total)` probe formula as
-    /// [`Self::estimate_vector_search_node_cost`], so callers that have
+    /// `Self::estimate_vector_search_node_cost` (private), so callers that have
     /// `ef_search` / `candidates` available (e.g. pre/post-filter strategy
     /// comparison in `plan_builder`) get a cost that reflects the real query
     /// instead of a fixed `k = 10`.

--- a/crates/velesdb-core/src/velesql/parser/match_clause.rs
+++ b/crates/velesdb-core/src/velesql/parser/match_clause.rs
@@ -1,7 +1,7 @@
 //! MATCH clause parser for graph pattern matching.
 //!
 //! Graph pattern parsing (node, relationship, path patterns) lives in the
-//! sibling [`super::match_patterns`] module. This module handles the top-level
+//! sibling `super::match_patterns` (private) module. This module handles the top-level
 //! MATCH clause orchestration, WHERE condition parsing, RETURN clause parsing,
 //! and shared string-scanning utilities.
 

--- a/crates/velesdb-core/src/velesql/window_evaluator.rs
+++ b/crates/velesdb-core/src/velesql/window_evaluator.rs
@@ -8,8 +8,8 @@
 //! Window evaluation happens **after** DISTINCT and **before** ORDER BY/LIMIT.
 //! This is an intentional deviation from SQL standard (which runs windows
 //! before DISTINCT) tailored to the vector-search use case; see the design
-//! note on [`crate::collection::search::query::select_dispatch::QueryExecutor::apply_select_postprocessing`]
-//! for the full rationale.
+//! note on `Collection::apply_select_postprocessing` (private, in
+//! `collection::search::query::select_dispatch`) for the full rationale.
 //!
 //! ## Design: Global snapshot-first evaluation
 //!

--- a/crates/velesdb-python/README.md
+++ b/crates/velesdb-python/README.md
@@ -37,9 +37,11 @@ import velesdb
 # Open or create a database
 db = velesdb.Database("./my_vectors")
 
-# Create a collection for 768-dimensional vectors (e.g., BERT embeddings)
-# Note: create_collection() uses the legacy Collection API. For new projects,
-# prefer create_vector_collection() which returns a typed VectorCollection.
+# Create a collection for 768-dimensional vectors (e.g., BERT embeddings).
+# v1.13: `create_collection` is the recommended Python entry point. It accepts
+# typed dataclasses (`hnsw=HnswOptions(...)`, `auto_reindex=AutoReindexOptions(...)`,
+# `limits=LimitsOptions(...)`) for tuning. The Rust core also exposes
+# `create_vector_collection` for callers who want the explicit typed API.
 collection = db.create_collection(
     name="documents",
     dimension=768,

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -57,12 +57,11 @@ The legacy `Collection` god-object is being replaced by three focused types. Her
 #### Rust migration
 
 ```rust
-// Before (legacy)
-#[allow(deprecated)]
-let coll = db.get_collection("docs").unwrap();
-coll.search(&query, 10)?;
+// Before (v1.12 and earlier — `Database::get_collection()` was removed in v1.13)
+// let coll = db.get_collection("docs").unwrap();
+// coll.search(&query, 10)?;
 
-// After (typed)
+// After (typed — v1.13+)
 let coll = db.get_vector_collection("docs").unwrap();
 coll.search(&query, 10)?;
 ```
@@ -125,15 +124,22 @@ db.train_pq("docs", m=16, k=128, opq=True)  # OPQ variant
 ### How can I tune HNSW parameters?
 
 ```python
+from velesdb import HnswOptions
+
 # Higher m = more connections = better recall, more memory
 # Higher ef_construction = better index quality, slower build
-coll = db.create_collection("docs", dimension=768, m=48, ef_construction=600)
+# v1.13: typed HnswOptions replaces the old flat kwargs (`m=`, `ef_construction=`).
+coll = db.create_collection(
+    "docs",
+    dimension=768,
+    hnsw=HnswOptions(m=48, ef_construction=600),
+)
 
 # At query time, increase ef_search for better recall
 results = coll.search_with_ef(vector=query, top_k=10, ef_search=256)
 ```
 
-Default values are auto-tuned by dimension: `m=24, ef_construction=300` for dim <= 256, and `m=32, ef_construction=400` for dim >= 257. These work well for most workloads up to 100K vectors. Use `HnswParams::for_dataset_size()` for larger datasets.
+These defaults apply when you omit `hnsw=HnswOptions(...)` on `create_collection`: `m=24, ef_construction=300` for dim <= 256, and `m=32, ef_construction=400` for dim >= 257. They work well for most workloads up to 100K vectors. Use `HnswParams::for_dataset_size()` for larger datasets.
 
 ### How do I use batch and streaming ingestion?
 

--- a/docs/guides/CONCURRENCY_LOCKING.md
+++ b/docs/guides/CONCURRENCY_LOCKING.md
@@ -342,7 +342,7 @@ let results = db.search("docs", &query, 10)?;
 // Lock released, process results freely
 
 // BAD: Holding a collection guard across async boundaries
-let coll = db.get_collection("docs")?;
+let coll = db.get_vector_collection("docs").expect("collection exists");
 tokio::time::sleep(Duration::from_secs(1)).await; // Lock held!
 let results = coll.search(&query, 10)?;
 ```

--- a/docs/guides/MULTIMODEL_QUERIES.md
+++ b/docs/guides/MULTIMODEL_QUERIES.md
@@ -43,7 +43,7 @@ response.results.forEach(r => {
 use velesdb_core::{Database, velesql::Parser};
 
 let db = Database::open("./data")?;
-let collection = db.get_collection("documents").unwrap();
+let collection = db.get_vector_collection("documents").unwrap();
 
 let query = Parser::parse("MATCH (d:Doc) WHERE vector NEAR $q LIMIT 20")?;
 let params = [("q".to_string(), serde_json::json!(query_vector))].into();

--- a/docs/guides/SEARCH_MODES.md
+++ b/docs/guides/SEARCH_MODES.md
@@ -600,7 +600,7 @@ SearchQuality::Accurate
 ### Rust
 
 ```rust
-use velesdb_core::Collection;
+use velesdb_core::VectorCollection;
 
 // Méthode 1: Mode par défaut (Balanced, ef_search=128)
 let results = collection.search(&query_vector, 10)?;

--- a/docs/guides/USE_CASES.md
+++ b/docs/guides/USE_CASES.md
@@ -136,7 +136,7 @@ LIMIT 5
 use velesdb_core::{Database, velesql::Parser};
 
 let db = Database::open("./research_db")?;
-let collection = db.get_collection("research").unwrap();
+let collection = db.get_vector_collection("research").unwrap();
 
 let query = Parser::parse(r#"
     MATCH (d:Document)-[:MENTIONS]->(t:Topic)<-[:IS_EXPERT_IN]-(p:Person)

--- a/docs/reference/ERROR_CODES.md
+++ b/docs/reference/ERROR_CODES.md
@@ -35,7 +35,7 @@ version incompatibility, or internal bugs:
 - **Variant**: `CollectionExists(String)`
 - **Message**: `Collection '{name}' already exists`
 - **Cause**: Attempting to create a collection with a name that already exists in the database.
-- **Resolution**: Use a different name, or open the existing collection with `db.get_collection()` / `db.get_vector_collection()`.
+- **Resolution**: Use a different name, or open the existing collection. Python: `db.get_collection(name)` (compat shim returning a unified facade). Rust: pick the typed accessor that matches the kind — `db.get_vector_collection(name)`, `db.get_graph_collection(name)`, or `db.get_metadata_collection(name)` (use `db.get_any_collection(name)` when the kind is unknown).
 - **Recoverable**: Yes
 
 ### VELES-002: CollectionNotFound

--- a/docs/reference/NATIVE_HNSW.md
+++ b/docs/reference/NATIVE_HNSW.md
@@ -154,14 +154,17 @@ For even higher performance, VelesDB includes a **dual-precision HNSW** implemen
 ```rust
 use velesdb_core::index::hnsw::native::DualPrecisionHnsw;
 
-let mut hnsw = DualPrecisionHnsw::new(distance, 768, 32, 200, 100000);
+// `new` returns `Result` — propagation with `?` is mandatory.
+let mut hnsw = DualPrecisionHnsw::new(distance, 768, 32, 200, 100_000)?;
 
-// Insert vectors (quantizer trains automatically after 1000 vectors)
-for (id, vec) in vectors {
-    hnsw.insert(vec);
+// Insert vectors (quantizer trains automatically after 1000 vectors).
+// `insert` returns `Result<NodeId>`.
+for (_id, vec) in vectors {
+    let _node_id = hnsw.insert(&vec)?;
 }
 
-// Search with dual-precision (graph traversal + exact rerank)
+// Search with dual-precision (graph traversal + exact rerank).
+// `search` returns `Vec<(NodeId, f32)>` — no `Result`.
 let results = hnsw.search(&query, 10, 128);
 ```
 
@@ -197,16 +200,24 @@ enum HnswBackend {
 Set `StorageMode::RaBitQ` when creating a collection:
 
 ```rust
-use velesdb_core::{Database, StorageMode};
+use velesdb_core::{Database, DistanceMetric, StorageMode};
 
 let db = Database::open("./data")?;
-db.create_collection_with_storage("documents", 768, "cosine", StorageMode::RaBitQ)?;
+db.create_collection_with_options(
+    "documents",
+    768,
+    DistanceMetric::Cosine,
+    StorageMode::RaBitQ,
+)?;
 ```
 
 **CLI**:
 
 ```bash
-velesdb-cli create --name documents --dim 768 --metric cosine --storage rabitq
+velesdb-cli collection create ./data documents \
+  --dimension 768 \
+  --metric cosine \
+  --storage rabitq
 ```
 
 **REST API**:


### PR DESCRIPTION
## Summary

Post-merge hotfix to main (v1.13.0 tag is blocked until this lands). Delivers:

1. **Complete documentation adherence pass** to the v1.13.0 API surface — 8 blockers + 6 HIGH + 2 medium fixed after a triple audit of `README.md`, `docs/**/*.md`, `crates/*/README.md`, and rustdoc inside `crates/velesdb-core/src/`.
2. **Fix the CI maturin step** broken in #649 (previous hotfix used `maturin develop` which requires an active virtualenv that `actions/setup-python` doesn't provide).

Both changes must land before tagging so main CI is green and documentation matches the released API.

## Commits (6 atomic)

1. `docs: fix Rust snippets using removed Database::get_collection` — 4 guides updated to `db.get_vector_collection(...)`.
2. `docs(faq): switch Python create_collection to typed HnswOptions and clean Rust migration block` — flat kwargs (`m=48, ef_construction=600`) → `hnsw=HnswOptions(...)`; `get_collection` "Before" block reframed as commented historical form.
3. `docs(reference): fix NATIVE_HNSW snippets and ERROR_CODES resolution wording` — `db.create_collection_with_storage(...)` (which does not exist in core; only in velesdb-mobile) → real `create_collection_with_options(...)` with typed `DistanceMetric` + `StorageMode`; CLI invocation corrected to `velesdb-cli collection create <path> <name> --dimension N --metric cosine --storage rabitq`; `DualPrecisionHnsw::new` + `insert` shown with proper `Result` handling; `ERROR_CODES.md:38` split Python-compat vs Rust.
4. `docs(readme): align velesdb-core + velesdb-python READMEs with v1.13 typed API` — `use velesdb_core::{..., Collection}` removed (now `pub(crate)`); comment at line 518 corrected; one example rewritten to use public `enable_streaming` + `stream_insert` instead of `pub(crate) StreamIngester::new`; confusing "legacy API" framing dropped from velesdb-python README.
5. `docs(rustdoc): fix 50 broken intra-doc links post Collection -> pub(crate)` — **50 rustdoc warnings → 0** across 27 Rust files in `crates/velesdb-core/src/`. Mix of `[VectorCollection::method]`, `[AnyCollection::method]`, `[Self::method]`, std-lib FQN for `Display`/`FromStr`, bracket-quoted SQL keywords.
6. `ci(hotfix): use 'maturin build + pip install' instead of 'maturin develop' for integrations` — unblocks python-integrations job on main.

## Quality gates (verified locally)

- `cargo fmt --all -- --check`: PASS
- `cargo check -p velesdb-core --features persistence`: PASS
- `cargo doc --no-deps -p velesdb-core --features persistence`: **0 warnings** (was 50)
- `cargo test --doc -p velesdb-core --features persistence`: PASS (46 tests)
- `python scripts/check-promise-contract.py`: PASS (15 claims)

## Residual

Audit flagged 5 medium items recommending Python `db.get_collection` → `db.get_vector_collection` in guides. Verification shows **`get_vector_collection` does not exist on the Python wrapper** — `db.get_collection(...)` is the correct v1.13 idiomatic entry point via the compat shim at `crates/velesdb-python/python/velesdb/__init__.py:326`. Those 5 items are correctly NOT fixed.

Demos + integrations + TypeScript SDK audit (3rd agent): CLEAN, 0 findings.

## Test plan

- [x] Local gates green (fmt, rustdoc 0 warnings, doc-tests pass, promise-contract pass)
- [ ] CI green on this PR including the python-integrations job (the fix target)
- [ ] Codacy Cloud clean
- [ ] Devin Review
- [ ] Merge → main CI passes → tag v1.13.0
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/650" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
