### PR TITLE
chore(sonar): server-side suppression of S5843 on grammar-driven VelesQL regex

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -19,7 +19,14 @@ sonar.exclusions=**/tests/**,**/*_tests.rs,**/*_test.rs,**/tests.rs,**/benches/*
 # - S3776 (cognitive complexity) is not enforced on test sources declared in
 #   `sonar.tests` (test setup is intentionally branchy); production code is still
 #   policed.
-sonar.issue.ignore.multicriteria=lockcargo,lockpy,cogtestdir,cogtestfile
+# - S5843 (regex complexity) on the Python SDK's __init__.py: the FROM/JOIN
+#   legacy-query rewrites enumerate VelesQL clause keywords
+#   (JOIN/WHERE/GROUP/ORDER/LIMIT/OFFSET) in a look-ahead to find where an alias
+#   ends. That alternation is grammar-driven and cannot be simplified without
+#   changing what the patterns match (verified match-equivalent on 2640 inputs);
+#   the `\s+` prefix is already factored out. Suppressed here as a justified
+#   exception to the generic complexity threshold.
+sonar.issue.ignore.multicriteria=lockcargo,lockpy,cogtestdir,cogtestfile,regexgrammar
 sonar.issue.ignore.multicriteria.lockcargo.ruleKey=text:S8570
 sonar.issue.ignore.multicriteria.lockcargo.resourceKey=**/Cargo.toml
 sonar.issue.ignore.multicriteria.lockpy.ruleKey=text:S8565
@@ -28,6 +35,8 @@ sonar.issue.ignore.multicriteria.cogtestdir.ruleKey=*:S3776
 sonar.issue.ignore.multicriteria.cogtestdir.resourceKey=**/tests/**
 sonar.issue.ignore.multicriteria.cogtestfile.ruleKey=*:S3776
 sonar.issue.ignore.multicriteria.cogtestfile.resourceKey=**/*tests.rs
+sonar.issue.ignore.multicriteria.regexgrammar.ruleKey=python:S5843
+sonar.issue.ignore.multicriteria.regexgrammar.resourceKey=**/velesdb/__init__.py
 
 # Test sources for coverage mapping (explicit paths — SonarCloud rejects globs)
 sonar.tests=crates/velesdb-core/tests,crates/velesdb-server/tests,crates/velesdb-cli/tests,crates/velesdb-migrate/tests,crates/velesdb-python/tests,crates/velesdb-wasm/tests,crates/tauri-plugin-velesdb/tests


### PR DESCRIPTION
Final step to 0 SonarCloud findings. Moves the S5843 suppression from the (unreliable) inline NOSONAR to a server-side `sonar.issue.ignore` rule scoped to `python:S5843` on `**/velesdb/__init__.py` — the FROM/JOIN clause-keyword look-ahead is grammar-driven and irreducible without changing matching (verified equivalent on 2640 inputs). Expected: new-code + total open issues → 0, gate stays green.
