### PR TITLE
perf(hnsw): align remaining ef_search call sites with ef_search_for_scale

### DIFF
--- a/crates/velesdb-core/src/collection/search/vector.rs
+++ b/crates/velesdb-core/src/collection/search/vector.rs
@@ -445,7 +445,12 @@ impl Collection {
     ) -> Result<Vec<SearchResult>> {
         let metric = self.validate_query_and_read_metric(query)?;
 
-        let ef_search = quality.ef_search(k);
+        // Issue #699 follow-up: align with HnswIndex::search_with_quality which
+        // uses ef_search_for_scale. Without scaling, this no-rerank path produced
+        // a smaller ef than search_with_quality on >10K datasets, breaking the
+        // implicit contract that "no rerank" only suppresses reranking, not the
+        // candidate-pool sizing.
+        let ef_search = quality.ef_search_for_scale(k, self.index.len());
         let index_results = self.index.search_hnsw_only(query, k, ef_search);
         Ok(self.finalize_search_results(query, k, metric, index_results))
     }

--- a/crates/velesdb-core/src/index/hnsw/index/batch.rs
+++ b/crates/velesdb-core/src/index/hnsw/index/batch.rs
@@ -211,14 +211,20 @@ impl HnswIndex {
     ) -> crate::error::Result<Vec<Vec<ScoredResult>>> {
         self.validate_batch_dimensions(queries)?;
 
-        // Perfect, Adaptive, or very small collections: delegate to search_with_quality
-        // per-query to match single-query behavior.
+        // Perfect, Adaptive, AutoTune, or very small collections: delegate to
+        // search_with_quality per-query to match single-query behavior.
         // - Perfect: uses brute-force for 100% recall
         // - Adaptive: uses spread-based two-phase escalation (not batch-compatible)
+        // - AutoTune: computes auto-ef range per dataset/dim/k (issue #699 follow-up)
         // - Small (<=100): uses brute-force for fully-connected graph safety
+        //
+        // Without AutoTune in this list, batch + AutoTune would fall through to the
+        // standard ef_search_for_scale HNSW path below — same fixed quality for every
+        // query — which silently disables the adaptive ef-range mechanism that the
+        // single-query path applies via try_search_special_quality.
         if matches!(
             quality,
-            SearchQuality::Perfect | SearchQuality::Adaptive { .. }
+            SearchQuality::Perfect | SearchQuality::Adaptive { .. } | SearchQuality::AutoTune
         ) || (self.len() <= 100 && self.enable_vector_storage && !self.vectors.is_empty())
         {
             let results: crate::error::Result<Vec<Vec<ScoredResult>>> = queries

--- a/crates/velesdb-core/src/index/hnsw/index/brute_force.rs
+++ b/crates/velesdb-core/src/index/hnsw/index/brute_force.rs
@@ -126,8 +126,11 @@ impl HnswIndex {
 
         // If vector storage is disabled, fall back to HNSW graph search.
         // RF-DEDUP: reuse search_hnsw_only instead of duplicating neighbour mapping.
+        // Issue #699 follow-up: ef_search_for_scale aligns this fallback with
+        // HnswIndex::search_with_quality on >10K datasets. The Accurate intent
+        // here (since we can't run brute force) deserves the scaled ef pool.
         if !self.enable_vector_storage || self.vectors.is_empty() {
-            let ef_search = SearchQuality::Accurate.ef_search(k);
+            let ef_search = SearchQuality::Accurate.ef_search_for_scale(k, self.len());
             return Ok(self.search_hnsw_only(query, k, ef_search));
         }
 

--- a/crates/velesdb-core/src/index/hnsw/index/rerank.rs
+++ b/crates/velesdb-core/src/index/hnsw/index/rerank.rs
@@ -25,7 +25,12 @@ impl HnswIndex {
         k: usize,
         rerank_k: usize,
     ) -> crate::error::Result<Vec<ScoredResult>> {
-        let ef_search = SearchQuality::Accurate.ef_search(rerank_k);
+        // Issue #699 follow-up: align with HnswIndex::search_with_quality which
+        // uses ef_search_for_scale. The Accurate quality profile expects a
+        // scaled ef on >10K datasets; without scaling here, the rerank pool was
+        // smaller than what an explicit `search_with_quality(Accurate)` call
+        // would produce.
+        let ef_search = SearchQuality::Accurate.ef_search_for_scale(rerank_k, self.len());
         let adaptive_rerank_k = self
             .should_two_stage_rerank(SearchQuality::Accurate, k, ef_search)
             .unwrap_or(rerank_k.min(self.len().max(k)));


### PR DESCRIPTION
Closes #699.

Follow-up to #694/#698. Devin Review on PR #698 flagged additional pre-existing inconsistencies that share the root pattern of #694 but live in different code paths. This PR addresses all four sites in one focused change.

## Fixes

| # | Site | Before | After |
|---|------|--------|-------|
| 1 | `collection/search/vector.rs:448` (`search_with_quality_no_rerank`) | `quality.ef_search(k)` | `quality.ef_search_for_scale(k, self.index.len())` |
| 2 | `index/hnsw/index/rerank.rs:28` (`search_with_rerank`) | `SearchQuality::Accurate.ef_search(rerank_k)` | `SearchQuality::Accurate.ef_search_for_scale(rerank_k, self.len())` |
| 3 | `index/hnsw/index/brute_force.rs:130` (HNSW-only fallback) | `SearchQuality::Accurate.ef_search(k)` | `SearchQuality::Accurate.ef_search_for_scale(k, self.len())` |
| 4 | `index/hnsw/index/batch.rs:219-222` (special-quality guard) | matches `Perfect \| Adaptive` only | matches `Perfect \| Adaptive \| AutoTune` |

## Behavior

- **Datasets <= 10K**: no change (`ef_search_for_scale` returns base ef).
- **Datasets > 10K**: ef increases by `sqrt(dataset_size / 10000)` capped at 2x. Effect: more candidates explored -> recall stays same or improves; latency increases proportionally. The change is **monotone** (never reduces ef), so recall regression is mathematically impossible.

## AutoTune fix detail

The single-query path delegates `AutoTune` to `search_adaptive` via `try_search_special_quality` (search.rs:375-378), computing an auto-ef range based on dataset/dim/k. The batch path was falling through to the standard `ef_search_for_scale` HNSW path, silently disabling the adaptive ef-range mechanism. Adding `AutoTune` to the special-quality guard makes batch + AutoTune delegate to `search_with_quality` per-query (rayon-parallel), matching the Perfect | Adaptive treatment.

## Verification

```
cargo fmt --all -- --check                                        : PASS
cargo clippy -p velesdb-core --features persistence --tests
  -- -D warnings -D clippy::pedantic                              : PASS
cargo test -p velesdb-core --release --features persistence
  --test bdd recall_contract                                      : PASS
    - Fast >= 90%      : ok
    - Balanced >= 95%  : ok
    - Accurate >= 99%  : ok
    - Perfect == 100%  : ok
python scripts/check_prod_unwraps.py                              : PASS
python scripts/check-promise-contract.py                          : PASS (15 claims)
```

## Test plan

- [x] Local recall gate passes (4/4)
- [x] Clippy strict pedantic clean
- [x] Promise contract synced
- [ ] CI green
- [ ] Devin clean
- [ ] Codacy clean

Resolves the follow-up tracked from PR #698 review. After this merge, all known `ef_search` call sites in production search paths use `ef_search_for_scale`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/700" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
