### PR TITLE
docs: document REST/mobile filter shape + reconcile error-code schemes (M6)

### DIFF
--- a/crates/velesdb-mobile/README.md
+++ b/crates/velesdb-mobile/README.md
@@ -193,6 +193,35 @@ cargo run --bin uniffi-bindgen generate \
 | `analyze()` | Runs ANALYZE and returns fresh statistics |
 | `getStats()` | Returns the latest statistics snapshot |
 
+#### The `filterJson` shape
+
+The `filterJson` argument on `searchWithFilter`, `textSearchWithFilter`,
+`hybridSearchWithFilter`, and `multiQuerySearchWithFilter` is a JSON string using the
+same canonical filter shape as the core engine and REST API:
+`{"condition": {"type": <op>, "field": ..., "value"/"values"/"pattern"/"conditions": ...}}`.
+Operators: `eq`, `neq`, `gt`, `gte`, `lt`, `lte`, `in`, `like`, `ilike`, `is_null`,
+`is_not_null`, `and`, `or`, `not`.
+
+Swift:
+
+```swift
+let results = try collection.searchWithFilter(
+    vector: queryVector,
+    limit: 5,
+    filterJson: #"{"condition": {"type": "eq", "field": "category", "value": "tech"}}"#
+)
+```
+
+Kotlin:
+
+```kotlin
+val results = collection.searchWithFilter(
+    queryVector,
+    5,
+    """{"condition": {"type": "eq", "field": "category", "value": "tech"}}"""
+)
+```
+
 ### VelesSemanticMemory
 
 Agent memory for on-device AI. Stores knowledge facts as vectors with similarity search.

--- a/crates/velesdb-mobile/README.md
+++ b/crates/velesdb-mobile/README.md
@@ -199,8 +199,9 @@ The `filterJson` argument on `searchWithFilter`, `textSearchWithFilter`,
 `hybridSearchWithFilter`, and `multiQuerySearchWithFilter` is a JSON string using the
 same canonical filter shape as the core engine and REST API:
 `{"condition": {"type": <op>, "field": ..., "value"/"values"/"pattern"/"conditions": ...}}`.
-Operators: `eq`, `neq`, `gt`, `gte`, `lt`, `lte`, `in`, `like`, `ilike`, `is_null`,
-`is_not_null`, `and`, `or`, `not`.
+Operators: `eq`, `neq`, `gt`, `gte`, `lt`, `lte`, `in`, `contains`, `like`, `ilike`,
+`is_null`, `is_not_null`, `array_contains`, `array_contains_any`, `array_contains_all`,
+`geo_distance`, `geo_bbox`, and `and`/`or`/`not` for composition.
 
 Swift:
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2737,7 +2737,13 @@ components:
       - query
       properties:
         filter:
+          type: object
           description: Optional metadata filter.
+          example:
+            condition:
+              type: eq
+              field: category
+              value: tech
         query:
           type: string
           description: Text query for BM25 search.
@@ -2982,7 +2988,13 @@ components:
           description: 'Relative score fusion: weight for the dense (vector) branch.'
           example: 0.5
         filter:
+          type: object
           description: Optional metadata filter.
+          example:
+            condition:
+              type: eq
+              field: category
+              value: tech
         hit_weight:
           type: number
           format: float
@@ -3343,7 +3355,13 @@ components:
           example: 128
           minimum: 0
         filter:
+          type: object
           description: Optional metadata filter.
+          example:
+            condition:
+              type: eq
+              field: category
+              value: tech
         fusion:
           oneOf:
           - type: 'null'
@@ -3544,7 +3562,13 @@ components:
       - query
       properties:
         filter:
+          type: object
           description: Optional metadata filter.
+          example:
+            condition:
+              type: eq
+              field: category
+              value: tech
         query:
           type: string
           description: Text query for full-text search.

--- a/docs/reference/ERROR_CODES.md
+++ b/docs/reference/ERROR_CODES.md
@@ -12,6 +12,46 @@ All error types are defined in `crates/velesdb-core/src/error.rs` and derive fro
 
 ---
 
+## Error code schemes
+
+VelesDB exposes **three independent error-code schemes**. They surface at different
+layers and **do not share a numbering space** — they only look similar.
+
+| Scheme | Where it surfaces | Format | Example |
+|--------|-------------------|--------|---------|
+| Parser codes | VelesQL syntax & query validation (parse stage) | `E0XX` | `E001` SyntaxError, `E004` DimensionMismatch |
+| Engine/runtime codes | Core engine errors and the REST `code` field | `VELES-XXX` | `VELES-001` CollectionExists, `VELES-004` DimensionMismatch |
+| REST VelesQL codes | Semantic/runtime errors on the REST `/query` (and `/aggregate`) VelesQL endpoints | `VELESQL_*` string identifiers | `VELESQL_MISSING_COLLECTION`, `VELESQL_AGGREGATION_ERROR` |
+
+**The numbers do NOT align across schemes — there is no 1:1 numeric mapping.**
+For example parser `E001` is a *syntax error*, whereas `VELES-001` is *CollectionExists*;
+they are entirely separate numbering spaces (`E0XX` ≠ `VELES-0XX`). Likewise parser
+`E004` (DimensionMismatch) and `VELES-004` (DimensionMismatch) happen to describe the
+same condition, but this is coincidental, not a guaranteed correspondence.
+
+Sources of truth:
+
+- Parser `E0XX`: `crates/velesdb-core/src/velesql/error.rs`
+  (`E001` SyntaxError/UnexpectedToken, `E002` UnknownColumn, `E003` CollectionNotFound,
+  `E004` DimensionMismatch, `E005` MissingParameter, `E006` TypeMismatch,
+  `E007` ComplexityLimit).
+- Engine/runtime `VELES-XXX`: this document (and `crates/velesdb-core/src/error.rs`).
+- REST VelesQL `VELESQL_*`: `docs/reference/VELESQL_CONTRACT.md`.
+
+Which scheme is canonical for which surface:
+
+- A **VelesQL parse/validation failure** is reported with an `E0XX` code (parser-specific
+  payload with `type`/`message`/`position`/`query`). It is also wrapped by the engine as
+  `VELES-010` (`Query`) when it propagates through the engine API.
+- A **core engine / general REST error** carries a `VELES-XXX` code in the `code` field
+  (e.g. `{"error": "...", "code": "VELES-004"}`).
+- A **semantic/runtime error on the REST VelesQL `/query` or `/aggregate` endpoints**
+  carries a `VELESQL_*` string identifier in the structured `error.code` field
+  (see `VELESQL_CONTRACT.md`). Syntax errors on those endpoints still use the
+  parser-specific `E0XX` payload.
+
+---
+
 ## Recoverability
 
 Most errors are recoverable (the caller can fix the input and retry). The following

--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -238,12 +238,28 @@ Search for similar vectors.
 |-------|------|----------|-------------|
 | vector | array[float] | Yes | Query vector |
 | top_k | integer | No | Number of results (default: 10) |
+| filter | object | No | Optional metadata filter (see shape below) |
 
 **Example:**
 ```json
 {
   "vector": [0.15, 0.25, 0.35, ...],
   "top_k": 5
+}
+```
+
+**Example with a metadata filter:**
+
+The `filter` uses the canonical VelesDB filter shape:
+`{"condition": {"type": <op>, "field": ..., "value"/"values"/"pattern"/"conditions": ...}}`.
+Operators: `eq`, `neq`, `gt`, `gte`, `lt`, `lte`, `in`, `like`, `ilike`, `is_null`,
+`is_not_null`, `and`, `or`, `not`. A malformed filter returns `400`.
+
+```json
+{
+  "vector": [0.1, 0.2, 0.3],
+  "top_k": 5,
+  "filter": {"condition": {"type": "eq", "field": "category", "value": "tech"}}
 }
 ```
 

--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -252,8 +252,10 @@ Search for similar vectors.
 
 The `filter` uses the canonical VelesDB filter shape:
 `{"condition": {"type": <op>, "field": ..., "value"/"values"/"pattern"/"conditions": ...}}`.
-Operators: `eq`, `neq`, `gt`, `gte`, `lt`, `lte`, `in`, `like`, `ilike`, `is_null`,
-`is_not_null`, `and`, `or`, `not`. A malformed filter returns `400`.
+Operators: `eq`, `neq`, `gt`, `gte`, `lt`, `lte`, `in`, `contains`, `like`, `ilike`,
+`is_null`, `is_not_null`, `array_contains`, `array_contains_any`, `array_contains_all`,
+`geo_distance`, `geo_bbox`, and `and`/`or`/`not` for composition. A malformed filter
+returns `400`.
 
 ```json
 {


### PR DESCRIPTION
## Contexte
Gaps de complétude (basse priorité) découverts lors de l'audit : la forme du filtre n'était documentée ni côté REST ni mobile, et trois nomenclatures de codes d'erreur coexistaient sans explication.

## Changements (doc uniquement)
- **REST** (`api-reference.md` + `openapi.yaml`) : le champ `filter` des endpoints de recherche n'avait ni type ni exemple → ajout du schéma + exemple canonique `{condition:{type:'eq',field,value}}` (le serveur renvoie 400 sinon).
- **Mobile** (`velesdb-mobile/README.md`) : ajout d'un exemple de `filterJson` (même JSON canonique que core/REST), avec snippets Swift/Kotlin.
- **M6** (`ERROR_CODES.md`) : nouvelle section « Error code schemes » réconciliant les 3 nomenclatures — parser `E0XX`, engine/REST `VELES-XXX`, REST VelesQL `VELESQL_*` — en précisant explicitement que ce sont des **espaces de numérotation indépendants** (`E001` ≠ `VELES-001`), avec où chacun apparaît et lequel est canonique par surface.

## Périmètre
Documentation seule. Aucune unification/renommage de code (ce serait un changement cassant, hors périmètre). Faits vérifiés contre `error.rs`, `ERROR_CODES.md`, `VELESQL_CONTRACT.md`, `filter/mod.rs`. `openapi.yaml` revalidé (`yaml.safe_load`).