### PR TITLE
fix(cli): stop advertising a non-existent '.guardrails set' command

### DIFF
--- a/crates/velesdb-cli/src/repl_search_cmds.rs
+++ b/crates/velesdb-cli/src/repl_search_cmds.rs
@@ -188,7 +188,8 @@ pub(crate) fn cmd_guardrails() -> CommandResult {
     println!();
     println!(
         "  {}",
-        "Use '.guardrails set <key> <value>' to modify (server restart required for persistence)."
+        "These are the built-in defaults (read-only here). Configure limits via \
+         velesdb.toml / server config; the REPL has no '.guardrails set' command."
             .dimmed()
     );
     println!();

--- a/crates/velesdb-cli/src/repl_search_cmds.rs
+++ b/crates/velesdb-cli/src/repl_search_cmds.rs
@@ -188,8 +188,9 @@ pub(crate) fn cmd_guardrails() -> CommandResult {
     println!();
     println!(
         "  {}",
-        "These are the built-in defaults (read-only here). Configure limits via \
-         velesdb.toml / server config; the REPL has no '.guardrails set' command."
+        "These are the built-in defaults (read-only in the REPL). A running \
+         velesdb-server can adjust them at runtime via its PUT /guardrails \
+         endpoint; the REPL has no '.guardrails set' command."
             .dimmed()
     );
     println!();


### PR DESCRIPTION
## Finding (ecosystem audit)
The `.guardrails` REPL command printed "Use '.guardrails set <key> <value>' to modify", but no such subcommand exists — `.guardrails` dispatches to an arg-less `cmd_guardrails()` that only displays the built-in `QueryLimits` defaults (read-only).

## Fix
Replaced the misleading line with an accurate note (values are read-only defaults; configure via velesdb.toml / server config; no `.guardrails set` command). cli clippy (pedantic) passes; no test asserted the old string.
