### PR TITLE
docs: disambiguate end-to-end (450us) vs index-only (55us) latency claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ VelesDB removes the US provider from the chain entirely. One Rust binary, local-
 
 | Today (3 systems to maintain) | With VelesDB (1 binary) |
 |-------------------------------|------------------------|
-| pgvector for embeddings | **Vector Engine** — ~55us HNSW search (5K/768D, k=10) |
+| pgvector for embeddings | **Vector Engine** — 450us p50 end-to-end (10K/384D, WAL ON, recall>=96%) |
 | Neo4j for knowledge graphs | **Graph Engine** — MATCH clause, BFS/DFS |
 | PostgreSQL/DuckDB for metadata | **ColumnStore** — 130x faster than JSON at 100K rows |
 | Custom glue code + 3 query languages | **VelesQL** — one language for everything |
@@ -262,12 +262,16 @@ Native HNSW index with SIMD-accelerated distance kernels. Sub-millisecond search
 <details>
 <summary>Detailed benchmarks and search modes</summary>
 
-| Benchmark | Result | How to reproduce |
+> **Headline number** (canonical, full path): **450 us p50** end-to-end search (10K/384D, WAL ON, recall>=96%) — see Performance summary above.
+>
+> The table below reports **index-only micro-benchmarks** (no WAL, no metadata fetch, hot cache) for components that can be measured in isolation. They are not directly comparable to end-to-end latency.
+
+| Component micro-benchmark | Result | How to reproduce |
 |-----------|--------|------------------|
-| HNSW Search (5K/768D, k=10) | **55 us** | `cargo bench -p velesdb-core --bench hnsw_benchmark -- hnsw_search_latency` |
-| SIMD Dot Product (768D, AVX2) | **21.7 ns** | `cargo bench -p velesdb-core --bench simd_benchmark` |
-| Recall@10 (Accurate) | **100%** | `cargo bench -p velesdb-core --bench recall_benchmark` |
-| BM25 Sparse Search (10K docs, top-10) | **57.6 us** (16x from 956 us in v1.12) | `cargo bench -p velesdb-core --bench sparse_benchmark -- top10_10k_corpus` |
+| HNSW Search index-only (5K/768D, k=10) | **55 us** | `cargo bench -p velesdb-core --bench hnsw_benchmark -- hnsw_search_latency` |
+| SIMD Dot Product kernel (768D, AVX2) | **21.7 ns** | `cargo bench -p velesdb-core --bench simd_benchmark` |
+| Recall@10 (Accurate mode) | **100%** | `cargo bench -p velesdb-core --bench recall_benchmark` |
+| BM25 Sparse Search index-only (10K docs, top-10) | **57.6 us** (16x from 956 us in v1.12) | `cargo bench -p velesdb-core --bench sparse_benchmark -- top10_10k_corpus` |
 
 | Mode | ef_search | Recall@10 | Use case |
 |------|-----------|-----------|----------|

--- a/crates/velesdb-core/README.md
+++ b/crates/velesdb-core/README.md
@@ -9,7 +9,7 @@ High-performance vector database engine written in Rust.
 
 ## Features
 
-- **Blazing Fast**: Native HNSW with AVX-512/AVX2/NEON SIMD (55µs search at 768D, 21.7ns dot product 768D — aligned with root README; see `docs/BENCHMARKS.md` for measurement context)
+- **Blazing Fast**: Native HNSW with AVX-512/AVX2/NEON SIMD — 450µs p50 end-to-end (10K/384D, WAL ON, recall>=96%); 55µs HNSW index-only micro-benchmark (5K/768D, k=10); 21.7ns dot product (768D AVX2). See `docs/BENCHMARKS.md` for measurement context.
 - **Adaptive Search**: Two-phase ef_search that auto-escalates only for hard queries (2-4x faster median)
 - **Hybrid Search**: Combine vector similarity + BM25 full-text search with RRF fusion
 - **Sparse Vectors**: Named sparse vector indexes with DAAT MaxScore search and RRF/RSF fusion
@@ -213,20 +213,27 @@ db.create_collection_with_options(
 
 *Aligned with root README canonical numbers. See `docs/BENCHMARKS.md` for full methodology (i9-14900KF, 64GB DDR5, Rust 1.94.1, AVX2, `--release`, `target-cpu=native`, sequential on idle machine).*
 
-### System Benchmarks (10K vectors, 768D)
+### Headline number (canonical, full path)
 
-| Benchmark | Result |
+**450 µs p50** end-to-end vector search (10K/384D, WAL ON, recall>=96%). See root README and `benchmarks/velesdb_benchmark.py --recall`.
+
+### Index-only micro-benchmarks (10K vectors, 768D)
+
+> These measure individual components in isolation (no WAL, no metadata fetch, hot cache). They are not directly comparable to end-to-end latency above.
+
+| Component micro-benchmark | Result |
 |-----------|--------|
-| **HNSW Search** | **55 µs** (k=10, Balanced mode — aligned with root README) |
+| **HNSW Search index-only** | **55 µs** (k=10, Balanced mode) |
 | **VelesQL Cache Hit** | **1.08 µs** (~926K QPS) |
-| **Sparse Search (top-10)** | **57.6 µs** (v1.13.0, PR #621 — 16x speedup from v1.12) |
+| **Sparse Search index-only (top-10)** | **57.6 µs** (v1.13.0, PR #621 — 16x speedup from v1.12) |
 | **Recall@10 (Accurate)** | **100%** |
 
 *Measured on Intel Core i9-14900KF, 64GB DDR5, Rust 1.94.1, AVX2, `--release`, `target-cpu=native`, sequential on idle machine. See `docs/BENCHMARKS.md` for full methodology.*
 
 ### Key Performance Features
 
-- Search latency: **~55 µs** for 10K/768D vectors (k=10, Balanced mode)
+- End-to-end search latency: **450 µs p50** (10K/384D, WAL ON, recall>=96%) — canonical full-path number
+- HNSW index-only micro-benchmark: **~55 µs** (10K/768D, k=10, Balanced mode)
 - Insert throughput: **3.8-7x faster** than pgvector (10K-100K vectors, Docker benchmark v0.7.3, [benchmark](../../benchmarks/README.md))
 - ColumnStore filtering: up to 130x faster than JSON scanning at scale (integer equality, 100K rows)
 
@@ -239,7 +246,7 @@ db.create_collection_with_options(
 | **10K/128D** | Perfect (ef=4096) | 4096 | **100%** | 200µs | ✅ |
 | **10K/128D** | Adaptive | 32-512 | **95%+** | ~40µs (easy) | ✅ |
 
-> *Latency P50 = median over 100 queries. The headline "~55 µs" (from the root README) is for 10K/768D Balanced — higher dimensions use SIMD more efficiently. 128D benchmarks above are worst-case for recall measurement.*
+> *Latency P50 = median over 100 queries. The "55 µs" index-only micro-benchmark is for 10K/768D Balanced — higher dimensions use SIMD more efficiently. 128D benchmarks above are worst-case for recall measurement. The canonical end-to-end latency is **450 µs p50** (see headline above).*
 
 > 📊 **Benchmark kit:** See [benchmarks/](../../benchmarks/) for reproducible tests.
 

--- a/docs/reference/promise-contract.json
+++ b/docs/reference/promise-contract.json
@@ -1,12 +1,13 @@
 {
-  "last_updated": "2026-04-23",
+  "last_updated": "2026-04-27",
   "claims": [
     {
       "id": "root_readme_hnsw_latency_microseconds",
       "file": "README.md",
-      "must_contain": "HNSW Search (5K/768D, k=10)",
+      "must_contain": "HNSW Search index-only (5K/768D, k=10)",
       "validation_command": "cargo bench -p velesdb-core --bench hnsw_benchmark",
-      "source": "benchmarks/results/pr363_365_comparison.md (47-56µs measured)"
+      "source": "benchmarks/results/pr363_365_comparison.md (47-56µs measured) — relabeled as 'index-only' for transparency vs the canonical 450µs end-to-end number",
+      "last_updated": "2026-04-27"
     },
     {
       "id": "root_readme_simd_dot",
@@ -109,10 +110,10 @@
     {
       "id": "readme_sparse_search_latency",
       "file": "README.md",
-      "must_contain": "BM25 Sparse Search (10K docs, top-10)",
+      "must_contain": "BM25 Sparse Search index-only (10K docs, top-10)",
       "validation_command": "cargo bench -p velesdb-core --bench sparse_benchmark -- top10_10k_corpus",
-      "source": "PR #621 (commit f4999a74, Phase 4.2 pre-seed remediation): 956us baseline (v1.12) -> 57.6us after linear_scan_dense + k-way merge dedup for corpus <= 100K",
-      "last_updated": "2026-04-21"
+      "source": "PR #621 (commit f4999a74, Phase 4.2 pre-seed remediation): 956us baseline (v1.12) -> 57.6us after linear_scan_dense + k-way merge dedup for corpus <= 100K. Relabeled 'index-only' for transparency.",
+      "last_updated": "2026-04-27"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Pre-seed technical due diligence audit (2026-04-27) flagged that the README cited two different latency numbers side-by-side without clear disambiguation:
- `~55us HNSW search (5K/768D, k=10)` — index-only micro-benchmark
- `450us p50 end-to-end (10K/384D, WAL ON, recall>=96%)` — full production path

A reader could legitimately read this as inconsistency. Both numbers are correct, but their juxtaposition created ambiguity.

## Changes

**Root README (`README.md`):**
- 'Why VelesDB' comparison table now uses the canonical 450us end-to-end number (replaces the 55us micro-bench reference)
- Benchmark deep-dive table is now explicitly labeled 'Index-only micro-benchmarks' with a headline pointing back to 450us as the canonical end-to-end number

**Crate README (`crates/velesdb-core/README.md`):**
- Same relabeling pattern: explicit 'Headline number (canonical, full path)' section above any micro-bench
- Key Performance Features list separates end-to-end from index-only

**Promise contract (`docs/reference/promise-contract.json`):**
- Updated `must_contain` strings to match new wording for two claims (`root_readme_hnsw_latency_microseconds`, `readme_sparse_search_latency`)
- `last_updated: 2026-04-27`

## Verification

```
python scripts/check-promise-contract.py
Promise contract check passed (15 claims).
```

No measurement changes. Numbers are the same; only the framing is now unambiguous.

## Test plan
- [x] `python scripts/check-promise-contract.py` passes
- [x] No code changes (docs + JSON only)
- [ ] CI green
- [ ] Devin review clean
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/688" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
