### PR TITLE
hotfix(ci): use PyO3/maturin-action v1 for integration wheel build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -335,21 +335,19 @@ jobs:
             crates/velesdb-python/target
           key: ${{ runner.os }}-integ-py-${{ hashFiles('Cargo.lock', 'crates/velesdb-python/Cargo.toml') }}
 
-      - name: Build velesdb-python from source (ensures integrations test the in-tree version, not a stale PyPI release)
-        run: |
-          pip install maturin
-          cd crates/velesdb-python
-          # Use `build` + `pip install` — `maturin develop` requires an active virtualenv
-          # which setup-python does not provide on GitHub runners.
-          # No explicit --features: velesdb-python's default already enables
-          # `velesdb-core/default` which includes `persistence`. Passing
-          # `--features persistence` fails because velesdb-python itself does
-          # not declare a `persistence` feature.
-          # Explicit -i python3.11 matches the setup-python version above.
-          # Without it, maturin cannot locate the interpreter and pyo3-build-config
-          # errors with "abi3-py3* feature must be specified".
-          maturin build --release --out dist -i python3.11
-          pip install dist/*.whl --force-reinstall
+      # Build velesdb-python from source so integrations test the in-tree
+      # version (not a stale PyPI release). Using the official PyO3 action
+      # because it handles PYTHON_SYS_EXECUTABLE + manylinux wiring that raw
+      # `maturin build` does not. Mirrors the approach in release.yml.
+      - name: Build velesdb-python from source
+        uses: PyO3/maturin-action@db323e2cf5679b7feb8bcb561a36b27a0bc19e79 # v1
+        with:
+          working-directory: crates/velesdb-python
+          args: --release --out dist -i python3.11
+          manylinux: auto
+
+      - name: Install built velesdb wheel
+        run: pip install crates/velesdb-python/dist/*.whl --force-reinstall
 
       - name: Install velesdb-common (local shared package)
         run: pip install -e integrations/common


### PR DESCRIPTION
## Summary

5th CI hotfix blocking v1.13.0 tag. The \`-i python3.11\` flag added in #652 still failed with the same pyo3-build-config error — \`-i\` tells maturin which interpreter to TARGET but does NOT set \`PYTHON_SYS_EXECUTABLE\` for cargo's subprocess. pyo3-build-config's build.rs runs interpreter discovery and fails.

## Fix

Adopt \`PyO3/maturin-action@v1\` which handles all env wiring + manylinux detection. Same pattern used by \`release.yml\` for wheel publishing.

## Hotfix sequence (logged for postmortem)

1. #649 — add maturin step (\`maturin develop\`) → no venv
2. #650 — \`maturin build --features persistence\` → invalid feature
3. #651 — drop \`--features persistence\` → no interpreter discovery
4. #652 — add \`-i python3.11\` → interpreter still not propagated to cargo
5. **this PR** — use the official action

## Test plan

- [ ] CI green on this PR
- [ ] Merge → main CI runs python-integrations end-to-end
- [ ] If green → tag v1.13.0
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/653" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
