### PR TITLE
fix(test) + docs: eliminate async_index_builder race + lint + ROADMAP sync to v1.16.0

### DIFF
--- a/QUALITY_BAR.md
+++ b/QUALITY_BAR.md
@@ -4,7 +4,7 @@ This document specifies the **explicit, enforceable thresholds** below which Vel
 
 These gates are not aspirational. They are enforced via CI workflows, scripts, and explicit pre-merge protocols. Each gate listed here links to its enforcement mechanism so that the gate can be inspected, contested, or extended publicly.
 
-> **Last updated:** 2026-05-15 — applies to v1.14.x and onward.
+> **Last updated:** 2026-05-31 — applies to v1.16.x and onward.
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,7 +4,7 @@ This roadmap commits to **what we are building**, **why**, and **when**. It is u
 
 It is intentionally narrow. Items not on this roadmap are tracked as `roadmap` issues but **not committed** until they reach a milestone here.
 
-> **Last updated:** 2026-05-31 — covers v1.16.0 (shipped 2026-05-29) → v1.17.0 horizon.
+> **Last updated:** 2026-05-31 — covers v1.16.0 (current) → v1.17.0 horizon.
 
 ---
 
@@ -26,7 +26,7 @@ It is intentionally narrow. Items not on this roadmap are tracked as `roadmap` i
 
 ---
 
-## Horizon 2 — ✅ Shipped (v1.15.0 → v1.16.0, released 2026-05-29)
+## Horizon 2 — ✅ Shipped (v1.15.0 → v1.16.0, released 2026-05-30)
 
 ### Theme: Performance narrative & SDK parity
 
@@ -38,7 +38,7 @@ It is intentionally narrow. Items not on this roadmap are tracked as `roadmap` i
 | 4 | **External `unsafe` audit** (SIMD module, Cure53 / independent Rust safety expert) | Required for "data sovereignty" enterprise positioning | ❌ Pending funding (~5-15 k€); carried to v1.17.0 |
 | 5 | **`velesdb-migrate` rework decision** (12,108 LOC, 9 connectors) | Workspace inflation without measured user base — decide keep / extract / archive based on crates.io download counts, GitHub stars attributable to migration tooling, opened issues count. See `docs/reference/KNOWN_LIMITATIONS.md` § 4 | ❌ Decision deferred — carried to v1.17.0 |
 
-**Also shipped in v1.16.0 (2026-05-29):** `audit-2026q2` security hardening wave (9 PRs: HNSW on-disk validation, WAL allocation caps, PQ hardening, parser DoS bounds, sparse/BM25 agent path, graph integrity, query/cache, config validation, rate limiter — PRs [#908](https://github.com/cyberlife-coder/VelesDB/pull/908)–[#916](https://github.com/cyberlife-coder/VelesDB/pull/916)); first-party Python + TypeScript embedding adapters (PR [#917](https://github.com/cyberlife-coder/VelesDB/pull/917)); multi-arch GHCR image with OIDC attestation; 9 typed Tauri guest-JS wrappers (PR [#928](https://github.com/cyberlife-coder/VelesDB/pull/928)); 44-PR dependency refresh (Docker base `rust 1.87→1.96`, `wgpu 29`, `redis 0.26→1.2`, `dashmap 5→6`, `uniffi 0.28→0.31`); VelesQL cheat sheet.
+**Also shipped in v1.16.0 (2026-05-30):** `audit-2026q2` security hardening wave (9 PRs: HNSW on-disk validation, WAL allocation caps, PQ hardening, parser DoS bounds, sparse/BM25 agent path, graph integrity, query/cache, config validation, rate limiter — PRs [#908](https://github.com/cyberlife-coder/VelesDB/pull/908)–[#916](https://github.com/cyberlife-coder/VelesDB/pull/916)); first-party Python + TypeScript embedding adapters (PR [#917](https://github.com/cyberlife-coder/VelesDB/pull/917)); multi-arch GHCR image with OIDC attestation; 9 typed Tauri guest-JS wrappers (PR [#928](https://github.com/cyberlife-coder/VelesDB/pull/928)); 44-PR dependency refresh (Docker base `rust 1.87→1.96`, `wgpu 29`, `redis 0.26→1.2`, `dashmap 5→6`, `uniffi 0.28→0.31`); VelesQL cheat sheet.
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,61 +4,65 @@ This roadmap commits to **what we are building**, **why**, and **when**. It is u
 
 It is intentionally narrow. Items not on this roadmap are tracked as `roadmap` issues but **not committed** until they reach a milestone here.
 
-> **Last updated:** 2026-05-14 — covers v1.16.0 (current) → v1.16.0 horizon.
+> **Last updated:** 2026-05-31 — covers v1.16.0 (shipped 2026-05-29) → v1.17.0 horizon.
 
 ---
 
-## Horizon 1 — Next 3 months (v1.14.x → v1.15.0)
+## Horizon 1 — ✅ Shipped (v1.14.x → v1.15.0, released 2026-05-14)
 
 ### Theme: Ecosystem credibility & adoption signals
-
-VelesDB v1.14.x has shipped the ecosystem-credibility foundations: the Python RAG framework trio (LangChain + LlamaIndex + Haystack) is complete and Haystack now translates filters to the VelesDB native shape end-to-end, MSRV is honestly aligned with the actual SIMD path, and the release pipeline now keeps **37 manifests/snippets/Dockerfile labels** in lock-step (was 18 at the start of the cycle). The next milestone moves the project from "ecosystem-credible" to "commercially adoptable" via Python DataFrame ergonomics, CBO calibration, and the SearchOptions builder refactor.
-
-**Milestone:** [v1.15.0](https://github.com/cyberlife-coder/VelesDB/milestones)
 
 | # | Item | Success criterion | Status |
 |---|------|------------------|--------|
 | 1 | [Haystack 2.x DocumentStore integration (#349)](https://github.com/cyberlife-coder/VelesDB/issues/349) | At least one BDD test passing in CI; published in `integrations/haystack/`; first community contribution merged | ✅ Shipped in v1.14.0 / v1.14.1 — PR [#672](https://github.com/cyberlife-coder/VelesDB/pull/672) by [@CrepuscularIRIS](https://github.com/CrepuscularIRIS); `pip install haystack-velesdb` live on PyPI |
 | 2 | [Onboarding time-to-first-search < 5 min (#379)](https://github.com/cyberlife-coder/VelesDB/issues/379) | Measured on clean Ubuntu/macOS/Windows; documented in `docs/quickstart/timing-results.md`; verified via reproducible Docker harness | ✅ Shipped in v1.13.7 (Phase 6) — median across 4 paths under 26 s; [`scripts/dx-timing/run_all.sh`](scripts/dx-timing/run_all.sh) reproduces it |
-| 3 | [CBO calibration loop (#469)](https://github.com/cyberlife-coder/VelesDB/issues/469) | `COST_UNIT_TO_MS` recalibrated from real query timings; method documented in `BENCHMARKS.md`; removes `KNOWN_LIMITATIONS.md #1` | Open (slated for v1.15.0) |
-| 4 | [Python DataFrame + Polars integration (#429)](https://github.com/cyberlife-coder/VelesDB/issues/429) | `upsert_dataframe(df)` + `search().to_polars()` round-trip; one notebook in `examples/python/` | Open (slated for v1.15.0) |
-| 5 | [PyO3 SearchOptions builder (#717)](https://github.com/cyberlife-coder/VelesDB/issues/717) | Replace the wide-kwarg `Collection.search` signature with a builder pattern + deprecation cycle; remove the `clippy::too_many_arguments` allow-list | Open (slated for v1.15.0/v2.0.0) |
+| 3 | [CBO calibration loop (#469)](https://github.com/cyberlife-coder/VelesDB/issues/469) | `COST_UNIT_TO_MS` recalibrated from real query timings; method documented in `BENCHMARKS.md`; removes `KNOWN_LIMITATIONS.md #1` | ⚠️ Phase 2 shipped in v1.15.0 — empirical EMA reported in `EXPLAIN ANALYZE` output (PR [#784](https://github.com/cyberlife-coder/VelesDB/pull/784)); full `COST_UNIT_TO_MS` empirical pin and removal of `KNOWN_LIMITATIONS.md #1` carried to v1.17.0 |
+| 4 | [Python DataFrame + Polars integration (#429)](https://github.com/cyberlife-coder/VelesDB/issues/429) | `upsert_dataframe(df)` + `search().to_polars()` round-trip; one notebook in `examples/python/` | ❌ Not shipped — carried to v1.17.0 |
+| 5 | [PyO3 SearchOptions builder (#717)](https://github.com/cyberlife-coder/VelesDB/issues/717) | Replace the wide-kwarg `Collection.search` signature with a builder pattern + deprecation cycle; remove the `clippy::too_many_arguments` allow-list | ✅ Shipped in v1.15.0 — fluent `SearchOptions` builder exposed in Python SDK (PR [#761](https://github.com/cyberlife-coder/VelesDB/pull/761), closes #717) |
 
-**Already shipped in v1.14.x:** MSRV bump 1.83 → 1.89 (#714), Dockerfile auto-sync (#715), full Python RAG framework trio (Haystack via #672), doc consistency sweep (#722), `haystack-velesdb` PyPI publishing (#723), Haystack `DuplicatePolicy.SKIP` contract fix (#726), full v1.14.2 doc alignment + fictional MSI installer removed + 14-entry tooling extension (#730), Haystack runtime gaps closed — `@component` decorator on retriever example + Haystack-filter→VelesDB-filter translator + real-Haystack CI (#731).
+**Also shipped in v1.14.x:** MSRV bump 1.83 → 1.89 (#714), Dockerfile auto-sync (#715), full Python RAG framework trio (Haystack via #672), doc consistency sweep (#722), `haystack-velesdb` PyPI publishing (#723), Haystack `DuplicatePolicy.SKIP` contract fix (#726), full v1.14.2 doc alignment + fictional MSI installer removed + 14-entry tooling extension (#730), Haystack runtime gaps closed — `@component` decorator on retriever example + Haystack-filter→VelesDB-filter translator + real-Haystack CI (#731).
+
+**Also shipped in v1.15.0:** ACT-R Phase 1 procedural learning (PR [#780](https://github.com/cyberlife-coder/VelesDB/pull/780)); Python auto-detect vector dimension from first upsert (PR [#778](https://github.com/cyberlife-coder/VelesDB/pull/778)); `IN` filter O(log n) binary search (PR [#765](https://github.com/cyberlife-coder/VelesDB/pull/765)); React+WASM and Node+Express RAG demos; `rand 0.9 → 0.10` and `toml 0.8 → 0.9` ecosystem majors absorbed.
 
 ---
 
-## Horizon 2 — 3 to 6 months (v1.15.0)
+## Horizon 2 — ✅ Shipped (v1.15.0 → v1.16.0, released 2026-05-29)
 
 ### Theme: Performance narrative & SDK parity
 
-By v1.15 we want a single sentence pitch: *"VelesDB is the only embedded vector + graph + columnar engine, faster than competitors on full-path latency, with first-class SDKs in 4 languages."*
+| # | Item | Why | Status |
+|---|------|-----|--------|
+| 1 | [HNSW <30µs index-only target (#377)](https://github.com/cyberlife-coder/VelesDB/issues/377) | Push the index-only micro-bench from 55µs to <30µs to widen the headroom on the 450µs full-path number | ✅ Shipped in v1.15.0 — `ANALYZE` now triggers in-place HNSW node reorder when fragmentation exceeds threshold; 10K-probe recall@10 off-by-one fixed (PR [#785](https://github.com/cyberlife-coder/VelesDB/pull/785), closes #377) |
+| 2 | [SDK parity: TypeScript/LangChain/LlamaIndex (#380)](https://github.com/cyberlife-coder/VelesDB/issues/380) | Close the cross-language gap so any framework user gets the same API surface | ✅ Shipped in v1.15.0 — TypeScript REST backend gains `sparseIndexName` and RSF weights (PR [#779](https://github.com/cyberlife-coder/VelesDB/pull/779), closes #380) |
+| 3 | **Reproducible head-to-head benchmark vs Qdrant + Chroma + pgvector** (Docker Compose) | Pre-seed audit P0: turn marketing claims into proven numbers | ❌ Not shipped — carried to v1.17.0 |
+| 4 | **External `unsafe` audit** (SIMD module, Cure53 / independent Rust safety expert) | Required for "data sovereignty" enterprise positioning | ❌ Pending funding (~5-15 k€); carried to v1.17.0 |
+| 5 | **`velesdb-migrate` rework decision** (12,108 LOC, 9 connectors) | Workspace inflation without measured user base — decide keep / extract / archive based on crates.io download counts, GitHub stars attributable to migration tooling, opened issues count. See `docs/reference/KNOWN_LIMITATIONS.md` § 4 | ❌ Decision deferred — carried to v1.17.0 |
 
-**Tentative scope:**
-
-| # | Item | Why |
-|---|------|-----|
-| 1 | [HNSW <30µs index-only target (#377)](https://github.com/cyberlife-coder/VelesDB/issues/377) | Push the index-only micro-bench from 55µs to <30µs to widen the headroom on the 450µs full-path number |
-| 2 | [SDK parity: TypeScript/LangChain/LlamaIndex (#380)](https://github.com/cyberlife-coder/VelesDB/issues/380) | Close the cross-language gap so any framework user gets the same API surface |
-| 3 | **Reproducible head-to-head benchmark vs Qdrant + Chroma + pgvector** (Docker Compose) | Pre-seed audit P0: turn marketing claims into proven numbers |
-| 4 | **External `unsafe` audit** (SIMD module, Cure53 / independent Rust safety expert) | Required for "data sovereignty" enterprise positioning |
-| 5 | **`velesdb-migrate` rework decision** (12,108 LOC, 9 connectors) | Workspace inflation without measured user base — decide keep / extract / archive based on crates.io download counts, GitHub stars attributable to migration tooling, opened issues count. See `docs/reference/KNOWN_LIMITATIONS.md` § 4 |
-
-These items need budget commitment (audit ~5-15k€) and are conditional on funding closing.
+**Also shipped in v1.16.0 (2026-05-29):** `audit-2026q2` security hardening wave (9 PRs: HNSW on-disk validation, WAL allocation caps, PQ hardening, parser DoS bounds, sparse/BM25 agent path, graph integrity, query/cache, config validation, rate limiter — PRs [#908](https://github.com/cyberlife-coder/VelesDB/pull/908)–[#916](https://github.com/cyberlife-coder/VelesDB/pull/916)); first-party Python + TypeScript embedding adapters (PR [#917](https://github.com/cyberlife-coder/VelesDB/pull/917)); multi-arch GHCR image with OIDC attestation; 9 typed Tauri guest-JS wrappers (PR [#928](https://github.com/cyberlife-coder/VelesDB/pull/928)); 44-PR dependency refresh (Docker base `rust 1.87→1.96`, `wgpu 29`, `redis 0.26→1.2`, `dashmap 5→6`, `uniffi 0.28→0.31`); VelesQL cheat sheet.
 
 ---
 
-## Horizon 3 — 6 to 12 months (v1.16.0+)
+## Horizon 3 — Next 3 months (v1.16.0 → v1.17.0)
 
-### Theme: Enterprise feature gate & multi-tenancy
+### Theme: Enterprise readiness & DataFrame ergonomics
 
-By v1.16 we want VelesDB to be deployable in production at small-team scale (5-50 user services) with credible operational primitives. Most of these features will live in the **`velesdb-premium`** companion crate (separate repo) under a commercial license, with the OSS core remaining feature-complete for single-tenant local-first use cases.
+Carry-forward open items from Horizons 1–2 plus the first enterprise-readiness primitives.
 
-**Tentative scope:**
+**Committed scope:**
+
+| # | Item | Why |
+|---|------|-----|
+| 1 | [Python DataFrame + Polars integration (#429)](https://github.com/cyberlife-coder/VelesDB/issues/429) | `upsert_dataframe(df)` + `search().to_polars()` — the last ergonomics gap for data-science workflows |
+| 2 | [CBO calibration — full `COST_UNIT_TO_MS` pin (#469)](https://github.com/cyberlife-coder/VelesDB/issues/469) | Pin the cost constant from a micro-benchmark; removes `KNOWN_LIMITATIONS.md #1` |
+| 3 | **Reproducible head-to-head benchmark vs Qdrant + Chroma + pgvector** (Docker Compose) | Pre-seed audit P0: turn marketing claims into proven numbers |
+| 4 | **External `unsafe` audit** (SIMD module, Cure53 / independent Rust safety expert) | Required for "data sovereignty" enterprise positioning; budget-conditional (~5-15 k€) |
+| 5 | **`velesdb-migrate` rework decision** | Evaluate keep / extract / archive based on crates.io download counts, GitHub stars, open-issue count |
+
+**Tentative scope (enterprise feature gate):**
 
 - **Concurrent WAL writer** with batching (today: single-writer mutex)
 - **Multi-tenancy / namespacing** (today: per-database isolation only)
-- **RBAC** (Role-Based Access Control) — premium
+- **RBAC** (Role-Based Access Control) — premium companion crate
 - **Distributed replication** (Raft) — premium, long horizon
 - **Query result caching with auth tags** — premium
 
@@ -105,8 +109,8 @@ To make the roadmap meaningful, here is what is **out of scope** for the foresee
 
 ## Cadence
 
-- **Patch releases (v1.13.x):** as needed, 1-2x per month, no roadmap commitment
-- **Minor releases (v1.14, v1.15, v1.16):** ~3 months apart, each with a public milestone and OKRs
+- **Patch releases (v1.16.x):** as needed, 1-2x per month, no roadmap commitment
+- **Minor releases (v1.14, v1.15, v1.16, v1.17):** ~3 months apart, each with a public milestone and OKRs
 - **Major release (v2.0):** no committed timeline. Will only happen if we need a breaking API change. The `#[non_exhaustive]` discipline on public enums keeps this option open.
 
 ## How this roadmap is governed

--- a/crates/velesdb-core/src/collection/streaming/async_index_builder.rs
+++ b/crates/velesdb-core/src/collection/streaming/async_index_builder.rs
@@ -202,4 +202,14 @@ impl AsyncIndexBuilder {
     pub fn merge_threshold(&self) -> usize {
         self.config.merge_threshold
     }
+
+    /// Directly sets the `building` flag for deterministic unit testing.
+    ///
+    /// Allows tests to inject the "already building" state without spawning a
+    /// real background thread, eliminating the race condition inherent in
+    /// timing-based probes.
+    #[cfg(test)]
+    pub(crate) fn force_set_building(&self, val: bool) {
+        self.building.store(val, Ordering::SeqCst);
+    }
 }

--- a/crates/velesdb-core/src/collection/streaming/async_index_builder_tests.rs
+++ b/crates/velesdb-core/src/collection/streaming/async_index_builder_tests.rs
@@ -238,8 +238,16 @@ fn test_trigger_build_async_skips_when_already_building() {
     builder.trigger_build_async(&index);
 
     // Buffer untouched; no thread was spawned; index is empty.
-    assert_eq!(builder.buffer_len(), 5, "buffer must not be drained when already building");
-    assert_eq!(index.len(), 0, "index must not change when trigger is skipped");
+    assert_eq!(
+        builder.buffer_len(),
+        5,
+        "buffer must not be drained when already building"
+    );
+    assert_eq!(
+        index.len(),
+        0,
+        "index must not change when trigger is skipped"
+    );
     assert!(builder.is_building(), "building flag must still be set");
 
     // Restore invariant so builder is not left in a permanently-locked state.

--- a/crates/velesdb-core/src/collection/streaming/async_index_builder_tests.rs
+++ b/crates/velesdb-core/src/collection/streaming/async_index_builder_tests.rs
@@ -201,48 +201,47 @@ fn test_trigger_build_async_noop_when_empty() {
     assert_eq!(index.len(), 0);
 }
 
+/// Verifies that `trigger_build_async` is a no-op when a build is already in
+/// progress.
+///
+/// The previous implementation polled `is_building()` with a sleep between the
+/// first `trigger_build_async` call and the second, which was racy: on fast
+/// hardware the background thread finished and cleared `building` before the
+/// second trigger was called, causing both triggers to run and the assertion
+/// `buffer_len() == 5` to fail with 0.
+///
+/// Fix: inject the "already building" state directly via
+/// `force_set_building(true)` without spawning a real background thread,
+/// making the test fully deterministic.
 #[test]
 fn test_trigger_build_async_skips_when_already_building() {
     let dim = 4;
     let index = std::sync::Arc::new(make_index(dim));
     let builder = AsyncIndexBuilder::new(default_config());
 
-    // Enqueue vectors
-    let vectors: Vec<(u64, Vec<f32>)> = (0..10)
+    // Simulate a build already in progress — no real thread needed.
+    builder.force_set_building(true);
+    assert!(builder.is_building());
+
+    // Enqueue vectors that should stay buffered because the trigger is skipped.
+    let vectors: Vec<(u64, Vec<f32>)> = (0..5_u64)
         .map(|i| {
             let mut v = vec![0.0_f32; dim];
-            v[i % dim] = 1.0;
-            (i as u64, v)
+            v[(i as usize) % dim] = 1.0;
+            (i, v)
         })
         .collect();
     builder.enqueue(vectors);
-
-    // Trigger first build
-    builder.trigger_build_async(&index);
-
-    // Enqueue more while building
-    let more: Vec<(u64, Vec<f32>)> = (10..15)
-        .map(|i| {
-            let mut v = vec![0.0_f32; dim];
-            v[i % dim] = 1.0;
-            (i as u64, v)
-        })
-        .collect();
-    builder.enqueue(more);
-
-    // Second trigger should be skipped (building flag is set)
-    builder.trigger_build_async(&index);
-
-    // Wait for first build to complete
-    let start = std::time::Instant::now();
-    while builder.is_building() {
-        std::thread::sleep(std::time::Duration::from_millis(10));
-        if start.elapsed() > std::time::Duration::from_secs(10) {
-            panic!("background build did not complete within 10s");
-        }
-    }
-
-    // First batch indexed, second batch still in buffer
-    assert_eq!(index.len(), 10);
     assert_eq!(builder.buffer_len(), 5);
+
+    // Call trigger — must be a no-op because `building` is already true.
+    builder.trigger_build_async(&index);
+
+    // Buffer untouched; no thread was spawned; index is empty.
+    assert_eq!(builder.buffer_len(), 5, "buffer must not be drained when already building");
+    assert_eq!(index.len(), 0, "index must not change when trigger is skipped");
+    assert!(builder.is_building(), "building flag must still be set");
+
+    // Restore invariant so builder is not left in a permanently-locked state.
+    builder.force_set_building(false);
 }

--- a/crates/velesdb-core/src/collection/streaming/async_index_builder_tests.rs
+++ b/crates/velesdb-core/src/collection/streaming/async_index_builder_tests.rs
@@ -224,11 +224,13 @@ fn test_trigger_build_async_skips_when_already_building() {
     assert!(builder.is_building());
 
     // Enqueue vectors that should stay buffered because the trigger is skipped.
-    let vectors: Vec<(u64, Vec<f32>)> = (0..5_u64)
+    // Iterate as usize so index arithmetic stays lossless; cast to u64 for the id
+    // (usize → u64 cannot truncate on any supported target).
+    let vectors: Vec<(u64, Vec<f32>)> = (0..5_usize)
         .map(|i| {
             let mut v = vec![0.0_f32; dim];
-            v[(i as usize) % dim] = 1.0;
-            (i, v)
+            v[i % dim] = 1.0;
+            (i as u64, v)
         })
         .collect();
     builder.enqueue(vectors);


### PR DESCRIPTION
## Changes (4 atomic commits)

### Commit 1 — `fix(test)`: Eliminate race condition in async_index_builder skip test

**Root cause:** `test_trigger_build_async_skips_when_already_building` was timing-dependent. On fast hardware the background thread finished and cleared `building = false` before the second `trigger_build_async` call, so the skip logic was never exercised and `buffer_len()` returned 0 instead of 5.

**Result before:** 4902 passed / **1 failed** (287 s run).

**Fix:**
- `async_index_builder.rs` — add `#[cfg(test)] pub(crate) fn force_set_building(&self, val: bool)` to inject the building state without spawning a thread.
- `async_index_builder_tests.rs` — rewrite the test using `force_set_building(true)` for a fully deterministic "skip" invariant check.

The full pipeline (enqueue → drain → background thread → index populated) is covered by `test_trigger_build_async_indexes_in_background`.

**Result after:** 4903/4903 ✅

---

### Commit 2 — `style`: Apply rustfmt to async_index_builder_tests

`assert_eq!` calls with message arguments exceeded the line-width threshold. Auto-applied `cargo fmt`.

---

### Commit 3 — `docs(roadmap)`: Sync factual status after v1.15.0 + v1.16.0 releases

`ROADMAP.md` was last updated 2026-05-14 (pre-release). v1.15.0 shipped 2026-05-14 and v1.16.0 shipped 2026-05-29.

| Item | Was | Now |
|------|-----|-----|
| CBO #469 | "Open (slated for v1.15.0)" | ⚠️ Phase 2 shipped (PR #784); full pin deferred → v1.17.0 |
| Polars #429 | "Open (slated for v1.15.0)" | ❌ Not shipped — carried to v1.17.0 |
| SearchOptions #717 | "Open (slated for v1.15.0)" | ✅ Shipped v1.15.0 (PR #761) |
| HNSW <30µs #377 | Pending Horizon 2 | ✅ Shipped v1.15.0 — ANALYZE auto-reorder (PR #785) |
| SDK parity #380 | Pending Horizon 2 | ✅ Shipped v1.15.0 — TS RSF + sparseIndexName (PR #779) |

Added v1.16.0 shipped-items summary. Renamed Horizon 3 to "v1.16.0 → v1.17.0". `QUALITY_BAR.md` date/version updated.

---

### Commit 4 — `fix(lint)`: Eliminate cast_possible_truncation in skip-test under --all-targets

`(i as usize)` where `i: u64` triggers `clippy::cast_possible_truncation` when compiled via `--all-targets -D warnings -D clippy::pedantic` (u64 → usize can truncate on 32-bit targets). The test code was excluded from the initial `--lib`-only clippy run.

**Fix:** iterate as `0..5_usize` and cast to `u64` for the external id (usize → u64 is always lossless).

---

## Verification (2026-05-31)

| Check | Result |
|-------|--------|
| `cargo test -p velesdb-core --lib` | 4903/4903 ✅ |
| `cargo clippy -p velesdb-core --all-targets --features persistence -D warnings -D clippy::pedantic` | clean ✅ |
| `cargo fmt --all -- --check` | clean ✅ |
| `python3 scripts/check_prod_unwraps.py` | PASSED ✅ |
| `python3 scripts/verify_unsafe_safety_template.py --strict` | PASSED ✅ |
| `python3 scripts/check-perf-claims.py --no-criterion` | PASSED ✅ |