### PR TITLE
docs(python): document secondary-index helper methods in README

### DIFF
--- a/crates/velesdb-python/README.md
+++ b/crates/velesdb-python/README.md
@@ -319,6 +319,11 @@ collection.create_property_index("Document", "category")  # O(1) equality lookup
 collection.create_range_index("Document", "price")         # O(log n) range queries
 indexes = collection.list_indexes()
 collection.drop_index("Document", "category")
+
+# Secondary indexes on a payload field (and their memory footprint)
+collection.has_secondary_index("category")                 # -> bool
+collection.drop_secondary_index("category")                # -> bool (True if dropped)
+collection.indexes_memory_usage()                          # -> int (total bytes)
 ```
 
 ### Sparse Vector Search


### PR DESCRIPTION
## Finding (ecosystem audit)
The Python binding exposes `has_secondary_index`, `drop_secondary_index`, and `indexes_memory_usage` (collection/mod.rs:213/225/233; declared in the `.pyi` stub), but the README 'Index management' section documented only the property/range/list/drop methods.

## Fix
Added the three missing methods with signatures. Doc-only; verified against the binding + type stub.
