### PR TITLE
fix(#473): fix misleading LET test docstring and add mixed-select projection tests [superseded by #763]

### DIFF
--- a/crates/velesdb-core/src/collection/search/query/let_execution_tests.rs
+++ b/crates/velesdb-core/src/collection/search/query/let_execution_tests.rs
@@ -448,8 +448,8 @@ fn test_evaluate_let_bindings_empty() {
 // J. Issue #473: LET bindings appear in SELECT projection
 // ============================================================================
 
-/// `LET hybrid = 0.5 SELECT *, hybrid FROM col LIMIT 5`
-/// Each result must have a "hybrid" field with value 0.5.
+/// `LET hybrid = 0.5 SELECT * FROM docs WHERE vector NEAR $v LIMIT 5`
+/// Each result's payload must contain a "hybrid" field with value 0.5.
 #[test]
 fn test_let_binding_appears_in_select_projection() {
     let (_dir, col) = setup_let_collection();
@@ -470,6 +470,34 @@ fn test_let_binding_appears_in_select_projection() {
         let hybrid_val = payload.get("hybrid").expect("hybrid field should exist");
         let v = hybrid_val.as_f64().expect("hybrid should be a number");
         assert!((v - 0.5).abs() < 1e-5, "hybrid should be 0.5, got {v}");
+    }
+}
+
+/// Issue #473: `LET hybrid = 0.5 SELECT docs.*, hybrid FROM docs`
+/// Tests the qualified-wildcard mixed SELECT case — the LET binding must
+/// appear in results both via wildcard expansion (payload) and explicit column.
+#[test]
+fn test_let_binding_in_qualified_wildcard_mixed_select() {
+    let (_dir, col) = setup_let_collection();
+    let mut params = HashMap::new();
+    params.insert("v".to_string(), serde_json::json!([0.5, 0.5, 0.5, 0.3]));
+
+    let results = col
+        .execute_query_str(
+            "LET hybrid = 0.5 \
+             SELECT docs.*, hybrid FROM docs WHERE vector NEAR $v LIMIT 5",
+            &params,
+        )
+        .expect("LET qualified wildcard mixed SELECT query");
+
+    assert_eq!(results.len(), 5);
+    for r in &results {
+        let payload = r.point.payload.as_ref().expect("payload should exist");
+        let hybrid_val = payload.get("hybrid").expect("hybrid must appear in mixed SELECT");
+        let v = hybrid_val.as_f64().expect("hybrid should be f64");
+        assert!((v - 0.5).abs() < 1e-5, "hybrid should be 0.5, got {v}");
+        // Wildcard also expanded other payload fields.
+        assert!(payload.get("idx").is_some(), "idx (from wildcard) should be present");
     }
 }
 

--- a/crates/velesdb-core/src/collection/search/query/projection.rs
+++ b/crates/velesdb-core/src/collection/search/query/projection.rs
@@ -427,4 +427,39 @@ mod tests {
         let obj = projected.as_object().unwrap();
         assert!(obj["title"].is_null());
     }
+
+    /// Issue #473: LET-injected values in the payload are visible through
+    /// `SelectColumns::Mixed` qualified wildcard expansion.
+    ///
+    /// The execution pipeline injects LET binding values into `point.payload`
+    /// before calling `project_results`. This test verifies that those injected
+    /// keys survive the `project_mixed` path (wildcard expansion + named column).
+    #[test]
+    fn test_project_mixed_wildcard_exposes_let_injected_payload_field() {
+        // Simulate post-LET-injection payload: original fields plus "hybrid" injected
+        // by inject_let_into_payloads in select_dispatch.rs.
+        let result = make_result(
+            3,
+            0.88,
+            serde_json::json!({"title": "Doc", "idx": 7, "hybrid": 0.5}),
+        );
+        let columns = SelectColumns::Mixed {
+            // SELECT docs.*, hybrid — qualified wildcard + explicit named column
+            columns: vec![Column::new("hybrid")],
+            aggregations: vec![],
+            similarity_scores: vec![],
+            qualified_wildcards: vec!["docs".to_string()],
+            window_functions: vec![],
+        };
+        let projected = project_single(&result, &columns);
+        let obj = projected.as_object().unwrap();
+
+        // Wildcard expansion must include original payload fields.
+        assert_eq!(obj["id"], 3);
+        assert_eq!(obj["title"], "Doc");
+        assert_eq!(obj["idx"], 7);
+        // LET-injected value must appear: both via wildcard expansion and explicit column.
+        let hybrid = obj["hybrid"].as_f64().expect("hybrid should be f64");
+        assert!((hybrid - 0.5).abs() < 1e-5, "hybrid should be 0.5, got {hybrid}");
+    }
 }


### PR DESCRIPTION
## Summary

- **Docstring fix**: `test_let_binding_appears_in_select_projection` claimed to test `SELECT *, hybrid` but actually used `SELECT *` (`SelectColumns::All`). The VelesQL grammar only allows qualified wildcards (`alias.*`) in a mixed select list — bare `*` cannot be combined with named columns in a `select_item_list`.
- **New integration test** `test_let_binding_in_qualified_wildcard_mixed_select`: exercises the real qualified-wildcard mixed path (`SELECT docs.*, hybrid FROM docs WHERE vector NEAR $v LIMIT 5`) end-to-end through `inject_let_into_payloads` → `project_mixed`.
- **New unit test** `test_project_mixed_wildcard_exposes_let_injected_payload_field` in `projection.rs`: documents and locks the invariant that LET values injected into `point.payload` before `project_results()` are visible via qualified-wildcard expansion in `project_mixed`.

## Root cause of the gap (issue #473)

The pipeline already correctly injects LET binding values into `point.payload` in `select_dispatch.rs::apply_select_postprocessing` before `project_results` is called. All 20 pre-existing LET tests passed, but the test claiming to cover the mixed-SELECT case (`SELECT *, hybrid`) was actually testing plain `SELECT *`. The qualified-wildcard + named-column combination was untested.

## Test plan

- [x] `cargo test -p velesdb-core "let_binding_in_qualified_wildcard_mixed_select"` → ok
- [x] `cargo test -p velesdb-core "test_project_mixed_wildcard_exposes_let_injected_payload_field"` → ok
- [x] `cargo test -p velesdb-core "let_execution_tests"` → 21 passed, 0 failed
- [x] Full `projection::tests` suite unaffected

https://claude.ai/code/session_019uj5qzqHAwaXmfQ9HvwJ9J
