### PR TITLE
fix(index/agent): cap untrusted deserialization + BM25 snapshot validation (#897)

### DIFF
--- a/crates/velesdb-core/src/agent/episodic_memory.rs
+++ b/crates/velesdb-core/src/agent/episodic_memory.rs
@@ -297,11 +297,18 @@ impl EpisodicMemory {
         id_fetcher: impl Fn(usize) -> Vec<u64>,
         collection: &crate::collection::Collection,
     ) -> Vec<(u64, String, i64)> {
-        let mut events = Vec::with_capacity(limit);
-        let mut fetch_limit = limit * 2;
-        let max_fetch = self.temporal_index.len().max(limit);
+        // Clamp the pre-allocation: the number of events can never exceed the
+        // total indexed entries, so a huge caller-supplied `limit` must not
+        // pre-allocate beyond available data.
+        let indexed = self.temporal_index.len();
+        let mut events = Vec::with_capacity(limit.min(indexed));
+        let mut fetch_limit = limit.saturating_mul(2);
+        // Saturating to keep an attacker-supplied `limit` near `usize::MAX` from
+        // overflowing the loop ceiling (panic under `panic=abort`, silent wrap in
+        // release). The `id_count < fetch_limit` break still terminates the loop.
+        let max_fetch = indexed.max(limit).saturating_mul(2);
 
-        while events.len() < limit && fetch_limit <= max_fetch * 2 {
+        while events.len() < limit && fetch_limit <= max_fetch {
             let ids = id_fetcher(fetch_limit);
             if ids.is_empty() {
                 break;
@@ -313,7 +320,7 @@ impl EpisodicMemory {
             if events.len() >= limit || id_count < fetch_limit {
                 break;
             }
-            fetch_limit *= 2;
+            fetch_limit = fetch_limit.saturating_mul(2);
         }
 
         events

--- a/crates/velesdb-core/src/agent/episodic_memory_tests.rs
+++ b/crates/velesdb-core/src/agent/episodic_memory_tests.rs
@@ -79,6 +79,32 @@ mod tests {
         assert_eq!(events.len(), 3);
     }
 
+    /// #897 follow-up: a caller-supplied `limit` near `usize::MAX` must not
+    /// overflow the internal fetch-doubling (panic under `panic=abort` / debug
+    /// overflow checks, silent wrap in release). It must return a bounded result.
+    #[test]
+    fn test_recent_huge_limit_no_overflow() {
+        let dir = tempdir().unwrap();
+        let db = Arc::new(Database::open(dir.path()).unwrap());
+        let ep = make_episodic(Arc::clone(&db));
+
+        for i in 0u64..3 {
+            #[allow(clippy::cast_possible_wrap)] // i < 3; u64→i64 cannot wrap.
+            ep.record(i, "ev", i as i64 * 1_000, None).unwrap();
+        }
+
+        // usize::MAX would overflow `max_fetch * 2` / `fetch_limit *= 2` before the fix.
+        let events = ep.recent(usize::MAX, None).unwrap();
+        assert_eq!(
+            events.len(),
+            3,
+            "must return all (and only) recorded events"
+        );
+
+        let older = ep.older_than(i64::MAX, usize::MAX).unwrap();
+        assert!(older.len() <= 3);
+    }
+
     #[test]
     fn test_recent_with_since_timestamp_filters_older() {
         let dir = tempdir().unwrap();

--- a/crates/velesdb-core/src/agent/memory_helpers.rs
+++ b/crates/velesdb-core/src/agent/memory_helpers.rs
@@ -230,7 +230,15 @@ pub(super) fn validate_binary_header(data: &[u8], entry_size: usize) -> Option<u
         return None;
     }
     let count = u64::from_le_bytes(data[0..8].try_into().ok()?) as usize;
-    if data.len() != 8 + count * entry_size {
+    let payload = data.len() - 8;
+    // Untrusted `count`: bound it against the actual payload first so the
+    // `count * entry_size` below cannot wrap on a 32-bit target and produce a
+    // total that spuriously equals `data.len()`.
+    if entry_size == 0 || count > payload / entry_size {
+        return None;
+    }
+    let total = 8usize.checked_add(count.checked_mul(entry_size)?)?;
+    if data.len() != total {
         return None;
     }
     Some(count)

--- a/crates/velesdb-core/src/agent/temporal_index.rs
+++ b/crates/velesdb-core/src/agent/temporal_index.rs
@@ -124,8 +124,12 @@ impl TemporalIndex {
     /// Vector of (id, timestamp) pairs, ordered by timestamp descending.
     #[must_use]
     pub fn recent(&self, limit: usize, since_timestamp: Option<i64>) -> Vec<TemporalEntry> {
+        // Read `id_to_timestamp` first (insert order) to honour lock ordering and
+        // to clamp the caller-supplied `limit`: results can never exceed the total
+        // number of indexed entries, so a huge `limit` must not pre-allocate beyond it.
+        let total = self.id_to_timestamp.read().len();
         let by_ts = self.by_timestamp.read();
-        let mut results = Vec::with_capacity(limit);
+        let mut results = Vec::with_capacity(limit.min(total));
 
         for (&ts, ids) in by_ts.iter().rev() {
             if let Some(since) = since_timestamp {
@@ -157,8 +161,11 @@ impl TemporalIndex {
     /// Vector of (id, timestamp) pairs, ordered by timestamp ascending.
     #[must_use]
     pub fn older_than(&self, before_timestamp: i64, limit: usize) -> Vec<TemporalEntry> {
+        // Clamp `limit` to the total indexed entries (read first, per lock order)
+        // so a huge caller-supplied `limit` cannot pre-allocate beyond available data.
+        let total = self.id_to_timestamp.read().len();
         let by_ts = self.by_timestamp.read();
-        let mut results = Vec::with_capacity(limit);
+        let mut results = Vec::with_capacity(limit.min(total));
 
         for (&ts, ids) in by_ts.iter() {
             if ts >= before_timestamp {

--- a/crates/velesdb-core/src/agent/temporal_index_tests.rs
+++ b/crates/velesdb-core/src/agent/temporal_index_tests.rs
@@ -98,6 +98,41 @@ mod tests {
         assert_eq!(restored.get_timestamp(3), Some(3000));
     }
 
+    /// #897: a binary header whose `count * entry_size` overflows `usize` so the
+    /// product wraps to match `data.len()` must be rejected, not blindly trusted
+    /// (which would `reserve(count)` and abort/OOM).
+    #[test]
+    fn test_deserialize_rejects_overflowing_count() {
+        // entry_size = 16 for TemporalIndex. With an 8-byte buffer (zero payload),
+        // count = 2^60 makes count*16 wrap to 0 (mod 2^64), so the pre-fix length
+        // check `8 + count*16 == data.len()` spuriously passed.
+        let count: u64 = 1u64 << 60;
+        let mut data = Vec::with_capacity(8);
+        data.extend_from_slice(&count.to_le_bytes());
+
+        let restored = TemporalIndex::deserialize(&data);
+        assert!(
+            restored.is_none(),
+            "overflowing count header must be rejected"
+        );
+    }
+
+    /// #897: a huge caller-supplied `limit` must not pre-allocate beyond the number
+    /// of indexed entries.
+    #[test]
+    fn test_recent_huge_limit_does_not_overallocate() {
+        let index = TemporalIndex::new();
+        index.insert(1, 1000);
+        index.insert(2, 2000);
+
+        // A `limit` near usize::MAX must not abort/OOM; results are bounded by data.
+        let recent = index.recent(usize::MAX, None);
+        assert_eq!(recent.len(), 2);
+
+        let older = index.older_than(i64::MAX, usize::MAX);
+        assert_eq!(older.len(), 2);
+    }
+
     #[test]
     fn test_temporal_index_stats() {
         let index = TemporalIndex::new();

--- a/crates/velesdb-core/src/index/bm25.rs
+++ b/crates/velesdb-core/src/index/bm25.rs
@@ -531,12 +531,20 @@ impl Bm25Index {
     ///
     /// # Errors
     ///
+    /// Returns [`Error::IndexCorrupted`] when `snapshot.version` does not match
+    /// [`BM25_SNAPSHOT_VERSION`], protecting against loading an incompatible
+    /// on-disk format. Document-length counters (`doc_count`,
+    /// `total_doc_length`) are recomputed from the authoritative `documents`
+    /// map and rejected if the recomputed `doc_count` would leave
+    /// `total_doc_length == 0` while `doc_count > 0` (which would make `avgdl`
+    /// produce inf/NaN BM25 scores).
+    ///
     /// Silently skips documents missing from `point_to_doc`. Such a
     /// mismatch would indicate a corrupt snapshot and is logged
     /// rather than raised, matching the existing BM25
     /// `remove_document_internal` tolerance for unknown ids.
-    #[must_use]
-    pub(crate) fn from_snapshot(snapshot: Bm25Snapshot) -> Self {
+    pub(crate) fn from_snapshot(mut snapshot: Bm25Snapshot) -> crate::Result<Self> {
+        Self::validate_snapshot(&mut snapshot)?;
         let index = Self::with_params(snapshot.params);
 
         // Rebuild inverted index from `documents` + `point_to_doc`.
@@ -569,6 +577,46 @@ impl Bm25Index {
         *index.doc_count.write() = snapshot.doc_count;
         *index.total_doc_length.write() = snapshot.total_doc_length;
 
-        index
+        Ok(index)
+    }
+
+    /// Validates an untrusted [`Bm25Snapshot`] and repairs its counters in place.
+    ///
+    /// Rejects version mismatches, then recomputes `doc_count` /
+    /// `total_doc_length` from the **scorable** corpus — the documents that are
+    /// also present in `point_to_doc` and therefore added to the inverted index
+    /// by [`Self::from_snapshot`]. Counting all of `documents` (including ones
+    /// skipped during reconstruction) would inflate `N`/`avgdl` and skew every
+    /// IDF and length-normalization, yielding wrong (but finite) scores. This
+    /// also prevents a tampered header from installing inconsistent counters
+    /// that would make `avgdl == 0` (inf/NaN scores).
+    fn validate_snapshot(snapshot: &mut Bm25Snapshot) -> crate::Result<()> {
+        if snapshot.version != BM25_SNAPSHOT_VERSION {
+            return Err(crate::Error::IndexCorrupted(format!(
+                "BM25 snapshot version mismatch: got {}, expected {BM25_SNAPSHOT_VERSION}",
+                snapshot.version
+            )));
+        }
+
+        let scorable = |point_id| snapshot.point_to_doc.contains_key(point_id);
+        let real_count = snapshot.documents.keys().filter(|id| scorable(id)).count();
+        let real_total: u64 = snapshot
+            .documents
+            .iter()
+            .filter(|(id, _)| scorable(id))
+            .map(|(_, d)| u64::from(d.length))
+            .sum();
+
+        // `avgdl = total_doc_length / doc_count` must never divide by a positive
+        // count with a zero numerator (→ 0 → division by avgdl yields inf/NaN).
+        if real_count > 0 && real_total == 0 {
+            return Err(crate::Error::IndexCorrupted(
+                "BM25 snapshot: doc_count > 0 but total document length is 0".to_string(),
+            ));
+        }
+
+        snapshot.doc_count = real_count;
+        snapshot.total_doc_length = real_total;
+        Ok(())
     }
 }

--- a/crates/velesdb-core/src/index/bm25_persistence.rs
+++ b/crates/velesdb-core/src/index/bm25_persistence.rs
@@ -82,7 +82,7 @@ pub(crate) fn load_snapshot(dir: &Path) -> Result<Option<Bm25Index>> {
     };
     let snapshot: Bm25Snapshot = postcard::from_bytes(&bytes)
         .map_err(|e| Error::Index(format!("BM25 snapshot deserialize: {e}")))?;
-    Ok(Some(Bm25Index::from_snapshot(snapshot)))
+    Ok(Some(Bm25Index::from_snapshot(snapshot)?))
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/velesdb-core/src/index/bm25_tests.rs
+++ b/crates/velesdb-core/src/index/bm25_tests.rs
@@ -377,3 +377,84 @@ fn test_update_document_removes_old_terms() {
     assert_eq!(new_term_results.len(), 1);
     assert_eq!(new_term_results[0].0, 1);
 }
+
+// =========================================================================
+// #897 — snapshot validation on load (untrusted on-disk state)
+// =========================================================================
+
+#[test]
+fn test_from_snapshot_valid_round_trips() {
+    let index = Bm25Index::new();
+    index.add_document(1, "rust systems programming");
+    index.add_document(2, "python data science");
+
+    let snapshot = index.to_snapshot();
+    let restored = Bm25Index::from_snapshot(snapshot).expect("valid snapshot must load");
+
+    assert_eq!(restored.len(), 2);
+    assert_eq!(restored.search("rust", 10).len(), 1);
+    assert_eq!(restored.search("python", 10).len(), 1);
+}
+
+#[test]
+fn test_from_snapshot_rejects_version_mismatch() {
+    let index = Bm25Index::new();
+    index.add_document(1, "hello world");
+
+    let mut snapshot = index.to_snapshot();
+    snapshot.version = BM25_SNAPSHOT_VERSION + 1;
+
+    match Bm25Index::from_snapshot(snapshot) {
+        Err(e) => assert!(
+            e.to_string().contains("version mismatch"),
+            "expected version-mismatch error, got: {e}"
+        ),
+        Ok(_) => panic!("version mismatch must be rejected"),
+    }
+}
+
+#[test]
+fn test_from_snapshot_recomputes_inconsistent_counters() {
+    let index = Bm25Index::new();
+    index.add_document(1, "alpha beta gamma");
+    index.add_document(2, "delta epsilon");
+
+    // Tamper the counters: zero total_doc_length while doc_count stays positive.
+    // The pre-fix code installed these verbatim → avgdl = 0 → inf/NaN scores.
+    let mut snapshot = index.to_snapshot();
+    snapshot.doc_count = 999;
+    snapshot.total_doc_length = 0;
+
+    // documents are intact, so validation recomputes consistent counters.
+    let restored = Bm25Index::from_snapshot(snapshot).expect("counters recomputed from documents");
+    assert_eq!(restored.len(), 2, "doc_count recomputed from documents");
+
+    // Scores must be finite (no inf/NaN from a zero avgdl).
+    for (_, score) in restored.search("alpha", 10) {
+        assert!(score.is_finite(), "BM25 score must be finite");
+    }
+}
+
+/// #897 follow-up: `from_snapshot` must recompute `doc_count`/`avgdl` from the
+/// SCORABLE corpus (docs present in `point_to_doc`), not all of `documents`.
+/// A doc in `documents` but missing from `point_to_doc` is skipped during
+/// inverted-index reconstruction, so counting it would inflate `N`/`avgdl` and
+/// skew every IDF and length-normalization.
+#[test]
+fn test_from_snapshot_counts_only_scorable_corpus() {
+    let index = Bm25Index::new();
+    index.add_document(1, "rust programming language");
+    index.add_document(2, "python programming language");
+
+    let mut snap = index.to_snapshot();
+    assert_eq!(snap.documents.len(), 2);
+    // Divergence: point 2 stays in `documents` but is no longer scorable.
+    snap.point_to_doc.remove(&2);
+
+    let restored = Bm25Index::from_snapshot(snap).expect("valid snapshot");
+    assert_eq!(
+        restored.len(),
+        1,
+        "doc_count must reflect only the scorable corpus, not all documents"
+    );
+}

--- a/crates/velesdb-core/src/index/sparse/persistence.rs
+++ b/crates/velesdb-core/src/index/sparse/persistence.rs
@@ -345,6 +345,17 @@ fn load_compacted_index(
     let term_entries: Vec<TermEntry> = postcard::from_bytes(&terms_data)
         .map_err(|e| Error::SparseIndexError(format!("load terms deserialize: {e}")))?;
 
+    // Untrusted input: the decoded term dictionary length must match the count
+    // recorded in the metadata header. A mismatch means a corrupt or crafted
+    // file (e.g. a `term_count` that disagrees with the actual postings layout).
+    if term_entries.len() != meta.term_count as usize {
+        return Err(Error::SparseIndexError(format!(
+            "load terms: term count mismatch (meta {} != decoded {})",
+            meta.term_count,
+            term_entries.len()
+        )));
+    }
+
     let idx_path = dir.join(format!("{prefix}.idx"));
     let idx_data = std::fs::read(&idx_path)
         .map_err(|e| Error::SparseIndexError(format!("load idx read: {e}")))?;
@@ -366,18 +377,30 @@ fn build_postings_from_idx(
     let mut postings: FxHashMap<u32, (Vec<PostingEntry>, f32)> = FxHashMap::default();
 
     for te in term_entries {
-        #[allow(clippy::cast_possible_truncation)] // 32-bit target: file offsets won't exceed usize
-        let start = te.offset as usize;
-        let byte_count = (te.len as usize) * POSTING_DISK_SIZE;
-        let end = start + byte_count;
+        // Untrusted lengths/offsets: do ALL bound arithmetic in u64 so a crafted
+        // `offset`/`len` cannot truncate on a 32-bit target and slip past the
+        // check below (which also caps the `Vec::with_capacity` that follows).
+        let byte_count = u64::from(te.len)
+            .checked_mul(POSTING_DISK_SIZE as u64)
+            .ok_or_else(|| {
+                Error::SparseIndexError(format!("load idx: term {} len overflow", te.term_id))
+            })?;
+        let end = te.offset.checked_add(byte_count).ok_or_else(|| {
+            Error::SparseIndexError(format!("load idx: term {} range overflow", te.term_id))
+        })?;
 
-        if end > idx_data.len() {
+        if end > idx_data.len() as u64 {
             return Err(Error::SparseIndexError(format!(
-                "load idx: term {} offset {start}+{byte_count} exceeds file size {}",
+                "load idx: term {} offset {}+{byte_count} exceeds file size {}",
                 te.term_id,
+                te.offset,
                 idx_data.len()
             )));
         }
+        // Safe to narrow now: `end <= idx_data.len() <= usize::MAX`, so `offset` fits.
+        let start = usize::try_from(te.offset).map_err(|_| {
+            Error::SparseIndexError(format!("load idx: term {} offset too large", te.term_id))
+        })?;
 
         let mut entries = Vec::with_capacity(te.len as usize);
         let mut pos = start;
@@ -395,4 +418,31 @@ fn build_postings_from_idx(
     }
 
     Ok(postings)
+}
+
+#[cfg(test)]
+mod offset_bound_tests {
+    use super::*;
+
+    /// #897 follow-up: offset/len bound arithmetic runs in `u64`, so an offset
+    /// that would truncate to a small in-bounds value on a 32-bit target (here
+    /// `0x1_0000_0000`, which is `0` as `u32`) is still rejected against the real
+    /// file length, and a valid entry is accepted.
+    #[test]
+    fn build_postings_rejects_offset_past_file() {
+        let idx = vec![0u8; POSTING_DISK_SIZE]; // exactly one posting
+        let entry = |offset, len| TermEntry {
+            term_id: 1,
+            offset,
+            len,
+            max_weight: 1.0,
+        };
+
+        assert!(build_postings_from_idx(&idx, &[entry(0, 1)]).is_ok());
+        assert!(
+            build_postings_from_idx(&idx, &[entry(0x1_0000_0000, 1)]).is_err(),
+            "offset past file must be rejected via the u64 bound, not 32-bit-truncated"
+        );
+        assert!(build_postings_from_idx(&idx, &[entry(u64::MAX, u32::MAX)]).is_err());
+    }
 }

--- a/crates/velesdb-core/src/index/sparse/persistence_tests.rs
+++ b/crates/velesdb-core/src/index/sparse/persistence_tests.rs
@@ -267,3 +267,67 @@ fn test_compaction_truncates_wal() {
     // WAL should be truncated
     assert_eq!(std::fs::metadata(&wal_path).unwrap().len(), 0);
 }
+
+/// #897: a compacted `sparse.meta` whose `term_count` disagrees with the decoded
+/// term dictionary must be rejected rather than loaded (untrusted-input guard).
+#[test]
+fn test_load_rejects_term_count_mismatch() {
+    let dir = tempdir().unwrap();
+
+    let index = SparseInvertedIndex::new();
+    for i in 0..10u64 {
+        index.insert(i, &make_vector(vec![(i as u32 % 3, 1.0)]));
+    }
+    compact(dir.path(), &index).unwrap();
+
+    // Sanity: the valid index still loads.
+    assert!(load_from_disk(dir.path()).unwrap().is_some());
+
+    // Overwrite the metadata header with an inflated `term_count` that no longer
+    // matches the on-disk term dictionary.
+    let meta_path = dir.path().join("sparse.meta");
+    let meta = super::persistence::SparseMeta {
+        version: 1,
+        doc_count: 10,
+        term_count: u32::MAX,
+    };
+    std::fs::write(&meta_path, postcard::to_allocvec(&meta).unwrap()).unwrap();
+
+    match load_from_disk(dir.path()) {
+        Err(e) => assert!(
+            e.to_string().contains("term count mismatch"),
+            "expected term-count mismatch rejection, got: {e}"
+        ),
+        Ok(_) => panic!("expected term-count mismatch rejection, got Ok"),
+    }
+}
+
+/// #897: a sparse WAL upsert header declaring a huge `nnz` (here `u32::MAX`) but a
+/// truncated body must be skipped without panicking or pre-allocating gigabytes.
+#[test]
+fn test_wal_oversized_nnz_is_rejected() {
+    use std::io::Write;
+
+    let dir = tempdir().unwrap();
+    let wal_path = dir.path().join("sparse.wal");
+
+    // Hand-craft a single upsert entry: [total_len u32][op u8][point_id u64][nnz u32]
+    // with total_len covering only the 13-byte header (no pair payload), but nnz
+    // set to u32::MAX. The body is truncated relative to the declared nnz.
+    let total_len: u32 = 1 + 8 + 4;
+    let mut bytes = Vec::new();
+    bytes.extend_from_slice(&total_len.to_le_bytes());
+    bytes.push(0x01); // WAL_OP_UPSERT
+    bytes.extend_from_slice(&7u64.to_le_bytes()); // point_id
+    bytes.extend_from_slice(&u32::MAX.to_le_bytes()); // crafted nnz
+    {
+        let mut f = std::fs::File::create(&wal_path).unwrap();
+        f.write_all(&bytes).unwrap();
+    }
+
+    let index = SparseInvertedIndex::new();
+    // Must not panic, must not OOM, and the truncated entry is skipped (0 replayed).
+    let replayed = wal_replay(&wal_path, &index).unwrap();
+    assert_eq!(replayed, 0, "crafted oversized-nnz entry must be skipped");
+    assert_eq!(index.doc_count(), 0);
+}

--- a/crates/velesdb-core/src/index/sparse/persistence_wal.rs
+++ b/crates/velesdb-core/src/index/sparse/persistence_wal.rs
@@ -263,7 +263,16 @@ fn replay_upsert_entry(
     let nnz = read_le_u32(data, pos, "WAL entry corrupted: bad nnz bytes")? as usize;
     pos += 4;
 
-    if body_start + total_len < pos + nnz * 8 {
+    // Untrusted `nnz`: each pair is 8 bytes (u32 term_id + f32 weight). Compute
+    // in u64 with checked/saturating arithmetic so a crafted `nnz` cannot wrap on
+    // a 32-bit target and defeat the truncation guard below. `read_term_weight_pairs`
+    // then bounds its own `Vec::with_capacity` against the validated `nnz`.
+    let Some(payload_bytes) = (nnz as u64).checked_mul(8) else {
+        tracing::warn!("Sparse WAL upsert entry nnz overflow at offset {body_start}");
+        return Ok(None);
+    };
+    let entry_end = (body_start as u64).saturating_add(total_len as u64);
+    if entry_end < (pos as u64).saturating_add(payload_bytes) {
         tracing::warn!("Sparse WAL upsert entry truncated at offset {body_start}");
         return Ok(None);
     }
@@ -276,7 +285,10 @@ fn replay_upsert_entry(
 
 /// Reads `nnz` (`term_id`, weight) pairs from the data buffer.
 fn read_term_weight_pairs(data: &[u8], pos: &mut usize, nnz: usize) -> Result<Vec<(u32, f32)>> {
-    let mut pairs = Vec::with_capacity(nnz);
+    // Defensive cap: a pair is 8 bytes, so the data buffer can hold at most
+    // `data.len() / 8` pairs. Clamp the pre-allocation so an untrusted `nnz`
+    // cannot pre-reserve far beyond what the buffer could ever supply.
+    let mut pairs = Vec::with_capacity(nnz.min(data.len() / 8));
     for _ in 0..nnz {
         let idx = read_le_u32(data, *pos, "WAL entry corrupted: bad term-index bytes")?;
         *pos += 4;


### PR DESCRIPTION
**Closes #897.** Completes the #897 umbrella (HNSW/quant/storage parts in sibling PRs tagged Refs #897): sparse term/nnz caps with u64 offset bounds, agent header overflow + `recent(usize::MAX)` fix, BM25 snapshot version check + scorable-corpus counter recompute.

---
Part of the 2026-05-28 `velesdb-core` security/perf/OOM audit (`report/AUDIT-velesdb-core-2026-05-28.md`). Implemented by a specialist sub-agent, then adversarial review→fix rounds to 0 findings. Integration-branch gate: `cargo fmt --check`, workspace `clippy -D warnings -D clippy::pedantic`, full lib suite (4914 tests), recall contracts — all green. Every fix ships a regression test.