### PR TITLE
refactor: reduce cognitive complexity of 29 functions below SonarCloud threshold

### DIFF
--- a/crates/velesdb-cli/src/repl.rs
+++ b/crates/velesdb-cli/src/repl.rs
@@ -98,52 +98,10 @@ pub fn run(path: PathBuf) -> Result<()> {
     let mut config = ReplConfig::default();
 
     loop {
-        // On Unix, wrap ANSI codes in \x01..\x02 so rustyline (readline
-        // backend) correctly computes the visible prompt width.
-        // On Windows, rustyline uses the crossterm backend which handles
-        // ANSI natively — the \x01\x02 markers appear as literal garbage
-        // characters there and must be omitted.
-        #[cfg(windows)]
-        let prompt = "\x1b[1;34mvelesdb> \x1b[0m".to_string();
-        #[cfg(not(windows))]
-        let prompt = "\x01\x1b[1;34m\x02velesdb> \x01\x1b[0m\x02".to_string();
-        match rl.readline(&prompt) {
+        match rl.readline(&prompt()) {
             Ok(line) => {
-                let line = line.trim();
-                if line.is_empty() {
-                    continue;
-                }
-
-                let _ = rl.add_history_entry(line);
-
-                if line.starts_with('.') || line.starts_with('\\') {
-                    match crate::repl_commands::handle_command(&db, line, &mut config) {
-                        crate::repl_commands::CommandResult::Continue => (),
-                        crate::repl_commands::CommandResult::Quit => break,
-                        crate::repl_commands::CommandResult::Error(e) => {
-                            println!("{} {}", "Error:".red().bold(), e);
-                        }
-                    }
-                } else {
-                    match execute_query(&db, line, config.session.active_collection()) {
-                        Ok(result) => {
-                            let fmt = match config.format {
-                                OutputFormat::Table => "table",
-                                OutputFormat::Json => "json",
-                            };
-                            print_result(&result, fmt);
-                            if config.timing {
-                                println!(
-                                    "\n{} rows ({:.2}ms)\n",
-                                    result.rows.len().to_string().green(),
-                                    result.duration_ms
-                                );
-                            }
-                        }
-                        Err(e) => {
-                            println!("{} {}\n", "Error:".red().bold(), e);
-                        }
-                    }
+                if handle_input(&db, &mut rl, &line, &mut config) == LoopAction::Quit {
+                    break;
                 }
             }
             Err(ReadlineError::Interrupted) => {
@@ -162,6 +120,87 @@ pub fn run(path: PathBuf) -> Result<()> {
     let _ = rl.save_history(&history_path);
     println!("Goodbye!");
     Ok(())
+}
+
+/// Whether the REPL loop should keep reading input or terminate.
+#[derive(PartialEq)]
+enum LoopAction {
+    Continue,
+    Quit,
+}
+
+/// Build the input prompt with platform-correct ANSI escaping.
+///
+/// On Unix, wrap ANSI codes in `\x01..\x02` so rustyline (readline backend)
+/// correctly computes the visible prompt width. On Windows, rustyline uses the
+/// crossterm backend which handles ANSI natively — the `\x01\x02` markers would
+/// appear as literal garbage there and must be omitted.
+fn prompt() -> String {
+    #[cfg(windows)]
+    {
+        "\x1b[1;34mvelesdb> \x1b[0m".to_string()
+    }
+    #[cfg(not(windows))]
+    {
+        "\x01\x1b[1;34m\x02velesdb> \x01\x1b[0m\x02".to_string()
+    }
+}
+
+/// Handle a single line of input: dot-commands vs. `VelesQL` queries.
+fn handle_input(
+    db: &Database,
+    rl: &mut Editor<ReplHelper, DefaultHistory>,
+    line: &str,
+    config: &mut ReplConfig,
+) -> LoopAction {
+    let line = line.trim();
+    if line.is_empty() {
+        return LoopAction::Continue;
+    }
+
+    let _ = rl.add_history_entry(line);
+
+    if line.starts_with('.') || line.starts_with('\\') {
+        handle_dot_command(db, line, config)
+    } else {
+        run_query(db, line, config);
+        LoopAction::Continue
+    }
+}
+
+/// Dispatch a dot/backslash command and map its result to a [`LoopAction`].
+fn handle_dot_command(db: &Database, line: &str, config: &mut ReplConfig) -> LoopAction {
+    match crate::repl_commands::handle_command(db, line, config) {
+        crate::repl_commands::CommandResult::Continue => LoopAction::Continue,
+        crate::repl_commands::CommandResult::Quit => LoopAction::Quit,
+        crate::repl_commands::CommandResult::Error(e) => {
+            println!("{} {}", "Error:".red().bold(), e);
+            LoopAction::Continue
+        }
+    }
+}
+
+/// Execute a `VelesQL` query line and print its result or error.
+fn run_query(db: &Database, line: &str, config: &ReplConfig) {
+    match execute_query(db, line, config.session.active_collection()) {
+        Ok(result) => {
+            let fmt = match config.format {
+                OutputFormat::Table => "table",
+                OutputFormat::Json => "json",
+            };
+            print_result(&result, fmt);
+            if config.timing {
+                println!(
+                    "\n{} rows ({:.2}ms)\n",
+                    result.rows.len().to_string().green(),
+                    result.duration_ms
+                );
+            }
+        }
+        Err(e) => {
+            println!("{} {}\n", "Error:".red().bold(), e);
+        }
+    }
 }
 
 /// Execute a `VelesQL` query and return results.

--- a/crates/velesdb-cli/src/repl_execute.rs
+++ b/crates/velesdb-cli/src/repl_execute.rs
@@ -53,8 +53,29 @@ pub fn execute_query(
         });
     }
 
-    // Determine query kind for display purposes.
-    let kind = if parsed.is_ddl_query() {
+    let kind = query_kind(&parsed);
+    let params = HashMap::new();
+
+    let results = if parsed.is_match_query() {
+        execute_match_query(db, &parsed, active_collection, &params)?
+    } else {
+        db.execute_query(&parsed, &params)
+            .map_err(|e| anyhow::anyhow!("Query error: {e}"))?
+    };
+
+    let rows = results.into_iter().map(result_to_row).collect();
+    let duration_ms = start.elapsed().as_secs_f64() * 1000.0;
+
+    Ok(QueryResult {
+        rows,
+        duration_ms,
+        kind,
+    })
+}
+
+/// Determine the [`QueryKind`] of a parsed query for display purposes.
+fn query_kind(parsed: &velesdb_core::velesql::Query) -> QueryKind {
+    if parsed.is_ddl_query() {
         QueryKind::Ddl
     } else if parsed.is_introspection_query() {
         QueryKind::Introspection
@@ -66,58 +87,44 @@ pub fn execute_query(
         QueryKind::Train
     } else {
         QueryKind::Select
-    };
+    }
+}
 
-    let params = HashMap::new();
-
-    // MATCH queries need a collection context — route via Collection::execute_query.
-    let results = if parsed.is_match_query() {
-        let col_name = active_collection.ok_or_else(|| {
-            anyhow::anyhow!(
-                "MATCH queries require an active collection. Use: .use <collection_name>"
-            )
-        })?;
-        // Try graph collection first (most likely for MATCH), then vector collection.
-        if let Some(graph_col) = db.get_graph_collection(col_name) {
-            graph_col
-                .execute_query(&parsed, &params)
-                .map_err(|e| anyhow::anyhow!("Query error: {e}"))?
-        } else if let Some(vec_col) = db.get_vector_collection(col_name) {
-            vec_col
-                .execute_query(&parsed, &params)
-                .map_err(|e| anyhow::anyhow!("Query error: {e}"))?
-        } else {
-            return Err(anyhow::anyhow!("Collection '{}' not found", col_name));
-        }
+/// Route a MATCH query to the active collection (graph first, then vector).
+fn execute_match_query(
+    db: &Database,
+    parsed: &velesdb_core::velesql::Query,
+    active_collection: Option<&str>,
+    params: &HashMap<String, serde_json::Value>,
+) -> Result<Vec<velesdb_core::SearchResult>> {
+    let col_name = active_collection.ok_or_else(|| {
+        anyhow::anyhow!("MATCH queries require an active collection. Use: .use <collection_name>")
+    })?;
+    if let Some(graph_col) = db.get_graph_collection(col_name) {
+        graph_col
+            .execute_query(parsed, params)
+            .map_err(|e| anyhow::anyhow!("Query error: {e}"))
+    } else if let Some(vec_col) = db.get_vector_collection(col_name) {
+        vec_col
+            .execute_query(parsed, params)
+            .map_err(|e| anyhow::anyhow!("Query error: {e}"))
     } else {
-        db.execute_query(&parsed, &params)
-            .map_err(|e| anyhow::anyhow!("Query error: {e}"))?
-    };
+        Err(anyhow::anyhow!("Collection '{}' not found", col_name))
+    }
+}
 
-    // Convert SearchResult to row format
-    let rows: Vec<HashMap<String, serde_json::Value>> = results
-        .into_iter()
-        .map(|r| {
-            let mut row = HashMap::new();
-            row.insert("id".to_string(), serde_json::json!(r.point.id));
-            row.insert("score".to_string(), serde_json::json!(r.score));
+/// Convert a single [`velesdb_core::SearchResult`] into a display row.
+fn result_to_row(r: velesdb_core::SearchResult) -> HashMap<String, serde_json::Value> {
+    let mut row = HashMap::new();
+    row.insert("id".to_string(), serde_json::json!(r.point.id));
+    row.insert("score".to_string(), serde_json::json!(r.score));
 
-            if let Some(serde_json::Value::Object(map)) = &r.point.payload {
-                for (k, v) in map {
-                    row.insert(k.clone(), v.clone());
-                }
-            }
-            row
-        })
-        .collect();
-
-    let duration_ms = start.elapsed().as_secs_f64() * 1000.0;
-
-    Ok(QueryResult {
-        rows,
-        duration_ms,
-        kind,
-    })
+    if let Some(serde_json::Value::Object(map)) = &r.point.payload {
+        for (k, v) in map {
+            row.insert(k.clone(), v.clone());
+        }
+    }
+    row
 }
 
 pub(crate) fn contains_param_vector(condition: &velesdb_core::velesql::Condition) -> bool {

--- a/crates/velesdb-core/src/collection/core/statistics.rs
+++ b/crates/velesdb-core/src/collection/core/statistics.rs
@@ -108,28 +108,37 @@ impl Collection {
         let payload_storage = self.payload_storage.read();
         let ids = payload_storage.ids();
         for id in ids.into_iter().take(1_000) {
-            if let Ok(Some(payload)) = payload_storage.retrieve(id) {
-                if let Ok(payload_bytes) = serde_json::to_vec(&payload) {
-                    payload_size_bytes =
-                        payload_size_bytes.saturating_add(saturating_u64(payload_bytes.len()));
-                }
-
-                if let Some(obj) = payload.as_object() {
-                    for (key, value) in obj {
-                        if value.is_null() {
-                            *null_counts.entry(key.clone()).or_insert(0) += 1;
-                        } else {
-                            distinct_values
-                                .entry(key.clone())
-                                .or_default()
-                                .insert(value.to_string());
-                        }
-                    }
-                }
+            let Ok(Some(payload)) = payload_storage.retrieve(id) else {
+                continue;
+            };
+            if let Ok(payload_bytes) = serde_json::to_vec(&payload) {
+                payload_size_bytes =
+                    payload_size_bytes.saturating_add(saturating_u64(payload_bytes.len()));
+            }
+            if let Some(obj) = payload.as_object() {
+                Self::accumulate_payload_fields(obj, &mut distinct_values, &mut null_counts);
             }
         }
 
         (payload_size_bytes, distinct_values, null_counts)
+    }
+
+    /// Accumulates distinct values and null counts from one payload object's fields.
+    fn accumulate_payload_fields(
+        obj: &serde_json::Map<String, serde_json::Value>,
+        distinct_values: &mut HashMap<String, HashSet<String>>,
+        null_counts: &mut HashMap<String, u64>,
+    ) {
+        for (key, value) in obj {
+            if value.is_null() {
+                *null_counts.entry(key.clone()).or_insert(0) += 1;
+            } else {
+                distinct_values
+                    .entry(key.clone())
+                    .or_default()
+                    .insert(value.to_string());
+            }
+        }
     }
 
     /// Samples up to `max_samples` rows from payload storage for histogram construction.

--- a/crates/velesdb-core/src/collection/graph/edge_concurrent/mod.rs
+++ b/crates/velesdb-core/src/collection/graph/edge_concurrent/mod.rs
@@ -460,16 +460,27 @@ impl ConcurrentEdgeStore {
             if *shard_idx == node_shard {
                 guard.remove_node_edges(node_id);
             } else {
-                for (edge_id, target) in outgoing {
-                    if self.shard_index(*target) == *shard_idx {
-                        guard.remove_edge_incoming_only(*edge_id);
-                    }
-                }
-                for (edge_id, source) in incoming {
-                    if self.shard_index(*source) == *shard_idx {
-                        guard.remove_edge_outgoing_only(*edge_id);
-                    }
-                }
+                self.cleanup_cross_shard_edges(*shard_idx, guard, outgoing, incoming);
+            }
+        }
+    }
+
+    /// Removes the dangling half-edges that terminate in `shard_idx` for a cross-shard cleanup.
+    fn cleanup_cross_shard_edges(
+        &self,
+        shard_idx: usize,
+        guard: &mut parking_lot::RwLockWriteGuard<'_, super::EdgeStore>,
+        outgoing: &[(u64, u64)],
+        incoming: &[(u64, u64)],
+    ) {
+        for (edge_id, target) in outgoing {
+            if self.shard_index(*target) == shard_idx {
+                guard.remove_edge_incoming_only(*edge_id);
+            }
+        }
+        for (edge_id, source) in incoming {
+            if self.shard_index(*source) == shard_idx {
+                guard.remove_edge_outgoing_only(*edge_id);
             }
         }
     }

--- a/crates/velesdb-core/src/collection/search/query/match_exec/similarity.rs
+++ b/crates/velesdb-core/src/collection/search/query/match_exec/similarity.rs
@@ -321,49 +321,54 @@ impl Collection {
             "similarity()" | "similarity" => {
                 results.sort_unstable_by(|a, b| {
                     let cmp = a.score.unwrap_or(0.0).total_cmp(&b.score.unwrap_or(0.0));
-                    if descending {
-                        cmp.reverse()
-                    } else {
-                        cmp
-                    }
+                    Self::apply_direction(cmp, descending)
                 });
             }
             "depth" => {
                 results.sort_unstable_by(|a, b| {
-                    let cmp = a.depth.cmp(&b.depth);
-                    if descending {
-                        cmp.reverse()
-                    } else {
-                        cmp
-                    }
+                    Self::apply_direction(a.depth.cmp(&b.depth), descending)
                 });
             }
-            _ => {
-                if let Some((alias, property)) = parse_property_path(order_by) {
-                    let payload_storage = self.payload_storage.read();
-                    results.sort_unstable_by(|a, b| {
-                        let get_value = |r: &MatchResult| -> Option<serde_json::Value> {
-                            let node_id = *r.bindings.get(alias)?;
-                            let payload = payload_storage.retrieve(node_id).ok().flatten()?;
-                            let object = payload.as_object()?;
-                            Self::get_nested_property(object, property).cloned()
-                        };
-
-                        let a_value = get_value(a);
-                        let b_value = get_value(b);
-                        let cmp =
-                            super::super::compare_json_values(a_value.as_ref(), b_value.as_ref());
-                        if descending {
-                            cmp.reverse()
-                        } else {
-                            cmp
-                        }
-                    });
-                } else {
-                    tracing::warn!("Unsupported MATCH ORDER BY expression '{}'", order_by);
-                }
-            }
+            _ => self.order_match_results_by_property(results, order_by, descending),
         }
+    }
+
+    /// Applies sort direction to a comparison (reverses when `descending`).
+    #[inline]
+    fn apply_direction(cmp: std::cmp::Ordering, descending: bool) -> std::cmp::Ordering {
+        if descending {
+            cmp.reverse()
+        } else {
+            cmp
+        }
+    }
+
+    /// ORDER BY a property path (e.g. `n.name`); warns and leaves order
+    /// unchanged when the expression is not a recognized property path.
+    fn order_match_results_by_property(
+        &self,
+        results: &mut [MatchResult],
+        order_by: &str,
+        descending: bool,
+    ) {
+        let Some((alias, property)) = parse_property_path(order_by) else {
+            tracing::warn!("Unsupported MATCH ORDER BY expression '{}'", order_by);
+            return;
+        };
+        let payload_storage = self.payload_storage.read();
+        results.sort_unstable_by(|a, b| {
+            let get_value = |r: &MatchResult| -> Option<serde_json::Value> {
+                let node_id = *r.bindings.get(alias)?;
+                let payload = payload_storage.retrieve(node_id).ok().flatten()?;
+                let object = payload.as_object()?;
+                Self::get_nested_property(object, property).cloned()
+            };
+
+            let a_value = get_value(a);
+            let b_value = get_value(b);
+            let cmp = super::super::compare_json_values(a_value.as_ref(), b_value.as_ref());
+            Self::apply_direction(cmp, descending)
+        });
     }
 
     /// Converts `MatchResults` to `SearchResults` for unified API (EPIC-045 US-002).

--- a/crates/velesdb-core/src/collection/search/query/union_query.rs
+++ b/crates/velesdb-core/src/collection/search/query/union_query.rs
@@ -170,71 +170,109 @@ impl Collection {
     ) {
         match condition {
             crate::velesql::Condition::Or(left, right) => {
-                // Direct OR at top level
-                let left_has_sim = Self::count_similarity_conditions(left) > 0;
-                let right_has_sim = Self::count_similarity_conditions(right) > 0;
-
-                match (left_has_sim, right_has_sim) {
-                    (true, false) => (Some((**left).clone()), Some((**right).clone()), None),
-                    (false, true) => (Some((**right).clone()), Some((**left).clone()), None),
-                    _ => (Some(condition.clone()), None, None),
-                }
+                Self::split_top_level_or(condition, left, right)
             }
             crate::velesql::Condition::And(left, right) => {
-                // Issue #122: Check if one side contains an OR with similarity
-                let left_has_problematic_or = Self::has_similarity_in_problematic_or(left);
-                let right_has_problematic_or = Self::has_similarity_in_problematic_or(right);
-
-                match (left_has_problematic_or, right_has_problematic_or) {
-                    (true, false) => {
-                        // Left has the OR, right is an outer filter
-                        let (sim, meta, inner_filter) =
-                            Self::split_or_condition_with_outer_filter(left);
-                        // Combine inner_filter with right as outer filter
-                        let outer = match inner_filter {
-                            Some(inner) => Some(crate::velesql::Condition::And(
-                                Box::new(inner),
-                                Box::new((**right).clone()),
-                            )),
-                            None => Some((**right).clone()),
-                        };
-                        (sim, meta, outer)
-                    }
-                    (false, true) => {
-                        // Right has the OR, left is an outer filter
-                        let (sim, meta, inner_filter) =
-                            Self::split_or_condition_with_outer_filter(right);
-                        let outer = match inner_filter {
-                            Some(inner) => Some(crate::velesql::Condition::And(
-                                Box::new((**left).clone()),
-                                Box::new(inner),
-                            )),
-                            None => Some((**left).clone()),
-                        };
-                        (sim, meta, outer)
-                    }
-                    _ => {
-                        // Both or neither - treat as before
-                        if Self::count_similarity_conditions(condition) > 0 {
-                            (Some(condition.clone()), None, None)
-                        } else {
-                            (None, Some(condition.clone()), None)
-                        }
-                    }
-                }
+                Self::split_top_level_and(condition, left, right)
             }
             crate::velesql::Condition::Group(inner) => {
                 // Unwrap group and recurse
                 Self::split_or_condition_with_outer_filter(inner)
             }
             // Not an OR or AND condition - treat as similarity if it contains similarity
-            _ => {
-                if Self::count_similarity_conditions(condition) > 0 {
-                    (Some(condition.clone()), None, None)
-                } else {
-                    (None, Some(condition.clone()), None)
-                }
+            _ => Self::classify_leaf_condition(condition),
+        }
+    }
+
+    /// Handles a top-level `OR`: routes the similarity-bearing side to the
+    /// similarity slot and the other to the metadata slot (Issue #122).
+    fn split_top_level_or(
+        condition: &crate::velesql::Condition,
+        left: &crate::velesql::Condition,
+        right: &crate::velesql::Condition,
+    ) -> (
+        Option<crate::velesql::Condition>,
+        Option<crate::velesql::Condition>,
+        Option<crate::velesql::Condition>,
+    ) {
+        let left_has_sim = Self::count_similarity_conditions(left) > 0;
+        let right_has_sim = Self::count_similarity_conditions(right) > 0;
+        match (left_has_sim, right_has_sim) {
+            (true, false) => (Some(left.clone()), Some(right.clone()), None),
+            (false, true) => (Some(right.clone()), Some(left.clone()), None),
+            _ => (Some(condition.clone()), None, None),
+        }
+    }
+
+    /// Handles a top-level `AND`: when exactly one side carries a problematic
+    /// OR, recurse into it and fold the other side into the outer filter.
+    fn split_top_level_and(
+        condition: &crate::velesql::Condition,
+        left: &crate::velesql::Condition,
+        right: &crate::velesql::Condition,
+    ) -> (
+        Option<crate::velesql::Condition>,
+        Option<crate::velesql::Condition>,
+        Option<crate::velesql::Condition>,
+    ) {
+        match (
+            Self::has_similarity_in_problematic_or(left),
+            Self::has_similarity_in_problematic_or(right),
+        ) {
+            (true, false) => {
+                let (sim, meta, inner_filter) = Self::split_or_condition_with_outer_filter(left);
+                (
+                    sim,
+                    meta,
+                    Some(Self::combine_outer_filter(inner_filter, right, true)),
+                )
             }
+            (false, true) => {
+                let (sim, meta, inner_filter) = Self::split_or_condition_with_outer_filter(right);
+                (
+                    sim,
+                    meta,
+                    Some(Self::combine_outer_filter(inner_filter, left, false)),
+                )
+            }
+            // Both or neither - treat as a leaf.
+            _ => Self::classify_leaf_condition(condition),
+        }
+    }
+
+    /// Combines a recursively-extracted inner filter with the AND's other side,
+    /// preserving operand order (`inner_on_left` keeps the inner condition left).
+    fn combine_outer_filter(
+        inner_filter: Option<crate::velesql::Condition>,
+        other: &crate::velesql::Condition,
+        inner_on_left: bool,
+    ) -> crate::velesql::Condition {
+        match inner_filter {
+            Some(inner) => {
+                let (l, r) = if inner_on_left {
+                    (Box::new(inner), Box::new(other.clone()))
+                } else {
+                    (Box::new(other.clone()), Box::new(inner))
+                };
+                crate::velesql::Condition::And(l, r)
+            }
+            None => other.clone(),
+        }
+    }
+
+    /// Classifies a non-OR/AND condition: similarity slot if it contains a
+    /// similarity predicate, otherwise the metadata slot.
+    fn classify_leaf_condition(
+        condition: &crate::velesql::Condition,
+    ) -> (
+        Option<crate::velesql::Condition>,
+        Option<crate::velesql::Condition>,
+        Option<crate::velesql::Condition>,
+    ) {
+        if Self::count_similarity_conditions(condition) > 0 {
+            (Some(condition.clone()), None, None)
+        } else {
+            (None, Some(condition.clone()), None)
         }
     }
 }

--- a/crates/velesdb-core/src/database/query_engine_dml.rs
+++ b/crates/velesdb-core/src/database/query_engine_dml.rs
@@ -163,40 +163,50 @@ impl Database {
             if !Self::matches_update_filter(&point, filter) {
                 continue;
             }
-
-            let mut payload_map = point
-                .payload
-                .as_ref()
-                .and_then(serde_json::Value::as_object)
-                .cloned()
-                .unwrap_or_default();
-
-            let mut updated_vector = point.vector.clone();
-
-            for (field, value) in assignments {
-                if field == "vector" {
-                    if collection.is_metadata_only() {
-                        return Err(Error::Query(
-                            "UPDATE on metadata-only collection cannot set 'vector'".to_string(),
-                        ));
-                    }
-                    updated_vector = Self::json_to_vector(value)?;
-                } else {
-                    payload_map.insert(field.clone(), value.clone());
-                }
-            }
-
-            let updated = if collection.is_metadata_only() {
-                crate::Point::metadata_only(point.id, serde_json::Value::Object(payload_map))
-            } else {
-                crate::Point::new(
-                    point.id,
-                    updated_vector,
-                    Some(serde_json::Value::Object(payload_map)),
-                )
-            };
-            updated_points.push(updated);
+            updated_points.push(Self::apply_assignments_to_point(
+                collection,
+                &point,
+                assignments,
+            )?);
         }
         Ok(updated_points)
+    }
+
+    /// Applies field assignments to a single point, producing the updated point.
+    fn apply_assignments_to_point(
+        collection: &crate::collection::Collection,
+        point: &crate::Point,
+        assignments: &[(String, serde_json::Value)],
+    ) -> Result<crate::Point> {
+        let mut payload_map = point
+            .payload
+            .as_ref()
+            .and_then(serde_json::Value::as_object)
+            .cloned()
+            .unwrap_or_default();
+        let mut updated_vector = point.vector.clone();
+
+        for (field, value) in assignments {
+            if field == "vector" {
+                if collection.is_metadata_only() {
+                    return Err(Error::Query(
+                        "UPDATE on metadata-only collection cannot set 'vector'".to_string(),
+                    ));
+                }
+                updated_vector = Self::json_to_vector(value)?;
+            } else {
+                payload_map.insert(field.clone(), value.clone());
+            }
+        }
+
+        Ok(if collection.is_metadata_only() {
+            crate::Point::metadata_only(point.id, serde_json::Value::Object(payload_map))
+        } else {
+            crate::Point::new(
+                point.id,
+                updated_vector,
+                Some(serde_json::Value::Object(payload_map)),
+            )
+        })
     }
 }

--- a/crates/velesdb-core/src/index/hnsw/native/graph/gpu_search.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/graph/gpu_search.rs
@@ -57,10 +57,7 @@ impl<D: DistanceEngine> NativeHnsw<D> {
 
         // Phase 1: CPU greedy descent through upper layers (tiny, < 1000 nodes)
         let max_layer = self.max_layer.load(Ordering::Relaxed);
-        let mut current_ep = ep;
-        for layer_idx in (1..=max_layer).rev() {
-            current_ep = self.search_layer_single(&prepared, current_ep, layer_idx);
-        }
+        let current_ep = self.descend_to_layer0(&prepared, ep, max_layer);
 
         // Phase 2: Build or reuse cached CSR from layer 0.
         //
@@ -138,11 +135,7 @@ impl<D: DistanceEngine> NativeHnsw<D> {
                 dimension,
                 metric,
             );
-            if results.is_empty() {
-                None
-            } else {
-                Some(results)
-            }
+            (!results.is_empty()).then_some(results)
         } else {
             // Multi-entry GPU search: launch from diversified entry points
             // and merge results (matching CPU search_multi_entry pattern).
@@ -163,22 +156,39 @@ impl<D: DistanceEngine> NativeHnsw<D> {
                 all_results.extend(results);
             }
 
-            if all_results.is_empty() {
-                return None;
-            }
-
-            // Deduplicate by node ID, then sort by distance.
-            //
-            // Must sort by node ID first because dedup_by_key only removes
-            // *consecutive* duplicates. Sorting by distance first would leave
-            // non-adjacent duplicates (same node from different probes)
-            // interleaved with other nodes at similar distances.
-            all_results.sort_unstable_by_key(|r| r.0);
-            all_results.dedup_by_key(|r| r.0);
-            all_results.sort_unstable_by(|a, b| a.1.total_cmp(&b.1));
-            all_results.truncate(k);
-            Some(all_results)
+            Self::merge_gpu_probe_results(all_results, k)
         }
+    }
+
+    /// CPU greedy descent through the upper layers (1..=`max_layer`), returning
+    /// the layer-0 entry point. Layer 0 itself is offloaded to the GPU.
+    fn descend_to_layer0(&self, prepared: &[f32], ep: usize, max_layer: usize) -> usize {
+        let mut current_ep = ep;
+        for layer_idx in (1..=max_layer).rev() {
+            current_ep = self.search_layer_single(prepared, current_ep, layer_idx);
+        }
+        current_ep
+    }
+
+    /// Merges multi-probe GPU results: dedups by node id and returns the top-`k`
+    /// by ascending distance, or `None` if no probe returned anything.
+    ///
+    /// Must sort by node ID first because `dedup_by_key` only removes
+    /// *consecutive* duplicates. Sorting by distance first would leave
+    /// non-adjacent duplicates (same node from different probes) interleaved
+    /// with other nodes at similar distances.
+    fn merge_gpu_probe_results(
+        mut all_results: Vec<(usize, f32)>,
+        k: usize,
+    ) -> Option<Vec<(usize, f32)>> {
+        if all_results.is_empty() {
+            return None;
+        }
+        all_results.sort_unstable_by_key(|r| r.0);
+        all_results.dedup_by_key(|r| r.0);
+        all_results.sort_unstable_by(|a, b| a.1.total_cmp(&b.1));
+        all_results.truncate(k);
+        Some(all_results)
     }
 
     /// Returns cached vector snapshot or refreshes it if the index version

--- a/crates/velesdb-core/src/index/hnsw/native/graph/neighbors.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/graph/neighbors.rs
@@ -3,6 +3,7 @@
 use super::super::distance::DistanceEngine;
 use super::super::layer::NodeId;
 use super::NativeHnsw;
+use crate::perf_optimizations::ContiguousVectors;
 use rustc_hash::FxHashSet;
 
 impl<D: DistanceEngine> NativeHnsw<D> {
@@ -40,39 +41,67 @@ impl<D: DistanceEngine> NativeHnsw<D> {
                 // Reason: neighbor-selection hot path; bounds check elided after assert.
                 let candidate_vec = unsafe { vectors.get_unchecked(candidate_id) };
 
-                let is_diverse = selected.iter().all(|&selected_id| {
-                    debug_assert!(
-                        selected_id < vectors.len(),
-                        "selected_id {selected_id} out of bounds (len {})",
-                        vectors.len()
-                    );
-                    // SAFETY: selected_id < vectors.len() — verified by debug_assert above.
-                    // - selected_id was previously inserted via the same code path as candidate_id.
-                    // Reason: diversity inner loop; bounds check elided after assert.
-                    let selected_vec = unsafe { vectors.get_unchecked(selected_id) };
-                    let dist_to_selected = self.distance.distance(candidate_vec, selected_vec);
-                    self.alpha * candidate_dist <= dist_to_selected
-                });
-
-                if is_diverse || selected.is_empty() {
+                // The first neighbor is always accepted; the empty-`selected`
+                // short-circuit matches the original vacuous `all()` (which
+                // returns true over an empty set), avoiding a needless scan.
+                if selected.is_empty()
+                    || self.is_candidate_diverse(vectors, candidate_vec, candidate_dist, &selected)
+                {
                     selected.push(candidate_id);
                     selected_set.insert(candidate_id);
                 }
             }
         });
 
-        if selected.len() < max_neighbors {
-            for &(candidate_id, _) in candidates {
-                if selected.len() >= max_neighbors {
-                    break;
-                }
-                if selected_set.insert(candidate_id) {
-                    selected.push(candidate_id);
-                }
-            }
-        }
+        Self::backfill_neighbors(candidates, &mut selected, &mut selected_set, max_neighbors);
 
         selected
+    }
+
+    /// VAMANA diversity test: true iff `candidate_vec` is at least `alpha *
+    /// candidate_dist` away from every already-selected neighbor.
+    #[inline]
+    fn is_candidate_diverse(
+        &self,
+        vectors: &ContiguousVectors,
+        candidate_vec: &[f32],
+        candidate_dist: f32,
+        selected: &[NodeId],
+    ) -> bool {
+        selected.iter().all(|&selected_id| {
+            debug_assert!(
+                selected_id < vectors.len(),
+                "selected_id {selected_id} out of bounds (len {})",
+                vectors.len()
+            );
+            // SAFETY: selected_id < vectors.len() — verified by debug_assert above.
+            // - selected_id was previously inserted via the same code path as candidate_id.
+            // Reason: diversity inner loop; bounds check elided after assert.
+            let selected_vec = unsafe { vectors.get_unchecked(selected_id) };
+            let dist_to_selected = self.distance.distance(candidate_vec, selected_vec);
+            self.alpha * candidate_dist <= dist_to_selected
+        })
+    }
+
+    /// Fills any remaining neighbor slots in candidate order, ignoring
+    /// diversity, until `max_neighbors` is reached (skipping duplicates).
+    fn backfill_neighbors(
+        candidates: &[(NodeId, f32)],
+        selected: &mut Vec<NodeId>,
+        selected_set: &mut FxHashSet<NodeId>,
+        max_neighbors: usize,
+    ) {
+        if selected.len() >= max_neighbors {
+            return;
+        }
+        for &(candidate_id, _) in candidates {
+            if selected.len() >= max_neighbors {
+                break;
+            }
+            if selected_set.insert(candidate_id) {
+                selected.push(candidate_id);
+            }
+        }
     }
 
     /// Batch-connects a new node to all its selected neighbors in a single lock scope.

--- a/crates/velesdb-core/src/velesql/json_path.rs
+++ b/crates/velesdb-core/src/velesql/json_path.rs
@@ -97,38 +97,10 @@ impl JsonPath {
 
         while let Some(c) = chars.next() {
             match c {
-                '.' => {
-                    // After an index like [0], a dot is valid and just separates
-                    if current.is_empty() && !last_was_index && !segments.is_empty() {
-                        return Err(JsonPathError::EmptySegment);
-                    }
-                    if !current.is_empty() {
-                        segments.push(PathSegment::Property(current.clone()));
-                        current.clear();
-                    }
-                    last_was_index = false;
-                }
+                '.' => Self::handle_dot(&mut segments, &mut current, &mut last_was_index)?,
                 '[' => {
-                    if !current.is_empty() {
-                        segments.push(PathSegment::Property(current.clone()));
-                        current.clear();
-                    }
-                    let mut idx_str = String::new();
-                    let mut closed = false;
-                    for ch in chars.by_ref() {
-                        if ch == ']' {
-                            closed = true;
-                            break;
-                        }
-                        idx_str.push(ch);
-                    }
-                    if !closed {
-                        return Err(JsonPathError::UnclosedBracket);
-                    }
-                    let index: usize = idx_str
-                        .trim()
-                        .parse()
-                        .map_err(|_| JsonPathError::InvalidArrayIndex(idx_str))?;
+                    Self::flush_property(&mut segments, &mut current);
+                    let index = Self::parse_bracket_index(&mut chars)?;
                     segments.push(PathSegment::Index(index));
                     last_was_index = true;
                 }
@@ -148,6 +120,50 @@ impl JsonPath {
         }
 
         Ok(JsonPath { segments })
+    }
+
+    /// Pushes the accumulated `current` buffer as a property segment and clears it.
+    fn flush_property(segments: &mut Vec<PathSegment>, current: &mut String) {
+        if !current.is_empty() {
+            segments.push(PathSegment::Property(std::mem::take(current)));
+        }
+    }
+
+    /// Handles a `.` separator: validates against empty segments, then flushes.
+    fn handle_dot(
+        segments: &mut Vec<PathSegment>,
+        current: &mut String,
+        last_was_index: &mut bool,
+    ) -> Result<(), JsonPathError> {
+        // After an index like [0], a dot is valid and just separates.
+        if current.is_empty() && !*last_was_index && !segments.is_empty() {
+            return Err(JsonPathError::EmptySegment);
+        }
+        Self::flush_property(segments, current);
+        *last_was_index = false;
+        Ok(())
+    }
+
+    /// Parses the contents of a `[...]` array index after the opening `[`.
+    fn parse_bracket_index(
+        chars: &mut std::iter::Peekable<std::str::Chars<'_>>,
+    ) -> Result<usize, JsonPathError> {
+        let mut idx_str = String::new();
+        let mut closed = false;
+        for ch in chars.by_ref() {
+            if ch == ']' {
+                closed = true;
+                break;
+            }
+            idx_str.push(ch);
+        }
+        if !closed {
+            return Err(JsonPathError::UnclosedBracket);
+        }
+        idx_str
+            .trim()
+            .parse()
+            .map_err(|_| JsonPathError::InvalidArrayIndex(idx_str))
     }
 
     /// Returns true if this is a simple (non-nested) path with a single property.

--- a/crates/velesdb-core/src/velesql/parser/match_parser.rs
+++ b/crates/velesdb-core/src/velesql/parser/match_parser.rs
@@ -134,27 +134,33 @@ impl Parser {
                 Rule::node_alias => {
                     node.alias = Some(spec_pair.as_str().to_string());
                 }
-                Rule::node_labels => {
-                    for label_pair in spec_pair.into_inner() {
-                        if label_pair.as_rule() == Rule::label_name {
-                            node.labels.push(label_pair.as_str().to_string());
-                        }
-                    }
-                }
+                Rule::node_labels => Self::collect_node_labels(spec_pair, node),
                 Rule::node_properties => {
                     node.properties = Self::parse_node_properties(spec_pair)?;
                 }
-                Rule::collection_annotation => {
-                    for coll_pair in spec_pair.into_inner() {
-                        if coll_pair.as_rule() == Rule::collection_ref {
-                            node.collection = Some(coll_pair.as_str().to_string());
-                        }
-                    }
-                }
+                Rule::collection_annotation => Self::apply_collection_annotation(spec_pair, node),
                 _ => {}
             }
         }
         Ok(())
+    }
+
+    /// Collects label names from a `node_labels` pest pair into the node.
+    fn collect_node_labels(spec_pair: pest::iterators::Pair<Rule>, node: &mut NodePattern) {
+        for label_pair in spec_pair.into_inner() {
+            if label_pair.as_rule() == Rule::label_name {
+                node.labels.push(label_pair.as_str().to_string());
+            }
+        }
+    }
+
+    /// Applies a `collection_annotation` pest pair to the node's collection field.
+    fn apply_collection_annotation(spec_pair: pest::iterators::Pair<Rule>, node: &mut NodePattern) {
+        for coll_pair in spec_pair.into_inner() {
+            if coll_pair.as_rule() == Rule::collection_ref {
+                node.collection = Some(coll_pair.as_str().to_string());
+            }
+        }
     }
 
     /// Parse node properties (EPIC-045 US-001).
@@ -342,26 +348,7 @@ impl Parser {
 
         for inner_pair in pair.into_inner() {
             if inner_pair.as_rule() == Rule::return_item_list {
-                for item_pair in inner_pair.into_inner() {
-                    if item_pair.as_rule() == Rule::return_item {
-                        let mut expression = String::new();
-                        let mut alias = None;
-
-                        for p in item_pair.into_inner() {
-                            match p.as_rule() {
-                                Rule::return_expr => {
-                                    expression = Self::parse_return_expr(p);
-                                }
-                                Rule::identifier => {
-                                    alias = Some(extract_identifier(&p));
-                                }
-                                _ => {}
-                            }
-                        }
-
-                        items.push(ReturnItem { expression, alias });
-                    }
-                }
+                Self::collect_return_items(inner_pair, &mut items);
             }
         }
 
@@ -370,6 +357,31 @@ impl Parser {
             order_by: None,
             limit: None,
         })
+    }
+
+    /// Collects `return_item` entries from a `return_item_list` pest pair.
+    fn collect_return_items(list_pair: pest::iterators::Pair<Rule>, items: &mut Vec<ReturnItem>) {
+        for item_pair in list_pair.into_inner() {
+            if item_pair.as_rule() == Rule::return_item {
+                items.push(Self::parse_return_item(item_pair));
+            }
+        }
+    }
+
+    /// Parses a single `return_item` pest pair into a `ReturnItem`.
+    fn parse_return_item(item_pair: pest::iterators::Pair<Rule>) -> ReturnItem {
+        let mut expression = String::new();
+        let mut alias = None;
+
+        for p in item_pair.into_inner() {
+            match p.as_rule() {
+                Rule::return_expr => expression = Self::parse_return_expr(p),
+                Rule::identifier => alias = Some(extract_identifier(&p)),
+                _ => {}
+            }
+        }
+
+        ReturnItem { expression, alias }
     }
 
     /// Parse RETURN expression (EPIC-045 US-001).

--- a/crates/velesdb-core/src/velesql/parser/match_patterns.rs
+++ b/crates/velesdb-core/src/velesql/parser/match_patterns.rs
@@ -246,29 +246,35 @@ fn parse_path_pattern(input: &str) -> Result<GraphPattern, ParseError> {
     let mut pos = 0;
     let input = input.trim();
     while pos < input.len() {
-        if let Some(s) = input[pos..].find('(') {
-            let abs = pos + s;
-            let end = find_matching_paren(input, abs)?;
-            nodes.push(parse_node_pattern(&input[abs..=end])?);
-            pos = end + 1;
-            if pos < input.len() {
-                let rem = &input[pos..];
-                if rem.starts_with('-') || rem.starts_with('<') {
-                    if let Some(np) = rem.find('(') {
-                        rels.push(parse_relationship_pattern(&rem[..np])?);
-                        pos += np;
-                    }
-                }
-            }
-        } else {
+        let Some(s) = input[pos..].find('(') else {
             break;
-        }
+        };
+        let abs = pos + s;
+        let end = find_matching_paren(input, abs)?;
+        nodes.push(parse_node_pattern(&input[abs..=end])?);
+        pos = end + 1;
+        pos += parse_trailing_relationship(&input[pos.min(input.len())..], &mut rels)?;
     }
     Ok(GraphPattern {
         name: None,
         nodes,
         relationships: rels,
     })
+}
+
+/// Parses a relationship pattern that may follow a node, returning how many bytes to advance.
+fn parse_trailing_relationship(
+    rem: &str,
+    rels: &mut Vec<RelationshipPattern>,
+) -> Result<usize, ParseError> {
+    if !(rem.starts_with('-') || rem.starts_with('<')) {
+        return Ok(0);
+    }
+    let Some(np) = rem.find('(') else {
+        return Ok(0);
+    };
+    rels.push(parse_relationship_pattern(&rem[..np])?);
+    Ok(np)
 }
 
 fn find_matching_paren(input: &str, start: usize) -> Result<usize, ParseError> {

--- a/crates/velesdb-core/src/velesql/parser/select/clause_group_order.rs
+++ b/crates/velesdb-core/src/velesql/parser/select/clause_group_order.rs
@@ -44,26 +44,36 @@ impl Parser {
         let mut operators = Vec::new();
         for inner_pair in pair.into_inner() {
             if inner_pair.as_rule() == Rule::having_condition {
-                for term_pair in inner_pair.into_inner() {
-                    match term_pair.as_rule() {
-                        Rule::having_term => conditions.push(Self::parse_having_term(term_pair)?),
-                        Rule::having_logical_op => {
-                            let text = term_pair.as_str().to_uppercase();
-                            if text == "AND" {
-                                operators.push(crate::velesql::LogicalOp::And);
-                            } else if text == "OR" {
-                                operators.push(crate::velesql::LogicalOp::Or);
-                            }
-                        }
-                        _ => {}
-                    }
-                }
+                Self::collect_having_terms(inner_pair, &mut conditions, &mut operators)?;
             }
         }
         Ok(HavingClause {
             conditions,
             operators,
         })
+    }
+
+    /// Collects HAVING terms and logical operators from a `having_condition` node.
+    fn collect_having_terms(
+        condition_pair: pest::iterators::Pair<Rule>,
+        conditions: &mut Vec<HavingCondition>,
+        operators: &mut Vec<crate::velesql::LogicalOp>,
+    ) -> Result<(), ParseError> {
+        for term_pair in condition_pair.into_inner() {
+            match term_pair.as_rule() {
+                Rule::having_term => conditions.push(Self::parse_having_term(term_pair)?),
+                Rule::having_logical_op => {
+                    let text = term_pair.as_str().to_uppercase();
+                    if text == "AND" {
+                        operators.push(crate::velesql::LogicalOp::And);
+                    } else if text == "OR" {
+                        operators.push(crate::velesql::LogicalOp::Or);
+                    }
+                }
+                _ => {}
+            }
+        }
+        Ok(())
     }
 
     fn parse_having_term(pair: pest::iterators::Pair<Rule>) -> Result<HavingCondition, ParseError> {

--- a/crates/velesdb-migrate/src/connectors/common.rs
+++ b/crates/velesdb-migrate/src/connectors/common.rs
@@ -115,70 +115,83 @@ pub fn validate_url(input: &str) -> Result<()> {
 /// otherwise.
 fn reject_unsafe_host(host: &url::Host<&str>, input: &str) -> Result<()> {
     match host {
-        url::Host::Ipv4(ip) => {
-            if ip.is_loopback() || ip.is_private() || ip.is_link_local() {
-                return Err(Error::Config(format!(
-                    "URL '{input}' targets a non-public IPv4 range ({ip}): \
-                     loopback, RFC 1918 private, or link-local. \
-                     Set VELESDB_MIGRATE_ALLOW_PRIVATE_NETWORKS=1 for \
-                     local development."
-                )));
-            }
-            // `is_link_local()` already covers 169.254.0.0/16; the
-            // additional exact-match check produces a clearer diagnostic
-            // for the well-known cloud metadata endpoint.
-            if ip.octets() == [169, 254, 169, 254] {
-                return Err(Error::Config(format!(
-                    "URL '{input}' targets the cloud metadata endpoint \
-                     (169.254.169.254)"
-                )));
-            }
-        }
-        url::Host::Ipv6(ip) => {
-            if ip.is_loopback() || ip.is_unspecified() {
-                return Err(Error::Config(format!(
-                    "URL '{input}' targets an IPv6 loopback or unspecified \
-                     address ({ip})"
-                )));
-            }
-            // Detect fe80::/10 (link-local) and fc00::/7 (unique local) via
-            // their IPv6 prefix masks: `Ipv6Addr::is_unique_local` and
-            // `is_unicast_link_local` are still nightly-only behind
-            // `feature(ip)` at our MSRV (1.89), so we match the prefixes by
-            // hand to keep the connector buildable on stable.
-            let first = ip.segments()[0];
-            if (first & 0xffc0) == 0xfe80 {
-                return Err(Error::Config(format!(
-                    "URL '{input}' targets an IPv6 link-local address ({ip})"
-                )));
-            }
-            if (first & 0xfe00) == 0xfc00 {
-                return Err(Error::Config(format!(
-                    "URL '{input}' targets an IPv6 unique-local address ({ip})"
-                )));
-            }
-        }
-        url::Host::Domain(name) => {
-            let lower = name.to_ascii_lowercase();
-            // Reject reserved suffixes that name on-host or internal-only
-            // services. These cover both standards-reserved labels
-            // (RFC 6761 `.localhost`, RFC 8375 `.home.arpa`) and common
-            // private-DNS conventions (`.internal`, `.local`).
-            const RESERVED_SUFFIXES: &[&str] =
-                &["localhost", ".localhost", ".local", ".internal", ".arpa"];
-            let is_reserved = lower == "localhost"
-                || RESERVED_SUFFIXES
-                    .iter()
-                    .any(|s| lower == s.trim_start_matches('.') || lower.ends_with(s));
-            if is_reserved {
-                return Err(Error::Config(format!(
-                    "URL '{input}' targets reserved hostname '{lower}' \
-                     (localhost / .local / .internal / .arpa). \
-                     Set VELESDB_MIGRATE_ALLOW_PRIVATE_NETWORKS=1 for \
-                     local development."
-                )));
-            }
-        }
+        url::Host::Ipv4(ip) => reject_unsafe_ipv4(*ip, input),
+        url::Host::Ipv6(ip) => reject_unsafe_ipv6(*ip, input),
+        url::Host::Domain(name) => reject_reserved_domain(name, input),
+    }
+}
+
+/// Rejects IPv4 hosts in loopback, RFC 1918 private, link-local ranges, or the
+/// cloud metadata endpoint. Helper for [`reject_unsafe_host`].
+fn reject_unsafe_ipv4(ip: std::net::Ipv4Addr, input: &str) -> Result<()> {
+    if ip.is_loopback() || ip.is_private() || ip.is_link_local() {
+        return Err(Error::Config(format!(
+            "URL '{input}' targets a non-public IPv4 range ({ip}): \
+             loopback, RFC 1918 private, or link-local. \
+             Set VELESDB_MIGRATE_ALLOW_PRIVATE_NETWORKS=1 for \
+             local development."
+        )));
+    }
+    // `is_link_local()` already covers 169.254.0.0/16; the
+    // additional exact-match check produces a clearer diagnostic
+    // for the well-known cloud metadata endpoint.
+    if ip.octets() == [169, 254, 169, 254] {
+        return Err(Error::Config(format!(
+            "URL '{input}' targets the cloud metadata endpoint \
+             (169.254.169.254)"
+        )));
+    }
+    Ok(())
+}
+
+/// Rejects IPv6 loopback/unspecified, link-local (fe80::/10), and
+/// unique-local (fc00::/7) hosts. Helper for [`reject_unsafe_host`].
+fn reject_unsafe_ipv6(ip: std::net::Ipv6Addr, input: &str) -> Result<()> {
+    if ip.is_loopback() || ip.is_unspecified() {
+        return Err(Error::Config(format!(
+            "URL '{input}' targets an IPv6 loopback or unspecified \
+             address ({ip})"
+        )));
+    }
+    // Detect fe80::/10 (link-local) and fc00::/7 (unique local) via
+    // their IPv6 prefix masks: `Ipv6Addr::is_unique_local` and
+    // `is_unicast_link_local` are still nightly-only behind
+    // `feature(ip)` at our MSRV (1.89), so we match the prefixes by
+    // hand to keep the connector buildable on stable.
+    let first = ip.segments()[0];
+    if (first & 0xffc0) == 0xfe80 {
+        return Err(Error::Config(format!(
+            "URL '{input}' targets an IPv6 link-local address ({ip})"
+        )));
+    }
+    if (first & 0xfe00) == 0xfc00 {
+        return Err(Error::Config(format!(
+            "URL '{input}' targets an IPv6 unique-local address ({ip})"
+        )));
+    }
+    Ok(())
+}
+
+/// Rejects reserved hostnames that name on-host or internal-only services.
+/// Helper for [`reject_unsafe_host`].
+fn reject_reserved_domain(name: &str, input: &str) -> Result<()> {
+    let lower = name.to_ascii_lowercase();
+    // Reject reserved suffixes that name on-host or internal-only
+    // services. These cover both standards-reserved labels
+    // (RFC 6761 `.localhost`, RFC 8375 `.home.arpa`) and common
+    // private-DNS conventions (`.internal`, `.local`).
+    const RESERVED_SUFFIXES: &[&str] = &["localhost", ".localhost", ".local", ".internal", ".arpa"];
+    let is_reserved = lower == "localhost"
+        || RESERVED_SUFFIXES
+            .iter()
+            .any(|s| lower == s.trim_start_matches('.') || lower.ends_with(s));
+    if is_reserved {
+        return Err(Error::Config(format!(
+            "URL '{input}' targets reserved hostname '{lower}' \
+             (localhost / .local / .internal / .arpa). \
+             Set VELESDB_MIGRATE_ALLOW_PRIVATE_NETWORKS=1 for \
+             local development."
+        )));
     }
     Ok(())
 }

--- a/crates/velesdb-migrate/src/connectors/csv_file.rs
+++ b/crates/velesdb-migrate/src/connectors/csv_file.rs
@@ -172,6 +172,79 @@ impl CsvFileConnector {
         }
         payload
     }
+
+    /// Reads the header row, or synthesises `col_N` headers from the first data
+    /// row when the file is headerless. The first data row is retained as a
+    /// record in the headerless case.
+    fn read_header_or_first_row(&mut self, lines: &mut std::io::Lines<BufReader<File>>) {
+        if self.config.has_header {
+            if let Some(Ok(header_line)) = lines.next() {
+                self.headers = Self::parse_csv_line(&header_line, self.config.delimiter);
+            }
+        } else if let Some(Ok(first_line)) = lines.next() {
+            let fields = Self::parse_csv_line(&first_line, self.config.delimiter);
+            self.headers = (0..fields.len()).map(|i| format!("col_{}", i)).collect();
+            self.records.push(fields);
+        }
+    }
+
+    /// Parses every remaining line into a record.
+    fn read_remaining_records(&mut self, lines: std::io::Lines<BufReader<File>>) -> Result<()> {
+        for line in lines {
+            let line =
+                line.map_err(|e| Error::Extraction(format!("Failed to read line: {}", e)))?;
+            self.records
+                .push(Self::parse_csv_line(&line, self.config.delimiter));
+        }
+        Ok(())
+    }
+
+    /// Builds the field list from the headers, excluding the id, vector, and
+    /// (when spread) dimension columns.
+    fn payload_field_infos(&self) -> Vec<FieldInfo> {
+        let mut fields = Vec::new();
+        for header in &self.headers {
+            if header == &self.config.id_column || header == &self.config.vector_column {
+                continue;
+            }
+            if self.config.vector_spread && header.starts_with(&self.config.dim_prefix) {
+                continue;
+            }
+            fields.push(FieldInfo {
+                name: header.clone(),
+                field_type: "string".to_string(),
+                indexed: false,
+            });
+        }
+        fields
+    }
+
+    /// Derives the source schema from the first record, when one exists.
+    fn build_schema(&mut self) -> Result<()> {
+        let Some(first) = self.records.first() else {
+            return Ok(());
+        };
+        let vector = self.parse_vector(first)?;
+        let fields = self.payload_field_infos();
+        self.schema = Some(SourceSchema {
+            source_type: "csv_file".to_string(),
+            collection: self
+                .config
+                .path
+                .file_stem()
+                .and_then(|s| s.to_str())
+                .unwrap_or("csv_import")
+                .to_string(),
+            dimension: vector.len(),
+            total_count: Some(self.records.len() as u64),
+            fields,
+            vector_column: Some(self.config.vector_column.clone()),
+            id_column: Some(self.config.id_column.clone()),
+            // File-backed connectors cannot introspect the metric.
+            metric: None,
+        });
+        Ok(())
+    }
 }
 
 #[async_trait]
@@ -192,57 +265,9 @@ impl SourceConnector for CsvFileConnector {
         let reader = BufReader::new(file);
         let mut lines = reader.lines();
 
-        if self.config.has_header {
-            if let Some(Ok(header_line)) = lines.next() {
-                self.headers = Self::parse_csv_line(&header_line, self.config.delimiter);
-            }
-        } else if let Some(Ok(first_line)) = lines.next() {
-            let fields = Self::parse_csv_line(&first_line, self.config.delimiter);
-            self.headers = (0..fields.len()).map(|i| format!("col_{}", i)).collect();
-            self.records.push(fields);
-        }
-
-        for line in lines {
-            let line =
-                line.map_err(|e| Error::Extraction(format!("Failed to read line: {}", e)))?;
-            self.records
-                .push(Self::parse_csv_line(&line, self.config.delimiter));
-        }
-
-        if let Some(first) = self.records.first() {
-            let vector = self.parse_vector(first)?;
-            let mut fields = Vec::new();
-            for header in &self.headers {
-                if header == &self.config.id_column || header == &self.config.vector_column {
-                    continue;
-                }
-                if self.config.vector_spread && header.starts_with(&self.config.dim_prefix) {
-                    continue;
-                }
-                fields.push(FieldInfo {
-                    name: header.clone(),
-                    field_type: "string".to_string(),
-                    indexed: false,
-                });
-            }
-            self.schema = Some(SourceSchema {
-                source_type: "csv_file".to_string(),
-                collection: self
-                    .config
-                    .path
-                    .file_stem()
-                    .and_then(|s| s.to_str())
-                    .unwrap_or("csv_import")
-                    .to_string(),
-                dimension: vector.len(),
-                total_count: Some(self.records.len() as u64),
-                fields,
-                vector_column: Some(self.config.vector_column.clone()),
-                id_column: Some(self.config.id_column.clone()),
-                // File-backed connectors cannot introspect the metric.
-                metric: None,
-            });
-        }
+        self.read_header_or_first_row(&mut lines);
+        self.read_remaining_records(lines)?;
+        self.build_schema()?;
         Ok(())
     }
 

--- a/crates/velesdb-migrate/src/connectors/redis.rs
+++ b/crates/velesdb-migrate/src/connectors/redis.rs
@@ -519,25 +519,39 @@ fn parse_ft_info_response(
 fn extract_vector_distance_metric(items: &[redis::Value], vector_field: &str) -> Option<String> {
     // Find the "attributes" key and scan each attribute array for the
     // vector field definition.
+    let attrs_array = find_attributes_array(items)?;
+    attrs_array
+        .iter()
+        .find_map(|attr| distance_metric_for_field(attr, vector_field))
+}
+
+/// Returns the value array following the `"attributes"` key in a flat
+/// `FT.INFO` response, if present.
+fn find_attributes_array(items: &[redis::Value]) -> Option<&[redis::Value]> {
     let mut i = 0;
     while i + 1 < items.len() {
         if extract_bulk_string(&items[i]).as_deref() == Some("attributes") {
             if let redis::Value::Array(attrs_array) = &items[i + 1] {
-                for attr in attrs_array {
-                    if let redis::Value::Array(parts) = attr {
-                        let identifier = find_string_after(parts, "identifier");
-                        if identifier.as_deref() == Some(vector_field) {
-                            return find_string_after(parts, "distance_metric")
-                                .or_else(|| find_string_after(parts, "DISTANCE_METRIC"));
-                        }
-                    }
-                }
+                return Some(attrs_array);
             }
-            break;
+            return None;
         }
         i += 2;
     }
     None
+}
+
+/// Extracts the distance metric from a single attribute array, but only if it
+/// describes `vector_field`.
+fn distance_metric_for_field(attr: &redis::Value, vector_field: &str) -> Option<String> {
+    let redis::Value::Array(parts) = attr else {
+        return None;
+    };
+    if find_string_after(parts, "identifier").as_deref() != Some(vector_field) {
+        return None;
+    }
+    find_string_after(parts, "distance_metric")
+        .or_else(|| find_string_after(parts, "DISTANCE_METRIC"))
 }
 
 /// Finds a numeric value by key in a flat key-value RESP list.

--- a/crates/velesdb-migrate/src/pipeline.rs
+++ b/crates/velesdb-migrate/src/pipeline.rs
@@ -179,16 +179,10 @@ impl Pipeline {
     /// # Errors
     ///
     /// Returns an error if the migration fails.
-    #[allow(clippy::cognitive_complexity)] // Reason: Pipeline orchestration requires sequential steps, refactoring would fragment the migration flow
     pub async fn run(&mut self) -> Result<MigrationStats> {
         let start = std::time::Instant::now();
         let mut stats = MigrationStats::default();
-        let checkpoint_ctx =
-            if !self.config.options.dry_run && self.config.options.checkpoint_enabled {
-                Some(CheckpointContext::new(&self.config)?)
-            } else {
-                None
-            };
+        let checkpoint_ctx = self.init_checkpoint_context()?;
         let mut offset: Option<serde_json::Value> = None;
         let mut resumed_duration_secs = 0.0;
 
@@ -201,35 +195,11 @@ impl Pipeline {
             "Source schema: {} dimension, {:?} total vectors",
             schema.dimension, schema.total_count
         );
-
-        if schema.dimension > 0 && schema.dimension != self.config.destination.dimension {
-            return Err(Error::SchemaMismatch(format!(
-                "Source dimension {} != destination dimension {}",
-                schema.dimension, self.config.destination.dimension
-            )));
-        }
-
-        check_metric_fidelity(
-            schema.metric.as_deref(),
-            self.config.destination.metric,
-            self.config.options.allow_metric_mismatch,
-        )?;
+        self.validate_source_schema(&schema)?;
 
         if let Some(ctx) = &checkpoint_ctx {
-            if let Some(state) = ctx.load().await? {
-                offset = state.next_offset;
-                stats.extracted = state.extracted;
-                stats.loaded = state.loaded;
-                stats.failed = state.failed;
-                stats.batches = state.batches;
-                resumed_duration_secs = state.duration_secs;
-                info!(
-                    "Resuming migration from checkpoint at '{}' (loaded={}, failed={})",
-                    ctx.path.display(),
-                    stats.loaded,
-                    stats.failed
-                );
-            }
+            apply_checkpoint_state(ctx, &mut offset, &mut stats, &mut resumed_duration_secs)
+                .await?;
         }
 
         let total = schema.total_count.unwrap_or(0);
@@ -240,104 +210,17 @@ impl Pipeline {
 
         let db = open_destination_db(&self.config.destination, self.config.options.dry_run).await?;
 
-        let batch_size = self.config.options.batch_size;
-        let retry_config = crate::retry::RetryConfig::for_transient_errors();
-
-        loop {
-            let connector = &mut *self.connector;
-            let batch = crate::retry::with_retry(&retry_config, "extract_batch", || {
-                connector.extract_batch(offset.clone(), batch_size)
-            })
-            .await?;
-
-            if batch.points.is_empty() {
-                break;
-            }
-
-            stats.extracted += batch.points.len() as u64;
-            stats.batches += 1;
-
-            let transformed = self.transformer.transform_batch(batch.points);
-
-            if let Some(ref db) = db {
-                #[allow(deprecated)] // TODO(MIGRATE-01): migrate to get_vector_collection()
-                let collection = db
-                    .get_vector_collection(&self.config.destination.collection)
-                    .ok_or_else(|| {
-                        Error::DestinationConnection("Collection not found".to_string())
-                    })?;
-
-                let points = crate::pipeline_points::prepare_points(
-                    transformed,
-                    self.config.options.workers,
-                    self.config.options.continue_on_error,
-                    &mut stats,
-                )?;
-
-                if !points.is_empty() {
-                    if self.config.options.continue_on_error {
-                        match collection.upsert_bulk(&points) {
-                            Ok(inserted) => {
-                                stats.loaded += inserted as u64;
-                            }
-                            Err(error) => {
-                                warn!(
-                                    "Bulk load failed for batch {}; falling back to point-by-point: {}",
-                                    stats.batches,
-                                    error
-                                );
-                                for point in points {
-                                    match collection.upsert(std::iter::once(point)) {
-                                        Ok(()) => stats.loaded += 1,
-                                        Err(load_error) => {
-                                            stats.failed += 1;
-                                            warn!(
-                                                "Failed to load point in fallback path: {}",
-                                                load_error
-                                            );
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    } else {
-                        let inserted = collection
-                            .upsert_bulk(&points)
-                            .map_err(|e| Error::Loading(e.to_string()))?;
-                        stats.loaded += inserted as u64;
-                    }
-
-                    // Use flush_full to persist HNSW graph + vectors.idx
-                    // so checkpoint resume finds all previously loaded points.
-                    collection
-                        .flush_full()
-                        .map_err(|e| Error::Loading(e.to_string()))?;
-
-                    // Save checkpoint immediately after successful flush, BEFORE
-                    // the next iteration's offset update.  This ensures that if
-                    // batch N succeeds but batch N+1 fails, the checkpoint
-                    // reflects batch N's completion.
-                    if let Some(ctx) = &checkpoint_ctx {
-                        ctx.save(
-                            batch.next_offset.clone(),
-                            &stats,
-                            resumed_duration_secs + start.elapsed().as_secs_f64(),
-                        )
-                        .await?;
-                    }
-                }
-            } else {
-                // dry_run: nothing loaded, stats.loaded stays 0
-            }
-
-            progress.set_position(stats.loaded.min(total));
-
-            if !batch.has_more {
-                break;
-            }
-
-            offset = batch.next_offset.clone();
-        }
+        self.process_batches(
+            db.as_ref(),
+            checkpoint_ctx.as_ref(),
+            &progress,
+            total,
+            &mut offset,
+            &mut stats,
+            start,
+            resumed_duration_secs,
+        )
+        .await?;
 
         progress.finish_with_message("Migration complete");
 
@@ -364,6 +247,101 @@ impl Pipeline {
         Ok(stats)
     }
 
+    /// Builds the checkpoint context unless the run is a dry run or checkpoints
+    /// are disabled.
+    fn init_checkpoint_context(&self) -> Result<Option<CheckpointContext>> {
+        if !self.config.options.dry_run && self.config.options.checkpoint_enabled {
+            Ok(Some(CheckpointContext::new(&self.config)?))
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// Validates the source schema against the destination dimension and metric.
+    fn validate_source_schema(&self, schema: &crate::connectors::SourceSchema) -> Result<()> {
+        if schema.dimension > 0 && schema.dimension != self.config.destination.dimension {
+            return Err(Error::SchemaMismatch(format!(
+                "Source dimension {} != destination dimension {}",
+                schema.dimension, self.config.destination.dimension
+            )));
+        }
+
+        check_metric_fidelity(
+            schema.metric.as_deref(),
+            self.config.destination.metric,
+            self.config.options.allow_metric_mismatch,
+        )
+    }
+
+    /// Drives the extract/transform/load loop until the source is exhausted.
+    #[allow(clippy::too_many_arguments)] // Reason: orchestration loop threads run-scoped state through one helper
+    async fn process_batches(
+        &mut self,
+        db: Option<&velesdb_core::Database>,
+        checkpoint_ctx: Option<&CheckpointContext>,
+        progress: &ProgressBar,
+        total: u64,
+        offset: &mut Option<serde_json::Value>,
+        stats: &mut MigrationStats,
+        start: std::time::Instant,
+        resumed_duration_secs: f64,
+    ) -> Result<()> {
+        let batch_size = self.config.options.batch_size;
+        let retry_config = crate::retry::RetryConfig::for_transient_errors();
+
+        loop {
+            let connector = &mut *self.connector;
+            let current_offset = offset.clone();
+            let batch = crate::retry::with_retry(&retry_config, "extract_batch", || {
+                connector.extract_batch(current_offset.clone(), batch_size)
+            })
+            .await?;
+
+            if batch.points.is_empty() {
+                break;
+            }
+
+            stats.extracted += batch.points.len() as u64;
+            stats.batches += 1;
+
+            let transformed = self.transformer.transform_batch(batch.points);
+
+            if let Some(db) = db {
+                let loaded = crate::pipeline_points::load_prepared_batch(
+                    db,
+                    &self.config.destination.collection,
+                    transformed,
+                    self.config.options.workers,
+                    self.config.options.continue_on_error,
+                    stats,
+                )?;
+
+                // Save checkpoint immediately after a successful flush, BEFORE
+                // the next iteration's offset update.  This ensures that if
+                // batch N succeeds but batch N+1 fails, the checkpoint
+                // reflects batch N's completion.
+                if let Some(ctx) = checkpoint_ctx.filter(|_| loaded) {
+                    ctx.save(
+                        batch.next_offset.clone(),
+                        stats,
+                        resumed_duration_secs + start.elapsed().as_secs_f64(),
+                    )
+                    .await?;
+                }
+            }
+
+            progress.set_position(stats.loaded.min(total));
+
+            if !batch.has_more {
+                break;
+            }
+
+            *offset = batch.next_offset.clone();
+        }
+
+        Ok(())
+    }
+
     async fn run_graph_phase(
         &self,
         db: &velesdb_core::Database,
@@ -385,6 +363,31 @@ impl Pipeline {
         stats.relations_processed = graph_stats.relations_processed;
         Ok(())
     }
+}
+
+/// Restores offset, stats, and resumed duration from a previously saved
+/// checkpoint, if one exists.
+async fn apply_checkpoint_state(
+    ctx: &CheckpointContext,
+    offset: &mut Option<serde_json::Value>,
+    stats: &mut MigrationStats,
+    resumed_duration_secs: &mut f64,
+) -> Result<()> {
+    if let Some(state) = ctx.load().await? {
+        *offset = state.next_offset;
+        stats.extracted = state.extracted;
+        stats.loaded = state.loaded;
+        stats.failed = state.failed;
+        stats.batches = state.batches;
+        *resumed_duration_secs = state.duration_secs;
+        info!(
+            "Resuming migration from checkpoint at '{}' (loaded={}, failed={})",
+            ctx.path.display(),
+            stats.loaded,
+            stats.failed
+        );
+    }
+    Ok(())
 }
 
 fn map_core_metric(m: crate::config::DistanceMetric) -> velesdb_core::DistanceMetric {

--- a/crates/velesdb-migrate/src/pipeline_points.rs
+++ b/crates/velesdb-migrate/src/pipeline_points.rs
@@ -129,3 +129,86 @@ fn build_point(point: ExtractedPoint) -> Result<velesdb_core::Point> {
         sparse_vectors,
     ))
 }
+
+/// Prepares and loads a single transformed batch into the destination
+/// collection, flushing on success.
+///
+/// Returns `Ok(true)` when points were loaded (so the caller may checkpoint),
+/// or `Ok(false)` when the batch produced no insertable points.
+pub(crate) fn load_prepared_batch(
+    db: &velesdb_core::Database,
+    collection_name: &str,
+    transformed: Vec<ExtractedPoint>,
+    workers: usize,
+    continue_on_error: bool,
+    stats: &mut MigrationStats,
+) -> Result<bool> {
+    #[allow(deprecated)] // TODO(MIGRATE-01): migrate to get_vector_collection()
+    let collection = db
+        .get_vector_collection(collection_name)
+        .ok_or_else(|| Error::DestinationConnection("Collection not found".to_string()))?;
+
+    let points = prepare_points(transformed, workers, continue_on_error, stats)?;
+    if points.is_empty() {
+        return Ok(false);
+    }
+
+    upsert_points(&collection, points, continue_on_error, stats)?;
+
+    // Use flush_full to persist HNSW graph + vectors.idx
+    // so checkpoint resume finds all previously loaded points.
+    collection
+        .flush_full()
+        .map_err(|e| Error::Loading(e.to_string()))?;
+
+    Ok(true)
+}
+
+/// Loads the prepared points, dispatching to the fail-fast or
+/// continue-on-error strategy.
+fn upsert_points(
+    collection: &velesdb_core::VectorCollection,
+    points: Vec<velesdb_core::Point>,
+    continue_on_error: bool,
+    stats: &mut MigrationStats,
+) -> Result<()> {
+    if continue_on_error {
+        upsert_points_lenient(collection, points, stats);
+        Ok(())
+    } else {
+        let inserted = collection
+            .upsert_bulk(&points)
+            .map_err(|e| Error::Loading(e.to_string()))?;
+        stats.loaded += inserted as u64;
+        Ok(())
+    }
+}
+
+/// Loads points in continue-on-error mode: tries a bulk upsert first, and on
+/// failure retries point-by-point, recording per-point successes and failures.
+fn upsert_points_lenient(
+    collection: &velesdb_core::VectorCollection,
+    points: Vec<velesdb_core::Point>,
+    stats: &mut MigrationStats,
+) {
+    match collection.upsert_bulk(&points) {
+        Ok(inserted) => {
+            stats.loaded += inserted as u64;
+        }
+        Err(error) => {
+            warn!(
+                "Bulk load failed for batch {}; falling back to point-by-point: {}",
+                stats.batches, error
+            );
+            for point in points {
+                match collection.upsert(std::iter::once(point)) {
+                    Ok(()) => stats.loaded += 1,
+                    Err(load_error) => {
+                        stats.failed += 1;
+                        warn!("Failed to load point in fallback path: {}", load_error);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/velesdb-mobile/src/graph.rs
+++ b/crates/velesdb-mobile/src/graph.rs
@@ -214,13 +214,7 @@ impl MobileGraphStore {
                 results.push(TraversalResult { node_id, depth });
             }
 
-            if depth < max_depth {
-                for edge in self.get_outgoing(node_id) {
-                    if visited.insert(edge.target) {
-                        queue.push_back((edge.target, depth + 1));
-                    }
-                }
-            }
+            self.enqueue_neighbors(node_id, depth, max_depth, &mut visited, &mut queue);
         }
 
         results
@@ -413,6 +407,27 @@ impl MobileGraphStore {
         idx.get(&node_id)
             .map(|ids| ids.iter().filter_map(|id| edges.get(id).cloned()).collect())
             .unwrap_or_default()
+    }
+
+    /// Enqueues unvisited outgoing neighbors of `node_id` for further traversal.
+    ///
+    /// No-op when `depth` has already reached `max_depth`.
+    fn enqueue_neighbors(
+        &self,
+        node_id: u64,
+        depth: u32,
+        max_depth: u32,
+        visited: &mut std::collections::HashSet<u64>,
+        queue: &mut std::collections::VecDeque<(u64, u32)>,
+    ) {
+        if depth >= max_depth {
+            return;
+        }
+        for edge in self.get_outgoing(node_id) {
+            if visited.insert(edge.target) {
+                queue.push_back((edge.target, depth + 1));
+            }
+        }
     }
 }
 

--- a/crates/velesdb-python/python/velesdb/__init__.py
+++ b/crates/velesdb-python/python/velesdb/__init__.py
@@ -609,19 +609,19 @@ class VelesQL:
     def _normalize_legacy_query(query: str) -> str:
         normalized = query
         normalized = re.sub(
-            r"USING\s+FUSION\s+([a-zA-Z_][a-zA-Z0-9_]*)\b",
+            r"USING\s+FUSION\s+([a-z_][a-z0-9_]*)\b",
             r"USING FUSION (strategy='\1')",
             normalized,
             flags=re.IGNORECASE,
         )
         normalized = re.sub(
-            r"\bFROM\s+([A-Za-z_][A-Za-z0-9_]*)\s+([A-Za-z_][A-Za-z0-9_]*)\b(?=\s+JOIN|\s+WHERE|\s+GROUP|\s+ORDER|\s+LIMIT|\s+OFFSET|$)",
+            r"\bFROM\s+([a-z_][a-z0-9_]*)\s+([a-z_][a-z0-9_]*)\b(?=\s+JOIN|\s+WHERE|\s+GROUP|\s+ORDER|\s+LIMIT|\s+OFFSET|$)",
             r"FROM \1 AS \2",
             normalized,
             flags=re.IGNORECASE,
         )
         normalized = re.sub(
-            r"\bJOIN\s+([A-Za-z_][A-Za-z0-9_]*)\s+([A-Za-z_][A-Za-z0-9_]*)\b(?=\s+ON|\s+WHERE|\s+GROUP|\s+ORDER|\s+LIMIT|\s+OFFSET|$)",
+            r"\bJOIN\s+([a-z_][a-z0-9_]*)\s+([a-z_][a-z0-9_]*)\b(?=\s+ON|\s+WHERE|\s+GROUP|\s+ORDER|\s+LIMIT|\s+OFFSET|$)",
             r"JOIN \1 AS \2",
             normalized,
             flags=re.IGNORECASE,

--- a/crates/velesdb-python/python/velesdb/dataframe_converter.py
+++ b/crates/velesdb-python/python/velesdb/dataframe_converter.py
@@ -54,6 +54,27 @@ def _get_backend(backend: str) -> Any:
         )
 
 
+def _resolve_safe_key(key: str, reserved: frozenset[str], payload: dict) -> str:
+    """Return a column name for a payload key, avoiding reserved-column clashes.
+
+    Keys matching a reserved structural column are prefixed with ``payload_``
+    (and further ``_`` prefixes) until the name no longer collides.
+    """
+    if key not in reserved:
+        return key
+    safe_key = f"payload_{key}"
+    while safe_key in payload:
+        safe_key = f"_{safe_key}"
+    return safe_key
+
+
+def _flatten_payload(payload: dict, reserved: frozenset[str]) -> dict[str, Any]:
+    """Flatten a dict payload into row columns, renaming reserved-key clashes."""
+    return {
+        _resolve_safe_key(k, reserved, payload): v for k, v in payload.items()
+    }
+
+
 def to_dataframe(results: list[dict], backend: str = "pandas") -> Any:
     """Convert search results to a DataFrame.
 
@@ -73,26 +94,20 @@ def to_dataframe(results: list[dict], backend: str = "pandas") -> Any:
     """
     lib = _get_backend(backend)
 
-    _SEARCH_RESERVED = frozenset({"id", "score"})
-
     if not results:
         if backend == "pandas":
             return lib.DataFrame(columns=["id", "score"])
         return lib.DataFrame(schema={"id": lib.Int64, "score": lib.Float64})
 
+    reserved = frozenset({"id", "score"})
     rows = []
     for r in results:
-        row: dict[str, Any] = {}
         payload = r.get("payload")
-        if isinstance(payload, dict):
-            for k, v in payload.items():
-                if k in _SEARCH_RESERVED:
-                    safe_key = f"payload_{k}"
-                    while safe_key in payload:
-                        safe_key = f"_{safe_key}"
-                else:
-                    safe_key = k
-                row[safe_key] = v
+        row: dict[str, Any] = (
+            _flatten_payload(payload, reserved)
+            if isinstance(payload, dict)
+            else {}
+        )
         row["id"] = r.get("id")
         row["score"] = r.get("score")
         rows.append(row)
@@ -156,32 +171,28 @@ def to_scroll_dataframe(batch: list[dict], backend: str = "pandas") -> Any:
     # - If no point has a dict payload: store raw payload under a "payload" column.
     # This guarantees a consistent schema regardless of per-point payload type.
     has_dict_payload = any(isinstance(p.get("payload"), dict) for p in batch)
+    reserved = frozenset({"id", "vector"})
 
-    _SCROLL_RESERVED = frozenset({"id", "vector"})
-
-    rows = []
-    for p in batch:
-        row: dict[str, Any] = {}
-        payload = p.get("payload")
-        if has_dict_payload:
-            if isinstance(payload, dict):
-                for k, v in payload.items():
-                    if k in _SCROLL_RESERVED:
-                        safe_key = f"payload_{k}"
-                        while safe_key in payload:
-                            safe_key = f"_{safe_key}"
-                    else:
-                        safe_key = k
-                    row[safe_key] = v
-            # Non-dict payloads in a mixed batch are silently skipped;
-            # their columns will be NaN/null in the final DataFrame.
-        else:
-            row["payload"] = payload
-        row["id"] = p.get("id")
-        row["vector"] = list(p.get("vector", []))
-        rows.append(row)
-
+    rows = [_scroll_row(p, has_dict_payload, reserved) for p in batch]
     return lib.DataFrame(rows)
+
+
+def _scroll_row(
+    point: dict, has_dict_payload: bool, reserved: frozenset[str]
+) -> dict[str, Any]:
+    """Build a single scroll-batch row, applying the chosen payload strategy."""
+    payload = point.get("payload")
+    if not has_dict_payload:
+        row: dict[str, Any] = {"payload": payload}
+    elif isinstance(payload, dict):
+        row = _flatten_payload(payload, reserved)
+    else:
+        # Non-dict payloads in a mixed batch are silently skipped;
+        # their columns will be NaN/null in the final DataFrame.
+        row = {}
+    row["id"] = point.get("id")
+    row["vector"] = list(point.get("vector", []))
+    return row
 
 
 def _df_to_records(df: Any) -> list[dict]:

--- a/crates/velesdb-python/src/graph_store.rs
+++ b/crates/velesdb-python/src/graph_store.rs
@@ -352,54 +352,72 @@ impl GraphStore {
         let relationship_types = config.relationship_types.clone();
 
         py.allow_threads(|| {
-            use std::collections::HashSet;
-
             let store = self.inner.read();
-
-            let mut results = Vec::new();
-            let mut visited: HashSet<u64> = HashSet::new();
-            let mut stack: Vec<(u64, usize)> = vec![(source_id, 0)];
-
-            while let Some((node_id, depth)) = stack.pop() {
-                if visited.len() >= max_visited {
-                    break;
-                }
-
-                if visited.contains(&node_id) {
-                    continue;
-                }
-                visited.insert(node_id);
-
-                if depth < max_depth {
-                    let edges = store.get_outgoing(node_id);
-                    let filtered: Vec<_> = edges
-                        .into_iter()
-                        .filter(|e| {
-                            if let Some(ref types) = relationship_types {
-                                types.contains(&e.label().to_string())
-                            } else {
-                                true
-                            }
-                        })
-                        .filter(|e| !visited.contains(&e.target()))
-                        .collect();
-
-                    for edge in filtered.into_iter().rev() {
-                        results.push(TraversalResult {
-                            depth: depth + 1,
-                            source: edge.source(),
-                            target: edge.target(),
-                            label: edge.label().to_string(),
-                            edge_id: edge.id(),
-                        });
-                        stack.push((edge.target(), depth + 1));
-                    }
-                }
-            }
-
-            Ok(results)
+            Ok(dfs_collect(
+                &store,
+                source_id,
+                max_depth,
+                max_visited,
+                relationship_types.as_ref(),
+            ))
         })
     }
+}
+
+/// Returns true when an edge passes the optional relationship-type filter.
+fn label_matches(label: &str, relationship_types: Option<&Vec<String>>) -> bool {
+    match relationship_types {
+        Some(types) => types.contains(&label.to_string()),
+        None => true,
+    }
+}
+
+/// Collects DFS traversal results from `store` starting at `source_id`.
+///
+/// Pure logic extracted from `traverse_dfs` so the PyO3 binding stays thin.
+fn dfs_collect(
+    store: &EdgeStore,
+    source_id: u64,
+    max_depth: usize,
+    max_visited: usize,
+    relationship_types: Option<&Vec<String>>,
+) -> Vec<TraversalResult> {
+    use std::collections::HashSet;
+
+    let mut results = Vec::new();
+    let mut visited: HashSet<u64> = HashSet::new();
+    let mut stack: Vec<(u64, usize)> = vec![(source_id, 0)];
+
+    while let Some((node_id, depth)) = stack.pop() {
+        if visited.len() >= max_visited {
+            break;
+        }
+        if !visited.insert(node_id) {
+            continue;
+        }
+        if depth >= max_depth {
+            continue;
+        }
+        let filtered: Vec<_> = store
+            .get_outgoing(node_id)
+            .into_iter()
+            .filter(|e| {
+                label_matches(e.label(), relationship_types) && !visited.contains(&e.target())
+            })
+            .collect();
+        for edge in filtered.into_iter().rev() {
+            results.push(TraversalResult {
+                depth: depth + 1,
+                source: edge.source(),
+                target: edge.target(),
+                label: edge.label().to_string(),
+                edge_id: edge.id(),
+            });
+            stack.push((edge.target(), depth + 1));
+        }
+    }
+
+    results
 }
 
 #[cfg(test)]

--- a/crates/velesdb-wasm/src/vector_ops.rs
+++ b/crates/velesdb-wasm/src/vector_ops.rs
@@ -146,30 +146,45 @@ impl ScratchBuffer {
             }
             // ProductQuantization/RaBitQ share the SQ8 decode path in WASM context.
             StorageMode::SQ8 | StorageMode::ProductQuantization | StorageMode::RaBitQ => {
-                let start = idx * dimension;
-                let min = sq8_mins[idx];
-                let scale = sq8_scales[idx];
-                for (i, &q) in data_sq8[start..start + dimension].iter().enumerate() {
-                    self.buf[i] = (f32::from(q) / scale) + min;
-                }
-                &self.buf[..dimension]
+                self.decode_sq8(idx, data_sq8, sq8_mins, sq8_scales, dimension)
             }
-            StorageMode::Binary => {
-                let start = idx * self.bytes_per_vec;
-                for (i, &byte) in data_binary[start..start + self.bytes_per_vec]
-                    .iter()
-                    .enumerate()
-                {
-                    for bit in 0..8 {
-                        let dim_idx = i * 8 + bit;
-                        if dim_idx < dimension {
-                            self.buf[dim_idx] = if byte & (1 << bit) != 0 { 1.0 } else { 0.0 };
-                        }
-                    }
+            StorageMode::Binary => self.decode_binary(idx, data_binary, dimension),
+        }
+    }
+
+    /// Decodes an SQ8-quantized vector at `idx` into the scratch buffer.
+    fn decode_sq8(
+        &mut self,
+        idx: usize,
+        data_sq8: &[u8],
+        sq8_mins: &[f32],
+        sq8_scales: &[f32],
+        dimension: usize,
+    ) -> &[f32] {
+        let start = idx * dimension;
+        let min = sq8_mins[idx];
+        let scale = sq8_scales[idx];
+        for (i, &q) in data_sq8[start..start + dimension].iter().enumerate() {
+            self.buf[i] = (f32::from(q) / scale) + min;
+        }
+        &self.buf[..dimension]
+    }
+
+    /// Decodes a binary-packed vector at `idx` into the scratch buffer.
+    fn decode_binary(&mut self, idx: usize, data_binary: &[u8], dimension: usize) -> &[f32] {
+        let start = idx * self.bytes_per_vec;
+        for (i, &byte) in data_binary[start..start + self.bytes_per_vec]
+            .iter()
+            .enumerate()
+        {
+            for bit in 0..8 {
+                let dim_idx = i * 8 + bit;
+                if dim_idx < dimension {
+                    self.buf[dim_idx] = if byte & (1 << bit) != 0 { 1.0 } else { 0.0 };
                 }
-                &self.buf[..dimension]
             }
         }
+        &self.buf[..dimension]
     }
 }
 


### PR DESCRIPTION
Resolves the genuine production SonarCloud findings (the ~52 non-product/false-positive items were scoped out in #941). Pure behavior-preserving helper extractions — no public signatures, AST output, error semantics, or lock ordering changed.

**Covered:** 27 Rust `S3776` functions across core (velesql parser, collection, search path incl. HNSW `neighbors`/`gpu_search`, database DML), migrate, cli, wasm, mobile, python-binding; 2 Python `S3776` functions; and the `__init__.py` regex cluster (`S5869` — removed `A-Z` ranges duplicated under `re.IGNORECASE`, verified match-equivalent).

**Validation (local):**
- `cargo fmt --check` clean
- `cargo clippy --workspace --all-targets --features persistence,gpu,update-check --exclude velesdb-python -- -D warnings -D clippy::pedantic` clean
- **Recall gate passes** (`test_recall_thresholds`) — HNSW neighbor-selection refactor preserves recall
- velesdb-core **5585** tests + migrate/cli/mobile **719** tests: all pass

Expected outcome: SonarCloud new-code findings → 0, quality gate stays green.
