### PR TITLE
fix(api): model request id fields as oneOf<integer,string> in OpenAPI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   responses quote the ID to preserve `u64` values above `2^53-1`). Schema-only
   change, no behaviour change. A CI drift check now keeps the committed
   `docs/openapi.{json,yaml}` snapshots in sync with the generated spec.
+- OpenAPI spec now models request body `id` fields as `oneOf` integer or
+  string, matching the input contract (both forms are accepted; string avoids
+  JavaScript precision loss above `2^53-1`). Schema-only, no behaviour change.
 
 ### Removed
 - **CLI**: removed the non-functional `--schemaless` flag from

--- a/crates/velesdb-core/src/api_types/requests.rs
+++ b/crates/velesdb-core/src/api_types/requests.rs
@@ -246,6 +246,7 @@ pub struct UpsertPointsRequest {
 pub struct PointRequest {
     /// Point ID.
     #[serde(deserialize_with = "serde_id::deserialize_id_from_string_or_number")]
+    #[cfg_attr(feature = "openapi", schema(schema_with = serde_id::id_input_schema))]
     pub id: u64,
     /// Vector data.
     pub vector: Vec<f32>,
@@ -265,6 +266,7 @@ pub struct PointRequest {
 pub struct StreamInsertRequest {
     /// Point ID.
     #[serde(deserialize_with = "serde_id::deserialize_id_from_string_or_number")]
+    #[cfg_attr(feature = "openapi", schema(schema_with = serde_id::id_input_schema))]
     pub id: u64,
     /// Dense vector data.
     pub vector: Vec<f32>,

--- a/crates/velesdb-core/src/api_types/serde_id.rs
+++ b/crates/velesdb-core/src/api_types/serde_id.rs
@@ -54,6 +54,30 @@ pub fn deserialize_id_from_string_or_number<'de, D: Deserializer<'de>>(
     deserializer.deserialize_any(IdVisitor)
 }
 
+/// `OpenAPI` schema for input `id` fields that accept either a JSON integer
+/// (native form) or a string. Mirrors [`deserialize_id_from_string_or_number`]:
+/// clients may send `12345` or `"12345"`, the latter being precision-safe for
+/// `u64` values above 2^53-1.
+///
+/// Apply with
+/// `#[cfg_attr(feature = "openapi", schema(schema_with = serde_id::id_input_schema))]`.
+#[cfg(feature = "openapi")]
+#[must_use]
+pub fn id_input_schema() -> utoipa::openapi::schema::OneOfBuilder {
+    use utoipa::openapi::schema::{KnownFormat, ObjectBuilder, OneOfBuilder, SchemaFormat, Type};
+    OneOfBuilder::new()
+        .item(
+            ObjectBuilder::new()
+                .schema_type(Type::Integer)
+                .format(Some(SchemaFormat::KnownFormat(KnownFormat::Int64))),
+        )
+        .item(ObjectBuilder::new().schema_type(Type::String))
+        .description(Some(
+            "Point ID. Accepts a JSON integer (native form) or a string; use a \
+             string for u64 values above 2^53-1 to avoid JavaScript precision loss.",
+        ))
+}
+
 /// Serializes an `Option<u64>` as a JSON string when `Some`, or `null` when `None`.
 ///
 /// Emits `"12345"` for `Some(12345)` and `null` for `None`.

--- a/crates/velesdb-server/src/handlers/graph/types.rs
+++ b/crates/velesdb-server/src/handlers/graph/types.rs
@@ -32,6 +32,7 @@ pub struct EdgeQueryParams {
 pub struct TraverseRequest {
     /// Source node ID to start traversal from.
     #[serde(deserialize_with = "serde_id::deserialize_id_from_string_or_number")]
+    #[cfg_attr(feature = "openapi", schema(schema_with = serde_id::id_input_schema))]
     pub source: u64,
     /// Traversal strategy: "bfs" or "dfs".
     #[serde(default = "default_strategy")]
@@ -123,12 +124,15 @@ pub struct EdgeResponse {
 pub struct AddEdgeRequest {
     /// Edge ID.
     #[serde(deserialize_with = "serde_id::deserialize_id_from_string_or_number")]
+    #[cfg_attr(feature = "openapi", schema(schema_with = serde_id::id_input_schema))]
     pub id: u64,
     /// Source node ID.
     #[serde(deserialize_with = "serde_id::deserialize_id_from_string_or_number")]
+    #[cfg_attr(feature = "openapi", schema(schema_with = serde_id::id_input_schema))]
     pub source: u64,
     /// Target node ID.
     #[serde(deserialize_with = "serde_id::deserialize_id_from_string_or_number")]
+    #[cfg_attr(feature = "openapi", schema(schema_with = serde_id::id_input_schema))]
     pub target: u64,
     /// Edge label (relationship type).
     pub label: String,

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -2807,10 +2807,16 @@
         ],
         "properties": {
           "id": {
-            "type": "integer",
-            "format": "int64",
-            "description": "Edge ID.",
-            "minimum": 0
+            "oneOf": [
+              {
+                "type": "integer",
+                "format": "int64"
+              },
+              {
+                "type": "string"
+              }
+            ],
+            "description": "Point ID. Accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss."
           },
           "label": {
             "type": "string",
@@ -2820,16 +2826,28 @@
             "description": "Edge properties."
           },
           "source": {
-            "type": "integer",
-            "format": "int64",
-            "description": "Source node ID.",
-            "minimum": 0
+            "oneOf": [
+              {
+                "type": "integer",
+                "format": "int64"
+              },
+              {
+                "type": "string"
+              }
+            ],
+            "description": "Point ID. Accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss."
           },
           "target": {
-            "type": "integer",
-            "format": "int64",
-            "description": "Target node ID.",
-            "minimum": 0
+            "oneOf": [
+              {
+                "type": "integer",
+                "format": "int64"
+              },
+              {
+                "type": "string"
+              }
+            ],
+            "description": "Point ID. Accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss."
           }
         }
       },
@@ -4418,10 +4436,16 @@
         ],
         "properties": {
           "id": {
-            "type": "integer",
-            "format": "int64",
-            "description": "Point ID.",
-            "minimum": 0
+            "oneOf": [
+              {
+                "type": "integer",
+                "format": "int64"
+              },
+              {
+                "type": "string"
+              }
+            ],
+            "description": "Point ID. Accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss."
           },
           "payload": {
             "description": "Optional payload."
@@ -4894,10 +4918,16 @@
         ],
         "properties": {
           "id": {
-            "type": "integer",
-            "format": "int64",
-            "description": "Point ID.",
-            "minimum": 0
+            "oneOf": [
+              {
+                "type": "integer",
+                "format": "int64"
+              },
+              {
+                "type": "string"
+              }
+            ],
+            "description": "Point ID. Accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss."
           },
           "payload": {
             "description": "Optional JSON payload (metadata)."
@@ -5071,10 +5101,16 @@
             "description": "Filter by relationship types (empty = all types)."
           },
           "source": {
-            "type": "integer",
-            "format": "int64",
-            "description": "Source node ID to start traversal from.",
-            "minimum": 0
+            "oneOf": [
+              {
+                "type": "integer",
+                "format": "int64"
+              },
+              {
+                "type": "string"
+              }
+            ],
+            "description": "Point ID. Accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss."
           },
           "strategy": {
             "type": "string",

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1849,25 +1849,28 @@ components:
       - label
       properties:
         id:
-          type: integer
-          format: int64
-          description: Edge ID.
-          minimum: 0
+          oneOf:
+          - type: integer
+            format: int64
+          - type: string
+          description: Point ID. Accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss.
         label:
           type: string
           description: Edge label (relationship type).
         properties:
           description: Edge properties.
         source:
-          type: integer
-          format: int64
-          description: Source node ID.
-          minimum: 0
+          oneOf:
+          - type: integer
+            format: int64
+          - type: string
+          description: Point ID. Accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss.
         target:
-          type: integer
-          format: int64
-          description: Target node ID.
-          minimum: 0
+          oneOf:
+          - type: integer
+            format: int64
+          - type: string
+          description: Point ID. Accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss.
     AggregationResponse:
       type: object
       description: Response from `VelesQL` aggregation query execution.
@@ -3137,10 +3140,11 @@ components:
       - vector
       properties:
         id:
-          type: integer
-          format: int64
-          description: Point ID.
-          minimum: 0
+          oneOf:
+          - type: integer
+            format: int64
+          - type: string
+          description: Point ID. Accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss.
         payload:
           description: Optional payload.
         sparse_vector:
@@ -3486,10 +3490,11 @@ components:
       - vector
       properties:
         id:
-          type: integer
-          format: int64
-          description: Point ID.
-          minimum: 0
+          oneOf:
+          - type: integer
+            format: int64
+          - type: string
+          description: Point ID. Accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss.
         payload:
           description: Optional JSON payload (metadata).
         vector:
@@ -3620,10 +3625,11 @@ components:
             type: string
           description: Filter by relationship types (empty = all types).
         source:
-          type: integer
-          format: int64
-          description: Source node ID to start traversal from.
-          minimum: 0
+          oneOf:
+          - type: integer
+            format: int64
+          - type: string
+          description: Point ID. Accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss.
         strategy:
           type: string
           description: 'Traversal strategy: "bfs" or "dfs".'


### PR DESCRIPTION
## What
Request body `id` fields are deserialized from **either** a JSON integer or a string (`serde_id::deserialize_id_from_string_or_number`), but the OpenAPI schema declared them integer-only. This makes the spec honest. **Schema-only, no wire/behaviour change.**

## Changes
- New shared helper `serde_id::id_input_schema()` → `oneOf: [{integer, int64}, {string}]` with a descriptive note.
- Applied via `#[cfg_attr(feature = "openapi", schema(schema_with = serde_id::id_input_schema))]` to the 6 request **body** id fields: `PointRequest.id`, `StreamInsertRequest.id`, `TraverseRequest.source`, `AddEdgeRequest.{id,source,target}`.
- The `StreamTraverseParams.start_node` **query param** (`IntoParams`) keeps its native integer type — a oneOf is not meaningful for a URL parameter.
- Regenerated `docs/openapi.{json,yaml}`; CHANGELOG entry.

## Verification
- `cargo clippy -p velesdb-core -p velesdb-server --features persistence,openapi -- -D warnings -D clippy::pedantic` clean.
- `cargo check -p velesdb-core --no-default-features` compiles (helper is `#[cfg(feature = "openapi")]`).
- `cargo fmt --all --check` clean.
- OpenAPI drift check passes (regenerate → no diff); the 6 fields render as oneOf.