### PR TITLE
fix(config): enforce validation in loaders + on open, bound RateLimiter (#907)

### DIFF
--- a/crates/velesdb-core/src/config.rs
+++ b/crates/velesdb-core/src/config.rs
@@ -333,9 +333,11 @@ impl VelesConfig {
             .merge(Toml::file(path.as_ref()))
             .merge(Env::prefixed("VELESDB_").split("_").lowercase(false));
 
-        figment
+        let config: Self = figment
             .extract()
-            .map_err(|e| ConfigError::ParseError(e.to_string()))
+            .map_err(|e| ConfigError::ParseError(e.to_string()))?;
+        config.validate()?;
+        Ok(config)
     }
 
     /// Creates a configuration from a TOML string.
@@ -352,9 +354,11 @@ impl VelesConfig {
             .merge(Serialized::defaults(Self::default()))
             .merge(Toml::string(toml_str));
 
-        figment
+        let config: Self = figment
             .extract()
-            .map_err(|e| ConfigError::ParseError(e.to_string()))
+            .map_err(|e| ConfigError::ParseError(e.to_string()))?;
+        config.validate()?;
+        Ok(config)
     }
 
     // Validation is in config_validation.rs

--- a/crates/velesdb-core/src/config_tests.rs
+++ b/crates/velesdb-core/src/config_tests.rs
@@ -274,6 +274,120 @@ default_mode = "ultra_fast"
         assert!(result.is_err());
     }
 
+    #[test]
+    fn test_from_toml_rejects_zero_max_collections() {
+        // Regression (#907): loaders previously skipped validate(), silently
+        // accepting out-of-range values. A zero capacity must now be rejected.
+        let toml = r"
+[limits]
+max_collections = 0
+";
+
+        // Act
+        let result = VelesConfig::from_toml(toml);
+
+        // Assert
+        assert!(result.is_err(), "max_collections = 0 must be rejected");
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains("limits.max_collections"));
+    }
+
+    #[test]
+    fn test_from_toml_default_config_validates_via_loader() {
+        // Regression (#907): the DEFAULT config must still pass validation
+        // when produced through the loader (no false-positive rejection).
+        let result = VelesConfig::from_toml("");
+
+        // Assert
+        assert!(
+            result.is_ok(),
+            "default config must validate via loader: {:?}",
+            result.err()
+        );
+    }
+
+    #[test]
+    fn test_config_validate_query_timeout_just_under_cap() {
+        // 24h cap (#907 follow-up): a long-but-finite batch timeout just below
+        // the cap must validate (the old 1h cap rejected such legit configs).
+        let mut config = VelesConfig::default();
+        config.search.query_timeout_ms = 86_400_000 - 1; // just under 24h
+
+        assert!(
+            config.validate().is_ok(),
+            "timeout just under the cap must validate"
+        );
+    }
+
+    #[test]
+    fn test_config_validate_query_timeout_zero_disables() {
+        // `0` means "disabled" and must always validate.
+        let mut config = VelesConfig::default();
+        config.search.query_timeout_ms = 0;
+
+        assert!(config.validate().is_ok(), "0 must disable, not reject");
+    }
+
+    #[test]
+    fn test_config_validate_query_timeout_absurd_rejected() {
+        // An absurdly large finite timeout (above the 24h cap) is rejected.
+        let mut config = VelesConfig::default();
+        config.search.query_timeout_ms = u64::MAX;
+
+        let result = config.validate();
+        assert!(result.is_err(), "absurd timeout must be rejected");
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("search.query_timeout_ms"));
+    }
+
+    #[test]
+    fn test_config_validate_mmap_cache_zero_rejected() {
+        // A zero-byte mmap cache is meaningless and must be rejected.
+        let mut config = VelesConfig::default();
+        config.storage.mmap_cache_mb = 0;
+
+        let result = config.validate();
+        assert!(result.is_err(), "mmap_cache_mb = 0 must be rejected");
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("storage.mmap_cache_mb"));
+    }
+
+    #[test]
+    fn test_config_validate_mmap_cache_too_large_rejected() {
+        let mut config = VelesConfig::default();
+        config.storage.mmap_cache_mb = usize::MAX;
+
+        let result = config.validate();
+        assert!(result.is_err(), "absurd mmap_cache_mb must be rejected");
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("storage.mmap_cache_mb"));
+    }
+
+    #[test]
+    fn test_config_validate_workers_zero_is_auto() {
+        // `0` workers means "auto" (derive from CPU count) and must validate.
+        let mut config = VelesConfig::default();
+        config.server.workers = 0;
+
+        assert!(config.validate().is_ok(), "workers = 0 means auto");
+    }
+
+    #[test]
+    fn test_config_validate_workers_too_large_rejected() {
+        let mut config = VelesConfig::default();
+        config.server.workers = usize::MAX;
+
+        let result = config.validate();
+        assert!(result.is_err(), "absurd worker count must be rejected");
+        assert!(result.unwrap_err().to_string().contains("server.workers"));
+    }
+
     // ========================================================================
     // Serialization tests
     // ========================================================================

--- a/crates/velesdb-core/src/config_validation.rs
+++ b/crates/velesdb-core/src/config_validation.rs
@@ -4,6 +4,49 @@
 
 use crate::config::{ConfigError, VelesConfig};
 
+// ---------------------------------------------------------------------------
+// Upper-bound caps for capacity/size limits.
+//
+// These caps reject absurd values that would silently invite resource
+// exhaustion or integer-overflow surprises downstream, while staying well
+// above every realistic deployment (and above the crate defaults so the
+// default config validates through the loaders). `0` is rejected for
+// capacities/sizes because a zero capacity is never a meaningful config.
+// ---------------------------------------------------------------------------
+
+/// Hard ceiling for `limits.max_vectors_per_collection` (10 billion).
+const MAX_VECTORS_PER_COLLECTION_CAP: usize = 10_000_000_000;
+/// Hard ceiling for `limits.max_collections` (1 million).
+const MAX_COLLECTIONS_CAP: usize = 1_000_000;
+/// Hard ceiling for `limits.max_payload_size` (1 GiB).
+const MAX_PAYLOAD_SIZE_CAP: usize = 1_073_741_824;
+/// Hard ceiling for `limits.max_perfect_mode_vectors` (100 million).
+const MAX_PERFECT_MODE_VECTORS_CAP: usize = 100_000_000;
+/// Hard ceiling for `search.query_timeout_ms` (24 hours). `0` means
+/// "disabled". The previous 1-hour cap rejected legitimate long batch
+/// timeouts; 24h is generous enough for any real query while still rejecting
+/// effectively-unbounded values.
+const QUERY_TIMEOUT_MS_CAP: u64 = 86_400_000;
+/// Hard ceiling for `hnsw.max_layers`. `0` means "auto".
+const MAX_LAYERS_CAP: usize = 64;
+/// Hard ceiling for `storage.mmap_cache_mb` (1 TiB). `0` is rejected: a
+/// zero-byte mmap cache is never a meaningful configuration.
+const MMAP_CACHE_MB_CAP: usize = 1_048_576;
+/// Hard ceiling for `server.workers`. `0` means "auto" (derive from CPU
+/// count), so it is allowed; any positive value is capped to a sane ceiling.
+const WORKERS_CAP: usize = 4_096;
+
+/// Rejects `0` and any value above `cap` for a capacity/size field.
+fn range_check_capacity(key: &str, value: usize, cap: usize) -> Result<(), ConfigError> {
+    if value == 0 || value > cap {
+        return Err(ConfigError::InvalidValue {
+            key: key.to_string(),
+            message: format!("value {value} is out of range [1, {cap}]"),
+        });
+    }
+    Ok(())
+}
+
 impl VelesConfig {
     /// Validates the configuration.
     ///
@@ -38,6 +81,18 @@ impl VelesConfig {
                 ),
             });
         }
+
+        // `query_timeout_ms == 0` disables the timeout (see `QueryContext`);
+        // any positive value is capped to avoid effectively-unbounded queries.
+        if self.search.query_timeout_ms > QUERY_TIMEOUT_MS_CAP {
+            return Err(ConfigError::InvalidValue {
+                key: "search.query_timeout_ms".to_string(),
+                message: format!(
+                    "value {} is out of range [0, {QUERY_TIMEOUT_MS_CAP}]",
+                    self.search.query_timeout_ms
+                ),
+            });
+        }
         Ok(())
     }
 
@@ -59,20 +114,44 @@ impl VelesConfig {
                 });
             }
         }
-        Ok(())
-    }
 
-    fn validate_limits(&self) -> Result<(), ConfigError> {
-        if self.limits.max_dimensions == 0 || self.limits.max_dimensions > 65536 {
+        // `max_layers == 0` means "auto" (see `HnswConfig`); a positive value
+        // is capped to a sane ceiling.
+        if self.hnsw.max_layers > MAX_LAYERS_CAP {
             return Err(ConfigError::InvalidValue {
-                key: "limits.max_dimensions".to_string(),
+                key: "hnsw.max_layers".to_string(),
                 message: format!(
-                    "value {} is out of range [1, 65536]",
-                    self.limits.max_dimensions
+                    "value {} is out of range [0, {MAX_LAYERS_CAP}]",
+                    self.hnsw.max_layers
                 ),
             });
         }
         Ok(())
+    }
+
+    fn validate_limits(&self) -> Result<(), ConfigError> {
+        let limits = &self.limits;
+        range_check_capacity("limits.max_dimensions", limits.max_dimensions, 65536)?;
+        range_check_capacity(
+            "limits.max_vectors_per_collection",
+            limits.max_vectors_per_collection,
+            MAX_VECTORS_PER_COLLECTION_CAP,
+        )?;
+        range_check_capacity(
+            "limits.max_collections",
+            limits.max_collections,
+            MAX_COLLECTIONS_CAP,
+        )?;
+        range_check_capacity(
+            "limits.max_payload_size",
+            limits.max_payload_size,
+            MAX_PAYLOAD_SIZE_CAP,
+        )?;
+        range_check_capacity(
+            "limits.max_perfect_mode_vectors",
+            limits.max_perfect_mode_vectors,
+            MAX_PERFECT_MODE_VECTORS_CAP,
+        )
     }
 
     fn validate_server(&self) -> Result<(), ConfigError> {
@@ -80,6 +159,18 @@ impl VelesConfig {
             return Err(ConfigError::InvalidValue {
                 key: "server.port".to_string(),
                 message: format!("value {} must be >= 1024", self.server.port),
+            });
+        }
+
+        // `workers == 0` means "auto" (derive from CPU count); a positive
+        // value is capped so a typo cannot spawn an absurd thread count.
+        if self.server.workers > WORKERS_CAP {
+            return Err(ConfigError::InvalidValue {
+                key: "server.workers".to_string(),
+                message: format!(
+                    "value {} is out of range [0, {WORKERS_CAP}]",
+                    self.server.workers
+                ),
             });
         }
         Ok(())
@@ -96,6 +187,14 @@ impl VelesConfig {
                 ),
             });
         }
+
+        // A zero-byte mmap cache is meaningless; cap the upper bound so an
+        // out-of-range value cannot drive an absurd reservation.
+        range_check_capacity(
+            "storage.mmap_cache_mb",
+            self.storage.mmap_cache_mb,
+            MMAP_CACHE_MB_CAP,
+        )?;
         Ok(())
     }
 

--- a/crates/velesdb-core/src/config_validation.rs
+++ b/crates/velesdb-core/src/config_validation.rs
@@ -47,6 +47,23 @@ fn range_check_capacity(key: &str, value: usize, cap: usize) -> Result<(), Confi
     Ok(())
 }
 
+/// Range-checks a field where `0` is a valid sentinel (disabled / auto) but any
+/// positive value must not exceed `cap`. Unlike [`range_check_capacity`], `0`
+/// is accepted.
+fn range_check_upper<T: PartialOrd + Copy + std::fmt::Display>(
+    key: &str,
+    value: T,
+    cap: T,
+) -> Result<(), ConfigError> {
+    if value > cap {
+        return Err(ConfigError::InvalidValue {
+            key: key.to_string(),
+            message: format!("value {value} is out of range [0, {cap}]"),
+        });
+    }
+    Ok(())
+}
+
 impl VelesConfig {
     /// Validates the configuration.
     ///
@@ -84,16 +101,11 @@ impl VelesConfig {
 
         // `query_timeout_ms == 0` disables the timeout (see `QueryContext`);
         // any positive value is capped to avoid effectively-unbounded queries.
-        if self.search.query_timeout_ms > QUERY_TIMEOUT_MS_CAP {
-            return Err(ConfigError::InvalidValue {
-                key: "search.query_timeout_ms".to_string(),
-                message: format!(
-                    "value {} is out of range [0, {QUERY_TIMEOUT_MS_CAP}]",
-                    self.search.query_timeout_ms
-                ),
-            });
-        }
-        Ok(())
+        range_check_upper(
+            "search.query_timeout_ms",
+            self.search.query_timeout_ms,
+            QUERY_TIMEOUT_MS_CAP,
+        )
     }
 
     fn validate_hnsw(&self) -> Result<(), ConfigError> {
@@ -117,16 +129,7 @@ impl VelesConfig {
 
         // `max_layers == 0` means "auto" (see `HnswConfig`); a positive value
         // is capped to a sane ceiling.
-        if self.hnsw.max_layers > MAX_LAYERS_CAP {
-            return Err(ConfigError::InvalidValue {
-                key: "hnsw.max_layers".to_string(),
-                message: format!(
-                    "value {} is out of range [0, {MAX_LAYERS_CAP}]",
-                    self.hnsw.max_layers
-                ),
-            });
-        }
-        Ok(())
+        range_check_upper("hnsw.max_layers", self.hnsw.max_layers, MAX_LAYERS_CAP)
     }
 
     fn validate_limits(&self) -> Result<(), ConfigError> {
@@ -164,16 +167,7 @@ impl VelesConfig {
 
         // `workers == 0` means "auto" (derive from CPU count); a positive
         // value is capped so a typo cannot spawn an absurd thread count.
-        if self.server.workers > WORKERS_CAP {
-            return Err(ConfigError::InvalidValue {
-                key: "server.workers".to_string(),
-                message: format!(
-                    "value {} is out of range [0, {WORKERS_CAP}]",
-                    self.server.workers
-                ),
-            });
-        }
-        Ok(())
+        range_check_upper("server.workers", self.server.workers, WORKERS_CAP)
     }
 
     fn validate_storage(&self) -> Result<(), ConfigError> {

--- a/crates/velesdb-core/src/database/database_tests.rs
+++ b/crates/velesdb-core/src/database/database_tests.rs
@@ -13,6 +13,27 @@ fn test_database_open() {
 }
 
 #[test]
+fn test_open_with_config_rejects_invalid_config() {
+    // #907 follow-up: a `VelesConfig` built programmatically (bypassing the
+    // loader, which is the only place that used to call validate()) must be
+    // validated at the open boundary, so an out-of-range field is rejected.
+    let dir = tempdir().unwrap();
+    let mut config = crate::config::VelesConfig::default();
+    config.limits.max_collections = 0; // out of range [1, ..]
+
+    let result = Database::open_with_config(dir.path(), config);
+    assert!(
+        result.is_err(),
+        "open_with_config must reject an invalid (unloader-validated) config"
+    );
+    let msg = result.err().unwrap().to_string();
+    assert!(
+        msg.contains("limits.max_collections"),
+        "error should name the offending key, got: {msg}"
+    );
+}
+
+#[test]
 fn test_create_collection() {
     let dir = tempdir().unwrap();
     let db = Database::open(dir.path()).unwrap();

--- a/crates/velesdb-core/src/database/mod.rs
+++ b/crates/velesdb-core/src/database/mod.rs
@@ -188,6 +188,16 @@ impl Database {
         observer: Option<std::sync::Arc<dyn DatabaseObserver>>,
         config: Option<crate::config::VelesConfig>,
     ) -> Result<Self> {
+        // Validate at the consumption boundary: a `VelesConfig` built
+        // programmatically (not through a loader) never passes through
+        // `validate()`, so an out-of-range field would otherwise reach the
+        // engine unchecked. Loaders already validate, but re-validating here
+        // is cheap and closes the bypass for direct API callers.
+        let config = config.unwrap_or_default();
+        config
+            .validate()
+            .map_err(|e| Error::Config(e.to_string()))?;
+
         let data_dir = path.as_ref().to_path_buf();
         std::fs::create_dir_all(&data_dir)?;
 
@@ -208,7 +218,7 @@ impl Database {
         let db = Self {
             data_dir,
             _lock_file: lock_file,
-            config: std::sync::Arc::new(config.unwrap_or_default()),
+            config: std::sync::Arc::new(config),
             vector_colls: parking_lot::RwLock::new(std::collections::HashMap::new()),
             graph_colls: parking_lot::RwLock::new(std::collections::HashMap::new()),
             metadata_colls: parking_lot::RwLock::new(std::collections::HashMap::new()),

--- a/crates/velesdb-core/src/guardrails/resilience.rs
+++ b/crates/velesdb-core/src/guardrails/resilience.rs
@@ -14,6 +14,27 @@ use super::limits::GuardRailViolation;
 // Rate Limiter
 // ─────────────────────────────────────────────────────────────────────────────
 
+/// Maximum number of distinct `client_id` buckets retained at once.
+///
+/// The per-client `TokenBucket` map is otherwise unbounded: an attacker
+/// rotating `client_id` on every request would grow it without limit and
+/// exhaust memory. When inserting a brand-new client would exceed this cap we
+/// evict one existing bucket (see [`RateLimiter::evict_one`]) to make room.
+/// Active clients within the cap keep accurate rate-limit state, and re-using
+/// an already-tracked id always hits its existing bucket (eviction only ever
+/// targets *other* buckets), so a client cannot reset its own throttle state.
+pub(super) const MAX_TRACKED_CLIENTS: usize = 100_000;
+
+/// Number of buckets examined per eviction.
+///
+/// Eviction inspects at most this many buckets (a bounded sample of the map,
+/// effectively randomized by the `HashMap`'s `SipHash` seed) rather than
+/// scanning all [`MAX_TRACKED_CLIENTS`] entries. This keeps eviction `O(k)`
+/// on the hot path under the exclusive write lock, closing the low-QPS `DoS`
+/// where every bucket is non-idle and a full scan would otherwise run on
+/// every new-client request.
+const EVICTION_SAMPLE_SIZE: usize = 16;
+
 /// Rate limiter for query throttling (EPIC-048 US-005).
 #[derive(Debug)]
 pub struct RateLimiter {
@@ -51,6 +72,12 @@ impl RateLimiter {
         let limit_qps = self.limit_qps.load(std::sync::atomic::Ordering::Relaxed);
         let limit = f64::from(limit_qps);
 
+        // Bound the map before inserting a brand-new client so that a rotating
+        // `client_id` attacker cannot grow it without limit (OOM guard).
+        if !clients.contains_key(client_id) && clients.len() >= MAX_TRACKED_CLIENTS {
+            Self::evict_one(&mut clients, limit);
+        }
+
         let bucket = clients.entry(client_id.to_string()).or_insert(TokenBucket {
             tokens: limit,
             last_update: now,
@@ -68,6 +95,52 @@ impl RateLimiter {
         } else {
             Err(GuardRailViolation::RateLimitExceeded { limit_qps })
         }
+    }
+
+    /// Evicts a single bucket to make room for a new client.
+    ///
+    /// Examines only a bounded sample of at most [`EVICTION_SAMPLE_SIZE`]
+    /// buckets — *not* the whole map — so the work is `O(k)` regardless of how
+    /// many clients are tracked. Within the sample it prefers an idle bucket
+    /// (one that has fully refilled to `limit` given the elapsed time —
+    /// dropping it is lossless since it is recreated full on demand); if none
+    /// in the sample are idle it evicts the oldest-touched bucket in the
+    /// sample. The sample is effectively randomized by the `HashMap`'s
+    /// `SipHash` seed, so under sustained pressure every bucket is eventually
+    /// a candidate and the map stays bounded even when all clients are active.
+    ///
+    /// This is safe against `client_id` rotation: eviction only runs when
+    /// inserting a *new* id, and only ever removes some *other* bucket, so a
+    /// client re-using a throttled id still hits its existing (throttled)
+    /// bucket and cannot reset its own limit.
+    fn evict_one(clients: &mut HashMap<String, TokenBucket>, limit: f64) {
+        let now = Instant::now();
+        let mut idle: Option<String> = None;
+        let mut oldest: Option<(String, Instant)> = None;
+        for (id, bucket) in clients.iter().take(EVICTION_SAMPLE_SIZE) {
+            let elapsed = now.duration_since(bucket.last_update).as_secs_f64();
+            if (bucket.tokens + elapsed * limit).min(limit) >= limit {
+                idle = Some(id.clone());
+                break;
+            }
+            if oldest
+                .as_ref()
+                .is_none_or(|(_, ts)| bucket.last_update < *ts)
+            {
+                oldest = Some((id.clone(), bucket.last_update));
+            }
+        }
+        if let Some(key) = idle.or_else(|| oldest.map(|(id, _)| id)) {
+            clients.remove(&key);
+        }
+    }
+
+    /// Returns the number of currently tracked client buckets.
+    ///
+    /// Test-only accessor used to assert the OOM guard keeps the map bounded.
+    #[cfg(test)]
+    pub(crate) fn tracked_clients(&self) -> usize {
+        self.clients.read().len()
     }
 
     /// Exhausts all tokens for a specific client, ensuring the next

--- a/crates/velesdb-core/src/guardrails/resilience_tests.rs
+++ b/crates/velesdb-core/src/guardrails/resilience_tests.rs
@@ -49,6 +49,72 @@ fn rate_limiter_isolates_clients() {
     assert!(limiter.check("client-b").is_ok());
 }
 
+#[test]
+fn rate_limiter_bounds_client_map_under_id_rotation() {
+    use crate::guardrails::resilience::MAX_TRACKED_CLIENTS;
+
+    let limiter = RateLimiter::new(10);
+
+    // Simulate an attacker rotating client_id on every request: insert far
+    // more distinct clients than the cap. The map must never exceed the cap
+    // (regression #907 — previously unbounded → OOM).
+    let total = MAX_TRACKED_CLIENTS + 500;
+    for i in 0..total {
+        let _ = limiter.check(&format!("attacker-{i}"));
+        assert!(
+            limiter.tracked_clients() <= MAX_TRACKED_CLIENTS,
+            "client map exceeded cap at iteration {i}: {}",
+            limiter.tracked_clients()
+        );
+    }
+    assert_eq!(limiter.tracked_clients(), MAX_TRACKED_CLIENTS);
+
+    // An active client is still correctly rate-limited: exhaust its tokens and
+    // confirm the next request is rejected.
+    for _ in 0..10 {
+        let _ = limiter.check("active");
+    }
+    assert!(
+        limiter.check("active").is_err(),
+        "active client should be rate-limited after exhausting tokens"
+    );
+}
+
+#[test]
+fn rate_limiter_bounded_eviction_under_low_qps_rotation() {
+    use crate::guardrails::resilience::MAX_TRACKED_CLIENTS;
+
+    // Low QPS is the worst case for eviction (#907 follow-up DoS): every fresh
+    // client immediately spends its single token and stays NON-idle for ~1s,
+    // so the old code took the LRU branch and scanned ALL 100k buckets under
+    // the write lock on every new-client request. The new code samples a
+    // bounded constant number of buckets, so this loop completes quickly and
+    // the map stays bounded even though no bucket is ever idle in the window.
+    let limiter = RateLimiter::new(1);
+
+    let total = MAX_TRACKED_CLIENTS + 500;
+    for i in 0..total {
+        let _ = limiter.check(&format!("rot-{i}"));
+        assert!(
+            limiter.tracked_clients() <= MAX_TRACKED_CLIENTS,
+            "client map exceeded cap at iteration {i}: {}",
+            limiter.tracked_clients()
+        );
+    }
+    assert_eq!(limiter.tracked_clients(), MAX_TRACKED_CLIENTS);
+
+    // Correctness under eviction pressure: a re-used (already-tracked) id must
+    // still hit its existing bucket and stay throttled — an attacker cannot
+    // reset their own limit by forcing eviction of other buckets. With qps=1
+    // the very first request spends the only token, so the immediate second
+    // request for the same id is rejected.
+    assert!(limiter.check("victim").is_ok(), "first token available");
+    assert!(
+        limiter.check("victim").is_err(),
+        "re-used id must remain throttled (no self-reset via eviction)"
+    );
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // CircuitBreaker: state transitions
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
**Closes #907.** `validate()` in all loaders and `open_with_config`; range caps for limits/timeouts/workers; RateLimiter client map bounded via O(1) sampled eviction.

---
Part of the 2026-05-28 `velesdb-core` security/perf/OOM audit (`report/AUDIT-velesdb-core-2026-05-28.md`). Implemented by a specialist sub-agent, then adversarial review→fix rounds to 0 findings. Integration-branch gate: `cargo fmt --check`, workspace `clippy -D warnings -D clippy::pedantic`, full lib suite (4914 tests), recall contracts — all green. Every fix ships a regression test.