### PR TITLE
hotfix(ci): set PYO3_PYTHON explicitly so pyo3-build-config locates the interpreter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -336,20 +336,19 @@ jobs:
           key: ${{ runner.os }}-integ-py-${{ hashFiles('Cargo.lock', 'crates/velesdb-python/Cargo.toml') }}
 
       # Build velesdb-python from source so integrations test the in-tree
-      # version (not a stale PyPI release). The PyO3 action runs natively
-      # (no manylinux Docker) so it can see the python3.11 from setup-python
-      # — `manylinux: auto` would launch a container where the interpreter
-      # is not on PATH and pyo3-build-config errors out with "abi3-py3*
-      # feature must be specified".
+      # version (not a stale PyPI release). PyO3 build.rs needs the Python
+      # interpreter explicitly via PYO3_PYTHON; without it, pyo3-build-config
+      # errors with "abi3-py3* feature must be specified". Setting
+      # PYO3_PYTHON via `which python3.11` resolves the venv-less build.
       - name: Build velesdb-python from source
-        uses: PyO3/maturin-action@db323e2cf5679b7feb8bcb561a36b27a0bc19e79 # v1
-        with:
-          working-directory: crates/velesdb-python
-          args: --release --out dist -i python3.11
-          manylinux: 'off'
-
-      - name: Install built velesdb wheel
-        run: pip install crates/velesdb-python/dist/*.whl --force-reinstall
+        run: |
+          pip install maturin
+          export PYO3_PYTHON="$(which python3.11)"
+          echo "PYO3_PYTHON=$PYO3_PYTHON"
+          "$PYO3_PYTHON" --version
+          cd crates/velesdb-python
+          maturin build --release --out dist
+          pip install dist/*.whl --force-reinstall
 
       - name: Install velesdb-common (local shared package)
         run: pip install -e integrations/common


### PR DESCRIPTION
## Summary

7th hotfix in the v1.13.0 maturin sequence. Setting \`PYO3_PYTHON=\$(which python3.11)\` explicitly is the documented pyo3 escape hatch when build.rs interpreter discovery fails.

## Hotfix sequence
1. #649 \`maturin develop\` — no venv
2. #650 \`maturin build --features persistence\` — invalid feature
3. #651 drop \`--features\` — no interpreter
4. #652 add \`-i python3.11\` — not propagated
5. #653 PyO3/maturin-action with \`manylinux: auto\` — Docker has no python
6. #654 \`manylinux: 'off'\` — action still doesn't set PYO3_PYTHON
7. **this PR** — raw bash with explicit \`PYO3_PYTHON=\$(which python3.11)\` + sanity prints
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/655" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
