### PR TITLE
feat(tauri): add guest-js wrappers for 9 unexposed plugin commands

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -64,6 +64,18 @@ exclude_paths:
   # SDK's own config (`@typescript-eslint/no-unused-vars`) + `tsc` enforce this
   # file correctly in CI (`npm run typecheck`).
   - "sdks/typescript/src/embed.ts"
+  # Tauri plugin guest-js bindings — a thin FFI layer with no flat-config of its
+  # own, so Codacy's bundled eslint@8.57.0 flags two idioms shared by all 29+
+  # existing wrappers (so they are conventions, not new issues):
+  #   - require-await: every export is `async fn(req): Promise<T> { return
+  #     invoke<T>('plugin:velesdb|x', { req }); }`, deliberately uniform so the
+  #     whole binding surface is async even when it only forwards to invoke().
+  #   - no-invalid-void-type: `invoke<void>` is valid TypeScript (void as a
+  #     generic argument); Codacy sets allowInGenericTypeArguments=false, stricter
+  #     than the rule's own default. 7 pre-existing wrappers already use it.
+  # Type correctness is enforced by the package's `tsup --dts` build (release
+  # pipeline) and `tsc --noEmit` (`npm run typecheck`).
+  - "crates/tauri-plugin-velesdb/guest-js/**"
   # Integration contains_text_search helpers — Codacy's online taint analysis
   # flags VelesQL query construction as SQL injection. All user inputs are
   # sanitized BEFORE the query is built:

--- a/.codacy.yml
+++ b/.codacy.yml
@@ -64,18 +64,6 @@ exclude_paths:
   # SDK's own config (`@typescript-eslint/no-unused-vars`) + `tsc` enforce this
   # file correctly in CI (`npm run typecheck`).
   - "sdks/typescript/src/embed.ts"
-  # Tauri plugin guest-js bindings — a thin FFI layer with no flat-config of its
-  # own, so Codacy's bundled eslint@8.57.0 flags two idioms shared by all 29+
-  # existing wrappers (so they are conventions, not new issues):
-  #   - require-await: every export is `async fn(req): Promise<T> { return
-  #     invoke<T>('plugin:velesdb|x', { req }); }`, deliberately uniform so the
-  #     whole binding surface is async even when it only forwards to invoke().
-  #   - no-invalid-void-type: `invoke<void>` is valid TypeScript (void as a
-  #     generic argument); Codacy sets allowInGenericTypeArguments=false, stricter
-  #     than the rule's own default. 7 pre-existing wrappers already use it.
-  # Type correctness is enforced by the package's `tsup --dts` build (release
-  # pipeline) and `tsc --noEmit` (`npm run typecheck`).
-  - "crates/tauri-plugin-velesdb/guest-js/**"
   # Integration contains_text_search helpers — Codacy's online taint analysis
   # flags VelesQL query construction as SQL injection. All user inputs are
   # sanitized BEFORE the query is built:

--- a/crates/tauri-plugin-velesdb/guest-js/index.ts
+++ b/crates/tauri-plugin-velesdb/guest-js/index.ts
@@ -1044,3 +1044,248 @@ export async function proceduralLearn(request: ProceduralLearnRequest): Promise<
 export async function proceduralRecall(request: ProceduralRecallRequest): Promise<ProceduralMatchResult[]> {
   return invoke<ProceduralMatchResult[]>('plugin:velesdb|procedural_recall', { request });
 }
+
+// ============================================================================
+// Sparse vectors
+// ============================================================================
+
+/** Request for sparse-only vector search. */
+export interface SparseSearchRequest {
+  /** Target collection name. */
+  collection: string;
+  /** Sparse vector as `{ "<dimIndex>": weight, ... }`. */
+  sparseVector: Record<string, number>;
+  /** Number of results to return. Default: 10. */
+  topK?: number;
+  /** Optional named sparse index to query. */
+  indexName?: string;
+}
+
+/** Request for hybrid dense + sparse search. */
+export interface HybridSparseSearchRequest {
+  /** Target collection name. */
+  collection: string;
+  /** Dense query vector. */
+  vector: number[];
+  /** Sparse vector as `{ "<dimIndex>": weight, ... }`. */
+  sparseVector: Record<string, number>;
+  /** Number of results to return. Default: 10. */
+  topK?: number;
+}
+
+/** A point input carrying an optional sparse vector. */
+export interface SparsePointInput {
+  /** Unique point identifier. */
+  id: number;
+  /** Dense vector data (must match collection dimension). */
+  vector: number[];
+  /** Optional JSON payload with metadata. */
+  payload?: Record<string, unknown>;
+  /** Optional sparse vector as `{ "<dimIndex>": weight, ... }`. */
+  sparseVector?: Record<string, number>;
+}
+
+/** Request to upsert points with optional sparse vectors. */
+export interface SparseUpsertRequest {
+  /** Target collection name. */
+  collection: string;
+  /** Points to insert or update. */
+  points: SparsePointInput[];
+}
+
+/**
+ * Searches a collection using a sparse vector (inverted-index retrieval).
+ *
+ * @param request - Sparse query parameters
+ * @returns Search results ordered by relevance
+ * @throws {CommandError} If the collection does not exist
+ *
+ * @example
+ * ```typescript
+ * const res = await sparseSearch({
+ *   collection: 'docs',
+ *   sparseVector: { '12': 0.8, '57': 0.6 },
+ *   topK: 10,
+ * });
+ * ```
+ */
+export async function sparseSearch(request: SparseSearchRequest): Promise<SearchResponse> {
+  return invoke<SearchResponse>('plugin:velesdb|sparse_search', { request });
+}
+
+/**
+ * Searches a collection using both a dense and a sparse vector, fusing results.
+ *
+ * @param request - Hybrid dense + sparse query parameters
+ * @returns Fused search results ordered by relevance
+ * @throws {CommandError} If the collection does not exist
+ */
+export async function hybridSparseSearch(request: HybridSparseSearchRequest): Promise<SearchResponse> {
+  return invoke<SearchResponse>('plugin:velesdb|hybrid_sparse_search', { request });
+}
+
+/**
+ * Upserts points with optional sparse vectors for hybrid retrieval.
+ *
+ * @param request - Points to insert or update
+ * @returns Number of points written
+ * @throws {CommandError} On dimension mismatch or write failure
+ */
+export async function sparseUpsert(request: SparseUpsertRequest): Promise<number> {
+  return invoke<number>('plugin:velesdb|sparse_upsert', { request });
+}
+
+// ============================================================================
+// Quantization training
+// ============================================================================
+
+/** Request to train a Product Quantizer over a collection's vectors. */
+export interface TrainPqRequest {
+  /** Target collection name. */
+  collection: string;
+  /** Number of sub-quantizers. */
+  m?: number;
+  /** Number of centroids per sub-quantizer. */
+  k?: number;
+  /** Whether to use Optimized Product Quantization (OPQ). */
+  opq?: boolean;
+}
+
+/**
+ * Trains a Product Quantizer on the collection's existing vectors.
+ *
+ * @param request - PQ training parameters
+ * @returns A human-readable training summary
+ * @throws {CommandError} If the collection has too few vectors to train
+ */
+export async function trainPq(request: TrainPqRequest): Promise<string> {
+  return invoke<string>('plugin:velesdb|train_pq', { request });
+}
+
+// ============================================================================
+// Streaming insert (persistence feature only)
+// ============================================================================
+
+/** Request to stream-insert points (requires the `persistence` feature). */
+export interface StreamInsertRequest {
+  /** Target collection name. */
+  collection: string;
+  /** Points to stream-insert. */
+  points: PointInput[];
+}
+
+/**
+ * Streams a batch of points into a collection for high-throughput ingestion.
+ *
+ * Only available when the plugin is built with the `persistence` feature.
+ *
+ * @param request - Points to stream-insert
+ * @returns Number of points written
+ * @throws {CommandError} If persistence is disabled or the write fails
+ */
+export async function streamInsert(request: StreamInsertRequest): Promise<number> {
+  return invoke<number>('plugin:velesdb|stream_insert', { request });
+}
+
+// ============================================================================
+// Secondary indexes
+// ============================================================================
+
+/** Request to create a secondary index on a metadata field. */
+export interface CreateIndexRequest {
+  /** Target collection name. */
+  collection: string;
+  /** Metadata field name to index. */
+  fieldName: string;
+}
+
+/** Request to drop a secondary index on a metadata field. */
+export interface DropIndexRequest {
+  /** Target collection name. */
+  collection: string;
+  /** Metadata field name whose index to drop. */
+  fieldName: string;
+}
+
+/** Request to list secondary indexes on a collection. */
+export interface ListIndexesRequest {
+  /** Target collection name. */
+  collection: string;
+}
+
+/** A single secondary index entry. */
+export interface IndexInfoOutput {
+  /** Node label (or field name for secondary indexes). */
+  label: string;
+  /** Property name. */
+  property: string;
+  /** Index type (`hash`, `range`, or `secondary`). */
+  indexType: string;
+  /** Number of unique values indexed. */
+  cardinality: number;
+  /** Memory usage in bytes. */
+  memoryBytes: number;
+}
+
+/**
+ * Creates a secondary index on a metadata field for faster filtered search.
+ *
+ * @param request - Index target
+ * @throws {CommandError} If the collection does not exist
+ */
+export async function createIndex(request: CreateIndexRequest): Promise<void> {
+  return invoke<void>('plugin:velesdb|create_index', { request });
+}
+
+/**
+ * Drops a secondary index on a metadata field.
+ *
+ * @param request - Index target
+ * @returns `true` if an index was removed, `false` if none existed
+ * @throws {CommandError} If the collection does not exist
+ */
+export async function dropIndex(request: DropIndexRequest): Promise<boolean> {
+  return invoke<boolean>('plugin:velesdb|drop_index', { request });
+}
+
+/**
+ * Lists all secondary indexes on a collection.
+ *
+ * @param request - Target collection
+ * @returns Array of index descriptors
+ * @throws {CommandError} If the collection does not exist
+ */
+export async function listIndexes(request: ListIndexesRequest): Promise<IndexInfoOutput[]> {
+  return invoke<IndexInfoOutput[]>('plugin:velesdb|list_indexes', { request });
+}
+
+// ============================================================================
+// Parallel graph traversal
+// ============================================================================
+
+/** Request for multi-source parallel BFS traversal. */
+export interface TraverseGraphParallelRequest {
+  /** Target collection name. */
+  collection: string;
+  /** Source node IDs to start traversal from. */
+  sources: number[];
+  /** Maximum traversal depth. Default: 3. */
+  maxDepth?: number;
+  /** Maximum results to return. Default: 100. */
+  limit?: number;
+  /** Optional relationship types to follow. */
+  relTypes?: string[];
+}
+
+/**
+ * Runs a multi-source parallel BFS traversal over a graph collection.
+ *
+ * @param request - Parallel traversal parameters
+ * @returns Array of traversal result nodes
+ * @throws {CommandError} If the collection is not a graph collection
+ */
+export async function traverseGraphParallel(
+  request: TraverseGraphParallelRequest,
+): Promise<TraversalOutput[]> {
+  return invoke<TraversalOutput[]>('plugin:velesdb|traverse_graph_parallel', { request });
+}

--- a/crates/tauri-plugin-velesdb/guest-js/index.ts
+++ b/crates/tauri-plugin-velesdb/guest-js/index.ts
@@ -1073,14 +1073,8 @@ export interface HybridSparseSearchRequest {
   topK?: number;
 }
 
-/** A point input carrying an optional sparse vector. */
-export interface SparsePointInput {
-  /** Unique point identifier. */
-  id: number;
-  /** Dense vector data (must match collection dimension). */
-  vector: number[];
-  /** Optional JSON payload with metadata. */
-  payload?: Record<string, unknown>;
+/** A {@link PointInput} carrying an optional sparse vector. */
+export interface SparsePointInput extends PointInput {
   /** Optional sparse vector as `{ "<dimIndex>": weight, ... }`. */
   sparseVector?: Record<string, number>;
 }

--- a/crates/tauri-plugin-velesdb/guest-js/index.ts
+++ b/crates/tauri-plugin-velesdb/guest-js/index.ts
@@ -1109,7 +1109,7 @@ export interface SparseUpsertRequest {
  * });
  * ```
  */
-export async function sparseSearch(request: SparseSearchRequest): Promise<SearchResponse> {
+export function sparseSearch(request: SparseSearchRequest): Promise<SearchResponse> {
   return invoke<SearchResponse>('plugin:velesdb|sparse_search', { request });
 }
 
@@ -1120,7 +1120,7 @@ export async function sparseSearch(request: SparseSearchRequest): Promise<Search
  * @returns Fused search results ordered by relevance
  * @throws {CommandError} If the collection does not exist
  */
-export async function hybridSparseSearch(request: HybridSparseSearchRequest): Promise<SearchResponse> {
+export function hybridSparseSearch(request: HybridSparseSearchRequest): Promise<SearchResponse> {
   return invoke<SearchResponse>('plugin:velesdb|hybrid_sparse_search', { request });
 }
 
@@ -1131,7 +1131,7 @@ export async function hybridSparseSearch(request: HybridSparseSearchRequest): Pr
  * @returns Number of points written
  * @throws {CommandError} On dimension mismatch or write failure
  */
-export async function sparseUpsert(request: SparseUpsertRequest): Promise<number> {
+export function sparseUpsert(request: SparseUpsertRequest): Promise<number> {
   return invoke<number>('plugin:velesdb|sparse_upsert', { request });
 }
 
@@ -1158,7 +1158,7 @@ export interface TrainPqRequest {
  * @returns A human-readable training summary
  * @throws {CommandError} If the collection has too few vectors to train
  */
-export async function trainPq(request: TrainPqRequest): Promise<string> {
+export function trainPq(request: TrainPqRequest): Promise<string> {
   return invoke<string>('plugin:velesdb|train_pq', { request });
 }
 
@@ -1183,7 +1183,7 @@ export interface StreamInsertRequest {
  * @returns Number of points written
  * @throws {CommandError} If persistence is disabled or the write fails
  */
-export async function streamInsert(request: StreamInsertRequest): Promise<number> {
+export function streamInsert(request: StreamInsertRequest): Promise<number> {
   return invoke<number>('plugin:velesdb|stream_insert', { request });
 }
 
@@ -1234,7 +1234,7 @@ export interface IndexInfoOutput {
  * @throws {CommandError} If the collection does not exist
  */
 export async function createIndex(request: CreateIndexRequest): Promise<void> {
-  return invoke<void>('plugin:velesdb|create_index', { request });
+  await invoke('plugin:velesdb|create_index', { request });
 }
 
 /**
@@ -1244,7 +1244,7 @@ export async function createIndex(request: CreateIndexRequest): Promise<void> {
  * @returns `true` if an index was removed, `false` if none existed
  * @throws {CommandError} If the collection does not exist
  */
-export async function dropIndex(request: DropIndexRequest): Promise<boolean> {
+export function dropIndex(request: DropIndexRequest): Promise<boolean> {
   return invoke<boolean>('plugin:velesdb|drop_index', { request });
 }
 
@@ -1255,7 +1255,7 @@ export async function dropIndex(request: DropIndexRequest): Promise<boolean> {
  * @returns Array of index descriptors
  * @throws {CommandError} If the collection does not exist
  */
-export async function listIndexes(request: ListIndexesRequest): Promise<IndexInfoOutput[]> {
+export function listIndexes(request: ListIndexesRequest): Promise<IndexInfoOutput[]> {
   return invoke<IndexInfoOutput[]>('plugin:velesdb|list_indexes', { request });
 }
 
@@ -1284,7 +1284,7 @@ export interface TraverseGraphParallelRequest {
  * @returns Array of traversal result nodes
  * @throws {CommandError} If the collection is not a graph collection
  */
-export async function traverseGraphParallel(
+export function traverseGraphParallel(
   request: TraverseGraphParallelRequest,
 ): Promise<TraversalOutput[]> {
   return invoke<TraversalOutput[]>('plugin:velesdb|traverse_graph_parallel', { request });


### PR DESCRIPTION
## Finding (ecosystem audit)
9 commands were registered in the Tauri invoke handler but had no typed wrapper in `guest-js/index.ts`, forcing raw `invoke()` calls: `train_pq, stream_insert, traverse_graph_parallel, create_index, drop_index, list_indexes, sparse_search, hybrid_sparse_search, sparse_upsert`.

## Fix
Added camelCase request/response interfaces (matching the Rust `serde(rename_all="camelCase")` DTOs) and exported async wrappers, reusing existing `PointInput`/`SearchResponse`/`TraversalOutput`.

## Verification
`tsc --noEmit` clean; `tsup --dts` build succeeds; command names + payload fields checked 1:1 against registered handlers. No Rust change.
