### PR TITLE
refactor(query-cost): make CboFeedbackLoop crate-internal

### DIFF
--- a/crates/velesdb-core/src/collection/query_cost/feedback.rs
+++ b/crates/velesdb-core/src/collection/query_cost/feedback.rs
@@ -45,8 +45,11 @@ const MAX_MS_PER_UNIT: f64 = 50.0;
 const SCALE: f64 = 1_000_000.0;
 
 /// Lock-free EMA-based feedback loop for CBO cost-unit calibration.
+///
+/// Crate-internal: instantiated by [`crate::velesql::planner::QueryPlanner`] and
+/// fed by the query pipeline. Not part of the public crate API.
 #[derive(Debug, Default)]
-pub struct CboFeedbackLoop {
+pub(crate) struct CboFeedbackLoop {
     /// EMA of observed ms-per-cost-unit (stored as u64 = value × SCALE).
     ema_scaled: AtomicU64,
     /// Total samples recorded.
@@ -56,7 +59,7 @@ pub struct CboFeedbackLoop {
 impl CboFeedbackLoop {
     /// Creates a new, empty feedback loop.
     #[must_use]
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self::default()
     }
 
@@ -65,7 +68,7 @@ impl CboFeedbackLoop {
     /// `dataset_size` — number of indexed vectors (used to estimate cost).
     /// `ef_search`    — effective ef_search used for this query.
     /// `actual_ms`    — wall-clock duration of the query in milliseconds.
-    pub fn record(&self, dataset_size: usize, ef_search: usize, actual_ms: f64) {
+    pub(crate) fn record(&self, dataset_size: usize, ef_search: usize, actual_ms: f64) {
         if actual_ms <= 0.0 || dataset_size == 0 {
             return;
         }
@@ -95,7 +98,7 @@ impl CboFeedbackLoop {
     /// Returns `None` until at least [`MIN_SAMPLES`] observations have been
     /// recorded, so the planner falls back to the static default during warm-up.
     #[must_use]
-    pub fn adjusted_ms_per_cost_unit(&self) -> Option<f64> {
+    pub(crate) fn adjusted_ms_per_cost_unit(&self) -> Option<f64> {
         if self.sample_count.load(Ordering::Relaxed) < MIN_SAMPLES {
             return None;
         }
@@ -109,13 +112,14 @@ impl CboFeedbackLoop {
 
     /// Returns the total number of samples recorded.
     #[must_use]
-    pub fn sample_count(&self) -> u64 {
+    pub(crate) fn sample_count(&self) -> u64 {
         self.sample_count.load(Ordering::Relaxed)
     }
 
-    /// Returns the current EMA value (for monitoring/EXPLAIN).
+    /// Returns the current EMA value (used internally for outlier rejection and
+    /// surfaced via [`Self::adjusted_ms_per_cost_unit`]).
     #[must_use]
-    pub fn current_ema(&self) -> f64 {
+    fn current_ema(&self) -> f64 {
         // u64 → f64: values are bounded by MAX_MS_PER_UNIT × SCALE = 50_000_000,
         // well within f64's exact integer range (2^53 ≈ 9 × 10^15).
         #[allow(clippy::cast_precision_loss)]

--- a/crates/velesdb-core/src/collection/query_cost/mod.rs
+++ b/crates/velesdb-core/src/collection/query_cost/mod.rs
@@ -42,7 +42,7 @@ use std::fmt;
 pub mod calibration;
 pub mod cost_factors;
 pub mod cost_model;
-pub mod feedback;
+pub(crate) mod feedback;
 pub mod plan_generator;
 pub mod query_executor;
 
@@ -52,7 +52,7 @@ mod plan_generator_tests;
 mod tests;
 
 pub use cost_model::{CostEstimator, OperationCost, OperationCostFactors};
-pub use feedback::CboFeedbackLoop;
+pub(crate) use feedback::CboFeedbackLoop;
 pub use plan_generator::{CandidatePlan, PlanGenerator, QueryCharacteristics};
 pub use query_executor::{ExecutionContext, PlanCache, QueryOptimizer};
 


### PR DESCRIPTION
## Summary

Addresses the 3 `UnusedCode` medium findings reported by Codacy on PR #783.

`CboFeedbackLoop` and its public methods were declared `pub` but have **no external consumer** — they are only used by `crate::velesql::planner::QueryPlanner` (which constructs the loop) and `crate::collection::search::query::query_pipeline` (which calls `record_cbo_feedback` on the planner). The visibility advertised did not match the actual API surface.

## Changes

| Item | Before | After |
|---|---|---|
| `pub mod feedback` | `pub` | `pub(crate)` |
| `pub struct CboFeedbackLoop` | `pub` | `pub(crate)` |
| `pub fn new` | `pub` | `pub(crate)` |
| `pub fn record` | `pub` | `pub(crate)` |
| `pub fn adjusted_ms_per_cost_unit` | `pub` | `pub(crate)` |
| `pub fn sample_count` | `pub` | `pub(crate)` |
| `pub fn current_ema` | `pub` | private (only used inside feedback.rs + tests) |
| `pub use feedback::CboFeedbackLoop` (mod.rs) | `pub use` | `pub(crate) use` |

Plus an intra-doc link normalised to `[Self::adjusted_ms_per_cost_unit]`.

## Why

- **No behaviour change.** Pure visibility tightening; the calibration logic is untouched.
- **No external callers exist** — verified by grepping `velesdb_core::collection::query_cost::` across `crates/velesdb-server`, `velesdb-python`, `velesdb-cli`, `velesdb-wasm`, `velesdb-mobile`, `velesdb-migrate`, `sdks/`, `examples/`, `benchmarks/` (zero hits).
- Brings Codacy from \"3 medium UnusedCode\" → 0 on the affected items.

## Out of scope (follow-up candidate)

The same pattern (\"`pub use` re-export with zero external consumer\") applies to several siblings in `query_cost/mod.rs` (`CostEstimator`, `PlanGenerator`, `QueryOptimizer`, …). Tightening them is a larger refactor and is deliberately not bundled here — see the simplify agent finding labelled \"out of scope\".

## Test plan

- [x] `cargo check -p velesdb-core --features persistence` exits 0
- [ ] CI \`Lint & Format\` (rustfmt + clippy pedantic) passes
- [ ] CI \`Tests\` passes (no logic change)
- [ ] Codacy reports 0 UnusedCode findings on this PR
