### PR TITLE
ci(compat-matrix): make Loom check a required gate

### DIFF
--- a/.github/workflows/compat-matrix.yml
+++ b/.github/workflows/compat-matrix.yml
@@ -84,9 +84,12 @@ jobs:
         run: cargo check -p velesdb-core -p velesdb-wasm --target wasm32-unknown-unknown --no-default-features
 
   loom-check:
-    name: Loom check (nightly optional)
+    # This is a compile check (no test run), so it's deterministic — no
+    # flake risk to weigh against making the gate required. Loom is also
+    # how we catch concurrency-model drift between the `loom` and non-loom
+    # builds; silencing this gate would let breakage land for free.
+    name: Loom check (nightly)
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 


### PR DESCRIPTION
## Summary

The Loom job in \`.github/workflows/compat-matrix.yml\` was marked \`continue-on-error: true\` with the name \"Loom check (nightly **optional**)\". The job runs \`cargo check --features loom,persistence\` — a **compile-only step**, no test execution. That's deterministic: it either compiles or it doesn't, with no flake risk to weigh against making the gate required.

The silence hides the one class of regression this job exists to catch: drift between the \`loom\` feature build and the regular build (a function that compiles under default cfg but no longer compiles under \`--cfg loom\`, or vice versa). With the silence removed, any such drift fails CI immediately.

## Change

\`\`\`diff
   loom-check:
-    name: Loom check (nightly optional)
+    name: Loom check (nightly)
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
\`\`\`

Plus a comment in-file explaining the reasoning so a future maintainer doesn't reflexively re-add \`continue-on-error\` thinking they're being safe.

## Why this isn't a fuzz job

The fuzzing jobs in \`.github/workflows/quality-deep.yml\` keep their \`continue-on-error: true\` — they run \`cargo fuzz run\` with a time budget; timeouts are expected and not a real failure signal. Loom is the opposite shape: a deterministic compile.

## Test plan

- [ ] Loom job runs on this PR and reports a success (compile passes today, so this is the no-op control)
- [ ] Future PRs that break loom-feature compilation now fail CI instead of silently shipping
