### PR TITLE
fix(integrations): migrate langchain/llamaindex/haystack off deprecated collection.search()

### DIFF
--- a/integrations/haystack/src/haystack_velesdb/document_store.py
+++ b/integrations/haystack/src/haystack_velesdb/document_store.py
@@ -535,10 +535,12 @@ class VelesDBDocumentStore:
             ValueError: When *filters* is structurally malformed.
         """
         veles_filter = _translate_haystack_filter(filters)
-        results: List[dict] = self._get_collection().search(
-            vector=query_embedding,
-            top_k=top_k,
-            filter=veles_filter,
+        results: List[dict] = self._get_collection().search_request(
+            velesdb.SearchOptions(
+                vector=query_embedding,
+                top_k=top_k,
+                filter=veles_filter,
+            )
         )
         return [_result_to_doc(r, scale_score=scale_score, metric=self._metric) for r in results]
 

--- a/integrations/haystack/tests/test_document_store.py
+++ b/integrations/haystack/tests/test_document_store.py
@@ -43,6 +43,27 @@ class DuplicateDocumentError(Exception):
 # ---------------------------------------------------------------------------
 
 
+class _FakeSearchOptions:
+    """Minimal stand-in for velesdb.SearchOptions used by search_request."""
+
+    def __init__(
+        self,
+        vector: Any = None,
+        *,
+        sparse_vector: Any = None,
+        top_k: int = 10,
+        filter: Any = None,  # pylint: disable=redefined-builtin
+        sparse_index_name: Any = None,
+        include_vectors: bool = False,
+    ) -> None:
+        self.vector = vector
+        self.sparse_vector = sparse_vector
+        self.top_k = top_k
+        self.filter = filter
+        self.sparse_index_name = sparse_index_name
+        self.include_vectors = include_vectors
+
+
 class _FakeCollection:
     def __init__(self) -> None:
         self._points: dict = {}  # int_id -> point dict
@@ -69,6 +90,10 @@ class _FakeCollection:
             {"id": p["id"], "score": 0.9, "payload": p.get("payload", {})}
             for p in list(self._points.values())[:top_k]
         ]
+
+    def search_request(self, opts: Any) -> list:
+        """Canonical search entry point — delegate to the legacy `search`."""
+        return self.search(opts.vector, top_k=opts.top_k, filter=opts.filter)
 
     def scroll(  # pylint: disable=redefined-builtin
         self,
@@ -146,7 +171,9 @@ def _load_module() -> types.ModuleType:
     errors_mod.DuplicateDocumentError = DuplicateDocumentError  # type: ignore[attr-defined]
     sys.modules["haystack.document_stores.errors"] = errors_mod
 
-    sys.modules["velesdb"] = types.SimpleNamespace(Database=_FakeDatabase)  # type: ignore
+    sys.modules["velesdb"] = types.SimpleNamespace(  # type: ignore
+        Database=_FakeDatabase, SearchOptions=_FakeSearchOptions
+    )
 
     # Stub velesdb_common.security with no-op validators (real package has its own tests).
     def _passthrough(value: Any, *args: Any, **kwargs: Any) -> Any:
@@ -727,7 +754,9 @@ def test_embedding_retrieval_translates_haystack_filter_to_veles_shape() -> None
 
     original_velesdb = _MOD.velesdb
     try:
-        _MOD.velesdb = types.SimpleNamespace(Database=_CapturingDatabase)  # type: ignore
+        _MOD.velesdb = types.SimpleNamespace(  # type: ignore
+            Database=_CapturingDatabase, SearchOptions=_FakeSearchOptions
+        )
         store = _MOD.VelesDBDocumentStore(path="/tmp/hs", collection_name="t_search_translate")
         store.write_documents([
             Document(id="y", content="world", embedding=[0.5])

--- a/integrations/langchain/src/langchain_velesdb/search_ops.py
+++ b/integrations/langchain/src/langchain_velesdb/search_ops.py
@@ -34,8 +34,10 @@ from langchain_velesdb.security import (
 # blocks below still catch the fallback path regardless of runtime.
 try:
     from velesdb import VelesDBError as _VelesDBError
+    from velesdb import SearchOptions as _SearchOptions
 except (ImportError, AttributeError):  # pragma: no cover — optional dependency fallback
     _VelesDBError = Exception  # type: ignore[misc,assignment]
+    _SearchOptions = None  # type: ignore[assignment]
 
 logger = logging.getLogger(__name__)
 
@@ -152,7 +154,7 @@ class SearchOpsMixin(MultiQueryOpsMixin):
             return collection.search_with_ef(query_embedding, top_k=k, ef_search=ef_search)
         if filter is not None:
             return collection.search_with_filter(query_embedding, top_k=k, filter=filter)
-        return collection.search(query_embedding, top_k=k)
+        return collection.search_request(_SearchOptions(vector=query_embedding, top_k=k))
 
     def _run_sparse_search(
         self,
@@ -192,7 +194,7 @@ class SearchOpsMixin(MultiQueryOpsMixin):
             search_kwargs["filter"] = filter
 
         try:
-            return collection.search(**search_kwargs)
+            return collection.search_request(_SearchOptions(**search_kwargs))
         except (RuntimeError, TypeError, ValueError, _VelesDBError) as exc:
             # Since Wave 3 Commit 2, `VELES-015 SearchNotSupported` is
             # routed to `ValueError`, and other sparse-search failures
@@ -206,7 +208,7 @@ class SearchOpsMixin(MultiQueryOpsMixin):
             )
             if filter is not None:
                 return collection.search_with_filter(query_embedding, top_k=k, filter=filter)
-            return collection.search(vector=query_embedding, top_k=k)
+            return collection.search_request(_SearchOptions(vector=query_embedding, top_k=k))
 
     def similarity_search(
         self,

--- a/integrations/langchain/tests/test_vectorstore.py
+++ b/integrations/langchain/tests/test_vectorstore.py
@@ -1047,7 +1047,8 @@ class TestSearchQualityLangChain:
         assert len(results) == 1
 
     def test_plain_search_called_when_quality_is_none(self, embeddings):
-        """When search_quality is None, collection.search is called (not search_with_quality)."""
+        """When search_quality is None, the canonical search_request is called
+        (not the deprecated search, and not search_with_quality)."""
         store = VelesDBVectorStore(
             embedding=embeddings,
             path="./unused",
@@ -1060,6 +1061,9 @@ class TestSearchQualityLangChain:
             def search(self, vector, top_k):
                 calls.append({"top_k": top_k})
                 return [{"payload": {"text": "world"}, "score": 0.8}]
+
+            def search_request(self, opts):
+                return self.search(opts.vector, top_k=opts.top_k)
 
         store._get_collection = lambda _dim: _MockCollection()  # type: ignore[method-assign]
         results = store.similarity_search("test query", k=3)

--- a/integrations/llamaindex/src/llamaindex_velesdb/search_ops.py
+++ b/integrations/llamaindex/src/llamaindex_velesdb/search_ops.py
@@ -37,8 +37,10 @@ from llamaindex_velesdb.security import (
 # below still catch the fallback path regardless of runtime.
 try:
     from velesdb import VelesDBError as _VelesDBError
+    from velesdb import SearchOptions as _SearchOptions
 except (ImportError, AttributeError):  # pragma: no cover — optional dependency fallback
     _VelesDBError = Exception  # type: ignore[misc,assignment]
+    _SearchOptions = None  # type: ignore[assignment]
 
 logger = logging.getLogger(__name__)
 
@@ -192,7 +194,7 @@ class SearchOpsMixin:
                 query_embedding, quality=search_quality, top_k=k,
             )
 
-        return collection.search(query_embedding, top_k=k)
+        return collection.search_request(_SearchOptions(vector=query_embedding, top_k=k))
 
     def _run_sparse_search(
         self,
@@ -224,7 +226,7 @@ class SearchOpsMixin:
             search_kwargs["sparse_index_name"] = sparse_index_name
 
         try:
-            return collection.search(**search_kwargs)
+            return collection.search_request(_SearchOptions(**search_kwargs))
         except (RuntimeError, ValueError, _VelesDBError):
             # Since Wave 3 Commit 2, `VELES-015 SearchNotSupported` is
             # routed to `ValueError` and other sparse-search failures
@@ -239,7 +241,7 @@ class SearchOpsMixin:
                 UserWarning,
                 stacklevel=2,
             )
-            return collection.search(query_embedding, top_k=k)
+            return collection.search_request(_SearchOptions(vector=query_embedding, top_k=k))
 
     def query_with_score_threshold(
         self,

--- a/integrations/llamaindex/tests/test_vectorstore.py
+++ b/integrations/llamaindex/tests/test_vectorstore.py
@@ -950,7 +950,7 @@ class TestSearchQualityLlamaIndex:
         assert calls[0]["top_k"] == 5
 
     def test_plain_search_called_when_quality_is_none(self, temp_dir):
-        """When search_quality is None, collection.search is called."""
+        """When search_quality is None, the canonical search_request is called."""
         from llama_index.core.vector_stores.types import VectorStoreQuery
 
         store = VelesDBVectorStore(path=temp_dir)
@@ -961,6 +961,9 @@ class TestSearchQualityLlamaIndex:
             def search(self, vector, top_k):
                 calls.append({"top_k": top_k})
                 return []
+
+            def search_request(self, opts):
+                return self.search(opts.vector, top_k=opts.top_k)
 
             def info(self):
                 return {"dimension": 4}


### PR DESCRIPTION
## Contexte
Gap cross-SDK découvert lors de l'audit de complétude : les 3 intégrations appelaient `collection.search(...)`, méthode du SDK Python **dépréciée depuis v1.15** (émet `DeprecationWarning`, retirée en v2.0).

## Changements
- **Code** : `langchain`/`llamaindex` `search_ops.py` + `haystack` `document_store.py` migrent le chemin dense (et le fallback sparse→dense) vers `search_request(SearchOptions(...))`. Frères non dépréciés (`search_with_ef`/`search_with_filter`/`search_with_quality`) inchangés.
- **Tests** : test doubles concernés gagnent un shim `search_request(opts)` ; les tests d'intention « plain path appelle search » assertent désormais l'API canonique.

## Validation (venv Python 3.13 — packages ≥3.10)
- **haystack : 46 passed** · **llamaindex : 201 passed, 17 skipped** · **langchain : 195 passed**

### 7 échecs langchain restants = PRÉEXISTANTS (vérifié : appel `search()` pré-migration → mêmes 7 échecs)
score cosinus hors [0,1] · setup graph-collection · API langchain retirée `get_relevant_documents` · `NotImplementedError` · pollution `sys.modules`.

## Note DRY
Blocs signalés = code d'adaptateurs **parallèles préexistant** (`text_search`/CONTAINS_TEXT langchain↔llamaindex), fixtures de test (`_CapturingDatabase`), et un bench `sift1m.rs` non touché — aucun introduit par ce commit (qui n'ajoute que les lignes `search_request`).