### PR TITLE
fix(ts-sdk): WasmBackend.init() works in Node.js (real DX bug)

### DIFF
--- a/sdks/typescript/src/backends/wasm-node-loader.ts
+++ b/sdks/typescript/src/backends/wasm-node-loader.ts
@@ -1,0 +1,83 @@
+/**
+ * Node-only helpers for the WASM backend.
+ *
+ * Browsers initialize the wasm-pack module via its default `fetch` path —
+ * no extra plumbing is needed there. Node consumers, however, fail at
+ * `default()` because Node's stdlib `fetch` has no `file://` scheme handler
+ * (the import explodes with "not implemented... yet..."). This module
+ * isolates the Node detection + bytes-loader so `wasm.ts` stays under the
+ * 500 NLOC limit (.claude/rules/code-quality.md).
+ *
+ * The functions here are referenced from `wasm.ts#init()` exactly when
+ * {@link isNodeRuntime} returns true; in browser bundles the readdir/fs/
+ * require imports are never hit because the conditional fences them off.
+ */
+
+// Ambient declaration so this TypeScript source can reference Node's CJS
+// `__filename` global without dragging in `@types/node`. The runtime check
+// `typeof __filename !== 'undefined'` keeps ESM bundles safe — the variable
+// only resolves under a CJS module wrapper.
+declare const __filename: string | undefined;
+
+/**
+ * True iff we're running under a Node.js runtime. Centralized so both the
+ * `init()` branch decision in `WasmBackend` and the bytes-loader below use
+ * the same signal.
+ */
+export function isNodeRuntime(): boolean {
+  return (
+    typeof process !== 'undefined' &&
+    Boolean((process as { versions?: { node?: string } }).versions?.node)
+  );
+}
+
+/**
+ * Read the wasm binary from disk in Node.js, returning a `Uint8Array` that
+ * the wasm-pack `default()` initializer accepts as a `BufferSource`.
+ *
+ * Implementation notes:
+ *   - The WASM filename is **discovered at runtime by listing the package
+ *     directory** (`fs.readdir`) and picking the first `*.wasm` entry. We
+ *     deliberately do NOT inspect `package.json#files` because that field
+ *     is an npm publish whitelist, not a general-purpose manifest — if the
+ *     `@wiscale/velesdb-wasm` package ever switches to `.npmignore` or
+ *     forgets to list the binary, the manifest-based lookup would fail
+ *     even though the file is present on disk.
+ *   - The module identifier passed to `createRequire` is selected per
+ *     module system: in CJS we use `__filename` (always defined under
+ *     Node's CommonJS wrapper); in ESM we fall back to `import.meta.url`.
+ *     Per-format branching is required because tsup's CJS output leaves
+ *     `import.meta.url` as `undefined`, which would make
+ *     `createRequire(undefined)` throw `ERR_INVALID_ARG_VALUE`.
+ *
+ * Browser callers never hit this path — the consumer's `init()` only
+ * invokes it when {@link isNodeRuntime} is true.
+ */
+export async function loadWasmBytesNode(): Promise<Uint8Array> {
+  const [{ createRequire }, { readFile, readdir }, path] = await Promise.all([
+    import('node:module'),
+    import('node:fs/promises'),
+    import('node:path'),
+  ]);
+
+  const cjsFilename =
+    typeof __filename !== 'undefined' ? __filename : undefined;
+  const moduleId =
+    typeof cjsFilename === 'string' && cjsFilename.length > 0
+      ? cjsFilename
+      : import.meta.url;
+  const require = createRequire(moduleId);
+  const pkgJsonPath = require.resolve('@wiscale/velesdb-wasm/package.json');
+  const pkgDir = path.dirname(pkgJsonPath);
+
+  const entries = await readdir(pkgDir);
+  const wasmFile = entries.find((name) => name.endsWith('.wasm'));
+  if (!wasmFile) {
+    throw new Error(
+      `Cannot locate a *.wasm binary in @wiscale/velesdb-wasm at ${pkgDir}. ` +
+        'The Node.js path expects wasm-pack output (e.g. velesdb_wasm_bg.wasm) ' +
+        'to be present alongside package.json.'
+    );
+  }
+  return readFile(path.join(pkgDir, wasmFile));
+}

--- a/sdks/typescript/src/backends/wasm-types.ts
+++ b/sdks/typescript/src/backends/wasm-types.ts
@@ -137,8 +137,15 @@ export interface WasmVectorStoreConstructor {
 
 /** Typed interface for the @wiscale/velesdb-wasm module. */
 export interface WasmModule {
-  /** WASM initialization function (must be called once before use). */
-  default(): Promise<void>;
+  /** WASM initialization function (must be called once before use).
+   *
+   * Accepts an optional argument that wasm-bindgen forwards to its loader:
+   *  - browser: omit, the loader will fetch the .wasm next to the JS module.
+   *  - Node.js: pass a `BufferSource` (e.g. `await fs.readFile(...)`) because
+   *    Node's stdlib fetch has no `file://` scheme handler. The WasmBackend
+   *    helper does this transparently when running under Node.
+   */
+  default(moduleOrPath?: Uint8Array | URL | string): Promise<void>;
 
   /** VectorStore class constructor. */
   VectorStore: WasmVectorStoreConstructor;

--- a/sdks/typescript/src/backends/wasm.ts
+++ b/sdks/typescript/src/backends/wasm.ts
@@ -51,6 +51,7 @@ import {
   buildWasmContext,
   buildCollectionInfo,
 } from './wasm-helpers';
+import { isNodeRuntime, loadWasmBytesNode } from './wasm-node-loader';
 
 // Search & query delegates
 import {
@@ -432,79 +433,7 @@ export class WasmBackend implements IVelesDBBackend {
   async graphSearch(c: string, r: import('../types').GraphSearchRequest): Promise<import('../types').GraphSearchResponse> { this.ensureInitialized(); return wasmGraphSearch(c, r); }
 }
 
-/**
- * True iff we're running under a Node.js runtime. Centralized so both the
- * init() branch decision and the bytes-loader use the same signal.
- */
-function isNodeRuntime(): boolean {
-  return (
-    typeof process !== 'undefined' &&
-    Boolean((process as { versions?: { node?: string } }).versions?.node)
-  );
-}
-
-/**
- * Read the wasm binary from disk in Node.js, returning a Uint8Array that
- * the wasm-pack `default()` initializer accepts as a `BufferSource`.
- *
- * Robustness against the bundled-package layout:
- *   - The WASM filename is **discovered** at runtime by reading
- *     `@wiscale/velesdb-wasm/package.json#files` for any `*.wasm` entry, so
- *     this code does not break if wasm-pack ever changes its default
- *     `<crate>_bg.wasm` naming or if `--out-name` is customized.
- *   - `createRequire(import.meta.url)` is the canonical pattern for module
- *     resolution under both ESM and CJS Node consumers. The CJS bundle
- *     produced by tsup rewrites `import.meta.url` to a `__filename`-based
- *     URL automatically, so this single line works under both module
- *     systems without per-format branching.
- *
- * Browser callers never hit this path — `init()` only invokes it when
- * {@link isNodeRuntime} is true.
- */
-// Ambient declaration so the TypeScript source can reference Node's CJS
-// `__filename` global without dragging in `@types/node`. The runtime check
-// `typeof __filename !== 'undefined'` keeps ESM bundles safe — the variable
-// only resolves under a CJS module wrapper.
-declare const __filename: string | undefined;
-
-async function loadWasmBytesNode(): Promise<Uint8Array> {
-  const [{ createRequire }, { readFile, readdir }, path] = await Promise.all([
-    import('node:module'),
-    import('node:fs/promises'),
-    import('node:path'),
-  ]);
-  // Pick whichever module identifier is actually defined in this runtime:
-  //   - CJS: `__filename` is wrapped in by Node's CommonJS module loader.
-  //   - ESM: `import.meta.url` is the spec-mandated locator.
-  // We prefer `__filename` first because tsup's CJS output leaves
-  // `import.meta.url` as `undefined`, which would make `createRequire`
-  // throw ERR_INVALID_ARG_VALUE under `require('@wiscale/velesdb-sdk')`.
-  const cjsFilename =
-    typeof __filename !== 'undefined' ? __filename : undefined;
-  const moduleId =
-    typeof cjsFilename === 'string' && cjsFilename.length > 0
-      ? cjsFilename
-      : import.meta.url;
-  const require = createRequire(moduleId);
-  const pkgJsonPath = require.resolve('@wiscale/velesdb-wasm/package.json');
-  const pkgDir = path.dirname(pkgJsonPath);
-
-  // Discover the WASM binary by listing files actually present on disk.
-  // We deliberately do NOT inspect package.json#files because that field is
-  // an npm publish whitelist, not a general manifest — if the publisher
-  // ever switches to .npmignore (or simply forgets to include the wasm in
-  // `files`), the manifest-based lookup would fail even though the binary
-  // is present in the installed package. Reading the directory matches
-  // what wasm-pack actually ships and is resilient to packaging convention
-  // changes upstream.
-  const entries = await readdir(pkgDir);
-  const wasmFile = entries.find((name) => name.endsWith('.wasm'));
-  if (!wasmFile) {
-    throw new Error(
-      `Cannot locate a *.wasm binary in @wiscale/velesdb-wasm at ${pkgDir}. ` +
-        'The Node.js path expects wasm-pack output (e.g. velesdb_wasm_bg.wasm) ' +
-        'to be present alongside package.json.'
-    );
-  }
-  return readFile(path.join(pkgDir, wasmFile));
-}
+// Node-only init helpers (`isNodeRuntime`, `loadWasmBytesNode`) live in
+// `./wasm-node-loader` so this file stays under the .claude/rules
+// code-quality.md 500-NLOC ceiling. Browser bundles never reach the
+// loader because `init()` gates the import on `isNodeRuntime()`.

--- a/sdks/typescript/src/backends/wasm.ts
+++ b/sdks/typescript/src/backends/wasm.ts
@@ -118,6 +118,11 @@ export class WasmBackend implements IVelesDBBackend {
   private wasmModule: WasmModule | null = null;
   private collections: Map<string, CollectionData> = new Map();
   private _initialized = false;
+  // Memoized single-shot init promise. Subsequent concurrent calls to init()
+  // await the same in-flight initialization instead of racing into duplicate
+  // wasm-bindgen `default()` invocations. Cleared on close() so a fresh
+  // backend instance can re-initialize if needed.
+  private _initInFlight: Promise<void> | null = null;
 
   // ========================================================================
   // Lifecycle
@@ -125,6 +130,14 @@ export class WasmBackend implements IVelesDBBackend {
 
   async init(): Promise<void> {
     if (this._initialized) { return; }
+    if (this._initInFlight) { return this._initInFlight; }
+    this._initInFlight = this.runInit().finally(() => {
+      this._initInFlight = null;
+    });
+    return this._initInFlight;
+  }
+
+  private async runInit(): Promise<void> {
     try {
       this.wasmModule = await import('@wiscale/velesdb-wasm') as unknown as WasmModule;
       // The wasm-pack default init() does `fetch(wasmUrl)` to locate the .wasm
@@ -132,10 +145,7 @@ export class WasmBackend implements IVelesDBBackend {
       // handler for `file://`, so the import explodes with
       // "not implemented... yet..." (see #379 honesty notes).
       // Detect Node and pass an explicit Buffer so init never relies on fetch.
-      const isNode =
-        typeof process !== 'undefined' &&
-        Boolean((process as { versions?: { node?: string } }).versions?.node);
-      if (isNode) {
+      if (isNodeRuntime()) {
         await this.wasmModule.default(await loadWasmBytesNode());
       } else {
         await this.wasmModule.default();
@@ -155,6 +165,7 @@ export class WasmBackend implements IVelesDBBackend {
     for (const [, data] of this.collections) { data.store.free(); }
     this.collections.clear();
     this._initialized = false;
+    this._initInFlight = null;
   }
 
   capabilities(): Readonly<CapabilityMap> { return WASM_CAPABILITIES; }
@@ -400,17 +411,71 @@ export class WasmBackend implements IVelesDBBackend {
 }
 
 /**
- * Read the wasm binary from disk in Node.js, returning a Buffer that the
- * wasm-pack `default()` initializer accepts as a `BufferSource`. Resolved
- * via `createRequire` so it works under both ESM and CJS consumers.
+ * True iff we're running under a Node.js runtime. Centralized so both the
+ * init() branch decision and the bytes-loader use the same signal.
+ */
+function isNodeRuntime(): boolean {
+  return (
+    typeof process !== 'undefined' &&
+    Boolean((process as { versions?: { node?: string } }).versions?.node)
+  );
+}
+
+/**
+ * Read the wasm binary from disk in Node.js, returning a Uint8Array that
+ * the wasm-pack `default()` initializer accepts as a `BufferSource`.
+ *
+ * Robustness against the bundled-package layout:
+ *   - The WASM filename is **discovered** at runtime by reading
+ *     `@wiscale/velesdb-wasm/package.json#files` for any `*.wasm` entry, so
+ *     this code does not break if wasm-pack ever changes its default
+ *     `<crate>_bg.wasm` naming or if `--out-name` is customized.
+ *   - `createRequire(import.meta.url)` is the canonical pattern for module
+ *     resolution under both ESM and CJS Node consumers. The CJS bundle
+ *     produced by tsup rewrites `import.meta.url` to a `__filename`-based
+ *     URL automatically, so this single line works under both module
+ *     systems without per-format branching.
  *
  * Browser callers never hit this path — `init()` only invokes it when
- * `process.versions.node` is set.
+ * {@link isNodeRuntime} is true.
  */
+// Ambient declaration so the TypeScript source can reference Node's CJS
+// `__filename` global without dragging in `@types/node`. The runtime check
+// `typeof __filename !== 'undefined'` keeps ESM bundles safe — the variable
+// only resolves under a CJS module wrapper.
+declare const __filename: string | undefined;
+
 async function loadWasmBytesNode(): Promise<Uint8Array> {
-  const { createRequire } = await import('node:module');
-  const { readFile } = await import('node:fs/promises');
-  const require = createRequire(import.meta.url);
-  const wasmPath = require.resolve('@wiscale/velesdb-wasm/velesdb_wasm_bg.wasm');
-  return readFile(wasmPath);
+  const [{ createRequire }, { readFile }, path] = await Promise.all([
+    import('node:module'),
+    import('node:fs/promises'),
+    import('node:path'),
+  ]);
+  // Pick whichever module identifier is actually defined in this runtime:
+  //   - CJS: `__filename` is wrapped in by Node's CommonJS module loader.
+  //   - ESM: `import.meta.url` is the spec-mandated locator.
+  // We prefer `__filename` first because tsup's CJS output leaves
+  // `import.meta.url` as `undefined`, which would make `createRequire`
+  // throw ERR_INVALID_ARG_VALUE under `require('@wiscale/velesdb-sdk')`.
+  const cjsFilename =
+    typeof __filename !== 'undefined' ? __filename : undefined;
+  const moduleId =
+    typeof cjsFilename === 'string' && cjsFilename.length > 0
+      ? cjsFilename
+      : import.meta.url;
+  const require = createRequire(moduleId);
+  const pkgJsonPath = require.resolve('@wiscale/velesdb-wasm/package.json');
+  const pkgDir = path.dirname(pkgJsonPath);
+
+  const pkgManifest = JSON.parse(
+    await readFile(pkgJsonPath, 'utf8')
+  ) as { files?: string[] };
+  const wasmFile = (pkgManifest.files ?? []).find((f) => f.endsWith('.wasm'));
+  if (!wasmFile) {
+    throw new Error(
+      '@wiscale/velesdb-wasm package.json declares no *.wasm in its `files` field; ' +
+        'cannot locate the WebAssembly binary for Node.js initialization.'
+    );
+  }
+  return readFile(path.join(pkgDir, wasmFile));
 }

--- a/sdks/typescript/src/backends/wasm.ts
+++ b/sdks/typescript/src/backends/wasm.ts
@@ -446,7 +446,7 @@ function isNodeRuntime(): boolean {
 declare const __filename: string | undefined;
 
 async function loadWasmBytesNode(): Promise<Uint8Array> {
-  const [{ createRequire }, { readFile }, path] = await Promise.all([
+  const [{ createRequire }, { readFile, readdir }, path] = await Promise.all([
     import('node:module'),
     import('node:fs/promises'),
     import('node:path'),
@@ -467,14 +467,21 @@ async function loadWasmBytesNode(): Promise<Uint8Array> {
   const pkgJsonPath = require.resolve('@wiscale/velesdb-wasm/package.json');
   const pkgDir = path.dirname(pkgJsonPath);
 
-  const pkgManifest = JSON.parse(
-    await readFile(pkgJsonPath, 'utf8')
-  ) as { files?: string[] };
-  const wasmFile = (pkgManifest.files ?? []).find((f) => f.endsWith('.wasm'));
+  // Discover the WASM binary by listing files actually present on disk.
+  // We deliberately do NOT inspect package.json#files because that field is
+  // an npm publish whitelist, not a general manifest — if the publisher
+  // ever switches to .npmignore (or simply forgets to include the wasm in
+  // `files`), the manifest-based lookup would fail even though the binary
+  // is present in the installed package. Reading the directory matches
+  // what wasm-pack actually ships and is resilient to packaging convention
+  // changes upstream.
+  const entries = await readdir(pkgDir);
+  const wasmFile = entries.find((name) => name.endsWith('.wasm'));
   if (!wasmFile) {
     throw new Error(
-      '@wiscale/velesdb-wasm package.json declares no *.wasm in its `files` field; ' +
-        'cannot locate the WebAssembly binary for Node.js initialization.'
+      `Cannot locate a *.wasm binary in @wiscale/velesdb-wasm at ${pkgDir}. ` +
+        'The Node.js path expects wasm-pack output (e.g. velesdb_wasm_bg.wasm) ' +
+        'to be present alongside package.json.'
     );
   }
   return readFile(path.join(pkgDir, wasmFile));

--- a/sdks/typescript/src/backends/wasm.ts
+++ b/sdks/typescript/src/backends/wasm.ts
@@ -123,6 +123,12 @@ export class WasmBackend implements IVelesDBBackend {
   // wasm-bindgen `default()` invocations. Cleared on close() so a fresh
   // backend instance can re-initialize if needed.
   private _initInFlight: Promise<void> | null = null;
+  // Generation token bumped by close(). runInit() captures the token at
+  // entry and refuses to publish its result if close() advanced the
+  // generation while the async work was in flight. Without this, calling
+  // close() during an in-flight init() would let the racy completion of
+  // runInit() flip _initialized back to true after close() set it false.
+  private _initGen = 0;
 
   // ========================================================================
   // Lifecycle
@@ -131,25 +137,35 @@ export class WasmBackend implements IVelesDBBackend {
   async init(): Promise<void> {
     if (this._initialized) { return; }
     if (this._initInFlight) { return this._initInFlight; }
-    this._initInFlight = this.runInit().finally(() => {
-      this._initInFlight = null;
+    const gen = this._initGen;
+    this._initInFlight = this.runInit(gen).finally(() => {
+      // Only clear the in-flight slot if this run is still the active one.
+      // close() may have already cleared it and advanced the generation.
+      if (this._initGen === gen) {
+        this._initInFlight = null;
+      }
     });
     return this._initInFlight;
   }
 
-  private async runInit(): Promise<void> {
+  private async runInit(gen: number): Promise<void> {
     try {
-      this.wasmModule = await import('@wiscale/velesdb-wasm') as unknown as WasmModule;
+      const mod = (await import('@wiscale/velesdb-wasm')) as unknown as WasmModule;
       // The wasm-pack default init() does `fetch(wasmUrl)` to locate the .wasm
       // binary. That works in the browser but Node's undici has no scheme
       // handler for `file://`, so the import explodes with
       // "not implemented... yet..." (see #379 honesty notes).
       // Detect Node and pass an explicit Buffer so init never relies on fetch.
       if (isNodeRuntime()) {
-        await this.wasmModule.default(await loadWasmBytesNode());
+        await mod.default(await loadWasmBytesNode());
       } else {
-        await this.wasmModule.default();
+        await mod.default();
       }
+      // Publish the result only if close() did not advance the generation
+      // while the async work above was running. Otherwise the run is stale
+      // and must not flip _initialized back to true after close() reset it.
+      if (this._initGen !== gen) { return; }
+      this.wasmModule = mod;
       this._initialized = true;
     } catch (error) {
       throw new ConnectionError(
@@ -166,6 +182,12 @@ export class WasmBackend implements IVelesDBBackend {
     this.collections.clear();
     this._initialized = false;
     this._initInFlight = null;
+    // Drop the WASM module reference so a future init() picks up a fresh
+    // import rather than reusing a possibly-stale handle, and bump the
+    // generation so any concurrently in-flight runInit() refuses to
+    // publish its result over our cleared state.
+    this.wasmModule = null;
+    this._initGen += 1;
   }
 
   capabilities(): Readonly<CapabilityMap> { return WASM_CAPABILITIES; }

--- a/sdks/typescript/src/backends/wasm.ts
+++ b/sdks/typescript/src/backends/wasm.ts
@@ -127,7 +127,19 @@ export class WasmBackend implements IVelesDBBackend {
     if (this._initialized) { return; }
     try {
       this.wasmModule = await import('@wiscale/velesdb-wasm') as unknown as WasmModule;
-      await this.wasmModule.default();
+      // The wasm-pack default init() does `fetch(wasmUrl)` to locate the .wasm
+      // binary. That works in the browser but Node's undici has no scheme
+      // handler for `file://`, so the import explodes with
+      // "not implemented... yet..." (see #379 honesty notes).
+      // Detect Node and pass an explicit Buffer so init never relies on fetch.
+      const isNode =
+        typeof process !== 'undefined' &&
+        Boolean((process as { versions?: { node?: string } }).versions?.node);
+      if (isNode) {
+        await this.wasmModule.default(await loadWasmBytesNode());
+      } else {
+        await this.wasmModule.default();
+      }
       this._initialized = true;
     } catch (error) {
       throw new ConnectionError(
@@ -385,4 +397,20 @@ export class WasmBackend implements IVelesDBBackend {
   async getNodePayload(c: string, id: number): Promise<import('../types').NodePayloadResponse> { this.ensureInitialized(); return wasmGetNodePayload(c, id); }
   async upsertNodePayload(c: string, id: number, p: Record<string, unknown>): Promise<void> { this.ensureInitialized(); return wasmUpsertNodePayload(c, id, p); }
   async graphSearch(c: string, r: import('../types').GraphSearchRequest): Promise<import('../types').GraphSearchResponse> { this.ensureInitialized(); return wasmGraphSearch(c, r); }
+}
+
+/**
+ * Read the wasm binary from disk in Node.js, returning a Buffer that the
+ * wasm-pack `default()` initializer accepts as a `BufferSource`. Resolved
+ * via `createRequire` so it works under both ESM and CJS consumers.
+ *
+ * Browser callers never hit this path — `init()` only invokes it when
+ * `process.versions.node` is set.
+ */
+async function loadWasmBytesNode(): Promise<Uint8Array> {
+  const { createRequire } = await import('node:module');
+  const { readFile } = await import('node:fs/promises');
+  const require = createRequire(import.meta.url);
+  const wasmPath = require.resolve('@wiscale/velesdb-wasm/velesdb_wasm_bg.wasm');
+  return readFile(wasmPath);
 }

--- a/sdks/typescript/tests/wasm-backend.test.ts
+++ b/sdks/typescript/tests/wasm-backend.test.ts
@@ -68,6 +68,19 @@ describe('WasmBackend', () => {
       await backend.init(); // Should not throw
       expect(backend.isInitialized()).toBe(true);
     });
+
+    it('should coalesce concurrent init() calls into one wasm-bindgen invocation', async () => {
+      // Pre-existing TOCTOU race in init() flagged by Devin Review on PR #709:
+      // two callers entering init() before _initialized is set both raced into
+      // wasm-bindgen's default(). The fix memoizes a single in-flight promise.
+      // This test makes sure the wasm `default()` initializer is invoked
+      // exactly once even with three concurrent init() callers.
+      const defaultSpy = mockWasmModule.default;
+      defaultSpy.mockClear();
+      await Promise.all([backend.init(), backend.init(), backend.init()]);
+      expect(defaultSpy).toHaveBeenCalledTimes(1);
+      expect(backend.isInitialized()).toBe(true);
+    });
   });
 
   describe('collection operations', () => {

--- a/sdks/typescript/tests/wasm-backend.test.ts
+++ b/sdks/typescript/tests/wasm-backend.test.ts
@@ -81,6 +81,34 @@ describe('WasmBackend', () => {
       expect(defaultSpy).toHaveBeenCalledTimes(1);
       expect(backend.isInitialized()).toBe(true);
     });
+
+    it('should not flip back to initialized when close() races an in-flight init()', async () => {
+      // Devin Review on PR #709 round 2 flagged that close() during in-flight
+      // runInit() did not cancel: runInit() would still complete and set
+      // _initialized = true after close() set it false. The fix bumps a
+      // generation counter in close() that runInit() captures at entry and
+      // checks before publishing _initialized. This test simulates the race
+      // by starting init() and calling close() before the awaited promise
+      // resolves, then ensures the backend stays closed.
+      const initPromise = backend.init();
+      await backend.close();
+      await initPromise;
+      expect(backend.isInitialized()).toBe(false);
+    });
+
+    it('should null out wasmModule on close()', async () => {
+      // Devin Review on PR #709 round 2: close() previously left wasmModule
+      // set, so a follow-up init() reused a stale handle. We now clear it
+      // and re-import on the next init().
+      await backend.init();
+      expect(backend.isInitialized()).toBe(true);
+      await backend.close();
+      expect(backend.isInitialized()).toBe(false);
+      // Re-init must succeed (i.e. the cleared module reference does not
+      // break the lifecycle).
+      await backend.init();
+      expect(backend.isInitialized()).toBe(true);
+    });
   });
 
   describe('collection operations', () => {


### PR DESCRIPTION
## Summary

`new VelesDB({ backend: 'wasm' })` followed by `db.init()` crashes 100% of the time in Node.js with:

```
Failed to initialize WASM module
  cause: Error: not implemented... yet...
    at schemeFetch (node:internal/deps/undici/undici:10891:34)
```

The wasm-pack `default()` initializer fetches the .wasm file via the global `fetch()`. Browsers handle this fine. Node.js's undici has no scheme handler for `file://` URLs, so the import explodes the first time.

The JSDoc on `VelesDB` ([sdks/typescript/src/index.ts:8](sdks/typescript/src/index.ts)) advertises *"WASM backend (browser/Node.js)"* — so this was a real DX bug, not a documented limitation.

## Discovered via

While building dx-timing onboarding scenarios for [#379](https://github.com/cyberlife-coder/VelesDB/issues/379), the Node container scenario crashed at `db.init()`. Reproducible on Node 20 + `@wiscale/velesdb-sdk@1.13.6`.

## Fix

- `WasmBackend.init()` ([wasm.ts:126](sdks/typescript/src/backends/wasm.ts)) detects Node via `process.versions.node` and, when running there, reads the `velesdb_wasm_bg.wasm` bytes from disk via `createRequire` + `node:fs/promises.readFile`, then passes them to the wasm-pack initializer as an explicit `Uint8Array`. Browsers keep the fetch path unchanged.
- `WasmModule.default()` type signature updated to accept the optional `Uint8Array | URL | string` arg the wasm-pack runtime actually supports.

## Validation

- 26/26 existing wasm-backend tests pass with the fix (no regression on browser-style mock).
- Manual smoke test in Docker `node:20-slim` container with `@wiscale/velesdb-sdk` installed locally:
  ```
  first match: id=1 score=1.0000
  ```
  Reproducible via the dx-timing scenario being prepared for #379.

## Impact

- **Browser**: zero change. The Node detection branch never executes in a browser environment (no `process` global).
- **Node.js**: the WASM backend now works. `new VelesDB({ backend: 'wasm' })` + `db.init()` succeeds.
- **REST backend**: unchanged.

## Release note

This fix should ship as v1.13.7 patch so the public npm package is usable from Node.js (not just browsers). No bump required for Rust crates / Python wheel — they are unaffected.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/709" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
