### PR TITLE
fix(core): align GPU feature gates

### DIFF
--- a/crates/velesdb-core/benches/datasets/sift1m.rs
+++ b/crates/velesdb-core/benches/datasets/sift1m.rs
@@ -345,9 +345,7 @@ fn is_fully_cached(cache_dir: &Path) -> bool {
 }
 
 fn download_allowed() -> bool {
-    std::env::var(ENV_ALLOW_DOWNLOAD)
-        .map(|v| v != "0" && !v.eq_ignore_ascii_case("false"))
-        .unwrap_or(true)
+    std::env::var(ENV_ALLOW_DOWNLOAD).map_or(true, |v| v != "0" && !v.eq_ignore_ascii_case("false"))
 }
 
 fn download_and_extract(cache_dir: &Path) -> Result<(), DatasetError> {

--- a/crates/velesdb-core/benches/scalability_benchmark.rs
+++ b/crates/velesdb-core/benches/scalability_benchmark.rs
@@ -135,7 +135,7 @@ fn get_memory_usage() -> usize {
     // Reason: benchmark needs peak RSS.
     unsafe {
         let mut usage = MaybeUninit::<Rusage>::zeroed().assume_init();
-        if getrusage(0, &mut usage) == 0 {
+        if getrusage(0, &raw mut usage) == 0 {
             usage.ru_maxrss as usize
         } else {
             0

--- a/crates/velesdb-core/benches/simd_benchmark.rs
+++ b/crates/velesdb-core/benches/simd_benchmark.rs
@@ -8,7 +8,7 @@
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
 #[cfg(feature = "internal-bench")]
 use velesdb_core::internal_bench;
-#[cfg(feature = "internal-bench")]
+#[cfg(all(feature = "internal-bench", target_arch = "x86_64"))]
 use velesdb_core::simd_native::SimdLevel;
 use velesdb_core::simd_native::{
     batch_hamming_native, batch_jaccard_native, cosine_similarity_native, dot_product_native,
@@ -94,7 +94,7 @@ fn bench_cosine_similarity(c: &mut Criterion) {
             bencher.iter(|| engine.cosine_similarity(black_box(&a), black_box(&b)));
         });
 
-        #[cfg(feature = "internal-bench")]
+        #[cfg(all(feature = "internal-bench", target_arch = "x86_64"))]
         if matches!(
             internal_bench::detected_simd_level(),
             SimdLevel::Avx2 | SimdLevel::Avx512
@@ -128,7 +128,7 @@ fn bench_cosine_similarity(c: &mut Criterion) {
             );
         }
 
-        #[cfg(feature = "internal-bench")]
+        #[cfg(all(feature = "internal-bench", target_arch = "x86_64"))]
         if matches!(internal_bench::detected_simd_level(), SimdLevel::Avx512) {
             group.bench_with_input(BenchmarkId::new("kernel_avx512", dim), dim, |bencher, _| {
                 warmup(|| {

--- a/crates/velesdb-core/src/gpu.rs
+++ b/crates/velesdb-core/src/gpu.rs
@@ -32,7 +32,7 @@ mod gpu_backend;
 #[path = "gpu/gpu_backend_tests.rs"]
 mod gpu_backend_tests;
 
-#[cfg(all(test, feature = "gpu"))]
+#[cfg(all(test, feature = "gpu", feature = "persistence"))]
 #[path = "gpu/gpu_csr_tests.rs"]
 mod gpu_csr_extended_tests;
 
@@ -40,25 +40,25 @@ mod gpu_csr_extended_tests;
 #[path = "gpu/pq_gpu.rs"]
 pub mod pq_gpu;
 
-#[cfg(feature = "gpu")]
+#[cfg(all(feature = "gpu", feature = "persistence"))]
 #[path = "gpu/gpu_csr.rs"]
 pub mod gpu_csr;
 
-#[cfg(feature = "gpu")]
+#[cfg(all(feature = "gpu", feature = "persistence"))]
 #[path = "gpu/gpu_traversal_buffers.rs"]
 mod gpu_traversal_buffers;
 
-#[cfg(feature = "gpu")]
+#[cfg(all(feature = "gpu", feature = "persistence"))]
 #[path = "gpu/gpu_traversal_pipelines.rs"]
 mod gpu_traversal_pipelines;
 
-#[cfg(feature = "gpu")]
+#[cfg(all(feature = "gpu", feature = "persistence"))]
 #[path = "gpu/gpu_traversal.rs"]
 pub mod gpu_traversal;
 
 #[cfg(feature = "gpu")]
 pub use gpu_backend::GpuAccelerator;
-#[cfg(feature = "gpu")]
+#[cfg(all(feature = "gpu", feature = "persistence"))]
 pub use gpu_traversal::{should_traverse_gpu, GpuTraversalContext, GpuTraversalStats};
 #[cfg(feature = "gpu")]
 pub use pq_gpu::{gpu_kmeans_assign, should_use_gpu, PqGpuContext};
@@ -70,8 +70,8 @@ pub fn should_use_gpu(_n: usize, _k: usize, _subspace_dim: usize) -> bool {
     false
 }
 
-/// Check if GPU traversal is worthwhile (always false without gpu feature).
-#[cfg(not(feature = "gpu"))]
+/// Check if GPU traversal is worthwhile (always false without GPU HNSW traversal support).
+#[cfg(not(all(feature = "gpu", feature = "persistence")))]
 #[must_use]
 pub fn should_traverse_gpu(_num_vectors: usize, _dimension: usize) -> bool {
     false

--- a/crates/velesdb-core/src/gpu/shaders.rs
+++ b/crates/velesdb-core/src/gpu/shaders.rs
@@ -180,6 +180,7 @@ fn batch_dot(@builtin(global_invocation_id) id: vec3<u32>) {
 /// - binding 4: `storage(read_write)` — visited bitset (atomic u32 words)
 /// - binding 5: `storage(read_write)` — counters (atomic: [0]=candidate_count)
 /// - binding 6: `uniform` — params
+#[cfg(feature = "persistence")]
 pub(crate) const EXPAND_FRONTIER_SHADER: &str = r"
 struct ExpandParams {
     num_frontier: u32,
@@ -253,6 +254,7 @@ fn expand_frontier(@builtin(global_invocation_id) id: vec3<u32>) {
 /// - binding 2: `storage(read)` — candidate_ids (node IDs from expand pass)
 /// - binding 3: `storage(read_write)` — results (distances, one per candidate)
 /// - binding 4: `uniform` — params (dimension, max_candidates)
+#[cfg(feature = "persistence")]
 pub(crate) const TRAVERSAL_EUCLIDEAN_SQ_SHADER: &str = r"
 struct Params {
     dimension: u32,
@@ -300,6 +302,7 @@ fn traversal_euclidean_sq(@builtin(global_invocation_id) id: vec3<u32>) {
 /// Same u32 offset limit as `TRAVERSAL_EUCLIDEAN_SQ_SHADER`: callers must
 /// ensure `num_vectors * dim <= u32::MAX` (gated by
 /// [`crate::gpu::should_traverse_gpu`]).
+#[cfg(feature = "persistence")]
 pub(crate) const TRAVERSAL_COSINE_SHADER: &str = r"
 struct Params {
     dimension: u32,
@@ -356,6 +359,7 @@ fn traversal_cosine(@builtin(global_invocation_id) id: vec3<u32>) {
 /// Same u32 offset limit as `TRAVERSAL_EUCLIDEAN_SQ_SHADER`: callers must
 /// ensure `num_vectors * dim <= u32::MAX` (gated by
 /// [`crate::gpu::should_traverse_gpu`]).
+#[cfg(feature = "persistence")]
 pub(crate) const TRAVERSAL_DOT_PRODUCT_SHADER: &str = r"
 struct Params {
     dimension: u32,
@@ -443,6 +447,7 @@ fn traversal_dot(@builtin(global_invocation_id) id: vec3<u32>) {
 /// iteration at `num_candidates` = 8192 / `k` = 128. Acceptable for the
 /// advertised 500K–5M-vector GPU range; a parallel reduction is a future
 /// perf win (tracked separately).
+#[cfg(feature = "persistence")]
 pub(crate) const SELECT_TOPK_SHADER: &str = r"
 struct SelectParams {
     num_candidates: u32,

--- a/crates/velesdb-core/src/index/trigram/simd.rs
+++ b/crates/velesdb-core/src/index/trigram/simd.rs
@@ -35,6 +35,7 @@ pub(crate) enum TrigramSimdLevel {
     #[cfg(target_arch = "aarch64")]
     Neon,
     /// Scalar fallback
+    #[cfg(not(target_arch = "aarch64"))]
     Scalar,
 }
 
@@ -50,15 +51,19 @@ impl TrigramSimdLevel {
             if is_x86_feature_detected!("avx2") {
                 return Self::Avx2;
             }
+            Self::Scalar
         }
 
         #[cfg(target_arch = "aarch64")]
         {
             // NEON is always available on aarch64
-            return Self::Neon;
+            Self::Neon
         }
 
-        Self::Scalar
+        #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
+        {
+            Self::Scalar
+        }
     }
 
     /// Get the name of the SIMD level
@@ -72,6 +77,7 @@ impl TrigramSimdLevel {
             Self::Avx2 => "AVX2",
             #[cfg(target_arch = "aarch64")]
             Self::Neon => "NEON",
+            #[cfg(not(target_arch = "aarch64"))]
             Self::Scalar => "Scalar",
         }
     }
@@ -91,6 +97,7 @@ pub fn extract_trigrams_simd(text: &str) -> HashSet<Trigram> {
         TrigramSimdLevel::Avx2 => extract_trigrams_avx2(text),
         #[cfg(target_arch = "aarch64")]
         TrigramSimdLevel::Neon => extract_trigrams_neon(text),
+        #[cfg(not(target_arch = "aarch64"))]
         TrigramSimdLevel::Scalar => extract_trigrams_scalar(text),
     }
 }

--- a/crates/velesdb-core/src/index/trigram/simd_tests.rs
+++ b/crates/velesdb-core/src/index/trigram/simd_tests.rs
@@ -138,9 +138,17 @@ fn test_extract_trigrams_scalar_two_chars() {
 }
 
 #[test]
+#[cfg(not(target_arch = "aarch64"))]
 fn test_trigram_simd_level_name() {
     let level = TrigramSimdLevel::Scalar;
     assert_eq!(level.name(), "Scalar");
+}
+
+#[test]
+#[cfg(target_arch = "aarch64")]
+fn test_trigram_simd_level_name() {
+    let level = TrigramSimdLevel::Neon;
+    assert_eq!(level.name(), "NEON");
 }
 
 #[test]

--- a/crates/velesdb-core/src/simd_native/adc.rs
+++ b/crates/velesdb-core/src/simd_native/adc.rs
@@ -239,8 +239,8 @@ unsafe fn adc_single_neon(lut: &[f32], code: &[u16], m: usize, k: usize) -> f32 
 
     // Handle tail subspaces with scalar loop
     let tail_start = full_chunks * 4;
-    for subspace in tail_start..tail_start + tail {
-        let idx = subspace * k + usize::from(code[subspace]);
+    for (subspace, &codeword) in code.iter().enumerate().skip(tail_start).take(tail) {
+        let idx = subspace * k + usize::from(codeword);
         total += lut[idx];
     }
 

--- a/crates/velesdb-core/src/simd_native/neon.rs
+++ b/crates/velesdb-core/src/simd_native/neon.rs
@@ -75,7 +75,7 @@ pub(crate) fn dot_product_neon(a: &[f32], b: &[f32]) -> f32 {
 ///
 /// SAFETY: `vfmaq_f32` is a non-faulting register operation on aarch64.
 #[cfg(target_arch = "aarch64")]
-#[inline(always)]
+#[inline]
 unsafe fn neon_fma_compat(
     a: std::arch::aarch64::float32x4_t,
     b: std::arch::aarch64::float32x4_t,

--- a/crates/velesdb-core/src/simd_neon.rs
+++ b/crates/velesdb-core/src/simd_neon.rs
@@ -277,8 +277,8 @@ mod tests {
     #[test]
     fn test_dot_product_neon_768d() {
         // Test with typical embedding dimension
-        let a: Vec<f32> = (0..768).map(|i| (i as f32) * 0.001).collect();
-        let b: Vec<f32> = (0..768).map(|i| (i as f32) * 0.002).collect();
+        let a: Vec<f32> = (0_u16..768).map(|i| f32::from(i) * 0.001).collect();
+        let b: Vec<f32> = (0_u16..768).map(|i| f32::from(i) * 0.002).collect();
 
         let neon_result = dot_product_neon_safe(&a, &b);
 

--- a/crates/velesdb-core/src/simd_neon_prefetch.rs
+++ b/crates/velesdb-core/src/simd_neon_prefetch.rs
@@ -37,7 +37,7 @@
 ///
 /// * `ptr` - Pointer to the data to prefetch
 #[cfg(target_arch = "aarch64")]
-#[inline(always)]
+#[inline]
 pub fn prefetch_read_l1(ptr: *const u8) {
     // SAFETY: `asm!(prfm ...)` emits a prefetch hint only.
     // - Condition 1: `prfm` does not dereference memory architecturally.
@@ -56,7 +56,7 @@ pub fn prefetch_read_l1(ptr: *const u8) {
 ///
 /// Use this for data that will be accessed soon but not immediately.
 #[cfg(target_arch = "aarch64")]
-#[inline(always)]
+#[inline]
 pub fn prefetch_read_l2(ptr: *const u8) {
     // SAFETY: `asm!(prfm ...)` emits a prefetch hint only.
     // - Condition 1: `prfm` does not dereference memory architecturally.
@@ -75,7 +75,7 @@ pub fn prefetch_read_l2(ptr: *const u8) {
 ///
 /// Use this for data that will be accessed later in the computation.
 #[cfg(target_arch = "aarch64")]
-#[inline(always)]
+#[inline]
 pub fn prefetch_read_l3(ptr: *const u8) {
     // SAFETY: `asm!(prfm ...)` emits a prefetch hint only.
     // - Condition 1: Invalid pointers are tolerated by hardware for prefetch hints.
@@ -94,7 +94,7 @@ pub fn prefetch_read_l3(ptr: *const u8) {
 ///
 /// Use this when you know you'll be writing to the data soon.
 #[cfg(target_arch = "aarch64")]
-#[inline(always)]
+#[inline]
 pub fn prefetch_write_l1(ptr: *const u8) {
     // SAFETY: `asm!(prfm ...)` emits a write-prefetch hint only.
     // - Condition 1: This does not perform a memory store.
@@ -121,18 +121,18 @@ pub fn prefetch_write_l1(ptr: *const u8) {
 /// - 768D vector (3072B): covers 512B = 16.7%
 /// - 128D vector (512B): covers 384B = 75%
 #[cfg(target_arch = "aarch64")]
-#[inline(always)]
+#[inline]
 pub fn prefetch_vector_neon(vector: &[f32]) {
-    if vector.is_empty() {
-        return;
-    }
-
     // Apple Silicon (M1-M4) uses 128-byte cache lines.
     // Graviton uses 64B but 128B stride still improves locality.
     const ARM_CACHE_LINE: usize = 128;
 
+    if vector.is_empty() {
+        return;
+    }
+
     let base = vector.as_ptr().cast::<u8>();
-    let vector_bytes = vector.len() * std::mem::size_of::<f32>();
+    let vector_bytes = std::mem::size_of_val(vector);
 
     // Line 0 → L1
     prefetch_read_l1(base);
@@ -188,27 +188,27 @@ pub fn calculate_prefetch_distance_neon(dimension: usize) -> usize {
 
 /// No-op prefetch for non-ARM64 targets.
 #[cfg(not(target_arch = "aarch64"))]
-#[inline(always)]
+#[inline]
 pub fn prefetch_read_l1(_ptr: *const u8) {}
 
 /// No-op prefetch for non-ARM64 targets.
 #[cfg(not(target_arch = "aarch64"))]
-#[inline(always)]
+#[inline]
 pub fn prefetch_read_l2(_ptr: *const u8) {}
 
 /// No-op prefetch for non-ARM64 targets.
 #[cfg(not(target_arch = "aarch64"))]
-#[inline(always)]
+#[inline]
 pub fn prefetch_read_l3(_ptr: *const u8) {}
 
 /// No-op prefetch for non-ARM64 targets.
 #[cfg(not(target_arch = "aarch64"))]
-#[inline(always)]
+#[inline]
 pub fn prefetch_write_l1(_ptr: *const u8) {}
 
 /// No-op prefetch for non-ARM64 targets.
 #[cfg(not(target_arch = "aarch64"))]
-#[inline(always)]
+#[inline]
 pub fn prefetch_vector_neon(_vector: &[f32]) {}
 
 #[cfg(test)]
@@ -231,7 +231,7 @@ mod tests {
 
     #[test]
     fn test_prefetch_vector_neon() {
-        let vector: Vec<f32> = (0..768).map(|i| i as f32).collect();
+        let vector: Vec<f32> = (0_u16..768).map(f32::from).collect();
         prefetch_vector_neon(&vector);
         // No crash = success
     }


### PR DESCRIPTION
## Summary
- Gate GPU HNSW traversal modules and traversal shaders behind `gpu` + `persistence`, while keeping the GPU backend and PQ GPU path available under `gpu`.
- Remove the aarch64 trigram SIMD unreachable-code warning with cfg-specific detection and tests.
- Clean the aarch64 Clippy blockers surfaced by the requested `--all-targets --all-features` gate.

Closes #846

## Tests
- `cargo check -p velesdb-core --no-default-features`
- `cargo check -p velesdb-core --features gpu --no-default-features`
- `cargo check -p velesdb-core --all-features`
- `cargo check -p velesdb-core --target wasm32-unknown-unknown --no-default-features`
- `cargo test -p velesdb-core simd_native -- --nocapture`
- `cargo clippy -p velesdb-core --all-targets --all-features -- -D warnings`