### PR TITLE
release: v1.13.2 — observability/ops + restore shared() alias for backward-compat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,59 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-_Nothing yet — post-v1.13.1 work lives under feature branches tracked in [#634](https://github.com/cyberlife-coder/VelesDB/issues/634) (GPU hardening PR-C, PR-E) and [#639](https://github.com/cyberlife-coder/VelesDB/issues/639) (ef_search alignment)._
+_Nothing yet — post-v1.13.2 work lives under feature branches tracked in [#634](https://github.com/cyberlife-coder/VelesDB/issues/634) (GPU hardening PR-C, PR-E) and [#639](https://github.com/cyberlife-coder/VelesDB/issues/639) (ef_search alignment)._
+
+## [1.13.2] — 2026-04-25
+
+### Summary
+
+Strictly additive patch release shipping the observability + ops
+endpoints work landed in [#648](https://github.com/cyberlife-coder/VelesDB/pull/648),
+together with two routine dependabot bumps and one breaking-API
+restoration to keep the v1.13.x series fully backward-compatible.
+
+### Added
+
+- **REST**: `POST /collections/{name}/points/delete` — bulk delete by
+  ID (max 10000 per batch). Idempotent: empty `ids: []` is a no-op
+  (200), unknown IDs are silently skipped.
+- **REST**: `POST /collections/{name}/vacuum` — explicit alias of
+  `/index/rebuild` exposed under a maintenance-oriented name.
+- **REST**: `POST /collections/{name}/compact` — storage compaction;
+  rewrites active vectors into a contiguous layout and reports
+  `bytes_reclaimed`.
+- **Prometheus**: 32 new time-series exposed via `/metrics` —
+  `OperationalMetrics`, `GuardRailsMetrics`, `TraversalMetrics`,
+  `DurationHistogram` (8-bucket query latency).
+- **Core**: `VectorCollection::compact_storage()` and
+  `Collection::compact_vector_storage()` public functions.
+- **Tests**: `crates/velesdb-server/tests/admin_endpoints_bdd_tests.rs`
+  with 13 nominal + edge + negative scenarios covering the three new
+  endpoints and the delete -> vacuum -> compact lifecycle (mandatory
+  per `.claude/rules/bdd-testing.md`).
+
+### Changed
+
+- **Naming**: `OperationalMetrics::shared()` is now an additive
+  forwarding alias of the new `OperationalMetrics::new_arc()`. The
+  rename improves API honesty (every call returns a fresh `Arc`,
+  not a shared singleton). The `shared()` symbol stays — marked
+  `#[deprecated(since = "1.13.2")]` — so v1.13.x consumers continue
+  to compile without changes.
+
+### Dependencies
+
+- Bump `rand` `0.8.5 -> 0.8.6` in `examples/rust` (GHSA security
+  advisory).
+- Bump `postcss` `8.5.6 -> 8.5.10` in `demos/tauri-rag-app`
+  (CVE-2024-XXX dev-dep).
+
+### CI
+
+- `.github/workflows/ci.yml` `python-integrations` job: build the
+  wheel from source via `pip install crates/velesdb-python` (PEP 517
+  / maturin backend), now possible thanks to the `abi3-py39` feature
+  added in v1.13.1.
 
 ## [1.13.1] — 2026-04-25
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5649,7 +5649,7 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-velesdb"
-version = "1.13.1"
+version = "1.13.2"
 dependencies = [
  "dirs 5.0.1",
  "parking_lot",
@@ -6615,7 +6615,7 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "velesdb-cli"
-version = "1.13.1"
+version = "1.13.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -6640,7 +6640,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-core"
-version = "1.13.1"
+version = "1.13.2"
 dependencies = [
  "arc-swap",
  "bytemuck",
@@ -6694,7 +6694,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-migrate"
-version = "1.13.1"
+version = "1.13.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6722,7 +6722,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-mobile"
-version = "1.13.1"
+version = "1.13.2"
 dependencies = [
  "parking_lot",
  "serde_json",
@@ -6736,7 +6736,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-python"
-version = "1.13.1"
+version = "1.13.2"
 dependencies = [
  "numpy",
  "parking_lot",
@@ -6748,7 +6748,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-server"
-version = "1.13.1"
+version = "1.13.2"
 dependencies = [
  "anyhow",
  "axum",
@@ -6781,7 +6781,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-wasm"
-version = "1.13.1"
+version = "1.13.2"
 dependencies = [
  "getrandom 0.2.17",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "1.13.1"
+version = "1.13.2"
 edition = "2021"
 rust-version = "1.83"
 license-file = "LICENSE"
@@ -77,7 +77,7 @@ base64 = "0.22"
 smallvec = { version = "1", features = ["serde"] }
 
 # Internal workspace crates
-velesdb-core = { path = "crates/velesdb-core", version = "1.13.1", default-features = false }
+velesdb-core = { path = "crates/velesdb-core", version = "1.13.2", default-features = false }
 
 [profile.release]
 lto = true

--- a/crates/tauri-plugin-velesdb/guest-js/package.json
+++ b/crates/tauri-plugin-velesdb/guest-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wiscale/tauri-plugin-velesdb",
-  "version": "1.13.1",
+  "version": "1.13.2",
   "description": "TypeScript bindings for the VelesDB Tauri plugin - Vector search in desktop apps",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/crates/velesdb-core/src/metrics/operational.rs
+++ b/crates/velesdb-core/src/metrics/operational.rs
@@ -62,6 +62,18 @@ impl OperationalMetrics {
         Arc::new(Self::new())
     }
 
+    /// Deprecated alias of [`OperationalMetrics::new_arc`].
+    ///
+    /// The original name implied a global singleton, but the
+    /// implementation always returned a fresh `Arc::new(Self::new())`.
+    /// Kept as a forwarding alias to preserve the v1.13.1 public API
+    /// surface; callers should migrate to `new_arc`.
+    #[must_use]
+    #[deprecated(since = "1.13.2", note = "use `OperationalMetrics::new_arc` instead")]
+    pub fn shared() -> Arc<Self> {
+        Self::new_arc()
+    }
+
     /// Increments the total query counter.
     pub fn inc_queries(&self) {
         self.queries_total.fetch_add(1, Ordering::Relaxed);

--- a/crates/velesdb-python/pyproject.toml
+++ b/crates/velesdb-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "velesdb"
-version = "1.13.1"
+version = "1.13.2"
 description = "VelesDB: The Local Vector Database for Python & AI. Microsecond semantic search, zero network latency."
 readme = "README.md"
 license = { text = "MIT" }

--- a/demos/rag-pdf-demo/pyproject.toml
+++ b/demos/rag-pdf-demo/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "velesdb-rag-demo"
-version = "1.13.1"
+version = "1.13.2"
 description = "RAG Demo with PDF ingestion using VelesDB for vector storage"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/integrations/common/pyproject.toml
+++ b/integrations/common/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "velesdb-common"
-version = "1.13.1"
+version = "1.13.2"
 description = "Shared utilities for VelesDB Python integrations (internal use)"
 readme = "README.md"
 license = {text = "MIT"}

--- a/integrations/langchain/pyproject.toml
+++ b/integrations/langchain/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "langchain-velesdb"
-version = "1.13.1"
+version = "1.13.2"
 description = "LangChain VectorStore for VelesDB: The Local AI Memory Database. Microsecond RAG retrieval."
 readme = "README.md"
 license = {text = "MIT"}

--- a/integrations/llamaindex/pyproject.toml
+++ b/integrations/llamaindex/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "llama-index-vector-stores-velesdb"
-version = "1.13.1"
+version = "1.13.2"
 description = "LlamaIndex VectorStore for VelesDB: The Local AI Memory Database. Microsecond RAG retrieval."
 readme = "README.md"
 license = "MIT"

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wiscale/velesdb-sdk",
-  "version": "1.13.1",
+  "version": "1.13.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wiscale/velesdb-sdk",
-      "version": "1.13.1",
+      "version": "1.13.2",
       "license": "MIT",
       "dependencies": {
         "@wiscale/velesdb-wasm": "^1.4.1"

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wiscale/velesdb-sdk",
-  "version": "1.13.1",
+  "version": "1.13.2",
   "description": "VelesDB TypeScript SDK: The Local Vector Database for AI & RAG. Microsecond semantic search in Browser & Node.js.",
   "main": "dist/index.js",
   "module": "dist/index.mjs",


### PR DESCRIPTION
## Summary

Strictly additive patch release on top of v1.13.1, shipping the work landed in [#648](https://github.com/cyberlife-coder/VelesDB/pull/648) (Prometheus metrics + bulk delete + vacuum/compact endpoints) plus two routine dependabot bumps already on develop.

## Backward-compat fix

PR #648 review renamed `OperationalMetrics::shared()` → `new_arc()` to fix a misleading name. While the rename is correct, removing `shared()` would have been a breaking change for v1.13.x consumers of `velesdb-core`. **This commit restores `shared()` as `#[deprecated(since = "1.13.2")]` forwarding alias of `new_arc()`** so the public API stays strictly additive.

## Version bumps

Workspace + per-crate `1.13.1 → 1.13.2` across:
- `Cargo.toml` (workspace + velesdb-core path version)
- `sdks/typescript/{package.json, package-lock.json}`
- `crates/velesdb-python/pyproject.toml`
- `crates/tauri-plugin-velesdb/guest-js/package.json`
- `integrations/{common,langchain,llamaindex}/pyproject.toml`
- `demos/rag-pdf-demo/pyproject.toml`
- `CHANGELOG.md` `[1.13.2]` section with full Added / Changed / Dependencies / CI breakdown

## Test plan

- [x] `cargo fmt --all -- --check`: PASS
- [x] `cargo clippy -p velesdb-core --features persistence --all-targets -- -D warnings -D clippy::pedantic`: PASS
- [x] `python scripts/check-promise-contract.py`: 15 claims pass
- [ ] CI green on this PR
- [ ] Codacy + Devin clean
- [ ] Merge → develop is at v1.13.2
- [ ] Then open final `develop → main` PR
- [ ] Tag v1.13.2

## Zero-debt assurance

This release is strictly additive vs v1.13.1:
- 3 new REST endpoints (`/points/delete`, `/vacuum`, `/compact`) — additive
- 32 new Prometheus time-series — additive
- New pub fns `compact_storage`, `compact_vector_storage`, `OperationalMetrics::new_arc` — additive
- `shared()` rename → kept as deprecated alias → no breaking change
- 13 BDD tests added — covered nominal/edge/negative per `bdd-testing.md`
- Local clippy pedantic 0 warnings, recall gate intact
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/667" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
