### PR TITLE
fix(velesql): pre-parse length/nesting guard vs stack-overflow DoS (#896)

### DIFF
--- a/crates/velesdb-core/src/velesql/parser/mod.rs
+++ b/crates/velesdb-core/src/velesql/parser/mod.rs
@@ -11,6 +11,7 @@ mod dml_helpers;
 pub(crate) mod helpers;
 mod introspection;
 mod match_parser;
+mod prescan;
 mod select;
 mod train;
 mod values;
@@ -98,6 +99,12 @@ impl Parser {
     /// let query = Parser::parse("SELECT * FROM documents LIMIT 10")?;
     /// ```
     pub fn parse(input: &str) -> Result<Query, ParseError> {
+        let config = ValidationConfig::default();
+        // #896: reject over-length / over-nested queries by a cheap linear
+        // pre-scan of the raw bytes BEFORE pest builds the full parse tree,
+        // so deeply nested ()/[]/(SELECT cannot overflow the native stack.
+        prescan::prescan(input, config.max_query_length)?;
+
         let pairs = VelesQLParser::parse(Rule::query, input).map_err(|e| {
             let position = match e.location {
                 pest::error::InputLocation::Pos(p) => p,
@@ -117,7 +124,7 @@ impl Parser {
             .ok_or_else(|| ParseError::syntax(0, input, "Empty query"))?;
 
         let query = Self::parse_query(query_pair)?;
-        QueryValidator::enforce_query_complexity(&query, input, &ValidationConfig::default())?;
+        QueryValidator::enforce_query_complexity(&query, input, &config)?;
         Ok(query)
     }
 }

--- a/crates/velesdb-core/src/velesql/parser/prescan.rs
+++ b/crates/velesdb-core/src/velesql/parser/prescan.rs
@@ -1,0 +1,251 @@
+//! Cheap, allocation-free pre-scan of the raw query string (GitHub #896).
+//!
+//! `pest` materialises the FULL recursive parse tree before any Rust callback
+//! runs, so the AST-level depth guards (`MAX_CONDITION_DEPTH`, `max_ast_depth`)
+//! and the length check in [`super::super::validation`] fire only *after* the
+//! tree is built. A deeply nested `(((…)))` (WHERE `primary_expr`, ORDER BY
+//! `arithmetic_atom`, or nested `(SELECT …)` `subquery_expr`) — or a
+//! bracket-free `NOT NOT NOT …` chain (`not_expr = { ^"NOT" ~ primary_expr }`)
+//! — therefore overflows the native stack inside `VelesQLParser::parse` itself,
+//! crashing the process (SIGABRT) before any guard can run.
+//!
+//! This module runs a single O(n) pass over the raw bytes BEFORE pest is ever
+//! invoked, rejecting queries whose effective parse-recursion depth exceeds a
+//! small bound. The depth metric is `bracket_depth + pending_prefix_run`:
+//!
+//! * `bracket_depth` — open `()`/`[]` not yet closed (drives `primary_expr`,
+//!   `arithmetic_atom`, `subquery_expr`, vector/array recursion).
+//! * `pending_prefix_run` — consecutive leading `NOT` tokens not yet followed
+//!   by an operand. `not_expr = { ^"NOT" ~ primary_expr }` recurses WITHOUT
+//!   any bracket, so a bracket-only scan misses `"NOT ".repeat(N)`; each `NOT`
+//!   nonetheless stacks one `primary_expr → not_expr → primary_expr` frame in
+//!   pest. The run resets to 0 as soon as any non-`NOT` operand token is read.
+//!   `NOT` is the ONLY bracket-free recursive prefix in `grammar.pest`: the
+//!   leading `-` in `integer`/`float` is part of the atomic literal token and
+//!   the arithmetic `+`/`-` (`add_op`/`sub_op`) are binary infix, so neither
+//!   drives prefix recursion.
+//!
+//! Parentheses/brackets inside string literals (`'…'`), backtick identifiers
+//! (`` `…` ``), double-quoted identifiers (`"…"`) and `--` line comments are
+//! ignored so the guard never produces a false positive on quoted or commented
+//! payload content. Comments are skipped in the SAME linear pass, matching the
+//! grammar exactly (`COMMENT = _{ "--" ~ (!"\n" ~ ANY)* }`; the grammar has no
+//! block-comment form), so an apostrophe inside a comment can no longer poison
+//! the quote state and hide later real brackets.
+
+use crate::velesql::error::{ParseError, ParseErrorKind};
+
+/// Maximum effective parse-recursion depth accepted in a raw query.
+///
+/// `pest`'s recursive descent overflows the native stack somewhere in the low
+/// thousands of nesting levels (the reproduced #896 vectors used ~3000–5000
+/// levels of either brackets or bracket-free `NOT`). We pick 64 — the same
+/// order of magnitude as the existing `max_ast_depth` budget (64) and far below
+/// any value that can exhaust the stack — so the bound leaves a
+/// multiple-orders-of-magnitude safety margin while remaining well above any
+/// realistic hand-written query (legitimate queries nest a handful of levels of
+/// parentheses, vector arrays, subqueries or `NOT`, never dozens).
+const MAX_NESTING_DEPTH: usize = 64;
+
+/// Lexer state while scanning: whether we are inside a quoted span where
+/// brackets must be ignored.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum ScanState {
+    /// Outside any quoted span; brackets count.
+    Normal,
+    /// Inside a single-quoted string literal (`'…'`, `''` escapes).
+    SingleQuote,
+    /// Inside a double-quoted identifier (`"…"`, `""` escapes).
+    DoubleQuote,
+    /// Inside a backtick identifier (`` `…` ``, no escapes).
+    Backtick,
+}
+
+/// Mutable scan cursor: bracket depth plus the pending leading-`NOT` run, with
+/// the running maximum of their sum (the effective recursion depth).
+struct Depth {
+    /// Open `()`/`[]` not yet closed.
+    brackets: usize,
+    /// Consecutive leading `NOT` tokens not yet followed by an operand.
+    prefix_run: usize,
+    /// Highest `brackets + prefix_run` observed so far.
+    max: usize,
+}
+
+impl Depth {
+    fn new() -> Self {
+        Self {
+            brackets: 0,
+            prefix_run: 0,
+            max: 0,
+        }
+    }
+
+    /// Records the current effective depth into the running maximum.
+    fn observe(&mut self) {
+        let effective = self.brackets + self.prefix_run;
+        if effective > self.max {
+            self.max = effective;
+        }
+    }
+}
+
+/// Validates raw query length and recursion depth before parsing.
+///
+/// Runs first on the hot path: a single linear pass, no allocations.
+///
+/// # Errors
+///
+/// Returns [`ParseErrorKind::ComplexityLimit`] if the query is longer than
+/// `max_query_length` or its effective recursion depth (open `()`/`[]` plus the
+/// pending leading-`NOT` run) exceeds [`MAX_NESTING_DEPTH`].
+pub(super) fn prescan(input: &str, max_query_length: usize) -> Result<(), ParseError> {
+    if input.len() > max_query_length {
+        return Err(length_error(input, max_query_length));
+    }
+    check_nesting_depth(input)
+}
+
+/// Linear scan computing the maximum effective recursion depth outside quotes
+/// and comments.
+fn check_nesting_depth(input: &str) -> Result<(), ParseError> {
+    let bytes = input.as_bytes();
+    let mut state = ScanState::Normal;
+    let mut depth = Depth::new();
+    let mut i = 0;
+    while i < bytes.len() {
+        i += step(bytes, i, &mut state, &mut depth);
+    }
+    if depth.max > MAX_NESTING_DEPTH {
+        return Err(depth_error(bytes, bytes.len().saturating_sub(1)));
+    }
+    Ok(())
+}
+
+/// Processes one position; returns how many bytes were consumed (>= 1).
+fn step(bytes: &[u8], i: usize, state: &mut ScanState, depth: &mut Depth) -> usize {
+    match *state {
+        ScanState::Normal => step_normal(bytes, i, state, depth),
+        ScanState::SingleQuote => step_quoted(bytes, i, bytes[i], b'\'', state),
+        ScanState::DoubleQuote => step_quoted(bytes, i, bytes[i], b'"', state),
+        ScanState::Backtick => {
+            if bytes[i] == b'`' {
+                *state = ScanState::Normal;
+            }
+            1
+        }
+    }
+}
+
+/// Handles a byte while outside any quoted span or comment.
+fn step_normal(bytes: &[u8], i: usize, state: &mut ScanState, depth: &mut Depth) -> usize {
+    let b = bytes[i];
+    if starts_line_comment(bytes, i) {
+        return skip_line_comment(bytes, i);
+    }
+    match b {
+        b'(' | b'[' => open_bracket(depth),
+        b')' | b']' => depth.brackets = depth.brackets.saturating_sub(1),
+        b'\'' => *state = ScanState::SingleQuote,
+        b'"' => *state = ScanState::DoubleQuote,
+        b'`' => *state = ScanState::Backtick,
+        _ if is_word_byte(b) => return word_token(bytes, i, depth),
+        _ => {}
+    }
+    1
+}
+
+/// True when position `i` begins a `--` line comment (grammar `COMMENT`).
+fn starts_line_comment(bytes: &[u8], i: usize) -> bool {
+    bytes[i] == b'-' && bytes.get(i + 1) == Some(&b'-')
+}
+
+/// Opens a `(`/`[`: an operand boundary, so the pending prefix run folds into
+/// bracket depth (the `NOT`s wrap the bracketed expression) and resets.
+/// Records the new effective depth.
+fn open_bracket(depth: &mut Depth) {
+    depth.brackets += depth.prefix_run + 1;
+    depth.prefix_run = 0;
+    depth.observe();
+}
+
+/// Consumes a maximal run of identifier bytes (one token) and updates the
+/// prefix run: a `NOT` keyword extends it (deeper `not_expr` recursion), any
+/// other word token is an operand and resets it. Returns the token length.
+fn word_token(bytes: &[u8], i: usize, depth: &mut Depth) -> usize {
+    let mut end = i;
+    while end < bytes.len() && is_word_byte(bytes[end]) {
+        end += 1;
+    }
+    if is_not_keyword(&bytes[i..end]) {
+        depth.prefix_run += 1;
+        depth.observe();
+    } else {
+        depth.prefix_run = 0;
+    }
+    end - i
+}
+
+/// Skips a `--` line comment up to (but not including) the next `\n`, so that
+/// quotes and brackets inside the comment are never interpreted. Returns the
+/// number of bytes consumed.
+fn skip_line_comment(bytes: &[u8], i: usize) -> usize {
+    let mut end = i + 2;
+    while end < bytes.len() && bytes[end] != b'\n' {
+        end += 1;
+    }
+    end - i
+}
+
+/// True for bytes that form a `VelesQL` `regular_identifier`
+/// (`ASCII_ALPHA | "_" | ASCII_ALPHANUMERIC`).
+fn is_word_byte(b: u8) -> bool {
+    b.is_ascii_alphanumeric() || b == b'_'
+}
+
+/// Case-insensitive exact match of the keyword `NOT` on a token slice. Because
+/// the caller passes a maximal identifier run, this can never match a `NOT`
+/// substring of a longer identifier (e.g. `NOTES`, `not_deleted`).
+fn is_not_keyword(token: &[u8]) -> bool {
+    token.len() == 3
+        && token[0].eq_ignore_ascii_case(&b'N')
+        && token[1].eq_ignore_ascii_case(&b'O')
+        && token[2].eq_ignore_ascii_case(&b'T')
+}
+
+/// Handles a byte inside a `quote`-delimited span supporting `quote``quote`
+/// doubling as an escape. Returns bytes consumed (2 when an escape is skipped).
+fn step_quoted(bytes: &[u8], i: usize, b: u8, quote: u8, state: &mut ScanState) -> usize {
+    if b != quote {
+        return 1;
+    }
+    if bytes.get(i + 1) == Some(&quote) {
+        // Doubled quote: escaped delimiter, stay inside the span.
+        return 2;
+    }
+    *state = ScanState::Normal;
+    1
+}
+
+/// Builds the over-length rejection error.
+fn length_error(input: &str, max: usize) -> ParseError {
+    ParseError::new(
+        ParseErrorKind::ComplexityLimit,
+        max,
+        input.chars().take(128).collect::<String>(),
+        format!("Query length exceeded: max={max}, actual={}", input.len()),
+    )
+}
+
+/// Builds the excessive-nesting rejection error.
+fn depth_error(bytes: &[u8], position: usize) -> ParseError {
+    let start = position.saturating_sub(32);
+    let end = position.min(bytes.len().saturating_sub(1));
+    let fragment = String::from_utf8_lossy(&bytes[start..=end]).into_owned();
+    ParseError::new(
+        ParseErrorKind::ComplexityLimit,
+        position,
+        fragment,
+        format!("Query nesting too deep: max={MAX_NESTING_DEPTH} levels of recursion"),
+    )
+}

--- a/crates/velesdb-core/src/velesql/parser/robustness_tests.rs
+++ b/crates/velesdb-core/src/velesql/parser/robustness_tests.rs
@@ -25,6 +25,9 @@ fn parse_join_condition_handles_quoted_identifiers_with_dots() {
 
 #[test]
 fn parse_rejects_excessive_condition_nesting_depth() {
+    // #896: deeply nested parentheses are now rejected by the raw-byte
+    // pre-scan BEFORE pest can build the tree (and before the AST-level
+    // MAX_CONDITION_DEPTH guard would have fired).
     let depth = 257;
     let mut query = String::from("SELECT * FROM t WHERE ");
     for _ in 0..depth {
@@ -37,7 +40,144 @@ fn parse_rejects_excessive_condition_nesting_depth() {
 
     let err = Parser::parse(&query).expect_err("deeply nested condition should be rejected");
     assert!(
-        err.to_string().contains("Condition nesting too deep"),
+        err.to_string().contains("Query nesting too deep"),
         "unexpected parser error: {err}"
     );
+}
+
+/// #896 vector 1: ~3000 nested parens in WHERE `primary_expr` previously
+/// overflowed pest's recursive descent (SIGABRT). Must now `Err` quickly.
+#[test]
+fn parse_rejects_deeply_nested_where_parens_without_overflow() {
+    let depth = 5000;
+    let query = format!(
+        "SELECT * FROM t WHERE {}x = 1{}",
+        "(".repeat(depth),
+        ")".repeat(depth)
+    );
+
+    let err = Parser::parse(&query).expect_err("deeply nested WHERE parens must be rejected");
+    assert!(
+        err.to_string().contains("Query nesting too deep"),
+        "unexpected parser error: {err}"
+    );
+}
+
+/// #896 vector 2: ~3000 nested parens in ORDER BY `arithmetic_atom`.
+#[test]
+fn parse_rejects_deeply_nested_order_by_arithmetic_without_overflow() {
+    let depth = 5000;
+    let query = format!(
+        "SELECT * FROM t ORDER BY {}1{}",
+        "(".repeat(depth),
+        ")".repeat(depth)
+    );
+
+    let err =
+        Parser::parse(&query).expect_err("deeply nested ORDER BY arithmetic must be rejected");
+    assert!(
+        err.to_string().contains("Query nesting too deep"),
+        "unexpected parser error: {err}"
+    );
+}
+
+/// #896 vector 3: deeply nested `(SELECT … WHERE x = (SELECT …))` subqueries.
+#[test]
+fn parse_rejects_deeply_nested_subqueries_without_overflow() {
+    // Depth kept under max_query_length (16384 bytes) so the nesting guard,
+    // not the length guard, is the rejecting check. 200 levels still far
+    // exceeds the 64-level nesting bound.
+    let depth = 200;
+    let mut query = String::from("SELECT * FROM t WHERE x = ");
+    for _ in 0..depth {
+        query.push_str("(SELECT id FROM t WHERE y = ");
+    }
+    query.push('1');
+    query.push_str(&")".repeat(depth));
+
+    let err = Parser::parse(&query).expect_err("deeply nested subqueries must be rejected");
+    assert!(
+        err.to_string().contains("Query nesting too deep"),
+        "unexpected parser error: {err}"
+    );
+}
+
+/// Parens inside a string literal must NOT count toward the nesting depth
+/// (no false positive from the pre-scan).
+#[test]
+fn parse_does_not_count_parens_inside_string_literal() {
+    let payload = "(".repeat(5000);
+    let query = format!("SELECT * FROM t WHERE name = '{payload}'");
+
+    // Must not be rejected for nesting; the literal parses fine.
+    let parsed = Parser::parse(&query)
+        .expect("parens inside a string literal must not trip the depth guard");
+    assert!(parsed.select.where_clause.is_some());
+}
+
+/// A normal moderately-nested query still parses fine (no regression).
+#[test]
+fn parse_accepts_moderately_nested_query() {
+    let query = "SELECT * FROM t WHERE ((a = 1 AND b = 2) OR (c = 3 AND (d = 4 OR e = 5)))";
+    let parsed = Parser::parse(query).expect("moderately nested query should parse");
+    assert!(parsed.select.where_clause.is_some());
+}
+
+/// #896 follow-up defect 1 (critical): a bracket-free `NOT NOT NOT …` chain
+/// recurses through `not_expr = { ^"NOT" ~ primary_expr }` with NO delimiter,
+/// so the bracket-only scan missed it and pest overflowed the stack (SIGABRT).
+/// The prefix-run metric must now reject it quickly without parsing.
+#[test]
+fn parse_rejects_bracket_free_not_chain_without_overflow() {
+    // 4000 `NOT ` = 16000 bytes, deliberately under the 16384 length cap so the
+    // prefix-run depth metric (not the length guard) is the rejecting check.
+    let query = format!("SELECT * FROM t WHERE {}a = 1", "NOT ".repeat(4000));
+
+    let err = Parser::parse(&query).expect_err("bracket-free NOT chain must be rejected");
+    assert!(
+        err.to_string().contains("Query nesting too deep"),
+        "unexpected parser error: {err}"
+    );
+}
+
+/// #896 follow-up defect 2 (critical): an apostrophe inside a `--` comment must
+/// NOT flip the scanner into a never-closing single-quote state. If it did, the
+/// deep real parens after the comment would be treated as in-string and the
+/// guard would be bypassed (SIGABRT). Comment-skipping must neutralise it.
+#[test]
+fn parse_rejects_deep_parens_after_comment_with_apostrophe() {
+    let query = format!(
+        "SELECT * FROM t -- it's deep\nWHERE {}a = 1{}",
+        "(".repeat(5000),
+        ")".repeat(5000)
+    );
+
+    let err =
+        Parser::parse(&query).expect_err("deep parens after a poisoned comment must be rejected");
+    assert!(
+        err.to_string().contains("Query nesting too deep"),
+        "unexpected parser error: {err}"
+    );
+}
+
+/// #896 follow-up defect 3 (false positive): brackets/quotes inside a `--`
+/// line comment must NOT be counted, so a query with a comment full of `(((`
+/// and an apostrophe still parses normally.
+#[test]
+fn parse_does_not_count_brackets_inside_line_comment() {
+    let comment = "(".repeat(5000);
+    let query = format!("SELECT * FROM t -- {comment} it's fine\nWHERE a = 1");
+
+    let parsed =
+        Parser::parse(&query).expect("brackets inside a -- comment must not trip the depth guard");
+    assert!(parsed.select.where_clause.is_some());
+}
+
+/// No regression: a small legitimate `NOT` nesting under the bound parses fine
+/// and the prefix run does not accumulate falsely across operands.
+#[test]
+fn parse_accepts_small_not_nesting() {
+    let query = "SELECT * FROM t WHERE NOT NOT a = 1 AND NOT b = 2";
+    let parsed = Parser::parse(query).expect("small NOT nesting should parse");
+    assert!(parsed.select.where_clause.is_some());
 }


### PR DESCRIPTION
**Closes #896.** O(n) pre-scan before pest rejects over-length / nesting-depth-64 queries (brackets + `NOT` chains, skipping comments/strings). Closes 3 reproduced SIGABRT vectors.

---
Part of the 2026-05-28 `velesdb-core` security/perf/OOM audit (`report/AUDIT-velesdb-core-2026-05-28.md`). Implemented by a specialist sub-agent, then adversarial review→fix rounds to 0 findings. Integration-branch gate: `cargo fmt --check`, workspace `clippy -D warnings -D clippy::pedantic`, full lib suite (4914 tests), recall contracts — all green. Every fix ships a regression test.