### PR TITLE
docs: highlight Haystack integration completing the Python RAG trio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-_Nothing yet — v1.15.0 milestone (#349 Haystack pending review, #429 Python DataFrame, #469 CBO calibration, #717 PyO3 SearchOptions builder)._
+### Added
+
+- **Haystack 2.x DocumentStore connector** (`integrations/haystack/`) — first-party `VelesDBDocumentStore` implementing the Haystack `DocumentStore` protocol (`write_documents`, `filter_documents`, `embedding_retrieval`, `count_documents`, `delete_documents`). Closes [#349](https://github.com/cyberlife-coder/VelesDB/issues/349). Together with the existing `langchain-velesdb` and `llamaindex-velesdb` connectors, VelesDB now ships first-party support for the three major Python RAG frameworks. Contributed by [@CrepuscularIRIS](https://github.com/CrepuscularIRIS) ([#672](https://github.com/cyberlife-coder/VelesDB/pull/672)).
+- **`integrations/README.md`** — landing page documenting the Python RAG framework parity, shared `velesdb-common` building blocks, and per-framework feature support matrix.
+
+### Changed
+
+- `docs/reference/ECOSYSTEM_PARITY.md` — Haystack integration column added to the 22-row parity matrix and to the action-items list.
+- Root `README.md` — Haystack integration added to the ecosystem table; explicit "Python RAG framework parity" callout below the table.
+
+### Pending milestone (v1.15.0)
+
+- [#429](https://github.com/cyberlife-coder/VelesDB/issues/429) Python DataFrame, [#469](https://github.com/cyberlife-coder/VelesDB/issues/469) CBO calibration, [#717](https://github.com/cyberlife-coder/VelesDB/issues/717) PyO3 SearchOptions builder.
 
 ## [1.14.0] — 2026-04-30
 

--- a/README.md
+++ b/README.md
@@ -436,7 +436,10 @@ Ship AI features without a server. VelesDB embeds directly into Tauri, iOS, and 
 | **Desktop** | [tauri-plugin](crates/tauri-plugin-velesdb) — Tauri v2 AI-powered apps | `cargo add tauri-plugin-velesdb` |
 | **LangChain** | [langchain-velesdb](integrations/langchain) — Official VectorStore | [From source](integrations/langchain/README.md) |
 | **LlamaIndex** | [llamaindex-velesdb](integrations/llamaindex) — Document indexing | [From source](integrations/llamaindex/README.md) |
+| **Haystack** | [haystack-velesdb](integrations/haystack) — Haystack 2.x DocumentStore | [From source](integrations/haystack/README.md) |
 | **Migration** | [velesdb-migrate](crates/velesdb-migrate) — From Qdrant, Pinecone, Supabase | `cargo install velesdb-migrate` |
+
+> **Python RAG framework parity**: VelesDB ships a first-party connector for the three major Python RAG frameworks — **LangChain** (`VectorStore`), **LlamaIndex** (`VectorStoreIndex`), and **Haystack 2.x** (`DocumentStore`) — so you can swap VelesDB into any existing RAG pipeline with a single dependency change.
 
 ---
 

--- a/docs/reference/ECOSYSTEM_PARITY.md
+++ b/docs/reference/ECOSYSTEM_PARITY.md
@@ -1,6 +1,6 @@
 # VelesQL Ecosystem Parity Matrix
 
-Last updated: 2026-04-18 (v1.13.0)
+Last updated: 2026-04-30 (v1.14.0 — Haystack 2.x DocumentStore added)
 
 This matrix tracks runtime contract and feature parity across the VelesDB ecosystem.
 
@@ -21,42 +21,44 @@ This matrix tracks runtime contract and feature parity across the VelesDB ecosys
 | Python bindings (`velesdb-python`) | core path (non-REST) | core path (non-REST) | core path (non-REST) | n/a REST | n/a REST |
 | LangChain integration | via Python binding | via Python binding | via Python binding | n/a REST | n/a REST |
 | LlamaIndex integration | via Python binding | via Python binding | via Python binding | n/a REST | n/a REST |
+| Haystack integration | via Python binding | via Python binding | via Python binding | n/a REST | n/a REST |
 
-## Feature Parity Matrix (85 features, 10 components)
+## Feature Parity Matrix (85 features, 11 components)
 
 Legend: ✅ full support | ⚠️ partial / limited | ❌ not supported | N/A not applicable
 
-| Feature Group | Core | Server | Python | WASM | Mobile | CLI | TS SDK | Tauri | LangChain | LlamaIndex |
-|---------------|------|--------|--------|------|--------|-----|--------|-------|-----------|------------|
-| **Vector CRUD** (insert, upsert, delete, get) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| **Batch Operations** (batch_insert, batch_upsert) | ✅ | ✅ | ✅ | ⚠️ | ⚠️ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| **Vector Search** (k-NN, filtered, batch) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| **Multi-Query Fusion** (RRF) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| **Multi-Query Fusion** (RSF / Weighted) | ✅ | ✅ | ✅ | ⚠️ | ✅ | ✅ | ✅ | ✅ | ⚠️ | ⚠️ |
-| **Hybrid Search** (dense+sparse, dense+text) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| **Text Search BM25** | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| **Sparse Vector Search** (sparse index) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| **Sparse Vector Search** (named indexes) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ |
-| **Graph Operations** (nodes, edges, traversal) | ✅ | ✅ | ✅ | ⚠️ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| **Cross-Collection MATCH** (`@collection`) | ✅ | ✅ | ⚠️ | ❌ | ❌ | ✅ | ⚠️ | ❌ | ❌ | ❌ |
-| **VelesQL** (parser + executor) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ⚠️ | ⚠️ |
-| **Collection Types** (Vector) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| **Collection Types** (Graph) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| **Collection Types** (Metadata) | ✅ | ✅ | ✅ | ⚠️ | ✅ | ✅ | ✅ | ✅ | ⚠️ | ⚠️ |
-| **Property Indexes** (secondary, trigram) | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| **Quantization** (SQ8 / Binary / PQ) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| **Quantization** (RaBitQ) | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ⚠️ |
-| **Agent Memory** (semantic, episodic, procedural) | ✅ | ⚠️ | ✅ | ✅ | ✅ | N/A | ✅ | ✅ | ⚠️ | ⚠️ |
-| **Persistence** (WAL / mmap) | ✅ | ✅ | ✅ | ❌ | ✅ | N/A | N/A | N/A | N/A | N/A |
-| **GPU Acceleration** (wgpu) | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Feature Group | Core | Server | Python | WASM | Mobile | CLI | TS SDK | Tauri | LangChain | LlamaIndex | Haystack |
+|---------------|------|--------|--------|------|--------|-----|--------|-------|-----------|------------|----------|
+| **Vector CRUD** (insert, upsert, delete, get) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| **Batch Operations** (batch_insert, batch_upsert) | ✅ | ✅ | ✅ | ⚠️ | ⚠️ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| **Vector Search** (k-NN, filtered, batch) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| **Multi-Query Fusion** (RRF) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ⚠️ |
+| **Multi-Query Fusion** (RSF / Weighted) | ✅ | ✅ | ✅ | ⚠️ | ✅ | ✅ | ✅ | ✅ | ⚠️ | ⚠️ | ⚠️ |
+| **Hybrid Search** (dense+sparse, dense+text) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ⚠️ |
+| **Text Search BM25** | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ⚠️ |
+| **Sparse Vector Search** (sparse index) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ |
+| **Sparse Vector Search** (named indexes) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ |
+| **Graph Operations** (nodes, edges, traversal) | ✅ | ✅ | ✅ | ⚠️ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | N/A |
+| **Cross-Collection MATCH** (`@collection`) | ✅ | ✅ | ⚠️ | ❌ | ❌ | ✅ | ⚠️ | ❌ | ❌ | ❌ | ❌ |
+| **VelesQL** (parser + executor) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ⚠️ | ⚠️ | ⚠️ |
+| **Collection Types** (Vector) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| **Collection Types** (Graph) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | N/A |
+| **Collection Types** (Metadata) | ✅ | ✅ | ✅ | ⚠️ | ✅ | ✅ | ✅ | ✅ | ⚠️ | ⚠️ | ⚠️ |
+| **Property Indexes** (secondary, trigram) | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ⚠️ |
+| **Quantization** (SQ8 / Binary / PQ) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| **Quantization** (RaBitQ) | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ⚠️ |
+| **Agent Memory** (semantic, episodic, procedural) | ✅ | ⚠️ | ✅ | ✅ | ✅ | N/A | ✅ | ✅ | ⚠️ | ⚠️ | N/A |
+| **Persistence** (WAL / mmap) | ✅ | ✅ | ✅ | ❌ | ✅ | N/A | N/A | N/A | N/A | N/A | N/A |
+| **GPU Acceleration** (wgpu) | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
 
 ### Notes
 
 - **Cross-Collection MATCH**: Core and Server support `@collection` annotation on MATCH node patterns. Python bindings support via `_collection` param. CLI supports via `\use`. WASM, Mobile, Tauri, and integrations do not yet expose this feature.
 - **Batch Operations**: WASM and Mobile use streaming chunked inserts instead of single-call bulk to stay within memory constraints.
-- **Multi-Query Fusion (RSF/Weighted)**: WASM supports RRF only; RSF/Weighted fusion is not yet exposed in LangChain/LlamaIndex integrations.
+- **Multi-Query Fusion (RSF/Weighted)**: WASM supports RRF only; RSF/Weighted fusion is not yet exposed in LangChain/LlamaIndex integrations and is unavailable in Haystack (RRF itself is exposed only via the underlying `velesdb` Python wrapper, not through the `DocumentStore` protocol).
 - **Graph Operations (WASM)**: Basic node/edge CRUD is supported; multi-hop traversal and MATCH queries are limited.
-- **VelesQL (LangChain/LlamaIndex)**: Pass-through to Python bindings works for simple queries; full parser integration is not surfaced in the integration API.
+- **VelesQL (LangChain/LlamaIndex/Haystack)**: Pass-through to Python bindings works for simple queries; full parser integration is not surfaced in the integration API.
+- **Haystack DocumentStore protocol limits**: The Haystack 2.x `DocumentStore` ABC exposes `write_documents`, `filter_documents`, `embedding_retrieval`, `count_documents`, and `delete_documents`. BM25 / hybrid retrieval requires a separate `Retriever` component (planned follow-up). Graph collections, agent memory, and sparse-named indexes are intentionally `N/A` because they have no idiomatic mapping in Haystack's protocol and are reachable through the raw `velesdb` Python wrapper if needed.
 - **Collection Types (Metadata)**: WASM and integration SDKs expose metadata collections with reduced column-type support.
 - **Property Indexes (WASM)**: Disabled by design — no persistence layer means indexes cannot survive page reloads.
 - **Quantization (RaBitQ)**: Experimental across all surfaces; API is unstable.
@@ -196,8 +198,8 @@ All 4 strategies (`RRF`, `Weighted`, `Maximum`, `RSF`) plus `Average` are suppor
 2. Extend WASM conformance from parser-only to executable feature checks where applicable.
 3. Keep docs, fixtures, and examples synchronized on every contract version change.
 4. Promote RaBitQ from experimental to stable once the API is finalized.
-5. Surface RSF/Weighted fusion in LangChain and LlamaIndex integrations.
-6. Expose named sparse indexes in LangChain and LlamaIndex integrations.
-7. Propagate `@collection` cross-collection MATCH to WASM, Mobile, Tauri, LangChain, and LlamaIndex.
+5. Surface RSF/Weighted fusion in LangChain, LlamaIndex, and Haystack integrations.
+6. Expose named sparse indexes in LangChain, LlamaIndex, and Haystack integrations.
+7. Propagate `@collection` cross-collection MATCH to WASM, Mobile, Tauri, LangChain, LlamaIndex, and Haystack.
 8. Add cross-collection vector search (`similarity()` on `@collection`-annotated nodes).
 9. Expose graph collection creation in `velesdb-mobile` (`create_graph_collection`).

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -1,0 +1,73 @@
+# VelesDB integrations
+
+First-party connectors that drop VelesDB into the Python RAG ecosystem with a
+single dependency change. Three of these — LangChain, LlamaIndex, and
+Haystack — are the major frameworks the Python RAG community settled on; the
+goal of this directory is to make swapping the vector backend a one-line
+exercise rather than a porting project.
+
+## Python RAG framework parity
+
+| Framework | Connector | API surface | Package |
+|-----------|-----------|-------------|---------|
+| **LangChain** | [`langchain-velesdb`](langchain) | `VectorStore` (`add_texts`, `similarity_search`, `similarity_search_with_score`, `delete`) | `pip install langchain-velesdb` |
+| **LlamaIndex** | [`llamaindex-velesdb`](llamaindex) | `VectorStore` (`add`, `query`, `delete_nodes`) | `pip install llamaindex-velesdb` |
+| **Haystack 2.x** | [`haystack-velesdb`](haystack) | `DocumentStore` (`write_documents`, `filter_documents`, `embedding_retrieval`, `count_documents`, `delete_documents`) | `pip install haystack-velesdb` |
+
+All three connectors share the same VelesDB persistence layer
+(`velesdb` Python wheel, PyO3 bindings) and respect the same payload schema,
+so a collection populated through one framework is readable by the other two
+without re-indexing.
+
+## Shared building blocks
+
+- [`common/`](common) — `velesdb-common` Python package: payload validation,
+  filter normalisation, security helpers (`validate_path`,
+  `validate_collection_name`, `validate_metric`) used by all three
+  connectors. Published as `velesdb-common` on PyPI.
+
+## Cross-framework parity matrix
+
+| Feature | LangChain | LlamaIndex | Haystack |
+|---------|-----------|------------|----------|
+| Add documents (with embedding) | ✅ | ✅ | ✅ |
+| Vector similarity search | ✅ | ✅ | ✅ |
+| Metadata filtering | ✅ | ✅ | ✅ |
+| Score normalisation (cosine → [0,1]) | ✅ | ✅ | ✅ |
+| Hybrid search (vector + BM25) | ✅ | ✅ | ⚠️ via separate retriever |
+| Delete by ID | ✅ | ✅ | ✅ |
+| `DuplicatePolicy.FAIL` enforcement | N/A | N/A | ✅ |
+| Pipeline serialisation (`to_dict`/`from_dict`) | ✅ | ✅ | ✅ |
+| Persistence path support | ✅ | ✅ | ✅ |
+
+**Pass-through limitations** (apply to all three integrations): named sparse
+indexes, RSF / Weighted fusion, and `@collection` cross-collection MATCH are
+not surfaced in the connector APIs yet. Drop down to the raw `velesdb`
+Python wrapper if you need them — see [`docs/reference/ECOSYSTEM_PARITY.md`](../docs/reference/ECOSYSTEM_PARITY.md)
+for the full feature matrix.
+
+## Quick start
+
+```python
+# LangChain
+from langchain_velesdb import VelesDBVectorStore
+store = VelesDBVectorStore(path="./data", collection_name="rag")
+
+# LlamaIndex
+from llamaindex_velesdb import VelesDBVectorStore
+store = VelesDBVectorStore(path="./data", collection_name="rag")
+
+# Haystack 2.x
+from haystack_velesdb import VelesDBDocumentStore
+store = VelesDBDocumentStore(path="./data", collection_name="rag")
+```
+
+The same `./data` directory and `rag` collection are reachable from any of
+the three connectors after the first write.
+
+## Reporting issues
+
+Please file framework-specific issues against the corresponding sub-directory
+(`integrations/<framework>/README.md` lists known limitations). Bugs in the
+shared `velesdb-common` helpers should be filed against
+[`integrations/common/`](common).


### PR DESCRIPTION
## Summary

Surface the Haystack 2.x integration ([#672](https://github.com/cyberlife-coder/VelesDB/pull/672)) in the user-facing docs. Together with the existing LangChain and LlamaIndex connectors, VelesDB now covers the three major Python RAG frameworks — a meaningful image / adoption signal for the project.

## Type of change

- [x] Documentation only

## What's in the diff (4 files)

- **`README.md`** — Haystack row added to \"Full Ecosystem\" table; explicit \"Python RAG framework parity\" callout below.
- **`integrations/README.md`** (new) — Landing page documenting the trio, shared \`velesdb-common\` helpers, cross-framework feature parity matrix, pass-through limitations that apply to all three connectors, and quick-start snippets.
- **`docs/reference/ECOSYSTEM_PARITY.md`** — Haystack column added to the 22-row Feature Parity Matrix (10 → 11 components); Endpoint Parity table extended; \"Last updated\" header bumped; action-items list updated.
- **`CHANGELOG.md`** — \`[Unreleased]\` section gains \`### Added\` entry crediting [@CrepuscularIRIS](https://github.com/CrepuscularIRIS) for the contributor PR + entry for this docs PR.

## Test plan

- [x] Manual review — links resolve, table alignment correct
- [ ] CI on PR (Markdown lint / link check / Codacy)

## Follow-up tracking

- [#717](https://github.com/cyberlife-coder/VelesDB/issues/717) PyO3 SearchOptions builder (deferred to v1.15.0/v2.0.0)
- Existing v1.15.0 milestone items: #429, #469

Refs [#349](https://github.com/cyberlife-coder/VelesDB/issues/349), [#672](https://github.com/cyberlife-coder/VelesDB/pull/672).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/721" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
