### PR TITLE
chore(docs): drop references to maintainer-local engineering-rule files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   created schemaless regardless of its value); drop it from any scripts —
   `velesdb collection create-graph <path> <name>` is unchanged in behaviour.
 
+### Changed
+- Public docs, tests, and SDK source comments no longer reference
+  maintainer-local engineering-rule files; they point to the public
+  `QUALITY_BAR.md` or describe the rule inline.
+
 ## [1.16.0] — 2026-05-29
 
 ### Summary

--- a/QUALITY_BAR.md
+++ b/QUALITY_BAR.md
@@ -53,7 +53,7 @@ A pull request that breaks any of these gates **cannot be merged**. There are no
 
 **When this triggers:** any change to `index/hnsw/`, `simd_native/`, `quantization/`, `fusion/`, or result-conversion code in Python bindings.
 
-**See also:** [`.claude/rules/recall-quality-gate.md`](.claude/rules/recall-quality-gate.md) (internal rule), [`docs/reference/KNOWN_LIMITATIONS.md`](docs/reference/KNOWN_LIMITATIONS.md).
+**See also:** [`docs/reference/KNOWN_LIMITATIONS.md`](docs/reference/KNOWN_LIMITATIONS.md).
 
 ---
 
@@ -80,8 +80,6 @@ A pull request that breaks any of these gates **cannot be merged**. There are no
 
 These are **not the same number** as the canonical 450 µs. The README explicitly disambiguates them since v1.13.3.
 
-**See also:** [`.claude/rules/perf-phase-gate.md`](.claude/rules/perf-phase-gate.md) (internal rule).
-
 ---
 
 ## Gate 3 — No `.unwrap()` in production code
@@ -105,8 +103,6 @@ These are **not the same number** as the canonical 450 µs. The README explicitl
 | `.unwrap()` | `.unwrap_or_else(\|\| ...)` | Default needs computation |
 
 **Lock acquisition:** we use `parking_lot::RwLock` / `Mutex` exclusively. These never poison, so `.read()` / `.write()` / `.lock()` return guards directly with no `.unwrap()`.
-
-**See also:** [`.claude/rules/rust-safety.md`](.claude/rules/rust-safety.md) (internal rule).
 
 ---
 
@@ -137,8 +133,6 @@ These are **not the same number** as the canonical 450 µs. The README explicitl
 - **Codacy Cloud (authoritative, blocking):** any PR introducing a function with CC > 8 fails the Codacy gate, blocks merge.
 - **Local CLI (lizard, threshold > 15):** advisory, used during development.
 - **Refactoring pattern:** Extract Function (Fowler #106) is the primary tool — if a fragment can be named, extract it.
-
-**See also:** [`.claude/rules/code-quality.md`](.claude/rules/code-quality.md), [`.claude/rules/rust-clean-code.md`](.claude/rules/rust-clean-code.md).
 
 ---
 
@@ -178,8 +172,6 @@ These are tracked but do not block release because they are SIMD intrinsics bloc
 - **Codacy Cloud:** server-side check, blocking.
 
 **Status:** enforced by Codacy Cloud on every PR; falling below the threshold blocks merge.
-
-**See also:** [`.claude/rules/no-duplication.md`](.claude/rules/no-duplication.md).
 
 ---
 
@@ -237,4 +229,4 @@ The quality bar is intentionally hard to lower. To change a threshold:
 - [`ROADMAP.md`](ROADMAP.md) — what we are building, when
 - [`CONTRIBUTING.md`](CONTRIBUTING.md) — how to contribute under these gates
 - [`docs/reference/KNOWN_LIMITATIONS.md`](docs/reference/KNOWN_LIMITATIONS.md) — current technical limitations
-- [`.claude/rules/`](.claude/rules/) — internal rules backing these gates (kept local; this public file is the externally-visible summary)
+- Detailed engineering rules backing these gates are kept maintainer-local; this public file is their externally-visible summary.

--- a/benchmarks/phase_results/phase_4_manifest.md
+++ b/benchmarks/phase_results/phase_4_manifest.md
@@ -8,8 +8,7 @@ the evidence behind the CHANGELOG claims without having to trust headline
 numbers.
 
 Future phases must use `python scripts/perf_phase_gate.py capture
---phase <ID> --stage before` before any code change, per
-[`.claude/rules/perf-phase-gate.md`](../../.claude/rules/perf-phase-gate.md).
+--phase <ID> --stage before` before any code change.
 
 ---
 
@@ -79,8 +78,7 @@ graph traversal (arXiv:2505.07621).
 - Bench: `crates/velesdb-core/benches/hnsw_benchmark.rs` and
   `prefetch_tuning_benchmark.rs` (prefetch stride tuning).
 - Recall preserved via the standing CI gate
-  `cargo test -p velesdb-core test_recall` (≥ 0.95 @ 10K,
-  see `.claude/rules/recall-quality-gate.md`).
+  `cargo test -p velesdb-core test_recall` (≥ 0.95 @ 10K).
 
 ---
 

--- a/crates/velesdb-core/tests/auto_reindex_bdd.rs
+++ b/crates/velesdb-core/tests/auto_reindex_bdd.rs
@@ -8,7 +8,7 @@
 //! `upsert_bulk_inner` that consults the attached manager after every
 //! successful batch.
 //!
-//! Test categories (per `.claude/rules/bdd-testing.md`):
+//! Test categories:
 //! - Nominal (≥ 60%): attach → upsert → query divergence
 //! - Edge (≈ 20%): detach / re-attach / disabled config / cooldown
 //! - Negative (≥ 20%): no attachment = no state leak, divergence without

--- a/crates/velesdb-core/tests/bdd/match_graph_first.rs
+++ b/crates/velesdb-core/tests/bdd/match_graph_first.rs
@@ -22,7 +22,7 @@
 //!    `Database::execute_query` and verify the returned node bindings match
 //!    what a correct GraphFirst execution must yield.
 //!
-//! Coverage breakdown (per `.claude/rules/bdd-testing.md`):
+//! Coverage breakdown:
 //!
 //! | Category | Count | Share |
 //! |----------|-------|-------|

--- a/crates/velesdb-python/tests/test_database_gil.py
+++ b/crates/velesdb-python/tests/test_database_gil.py
@@ -22,7 +22,7 @@ against the regression that would re-introduce the GIL-held
 behaviour (symptom: deadlock) or a borrow-checker refactor that
 breaks a method's contract (symptom: errors captured in the thread).
 
-Categories covered (per `.claude/rules/bdd-testing.md`):
+Categories covered:
 
 * Nominal:
     - `Database(path)` opens cleanly even under the new GIL-release

--- a/crates/velesdb-python/tests/test_options.py
+++ b/crates/velesdb-python/tests/test_options.py
@@ -7,7 +7,7 @@ Covers:
 - VelesConfigOptions wrapping LimitsOptions
 - Negative paths: invalid values, wrong types, missing required kwargs
 
-Test categories follow `.claude/rules/bdd-testing.md`:
+Test categories:
 - Nominal (≥ 60%): happy-path construction + create_collection flow
 - Edge (≈ 20%): None fields, boundary values, defaults pass-through
 - Negative (≥ 20%): invalid types, breaking-change guardrails

--- a/crates/velesdb-python/tests/test_recall_gate.py
+++ b/crates/velesdb-python/tests/test_recall_gate.py
@@ -2,7 +2,7 @@
 Recall quality gate — ensures search accuracy doesn't regress.
 
 Threshold: recall@10 >= 0.95 at 10K vectors for all distance metrics.
-See .claude/rules/recall-quality-gate.md for rationale.
+See QUALITY_BAR.md (Gate 1) for rationale.
 
 Run with: pytest tests/test_recall_gate.py -v
 Run slow tests only: pytest tests/test_recall_gate.py -m slow -v

--- a/crates/velesdb-python/tests/test_scroll.py
+++ b/crates/velesdb-python/tests/test_scroll.py
@@ -6,7 +6,7 @@ Wave 3 wraps the core call in `py.allow_threads(...)` so that two
 Python threads scrolling two different collections can progress in
 parallel instead of being serialised through the GIL.
 
-Categories covered (per `.claude/rules/bdd-testing.md`):
+Categories covered:
 
 * Nominal (happy path):
     - Single-page scroll yields the full dataset in one batch.

--- a/crates/velesdb-server/tests/admin_endpoints_bdd_tests.rs
+++ b/crates/velesdb-server/tests/admin_endpoints_bdd_tests.rs
@@ -6,7 +6,7 @@
 //! - `POST /collections/{name}/vacuum`         — HNSW index vacuum
 //! - `POST /collections/{name}/compact`        — storage compaction
 //!
-//! Coverage per `.claude/rules/bdd-testing.md`:
+//! Coverage:
 //! - Nominal (~60%): happy paths, end-to-end behaviour observable from
 //!   the REST surface.
 //! - Edge (~20%): boundary conditions (empty payload, max-batch size,

--- a/report/audit-2026q2/02-complexity.md
+++ b/report/audit-2026q2/02-complexity.md
@@ -283,8 +283,8 @@ All 4 functions are **Extract Function** candidates. Prioritize `pipeline.rs:run
 
 ## Related Documentation
 
-- [code-quality.md](./.claude/rules/code-quality.md) — CC ≤ 8, NLOC limits
-- [rust-clean-code.md](./.claude/rules/rust-clean-code.md) — Extract Function, Strategy, Repository patterns
+- [QUALITY_BAR.md](../../QUALITY_BAR.md) — CC ≤ 8, NLOC limits
+- Refactoring patterns — Extract Function, Strategy, Repository
 - [CONCURRENCY_MODEL.md](./docs/CONCURRENCY_MODEL.md) — Lock ordering (relevant to config + pipeline synchronization)
 - [TDD_RULES.md](./docs/contributing/TDD_RULES.md) — Test strategy for refactoring
 

--- a/sdks/typescript/src/backends/wasm-node-loader.ts
+++ b/sdks/typescript/src/backends/wasm-node-loader.ts
@@ -6,7 +6,7 @@
  * `default()` because Node's stdlib `fetch` has no `file://` scheme handler
  * (the import explodes with "not implemented... yet..."). This module
  * isolates the Node detection + bytes-loader so `wasm.ts` stays under the
- * 500 NLOC limit (.claude/rules/code-quality.md).
+ * 500 NLOC limit (see QUALITY_BAR.md).
  *
  * The functions here are referenced from `wasm.ts#init()` exactly when
  * {@link isNodeRuntime} returns true; in browser bundles the readdir/fs/

--- a/sdks/typescript/src/backends/wasm.ts
+++ b/sdks/typescript/src/backends/wasm.ts
@@ -442,6 +442,6 @@ export class WasmBackend implements IVelesDBBackend {
 }
 
 // Node-only init helpers (`isNodeRuntime`, `loadWasmBytesNode`) live in
-// `./wasm-node-loader` so this file stays under the .claude/rules
-// code-quality.md 500-NLOC ceiling. Browser bundles never reach the
+// `./wasm-node-loader` so this file stays under the project's
+// 500-NLOC code-quality ceiling. Browser bundles never reach the
 // loader because `init()` gates the import on `isNodeRuntime()`.


### PR DESCRIPTION
## What

Public files (docs, tests, SDK) linked to `.claude/rules/*.md` engineering-rule files that are gitignored and therefore unreachable by anyone reading the repo. This removes those dangling internal-only references.

## Changes (13 files, comments/docs only — no code or behaviour change)
- **`QUALITY_BAR.md`**: dropped the per-gate `See also: internal rule` footers (the file itself is the public summary of those rules); kept the public `KNOWN_LIMITATIONS.md` link; reworded the closing bullet.
- **`report/audit-2026q2/02-complexity.md`**: repointed the code-quality link to the public `QUALITY_BAR.md`; made the refactoring-patterns entry plain text.
- **`benchmarks/phase_results/phase_4_manifest.md`**: removed two trailing internal-rule pointers.
- **TS SDK** (`wasm.ts`, `wasm-node-loader.ts`): comments now reference the public NLOC limit / `QUALITY_BAR.md`.
- **7 test files** (Rust + Python BDD/recall): docstring/comment headers no longer cite the internal BDD/recall rule path; the category breakdowns themselves are unchanged. `test_recall_gate.py` points to `QUALITY_BAR.md` (Gate 1).
- CHANGELOG `### Changed` entry.

## Verification
- `cargo fmt --all --check` clean.
- Comments/docstrings only → zero functional impact (no Rust/TS/Python code paths touched).
- Repo scan: no remaining reference to the internal rule files in public docs/tests/SDK.

## Note
The string `claude` deliberately remains only in the ignore/exclusion configs (`.gitignore`, `.codacy*`, `.semgrepignore`, `sonar-project.properties`) — those are the mechanism that keeps the maintainer-local directory out of the repository, so removing them would be counterproductive. The CLA signatures and PR-governance branch pattern are tracked separately.