### PR TITLE
docs(changelog): correct stale roadmap (drop shipped + Enterprise items)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4755,15 +4755,20 @@ This change ensures VelesDB remains freely available while protecting against cl
 
 ---
 
-## [Unreleased]
+## Roadmap
 
-### Planned
-- LlamaIndex integration (WIS-66)
-- Prometheus /metrics endpoint (WIS-63)
-- Product Quantization (WIS-65)
-- Multi-tenancy (WIS-68)
-- API Authentication (WIS-69)
-- Starlight documentation site
+Community roadmap and timelines live in [`ROADMAP.md`](ROADMAP.md). LlamaIndex
+integration, the Prometheus `/metrics` endpoint, Product Quantization, and
+API-key authentication previously listed here have all shipped. The one item
+still genuinely pending is:
+
+- Unified documentation site (Astro/Starlight) — the reference docs currently
+  ship as Markdown under `docs/`.
+
+> Distributed replication, lock-free concurrent-WAL writes, and production
+> RBAC / multi-tenant isolation are **VelesDB Enterprise** features (a separate
+> product), not part of the open-source Community roadmap — see the
+> "Scope & boundaries" section of the README.
 
 [Unreleased]: https://github.com/cyberlife-coder/VelesDB/compare/v1.16.0...HEAD
 [1.16.0]: https://github.com/cyberlife-coder/VelesDB/releases/tag/v1.16.0


### PR DESCRIPTION
The CHANGELOG footer roadmap was stale/misleading:
- **4 already-shipped features listed as "Planned"**: LlamaIndex (`integrations/llamaindex/`), Prometheus `/metrics` (`handlers/metrics.rs`), Product Quantization (`quantization/`: pq/opq/rabitq), API-key auth (`auth.rs`, wired in `main.rs`).
- **Enterprise item leaked** into the public Community roadmap (multi-tenancy) — belongs to the separate `velesdb-private` product (README "Scope & boundaries" already frames it).
- Internal `WIS-xx` tracker IDs exposed in a forward-looking public section.
- **Duplicate `## [Unreleased]` heading**.

### Fix
- Replaced with a concise pointer to `ROADMAP.md`; kept the one genuinely-pending Community item (Astro/Starlight docs site); clear Enterprise framing without internal IDs; removed the duplicate heading.

Doc-only. Historical release entries keep their original IDs (history not rewritten).