### PR TITLE
chore: sync develop after v1.13.7 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-_Nothing yet — post-v1.13.6 work lives under the v1.14.0 milestone (#349 Haystack, #379 DX, #429 Python DataFrame, #469 CBO calibration)._
+_Nothing yet — post-v1.13.7 work lives under the v1.14.0 milestone (#349 Haystack, #379 DX, #429 Python DataFrame, #469 CBO calibration)._
+
+## [1.13.7] — 2026-04-28
+
+### Summary
+
+TypeScript SDK patch release. Fixes a Node.js-specific bug discovered while
+building the dx-timing onboarding scenarios for [#379](https://github.com/cyberlife-coder/VelesDB/issues/379):
+`new VelesDB({ backend: 'wasm' })` followed by `db.init()` crashed 100% of the
+time in Node.js because wasm-pack's default initializer relies on
+`fetch('file://...')`, which Node's stdlib `fetch` (undici) does not support.
+
+The JSDoc on the public `VelesDB` class advertises *"WASM backend (browser/Node.js)"*,
+so the crash was a real DX bug, not a documented limitation. v1.13.7 makes
+that promise true.
+
+### Fixed
+
+- **TS SDK `WasmBackend.init()` now works in Node.js** ([#709](https://github.com/cyberlife-coder/VelesDB/pull/709)). When running under Node, the backend reads the `velesdb_wasm_bg.wasm` bytes from disk via `fs.readFile` and passes them to wasm-pack's initializer as an explicit `Uint8Array`, bypassing the broken `fetch('file://...')` path. Browsers keep the original fetch behaviour unchanged.
+- **TS SDK lifecycle hardening** (same PR). `init()` is now race-free: a memoized in-flight promise coalesces concurrent callers into a single wasm-bindgen invocation, and `close()` bumps a generation counter so a still-running `runInit()` cannot flip `_initialized` back to `true` after the backend has been closed. `close()` also nulls out `wasmModule` so subsequent `init()` calls re-import cleanly.
+
+### Changed
+
+- TS SDK build now emits both ESM and CJS bundles that work end-to-end in Node.js. Verified with `node:20-slim` Docker container (smoke test in [#709](https://github.com/cyberlife-coder/VelesDB/pull/709)).
+- TS SDK gains a new internal module `src/backends/wasm-node-loader.ts` that hosts the Node-only init helpers (`isNodeRuntime`, `loadWasmBytesNode`). Browser bundles never reach this file because `WasmBackend.init()` gates the import on the runtime detection.
+
+### No-op for non-TS consumers
+
+- Rust crates: no source change. Workspace version bumped from 1.13.6 to 1.13.7 to keep all manifests aligned (the release pipeline publishes them in lock-step).
+- Python wheel: no source change.
+- WASM artifact: no source change. The `@wiscale/velesdb-wasm` npm package is unchanged at 1.13.6 — the TS SDK consumes it via the same dependency range.
+- 450 µs p50 end-to-end path preserved.
 
 ## [1.13.6] — 2026-04-28
 
@@ -4425,7 +4456,8 @@ This change ensures VelesDB remains freely available while protecting against cl
 - API Authentication (WIS-69)
 - Starlight documentation site
 
-[Unreleased]: https://github.com/cyberlife-coder/VelesDB/compare/v1.13.6...HEAD
+[Unreleased]: https://github.com/cyberlife-coder/VelesDB/compare/v1.13.7...HEAD
+[1.13.7]: https://github.com/cyberlife-coder/VelesDB/releases/tag/v1.13.7
 [1.13.6]: https://github.com/cyberlife-coder/VelesDB/releases/tag/v1.13.6
 [1.13.5]: https://github.com/cyberlife-coder/VelesDB/releases/tag/v1.13.5
 [1.13.4]: https://github.com/cyberlife-coder/VelesDB/releases/tag/v1.13.4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5709,7 +5709,7 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-velesdb"
-version = "1.13.6"
+version = "1.13.7"
 dependencies = [
  "dirs 5.0.1",
  "parking_lot",
@@ -6681,7 +6681,7 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "velesdb-cli"
-version = "1.13.6"
+version = "1.13.7"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -6706,7 +6706,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-core"
-version = "1.13.6"
+version = "1.13.7"
 dependencies = [
  "arc-swap",
  "bytemuck",
@@ -6760,7 +6760,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-migrate"
-version = "1.13.6"
+version = "1.13.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6788,7 +6788,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-mobile"
-version = "1.13.6"
+version = "1.13.7"
 dependencies = [
  "parking_lot",
  "serde_json",
@@ -6802,7 +6802,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-python"
-version = "1.13.6"
+version = "1.13.7"
 dependencies = [
  "numpy",
  "parking_lot",
@@ -6814,7 +6814,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-server"
-version = "1.13.6"
+version = "1.13.7"
 dependencies = [
  "anyhow",
  "axum",
@@ -6847,7 +6847,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-wasm"
-version = "1.13.6"
+version = "1.13.7"
 dependencies = [
  "getrandom 0.3.4",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "1.13.6"
+version = "1.13.7"
 edition = "2021"
 rust-version = "1.83"
 license-file = "LICENSE"
@@ -77,7 +77,7 @@ base64 = "0.22"
 smallvec = { version = "1", features = ["serde"] }
 
 # Internal workspace crates
-velesdb-core = { path = "crates/velesdb-core", version = "1.13.6", default-features = false }
+velesdb-core = { path = "crates/velesdb-core", version = "1.13.7", default-features = false }
 
 [profile.release]
 lto = true

--- a/crates/tauri-plugin-velesdb/guest-js/package.json
+++ b/crates/tauri-plugin-velesdb/guest-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wiscale/tauri-plugin-velesdb",
-  "version": "1.13.6",
+  "version": "1.13.7",
   "description": "TypeScript bindings for the VelesDB Tauri plugin - Vector search in desktop apps",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/crates/velesdb-python/pyproject.toml
+++ b/crates/velesdb-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "velesdb"
-version = "1.13.6"
+version = "1.13.7"
 description = "VelesDB: The Local Vector Database for Python & AI. Microsecond semantic search, zero network latency."
 readme = "README.md"
 license = { text = "MIT" }

--- a/demos/rag-pdf-demo/pyproject.toml
+++ b/demos/rag-pdf-demo/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "velesdb-rag-demo"
-version = "1.13.6"
+version = "1.13.7"
 description = "RAG Demo with PDF ingestion using VelesDB for vector storage"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -11,7 +11,7 @@
       "name": "VelesDB Core License 1.0",
       "url": "https://github.com/cyberlife-coder/VelesDB/blob/main/LICENSE"
     },
-    "version": "1.13.6"
+    "version": "1.13.7"
   },
   "servers": [
     {

--- a/integrations/common/pyproject.toml
+++ b/integrations/common/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "velesdb-common"
-version = "1.13.6"
+version = "1.13.7"
 description = "Shared utilities for VelesDB Python integrations (internal use)"
 readme = "README.md"
 license = {text = "MIT"}

--- a/integrations/langchain/pyproject.toml
+++ b/integrations/langchain/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "langchain-velesdb"
-version = "1.13.6"
+version = "1.13.7"
 description = "LangChain VectorStore for VelesDB: The Local AI Memory Database. Microsecond RAG retrieval."
 readme = "README.md"
 license = {text = "MIT"}

--- a/integrations/llamaindex/pyproject.toml
+++ b/integrations/llamaindex/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "llama-index-vector-stores-velesdb"
-version = "1.13.6"
+version = "1.13.7"
 description = "LlamaIndex VectorStore for VelesDB: The Local AI Memory Database. Microsecond RAG retrieval."
 readme = "README.md"
 license = "MIT"

--- a/scripts/check-version-sync.py
+++ b/scripts/check-version-sync.py
@@ -16,6 +16,11 @@ TARGETS = {
     "integrations/llamaindex/pyproject.toml": "toml",
     "demos/rag-pdf-demo/pyproject.toml": "toml",
     "sdks/typescript/package.json": "json",
+    # The TS SDK's npm lockfile carries its own root "version" string that
+    # must track package.json. v1.13.4/.5/.6 each shipped with a stale
+    # lockfile because no script policed it; v1.13.7 caught the same drift
+    # via Devin Review (PR #710). Now this checker fails fast if we forget.
+    "sdks/typescript/package-lock.json": "json",
     "docs/openapi.json": "json_openapi",
 }
 

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wiscale/velesdb-sdk",
-  "version": "1.13.6",
+  "version": "1.13.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wiscale/velesdb-sdk",
-      "version": "1.13.6",
+      "version": "1.13.7",
       "license": "MIT",
       "dependencies": {
         "@wiscale/velesdb-wasm": "^1.4.1"

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wiscale/velesdb-sdk",
-  "version": "1.13.6",
+  "version": "1.13.7",
   "description": "VelesDB TypeScript SDK: The Local Vector Database for AI & RAG. Microsecond semantic search in Browser & Node.js.",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/sdks/typescript/src/backends/wasm-node-loader.ts
+++ b/sdks/typescript/src/backends/wasm-node-loader.ts
@@ -71,7 +71,7 @@ export async function loadWasmBytesNode(): Promise<Uint8Array> {
   const pkgDir = path.dirname(pkgJsonPath);
 
   const entries = await readdir(pkgDir);
-  const wasmFile = entries.find((name) => name.endsWith('.wasm'));
+  const wasmFile = pickWasmBinary(entries);
   if (!wasmFile) {
     throw new Error(
       `Cannot locate a *.wasm binary in @wiscale/velesdb-wasm at ${pkgDir}. ` +
@@ -80,4 +80,26 @@ export async function loadWasmBytesNode(): Promise<Uint8Array> {
     );
   }
   return readFile(path.join(pkgDir, wasmFile));
+}
+
+/**
+ * Choose the WASM binary to load when the package directory contains more
+ * than one `.wasm` file. wasm-pack ships a single `<crate>_bg.wasm` by
+ * default, but consumers occasionally publish a debug build alongside the
+ * release build (`<crate>_bg.wasm` + `<crate>_slim.wasm`, or similar). A
+ * naive `entries.find('.wasm')` would depend on filesystem ordering — fine
+ * on most platforms today, fragile in principle.
+ *
+ * Strategy:
+ *   1. Prefer the wasm-pack default `*_bg.wasm` naming.
+ *   2. If no `*_bg.wasm` is present, fall back to the first plain `*.wasm`.
+ *   3. If no `*.wasm` is present at all, return undefined and let the caller
+ *      raise a descriptive error.
+ */
+function pickWasmBinary(entries: string[]): string | undefined {
+  const bg = entries.find((name) => name.endsWith('_bg.wasm'));
+  if (bg !== undefined) {
+    return bg;
+  }
+  return entries.find((name) => name.endsWith('.wasm'));
 }

--- a/sdks/typescript/src/backends/wasm.ts
+++ b/sdks/typescript/src/backends/wasm.ts
@@ -51,7 +51,6 @@ import {
   buildWasmContext,
   buildCollectionInfo,
 } from './wasm-helpers';
-import { isNodeRuntime, loadWasmBytesNode } from './wasm-node-loader';
 
 // Search & query delegates
 import {
@@ -156,9 +155,16 @@ export class WasmBackend implements IVelesDBBackend {
       // binary. That works in the browser but Node's undici has no scheme
       // handler for `file://`, so the import explodes with
       // "not implemented... yet..." (see #379 honesty notes).
-      // Detect Node and pass an explicit Buffer so init never relies on fetch.
-      if (isNodeRuntime()) {
-        await mod.default(await loadWasmBytesNode());
+      //
+      // Import the Node-only loader **dynamically** so browser bundlers can
+      // tree-shake the entire `wasm-node-loader` module — including the
+      // `node:module` / `node:fs/promises` / `node:path` references inside
+      // it — out of browser builds. A static `import { ... } from '...'`
+      // would force every bundle (web, react-native, electron-renderer) to
+      // ship those `node:` specifiers, which some bundlers warn on.
+      const nodeLoader = await import('./wasm-node-loader');
+      if (nodeLoader.isNodeRuntime()) {
+        await mod.default(await nodeLoader.loadWasmBytesNode());
       } else {
         await mod.default();
       }

--- a/sdks/typescript/tests/wasm-backend.test.ts
+++ b/sdks/typescript/tests/wasm-backend.test.ts
@@ -49,6 +49,17 @@ const mockWasmModule = {
 // Mock the dynamic import - must match the import path in wasm.ts
 vi.mock('@wiscale/velesdb-wasm', () => mockWasmModule);
 
+// Stub the Node-only loader so the unit suite does not touch the real
+// filesystem. Without this, `WasmBackend.init()` would call into
+// `loadWasmBytesNode()` which uses `createRequire` + `fs.readdir` to
+// locate the real velesdb_wasm package on disk — turning these unit
+// tests into integration tests that depend on `@wiscale/velesdb-wasm`
+// being installed AND containing a `.wasm` binary. (Devin Review PR #710.)
+vi.mock('../src/backends/wasm-node-loader', () => ({
+  isNodeRuntime: () => false,
+  loadWasmBytesNode: vi.fn(() => Promise.resolve(new Uint8Array(0))),
+}));
+
 describe('WasmBackend', () => {
   let backend: WasmBackend;
 


### PR DESCRIPTION
Brings v1.13.7 commits into develop. TS SDK Node WASM init fix shipped via PR #710. No new code — mirrors main.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/711" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
