### PR TITLE
perf(payload): skip WAL fsync when deleting an id that was never stored

### DIFF
--- a/crates/velesdb-core/src/storage/log_payload.rs
+++ b/crates/velesdb-core/src/storage/log_payload.rs
@@ -412,6 +412,19 @@ impl PayloadStorage for LogPayloadStorage {
     }
 
     fn delete(&mut self, id: u64) -> io::Result<()> {
+        // If the id is not in the index there is nothing for a tombstone to
+        // shadow on WAL replay. Without this guard, callers that issue
+        // per-entry deletes (e.g. `write_deduped_payloads` with all-None
+        // payloads) pay one fsync per never-stored id.
+        //
+        // SAFETY: `&mut self` serializes all writers, so the read-then-write
+        // gap below cannot race a concurrent `store(id)`. If this signature
+        // is ever relaxed to `&self`, replace this with a single write-lock
+        // acquisition or fold the check inside the existing scoped block.
+        if !self.index.read().contains_key(&id) {
+            return Ok(());
+        }
+
         let crc = compute_delete_crc(id);
 
         // Scoped block: all lock guards are released before the auto-snapshot

--- a/crates/velesdb-core/src/storage/log_payload_tests.rs
+++ b/crates/velesdb-core/src/storage/log_payload_tests.rs
@@ -50,6 +50,26 @@ fn test_delete_payload() {
 }
 
 #[test]
+fn test_delete_never_stored_id_is_no_op() {
+    // Regression: `write_deduped_payloads` calls `delete()` for every batch
+    // entry with no payload — used to write one tombstone (+ fsync) per
+    // never-stored id, adding O(N × fsync_latency) to fresh upserts.
+    let temp = TempDir::new().expect("Failed to create temp dir");
+    let mut storage = LogPayloadStorage::new_with_durability(temp.path(), DurabilityMode::Fsync)
+        .expect("Create failed");
+    let wal_path = temp.path().join("payloads.log");
+    let wal_size_before = std::fs::metadata(&wal_path).expect("WAL exists").len();
+
+    storage.delete(42).expect("Delete of never-stored id should succeed");
+
+    let wal_size_after = std::fs::metadata(&wal_path).expect("WAL exists").len();
+    assert_eq!(
+        wal_size_before, wal_size_after,
+        "delete() on a never-stored id must not append to the WAL"
+    );
+}
+
+#[test]
 fn test_ids_returns_all_stored_ids() {
     // Arrange
     let (mut storage, _temp) = create_test_storage();

--- a/crates/velesdb-core/src/storage/traits.rs
+++ b/crates/velesdb-core/src/storage/traits.rs
@@ -87,6 +87,10 @@ pub trait PayloadStorage: Send + Sync {
 
     /// Deletes a payload by ID.
     ///
+    /// Implementations MAY treat a delete of an unknown id as a no-op
+    /// (returning `Ok(())` without producing a durable record). Callers
+    /// must not rely on this method to emit an audit trail for every call.
+    ///
     /// # Errors
     ///
     /// Returns an error if the delete operation fails.


### PR DESCRIPTION
## Summary

`LogPayloadStorage::delete()` unconditionally wrote a 13-byte tombstone and called `sync_wal_or_resync` on every call. Callers that issue deletes speculatively for every entry in a batch — notably [`write_deduped_payloads`](crates/velesdb-core/src/collection/core/crud.rs#L221-L242), which loops over all points whose final payload is `None` and calls `storage.delete(p.id)` for each — paid one fsync per never-stored id.

On a fresh collection upserting 500 vectors with no payload, this translated to ~2 s of overhead, making the `upsert()` path **27× slower than `upsert_bulk()` in debug** and **200× slower in release**. The regression test [`test_upsert_throughput_not_degraded_vs_bulk`](crates/velesdb-core/src/collection/core/crud_tests.rs#L293), whose threshold had already been bumped twice (8x → 10x → 15x), finally tripped on aarch64-apple-darwin where macOS fsync is slowest.

### Fix

Fast-path: when the id is absent from the in-memory index, no tombstone is needed (nothing to shadow on WAL replay). The WAL write and fsync are skipped entirely. Safe because `delete()` takes `&mut self` — Rust serializes all writers on the same instance.

### Measured impact (release, 500 points, dim 32, fresh collection)

|             | Before    | After    |
|-------------|-----------|----------|
| `upsert()`  | 1.94 s    | ~50 ms   |
| Ratio       | 204×      | < 1×     |

### Review polish

- Added `SAFETY:` comment anchoring the `&mut self` invariant (prevents silent regression if the signature is ever relaxed to `&self`).
- Updated [`PayloadStorage::delete`](crates/velesdb-core/src/storage/traits.rs#L88) trait doc to state implementations MAY treat unknown ids as no-op.

## Test plan

- [x] New regression test `test_delete_never_stored_id_is_no_op` verifies the WAL is not appended to when deleting an absent id.
- [x] Existing `test_delete_payload`, `test_delete_persists_with_fsync_mode`, `test_load_from_snapshot_with_deletes_in_delta` still pass.
- [x] `test_upsert_throughput_not_degraded_vs_bulk` passes in both debug (3 consecutive runs) and release.
- [x] Full workspace test suite (4888 lib tests + integration) green on aarch64-apple-darwin.
