### PR TITLE
ci: run heavyweight python-integrations job on develop pushes too

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -318,7 +318,7 @@ jobs:
     name: Python Integrations
     runs-on: ubuntu-latest
     needs: test
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop')
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 


### PR DESCRIPTION
## Summary

The \`python-integrations\` job in \`.github/workflows/ci.yml\` runs the maturin release build of \`velesdb-python\` plus LangChain / LlamaIndex / Haystack parity tests. It was gated \`if: github.event_name == 'push' && github.ref == 'refs/heads/main'\` — so regressions only became visible at release time when CI runs on \`main\`.

Extends the predicate to also fire on \`develop\` pushes, so any PR that breaks LangChain or LlamaIndex contract surfaces **at merge** (within minutes), not at release.

## Why this isn't on every PR

Per-PR runs would cost ~6 min × (every PR × every push) — the maturin release build is the long pole. Gating to \`push\` events (no \`pull_request\` runs) keeps that cost on the post-merge develop pipeline only, which is the standard place to detect integration drift in a multi-SDK monorepo.

## Symmetry note

This matches the \`sonarcloud-analysis\` job at line 572 which is already on the \`main || develop\` shape; this PR aligns \`python-integrations\` to the same convention.
