### PR TITLE
fix(release): paginate REL-06 check-runs query to find CI Success on dense commits

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,8 +80,9 @@ jobs:
           SHA="${{ github.sha }}"
           echo "Checking CI status for commit $SHA..."
 
-          # Query check runs for this commit
-          RESULT=$(gh api "repos/${{ github.repository }}/commits/$SHA/check-runs" \
+          # Query check runs for this commit (paginated: a release-track commit can carry 30+ check-runs,
+          # so the default 30/page can omit "CI Success" and silently fail REL-06).
+          RESULT=$(gh api "repos/${{ github.repository }}/commits/$SHA/check-runs?per_page=100" --paginate \
             --jq '[.check_runs[] | select(.name == "CI Success")] | first')
 
           if [ -z "$RESULT" ] || [ "$RESULT" = "null" ]; then


### PR DESCRIPTION
## Summary

The Validate job's REL-06 guard in `release.yml` queries the GitHub check-runs API to find `CI Success` on the tagged commit. Without pagination, default page size is **30** — but a release-track commit on `main` carries **32-36 check-runs** (CI workflow + Promise Contract + Doc Contract + Propagation Guard + Compatibility Matrix + Scalability Benchmark + Release workflow, each with multiple jobs).

Result: `CI Success` was randomly omitted from page 1 depending on GitHub's job ordering, and Validate failed with `No CI workflow found` even when CI Success was actually `completed:success` on the commit.

## Symptom

Encountered on v1.14.4 tag push (2026-05-01):

- Tag `v1.14.4` pushed at SHA `a453ec2c`
- CI workflow on `a453ec2c`: 11 jobs, all completed, `CI Success: success`
- **36 check-runs total** on the SHA (verified via `per_page=100` query)
- Release workflow REL-06: failed **4x consecutively** with same `No CI workflow found` error
- Manual `--paginate` query found `CI Success` immediately

## Fix

`.github/workflows/release.yml` line 84:

```diff
-          RESULT=$(gh api "repos/${{ github.repository }}/commits/$SHA/check-runs" \
+          RESULT=$(gh api "repos/${{ github.repository }}/commits/$SHA/check-runs?per_page=100" --paginate \
             --jq '[.check_runs[] | select(.name == "CI Success")] | first')
```

Future-proofs as the workspace keeps growing parallel CI workflows. No behavior change when fewer than 100 check-runs exist — `gh api --paginate` is a no-op on a single page.

## Recovery path for v1.14.4 release

After this hotfix lands on main:

1. Delete tag `v1.14.4` (no publication has succeeded yet — all jobs skipped behind Validate)
2. Re-create tag `v1.14.4` on new main HEAD (post-fix)
3. Push tag → triggers fresh Release workflow run with paginated query

## Test plan

- [x] Bash command equivalent locally produces correct CI Success match
- [ ] Validate job in next workflow run finds CI Success without `--paginate` only on small commit counts (< 30 check-runs); with this fix, works regardless of count