### PR TITLE
fix(python): clear last 2 SonarCloud S5843 regex findings

### DIFF
--- a/crates/velesdb-python/python/velesdb/__init__.py
+++ b/crates/velesdb-python/python/velesdb/__init__.py
@@ -614,14 +614,19 @@ class VelesQL:
             normalized,
             flags=re.IGNORECASE,
         )
+        # NOSONAR(python:S5843) — the trailing look-ahead enumerates VelesQL
+        # clause keywords (JOIN/WHERE/GROUP/ORDER/LIMIT/OFFSET) to mark where the
+        # alias ends; this alternation is grammar-driven and cannot be simplified
+        # without changing what the pattern matches. The `\s+` prefix is already
+        # factored out of the alternation.
         normalized = re.sub(
-            r"\bFROM\s+([a-z_][a-z0-9_]*)\s+([a-z_][a-z0-9_]*)\b(?=\s+JOIN|\s+WHERE|\s+GROUP|\s+ORDER|\s+LIMIT|\s+OFFSET|$)",
+            r"\bFROM\s+([a-z_][a-z0-9_]*)\s+([a-z_][a-z0-9_]*)\b(?=\s+(?:JOIN|WHERE|GROUP|ORDER|LIMIT|OFFSET)|$)",  # NOSONAR(python:S5843)
             r"FROM \1 AS \2",
             normalized,
             flags=re.IGNORECASE,
         )
         normalized = re.sub(
-            r"\bJOIN\s+([a-z_][a-z0-9_]*)\s+([a-z_][a-z0-9_]*)\b(?=\s+ON|\s+WHERE|\s+GROUP|\s+ORDER|\s+LIMIT|\s+OFFSET|$)",
+            r"\bJOIN\s+([a-z_][a-z0-9_]*)\s+([a-z_][a-z0-9_]*)\b(?=\s+(?:ON|WHERE|GROUP|ORDER|LIMIT|OFFSET)|$)",  # NOSONAR(python:S5843)
             r"JOIN \1 AS \2",
             normalized,
             flags=re.IGNORECASE,


### PR DESCRIPTION
Final cleanup to reach **0 new-code SonarCloud findings**. The FROM/JOIN alias-rewrite regexes trip `python:S5843` (complexity 34>20) due to the clause-keyword look-ahead, which is grammar-driven and irreducible without changing match semantics. Factored `\s+` out of the alternation (verified equivalent on 2640 inputs) and added an inline `# NOSONAR(python:S5843)` with justification. Gate already green (84.4% coverage); this takes new issues 40→0 across the cleanup PRs (#941, #942, this).
