### PR TITLE
ci(release): add macOS Intel (x86_64) wheel via macos-13 runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -303,6 +303,7 @@ jobs:
           - { os: ubuntu-latest, target: x86_64, manylinux: auto }
           - { os: ubuntu-latest, target: aarch64, manylinux: auto }
           - { os: macos-14, target: aarch64 }
+          - { os: macos-13, target: x86_64 }
           - { os: windows-latest, target: x64 }
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0


### PR DESCRIPTION
## Summary

Adds the missing macos-13 / x86_64 entry to the `publish-pypi-wheels` matrix in `release.yml`.

**Before**: 4 wheels (linux x86_64, linux aarch64, macos arm64, windows x64).
**After**: 5 wheels (+ macos x86_64 via macos-13 runner).

## Why

Discovered during the v1.14.4 pre-seed audit (2026-05-01): the matrix produced no Intel-Mac wheel, leaving Intel Mac users to fall back on source builds (build-from-source = friction for end-users on a 30-second pitch).

## Diff

`.github/workflows/release.yml` line 305 — single additive entry:

```yaml
          - { os: macos-13, target: x86_64 }
```

## Validation

- Cannot validate runtime before tag — macos-13 wheel only builds on real release run.
- **Validation deferred to next release (v1.14.4)**: `pypi.org/pypi/velesdb/1.14.4/json` must list `macosx_*_x86_64.whl` alongside the existing 4 wheels.
- macos-13 runner remains available on GHA until mid-2026 — if retired, fallback path is self-hosted runner or rollback this fix.

## Test plan

- [x] YAML structurally valid (1 line additive, identical schema to existing entries)
- [ ] Runtime validation deferred to next release run

Part of v1.14.4 pre-seed audit hygiene patch (Fix 4 of 7).