### PR TITLE
docs: deref v1.13.2-frozen stats in QUALITY_BAR.md / ARCHITECTURE.md

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 This document is the **15-minute read** an engineer or a technical due-diligence reviewer should start with. It tells you what VelesDB is, how it is shaped, and where to dig deeper.
 
-> **Last updated:** 2026-04-27 — applies to v1.14.x and beyond.
+> **Last updated:** 2026-05-14 — applies to v1.14.x and beyond.
 
 ---
 
@@ -182,7 +182,7 @@ The areas where VelesDB uses `unsafe` are:
 | FFI for UniFFI mobile bindings | C ABI boundary | `crates/velesdb-mobile/` |
 | Compute shader buffer mapping (GPU) | wgpu buffer lifetime | `crates/velesdb-core/src/gpu/` |
 
-Every `unsafe` block has a `// SAFETY: <reason>` comment, enforced by `scripts/verify_unsafe_safety_template.py` in CI. As of v1.13.2: 129 unsafe blocks, 431 SAFETY comments. The full audit narrative is in [`docs/SOUNDNESS.md`](docs/SOUNDNESS.md) (964 lines).
+Every `unsafe` block has a `// SAFETY: <reason>` comment, enforced by `scripts/verify_unsafe_safety_template.py` in CI. Live counts (unsafe sites and `// SAFETY:` comments) are reported by the script on every push and tracked release-over-release in `CHANGELOG.md`. The full audit narrative is in [`docs/SOUNDNESS.md`](docs/SOUNDNESS.md).
 
 External soundness audit (Cure53 / independent Rust safety expert) is in the v1.15 horizon, conditional on funding. See ROADMAP.md.
 

--- a/QUALITY_BAR.md
+++ b/QUALITY_BAR.md
@@ -4,7 +4,7 @@ This document specifies the **explicit, enforceable thresholds** below which Vel
 
 These gates are not aspirational. They are enforced via CI workflows, scripts, and explicit pre-merge protocols. Each gate listed here links to its enforcement mechanism so that the gate can be inspected, contested, or extended publicly.
 
-> **Last updated:** 2026-04-30 — applies to v1.14.x and onward.
+> **Last updated:** 2026-05-14 — applies to v1.14.x and onward.
 
 ---
 
@@ -89,7 +89,7 @@ These are **not the same number** as the canonical 450 µs. The README explicitl
 **Enforcement:**
 
 - **CI script:** `scripts/check_prod_unwraps.py` — runs on every push, blocks merge if non-zero.
-- **Status:** **PASSED** as of v1.13.2.
+- **Status:** **PASSED** — re-verified per push; the script exits 0 on the current workspace.
 
 **Approved alternatives** (in order of preference):
 
@@ -114,9 +114,9 @@ These are **not the same number** as the canonical 450 µs. The README explicitl
 
 **Enforcement:**
 
-- **CI script:** `scripts/verify_unsafe_safety_template.py` — runs on every push, blocks merge if any `unsafe {` is not preceded or annotated with `// SAFETY:`.
-- **Coverage:** 129 unsafe blocks workspace-wide, 431 SAFETY comments (ratio > 3:1, well-documented).
-- **Audit trail:** [`docs/SOUNDNESS.md`](docs/SOUNDNESS.md) documents invariants for every unsafe pattern in the codebase (964 lines).
+- **CI script:** `scripts/verify_unsafe_safety_template.py` — runs on every push, blocks merge if any `unsafe { … }` / `unsafe impl …` site is not preceded by a `// SAFETY:` comment.
+- **Coverage:** every unsafe site in the workspace is annotated; live counts (unsafe sites and `// SAFETY:` comments) are reported by the script in CI logs and tracked release-over-release in `CHANGELOG.md`.
+- **Audit trail:** [`docs/SOUNDNESS.md`](docs/SOUNDNESS.md) documents invariants for every unsafe pattern in the codebase.
 
 **External audit:** Planned in v1.15 horizon (Cure53 / independent Rust safety expert), conditional on funding.
 
@@ -173,7 +173,7 @@ These are tracked but do not block release because they are SIMD intrinsics bloc
 - **Local:** `npx jscpd --min-tokens 50 --reporters console --format rust crates/` — integrated in `scripts/local-ci.ps1`.
 - **Codacy Cloud:** server-side check, blocking.
 
-**Status:** Within budget across all crates as of v1.13.2.
+**Status:** enforced by Codacy Cloud on every PR; falling below the threshold blocks merge.
 
 **See also:** [`.claude/rules/no-duplication.md`](.claude/rules/no-duplication.md).
 


### PR DESCRIPTION
## Summary
Four lines were frozen at v1.13.2 while the workspace is on v1.14.4:

- `QUALITY_BAR.md` Gate 3 (no-unwrap) — `Status: PASSED as of v1.13.2`
- `QUALITY_BAR.md` Gate 4 (unsafe) — `Coverage: 129 unsafe blocks workspace-wide, 431 SAFETY comments (ratio > 3:1, …)`. **The numbers have drifted**: a manual run of `scripts/verify_unsafe_safety_template.py` matches ~161 unsafe sites today, not 129; the `> 3:1` ratio claim is similarly stale.
- `QUALITY_BAR.md` Gate 7 (duplication) — `Status: Within budget as of v1.13.2`
- `ARCHITECTURE.md` §Soundness — same `As of v1.13.2: 129 unsafe blocks, 431 SAFETY comments` literal

This PR replaces the frozen literals with pointers to the live source of truth (CI script output + `CHANGELOG.md` per-release tracking), so the lines stop going stale release-over-release. **Gate logic is unchanged** — only the wording.

Both `Last updated:` headers bumped to `2026-05-14`.

## Independent finding — NOT in this PR
While re-running `scripts/verify_unsafe_safety_template.py`, the strict-mode check reports **15 unsafe blocks** with incomplete SAFETY templates (missing condition bullets or `Reason:` line). Files: `crates/velesdb-core/src/index/hnsw/native/graph/{search_state,…}.rs` and a few others. This is a real Gate 4 strict-mode failure but it's a code fix, not a doc fix — out of scope for this PR. Tracking suggestion: separate `fix(soundness): complete SAFETY templates …` PR.

## Test plan
- [x] `grep "v1.13.2" QUALITY_BAR.md ARCHITECTURE.md` returns nothing
- [x] `python3 scripts/check_prod_unwraps.py` still exits 0 (Gate 3 status claim verified)
- [x] No threshold value changed — only narrative around stats
- [ ] Render the two files in the PR view and confirm the bullet structure is intact
