### PR TITLE
fix(bench): partial-file cleanup, bounded reader, and build_index batch consistency

### DIFF
--- a/crates/velesdb-core/benches/datasets/sift1m.rs
+++ b/crates/velesdb-core/benches/datasets/sift1m.rs
@@ -128,6 +128,11 @@ const GT_K: u32 = 100;
 const BASE_COUNT: usize = 1_000_000;
 const QUERY_COUNT: usize = 10_000;
 
+/// Hard cap on bytes read per individual file download.
+/// `sift_base.fvecs` is ~492 MiB (1M × 516 B); 600 MiB gives ~22 % headroom.
+/// Prevents a misconfigured or adversarial mirror from exhausting disk space.
+const MAX_DOWNLOAD_BYTES: u64 = 600 * 1024 * 1024;
+
 // Fallback fingerprints used when the JSON sidecar is absent. The
 // official INRIA distribution does not publish checksums for the
 // uncompressed files; the recommended workflow is to run the
@@ -237,26 +242,26 @@ fn ensure_cached(cache_dir: &Path) -> Result<(), DatasetError> {
 /// Downloads the SIFT1M dataset, trying the tarball mirror first and falling
 /// back to individual file downloads from Hugging Face on failure.
 fn fetch_dataset(cache_dir: &Path) -> Result<(), DatasetError> {
-    match download_and_extract(cache_dir) {
-        Ok(()) => return Ok(()),
-        Err(e) => {
-            eprintln!(
-                "[sift1m] primary tarball download failed: {e}\n\
-                 [sift1m] Trying individual file download from Hugging Face mirror …\n\
-                 [sift1m] Tip: set VELESDB_SIFT1M_URL to override the tarball URL, or\n\
-                 [sift1m]     set VELESDB_SIFT1M_DIR to a directory with pre-extracted files.\n\
-                 [sift1m]     FTP (manual): ftp://ftp.irisa.fr/local/texmex/corpus/sift.tar.gz"
-            );
-        }
+    if let Err(e) = download_and_extract(cache_dir) {
+        eprintln!(
+            "[sift1m] primary tarball download failed: {e}\n\
+             [sift1m] Trying individual file download from Hugging Face mirror …\n\
+             [sift1m] Tip: set VELESDB_SIFT1M_URL to override the tarball URL, or\n\
+             [sift1m]     set VELESDB_SIFT1M_DIR to a directory with pre-extracted files.\n\
+             [sift1m]     FTP (manual): ftp://ftp.irisa.fr/local/texmex/corpus/sift.tar.gz"
+        );
+        return download_individual_files(cache_dir);
     }
-    download_individual_files(cache_dir)
+    Ok(())
 }
 
 /// Downloads each of the three SIFT1M files individually from the HF mirror.
 ///
-/// Skips files that are already present on disk to support partial-retry
-/// scenarios. Uses a 600-second timeout to accommodate the 516 MB base file
-/// on slow connections.
+/// Already-complete files (present on disk from a previous successful run) are
+/// skipped. Partial files written by a failed prior attempt are removed on
+/// error so the next retry starts clean. The reader is capped at
+/// [`MAX_DOWNLOAD_BYTES`] to prevent a misconfigured mirror from exhausting
+/// disk space. Uses a 600-second timeout to accommodate the 516 MB base file.
 fn download_individual_files(cache_dir: &Path) -> Result<(), DatasetError> {
     for filename in [BASE_FILE, QUERY_FILE, GT_FILE] {
         let dest = cache_dir.join(filename);
@@ -271,7 +276,11 @@ fn download_individual_files(cache_dir: &Path) -> Result<(), DatasetError> {
             .call()
             .map_err(|e| DatasetError::Download(format!("GET {url}: {e}")))?;
         let mut out = File::create(&dest)?;
-        io::copy(&mut resp.into_reader(), &mut out)?;
+        let copy_result = io::copy(&mut resp.into_reader().take(MAX_DOWNLOAD_BYTES), &mut out);
+        if let Err(e) = copy_result {
+            let _ = fs::remove_file(&dest); // remove partial file so retry re-downloads cleanly
+            return Err(DatasetError::Io(e));
+        }
     }
     Ok(())
 }

--- a/crates/velesdb-core/benches/datasets/sift1m.rs
+++ b/crates/velesdb-core/benches/datasets/sift1m.rs
@@ -92,12 +92,29 @@ pub enum DatasetError {
     Io(#[from] io::Error),
 }
 
-/// HTTP mirror used as the default download URL. Override with
-/// `VELESDB_SIFT1M_URL` env for corporate mirrors. `ureq` only supports
-/// HTTP/HTTPS, so the INRIA FTP endpoint cannot be used here — the HTTP
-/// mirror served by `corpus-texmex.irisa.fr` is the canonical fetch
-/// target for this loader.
+/// Primary tarball mirror (INRIA TEXMEX corpus).
+///
+/// The original HTTP mirror at `corpus-texmex.irisa.fr` has been returning 404
+/// since mid-2025.  The FTP endpoint `ftp://ftp.irisa.fr/local/texmex/corpus/
+/// sift.tar.gz` is still live but `ureq` is HTTP-only and cannot reach it.
+///
+/// This constant is kept for backward compatibility with `VELESDB_SIFT1M_URL`
+/// overrides.  If this URL continues to fail, the loader automatically falls
+/// back to downloading the three dataset files individually from the Hugging
+/// Face mirror (`HF_MIRROR`).
+///
+/// Manual workaround (no network access at bench time):
+///   ```text
+///   wget ftp://ftp.irisa.fr/local/texmex/corpus/sift.tar.gz
+///   tar -xzf sift.tar.gz
+///   export VELESDB_SIFT1M_DIR=/path/to/extracted/sift/
+///   ```
 const DOWNLOAD_MIRROR: &str = "http://corpus-texmex.irisa.fr/sift.tar.gz";
+
+/// Hugging Face mirror hosting the three SIFT1M files individually.
+/// Used as automatic fallback when the primary tarball download fails.
+/// Dataset: <https://huggingface.co/datasets/qbo-odp/sift1m> (public, no auth).
+const HF_MIRROR: &str = "https://huggingface.co/datasets/qbo-odp/sift1m/resolve/main";
 
 /// Base vectors: 1M × 128D.
 const BASE_FILE: &str = "sift_base.fvecs";
@@ -212,9 +229,51 @@ fn ensure_cached(cache_dir: &Path) -> Result<(), DatasetError> {
             return Err(DatasetError::NotCached);
         }
         fs::create_dir_all(cache_dir)?;
-        download_and_extract(cache_dir)?;
+        fetch_dataset(cache_dir)?;
     }
     verify_all_fingerprints(cache_dir)
+}
+
+/// Downloads the SIFT1M dataset, trying the tarball mirror first and falling
+/// back to individual file downloads from Hugging Face on failure.
+fn fetch_dataset(cache_dir: &Path) -> Result<(), DatasetError> {
+    match download_and_extract(cache_dir) {
+        Ok(()) => return Ok(()),
+        Err(e) => {
+            eprintln!(
+                "[sift1m] primary tarball download failed: {e}\n\
+                 [sift1m] Trying individual file download from Hugging Face mirror …\n\
+                 [sift1m] Tip: set VELESDB_SIFT1M_URL to override the tarball URL, or\n\
+                 [sift1m]     set VELESDB_SIFT1M_DIR to a directory with pre-extracted files.\n\
+                 [sift1m]     FTP (manual): ftp://ftp.irisa.fr/local/texmex/corpus/sift.tar.gz"
+            );
+        }
+    }
+    download_individual_files(cache_dir)
+}
+
+/// Downloads each of the three SIFT1M files individually from the HF mirror.
+///
+/// Skips files that are already present on disk to support partial-retry
+/// scenarios. Uses a 600-second timeout to accommodate the 516 MB base file
+/// on slow connections.
+fn download_individual_files(cache_dir: &Path) -> Result<(), DatasetError> {
+    for filename in [BASE_FILE, QUERY_FILE, GT_FILE] {
+        let dest = cache_dir.join(filename);
+        if dest.is_file() {
+            eprintln!("[sift1m] {filename} already cached — skipping");
+            continue;
+        }
+        let url = format!("{HF_MIRROR}/{filename}");
+        eprintln!("[sift1m] downloading {url} → {}", dest.display());
+        let resp = ureq::get(&url)
+            .timeout(std::time::Duration::from_secs(600))
+            .call()
+            .map_err(|e| DatasetError::Download(format!("GET {url}: {e}")))?;
+        let mut out = File::create(&dest)?;
+        io::copy(&mut resp.into_reader(), &mut out)?;
+    }
+    Ok(())
 }
 
 /// Pinned SHA-256 fingerprints loaded from the JSON sidecar or inlined
@@ -274,7 +333,7 @@ pub fn compute_fingerprints(cache_dir: &Path) -> Result<PinnedFingerprints, Data
             return Err(DatasetError::NotCached);
         }
         fs::create_dir_all(cache_dir)?;
-        download_and_extract(cache_dir)?;
+        fetch_dataset(cache_dir)?;
     }
     Ok(PinnedFingerprints {
         base: hash_file(&cache_dir.join(BASE_FILE))?,

--- a/crates/velesdb-core/benches/sparse_benchmark.rs
+++ b/crates/velesdb-core/benches/sparse_benchmark.rs
@@ -15,8 +15,6 @@ use rand::rngs::StdRng;
 use rand::{RngExt, SeedableRng};
 
 use velesdb_core::index::sparse::{sparse_search, ScoredDoc, SparseInvertedIndex, SparseVector};
-#[cfg(feature = "internal-bench")]
-use velesdb_core::internal_bench;
 
 /// Sample size used for the recall validation pass.
 const RECALL_SAMPLE_SIZE: usize = 20;
@@ -124,12 +122,20 @@ fn build_index(corpus: &[SparseVector]) -> SparseInvertedIndex {
 
 fn sparse_insert_benchmarks(c: &mut Criterion) {
     let corpus = generate_splade_corpus(10_000, 42);
+    // Build the (id, vector) pairs once for batch-insert benchmarks.
+    let docs: Vec<(u64, SparseVector)> = corpus
+        .iter()
+        .cloned()
+        .enumerate()
+        .map(|(i, v)| (i as u64, v))
+        .collect();
+    let docs = Arc::new(docs);
 
     let mut group = c.benchmark_group("sparse_insert");
     group.sample_size(10);
     group.measurement_time(std::time::Duration::from_secs(10));
 
-    // Sequential insert of 10K documents
+    // Sequential insert of 10K documents (single-thread baseline).
     group.bench_function("sequential_10k", |b| {
         b.iter(|| {
             let index = SparseInvertedIndex::new();
@@ -140,57 +146,12 @@ fn sparse_insert_benchmarks(c: &mut Criterion) {
         });
     });
 
-    // Parallel insert of 10K documents (4 threads, rayon)
-    #[cfg(feature = "persistence")]
-    group.bench_function("parallel_10k_rayon_doc_granular", |b| {
-        use rayon::prelude::*;
+    // 4 threads × 2500-doc batch insert: lock acquired once per chunk, not per document.
+    // This is the correct parallel insert pattern — see insert_batch_chunk for details.
+    group.bench_function("parallel_10k_manual_4x2500_batch", |b| {
+        let docs = Arc::clone(&docs);
         b.iter(|| {
             let index = Arc::new(SparseInvertedIndex::new());
-            corpus.par_iter().enumerate().for_each(|(i, vec)| {
-                index.insert(black_box(i as u64), black_box(vec));
-            });
-            index
-        });
-    });
-
-    group.bench_function("parallel_10k_manual_4x2500_doc_granular", |b| {
-        b.iter(|| {
-            let index = Arc::new(SparseInvertedIndex::new());
-            let corpus = Arc::new(corpus.clone());
-            let mut handles = Vec::with_capacity(4);
-
-            for chunk_id in 0..4_usize {
-                let index = Arc::clone(&index);
-                let docs = Arc::clone(&corpus);
-                handles.push(std::thread::spawn(move || {
-                    let start = chunk_id * 2500;
-                    let end = start + 2500;
-                    for i in start..end {
-                        index.insert(i as u64, &docs[i]);
-                    }
-                }));
-            }
-
-            for handle in handles {
-                handle.join().expect("thread panicked");
-            }
-
-            index
-        });
-    });
-
-    #[cfg(feature = "internal-bench")]
-    group.bench_function("parallel_10k_manual_4x2500_chunked", |b| {
-        let docs: Vec<(u64, SparseVector)> = corpus
-            .iter()
-            .cloned()
-            .enumerate()
-            .map(|(i, vec)| (i as u64, vec))
-            .collect();
-
-        b.iter(|| {
-            let index = Arc::new(SparseInvertedIndex::new());
-            let docs = Arc::new(docs.clone());
             let mut handles = Vec::with_capacity(4);
 
             for chunk_id in 0..4_usize {
@@ -199,7 +160,7 @@ fn sparse_insert_benchmarks(c: &mut Criterion) {
                 handles.push(std::thread::spawn(move || {
                     let start = chunk_id * 2500;
                     let end = start + 2500;
-                    internal_bench::sparse_insert_batch(&index, &docs[start..end]);
+                    index.insert_batch_chunk(&docs[start..end]);
                 }));
             }
 
@@ -207,6 +168,21 @@ fn sparse_insert_benchmarks(c: &mut Criterion) {
                 handle.join().expect("thread panicked");
             }
 
+            index
+        });
+    });
+
+    // Rayon parallel batch insert: par_chunks dispatches 250-doc chunks across
+    // the thread pool, each acquiring the write lock once.
+    #[cfg(feature = "persistence")]
+    group.bench_function("parallel_10k_rayon_batch", |b| {
+        use rayon::prelude::*;
+        let docs = Arc::clone(&docs);
+        b.iter(|| {
+            let index = Arc::new(SparseInvertedIndex::new());
+            docs.par_chunks(250).for_each(|chunk| {
+                index.insert_batch_chunk(chunk);
+            });
             index
         });
     });
@@ -291,36 +267,46 @@ fn sparse_concurrent_benchmarks(c: &mut Criterion) {
     let corpus = generate_splade_corpus(10_000, 42);
     let queries = generate_splade_corpus(100, 123);
 
+    // Build (id, vector) pairs for batch insert in concurrent threads.
+    let all_docs: Arc<Vec<(u64, SparseVector)>> = Arc::new(
+        corpus
+            .iter()
+            .cloned()
+            .enumerate()
+            .map(|(i, v)| (i as u64, v))
+            .collect(),
+    );
+
     let mut group = c.benchmark_group("sparse_concurrent_insert_search");
     group.sample_size(10);
     group.measurement_time(std::time::Duration::from_secs(15));
 
-    // 16-thread benchmark: 8 inserting, 8 searching
+    // 16-thread benchmark: 8 inserting (batch), 8 searching.
+    // Insert threads use insert_batch_chunk to acquire the write lock once per
+    // 1000-doc chunk instead of 1000 times, matching production bulk-import usage.
     group.bench_function("16_threads_8_insert_8_search", |b| {
+        let all_docs = Arc::clone(&all_docs);
         b.iter(|| {
             let index = Arc::new(SparseInvertedIndex::new());
-            // Pre-load some data so searchers have something to find
-            for (i, vec) in corpus.iter().take(1000).enumerate() {
-                index.insert(i as u64, vec);
-            }
+            // Pre-load 1000 docs so search threads have something to find.
+            index.insert_batch_chunk(&all_docs[..1000]);
 
             let mut handles = Vec::with_capacity(16);
 
-            // 8 insert threads
+            // 8 insert threads — one batch per thread, no per-doc locking.
             for thread_id in 0..8_u64 {
                 let idx = Arc::clone(&index);
-                let docs = corpus.clone();
+                let docs = Arc::clone(&all_docs);
                 handles.push(std::thread::spawn(move || {
                     let start = (thread_id as usize * 1000) + 1000;
-                    let end = start + 1000;
-                    let end = end.min(docs.len());
-                    for i in start..end {
-                        idx.insert(i as u64, &docs[i % docs.len()]);
+                    let end = (start + 1000).min(docs.len());
+                    if start < end {
+                        idx.insert_batch_chunk(&docs[start..end]);
                     }
                 }));
             }
 
-            // 8 search threads
+            // 8 search threads.
             for thread_id in 0..8_u64 {
                 let idx = Arc::clone(&index);
                 let qs = queries.clone();
@@ -337,7 +323,6 @@ fn sparse_concurrent_benchmarks(c: &mut Criterion) {
                 h.join().expect("thread panicked");
             }
 
-            // Verify no deadlock occurred — index is still usable
             assert!(index.doc_count() > 0);
         });
     });

--- a/crates/velesdb-core/benches/sparse_benchmark.rs
+++ b/crates/velesdb-core/benches/sparse_benchmark.rs
@@ -112,11 +112,19 @@ fn generate_splade_corpus(n: usize, seed: u64) -> Vec<SparseVector> {
 }
 
 /// Build an index pre-loaded with a corpus.
+///
+/// Uses [`SparseInvertedIndex::insert_batch_chunk`] so the write lock is
+/// acquired once for the whole corpus, consistent with the production
+/// bulk-import pattern.
 fn build_index(corpus: &[SparseVector]) -> SparseInvertedIndex {
     let index = SparseInvertedIndex::new();
-    for (i, vec) in corpus.iter().enumerate() {
-        index.insert(i as u64, vec);
-    }
+    let docs: Vec<(u64, SparseVector)> = corpus
+        .iter()
+        .cloned()
+        .enumerate()
+        .map(|(i, v)| (i as u64, v))
+        .collect();
+    index.insert_batch_chunk(&docs);
     index
 }
 

--- a/crates/velesdb-core/src/index/hnsw/native/graph/mod.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/graph/mod.rs
@@ -405,6 +405,47 @@ impl<D: DistanceEngine> NativeHnsw<D> {
     /// Acquires locks in correct rank order: vectors (10) → layers (20).
     /// This avoids repeated lock acquire/release in tight search loops (F-03/F-04).
     ///
+    /// # Concurrent-search scalability (issue #967 — 2026-06-01)
+    ///
+    /// Benchmark (`scalability_benchmark::concurrent_queries`, M5 Pro):
+    /// 8 parallel searches achieve ~5× throughput instead of the ideal ~8×,
+    /// with per-batch latency 66% higher than single-threaded.
+    ///
+    /// Both locks are held for the **entire** HNSW traversal (~10 ms, 300-500
+    /// distance evaluations at layer 0). Analysis of potential causes:
+    ///
+    /// - **`parking_lot::RwLock` reader-counter bouncing** — each thread does
+    ///   one `fetch_add` + one `fetch_sub` on the shared atomic lock word. At
+    ///   8 threads × 2 ops = 16 atomic ops over 10 ms, this adds <1 µs
+    ///   overhead and cannot explain the 66% regression.
+    ///
+    /// - **Memory bandwidth / L3 pressure** — a 6.4 MB index (100 K × 512 B)
+    ///   fits comfortably in the M5 Pro's 32 MB L3. However on larger indices
+    ///   (≥ 512 MB for 1 M vectors) random DRAM accesses do become the
+    ///   bottleneck; the slowdown is then an inherent physical limit, not a
+    ///   software bug.
+    ///
+    /// - **Inter-cluster L2 cache traffic** — M5 Pro has two clusters of 4
+    ///   P-cores, each with 16 MB L2. Threads on different clusters accessing
+    ///   overlapping cache lines must transfer via shared L3, limiting
+    ///   effective bandwidth.
+    ///
+    /// **Recommended investigation before any code change**: profile with
+    /// `cargo bench --bench scalability_benchmark` while varying index size
+    /// (10 K, 100 K, 1 M vectors) and thread-to-cluster pinning to distinguish
+    /// bandwidth-bound from contention-bound behaviour.
+    ///
+    /// **If contention-bound**: replace the two `RwLock` guards with
+    /// `Arc`-snapshot reads — clone `Arc<ContiguousVectors>` and
+    /// `Arc<Vec<Layer>>` under a brief lock, release immediately, then run the
+    /// traversal lock-free. `arc-swap` is already a workspace dependency.
+    /// Caveat: `Arc::make_mut` on concurrent insert paths triggers
+    /// copy-on-write, which is O(N·D) for vectors and O(N·M) for layers.
+    /// Measure insert throughput regression before shipping.
+    ///
+    /// **If bandwidth-bound**: the ~5× scaling at 8 threads is expected and
+    /// not a correctness or software issue.
+    ///
     /// If vector storage is not yet initialized, the closure is **not** called
     /// and `R::default()` is returned.
     #[inline]

--- a/crates/velesdb-core/src/sparse_index/inverted_index.rs
+++ b/crates/velesdb-core/src/sparse_index/inverted_index.rs
@@ -142,14 +142,15 @@ impl SparseInvertedIndex {
 
     /// Inserts a batch of sparse vectors while acquiring the mutable lock once.
     ///
+    /// Acquires the write lock once for the entire slice, making this significantly
+    /// faster than calling [`insert`] per document in a parallel/bulk context.
+    /// Callers building a parallel bulk-import pipeline should chunk their input
+    /// and call this method once per chunk rather than calling `insert` per document.
+    ///
     /// Preserves the current per-term upsert semantics of repeated `insert()`:
     /// later entries in the batch overwrite earlier entries for the same
     /// `(term_id, doc_id)` pair, while untouched terms from prior inserts remain.
-    // Reason: called from `collection::core::crud::upsert_bulk` and `internal_bench::sparse_insert_batch`.
-    // The dead_code lint has a false positive because the call site reaches this method through
-    // a `RwLockWriteGuard<BTreeMap<_,SparseInvertedIndex>>` deref chain which the lint does not trace.
-    #[allow(dead_code)] // Reason: False positive — called via RwLockWriteGuard deref chain
-    pub(crate) fn insert_batch_chunk(&self, docs: &[(u64, SparseVector)]) {
+    pub fn insert_batch_chunk(&self, docs: &[(u64, SparseVector)]) {
         if docs.is_empty() {
             return;
         }


### PR DESCRIPTION
## Context

This PR builds on PR #975 (`claude/admiring-fermi-GE51D`) which introduced the HuggingFace fallback mirror for SIFT1M and promoted `insert_batch_chunk` to `pub`. During a 5-perspective review of that PR, two correctness/safety issues and one consistency gap were found. This PR fixes all three.

---

## Changes

### fix(bench/sift1m): partial-file residue + unbounded reader — `download_individual_files`

**Issue 1 — Partial file left on disk after failed download**

If `io::copy` was interrupted mid-download (network drop, disk full), the truncated file remained on disk. On the next retry, `dest.is_file()` returned `true`, the download was silently skipped, and `verify_all_fingerprints` failed with a confusing hash-mismatch error instead of a clear "incomplete download" message.

**Fix:** `fs::remove_file(&dest)` on `io::copy` failure — partial file is removed so the next retry starts from a clean state.

**Issue 2 — Unbounded HTTP reader**

`resp.into_reader()` had no size cap. A misconfigured or adversarial mirror could serve an unbounded stream and exhaust disk space.

**Fix:** `.take(MAX_DOWNLOAD_BYTES)` caps each file at 600 MiB. `sift_base.fvecs` is ~492 MiB; the 22 % headroom covers any minor corpus revision. Constant is documented with the size rationale.

**Bonus — idiomatic `if let Err`**

`fetch_dataset` used a `match` with an early `return Ok(())` in the `Ok` arm. Replaced with `if let Err(e)` which is the idiomatic pattern when only the error arm carries a body.

---

### perf(bench/sparse): use `insert_batch_chunk` in `build_index`

`build_index` (used as warm-up for search benchmarks) called `insert()` per document — 10 000 individual write-lock acquisitions. Now that `insert_batch_chunk` is `pub`, it is used here too, consistent with the production bulk-import pattern documented in PR #975.

---

## Test plan

- [x] `cargo check -p velesdb-core` — clean
- [x] `cargo check -p velesdb-core --features bench-sift1m` — clean
- [x] `cargo check -p velesdb-core --bench sparse_benchmark` — clean
- [x] `cargo clippy -p velesdb-core --features bench-sift1m -- -D warnings` — zero warnings
- [x] `cargo test -p velesdb-core --lib` — **4903 passed, 0 failed** (2026-06-02)

## Date

2026-06-02
