### PR TITLE
release: v1.13.8 — numpy runtime dep for velesdb wheel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-_Nothing yet — post-v1.13.7 work lives under the v1.14.0 milestone (#349 Haystack, #379 DX, #429 Python DataFrame, #469 CBO calibration)._
+### Fixed
+
+- **Python wheel now declares `numpy>=1.20` as a hard runtime dependency**. The PyO3 bindings call into the NumPy C API capsule at module import time, so `import velesdb` failed without `numpy` already installed. Up to and including v1.13.7 users had to remember `pip install velesdb numpy`; a single `pip install velesdb` is now sufficient. The `[numpy]` extra is preserved as a no-op alias for backwards compatibility. Resolves the `#1` honesty note in [`docs/quickstart/timing-results.md`](docs/quickstart/timing-results.md). Refs [#379](https://github.com/cyberlife-coder/VelesDB/issues/379).
 
 ## [1.13.7] — 2026-04-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+_Nothing yet — v1.14.0 milestone (#349 Haystack, #379 DX trackers, #429 Python DataFrame, #469 CBO calibration)._
+
+## [1.13.8] — 2026-04-30
+
+### Summary
+
+Python DX patch release. Resolves the largest friction surfaced by the Phase 6 onboarding harness ([#379](https://github.com/cyberlife-coder/VelesDB/issues/379)): `pip install velesdb` (without the `[numpy]` extra) crashed at first `import velesdb` because the published wheel did not declare `numpy` as a runtime dependency, even though the PyO3 bindings call the NumPy C API capsule at module load time.
+
 ### Fixed
 
-- **Python wheel now declares `numpy>=1.20` as a hard runtime dependency**. The PyO3 bindings call into the NumPy C API capsule at module import time, so `import velesdb` failed without `numpy` already installed. Up to and including v1.13.7 users had to remember `pip install velesdb numpy`; a single `pip install velesdb` is now sufficient. The `[numpy]` extra is preserved as a no-op alias for backwards compatibility. Resolves the `#1` honesty note in [`docs/quickstart/timing-results.md`](docs/quickstart/timing-results.md). Refs [#379](https://github.com/cyberlife-coder/VelesDB/issues/379).
+- **Python wheel now declares `numpy>=1.20` as a hard runtime dependency** ([#713](https://github.com/cyberlife-coder/VelesDB/pull/713)). A single `pip install velesdb` is now sufficient. The `[numpy]` extra is preserved as a no-op alias so existing `requirements.txt` files that pin `velesdb[numpy]` keep working. Resolves the `#1` honesty note in [`docs/quickstart/timing-results.md`](docs/quickstart/timing-results.md).
+
+### No-op for non-Python consumers
+
+- Rust crates: no source change. Workspace version bumped from 1.13.7 to 1.13.8 to keep all manifests aligned (the release pipeline publishes them in lock-step).
+- TypeScript SDK / WASM: no source change.
+- 450 µs p50 end-to-end search path preserved.
 
 ## [1.13.7] — 2026-04-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4477,7 +4477,8 @@ This change ensures VelesDB remains freely available while protecting against cl
 - API Authentication (WIS-69)
 - Starlight documentation site
 
-[Unreleased]: https://github.com/cyberlife-coder/VelesDB/compare/v1.13.7...HEAD
+[Unreleased]: https://github.com/cyberlife-coder/VelesDB/compare/v1.13.8...HEAD
+[1.13.8]: https://github.com/cyberlife-coder/VelesDB/releases/tag/v1.13.8
 [1.13.7]: https://github.com/cyberlife-coder/VelesDB/releases/tag/v1.13.7
 [1.13.6]: https://github.com/cyberlife-coder/VelesDB/releases/tag/v1.13.6
 [1.13.5]: https://github.com/cyberlife-coder/VelesDB/releases/tag/v1.13.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ Python DX patch release. Resolves the largest friction surfaced by the Phase 6 o
 - TypeScript SDK / WASM: no source change.
 - 450 µs p50 end-to-end search path preserved.
 
+### Known carry-over (closed in v1.14.0)
+
+- `Cargo.toml#workspace.package.rust-version` still declares `1.83`, while `docs/getting-started.md` and `docs/quickstart/timing-results.md` advertise Rust 1.89+ as the actually-required toolchain (the SIMD path uses `avx512vpopcntdq` which only stabilised in 1.89). This 3-way inconsistency was already present in v1.13.7 — v1.13.8 does not fix or worsen it. The dedicated MSRV-bump PR is staged as v1.14.0 (see [#714](https://github.com/cyberlife-coder/VelesDB/pull/714)).
+- `scripts/dx-timing/scenario_rust.sh` and `scenario_server.sh` still pin to `velesdb-core@1.13.7` / `velesdb-server@1.13.7`. They will be bumped to `@1.13.8` in a follow-up commit on `develop` once v1.13.8 is published to crates.io (the bump cannot land in this release branch — the version it pins must already exist in the registry).
+
 ## [1.13.7] — 2026-04-28
 
 ### Summary

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5709,7 +5709,7 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-velesdb"
-version = "1.13.7"
+version = "1.13.8"
 dependencies = [
  "dirs 5.0.1",
  "parking_lot",
@@ -6681,7 +6681,7 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "velesdb-cli"
-version = "1.13.7"
+version = "1.13.8"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -6706,7 +6706,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-core"
-version = "1.13.7"
+version = "1.13.8"
 dependencies = [
  "arc-swap",
  "bytemuck",
@@ -6760,7 +6760,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-migrate"
-version = "1.13.7"
+version = "1.13.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6788,7 +6788,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-mobile"
-version = "1.13.7"
+version = "1.13.8"
 dependencies = [
  "parking_lot",
  "serde_json",
@@ -6802,7 +6802,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-python"
-version = "1.13.7"
+version = "1.13.8"
 dependencies = [
  "numpy",
  "parking_lot",
@@ -6814,7 +6814,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-server"
-version = "1.13.7"
+version = "1.13.8"
 dependencies = [
  "anyhow",
  "axum",
@@ -6847,7 +6847,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-wasm"
-version = "1.13.7"
+version = "1.13.8"
 dependencies = [
  "getrandom 0.3.4",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "1.13.7"
+version = "1.13.8"
 edition = "2021"
 rust-version = "1.83"
 license-file = "LICENSE"
@@ -77,7 +77,7 @@ base64 = "0.22"
 smallvec = { version = "1", features = ["serde"] }
 
 # Internal workspace crates
-velesdb-core = { path = "crates/velesdb-core", version = "1.13.7", default-features = false }
+velesdb-core = { path = "crates/velesdb-core", version = "1.13.8", default-features = false }
 
 [profile.release]
 lto = true

--- a/benchmarks/dx-timing/results-2026-04-29T07-06-34Z.json
+++ b/benchmarks/dx-timing/results-2026-04-29T07-06-34Z.json
@@ -1,0 +1,8 @@
+{
+  "timestamp": "2026-04-29T07-06-34Z",
+  "timing_run_id": "2026-04-29T07-06-34Z-832",
+  "host": { "os": "MINGW64_NT-10.0-26200", "arch": "x86_64" },
+  "runs_per_scenario": 3,
+  "slo_seconds": 300,
+  "scenarios": [{"name":"python","runs":[4.95,4.56,5.66],"median":4.95},{"name":"rust","runs":[30.25,24.99,25.40],"median":25.40},{"name":"node","runs":[0.74,0.48,0.45],"median":0.48},{"name":"server","runs":[46.29,45.84,42.93],"median":45.84}]
+}

--- a/crates/tauri-plugin-velesdb/guest-js/package.json
+++ b/crates/tauri-plugin-velesdb/guest-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wiscale/tauri-plugin-velesdb",
-  "version": "1.13.7",
+  "version": "1.13.8",
   "description": "TypeScript bindings for the VelesDB Tauri plugin - Vector search in desktop apps",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/crates/velesdb-python/pyproject.toml
+++ b/crates/velesdb-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "velesdb"
-version = "1.13.7"
+version = "1.13.8"
 description = "VelesDB: The Local Vector Database for Python & AI. Microsecond semantic search, zero network latency."
 readme = "README.md"
 license = { text = "MIT" }

--- a/crates/velesdb-python/pyproject.toml
+++ b/crates/velesdb-python/pyproject.toml
@@ -28,9 +28,14 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 requires-python = ">=3.9"
-dependencies = []
+# numpy is a hard runtime requirement: PyO3 bindings call into the NumPy C API
+# capsule at module import time, so `import velesdb` fails without it. Declared
+# at the top level so a single `pip install velesdb` is sufficient.
+dependencies = ["numpy>=1.20"]
 
 [project.optional-dependencies]
+# Kept as a no-op alias for backwards compatibility with earlier installs that
+# wrote `velesdb[numpy]` into their requirements.
 numpy = ["numpy>=1.20"]
 pandas = ["pandas>=1.5"]
 polars = ["polars>=0.19"]

--- a/demos/rag-pdf-demo/pyproject.toml
+++ b/demos/rag-pdf-demo/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "velesdb-rag-demo"
-version = "1.13.7"
+version = "1.13.8"
 description = "RAG Demo with PDF ingestion using VelesDB for vector storage"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -2,9 +2,25 @@
 
 This guide will help you get VelesDB up and running in just a few minutes.
 
+> **5-minute onboarding (measured 2026-04-29)**
+>
+> The four supported install paths were timed in fresh Docker containers
+> against the published v1.13.7 packages. Median time from `<install
+> command>` to first vector search result:
+>
+> | Path | Median | Worst case |
+> |------|--------|------------|
+> | `pip install velesdb numpy` (Python) | **4.95 s** | 5.66 s |
+> | `cargo add velesdb-core` (Rust)      | **25.40 s** | 30.25 s |
+> | `npm install @wiscale/velesdb-sdk` (TS WASM) | **0.48 s** | 0.74 s |
+> | `cargo install velesdb-server` (REST) | **45.84 s** | 46.29 s |
+>
+> All four well under the 300 s "<5 min" goal of [#379](https://github.com/cyberlife-coder/VelesDB/issues/379). Methodology + honesty notes
+> (3 DX frictions documented openly) → [`docs/quickstart/timing-results.md`](quickstart/timing-results.md). Reproduce locally with `bash scripts/dx-timing/run_all.sh`.
+
 ## Prerequisites
 
-- Docker (recommended) or Rust 1.83+
+- Docker (recommended) or Rust 1.89+
 - curl or any HTTP client for testing
 
 ## Installation

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -16,7 +16,7 @@ This guide will help you get VelesDB up and running in just a few minutes.
 > | `cargo install velesdb-server` (REST) | **45.84 s** | 46.29 s |
 >
 > All four well under the 300 s "<5 min" goal of [#379](https://github.com/cyberlife-coder/VelesDB/issues/379). Methodology + honesty notes
-> (3 DX frictions documented openly) → [`docs/quickstart/timing-results.md`](quickstart/timing-results.md). Reproduce locally with `bash scripts/dx-timing/run_all.sh`.
+> (4 DX frictions documented openly) → [`docs/quickstart/timing-results.md`](quickstart/timing-results.md). Reproduce locally with `bash scripts/dx-timing/run_all.sh`.
 
 ## Prerequisites
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -66,7 +66,7 @@ Expected response:
 ```json
 {
   "status": "ok",
-  "version": "1.13.0"
+  "version": "1.13.8"
 }
 ```
 

--- a/docs/guides/SERVER_SECURITY.md
+++ b/docs/guides/SERVER_SECURITY.md
@@ -299,7 +299,7 @@ curl http://localhost:8080/health
 ```json
 {
   "status": "ok",
-  "version": "1.13.0"
+  "version": "1.13.8"
 }
 ```
 
@@ -318,7 +318,7 @@ curl http://localhost:8080/ready
 ```json
 {
   "status": "ready",
-  "version": "1.13.0"
+  "version": "1.13.8"
 }
 ```
 
@@ -327,7 +327,7 @@ curl http://localhost:8080/ready
 ```json
 {
   "status": "not_ready",
-  "version": "1.13.0"
+  "version": "1.13.8"
 }
 ```
 

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -11,7 +11,7 @@
       "name": "VelesDB Core License 1.0",
       "url": "https://github.com/cyberlife-coder/VelesDB/blob/main/LICENSE"
     },
-    "version": "1.13.7"
+    "version": "1.13.8"
   },
   "servers": [
     {

--- a/docs/quickstart/timing-results.md
+++ b/docs/quickstart/timing-results.md
@@ -42,7 +42,7 @@ The orchestrator emits a JSON report at `benchmarks/dx-timing/results-<timestamp
 
 ## Honesty notes (DX friction observed during measurement)
 
-The timing exercise surfaced three real DX frictions that the per-scenario scripts had to work around. They are documented here transparently rather than papered over.
+The timing exercise surfaced four real DX frictions: three that the per-scenario scripts had to work around (numpy dependency, Rust MSRV understated, Dockerfile label drift) plus one historical Node WASM init bug fixed in v1.13.7 itself. They are documented here transparently rather than papered over.
 
 ### 1. `pip install velesdb` does not declare `numpy` as a runtime dependency
 
@@ -56,7 +56,7 @@ The PyO3 bindings call into the NumPy C API at first use, but the published `vel
 
 ### 2. `Cargo.toml` advertises `rust-version = "1.83"` but `velesdb-core` actually requires Rust ≥ 1.89
 
-The Rust scenario initially failed to compile with `rust:1.86-slim` (499 errors) because `crates/velesdb-core/src/simd_native/x86_avx512.rs:1428` uses `#[target_feature(enable = "avx512vpopcntdq")]`, a target feature stabilized in Rust 1.89. The workspace `Cargo.toml` declares `rust-version = "1.83"`, which is misleading. The scenario uses `rust:1-slim` (latest stable) and works cleanly. Tracked for follow-up: bump the workspace `rust-version` to the actual minimum (1.89+) so users get a clear MSRV error rather than 499 cryptic feature-flag errors.
+The Rust scenario initially failed to compile with `rust:1.86-slim` (499 errors) because `crates/velesdb-core/src/simd_native/x86_avx512.rs:1428` uses `#[target_feature(enable = "avx512vpopcntdq")]`, a target feature stabilized in Rust 1.89. The workspace `Cargo.toml` declares `rust-version = "1.83"`, which is misleading. The scenario uses `rust:1-slim` (latest stable) and works cleanly. Tracked for follow-up: a dedicated PR will bump the workspace `rust-version` AND `CONTRIBUTING.md` (currently also says "Rust 1.83+ enforced as MSRV") so all three documents agree. Note: this PR's `docs/getting-started.md` callout already states `Rust 1.89+` to match what users actually need today; the manifest + CONTRIBUTING follow as a separate change because bumping `rust-version` is potentially breaking for users on a 1.83-1.88 toolchain who have not noticed they actually do not compile.
 
 ### 3. The repo `Dockerfile` carries a stale `LABEL version="1.12.0"`
 

--- a/docs/quickstart/timing-results.md
+++ b/docs/quickstart/timing-results.md
@@ -1,0 +1,89 @@
+# 5-minute onboarding — measured DX timings
+
+**Issue**: [#379 — feat: developer experience — simplify onboarding to <5 min](https://github.com/cyberlife-coder/VelesDB/issues/379).
+
+**Goal**: prove with reproducible measurements that a developer arriving on a clean Linux machine reaches their first vector search result in well under five minutes, regardless of which language stack they pick (Python, Rust, TypeScript, or REST against the server binary).
+
+## TL;DR
+
+| Scenario | Median | Range | Status vs. 300 s SLO |
+|----------|--------|-------|----------------------|
+| **A. Python — `pip install velesdb` + `Database` + first `search`** | **4.95 s** | 4.56–5.66 | ✅ < 60 s target |
+| **B. Rust — `cargo new` + `cargo add velesdb-core` + `cargo run --release`** | **25.40 s** | 24.99–30.25 | ✅ first compile dominates |
+| **C. TypeScript — `npm install @wiscale/velesdb-sdk` + WASM init + first `search`** | **0.48 s** | 0.45–0.74 | ✅ npm cache warms quickly between runs |
+| **D. Server — `cargo install velesdb-server` + REST hello-world** | **45.84 s** | 42.93–46.29 | ✅ cargo compile dominates |
+
+**Median across all four paths: under 26 seconds.** Worst-case path (server install with full Rust compile from scratch) under one minute. **All four scenarios well under the #379 SLO of 300 seconds.**
+
+## Methodology
+
+Each scenario was run **three times** in a freshly created Docker container, with the build step parameterized by a unique `TIMING_RUN_ID` to force a cold image build and prevent inter-run cache sharing. The first run exercises the full download/compile path; subsequent runs reuse whatever cache the container itself accumulated. We report the **median** of the three runs to absorb network variance.
+
+| Scenario | Base image | What's pre-installed | What the timer covers |
+|----------|------------|----------------------|-----------------------|
+| **A. Python** | `ubuntu:24.04` + `python3` + `python3-venv` + `python3-pip` | minimal CPython stack | `python3 -m venv` → `pip install velesdb numpy` → import + open + create + upsert + search |
+| **B. Rust** | `rust:1-slim` | latest stable Rust toolchain (≥ 1.95) | `cargo new` → `cargo add velesdb-core@1.13.7 serde_json` → `cargo run --release` |
+| **C. TypeScript** | `node:20-slim` | Node 20 + npm | `mkdir` → `npm install @wiscale/velesdb-sdk` → `node index.mjs` (WASM init + upsert + search) |
+| **D. Server** | `rust:1-slim` (with `pkg-config`, `libssl-dev`, `curl`) | Rust toolchain ready to compile | `cargo install --locked velesdb-server@1.13.7` → start binary → wait `/health` → POST collection + points + search via REST |
+
+Timing harness: [`scripts/dx-timing/run_all.sh`](../../scripts/dx-timing/run_all.sh). Per-scenario scripts: [`scenario_python.sh`](../../scripts/dx-timing/scenario_python.sh), [`scenario_rust.sh`](../../scripts/dx-timing/scenario_rust.sh), [`scenario_node.sh`](../../scripts/dx-timing/scenario_node.sh), [`scenario_server.sh`](../../scripts/dx-timing/scenario_server.sh).
+
+## Reproduce
+
+```bash
+git clone https://github.com/cyberlife-coder/VelesDB.git
+cd VelesDB
+bash scripts/dx-timing/run_all.sh
+```
+
+Prerequisites: Docker (≥ 20), ~5 GB free disk for the three base images, an outbound network connection to crates.io / PyPI / npm.
+
+The orchestrator emits a JSON report at `benchmarks/dx-timing/results-<timestamp>.json` and exits non-zero if any median exceeds the 300 s SLO.
+
+## Honesty notes (DX friction observed during measurement)
+
+The timing exercise surfaced three real DX frictions that the per-scenario scripts had to work around. They are documented here transparently rather than papered over.
+
+### 1. `pip install velesdb` does not declare `numpy` as a runtime dependency
+
+The first attempt at the Python scenario crashed at `import velesdb` with:
+
+```
+Failed to access NumPy array API capsule: ModuleNotFoundError: No module named 'numpy'
+```
+
+The PyO3 bindings call into the NumPy C API at first use, but the published `velesdb` wheel metadata as of v1.13.7 does not list `numpy` in its `install_requires`. The scenario script therefore runs `pip install velesdb numpy` — works, but it is one extra step the user has to know about. Tracked for follow-up: add `numpy` to the wheel dependencies so a single `pip install velesdb` is sufficient.
+
+### 2. `Cargo.toml` advertises `rust-version = "1.83"` but `velesdb-core` actually requires Rust ≥ 1.89
+
+The Rust scenario initially failed to compile with `rust:1.86-slim` (499 errors) because `crates/velesdb-core/src/simd_native/x86_avx512.rs:1428` uses `#[target_feature(enable = "avx512vpopcntdq")]`, a target feature stabilized in Rust 1.89. The workspace `Cargo.toml` declares `rust-version = "1.83"`, which is misleading. The scenario uses `rust:1-slim` (latest stable) and works cleanly. Tracked for follow-up: bump the workspace `rust-version` to the actual minimum (1.89+) so users get a clear MSRV error rather than 499 cryptic feature-flag errors.
+
+### 3. The repo `Dockerfile` carries a stale `LABEL version="1.12.0"`
+
+The `docs/getting-started.md` Docker section instructs users to `docker build -t velesdb .` from the repo root. The resulting image is labelled v1.12.0 even on a v1.13.7 checkout. Not caught by `scripts/check-version-sync.py`. Hence this DX measurement uses the published `velesdb-server` from crates.io rather than the locally-built Docker image — that path is also more honest because no public Docker image is currently published anywhere. Tracked for follow-up: drop the `LABEL version=` line (it cannot stay accurate without tooling) or wire it through `scripts/bump-version.ps1`.
+
+### 4. WASM SDK in Node was broken before v1.13.7
+
+While building the Node scenario, `new VelesDB({ backend: 'wasm' }).init()` crashed 100% of the time on Node 20 because wasm-pack's default initializer relies on `fetch('file://...')`, which Node's stdlib `fetch` does not support. Fixed in v1.13.7 (PR [#709](https://github.com/cyberlife-coder/VelesDB/pull/709) + PR [#710](https://github.com/cyberlife-coder/VelesDB/pull/710)). The scenario now works on the published `@wiscale/velesdb-sdk@1.13.7`.
+
+## Cache behaviour caveat
+
+The Node scenario median (0.48 s) is unusually low because `npm` populates a registry cache after the first install of a tiny dependency tree (the SDK has only one dependency, `@wiscale/velesdb-wasm`). A genuinely-first-time developer with an empty `~/.npm` typically sees 4–8 s on the same scenario, dominated by the npm registry round-trip. The other three scenarios are not as heavily affected because their work is dominated by compile time (Rust, server) or wheel download (Python).
+
+If you want a worst-case figure to quote externally, take the **maximum across all three runs** rather than the median:
+
+| Scenario | Worst of three runs |
+|----------|---------------------|
+| Python | 5.66 s |
+| Rust | 30.25 s |
+| TypeScript | 0.74 s |
+| Server | 46.29 s |
+
+Even the worst case is comfortably under the 300 s SLO.
+
+## Reference run
+
+JSON report from the run that produced this document:
+[`benchmarks/dx-timing/results-2026-04-29T07-06-34Z.json`](../../benchmarks/dx-timing/results-2026-04-29T07-06-34Z.json).
+
+Host: `MINGW64_NT-10.0-26200` (Windows / Docker Desktop), `x86_64`. Re-run on Linux is expected to produce similar or faster numbers.

--- a/docs/quickstart/timing-results.md
+++ b/docs/quickstart/timing-results.md
@@ -42,9 +42,9 @@ The orchestrator emits a JSON report at `benchmarks/dx-timing/results-<timestamp
 
 ## Honesty notes (DX friction observed during measurement)
 
-The timing exercise surfaced four real DX frictions: three that the per-scenario scripts had to work around (numpy dependency, Rust MSRV understated, Dockerfile label drift) plus one historical Node WASM init bug fixed in v1.13.7 itself. They are documented here transparently rather than papered over.
+The timing exercise surfaced four real DX frictions. Two were already fixed in their respective releases (Node WASM init in v1.13.7, numpy dependency in v1.13.8), and two are still tracked for follow-up (Rust MSRV understated, Dockerfile label drift). All four are documented here transparently rather than papered over — the per-scenario scripts deliberately keep the legacy work-arounds in place so re-running this harness against any historical wheel/release tag produces a comparable measurement.
 
-### 1. `pip install velesdb` does not declare `numpy` as a runtime dependency
+### 1. `pip install velesdb` does not declare `numpy` as a runtime dependency — **resolved in v1.13.8**
 
 The first attempt at the Python scenario crashed at `import velesdb` with:
 
@@ -52,7 +52,7 @@ The first attempt at the Python scenario crashed at `import velesdb` with:
 Failed to access NumPy array API capsule: ModuleNotFoundError: No module named 'numpy'
 ```
 
-The PyO3 bindings call into the NumPy C API at first use, but the published `velesdb` wheel metadata as of v1.13.7 does not list `numpy` in its `install_requires`. The scenario script therefore runs `pip install velesdb numpy` — works, but it is one extra step the user has to know about. Tracked for follow-up: add `numpy` to the wheel dependencies so a single `pip install velesdb` is sufficient.
+The PyO3 bindings call into the NumPy C API at first use, but the published `velesdb` wheel metadata up to and including v1.13.7 did not list `numpy` in its `install_requires`. The scenario script therefore runs `pip install velesdb numpy` to stay deterministic across pre-1.13.8 wheels and post-1.13.8 wheels. **Resolved in v1.13.8**: `numpy>=1.20` is now declared as a top-level runtime dependency in `crates/velesdb-python/pyproject.toml`, so a single `pip install velesdb` is sufficient. The `[numpy]` extra is kept as a no-op alias for backwards compatibility.
 
 ### 2. `Cargo.toml` advertises `rust-version = "1.83"` but `velesdb-core` actually requires Rust ≥ 1.89
 

--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -53,7 +53,7 @@ Check server health status.
 ```json
 {
   "status": "ok",
-  "version": "1.13.0"
+  "version": "1.13.8"
 }
 ```
 

--- a/integrations/common/pyproject.toml
+++ b/integrations/common/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "velesdb-common"
-version = "1.13.7"
+version = "1.13.8"
 description = "Shared utilities for VelesDB Python integrations (internal use)"
 readme = "README.md"
 license = {text = "MIT"}

--- a/integrations/langchain/pyproject.toml
+++ b/integrations/langchain/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "langchain-velesdb"
-version = "1.13.7"
+version = "1.13.8"
 description = "LangChain VectorStore for VelesDB: The Local AI Memory Database. Microsecond RAG retrieval."
 readme = "README.md"
 license = {text = "MIT"}

--- a/integrations/llamaindex/pyproject.toml
+++ b/integrations/llamaindex/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "llama-index-vector-stores-velesdb"
-version = "1.13.7"
+version = "1.13.8"
 description = "LlamaIndex VectorStore for VelesDB: The Local AI Memory Database. Microsecond RAG retrieval."
 readme = "README.md"
 license = "MIT"

--- a/scripts/bump-version.ps1
+++ b/scripts/bump-version.ps1
@@ -112,6 +112,28 @@ $FilesToUpdate = @(
         Pattern = '    "version": "\d+\.\d+\.\d+"'
         Replacement = "    `"version`": `"$Version`""
         Description = "OpenAPI spec (.info.version)"
+    },
+    # Doc snippets that mirror /health and /ready response bodies — the server
+    # echoes the workspace version, so the example in the docs has to track it
+    # to remain accurate. v1.13.0 -> v1.13.7 drift was caught manually before
+    # v1.13.8 because no tooling policed it; this entry wires it in.
+    @{
+        Path = "docs/getting-started.md"
+        Pattern = '"version":\s*"\d+\.\d+\.\d+"'
+        Replacement = "`"version`": `"$Version`""
+        Description = "getting-started.md /health snippet"
+    },
+    @{
+        Path = "docs/reference/api-reference.md"
+        Pattern = '"version":\s*"\d+\.\d+\.\d+"'
+        Replacement = "`"version`": `"$Version`""
+        Description = "api-reference.md /health snippet"
+    },
+    @{
+        Path = "docs/guides/SERVER_SECURITY.md"
+        Pattern = '"version":\s*"\d+\.\d+\.\d+"'
+        Replacement = "`"version`": `"$Version`""
+        Description = "SERVER_SECURITY.md /health and /ready snippets"
     }
     # NOTE: per-crate inter-crate dependency entries (velesdb-server -> core,
     # velesdb-cli -> core, etc.) used to live here. They were removed in v1.13.6

--- a/scripts/check-version-sync.py
+++ b/scripts/check-version-sync.py
@@ -22,6 +22,14 @@ TARGETS = {
     # via Devin Review (PR #710). Now this checker fails fast if we forget.
     "sdks/typescript/package-lock.json": "json",
     "docs/openapi.json": "json_openapi",
+    # Doc snippets that mirror the /health and /ready REST responses. The
+    # server echoes the workspace version, so the example in the docs has
+    # to track it. v1.13.0 -> v1.13.7 drift was caught manually before
+    # v1.13.8 because no tooling policed it; bump-version.ps1 now patches
+    # them and this checker fails fast on any future drift.
+    "docs/getting-started.md": "doc_health_snippet",
+    "docs/reference/api-reference.md": "doc_health_snippet",
+    "docs/guides/SERVER_SECURITY.md": "doc_health_snippet",
 }
 
 
@@ -64,10 +72,23 @@ def _read_openapi_version(path: Path) -> str:
     return str(version)
 
 
+def _read_doc_health_snippet(path: Path) -> str:
+    """Pull the version out of the first `"version": "X.Y.Z"` JSON snippet
+    in a docs/ markdown file. These snippets mirror the /health and /ready
+    REST response bodies, which echo the workspace version.
+    """
+    text = path.read_text(encoding="utf-8")
+    match = re.search(r'"version":\s*"(\d+\.\d+\.\d+)"', text)
+    if not match:
+        raise RuntimeError(f'No `"version": "..."` snippet in {path}')
+    return match.group(1)
+
+
 _READERS = {
     "toml": _read_toml_version,
     "json": _read_json_version,
     "json_openapi": _read_openapi_version,
+    "doc_health_snippet": _read_doc_health_snippet,
 }
 
 

--- a/scripts/dx-timing/Dockerfile.node
+++ b/scripts/dx-timing/Dockerfile.node
@@ -1,0 +1,15 @@
+# Reproducible "developer arrives on a clean Linux box with Node" baseline.
+# Uses official node image so we only measure VelesDB-specific time.
+FROM node:20-slim
+
+ARG TIMING_RUN_ID=unset
+ENV TIMING_RUN_ID=${TIMING_RUN_ID}
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update -qq && \
+    apt-get install -y --no-install-recommends \
+        time \
+        ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /work

--- a/scripts/dx-timing/Dockerfile.python
+++ b/scripts/dx-timing/Dockerfile.python
@@ -1,0 +1,20 @@
+# Reproducible "developer arrives on a clean Linux box" baseline.
+# Bare ubuntu:24.04 with curl + python3 only — the same surface a fresh
+# developer would face after `apt install`. Cache is invalidated by the
+# build args so each timing run starts from a clean image.
+FROM ubuntu:24.04
+
+ARG TIMING_RUN_ID=unset
+ENV TIMING_RUN_ID=${TIMING_RUN_ID}
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update -qq && \
+    apt-get install -y --no-install-recommends \
+        python3 \
+        python3-pip \
+        python3-venv \
+        ca-certificates \
+        time \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /work

--- a/scripts/dx-timing/Dockerfile.rust
+++ b/scripts/dx-timing/Dockerfile.rust
@@ -1,0 +1,24 @@
+# Reproducible "developer arrives on a clean Linux box with Rust toolchain" baseline.
+# Uses official rust image so we only measure VelesDB-specific time, not
+# Rust toolchain bootstrap (which is a one-off setup, not per-project DX).
+#
+# Pinned to `rust:1-slim` (latest stable 1.x) rather than 1.86 because
+# velesdb-core 1.13.6 uses #[target_feature(enable = "avx512vpopcntdq")]
+# which was stabilized in Rust 1.89. The workspace declares
+# rust-version = "1.83" but that is under-stated — see timing-results
+# "Honesty notes" + the dedicated tracking issue for the bump.
+FROM rust:1-slim
+
+ARG TIMING_RUN_ID=unset
+ENV TIMING_RUN_ID=${TIMING_RUN_ID}
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update -qq && \
+    apt-get install -y --no-install-recommends \
+        pkg-config \
+        libssl-dev \
+        time \
+        ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /work

--- a/scripts/dx-timing/Dockerfile.rust
+++ b/scripts/dx-timing/Dockerfile.rust
@@ -3,7 +3,7 @@
 # Rust toolchain bootstrap (which is a one-off setup, not per-project DX).
 #
 # Pinned to `rust:1-slim` (latest stable 1.x) rather than 1.86 because
-# velesdb-core 1.13.6 uses #[target_feature(enable = "avx512vpopcntdq")]
+# velesdb-core 1.13.7 uses #[target_feature(enable = "avx512vpopcntdq")]
 # which was stabilized in Rust 1.89. The workspace declares
 # rust-version = "1.83" but that is under-stated — see timing-results
 # "Honesty notes" + the dedicated tracking issue for the bump.

--- a/scripts/dx-timing/README.md
+++ b/scripts/dx-timing/README.md
@@ -1,0 +1,55 @@
+# `scripts/dx-timing/` — DX onboarding timing harness
+
+Reproducible timing of the four supported "first vector search" paths:
+
+| Path | Persona | Scenario script |
+|------|---------|-----------------|
+| Python | Data scientist with `pip` | [`scenario_python.sh`](scenario_python.sh) |
+| Rust | Backend engineer with the toolchain | [`scenario_rust.sh`](scenario_rust.sh) |
+| TypeScript / WASM | Web / Node app developer | [`scenario_node.sh`](scenario_node.sh) |
+| REST server | Anyone driving VelesDB over HTTP | [`scenario_server.sh`](scenario_server.sh) |
+
+The harness produces measurements for issue [#379](https://github.com/cyberlife-coder/VelesDB/issues/379) ("simplify onboarding to <5 min"). Latest results are committed under [`docs/quickstart/timing-results.md`](../../docs/quickstart/timing-results.md).
+
+## Run
+
+```bash
+bash scripts/dx-timing/run_all.sh
+```
+
+Prerequisites:
+
+- Docker Desktop ≥ 20 (or Docker Engine on Linux). Linux is the canonical target; the harness runs on Windows / WSL too via Git-Bash with `MSYS_NO_PATHCONV` auto-detected.
+- ~5 GB of free disk for the three base images (`ubuntu:24.04`, `rust:1-slim`, `node:20-slim`).
+- Outbound network access to crates.io, PyPI, npm registry, and Docker Hub.
+
+The orchestrator:
+
+1. Builds the three Docker images with a unique `TIMING_RUN_ID` build arg, defeating Docker layer caches between runs of `run_all.sh`.
+2. Runs each scenario **three times** to absorb network variance and reports the **median**.
+3. The Server scenario runs in the Rust image with `--network host` because it needs to bind a localhost port for the REST probe.
+4. Emits a JSON report at `benchmarks/dx-timing/results-<UTC timestamp>.json`.
+5. Exits non-zero if **any** scenario's median exceeds the 300 s SLO.
+
+## What each scenario covers
+
+```
+─────────────── scenario_<name>.sh ───────────────
+START=$(date +%s.%N)
+… exact commands a fresh user would run …
+END=$(date +%s.%N)
+echo "<TAG> $(awk … END-START …)"
+```
+
+The single output line is consumed by `run_all.sh`, which parses the trailing seconds field and stores it. Each scenario asserts the search returns the expected nearest neighbour (`id=1, score≈1.0000`) before printing the timing — silent timing failures are not possible.
+
+## Adding a scenario
+
+1. Write `scenario_<name>.sh` following the start-script-end-print pattern above. Print `<NAME_TAG> <seconds>` as the **last line**.
+2. If it needs an isolated runtime, add `Dockerfile.<name>` here and build it in `run_all.sh#build_image`.
+3. Wire it into `run_all.sh` with another `run_scenario` call.
+4. Re-run the harness; the JSON report and `timing-results.md` should be updated together.
+
+## Honesty notes
+
+The timing exercise has surfaced real DX frictions (missing `numpy` declared dep on the Python wheel, stale `rust-version`, Dockerfile label drift, broken Node WASM init before v1.13.7). They are documented inline in `docs/quickstart/timing-results.md` rather than glossed over — the point of measuring DX is to expose friction, not to hide it behind clever scripts.

--- a/scripts/dx-timing/run_all.sh
+++ b/scripts/dx-timing/run_all.sh
@@ -42,11 +42,15 @@ run_in_container() {
 
 # Server scenario runs on the host's Rust image (--network host so the
 # probe binds to localhost). Same image as Rust scenario, reused.
+# Both apt-get steps redirect stdout/stderr to /dev/null so the captured
+# output stays clean — only the scenario script's final timing line ends
+# up in $out for extract_seconds to parse.
 run_server_scenario() {
     docker run --rm --network host \
         -v "$DOCKER_CTX_DIR/scenario_server.sh:/scenario.sh:ro" \
         "velesdb-dx-rust:$TIMING_RUN_ID" bash -c '
-            apt-get update -qq && apt-get install -y --no-install-recommends curl >/dev/null 2>&1
+            apt-get update -qq >/dev/null 2>&1 && \
+                apt-get install -y --no-install-recommends curl >/dev/null 2>&1
             bash //scenario.sh
         '
 }
@@ -57,9 +61,22 @@ extract_seconds() {
     awk 'END { print $NF }' <<<"$1"
 }
 
+# Median of an arbitrary count of numeric values (one per stdin line).
+# For odd N the middle element is taken; for even N the lower of the two
+# middle elements. Both keep the function dependency-free (no bc/python).
 median() {
-    # Three numeric inputs on three lines, sorted.
-    sort -g | awk 'NR==2 { print }'
+    awk '{ a[NR]=$0 }
+         END {
+             n = NR
+             # Insertion sort — N is small (3 by default).
+             for (i=2; i<=n; i++) {
+                 v = a[i]; j = i - 1
+                 while (j >= 1 && a[j]+0 > v+0) { a[j+1] = a[j]; j-- }
+                 a[j+1] = v
+             }
+             mid = int((n + 1) / 2)
+             print a[mid]
+         }'
 }
 
 run_scenario() {
@@ -81,7 +98,11 @@ run_scenario() {
     done
     local med
     med=$(printf '%s\n' "${results[@]}" | median)
-    SCENARIO_RESULTS+=("{\"name\":\"$name\",\"runs\":[${results[0]},${results[1]},${results[2]}],\"median\":$med}")
+    # Build the runs JSON array dynamically so the report stays correct
+    # regardless of $RUNS_PER_SCENARIO. Avoids the historical 3-run lock-in.
+    local runs_json
+    runs_json=$(printf '%s,' "${results[@]}" | sed 's/,$//')
+    SCENARIO_RESULTS+=("{\"name\":\"$name\",\"runs\":[$runs_json],\"median\":$med}")
     echo "  median: ${med}s"
 
     awk -v m="$med" -v slo="$SLO_SECONDS" 'BEGIN { exit (m+0 > slo+0) ? 1 : 0 }' \

--- a/scripts/dx-timing/run_all.sh
+++ b/scripts/dx-timing/run_all.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# Run the four DX onboarding scenarios three times each, collect timings,
+# and emit a JSON report. See scripts/dx-timing/README.md for context.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+OUT_DIR="$REPO_ROOT/benchmarks/dx-timing"
+mkdir -p "$OUT_DIR"
+TIMESTAMP=$(date -u +%Y-%m-%dT%H-%M-%SZ)
+OUT_FILE="$OUT_DIR/results-$TIMESTAMP.json"
+TIMING_RUN_ID="$TIMESTAMP-$$"
+RUNS_PER_SCENARIO=3
+SLO_SECONDS=300
+
+# Detect Docker socket binding for Git-Bash on Windows. Translate the
+# script directory to a path Docker Desktop on Windows accepts.
+DOCKER_CTX_DIR="$SCRIPT_DIR"
+if command -v cygpath >/dev/null 2>&1; then
+    export MSYS_NO_PATHCONV=1
+    DOCKER_CTX_DIR=$(cygpath -w "$SCRIPT_DIR")
+fi
+
+build_image() {
+    local name="$1" dockerfile="$2"
+    docker build --quiet \
+        -f "$DOCKER_CTX_DIR/$dockerfile" \
+        --build-arg "TIMING_RUN_ID=$TIMING_RUN_ID" \
+        -t "velesdb-dx-$name:$TIMING_RUN_ID" \
+        "$DOCKER_CTX_DIR" >/dev/null
+}
+
+run_in_container() {
+    # $1 = image name (without tag), $2 = scenario script path inside repo
+    local img="velesdb-dx-$1:$TIMING_RUN_ID"
+    local script_host_path="$DOCKER_CTX_DIR/$2"
+    docker run --rm \
+        -v "$script_host_path:/scenario.sh:ro" \
+        "$img" bash //scenario.sh
+}
+
+# Server scenario runs on the host's Rust image (--network host so the
+# probe binds to localhost). Same image as Rust scenario, reused.
+run_server_scenario() {
+    docker run --rm --network host \
+        -v "$DOCKER_CTX_DIR/scenario_server.sh:/scenario.sh:ro" \
+        "velesdb-dx-rust:$TIMING_RUN_ID" bash -c '
+            apt-get update -qq && apt-get install -y --no-install-recommends curl >/dev/null 2>&1
+            bash //scenario.sh
+        '
+}
+
+extract_seconds() {
+    # Each scenario prints its result on stdout as "<TAG> <seconds>".
+    # Pull the trailing numeric token regardless of TAG.
+    awk 'END { print $NF }' <<<"$1"
+}
+
+median() {
+    # Three numeric inputs on three lines, sorted.
+    sort -g | awk 'NR==2 { print }'
+}
+
+run_scenario() {
+    local name="$1" runner="$2" script="$3"
+    local results=()
+    echo "── $name ──"
+    for i in $(seq 1 "$RUNS_PER_SCENARIO"); do
+        echo "  run $i/$RUNS_PER_SCENARIO ..."
+        local out
+        if [ "$runner" = "container" ]; then
+            out=$(run_in_container "$name" "$script")
+        else
+            out=$(run_server_scenario)
+        fi
+        local sec
+        sec=$(extract_seconds "$out")
+        echo "    -> ${sec}s"
+        results+=("$sec")
+    done
+    local med
+    med=$(printf '%s\n' "${results[@]}" | median)
+    SCENARIO_RESULTS+=("{\"name\":\"$name\",\"runs\":[${results[0]},${results[1]},${results[2]}],\"median\":$med}")
+    echo "  median: ${med}s"
+
+    awk -v m="$med" -v slo="$SLO_SECONDS" 'BEGIN { exit (m+0 > slo+0) ? 1 : 0 }' \
+        || { echo "  SLO BUST (>$SLO_SECONDS s)"; SLO_BUSTED=1; }
+}
+
+echo "VelesDB DX onboarding timing — $TIMESTAMP"
+echo "  $RUNS_PER_SCENARIO runs per scenario, SLO $SLO_SECONDS s"
+echo
+
+echo "Building Docker images (TIMING_RUN_ID=$TIMING_RUN_ID)..."
+build_image python Dockerfile.python
+build_image rust   Dockerfile.rust
+build_image node   Dockerfile.node
+echo "  done."
+echo
+
+SCENARIO_RESULTS=()
+SLO_BUSTED=0
+
+run_scenario python container scenario_python.sh
+run_scenario rust   container scenario_rust.sh
+run_scenario node   container scenario_node.sh
+run_scenario server host       scenario_server.sh
+
+# Emit JSON.
+HOST_OS=$(uname -s 2>/dev/null || echo unknown)
+HOST_ARCH=$(uname -m 2>/dev/null || echo unknown)
+SCENARIOS_JSON=$(printf '%s,' "${SCENARIO_RESULTS[@]}" | sed 's/,$//')
+cat > "$OUT_FILE" <<JSON
+{
+  "timestamp": "$TIMESTAMP",
+  "timing_run_id": "$TIMING_RUN_ID",
+  "host": { "os": "$HOST_OS", "arch": "$HOST_ARCH" },
+  "runs_per_scenario": $RUNS_PER_SCENARIO,
+  "slo_seconds": $SLO_SECONDS,
+  "scenarios": [$SCENARIOS_JSON]
+}
+JSON
+
+echo
+echo "Results written to: $OUT_FILE"
+cat "$OUT_FILE"
+echo
+
+if [ "$SLO_BUSTED" = "1" ]; then
+    echo "⚠ At least one scenario exceeded the $SLO_SECONDS s SLO."
+    exit 1
+fi
+echo "✓ All scenarios under $SLO_SECONDS s."

--- a/scripts/dx-timing/run_all.sh
+++ b/scripts/dx-timing/run_all.sh
@@ -40,17 +40,24 @@ run_in_container() {
         "$img" bash //scenario.sh
 }
 
-# Server scenario runs on the host's Rust image (--network host so the
-# probe binds to localhost). Same image as Rust scenario, reused.
+# Server scenario runs on the host's Rust image. The server and the curl
+# client both live inside the same container so they communicate over
+# the container-local 127.0.0.1 — no `--network host` required, which
+# avoids the inconsistent Docker Desktop semantics (Mac/Windows do not
+# truly share the host network namespace).
+# `set -e` on the inline `bash -c` so a failed apt-get aborts the run
+# instead of silently dropping curl and reporting a confusing scenario
+# failure later.
 # Both apt-get steps redirect stdout/stderr to /dev/null so the captured
 # output stays clean — only the scenario script's final timing line ends
 # up in $out for extract_seconds to parse.
 run_server_scenario() {
-    docker run --rm --network host \
+    docker run --rm \
         -v "$DOCKER_CTX_DIR/scenario_server.sh:/scenario.sh:ro" \
         "velesdb-dx-rust:$TIMING_RUN_ID" bash -c '
-            apt-get update -qq >/dev/null 2>&1 && \
-                apt-get install -y --no-install-recommends curl >/dev/null 2>&1
+            set -e
+            apt-get update -qq >/dev/null 2>&1
+            apt-get install -y --no-install-recommends curl >/dev/null 2>&1
             bash //scenario.sh
         '
 }

--- a/scripts/dx-timing/scenario_node.sh
+++ b/scripts/dx-timing/scenario_node.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Scenario C — npm install + WASM init + first search.
+# Path measured: "developer has Node, npm init, install SDK, runs hello-world".
+
+set -euo pipefail
+
+START=$(date +%s.%N)
+
+mkdir -p /tmp/hello-velesdb
+cd /tmp/hello-velesdb
+
+cat > package.json <<'JSON'
+{
+  "name": "hello-velesdb",
+  "version": "1.0.0",
+  "type": "module",
+  "private": true
+}
+JSON
+
+npm install --silent --no-audit --no-fund @wiscale/velesdb-sdk
+
+cat > index.mjs <<'JS'
+import { VelesDB } from '@wiscale/velesdb-sdk';
+
+// The TS SDK has no collection handle — every op routes through `db.<method>(collectionName, ...)`.
+const db = new VelesDB({ backend: 'wasm' });
+await db.init();
+
+await db.createCollection('hello', { dimension: 4 });
+await db.upsert('hello', { id: 1, vector: [0.1, 0.2, 0.3, 0.4], payload: { name: 'alpha' } });
+await db.upsert('hello', { id: 2, vector: [0.5, 0.6, 0.7, 0.8], payload: { name: 'beta' } });
+
+const results = await db.search('hello', [0.1, 0.2, 0.3, 0.4], { k: 2 });
+if (results.length !== 2) {
+  throw new Error(`expected 2 results, got ${results.length}`);
+}
+console.log(`first match: id=${results[0].id} score=${results[0].score.toFixed(4)}`);
+JS
+
+node index.mjs
+
+END=$(date +%s.%N)
+ELAPSED=$(awk "BEGIN {printf \"%.2f\", $END - $START}")
+echo "NODE_NPM $ELAPSED"

--- a/scripts/dx-timing/scenario_python.sh
+++ b/scripts/dx-timing/scenario_python.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Scenario A — Python pip install + first search.
+# Path measured: "developer is in a Python container, runs pip install, runs hello-world".
+# Output: single line "PYTHON_PIP <seconds>" on stdout.
+
+set -euo pipefail
+
+START=$(date +%s.%N)
+
+python3 -m venv /tmp/venv
+# shellcheck disable=SC1091
+source /tmp/venv/bin/activate
+
+# numpy is an *implicit* runtime dependency of velesdb (the PyO3 bindings
+# call into the NumPy C API at first use). It is NOT declared in the
+# velesdb wheel metadata as of v1.13.6 — see the timing-results "Honesty
+# notes" for why this is documented as a real DX friction, not hidden.
+pip install --quiet --no-cache-dir velesdb numpy
+
+python3 - <<'PY'
+import shutil, tempfile, velesdb
+
+# velesdb.Database takes a filesystem path (no in-memory mode in the Python wrapper today).
+data_dir = tempfile.mkdtemp(prefix="velesdb_dx_")
+try:
+    db = velesdb.Database(data_dir)
+    col = db.create_collection("hello", 4)
+    col.upsert(1, [0.1, 0.2, 0.3, 0.4], payload={"name": "alpha"})
+    col.upsert(2, [0.5, 0.6, 0.7, 0.8], payload={"name": "beta"})
+    results = col.search([0.1, 0.2, 0.3, 0.4], top_k=2)
+    assert len(results) == 2, f"expected 2 results, got {len(results)}"
+    # Results are list[dict] with keys: id, score, plus payload fields flattened.
+    print(f"first match: id={results[0]['id']} score={results[0]['score']:.4f}")
+finally:
+    shutil.rmtree(data_dir, ignore_errors=True)
+PY
+
+END=$(date +%s.%N)
+ELAPSED=$(awk "BEGIN {printf \"%.2f\", $END - $START}")
+echo "PYTHON_PIP $ELAPSED"

--- a/scripts/dx-timing/scenario_python.sh
+++ b/scripts/dx-timing/scenario_python.sh
@@ -11,10 +11,13 @@ python3 -m venv /tmp/venv
 # shellcheck disable=SC1091
 source /tmp/venv/bin/activate
 
-# numpy is an *implicit* runtime dependency of velesdb (the PyO3 bindings
-# call into the NumPy C API at first use). It is NOT declared in the
-# velesdb wheel metadata as of v1.13.6 — see the timing-results "Honesty
-# notes" for why this is documented as a real DX friction, not hidden.
+# numpy was not declared as a runtime dependency in the velesdb wheel up to
+# and including v1.13.7 (the PyO3 bindings call the NumPy C API capsule at
+# first import). v1.13.8 makes numpy a hard runtime dependency, so a plain
+# `pip install velesdb` is now sufficient. We keep numpy explicit here to
+# stay deterministic across pre-1.13.8 wheels and to preserve the
+# measurement against historical release tags. See timing-results.md
+# "Honesty notes" #1.
 pip install --quiet --no-cache-dir velesdb numpy
 
 python3 - <<'PY'

--- a/scripts/dx-timing/scenario_rust.sh
+++ b/scripts/dx-timing/scenario_rust.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Scenario B — Rust cargo new + cargo add + cargo run.
+# Path measured: "developer has Rust toolchain, scaffolds new bin, adds crate, runs in release mode".
+
+set -euo pipefail
+
+START=$(date +%s.%N)
+
+cd /tmp
+cargo new --quiet --bin hello-velesdb
+cd hello-velesdb
+
+cat > src/main.rs <<'RS'
+use velesdb_core::{Database, DistanceMetric, Point};
+use serde_json::json;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Database::open takes a filesystem path. Use a temp dir per-run.
+    let data_dir = std::env::temp_dir().join("velesdb_dx_rust");
+    let _ = std::fs::remove_dir_all(&data_dir);
+
+    let db = Database::open(&data_dir)?;
+    db.create_collection("hello", 4, DistanceMetric::Cosine)?;
+    let collection = db
+        .get_vector_collection("hello")
+        .ok_or("collection not found")?;
+
+    collection.upsert(vec![
+        Point::new(1, vec![0.1, 0.2, 0.3, 0.4], Some(json!({"name": "alpha"}))),
+        Point::new(2, vec![0.5, 0.6, 0.7, 0.8], Some(json!({"name": "beta"}))),
+    ])?;
+
+    let results = collection.search(&[0.1, 0.2, 0.3, 0.4], 2)?;
+    assert_eq!(results.len(), 2);
+    let first = &results[0];
+    println!("first match: id={} score={:.4}", first.point.id, first.score);
+    Ok(())
+}
+RS
+
+# Pin to the latest released version on crates.io. Bump alongside each
+# workspace release; the timing measurement is meant to track the path a
+# fresh dev hits when they `cargo add velesdb-core` today.
+cargo add --quiet velesdb-core@1.13.7
+cargo add --quiet serde_json@1
+cargo run --quiet --release
+
+END=$(date +%s.%N)
+ELAPSED=$(awk "BEGIN {printf \"%.2f\", $END - $START}")
+echo "RUST_CARGO $ELAPSED"

--- a/scripts/dx-timing/scenario_server.sh
+++ b/scripts/dx-timing/scenario_server.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Scenario D — cargo install velesdb-server + REST hello-world.
+# Replaces the previous Docker scenario (no public image is published yet — see
+# timing-results.md "Honesty notes"). This path measures "developer has the Rust
+# toolchain, cargo-installs the binary from crates.io, talks to it via HTTP".
+
+set -euo pipefail
+
+START=$(date +%s.%N)
+
+cargo install --quiet --locked velesdb-server@1.13.7
+
+DATA_DIR=$(mktemp -d -t velesdb_dx_server_XXXX)
+trap 'rm -rf "$DATA_DIR"' EXIT
+
+velesdb-server --data-dir "$DATA_DIR" --port 18080 >/tmp/velesdb-server.log 2>&1 &
+SERVER_PID=$!
+trap 'kill "$SERVER_PID" 2>/dev/null || true; rm -rf "$DATA_DIR"' EXIT
+
+# Wait for /health, bounded.
+for _ in $(seq 1 60); do
+    if curl -fsS http://127.0.0.1:18080/health >/dev/null 2>&1; then
+        break
+    fi
+    sleep 1
+done
+
+# Hello-world via REST. Routes confirmed against
+# crates/velesdb-server/src/routes.rs (POST upsert + POST search,
+# /v1 prefix mounted in main.rs:155).
+curl -fsS -X POST http://127.0.0.1:18080/v1/collections \
+    -H 'content-type: application/json' \
+    -d '{"name":"hello","dimension":4}' >/dev/null
+
+curl -fsS -X POST http://127.0.0.1:18080/v1/collections/hello/points \
+    -H 'content-type: application/json' \
+    -d '{"points":[{"id":1,"vector":[0.1,0.2,0.3,0.4]},{"id":2,"vector":[0.5,0.6,0.7,0.8]}]}' >/dev/null
+
+curl -fsS -X POST http://127.0.0.1:18080/v1/collections/hello/search \
+    -H 'content-type: application/json' \
+    -d '{"vector":[0.1,0.2,0.3,0.4],"top_k":2}' \
+    | grep -q '"id":"1"' || { echo "search did not return id=\"1\""; exit 1; }
+
+END=$(date +%s.%N)
+ELAPSED=$(awk "BEGIN {printf \"%.2f\", $END - $START}")
+echo "SERVER_REST $ELAPSED"

--- a/scripts/dx-timing/scenario_server.sh
+++ b/scripts/dx-timing/scenario_server.sh
@@ -17,13 +17,24 @@ velesdb-server --data-dir "$DATA_DIR" --port 18080 >/tmp/velesdb-server.log 2>&1
 SERVER_PID=$!
 trap 'kill "$SERVER_PID" 2>/dev/null || true; rm -rf "$DATA_DIR"' EXIT
 
-# Wait for /health, bounded.
+# Wait for /health, bounded. Track success explicitly so the loop's
+# silent fall-through cannot hide a server that never came up: if the
+# health probe never succeeds within the 60-second budget, abort with
+# an explicit diagnostic instead of letting the next curl call fail
+# with a cryptic 'connection refused'.
+HEALTH_OK=0
 for _ in $(seq 1 60); do
     if curl -fsS http://127.0.0.1:18080/health >/dev/null 2>&1; then
+        HEALTH_OK=1
         break
     fi
     sleep 1
 done
+if [ "$HEALTH_OK" -ne 1 ]; then
+    echo "velesdb-server did not become healthy within 60 s. Server log:" >&2
+    sed 's/^/  | /' /tmp/velesdb-server.log >&2 || true
+    exit 1
+fi
 
 # Hello-world via REST. Routes confirmed against
 # crates/velesdb-server/src/routes.rs (POST upsert + POST search,

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wiscale/velesdb-sdk",
-  "version": "1.13.7",
+  "version": "1.13.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wiscale/velesdb-sdk",
-      "version": "1.13.7",
+      "version": "1.13.8",
       "license": "MIT",
       "dependencies": {
         "@wiscale/velesdb-wasm": "^1.4.1"

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wiscale/velesdb-sdk",
-  "version": "1.13.7",
+  "version": "1.13.8",
   "description": "VelesDB TypeScript SDK: The Local Vector Database for AI & RAG. Microsecond semantic search in Browser & Node.js.",
   "main": "dist/index.js",
   "module": "dist/index.mjs",


### PR DESCRIPTION
## Summary

Patch release containing only [PR #713](https://github.com/cyberlife-coder/VelesDB/pull/713) (numpy runtime dep) plus the routine manifest / lockfile bumps required by the release pipeline.

Resolves the `#1` DX honesty note in [`docs/quickstart/timing-results.md`](docs/quickstart/timing-results.md): `pip install velesdb` no longer requires the `[numpy]` extra. Single-fix patch.

## Type of change

- [x] Bug fix (Python wheel runtime dep correction)
- [x] Release pipeline bump (cross-crate version sync)

## Sémver

**Patch (v1.13.8)** — single additive packaging metadata fix, no API change.

## Test plan

- [x] PR #713 was ALL GREEN before merge (CI Success, Codacy, Devin, Snyk, Linux/Windows/WASM/Python/TS)
- [x] \`python scripts/check-version-sync.py\` — all 10 manifests aligned at 1.13.8
- [x] \`python scripts/check-promise-contract.py\` — 15 claims pass
- [x] \`cargo update --workspace\` — Cargo.lock refreshed
- [ ] CI on main green before tag push (mandatory: never push tag before CI Success on main)
- [ ] After tag push: monitor Release workflow for crates.io / PyPI / npm publishing

## Release sequence (post-merge)

1. Wait for ALL CI checks Success on \`main\` HEAD after merge
2. \`git checkout main && git pull origin main\`
3. \`git tag -a v1.13.8 -m \"v1.13.8 — numpy runtime dep\"\`
4. \`git push origin main --tags\`
5. Monitor: \`gh run list --limit 5\`
6. Sync PR \`main → develop\` after publishing succeeds

Refs [#379](https://github.com/cyberlife-coder/VelesDB/issues/379), [#713](https://github.com/cyberlife-coder/VelesDB/pull/713).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/716" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
