### PR TITLE
fix(sdk/ts): ignoreDeprecations 6.0 to unblock npm publish under TS 6.0

### DIFF
--- a/sdks/typescript/tsconfig.json
+++ b/sdks/typescript/tsconfig.json
@@ -19,7 +19,8 @@
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedIndexedAccess": true,
-    "types": ["node"]
+    "types": ["node"],
+    "ignoreDeprecations": "6.0"
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist", "tests"]


### PR DESCRIPTION
## Why

[Release run 25873694101](https://github.com/cyberlife-coder/VelesDB/actions/runs/25873694101) for **v1.15.0** had the \`Publish npm typescript-sdk\` job fail on \`npm run build\` with:

\`\`\`
error TS5101: Option 'baseUrl' is deprecated and will stop functioning in
TypeScript 7.0. Specify compilerOption '"ignoreDeprecations": "6.0"' to silence
this error.
\`\`\`

TypeScript 6.0 (bumped from 5.9 in #748) emits a hard error on the implicit \`baseUrl\` that \`moduleResolution: "bundler"\` carries. The error is fatal to \`tsup --dts\`. Other publish targets (crates.io, PyPI wheels, PyPI common, PyPI pure, npm tauri-plugin, npm wasm, GitHub Release) all succeeded — only the typescript-sdk npm package is now lagging at 1.14.4 while every other artefact is 1.15.0.

## Fix

One-line addition to \`sdks/typescript/tsconfig.json\`:

\`\`\`json
\"ignoreDeprecations\": \"6.0\"
\`\`\`

Verified locally: \`npm run build\` → CJS ✅ + ESM ✅ + DTS ✅.

To be revisited when bumping to TypeScript 7.x (the option must be removed AND any actual \`baseUrl\` usage migrated to a \`paths\`-equivalent).

## Why CI didn't catch this on PR #783 / #748

The CI \`TypeScript SDK Check\` workflow runs \`npm test\` (vitest), not \`npm run build\` — so the DTS path is never exercised in CI. The error only manifests on \`release.yml\`'s pre-publish build.

A separate follow-up should add \`npm run build\` to the TypeScript SDK CI gate to catch this class of regression earlier.

## Post-merge action plan

1. Wait for CI green on main HEAD after merge
2. Trigger \`release.yml\` via \`workflow_dispatch\`:
   - \`version: 1.15.0\`
   - \`publish_npm: true\`
   - \`publish_pypi: false\` (already published)
   - \`publish_crates: false\` (already published)
   - \`publish_binaries: false\` (already on GitHub Release)
   - \`publish_github: false\` (already done)
3. The typescript-sdk publish runs, finds 1.15.0 not yet on npm, publishes it. Other targets skip via "already published" guards.
4. Verify on https://www.npmjs.com/package/@wiscale/velesdb → 1.15.0

## Out of scope

- The CI gap that let this slip past (separate PR)
- Bumping to TypeScript 7.x (planned for v1.16 line)