### PR TITLE
fix(velesql): raise on WHERE-clause subqueries instead of silently returning NULL

### DIFF
--- a/crates/velesdb-core/src/velesql/ast/condition.rs
+++ b/crates/velesdb-core/src/velesql/ast/condition.rs
@@ -281,4 +281,31 @@ impl Condition {
             | Self::GeoBbox(_) => false,
         }
     }
+
+    /// Returns `true` if this condition (or any nested sub-condition) compares
+    /// against a subquery value.
+    ///
+    /// Subqueries parse but are not yet executed; left unchecked they silently
+    /// evaluate to `NULL`, producing wrong or empty results.
+    #[must_use]
+    pub fn has_subquery(&self) -> bool {
+        self.leaf_has_subquery()
+            || match self {
+                Self::And(l, r) | Self::Or(l, r) => l.has_subquery() || r.has_subquery(),
+                Self::Group(inner) | Self::Not(inner) => inner.has_subquery(),
+                _ => false,
+            }
+    }
+
+    /// Returns `true` if a value compared directly in this condition (ignoring
+    /// nested logical operators) is a subquery.
+    fn leaf_has_subquery(&self) -> bool {
+        match self {
+            Self::Comparison(c) => c.value.is_subquery(),
+            Self::Between(c) => [&c.low, &c.high].into_iter().any(Value::is_subquery),
+            Self::In(c) => c.values.iter().any(Value::is_subquery),
+            Self::Contains(c) => c.values.iter().any(Value::is_subquery),
+            _ => false,
+        }
+    }
 }

--- a/crates/velesdb-core/src/velesql/ast/condition.rs
+++ b/crates/velesdb-core/src/velesql/ast/condition.rs
@@ -299,13 +299,31 @@ impl Condition {
 
     /// Returns `true` if a value compared directly in this condition (ignoring
     /// nested logical operators) is a subquery.
+    ///
+    /// Matched exhaustively (like [`Self::has_vector_search`]) so that a future
+    /// value-bearing condition variant fails to compile until it is classified
+    /// here, rather than silently escaping subquery detection.
     fn leaf_has_subquery(&self) -> bool {
         match self {
             Self::Comparison(c) => c.value.is_subquery(),
             Self::Between(c) => [&c.low, &c.high].into_iter().any(Value::is_subquery),
             Self::In(c) => c.values.iter().any(Value::is_subquery),
             Self::Contains(c) => c.values.iter().any(Value::is_subquery),
-            _ => false,
+            Self::VectorSearch(_)
+            | Self::VectorFusedSearch(_)
+            | Self::SparseVectorSearch(_)
+            | Self::Similarity(_)
+            | Self::Like(_)
+            | Self::IsNull(_)
+            | Self::Match(_)
+            | Self::GraphMatch(_)
+            | Self::ContainsText(_)
+            | Self::GeoDistance(_)
+            | Self::GeoBbox(_)
+            | Self::And(..)
+            | Self::Or(..)
+            | Self::Not(_)
+            | Self::Group(_) => false,
         }
     }
 }

--- a/crates/velesdb-core/src/velesql/ast/values.rs
+++ b/crates/velesdb-core/src/velesql/ast/values.rs
@@ -156,6 +156,15 @@ impl IntervalValue {
 }
 
 impl Value {
+    /// Returns `true` if this value is a subquery.
+    ///
+    /// Subqueries parse but are not yet executable; callers use this to reject
+    /// them before they silently evaluate to `Value::Null`.
+    #[must_use]
+    pub fn is_subquery(&self) -> bool {
+        matches!(self, Self::Subquery(_))
+    }
+
     /// Converts this VelesQL value to a JSON value.
     ///
     /// Literal values (integer, float, string, boolean, null) map directly

--- a/crates/velesdb-core/src/velesql/validation.rs
+++ b/crates/velesdb-core/src/velesql/validation.rs
@@ -510,7 +510,8 @@ fn reject_subqueries(query: &Query) -> Result<(), ValidationError> {
             ValidationErrorKind::SubqueryNotExecutable,
             None,
             "subquery",
-            "Subqueries are parsed but not yet executed; rewrite the predicate without a subquery",
+            "Compute the value separately and pass it as a literal or $parameter, \
+             or rewrite the predicate without a subquery",
         ));
     }
     Ok(())

--- a/crates/velesdb-core/src/velesql/validation.rs
+++ b/crates/velesdb-core/src/velesql/validation.rs
@@ -4,7 +4,7 @@
 //! `ComplexityStats`) live in `validation_types.rs` to keep each file under
 //! the 500 NLOC limit.
 
-use super::ast::{ArithmeticExpr, Condition, OrderByExpr, Query, SelectColumns};
+use super::ast::{ArithmeticExpr, Condition, DmlStatement, OrderByExpr, Query, SelectColumns};
 use super::error::{ParseError, ParseErrorKind};
 
 // Re-export types so that existing `use crate::velesql::validation::*` paths
@@ -42,6 +42,10 @@ impl QueryValidator {
         query: &Query,
         config: &ValidationConfig,
     ) -> Result<(), ValidationError> {
+        // Subqueries parse but are not executable; reject them in any WHERE
+        // clause (SELECT, compound operands, or DML) before further validation.
+        reject_subqueries(query)?;
+
         // Non-SELECT statements: only check LET bindings.
         if !requires_select_validation(query) {
             return reject_let_on_non_select(query);
@@ -490,6 +494,52 @@ fn requires_select_validation(query: &Query) -> bool {
         && !query.is_train()
         && !query.is_introspection_query()
         && !query.is_admin_query()
+}
+
+/// Rejects subqueries appearing in any WHERE clause of the query.
+///
+/// Subqueries are parsed but not yet executed: left unchecked, a predicate like
+/// `WHERE price > (SELECT AVG(price) FROM products)` silently evaluates to NULL,
+/// yielding wrong/empty results (or a silently no-op UPDATE) instead of an error.
+fn reject_subqueries(query: &Query) -> Result<(), ValidationError> {
+    if where_clauses(query)
+        .into_iter()
+        .any(Condition::has_subquery)
+    {
+        return Err(ValidationError::new(
+            ValidationErrorKind::SubqueryNotExecutable,
+            None,
+            "subquery",
+            "Subqueries are parsed but not yet executed; rewrite the predicate without a subquery",
+        ));
+    }
+    Ok(())
+}
+
+/// Collects every WHERE clause in the query: the main SELECT, compound
+/// operands (UNION/INTERSECT/EXCEPT), and DML statements (UPDATE/DELETE/SELECT EDGES).
+fn where_clauses(query: &Query) -> Vec<&Condition> {
+    let mut clauses: Vec<&Condition> = query.select.where_clause.as_ref().into_iter().collect();
+    if let Some(ref compound) = query.compound {
+        clauses.extend(
+            compound
+                .operations
+                .iter()
+                .filter_map(|(_, stmt)| stmt.where_clause.as_ref()),
+        );
+    }
+    clauses.extend(dml_where_clauses(query.dml.as_ref()));
+    clauses
+}
+
+/// Returns the optional WHERE clauses carried by a DML statement.
+fn dml_where_clauses(dml: Option<&DmlStatement>) -> Vec<&Condition> {
+    match dml {
+        Some(DmlStatement::Update(u)) => u.where_clause.iter().collect(),
+        Some(DmlStatement::Delete(d)) => vec![&d.where_clause],
+        Some(DmlStatement::SelectEdges(s)) => s.where_clause.iter().collect(),
+        _ => Vec::new(),
+    }
 }
 
 /// Returns `Ok(())` if there are no LET bindings, otherwise rejects.

--- a/crates/velesdb-core/src/velesql/validation_tests.rs
+++ b/crates/velesdb-core/src/velesql/validation_tests.rs
@@ -1450,3 +1450,58 @@ fn test_validation_error_kind_message_invalid_let() {
         .message()
         .contains("LET"));
 }
+
+// ============================================================================
+// FU-2: Subqueries parse but are not executable (V010)
+//
+// A WHERE-clause subquery parses, then silently evaluates to NULL during
+// filtering (wrong/empty results, or a silently no-op UPDATE). Validation
+// must reject it instead.
+// ============================================================================
+
+fn validate_sql(sql: &str) -> Result<(), ValidationError> {
+    let query = super::Parser::parse(sql).expect("query should parse");
+    QueryValidator::validate(&query)
+}
+
+fn assert_subquery_rejected(sql: &str) {
+    let err = validate_sql(sql).expect_err("subquery WHERE clause should be rejected");
+    assert_eq!(err.kind, ValidationErrorKind::SubqueryNotExecutable);
+}
+
+#[test]
+fn test_scalar_subquery_in_where_is_rejected() {
+    assert_subquery_rejected(
+        "SELECT * FROM products WHERE price > (SELECT AVG(price) FROM products) LIMIT 10",
+    );
+}
+
+#[test]
+fn test_between_subquery_in_where_is_rejected() {
+    assert_subquery_rejected(
+        "SELECT * FROM docs WHERE id BETWEEN (SELECT AVG(id) FROM docs) AND 100 LIMIT 10",
+    );
+}
+
+#[test]
+fn test_subquery_nested_in_and_is_rejected() {
+    assert_subquery_rejected(
+        "SELECT * FROM docs WHERE category = 'tech' AND id > (SELECT AVG(id) FROM docs) LIMIT 10",
+    );
+}
+
+#[test]
+fn test_update_where_subquery_is_rejected() {
+    // Previously this returned "executed successfully" while matching nothing.
+    assert_subquery_rejected("UPDATE docs SET x = 1 WHERE id > (SELECT AVG(id) FROM docs)");
+}
+
+#[test]
+fn test_query_without_subquery_passes() {
+    assert!(validate_sql("SELECT * FROM docs WHERE price > 100 LIMIT 10").is_ok());
+}
+
+#[test]
+fn test_validation_error_kind_code_v010() {
+    assert_eq!(ValidationErrorKind::SubqueryNotExecutable.code(), "V010");
+}

--- a/crates/velesdb-core/src/velesql/validation_tests.rs
+++ b/crates/velesdb-core/src/velesql/validation_tests.rs
@@ -1497,6 +1497,15 @@ fn test_update_where_subquery_is_rejected() {
 }
 
 #[test]
+fn test_subquery_in_compound_operand_is_rejected() {
+    // The subquery sits in the UNION's right-hand SELECT, exercising the
+    // compound-operand branch of where_clauses().
+    assert_subquery_rejected(
+        "SELECT id FROM a WHERE x = 1 UNION SELECT id FROM b WHERE y > (SELECT AVG(z) FROM b)",
+    );
+}
+
+#[test]
 fn test_query_without_subquery_passes() {
     assert!(validate_sql("SELECT * FROM docs WHERE price > 100 LIMIT 10").is_ok());
 }

--- a/crates/velesdb-core/src/velesql/validation_types.rs
+++ b/crates/velesdb-core/src/velesql/validation_types.rs
@@ -120,6 +120,8 @@ pub enum ValidationErrorKind {
     UnsupportedArithmeticSimilarity,
     /// LET bindings used with DDL or DML statements (nonsensical).
     InvalidLetBinding,
+    /// Subquery used in a WHERE clause; parsed but not yet executable.
+    SubqueryNotExecutable,
 }
 
 impl ValidationErrorKind {
@@ -136,6 +138,7 @@ impl ValidationErrorKind {
             Self::UndeclaredAlias => "V007",
             Self::UnsupportedArithmeticSimilarity => "V008",
             Self::InvalidLetBinding => "V009",
+            Self::SubqueryNotExecutable => "V010",
         }
     }
 
@@ -157,6 +160,7 @@ impl ValidationErrorKind {
                  is not yet supported"
             }
             Self::InvalidLetBinding => "LET bindings are not supported with DDL or DML statements",
+            Self::SubqueryNotExecutable => "Subqueries are parsed but not yet executable",
         }
     }
 }


### PR DESCRIPTION
## The bug

A scalar subquery in a WHERE clause parses, then `filter::conversion::velesql_value_to_json` maps the subquery to `Value::Null`. The predicate silently evaluates against NULL:

```sql
-- parses, then silently returns NO results (id > NULL is never true)
SELECT * FROM products WHERE price > (SELECT AVG(price) FROM products) LIMIT 10;

-- reports "executed successfully" while matching/updating NOTHING
UPDATE docs SET x = 1 WHERE id > (SELECT AVG(id) FROM docs);
```

No error is raised — the user gets wrong or empty results, or a silent no-op write. VelesQL documents subqueries as *parsed but not yet executed*, so this should be a clear error.

## The fix

Reject subqueries in **any** WHERE clause at validation time, before any execution/dispatch:

- `Value::is_subquery()` and `Condition::has_subquery()` AST helpers (the latter mirrors the existing `has_vector_search()`, recursing through AND/OR/NOT/Group and checking Comparison/Between/In/Contains values).
- New `ValidationErrorKind::SubqueryNotExecutable` (code `V010`).
- `reject_subqueries()` runs at the top of `QueryValidator::validate_with_config`, covering the main SELECT, compound operands (UNION/INTERSECT/EXCEPT), and DML (UPDATE/DELETE/SELECT EDGES). `execute_query` validates before dispatching DML, so UPDATE is now caught too.

SET-clause subqueries (`UPDATE ... SET y = (SELECT ...)`) already error via `resolve_dml_value`; this closes the remaining silent WHERE path. Parsing is unchanged — the parser still produces `Value::Subquery`, so the existing parser/AST tests are untouched.

## Tests

Added to `validation_tests.rs`: scalar, BETWEEN, nested-in-AND, and UPDATE subquery cases are rejected with `V010`; a subquery-free query still validates. Full velesql lib suite (1172) + parser conformance + DML/update/delete tests (205) green; `clippy --pedantic` and `fmt` clean. No search-path code touched (no recall-gate impact).