### PR TITLE
docs(readme): correct REST search output shape and point-id type

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,9 @@ curl -X POST http://localhost:8080/collections/docs/points \
 
 curl -X POST http://localhost:8080/collections/docs/search \
   -d '{"vector": [0.9, 0.1, 0.0, 0.0], "top_k": 2}' -H "Content-Type: application/json"
-# [{"id":1,"score":0.995,"payload":{"title":"AI Intro","category":"tech"}}, ...]
+# {"results":[{"id":"1","score":0.994,"payload":{"title":"AI Intro","category":"tech"}}, ...]}
+# Results are wrapped in {"results":[...]} and point ids serialize as strings.
+# (The unified POST /query endpoint instead returns projected rows with integer ids.)
 ```
 
 </details>


### PR DESCRIPTION
## Why

The root README quickstart documented the `POST /collections/{name}/search` response as a bare array with integer ids:

```
# [{"id":1,"score":0.995,"payload":{...}}, ...]
```

The server actually returns a **wrapped** object and serializes point ids as **strings**. Verified live against `velesdb-server` 1.16.0:

```json
{"results":[{"id":"1","score":0.9938837,"payload":{"category":"tech","title":"AI Intro"}}, ...]}
```

(`SearchResultResponse.id` uses `serialize_id_as_string`; results are wrapped in `SearchResponse { results }`.)

## What

- Fix the README example to the real shape (`{"results":[...]}`, string ids).
- Add a one-line note that the unified `POST /query` endpoint instead returns projected rows with **integer** ids — documenting the existing cross-endpoint id-type difference (verified: `/query` returns `"id":1`).

Doc-only. The id-type *inconsistency* between `/search` (string) and `/query` (int) is a pre-existing API-design question (normalising it would be a breaking change); this PR documents the current behaviour rather than changing it.