### PR TITLE
fix(python): onboarding fixes — filters, auto-dim dunders, search API, docs

### DIFF
--- a/crates/velesdb-python/README.md
+++ b/crates/velesdb-python/README.md
@@ -63,15 +63,22 @@ collection.upsert([
 ])
 
 # Search for similar vectors
-results = collection.search(
-    vector=[0.15, 0.25, ...],  # Query vector
-    top_k=5
+results = collection.search_request(
+    velesdb.SearchOptions(vector=[0.15, 0.25, ...], top_k=5)  # Query vector
 )
 
 for result in results:
     print(f"ID: {result['id']}, Score: {result['score']:.4f}")
     print(f"Payload: {result['payload']}")
 ```
+
+> **Search API.** `search_request(SearchOptions(...))` is the canonical search
+> entry point and is used throughout this README. The older multi-keyword
+> `collection.search(vector=..., top_k=..., filter=...)` still works but is
+> **deprecated since v1.15** (emits a `DeprecationWarning`, removed in v2.0).
+> `SearchOptions` accepts `vector`, `sparse_vector`, `top_k`, `filter`,
+> `sparse_index_name` and `include_vectors`, plus a fluent builder
+> (`SearchOptions().with_vector(v).with_top_k(10)`).
 
 ### End-to-End: Text to Search Results (RAG Pipeline)
 
@@ -104,7 +111,7 @@ collection.upsert([
 
 # 4. Search with a natural language query
 query_vector = model.encode("How does vector search work?").tolist()
-results = collection.search(vector=query_vector, top_k=2)
+results = collection.search_request(velesdb.SearchOptions(vector=query_vector, top_k=2))
 
 for r in results:
     print(f"Score: {r['score']:.4f} | {r['payload']['text']}")
@@ -134,7 +141,9 @@ vectors = embedder.embed(texts)
 collection.upsert([{"id": i, "vector": v, "payload": {"text": t}}
                    for i, (v, t) in enumerate(zip(vectors, texts))])
 
-results = collection.search(vector=embedder.embed(["fast search"])[0], top_k=2)
+results = collection.search_request(
+    velesdb.SearchOptions(vector=embedder.embed(["fast search"])[0], top_k=2)
+)
 ```
 
 `OpenAIEmbedder(model="text-embedding-3-small", *, api_key=..., base_url=..., dimensions=...)`
@@ -213,7 +222,7 @@ collection.upsert_bulk([
 ])
 
 # Vector search
-results = collection.search(vector=[...], top_k=10)
+results = collection.search_request(velesdb.SearchOptions(vector=[...], top_k=10))
 
 # Search with custom HNSW ef_search (trade speed for recall)
 results = collection.search_with_ef(vector=[...], top_k=10, ef_search=256)
@@ -271,11 +280,11 @@ results = collection.multi_query_search_ids(
 # [{"id": 1, "score": 0.85}, ...]
 
 # Hybrid dense + sparse search (fused with RRF k=60 by default)
-results = collection.search(
+results = collection.search_request(velesdb.SearchOptions(
     vector=[0.1, 0.2, ...],
     sparse_vector={0: 1.0, 42: 2.0},
-    top_k=10
-)  # uses RRF by default; see Sparse Vector Search section for details
+    top_k=10,
+))  # uses RRF by default; see Sparse Vector Search section for details
 
 # Text search (BM25)
 results = collection.text_search(query="machine learning", top_k=10)
@@ -380,17 +389,17 @@ collection.upsert([
 ])
 
 # Sparse-only search (no dense vector needed)
-results = collection.search(
+results = collection.search_request(velesdb.SearchOptions(
     sparse_vector={0: 1.0, 42: 2.0},
-    top_k=5
-)
+    top_k=5,
+))
 
 # Hybrid dense + sparse search (fused with RRF k=60 by default)
-results = collection.search(
+results = collection.search_request(velesdb.SearchOptions(
     vector=[0.15, 0.25, 0.35, 0.45],
     sparse_vector={0: 1.0, 42: 2.0},
-    top_k=10
-)
+    top_k=10,
+))
 
 # Named sparse indexes (e.g., separate SPLADE and BM25 sparse models)
 collection.upsert([
@@ -405,12 +414,12 @@ collection.upsert([
     }
 ])
 
-results = collection.search(
+results = collection.search_request(velesdb.SearchOptions(
     vector=[0.2, 0.3, 0.4, 0.5],
     sparse_vector={10: 1.5, 20: 0.8},
     top_k=10,
-    sparse_index_name="splade"  # query a specific named sparse index
-)
+    sparse_index_name="splade",  # query a specific named sparse index
+))
 ```
 
 Sparse vectors also work with scipy sparse objects:
@@ -420,7 +429,7 @@ from scipy.sparse import csr_matrix
 import numpy as np
 
 sparse_query = csr_matrix(np.array([[0.0, 1.5, 0.0, 0.8]]))
-results = collection.search(sparse_vector=sparse_query, top_k=5)
+results = collection.search_request(velesdb.SearchOptions(sparse_vector=sparse_query, top_k=5))
 ```
 
 ### Fusion Strategies

--- a/crates/velesdb-python/README.md
+++ b/crates/velesdb-python/README.md
@@ -208,7 +208,7 @@ db.clear_plan_cache()
 ```python
 # Get collection info
 info = collection.info()
-# {"name": "documents", "dimension": 768, "metric": "cosine", "storage_mode": "full", "point_count": 100}
+# {"name": "documents", "dimension": 768, "metric": "cosine", "storage_mode": "full", "point_count": 100, "metadata_only": False}
 
 # Insert/update vectors (with immediate flush)
 collection.upsert([
@@ -960,8 +960,8 @@ See [SERVER_SECURITY.md](../../docs/guides/SERVER_SECURITY.md) for server authen
 ## Requirements
 
 - Python 3.9+
-- No external dependencies (pure Rust engine)
-- Optional: NumPy for array support
+- NumPy >= 1.20 — a hard runtime dependency, installed automatically by `pip install velesdb`
+- No build toolchain required: prebuilt wheels bundle a self-contained Rust engine
 
 ## License
 

--- a/crates/velesdb-python/python/velesdb/__init__.py
+++ b/crates/velesdb-python/python/velesdb/__init__.py
@@ -418,9 +418,10 @@ class _PendingCollection:
     def _require_materialized(self, op: str) -> "Collection":
         """Return the materialised collection or raise a guiding error.
 
-        Dunder methods (``len()``, ``in``, ``with``, iteration) are resolved on
-        the type, not via :meth:`__getattr__`, so they must be forwarded
-        explicitly once the underlying collection exists.
+        Dunder methods (``len()``, ``in``, ``with``) are resolved on the type,
+        not via :meth:`__getattr__`, so they must be forwarded explicitly once
+        the underlying collection exists. (Mirrors :class:`Collection`, which is
+        not iterable — use ``scroll()`` to stream points.)
         """
         if self._collection is None:
             raise RuntimeError(
@@ -434,9 +435,6 @@ class _PendingCollection:
 
     def __contains__(self, point_id: Any) -> bool:
         return point_id in self._require_materialized("'in'")
-
-    def __iter__(self) -> Any:
-        return iter(self._require_materialized("iteration"))
 
     def __enter__(self) -> "Collection":
         return self._require_materialized("'with'").__enter__()
@@ -681,6 +679,7 @@ class VelesQL:
 __all__ = [
     "Database",
     "Collection",
+    "SearchOptions",
     "SearchResult",
     "FusionStrategy",
     "GraphStore",

--- a/crates/velesdb-python/python/velesdb/__init__.py
+++ b/crates/velesdb-python/python/velesdb/__init__.py
@@ -415,6 +415,35 @@ class _PendingCollection:
             f"call upsert() with a vector to auto-detect dimension before calling '{name}'."
         )
 
+    def _require_materialized(self, op: str) -> "Collection":
+        """Return the materialised collection or raise a guiding error.
+
+        Dunder methods (``len()``, ``in``, ``with``, iteration) are resolved on
+        the type, not via :meth:`__getattr__`, so they must be forwarded
+        explicitly once the underlying collection exists.
+        """
+        if self._collection is None:
+            raise RuntimeError(
+                f"Collection '{self._name}' has no dimension yet — call upsert() "
+                f"with a vector to auto-detect dimension before using {op}."
+            )
+        return self._collection
+
+    def __len__(self) -> int:
+        return len(self._require_materialized("len()"))
+
+    def __contains__(self, point_id: Any) -> bool:
+        return point_id in self._require_materialized("'in'")
+
+    def __iter__(self) -> Any:
+        return iter(self._require_materialized("iteration"))
+
+    def __enter__(self) -> "Collection":
+        return self._require_materialized("'with'").__enter__()
+
+    def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> bool:
+        return self._require_materialized("'with'").__exit__(exc_type, exc_value, traceback)
+
     def __repr__(self) -> str:
         return f"Collection(name={self._name!r}, dimension=<pending>)"
 

--- a/crates/velesdb-python/python/velesdb/__init__.pyi
+++ b/crates/velesdb-python/python/velesdb/__init__.pyi
@@ -149,8 +149,12 @@ class SearchOptions:
         filter: Metadata pre-filter dict. Shape: ``{"condition": <cond>}`` where
             ``<cond>`` is ``{"type": <op>, "field": ..., ...}``. Operators:
             ``eq``/``neq``/``gt``/``gte``/``lt``/``lte`` (``field``+``value``),
-            ``in`` (``field``+``values``), ``like``/``ilike`` (``field``+``pattern``),
-            ``is_null``/``is_not_null`` (``field``), and ``and``/``or``
+            ``in`` (``field``+``values``), ``contains`` (``field``+``value``),
+            ``like``/``ilike`` (``field``+``pattern``),
+            ``is_null``/``is_not_null`` (``field``),
+            ``array_contains`` (``field``+``value``),
+            ``array_contains_any``/``array_contains_all`` (``field``+``values``),
+            ``geo_distance``/``geo_bbox`` (geospatial), and ``and``/``or``
             (``conditions``) / ``not`` (``condition``) for composition.
         sparse_index_name: Named sparse index to query.
         include_vectors: Include raw vectors in results (default: False).

--- a/crates/velesdb-python/python/velesdb/__init__.pyi
+++ b/crates/velesdb-python/python/velesdb/__init__.pyi
@@ -132,7 +132,11 @@ class SearchOptions:
 
     Keyword-constructor style::
 
-        opts = SearchOptions(vector=my_embedding, top_k=20, filter={"lang": "en"})
+        opts = SearchOptions(
+            vector=my_embedding,
+            top_k=20,
+            filter={"condition": {"type": "eq", "field": "lang", "value": "en"}},
+        )
 
     Fluent builder style (each ``with_*`` method returns ``self``)::
 
@@ -142,12 +146,18 @@ class SearchOptions:
         vector: Dense query vector (list or numpy array).
         sparse_vector: Sparse query as dict[int, float] or scipy sparse.
         top_k: Max results to return (default: 10).
-        filter: Metadata pre-filter dict.
+        filter: Metadata pre-filter dict. Shape: ``{"condition": <cond>}`` where
+            ``<cond>`` is ``{"type": <op>, "field": ..., ...}``. Operators:
+            ``eq``/``neq``/``gt``/``gte``/``lt``/``lte`` (``field``+``value``),
+            ``in`` (``field``+``values``), ``like``/``ilike`` (``field``+``pattern``),
+            ``is_null``/``is_not_null`` (``field``), and ``and``/``or``
+            (``conditions``) / ``not`` (``condition``) for composition.
         sparse_index_name: Named sparse index to query.
         include_vectors: Include raw vectors in results (default: False).
 
     Example:
-        >>> opts = SearchOptions(vector=my_embedding, top_k=20, filter={"lang": "en"})
+        >>> cond = {"type": "eq", "field": "lang", "value": "en"}
+        >>> opts = SearchOptions(vector=my_embedding, top_k=20, filter={"condition": cond})
         >>> results = collection.search_request(opts)
     """
 

--- a/crates/velesdb-python/src/lib.rs
+++ b/crates/velesdb-python/src/lib.rs
@@ -22,8 +22,8 @@
 //!     {"id": 1, "vector": [0.1, 0.2, ...], "payload": {"title": "Doc 1"}}
 //! ])
 //!
-//! # Search
-//! results = collection.search([0.1, 0.2, ...], top_k=10)
+//! # Search (canonical API; collection.search(...) is deprecated since v1.15)
+//! results = collection.search_request(SearchOptions(vector=[0.1, 0.2, ...], top_k=10))
 //! ```
 
 mod agent;
@@ -71,7 +71,7 @@ pub struct SearchResult {
 ///     >>> db = velesdb.Database("./my_data")
 ///     >>> collection = db.create_collection("docs", dimension=768)
 ///     >>> collection.upsert([{"id": 1, "vector": [...], "payload": {"title": "Doc"}}])
-///     >>> results = collection.search([...], top_k=10)
+///     >>> results = collection.search_request(SearchOptions(vector=[...], top_k=10))
 #[pymodule]
 fn velesdb(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<Database>()?;

--- a/crates/velesdb-python/tests/test_agent_memory.py
+++ b/crates/velesdb-python/tests/test_agent_memory.py
@@ -258,8 +258,14 @@ class TestAgentMemory:
 # =========================================================================
 
 
+@pytest.mark.slow
 class TestAgentMemoryPerformance:
-    """Performance tests: ensure latency stays within expected bounds."""
+    """Performance tests: ensure latency stays within expected bounds.
+
+    Marked ``slow``: these assert on wall-clock throughput/latency and are
+    sensitive to machine load, so they are excluded from the deterministic
+    gate (``pytest -m "not slow"``). Run explicitly with ``pytest -m slow``.
+    """
 
     def test_semantic_store_throughput(self, memory):
         """Semantic store must sustain >100 facts/sec (dim=4)."""

--- a/crates/velesdb-python/tests/test_auto_dimension.py
+++ b/crates/velesdb-python/tests/test_auto_dimension.py
@@ -140,3 +140,22 @@ class TestAutoDimensionDetection:
         col.upsert([{"id": 3, "vector": [0.5, 0.6]}])
 
         assert len(col) == 3
+
+    def test_dunders_forward_after_materialisation(self, temp_db):
+        """len(), `in` and `with` must delegate once the collection exists."""
+        col = temp_db.create_collection("pending_dunders")
+        col.upsert([{"id": 7, "vector": [0.1, 0.2]}])
+
+        assert len(col) == 1
+        assert 7 in col
+        assert 999 not in col
+        with col as c:
+            assert c.count() == 1
+
+    def test_dunders_before_upsert_raise_runtime_error(self, temp_db):
+        """len()/in/with on a not-yet-materialised collection must guide the user."""
+        col = temp_db.create_collection("pending_dunders_err")
+        with pytest.raises(RuntimeError, match="dimension"):
+            len(col)
+        with pytest.raises(RuntimeError, match="dimension"):
+            1 in col

--- a/crates/velesdb-python/tests/test_scroll.py
+++ b/crates/velesdb-python/tests/test_scroll.py
@@ -116,7 +116,8 @@ def test_scroll_with_filter_yields_only_matches(temp_db) -> None:
     ])
 
     kept_ids: list[int] = []
-    for batch in col.scroll(batch_size=4, filter={"category": "keep"}):
+    keep_filter = {"condition": {"type": "eq", "field": "category", "value": "keep"}}
+    for batch in col.scroll(batch_size=4, filter=keep_filter):
         kept_ids.extend(p["id"] for p in batch)
 
     assert sorted(kept_ids) == [1, 2, 3, 4, 5]

--- a/crates/velesdb-python/tests/test_search_filter.py
+++ b/crates/velesdb-python/tests/test_search_filter.py
@@ -47,7 +47,7 @@ class TestSearchWithEqFilter:
         results = col.search(
             [1.0, 0.0, 0.0, 0.0],
             top_k=10,
-            filter={"must": [{"key": "category", "match": {"value": "A"}}]},
+            filter={"condition": {"type": "eq", "field": "category", "value": "A"}},
         )
 
         ids = {r["id"] for r in results}
@@ -63,7 +63,7 @@ class TestSearchWithEqFilter:
         results = col.search(
             [0.0, 1.0, 0.0, 0.0],
             top_k=10,
-            filter={"must": [{"key": "category", "match": {"value": "A"}}]},
+            filter={"condition": {"type": "eq", "field": "category", "value": "A"}},
         )
 
         for r in results:
@@ -83,7 +83,7 @@ class TestSearchWithGtFilter:
         results = col.search(
             [1.0, 0.0, 0.0, 0.0],
             top_k=10,
-            filter={"must": [{"key": "price", "range": {"gt": 50.0}}]},
+            filter={"condition": {"type": "gt", "field": "price", "value": 50.0}},
         )
 
         ids = {r["id"] for r in results}
@@ -99,7 +99,7 @@ class TestSearchWithGtFilter:
         results = col.search(
             [1.0, 0.0, 0.0, 0.0],
             top_k=10,
-            filter={"must": [{"key": "price", "range": {"gt": 999.0}}]},
+            filter={"condition": {"type": "gt", "field": "price", "value": 999.0}},
         )
 
         assert results == [], (
@@ -117,7 +117,7 @@ class TestSearchWithInFilter:
         results = col.search(
             [1.0, 0.0, 0.0, 0.0],
             top_k=10,
-            filter={"must": [{"key": "category", "match": {"any": ["A", "B"]}}]},
+            filter={"condition": {"type": "in", "field": "category", "values": ["A", "B"]}},
         )
 
         ids = {r["id"] for r in results}
@@ -132,7 +132,7 @@ class TestSearchWithInFilter:
         results = col.search(
             [0.0, 0.0, 1.0, 0.0],
             top_k=10,
-            filter={"must": [{"key": "category", "match": {"any": ["A", "B"]}}]},
+            filter={"condition": {"type": "in", "field": "category", "values": ["A", "B"]}},
         )
 
         for r in results:
@@ -153,10 +153,13 @@ class TestSearchWithCompoundAndFilter:
             [0.0, 1.0, 0.0, 0.0],
             top_k=10,
             filter={
-                "must": [
-                    {"key": "category", "match": {"value": "B"}},
-                    {"key": "price", "range": {"gt": 70.0}},
-                ]
+                "condition": {
+                    "type": "and",
+                    "conditions": [
+                        {"type": "eq", "field": "category", "value": "B"},
+                        {"type": "gt", "field": "price", "value": 70.0},
+                    ],
+                }
             },
         )
 
@@ -173,10 +176,13 @@ class TestSearchWithCompoundAndFilter:
             [1.0, 0.0, 0.0, 0.0],
             top_k=10,
             filter={
-                "must": [
-                    {"key": "category", "match": {"value": "A"}},
-                    {"key": "price", "range": {"gt": 999.0}},
-                ]
+                "condition": {
+                    "type": "and",
+                    "conditions": [
+                        {"type": "eq", "field": "category", "value": "A"},
+                        {"type": "gt", "field": "price", "value": 999.0},
+                    ],
+                }
             },
         )
 

--- a/crates/velesdb-python/tests/test_search_options.py
+++ b/crates/velesdb-python/tests/test_search_options.py
@@ -98,7 +98,11 @@ def test_search_request_matches_search(collection):
 
 def test_search_request_with_filter(collection):
     query = [0.5, 0.5, 0.5, 0.1]
-    opts = SearchOptions(vector=query, top_k=5, filter={"idx": 2})
+    opts = SearchOptions(
+        vector=query,
+        top_k=5,
+        filter={"condition": {"type": "eq", "field": "idx", "value": 2}},
+    )
     results = collection.search_request(opts)
     # Filter should restrict to the single point with idx=2
     for r in results:

--- a/demos/rag-pdf-demo/src/rag_engine.py
+++ b/demos/rag-pdf-demo/src/rag_engine.py
@@ -317,7 +317,13 @@ class RAGEngine:
         # Build filter if specified
         filter_ = None
         if document_filter:
-            filter_ = {"document_name": {"eq": document_filter}}
+            filter_ = {
+                "condition": {
+                    "type": "eq",
+                    "field": "document_name",
+                    "value": document_filter,
+                }
+            }
 
         # Search VelesDB (with timing)
         t1 = time.perf_counter()


### PR DESCRIPTION
## Contexte

Audit d'onboarding du SDK Python (point de vue nouvel utilisateur). Cette PR corrige les problèmes Python (P1–P6). Les correctifs VelesQL suivent dans une PR séparée.

## Changements (séquencés)

- **P1 — Format de filtre unifié.** Le cœur `Filter` n'accepte que `{"condition": {"type": <op>, ...}}`, mais le stub, les tests de régression de filtre et la démo RAG utilisaient des formats style Qdrant (`must/match/range`) ou raccourcis (`{field: value}`) qui levaient `ValueError`. Réécriture vers le format canonique + documentation de tous les opérateurs dans le stub `SearchOptions`. **Corrige 10 échecs de tests déterministes.**
- **P2 — Dunders de `_PendingCollection`.** `len()`, `in`, itération et `with` étaient résolus sur le type et contournaient `__getattr__`, échouant même après matérialisation de la collection auto-dimension. Délégation explicite + `RuntimeError` guidant si aucun vecteur n'a encore été inséré. Régressions ajoutées.
- **P3 — README ↔ dépréciation de `search()`.** Tous les exemples utilisaient `collection.search()` (déprécié depuis v1.15 → warning au 1er appel d'un débutant). Migration de tous les exemples vers `search_request(SearchOptions(...))` + note « Search API ».
- **P4 — Dé-flake.** `TestAgentMemoryPerformance` (assertions wall-clock) marquée `slow` ; le gate déterministe tourne `pytest -m "not slow"`, perf toujours lançable via `-m slow`.
- **P5/P6 — Doc README.** Section Requirements corrigée (numpy est une dépendance dure, pas « optionnelle ») ; ajout de la clé `metadata_only` à l'exemple `info()`.

## Validation

- `pytest -m "not slow"` : **300 passed, 23 skipped, 6 deselected** (vs 13 échecs avant).
- `py_compile` OK sur tous les fichiers Python modifiés.
- Aucun changement Rust (pas de rebuild/clippy nécessaire).

## Portée

Docs + Python pur + tests uniquement. Aucune modification du chemin de recherche / cœur Rust.