### PR TITLE
fix(release): close 1.16.0 version-drift blind spots blocking the bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4742,7 +4742,11 @@ This change ensures VelesDB remains freely available while protecting against cl
 - API Authentication (WIS-69)
 - Starlight documentation site
 
-[Unreleased]: https://github.com/cyberlife-coder/VelesDB/compare/v1.14.2...HEAD
+[Unreleased]: https://github.com/cyberlife-coder/VelesDB/compare/v1.16.0...HEAD
+[1.16.0]: https://github.com/cyberlife-coder/VelesDB/releases/tag/v1.16.0
+[1.15.0]: https://github.com/cyberlife-coder/VelesDB/releases/tag/v1.15.0
+[1.14.4]: https://github.com/cyberlife-coder/VelesDB/releases/tag/v1.14.4
+[1.14.3]: https://github.com/cyberlife-coder/VelesDB/releases/tag/v1.14.3
 [1.14.2]: https://github.com/cyberlife-coder/VelesDB/releases/tag/v1.14.2
 [1.14.1]: https://github.com/cyberlife-coder/VelesDB/releases/tag/v1.14.1
 [1.14.0]: https://github.com/cyberlife-coder/VelesDB/releases/tag/v1.14.0

--- a/demos/rag-pdf-demo/src/__init__.py
+++ b/demos/rag-pdf-demo/src/__init__.py
@@ -1,3 +1,3 @@
 """VelesDB RAG Demo - PDF Question Answering System."""
 
-__version__ = "1.7.0"
+__version__ = "1.16.0"

--- a/demos/rag-pdf-demo/src/main.py
+++ b/demos/rag-pdf-demo/src/main.py
@@ -46,7 +46,7 @@ async def lifespan(app: FastAPI):
 app = FastAPI(
     title="VelesDB RAG Demo",
     description="PDF Question Answering with VelesDB vector search",
-    version="1.7.0",
+    version="1.16.0",
     lifespan=lifespan
 )
 

--- a/docs/guides/INSTALLATION.md
+++ b/docs/guides/INSTALLATION.md
@@ -32,7 +32,7 @@ the roadmap but not yet available; use the steps below in the meantime.
 
 ```powershell
 # 1. Download
-Invoke-WebRequest -Uri "https://github.com/cyberlife-coder/VelesDB/releases/download/v1.14.2/velesdb-x86_64-pc-windows-msvc.zip" -OutFile velesdb.zip
+Invoke-WebRequest -Uri "https://github.com/cyberlife-coder/VelesDB/releases/latest/download/velesdb-x86_64-pc-windows-msvc.zip" -OutFile velesdb.zip
 
 # 2. Extract anywhere you have write access (no admin required)
 Expand-Archive velesdb.zip -DestinationPath C:\VelesDB
@@ -60,10 +60,10 @@ entry.
 
 ```bash
 # Download
-wget https://github.com/cyberlife-coder/VelesDB/releases/download/v1.14.2/velesdb-1.14.2-amd64.deb
+wget https://github.com/cyberlife-coder/VelesDB/releases/download/v1.16.0/velesdb-1.16.0-amd64.deb
 
 # Install
-sudo dpkg -i velesdb-1.14.2-amd64.deb
+sudo dpkg -i velesdb-1.16.0-amd64.deb
 
 # Verify
 velesdb --version
@@ -85,7 +85,7 @@ sudo dpkg -r velesdb
 
 ```bash
 # Download and extract
-wget https://github.com/cyberlife-coder/VelesDB/releases/download/v1.14.2/velesdb-x86_64-unknown-linux-gnu.tar.gz
+wget https://github.com/cyberlife-coder/VelesDB/releases/latest/download/velesdb-x86_64-unknown-linux-gnu.tar.gz
 sudo mkdir -p /opt/velesdb
 sudo tar -xzf velesdb-x86_64-unknown-linux-gnu.tar.gz -C /opt/velesdb
 

--- a/examples/wasm-browser-demo/README.md
+++ b/examples/wasm-browser-demo/README.md
@@ -22,7 +22,7 @@ cd crates/velesdb-wasm
 wasm-pack build --target web --out-dir ../../examples/wasm-browser-demo/pkg
 
 # Then update index.html to use the local path instead of CDN:
-# Change: import init from 'https://unpkg.com/@wiscale/velesdb-wasm@1.15.0/velesdb_wasm.js'
+# Change: import init from 'https://unpkg.com/@wiscale/velesdb-wasm@1.16.0/velesdb_wasm.js'
 # To:     import init from './pkg/velesdb_wasm.js'
 ```
 
@@ -80,7 +80,7 @@ Typical results on modern hardware:
 ```html
 <script type="module">
   // If published on npm:
-  // import init, { VectorStore } from 'https://unpkg.com/@wiscale/velesdb-wasm@1.15.0/velesdb_wasm.js';
+  // import init, { VectorStore } from 'https://unpkg.com/@wiscale/velesdb-wasm@1.16.0/velesdb_wasm.js';
   // If built locally with wasm-pack:
   import init, { VectorStore } from './pkg/velesdb_wasm.js';
 

--- a/scripts/bump-version.ps1
+++ b/scripts/bump-version.ps1
@@ -144,6 +144,53 @@ $FilesToUpdate = @(
         Replacement = "version = `"$Version`""
         Description = "RAG demo"
     },
+    # RAG demo source carries two runtime version strings the bump script
+    # never touched (only the pyproject above was rewritten). Both were found
+    # frozen at 1.7.0 — nine minor versions stale — during the v1.16.0 audit:
+    # `__version__` exposed via `src.__version__`, and the FastAPI `version=`
+    # echoed in the demo's generated OpenAPI `/openapi.json`. The FastAPI
+    # pattern uses a `(?<!_)` guard so it never rewrites the `__version__`
+    # constant in the same package.
+    @{
+        Path = "demos/rag-pdf-demo/src/__init__.py"
+        Pattern = '__version__ = "\d+\.\d+\.\d+"'
+        Replacement = "__version__ = `"$Version`""
+        Description = "RAG demo __init__.py __version__"
+    },
+    @{
+        Path = "demos/rag-pdf-demo/src/main.py"
+        Pattern = '(?<!_)version="\d+\.\d+\.\d+"'
+        Replacement = "version=`"$Version`""
+        Description = "RAG demo FastAPI app version (OpenAPI /openapi.json)"
+    },
+    # Browser-demo README documents the same wasm CDN URL as its index.html;
+    # found frozen at 1.15.0 during the v1.16.0 audit (only index.html was
+    # rewritten). Like the CDN tag it resolves at runtime, so it tracks the
+    # workspace. NOTE: the npm-installed example apps (react-wasm-search,
+    # node-express-rag) are intentionally NOT rewritten here — they are `npm ci`
+    # consumers of the PUBLISHED @wiscale packages, so they are bumped after the
+    # npm publish, not in lock-step with the workspace.
+    @{
+        Path = "examples/wasm-browser-demo/README.md"
+        Pattern = '@wiscale/velesdb-wasm@\d+\.\d+\.\d+/'
+        Replacement = "@wiscale/velesdb-wasm@$Version/"
+        Description = "wasm-browser-demo README CDN URLs"
+    },
+    # Install guide DEB asset filename carries the version (the zip/tarball
+    # install URLs were de-versioned to releases/latest). Two patterns: the
+    # download tag and the .deb filename.
+    @{
+        Path = "docs/guides/INSTALLATION.md"
+        Pattern = 'releases/download/v\d+\.\d+\.\d+/velesdb-\d+\.\d+\.\d+-amd64\.deb'
+        Replacement = "releases/download/v$Version/velesdb-$Version-amd64.deb"
+        Description = "INSTALLATION.md DEB download URL"
+    },
+    @{
+        Path = "docs/guides/INSTALLATION.md"
+        Pattern = 'dpkg -i velesdb-\d+\.\d+\.\d+-amd64\.deb'
+        Replacement = "dpkg -i velesdb-$Version-amd64.deb"
+        Description = "INSTALLATION.md DEB dpkg filename"
+    },
     @{
         Path = "docs/openapi.json"
         # Match the "version" field inside the .info object. Anchored on the

--- a/scripts/check-version-sync.py
+++ b/scripts/check-version-sync.py
@@ -109,6 +109,28 @@ TARGETS: "list[tuple[str, str]]" = [
     # The `docker pull ...:X.Y.Z` example must track the workspace version so
     # readers copy a tag that actually exists; bump-version.ps1 rewrites it.
     ("docs/guides/INSTALLATION.md", "ghcr_image"),
+    # rag-pdf-demo source carries TWO runtime version strings that the bump
+    # script never touched (it only rewrote the demo's pyproject.toml). Both
+    # were found frozen at 1.7.0 — nine minor versions stale — during the
+    # v1.16.0 audit: `__version__` is exposed via `src.__version__`, and the
+    # FastAPI `version=` is echoed in the demo's OpenAPI `/openapi.json`. Same
+    # gap class as the Haystack `__init__.py` drift caught in v1.14.2.
+    ("demos/rag-pdf-demo/src/__init__.py", "py_init_version"),
+    ("demos/rag-pdf-demo/src/main.py", "fastapi_app_version"),
+    # The browser demo's README documents the same wasm CDN URL as its
+    # index.html; found frozen at 1.15.0 during the v1.16.0 audit while only
+    # index.html was policed. Like the CDN tag it resolves at runtime, so it
+    # tracks the workspace version. NOTE: the npm-installed example apps
+    # (examples/react-wasm-search, examples/node-express-rag) are deliberately
+    # NOT policed here — they are `npm ci` CONSUMERS of the PUBLISHED @wiscale
+    # packages (propagation-guard.yml builds them), so they can only pin a
+    # version that already exists on the npm registry and are bumped after the
+    # npm publish, not in lock-step with the workspace.
+    ("examples/wasm-browser-demo/README.md", "wasm_cdn_url"),
+    # Install guide's DEB asset filename carries the version (the zip/tarball
+    # were de-versioned to `releases/latest/`). Found pinned at v1.14.2 during
+    # the v1.16.0 audit — the documented `wget` URL would 404 on release.
+    ("docs/guides/INSTALLATION.md", "deb_release_tag"),
 ]
 
 
@@ -317,6 +339,32 @@ def _read_ghcr_image(path: Path) -> str:
     return match.group(1)
 
 
+def _read_fastapi_app_version(path: Path) -> str:
+    """Pull the version out of a FastAPI `version="X.Y.Z"` kwarg. This is the
+    app version surfaced in the demo's generated OpenAPI `/openapi.json`. The
+    `\b` guard avoids matching the adjacent `__version__ = "..."` constant.
+    """
+    text = path.read_text(encoding="utf-8")
+    match = re.search(r'\bversion\s*=\s*"(\d+\.\d+\.\d+)"', text)
+    if not match:
+        raise RuntimeError(f'No `version="X.Y.Z"` kwarg in {path}')
+    return match.group(1)
+
+
+def _read_deb_release_tag(path: Path) -> str:
+    """Pull the version out of the `velesdb-X.Y.Z-amd64.deb` release asset
+    referenced in the install guide. The asset filename carries the version, so
+    (unlike the version-agnostic zip/tarball which use `releases/latest/`) it
+    must track the workspace or the documented `wget` URL 404s. Found pinned at
+    v1.14.2 during the v1.16.0 audit.
+    """
+    text = path.read_text(encoding="utf-8")
+    match = re.search(r"velesdb-(\d+\.\d+\.\d+)-amd64\.deb", text)
+    if not match:
+        raise RuntimeError(f"No `velesdb-X.Y.Z-amd64.deb` reference in {path}")
+    return match.group(1)
+
+
 _READERS = {
     "toml": _read_toml_version,
     "json": _read_json_version,
@@ -335,6 +383,8 @@ _READERS = {
     "ts_sdk_banner": _read_ts_sdk_banner,
     "cargo_pin": _read_cargo_pin,
     "ghcr_image": _read_ghcr_image,
+    "fastapi_app_version": _read_fastapi_app_version,
+    "deb_release_tag": _read_deb_release_tag,
 }
 
 


### PR DESCRIPTION
Supersedes #949 (renamed branch to satisfy Git Flow governance: only develop/release/hotfix/support may target main).

## Blockers fixed (NO-GO → GO)
- **`docs/guides/INSTALLATION.md`** — download URLs pinned to `v1.14.2`. DEB URL would **404** on a 1.16.0 install; zip/tarball served stale binaries. DEB → `v1.16.0`; zip/tarball **de-versioned to `releases/latest/`** (self-tracking, matches `scripts/install.sh`).
- **`CHANGELOG.md`** — `1.16.0`/`1.15.0` (+ intervening `1.14.4`/`1.14.3`) headers had no link-defs and `[Unreleased]` still compared from `v1.14.2` → dead links. Added defs + `compare/v1.16.0...HEAD`.

## Drift fixed
- **`demos/rag-pdf-demo/src/{__init__.py,main.py}`** — `__version__` + FastAPI app version frozen at `1.7.0` (bump script only rewrote the pyproject).
- **`examples/wasm-browser-demo/README.md`** — wasm CDN URL frozen at `1.15.0`.

## Anti-recurrence
- `check-version-sync.py` (new `fastapi_app_version` + `deb_release_tag` readers) and `bump-version.ps1` now police the demo sources, browser-demo README CDN, and INSTALLATION DEB tag. All release gates green locally (version-sync, promise-contract, perf/feature-claims, todo, unwraps).

## Intentionally NOT changed
- npm-consumer example apps (`react-wasm-search`, `node-express-rag`) stay at `1.15.0` — `npm ci` consumers, bumped after the npm publish.
- The 55µs `5K/768D` benchmark label (pinned by `promise-contract.json`, echoed in QUALITY_BAR/ARCHITECTURE/TUNING_GUIDE) — reconciling it with the bench's 10K insert is a separate benchmark-relabeling decision that must update the promise contract in lockstep.
