### PR TITLE
hotfix(ci): drop MATURIN_PEP517_ARGS=--release (not accepted by write-dist-info)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -346,10 +346,13 @@ jobs:
       # with "abi3-py3* feature must be specified", even with PYO3_PYTHON
       # set explicitly — see hotfix log #649-#655).
       - name: Build & install velesdb-python from source
-        env:
-          # Force release optimisation for the integration tests
-          MATURIN_PEP517_ARGS: "--release"
         run: |
+          # PEP 517 default build (debug profile). MATURIN_PEP517_ARGS=--release
+          # was rejected because the flag was forwarded to ALL maturin
+          # subcommands including `pep517 write-dist-info` which does not
+          # accept it. Debug build is acceptable for the integration test
+          # suite; test datasets are small enough that performance overhead
+          # is not measurable on the bench.
           pip install --upgrade pip maturin
           pip install ./crates/velesdb-python --force-reinstall
 


### PR DESCRIPTION
## Summary

9th CI hotfix. PR #656 successfully invoked the PEP 517 build path, but \`MATURIN_PEP517_ARGS=--release\` was forwarded to ALL maturin subcommands (including \`pep517 write-dist-info\` which rejects \`--release\`). Drop the env var; debug profile is fine for integration tests.

## Test plan
- [ ] CI green
- [ ] Merge → main CI runs python-integrations end-to-end
- [ ] If green → tag v1.13.0
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/657" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
