### PR TITLE
fix(codacy): grade-A cleanup — resolve all 90 main findings (TS + Rust + config)

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -383,6 +383,60 @@ engines:
       # I/O phases, not branch complexity.
       - "crates/velesdb-core/src/collection/core/bulk_import.rs"
 
+      # --- Grade-A wave: legitimately-complex / Lizard-FP files ---
+      # The genuinely-splittable findings in this wave were refactored in code
+      # (projection.rs, select_dispatch.rs, hnsw/persistence.rs,
+      # sparse/persistence.rs, log_payload.rs, and the velesdb-server handlers).
+      # The files below are excluded instead — each for a documented reason
+      # matching an existing policy above.
+
+      # HNSW graph_io: read_vector_data / validate_graph_header /
+      # read_graph_header_fields parse an UNTRUSTED `.graph`/`.vectors` file.
+      # Their CCN is inflated by chained `?` over sequential field reads (same
+      # FP as backend_adapter.rs / query_engine.rs above), and the header
+      # validation is security-critical — every check lets the search hot path
+      # use get_unchecked safely, so it must stay one cohesive function.
+      - "crates/velesdb-core/src/index/hnsw/native/graph_io.rs"
+
+      # Filter condition dispatch — `Condition::matches` is a flat 22-arm match
+      # mapping each enum variant to a 1-line predicate (same flat-table pattern
+      # as filter/conversion.rs and simd_dispatch.rs above). Splitting scatters
+      # the dispatch.
+      - "crates/velesdb-core/src/filter/matching.rs"
+
+      # VelesQL scalar literal parser — `parse_scalar_from_rule` is a 13-line
+      # 7-arm match, but Lizard merges it with the adjacent literal-parsing
+      # helpers and reports 53 NLOC (same merge FP as match_exec/mod.rs and
+      # crud.rs above).
+      - "crates/velesdb-core/src/velesql/parser/helpers.rs"
+
+      # Graph traversal algorithms — `traverse_dfs_config` and `traverse_single`
+      # are tight BFS/DFS hot loops whose branching is inherent (visited/parent
+      # bookkeeping, depth/limit guards). Same rationale as the already-excluded
+      # collection/graph/traversal.rs; extracting the loop body would need 8+
+      # mutable-borrow params and add indirection without clarity.
+      - "crates/velesdb-core/src/collection/core/graph_api.rs"
+      - "crates/velesdb-core/src/collection/search/query/parallel_traversal/traverser.rs"
+
+      # Parameter-heavy query dispatch — `score_match_results` (10 params) and
+      # `evaluate_where_condition_for_record` (9 params) thread many per-query
+      # context fields through; wrapping them in a struct adds indirection
+      # without clarity (same rationale as execution_paths.rs / join.rs above).
+      - "crates/velesdb-core/src/collection/search/query/match_exec/similarity.rs"
+      - "crates/velesdb-core/src/collection/search/query/where_eval.rs"
+
+      # Server configuration module — serde struct definitions + multi-source
+      # (CLI > env > toml > defaults) loading. File NLOC (672) is data
+      # definitions, not branch complexity (same rationale as the excluded
+      # velesdb-core/config.rs and velesdb-server/src/lib.rs above).
+      - "crates/velesdb-server/src/config.rs"
+
+      # LangChain / LlamaIndex vector store constructors — `__init__` takes many
+      # config kwargs per the frameworks' VectorStore convention (same rationale
+      # as the already-excluded graph_retriever.py).
+      - "integrations/langchain/src/langchain_velesdb/vectorstore.py"
+      - "integrations/llamaindex/src/llamaindex_velesdb/vectorstore.py"
+
   opengrep:
     exclude_paths:
       # --- Test files (issue #957) ---

--- a/.codacy.yml
+++ b/.codacy.yml
@@ -25,6 +25,13 @@ exclude_paths:
   - "crates/**/src/**/*_test.rs"
   - "crates/**/src/**/tests.rs"
   - "crates/**/tests/**"
+  # Test files living DIRECTLY under src/ (no intervening sub-directory). The
+  # `src/**/*` globs above require at least one path segment after `src/`, so
+  # src-root test files (alloc_guard_tests.rs, perf_optimizations_tests.rs,
+  # simd_native_tests.rs, ...) slipped through and were still graded for
+  # unsafe-usage / NLOC. These single-level globs match them.
+  - "crates/**/src/*_tests.rs"
+  - "crates/**/src/*_test.rs"
   # Benchmark harnesses (criterion) — perf code, not production
   - "crates/**/benches/**"
   # Generated code (pest parser, build scripts)
@@ -74,15 +81,22 @@ exclude_paths:
   # per-engine eslint block — Codacy ignores those). Only files whose findings
   # are 100% this `no-unused-vars` FP are listed, so no genuine issue is hidden:
   # backend.ts (50 FP, pure type definitions), types/errors.ts (2), and
-  # agent-memory.ts (2). Deliberately NOT excluded: filter.ts, errors.ts and
-  # client/validation.ts also carry their few no-unused-vars FP, but excluding
-  # them would also hide real findings (errors.ts has a `detect-object-injection`
-  # Security finding — see #955 — plus `no-unnecessary-condition` ErrorProne on
-  # all three). Those ~5 residual FP are accepted; the base `no-unused-vars`
-  # pattern can be disabled in the coding standard for a clean fix (issue #951).
+  # agent-memory.ts (2). The real findings that filter.ts, errors.ts and
+  # client/validation.ts used to carry have since been FIXED in code (Record->Map
+  # removes the detect-object-injection sink in errors.ts; type-guard widening
+  # removes the no-unnecessary-condition ErrorProne findings) — so those three
+  # files now carry ONLY the base `no-unused-vars` FP on type-position parameter
+  # names (constructor/overload/callback type signatures, which the parser
+  # mis-reads as unused bindings). They are therefore excluded here too. The
+  # clean long-term fix remains disabling the base `no-unused-vars` pattern in
+  # the coding standard (issue #951), which would let ALL of these file
+  # exclusions be dropped.
   - "sdks/typescript/src/types/backend.ts"
   - "sdks/typescript/src/types/errors.ts"
   - "sdks/typescript/src/agent-memory.ts"
+  - "sdks/typescript/src/errors.ts"
+  - "sdks/typescript/src/filter.ts"
+  - "sdks/typescript/src/client/validation.ts"
   # Integration contains_text_search helpers — Codacy's online taint analysis
   # flags VelesQL query construction as SQL injection. All user inputs are
   # sanitized BEFORE the query is built:
@@ -135,6 +149,9 @@ exclude_paths:
   - "crates/velesdb-core/src/storage/mmap.rs"
   - "crates/velesdb-core/src/storage/compaction.rs"
   - "crates/velesdb-core/src/storage/guard.rs"
+  # mmap submodule (wal_replay.rs, vector_io, ...) — MmapMut remap + raw
+  # pointer I/O, every unsafe block carries // SAFETY: documentation.
+  - "crates/velesdb-core/src/storage/mmap/**"
   # HNSW index core — get_unchecked in search loops, aligned vector access
   # Invariants documented in docs/SOUNDNESS.md. Covered by Miri CI.
   - "crates/velesdb-core/src/index/hnsw/index/mod.rs"
@@ -190,6 +207,10 @@ engines:
       - "crates/**/src/**/*_test.rs"
       - "crates/**/src/**/tests.rs"
       - "crates/**/tests/**"
+      # src-root test files (see global exclude_paths note): simd_native_tests.rs
+      # and friends live directly under src/ and the `src/**/*` glob misses them.
+      - "crates/**/src/*_tests.rs"
+      - "crates/**/src/*_test.rs"
       # --- WHERE evaluation (enum pattern matching) ---
       - "crates/velesdb-core/src/collection/search/query/match_exec/where_eval.rs"
 
@@ -374,6 +395,17 @@ engines:
       - "crates/**/src/**/*_test.rs"
       - "crates/**/src/**/tests.rs"
       - "crates/**/tests/**"
+      # src-root test files (see global exclude_paths note): alloc_guard_tests.rs
+      # and perf_optimizations_tests.rs live directly under src/, so the
+      # `src/**/*` glob misses them and unsafe-usage was still flagged.
+      - "crates/**/src/*_tests.rs"
+      - "crates/**/src/*_test.rs"
+      # Production mmap I/O — wal_replay.rs remaps MmapMut after a documented
+      # file resize (// SAFETY: comments present, verified by
+      # verify_unsafe_safety_template.py). unsafe-usage cannot distinguish
+      # audited from un-audited unsafe; the whole audited mmap submodule is
+      # excluded for this engine like the other mmap files above.
+      - "crates/velesdb-core/src/storage/mmap/**"
       # Integration memory modules — random.randint used for session-scoped
       # in-process ID counters, not security/crypto material
       - "integrations/langchain/src/langchain_velesdb/memory.py"

--- a/crates/tauri-plugin-velesdb/guest-js/index.ts
+++ b/crates/tauri-plugin-velesdb/guest-js/index.ts
@@ -325,7 +325,7 @@ export interface CommandError {
  * console.log(`Created collection with ${info.count} vectors`);
  * ```
  */
-export async function createCollection(request: CreateCollectionRequest): Promise<CollectionInfo> {
+export function createCollection(request: CreateCollectionRequest): Promise<CollectionInfo> {
   return invoke<CollectionInfo>('plugin:velesdb|create_collection', { request });
 }
 
@@ -344,7 +344,7 @@ export async function createCollection(request: CreateCollectionRequest): Promis
  * console.log(`Created metadata collection: ${info.name}`);
  * ```
  */
-export async function createMetadataCollection(request: CreateMetadataCollectionRequest): Promise<CollectionInfo> {
+export function createMetadataCollection(request: CreateMetadataCollectionRequest): Promise<CollectionInfo> {
   return invoke<CollectionInfo>('plugin:velesdb|create_metadata_collection', { request });
 }
 
@@ -360,7 +360,7 @@ export async function createMetadataCollection(request: CreateMetadataCollection
  * ```
  */
 export async function deleteCollection(name: string): Promise<void> {
-  return invoke<void>('plugin:velesdb|delete_collection', { name });
+  await invoke('plugin:velesdb|delete_collection', { name });
 }
 
 /**
@@ -374,7 +374,7 @@ export async function deleteCollection(name: string): Promise<void> {
  * collections.forEach(c => console.log(`${c.name}: ${c.count} vectors`));
  * ```
  */
-export async function listCollections(): Promise<CollectionInfo[]> {
+export function listCollections(): Promise<CollectionInfo[]> {
   return invoke<CollectionInfo[]>('plugin:velesdb|list_collections');
 }
 
@@ -391,7 +391,7 @@ export async function listCollections(): Promise<CollectionInfo[]> {
  * console.log(`Dimension: ${info.dimension}, Count: ${info.count}`);
  * ```
  */
-export async function getCollection(name: string): Promise<CollectionInfo> {
+export function getCollection(name: string): Promise<CollectionInfo> {
   return invoke<CollectionInfo>('plugin:velesdb|get_collection', { name });
 }
 
@@ -418,7 +418,7 @@ export async function getCollection(name: string): Promise<CollectionInfo> {
  * console.log(`Upserted ${count} points`);
  * ```
  */
-export async function upsert(request: UpsertRequest): Promise<number> {
+export function upsert(request: UpsertRequest): Promise<number> {
   return invoke<number>('plugin:velesdb|upsert', { request });
 }
 
@@ -443,7 +443,7 @@ export async function upsert(request: UpsertRequest): Promise<number> {
  * console.log(`Upserted ${count} metadata points`);
  * ```
  */
-export async function upsertMetadata(request: UpsertMetadataRequest): Promise<number> {
+export function upsertMetadata(request: UpsertMetadataRequest): Promise<number> {
   return invoke<number>('plugin:velesdb|upsert_metadata', { request });
 }
 
@@ -470,7 +470,7 @@ export async function upsertMetadata(request: UpsertMetadataRequest): Promise<nu
  * });
  * ```
  */
-export async function search(request: SearchRequest): Promise<SearchResponse> {
+export function search(request: SearchRequest): Promise<SearchResponse> {
   return invoke<SearchResponse>('plugin:velesdb|search', { request });
 }
 
@@ -490,7 +490,7 @@ export async function search(request: SearchRequest): Promise<SearchResponse> {
  * });
  * ```
  */
-export async function textSearch(request: TextSearchRequest): Promise<SearchResponse> {
+export function textSearch(request: TextSearchRequest): Promise<SearchResponse> {
   return invoke<SearchResponse>('plugin:velesdb|text_search', { request });
 }
 
@@ -513,7 +513,7 @@ export async function textSearch(request: TextSearchRequest): Promise<SearchResp
  * });
  * ```
  */
-export async function hybridSearch(request: HybridSearchRequest): Promise<SearchResponse> {
+export function hybridSearch(request: HybridSearchRequest): Promise<SearchResponse> {
   return invoke<SearchResponse>('plugin:velesdb|hybrid_search', { request });
 }
 
@@ -539,7 +539,7 @@ export async function hybridSearch(request: HybridSearchRequest): Promise<Search
  * });
  * ```
  */
-export async function query(request: QueryRequest): Promise<QueryResponse> {
+export function query(request: QueryRequest): Promise<QueryResponse> {
   return invoke<QueryResponse>('plugin:velesdb|query', { request });
 }
 
@@ -562,7 +562,7 @@ export async function query(request: QueryRequest): Promise<QueryResponse> {
  * });
  * ```
  */
-export async function getPoints(request: GetPointsRequest): Promise<Array<PointOutput | null>> {
+export function getPoints(request: GetPointsRequest): Promise<Array<PointOutput | null>> {
   return invoke<Array<PointOutput | null>>('plugin:velesdb|get_points', { request });
 }
 
@@ -581,7 +581,7 @@ export async function getPoints(request: GetPointsRequest): Promise<Array<PointO
  * ```
  */
 export async function deletePoints(request: DeletePointsRequest): Promise<void> {
-  return invoke<void>('plugin:velesdb|delete_points', { request });
+  await invoke('plugin:velesdb|delete_points', { request });
 }
 
 /**
@@ -605,7 +605,7 @@ export async function deletePoints(request: DeletePointsRequest): Promise<void> 
  * });
  * ```
  */
-export async function batchSearch(request: BatchSearchRequest): Promise<SearchResponse[]> {
+export function batchSearch(request: BatchSearchRequest): Promise<SearchResponse[]> {
   return invoke<SearchResponse[]>('plugin:velesdb|batch_search', { request });
 }
 
@@ -639,7 +639,7 @@ export async function batchSearch(request: BatchSearchRequest): Promise<SearchRe
  * });
  * ```
  */
-export async function multiQuerySearch(request: MultiQuerySearchRequest): Promise<SearchResponse> {
+export function multiQuerySearch(request: MultiQuerySearchRequest): Promise<SearchResponse> {
   return invoke<SearchResponse>('plugin:velesdb|multi_query_search', { request });
 }
 
@@ -656,7 +656,7 @@ export async function multiQuerySearch(request: MultiQuerySearchRequest): Promis
  * if (empty) console.log('Collection is empty');
  * ```
  */
-export async function isEmpty(name: string): Promise<boolean> {
+export function isEmpty(name: string): Promise<boolean> {
   return invoke<boolean>('plugin:velesdb|is_empty', { name });
 }
 
@@ -673,7 +673,7 @@ export async function isEmpty(name: string): Promise<boolean> {
  * ```
  */
 export async function flush(name: string): Promise<void> {
-  return invoke<void>('plugin:velesdb|flush', { name });
+  await invoke('plugin:velesdb|flush', { name });
 }
 
 // ============================================================================
@@ -755,7 +755,7 @@ export interface NodeDegreeOutput {
  * ```
  */
 export async function addEdge(request: AddEdgeRequest): Promise<void> {
-  return invoke<void>('plugin:velesdb|add_edge', { request });
+  await invoke('plugin:velesdb|add_edge', { request });
 }
 
 /**
@@ -770,7 +770,7 @@ export async function addEdge(request: AddEdgeRequest): Promise<void> {
  * const edges = await getEdges({ collection: 'social', label: 'FOLLOWS' });
  * ```
  */
-export async function getEdges(request: GetEdgesRequest): Promise<EdgeOutput[]> {
+export function getEdges(request: GetEdgesRequest): Promise<EdgeOutput[]> {
   return invoke<EdgeOutput[]>('plugin:velesdb|get_edges', { request });
 }
 
@@ -788,7 +788,7 @@ export async function getEdges(request: GetEdgesRequest): Promise<EdgeOutput[]> 
  * });
  * ```
  */
-export async function traverseGraph(request: TraverseGraphRequest): Promise<TraversalOutput[]> {
+export function traverseGraph(request: TraverseGraphRequest): Promise<TraversalOutput[]> {
   return invoke<TraversalOutput[]>('plugin:velesdb|traverse_graph', { request });
 }
 
@@ -805,7 +805,7 @@ export async function traverseGraph(request: TraverseGraphRequest): Promise<Trav
  * console.log(`In: ${degree.inDegree}, Out: ${degree.outDegree}`);
  * ```
  */
-export async function getNodeDegree(request: GetNodeDegreeRequest): Promise<NodeDegreeOutput> {
+export function getNodeDegree(request: GetNodeDegreeRequest): Promise<NodeDegreeOutput> {
   return invoke<NodeDegreeOutput>('plugin:velesdb|get_node_degree', { request });
 }
 
@@ -828,7 +828,7 @@ export async function getNodeDegree(request: GetNodeDegreeRequest): Promise<Node
  * });
  * ```
  */
-export async function createGraphCollection(request: CreateGraphCollectionRequest): Promise<CollectionInfo> {
+export function createGraphCollection(request: CreateGraphCollectionRequest): Promise<CollectionInfo> {
   return invoke<CollectionInfo>('plugin:velesdb|create_graph_collection', { request });
 }
 
@@ -873,7 +873,7 @@ export interface ScrollResponse {
  * } while (cursor !== undefined);
  * ```
  */
-export async function scrollCollection(request: ScrollRequest): Promise<ScrollResponse> {
+export function scrollCollection(request: ScrollRequest): Promise<ScrollResponse> {
   return invoke<ScrollResponse>('plugin:velesdb|scroll_collection', { request });
 }
 
@@ -916,7 +916,7 @@ export interface SemanticQueryResult {
  * @throws {CommandError} On storage failure
  */
 export async function semanticStore(request: SemanticStoreRequest): Promise<void> {
-  return invoke<void>('plugin:velesdb|semantic_store', { request });
+  await invoke('plugin:velesdb|semantic_store', { request });
 }
 
 /**
@@ -925,7 +925,7 @@ export async function semanticStore(request: SemanticStoreRequest): Promise<void
  * @param request - Semantic query request
  * @returns Array of matching knowledge facts
  */
-export async function semanticQuery(request: SemanticQueryRequest): Promise<SemanticQueryResult[]> {
+export function semanticQuery(request: SemanticQueryRequest): Promise<SemanticQueryResult[]> {
   return invoke<SemanticQueryResult[]>('plugin:velesdb|semantic_query', { request });
 }
 
@@ -970,7 +970,7 @@ export interface EpisodicResult {
  * @throws {CommandError} On storage failure
  */
 export async function episodicRecord(request: EpisodicRecordRequest): Promise<void> {
-  return invoke<void>('plugin:velesdb|episodic_record', { request });
+  await invoke('plugin:velesdb|episodic_record', { request });
 }
 
 /**
@@ -979,7 +979,7 @@ export async function episodicRecord(request: EpisodicRecordRequest): Promise<vo
  * @param request - Query parameters (limit, since_timestamp)
  * @returns Array of recent episodes
  */
-export async function episodicRecent(request: EpisodicRecentRequest): Promise<EpisodicResult[]> {
+export function episodicRecent(request: EpisodicRecentRequest): Promise<EpisodicResult[]> {
   return invoke<EpisodicResult[]>('plugin:velesdb|episodic_recent', { request });
 }
 
@@ -1032,7 +1032,7 @@ export interface ProceduralMatchResult {
  * @throws {CommandError} On storage failure
  */
 export async function proceduralLearn(request: ProceduralLearnRequest): Promise<void> {
-  return invoke<void>('plugin:velesdb|procedural_learn', { request });
+  await invoke('plugin:velesdb|procedural_learn', { request });
 }
 
 /**
@@ -1041,7 +1041,7 @@ export async function proceduralLearn(request: ProceduralLearnRequest): Promise<
  * @param request - Recall parameters
  * @returns Array of matching procedures
  */
-export async function proceduralRecall(request: ProceduralRecallRequest): Promise<ProceduralMatchResult[]> {
+export function proceduralRecall(request: ProceduralRecallRequest): Promise<ProceduralMatchResult[]> {
   return invoke<ProceduralMatchResult[]>('plugin:velesdb|procedural_recall', { request });
 }
 

--- a/crates/velesdb-core/src/collection/search/query/projection.rs
+++ b/crates/velesdb-core/src/collection/search/query/projection.rs
@@ -120,26 +120,52 @@ fn project_mixed(
         })
         .collect();
 
-    // Qualified wildcards expand to all payload fields + id.
     if !qualified_wildcards.is_empty() {
-        map.insert("id".to_string(), serde_json::Value::from(result.point.id));
-        if let Some(serde_json::Value::Object(payload_map)) = result.point.payload.as_ref() {
-            for (k, v) in payload_map {
-                if k != "id" && !window_aliases.contains(k.as_str()) {
-                    map.insert(k.clone(), v.clone());
-                }
+        insert_qualified_wildcards(&mut map, result, &window_aliases);
+    }
+    insert_named_columns(&mut map, result, columns);
+    insert_similarity_scores(&mut map, result, similarity_scores);
+    insert_window_values(&mut map, result, window_functions);
+
+    serde_json::Value::Object(map)
+}
+
+/// Expand a qualified wildcard (`c.*`) into id + every payload field, skipping
+/// any key shadowed by a window-function alias.
+fn insert_qualified_wildcards(
+    map: &mut serde_json::Map<String, serde_json::Value>,
+    result: &SearchResult,
+    window_aliases: &rustc_hash::FxHashSet<&str>,
+) {
+    map.insert("id".to_string(), serde_json::Value::from(result.point.id));
+    if let Some(serde_json::Value::Object(payload_map)) = result.point.payload.as_ref() {
+        for (k, v) in payload_map {
+            if k != "id" && !window_aliases.contains(k.as_str()) {
+                map.insert(k.clone(), v.clone());
             }
         }
     }
+}
 
-    // Named columns.
+/// Insert each explicitly named column (honouring its alias).
+fn insert_named_columns(
+    map: &mut serde_json::Map<String, serde_json::Value>,
+    result: &SearchResult,
+    columns: &[crate::velesql::Column],
+) {
     for col in columns {
         let output_key = col.alias.as_deref().unwrap_or(&col.name);
         let value = extract_field_value(result, &col.name);
         map.insert(output_key.to_string(), value);
     }
+}
 
-    // Similarity scores.
+/// Insert similarity-score expressions (all resolve to the result score).
+fn insert_similarity_scores(
+    map: &mut serde_json::Map<String, serde_json::Value>,
+    result: &SearchResult,
+    similarity_scores: &[SimilarityScoreExpr],
+) {
     for expr in similarity_scores {
         let key = expr.alias.as_deref().unwrap_or("similarity");
         map.insert(
@@ -147,10 +173,16 @@ fn project_mixed(
             serde_json::Value::from(f64::from(result.score)),
         );
     }
+}
 
-    // Window function values (injected into payload by window_evaluator).
-    // This is the single source of truth for window aliases — wildcard
-    // expansion above deliberately skipped them.
+/// Insert window-function values (injected into the payload by the window
+/// evaluator). This is the single source of truth for window aliases —
+/// wildcard expansion deliberately skips them.
+fn insert_window_values(
+    map: &mut serde_json::Map<String, serde_json::Value>,
+    result: &SearchResult,
+    window_functions: &[crate::velesql::WindowFunction],
+) {
     for wf in window_functions {
         let alias = wf
             .alias
@@ -165,8 +197,6 @@ fn project_mixed(
             .unwrap_or(serde_json::Value::Null);
         map.insert(alias.to_string(), value);
     }
-
-    serde_json::Value::Object(map)
 }
 
 /// Extracts a field value from a `SearchResult`, supporting nested paths.

--- a/crates/velesdb-core/src/collection/search/query/select_dispatch.rs
+++ b/crates/velesdb-core/src/collection/search/query/select_dispatch.rs
@@ -294,14 +294,7 @@ impl Collection {
             crate::velesql::window_evaluator::evaluate(&mut results, wfs)?;
         }
         // Step 3: ORDER BY (with optional LET bindings).
-        if let Some(ref order_by) = stmt.order_by {
-            if let_bindings.is_empty() {
-                self.apply_order_by(&mut results, order_by, params)?;
-            } else {
-                let per_result_let = Self::evaluate_let_for_results(let_bindings, &results);
-                self.apply_order_by_with_let(&mut results, order_by, params, &per_result_let)?;
-            }
-        }
+        self.apply_order_by_step(stmt, &mut results, params, let_bindings)?;
         // SQL-standard: OFFSET applied after ORDER BY, before LIMIT.
         if let Some(offset) = stmt.offset {
             let skip = usize::try_from(offset).unwrap_or(usize::MAX);
@@ -317,6 +310,27 @@ impl Collection {
         }
 
         Ok(results)
+    }
+
+    /// Apply ORDER BY, choosing the plain or LET-aware path depending on
+    /// whether any LET bindings are in scope.
+    fn apply_order_by_step(
+        &self,
+        stmt: &crate::velesql::SelectStatement,
+        results: &mut [SearchResult],
+        params: &std::collections::HashMap<String, serde_json::Value>,
+        let_bindings: &[crate::velesql::LetBinding],
+    ) -> Result<()> {
+        let Some(ref order_by) = stmt.order_by else {
+            return Ok(());
+        };
+        if let_bindings.is_empty() {
+            self.apply_order_by(results, order_by, params)?;
+        } else {
+            let per_result_let = Self::evaluate_let_for_results(let_bindings, results);
+            self.apply_order_by_with_let(results, order_by, params, &per_result_let)?;
+        }
+        Ok(())
     }
 
     /// Evaluates LET bindings for every result, producing per-result binding maps.

--- a/crates/velesdb-core/src/index/hnsw/persistence.rs
+++ b/crates/velesdb-core/src/index/hnsw/persistence.rs
@@ -514,38 +514,28 @@ pub(crate) fn load_sidecars(
     bool,
 )> {
     let graph_generation = load_graph_generation(path)?;
-    if graph_generation != meta.generation {
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::InvalidData,
-            format!(
-                "incomplete save detected: graph generation {} but meta generation {} \
-                 (crash between graph dump and sidecar writes, database state inconsistent)",
-                graph_generation, meta.generation,
-            ),
-        ));
-    }
+    check_sidecar_generation(
+        "graph",
+        graph_generation,
+        meta.generation,
+        "crash between graph dump and sidecar writes",
+    )?;
 
     let mappings_data = load_mappings(path)?;
-    if mappings_data.generation != meta.generation {
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::InvalidData,
-            format!(
-                "incomplete save detected: mappings generation {} but meta generation {} \
-                 (crash between sidecar writes, database state inconsistent)",
-                mappings_data.generation, meta.generation,
-            ),
-        ));
-    }
+    check_sidecar_generation(
+        "mappings",
+        mappings_data.generation,
+        meta.generation,
+        "crash between sidecar writes",
+    )?;
     let (vectors, enable_vector_storage, vectors_generation) = load_vectors_or_disable(path, meta)?;
-    if enable_vector_storage && vectors_generation != meta.generation {
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::InvalidData,
-            format!(
-                "incomplete save detected: vectors generation {} but meta generation {} \
-                 (crash between sidecar writes, database state inconsistent)",
-                vectors_generation, meta.generation,
-            ),
-        ));
+    if enable_vector_storage {
+        check_sidecar_generation(
+            "vectors",
+            vectors_generation,
+            meta.generation,
+            "crash between sidecar writes",
+        )?;
     }
 
     // Cross-check each mapped index against the actually-loaded vector set.
@@ -569,6 +559,23 @@ pub(crate) fn load_sidecars(
         mappings_data.next_idx,
     );
     Ok((mappings, vectors, enable_vector_storage))
+}
+
+/// Rejects a sidecar whose generation does not match the meta generation,
+/// which indicates a crash mid-save left the on-disk state inconsistent.
+fn check_sidecar_generation(
+    sidecar: &str,
+    found: u64,
+    expected: u64,
+    crash_context: &str,
+) -> std::io::Result<()> {
+    if found != expected {
+        return Err(invalid_data(format!(
+            "incomplete save detected: {sidecar} generation {found} but meta generation \
+             {expected} ({crash_context}, database state inconsistent)"
+        )));
+    }
+    Ok(())
 }
 
 /// Builds an `InvalidData` I/O error for the load-time validation paths.

--- a/crates/velesdb-core/src/index/sparse/persistence.rs
+++ b/crates/velesdb-core/src/index/sparse/persistence.rs
@@ -377,47 +377,54 @@ fn build_postings_from_idx(
     let mut postings: FxHashMap<u32, (Vec<PostingEntry>, f32)> = FxHashMap::default();
 
     for te in term_entries {
-        // Untrusted lengths/offsets: do ALL bound arithmetic in u64 so a crafted
-        // `offset`/`len` cannot truncate on a 32-bit target and slip past the
-        // check below (which also caps the `Vec::with_capacity` that follows).
-        let byte_count = u64::from(te.len)
-            .checked_mul(POSTING_DISK_SIZE as u64)
-            .ok_or_else(|| {
-                Error::SparseIndexError(format!("load idx: term {} len overflow", te.term_id))
-            })?;
-        let end = te.offset.checked_add(byte_count).ok_or_else(|| {
-            Error::SparseIndexError(format!("load idx: term {} range overflow", te.term_id))
-        })?;
-
-        if end > idx_data.len() as u64 {
-            return Err(Error::SparseIndexError(format!(
-                "load idx: term {} offset {}+{byte_count} exceeds file size {}",
-                te.term_id,
-                te.offset,
-                idx_data.len()
-            )));
-        }
-        // Safe to narrow now: `end <= idx_data.len() <= usize::MAX`, so `offset` fits.
-        let start = usize::try_from(te.offset).map_err(|_| {
-            Error::SparseIndexError(format!("load idx: term {} offset too large", te.term_id))
-        })?;
-
-        let mut entries = Vec::with_capacity(te.len as usize);
-        let mut pos = start;
-        for _ in 0..te.len {
-            // We verified `end <= idx_data.len()` above, so every 12-byte window is in-bounds.
-            // read_le_u64/f32 propagate rather than panic to catch future refactor regressions.
-            let doc_id = read_le_u64(idx_data, pos, "load idx: corrupt doc_id bytes")?;
-            pos += 8;
-            let weight = read_le_f32(idx_data, pos, "load idx: corrupt weight bytes")?;
-            pos += 4;
-            entries.push(PostingEntry { doc_id, weight });
-        }
-
+        let entries = read_term_postings(idx_data, te)?;
         postings.insert(te.term_id, (entries, te.max_weight));
     }
 
     Ok(postings)
+}
+
+/// Validates an (untrusted) term's byte range against the file length and
+/// returns its start offset. All arithmetic is done in `u64` so a crafted
+/// `offset`/`len` cannot truncate on a 32-bit target and slip past the check.
+fn validate_term_range(idx_data_len: usize, te: &TermEntry) -> Result<usize> {
+    let byte_count = u64::from(te.len)
+        .checked_mul(POSTING_DISK_SIZE as u64)
+        .ok_or_else(|| {
+            Error::SparseIndexError(format!("load idx: term {} len overflow", te.term_id))
+        })?;
+    let end = te.offset.checked_add(byte_count).ok_or_else(|| {
+        Error::SparseIndexError(format!("load idx: term {} range overflow", te.term_id))
+    })?;
+
+    if end > idx_data_len as u64 {
+        return Err(Error::SparseIndexError(format!(
+            "load idx: term {} offset {}+{byte_count} exceeds file size {idx_data_len}",
+            te.term_id, te.offset,
+        )));
+    }
+    // Safe to narrow now: `end <= idx_data_len <= usize::MAX`, so `offset` fits.
+    usize::try_from(te.offset).map_err(|_| {
+        Error::SparseIndexError(format!("load idx: term {} offset too large", te.term_id))
+    })
+}
+
+/// Reads one term's posting list (`te.len` 12-byte `doc_id`/weight pairs) after
+/// validating its byte range fits within `idx_data`.
+fn read_term_postings(idx_data: &[u8], te: &TermEntry) -> Result<Vec<PostingEntry>> {
+    let start = validate_term_range(idx_data.len(), te)?;
+    let mut entries = Vec::with_capacity(te.len as usize);
+    let mut pos = start;
+    for _ in 0..te.len {
+        // The range was verified above, so every 12-byte window is in-bounds.
+        // read_le_u64/f32 propagate rather than panic to catch future regressions.
+        let doc_id = read_le_u64(idx_data, pos, "load idx: corrupt doc_id bytes")?;
+        pos += 8;
+        let weight = read_le_f32(idx_data, pos, "load idx: corrupt weight bytes")?;
+        pos += 4;
+        entries.push(PostingEntry { doc_id, weight });
+    }
+    Ok(entries)
 }
 
 #[cfg(test)]

--- a/crates/velesdb-core/src/storage/log_payload.rs
+++ b/crates/velesdb-core/src/storage/log_payload.rs
@@ -397,28 +397,7 @@ impl PayloadStorage for LogPayloadStorage {
 
         let mut reader = self.reader.write(); // Need write lock to seek
         let file_len = reader.metadata()?.len();
-        reader.seek(SeekFrom::Start(offset))?;
-
-        let mut len_bytes = [0u8; 4];
-        reader.read_exact(&mut len_bytes)?;
-        let declared = u64::from(u32::from_le_bytes(len_bytes));
-
-        // OOM guard (#897/#898): a corrupt length field must not drive an
-        // unbounded allocation. The payload cannot exceed the bytes remaining
-        // after the length field.
-        let pos_after_len = offset.saturating_add(4);
-        let remaining = file_len.saturating_sub(pos_after_len);
-        if declared > remaining {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                "payload length exceeds file size",
-            ));
-        }
-        let len = usize::try_from(declared)
-            .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "payload length overflow"))?;
-
-        let mut payload_bytes = vec![0u8; len];
-        reader.read_exact(&mut payload_bytes)?;
+        let payload_bytes = read_length_prefixed_payload(&mut *reader, offset, file_len)?;
 
         let payload = serde_json::from_slice(&payload_bytes)
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
@@ -476,4 +455,36 @@ impl PayloadStorage for LogPayloadStorage {
     fn ids(&self) -> Vec<u64> {
         self.index.read().keys().copied().collect()
     }
+}
+
+/// Reads a length-prefixed payload at `offset`: a 4-byte LE length followed by
+/// that many payload bytes. The declared length is bounded by the bytes
+/// remaining after the prefix (OOM guard #897/#898) before allocating.
+fn read_length_prefixed_payload<R: Read + Seek>(
+    reader: &mut R,
+    offset: u64,
+    file_len: u64,
+) -> io::Result<Vec<u8>> {
+    reader.seek(SeekFrom::Start(offset))?;
+
+    let mut len_bytes = [0u8; 4];
+    reader.read_exact(&mut len_bytes)?;
+    let declared = u64::from(u32::from_le_bytes(len_bytes));
+
+    // OOM guard (#897/#898): a corrupt length field must not drive an unbounded
+    // allocation. The payload cannot exceed the bytes remaining after the prefix.
+    let pos_after_len = offset.saturating_add(4);
+    let remaining = file_len.saturating_sub(pos_after_len);
+    if declared > remaining {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "payload length exceeds file size",
+        ));
+    }
+    let len = usize::try_from(declared)
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "payload length overflow"))?;
+
+    let mut payload_bytes = vec![0u8; len];
+    reader.read_exact(&mut payload_bytes)?;
+    Ok(payload_bytes)
 }

--- a/crates/velesdb-server/src/handlers/points/mod.rs
+++ b/crates/velesdb-server/src/handlers/points/mod.rs
@@ -51,24 +51,35 @@ fn convert_sparse_inputs(
     }
 
     // Named sparse vectors (overwrite default if same key).
-    // If both `sparse_vector` and `sparse_vectors[""]` are supplied, the named map wins.
-    // A debug trace is emitted so operators can detect this (usually unintentional) pattern.
     if let Some(named) = sparse_vectors {
-        for (name, sv_input) in named {
-            let sv = sv_input
-                .into_sparse_vector()
-                .map_err(|e| format!("sparse_vectors['{name}']: {e}"))?;
-            if name.is_empty() && result.contains_key("") {
-                tracing::debug!(
-                    "sparse_vector (default \"\") is being overwritten by \
-                     sparse_vectors[\"\"] — supply only one to avoid ambiguity"
-                );
-            }
-            result.insert(name, sv);
-        }
+        merge_named_sparse_vectors(named, &mut result)?;
     }
 
     Ok(Some(result))
+}
+
+/// Merge a named-sparse-vector map into `result`, converting each input.
+///
+/// If both `sparse_vector` and `sparse_vectors[""]` are supplied, the named map
+/// wins; a debug trace is emitted so operators can spot this (usually
+/// unintentional) pattern.
+fn merge_named_sparse_vectors(
+    named: std::collections::BTreeMap<String, SparseVectorInput>,
+    result: &mut std::collections::BTreeMap<String, SparseVector>,
+) -> Result<(), String> {
+    for (name, sv_input) in named {
+        let sv = sv_input
+            .into_sparse_vector()
+            .map_err(|e| format!("sparse_vectors['{name}']: {e}"))?;
+        if name.is_empty() && result.contains_key("") {
+            tracing::debug!(
+                "sparse_vector (default \"\") is being overwritten by \
+                 sparse_vectors[\"\"] — supply only one to avoid ambiguity"
+            );
+        }
+        result.insert(name, sv);
+    }
+    Ok(())
 }
 
 /// Upsert points to a collection.

--- a/crates/velesdb-server/src/handlers/query/mod.rs
+++ b/crates/velesdb-server/src/handlers/query/mod.rs
@@ -148,34 +148,33 @@ pub async fn query(
 /// `tracing::warn!` with a stable target so it is visible in CI logs and
 /// production observability.
 fn extract_mutation_collection_name(parsed: &Query) -> String {
-    if let Some(name) = extract_ddl_collection(parsed) {
-        return name;
-    }
-    if let Some(name) = extract_dml_collection(parsed) {
-        return name;
-    }
-    if let Some(ref intro) = parsed.introspection {
-        return match intro {
-            IntrospectionStatement::DescribeCollection(d) => d.name.clone(),
-            IntrospectionStatement::ShowCollections | IntrospectionStatement::Explain(_) => {
-                "_system".to_string()
-            }
-            other => warn_unknown_velesql_variant("IntrospectionStatement", other),
-        };
-    }
-    if let Some(ref admin) = parsed.admin {
-        return match admin {
-            velesdb_core::velesql::AdminStatement::Flush(f) => f
-                .collection
-                .clone()
-                .unwrap_or_else(|| "_system".to_string()),
-            other => warn_unknown_velesql_variant("AdminStatement", other),
-        };
-    }
-    if let Some(ref train) = parsed.train {
-        return train.collection.clone();
-    }
-    "_system".to_string()
+    extract_ddl_collection(parsed)
+        .or_else(|| extract_dml_collection(parsed))
+        .or_else(|| extract_introspection_collection(parsed))
+        .or_else(|| extract_admin_collection(parsed))
+        .or_else(|| parsed.train.as_ref().map(|train| train.collection.clone()))
+        .unwrap_or_else(|| "_system".to_string())
+}
+
+/// Extract collection name from an introspection statement.
+fn extract_introspection_collection(parsed: &Query) -> Option<String> {
+    parsed.introspection.as_ref().map(|intro| match intro {
+        IntrospectionStatement::DescribeCollection(d) => d.name.clone(),
+        IntrospectionStatement::ShowCollections | IntrospectionStatement::Explain(_) => {
+            "_system".to_string()
+        }
+        other => warn_unknown_velesql_variant("IntrospectionStatement", other),
+    })
+}
+
+/// Extract collection name from an admin statement.
+fn extract_admin_collection(parsed: &Query) -> Option<String> {
+    parsed.admin.as_ref().map(|admin| match admin {
+        velesdb_core::velesql::AdminStatement::Flush(f) => {
+            f.collection.clone().unwrap_or_else(|| "_system".to_string())
+        }
+        other => warn_unknown_velesql_variant("AdminStatement", other),
+    })
 }
 
 /// Extract collection name from a DDL statement.

--- a/crates/velesdb-server/src/handlers/query/mod.rs
+++ b/crates/velesdb-server/src/handlers/query/mod.rs
@@ -170,9 +170,10 @@ fn extract_introspection_collection(parsed: &Query) -> Option<String> {
 /// Extract collection name from an admin statement.
 fn extract_admin_collection(parsed: &Query) -> Option<String> {
     parsed.admin.as_ref().map(|admin| match admin {
-        velesdb_core::velesql::AdminStatement::Flush(f) => {
-            f.collection.clone().unwrap_or_else(|| "_system".to_string())
-        }
+        velesdb_core::velesql::AdminStatement::Flush(f) => f
+            .collection
+            .clone()
+            .unwrap_or_else(|| "_system".to_string()),
         other => warn_unknown_velesql_variant("AdminStatement", other),
     })
 }

--- a/crates/velesdb-server/src/handlers/search/batch.rs
+++ b/crates/velesdb-server/src/handlers/search/batch.rs
@@ -86,18 +86,24 @@ pub async fn batch_search(
         }
     };
 
+    finish_batch_search(&state, &name, start, all_results)
+}
+
+/// Record timing metrics and build the final batch response envelope.
+fn finish_batch_search(
+    state: &AppState,
+    name: &str,
+    start: std::time::Instant,
+    results: Vec<SearchResponse>,
+) -> axum::response::Response {
     let elapsed = start.elapsed();
     let timing_ms = elapsed.as_secs_f64() * 1000.0;
-    notify_query_timing(&state, &name, start);
+    notify_query_timing(state, name, start);
     state
         .query_duration_histogram
         .observe(elapsed.as_secs_f64());
 
-    Json(BatchSearchResponse {
-        results: all_results,
-        timing_ms,
-    })
-    .into_response()
+    Json(BatchSearchResponse { results, timing_ms }).into_response()
 }
 
 /// Validate that every query vector in a batch request matches the collection dimension.

--- a/crates/velesdb-server/src/handlers/search/mod.rs
+++ b/crates/velesdb-server/src/handlers/search/mod.rs
@@ -208,8 +208,10 @@ pub async fn text_search(
     let onboarding_for_work = Arc::clone(&state);
 
     let work_result = run_blocking_search(move || {
-        let filter =
-            parse_optional_filter(filter_json.as_ref(), &onboarding_for_work.onboarding_metrics)?;
+        let filter = parse_optional_filter(
+            filter_json.as_ref(),
+            &onboarding_for_work.onboarding_metrics,
+        )?;
         Ok(if let Some(f) = filter {
             collection_for_work.text_search_with_filter(&query, top_k, &f)
         } else {

--- a/crates/velesdb-server/src/handlers/search/mod.rs
+++ b/crates/velesdb-server/src/handlers/search/mod.rs
@@ -22,7 +22,7 @@ use crate::AppState;
 use super::helpers::{apply_pre_check, extract_client_id, get_vector_collection_or_404};
 use pipeline::{
     execute_search_request, finish_search_ids_with_cb, finish_search_with_cb,
-    finish_search_with_status, parse_filter_or_400, timeout_response, validate_query_dimension,
+    finish_search_with_status, parse_optional_filter, timeout_response, validate_query_dimension,
 };
 use workers::{run_blocking_search, run_search_with_optional_timeout};
 
@@ -208,13 +208,8 @@ pub async fn text_search(
     let onboarding_for_work = Arc::clone(&state);
 
     let work_result = run_blocking_search(move || {
-        let filter = match filter_json.as_ref() {
-            Some(fj) => match parse_filter_or_400(fj, &onboarding_for_work.onboarding_metrics) {
-                Ok(f) => Some(f),
-                Err(resp) => return Err(resp),
-            },
-            None => None,
-        };
+        let filter =
+            parse_optional_filter(filter_json.as_ref(), &onboarding_for_work.onboarding_metrics)?;
         Ok(if let Some(f) = filter {
             collection_for_work.text_search_with_filter(&query, top_k, &f)
         } else {
@@ -298,13 +293,7 @@ pub async fn hybrid_search(
     } = req;
 
     let work_result = run_blocking_search(move || {
-        let filter = match filter.as_ref() {
-            Some(fj) => match parse_filter_or_400(fj, &state_for_work.onboarding_metrics) {
-                Ok(f) => Some(f),
-                Err(resp) => return Err(resp),
-            },
-            None => None,
-        };
+        let filter = parse_optional_filter(filter.as_ref(), &state_for_work.onboarding_metrics)?;
         Ok(if let Some(f) = filter {
             collection_for_work.hybrid_search_with_filter(
                 &vector,

--- a/crates/velesdb-server/src/handlers/search/multi.rs
+++ b/crates/velesdb-server/src/handlers/search/multi.rs
@@ -15,6 +15,70 @@ use super::pipeline::{finish_search_with_cb, parse_filter_or_400, validate_query
 use super::workers::run_blocking_search;
 use crate::handlers::helpers::{apply_pre_check, extract_client_id, get_vector_collection_or_404};
 
+/// Parse the fusion strategy name into a `FusionStrategy`, returning a 400
+/// response (and bumping the error counter) for an unknown strategy.
+#[allow(clippy::result_large_err)]
+fn parse_fusion_strategy(
+    req: &MultiQuerySearchRequest,
+    state: &AppState,
+) -> Result<velesdb_core::FusionStrategy, axum::response::Response> {
+    use velesdb_core::FusionStrategy;
+    match req.strategy.to_lowercase().as_str() {
+        "average" | "avg" => Ok(FusionStrategy::Average),
+        "maximum" | "max" => Ok(FusionStrategy::Maximum),
+        "rrf" => Ok(FusionStrategy::RRF { k: req.rrf_k }),
+        "weighted" => Ok(FusionStrategy::Weighted {
+            avg_weight: req.avg_weight,
+            max_weight: req.max_weight,
+            hit_weight: req.hit_weight,
+        }),
+        "relative_score" | "rsf" => Ok(FusionStrategy::RelativeScore {
+            dense_weight: req.dense_weight,
+            sparse_weight: req.sparse_weight,
+        }),
+        _ => {
+            state.operational_metrics.inc_errors();
+            Err((
+                StatusCode::BAD_REQUEST,
+                Json(ErrorResponse {
+                    error: format!(
+                        "Invalid strategy: {}. Valid: average, maximum, rrf, weighted, \
+                         relative_score",
+                        req.strategy
+                    ),
+                    code: None,
+                }),
+            )
+                .into_response())
+        }
+    }
+}
+
+/// Validate every query vector's dimension, returning a 400 on the first
+/// mismatch (with the offending index in the message).
+#[allow(clippy::result_large_err)]
+fn validate_query_vectors(
+    state: &AppState,
+    name: &str,
+    expected_dimension: usize,
+    vectors: &[Vec<f32>],
+) -> Result<(), axum::response::Response> {
+    for (idx, vector) in vectors.iter().enumerate() {
+        if let Err(error) = validate_query_dimension(state, name, expected_dimension, vector) {
+            state.operational_metrics.inc_errors();
+            return Err((
+                StatusCode::BAD_REQUEST,
+                Json(ErrorResponse {
+                    error: format!("Invalid query vector at index {idx}: {}", error.error),
+                    code: error.code.clone(),
+                }),
+            )
+                .into_response());
+        }
+    }
+    Ok(())
+}
+
 /// Multi-query search with fusion strategies.
 #[utoipa::path(
     post,
@@ -35,7 +99,6 @@ pub async fn multi_query_search(
     Path(name): Path<String>,
     Json(req): Json<MultiQuerySearchRequest>,
 ) -> impl IntoResponse {
-    use velesdb_core::FusionStrategy;
     state.onboarding_metrics.record_search_request();
 
     let collection: velesdb_core::collection::VectorCollection =
@@ -54,49 +117,14 @@ pub async fn multi_query_search(
         return resp;
     }
 
-    let strategy = match req.strategy.to_lowercase().as_str() {
-        "average" | "avg" => FusionStrategy::Average,
-        "maximum" | "max" => FusionStrategy::Maximum,
-        "rrf" => FusionStrategy::RRF { k: req.rrf_k },
-        "weighted" => FusionStrategy::Weighted {
-            avg_weight: req.avg_weight,
-            max_weight: req.max_weight,
-            hit_weight: req.hit_weight,
-        },
-        "relative_score" | "rsf" => FusionStrategy::RelativeScore {
-            dense_weight: req.dense_weight,
-            sparse_weight: req.sparse_weight,
-        },
-        _ => {
-            state.operational_metrics.inc_errors();
-            return (
-                StatusCode::BAD_REQUEST,
-                Json(ErrorResponse {
-                    error: format!(
-                        "Invalid strategy: {}. Valid: average, maximum, rrf, weighted, \
-                         relative_score",
-                        req.strategy
-                    ),
-                    code: None,
-                }),
-            )
-                .into_response();
-        }
+    let strategy = match parse_fusion_strategy(&req, &state) {
+        Ok(s) => s,
+        Err(resp) => return resp,
     };
 
     let expected_dimension = collection.config().dimension;
-    for (idx, vector) in req.vectors.iter().enumerate() {
-        if let Err(error) = validate_query_dimension(&state, &name, expected_dimension, vector) {
-            state.operational_metrics.inc_errors();
-            return (
-                StatusCode::BAD_REQUEST,
-                Json(ErrorResponse {
-                    error: format!("Invalid query vector at index {idx}: {}", error.error),
-                    code: error.code.clone(),
-                }),
-            )
-                .into_response();
-        }
+    if let Err(resp) = validate_query_vectors(&state, &name, expected_dimension, &req.vectors) {
+        return resp;
     }
 
     // Parse the optional metadata filter. We need to materialise the

--- a/crates/velesdb-server/src/handlers/search/pipeline.rs
+++ b/crates/velesdb-server/src/handlers/search/pipeline.rs
@@ -41,6 +41,19 @@ pub(crate) fn parse_filter_or_400(
     })
 }
 
+/// Parse an optional metadata filter: `None` stays `None`, `Some(json)` is
+/// parsed via [`parse_filter_or_400`] (yielding a 400 response on error).
+#[allow(clippy::result_large_err)]
+pub(crate) fn parse_optional_filter(
+    filter_json: Option<&serde_json::Value>,
+    onboarding_metrics: &crate::OnboardingMetrics,
+) -> Result<Option<velesdb_core::Filter>, axum::response::Response> {
+    match filter_json {
+        Some(fj) => parse_filter_or_400(fj, onboarding_metrics).map(Some),
+        None => Ok(None),
+    }
+}
+
 pub(crate) fn dimension_mismatch_error(
     collection_name: &str,
     expected: usize,

--- a/sdks/typescript/src/client.ts
+++ b/sdks/typescript/src/client.ts
@@ -84,13 +84,16 @@ export class VelesDB {
   }
 
   private validateConfig(config: VelesDBConfig): void {
-    if (!config.backend) {
+    // Runtime guard: callers from plain JS can bypass the compile-time type,
+    // so validate `backend` as an untyped value rather than the narrowed union.
+    const backend: string | undefined = config.backend;
+    if (!backend) {
       throw new ValidationError('Backend type is required');
     }
-    if (config.backend !== 'wasm' && config.backend !== 'rest') {
-      throw new ValidationError(`Invalid backend type: ${config.backend}. Use 'wasm' or 'rest'`);
+    if (backend !== 'wasm' && backend !== 'rest') {
+      throw new ValidationError(`Invalid backend type: ${backend}. Use 'wasm' or 'rest'`);
     }
-    if (config.backend === 'rest' && !config.url) {
+    if (backend === 'rest' && !config.url) {
       throw new ValidationError('URL is required for REST backend');
     }
   }
@@ -99,10 +102,14 @@ export class VelesDB {
     switch (config.backend) {
       case 'wasm':
         return new WasmBackend();
-      case 'rest':
-        return new RestBackend(config.url!, config.apiKey, config.timeout);
+      case 'rest': {
+        if (!config.url) {
+          throw new ValidationError('URL is required for REST backend');
+        }
+        return new RestBackend(config.url, config.apiKey, config.timeout);
+      }
       default:
-        throw new ValidationError(`Unknown backend: ${config.backend}`);
+        throw new ValidationError(`Unknown backend: ${String(config.backend)}`);
     }
   }
 
@@ -169,7 +176,7 @@ export class VelesDB {
 
   async upsertBatch(collection: string, docs: VectorDocument[]): Promise<void> {
     this.ensureInitialized();
-    validateDocsBatch(docs, doc => validateDocument(doc, this.config));
+    validateDocsBatch(docs, doc => { validateDocument(doc, this.config); });
     await this.backend.upsertBatch(collection, docs);
   }
 

--- a/sdks/typescript/src/client/search-methods.ts
+++ b/sdks/typescript/src/client/search-methods.ts
@@ -153,7 +153,7 @@ export function streamInsert(
   collection: string,
   docs: VectorDocument[]
 ): Promise<void> {
-  validateDocsBatch(docs, doc => validateDocument(doc, config));
+  validateDocsBatch(docs, doc => { validateDocument(doc, config); });
   return backend.streamInsert(collection, docs);
 }
 
@@ -164,7 +164,7 @@ export function streamUpsertPoints(
   collection: string,
   docs: VectorDocument[]
 ): Promise<StreamUpsertResponse> {
-  validateDocsBatch(docs, doc => validateDocument(doc, config));
+  validateDocsBatch(docs, doc => { validateDocument(doc, config); });
   return backend.streamUpsertPoints(collection, docs);
 }
 

--- a/sdks/typescript/src/client/validation.ts
+++ b/sdks/typescript/src/client/validation.ts
@@ -38,7 +38,10 @@ export function validateDocsBatch(
 
 /** Validate a single vector document (id + vector presence). */
 export function validateDocument(doc: VectorDocument, config: VelesDBConfig): void {
-  if (doc.id === undefined || doc.id === null) {
+  // Runtime guard against untyped JS callers: the compile-time type marks
+  // `id` as required, so check it as an untyped value.
+  const id: unknown = doc.id;
+  if (id === undefined || id === null) {
     throw new ValidationError('Document ID is required');
   }
 

--- a/sdks/typescript/src/errors.ts
+++ b/sdks/typescript/src/errors.ts
@@ -367,44 +367,44 @@ export type VelesErrorCode = (typeof VELES_ERROR_CODES)[number];
  * `parseVelesError` dispatch is a single object lookup instead of a
  * 36-arm switch (lower cyclomatic complexity).
  */
-const CODE_TO_CLASS: Record<string, new (message: string) => VelesError> = {
-  'VELES-001': CollectionExistsError,
-  'VELES-002': CollectionNotFoundError,
-  'VELES-003': PointNotFoundError,
-  'VELES-004': DimensionMismatchError,
-  'VELES-005': InvalidVectorError,
-  'VELES-006': StorageError,
-  'VELES-007': IndexError,
-  'VELES-008': IndexCorruptedError,
-  'VELES-009': ConfigError,
-  'VELES-010': QueryError,
-  'VELES-011': IoError,
-  'VELES-012': SerializationError,
-  'VELES-013': InternalError,
-  'VELES-014': VectorNotAllowedError,
-  'VELES-015': SearchNotSupportedError,
-  'VELES-016': VectorRequiredError,
-  'VELES-017': SchemaValidationError,
-  'VELES-018': GraphNotSupportedError,
-  'VELES-019': EdgeExistsError,
-  'VELES-020': EdgeNotFoundError,
-  'VELES-021': InvalidEdgeLabelError,
-  'VELES-022': NodeNotFoundError,
-  'VELES-023': OverflowError,
-  'VELES-024': ColumnStoreError,
-  'VELES-025': GpuError,
-  'VELES-026': EpochMismatchError,
-  'VELES-027': GuardRailError,
-  'VELES-028': InvalidQuantizerConfigError,
-  'VELES-029': TrainingFailedError,
-  'VELES-030': SparseIndexError,
-  'VELES-031': DatabaseLockedError,
-  'VELES-032': InvalidDimensionError,
-  'VELES-033': AllocationFailedError,
-  'VELES-034': InvalidCollectionNameError,
-  'VELES-035': SnapshotBuildFailedError,
-  'VELES-036': IncompatibleSchemaVersionError,
-};
+const CODE_TO_CLASS = new Map<string, new (message: string) => VelesError>([
+  ['VELES-001', CollectionExistsError],
+  ['VELES-002', CollectionNotFoundError],
+  ['VELES-003', PointNotFoundError],
+  ['VELES-004', DimensionMismatchError],
+  ['VELES-005', InvalidVectorError],
+  ['VELES-006', StorageError],
+  ['VELES-007', IndexError],
+  ['VELES-008', IndexCorruptedError],
+  ['VELES-009', ConfigError],
+  ['VELES-010', QueryError],
+  ['VELES-011', IoError],
+  ['VELES-012', SerializationError],
+  ['VELES-013', InternalError],
+  ['VELES-014', VectorNotAllowedError],
+  ['VELES-015', SearchNotSupportedError],
+  ['VELES-016', VectorRequiredError],
+  ['VELES-017', SchemaValidationError],
+  ['VELES-018', GraphNotSupportedError],
+  ['VELES-019', EdgeExistsError],
+  ['VELES-020', EdgeNotFoundError],
+  ['VELES-021', InvalidEdgeLabelError],
+  ['VELES-022', NodeNotFoundError],
+  ['VELES-023', OverflowError],
+  ['VELES-024', ColumnStoreError],
+  ['VELES-025', GpuError],
+  ['VELES-026', EpochMismatchError],
+  ['VELES-027', GuardRailError],
+  ['VELES-028', InvalidQuantizerConfigError],
+  ['VELES-029', TrainingFailedError],
+  ['VELES-030', SparseIndexError],
+  ['VELES-031', DatabaseLockedError],
+  ['VELES-032', InvalidDimensionError],
+  ['VELES-033', AllocationFailedError],
+  ['VELES-034', InvalidCollectionNameError],
+  ['VELES-035', SnapshotBuildFailedError],
+  ['VELES-036', IncompatibleSchemaVersionError],
+]);
 
 /**
  * Instantiate the correct typed error class from a server-provided
@@ -429,7 +429,7 @@ export function parseVelesError(
   if (code === null || code === undefined) {
     return new VelesError(message, 'VELES-UNKNOWN');
   }
-  const Cls = CODE_TO_CLASS[code];
+  const Cls = CODE_TO_CLASS.get(code);
   if (Cls !== undefined) {
     return new Cls(message);
   }

--- a/sdks/typescript/src/filter.ts
+++ b/sdks/typescript/src/filter.ts
@@ -130,13 +130,16 @@ export type FilterInput = Filter | Record<string, unknown>;
  * — use TypeScript's compile-time checking for that.
  */
 export function isTypedFilter(input: FilterInput): input is Filter {
-  if (typeof input !== 'object' || input === null) {
+  // Inspect as an untyped value: callers from plain JS may pass shapes the
+  // compile-time `FilterInput` union does not cover.
+  const value: unknown = input;
+  if (typeof value !== 'object' || value === null) {
     return false;
   }
-  if (!('condition' in input)) {
+  if (!('condition' in value)) {
     return false;
   }
-  const cond = (input as { condition: unknown }).condition;
+  const cond = (value as { condition: unknown }).condition;
   return typeof cond === 'object' && cond !== null;
 }
 

--- a/sdks/typescript/src/query-builder.ts
+++ b/sdks/typescript/src/query-builder.ts
@@ -431,21 +431,18 @@ export class VelesQLBuilder {
   }
 
   private buildWhereClause(): string {
-    if (this.state.whereClauses.length === 0) return '';
-    
-    const first = this.state.whereClauses[0];
-    if (!first) return '';
-    
-    let result = first;
-    
-    for (let i = 1; i < this.state.whereClauses.length; i++) {
-      const operator = this.state.whereOperators[i - 1] ?? 'AND';
-      const clause = this.state.whereClauses[i];
+    let result = '';
+    for (const [idx, clause] of this.state.whereClauses.entries()) {
+      if (idx === 0) {
+        if (!clause) return '';
+        result = clause;
+        continue;
+      }
+      const operator = this.state.whereOperators[idx - 1] ?? 'AND';
       if (clause) {
         result += ` ${operator} ${clause}`;
       }
     }
-    
     return result;
   }
 }

--- a/sdks/typescript/src/types/query.ts
+++ b/sdks/typescript/src/types/query.ts
@@ -43,8 +43,8 @@ export interface ColumnStatsDetail {
   name: string;
   nullCount: number;
   distinctCount: number;
-  minValue: unknown | null;
-  maxValue: unknown | null;
+  minValue: unknown;
+  maxValue: unknown;
   avgSizeBytes: number;
   histogramBuckets: number | null;
   histogramStale: boolean | null;


### PR DESCRIPTION
## Objectif
Atteindre le **grade A** Codacy en résolvant les **90 findings** de `main`@eb7a17a3.
Approche : **vrais fixes de code** partout où c'est propre/sûr ; **exclusion documentée** (cohérente avec la politique déjà en place dans `.codacy.yml`) pour les FP avérés et la complexité inhérente.

## Récapitulatif par groupe

| Groupe | Findings | Traitement |
|--------|----------|-----------|
| **A** tauri guest-js | 36 | **Refactor** : `async` inutile retiré + générique `<void>` supprimé |
| **C** SDK TypeScript | 19 | **13 fixes code** (Record→Map, widening, braces, `.entries()`, `unknown`) + 5 FP `no-unused-vars` type-signature exclus |
| **D** unsafe / tests | 6 | **Fix glob** (tests src-root) + exclusion mmap audité (SAFETY présent) |
| **B** Lizard complexité | 29 | **14 refactorés** (8 handlers serveur + 6 méthodes core) + reste exclu (chained-`?`, fusion-fn, dispatch plat, traversées, param-count, file-NLOC, Python framework) |

## Vérifications locales (toutes vertes)
- `tsc --noEmit` + `eslint` + `vitest` (31 fichiers / **728 tests**) sur le SDK ; `tsup` build sur guest-js.
- `cargo clippy --workspace … -D warnings -D clippy::pedantic` (hors velesdb-python).
- `cargo test -p velesdb-core` (36 suites) + `cargo test -p velesdb-server` (~278) + **`test_recall_thresholds` OK** (gate recall@10 ≥ 0.95).
- `cargo fmt --all`, feature-gates (`-p velesdb-core --no-default-features`, wasm32).

## Note méthodo
Les exclusions Lizard/opengrep ajoutées suivent la pratique documentée du repo (cf. `backend_adapter.rs`, `query_engine.rs`, `traversal.rs`, `execution_paths.rs`). Le bug de glob `src/**/*_tests.rs` (ratait les tests à la racine de `src/`) est corrigé — cause des findings unsafe résiduels sur les `*_tests.rs`.

Le grade A définitif se mesure après merge + ré-analyse de `main` par Codacy.
