### PR TITLE
ci(sonar): feed lcov coverage to SonarCloud's native Rust analyzer

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -11,9 +11,13 @@ sonar.exclusions=**/tests/**,**/*_tests.rs,**/*_test.rs,**/benches/**,**/example
 # Test sources for coverage mapping (explicit paths — SonarCloud rejects globs)
 sonar.tests=crates/velesdb-core/tests,crates/velesdb-server/tests,crates/velesdb-cli/tests,crates/velesdb-migrate/tests,crates/velesdb-python/tests,crates/velesdb-wasm/tests,crates/tauri-plugin-velesdb/tests
 
-# Coverage — Rust is analyzed via community plugin; lcov is uploaded to Codecov separately.
-# SonarCloud's genericCoverage expects XML, not lcov. Disable to avoid parse errors.
-# sonar.coverageReportPaths=lcov.info
+# Coverage — SonarQube Cloud's native Rust analyzer ingests LCOV directly via
+# sonar.rust.lcov.reportPaths (comma-separated, absolute or project-root-relative).
+# lcov.info is produced by the "Code Coverage" CI job (cargo llvm-cov, threshold
+# enforced there at 78% lines) and downloaded into the scan workspace root by the
+# SonarCloud job's download-artifact step. The older sonar.coverageReportPaths /
+# genericCoverage route expected XML and is not used.
+sonar.rust.lcov.reportPaths=lcov.info
 
 # Duplication exclusions (test and benchmark code is intentionally repetitive)
 sonar.cpd.exclusions=**/*_tests.rs,**/tests/**,**/benches/**,conformance/**


### PR DESCRIPTION
Fixes the pre-existing **SonarCloud "Quality Gate failed → 0.0% Coverage on New Code"** red (v1.15.0 shipped with the same).

**Root cause:** `sonar.coverageReportPaths` was commented out (it expects XML), so Sonar ingested **no** coverage → mechanical 0% on all new lines.

**Fix:** SonarQube Cloud's native Rust analyzer reads LCOV via `sonar.rust.lcov.reportPaths`. The `Code Coverage` job already produces `lcov.info` (cargo llvm-cov, 78% line threshold enforced) and the SonarCloud job downloads it to the workspace root — so we point Sonar at it.

Real coverage is unchanged (still enforced by `cargo llvm-cov --fail-under-lines 78`); this only makes the Sonar gate reflect reality. Blocks tagging v1.16.0 until the gate is green per the release quality bar.
