### PR TITLE
fix(query): bound materialization + collision-safe/lock-light caches (#901, #904, #902, #903)

### DIFF
--- a/crates/velesdb-core/src/cache/plan_cache.rs
+++ b/crates/velesdb-core/src/cache/plan_cache.rs
@@ -15,25 +15,45 @@ use crate::velesql::QueryPlan;
 
 /// Deterministic cache key for compiled query plans.
 ///
-/// Two keys are equal iff the query text is identical AND the database state
-/// (schema version + per-collection write generations) has not changed.
+/// Two keys are equal iff the **canonical query text is byte-for-byte
+/// identical** AND the database state (schema version + per-collection write /
+/// analyze generations) has not changed.
 ///
 /// `collection_generations` must be sorted by collection name before
 /// insertion for deterministic hashing.
 ///
-/// # Correctness invariant (CACHE-01)
+/// # Correctness invariant (CACHE-01, issue #902)
 ///
-/// Cache correctness depends on `query_hash` capturing **all** collection
-/// names referenced by the query (base table + JOIN targets). If two
-/// structurally different queries happened to hash to the same value the cache
-/// would serve a stale plan. This is prevented by using the full canonical
-/// serialization of the `Query` AST — not just the collection name — as the
-/// hash input (see `Database::build_plan_key`). The `collection_generations`
-/// vector is then ordered by collection name so that the same set of
-/// collections always produces the same key regardless of JOIN ordering.
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+/// `query_hash` is a 64-bit `FxHash` of the canonical query text. `FxHash` is a
+/// fast, **non-cryptographic** hash: distinct queries can be engineered to
+/// collide on the same 64-bit value. If equality were decided on `query_hash`
+/// alone, a colliding query would be treated as equal to an unrelated cached
+/// query and the cache could return **another query's compiled plan** (wrong
+/// results).
+///
+/// To make this impossible, `PlanKey` stores the canonical `query_text` and the
+/// hand-written [`PartialEq`]/[`Eq`] impls compare the full text (not the
+/// hash). `query_hash` is retained purely as a [`Hash`] accelerator so that the
+/// `DashMap`/`LruCache` buckets stay cheap to compute; the `Hash` impl
+/// deliberately feeds only `query_hash` (plus the generation fields) into the
+/// hasher rather than re-hashing the whole string on every lookup. This mirrors
+/// the safe pattern used by the `VelesQL` parse cache (`velesql/cache.rs`),
+/// which re-checks query-text equality on every lookup.
+///
+/// `Hash`/`Eq` consistency: equal keys have identical `query_text`, and
+/// `query_hash` is a pure function of `query_text`, so equal keys always hash
+/// identically — the `Hash`/`Eq` contract holds.
+#[derive(Clone, Debug)]
 pub struct PlanKey {
-    /// `FxHash` of canonical query text.
+    /// Canonical serialization of the query AST (see `Database::build_plan_key`).
+    ///
+    /// This is the authoritative query-identity field: equality is decided on
+    /// this string, never on `query_hash` alone. Stored behind `Arc<str>` so
+    /// cloning a `PlanKey` (done on every cache insert / promotion) is a cheap
+    /// refcount bump rather than a full string copy.
+    pub query_text: Arc<str>,
+    /// `FxHash` of `query_text`. Hash accelerator only — **not** an identity
+    /// field. Collisions are resolved by the `query_text` comparison in `Eq`.
     pub query_hash: u64,
     /// Monotonic counter incremented on every DDL operation.
     pub schema_version: u64,
@@ -47,6 +67,33 @@ pub struct PlanKey {
     /// `write_generation` — still invalidates plans whose cost estimates
     /// were derived from pre-analyze heuristics.
     pub analyze_generations: SmallVec<[u64; 4]>,
+}
+
+impl PartialEq for PlanKey {
+    /// Equality compares the **canonical query text** (collision-safe), never
+    /// `query_hash` alone (issue #902). The generation fields gate cache
+    /// invalidation.
+    fn eq(&self, other: &Self) -> bool {
+        self.schema_version == other.schema_version
+            && self.collection_generations == other.collection_generations
+            && self.analyze_generations == other.analyze_generations
+            && self.query_text == other.query_text
+    }
+}
+
+impl Eq for PlanKey {}
+
+impl std::hash::Hash for PlanKey {
+    /// Feeds only the cheap `query_hash` accelerator (plus generation fields)
+    /// into the hasher — never the full `query_text` — so lookups stay fast.
+    /// Equal keys hash identically because `query_hash` is a pure function of
+    /// `query_text`.
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.query_hash.hash(state);
+        self.schema_version.hash(state);
+        self.collection_generations.hash(state);
+        self.analyze_generations.hash(state);
+    }
 }
 
 /// A compiled (cached) query execution plan.

--- a/crates/velesdb-core/src/cache/plan_cache_tests.rs
+++ b/crates/velesdb-core/src/cache/plan_cache_tests.rs
@@ -49,12 +49,14 @@ fn dummy_compiled_plan() -> Arc<CompiledPlan> {
 #[test]
 fn plan_key_equal_fields_are_equal() {
     let a = PlanKey {
+        query_text: "SELECT * FROM a".into(),
         query_hash: 42,
         schema_version: 1,
         collection_generations: smallvec![10, 20],
         analyze_generations: smallvec::SmallVec::new(),
     };
     let b = PlanKey {
+        query_text: "SELECT * FROM a".into(),
         query_hash: 42,
         schema_version: 1,
         collection_generations: smallvec![10, 20],
@@ -71,12 +73,14 @@ fn plan_key_equal_fields_are_equal() {
 #[test]
 fn plan_key_different_generations_are_not_equal() {
     let a = PlanKey {
+        query_text: "SELECT * FROM a".into(),
         query_hash: 42,
         schema_version: 1,
         collection_generations: smallvec![10, 20],
         analyze_generations: smallvec::SmallVec::new(),
     };
     let b = PlanKey {
+        query_text: "SELECT * FROM a".into(),
         query_hash: 42,
         schema_version: 1,
         collection_generations: smallvec![10, 21],
@@ -85,12 +89,63 @@ fn plan_key_different_generations_are_not_equal() {
     assert_ne!(a, b);
 }
 
+/// Issue #902 regression: two distinct queries forced to share the same
+/// `query_hash` (the FxHash accelerator) — but with different canonical
+/// `query_text` — must **not** be treated as the same cache key. Looking up
+/// query B must never return query A's compiled plan.
+///
+/// This is the wrong-plan scenario: `FxHash` is non-cryptographic, so 64-bit
+/// collisions are constructible. The fix decides equality on `query_text`, so a
+/// collision is a guaranteed cache miss, never a wrong hit.
+#[test]
+fn plan_key_hash_collision_does_not_alias_distinct_queries() {
+    // Same query_hash + same generations, different canonical text.
+    let key_a = PlanKey {
+        query_text: "SELECT * FROM users".into(),
+        query_hash: 0xDEAD_BEEF,
+        schema_version: 1,
+        collection_generations: smallvec![7],
+        analyze_generations: smallvec::SmallVec::new(),
+    };
+    let key_b = PlanKey {
+        query_text: "DELETE FROM users".into(),
+        query_hash: 0xDEAD_BEEF, // forced collision
+        schema_version: 1,
+        collection_generations: smallvec![7],
+        analyze_generations: smallvec::SmallVec::new(),
+    };
+
+    // Keys must compare unequal despite the identical hash accelerator.
+    assert_ne!(key_a, key_b, "colliding hash must not make keys equal");
+
+    let cache = CompiledPlanCache::new(100, 1_000);
+    let plan_a = dummy_compiled_plan();
+    cache.insert(key_a.clone(), Arc::clone(&plan_a));
+
+    // Lookup for query B (the colliding key) must MISS — never return A's plan.
+    assert!(
+        cache.get(&key_b).is_none(),
+        "colliding query B must not retrieve query A's cached plan (issue #902)"
+    );
+    assert!(
+        !cache.contains(&key_b),
+        "contains() must also reject the collision"
+    );
+
+    // Sanity: query A still resolves to its own plan.
+    let got_a = cache
+        .get(&key_a)
+        .expect("query A must still hit its own plan");
+    assert_eq!(got_a.plan, plan_a.plan);
+}
+
 // ---- CompiledPlanCache insert + get ----
 
 #[test]
 fn plan_cache_insert_and_get() {
     let cache = CompiledPlanCache::new(100, 1_000);
     let key = PlanKey {
+        query_text: "SELECT 1".into(),
         query_hash: 1,
         schema_version: 0,
         collection_generations: smallvec![0],
@@ -108,6 +163,7 @@ fn plan_cache_insert_and_get() {
 fn plan_cache_miss_on_different_key() {
     let cache = CompiledPlanCache::new(100, 1_000);
     let key = PlanKey {
+        query_text: "SELECT 1".into(),
         query_hash: 1,
         schema_version: 0,
         collection_generations: smallvec![0],
@@ -116,6 +172,7 @@ fn plan_cache_miss_on_different_key() {
     cache.insert(key, dummy_compiled_plan());
 
     let other = PlanKey {
+        query_text: "SELECT 2".into(),
         query_hash: 2,
         schema_version: 0,
         collection_generations: smallvec![0],
@@ -310,6 +367,7 @@ fn write_generation_accessible_from_database() {
 fn plan_cache_reuse_count_increments() {
     let cache = CompiledPlanCache::new(100, 1_000);
     let key = PlanKey {
+        query_text: "SELECT 99".into(),
         query_hash: 99,
         schema_version: 0,
         collection_generations: smallvec![0],

--- a/crates/velesdb-core/src/collection/search/query/aggregation/having.rs
+++ b/crates/velesdb-core/src/collection/search/query/aggregation/having.rs
@@ -20,6 +20,18 @@ use crate::velesql::{
 };
 use std::collections::HashMap;
 
+/// Default maximum number of groups allowed when the query does not specify one
+/// (memory protection).
+pub(super) const DEFAULT_MAX_GROUPS: usize = 10_000;
+
+/// Server-side hard ceiling on the number of GROUP BY groups (#903).
+///
+/// This is a SERVER-controlled constant. A query may use `WITH (max_groups=N)`
+/// to *lower* its group budget, but `N` is always clamped down to this ceiling
+/// so an untrusted query cannot inflate the per-query memory bound. Bounding
+/// distinct groups is the DoS guard for GROUP BY aggregation.
+pub(super) const SERVER_MAX_GROUPS_CEILING: usize = 1_000_000;
+
 impl Collection {
     /// BUG-3 FIX: Sort aggregation results by ORDER BY clause.
     pub(crate) fn sort_aggregation_results(
@@ -176,12 +188,13 @@ impl Collection {
     /// Extract max_groups limit from WITH clause (EPIC-040 US-004).
     /// Supports both `max_groups` and `group_limit` option names.
     /// Returns `DEFAULT_MAX_GROUPS` if not specified.
+    ///
+    /// #903 (DoS hardening): the value supplied by the (untrusted) query is
+    /// **clamped down** to [`SERVER_MAX_GROUPS_CEILING`]. The query can lower
+    /// the limit but can never raise the server-side memory ceiling above it.
     pub(super) fn extract_max_groups_limit(
         with_clause: Option<&crate::velesql::WithClause>,
     ) -> usize {
-        /// Default maximum number of groups allowed (memory protection).
-        const DEFAULT_MAX_GROUPS: usize = 10000;
-
         let Some(with) = with_clause else {
             return DEFAULT_MAX_GROUPS;
         };
@@ -190,9 +203,10 @@ impl Collection {
             if opt.key == "max_groups" || opt.key == "group_limit" {
                 // Try to parse value as integer
                 if let crate::velesql::WithValue::Integer(n) = &opt.value {
-                    // Ensure positive and reasonable limit
+                    // Ensure positive, then clamp to the server-side ceiling.
+                    // The query CANNOT raise the limit above SERVER_MAX_GROUPS_CEILING.
                     let limit = (*n).max(1) as usize;
-                    return limit.min(1_000_000); // Hard cap at 1M groups
+                    return limit.min(SERVER_MAX_GROUPS_CEILING);
                 }
             }
         }

--- a/crates/velesdb-core/src/collection/search/query/aggregation/having_tests.rs
+++ b/crates/velesdb-core/src/collection/search/query/aggregation/having_tests.rs
@@ -1,5 +1,6 @@
 #![cfg(all(test, feature = "persistence"))]
 
+use super::having::{DEFAULT_MAX_GROUPS, SERVER_MAX_GROUPS_CEILING};
 use super::*;
 use crate::velesql::{AggregateArg, AggregateFunction, AggregateType, OrderByExpr, SelectOrderBy};
 
@@ -33,4 +34,43 @@ fn test_sort_aggregation_results_order_by_count_desc_sorts_rows() {
         })
         .collect();
     assert_eq!(ordered_categories, vec!["tech", "history", "science"]);
+}
+
+// -------------------------------------------------------------------------
+// #903: GROUP BY group ceiling is a server-side hard cap.
+// -------------------------------------------------------------------------
+
+/// A query CANNOT raise `max_groups` above the server-side ceiling: an absurdly
+/// large `WITH (max_groups=...)` is clamped down, not honored.
+#[test]
+fn test_max_groups_clamped_to_server_ceiling() {
+    use crate::velesql::{WithClause, WithValue};
+
+    // Query tries to demand far more groups than the server permits.
+    let with = WithClause::new().with_option("max_groups", WithValue::Integer(i64::MAX));
+    let resolved = Collection::extract_max_groups_limit(Some(&with));
+
+    assert_eq!(
+        resolved, SERVER_MAX_GROUPS_CEILING,
+        "untrusted query must not raise the group ceiling above the server cap"
+    );
+}
+
+/// A query may LOWER its own group budget below the ceiling.
+#[test]
+fn test_max_groups_below_ceiling_is_honored() {
+    use crate::velesql::{WithClause, WithValue};
+
+    let with = WithClause::new().with_option("group_limit", WithValue::Integer(42));
+    let resolved = Collection::extract_max_groups_limit(Some(&with));
+
+    assert_eq!(resolved, 42);
+}
+
+/// Absent a WITH clause, the conservative default applies (well below ceiling).
+#[test]
+fn test_max_groups_default_when_unspecified() {
+    let resolved = Collection::extract_max_groups_limit(None);
+    assert_eq!(resolved, DEFAULT_MAX_GROUPS);
+    assert!(resolved < SERVER_MAX_GROUPS_CEILING);
 }

--- a/crates/velesdb-core/src/collection/search/query/aggregation/mod.rs
+++ b/crates/velesdb-core/src/collection/search/query/aggregation/mod.rs
@@ -225,7 +225,13 @@ impl Collection {
         }
     }
 
-    /// Pre-fetches payloads and runs parallel aggregation.
+    /// Runs parallel aggregation, streaming payloads per chunk.
+    ///
+    /// #901: previously this pre-collected **every** payload into one
+    /// `Vec<Option<Value>>` before aggregating — O(n) peak memory for the
+    /// whole collection. Now each rayon chunk retrieves only its own slice of
+    /// payloads on the fly, so peak memory is bounded to `O(CHUNK_SIZE ×
+    /// rayon_threads)`. Aggregation results are unchanged.
     fn run_parallel_path(
         ids: &[u64],
         payload_storage: &dyn PayloadStorage,
@@ -233,12 +239,7 @@ impl Collection {
         columns_vec: &[String],
         has_count_star: bool,
     ) -> crate::velesql::AggregateResult {
-        let payloads: Vec<Option<serde_json::Value>> = ids
-            .iter()
-            .map(|&id| payload_storage.retrieve(id).ok().flatten())
-            .collect();
-
-        Self::aggregate_parallel(&payloads, filter, columns_vec, has_count_star)
+        Self::aggregate_parallel(ids, payload_storage, filter, columns_vec, has_count_star)
     }
 
     /// Returns true if the payload passes the static filter.
@@ -271,18 +272,23 @@ impl Collection {
         }
     }
 
-    /// Parallel aggregation on pre-fetched payloads.
+    /// Parallel aggregation that streams payloads per chunk (#901).
+    ///
+    /// Each chunk of IDs retrieves its own payloads inside the rayon closure,
+    /// so the full payload set is never materialized at once.
     fn aggregate_parallel(
-        payloads: &[Option<serde_json::Value>],
+        ids: &[u64],
+        payload_storage: &dyn PayloadStorage,
         filter: Option<&crate::filter::Filter>,
         columns_to_aggregate: &[String],
         has_count_star: bool,
     ) -> crate::velesql::AggregateResult {
-        let partial_aggregators: Vec<Aggregator> = payloads
+        let partial_aggregators: Vec<Aggregator> = ids
             .par_chunks(CHUNK_SIZE)
             .map(|chunk| {
                 let mut chunk_agg = Aggregator::new();
-                for payload in chunk {
+                for &id in chunk {
+                    let payload = payload_storage.retrieve(id).ok().flatten();
                     if let Some(f) = filter {
                         if !Self::payload_passes_filter(f, payload.as_ref()) {
                             continue;

--- a/crates/velesdb-core/src/collection/search/query/bounded_top_k.rs
+++ b/crates/velesdb-core/src/collection/search/query/bounded_top_k.rs
@@ -1,0 +1,188 @@
+//! Bounded top-k accumulator for the scan/score path (#901).
+//!
+//! Collects the `k` best [`SearchResult`]s by score **without** materializing
+//! the full candidate set. Memory is bounded to `O(k)` rather than `O(n)`,
+//! while the returned results and their ordering are identical to a full sort
+//! followed by `truncate(k)`.
+//!
+//! The accumulator keeps a binary heap whose *root is the worst* result kept so
+//! far (for the current metric direction). Once the heap is full, a new
+//! candidate only displaces the root when it is strictly better — exactly the
+//! semantics of `sort` + `truncate`, but in bounded memory.
+
+use crate::point::SearchResult;
+use std::cmp::Ordering;
+use std::collections::BinaryHeap;
+
+/// One entry kept in the bounded heap, ordered so that the heap's max element
+/// is the *worst* result currently retained.
+struct HeapEntry {
+    /// Insertion order, used as a deterministic tie-breaker so equal-score
+    /// results keep first-seen order (matching `sort_unstable` stability for
+    /// the scan path, where input order is the storage id order).
+    seq: u64,
+    result: SearchResult,
+    higher_is_better: bool,
+}
+
+impl HeapEntry {
+    /// Orders two entries from *best to worst*. The heap inverts this so the
+    /// root is the worst kept entry and can be popped when displaced.
+    fn cmp_best_to_worst(&self, other: &Self) -> Ordering {
+        let by_score = if self.higher_is_better {
+            // Higher score is better → better entry compares as Less ("front").
+            other.result.score.total_cmp(&self.result.score)
+        } else {
+            self.result.score.total_cmp(&other.result.score)
+        };
+        // Tie-break on insertion order so earlier candidates rank ahead.
+        by_score.then(self.seq.cmp(&other.seq))
+    }
+}
+
+impl PartialEq for HeapEntry {
+    fn eq(&self, other: &Self) -> bool {
+        self.cmp_best_to_worst(other) == Ordering::Equal
+    }
+}
+impl Eq for HeapEntry {}
+
+impl PartialOrd for HeapEntry {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for HeapEntry {
+    fn cmp(&self, other: &Self) -> Ordering {
+        // `BinaryHeap` is a max-heap and `peek()` returns the greatest element.
+        // We want the *worst* kept entry at the root so it can be evicted, so
+        // the worst entry must compare as greatest. `cmp_best_to_worst` already
+        // ranks the worst entry as `Greater`, so use it directly.
+        self.cmp_best_to_worst(other)
+    }
+}
+
+/// Bounded top-k accumulator. Retains at most `k` best results by score.
+pub(super) struct BoundedTopK {
+    heap: BinaryHeap<HeapEntry>,
+    k: usize,
+    higher_is_better: bool,
+    next_seq: u64,
+}
+
+impl BoundedTopK {
+    /// Creates an accumulator that keeps the `k` best results. `higher_is_better`
+    /// selects the metric direction (similarity vs. distance).
+    pub(super) fn new(k: usize, higher_is_better: bool) -> Self {
+        Self {
+            // Reserve k+1: we push then pop when over capacity.
+            heap: BinaryHeap::with_capacity(k.saturating_add(1).min(4096)),
+            k,
+            higher_is_better,
+            next_seq: 0,
+        }
+    }
+
+    /// Offers a scored candidate. Kept only if it ranks within the top `k`.
+    pub(super) fn offer(&mut self, result: SearchResult) {
+        if self.k == 0 {
+            return;
+        }
+        let entry = HeapEntry {
+            seq: self.next_seq,
+            result,
+            higher_is_better: self.higher_is_better,
+        };
+        self.next_seq += 1;
+
+        if self.heap.len() < self.k {
+            self.heap.push(entry);
+            return;
+        }
+        // Heap is full: replace the worst kept entry only if the candidate is
+        // strictly better. The heap root is the worst kept entry.
+        if let Some(worst) = self.heap.peek() {
+            if entry.cmp_best_to_worst(worst) == Ordering::Less {
+                self.heap.pop();
+                self.heap.push(entry);
+            }
+        }
+    }
+
+    /// Consumes the accumulator, returning results sorted best-to-worst —
+    /// identical ordering to a full `sort` + `truncate(k)`.
+    pub(super) fn into_sorted_vec(self) -> Vec<SearchResult> {
+        let mut entries: Vec<HeapEntry> = self.heap.into_vec();
+        entries.sort_unstable_by(HeapEntry::cmp_best_to_worst);
+        entries.into_iter().map(|e| e.result).collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::point::Point;
+
+    fn result(id: u64, score: f32) -> SearchResult {
+        SearchResult::new(
+            Point {
+                id,
+                vector: vec![],
+                payload: None,
+                sparse_vectors: None,
+            },
+            score,
+        )
+    }
+
+    /// Bounded top-k returns the same ids/order as full sort+truncate
+    /// (higher-is-better direction).
+    #[test]
+    fn test_bounded_top_k_matches_full_sort_higher_better() {
+        let scores = [0.1f32, 0.9, 0.5, 0.95, 0.3, 0.7];
+        let mut topk = BoundedTopK::new(3, true);
+        for (i, s) in scores.iter().enumerate() {
+            topk.offer(result(i as u64, *s));
+        }
+        let got: Vec<(u64, f32)> = topk
+            .into_sorted_vec()
+            .iter()
+            .map(|r| (r.point.id, r.score))
+            .collect();
+
+        // Reference: full sort desc + truncate(3).
+        let mut reference: Vec<(u64, f32)> = scores
+            .iter()
+            .enumerate()
+            .map(|(i, s)| (i as u64, *s))
+            .collect();
+        reference.sort_by(|a, b| b.1.total_cmp(&a.1));
+        reference.truncate(3);
+
+        assert_eq!(got, reference);
+    }
+
+    /// Lower-is-better (distance) direction keeps the smallest scores.
+    #[test]
+    fn test_bounded_top_k_matches_full_sort_lower_better() {
+        let scores = [5.0f32, 1.0, 3.0, 0.5, 9.0, 2.0];
+        let mut topk = BoundedTopK::new(2, false);
+        for (i, s) in scores.iter().enumerate() {
+            topk.offer(result(i as u64, *s));
+        }
+        let got: Vec<u64> = topk.into_sorted_vec().iter().map(|r| r.point.id).collect();
+        assert_eq!(got, vec![3, 1]); // 0.5 then 1.0
+    }
+
+    /// Equal scores keep first-seen (insertion) order.
+    #[test]
+    fn test_bounded_top_k_ties_keep_insertion_order() {
+        let mut topk = BoundedTopK::new(2, true);
+        topk.offer(result(10, 0.5));
+        topk.offer(result(20, 0.5));
+        topk.offer(result(30, 0.5));
+        let got: Vec<u64> = topk.into_sorted_vec().iter().map(|r| r.point.id).collect();
+        assert_eq!(got, vec![10, 20]);
+    }
+}

--- a/crates/velesdb-core/src/collection/search/query/join.rs
+++ b/crates/velesdb-core/src/collection/search/query/join.rs
@@ -32,6 +32,10 @@ impl JoinedResult {
     }
 }
 
+/// Conservative server-side ceiling on the number of joined rows materialized
+/// when the query carries no explicit LIMIT (mirrors `query::options::MAX_LIMIT`).
+pub const JOIN_ROW_CEILING: usize = 100_000;
+
 /// Adaptive batch size thresholds.
 const SMALL_BATCH_THRESHOLD: usize = 100;
 const MEDIUM_BATCH_THRESHOLD: usize = 10_000;
@@ -110,10 +114,14 @@ pub fn extract_join_keys(results: &[SearchResult], condition: &JoinCondition) ->
 /// * `results` - Search results from vector/graph query
 /// * `join` - JOIN clause from parsed query
 /// * `column_store` - ColumnStore to join with
+/// * `row_budget` - Maximum number of joined rows to materialize. Callers pass
+///   the query's effective `LIMIT + OFFSET`; pass [`JOIN_ROW_CEILING`] when the
+///   query has no LIMIT. Bounds OOM on RIGHT/FULL joins over large stores
+///   without dropping rows inside the requested window.
 ///
 /// # Returns
 ///
-/// Vector of JoinedResults containing merged data.
+/// Vector of JoinedResults containing merged data (at most `row_budget` rows).
 /// Returns empty vector if the join condition's left column doesn't match the primary key.
 ///
 /// # Errors
@@ -127,6 +135,7 @@ pub fn execute_join(
     results: &[SearchResult],
     join: &JoinClause,
     column_store: &ColumnStore,
+    row_budget: usize,
 ) -> Result<Vec<JoinedResult>> {
     let condition = validate_join_condition(join, column_store)?;
     let join_keys = extract_join_keys(results, &condition);
@@ -150,23 +159,30 @@ pub fn execute_join(
         &null_row_data,
         &mut matched_left_indices,
         &mut matched_right_pks,
+        row_budget,
     );
 
-    if matches!(join.join_type, JoinType::Right | JoinType::Full) {
+    if joined_results.len() < row_budget
+        && matches!(join.join_type, JoinType::Right | JoinType::Full)
+    {
         append_unmatched_right_rows(
             column_store,
             &condition.left.column,
             &matched_right_pks,
             &mut joined_results,
+            row_budget,
         );
     }
 
-    if matches!(join.join_type, JoinType::Left | JoinType::Full) {
+    if joined_results.len() < row_budget
+        && matches!(join.join_type, JoinType::Left | JoinType::Full)
+    {
         append_unmatched_left_rows(
             results,
             &matched_left_indices,
             &null_row_data,
             &mut joined_results,
+            row_budget,
         );
     }
 
@@ -211,14 +227,21 @@ fn process_join_batches(
     null_row_data: &HashMap<String, serde_json::Value>,
     matched_left_indices: &mut [bool],
     matched_right_pks: &mut HashSet<i64>,
+    row_budget: usize,
 ) -> Vec<JoinedResult> {
-    let mut joined_results = Vec::with_capacity(join_keys.len());
+    let mut joined_results = Vec::with_capacity(join_keys.len().min(row_budget));
 
     for chunk in join_keys.chunks(batch_size) {
+        if joined_results.len() >= row_budget {
+            break;
+        }
         let pks: Vec<i64> = chunk.iter().map(|(_, pk)| *pk).collect();
         let row_map = batch_get_rows(column_store, &pks);
 
         for (result_idx, pk) in chunk {
+            if joined_results.len() >= row_budget {
+                break;
+            }
             if let Some(column_data) = row_map.get(pk) {
                 joined_results.push(JoinedResult::new(
                     results[*result_idx].clone(),
@@ -245,8 +268,12 @@ fn append_unmatched_right_rows(
     join_column: &str,
     matched_right_pks: &HashSet<i64>,
     joined_results: &mut Vec<JoinedResult>,
+    row_budget: usize,
 ) {
     for row_idx in column_store.live_row_indices() {
+        if joined_results.len() >= row_budget {
+            break;
+        }
         let Some(pk_value) = column_store.get_value_as_json(join_column, row_idx) else {
             continue;
         };
@@ -272,8 +299,12 @@ fn append_unmatched_left_rows(
     matched_left_indices: &[bool],
     null_row_data: &HashMap<String, serde_json::Value>,
     joined_results: &mut Vec<JoinedResult>,
+    row_budget: usize,
 ) {
     for (idx, left_result) in results.iter().enumerate() {
+        if joined_results.len() >= row_budget {
+            break;
+        }
         if !matched_left_indices[idx] {
             joined_results.push(JoinedResult::new(
                 left_result.clone(),

--- a/crates/velesdb-core/src/collection/search/query/join_tests.rs
+++ b/crates/velesdb-core/src/collection/search/query/join_tests.rs
@@ -6,6 +6,9 @@ use crate::point::Point;
 use crate::point::SearchResult;
 use crate::velesql::{ColumnRef, JoinClause, JoinCondition};
 
+/// Effectively unbounded row budget for tests asserting full (unbounded) output.
+const NO_LIMIT: usize = usize::MAX;
+
 fn make_search_result(id: u64, payload_id: i64) -> SearchResult {
     SearchResult::new(
         Point {
@@ -131,7 +134,7 @@ fn test_execute_join_basic() {
     let column_store = make_column_store();
     let join = make_join_clause();
 
-    let joined = execute_join(&results, &join, &column_store).unwrap();
+    let joined = execute_join(&results, &join, &column_store, NO_LIMIT).unwrap();
 
     assert_eq!(joined.len(), 3);
     assert!(joined[0].column_data.contains_key("price"));
@@ -154,7 +157,7 @@ fn test_execute_join_inner_skips_missing() {
     let column_store = make_column_store();
     let join = make_join_clause();
 
-    let joined = execute_join(&results, &join, &column_store).unwrap();
+    let joined = execute_join(&results, &join, &column_store, NO_LIMIT).unwrap();
     assert_eq!(joined.len(), 2);
 }
 
@@ -164,7 +167,7 @@ fn test_joined_to_search_results() {
     let column_store = make_column_store();
     let join = make_join_clause();
 
-    let joined = execute_join(&results, &join, &column_store).unwrap();
+    let joined = execute_join(&results, &join, &column_store, NO_LIMIT).unwrap();
     let search_results = joined_to_search_results(joined);
 
     assert_eq!(search_results.len(), 1);
@@ -291,7 +294,7 @@ fn test_execute_join_validates_pk_column() {
         using_columns: None,
     };
 
-    let joined = execute_join(&results, &wrong_join, &column_store);
+    let joined = execute_join(&results, &wrong_join, &column_store, NO_LIMIT);
     assert!(
         joined.is_err(),
         "JOIN on non-PK column must return an error"
@@ -320,7 +323,7 @@ fn test_execute_join_correct_pk_column_works() {
         using_columns: None,
     };
 
-    let joined = execute_join(&results, &correct_join, &column_store).unwrap();
+    let joined = execute_join(&results, &correct_join, &column_store, NO_LIMIT).unwrap();
     assert_eq!(joined.len(), 1);
 }
 
@@ -341,7 +344,7 @@ fn test_execute_join_using_single_column_supported() {
         using_columns: Some(vec!["product_id".to_string()]),
     };
 
-    let joined = execute_join(&results, &using_join, &column_store).unwrap();
+    let joined = execute_join(&results, &using_join, &column_store, NO_LIMIT).unwrap();
     assert_eq!(joined.len(), 2);
     assert!(joined[0].column_data.contains_key("price"));
 }
@@ -362,7 +365,7 @@ fn test_execute_join_using_rejects_multi_column() {
         using_columns: Some(vec!["product_id".to_string(), "region_id".to_string()]),
     };
 
-    let joined = execute_join(&results, &using_join, &column_store);
+    let joined = execute_join(&results, &using_join, &column_store, NO_LIMIT);
     assert!(
         joined.is_err(),
         "USING with multiple columns must return an error"
@@ -390,7 +393,7 @@ fn test_execute_left_join_keeps_unmatched_left_rows() {
         using_columns: None,
     };
 
-    let joined = execute_join(&results, &join, &column_store).unwrap();
+    let joined = execute_join(&results, &join, &column_store, NO_LIMIT).unwrap();
     assert_eq!(joined.len(), 2);
     assert!(joined[0].column_data.contains_key("price"));
     assert_eq!(
@@ -420,7 +423,7 @@ fn test_execute_right_join_includes_unmatched_right_rows() {
         using_columns: None,
     };
 
-    let joined = execute_join(&results, &join, &column_store).unwrap();
+    let joined = execute_join(&results, &join, &column_store, NO_LIMIT).unwrap();
     assert_eq!(joined.len(), 3);
 }
 
@@ -445,11 +448,102 @@ fn test_execute_full_join_combines_left_and_right_unmatched() {
         using_columns: None,
     };
 
-    let joined = execute_join(&results, &join, &column_store).unwrap();
+    let joined = execute_join(&results, &join, &column_store, NO_LIMIT).unwrap();
     assert_eq!(joined.len(), 4);
     let null_join_count = joined
         .iter()
         .filter(|row| row.column_data.get("price") == Some(&serde_json::Value::Null))
         .count();
     assert_eq!(null_join_count, 1);
+}
+
+/// Builds a ColumnStore with `n` rows keyed `1..=n` on `product_id`.
+fn make_large_column_store(n: i64) -> ColumnStore {
+    let mut store = ColumnStore::with_primary_key(
+        &[
+            ("product_id", ColumnType::Int),
+            ("price", ColumnType::Float),
+        ],
+        "product_id",
+    )
+    .unwrap();
+    for pk in 1..=n {
+        store
+            .insert_row(&[
+                ("product_id", ColumnValue::Int(pk)),
+                ("price", ColumnValue::Float(9.99)),
+            ])
+            .unwrap();
+    }
+    store
+}
+
+/// #901: a RIGHT JOIN with a small budget over a large right side must stop at
+/// the budget instead of materializing one joined row per live ColumnStore row.
+#[test]
+fn test_execute_right_join_respects_row_budget() {
+    // 10_000 right-side rows, only one matches the single left result.
+    let results = vec![make_search_result(1, 1)];
+    let column_store = make_large_column_store(10_000);
+    let join = JoinClause {
+        join_type: crate::velesql::JoinType::Right,
+        table: "prices".to_string(),
+        alias: None,
+        condition: Some(JoinCondition {
+            left: ColumnRef {
+                table: Some("prices".to_string()),
+                column: "product_id".to_string(),
+            },
+            right: ColumnRef {
+                table: Some("products".to_string()),
+                column: "id".to_string(),
+            },
+        }),
+        using_columns: None,
+    };
+
+    // Budget 5: 1 matched row + 4 unmatched-right rows, NOT all 10_000.
+    let joined = execute_join(&results, &join, &column_store, 5).unwrap();
+    assert_eq!(joined.len(), 5, "RIGHT join must stop at the row budget");
+
+    // The matched row (pk=1) is emitted first.
+    assert_eq!(joined[0].search_result.point.id, 1);
+    assert!(joined[0].column_data.contains_key("price"));
+
+    // Unbounded run returns every right row (regression guard on correctness).
+    let full = execute_join(&results, &join, &column_store, NO_LIMIT).unwrap();
+    assert_eq!(full.len(), 10_000);
+}
+
+/// #901: a LEFT JOIN with a small budget over a large left side stops at the
+/// budget while still emitting matched rows first.
+#[test]
+fn test_execute_left_join_respects_row_budget() {
+    // 50 left results, none match the 3-row store -> all become unmatched-left.
+    let results: Vec<SearchResult> = (1u64..=50)
+        .map(|i| make_search_result(i, 9_000 + i64::try_from(i).unwrap_or(0)))
+        .collect();
+    let column_store = make_column_store();
+    let join = JoinClause {
+        join_type: crate::velesql::JoinType::Left,
+        table: "prices".to_string(),
+        alias: None,
+        condition: Some(JoinCondition {
+            left: ColumnRef {
+                table: Some("prices".to_string()),
+                column: "product_id".to_string(),
+            },
+            right: ColumnRef {
+                table: Some("products".to_string()),
+                column: "id".to_string(),
+            },
+        }),
+        using_columns: None,
+    };
+
+    let joined = execute_join(&results, &join, &column_store, 7).unwrap();
+    assert_eq!(joined.len(), 7, "LEFT join must stop at the row budget");
+
+    let full = execute_join(&results, &join, &column_store, NO_LIMIT).unwrap();
+    assert_eq!(full.len(), 50);
 }

--- a/crates/velesdb-core/src/collection/search/query/mod.rs
+++ b/crates/velesdb-core/src/collection/search/query/mod.rs
@@ -31,6 +31,7 @@
 #![allow(clippy::implicit_hasher)] // HashSet hasher genericity adds noise for internal APIs.
 
 mod aggregation;
+mod bounded_top_k;
 #[cfg(test)]
 mod component_scores_tests;
 pub(crate) mod condition_tree;
@@ -95,7 +96,7 @@ mod with_options_tests;
 pub use ordering::compare_json_values;
 // Re-export join functions for future integration with execute_query
 #[allow(unused_imports)]
-pub use join::{execute_join, JoinedResult};
+pub use join::{execute_join, JoinedResult, JOIN_ROW_CEILING};
 
 // Re-export types from options.rs so sibling submodules can use `super::*`.
 pub(crate) use options::QuerySearchOptions;
@@ -147,8 +148,14 @@ impl Collection {
                 right_query.select.limit = compound_limit;
                 let right_results =
                     self.execute_query_with_client(&right_query, params, "default")?;
-                accumulated =
-                    set_operations::apply_set_operation(accumulated, right_results, *operator);
+                // Intermediate ops keep the server-side ceiling: truncating to the
+                // user LIMIT here would drop rows a later chained set op still needs.
+                accumulated = set_operations::apply_set_operation(
+                    accumulated,
+                    right_results,
+                    *operator,
+                    MAX_LIMIT,
+                );
             }
             // SQL-standard: OFFSET then LIMIT on the combined result.
             if let Some(offset) = query.select.offset {

--- a/crates/velesdb-core/src/collection/search/query/parallel_traversal/frontier.rs
+++ b/crates/velesdb-core/src/collection/search/query/parallel_traversal/frontier.rs
@@ -55,7 +55,18 @@ impl FrontierParallelBFS {
         while !frontier.is_empty() && depth < self.config.max_depth {
             depth += 1;
 
-            let next_frontier = self.expand_frontier(&frontier, &adjacency, &stats);
+            // Bound expansion to the remaining result budget so a wide level
+            // never materializes more neighbors than can still be returned. The
+            // cap counts only NEW unique nodes (candidates already in `visited`
+            // or duplicated within the level are filtered before the cap), so it
+            // bounds new results -- never raw candidates -- and cannot under-fill
+            // below the limit.
+            let remaining = self.config.limit.saturating_sub(results.len());
+            if remaining == 0 {
+                break;
+            }
+            let next_frontier =
+                self.expand_frontier(&frontier, &adjacency, &stats, remaining, &visited);
 
             frontier = Vec::new();
             for (neighbor, path, _edge_id) in next_frontier {
@@ -77,11 +88,22 @@ impl FrontierParallelBFS {
     }
 
     /// Expands the frontier (parallel or sequential based on size).
+    ///
+    /// Candidate neighbors are produced (in parallel for wide levels), then
+    /// deterministically filtered against `visited` and deduplicated within the
+    /// level so that *at most* `remaining` genuinely-new unique nodes are kept.
+    /// Because the cap counts only new unique nodes -- not raw (possibly
+    /// already-visited or within-level duplicate) candidates -- it bounds peak
+    /// buffering without ever dropping a node that would fit inside the limit.
+    /// The caller's `visited.insert` remains the authoritative dedup; here it is
+    /// a no-op given the pre-filter, preserving BFS level ordering.
     fn expand_frontier<F>(
         &self,
         frontier: &[(u64, Vec<u64>)],
         adjacency: &F,
         stats: &TraversalStats,
+        remaining: usize,
+        visited: &FxHashSet<u64>,
     ) -> Vec<(u64, Vec<u64>, u64)>
     where
         F: Fn(u64) -> Vec<(u64, u64)> + Send + Sync,
@@ -99,15 +121,30 @@ impl FrontierParallelBFS {
                 .collect::<Vec<_>>()
         };
 
+        // Keep only genuinely-new unique nodes, in frontier order, capped at the
+        // remaining budget. The wide-level parallel branch expands neighbors in
+        // parallel (`collect` preserves order) and the cheap dedup runs after;
+        // the sequential branch keeps the lazy `take` so a deep narrow frontier
+        // never materializes neighbors past the budget. Both are deterministic.
+        let mut level_seen = FxHashSet::default();
+        let mut keep = |neighbor: u64| !visited.contains(&neighbor) && level_seen.insert(neighbor);
+
         if self.config.should_parallelize_frontier(frontier.len()) {
-            frontier
+            let candidates: Vec<(u64, Vec<u64>, u64)> = frontier
                 .par_iter()
                 .flat_map(|(node, path)| expand_node(node, path))
+                .collect();
+            candidates
+                .into_iter()
+                .filter(|(neighbor, _, _)| keep(*neighbor))
+                .take(remaining)
                 .collect()
         } else {
             frontier
                 .iter()
                 .flat_map(|(node, path)| expand_node(node, path))
+                .filter(|(neighbor, _, _)| keep(*neighbor))
+                .take(remaining)
                 .collect()
         }
     }

--- a/crates/velesdb-core/src/collection/search/query/parallel_traversal/sharded.rs
+++ b/crates/velesdb-core/src/collection/search/query/parallel_traversal/sharded.rs
@@ -105,7 +105,22 @@ impl ShardedTraverser {
                 break;
             }
 
-            let shard_results = self.expand_shards(&shard_frontiers, &adjacency, &stats, depth);
+            // Bound each shard's emission to the remaining budget so a wide level
+            // cannot materialize the whole frontier before merge/dedup caps it.
+            // The cap counts only NEW unique nodes (candidates already globally
+            // visited, or duplicated within the shard's level, are filtered
+            // before the cap), so it bounds peak buffering without dropping a
+            // node that would fit inside the limit. `merge_shard_results` stays
+            // the authoritative cross-shard dedup.
+            let remaining = self.config.limit.saturating_sub(all_results.len());
+            let shard_results = self.expand_shards(
+                &shard_frontiers,
+                &adjacency,
+                &stats,
+                depth,
+                remaining,
+                &global_visited,
+            );
 
             shard_frontiers = self.merge_shard_results(
                 shard_results,
@@ -132,6 +147,13 @@ impl ShardedTraverser {
     }
 
     /// Expands all shard frontiers in parallel.
+    ///
+    /// Each shard keeps at most `remaining` genuinely-new unique nodes:
+    /// candidates already in `global_visited` (from prior levels/start nodes) or
+    /// duplicated within this shard's level are skipped before the budget check,
+    /// so the cap counts new results -- not raw candidates -- and never stops a
+    /// shard before it has surfaced reachable unvisited nodes that fit inside the
+    /// limit. `merge_shard_results` remains the authoritative cross-shard dedup.
     #[allow(clippy::type_complexity, clippy::unused_self)]
     fn expand_shards<F>(
         &self,
@@ -139,6 +161,8 @@ impl ShardedTraverser {
         adjacency: &F,
         stats: &TraversalStats,
         depth: u32,
+        remaining: usize,
+        global_visited: &FxHashSet<u64>,
     ) -> Vec<(Vec<TraversalResult>, Vec<(u64, u64, Vec<u64>)>)>
     where
         F: Fn(u64) -> Vec<(u64, u64)> + Send + Sync,
@@ -148,10 +172,17 @@ impl ShardedTraverser {
             .map(|frontier| {
                 let mut results = Vec::new();
                 let mut next_frontier = Vec::new();
-                for (start_node, current_node, path) in frontier {
+                let mut shard_seen = FxHashSet::default();
+                'frontier: for (start_node, current_node, path) in frontier {
                     let neighbors = adjacency(*current_node);
                     stats.add_edges_traversed(neighbors.len());
                     for (neighbor, edge_id) in neighbors {
+                        if global_visited.contains(&neighbor) || !shard_seen.insert(neighbor) {
+                            continue;
+                        }
+                        if results.len() >= remaining {
+                            break 'frontier;
+                        }
                         let mut new_path = path.clone();
                         new_path.push(edge_id);
                         results.push(TraversalResult::new(
@@ -182,13 +213,15 @@ impl ShardedTraverser {
 
         for (results, next_frontier) in shard_results {
             for result in results {
+                // Stop globally at the limit so merging across shards yields
+                // EXACTLY `limit` results, never overshooting by a shard's worth.
+                if all_results.len() >= self.config.limit {
+                    break;
+                }
                 if global_visited.insert(result.end_node) {
                     stats.add_nodes_visited(1);
                     newly_visited.insert(result.end_node);
                     all_results.push(result);
-                    if all_results.len() >= self.config.limit {
-                        break;
-                    }
                 }
             }
             for (start, node, path) in next_frontier {

--- a/crates/velesdb-core/src/collection/search/query/parallel_traversal/traverser.rs
+++ b/crates/velesdb-core/src/collection/search/query/parallel_traversal/traverser.rs
@@ -173,6 +173,11 @@ impl ParallelTraverser {
             stats.add_edges_traversed(neighbors.len());
 
             for (neighbor, edge_id) in neighbors {
+                // Stop expanding this node's neighbors once the budget is hit so a
+                // high fan-out node cannot blow past the limit in a single step.
+                if results.len() >= self.config.limit {
+                    break;
+                }
                 if visited.insert(neighbor) {
                     stats.add_nodes_visited(1);
                     let mut new_path = path.clone();

--- a/crates/velesdb-core/src/collection/search/query/parallel_traversal_tests.rs
+++ b/crates/velesdb-core/src/collection/search/query/parallel_traversal_tests.rs
@@ -456,3 +456,215 @@ fn test_sharded_traverser_num_shards() {
     let traverser = ShardedTraverser::new(8);
     assert_eq!(traverser.num_shards(), 8);
 }
+
+// ============================================================================
+// #901 follow-up: bounded frontier expansion over wide graphs.
+// ============================================================================
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+/// Two-level wide graph: root has `fan_out` level-1 neighbors, and each level-1
+/// node has one level-2 neighbor. `adjacency_calls` records how many distinct
+/// nodes are expanded, which is the observable seam: bounded expansion stops
+/// pushing the whole level into the next frontier, so far fewer level-1 nodes
+/// get their neighbors queried.
+fn counting_wide_graph(
+    fan_out: u64,
+    adjacency_calls: &AtomicUsize,
+) -> impl Fn(u64) -> Vec<(u64, u64)> + '_ {
+    move |node: u64| -> Vec<(u64, u64)> {
+        adjacency_calls.fetch_add(1, Ordering::Relaxed);
+        if node == 1 {
+            // Level 1: fan_out neighbors (ids 1_000..).
+            (0..fan_out).map(|i| (1_000 + i, 10_000 + i)).collect()
+        } else if (1_000..1_000 + fan_out).contains(&node) {
+            // Level 2: each level-1 node points to a unique deeper node.
+            vec![(node + 100_000, node + 200_000)]
+        } else {
+            Vec::new()
+        }
+    }
+}
+
+#[test]
+fn test_frontier_bfs_bounds_wide_level() {
+    // Root with 50_000 neighbors; a limit of 10 must not expand the full level
+    // nor query level-2 neighbors for all 50_000 frontier nodes.
+    let calls = AtomicUsize::new(0);
+    let bfs = FrontierParallelBFS::with_config(
+        ParallelConfig::new()
+            .with_max_depth(3)
+            .with_min_frontier(1)
+            .with_limit(10),
+    );
+
+    let (results, _) = bfs.traverse(1, counting_wide_graph(50_000, &calls));
+
+    // Exactly `limit` results (start node + 9 neighbors), correctly bounded.
+    assert_eq!(results.len(), 10);
+    // Bounded expansion: only the root plus a handful of frontier nodes are
+    // expanded, never all 50_000.
+    assert!(
+        calls.load(Ordering::Relaxed) < 1_000,
+        "expanded too many nodes: {}",
+        calls.load(Ordering::Relaxed)
+    );
+}
+
+#[test]
+fn test_traverse_single_bounds_high_fanout_node() {
+    // A single high-fan-out node: the per-node neighbor loop must break at the
+    // limit instead of pushing all 50_000 neighbors into results in one step.
+    let calls = AtomicUsize::new(0);
+    let traverser = ParallelTraverser::with_config(
+        ParallelConfig::new()
+            .with_max_depth(3)
+            .with_parallel_threshold(100) // sequential single start
+            .with_limit(8),
+    );
+
+    let (results, _) = traverser.bfs_parallel(&[1], counting_wide_graph(50_000, &calls));
+
+    // Result count is bounded -- without the inner-loop break this would be ~50_000.
+    assert_eq!(results.len(), 8);
+}
+
+#[test]
+fn test_sharded_bounds_wide_level() {
+    let calls = AtomicUsize::new(0);
+    let traverser =
+        ShardedTraverser::with_config(4, ParallelConfig::new().with_max_depth(3).with_limit(12));
+
+    let (results, _) = traverser.traverse_parallel(&[1], counting_wide_graph(50_000, &calls));
+
+    assert!(results.len() <= 12, "sharded result exceeded limit");
+    // Each shard caps emission at the remaining budget, so the next frontier --
+    // and thus the number of expanded nodes -- stays far below 50_000.
+    assert!(
+        calls.load(Ordering::Relaxed) < 1_000,
+        "expanded too many nodes: {}",
+        calls.load(Ordering::Relaxed)
+    );
+}
+
+#[test]
+fn test_frontier_bfs_unbounded_matches_full_graph() {
+    // Regression guard: a non-pathological graph still returns the full result.
+    let graph = create_test_graph();
+    let bfs =
+        FrontierParallelBFS::with_config(ParallelConfig::new().with_max_depth(5).with_limit(1000));
+    let get_neighbors =
+        |node: u64| -> Vec<(u64, u64)> { graph.get(&node).cloned().unwrap_or_default() };
+
+    let (results, _) = bfs.traverse(1, get_neighbors);
+    assert_eq!(results.len(), 6);
+}
+
+/// Cross-edged graph where near-limit candidates are already visited.
+///
+/// `1 -> {2, 3}`; nodes `2` and `3` each emit BACK-edges to the already-visited
+/// `{1, 2, 3}` first, then forward-edges to fresh nodes `{4, 5, 6, 7}`. With a
+/// small limit, the pre-#901-followup cap counted raw candidates: the first
+/// `remaining` candidates were the already-visited back-edges, deduping to zero
+/// new nodes and under-filling. The cap must count NEW unique nodes instead.
+fn back_edge_graph() -> HashMap<u64, Vec<(u64, u64)>> {
+    let mut graph = HashMap::new();
+    graph.insert(1, vec![(2, 12), (3, 13)]);
+    // Back-edges (to visited 1/2/3) precede forward-edges (to fresh 4..7).
+    graph.insert(2, vec![(1, 21), (3, 23), (2, 22), (4, 24), (5, 25)]);
+    graph.insert(3, vec![(1, 31), (2, 32), (3, 33), (6, 36), (7, 37)]);
+    graph.insert(4, vec![]);
+    graph.insert(5, vec![]);
+    graph.insert(6, vec![]);
+    graph.insert(7, vec![]);
+    graph
+}
+
+#[test]
+fn test_frontier_bfs_back_edges_fill_to_limit() {
+    // 7 unique nodes are reachable; limit 5 must return EXACTLY 5, not fewer,
+    // even though the first level-2 candidates are all already-visited.
+    let graph = back_edge_graph();
+    let bfs = FrontierParallelBFS::with_config(
+        ParallelConfig::new()
+            .with_max_depth(5)
+            .with_min_frontier(1)
+            .with_limit(5),
+    );
+    let get_neighbors =
+        |node: u64| -> Vec<(u64, u64)> { graph.get(&node).cloned().unwrap_or_default() };
+
+    let (results, _) = bfs.traverse(1, get_neighbors);
+    assert_eq!(
+        results.len(),
+        5,
+        "frontier BFS under-filled below the limit"
+    );
+}
+
+#[test]
+fn test_frontier_bfs_back_edges_deterministic_count() {
+    // The parallel frontier path must return a consistent count across runs.
+    let graph = back_edge_graph();
+    let get_neighbors =
+        |node: u64| -> Vec<(u64, u64)> { graph.get(&node).cloned().unwrap_or_default() };
+    let mut counts = std::collections::HashSet::new();
+    for _ in 0..32 {
+        let bfs = FrontierParallelBFS::with_config(
+            ParallelConfig::new()
+                .with_max_depth(5)
+                .with_min_frontier(1)
+                .with_limit(5),
+        );
+        let (results, _) = bfs.traverse(1, get_neighbors);
+        counts.insert(results.len());
+    }
+    assert_eq!(counts, std::collections::HashSet::from([5]));
+}
+
+#[test]
+fn test_sharded_back_edges_fill_to_limit() {
+    // Same back-edge graph through the sharded path: a shard whose first
+    // candidates are already-visited must not stop before surfacing fresh nodes.
+    let graph = back_edge_graph();
+    let traverser =
+        ShardedTraverser::with_config(4, ParallelConfig::new().with_max_depth(5).with_limit(5));
+    let get_neighbors =
+        |node: u64| -> Vec<(u64, u64)> { graph.get(&node).cloned().unwrap_or_default() };
+
+    let (results, _) = traverser.traverse_parallel(&[1], get_neighbors);
+    assert_eq!(
+        results.len(),
+        5,
+        "sharded traversal under-filled below the limit"
+    );
+}
+
+#[test]
+fn test_sharded_back_edges_deterministic_count() {
+    // The sharded parallel path must return a consistent count across runs.
+    let graph = back_edge_graph();
+    let get_neighbors =
+        |node: u64| -> Vec<(u64, u64)> { graph.get(&node).cloned().unwrap_or_default() };
+    let mut counts = std::collections::HashSet::new();
+    for _ in 0..32 {
+        let traverser =
+            ShardedTraverser::with_config(4, ParallelConfig::new().with_max_depth(5).with_limit(5));
+        let (results, _) = traverser.traverse_parallel(&[1], get_neighbors);
+        counts.insert(results.len());
+    }
+    assert_eq!(counts, std::collections::HashSet::from([5]));
+}
+
+#[test]
+fn test_sharded_unbounded_matches_full_graph() {
+    // Regression guard: a non-pathological graph still returns the full result.
+    let graph = create_test_graph();
+    let traverser =
+        ShardedTraverser::with_config(4, ParallelConfig::new().with_max_depth(5).with_limit(1000));
+    let get_neighbors =
+        |node: u64| -> Vec<(u64, u64)> { graph.get(&node).cloned().unwrap_or_default() };
+
+    let (results, _) = traverser.traverse_parallel(&[1], get_neighbors);
+    assert_eq!(results.len(), 6);
+}

--- a/crates/velesdb-core/src/collection/search/query/set_operations.rs
+++ b/crates/velesdb-core/src/collection/search/query/set_operations.rs
@@ -8,7 +8,7 @@ use std::collections::HashMap;
 use crate::point::SearchResult;
 use crate::velesql::SetOperator;
 
-/// Applies a set operator to two result sets.
+/// Applies a set operator to two result sets, bounding the output at `limit`.
 ///
 /// Scoring rules per operator:
 /// - **Union**: deduplicate by point ID, keep highest score.
@@ -16,11 +16,16 @@ use crate::velesql::SetOperator;
 /// - **Intersect**: keep only IDs present in both; take the higher score.
 /// - **Except**: keep left-side IDs that do not appear in the right side.
 ///
-/// Results are returned sorted by score descending.
+/// Results are returned sorted by score descending and truncated to `limit`.
+/// Because the final result is score-ranked then capped, only the top `limit`
+/// rows are ever observable — so truncating here drops nothing within the
+/// requested window. Operands are expected to already be capped by the caller
+/// (`MAX_LIMIT`), which bounds buffering on the smaller-side scan for INTERSECT.
 pub(crate) fn apply_set_operation(
     left: Vec<SearchResult>,
     right: Vec<SearchResult>,
     operator: SetOperator,
+    limit: usize,
 ) -> Vec<SearchResult> {
     let mut results = match operator {
         SetOperator::Union => union_dedup(left, right),
@@ -35,6 +40,7 @@ pub(crate) fn apply_set_operation(
             .unwrap_or(std::cmp::Ordering::Equal)
     });
 
+    results.truncate(limit);
     results
 }
 
@@ -47,13 +53,16 @@ fn union_dedup(left: Vec<SearchResult>, right: Vec<SearchResult>) -> Vec<SearchR
     }
 
     for result in right {
-        map.entry(result.point.id)
-            .and_modify(|existing| {
-                if result.score > existing.score {
-                    *existing = result.clone();
+        match map.entry(result.point.id) {
+            std::collections::hash_map::Entry::Occupied(mut existing) => {
+                if result.score > existing.get().score {
+                    existing.insert(result);
                 }
-            })
-            .or_insert(result);
+            }
+            std::collections::hash_map::Entry::Vacant(slot) => {
+                slot.insert(result);
+            }
+        }
     }
 
     map.into_values().collect()
@@ -92,6 +101,9 @@ mod tests {
     use super::*;
     use crate::point::{Point, SearchResult};
 
+    /// Large bound used by tests that assert full (untruncated) set-op output.
+    const TEST_LIMIT: usize = 100_000;
+
     fn make_result(id: u64, score: f32) -> SearchResult {
         SearchResult::new(Point::new(id, vec![0.0; 3], None), score)
     }
@@ -101,7 +113,7 @@ mod tests {
         let left = vec![make_result(1, 0.9), make_result(2, 0.5)];
         let right = vec![make_result(2, 0.8), make_result(3, 0.7)];
 
-        let results = apply_set_operation(left, right, SetOperator::Union);
+        let results = apply_set_operation(left, right, SetOperator::Union, TEST_LIMIT);
 
         assert_eq!(results.len(), 3);
         let ids: Vec<u64> = results.iter().map(|r| r.point.id).collect();
@@ -119,7 +131,7 @@ mod tests {
         let left = vec![make_result(1, 0.9), make_result(2, 0.5)];
         let right = vec![make_result(2, 0.8), make_result(3, 0.7)];
 
-        let results = apply_set_operation(left, right, SetOperator::UnionAll);
+        let results = apply_set_operation(left, right, SetOperator::UnionAll, TEST_LIMIT);
 
         assert_eq!(results.len(), 4);
     }
@@ -129,7 +141,7 @@ mod tests {
         let left = vec![make_result(1, 0.9), make_result(2, 0.5)];
         let right = vec![make_result(2, 0.8), make_result(3, 0.7)];
 
-        let results = apply_set_operation(left, right, SetOperator::Intersect);
+        let results = apply_set_operation(left, right, SetOperator::Intersect, TEST_LIMIT);
 
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].point.id, 2);
@@ -142,7 +154,7 @@ mod tests {
         let left = vec![make_result(1, 0.9), make_result(2, 0.5)];
         let right = vec![make_result(2, 0.8), make_result(3, 0.7)];
 
-        let results = apply_set_operation(left, right, SetOperator::Except);
+        let results = apply_set_operation(left, right, SetOperator::Except, TEST_LIMIT);
 
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].point.id, 1);
@@ -153,7 +165,7 @@ mod tests {
         let left = vec![make_result(1, 0.3), make_result(2, 0.9)];
         let right = vec![make_result(3, 0.6)];
 
-        let results = apply_set_operation(left, right, SetOperator::UnionAll);
+        let results = apply_set_operation(left, right, SetOperator::UnionAll, TEST_LIMIT);
 
         let scores: Vec<f32> = results.iter().map(|r| r.score).collect();
         for window in scores.windows(2) {
@@ -167,15 +179,70 @@ mod tests {
         let non_empty = vec![make_result(1, 0.5)];
 
         // UNION with empty left.
-        let r = apply_set_operation(Vec::new(), non_empty.clone(), SetOperator::Union);
+        let r = apply_set_operation(
+            Vec::new(),
+            non_empty.clone(),
+            SetOperator::Union,
+            TEST_LIMIT,
+        );
         assert_eq!(r.len(), 1);
 
         // INTERSECT with empty left.
-        let r = apply_set_operation(Vec::new(), non_empty.clone(), SetOperator::Intersect);
+        let r = apply_set_operation(
+            Vec::new(),
+            non_empty.clone(),
+            SetOperator::Intersect,
+            TEST_LIMIT,
+        );
         assert!(r.is_empty());
 
         // EXCEPT with empty right.
-        let r = apply_set_operation(non_empty, empty, SetOperator::Except);
+        let r = apply_set_operation(non_empty, empty, SetOperator::Except, TEST_LIMIT);
         assert_eq!(r.len(), 1);
+    }
+
+    /// Builds a result whose score equals its (small) id, avoiding lossy casts.
+    fn scored(id: u16) -> SearchResult {
+        make_result(u64::from(id), f32::from(id))
+    }
+
+    /// #901: UNION bounded by `limit` keeps the top-scoring rows and truncates.
+    #[test]
+    fn test_union_respects_limit() {
+        let left: Vec<SearchResult> = (1..=100).map(scored).collect();
+        let right: Vec<SearchResult> = (101..=200).map(scored).collect();
+
+        let results = apply_set_operation(left, right, SetOperator::Union, 5);
+
+        // Bounded to 5, and those 5 are the highest scores (196..=200).
+        assert_eq!(results.len(), 5);
+        let ids: Vec<u64> = results.iter().map(|r| r.point.id).collect();
+        assert_eq!(ids, vec![200, 199, 198, 197, 196]);
+    }
+
+    /// #901: INTERSECT bounded by `limit` keeps the highest-scoring common rows.
+    #[test]
+    fn test_intersect_respects_limit() {
+        // 0..=99 common to both sides; left scores ascending so common = all 100.
+        let left: Vec<SearchResult> = (0u16..100).map(scored).collect();
+        let right: Vec<SearchResult> = (0u16..100)
+            .map(|i| make_result(u64::from(i), 0.0))
+            .collect();
+
+        let results = apply_set_operation(left, right, SetOperator::Intersect, 3);
+
+        assert_eq!(results.len(), 3);
+        let ids: Vec<u64> = results.iter().map(|r| r.point.id).collect();
+        assert_eq!(ids, vec![99, 98, 97]);
+    }
+
+    /// #901: a limit larger than the result set is a no-op (no rows dropped).
+    #[test]
+    fn test_limit_larger_than_results_is_noop() {
+        let left = vec![make_result(1, 0.9), make_result(2, 0.5)];
+        let right = vec![make_result(3, 0.7)];
+
+        let results = apply_set_operation(left, right, SetOperator::Union, 100);
+        assert_eq!(results.len(), 3);
     }
 }

--- a/crates/velesdb-core/src/collection/search/query/similarity_filter.rs
+++ b/crates/velesdb-core/src/collection/search/query/similarity_filter.rs
@@ -96,7 +96,9 @@ impl Collection {
         let (sim_field, sim_vec, sim_op, sim_threshold) =
             self.extract_not_similarity_condition(condition, params)?;
 
-        Self::warn_large_scan(self.vector_storage.read().ids().len(), limit);
+        let total_count = self.vector_storage.read().ids().len();
+        Self::guard_not_similarity_scan(total_count)?;
+        Self::warn_large_scan(total_count, limit);
 
         let metadata_filter = Self::extract_metadata_filter(condition);
         let filter = metadata_filter
@@ -184,6 +186,29 @@ impl Collection {
         }
     }
 
+    /// Server-side hard ceiling on the number of vectors a single
+    /// `NOT similarity()` query may scan (#901).
+    ///
+    /// A `NOT similarity()` predicate has no index acceleration and may scan
+    /// the entire collection. Beyond this generous ceiling the query is a
+    /// likely DoS vector, so it is **rejected** rather than merely warned.
+    /// This is a SERVER-controlled constant and cannot be raised by the query.
+    const NOT_SIMILARITY_MAX_SCAN: usize = 5_000_000;
+
+    /// Rejects a `NOT similarity()` full scan whose collection size exceeds the
+    /// server-side ceiling [`Self::NOT_SIMILARITY_MAX_SCAN`] (#901).
+    fn guard_not_similarity_scan(total_count: usize) -> Result<()> {
+        if total_count > Self::NOT_SIMILARITY_MAX_SCAN {
+            return Err(crate::error::Error::Config(format!(
+                "NOT similarity() would scan {total_count} vectors, exceeding the \
+                 server scan limit of {}. Add a more selective metadata filter or \
+                 use a positive similarity() predicate (index-accelerated).",
+                Self::NOT_SIMILARITY_MAX_SCAN
+            )));
+        }
+        Ok(())
+    }
+
     /// Emits a performance warning for large NOT-similarity scans.
     fn warn_large_scan(total_count: usize, limit: usize) {
         if total_count > 10_000 && limit > 1000 {
@@ -256,6 +281,19 @@ impl Collection {
             vector_ids
         };
 
+        Self::collect_filtered_scan(&*payload_storage, &*vector_storage, ids, filter, limit)
+    }
+
+    /// Shared scan body: iterates `ids`, hydrates each matching point, and
+    /// stops once `limit` results are collected. Extracted to keep the full
+    /// scan and the candidate-id scan from duplicating the hydration loop.
+    fn collect_filtered_scan(
+        payload_storage: &dyn PayloadStorage,
+        vector_storage: &dyn VectorStorage,
+        ids: impl IntoIterator<Item = u64>,
+        filter: &crate::filter::Filter,
+        limit: usize,
+    ) -> Vec<SearchResult> {
         let mut results = Vec::new();
         for id in ids {
             let payload = payload_storage.retrieve(id).ok().flatten();
@@ -263,7 +301,6 @@ impl Collection {
                 Some(ref p) => filter.matches(p),
                 None => filter.matches(&serde_json::Value::Null),
             };
-
             if matches {
                 let vector = vector_storage
                     .retrieve(id)
@@ -280,12 +317,10 @@ impl Collection {
                     1.0,
                 ));
             }
-
             if results.len() >= limit {
                 break;
             }
         }
-
         results
     }
 
@@ -337,35 +372,13 @@ impl Collection {
     ) -> Vec<SearchResult> {
         let payload_storage = self.payload_storage.read();
         let vector_storage = self.vector_storage.read();
-        let mut results = Vec::new();
-
-        for &id in candidate_ids {
-            let payload = payload_storage.retrieve(id).ok().flatten();
-            let matches = match payload {
-                Some(ref p) => filter.matches(p),
-                None => filter.matches(&serde_json::Value::Null),
-            };
-            if matches {
-                let vector = vector_storage
-                    .retrieve(id)
-                    .ok()
-                    .flatten()
-                    .unwrap_or_default();
-                results.push(SearchResult::new(
-                    Point {
-                        id,
-                        vector,
-                        payload,
-                        sparse_vectors: None,
-                    },
-                    1.0,
-                ));
-            }
-            if results.len() >= limit {
-                break;
-            }
-        }
-        results
+        Self::collect_filtered_scan(
+            &*payload_storage,
+            &*vector_storage,
+            candidate_ids.iter().copied(),
+            filter,
+            limit,
+        )
     }
 
     /// Scans all metadata-matching points and rescores them by exact vector similarity.
@@ -378,7 +391,8 @@ impl Collection {
     /// `GraphFirst` inverts the order:
     /// 1. Full-scan filtered by metadata → produces a *small* candidate set.
     /// 2. Exact vector similarity is computed for each candidate using the stored vector.
-    /// 3. Results are sorted by score and truncated to `limit`.
+    /// 3. A bounded top-k heap (#901) retains only the `limit` best results in
+    ///    `O(limit)` memory, yielding the same top-k as a full sort + truncate.
     ///
     /// # Performance characteristic
     ///
@@ -395,26 +409,50 @@ impl Collection {
         query: &[f32],
         limit: usize,
     ) -> Vec<SearchResult> {
-        // MAX_LIMIT inline: same bound as the constant in query/mod.rs.
+        // #901: bound the scored candidate set with a top-k heap instead of
+        // materializing every metadata match and full-sorting. `SCAN_CAP`
+        // caps how many *matches* we score (pathological-query guard); the
+        // heap caps retained memory to O(limit). Results and ordering are
+        // identical to the previous full sort + truncate.
         const SCAN_CAP: usize = 100_000;
 
         let metric = self.config().metric;
+        let higher_is_better = metric.higher_is_better();
 
-        let mut candidates = self.execute_scan_query(metadata_filter, SCAN_CAP);
-
-        for r in &mut candidates {
+        let candidates = self.execute_scan_query(metadata_filter, SCAN_CAP);
+        let mut topk = super::bounded_top_k::BoundedTopK::new(limit, higher_is_better);
+        for mut r in candidates {
             // Exact distance computation using the stored vector.
             // Clamp is mandatory (SecDev) to guard against NaN from zero-norm vectors.
             r.score = metric.calculate(&r.point.vector, query).clamp(-1.0, 1.0);
+            topk.offer(r);
         }
 
-        if metric.higher_is_better() {
-            candidates.sort_unstable_by(|a, b| b.score.total_cmp(&a.score));
-        } else {
-            candidates.sort_unstable_by(|a, b| a.score.total_cmp(&b.score));
-        }
+        topk.into_sorted_vec()
+    }
+}
 
-        candidates.truncate(limit);
-        candidates
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// #901: a `NOT similarity()` scan within the server ceiling is allowed.
+    #[test]
+    fn test_not_similarity_guard_allows_within_ceiling() {
+        assert!(Collection::guard_not_similarity_scan(Collection::NOT_SIMILARITY_MAX_SCAN).is_ok());
+        assert!(Collection::guard_not_similarity_scan(10_000).is_ok());
+    }
+
+    /// #901: a `NOT similarity()` scan over the server ceiling is REJECTED
+    /// (not merely warned) to block the unbounded-scan DoS vector.
+    #[test]
+    fn test_not_similarity_guard_rejects_above_ceiling() {
+        let err = Collection::guard_not_similarity_scan(Collection::NOT_SIMILARITY_MAX_SCAN + 1)
+            .expect_err("scan above ceiling must be rejected");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("scan limit") || msg.contains("exceeding"),
+            "error should explain the scan-limit rejection, got: {msg}"
+        );
     }
 }

--- a/crates/velesdb-core/src/collection/search/query/where_eval.rs
+++ b/crates/velesdb-core/src/collection/search/query/where_eval.rs
@@ -9,10 +9,18 @@ use crate::point::SearchResult;
 use crate::velesql::{CompareOp, Condition, GraphMatchPredicate};
 use std::collections::HashSet;
 
-/// Cache for graph predicate anchor sets during a single query execution.
+/// Per-query evaluation cache shared across all result rows.
+///
+/// Holds graph-predicate anchor sets and (#904) the `Filter` built for each
+/// metadata-leaf condition node, so neither is recomputed per row.
 #[derive(Default)]
 pub(crate) struct GraphMatchEvalCache {
     entries: Vec<(GraphMatchPredicate, HashSet<u64>)>,
+    /// #904: cached `Filter`s for metadata-leaf conditions, keyed by the leaf
+    /// node's pointer address. The borrowed condition AST is the *same* across
+    /// every row of a single evaluation, so pointer identity is a stable key
+    /// and lets us build each leaf `Filter` exactly once instead of per row.
+    filters: Vec<(usize, crate::filter::Filter)>,
 }
 
 impl GraphMatchEvalCache {
@@ -31,6 +39,25 @@ impl GraphMatchEvalCache {
         self.entries.push((predicate.clone(), ids));
         let idx = self.entries.len() - 1;
         Ok(&self.entries[idx].1)
+    }
+
+    /// Returns the cached `Filter` for a metadata-leaf `condition`, building it
+    /// once on first use (#904).
+    fn metadata_filter(&mut self, condition: &Condition) -> &crate::filter::Filter {
+        let key = std::ptr::from_ref(condition) as usize;
+        if let Some(idx) = self.filters.iter().position(|(k, _)| *k == key) {
+            return &self.filters[idx].1;
+        }
+        let filter = crate::filter::Filter::new(crate::filter::Condition::from(condition.clone()));
+        self.filters.push((key, filter));
+        let idx = self.filters.len() - 1;
+        &self.filters[idx].1
+    }
+
+    /// Test seam (#904): number of distinct metadata-leaf `Filter`s built.
+    #[cfg(test)]
+    pub(crate) fn filters_built(&self) -> usize {
+        self.filters.len()
     }
 }
 
@@ -165,7 +192,12 @@ impl Collection {
             Condition::Group(inner) => self.eval_condition(inner, ctx, graph_cache),
             Condition::Similarity(sim) => self.evaluate_similarity(sim, ctx.vector, ctx.params),
             Condition::VectorSearch(_) | Condition::VectorFusedSearch(_) => Ok(true),
-            other => Ok(Self::evaluate_metadata_filter(other, ctx.payload)),
+            // #904: reuse the per-query cached `Filter` for this metadata leaf
+            // instead of rebuilding it (and cloning the AST) on every row.
+            other => {
+                let filter = graph_cache.metadata_filter(other);
+                Ok(Self::payload_passes_filter(filter, ctx.payload))
+            }
         }
     }
 
@@ -248,24 +280,63 @@ impl Collection {
             }
         }
     }
-
-    /// Evaluates a metadata-only condition via the filter engine.
-    fn evaluate_metadata_filter(
-        condition: &Condition,
-        payload: Option<&serde_json::Value>,
-    ) -> bool {
-        let filter = crate::filter::Filter::new(crate::filter::Condition::from(condition.clone()));
-        match payload {
-            Some(p) => filter.matches(p),
-            None => filter.matches(&serde_json::Value::Null),
-        }
-    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::velesql::{CompareOp, Comparison, Value};
+
+    /// #904: the metadata `Filter` for a leaf condition is built **once** and
+    /// reused across repeated evaluations of the same AST node (one per result
+    /// row), instead of rebuilding + cloning per row. Results are unchanged.
+    #[test]
+    fn test_metadata_filter_built_once_per_leaf() {
+        let cond = Condition::Comparison(Comparison {
+            column: "status".to_string(),
+            operator: CompareOp::Eq,
+            value: Value::String("active".to_string()),
+        });
+
+        let mut cache = GraphMatchEvalCache::default();
+        let active = serde_json::json!({"status": "active"});
+        let inactive = serde_json::json!({"status": "inactive"});
+
+        // Evaluate the SAME borrowed node many times (simulates N result rows).
+        for _ in 0..100 {
+            let f = cache.metadata_filter(&cond);
+            assert!(f.matches(&active));
+            assert!(!f.matches(&inactive));
+        }
+
+        assert_eq!(
+            cache.filters_built(),
+            1,
+            "metadata Filter must be built exactly once, not per row"
+        );
+    }
+
+    /// #904: distinct leaf nodes each get their own cached `Filter`.
+    #[test]
+    fn test_metadata_filter_distinct_leaves_cached_separately() {
+        let cond_a = Condition::Comparison(Comparison {
+            column: "a".to_string(),
+            operator: CompareOp::Eq,
+            value: Value::Integer(1),
+        });
+        let cond_b = Condition::Comparison(Comparison {
+            column: "b".to_string(),
+            operator: CompareOp::Eq,
+            value: Value::Integer(2),
+        });
+
+        let mut cache = GraphMatchEvalCache::default();
+        let _ = cache.metadata_filter(&cond_a);
+        let _ = cache.metadata_filter(&cond_b);
+        let _ = cache.metadata_filter(&cond_a);
+
+        assert_eq!(cache.filters_built(), 2);
+    }
 
     #[test]
     fn test_condition_contains_or_detects_nested_or() {

--- a/crates/velesdb-core/src/database/query_engine.rs
+++ b/crates/velesdb-core/src/database/query_engine.rs
@@ -125,6 +125,9 @@ impl Database {
             .collect();
 
         crate::cache::PlanKey {
+            // Issue #902: store the canonical text so PlanKey equality is
+            // collision-safe. query_hash stays a Hash accelerator only.
+            query_text: query_text.into(),
             query_hash,
             schema_version,
             collection_generations,
@@ -343,7 +346,8 @@ impl Database {
         // the set operation sees the full result sets.  The final LIMIT is applied
         // once on the merged output (SQL-standard behaviour).
         // Use MAX_LIMIT (not None) to avoid the default-10 cap downstream.
-        let compound_limit = Some(100_000_u64);
+        const COMPOUND_LIMIT: usize = 100_000;
+        let compound_limit = Some(COMPOUND_LIMIT as u64); // 100_000 fits u64 exactly.
         let left_results = if query.compound.is_some() {
             let mut left_query = query.clone();
             left_query.select.limit = compound_limit;
@@ -363,6 +367,9 @@ impl Database {
                     accumulated,
                     right_results,
                     *operator,
+                    // Intermediate ops keep the server-side ceiling: truncating to the
+                    // user LIMIT here would drop rows a later chained set op still needs.
+                    COMPOUND_LIMIT,
                 );
             }
             // SQL-standard: LIMIT from the left (outer) SELECT applies to the final result.
@@ -466,9 +473,11 @@ impl Database {
                 Self::strip_pushed_conditions(query.select.where_clause.as_ref(), &pushed);
         }
 
+        let row_budget = Self::join_row_budget(&query.select, &analysis);
+
         let mut results = base_collection.execute_query(&single_query, params)?;
         for join in &query.select.joins {
-            results = self.execute_single_join(&results, join, &pushed)?;
+            results = self.execute_single_join(&results, join, &pushed, row_budget)?;
         }
 
         // Apply post-join filters: cross-source predicates that reference
@@ -484,6 +493,39 @@ impl Database {
         }
 
         Ok(results)
+    }
+
+    /// Computes the bound on joined rows to materialize.
+    ///
+    /// When the query has an explicit LIMIT, no post-join filters, and no
+    /// ORDER BY (which could reorder past the window), the bound is the
+    /// effective `LIMIT + OFFSET`. GROUP BY / HAVING / DISTINCT also disqualify
+    /// the bounded shape: SQL LIMIT bounds output *groups/rows*, not input rows,
+    /// so truncating joined input to `LIMIT` would drop rows that belong to
+    /// groups still inside the window. Otherwise downstream stages may reorder or
+    /// drop rows, so we fall back to the conservative server-side ceiling
+    /// [`JOIN_ROW_CEILING`] — still bounding OOM without affecting correctness.
+    pub(super) fn join_row_budget(
+        select: &crate::velesql::SelectStatement,
+        analysis: &crate::collection::search::query::pushdown::PushdownAnalysis,
+    ) -> usize {
+        use crate::collection::search::query::JOIN_ROW_CEILING;
+        use crate::velesql::DistinctMode;
+        let bounded_shape = analysis.post_join_filters.is_empty()
+            && select.order_by.is_none()
+            && select.group_by.is_none()
+            && select.having.is_none()
+            && select.distinct == DistinctMode::None;
+        match select.limit {
+            Some(limit) if bounded_shape => {
+                let limit = usize::try_from(limit).unwrap_or(JOIN_ROW_CEILING);
+                let offset = select
+                    .offset
+                    .map_or(0, |o| usize::try_from(o).unwrap_or(JOIN_ROW_CEILING));
+                limit.saturating_add(offset).min(JOIN_ROW_CEILING)
+            }
+            _ => JOIN_ROW_CEILING,
+        }
     }
 
     // NOTE: analyze_join_pushdown_for_select, apply_post_join_filters

--- a/crates/velesdb-core/src/database/query_engine_tests.rs
+++ b/crates/velesdb-core/src/database/query_engine_tests.rs
@@ -188,3 +188,52 @@ fn test_schema_version_increments_on_create_and_delete() {
     let v2 = db.schema_version();
     assert!(v2 > v1, "schema_version should increment after delete");
 }
+
+// =========================================================================
+// join_row_budget: LIMIT must NOT bound joined INPUT rows for shapes where
+// downstream stages aggregate/dedup/reorder (GROUP BY / HAVING / DISTINCT /
+// ORDER BY). SQL LIMIT bounds output groups/rows, not input rows.
+// =========================================================================
+
+use crate::collection::search::query::pushdown::PushdownAnalysis;
+use crate::collection::search::query::JOIN_ROW_CEILING;
+
+fn select_of(sql: &str) -> crate::velesql::SelectStatement {
+    Parser::parse(sql).unwrap().select
+}
+
+#[test]
+fn test_join_row_budget_plain_limit_uses_limit() {
+    // No GROUP BY / DISTINCT / HAVING / ORDER BY: LIMIT bounds input rows.
+    let select = select_of("SELECT d.id FROM docs AS d JOIN meta AS m ON d.id = m.id LIMIT 5");
+    let budget = Database::join_row_budget(&select, &PushdownAnalysis::default());
+    assert_eq!(budget, 5);
+}
+
+#[test]
+fn test_join_row_budget_group_by_uses_ceiling() {
+    // GROUP BY ... LIMIT n bounds GROUPS, not input rows: must NOT truncate to n.
+    let select = select_of(
+        "SELECT m.tag FROM docs AS d JOIN meta AS m ON d.id = m.id GROUP BY m.tag LIMIT 2",
+    );
+    let budget = Database::join_row_budget(&select, &PushdownAnalysis::default());
+    assert_eq!(budget, JOIN_ROW_CEILING);
+}
+
+#[test]
+fn test_join_row_budget_distinct_uses_ceiling() {
+    // DISTINCT dedups output rows: LIMIT must not truncate the join input.
+    let select =
+        select_of("SELECT DISTINCT m.tag FROM docs AS d JOIN meta AS m ON d.id = m.id LIMIT 2");
+    let budget = Database::join_row_budget(&select, &PushdownAnalysis::default());
+    assert_eq!(budget, JOIN_ROW_CEILING);
+}
+
+#[test]
+fn test_join_row_budget_order_by_uses_ceiling() {
+    // ORDER BY can reorder past the window: still falls back to the ceiling.
+    let select =
+        select_of("SELECT d.id FROM docs AS d JOIN meta AS m ON d.id = m.id ORDER BY d.id LIMIT 3");
+    let budget = Database::join_row_budget(&select, &PushdownAnalysis::default());
+    assert_eq!(budget, JOIN_ROW_CEILING);
+}

--- a/crates/velesdb-core/src/database/query_join.rs
+++ b/crates/velesdb-core/src/database/query_join.rs
@@ -111,11 +111,16 @@ impl Database {
     }
 
     /// Executes a single JOIN using the optimal strategy: lookup, filtered, or full.
+    ///
+    /// `row_budget` bounds how many joined rows are materialized (the query's
+    /// effective `LIMIT + OFFSET`), preventing OOM on RIGHT/FULL joins over large
+    /// stores. It never drops rows within the requested window.
     pub(super) fn execute_single_join(
         &self,
         results: &[SearchResult],
         join: &crate::velesql::JoinClause,
         pushed: &[crate::velesql::Condition],
+        row_budget: usize,
     ) -> Result<Vec<SearchResult>> {
         let join_collection = self.resolve_collection(&join.table)?;
 
@@ -129,8 +134,12 @@ impl Database {
             Self::build_filtered_join_column_store(&join_collection, pushed)?
         };
 
-        let joined =
-            crate::collection::search::query::join::execute_join(results, join, &column_store)?;
+        let joined = crate::collection::search::query::join::execute_join(
+            results,
+            join,
+            &column_store,
+            row_budget,
+        )?;
         Ok(crate::collection::search::query::join::joined_to_search_results(joined))
     }
 }

--- a/crates/velesdb-core/src/internal_bench.rs
+++ b/crates/velesdb-core/src/internal_bench.rs
@@ -80,7 +80,10 @@ pub fn sparse_insert_batch(index: &SparseInvertedIndex, docs: &[(u64, SparseVect
 }
 
 /// Parses a query through the cache without recording stats.
-pub fn velesql_parse_without_stats(cache: &QueryCache, query: &str) -> Result<Query, ParseError> {
+pub fn velesql_parse_without_stats(
+    cache: &QueryCache,
+    query: &str,
+) -> Result<std::sync::Arc<Query>, ParseError> {
     cache.parse_without_stats(query)
 }
 

--- a/crates/velesdb-core/src/velesql/cache.rs
+++ b/crates/velesdb-core/src/velesql/cache.rs
@@ -7,7 +7,8 @@ use parking_lot::RwLock;
 use rustc_hash::FxHashMap;
 use std::collections::VecDeque;
 use std::hash::{BuildHasher, Hasher};
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
+use std::sync::Arc;
 
 use super::ast::Query;
 use super::error::ParseError;
@@ -37,21 +38,41 @@ impl CacheStats {
     }
 }
 
-/// LRU cache for parsed `VelesQL` queries.
+/// Bounded query cache for parsed `VelesQL` queries (issue #903).
 ///
 /// Thread-safe implementation using `parking_lot::RwLock`.
 ///
 /// # Design notes
 ///
 /// - Canonical query text is hashed for compact bucketing.
-/// - Hash collisions are handled explicitly via a per-bucket vector.
-/// - A strict equality check on original query text is required before reuse.
-/// - LRU order stores unique cache keys and is kept in sync with entry count.
+/// - Hash collisions are handled explicitly via a per-bucket vector, with a
+///   strict equality check on the original query text before reuse.
+/// - Parsed ASTs are stored behind `Arc<Query>`; a hit returns `Arc::clone`
+///   (a refcount bump) instead of deep-cloning the AST.
+/// - A live `usize` size counter (`AtomicUsize`) gives O(1) `len()` and avoids
+///   re-summing every bucket on each insert/eviction.
+///
+/// # Hot-path concurrency (issue #903)
+///
+/// The previous design took a **global write lock** (`order.write()`) on every
+/// cache hit to promote the entry to the MRU position, serialising all reads.
+/// This implementation replaces strict LRU with a **CLOCK / second-chance**
+/// policy:
+///
+/// - A cache **hit** takes only a shared `read()` lock and sets a per-entry
+///   `referenced` bit via a relaxed atomic store — no write lock, so concurrent
+///   hits run in parallel.
+/// - Eviction (on the cold insert path, under the write lock) sweeps the
+///   insertion-order ring: an entry whose `referenced` bit is set gets a second
+///   chance (bit cleared, moved to the back); an entry with a clear bit is
+///   evicted. This approximates LRU while keeping the hit path lock-light.
 pub struct QueryCache {
-    /// Cache storage: canonical-hash -> collision-safe entries.
-    cache: RwLock<FxHashMap<u64, Vec<CacheEntry>>>,
-    /// LRU order: front = oldest key, back = most recently used.
-    order: RwLock<VecDeque<CacheKey>>,
+    /// Cache storage + CLOCK ring guarded by a single lock so a hit can observe
+    /// both under one `read()` acquisition.
+    inner: RwLock<CacheInner>,
+    /// Live entry count. O(1) `len()`; kept in sync with `inner` under the write
+    /// lock on insert/evict and reset on clear.
+    size: AtomicUsize,
     /// Maximum cache size.
     max_size: usize,
     /// Hash function for canonical query text.
@@ -60,17 +81,30 @@ pub struct QueryCache {
     stats: AtomicCacheStats,
 }
 
+/// Storage + CLOCK ring, guarded together by `QueryCache::inner`.
+struct CacheInner {
+    /// Cache storage: canonical-hash -> collision-safe entries.
+    map: FxHashMap<u64, Vec<CacheEntry>>,
+    /// CLOCK ring of cache keys in insertion order; the eviction hand sweeps
+    /// from the front. Mutated only under the write lock (insert / evict).
+    order: VecDeque<CacheKey>,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 struct CacheKey {
     hash: u64,
     original_query: String,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 struct CacheEntry {
     original_query: String,
     canonical_query: String,
-    parsed: Query,
+    /// Parsed AST shared via `Arc`; hits return `Arc::clone`, never a deep copy.
+    parsed: Arc<Query>,
+    /// CLOCK second-chance bit. Set on every hit (relaxed atomic under a read
+    /// lock); consulted and cleared by the eviction sweep.
+    referenced: AtomicBool,
 }
 
 #[derive(Debug, Default)]
@@ -108,158 +142,168 @@ impl QueryCache {
     }
 
     fn new_with_hasher(max_size: usize, hash_fn: fn(&str) -> u64) -> Self {
+        let max_size = max_size.max(1);
         Self {
-            cache: RwLock::new(FxHashMap::default()),
-            order: RwLock::new(VecDeque::with_capacity(max_size.max(1))),
-            max_size: max_size.max(1),
+            inner: RwLock::new(CacheInner {
+                map: FxHashMap::default(),
+                order: VecDeque::with_capacity(max_size),
+            }),
+            size: AtomicUsize::new(0),
+            max_size,
             hash_fn,
             stats: AtomicCacheStats::default(),
         }
     }
 
-    /// Parses a query, returning cached AST if available.
+    /// Parses a query, returning a shared (`Arc`) cached AST if available.
     ///
     /// # Errors
     ///
     /// Returns `ParseError` if the query is invalid.
-    pub fn parse(&self, query: &str) -> Result<Query, ParseError> {
+    pub fn parse(&self, query: &str) -> Result<Arc<Query>, ParseError> {
         self.parse_impl(query, true)
     }
 
     #[cfg(feature = "internal-bench")]
-    pub(crate) fn parse_without_stats(&self, query: &str) -> Result<Query, ParseError> {
+    pub(crate) fn parse_without_stats(&self, query: &str) -> Result<Arc<Query>, ParseError> {
         self.parse_impl(query, false)
     }
 
-    fn parse_impl(&self, query: &str, record_stats: bool) -> Result<Query, ParseError> {
+    fn parse_impl(&self, query: &str, record_stats: bool) -> Result<Arc<Query>, ParseError> {
         let canonical_query = canonicalize_query(query);
-        let original_query = query.to_string();
         let hash = (self.hash_fn)(&canonical_query);
 
-        if let Some(cached) =
-            self.try_cache_hit(hash, &original_query, &canonical_query, record_stats)
-        {
+        if let Some(cached) = self.try_cache_hit(hash, query, &canonical_query, record_stats) {
             return Ok(cached);
         }
 
-        let parsed = Parser::parse(query)?;
-        self.insert_into_cache(
-            hash,
-            original_query,
-            canonical_query,
-            query,
-            &parsed,
-            record_stats,
-        );
+        let parsed = Arc::new(Parser::parse(query)?);
+        self.insert_into_cache(hash, canonical_query, query, &parsed, record_stats);
         Ok(parsed)
     }
 
-    /// Attempts to find and return a cached query, promoting it in LRU order.
+    /// Read-only hot path (issue #903): looks up a cached query under a **shared**
+    /// lock and, on a hit, sets the CLOCK `referenced` bit with a relaxed atomic
+    /// store. No write lock is taken, so concurrent hits do not serialise.
     fn try_cache_hit(
         &self,
         hash: u64,
         original_query: &str,
         canonical_query: &str,
         record_stats: bool,
-    ) -> Option<Query> {
-        let cache = self.cache.upgradable_read();
-        let cached = cache.get(&hash).and_then(|entries| {
-            entries
-                .iter()
-                .find(|entry| {
-                    entry.original_query == original_query
-                        && entry.canonical_query == canonical_query
-                })
-                .cloned()
+    ) -> Option<Arc<Query>> {
+        let inner = self.inner.read();
+        let entry = inner.map.get(&hash).and_then(|entries| {
+            entries.iter().find(|entry| {
+                entry.original_query == original_query && entry.canonical_query == canonical_query
+            })
         })?;
 
-        let key = CacheKey {
-            hash,
-            original_query: original_query.to_string(),
-        };
-        // O(n) LRU promotion: VecDeque::remove shifts elements. For L1 cache size
-        // of 1000 entries, this is ~4KB of data movement per hit — acceptable for
-        // the current QPS targets. If cache hit rate becomes a bottleneck at >50k QPS,
-        // replace with an IndexMap or intrusive linked list for O(1) promotion.
-        let mut order = self.order.write();
-        if let Some(pos) = order.iter().position(|existing| existing == &key) {
-            order.remove(pos);
-        }
-        order.push_back(key);
-        drop(order);
+        // Second-chance bit: cheap relaxed store, safe under a shared lock via
+        // interior mutability (AtomicBool). No global write lock on the hit path.
+        entry.referenced.store(true, Ordering::Relaxed);
+        let parsed = Arc::clone(&entry.parsed);
+        drop(inner);
 
         if record_stats {
             self.stats.hits.fetch_add(1, Ordering::Relaxed);
         }
-        Some(cached.parsed)
+        Some(parsed)
     }
 
-    /// Inserts a freshly parsed query into the cache, evicting old entries as needed.
+    /// Inserts a freshly parsed query into the cache, evicting via CLOCK as needed.
     fn insert_into_cache(
         &self,
         hash: u64,
-        original_query: String,
         canonical_query: String,
         raw_query: &str,
-        parsed: &Query,
+        parsed: &Arc<Query>,
         record_stats: bool,
     ) {
-        let mut cache = self.cache.write();
-        let mut order = self.order.write();
+        let mut inner = self.inner.write();
 
         if record_stats {
             self.stats.misses.fetch_add(1, Ordering::Relaxed);
         }
 
-        self.evict_oldest(&mut cache, &mut order, record_stats);
-
         let key = CacheKey {
             hash,
-            original_query: original_query.clone(),
+            original_query: raw_query.to_string(),
         };
 
-        if let Some(pos) = order.iter().position(|existing| existing == &key) {
-            order.remove(pos);
+        // Replacing an existing entry for the same query is not a net size change,
+        // so only evict when inserting a genuinely new key.
+        let is_new_key = !Self::bucket_contains(&inner.map, hash, raw_query);
+        if is_new_key {
+            self.evict_until_below_bound(&mut inner, record_stats);
         }
 
         let new_entry = CacheEntry {
-            original_query,
+            original_query: raw_query.to_string(),
             canonical_query,
-            parsed: parsed.clone(),
+            parsed: Arc::clone(parsed),
+            referenced: AtomicBool::new(false),
         };
 
-        cache
-            .entry(hash)
-            .and_modify(|bucket| {
-                bucket.retain(|entry| entry.original_query != raw_query);
-                bucket.push(new_entry.clone());
-            })
-            .or_insert_with(|| vec![new_entry]);
+        let bucket = inner.map.entry(hash).or_default();
+        bucket.retain(|entry| entry.original_query != raw_query);
+        bucket.push(new_entry);
 
-        order.push_back(key);
-        debug_assert_eq!(Self::entry_count(&cache), order.len());
+        if is_new_key {
+            inner.order.push_back(key);
+            self.size.fetch_add(1, Ordering::Relaxed);
+        }
+        debug_assert_eq!(self.size.load(Ordering::Relaxed), inner.order.len());
     }
 
-    /// Evicts oldest entries until the cache is below `max_size`.
-    fn evict_oldest(
-        &self,
-        cache: &mut FxHashMap<u64, Vec<CacheEntry>>,
-        order: &mut VecDeque<CacheKey>,
-        record_stats: bool,
-    ) {
-        while Self::entry_count(cache) >= self.max_size {
-            if let Some(oldest) = order.pop_front() {
-                if let Some(bucket) = cache.get_mut(&oldest.hash) {
-                    bucket.retain(|entry| entry.original_query != oldest.original_query);
-                    if bucket.is_empty() {
-                        cache.remove(&oldest.hash);
-                    }
-                }
-                if record_stats {
-                    self.stats.evictions.fetch_add(1, Ordering::Relaxed);
-                }
+    /// CLOCK / second-chance eviction: sweep the insertion-order ring until the
+    /// live size is back under `max_size`. An entry whose `referenced` bit is set
+    /// gets a second chance (bit cleared, re-queued at the back); otherwise it is
+    /// evicted. Amortised O(1) per insert — no per-iteration bucket re-sum.
+    fn evict_until_below_bound(&self, inner: &mut CacheInner, record_stats: bool) {
+        while self.size.load(Ordering::Relaxed) >= self.max_size {
+            let Some(candidate) = inner.order.pop_front() else {
+                break;
+            };
+            if Self::take_second_chance(&inner.map, &candidate) {
+                inner.order.push_back(candidate);
+                continue;
+            }
+            Self::remove_entry(&mut inner.map, &candidate);
+            self.size.fetch_sub(1, Ordering::Relaxed);
+            if record_stats {
+                self.stats.evictions.fetch_add(1, Ordering::Relaxed);
             }
         }
+    }
+
+    /// Returns `true` (granting a second chance) if the candidate's entry has its
+    /// `referenced` bit set, clearing the bit as a side effect.
+    fn take_second_chance(map: &FxHashMap<u64, Vec<CacheEntry>>, key: &CacheKey) -> bool {
+        map.get(&key.hash)
+            .and_then(|bucket| {
+                bucket
+                    .iter()
+                    .find(|entry| entry.original_query == key.original_query)
+            })
+            .is_some_and(|entry| entry.referenced.swap(false, Ordering::Relaxed))
+    }
+
+    /// Removes the entry identified by `key` from its bucket, dropping the bucket
+    /// if it becomes empty.
+    fn remove_entry(map: &mut FxHashMap<u64, Vec<CacheEntry>>, key: &CacheKey) {
+        if let Some(bucket) = map.get_mut(&key.hash) {
+            bucket.retain(|entry| entry.original_query != key.original_query);
+            if bucket.is_empty() {
+                map.remove(&key.hash);
+            }
+        }
+    }
+
+    /// Returns `true` if a bucket already holds an entry for `raw_query`.
+    fn bucket_contains(map: &FxHashMap<u64, Vec<CacheEntry>>, hash: u64, raw_query: &str) -> bool {
+        map.get(&hash)
+            .is_some_and(|bucket| bucket.iter().any(|entry| entry.original_query == raw_query))
     }
 
     /// Returns current cache statistics.
@@ -268,10 +312,10 @@ impl QueryCache {
         self.stats.snapshot()
     }
 
-    /// Returns the current number of cached queries.
+    /// Returns the current number of cached queries (O(1)).
     #[must_use]
     pub fn len(&self) -> usize {
-        Self::entry_count(&self.cache.read())
+        self.size.load(Ordering::Relaxed)
     }
 
     /// Returns true if the cache is empty.
@@ -282,16 +326,11 @@ impl QueryCache {
 
     /// Clears all cached queries and resets statistics.
     pub fn clear(&self) {
-        let mut cache = self.cache.write();
-        let mut order = self.order.write();
-
-        cache.clear();
-        order.clear();
+        let mut inner = self.inner.write();
+        inner.map.clear();
+        inner.order.clear();
+        self.size.store(0, Ordering::Relaxed);
         self.stats.clear();
-    }
-
-    fn entry_count(cache: &FxHashMap<u64, Vec<CacheEntry>>) -> usize {
-        cache.values().map(std::vec::Vec::len).sum()
     }
 }
 
@@ -395,7 +434,10 @@ mod tests {
     }
 
     #[test]
-    fn test_query_cache_hit_refreshes_mru_without_duplicates() {
+    fn test_query_cache_hit_keeps_clock_ring_unique() {
+        // Issue #903: a hit no longer rewrites LRU order (CLOCK promotion sets a
+        // referenced bit instead). The ring must still contain each key once and
+        // stay in sync with the O(1) size counter.
         let cache = QueryCache::new(3);
         let q1 = "SELECT * FROM docs LIMIT 1";
         let q2 = "SELECT * FROM docs LIMIT 2";
@@ -404,18 +446,83 @@ mod tests {
         let _ = cache.parse(q1);
         let _ = cache.parse(q2);
         let _ = cache.parse(q3);
-        let _ = cache.parse(q1);
+        let _ = cache.parse(q1); // hit: sets referenced bit, no reordering
 
-        let order = cache.order.read();
-        assert_eq!(order.len(), cache.len());
+        let inner = cache.inner.read();
+        assert_eq!(inner.order.len(), cache.len());
         assert_eq!(
-            order
+            inner
+                .order
                 .iter()
                 .filter(|v| v.original_query.as_str() == q1)
                 .count(),
-            1
+            1,
+            "no duplicate ring entries on hit"
         );
-        assert_eq!(order.back().map(|v| v.original_query.as_str()), Some(q1));
+    }
+
+    #[test]
+    fn test_query_cache_clock_referenced_entry_survives_eviction() {
+        // Issue #903: CLOCK second chance. q1 is referenced (hit) before pressure;
+        // it must survive while an un-referenced entry is evicted instead.
+        let cache = QueryCache::new(2);
+        let q1 = "SELECT * FROM docs LIMIT 1";
+        let q2 = "SELECT * FROM docs LIMIT 2";
+        let q3 = "SELECT * FROM docs LIMIT 3";
+
+        let _ = cache.parse(q1);
+        let _ = cache.parse(q2);
+        let _ = cache.parse(q1); // hit -> q1 gets the referenced bit
+        let _ = cache.parse(q3); // miss -> eviction sweep: q2 evicted, q1 spared
+
+        assert_eq!(cache.len(), 2);
+        // q1 still hits (was spared), q2 should now miss.
+        let hits_before = cache.stats().hits;
+        let _ = cache.parse(q1);
+        assert_eq!(cache.stats().hits, hits_before + 1, "q1 must survive");
+    }
+
+    #[test]
+    fn test_query_cache_hit_path_takes_no_write_lock() {
+        // Issue #903: a hit must not need the write lock. We hold a read guard on
+        // the cache and concurrently issue a hit from another thread; if the hit
+        // tried to take a write lock it would deadlock against our read guard.
+        use std::sync::Arc;
+        use std::thread;
+
+        let cache = Arc::new(QueryCache::new(10));
+        let q = "SELECT * FROM docs LIMIT 1";
+        let _ = cache.parse(q); // populate
+
+        let held = cache.inner.read(); // hold a shared lock for the whole test
+
+        let cache2 = Arc::clone(&cache);
+        let handle = thread::spawn(move || cache2.parse(q).map(|_| ()));
+
+        // If the hit path were write-locking, join() would block forever; the
+        // test harness would hang. A successful join proves the hit is read-only.
+        let res = handle
+            .join()
+            .expect("hit thread must finish without deadlock");
+        assert!(res.is_ok());
+        drop(held);
+    }
+
+    #[test]
+    fn test_query_cache_hit_returns_shared_arc() {
+        // Issue #903: a hit returns Arc::clone of the stored AST, not a deep copy.
+        let cache = QueryCache::new(10);
+        let q = "SELECT * FROM docs LIMIT 1";
+
+        let first = cache.parse(q).expect("parse");
+        let second = cache.parse(q).expect("hit");
+
+        assert!(
+            Arc::ptr_eq(&first, &second),
+            "hit must return the same Arc allocation (no deep clone)"
+        );
+        // The cache also retains its own reference, so strong count is >= 3.
+        assert!(Arc::strong_count(&first) >= 3);
     }
 
     #[test]
@@ -447,12 +554,12 @@ mod tests {
             h.join().expect("thread must complete");
         }
 
-        let order = cache.order.read();
+        let inner = cache.inner.read();
         let mut uniq = std::collections::HashSet::new();
-        for key in order.iter() {
-            assert!(uniq.insert(key.clone()), "duplicate query in LRU order");
+        for key in &inner.order {
+            assert!(uniq.insert(key.clone()), "duplicate query in CLOCK ring");
         }
-        assert_eq!(order.len(), cache.len());
+        assert_eq!(inner.order.len(), cache.len());
     }
 
     #[test]


### PR DESCRIPTION
**Closes #901, Closes #904, Closes #902, Closes #903.** Grouped: plan-cache (#902) and JOIN bounding (#901) share `query_engine.rs`.

- **#901:** bounded top-k (identical results), GROUP BY ceiling, NOT-similarity guard-rail, JOIN/traversal/set-op bounds (post-dedup, exact `limit`).
- **#904:** per-query Filter built once.
- **#902:** collision-safe plan-cache key.
- **#903:** parse-cache CLOCK + O(1) size + `Arc<Query>`.

---
Part of the 2026-05-28 `velesdb-core` security/perf/OOM audit (`report/AUDIT-velesdb-core-2026-05-28.md`). Implemented by a specialist sub-agent, then adversarial review→fix rounds to 0 findings. Integration-branch gate: `cargo fmt --check`, workspace `clippy -D warnings -D clippy::pedantic`, full lib suite (4914 tests), recall contracts — all green. Every fix ships a regression test.