### PR TITLE
chore: back-merge main into develop (sync #962/#965/#969)

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,18 +301,20 @@ Native HNSW index with SIMD-accelerated distance kernels. Sub-millisecond search
 
 Fresh figures on Apple Silicon (single-thread, run in isolation). They confirm the engine profile and make the *scope* of each number explicit; they are not a substitute for the x86_64/AVX2 reference figures above.
 
-| What it actually measures | Result | Reproduce |
-|---|---|---|
-| HNSW search, **index-only** (10K/768D, k=10; no WAL/payload, hot cache) | 55 µs | `... hnsw_benchmark -- hnsw_search_latency` |
-| HNSW search **scaling** (top-10, index-only) | 116 µs @100K · 128 µs @500K · 129 µs @1M | `... scalability_benchmark` |
-| **VelesQL engine** (parse→plan→execute→project, 10K) | 41 µs | `... velesql_execution_benchmark` |
-| **End-to-end via PyO3/NumPy** (10K/384D, p50; the Python production path) | 55 µs (p99 99 µs) | `python benchmarks/velesdb_benchmark.py` |
-| SIMD distance, **NEON** (768D): dot / euclidean / cosine | 31 / 35 / 47 ns | `... simd_benchmark` |
-| BM25 full-text search (10K, single / multi-term) | 23.5 / 71 µs | `... bm25_benchmark` |
-| Sparse search (top-10, 10K corpus) | 29.8 µs | `... sparse_benchmark -- top10_10k_corpus` |
-| **Recall@10** (n=10K/128D, exact brute-force ground truth) | Fast (ef96) 97.4% · Balanced (ef160) 99.8% · Accurate (ef512) 100% | `... recall_benchmark` |
+All `cargo bench` commands below are run as `cargo bench -p velesdb-core --bench <NAME>`.
 
-> On this machine the PyO3/NumPy binding overhead is negligible: end-to-end ≈ index-only ≈ 55 µs. The **450 µs** canonical figure is the i9-14900KF reference under WAL-on production conditions; per-machine results vary. Recall figures use a real exact-kNN ground truth, not approximate self-comparison.
+| What it actually measures | Result | Bench |
+|---|---|---|
+| HNSW search, **index-only** (10K/768D, k=10; no WAL/payload, hot cache) | 55 µs | `hnsw_benchmark -- hnsw_search_latency` |
+| HNSW search **scaling** (top-10, index-only) | 116 µs @100K · 128 µs @500K · 129 µs @1M | `scalability_benchmark` |
+| **VelesQL engine** (parse→plan→execute→project, 10K) | 41 µs | `velesql_execution_benchmark` |
+| **End-to-end via PyO3/NumPy** (10K/384D, p50; the Python production path) | 55 µs (p99 99 µs) | `python benchmarks/velesdb_benchmark.py` |
+| SIMD distance, **NEON** (768D): dot / euclidean / cosine | 31 / 35 / 47 ns | `simd_benchmark` |
+| BM25 full-text search (10K, single / multi-term) | 23.5 / 71 µs | `bm25_benchmark` |
+| Sparse search (top-10, 10K corpus) | 29.8 µs | `sparse_benchmark -- top10_10k_corpus` |
+| **Recall@10** (n=10K/128D, exact brute-force GT; ef sweep) | ef=96 → 97.4% · ef=160 → 99.8% · ef=512 → 100% | `recall_benchmark` |
+
+> The recall figures above are `recall_benchmark`'s internal ef sweep (96/160/512) — **distinct** from the product "Modes" table below (Fast/Balanced/Accurate use ef 64/128/512). On this machine the PyO3/NumPy binding overhead is negligible: end-to-end ≈ index-only ≈ 55 µs. The **450 µs** canonical figure is the i9-14900KF reference under WAL-on production conditions; per-machine results vary. Recall uses a real exact-kNN ground truth, not approximate self-comparison.
 
 | Mode | ef_search | Recall@10 | Use case |
 |------|-----------|-----------|----------|

--- a/README.md
+++ b/README.md
@@ -279,6 +279,8 @@ Native HNSW index with SIMD-accelerated distance kernels. Sub-millisecond search
 | Recall@10 (Balanced) | **98.8%** |
 | Quantization | SQ8 (4x), PQ (32x), Binary (32x), RaBitQ (32x) |
 
+> **Provenance of the canonical figures above:** Intel Core **i9-14900KF** (x86_64, AVX2), `velesdb_benchmark.py`. "End-to-end / p50" = the full production path (VelesQL → HNSW → **WAL ON** → payload hydration), median over the query set. "Index-only" figures (in the details below) exclude WAL and payload and run on a hot cache — they are not comparable to the end-to-end number. Per-machine figures vary; fresh Apple-Silicon measurements are given below.
+
 5 search quality modes (Fast → Perfect), adaptive two-phase ef, AutoTune.
 
 <details>
@@ -294,6 +296,23 @@ Native HNSW index with SIMD-accelerated distance kernels. Sub-millisecond search
 | SIMD Dot Product kernel (768D, AVX2) | **21.7 ns** | `cargo bench -p velesdb-core --bench simd_benchmark` |
 | Recall@10 (Accurate mode) | **100%** | `cargo bench -p velesdb-core --bench recall_benchmark` |
 | BM25 Sparse Search index-only (10K docs, top-10) | **57.6 us** (16x from 956 us in v1.12) | `cargo bench -p velesdb-core --bench sparse_benchmark -- top10_10k_corpus` |
+
+#### Cross-checked on Apple M5 Pro (ARM64 / NEON, 18-core) — measured 2026-05-31, v1.16.0
+
+Fresh figures on Apple Silicon (single-thread, run in isolation). They confirm the engine profile and make the *scope* of each number explicit; they are not a substitute for the x86_64/AVX2 reference figures above.
+
+| What it actually measures | Result | Reproduce |
+|---|---|---|
+| HNSW search, **index-only** (10K/768D, k=10; no WAL/payload, hot cache) | 55 µs | `... hnsw_benchmark -- hnsw_search_latency` |
+| HNSW search **scaling** (top-10, index-only) | 116 µs @100K · 128 µs @500K · 129 µs @1M | `... scalability_benchmark` |
+| **VelesQL engine** (parse→plan→execute→project, 10K) | 41 µs | `... velesql_execution_benchmark` |
+| **End-to-end via PyO3/NumPy** (10K/384D, p50; the Python production path) | 55 µs (p99 99 µs) | `python benchmarks/velesdb_benchmark.py` |
+| SIMD distance, **NEON** (768D): dot / euclidean / cosine | 31 / 35 / 47 ns | `... simd_benchmark` |
+| BM25 full-text search (10K, single / multi-term) | 23.5 / 71 µs | `... bm25_benchmark` |
+| Sparse search (top-10, 10K corpus) | 29.8 µs | `... sparse_benchmark -- top10_10k_corpus` |
+| **Recall@10** (n=10K/128D, exact brute-force ground truth) | Fast (ef96) 97.4% · Balanced (ef160) 99.8% · Accurate (ef512) 100% | `... recall_benchmark` |
+
+> On this machine the PyO3/NumPy binding overhead is negligible: end-to-end ≈ index-only ≈ 55 µs. The **450 µs** canonical figure is the i9-14900KF reference under WAL-on production conditions; per-machine results vary. Recall figures use a real exact-kNN ground truth, not approximate self-comparison.
 
 | Mode | ef_search | Recall@10 | Use case |
 |------|-----------|-----------|----------|

--- a/integrations/common/src/velesdb_common/scroll.py
+++ b/integrations/common/src/velesdb_common/scroll.py
@@ -1,0 +1,68 @@
+"""Shared cursor-paginated scroll helper for the framework integrations.
+
+Both ``langchain_velesdb`` and ``llamaindex_velesdb`` expose a ``scroll()``
+mixin that returns framework-specific objects (LangChain ``Document`` /
+LlamaIndex ``TextNode``).  The underlying batch-pull against a raw
+``velesdb.Collection`` is framework-agnostic and lives here so the two
+integrations don't duplicate it.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+
+def scroll_one_batch(
+    collection: Any,
+    cursor: Optional[int],
+    batch_size: int,
+    filter: Optional[dict] = None,  # pylint: disable=redefined-builtin  # public API kwarg name, cannot rename without breaking callers
+) -> tuple:
+    """Pull one batch from a velesdb Collection using its scroll iterator.
+
+    Creates a fresh ``collection.scroll()`` iterator on every call and skips
+    batches until the one past *cursor* is found.
+
+    .. warning::
+        **Complexity: O(page_index * batch_size)** — this function re-scans
+        from the beginning of the collection on each call because the native
+        SDK does not yet expose a cursor-based ``scroll_batch`` method at the
+        Python level (the Rust ``VectorCollection.scroll_batch`` method is
+        internal to the ``ScrollIterator`` PyO3 class).  For large collections
+        with many pages, callers should either:
+
+        * keep the ``ScrollIterator`` alive across calls (use
+          ``collection.scroll(batch_size=N)`` as a Python generator and drive
+          it with ``next()``), or
+        * wait for a future ``Collection.scroll_batch(cursor, batch_size)``
+          Python binding that will provide true O(1) cursor seek.
+
+    Args:
+        collection: A ``velesdb.Collection`` instance.
+        cursor: Last-seen integer point ID from the previous call, or ``None``.
+        batch_size: Maximum points to return.
+        filter: Optional payload filter dict forwarded to the SDK (omitted when
+            ``None`` so backends that don't accept it stay unaffected).
+
+    Returns:
+        A ``(points, next_cursor)`` tuple.  *points* is a list of raw dicts
+        with ``"id"``, ``"vector"``, and ``"payload"`` keys; *next_cursor* is
+        the last point ID (``int``) or ``None`` when the collection is
+        exhausted.
+    """
+    scroll_kwargs: dict = {"batch_size": batch_size}
+    if filter is not None:
+        scroll_kwargs["filter"] = filter
+
+    iterator = collection.scroll(**scroll_kwargs)
+    for batch in iterator:
+        if not batch:
+            continue
+        last_id = batch[-1].get("id")
+        if cursor is not None and last_id is not None and last_id <= cursor:
+            continue
+        return batch, (int(last_id) if last_id is not None else None)
+    return [], None
+
+
+__all__ = ["scroll_one_batch"]

--- a/integrations/common/src/velesdb_common/security.py
+++ b/integrations/common/src/velesdb_common/security.py
@@ -501,3 +501,37 @@ def validate_sparse_vector(sparse_vector: Any) -> dict:
     for key, value in sparse_vector.items():
         _validate_sparse_entry(key, value)
     return sparse_vector
+
+
+# Public API surface — re-exported verbatim by the framework shim modules
+# (langchain_velesdb.security / llamaindex_velesdb.security) via
+# ``from velesdb_common.security import *``.
+__all__ = [
+    "ALLOWED_STORAGE_MODES",
+    "STORAGE_MODE_ALIASES",
+    "DEFAULT_TIMEOUT_MS",
+    "MAX_BATCH_SIZE",
+    "MAX_DIMENSION",
+    "MAX_K_VALUE",
+    "MAX_PATH_LENGTH",
+    "MAX_QUERY_LENGTH",
+    "MAX_SPARSE_VECTOR_SIZE",
+    "MAX_TEXT_LENGTH",
+    "MIN_DIMENSION",
+    "SecurityError",
+    "validate_batch_size",
+    "validate_collection_name",
+    "validate_column_name",
+    "validate_dimension",
+    "validate_k",
+    "validate_metric",
+    "validate_path",
+    "validate_query",
+    "validate_search_quality",
+    "validate_sparse_vector",
+    "validate_storage_mode",
+    "validate_text",
+    "validate_timeout",
+    "validate_url",
+    "validate_weight",
+]

--- a/integrations/langchain/src/langchain_velesdb/multi_query_ops.py
+++ b/integrations/langchain/src/langchain_velesdb/multi_query_ops.py
@@ -117,16 +117,8 @@ class MultiQueryOpsMixin:
         k: int = 4,
         **kwargs: Any,
     ) -> List[List[Tuple[Document, float]]]:
-        """Batch search with scores for multiple queries.
-
-        Args:
-            queries: List of query strings.
-            k: Number of results per query. Defaults to 4.
-            **kwargs: Additional arguments.
-
-        Returns:
-            List of (Document, score) tuple lists, one per query.
-        """
+        """Like :meth:`batch_search` but each result is a ``(Document, score)``
+        tuple instead of a bare ``Document``."""
         if not queries:
             return []
         return [_results_to_docs_with_score(r) for r in self._run_batch_search(queries, k)]
@@ -207,19 +199,8 @@ class MultiQueryOpsMixin:
         filter: Optional[dict] = None,  # pylint: disable=redefined-builtin  # public API kwarg name, cannot rename without breaking callers
         **kwargs: Any,
     ) -> List[Tuple[Document, float]]:
-        """Multi-query search with fused scores.
-
-        Args:
-            queries: List of query strings.
-            k: Number of results. Defaults to 4.
-            fusion: Fusion strategy. Defaults to "rrf".
-            fusion_params: Optional fusion parameters.
-            filter: Optional metadata filter.
-            **kwargs: Additional arguments.
-
-        Returns:
-            List of (Document, fused_score) tuples.
-        """
+        """Like :meth:`multi_query_search` but each result is a
+        ``(Document, fused_score)`` tuple instead of a bare ``Document``."""
         if not queries:
             return []
         results = self._run_multi_query(queries, k, fusion, fusion_params, query_filter=filter)

--- a/integrations/langchain/src/langchain_velesdb/scroll_ops.py
+++ b/integrations/langchain/src/langchain_velesdb/scroll_ops.py
@@ -6,63 +6,12 @@ Extracted from ``vectorstore.py`` to keep each file under the 500 NLOC limit.
 from __future__ import annotations
 
 import logging
-from typing import Any, List, Optional
+from typing import List, Optional
 
 from langchain_core.documents import Document
+from velesdb_common.scroll import scroll_one_batch
 
 logger = logging.getLogger(__name__)
-
-
-def _scroll_one_batch(
-    collection: Any,
-    cursor: Optional[int],
-    batch_size: int,
-    filter: Optional[dict],  # pylint: disable=redefined-builtin  # public API kwarg name, cannot rename without breaking callers
-) -> tuple:
-    """Pull one batch from a velesdb Collection using its scroll iterator.
-
-    Creates a fresh ``collection.scroll()`` iterator on every call and skips
-    batches until the one past *cursor* is found.
-
-    .. warning::
-        **Complexity: O(page_index * batch_size)** — this function re-scans
-        from the beginning of the collection on each call because the native
-        SDK does not yet expose a cursor-based ``scroll_batch`` method at the
-        Python level (the Rust ``VectorCollection.scroll_batch`` method is
-        internal to the ``ScrollIterator`` PyO3 class).  For large collections
-        with many pages, callers should either:
-
-        * keep the ``ScrollIterator`` alive across calls (use
-          ``collection.scroll(batch_size=N)`` as a Python generator and drive
-          it with ``next()``), or
-        * wait for a future ``Collection.scroll_batch(cursor, batch_size)``
-          Python binding that will provide true O(1) cursor seek.
-
-    Args:
-        collection: A ``velesdb.Collection`` instance.
-        cursor: Last-seen integer point ID from the previous call, or ``None``.
-        batch_size: Maximum points to return.
-        filter: Optional payload filter dict forwarded to the SDK.
-
-    Returns:
-        A ``(points, next_cursor)`` tuple.  *points* is a list of raw dicts
-        with ``"id"``, ``"vector"``, and ``"payload"`` keys; *next_cursor* is
-        the last point ID (``int``) or ``None`` when the collection is
-        exhausted.
-    """
-    scroll_kwargs: dict = {"batch_size": batch_size}
-    if filter is not None:
-        scroll_kwargs["filter"] = filter
-
-    iterator = collection.scroll(**scroll_kwargs)
-    for batch in iterator:
-        if not batch:
-            continue
-        last_id = batch[-1].get("id")
-        if cursor is not None and last_id is not None and last_id <= cursor:
-            continue
-        return batch, (int(last_id) if last_id is not None else None)
-    return [], None
 
 
 class ScrollOpsMixin:
@@ -106,7 +55,7 @@ class ScrollOpsMixin:
         """
         if self._collection is None:  # type: ignore[attr-defined]
             return [], None
-        raw_batch, next_cursor = _scroll_one_batch(
+        raw_batch, next_cursor = scroll_one_batch(
             self._collection, cursor, batch_size, filter  # type: ignore[attr-defined]
         )
         docs: List[Document] = [self._to_document(pt) for pt in raw_batch]  # type: ignore[attr-defined]

--- a/integrations/langchain/src/langchain_velesdb/scroll_ops.py
+++ b/integrations/langchain/src/langchain_velesdb/scroll_ops.py
@@ -9,7 +9,11 @@ import logging
 from typing import List, Optional
 
 from langchain_core.documents import Document
-from velesdb_common.scroll import scroll_one_batch
+
+# Imported under the historical private name: ``vectorstore`` re-exports it and
+# the parity tests import/monkeypatch it. Implementation lives in
+# velesdb_common.scroll (shared with the LlamaIndex integration).
+from velesdb_common.scroll import scroll_one_batch as _scroll_one_batch
 
 logger = logging.getLogger(__name__)
 
@@ -55,7 +59,7 @@ class ScrollOpsMixin:
         """
         if self._collection is None:  # type: ignore[attr-defined]
             return [], None
-        raw_batch, next_cursor = scroll_one_batch(
+        raw_batch, next_cursor = _scroll_one_batch(
             self._collection, cursor, batch_size, filter  # type: ignore[attr-defined]
         )
         docs: List[Document] = [self._to_document(pt) for pt in raw_batch]  # type: ignore[attr-defined]

--- a/integrations/langchain/src/langchain_velesdb/security.py
+++ b/integrations/langchain/src/langchain_velesdb/security.py
@@ -1,70 +1,9 @@
 """Security utilities for the LangChain VelesDB integration.
 
-All validation logic lives in ``velesdb_common.security``.  This module
-re-exports every public name so that existing ``from langchain_velesdb.security
-import ...`` call-sites continue to work without modification.
+All validation logic lives in :mod:`velesdb_common.security`; this module
+re-exports its public surface so that existing
+``from langchain_velesdb.security import ...`` call-sites keep working.
 """
 
-from velesdb_common.security import (  # pylint: disable=unused-import  # public re-exports declared in __all__ below
-    ALLOWED_STORAGE_MODES,
-    STORAGE_MODE_ALIASES,
-    DEFAULT_TIMEOUT_MS,
-    MAX_BATCH_SIZE,
-    MAX_DIMENSION,
-    MAX_K_VALUE,
-    MAX_PATH_LENGTH,
-    MAX_QUERY_LENGTH,
-    MAX_SPARSE_VECTOR_SIZE,
-    MAX_TEXT_LENGTH,
-    MIN_DIMENSION,
-    SecurityError,
-    validate_batch_size,
-    validate_collection_name,
-    validate_column_name,
-    validate_dimension,
-    validate_k,
-    validate_metric,
-    validate_path,
-    validate_query,
-    validate_search_quality,
-    validate_sparse_vector,
-    validate_storage_mode,
-    validate_text,
-    validate_timeout,
-    validate_url,
-    validate_weight,
-)
-
-# Explicit re-export list. Declaring ``__all__`` tells both pylint
-# (W0611 unused-import) and flake8 (F401) that every imported name is
-# part of the public surface of this shim module, removing the need for
-# per-line ``# noqa`` markers.
-__all__ = [
-    "ALLOWED_STORAGE_MODES",
-    "STORAGE_MODE_ALIASES",
-    "DEFAULT_TIMEOUT_MS",
-    "MAX_BATCH_SIZE",
-    "MAX_DIMENSION",
-    "MAX_K_VALUE",
-    "MAX_PATH_LENGTH",
-    "MAX_QUERY_LENGTH",
-    "MAX_SPARSE_VECTOR_SIZE",
-    "MAX_TEXT_LENGTH",
-    "MIN_DIMENSION",
-    "SecurityError",
-    "validate_batch_size",
-    "validate_collection_name",
-    "validate_column_name",
-    "validate_dimension",
-    "validate_k",
-    "validate_metric",
-    "validate_path",
-    "validate_query",
-    "validate_search_quality",
-    "validate_sparse_vector",
-    "validate_storage_mode",
-    "validate_text",
-    "validate_timeout",
-    "validate_url",
-    "validate_weight",
-]
+from velesdb_common.security import *  # noqa: F401,F403  # public re-export shim
+from velesdb_common.security import __all__  # noqa: F401  # mirror the public surface

--- a/integrations/llamaindex/src/llamaindex_velesdb/scroll_ops.py
+++ b/integrations/llamaindex/src/llamaindex_velesdb/scroll_ops.py
@@ -6,57 +6,12 @@ Extracted from ``vectorstore.py`` to keep each file under the 500 NLOC limit.
 from __future__ import annotations
 
 import logging
-from typing import Any, List, Optional
+from typing import List, Optional
 
 from llama_index.core.schema import TextNode
+from velesdb_common.scroll import scroll_one_batch
 
 logger = logging.getLogger(__name__)
-
-
-def _scroll_one_batch(
-    collection: Any,
-    cursor: Optional[int],
-    batch_size: int,
-) -> tuple:
-    """Pull one batch from a velesdb Collection using its scroll iterator.
-
-    Creates a fresh ``collection.scroll()`` iterator on every call and skips
-    batches until the one past *cursor* is found.
-
-    .. warning::
-        **Complexity: O(page_index * batch_size)** — this function re-scans
-        from the beginning of the collection on each call because the native
-        SDK does not yet expose a cursor-based ``scroll_batch`` method at the
-        Python level (the Rust ``VectorCollection.scroll_batch`` method is
-        internal to the ``ScrollIterator`` PyO3 class).  For large collections
-        with many pages, callers should either:
-
-        * keep the ``ScrollIterator`` alive across calls (use
-          ``collection.scroll(batch_size=N)`` as a Python generator and drive
-          it with ``next()``), or
-        * wait for a future ``Collection.scroll_batch(cursor, batch_size)``
-          Python binding that will provide true O(1) cursor seek.
-
-    Args:
-        collection: A ``velesdb.Collection`` instance.
-        cursor: Last-seen integer point ID from the previous call, or ``None``.
-        batch_size: Maximum points to return.
-
-    Returns:
-        A ``(points, next_cursor)`` tuple.  *points* is a list of raw dicts
-        with ``"id"``, ``"vector"``, and ``"payload"`` keys; *next_cursor* is
-        the last point ID (``int``) or ``None`` when the collection is
-        exhausted.
-    """
-    iterator = collection.scroll(batch_size=batch_size)
-    for batch in iterator:
-        if not batch:
-            continue
-        last_id = batch[-1].get("id")
-        if cursor is not None and last_id is not None and last_id <= cursor:
-            continue
-        return batch, (int(last_id) if last_id is not None else None)
-    return [], None
 
 
 class ScrollOpsMixin:
@@ -98,7 +53,7 @@ class ScrollOpsMixin:
         """
         if self._collection is None:  # type: ignore[attr-defined]
             return [], None
-        raw_batch, next_cursor = _scroll_one_batch(
+        raw_batch, next_cursor = scroll_one_batch(
             self._collection, cursor, batch_size  # type: ignore[attr-defined]
         )
         nodes: List[TextNode] = [

--- a/integrations/llamaindex/src/llamaindex_velesdb/scroll_ops.py
+++ b/integrations/llamaindex/src/llamaindex_velesdb/scroll_ops.py
@@ -9,7 +9,11 @@ import logging
 from typing import List, Optional
 
 from llama_index.core.schema import TextNode
-from velesdb_common.scroll import scroll_one_batch
+
+# Imported under the historical private name: ``vectorstore`` re-exports it and
+# the scroll tests import/monkeypatch it. Implementation lives in
+# velesdb_common.scroll (shared with the LangChain integration).
+from velesdb_common.scroll import scroll_one_batch as _scroll_one_batch
 
 logger = logging.getLogger(__name__)
 
@@ -53,7 +57,7 @@ class ScrollOpsMixin:
         """
         if self._collection is None:  # type: ignore[attr-defined]
             return [], None
-        raw_batch, next_cursor = scroll_one_batch(
+        raw_batch, next_cursor = _scroll_one_batch(
             self._collection, cursor, batch_size  # type: ignore[attr-defined]
         )
         nodes: List[TextNode] = [

--- a/integrations/llamaindex/src/llamaindex_velesdb/security.py
+++ b/integrations/llamaindex/src/llamaindex_velesdb/security.py
@@ -1,71 +1,9 @@
 """Security utilities for the LlamaIndex VelesDB integration.
 
-All validation logic lives in ``velesdb_common.security``.  This module
-re-exports every public name so that existing ``from llamaindex_velesdb.security
-import ...`` call-sites continue to work without modification.
+All validation logic lives in :mod:`velesdb_common.security`; this module
+re-exports its public surface so that existing
+``from llamaindex_velesdb.security import ...`` call-sites keep working.
 """
 
-from velesdb_common.security import (  # pylint: disable=unused-import  # public re-exports declared in __all__ below
-    ALLOWED_STORAGE_MODES,
-    STORAGE_MODE_ALIASES,
-    DEFAULT_TIMEOUT_MS,
-    MAX_BATCH_SIZE,
-    MAX_DIMENSION,
-    MAX_K_VALUE,
-    MAX_PATH_LENGTH,
-    MAX_QUERY_LENGTH,
-    MAX_SPARSE_VECTOR_SIZE,
-    MAX_TEXT_LENGTH,
-    MIN_DIMENSION,
-    SecurityError,
-    validate_batch_size,
-    validate_collection_name,
-    validate_column_name,
-    validate_dimension,
-    validate_k,
-    validate_metric,
-    validate_path,
-    validate_query,
-    validate_search_quality,
-    validate_sparse_vector,
-    validate_storage_mode,
-    validate_text,
-    validate_timeout,
-    validate_url,
-    validate_weight,
-)
-
-# Explicit re-export list. Declaring ``__all__`` tells both pylint
-# (W0611 unused-import) and flake8 (F401) that every imported name is
-# part of the public surface of this shim module, removing the need for
-# per-line ``# noqa`` markers.
-__all__ = [
-    "ALLOWED_STORAGE_MODES",
-    "STORAGE_MODE_ALIASES",
-    "DEFAULT_TIMEOUT_MS",
-    "MAX_BATCH_SIZE",
-    "MAX_DIMENSION",
-    "MAX_K_VALUE",
-    "MAX_PATH_LENGTH",
-    "MAX_QUERY_LENGTH",
-    "MAX_SPARSE_VECTOR_SIZE",
-    "MAX_TEXT_LENGTH",
-    "MIN_DIMENSION",
-    "SecurityError",
-    "validate_batch_size",
-    "validate_collection_name",
-    "validate_column_name",
-    "validate_dimension",
-    "validate_k",
-    "validate_metric",
-    "validate_path",
-    "validate_query",
-    "validate_search_quality",
-    "validate_sparse_vector",
-    "validate_storage_mode",
-    "validate_text",
-    "validate_timeout",
-    "validate_url",
-    "validate_weight",
-]
-
+from velesdb_common.security import *  # noqa: F401,F403  # public re-export shim
+from velesdb_common.security import __all__  # noqa: F401  # mirror the public surface


### PR DESCRIPTION
## Git Flow — resync post-#964
Depuis le dernier back-merge (#964), du travail qualité/docs a atterri sur `main` ; ce merge le ramène sur `develop` :
- **#965** dédup SDK (security/scroll/multi_query → `velesdb_common`)
- **#969** provenance des claims perf (machine/date/scope + bloc M5 Pro)
- **#962** port fusion RSF (déjà équivalent au #948 de develop → 0 conflit)

Après merge, **`develop` ⊇ `main`** (`HEAD..main = 0`). Le travail propre à develop (#970 test de-flake + sync ROADMAP, #948) repartira vers main à la prochaine release.

## Sûreté
Merge **sans conflit** (les deux `pipeline.rs`/`fusion/strategy.rs` sont identiques). `check-version-sync` ✅ + `check-promise-contract` ✅ + py_compile des modules SDK ✅.
