### PR TITLE
release: v1.13.1 — abi3-py39 + restore python-integrations CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -314,23 +314,7 @@ jobs:
     name: Python Integrations
     runs-on: ubuntu-latest
     needs: test
-    # Temporarily disabled until v1.13.0 wheel ships on PyPI.
-    # The integration test suite references v1.13.0-only APIs (Collection.scroll,
-    # HnswOptions, ParsedStatement.collection_name) but the wheel cannot be
-    # built from source on the CI runner because pyo3-build-config 0.24.2
-    # rejects the host Python interpreter under PEP 517 with
-    # "abi3-py3* feature must be specified". Nine hotfix iterations
-    # (#649-#657) failed to coax pyo3 into recognising the interpreter
-    # without abi3 mode, which would be a Cargo.toml change to velesdb-python
-    # that we do not want to ship at the v1.13.0 release cut.
-    # Re-enable after the v1.13.0 release workflow publishes the wheel to
-    # PyPI; pip will then resolve it from PyPI like any normal user.
-    # Tracked in v1.13.1 as: re-enable python-integrations + add abi3-py310
-    # feature to crates/velesdb-python pyo3 dep so future tag cycles do not
-    # hit the same chicken-and-egg.
-    if: false
-    # Original guard (restore in v1.13.1):
-    # if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-_Nothing yet — post-v1.13.0 work lives under feature branches tracked in [#634](https://github.com/cyberlife-coder/VelesDB/issues/634) (GPU hardening PR-C, PR-E) and [#639](https://github.com/cyberlife-coder/VelesDB/issues/639) (ef_search alignment)._
+_Nothing yet — post-v1.13.1 work lives under feature branches tracked in [#634](https://github.com/cyberlife-coder/VelesDB/issues/634) (GPU hardening PR-C, PR-E) and [#639](https://github.com/cyberlife-coder/VelesDB/issues/639) (ef_search alignment)._
+
+## [1.13.1] — 2026-04-25
+
+### Summary
+
+Patch release closing the v1.13.0 release-cut CI debt. Adds the
+`abi3-py39` feature to the `pyo3` dependency in `velesdb-python` so the
+Python wheel can be built from source on standard CI runners without the
+interpreter-discovery dance that took 9 hotfix iterations (#649-#657)
+to bypass at the v1.13.0 tag. The `python-integrations` CI job, which
+was temporarily disabled in #658 to unblock the v1.13.0 tag push, is
+restored to its original guard. Future `develop -> main` release
+cycles therefore exercise the integration tests end-to-end again.
+
+The `abi3-py39` feature also reduces the per-Python-version wheel
+matrix to a single ABI-stable wheel (Python 3.9+) rather than one wheel
+per minor version. Same source code, same behaviour, smaller release
+footprint.
+
+### Changed
+
+- `crates/velesdb-python/Cargo.toml` — pyo3 features now include
+  `abi3-py39` alongside `extension-module` and `multiple-pymethods`.
+  The published wheel is `cp39-abi3-...` instead of `cp310-cp310-...`
+  / `cp311-cp311-...`. Functionally identical from Python users' point
+  of view; the wheel is just compatible with a wider range of Python
+  versions in one binary.
+- `.github/workflows/ci.yml` — `python-integrations` job re-enabled
+  with its original `if: github.event_name == 'push' && github.ref ==
+  'refs/heads/main'` guard.
+
+### Fixed
+
+- The `develop -> main` release CI cycle no longer requires a wheel
+  to be already on PyPI for the integration test job to pass. The
+  abi3 wheel builds from source on the runner without a venv, which
+  was the chicken-and-egg the v1.13.0 release cut hit.
 
 ## [1.13.0] — 2026-04-23
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5649,7 +5649,7 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-velesdb"
-version = "1.13.0"
+version = "1.13.1"
 dependencies = [
  "dirs 5.0.1",
  "parking_lot",
@@ -6615,7 +6615,7 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "velesdb-cli"
-version = "1.13.0"
+version = "1.13.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -6640,7 +6640,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-core"
-version = "1.13.0"
+version = "1.13.1"
 dependencies = [
  "arc-swap",
  "bytemuck",
@@ -6694,7 +6694,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-migrate"
-version = "1.13.0"
+version = "1.13.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6722,7 +6722,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-mobile"
-version = "1.13.0"
+version = "1.13.1"
 dependencies = [
  "parking_lot",
  "serde_json",
@@ -6736,7 +6736,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-python"
-version = "1.13.0"
+version = "1.13.1"
 dependencies = [
  "numpy",
  "parking_lot",
@@ -6748,7 +6748,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-server"
-version = "1.13.0"
+version = "1.13.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -6781,7 +6781,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-wasm"
-version = "1.13.0"
+version = "1.13.1"
 dependencies = [
  "getrandom 0.2.17",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "1.13.0"
+version = "1.13.1"
 edition = "2021"
 rust-version = "1.83"
 license-file = "LICENSE"
@@ -77,7 +77,7 @@ base64 = "0.22"
 smallvec = { version = "1", features = ["serde"] }
 
 # Internal workspace crates
-velesdb-core = { path = "crates/velesdb-core", version = "1.13.0", default-features = false }
+velesdb-core = { path = "crates/velesdb-core", version = "1.13.1", default-features = false }
 
 [profile.release]
 lto = true

--- a/crates/tauri-plugin-velesdb/guest-js/package.json
+++ b/crates/tauri-plugin-velesdb/guest-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wiscale/tauri-plugin-velesdb",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "description": "TypeScript bindings for the VelesDB Tauri plugin - Vector search in desktop apps",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/crates/velesdb-python/Cargo.toml
+++ b/crates/velesdb-python/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 velesdb-core = { workspace = true }
-pyo3 = { version = "0.24", features = ["extension-module", "multiple-pymethods"] }
+pyo3 = { version = "0.24", features = ["extension-module", "multiple-pymethods", "abi3-py39"] }
 serde_json = { workspace = true }
 numpy = "0.24"
 parking_lot = "0.12"

--- a/crates/velesdb-python/pyproject.toml
+++ b/crates/velesdb-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "velesdb"
-version = "1.13.0"
+version = "1.13.1"
 description = "VelesDB: The Local Vector Database for Python & AI. Microsecond semantic search, zero network latency."
 readme = "README.md"
 license = { text = "MIT" }

--- a/demos/rag-pdf-demo/pyproject.toml
+++ b/demos/rag-pdf-demo/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "velesdb-rag-demo"
-version = "1.13.0"
+version = "1.13.1"
 description = "RAG Demo with PDF ingestion using VelesDB for vector storage"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/integrations/common/pyproject.toml
+++ b/integrations/common/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "velesdb-common"
-version = "1.13.0"
+version = "1.13.1"
 description = "Shared utilities for VelesDB Python integrations (internal use)"
 readme = "README.md"
 license = {text = "MIT"}

--- a/integrations/langchain/pyproject.toml
+++ b/integrations/langchain/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "langchain-velesdb"
-version = "1.13.0"
+version = "1.13.1"
 description = "LangChain VectorStore for VelesDB: The Local AI Memory Database. Microsecond RAG retrieval."
 readme = "README.md"
 license = {text = "MIT"}

--- a/integrations/llamaindex/pyproject.toml
+++ b/integrations/llamaindex/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "llama-index-vector-stores-velesdb"
-version = "1.13.0"
+version = "1.13.1"
 description = "LlamaIndex VectorStore for VelesDB: The Local AI Memory Database. Microsecond RAG retrieval."
 readme = "README.md"
 license = "MIT"

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wiscale/velesdb-sdk",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wiscale/velesdb-sdk",
-      "version": "1.13.0",
+      "version": "1.13.1",
       "license": "MIT",
       "dependencies": {
         "@wiscale/velesdb-wasm": "^1.4.1"

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wiscale/velesdb-sdk",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "description": "VelesDB TypeScript SDK: The Local Vector Database for AI & RAG. Microsecond semantic search in Browser & Node.js.",
   "main": "dist/index.js",
   "module": "dist/index.mjs",


### PR DESCRIPTION
## Summary

Patch release closing the v1.13.0 release-cut CI debt. Three coordinated changes:

1. **`crates/velesdb-python/Cargo.toml`** — add `abi3-py39` to the pyo3 features. Generates an ABI-stable wheel compatible with Python 3.9+ that builds from source on stock GitHub runners without the venv/PEP-517/manylinux gymnastics needed at the v1.13.0 cut.
2. **`.github/workflows/ci.yml`** — re-enable the `python-integrations` job (disabled in #658 with `if: false`).
3. **Workspace 1.13.0 → 1.13.1** across all crates, SDKs, integrations, demos + CHANGELOG.

## Why this is a separate hotfix

Per `release-checklist.md`, version bumps + CI flow changes warrant a clean tag rather than amending v1.13.0. The abi3 transition is a wheel-format change (cp310/cp311 → cp39-abi3) that downstream users will see on `pip install velesdb` upgrade.

## Wheel format note

- v1.13.0 published `cp310-cp310-…` + `cp311-cp311-…` wheels.
- v1.13.1 publishes a single `cp39-abi3-…` wheel that works on Python 3.9 through 3.12.
- Existing v1.13.0 wheels remain addressable on PyPI; pip resolves the abi3 wheel preferentially on upgrade.

## Test plan

- [x] Local: cargo fmt clean, cargo check (default features) PASS, promise-contract 15 claims PASS
- [ ] CI green on this PR (including the now-enabled python-integrations job which will skip on PR but run on push)
- [ ] Codacy + Devin clean
- [ ] Merge → main CI runs python-integrations end-to-end against the source-built abi3 wheel
- [ ] If green → tag v1.13.1 + Release workflow republishes
- [ ] Sync develop after release

## Hotfix log closed

Resolves the 9-iteration loop documented in #658:
#649 → #650 → #651 → #652 → #653 → #654 → #655 → #656 → #657 → #658 (bypass) → **this PR (proper fix)**.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/662" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
