### PR TITLE
fix(release): npm publish must fail loudly, not swallow errors

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -481,7 +481,17 @@ jobs:
           cd pkg
           VERSION=${{ needs.validate.outputs.version }}
           node -e "const p=require('./package.json'); p.name='@wiscale/velesdb-wasm'; p.version='$VERSION'; require('fs').writeFileSync('package.json',JSON.stringify(p,null,2))"
-          npm publish --access public || echo "⏭️ WASM already published"
+          # Publish, but only tolerate a genuine "already published" (same version
+          # on npm). Any other failure (auth/E404-on-PUT, registry) MUST fail the
+          # job — do not swallow it (regression guard: v1.16.0 npm publish failed
+          # silently on an expired token and shipped nothing).
+          if npm publish --access public; then
+            echo "✅ published @wiscale/velesdb-wasm@$VERSION"
+          elif npm view "@wiscale/velesdb-wasm@$VERSION" version >/dev/null 2>&1; then
+            echo "⏭️ @wiscale/velesdb-wasm@$VERSION already on npm — skipping"
+          else
+            echo "❌ npm publish FAILED for @wiscale/velesdb-wasm@$VERSION (auth/registry error, NOT already-published)"; exit 1
+          fi
 
       - name: Build & Publish TypeScript SDK
         if: matrix.package == 'typescript-sdk'
@@ -490,7 +500,14 @@ jobs:
         run: |
           cd sdks/typescript
           npm install && npm run build
-          npm publish --access public || echo "⏭️ SDK already published"
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          if npm publish --access public; then
+            echo "✅ published @wiscale/velesdb-sdk@$PKG_VERSION"
+          elif npm view "@wiscale/velesdb-sdk@$PKG_VERSION" version >/dev/null 2>&1; then
+            echo "⏭️ @wiscale/velesdb-sdk@$PKG_VERSION already on npm — skipping"
+          else
+            echo "❌ npm publish FAILED for @wiscale/velesdb-sdk@$PKG_VERSION (auth/registry error, NOT already-published)"; exit 1
+          fi
 
       - name: Build & Publish Tauri Plugin
         if: matrix.package == 'tauri-plugin'
@@ -499,7 +516,14 @@ jobs:
         run: |
           cd crates/tauri-plugin-velesdb/guest-js
           npm install && npm run build
-          npm publish --access public || echo "⏭️ Tauri plugin already published"
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          if npm publish --access public; then
+            echo "✅ published @wiscale/tauri-plugin-velesdb@$PKG_VERSION"
+          elif npm view "@wiscale/tauri-plugin-velesdb@$PKG_VERSION" version >/dev/null 2>&1; then
+            echo "⏭️ @wiscale/tauri-plugin-velesdb@$PKG_VERSION already on npm — skipping"
+          else
+            echo "❌ npm publish FAILED for @wiscale/tauri-plugin-velesdb@$PKG_VERSION (auth/registry error, NOT already-published)"; exit 1
+          fi
 
   # ===========================================================================
   # 6. Create GitHub Release


### PR DESCRIPTION
## Problème (découvert sur le README main : npm bloqué en 1.15.0)
La v1.16.0 n'a **pas** été publiée sur npm. Les 3 packages (`@wiscale/velesdb-sdk`, `velesdb-wasm`, `tauri-plugin-velesdb`) sont restés en **1.15.0** alors que le release workflow affichait « Publish npm ✓ ».

**Cause** : les steps faisaient `npm publish --access public || echo "… already published"`. Le `|| echo` **avale toute erreur**. Le log v1.16.0 montre :
```
npm error 404 Not Found - PUT .../@wiscale%2fvelesdb-sdk
npm error 404 '@wiscale/velesdb-sdk@1.16.0' is not in this registry.
⏭️ SDK already published
```
Un **E404 sur PUT = échec d'AUTH** (npm renvoie 404 pour un PUT non autorisé sur un scope existant) → le secret **`NPM_TOKEN` est expiré/invalide**. Le `|| echo` a masqué l'échec → step vert, rien publié.

## Fix (ce PR)
Chaque step distingue désormais :
- publish OK → ✅
- version déjà sur npm (`npm view` la voit) → ⏭️ skip légitime
- **toute autre erreur (auth/registry) → `exit 1`** (le job échoue bruyamment)

## ⚠️ Action requise (hors PR — nécessite ton accès npm)
Ce PR empêche la récidive mais **ne republie pas** 1.16.0. Pour livrer npm 1.16.0 :
1. **Régénérer `NPM_TOKEN`** (token automation npm avec droits publish sur `@wiscale`) → mettre à jour le secret repo.
2. Re-déclencher : `gh workflow run release.yml -f version=1.16.0 -f publish_npm=true …` (ou `npm publish` manuel par package après `npm login`).
