### PR TITLE
docs: document velesdb-migrate (12k LOC, 9 connectors) rework decision in v1.15.0

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -42,6 +42,7 @@ By v1.15 we want a single sentence pitch: *"VelesDB is the only embedded vector 
 | 2 | [SDK parity: TypeScript/LangChain/LlamaIndex (#380)](https://github.com/cyberlife-coder/VelesDB/issues/380) | Close the cross-language gap so any framework user gets the same API surface |
 | 3 | **Reproducible head-to-head benchmark vs Qdrant + Chroma + pgvector** (Docker Compose) | Pre-seed audit P0: turn marketing claims into proven numbers |
 | 4 | **External `unsafe` audit** (SIMD module, Cure53 / independent Rust safety expert) | Required for "data sovereignty" enterprise positioning |
+| 5 | **`velesdb-migrate` rework decision** (12,108 LOC, 9 connectors) | Workspace inflation without measured user base — decide keep / extract / archive based on crates.io download counts, GitHub stars attributable to migration tooling, opened issues count. See `docs/reference/KNOWN_LIMITATIONS.md` § 4 |
 
 These items need budget commitment (audit ~5-15k€) and are conditional on funding closing.
 

--- a/docs/reference/KNOWN_LIMITATIONS.md
+++ b/docs/reference/KNOWN_LIMITATIONS.md
@@ -53,6 +53,26 @@ When no calibrated `CollectionStats` is available (collection never analyzed, SD
 
 ---
 
+## Workspace scope
+
+### 4. `velesdb-migrate` (12,108 LOC, 9 connectors) — to be reworked
+
+**Status**: open, scheduled for rework decision in v1.15.0. Source: `crates/velesdb-migrate/` (workspace member).
+
+The `velesdb-migrate` sub-crate ships a migration toolkit covering 9 source databases (Supabase, Qdrant, Pinecone, Weaviate, Milvus, ChromaDB, JSON/CSV, Elasticsearch, Redis). It is currently bundled in the workspace but is identified for **rework or extraction in a future release**: the current scope inflates the workspace surface (12k LOC, 9 third-party API surfaces) without a measured user base, and the connectors evolve at different cadences than the core engine.
+
+**Decision criteria for v1.15.0** (per ROADMAP.md Horizon 2):
+
+- crates.io download counts for `velesdb-migrate` over the last 90 days
+- GitHub stars / watchers attributable to migration tooling
+- Open issues count specifically scoped to migration connectors
+
+**User impact**: until the rework decision lands, the crate is maintained on a best-effort basis. Users depending on it should pin to the v1.14.x line. No migration tooling will be removed or moved during the v1.14.x line — this is purely a forward-looking transparency note.
+
+**Resolution path**: tracked for v1.15.0 evaluation; the candidate outcomes are (a) keep + invest, (b) extract to separate `velesdb-migrate` repository under the same org, or (c) archive with documented sunset window. The decision will be made in a separate planning issue once the criteria above are measurable.
+
+---
+
 ## Reading this document
 
 Each entry states:


### PR DESCRIPTION
## Summary

Adds transparency entry #4 to `KNOWN_LIMITATIONS.md` for the `velesdb-migrate` sub-crate (12,108 LOC, 9 connectors covering Supabase / Qdrant / Pinecone / Weaviate / Milvus / ChromaDB / JSON-CSV / Elasticsearch / Redis), and matching item #5 in `ROADMAP.md` Horizon 2.

## Why

Discovered during the v1.14.4 pre-seed audit (2026-05-01): the migration crate inflates the workspace surface (12k LOC + 9 third-party API surfaces) without a measured user base, and the connectors evolve at different cadences than the core engine.

Rather than silently keep maintaining it, this PR makes the situation explicit and schedules the decision for v1.15.0 with measurable criteria.

## Decision criteria for v1.15.0

- crates.io download counts for `velesdb-migrate` over the last 90 days
- GitHub stars / watchers attributable to migration tooling
- Open issues count specifically scoped to migration connectors

Candidate outcomes: (a) keep + invest, (b) extract to a separate `velesdb-migrate` repo under same org, or (c) archive with documented sunset window.

## User impact (v1.14.x line)

- **No behavior change in v1.14.4**: the crate continues to be maintained on a best-effort basis.
- Users currently depending on it should pin to the v1.14.x line.
- This PR is a forward-looking transparency note, **not** a removal or deprecation.

## Files

- `docs/reference/KNOWN_LIMITATIONS.md` — new section "Workspace scope" with entry #4.
- `ROADMAP.md` — new row in Horizon 2 table (item #5).

## Test plan

- [x] `python scripts/check-version-sync.py` passes (37 OK)
- [x] No code change — pure documentation
- [x] No promise-contract claim affected

Part of v1.14.4 pre-seed audit hygiene patch (Fix 5 of 7).