### PR TITLE
docs(haystack): document all 5 supported distance metrics

### DIFF
--- a/integrations/haystack/README.md
+++ b/integrations/haystack/README.md
@@ -108,7 +108,7 @@ print(result["retriever"]["documents"])
 | `path` | `"./velesdb_haystack"` | Directory where VelesDB persists data |
 | `collection_name` | `"haystack_documents"` | VelesDB collection name |
 | `embedding_dim` | `768` | Embedding vector dimension |
-| `metric` | `"cosine"` | Distance metric: `"cosine"`, `"euclidean"`, or `"dot"` |
+| `metric` | `"cosine"` | Distance metric: `"cosine"`, `"euclidean"`, `"dot"`, `"hamming"`, or `"jaccard"` |
 
 ### Methods
 

--- a/integrations/haystack/src/haystack_velesdb/document_store.py
+++ b/integrations/haystack/src/haystack_velesdb/document_store.py
@@ -368,7 +368,8 @@ class VelesDBDocumentStore:
         path: Directory path where VelesDB persists data.
         collection_name: Name of the VelesDB collection to use.
         embedding_dim: Dimensionality of the embedding vectors.
-        metric: Distance metric: ``"cosine"``, ``"euclidean"``, or ``"dot"``.
+        metric: Distance metric: ``"cosine"``, ``"euclidean"``, ``"dot"``,
+            ``"hamming"``, or ``"jaccard"``.
         scroll_limit: Maximum documents returned by :meth:`filter_documents`.
             Increase this value when your collection exceeds 10 000 documents.
     """


### PR DESCRIPTION
## Finding (integration audit)
The Haystack DocumentStore delegates to `validate_metric` (ALLOWED_METRICS = 5 metrics), but the README + `__init__` docstring listed only 3 (cosine/euclidean/dot), hiding hamming & jaccard. Matches the ECOSYSTEM_PARITY DistanceMetric row (Haystack 10/10).

## Fix
Documented all 5 metrics in both places. Doc-only.
