### PR TITLE
chore: sync develop with v1.13.3 release commits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,62 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-_Nothing yet — post-v1.13.2 work lives under feature branches tracked in [#634](https://github.com/cyberlife-coder/VelesDB/issues/634) (GPU hardening PR-C, PR-E) and [#639](https://github.com/cyberlife-coder/VelesDB/issues/639) (ef_search alignment)._
+_Nothing yet — post-v1.13.3 work lives under feature branches tracked in [#634](https://github.com/cyberlife-coder/VelesDB/issues/634) (GPU hardening PR-C, PR-E) and the v1.14.0 milestone (#349, #379, #429, #469)._
+
+## [1.13.3] — 2026-04-27
+
+### Summary
+
+Strictly additive patch release. Two themes:
+
+1. **Operational excellence pack** — three new top-level documents (`ARCHITECTURE.md`, `ROADMAP.md`, `QUALITY_BAR.md`) and a clarified README to make the project's discipline visible in technical due diligence. No code changes for this theme.
+2. **Internal feature additions** — Python Pythonic protocols (`__contains__`, context manager, `close()`), TypedDict return-type stubs, CBO `indexed_fields` cardinality wiring, HNSW `search_with_quality` alignment, WASM getrandom 0.3 fix, and the `rand 0.8 -> 0.9` migration.
+
+This release is fully backward-compatible — no API breakage, no behavioural change in the canonical end-to-end performance path (450 µs p50 preserved).
+
+### Added
+
+- **`ARCHITECTURE.md`** at repo root (15-minute narrative gateway): TL;DR, three engines, layered diagram, crate map, anatomy of a query walkthrough, concurrency model, storage on disk, what's NOT in scope, soundness summary, canonical 450 µs perf number disambiguation ([#692](https://github.com/cyberlife-coder/VelesDB/pull/692)).
+- **`ROADMAP.md`** at repo root: 3/6/12-month horizons with explicit OKRs, governance section, hierarchy of decisions ([#690](https://github.com/cyberlife-coder/VelesDB/pull/690)).
+- **`QUALITY_BAR.md`** at repo root: seven non-negotiable shipping gates (recall, latency, unwrap, unsafe, cyclomatic, NLOC, duplication) with enforcement scripts referenced ([#691](https://github.com/cyberlife-coder/VelesDB/pull/691)).
+- **GitHub milestone v1.14.0** with four focused issues (#349 Haystack, #379 DX, #469 CBO calibration, #429 Python DataFrame).
+- **Python**: Pythonic protocols `__contains__`, context manager (`with db:`), `close()` on `Database` and collection types ([#426](https://github.com/cyberlife-coder/VelesDB/pull/426)).
+- **Python**: TypedDict return-type stubs and complete `PyGraphSchema` stub for IDE completion and `mypy` ([#428](https://github.com/cyberlife-coder/VelesDB/pull/428)).
+- **VelesQL CBO**: `indexed_fields` cardinality wiring for the cost estimator ([#607](https://github.com/cyberlife-coder/VelesDB/pull/607)).
+- **CONTRIBUTORS.md**: contributor recognition, plus a CLA Assistant GitHub Action ([#676](https://github.com/cyberlife-coder/VelesDB/pull/676)).
+
+### Changed
+
+- **README.md**: top navigation bar now links to `ARCHITECTURE.md` / `ROADMAP.md` / `QUALITY_BAR.md`. The "Why VelesDB?" comparison table now uses the canonical 450 µs end-to-end number (replacing the 55 µs index-only micro-benchmark that was juxtaposed with the end-to-end number, creating a small ambiguity flagged in the 2026-04-27 pre-seed audit). The "System Benchmarks" deep-dive table is now explicitly labeled *Index-only micro-benchmarks* with a headline pointing back to the canonical 450 µs number ([#688](https://github.com/cyberlife-coder/VelesDB/pull/688)).
+- **`crates/velesdb-core/README.md`**: same disambiguation pattern applied.
+- **`docs/ARCHITECTURE.md`**: clarifying banner stating it's a tech-debt registry, not the architecture overview, with explicit pointer to the new top-level `ARCHITECTURE.md`.
+- **`docs/reference/promise-contract.json`**: `must_contain` substrings updated to match the disambiguated wording.
+- **`CONTRIBUTING.md`**: Release Process section translated from French to English for consistency.
+- **HNSW**: `NativeHnswIndex::search_with_quality` aligned with `ef_search_for_scale` ([#639](https://github.com/cyberlife-coder/VelesDB/pull/639)).
+- **velesdb-server**: deduplicated batch search response building ([#453](https://github.com/cyberlife-coder/VelesDB/pull/453)).
+- **velesdb-python**: `storage_mode` returns canonical names matching the core enum ([PR #674](https://github.com/cyberlife-coder/VelesDB/pull/674)).
+
+### Fixed
+
+- **WASM**: configure `getrandom 0.3` for `wasm32` after `rand 0.9` migration ([#645](https://github.com/cyberlife-coder/VelesDB/pull/645)).
+- **velesdb-python**: dot metric test correctness.
+
+### Dependencies
+
+- Migrate `rand 0.8 -> 0.9` workspace-wide ([#645](https://github.com/cyberlife-coder/VelesDB/pull/645)).
+- Bump `postcss` `8.5.6 -> 8.5.12` in `sdks/typescript` ([#675](https://github.com/cyberlife-coder/VelesDB/pull/675)).
+
+### Documentation
+
+- New Python `upsert_bulk_numpy()` performance best-practices guide ([#409](https://github.com/cyberlife-coder/VelesDB/pull/409)).
+
+### Internal
+
+- Closed seven SIMD/GPU roadmap issues (#498, #499, #500, #501, #503, #504, #505) into a single tracking issue [#689 — Hardware accelerator backlog (deferred)](https://github.com/cyberlife-coder/VelesDB/issues/689), reducing the visible roadmap from 21 to 15 issues to make focus visible to investors and to the community.
+
+### Migration notes
+
+No migration needed. All changes are additive.
 
 ## [1.13.2] — 2026-04-25
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5647,7 +5647,7 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-velesdb"
-version = "1.13.2"
+version = "1.13.3"
 dependencies = [
  "dirs 5.0.1",
  "parking_lot",
@@ -6613,7 +6613,7 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "velesdb-cli"
-version = "1.13.2"
+version = "1.13.3"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -6638,7 +6638,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-core"
-version = "1.13.2"
+version = "1.13.3"
 dependencies = [
  "arc-swap",
  "bytemuck",
@@ -6692,7 +6692,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-migrate"
-version = "1.13.2"
+version = "1.13.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6720,7 +6720,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-mobile"
-version = "1.13.2"
+version = "1.13.3"
 dependencies = [
  "parking_lot",
  "serde_json",
@@ -6734,7 +6734,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-python"
-version = "1.13.2"
+version = "1.13.3"
 dependencies = [
  "numpy",
  "parking_lot",
@@ -6746,7 +6746,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-server"
-version = "1.13.2"
+version = "1.13.3"
 dependencies = [
  "anyhow",
  "axum",
@@ -6779,7 +6779,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-wasm"
-version = "1.13.2"
+version = "1.13.3"
 dependencies = [
  "getrandom 0.3.4",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "1.13.2"
+version = "1.13.3"
 edition = "2021"
 rust-version = "1.83"
 license-file = "LICENSE"
@@ -77,7 +77,7 @@ base64 = "0.22"
 smallvec = { version = "1", features = ["serde"] }
 
 # Internal workspace crates
-velesdb-core = { path = "crates/velesdb-core", version = "1.13.2", default-features = false }
+velesdb-core = { path = "crates/velesdb-core", version = "1.13.3", default-features = false }
 
 [profile.release]
 lto = true

--- a/crates/tauri-plugin-velesdb/guest-js/package.json
+++ b/crates/tauri-plugin-velesdb/guest-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wiscale/tauri-plugin-velesdb",
-  "version": "1.13.2",
+  "version": "1.13.3",
   "description": "TypeScript bindings for the VelesDB Tauri plugin - Vector search in desktop apps",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/crates/velesdb-python/pyproject.toml
+++ b/crates/velesdb-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "velesdb"
-version = "1.13.2"
+version = "1.13.3"
 description = "VelesDB: The Local Vector Database for Python & AI. Microsecond semantic search, zero network latency."
 readme = "README.md"
 license = { text = "MIT" }

--- a/demos/rag-pdf-demo/pyproject.toml
+++ b/demos/rag-pdf-demo/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "velesdb-rag-demo"
-version = "1.13.2"
+version = "1.13.3"
 description = "RAG Demo with PDF ingestion using VelesDB for vector storage"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/integrations/common/pyproject.toml
+++ b/integrations/common/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "velesdb-common"
-version = "1.13.2"
+version = "1.13.3"
 description = "Shared utilities for VelesDB Python integrations (internal use)"
 readme = "README.md"
 license = {text = "MIT"}

--- a/integrations/langchain/pyproject.toml
+++ b/integrations/langchain/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "langchain-velesdb"
-version = "1.13.2"
+version = "1.13.3"
 description = "LangChain VectorStore for VelesDB: The Local AI Memory Database. Microsecond RAG retrieval."
 readme = "README.md"
 license = {text = "MIT"}

--- a/integrations/llamaindex/pyproject.toml
+++ b/integrations/llamaindex/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "llama-index-vector-stores-velesdb"
-version = "1.13.2"
+version = "1.13.3"
 description = "LlamaIndex VectorStore for VelesDB: The Local AI Memory Database. Microsecond RAG retrieval."
 readme = "README.md"
 license = "MIT"

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wiscale/velesdb-sdk",
-  "version": "1.13.2",
+  "version": "1.13.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wiscale/velesdb-sdk",
-      "version": "1.13.2",
+      "version": "1.13.3",
       "license": "MIT",
       "dependencies": {
         "@wiscale/velesdb-wasm": "^1.4.1"
@@ -1168,6 +1168,7 @@
       "integrity": "sha512-N2clP5pJhB2YnZJ3PIHFk5RkygRX5WO/5f0WC08tp0wd+sv0rsJk3MqWn3CbNmT2J505a5336jaQj4ph1AdMug==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -1221,6 +1222,7 @@
       "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "6.21.0",
         "@typescript-eslint/types": "6.21.0",
@@ -1572,6 +1574,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1897,6 +1900,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -1952,6 +1956,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -3062,6 +3067,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -3526,6 +3532,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3681,6 +3688,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3719,6 +3727,7 @@
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -3812,6 +3821,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3825,6 +3835,7 @@
       "integrity": "sha512-E4t7DJ9pESL6E3I8nFjPa4xGUd3PmiWDLsDztS2qXSJWfHtbQnwAWylaBvSNY48I3vr8PTqIZlyK8TE3V3CA4Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.16",
         "@vitest/mocker": "4.0.16",

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wiscale/velesdb-sdk",
-  "version": "1.13.2",
+  "version": "1.13.3",
   "description": "VelesDB TypeScript SDK: The Local Vector Database for AI & RAG. Microsecond semantic search in Browser & Node.js.",
   "main": "dist/index.js",
   "module": "dist/index.mjs",


### PR DESCRIPTION
## Summary

Back-merge of release/v1.13.3 commits (version bumps + CHANGELOG entry) from `main` to `develop`.

This is the standard Git Flow back-merge after a release tag. No code or behavior change — just the 2 commits that landed on main during the v1.13.3 release:

- `833b67c2` release: v1.13.3 - operational excellence pack + internal improvements
- `5fdae063` Merge pull request #693 from cyberlife-coder/release/v1.13.3

## Why

Without this sync, develop stays behind main on:
- Cargo.toml workspace version (1.13.2 → 1.13.3)
- All package.json / pyproject.toml versions
- Cargo.lock + sdks/typescript/package-lock.json
- CHANGELOG.md `[1.13.3]` section

Future PRs branching from develop would compile against `1.13.2` stale lock entries and the next release (v1.13.4 or v1.14.0) would need to bump from 1.13.2 instead of 1.13.3.

## Verification

- [x] No code change
- [x] Only version manifest bumps + CHANGELOG entry
- [ ] CI green on develop after merge

🤖 Standard post-release sync per release-checklist.md.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/696" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
