### PR TITLE
docs(agent-memory): document ACT-R decay + DiminishingReturns + CompositeStrategy (closes #433)

### DIFF
--- a/docs/guides/AGENT_MEMORY.md
+++ b/docs/guides/AGENT_MEMORY.md
@@ -525,7 +525,7 @@ Each `.vamm` file contains:
 
 ## Reinforcement Strategies
 
-Procedural memory confidence scores can be updated with 4 strategies:
+Procedural memory confidence scores can be updated with one of six strategies:
 
 | Strategy | Behavior | Best For |
 |----------|----------|----------|
@@ -533,6 +533,8 @@ Procedural memory confidence scores can be updated with 4 strategies:
 | **AdaptiveLearningRate** | Learning rate decays with usage | Stable procedures |
 | **TemporalDecay** | Confidence decays over time (30-day half-life) | Perishable knowledge |
 | **ContextualReinforcement** | Mix: 30% success rate + 30% usage + 40% recency | Sophisticated evaluation |
+| **DiminishingReturns** | `delta = base / (1 + k · count)` — early reinforcements weigh more than later ones (Rescorla-Wagner 1972; ACT-R Phase 2) | Fast convergence on novel procedures |
+| **CompositeStrategy** | Weighted average of any combination of the strategies above | Tuning a custom blend |
 
 The default strategy is `FixedRate`. Advanced strategies are available via the Rust API:
 
@@ -542,6 +544,39 @@ use velesdb_core::agent::reinforcement::AdaptiveLearningRate;
 let strategy = AdaptiveLearningRate::new(0.1, 10); // lr=0.1, half-life=10 uses
 memory.procedural().reinforce_with_strategy(proc_id, true, &strategy)?;
 ```
+
+```rust
+use velesdb_core::agent::reinforcement::{CompositeStrategy, FixedRate, TemporalDecay};
+
+// 70% fixed-rate + 30% temporal decay
+let strategy = CompositeStrategy::new()
+    .add_strategy(FixedRate::default(), 0.7)
+    .add_strategy(TemporalDecay::new(30), 0.3);
+memory.procedural().reinforce_with_strategy(proc_id, true, &strategy)?;
+```
+
+### Apply activation decay at recall time
+
+Procedural memory also supports **base-level activation decay** (ACT-R
+Phase 1, Anderson 1996): the confidence returned by `recall()` is
+multiplied by `max(1, t_days)^(-d)` where `t_days` is days since the
+procedure was last reinforced and `d` is the decay exponent (≈ 0.5 in
+ACT-R). The stored confidence is **not** modified — decay is a
+read-side modulation only.
+
+```rust
+use velesdb_core::agent::ProceduralMemory;
+
+let procedural = ProceduralMemory::new_from_db(db, 384)?
+    .with_activation_decay(0.5);
+let matches = procedural.recall(&query_emb, 5, 0.3)?;
+// matches[i].confidence reflects passive decay; storage is untouched.
+```
+
+Decay is opt-in (`None` by default), so existing data and behaviour are
+backward-compatible. The knob is Rust-only today; the Python and
+TypeScript bindings expose the rest of the procedural API but not the
+decay setting yet.
 
 ---
 


### PR DESCRIPTION
## Summary
Brings `docs/guides/AGENT_MEMORY.md` in sync with the procedural-memory work that shipped in [#780](https://github.com/cyberlife-coder/VelesDB/pull/780) but never made it to the user-facing guide.

- **Reinforcement strategies table**: was 4 rows, now 6 — adds `DiminishingReturns` (`delta = base / (1 + k · count)`, Rescorla-Wagner 1972 / ACT-R Phase 2) and `CompositeStrategy` (weighted blend).
- **CompositeStrategy snippet**: 70% FixedRate + 30% TemporalDecay example.
- **New subsection** "Apply activation decay at recall time" — documents `ProceduralMemory::with_activation_decay()`, the ACT-R Phase 1 base-level power-law decay (`max(1, t_days)^(-d)`, Anderson 1996, d ≈ 0.5), the read-only-at-recall semantics, the opt-in default, and the Rust-only binding gap.

## Why
Issue #433 asked for ACT-R-inspired procedural learning in three phases. Phases 1 (decay) and 2 (Rescorla-Wagner diminishing returns) **already landed** via PR #780 (commit `cedf234e`), but the guide still listed only the four pre-existing strategies and made no mention of the decay knob — so the issue stayed open even though most of the work was done. This PR closes that loop.

Phase 3 (cross-memory spreading activation, explicitly labelled "experimental" in the original issue) is **not** addressed here — it needs its own API design pass and is scoped out for a future ticket.

## Test plan
- [x] All formulas cross-checked against \`crates/velesdb-core/src/agent/reinforcement.rs\` (\`power_law_decay\` line 537, \`DiminishingReturns::effective_delta\` line 482, \`CompositeStrategy::update_confidence\` lines 408–433) and \`procedural_memory.rs\` (\`with_activation_decay\` line 161, clamp range \`[0.0, 2.0]\`)
- [x] Citations verified — Rescorla-Wagner 1972 for DiminishingReturns (matches the code comment at \`reinforcement.rs:440\`), Anderson 1996 for activation decay
- [x] Python + TS binding gap verified via grep — \`with_activation_decay\` is not exposed
- [x] \`/simplify\` reviewed (3 agents): citation corrected (was misattributed to Anderson), heading rewritten to verb-form to match the rest of the file, redundant lead-in trimmed

Closes #433.
