### PR TITLE
fix(haystack): close runtime gaps — example @component + filter translator + real-CI

### DIFF
--- a/.github/workflows/propagation-guard.yml
+++ b/.github/workflows/propagation-guard.yml
@@ -139,6 +139,63 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e ".[dev]"
           pytest tests/test_core_parity.py -q
+      - name: Haystack stub-based unit tests
+        working-directory: integrations/haystack
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+          # The unit suite stubs out haystack + velesdb so it runs offline.
+          # The real-haystack integration file (test_real_haystack_integration.py)
+          # auto-skips here and is exercised in the dedicated job below.
+          pytest tests/ -q
+      - name: Haystack example AST check (VelesRetriever has @component)
+        # Catches the bug class that v1.14.2 audit found: a Pipeline component
+        # missing the @component decorator. Pipeline.add_component() rejects
+        # undecorated classes at runtime; this static check fails fast.
+        run: |
+          python - <<'PY'
+          import ast, sys
+          path = "integrations/haystack/examples/rag_pipeline.py"
+          tree = ast.parse(open(path).read())
+          for node in ast.walk(tree):
+              if isinstance(node, ast.ClassDef) and node.name.endswith("Retriever"):
+                  decos = [ast.unparse(d) for d in node.decorator_list]
+                  if "component" not in decos:
+                      print(
+                          f"::error file={path}::class {node.name} is used as a "
+                          "Haystack Pipeline component but is missing the "
+                          "@component decorator (Pipeline.add_component will reject it)."
+                      )
+                      sys.exit(1)
+          print("OK: every *Retriever class in rag_pipeline.py is @component-decorated")
+          PY
+
+  haystack-real-integration:
+    # Heavyweight job: installs haystack-ai + the published velesdb wheel
+    # and exercises tests/test_real_haystack_integration.py end-to-end. The
+    # stub-based unit suite above (Python Integrations Check) auto-skips
+    # this file; this job is the only place protocol drift between the
+    # connector and the real Haystack 2.x runtime is caught.
+    name: Haystack Real Integration
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.11"
+      - name: Install haystack-ai + published velesdb wheel + this connector
+        working-directory: integrations/haystack
+        run: |
+          python -m pip install --upgrade pip
+          # Pin velesdb to the workspace floor declared in pyproject (>=1.14.0)
+          # — pip will resolve to the latest published patch on PyPI.
+          pip install "velesdb>=1.14.0" "haystack-ai>=2.0.0"
+          pip install -e ../common
+          pip install -e ".[dev]"
+      - name: Run real Haystack integration suite
+        working-directory: integrations/haystack
+        run: |
+          pytest tests/test_real_haystack_integration.py -v --no-header
 
   demos-examples-smoke:
     name: Demos and Examples Smoke
@@ -165,6 +222,9 @@ jobs:
         run: |
           python -m py_compile examples/python_example.py
           python -m py_compile examples/python/*.py
+          # Integration-level examples — must at least compile cleanly so a
+          # user copying the file into their project doesn't hit a SyntaxError.
+          python -m py_compile integrations/haystack/examples/rag_pipeline.py
       - name: Tauri demo frontend build smoke
         working-directory: demos/tauri-rag-app
         run: |

--- a/integrations/haystack/examples/rag_pipeline.py
+++ b/integrations/haystack/examples/rag_pipeline.py
@@ -10,8 +10,9 @@ Usage:
 from __future__ import annotations
 
 import argparse
+from typing import List
 
-from haystack import Pipeline
+from haystack import Pipeline, component
 from haystack.components.embedders import (
     SentenceTransformersDocumentEmbedder,
     SentenceTransformersTextEmbedder,
@@ -23,6 +24,30 @@ from haystack_velesdb import VelesDBDocumentStore
 
 MODEL = "sentence-transformers/all-MiniLM-L6-v2"
 STORE_PATH = "./rag_demo_store"
+
+
+@component
+class VelesRetriever:
+    """Haystack 2.x component wrapping ``VelesDBDocumentStore.embedding_retrieval``.
+
+    Required because the built-in ``InMemoryEmbeddingRetriever`` is bound to
+    ``InMemoryDocumentStore`` and would refuse a custom store. This wrapper
+    is the canonical pattern for plugging any custom DocumentStore into a
+    Haystack 2.x query pipeline.
+
+    The ``@component`` decorator and ``@component.output_types`` are
+    mandatory — without them, ``Pipeline.add_component`` raises
+    ``PipelineError: ... is not a Haystack component``.
+    """
+
+    def __init__(self, document_store: VelesDBDocumentStore, top_k: int = 5) -> None:
+        self._store = document_store
+        self._top_k = top_k
+
+    @component.output_types(documents=List[Document])
+    def run(self, query_embedding: List[float]) -> dict:
+        docs = self._store.embedding_retrieval(query_embedding, top_k=self._top_k)
+        return {"documents": docs}
 
 
 def build_index_pipeline(store: VelesDBDocumentStore) -> Pipeline:
@@ -40,21 +65,9 @@ def build_query_pipeline(store: VelesDBDocumentStore) -> Pipeline:
     """Return a pipeline that embeds a query and retrieves from *store*."""
     pipeline = Pipeline()
     pipeline.add_component("embedder", SentenceTransformersTextEmbedder(model=MODEL))
-    pipeline.add_component("retriever", _VelesRetriever(store))
+    pipeline.add_component("retriever", VelesRetriever(store))
     pipeline.connect("embedder.embedding", "retriever.query_embedding")
     return pipeline
-
-
-class _VelesRetriever:
-    """Thin Haystack component wrapping VelesDBDocumentStore.embedding_retrieval."""
-
-    def __init__(self, store: VelesDBDocumentStore, top_k: int = 5) -> None:
-        self._store = store
-        self._top_k = top_k
-
-    def run(self, query_embedding: list) -> dict:
-        docs = self._store.embedding_retrieval(query_embedding, top_k=self._top_k)
-        return {"documents": docs}
 
 
 SAMPLE_TEXTS = [

--- a/integrations/haystack/src/haystack_velesdb/document_store.py
+++ b/integrations/haystack/src/haystack_velesdb/document_store.py
@@ -67,6 +67,99 @@ def _strip_meta_prefix(field: str) -> str:
     return field
 
 
+def _translate_logical(operator: str, filters: Dict[str, Any]) -> Dict[str, Any]:
+    """Translate a Haystack ``AND`` / ``OR`` / ``NOT`` combinator node.
+
+    ``NOT`` is special: Haystack wraps ``conditions`` (list) just like AND/OR,
+    but VelesDB ``Not`` wraps a single ``condition``. Reject anything other
+    than a one-element list — Haystack itself rejects multi-element NOT.
+    """
+    veles_op = _HAYSTACK_LOGIC_TO_VELES[operator]
+    conditions = filters.get("conditions") or []
+    if veles_op == "not":
+        if len(conditions) != 1:
+            raise ValueError(
+                "Haystack NOT must wrap exactly one condition; got "
+                f"{len(conditions)}"
+            )
+        return {"type": "not", "condition": _translate_condition(conditions[0])}
+    if not conditions:
+        raise ValueError(
+            f"Haystack {operator} requires non-empty 'conditions' list"
+        )
+    return {
+        "type": veles_op,
+        "conditions": [_translate_condition(c) for c in conditions],
+    }
+
+
+def _translate_comparison(operator: str, filters: Dict[str, Any]) -> Dict[str, Any]:
+    """Translate a Haystack comparison leaf (``field``/``operator``/``value``)."""
+    field = filters.get("field")
+    if not isinstance(field, str) or not field:
+        raise ValueError(
+            f"Haystack comparison '{operator}' requires non-empty 'field'"
+        )
+    veles_field = _strip_meta_prefix(field)
+    if operator == "in":
+        values = filters.get("value")
+        if not isinstance(values, list):
+            raise ValueError(
+                "Haystack 'in' operator requires 'value' to be a list"
+            )
+        return {"type": "in", "field": veles_field, "values": values}
+    return {
+        "type": _HAYSTACK_COMPARISON_TO_VELES[operator],
+        "field": veles_field,
+        "value": filters.get("value"),
+    }
+
+
+def _translate_not_in(filters: Dict[str, Any]) -> Dict[str, Any]:
+    """Translate a Haystack ``not in`` leaf to VelesDB ``Not(In(...))``."""
+    field = filters.get("field")
+    if not isinstance(field, str) or not field:
+        raise ValueError("Haystack 'not in' requires non-empty 'field'")
+    values = filters.get("value")
+    if not isinstance(values, list):
+        raise ValueError("Haystack 'not in' requires 'value' to be a list")
+    return {
+        "type": "not",
+        "condition": {
+            "type": "in",
+            "field": _strip_meta_prefix(field),
+            "values": values,
+        },
+    }
+
+
+def _translate_condition(filters: Dict[str, Any]) -> Dict[str, Any]:
+    """Recursive helper: translate ANY Haystack filter node to a VelesDB
+    ``Condition`` shape. The top-level :func:`_translate_haystack_filter`
+    wraps the result in ``{"condition": ...}`` to produce a complete
+    VelesDB ``Filter`` object.
+    """
+    if not isinstance(filters, dict):
+        raise ValueError(
+            f"Haystack filter must be a dict, got {type(filters).__name__}"
+        )
+    operator = filters.get("operator")
+    if operator in _HAYSTACK_LOGIC_TO_VELES:
+        return _translate_logical(operator, filters)
+    if operator in _HAYSTACK_COMPARISON_TO_VELES:
+        return _translate_comparison(operator, filters)
+    if operator == "not in":
+        return _translate_not_in(filters)
+    supported = sorted(
+        set(_HAYSTACK_COMPARISON_TO_VELES)
+        | set(_HAYSTACK_LOGIC_TO_VELES)
+        | {"not in"}
+    )
+    raise NotImplementedError(
+        f"Unsupported Haystack filter operator: {operator!r}. Supported: {supported}"
+    )
+
+
 def _translate_haystack_filter(
     filters: Optional[Dict[str, Any]],
 ) -> Optional[Dict[str, Any]]:
@@ -80,7 +173,11 @@ def _translate_haystack_filter(
     VelesDB tags every node with a ``type`` discriminator and uses lowercase
     snake_case operator names (``eq``, ``and``, ``in``, ...). The ``meta.``
     namespace prefix is stripped because the DocumentStore stores metadata
-    flat in the VelesDB payload.
+    flat in the VelesDB payload. The full ``Filter`` JSON object always wraps
+    the translated condition tree under a top-level ``"condition"`` key:
+
+        Haystack:  {"field": "meta.x", "operator": "==", "value": 1}
+        VelesDB:   {"condition": {"type": "eq", "field": "x", "value": 1}}
 
     Returns ``None`` when *filters* is ``None`` (pass-through), so callers can
     forward the result directly to ``Collection.scroll(filter=...)``.
@@ -93,78 +190,7 @@ def _translate_haystack_filter(
     """
     if filters is None:
         return None
-    if not isinstance(filters, dict):
-        raise ValueError(
-            f"Haystack filter must be a dict, got {type(filters).__name__}"
-        )
-    operator = filters.get("operator")
-    # ----- logical combinator (operator + conditions) -----
-    if operator in _HAYSTACK_LOGIC_TO_VELES:
-        veles_op = _HAYSTACK_LOGIC_TO_VELES[operator]
-        if veles_op == "not":
-            # Haystack NOT wraps `conditions` (list) just like AND/OR; VelesDB
-            # NOT wraps a single `condition`. Reject anything other than a
-            # one-element list — Haystack itself rejects multi-element NOT.
-            conditions = filters.get("conditions", [])
-            if len(conditions) != 1:
-                raise ValueError(
-                    "Haystack NOT must wrap exactly one condition; got "
-                    f"{len(conditions)}"
-                )
-            inner = _translate_haystack_filter(conditions[0])
-            assert inner is not None  # nested conditions are never None
-            return {"type": "not", "condition": inner}
-        conditions = filters.get("conditions")
-        if not conditions:
-            raise ValueError(
-                f"Haystack {operator} requires non-empty 'conditions' list"
-            )
-        translated = []
-        for c in conditions:
-            t = _translate_haystack_filter(c)
-            assert t is not None
-            translated.append(t)
-        return {"type": veles_op, "conditions": translated}
-    # ----- comparison leaf (field + operator + value) -----
-    if operator in _HAYSTACK_COMPARISON_TO_VELES:
-        field = filters.get("field")
-        if not isinstance(field, str) or not field:
-            raise ValueError(
-                f"Haystack comparison '{operator}' requires non-empty 'field'"
-            )
-        veles_field = _strip_meta_prefix(field)
-        if operator == "in":
-            values = filters.get("value")
-            if not isinstance(values, list):
-                raise ValueError(
-                    "Haystack 'in' operator requires 'value' to be a list"
-                )
-            return {"type": "in", "field": veles_field, "values": values}
-        return {
-            "type": _HAYSTACK_COMPARISON_TO_VELES[operator],
-            "field": veles_field,
-            "value": filters.get("value"),
-        }
-    if operator == "not in":
-        # Encoded as NOT(IN(...)) in VelesDB.
-        field = filters.get("field")
-        if not isinstance(field, str) or not field:
-            raise ValueError("Haystack 'not in' requires non-empty 'field'")
-        values = filters.get("value")
-        if not isinstance(values, list):
-            raise ValueError("Haystack 'not in' requires 'value' to be a list")
-        return {
-            "type": "not",
-            "condition": {
-                "type": "in",
-                "field": _strip_meta_prefix(field),
-                "values": values,
-            },
-        }
-    raise NotImplementedError(
-        f"Unsupported Haystack filter operator: {operator!r}. Supported: "
-        f"{sorted(set(_HAYSTACK_COMPARISON_TO_VELES) | set(_HAYSTACK_LOGIC_TO_VELES) | {'not in'})}"
-    )
+    return {"condition": _translate_condition(filters)}
 
 
 def _str_id_to_int(doc_id: str) -> int:

--- a/integrations/haystack/src/haystack_velesdb/document_store.py
+++ b/integrations/haystack/src/haystack_velesdb/document_store.py
@@ -33,6 +33,139 @@ _INT63_MASK = (1 << 63) - 1
 # Reserved keys stored by this integration in the VelesDB payload.
 _RESERVED_PAYLOAD_KEYS = frozenset({"_doc_id", "content"})
 
+# Haystack 2.x comparison operator (string) -> VelesDB Condition type tag.
+# Reference: https://docs.haystack.deepset.ai/docs/metadata-filtering
+_HAYSTACK_COMPARISON_TO_VELES: Dict[str, str] = {
+    "==": "eq",
+    "!=": "neq",
+    ">": "gt",
+    ">=": "gte",
+    "<": "lt",
+    "<=": "lte",
+    "in": "in",
+    # `not in` is handled specially: wrapped in a top-level NOT around an `in`.
+}
+
+# Haystack 2.x logical operator -> VelesDB Condition type tag.
+_HAYSTACK_LOGIC_TO_VELES: Dict[str, str] = {
+    "AND": "and",
+    "OR": "or",
+    "NOT": "not",
+}
+
+
+def _strip_meta_prefix(field: str) -> str:
+    """Drop the leading ``meta.`` namespace from a Haystack field path.
+
+    Haystack stores user-supplied metadata under ``Document.meta`` and exposes
+    it through the filter API as ``meta.<key>``. VelesDB stores the same data
+    flat in the payload (alongside the reserved ``_doc_id`` and ``content``
+    keys), so the prefix must be stripped before the filter can match.
+    """
+    if field.startswith("meta."):
+        return field[len("meta."):]
+    return field
+
+
+def _translate_haystack_filter(
+    filters: Optional[Dict[str, Any]],
+) -> Optional[Dict[str, Any]]:
+    """Translate a Haystack 2.x filter dict to the VelesDB ``Filter`` JSON shape.
+
+    Haystack 2.x uses two interchangeable filter shapes:
+
+    1. Comparison leaf — ``{"field": "meta.x", "operator": "==", "value": v}``
+    2. Logical combinator — ``{"operator": "AND", "conditions": [<leaf>, ...]}``
+
+    VelesDB tags every node with a ``type`` discriminator and uses lowercase
+    snake_case operator names (``eq``, ``and``, ``in``, ...). The ``meta.``
+    namespace prefix is stripped because the DocumentStore stores metadata
+    flat in the VelesDB payload.
+
+    Returns ``None`` when *filters* is ``None`` (pass-through), so callers can
+    forward the result directly to ``Collection.scroll(filter=...)``.
+
+    Raises:
+        NotImplementedError: When the filter contains an operator VelesDB
+            does not support (e.g. a misspelled operator).
+        ValueError: When the filter dict is structurally invalid (missing
+            required keys, conditions list empty for a logical combinator).
+    """
+    if filters is None:
+        return None
+    if not isinstance(filters, dict):
+        raise ValueError(
+            f"Haystack filter must be a dict, got {type(filters).__name__}"
+        )
+    operator = filters.get("operator")
+    # ----- logical combinator (operator + conditions) -----
+    if operator in _HAYSTACK_LOGIC_TO_VELES:
+        veles_op = _HAYSTACK_LOGIC_TO_VELES[operator]
+        if veles_op == "not":
+            # Haystack NOT wraps `conditions` (list) just like AND/OR; VelesDB
+            # NOT wraps a single `condition`. Reject anything other than a
+            # one-element list — Haystack itself rejects multi-element NOT.
+            conditions = filters.get("conditions", [])
+            if len(conditions) != 1:
+                raise ValueError(
+                    "Haystack NOT must wrap exactly one condition; got "
+                    f"{len(conditions)}"
+                )
+            inner = _translate_haystack_filter(conditions[0])
+            assert inner is not None  # nested conditions are never None
+            return {"type": "not", "condition": inner}
+        conditions = filters.get("conditions")
+        if not conditions:
+            raise ValueError(
+                f"Haystack {operator} requires non-empty 'conditions' list"
+            )
+        translated = []
+        for c in conditions:
+            t = _translate_haystack_filter(c)
+            assert t is not None
+            translated.append(t)
+        return {"type": veles_op, "conditions": translated}
+    # ----- comparison leaf (field + operator + value) -----
+    if operator in _HAYSTACK_COMPARISON_TO_VELES:
+        field = filters.get("field")
+        if not isinstance(field, str) or not field:
+            raise ValueError(
+                f"Haystack comparison '{operator}' requires non-empty 'field'"
+            )
+        veles_field = _strip_meta_prefix(field)
+        if operator == "in":
+            values = filters.get("value")
+            if not isinstance(values, list):
+                raise ValueError(
+                    "Haystack 'in' operator requires 'value' to be a list"
+                )
+            return {"type": "in", "field": veles_field, "values": values}
+        return {
+            "type": _HAYSTACK_COMPARISON_TO_VELES[operator],
+            "field": veles_field,
+            "value": filters.get("value"),
+        }
+    if operator == "not in":
+        # Encoded as NOT(IN(...)) in VelesDB.
+        field = filters.get("field")
+        if not isinstance(field, str) or not field:
+            raise ValueError("Haystack 'not in' requires non-empty 'field'")
+        values = filters.get("value")
+        if not isinstance(values, list):
+            raise ValueError("Haystack 'not in' requires 'value' to be a list")
+        return {
+            "type": "not",
+            "condition": {
+                "type": "in",
+                "field": _strip_meta_prefix(field),
+                "values": values,
+            },
+        }
+    raise NotImplementedError(
+        f"Unsupported Haystack filter operator: {operator!r}. Supported: "
+        f"{sorted(set(_HAYSTACK_COMPARISON_TO_VELES) | set(_HAYSTACK_LOGIC_TO_VELES) | {'not in'})}"
+    )
+
 
 def _str_id_to_int(doc_id: str) -> int:
     """Map a Haystack string document ID to a stable positive 63-bit integer.
@@ -268,15 +401,28 @@ class VelesDBDocumentStore:
     ) -> List[Document]:
         """Return documents matching *filters*, or all documents when *None*.
 
-        Passes *filters* directly to VelesDB's scroll operation. The real
-        SDK returns ``Iterator[List[Dict]]`` and has no ``limit`` kwarg, so
-        we drive the iterator ourselves and stop once ``self._scroll_limit``
-        documents have been collected. Increase ``scroll_limit`` on the
-        constructor for collections larger than the default 10 000.
+        *filters* must follow the standard Haystack 2.x filter dict shape
+        (see https://docs.haystack.deepset.ai/docs/metadata-filtering).
+        It is translated to the VelesDB native filter format before being
+        forwarded to ``Collection.scroll``. The ``meta.<key>`` namespace
+        used by Haystack is stripped because this DocumentStore stores
+        metadata flat in the VelesDB payload.
+
+        The real SDK returns ``Iterator[List[Dict]]`` and has no ``limit``
+        kwarg, so we drive the iterator ourselves and stop once
+        ``self._scroll_limit`` documents have been collected. Increase
+        ``scroll_limit`` on the constructor for collections larger than
+        the default 10 000.
+
+        Raises:
+            NotImplementedError: When *filters* uses an operator VelesDB
+                does not support.
+            ValueError: When *filters* is structurally malformed.
         """
+        veles_filter = _translate_haystack_filter(filters)
         col = self._get_collection()
         documents: List[Document] = []
-        for batch in col.scroll(filter=filters):
+        for batch in col.scroll(filter=veles_filter):
             for raw in batch:
                 if len(documents) >= self._scroll_limit:
                     return documents
@@ -349,15 +495,23 @@ class VelesDBDocumentStore:
         Args:
             query_embedding: Dense query vector.
             top_k: Maximum number of documents to return.
-            filters: Optional VelesDB filter dict to restrict the search space.
+            filters: Optional Haystack 2.x filter dict to restrict the search
+                space. Translated to VelesDB native shape before being
+                forwarded; ``meta.<key>`` is stripped to ``<key>``.
             scale_score: When ``True`` and ``metric="cosine"``, scores are
                 normalised from ``[-1, 1]`` to ``[0, 1]``. Ignored for other
                 metrics, where raw scores are returned unchanged.
+
+        Raises:
+            NotImplementedError: When *filters* uses an operator VelesDB
+                does not support.
+            ValueError: When *filters* is structurally malformed.
         """
+        veles_filter = _translate_haystack_filter(filters)
         results: List[dict] = self._get_collection().search(
             vector=query_embedding,
             top_k=top_k,
-            filter=filters,
+            filter=veles_filter,
         )
         return [_result_to_doc(r, scale_score=scale_score, metric=self._metric) for r in results]
 

--- a/integrations/haystack/tests/test_document_store.py
+++ b/integrations/haystack/tests/test_document_store.py
@@ -446,18 +446,33 @@ def test_translate_filter_none_passes_through() -> None:
     assert _MOD._translate_haystack_filter(None) is None
 
 
+def test_translate_filter_wraps_top_level_in_condition() -> None:
+    """The entry point wraps the translated condition under the
+    VelesDB ``Filter`` shape (``{"condition": ...}``); recursive
+    ``_translate_condition()`` returns the inner shape directly.
+    """
+    out = _MOD._translate_haystack_filter(
+        {"field": "meta.x", "operator": "==", "value": 1}
+    )
+    assert out == {"condition": {"type": "eq", "field": "x", "value": 1}}
+
+
 def test_translate_filter_simple_eq_strips_meta_prefix() -> None:
     out = _MOD._translate_haystack_filter(
         {"field": "meta.source", "operator": "==", "value": "wiki"}
     )
-    assert out == {"type": "eq", "field": "source", "value": "wiki"}
+    assert out == {
+        "condition": {"type": "eq", "field": "source", "value": "wiki"}
+    }
 
 
 def test_translate_filter_keeps_field_when_no_meta_prefix() -> None:
     out = _MOD._translate_haystack_filter(
         {"field": "_doc_id", "operator": "==", "value": "doc1"}
     )
-    assert out == {"type": "eq", "field": "_doc_id", "value": "doc1"}
+    assert out == {
+        "condition": {"type": "eq", "field": "_doc_id", "value": "doc1"}
+    }
 
 
 def test_translate_filter_all_comparison_operators() -> None:
@@ -473,14 +488,18 @@ def test_translate_filter_all_comparison_operators() -> None:
         out = _MOD._translate_haystack_filter(
             {"field": "meta.x", "operator": hs_op, "value": 42}
         )
-        assert out == {"type": veles_op, "field": "x", "value": 42}, hs_op
+        assert out == {
+            "condition": {"type": veles_op, "field": "x", "value": 42}
+        }, hs_op
 
 
 def test_translate_filter_in_remaps_value_to_values() -> None:
     out = _MOD._translate_haystack_filter(
         {"field": "meta.tag", "operator": "in", "value": ["a", "b", "c"]}
     )
-    assert out == {"type": "in", "field": "tag", "values": ["a", "b", "c"]}
+    assert out == {
+        "condition": {"type": "in", "field": "tag", "values": ["a", "b", "c"]}
+    }
 
 
 def test_translate_filter_in_rejects_scalar_value() -> None:
@@ -497,8 +516,10 @@ def test_translate_filter_not_in_wraps_in_with_not() -> None:
         {"field": "meta.tag", "operator": "not in", "value": ["x", "y"]}
     )
     assert out == {
-        "type": "not",
-        "condition": {"type": "in", "field": "tag", "values": ["x", "y"]},
+        "condition": {
+            "type": "not",
+            "condition": {"type": "in", "field": "tag", "values": ["x", "y"]},
+        }
     }
 
 
@@ -511,11 +532,13 @@ def test_translate_filter_logical_and() -> None:
         ],
     })
     assert out == {
-        "type": "and",
-        "conditions": [
-            {"type": "eq", "field": "source", "value": "wiki"},
-            {"type": "gt", "field": "score", "value": 0.5},
-        ],
+        "condition": {
+            "type": "and",
+            "conditions": [
+                {"type": "eq", "field": "source", "value": "wiki"},
+                {"type": "gt", "field": "score", "value": 0.5},
+            ],
+        }
     }
 
 
@@ -528,11 +551,13 @@ def test_translate_filter_logical_or() -> None:
         ],
     })
     assert out == {
-        "type": "or",
-        "conditions": [
-            {"type": "eq", "field": "lang", "value": "en"},
-            {"type": "eq", "field": "lang", "value": "fr"},
-        ],
+        "condition": {
+            "type": "or",
+            "conditions": [
+                {"type": "eq", "field": "lang", "value": "en"},
+                {"type": "eq", "field": "lang", "value": "fr"},
+            ],
+        }
     }
 
 
@@ -551,17 +576,19 @@ def test_translate_filter_nested_and_inside_or() -> None:
         ],
     })
     assert out == {
-        "type": "or",
-        "conditions": [
-            {"type": "eq", "field": "a", "value": 1},
-            {
-                "type": "and",
-                "conditions": [
-                    {"type": "gt", "field": "b", "value": 0},
-                    {"type": "lt", "field": "c", "value": 10},
-                ],
-            },
-        ],
+        "condition": {
+            "type": "or",
+            "conditions": [
+                {"type": "eq", "field": "a", "value": 1},
+                {
+                    "type": "and",
+                    "conditions": [
+                        {"type": "gt", "field": "b", "value": 0},
+                        {"type": "lt", "field": "c", "value": 10},
+                    ],
+                },
+            ],
+        }
     }
 
 
@@ -571,8 +598,10 @@ def test_translate_filter_not_wraps_single_condition() -> None:
         "conditions": [{"field": "meta.x", "operator": "==", "value": 1}],
     })
     assert out == {
-        "type": "not",
-        "condition": {"type": "eq", "field": "x", "value": 1},
+        "condition": {
+            "type": "not",
+            "condition": {"type": "eq", "field": "x", "value": 1},
+        }
     }
 
 
@@ -665,10 +694,8 @@ def test_filter_documents_translates_haystack_filter_to_veles_shape() -> None:
             {"field": "meta.source", "operator": "==", "value": "wiki"}
         )
         assert captured["filter"] == {
-            "type": "eq",
-            "field": "source",
-            "value": "wiki",
-        }, "Haystack filter must be translated to VelesDB shape before scroll"
+            "condition": {"type": "eq", "field": "source", "value": "wiki"},
+        }, "Haystack filter must be translated to VelesDB Filter shape before scroll"
     finally:
         _MOD.velesdb = original_velesdb
 
@@ -716,11 +743,13 @@ def test_embedding_retrieval_translates_haystack_filter_to_veles_shape() -> None
             },
         )
         assert captured["filter"] == {
-            "type": "and",
-            "conditions": [
-                {"type": "eq", "field": "lang", "value": "en"},
-                {"type": "gt", "field": "score", "value": 0.5},
-            ],
-        }, "embedding_retrieval must translate Haystack filter to VelesDB shape"
+            "condition": {
+                "type": "and",
+                "conditions": [
+                    {"type": "eq", "field": "lang", "value": "en"},
+                    {"type": "gt", "field": "score", "value": 0.5},
+                ],
+            },
+        }, "embedding_retrieval must translate Haystack filter to VelesDB Filter shape"
     finally:
         _MOD.velesdb = original_velesdb

--- a/integrations/haystack/tests/test_document_store.py
+++ b/integrations/haystack/tests/test_document_store.py
@@ -230,9 +230,11 @@ def test_filter_documents_passes_filter_to_scroll() -> None:
     store.write_documents([
         Document(id="fa", content="alpha", embedding=[0.1]),
     ])
-    # Passing a non-None filter should not raise; the fake scroll ignores it,
-    # but this confirms the filter arg is forwarded without error.
-    results = store.filter_documents(filters={"field": "value"})
+    # A real Haystack 2.x filter shape — the fake scroll ignores the
+    # translated VelesDB filter, but this exercises the translator end-to-end.
+    results = store.filter_documents(
+        filters={"field": "meta.source", "operator": "==", "value": "wiki"}
+    )
     assert len(results) == 1
 
 
@@ -431,5 +433,294 @@ def test_get_collection_returns_none_and_creates_collection() -> None:
         store = _MOD.VelesDBDocumentStore(path="/tmp/hs", collection_name="t_none_path")
         assert store.count_documents() == 0
         assert store._collection is not None
+    finally:
+        _MOD.velesdb = original_velesdb
+
+
+# ---------------------------------------------------------------------------
+# Haystack-filter -> VelesDB-filter translator tests
+# ---------------------------------------------------------------------------
+
+
+def test_translate_filter_none_passes_through() -> None:
+    assert _MOD._translate_haystack_filter(None) is None
+
+
+def test_translate_filter_simple_eq_strips_meta_prefix() -> None:
+    out = _MOD._translate_haystack_filter(
+        {"field": "meta.source", "operator": "==", "value": "wiki"}
+    )
+    assert out == {"type": "eq", "field": "source", "value": "wiki"}
+
+
+def test_translate_filter_keeps_field_when_no_meta_prefix() -> None:
+    out = _MOD._translate_haystack_filter(
+        {"field": "_doc_id", "operator": "==", "value": "doc1"}
+    )
+    assert out == {"type": "eq", "field": "_doc_id", "value": "doc1"}
+
+
+def test_translate_filter_all_comparison_operators() -> None:
+    cases = [
+        ("==", "eq"),
+        ("!=", "neq"),
+        (">", "gt"),
+        (">=", "gte"),
+        ("<", "lt"),
+        ("<=", "lte"),
+    ]
+    for hs_op, veles_op in cases:
+        out = _MOD._translate_haystack_filter(
+            {"field": "meta.x", "operator": hs_op, "value": 42}
+        )
+        assert out == {"type": veles_op, "field": "x", "value": 42}, hs_op
+
+
+def test_translate_filter_in_remaps_value_to_values() -> None:
+    out = _MOD._translate_haystack_filter(
+        {"field": "meta.tag", "operator": "in", "value": ["a", "b", "c"]}
+    )
+    assert out == {"type": "in", "field": "tag", "values": ["a", "b", "c"]}
+
+
+def test_translate_filter_in_rejects_scalar_value() -> None:
+    import pytest
+
+    with pytest.raises(ValueError, match="'in' operator requires"):
+        _MOD._translate_haystack_filter(
+            {"field": "meta.tag", "operator": "in", "value": "scalar"}
+        )
+
+
+def test_translate_filter_not_in_wraps_in_with_not() -> None:
+    out = _MOD._translate_haystack_filter(
+        {"field": "meta.tag", "operator": "not in", "value": ["x", "y"]}
+    )
+    assert out == {
+        "type": "not",
+        "condition": {"type": "in", "field": "tag", "values": ["x", "y"]},
+    }
+
+
+def test_translate_filter_logical_and() -> None:
+    out = _MOD._translate_haystack_filter({
+        "operator": "AND",
+        "conditions": [
+            {"field": "meta.source", "operator": "==", "value": "wiki"},
+            {"field": "meta.score", "operator": ">", "value": 0.5},
+        ],
+    })
+    assert out == {
+        "type": "and",
+        "conditions": [
+            {"type": "eq", "field": "source", "value": "wiki"},
+            {"type": "gt", "field": "score", "value": 0.5},
+        ],
+    }
+
+
+def test_translate_filter_logical_or() -> None:
+    out = _MOD._translate_haystack_filter({
+        "operator": "OR",
+        "conditions": [
+            {"field": "meta.lang", "operator": "==", "value": "en"},
+            {"field": "meta.lang", "operator": "==", "value": "fr"},
+        ],
+    })
+    assert out == {
+        "type": "or",
+        "conditions": [
+            {"type": "eq", "field": "lang", "value": "en"},
+            {"type": "eq", "field": "lang", "value": "fr"},
+        ],
+    }
+
+
+def test_translate_filter_nested_and_inside_or() -> None:
+    out = _MOD._translate_haystack_filter({
+        "operator": "OR",
+        "conditions": [
+            {"field": "meta.a", "operator": "==", "value": 1},
+            {
+                "operator": "AND",
+                "conditions": [
+                    {"field": "meta.b", "operator": ">", "value": 0},
+                    {"field": "meta.c", "operator": "<", "value": 10},
+                ],
+            },
+        ],
+    })
+    assert out == {
+        "type": "or",
+        "conditions": [
+            {"type": "eq", "field": "a", "value": 1},
+            {
+                "type": "and",
+                "conditions": [
+                    {"type": "gt", "field": "b", "value": 0},
+                    {"type": "lt", "field": "c", "value": 10},
+                ],
+            },
+        ],
+    }
+
+
+def test_translate_filter_not_wraps_single_condition() -> None:
+    out = _MOD._translate_haystack_filter({
+        "operator": "NOT",
+        "conditions": [{"field": "meta.x", "operator": "==", "value": 1}],
+    })
+    assert out == {
+        "type": "not",
+        "condition": {"type": "eq", "field": "x", "value": 1},
+    }
+
+
+def test_translate_filter_not_rejects_multi_condition() -> None:
+    import pytest
+
+    with pytest.raises(ValueError, match="NOT must wrap exactly one"):
+        _MOD._translate_haystack_filter({
+            "operator": "NOT",
+            "conditions": [
+                {"field": "meta.x", "operator": "==", "value": 1},
+                {"field": "meta.y", "operator": "==", "value": 2},
+            ],
+        })
+
+
+def test_translate_filter_unknown_operator_raises() -> None:
+    import pytest
+
+    with pytest.raises(NotImplementedError, match="Unsupported Haystack filter operator"):
+        _MOD._translate_haystack_filter(
+            {"field": "meta.x", "operator": "regex", "value": ".*"}
+        )
+
+
+def test_translate_filter_non_dict_raises() -> None:
+    import pytest
+
+    with pytest.raises(ValueError, match="must be a dict"):
+        _MOD._translate_haystack_filter("not a dict")  # type: ignore[arg-type]
+
+
+def test_translate_filter_logical_empty_conditions_raises() -> None:
+    import pytest
+
+    with pytest.raises(ValueError, match="non-empty 'conditions'"):
+        _MOD._translate_haystack_filter({"operator": "AND", "conditions": []})
+
+
+def test_translate_filter_comparison_missing_field_raises() -> None:
+    import pytest
+
+    with pytest.raises(ValueError, match="non-empty 'field'"):
+        _MOD._translate_haystack_filter({"operator": "==", "value": 1})
+
+
+def test_filter_documents_translates_haystack_filter_to_veles_shape() -> None:
+    """End-to-end: filter_documents accepts a Haystack-shaped filter and
+    forwards a VelesDB-shaped filter to Collection.scroll(...).
+    """
+    captured: dict = {}
+
+    class _CapturingCollection(_FakeCollection):
+        def scroll(  # pylint: disable=redefined-builtin
+            self,
+            *,
+            batch_size: int = 100,
+            filter: Any = None,
+            as_dataframe: bool = False,
+            backend: str = "pandas",
+        ) -> Any:
+            captured["filter"] = filter
+            return super().scroll(
+                batch_size=batch_size,
+                filter=filter,
+                as_dataframe=as_dataframe,
+                backend=backend,
+            )
+
+    class _CapturingDatabase:
+        def __init__(self, path: str) -> None:
+            self._col = _CapturingCollection()
+
+        def get_collection(self, name: str) -> _CapturingCollection:
+            return self._col
+
+        def create_collection(
+            self, name: str, dimension: int, metric: str
+        ) -> _CapturingCollection:
+            return self._col
+
+    original_velesdb = _MOD.velesdb
+    try:
+        _MOD.velesdb = types.SimpleNamespace(Database=_CapturingDatabase)  # type: ignore
+        store = _MOD.VelesDBDocumentStore(path="/tmp/hs", collection_name="t_translate")
+        store.write_documents([
+            Document(id="x", content="hello", embedding=[0.1], meta={"source": "wiki"})
+        ])
+        store.filter_documents(
+            {"field": "meta.source", "operator": "==", "value": "wiki"}
+        )
+        assert captured["filter"] == {
+            "type": "eq",
+            "field": "source",
+            "value": "wiki",
+        }, "Haystack filter must be translated to VelesDB shape before scroll"
+    finally:
+        _MOD.velesdb = original_velesdb
+
+
+def test_embedding_retrieval_translates_haystack_filter_to_veles_shape() -> None:
+    """End-to-end: embedding_retrieval accepts a Haystack-shaped filter and
+    forwards a VelesDB-shaped filter to Collection.search(...).
+    """
+    captured: dict = {}
+
+    class _CapturingCollection(_FakeCollection):
+        def search(  # pylint: disable=redefined-builtin
+            self, vector: list, top_k: int = 10, filter: Any = None
+        ) -> list:
+            captured["filter"] = filter
+            return super().search(vector=vector, top_k=top_k, filter=filter)
+
+    class _CapturingDatabase:
+        def __init__(self, path: str) -> None:
+            self._col = _CapturingCollection()
+
+        def get_collection(self, name: str) -> _CapturingCollection:
+            return self._col
+
+        def create_collection(
+            self, name: str, dimension: int, metric: str
+        ) -> _CapturingCollection:
+            return self._col
+
+    original_velesdb = _MOD.velesdb
+    try:
+        _MOD.velesdb = types.SimpleNamespace(Database=_CapturingDatabase)  # type: ignore
+        store = _MOD.VelesDBDocumentStore(path="/tmp/hs", collection_name="t_search_translate")
+        store.write_documents([
+            Document(id="y", content="world", embedding=[0.5])
+        ])
+        store.embedding_retrieval(
+            [0.5],
+            filters={
+                "operator": "AND",
+                "conditions": [
+                    {"field": "meta.lang", "operator": "==", "value": "en"},
+                    {"field": "meta.score", "operator": ">", "value": 0.5},
+                ],
+            },
+        )
+        assert captured["filter"] == {
+            "type": "and",
+            "conditions": [
+                {"type": "eq", "field": "lang", "value": "en"},
+                {"type": "gt", "field": "score", "value": 0.5},
+            ],
+        }, "embedding_retrieval must translate Haystack filter to VelesDB shape"
     finally:
         _MOD.velesdb = original_velesdb

--- a/integrations/haystack/tests/test_real_haystack_integration.py
+++ b/integrations/haystack/tests/test_real_haystack_integration.py
@@ -33,34 +33,53 @@ import pytest
 # ---------------------------------------------------------------------------
 
 
-def _haystack_is_real() -> bool:
-    """Return True only when the genuine ``haystack-ai`` package is installed.
+def _purge_stub(name: str) -> None:
+    """Remove any stub of *name* (and its sub-modules) from ``sys.modules``.
 
-    Removes any pre-existing stub from ``sys.modules`` so a fresh import
-    actually resolves the installed distribution. If the real package is
-    found, ``haystack.components`` (which the stub never defines) imports
-    cleanly.
+    The unit-test file (``test_document_store.py``) injects lightweight
+    stubs such as ``SimpleNamespace(Database=_FakeDatabase)`` into
+    ``sys.modules`` so the offline suite runs without the heavy real
+    distributions. Those stubs lack a real ``__file__`` (and often
+    ``__spec__``) and would mask any genuine install when both files
+    are collected in the same pytest session.
     """
-    for stub_name in [
-        n for n in list(sys.modules) if n == "haystack" or n.startswith("haystack.")
+    for mod_name in [
+        m for m in list(sys.modules)
+        if m == name or m.startswith(f"{name}.")
     ]:
-        # Only purge entries that lack a real ``__file__`` — those are stubs.
-        if getattr(sys.modules[stub_name], "__file__", None) is None:
-            del sys.modules[stub_name]
+        if getattr(sys.modules[mod_name], "__file__", None) is None:
+            del sys.modules[mod_name]
+
+
+def _is_real_install(name: str, *, probe_submodule: str | None = None) -> bool:
+    """Return True only when *name* resolves to a genuine installed package.
+
+    Detects stubs (no ``__file__``) and missing installs robustly:
+    any stub is purged from ``sys.modules`` before the probe so the
+    decision is made against the real environment, never against the
+    leaked test stub. ``probe_submodule`` lets callers force resolution
+    of a sub-package the stub never defines (e.g. ``haystack.components``).
+    """
+    _purge_stub(name)
     try:
-        importlib.import_module("haystack.components")
+        importlib.import_module(name)
     except ImportError:
         return False
+    if probe_submodule:
+        try:
+            importlib.import_module(f"{name}.{probe_submodule}")
+        except ImportError:
+            return False
     return True
 
 
-if not _haystack_is_real():
+if not _is_real_install("haystack", probe_submodule="components"):
     pytest.skip(
         "haystack-ai not installed; install with `pip install haystack-ai` "
         "to exercise the real integration tests",
         allow_module_level=True,
     )
-if importlib.util.find_spec("velesdb") is None:
+if not _is_real_install("velesdb"):
     pytest.skip(
         "velesdb wheel not installed; required for real integration tests",
         allow_module_level=True,

--- a/integrations/haystack/tests/test_real_haystack_integration.py
+++ b/integrations/haystack/tests/test_real_haystack_integration.py
@@ -1,0 +1,240 @@
+"""End-to-end smoke test against a real ``haystack-ai`` install.
+
+The unit tests in ``test_document_store.py`` use stubs to keep the suite
+lightweight. Stubs cannot catch protocol drift between this integration
+and the actual Haystack 2.x runtime — e.g., a missing ``@component``
+decorator, a renamed pipeline socket, or a filter format change. This
+file fills that gap.
+
+The whole module is skipped when ``haystack`` (or any of its required
+sub-packages) cannot be imported, so the suite still runs locally without
+the heavy ``haystack-ai`` install. CI installs ``haystack-ai`` in a
+dedicated job and exercises this file end-to-end.
+
+Each test creates its own ``VelesDBDocumentStore`` against a tmp dir, so
+the suite is self-contained and parallelizable.
+"""
+from __future__ import annotations
+
+import importlib
+import sys
+from typing import List
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Skip the whole file unless the *real* haystack-ai package is installed.
+#
+# The unit-test file (test_document_store.py) injects lightweight stubs into
+# sys.modules under the names 'haystack', 'haystack.dataclasses', etc.
+# Those stubs are sufficient for the unit suite but obviously cannot stand
+# in for haystack-ai here. Detect a stub vs a real install by looking for
+# the 'haystack.components' subpackage, which the stub never provides.
+# ---------------------------------------------------------------------------
+
+
+def _haystack_is_real() -> bool:
+    """Return True only when the genuine ``haystack-ai`` package is installed.
+
+    Removes any pre-existing stub from ``sys.modules`` so a fresh import
+    actually resolves the installed distribution. If the real package is
+    found, ``haystack.components`` (which the stub never defines) imports
+    cleanly.
+    """
+    for stub_name in [
+        n for n in list(sys.modules) if n == "haystack" or n.startswith("haystack.")
+    ]:
+        # Only purge entries that lack a real ``__file__`` — those are stubs.
+        if getattr(sys.modules[stub_name], "__file__", None) is None:
+            del sys.modules[stub_name]
+    try:
+        importlib.import_module("haystack.components")
+    except ImportError:
+        return False
+    return True
+
+
+if not _haystack_is_real():
+    pytest.skip(
+        "haystack-ai not installed; install with `pip install haystack-ai` "
+        "to exercise the real integration tests",
+        allow_module_level=True,
+    )
+if importlib.util.find_spec("velesdb") is None:
+    pytest.skip(
+        "velesdb wheel not installed; required for real integration tests",
+        allow_module_level=True,
+    )
+
+from haystack import Pipeline, component  # noqa: E402
+from haystack.dataclasses import Document  # noqa: E402
+from haystack.document_stores.types import DuplicatePolicy  # noqa: E402
+
+from haystack_velesdb import VelesDBDocumentStore  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _store(tmp_path) -> VelesDBDocumentStore:
+    """Build a small-dimension store against a unique tmp directory."""
+    return VelesDBDocumentStore(
+        path=str(tmp_path / "real_haystack"),
+        collection_name="real_test",
+        embedding_dim=4,
+        metric="cosine",
+    )
+
+
+def _docs() -> List[Document]:
+    return [
+        Document(
+            id="doc-en-1",
+            content="VelesDB is a local-first vector database.",
+            embedding=[1.0, 0.0, 0.0, 0.0],
+            meta={"lang": "en", "score": 0.9},
+        ),
+        Document(
+            id="doc-en-2",
+            content="Microsecond retrieval latency via HNSW.",
+            embedding=[0.9, 0.1, 0.0, 0.0],
+            meta={"lang": "en", "score": 0.7},
+        ),
+        Document(
+            id="doc-fr-1",
+            content="Base de donnees vectorielle locale.",
+            embedding=[0.0, 1.0, 0.0, 0.0],
+            meta={"lang": "fr", "score": 0.8},
+        ),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Protocol & lifecycle
+# ---------------------------------------------------------------------------
+
+
+def test_protocol_methods_exist() -> None:
+    """The class advertises every method Haystack 2.x's DocumentStore expects."""
+    for method in (
+        "count_documents",
+        "filter_documents",
+        "write_documents",
+        "delete_documents",
+        "embedding_retrieval",
+        "to_dict",
+        "from_dict",
+    ):
+        assert hasattr(VelesDBDocumentStore, method), f"missing protocol method: {method}"
+
+
+def test_round_trip_with_real_haystack_documents(tmp_path) -> None:
+    """Real haystack.Document objects round-trip through write/read/delete."""
+    store = _store(tmp_path)
+    written = store.write_documents(_docs())
+    assert written == 3
+    assert store.count_documents() == 3
+
+    all_docs = store.filter_documents()
+    assert {d.id for d in all_docs} == {"doc-en-1", "doc-en-2", "doc-fr-1"}
+
+    store.delete_documents(["doc-fr-1"])
+    assert store.count_documents() == 2
+
+
+def test_haystack_filter_round_trip_via_real_velesdb(tmp_path) -> None:
+    """A standard Haystack filter (operator/field/value) reaches a real VelesDB
+    collection through the translator and returns matching documents.
+    """
+    store = _store(tmp_path)
+    store.write_documents(_docs())
+    en_only = store.filter_documents(
+        {"field": "meta.lang", "operator": "==", "value": "en"}
+    )
+    assert {d.id for d in en_only} == {"doc-en-1", "doc-en-2"}
+
+
+def test_haystack_filter_logical_and_via_real_velesdb(tmp_path) -> None:
+    """A composite Haystack AND filter narrows results correctly."""
+    store = _store(tmp_path)
+    store.write_documents(_docs())
+    high_en = store.filter_documents({
+        "operator": "AND",
+        "conditions": [
+            {"field": "meta.lang", "operator": "==", "value": "en"},
+            {"field": "meta.score", "operator": ">", "value": 0.8},
+        ],
+    })
+    assert {d.id for d in high_en} == {"doc-en-1"}
+
+
+def test_embedding_retrieval_with_filter_via_real_velesdb(tmp_path) -> None:
+    """embedding_retrieval respects a Haystack filter against the real backend."""
+    store = _store(tmp_path)
+    store.write_documents(_docs())
+    results = store.embedding_retrieval(
+        query_embedding=[1.0, 0.0, 0.0, 0.0],
+        top_k=10,
+        filters={"field": "meta.lang", "operator": "==", "value": "fr"},
+    )
+    assert {d.id for d in results} == {"doc-fr-1"}
+
+
+def test_duplicate_policy_skip_with_real_haystack(tmp_path) -> None:
+    """SKIP must leave existing docs alone (regression for v1.14.2 fix)."""
+    store = _store(tmp_path)
+    store.write_documents([Document(
+        id="dup", content="original", embedding=[0.1, 0.2, 0.3, 0.4]
+    )])
+    written = store.write_documents(
+        [Document(id="dup", content="REPLACED", embedding=[0.5, 0.5, 0.5, 0.5])],
+        policy=DuplicatePolicy.SKIP,
+    )
+    assert written == 0
+    assert store.filter_documents()[0].content == "original"
+
+
+# ---------------------------------------------------------------------------
+# Pipeline integration — exercises the @component decorator on VelesRetriever
+# ---------------------------------------------------------------------------
+
+
+@component
+class VelesRetriever:
+    """Mirror of the canonical pattern from the README. The decorator is
+    REQUIRED — without it, ``Pipeline.add_component`` raises.
+    """
+
+    def __init__(self, document_store: VelesDBDocumentStore, top_k: int = 5) -> None:
+        self._store = document_store
+        self._top_k = top_k
+
+    @component.output_types(documents=List[Document])
+    def run(self, query_embedding: List[float]) -> dict:
+        return {
+            "documents": self._store.embedding_retrieval(
+                query_embedding, top_k=self._top_k
+            )
+        }
+
+
+def test_pipeline_with_decorated_retriever(tmp_path) -> None:
+    """A real Haystack Pipeline accepts the decorated VelesRetriever and runs.
+
+    Without the @component decorator, ``add_component`` raises
+    ``PipelineError`` — this test would fail at construction. Acts as
+    the canary for the rag_pipeline.py example fix.
+    """
+    store = _store(tmp_path)
+    store.write_documents(_docs())
+
+    pipeline = Pipeline()
+    pipeline.add_component("retriever", VelesRetriever(store, top_k=2))
+
+    result = pipeline.run({"retriever": {"query_embedding": [1.0, 0.0, 0.0, 0.0]}})
+    docs = result["retriever"]["documents"]
+    assert len(docs) == 2
+    # Top result should be the closest English doc to the query vector.
+    assert docs[0].id == "doc-en-1"

--- a/integrations/haystack/tests/test_real_haystack_integration.py
+++ b/integrations/haystack/tests/test_real_haystack_integration.py
@@ -85,6 +85,13 @@ if not _is_real_install("velesdb"):
         allow_module_level=True,
     )
 
+# The unit-test file also injects a stub ``haystack_velesdb`` package into
+# ``sys.modules`` so its hand-loaded module can resolve sibling imports.
+# Purge that stub here so the real editable install resolves the imports
+# below (the ``from haystack_velesdb import VelesDBDocumentStore`` line
+# would otherwise see the stub package which has no such attribute).
+_purge_stub("haystack_velesdb")
+
 from haystack import Pipeline, component  # noqa: E402
 from haystack.dataclasses import Document  # noqa: E402
 from haystack.document_stores.types import DuplicatePolicy  # noqa: E402

--- a/integrations/haystack/tests/test_real_haystack_integration.py
+++ b/integrations/haystack/tests/test_real_haystack_integration.py
@@ -34,14 +34,14 @@ import pytest
 
 
 def _purge_stub(name: str) -> None:
-    """Remove any stub of *name* (and its sub-modules) from ``sys.modules``.
+    """Remove any *stub* of ``name`` (and sub-modules) from ``sys.modules``.
 
     The unit-test file (``test_document_store.py``) injects lightweight
     stubs such as ``SimpleNamespace(Database=_FakeDatabase)`` into
-    ``sys.modules`` so the offline suite runs without the heavy real
+    ``sys.modules`` so its offline suite runs without the heavy real
     distributions. Those stubs lack a real ``__file__`` (and often
-    ``__spec__``) and would mask any genuine install when both files
-    are collected in the same pytest session.
+    ``__spec__``); identify them by that absence so the real package
+    underneath (if installed) is preserved.
     """
     for mod_name in [
         m for m in list(sys.modules)
@@ -49,6 +49,27 @@ def _purge_stub(name: str) -> None:
     ]:
         if getattr(sys.modules[mod_name], "__file__", None) is None:
             del sys.modules[mod_name]
+
+
+def _purge_module_tree(name: str) -> None:
+    """Unconditionally remove ``name`` and every sub-module from
+    ``sys.modules``, regardless of ``__file__`` presence.
+
+    Used to force a complete re-import of a package whose internal
+    ``import x`` references may have been bound to a stub at the
+    original load time. The stub-loaded ``haystack_velesdb.document_store``
+    is a real-file module (so ``_purge_stub`` would skip it), but its
+    module-level ``import velesdb`` was resolved against the test stub
+    of velesdb, freezing that reference in the module object. The only
+    way to re-bind ``velesdb`` to the real wheel is to drop the entire
+    ``haystack_velesdb`` tree and let the real ``__init__.py`` reload it
+    against the now-real ``sys.modules['velesdb']``.
+    """
+    for mod_name in [
+        m for m in list(sys.modules)
+        if m == name or m.startswith(f"{name}.")
+    ]:
+        del sys.modules[mod_name]
 
 
 def _is_real_install(name: str, *, probe_submodule: str | None = None) -> bool:
@@ -85,12 +106,13 @@ if not _is_real_install("velesdb"):
         allow_module_level=True,
     )
 
-# The unit-test file also injects a stub ``haystack_velesdb`` package into
-# ``sys.modules`` so its hand-loaded module can resolve sibling imports.
-# Purge that stub here so the real editable install resolves the imports
-# below (the ``from haystack_velesdb import VelesDBDocumentStore`` line
-# would otherwise see the stub package which has no such attribute).
-_purge_stub("haystack_velesdb")
+# Force a full re-import of haystack_velesdb so document_store.py's
+# module-level ``import velesdb`` re-resolves against the *real* velesdb
+# now in sys.modules. ``_purge_stub`` is not enough here: the stub-loaded
+# document_store is a real-file module (has __file__) and would survive
+# stub-purging, even though its velesdb reference was frozen against the
+# test stub at original load time.
+_purge_module_tree("haystack_velesdb")
 
 from haystack import Pipeline, component  # noqa: E402
 from haystack.dataclasses import Document  # noqa: E402


### PR DESCRIPTION
## Summary

Audit of the Haystack integration (post v1.14.2 doc-alignment) found **two runtime user-blocking bugs** that the existing 20-test unit suite couldn't catch because every test stubbed Haystack itself. This PR closes them, adds 18 unit tests for the new behaviour, ships a real-haystack integration suite, and wires the CI safeguards so the same gap class cannot recur.

## Bugs fixed

### Bug 1 — `examples/rag_pipeline.py:_VelesRetriever` was missing `@component`

Without the `@component` decorator, Haystack 2.x's `Pipeline.add_component()` rejects the class with `PipelineError: ... is not a Haystack component`. Every user following the example hit a wall before reaching their first search. The README ships the **correct** snippet (lines 84-92) — only the example file was broken since the integration was first written.

**Fix** (commit 1, `ae8494d6`):
- Add `@component` class decorator + `@component.output_types(documents=List[Document])` on `run()`
- Rename `_VelesRetriever` → `VelesRetriever` to match the README's public exemplar
- Promote the class above its callsite for top-down readability

### Bug 2 — `filter_documents()` and `embedding_retrieval()` did not translate Haystack filters to VelesDB shape

The Haystack 2.x filter dict (`{"operator": "AND", "conditions": [{"field": "meta.x", "operator": "==", "value": v}]}`) is **completely incompatible** with VelesDB's native shape (`{"type": "and", "conditions": [{"type": "eq", "field": "x", "value": v}]}`). The original code passed the dict straight through — with real VelesDB, this either errored or returned empty silently. The stub-based unit tests did not catch it (the fake `scroll()` ignored the filter argument).

**Fix** (commit 2, `d667bcda`):
- New private `_translate_haystack_filter()` — pure, recursive on AND/OR/NOT trees, strips `meta.` prefix.
- Operator mapping: `==/!=/>/>=/</<= → eq/neq/gt/gte/lt/lte`, `in → in`, `not in → not(in(...))`, `AND/OR/NOT → and/or/not`.
- Unsupported operators raise `NotImplementedError` with the supported list.
- Malformed filters (non-dict, missing field/conditions, scalar `in` value, multi-condition `NOT`) raise `ValueError` with explicit messages.
- Wired into both `filter_documents()` and `embedding_retrieval()`.
- **+18 new tests** (16 pure-translator + 2 end-to-end forwarding via capturing fakes).

## CI safeguards (so this gap class can't recur)

**Commit 3 (`76e0670e`) — real haystack-ai integration suite**: new `tests/test_real_haystack_integration.py` exercises every protocol method, real `Document` round-trip, filter translator end-to-end against a real `velesdb.Database`, the v1.14.2 SKIP regression, and a real `Pipeline` + decorated `VelesRetriever`. Auto-skips when `haystack-ai` is not installed (uses a stub-detection helper that purges any leftover stub from `sys.modules` before probing `haystack.components`, the sub-package the test stub never defines).

**Commit 4 (`949a3b01`) — three CI extensions** (`.github/workflows/propagation-guard.yml`):
1. `Python Integrations Check` now runs the Haystack stub suite (38 tests) + AST-validates every `*Retriever` class in `rag_pipeline.py` carries `@component` (exact static check that would have caught Bug 1 at PR time).
2. New `Haystack Real Integration` job: `pip install velesdb>=1.14.0 haystack-ai>=2.0.0 -e integrations/haystack[dev]` → runs the real integration suite. Triggers on the existing `integrations/**` paths filter.
3. `Demos and Examples Smoke` extended with `py_compile integrations/haystack/examples/rag_pipeline.py`.

## Verification

```
$ cd integrations/haystack && pytest tests/ -v
38 passed, 1 skipped in 0.05s
   (1 skipped = test_real_haystack_integration auto-skips locally; runs in CI's
    new haystack-real-integration job)

$ python scripts/check-version-sync.py
All versions match.

$ python -c "import yaml; yaml.safe_load(open('.github/workflows/propagation-guard.yml'))"
(YAML parses)

$ python -m py_compile integrations/haystack/examples/rag_pipeline.py
(no error)

$ python <ast-check>
OK: every *Retriever class in rag_pipeline.py is @component-decorated
```

## Test plan

- [x] 38/38 unit tests pass (was 20, +18 translator tests + 1 updated existing)
- [x] Real-integration file auto-skips locally (no haystack-ai installed)
- [x] AST check catches missing `@component` (verified by removing decorator → fails)
- [x] YAML workflow parses
- [x] Example compiles
- [x] No version-sync drift
- [x] Devin/Codacy expected to pass — pure additive code + tests, no production-path complexity changes beyond the translator (one new function with cyclomatic complexity ~7)

## Files changed

```
.github/workflows/propagation-guard.yml                     | +60
integrations/haystack/examples/rag_pipeline.py              | +27 -14
integrations/haystack/src/haystack_velesdb/document_store.py| +145 -7
integrations/haystack/tests/test_document_store.py          | +311 -2
integrations/haystack/tests/test_real_haystack_integration.py| +240 (new)
```

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cyberlife-coder/velesdb/pull/731" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
