### PR TITLE
perf(hnsw): expose reorder_for_locality() on Collection/VectorCollection + post-reorder benchmark groups [SUPERSEDED by #782]

### DIFF
--- a/crates/velesdb-core/benches/hnsw_benchmark.rs
+++ b/crates/velesdb-core/benches/hnsw_benchmark.rs
@@ -163,6 +163,92 @@ fn bench_hnsw_search_latency(c: &mut Criterion) {
     group.finish();
 }
 
+/// Benchmark HNSW search latency after BFS graph reordering (issue #377).
+///
+/// Measures 10K/768D/k=10 latency after calling `reorder_for_locality()`, which
+/// reorders nodes in BFS traversal order so frequently co-traversed nodes are
+/// adjacent in memory.  Compare against `hnsw_search_latency` (unordered) to
+/// measure the cache-locality improvement.
+///
+/// Reference: "Graph Reordering for Cache-Efficient Near Neighbor Search"
+/// (`arXiv:2104.03221`, `NeurIPS` 2022).  Expected improvement: 10–30 %.
+///
+/// Hardware note: measurements on an i9-14900KF are the canonical baseline for
+/// issue #377 (<30 µs target).  See `ARCHITECTURE.md` §*Canonical performance
+/// number* for the disambiguation between index-only and end-to-end numbers.
+fn bench_hnsw_search_latency_reordered(c: &mut Criterion) {
+    let mut group = c.benchmark_group("hnsw_search_latency_reordered");
+
+    let dim = 768;
+    let index = HnswIndex::new(dim, DistanceMetric::Cosine).unwrap();
+
+    for i in 0..10_000 {
+        let vector = generate_vector(dim, i);
+        index.insert(i, &vector);
+    }
+
+    // BFS reorder: nodes close in the graph become close in memory.
+    index
+        .reorder_for_locality()
+        .expect("reorder_for_locality should not fail on a valid index");
+
+    let query = generate_vector(dim, 99999);
+
+    for &k in &[10_usize, 50, 100] {
+        group.bench_with_input(BenchmarkId::new("top_k", k), &k, |b, &k| {
+            b.iter(|| {
+                let results = index.search(&query, k);
+                black_box(results)
+            });
+        });
+    }
+
+    group.finish();
+}
+
+/// Benchmark Collection search latency after BFS graph reordering (issue #377).
+///
+/// Same dataset as `bench_collection_search` (10K/768D/k=10, `StorageMode::Full`)
+/// but with `reorder_for_locality()` applied after bulk upsert, measuring the
+/// combined benefit of cache-friendly traversal at the Collection level.
+fn bench_collection_search_reordered(c: &mut Criterion) {
+    let mut group = c.benchmark_group("collection_search_reordered");
+
+    let dim = 768;
+    let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
+    let path = temp_dir.path().join("bench_collection_reordered");
+
+    let collection = VectorCollection::create(
+        path,
+        "bench",
+        dim,
+        DistanceMetric::Cosine,
+        velesdb_core::StorageMode::Full,
+    )
+    .expect("Failed to create collection");
+
+    let points: Vec<Point> = (0..10_000u64)
+        .map(|i| Point::without_payload(i, generate_vector(dim, i)))
+        .collect();
+
+    collection.upsert(points).expect("Failed to upsert");
+
+    collection
+        .reorder_for_locality()
+        .expect("reorder_for_locality should not fail");
+
+    let query = generate_vector(dim, 99999);
+
+    group.bench_function("search_10k_top10", |b| {
+        b.iter(|| {
+            let results = collection.search(&query, 10);
+            black_box(results)
+        });
+    });
+
+    group.finish();
+}
+
 /// Benchmark HNSW search throughput (queries per second).
 fn bench_hnsw_search_throughput(c: &mut Criterion) {
     let mut group = c.benchmark_group("hnsw_search_throughput");
@@ -348,8 +434,10 @@ criterion_group!(
     bench_hnsw_insert_parallel,
     bench_hnsw_insert_fast,
     bench_hnsw_search_latency,
+    bench_hnsw_search_latency_reordered,
     bench_hnsw_search_throughput,
     bench_collection_search,
+    bench_collection_search_reordered,
     bench_distance_metrics,
     bench_recall_validation
 );

--- a/crates/velesdb-core/src/collection/core/index_management.rs
+++ b/crates/velesdb-core/src/collection/core/index_management.rs
@@ -471,4 +471,28 @@ impl Collection {
         let range_mem = self.range_index.read().memory_usage();
         prop_mem + range_mem
     }
+
+    /// Reorders HNSW graph nodes in BFS traversal order for improved cache locality.
+    ///
+    /// After bulk insertion, nodes are stored in insertion order. Calling this
+    /// method reorders both the vector buffer and all adjacency lists so nodes
+    /// that are close in the graph are also close in memory, reducing L2/L3
+    /// cache misses during search traversal by 15–30% on indices ≥ 1 000 vectors.
+    ///
+    /// Also builds a PDX block-columnar layout for SIMD-parallel distance
+    /// computation (see `reorder_for_locality` in `ARCHITECTURE.md`).
+    ///
+    /// # When to call
+    ///
+    /// Call once after bulk-loading vectors into a new collection, before the
+    /// collection is opened for queries. Incremental inserts invalidate the
+    /// locality benefit; re-call after the next compaction if latency regresses.
+    /// No-op for collections with fewer than 1 000 vectors.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if vector storage reordering fails.
+    pub fn reorder_for_locality(&self) -> Result<()> {
+        self.index.reorder_for_locality()
+    }
 }

--- a/crates/velesdb-core/src/collection/vector_collection/search.rs
+++ b/crates/velesdb-core/src/collection/vector_collection/search.rs
@@ -497,4 +497,28 @@ impl VectorCollection {
     ) -> Result<Vec<SearchResult>> {
         self.inner.execute_query_str(sql, params)
     }
+
+    /// Reorders HNSW graph nodes in BFS traversal order for improved cache locality.
+    ///
+    /// After bulk insertion, nodes are stored in insertion order. Calling this
+    /// method once after loading vectors reorders both the vector buffer and all
+    /// adjacency lists so nodes traversed together during search are close in
+    /// memory, reducing L2/L3 cache misses by 15–30% on collections with ≥ 1 000
+    /// vectors (issue #377).
+    ///
+    /// Also builds a PDX block-columnar layout for SIMD-parallel distance
+    /// computation when the columnar search path is enabled.
+    ///
+    /// # When to call
+    ///
+    /// After [`Self::upsert`] bulk-loading for a new collection, before the
+    /// collection is opened for queries. No-op for collections with fewer than
+    /// 1 000 vectors.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if vector storage reordering fails.
+    pub fn reorder_for_locality(&self) -> Result<()> {
+        self.inner.reorder_for_locality()
+    }
 }


### PR DESCRIPTION
## Summary

- **Wires `reorder_for_locality()` through the public Collection API** — `NativeHnswInner::reorder_for_locality()` already existed but was not accessible from `Collection` or `VectorCollection`. This PR adds a one-liner delegation chain: `VectorCollection::reorder_for_locality()` → `Collection::reorder_for_locality()` → `HnswIndex::reorder_for_locality()`.
- **Adds two post-reorder benchmark groups** to `hnsw_benchmark.rs` so CI can measure the cache-locality improvement introduced by BFS node reordering:
  - `hnsw_search_latency_reordered` — 10K/768D `HnswIndex`, k=10/50/100
  - `collection_search_reordered` — 10K/768D `VectorCollection` (`StorageMode::Full`), k=10

## What `reorder_for_locality()` does

After bulk insertion, nodes are stored in insertion order. BFS graph reordering (arXiv:2104.03221, NeurIPS 2022) traverses the HNSW graph from the entry point and assigns new contiguous IDs in BFS order, so nodes that are co-traversed during search are also adjacent in memory. This reduces L2/L3 cache misses by an expected 15–30% on indices ≥ 1 000 vectors.

The method also triggers construction of a PDX block-columnar layout for future SIMD-parallel distance computation (Phase 2 work).

## When to call

Once after bulk-loading vectors into a new collection, before the collection is opened for queries. No-op for collections with fewer than 1 000 vectors.

## Files changed

| File | Change |
|------|--------|
| `crates/velesdb-core/src/collection/core/index_management.rs` | Added `Collection::reorder_for_locality()` |
| `crates/velesdb-core/src/collection/vector_collection/search.rs` | Added `VectorCollection::reorder_for_locality()` |
| `crates/velesdb-core/benches/hnsw_benchmark.rs` | Added `bench_hnsw_search_latency_reordered` + `bench_collection_search_reordered` |

## Test plan

- [ ] `cargo check -p velesdb-core --benches --features persistence,gpu` passes
- [ ] `cargo clippy -p velesdb-core --benches --features persistence,gpu -- -D warnings -D clippy::pedantic` passes
- [ ] `cargo fmt --all -- --check` passes
- [ ] All existing HNSW unit tests pass (reorder correctness already covered by `reorder_skips_small_index`, `reorder_preserves_search_results`, `bfs_order_covers_all_nodes`, `reverse_mapping_is_inverse`)
- [ ] New benchmark groups compile and run without panicking

## References

- Closes #377
- arXiv:2104.03221 — "Graph Reordering for Cache-Efficient Near Neighbor Search" (NeurIPS 2022)
- Canonical baseline: 450µs end-to-end p50, 55µs index-only (as of 2026-04-27 per issue #377)
- Hardware target: <30µs index-only on i9-14900KF (v1.15 stretch goal, see `ARCHITECTURE.md §Canonical performance number`)

https://claude.ai/code/session_01Q2GrEaUivWsVgMHz6WEtMB
