### PR TITLE
docs(langchain): list relative_score (RSF) in multi_query_search docstring

### DIFF
--- a/integrations/langchain/src/langchain_velesdb/multi_query_ops.py
+++ b/integrations/langchain/src/langchain_velesdb/multi_query_ops.py
@@ -178,11 +178,12 @@ class MultiQueryOpsMixin:
         Args:
             queries: List of query strings (reformulations of user query).
             k: Number of results to return after fusion. Defaults to 4.
-            fusion: Fusion strategy - "average", "maximum", "rrf", or "weighted".
-                Defaults to "rrf".
+            fusion: Fusion strategy - "average", "maximum", "rrf", "weighted",
+                or "relative_score" (alias "rsf"). Defaults to "rrf".
             fusion_params: Optional parameters for fusion strategy:
                 - For "rrf": {"k": 60} (ranking constant)
                 - For "weighted": {"avg_weight": 0.6, "max_weight": 0.3, "hit_weight": 0.1}
+                - For "relative_score"/"rsf": {"dense_weight": 0.5, "sparse_weight": 0.5}
             filter: Optional metadata filter dict.
             **kwargs: Additional arguments.
 


### PR DESCRIPTION
## Finding (integration audit)
`multi_query_search` delegates to the shared `velesdb_common.fusion.build_fusion_strategy`, which supports `relative_score`/`rsf` (with `dense_weight`/`sparse_weight`) — and the README documents it — but the method docstring listed only average/maximum/rrf/weighted.

## Fix
Added `relative_score` (alias `rsf`) and its params to the docstring. Docstring-only; the strategy was already reachable (no behavior change).
