### PR TITLE
chore: sync develop after v1.13.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-_Nothing yet — post-v1.13.3 work lives under feature branches tracked in [#634](https://github.com/cyberlife-coder/VelesDB/issues/634) (GPU hardening PR-C, PR-E) and the v1.14.0 milestone (#349, #379, #429, #469)._
+_Nothing yet — post-v1.13.4 work lives under the v1.14.0 milestone (#349 Haystack, #379 DX, #429 Python DataFrame, #469 CBO calibration)._
+
+## [1.13.4] — 2026-04-27
+
+### Summary
+
+Strictly additive patch release. Two themes:
+
+1. **Devin-flagged technical debt resolutions** — three follow-ups merged from the v1.13.3 review pass: LTO config canonical source, HNSW `search_batch_parallel` ef_search alignment, and the remaining `ef_search` call sites alignment.
+2. **Dependency hygiene batch** — seven Dependabot bumps validated and merged (one upload-artifact GH Action, two npm dev deps, four cargo deps including `roaring 0.11.4` for upstream bugfixes and `sha2 0.11.0`).
+
+This release is fully backward-compatible — no API breakage, no behavioural change in the canonical end-to-end performance path (450 µs p50 preserved).
+
+### Fixed
+
+- **HNSW batch search**: `HnswIndex::search_batch_parallel` now uses `ef_search_for_scale()` consistently with the single-search path, ensuring identical recall behaviour across batch and individual queries ([#698](https://github.com/cyberlife-coder/VelesDB/pull/698), closes [#695](https://github.com/cyberlife-coder/VelesDB/issues/695)).
+- **HNSW remaining call sites**: aligned all remaining `ef_search` invocations with `ef_search_for_scale` per Devin finding, completing the consistency pass started in v1.13.3 ([#700](https://github.com/cyberlife-coder/VelesDB/pull/700), closes [#699](https://github.com/cyberlife-coder/VelesDB/issues/699)).
+
+### Changed
+
+- **Build profile**: `Cargo.toml` is now the authoritative source for `[profile.release]` and `[profile.bench]` — removed duplicate definitions from per-crate manifests that could drift ([#697](https://github.com/cyberlife-coder/VelesDB/pull/697), closes [#694](https://github.com/cyberlife-coder/VelesDB/issues/694)).
+
+### Dependencies
+
+- **cargo**: `roaring 0.10.12 → 0.11.4` (upstream bugfixes: 32-bit overflow, `advance_back_to` invariant, vector sub zeros) ([#684](https://github.com/cyberlife-coder/VelesDB/pull/684)).
+- **cargo**: `sha2 0.10.9 → 0.11.0` (RustCrypto major; usage limited to standard `Sha256` Digest API, no breakage) ([#682](https://github.com/cyberlife-coder/VelesDB/pull/682)).
+- **cargo**: `indexmap 2.13.0 → 2.14.0` ([#687](https://github.com/cyberlife-coder/VelesDB/pull/687)).
+- **cargo**: `dialoguer 0.11.0 → 0.12.0` ([#686](https://github.com/cyberlife-coder/VelesDB/pull/686)).
+- **npm (dev)**: `@vitest/coverage-v8 4.0.16 → 4.1.5` ([#681](https://github.com/cyberlife-coder/VelesDB/pull/681)).
+- **npm (dev)**: `@types/node 20.19.27 → 25.6.0` ([#679](https://github.com/cyberlife-coder/VelesDB/pull/679)).
+- **GitHub Actions**: `actions/upload-artifact 6.0.0 → 7.0.1` ([#678](https://github.com/cyberlife-coder/VelesDB/pull/678)).
+
+### No-op
+
+- No public API change.
+- No behavioural change in the canonical 450 µs p50 end-to-end path.
+- No SemVer breakage. Workspace SDK versions (Rust crates, Python wheel, npm SDK) all bumped to `1.13.4`.
 
 ## [1.13.3] — 2026-04-27
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "1.13.3"
+version = "1.13.4"
 edition = "2021"
 rust-version = "1.83"
 license-file = "LICENSE"
@@ -77,7 +77,7 @@ base64 = "0.22"
 smallvec = { version = "1", features = ["serde"] }
 
 # Internal workspace crates
-velesdb-core = { path = "crates/velesdb-core", version = "1.13.3", default-features = false }
+velesdb-core = { path = "crates/velesdb-core", version = "1.13.4", default-features = false }
 
 [profile.release]
 lto = true

--- a/crates/tauri-plugin-velesdb/guest-js/package.json
+++ b/crates/tauri-plugin-velesdb/guest-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wiscale/tauri-plugin-velesdb",
-  "version": "1.13.3",
+  "version": "1.13.4",
   "description": "TypeScript bindings for the VelesDB Tauri plugin - Vector search in desktop apps",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/crates/velesdb-python/pyproject.toml
+++ b/crates/velesdb-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "velesdb"
-version = "1.13.3"
+version = "1.13.4"
 description = "VelesDB: The Local Vector Database for Python & AI. Microsecond semantic search, zero network latency."
 readme = "README.md"
 license = { text = "MIT" }

--- a/demos/rag-pdf-demo/pyproject.toml
+++ b/demos/rag-pdf-demo/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "velesdb-rag-demo"
-version = "1.13.3"
+version = "1.13.4"
 description = "RAG Demo with PDF ingestion using VelesDB for vector storage"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/integrations/langchain/pyproject.toml
+++ b/integrations/langchain/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "langchain-velesdb"
-version = "1.13.3"
+version = "1.13.4"
 description = "LangChain VectorStore for VelesDB: The Local AI Memory Database. Microsecond RAG retrieval."
 readme = "README.md"
 license = {text = "MIT"}

--- a/integrations/llamaindex/pyproject.toml
+++ b/integrations/llamaindex/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "llama-index-vector-stores-velesdb"
-version = "1.13.3"
+version = "1.13.4"
 description = "LlamaIndex VectorStore for VelesDB: The Local AI Memory Database. Microsecond RAG retrieval."
 readme = "README.md"
 license = "MIT"

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wiscale/velesdb-sdk",
-  "version": "1.13.3",
+  "version": "1.13.4",
   "description": "VelesDB TypeScript SDK: The Local Vector Database for AI & RAG. Microsecond semantic search in Browser & Node.js.",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
@@ -66,7 +66,7 @@
     "vitest": "^4.0.16"
   },
   "dependencies": {
-    "@wiscale/velesdb-wasm": "^1.4.1"
+    "@wiscale/velesdb-wasm": "^1.13.4"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -66,7 +66,7 @@
     "vitest": "^4.0.16"
   },
   "dependencies": {
-    "@wiscale/velesdb-wasm": "^1.13.4"
+    "@wiscale/velesdb-wasm": "^1.4.1"
   },
   "engines": {
     "node": ">=18.0.0"


### PR DESCRIPTION
Brings the v1.13.4 release commits into develop.

## What's included

Merges main into develop after the v1.13.4 release tag (PR #701).

The following commits are propagated:
- `d5534fc8` chore(release): bump workspace version to 1.13.4
- `692bdb45` docs(changelog): document v1.13.4 release
- `e6153c94` fix(release): restore @wiscale/velesdb-wasm dep to ^1.4.1
- `1b5b03b7` Merge PR #701

## Why merge (not rebase)

Standard sync pattern after release tags: preserves history of release branch, cleanly mirrors main into develop without rewriting commit identifiers downstream contributors might have referenced.

## No new code

This PR only mirrors main into develop. No behavioural change, no new features.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/702" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
