### PR TITLE
chore: sync develop after v1.13.5 fix-up release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-_Nothing yet — post-v1.13.4 work lives under the v1.14.0 milestone (#349 Haystack, #379 DX, #429 Python DataFrame, #469 CBO calibration)._
+_Nothing yet — post-v1.13.5 work lives under the v1.14.0 milestone (#349 Haystack, #379 DX, #429 Python DataFrame, #469 CBO calibration)._
+
+## [1.13.5] — 2026-04-28
+
+### Summary
+
+Fix-up patch release for v1.13.4. PyPI and npm packages were published successfully at `1.13.4`, but `cargo publish --locked` to `crates.io` failed because `Cargo.lock` was not regenerated after the version bump (lock file still listed crates at `1.13.3`). v1.13.5 ships the regenerated `Cargo.lock` so all eight workspace crates can be published to `crates.io` consistently with the npm/PyPI packages.
+
+### Fixed
+
+- **crates.io publishing**: `Cargo.lock` regenerated to match the workspace version, unblocking `cargo publish --locked` for all eight workspace crates ([#701](https://github.com/cyberlife-coder/VelesDB/pull/701) follow-up).
+
+### No-op
+
+- No source code change beyond `Cargo.lock` regeneration and version-string bumps from `1.13.4` to `1.13.5`.
+- No public API change.
+- No behavioural change in the canonical 450 µs p50 end-to-end path.
 
 ## [1.13.4] — 2026-04-27
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5728,7 +5728,7 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-velesdb"
-version = "1.13.3"
+version = "1.13.5"
 dependencies = [
  "dirs 5.0.1",
  "parking_lot",
@@ -6694,7 +6694,7 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "velesdb-cli"
-version = "1.13.3"
+version = "1.13.5"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -6719,7 +6719,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-core"
-version = "1.13.3"
+version = "1.13.5"
 dependencies = [
  "arc-swap",
  "bytemuck",
@@ -6773,7 +6773,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-migrate"
-version = "1.13.3"
+version = "1.13.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6801,7 +6801,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-mobile"
-version = "1.13.3"
+version = "1.13.5"
 dependencies = [
  "parking_lot",
  "serde_json",
@@ -6815,7 +6815,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-python"
-version = "1.13.3"
+version = "1.13.5"
 dependencies = [
  "numpy",
  "parking_lot",
@@ -6827,7 +6827,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-server"
-version = "1.13.3"
+version = "1.13.5"
 dependencies = [
  "anyhow",
  "axum",
@@ -6860,7 +6860,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-wasm"
-version = "1.13.3"
+version = "1.13.5"
 dependencies = [
  "getrandom 0.3.4",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "1.13.4"
+version = "1.13.5"
 edition = "2021"
 rust-version = "1.83"
 license-file = "LICENSE"
@@ -77,7 +77,7 @@ base64 = "0.22"
 smallvec = { version = "1", features = ["serde"] }
 
 # Internal workspace crates
-velesdb-core = { path = "crates/velesdb-core", version = "1.13.4", default-features = false }
+velesdb-core = { path = "crates/velesdb-core", version = "1.13.5", default-features = false }
 
 [profile.release]
 lto = true

--- a/crates/tauri-plugin-velesdb/guest-js/package.json
+++ b/crates/tauri-plugin-velesdb/guest-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wiscale/tauri-plugin-velesdb",
-  "version": "1.13.4",
+  "version": "1.13.5",
   "description": "TypeScript bindings for the VelesDB Tauri plugin - Vector search in desktop apps",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/crates/velesdb-python/pyproject.toml
+++ b/crates/velesdb-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "velesdb"
-version = "1.13.4"
+version = "1.13.5"
 description = "VelesDB: The Local Vector Database for Python & AI. Microsecond semantic search, zero network latency."
 readme = "README.md"
 license = { text = "MIT" }

--- a/demos/rag-pdf-demo/pyproject.toml
+++ b/demos/rag-pdf-demo/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "velesdb-rag-demo"
-version = "1.13.4"
+version = "1.13.5"
 description = "RAG Demo with PDF ingestion using VelesDB for vector storage"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/integrations/langchain/pyproject.toml
+++ b/integrations/langchain/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "langchain-velesdb"
-version = "1.13.4"
+version = "1.13.5"
 description = "LangChain VectorStore for VelesDB: The Local AI Memory Database. Microsecond RAG retrieval."
 readme = "README.md"
 license = {text = "MIT"}

--- a/integrations/llamaindex/pyproject.toml
+++ b/integrations/llamaindex/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "llama-index-vector-stores-velesdb"
-version = "1.13.4"
+version = "1.13.5"
 description = "LlamaIndex VectorStore for VelesDB: The Local AI Memory Database. Microsecond RAG retrieval."
 readme = "README.md"
 license = "MIT"

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wiscale/velesdb-sdk",
-  "version": "1.13.4",
+  "version": "1.13.5",
   "description": "VelesDB TypeScript SDK: The Local Vector Database for AI & RAG. Microsecond semantic search in Browser & Node.js.",
   "main": "dist/index.js",
   "module": "dist/index.mjs",


### PR DESCRIPTION
Brings v1.13.5 commits into develop. No new code, mirrors main.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/704" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
