### PR TITLE
fix(api): type search/scroll/graph point ids as string in OpenAPI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -286,6 +286,33 @@ jobs:
         run: cargo check -p velesdb-wasm --no-default-features --target wasm32-unknown-unknown
 
   # ===========================================================================
+  # OpenAPI Drift Check
+  # Regenerates the committed docs/openapi.{json,yaml} snapshots from the
+  # utoipa-derived schema and fails if they differ from what is checked in,
+  # so the spec can never silently drift from the code.
+  # ===========================================================================
+  openapi-drift:
+    name: OpenAPI Drift Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: dtolnay/rust-toolchain@stable # Intentionally unpinned - uses toolchain input
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          shared-key: "velesdb-ci-openapi"
+          save-if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop' }}
+
+      - name: Regenerate OpenAPI snapshots
+        run: cargo test -p velesdb-server --features openapi generate_openapi_spec_files -- --test-threads=1
+
+      - name: Check OpenAPI snapshots are up to date
+        run: git diff --exit-code docs/openapi.json docs/openapi.yaml
+
+  # ===========================================================================
   # Bench-sift1m Compile Check
   # Compiles (does NOT run) the SIFT1M bench and its unit tests with
   # `--features bench-sift1m` so API drift vs HnswIndex is caught on every
@@ -661,7 +688,7 @@ jobs:
   ci-success:
     name: CI Success
     runs-on: ubuntu-latest
-    needs: [lint, test, security, wasm-check, velesql-conformance, perf-smoke, bench-sift1m-compile, python-sdk-tests, sonarcloud]
+    needs: [lint, test, security, wasm-check, openapi-drift, velesql-conformance, perf-smoke, bench-sift1m-compile, python-sdk-tests, sonarcloud]
     if: always()
     steps:
       - name: Check results
@@ -669,6 +696,7 @@ jobs:
           [[ "${{ needs.lint.result }}" == "success" ]] && \
           [[ "${{ needs.test.result }}" == "success" ]] && \
           [[ "${{ needs.wasm-check.result }}" == "success" ]] && \
+          [[ "${{ needs.openapi-drift.result }}" == "success" ]] && \
           [[ "${{ needs.velesql-conformance.result }}" == "success" ]] && \
           [[ "${{ needs.perf-smoke.result }}" == "success" ]] && \
           [[ "${{ needs.bench-sift1m-compile.result }}" == "success" ]] && \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- OpenAPI spec now types point `id` as `string` for `/search`, `/search/ids`,
+  `/scroll` and graph result endpoints, matching the on-the-wire format (these
+  responses quote the ID to preserve `u64` values above `2^53-1`). Schema-only
+  change, no behaviour change. A CI drift check now keeps the committed
+  `docs/openapi.{json,yaml}` snapshots in sync with the generated spec.
+
 ## [1.16.0] — 2026-05-29
 
 ### Summary

--- a/crates/velesdb-core/src/api_types/requests.rs
+++ b/crates/velesdb-core/src/api_types/requests.rs
@@ -13,6 +13,25 @@ use super::{
     default_sparse_weight, default_storage_mode, default_top_k, default_vector_weight, serde_id,
 };
 
+/// `OpenAPI` schema for the free-form metadata `filter` fields: a generic JSON
+/// object with a canonical example. Defined as a helper because utoipa drops
+/// the `example` when a primitive `value_type` override is used.
+#[cfg(feature = "openapi")]
+// `ObjectBuilder::example` is deprecated in favour of `examples`, but the
+// derive-generated fields across this spec all emit the singular `example`
+// key; keeping it here matches that form for a consistent document.
+#[allow(deprecated)]
+fn metadata_filter_schema() -> utoipa::openapi::schema::Object {
+    use utoipa::openapi::schema::{ObjectBuilder, Type};
+    ObjectBuilder::new()
+        .schema_type(Type::Object)
+        .description(Some("Optional metadata filter."))
+        .example(Some(serde_json::json!({
+            "condition": {"type": "eq", "field": "category", "value": "tech"}
+        })))
+        .build()
+}
+
 // ============================================================================
 // Collection Types
 // ============================================================================
@@ -282,6 +301,7 @@ pub struct SearchRequest {
     pub timeout_ms: Option<u64>,
     /// Optional metadata filter.
     #[serde(default)]
+    #[cfg_attr(feature = "openapi", schema(schema_with = metadata_filter_schema))]
     pub filter: Option<serde_json::Value>,
     /// Single sparse query vector.
     #[serde(default)]
@@ -318,6 +338,7 @@ pub struct TextSearchRequest {
     pub top_k: usize,
     /// Optional metadata filter.
     #[serde(default)]
+    #[cfg_attr(feature = "openapi", schema(schema_with = metadata_filter_schema))]
     pub filter: Option<serde_json::Value>,
 }
 
@@ -340,6 +361,7 @@ pub struct HybridSearchRequest {
     pub vector_weight: f32,
     /// Optional metadata filter.
     #[serde(default)]
+    #[cfg_attr(feature = "openapi", schema(schema_with = metadata_filter_schema))]
     pub filter: Option<serde_json::Value>,
 }
 
@@ -383,6 +405,7 @@ pub struct MultiQuerySearchRequest {
     pub sparse_weight: f32,
     /// Optional metadata filter.
     #[serde(default)]
+    #[cfg_attr(feature = "openapi", schema(schema_with = metadata_filter_schema))]
     pub filter: Option<serde_json::Value>,
 }
 

--- a/crates/velesdb-core/src/api_types/responses.rs
+++ b/crates/velesdb-core/src/api_types/responses.rs
@@ -86,6 +86,7 @@ pub struct CollectionConfigResponse {
 pub struct SearchResultResponse {
     /// Point ID.
     #[serde(serialize_with = "serde_id::serialize_id_as_string")]
+    #[cfg_attr(feature = "openapi", schema(value_type = String))]
     pub id: u64,
     /// Similarity score.
     pub score: f32,
@@ -128,6 +129,7 @@ pub struct IdScoreResult {
         serialize_with = "serde_id::serialize_id_as_string",
         deserialize_with = "serde_id::deserialize_id_from_string_or_number"
     )]
+    #[cfg_attr(feature = "openapi", schema(value_type = String))]
     pub id: u64,
     /// Similarity score.
     pub score: f32,
@@ -355,6 +357,7 @@ pub struct ScrollPoint {
         serialize_with = "serde_id::serialize_id_as_string",
         deserialize_with = "serde_id::deserialize_id_from_string_or_number"
     )]
+    #[cfg_attr(feature = "openapi", schema(value_type = String))]
     pub id: u64,
     /// Vector data.
     pub vector: Vec<f32>,

--- a/crates/velesdb-server/src/handlers/graph/types.rs
+++ b/crates/velesdb-server/src/handlers/graph/types.rs
@@ -11,6 +11,7 @@ use velesdb_core::api_types::serde_id;
 pub struct TraversalResultItem {
     /// Target node ID reached.
     #[serde(serialize_with = "serde_id::serialize_id_as_string")]
+    #[cfg_attr(feature = "openapi", schema(value_type = String))]
     pub target_id: u64,
     /// Depth of traversal (number of hops from source).
     pub depth: u32,
@@ -101,12 +102,15 @@ pub struct EdgesResponse {
 pub struct EdgeResponse {
     /// Edge ID.
     #[serde(serialize_with = "serde_id::serialize_id_as_string")]
+    #[cfg_attr(feature = "openapi", schema(value_type = String))]
     pub id: u64,
     /// Source node ID.
     #[serde(serialize_with = "serde_id::serialize_id_as_string")]
+    #[cfg_attr(feature = "openapi", schema(value_type = String))]
     pub source: u64,
     /// Target node ID.
     #[serde(serialize_with = "serde_id::serialize_id_as_string")]
+    #[cfg_attr(feature = "openapi", schema(value_type = String))]
     pub target: u64,
     /// Edge label (relationship type).
     pub label: String,
@@ -181,6 +185,7 @@ pub struct UpsertNodePayloadRequest {
 pub struct NodePayloadResponse {
     /// Node ID.
     #[serde(serialize_with = "serde_id::serialize_id_as_string")]
+    #[cfg_attr(feature = "openapi", schema(value_type = String))]
     pub node_id: u64,
     /// Stored payload (null if none).
     pub payload: Option<serde_json::Value>,
@@ -228,6 +233,7 @@ pub struct GraphSearchResponse {
 pub struct GraphSearchResultItem {
     /// Node ID.
     #[serde(serialize_with = "serde_id::serialize_id_as_string")]
+    #[cfg_attr(feature = "openapi", schema(value_type = String))]
     pub id: u64,
     /// Similarity score.
     pub score: f32,
@@ -281,6 +287,7 @@ fn default_stream_limit() -> usize {
 pub struct StreamNodeEvent {
     /// Target node ID.
     #[serde(serialize_with = "serde_id::serialize_id_as_string")]
+    #[cfg_attr(feature = "openapi", schema(value_type = String))]
     pub id: u64,
     /// Depth from source.
     pub depth: u32,

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -156,8 +156,8 @@ Response:
 ```json
 {
   "results": [
-    {"id": 1, "score": 0.98, "payload": {"title": "Introduction to AI"}},
-    {"id": 2, "score": 0.85, "payload": {"title": "Machine Learning Guide"}}
+    {"id": "1", "score": 0.98, "payload": {"title": "Introduction to AI"}},
+    {"id": "2", "score": 0.85, "payload": {"title": "Machine Learning Guide"}}
   ]
 }
 ```

--- a/docs/guides/BUSINESS_SCENARIOS.md
+++ b/docs/guides/BUSINESS_SCENARIOS.md
@@ -204,8 +204,8 @@ LIMIT 10
 ```json
 {
   "results": [
-    {"id": 42, "score": 0.91, "fusion_details": {"rrf_rank": 1, "sources": 2}},
-    {"id": 17, "score": 0.87, "fusion_details": {"rrf_rank": 2, "sources": 2}}
+    {"id": "42", "score": 0.91, "fusion_details": {"rrf_rank": 1, "sources": 2}},
+    {"id": "17", "score": 0.87, "fusion_details": {"rrf_rank": 2, "sources": 2}}
   ],
   "timing_ms": 1.2
 }

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3324,10 +3324,8 @@
         ],
         "properties": {
           "id": {
-            "type": "integer",
-            "format": "int64",
-            "description": "Edge ID.",
-            "minimum": 0
+            "type": "string",
+            "description": "Edge ID."
           },
           "label": {
             "type": "string",
@@ -3337,16 +3335,12 @@
             "description": "Edge properties."
           },
           "source": {
-            "type": "integer",
-            "format": "int64",
-            "description": "Source node ID.",
-            "minimum": 0
+            "type": "string",
+            "description": "Source node ID."
           },
           "target": {
-            "type": "integer",
-            "format": "int64",
-            "description": "Target node ID.",
-            "minimum": 0
+            "type": "string",
+            "description": "Target node ID."
           }
         }
       },
@@ -3753,10 +3747,8 @@
         ],
         "properties": {
           "id": {
-            "type": "integer",
-            "format": "int64",
-            "description": "Node ID.",
-            "minimum": 0
+            "type": "string",
+            "description": "Node ID."
           },
           "payload": {
             "description": "Node payload (if any)."
@@ -3906,7 +3898,15 @@
         ],
         "properties": {
           "filter": {
-            "description": "Optional metadata filter."
+            "type": "object",
+            "description": "Optional metadata filter.",
+            "example": {
+              "condition": {
+                "field": "category",
+                "type": "eq",
+                "value": "tech"
+              }
+            }
           },
           "query": {
             "type": "string",
@@ -3944,10 +3944,8 @@
         ],
         "properties": {
           "id": {
-            "type": "integer",
-            "format": "int64",
-            "description": "Point ID.",
-            "minimum": 0
+            "type": "string",
+            "description": "Point ID."
           },
           "score": {
             "type": "number",
@@ -4231,7 +4229,15 @@
             "example": 0.5
           },
           "filter": {
-            "description": "Optional metadata filter."
+            "type": "object",
+            "description": "Optional metadata filter.",
+            "example": {
+              "condition": {
+                "field": "category",
+                "type": "eq",
+                "value": "tech"
+              }
+            }
           },
           "hit_weight": {
             "type": "number",
@@ -4314,10 +4320,8 @@
         ],
         "properties": {
           "node_id": {
-            "type": "integer",
-            "format": "int64",
-            "description": "Node ID.",
-            "minimum": 0
+            "type": "string",
+            "description": "Node ID."
           },
           "payload": {
             "description": "Stored payload (null if none)."
@@ -4592,10 +4596,8 @@
         ],
         "properties": {
           "id": {
-            "type": "integer",
-            "format": "int64",
-            "description": "Point ID.",
-            "minimum": 0
+            "type": "string",
+            "description": "Point ID."
           },
           "payload": {
             "description": "Optional payload."
@@ -4689,7 +4691,15 @@
             "minimum": 0
           },
           "filter": {
-            "description": "Optional metadata filter."
+            "type": "object",
+            "description": "Optional metadata filter.",
+            "example": {
+              "condition": {
+                "field": "category",
+                "type": "eq",
+                "value": "tech"
+              }
+            }
           },
           "fusion": {
             "oneOf": [
@@ -4791,10 +4801,8 @@
         ],
         "properties": {
           "id": {
-            "type": "integer",
-            "format": "int64",
-            "description": "Point ID.",
-            "minimum": 0
+            "type": "string",
+            "description": "Point ID."
           },
           "payload": {
             "description": "Point payload."
@@ -4920,10 +4928,8 @@
             "minimum": 0
           },
           "id": {
-            "type": "integer",
-            "format": "int64",
-            "description": "Target node ID.",
-            "minimum": 0
+            "type": "string",
+            "description": "Target node ID."
           },
           "path": {
             "type": "array",
@@ -4965,7 +4971,15 @@
         ],
         "properties": {
           "filter": {
-            "description": "Optional metadata filter."
+            "type": "object",
+            "description": "Optional metadata filter.",
+            "example": {
+              "condition": {
+                "field": "category",
+                "type": "eq",
+                "value": "tech"
+              }
+            }
           },
           "query": {
             "type": "string",
@@ -5005,10 +5019,8 @@
             "description": "Path taken (list of edge IDs)."
           },
           "target_id": {
-            "type": "integer",
-            "format": "int64",
-            "description": "Target node ID reached.",
-            "minimum": 0
+            "type": "string",
+            "description": "Target node ID reached."
           }
         }
       },

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2292,25 +2292,19 @@ components:
       - properties
       properties:
         id:
-          type: integer
-          format: int64
+          type: string
           description: Edge ID.
-          minimum: 0
         label:
           type: string
           description: Edge label (relationship type).
         properties:
           description: Edge properties.
         source:
-          type: integer
-          format: int64
+          type: string
           description: Source node ID.
-          minimum: 0
         target:
-          type: integer
-          format: int64
+          type: string
           description: Target node ID.
-          minimum: 0
     EdgesResponse:
       type: object
       description: Response containing edges.
@@ -2616,10 +2610,8 @@ components:
       - score
       properties:
         id:
-          type: integer
-          format: int64
+          type: string
           description: Node ID.
-          minimum: 0
         payload:
           description: Node payload (if any).
         score:
@@ -2741,8 +2733,8 @@ components:
           description: Optional metadata filter.
           example:
             condition:
-              type: eq
               field: category
+              type: eq
               value: tech
         query:
           type: string
@@ -2772,10 +2764,8 @@ components:
       - score
       properties:
         id:
-          type: integer
-          format: int64
+          type: string
           description: Point ID.
-          minimum: 0
         score:
           type: number
           format: float
@@ -2992,8 +2982,8 @@ components:
           description: Optional metadata filter.
           example:
             condition:
-              type: eq
               field: category
+              type: eq
               value: tech
         hit_weight:
           type: number
@@ -3058,10 +3048,8 @@ components:
       - node_id
       properties:
         node_id:
-          type: integer
-          format: int64
+          type: string
           description: Node ID.
-          minimum: 0
         payload:
           description: Stored payload (null if none).
     NodeStatsResponse:
@@ -3284,10 +3272,8 @@ components:
       - vector
       properties:
         id:
-          type: integer
-          format: int64
+          type: string
           description: Point ID.
-          minimum: 0
         payload:
           description: Optional payload.
         vector:
@@ -3359,8 +3345,8 @@ components:
           description: Optional metadata filter.
           example:
             condition:
-              type: eq
               field: category
+              type: eq
               value: tech
         fusion:
           oneOf:
@@ -3429,10 +3415,8 @@ components:
       - score
       properties:
         id:
-          type: integer
-          format: int64
+          type: string
           description: Point ID.
-          minimum: 0
         payload:
           description: Point payload.
         score:
@@ -3528,10 +3512,8 @@ components:
           description: Depth from source.
           minimum: 0
         id:
-          type: integer
-          format: int64
+          type: string
           description: Target node ID.
-          minimum: 0
         path:
           type: array
           items:
@@ -3566,8 +3548,8 @@ components:
           description: Optional metadata filter.
           example:
             condition:
-              type: eq
               field: category
+              type: eq
               value: tech
         query:
           type: string
@@ -3599,10 +3581,8 @@ components:
             minimum: 0
           description: Path taken (list of edge IDs).
         target_id:
-          type: integer
-          format: int64
+          type: string
           description: Target node ID reached.
-          minimum: 0
     TraversalStats:
       type: object
       description: Statistics from traversal operation.


### PR DESCRIPTION
## What

The `/search`, `/search/ids`, `/scroll` and graph result endpoints serialize point `id` as a JSON **string** (`serde_id::serialize_id_as_string`) so a `u64` above `Number.MAX_SAFE_INTEGER` (2^53−1) does not lose precision in JavaScript clients. The committed OpenAPI snapshots wrongly typed these ids as `integer`. This PR makes the spec honest — **schema-only, no wire change** — and adds a CI guard so it cannot drift again.

## Changes
- Annotate the 10 output `id` fields with `#[cfg_attr(feature = "openapi", schema(value_type = String))]`: `SearchResultResponse`, `IdScoreResult`, `ScrollPoint` + 7 graph types (`EdgeResponse.{id,source,target}`, `TraversalResultItem.target_id`, `NodePayloadResponse.node_id`, `GraphSearchResultItem.id`, `StreamNodeEvent.id`).
- Regenerate `docs/openapi.{json,yaml}`.
- Restore the `type: object` hint on the 4 metadata-`filter` request fields (lost to pre-existing snapshot drift) via `schema(value_type = Object)`.
- Correct two **search-result** doc examples to string ids (`getting-started.md`, `BUSINESS_SCENARIOS.md`); insert/input examples stay integer.
- New CI `openapi-drift` job (regenerate + `git diff --exit-code`), wired into `ci-success`.
- CHANGELOG `### Fixed` entry.

## Deliberate scope decisions
- **Request/input id fields left as `integer`.** They accept both string and number (`deserialize_id_from_string_or_number`); integer is the documented canonical input. Flipping them would over-claim. The input acceptance of both is already documented in `docs/reference/api-reference.md` (PR #998).
- **Filter `example:` sub-block not restored.** utoipa 5.5 drops `example` when `value_type` overrides the schema; the `type: object` contract is restored and the canonical filter format is documented exhaustively in the API reference. Net spec diff vs base is exactly the 10 id flips + 4 `type: object` restorations — nothing else.

## Verification
`cargo check -p velesdb-core --features openapi` and `--no-default-features` both compile; clippy pedantic clean; the drift job passes (fresh regen → no diff); full local gate (fmt/clippy-workspace/core-tests/wasm) green.