### PR TITLE
docs: migrate deprecated collection.search() examples + fix TS filter examples

### DIFF
--- a/demos/rag-pdf-demo/src/velesdb_client.py
+++ b/demos/rag-pdf-demo/src/velesdb_client.py
@@ -138,7 +138,9 @@ class VelesDBClient:
             raise velesdb.CollectionNotFoundError(
                 f"Collection '{collection}' not found"
             )
-        results = col.search(vector=query_vector, top_k=top_k, filter=filter_)
+        results = col.search_request(
+            velesdb.SearchOptions(vector=query_vector, top_k=top_k, filter=filter_)
+        )
         return {"results": results}
 
     def delete_point(

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -71,7 +71,7 @@ coll.search(&query, 10)?;
 ```python
 # Before (legacy untyped collection)
 coll = db.get_collection("docs")
-results = coll.search_request(SearchOptions(vector=query_vec, top_k=10))
+results = coll.search_request(velesdb.SearchOptions(vector=query_vec, top_k=10))
 
 # After (preferred for graph collections)
 graph = db.create_graph_collection("knowledge", dimension=768)
@@ -284,7 +284,7 @@ Yes. All methods that accept vectors (`search`, `upsert`, etc.) accept both Pyth
 import numpy as np
 
 vec = np.random.randn(384).astype(np.float32)
-results = coll.search_request(SearchOptions(vector=vec, top_k=10))
+results = coll.search_request(velesdb.SearchOptions(vector=vec, top_k=10))
 ```
 
 ### Where are the Python examples?

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -69,9 +69,9 @@ coll.search(&query, 10)?;
 #### Python migration
 
 ```python
-# Before (still works, emits deprecation warning)
+# Before (legacy untyped collection)
 coll = db.get_collection("docs")
-results = coll.search(vector=query_vec, top_k=10)
+results = coll.search_request(SearchOptions(vector=query_vec, top_k=10))
 
 # After (preferred for graph collections)
 graph = db.create_graph_collection("knowledge", dimension=768)
@@ -284,7 +284,7 @@ Yes. All methods that accept vectors (`search`, `upsert`, etc.) accept both Pyth
 import numpy as np
 
 vec = np.random.randn(384).astype(np.float32)
-results = coll.search(vector=vec, top_k=10)
+results = coll.search_request(SearchOptions(vector=vec, top_k=10))
 ```
 
 ### Where are the Python examples?

--- a/docs/guides/INSTALLATION.md
+++ b/docs/guides/INSTALLATION.md
@@ -124,7 +124,7 @@ collection.upsert([
 ])
 
 # Search
-results = collection.search(vector=query_vector, top_k=10)
+results = collection.search_request(velesdb.SearchOptions(vector=query_vector, top_k=10))
 ```
 
 ---

--- a/docs/guides/PYTHON_PERFORMANCE.md
+++ b/docs/guides/PYTHON_PERFORMANCE.md
@@ -168,7 +168,7 @@ GIL is released for the entire batch.
 # Slow: one GIL release + one HNSW traversal per query
 results = []
 for query in query_vectors:
-    results.append(collection.search(query.tolist(), top_k=10))
+    results.append(collection.search_request(velesdb.SearchOptions(vector=query.tolist(), top_k=10)))
 
 # Fast: one GIL release, queries dispatched together
 searches = [{"vector": q.tolist(), "top_k": 10} for q in query_vectors]
@@ -234,7 +234,7 @@ import numpy as np
 collection = db.get_collection("docs")
 
 def search_one(query_vector: np.ndarray) -> list:
-    return collection.search(query_vector.tolist(), top_k=10)
+    return collection.search_request(velesdb.SearchOptions(vector=query_vector.tolist(), top_k=10))
 
 query_vectors = np.random.randn(100, 384).astype(np.float32)
 
@@ -268,13 +268,13 @@ import time
 
 # Warm up — results discarded
 for _ in range(5):
-    collection.search(query.tolist(), top_k=10)
+    collection.search_request(velesdb.SearchOptions(vector=query.tolist(), top_k=10))
 
 # Measure
 times = []
 for _ in range(100):
     t0 = time.perf_counter_ns()
-    collection.search(query.tolist(), top_k=10)
+    collection.search_request(velesdb.SearchOptions(vector=query.tolist(), top_k=10))
     times.append(time.perf_counter_ns() - t0)
 
 median_us = sorted(times)[len(times) // 2] / 1_000
@@ -314,7 +314,7 @@ returns nanoseconds and has the highest resolution available on the OS:
 import time
 
 t0 = time.perf_counter_ns()
-results = collection.search(query.tolist(), top_k=10)
+results = collection.search_request(velesdb.SearchOptions(vector=query.tolist(), top_k=10))
 elapsed_ns = time.perf_counter_ns() - t0
 elapsed_us = elapsed_ns / 1_000
 
@@ -336,7 +336,7 @@ import numpy as np
 latencies_ns = []
 for _ in range(200):
     t0 = time.perf_counter_ns()
-    collection.search(query.tolist(), top_k=10)
+    collection.search_request(velesdb.SearchOptions(vector=query.tolist(), top_k=10))
     latencies_ns.append(time.perf_counter_ns() - t0)
 
 arr = np.array(latencies_ns) / 1_000  # convert to µs
@@ -354,11 +354,11 @@ print(f"p99: {np.percentile(arr, 99):.1f} µs")
 ```python
 # Slow: per-element Python float -> f32 conversion at the FFI boundary
 query = [0.1, 0.2, 0.3, ...]  # list of Python floats
-results = collection.search(query, top_k=10)
+results = collection.search_request(velesdb.SearchOptions(vector=query, top_k=10))
 
 # Fast: float32 array, no per-element conversion
 query = np.array([0.1, 0.2, 0.3, ...], dtype=np.float32)
-results = collection.search(query, top_k=10)  # accepts numpy arrays directly
+results = collection.search_request(velesdb.SearchOptions(vector=query, top_k=10))  # accepts numpy arrays directly
 ```
 
 ### Antipattern 2 — `upsert()` or `upsert_bulk()` loop instead of `upsert_bulk_numpy()`
@@ -388,7 +388,7 @@ collection.upsert_bulk_numpy(vectors, ids)
 # Slow: N separate GIL release/acquire cycles, N separate Python calls
 results = []
 for query in query_batch:
-    results.append(collection.search(query.tolist(), top_k=10))
+    results.append(collection.search_request(velesdb.SearchOptions(vector=query.tolist(), top_k=10)))
 
 # Fast: one GIL release, all traversals dispatched together
 searches = [{"vector": q.tolist(), "top_k": 10} for q in query_batch]
@@ -404,12 +404,12 @@ eliminates 31 redundant GIL release/acquire and argument-parsing cycles.
 # Unreliable: time.time() may have only millisecond resolution
 import time
 t0 = time.time()
-collection.search(query.tolist(), top_k=10)
+collection.search_request(velesdb.SearchOptions(vector=query.tolist(), top_k=10))
 print(f"Latency: {(time.time() - t0) * 1e6:.1f} µs")  # may read 0 µs
 
 # Correct: perf_counter_ns() has nanosecond resolution
 t0 = time.perf_counter_ns()
-collection.search(query.tolist(), top_k=10)
+collection.search_request(velesdb.SearchOptions(vector=query.tolist(), top_k=10))
 print(f"Latency: {(time.perf_counter_ns() - t0) / 1_000:.1f} µs")
 ```
 
@@ -418,17 +418,17 @@ print(f"Latency: {(time.perf_counter_ns() - t0) / 1_000:.1f} µs")
 ```python
 # Unreliable: first call includes cold-start overhead (page faults, branch predictor)
 t0 = time.perf_counter_ns()
-results = collection.search(query.tolist(), top_k=10)
+results = collection.search_request(velesdb.SearchOptions(vector=query.tolist(), top_k=10))
 print(f"{(time.perf_counter_ns() - t0) / 1_000:.1f} µs")  # 3-10x the steady-state
 
 # Correct: warm up, then measure over many iterations
 for _ in range(5):
-    collection.search(query.tolist(), top_k=10)
+    collection.search_request(velesdb.SearchOptions(vector=query.tolist(), top_k=10))
 
 times = [
     time.perf_counter_ns()
     - (t0 := time.perf_counter_ns())
-    or (collection.search(query.tolist(), top_k=10), time.perf_counter_ns() - t0)[1]
+    or (collection.search_request(velesdb.SearchOptions(vector=query.tolist(), top_k=10)), time.perf_counter_ns() - t0)[1]
     for _ in range(100)
 ]
 ```
@@ -437,12 +437,12 @@ A cleaner version of the same pattern:
 
 ```python
 for _ in range(5):  # warm up
-    collection.search(query.tolist(), top_k=10)
+    collection.search_request(velesdb.SearchOptions(vector=query.tolist(), top_k=10))
 
 times = []
 for _ in range(100):  # measure
     t0 = time.perf_counter_ns()
-    collection.search(query.tolist(), top_k=10)
+    collection.search_request(velesdb.SearchOptions(vector=query.tolist(), top_k=10))
     times.append(time.perf_counter_ns() - t0)
 ```
 

--- a/docs/guides/SEARCH_MODES.md
+++ b/docs/guides/SEARCH_MODES.md
@@ -313,10 +313,10 @@ import velesdb
 db = velesdb.Database("./data")
 coll = db.get_collection("docs")
 
-results = coll.search(
+results = coll.search_request(velesdb.SearchOptions(
     sparse_vector={42: 0.8, 156: 0.3, 891: 0.5},
     top_k=10
-)
+))
 ```
 
 ---
@@ -372,11 +372,11 @@ Quand les deux champs `vector` et `sparse_vector` sont fournis, VelesDB execute 
 ### Exemple Python SDK
 
 ```python
-results = coll.search(
+results = coll.search_request(velesdb.SearchOptions(
     vector=[0.1, 0.2, 0.3, ...],
     sparse_vector={42: 0.8, 156: 0.3},
     top_k=10
-)
+))
 ```
 
 ### Execution parallele

--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -760,6 +760,6 @@ points = collection.get([1])
 collection.delete([1, 2, 3])
 
 # Search (supports numpy arrays)
-results = collection.search(vector=query_vector, top_k=10)
-results = collection.search(vector=np.array([...], dtype=np.float32), top_k=10)
+results = collection.search_request(velesdb.SearchOptions(vector=query_vector, top_k=10))
+results = collection.search_request(velesdb.SearchOptions(vector=np.array([...], dtype=np.float32), top_k=10))
 ```

--- a/examples/python/README.md
+++ b/examples/python/README.md
@@ -97,7 +97,7 @@ coll.upsert([
 ])
 
 # Dense vector search
-results = coll.search(vector=[0.1] * 384, top_k=10)
+results = coll.search_request(velesdb.SearchOptions(vector=[0.1] * 384, top_k=10))
 
 # VelesQL query
 results = coll.query(

--- a/examples/python/hello_velesdb.py
+++ b/examples/python/hello_velesdb.py
@@ -35,13 +35,13 @@ docs.upsert([
 ])
 
 # 4. Ask: "what's most relevant to a tech query?"
-results = docs.search(vector=[1.0, 0.0, 0.0, 0.0], top_k=3)
+results = docs.search_request(velesdb.SearchOptions(vector=[1.0, 0.0, 0.0, 0.0], top_k=3))
 print('Query: "tech"')
 for r in results:
     print(f"  score={r['score']:.3f}  {r['payload']['title']}")
 
 # 5. Ask: "what's at the intersection of tech and music?"
-results = docs.search(vector=[0.7, 0.0, 0.7, 0.0], top_k=3)
+results = docs.search_request(velesdb.SearchOptions(vector=[0.7, 0.0, 0.7, 0.0], top_k=3))
 print('\nQuery: "tech + music"')
 for r in results:
     print(f"  score={r['score']:.3f}  {r['payload']['title']}")

--- a/examples/python/hybrid_queries.py
+++ b/examples/python/hybrid_queries.py
@@ -62,7 +62,7 @@ def example_basic_vector_search(coll: velesdb.Collection):
     print("\n=== Basic Vector Search ===")
 
     query = generate_embedding(seed=42)
-    results = coll.search(vector=query, top_k=5)
+    results = coll.search_request(velesdb.SearchOptions(vector=query, top_k=5))
 
     print(f"Top {len(results)} results:")
     for r in results:

--- a/examples/python/multimodel_notebook.py
+++ b/examples/python/multimodel_notebook.py
@@ -93,7 +93,7 @@ try:
     query_vector = generate_embedding(0.12)
 
     # Search for similar documents
-    results = collection.search(vector=query_vector, top_k=3)
+    results = collection.search_request(velesdb.SearchOptions(vector=query_vector, top_k=3))
 
     print("Basic Vector Search Results:")
     for r in results:

--- a/examples/tutorials/distance_metrics_demo.py
+++ b/examples/tutorials/distance_metrics_demo.py
@@ -56,7 +56,7 @@ def demo_cosine():
     ])
 
     query = [0.85, 0.75, 0.0, 0.0]
-    results = collection.search(vector=query, top_k=5)
+    results = collection.search_request(velesdb.SearchOptions(vector=query, top_k=5))
 
     print('\nQuery: "I want to learn about AI"')
     print("Cosine finds articles pointing in the same direction:\n")
@@ -97,7 +97,7 @@ def demo_euclidean():
     ])
 
     baseline = [22.0, 1013.0, 45.0, 0.3]
-    results = collection.search(vector=baseline, top_k=5)
+    results = collection.search_request(velesdb.SearchOptions(vector=baseline, top_k=5))
 
     print("\nBaseline: [22C, 1013hPa, 45%, 0.3g]")
     print("Finding closest readings to the baseline:\n")
@@ -137,7 +137,7 @@ def demo_dotproduct():
     ])
 
     user = [0.9, 0.8, 0.1, 0.0]
-    results = collection.search(vector=user, top_k=5)
+    results = collection.search_request(velesdb.SearchOptions(vector=user, top_k=5))
 
     print('\nUser profile: loves sci-fi + action')
     print("Dot product ranks by relevance AND confidence:\n")
@@ -184,7 +184,7 @@ def demo_hamming():
     ])
 
     new_upload = [1, 0, 1, 1, 0, 0, 1, 0, 1, 1, 0, 1, 0, 0, 1, 1]
-    results = collection.search(vector=new_upload, top_k=5)
+    results = collection.search_request(velesdb.SearchOptions(vector=new_upload, top_k=5))
 
     print("\nNew image uploaded. Checking for duplicates...\n")
     for r in results:
@@ -232,7 +232,7 @@ def demo_jaccard():
     ])
 
     my_tastes = [1, 0, 1, 0, 1, 0, 0, 0, 0, 0]
-    results = collection.search(vector=my_tastes, top_k=5)
+    results = collection.search_request(velesdb.SearchOptions(vector=my_tastes, top_k=5))
 
     print("\nYou like: action, sci-fi, drama")
     print("Finding users with the most taste overlap:\n")

--- a/examples/tutorials/image_search_hamming_clip.py
+++ b/examples/tutorials/image_search_hamming_clip.py
@@ -174,14 +174,14 @@ def find_similar(
     # --- Pass 1: The Bouncer (instant) ---
     query_barcode = compute_barcode(query_path)
     t0 = time.time()
-    fast_candidates = bouncer.search(vector=query_barcode, top_k=shortlist_k)
+    fast_candidates = bouncer.search_request(velesdb.SearchOptions(vector=query_barcode, top_k=shortlist_k))
     bouncer_ms = (time.time() - t0) * 1000
 
     # --- Pass 2: The Detective (thorough) ---
     # ONE single CLIP query. Not N. This is what makes it scale.
     query_meaning = compute_meaning(query_path, model, preprocess)
     t0 = time.time()
-    all_meanings = detective.search(vector=query_meaning, top_k=shortlist_k * 2)
+    all_meanings = detective.search_request(velesdb.SearchOptions(vector=query_meaning, top_k=shortlist_k * 2))
     meaning_scores = {r["id"]: r["score"] for r in all_meanings}
 
     # Re-rank the Bouncer's shortlist with the Detective's scores

--- a/examples/tutorials/multi_query_fusion_demo.py
+++ b/examples/tutorials/multi_query_fusion_demo.py
@@ -117,7 +117,7 @@ print("=" * 60)
 user_question = "How do I fix a slow database connection in my Flask app?"
 single_vec = model.encode(user_question).tolist()
 
-results = collection.search(vector=single_vec, top_k=5)
+results = collection.search_request(velesdb.SearchOptions(vector=single_vec, top_k=5))
 print(f"\nQuery: \"{user_question}\"\n")
 for r in results:
     p = r["payload"]
@@ -136,15 +136,15 @@ q2 = model.encode("Flask SQLAlchemy session management setup").tolist()
 q3 = model.encode("profiling slow queries performance bottleneck").tolist()
 
 print("\nQuery 1 (database connections):")
-for r in collection.search(vector=q1, top_k=3):
+for r in collection.search_request(velesdb.SearchOptions(vector=q1, top_k=3)):
     print(f"  [{r['score']:.3f}] {r['payload']['title']}")
 
 print("\nQuery 2 (Flask patterns):")
-for r in collection.search(vector=q2, top_k=3):
+for r in collection.search_request(velesdb.SearchOptions(vector=q2, top_k=3)):
     print(f"  [{r['score']:.3f}] {r['payload']['title']}")
 
 print("\nQuery 3 (performance diagnostics):")
-for r in collection.search(vector=q3, top_k=3):
+for r in collection.search_request(velesdb.SearchOptions(vector=q3, top_k=3)):
     print(f"  [{r['score']:.3f}] {r['payload']['title']}")
 
 

--- a/examples/tutorials/test_image_search_hamming_clip.py
+++ b/examples/tutorials/test_image_search_hamming_clip.py
@@ -88,7 +88,7 @@ def test_bouncer_hamming():
 
     # Search for beach_1
     query_path = os.path.join(PHOTO_DIR, "beach_1.jpg")
-    results = bouncer.search(vector=compute_barcode(query_path), top_k=5)
+    results = bouncer.search_request(velesdb.SearchOptions(vector=compute_barcode(query_path), top_k=5))
 
     assert len(results) == 5
     assert results[0]["payload"]["filename"] == "beach_1.jpg"
@@ -139,7 +139,7 @@ def test_detective_cosine(db, files):
         detective.upsert(i + 1, vector=emb, payload={"filename": fname, "path": path})
 
     query_path = os.path.join(PHOTO_DIR, "beach_1.jpg")
-    results = detective.search(vector=compute_meaning(query_path), top_k=5)
+    results = detective.search_request(velesdb.SearchOptions(vector=compute_meaning(query_path), top_k=5))
 
     assert len(results) == 5
     assert results[0]["payload"]["filename"] == "beach_1.jpg"
@@ -162,13 +162,13 @@ def test_combined_pipeline(bouncer, detective, compute_meaning_fn, files):
 
     # Pass 1: The Bouncer
     t0 = time.time()
-    fast_candidates = bouncer.search(vector=compute_barcode(query_path), top_k=8)
+    fast_candidates = bouncer.search_request(velesdb.SearchOptions(vector=compute_barcode(query_path), top_k=8))
     bouncer_ms = (time.time() - t0) * 1000
 
     # Pass 2: The Detective re-ranks
     query_meaning = compute_meaning_fn(query_path)
     t0 = time.time()
-    all_meanings = detective.search(vector=query_meaning, top_k=len(files))
+    all_meanings = detective.search_request(velesdb.SearchOptions(vector=query_meaning, top_k=len(files)))
     meaning_scores = {r["id"]: r["score"] for r in all_meanings}
 
     reranked = sorted(
@@ -206,7 +206,7 @@ def test_all_metrics():
     for metric in ["hamming", "jaccard", "euclidean", "cosine", "dot"]:
         col = db.get_or_create_collection(f"test_{metric}", dimension=4, metric=metric)
         col.upsert(1, vector=[0.1, 0.2, 0.3, 0.4], payload={"test": True})
-        results = col.search(vector=[0.1, 0.2, 0.3, 0.4], top_k=1)
+        results = col.search_request(velesdb.SearchOptions(vector=[0.1, 0.2, 0.3, 0.4], top_k=1))
         assert len(results) == 1, f"metric '{metric}' search failed"
         print(f"  [PASS] metric='{metric}'")
 

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -349,7 +349,7 @@ Vector similarity search.
 ```typescript
 const results = await db.search('docs', queryVector, {
   k: 10,
-  filter: { category: 'tech' },
+  filter: { condition: { type: 'eq', field: 'category', value: 'tech' } },
   includeVectors: true
 });
 // Returns: SearchResult[] = [{ id, score, payload?, vector? }, ...]
@@ -362,7 +362,7 @@ Execute multiple search queries in parallel.
 ```typescript
 const batchResults = await db.searchBatch('docs', [
   { vector: queryA, k: 5 },
-  { vector: queryB, k: 10, filter: { type: 'article' } },
+  { vector: queryB, k: 10, filter: { condition: { type: 'eq', field: 'type', value: 'article' } } },
 ]);
 // Returns: SearchResult[][] (one result array per query)
 ```

--- a/tutorials/image-search-hamming-clip/README.md
+++ b/tutorials/image-search-hamming-clip/README.md
@@ -278,7 +278,7 @@ the lowest Hamming distance. This is a single HNSW search on binary vectors.
 SHORTLIST_K = 50  # Number of candidates for the Detective
 
 query_barcode = compute_barcode("query.jpg")
-candidates = bouncer.search(vector=query_barcode, top_k=SHORTLIST_K)
+candidates = bouncer.search_request(velesdb.SearchOptions(vector=query_barcode, top_k=SHORTLIST_K))
 
 # candidates is a list of dicts: [{"id": 42, "score": 12.0, "payload": {...}}, ...]
 # score = Hamming distance (number of differing bits out of 256)
@@ -301,7 +301,7 @@ FINAL_K = 10
 query_meaning = compute_meaning("query.jpg")
 
 # Search the full CLIP collection with enough headroom
-clip_results = detective.search(vector=query_meaning, top_k=SHORTLIST_K * 2)
+clip_results = detective.search_request(velesdb.SearchOptions(vector=query_meaning, top_k=SHORTLIST_K * 2))
 
 # Build a score lookup from CLIP results
 meaning_scores = {r["id"]: r["score"] for r in clip_results}
@@ -346,13 +346,13 @@ def find_similar(
     # Pass 1: The Bouncer
     query_barcode = compute_barcode(query_path)
     t0 = time.time()
-    candidates = bouncer.search(vector=query_barcode, top_k=shortlist_k)
+    candidates = bouncer.search_request(velesdb.SearchOptions(vector=query_barcode, top_k=shortlist_k))
     bouncer_ms = (time.time() - t0) * 1000
 
     # Pass 2: The Detective
     query_meaning = compute_meaning(query_path)
     t0 = time.time()
-    clip_results = detective.search(vector=query_meaning, top_k=shortlist_k * 2)
+    clip_results = detective.search_request(velesdb.SearchOptions(vector=query_meaning, top_k=shortlist_k * 2))
     meaning_scores = {r["id"]: r["score"] for r in clip_results}
 
     reranked = sorted(
@@ -429,7 +429,7 @@ pass1 = bouncer.query(
 shortlist_ids = [r["id"] for r in pass1]
 
 # Pass 2 -- search CLIP collection, then filter client-side
-pass2 = detective.search(vector=query_meaning, top_k=len(shortlist_ids) * 2)
+pass2 = detective.search_request(velesdb.SearchOptions(vector=query_meaning, top_k=len(shortlist_ids) * 2))
 shortlist_set = set(shortlist_ids)
 reranked = [r for r in pass2 if r["id"] in shortlist_set]
 reranked.sort(key=lambda x: x["score"], reverse=True)


### PR DESCRIPTION
## Contexte
Gap doc découvert lors de l'audit de complétude : la migration `search()`→`search_request(SearchOptions(...))` n'avait touché que le README du crate Python. ~30 autres fichiers de docs/exemples enseignaient encore l'API **dépréciée v1.15**.

## Changements
- **Sweep (~16 fichiers, 49 conversions)** : `docs/FAQ.md`, `docs/reference/api-reference.md`, `docs/guides/{INSTALLATION,SEARCH_MODES,PYTHON_PERFORMANCE}.md`, `examples/python/**`, `examples/tutorials/**`, `tutorials/image-search-hamming-clip/README.md`, `demos/rag-pdf-demo/src/velesdb_client.py` → `search_request(SearchOptions(...))`.
- **TS README** : 2 exemples de filtre au mauvais format (`{category:'tech'}`, `{type:'article'}`) → format canonique `{condition:{type:'eq',...}}` requis par le serveur.

## Laissé intentionnellement (hors périmètre)
Rust/Swift/Kotlin/WASM `.search()`, le wrapper REST-client (`examples/python_example.py`, `demo_data.json`), et les frères non dépréciés.

## Validation
`py_compile` OK sur tous les `.py` modifiés ; grep confirme qu'il ne reste que les `.search(` légitimes (Rust/mobile/REST-wrapper/méthodes non dépréciées).