### PR TITLE
ci(propagation-guard): build examples/react-wasm-search and examples/node-express-rag in smoke

### DIFF
--- a/.github/workflows/propagation-guard.yml
+++ b/.github/workflows/propagation-guard.yml
@@ -215,6 +215,8 @@ jobs:
           cache-dependency-path: |
             demos/tauri-rag-app/package-lock.json
             sdks/typescript/package-lock.json
+            examples/react-wasm-search/package-lock.json
+            examples/node-express-rag/package-lock.json
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - name: Rust examples compile smoke
         run: cargo check --manifest-path examples/rust/Cargo.toml
@@ -227,6 +229,16 @@ jobs:
           python -m py_compile integrations/haystack/examples/rag_pipeline.py
       - name: Tauri demo frontend build smoke
         working-directory: demos/tauri-rag-app
+        run: |
+          npm ci
+          npm run build
+      - name: React WASM example build smoke
+        working-directory: examples/react-wasm-search
+        run: |
+          npm ci
+          npm run build
+      - name: Node Express RAG example typecheck smoke
+        working-directory: examples/node-express-rag
         run: |
           npm ci
           npm run build


### PR DESCRIPTION
## Summary

The \`Demos and Examples Smoke\` job built only Rust/Python examples and the Tauri demo frontend. Two TypeScript examples (\`examples/react-wasm-search\`, \`examples/node-express-rag\`) had buildable artifacts but were never exercised in CI — so Dependabot PRs #798 and #799 shipped fully green while \`npm install\` was actually broken (vite 8 bump dropped \`@vitejs/plugin-react\` peer-dep compatibility).

Adds explicit \`npm ci && npm run build\` steps for both, and extends \`cache-dependency-path\` so the npm cache covers their lockfiles.

## Why

Root cause of the wasted cycles on PRs #798/#799. Closes the silent gap; future dep bumps on these examples now surface real install/build failures pre-merge.

## Test plan

- [x] \`npm ci && npm run build\` validates locally for both examples (0 vulnerabilities)
- [ ] CI \`Demos and Examples Smoke\` now runs ~3 extra minutes; results green
