### PR TITLE
docs(core): document audit-hardening behavior

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -88,7 +88,7 @@ The dependency graph is strictly downward: `server`, `python`, `wasm`, `mobile`,
 
 Here is what happens, end-to-end, in roughly the order it happens. This is the path that the canonical 450 µs p50 latency claim measures.
 
-1. **Parse.** The query enters the VelesQL parser (PEG grammar in `crates/velesdb-core/src/velesql/parser/`). Output: a typed AST (`Query`).
+1. **Parse.** The query enters the VelesQL parser (PEG grammar in `crates/velesdb-core/src/velesql/parser/`). A cheap O(n) pre-scan first rejects queries over `max_query_length` or with bracket/`NOT` nesting depth > 64 (guarding against a parser stack-overflow DoS) before `pest` runs. Output: a typed AST (`Query`).
 2. **Validate.** Names, types, dimension, distance metric, and feature gates are checked against the live catalog (`Database` registry).
 3. **Plan.** The cost-based optimizer (CBO) in `crates/velesdb-core/src/velesql/cost_estimator/` picks an execution strategy. For a vector + filter query, the choice is typically between *pre-filter* (apply the WHERE first then NEAR on the remaining points) and *post-filter* (NEAR first then WHERE on the result). Selectivity statistics drive the choice.
 4. **Cache.** A two-tier LRU plan cache (write-generation invalidated) hits or misses. A hit short-circuits steps 1–3 for repeat queries (~1 µs cache hit).

--- a/QUALITY_BAR.md
+++ b/QUALITY_BAR.md
@@ -195,6 +195,7 @@ These signals are tracked but do not block release individually:
 | Promise contract sync | All numeric claims in README backed by benchmark commands | `scripts/check-promise-contract.py` in CI |
 | TODO governance | All TODOs in format `// TODO(EPIC-XXX):` | `scripts/check-todo-annotations.py` |
 | RUSTSEC | All advisories tracked or justified in `deny.toml` | `cargo deny check` in CI (Security Audit job) |
+| Untrusted-input hardening | Corrupt/oversized persisted artifacts (HNSW graph, PQ codebook, sparse, BM25, WAL) are rejected at load, not used to size allocations; WAL `Fsync` is durable before ack; config limits validated in loaders + on open | Regression suites: `storage/storage_reliability_tests.rs`, `index/hnsw/persistence_atomicity_tests.rs`, `quantization/pq_tests.rs`, `quantization/rabitq_tests.rs`, `index/sparse/persistence_tests.rs`, `index/bm25_tests.rs`, `config_tests.rs`, `velesql/parser/robustness_tests.rs` (gated by `cargo test`) |
 
 ---
 

--- a/docs/CONCURRENCY_MODEL.md
+++ b/docs/CONCURRENCY_MODEL.md
@@ -152,7 +152,14 @@ let mut target = shards[target_shard].write();  // DEADLOCK if another thread ho
 
 ### Cascade Delete (remove_node_edges)
 
-Uses BTreeSet for automatic ascending order:
+Deleting a graph node now **cascades to its edges**: the node-delete path
+(`collection/core/crud_read_delete.rs`) calls
+`ConcurrentEdgeStore::remove_node_edges(id)` so both outgoing and incoming
+edges are removed, leaving no dangling edges pointing at a phantom node (#900).
+
+The cascade follows the global lock order: it acquires `edge_ids` **first**,
+then the affected shards in **ascending** index order, using a `BTreeSet` whose
+iteration is already sorted:
 
 ```rust
 let mut shards_to_clean: BTreeSet<usize> = BTreeSet::new();
@@ -161,6 +168,10 @@ for &idx in &shards_to_clean {
     guards.push(shards[idx].write());
 }
 ```
+
+The snapshot invalidation / debounced rebuild (see below) runs **after** the
+`edge_ids` write lock is released, never while holding it, to avoid deadlocking
+against the downstream rebuild lock acquisition.
 
 ## RaBitQ Interior Mutability
 
@@ -268,13 +279,27 @@ neighbor access during BFS/DFS traversal.
 2. **Read**: `csr_snapshot().neighbors(source_id)` returns `&[u64]` -- a
    zero-copy slice into the contiguous target array.
 3. **Invalidate**: Every write operation (`add_edge`, `remove_edge`,
-   `remove_node_edges`) sets `csr_snapshot = None`. Subsequent reads fall
-   back to per-shard edge lookup until the snapshot is rebuilt.
+   `remove_node_edges`) sets `csr_snapshot = None` and increments a
+   pending-write counter. Subsequent reads fall back to per-shard edge lookup
+   until the snapshot is rebuilt.
+
+**Debounced rebuild** (#905): The actual O(N+E) CSR rebuild (which clones every
+edge into a fresh `EdgeStore`) is **debounced** rather than run on the first
+read after any write. A mutation only flips the dirty flag and bumps
+`pending_writes`; the rebuild is deferred until the accumulated write count
+reaches `CSR_REBUILD_WRITE_THRESHOLD` (64). Batch writes count their full size
+toward the threshold. While dirty-but-below-threshold, reads remain correct by
+falling back to per-shard lookup — debouncing trades a slightly slower fallback
+read for avoiding a full rebuild on every interleaved read/write. A completed
+rebuild clears the dirty flag and resets the counter to 0.
 
 **Thread safety** (ConcurrentEdgeStore): The snapshot is stored under the
 same `RwLock` as the shard data. A read lock on the snapshot shard is
 sufficient for BFS access. Write operations acquire write locks and
-invalidate the snapshot as part of the same critical section.
+invalidate the snapshot as part of the same critical section. The deferred
+rebuild path acquires `edge_ids` **read-only** (never write) and releases
+per-shard read locks promptly, so it never violates the `edge_ids → shards`
+ordering and the caller must not hold an `edge_ids` write lock across it.
 
 ## Performance vs Safety Tradeoffs
 

--- a/docs/SOUNDNESS.md
+++ b/docs/SOUNDNESS.md
@@ -195,6 +195,13 @@ in-place vector normalization using `_mm256_mul_ps`.
 3. `code[i] < k` for all `i` asserted via `debug_assert!` at function entry
 4. AVX2 gather indices computed as `subspace * k + code[subspace]`, bounded by `m * k`
 5. Scalar fallback exists for CPUs without AVX2 or NEON
+6. (#895) The `code[i] < k` precondition (3) — only a `debug_assert!` here — is
+   upheld for codes originating from a deserialized on-disk codebook by
+   **load-time validation**: every PQ code is checked `< num_centroids` and the
+   OPQ rotation length `== dim * dim` after deserialization (`quantization/pq.rs`,
+   `quantization/pq_persistence.rs`). An invalid code is skipped gracefully
+   rather than reaching the gather, so the release-mode OOB gather / scalar-path
+   panic class is closed before the unsafe kernel runs.
 
 **Why It's Sound**:
 ```rust
@@ -372,6 +379,11 @@ unsafe {
 2. `data` points to memory allocated with 64-byte alignment
 3. `capacity * dimension * sizeof(f32)` bytes are always allocated
 4. `count <= capacity` is always maintained
+5. (#899) All offset/capacity arithmetic (`index * dimension`, `capacity * 2`,
+   `ensure_capacity(index + 1)`) uses `checked_mul`/`checked_add`. An overflow
+   returns an error instead of wrapping, so a crafted index can no longer wrap
+   an offset to a small value and drive an out-of-bounds `copy_nonoverlapping`
+   write in release builds.
 
 **Why It's Sound**:
 ```rust
@@ -442,6 +454,18 @@ unsafe { dealloc(self.data.as_ptr().cast::<u8>(), layout); }
 1. `ptr` is either valid or `owns_memory = false`
 2. `layout` matches the allocation
 3. Drop deallocates if and only if `owns_memory = true`
+4. (#899) `new`/`new_zeroed` return `None` when `layout.size()` exceeds the
+   process-wide per-allocation ceiling (`DEFAULT_ALLOC_BYTE_LIMIT`, **1 TiB**;
+   configurable via `set_alloc_byte_limit`). This is a deliberately high
+   *backstop* against pathological/attacker-controlled or arithmetic-wrapped
+   sizes — far above any single contiguous buffer VelesDB legitimately
+   allocates, so it never rejects a real index. It is threaded through the
+   `ContiguousVectors` construct / resize / reorder allocation paths plus the
+   `check_alloc_bound` pre-check. It does not affect soundness of the RAII
+   guarantee; it only narrows which requests reach the system allocator.
+   Primary defense against untrusted sizes remains the per-artifact load-time
+   validation (file-length-bounded counts, see below) — `AllocGuard` only
+   catches whatever slips past those local checks.
 
 **Why It's Sound**:
 ```rust
@@ -670,6 +694,13 @@ traversal, where the node IDs are guaranteed valid by construction.
    it appears in any neighbor list
 3. Vectors are never removed from `ContiguousVectors` during the lifetime
    of a search (vectors outlive graph references)
+4. (#894) For a graph loaded from disk — the untrusted-input path — invariant 1
+   is upheld by **load-time validation** in `index/hnsw/native/graph_io.rs`:
+   the header `count_check` must equal the vector count, `entry_point < count`,
+   and every neighbor ID is checked `< count` before being stored in a layer.
+   A file violating any of these is rejected with `InvalidData` at load, so no
+   out-of-range ID ever reaches `get_unchecked` on the search hot path (the
+   release-mode OOB read class is closed at the source).
 
 **Usage in `neighbors.rs`** (neighbor selection with VAMANA diversification):
 ```rust

--- a/docs/STORAGE_FORMAT.md
+++ b/docs/STORAGE_FORMAT.md
@@ -131,6 +131,24 @@ Write-Ahead Log for vector durability.
 | STORE | 0x01 | Vector insertion/update |
 | DELETE | 0x02 | Vector deletion |
 
+### CRC32 Framing and Bounded Lengths
+
+The vector WAL is **CRC32-framed**: each record carries a trailing CRC that is
+verified before the record is applied. Length fields read from the WAL (payload
+byte length, vector dimension) are bounded against the remaining file size
+before any buffer is allocated, so a corrupt or malicious length field cannot
+drive an unbounded allocation. A WAL whose *first* record fails CRC is treated
+as the pre-CRC **legacy format** and skipped (the persisted index is
+authoritative for that data).
+
+### Durability (`DurabilityMode`)
+
+| Mode | STORE / DELETE acknowledgement |
+|------|--------------------------------|
+| `Fsync` | The WAL record is written **and `fsync`-ed** before the call returns `Ok`. This now holds for single `store` **and** `delete`: a delete is made durable *before* the destructive on-disk hole-punch, so a crash can never lose a delete and silently resurrect the id on replay. |
+| `FlushOnly` | WAL buffer is flushed (not fsynced); durability is the caller's responsibility via `flush()`. |
+| `None` | WAL is skipped entirely (bulk-import fast path); those writes are not crash-recoverable. |
+
 ## Payload Storage (payloads.log)
 
 Append-only log for JSON payloads.
@@ -225,10 +243,10 @@ All multi-byte integers are stored in **little-endian** format.
 │  3. Load vectors.idx + vectors.bin                               │
 │     │                                                            │
 │     ▼                                                            │
-│  4. Replay vectors.wal                                           │
+│  4. Replay vectors.wal (crash-safe order, see below)             │
 │     │                                                            │
 │     ▼                                                            │
-│  5. Load/rebuild HNSW index                                      │
+│  5. Load/rebuild HNSW index (load-time validation, see below)    │
 │     │                                                            │
 │     ▼                                                            │
 │  6. Gap detection: compare storage IDs vs HNSW IDs               │
@@ -240,6 +258,32 @@ All multi-byte integers are stored in **little-endian** format.
 │                                                                  │
 └─────────────────────────────────────────────────────────────────┘
 ```
+
+### Crash-safe WAL replay ordering
+
+Vector WAL replay is ordered so that no acknowledged write can be lost across a
+crash mid-recovery:
+
+1. **Apply** each CRC-valid WAL entry into the in-memory index and mmap.
+2. **`mmap.flush()`** — make the recovered vector bytes durable.
+3. **Persist `vectors.idx`** — write the rebuilt index so recovered state
+   survives even if the mmap flush is later lost.
+4. **Only then truncate the WAL** (`set_len(0)` + `fsync`).
+
+Truncating the WAL before the mmap and index are durable would lose the
+replayed writes on a crash in the window, so the order is strict.
+
+### Torn tail vs mid-stream corruption
+
+Replay distinguishes two failure shapes:
+
+| Shape | Detection | Policy |
+|-------|-----------|--------|
+| **Torn tail** | A short/truncated final record, or a CRC failure at EOF with no validly framed bytes after it (normal after a crash mid-write). | Stop replay cleanly; everything before it is recovered. |
+| **Mid-stream corruption** | A CRC failure followed by further validly framed records (bit-rot / tampering). | Skip the bad record, emit a metric + warning, and continue replaying the later valid entries. |
+
+An unknown opcode mid-stream is treated as a torn tail (framing is no longer
+trustworthy), so replay stops rather than fabricating further entries.
 
 ## Versioning
 
@@ -278,12 +322,34 @@ VelesDB handles corruption gracefully:
 
 | Corruption Type | Behavior |
 |-----------------|----------|
-| Truncated WAL | Replay up to last valid entry |
+| Truncated WAL (torn tail) | Replay up to last valid entry, then stop cleanly |
+| Mid-stream WAL CRC failure | Skip the bad record, emit a metric, continue replaying later valid entries |
 | Invalid snapshot CRC | Fall back to full WAL replay |
 | Missing files | Return explicit error |
 | Bitflip in data | Detected via checksum (if enabled) |
+| Out-of-range length/count field | Rejected at load (`InvalidData`); never used to size an allocation |
 
 See `tests/crash_recovery/corruption.rs` for comprehensive corruption tests.
+
+## Load-time validation of persisted artifacts
+
+Persisted artifacts are treated as **untrusted input** and validated at load
+time so that a corrupt or maliciously crafted file is rejected rather than
+reaching an unchecked memory access. Every count/length/dimension field is
+bounded against the actual file size (and a sane maximum) before it is used to
+size an allocation.
+
+| Artifact | Validation at load |
+|----------|--------------------|
+| **HNSW graph** (`.graph`) | Header `count_check` must equal the trusted vector count; `entry_point < count`; every neighbor ID `< count`; `num_neighbors` capped; node iteration bounded by the file length (not a static ceiling). Any violation returns `InvalidData`, so the search hot path can rely on in-bounds IDs. |
+| **PQ codebook** | Every PQ code must be `< num_centroids` and the OPQ rotation matrix length must equal `dim × dim`. An invalid code is skipped gracefully rather than reaching the SIMD/scalar ADC gather. |
+| **Sparse index** | Version, term count, and per-term offset/length fields bounded; 32-bit offset overflow guarded. |
+| **BM25 snapshot** | `version` must match `BM25_SNAPSHOT_VERSION` or the load is rejected; `doc_count`/`total_doc_length` are recomputed from the **scorable** corpus (documents present in `point_to_doc`) so a tampered counter cannot produce inf/NaN `avgdl`. |
+| **Vector index** (`vectors.idx`) | Every persisted offset is validated against the backing file size. |
+
+A high global allocation backstop (`AllocGuard`, default 1 TiB, configurable via
+`set_alloc_byte_limit`) catches any wrapped/pathological size that slips past a
+local check; it is sized never to reject a legitimately large index.
 
 ## References
 

--- a/docs/VELESQL_SPEC.md
+++ b/docs/VELESQL_SPEC.md
@@ -1352,6 +1352,14 @@ WITH (mode = 'accurate', ef_search = 512, timeout_ms = 5000)
 | `rerank` | boolean | `true`/`false` | Two-stage SIMD reranking (retrieves 4x candidates, re-ranks with exact distance) |
 | `quantization` | string | `f32`, `int8`, `dual`, `auto` | Quantization mode for search |
 | `oversampling` | float | >= 1.0 | Oversampling ratio for dual-precision mode |
+| `max_groups` (alias `group_limit`) | integer | 1 .. 1,000,000 | GROUP BY group budget. Lowers the default (10,000); **clamped down** to the server ceiling of 1,000,000 — cannot raise it. See [GROUP BY](#group-by-clause-v20). |
+
+> **Query guard-rails.** Two hard limits protect the server from adversarial
+> queries. (1) A query is rejected before parsing if its length exceeds the
+> configured `max_query_length` or its bracket/`NOT` nesting depth exceeds
+> **64** (prevents a parser stack-overflow DoS). (2) `WITH (max_groups = N)` for
+> GROUP BY is clamped to a server-side ceiling of **1,000,000** groups; the
+> query can lower its budget but never raise the server memory ceiling.
 
 ### Examples
 

--- a/docs/reference/KNOWN_LIMITATIONS.md
+++ b/docs/reference/KNOWN_LIMITATIONS.md
@@ -93,6 +93,100 @@ A measurable decision will be made when one of: download counts on `manylinux201
 
 ---
 
+## Hardening limits (security / OOM / DoS guard-rails)
+
+These are **intentional hard limits** introduced by the core hardening effort to
+bound resource use against corrupt files and adversarial queries. They are not
+bugs; they are the documented ceilings of the current implementation.
+
+### 6. VelesQL query length and nesting depth
+
+**Status**: resolved (hard limit). Source: `crates/velesdb-core/src/velesql/parser/prescan.rs` (`MAX_NESTING_DEPTH = 64`).
+
+Before a query reaches the `pest` parser, a single O(n) pre-scan rejects any
+query that:
+
+- exceeds the configured `max_query_length`, or
+- has an effective parse-recursion depth (open `()`/`[]` brackets plus a leading
+  `NOT NOT …` run) greater than **64**.
+
+The pre-scan exists because `pest` builds the full recursive parse tree before
+any Rust-level guard runs, so a deeply nested query (~thousands of levels) would
+otherwise overflow the native stack and abort the process. Quoted strings,
+backtick/double-quoted identifiers, and `--` comments are skipped so the guard
+never false-positives on literal bracket content.
+
+**User impact**: legitimate hand-written queries nest a handful of levels and
+are unaffected; programmatically generated queries must keep bracket/NOT nesting
+at or below 64.
+
+### 7. GROUP BY group-count ceiling
+
+**Status**: resolved (server-side hard ceiling). Source: `crates/velesdb-core/src/collection/search/query/aggregation/having.rs` (`DEFAULT_MAX_GROUPS = 10_000`, `SERVER_MAX_GROUPS_CEILING = 1_000_000`).
+
+A GROUP BY query retains at most `DEFAULT_MAX_GROUPS` (10,000) groups by default.
+A query may use `WITH (max_groups = N)` (or `group_limit`) to **lower** its group
+budget, but `N` is always **clamped down** to the server-side ceiling of
+**1,000,000** — a query can never raise the memory ceiling. Exceeding the
+effective limit returns a "Too many groups" error rather than growing unbounded.
+
+### 8. `NOT similarity()` scan cap
+
+**Status**: resolved (hard limit). Source: `crates/velesdb-core/src/collection/search/query/similarity_filter.rs` (`NOT_SIMILARITY_MAX_SCAN = 5_000_000`).
+
+A `NOT similarity(...)` predicate has no index acceleration and must full-scan
+the collection. It is now a hard guard-rail (not just a warning): if the
+collection holds more than **5,000,000** vectors the query is **rejected** with
+guidance to add a selective metadata filter or use a positive `similarity()`
+predicate (which is index-accelerated).
+
+### 9. Bounded query-result materialization
+
+**Status**: resolved (bounded memory). Source: `crates/velesdb-core/src/collection/search/query/` (set_operations, parallel_traversal, similarity_filter), `database/query_engine.rs`, `database/query_join.rs`.
+
+Result materialization for top-k scans, JOIN, parallel graph traversal, and
+set operations (UNION/INTERSECT) is bounded by the effective LIMIT via bounded
+top-k rather than collect-all-then-truncate. Results are identical to the
+unbounded path; only peak memory is bounded. Intermediate operators that can
+legitimately drop rows fall back to the conservative server-side ceiling.
+
+### 10. Configuration range caps
+
+**Status**: resolved (validated in every loader and on open). Source: `crates/velesdb-core/src/config_validation.rs`; called from `Config` loaders and `Database::open_with_config`.
+
+`VelesConfig::validate()` now runs in every config loader (`load`,
+`load_from_path`, `from_toml`) **and** on `open_with_config`. Each capacity/limit
+field is range-checked against a hard ceiling:
+
+| Field | `0` means | Hard ceiling |
+|-------|-----------|--------------|
+| `limits.max_vectors_per_collection` | rejected | 10,000,000,000 |
+| `limits.max_collections` | rejected | 1,000,000 |
+| `limits.max_payload_size` | rejected | 1 GiB (1,073,741,824) |
+| `search.query_timeout_ms` | disabled | 24 h (86,400,000 ms) |
+| `hnsw.max_layers` | auto | 64 |
+| `storage.mmap_cache_mb` | rejected | 1 TiB (1,048,576 MiB) |
+| `server.workers` | auto (CPU count) | 4,096 |
+
+An out-of-range value fails the loader/open with `ConfigError::InvalidValue`
+rather than being silently accepted (which previously allowed `0` = DoS or
+absurdly large = unbounded). The per-client `RateLimiter` map is also bounded
+with sampled eviction so a client cycling `client_id` values cannot OOM the
+limiter.
+
+### 11. `AllocGuard` per-allocation ceiling
+
+**Status**: resolved (backstop). Source: `crates/velesdb-core/src/alloc_guard.rs` (`DEFAULT_ALLOC_BYTE_LIMIT = 1 TiB`).
+
+Every raw aligned allocation is capped at a process-wide per-allocation ceiling
+of **1 TiB**, configurable at runtime via `set_alloc_byte_limit`. This is a
+deliberately high *backstop* against arithmetic-wrapped or pathological sizes; it
+is far above any single contiguous buffer VelesDB legitimately allocates, so it
+never rejects a real index. Primary defense against untrusted sizes is the
+per-artifact load-time validation (file-length-bounded counts).
+
+---
+
 ## Reading this document
 
 Each entry states:

--- a/docs/reference/NATIVE_HNSW.md
+++ b/docs/reference/NATIVE_HNSW.md
@@ -103,6 +103,31 @@ let loaded = NativeHnswIndex::load("./my_index", 768, DistanceMetric::Cosine)?;
 | `save(path)` | Save index to disk |
 | `load(path, dim, metric)` | Load index from disk |
 
+#### Load-time validation (untrusted file safety)
+
+A persisted index is treated as **untrusted input**. `load` validates the
+`.graph` file against the trusted vector `count` (read from the `.vectors` file)
+**before** any node ID can reach the search hot path, which uses `get_unchecked`
+on the contiguous vector buffer. All of the following are checked once at load
+and a violation is rejected with `InvalidData`:
+
+- Graph header `count_check` must equal the vector `count` (mismatched
+  `.graph` / `.vectors` files are rejected).
+- `entry_point < count` (when `count > 0`).
+- Every neighbor ID is `< count`.
+- `num_neighbors` per node is capped (`MAX_NEIGHBORS_PER_NODE`), and node
+  iteration is bounded by the **remaining file length** (each node serializes at
+  least a 4-byte length), not a static ceiling — so a corrupt length field
+  cannot drive an unbounded allocation.
+- The `.vectors` header `(count, dimension)` is validated to fit within the
+  actual file size before any pointer cast.
+
+Because these invariants are established at load, the release-mode
+`get_unchecked` reads during search are provably in-bounds (closing the
+out-of-bounds-read class for a tampered index). See
+[SOUNDNESS.md](../SOUNDNESS.md#hnsw-graph-unsafe-operations) and
+[STORAGE_FORMAT.md](../STORAGE_FORMAT.md#load-time-validation-of-persisted-artifacts).
+
 ## Batch Insert Internals
 
 ### Two-Phase Allocation

--- a/docs/reference/VELESQL_CONTRACT.md
+++ b/docs/reference/VELESQL_CONTRACT.md
@@ -189,6 +189,20 @@ Current codes:
 
 Syntax errors still use parser-specific payload (`QueryErrorResponse` with `type/message/position/query`).
 
+## Resource Limits (Guard-rails)
+
+These limits are part of the runtime contract and apply to every VelesQL query:
+
+| Limit | Value | Behavior on breach |
+|-------|-------|--------------------|
+| Query length | configurable `max_query_length` | Rejected **before parsing** (pre-scan), parse error. |
+| Bracket / `NOT` nesting depth | 64 | Rejected **before parsing** (pre-scan), parse error. Prevents a parser stack-overflow DoS. |
+| GROUP BY groups | server ceiling 1,000,000 (default 10,000) | `WITH (max_groups = N)` may lower the budget but `N` is clamped down to the ceiling; exceeding the effective budget returns an aggregation error. |
+| `NOT similarity()` scan | 5,000,000 vectors | Rejected with guidance (no index acceleration for `NOT similarity()`). |
+
+Both pre-scan rejections are evaluated before `pest` is invoked, so they fire
+regardless of how the query nests.
+
 ## Syntax Profiles (Frozen)
 
 These syntax profiles are frozen for this contract version:


### PR DESCRIPTION
Docs for the audit (Refs #894–#907): STORAGE_FORMAT, CONCURRENCY_MODEL, SOUNDNESS, KNOWN_LIMITATIONS, VELESQL_SPEC/CONTRACT, NATIVE_HNSW, ARCHITECTURE, QUALITY_BAR. **Merge after the code PRs.** Promise-contract check passes.

---
Part of the 2026-05-28 `velesdb-core` security/perf/OOM audit (`report/AUDIT-velesdb-core-2026-05-28.md`). Implemented by a specialist sub-agent, then adversarial review→fix rounds to 0 findings. Integration-branch gate: `cargo fmt --check`, workspace `clippy -D warnings -D clippy::pedantic`, full lib suite (4914 tests), recall contracts — all green. Every fix ships a regression test.