### PR TITLE
fix(soundness): complete SAFETY templates to satisfy --strict verifier

### DIFF
--- a/crates/velesdb-core/benches/scalability_benchmark.rs
+++ b/crates/velesdb-core/benches/scalability_benchmark.rs
@@ -76,7 +76,11 @@ fn get_memory_usage() -> usize {
         fn GetCurrentProcess() -> isize;
     }
 
-    // SAFETY: FFI call to Windows GetProcessMemoryInfo — struct is zeroed and cb is set correctly.
+    // SAFETY: FFI call to Windows GetProcessMemoryInfo.
+    // - ProcessMemoryCounters has no Drop and is valid byte-zero.
+    // - cb is set to the correct size before the call (Win32 contract).
+    // - GetCurrentProcess returns a pseudo-handle requiring no release.
+    // Reason: benchmark needs current process RSS.
     unsafe {
         let mut pmc = MaybeUninit::<ProcessMemoryCounters>::zeroed().assume_init();
         pmc.cb = std::mem::size_of::<ProcessMemoryCounters>() as u32;
@@ -124,6 +128,11 @@ fn get_memory_usage() -> usize {
         fn getrusage(who: i32, usage: *mut Rusage) -> i32;
     }
 
+    // SAFETY: FFI call to libc `getrusage(2)`.
+    // - Rusage matches the macOS C ABI layout above.
+    // - usage is fully zeroed via MaybeUninit::zeroed before the call.
+    // - who=0 (RUSAGE_SELF) is a valid value per the man page.
+    // Reason: benchmark needs peak RSS.
     unsafe {
         let mut usage = MaybeUninit::<Rusage>::zeroed().assume_init();
         if getrusage(0, &mut usage) == 0 {

--- a/crates/velesdb-core/src/index/hnsw/native/graph/neighbors.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/graph/neighbors.rs
@@ -36,7 +36,8 @@ impl<D: DistanceEngine> NativeHnsw<D> {
                     vectors.len()
                 );
                 // SAFETY: candidate_id < vectors.len() — verified by debug_assert above.
-                // candidate_id comes from search results (only successfully inserted nodes).
+                // - candidate_id comes from search results (only successfully inserted nodes).
+                // Reason: neighbor-selection hot path; bounds check elided after assert.
                 let candidate_vec = unsafe { vectors.get_unchecked(candidate_id) };
 
                 let is_diverse = selected.iter().all(|&selected_id| {
@@ -46,6 +47,8 @@ impl<D: DistanceEngine> NativeHnsw<D> {
                         vectors.len()
                     );
                     // SAFETY: selected_id < vectors.len() — verified by debug_assert above.
+                    // - selected_id was previously inserted via the same code path as candidate_id.
+                    // Reason: diversity inner loop; bounds check elided after assert.
                     let selected_vec = unsafe { vectors.get_unchecked(selected_id) };
                     let dist_to_selected = self.distance.distance(candidate_vec, selected_vec);
                     self.alpha * candidate_dist <= dist_to_selected
@@ -136,6 +139,8 @@ impl<D: DistanceEngine> NativeHnsw<D> {
             vectors.len()
         );
         // SAFETY: neighbor < vectors.len() — verified by debug_assert above.
+        // - neighbor is a NodeId already returned by the layer's neighbor list.
+        // Reason: backward-connection write path; bounds check elided after assert.
         let neighbor_vec = unsafe { vectors.get_unchecked(neighbor) };
 
         let _ = layers[layer].with_neighbors_mut(neighbor, |neighbors| {
@@ -154,6 +159,8 @@ impl<D: DistanceEngine> NativeHnsw<D> {
                 vectors.len()
             );
             // SAFETY: new_node < vectors.len() — verified by debug_assert above.
+            // - new_node was just inserted into the vectors store by the caller.
+            // Reason: pruning loop distance computation.
             let new_node_vec = unsafe { vectors.get_unchecked(new_node) };
             let new_dist = self.distance.distance(neighbor_vec, new_node_vec);
 
@@ -183,6 +190,8 @@ impl<D: DistanceEngine> NativeHnsw<D> {
             vectors.len()
         );
         // SAFETY: new_node < vectors.len() — verified by debug_assert above.
+        // - new_node was just inserted into the vectors store by the caller.
+        // Reason: anchor distance for redundancy eviction.
         let new_vec = unsafe { vectors.get_unchecked(new_node) };
 
         let mut worst_idx = 0;
@@ -197,6 +206,8 @@ impl<D: DistanceEngine> NativeHnsw<D> {
                 vectors.len()
             );
             // SAFETY: n < vectors.len() — verified by debug_assert above.
+            // - n iterates over an existing neighbor list whose entries were inserted previously.
+            // Reason: O(M) eviction scan inner loop.
             let n_vec = unsafe { vectors.get_unchecked(n) };
             let d_to_anchor = self.distance.distance(anchor_vec, n_vec);
             let d_to_new = self.distance.distance(new_vec, n_vec);

--- a/crates/velesdb-core/src/index/hnsw/native/graph/search_state.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/graph/search_state.rs
@@ -188,6 +188,9 @@ pub(super) fn gather_unvisited_neighbors<'a>(
                 vectors.len()
             );
             // SAFETY: neighbor < vectors.len() — verified by debug_assert above.
+            // - neighbor was just inserted into `visited` after originating from
+            //   a layer neighbor list, so it is a valid NodeId already in storage.
+            // Reason: per-iteration distance batch accumulation.
             let vec = unsafe { vectors.get_unchecked(neighbor) };
             batch.push((neighbor, vec));
         }

--- a/crates/velesdb-core/src/index/hnsw/native/tests.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/tests.rs
@@ -1062,6 +1062,8 @@ fn test_backward_pruning_preserves_diversity_across_clusters() {
         let mut clusters_seen = std::collections::HashSet::new();
         for &n in &neighbors {
             // SAFETY: test code — all node IDs were just inserted.
+            // - n iterates over `neighbors`, populated from this test's own inserts.
+            // Reason: mirror production indexing style.
             let vec = unsafe { vectors.get_unchecked(n) };
             let cluster_id = vec[..4]
                 .iter()

--- a/crates/velesdb-core/src/storage/compaction_tests.rs
+++ b/crates/velesdb-core/src/storage/compaction_tests.rs
@@ -422,6 +422,9 @@ fn build_context_parts(
     data_file.set_len(file_size)?;
 
     // SAFETY: File is open read/write and sized via set_len.
+    // - data_file was just opened with `.write(true).create(true)`.
+    // - set_len(file_size) succeeded above, so the file has the expected length.
+    // Reason: exclusive access to a temp file for the block's lifetime.
     let mut mmap = unsafe { MmapMut::map_mut(&data_file)? };
 
     let index = ShardedIndex::new();

--- a/crates/velesdb-migrate/tests/metric_fidelity_wiremock.rs
+++ b/crates/velesdb-migrate/tests/metric_fidelity_wiremock.rs
@@ -31,9 +31,11 @@ use wiremock::{Mock, MockServer, ResponseTemplate};
 /// Starts a wiremock server and opts the test process into the
 /// SSRF escape hatch so `validate_url` accepts the loopback URL.
 async fn start_mock_server() -> MockServer {
-    // SAFETY: set_var is unsafe on newer Rust editions because it is
-    // not thread-safe. These integration tests run under
-    // --test-threads=1, so no other thread can observe the store.
+    // SAFETY: set_var is `unsafe` (env mutation is not thread-safe).
+    // - Integration tests run under `cargo test -- --test-threads=1`
+    //   (CONTRIBUTING.md §"Concurrency Rules").
+    // - No other thread reads the variable between this write and the wiremock start.
+    // Reason: enable the SSRF escape hatch for wiremock's loopback URL.
     unsafe {
         std::env::set_var("VELESDB_MIGRATE_ALLOW_PRIVATE_NETWORKS", "1");
     }

--- a/crates/velesdb-migrate/tests/pipeline_e2e.rs
+++ b/crates/velesdb-migrate/tests/pipeline_e2e.rs
@@ -25,10 +25,11 @@ use wiremock::{Mock, MockServer, ResponseTemplate};
 /// variable once per process — tests in this file run single-threaded
 /// under `cargo test -- --test-threads=1`, so there is no race.
 async fn start_mock_server() -> MockServer {
-    // SAFETY: set_var is `unsafe` on newer Rust editions because setting
-    // environment variables is not thread-safe. These integration tests
-    // run under `--test-threads=1`, so no other thread can observe an
-    // inconsistent state.
+    // SAFETY: set_var is `unsafe` (env mutation is not thread-safe).
+    // - Integration tests run under `cargo test -- --test-threads=1`
+    //   (CONTRIBUTING.md §"Concurrency Rules").
+    // - No other thread reads the variable between this write and the wiremock start.
+    // Reason: enable the SSRF escape hatch for wiremock's loopback URL.
     unsafe {
         std::env::set_var("VELESDB_MIGRATE_ALLOW_PRIVATE_NETWORKS", "1");
     }

--- a/crates/velesdb-python/src/database.rs
+++ b/crates/velesdb-python/src/database.rs
@@ -256,13 +256,12 @@ impl Database {
                 // raising — the typed split is tracked as a post-seed
                 // EPIC in docs/ARCHITECTURE.md.
                 //
-                // SAFETY: Python SDK intentionally exposes a single
-                // Collection facade over all variants. Only the shared
-                // surface (config, flush, diagnostics, execute_query_str,
-                // etc.) is guaranteed correct on non-Vector variants; the
-                // Python wrapper and BDD tests cover that contract. See
-                // `AnyCollection::into_vector_unchecked` for full caller
-                // obligations.
+                // SAFETY: Python SDK exposes a single Collection facade over all variants.
+                // - any_coll comes from `get_any_collection`, returned Some, so the
+                //   underlying `AnyCollection` is registered and valid.
+                // - Only the shared surface is guaranteed correct on non-Vector variants;
+                //   vector-only methods return empty results by design.
+                // Reason: single-Collection Python ergonomic facade.
                 let vc = unsafe { any_coll.into_vector_unchecked() };
                 Ok(Some(Collection::new(vc, name.to_string())))
             }
@@ -332,10 +331,12 @@ impl Database {
             .inner
             .get_any_collection(&name_owned)
             .ok_or_else(|| PyRuntimeError::new_err("Collection not found after creation"))?;
-        // SAFETY: Python SDK intentionally wraps the freshly-created metadata
-        // collection in the single `Collection` facade. Only the shared
-        // surface is exercised on metadata variants. See
-        // `AnyCollection::into_vector_unchecked` for full caller obligations.
+        // SAFETY: Python SDK wraps the freshly-created metadata collection in the
+        // single Collection facade (mirrors `get_collection` above).
+        // - any was just registered by `create_metadata_collection` and retrieved
+        //   via `get_any_collection`, so it is a valid registered handle.
+        // - Only the shared surface is exercised on metadata variants.
+        // Reason: single-Collection Python ergonomic facade.
         let collection = unsafe { any.into_vector_unchecked() };
 
         Ok(Collection::new(collection, name_owned))


### PR DESCRIPTION
## Summary

\`scripts/verify_unsafe_safety_template.py --strict\` was failing on **15 unsafe sites** across 8 files where the SAFETY comment had only a single-line header and was missing the canonical template structure (condition bullets + Reason line).

This PR adds `// - <condition>` bullets and a terse `// Reason: <why>` line to each site so the strict verifier passes workspace-wide.

## Diff scope

- \`crates/velesdb-core/src/index/hnsw/native/graph/neighbors.rs\` — 6 sites (neighbor selection + back-connection + redundancy eviction hot paths)
- \`crates/velesdb-core/src/index/hnsw/native/graph/search_state.rs\` — 1 site (per-iteration batch accumulation)
- \`crates/velesdb-core/src/index/hnsw/native/tests.rs\` — 1 site (test mirror of production indexing style)
- \`crates/velesdb-core/src/storage/compaction_tests.rs\` — 1 site (memmap2 on temp file)
- \`crates/velesdb-core/benches/scalability_benchmark.rs\` — 2 sites (Windows GetProcessMemoryInfo + macOS getrusage FFI)
- \`crates/velesdb-python/src/database.rs\` — 2 sites (\`AnyCollection::into_vector_unchecked\` facade)
- \`crates/velesdb-migrate/tests/pipeline_e2e.rs\`, \`tests/metric_fidelity_wiremock.rs\` — 1 site each (\`std::env::set_var\` under \`--test-threads=1\`)

## Why a terse template

The verifier's bullet regex is \`//\\s*(?:-\\s+|\\*\\s+|\\d+\\.\\s+)\\w+\`, so bullets must start with a word character (no leading backtick).  Bullets restate the invariant; the Reason line gives the *why* in one line — long Reason narratives are not safety information and belong in the surrounding non-SAFETY doc comment.

## Verification

\`\`\`
python3 scripts/verify_unsafe_safety_template.py --files <992 files>
→ PASSED: All unsafe blocks have complete SAFETY documentation
\`\`\`

No behaviour change — comment-only edits.

## Test plan

- [x] \`scripts/verify_unsafe_safety_template.py --files <all .rs>\` exits 0
- [ ] CI \`Lint & Format\` passes (rustfmt + clippy pedantic are unaffected by comment edits)
- [ ] CI \`Tests\` passes (no logic change)
- [ ] CI \`Codacy\` passes
