### PR TITLE
test(llamaindex): align test_fetch_node with actual get_nodes_by_int_ids impl

### DIFF
--- a/integrations/llamaindex/tests/test_graph_loader.py
+++ b/integrations/llamaindex/tests/test_graph_loader.py
@@ -377,22 +377,24 @@ class TestGraphLoaderNativeGraph:
 
 
 class TestGraphRetriever:
-    def test_fetch_node_uses_get_nodes(self):
+    def test_fetch_node_uses_get_nodes_by_int_ids(self):
         from llamaindex_velesdb import GraphRetriever
         from llama_index.core.schema import TextNode
 
         mock_vector_store = MagicMock()
         expected = TextNode(text="Neighbor", id_="42")
-        mock_vector_store.get_nodes.return_value = [expected]
+        # `_fetch_node` deliberately uses `get_nodes_by_int_ids`, NOT
+        # `get_nodes`, because the latter re-hashes the int's string form
+        # and returns nothing — see graph_retriever.py:483 docstring.
+        mock_vector_store.get_nodes_by_int_ids.return_value = [expected]
 
         mock_index = MagicMock()
         mock_index._vector_store = mock_vector_store
 
-        # Use REST mode so the constructor does not require `graph_collection_name`
-        # (a `db_path` is also required for native mode). The unit test only
-        # exercises `_fetch_node` which delegates to the mocked vector store.
+        # mode='rest' avoids the native-mode requirement for `graph_collection_name`.
+        # The unit test only exercises `_fetch_node` against the mocked vector store.
         retriever = GraphRetriever(index=mock_index, mode="rest")
         node = retriever._fetch_node(42)
 
-        mock_vector_store.get_nodes.assert_called_once_with(["42"])
+        mock_vector_store.get_nodes_by_int_ids.assert_called_once_with([42])
         assert node == expected


### PR DESCRIPTION
## Summary

Last test bug from the now-running python-integrations job. The previous fix in #663 only partially addressed it — \`mode='rest'\` made the constructor pass, but the assertion still expected the wrong API call.

## Root cause

\`GraphRetriever._fetch_node\` deliberately uses \`get_nodes_by_int_ids([42])\` (int), NOT \`get_nodes(['42'])\` (string). The implementation docstring at \`graph_retriever.py:483-492\` explains this is intentional — \`get_nodes\` re-hashes the int's string form and would silently return nothing, breaking graph expansion.

## Fix

- Mock \`get_nodes_by_int_ids\` instead of \`get_nodes\`
- Assert \`called_once_with([42])\` (int)
- Renamed test method to \`test_fetch_node_uses_get_nodes_by_int_ids\` for accuracy

## Test plan

- [ ] CI green on this PR
- [ ] Merge → main CI's python-integrations passes (was 1 failure / 200 passed; now expect 201/201)
- [ ] Re-tag v1.13.1
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/665" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
