### PR TITLE
fix(graph): edge cascade on delete, debounced CSR, bounded traversal (#900, #905, #906)

### DIFF
--- a/crates/velesdb-core/src/collection/core/crud_read_delete.rs
+++ b/crates/velesdb-core/src/collection/core/crud_read_delete.rs
@@ -69,8 +69,52 @@ impl Collection {
         // Decrement histogram buckets BEFORE cache invalidation.
         self.update_histograms_on_delete(&old_payloads);
 
+        // Issue #900: deleting a node must cascade to its edges. Otherwise the
+        // edge store retains dangling edges pointing at (or from) a node that
+        // no longer exists, silently corrupting the graph. Gated to graph
+        // collections; no-op for vector / metadata-only collections.
+        self.cascade_delete_node_edges(ids);
+
         self.invalidate_caches_and_bump_generation();
         Ok(())
+    }
+
+    /// Removes every edge connected to each deleted node id (issue #900).
+    ///
+    /// Only graph collections own a populated edge store; for vector and
+    /// metadata-only collections this is a cheap config check followed by an
+    /// early return.
+    ///
+    /// # Lock ordering
+    ///
+    /// Runs **after** the storage / cache / label-index write locks acquired
+    /// in [`delete_vector_core_stores`](Self::delete_vector_core_stores) and
+    /// [`delete_metadata_only`](Self::delete_metadata_only) have been released
+    /// (those helpers drop their guards before returning). The edge store uses
+    /// its own internal lock chain (`edge_ids` registry → `shards[*]` in
+    /// ascending order, per `docs/CONCURRENCY_MODEL.md`), acquired here with no
+    /// other collection lock held — so taking them respects the documented
+    /// ascending lock order and cannot deadlock.
+    fn cascade_delete_node_edges(&self, ids: &[u64]) {
+        if self.config.read().graph_schema.is_none() {
+            return;
+        }
+        let mut removed_any = false;
+        for &id in ids {
+            // Both directions: `remove_node_edges` clears outgoing AND incoming
+            // edges so no dangling edge references the deleted node.
+            let before = self.edge_store.outgoing_degree(id) + self.edge_store.incoming_degree(id);
+            if before > 0 {
+                self.edge_store.remove_node_edges(id);
+                removed_any = true;
+            }
+        }
+        if removed_any {
+            // Bump write generation so cached query plans referencing the now
+            // removed edges are invalidated on the next query (CACHE-01).
+            self.write_generation
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        }
     }
 
     /// Collects current payloads for the given IDs (for histogram decrements on delete).

--- a/crates/velesdb-core/src/collection/core/graph_api.rs
+++ b/crates/velesdb-core/src/collection/core/graph_api.rs
@@ -14,7 +14,7 @@ use crate::storage::{PayloadStorage, VectorStorage};
 
 use super::graph_traversal_helpers::{
     bfs_pop, bfs_push, dfs_pop, dfs_push, expand_dfs_neighbors, reconstruct_path,
-    traverse_with_frontier, TraversalEntry, TraversalParams,
+    traverse_with_frontier, DfsFrontier, TraversalEntry, TraversalParams,
 };
 
 // Traversal helper functions are in graph_traversal_helpers.rs
@@ -329,23 +329,32 @@ impl Collection {
         source_id: u64,
         config: &TraversalConfig,
     ) -> Vec<TraversalResult> {
-        use crate::collection::graph::{concurrent_bfs_stream, StreamingConfig};
+        use crate::collection::graph::{concurrent_bfs_stream, StreamingConfig, MAX_VISITED_SIZE};
 
-        // Prefer the lock-free CSR snapshot path when available (Issue #491).
-        let snapshot = self.edge_store.get_csr_snapshot();
-        // Guard: only use the CSR path when the snapshot has been populated
-        // (node_count > 0). An empty snapshot means no edges have been
-        // ingested yet, so we fall through to the per-shard streaming BFS.
-        if snapshot.node_count() > 0 {
-            return crate::collection::graph::bfs_traverse_csr(&snapshot, source_id, config);
+        // Issue #905 debounce: only pay for the O(N+E) CSR rebuild when the
+        // snapshot is already authoritative (no pending writes) or enough
+        // writes have accumulated to make the rebuild worthwhile. While the
+        // snapshot is stale-but-below-threshold we serve from the
+        // authoritative per-shard streaming path instead of rebuilding on
+        // every read — correct results, no stale data, no rebuild.
+        if self.edge_store.csr_is_authoritative() || self.edge_store.csr_rebuild_due() {
+            // Prefer the lock-free CSR snapshot path when available (Issue #491).
+            let snapshot = self.edge_store.get_csr_snapshot();
+            // Guard: only use the CSR path when the snapshot has been populated
+            // (node_count > 0). An empty snapshot means no edges have been
+            // ingested yet, so we fall through to the per-shard streaming BFS.
+            if snapshot.node_count() > 0 {
+                return crate::collection::graph::bfs_traverse_csr(&snapshot, source_id, config);
+            }
         }
 
-        // Fallback: streaming BFS via per-shard locks
+        // Fallback: streaming BFS via per-shard locks (also the correctness
+        // path while the CSR rebuild is debounced).
         let streaming = StreamingConfig {
             max_depth: config.max_depth,
             rel_types: config.rel_types.clone(),
             limit: Some(config.limit),
-            max_visited_size: 100_000,
+            max_visited_size: MAX_VISITED_SIZE,
         };
         concurrent_bfs_stream(&self.edge_store, source_id, streaming)
             .filter(|result| result.depth >= config.min_depth)
@@ -373,6 +382,18 @@ impl Collection {
             if results.len() >= config.limit {
                 break;
             }
+            // Issue #906: bound the visited set / parent map. A highly-connected
+            // graph with a high limit/max_depth would otherwise grow these
+            // unboundedly (OOM). Consistent with the streaming iterators and
+            // `traverse_with_frontier`: stop and return the bounded result.
+            //
+            // NOTE: this pop-time guard alone is insufficient for DFS — a single
+            // high-out-degree hub fills `stack`/`parent_map` at PUSH time while
+            // `visited` stays tiny. `expand_dfs_neighbors` therefore also caps
+            // push-time growth at `MAX_VISITED_SIZE`.
+            if visited.len() >= crate::collection::graph::MAX_VISITED_SIZE {
+                break;
+            }
             if !visited.insert(node_id) {
                 continue;
             }
@@ -384,14 +405,18 @@ impl Collection {
                 }
             }
             if depth < config.max_depth {
+                let mut frontier = DfsFrontier {
+                    stack: &mut stack,
+                    parent_map: &mut parent_map,
+                    max_pending: crate::collection::graph::MAX_VISITED_SIZE,
+                };
                 expand_dfs_neighbors(
                     &self.edge_store,
                     node_id,
                     depth,
                     &rel_filter,
                     &visited,
-                    &mut stack,
-                    &mut parent_map,
+                    &mut frontier,
                 );
             }
         }

--- a/crates/velesdb-core/src/collection/core/graph_api_tests.rs
+++ b/crates/velesdb-core/src/collection/core/graph_api_tests.rs
@@ -475,4 +475,244 @@ mod tests {
         let (collection, _temp) = create_test_collection();
         assert!(collection.graph_schema().is_none());
     }
+
+    // =========================================================================
+    // Issue #900 — node delete cascades to edges
+    // =========================================================================
+
+    fn create_graph_test_collection() -> (Collection, TempDir) {
+        use crate::collection::graph::GraphSchema;
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let collection = Collection::create_graph_collection(
+            temp_dir.path().to_path_buf(),
+            "kg",
+            GraphSchema::schemaless(),
+            None,
+            DistanceMetric::Cosine,
+        )
+        .expect("Failed to create graph collection");
+        (collection, temp_dir)
+    }
+
+    #[test]
+    fn test_delete_node_cascades_to_outgoing_edge() {
+        // Insert nodes A=100, B=200 with an edge A -> B, delete A.
+        let (collection, _temp) = create_graph_test_collection();
+        collection
+            .store_node_payload(100, &serde_json::json!({"name": "A"}))
+            .unwrap();
+        collection
+            .store_node_payload(200, &serde_json::json!({"name": "B"}))
+            .unwrap();
+        collection
+            .add_edge(make_edge(1, 100, 200, "KNOWS"))
+            .unwrap();
+        assert_eq!(collection.edge_count(), 1);
+
+        collection.delete(&[100]).unwrap();
+
+        // The edge must be gone: no outgoing from A, no incoming to B, and the
+        // global edge count is zero (no dangling edge).
+        assert_eq!(collection.edge_count(), 0, "edge should be cascaded away");
+        assert!(collection.get_outgoing_edges(100).is_empty());
+        assert!(
+            collection.get_incoming_edges(200).is_empty(),
+            "B must have no incoming edge to the deleted node A"
+        );
+        // Traversal from A returns nothing.
+        let results = collection.traverse_bfs(100, 5, None, 100).unwrap();
+        assert!(
+            results.is_empty(),
+            "traversal from deleted node yields nothing"
+        );
+    }
+
+    #[test]
+    fn test_delete_node_cascades_both_directions() {
+        // A -> B and C -> B; deleting B must remove BOTH edges (outgoing from
+        // others into B, i.e. incoming on the deleted node).
+        let (collection, _temp) = create_graph_test_collection();
+        collection.add_edge(make_edge(1, 100, 200, "OUT")).unwrap();
+        collection.add_edge(make_edge(2, 300, 200, "IN")).unwrap();
+        // Also an outgoing edge from B so we cover both directions on the
+        // deleted node itself.
+        collection.add_edge(make_edge(3, 200, 400, "OUT")).unwrap();
+        assert_eq!(collection.edge_count(), 3);
+
+        collection.delete(&[200]).unwrap();
+
+        assert_eq!(
+            collection.edge_count(),
+            0,
+            "all edges touching the deleted node must be gone"
+        );
+        assert!(collection.get_outgoing_edges(100).is_empty());
+        assert!(collection.get_outgoing_edges(300).is_empty());
+        assert!(collection.get_outgoing_edges(200).is_empty());
+        assert!(collection.get_incoming_edges(400).is_empty());
+    }
+
+    #[test]
+    fn test_delete_node_does_not_touch_unrelated_edges() {
+        let (collection, _temp) = create_graph_test_collection();
+        collection.add_edge(make_edge(1, 100, 200, "A")).unwrap();
+        collection.add_edge(make_edge(2, 300, 400, "B")).unwrap();
+
+        collection.delete(&[100]).unwrap();
+
+        // Only the edge touching node 100 is removed.
+        assert_eq!(collection.edge_count(), 1);
+        assert_eq!(collection.get_outgoing_edges(300).len(), 1);
+    }
+
+    // =========================================================================
+    // Issue #906 — eager traversal is bounded (no unbounded visited/parent map)
+    // =========================================================================
+
+    /// Builds a dense, highly-connected cyclic graph: every node points to the
+    /// next `fanout` nodes (mod `n`), creating many cycles and a large frontier.
+    fn build_dense_cyclic_graph(collection: &Collection, n: u64, fanout: u64) {
+        let mut edge_id = 1u64;
+        for src in 0..n {
+            for step in 1..=fanout {
+                let dst = (src + step) % n;
+                collection
+                    .add_edge(make_edge(edge_id, src, dst, "E"))
+                    .unwrap();
+                edge_id += 1;
+            }
+        }
+    }
+
+    #[test]
+    fn test_eager_dfs_bounded_on_dense_cyclic_graph() {
+        // A dense cyclic graph with an absurdly high depth/limit must still
+        // terminate and stay bounded (visited cap prevents unbounded growth).
+        let (collection, _temp) = create_graph_test_collection();
+        build_dense_cyclic_graph(&collection, 200, 8);
+
+        let config = TraversalConfig {
+            max_depth: u32::MAX,
+            min_depth: 0,
+            rel_types: vec![],
+            limit: usize::MAX,
+        };
+        let results = collection.traverse_dfs_config(0, &config);
+
+        // Bounded by the number of distinct reachable nodes (199 targets, the
+        // source itself is not emitted) and by MAX_VISITED_SIZE. The key
+        // assertion is that the call terminates and never exceeds these bounds.
+        assert!(
+            results.len() <= crate::collection::graph::MAX_VISITED_SIZE,
+            "DFS result must be bounded by the visited cap"
+        );
+        assert!(
+            results.len() <= 199,
+            "cannot exceed distinct reachable nodes"
+        );
+        assert!(
+            !results.is_empty(),
+            "should still traverse the reachable graph"
+        );
+    }
+
+    #[test]
+    fn test_expand_dfs_neighbors_bounds_push_growth() {
+        // Regression (#906): a single high-out-degree hub must not push more
+        // than `max_pending` neighbors into the stack / parent_map at PUSH time.
+        // The pop-time `visited.len()` guard in `traverse_dfs_config` does NOT
+        // cover this, because DFS records neighbors before they are popped.
+        use crate::collection::core::graph_traversal_helpers::{expand_dfs_neighbors, DfsFrontier};
+        use rustc_hash::{FxHashMap, FxHashSet};
+
+        let (collection, _temp) = create_graph_test_collection();
+        // Hub node 0 with 5_000 distinct out-edges.
+        let fanout = 5_000u64;
+        for t in 1..=fanout {
+            collection
+                .add_edge(make_edge(t, 0, t, "E"))
+                .expect("add edge");
+        }
+
+        let rel_filter: FxHashSet<&str> = FxHashSet::default();
+        let visited: FxHashSet<u64> = FxHashSet::default();
+        let mut stack: Vec<(u64, u32)> = Vec::new();
+        let mut parent_map: FxHashMap<u64, (u64, u64)> = FxHashMap::default();
+        let max_pending = 10usize;
+
+        let mut frontier = DfsFrontier {
+            stack: &mut stack,
+            parent_map: &mut parent_map,
+            max_pending,
+        };
+        expand_dfs_neighbors(
+            collection.edge_store.as_ref(),
+            0,
+            0,
+            &rel_filter,
+            &visited,
+            &mut frontier,
+        );
+
+        assert!(
+            parent_map.len() <= max_pending,
+            "parent_map must be capped at max_pending, got {}",
+            parent_map.len()
+        );
+        assert!(
+            stack.len() <= max_pending,
+            "stack must be capped at max_pending, got {}",
+            stack.len()
+        );
+    }
+
+    #[test]
+    fn test_dfs_hub_stays_bounded_and_terminates() {
+        // Regression (#906): DFS from a single very-high-out-degree hub with
+        // min_depth past the graph's reach yields an empty result but must
+        // terminate quickly without OOM. A star graph (hub -> many leaves) has
+        // no depth-2 node, so with min_depth=2 the result is empty even though
+        // the hub queues thousands of neighbors at push time.
+        let (collection, _temp) = create_graph_test_collection();
+        let fanout = 20_000u64;
+        for t in 1..=fanout {
+            collection
+                .add_edge(make_edge(t, 0, t, "E"))
+                .expect("add edge");
+        }
+
+        let config = TraversalConfig {
+            max_depth: u32::MAX,
+            min_depth: 2,
+            rel_types: vec![],
+            limit: usize::MAX,
+        };
+        let results = collection.traverse_dfs_config(0, &config);
+        assert!(
+            results.is_empty(),
+            "star graph has no node at depth >= 2, result must be empty"
+        );
+    }
+
+    #[test]
+    fn test_eager_bfs_frontier_bounded_on_dense_cyclic_graph() {
+        // traverse_bfs (frontier helper) on a dense cyclic graph with high
+        // limit/depth must terminate and stay bounded.
+        let (collection, _temp) = create_graph_test_collection();
+        build_dense_cyclic_graph(&collection, 200, 8);
+
+        let results = collection
+            .traverse_bfs(0, u32::MAX, None, usize::MAX)
+            .unwrap();
+
+        assert!(
+            results.len() <= crate::collection::graph::MAX_VISITED_SIZE,
+            "BFS result must be bounded by the visited cap"
+        );
+        assert!(
+            results.len() <= 199,
+            "cannot exceed distinct reachable nodes"
+        );
+        assert!(!results.is_empty());
+    }
 }

--- a/crates/velesdb-core/src/collection/core/graph_traversal_helpers.rs
+++ b/crates/velesdb-core/src/collection/core/graph_traversal_helpers.rs
@@ -4,7 +4,7 @@
 
 use rustc_hash::{FxHashMap, FxHashSet};
 
-use crate::collection::graph::{ConcurrentEdgeStore, GraphEdge, TraversalResult};
+use crate::collection::graph::{ConcurrentEdgeStore, GraphEdge, TraversalResult, MAX_VISITED_SIZE};
 
 /// Returns `true` if the edge's label is accepted by the relationship filter.
 #[inline]
@@ -55,9 +55,31 @@ pub(super) fn collect_neighbor_expansions(
         .collect()
 }
 
+/// Mutable DFS push-side state plus its growth cap.
+///
+/// Bundles `stack`, `parent_map`, and `max_pending` so `expand_dfs_neighbors`
+/// stays under the argument-count limit while still exposing the cap for tests.
+pub(super) struct DfsFrontier<'a> {
+    pub(super) stack: &'a mut Vec<TraversalEntry>,
+    pub(super) parent_map: &'a mut FxHashMap<u64, (u64, u64)>,
+    /// Maximum number of pending (queued-but-unpopped) neighbors. Once
+    /// `parent_map` reaches this, no further neighbors are queued.
+    pub(super) max_pending: usize,
+}
+
 /// Pushes unvisited, rel-type-filtered neighbors onto the DFS stack.
 ///
 /// Records parent pointers for lazy path reconstruction (G4).
+///
+/// Issue #906: bounds **push-time** growth of `stack` / `parent_map`. The
+/// caller's pop-time `visited.len()` guard does not protect these structures,
+/// because DFS inserts every unvisited neighbor at PUSH time while `visited`
+/// only grows at POP time. A single high-out-degree hub would otherwise add
+/// millions of entries to `stack` / `parent_map` in one expansion before the
+/// pop-time guard ever fires. Once `parent_map` reaches `frontier.max_pending`
+/// we stop queuing new neighbors, capping peak memory regardless of out-degree.
+/// (BFS's `collect_neighbor_expansions` already grows `visited` + `parent_map`
+/// in lockstep, so it needs no such guard.)
 #[inline]
 pub(super) fn expand_dfs_neighbors(
     store: &ConcurrentEdgeStore,
@@ -65,19 +87,26 @@ pub(super) fn expand_dfs_neighbors(
     depth: u32,
     rel_filter: &FxHashSet<&str>,
     visited: &FxHashSet<u64>,
-    stack: &mut Vec<TraversalEntry>,
-    parent_map: &mut FxHashMap<u64, (u64, u64)>,
+    frontier: &mut DfsFrontier<'_>,
 ) {
     let outgoing = store.get_outgoing(node_id);
     for edge in outgoing.iter().rev() {
+        // `parent_map` is monotonic (one entry per ever-queued node, never
+        // removed), so its length is an upper bound on the live `stack` size;
+        // gating total queued-node memory on it bounds both.
+        if frontier.parent_map.len() >= frontier.max_pending {
+            break;
+        }
         if !rel_filter.is_empty() && !rel_filter.contains(edge.label()) {
             continue;
         }
         if visited.contains(&edge.target()) {
             continue;
         }
-        parent_map.insert(edge.target(), (node_id, edge.id()));
-        stack.push((edge.target(), depth + 1));
+        frontier
+            .parent_map
+            .insert(edge.target(), (node_id, edge.id()));
+        frontier.stack.push((edge.target(), depth + 1));
     }
 }
 
@@ -109,6 +138,13 @@ pub(super) fn traverse_with_frontier<F>(
 
     while let Some((node, depth)) = (pop_fn)(frontier) {
         if results.len() >= params.limit {
+            break;
+        }
+        // Issue #906: bound the visited set / parent map so a large or
+        // highly-connected graph cannot grow them without limit (OOM). Mirrors
+        // the streaming iterators' `max_visited_size` guard: stop expanding and
+        // return the bounded result accumulated so far.
+        if visited.len() >= MAX_VISITED_SIZE {
             break;
         }
         if depth >= params.max_depth {

--- a/crates/velesdb-core/src/collection/graph/edge_concurrent/mod.rs
+++ b/crates/velesdb-core/src/collection/graph/edge_concurrent/mod.rs
@@ -23,7 +23,18 @@ use arc_swap::ArcSwap;
 use parking_lot::RwLock;
 use rustc_hash::FxHashMap;
 use rustc_hash::FxHashSet;
-use std::sync::atomic::AtomicBool;
+use std::sync::atomic::{AtomicBool, AtomicU64};
+
+/// Number of pending edge mutations that may accumulate before the lazy CSR
+/// rebuild is forced (issue #905 debounce).
+///
+/// Below this threshold a dirty CSR snapshot is **not** rebuilt on read;
+/// callers fall back to the always-correct per-shard traversal path instead
+/// (see `traverse_bfs_config`). This amortises the O(N+E) clone-and-rebuild
+/// across many writes rather than paying it on every single read that follows
+/// a write. A pure write-count threshold (no wall-clock) keeps the behaviour
+/// deterministic for single-threaded tests.
+pub(crate) const CSR_REBUILD_WRITE_THRESHOLD: u64 = 64;
 
 /// Default number of shards for concurrent edge store.
 /// Increased from 64 to 256 for better scalability with 10M+ edges (EPIC-019 US-001).
@@ -80,6 +91,14 @@ pub struct ConcurrentEdgeStore {
     /// This eliminates O(N+E) rebuilds on every mutation, deferring the
     /// cost to the next read.
     csr_dirty: AtomicBool,
+    /// Number of edge mutations accumulated since the last CSR rebuild.
+    ///
+    /// Used to debounce the lazy rebuild (issue #905): the next reader only
+    /// pays for a full O(N+E) rebuild once this reaches
+    /// [`CSR_REBUILD_WRITE_THRESHOLD`]. While dirty-but-below-threshold the
+    /// CSR snapshot is intentionally stale and callers must consult the
+    /// authoritative per-shard data (see [`Self::csr_is_authoritative`]).
+    pending_writes: AtomicU64,
     /// Shared label table for interning edge labels during snapshot builds.
     label_table: RwLock<LabelTable>,
 }
@@ -118,6 +137,7 @@ impl ConcurrentEdgeStore {
             clustered_snapshot: RwLock::new(None),
             csr_snapshot: ArcSwap::from_pointee(SnapshotBuilder::empty()),
             csr_dirty: AtomicBool::new(false),
+            pending_writes: AtomicU64::new(0),
             label_table: RwLock::new(LabelTable::new()),
         })
     }
@@ -253,7 +273,11 @@ impl ConcurrentEdgeStore {
 
         if count > 0 {
             self.invalidate_snapshot();
-            self.rebuild_snapshot_best_effort();
+            // Count every inserted edge toward the CSR rebuild debounce
+            // (issue #905 follow-up). Reporting a flat `1` per batch would
+            // keep a bulk-loaded graph permanently below the rebuild
+            // threshold, so the CSR fast path would never engage.
+            self.record_pending_writes(count as u64);
         }
         count
     }

--- a/crates/velesdb-core/src/collection/graph/edge_concurrent/persistence.rs
+++ b/crates/velesdb-core/src/collection/graph/edge_concurrent/persistence.rs
@@ -9,17 +9,29 @@ impl ConcurrentEdgeStore {
     /// Builds a `ConcurrentEdgeStore` from a persisted `EdgeStore`.
     ///
     /// Re-distributes edges across shards based on source node ID.
+    ///
+    /// Issue #905: uses [`add_edges_batch`](Self::add_edges_batch) (one
+    /// `edge_ids` write-lock acquisition for the whole set, snapshot
+    /// invalidated once) instead of a per-edge `add_edge` loop (one lock
+    /// cycle + one snapshot-dirty flip per edge). The single
+    /// [`build_read_snapshot`](Self::build_read_snapshot) at the end performs
+    /// exactly one O(N+E) CSR build for the whole reconstruction.
     #[must_use]
     pub fn from_edge_store(store: &EdgeStore) -> Self {
-        let edges = store.all_edges();
+        let edges: Vec<_> = store.all_edges().into_iter().cloned().collect();
         let concurrent = Self::with_estimated_edges(edges.len());
 
-        for edge in edges {
-            if concurrent.add_edge(edge.clone()).is_err() {
-                #[cfg(debug_assertions)]
-                eprintln!("[velesdb] WARNING: skipped duplicate edge during CES reconstruction");
-            }
+        let expected = edges.len();
+        let added = concurrent.add_edges_batch(edges);
+        #[cfg(debug_assertions)]
+        if added != expected {
+            eprintln!(
+                "[velesdb] WARNING: skipped {} duplicate edge(s) during CES reconstruction",
+                expected - added
+            );
         }
+        #[cfg(not(debug_assertions))]
+        let _ = (expected, added);
 
         concurrent.build_read_snapshot();
         concurrent

--- a/crates/velesdb-core/src/collection/graph/edge_concurrent/query.rs
+++ b/crates/velesdb-core/src/collection/graph/edge_concurrent/query.rs
@@ -258,12 +258,28 @@ impl ConcurrentEdgeStore {
     /// Uses `swap(false, AcqRel)` to atomically clear the flag and check
     /// the previous value. Only one thread performs the rebuild; concurrent
     /// readers see the stale-but-valid snapshot until the swap completes.
+    ///
+    /// This is the **correctness-first** entry point used by CSR consumers
+    /// that have no per-shard fallback (`traverse_bfs_csr`,
+    /// `traverse_bfs_filtered`, `label_count`, `get_csr_snapshot`). It always
+    /// rebuilds when dirty so the returned snapshot reflects every prior
+    /// write. The write-count debounce (issue #905) is applied one level up in
+    /// `traverse_bfs_config`, which prefers the per-shard path while the CSR
+    /// is stale and only reaches this method once a rebuild is actually wanted.
     #[inline]
     fn ensure_csr_fresh(&self) {
         if self
             .csr_dirty
             .swap(false, std::sync::atomic::Ordering::AcqRel)
         {
+            // Snapshot the write count *before* reading the shards. The
+            // rebuild below reflects exactly these writes; any writer that
+            // bumps the counter while we walk the shards must stay counted so
+            // the next reader still rebuilds (issue #905 follow-up — a blind
+            // `store(0)` after the rebuild would silently drop that increment).
+            let observed = self
+                .pending_writes
+                .load(std::sync::atomic::Ordering::Acquire);
             #[allow(unused_variables)]
             if let Err(e) = self.rebuild_snapshot() {
                 // Restore dirty flag so the next caller retries the rebuild.
@@ -271,8 +287,45 @@ impl ConcurrentEdgeStore {
                     .store(true, std::sync::atomic::Ordering::Release);
                 #[cfg(debug_assertions)]
                 eprintln!("[velesdb] WARNING: lazy CSR snapshot rebuild failed: {e}");
+                return;
             }
+            // Rebuild succeeded: subtract only the writes we accounted for, so
+            // a concurrent `fetch_add` between the load above and here is
+            // preserved instead of being clobbered to zero. Saturating at zero
+            // so two concurrent reader-triggered rebuilds cannot underflow the
+            // counter — a plain `fetch_sub` could wrap to ~`u64::MAX` and wedge
+            // `csr_rebuild_due` permanently true (forcing a rebuild on every read).
+            let _ = self.pending_writes.fetch_update(
+                std::sync::atomic::Ordering::AcqRel,
+                std::sync::atomic::Ordering::Acquire,
+                |cur| Some(cur.saturating_sub(observed)),
+            );
         }
+    }
+
+    /// Returns `true` when the CSR snapshot reflects every committed write,
+    /// i.e. it is safe to traverse without first rebuilding.
+    ///
+    /// A clean snapshot (no pending writes) is always authoritative. When the
+    /// snapshot is dirty this returns `false` **without** triggering a
+    /// rebuild, so callers with an authoritative per-shard fallback (issue
+    /// #905 debounce) can avoid the O(N+E) rebuild on every read after a
+    /// write.
+    #[inline]
+    #[must_use]
+    pub(crate) fn csr_is_authoritative(&self) -> bool {
+        !self.csr_dirty.load(std::sync::atomic::Ordering::Acquire)
+    }
+
+    /// Returns `true` when enough writes have accumulated that the next CSR
+    /// read should pay for a rebuild rather than continue serving from the
+    /// per-shard fallback (issue #905 debounce threshold reached).
+    #[inline]
+    #[must_use]
+    pub(crate) fn csr_rebuild_due(&self) -> bool {
+        self.pending_writes
+            .load(std::sync::atomic::Ordering::Acquire)
+            >= super::CSR_REBUILD_WRITE_THRESHOLD
     }
 
     /// Returns the current CSR snapshot (lock-free read).

--- a/crates/velesdb-core/src/collection/graph/edge_concurrent/snapshot.rs
+++ b/crates/velesdb-core/src/collection/graph/edge_concurrent/snapshot.rs
@@ -30,11 +30,31 @@ impl ConcurrentEdgeStore {
 
     /// Best-effort CSR snapshot rebuild after a mutation.
     ///
-    /// Sets the `csr_dirty` flag so the next read triggers a rebuild.
-    /// This eliminates the O(N+E) rebuild on every `add_edge`/`remove_edge`,
-    /// deferring the cost to the next read.
+    /// Sets the `csr_dirty` flag and increments the pending-write counter so
+    /// the lazy rebuild can be debounced (issue #905). The actual O(N+E)
+    /// rebuild is deferred until either a reader observes
+    /// [`CSR_REBUILD_WRITE_THRESHOLD`](super::CSR_REBUILD_WRITE_THRESHOLD)
+    /// accumulated writes, or a reader that has no per-shard fallback forces
+    /// it. Until then readers fall back to the authoritative per-shard data.
     #[inline]
     pub(super) fn rebuild_snapshot_best_effort(&self) {
+        self.record_pending_writes(1);
+    }
+
+    /// Records `count` accumulated edge mutations toward the CSR rebuild
+    /// debounce threshold and marks the snapshot dirty.
+    ///
+    /// Batch writers (`add_edges_batch`) must report the actual number of
+    /// edges inserted (issue #905 follow-up): reporting a flat `1` per batch
+    /// would let a bulk-loaded graph stay permanently below
+    /// [`CSR_REBUILD_WRITE_THRESHOLD`](super::CSR_REBUILD_WRITE_THRESHOLD),
+    /// so the CSR fast path would never engage.
+    #[inline]
+    pub(super) fn record_pending_writes(&self, count: u64) {
+        if count == 0 {
+            return;
+        }
+        self.pending_writes.fetch_add(count, Ordering::AcqRel);
         self.csr_dirty.store(true, Ordering::Release);
     }
 
@@ -134,6 +154,13 @@ impl ConcurrentEdgeStore {
 
         // Also rebuild the lock-free CSR snapshot.
         let _ = self.rebuild_snapshot();
+
+        // The freshly built snapshot reflects all edges, so clear the dirty
+        // flag and reset the debounce counter (issue #905). Without this the
+        // next reader would needlessly rebuild again even though the snapshot
+        // is already authoritative.
+        self.pending_writes.store(0, Ordering::Release);
+        self.csr_dirty.store(false, Ordering::Release);
     }
 
     /// Returns `true` if a CSR read snapshot is currently available.

--- a/crates/velesdb-core/src/collection/graph/edge_concurrent_tests.rs
+++ b/crates/velesdb-core/src/collection/graph/edge_concurrent_tests.rs
@@ -1262,3 +1262,175 @@ fn test_from_edge_store_builds_snapshot() {
     neighbors.sort_unstable();
     assert_eq!(neighbors, vec![20, 30]);
 }
+
+// =============================================================================
+// Issue #905 — CSR rebuild debounce + from_edge_store round-trip correctness
+// =============================================================================
+
+/// `from_edge_store()` round-trips edges (including cross-shard) correctly and
+/// leaves the store with an authoritative, fresh CSR snapshot.
+#[test]
+fn test_from_edge_store_roundtrip_correctness() {
+    use super::edge::EdgeStore;
+
+    let mut es = EdgeStore::new();
+    // Mix of same-shard and cross-shard edges (shard = node_id % 256).
+    es.add_edge(GraphEdge::new(1, 1, 2, "R").expect("valid"))
+        .expect("add");
+    es.add_edge(GraphEdge::new(2, 1, 257, "R").expect("valid")) // cross-shard target
+        .expect("add");
+    es.add_edge(GraphEdge::new(3, 2, 3, "R").expect("valid"))
+        .expect("add");
+
+    let store = ConcurrentEdgeStore::from_edge_store(&es);
+
+    // Edge count and connectivity must match the source store exactly.
+    assert_eq!(store.edge_count(), 3, "all edges round-tripped");
+    let mut n1 = store.get_neighbors(1);
+    n1.sort_unstable();
+    assert_eq!(n1, vec![2, 257]);
+    assert_eq!(store.get_neighbors(2), vec![3]);
+
+    // After a full rebuild the snapshot must be authoritative (no pending
+    // debounce that would force a needless rebuild on the next read).
+    assert!(
+        store.csr_is_authoritative(),
+        "freshly reconstructed store must have an authoritative CSR snapshot"
+    );
+}
+
+/// A single write does not mark the CSR authoritative, but the per-shard read
+/// path still returns the write's effect immediately (no stale data).
+#[test]
+fn test_csr_debounce_keeps_reads_correct_without_rebuild() {
+    let store = ConcurrentEdgeStore::new();
+    // Build an authoritative snapshot first.
+    store
+        .add_edge(GraphEdge::new(1, 1, 2, "R").expect("valid"))
+        .expect("add");
+    store.build_read_snapshot();
+    assert!(store.csr_is_authoritative());
+
+    // A handful of writes below the debounce threshold must NOT make the CSR
+    // authoritative again (i.e. it is intentionally not rebuilt on every
+    // write), proving the rebuild is debounced rather than eager.
+    for id in 2..10u64 {
+        store
+            .add_edge(GraphEdge::new(id, 1, id + 100, "R").expect("valid"))
+            .expect("add");
+    }
+    assert!(
+        !store.csr_is_authoritative(),
+        "writes below threshold must leave the CSR stale (debounced, not rebuilt)"
+    );
+    assert!(
+        !store.csr_rebuild_due(),
+        "a handful of writes must not yet trigger a forced rebuild"
+    );
+
+    // ...yet the authoritative per-shard read path reflects every write.
+    let mut neighbors = store.get_outgoing(1);
+    neighbors.sort_by_key(super::edge::GraphEdge::target);
+    let targets: Vec<u64> = neighbors.iter().map(GraphEdge::target).collect();
+    assert!(targets.contains(&2), "original edge still visible");
+    assert!(
+        targets.contains(&102),
+        "new edge visible without a CSR rebuild"
+    );
+    assert_eq!(
+        store.edge_count(),
+        9,
+        "all writes are reflected in the live store"
+    );
+}
+
+/// Crossing the write threshold makes the next CSR read rebuild (and become
+/// authoritative again), and the rebuilt snapshot reflects every write.
+#[test]
+fn test_csr_debounce_rebuilds_after_threshold() {
+    use super::traversal::TraversalConfig;
+
+    let store = ConcurrentEdgeStore::new();
+    // Exceed the debounce threshold with a chain 0->1->2->...
+    let total = super::edge_concurrent::CSR_REBUILD_WRITE_THRESHOLD + 5;
+    for i in 0..total {
+        store
+            .add_edge(GraphEdge::new(i + 1, i, i + 1, "R").expect("valid"))
+            .expect("add");
+    }
+    assert!(
+        store.csr_rebuild_due(),
+        "writes past the threshold must mark a rebuild as due"
+    );
+
+    // A CSR traversal forces the (single) rebuild and returns correct results.
+    let config = TraversalConfig {
+        max_depth: 3,
+        min_depth: 1,
+        rel_types: vec![],
+        limit: 100,
+    };
+    let results = store.traverse_bfs_csr(0, &config);
+    let targets: std::collections::HashSet<u64> = results.iter().map(|r| r.target_id).collect();
+    assert!(
+        targets.contains(&1),
+        "1-hop neighbor reachable after rebuild"
+    );
+    assert!(
+        targets.contains(&2),
+        "2-hop neighbor reachable after rebuild"
+    );
+
+    // After the forced rebuild the snapshot is authoritative again.
+    assert!(
+        store.csr_is_authoritative(),
+        "CSR snapshot is authoritative after the debounced rebuild"
+    );
+}
+
+#[test]
+fn test_add_edges_batch_counts_each_edge_toward_csr_debounce() {
+    // Regression (#905 follow-up): `add_edges_batch` must count every inserted
+    // edge toward the rebuild debounce, not a flat `1` per batch. With the old
+    // behavior a single bulk load stayed permanently below the threshold so the
+    // CSR fast path never engaged (permanent slow per-shard reads).
+    use super::traversal::TraversalConfig;
+
+    let store = ConcurrentEdgeStore::new();
+    let total = super::edge_concurrent::CSR_REBUILD_WRITE_THRESHOLD + 5;
+
+    // A *single* batch of >= threshold distinct edges (chain 0->1->2->...).
+    let edges: Vec<GraphEdge> = (0..total)
+        .map(|i| GraphEdge::new(i + 1, i, i + 1, "R").expect("valid"))
+        .collect();
+    let inserted = store.add_edges_batch(edges);
+    assert_eq!(inserted as u64, total, "all distinct edges inserted");
+
+    assert!(
+        store.csr_rebuild_due(),
+        "a single batch of >= threshold edges must mark a CSR rebuild as due"
+    );
+
+    // The subsequent CSR read engages the fast path: it rebuilds once, the
+    // snapshot becomes authoritative, and neighbors are correct.
+    let config = TraversalConfig {
+        max_depth: 3,
+        min_depth: 1,
+        rel_types: vec![],
+        limit: 100,
+    };
+    let results = store.traverse_bfs_csr(0, &config);
+    let targets: std::collections::HashSet<u64> = results.iter().map(|r| r.target_id).collect();
+    assert!(
+        targets.contains(&1),
+        "1-hop neighbor reachable after rebuild"
+    );
+    assert!(
+        targets.contains(&2),
+        "2-hop neighbor reachable after rebuild"
+    );
+    assert!(
+        store.csr_is_authoritative(),
+        "CSR snapshot is authoritative after the batch-triggered rebuild"
+    );
+}

--- a/crates/velesdb-core/src/collection/graph/mod.rs
+++ b/crates/velesdb-core/src/collection/graph/mod.rs
@@ -98,6 +98,7 @@ pub use range_index::RangeIndex;
 pub use schema::{EdgeType, GraphSchema, NodeType, ValueType};
 pub use streaming::{
     bfs_stream, concurrent_bfs_stream, BfsIterator, ConcurrentBfsIterator, StreamingConfig,
+    MAX_VISITED_SIZE,
 };
 pub use traversal::{TraversalConfig, TraversalPath, TraversalResult, DEFAULT_MAX_DEPTH};
 pub use traversal_bidir::bfs_traverse_both;

--- a/crates/velesdb-core/src/collection/graph/streaming.rs
+++ b/crates/velesdb-core/src/collection/graph/streaming.rs
@@ -9,6 +9,14 @@ use super::{EdgeStore, TraversalResult, DEFAULT_MAX_DEPTH};
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::collections::VecDeque;
 
+/// Default upper bound on the visited-set / parent-map size for a single
+/// traversal (issue #906).
+///
+/// ~800 KB for an `FxHashSet<u64>` of this size. The streaming iterators
+/// switch to approximate mode at this bound; the eager BFS/DFS helpers stop
+/// expanding and return the bounded result they have accumulated so far.
+pub const MAX_VISITED_SIZE: usize = 100_000;
+
 /// Configuration for streaming traversal.
 ///
 /// Unlike `TraversalConfig`, this is optimized for memory-bounded streaming
@@ -32,7 +40,7 @@ impl Default for StreamingConfig {
         Self {
             max_depth: DEFAULT_MAX_DEPTH,
             limit: None,
-            max_visited_size: 100_000, // ~800KB for FxHashSet<u64>
+            max_visited_size: MAX_VISITED_SIZE, // ~800KB for FxHashSet<u64>
             rel_types: Vec::new(),
         }
     }


### PR DESCRIPTION
**Closes #900, Closes #905, Closes #906.** Node-delete cascades to edges; CSR rebuild debounced by write-count (live-store fallback while dirty — never stale); eager DFS/BFS bounded at push time.

---
Part of the 2026-05-28 `velesdb-core` security/perf/OOM audit (`report/AUDIT-velesdb-core-2026-05-28.md`). Implemented by a specialist sub-agent, then adversarial review→fix rounds to 0 findings. Integration-branch gate: `cargo fmt --check`, workspace `clippy -D warnings -D clippy::pedantic`, full lib suite (4914 tests), recall contracts — all green. Every fix ships a regression test.