### PR TITLE
fix(demo): use oxc minifier so tauri-rag-app builds on vite 8

### DIFF
--- a/demos/tauri-rag-app/vite.config.ts
+++ b/demos/tauri-rag-app/vite.config.ts
@@ -12,7 +12,9 @@ export default defineConfig({
   envPrefix: ['VITE_', 'TAURI_'],
   build: {
     target: ['es2021', 'chrome100', 'safari13'],
-    minify: !process.env.TAURI_DEBUG ? 'esbuild' : false,
+    // 'oxc' is rolldown-vite's native minifier; 'esbuild' is deprecated and no
+    // longer bundled with vite 8, so requesting it breaks `vite build`.
+    minify: !process.env.TAURI_DEBUG ? 'oxc' : false,
     sourcemap: !!process.env.TAURI_DEBUG,
   },
 });


### PR DESCRIPTION
## Problem

The **Demos and Examples Smoke** check fails on `develop` (and therefore on every open PR) at the Tauri demo frontend build step:

```
[plugin vite:esbuild-transpile]
Error: Failed to load `transformWithEsbuild`. It is deprecated and it now
requires esbuild to be installed separately...
Caused by: Cannot find package 'esbuild' ...
```

`vite` 8 is rolldown-based and no longer bundles `esbuild`. The demo's `vite.config.ts` still requested `minify: 'esbuild'`, so `vite build` tries to load the now-absent `esbuild` package and aborts. This surfaced after the `@vitejs/plugin-react` / vite-8 dependency bumps.

## Fix

Switch the minifier to `'oxc'` — rolldown-vite's native minifier and exactly the migration the deprecation warning recommends. No new dependency, no behavioral change to the bundle output.

## Verification

```
$ cd demos/tauri-rag-app && npm ci && npm run build
✓ 1746 modules transformed.
✓ built in 71ms
```

Root cause of the failing **Demos and Examples Smoke** check across all currently open PRs (#926–#936).
