### PR TITLE
fix: residual newcomer irritants from final 7-angle review

### DIFF
--- a/crates/tauri-plugin-velesdb/guest-js/index.ts
+++ b/crates/tauri-plugin-velesdb/guest-js/index.ts
@@ -597,7 +597,7 @@ export async function deletePoints(request: DeletePointsRequest): Promise<void> 
  *   collection: 'documents',
  *   searches: [
  *     { vector: embedding1, topK: 5 },
- *     { vector: embedding2, topK: 10, filter: { category: 'tech' } }
+ *     { vector: embedding2, topK: 10, filter: { condition: { type: 'eq', field: 'category', value: 'tech' } } }
  *   ]
  * });
  * responses.forEach((resp, i) => {

--- a/crates/velesdb-mobile/README.md
+++ b/crates/velesdb-mobile/README.md
@@ -145,7 +145,7 @@ cargo run --bin uniffi-bindgen generate \
 
 | Method | Description |
 |--------|-------------|
-| `VelesDatabase(path)` | Opens or creates a database at the specified path (constructor) |
+| `VelesDatabase.open(path)` | Opens or creates a database at the specified path (named constructor — use `.open(...)`) |
 | `createCollection(name, dimension, metric)` | Creates a new vector collection |
 | `createCollectionWithStorage(name, dimension, metric, storageMode)` | Creates collection with quantized storage |
 | `createMetadataCollection(name)` | Creates a metadata-only collection (no vectors) |

--- a/crates/velesdb-server/README.md
+++ b/crates/velesdb-server/README.md
@@ -195,7 +195,7 @@ curl -X POST http://localhost:8080/collections/documents/search \
   -d '{
     "vector": [0.15, 0.25, ...],
     "top_k": 5,
-    "filter": {"type": "eq", "field": "category", "value": "tech"}
+    "filter": {"condition": {"type": "eq", "field": "category", "value": "tech"}}
   }'
 
 # Search with explicit search quality mode

--- a/examples/langchain/hybrid_search.py
+++ b/examples/langchain/hybrid_search.py
@@ -177,10 +177,12 @@ class VelesDBVectorStore(VectorStore):
 
         sparse_vector = kwargs.get("sparse_vector")
 
-        results = self._collection.search(
-            vector=query_embedding,
-            sparse_vector=sparse_vector,
-            top_k=k,
+        results = self._collection.search_request(
+            velesdb.SearchOptions(
+                vector=query_embedding,
+                sparse_vector=sparse_vector,
+                top_k=k,
+            )
         )
 
         docs_and_scores: list[tuple[Document, float]] = []

--- a/examples/llamaindex/hybrid_search.py
+++ b/examples/llamaindex/hybrid_search.py
@@ -159,10 +159,12 @@ class VelesDBVectorStore(BasePydanticVectorStore):
         """
         sparse_vector = kwargs.get("sparse_vector")
 
-        results = self._collection.search(
-            vector=query.query_embedding,
-            sparse_vector=sparse_vector,
-            top_k=query.similarity_top_k,
+        results = self._collection.search_request(
+            velesdb.SearchOptions(
+                vector=query.query_embedding,
+                sparse_vector=sparse_vector,
+                top_k=query.similarity_top_k,
+            )
         )
 
         nodes: list[TextNode] = []

--- a/examples/python_example.py
+++ b/examples/python_example.py
@@ -11,7 +11,7 @@ library. For new projects, use the native Python SDK instead:
     db = velesdb.Database("./my_data")
     col = db.get_or_create_collection("docs", dimension=768)
     col.upsert([{"id": 1, "vector": [...], "payload": {"title": "Doc"}}])
-    results = col.search([...], top_k=10)
+    results = col.search_request(velesdb.SearchOptions(vector=[...], top_k=10))
 
 See examples/langchain/hybrid_search.py and examples/llamaindex/hybrid_search.py
 for production-ready integration examples.

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -129,6 +129,7 @@ await db.upsertBatch('documents', [
 ]);
 
 // 5. Search for similar vectors
+const queryVector = new Float32Array(768).fill(0.1);
 const results = await db.search('documents', queryVector, { k: 5 });
 console.log(results);
 // [{ id: 'doc-1', score: 0.95, payload: { title: 'Hello World', ... } }, ...]
@@ -155,6 +156,7 @@ await db.init();
 // Same API as WASM backend
 await db.createCollection('products', { dimension: 1536 });
 await db.upsert('products', { id: 1, vector: embedding });
+const queryVector = new Float32Array(1536).fill(0.1);
 const results = await db.search('products', queryVector, { k: 10 });
 ```
 
@@ -575,7 +577,7 @@ const combined = await db.query('users',
 
 // Fusion strategy
 const fused = await db.query('docs',
-  "SELECT * FROM docs USING FUSION(strategy = 'rrf', k = 60) LIMIT 20"
+  "SELECT * FROM docs LIMIT 20 USING FUSION(strategy = 'rrf', k = 60)"
 );
 ```
 


### PR DESCRIPTION
## Contexte
Revue finale 7-angles de la campagne d'onboarding (sur l'état combiné des 5 PR). Régression : **zéro**. Nouveau contenu : **correct**. Cette PR corrige les irritants résiduels surfacés (gaps préexistants dans des surfaces non encore couvertes).

## Changements (doc/exemples uniquement)
- **Exemples de référence** `examples/{langchain,llamaindex}/hybrid_search.py` + `examples/python_example.py` (docstring) : migrés hors de `collection.search()` déprécié → `search_request(velesdb.SearchOptions(...))`.
- **Filtres au mauvais format** : `tauri-plugin-velesdb/guest-js/index.ts` (`{category:'tech'}`) et `velesdb-server/README.md` (filtre sans wrapper `condition`) → format canonique `{condition:{type,field,value}}`.
- **VelesQL TS README** : `USING FUSION(...)` réordonné après `LIMIT` (clause finale) ; déclaration `queryVector` manquante ajoutée dans 2 snippets quickstart.
- **Mobile README** : table API montre `VelesDatabase.open(path)` (constructeur nommé UniFFI) pour coller au Quick Start.

## Validation
`py_compile` OK sur les 3 `.py`. Précisions vérifiées contre la source (UniFFI constructeurs, grammaire FUSION, enum Filter).

## Suite recommandée (hors périmètre, plus gros / préexistant)
- `crates/velesdb-cli/README.md` : ~23 invocations obsolètes (structure plate vs sous-commandes `collection`/`data`/`query`) — overhaul CLI séparé.
- README racine : shape de réponse REST + incohérence type d'ID (string vs int) entre `/search` et `/query`.