### PR TITLE
chore: gitignore CLAUDE.md alongside other AI-assistant configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 .windsurf*
 .planning*
 AGENTS.md
+CLAUDE.md
 *.swo
 *~
 


### PR DESCRIPTION
## Summary
- Add `CLAUDE.md` to `.gitignore` next to the existing `AGENTS.md` / `.windsurf*` / `.opencode/` block.
- Mirrors the established pattern for author-local AI-assistant config files — keeps Claude-specific scaffolding out of the public repo without affecting contributors.

## Test plan
- [x] `git check-ignore -v CLAUDE.md` reports the new rule
- [x] No tracked file is removed or renamed (one-line additive change to `.gitignore`)
- [x] Unrelated assistant entries (`AGENTS.md`, `.windsurf*`, `.opencode/`) remain untouched
