### PR TITLE
docs(contributing): fix leaked local path and placeholder clone URL

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -131,8 +131,9 @@ cargo test -p velesdb-core --features persistence test_recall -- --test-threads=
 cargo check --no-default-features
 cargo check -p velesdb-wasm --no-default-features --target wasm32-unknown-unknown
 
-# 6. (Optional) Codacy CLI via WSL
-wsl -- bash -c "cd /mnt/d/Projets-dev/velesDB/velesdb-core && codacy-cli analyze 2>&1"
+# 6. (Optional) Codacy CLI — run from the repo root
+codacy-cli analyze
+# Windows: prefix with `wsl -- bash -c "cd $(wslpath -a .) && ..."` if the CLI runs under WSL.
 ```
 
 Or use the local CI script: `.\scripts\local-ci.ps1` (Full) or `.\scripts\local-ci.ps1 -Quick` (fmt + clippy only).
@@ -149,9 +150,9 @@ Git hooks are provided in `.githooks/` — activate with: `git config core.hooks
 ### Building from Source
 
 ```bash
-# Clone the repository
-git clone https://github.com/YOUR_USERNAME/velesdb.git
-cd velesdb
+# Clone the repository (replace cyberlife-coder with your fork if contributing via PR)
+git clone https://github.com/cyberlife-coder/VelesDB.git
+cd VelesDB
 
 # Build the project
 cargo build --workspace


### PR DESCRIPTION
## Summary
- Remove maintainer-specific WSL path (`/mnt/d/Projets-dev/velesDB/...`) from the optional Codacy CLI step in §Pre-Push Validation — replaced by a generic `codacy-cli analyze` invocation plus a one-line Windows/WSL note.
- Replace the `YOUR_USERNAME` placeholder in §Building from Source with the canonical `https://github.com/cyberlife-coder/VelesDB.git` URL, consistent with the `README.md` clone examples.

Both are doc-only fixes — no code, no CI config touched.

## Test plan
- [x] `grep YOUR_USERNAME CONTRIBUTING.md` returns nothing
- [x] `grep /mnt/d/Projets-dev CONTRIBUTING.md` returns nothing
- [x] Diff is limited to two adjacent blocks in `CONTRIBUTING.md`
- [ ] Manual: render the file on the PR page and confirm both code blocks still highlight correctly
