### PR TITLE
docs: factual-accuracy pass against the code (2026-05-15)

### DIFF
--- a/crates/velesdb-cli/README.md
+++ b/crates/velesdb-cli/README.md
@@ -120,7 +120,7 @@ History is persisted across sessions in `~/.local/share/.velesdb_history` (Linux
 | `.count <name>` | | Show record/edge/item count |
 | `.sample <name> [n]` | | Show first N records (default: 5). Works for Vector, Graph, and Metadata collections. |
 | `.browse <name> [page]` | | Paginated record browsing (10 per page). Works for Vector, Graph, and Metadata collections. |
-| `.nodes <name> [page]` | | Paginated node browsing for Graph collections (10 per page, includes payload). |
+| `.nodes <name> [page]` | | Paginated node browsing for Graph collections (20 per page, includes payload). |
 
 ### Data Operations
 

--- a/crates/velesdb-core/README.md
+++ b/crates/velesdb-core/README.md
@@ -67,8 +67,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         &query,
         "rust programming",
         5,
-        Some(0.7), // 70% vector, 30% text
-        None,       // RRF k=60 (default)
+        Some(0.7), // alpha: 70% vector, 30% text (None = balanced default)
     )?;
 
     // BM25 full-text search only

--- a/crates/velesdb-python/README.md
+++ b/crates/velesdb-python/README.md
@@ -5,7 +5,7 @@
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![Version](https://img.shields.io/badge/version-1.15.0-blue)](https://github.com/cyberlife-coder/VelesDB/releases)
 
-Python bindings for [VelesDB](https://github.com/cyberlife-coder/VelesDB) — a high-performance vector database for AI applications. The current published wheel is `velesdb` v1.14.0; `numpy>=1.20` ships as a hard runtime dependency since v1.13.8 so a single `pip install velesdb` is sufficient.
+Python bindings for [VelesDB](https://github.com/cyberlife-coder/VelesDB) — a high-performance vector database for AI applications. The current published wheel is `velesdb` v1.15.0; `numpy>=1.20` ships as a hard runtime dependency since v1.13.8 so a single `pip install velesdb` is sufficient.
 
 ## Features
 

--- a/integrations/common/README.md
+++ b/integrations/common/README.md
@@ -23,14 +23,76 @@ The following symbols form the stable internal API consumed by `langchain-velesd
 `llama-index-vector-stores-velesdb`, and `haystack-velesdb`. They are not intended for
 direct use by end users.
 
+**Fusion**
+
 | Export | Type | Description |
 |--------|------|-------------|
 | `build_fusion_strategy` | function | Converts a strategy name + params dict into the native `FusionStrategy` object |
-| `validate_url` | function | Validates a server URL string; raises `ValueError` on malformed input |
-| `validate_text` | function | Sanitizes free-text query strings against injection patterns |
-| `validate_collection_name` | function | Ensures a collection name meets naming rules (alphanumeric + underscore, ≤ 64 chars) |
+
+**Shared mixins / bases**
+
+| Export | Type | Description |
+|--------|------|-------------|
 | `CollectionAdminMixin` | class | Mixin providing shared admin operations (`flush`, `get_collection_info`, `is_empty`) |
 | `GraphOpsBase` | class | Base class for graph query helpers used by both integrations |
+
+**ID helpers**
+
+| Export | Type | Description |
+|--------|------|-------------|
+| `stable_hash_id` | function | Deterministic 64-bit hash of an input string (used as collection-stable ID) |
+| `make_initial_id_counter` | function | Builds a thread-safe sequential ID counter seeded from existing collection state |
+
+**Memory helpers**
+
+| Export | Type | Description |
+|--------|------|-------------|
+| `format_procedural_results` | function | Normalizes raw procedural-memory recall output into a stable result list |
+| `store_procedure` | function | Inserts a procedural-memory entry with the canonical schema used by both integrations |
+
+**Security: validators**
+
+| Export | Type | Description |
+|--------|------|-------------|
+| `SecurityError` | exception | Raised by every `validate_*` on rejected input |
+| `validate_url` | function | Validates a server URL string |
+| `validate_text` | function | Sanitizes free-text query strings against injection patterns |
+| `validate_query` | function | Validates VelesQL query strings against length / character limits |
+| `validate_collection_name` | function | Alphanumeric + underscore, ≤ 64 chars |
+| `validate_dimension` | function | Within `MIN_DIMENSION`..=`MAX_DIMENSION` |
+| `validate_metric` | function | Against `ALLOWED_METRICS` |
+| `validate_storage_mode` | function | Against `ALLOWED_STORAGE_MODES` / `STORAGE_MODE_ALIASES` |
+| `validate_path` | function | Filesystem path bounds + character rules |
+| `validate_k` | function | k value in `[1, MAX_K_VALUE]` |
+| `validate_batch_size` | function | Batch size in `[1, MAX_BATCH_SIZE]` |
+| `validate_timeout` | function | Timeout ms within sane bounds |
+| `validate_weight` | function | Fusion weight in `[0.0, 1.0]` |
+| `validate_sparse_vector` | function | Sparse pair list bounds |
+
+**Security: constants**
+
+| Export | Type | Description |
+|--------|------|-------------|
+| `ALLOWED_METRICS` | set | Canonical metric strings (cosine, euclidean, dot, …) |
+| `ALLOWED_STORAGE_MODES` | set | Canonical storage modes (full, sq8, binary, pq, rabitq) |
+| `STORAGE_MODE_ALIASES` | dict | Alias → canonical mapping (e.g. `int8` → `sq8`) |
+| `DEFAULT_TIMEOUT_MS` | int | Default timeout used when callers don't specify one |
+| `MIN_DIMENSION` / `MAX_DIMENSION` | int | Vector dimension bounds |
+| `MAX_BATCH_SIZE` | int | Hard cap on per-call batch operations |
+| `MAX_K_VALUE` | int | Hard cap on retrieval `k` |
+| `MAX_PATH_LENGTH` | int | Filesystem path length cap |
+| `MAX_QUERY_LENGTH` | int | VelesQL query length cap |
+| `MAX_SPARSE_VECTOR_SIZE` | int | Sparse vector non-zero entry cap |
+| `MAX_TEXT_LENGTH` | int | Free-text query length cap |
+
+**Graph helpers**
+
+| Export | Type | Description |
+|--------|------|-------------|
+| `build_graph_rest_payload` | function | Constructs the JSON body for REST-backed graph traversal calls |
+| `parse_graph_traverse_response` | function | Decodes a graph traversal REST response into the shared result shape |
+| `open_native_graph` | function | Opens (or attaches to) a native-backend graph collection |
+| `is_timeout_exception` | function | Cross-backend timeout-error predicate |
 
 ## License
 

--- a/integrations/langchain/README.md
+++ b/integrations/langchain/README.md
@@ -82,6 +82,7 @@ VelesDBVectorStore(
 **Core Operations:**
 - `add_texts(texts, metadatas=None, ids=None)` - Add texts to the store
 - `add_texts_bulk(texts, metadatas=None, ids=None)` - Bulk insert (2-3x faster for large batches)
+- `add_texts_streaming(texts, metadatas=None, ids=None, ...)` - Stream-insert via the bounded-channel ingestion pipeline (returns backpressure status)
 - `delete(ids)` - Delete documents by ID
 - `get_by_ids(ids)` - Retrieve documents by their IDs
 - `flush()` - Flush pending changes to disk
@@ -274,6 +275,25 @@ for row in results:
 - **Metadata Filtering**: Filter results by document attributes
 - **Simple Setup**: Self-contained single binary, no external services required
 - **Full LangChain Compatibility**: Works with all LangChain chains and agents
+
+## Agent Memory (optional)
+
+`langchain-velesdb` also re-exports three agent-memory wrappers around VelesDB's
+native memory subsystems. They are imported lazily — if the underlying
+`langchain` extras aren't installed, the import becomes a no-op and the
+symbols are exposed as `None`.
+
+```python
+from langchain_velesdb import (
+    VelesDBChatMemory,           # short-term conversational buffer
+    VelesDBSemanticMemory,       # long-term knowledge store
+    VelesDBProceduralMemory,     # learned action patterns with reinforcement
+)
+```
+
+See `langchain_velesdb/memory.py` for the full per-class API (chat history
+buffer with optional embedding, semantic recall with score, procedural
+reinforcement). Tests under `integrations/langchain/tests/` exercise each.
 
 ## License
 

--- a/integrations/llamaindex/README.md
+++ b/integrations/llamaindex/README.md
@@ -276,6 +276,26 @@ Source: `benchmarks/baseline.json`.
 | Hybrid (vector + filter) | ~0.27 ms | Filtered vector search |
 | Batch insert (10K / 128D) | ~9 s total | Sequential HNSW build |
 
+## Agent Memory (optional)
+
+`llamaindex-velesdb` re-exports three agent-memory wrappers around VelesDB's
+native memory subsystems. They are imported lazily — if the underlying
+`velesdb` native extension isn't installed, the import becomes a no-op and
+the symbols are exposed as `None`.
+
+```python
+from llamaindex_velesdb import (
+    VelesDBSemanticMemory,       # long-term knowledge store
+    VelesDBEpisodicMemory,       # time-sequenced event recall
+    VelesDBProceduralMemory,     # learned procedures with reinforcement
+)
+```
+
+See `llamaindex_velesdb/memory.py` for the full per-class API. The
+companion `GraphLoader`, `GraphRetriever`, and `GraphQARetriever` exports
+(top of the public namespace) are documented in the Graph Retrieval
+section above.
+
 ## Comparison with Other Stores
 
 | Feature | VelesDB | Chroma | Pinecone |


### PR DESCRIPTION
## Summary

Documentation audit on 2026-05-15. Every public-API claim verified against the current \`develop\` HEAD via grep / Read. The six fixes below are **all** the divergences the audit found across the entire workspace — \`crates/velesdb-core\`, \`crates/velesdb-python\`, \`crates/velesdb-cli\`, \`integrations/langchain\`, \`integrations/llamaindex\`, \`integrations/common\`. Supersedes the now-closed #835 (which was a one-line subset of this).

## Fixes

### \`crates/velesdb-core/README.md\` — Quick Start hybrid_search signature
\`VectorCollection::hybrid_search\` is **4 params** in code (\`src/collection/vector_collection/search.rs:151\`): \`(vector, text, k, alpha: Option<f32>)\`. The README's Quick Start passed 5 with a phantom \`None\` labeled \"RRF k=60 (default)\". Drop the bogus 5th and document \`alpha\`'s real meaning.

### \`crates/velesdb-python/README.md\` — wheel version
Opening sentence said \"The current published wheel is \`velesdb\` v1.14.0\". Workspace version is **1.15.0** (root \`Cargo.toml:20\`).

### \`crates/velesdb-cli/README.md\` — .nodes pagination
\`.nodes <name>\` table entry said \"10 per page\". Actual page size is **20** at \`src/repl_graph_cmds.rs:407\` and \`src/graph_handlers.rs:302\`. \`.browse\` correctly stays at 10 (\`repl_collection_cmds.rs:214\`).

### \`integrations/langchain/README.md\` — missing add_texts_streaming + Agent Memory
- Adds \`add_texts_streaming(...)\` to Core Operations (exists at \`vectorstore.py:481\`).
- Adds new \"Agent Memory (optional)\" section documenting the three optional re-exports (\`VelesDBChatMemory\`, \`VelesDBSemanticMemory\`, \`VelesDBProceduralMemory\`) gated behind the langchain extra (\`__init__.py:29-40\` lazy block + \`:50-55\` conditional \`__all__\`).

### \`integrations/llamaindex/README.md\` — missing Agent Memory
Adds new \"Agent Memory (optional)\" section documenting the three optional re-exports gated behind the native velesdb extension (\`VelesDBSemanticMemory\`, \`VelesDBEpisodicMemory\`, \`VelesDBProceduralMemory\` — \`__init__.py:21-33\`). \`batch_query()\` is correctly documented and exists at \`search_ops.py:384\`.

### \`integrations/common/README.md\` — Public Exports table was 6 of ~30
Replaced with a grouped table (Fusion / Mixins / IDs / Memory / Security validators / Security constants / Graph helpers) that mirrors the lazy-imported namespace in \`velesdb_common/__init__.py:9-94\`.

## Files audited & confirmed accurate (no fix needed)

- Root \`README.md\`, \`ARCHITECTURE.md\`, \`ROADMAP.md\`, \`QUALITY_BAR.md\`
- \`crates/velesdb-server/README.md\`, \`crates/velesdb-wasm/README.md\`, \`crates/velesdb-mobile/README.md\`, \`crates/velesdb-migrate/README.md\`, \`crates/tauri-plugin-velesdb/README.md\`
- \`sdks/typescript/README.md\`
