### PR TITLE
docs(migrate): document sparse-vector migration support per source

### DIFF
--- a/crates/velesdb-migrate/README.md
+++ b/crates/velesdb-migrate/README.md
@@ -38,6 +38,23 @@ Switch to VelesDB in minutes, not days. `velesdb-migrate` handles the heavy lift
 | **Elasticsearch** | ✅ Ready | REST API | OpenSearch compatible, `search_after` pagination |
 | **Redis** | ✅ Ready | REST API | Redis Stack with RediSearch, FT.SEARCH |
 
+### Sparse vector migration
+
+Sparse vectors (e.g. SPLADE / learned-sparse, BM25-style indexes) are extracted
+and carried through to the destination **only** for sources that expose them in
+their API:
+
+| Source | Sparse extraction |
+|--------|-------------------|
+| **Qdrant** (named sparse vectors) | ✅ |
+| **Pinecone** (`sparseValues`) | ✅ |
+| Supabase, Weaviate, Milvus, ChromaDB, Elasticsearch, Redis, JSON, CSV | ❌ (none extracted) |
+
+> ⚠️ If your source stores sparse vectors but is **not** in the ✅ list, those
+> sparse vectors are silently dropped during migration (dense vectors and
+> payloads still migrate normally). Export the sparse vectors separately and
+> re-ingest them, or open an issue if you need a connector to add sparse support.
+
 ### Previously supported (removed)
 
 | Source | Removed | Reason | Workaround |


### PR DESCRIPTION
## Finding (ecosystem audit)
Only the **Qdrant** and **Pinecone** connectors extract sparse vectors; the other 8 set `sparse_vector: None` (src/connectors/*.rs). The README never mentioned sparse migration, so users migrating from a non-supporting source silently lost sparse data.

## Fix
Added a per-source sparse-support table + an explicit data-loss warning. Doc-only; verified against the connector implementations.
