### PR TITLE
fix(cli): remove no-op --schemaless flag from create-graph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+- **CLI**: removed the non-functional `--schemaless` flag from
+  `collection create-graph`. The flag was a no-op (graphs were always
+  created schemaless regardless of its value); drop it from any scripts —
+  `velesdb collection create-graph <path> <name>` is unchanged in behaviour.
+
 ## [1.16.0] — 2026-05-29
 
 ### Summary

--- a/crates/velesdb-cli/README.md
+++ b/crates/velesdb-cli/README.md
@@ -248,7 +248,7 @@ velesdb collection create ./data my_vectors \
   --storage full
 
 # Create a graph collection
-velesdb collection create-graph ./data my_graph --schemaless
+velesdb collection create-graph ./data my_graph
 
 # Create a metadata-only collection (no vectors, no graph -- structured payloads only)
 velesdb collection create-metadata ./data my_metadata

--- a/crates/velesdb-cli/src/commands.rs
+++ b/crates/velesdb-cli/src/commands.rs
@@ -117,10 +117,6 @@ pub enum CollectionCommands {
 
         /// Collection name
         name: String,
-
-        /// Create with schemaless mode (any node/edge types accepted)
-        #[arg(long, default_value = "true")]
-        schemaless: bool,
     },
 
     /// Create a metadata-only collection (no vectors)

--- a/crates/velesdb-cli/src/handlers/collections.rs
+++ b/crates/velesdb-cli/src/handlers/collections.rs
@@ -31,21 +31,15 @@ pub fn handle_create_vector_collection(
 }
 
 /// Handles the `create-graph-collection` subcommand.
-pub fn handle_create_graph_collection(path: &Path, name: &str, schemaless: bool) -> Result<()> {
+pub fn handle_create_graph_collection(path: &Path, name: &str) -> Result<()> {
     let db = velesdb_core::Database::open(path)?;
-    let schema = if schemaless {
-        velesdb_core::GraphSchema::schemaless()
-    } else {
-        // Reason: Strict schema from file is planned for future; default to schemaless.
-        velesdb_core::GraphSchema::schemaless()
-    };
+    let schema = velesdb_core::GraphSchema::schemaless();
     db.create_graph_collection(name, schema)?;
 
     println!(
-        "{} Graph collection '{}' created (schemaless: {})",
+        "{} Graph collection '{}' created (schemaless)",
         "\u{2705}".green(),
         name.cyan(),
-        schemaless,
     );
     Ok(())
 }

--- a/crates/velesdb-cli/src/main.rs
+++ b/crates/velesdb-cli/src/main.rs
@@ -123,11 +123,9 @@ fn dispatch_collection(action: CollectionCommands) -> anyhow::Result<()> {
             metric,
             storage,
         } => handlers::handle_create_vector_collection(&path, &name, dimension, metric, storage),
-        CollectionCommands::CreateGraph {
-            path,
-            name,
-            schemaless,
-        } => handlers::handle_create_graph_collection(&path, &name, schemaless),
+        CollectionCommands::CreateGraph { path, name } => {
+            handlers::handle_create_graph_collection(&path, &name)
+        }
         CollectionCommands::CreateMetadata { path, name } => {
             handlers::handle_create_metadata_collection(&path, &name)
         }

--- a/crates/velesdb-cli/tests/phase3_commands_tests.rs
+++ b/crates/velesdb-cli/tests/phase3_commands_tests.rs
@@ -201,7 +201,8 @@ fn test_create_graph_collection_help() {
         .arg("--help")
         .assert()
         .success()
-        .stdout(predicate::str::contains("schemaless"));
+        // The removed `--schemaless` flag must not reappear in the help output.
+        .stdout(predicate::str::contains("schemaless").not());
 }
 
 // =============================================================================


### PR DESCRIPTION
## What

Removes the `--schemaless` flag from `velesdb collection create-graph`. The flag was a **no-op**: both branches of its `if/else` called `GraphSchema::schemaless()`, it defaulted to `true`, and could not be turned off (strict schema is not supported by the core). It only created false affordance.

## Changes
- Drop the `schemaless` field from the `CreateGraph` command variant and its handler; the handler now just `let schema = GraphSchema::schemaless();`.
- Update the `main.rs` dispatch arm and the success message.
- `crates/velesdb-cli/README.md`: example is now `velesdb collection create-graph <path> <name>`.
- Update the help-text test assertion.
- CHANGELOG `### Removed` entry.

## Behaviour
No behaviour change — graphs were always created schemaless and still are. Scripts passing `--schemaless` will now error and should drop the flag (noted in CHANGELOG).

## Verification
`cargo fmt --check`, `cargo clippy -p velesdb-cli --all-targets -- -D warnings -D clippy::pedantic`, full `cargo test -p velesdb-cli` (all pass), and `collection create-graph --help` confirm the flag is gone and the command works.