### PR TITLE
refactor(fusion): port RSF/min-max simplification to main (from #948)

### DIFF
--- a/crates/velesdb-core/src/fusion/strategy.rs
+++ b/crates/velesdb-core/src/fusion/strategy.rs
@@ -333,17 +333,16 @@ impl FusionStrategy {
         let norm_dense = min_max_normalize(dense);
         let norm_sparse = min_max_normalize(sparse);
 
-        // Collect all doc IDs
-        let mut all_ids: HashMap<u64, f32> = HashMap::new();
+        // Collect all doc IDs — capacity upper-bounds total unique docs.
+        let mut all_ids: HashMap<u64, f32> =
+            HashMap::with_capacity(norm_dense.len() + norm_sparse.len());
         for (&id, &nd) in &norm_dense {
             let ns = norm_sparse.get(&id).copied().unwrap_or(0.0);
             all_ids.insert(id, dense_weight * nd + sparse_weight * ns);
         }
+        // For sparse-only IDs (not in norm_dense), dense contribution is 0.
         for (&id, &ns) in &norm_sparse {
-            all_ids.entry(id).or_insert_with(|| {
-                let nd = norm_dense.get(&id).copied().unwrap_or(0.0);
-                dense_weight * nd + sparse_weight * ns
-            });
+            all_ids.entry(id).or_insert(sparse_weight * ns);
         }
 
         let mut fused: Vec<(u64, f32)> = all_ids.into_iter().collect();
@@ -387,21 +386,21 @@ fn min_max_normalize(branch: &[(u64, f32)]) -> HashMap<u64, f32> {
     if branch.is_empty() {
         return HashMap::new();
     }
-    let min = branch.iter().map(|&(_, s)| s).fold(f32::INFINITY, f32::min);
-    let max = branch
+    // Single pass to find both min and max.
+    let (min, max) = branch
         .iter()
-        .map(|&(_, s)| s)
-        .fold(f32::NEG_INFINITY, f32::max);
+        .fold((f32::INFINITY, f32::NEG_INFINITY), |(lo, hi), &(_, s)| {
+            (lo.min(s), hi.max(s))
+        });
     let range = max - min;
-    branch
-        .iter()
-        .map(|&(id, s)| {
-            let norm = if range < f32::EPSILON {
-                0.5
-            } else {
-                (s - min) / range
-            };
-            (id, norm)
-        })
-        .collect()
+    let mut out = HashMap::with_capacity(branch.len());
+    for &(id, s) in branch {
+        let norm = if range < f32::EPSILON {
+            0.5
+        } else {
+            (s - min) / range
+        };
+        out.insert(id, norm);
+    }
+    out
 }

--- a/crates/velesdb-core/tests/property_index_e2e_tests.rs
+++ b/crates/velesdb-core/tests/property_index_e2e_tests.rs
@@ -497,7 +497,7 @@ fn test_match_where_range_filter_gt() {
 /// GIVEN: Graph collection with nodes having different labels
 /// WHEN:  MATCH filters by label (n:Person)
 /// THEN:  Only Person-labeled nodes are used as start nodes
-/// This tests that the `LabelIndex` in `store_node_payload` is auto-populated.
+/// This tests that the `LabelIndex` in `upsert_node_payload` is auto-populated.
 #[test]
 fn test_label_index_auto_populated_on_insert() {
     let (_dir, _db, gc) = setup_graph_db();


### PR DESCRIPTION
Porte sur `main` (donc dans 1.16.0) le refactor fusion mergé dans `develop` via #948.

## Pourquoi
#948 ne touchait que `develop` (1.15.0). `main`'s `fusion/strategy.rs` était **identique au parent de #948** → les changements s'appliquent proprement. Souhaité dans 1.16.0.

## Contenu (refactor, pas de changement fonctionnel)
- **RSF combine** : pré-dimensionne le HashMap fusionné (capacité = dense+sparse) et supprime le `or_insert_with` redondant sur la branche sparse-only (les IDs sparse-only ont une contribution dense nulle par construction — équivalent).
- **min_max_normalize** : min et max calculés en un seul `fold`.
- 1 commentaire de test : `store_node_payload` → `upsert_node_payload` (annotation périmée).

La partie `migrate/pipeline.rs` de #948 est **omise** (le `#[allow(deprecated)]` retiré n'existe plus dans le pipeline.rs de main).

## Validation locale (chemin search → recall)
- Tests RSF/fusion strategy ✅, hybrid-search (12 tests) ✅, **suite recall (55+7 tests dont `test_recall_thresholds`)** ✅
- `clippy --workspace -D pedantic` clean
- La CI re-valide (gate **Recall ≥ 0.95**).
