### PR TITLE
docs(integrations): correct cross-collection @collection MATCH over-claim

### DIFF
--- a/integrations/langchain/README.md
+++ b/integrations/langchain/README.md
@@ -249,21 +249,23 @@ results = vectorstore.similarity_search_with_filter(
 
 ### Cross-Collection MATCH
 
-Use the `query()` method with the `_collection` parameter to run MATCH queries
-that enrich results with data from other collections. Nodes annotated with
-`@collection` in the MATCH pattern have their payloads looked up from the named
-collection after traversal.
+The `query()` method runs single-collection VelesQL/MATCH queries against the
+vector store's own collection:
 
 ```python
-# Enrich Product nodes with Inventory data from the 'inventory' collection
 results = vectorstore.query(
-    "MATCH (p:Product)-[:STORED_IN]->(inv:Inventory@inventory) "
-    "RETURN p.name, inv.price, inv.stock LIMIT 20",
-    params={"_collection": "catalog_graph"}
+    "MATCH (p:Product)-[:STORED_IN]->(w:Warehouse) RETURN p.name, w.city LIMIT 20"
 )
 for row in results:
-    print(row["p.name"], row["inv.price"])
+    print(row["p.name"], row["w.city"])
 ```
+
+> **Cross-collection `@collection` MATCH is not available through the LangChain
+> integration.** `vectorstore.query()` delegates to a single `velesdb.Collection`,
+> which cannot resolve `@collection`-annotated nodes from *other* collections —
+> that requires `Database`-level routing. For cross-collection MATCH, use the
+> core `velesdb.Database` API or the [REST server](https://github.com/cyberlife-coder/VelesDB)
+> directly. (Tracked in `docs/reference/ECOSYSTEM_PARITY.md`, action item #7.)
 
 ## Features
 

--- a/integrations/llamaindex/README.md
+++ b/integrations/llamaindex/README.md
@@ -251,20 +251,23 @@ results = vector_store.text_query(
 
 ### Cross-Collection MATCH
 
-Use the `velesql()` method with the `_collection` parameter to run MATCH queries
-that enrich results with data from other collections. Nodes annotated with
-`@collection` in the MATCH pattern have their payloads looked up from the named
-collection after traversal.
+The `velesql()` method runs single-collection VelesQL/MATCH queries against the
+vector store's own collection:
 
 ```python
 results = vector_store.velesql(
-    "MATCH (p:Product)-[:STORED_IN]->(inv:Inventory@inventory) "
-    "RETURN p.name, inv.price, inv.stock LIMIT 20",
-    params={"_collection": "catalog_graph"}
+    "MATCH (p:Product)-[:STORED_IN]->(w:Warehouse) RETURN p.name, w.city LIMIT 20"
 )
 for row in results:
-    print(row["p.name"], row["inv.price"])
+    print(row["p.name"], row["w.city"])
 ```
+
+> **Cross-collection `@collection` MATCH is not available through the LlamaIndex
+> integration.** `velesql()` delegates to a single `velesdb.Collection`, which
+> cannot resolve `@collection`-annotated nodes from *other* collections — that
+> requires `Database`-level routing. For cross-collection MATCH, use the core
+> `velesdb.Database` API or the [REST server](https://github.com/cyberlife-coder/VelesDB)
+> directly. (Tracked in `docs/reference/ECOSYSTEM_PARITY.md`, action item #7.)
 
 ## Performance
 


### PR DESCRIPTION
## Finding (integration audit + matrix verification)
LangChain & LlamaIndex READMEs claimed `query()`/`velesql()` with `_collection` does cross-collection `@collection` enrichment. **Verified false**: both delegate to a single `velesdb.Collection` (`graph_ops.py → self._collection.query()`), which has no cross-collection access. `_collection` is only honored at the Database level (query_engine.rs:309) and only selects the MATCH target collection. Matrix correctly marks both ❌ (line 42).

## Fix
Rewrote both sections: single-collection MATCH example (works) + explicit note that cross-collection MATCH needs the core `Database` API / REST server (parity action item #7). README ↔ code ↔ matrix now consistent. Doc-only.
