### PR TITLE
docs(velesdb-core): fix hybrid_search snippet to match real 4-arg signature

### DIFF
--- a/crates/velesdb-core/README.md
+++ b/crates/velesdb-core/README.md
@@ -67,8 +67,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         &query,
         "rust programming",
         5,
-        Some(0.7), // 70% vector, 30% text
-        None,       // RRF k=60 (default)
+        Some(0.7), // alpha: 70% vector, 30% text (None = balanced default)
     )?;
 
     // BM25 full-text search only


### PR DESCRIPTION
## Summary

\`VectorCollection::hybrid_search\` at \`crates/velesdb-core/src/collection/vector_collection/search.rs:151\` is **4 parameters**: \`(vector, text, k, alpha: Option<f32>)\`. The Quick Start in \`crates/velesdb-core/README.md\` was calling it with **5** — a trailing \`None\` labeled \"RRF k=60 (default)\" — which never compiled against the current API.

Drop the bogus 5th argument and document the real meaning of the 4th: \`alpha\` is the vector-vs-text weight (\`None\` falls back to the balanced default).

## Audit context

This is part of the documentation factual-accuracy pass started 2026-05-15. I audited every public-API claim in \`crates/velesdb-core/README.md\` (exports list, type paths, method signatures, agent memory, streaming, cache, VelesQL filter operators) against the code at the current \`develop\` HEAD. Only this one signature drift remained.
