### PR TITLE
feat(python): SearchOptions builder — issue #717 v1.15 additive API

### DIFF
--- a/crates/velesdb-python/python/velesdb/__init__.py
+++ b/crates/velesdb-python/python/velesdb/__init__.py
@@ -30,6 +30,7 @@ from velesdb.velesdb import (  # type: ignore[attr-defined]
     GraphSchema as PyGraphSchema,
     PyProceduralMemory,
     PySemanticMemory,
+    SearchOptions,
     SearchResult,
     StreamingConfig,
     TraversalResult,
@@ -189,6 +190,19 @@ class Collection:
         if sparse_index_name is not None:
             kwargs["sparse_index_name"] = sparse_index_name
         return self._inner.search(**kwargs)
+
+    def search_request(self, opts: SearchOptions) -> list[dict[str, Any]]:
+        """Search using a :py:class:`SearchOptions` builder (v1.15+).
+
+        Preferred over :py:meth:`search` for new code.
+
+        Args:
+            opts: Populated :py:class:`SearchOptions` instance.
+
+        Returns:
+            List of dicts with ``id``, ``score``, and ``payload`` keys.
+        """
+        return self._inner.search_request(opts)
 
     def batch_search(
         self,

--- a/crates/velesdb-python/python/velesdb/__init__.pyi
+++ b/crates/velesdb-python/python/velesdb/__init__.pyi
@@ -114,6 +114,47 @@ class FusionStrategy:
         ...
 
 
+class SearchOptions:
+    """Options for a vector search request (v1.15+).
+
+    Use with :py:meth:`Collection.search_request` as the canonical replacement
+    for the deprecated multi-kwarg :py:meth:`Collection.search` signature.
+
+    All fields are keyword-only.  At least one of ``vector`` or
+    ``sparse_vector`` must be set before calling ``search_request``.
+
+    Attributes:
+        vector: Dense query vector (list or numpy array).
+        sparse_vector: Sparse query as dict[int, float] or scipy sparse.
+        top_k: Max results to return (default: 10).
+        filter: Metadata pre-filter dict.
+        sparse_index_name: Named sparse index to query.
+        include_vectors: Include raw vectors in results (default: False).
+
+    Example:
+        >>> opts = SearchOptions(vector=my_embedding, top_k=20, filter={"lang": "en"})
+        >>> results = collection.search_request(opts)
+    """
+
+    vector: Optional[Union[List[float], "np.ndarray"]]
+    sparse_vector: Optional[Dict[int, float]]
+    top_k: int
+    filter: Optional[Dict[str, Any]]
+    sparse_index_name: Optional[str]
+    include_vectors: bool
+
+    def __init__(
+        self,
+        vector: Optional[Union[List[float], "np.ndarray"]] = None,
+        *,
+        sparse_vector: Optional[Dict[int, float]] = None,
+        top_k: int = 10,
+        filter: Optional[Dict[str, Any]] = None,
+        sparse_index_name: Optional[str] = None,
+        include_vectors: bool = False,
+    ) -> None: ...
+
+
 class SearchResult:
     """A single search result from a vector search.
 
@@ -343,6 +384,10 @@ class Collection:
     ) -> List[Dict[str, Any]]:
         """Search for similar vectors (dense, sparse, or hybrid).
 
+        .. deprecated:: 1.15.0
+            Use :py:meth:`search_request` with a :py:class:`SearchOptions` object.
+            This method will be removed in v2.0.0.
+
         Modes:
         - Dense only: ``search(vector, top_k=10)``
         - Sparse only: ``search(sparse_vector={0: 1.5}, top_k=10)``
@@ -357,6 +402,24 @@ class Collection:
 
         Returns:
             List of dicts with id, score, and payload.
+        """
+        ...
+
+    def search_request(self, opts: "SearchOptions") -> List[Dict[str, Any]]:
+        """Search for similar vectors using a :py:class:`SearchOptions` builder (v1.15+).
+
+        Preferred over :py:meth:`search` for new code; avoids the long
+        parameter list warning and is the sole canonical entry point from v2.0.
+
+        Args:
+            opts: A populated :py:class:`SearchOptions` instance.
+
+        Returns:
+            List of dicts with ``id``, ``score``, and ``payload`` keys.
+
+        Example:
+            >>> opts = SearchOptions(vector=my_embedding, top_k=20)
+            >>> results = collection.search_request(opts)
         """
         ...
 

--- a/crates/velesdb-python/src/collection/mod.rs
+++ b/crates/velesdb-python/src/collection/mod.rs
@@ -16,6 +16,7 @@ mod mutation;
 pub(crate) mod query;
 pub(crate) mod scroll;
 mod search;
+pub mod search_options;
 
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyString};

--- a/crates/velesdb-python/src/collection/mod.rs
+++ b/crates/velesdb-python/src/collection/mod.rs
@@ -16,7 +16,7 @@ mod mutation;
 pub(crate) mod query;
 pub(crate) mod scroll;
 mod search;
-pub mod search_options;
+pub(crate) mod search_options;
 
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyString};

--- a/crates/velesdb-python/src/collection/search.rs
+++ b/crates/velesdb-python/src/collection/search.rs
@@ -2,7 +2,7 @@
 
 use std::collections::HashMap;
 
-use pyo3::exceptions::PyValueError;
+use pyo3::exceptions::{PyDeprecationWarning, PyValueError};
 use pyo3::prelude::*;
 use velesdb_core::FusionStrategy as CoreFusionStrategy;
 use velesdb_core::SearchResult;
@@ -67,17 +67,13 @@ impl Collection {
         sparse_index_name: Option<String>,
         include_vectors: bool,
     ) -> PyResult<Vec<PyObject>> {
-        // Emit DeprecationWarning: callers should migrate to search_request().
-        py.run(
-            pyo3::ffi::c_str!(
-                "import warnings; warnings.warn(\
-                'Collection.search() is deprecated since v1.15. \
-                Use Collection.search_request(SearchOptions(...)) instead. \
-                Will be removed in v2.0.', \
-                DeprecationWarning, stacklevel=2)"
-            ),
-            None,
-            None,
+        PyErr::warn(
+            py,
+            &py.get_type::<PyDeprecationWarning>(),
+            c"Collection.search() is deprecated since v1.15. \
+              Use Collection.search_request(SearchOptions(...)) instead. \
+              Will be removed in v2.0.",
+            2,
         )?;
 
         let opts = SearchOptions::new(

--- a/crates/velesdb-python/src/collection/search.rs
+++ b/crates/velesdb-python/src/collection/search.rs
@@ -14,6 +14,7 @@ use crate::collection_helpers::{
 use crate::utils::extract_vector;
 use crate::FusionStrategy;
 
+use super::search_options::SearchOptions;
 use super::Collection;
 
 /// Default fusion strategy when none is specified by the caller.
@@ -29,6 +30,10 @@ struct ParsedSearch {
 #[pymethods]
 impl Collection {
     /// Search for similar vectors (dense, sparse, or hybrid).
+    ///
+    /// .. deprecated:: 1.15.0
+    ///    Use :py:meth:`search_request` with a :py:class:`SearchOptions` object
+    ///    instead.  This method will be removed in v2.0.0.
     ///
     /// Supports three modes depending on which arguments are provided:
     /// - Dense only: `search(vector, top_k=10)` (backward compatible)
@@ -46,11 +51,10 @@ impl Collection {
     ///
     /// Returns:
     ///     List of dicts with id, score, and payload.
-    // Allowed: every parameter below is a Python keyword argument exposed via
-    // `#[pyo3(signature = ...)]`. PyO3 requires one positional Rust parameter
-    // per Python kwarg, so a `SearchOptions` struct would either break the
-    // public API or require a hand-written `FromPyObject` impl that adds more
-    // code than it saves. The signature is stable and documented.
+    // The too_many_arguments allow is preserved here because this legacy method
+    // retains its original 6-kwarg signature for backward compatibility until
+    // v2.0.  New callers should use search_request(SearchOptions) instead
+    // (issue #717 v1.15 path).
     #[allow(clippy::too_many_arguments)]
     #[pyo3(signature = (vector=None, *, sparse_vector=None, top_k=10, filter=None, sparse_index_name=None, include_vectors=false))]
     fn search(
@@ -63,13 +67,64 @@ impl Collection {
         sparse_index_name: Option<String>,
         include_vectors: bool,
     ) -> PyResult<Vec<PyObject>> {
+        // Emit DeprecationWarning: callers should migrate to search_request().
+        py.run(
+            pyo3::ffi::c_str!(
+                "import warnings; warnings.warn(\
+                'Collection.search() is deprecated since v1.15. \
+                Use Collection.search_request(SearchOptions(...)) instead. \
+                Will be removed in v2.0.', \
+                DeprecationWarning, stacklevel=2)"
+            ),
+            None,
+            None,
+        )?;
+
+        let opts = SearchOptions::new(
+            vector,
+            sparse_vector,
+            top_k,
+            filter,
+            sparse_index_name,
+            include_vectors,
+        );
+        self.search_request(py, &opts)
+    }
+
+    /// Search for similar vectors using a :py:class:`SearchOptions` builder.
+    ///
+    /// This is the v1.15+ canonical search entry point.  It accepts all search
+    /// parameters as a single ``SearchOptions`` object, eliminating the
+    /// ``too_many_arguments`` lint suppression required by the legacy
+    /// ``search()`` method (issue #717).
+    ///
+    /// Args:
+    ///     opts: A :py:class:`SearchOptions` instance with all search parameters.
+    ///
+    /// Returns:
+    ///     List of dicts with ``id``, ``score``, and ``payload`` keys.
+    ///
+    /// Example:
+    ///     >>> opts = SearchOptions(vector=my_emb, top_k=20, filter={"lang": "en"})
+    ///     >>> results = collection.search_request(opts)
+    #[pyo3(signature = (opts))]
+    fn search_request(&self, py: Python<'_>, opts: &SearchOptions) -> PyResult<Vec<PyObject>> {
         // Phase 1: Parse Python args (GIL held — required for PyObject access)
-        let dense = vector.as_ref().map(|v| extract_vector(py, v)).transpose()?;
-        let sparse = sparse_vector
+        let dense = opts
+            .vector
+            .as_ref()
+            .map(|v| extract_vector(py, v))
+            .transpose()?;
+        let sparse = opts
+            .sparse_vector
             .as_ref()
             .map(|sv| parse_sparse_vector(py, sv))
             .transpose()?;
-        let filter_obj = parse_optional_filter(py, filter)?;
+        let filter_obj = parse_optional_filter(py, opts.filter.as_ref().map(|f| f.clone_ref(py)))?;
+
+        let top_k = opts.top_k;
+        let sparse_index_name = opts.sparse_index_name.clone();
+        let include_vectors = opts.include_vectors;
 
         // Phase 2: Release GIL during Rust computation
         let results = py.allow_threads(|| {

--- a/crates/velesdb-python/src/collection/search_options.rs
+++ b/crates/velesdb-python/src/collection/search_options.rs
@@ -107,9 +107,7 @@ impl SearchOptions {
     fn __repr__(&self) -> String {
         format!(
             "SearchOptions(top_k={}, include_vectors={}, sparse_index_name={:?})",
-            self.top_k,
-            self.include_vectors,
-            self.sparse_index_name,
+            self.top_k, self.include_vectors, self.sparse_index_name,
         )
     }
 }

--- a/crates/velesdb-python/src/collection/search_options.rs
+++ b/crates/velesdb-python/src/collection/search_options.rs
@@ -1,0 +1,115 @@
+//! `SearchOptions` builder for Python — VelesDB v1.15 additive API.
+//!
+//! Resolves issue #717: replaces the 6-kwargs `search()` signature with a
+//! builder object that satisfies the project's `too_many_arguments` threshold
+//! (≤5 args) without breaking the existing `search()` public API.
+//!
+//! # Migration path
+//!
+//! v1.14 (current)
+//!   `collection.search(vector, top_k=10, filter={"k": "v"})`
+//!
+//! v1.15 (additive — no breaking change):
+//!   ```python
+//!   opts = SearchOptions(vector=embedding, top_k=10, filter={"k": "v"})
+//!   results = collection.search_request(opts)
+//!   ```
+//!
+//! v2.0 (breaking): `search()` kwargs path removed, `search_request()` is the
+//! single canonical entry point.
+
+use pyo3::prelude::*;
+
+/// Options for a vector search request.
+///
+/// Use as the argument to :py:meth:`Collection.search_request` (v1.15+).
+/// All fields are optional except that at least one of ``vector`` or
+/// ``sparse_vector`` must be set before calling ``search_request``.
+///
+/// Example:
+///     >>> from velesdb import SearchOptions
+///     >>> opts = SearchOptions(
+///     ...     vector=my_embedding,
+///     ...     top_k=20,
+///     ...     filter={"category": "news"},
+///     ... )
+///     >>> results = collection.search_request(opts)
+#[pyclass(module = "velesdb")]
+pub struct SearchOptions {
+    /// Dense query vector (list or numpy array). Optional when
+    /// ``sparse_vector`` is provided.
+    #[pyo3(get, set)]
+    pub vector: Option<PyObject>,
+    /// Sparse query as ``dict[int, float]`` or scipy sparse matrix.
+    /// Optional when ``vector`` is provided.
+    #[pyo3(get, set)]
+    pub sparse_vector: Option<PyObject>,
+    /// Number of results to return (default: 10).
+    #[pyo3(get, set)]
+    pub top_k: usize,
+    /// Optional metadata filter dict.
+    #[pyo3(get, set)]
+    pub filter: Option<PyObject>,
+    /// Named sparse index to query.  When ``None``, the default (unnamed)
+    /// sparse index is used.
+    #[pyo3(get, set)]
+    pub sparse_index_name: Option<String>,
+    /// When ``True`` the raw vector array is included in each result dict
+    /// under the key ``"vector"``.  Disabled by default to keep response
+    /// sizes small.
+    #[pyo3(get, set)]
+    pub include_vectors: bool,
+}
+
+#[pymethods]
+impl SearchOptions {
+    /// Create a new ``SearchOptions``.
+    ///
+    /// All arguments are keyword-only and optional at construction time;
+    /// provide them here or assign to the corresponding attributes before
+    /// passing to :py:meth:`Collection.search_request`.
+    ///
+    /// Args:
+    ///     vector: Dense query vector.
+    ///     sparse_vector: Sparse query (dict[int, float] or scipy sparse).
+    ///     top_k: Max results to return (default: 10).
+    ///     filter: Metadata pre-filter dict.
+    ///     sparse_index_name: Named sparse index to query.
+    ///     include_vectors: Include raw vectors in results (default: False).
+    #[new]
+    #[pyo3(signature = (
+        vector = None,
+        *,
+        sparse_vector = None,
+        top_k = 10,
+        filter = None,
+        sparse_index_name = None,
+        include_vectors = false,
+    ))]
+    pub fn new(
+        vector: Option<PyObject>,
+        sparse_vector: Option<PyObject>,
+        top_k: usize,
+        filter: Option<PyObject>,
+        sparse_index_name: Option<String>,
+        include_vectors: bool,
+    ) -> Self {
+        Self {
+            vector,
+            sparse_vector,
+            top_k,
+            filter,
+            sparse_index_name,
+            include_vectors,
+        }
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "SearchOptions(top_k={}, include_vectors={}, sparse_index_name={:?})",
+            self.top_k,
+            self.include_vectors,
+            self.sparse_index_name,
+        )
+    }
+}

--- a/crates/velesdb-python/src/lib.rs
+++ b/crates/velesdb-python/src/lib.rs
@@ -42,6 +42,7 @@ mod utils;
 mod velesql;
 mod velesql_helpers;
 
+pub use collection::search_options::SearchOptions;
 pub use collection::Collection;
 pub use database::Database;
 pub use fusion::FusionStrategy;
@@ -77,6 +78,9 @@ fn velesdb(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<Collection>()?;
     m.add_class::<SearchResult>()?;
     m.add_class::<FusionStrategy>()?;
+
+    // SearchOptions builder (issue #717 v1.15 additive path)
+    m.add_class::<SearchOptions>()?;
 
     // Scroll iterator (issue #429)
     m.add_class::<collection::scroll::ScrollIterator>()?;

--- a/crates/velesdb-python/tests/test_search_options.py
+++ b/crates/velesdb-python/tests/test_search_options.py
@@ -1,0 +1,129 @@
+"""Tests for SearchOptions builder (issue #717 — v1.15 additive path).
+
+Validates:
+  - SearchOptions construction (defaults, fields)
+  - search_request() produces same results as search()
+  - DeprecationWarning emitted by legacy search()
+  - __repr__ works
+
+Date: 2026-05-09
+"""
+
+import warnings
+
+import pytest
+
+from tests.conftest import _SKIP_NO_BINDINGS
+
+pytestmark = _SKIP_NO_BINDINGS
+
+try:
+    from velesdb import Database, SearchOptions
+
+    VELESDB_AVAILABLE = True
+except (ImportError, AttributeError):
+    VELESDB_AVAILABLE = False
+    SearchOptions = None  # type: ignore[assignment,misc]
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def collection(temp_db):
+    """4-dim cosine collection with 5 pre-inserted points."""
+    col = temp_db.create_collection("test_opts", dimension=4, metric="cosine")
+    points = [
+        {"id": i, "vector": [float(i) / 4, float(4 - i) / 4, 0.5, 0.1], "payload": {"idx": i}}
+        for i in range(5)
+    ]
+    col.upsert(points)
+    return col
+
+
+# ---------------------------------------------------------------------------
+# A. SearchOptions construction
+# ---------------------------------------------------------------------------
+
+
+def test_search_options_defaults():
+    opts = SearchOptions()
+    assert opts.top_k == 10
+    assert opts.vector is None
+    assert opts.sparse_vector is None
+    assert opts.filter is None
+    assert opts.sparse_index_name is None
+    assert opts.include_vectors is False
+
+
+def test_search_options_fields_set():
+    vec = [0.1, 0.2, 0.3, 0.4]
+    opts = SearchOptions(vector=vec, top_k=5, include_vectors=True)
+    assert opts.top_k == 5
+    assert opts.include_vectors is True
+    # vector is stored as a Python object; just confirm it's not None
+    assert opts.vector is not None
+
+
+def test_search_options_repr():
+    opts = SearchOptions(top_k=20, include_vectors=True, sparse_index_name="my_idx")
+    r = repr(opts)
+    assert "SearchOptions" in r
+    assert "20" in r
+    assert "my_idx" in r
+
+
+# ---------------------------------------------------------------------------
+# B. search_request() produces same results as search()
+# ---------------------------------------------------------------------------
+
+
+def test_search_request_matches_search(collection):
+    query = [0.5, 0.5, 0.5, 0.1]
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        legacy = collection.search(vector=query, top_k=3)
+
+    opts = SearchOptions(vector=query, top_k=3)
+    modern = collection.search_request(opts)
+
+    assert len(legacy) == len(modern)
+    for l, m in zip(legacy, modern):
+        assert l["id"] == m["id"]
+        assert abs(l["score"] - m["score"]) < 1e-5
+
+
+def test_search_request_with_filter(collection):
+    query = [0.5, 0.5, 0.5, 0.1]
+    opts = SearchOptions(vector=query, top_k=5, filter={"idx": 2})
+    results = collection.search_request(opts)
+    # Filter should restrict to the single point with idx=2
+    for r in results:
+        assert r["payload"]["idx"] == 2
+
+
+def test_search_request_top_k_respected(collection):
+    query = [0.5, 0.5, 0.5, 0.1]
+    opts = SearchOptions(vector=query, top_k=2)
+    results = collection.search_request(opts)
+    assert len(results) <= 2
+
+
+# ---------------------------------------------------------------------------
+# C. DeprecationWarning from legacy search()
+# ---------------------------------------------------------------------------
+
+
+def test_legacy_search_emits_deprecation_warning(collection):
+    query = [0.5, 0.5, 0.5, 0.1]
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        collection.search(vector=query, top_k=2)
+
+    deprecations = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+    assert deprecations, "Expected at least one DeprecationWarning from search()"
+    msg = str(deprecations[0].message)
+    assert "search_request" in msg or "deprecated" in msg.lower()


### PR DESCRIPTION
## Summary

Resolves #717 — replaces the 6-kwargs `search()` signature with a `SearchOptions` builder object, satisfying the `too_many_arguments` lint threshold (≤5 args) without a breaking change.

- **`SearchOptions` PyO3 `#[pyclass]`** (`search_options.rs`): 6 fields (`vector`, `sparse_vector`, `top_k`, `filter`, `sparse_index_name`, `include_vectors`), all gettable/settable. No `Clone`/`Default` derives — `PyObject` (`Py<PyAny>`) does not implement `Clone` in PyO3 0.24.2; cloning uses `.clone_ref(py)` inside `search_request`.
- **`Collection.search_request(opts)`** (`search.rs`): New method that accepts a `SearchOptions`. The legacy `search()` now delegates to it and emits a `DeprecationWarning`.
- **Python stubs** (`__init__.py`, `__init__.pyi`): `SearchOptions` exported, `search_request()` wired, `search()` marked deprecated.
- **Tests** (`test_search_options.py`): defaults, field mutation, result parity with `search()`, filter propagation, `top_k` limit, `DeprecationWarning`.

## Migration path

| Version | API |
|---------|-----|
| v1.14 (current) | `collection.search(vector, top_k=10, filter={"k": "v"})` |
| v1.15 (this PR, additive) | `opts = SearchOptions(vector=emb, top_k=10); collection.search_request(opts)` |
| v2.0 (future breaking) | `search()` kwargs path removed |

## Test plan

- [ ] `SearchOptions()` defaults: `top_k=10`, all others `None`/`False`
- [ ] `search_request(opts)` results match `search()` (id + score within 1e-5)
- [ ] `search()` emits `DeprecationWarning` containing `"search_request"` or `"deprecated"`
- [ ] `top_k` limit respected (`len(results) <= top_k`)
- [ ] Filter propagation: only matching payload returned
- [ ] `__repr__` includes `top_k`, `include_vectors`, `sparse_index_name`

> Supersedes PR #760 (same commits, branch renamed to `feat/` prefix to satisfy Git Flow CI).

_2026-05-09_

https://claude.ai/code/session_01EPGTXcdEyqkfBC9D2XyDef
