### PR TITLE
chore(docker): auto-sync LABEL version with workspace (refs #379)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **MSRV bumped to Rust 1.89** (workspace `Cargo.toml`, `.clippy.toml`, `CONTRIBUTING.md`, examples READMEs, CI workflows). The previous `1.83` claim was inaccurate from day one: `crates/velesdb-core/src/simd_native/x86_avx512.rs` uses `#[target_feature(enable = "avx512vpopcntdq")]`, stabilised in Rust 1.89, so builds on toolchains 1.83–1.88 were already failing silently with hundreds of errors. This corrects the manifest to match reality and pulls the CI environment forward to the same minimum. Resolves the `#2` honesty note in [`docs/quickstart/timing-results.md`](docs/quickstart/timing-results.md). Refs [#379](https://github.com/cyberlife-coder/VelesDB/issues/379).
+- **Docker `LABEL version` lines are now auto-synced with the workspace version**. The root `Dockerfile` shipped a stale `LABEL version="1.12.0"` across seven patch releases (v1.12.1 → v1.13.7) because no tooling touched it. `scripts/bump-version.ps1` now rewrites the `^LABEL version=` line on every release across `Dockerfile`, `benchmarks/Dockerfile.optimized`, `benchmarks/Dockerfile.nightly`, and `benchmarks/Dockerfile.bench`; `scripts/check-version-sync.py` fails fast if any of them drift. Resolves the `#3` honesty note in [`docs/quickstart/timing-results.md`](docs/quickstart/timing-results.md). Refs [#379](https://github.com/cyberlife-coder/VelesDB/issues/379).
 
 ## [1.13.8] — 2026-04-30
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM rust:1.87-bookworm AS builder
 
 LABEL maintainer="VelesDB Team <contact@wiscale.fr>"
-LABEL version="1.12.0"
+LABEL version="1.13.8"
 
 WORKDIR /app
 
@@ -25,7 +25,7 @@ RUN cargo build --release --bin velesdb-server
 FROM debian:bookworm-slim
 
 LABEL maintainer="VelesDB Team <contact@wiscale.fr>"
-LABEL version="1.12.0"
+LABEL version="1.13.8"
 
 WORKDIR /app
 

--- a/benchmarks/Dockerfile.bench
+++ b/benchmarks/Dockerfile.bench
@@ -6,7 +6,7 @@
 FROM debian:bookworm-slim
 
 LABEL maintainer="VelesDB Team <contact@wiscale.fr>"
-LABEL version="1.13.0"
+LABEL version="1.13.8"
 
 WORKDIR /app
 

--- a/benchmarks/Dockerfile.nightly
+++ b/benchmarks/Dockerfile.nightly
@@ -4,7 +4,7 @@
 FROM rust:slim-bookworm AS builder
 
 LABEL maintainer="VelesDB Team <contact@wiscale.fr>"
-LABEL version="1.13.0"
+LABEL version="1.13.8"
 
 WORKDIR /app
 
@@ -29,7 +29,7 @@ RUN cargo build --release --bin velesdb-server
 FROM debian:bookworm-slim
 
 LABEL maintainer="VelesDB Team <contact@wiscale.fr>"
-LABEL version="1.13.0"
+LABEL version="1.13.8"
 
 WORKDIR /app
 

--- a/benchmarks/Dockerfile.optimized
+++ b/benchmarks/Dockerfile.optimized
@@ -7,7 +7,7 @@
 FROM rust:slim-bookworm AS builder
 
 LABEL maintainer="VelesDB Team <contact@wiscale.fr>"
-LABEL version="1.13.0"
+LABEL version="1.13.8"
 
 WORKDIR /app
 
@@ -49,7 +49,7 @@ RUN cargo build --release --bin velesdb-server \
 FROM debian:bookworm-slim
 
 LABEL maintainer="VelesDB Team <contact@wiscale.fr>"
-LABEL version="1.13.0"
+LABEL version="1.13.8"
 
 WORKDIR /app
 

--- a/docs/quickstart/timing-results.md
+++ b/docs/quickstart/timing-results.md
@@ -58,9 +58,9 @@ The PyO3 bindings call into the NumPy C API at first use, but the published `vel
 
 The Rust scenario initially failed to compile with `rust:1.86-slim` (499 errors) because `crates/velesdb-core/src/simd_native/x86_avx512.rs:1428` uses `#[target_feature(enable = "avx512vpopcntdq")]`, a target feature stabilized in Rust 1.89. Up to and including v1.13.8 the workspace `Cargo.toml` declared `rust-version = "1.83"`, which was misleading: builds on a 1.83–1.88 toolchain were already broken silently. **Resolved in v1.14.0**: the workspace `rust-version` is now `1.89`, `CONTRIBUTING.md` and the examples READMEs say `Rust 1.89+`, and `.clippy.toml` matches. The DX harness pins `rust:1-slim` (latest stable) so it tracks the MSRV automatically.
 
-### 3. The repo `Dockerfile` carries a stale `LABEL version="1.12.0"`
+### 3. The repo `Dockerfile` carried a stale `LABEL version="1.12.0"` — **resolved in v1.14.0**
 
-The `docs/getting-started.md` Docker section instructs users to `docker build -t velesdb .` from the repo root. The resulting image is labelled v1.12.0 even on a v1.13.7 checkout. Not caught by `scripts/check-version-sync.py`. Hence this DX measurement uses the published `velesdb-server` from crates.io rather than the locally-built Docker image — that path is also more honest because no public Docker image is currently published anywhere. Tracked for follow-up: drop the `LABEL version=` line (it cannot stay accurate without tooling) or wire it through `scripts/bump-version.ps1`.
+The `docs/getting-started.md` Docker section instructs users to `docker build -t velesdb .` from the repo root. Up to and including v1.13.7 the resulting image was labelled `1.12.0` (seven patch releases of drift) because `scripts/bump-version.ps1` did not touch the `LABEL version=` line and `scripts/check-version-sync.py` did not verify it. **Resolved in v1.14.0**: `bump-version.ps1` now rewrites the `LABEL version=` line on every release across the root `Dockerfile` and `benchmarks/Dockerfile.{optimized,nightly,bench}`, and `check-version-sync.py` fails fast on any future drift. The DX measurement still uses the published `velesdb-server` binary rather than a locally-built image because no public Docker image is published yet; that is a separate tracker.
 
 ### 4. WASM SDK in Node was broken before v1.13.7
 

--- a/scripts/bump-version.ps1
+++ b/scripts/bump-version.ps1
@@ -12,6 +12,7 @@
     - LangChain integration (pyproject.toml)
     - LlamaIndex integration (pyproject.toml)
     - RAG demo (pyproject.toml)
+    - Dockerfiles (LABEL version="...")
 
 .PARAMETER Version
     The new version number (e.g., "0.8.9")
@@ -134,6 +135,35 @@ $FilesToUpdate = @(
         Pattern = '"version":\s*"\d+\.\d+\.\d+"'
         Replacement = "`"version`": `"$Version`""
         Description = "SERVER_SECURITY.md /health and /ready snippets"
+    },
+    # Dockerfile LABEL version drift was undetectable until v1.13.7 — the root
+    # Dockerfile shipped a stale `1.12.0` label across seven patch releases
+    # (see docs/quickstart/timing-results.md honesty note #3). Each Dockerfile
+    # is anchored on `^LABEL version=` so we never accidentally rewrite an
+    # arbitrary version string elsewhere in the file.
+    @{
+        Path = "Dockerfile"
+        Pattern = '(?m)^LABEL version="\d+\.\d+\.\d+"'
+        Replacement = "LABEL version=`"$Version`""
+        Description = "Dockerfile LABEL (root, build + runtime stages)"
+    },
+    @{
+        Path = "benchmarks/Dockerfile.optimized"
+        Pattern = '(?m)^LABEL version="\d+\.\d+\.\d+"'
+        Replacement = "LABEL version=`"$Version`""
+        Description = "benchmarks/Dockerfile.optimized LABEL"
+    },
+    @{
+        Path = "benchmarks/Dockerfile.nightly"
+        Pattern = '(?m)^LABEL version="\d+\.\d+\.\d+"'
+        Replacement = "LABEL version=`"$Version`""
+        Description = "benchmarks/Dockerfile.nightly LABEL"
+    },
+    @{
+        Path = "benchmarks/Dockerfile.bench"
+        Pattern = '(?m)^LABEL version="\d+\.\d+\.\d+"'
+        Replacement = "LABEL version=`"$Version`""
+        Description = "benchmarks/Dockerfile.bench LABEL"
     }
     # NOTE: per-crate inter-crate dependency entries (velesdb-server -> core,
     # velesdb-cli -> core, etc.) used to live here. They were removed in v1.13.6

--- a/scripts/check-version-sync.py
+++ b/scripts/check-version-sync.py
@@ -30,6 +30,14 @@ TARGETS = {
     "docs/getting-started.md": "doc_health_snippet",
     "docs/reference/api-reference.md": "doc_health_snippet",
     "docs/guides/SERVER_SECURITY.md": "doc_health_snippet",
+    # Dockerfile `LABEL version="X.Y.Z"` lines were not policed before
+    # v1.14.0 — the root Dockerfile shipped a stale `1.12.0` label across
+    # seven patch releases. bump-version.ps1 now rewrites them on every
+    # release; this checker fails fast if any drift sneaks in.
+    "Dockerfile": "dockerfile_label",
+    "benchmarks/Dockerfile.optimized": "dockerfile_label",
+    "benchmarks/Dockerfile.nightly": "dockerfile_label",
+    "benchmarks/Dockerfile.bench": "dockerfile_label",
 }
 
 
@@ -84,11 +92,21 @@ def _read_doc_health_snippet(path: Path) -> str:
     return match.group(1)
 
 
+def _read_dockerfile_label(path: Path) -> str:
+    """Pull the version out of the first `LABEL version="X.Y.Z"` line."""
+    text = path.read_text(encoding="utf-8")
+    match = re.search(r'^LABEL\s+version="([^"]+)"', text, re.MULTILINE)
+    if not match:
+        raise RuntimeError(f"No `LABEL version=\"...\"` line in {path}")
+    return match.group(1)
+
+
 _READERS = {
     "toml": _read_toml_version,
     "json": _read_json_version,
     "json_openapi": _read_openapi_version,
     "doc_health_snippet": _read_doc_health_snippet,
+    "dockerfile_label": _read_dockerfile_label,
 }
 
 


### PR DESCRIPTION
## Summary

The root \`Dockerfile\` carried a stale \`LABEL version=\"1.12.0\"\` from v1.12.1 through v1.13.7 (seven patch releases of drift) because no tooling touched the line. Same pattern in \`benchmarks/Dockerfile.{optimized,nightly,bench}\`. The Phase 6 DX onboarding harness flagged this ([docs/quickstart/timing-results.md](docs/quickstart/timing-results.md) honesty note #3).

This PR wires \`LABEL version=\` into the existing release tooling so the label cannot drift again.

## Type of change

- [x] Build / release tooling
- [x] Documentation update

## Sémver

**Minor (v1.14.0)** — piggy-backs on the MSRV bump in [PR #714](https://github.com/cyberlife-coder/VelesDB/pull/714). Tooling-only, no source code change.

## Files changed (8)

**Tooling**
- \`scripts/bump-version.ps1\`: 4 new entries rewriting \`^LABEL version=\"X.Y.Z\"\` on every release.
- \`scripts/check-version-sync.py\`: new \`dockerfile_label\` reader type with regex \`^LABEL\s+version=\"...\"\`; fails fast on drift.

**Catch-up (one-shot)**
- \`Dockerfile\`: \`1.12.0\` → \`1.13.7\`
- \`benchmarks/Dockerfile.optimized\`: \`1.13.0\` → \`1.13.7\`
- \`benchmarks/Dockerfile.nightly\`: \`1.13.0\` → \`1.13.7\`
- \`benchmarks/Dockerfile.bench\`: \`1.13.0\` → \`1.13.7\`

**Docs**
- \`docs/quickstart/timing-results.md\` friction #3 marked resolved
- \`CHANGELOG.md\` entry under [Unreleased]

## Test plan

- [x] \`pwsh scripts/bump-version.ps1 -Version 1.13.7\`: 4 Dockerfiles updated, manifests no-op
- [x] \`pwsh scripts/bump-version.ps1 -Version 1.14.0 -DryRun\`: 14 targets would update (10 manifests + 4 Dockerfiles)
- [x] \`python scripts/check-version-sync.py\`: 13 tracked targets all OK at 1.13.7
- [ ] CI on PR

## Merge ordering

Per the v1.14.0 release plan, this lands alongside [PR #714](https://github.com/cyberlife-coder/VelesDB/pull/714) (MSRV bump) and is published in the v1.14.0 release. Phase A ([PR #713](https://github.com/cyberlife-coder/VelesDB/pull/713), v1.13.8 numpy fix) merges first.

Refs [#379](https://github.com/cyberlife-coder/VelesDB/issues/379).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/715" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
