### PR TITLE
fix(python-stub): TraversalResultDict keys match the PyO3 binding output

### DIFF
--- a/crates/velesdb-python/python/velesdb/__init__.pyi
+++ b/crates/velesdb-python/python/velesdb/__init__.pyi
@@ -44,13 +44,18 @@ class GraphNodeDict(TypedDict, total=False):
 
 
 class TraversalResultDict(TypedDict, total=False):
-    """Shape of a traversal step (BFS/DFS) returned by ``traverse_*`` methods."""
+    """Shape of a traversal step (BFS/DFS) returned by ``traverse_*`` methods.
 
-    node_id: int
+    The keys mirror exactly what the PyO3 binding emits in
+    ``crates/velesdb-python/src/graph.rs::traversal_to_dict``.
+    """
+
+    target_id: int
+    """ID of the node reached at this traversal step."""
+    path: List[int]
+    """Node IDs visited from the source up to and including ``target_id``."""
     depth: int
-    parent_id: Optional[int]
-    label: Optional[str]
-    payload: Optional[Dict[str, Any]]
+    """Number of edges from the source to ``target_id`` (source = depth 0)."""
 
 
 class FusionStrategy:


### PR DESCRIPTION
## Summary
- `crates/velesdb-python/src/graph.rs::traversal_to_dict` (lines 147-153) emits dicts with `{target_id, path, depth}` keys.
- `__init__.pyi`'s `TraversalResultDict` declared the entirely different set `{node_id, depth, parent_id, label, payload}`.
- Runtime users (e.g. `examples/python/graph_traversal.py`) were silently correct because they used the actual binding keys. Anyone trusting the type stub (mypy, Pylance, IDE autocomplete) would index by names that don't exist and hit `KeyError` at runtime.
- Cross-checked against `crates/velesdb-python/src/graph_collection.rs:299, 330` doc-strings, which already documented the correct `target_id, path, depth` shape.

## Change
Update the `TraversalResultDict` TypedDict to mirror what the binding actually emits, with a docstring pointer to the Rust function that produces the dict so the two stay in sync.

## Context
Discovered during a full audit of demos + examples against the current code on 2026-05-16. The `examples/python/graph_traversal.py` example was initially flagged as broken by an audit subagent that trusted the stub; deeper inspection showed the example was right and the stub was the actual defect.

This is one of three docs/stub PRs from that audit:
- [#842](https://github.com/cyberlife-coder/VelesDB/pull/842) — wasm-browser-demo CDN snippets
- [#843](https://github.com/cyberlife-coder/VelesDB/pull/843) — rag-pdf-demo README (embedded SDK arch)
- this PR — Python stub matches binding

## Test plan
- [ ] CI: existing `cargo make ci` + Python integration tests stay green (no runtime change — `.pyi` stub only).
- [ ] Manual: `python -c "from velesdb import *"` and check `TraversalResultDict.__annotations__` matches `{target_id, path, depth}`.
- [ ] Manual: run `examples/python/graph_traversal.py` end-to-end and confirm result keys agree with the new stub.
