### PR TITLE
fix(scripts): close check-version-sync gap on server/python README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-_Nothing yet — work toward v1.15.0 lives under feature branches._
+### Fixed
+
+- **`scripts/check-version-sync.py` now polices the same set as `bump-version.ps1`** (22 targets, was 20). Devin caught the asymmetry on PR #726/#727: v1.14.2 added `crates/velesdb-server/README.md` and `crates/velesdb-python/README.md` to the bump script but forgot to mirror them in the verifier — meaning future drift could land silently. Two new readers added (`doc_health_snippet` reused for the server README, new `doc_version_badge` for the Python README's shields.io banner). The CHANGELOG line for v1.14.2 claiming "21 targets" was off-by-one for the same reason — corrected here.
 
 ## [1.14.2] — 2026-05-01
 

--- a/scripts/check-version-sync.py
+++ b/scripts/check-version-sync.py
@@ -27,6 +27,13 @@ TARGETS = {
     # CONFIGURATION.md TOML example header carries a hardcoded "# Version:" line.
     # Found drifting at 1.13.0 while the doc body banner was already 1.14.0.
     "docs/guides/CONFIGURATION.md": "doc_toml_header",
+    # Server README ships /health JSON examples that echo the workspace version;
+    # bump-version.ps1 already rewrites them, this entry mirrors that policing
+    # in the verifier (Devin found the 1-sided drift gap on PR #726/#727).
+    "crates/velesdb-server/README.md": "doc_health_snippet",
+    # Python wheel README carries a shields.io static badge `version-X.Y.Z-blue`
+    # that bump-version.ps1 rewrites; mirrored here so drift can't sneak in.
+    "crates/velesdb-python/README.md": "doc_version_badge",
     "demos/rag-pdf-demo/pyproject.toml": "toml",
     "sdks/typescript/package.json": "json",
     # The TS SDK's npm lockfile carries its own root "version" string that
@@ -139,6 +146,17 @@ def _read_doc_toml_header(path: Path) -> str:
     return match.group(1)
 
 
+def _read_doc_version_badge(path: Path) -> str:
+    """Pull the version out of a shields.io static badge of the form
+    `version-X.Y.Z-blue` (used in `crates/velesdb-python/README.md`).
+    """
+    text = path.read_text(encoding="utf-8")
+    match = re.search(r"version-(\d+\.\d+\.\d+)-blue", text)
+    if not match:
+        raise RuntimeError(f'No `version-X.Y.Z-blue` badge in {path}')
+    return match.group(1)
+
+
 def _read_dockerfile_label(path: Path) -> str:
     """Pull the version out of the first `LABEL version="X.Y.Z"` line."""
     text = path.read_text(encoding="utf-8")
@@ -157,6 +175,7 @@ _READERS = {
     "py_init_version": _read_py_init_version,
     "wasm_cdn_url": _read_wasm_cdn_url,
     "doc_toml_header": _read_doc_toml_header,
+    "doc_version_badge": _read_doc_version_badge,
 }
 
 


### PR DESCRIPTION
## Summary

Devin caught an asymmetry between \`scripts/bump-version.ps1\` and \`scripts/check-version-sync.py\` introduced in v1.14.2 (PR #726). Both scripts must police the same set of files for the lock-step guarantee to hold; v1.14.2 added 2 entries to the bumper but only mirrored them partially in the verifier — meaning future drift on \`crates/velesdb-server/README.md\` and \`crates/velesdb-python/README.md\` would have shipped silently.

## Type of change

- [x] Bug fix (tooling)
- [x] Documentation (CHANGELOG entry under [Unreleased])

## What changed

- \`scripts/check-version-sync.py\` TARGETS dict: 2 new entries (server README via existing \`doc_health_snippet\`, Python README via new \`doc_version_badge\`).
- New reader \`_read_doc_version_badge\` for shields.io static badges.
- CHANGELOG \`[Unreleased]\` entry documenting the fix + off-by-one correction (v1.14.2 entry said "21 targets", reality is 22).

## Test plan

- [x] \`python scripts/check-version-sync.py\` — all 22 targets OK at 1.14.2
- [x] \`python scripts/check-promise-contract.py\` — 15 claims pass
- [ ] CI on PR

## No release tag

Tooling-only fix, no user-visible behavior change, no version bump. Will ride the next regular release.

Refs Devin findings on PR [#726](https://github.com/cyberlife-coder/VelesDB/pull/726), PR [#727](https://github.com/cyberlife-coder/VelesDB/pull/727).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/728" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
