### PR TITLE
docs: contributors recognition + CLA workflow

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -7,7 +7,6 @@ on:
     types: [opened, closed, synchronize]
 
 permissions:
-  actions: write
   contents: write
   pull-requests: write
   statuses: write

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,42 @@
+name: CLA Assistant
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, closed, synchronize]
+
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+  statuses: write
+
+jobs:
+  cla-assistant:
+    runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'pull_request_target' ||
+      (github.event.comment.body == 'recheck' ||
+       github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA')
+    steps:
+      - name: CLA Assistant
+        uses: contributor-assistant/github-action@v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          path-to-signatures: signatures/cla.json
+          path-to-document: https://github.com/cyberlife-coder/velesdb/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla
+          branch: main
+          allowlist: cyberlife-coder,dependabot[bot],github-actions[bot]
+          lock-pullrequest-aftermerge: false
+          custom-notsigned-prcomment: |
+            Thank you for your contribution to VelesDB!
+
+            Before this PR can be merged, please sign the Contributor License Agreement by posting the following comment:
+
+            `I have read the CLA Document and I hereby sign the CLA`
+
+            This grants the project a license to use your contribution under the Elastic License 2.0 and future licensing terms.
+          custom-pr-sign-comment: "I have read the CLA Document and I hereby sign the CLA"
+          custom-allsigned-prcomment: "All contributors have signed the CLA. Thank you!"

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -37,6 +37,6 @@ jobs:
 
             `I have read the CLA Document and I hereby sign the CLA`
 
-            This grants the project a license to use your contribution under the Elastic License 2.0 and future licensing terms.
+            This grants the project a license to use your contribution under the VelesDB Core License 1.0 and future licensing terms.
           custom-pr-sign-comment: "I have read the CLA Document and I hereby sign the CLA"
           custom-allsigned-prcomment: "All contributors have signed the CLA. Thank you!"

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -20,12 +20,12 @@ jobs:
        github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA')
     steps:
       - name: CLA Assistant
-        uses: contributor-assistant/github-action@v2.6.1
+        uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           path-to-signatures: signatures/cla.json
-          path-to-document: https://github.com/cyberlife-coder/velesdb/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla
+          path-to-document: https://github.com/cyberlife-coder/velesdb/blob/develop/CONTRIBUTING.md#contributor-license-agreement-cla
           branch: develop
           allowlist: cyberlife-coder,dependabot[bot],github-actions[bot]
           lock-pullrequest-aftermerge: false

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           path-to-signatures: signatures/cla.json
           path-to-document: https://github.com/cyberlife-coder/velesdb/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla
-          branch: main
+          branch: develop
           allowlist: cyberlife-coder,dependabot[bot],github-actions[bot]
           lock-pullrequest-aftermerge: false
           custom-notsigned-prcomment: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -232,7 +232,7 @@ docs(readme): update quick start guide
 
 ## Contributor License Agreement (CLA)
 
-By submitting a pull request, you agree to the VelesDB CLA: you grant cyberlife-coder a perpetual, worldwide, non-exclusive, royalty-free license to use, modify, and distribute your contribution under the terms of the [Elastic License 2.0](LICENSE) or any future license chosen by the project.
+By submitting a pull request, you agree to the VelesDB CLA: you grant cyberlife-coder a perpetual, worldwide, non-exclusive, royalty-free license to use, modify, and distribute your contribution under the terms of the [VelesDB Core License 1.0](LICENSE) or any future license chosen by the project.
 
 This is required to allow VelesDB to offer commercial licensing alongside the source-available version. All past contributions are covered retroactively.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -230,11 +230,17 @@ docs(readme): update quick start guide
 - Keep README focused on getting started
 - Put detailed docs in the `/docs` folder
 
+## Contributor License Agreement (CLA)
+
+By submitting a pull request, you agree to the VelesDB CLA: you grant cyberlife-coder a perpetual, worldwide, non-exclusive, royalty-free license to use, modify, and distribute your contribution under the terms of the [Elastic License 2.0](LICENSE) or any future license chosen by the project.
+
+This is required to allow VelesDB to offer commercial licensing alongside the source-available version. All past contributions are covered retroactively.
+
 ## Recognition
 
-Contributors will be recognized in:
-- The project's README
-- Release notes for significant contributions
+Contributors are recognized in:
+- [CONTRIBUTORS.md](CONTRIBUTORS.md) — full list with PR links
+- Release notes for each version they contributed to
 - Our Discord community
 
 ## Release Process

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,18 @@
+# Contributors
+
+Thank you to everyone who has contributed to VelesDB!
+
+## External Contributors
+
+| Contributor | PR | Contribution | Version |
+|------------|-----|--------------|---------|
+| [@SBALAVIGNESH123](https://github.com/SBALAVIGNESH123) | [#648](https://github.com/cyberlife-coder/velesdb/pull/648) | Observability & ops: Prometheus metrics, bulk delete, vacuum/compact, 13 BDD scenarios | v1.13.2 |
+| [@CrepuscularIRIS](https://github.com/CrepuscularIRIS) | [#672](https://github.com/cyberlife-coder/velesdb/pull/672) | Haystack 2.x DocumentStore integration (LangChain + LlamaIndex + Haystack trilogy) | pending |
+
+## Core Team
+
+- [@cyberlife-coder](https://github.com/cyberlife-coder) — Creator and maintainer
+
+---
+
+Want to contribute? See [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/signatures/cla.json
+++ b/signatures/cla.json
@@ -1,0 +1,3 @@
+{
+  "signedContributors": []
+}


### PR DESCRIPTION
## Summary

- Add `CONTRIBUTORS.md` listing the two external contributors: @SBALAVIGNESH123 (PR #648, v1.13.2) and @CrepuscularIRIS (PR #672, pending)
- Add Contributor License Agreement section to `CONTRIBUTING.md` -- required before any further external PRs can be merged, and a standard due-diligence item for VC conversations
- Add `.github/workflows/cla.yml` using `contributor-assistant/github-action@v2.6.1`: automatically prompts unsigned contributors on any new PR and stores signed acknowledgments in `signatures/cla.json` on main
- Add `signatures/cla.json` as empty initial store

## Why now

Two external contributors have already submitted PRs. Before merging PR #672 (Haystack integration), the CLA must be in place. This PR provides the infrastructure.

## Related

- Closes no issue -- additive governance infrastructure
- PR #648 (merged, @SBALAVIGNESH123 -- retroactive coverage by CLA clause in CONTRIBUTING.md)
- PR #672 (open, @CrepuscularIRIS -- CLA bot will prompt on merge of this PR)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/676" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
