### PR TITLE
fix(readme): repair quality/coverage/test badges + enable coverage refresh

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,10 @@ on:
       - 'Cargo.lock'
       - 'sonar-project.properties'
       - '.github/workflows/**'
+  # Manual trigger so coverage can be refreshed on demand (e.g. after a
+  # config-only commit to main that skipped the path-filtered CI, leaving the
+  # Codacy coverage badge stale).
+  workflow_dispatch:
 
 # Annuler les runs précédents pour la même branche/PR
 concurrency:
@@ -384,7 +388,7 @@ jobs:
     # llvm-cov + gpu features runs well within this.
     timeout-minutes: 45
     needs: test
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 

--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@
 </p>
 <p align="center">
   <a href="https://github.com/cyberlife-coder/VelesDB/actions/workflows/ci.yml"><img src="https://github.com/cyberlife-coder/VelesDB/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <a href="https://app.codacy.com/gh/cyberlife-coder/VelesDB/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade"><img src="https://app.codacy.com/project/badge/Grade/58c73832dd294ba38144856ae69e9cf2" alt="Codacy Badge"></a>
+  <a href="https://app.codacy.com/gh/cyberlife-coder/VelesDB/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade"><img src="https://img.shields.io/codacy/grade/58c73832dd294ba38144856ae69e9cf2?branch=main&label=code%20quality" alt="Codacy code quality"></a>
   <a href="https://crates.io/crates/velesdb-core"><img src="https://img.shields.io/crates/v/velesdb-core.svg" alt="Crates.io"></a>
   <a href="https://crates.io/crates/velesdb-core"><img src="https://img.shields.io/crates/d/velesdb-core.svg" alt="Crates.io Downloads"></a>
   <a href="https://pypi.org/project/velesdb/"><img src="https://img.shields.io/pypi/v/velesdb.svg" alt="PyPI"></a>
   <a href="https://www.npmjs.com/package/@wiscale/velesdb-sdk"><img src="https://img.shields.io/npm/v/@wiscale/velesdb-sdk.svg" alt="npm"></a>
-  <a href="https://app.codacy.com/gh/cyberlife-coder/VelesDB/dashboard"><img src="https://app.codacy.com/project/badge/Coverage/58c73832dd294ba38144856ae69e9cf2" alt="Coverage"></a>
-  <img src="https://img.shields.io/badge/tests-7634_(Rust%2BTS%2BPy)-brightgreen" alt="Tests">
+  <a href="https://app.codacy.com/gh/cyberlife-coder/VelesDB/dashboard"><img src="https://img.shields.io/codacy/coverage/58c73832dd294ba38144856ae69e9cf2?branch=main" alt="Codacy coverage"></a>
+  <img src="https://img.shields.io/badge/tests-8526_(Rust%2BTS%2BPy)-brightgreen" alt="Tests">
   <a href="https://github.com/cyberlife-coder/VelesDB/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-VelesDB_Core_1.0-blue" alt="License"></a>
   <a href="https://github.com/cyberlife-coder/VelesDB"><img src="https://img.shields.io/github/stars/cyberlife-coder/VelesDB?style=flat-square" alt="Stars"></a>
   <a href="https://img.shields.io/badge/contributors-welcome-brightgreen"><img src="https://img.shields.io/badge/contributors-welcome-brightgreen" alt="Contributors Welcome"></a>


### PR DESCRIPTION
## Problème
Les widgets de qualité du README s'affichaient **vides ou périmés** :
- **Badge Codacy Grade** : le SVG hébergé par `app.codacy.com` ne contient **aucune lettre de grade** (rend blanc).
- **Badge Codacy Coverage** : même problème de SVG vide.
- **Badge Tests** : `7634` codé en dur, périmé.

## Correctifs
- **Grade** → `img.shields.io/codacy/grade/...` → rend **« code quality: A »** ✅
- **Coverage** → `img.shields.io/codacy/coverage/...` (rendu fiable). L'upload Codacy **est déjà câblé et fonctionne** (vérifié : `codacy-coverage-reporter` → « Coverage received successfully » sur le push `ead68f9c`). Le 0% actuel vient du HEAD `05cae8db` (commit config-only que la CI path-filtrée a sauté → pas d'upload pour ce commit). **Le merge de cette PR touche `.github/workflows/**` (dans le filtre)** → la CI post-merge relance le job coverage et rafraîchit le badge.
- **Tests** : recompté par déclaration — Rust `#[test]`/`#[tokio::test]` 7426 + TS `it/test` 603 + Py `def test_` 497 = **8526** (conservateur ; les cas paramétrés gonflent le réel). Badge mis à jour.
- **`workflow_dispatch`** ajouté + job coverage autorisé dessus → la couverture peut être rafraîchie à la demande après un futur commit config-only.

Config/doc-only, aucun changement de code runtime.
