### PR TITLE
docs(quickstart): lead with a 5-second Python first-search for newcomers

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,19 +167,39 @@ For **internal technical limitations** (query-planner approximations, plan cache
 
 ## Getting Started in 60 Seconds
 
-### Install
+**The fastest path is Python — under 5 seconds median, measured.** ([timing methodology](docs/quickstart/timing-results.md))
 
-**Cargo (Rust):**
+```bash
+pip install velesdb
+curl -O https://raw.githubusercontent.com/cyberlife-coder/VelesDB/main/examples/python/hello_velesdb.py
+python hello_velesdb.py
+```
+
+Expected output:
+
+```
+Query: "tech"
+  score=1.000  Rust 1.89 release notes
+  score=0.600  AI-generated jazz: the new wave
+  score=0.000  Best ramen in Tokyo
+
+Query: "tech + music"
+  score=0.990  AI-generated jazz: the new wave
+  score=0.707  Rust 1.89 release notes
+  score=0.707  Miles Davis discography
+```
+
+That's it — no server, no JSON, no embedding model. Read the [25-line script](examples/python/hello_velesdb.py) to see what happened. From here, the [Agent Memory guide](docs/guides/AGENT_MEMORY.md) and the [VelesQL spec](docs/VELESQL_SPEC.md) are the natural next stops.
+
+<details>
+<summary><strong>Other install paths — Rust, Docker, WASM, REST server</strong></summary>
+
+**Cargo (Rust + REST server):**
 ```bash
 cargo install velesdb-server velesdb-cli
 ```
 
-**Python:**
-```bash
-pip install velesdb
-```
-
-**Docker:**
+**Docker (REST server):**
 ```bash
 # Build the image locally
 git clone https://github.com/cyberlife-coder/VelesDB.git && cd VelesDB
@@ -191,10 +211,8 @@ docker run -d -p 8080:8080 -v velesdb_data:/data --name velesdb velesdb
 # Verify it's running
 curl http://localhost:8080/health
 ```
-Data is stored in the `/data` directory inside the container. The named volume `velesdb_data` persists data across container restarts. The built-in health check polls `GET /health` every 30 seconds.
 
-<details>
-<summary>More install options (Docker Compose, WASM, install scripts)</summary>
+Data is stored in `/data` inside the container; the named volume `velesdb_data` persists across restarts.
 
 **Docker Compose:**
 ```bash
@@ -224,14 +242,9 @@ curl -fsSL https://raw.githubusercontent.com/cyberlife-coder/VelesDB/main/script
 irm https://raw.githubusercontent.com/cyberlife-coder/VelesDB/main/scripts/install.ps1 | iex
 ```
 
-</details>
-
-### First search in 30 seconds
+**First search against the REST server (once `velesdb-server` is running on :8080):**
 
 ```bash
-velesdb-server --data-dir ./my_data &
-
-# Create collection + insert + search
 curl -X POST http://localhost:8080/collections \
   -d '{"name": "docs", "dimension": 4, "metric": "cosine"}' -H "Content-Type: application/json"
 
@@ -246,6 +259,8 @@ curl -X POST http://localhost:8080/collections/docs/search \
   -d '{"vector": [0.9, 0.1, 0.0, 0.0], "top_k": 2}' -H "Content-Type: application/json"
 # [{"id":1,"score":0.995,"payload":{"title":"AI Intro","category":"tech"}}, ...]
 ```
+
+</details>
 
 > Full installation guide: [docs/guides/INSTALLATION.md](docs/guides/INSTALLATION.md)
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -18,7 +18,37 @@ This guide will help you get VelesDB up and running in just a few minutes.
 > All four well under the 300 s "<5 min" goal of [#379](https://github.com/cyberlife-coder/VelesDB/issues/379). Methodology + honesty notes
 > (4 DX frictions documented openly) → [`docs/quickstart/timing-results.md`](quickstart/timing-results.md). Reproduce locally with `bash scripts/dx-timing/run_all.sh`.
 
-## Prerequisites
+## Fastest path: Python (≈ 5 seconds)
+
+If you just want to see VelesDB work, you only need Python ≥ 3.9.
+
+```bash
+pip install velesdb
+curl -O https://raw.githubusercontent.com/cyberlife-coder/VelesDB/main/examples/python/hello_velesdb.py
+python hello_velesdb.py
+```
+
+Expected output:
+
+```
+Query: "tech"
+  score=1.000  Rust 1.89 release notes
+  score=0.600  AI-generated jazz: the new wave
+  score=0.000  Best ramen in Tokyo
+
+Query: "tech + music"
+  score=0.990  AI-generated jazz: the new wave
+  score=0.707  Rust 1.89 release notes
+  score=0.707  Miles Davis discography
+```
+
+No server, no JSON, no embedding model. The full script is [`examples/python/hello_velesdb.py`](../examples/python/hello_velesdb.py) — read it, it is ~25 lines.
+
+Want to keep going in Python? See [`examples/python/`](../examples/python/) for fusion, graph traversal, VelesQL, and hybrid queries.
+
+The rest of this page is the **REST API** path — useful if you want to drive VelesDB from a non-Python language, or run it as a shared service.
+
+## Prerequisites (REST API path)
 
 - Docker (recommended) or Rust 1.89+
 - curl or any HTTP client for testing

--- a/examples/python/README.md
+++ b/examples/python/README.md
@@ -4,26 +4,33 @@
 
 Runnable examples demonstrating the VelesDB Python SDK (PyO3 bindings).
 
-## Prerequisites
+## Start here — `hello_velesdb.py` (≈ 5 seconds)
+
+```bash
+pip install velesdb
+python hello_velesdb.py
+```
+
+A self-contained ~25-line script: open a database, store five tiny documents, run two searches, print results. No NumPy import needed, no server, no embedding model. If this works, your VelesDB install is healthy.
+
+## Prerequisites (other examples)
 
 - Python 3.9+
-- Rust toolchain (for building the SDK from source)
-- maturin (`pip install maturin`)
+- The other scripts below import NumPy directly (already a transitive dependency of `velesdb`, but they use it explicitly).
+- For `graphrag_*.py`: an OpenAI API key and a running `velesdb-server`.
 
 ## Installation
 
-### Option 1: Build from source (recommended for development)
+```bash
+pip install velesdb
+```
+
+Or, if you are hacking on the SDK itself and want to rebuild from source:
 
 ```bash
 cd crates/velesdb-python
 pip install maturin
 maturin develop
-```
-
-### Option 2: Install from wheel (when published)
-
-```bash
-pip install velesdb
 ```
 
 ### Install example dependencies
@@ -36,10 +43,11 @@ pip install -r requirements.txt
 
 All examples use synthetic data (random vectors via NumPy) and create temporary
 directories that are cleaned up automatically. No external embedding models or
-API keys are needed.
+API keys are needed (except for the GraphRAG examples).
 
 | File | Description |
 |---|---|
+| `hello_velesdb.py` | **Start here.** 25-line first-search example, no NumPy required. |
 | `fusion_strategies.py` | Multi-query search with RRF, Average, Maximum, Weighted, and Relative Score fusion strategies |
 | `graph_traversal.py` | Persistent GraphCollection: edges, BFS/DFS traversal, node payloads, degree analysis |
 | `hybrid_queries.py` | Dense vector search, VelesQL queries, batch search, EXPLAIN plans, CRUD operations |

--- a/examples/python/hello_velesdb.py
+++ b/examples/python/hello_velesdb.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""hello_velesdb.py — Your first VelesDB search in ~25 lines.
+
+Run:
+    pip install velesdb
+    python hello_velesdb.py
+
+No server, no embedding model, no JSON wrangling. Just one file on disk.
+
+Each vector is 4-D. The axes stand for four made-up "topics":
+    [tech, food, music, sport]
+Documents with a 1.0 on an axis are about that topic; a 0.0 means they
+are not. The closer your query is to a document, the higher the score.
+"""
+import velesdb
+
+# 1. Open (or create) a local database. Data is persisted in ./hello_velesdb_data
+db = velesdb.Database("./hello_velesdb_data")
+
+# 2. Create a collection. dimension=None → auto-detected on first upsert.
+docs = db.get_or_create_collection("docs", metric="cosine")
+
+# 3. Insert five short documents. The vector says what the doc is about.
+docs.upsert([
+    {"id": 1, "vector": [1.0, 0.0, 0.0, 0.0],
+     "payload": {"title": "Rust 1.89 release notes"}},
+    {"id": 2, "vector": [0.0, 1.0, 0.0, 0.0],
+     "payload": {"title": "Best ramen in Tokyo"}},
+    {"id": 3, "vector": [0.0, 0.0, 1.0, 0.0],
+     "payload": {"title": "Miles Davis discography"}},
+    {"id": 4, "vector": [0.0, 0.0, 0.0, 1.0],
+     "payload": {"title": "World Cup highlights"}},
+    {"id": 5, "vector": [0.6, 0.0, 0.8, 0.0],
+     "payload": {"title": "AI-generated jazz: the new wave"}},
+])
+
+# 4. Ask: "what's most relevant to a tech query?"
+results = docs.search(vector=[1.0, 0.0, 0.0, 0.0], top_k=3)
+print('Query: "tech"')
+for r in results:
+    print(f"  score={r['score']:.3f}  {r['payload']['title']}")
+
+# 5. Ask: "what's at the intersection of tech and music?"
+results = docs.search(vector=[0.7, 0.0, 0.7, 0.0], top_k=3)
+print('\nQuery: "tech + music"')
+for r in results:
+    print(f"  score={r['score']:.3f}  {r['payload']['title']}")


### PR DESCRIPTION
## Summary

A newcomer landing on the README today hits two friction points:

1. The **README "Getting Started in 60 Seconds"** advertises `pip install velesdb` *and* a curl-against-`velesdb-server` quickstart — but `pip install velesdb` does **not** install the `velesdb-server` binary. A Python user following the install step cannot run the quickstart.
2. **`docs/getting-started.md`** opens with a measured timing table showing Python is the fastest path (4.95 s median, per `docs/quickstart/timing-results.md`) — then immediately tells the reader to install Docker or Rust and never shows a Python snippet.

### What this PR does

- **New file `examples/python/hello_velesdb.py`** — a single self-contained ~25-line script. `pip install velesdb` is the only dependency (no NumPy import, no embedding model, no server). It demonstrates auto-dimension detection, `upsert`, and two cosine searches whose scores are pre-computable (1.000, 0.600, 0.000, 0.990, 0.707…) so the expected output in the README is verifiable.
- **`README.md`** — "Getting Started in 60 Seconds" now leads with the three-command Python paste path plus its expected output. The previous Cargo/Docker/REST quickstart is folded into a collapsible `<details>` block for users who want a long-running server.
- **`docs/getting-started.md`** — adds a "Fastest path: Python (~5 seconds)" section at the top, before the existing Docker/REST tutorial. The REST section is now framed explicitly as "useful if you want to drive VelesDB from a non-Python language".
- **`examples/python/README.md`** — `hello_velesdb.py` is listed first as the beginner entry point; "build from source with maturin" is demoted from "recommended for development" to "only needed if you are hacking on the SDK itself", since the published wheel works fine for every other example.

### Why this matters

A newcomer arriving at VelesDB should reach a working search in well under five minutes regardless of which doc they click. After this PR, the README, `docs/getting-started.md`, and `examples/python/README.md` all converge on the same three-line paste, and that paste only uses `pip install velesdb`.

## Test plan

- [ ] Confirm `python examples/python/hello_velesdb.py` produces the documented output against the published wheel (`pip install velesdb`).
- [ ] Confirm the README block renders cleanly on GitHub (collapsible `<details>` works, code blocks unbroken).
- [ ] Confirm CI green (no perf-claim contract drift — no numbers changed in this PR).
