### PR TITLE
docs(sdk/ts): clarify sparseIndexName vs sparseSearchNamed usage

### DIFF
--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -430,6 +430,37 @@ const results = await db.multiQuerySearch('docs', [emb1, emb2], {
 
 > **Note:** WASM supports `rrf`, `average`, `maximum`. The `weighted` and `relative_score` strategies are REST-only.
 
+#### Named sparse indexes — `sparseIndexName` vs `sparseSearchNamed()`
+
+A collection can carry multiple sparse indexes (e.g. `splade_v2`, `bm25_titles`). The TypeScript SDK exposes two distinct APIs depending on whether you want a dense + sparse hybrid query or a pure sparse query against a named index.
+
+| API | Shape | Use when |
+|---|---|---|
+| `db.search(coll, denseVec, { sparseVector, sparseIndexName })` | dense + sparse hybrid against the named sparse index | You already have a dense embedding and want to combine it with a specific named sparse index in a single search call. The dense vector drives the primary candidate set; the named sparse index re-ranks. |
+| `db.sparseSearchNamed(coll, sparseVec, indexName, options?)` | pure sparse against a named index | You have only a sparse vector (e.g. SPLADE expansion, lexical query) and want to query a specific named sparse index directly. No dense component. |
+
+```typescript
+// Hybrid: dense + sparse via the splade_v2 named index
+const hybrid = await db.search('docs', denseEmbedding, {
+  k: 10,
+  sparseVector: { 42: 0.8, 99: 0.3 },
+  sparseIndexName: 'splade_v2',
+});
+
+// Pure sparse against the same named index
+const sparseOnly = await db.sparseSearchNamed(
+  'docs',
+  { 42: 0.8, 99: 0.3 },
+  'splade_v2',
+  { k: 10 },
+);
+```
+
+When the collection has only one (default) sparse index, omit `sparseIndexName` on `db.search()`; the server picks the default. For named indexes, both APIs require the explicit name.
+
+> **Note:** Both APIs are REST-only when a named index is required.
+> The WASM backend has no concept of named sparse indexes — `sparseIndexName` is silently ignored on `db.search()` (the collection's single sparse index is used), and `db.sparseSearchNamed()` throws `wasmNotSupported`. Tracked as a follow-up to either surface a `wasmNotSupported` throw on `sparseIndexName` or implement named-sparse support in WASM.
+
 ---
 
 ### Collection Utilities

--- a/sdks/typescript/src/client.ts
+++ b/sdks/typescript/src/client.ts
@@ -231,6 +231,12 @@ export class VelesDB {
     return searchMethods.multiQuerySearch(this.backend, collection, vectors, options);
   }
 
+  /**
+   * Pure sparse search against a named sparse index.
+   *
+   * @see {@link SparseSearchNamedOptions} for the full pure-sparse vs hybrid comparison.
+   * @see {@link VelesDB.search} for dense + sparse hybrid against a named index.
+   */
   async sparseSearchNamed(collection: string, query: SparseVector, indexName: string, options?: SparseSearchNamedOptions): Promise<SearchResult[]> {
     this.ensureInitialized();
     return searchMethods.sparseSearchNamed(this.backend, collection, query, indexName, options);

--- a/sdks/typescript/src/client/search-methods.ts
+++ b/sdks/typescript/src/client/search-methods.ts
@@ -100,10 +100,12 @@ export function hybridSearch(
 }
 
 /**
- * Search a named sparse index (issue #380).
+ * Pure sparse search against a named sparse index (issue #380).
  *
  * Parity with `Collection::sparse_search_named()` in the Rust core.
- * Optionally accepts a dense vector for hybrid sparse+dense named search.
+ *
+ * @see {@link SparseSearchNamedOptions} for the full pure-sparse vs hybrid comparison.
+ * @see {@link VelesDB.search} for dense + sparse hybrid against a named index.
  */
 export function sparseSearchNamed(
   backend: IVelesDBBackend,

--- a/sdks/typescript/src/types/search.ts
+++ b/sdks/typescript/src/types/search.ts
@@ -8,7 +8,20 @@
 import type { FilterInput } from '../filter';
 import type { SearchQuality, SparseVector } from './core';
 
-/** Options for named sparse index search (issue #380). */
+/**
+ * Options for `db.sparseSearchNamed()` — **pure sparse** query against a
+ * named sparse index (issue #380).
+ *
+ * Use this when you have only a sparse vector and want to query a specific
+ * named sparse index directly. The query carries no dense component.
+ *
+ * For **dense + sparse hybrid** against a named index, use
+ * `db.search(..., { sparseVector, sparseIndexName })` instead
+ * (see {@link SearchOptions.sparseIndexName}).
+ *
+ * **Backend support:** REST only. The WASM backend has no concept of named
+ * sparse indexes; this method throws `wasmNotSupported` on WASM.
+ */
 export interface SparseSearchNamedOptions {
   /** Number of results to return (default: 10) */
   k?: number;
@@ -31,8 +44,15 @@ export interface SearchOptions {
   /** Optional sparse vector for hybrid sparse+dense search */
   sparseVector?: SparseVector;
   /**
-   * Named sparse index to query (when the collection has multiple sparse indexes).
-   * When omitted the default sparse index is used.
+   * Named sparse index to combine with the dense query for **hybrid** search
+   * (when the collection has multiple sparse indexes). When omitted, the
+   * default sparse index is used.
+   *
+   * For a **pure sparse** query against a named index (no dense vector),
+   * call `db.sparseSearchNamed()` instead — see {@link SparseSearchNamedOptions}.
+   *
+   * **Backend support:** REST only. The WASM backend silently ignores this
+   * field and uses the collection's single sparse index regardless.
    */
   sparseIndexName?: string;
   /** Search quality preset (default: 'balanced'). */


### PR DESCRIPTION
## Summary

#779 added `sparseIndexName` (dense + sparse hybrid against a named sparse index) and #783 added `sparseSearchNamed()` (pure sparse against a named index). Both close issue #380 but the two APIs are **not duplicates** — they serve different query shapes. Without inline guidance, TS SDK users picked the wrong one or assumed one superseded the other.

## Changes

| File | Edit |
|---|---|
| `sdks/typescript/README.md` | New subsection \"Named sparse indexes\" under Multi-Query Search with a comparison table and side-by-side example. |
| `src/types/search.ts` | JSDoc on `SparseSearchNamedOptions` and `SearchOptions.sparseIndexName` cross-link to each other and both include a **Backend support** note. |
| `src/client/search-methods.ts` | JSDoc on standalone `sparseSearchNamed()` shortened to one sentence + `@see {@link SparseSearchNamedOptions}` and `@see {@link VelesDB.search}`. |
| `src/client.ts` | JSDoc on `VelesDB.sparseSearchNamed()` mirrors the standalone shape. |

No behaviour change — documentation only.

## Correction from simplify pass

The first draft of the README incorrectly claimed *\"WASM backend: `sparseIndexName` on `db.search()` is supported\"*.  Verified against `sdks/typescript/src/backends/wasm-search.ts` — the WASM `search()` path **does not** forward `sparseIndexName` to the WASM bindings.  Corrected to:

> WASM has no concept of named sparse indexes — `sparseIndexName` is silently ignored on `db.search()`, and `db.sparseSearchNamed()` throws `wasmNotSupported`.

Tracked as a separate follow-up: either surface a `wasmNotSupported` throw on `sparseIndexName` in WASM or implement named-sparse there.

## Test plan

- [x] `npx tsc --noEmit` passes (JSDoc-only edits, no TS surface change)
- [ ] CI `TypeScript SDK Check` passes
- [ ] Markdown renders correctly in the GitHub PR view
