### PR TITLE
ci: promote feature-claims audit to a blocking gate and run its test suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,9 +153,11 @@ jobs:
       - name: Check for .unwrap() in production code
         run: python3 scripts/check_prod_unwraps.py
 
+      - name: Test feature-claims audit script
+        run: python3 -m unittest scripts.tests.test_check_feature_claims
+
       - name: Audit feature claims vs exports
         run: python3 scripts/check-feature-claims.py
-        continue-on-error: true  # Advisory — does not block merge
 
       - name: Audit performance claims consistency
         run: python3 scripts/check-perf-claims.py --no-criterion


### PR DESCRIPTION
## Summary

Closes the quality-gate loop on the feature-claims audit by making two small but tightly related changes in the `Contract and Doc Guards` job:

1. **Drop `continue-on-error: true`** from the audit step. PR #873 brought the audit to a clean 0 MISSING / 0 [UNDOC] state across all 7 crates; the script is now stable enough to promote from advisory to blocking. Catches future doc↔API drift at the PR that introduces it, not three months later.

2. **Run the script's own unit-test suite in CI**. The 15 tests added in #873 (`scripts/tests/test_check_feature_claims.py`) pin every contract that matters — `#[cfg(test)]` stripping, prose stripping, symlink defense, the unified `_audit_crate` builder, and the real-repo regression for velesdb-python. They exist locally but nothing in CI was actually invoking them; without that wiring they cannot defend against regression.

Order matters: unit tests first, then the audit blob. If the helper logic regresses, CI surfaces the unit-test failure before the audit even runs.

## Verification

- `python3 -m unittest scripts.tests.test_check_feature_claims` — 15/15 OK locally
- `python3 scripts/check-feature-claims.py` — exits 0
- Diff is 3 lines in a single workflow file; revert is trivial if a flake ever appears

## Test plan

- [x] Local unittest run green
- [x] Local audit script green
- [ ] CI green on this branch (will arrive via webhooks)

https://claude.ai/code/session_01Lf9qtEGsYGgMCtbjGPekuy
