### PR TITLE
hotfix(ci): drop invalid --features persistence from maturin build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -341,7 +341,11 @@ jobs:
           cd crates/velesdb-python
           # Use `build` + `pip install` — `maturin develop` requires an active virtualenv
           # which setup-python does not provide on GitHub runners.
-          maturin build --release --features persistence --out dist
+          # No explicit --features: velesdb-python's default already enables
+          # `velesdb-core/default` which includes `persistence`. Passing
+          # `--features persistence` fails because velesdb-python itself does
+          # not declare a `persistence` feature.
+          maturin build --release --out dist
           pip install dist/*.whl --force-reinstall
 
       - name: Install velesdb-common (local shared package)


### PR DESCRIPTION
## Summary

Third (and hopefully final) CI hotfix in the v1.13.0 tag-push sequence. Main CI on `21d75923` fails with:

\`\`\`
error: the package 'velesdb-python' does not contain this feature: persistence
help: packages with the missing feature: velesdb-core, velesdb-server, tauri-plugin-velesdb
\`\`\`

## Root cause

\`velesdb-python/Cargo.toml\` declares only \`default\`, \`gpu\`, \`update-check\`, \`loom\` features. It activates persistence **transitively** via \`default = ["velesdb-core/default"]\` → \`velesdb-core: default = ["persistence"]\`.

Passing \`--features persistence\` to \`maturin build\` is a feature name that does not exist on this crate.

## Fix

Drop the \`--features persistence\` flag. Default features on velesdb-python already enable persistence end-to-end for the integration test suite.

## Precedent

- PR #649 introduced the maturin step (but used \`maturin develop\` → failed: no venv)
- PR #650 switched to \`maturin build --features persistence\` (fixed venv issue, exposed feature-name bug)
- **This PR** drops \`--features persistence\` — unblocks the python-integrations job for v1.13.0 tag push.

## Test plan

- [ ] CI green on this PR
- [ ] Merge → main CI's python-integrations job actually runs the build + integration suite
- [ ] If green → tag v1.13.0

No source/runtime change; pure CI config.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/651" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
