### PR TITLE
hotfix(ci): set manylinux: 'off' so the integration wheel builds natively

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -336,15 +336,17 @@ jobs:
           key: ${{ runner.os }}-integ-py-${{ hashFiles('Cargo.lock', 'crates/velesdb-python/Cargo.toml') }}
 
       # Build velesdb-python from source so integrations test the in-tree
-      # version (not a stale PyPI release). Using the official PyO3 action
-      # because it handles PYTHON_SYS_EXECUTABLE + manylinux wiring that raw
-      # `maturin build` does not. Mirrors the approach in release.yml.
+      # version (not a stale PyPI release). The PyO3 action runs natively
+      # (no manylinux Docker) so it can see the python3.11 from setup-python
+      # — `manylinux: auto` would launch a container where the interpreter
+      # is not on PATH and pyo3-build-config errors out with "abi3-py3*
+      # feature must be specified".
       - name: Build velesdb-python from source
         uses: PyO3/maturin-action@db323e2cf5679b7feb8bcb561a36b27a0bc19e79 # v1
         with:
           working-directory: crates/velesdb-python
           args: --release --out dist -i python3.11
-          manylinux: auto
+          manylinux: 'off'
 
       - name: Install built velesdb wheel
         run: pip install crates/velesdb-python/dist/*.whl --force-reinstall


### PR DESCRIPTION
## Summary

6th CI hotfix in the v1.13.0 tag-push sequence. \`manylinux: auto\` (#653) launched the build inside a Docker container where the host's \`python3.11\` (from \`setup-python\`) was not on PATH, so pyo3-build-config still errored.

## Fix

\`manylinux: 'off'\` makes \`PyO3/maturin-action\` build natively on the runner, picking up python3.11 directly. The integration wheel is consumed by the same runner — no manylinux compat needed.

## Hotfix sequence
1. #649 — \`maturin develop\` → no venv
2. #650 — \`maturin build --features persistence\` → invalid feature
3. #651 — drop \`--features persistence\` → no interpreter
4. #652 — add \`-i python3.11\` → not propagated
5. #653 — adopt PyO3/maturin-action with \`manylinux: auto\` → Docker no Python
6. **this PR** — \`manylinux: 'off'\` → native build, host Python visible

## Test plan
- [ ] CI green
- [ ] Merge → main CI runs python-integrations end-to-end
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/654" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
