### PR TITLE
docs(roadmap): consolidate deferred hardware-accelerator backlog (closes #689)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,7 +4,7 @@ This roadmap commits to **what we are building**, **why**, and **when**. It is u
 
 It is intentionally narrow. Items not on this roadmap are tracked as `roadmap` issues but **not committed** until they reach a milestone here.
 
-> **Last updated:** 2026-05-01 — covers v1.14.4 (current) → v1.16.0 horizon.
+> **Last updated:** 2026-05-14 — covers v1.14.4 (current) → v1.16.0 horizon.
 
 ---
 
@@ -62,7 +62,30 @@ By v1.16 we want VelesDB to be deployable in production at small-team scale (5-5
 - **Distributed replication** (Raft) — premium, long horizon
 - **Query result caching with auth tags** — premium
 
-The deferred [Hardware Accelerator backlog (#689)](https://github.com/cyberlife-coder/VelesDB/issues/689) (CUDA, AVX-512-VNNI, SVE, FP16, etc.) will be re-evaluated at this horizon based on customer requests.
+The [Deferred — Hardware accelerator backlog](#deferred--hardware-accelerator-backlog) will be re-evaluated at this horizon based on customer requests.
+
+---
+
+## Deferred — Hardware accelerator backlog
+
+SIMD and GPU items that are part of the long-term roadmap but **explicitly on hold** until VelesDB has clearer signal on hardware-target priorities (cloud GPUs vs ARM vs legacy x86). Consolidated from individual issues during the 2026-04-27 pre-seed audit to keep the active roadmap visible vs the long-tail wishlist.
+
+| Item | Rationale to defer |
+|------|-------------------|
+| `perf(gpu)`: CUDA/cuBLAS backend for NVIDIA GPUs | Existing wgpu pipeline (PR #626) covers cross-vendor GPU; CUDA-specific only valuable for NVIDIA-tied datacenter customers, defer until first such request |
+| `perf(simd)`: SSE4.2 fallback kernels for legacy x86_64 | AVX2 covers ~99% of CPUs from 2013+, SSE4.2-only fallback ROI is minimal |
+| `perf(simd)`: FP16 native SIMD kernels (AVX-512FP16, NEON fp16) | Niche compute; SQ8 quantization already covers most memory-bound use cases |
+| `perf(gpu)`: batch Hamming & Jaccard distance compute shaders (WGSL) | Existing GPU SONG pipeline covers L2/cosine; binary metrics defer until user demand |
+| `perf(simd)`: AVX-512-VNNI kernels for INT8 quantized distance | Niche; SQ8 + AVX2 already gives 4× compression at acceptable speed |
+| `perf(gpu)`: async CPU/GPU pipelining with double buffering | Optimization on existing GPU path; defer until profiling shows it as a top bottleneck |
+| `perf(simd)`: SVE kernels for AWS Graviton3/4 | NEON covers ARM today; SVE valuable only for AWS-Graviton-specific workloads |
+
+**Re-activation criteria** — any of:
+- A paying customer / design partner requests a specific item
+- Profiling on a real workload identifies one as a top-3 bottleneck
+- A community contributor opens a draft PR for one
+
+**What is NOT deferred** (already shipped in v1.13.x): AVX-512 / AVX2 / NEON kernels for f32/f16 cosine·dot·euclidean, WASM SIMD128, GPU SONG 3-stage pipeline (PR #626), GPU `search_auto` wiring (PR #638). Current SIMD coverage matrix in [`docs/reference/NATIVE_HNSW.md`](docs/reference/NATIVE_HNSW.md).
 
 ---
 


### PR DESCRIPTION
## Summary
- Moves the 7 deferred SIMD/GPU items from tracking issue #689 into a dedicated `## Deferred — Hardware accelerator backlog` section in `ROADMAP.md`, including the rationale per item, re-activation criteria, and the explicit "what is NOT deferred" boundary that links to `docs/reference/NATIVE_HNSW.md`.
- Updates the Horizon 3 reference from the GitHub issue link to the new local anchor and trims the redundant `(CUDA, AVX-512-VNNI, SVE, FP16, etc.)` tease since the dedicated section now lives right below.
- Bumps the `Last updated:` header to today.

## Why
Tracking issue #689 was created during the 2026-04-27 pre-seed audit purely to consolidate 7 individual deferred-HW issues (#498, #499, #500, #501, #503, #504, #505 — all closed). Its content is more discoverable and version-controlled in `ROADMAP.md`. Closing #689 once this lands removes a meta-issue from the open list without losing the deferred-roadmap signal.

## Test plan
- [x] Manual review of `ROADMAP.md` rendering in GitHub preview
- [x] Anchor `#deferred--hardware-accelerator-backlog` resolves from the Horizon 3 reference (verified GFM slug generation)
- [x] PRs #626 and #638 (referenced in the new section) are MERGED — confirmed via `gh pr view`
- [x] `docs/reference/NATIVE_HNSW.md` exists at the linked path
- [x] `/simplify` reviewed (3 agents): no broken links, no anchor collisions, one redundancy fixed (the parenthetical tease)

Closes #689.
