### PR TITLE
hotfix(ci): pass -i python3.11 to maturin build (pyo3 cannot locate interpreter otherwise)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -345,7 +345,10 @@ jobs:
           # `velesdb-core/default` which includes `persistence`. Passing
           # `--features persistence` fails because velesdb-python itself does
           # not declare a `persistence` feature.
-          maturin build --release --out dist
+          # Explicit -i python3.11 matches the setup-python version above.
+          # Without it, maturin cannot locate the interpreter and pyo3-build-config
+          # errors with "abi3-py3* feature must be specified".
+          maturin build --release --out dist -i python3.11
           pip install dist/*.whl --force-reinstall
 
       - name: Install velesdb-common (local shared package)


### PR DESCRIPTION
## Summary

4th CI hotfix blocking v1.13.0 tag. After #651 (dropping --features), main CI on 24b17f0e errored:

\`\`\`
error: failed to run custom build command for pyo3-build-config v0.24.2
error: An abi3-py3* feature must be specified when compiling without a Python interpreter.
\`\`\`

## Root cause

\`setup-python\` puts python3.11 on PATH, but \`maturin build\` without an explicit \`-i\` flag AND no active virtualenv does NOT propagate \`PYTHON_SYS_EXECUTABLE\` to cargo. pyo3's build.rs then has no target ABI and fails.

## Fix

Pass \`-i python3.11\` explicitly (matches \`python-version: '3.11'\` used above). Same pattern as \`release.yml\` which uses \`-i python3.10 python3.11\` via \`PyO3/maturin-action\`.

## Hotfix sequence

1. #649 — add maturin step (\`maturin develop\`) → failed: no venv
2. #650 — switch to \`maturin build --features persistence\` → failed: feature not declared
3. #651 — drop \`--features persistence\` → failed: no python interpreter found
4. **This PR** — add \`-i python3.11\`

## Test plan

- [ ] CI green on this PR
- [ ] Merge → main CI runs python-integrations end-to-end
- [ ] If green → tag v1.13.0
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/652" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
