### PR TITLE
perf: sort_unstable_by sweep and reduce reindex log allocation

### DIFF
--- a/crates/velesdb-core/src/collection/graph/clustered_index.rs
+++ b/crates/velesdb-core/src/collection/graph/clustered_index.rs
@@ -272,7 +272,7 @@ impl ClusteredIndex {
         }
 
         // Sort by offset
-        self.free_slots.sort_by_key(|(offset, _)| *offset);
+        self.free_slots.sort_unstable_by_key(|(offset, _)| *offset);
 
         // Merge adjacent slots
         let mut i = 0;

--- a/crates/velesdb-core/src/collection/graph/property_index/advisor.rs
+++ b/crates/velesdb-core/src/collection/graph/property_index/advisor.rs
@@ -98,7 +98,7 @@ impl QueryPatternTracker {
     #[must_use]
     pub fn expensive_patterns(&self) -> Vec<(&QueryPattern, &PatternStats)> {
         let mut patterns: Vec<_> = self.patterns.iter().collect();
-        patterns.sort_by_key(|b| std::cmp::Reverse(b.1.total_time_ms));
+        patterns.sort_unstable_by_key(|b| std::cmp::Reverse(b.1.total_time_ms));
         patterns
     }
 
@@ -195,8 +195,7 @@ impl IndexAdvisor {
             });
         }
 
-        // Sort by priority (highest first)
-        suggestions.sort_by(|a, b| {
+        suggestions.sort_unstable_by(|a, b| {
             b.priority_score
                 .partial_cmp(&a.priority_score)
                 .unwrap_or(std::cmp::Ordering::Equal)

--- a/crates/velesdb-core/src/collection/search/query/aggregation/having.rs
+++ b/crates/velesdb-core/src/collection/search/query/aggregation/having.rs
@@ -43,7 +43,7 @@ impl Collection {
             })
             .collect();
 
-        results.sort_by(|a, b| {
+        results.sort_unstable_by(|a, b| {
             for (column, descending) in &sort_columns {
                 let val_a = a.get(column);
                 let val_b = b.get(column);

--- a/crates/velesdb-core/src/collection/search/query/match_dispatch.rs
+++ b/crates/velesdb-core/src/collection/search/query/match_dispatch.rs
@@ -368,13 +368,13 @@ fn sort_match_results_by_score(
     higher_is_better: bool,
 ) {
     if higher_is_better {
-        merged.sort_by(|a, b| {
+        merged.sort_unstable_by(|a, b| {
             let sa = a.score.unwrap_or(f32::NEG_INFINITY);
             let sb = b.score.unwrap_or(f32::NEG_INFINITY);
             sb.total_cmp(&sa)
         });
     } else {
-        merged.sort_by(|a, b| {
+        merged.sort_unstable_by(|a, b| {
             let sa = a.score.unwrap_or(f32::MAX);
             let sb = b.score.unwrap_or(f32::MAX);
             sa.total_cmp(&sb)

--- a/crates/velesdb-core/src/collection/search/query/match_exec/similarity.rs
+++ b/crates/velesdb-core/src/collection/search/query/match_exec/similarity.rs
@@ -318,7 +318,7 @@ impl Collection {
     ) {
         match order_by {
             "similarity()" | "similarity" => {
-                results.sort_by(|a, b| {
+                results.sort_unstable_by(|a, b| {
                     let cmp = a.score.unwrap_or(0.0).total_cmp(&b.score.unwrap_or(0.0));
                     if descending {
                         cmp.reverse()
@@ -328,7 +328,7 @@ impl Collection {
                 });
             }
             "depth" => {
-                results.sort_by(|a, b| {
+                results.sort_unstable_by(|a, b| {
                     let cmp = a.depth.cmp(&b.depth);
                     if descending {
                         cmp.reverse()
@@ -340,7 +340,7 @@ impl Collection {
             _ => {
                 if let Some((alias, property)) = parse_property_path(order_by) {
                     let payload_storage = self.payload_storage.read();
-                    results.sort_by(|a, b| {
+                    results.sort_unstable_by(|a, b| {
                         let get_value = |r: &MatchResult| -> Option<serde_json::Value> {
                             let node_id = *r.bindings.get(alias)?;
                             let payload = payload_storage.retrieve(node_id).ok().flatten()?;

--- a/crates/velesdb-core/src/collection/search/query/ordering.rs
+++ b/crates/velesdb-core/src/collection/search/query/ordering.rs
@@ -105,7 +105,7 @@ impl Collection {
         let higher_is_better = self.config.read().metric.higher_is_better();
 
         let mut indices: Vec<usize> = (0..results.len()).collect();
-        indices.sort_by(|&i, &j| {
+        indices.sort_unstable_by(|&i, &j| {
             Self::compare_by_order_columns(
                 i,
                 j,

--- a/crates/velesdb-core/src/collection/search/query/parallel_traversal/traverser.rs
+++ b/crates/velesdb-core/src/collection/search/query/parallel_traversal/traverser.rs
@@ -90,7 +90,7 @@ impl ParallelTraverser {
             .collect();
 
         // Sort by score descending (highest first), break ties by depth ascending
-        unique.sort_by(|a, b| {
+        unique.sort_unstable_by(|a, b| {
             let score_cmp = b
                 .score
                 .unwrap_or(f32::NEG_INFINITY)

--- a/crates/velesdb-core/src/collection/search/query/set_operations.rs
+++ b/crates/velesdb-core/src/collection/search/query/set_operations.rs
@@ -29,8 +29,7 @@ pub(crate) fn apply_set_operation(
         SetOperator::Except => except(left, &right),
     };
 
-    // Stable sort by score descending.
-    results.sort_by(|a, b| {
+    results.sort_unstable_by(|a, b| {
         b.score
             .partial_cmp(&a.score)
             .unwrap_or(std::cmp::Ordering::Equal)

--- a/crates/velesdb-core/src/collection/search/query/union_query.rs
+++ b/crates/velesdb-core/src/collection/search/query/union_query.rs
@@ -68,7 +68,7 @@ impl Collection {
         let mut results: Vec<SearchResult> = results_map.into_values().collect();
 
         // Sort by score descending (similarity matches first)
-        results.sort_by(|a, b| {
+        results.sort_unstable_by(|a, b| {
             b.score
                 .partial_cmp(&a.score)
                 .unwrap_or(std::cmp::Ordering::Equal)

--- a/crates/velesdb-core/src/collection/stats/mod.rs
+++ b/crates/velesdb-core/src/collection/stats/mod.rs
@@ -259,7 +259,7 @@ impl StatsCollector {
         self.stats
             .column_stats
             .insert(stats.name.clone(), stats.clone());
-        self.stats.field_stats.insert(stats.name.clone(), stats);
+        self.stats.field_stats.insert(stats.name, stats);
     }
 
     /// Adds index statistics

--- a/crates/velesdb-core/src/collection/stats/mod.rs
+++ b/crates/velesdb-core/src/collection/stats/mod.rs
@@ -259,7 +259,7 @@ impl StatsCollector {
         self.stats
             .column_stats
             .insert(stats.name.clone(), stats.clone());
-        self.stats.field_stats.insert(stats.name, stats);
+        self.stats.field_stats.insert(stats.name.clone(), stats);
     }
 
     /// Adds index statistics

--- a/crates/velesdb-core/src/collection/types.rs
+++ b/crates/velesdb-core/src/collection/types.rs
@@ -527,9 +527,8 @@ impl Collection {
         };
         let (params, size, dimension) = self.auto_reindex_inputs();
         if manager.should_reindex(&params, size, dimension) {
-            let name = self.config.read().name.clone();
             tracing::info!(
-                collection = %name,
+                collection = %self.config.read().name,
                 current_size = size,
                 dimension = dimension,
                 "auto-reindex manager reports divergence — reindex recommended"

--- a/crates/velesdb-core/src/index/hnsw/native/int8_traversal.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/int8_traversal.rs
@@ -90,7 +90,7 @@ impl<D: DistanceEngine> DualPrecisionHnsw<D> {
         }
 
         let mut result_vec: Vec<(NodeId, u32)> = results.into_iter().map(|(d, n)| (n, d)).collect();
-        result_vec.sort_by_key(|&(_, d)| d);
+        result_vec.sort_unstable_by_key(|&(_, d)| d);
         result_vec.truncate(k);
         result_vec
     }

--- a/crates/velesdb-core/src/metrics/retrieval.rs
+++ b/crates/velesdb-core/src/metrics/retrieval.rs
@@ -200,7 +200,7 @@ pub fn ndcg_at_k(relevances: &[f64], k: usize) -> f64 {
     let dcg = compute_dcg(relevances, k);
 
     let mut sorted_relevances = relevances.to_vec();
-    sorted_relevances.sort_by(|a, b| b.partial_cmp(a).unwrap_or(std::cmp::Ordering::Equal));
+    sorted_relevances.sort_unstable_by(|a, b| b.partial_cmp(a).unwrap_or(std::cmp::Ordering::Equal));
     let idcg = compute_dcg(&sorted_relevances, k);
 
     if idcg == 0.0 {

--- a/crates/velesdb-core/src/sparse_index/search/mod.rs
+++ b/crates/velesdb-core/src/sparse_index/search/mod.rs
@@ -164,7 +164,7 @@ pub(crate) fn brute_force_search(
         .into_iter()
         .map(|(doc_id, score)| ScoredDoc { score, doc_id })
         .collect();
-    all_docs.sort_by(|a, b| b.cmp(a)); // descending
+    all_docs.sort_unstable_by(|a, b| b.cmp(a)); // descending
     all_docs.truncate(k);
     all_docs
 }

--- a/crates/velesdb-core/src/sparse_index/search/scoring.rs
+++ b/crates/velesdb-core/src/sparse_index/search/scoring.rs
@@ -53,7 +53,7 @@ pub(crate) fn prepare_term_data(
     }
 
     // Sort by max_contribution ascending (least contributing first)
-    terms.sort_by(|a, b| {
+    terms.sort_unstable_by(|a, b| {
         let ca = a.query_weight.abs() * a.max_doc_weight;
         let cb = b.query_weight.abs() * b.max_doc_weight;
         ca.total_cmp(&cb)
@@ -131,6 +131,6 @@ pub(crate) fn find_split(upper_bound: &[f32], threshold: f32) -> usize {
 /// Extract results from a min-heap and sort descending by score.
 pub(crate) fn extract_sorted_results(heap: BinaryHeap<Reverse<ScoredDoc>>) -> Vec<ScoredDoc> {
     let mut results: Vec<ScoredDoc> = heap.into_iter().map(|Reverse(s)| s).collect();
-    results.sort_by(|a, b| b.cmp(a)); // descending
+    results.sort_unstable_by(|a, b| b.cmp(a)); // descending
     results
 }

--- a/crates/velesdb-core/src/sparse_index/types.rs
+++ b/crates/velesdb-core/src/sparse_index/types.rs
@@ -41,7 +41,7 @@ impl SparseVector {
         }
 
         // Sort by index
-        pairs.sort_by_key(|&(idx, _)| idx);
+        pairs.sort_unstable_by_key(|&(idx, _)| idx);
 
         let mut indices = Vec::with_capacity(pairs.len());
         let mut values = Vec::with_capacity(pairs.len());


### PR DESCRIPTION
## Superseded

This PR was replaced by #848 because the original source branch prefix was rejected by PR Governance for targeting `develop`.

Replacement PR: https://github.com/cyberlife-coder/VelesDB/pull/848

The replacement PR uses the same head commit (`66354a82b9f40e5dcc0dc466f4629ee81be6a2de`) from an allowed `perf/*` branch and keeps the corrected PR description.