### PR TITLE
chore(build): make Cargo.toml authoritative for [profile.release]

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -35,21 +35,25 @@ test-all = "test --all-features"
 #   x86-64-v4: AVX-512 (2017+)
 # =============================================================================
 
-# Build profiles
-[profile.release]
-lto = "thin"
-codegen-units = 1
-panic = "abort"
+# Build profiles are defined in Cargo.toml (workspace root).
+#
+# Why here: Cargo merges [profile.release] from .cargo/config.toml and from
+# Cargo.toml, with config.toml values WINNING for matching keys. Having
+# duplicate definitions silently overrode Cargo.toml's `lto = true` (full LTO)
+# with `lto = "thin"` (thin LTO), downgrading release optimization in a way
+# that was invisible to anyone reading Cargo.toml. Removed — see issue #695.
+# Cargo.toml is now the single source of truth for release/bench optimization
+# flags.
+#
+# To override locally without committing (e.g. faster local link time):
+#   CARGO_PROFILE_RELEASE_LTO=thin cargo build --release
 
+# `release-with-debug` lives here because it inherits from the `release`
+# profile defined in Cargo.toml. Inheritance works regardless of which file
+# the parent profile is in.
 [profile.release-with-debug]
 inherits = "release"
 debug = true
-
-# Benchmark profile - optimized but faster compilation
-[profile.bench]
-lto = "thin"
-codegen-units = 1
-opt-level = 3
 
 # === LOCAL PERFORMANCE OPTIMIZATION ===
 # Uncomment ONLY for local development/benchmarking.


### PR DESCRIPTION
Closes #695.

## Background

Devin Review on PR #693 (release/v1.13.3) flagged a pre-existing config conflict:

- `Cargo.toml` `[profile.release]`: `lto = true` (full LTO)
- `.cargo/config.toml` `[profile.release]`: `lto = "thin"`

When both are present, Cargo merges them with **`config.toml` values WINNING** for matching keys. So the actual release builds were using **thin LTO** instead of the full LTO declared in `Cargo.toml` — a silent downgrade invisible to anyone reading `Cargo.toml`.

## Change

Remove duplicate `[profile.release]` and `[profile.bench]` blocks from `.cargo/config.toml`, leaving `Cargo.toml` as the single source of truth.

`[profile.release-with-debug]` stays in `.cargo/config.toml` (inherits from `release` — works regardless of where the parent is defined).

## Net effect

| Aspect | Before | After |
|--------|--------|-------|
| LTO mode | thin (silent override) | true (full, as declared) |
| codegen-units | 1 | 1 (unchanged) |
| panic | abort | abort (unchanged) |
| strip | true | true (unchanged) |
| Release link time | baseline | +20-30% (full LTO is slower to link) |
| Release runtime hot path | baseline | **neutral** (see local benchmark below) |

For developers who need faster local link time:

```bash
CARGO_PROFILE_RELEASE_LTO=thin cargo build --release
```

## Local benchmark validation (i9-14900K, Windows, smoke_test bench)

Comparing `pre_697_698` baseline (develop, thin LTO) to this branch (full LTO):

| Bench | Baseline | This PR | Change | Verdict |
|-------|----------|---------|--------|---------|
| smoke_insert/10k/128d | 5.0s | 5.02s | +0.04% (p=0.97) | No change |
| smoke_search/10k_k10/128d | 255µs | 258µs | +5.1% (p=0.09) | No significant change |
| smoke_hybrid/vector_plus_filter (run 1) | 473µs | 480µs | +6.9% (p=0.02) | flagged, but... |
| smoke_hybrid/vector_plus_filter (run 2) | 473µs | 504µs | +5.2% (p=0.11) | No significant change |
| smoke_hybrid/vector_plus_filter (run 3) | 473µs | 451µs | -1.6% (p=0.54) | No significant change |

**Verdict per `.claude/rules/perf-phase-gate.md` noise protocol:** 2/3 hybrid runs not statistically significant -> Windows thermal noise on i9-14900K (documented as unreliable in `feedback_bench_noise_windows.md`). CI Ubuntu perf-smoke gate (15% threshold) is the authoritative arbiter.

**Honest take:** the change is for **correctness** (silent override removed, intent honored) more than for **performance**. Full LTO is not noticeably faster than thin LTO on this workload — the rationale is restoring the configuration that Cargo.toml claims to use.

## Verification

- [x] `cargo check -p velesdb-core --release`: PASS
- [x] Local smoke bench: no statistically significant regression (3-run noise check)
- [ ] CI green
- [ ] Devin clean
- [ ] Codacy clean

This change addresses Devin finding #1 from the v1.13.3 release review. The second finding (HnswIndex batch path ef_search alignment, #694) is being addressed in PR #698.