### PR TITLE
ci(propagation-guard): py_compile smoke for demos/rag-pdf-demo

### DIFF
--- a/.github/workflows/propagation-guard.yml
+++ b/.github/workflows/propagation-guard.yml
@@ -227,6 +227,12 @@ jobs:
           # Integration-level examples — must at least compile cleanly so a
           # user copying the file into their project doesn't hit a SyntaxError.
           python -m py_compile integrations/haystack/examples/rag_pipeline.py
+          # rag-pdf-demo had no CI coverage at all until 2026-05-15; a
+          # syntax smoke catches the most common breakage class for a
+          # demo that's frequently copy-pasted by RAG users.
+          python -m py_compile demos/rag-pdf-demo/src/*.py
+          python -m py_compile demos/rag-pdf-demo/benchmark_latency.py
+          python -m py_compile demos/rag-pdf-demo/benchmark_layers.py
       - name: Tauri demo frontend build smoke
         working-directory: demos/tauri-rag-app
         run: |


### PR DESCRIPTION
## Summary

Closes the last \`demos/\` directory CI coverage gap surfaced by the CTO audit on 2026-05-15. \`demos/rag-pdf-demo\` ships 15 Python files (RAG engine, PDF processor, embeddings, VelesDB client + benchmarks) but the only thing checking them was the \`paths:\` trigger on the workflow — the job fired without actually running anything against the directory.

Adds a \`python -m py_compile\` step covering:
- \`demos/rag-pdf-demo/src/*.py\` (7 modules)
- \`demos/rag-pdf-demo/benchmark_latency.py\`
- \`demos/rag-pdf-demo/benchmark_layers.py\`

That's the minimum bar — catches \`SyntaxError\` and broken top-level imports, which is the most common failure class for a copy-paste-style demo. The \`tests/\` suite needs model weights / GPU and belongs in \`quality-deep.yml\` if we ever invest; out of scope here.

## Test plan

- [x] Local \`python3 -m py_compile\` on all targeted files (Python 3.11) — clean
- [ ] CI \`Demos and Examples Smoke\` continues to pass
