### PR TITLE
ci(release): remove macos-13 (Intel x86_64) entry from publish-pypi-wheels matrix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -304,7 +304,10 @@ jobs:
           - { os: ubuntu-latest, target: x86_64, manylinux: auto }
           - { os: ubuntu-latest, target: aarch64, manylinux: auto }
           - { os: macos-14, target: aarch64 }
-          - { os: macos-13, target: x86_64 }
+          # NOTE: macos-13 (x86_64) removed in v1.14.5 — GHA macos-13 runner availability
+          # is unreliable (one v1.14.4 release attempt stayed queued >9h). Intel Mac users
+          # should use the macos-14 (aarch64) wheel via Rosetta 2, or build from source.
+          # Re-add when self-hosted macos-13 runner is provisioned. See KNOWN_LIMITATIONS.md § 5.
           - { os: windows-latest, target: x64 }
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0

--- a/docs/reference/KNOWN_LIMITATIONS.md
+++ b/docs/reference/KNOWN_LIMITATIONS.md
@@ -71,6 +71,26 @@ The `velesdb-migrate` sub-crate ships a migration toolkit covering 9 source data
 
 **Resolution path**: tracked for v1.15.0 evaluation; the candidate outcomes are (a) keep + invest, (b) extract to separate `velesdb-migrate` repository under the same org, or (c) archive with documented sunset window. The decision will be made in a separate planning issue once the criteria above are measurable.
 
+### 5. No macOS Intel (x86_64) wheel on PyPI
+
+**Status**: open, no ETA. Source: `.github/workflows/release.yml` `publish-pypi-wheels` matrix.
+
+The `macos-13` (Intel x86_64) entry was added briefly in v1.14.4 (PR #738) but the GitHub-hosted `macos-13` runner availability proved unreliable: one v1.14.4 publish attempt left the wheel-build job queued for over 9 hours without a runner being assigned, blocking the rest of the release pipeline. The entry was removed in v1.14.5 to keep the release pipeline reliable.
+
+**User impact**: Intel Mac users have three options.
+
+1. **Recommended**: install via the macOS aarch64 wheel under Rosetta 2 — `arch -arm64 pip install velesdb`. Performance is within ~3-5% of native on Intel Macs running macOS 12+ with Rosetta 2.
+2. **Build from source**: `cargo install velesdb-cli` (or `pip install velesdb --no-binary :all:` with a working Rust toolchain) produces a native x86_64 binary.
+3. Use the Linux x86_64 wheel inside Docker / Lima / Multipass.
+
+**Resolution path**: tracked for v1.15.0+. Candidate outcomes:
+
+- (a) Provision a self-hosted `macos-13` runner via a paid CI provider with reliable Intel-Mac capacity.
+- (b) Wait for GitHub-hosted `macos-13` queue times to stabilize and re-add the matrix entry.
+- (c) Drop x86_64 macOS wheel support officially — Apple stopped shipping new Intel Macs in 2023, and Rosetta 2 covers existing devices.
+
+A measurable decision will be made when one of: download counts on `manylinux2014_x86_64.whl` from macOS user-agents drops below 5%/month, OR a self-hosted runner is funded.
+
 ---
 
 ## Reading this document


### PR DESCRIPTION
## Summary

Reverts the `macos-13` entry added in v1.14.4 ([#738](https://github.com/cyberlife-coder/VelesDB/pull/738)). GitHub-hosted `macos-13` runner availability is unreliable: the v1.14.4 release left the wheel-build job ([74006970645](https://github.com/cyberlife-coder/VelesDB/actions/runs/25237142960/job/74006970645)) queued for **over 9 hours** without a runner pickup, ultimately forcing a cancellation. We have no self-hosted runner, so we cannot reliably build & publish this wheel without external infra investment.

## Why this is the right call

Apple stopped shipping new Intel Macs in 2023. Rosetta 2 covers existing Intel Mac devices well — running the `macos-14 (aarch64)` wheel under Rosetta 2 is within ~3-5% of native on macOS 12+. Forcing a release-pipeline coupling to a flaky runner queue cost us ~9h of release latency on v1.14.4 for a wheel that nobody had downloaded yet.

## Diff

- `.github/workflows/release.yml`: matrix entry `{ os: macos-13, target: x86_64 }` removed; replaced with a comment + reference to `KNOWN_LIMITATIONS.md § 5`.
- `docs/reference/KNOWN_LIMITATIONS.md`: new entry **§ 5 "No macOS Intel (x86_64) wheel on PyPI"** documenting:
  - Impact (3 paths for Intel Mac users)
  - Resolution path (self-hosted runner vs GH-hosted stability vs deprecate)
  - Decision criteria for v1.15.0+

## Reversibility

This change is fully reversible: re-add the matrix entry in a single 1-line PR if/when (a) a self-hosted `macos-13` runner is provisioned, OR (b) GHA queue times stabilize, OR (c) Intel Mac usage drops below 5%/month and we deprecate officially.

## Validation

- `python scripts/check-version-sync.py` → 37 OK, all versions match
- No code change, no schema change
- Future v1.14.5+ release runs will have 4 PyPI wheels (linux x86_64 + linux aarch64 + macos arm64 + windows x64)

## Test plan

- [x] release.yml YAML structurally valid (1 entry removed + 1 comment block)
- [x] check-version-sync passes
- [x] KNOWN_LIMITATIONS § 5 accurate

Followup to v1.14.4 release ([#742](https://github.com/cyberlife-coder/VelesDB/pull/742)) and audit findings on macos-13 runner unreliability.