### PR TITLE
fix(core): HNSW load validation + allocation safety (#894, #899)

### DIFF
--- a/crates/velesdb-core/src/alloc_guard.rs
+++ b/crates/velesdb-core/src/alloc_guard.rs
@@ -23,6 +23,121 @@
 
 use std::alloc::{alloc, alloc_zeroed, dealloc, Layout};
 use std::ptr::NonNull;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+/// Default ceiling for a single raw allocation, in bytes: **1 TiB**.
+///
+/// # Rationale (#899 + follow-up)
+///
+/// This is purely a *backstop against pathological / attacker-controlled /
+/// overflow-class sizes*, **not** a workload limit. It must NEVER reject a
+/// legitimate large index.
+///
+/// `ContiguousVectors` is a **single monolithic buffer holding ALL vectors of an
+/// HNSW graph** — it is not sharded. The previous 16 GiB ceiling therefore
+/// falsely rejected legitimate ingests: a collection only needs ~5.6M vectors at
+/// 768D to exceed 16 GiB in one buffer, and the geometric doubling in
+/// `ensure_capacity`/`resize` tripped even earlier (~2.8M @768D, when the next
+/// doubling crosses 16 GiB). Worse, an index built+persisted under the old code
+/// with > 16 GiB of vectors became **un-loadable** after upgrade.
+///
+/// 1 TiB is chosen because:
+/// - It is far above any single in-RAM vector buffer a real deployment builds
+///   (~358M vectors at 768D, ~715M at 384D), so legitimate workloads never trip
+///   it; the OS allocator / OOM killer rejects genuinely-impossible sizes first.
+/// - It still sits *vastly* below overflow-class requests: a wrapped `usize`
+///   lands near `usize::MAX` (~16 EiB on 64-bit), four-plus orders of magnitude
+///   above 1 TiB, so wrapped/absurd sizes are still cut off before they reach the
+///   system allocator.
+/// - The real overflow guard is the `checked_mul`/`checked_add` arithmetic in
+///   [`ContiguousVectors::byte_size`](crate::perf_optimizations::ContiguousVectors)
+///   and the insert/resize paths; this ceiling is a coarse secondary net.
+///
+/// Configurable at runtime via [`set_alloc_byte_limit`] if an operator
+/// legitimately needs an even larger single allocation, or to harden it down.
+pub const DEFAULT_ALLOC_BYTE_LIMIT: usize = 1024 * 1024 * 1024 * 1024;
+
+/// Process-wide per-allocation byte ceiling, initialized to
+/// [`DEFAULT_ALLOC_BYTE_LIMIT`]. See [`set_alloc_byte_limit`].
+static ALLOC_BYTE_LIMIT: AtomicUsize = AtomicUsize::new(DEFAULT_ALLOC_BYTE_LIMIT);
+
+/// Overrides the per-allocation byte ceiling enforced by [`AllocGuard`].
+///
+/// Use to raise the limit for genuinely huge single-buffer workloads, or lower
+/// it to harden against pathological sizes. Affects all subsequent allocations
+/// through [`AllocGuard::new`] / [`AllocGuard::new_zeroed`] and
+/// [`check_alloc_bound`]. Passing `0` is treated as "no override" and restores
+/// the default ceiling.
+pub fn set_alloc_byte_limit(limit_bytes: usize) {
+    let effective = if limit_bytes == 0 {
+        DEFAULT_ALLOC_BYTE_LIMIT
+    } else {
+        limit_bytes
+    };
+    ALLOC_BYTE_LIMIT.store(effective, Ordering::Relaxed);
+}
+
+/// Returns the current per-allocation byte ceiling.
+#[must_use]
+pub fn alloc_byte_limit() -> usize {
+    ALLOC_BYTE_LIMIT.load(Ordering::Relaxed)
+}
+
+/// Runs `f` with the per-allocation ceiling raised to **at least** `min_bytes`,
+/// restoring the previous ceiling afterward (even on panic).
+///
+/// Used by the persisted-index **load** path: the on-disk vector payload has
+/// already been validated to fit within the actual file length (see
+/// `validate_vectors_file_len`), so it is a *real, legitimately-built* size — it
+/// must reload regardless of the process-wide backstop. Bounding the temporary
+/// raise by the file-derived `min_bytes` (rather than removing the ceiling) keeps
+/// the backstop meaningful: a corrupt oversized header is still rejected earlier
+/// by the file-length check, and unrelated allocations during `f` are still
+/// bounded by `max(previous_limit, min_bytes)`.
+///
+/// If the current ceiling already covers `min_bytes`, this is a transparent
+/// pass-through with no mutation.
+pub fn with_min_alloc_byte_limit<T>(min_bytes: usize, f: impl FnOnce() -> T) -> T {
+    let previous = alloc_byte_limit();
+    if min_bytes <= previous {
+        return f();
+    }
+    // RAII restore so a panic inside `f` cannot leave the ceiling raised.
+    let _restore = LimitRestore(previous);
+    ALLOC_BYTE_LIMIT.store(min_bytes, Ordering::Relaxed);
+    f()
+}
+
+/// RAII helper that restores [`ALLOC_BYTE_LIMIT`] to a saved value on drop,
+/// including during unwinding. Used by [`with_min_alloc_byte_limit`].
+struct LimitRestore(usize);
+
+impl Drop for LimitRestore {
+    fn drop(&mut self) {
+        ALLOC_BYTE_LIMIT.store(self.0, Ordering::Relaxed);
+    }
+}
+
+/// Validates that a requested allocation of `bytes` is within the configured
+/// ceiling, *without* allocating.
+///
+/// Lets callers reject pathological sizes before building a [`Layout`] or
+/// reserving a `Vec`. Thread this in front of resize / gather / reorder paths.
+///
+/// # Errors
+///
+/// Returns [`Error::AllocationFailed`](crate::error::Error::AllocationFailed) if
+/// `bytes` exceeds [`alloc_byte_limit`].
+pub fn check_alloc_bound(bytes: usize) -> crate::error::Result<()> {
+    let limit = alloc_byte_limit();
+    if bytes > limit {
+        return Err(crate::error::Error::AllocationFailed(format!(
+            "requested allocation of {bytes} bytes exceeds ceiling of {limit} bytes \
+             (raise via set_alloc_byte_limit if intentional)"
+        )));
+    }
+    Ok(())
+}
 
 /// RAII guard for raw allocations.
 ///
@@ -42,7 +157,8 @@ impl AllocGuard {
     /// # Returns
     ///
     /// - `Some(guard)` if allocation succeeded
-    /// - `None` if allocation failed (OOM) or layout size is zero
+    /// - `None` if allocation failed (OOM), layout size is zero, or the request
+    ///   exceeds the configured [`alloc_byte_limit`] (#899 backstop)
     ///
     /// # Panics
     ///
@@ -55,7 +171,7 @@ impl AllocGuard {
     /// proper initialization before use.
     #[must_use]
     pub fn new(layout: Layout) -> Option<Self> {
-        if layout.size() == 0 {
+        if layout.size() == 0 || layout.size() > alloc_byte_limit() {
             return None;
         }
 
@@ -76,9 +192,12 @@ impl AllocGuard {
     ///
     /// Same as [`new`](Self::new) but guarantees all bytes are zero.
     /// Use for buffers where sparse writes (e.g., `insert_at`) may leave gaps.
+    ///
+    /// Returns `None` when the layout size is zero or exceeds the configured
+    /// [`alloc_byte_limit`] (#899 backstop).
     #[must_use]
     pub fn new_zeroed(layout: Layout) -> Option<Self> {
-        if layout.size() == 0 {
+        if layout.size() == 0 || layout.size() > alloc_byte_limit() {
             return None;
         }
 

--- a/crates/velesdb-core/src/alloc_guard_tests.rs
+++ b/crates/velesdb-core/src/alloc_guard_tests.rs
@@ -1,6 +1,7 @@
 //! Tests for `alloc_guard` module
 
 use super::alloc_guard::*;
+use serial_test::serial;
 use std::alloc::{dealloc, Layout};
 
 #[test]
@@ -106,4 +107,163 @@ fn test_alloc_guard_panic_safety() {
 
     assert!(result.is_err());
     // Memory should have been freed by drop during unwind
+}
+
+// =========================================================================
+// #899 — Allocation-bound regression tests
+//
+// Tests that read or mutate the process-global `ALLOC_BYTE_LIMIT` are marked
+// `#[serial]` so they cannot observe or corrupt each other's view of the
+// global; each one also saves and restores the limit it changes.
+// =========================================================================
+
+/// The default ceiling is the high 1 TiB backstop — not a 16 GiB workload cap.
+#[test]
+#[serial]
+fn test_default_ceiling_is_high_backstop() {
+    let saved = alloc_byte_limit();
+    set_alloc_byte_limit(0); // normalize to the default
+    assert_eq!(alloc_byte_limit(), DEFAULT_ALLOC_BYTE_LIMIT);
+    assert_eq!(DEFAULT_ALLOC_BYTE_LIMIT, 1024 * 1024 * 1024 * 1024);
+    set_alloc_byte_limit(saved);
+}
+
+/// A request above the configured byte ceiling returns `None` (no allocation),
+/// while a normal-sized request still succeeds.
+#[test]
+#[serial]
+fn test_alloc_guard_rejects_above_ceiling() {
+    let saved = alloc_byte_limit();
+    set_alloc_byte_limit(0);
+    let limit = alloc_byte_limit();
+    assert_eq!(limit, DEFAULT_ALLOC_BYTE_LIMIT);
+
+    // Just above the ceiling: rejected without touching the allocator
+    // (constructing the Layout never allocates).
+    let oversized = Layout::from_size_align(limit + 1, 8).unwrap();
+    assert!(AllocGuard::new(oversized).is_none());
+    assert!(AllocGuard::new_zeroed(oversized).is_none());
+
+    // A normal, sane allocation still succeeds.
+    let ok = Layout::from_size_align(4096, 64).unwrap();
+    assert!(AllocGuard::new(ok).is_some());
+    assert!(AllocGuard::new_zeroed(ok).is_some());
+    set_alloc_byte_limit(saved);
+}
+
+/// `check_alloc_bound` errors above the limit and is OK at/below it.
+#[test]
+#[serial]
+fn test_check_alloc_bound() {
+    let saved = alloc_byte_limit();
+    set_alloc_byte_limit(0);
+    let limit = alloc_byte_limit();
+    assert!(check_alloc_bound(limit).is_ok());
+    assert!(check_alloc_bound(0).is_ok());
+    assert!(check_alloc_bound(limit + 1).is_err());
+    set_alloc_byte_limit(saved);
+}
+
+/// The ceiling is configurable; `0` restores the default.
+#[test]
+#[serial]
+fn test_set_alloc_byte_limit_roundtrip() {
+    let original = alloc_byte_limit();
+
+    set_alloc_byte_limit(8192);
+    assert_eq!(alloc_byte_limit(), 8192);
+    assert!(AllocGuard::new(Layout::from_size_align(16384, 8).unwrap()).is_none());
+    assert!(AllocGuard::new(Layout::from_size_align(4096, 8).unwrap()).is_some());
+
+    // `0` means "no override" → back to default.
+    set_alloc_byte_limit(0);
+    assert_eq!(alloc_byte_limit(), DEFAULT_ALLOC_BYTE_LIMIT);
+
+    // Restore whatever the harness started with.
+    set_alloc_byte_limit(original);
+}
+
+/// REGRESSION (#899 follow-up): a large-but-legitimate single-buffer size that
+/// the old 16 GiB cap would have falsely rejected is now accepted by the
+/// bound-decision function. We test the *decision*, never a real 20 GiB alloc.
+#[test]
+#[serial]
+fn test_large_legit_buffer_not_falsely_rejected() {
+    const GIB: usize = 1024 * 1024 * 1024;
+    let saved = alloc_byte_limit();
+    set_alloc_byte_limit(0); // default 1 TiB backstop
+
+    // ~2.8M vectors @768D ≈ 8.2 GiB; ~5.6M @768D ≈ 16.5 GiB — both tripped the
+    // old 16 GiB cap. Probe sizes well above 16 GiB but below 1 TiB: all OK now.
+    for gib in [20usize, 64, 128, 512] {
+        let bytes = gib * GIB;
+        assert!(
+            check_alloc_bound(bytes).is_ok(),
+            "{gib} GiB single buffer must not be falsely rejected"
+        );
+    }
+    set_alloc_byte_limit(saved);
+}
+
+/// REGRESSION (#899 follow-up): the persisted-index LOAD bound is derived from
+/// the file-backed payload, so a realistic large `count` (above the old cap)
+/// reloads. `with_min_alloc_byte_limit` raises the ceiling to the file-backed
+/// size for the load scope, then restores it.
+#[test]
+#[serial]
+fn test_load_path_bound_allows_realistic_large_count() {
+    let saved = alloc_byte_limit();
+    // Pin a deliberately low limit to prove the load path raises past it.
+    set_alloc_byte_limit(4096);
+
+    // ~30 GiB file-backed payload (8M vectors @768D *4 ≈ 24 GiB) — a legit
+    // persisted index. The load path must accept its own file-backed size.
+    let file_backed_bytes = 30usize * 1024 * 1024 * 1024;
+    let inner = with_min_alloc_byte_limit(file_backed_bytes, || {
+        // Inside the scope the ceiling covers the file-backed size.
+        assert!(check_alloc_bound(file_backed_bytes).is_ok());
+        alloc_byte_limit()
+    });
+    assert_eq!(inner, file_backed_bytes, "ceiling raised within load scope");
+
+    // Restored after the scope (no leak of the raised limit).
+    assert_eq!(alloc_byte_limit(), 4096);
+    set_alloc_byte_limit(saved);
+}
+
+/// `with_min_alloc_byte_limit` is a transparent pass-through when the current
+/// ceiling already covers the requested minimum (no mutation).
+#[test]
+#[serial]
+fn test_with_min_alloc_byte_limit_passthrough() {
+    let saved = alloc_byte_limit();
+    set_alloc_byte_limit(0); // 1 TiB default
+    let before = alloc_byte_limit();
+    let observed = with_min_alloc_byte_limit(1024, alloc_byte_limit);
+    assert_eq!(
+        observed, before,
+        "no raise needed; ceiling unchanged in scope"
+    );
+    assert_eq!(alloc_byte_limit(), before);
+    set_alloc_byte_limit(saved);
+}
+
+/// `with_min_alloc_byte_limit` restores the previous ceiling even if the closure
+/// panics (RAII restore), so a panicking load cannot leak a raised limit.
+#[test]
+#[serial]
+fn test_with_min_alloc_byte_limit_restores_on_panic() {
+    use std::panic;
+    let saved = alloc_byte_limit();
+    set_alloc_byte_limit(4096);
+
+    let huge = 30usize * 1024 * 1024 * 1024;
+    let result = panic::catch_unwind(|| {
+        with_min_alloc_byte_limit(huge, || {
+            panic!("simulated load failure");
+        });
+    });
+    assert!(result.is_err());
+    assert_eq!(alloc_byte_limit(), 4096, "ceiling restored after panic");
+    set_alloc_byte_limit(saved);
 }

--- a/crates/velesdb-core/src/contiguous_resize.rs
+++ b/crates/velesdb-core/src/contiguous_resize.rs
@@ -21,7 +21,12 @@ impl ContiguousVectors {
     /// [`Error::AllocationFailed`]: crate::error::Error::AllocationFailed
     pub fn ensure_capacity(&mut self, required_capacity: usize) -> crate::error::Result<()> {
         if required_capacity > self.capacity {
-            let new_capacity = required_capacity.max(self.capacity * 2);
+            // #899: `self.capacity * 2` could overflow `usize` and wrap to a tiny
+            // value, defeating the `.max(required_capacity)` guard. Saturate the
+            // doubling so growth always satisfies `required_capacity` and the
+            // final layout-size check (in `resize`) still rejects true overflow.
+            let doubled = self.capacity.saturating_mul(2);
+            let new_capacity = required_capacity.max(doubled);
             self.resize(new_capacity)?;
         }
         Ok(())

--- a/crates/velesdb-core/src/index/hnsw/direct_writer.rs
+++ b/crates/velesdb-core/src/index/hnsw/direct_writer.rs
@@ -93,7 +93,15 @@ impl<'a> DirectVectorWriter<'a> {
         inner.with_contiguous_vectors_mut(|storage| {
             // Ensure capacity for all new vectors.
             let max_idx = results.iter().map(|r| r.idx).max().unwrap_or(0);
-            storage.ensure_capacity(max_idx + 1)?;
+            // #899 follow-up: use checked_add for consistency with the rest of
+            // the allocation hardening — a wrapped `max_idx + 1` would otherwise
+            // request capacity 0 and let `insert_at` write out of bounds.
+            let required = max_idx.checked_add(1).ok_or_else(|| {
+                crate::error::Error::AllocationFailed(format!(
+                    "write_to_contiguous: max index {max_idx} + 1 overflows usize"
+                ))
+            })?;
+            storage.ensure_capacity(required)?;
 
             for ((_, vector), result) in vectors.iter().zip(results.iter()) {
                 storage.insert_at(result.idx, vector)?;

--- a/crates/velesdb-core/src/index/hnsw/native/backend_adapter_tests.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/backend_adapter_tests.rs
@@ -193,6 +193,161 @@ fn test_file_dump_and_load_roundtrip() {
 }
 
 // =========================================================================
+// Regression tests (#894): reject corrupt/malicious persisted graph files
+// so that out-of-bounds node/neighbor IDs cannot reach `get_unchecked` in
+// the release search hot path. Each test corrupts exactly one field.
+// =========================================================================
+
+/// Builds a small index and dumps it, returning the temp dir so the files
+/// outlive the helper. The dir must be kept alive by the caller.
+fn dump_small_index(dir: &tempfile::TempDir, basename: &str) {
+    let engine = CachedSimdDistance::new(DistanceMetric::Euclidean, 8);
+    let hnsw = NativeHnsw::new(engine, 16, 100, 100);
+    for i in 0..20 {
+        hnsw.insert(&[i as f32; 8]).expect("insert");
+    }
+    hnsw.file_dump(dir.path(), basename).expect("dump");
+}
+
+/// Overwrites `len` bytes at `offset` in the named file with `bytes`.
+fn patch_file(path: &std::path::Path, offset: usize, bytes: &[u8]) {
+    let mut data = std::fs::read(path).expect("read file");
+    data[offset..offset + bytes.len()].copy_from_slice(bytes);
+    std::fs::write(path, &data).expect("write file");
+}
+
+fn load_corrupt(dir: &tempfile::TempDir, basename: &str) -> std::io::Result<()> {
+    let engine = CachedSimdDistance::new(DistanceMetric::Euclidean, 8);
+    NativeHnsw::file_load(dir.path(), basename, engine).map(|_| ())
+}
+
+// Graph header byte layout (little-endian): version u32 @0, num_layers u32 @4,
+// max_connections u32 @8, max_connections_0 u32 @12, ef_construction u32 @16,
+// entry_point u64 @20, max_layer u32 @28, count u64 @32. Layer 0 starts @40
+// with num_nodes u64, then per node: num_neighbors u32 followed by neighbor u32s.
+
+#[test]
+fn test_file_load_rejects_neighbor_id_beyond_count() {
+    let dir = tempdir().unwrap();
+    dump_small_index(&dir, "corrupt_nbr");
+    let graph = dir.path().join("corrupt_nbr.graph");
+    // First node's first neighbor id sits at offset 40 (num_nodes u64)
+    // + 4 (num_neighbors u32) = 44. Set it to a huge value >= count.
+    patch_file(&graph, 44, &u32::MAX.to_le_bytes());
+    assert!(
+        load_corrupt(&dir, "corrupt_nbr").is_err(),
+        "load must reject an out-of-range neighbor id"
+    );
+}
+
+#[test]
+fn test_file_load_rejects_entry_point_beyond_count() {
+    let dir = tempdir().unwrap();
+    dump_small_index(&dir, "corrupt_ep");
+    let graph = dir.path().join("corrupt_ep.graph");
+    // entry_point u64 @20
+    patch_file(&graph, 20, &9_999_999u64.to_le_bytes());
+    assert!(
+        load_corrupt(&dir, "corrupt_ep").is_err(),
+        "load must reject an out-of-range entry_point"
+    );
+}
+
+#[test]
+fn test_file_load_rejects_absurd_num_nodes() {
+    let dir = tempdir().unwrap();
+    dump_small_index(&dir, "corrupt_nodes");
+    let graph = dir.path().join("corrupt_nodes.graph");
+    // Layer 0 num_nodes u64 @40 — far larger than the 20 vectors.
+    patch_file(&graph, 40, &1_000_000_000u64.to_le_bytes());
+    assert!(
+        load_corrupt(&dir, "corrupt_nodes").is_err(),
+        "load must reject num_nodes exceeding the vector count"
+    );
+}
+
+#[test]
+fn test_file_load_rejects_absurd_num_neighbors() {
+    let dir = tempdir().unwrap();
+    dump_small_index(&dir, "corrupt_nnbr");
+    let graph = dir.path().join("corrupt_nnbr.graph");
+    // First node's num_neighbors u32 @40 + 8 = 48; absurd value > cap.
+    patch_file(&graph, 48, &u32::MAX.to_le_bytes());
+    assert!(
+        load_corrupt(&dir, "corrupt_nnbr").is_err(),
+        "load must reject num_neighbors exceeding the safety cap"
+    );
+}
+
+#[test]
+fn test_file_load_rejects_degenerate_max_connections() {
+    let dir = tempdir().unwrap();
+    dump_small_index(&dir, "corrupt_mc");
+    let graph = dir.path().join("corrupt_mc.graph");
+    // max_connections u32 @8 set to 1 (invalid: level_mult = 1/ln(1) = inf).
+    patch_file(&graph, 8, &1u32.to_le_bytes());
+    assert!(
+        load_corrupt(&dir, "corrupt_mc").is_err(),
+        "load must reject max_connections < 2"
+    );
+}
+
+#[test]
+fn test_file_load_rejects_count_mismatch() {
+    let dir = tempdir().unwrap();
+    dump_small_index(&dir, "corrupt_count");
+    let graph = dir.path().join("corrupt_count.graph");
+    // graph count u64 @32 set to a value != vectors count (20).
+    patch_file(&graph, 32, &7u64.to_le_bytes());
+    assert!(
+        load_corrupt(&dir, "corrupt_count").is_err(),
+        "load must reject a graph/vectors count mismatch"
+    );
+}
+
+#[test]
+fn test_file_load_rejects_truncated_vectors_header() {
+    let dir = tempdir().unwrap();
+    dump_small_index(&dir, "corrupt_vlen");
+    let vectors = dir.path().join("corrupt_vlen.vectors");
+    // Vectors header: version u32 @0, count u64 @4, dimension u32 @12.
+    // Inflate the declared count so the file is far too short to back it.
+    patch_file(&vectors, 4, &1_000_000u64.to_le_bytes());
+    assert!(
+        load_corrupt(&dir, "corrupt_vlen").is_err(),
+        "load must reject a vectors file shorter than its declared payload"
+    );
+}
+
+#[test]
+fn test_file_load_valid_index_still_loads() {
+    // Regression guard: the new validation must not reject a genuine index.
+    let dir = tempdir().unwrap();
+    let engine = CachedSimdDistance::new(DistanceMetric::Euclidean, 8);
+    let hnsw = NativeHnsw::new(engine, 16, 100, 100);
+    let vectors: Vec<Vec<f32>> = (0..25).map(|i| vec![i as f32 * 0.1; 8]).collect();
+    for v in &vectors {
+        hnsw.insert(v).expect("insert");
+    }
+    hnsw.file_dump(dir.path(), "valid").expect("dump");
+
+    let engine2 = CachedSimdDistance::new(DistanceMetric::Euclidean, 8);
+    let loaded = NativeHnsw::file_load(dir.path(), "valid", engine2).expect("valid load");
+    assert_eq!(loaded.len(), 25);
+
+    let query = vectors[3].clone();
+    let orig = hnsw.search(&query, 5, 50);
+    let after = loaded.search(&query, 5, 50);
+    assert_eq!(orig.len(), after.len());
+    if !orig.is_empty() {
+        assert_eq!(
+            orig[0].0, after[0].0,
+            "nearest neighbor must match after load"
+        );
+    }
+}
+
+// =========================================================================
 // TDD Tests: set_searching_mode (no-op but should not panic)
 // =========================================================================
 

--- a/crates/velesdb-core/src/index/hnsw/native/graph/search.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/graph/search.rs
@@ -229,6 +229,9 @@ impl<D: DistanceEngine> NativeHnsw<D> {
             );
             // SAFETY: `get_unchecked` dereferences `entry` without bounds checks.
             // - Condition 1: `entry < vectors.len()` verified by `debug_assert!` above.
+            //   Persisted entry points / neighbor IDs are validated `< count`
+            //   once at load time (`graph_io::validate_graph_header`,
+            //   `read_node_neighbors`), so this holds in release too.
             // SAFETY: Skipping the bounds check avoids a branch in the HNSW hot path.
             let entry_vec = unsafe { vectors.get_unchecked(entry) };
             let mut best_dist = self.distance.distance(query, entry_vec);
@@ -308,6 +311,8 @@ impl<D: DistanceEngine> NativeHnsw<D> {
             );
             // SAFETY: `get_unchecked` dereferences `neighbor` without bounds checks.
             // - Condition 1: `neighbor < vectors.len()` verified by `debug_assert!` above.
+            //   Persisted neighbor IDs are validated `< count` once at load
+            //   time (`graph_io::read_node_neighbors`), so this holds in release.
             // SAFETY: Skipping the bounds check avoids a branch in the HNSW hot path.
             let neighbor_vec = unsafe { vectors.get_unchecked(neighbor) };
             let dist = self.distance.distance(query, neighbor_vec);
@@ -364,6 +369,8 @@ impl<D: DistanceEngine> NativeHnsw<D> {
                 );
                 // SAFETY: `get_unchecked` dereferences `ep` without bounds checks.
                 // - Condition 1: `ep < vectors.len()` verified by `debug_assert!` above.
+                //   Persisted entry points / neighbor IDs are validated `< count`
+                //   once at load time (`graph_io` validation), so this holds in release.
                 // SAFETY: Skipping the bounds check avoids a branch in the HNSW hot path.
                 let ep_vec = unsafe { vectors.get_unchecked(ep) };
                 let dist = self.distance.distance(query, ep_vec);

--- a/crates/velesdb-core/src/index/hnsw/native/graph/search_state.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/graph/search_state.rs
@@ -187,10 +187,11 @@ pub(super) fn gather_unvisited_neighbors<'a>(
                 "neighbor {neighbor} out of bounds (len {})",
                 vectors.len()
             );
-            // SAFETY: neighbor < vectors.len() — verified by debug_assert above.
-            // - neighbor was just inserted into `visited` after originating from
-            //   a layer neighbor list, so it is a valid NodeId already in storage.
-            // Reason: per-iteration distance batch accumulation.
+            // SAFETY: `get_unchecked` dereferences `neighbor` without bounds checks.
+            // - Condition 1: `neighbor < vectors.len()` verified by `debug_assert!` above.
+            //   Persisted neighbor IDs are validated `< count` once at load
+            //   time (`graph_io::read_node_neighbors`), so this holds in release.
+            // SAFETY: Skipping the bounds check avoids a branch in the HNSW hot path.
             let vec = unsafe { vectors.get_unchecked(neighbor) };
             batch.push((neighbor, vec));
         }

--- a/crates/velesdb-core/src/index/hnsw/native/graph_io.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/graph_io.rs
@@ -12,6 +12,21 @@ use std::fs::File;
 use std::io::{BufReader, BufWriter, Read, Write};
 use std::path::Path;
 
+/// Hard ceiling on layer counts read from an untrusted graph file,
+/// independent of the vector count. Prevents pathological allocations from
+/// a corrupt header. HNSW never builds more than a few dozen layers in
+/// practice.
+const MAX_LAYERS: usize = 4096;
+
+/// Upper bound on neighbors per node accepted from disk. Real indices keep
+/// this below ~1024 (`max_connections_0`); this is a generous safety ceiling.
+const MAX_NEIGHBORS_PER_NODE: usize = 1 << 20;
+
+/// Builds an `InvalidData` I/O error with the given message.
+fn corrupt(msg: impl Into<String>) -> std::io::Error {
+    std::io::Error::new(std::io::ErrorKind::InvalidData, msg.into())
+}
+
 /// Deserialized HNSW graph structure loaded from disk.
 pub(super) struct LoadedGraph {
     pub(super) layers: Vec<Layer>,
@@ -213,7 +228,7 @@ impl<D: DistanceEngine + Send + Sync> NativeHnsw<D> {
         let (vectors, count) = Self::load_vectors_file(&vectors_path)?;
 
         let graph_path = path.join(format!("{basename}.graph"));
-        let graph = Self::load_graph_file(&graph_path)?;
+        let graph = Self::load_graph_file(&graph_path, count)?;
 
         let level_mult = 1.0 / (graph.max_connections as f64).ln();
 
@@ -255,15 +270,47 @@ impl<D: DistanceEngine + Send + Sync> NativeHnsw<D> {
     fn load_vectors_file(
         path: &Path,
     ) -> std::io::Result<(Option<crate::perf_optimizations::ContiguousVectors>, usize)> {
-        let mut reader = BufReader::new(File::open(path)?);
+        let file = File::open(path)?;
+        let file_len = file.metadata()?.len();
+        let mut reader = BufReader::new(file);
 
         let (count, dimension) = Self::read_vectors_header(&mut reader)?;
         if count == 0 || dimension == 0 {
             return Ok((None, 0));
         }
 
+        // Validate the declared payload size against the actual file length
+        // BEFORE allocating `count * dimension` floats. A corrupt/malicious
+        // header could otherwise request a multi-gigabyte allocation that the
+        // file cannot possibly back. Header = version(4) + count(8) + dim(4).
+        Self::validate_vectors_file_len(count, dimension, file_len)?;
+
         let storage = Self::read_vector_data(&mut reader, count, dimension)?;
         Ok((Some(storage), count))
+    }
+
+    /// Rejects vector headers whose declared `count * dimension * 4` payload
+    /// cannot fit in the actual file (guards untrusted allocations / OOB).
+    fn validate_vectors_file_len(
+        count: usize,
+        dimension: usize,
+        file_len: u64,
+    ) -> std::io::Result<()> {
+        const HEADER_BYTES: u64 = 16; // version(4) + count(8) + dimension(4)
+        let payload = (count as u64)
+            .checked_mul(dimension as u64)
+            .and_then(|n| n.checked_mul(4))
+            .ok_or_else(|| corrupt("vector payload size overflows u64"))?;
+        let expected = payload
+            .checked_add(HEADER_BYTES)
+            .ok_or_else(|| corrupt("vector file size overflows u64"))?;
+        if file_len < expected {
+            return Err(corrupt(format!(
+                "vector file too short: header declares {count}x{dimension} \
+                 ({expected} bytes) but file is {file_len} bytes"
+            )));
+        }
+        Ok(())
     }
 
     /// Reads and validates the vectors file header, returning `(count, dimension)`.
@@ -294,28 +341,51 @@ impl<D: DistanceEngine + Send + Sync> NativeHnsw<D> {
         count: usize,
         dimension: usize,
     ) -> std::io::Result<crate::perf_optimizations::ContiguousVectors> {
-        let mut storage =
-            crate::perf_optimizations::ContiguousVectors::new(dimension, count.max(16))
-                .map_err(|e| std::io::Error::other(e.to_string()))?;
-        let mut buf4 = [0u8; 4];
-        let mut buf_vec = vec![0f32; dimension];
-        for _ in 0..count {
-            for slot in &mut buf_vec {
-                reader.read_exact(&mut buf4)?;
-                *slot = f32::from_le_bytes(buf4);
+        // The (count, dimension) here was already validated to fit within the
+        // actual file length by `validate_vectors_file_len`, so this is a real,
+        // legitimately-persisted size — it MUST reload regardless of the
+        // process-wide allocation backstop. Raise the ceiling to at least the
+        // file-backed payload for the duration of the load so a genuine index
+        // built under a looser limit always reloads (#899 follow-up: a fixed
+        // ceiling must never block loading a valid persisted index). The bound is
+        // derived from the file, not a fixed constant: corrupt oversized headers
+        // were already rejected above.
+        let min_bytes = count
+            .checked_mul(dimension)
+            .and_then(|n| n.checked_mul(std::mem::size_of::<f32>()))
+            .ok_or_else(|| corrupt("vector payload size overflows usize"))?;
+
+        crate::alloc_guard::with_min_alloc_byte_limit(min_bytes, || {
+            let mut storage =
+                crate::perf_optimizations::ContiguousVectors::new(dimension, count.max(16))
+                    .map_err(|e| std::io::Error::other(e.to_string()))?;
+            let mut buf4 = [0u8; 4];
+            let mut buf_vec = vec![0f32; dimension];
+            for _ in 0..count {
+                for slot in &mut buf_vec {
+                    reader.read_exact(&mut buf4)?;
+                    *slot = f32::from_le_bytes(buf4);
+                }
+                storage
+                    .push(&buf_vec)
+                    .map_err(|e| std::io::Error::other(e.to_string()))?;
             }
-            storage
-                .push(&buf_vec)
-                .map_err(|e| std::io::Error::other(e.to_string()))?;
-        }
-        Ok(storage)
+            Ok(storage)
+        })
     }
 
-    fn load_graph_file(path: &Path) -> std::io::Result<LoadedGraph> {
-        let mut reader = BufReader::new(File::open(path)?);
+    /// Loads and validates the `.graph` file against the trusted vector
+    /// `count` (read from the `.vectors` file). All node/neighbor IDs and
+    /// header counts are validated ONCE here so the search hot path can rely
+    /// on every stored ID being `< count` and use `get_unchecked` safely.
+    fn load_graph_file(path: &Path, count: usize) -> std::io::Result<LoadedGraph> {
+        let file = File::open(path)?;
+        let file_len = file.metadata()?.len();
+        let mut reader = BufReader::new(file);
 
-        let graph_header = Self::read_graph_header(&mut reader)?;
-        let layers = Self::read_graph_layers(&mut reader, graph_header.num_layers)?;
+        let graph_header = Self::read_graph_header(&mut reader, count)?;
+        let layers =
+            Self::read_graph_layers(&mut reader, graph_header.num_layers, count, file_len)?;
 
         Ok(LoadedGraph {
             layers,
@@ -328,10 +398,59 @@ impl<D: DistanceEngine + Send + Sync> NativeHnsw<D> {
         })
     }
 
-    /// Reads and validates the graph file header.
-    fn read_graph_header(reader: &mut BufReader<File>) -> std::io::Result<LoadedGraph> {
+    /// Reads and validates the graph file header against the trusted vector
+    /// `count`.
+    fn read_graph_header(
+        reader: &mut BufReader<File>,
+        count: usize,
+    ) -> std::io::Result<LoadedGraph> {
         Self::validate_graph_version(reader)?;
-        Self::read_graph_header_fields(reader)
+        let header = Self::read_graph_header_fields(reader, count)?;
+        Self::validate_graph_header(&header, count)?;
+        Ok(header)
+    }
+
+    /// Validates header fields read from an untrusted `.graph` file against
+    /// the trusted vector `count`. Rejects out-of-range entry points, absurd
+    /// counts, and degenerate HNSW parameters that would corrupt the graph or
+    /// trigger out-of-bounds reads during search.
+    fn validate_graph_header(header: &LoadedGraph, count: usize) -> std::io::Result<()> {
+        if header.max_connections < 2 {
+            return Err(corrupt(format!(
+                "max_connections {} < 2 (invalid HNSW graph)",
+                header.max_connections
+            )));
+        }
+        if header.max_connections_0 < 2 {
+            return Err(corrupt(format!(
+                "max_connections_0 {} < 2 (invalid HNSW graph)",
+                header.max_connections_0
+            )));
+        }
+        if header.ef_construction < 1 {
+            return Err(corrupt("ef_construction < 1 (invalid HNSW graph)"));
+        }
+        if header.num_layers > MAX_LAYERS {
+            return Err(corrupt(format!(
+                "num_layers {} exceeds cap {MAX_LAYERS}",
+                header.num_layers
+            )));
+        }
+        if header.max_layer >= header.num_layers.max(1) && count > 0 {
+            return Err(corrupt(format!(
+                "max_layer {} out of range for {} layers",
+                header.max_layer, header.num_layers
+            )));
+        }
+        // entry_point indexes into the vectors; it must be < count (when any
+        // vectors exist). For an empty index the caller forces NO_ENTRY_POINT.
+        if count > 0 && header.entry_point >= count {
+            return Err(corrupt(format!(
+                "entry_point {} out of range for {count} vectors",
+                header.entry_point
+            )));
+        }
+        Ok(())
     }
 
     /// Validates the graph file version byte is supported.
@@ -349,14 +468,26 @@ impl<D: DistanceEngine + Send + Sync> NativeHnsw<D> {
     }
 
     /// Reads the graph header fields after version validation.
-    fn read_graph_header_fields(reader: &mut BufReader<File>) -> std::io::Result<LoadedGraph> {
+    ///
+    /// `count` is the trusted vector count from the `.vectors` file; the
+    /// header's own `count_check` field must match it, otherwise the two
+    /// files are inconsistent (corruption / mismatched pair).
+    fn read_graph_header_fields(
+        reader: &mut BufReader<File>,
+        count: usize,
+    ) -> std::io::Result<LoadedGraph> {
         let num_layers = read_u32_field(reader)?;
         let max_connections = read_u32_field(reader)?;
         let max_connections_0 = read_u32_field(reader)?;
         let ef_construction = read_u32_field(reader)?;
         let entry_point = read_u64_field(reader)?;
         let max_layer = read_u32_field(reader)?;
-        let _count_check = read_u64_field(reader)?;
+        let count_check = read_u64_field(reader)?;
+        if count_check != count {
+            return Err(corrupt(format!(
+                "graph count {count_check} != vectors count {count} (mismatched files)"
+            )));
+        }
 
         Ok(LoadedGraph {
             layers: Vec::new(), // populated by caller
@@ -369,32 +500,123 @@ impl<D: DistanceEngine + Send + Sync> NativeHnsw<D> {
         })
     }
 
-    /// Reads `num_layers` layers from the graph file.
+    /// Reads `num_layers` layers from the graph file, validating every node
+    /// and neighbor ID against the trusted vector `count`.
+    ///
+    /// `num_layers` is already capped by [`Self::validate_graph_header`], so
+    /// the `Vec::with_capacity` here is bounded. A layer's `num_nodes` is the
+    /// slot count of its adjacency table and may legitimately exceed `count`
+    /// (the base layer is over-allocated to `max_elements` at build time), so
+    /// it is NOT bounded by `count`; instead it is bounded by the remaining
+    /// file length (each node serializes at least a 4-byte `num_neighbors`),
+    /// which prevents a corrupt header from driving a huge `Layer::new`
+    /// allocation. Neighbor IDs are still validated `< count`, which is the
+    /// invariant the search hot path relies on.
     fn read_graph_layers(
         reader: &mut BufReader<File>,
         num_layers: usize,
+        count: usize,
+        file_len: u64,
     ) -> std::io::Result<Vec<Layer>> {
-        let mut buf4 = [0u8; 4];
         let mut buf8 = [0u8; 8];
         let mut layers = Vec::with_capacity(num_layers);
+        // Each node costs >= 4 bytes on disk; no layer can declare more nodes
+        // than the file could possibly contain.
+        let max_nodes = (file_len / 4) as usize;
 
         for _ in 0..num_layers {
             reader.read_exact(&mut buf8)?;
             let num_nodes = u64::from_le_bytes(buf8) as usize;
+            if num_nodes > max_nodes {
+                return Err(corrupt(format!(
+                    "layer num_nodes {num_nodes} exceeds file capacity {max_nodes}"
+                )));
+            }
             let layer = Layer::new(num_nodes);
             for node_id in 0..num_nodes {
-                reader.read_exact(&mut buf4)?;
-                let num_neighbors = u32::from_le_bytes(buf4) as usize;
-                let mut neighbors = Vec::with_capacity(num_neighbors);
-                for _ in 0..num_neighbors {
-                    reader.read_exact(&mut buf4)?;
-                    neighbors.push(u32::from_le_bytes(buf4) as usize);
-                }
+                let neighbors = Self::read_node_neighbors(reader, count)?;
                 layer.set_neighbors(node_id, neighbors);
             }
             layers.push(layer);
         }
 
         Ok(layers)
+    }
+
+    /// Reads one node's neighbor list, validating the neighbor count against
+    /// the safety cap and every neighbor ID against `count`.
+    fn read_node_neighbors(
+        reader: &mut BufReader<File>,
+        count: usize,
+    ) -> std::io::Result<Vec<usize>> {
+        let mut buf4 = [0u8; 4];
+        reader.read_exact(&mut buf4)?;
+        let num_neighbors = u32::from_le_bytes(buf4) as usize;
+        if num_neighbors > MAX_NEIGHBORS_PER_NODE {
+            return Err(corrupt(format!(
+                "num_neighbors {num_neighbors} exceeds cap {MAX_NEIGHBORS_PER_NODE}"
+            )));
+        }
+        // Bounded reserve: `num_neighbors` is capped above, never wired
+        // straight from the header into an unbounded `with_capacity`.
+        let mut neighbors = Vec::with_capacity(num_neighbors.min(count.max(1)));
+        for _ in 0..num_neighbors {
+            reader.read_exact(&mut buf4)?;
+            let neighbor = u32::from_le_bytes(buf4) as usize;
+            if neighbor >= count {
+                return Err(corrupt(format!(
+                    "neighbor id {neighbor} out of range for {count} vectors"
+                )));
+            }
+            neighbors.push(neighbor);
+        }
+        Ok(neighbors)
+    }
+}
+
+#[cfg(test)]
+mod load_bound_tests {
+    use super::super::distance::CpuDistance;
+    use super::NativeHnsw;
+
+    type H = NativeHnsw<CpuDistance>;
+
+    /// REGRESSION (#899 follow-up): the persisted-index LOAD bound is the file
+    /// length, NOT a fixed byte ceiling. A realistic large `count` whose
+    /// declared payload fits the actual file length is ACCEPTED — even far above
+    /// the old 16 GiB cap — so a genuine index always reloads.
+    #[test]
+    fn validate_vectors_file_len_accepts_large_file_backed_count() {
+        const HEADER: u64 = 16;
+        // ~6.8M vectors @768D ≈ 20 GiB payload — above the old 16 GiB cap.
+        let dimension = 768usize;
+        let count = (20u64 * 1024 * 1024 * 1024) / (dimension as u64 * 4);
+        let payload = count * dimension as u64 * 4;
+        let file_len = payload + HEADER; // file genuinely holds the data
+        assert!(
+            H::validate_vectors_file_len(count as usize, dimension, file_len).is_ok(),
+            "a file-backed large count must load, regardless of the alloc backstop"
+        );
+    }
+
+    /// A header declaring more data than the file can hold is rejected
+    /// (corrupt/malicious oversized header).
+    #[test]
+    fn validate_vectors_file_len_rejects_short_file() {
+        let dimension = 128usize;
+        let count = 1_000_000usize;
+        // File is only 100 bytes — cannot back the declared payload.
+        let err = H::validate_vectors_file_len(count, dimension, 100)
+            .expect_err("file shorter than declared payload must be rejected");
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+    }
+
+    /// An overflow-class header (count * dimension * 4 wraps u64) is rejected
+    /// rather than wrapping to a small accepted size.
+    #[test]
+    fn validate_vectors_file_len_rejects_overflow_header() {
+        let err = H::validate_vectors_file_len(usize::MAX, usize::MAX, u64::MAX)
+            .expect_err("overflow-class payload must be rejected");
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
     }
 }

--- a/crates/velesdb-core/src/index/hnsw/persistence.rs
+++ b/crates/velesdb-core/src/index/hnsw/persistence.rs
@@ -292,6 +292,7 @@ pub(crate) fn load_vectors_or_disable(
 
     match load_vectors(path) {
         Ok(vectors_data) => {
+            validate_loaded_vectors(&vectors_data.vectors, meta.dimension)?;
             let vectors = ShardedVectors::new(meta.dimension);
             vectors.insert_batch(vectors_data.vectors);
             Ok((vectors, true, vectors_data.generation))
@@ -535,7 +536,6 @@ pub(crate) fn load_sidecars(
             ),
         ));
     }
-
     let (vectors, enable_vector_storage, vectors_generation) = load_vectors_or_disable(path, meta)?;
     if enable_vector_storage && vectors_generation != meta.generation {
         return Err(std::io::Error::new(
@@ -548,12 +548,102 @@ pub(crate) fn load_sidecars(
         ));
     }
 
+    // Cross-check each mapped index against the REAL number of loaded vectors
+    // — not the file's own `next_idx`, which comes from the same untrusted
+    // blob and offers no independent assurance. When vector storage is
+    // disabled there is no vector store to resolve into, so the file's
+    // `next_idx` remains the only available bound.
+    let index_bound = if enable_vector_storage {
+        vectors.len()
+    } else {
+        mappings_data.next_idx
+    };
+    validate_loaded_mappings(&mappings_data, index_bound)?;
+
     let mappings = super::sharded_mappings::ShardedMappings::from_parts(
         mappings_data.id_to_idx,
         mappings_data.idx_to_id,
         mappings_data.next_idx,
     );
     Ok((mappings, vectors, enable_vector_storage))
+}
+
+/// Builds an `InvalidData` I/O error for the load-time validation paths.
+///
+/// Single idiom shared by [`validate_loaded_vectors`] and
+/// [`validate_loaded_mappings`] so the new validation code does not
+/// re-spell `std::io::Error::new(InvalidData, …)` at every site.
+fn invalid_data(msg: String) -> std::io::Error {
+    std::io::Error::new(std::io::ErrorKind::InvalidData, msg)
+}
+
+/// Validates vectors deserialized from an untrusted `native_vectors.bin`.
+///
+/// Every stored vector must have exactly `dimension` components and a unique
+/// internal index. A corrupt file with the wrong dimension would otherwise
+/// produce malformed rows in `ShardedVectors` and feed wrong-length slices
+/// into the SIMD distance kernels (out-of-bounds reads).
+///
+/// # Errors
+///
+/// Returns `InvalidData` if any vector length differs from `dimension` or any
+/// internal index is duplicated.
+fn validate_loaded_vectors(vectors: &[(usize, Vec<f32>)], dimension: usize) -> std::io::Result<()> {
+    let mut seen = std::collections::HashSet::with_capacity(vectors.len());
+    for (idx, vec) in vectors {
+        if vec.len() != dimension {
+            return Err(invalid_data(format!(
+                "vector at index {idx} has length {} but dimension is {dimension}",
+                vec.len()
+            )));
+        }
+        if !seen.insert(*idx) {
+            return Err(invalid_data(format!(
+                "duplicate internal index {idx} in persisted vectors"
+            )));
+        }
+    }
+    Ok(())
+}
+
+/// Validates id-mappings deserialized from an untrusted `native_mappings.bin`.
+///
+/// Enforces the bijection invariant `HnswIndex` relies on: every internal
+/// index is `< index_bound`, and `id_to_idx` / `idx_to_id` are exact inverses
+/// of each other (same cardinality, every entry round-trips).
+///
+/// `index_bound` is the REAL number of vectors loaded into the store (passed by
+/// [`load_sidecars`]), so this rejects a mapping that resolves to an index past
+/// the end of the actual vector store — not merely past the file's own
+/// self-reported `next_idx`, which is read from the same untrusted blob and
+/// therefore cannot vouch for itself. When vector storage is disabled the
+/// caller passes the file's `next_idx`, since there is no vector store to
+/// resolve into.
+///
+/// # Errors
+///
+/// Returns `InvalidData` on any out-of-range index or broken bijection.
+fn validate_loaded_mappings(data: &HnswMappingsData, index_bound: usize) -> std::io::Result<()> {
+    if data.id_to_idx.len() != data.idx_to_id.len() {
+        return Err(invalid_data(format!(
+            "mapping cardinality mismatch: id_to_idx={} idx_to_id={}",
+            data.id_to_idx.len(),
+            data.idx_to_id.len()
+        )));
+    }
+    for (&id, &idx) in &data.id_to_idx {
+        if idx >= index_bound {
+            return Err(invalid_data(format!(
+                "mapping index {idx} >= vector count {index_bound}"
+            )));
+        }
+        if data.idx_to_id.get(&idx) != Some(&id) {
+            return Err(invalid_data(format!(
+                "mapping bijection broken for id {id} / idx {idx}"
+            )));
+        }
+    }
+    Ok(())
 }
 
 /// Converts a u8 discriminant to a `DistanceMetric`.

--- a/crates/velesdb-core/src/index/hnsw/persistence.rs
+++ b/crates/velesdb-core/src/index/hnsw/persistence.rs
@@ -548,17 +548,20 @@ pub(crate) fn load_sidecars(
         ));
     }
 
-    // Cross-check each mapped index against the REAL number of loaded vectors
-    // — not the file's own `next_idx`, which comes from the same untrusted
-    // blob and offers no independent assurance. When vector storage is
-    // disabled there is no vector store to resolve into, so the file's
-    // `next_idx` remains the only available bound.
-    let index_bound = if enable_vector_storage {
-        vectors.len()
+    // Cross-check each mapped index against the actually-loaded vector set.
+    // Internal indices are sparse and monotonic (never reused after an
+    // upsert/delete), so a perfectly valid live index can exceed
+    // `vectors.len()`; membership in the loaded store is the correct test —
+    // and strictly stronger than the file's own `next_idx`, which comes from
+    // the same untrusted blob and cannot vouch for itself. When vector storage
+    // is disabled there is no store to resolve into, so the file's `next_idx`
+    // remains the only available bound.
+    let bound = if enable_vector_storage {
+        MappingBound::Loaded(&vectors)
     } else {
-        mappings_data.next_idx
+        MappingBound::MaxExclusive(mappings_data.next_idx)
     };
-    validate_loaded_mappings(&mappings_data, index_bound)?;
+    validate_loaded_mappings(&mappings_data, bound)?;
 
     let mappings = super::sharded_mappings::ShardedMappings::from_parts(
         mappings_data.id_to_idx,
@@ -612,18 +615,29 @@ fn validate_loaded_vectors(vectors: &[(usize, Vec<f32>)], dimension: usize) -> s
 /// index is `< index_bound`, and `id_to_idx` / `idx_to_id` are exact inverses
 /// of each other (same cardinality, every entry round-trips).
 ///
-/// `index_bound` is the REAL number of vectors loaded into the store (passed by
-/// [`load_sidecars`]), so this rejects a mapping that resolves to an index past
-/// the end of the actual vector store — not merely past the file's own
-/// self-reported `next_idx`, which is read from the same untrusted blob and
-/// therefore cannot vouch for itself. When vector storage is disabled the
-/// caller passes the file's `next_idx`, since there is no vector store to
-/// resolve into.
+/// How a mapped internal index is bound-checked, depending on whether the
+/// vector store was loaded.
+#[derive(Clone, Copy)]
+enum MappingBound<'a> {
+    /// Vector storage enabled: every mapped index must be a vector actually
+    /// present in the loaded store. Correct for sparse/monotonic indices and
+    /// strictly stronger than the file's self-reported `next_idx`.
+    Loaded(&'a super::sharded_vectors::ShardedVectors),
+    /// Vector storage disabled: no store to resolve into, so the only bound is
+    /// the file's `next_idx` (indices must be `< next_idx`).
+    MaxExclusive(usize),
+}
+
+/// Validates id-mappings deserialized from an untrusted `native_mappings.bin`.
+///
+/// Enforces the bijection invariant `HnswIndex` relies on: every internal
+/// index is valid under `bound`, and `id_to_idx` / `idx_to_id` are exact
+/// inverses of each other (same cardinality, every entry round-trips).
 ///
 /// # Errors
 ///
 /// Returns `InvalidData` on any out-of-range index or broken bijection.
-fn validate_loaded_mappings(data: &HnswMappingsData, index_bound: usize) -> std::io::Result<()> {
+fn validate_loaded_mappings(data: &HnswMappingsData, bound: MappingBound) -> std::io::Result<()> {
     if data.id_to_idx.len() != data.idx_to_id.len() {
         return Err(invalid_data(format!(
             "mapping cardinality mismatch: id_to_idx={} idx_to_id={}",
@@ -632,9 +646,13 @@ fn validate_loaded_mappings(data: &HnswMappingsData, index_bound: usize) -> std:
         )));
     }
     for (&id, &idx) in &data.id_to_idx {
-        if idx >= index_bound {
+        let valid = match bound {
+            MappingBound::Loaded(vectors) => vectors.contains(idx),
+            MappingBound::MaxExclusive(next_idx) => idx < next_idx,
+        };
+        if !valid {
             return Err(invalid_data(format!(
-                "mapping index {idx} >= vector count {index_bound}"
+                "mapping id {id} resolves to index {idx} absent from the loaded vector store"
             )));
         }
         if data.idx_to_id.get(&idx) != Some(&id) {

--- a/crates/velesdb-core/src/index/hnsw/persistence_atomicity_tests.rs
+++ b/crates/velesdb-core/src/index/hnsw/persistence_atomicity_tests.rs
@@ -507,3 +507,146 @@ fn test_next_generation_propagates_corrupted_meta_error() {
         "missing meta must yield generation 1, not propagate NotFound"
     );
 }
+
+// -----------------------------------------------------------------------
+// Regression tests (#894): reject corrupt sidecar payloads on load so that
+// a malformed vector dimension or a broken id<->idx bijection cannot reach
+// the SIMD distance kernels or resolve a result to an out-of-range index.
+// -----------------------------------------------------------------------
+
+/// Writes a consistent generation-4 baseline (graph marker + mappings +
+/// vectors + meta) so that the generation checks in `load_sidecars` pass and
+/// the new content validation is what decides accept/reject.
+fn seed_consistent_gen4(path: &Path, mappings: &ShardedMappings, vectors: &ShardedVectors) {
+    persistence::save_graph_generation(path, 4).expect("test: graph gen 4");
+    persistence::save_mappings(path, &mappings_data(mappings, 4)).expect("test: save mappings 4");
+    persistence::save_vectors(path, &vectors_data(vectors, 4)).expect("test: save vectors 4");
+    persistence::save_meta(path, &build_meta(4)).expect("test: save meta 4");
+}
+
+#[test]
+fn test_load_sidecars_rejects_wrong_vector_dimension() {
+    let dir = TempDir::new().expect("test: temp dir");
+    let path = dir.path();
+    let mappings = build_mappings();
+    let vectors = build_vectors();
+    seed_consistent_gen4(path, &mappings, &vectors);
+
+    // Overwrite vectors at the SAME generation (4) with a wrong-dimension
+    // payload: meta declares dimension 4, this vector has length 3.
+    let bad = HnswVectorsData {
+        vectors: vec![
+            (0_usize, vec![1.0_f32, 2.0, 3.0]),
+            (1_usize, vec![0.0_f32; 4]),
+        ],
+        generation: 4,
+    };
+    persistence::save_vectors(path, &bad).expect("test: overwrite vectors");
+
+    let meta = persistence::load_meta(path).expect("test: reload meta");
+    let err = load_sidecars(path, &meta).expect_err("test: wrong dimension must be rejected");
+    assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+    assert!(
+        err.to_string().contains("dimension"),
+        "error should mention dimension, got: {err}"
+    );
+}
+
+/// Seeds a consistent gen-4 baseline, overwrites the mappings sidecar at the
+/// same generation with a single corrupt `id -> idx` pair (so the new content
+/// validation, not the generation check, decides), then runs `load_sidecars`
+/// and returns the resulting error.
+fn load_with_corrupt_single_mapping(id: u64, idx: usize, mapped_back: u64) -> std::io::Error {
+    let dir = TempDir::new().expect("test: temp dir");
+    let path = dir.path();
+    seed_consistent_gen4(path, &build_mappings(), &build_vectors());
+
+    let mut id_to_idx = HashMap::new();
+    id_to_idx.insert(id, idx);
+    let mut idx_to_id = HashMap::new();
+    idx_to_id.insert(idx, mapped_back);
+    let bad = HnswMappingsData {
+        id_to_idx,
+        idx_to_id,
+        next_idx: 2,
+        generation: 4,
+    };
+    persistence::save_mappings(path, &bad).expect("test: overwrite mappings");
+
+    let meta = persistence::load_meta(path).expect("test: reload meta");
+    load_sidecars(path, &meta).expect_err("test: corrupt mapping must be rejected")
+}
+
+#[test]
+fn test_load_sidecars_rejects_index_beyond_vector_count() {
+    // Internal index 99 is >= the loaded vector count (2); id_to_idx/idx_to_id
+    // agree. `load_with_corrupt_single_mapping` writes next_idx=2, so this is
+    // also out of range against the file's own counter.
+    let err = load_with_corrupt_single_mapping(1, 99, 1);
+    assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+    assert!(
+        err.to_string().contains("vector count"),
+        "error should mention vector count, got: {err}"
+    );
+}
+
+#[test]
+fn test_load_sidecars_rejects_index_within_next_idx_but_beyond_vector_count() {
+    // Regression for #894 follow-up: the mapping's idx (5) is VALID against the
+    // file's own self-reported `next_idx` (6) — the old check would accept it —
+    // but it points BEYOND the actual loaded vector count (2). Cross-checking
+    // against the real vector store length must reject it.
+    let dir = TempDir::new().expect("test: temp dir");
+    let path = dir.path();
+    seed_consistent_gen4(path, &build_mappings(), &build_vectors());
+
+    let mut id_to_idx = HashMap::new();
+    id_to_idx.insert(1_u64, 5_usize);
+    let mut idx_to_id = HashMap::new();
+    idx_to_id.insert(5_usize, 1_u64);
+    let bad = HnswMappingsData {
+        id_to_idx,
+        idx_to_id,
+        next_idx: 6, // > idx, so the file's own bound would pass
+        generation: 4,
+    };
+    persistence::save_mappings(path, &bad).expect("test: overwrite mappings");
+
+    let meta = persistence::load_meta(path).expect("test: reload meta");
+    let err = load_sidecars(path, &meta)
+        .expect_err("test: index beyond real vector count must be rejected");
+    assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+    assert!(
+        err.to_string().contains("vector count"),
+        "error should mention vector count, got: {err}"
+    );
+}
+
+#[test]
+fn test_load_sidecars_rejects_broken_bijection() {
+    // idx 0 is in range but idx_to_id maps it back to a different id (7 != 1).
+    let err = load_with_corrupt_single_mapping(1, 0, 7);
+    assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+    assert!(
+        err.to_string().contains("bijection"),
+        "error should mention bijection, got: {err}"
+    );
+}
+
+#[test]
+fn test_load_sidecars_accepts_valid_sidecars() {
+    // Regression guard: the new content validation must not reject genuine data.
+    let dir = TempDir::new().expect("test: temp dir");
+    let path = dir.path();
+    let mappings = build_mappings();
+    let vectors = build_vectors();
+    seed_consistent_gen4(path, &mappings, &vectors);
+
+    let meta = persistence::load_meta(path).expect("test: reload meta");
+    let (loaded_mappings, _vectors, enabled) =
+        load_sidecars(path, &meta).expect("test: valid sidecars must load");
+    assert!(enabled, "vector storage should remain enabled");
+    let (id_to_idx, _, next_idx) = loaded_mappings.as_parts();
+    assert_eq!(id_to_idx.len(), 2);
+    assert_eq!(next_idx, 2);
+}

--- a/crates/velesdb-core/src/index/hnsw/persistence_atomicity_tests.rs
+++ b/crates/velesdb-core/src/index/hnsw/persistence_atomicity_tests.rs
@@ -579,23 +579,22 @@ fn load_with_corrupt_single_mapping(id: u64, idx: usize, mapped_back: u64) -> st
 
 #[test]
 fn test_load_sidecars_rejects_index_beyond_vector_count() {
-    // Internal index 99 is >= the loaded vector count (2); id_to_idx/idx_to_id
-    // agree. `load_with_corrupt_single_mapping` writes next_idx=2, so this is
-    // also out of range against the file's own counter.
+    // Internal index 99 is absent from the loaded vector store ({0,1});
+    // id_to_idx/idx_to_id agree but the index is dangling.
     let err = load_with_corrupt_single_mapping(1, 99, 1);
     assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
     assert!(
-        err.to_string().contains("vector count"),
-        "error should mention vector count, got: {err}"
+        err.to_string().contains("absent from the loaded vector store"),
+        "error should flag the absent index, got: {err}"
     );
 }
 
 #[test]
-fn test_load_sidecars_rejects_index_within_next_idx_but_beyond_vector_count() {
-    // Regression for #894 follow-up: the mapping's idx (5) is VALID against the
-    // file's own self-reported `next_idx` (6) — the old check would accept it —
-    // but it points BEYOND the actual loaded vector count (2). Cross-checking
-    // against the real vector store length must reject it.
+fn test_load_sidecars_rejects_dangling_index_within_next_idx() {
+    // The mapping's idx (5) is VALID against the file's own self-reported
+    // `next_idx` (6) — the file's own bound would accept it — but no vector
+    // exists at index 5 in the loaded store ({0,1}). Membership in the real
+    // store must reject this dangling index.
     let dir = TempDir::new().expect("test: temp dir");
     let path = dir.path();
     seed_consistent_gen4(path, &build_mappings(), &build_vectors());
@@ -614,12 +613,40 @@ fn test_load_sidecars_rejects_index_within_next_idx_but_beyond_vector_count() {
 
     let meta = persistence::load_meta(path).expect("test: reload meta");
     let err = load_sidecars(path, &meta)
-        .expect_err("test: index beyond real vector count must be rejected");
+        .expect_err("test: dangling index must be rejected");
     assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
     assert!(
-        err.to_string().contains("vector count"),
-        "error should mention vector count, got: {err}"
+        err.to_string().contains("absent from the loaded vector store"),
+        "error should flag the absent index, got: {err}"
     );
+}
+
+#[test]
+fn test_load_sidecars_accepts_sparse_index_beyond_count() {
+    // Regression for the #908 review: internal indices are sparse and monotonic
+    // (never reused after an upsert/delete), so a live vector legitimately sits
+    // at an index >= the live count. Here 2 vectors are loaded at indices {0, 5}
+    // with id 2 -> idx 5; a `idx < count` bound would WRONGLY reject this valid,
+    // previously-saved index. Membership in the loaded store must accept it.
+    let dir = TempDir::new().expect("test: temp dir");
+    let path = dir.path();
+
+    let vectors = ShardedVectors::new(4);
+    vectors.insert_batch(vec![(0_usize, vec![1.0_f32; 4]), (5_usize, vec![2.0_f32; 4])]);
+    let mut id_to_idx = HashMap::new();
+    id_to_idx.insert(1_u64, 0_usize);
+    id_to_idx.insert(2_u64, 5_usize);
+    let mut idx_to_id = HashMap::new();
+    idx_to_id.insert(0_usize, 1_u64);
+    idx_to_id.insert(5_usize, 2_u64);
+    let mappings = ShardedMappings::from_parts(id_to_idx, idx_to_id, 6);
+    seed_consistent_gen4(path, &mappings, &vectors);
+
+    let meta = persistence::load_meta(path).expect("test: reload meta");
+    let (loaded, _vectors, enabled) =
+        load_sidecars(path, &meta).expect("test: sparse-but-valid index must load");
+    assert!(enabled);
+    assert_eq!(loaded.get_id(5), Some(2_u64), "id 2 must resolve via sparse idx 5");
 }
 
 #[test]

--- a/crates/velesdb-core/src/perf_optimizations.rs
+++ b/crates/velesdb-core/src/perf_optimizations.rs
@@ -17,7 +17,7 @@
 //! eliminating null pointer checks and making invariants explicit. Memory is managed
 //! via RAII with `AllocGuard` for panic-safe resize operations.
 
-use crate::validation::validate_dimension_match;
+use crate::validation::{validate_dimension, validate_dimension_match};
 use std::alloc::{alloc_zeroed, Layout};
 use std::fmt;
 use std::ptr::{self, NonNull};
@@ -85,22 +85,25 @@ impl ContiguousVectors {
     ///
     /// # Errors
     ///
-    /// Returns [`Error::InvalidDimension`] if `dimension` is 0.
-    /// Returns [`Error::AllocationFailed`] if memory allocation fails.
+    /// Returns [`Error::InvalidDimension`] if `dimension` is 0 or exceeds
+    /// [`MAX_DIMENSION`](crate::validation::MAX_DIMENSION).
+    /// Returns [`Error::AllocationFailed`] if memory allocation fails or exceeds
+    /// the [`AllocGuard`](crate::alloc_guard::AllocGuard) ceiling.
     ///
     /// [`Error::InvalidDimension`]: crate::error::Error::InvalidDimension
     /// [`Error::AllocationFailed`]: crate::error::Error::AllocationFailed
     #[allow(clippy::cast_ptr_alignment)] // Layout is 64-byte aligned
     pub fn new(dimension: usize, capacity: usize) -> crate::error::Result<Self> {
-        if dimension == 0 {
-            return Err(crate::error::Error::InvalidDimension {
-                dimension: 0,
-                min: 1,
-                max: 65_536,
-            });
-        }
+        // Enforce the advertised dimension range (#899): previously `max: 65_536`
+        // was reported in errors but never validated, so an oversized dimension
+        // could drive `dimension * capacity` products toward overflow.
+        validate_dimension(dimension)?;
 
         let capacity = capacity.max(16); // Minimum 16 vectors
+
+        // Reject pathological/attacker-sized allocations before touching the
+        // allocator (#899). Legitimate large indexes stay well under the ceiling.
+        crate::alloc_guard::check_alloc_bound(Self::byte_size(dimension, capacity)?)?;
         let layout = Self::layout(dimension, capacity)?;
 
         // SAFETY: `alloc_zeroed` requires a valid non-zero layout.
@@ -125,6 +128,26 @@ impl ContiguousVectors {
         })
     }
 
+    /// Returns the buffer size in bytes for `dimension * capacity` f32s.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::AllocationFailed`] if `dimension * capacity * 4` overflows
+    /// `usize`.
+    ///
+    /// [`Error::AllocationFailed`]: crate::error::Error::AllocationFailed
+    pub(crate) fn byte_size(dimension: usize, capacity: usize) -> crate::error::Result<usize> {
+        dimension
+            .checked_mul(capacity)
+            .and_then(|s| s.checked_mul(std::mem::size_of::<f32>()))
+            .ok_or_else(|| {
+                crate::error::Error::AllocationFailed(format!(
+                    "Size overflow: {dimension} * {capacity} * {}",
+                    std::mem::size_of::<f32>()
+                ))
+            })
+    }
+
     /// Returns the memory layout for the given dimension and capacity.
     ///
     /// # Errors
@@ -133,15 +156,7 @@ impl ContiguousVectors {
     ///
     /// [`Error::AllocationFailed`]: crate::error::Error::AllocationFailed
     pub(crate) fn layout(dimension: usize, capacity: usize) -> crate::error::Result<Layout> {
-        let size = dimension
-            .checked_mul(capacity)
-            .and_then(|s| s.checked_mul(std::mem::size_of::<f32>()))
-            .ok_or_else(|| {
-                crate::error::Error::AllocationFailed(format!(
-                    "Size overflow: {dimension} * {capacity} * {}",
-                    std::mem::size_of::<f32>()
-                ))
-            })?;
+        let size = Self::byte_size(dimension, capacity)?;
         let align = 64; // Cache line alignment for optimal prefetch
         Layout::from_size_align(size.max(64), align)
             .map_err(|e| crate::error::Error::AllocationFailed(format!("Invalid layout: {e}")))
@@ -186,7 +201,9 @@ impl ContiguousVectors {
         if self.count == 0 {
             return &[];
         }
-        let total = self.count * self.dimension;
+        // `count <= capacity` and `capacity * dimension` was validated to fit in
+        // `usize` at allocation time, so this product cannot overflow here.
+        let total = self.count.saturating_mul(self.dimension);
         // SAFETY: All `capacity * dimension` f32s are valid because both initial allocation
         // (`alloc_zeroed`) and resize (`AllocGuard::new_zeroed`) zero-initialize the buffer.
         // `count * dimension <= capacity * dimension`, `data` is non-null per `NonNull`
@@ -212,7 +229,10 @@ impl ContiguousVectors {
     /// will be misattributed to wrong IDs.
     #[must_use]
     pub fn gather_flat(&self, indices: &[usize]) -> Vec<f32> {
-        let mut result = Vec::with_capacity(indices.len() * self.dimension);
+        // Saturating reservation hint: an overflowing `indices.len() * dimension`
+        // would otherwise panic inside `Vec::with_capacity`. `extend_from_slice`
+        // grows on demand, so a clamped hint stays correct (#899).
+        let mut result = Vec::with_capacity(indices.len().saturating_mul(self.dimension));
         for &idx in indices {
             if let Some(vec) = self.get(idx) {
                 result.extend_from_slice(vec);
@@ -222,10 +242,16 @@ impl ContiguousVectors {
     }
 
     /// Returns total memory usage in bytes.
+    ///
+    /// Saturates instead of overflowing; `capacity * dimension * 4` was validated
+    /// to fit in `usize` at allocation time, so saturation is unreachable for a
+    /// live buffer and exists purely as a defensive backstop (#899).
     #[inline]
     #[must_use]
     pub const fn memory_bytes(&self) -> usize {
-        self.capacity * self.dimension * std::mem::size_of::<f32>()
+        self.capacity
+            .saturating_mul(self.dimension)
+            .saturating_mul(std::mem::size_of::<f32>())
     }
 
     /// Inserts a vector at a specific index.
@@ -244,9 +270,22 @@ impl ContiguousVectors {
     pub fn insert_at(&mut self, index: usize, vector: &[f32]) -> crate::error::Result<()> {
         validate_dimension_match(self.dimension, vector.len())?;
 
-        self.ensure_capacity(index + 1)?;
+        // #899: `index == usize::MAX` made `index + 1` wrap to 0, so capacity was
+        // never grown and `index * dimension` overflowed, producing an OOB
+        // `copy_nonoverlapping` write in release builds. Reject overflow instead.
+        let required = index.checked_add(1).ok_or_else(|| {
+            crate::error::Error::AllocationFailed(format!(
+                "insert_at: index {index} + 1 overflows usize"
+            ))
+        })?;
+        self.ensure_capacity(required)?;
 
-        let offset = index * self.dimension;
+        let offset = index.checked_mul(self.dimension).ok_or_else(|| {
+            crate::error::Error::AllocationFailed(format!(
+                "insert_at: offset {index} * {} overflows usize",
+                self.dimension
+            ))
+        })?;
         // SAFETY: We ensured capacity covers index, data is non-null (NonNull invariant)
         // - Condition 1: Capacity was verified to cover the target index.
         // - Condition 2: Both source and destination pointers are valid and properly aligned.
@@ -259,9 +298,10 @@ impl ContiguousVectors {
             );
         }
 
-        // Update count if we're extending the "used" range
+        // Update count if we're extending the "used" range.
+        // `required == index + 1` (checked above), so this cannot overflow.
         if index >= self.count {
-            self.count = index + 1;
+            self.count = required;
         }
         Ok(())
     }
@@ -304,9 +344,18 @@ impl ContiguousVectors {
         for vector in vectors {
             validate_dimension_match(self.dimension, vector.len())?;
         }
-        self.ensure_capacity(self.count + vectors.len())?;
+        let required = self.count.checked_add(vectors.len()).ok_or_else(|| {
+            crate::error::Error::AllocationFailed(format!(
+                "push_batch: count {} + {} overflows usize",
+                self.count,
+                vectors.len()
+            ))
+        })?;
+        self.ensure_capacity(required)?;
         for vector in vectors {
-            let offset = self.count * self.dimension;
+            // `offset < required * dimension`, and `required * dimension` was
+            // validated to fit in `usize` by `ensure_capacity`/`layout` above.
+            let offset = self.count.saturating_mul(self.dimension);
             // SAFETY: ensure_capacity (called above) guarantees room for
             // self.count + vectors.len() elements, and all dimensions were
             // validated above so offset + dimension is within bounds.

--- a/crates/velesdb-core/src/perf_optimizations_tests.rs
+++ b/crates/velesdb-core/src/perf_optimizations_tests.rs
@@ -434,8 +434,20 @@ fn test_new_zero_dimension_returns_error() {
 
 #[test]
 fn test_new_overflow_dimension_returns_error() {
-    // Requesting absurd sizes should return AllocationFailed, not panic
+    // Requesting absurd sizes must return an error, not panic. Since #899
+    // enforces the dimension range up front, an absurd dimension is rejected as
+    // InvalidDimension (VELES-032) before the size product is ever computed.
     let result = ContiguousVectors::new(usize::MAX / 2, usize::MAX / 2);
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert_eq!(err.code(), "VELES-032");
+}
+
+#[test]
+fn test_new_overflow_capacity_returns_alloc_error() {
+    // With a valid dimension but an absurd capacity, the size product overflows /
+    // exceeds the ceiling and surfaces as AllocationFailed (VELES-033), not a panic.
+    let result = ContiguousVectors::new(crate::validation::MAX_DIMENSION, usize::MAX / 2);
     assert!(result.is_err());
     let err = result.unwrap_err();
     assert_eq!(err.code(), "VELES-033");
@@ -581,4 +593,125 @@ fn test_reserve_additional_then_push_batch_no_resize() {
         let actual = cv.get(i).expect("test: vector should exist");
         assert_eq!(actual, expected.as_slice(), "vector {i} data mismatch");
     }
+}
+
+// =========================================================================
+// #899 — Checked arithmetic / allocation-bound regression tests
+// =========================================================================
+
+/// `insert_at(usize::MAX, ..)` must error (no `index + 1` wrap to 0 → OOB write).
+#[test]
+fn test_insert_at_usize_max_index_rejected() {
+    let mut cv = ContiguousVectors::new(4, 16).expect("test");
+    let v = vec![1.0_f32, 2.0, 3.0, 4.0];
+    let err = cv
+        .insert_at(usize::MAX, &v)
+        .expect_err("usize::MAX index must be rejected, not wrap to OOB write");
+    assert!(matches!(err, crate::error::Error::AllocationFailed(_)));
+    // State must be unchanged — no partial/OOB write occurred.
+    assert_eq!(cv.len(), 0);
+}
+
+/// A large-but-not-MAX index whose `index * dimension` offset overflows must error.
+#[test]
+fn test_insert_at_offset_overflow_rejected() {
+    let mut cv = ContiguousVectors::new(4, 16).expect("test");
+    let v = vec![1.0_f32, 2.0, 3.0, 4.0];
+    // index * 4 overflows usize for this index.
+    let index = usize::MAX / 2;
+    let err = cv
+        .insert_at(index, &v)
+        .expect_err("offset overflow must be rejected");
+    assert!(matches!(err, crate::error::Error::AllocationFailed(_)));
+    assert_eq!(cv.len(), 0);
+}
+
+/// Oversized dimension (> MAX_DIMENSION) must be rejected at construction.
+#[test]
+fn test_oversized_dimension_rejected_at_construction() {
+    let err = ContiguousVectors::new(crate::validation::MAX_DIMENSION + 1, 16)
+        .expect_err("dimension above MAX_DIMENSION must be rejected");
+    assert!(matches!(err, crate::error::Error::InvalidDimension { .. }));
+    // The maximum valid dimension must still succeed.
+    assert!(ContiguousVectors::new(crate::validation::MAX_DIMENSION, 1).is_ok());
+}
+
+/// A construction request above the AllocGuard byte ceiling must be rejected.
+///
+/// #899 follow-up: the default ceiling is now a high 1 TiB backstop, so this
+/// uses a deliberately impossible ~238 TiB request (still below `usize`
+/// overflow) to exercise the ceiling rejection itself rather than the checked
+/// arithmetic. A legitimate large index (tens/hundreds of GiB) is NOT rejected.
+#[test]
+fn test_construction_above_alloc_ceiling_rejected() {
+    // dimension * capacity * 4 well above the 1 TiB default ceiling, but each
+    // factor is small enough not to overflow usize on its own.
+    let dimension = 65_536; // == MAX_DIMENSION, a valid dimension
+    let capacity = 1_000_000_000; // 65_536 * 1e9 * 4 bytes ≈ 238 TiB ≫ 1 TiB
+    let err = ContiguousVectors::new(dimension, capacity)
+        .expect_err("allocation above ceiling must be rejected");
+    assert!(matches!(err, crate::error::Error::AllocationFailed(_)));
+}
+
+/// REGRESSION (#899 follow-up): a large-but-legitimate single buffer that the
+/// old 16 GiB cap would have falsely rejected now constructs successfully —
+/// only the metadata/decision is exercised; we do NOT actually back 20 GiB.
+///
+/// `byte_size` is `pub(crate)`, so this test (compiled into the crate) can call
+/// the exact bound-decision path used by `new` without allocating.
+#[test]
+fn test_large_legit_buffer_size_decision_accepted() {
+    const GIB: usize = 1024 * 1024 * 1024;
+    // 20 GiB at 768D ≈ 6.8M vectors — above the old 16 GiB cap, below 1 TiB.
+    let dimension = 768;
+    let capacity = (20 * GIB) / (dimension * std::mem::size_of::<f32>());
+    let bytes = ContiguousVectors::byte_size(dimension, capacity)
+        .expect("byte_size must not overflow for a legit large buffer");
+    assert!(
+        bytes > 16 * GIB,
+        "test setup: should exceed the old 16 GiB cap"
+    );
+    assert!(
+        crate::alloc_guard::check_alloc_bound(bytes).is_ok(),
+        "legit ~20 GiB single buffer must not be falsely rejected"
+    );
+}
+
+/// Geometric-growth doubling must not wrap: a resize request near usize::MAX
+/// fails cleanly rather than wrapping `capacity * 2` to a tiny value.
+#[test]
+fn test_ensure_capacity_doubling_overflow_handled() {
+    let mut cv = ContiguousVectors::new(4, 16).expect("test");
+    let err = cv
+        .ensure_capacity(usize::MAX)
+        .expect_err("usize::MAX capacity must fail cleanly");
+    assert!(matches!(err, crate::error::Error::AllocationFailed(_)));
+    // Buffer remains usable after the rejected growth.
+    assert_eq!(cv.capacity(), 16);
+    cv.push(&[1.0, 2.0, 3.0, 4.0]).expect("test");
+    assert_eq!(cv.len(), 1);
+}
+
+/// `gather_flat` with a huge index list must not panic on the capacity hint and
+/// must skip out-of-bounds indices.
+#[test]
+fn test_gather_flat_overflow_hint_safe() {
+    let mut cv = ContiguousVectors::new(4, 16).expect("test");
+    cv.push(&[1.0, 2.0, 3.0, 4.0]).expect("test");
+    // Valid index plus an out-of-bounds one; result holds only the valid vector.
+    let out = cv.gather_flat(&[0, 999]);
+    assert_eq!(out, vec![1.0, 2.0, 3.0, 4.0]);
+}
+
+/// Normal store / insert / gather paths remain unaffected by the new guards.
+#[test]
+fn test_normal_paths_unaffected_by_guards() {
+    let mut cv = ContiguousVectors::new(3, 16).expect("test");
+    cv.insert_at(0, &[1.0, 2.0, 3.0]).expect("test");
+    cv.insert_at(2, &[7.0, 8.0, 9.0]).expect("test"); // sparse insert
+    cv.push(&[4.0, 5.0, 6.0]).expect("test");
+    assert_eq!(cv.get(0), Some(&[1.0, 2.0, 3.0][..]));
+    assert_eq!(cv.get(2), Some(&[7.0, 8.0, 9.0][..]));
+    let flat = cv.gather_flat(&[0, 2]);
+    assert_eq!(flat, vec![1.0, 2.0, 3.0, 7.0, 8.0, 9.0]);
 }


### PR DESCRIPTION
**Closes #894, Closes #899. Refs #897.** Grouped: AllocGuard load-bound (#899) and HNSW load validation (#894) both touch `graph_io.rs`.

- **#894:** validate persisted neighbor IDs / `entry_point` / counts before `get_unchecked` (kills release OOB read on corrupt `.graph`); postcard sidecar validation.
- **#899:** checked arithmetic in `ContiguousVectors`, enforced dimension max, real `AllocGuard` backstop (1 TiB, configurable); index-load path bounded by file length.

---
Part of the 2026-05-28 `velesdb-core` security/perf/OOM audit (`report/AUDIT-velesdb-core-2026-05-28.md`). Implemented by a specialist sub-agent, then adversarial review→fix rounds to 0 findings. Integration-branch gate: `cargo fmt --check`, workspace `clippy -D warnings -D clippy::pedantic`, full lib suite (4914 tests), recall contracts — all green. Every fix ships a regression test.