### PR TITLE
test(llamaindex): fix two stale tests revealed by re-enabled python-integrations CI

### DIFF
--- a/integrations/llamaindex/tests/test_graph_loader.py
+++ b/integrations/llamaindex/tests/test_graph_loader.py
@@ -73,7 +73,7 @@ class TestGraphLoader:
 
         loader = GraphLoader(mock_store)
         loader.add_edge(
-            id=1,
+            edge_id=1,
             source=100,
             target=200,
             label="WORKS_AT",
@@ -388,7 +388,10 @@ class TestGraphRetriever:
         mock_index = MagicMock()
         mock_index._vector_store = mock_vector_store
 
-        retriever = GraphRetriever(index=mock_index)
+        # Use REST mode so the constructor does not require `graph_collection_name`
+        # (a `db_path` is also required for native mode). The unit test only
+        # exercises `_fetch_node` which delegates to the mocked vector store.
+        retriever = GraphRetriever(index=mock_index, mode="rest")
         node = retriever._fetch_node(42)
 
         mock_vector_store.get_nodes.assert_called_once_with(["42"])


### PR DESCRIPTION
## Summary

Two minor test bugs that had drifted while \`python-integrations\` was disabled (v1.12 → v1.13.0). Re-enabling the job in v1.13.1 (#662) surfaced both. This PR fixes them so v1.13.1 main CI is green.

## Fixes

1. **\`test_add_edge_with_metadata\`** — used \`id=1\` but \`GraphLoader.add_edge\`'s parameter is \`edge_id=\`. Other tests in the same file use the correct name; this was a single missed call.
2. **\`test_fetch_node_uses_get_nodes\`** — constructed \`GraphRetriever(index=mock_index)\` which defaults to \`mode='native'\`, requiring \`graph_collection_name\`. The test only exercises \`_fetch_node\` against a mocked vector store, so \`mode='rest'\` (with default \`server_url\`) is sufficient and avoids the native validation entirely.

## Verification

Production signatures cross-checked against:
- \`integrations/llamaindex/src/llamaindex_velesdb/graph_loader.py:205\` — \`def add_edge(self, edge_id: int, ...)\`
- \`integrations/llamaindex/src/llamaindex_velesdb/graph_retriever.py:140\` — \`__init__(..., mode: str = "native", ...)\` with native-mode validation in body

Expected post-merge: \`pytest integrations/llamaindex/tests/\` returns 201/201 passing (was 199 + 2 fail).

## Hotfix sequence wrap-up

Final piece for v1.13.1 release:
1. #662 (already merged) — abi3-py39 + restore python-integrations job
2. **this PR** — fix the 2 stale tests the re-enabled job exposed
3. Then tag v1.13.1
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/663" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
