### PR TITLE
fix(storage): WAL allocation caps, replay ordering & durability (#898)

### DIFF
--- a/crates/velesdb-core/src/metrics/guardrails.rs
+++ b/crates/velesdb-core/src/metrics/guardrails.rs
@@ -154,6 +154,8 @@ pub struct GuardRailsMetrics {
     pub invalid_offset_read_errors: AtomicU64,
     /// Query-cache collision fallback counter (reserved for hash-keyed implementations)
     pub cache_collision_fallback_total: AtomicU64,
+    /// Mid-stream corrupt WAL entries skipped during replay (#898)
+    pub wal_replay_corrupt_entries: AtomicU64,
 }
 
 impl GuardRailsMetrics {
@@ -205,6 +207,12 @@ impl GuardRailsMetrics {
     /// Records a cache collision fallback event.
     pub fn record_cache_collision_fallback(&self) {
         self.cache_collision_fallback_total
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Records a mid-stream corrupt WAL entry skipped during replay (#898).
+    pub fn record_wal_replay_corrupt_entry(&self) {
+        self.wal_replay_corrupt_entries
             .fetch_add(1, Ordering::Relaxed);
     }
 
@@ -329,6 +337,20 @@ impl GuardRailsMetrics {
             output,
             "velesdb_cache_collision_fallback_total {}",
             self.cache_collision_fallback_total.load(Ordering::Relaxed)
+        );
+        let _ = writeln!(output);
+        let _ = writeln!(
+            output,
+            "# HELP velesdb_wal_replay_corrupt_entries_total Mid-stream corrupt WAL entries skipped during replay"
+        );
+        let _ = writeln!(
+            output,
+            "# TYPE velesdb_wal_replay_corrupt_entries_total counter"
+        );
+        let _ = writeln!(
+            output,
+            "velesdb_wal_replay_corrupt_entries_total {}",
+            self.wal_replay_corrupt_entries.load(Ordering::Relaxed)
         );
     }
 }

--- a/crates/velesdb-core/src/storage/compaction.rs
+++ b/crates/velesdb-core/src/storage/compaction.rs
@@ -371,7 +371,23 @@ impl CompactionContext<'_> {
 
         let mut new_offset = 0usize;
         for (&id, &old_offset) in &old_index {
-            let src = &mmap[old_offset..old_offset + vector_size];
+            // #898: bounds-check the source slice against the live mmap. A
+            // corrupt/overflowing index offset must be skipped, not allowed to
+            // panic the compaction with an out-of-range slice.
+            let Some(src_end) = old_offset.checked_add(vector_size) else {
+                tracing::warn!(id, old_offset, "compaction: skipping offset overflow");
+                continue;
+            };
+            if src_end > mmap.len() {
+                tracing::warn!(
+                    id,
+                    old_offset,
+                    mmap_len = mmap.len(),
+                    "compaction: skipping out-of-bounds vector offset"
+                );
+                continue;
+            }
+            let src = &mmap[old_offset..src_end];
             temp_mmap[new_offset..new_offset + vector_size].copy_from_slice(src);
             new_index.insert(id, new_offset);
             new_offset += vector_size;

--- a/crates/velesdb-core/src/storage/log_payload.rs
+++ b/crates/velesdb-core/src/storage/log_payload.rs
@@ -214,7 +214,7 @@ impl LogPayloadStorage {
             let Some(entry) = WalEntry::read(&mut reader_buf, pos)? else {
                 break;
             };
-            pos = entry.apply(&mut index, &mut reader_buf)?;
+            pos = entry.apply(&mut index, &mut reader_buf, end_pos)?;
         }
 
         Ok(index)
@@ -396,11 +396,26 @@ impl PayloadStorage for LogPayloadStorage {
         }
 
         let mut reader = self.reader.write(); // Need write lock to seek
+        let file_len = reader.metadata()?.len();
         reader.seek(SeekFrom::Start(offset))?;
 
         let mut len_bytes = [0u8; 4];
         reader.read_exact(&mut len_bytes)?;
-        let len = u32::from_le_bytes(len_bytes) as usize;
+        let declared = u64::from(u32::from_le_bytes(len_bytes));
+
+        // OOM guard (#897/#898): a corrupt length field must not drive an
+        // unbounded allocation. The payload cannot exceed the bytes remaining
+        // after the length field.
+        let pos_after_len = offset.saturating_add(4);
+        let remaining = file_len.saturating_sub(pos_after_len);
+        if declared > remaining {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "payload length exceeds file size",
+            ));
+        }
+        let len = usize::try_from(declared)
+            .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "payload length overflow"))?;
 
         let mut payload_bytes = vec![0u8; len];
         reader.read_exact(&mut payload_bytes)?;

--- a/crates/velesdb-core/src/storage/log_payload_tests.rs
+++ b/crates/velesdb-core/src/storage/log_payload_tests.rs
@@ -60,7 +60,9 @@ fn test_delete_never_stored_id_is_no_op() {
     let wal_path = temp.path().join("payloads.log");
     let wal_size_before = std::fs::metadata(&wal_path).expect("WAL exists").len();
 
-    storage.delete(42).expect("Delete of never-stored id should succeed");
+    storage
+        .delete(42)
+        .expect("Delete of never-stored id should succeed");
 
     // No WAL append: confirms the fsync-per-call cost is gone.
     let wal_size_after = std::fs::metadata(&wal_path).expect("WAL exists").len();

--- a/crates/velesdb-core/src/storage/mmap.rs
+++ b/crates/velesdb-core/src/storage/mmap.rs
@@ -141,10 +141,18 @@ impl MmapStorage {
         let wal = Self::open_wal(&wal_path)?;
 
         let index_path = path.join("vectors.idx");
-        let (index, next_offset) = Self::load_index(&index_path, dimension)?;
+        let data_len = data_file.metadata()?.len();
+        let (index, next_offset) = Self::load_index(&index_path, dimension, data_len)?;
 
-        let (mmap, next_offset) =
-            Self::replay_wal(mmap, next_offset, &wal_path, &index, dimension)?;
+        let (mmap, next_offset) = Self::replay_wal(
+            mmap,
+            next_offset,
+            &wal_path,
+            &index_path,
+            &index,
+            dimension,
+            &data_file,
+        )?;
 
         Ok(Self {
             path,
@@ -214,7 +222,16 @@ impl MmapStorage {
     }
 
     /// Loads the sharded index from disk, returning the index and the next write offset.
-    fn load_index(index_path: &Path, dimension: usize) -> io::Result<(ShardedIndex, usize)> {
+    ///
+    /// Validates every persisted offset against the backing file size (#898):
+    /// a corrupt index entry whose `offset + vector_size` overflows or exceeds
+    /// `data_len` would otherwise yield out-of-bounds reads or an inflated
+    /// `next_offset`. Such an index is rejected as corrupt.
+    fn load_index(
+        index_path: &Path,
+        dimension: usize,
+        data_len: u64,
+    ) -> io::Result<(ShardedIndex, usize)> {
         if !index_path.exists() {
             return Ok((ShardedIndex::new(), 0));
         }
@@ -223,35 +240,83 @@ impl MmapStorage {
         let flat_index: FxHashMap<u64, usize> = postcard::from_bytes(&bytes)
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
 
-        let max_offset = flat_index.values().max().copied().unwrap_or(0);
-        let size = if flat_index.is_empty() {
-            0
-        } else {
-            max_offset + dimension * 4
-        };
+        let vector_size = dimension * std::mem::size_of::<f32>();
+        let mut max_end = 0usize;
+        for &offset in flat_index.values() {
+            let end = offset.checked_add(vector_size).ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "index offset arithmetic overflow",
+                )
+            })?;
+            let end_u64 = u64::try_from(end).map_err(|_| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "index offset exceeds addressable range",
+                )
+            })?;
+            if end_u64 > data_len {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "index offset exceeds data file size",
+                ));
+            }
+            max_end = max_end.max(end);
+        }
 
-        Ok((ShardedIndex::from_hashmap(flat_index), size))
+        Ok((ShardedIndex::from_hashmap(flat_index), max_end))
     }
 
     /// Replays the WAL to recover writes since the last flush.
+    ///
+    /// Crash-safe ordering (#898): apply WAL entries → flush the recovered mmap
+    /// → persist `vectors.idx` → only then truncate the WAL. Truncating before
+    /// the mmap and index are durable would lose the replayed writes on a crash
+    /// in that window.
     fn replay_wal(
         mut mmap: MmapMut,
         mut next_offset: usize,
         wal_path: &Path,
+        index_path: &Path,
         index: &ShardedIndex,
         dimension: usize,
+        data_file: &File,
     ) -> io::Result<(MmapMut, usize)> {
         let replayed = wal_replay::replay_wal_to_index(
             wal_path,
             index,
             dimension,
             &mut mmap,
+            data_file,
             &mut next_offset,
         )?;
         if replayed > 0 {
+            // 1. Make the recovered vector bytes durable.
             mmap.flush()?;
+            // 2. Persist the rebuilt index so the recovered state survives even
+            //    after the WAL is cleared.
+            Self::persist_index_file(index_path, index)?;
+            // 3. Safe to clear the WAL now that mmap + index are durable.
+            wal_replay::truncate_wal(wal_path)?;
         }
         Ok((mmap, next_offset))
+    }
+
+    /// Serializes the sharded index to `index_path` with fsync.
+    ///
+    /// Shared by [`Self::flush_index`] and WAL replay recovery.
+    fn persist_index_file(index_path: &Path, index: &ShardedIndex) -> io::Result<()> {
+        let file = File::create(index_path)?;
+        let mut writer = io::BufWriter::new(file);
+        let flat_index = index.to_hashmap();
+        let bytes = postcard::to_allocvec(&flat_index).map_err(io::Error::other)?;
+        writer.write_all(&bytes)?;
+        writer.flush()?;
+        writer
+            .into_inner()
+            .map_err(std::io::IntoInnerError::into_error)?
+            .sync_all()?;
+        Ok(())
     }
 
     // ensure_capacity, reserve_capacity, compact, fragmentation_ratio are in mmap_capacity.rs
@@ -350,17 +415,7 @@ impl MmapStorage {
         // EPIC-033/US-004: Convert ShardedIndex to flat HashMap for serialization
         // EPIC-069/US-001: fsync index file for crash recovery on Windows
         let index_path = self.path.join("vectors.idx");
-        let file = File::create(&index_path)?;
-        let mut writer = io::BufWriter::new(file);
-        let flat_index = self.index.to_hashmap();
-        let bytes = postcard::to_allocvec(&flat_index).map_err(io::Error::other)?;
-        writer.write_all(&bytes)?;
-        writer.flush()?;
-        writer
-            .into_inner()
-            .map_err(std::io::IntoInnerError::into_error)?
-            .sync_all()?;
-        Ok(())
+        Self::persist_index_file(&index_path, &self.index)
     }
 
     /// Full durability flush: WAL + mmap + `vectors.idx`.

--- a/crates/velesdb-core/src/storage/mmap/vector_io.rs
+++ b/crates/velesdb-core/src/storage/mmap/vector_io.rs
@@ -34,15 +34,7 @@ fn write_wal_store_entry(
     data: &[u8],
     buf: &mut Vec<u8>,
 ) -> io::Result<()> {
-    buf.clear();
-    buf.push(1u8);
-    buf.extend_from_slice(&id.to_le_bytes());
-    // Reason: Vector byte length is dimension * 4. With max dimension 65536,
-    // max bytes = 262144 which fits in u32 (max 4,294,967,295).
-    #[allow(clippy::cast_possible_truncation)]
-    let len_u32 = data.len() as u32;
-    buf.extend_from_slice(&len_u32.to_le_bytes());
-    buf.extend_from_slice(data);
+    serialize_wal_store_entry(id, data, buf);
     let crc = crc32_hash(buf);
     wal.write_all(buf)?;
     wal.write_all(&crc.to_le_bytes())
@@ -137,32 +129,51 @@ impl VectorStorage for MmapStorage {
 
         let vector_bytes = vector_to_bytes(vector);
 
-        // 1. Write to WAL with CRC32 framing (Issue #317)
+        // 1. Write to WAL with CRC32 framing (Issue #317).
         // Issue #423: Skip WAL when DurabilityMode::None for bulk imports.
+        // #898: Honor DurabilityMode::Fsync on the single-store path — the
+        // entry must be durable on disk before this call returns Ok. Batched
+        // paths stay deferred and rely on `flush()` for their barrier.
         if self.durability != DurabilityMode::None {
             let mut wal = self.wal.write();
             let mut buf = Vec::with_capacity(1 + 8 + 4 + vector_bytes.len());
             write_wal_store_entry(&mut wal, id, vector_bytes, &mut buf)?;
+            if self.durability == DurabilityMode::Fsync {
+                wal.flush()?;
+                wal.get_ref().sync_all()?;
+            }
         }
 
         // 2. Determine offset (EPIC-033/US-004: Use sharded index)
         let vector_size = vector_bytes.len();
 
-        let (offset, is_new) = if let Some(existing_offset) = self.index.get(id) {
-            (existing_offset, false)
+        // #898 follow-up: validate the new offset with `checked_add` BEFORE
+        // committing the `fetch_add`. Previously the allocator was advanced
+        // first, so on the overflow error path `next_offset` was left
+        // advanced/wrapped — corrupting allocator state for subsequent stores.
+        // We reserve the slot only after the bounds check passes.
+        let (offset, end, is_new) = if let Some(existing_offset) = self.index.get(id) {
+            let end = existing_offset.checked_add(vector_size).ok_or_else(|| {
+                io::Error::new(io::ErrorKind::InvalidData, "store offset overflow")
+            })?;
+            (existing_offset, end, false)
         } else {
             // M-2: Use Acquire/AcqRel to ensure mmap writes are visible on ARM/RISC-V.
             let offset = self.next_offset.load(Ordering::Acquire);
-            self.next_offset.fetch_add(vector_size, Ordering::AcqRel);
-            (offset, true)
+            let end = offset.checked_add(vector_size).ok_or_else(|| {
+                io::Error::new(io::ErrorKind::InvalidData, "store offset overflow")
+            })?;
+            // Reserve only after validation: `end` is the new watermark.
+            self.next_offset.store(end, Ordering::Release);
+            (offset, end, true)
         };
 
         // Ensure capacity and write
-        self.ensure_capacity(offset + vector_size)?;
+        self.ensure_capacity(end)?;
 
         {
             let mut mmap = self.mmap.write();
-            mmap[offset..offset + vector_size].copy_from_slice(vector_bytes);
+            mmap[offset..end].copy_from_slice(vector_bytes);
         }
 
         // 3. Update Index if new (EPIC-033/US-004: Use sharded index)
@@ -248,12 +259,23 @@ impl VectorStorage for MmapStorage {
     }
 
     fn delete(&mut self, id: u64) -> io::Result<()> {
-        // 1. Write to WAL with CRC32 framing (Issue #317)
+        // 1. Write to WAL with CRC32 framing (Issue #317).
         // Issue #423 Component 4: Skip WAL when DurabilityMode::None.
+        // #898 follow-up: the delete intent MUST reach the WAL before the
+        // destructive `punch_hole` below. The hole-punch zeroes the on-disk
+        // bytes; if we crashed after punching but before the delete record was
+        // durable, replay would never see the delete and would re-insert the id
+        // pointing at now-zeroed data — resurrecting it as a zero vector. So we
+        // flush the BufWriter unconditionally (ordering correctness) and fsync
+        // under Fsync (durability ack), mirroring the single-store path.
         if self.durability != DurabilityMode::None {
             let mut wal = self.wal.write();
             let mut buf = Vec::with_capacity(1 + 8);
             write_wal_delete_entry(&mut wal, id, &mut buf)?;
+            wal.flush()?;
+            if self.durability == DurabilityMode::Fsync {
+                wal.get_ref().sync_all()?;
+            }
         }
 
         // 2. Get offset before removing from index (for hole-punch)
@@ -370,7 +392,10 @@ impl MmapStorage {
                 })?
             };
 
-            mmap[offset..offset + vector_size].copy_from_slice(vector_bytes);
+            let end = offset.checked_add(vector_size).ok_or_else(|| {
+                io::Error::new(io::ErrorKind::InvalidData, "batch store offset overflow")
+            })?;
+            mmap[offset..end].copy_from_slice(vector_bytes);
         }
 
         Ok(())

--- a/crates/velesdb-core/src/storage/mmap/vector_io.rs
+++ b/crates/velesdb-core/src/storage/mmap/vector_io.rs
@@ -199,14 +199,19 @@ impl VectorStorage for MmapStorage {
         // 1. Calculate total space needed and prepare batch WAL entry
         // Perf: Use FxHashMap for O(1) lookup instead of Vec with O(n) find
         // EPIC-033/US-004: Use sharded index for reduced contention
-        let (new_vector_offsets, total_new_size) = self.compute_new_offsets(vectors, vector_size);
+        let (new_vector_offsets, total_new_size) = self.compute_new_offsets(vectors, vector_size)?;
 
-        // 2. Pre-allocate space for all new vectors at once
+        // 2. Pre-allocate space for all new vectors at once.
+        // #898 follow-up: validate the new watermark with `checked_add` BEFORE
+        // committing it (mirroring `store()`), so an overflowing batch cannot
+        // leave `next_offset` advanced/wrapped and corrupt allocator state.
         if total_new_size > 0 {
-            // M-2: Acquire/AcqRel ordering for cross-platform visibility
             let start_offset = self.next_offset.load(Ordering::Acquire);
-            self.ensure_capacity(start_offset + total_new_size)?;
-            self.next_offset.fetch_add(total_new_size, Ordering::AcqRel);
+            let end = start_offset.checked_add(total_new_size).ok_or_else(|| {
+                io::Error::new(io::ErrorKind::InvalidData, "batch store offset overflow")
+            })?;
+            self.ensure_capacity(end)?;
+            self.next_offset.store(end, Ordering::Release);
         }
 
         // 3. WAL group write: serialize all entries into one buffer, single
@@ -351,21 +356,28 @@ impl MmapStorage {
         &self,
         vectors: &[(u64, &[f32])],
         vector_size: usize,
-    ) -> (FxHashMap<u64, usize>, usize) {
+    ) -> io::Result<(FxHashMap<u64, usize>, usize)> {
         let mut new_vector_offsets: FxHashMap<u64, usize> = FxHashMap::default();
         new_vector_offsets.reserve(vectors.len());
+        // M-2: single Acquire load gives a consistent base under `&mut self`.
+        let base = self.next_offset.load(Ordering::Acquire);
         let mut total_new_size = 0usize;
 
         for &(id, _) in vectors {
             if !self.index.contains_key(id) {
-                // M-2: Acquire ordering for cross-platform visibility
-                let offset = self.next_offset.load(Ordering::Acquire) + total_new_size;
+                // #898 follow-up: checked arithmetic so a pathological batch
+                // cannot wrap an offset/size past the validated allocator state.
+                let offset = base.checked_add(total_new_size).ok_or_else(|| {
+                    io::Error::new(io::ErrorKind::InvalidData, "batch store offset overflow")
+                })?;
                 new_vector_offsets.insert(id, offset);
-                total_new_size += vector_size;
+                total_new_size = total_new_size.checked_add(vector_size).ok_or_else(|| {
+                    io::Error::new(io::ErrorKind::InvalidData, "batch store size overflow")
+                })?;
             }
         }
 
-        (new_vector_offsets, total_new_size)
+        Ok((new_vector_offsets, total_new_size))
     }
 
     /// Writes all vectors to the mmap, resolving offsets from the index

--- a/crates/velesdb-core/src/storage/mmap/wal_replay.rs
+++ b/crates/velesdb-core/src/storage/mmap/wal_replay.rs
@@ -16,23 +16,84 @@
 //! Detected by validating the CRC of the first entry. If validation fails,
 //! the file is legacy format and replay is skipped (the persisted index is
 //! authoritative for legacy data).
+//!
+//! # Corruption policy (#898)
+//!
+//! Replay distinguishes two failure shapes:
+//!
+//! - **Torn tail** — the last record is short or its declared length runs past
+//!   EOF because the process crashed mid-append. This is expected after a
+//!   crash, so replay stops cleanly and keeps every prior entry.
+//! - **Mid-stream corruption** — a fully-framed record fails CRC. This
+//!   indicates bit-rot or a malformed WAL; the entry is skipped, a metric and
+//!   warning are recorded, and replay continues so later valid entries are
+//!   still recovered. Unknown opcodes mid-stream stop replay (the framing can
+//!   no longer be trusted).
 
 use crate::storage::log_payload::crc32_hash;
 use crate::storage::sharded_index::ShardedIndex;
 
+use memmap2::MmapMut;
 use std::fs::{File, OpenOptions};
 use std::io::{self, BufReader, Read, Seek};
 use std::path::Path;
 
 /// Minimum store entry size: op(1) + id(8) + len(4) + crc(4) = 17.
-const MIN_STORE_ENTRY: usize = 17;
+const MIN_STORE_ENTRY: u64 = 17;
 /// Delete entry size: op(1) + id(8) + crc(4) = 13.
-const DELETE_ENTRY_SIZE: usize = 13;
+const DELETE_ENTRY_SIZE: u64 = 13;
+
+/// Outcome of attempting to replay a single WAL entry.
+enum EntryOutcome {
+    /// Entry applied (or intentionally skipped on mid-stream corruption); keep going.
+    Applied,
+    /// Clean stop: EOF or a torn tail record left by a crash.
+    Stop,
+}
+
+impl EntryOutcome {
+    /// Returns `true` while replay should continue.
+    const fn should_continue(&self) -> bool {
+        matches!(self, Self::Applied)
+    }
+}
+
+/// Grows the mmap during replay (mirroring the live `ensure_capacity` path) so
+/// recovered vectors that extend past the last flushed size are not dropped.
+struct ReplayTarget<'a> {
+    mmap: &'a mut MmapMut,
+    data_file: &'a File,
+}
+
+impl ReplayTarget<'_> {
+    /// Ensures the mapping covers at least `required_len` bytes, growing the
+    /// backing file and remapping if necessary.
+    fn ensure_capacity(&mut self, required_len: usize) -> io::Result<()> {
+        if self.mmap.len() >= required_len {
+            return Ok(());
+        }
+        self.mmap.flush()?;
+        let required_u64 = u64::try_from(required_len)
+            .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "replay length overflow"))?;
+        // Match the live growth floor (64 MB) to amortize remaps during replay.
+        let new_len = required_u64.saturating_add(super::MmapStorage::MIN_GROWTH);
+        self.data_file.set_len(new_len)?;
+        // SAFETY: `set_len(new_len)` resized the backing file to fully cover the
+        // mapping range before remapping; the old mapping is dropped on assign.
+        // - Condition 1: file resized to `new_len` immediately above.
+        // - Condition 2: `data_file` is the read+write handle owning the file.
+        // SAFETY: remapping requires unsafe; resize guarantees mapping <= file size.
+        *self.mmap = unsafe { MmapMut::map_mut(self.data_file)? };
+        Ok(())
+    }
+}
 
 /// Replays CRC32-framed WAL entries into the sharded index and mmap.
 ///
-/// Skips legacy (non-CRC) WAL files. Truncates the WAL after a
-/// successful replay so entries are not replayed twice.
+/// Skips legacy (non-CRC) WAL files. The WAL is **not** truncated here: the
+/// caller must first flush the recovered mmap and persist the index, then call
+/// [`truncate_wal`]. Truncating before the mmap is durable would open a
+/// data-loss window (#898).
 ///
 /// # Returns
 ///
@@ -42,7 +103,8 @@ pub(crate) fn replay_wal_to_index(
     wal_path: &Path,
     index: &ShardedIndex,
     dimension: usize,
-    mmap_data: &mut [u8],
+    mmap: &mut MmapMut,
+    data_file: &File,
     next_offset: &mut usize,
 ) -> io::Result<usize> {
     let Some((mut reader, file_len)) = open_crc_wal(wal_path)? else {
@@ -50,20 +112,25 @@ pub(crate) fn replay_wal_to_index(
     };
 
     let vector_size = dimension * std::mem::size_of::<f32>();
-    let replayed = drain_wal_entries(
+    let mut target = ReplayTarget { mmap, data_file };
+    drain_wal_entries(
         &mut reader,
         file_len,
         index,
-        mmap_data,
+        &mut target,
         next_offset,
         vector_size,
-    );
+    )
+}
 
-    if replayed > 0 {
-        truncate_wal(wal_path)?;
-    }
-
-    Ok(replayed)
+/// Truncates the WAL after the recovered state has been made durable.
+///
+/// Must only be called once the mmap has been flushed and the index persisted,
+/// otherwise a crash between truncation and flush loses the replayed writes.
+pub(crate) fn truncate_wal(wal_path: &Path) -> io::Result<()> {
+    let file = OpenOptions::new().write(true).open(wal_path)?;
+    file.set_len(0)?;
+    file.sync_all()
 }
 
 /// Opens the WAL file and validates it uses CRC32-framed format.
@@ -89,21 +156,24 @@ fn open_crc_wal(wal_path: &Path) -> io::Result<Option<(BufReader<File>, u64)>> {
 }
 
 /// Replays all valid entries from the WAL, returning the count.
+///
+/// Returns an error only for unrecoverable I/O failures; torn tail records (a
+/// crash mid-append) stop replay cleanly with the entries seen so far.
 fn drain_wal_entries(
     reader: &mut BufReader<File>,
     file_len: u64,
     index: &ShardedIndex,
-    mmap_data: &mut [u8],
+    target: &mut ReplayTarget<'_>,
     next_offset: &mut usize,
     vector_size: usize,
-) -> usize {
+) -> io::Result<usize> {
     let mut replayed = 0usize;
-    while let Ok(true) =
-        replay_one_entry(reader, file_len, index, mmap_data, next_offset, vector_size)
+    while replay_one_entry(reader, file_len, index, target, next_offset, vector_size)?
+        .should_continue()
     {
         replayed += 1;
     }
-    replayed
+    Ok(replayed)
 }
 
 // ---------------------------------------------------------------------------
@@ -112,7 +182,7 @@ fn drain_wal_entries(
 
 /// Returns `true` if the WAL uses CRC32-framed entries.
 fn is_crc_framed_wal(wal_path: &Path, file_len: u64) -> io::Result<bool> {
-    let min_size = MIN_STORE_ENTRY.min(DELETE_ENTRY_SIZE) as u64;
+    let min_size = MIN_STORE_ENTRY.min(DELETE_ENTRY_SIZE);
     if file_len < min_size {
         return Ok(false);
     }
@@ -124,22 +194,25 @@ fn is_crc_framed_wal(wal_path: &Path, file_len: u64) -> io::Result<bool> {
     }
 
     match op[0] {
-        1 => validate_first_store_crc(&mut reader),
+        1 => validate_first_store_crc(&mut reader, file_len),
         2 => Ok(validate_first_delete_crc(&mut reader)),
         _ => Ok(false),
     }
 }
 
 /// Validates the CRC of the first store entry.
-fn validate_first_store_crc(reader: &mut BufReader<File>) -> io::Result<bool> {
+fn validate_first_store_crc(reader: &mut BufReader<File>, file_len: u64) -> io::Result<bool> {
     let mut id_bytes = [0u8; 8];
     let mut len_bytes = [0u8; 4];
     if reader.read_exact(&mut id_bytes).is_err() || reader.read_exact(&mut len_bytes).is_err() {
         return Ok(false);
     }
 
-    let data_len = usize::try_from(u32::from_le_bytes(len_bytes))
-        .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "data_len overflow"))?;
+    // OOM guard (#897/#898): cap the declared length against the bytes that can
+    // actually follow in the file before allocating.
+    let Some(data_len) = checked_store_data_len(len_bytes, reader, file_len)? else {
+        return Ok(false);
+    };
 
     let mut data = vec![0u8; data_len];
     if reader.read_exact(&mut data).is_err() {
@@ -151,13 +224,7 @@ fn validate_first_store_crc(reader: &mut BufReader<File>) -> io::Result<bool> {
         return Ok(false);
     }
 
-    let mut frame = Vec::with_capacity(1 + 8 + 4 + data_len);
-    frame.push(1u8);
-    frame.extend_from_slice(&id_bytes);
-    frame.extend_from_slice(&len_bytes);
-    frame.extend_from_slice(&data);
-
-    Ok(crc32_hash(&frame) == u32::from_le_bytes(stored_crc))
+    Ok(store_crc_matches(id_bytes, len_bytes, &data, stored_crc))
 }
 
 /// Validates the CRC of the first delete entry.
@@ -183,146 +250,219 @@ fn validate_first_delete_crc(reader: &mut BufReader<File>) -> bool {
 // Entry Replay
 // ---------------------------------------------------------------------------
 
-/// Replays one WAL entry. Returns `Ok(true)` on success, `Ok(false)` at EOF.
+/// Replays one WAL entry.
 fn replay_one_entry(
     reader: &mut BufReader<File>,
     file_len: u64,
     index: &ShardedIndex,
-    mmap_data: &mut [u8],
+    target: &mut ReplayTarget<'_>,
     next_offset: &mut usize,
     vector_size: usize,
-) -> io::Result<bool> {
-    if reader.stream_position()? >= file_len {
-        return Ok(false);
+) -> io::Result<EntryOutcome> {
+    let pos = reader.stream_position()?;
+    if pos >= file_len {
+        return Ok(EntryOutcome::Stop);
     }
 
     let mut op = [0u8; 1];
     if reader.read_exact(&mut op).is_err() {
-        return Ok(false);
+        return Ok(EntryOutcome::Stop);
     }
 
     match op[0] {
-        1 => replay_store(reader, index, mmap_data, next_offset, vector_size),
-        2 => replay_delete(reader, index),
-        _ => Err(io::Error::new(io::ErrorKind::InvalidData, "unknown WAL op")),
+        1 => replay_store(reader, file_len, index, target, next_offset, vector_size),
+        2 => replay_delete(reader, file_len, index),
+        // Unknown opcode mid-stream: framing is no longer trustworthy. Treat as
+        // a torn tail (stop cleanly) rather than fabricating further entries.
+        _ => Ok(EntryOutcome::Stop),
     }
 }
 
-/// Reads and CRC-validates a store entry from the WAL.
-///
-/// Returns `(id, data)` on success.
-fn read_store_entry(reader: &mut BufReader<File>) -> io::Result<(u64, Vec<u8>)> {
+/// Reads a store entry, returning `None` for a torn tail (short/truncated)
+/// record and `Some((id, data, crc_ok))` for a fully-framed record.
+fn read_store_entry(
+    reader: &mut BufReader<File>,
+    file_len: u64,
+) -> io::Result<Option<(u64, Vec<u8>, bool)>> {
     let mut id_bytes = [0u8; 8];
     let mut len_bytes = [0u8; 4];
-    reader.read_exact(&mut id_bytes)?;
-    reader.read_exact(&mut len_bytes)?;
+    if reader.read_exact(&mut id_bytes).is_err() || reader.read_exact(&mut len_bytes).is_err() {
+        return Ok(None);
+    }
 
-    let data_len = usize::try_from(u32::from_le_bytes(len_bytes))
-        .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "data_len overflow"))?;
+    // OOM guard (#897/#898): reject a declared length larger than the remaining
+    // file before allocating `data`.
+    let Some(data_len) = checked_store_data_len(len_bytes, reader, file_len)? else {
+        return Ok(None);
+    };
 
     let mut data = vec![0u8; data_len];
-    reader.read_exact(&mut data)?;
+    if reader.read_exact(&mut data).is_err() {
+        return Ok(None);
+    }
 
     let mut stored_crc = [0u8; 4];
-    reader.read_exact(&mut stored_crc)?;
+    if reader.read_exact(&mut stored_crc).is_err() {
+        return Ok(None);
+    }
 
-    verify_store_crc(id_bytes, len_bytes, &data, stored_crc)?;
-
-    Ok((u64::from_le_bytes(id_bytes), data))
+    let crc_ok = store_crc_matches(id_bytes, len_bytes, &data, stored_crc);
+    Ok(Some((u64::from_le_bytes(id_bytes), data, crc_ok)))
 }
 
-/// Verifies the CRC32 of a store WAL frame.
-fn verify_store_crc(
+/// Validates a store entry's declared payload length against the bytes that can
+/// physically follow it in the file.
+///
+/// Returns `Ok(None)` when the record is a torn tail (declared length plus the
+/// trailing CRC would run past EOF), so the caller can stop replay cleanly
+/// instead of allocating an oversized buffer.
+fn checked_store_data_len(
+    len_bytes: [u8; 4],
+    reader: &mut BufReader<File>,
+    file_len: u64,
+) -> io::Result<Option<usize>> {
+    let data_len = u64::from(u32::from_le_bytes(len_bytes));
+    let pos = reader.stream_position()?;
+    // Remaining bytes after the length field; the record needs `data_len + 4`
+    // (payload + CRC). If it would overrun the file it is a torn/corrupt tail.
+    let remaining = file_len.saturating_sub(pos);
+    if data_len.saturating_add(4) > remaining {
+        return Ok(None);
+    }
+    let data_len = usize::try_from(data_len)
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "data_len overflow"))?;
+    Ok(Some(data_len))
+}
+
+/// Returns `true` when the reader sits at (or past) EOF, i.e. the record just
+/// consumed was the last one in the file.
+///
+/// Used to tell a normal post-crash torn tail (CRC-failing record at EOF, no
+/// bytes after it) apart from genuine mid-stream corruption (a CRC failure
+/// followed by validly framed records) so torn tails do not raise bit-rot
+/// alerts (#898 follow-up).
+fn is_at_tail(reader: &mut BufReader<File>, file_len: u64) -> io::Result<bool> {
+    Ok(reader.stream_position()? >= file_len)
+}
+
+/// Computes the CRC32 of a store frame and compares it with `stored_crc`.
+fn store_crc_matches(
     id_bytes: [u8; 8],
     len_bytes: [u8; 4],
     data: &[u8],
     stored_crc: [u8; 4],
-) -> io::Result<()> {
+) -> bool {
     let mut frame = Vec::with_capacity(1 + 8 + 4 + data.len());
     frame.push(1u8);
     frame.extend_from_slice(&id_bytes);
     frame.extend_from_slice(&len_bytes);
     frame.extend_from_slice(data);
-
-    if crc32_hash(&frame) == u32::from_le_bytes(stored_crc) {
-        Ok(())
-    } else {
-        Err(io::Error::new(io::ErrorKind::InvalidData, "CRC mismatch"))
-    }
+    crc32_hash(&frame) == u32::from_le_bytes(stored_crc)
 }
 
 /// Replays a store entry: validates CRC, writes data to mmap, updates index.
 fn replay_store(
     reader: &mut BufReader<File>,
+    file_len: u64,
     index: &ShardedIndex,
-    mmap_data: &mut [u8],
+    target: &mut ReplayTarget<'_>,
     next_offset: &mut usize,
     vector_size: usize,
-) -> io::Result<bool> {
-    let (id, data) = read_store_entry(reader)?;
+) -> io::Result<EntryOutcome> {
+    let Some((id, data, crc_ok)) = read_store_entry(reader, file_len)? else {
+        // Torn tail: stop cleanly, keeping prior entries.
+        return Ok(EntryOutcome::Stop);
+    };
 
-    if data.len() == vector_size {
-        apply_store_to_mmap(id, &data, index, mmap_data, next_offset, vector_size);
+    if !crc_ok {
+        // #898 follow-up: distinguish a torn tail from genuine mid-stream
+        // corruption. A fully-framed-but-CRC-failing record that is the LAST
+        // record (no bytes remain after it) is the normal post-crash torn tail
+        // and must NOT raise a bit-rot alert: stop cleanly, no metric. Only a
+        // CRC failure with valid framing AFTER it is true mid-stream corruption.
+        if is_at_tail(reader, file_len)? {
+            return Ok(EntryOutcome::Stop);
+        }
+        crate::metrics::global_guardrails_metrics().record_wal_replay_corrupt_entry();
+        tracing::warn!(id, "WAL replay: skipping mid-stream corrupt store entry");
+        return Ok(EntryOutcome::Applied);
     }
 
-    Ok(true)
+    if data.len() == vector_size {
+        apply_store_to_mmap(id, &data, index, target, next_offset, vector_size)?;
+    }
+
+    Ok(EntryOutcome::Applied)
 }
 
 /// Writes vector data into the mmap region and updates the index.
+///
+/// Grows the mmap when the recovered vector extends past the current mapping
+/// (#898), so replayed writes are never silently dropped, and only advances
+/// `next_offset` after the bounds-checked write succeeds.
 fn apply_store_to_mmap(
     id: u64,
     data: &[u8],
     index: &ShardedIndex,
-    mmap_data: &mut [u8],
+    target: &mut ReplayTarget<'_>,
     next_offset: &mut usize,
     vector_size: usize,
-) {
-    let offset = index.get(id).unwrap_or_else(|| {
-        let off = *next_offset;
-        *next_offset += vector_size;
-        off
-    });
+) -> io::Result<()> {
+    let offset = index.get(id).unwrap_or(*next_offset);
 
-    let end = offset + vector_size;
-    if end <= mmap_data.len() {
-        mmap_data[offset..end].copy_from_slice(data);
-        index.insert(id, offset);
-    } else {
-        tracing::warn!(
-            id = id,
-            offset = offset,
-            end = end,
-            mmap_len = mmap_data.len(),
-            "WAL replay: skipping vector — mmap too small"
-        );
+    // Bounds check BEFORE advancing `next_offset` (#898): grow the mapping so
+    // the write fits, then commit the offset advance only on success.
+    let end = offset
+        .checked_add(vector_size)
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "WAL replay offset overflow"))?;
+    target.ensure_capacity(end)?;
+
+    target.mmap[offset..end].copy_from_slice(data);
+    index.insert(id, offset);
+    if offset == *next_offset {
+        *next_offset = end;
     }
+    Ok(())
 }
 
 /// Replays a delete entry: validates CRC, removes id from index.
-fn replay_delete(reader: &mut BufReader<File>, index: &ShardedIndex) -> io::Result<bool> {
+fn replay_delete(
+    reader: &mut BufReader<File>,
+    file_len: u64,
+    index: &ShardedIndex,
+) -> io::Result<EntryOutcome> {
+    // op(1) already consumed; a delete needs id(8) + crc(4) to follow.
+    let pos = reader.stream_position()?;
+    if file_len.saturating_sub(pos) < 8 + 4 {
+        return Ok(EntryOutcome::Stop);
+    }
+
     let mut id_bytes = [0u8; 8];
-    reader.read_exact(&mut id_bytes)?;
+    if reader.read_exact(&mut id_bytes).is_err() {
+        return Ok(EntryOutcome::Stop);
+    }
 
     let mut stored_crc = [0u8; 4];
-    reader.read_exact(&mut stored_crc)?;
+    if reader.read_exact(&mut stored_crc).is_err() {
+        return Ok(EntryOutcome::Stop);
+    }
 
-    // Validate CRC
     let mut frame = Vec::with_capacity(1 + 8);
     frame.push(2u8);
     frame.extend_from_slice(&id_bytes);
 
-    if crc32_hash(&frame) != u32::from_le_bytes(stored_crc) {
-        return Err(io::Error::new(io::ErrorKind::InvalidData, "CRC mismatch"));
+    if crc32_hash(&frame) == u32::from_le_bytes(stored_crc) {
+        index.remove(u64::from_le_bytes(id_bytes));
+        return Ok(EntryOutcome::Applied);
     }
 
-    let id = u64::from_le_bytes(id_bytes);
-    index.remove(id);
-    Ok(true)
-}
-
-/// Truncates WAL after successful replay.
-fn truncate_wal(wal_path: &Path) -> io::Result<()> {
-    let file = OpenOptions::new().write(true).open(wal_path)?;
-    file.set_len(0)?;
-    file.sync_all()
+    // #898 follow-up: a CRC-failing delete that is the LAST record is a torn
+    // tail (stop cleanly, no metric); only a CRC failure with valid framing
+    // after it is genuine mid-stream corruption.
+    if is_at_tail(reader, file_len)? {
+        return Ok(EntryOutcome::Stop);
+    }
+    crate::metrics::global_guardrails_metrics().record_wal_replay_corrupt_entry();
+    tracing::warn!("WAL replay: skipping mid-stream corrupt delete entry");
+    Ok(EntryOutcome::Applied)
 }

--- a/crates/velesdb-core/src/storage/mmap/wal_replay.rs
+++ b/crates/velesdb-core/src/storage/mmap/wal_replay.rs
@@ -272,9 +272,16 @@ fn replay_one_entry(
     match op[0] {
         1 => replay_store(reader, file_len, index, target, next_offset, vector_size),
         2 => replay_delete(reader, file_len, index),
-        // Unknown opcode mid-stream: framing is no longer trustworthy. Treat as
-        // a torn tail (stop cleanly) rather than fabricating further entries.
-        _ => Ok(EntryOutcome::Stop),
+        // Unknown opcode: framing is no longer trustworthy, so stop cleanly. If
+        // bytes still follow the opcode this is mid-stream corruption — record
+        // it for visibility, mirroring the CRC path; a trailing partial byte is
+        // just a torn tail and stays silent.
+        _ => {
+            if reader.stream_position()? < file_len {
+                crate::metrics::global_guardrails_metrics().record_wal_replay_corrupt_entry();
+            }
+            Ok(EntryOutcome::Stop)
+        }
     }
 }
 

--- a/crates/velesdb-core/src/storage/snapshot.rs
+++ b/crates/velesdb-core/src/storage/snapshot.rs
@@ -207,7 +207,23 @@ pub(crate) fn create_snapshot_file(
     }
     std::fs::rename(&temp_path, &snapshot_path)?;
 
+    // #898: fsync the parent directory so the rename itself is durable. Without
+    // this, a power loss after rename can leave the directory entry pointing at
+    // the old (or no) snapshot even though the file contents were fsynced.
+    sync_parent_dir(dir);
+
     Ok(())
+}
+
+/// Best-effort fsync of a directory so a preceding rename/create is durable.
+///
+/// Errors are intentionally ignored: not all platforms permit opening or
+/// syncing a directory handle, and the snapshot is still recoverable via WAL
+/// replay if the directory entry is lost.
+fn sync_parent_dir(dir: &Path) {
+    if let Ok(handle) = File::open(dir) {
+        let _ = handle.sync_all();
+    }
 }
 
 /// Returns whether a new snapshot should be created based on WAL growth.

--- a/crates/velesdb-core/src/storage/storage_reliability_tests.rs
+++ b/crates/velesdb-core/src/storage/storage_reliability_tests.rs
@@ -694,6 +694,37 @@ fn test_898b_store_offset_overflow_leaves_next_offset_unchanged() {
 }
 
 #[test]
+fn test_898_store_batch_offset_overflow_leaves_next_offset_unchanged() {
+    // Same guarantee as the single-store path, for the batch allocator: an
+    // overflowing batch must be rejected BEFORE next_offset is advanced.
+    let dir = tempdir().unwrap();
+    let path = dir.path().to_path_buf();
+    let dim = 3;
+    let vector_size = dim * std::mem::size_of::<f32>();
+
+    let mut storage = MmapStorage::new(&path, dim).unwrap();
+    let poisoned = usize::MAX - (vector_size - 1);
+    storage
+        .next_offset
+        .store(poisoned, std::sync::atomic::Ordering::SeqCst);
+
+    let before = storage
+        .next_offset
+        .load(std::sync::atomic::Ordering::SeqCst);
+    let v = [1.0_f32, 2.0, 3.0];
+    let result = storage.store_batch(&[(999_u64, &v[..])]);
+    let after = storage
+        .next_offset
+        .load(std::sync::atomic::Ordering::SeqCst);
+
+    assert!(result.is_err(), "overflowing batch store must be rejected");
+    assert_eq!(
+        before, after,
+        "next_offset must not advance on the batch overflow error path"
+    );
+}
+
+#[test]
 fn test_898b_torn_tail_crc_fail_at_eof_no_corrupt_metric() {
     // A fully-framed but CRC-failing record that is the LAST record is a normal
     // post-crash torn tail: replay stops cleanly, recovers prior entries, and

--- a/crates/velesdb-core/src/storage/storage_reliability_tests.rs
+++ b/crates/velesdb-core/src/storage/storage_reliability_tests.rs
@@ -352,3 +352,407 @@ fn test_tmp_recovery_removes_incomplete_compaction() {
     let _storage = MmapStorage::new(&path, 3).unwrap();
     assert!(!tmp_path.exists(), ".tmp should be removed on startup");
 }
+
+// ===========================================================================
+// #898: WAL replay hardening — OOM caps, ordering, overflow, corruption policy
+// ===========================================================================
+
+/// Builds a valid CRC32-framed store entry: `[op=1][id][len][data][crc]`.
+fn crc_store_entry(id: u64, data: &[u8]) -> Vec<u8> {
+    use crate::storage::log_payload::crc32_hash;
+    let mut frame = Vec::new();
+    frame.push(1u8);
+    frame.extend_from_slice(&id.to_le_bytes());
+    frame.extend_from_slice(&(data.len() as u32).to_le_bytes());
+    frame.extend_from_slice(data);
+    let crc = crc32_hash(&frame);
+    frame.extend_from_slice(&crc.to_le_bytes());
+    frame
+}
+
+fn vec3_bytes(v: [f32; 3]) -> Vec<u8> {
+    v.iter().flat_map(|f| f.to_le_bytes()).collect()
+}
+
+#[test]
+fn test_898_replay_rejects_oversized_wal_length_no_huge_alloc() {
+    // A store record declaring a 4 GiB payload but with only a few real bytes
+    // must be rejected as a torn/corrupt tail rather than allocating 4 GiB.
+    let dir = tempdir().unwrap();
+    let path = dir.path().to_path_buf();
+    let dim = 3;
+
+    // Force CRC-framed detection with a valid first entry, then a bogus one.
+    let mut wal = crc_store_entry(1, &vec3_bytes([1.0, 2.0, 3.0]));
+    // Oversized record: op=1, id=2, len=u32::MAX, but no payload follows.
+    wal.push(1u8);
+    wal.extend_from_slice(&2u64.to_le_bytes());
+    wal.extend_from_slice(&u32::MAX.to_le_bytes());
+    std::fs::write(path.join("vectors.wal"), &wal).unwrap();
+
+    // Must not panic / OOM; first entry recovers, oversized tail is dropped.
+    let storage = MmapStorage::new(&path, dim).unwrap();
+    assert_eq!(storage.retrieve(1).unwrap(), Some(vec![1.0, 2.0, 3.0]));
+    assert!(storage.retrieve(2).unwrap().is_none());
+}
+
+#[test]
+fn test_898_replay_torn_tail_recovers_prior_entries() {
+    // Two valid entries followed by a truncated (torn) third record.
+    let dir = tempdir().unwrap();
+    let path = dir.path().to_path_buf();
+    let dim = 3;
+
+    let mut wal = crc_store_entry(1, &vec3_bytes([1.0, 2.0, 3.0]));
+    wal.extend_from_slice(&crc_store_entry(2, &vec3_bytes([4.0, 5.0, 6.0])));
+    // Torn tail: only an op byte + partial id, no len/data/crc.
+    wal.push(1u8);
+    wal.extend_from_slice(&7u64.to_le_bytes()[..3]);
+    std::fs::write(path.join("vectors.wal"), &wal).unwrap();
+
+    let storage = MmapStorage::new(&path, dim).unwrap();
+    assert_eq!(storage.retrieve(1).unwrap(), Some(vec![1.0, 2.0, 3.0]));
+    assert_eq!(storage.retrieve(2).unwrap(), Some(vec![4.0, 5.0, 6.0]));
+    assert_eq!(storage.len(), 2, "torn tail must not corrupt prior entries");
+}
+
+#[test]
+fn test_898_replay_midstream_crc_corruption_skips_and_continues() {
+    // First entry valid, second fully-framed but CRC-corrupt, third valid.
+    // Policy: skip the corrupt mid-stream entry, recover the rest.
+    let dir = tempdir().unwrap();
+    let path = dir.path().to_path_buf();
+    let dim = 3;
+
+    let mut bad = crc_store_entry(2, &vec3_bytes([4.0, 5.0, 6.0]));
+    let last = bad.len() - 1;
+    bad[last] ^= 0xFF; // flip CRC -> mid-stream corruption
+
+    let mut wal = crc_store_entry(1, &vec3_bytes([1.0, 2.0, 3.0]));
+    wal.extend_from_slice(&bad);
+    wal.extend_from_slice(&crc_store_entry(3, &vec3_bytes([7.0, 8.0, 9.0])));
+    std::fs::write(path.join("vectors.wal"), &wal).unwrap();
+
+    let before = crate::metrics::global_guardrails_metrics()
+        .wal_replay_corrupt_entries
+        .load(std::sync::atomic::Ordering::Relaxed);
+
+    let storage = MmapStorage::new(&path, dim).unwrap();
+    assert_eq!(storage.retrieve(1).unwrap(), Some(vec![1.0, 2.0, 3.0]));
+    assert!(
+        storage.retrieve(2).unwrap().is_none(),
+        "corrupt mid-stream entry must be skipped"
+    );
+    assert_eq!(
+        storage.retrieve(3).unwrap(),
+        Some(vec![7.0, 8.0, 9.0]),
+        "entries after a mid-stream corruption must still be recovered"
+    );
+
+    let after = crate::metrics::global_guardrails_metrics()
+        .wal_replay_corrupt_entries
+        .load(std::sync::atomic::Ordering::Relaxed);
+    assert!(after > before, "corrupt-entry metric must be incremented");
+}
+
+#[test]
+fn test_898_replay_grows_mmap_no_silent_gap() {
+    // A WAL that places vectors past the 16 MB initial mmap must grow the
+    // mapping and recover every vector — never silently drop one.
+    let dir = tempdir().unwrap();
+    let path = dir.path().to_path_buf();
+    let dim = 3;
+    let vec_size = dim * 4;
+
+    // Build an index whose highest offset is already near 16 MB so the next
+    // replayed vector lands beyond the initial mapping.
+    let near_cap = 16 * 1024 * 1024 - vec_size; // last slot in the initial map
+    let mut index: FxHashMap<u64, usize> = FxHashMap::default();
+    index.insert(1, near_cap);
+    std::fs::write(
+        path.join("vectors.idx"),
+        postcard::to_allocvec(&index).unwrap(),
+    )
+    .unwrap();
+
+    // Data file sized to initial 16 MB, vector 1 written at near_cap.
+    let mut data = vec![0u8; 16 * 1024 * 1024];
+    data[near_cap..near_cap + vec_size].copy_from_slice(&vec3_bytes([1.0, 2.0, 3.0]));
+    std::fs::write(path.join("vectors.dat"), &data).unwrap();
+
+    // WAL stores a NEW vector (id=2) which will be placed at next_offset
+    // (== 16 MB), beyond the initial mapping -> replay must grow.
+    let wal = crc_store_entry(2, &vec3_bytes([4.0, 5.0, 6.0]));
+    std::fs::write(path.join("vectors.wal"), &wal).unwrap();
+
+    let storage = MmapStorage::new(&path, dim).unwrap();
+    assert_eq!(storage.retrieve(1).unwrap(), Some(vec![1.0, 2.0, 3.0]));
+    assert_eq!(
+        storage.retrieve(2).unwrap(),
+        Some(vec![4.0, 5.0, 6.0]),
+        "vector beyond initial mmap must be recovered, not dropped"
+    );
+}
+
+#[test]
+fn test_898_load_index_rejects_out_of_bounds_offset() {
+    // A corrupt index offset that points past the data file must be rejected,
+    // not silently accepted (which would wrap into an OOB read later).
+    let dir = tempdir().unwrap();
+    let path = dir.path().to_path_buf();
+    let dim = 3;
+
+    // Tiny data file but an index offset far beyond it.
+    std::fs::write(path.join("vectors.dat"), vec![0u8; 64]).unwrap();
+    let mut index: FxHashMap<u64, usize> = FxHashMap::default();
+    index.insert(1, 1_000_000);
+    std::fs::write(
+        path.join("vectors.idx"),
+        postcard::to_allocvec(&index).unwrap(),
+    )
+    .unwrap();
+    std::fs::write(path.join("vectors.wal"), b"").unwrap();
+
+    let result = MmapStorage::new(&path, dim);
+    assert!(
+        result.is_err(),
+        "index offset beyond data file must be rejected as corrupt"
+    );
+}
+
+#[test]
+fn test_898_fsync_store_persists_wal_before_ok() {
+    // DurabilityMode::Fsync single-store path must leave the entry on disk
+    // (flushed past the BufWriter) by the time store() returns Ok.
+    let dir = tempdir().unwrap();
+    let path = dir.path().to_path_buf();
+    let dim = 3;
+
+    let mut storage = MmapStorage::new_with_durability(&path, dim, DurabilityMode::Fsync).unwrap();
+    storage.store(1, &[1.0, 2.0, 3.0]).unwrap();
+
+    // Inspect the WAL file directly without any further flush/drop: a full
+    // CRC-framed store entry (17 + 12 bytes) must already be present.
+    let wal_len = std::fs::metadata(path.join("vectors.wal")).unwrap().len();
+    assert!(
+        wal_len >= (17 + dim * 4) as u64,
+        "Fsync store must persist the WAL entry before returning Ok (got {wal_len} bytes)"
+    );
+}
+
+#[test]
+fn test_898_valid_roundtrip_and_crash_recovery_still_works() {
+    // Sanity: normal store -> simulated crash (no flush_full) -> reopen recovers.
+    let dir = tempdir().unwrap();
+    let path = dir.path().to_path_buf();
+    let dim = 3;
+
+    {
+        let mut storage = MmapStorage::new(&path, dim).unwrap();
+        storage.store(1, &[1.0, 2.0, 3.0]).unwrap();
+        storage.store(2, &[4.0, 5.0, 6.0]).unwrap();
+        storage.flush().unwrap();
+        // Drop without flush_index() — simulates a crash before idx persist.
+    }
+
+    let storage = MmapStorage::new(&path, dim).unwrap();
+    assert_eq!(storage.retrieve(1).unwrap(), Some(vec![1.0, 2.0, 3.0]));
+    assert_eq!(storage.retrieve(2).unwrap(), Some(vec![4.0, 5.0, 6.0]));
+    assert_eq!(storage.len(), 2);
+
+    // WAL must be cleared after the recovery truncation.
+    let wal_len = std::fs::metadata(path.join("vectors.wal")).unwrap().len();
+    assert_eq!(wal_len, 0, "WAL truncated only after mmap+idx made durable");
+}
+
+// ===========================================================================
+// #898 follow-up: durable delete before hole-punch, offset-reserve ordering,
+// and torn-tail vs mid-stream CRC classification.
+// ===========================================================================
+
+/// Builds a valid CRC32-framed delete entry: `[op=2][id][crc]`.
+fn crc_delete_entry(id: u64) -> Vec<u8> {
+    use crate::storage::log_payload::crc32_hash;
+    let mut frame = Vec::new();
+    frame.push(2u8);
+    frame.extend_from_slice(&id.to_le_bytes());
+    let crc = crc32_hash(&frame);
+    frame.extend_from_slice(&crc.to_le_bytes());
+    frame
+}
+
+/// Reads the global mid-stream corrupt-WAL-entry counter.
+fn corrupt_entry_count() -> u64 {
+    crate::metrics::global_guardrails_metrics()
+        .wal_replay_corrupt_entries
+        .load(std::sync::atomic::Ordering::Relaxed)
+}
+
+#[test]
+fn test_898b_fsync_delete_persists_wal_before_punch_hole() {
+    // The fix: under DurabilityMode::Fsync, delete() must make the WAL delete
+    // record durable BEFORE the destructive punch_hole. We assert the record is
+    // already on disk the instant delete() returns — no drop/flush in between.
+    let dir = tempdir().unwrap();
+    let path = dir.path().to_path_buf();
+    let dim = 3;
+
+    let mut storage = MmapStorage::new_with_durability(&path, dim, DurabilityMode::Fsync).unwrap();
+    storage.store(1, &[1.0, 2.0, 3.0]).unwrap();
+    storage.flush_full().unwrap(); // persist idx + truncate WAL
+
+    let wal_before = std::fs::metadata(path.join("vectors.wal")).unwrap().len();
+    storage.delete(1).unwrap();
+    let wal_after = std::fs::metadata(path.join("vectors.wal")).unwrap().len();
+
+    // A CRC-framed delete record is op(1)+id(8)+crc(4) = 13 bytes; it must be
+    // physically present (flushed past the BufWriter) before delete() returns.
+    assert_eq!(
+        wal_after - wal_before,
+        13,
+        "Fsync delete must persist the WAL delete record before punch_hole"
+    );
+}
+
+#[test]
+fn test_898b_delete_survives_crash_no_zero_resurrection() {
+    // Faithful crash scenario via the replay seam: a durable store record
+    // followed by a durable delete record for the same id. On reopen, replay
+    // must apply both in order -> the id stays deleted and does NOT come back
+    // as a zero vector.
+    let dir = tempdir().unwrap();
+    let path = dir.path().to_path_buf();
+    let dim = 3;
+
+    let mut wal = crc_store_entry(1, &vec3_bytes([1.0, 2.0, 3.0]));
+    wal.extend_from_slice(&crc_delete_entry(1));
+    std::fs::write(path.join("vectors.wal"), &wal).unwrap();
+
+    let storage = MmapStorage::new(&path, dim).unwrap();
+    assert!(
+        storage.retrieve(1).unwrap().is_none(),
+        "deleted id must stay deleted after replay, not resurrect as zeros"
+    );
+    assert_eq!(storage.len(), 0);
+}
+
+#[test]
+fn test_898b_valid_delete_normal_recovery_no_regression() {
+    // Regression guard: a normal store + delete + flush cycle still recovers
+    // with the id absent after reopen.
+    let dir = tempdir().unwrap();
+    let path = dir.path().to_path_buf();
+    let dim = 3;
+
+    {
+        let mut storage = MmapStorage::new(&path, dim).unwrap();
+        storage.store(1, &[1.0, 2.0, 3.0]).unwrap();
+        storage.store(2, &[4.0, 5.0, 6.0]).unwrap();
+        storage.delete(1).unwrap();
+        storage.flush().unwrap();
+    }
+
+    let storage = MmapStorage::new(&path, dim).unwrap();
+    assert!(
+        storage.retrieve(1).unwrap().is_none(),
+        "id 1 must stay deleted"
+    );
+    assert_eq!(storage.retrieve(2).unwrap(), Some(vec![4.0, 5.0, 6.0]));
+    assert_eq!(storage.len(), 1);
+}
+
+#[test]
+fn test_898b_store_offset_overflow_leaves_next_offset_unchanged() {
+    // The fix: the overflow guard must run BEFORE next_offset is advanced, so a
+    // rejected store leaves the allocator watermark exactly where it was.
+    let dir = tempdir().unwrap();
+    let path = dir.path().to_path_buf();
+    let dim = 3;
+    let vector_size = dim * std::mem::size_of::<f32>();
+
+    let mut storage = MmapStorage::new(&path, dim).unwrap();
+
+    // Force next_offset so close to usize::MAX that offset + vector_size wraps.
+    let poisoned = usize::MAX - (vector_size - 1);
+    storage
+        .next_offset
+        .store(poisoned, std::sync::atomic::Ordering::SeqCst);
+
+    let before = storage
+        .next_offset
+        .load(std::sync::atomic::Ordering::SeqCst);
+    let result = storage.store(999, &[1.0, 2.0, 3.0]);
+    let after = storage
+        .next_offset
+        .load(std::sync::atomic::Ordering::SeqCst);
+
+    assert!(result.is_err(), "overflowing store offset must be rejected");
+    assert_eq!(
+        before, after,
+        "next_offset must not advance on the overflow error path"
+    );
+}
+
+#[test]
+fn test_898b_torn_tail_crc_fail_at_eof_no_corrupt_metric() {
+    // A fully-framed but CRC-failing record that is the LAST record is a normal
+    // post-crash torn tail: replay stops cleanly, recovers prior entries, and
+    // must NOT increment the corrupt-entry metric (no false bit-rot alert).
+    let dir = tempdir().unwrap();
+    let path = dir.path().to_path_buf();
+    let dim = 3;
+
+    let mut tail = crc_store_entry(2, &vec3_bytes([4.0, 5.0, 6.0]));
+    let last = tail.len() - 1;
+    tail[last] ^= 0xFF; // flip CRC on the final record
+
+    let mut wal = crc_store_entry(1, &vec3_bytes([1.0, 2.0, 3.0]));
+    wal.extend_from_slice(&tail);
+    std::fs::write(path.join("vectors.wal"), &wal).unwrap();
+
+    let before = corrupt_entry_count();
+
+    let storage = MmapStorage::new(&path, dim).unwrap();
+    assert_eq!(storage.retrieve(1).unwrap(), Some(vec![1.0, 2.0, 3.0]));
+    assert!(
+        storage.retrieve(2).unwrap().is_none(),
+        "torn-tail record must be dropped"
+    );
+
+    assert_eq!(
+        before,
+        corrupt_entry_count(),
+        "a CRC-failing torn tail at EOF must NOT raise a corruption alert"
+    );
+}
+
+#[test]
+fn test_898b_midstream_crc_fail_with_valid_after_increments_metric() {
+    // Counterpart to the torn-tail test: a CRC-failing record followed by a
+    // validly framed record IS genuine mid-stream corruption and MUST increment
+    // the corrupt-entry metric while still recovering the trailing valid entry.
+    let dir = tempdir().unwrap();
+    let path = dir.path().to_path_buf();
+    let dim = 3;
+
+    let mut bad = crc_store_entry(2, &vec3_bytes([4.0, 5.0, 6.0]));
+    let last = bad.len() - 1;
+    bad[last] ^= 0xFF; // flip CRC -> corruption
+
+    let mut wal = crc_store_entry(1, &vec3_bytes([1.0, 2.0, 3.0]));
+    wal.extend_from_slice(&bad);
+    wal.extend_from_slice(&crc_store_entry(3, &vec3_bytes([7.0, 8.0, 9.0])));
+    std::fs::write(path.join("vectors.wal"), &wal).unwrap();
+
+    let before = corrupt_entry_count();
+
+    let storage = MmapStorage::new(&path, dim).unwrap();
+    assert_eq!(storage.retrieve(1).unwrap(), Some(vec![1.0, 2.0, 3.0]));
+    assert!(storage.retrieve(2).unwrap().is_none());
+    assert_eq!(storage.retrieve(3).unwrap(), Some(vec![7.0, 8.0, 9.0]));
+
+    assert!(
+        corrupt_entry_count() > before,
+        "a CRC failure with valid framing after it must increment the metric"
+    );
+}

--- a/crates/velesdb-core/src/storage/wal_batcher.rs
+++ b/crates/velesdb-core/src/storage/wal_batcher.rs
@@ -16,7 +16,48 @@
 
 use crate::config::WalBatchConfig;
 use parking_lot::Mutex;
+use std::fs::File;
 use std::io::{self, Write};
+
+/// A WAL write target that can be both buffered-flushed and durably synced.
+///
+/// #898: group commit previously only flushed the `BufWriter`, never issuing an
+/// `fsync`, so a power loss after a "committed" batch could lose it. Flushing a
+/// batch now also calls [`WalSink::sync`]; for file-backed sinks this is
+/// `sync_all()`, while in-memory sinks (tests) are a no-op.
+pub trait WalSink: Write {
+    /// Durably persists previously written bytes (file-backed: `fsync`).
+    ///
+    /// # Errors
+    ///
+    /// Returns an I/O error if the underlying sync fails.
+    fn sync(&mut self) -> io::Result<()>;
+}
+
+impl WalSink for File {
+    fn sync(&mut self) -> io::Result<()> {
+        self.sync_all()
+    }
+}
+
+impl WalSink for io::BufWriter<File> {
+    fn sync(&mut self) -> io::Result<()> {
+        self.flush()?;
+        self.get_ref().sync_all()
+    }
+}
+
+impl WalSink for Vec<u8> {
+    fn sync(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+impl<W: WalSink + ?Sized> WalSink for &mut W {
+    fn sync(&mut self) -> io::Result<()> {
+        (**self).sync()
+    }
+}
 
 /// A batch of pending WAL entries awaiting flush.
 struct PendingBatch {
@@ -80,9 +121,9 @@ impl WalBatcher {
     /// # Errors
     ///
     /// Returns an I/O error if the underlying write or flush fails.
-    pub fn submit(&self, data: &[u8], writer: &mut impl Write) -> io::Result<()> {
+    pub fn submit(&self, data: &[u8], writer: &mut impl WalSink) -> io::Result<()> {
         if !self.config.enabled {
-            return write_and_flush(writer, data);
+            return write_and_sync(writer, data);
         }
 
         let needs_flush = {
@@ -106,7 +147,7 @@ impl WalBatcher {
     /// # Errors
     ///
     /// Returns an I/O error if the underlying write or flush fails.
-    pub fn flush(&self, writer: &mut impl Write) -> io::Result<()> {
+    pub fn flush(&self, writer: &mut impl WalSink) -> io::Result<()> {
         let data = {
             let mut batch = self.pending.lock();
             if batch.entry_count == 0 {
@@ -118,7 +159,9 @@ impl WalBatcher {
         };
 
         writer.write_all(&data)?;
-        writer.flush()
+        writer.flush()?;
+        // #898: group commit is only durable once the batch is fsynced.
+        writer.sync()
     }
 
     /// Returns `true` if batching is enabled.
@@ -144,8 +187,10 @@ impl WalBatcher {
     }
 }
 
-/// Writes data and flushes the writer in a single operation.
-fn write_and_flush(writer: &mut impl Write, data: &[u8]) -> io::Result<()> {
+/// Writes data, flushes, and fsyncs the writer in a single operation.
+fn write_and_sync(writer: &mut impl WalSink, data: &[u8]) -> io::Result<()> {
     writer.write_all(data)?;
-    writer.flush()
+    writer.flush()?;
+    // #898: pass-through (batching disabled) must still be durable.
+    writer.sync()
 }

--- a/crates/velesdb-core/src/storage/wal_batcher_tests.rs
+++ b/crates/velesdb-core/src/storage/wal_batcher_tests.rs
@@ -180,6 +180,12 @@ mod tests {
         }
     }
 
+    impl crate::storage::wal_batcher::WalSink for FailWriter {
+        fn sync(&mut self) -> std::io::Result<()> {
+            Err(std::io::Error::other("simulated sync failure"))
+        }
+    }
+
     #[test]
     fn disabled_mode_propagates_write_error() {
         let batcher = WalBatcher::new(WalBatchConfig::default());
@@ -201,5 +207,39 @@ mod tests {
         // Second entry triggers flush -> writer error
         let result = batcher.submit(b"b", &mut writer);
         assert!(result.is_err());
+    }
+
+    // ========================================================================
+    // #898: group commit fsyncs the batch on flush (file-backed sink)
+    // ========================================================================
+
+    #[test]
+    fn flush_syncs_and_persists_to_file() {
+        use std::io::Read;
+
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = dir.path().join("batch.wal");
+        let mut file = std::fs::OpenOptions::new()
+            .create(true)
+            .truncate(true)
+            .read(true)
+            .write(true)
+            .open(&path)
+            .expect("open wal");
+
+        let batcher = WalBatcher::new(enabled_config(128));
+        batcher.submit(b"alpha", &mut file).expect("submit");
+        batcher.submit(b"beta", &mut file).expect("submit");
+        // Explicit flush triggers write_all + flush + sync_all (fsync).
+        batcher.flush(&mut file).expect("flush");
+
+        // Re-read the file from a fresh handle: the bytes are durably on disk.
+        let mut on_disk = Vec::new();
+        std::fs::File::open(&path)
+            .expect("reopen")
+            .read_to_end(&mut on_disk)
+            .expect("read");
+        assert_eq!(on_disk, b"alphabeta");
+        assert_eq!(batcher.pending_count(), 0);
     }
 }

--- a/crates/velesdb-core/src/storage/wal_entry.rs
+++ b/crates/velesdb-core/src/storage/wal_entry.rs
@@ -69,13 +69,18 @@ impl WalEntry {
     }
 
     /// Applies this entry to the index, returning the new file position.
+    ///
+    /// `wal_end` is the logical end of the WAL being replayed; it bounds the
+    /// declared payload length so a corrupt length field cannot drive an
+    /// unbounded allocation (#897/#898).
     pub(super) fn apply(
         self,
         index: &mut FxHashMap<u64, u64>,
         reader: &mut BufReader<File>,
+        wal_end: u64,
     ) -> io::Result<u64> {
         match self.op {
-            WalOp::Store { id } => self.apply_store(id, index, reader),
+            WalOp::Store { id } => self.apply_store(id, index, reader, wal_end),
             WalOp::Delete { id } => self.apply_delete(id, index, reader),
         }
     }
@@ -85,11 +90,24 @@ impl WalEntry {
         id: u64,
         index: &mut FxHashMap<u64, u64>,
         reader: &mut BufReader<File>,
+        wal_end: u64,
     ) -> io::Result<u64> {
         let len_offset = self.pos_after_header;
         let mut len_bytes = [0u8; 4];
         reader.read_exact(&mut len_bytes)?;
         let payload_len = u64::from(u32::from_le_bytes(len_bytes));
+
+        // OOM guard (#897/#898): the payload (plus the 4-byte CRC for v2
+        // records) cannot extend past the WAL end. Reject before allocating.
+        let payload_start = self.pos_after_header + 4;
+        let crc_bytes = u64::from(self.has_crc) * 4;
+        let max_payload = wal_end.saturating_sub(payload_start);
+        if payload_len.saturating_add(crc_bytes) > max_payload {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "WAL payload length exceeds remaining file",
+            ));
+        }
 
         let end_pos = if self.has_crc {
             self.apply_store_with_crc(id, payload_len, index, reader, len_offset)?

--- a/crates/velesdb-core/src/storage/wal_recovery_tests.rs
+++ b/crates/velesdb-core/src/storage/wal_recovery_tests.rs
@@ -855,3 +855,69 @@ fn test_crc_entries_survive_snapshot_cycle() {
     let val = storage.retrieve(10).expect("retrieve").expect("exists");
     assert_eq!(val["id"], 10);
 }
+
+// ===========================================================================
+// #898 / #897: OOM caps on untrusted WAL/payload lengths
+// ===========================================================================
+
+#[test]
+fn test_898_replay_rejects_oversized_payload_length_no_huge_alloc() {
+    // Legacy store entry whose declared length is 4 GiB but with no payload:
+    // replay must reject it (not allocate 4 GiB), without panicking.
+    let mut wal = vec![1u8];
+    wal.extend_from_slice(&1u64.to_le_bytes());
+    wal.extend_from_slice(&u32::MAX.to_le_bytes()); // bogus 4 GiB length
+                                                    // no payload bytes follow
+
+    let result = open_storage_with_wal(&wal);
+    assert!(
+        result.is_err(),
+        "oversized declared payload length must be rejected as corrupt"
+    );
+}
+
+#[test]
+fn test_898_replay_rejects_oversized_crc_payload_no_huge_alloc() {
+    // CRC-framed store entry declaring an impossibly large payload length.
+    let mut wal = Vec::new();
+    wal.push(0xC3u8);
+    wal.extend_from_slice(&1u64.to_le_bytes());
+    wal.extend_from_slice(&u32::MAX.to_le_bytes());
+    // no payload / crc follow
+
+    let result = open_storage_with_wal(&wal);
+    assert!(
+        result.is_err(),
+        "oversized CRC payload length must be rejected before allocation"
+    );
+}
+
+#[test]
+fn test_898_retrieve_rejects_corrupt_length_field() {
+    // Defense-in-depth: retrieve() must reject a corrupt on-disk length field
+    // (larger than the file) instead of allocating an unbounded buffer.
+    //
+    // A snapshot is taken so that on reopen the index is loaded from the
+    // snapshot and WAL replay starts past the record — exercising the retrieve
+    // path (not the replay cap) against the corrupted length field.
+    let temp = TempDir::new().expect("temp dir");
+    {
+        let mut storage = LogPayloadStorage::new(temp.path()).expect("create");
+        storage.store(1, &json!({"k": "v"})).expect("store");
+        storage.create_snapshot().expect("snapshot");
+    }
+
+    // Corrupt the length field of the single record. The index stores the
+    // offset of the length field (record_start + 9 = marker(1)+id(8)).
+    let log_path = temp.path().join("payloads.log");
+    let mut bytes = fs::read(&log_path).expect("read log");
+    bytes[9..13].copy_from_slice(&u32::MAX.to_le_bytes());
+    fs::write(&log_path, &bytes).expect("write log");
+
+    let storage = LogPayloadStorage::new(temp.path()).expect("reopen from snapshot");
+    let result = storage.retrieve(1);
+    assert!(
+        result.is_err(),
+        "retrieve must reject a length field larger than the file"
+    );
+}


### PR DESCRIPTION
**Closes #898. Refs #897.** WAL/payload allocation caps; recovery order apply→flush→persist→truncate (no data-loss window); durable delete before hole-punch; Fsync honored; torn-tail vs mid-stream policy; checked offsets.

---
Part of the 2026-05-28 `velesdb-core` security/perf/OOM audit (`report/AUDIT-velesdb-core-2026-05-28.md`). Implemented by a specialist sub-agent, then adversarial review→fix rounds to 0 findings. Integration-branch gate: `cargo fmt --check`, workspace `clippy -D warnings -D clippy::pedantic`, full lib suite (4914 tests), recall contracts — all green. Every fix ships a regression test.