### PR TITLE
chore(code-review): drop module-wide doc_markdown allow + strengthen delete test

### DIFF
--- a/crates/velesdb-core/src/simd_neon.rs
+++ b/crates/velesdb-core/src/simd_neon.rs
@@ -1,12 +1,10 @@
 //! NEON SIMD implementations for ARM64 (EPIC-054 US-001).
 //!
 //! This module provides NEON-optimized distance calculations for aarch64 targets.
-//! Performance is comparable to x86_64 AVX2 (≥95% parity).
+//! Performance is comparable to `x86_64` AVX2 (≥95% parity).
 
 // Wildcard import of NEON intrinsics is the idiomatic pattern for SIMD kernels.
-// `doc_markdown` is too noisy on intrinsic names (`vfmaq_f32`, etc.) referenced
-// in safety/performance notes.
-#![allow(clippy::wildcard_imports, clippy::doc_markdown)]
+#![allow(clippy::wildcard_imports)]
 
 #[cfg(target_arch = "aarch64")]
 use std::arch::aarch64::*;
@@ -18,7 +16,7 @@ use std::arch::aarch64::*;
 /// Input slices must have equal length.
 ///
 /// # Performance
-/// - Uses vfmaq_f32 (fused multiply-add)
+/// - Uses `vfmaq_f32` (fused multiply-add)
 /// - Processes 4 elements per iteration
 /// - ~3-4x faster than scalar on M1/M2
 #[cfg(target_arch = "aarch64")]

--- a/crates/velesdb-core/src/storage/log_payload_tests.rs
+++ b/crates/velesdb-core/src/storage/log_payload_tests.rs
@@ -62,11 +62,31 @@ fn test_delete_never_stored_id_is_no_op() {
 
     storage.delete(42).expect("Delete of never-stored id should succeed");
 
+    // No WAL append: confirms the fsync-per-call cost is gone.
     let wal_size_after = std::fs::metadata(&wal_path).expect("WAL exists").len();
     assert_eq!(
         wal_size_before, wal_size_after,
         "delete() on a never-stored id must not append to the WAL"
     );
+
+    // In-memory state matches the WAL: no spurious tombstone, no phantom id.
+    // Catches a future regression that writes a tombstone but truncates the
+    // file, or that marks the id present in the index.
+    assert_eq!(
+        storage
+            .retrieve(42)
+            .expect("Retrieve of never-stored id should succeed"),
+        None,
+        "delete() on a never-stored id must leave retrieve() returning None"
+    );
+    assert!(
+        storage.ids().is_empty(),
+        "delete() on a never-stored id must not introduce an id into the index"
+    );
+
+    // Drop storage before TempDir cleanup so Windows can remove the WAL file
+    // (no-op on Unix, defensive against future test reordering).
+    drop(storage);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Post-merge code review (high-effort, 5-angle + sweep) on #889 + #890 surfaced two polish items, both addressed here. Verdict was 0 CONFIRMED bugs; everything below is preventive.

### 1. Drop module-wide `doc_markdown` allow in `simd_neon.rs`

#890 added `#![allow(clippy::wildcard_imports, clippy::doc_markdown)]` to silence two doc-comment lints (`x86_64` and `vfmaq_f32`). A module-wide allow on \`doc_markdown\` masks any future legit hit. Empirical clippy run shows only **2** offending lines:
- L4 — `Performance is comparable to x86_64 AVX2 (≥95% parity).` → \`\`x86_64\`\`
- L19 — `Uses vfmaq_f32 (fused multiply-add)` → \`\`vfmaq_f32\`\`

Replaced the allow with backticks on those two identifiers. \`wildcard_imports\` allow kept (still needed for \`use std::arch::aarch64::*\`).

### 2. Strengthen \`test_delete_never_stored_id_is_no_op\`

Original test only asserted WAL byte count unchanged. Two regression families would slip through:
- write tombstone then truncate → bytes match, broken
- record id in in-memory index without WAL writes → bytes match, broken

Added \`retrieve(42) == None\` and \`storage.ids().is_empty()\` assertions, plus a defensive \`drop(storage)\` before TempDir cleanup (no-op on Unix, hardens against future test reordering on Windows).

## Test plan

- [x] \`cargo clippy --workspace --all-targets --features persistence,gpu,update-check --exclude velesdb-python -- -D warnings -D clippy::pedantic\` clean on aarch64-apple-darwin
- [x] \`test_delete_never_stored_id_is_no_op\`, \`test_delete_payload\`, \`test_delete_persists_with_fsync_mode\`, \`test_upsert_throughput_not_degraded_vs_bulk\` all pass
