### PR TITLE
fix(clippy): allow wildcard SIMD intrinsic imports on aarch64

### DIFF
--- a/crates/velesdb-core/src/simd_native/adc.rs
+++ b/crates/velesdb-core/src/simd_native/adc.rs
@@ -206,6 +206,7 @@ unsafe fn adc_single_avx2(lut: &[f32], code: &[u16], m: usize, k: usize) -> f32 
 ///   well-defined.
 #[cfg(target_arch = "aarch64")]
 #[target_feature(enable = "neon")]
+#[allow(clippy::wildcard_imports)] // idiomatic for NEON intrinsics
 unsafe fn adc_single_neon(lut: &[f32], code: &[u16], m: usize, k: usize) -> f32 {
     use std::arch::aarch64::*;
     debug_assert_eq!(code.len(), m, "code length must equal m");

--- a/crates/velesdb-core/src/simd_native/neon.rs
+++ b/crates/velesdb-core/src/simd_native/neon.rs
@@ -13,6 +13,8 @@
 #![allow(clippy::cast_possible_truncation)]
 #![allow(clippy::cast_sign_loss)]
 #![allow(clippy::missing_panics_doc)]
+// Wildcard import of NEON intrinsics is idiomatic for SIMD kernels.
+#![allow(clippy::wildcard_imports)]
 #![allow(clippy::similar_names)]
 
 // =============================================================================

--- a/crates/velesdb-core/src/simd_neon.rs
+++ b/crates/velesdb-core/src/simd_neon.rs
@@ -3,6 +3,11 @@
 //! This module provides NEON-optimized distance calculations for aarch64 targets.
 //! Performance is comparable to x86_64 AVX2 (≥95% parity).
 
+// Wildcard import of NEON intrinsics is the idiomatic pattern for SIMD kernels.
+// `doc_markdown` is too noisy on intrinsic names (`vfmaq_f32`, etc.) referenced
+// in safety/performance notes.
+#![allow(clippy::wildcard_imports, clippy::doc_markdown)]
+
 #[cfg(target_arch = "aarch64")]
 use std::arch::aarch64::*;
 


### PR DESCRIPTION
## Summary

- `use std::arch::aarch64::*` is the idiomatic pattern for NEON SIMD kernels — listing every intrinsic individually is noise.
- CI runs on x86_64 Linux so these `clippy::pedantic` lints never fire there; running `cargo clippy --workspace -- -D clippy::pedantic` on macOS arm64 surfaces 16 errors across three aarch64-only modules.

## Files touched

- [`simd_neon.rs`](crates/velesdb-core/src/simd_neon.rs) — module-level allow for `wildcard_imports` and `doc_markdown` (intrinsic names like `vfmaq_f32` in safety/perf notes are noisy under markdown lint).
- [`simd_native/neon.rs`](crates/velesdb-core/src/simd_native/neon.rs) — append `wildcard_imports` to the existing module-level allow list.
- [`simd_native/adc.rs`](crates/velesdb-core/src/simd_native/adc.rs) — function-level allow on `adc_single_neon` only (the rest of the file is multi-target).

## Test plan

- [x] `cargo clippy --workspace --all-targets --features persistence,gpu,update-check --exclude velesdb-python -- -D warnings -D clippy::pedantic` is clean on aarch64-apple-darwin.
- [x] `cargo test --workspace --features persistence,gpu,update-check --exclude velesdb-python -- --test-threads=1` still passes (4888 + others).
