### PR TITLE
ci(dependabot): group non-major bumps and add JS-example coverage

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,19 @@ updates:
     labels: ["dependencies", "rust"]
     open-pull-requests-limit: 5
     target-branch: "develop"
+    groups:
+      # Batch all non-major cargo bumps into one PR per week so the
+      # backlog stays manageable. Major bumps stay one-per-PR because
+      # they need targeted review (API changes, MSRV drift, etc.).
+      cargo-non-major:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
+      security-cargo:
+        applies-to: security-updates
+        patterns:
+          - "*"
 
   - package-ecosystem: "npm"
     directory: "/sdks/typescript"
@@ -17,6 +30,61 @@ updates:
     labels: ["dependencies", "typescript"]
     open-pull-requests-limit: 3
     target-branch: "develop"
+    groups:
+      npm-sdk-non-major:
+        applies-to: version-updates
+        update-types: ["minor", "patch"]
+      security-npm-sdk:
+        applies-to: security-updates
+        patterns: ["*"]
+
+  - package-ecosystem: "npm"
+    directory: "/examples/react-wasm-search"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels: ["dependencies", "javascript", "examples"]
+    open-pull-requests-limit: 3
+    target-branch: "develop"
+    groups:
+      npm-react-example-non-major:
+        applies-to: version-updates
+        update-types: ["minor", "patch"]
+      security-npm-react-example:
+        applies-to: security-updates
+        patterns: ["*"]
+
+  - package-ecosystem: "npm"
+    directory: "/examples/node-express-rag"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels: ["dependencies", "javascript", "examples"]
+    open-pull-requests-limit: 3
+    target-branch: "develop"
+    groups:
+      npm-node-example-non-major:
+        applies-to: version-updates
+        update-types: ["minor", "patch"]
+      security-npm-node-example:
+        applies-to: security-updates
+        patterns: ["*"]
+
+  - package-ecosystem: "npm"
+    directory: "/demos/tauri-rag-app"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels: ["dependencies", "javascript", "demos"]
+    open-pull-requests-limit: 3
+    target-branch: "develop"
+    groups:
+      npm-tauri-demo-non-major:
+        applies-to: version-updates
+        update-types: ["minor", "patch"]
+      security-npm-tauri-demo:
+        applies-to: security-updates
+        patterns: ["*"]
 
   - package-ecosystem: "pip"
     directory: "/crates/velesdb-python"
@@ -26,6 +94,13 @@ updates:
     labels: ["dependencies", "python"]
     open-pull-requests-limit: 3
     target-branch: "develop"
+    groups:
+      pip-non-major:
+        applies-to: version-updates
+        update-types: ["minor", "patch"]
+      security-pip:
+        applies-to: security-updates
+        patterns: ["*"]
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -35,3 +110,10 @@ updates:
     labels: ["ci", "dependencies"]
     open-pull-requests-limit: 3
     target-branch: "develop"
+    groups:
+      gha-non-major:
+        applies-to: version-updates
+        update-types: ["minor", "patch"]
+      security-gha:
+        applies-to: security-updates
+        patterns: ["*"]


### PR DESCRIPTION
## Summary

Two Dependabot issues surfaced in the CTO audit on 2026-05-15:

1. **Every minor/patch bump = its own PR.** Mondays produced 10+ small PRs requiring individual reviews — high toil, biased toward rubber-stamping or batching under a single cover PR (see #783 superseding #782).
2. **JS example workspaces had no Dependabot coverage at all.** Security updates for the vite example arrived via security-advisory auto-branches (#798/#799) — no scheduled scanning. Same gap for \`examples/node-express-rag\` and \`demos/tauri-rag-app\` (whose Cargo.lock just shipped 8 CVEs in #807).

## Changes

- **Group \`minor\` + \`patch\`** for every ecosystem (one batched PR per directory per week). **Majors stay one-per-PR** — they need targeted review (MSRV drift, API breaks, transitive-tree shifts).
- **Security updates get their own group** per ecosystem so they keep arriving promptly without waiting for the weekly batch.
- **Add three new npm watch directories**: \`/examples/react-wasm-search\`, \`/examples/node-express-rag\`, \`/demos/tauri-rag-app\`. Combined with the \`npm ci && npm run build\` smoke gates that landed in #806, broken bumps now fail CI pre-merge rather than slipping through (the exact failure mode of #798/#799).
- Same pattern applied to pip + github-actions for consistency.

## Test plan

- [ ] Next Monday's Dependabot run produces 1 batched PR per directory (instead of N)
- [ ] Security advisories continue to arrive as individual PRs in real time
- [ ] The new JS-example watches trigger when their deps drift
