### PR TITLE
fix(quantization): validate PQ codes/rotation + RaBitQ bits on load (#895)

### DIFF
--- a/crates/velesdb-core/src/collection/search/vector.rs
+++ b/crates/velesdb-core/src/collection/search/vector.rs
@@ -211,15 +211,13 @@ fn rescore_euclidean_batch(
             }
         }
         Err(err) => {
-            // ADC batch failed (should not happen with valid quantizer);
-            // fall back to per-item scalar scoring.
-            tracing::warn!(%err, "batch ADC rescore failed; falling back to scalar");
-            for &(orig_idx, pq_vec) in &with_pq {
-                scores[orig_idx] = ScoredResult::new(
-                    index_results[orig_idx].id,
-                    distance_pq_l2(query, pq_vec, quantizer),
-                );
-            }
+            // ADC batch rejected the candidates (e.g. an out-of-range PQ code on a
+            // tampered/corrupt persisted vector). The same codes would also drive the
+            // scalar `distance_pq_l2` path out of bounds (LUT indexing panic), so we
+            // do NOT re-invoke it here. The affected candidates keep their original
+            // HNSW score (already seeded into `scores`) — a clean skip, matching the
+            // graceful degradation used for cache misses above.
+            tracing::warn!(%err, "batch ADC rescore rejected candidates; keeping HNSW scores");
         }
     }
 
@@ -533,5 +531,48 @@ impl Collection {
             return self.merge_delta(results, query, candidates_k, metric);
         }
         self.search_ids_with_adc_if_pq(query, candidates_k)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{rescore_euclidean_batch, PQVector, ProductQuantizer};
+    use crate::scored_result::ScoredResult;
+    use std::collections::HashMap;
+
+    fn small_trained_pq() -> ProductQuantizer {
+        let vectors = vec![
+            vec![1.0, 2.0, 3.0, 4.0],
+            vec![5.0, 6.0, 7.0, 8.0],
+            vec![-1.0, -2.0, 9.0, 10.0],
+        ];
+        ProductQuantizer::train(&vectors, 2, 2).expect("train small PQ")
+    }
+
+    #[test]
+    fn invalid_pq_code_in_search_path_skips_candidate_without_panic() {
+        // Routing an out-of-range PQ code through the Euclidean batch scoring entry
+        // point (the same one the fallback uses) must NOT panic and must NOT re-invoke
+        // the unvalidated scalar indexing path. The candidate keeps its HNSW score.
+        let quantizer = small_trained_pq();
+        // num_centroids == 2, so code 99 is out of range for both subspaces.
+        let bad = PQVector { codes: vec![0, 99] };
+
+        let mut pq_cache: HashMap<u64, PQVector> = HashMap::new();
+        pq_cache.insert(7, bad);
+
+        let index_results = vec![ScoredResult::new(7, 0.42)];
+        let query = vec![1.0, 2.0, 3.0, 4.0];
+
+        let scored = rescore_euclidean_batch(&query, &quantizer, &pq_cache, &index_results);
+
+        assert_eq!(scored.len(), 1);
+        assert_eq!(scored[0].id, 7);
+        // Clean skip: original HNSW score is retained, no panic, no garbage.
+        assert!(
+            (scored[0].score - 0.42).abs() < 1e-6,
+            "rejected candidate must keep its HNSW score, got {}",
+            scored[0].score
+        );
     }
 }

--- a/crates/velesdb-core/src/quantization/mod.rs
+++ b/crates/velesdb-core/src/quantization/mod.rs
@@ -14,6 +14,33 @@ use std::io;
 
 use serde::{Deserialize, Serialize};
 
+/// Validate that a flat row-major rotation matrix has exactly `dimension^2`
+/// elements, returning [`crate::error::Error::IndexCorrupted`] otherwise.
+///
+/// Shared by the PQ (OPQ) and `RaBitQ` load-time validators so the unchecked
+/// `matrix[i * d + j]` indexing in their rotation kernels stays in bounds.
+pub(crate) fn validate_rotation_len(
+    len: usize,
+    dimension: usize,
+    label: &str,
+) -> Result<(), crate::error::Error> {
+    // `checked_mul`: `dimension` is attacker-controlled post-deserialize; a wrapping
+    // `dimension * dimension` (esp. on 32-bit targets) could yield a small `expected`
+    // that a tampered `len` matches, false-passing the shape check that the unchecked
+    // `matrix[i * d + j]` indexing relies on.
+    let Some(expected) = dimension.checked_mul(dimension) else {
+        return Err(crate::error::Error::IndexCorrupted(format!(
+            "{label} rotation dimension {dimension} squared overflows usize"
+        )));
+    };
+    if len != expected {
+        return Err(crate::error::Error::IndexCorrupted(format!(
+            "{label} rotation has {len} elements, expected dimension^2 = {expected}"
+        )));
+    }
+    Ok(())
+}
+
 mod binary;
 pub(crate) mod codec_helpers;
 mod pq;

--- a/crates/velesdb-core/src/quantization/pq.rs
+++ b/crates/velesdb-core/src/quantization/pq.rs
@@ -331,6 +331,129 @@ fn check_degenerate_centroids(centroids: &[Vec<Vec<f32>>]) {
 }
 
 impl ProductQuantizer {
+    /// Validate a deserialized quantizer's structural invariants.
+    ///
+    /// Must be called once on every quantizer loaded from untrusted bytes
+    /// (see [`Self::load_codebook`]) before it is used for search. After this
+    /// returns `Ok`, the codebook layout matches its declared dimensions and
+    /// the rotation matrix (if present) is `dimension * dimension`, so the
+    /// unchecked indexing in [`apply_rotation`](Self::apply_rotation) operates
+    /// only on in-bounds offsets.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::IndexCorrupted` if the centroid table shape, subspace
+    /// dimension, or rotation length is inconsistent with the declared
+    /// `dimension` / `num_subspaces` / `num_centroids`.
+    pub fn validate_loaded(&self) -> Result<(), Error> {
+        let cb = &self.codebook;
+        if cb.num_subspaces == 0 || cb.num_centroids == 0 || cb.subspace_dim == 0 {
+            return Err(Error::IndexCorrupted(
+                "PQ codebook has zero subspaces, centroids, or subspace_dim".into(),
+            ));
+        }
+        Self::validate_dimensions(cb)?;
+        if cb.centroids.len() != cb.num_subspaces {
+            return Err(Error::IndexCorrupted(format!(
+                "PQ codebook has {} centroid tables, expected num_subspaces {}",
+                cb.centroids.len(),
+                cb.num_subspaces
+            )));
+        }
+        Self::validate_centroid_tables(cb)?;
+        self.validate_rotation()
+    }
+
+    /// Validate the `num_centroids` ceiling and the `subspace_dim * num_subspaces`
+    /// shape invariant against attacker-controlled, post-deserialize fields.
+    fn validate_dimensions(cb: &PQCodebook) -> Result<(), Error> {
+        // `train()` enforces `num_centroids <= u16::MAX` so codes (u16) can index
+        // every centroid. Without this, `validate_codes` (`code < num_centroids`)
+        // is trivially true for any `num_centroids > 65535`, letting out-of-table
+        // codes slip past. Reject here, consistent with `train`.
+        if u16::try_from(cb.num_centroids).is_err() {
+            return Err(Error::IndexCorrupted(format!(
+                "PQ codebook num_centroids {} exceeds u16::MAX (65535)",
+                cb.num_centroids
+            )));
+        }
+        // `checked_mul`: both operands are attacker-controlled post-deserialize; a
+        // wrapping multiply (esp. on 32-bit targets) could false-pass this check.
+        let Some(product) = cb.subspace_dim.checked_mul(cb.num_subspaces) else {
+            return Err(Error::IndexCorrupted(format!(
+                "PQ codebook subspace_dim {} * num_subspaces {} overflows usize",
+                cb.subspace_dim, cb.num_subspaces
+            )));
+        };
+        if product != cb.dimension {
+            return Err(Error::IndexCorrupted(format!(
+                "PQ codebook dimension {} != num_subspaces {} * subspace_dim {}",
+                cb.dimension, cb.num_subspaces, cb.subspace_dim
+            )));
+        }
+        Ok(())
+    }
+
+    /// Validate that every subspace has `num_centroids` centroids of `subspace_dim`.
+    fn validate_centroid_tables(cb: &PQCodebook) -> Result<(), Error> {
+        for (subspace, table) in cb.centroids.iter().enumerate() {
+            if table.len() != cb.num_centroids {
+                return Err(Error::IndexCorrupted(format!(
+                    "PQ subspace {subspace} has {} centroids, expected {}",
+                    table.len(),
+                    cb.num_centroids
+                )));
+            }
+            if let Some(bad) = table.iter().position(|c| c.len() != cb.subspace_dim) {
+                return Err(Error::IndexCorrupted(format!(
+                    "PQ subspace {subspace} centroid {bad} has wrong length, expected {}",
+                    cb.subspace_dim
+                )));
+            }
+        }
+        Ok(())
+    }
+
+    /// Validate the OPQ rotation matrix length against the codebook dimension.
+    fn validate_rotation(&self) -> Result<(), Error> {
+        if let Some(matrix) = &self.rotation {
+            super::validate_rotation_len(matrix.len(), self.codebook.dimension, "OPQ")?;
+        }
+        Ok(())
+    }
+
+    /// Verify every code in `pq_vector` is a valid centroid index `< num_centroids`
+    /// and that the code count matches `num_subspaces`.
+    ///
+    /// This is the precondition the unsafe SIMD ADC kernels rely on: once it
+    /// returns `Ok`, `code[i] < num_centroids` for all `i`, so every gather
+    /// index `subspace * num_centroids + code` stays within the LUT bounds.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::IndexCorrupted` if a code is out of range or the code
+    /// count is wrong.
+    pub fn validate_codes(&self, pq_vector: &PQVector) -> Result<(), Error> {
+        if pq_vector.codes.len() != self.codebook.num_subspaces {
+            return Err(Error::IndexCorrupted(format!(
+                "PQ vector has {} codes, expected num_subspaces {}",
+                pq_vector.codes.len(),
+                self.codebook.num_subspaces
+            )));
+        }
+        if let Some(bad) = pq_vector
+            .codes
+            .iter()
+            .position(|&c| usize::from(c) >= self.codebook.num_centroids)
+        {
+            return Err(Error::IndexCorrupted(format!(
+                "PQ code {} at subspace {bad} >= num_centroids {}",
+                pq_vector.codes[bad], self.codebook.num_centroids
+            )));
+        }
+        Ok(())
+    }
+
     /// Precompute ADC lookup table for a query vector.
     ///
     /// Returns flat `[m * k]` table indexed as `lut[subspace * k + centroid_id]`.
@@ -437,9 +560,9 @@ const ADC_SIMD_BATCH_THRESHOLD: usize = 8;
 ///
 /// # Errors
 ///
-/// Returns `Err` only if LUT construction parameters are inconsistent
-/// (zero subspaces). In practice this cannot happen with a validly
-/// trained `ProductQuantizer`.
+/// Returns `Err` if a candidate's PQ codes are out of range for the codebook
+/// (`Error::IndexCorrupted`, e.g. from a tampered/corrupt persisted vector) or
+/// if LUT construction parameters are inconsistent (zero subspaces).
 #[cfg_attr(not(feature = "persistence"), allow(dead_code))]
 pub(crate) fn pq_adc_batch_rescore(
     quantizer: &ProductQuantizer,
@@ -451,6 +574,15 @@ pub(crate) fn pq_adc_batch_rescore(
     }
 
     let m = quantizer.codebook.num_subspaces;
+
+    // Validate every code once, before any indexing into the LUT. This upholds
+    // the unsafe SIMD kernel precondition `code[i] < num_centroids` (== k) for
+    // the whole batch — so the gather indices stay within the LUT bounds — and
+    // keeps the scalar fallback panic-free. A single linear scan here keeps the
+    // check out of both the scalar and SIMD hot loops.
+    for pq_vec in pq_vectors {
+        quantizer.validate_codes(pq_vec)?;
+    }
 
     // Small batches: scalar path avoids slice-building overhead.
     if pq_vectors.len() < ADC_SIMD_BATCH_THRESHOLD {

--- a/crates/velesdb-core/src/quantization/pq_persistence.rs
+++ b/crates/velesdb-core/src/quantization/pq_persistence.rs
@@ -9,6 +9,15 @@ use serde::{Deserialize, Serialize};
 
 use super::pq::ProductQuantizer;
 
+/// Maximum accepted size of a persisted PQ artifact (codebook or rotation).
+///
+/// A valid codebook is `num_subspaces * num_centroids * subspace_dim` f32s
+/// plus small metadata; with the trained bounds (`num_subspaces <= 64`,
+/// `num_centroids <= u16::MAX`, `subspace_dim` modest) this stays well under
+/// 256 MiB. The cap rejects absurd/hostile files before they are decoded into
+/// a multi-gigabyte allocation. (Addresses the alloc-cap concern of #897.)
+const MAX_PQ_ARTIFACT_BYTES: u64 = 256 * 1024 * 1024;
+
 /// RF-2: Serializes `value` with postcard and atomically writes to `dir/filename`.
 ///
 /// Write goes to `.tmp` suffix first, then renamed for crash safety.
@@ -43,6 +52,12 @@ fn postcard_load<T: for<'de> Deserialize<'de>>(
     if !path.exists() {
         return Ok(None);
     }
+    let file_len = std::fs::metadata(&path)?.len();
+    if file_len > MAX_PQ_ARTIFACT_BYTES {
+        return Err(Error::IndexCorrupted(format!(
+            "{label} file is {file_len} bytes, exceeds cap {MAX_PQ_ARTIFACT_BYTES}"
+        )));
+    }
     let data = std::fs::read(&path)?;
     let value: T = postcard::from_bytes(&data).map_err(|e| {
         Error::Io(std::io::Error::new(
@@ -67,11 +82,22 @@ impl ProductQuantizer {
 
     /// Load codebook from `<dir>/codebook.pq`. Returns `None` if file doesn't exist.
     ///
+    /// The decoded quantizer is structurally validated ([`Self::validate_loaded`])
+    /// before being returned, so a corrupt or tampered codebook is rejected here
+    /// rather than producing out-of-bounds indexing during search.
+    ///
     /// # Errors
     ///
-    /// Returns `Error::Io` if deserialization or file I/O fails.
+    /// Returns `Error::Io` if deserialization or file I/O fails, or
+    /// `Error::IndexCorrupted` if the decoded codebook/rotation is inconsistent
+    /// or the file exceeds [`MAX_PQ_ARTIFACT_BYTES`].
     pub fn load_codebook(dir: &std::path::Path) -> Result<Option<Self>, Error> {
-        postcard_load(dir, "codebook.pq", "PQ codebook")
+        let Some(quantizer): Option<Self> = postcard_load(dir, "codebook.pq", "PQ codebook")?
+        else {
+            return Ok(None);
+        };
+        quantizer.validate_loaded()?;
+        Ok(Some(quantizer))
     }
 
     /// Save OPQ rotation matrix to `<dir>/rotation.opq` using postcard.

--- a/crates/velesdb-core/src/quantization/pq_tests.rs
+++ b/crates/velesdb-core/src/quantization/pq_tests.rs
@@ -978,3 +978,155 @@ fn adc_batch_rescore_preserves_ordering() {
         "batch ADC top-k should match scalar top-k exactly, got recall={recall}"
     );
 }
+
+// ====================================================================
+// #895: load-time validation of PQ codes / rotation (OOB gather guard)
+// ====================================================================
+
+/// Train a small valid PQ for validation tests: 4D, 2 subspaces, 2 centroids.
+fn small_trained_pq() -> ProductQuantizer {
+    let vectors = vec![
+        vec![1.0, 2.0, 3.0, 4.0],
+        vec![5.0, 6.0, 7.0, 8.0],
+        vec![-1.0, -2.0, 9.0, 10.0],
+    ];
+    ProductQuantizer::train(&vectors, 2, 2).expect("train small PQ")
+}
+
+#[test]
+fn validate_codes_rejects_out_of_range_code() {
+    let pq = small_trained_pq();
+    // num_centroids == 2, so code 2 is out of range (valid are 0,1).
+    let corrupt = PQVector { codes: vec![0, 2] };
+    let err = pq
+        .validate_codes(&corrupt)
+        .expect_err("out-of-range code must be rejected");
+    assert!(matches!(err, Error::IndexCorrupted(_)), "got {err:?}");
+}
+
+#[test]
+fn validate_codes_rejects_wrong_code_count() {
+    let pq = small_trained_pq();
+    let corrupt = PQVector {
+        codes: vec![0, 1, 0],
+    };
+    let err = pq
+        .validate_codes(&corrupt)
+        .expect_err("wrong code count must be rejected");
+    assert!(matches!(err, Error::IndexCorrupted(_)), "got {err:?}");
+}
+
+#[test]
+fn validate_codes_accepts_valid_codes() {
+    let pq = small_trained_pq();
+    let valid = PQVector { codes: vec![1, 0] };
+    assert!(pq.validate_codes(&valid).is_ok());
+}
+
+#[test]
+fn batch_rescore_rejects_out_of_range_code_without_ub() {
+    // The SIMD ADC dispatch path must return Err (not OOB gather / UB / panic)
+    // when a candidate carries a tampered code >= num_centroids.
+    let pq = small_trained_pq();
+    let bad = PQVector { codes: vec![0, 99] };
+    let refs: Vec<&PQVector> = vec![&bad];
+    let query = vec![1.0, 2.0, 3.0, 4.0];
+    let err = pq_adc_batch_rescore(&pq, &query, &refs)
+        .expect_err("batch rescore must reject out-of-range codes");
+    assert!(matches!(err, Error::IndexCorrupted(_)), "got {err:?}");
+}
+
+#[test]
+fn validate_loaded_rejects_rotation_length_mismatch() {
+    let mut pq = small_trained_pq();
+    // dimension == 4 → rotation must be 16 elements; give 9 instead.
+    pq.rotation = Some(vec![0.0; 9]);
+    let err = pq
+        .validate_loaded()
+        .expect_err("rotation length mismatch must be rejected");
+    assert!(matches!(err, Error::IndexCorrupted(_)), "got {err:?}");
+}
+
+#[test]
+fn validate_loaded_rejects_centroid_table_count_mismatch() {
+    let mut pq = small_trained_pq();
+    // Drop a subspace table so centroids.len() != num_subspaces.
+    pq.codebook.centroids.pop();
+    let err = pq
+        .validate_loaded()
+        .expect_err("centroid table count mismatch must be rejected");
+    assert!(matches!(err, Error::IndexCorrupted(_)), "got {err:?}");
+}
+
+#[test]
+fn validate_loaded_accepts_valid_quantizer() {
+    let pq = small_trained_pq();
+    assert!(pq.validate_loaded().is_ok());
+}
+
+#[test]
+fn validate_loaded_rejects_num_centroids_above_u16_max() {
+    // `train()` caps num_centroids at u16::MAX; a tampered codebook declaring more
+    // would let out-of-table u16 codes pass `validate_codes` trivially. Reject it.
+    let mut pq = small_trained_pq();
+    pq.codebook.num_centroids = usize::from(u16::MAX) + 1;
+    let err = pq
+        .validate_loaded()
+        .expect_err("num_centroids > 65535 must be rejected");
+    assert!(matches!(err, Error::IndexCorrupted(_)), "got {err:?}");
+}
+
+#[test]
+fn validate_loaded_rejects_shape_check_multiply_overflow() {
+    // `subspace_dim * num_subspaces` must use checked_mul: a wrapping product could
+    // false-pass the `== dimension` shape check on attacker-controlled fields.
+    let mut pq = small_trained_pq();
+    // Pick operands whose usize product overflows but whose declared dimension is
+    // left small, so an unchecked multiply could wrap to match `dimension`.
+    pq.codebook.subspace_dim = usize::MAX;
+    pq.codebook.num_subspaces = 2;
+    let err = pq
+        .validate_loaded()
+        .expect_err("multiply overflow must be rejected, not false-passed");
+    assert!(matches!(err, Error::IndexCorrupted(_)), "got {err:?}");
+}
+
+#[cfg(feature = "persistence")]
+#[test]
+fn load_codebook_rejects_corrupt_centroid_table() {
+    let mut pq = small_trained_pq();
+    let dir = tempfile::tempdir().expect("tempdir");
+    pq.save_codebook(dir.path()).expect("save");
+
+    // Corrupt on disk: re-serialize a quantizer with a dropped centroid table.
+    pq.codebook.centroids.pop();
+    let bytes = postcard::to_allocvec(&pq).expect("serialize corrupt");
+    std::fs::write(dir.path().join("codebook.pq"), &bytes).expect("write corrupt");
+
+    let err = ProductQuantizer::load_codebook(dir.path())
+        .expect_err("corrupt codebook must fail to load");
+    assert!(matches!(err, Error::IndexCorrupted(_)), "got {err:?}");
+}
+
+#[cfg(feature = "persistence")]
+#[test]
+fn load_codebook_valid_roundtrip_unchanged_distances() {
+    // Recall non-regression at the unit level: a valid round-trip loads and
+    // produces identical ADC distances to the in-memory quantizer.
+    let pq = small_trained_pq();
+    let query = vec![0.5, 1.5, 2.5, 3.5];
+    let encoded = pq.quantize(&query).expect("quantize");
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    pq.save_codebook(dir.path()).expect("save");
+    let loaded = ProductQuantizer::load_codebook(dir.path())
+        .expect("load ok")
+        .expect("codebook exists");
+
+    let before = distance_pq_l2(&query, &encoded, &pq);
+    let after = distance_pq_l2(&query, &encoded, &loaded);
+    assert!(
+        (before - after).abs() < 1e-6,
+        "distance changed across round-trip: {before} vs {after}"
+    );
+}

--- a/crates/velesdb-core/src/quantization/rabitq.rs
+++ b/crates/velesdb-core/src/quantization/rabitq.rs
@@ -66,6 +66,21 @@ pub(crate) fn signs_to_bits(values: &[f32], dim: usize) -> Vec<u64> {
     bits
 }
 
+/// Bitmask selecting the in-use bits of the last u64 word for `dim` dimensions.
+///
+/// Returns `u64::MAX` when `dim` is a multiple of 64 (the last word is fully
+/// used) or when `dim == 0`. Otherwise returns a mask with the low `dim % 64`
+/// bits set, so a bitwise-AND on the last word zeroes the high padding bits.
+#[must_use]
+pub(crate) const fn last_word_mask(dim: usize) -> u64 {
+    let rem = dim % 64;
+    if rem == 0 {
+        u64::MAX
+    } else {
+        (1u64 << rem) - 1
+    }
+}
+
 /// Apply a flat row-major rotation matrix to a vector.
 ///
 /// Computes `result[i] = sum_j rotation[i * dim + j] * vector[j]` for each `i`.
@@ -96,17 +111,21 @@ fn xor_popcount_ip(q_bits: &[u64], enc_bits: &[u64], num_words: usize, dim: usiz
     let differing_bits =
         crate::simd_native::hamming_binary_native(&q_bits[..num_words], &enc_bits[..num_words]);
 
-    // Invariant: differing_bits <= dim because padding bits never contribute.
+    // When padding bits are zero, `differing_bits <= dim`, so
+    // `matching_bits = dim - differing_bits` is exact. Clean vectors satisfy
+    // this: `signs_to_bits` zeroes padding on encode and `RaBitQVectorStore::push`
+    // masks it on store (the only paths that populate the bit store).
+    //
+    // This clamp is defense-in-depth for any vector whose padding bits are
+    // nonetheless set (e.g. a tampered in-memory value): set padding bits would
+    // push `differing_bits` above `dim`. We clamp so `matching_bits` cannot
+    // underflow (u32 wraparound → garbage / non-finite distance), keeping the
+    // estimate finite and within `[-1, 1]`. This is graceful degradation, not
+    // exact recovery — exactness comes from the masking on the encode/store path.
     // Reason: dim fits in u32 for any practical vector dimension (< 2^32).
     #[allow(clippy::cast_possible_truncation)]
     let dim_u32 = dim as u32;
-    debug_assert!(
-        differing_bits <= dim_u32,
-        "differing_bits ({differing_bits}) > dim ({dim}): \
-         signs_to_bits must zero padding bits"
-    );
-
-    let matching_bits = dim_u32 - differing_bits;
+    let matching_bits = dim_u32 - differing_bits.min(dim_u32);
 
     // Inner product estimate: each matching bit contributes +1/D,
     // each differing bit contributes -1/D.
@@ -363,13 +382,25 @@ impl RaBitQIndex {
 
     /// Load `RaBitQ` index from `<dir>/rabitq.idx`. Returns `None` if file doesn't exist.
     ///
+    /// The decoded index is validated ([`Self::validate_loaded`]) so a corrupt
+    /// rotation/centroid is rejected here rather than producing out-of-bounds
+    /// indexing in [`apply_rotation_flat`] during search.
+    ///
     /// # Errors
     ///
-    /// Returns `Error::Io` if deserialization or file I/O fails.
+    /// Returns `Error::Io` if deserialization or file I/O fails, or
+    /// `Error::IndexCorrupted` if the file exceeds the size cap or the decoded
+    /// rotation/centroid lengths are inconsistent with `dimension`.
     pub fn load(dir: &std::path::Path) -> Result<Option<Self>, Error> {
         let path = dir.join("rabitq.idx");
         if !path.exists() {
             return Ok(None);
+        }
+        let file_len = std::fs::metadata(&path)?.len();
+        if file_len > MAX_RABITQ_INDEX_BYTES {
+            return Err(Error::IndexCorrupted(format!(
+                "RaBitQ index file is {file_len} bytes, exceeds cap {MAX_RABITQ_INDEX_BYTES}"
+            )));
         }
         let data = std::fs::read(&path)?;
         let index: Self = postcard::from_bytes(&data).map_err(|e| {
@@ -378,9 +409,43 @@ impl RaBitQIndex {
                 format!("failed to deserialize RaBitQ index: {e}"),
             ))
         })?;
+        index.validate_loaded()?;
         Ok(Some(index))
     }
+
+    /// Validate a deserialized index's structural invariants.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::IndexCorrupted` if `dimension` is zero, the centroid
+    /// length is not `dimension`, or the rotation length is not `dimension^2`.
+    fn validate_loaded(&self) -> Result<(), Error> {
+        if self.dimension == 0 {
+            return Err(Error::IndexCorrupted(
+                "RaBitQ index has zero dimension".into(),
+            ));
+        }
+        if self.centroid.len() != self.dimension {
+            return Err(Error::IndexCorrupted(format!(
+                "RaBitQ centroid has {} elements, expected dimension {}",
+                self.centroid.len(),
+                self.dimension
+            )));
+        }
+        super::validate_rotation_len(self.rotation.len(), self.dimension, "RaBitQ")?;
+        Ok(())
+    }
 }
+
+/// Maximum accepted size of a persisted `RaBitQ` index file.
+///
+/// The index stores a `dimension^2` rotation matrix plus a `dimension`
+/// centroid. For the documented stability ceiling (`dimension <= 2048`) the
+/// rotation is `2048^2` f32 ≈ 16 MiB; the 256 MiB cap rejects hostile files
+/// before they trigger a huge allocation. (Addresses the alloc-cap concern of
+/// #897.)
+#[cfg(feature = "persistence")]
+const MAX_RABITQ_INDEX_BYTES: u64 = 256 * 1024 * 1024;
 
 /// Generate a random orthogonal matrix using modified Gram-Schmidt.
 ///

--- a/crates/velesdb-core/src/quantization/rabitq_store.rs
+++ b/crates/velesdb-core/src/quantization/rabitq_store.rs
@@ -55,9 +55,20 @@ impl RaBitQVectorStore {
     }
 
     /// Appends an encoded vector's bits and correction to the store.
+    ///
+    /// The unused padding bits of the last word are masked to zero so that the
+    /// XOR + popcount distance estimator cannot underflow even if `bits` came
+    /// from untrusted (deserialized/tampered) input. Masking is correctness-
+    /// preserving: padding bits carry no information (see
+    /// [`super::rabitq::signs_to_bits`]).
     pub fn push(&mut self, bits: &[u64], correction: RaBitQCorrection) {
         debug_assert_eq!(bits.len(), self.words_per_vector);
         self.bits_data.extend_from_slice(bits);
+        if !bits.is_empty() {
+            if let Some(last) = self.bits_data.last_mut() {
+                *last &= super::rabitq::last_word_mask(self.dimension);
+            }
+        }
         self.corrections.push(correction);
         self.count += 1;
     }

--- a/crates/velesdb-core/src/quantization/rabitq_tests.rs
+++ b/crates/velesdb-core/src/quantization/rabitq_tests.rs
@@ -1,4 +1,6 @@
 use super::*;
+#[cfg(feature = "persistence")]
+use crate::error::Error;
 
 /// Compute brute-force L2 (Euclidean) top-k neighbors for a query.
 ///
@@ -610,4 +612,106 @@ fn rabitq_prepared_query_is_pub_crate() {
     assert!(pq.norm_sq > 0.0);
     assert_eq!(pq.bits.len(), 1);
     assert_eq!(pq.rotated.len(), dim);
+}
+
+// ====================================================================
+// #895: RaBitQ padding-bit safety (u32 underflow guard on load)
+// ====================================================================
+
+#[test]
+fn last_word_mask_covers_used_bits_only() {
+    // dim multiple of 64 → all bits used.
+    assert_eq!(last_word_mask(64), u64::MAX);
+    assert_eq!(last_word_mask(128), u64::MAX);
+    // dim == 0 → no in-use bits in a (nonexistent) last word; mask is full.
+    assert_eq!(last_word_mask(0), u64::MAX);
+    // dim = 70 → last word uses 6 low bits.
+    assert_eq!(last_word_mask(70), (1u64 << 6) - 1);
+    // dim = 1 → only bit 0.
+    assert_eq!(last_word_mask(1), 1);
+}
+
+#[test]
+fn xor_popcount_ip_no_underflow_with_set_padding_bits() {
+    // dim = 70 → 2 words; bits 70..128 of word 1 are padding.
+    let dim: usize = 70;
+    let num_words = dim.div_ceil(64);
+    // Query and encoded agree on all real bits (all zero), so a clean estimate
+    // would be ip = +1 (all matching). Inject padding bits into the encoded
+    // word — without the guard these would count as "differing" and drive
+    // matching_bits negative (u32 underflow → garbage / non-finite).
+    let q_bits = vec![0u64; num_words];
+    let mut enc_bits = vec![0u64; num_words];
+    enc_bits[1] = !((1u64 << 6) - 1); // set every padding bit (bits 6..64).
+
+    // Safety: with raw (unsanitized) padding bits set, the clamp keeps the
+    // estimate finite and in range — no u32 underflow / garbage.
+    let ip = xor_popcount_ip(&q_bits, &enc_bits, num_words, dim);
+    assert!(ip.is_finite(), "ip must be finite, got {ip}");
+    assert!(
+        (-1.0..=1.0).contains(&ip),
+        "ip must stay in [-1, 1], got {ip}"
+    );
+
+    // Correctness: masking padding to zero restores the exact clean estimate.
+    let mut masked = enc_bits.clone();
+    masked[1] &= last_word_mask(dim);
+    let ref_ip = xor_popcount_ip(&q_bits, &masked, num_words, dim);
+    assert!((ref_ip - 1.0).abs() < 1e-6, "all-matching ip should be 1.0");
+}
+
+#[test]
+fn distance_with_tampered_padding_stays_finite_and_masks_to_clean() {
+    // End-to-end: a tampered RaBitQVector (padding bits set) must yield a finite
+    // distance (the `xor_popcount_ip` clamp is defense-in-depth, no underflow), and
+    // masking the padding (what `signs_to_bits`/`push` do) restores the exact clean
+    // encoding and distance.
+    let dim: usize = 70;
+    let index = identity_index(dim);
+    let mut vector = vec![0.0f32; dim];
+    for (i, x) in vector.iter_mut().enumerate() {
+        #[allow(clippy::cast_precision_loss)]
+        let v = (i as f32) - 35.0;
+        *x = v;
+    }
+    let clean = index.encode(&vector).expect("encode");
+
+    // Tamper: set the padding bits of the last word.
+    let mut tampered = clean.clone();
+    let last = tampered.bits.len() - 1;
+    tampered.bits[last] |= !last_word_mask(dim);
+
+    let query = vec![1.0f32; dim];
+    let d_clean = index.distance(&query, &clean);
+    let d_tampered = index.distance(&query, &tampered);
+    assert!(d_tampered.is_finite(), "tampered distance must be finite");
+    assert!(d_clean.is_finite());
+
+    // Masking the padding (the encode/store invariant) restores the clean bit
+    // pattern and the clean distance exactly.
+    let mut masked = tampered.clone();
+    let last = masked.bits.len() - 1;
+    masked.bits[last] &= last_word_mask(dim);
+    assert_eq!(masked.bits, clean.bits);
+    let d_masked = index.distance(&query, &masked);
+    assert!(
+        (d_clean - d_masked).abs() < 1e-4,
+        "masked distance {d_masked} != clean {d_clean}"
+    );
+}
+
+#[cfg(feature = "persistence")]
+#[test]
+fn rabitq_load_rejects_rotation_length_mismatch() {
+    let dim = 8;
+    let mut index = identity_index(dim);
+    // Corrupt the rotation length (must be dim*dim = 64).
+    index.rotation.truncate(40);
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let bytes = postcard::to_allocvec(&index).expect("serialize");
+    std::fs::write(dir.path().join("rabitq.idx"), &bytes).expect("write");
+
+    let err = RaBitQIndex::load(dir.path()).expect_err("corrupt rotation length must fail to load");
+    assert!(matches!(err, Error::IndexCorrupted(_)), "got {err:?}");
 }

--- a/crates/velesdb-core/src/simd_native/adc.rs
+++ b/crates/velesdb-core/src/simd_native/adc.rs
@@ -4,7 +4,10 @@
 //! Dispatches to AVX2 gather, NEON, or scalar path based on runtime detection.
 //!
 //! The crate-private API (`adc_distances_batch`) is called from the PQ
-//! rescoring pipeline in `crate::quantization::pq::pq_adc_batch_rescore`.
+//! rescoring pipeline in `crate::quantization::pq::pq_adc_batch_rescore`, which
+//! validates that every PQ code is `< k` (via `ProductQuantizer::validate_codes`)
+//! before reaching the unsafe gather kernels here. That validation is the
+//! precondition the `unsafe` blocks below rely on for in-bounds LUT indexing.
 
 // The sole caller (`pq_adc_batch_rescore`) is persistence-gated, so all items
 // in this module are dead when persistence is disabled.
@@ -63,7 +66,9 @@ pub(crate) fn adc_distances_batch(
                     if i + 1 < codes.len() {
                         super::prefetch::prefetch_vector_from_u16(codes[i + 1]);
                     }
-                    // SAFETY: AVX2 ADC gather kernel — `simd_level()` confirmed Avx2/Avx512 above.
+                    // SAFETY: AVX2 ADC gather kernel — `simd_level()` confirmed Avx2/Avx512 above;
+                    // codes were validated `< k` by `pq_adc_batch_rescore::validate_codes` (see
+                    // module/function docs), so gather indices stay within `lut`.
                     unsafe { adc_single_avx2(lut, c, m, k) }
                 })
                 .collect()
@@ -83,6 +88,9 @@ pub(crate) fn adc_distances_batch(
                     }
                     // SAFETY: NEON is available (checked by `simd_level()` in outer match).
                     // - Condition 1: `simd_level()` selected `Neon`, confirming aarch64 NEON support.
+                    // - Condition 2: codes were validated `< k` by
+                    //   `pq_adc_batch_rescore::validate_codes` before this dispatch, so the
+                    //   `get_unchecked` indices stay within `lut` (length `m * k`).
                     // SAFETY: Call per-code NEON ADC kernel for throughput inside the iterator.
                     unsafe { adc_single_neon(lut, c, m, k) }
                 })


### PR DESCRIPTION
**Closes #895. Refs #897.** Validate PQ codes `< num_centroids` and `rotation.len()==dim²` after deserialize (kills release OOB SIMD gather); mask RaBitQ padding bits (arXiv:2405.12497); postcard size caps. Distance math untouched — recall intact.

---
Part of the 2026-05-28 `velesdb-core` security/perf/OOM audit (`report/AUDIT-velesdb-core-2026-05-28.md`). Implemented by a specialist sub-agent, then adversarial review→fix rounds to 0 findings. Integration-branch gate: `cargo fmt --check`, workspace `clippy -D warnings -D clippy::pedantic`, full lib suite (4914 tests), recall contracts — all green. Every fix ships a regression test.