### PR TITLE
test(safety): strengthen 67 test-fixture unwraps with diagnostic expect on 4 user-facing crates

### DIFF
--- a/crates/velesdb-mobile/src/agent.rs
+++ b/crates/velesdb-mobile/src/agent.rs
@@ -151,32 +151,35 @@ mod tests {
     use tempfile::TempDir;
 
     fn create_test_db() -> (TempDir, std::sync::Arc<VelesDatabase>) {
-        let dir = TempDir::new().unwrap();
-        let db = VelesDatabase::open(dir.path().to_string_lossy().to_string()).unwrap();
+        let dir = TempDir::new().expect("test: create temp dir");
+        let db = VelesDatabase::open(dir.path().to_string_lossy().to_string())
+            .expect("test: open database");
         (dir, db)
     }
 
     #[test]
     fn test_semantic_memory_new() {
         let (_dir, db) = create_test_db();
-        let memory = VelesSemanticMemory::new(&db, 4).unwrap();
+        let memory = VelesSemanticMemory::new(&db, 4).expect("test: construct semantic memory");
         assert_eq!(memory.dimension(), 4);
-        assert!(memory.is_empty().unwrap());
+        assert!(memory.is_empty().expect("test: is_empty on fresh memory"));
     }
 
     #[test]
     fn test_semantic_memory_store_and_query() {
         let (_dir, db) = create_test_db();
-        let memory = VelesSemanticMemory::new(&db, 4).unwrap();
+        let memory = VelesSemanticMemory::new(&db, 4).expect("test: construct semantic memory");
 
         memory
             .store(1, "Test content".to_string(), vec![0.1, 0.2, 0.3, 0.4])
-            .unwrap();
+            .expect("test: store knowledge fact");
 
-        assert_eq!(memory.len().unwrap(), 1);
-        assert!(!memory.is_empty().unwrap());
+        assert_eq!(memory.len().expect("test: read len"), 1);
+        assert!(!memory.is_empty().expect("test: is_empty after store"));
 
-        let results = memory.query(vec![0.1, 0.2, 0.3, 0.4], 5).unwrap();
+        let results = memory
+            .query(vec![0.1, 0.2, 0.3, 0.4], 5)
+            .expect("test: query semantic memory");
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].id, 1);
         assert_eq!(results[0].content, "Test content");
@@ -185,15 +188,15 @@ mod tests {
     #[test]
     fn test_semantic_memory_remove() {
         let (_dir, db) = create_test_db();
-        let memory = VelesSemanticMemory::new(&db, 4).unwrap();
+        let memory = VelesSemanticMemory::new(&db, 4).expect("test: construct semantic memory");
 
         memory
             .store(1, "Content".to_string(), vec![0.1, 0.2, 0.3, 0.4])
-            .unwrap();
-        assert_eq!(memory.len().unwrap(), 1);
+            .expect("test: store knowledge fact");
+        assert_eq!(memory.len().expect("test: read len"), 1);
 
-        let removed = memory.remove(1).unwrap();
+        let removed = memory.remove(1).expect("test: remove knowledge fact");
         assert!(removed);
-        assert!(memory.is_empty().unwrap());
+        assert!(memory.is_empty().expect("test: is_empty after remove"));
     }
 }

--- a/crates/velesdb-python/src/utils.rs
+++ b/crates/velesdb-python/src/utils.rs
@@ -232,7 +232,10 @@ mod tests {
         pyo3::prepare_freethreaded_python();
         Python::with_gil(|py| {
             let list = vec![1.0_f32, f32::NAN, 3.0];
-            let obj: PyObject = list.into_pyobject(py).unwrap().into();
+            let obj: PyObject = list
+                .into_pyobject(py)
+                .expect("test: convert Vec<f32> to Python list")
+                .into();
             let err = extract_vector(py, &obj).unwrap_err();
             assert!(err.to_string().contains("non-finite"));
         });
@@ -243,11 +246,12 @@ mod tests {
         pyo3::prepare_freethreaded_python();
         Python::with_gil(|_py| {
             assert!(matches!(
-                parse_metric("cosine").unwrap(),
+                parse_metric("cosine").expect("test: 'cosine' is a valid metric"),
                 DistanceMetric::Cosine
             ));
             assert!(matches!(
-                parse_metric("COSINE").unwrap(),
+                parse_metric("COSINE")
+                    .expect("test: 'COSINE' is a valid metric (case-insensitive)"),
                 DistanceMetric::Cosine
             ));
         });
@@ -258,11 +262,11 @@ mod tests {
         pyo3::prepare_freethreaded_python();
         Python::with_gil(|_py| {
             assert!(matches!(
-                parse_metric("euclidean").unwrap(),
+                parse_metric("euclidean").expect("test: 'euclidean' is a valid metric"),
                 DistanceMetric::Euclidean
             ));
             assert!(matches!(
-                parse_metric("l2").unwrap(),
+                parse_metric("l2").expect("test: 'l2' is an alias for euclidean"),
                 DistanceMetric::Euclidean
             ));
         });
@@ -273,15 +277,15 @@ mod tests {
         pyo3::prepare_freethreaded_python();
         Python::with_gil(|_py| {
             assert!(matches!(
-                parse_metric("dot").unwrap(),
+                parse_metric("dot").expect("test: 'dot' is a valid metric"),
                 DistanceMetric::DotProduct
             ));
             assert!(matches!(
-                parse_metric("dotproduct").unwrap(),
+                parse_metric("dotproduct").expect("test: 'dotproduct' is an alias for dot"),
                 DistanceMetric::DotProduct
             ));
             assert!(matches!(
-                parse_metric("ip").unwrap(),
+                parse_metric("ip").expect("test: 'ip' (inner product) is an alias for dot"),
                 DistanceMetric::DotProduct
             ));
         });
@@ -292,7 +296,7 @@ mod tests {
         pyo3::prepare_freethreaded_python();
         Python::with_gil(|_py| {
             assert!(matches!(
-                parse_metric("hamming").unwrap(),
+                parse_metric("hamming").expect("test: 'hamming' is a valid metric"),
                 DistanceMetric::Hamming
             ));
         });
@@ -303,7 +307,7 @@ mod tests {
         pyo3::prepare_freethreaded_python();
         Python::with_gil(|_py| {
             assert!(matches!(
-                parse_metric("jaccard").unwrap(),
+                parse_metric("jaccard").expect("test: 'jaccard' is a valid metric"),
                 DistanceMetric::Jaccard
             ));
         });
@@ -322,11 +326,11 @@ mod tests {
         pyo3::prepare_freethreaded_python();
         Python::with_gil(|_py| {
             assert!(matches!(
-                parse_storage_mode("full").unwrap(),
+                parse_storage_mode("full").expect("test: 'full' is a valid storage mode"),
                 StorageMode::Full
             ));
             assert!(matches!(
-                parse_storage_mode("f32").unwrap(),
+                parse_storage_mode("f32").expect("test: 'f32' is an alias for full"),
                 StorageMode::Full
             ));
         });
@@ -337,11 +341,11 @@ mod tests {
         pyo3::prepare_freethreaded_python();
         Python::with_gil(|_py| {
             assert!(matches!(
-                parse_storage_mode("sq8").unwrap(),
+                parse_storage_mode("sq8").expect("test: 'sq8' is a valid storage mode"),
                 StorageMode::SQ8
             ));
             assert!(matches!(
-                parse_storage_mode("int8").unwrap(),
+                parse_storage_mode("int8").expect("test: 'int8' is an alias for sq8"),
                 StorageMode::SQ8
             ));
         });
@@ -352,11 +356,11 @@ mod tests {
         pyo3::prepare_freethreaded_python();
         Python::with_gil(|_py| {
             assert!(matches!(
-                parse_storage_mode("binary").unwrap(),
+                parse_storage_mode("binary").expect("test: 'binary' is a valid storage mode"),
                 StorageMode::Binary
             ));
             assert!(matches!(
-                parse_storage_mode("bit").unwrap(),
+                parse_storage_mode("bit").expect("test: 'bit' is an alias for binary"),
                 StorageMode::Binary
             ));
         });
@@ -367,16 +371,17 @@ mod tests {
         pyo3::prepare_freethreaded_python();
         Python::with_gil(|_py| {
             assert!(matches!(
-                parse_storage_mode("pq").unwrap(),
+                parse_storage_mode("pq").expect("test: 'pq' is a valid storage mode"),
                 StorageMode::ProductQuantization
             ));
             assert!(matches!(
-                parse_storage_mode("product_quantization").unwrap(),
+                parse_storage_mode("product_quantization")
+                    .expect("test: 'product_quantization' is an alias for pq"),
                 StorageMode::ProductQuantization
             ));
             // Case-insensitive (delegates to core `StorageMode::from_str`).
             assert!(matches!(
-                parse_storage_mode("PQ").unwrap(),
+                parse_storage_mode("PQ").expect("test: 'PQ' is case-insensitive alias for pq"),
                 StorageMode::ProductQuantization
             ));
         });
@@ -387,16 +392,18 @@ mod tests {
         pyo3::prepare_freethreaded_python();
         Python::with_gil(|_py| {
             assert!(matches!(
-                parse_storage_mode("rabitq").unwrap(),
+                parse_storage_mode("rabitq").expect("test: 'rabitq' is a valid storage mode"),
                 StorageMode::RaBitQ
             ));
             // Case-insensitive (delegates to core `StorageMode::from_str`).
             assert!(matches!(
-                parse_storage_mode("RaBitQ").unwrap(),
+                parse_storage_mode("RaBitQ")
+                    .expect("test: 'RaBitQ' is case-insensitive alias for rabitq"),
                 StorageMode::RaBitQ
             ));
             assert!(matches!(
-                parse_storage_mode("RABITQ").unwrap(),
+                parse_storage_mode("RABITQ")
+                    .expect("test: 'RABITQ' is case-insensitive alias for rabitq"),
                 StorageMode::RaBitQ
             ));
         });

--- a/crates/velesdb-server/src/config.rs
+++ b/crates/velesdb-server/src/config.rs
@@ -441,7 +441,8 @@ api_keys = ["key-alpha", "key-beta"]
 cert = "/etc/ssl/cert.pem"
 key = "/etc/ssl/key.pem"
 "#;
-        let file_cfg: FileConfig = toml::from_str(toml_content).unwrap();
+        let file_cfg: FileConfig =
+            toml::from_str(toml_content).expect("test: valid FileConfig TOML");
         let cli = CliOverrides::default();
         let cfg = ServerConfig::merge(ServerConfig::default(), file_cfg, cli);
 
@@ -463,7 +464,8 @@ key = "/etc/ssl/key.pem"
 host = "0.0.0.0"
 port = 9090
 "#;
-        let file_cfg: FileConfig = toml::from_str(toml_content).unwrap();
+        let file_cfg: FileConfig =
+            toml::from_str(toml_content).expect("test: valid FileConfig TOML");
         let cli = CliOverrides {
             port: Some(3000),
             host: Some("10.0.0.1".to_string()),
@@ -484,7 +486,8 @@ port = 9090
 [server]
 port = 4000
 "#;
-        let file_cfg: FileConfig = toml::from_str(toml_content).unwrap();
+        let file_cfg: FileConfig =
+            toml::from_str(toml_content).expect("test: valid FileConfig TOML");
         let cli = CliOverrides::default();
         let cfg = ServerConfig::merge(ServerConfig::default(), file_cfg, cli);
 
@@ -495,7 +498,7 @@ port = 4000
 
     #[test]
     fn test_empty_toml_uses_all_defaults() {
-        let file_cfg: FileConfig = toml::from_str("").unwrap();
+        let file_cfg: FileConfig = toml::from_str("").expect("test: empty TOML parses to default");
         let cli = CliOverrides::default();
         let cfg = ServerConfig::merge(ServerConfig::default(), file_cfg, cli);
 
@@ -555,17 +558,17 @@ port = 4000
 
     #[test]
     fn test_validate_tls_valid_files() {
-        let dir = tempfile::tempdir().unwrap();
+        let dir = tempfile::tempdir().expect("test: create temp dir");
         let cert_path = dir.path().join("cert.pem");
         let key_path = dir.path().join("key.pem");
         std::fs::File::create(&cert_path)
-            .unwrap()
+            .expect("test: create cert file")
             .write_all(b"cert")
-            .unwrap();
+            .expect("test: write cert content");
         std::fs::File::create(&key_path)
-            .unwrap()
+            .expect("test: create key file")
             .write_all(b"key")
-            .unwrap();
+            .expect("test: write key content");
 
         let cfg = ServerConfig {
             tls_cert: Some(cert_path.to_string_lossy().to_string()),
@@ -613,7 +616,8 @@ port = 9090
 host = "0.0.0.0"
 data_dir = "/toml/data"
 "#;
-        let file_cfg: FileConfig = toml::from_str(toml_content).unwrap();
+        let file_cfg: FileConfig =
+            toml::from_str(toml_content).expect("test: valid FileConfig TOML");
         let cli = CliOverrides {
             port: Some(3000),
             // host not set in CLI → TOML should win
@@ -632,7 +636,8 @@ data_dir = "/toml/data"
 [server]
 rate_limit = 50
 "#;
-        let file_cfg: FileConfig = toml::from_str(toml_content).unwrap();
+        let file_cfg: FileConfig =
+            toml::from_str(toml_content).expect("test: valid FileConfig TOML");
         let cli = CliOverrides::default();
         let cfg = ServerConfig::merge(ServerConfig::default(), file_cfg, cli);
 
@@ -646,7 +651,8 @@ rate_limit = 50
 [server]
 rate_limit = 0
 "#;
-        let file_cfg: FileConfig = toml::from_str(toml_content).unwrap();
+        let file_cfg: FileConfig =
+            toml::from_str(toml_content).expect("test: valid FileConfig TOML");
         let cli = CliOverrides::default();
         let cfg = ServerConfig::merge(ServerConfig::default(), file_cfg, cli);
 
@@ -660,7 +666,8 @@ rate_limit = 0
 [server]
 rate_limit = 50
 "#;
-        let file_cfg: FileConfig = toml::from_str(toml_content).unwrap();
+        let file_cfg: FileConfig =
+            toml::from_str(toml_content).expect("test: valid FileConfig TOML");
         let cli = CliOverrides {
             rate_limit: Some(200),
             ..Default::default()
@@ -720,7 +727,8 @@ allowed_headers = ["Content-Type", "Authorization"]
 allow_credentials = true
 max_age_secs = 7200
 "#;
-        let file_cfg: FileConfig = toml::from_str(toml_content).unwrap();
+        let file_cfg: FileConfig =
+            toml::from_str(toml_content).expect("test: valid FileConfig TOML");
         let cli = CliOverrides::default();
         let cfg = ServerConfig::merge(ServerConfig::default(), file_cfg, cli);
 
@@ -744,7 +752,8 @@ max_age_secs = 7200
 [cors]
 allowed_origins = ["https://myapp.com"]
 "#;
-        let file_cfg: FileConfig = toml::from_str(toml_content).unwrap();
+        let file_cfg: FileConfig =
+            toml::from_str(toml_content).expect("test: valid FileConfig TOML");
         let cli = CliOverrides::default();
         let cfg = ServerConfig::merge(ServerConfig::default(), file_cfg, cli);
 
@@ -763,7 +772,8 @@ allowed_origins = ["https://myapp.com"]
 [server]
 port = 9090
 "#;
-        let file_cfg: FileConfig = toml::from_str(toml_content).unwrap();
+        let file_cfg: FileConfig =
+            toml::from_str(toml_content).expect("test: valid FileConfig TOML");
         let cli = CliOverrides::default();
         let cfg = ServerConfig::merge(ServerConfig::default(), file_cfg, cli);
 
@@ -776,7 +786,8 @@ port = 9090
         let toml_content = r#"
 [cors]
 "#;
-        let file_cfg: FileConfig = toml::from_str(toml_content).unwrap();
+        let file_cfg: FileConfig =
+            toml::from_str(toml_content).expect("test: valid FileConfig TOML");
         let cli = CliOverrides::default();
         let cfg = ServerConfig::merge(ServerConfig::default(), file_cfg, cli);
 

--- a/crates/velesdb-server/src/lib.rs
+++ b/crates/velesdb-server/src/lib.rs
@@ -356,9 +356,9 @@ mod tests {
         // Write to docs/ relative to workspace root
         let docs_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
             .parent()
-            .unwrap()
+            .expect("test: CARGO_MANIFEST_DIR has a parent (crates/)")
             .parent()
-            .unwrap()
+            .expect("test: crates/ has a parent (workspace root)")
             .join("docs");
         std::fs::create_dir_all(&docs_dir).expect("Failed to create docs dir");
 
@@ -457,35 +457,40 @@ mod tests {
     #[test]
     fn test_create_collection_request_default_metric() {
         let json = r#"{"name": "test", "dimension": 128}"#;
-        let req: CreateCollectionRequest = serde_json::from_str(json).unwrap();
+        let req: CreateCollectionRequest =
+            serde_json::from_str(json).expect("test: valid CreateCollectionRequest JSON");
         assert_eq!(req.metric, "cosine");
     }
 
     #[test]
     fn test_create_collection_request_with_hamming() {
         let json = r#"{"name": "test", "dimension": 128, "metric": "hamming"}"#;
-        let req: CreateCollectionRequest = serde_json::from_str(json).unwrap();
+        let req: CreateCollectionRequest =
+            serde_json::from_str(json).expect("test: valid CreateCollectionRequest JSON");
         assert_eq!(req.metric, "hamming");
     }
 
     #[test]
     fn test_create_collection_request_with_jaccard() {
         let json = r#"{"name": "test", "dimension": 128, "metric": "jaccard"}"#;
-        let req: CreateCollectionRequest = serde_json::from_str(json).unwrap();
+        let req: CreateCollectionRequest =
+            serde_json::from_str(json).expect("test: valid CreateCollectionRequest JSON");
         assert_eq!(req.metric, "jaccard");
     }
 
     #[test]
     fn test_create_collection_request_with_storage_mode() {
         let json = r#"{"name": "test", "dimension": 128, "storage_mode": "sq8"}"#;
-        let req: CreateCollectionRequest = serde_json::from_str(json).unwrap();
+        let req: CreateCollectionRequest =
+            serde_json::from_str(json).expect("test: valid CreateCollectionRequest JSON");
         assert_eq!(req.storage_mode, "sq8");
     }
 
     #[test]
     fn test_search_request_deserialize() {
         let json = r#"{"vector": [0.1, 0.2, 0.3], "top_k": 5}"#;
-        let req: SearchRequest = serde_json::from_str(json).unwrap();
+        let req: SearchRequest =
+            serde_json::from_str(json).expect("test: valid SearchRequest JSON");
         assert_eq!(req.vector, vec![0.1, 0.2, 0.3]);
         assert_eq!(req.top_k, 5);
     }
@@ -493,7 +498,8 @@ mod tests {
     #[test]
     fn test_batch_search_request_deserialize() {
         let json = r#"{"searches": [{"vector": [0.1, 0.2], "top_k": 3}]}"#;
-        let req: BatchSearchRequest = serde_json::from_str(json).unwrap();
+        let req: BatchSearchRequest =
+            serde_json::from_str(json).expect("test: valid BatchSearchRequest JSON");
         assert_eq!(req.searches.len(), 1);
         assert_eq!(req.searches[0].top_k, 3);
     }
@@ -501,7 +507,8 @@ mod tests {
     #[test]
     fn test_text_search_request_deserialize() {
         let json = r#"{"query": "machine learning", "top_k": 10}"#;
-        let req: TextSearchRequest = serde_json::from_str(json).unwrap();
+        let req: TextSearchRequest =
+            serde_json::from_str(json).expect("test: valid TextSearchRequest JSON");
         assert_eq!(req.query, "machine learning");
         assert_eq!(req.top_k, 10);
     }
@@ -509,7 +516,8 @@ mod tests {
     #[test]
     fn test_hybrid_search_request_deserialize() {
         let json = r#"{"vector": [0.1, 0.2], "query": "test", "top_k": 5}"#;
-        let req: HybridSearchRequest = serde_json::from_str(json).unwrap();
+        let req: HybridSearchRequest =
+            serde_json::from_str(json).expect("test: valid HybridSearchRequest JSON");
         assert_eq!(req.vector, vec![0.1, 0.2]);
         assert_eq!(req.query, "test");
         assert_eq!(req.top_k, 5);
@@ -518,7 +526,8 @@ mod tests {
     #[test]
     fn test_upsert_points_request_deserialize() {
         let json = r#"{"points": [{"id": 1, "vector": [0.1, 0.2]}]}"#;
-        let req: UpsertPointsRequest = serde_json::from_str(json).unwrap();
+        let req: UpsertPointsRequest =
+            serde_json::from_str(json).expect("test: valid UpsertPointsRequest JSON");
         assert_eq!(req.points.len(), 1);
         assert_eq!(req.points[0].id, 1);
     }
@@ -532,7 +541,7 @@ mod tests {
             storage_mode: "full".to_string(),
             point_count: 100,
         };
-        let json = serde_json::to_string(&resp).unwrap();
+        let json = serde_json::to_string(&resp).expect("test: serialize CollectionResponse");
         assert!(json.contains("\"name\":\"test\""));
         assert!(json.contains("\"dimension\":128"));
         assert!(json.contains("\"metric\":\"cosine\""));
@@ -549,7 +558,7 @@ mod tests {
                 payload: None,
             }],
         };
-        let json = serde_json::to_string(&resp).unwrap();
+        let json = serde_json::to_string(&resp).expect("test: serialize SearchResponse");
         assert!(json.contains("\"results\""));
         // IDs are serialized as strings to prevent JavaScript precision loss (WP-0D).
         assert!(json.contains("\"id\":\"1\""));
@@ -561,7 +570,7 @@ mod tests {
             error: "Test error".to_string(),
             code: None,
         };
-        let json = serde_json::to_string(&resp).unwrap();
+        let json = serde_json::to_string(&resp).expect("test: serialize ErrorResponse");
         assert!(json.contains("\"error\":\"Test error\""));
         // code: None is omitted from JSON output
         assert!(!json.contains("\"code\""));


### PR DESCRIPTION
## Summary

Replaces 67 `.unwrap()` calls with `.expect("test: <reason>")` across 4 user-facing crates (server/lib, server/config, python/utils, mobile/agent).

**Important factual correction**: All 67 unwraps were inside `#[cfg(test)] mod tests` blocks. Per `.claude/rules/rust-safety.md`, `.unwrap()` is **explicitly acceptable in test code**. This change therefore:

- ✅ **Strengthens diagnostic signal** on fixture regressions (better failure messages).
- ❌ **Does NOT reduce production unwrap debt** — the original pre-seed audit (P1 #4) cited "unwrap debt on 4 user-facing files" without distinguishing test vs production scope.

## Production unwrap debt — actual state

The real production unwrap count workspace-wide is ~333 calls, concentrated in:

| File | Production unwraps |
|---|---|
| `crates/velesdb-core/src/collection/graph_collection.rs` | 23 |
| `crates/velesdb-wasm/src/velesql.rs` | 20 |
| `crates/velesdb-core/src/velesql/parser/helpers.rs` | 17 |
| `crates/velesdb-core/src/collection/search/query/projection.rs` | 15 |
| `crates/velesdb-core/src/collection/core/statistics.rs` | 15 |
| `crates/velesdb-python/src/graph.rs` | 14 |
| ... (rest distributed across other modules) | |

A follow-up issue/PR is needed to scope and address those — explicitly **out of scope** for v1.14.4.

## Per-file change

| File | Before | After | Strategy |
|---|---|---|---|
| `crates/velesdb-server/src/lib.rs` | 14 | 0 | `expect("test: <reason>")` |
| `crates/velesdb-server/src/config.rs` | 17 | 0 | `expect("test: ...")` (toml/tempfile fixtures) |
| `crates/velesdb-python/src/utils.rs` | 22 | 0 | `expect("test: ...")` (parse_metric/parse_storage_mode) |
| `crates/velesdb-mobile/src/agent.rs` | 14 | 0 | `expect("test: ...")` (TempDir/Database fixtures) |

No production code modified, no public API change, no signature widening.

## Validation

- `cargo fmt --all` clean
- `cargo clippy -p velesdb-server -p velesdb-python -p velesdb-mobile --features persistence --tests -- -D warnings -D clippy::pedantic` clean
- `cargo test --workspace --features persistence --exclude velesdb-python -- --test-threads=1`: **all pass** (velesdb-core 4739 + server 136 + mobile 93)
- Recall gate: 4 mode contract tests pass (perfect=100%, accurate≥99%, balanced≥95%, fast≥90%)
- Codacy CLI: no new finding, no new CC>8

## Test plan

- [x] grep `\.unwrap()` returns 0 on all 4 files
- [x] Full velesdb-core/server/mobile test suite green
- [x] Recall gate ≥ 0.95 (4 mode tests)
- [x] No production code modified — only test fixtures touched

Part of v1.14.4 pre-seed audit hygiene patch (Fix 3 of 7) — with honest factual correction of the audit's premise.