### PR TITLE
perf(filter): O(log n) binary search for large IN conditions — issue #512

### DIFF
--- a/crates/velesdb-core/src/filter/conversion.rs
+++ b/crates/velesdb-core/src/filter/conversion.rs
@@ -1,5 +1,6 @@
 //! Conversion from `VelesQL` conditions to filter conditions.
 
+use super::matching::json_value_cmp;
 use super::Condition;
 use serde_json::Value;
 
@@ -69,10 +70,18 @@ fn convert_comparison(
 }
 
 /// Converts an IN condition, optionally negated via NOT.
+///
+/// Values are sorted by [`json_value_cmp`] so that large IN lists can use
+/// O(log n) binary search in `matching.rs::in_list_matches` instead of a
+/// linear scan (issue #512). Exact duplicates are removed after sorting to
+/// avoid redundant comparisons.
 fn convert_in(inc: crate::velesql::InCondition) -> Condition {
+    let mut values: Vec<Value> = inc.values.into_iter().map(velesql_value_to_json).collect();
+    values.sort_by(json_value_cmp);
+    values.dedup_by(|a, b| a == b);
     let in_cond = Condition::In {
         field: inc.column,
-        values: inc.values.into_iter().map(velesql_value_to_json).collect(),
+        values,
     };
     if inc.negated {
         Condition::Not {

--- a/crates/velesdb-core/src/filter/conversion_tests.rs
+++ b/crates/velesdb-core/src/filter/conversion_tests.rs
@@ -308,7 +308,7 @@ fn test_in_values_are_sorted_at_conversion() {
     };
     let result: Condition = crate::velesql::Condition::In(inc).into();
     if let Condition::In { values, .. } = result {
-        let strings: Vec<&str> = values.iter().filter_map(|v| v.as_str()).collect();
+        let strings: Vec<&str> = values.iter().filter_map(serde_json::Value::as_str).collect();
         assert_eq!(strings, vec!["apple", "mango", "zoo"], "must be sorted");
     } else {
         panic!("expected Condition::In");
@@ -353,7 +353,7 @@ fn test_in_integer_values_sorted_numerically() {
     };
     let result: Condition = crate::velesql::Condition::In(inc).into();
     if let Condition::In { values, .. } = result {
-        let nums: Vec<i64> = values.iter().filter_map(|v| v.as_i64()).collect();
+        let nums: Vec<i64> = values.iter().filter_map(serde_json::Value::as_i64).collect();
         assert_eq!(nums, vec![10, 20, 30], "must be sorted numerically");
     } else {
         panic!("expected Condition::In");

--- a/crates/velesdb-core/src/filter/conversion_tests.rs
+++ b/crates/velesdb-core/src/filter/conversion_tests.rs
@@ -308,7 +308,10 @@ fn test_in_values_are_sorted_at_conversion() {
     };
     let result: Condition = crate::velesql::Condition::In(inc).into();
     if let Condition::In { values, .. } = result {
-        let strings: Vec<&str> = values.iter().filter_map(serde_json::Value::as_str).collect();
+        let strings: Vec<&str> = values
+            .iter()
+            .filter_map(serde_json::Value::as_str)
+            .collect();
         assert_eq!(strings, vec!["apple", "mango", "zoo"], "must be sorted");
     } else {
         panic!("expected Condition::In");
@@ -353,7 +356,10 @@ fn test_in_integer_values_sorted_numerically() {
     };
     let result: Condition = crate::velesql::Condition::In(inc).into();
     if let Condition::In { values, .. } = result {
-        let nums: Vec<i64> = values.iter().filter_map(serde_json::Value::as_i64).collect();
+        let nums: Vec<i64> = values
+            .iter()
+            .filter_map(serde_json::Value::as_i64)
+            .collect();
         assert_eq!(nums, vec![10, 20, 30], "must be sorted numerically");
     } else {
         panic!("expected Condition::In");
@@ -419,8 +425,14 @@ fn test_in_at_threshold_boundary_linear_scan() {
         negated: false,
     };
     let cond: Condition = crate::velesql::Condition::In(inc).into();
-    assert!(cond.matches(&json!({"code": "v07"})), "v07 must be found at threshold");
-    assert!(!cond.matches(&json!({"code": "v99"})), "v99 must not match at threshold");
+    assert!(
+        cond.matches(&json!({"code": "v07"})),
+        "v07 must be found at threshold"
+    );
+    assert!(
+        !cond.matches(&json!({"code": "v99"})),
+        "v99 must not match at threshold"
+    );
 }
 
 /// GIVEN an IN condition with exactly 17 values (first binary-search case)

--- a/crates/velesdb-core/src/filter/conversion_tests.rs
+++ b/crates/velesdb-core/src/filter/conversion_tests.rs
@@ -289,6 +289,122 @@ fn test_like_case_insensitive() {
 }
 
 // ============================================================================
+// Issue #512: IN list pre-sorting and deduplication
+// ============================================================================
+
+/// GIVEN an IN condition with unordered string values
+/// WHEN converted to Condition::In
+/// THEN values are sorted lexicographically (enables binary search in matching.rs)
+#[test]
+fn test_in_values_are_sorted_at_conversion() {
+    let inc = InCondition {
+        column: "tag".to_string(),
+        values: vec![
+            VelesValue::String("zoo".to_string()),
+            VelesValue::String("apple".to_string()),
+            VelesValue::String("mango".to_string()),
+        ],
+        negated: false,
+    };
+    let result: Condition = crate::velesql::Condition::In(inc).into();
+    if let Condition::In { values, .. } = result {
+        let strings: Vec<&str> = values.iter().filter_map(|v| v.as_str()).collect();
+        assert_eq!(strings, vec!["apple", "mango", "zoo"], "must be sorted");
+    } else {
+        panic!("expected Condition::In");
+    }
+}
+
+/// GIVEN an IN condition with duplicate string values
+/// WHEN converted to Condition::In
+/// THEN exact duplicates are removed
+#[test]
+fn test_in_values_are_deduplicated_at_conversion() {
+    let inc = InCondition {
+        column: "cat".to_string(),
+        values: vec![
+            VelesValue::String("a".to_string()),
+            VelesValue::String("b".to_string()),
+            VelesValue::String("a".to_string()),
+        ],
+        negated: false,
+    };
+    let result: Condition = crate::velesql::Condition::In(inc).into();
+    if let Condition::In { values, .. } = result {
+        assert_eq!(values.len(), 2, "duplicate 'a' must be removed");
+    } else {
+        panic!("expected Condition::In");
+    }
+}
+
+/// GIVEN an IN condition with integer values out of order
+/// WHEN converted to Condition::In
+/// THEN values are sorted numerically
+#[test]
+fn test_in_integer_values_sorted_numerically() {
+    let inc = InCondition {
+        column: "id".to_string(),
+        values: vec![
+            VelesValue::Integer(30),
+            VelesValue::Integer(10),
+            VelesValue::Integer(20),
+        ],
+        negated: false,
+    };
+    let result: Condition = crate::velesql::Condition::In(inc).into();
+    if let Condition::In { values, .. } = result {
+        let nums: Vec<i64> = values.iter().filter_map(|v| v.as_i64()).collect();
+        assert_eq!(nums, vec![10, 20, 30], "must be sorted numerically");
+    } else {
+        panic!("expected Condition::In");
+    }
+}
+
+/// GIVEN an IN condition with > 16 values (binary search threshold)
+/// WHEN matching against a payload containing one of the values
+/// THEN the match succeeds (binary search correctness)
+#[test]
+fn test_in_large_list_binary_search_finds_value() {
+    use serde_json::json;
+
+    // Build IN list with 20 string values (> IN_BINARY_SEARCH_THRESHOLD=16)
+    let values: Vec<VelesValue> = (0..20)
+        .map(|i| VelesValue::String(format!("val_{i:02}")))
+        .collect();
+    let inc = InCondition {
+        column: "code".to_string(),
+        values,
+        negated: false,
+    };
+    let cond: Condition = crate::velesql::Condition::In(inc).into();
+    let payload = json!({"code": "val_07"});
+    assert!(
+        cond.matches(&payload),
+        "val_07 must be found via binary search"
+    );
+}
+
+/// GIVEN an IN condition with > 16 values
+/// WHEN matching against a payload with a value NOT in the list
+/// THEN the match fails (binary search correctness for non-members)
+#[test]
+fn test_in_large_list_binary_search_rejects_absent_value() {
+    use serde_json::json;
+
+    let values: Vec<VelesValue> = (0..20)
+        .map(|i| VelesValue::String(format!("val_{i:02}")))
+        .collect();
+    let inc = InCondition {
+        column: "code".to_string(),
+        values,
+        negated: false,
+    };
+    let cond: Condition = crate::velesql::Condition::In(inc).into();
+    let payload = json!({"code": "absent"});
+    assert!(!cond.matches(&payload), "absent value must not match");
+}
+
+// ============================================================================
 // Issue #486: Value::UnsignedInteger filter conversion
 // ============================================================================
 

--- a/crates/velesdb-core/src/filter/conversion_tests.rs
+++ b/crates/velesdb-core/src/filter/conversion_tests.rs
@@ -404,6 +404,50 @@ fn test_in_large_list_binary_search_rejects_absent_value() {
     assert!(!cond.matches(&payload), "absent value must not match");
 }
 
+/// GIVEN an IN condition with exactly 16 values (linear-scan boundary)
+/// WHEN matching with a present and an absent value
+/// THEN linear scan returns the correct results
+#[test]
+fn test_in_at_threshold_boundary_linear_scan() {
+    use serde_json::json;
+    let values: Vec<VelesValue> = (0..16)
+        .map(|i| VelesValue::String(format!("v{i:02}")))
+        .collect();
+    let inc = InCondition {
+        column: "code".to_string(),
+        values,
+        negated: false,
+    };
+    let cond: Condition = crate::velesql::Condition::In(inc).into();
+    assert!(cond.matches(&json!({"code": "v07"})), "v07 must be found at threshold");
+    assert!(!cond.matches(&json!({"code": "v99"})), "v99 must not match at threshold");
+}
+
+/// GIVEN an IN condition with exactly 17 values (first binary-search case)
+/// WHEN matching with a present and an absent value
+/// THEN binary search returns the correct results
+#[test]
+fn test_in_just_above_threshold_binary_search() {
+    use serde_json::json;
+    let values: Vec<VelesValue> = (0..17)
+        .map(|i| VelesValue::String(format!("v{i:02}")))
+        .collect();
+    let inc = InCondition {
+        column: "code".to_string(),
+        values,
+        negated: false,
+    };
+    let cond: Condition = crate::velesql::Condition::In(inc).into();
+    assert!(
+        cond.matches(&json!({"code": "v07"})),
+        "v07 must be found just above threshold"
+    );
+    assert!(
+        !cond.matches(&json!({"code": "v99"})),
+        "v99 must not match just above threshold"
+    );
+}
+
 // ============================================================================
 // Issue #486: Value::UnsignedInteger filter conversion
 // ============================================================================

--- a/crates/velesdb-core/src/filter/matching.rs
+++ b/crates/velesdb-core/src/filter/matching.rs
@@ -29,7 +29,8 @@ fn json_type_rank(v: &Value) -> u8 {
 /// Total ordering over `serde_json::Value` used for sorting IN-list values
 /// and binary-searching them at match time (issue #512).
 ///
-/// Within each type: Null = Null, Bool by value, Number by f64, String
+/// Within each type: Null = Null, Bool by value, Number by `f64::total_cmp`
+/// (NaN sorts after +∞, giving a deterministic total order), String
 /// lexicographic, Arrays and Objects by type rank only (equal among themselves,
 /// which is acceptable since they are not used in IN conditions in practice).
 pub(super) fn json_value_cmp(a: &Value, b: &Value) -> std::cmp::Ordering {
@@ -43,9 +44,7 @@ pub(super) fn json_value_cmp(a: &Value, b: &Value) -> std::cmp::Ordering {
         (Value::Number(a), Value::Number(b)) => a
             .as_f64()
             .zip(b.as_f64())
-            .map_or(Ordering::Equal, |(fa, fb)| {
-                fa.partial_cmp(&fb).unwrap_or(Ordering::Equal)
-            }),
+            .map_or(Ordering::Equal, |(fa, fb)| fa.total_cmp(&fb)),
         (Value::String(a), Value::String(b)) => a.cmp(b),
         _ => Ordering::Equal,
     }
@@ -55,15 +54,25 @@ pub(super) fn json_value_cmp(a: &Value, b: &Value) -> std::cmp::Ordering {
 ///
 /// Switches strategy based on list length:
 /// - `values.len() <= IN_BINARY_SEARCH_THRESHOLD`: O(n) linear scan via
-///   `values_equal` (handles f64 epsilon comparison correctly).
-/// - `values.len() > IN_BINARY_SEARCH_THRESHOLD`: O(log n) binary search
-///   via `json_value_cmp` (requires `values` to be pre-sorted, which
-///   `conversion.rs::convert_in` guarantees).
+///   `values_equal` (epsilon-tolerant float equality).
+/// - `values.len() > IN_BINARY_SEARCH_THRESHOLD`: O(log n) lower-bound via
+///   `json_value_cmp` to narrow position, then `values_equal` for the final
+///   check — preserving epsilon semantics on both paths and requiring
+///   `values` to be pre-sorted (`conversion.rs::convert_in` guarantees this).
 fn in_list_matches(field_val: &Value, values: &[Value]) -> bool {
     if values.len() > IN_BINARY_SEARCH_THRESHOLD {
-        values
-            .binary_search_by(|probe| json_value_cmp(probe, field_val))
-            .is_ok()
+        debug_assert!(
+            values
+                .windows(2)
+                .all(|w| json_value_cmp(&w[0], &w[1]) != std::cmp::Ordering::Greater),
+            "Condition::In values must be pre-sorted by json_value_cmp"
+        );
+        // Lower-bound: first position where probe is NOT less than field_val.
+        let pos = values
+            .partition_point(|probe| json_value_cmp(probe, field_val) == std::cmp::Ordering::Less);
+        // Check the candidate at pos and its predecessor for epsilon-equal floats.
+        let check = |i: usize| values.get(i).is_some_and(|v| values_equal(v, field_val));
+        check(pos) || pos > 0 && check(pos - 1)
     } else {
         values.iter().any(|val| values_equal(field_val, val))
     }

--- a/crates/velesdb-core/src/filter/matching.rs
+++ b/crates/velesdb-core/src/filter/matching.rs
@@ -7,6 +7,68 @@ use serde_json::Value;
 const LIKE_MAX_PATTERN_BYTES: usize = 4096;
 const LIKE_MAX_DYN_OPS: usize = 2_000_000;
 
+/// List length above which IN matching switches from O(n) linear scan to
+/// O(log n) binary search. Values must be pre-sorted by [`json_value_cmp`]
+/// at `Condition::In` construction time (done in `conversion.rs::convert_in`).
+const IN_BINARY_SEARCH_THRESHOLD: usize = 16;
+
+/// Assigns a numeric rank to a JSON value type for consistent total ordering.
+///
+/// Type rank: Null(0) < Bool(1) < Number(2) < String(3) < Array(4) < Object(5).
+fn json_type_rank(v: &Value) -> u8 {
+    match v {
+        Value::Null => 0,
+        Value::Bool(_) => 1,
+        Value::Number(_) => 2,
+        Value::String(_) => 3,
+        Value::Array(_) => 4,
+        Value::Object(_) => 5,
+    }
+}
+
+/// Total ordering over `serde_json::Value` used for sorting IN-list values
+/// and binary-searching them at match time (issue #512).
+///
+/// Within each type: Null = Null, Bool by value, Number by f64, String
+/// lexicographic, Arrays and Objects by type rank only (equal among themselves,
+/// which is acceptable since they are not used in IN conditions in practice).
+pub(super) fn json_value_cmp(a: &Value, b: &Value) -> std::cmp::Ordering {
+    use std::cmp::Ordering;
+    let rank = json_type_rank(a).cmp(&json_type_rank(b));
+    if rank != Ordering::Equal {
+        return rank;
+    }
+    match (a, b) {
+        (Value::Bool(a), Value::Bool(b)) => a.cmp(b),
+        (Value::Number(a), Value::Number(b)) => a
+            .as_f64()
+            .zip(b.as_f64())
+            .map_or(Ordering::Equal, |(fa, fb)| {
+                fa.partial_cmp(&fb).unwrap_or(Ordering::Equal)
+            }),
+        (Value::String(a), Value::String(b)) => a.cmp(b),
+        _ => Ordering::Equal,
+    }
+}
+
+/// Returns whether `field_val` appears in `values`.
+///
+/// Switches strategy based on list length:
+/// - `values.len() <= IN_BINARY_SEARCH_THRESHOLD`: O(n) linear scan via
+///   `values_equal` (handles f64 epsilon comparison correctly).
+/// - `values.len() > IN_BINARY_SEARCH_THRESHOLD`: O(log n) binary search
+///   via `json_value_cmp` (requires `values` to be pre-sorted, which
+///   `conversion.rs::convert_in` guarantees).
+fn in_list_matches(field_val: &Value, values: &[Value]) -> bool {
+    if values.len() > IN_BINARY_SEARCH_THRESHOLD {
+        values
+            .binary_search_by(|probe| json_value_cmp(probe, field_val))
+            .is_ok()
+    } else {
+        values.iter().any(|val| values_equal(field_val, val))
+    }
+}
+
 /// Evaluates array-level conditions (single, any, all).
 fn match_array_condition(payload: &Value, field: &str, values: &[Value], mode: ArrayMode) -> bool {
     get_field(payload, field).is_some_and(|v| match v {
@@ -96,8 +158,9 @@ impl Condition {
             Self::Lte { field, value } => {
                 get_field(payload, field).is_some_and(|v| compare_values(v, value) <= 0)
             }
-            Self::In { field, values } => get_field(payload, field)
-                .is_some_and(|v| values.iter().any(|val| values_equal(v, val))),
+            Self::In { field, values } => {
+                get_field(payload, field).is_some_and(|v| in_list_matches(v, values))
+            }
             Self::Contains { field, value } => get_field(payload, field)
                 .is_some_and(|v| v.as_str().is_some_and(|s| s.contains(value.as_str()))),
             Self::IsNull { field } => get_field(payload, field).is_none_or(Value::is_null),


### PR DESCRIPTION
## Summary

Closes the post-filter performance gap identified in the [2026-04-26 audit comment on #512](https://github.com/cyberlife-coder/VelesDB/issues/512#issuecomment-4322402850):

> The VelesQL executor does not route large IN clauses to the bitmap path.

**Root cause**: `Condition::In` matching used an O(n) linear scan through all values for every document checked in the post-filter path (unindexed fields, or selectivity > 80%).

**Fix**: Sort IN values at `Condition` construction time; use O(log n) binary search at match time when the list exceeds the threshold.

Closes #512

## Changes

| File | What changed |
|------|-------------|
| `filter/matching.rs` | `json_value_cmp` total-order function; `in_list_matches` dispatcher (linear ≤ 16, binary search > 16) |
| `filter/conversion.rs` | `convert_in` sorts + deduplicates values via `json_value_cmp` |
| `filter/conversion_tests.rs` | 5 new unit tests: sort order, dedup, binary search finds/rejects, integer numeric order |

## Performance impact

For post-filter IN matching with `n` list values and `C` candidate documents:

| List size | Before | After |
|-----------|--------|-------|
| ≤ 16      | O(C × n) linear | O(C × n) linear (unchanged) |
| > 16      | O(C × n) linear | O(C × log n) binary search |
| n = 10 000, C = 1 000 | ~10 M comparisons | ~14 K comparisons (**~700× faster**) |

The secondary-index bitmap path (indexed fields) is unchanged and continues to provide the optimal pre-filter.

## Design decisions

- **Threshold = 16**: Matches the column-store `filter_in_int_bitmap` fast-path threshold already in `column_store/filter.rs:283`. Linear scan is cheaper for tiny lists due to no overhead.
- **`json_value_cmp` total ordering**: Null < Bool < Number < String < Array < Object; within type by natural order. Arrays/Objects compare equal (not used in IN conditions in practice).
- **Dedup via `dedup_by(|a, b| a == b)`**: Exact equality; avoids the epsilon-comparison issue for f64 during deduplication, which matches user intent (exact values in IN lists).
- **No architectural change**: No ColumnStore access needed; the existing `build_prefilter_bitmap` path (for indexed fields) is untouched.

## Test plan

- [x] `cargo test -p velesdb-core --lib filter::conversion_tests` → 28 passed (5 new)
- [x] `cargo test -p velesdb-core --test bdd secondary_index_bitmap_in` → 10 passed
- [x] `cargo test -p velesdb-core --test bdd` → 388 passed, 0 failed
- [x] `cargo clippy -p velesdb-core -- -D warnings` → 0 errors
- [x] `cargo fmt --check -p velesdb-core` → clean

Date: 2026-05-10

https://claude.ai/code/session_01VAdVE7xtXsN6v39k2ps91W
