### PR TITLE
docs(examples): bump wasm-browser-demo CDN snippets to 1.15.0

### DIFF
--- a/examples/wasm-browser-demo/README.md
+++ b/examples/wasm-browser-demo/README.md
@@ -22,7 +22,7 @@ cd crates/velesdb-wasm
 wasm-pack build --target web --out-dir ../../examples/wasm-browser-demo/pkg
 
 # Then update index.html to use the local path instead of CDN:
-# Change: import init from 'https://unpkg.com/@wiscale/velesdb-wasm@1.14.2/velesdb_wasm.js'
+# Change: import init from 'https://unpkg.com/@wiscale/velesdb-wasm@1.15.0/velesdb_wasm.js'
 # To:     import init from './pkg/velesdb_wasm.js'
 ```
 
@@ -80,7 +80,7 @@ Typical results on modern hardware:
 ```html
 <script type="module">
   // If published on npm:
-  // import init, { VectorStore } from 'https://unpkg.com/@wiscale/velesdb-wasm@1.14.2/velesdb_wasm.js';
+  // import init, { VectorStore } from 'https://unpkg.com/@wiscale/velesdb-wasm@1.15.0/velesdb_wasm.js';
   // If built locally with wasm-pack:
   import init, { VectorStore } from './pkg/velesdb_wasm.js';
 


### PR DESCRIPTION
## Summary
- `examples/wasm-browser-demo/index.html` already pins `@wiscale/velesdb-wasm@1.15.0` on lines 174-175.
- The companion `README.md` had two snippets (build instructions + integration example) that still cited the older `@1.14.2` tag.
- Aligns the README with the actual code so copy-pasters get a CDN URL that exists and matches v1.15.0 behavior (JOIN OUTER, EXPLAIN ANALYZE).

## Context
Spotted during a full audit of demos + examples against the current code on 2026-05-16. All other WASM/Node/React demos already track `1.15.0`.

## Test plan
- [ ] CI: Demos & Examples Smoke job remains green (no executable code change — README only).
- [ ] Manual: open `examples/wasm-browser-demo/README.md` and confirm both snippets show `@wiscale/velesdb-wasm@1.15.0`.
