### PR TITLE
chore(sonar): scope analysis to production code + suppress lockfile FPs

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -5,8 +5,29 @@ sonar.projectVersion=1.0
 sonar.sources=crates
 sonar.sourceEncoding=UTF-8
 
-# Exclude non-production code from main analysis
-sonar.exclusions=**/tests/**,**/*_tests.rs,**/*_test.rs,**/benches/**,**/examples/**,.claude/**,conformance/**,scripts/**,docs/**,demos/**,sdks/**/tests/**,sdks/**/__tests__/**
+# Exclude non-production code from main analysis.
+# Additions: `**/tests.rs` (bare unit-test modules that don't match `*_tests.rs`,
+# e.g. index/hnsw/native/tests.rs); `**/scripts/**` (crate-level dev/release
+# tooling — top-level `scripts/**` was already excluded); `**/e2e/**` (the WASM
+# end-to-end browser harness, not shipped product code).
+sonar.exclusions=**/tests/**,**/*_tests.rs,**/*_test.rs,**/tests.rs,**/benches/**,**/examples/**,.claude/**,conformance/**,scripts/**,**/scripts/**,**/e2e/**,docs/**,demos/**,sdks/**/tests/**,sdks/**/__tests__/**
+
+# Rule-specific suppressions (false positives / non-product scope).
+# - S8570/S8565 ("lock file missing") are false positives in a Cargo workspace:
+#   the single root Cargo.lock IS committed; member crates correctly carry no
+#   per-crate lock and pyproject has no uv/poetry lock by design.
+# - S3776 (cognitive complexity) is not enforced on test sources declared in
+#   `sonar.tests` (test setup is intentionally branchy); production code is still
+#   policed.
+sonar.issue.ignore.multicriteria=lockcargo,lockpy,cogtestdir,cogtestfile
+sonar.issue.ignore.multicriteria.lockcargo.ruleKey=text:S8570
+sonar.issue.ignore.multicriteria.lockcargo.resourceKey=**/Cargo.toml
+sonar.issue.ignore.multicriteria.lockpy.ruleKey=text:S8565
+sonar.issue.ignore.multicriteria.lockpy.resourceKey=**/pyproject.toml
+sonar.issue.ignore.multicriteria.cogtestdir.ruleKey=*:S3776
+sonar.issue.ignore.multicriteria.cogtestdir.resourceKey=**/tests/**
+sonar.issue.ignore.multicriteria.cogtestfile.ruleKey=*:S3776
+sonar.issue.ignore.multicriteria.cogtestfile.resourceKey=**/*tests.rs
 
 # Test sources for coverage mapping (explicit paths — SonarCloud rejects globs)
 sonar.tests=crates/velesdb-core/tests,crates/velesdb-server/tests,crates/velesdb-cli/tests,crates/velesdb-migrate/tests,crates/velesdb-python/tests,crates/velesdb-wasm/tests,crates/tauri-plugin-velesdb/tests


### PR DESCRIPTION
Reduces the 87 new-code Sonar findings by removing ~52 non-product/false-positive items (lockfile FP in a Cargo workspace, WASM e2e harness JS, crate-level .ps1 tooling, bare tests.rs). Production src is untouched and still policed; remaining genuine complexity findings handled in a follow-up. Triggers CI+SonarCloud re-analysis (sonar-project.properties is now in the CI path filter, #940).
