### PR TITLE
test(gpu)+chore(core): audit-2026q2 M4+M6 — improved property tests & dead_code sweep

### DIFF
--- a/crates/velesdb-core/src/agent/memory.rs
+++ b/crates/velesdb-core/src/agent/memory.rs
@@ -52,8 +52,8 @@ pub struct AgentMemory {
     episodic: EpisodicMemory,
     procedural: ProceduralMemory,
     ttl: Arc<MemoryTtl>,
-    // Reason: temporal_index will be used for time-based queries in future implementation
     #[allow(dead_code)]
+    // Reason: temporal_index will be used for time-based queries in future implementation
     temporal_index: Arc<TemporalIndex>,
     eviction_config: EvictionConfig,
     snapshot_manager: Option<SnapshotManager>,

--- a/crates/velesdb-core/src/collection/graph/traversal.rs
+++ b/crates/velesdb-core/src/collection/graph/traversal.rs
@@ -71,8 +71,7 @@ impl TraversalResult {
     /// public API boundary.
     #[must_use]
     #[allow(clippy::needless_pass_by_value)]
-    // Reason: Constructor used by MATCH clause traversal (Wave 6 wiring).
-    #[allow(dead_code)]
+    #[allow(dead_code)] // Reason: Constructor used by MATCH clause traversal (Wave 6 wiring)
     pub(crate) fn from_smallvec(target_id: u64, path: TraversalPath, depth: u32) -> Self {
         Self {
             target_id,

--- a/crates/velesdb-core/src/collection/search/query/hybrid_sparse.rs
+++ b/crates/velesdb-core/src/collection/search/query/hybrid_sparse.rs
@@ -52,7 +52,7 @@ impl Collection {
     ///
     /// Returns `Err` when the condition contains more than one
     /// `SparseVectorSearch` node (ambiguous multi-sparse query).
-    #[allow(dead_code)]
+    #[allow(dead_code)] // Reason: Query validator guard for multi-sparse disambiguation — wired in future planner
     pub(crate) fn validate_single_sparse_search(condition: &Condition) -> Result<()> {
         fn count(cond: &Condition) -> usize {
             match cond {
@@ -229,7 +229,7 @@ impl Collection {
     ///
     /// Currently only exercised by integration tests; production callers use
     /// [`Self::execute_hybrid_search_with_strategy`] directly.
-    #[allow(dead_code)]
+    #[allow(dead_code)] // Reason: Integration-test entry point; production callers use execute_hybrid_search_with_strategy
     pub(crate) fn execute_hybrid_search(
         &self,
         dense_vector: &[f32],

--- a/crates/velesdb-core/src/collection/search/resolve.rs
+++ b/crates/velesdb-core/src/collection/search/resolve.rs
@@ -104,7 +104,7 @@ pub(crate) fn sort_scored_by_metric(results: &mut [ScoredResult], higher_is_bett
 /// higher scores always indicate better matches.
 ///
 /// Uses unstable sort: equal-score tie-breaking order is irrelevant for ranking.
-#[allow(dead_code)]
+#[allow(dead_code)] // Reason: BM25/sparse search utility — callers exist in test suite; future SDK wiring pending
 pub(crate) fn sort_results_descending(results: &mut [SearchResult]) {
     results.sort_unstable_by(|a, b| {
         b.score

--- a/crates/velesdb-core/src/gpu/gpu_traversal.rs
+++ b/crates/velesdb-core/src/gpu/gpu_traversal.rs
@@ -535,6 +535,7 @@ impl GpuTraversalContext {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use proptest::prelude::*;
 
     #[test]
     fn test_should_traverse_gpu_threshold() {
@@ -611,6 +612,152 @@ mod tests {
                 crate::distance::DistanceMetric::Hamming,
             );
             assert!(result.is_empty());
+        }
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(300))]
+
+        /// `adaptive_gpu_iterations` output is always within [10, 20].
+        #[test]
+        fn prop_adaptive_iterations_in_range(ef in 0usize..100_000usize) {
+            let iters = adaptive_gpu_iterations(ef);
+            prop_assert!(
+                (10..=20).contains(&iters),
+                "iterations={iters} out of [10,20] for ef_search={ef}"
+            );
+        }
+
+        /// `adaptive_gpu_iterations` is monotone non-increasing over its full domain.
+        /// Generates strictly-ordered pairs to cover every step boundary, not just 64/65.
+        #[test]
+        fn prop_adaptive_iterations_monotone_nonincreasing(
+            (ef_lo, ef_hi) in (0usize..99_999usize)
+                .prop_flat_map(|lo| (lo + 1..100_000usize).prop_map(move |hi| (lo, hi))),
+        ) {
+            prop_assert!(
+                adaptive_gpu_iterations(ef_lo) >= adaptive_gpu_iterations(ef_hi),
+                "iters(ef={ef_lo}) must be >= iters(ef={ef_hi})"
+            );
+        }
+
+        /// Performance gate: n ≤ 500_000 always returns false regardless of dimension.
+        #[test]
+        fn prop_should_traverse_gpu_small_n_always_false(
+            n in 0usize..=500_000usize,
+            dim in 1usize..=4096usize,
+        ) {
+            prop_assert!(
+                !should_traverse_gpu(n, dim),
+                "n={n} <= 500_000 must return false (perf gate), dim={dim}"
+            );
+        }
+
+        /// Euclidean squared distance from a vector to itself is 0.
+        #[test]
+        fn prop_cpu_distance_euclidean_identity(
+            v in proptest::collection::vec(0.01f32..=1.0f32, 1..=64usize),
+        ) {
+            let d = gpu_distance_cpu_fallback(&v, &v, crate::distance::DistanceMetric::Euclidean);
+            prop_assert!(d.abs() < 1e-5, "Euclidean sq(v,v) must be 0, got {d}");
+        }
+
+        /// Cosine distance from a non-zero vector to itself is ≈0.
+        #[test]
+        fn prop_cpu_distance_cosine_identity(
+            v in proptest::collection::vec(0.01f32..=1.0f32, 1..=64usize),
+        ) {
+            let d = gpu_distance_cpu_fallback(&v, &v, crate::distance::DistanceMetric::Cosine);
+            prop_assert!(d.abs() < 1e-5, "Cosine dist(v,v) must be ~0, got {d}");
+        }
+
+        /// Euclidean squared distance is non-negative for any two same-length vectors.
+        #[test]
+        fn prop_cpu_distance_euclidean_nonneg(
+            vw in (1usize..=32usize).prop_flat_map(|len| (
+                proptest::collection::vec(-1.0f32..=1.0f32, len),
+                proptest::collection::vec(-1.0f32..=1.0f32, len),
+            )),
+        ) {
+            let (v, w) = vw;
+            let d = gpu_distance_cpu_fallback(&v, &w, crate::distance::DistanceMetric::Euclidean);
+            prop_assert!(d >= 0.0, "Euclidean sq must be non-negative, got {d}");
+        }
+
+        /// Euclidean squared distance is symmetric: d(a,b) == d(b,a).
+        #[test]
+        fn prop_cpu_distance_euclidean_symmetric(
+            vw in (1usize..=32usize).prop_flat_map(|len| (
+                proptest::collection::vec(-1.0f32..=1.0f32, len),
+                proptest::collection::vec(-1.0f32..=1.0f32, len),
+            )),
+        ) {
+            let (v, w) = vw;
+            let d_ab = gpu_distance_cpu_fallback(&v, &w, crate::distance::DistanceMetric::Euclidean);
+            let d_ba = gpu_distance_cpu_fallback(&w, &v, crate::distance::DistanceMetric::Euclidean);
+            prop_assert!(
+                (d_ab - d_ba).abs() < 1e-4,
+                "Euclidean sq must be symmetric: d(a,b)={d_ab} vs d(b,a)={d_ba}"
+            );
+        }
+
+        /// Cosine distance is in [0, 2] for two independently-generated non-zero vectors.
+        #[test]
+        fn prop_cpu_distance_cosine_in_range(
+            vw in (1usize..=32usize).prop_flat_map(|len| (
+                proptest::collection::vec(0.01f32..=1.0f32, len),
+                proptest::collection::vec(0.01f32..=1.0f32, len),
+            )),
+        ) {
+            let (v, w) = vw;
+            let d = gpu_distance_cpu_fallback(&v, &w, crate::distance::DistanceMetric::Cosine);
+            prop_assert!(
+                ((-1e-5f32)..=(2.0_f32 + 1e-5)).contains(&d),
+                "Cosine distance must be in [0,2], got {d}"
+            );
+        }
+
+        /// DotProduct(v, v) = -‖v‖² ≤ 0 for any non-zero v.
+        #[test]
+        fn prop_cpu_distance_dot_product_self_nonpositive(
+            v in proptest::collection::vec(0.01f32..=1.0f32, 1..=64usize),
+        ) {
+            let d = gpu_distance_cpu_fallback(&v, &v, crate::distance::DistanceMetric::DotProduct);
+            prop_assert!(d <= 0.0, "DotProduct(v,v) = -‖v‖² must be <= 0, got {d}");
+        }
+
+        /// DotProduct is symmetric since the dot product is commutative.
+        #[test]
+        fn prop_cpu_distance_dot_product_symmetric(
+            vw in (1usize..=32usize).prop_flat_map(|len| (
+                proptest::collection::vec(-1.0f32..=1.0f32, len),
+                proptest::collection::vec(-1.0f32..=1.0f32, len),
+            )),
+        ) {
+            let (v, w) = vw;
+            let d_ab = gpu_distance_cpu_fallback(&v, &w, crate::distance::DistanceMetric::DotProduct);
+            let d_ba = gpu_distance_cpu_fallback(&w, &v, crate::distance::DistanceMetric::DotProduct);
+            prop_assert!(
+                (d_ab - d_ba).abs() < 1e-4,
+                "DotProduct must be symmetric: d(a,b)={d_ab} vs d(b,a)={d_ba}"
+            );
+        }
+
+        /// Hamming and Jaccard return f32::MAX — no GPU shader for binary metrics.
+        #[test]
+        fn prop_cpu_distance_unsupported_metrics_return_max(
+            v in proptest::collection::vec(0.1f32..=1.0f32, 1..=16usize),
+        ) {
+            prop_assert!(
+                gpu_distance_cpu_fallback(&v, &v, crate::distance::DistanceMetric::Hamming)
+                    .to_bits() == f32::MAX.to_bits(),
+                "Hamming must return f32::MAX (no GPU shader)"
+            );
+            prop_assert!(
+                gpu_distance_cpu_fallback(&v, &v, crate::distance::DistanceMetric::Jaccard)
+                    .to_bits() == f32::MAX.to_bits(),
+                "Jaccard must return f32::MAX (no GPU shader)"
+            );
         }
     }
 }

--- a/crates/velesdb-core/src/velesql/parser/select/clause_projection.rs
+++ b/crates/velesdb-core/src/velesql/parser/select/clause_projection.rs
@@ -174,7 +174,7 @@ impl Parser {
         alias
     }
 
-    #[allow(dead_code)]
+    #[allow(dead_code)] // Reason: VelesQL GROUP BY / aggregation parser — wired from future ANALYZE/GROUP clause
     pub(crate) fn parse_aggregation_list(
         pair: pest::iterators::Pair<Rule>,
     ) -> Result<Vec<AggregateFunction>, ParseError> {
@@ -253,7 +253,7 @@ impl Parser {
         AggregateArg::Column(raw.to_string())
     }
 
-    #[allow(dead_code)]
+    #[allow(dead_code)] // Reason: VelesQL column projection parser — wired from future SELECT clause handler
     pub(crate) fn parse_column_list(
         pair: pest::iterators::Pair<Rule>,
     ) -> Result<Vec<Column>, ParseError> {


### PR DESCRIPTION
## Summary

Supersedes #872 with two targeted improvements over that draft.

### Commit 1 — `chore(core)`: audit-2026q2 M4 — `#[allow(dead_code)]` annotation sweep

Adds inline `// Reason:` to all 7 suppression sites so future auditors can
distinguish intentional suppression from oversight.

| File | Symbol | Reason |
|---|---|---|
| `agent/memory.rs` | `temporal_index` | Future time-based query path |
| `collection/graph/traversal.rs` | `from_smallvec` | MATCH clause Wave 6 wiring |
| `collection/search/query/hybrid_sparse.rs` | `validate_single_sparse_search` | Multi-sparse guard |
| `collection/search/query/hybrid_sparse.rs` | `execute_hybrid_search` | Integration-test entry point |
| `collection/search/resolve.rs` | `sort_results_descending` | BM25/sparse utility |
| `velesql/parser/select/clause_projection.rs` | `parse_aggregation_list` | Future GROUP BY clause |
| `velesql/parser/select/clause_projection.rs` | `parse_column_list` | Future SELECT clause |

`memory.rs` uses a separate comment line (comment below attribute, above field)
because the inline version exceeds `max_width = 100`; all function-level sites
are inlined on the attribute line.

No behaviour change — annotation style only.

### Commit 2 — `test(gpu)`: audit-2026q2 M6 — property tests (improved over #872)

**11 proptest cases (300 runs each)** covering all CPU-side invariants of
`gpu_traversal` without requiring a physical GPU.

**Fixes vs #872 draft:**

| Issue | #872 approach | This PR |
|---|---|---|
| Monotonicity range | Hardcoded `ef_lo ∈ [0,64]` / `ef_hi ∈ [65,…]` — only tests the first step boundary | `prop_flat_map` over full `[0, 99_999) × (lo+1, 100_000)` — covers every step boundary |
| Distance test vectors | `w` derived from `v` via a fixed formula — limits the covered input space | Two independently-generated same-length vectors via `prop_flat_map(len)` |
| DotProduct coverage | Not tested (metric exists but was skipped) | Two new tests: `self_nonpositive` (`d(v,v) = -‖v‖² ≤ 0`) and `symmetric` |

**Full property inventory:**

```
adaptive_gpu_iterations
  prop_adaptive_iterations_in_range              — output ∈ [10, 20]
  prop_adaptive_iterations_monotone_nonincreasing — monotone over full domain

should_traverse_gpu
  prop_should_traverse_gpu_small_n_always_false  — perf gate n ≤ 500_000

gpu_distance_cpu_fallback
  prop_cpu_distance_euclidean_identity           — d(v,v) = 0
  prop_cpu_distance_euclidean_nonneg             — d(v,w) ≥ 0
  prop_cpu_distance_euclidean_symmetric          — d(a,b) = d(b,a)
  prop_cpu_distance_cosine_identity              — d(v,v) ≈ 0
  prop_cpu_distance_cosine_in_range              — d(v,w) ∈ [0, 2]
  prop_cpu_distance_dot_product_self_nonpositive — d(v,v) = -‖v‖² ≤ 0  ← new
  prop_cpu_distance_dot_product_symmetric        — d(a,b) = d(b,a)      ← new
  prop_cpu_distance_unsupported_metrics_return_max — Hamming/Jaccard → f32::MAX (bit-exact)
```

## Test plan

- [x] `cargo check -p velesdb-core --features gpu,persistence` — clean
- [x] `cargo test -p velesdb-core --features gpu,persistence --lib -- gpu_traversal` — **16 passed, 0 failed**
- [x] `cargo clippy -p velesdb-core --features gpu,persistence -- -D warnings` — clean

## References

- Audit report: `report/audit-2026q2/PRIORITIZED.md` items M4 + M6
- Scan date: 2026-05-22; fixes applied 2026-05-24
- proptest 1.5 — property-based testing for Rust (2024)

https://claude.ai/code/session_01TgrSHwpsyn68ps8eqxDKR9
