### PR TITLE
fix(velesql): onboarding DX — accurate cheat sheet, subquery status, parser hints, REPL docs

### DIFF
--- a/crates/velesdb-cli/README.md
+++ b/crates/velesdb-cli/README.md
@@ -600,32 +600,27 @@ The `USING FUSION` clause at query level combines results from multiple search s
 -- Dense vector + BM25 full-text combined with RRF
 SELECT * FROM documents
 WHERE vector NEAR $v AND content MATCH 'rust programming'
-USING FUSION(strategy = 'rrf', k = 60)
-LIMIT 10;
+LIMIT 10 USING FUSION(strategy = 'rrf', k = 60);
 
 -- Dense + sparse vector fusion with RSF
 SELECT * FROM documents
 WHERE vector NEAR $dense AND vector SPARSE_NEAR $sparse
-USING FUSION(strategy = 'rsf', dense_w = 0.7, sparse_w = 0.3)
-LIMIT 10;
+LIMIT 10 USING FUSION(strategy = 'rsf', dense_w = 0.7, sparse_w = 0.3);
 
 -- Weighted fusion
 SELECT * FROM docs
 WHERE vector NEAR $v
-USING FUSION(strategy = 'weighted', vector_weight = 0.7, graph_weight = 0.3)
-LIMIT 10;
+LIMIT 10 USING FUSION(strategy = 'weighted', vector_weight = 0.7, graph_weight = 0.3);
 
 -- Maximum fusion (take best score)
 SELECT * FROM docs
 WHERE vector NEAR $v
-USING FUSION(strategy = 'maximum')
-LIMIT 10;
+LIMIT 10 USING FUSION(strategy = 'maximum');
 
 -- Default USING FUSION (defaults to RRF)
 SELECT * FROM docs
 WHERE vector NEAR $v
-USING FUSION
-LIMIT 10;
+LIMIT 10 USING FUSION;
 ```
 
 ### Graph MATCH Queries

--- a/crates/velesdb-core/src/velesql/parser/hints.rs
+++ b/crates/velesdb-core/src/velesql/parser/hints.rs
@@ -1,0 +1,118 @@
+//! Friendlier syntax-error messages for the `VelesQL` parser.
+//!
+//! pest's raw error already renders a caret diagram, but it lists grammar rule
+//! names (`expected select_stmt, match_query, …`) that mean nothing to a user.
+//! These helpers prepend a plain-language summary and a "did you mean" keyword
+//! suggestion, while keeping pest's diagram underneath.
+
+/// Keywords used for typo ("did you mean") suggestions at the failure point.
+const KEYWORDS: &[&str] = &[
+    "SELECT", "FROM", "WHERE", "LIMIT", "OFFSET", "ORDER", "GROUP", "HAVING",
+    "INSERT", "UPSERT", "UPDATE", "DELETE", "INTO", "VALUES", "CREATE", "DROP",
+    "COLLECTION", "INDEX", "MATCH", "RETURN", "EXPLAIN", "ANALYZE", "TRUNCATE",
+    "FLUSH", "DESCRIBE", "DISTINCT", "JOIN", "UNION", "INTERSECT", "EXCEPT",
+    "BETWEEN", "LIKE", "ILIKE", "NEAR",
+];
+
+/// Returns the identifier-like word starting at `position`, if any.
+fn word_at(input: &str, position: usize) -> Option<&str> {
+    let rest = input.get(position..)?;
+    let end = rest
+        .find(|c: char| !c.is_ascii_alphanumeric() && c != '_')
+        .unwrap_or(rest.len());
+    let word = &rest[..end];
+    (!word.is_empty()).then_some(word)
+}
+
+/// Levenshtein distance between two byte slices (used only for short keywords).
+fn edit_distance(a: &[u8], b: &[u8]) -> usize {
+    let mut prev: Vec<usize> = (0..=b.len()).collect();
+    let mut cur = vec![0usize; b.len() + 1];
+    for (i, &ca) in a.iter().enumerate() {
+        cur[0] = i + 1;
+        for (j, &cb) in b.iter().enumerate() {
+            let cost = usize::from(ca != cb);
+            cur[j + 1] = (prev[j] + cost).min(prev[j + 1] + 1).min(cur[j] + 1);
+        }
+        std::mem::swap(&mut prev, &mut cur);
+    }
+    prev[b.len()]
+}
+
+/// Suggests the closest keyword to the word at `position` (edit distance ≤ 2),
+/// unless that word already *is* a keyword (then it is misused, not misspelled).
+fn did_you_mean(input: &str, position: usize) -> Option<&'static str> {
+    let word = word_at(input, position)?;
+    if word.len() < 3 {
+        return None;
+    }
+    let upper = word.to_ascii_uppercase();
+    if KEYWORDS.iter().any(|kw| kw.eq_ignore_ascii_case(word)) {
+        return None;
+    }
+    KEYWORDS
+        .iter()
+        .map(|kw| (*kw, edit_distance(upper.as_bytes(), kw.as_bytes())))
+        .filter(|(_, distance)| *distance <= 2)
+        .min_by_key(|(_, distance)| *distance)
+        .map(|(kw, _)| kw)
+}
+
+/// Builds an enriched message: plain-language lead + optional suggestion, then
+/// pest's original diagram on the following lines.
+pub(super) fn enrich_message(input: &str, position: usize, pest_message: &str) -> String {
+    let mut lead = if position == 0 {
+        "VelesQL statements must start with a keyword such as SELECT, MATCH, \
+         INSERT, UPSERT, UPDATE, DELETE, CREATE, DROP, or EXPLAIN"
+            .to_string()
+    } else if let Some(word) = word_at(input, position) {
+        format!("Unexpected syntax near '{word}'")
+    } else {
+        "Unexpected syntax".to_string()
+    };
+    if let Some(keyword) = did_you_mean(input, position) {
+        lead.push_str(&format!(". Did you mean `{keyword}`?"));
+    }
+    format!("{lead}.\n{pest_message}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn suggests_keyword_for_simple_typo() {
+        assert_eq!(did_you_mean("SELEC * FROM docs", 0), Some("SELECT"));
+    }
+
+    #[test]
+    fn suggests_keyword_for_transposition() {
+        // "FORM" -> "FROM" is edit distance 2.
+        assert_eq!(did_you_mean("SELECT * FORM docs", 9), Some("FROM"));
+    }
+
+    #[test]
+    fn no_suggestion_for_correct_keyword() {
+        assert_eq!(did_you_mean("FROM docs", 0), None);
+    }
+
+    #[test]
+    fn no_suggestion_for_short_word() {
+        assert_eq!(did_you_mean("ab cd", 0), None);
+    }
+
+    #[test]
+    fn enrich_at_start_mentions_keywords_and_keeps_diagram() {
+        let msg = enrich_message("SELEC * FROM docs", 0, "<pest diagram>");
+        assert!(msg.contains("must start with a keyword"));
+        assert!(msg.contains("Did you mean `SELECT`?"));
+        assert!(msg.contains("<pest diagram>"));
+    }
+
+    #[test]
+    fn enrich_midquery_points_at_word() {
+        let msg = enrich_message("SELECT * docs", 9, "<diagram>");
+        assert!(msg.contains("Unexpected syntax near 'docs'"));
+        assert!(msg.contains("<diagram>"));
+    }
+}

--- a/crates/velesdb-core/src/velesql/parser/hints.rs
+++ b/crates/velesdb-core/src/velesql/parser/hints.rs
@@ -7,11 +7,40 @@
 
 /// Keywords used for typo ("did you mean") suggestions at the failure point.
 const KEYWORDS: &[&str] = &[
-    "SELECT", "FROM", "WHERE", "LIMIT", "OFFSET", "ORDER", "GROUP", "HAVING",
-    "INSERT", "UPSERT", "UPDATE", "DELETE", "INTO", "VALUES", "CREATE", "DROP",
-    "COLLECTION", "INDEX", "MATCH", "RETURN", "EXPLAIN", "ANALYZE", "TRUNCATE",
-    "FLUSH", "DESCRIBE", "DISTINCT", "JOIN", "UNION", "INTERSECT", "EXCEPT",
-    "BETWEEN", "LIKE", "ILIKE", "NEAR",
+    "SELECT",
+    "FROM",
+    "WHERE",
+    "LIMIT",
+    "OFFSET",
+    "ORDER",
+    "GROUP",
+    "HAVING",
+    "INSERT",
+    "UPSERT",
+    "UPDATE",
+    "DELETE",
+    "INTO",
+    "VALUES",
+    "CREATE",
+    "DROP",
+    "COLLECTION",
+    "INDEX",
+    "MATCH",
+    "RETURN",
+    "EXPLAIN",
+    "ANALYZE",
+    "TRUNCATE",
+    "FLUSH",
+    "DESCRIBE",
+    "DISTINCT",
+    "JOIN",
+    "UNION",
+    "INTERSECT",
+    "EXCEPT",
+    "BETWEEN",
+    "LIKE",
+    "ILIKE",
+    "NEAR",
 ];
 
 /// Returns the identifier-like word starting at `position`, if any.
@@ -61,7 +90,7 @@ fn did_you_mean(input: &str, position: usize) -> Option<&'static str> {
 /// Builds an enriched message: plain-language lead + optional suggestion, then
 /// pest's original diagram on the following lines.
 pub(super) fn enrich_message(input: &str, position: usize, pest_message: &str) -> String {
-    let mut lead = if position == 0 {
+    let lead = if position == 0 {
         "VelesQL statements must start with a keyword such as SELECT, MATCH, \
          INSERT, UPSERT, UPDATE, DELETE, CREATE, DROP, or EXPLAIN"
             .to_string()
@@ -70,10 +99,10 @@ pub(super) fn enrich_message(input: &str, position: usize, pest_message: &str) -
     } else {
         "Unexpected syntax".to_string()
     };
-    if let Some(keyword) = did_you_mean(input, position) {
-        lead.push_str(&format!(". Did you mean `{keyword}`?"));
-    }
-    format!("{lead}.\n{pest_message}")
+    let suggestion = did_you_mean(input, position)
+        .map(|keyword| format!(". Did you mean `{keyword}`?"))
+        .unwrap_or_default();
+    format!("{lead}{suggestion}.\n{pest_message}")
 }
 
 #[cfg(test)]

--- a/crates/velesdb-core/src/velesql/parser/hints.rs
+++ b/crates/velesdb-core/src/velesql/parser/hints.rs
@@ -53,23 +53,40 @@ fn word_at(input: &str, position: usize) -> Option<&str> {
     (!word.is_empty()).then_some(word)
 }
 
-/// Levenshtein distance between two byte slices (used only for short keywords).
+/// True when `a[i]`/`b[j]` form an adjacent transposition (e.g. `FORM`↔`FROM`).
+fn is_transposition(a: &[u8], b: &[u8], i: usize, j: usize) -> bool {
+    i > 0 && j > 0 && a[i] == b[j - 1] && a[i - 1] == b[j]
+}
+
+/// Damerau-Levenshtein (optimal string alignment) distance between two byte
+/// slices. Counts an adjacent transposition as 1 so a single keyword typo —
+/// substitution, insertion, deletion, or swap — stays within distance 1.
 fn edit_distance(a: &[u8], b: &[u8]) -> usize {
-    let mut prev: Vec<usize> = (0..=b.len()).collect();
-    let mut cur = vec![0usize; b.len() + 1];
+    let n = b.len();
+    let mut prev2 = vec![0usize; n + 1];
+    let mut prev: Vec<usize> = (0..=n).collect();
+    let mut cur = vec![0usize; n + 1];
     for (i, &ca) in a.iter().enumerate() {
         cur[0] = i + 1;
         for (j, &cb) in b.iter().enumerate() {
             let cost = usize::from(ca != cb);
-            cur[j + 1] = (prev[j] + cost).min(prev[j + 1] + 1).min(cur[j] + 1);
+            let mut best = (prev[j] + cost).min(prev[j + 1] + 1).min(cur[j] + 1);
+            if is_transposition(a, b, i, j) {
+                best = best.min(prev2[j - 1] + 1);
+            }
+            cur[j + 1] = best;
         }
+        std::mem::swap(&mut prev2, &mut prev);
         std::mem::swap(&mut prev, &mut cur);
     }
-    prev[b.len()]
+    prev[n]
 }
 
-/// Suggests the closest keyword to the word at `position` (edit distance ≤ 2),
+/// Suggests the closest keyword to the word at `position` (edit distance ≤ 1),
 /// unless that word already *is* a keyword (then it is misused, not misspelled).
+///
+/// The tight threshold avoids suggesting keywords for ordinary identifiers that
+/// merely resemble one (e.g. a column named `user` is *not* a typo of `UPSERT`).
 fn did_you_mean(input: &str, position: usize) -> Option<&'static str> {
     let word = word_at(input, position)?;
     if word.len() < 3 {
@@ -82,7 +99,7 @@ fn did_you_mean(input: &str, position: usize) -> Option<&'static str> {
     KEYWORDS
         .iter()
         .map(|kw| (*kw, edit_distance(upper.as_bytes(), kw.as_bytes())))
-        .filter(|(_, distance)| *distance <= 2)
+        .filter(|(_, distance)| *distance <= 1)
         .min_by_key(|(_, distance)| *distance)
         .map(|(kw, _)| kw)
 }
@@ -116,7 +133,7 @@ mod tests {
 
     #[test]
     fn suggests_keyword_for_transposition() {
-        // "FORM" -> "FROM" is edit distance 2.
+        // "FORM" -> "FROM" is an adjacent transposition (Damerau distance 1).
         assert_eq!(did_you_mean("SELECT * FORM docs", 9), Some("FROM"));
     }
 
@@ -128,6 +145,15 @@ mod tests {
     #[test]
     fn no_suggestion_for_short_word() {
         assert_eq!(did_you_mean("ab cd", 0), None);
+    }
+
+    #[test]
+    fn no_suggestion_for_ordinary_identifier() {
+        // Common column/collection names are distance 2 from a keyword and must
+        // NOT be reported as typos (regression: user->UPSERT, date->UPDATE).
+        assert_eq!(did_you_mean("user", 0), None);
+        assert_eq!(did_you_mean("date", 0), None);
+        assert_eq!(did_you_mean("main", 0), None);
     }
 
     #[test]

--- a/crates/velesdb-core/src/velesql/parser/mod.rs
+++ b/crates/velesdb-core/src/velesql/parser/mod.rs
@@ -9,6 +9,7 @@ mod ddl_helpers;
 mod dml;
 mod dml_helpers;
 pub(crate) mod helpers;
+mod hints;
 mod introspection;
 mod match_parser;
 mod prescan;
@@ -114,7 +115,7 @@ impl Parser {
                 ParseErrorKind::SyntaxError,
                 position,
                 input.chars().take(50).collect::<String>(),
-                e.to_string(),
+                hints::enrich_message(input, position, &e.to_string()),
             )
         })?;
 

--- a/crates/velesdb-core/tests/velesql_cheatsheet_docs.rs
+++ b/crates/velesdb-core/tests/velesql_cheatsheet_docs.rs
@@ -2,7 +2,7 @@
 //!
 //! The cheat sheet historically described a syntax the parser never accepted,
 //! which is the worst possible trap for a newcomer. This test extracts every
-//! fenced ```sql block from the cheat sheet and asserts each statement parses
+//! fenced sql code block from the cheat sheet and asserts each statement parses
 //! with the real grammar, so an example can never silently drift again.
 
 use std::path::PathBuf;
@@ -12,7 +12,7 @@ fn cheatsheet_path() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../docs/reference/VELESQL_CHEATSHEET.md")
 }
 
-/// Collect the contents of every ```` ```sql ```` fenced block.
+/// Collect the contents of every fenced sql code block.
 fn sql_blocks(markdown: &str) -> Vec<String> {
     let mut blocks = Vec::new();
     let mut current: Option<String> = None;

--- a/crates/velesdb-core/tests/velesql_cheatsheet_docs.rs
+++ b/crates/velesdb-core/tests/velesql_cheatsheet_docs.rs
@@ -1,0 +1,76 @@
+//! Anti-drift guard for `docs/reference/VELESQL_CHEATSHEET.md`.
+//!
+//! The cheat sheet historically described a syntax the parser never accepted,
+//! which is the worst possible trap for a newcomer. This test extracts every
+//! fenced ```sql block from the cheat sheet and asserts each statement parses
+//! with the real grammar, so an example can never silently drift again.
+
+use std::path::PathBuf;
+use velesdb_core::velesql::Parser;
+
+fn cheatsheet_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../docs/reference/VELESQL_CHEATSHEET.md")
+}
+
+/// Collect the contents of every ```` ```sql ```` fenced block.
+fn sql_blocks(markdown: &str) -> Vec<String> {
+    let mut blocks = Vec::new();
+    let mut current: Option<String> = None;
+    for line in markdown.lines() {
+        match current {
+            Some(ref mut buf) => {
+                if line.trim_start().starts_with("```") {
+                    blocks.push(std::mem::take(buf));
+                    current = None;
+                } else {
+                    buf.push_str(line);
+                    buf.push('\n');
+                }
+            }
+            None if line.trim_start().starts_with("```sql") => current = Some(String::new()),
+            None => {}
+        }
+    }
+    blocks
+}
+
+/// Split a block into individual statements. Line comments are stripped first
+/// (a `--` comment may itself contain a `;`, which must not split a statement).
+fn statements(block: &str) -> Vec<String> {
+    let without_comments = block
+        .lines()
+        .map(|line| line.find("--").map_or(line, |idx| &line[..idx]))
+        .collect::<Vec<_>>()
+        .join("\n");
+    without_comments
+        .split(';')
+        .map(str::trim)
+        .filter(|fragment| !fragment.is_empty())
+        .map(String::from)
+        .collect()
+}
+
+#[test]
+fn cheatsheet_sql_examples_all_parse() {
+    let markdown = std::fs::read_to_string(cheatsheet_path()).expect("read VELESQL_CHEATSHEET.md");
+    let blocks = sql_blocks(&markdown);
+    assert!(!blocks.is_empty(), "no ```sql blocks found in cheat sheet");
+
+    let mut verified = 0_usize;
+    for block in &blocks {
+        for statement in statements(block) {
+            let result = Parser::parse(&statement);
+            assert!(
+                result.is_ok(),
+                "cheat sheet example failed to parse:\n  {statement}\n  error: {:?}",
+                result.err()
+            );
+            verified += 1;
+        }
+    }
+
+    assert!(
+        verified >= 30,
+        "expected the cheat sheet to verify many statements, got {verified}"
+    );
+}

--- a/docs/VELESQL_SPEC.md
+++ b/docs/VELESQL_SPEC.md
@@ -2558,6 +2558,34 @@ Parameters can be used for:
 
 ---
 
+## Execution Surfaces & CLI REPL Limitations
+
+VelesQL is accepted by the REST API (`velesdb-server`), the language SDKs, and
+the interactive CLI REPL (`velesdb-cli`). The grammar is identical across all
+three, but the **CLI REPL has two execution limitations** a newcomer should know:
+
+- **Parameterized vector search is not executed in the REPL.** A query whose
+  `WHERE` uses `vector NEAR $param` (or `MATCH ... $param`) prints
+  *"Vector search with $parameter requires REST API"* and returns **zero rows** —
+  the REPL has no way to bind an external vector. Use an **inline vector literal**
+  (`WHERE vector NEAR [0.1, 0.2, 0.3]`), a metadata-only query, or the REST API
+  with the parameter supplied in the request body.
+- **`MATCH` requires an active collection.** Run `.use <collection_name>` first;
+  otherwise the REPL reports *"MATCH queries require an active collection"*.
+
+These limitations are specific to the REPL; the REST API and SDKs execute both
+parameterized vector search and `MATCH` normally.
+
+### Divergences from standard SQL
+
+- **Table aliases require `AS`**: `FROM docs AS d`, not `FROM docs d` (the
+  no-`AS` form is intentionally rejected to avoid ambiguity with `JOIN`).
+- **`vector` and `score` are reserved keywords**, not free payload field names —
+  `vector NEAR ...` and `score` in aggregates/ordering refer to the query vector
+  and the computed similarity score.
+
+---
+
 ## Identifier Quoting
 
 ### Reserved Keywords

--- a/docs/VELESQL_SPEC.md
+++ b/docs/VELESQL_SPEC.md
@@ -2,7 +2,7 @@
 
 > SQL-like query language for vector + graph + column-store search in VelesDB.
 
-**Version**: 3.10.0 | **Last Updated**: 2026-05-15 (VelesDB v1.15.0)
+**Version**: 3.10.0 | **Last Updated**: 2026-06-03 (VelesDB v1.16.0)
 
 ---
 
@@ -1408,36 +1408,35 @@ USING FUSION(strategy = 'rrf', k = 60)
 | Strategy | Description | Parameters | Use Case |
 |----------|-------------|------------|----------|
 | `rrf` | Reciprocal Rank Fusion | `k` (default: 60) | Balanced ranking (default) |
-| `weighted` | Weighted combination | `weights = [w1, w2]` | Custom importance |
+| `weighted` | Weighted combination | `vector_weight`, `graph_weight` | Custom importance |
 | `maximum` | Take highest score | (none) | Best match wins |
 | `rsf` | Reciprocal Score Fusion | `dense_weight`, `sparse_weight` | Dense + sparse blending |
 
 ### Examples
 
+> `USING FUSION(...)` is a **trailing clause**: it must come *after* `LIMIT`
+> (and `OFFSET`), not before it.
+
 ```sql
 -- Default RRF fusion
 SELECT * FROM docs
 WHERE vector NEAR $v AND content MATCH 'neural networks'
-USING FUSION(strategy = 'rrf', k = 60)
-LIMIT 10
+LIMIT 10 USING FUSION(strategy = 'rrf', k = 60)
 
--- Weighted fusion (70% vector, 30% text)
+-- Weighted fusion (70% vector, 30% graph/text)
 SELECT * FROM docs
 WHERE vector NEAR $semantic AND content MATCH $keywords
-USING FUSION(strategy = 'weighted', weights = [0.7, 0.3])
-LIMIT 20
+LIMIT 20 USING FUSION(strategy = 'weighted', vector_weight = 0.7, graph_weight = 0.3)
 
 -- Dense + sparse hybrid with RSF
 SELECT * FROM docs
 WHERE vector NEAR $dense AND vector SPARSE_NEAR $sparse
-USING FUSION(strategy = 'rsf', dense_weight = 0.7, sparse_weight = 0.3)
-LIMIT 10
+LIMIT 10 USING FUSION(strategy = 'rsf', dense_weight = 0.7, sparse_weight = 0.3)
 
 -- Maximum score fusion
 SELECT * FROM docs
 WHERE similarity(embedding, $q1) > 0.5
-USING FUSION(strategy = 'maximum')
-LIMIT 10
+LIMIT 10 USING FUSION(strategy = 'maximum')
 ```
 
 ### FUSE BY (Planned Syntax)
@@ -1904,7 +1903,7 @@ significantly away from `0.1`.
 The CLI REPL provides the `.explain-analyze` command:
 
 ```
-velesdb> .explain-analyze SELECT * FROM docs WHERE vector NEAR $v LIMIT 10
+velesdb> .explain-analyze SELECT * FROM docs WHERE vector NEAR [0.1, 0.2, 0.3] LIMIT 10
 
 Query Plan:
 └─ VectorSearch
@@ -2883,8 +2882,7 @@ SELECT * FROM products WHERE sku LIKE 'SKU-2024-%'
 -- Dense vector + BM25 text with RRF fusion
 SELECT * FROM docs
 WHERE vector NEAR $query AND content MATCH 'neural networks'
-USING FUSION(strategy = 'rrf', k = 60)
-LIMIT 10
+LIMIT 10 USING FUSION(strategy = 'rrf', k = 60)
 
 -- With custom scoring weights
 LET score = 0.7 * vector_score + 0.3 * bm25_score
@@ -2897,13 +2895,11 @@ LIMIT 10
 -- Dense + sparse vector fusion
 SELECT * FROM docs
 WHERE vector NEAR $dense_query AND vector SPARSE_NEAR $sparse_query
-USING FUSION(strategy = 'rrf', k = 60)
-LIMIT 10
+LIMIT 10 USING FUSION(strategy = 'rrf', k = 60)
 
--- Multi-vector fusion (text + image embeddings)
+-- Multi-vector fusion (text + image embeddings) — inline NEAR_FUSED form
 SELECT * FROM products
-WHERE vector NEAR_FUSED [$text_emb, $image_emb]
-USING FUSION(strategy = 'weighted')
+WHERE vector NEAR_FUSED [$text_emb, $image_emb] USING FUSION 'weighted'
 LIMIT 20
 ```
 

--- a/docs/VELESQL_SPEC.md
+++ b/docs/VELESQL_SPEC.md
@@ -50,7 +50,7 @@ equivalent. Identifiers (collection names, column names) are case-sensitive.
 | DISTINCT modifier | Stable | 3.3 |
 | ILIKE case-insensitive pattern | Stable | 3.3 |
 | FROM / JOIN aliases | Stable (INNER JOIN) | 2.0 |
-| Scalar subqueries | Stable | 3.2 |
+| Scalar subqueries | Parsed only — **not executed** (see below) | 3.2 |
 | SQL comments (`--`) | Stable | 1.0 |
 | Identifier quoting (backtick, double-quote) | Stable | 1.3 |
 | SHOW COLLECTIONS | Stable | 3.4 |
@@ -873,18 +873,22 @@ SELECT * FROM logs WHERE created_at < NOW() - INTERVAL '30 days'
 
 ### Scalar Subqueries (v3.2+)
 
-Use a scalar subquery in WHERE to compare against a computed value from another
-(or the same) collection. The subquery must return exactly one row and one column.
+> ⚠️ **Parsed but not executed.** A scalar subquery in `WHERE` is accepted by the
+> parser (EPIC-039) but has **no executor support**: at evaluation time it
+> resolves to `NULL`, so the surrounding comparison silently yields empty or
+> incorrect results — no error is raised. This matches the
+> [conformance matrix](reference/VELESQL_CONFORMANCE_MATRIX.md) ("Parsed only").
+> Do not rely on subqueries in production; compute the value in your application
+> and pass it as a bind parameter instead. The syntax below documents what the
+> grammar accepts, not a working feature.
+
+A scalar subquery in WHERE is intended to compare against a computed value from
+another (or the same) collection, returning exactly one row and one column.
 
 ```sql
--- Filter where amount exceeds the average
+-- Parsed, but NOT executed — the subquery evaluates to NULL at runtime
 SELECT * FROM orders
 WHERE amount > (SELECT AVG(amount) FROM orders)
-
--- Compare against a value from another collection
-SELECT * FROM products
-WHERE price < (SELECT MAX(budget) FROM departments WHERE name = 'engineering')
-LIMIT 20
 ```
 
 A subquery is enclosed in parentheses and contains a full SELECT statement
@@ -2708,7 +2712,7 @@ VelesQL returns structured errors:
 | BETWEEN | `column BETWEEN low AND high` | `WHERE price BETWEEN 50 AND 200` |
 | LIKE / ILIKE | `column [I]LIKE 'pattern'` | `WHERE title LIKE 'rust%'`, `WHERE name ILIKE '%rust%'` |
 | IS NULL / IS NOT NULL | `column IS [NOT] NULL` | `WHERE email IS NOT NULL` |
-| Scalar subquery | `column op (SELECT … LIMIT 1)` | `WHERE views > (SELECT AVG(views) FROM stats LIMIT 1)` |
+| Scalar subquery ⚠️ parsed only, not executed | `column op (SELECT … LIMIT 1)` | `WHERE views > (SELECT AVG(views) FROM stats LIMIT 1)` — evaluates to NULL at runtime |
 | Graph match predicate | `MATCH (...)` in WHERE | `WHERE MATCH (a:Person)-[:KNOWS]->(b) AND a.id = $u` |
 | GEO_DISTANCE | `GEO_DISTANCE(col, lat, lng) op meters` | `WHERE GEO_DISTANCE(location, 48.8566, 2.3522) < 500` |
 | GEO_BBOX | `GEO_BBOX(col, lat_min, lng_min, lat_max, lng_max)` | `WHERE GEO_BBOX(location, 48.8, 2.3, 48.9, 2.4)` |

--- a/docs/VELESQL_SPEC.md
+++ b/docs/VELESQL_SPEC.md
@@ -1425,7 +1425,7 @@ LIMIT 10 USING FUSION(strategy = 'rrf', k = 60)
 
 -- Weighted fusion (70% vector, 30% graph/text)
 SELECT * FROM docs
-WHERE vector NEAR $semantic AND content MATCH $keywords
+WHERE vector NEAR $semantic AND content MATCH 'machine learning'
 LIMIT 20 USING FUSION(strategy = 'weighted', vector_weight = 0.7, graph_weight = 0.3)
 
 -- Dense + sparse hybrid with RSF

--- a/docs/guides/SEARCH_MODES.md
+++ b/docs/guides/SEARCH_MODES.md
@@ -342,17 +342,15 @@ La recherche hybride combine la recherche **dense** (embeddings semantiques) et 
 ### Exemple VelesQL
 
 ```sql
--- Hybrid search avec RRF
+-- Hybrid search avec RRF (USING FUSION est une clause finale : après LIMIT)
 SELECT * FROM products
 WHERE vector NEAR $embedding AND vector SPARSE_NEAR $bm25
-USING FUSION(strategy = 'rrf', k = 60)
-LIMIT 10
+LIMIT 10 USING FUSION(strategy = 'rrf', k = 60)
 
 -- Hybrid search avec poids explicites
 SELECT * FROM docs
 WHERE vector NEAR $dense AND vector SPARSE_NEAR $sparse
-USING FUSION(strategy = 'rsf', dense_weight = 0.7, sparse_weight = 0.3)
-LIMIT 20
+LIMIT 20 USING FUSION(strategy = 'rsf', dense_weight = 0.7, sparse_weight = 0.3)
 ```
 
 ### Exemple REST API

--- a/docs/reference/ARCHITECTURE.md
+++ b/docs/reference/ARCHITECTURE.md
@@ -427,10 +427,9 @@ WHERE status = 'active'
 -- Set operations
 SELECT * FROM active_users UNION SELECT * FROM archived_users
 
--- Hybrid fusion search
+-- Hybrid fusion search (USING FUSION is a trailing clause: after LIMIT)
 SELECT * FROM documents 
-USING FUSION(strategy='rrf', k=60)
-LIMIT 20
+LIMIT 20 USING FUSION(strategy='rrf', k=60)
 ```
 
 ## Performance Characteristics

--- a/docs/reference/VELESQL_CHEATSHEET.md
+++ b/docs/reference/VELESQL_CHEATSHEET.md
@@ -78,6 +78,9 @@ SELECT title, similarity() AS score FROM docs
 WHERE vector NEAR $q
 ORDER BY similarity() DESC
 LIMIT 10;
+
+-- Query-time HNSW override (trade speed for recall) via WITH (after LIMIT)
+SELECT * FROM docs WHERE vector NEAR $q LIMIT 10 WITH (ef_search = 512);
 ```
 
 ---
@@ -101,6 +104,20 @@ LIMIT 10;
 
 -- Combine vector search with full-text MATCH
 SELECT * FROM docs WHERE vector NEAR $q AND content MATCH 'database' LIMIT 10;
+
+-- Hybrid dense + text with an explicit fusion strategy.
+-- USING FUSION(...) is a trailing clause: it comes AFTER LIMIT.
+SELECT * FROM docs
+WHERE vector NEAR $q AND content MATCH 'database'
+LIMIT 10 USING FUSION(strategy = 'rrf', k = 60);
+
+-- Weighted fusion (parser reads vector_weight / graph_weight, not a weights[] array)
+SELECT * FROM docs
+WHERE vector NEAR $q AND content MATCH 'database'
+LIMIT 10 USING FUSION(strategy = 'weighted', vector_weight = 0.7, graph_weight = 0.3);
+
+-- Inline NEAR_FUSED with a bare strategy string (no params)
+SELECT * FROM products WHERE vector NEAR_FUSED [$a, $b] USING FUSION 'weighted' LIMIT 20;
 ```
 
 ---

--- a/docs/reference/VELESQL_CHEATSHEET.md
+++ b/docs/reference/VELESQL_CHEATSHEET.md
@@ -4,10 +4,11 @@
 > **VelesDB version:** 1.16.0
 > See the full specification in [`docs/VELESQL_SPEC.md`](../VELESQL_SPEC.md).
 
-> Every `sql` block below is verified against the real grammar by an automated
+> Every `sql` block below is **parsed** against the real grammar by an automated
 > test (`crates/velesdb-core/tests/velesql_cheatsheet_docs.rs`) — if an example
-> stops parsing, CI fails. Vectors are passed as bind parameters (`$v`); inline
-> vector literals like `[0.1, 0.2, 0.3]` are also accepted in `WHERE ... NEAR`.
+> stops parsing, CI fails. (The test guards syntax, not runtime execution.)
+> Vectors are passed as bind parameters (`$v`); inline vector literals like
+> `[0.1, 0.2, 0.3]` are also accepted in `WHERE ... NEAR`.
 
 ---
 
@@ -164,8 +165,9 @@ FROM items;
 ## Joins & set operations
 
 ```sql
--- INNER JOIN across collections (alias requires AS)
-SELECT d.name, t.tag FROM docs AS d JOIN tags AS t ON d.id = t.doc_id;
+-- INNER JOIN across collections (alias requires AS).
+-- The joined (right) table must be matched on its primary key `id`.
+SELECT d.name, t.tag FROM docs AS d JOIN tags AS t ON d.tag_id = t.id;
 
 -- Set operations
 SELECT * FROM a UNION SELECT * FROM b;

--- a/docs/reference/VELESQL_CHEATSHEET.md
+++ b/docs/reference/VELESQL_CHEATSHEET.md
@@ -1,20 +1,37 @@
 # VelesQL Cheat Sheet
 
-> **Date:** 2026-05-29  
-> **VelesDB version:** 1.15.x  
+> **Date:** 2026-06-03
+> **VelesDB version:** 1.16.0
 > See the full specification in [`docs/VELESQL_SPEC.md`](../VELESQL_SPEC.md).
+
+> Every `sql` block below is verified against the real grammar by an automated
+> test (`crates/velesdb-core/tests/velesql_cheatsheet_docs.rs`) — if an example
+> stops parsing, CI fails. Vectors are passed as bind parameters (`$v`); inline
+> vector literals like `[0.1, 0.2, 0.3]` are also accepted in `WHERE ... NEAR`.
 
 ---
 
 ## DDL
 
 ```sql
--- Create a vector collection
-CREATE COLLECTION docs DIMENSION 768;
-CREATE COLLECTION docs DIMENSION 768 METRIC cosine;
+-- Create a vector collection (dimension is required; metric defaults to cosine)
+CREATE COLLECTION docs (dimension = 768);
+CREATE COLLECTION docs (dimension = 768, metric = 'cosine');
+
+-- Tune storage / HNSW at creation time
+CREATE COLLECTION docs (dimension = 768, metric = 'cosine') WITH (storage = 'sq8');
+
+-- Graph and metadata-only collections
+CREATE GRAPH COLLECTION kg (dimension = 768, metric = 'cosine') SCHEMALESS;
+CREATE METADATA COLLECTION tags;
+
+-- Secondary index on a payload field
+CREATE INDEX ON docs (category);
+DROP INDEX ON docs (category);
 
 -- Drop a collection
 DROP COLLECTION docs;
+DROP COLLECTION IF EXISTS docs;
 ```
 
 ---
@@ -22,46 +39,67 @@ DROP COLLECTION docs;
 ## DML
 
 ```sql
--- Upsert a point (vector + optional payload)
-UPSERT INTO docs (id, vector, payload)
-VALUES ('a1', [0.1, 0.2, ...], '{"title": "hello"}');
+-- Insert scalar columns (multi-row supported)
+INSERT INTO docs (id, title) VALUES (1, 'Hello'), (2, 'World');
 
--- Delete a point
-DELETE FROM docs WHERE id = 'a1';
+-- Insert / update with a vector passed as a bind parameter ($v)
+UPSERT INTO docs (id, vector, title) VALUES (1, $v, 'First');
+
+-- Update payload columns
+UPDATE docs SET title = 'Renamed' WHERE id = 1;
+
+-- Delete (WHERE is mandatory to prevent accidental full wipes)
+DELETE FROM docs WHERE id = 1;
+DELETE FROM docs WHERE id IN (1, 2, 3);
 ```
 
 ---
 
-## NEAR vector search
+## Vector search (`vector NEAR`)
+
+Vector search is a `WHERE` predicate inside a `SELECT`. The distance metric is
+fixed at collection creation, not per query.
 
 ```sql
--- Top-k nearest neighbours
-NEAR docs [0.1, 0.2, ...] LIMIT 10;
+-- Top-k nearest neighbours (bind parameter)
+SELECT * FROM docs WHERE vector NEAR $q LIMIT 10;
 
--- With ef_search override
-NEAR docs [0.1, 0.2, ...] LIMIT 10 EF 128;
+-- Inline vector literal
+SELECT * FROM docs WHERE vector NEAR [0.1, 0.2, 0.3] LIMIT 5;
 
--- Filtered NEAR
-NEAR docs [0.1, 0.2, ...] LIMIT 10
-WHERE payload->>'category' = 'news';
+-- Filtered vector search (payload fields use dot paths)
+SELECT id, title FROM docs
+WHERE vector NEAR $q AND category = 'news'
+LIMIT 10;
+
+-- Expose the similarity score and sort by it
+SELECT title, similarity() AS score FROM docs
+WHERE vector NEAR $q
+ORDER BY similarity() DESC
+LIMIT 10;
 ```
 
 ---
 
-## Hybrid search — FUSION
+## Sparse & hybrid search
 
 ```sql
--- Reciprocal Rank Fusion of two NEAR clauses
-FUSION rrf (
-  NEAR docs [0.1, 0.2, ...] LIMIT 50,
-  NEAR docs [0.9, 0.8, ...] LIMIT 50
-) LIMIT 10;
+-- Sparse-only search (inline {index: weight} literal, weights are floats)
+SELECT * FROM docs WHERE vector SPARSE_NEAR {1: 0.5, 2: 0.3} LIMIT 5;
 
--- Weighted sum fusion
-FUSION weighted_sum (
-  NEAR docs [0.1, 0.2, ...] LIMIT 50 WEIGHT 0.7,
-  NEAR docs [0.9, 0.8, ...] LIMIT 50 WEIGHT 0.3
-) LIMIT 10;
+-- Sparse with a named index
+SELECT * FROM docs WHERE vector SPARSE_NEAR $sv USING 'splade' LIMIT 5;
+
+-- Dense + sparse in one query
+SELECT * FROM docs WHERE vector NEAR $q AND vector SPARSE_NEAR $sv LIMIT 5;
+
+-- Multi-vector fusion (RRF over several query vectors)
+SELECT * FROM docs
+WHERE vector NEAR_FUSED [$v1, $v2] USING FUSION 'rrf' (k = 60)
+LIMIT 10;
+
+-- Combine vector search with full-text MATCH
+SELECT * FROM docs WHERE vector NEAR $q AND content MATCH 'database' LIMIT 10;
 ```
 
 ---
@@ -69,7 +107,7 @@ FUSION weighted_sum (
 ## Graph — MATCH traversal
 
 ```sql
--- Find 1-hop neighbours
+-- 1-hop neighbours
 MATCH (a:Author)-[:WROTE]->(p:Post)
 WHERE a.id = 'auth-42'
 RETURN p LIMIT 20;
@@ -78,64 +116,93 @@ RETURN p LIMIT 20;
 MATCH (src)-[:LINKS*1..3]->(dst)
 WHERE src.id = 'node-1'
 RETURN dst LIMIT 100;
+
+-- Graph predicate inside a SELECT
+SELECT * FROM docs
+WHERE category = 'tech' AND MATCH (d:Doc)-[:REL]->(x)
+LIMIT 10;
 ```
 
 ---
 
 ## WHERE operators
 
-| Operator | Example |
-|---|---|
-| `=` | `payload->>'lang' = 'en'` |
-| `!=` | `payload->>'status' != 'draft'` |
-| `>`, `>=`, `<`, `<=` | `payload->>'score'::float >= 0.8` |
-| `IN` | `payload->>'tag' IN ('ai', 'ml')` |
-| `IS NULL` / `IS NOT NULL` | `payload->>'deleted_at' IS NULL` |
-| `AND`, `OR`, `NOT` | combine any of the above |
+```sql
+SELECT * FROM docs WHERE lang = 'en' LIMIT 10;
+SELECT * FROM docs WHERE status != 'draft' LIMIT 10;
+SELECT * FROM docs WHERE score >= 0.8 LIMIT 10;
+SELECT * FROM docs WHERE tag IN ('ai', 'ml') LIMIT 10;
+SELECT * FROM docs WHERE year BETWEEN 2020 AND 2024 LIMIT 10;
+SELECT * FROM docs WHERE title LIKE '%search%' LIMIT 10;
+SELECT * FROM docs WHERE deleted_at IS NULL LIMIT 10;
+SELECT * FROM docs WHERE tags CONTAINS 'ml' LIMIT 10;
+SELECT * FROM docs WHERE tags CONTAINS ANY ('ai', 'ml') LIMIT 10;
+SELECT * FROM docs WHERE body MATCH 'machine learning' LIMIT 10;
+SELECT * FROM docs WHERE (lang = 'en' OR lang = 'fr') AND NOT archived = true LIMIT 10;
+```
+
+Payload sub-fields use dot paths: `payload.author.name = 'Ada'`.
+
+---
+
+## Aggregation, grouping & windows
+
+```sql
+-- GROUP BY with an aggregate and a HAVING filter
+SELECT category, COUNT(*) AS n FROM docs
+GROUP BY category
+HAVING COUNT(*) > 5
+LIMIT 50;
+
+-- Window ranking function
+SELECT id, category, RANK() OVER (PARTITION BY category ORDER BY score DESC) AS rk
+FROM items;
+```
+
+---
+
+## Joins & set operations
+
+```sql
+-- INNER JOIN across collections (alias requires AS)
+SELECT d.name, t.tag FROM docs AS d JOIN tags AS t ON d.id = t.doc_id;
+
+-- Set operations
+SELECT * FROM a UNION SELECT * FROM b;
+SELECT * FROM a INTERSECT SELECT * FROM b;
+```
 
 ---
 
 ## Pagination
 
 ```sql
--- Offset-based
-NEAR docs [...] LIMIT 10 OFFSET 20;
-
--- Cursor-based (preferred for large result sets)
-NEAR docs [...] LIMIT 10 AFTER 'cursor-token';
+SELECT * FROM docs WHERE vector NEAR $q LIMIT 10 OFFSET 20;
 ```
+
+> There is no cursor/`AFTER` clause in VelesQL; use `LIMIT ... OFFSET ...`.
 
 ---
 
-## Aggregation / grouping
+## Introspection & maintenance
 
 ```sql
-SELECT payload->>'category', COUNT(*) AS n
-FROM docs
-GROUP BY payload->>'category'
-LIMIT 50
-MAX_GROUPS 200;
-```
+SHOW COLLECTIONS;
+DESCRIBE docs;
+DESCRIBE COLLECTION docs;
 
----
+-- Query plan without executing
+EXPLAIN SELECT * FROM docs WHERE vector NEAR $q LIMIT 10;
 
-## EXPLAIN
+-- Compute optimizer statistics
+ANALYZE docs;
+ANALYZE COLLECTION docs;
 
-```sql
--- Show query plan without executing
-EXPLAIN NEAR docs [0.1, 0.2, ...] LIMIT 10;
-```
-
----
-
-## Maintenance
-
-```sql
--- Rebuild HNSW index
-REINDEX COLLECTION docs;
-
--- Compact WAL / merge segments
-COMPACT COLLECTION docs;
+-- Maintenance
+TRUNCATE COLLECTION docs;
+ALTER COLLECTION docs SET (auto_reindex = true);
+FLUSH;
+FLUSH FULL docs;
 ```
 
 ---
@@ -146,5 +213,8 @@ COMPACT COLLECTION docs;
 |---|---|
 | Max results per query | 10 000 |
 | Query timeout | configurable (`search.query_timeout_ms`) |
-| Max groups per GROUP BY | 10 000 (override with `MAX_GROUPS`) |
+| Max groups per GROUP BY | 10 000 |
 | Max payload size | configurable (`limits.max_payload_size`) |
+
+> Reserved words: `vector` and `score` are language keywords, not free payload
+> field names. Table aliases require `AS` (`FROM docs AS d`, not `FROM docs d`).

--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -567,10 +567,9 @@ FROM products AS p
 JOIN prices AS pr ON pr.product_id = p.id 
 WHERE pr.amount < 100
 
--- Hybrid search with fusion
+-- Hybrid search with fusion (USING FUSION is a trailing clause: after LIMIT)
 SELECT * FROM docs 
-USING FUSION(strategy='rrf', k=60) 
-LIMIT 20
+LIMIT 20 USING FUSION(strategy='rrf', k=60)
 
 -- Set operations
 SELECT * FROM active_users 

--- a/examples/README.md
+++ b/examples/README.md
@@ -194,11 +194,10 @@ WHERE vector NEAR $query
   AND price < 100
 LIMIT 20
 
--- Hybrid search (vector + text)
+-- Hybrid search (vector + text) — USING FUSION is a trailing clause: after LIMIT
 SELECT * FROM docs
 WHERE vector NEAR $vec AND text MATCH 'machine learning'
-USING FUSION(strategy = 'rrf', k = 60)
-LIMIT 10
+LIMIT 10 USING FUSION(strategy = 'rrf', k = 60)
 
 -- Aggregations
 SELECT category, COUNT(*), AVG(price)


### PR DESCRIPTION
## Contexte

Volet VelesQL de l'audit d'onboarding (point de vue nouvel utilisateur). PR séparée des correctifs Python (#986).

## Changements (séquencés)

- **Q1 — Cheat sheet réécrit + test anti-dérive.** `VELESQL_CHEATSHEET.md` décrivait une syntaxe que le parser n'a jamais acceptée (`NEAR`/`FUSION` top-level, `->>`, `::float`, `EF`, `WEIGHT`, `AFTER`, `REINDEX`, `COMPACT`, `MAX_GROUPS`, `DIMENSION 768`) — le pire piège pour un débutant, qui ouvre le « cheat sheet » en premier. Réécriture de chaque exemple depuis la vraie grammaire (vérifiés contre les cas de conformance). Nouveau test `tests/velesql_cheatsheet_docs.rs` qui parse **chaque** bloc ` ```sql ` → un exemple ne peut plus dériver silencieusement.
- **Q2 — Sous-requêtes scalaires.** Le SPEC les listait « Stable » alors qu'elles sont parsées mais **non exécutées** (`Value::Subquery` → `NULL` à l'évaluation, résultats silencieusement faux). Alignement du SPEC sur la matrice de conformité (« Parsed only ») avec avertissement explicite dans le tableau des features, la section dédiée et le tableau des opérateurs.
- **Q3 — Messages d'erreur parser.** Le parser renvoyait le message brut de pest (`expected select_stmt, match_query, …`). Nouveau `parser/hints.rs` : préfixe en langage clair (« statements must start with a keyword » / « unexpected syntax near '<mot>' ») + suggestion « Did you mean \`FROM\`? » (Levenshtein ≤ 2), tout en gardant le diagramme caret de pest. Aucun changement de ce qui parse.
- **Q4 — Limites du REPL CLI.** Nouvelle section SPEC : `vector NEAR $param` non exécutable dans le REPL (retourne 0 ligne — utiliser un littéral ou la REST API) ; `.use <collection>` requis avant `MATCH`. + note sur les divergences SQL (`AS` obligatoire pour les alias, `vector`/`score` réservés).

## Validation

- `cargo clippy -p velesdb-core --all-targets --features persistence -- -D warnings -D clippy::pedantic` : clean.
- `cargo fmt --all --check` : clean.
- `cargo test -p velesdb-core --features persistence --lib velesql` : **1172 passed**.
- Tests d'intégration : `velesql_cheatsheet_docs` (nouveau) + `velesql_parser_conformance` : verts.
- `cargo check -p velesdb-core --no-default-features` : OK.

## Portée

VelesQL : docs + un module parser (messages d'erreur, sans changement de comportement de parsing) + 1 test anti-dérive. Pas de modification du chemin de recherche/recall.