### PR TITLE
refactor(integrations): kill file-grade duplication (security/scroll/multi-query)

### DIFF
--- a/integrations/common/src/velesdb_common/scroll.py
+++ b/integrations/common/src/velesdb_common/scroll.py
@@ -1,0 +1,68 @@
+"""Shared cursor-paginated scroll helper for the framework integrations.
+
+Both ``langchain_velesdb`` and ``llamaindex_velesdb`` expose a ``scroll()``
+mixin that returns framework-specific objects (LangChain ``Document`` /
+LlamaIndex ``TextNode``).  The underlying batch-pull against a raw
+``velesdb.Collection`` is framework-agnostic and lives here so the two
+integrations don't duplicate it.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+
+def scroll_one_batch(
+    collection: Any,
+    cursor: Optional[int],
+    batch_size: int,
+    filter: Optional[dict] = None,  # pylint: disable=redefined-builtin  # public API kwarg name, cannot rename without breaking callers
+) -> tuple:
+    """Pull one batch from a velesdb Collection using its scroll iterator.
+
+    Creates a fresh ``collection.scroll()`` iterator on every call and skips
+    batches until the one past *cursor* is found.
+
+    .. warning::
+        **Complexity: O(page_index * batch_size)** — this function re-scans
+        from the beginning of the collection on each call because the native
+        SDK does not yet expose a cursor-based ``scroll_batch`` method at the
+        Python level (the Rust ``VectorCollection.scroll_batch`` method is
+        internal to the ``ScrollIterator`` PyO3 class).  For large collections
+        with many pages, callers should either:
+
+        * keep the ``ScrollIterator`` alive across calls (use
+          ``collection.scroll(batch_size=N)`` as a Python generator and drive
+          it with ``next()``), or
+        * wait for a future ``Collection.scroll_batch(cursor, batch_size)``
+          Python binding that will provide true O(1) cursor seek.
+
+    Args:
+        collection: A ``velesdb.Collection`` instance.
+        cursor: Last-seen integer point ID from the previous call, or ``None``.
+        batch_size: Maximum points to return.
+        filter: Optional payload filter dict forwarded to the SDK (omitted when
+            ``None`` so backends that don't accept it stay unaffected).
+
+    Returns:
+        A ``(points, next_cursor)`` tuple.  *points* is a list of raw dicts
+        with ``"id"``, ``"vector"``, and ``"payload"`` keys; *next_cursor* is
+        the last point ID (``int``) or ``None`` when the collection is
+        exhausted.
+    """
+    scroll_kwargs: dict = {"batch_size": batch_size}
+    if filter is not None:
+        scroll_kwargs["filter"] = filter
+
+    iterator = collection.scroll(**scroll_kwargs)
+    for batch in iterator:
+        if not batch:
+            continue
+        last_id = batch[-1].get("id")
+        if cursor is not None and last_id is not None and last_id <= cursor:
+            continue
+        return batch, (int(last_id) if last_id is not None else None)
+    return [], None
+
+
+__all__ = ["scroll_one_batch"]

--- a/integrations/common/src/velesdb_common/security.py
+++ b/integrations/common/src/velesdb_common/security.py
@@ -501,3 +501,37 @@ def validate_sparse_vector(sparse_vector: Any) -> dict:
     for key, value in sparse_vector.items():
         _validate_sparse_entry(key, value)
     return sparse_vector
+
+
+# Public API surface — re-exported verbatim by the framework shim modules
+# (langchain_velesdb.security / llamaindex_velesdb.security) via
+# ``from velesdb_common.security import *``.
+__all__ = [
+    "ALLOWED_STORAGE_MODES",
+    "STORAGE_MODE_ALIASES",
+    "DEFAULT_TIMEOUT_MS",
+    "MAX_BATCH_SIZE",
+    "MAX_DIMENSION",
+    "MAX_K_VALUE",
+    "MAX_PATH_LENGTH",
+    "MAX_QUERY_LENGTH",
+    "MAX_SPARSE_VECTOR_SIZE",
+    "MAX_TEXT_LENGTH",
+    "MIN_DIMENSION",
+    "SecurityError",
+    "validate_batch_size",
+    "validate_collection_name",
+    "validate_column_name",
+    "validate_dimension",
+    "validate_k",
+    "validate_metric",
+    "validate_path",
+    "validate_query",
+    "validate_search_quality",
+    "validate_sparse_vector",
+    "validate_storage_mode",
+    "validate_text",
+    "validate_timeout",
+    "validate_url",
+    "validate_weight",
+]

--- a/integrations/langchain/src/langchain_velesdb/multi_query_ops.py
+++ b/integrations/langchain/src/langchain_velesdb/multi_query_ops.py
@@ -117,16 +117,8 @@ class MultiQueryOpsMixin:
         k: int = 4,
         **kwargs: Any,
     ) -> List[List[Tuple[Document, float]]]:
-        """Batch search with scores for multiple queries.
-
-        Args:
-            queries: List of query strings.
-            k: Number of results per query. Defaults to 4.
-            **kwargs: Additional arguments.
-
-        Returns:
-            List of (Document, score) tuple lists, one per query.
-        """
+        """Like :meth:`batch_search` but each result is a ``(Document, score)``
+        tuple instead of a bare ``Document``."""
         if not queries:
             return []
         return [_results_to_docs_with_score(r) for r in self._run_batch_search(queries, k)]
@@ -207,19 +199,8 @@ class MultiQueryOpsMixin:
         filter: Optional[dict] = None,  # pylint: disable=redefined-builtin  # public API kwarg name, cannot rename without breaking callers
         **kwargs: Any,
     ) -> List[Tuple[Document, float]]:
-        """Multi-query search with fused scores.
-
-        Args:
-            queries: List of query strings.
-            k: Number of results. Defaults to 4.
-            fusion: Fusion strategy. Defaults to "rrf".
-            fusion_params: Optional fusion parameters.
-            filter: Optional metadata filter.
-            **kwargs: Additional arguments.
-
-        Returns:
-            List of (Document, fused_score) tuples.
-        """
+        """Like :meth:`multi_query_search` but each result is a
+        ``(Document, fused_score)`` tuple instead of a bare ``Document``."""
         if not queries:
             return []
         results = self._run_multi_query(queries, k, fusion, fusion_params, query_filter=filter)

--- a/integrations/langchain/src/langchain_velesdb/scroll_ops.py
+++ b/integrations/langchain/src/langchain_velesdb/scroll_ops.py
@@ -6,63 +6,12 @@ Extracted from ``vectorstore.py`` to keep each file under the 500 NLOC limit.
 from __future__ import annotations
 
 import logging
-from typing import Any, List, Optional
+from typing import List, Optional
 
 from langchain_core.documents import Document
+from velesdb_common.scroll import scroll_one_batch
 
 logger = logging.getLogger(__name__)
-
-
-def _scroll_one_batch(
-    collection: Any,
-    cursor: Optional[int],
-    batch_size: int,
-    filter: Optional[dict],  # pylint: disable=redefined-builtin  # public API kwarg name, cannot rename without breaking callers
-) -> tuple:
-    """Pull one batch from a velesdb Collection using its scroll iterator.
-
-    Creates a fresh ``collection.scroll()`` iterator on every call and skips
-    batches until the one past *cursor* is found.
-
-    .. warning::
-        **Complexity: O(page_index * batch_size)** — this function re-scans
-        from the beginning of the collection on each call because the native
-        SDK does not yet expose a cursor-based ``scroll_batch`` method at the
-        Python level (the Rust ``VectorCollection.scroll_batch`` method is
-        internal to the ``ScrollIterator`` PyO3 class).  For large collections
-        with many pages, callers should either:
-
-        * keep the ``ScrollIterator`` alive across calls (use
-          ``collection.scroll(batch_size=N)`` as a Python generator and drive
-          it with ``next()``), or
-        * wait for a future ``Collection.scroll_batch(cursor, batch_size)``
-          Python binding that will provide true O(1) cursor seek.
-
-    Args:
-        collection: A ``velesdb.Collection`` instance.
-        cursor: Last-seen integer point ID from the previous call, or ``None``.
-        batch_size: Maximum points to return.
-        filter: Optional payload filter dict forwarded to the SDK.
-
-    Returns:
-        A ``(points, next_cursor)`` tuple.  *points* is a list of raw dicts
-        with ``"id"``, ``"vector"``, and ``"payload"`` keys; *next_cursor* is
-        the last point ID (``int``) or ``None`` when the collection is
-        exhausted.
-    """
-    scroll_kwargs: dict = {"batch_size": batch_size}
-    if filter is not None:
-        scroll_kwargs["filter"] = filter
-
-    iterator = collection.scroll(**scroll_kwargs)
-    for batch in iterator:
-        if not batch:
-            continue
-        last_id = batch[-1].get("id")
-        if cursor is not None and last_id is not None and last_id <= cursor:
-            continue
-        return batch, (int(last_id) if last_id is not None else None)
-    return [], None
 
 
 class ScrollOpsMixin:
@@ -106,7 +55,7 @@ class ScrollOpsMixin:
         """
         if self._collection is None:  # type: ignore[attr-defined]
             return [], None
-        raw_batch, next_cursor = _scroll_one_batch(
+        raw_batch, next_cursor = scroll_one_batch(
             self._collection, cursor, batch_size, filter  # type: ignore[attr-defined]
         )
         docs: List[Document] = [self._to_document(pt) for pt in raw_batch]  # type: ignore[attr-defined]

--- a/integrations/langchain/src/langchain_velesdb/scroll_ops.py
+++ b/integrations/langchain/src/langchain_velesdb/scroll_ops.py
@@ -9,7 +9,11 @@ import logging
 from typing import List, Optional
 
 from langchain_core.documents import Document
-from velesdb_common.scroll import scroll_one_batch
+
+# Imported under the historical private name: ``vectorstore`` re-exports it and
+# the parity tests import/monkeypatch it. Implementation lives in
+# velesdb_common.scroll (shared with the LlamaIndex integration).
+from velesdb_common.scroll import scroll_one_batch as _scroll_one_batch
 
 logger = logging.getLogger(__name__)
 
@@ -55,7 +59,7 @@ class ScrollOpsMixin:
         """
         if self._collection is None:  # type: ignore[attr-defined]
             return [], None
-        raw_batch, next_cursor = scroll_one_batch(
+        raw_batch, next_cursor = _scroll_one_batch(
             self._collection, cursor, batch_size, filter  # type: ignore[attr-defined]
         )
         docs: List[Document] = [self._to_document(pt) for pt in raw_batch]  # type: ignore[attr-defined]

--- a/integrations/langchain/src/langchain_velesdb/security.py
+++ b/integrations/langchain/src/langchain_velesdb/security.py
@@ -1,70 +1,9 @@
 """Security utilities for the LangChain VelesDB integration.
 
-All validation logic lives in ``velesdb_common.security``.  This module
-re-exports every public name so that existing ``from langchain_velesdb.security
-import ...`` call-sites continue to work without modification.
+All validation logic lives in :mod:`velesdb_common.security`; this module
+re-exports its public surface so that existing
+``from langchain_velesdb.security import ...`` call-sites keep working.
 """
 
-from velesdb_common.security import (  # pylint: disable=unused-import  # public re-exports declared in __all__ below
-    ALLOWED_STORAGE_MODES,
-    STORAGE_MODE_ALIASES,
-    DEFAULT_TIMEOUT_MS,
-    MAX_BATCH_SIZE,
-    MAX_DIMENSION,
-    MAX_K_VALUE,
-    MAX_PATH_LENGTH,
-    MAX_QUERY_LENGTH,
-    MAX_SPARSE_VECTOR_SIZE,
-    MAX_TEXT_LENGTH,
-    MIN_DIMENSION,
-    SecurityError,
-    validate_batch_size,
-    validate_collection_name,
-    validate_column_name,
-    validate_dimension,
-    validate_k,
-    validate_metric,
-    validate_path,
-    validate_query,
-    validate_search_quality,
-    validate_sparse_vector,
-    validate_storage_mode,
-    validate_text,
-    validate_timeout,
-    validate_url,
-    validate_weight,
-)
-
-# Explicit re-export list. Declaring ``__all__`` tells both pylint
-# (W0611 unused-import) and flake8 (F401) that every imported name is
-# part of the public surface of this shim module, removing the need for
-# per-line ``# noqa`` markers.
-__all__ = [
-    "ALLOWED_STORAGE_MODES",
-    "STORAGE_MODE_ALIASES",
-    "DEFAULT_TIMEOUT_MS",
-    "MAX_BATCH_SIZE",
-    "MAX_DIMENSION",
-    "MAX_K_VALUE",
-    "MAX_PATH_LENGTH",
-    "MAX_QUERY_LENGTH",
-    "MAX_SPARSE_VECTOR_SIZE",
-    "MAX_TEXT_LENGTH",
-    "MIN_DIMENSION",
-    "SecurityError",
-    "validate_batch_size",
-    "validate_collection_name",
-    "validate_column_name",
-    "validate_dimension",
-    "validate_k",
-    "validate_metric",
-    "validate_path",
-    "validate_query",
-    "validate_search_quality",
-    "validate_sparse_vector",
-    "validate_storage_mode",
-    "validate_text",
-    "validate_timeout",
-    "validate_url",
-    "validate_weight",
-]
+from velesdb_common.security import *  # noqa: F401,F403  # public re-export shim
+from velesdb_common.security import __all__  # noqa: F401  # mirror the public surface

--- a/integrations/llamaindex/src/llamaindex_velesdb/scroll_ops.py
+++ b/integrations/llamaindex/src/llamaindex_velesdb/scroll_ops.py
@@ -6,57 +6,12 @@ Extracted from ``vectorstore.py`` to keep each file under the 500 NLOC limit.
 from __future__ import annotations
 
 import logging
-from typing import Any, List, Optional
+from typing import List, Optional
 
 from llama_index.core.schema import TextNode
+from velesdb_common.scroll import scroll_one_batch
 
 logger = logging.getLogger(__name__)
-
-
-def _scroll_one_batch(
-    collection: Any,
-    cursor: Optional[int],
-    batch_size: int,
-) -> tuple:
-    """Pull one batch from a velesdb Collection using its scroll iterator.
-
-    Creates a fresh ``collection.scroll()`` iterator on every call and skips
-    batches until the one past *cursor* is found.
-
-    .. warning::
-        **Complexity: O(page_index * batch_size)** — this function re-scans
-        from the beginning of the collection on each call because the native
-        SDK does not yet expose a cursor-based ``scroll_batch`` method at the
-        Python level (the Rust ``VectorCollection.scroll_batch`` method is
-        internal to the ``ScrollIterator`` PyO3 class).  For large collections
-        with many pages, callers should either:
-
-        * keep the ``ScrollIterator`` alive across calls (use
-          ``collection.scroll(batch_size=N)`` as a Python generator and drive
-          it with ``next()``), or
-        * wait for a future ``Collection.scroll_batch(cursor, batch_size)``
-          Python binding that will provide true O(1) cursor seek.
-
-    Args:
-        collection: A ``velesdb.Collection`` instance.
-        cursor: Last-seen integer point ID from the previous call, or ``None``.
-        batch_size: Maximum points to return.
-
-    Returns:
-        A ``(points, next_cursor)`` tuple.  *points* is a list of raw dicts
-        with ``"id"``, ``"vector"``, and ``"payload"`` keys; *next_cursor* is
-        the last point ID (``int``) or ``None`` when the collection is
-        exhausted.
-    """
-    iterator = collection.scroll(batch_size=batch_size)
-    for batch in iterator:
-        if not batch:
-            continue
-        last_id = batch[-1].get("id")
-        if cursor is not None and last_id is not None and last_id <= cursor:
-            continue
-        return batch, (int(last_id) if last_id is not None else None)
-    return [], None
 
 
 class ScrollOpsMixin:
@@ -98,7 +53,7 @@ class ScrollOpsMixin:
         """
         if self._collection is None:  # type: ignore[attr-defined]
             return [], None
-        raw_batch, next_cursor = _scroll_one_batch(
+        raw_batch, next_cursor = scroll_one_batch(
             self._collection, cursor, batch_size  # type: ignore[attr-defined]
         )
         nodes: List[TextNode] = [

--- a/integrations/llamaindex/src/llamaindex_velesdb/scroll_ops.py
+++ b/integrations/llamaindex/src/llamaindex_velesdb/scroll_ops.py
@@ -9,7 +9,11 @@ import logging
 from typing import List, Optional
 
 from llama_index.core.schema import TextNode
-from velesdb_common.scroll import scroll_one_batch
+
+# Imported under the historical private name: ``vectorstore`` re-exports it and
+# the scroll tests import/monkeypatch it. Implementation lives in
+# velesdb_common.scroll (shared with the LangChain integration).
+from velesdb_common.scroll import scroll_one_batch as _scroll_one_batch
 
 logger = logging.getLogger(__name__)
 
@@ -53,7 +57,7 @@ class ScrollOpsMixin:
         """
         if self._collection is None:  # type: ignore[attr-defined]
             return [], None
-        raw_batch, next_cursor = scroll_one_batch(
+        raw_batch, next_cursor = _scroll_one_batch(
             self._collection, cursor, batch_size  # type: ignore[attr-defined]
         )
         nodes: List[TextNode] = [

--- a/integrations/llamaindex/src/llamaindex_velesdb/security.py
+++ b/integrations/llamaindex/src/llamaindex_velesdb/security.py
@@ -1,71 +1,9 @@
 """Security utilities for the LlamaIndex VelesDB integration.
 
-All validation logic lives in ``velesdb_common.security``.  This module
-re-exports every public name so that existing ``from llamaindex_velesdb.security
-import ...`` call-sites continue to work without modification.
+All validation logic lives in :mod:`velesdb_common.security`; this module
+re-exports its public surface so that existing
+``from llamaindex_velesdb.security import ...`` call-sites keep working.
 """
 
-from velesdb_common.security import (  # pylint: disable=unused-import  # public re-exports declared in __all__ below
-    ALLOWED_STORAGE_MODES,
-    STORAGE_MODE_ALIASES,
-    DEFAULT_TIMEOUT_MS,
-    MAX_BATCH_SIZE,
-    MAX_DIMENSION,
-    MAX_K_VALUE,
-    MAX_PATH_LENGTH,
-    MAX_QUERY_LENGTH,
-    MAX_SPARSE_VECTOR_SIZE,
-    MAX_TEXT_LENGTH,
-    MIN_DIMENSION,
-    SecurityError,
-    validate_batch_size,
-    validate_collection_name,
-    validate_column_name,
-    validate_dimension,
-    validate_k,
-    validate_metric,
-    validate_path,
-    validate_query,
-    validate_search_quality,
-    validate_sparse_vector,
-    validate_storage_mode,
-    validate_text,
-    validate_timeout,
-    validate_url,
-    validate_weight,
-)
-
-# Explicit re-export list. Declaring ``__all__`` tells both pylint
-# (W0611 unused-import) and flake8 (F401) that every imported name is
-# part of the public surface of this shim module, removing the need for
-# per-line ``# noqa`` markers.
-__all__ = [
-    "ALLOWED_STORAGE_MODES",
-    "STORAGE_MODE_ALIASES",
-    "DEFAULT_TIMEOUT_MS",
-    "MAX_BATCH_SIZE",
-    "MAX_DIMENSION",
-    "MAX_K_VALUE",
-    "MAX_PATH_LENGTH",
-    "MAX_QUERY_LENGTH",
-    "MAX_SPARSE_VECTOR_SIZE",
-    "MAX_TEXT_LENGTH",
-    "MIN_DIMENSION",
-    "SecurityError",
-    "validate_batch_size",
-    "validate_collection_name",
-    "validate_column_name",
-    "validate_dimension",
-    "validate_k",
-    "validate_metric",
-    "validate_path",
-    "validate_query",
-    "validate_search_quality",
-    "validate_sparse_vector",
-    "validate_storage_mode",
-    "validate_text",
-    "validate_timeout",
-    "validate_url",
-    "validate_weight",
-]
-
+from velesdb_common.security import *  # noqa: F401,F403  # public re-export shim
+from velesdb_common.security import __all__  # noqa: F401  # mirror the public surface


### PR DESCRIPTION
Première vague vers le **grade A par fichier** (le repo est déjà grade A ; ces fichiers étaient B/D à cause de **duplication**, pas d'issues — 0 issue partout).

## Fichiers corrigés (5)
- **security.py** ×2 (langchain+llamaindex) — était 63% dup (B). Les shims re-listaient 27 noms deux fois → `__all__` centralisé dans `velesdb_common.security`, shims réduits à un re-export 2 lignes. API inchangée (27 noms, tous résolvent).
- **scroll_ops.py** ×2 — ~50 lignes de `_scroll_one_batch` identiques → extraites vers `velesdb_common.scroll.scroll_one_batch` (superset avec `filter` optionnel). Comportement préservé.
- **multi_query_ops.py** (le seul **D**=46) — docstrings dupliquées des variantes `_with_score` → remplacées par des renvois 1-ligne vers la méthode principale (la logique était déjà partagée via `_run_*`). API inchangée.

## Vérifs locales
`py_compile` OK sur tous ; `velesdb_common.security.__all__` (27) et `scroll_one_batch` validés en isolation. (Tests Python complets via la CI — deps non installées en local.)

## Reste (non inclus, voir discussion)
- `memory.py` ×2 (11% dup) : deduplicable via extraction d'une classe de base, plus impliqué.
- 11 fichiers à complexité-de-fichier élevée (core Rust/TS) : scission en sous-modules, invasif sur des chemins recall-sensibles.
