### PR TITLE
ci: trigger CI + SonarCloud re-analysis on sonar-project.properties changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ on:
       - 'demos/**'
       - 'Cargo.toml'
       - 'Cargo.lock'
+      - 'sonar-project.properties'
       - '.github/workflows/**'
   pull_request:
     branches: [main, develop]
@@ -39,6 +40,7 @@ on:
       - 'demos/**'
       - 'Cargo.toml'
       - 'Cargo.lock'
+      - 'sonar-project.properties'
       - '.github/workflows/**'
 
 # Annuler les runs précédents pour la même branche/PR


### PR DESCRIPTION
Follow-up to #939. The CI path filter omitted `sonar-project.properties`, so the lcov→Sonar wiring never re-ran the SonarCloud job. Add it to the push + pull_request path filters. Editing `ci.yml` also re-triggers CI now (covered by `.github/workflows/**`), so SonarCloud re-analyzes with `sonar.rust.lcov.reportPaths` in effect.
