### PR TITLE
perf: code quality pass — O(n²)→O(n) histogram, NaN guard, sort_unstable_by, Arc::from slice

### DIFF
--- a/crates/velesdb-core/src/collection/core/bulk_import.rs
+++ b/crates/velesdb-core/src/collection/core/bulk_import.rs
@@ -90,7 +90,7 @@ impl Collection {
         self.update_label_index_from_raw(ids, payloads);
         self.update_secondary_indexes_from_raw(ids, payloads);
 
-        let inserted = self.bulk_index_or_defer(vector_refs);
+        let inserted = self.bulk_index_or_defer(&vector_refs);
         self.config.write().point_count = self.vector_storage.read().len();
 
         self.maintain_histograms_for_raw(ids, payloads, &old_payloads);

--- a/crates/velesdb-core/src/collection/core/crud.rs
+++ b/crates/velesdb-core/src/collection/core/crud.rs
@@ -91,7 +91,7 @@ impl Collection {
         // Phase 3: Batch HNSW insert
         let vector_refs: Vec<(u64, &[f32])> =
             points.iter().map(|p| (p.id, p.vector.as_slice())).collect();
-        self.bulk_index_or_defer(vector_refs);
+        self.bulk_index_or_defer(&vector_refs);
 
         Ok((sparse_batch, old_payloads))
     }

--- a/crates/velesdb-core/src/collection/core/crud_bulk.rs
+++ b/crates/velesdb-core/src/collection/core/crud_bulk.rs
@@ -179,7 +179,7 @@ impl Collection {
 
         self.store_vectors_and_payloads_inner(vector_refs, points, fsync)?;
 
-        let inserted = self.bulk_index_or_defer(vector_refs.to_vec());
+        let inserted = self.bulk_index_or_defer(vector_refs);
         self.config.write().point_count = self.vector_storage.read().len();
 
         self.apply_sparse_batch_bulk(sparse_batch)?;

--- a/crates/velesdb-core/src/collection/core/crud_indexing.rs
+++ b/crates/velesdb-core/src/collection/core/crud_indexing.rs
@@ -289,7 +289,9 @@ impl Collection {
                 .fetch_add(count as u64, std::sync::atomic::Ordering::Relaxed);
             return count;
         }
-        let inserted = self.index.insert_batch_parallel(vector_refs.iter().copied());
+        let inserted = self
+            .index
+            .insert_batch_parallel(vector_refs.iter().copied());
         #[allow(clippy::cast_possible_truncation)]
         self.inserts_since_last_hnsw_save
             .fetch_add(count as u64, std::sync::atomic::Ordering::Relaxed);

--- a/crates/velesdb-core/src/collection/core/crud_indexing.rs
+++ b/crates/velesdb-core/src/collection/core/crud_indexing.rs
@@ -276,7 +276,7 @@ impl Collection {
     }
 
     /// Batch-inserts into HNSW or defers into the deferred indexer.
-    pub(super) fn bulk_index_or_defer(&self, vector_refs: Vec<(u64, &[f32])>) -> usize {
+    pub(super) fn bulk_index_or_defer(&self, vector_refs: &[(u64, &[f32])]) -> usize {
         let count = vector_refs.len();
         #[cfg(feature = "persistence")]
         if let Some(ref di) = self.deferred_indexer {
@@ -289,7 +289,7 @@ impl Collection {
                 .fetch_add(count as u64, std::sync::atomic::Ordering::Relaxed);
             return count;
         }
-        let inserted = self.index.insert_batch_parallel(vector_refs);
+        let inserted = self.index.insert_batch_parallel(vector_refs.iter().copied());
         #[allow(clippy::cast_possible_truncation)]
         self.inserts_since_last_hnsw_save
             .fetch_add(count as u64, std::sync::atomic::Ordering::Relaxed);

--- a/crates/velesdb-core/src/collection/search/batch.rs
+++ b/crates/velesdb-core/src/collection/search/batch.rs
@@ -40,13 +40,15 @@ impl Collection {
             )));
         }
 
-        let dimension = self.config.read().dimension;
+        let (dimension, metric) = {
+            let cfg = self.config.read();
+            (cfg.dimension, cfg.metric)
+        };
         for query in queries {
             validate_dimension_match(dimension, query.len())?;
         }
 
         let candidates_k = k.saturating_mul(4).max(k + 10);
-        let metric = self.config.read().metric;
         let higher_is_better = metric.higher_is_better();
         let index_results =
             self.index
@@ -136,9 +138,10 @@ impl Collection {
         queries: &[&[f32]],
         k: usize,
     ) -> Result<Vec<Vec<SearchResult>>> {
-        let config = self.config.read();
-        let dimension = config.dimension;
-        drop(config);
+        let (dimension, metric) = {
+            let cfg = self.config.read();
+            (cfg.dimension, cfg.metric)
+        };
 
         // Validate all query dimensions first
         for query in queries {
@@ -146,7 +149,6 @@ impl Collection {
         }
 
         // Perf: Use parallel HNSW search (P0 optimization)
-        let metric = self.config.read().metric;
         let index_results =
             self.index
                 .search_batch_parallel(queries, k, SearchQuality::Balanced)?;

--- a/crates/velesdb-core/src/collection/search/query/distinct.rs
+++ b/crates/velesdb-core/src/collection/search/query/distinct.rs
@@ -119,7 +119,7 @@ fn canonical_json_string(value: &serde_json::Value) -> String {
         serde_json::Value::Object(map) => {
             // Sort keys alphabetically for deterministic output
             let mut keys: Vec<_> = map.keys().collect();
-            keys.sort();
+            keys.sort_unstable();
             let pairs: Vec<String> = keys
                 .iter()
                 .map(|k| format!("{}:{}", k, canonical_json_string(&map[*k])))

--- a/crates/velesdb-core/src/collection/search/query/distinct.rs
+++ b/crates/velesdb-core/src/collection/search/query/distinct.rs
@@ -2,6 +2,8 @@
 //!
 //! Extracted from mod.rs to reduce file size and improve modularity.
 
+use std::fmt::Write as _;
+
 use crate::point::SearchResult;
 use crate::velesql::SelectColumns;
 use rustc_hash::FxHashSet;
@@ -103,8 +105,8 @@ pub fn compute_distinct_key(
     };
 
     if include_score {
-        key.push('\x1F');
-        key.push_str(&result.score.to_string());
+        // write! into String is infallible; avoids a temporary String allocation
+        let _ = write!(key, "\x1F{}", result.score);
     }
 
     key

--- a/crates/velesdb-core/src/collection/search/query/match_exec/similarity.rs
+++ b/crates/velesdb-core/src/collection/search/query/match_exec/similarity.rs
@@ -294,7 +294,8 @@ impl Collection {
     /// ascending for distance metrics.
     pub(super) fn sort_by_score(results: &mut [MatchResult], higher_is_better: bool) {
         if higher_is_better {
-            results.sort_unstable_by(|a, b| b.score.unwrap_or(0.0).total_cmp(&a.score.unwrap_or(0.0)));
+            results
+                .sort_unstable_by(|a, b| b.score.unwrap_or(0.0).total_cmp(&a.score.unwrap_or(0.0)));
         } else {
             results.sort_unstable_by(|a, b| {
                 a.score

--- a/crates/velesdb-core/src/collection/search/query/match_exec/similarity.rs
+++ b/crates/velesdb-core/src/collection/search/query/match_exec/similarity.rs
@@ -294,9 +294,9 @@ impl Collection {
     /// ascending for distance metrics.
     pub(super) fn sort_by_score(results: &mut [MatchResult], higher_is_better: bool) {
         if higher_is_better {
-            results.sort_by(|a, b| b.score.unwrap_or(0.0).total_cmp(&a.score.unwrap_or(0.0)));
+            results.sort_unstable_by(|a, b| b.score.unwrap_or(0.0).total_cmp(&a.score.unwrap_or(0.0)));
         } else {
-            results.sort_by(|a, b| {
+            results.sort_unstable_by(|a, b| {
                 a.score
                     .unwrap_or(f32::MAX)
                     .total_cmp(&b.score.unwrap_or(f32::MAX))

--- a/crates/velesdb-core/src/collection/search/query/similarity_filter.rs
+++ b/crates/velesdb-core/src/collection/search/query/similarity_filter.rs
@@ -409,9 +409,9 @@ impl Collection {
         }
 
         if metric.higher_is_better() {
-            candidates.sort_by(|a, b| b.score.total_cmp(&a.score));
+            candidates.sort_unstable_by(|a, b| b.score.total_cmp(&a.score));
         } else {
-            candidates.sort_by(|a, b| a.score.total_cmp(&b.score));
+            candidates.sort_unstable_by(|a, b| a.score.total_cmp(&b.score));
         }
 
         candidates.truncate(limit);

--- a/crates/velesdb-core/src/collection/search/resolve.rs
+++ b/crates/velesdb-core/src/collection/search/resolve.rs
@@ -65,8 +65,10 @@ pub(crate) fn resolve_scored_results(
 ///
 /// - `higher_is_better = true`: descending (cosine, dot product)
 /// - `higher_is_better = false`: ascending (euclidean distance)
+///
+/// Uses unstable sort: equal-score tie-breaking order is irrelevant for ranking.
 pub(crate) fn sort_results_by_metric(results: &mut [SearchResult], higher_is_better: bool) {
-    results.sort_by(|a, b| {
+    results.sort_unstable_by(|a, b| {
         if higher_is_better {
             b.score
                 .partial_cmp(&a.score)
@@ -80,8 +82,10 @@ pub(crate) fn sort_results_by_metric(results: &mut [SearchResult], higher_is_bet
 }
 
 /// Sorts `ScoredResult` values by score according to metric direction.
+///
+/// Uses unstable sort: equal-score tie-breaking order is irrelevant for ranking.
 pub(crate) fn sort_scored_by_metric(results: &mut [ScoredResult], higher_is_better: bool) {
-    results.sort_by(|a, b| {
+    results.sort_unstable_by(|a, b| {
         if higher_is_better {
             b.score
                 .partial_cmp(&a.score)
@@ -98,9 +102,11 @@ pub(crate) fn sort_scored_by_metric(results: &mut [ScoredResult], higher_is_bett
 ///
 /// Used for BM25 text search, sparse search, and fusion results where
 /// higher scores always indicate better matches.
+///
+/// Uses unstable sort: equal-score tie-breaking order is irrelevant for ranking.
 #[allow(dead_code)]
 pub(crate) fn sort_results_descending(results: &mut [SearchResult]) {
-    results.sort_by(|a, b| {
+    results.sort_unstable_by(|a, b| {
         b.score
             .partial_cmp(&a.score)
             .unwrap_or(std::cmp::Ordering::Equal)

--- a/crates/velesdb-core/src/collection/search/text.rs
+++ b/crates/velesdb-core/src/collection/search/text.rs
@@ -230,7 +230,7 @@ impl Collection {
             .into_iter()
             .map(|Reverse((OrderedFloat(s), id))| (id, s))
             .collect();
-        scored.sort_by(|a, b| b.1.total_cmp(&a.1));
+        scored.sort_unstable_by(|a, b| b.1.total_cmp(&a.1));
         scored
     }
 
@@ -308,7 +308,7 @@ impl Collection {
         );
 
         let mut scored_ids: Vec<_> = fused_scores.into_iter().collect();
-        scored_ids.sort_by(|a, b| b.1.total_cmp(&a.1));
+        scored_ids.sort_unstable_by(|a, b| b.1.total_cmp(&a.1));
 
         Ok(
             self.resolve_scored_ids_filtered_with_components(

--- a/crates/velesdb-core/src/collection/search/vector_filter.rs
+++ b/crates/velesdb-core/src/collection/search/vector_filter.rs
@@ -161,7 +161,11 @@ fn resolve_quality(
 
 /// Computes the oversampled candidate count for filtered search.
 pub(super) fn compute_oversampled_k(k: usize, filter: &crate::filter::Filter) -> usize {
-    let selectivity = estimate_filter_selectivity(filter);
+    // Clamp to a tiny positive value so that a zero-selectivity filter (e.g. empty
+    // IN clause) never produces NaN (0.0/0.0 when k=0) or Inf (k>0/0.0). Both would
+    // be handled by the clamp below, but NaN→usize is implementation-defined (LLVM
+    // saturates to 0, giving zero candidates instead of the minimum sensible count).
+    let selectivity = estimate_filter_selectivity(filter).max(1e-9);
     #[allow(clippy::cast_precision_loss)]
     let k_f64 = k as f64;
     #[allow(clippy::cast_precision_loss)]

--- a/crates/velesdb-core/src/collection/stats/histogram.rs
+++ b/crates/velesdb-core/src/collection/stats/histogram.rs
@@ -395,9 +395,13 @@ fn build_per_distinct_buckets(sorted: &[f64], distinct: usize) -> Vec<HistogramB
 fn build_equidepth_buckets(sorted: &[f64], num_buckets: usize) -> Vec<HistogramBucket> {
     let chunk_size = sorted.len().div_ceil(num_buckets);
     let mut buckets = Vec::with_capacity(num_buckets);
+    // Track the running start offset of each chunk instead of re-summing existing
+    // bucket counts on every iteration (O(n) per call → O(n²) total without this).
+    let mut offset = 0usize;
     for chunk in sorted.chunks(chunk_size) {
         let lower = chunk[0];
-        let upper = upper_bound_for_chunk(chunk, sorted, &buckets);
+        let upper = upper_bound_for_chunk(chunk, sorted, offset);
+        offset += chunk.len();
         buckets.push(HistogramBucket {
             lower_bound: lower,
             upper_bound: upper,
@@ -461,9 +465,10 @@ pub(crate) fn merge_zero_width_buckets(buckets: Vec<HistogramBucket>) -> Vec<His
 
 /// Computes the upper bound for an equi-depth chunk.
 ///
+/// `offset` is the index in `sorted` where this chunk starts.
 /// Uses the next chunk's first value if available, otherwise last value + epsilon.
-fn upper_bound_for_chunk(chunk: &[f64], sorted: &[f64], existing: &[HistogramBucket]) -> f64 {
-    let chunk_end_offset = existing.iter().map(|b| b.count as usize).sum::<usize>() + chunk.len();
+fn upper_bound_for_chunk(chunk: &[f64], sorted: &[f64], offset: usize) -> f64 {
+    let chunk_end_offset = offset + chunk.len();
     if chunk_end_offset < sorted.len() {
         sorted[chunk_end_offset]
     } else {

--- a/crates/velesdb-core/src/distance.rs
+++ b/crates/velesdb-core/src/distance.rs
@@ -131,10 +131,10 @@ impl DistanceMetric {
     pub fn sort_results(&self, results: &mut [(u64, f32)]) {
         if self.higher_is_better() {
             // Similarity metrics: descending order (higher = better)
-            results.sort_by(|a, b| b.1.total_cmp(&a.1));
+            results.sort_unstable_by(|a, b| b.1.total_cmp(&a.1));
         } else {
             // Distance metrics: ascending order (lower = better)
-            results.sort_by(|a, b| a.1.total_cmp(&b.1));
+            results.sort_unstable_by(|a, b| a.1.total_cmp(&b.1));
         }
     }
 
@@ -144,9 +144,9 @@ impl DistanceMetric {
     /// [`ScoredResult`](crate::scored_result::ScoredResult) slices.
     pub fn sort_scored_results(&self, results: &mut [crate::scored_result::ScoredResult]) {
         if self.higher_is_better() {
-            results.sort_by(|a, b| b.score.total_cmp(&a.score));
+            results.sort_unstable_by(|a, b| b.score.total_cmp(&a.score));
         } else {
-            results.sort_by(|a, b| a.score.total_cmp(&b.score));
+            results.sort_unstable_by(|a, b| a.score.total_cmp(&b.score));
         }
     }
 }

--- a/crates/velesdb-core/src/fusion/strategy.rs
+++ b/crates/velesdb-core/src/fusion/strategy.rs
@@ -211,7 +211,7 @@ impl FusionStrategy {
 
     /// Sorts a fused result set by score descending.
     fn sort_descending(fused: &mut [(u64, f32)]) {
-        fused.sort_by(|a, b| b.1.total_cmp(&a.1));
+        fused.sort_unstable_by(|a, b| b.1.total_cmp(&a.1));
     }
 
     /// Average fusion: mean of scores for each document.

--- a/crates/velesdb-core/src/gpu/gpu_traversal.rs
+++ b/crates/velesdb-core/src/gpu/gpu_traversal.rs
@@ -397,7 +397,7 @@ impl GpuTraversalContext {
             .map(|(&id, &dist)| (id as usize, dist))
             .collect();
 
-        results.sort_by(|a, b| a.1.total_cmp(&b.1));
+        results.sort_unstable_by(|a, b| a.1.total_cmp(&b.1));
         results.truncate(k);
 
         Some(results)

--- a/crates/velesdb-core/src/index/hnsw/native/dual_precision.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/dual_precision.rs
@@ -296,7 +296,7 @@ impl<D: DistanceEngine> DualPrecisionHnsw<D> {
             Vec::new()
         };
 
-        reranked.sort_by(|a, b| a.1.total_cmp(&b.1));
+        reranked.sort_unstable_by(|a, b| a.1.total_cmp(&b.1));
         reranked.truncate(k);
         reranked
     }

--- a/crates/velesdb-core/src/index/hnsw/native/graph/gpu_search.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/graph/gpu_search.rs
@@ -231,7 +231,7 @@ impl<D: DistanceEngine> NativeHnsw<D> {
         // is the declared lock order.
         let (dim, arc) = self.with_vectors_read(|vectors| {
             let d = vectors.dimension();
-            let arc: std::sync::Arc<[f32]> = vectors.as_flat_slice().to_vec().into();
+            let arc: std::sync::Arc<[f32]> = std::sync::Arc::from(vectors.as_flat_slice());
             (d, arc)
         });
         *snapshot = Some((current_version, dim, arc.clone()));

--- a/crates/velesdb-core/src/index/hnsw/native/graph/gpu_search.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/graph/gpu_search.rs
@@ -175,7 +175,7 @@ impl<D: DistanceEngine> NativeHnsw<D> {
             // interleaved with other nodes at similar distances.
             all_results.sort_unstable_by_key(|r| r.0);
             all_results.dedup_by_key(|r| r.0);
-            all_results.sort_by(|a, b| a.1.total_cmp(&b.1));
+            all_results.sort_unstable_by(|a, b| a.1.total_cmp(&b.1));
             all_results.truncate(k);
             Some(all_results)
         }

--- a/crates/velesdb-core/src/index/hnsw/native/rabitq_precision.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/rabitq_precision.rs
@@ -360,7 +360,7 @@ impl<D: DistanceEngine> RaBitQPrecisionHnsw<D> {
             Vec::new()
         };
 
-        reranked.sort_by(|a, b| a.1.total_cmp(&b.1));
+        reranked.sort_unstable_by(|a, b| a.1.total_cmp(&b.1));
         reranked.truncate(k);
         reranked
     }

--- a/crates/velesdb-core/src/index/hnsw/native/rabitq_traversal.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/rabitq_traversal.rs
@@ -159,7 +159,7 @@ impl<D: DistanceEngine> RaBitQPrecisionHnsw<D> {
 
         let mut result_vec: Vec<(NodeId, f32)> =
             results.into_iter().map(|dn| (dn.node, dn.dist)).collect();
-        result_vec.sort_by(|a, b| a.1.total_cmp(&b.1));
+        result_vec.sort_unstable_by(|a, b| a.1.total_cmp(&b.1));
         result_vec.truncate(k);
         result_vec
     }

--- a/crates/velesdb-core/src/index/trigram/index.rs
+++ b/crates/velesdb-core/src/index/trigram/index.rs
@@ -373,7 +373,7 @@ impl TrigramIndex {
             .collect();
 
         // Sort by score descending
-        results.sort_by(|a, b| b.1.total_cmp(&a.1));
+        results.sort_unstable_by(|a, b| b.1.total_cmp(&a.1));
 
         results
     }

--- a/crates/velesdb-core/src/quantization/pq_opq.rs
+++ b/crates/velesdb-core/src/quantization/pq_opq.rs
@@ -206,7 +206,7 @@ fn sort_eigenvectors_into_rotation(cov: &[f64], q_cols: &[Vec<f64>], d: usize) -
             (lambda, j)
         })
         .collect();
-    eigenvalue_col_pairs.sort_by(|a, b| b.0.total_cmp(&a.0));
+    eigenvalue_col_pairs.sort_unstable_by(|a, b| b.0.total_cmp(&a.0));
 
     let mut rotation = vec![0.0_f32; d * d];
     for (i, (_, col_idx)) in eigenvalue_col_pairs.iter().enumerate() {

--- a/crates/velesdb-migrate/src/retry.rs
+++ b/crates/velesdb-migrate/src/retry.rs
@@ -109,27 +109,23 @@ fn rand_jitter() -> f64 {
 
 /// Determines if an error is retryable.
 pub fn is_retryable_error(error: &Error) -> bool {
-    // Check error message for retryable patterns
-    let error_msg = error.to_string().to_lowercase();
-
-    // Rate limits are always retryable
+    // Check struct-level variants first to avoid the string allocation.
     if matches!(error, Error::RateLimit(_)) {
         return true;
     }
-
-    // IO errors are often transient
     if matches!(error, Error::Io(_)) {
         return true;
     }
 
-    // HTTP errors - check for retryable status codes
+    // Fall back to message inspection — allocate the lowercase string once.
+    let error_msg = error.to_string().to_lowercase();
+
     if matches!(error, Error::Http(_)) {
         return error_msg.contains("timeout")
             || error_msg.contains("connection")
             || error_msg.contains("reset");
     }
 
-    // Check message content for retryable patterns
     let is_rate_limit = error_msg.contains("429")
         || error_msg.contains("rate limit")
         || error_msg.contains("too many requests");
@@ -147,13 +143,7 @@ pub fn is_retryable_error(error: &Error) -> bool {
         || error_msg.contains("bad gateway")
         || error_msg.contains("service unavailable");
 
-    // Source/Extraction errors with retryable messages
-    match error {
-        Error::SourceConnection(_) | Error::Extraction(_) => {
-            is_rate_limit || is_transient || is_server_error
-        }
-        _ => is_rate_limit || is_transient || is_server_error,
-    }
+    is_rate_limit || is_transient || is_server_error
 }
 
 /// Executes an async operation with retry logic.


### PR DESCRIPTION
## Summary

Systematic performance and correctness pass across `velesdb-core` and `velesdb-migrate`, applying Rust best practices (2026 idioms). Six atomic commits, each independently verifiable. Supersedes #840 (closed — branch naming violated git-flow rules).

### Commit 1 — `perf(histogram)`: O(n²)→O(n) bucket construction; NaN guard in oversampled_k

**`crates/velesdb-core/src/collection/stats/histogram.rs`**

`build_equidepth_buckets` called `upper_bound_for_chunk` N times; each call summed all prior bucket counts to recompute the slice offset → O(n²) total work. Fixed by tracking `offset` as a running counter, passing it directly to `upper_bound_for_chunk` → O(n).

```rust
// Before (O(n²)):
for chunk in sorted.chunks(chunk_size) {
    let upper = upper_bound_for_chunk(chunk, sorted, &buckets); // re-sums all prior counts
    buckets.push(...);
}

// After (O(n)):
let mut offset = 0usize;
for chunk in sorted.chunks(chunk_size) {
    let upper = upper_bound_for_chunk(chunk, sorted, offset);
    offset += chunk.len();
    buckets.push(...);
}
```

**`crates/velesdb-core/src/collection/search/vector_filter.rs`**

`estimate_filter_selectivity` returns `0.0` for empty `IN {}` clauses. Dividing by that selectivity to compute `oversampled_k` yields NaN for k=0 (0/0) or Inf for k>0. Both are clamped downstream but NaN→usize is implementation-defined on LLVM. Added `.max(1e-9)` guard before division.

### Commit 2 — `perf(search)`: merge double config reads; sort_unstable_by across score sorts

**`crates/velesdb-core/src/collection/search/batch.rs`**

`search_batch_with_filters` and `search_batch_parallel` each called `self.config.read()` twice (once for `dimension`, once for `metric`). Merged into a single lock scope.

**Score sorts — 8 sites** (`resolve.rs`, `text.rs`, `distance.rs`, `similarity_filter.rs`, `fusion/strategy.rs`, `rabitq_traversal.rs`, `rabitq_precision.rs`, `dual_precision.rs`):

`sort_by` → `sort_unstable_by`. Score-ranking has no meaningful stable-sort semantics; unstable sort (pdqsort) avoids merge-sort's O(n) auxiliary allocation and is typically 10–40% faster on f32 slices.

### Commit 3 — `perf(bulk-insert)`: &[(u64, &[f32])] slice ref; sort_unstable_by in DISTINCT/MATCH

**`crates/velesdb-core/src/collection/core/crud_indexing.rs`**

`bulk_index_or_defer` accepted `Vec<(u64, &[f32])>` (owned), forcing `crud_bulk.rs` to call `.to_vec()` on an already-materialised slice. Changed to `&[(u64, &[f32])]`; callers pass the slice directly. `.iter().copied()` is valid because `(u64, &[f32])` is `Copy`.

**`crates/velesdb-core/src/collection/search/query/distinct.rs`**

`canonical_json_string`: `keys.sort()` → `keys.sort_unstable()`.

**`crates/velesdb-core/src/collection/search/query/match_exec/similarity.rs`**

`sort_by_score`: `sort_by` → `sort_unstable_by`.

### Commit 4 — `perf(sort)`: sort_unstable_by in pq_opq and GPU result sort

`crates/velesdb-core/src/quantization/pq_opq.rs` — eigenvalue sort.
`crates/velesdb-core/src/gpu/gpu_traversal.rs` — GPU candidate sort.
`crates/velesdb-core/src/index/trigram/index.rs` — trigram candidate sort.

### Commit 5 — `fix(retry)` + `perf(distinct,gpu)`

**`crates/velesdb-migrate/src/retry.rs`** — `is_retryable_error`:

Eager `error.to_string().to_lowercase()` allocated a heap String on every call, even for `Error::RateLimit` and `Error::Io` which return `true` immediately. Moved the allocation below both early-return checks. Removed vacuous `match` block whose two arms produced identical expressions.

**`crates/velesdb-core/src/collection/search/query/distinct.rs`** — score key:

`key.push_str(&result.score.to_string())` allocated a temporary `String`. Replaced with `write!(key, "\x1F{}", result.score)` (infallible `fmt::Write` into `String`).

**`crates/velesdb-core/src/index/hnsw/native/graph/gpu_search.rs`** — vector snapshot:

`vectors.as_flat_slice().to_vec().into()` performed two allocations (Vec heap + Arc heap) plus one copy. `Arc::from(vectors.as_flat_slice())` copies directly into the Arc allocation: one allocation, one copy.

### Commit 6 — `style`: fix rustfmt line-length violations

Two chained method calls introduced above exceeded the project's 100-char line width. Fixed with `cargo fmt`.

## Test plan

- [x] `cargo fmt --all -- --check` — zero diffs
- [x] `cargo clippy -p velesdb-core -p velesdb-migrate` — zero warnings
- [x] `cargo test -p velesdb-core` — 4 759 unit tests pass
- [x] `cargo test -p velesdb-migrate` — 15 tests pass
- [x] All changes are purely internal (no public API surface changes)
- [x] Lock ordering invariants preserved (no new lock acquisitions)
- [x] No unsafe code introduced

_Date: 2026-05-16_

https://claude.ai/code/session_01VvFNBSnCEcUhpSaFKg1A1s
