### PR TITLE
fix(mobile): repair broken/misleading graph-collection doc references

### DIFF
--- a/crates/velesdb-mobile/src/lib.rs
+++ b/crates/velesdb-mobile/src/lib.rs
@@ -218,8 +218,9 @@ impl VelesDatabase {
     /// Gets a vector collection by name.
     ///
     /// Returns `None` if the collection does not exist.
-    /// Returns an error if the collection exists but is not a vector collection
-    /// (use [`get_graph_collection`](Self::get_graph_collection) for graph collections).
+    /// Returns an error if the collection exists but is not a vector collection.
+    /// Graph collections are queried through [`execute_query`](Self::execute_query)
+    /// (VelesQL); metadata collections are not retrievable through this accessor.
     pub fn get_collection(&self, name: String) -> Result<Option<Arc<VelesCollection>>, VelesError> {
         match self.inner.get_any_collection(&name) {
             Some(any_coll) => match any_coll.into_vector() {
@@ -227,7 +228,7 @@ impl VelesDatabase {
                 Err(_other_variant) => Err(VelesError::Collection {
                     message: format!(
                         "Collection '{name}' is not a vector collection. \
-                         Use get_graph_collection() for graph collections."
+                         Query graph collections through execute_query() (VelesQL)."
                     ),
                 }),
             },

--- a/crates/velesdb-mobile/src/query.rs
+++ b/crates/velesdb-mobile/src/query.rs
@@ -49,7 +49,7 @@ pub struct QueryResultRow {
     pub data_json: String,
 }
 
-/// Result of executing a VelesQL query via [`VelesDatabase::execute_query`].
+/// Result of executing a VelesQL query via [`crate::VelesDatabase::execute_query`].
 #[derive(Debug, Clone, uniffi::Record)]
 pub struct QueryResult {
     /// What kind of statement produced this result.


### PR DESCRIPTION
## Finding (ecosystem audit)
`VelesDatabase::get_collection` documented and pointed users (in its error message) to a non-existent `get_graph_collection()` method, and used a broken intra-doc link. A second pre-existing broken link existed in `query.rs`.

## Fix
Graph collections are queried via `execute_query()` (VelesQL); corrected the docstring + runtime error message, and fixed both broken intra-doc links.

## Verification
`cargo doc -D rustdoc::broken_intra_doc_links` passes; mobile tests + clippy pass.
