### PR TITLE
docs(ts-sdk): add Supported Node.js versions table + WASM init fix note

### DIFF
--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -82,6 +82,16 @@ Official TypeScript SDK for [VelesDB](https://github.com/cyberlife-coder/VelesDB
 npm install @wiscale/velesdb-sdk
 ```
 
+### Supported Node.js versions
+
+| Node.js | TS SDK | Browser (WASM) | Notes |
+|---------|--------|----------------|-------|
+| 18 LTS  | ✅      | ✅              | minimum supported |
+| 20 LTS  | ✅ (CI) | ✅              | tested matrix on every PR |
+| 22 LTS  | ✅      | ✅              | latest LTS |
+
+The Node.js WASM `init()` path was fixed in v1.13.7 to read `velesdb_wasm_bg.wasm` bytes from disk via `fs.readFile` instead of the broken `fetch('file://')` URL — Node ≥ 18 now works out-of-the-box. Browsers were never affected.
+
 ## Quick Start
 
 ### WASM Backend (Browser / Node.js)


### PR DESCRIPTION
## Summary

Adds a Node.js compatibility table (18/20/22 LTS) to `sdks/typescript/README.md`, right after the Installation section. Mirrors the Python integration support matrices added in PRs #730 and #734.

Also captures the v1.13.7 Node.js WASM init fix as an explicit user-facing note so users land on the working code path.

## Why

Discovered during the v1.14.4 pre-seed audit (2026-05-01): the TS SDK README declared `Node.js >= 18` in the title bar but had no detailed support matrix, leaving users (and reviewers) without a clear answer to *"which Node versions are actually CI-tested?"*.

## Diff

`sdks/typescript/README.md` — single hunk, +10 lines after the `## Installation` block:

| Node.js | TS SDK | Browser (WASM) | Notes |
|---------|--------|----------------|-------|
| 18 LTS  | ✅      | ✅              | minimum supported |
| 20 LTS  | ✅ (CI) | ✅              | tested matrix on every PR |
| 22 LTS  | ✅      | ✅              | latest LTS |

Plus a 1-paragraph mention of the v1.13.7 Node WASM init fix.

## Test plan

- [x] `python scripts/check-version-sync.py` passes (37 OK)
- [x] No code change — pure documentation
- [x] Aligns with the Python integration support matrices recently added

Part of v1.14.4 pre-seed audit hygiene patch (Fix 6 of 7).