### PR TITLE
feat(agent): ACT-R procedural learning — power-law decay and diminishing returns (#433)

### DIFF
--- a/crates/velesdb-core/src/agent/mod.rs
+++ b/crates/velesdb-core/src/agent/mod.rs
@@ -65,8 +65,8 @@ pub use memory::{
     SemanticMemory, DEFAULT_DIMENSION,
 };
 pub use reinforcement::{
-    AdaptiveLearningRate, CompositeStrategy, ContextualReinforcement, FixedRate,
-    ReinforcementContext, ReinforcementStrategy, TemporalDecay,
+    power_law_decay, AdaptiveLearningRate, CompositeStrategy, ContextualReinforcement,
+    DiminishingReturns, FixedRate, ReinforcementContext, ReinforcementStrategy, TemporalDecay,
 };
 pub use snapshot::{
     load_snapshot, load_snapshot_from_file, save_snapshot_to_file, MemoryState, SnapshotManager,

--- a/crates/velesdb-core/src/agent/procedural_memory.rs
+++ b/crates/velesdb-core/src/agent/procedural_memory.rs
@@ -22,7 +22,7 @@ use std::sync::Arc;
 
 use super::error::AgentMemoryError;
 use super::memory_helpers;
-use super::reinforcement::{FixedRate, ReinforcementContext, ReinforcementStrategy};
+use super::reinforcement::{power_law_decay, FixedRate, ReinforcementContext, ReinforcementStrategy};
 use super::ttl::MemoryTtl;
 
 struct ProcedureState {
@@ -31,6 +31,7 @@ struct ProcedureState {
     confidence: f32,
     usage_count: u64,
     created_at: i64,
+    last_used_at: i64,
     success_count: u64,
     failure_count: u64,
 }
@@ -43,13 +44,16 @@ impl ProcedureState {
         } else {
             0.5
         };
+        let mut custom = std::collections::HashMap::new();
+        custom.insert("success_count".to_string(), self.success_count as f64);
+        custom.insert("failure_count".to_string(), self.failure_count as f64);
         ReinforcementContext {
             usage_count: self.usage_count,
             created_at: self.created_at as u64,
-            last_used: now as u64,
+            last_used: self.last_used_at as u64,
             current_time: now as u64,
             recent_success_rate: Some(success_rate),
-            custom: std::collections::HashMap::new(),
+            custom,
         }
     }
 }
@@ -73,6 +77,14 @@ pub struct ProcedureMatch {
 ///
 /// Stores procedures as embedding vectors with associated metadata.
 /// Supports confidence-based recall, reinforcement learning, and TTL expiration.
+///
+/// ### ACT-R activation decay
+///
+/// When built with [`with_activation_decay`](Self::with_activation_decay), the
+/// confidence returned by [`recall`](Self::recall) is modulated by the ACT-R
+/// base-level power-law formula: `c × max(1, t_days)^(-d)` where `d` is the
+/// decay exponent (Anderson 1996, default ≈ 0.5).  The stored value is
+/// unchanged — decay is applied read-only at retrieval time.
 pub struct ProceduralMemory {
     collection_name: String,
     db: Arc<Database>,
@@ -80,6 +92,9 @@ pub struct ProceduralMemory {
     ttl: Arc<MemoryTtl>,
     reinforcement_strategy: Arc<dyn ReinforcementStrategy>,
     stored_ids: RwLock<HashSet<u64>>,
+    /// ACT-R decay exponent `d` for passive confidence decay at recall time.
+    /// `None` disables decay (default — backward-compatible behaviour).
+    activation_decay_exponent: Option<f32>,
 }
 
 impl ProceduralMemory {
@@ -121,6 +136,7 @@ impl ProceduralMemory {
             ttl,
             reinforcement_strategy: Arc::new(FixedRate::default()),
             stored_ids,
+            activation_decay_exponent: None,
         })
     }
 
@@ -128,6 +144,20 @@ impl ProceduralMemory {
     #[must_use]
     pub fn with_reinforcement_strategy(mut self, strategy: Arc<dyn ReinforcementStrategy>) -> Self {
         self.reinforcement_strategy = strategy;
+        self
+    }
+
+    /// Enables ACT-R base-level activation decay at recall time.
+    ///
+    /// When set, the confidence returned by [`recall`](Self::recall) is
+    /// multiplied by `max(1, t_days)^(-decay_exponent)` where `t_days` is the
+    /// number of days since the procedure was last reinforced.
+    ///
+    /// The stored confidence is **not** modified — decay is applied read-only.
+    /// ACT-R recommends `decay_exponent ≈ 0.5` (Anderson 1996).
+    #[must_use]
+    pub fn with_activation_decay(mut self, decay_exponent: f32) -> Self {
+        self.activation_decay_exponent = Some(decay_exponent.clamp(0.0, 2.0));
         self
     }
 
@@ -193,6 +223,11 @@ impl ProceduralMemory {
 
     /// Recalls matching procedures by vector similarity.
     ///
+    /// When ACT-R activation decay is configured via
+    /// [`with_activation_decay`](Self::with_activation_decay), the returned
+    /// `confidence` reflects power-law decay since last use without modifying
+    /// the stored value.
+    ///
     /// # Errors
     ///
     /// Returns an error when embedding dimension is invalid, collection access fails,
@@ -212,10 +247,22 @@ impl ProceduralMemory {
             &self.ttl,
         )?;
 
+        let now_secs = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map_or(0, |d| d.as_secs());
+
         Ok(results
             .into_iter()
             .filter_map(|r| {
-                let pm = extract_procedure_match(&r.point, r.score)?;
+                let mut pm = extract_procedure_match(&r.point, r.score)?;
+                if let Some(exponent) = self.activation_decay_exponent {
+                    let last_used = r.point.payload.as_ref()
+                        .and_then(|p| p.get("last_used_at"))
+                        .and_then(serde_json::Value::as_i64)
+                        .unwrap_or(0);
+                    let elapsed_secs = (now_secs as i64).saturating_sub(last_used).max(0) as u64;
+                    pm.confidence = power_law_decay(pm.confidence, elapsed_secs, exponent);
+                }
                 if pm.confidence < min_confidence {
                     return None;
                 }
@@ -317,6 +364,10 @@ impl ProceduralMemory {
                 .unwrap_or(0),
             created_at: payload
                 .get("created_at")
+                .and_then(serde_json::Value::as_i64)
+                .unwrap_or(0),
+            last_used_at: payload
+                .get("last_used_at")
                 .and_then(serde_json::Value::as_i64)
                 .unwrap_or(0),
             success_count: payload

--- a/crates/velesdb-core/src/agent/procedural_memory.rs
+++ b/crates/velesdb-core/src/agent/procedural_memory.rs
@@ -22,7 +22,9 @@ use std::sync::Arc;
 
 use super::error::AgentMemoryError;
 use super::memory_helpers;
-use super::reinforcement::{power_law_decay, FixedRate, ReinforcementContext, ReinforcementStrategy};
+use super::reinforcement::{
+    power_law_decay, FixedRate, ReinforcementContext, ReinforcementStrategy,
+};
 use super::ttl::MemoryTtl;
 
 struct ProcedureState {
@@ -256,7 +258,10 @@ impl ProceduralMemory {
             .filter_map(|r| {
                 let mut pm = extract_procedure_match(&r.point, r.score)?;
                 if let Some(exponent) = self.activation_decay_exponent {
-                    let last_used = r.point.payload.as_ref()
+                    let last_used = r
+                        .point
+                        .payload
+                        .as_ref()
                         .and_then(|p| p.get("last_used_at"))
                         .and_then(serde_json::Value::as_i64)
                         .unwrap_or(0);

--- a/crates/velesdb-core/src/agent/reinforcement.rs
+++ b/crates/velesdb-core/src/agent/reinforcement.rs
@@ -437,6 +437,109 @@ impl ReinforcementStrategy for CompositeStrategy {
     }
 }
 
+/// Rescorla-Wagner diminishing-returns reinforcement strategy (ACT-R Phase 2).
+///
+/// Adjusts the confidence delta based on practice history, giving early
+/// reinforcements maximal impact while later ones taper off:
+///
+/// `Δ = base_delta / (1 + k × success_count)` on success,
+/// `Δ = base_delta / (1 + k × failure_count)` on failure.
+///
+/// Reference: Rescorla & Wagner (1972), "A Theory of Pavlovian Conditioning",
+/// in *Classical Conditioning II: Current Research and Theory*, pp. 64-99.
+#[derive(Debug, Clone)]
+pub struct DiminishingReturns {
+    /// Base confidence delta on success.
+    pub base_success_delta: f32,
+    /// Base confidence delta on failure (positive value; subtracted).
+    pub base_failure_delta: f32,
+    /// Diminishing-returns coefficient k (default 0.1).
+    /// Higher values compress the learning curve more aggressively.
+    pub k: f32,
+}
+
+impl Default for DiminishingReturns {
+    fn default() -> Self {
+        Self {
+            base_success_delta: 0.1,
+            base_failure_delta: 0.05,
+            k: 0.1,
+        }
+    }
+}
+
+impl DiminishingReturns {
+    /// Creates a new strategy with custom base deltas and coefficient.
+    #[must_use]
+    pub fn new(base_success_delta: f32, base_failure_delta: f32, k: f32) -> Self {
+        Self {
+            base_success_delta,
+            base_failure_delta,
+            k,
+        }
+    }
+
+    fn effective_delta(base: f32, count: f32, k: f32) -> f32 {
+        base / (1.0 + k * count)
+    }
+}
+
+impl ReinforcementStrategy for DiminishingReturns {
+    #[allow(clippy::cast_possible_truncation)]
+    // Reason: success/failure counts are bounded by practical usage limits (<10^6);
+    // f64→f32 truncation is operationally irrelevant for confidence heuristics.
+    fn update_confidence(
+        &self,
+        old_confidence: f32,
+        success: bool,
+        context: &ReinforcementContext,
+    ) -> f32 {
+        // Use success_count/failure_count from custom context if available,
+        // otherwise approximate from usage_count × recent_success_rate.
+        let (s_count, f_count) = if let (Some(&sc), Some(&fc)) = (
+            context.custom.get("success_count"),
+            context.custom.get("failure_count"),
+        ) {
+            (sc as f32, fc as f32)
+        } else {
+            let rate = context.recent_success_rate.unwrap_or(0.5);
+            let uses = context.usage_count as f32;
+            (uses * rate, uses * (1.0 - rate))
+        };
+
+        let delta = if success {
+            Self::effective_delta(self.base_success_delta, s_count, self.k)
+        } else {
+            -Self::effective_delta(self.base_failure_delta, f_count, self.k)
+        };
+
+        (old_confidence + delta).clamp(0.0, 1.0)
+    }
+
+    fn name(&self) -> &'static str {
+        "DiminishingReturns"
+    }
+}
+
+/// Applies ACT-R base-level power-law activation decay.
+///
+/// Returns `confidence × max(1, t_days)^(-d)` where:
+/// - `t_days` is time since last use in days
+/// - `d` is the decay exponent (ACT-R default ≈ 0.5, Anderson 1996)
+///
+/// Use this during recall (not reinforce) to dynamically reduce the
+/// *effective* confidence of long-unused procedures without modifying
+/// the stored value.
+///
+/// Reference: Anderson (1996), "ACT-R: A Theory of Higher Level Cognition",
+/// *Human-Computer Interaction* 12(4), 439-462.
+#[must_use]
+pub fn power_law_decay(confidence: f32, time_since_last_use_secs: u64, decay_exponent: f32) -> f32 {
+    let days = time_since_last_use_secs as f32 / 86_400.0;
+    let multiplier = days.max(1.0).powf(-decay_exponent);
+    (confidence * multiplier).clamp(0.0, 1.0)
+}
+
 /// Default strategy factory.
 ///
 /// Returns the default reinforcement strategy (`FixedRate`).

--- a/crates/velesdb-core/src/agent/reinforcement_tests.rs
+++ b/crates/velesdb-core/src/agent/reinforcement_tests.rs
@@ -73,4 +73,91 @@ mod tests {
         let new_confidence = strategy.update_confidence(0.5, true, &context);
         assert!(new_confidence > 0.5);
     }
+
+    // --- DiminishingReturns (Phase 2) ---
+
+    #[test]
+    fn test_diminishing_returns_first_success_equals_fixed_rate() {
+        // At success_count=0 the delta should equal base_success_delta.
+        let strategy = DiminishingReturns::default();
+        let mut ctx = ReinforcementContext::new();
+        ctx.custom.insert("success_count".to_string(), 0.0);
+        ctx.custom.insert("failure_count".to_string(), 0.0);
+        let new_confidence = strategy.update_confidence(0.5, true, &ctx);
+        // delta = 0.1 / (1 + 0.1*0) = 0.1 → 0.6
+        assert!((new_confidence - 0.6).abs() < 0.001, "got {new_confidence}");
+    }
+
+    #[test]
+    fn test_diminishing_returns_decreases_with_practice() {
+        let strategy = DiminishingReturns::default();
+        let mut ctx0 = ReinforcementContext::new();
+        ctx0.custom.insert("success_count".to_string(), 0.0);
+        ctx0.custom.insert("failure_count".to_string(), 0.0);
+        let mut ctx10 = ReinforcementContext::new();
+        ctx10.custom.insert("success_count".to_string(), 10.0);
+        ctx10.custom.insert("failure_count".to_string(), 0.0);
+
+        let d0 = strategy.update_confidence(0.5, true, &ctx0) - 0.5;
+        let d10 = strategy.update_confidence(0.5, true, &ctx10) - 0.5;
+        assert!(d10 < d0, "delta should decrease with practice: {d10} < {d0}");
+    }
+
+    #[test]
+    fn test_diminishing_returns_failure_decrements() {
+        let strategy = DiminishingReturns::default();
+        let mut ctx = ReinforcementContext::new();
+        ctx.custom.insert("success_count".to_string(), 0.0);
+        ctx.custom.insert("failure_count".to_string(), 0.0);
+        let new_confidence = strategy.update_confidence(0.5, false, &ctx);
+        assert!(new_confidence < 0.5, "failure should lower confidence");
+    }
+
+    #[test]
+    fn test_diminishing_returns_clamp() {
+        let strategy = DiminishingReturns::new(0.5, 0.5, 0.0);
+        let mut ctx = ReinforcementContext::new();
+        ctx.custom.insert("success_count".to_string(), 0.0);
+        ctx.custom.insert("failure_count".to_string(), 0.0);
+        let high = strategy.update_confidence(0.9, true, &ctx);
+        assert!(high <= 1.0, "should not exceed 1.0");
+        let low = strategy.update_confidence(0.1, false, &ctx);
+        assert!(low >= 0.0, "should not go below 0.0");
+    }
+
+    // --- power_law_decay (Phase 1) ---
+
+    #[test]
+    fn test_power_law_decay_zero_elapsed_no_decay() {
+        // 0 seconds elapsed → days=0, max(1,0)=1, 1^(-0.5)=1 → confidence unchanged
+        let result = power_law_decay(0.8, 0, 0.5);
+        assert!((result - 0.8).abs() < 0.001, "got {result}");
+    }
+
+    #[test]
+    fn test_power_law_decay_four_days_halves_with_d05() {
+        // 4 days → max(1, 4)^(-0.5) = 4^(-0.5) = 0.5 → confidence × 0.5
+        let secs = 4 * 24 * 3600;
+        let result = power_law_decay(1.0, secs, 0.5);
+        assert!((result - 0.5).abs() < 0.001, "got {result}");
+    }
+
+    #[test]
+    fn test_power_law_decay_less_than_one_day_no_extra_decay() {
+        // Less than 1 day → max(1, t_days) clamps to 1 → multiplier = 1^(-d) = 1
+        let secs_12h = 12 * 3600;
+        let result = power_law_decay(0.7, secs_12h, 0.5);
+        assert!((result - 0.7).abs() < 0.001, "got {result}");
+    }
+
+    #[test]
+    fn test_power_law_decay_monotone_decreasing() {
+        let d = 0.5;
+        let c = 1.0;
+        let r1d = power_law_decay(c, 86_400, d);    // 1 day
+        let r4d = power_law_decay(c, 4 * 86_400, d); // 4 days
+        let r16d = power_law_decay(c, 16 * 86_400, d); // 16 days
+        assert!(r1d >= r4d, "decay should increase with time");
+        assert!(r4d >= r16d, "decay should increase with time");
+    }
 }

--- a/crates/velesdb-core/src/agent/reinforcement_tests.rs
+++ b/crates/velesdb-core/src/agent/reinforcement_tests.rs
@@ -89,6 +89,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::similar_names)]
     fn test_diminishing_returns_decreases_with_practice() {
         let strategy = DiminishingReturns::default();
         let mut ctx0 = ReinforcementContext::new();
@@ -154,6 +155,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::similar_names)]
     fn test_power_law_decay_monotone_decreasing() {
         let d = 0.5;
         let c = 1.0;

--- a/crates/velesdb-core/src/agent/reinforcement_tests.rs
+++ b/crates/velesdb-core/src/agent/reinforcement_tests.rs
@@ -100,7 +100,10 @@ mod tests {
 
         let d0 = strategy.update_confidence(0.5, true, &ctx0) - 0.5;
         let d10 = strategy.update_confidence(0.5, true, &ctx10) - 0.5;
-        assert!(d10 < d0, "delta should decrease with practice: {d10} < {d0}");
+        assert!(
+            d10 < d0,
+            "delta should decrease with practice: {d10} < {d0}"
+        );
     }
 
     #[test]
@@ -154,7 +157,7 @@ mod tests {
     fn test_power_law_decay_monotone_decreasing() {
         let d = 0.5;
         let c = 1.0;
-        let r1d = power_law_decay(c, 86_400, d);    // 1 day
+        let r1d = power_law_decay(c, 86_400, d); // 1 day
         let r4d = power_law_decay(c, 4 * 86_400, d); // 4 days
         let r16d = power_law_decay(c, 16 * 86_400, d); // 16 days
         assert!(r1d >= r4d, "decay should increase with time");


### PR DESCRIPTION
## Summary

Implements Phase 1 and Phase 2 of issue #433 (ACT-R inspired procedural learning).

### Phase 1 — Base-level activation decay (Anderson 1996)

ACT-R's core insight: procedures that haven't been used recently should lose confidence, following the **power-law forgetting curve** observed in human memory research (`B(t) = c × t^(-d)`, d ≈ 0.5).

- New `power_law_decay(confidence, elapsed_secs, d)` free function — exported from `agent` module
- New `ProceduralMemory::with_activation_decay(decay_exponent)` builder
- When set, `recall()` applies passive decay without touching stored values (faithful to ACT-R: activation is computed at retrieval, not stored)

**Example:** A procedure with confidence=0.8 unused for 4 days has effective confidence `0.8 × 4^(-0.5) ≈ 0.4` at recall time. The stored value stays 0.8 until `reinforce()` is called.

### Bug fix in TemporalDecay

`ProcedureState` was missing the `last_used_at` field, so `build_reinforcement_context()` set `last_used = now`, making `time_since_last_use()` always return 0. `TemporalDecay` was silently a no-op. Fixed by extracting `last_used_at` from the Point payload.

### Phase 2 — Diminishing-returns reinforcement (Rescorla-Wagner 1972)

- New `DiminishingReturns` strategy: `Δ = base_delta / (1 + k × success_count)`
- Early successes boost confidence more; later ones taper (learning curve)
- `build_reinforcement_context()` now populates `success_count`/`failure_count` as custom fields so strategies can distinguish the two

### What's not in this PR (Phase 3)

Spreading activation across memory types requires API changes and is deferred to a follow-up.

## Changes

| File | Change |
|---|---|
| `src/agent/reinforcement.rs` | `DiminishingReturns` strategy, `power_law_decay` fn |
| `src/agent/procedural_memory.rs` | Add `last_used_at` to `ProcedureState`, fix `build_reinforcement_context()`, add `activation_decay_exponent` + `with_activation_decay()` |
| `src/agent/mod.rs` | Export `DiminishingReturns`, `power_law_decay` |
| `src/agent/reinforcement_tests.rs` | 8 new unit tests |

## Test plan

- [x] `cargo test -p velesdb-core --lib -- agent::reinforcement_tests` — 16/16 passed (8 new)
- [x] `cargo clippy -p velesdb-core --lib -- -D warnings` — clean
- [x] All ACT-R formulas verified against reference values (4-day test, monotone decrease)

*2026-05-12*

References:
- Anderson (1996) *ACT-R: A Theory of Higher Level Cognition*, HCI 12(4), 439-462
- Rescorla & Wagner (1972) *A Theory of Pavlovian Conditioning*, pp. 64-99

https://claude.ai/code/session_01Q2GrEaUivWsVgMHz6WEtMB
