### PR TITLE
chore: remove internal WIS-xx tracker IDs from the public repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4446,12 +4446,12 @@ This change ensures VelesDB remains freely available while protecting against cl
   - Support for Python lists and NumPy arrays
   - Automatic `float64` → `float32` conversion
 
-- **NumPy Integration** (WIS-23):
+- **NumPy Integration**:
   - Direct support for `numpy.ndarray` in `upsert()` and `search()`
   - Zero-copy when possible for performance
   - Mixed Python list / NumPy array in same batch
 
-#### VelesQL CLI/REPL (WIS-19)
+#### VelesQL CLI/REPL
 - **Interactive REPL**: `velesdb-cli repl`
   - Syntax highlighting
   - Command history
@@ -4459,14 +4459,14 @@ This change ensures VelesDB remains freely available while protecting against cl
 - **Single Query Mode**: `velesdb-cli query "SELECT ..."`
 - **Database Info**: `velesdb-cli info ./data`
 
-#### LangChain Integration (WIS-30)
+#### LangChain Integration
 - **`langchain-velesdb` package**: LangChain VectorStore adapter
   - `VelesDBVectorStore` class
   - `add_texts()`, `similarity_search()`, `delete()`
   - `as_retriever()` for RAG pipelines
   - Full test suite (9 tests)
 
-#### Additional Distance Metrics (WIS-33)
+#### Additional Distance Metrics
 - **Hamming Distance**: For binary vectors and locality-sensitive hashing
   - Ultra-fast bit comparison (XOR + popcount)
   - Ideal for: image hashing, fingerprints, duplicate detection
@@ -4493,13 +4493,13 @@ This change ensures VelesDB remains freely available while protecting against cl
 
 ### Added
 
-#### Performance Optimizations (WIS-44)
-- **Explicit SIMD** (WIS-47): 4.2x faster cosine similarity using `wide` crate
+#### Performance Optimizations
+- **Explicit SIMD**: 4.2x faster cosine similarity using `wide` crate
   - Cosine: 320ns → **76ns** (4.2x speedup)
   - Euclidean: 138ns → **47ns** (2.9x speedup)
   - Dot Product: 130ns → **45ns** (2.9x speedup)
 
-- **ColumnStore Filtering** (WIS-46): 122x faster metadata filtering
+- **ColumnStore Filtering**: 122x faster metadata filtering
   - Columnar storage for typed metadata (i64, f64, string, bool)
   - String interning for efficient string comparisons
   - RoaringBitmap for combining filters (AND/OR)
@@ -4511,7 +4511,7 @@ This change ensures VelesDB remains freely available while protecting against cl
   - Linux/macOS: `curl -fsSL .../install.sh | bash`
   - Windows: `irm .../install.ps1 | iex`
 
-- **OpenAPI/Swagger** (WIS-34): Full API documentation
+- **OpenAPI/Swagger**: Full API documentation
   - Swagger UI at `/swagger-ui`
   - OpenAPI spec at `/api-docs/openapi.json`
 
@@ -4537,7 +4537,7 @@ This change ensures VelesDB remains freely available while protecting against cl
 
 ### Added
 
-#### Half-Precision Support (WIS-61)
+#### Half-Precision Support
 - **f16/bf16 vectors**: 50% memory reduction
   - `VectorPrecision` enum: F32, F16, BF16
   - `VectorData` with automatic conversions
@@ -4549,14 +4549,14 @@ This change ensures VelesDB remains freely available while protecting against cl
 | 768 (BERT)| 3.0 KB   | 1.5 KB   | 50%     |
 | 1536 (GPT)| 6.0 KB   | 3.0 KB   | 50%     |
 
-#### WASM Support (WIS-60)
+#### WASM Support
 - **`velesdb-wasm` crate**: Vector search in the browser
   - `VectorStore` with insert/search/remove
   - Cosine, Euclidean, Dot Product metrics
   - WASM SIMD128 optimizations via `wide` crate
   - JavaScript API via wasm-bindgen
 
-#### AVX-512 Optimizations (WIS-59)
+#### AVX-512 Optimizations
 - **wide32 processing**: 4x f32x8 accumulators for maximum ILP
   - 40-50% improvement on HNSW recall benchmarks
   - Automatic CPU feature detection
@@ -4575,7 +4575,7 @@ This change ensures VelesDB remains freely available while protecting against cl
 
 ### Added
 
-#### BM25 Full-Text Search (WIS-55)
+#### BM25 Full-Text Search
 - **`Bm25Index`**: Full-text search with BM25 ranking algorithm
   - Tokenization with stopword removal
   - Term frequency / inverse document frequency scoring
@@ -4598,7 +4598,7 @@ This change ensures VelesDB remains freely available while protecting against cl
   - `POST /collections/{name}/search/text` - BM25 text search
   - `POST /collections/{name}/search/hybrid` - Hybrid search
 
-#### Tauri Desktop Plugin (WIS-67)
+#### Tauri Desktop Plugin
 - **`tauri-plugin-velesdb`**: Vector search in desktop applications
   - Full Tauri v2 compatibility
   - 9 commands: CRUD, search, text_search, hybrid_search, query
@@ -4650,7 +4650,7 @@ This change ensures VelesDB remains freely available while protecting against cl
 
 ### Added
 
-#### TypeScript SDK (WIS-71)
+#### TypeScript SDK
 - **`@velesdb/sdk`**: Unified TypeScript client for browser and Node.js
   - WASM backend for client-side vector search
   - REST backend for server communication
@@ -4669,7 +4669,7 @@ This change ensures VelesDB remains freely available while protecting against cl
   const results = await db.search('docs', query, { k: 5 });
   ```
 
-#### IndexedDB Persistence (WIS-73)
+#### IndexedDB Persistence
 - **`export_to_bytes()`**: Serialize vector store to binary format
 - **`import_from_bytes()`**: Restore from binary data
 - Custom binary format with "VELS" magic number, versioning
@@ -4681,7 +4681,7 @@ This change ensures VelesDB remains freely available while protecting against cl
   | Export | **4479 MB/s** |
   | Import | **2943 MB/s** |
 
-#### Tauri RAG Tutorial (WIS-74)
+#### Tauri RAG Tutorial
 - **`examples/tauri-rag-app`**: Complete desktop RAG application
   - React + Tailwind UI
   - Document ingestion with chunking
@@ -4711,7 +4711,7 @@ This change ensures VelesDB remains freely available while protecting against cl
 
 ### Added
 
-#### Performance Optimizations P1 (WIS-86/87)
+#### Performance Optimizations P1
 
 - **ContiguousVectors**: Cache-optimized memory layout
   - 64-byte aligned contiguous buffer for cache line efficiency

--- a/crates/velesdb-core/Cargo.toml
+++ b/crates/velesdb-core/Cargo.toml
@@ -164,7 +164,7 @@ name = "scalability_benchmark"
 harness = false
 
 [[bench]]
-name = "wis1_validation"
+name = "recall_perf_validation"
 harness = false
 
 [[bench]]

--- a/crates/velesdb-core/benches/column_filter_benchmark.rs
+++ b/crates/velesdb-core/benches/column_filter_benchmark.rs
@@ -2,7 +2,7 @@
 //!
 //! Run with: `cargo bench --bench column_filter_benchmark`
 //!
-//! # WIS-46: Column Store Performance Validation
+//! # Column Store Performance Validation
 
 #![allow(clippy::cast_precision_loss)]
 #![allow(clippy::cast_possible_wrap)]

--- a/crates/velesdb-core/benches/hnsw_benchmark.rs
+++ b/crates/velesdb-core/benches/hnsw_benchmark.rs
@@ -350,7 +350,7 @@ fn bench_distance_metrics(c: &mut Criterion) {
     group.finish();
 }
 
-/// Validate recall ≥95% at different dimensions (WIS-12 acceptance criteria).
+/// Validate recall ≥95% at different dimensions (acceptance criteria).
 ///
 /// Recall = |HNSW results ∩ Brute-force results| / k
 fn bench_recall_validation(c: &mut Criterion) {

--- a/crates/velesdb-core/benches/overhead_benchmark.rs
+++ b/crates/velesdb-core/benches/overhead_benchmark.rs
@@ -8,7 +8,7 @@
 //!
 //! Run with: `cargo bench --bench overhead_benchmark`
 //!
-//! # WIS-45: Performance Diagnostic
+//! # Performance Diagnostic
 
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
 use velesdb_core::simd_native::{cosine_similarity_native, dot_product_native, euclidean_native};

--- a/crates/velesdb-core/benches/parallel_benchmark.rs
+++ b/crates/velesdb-core/benches/parallel_benchmark.rs
@@ -121,7 +121,7 @@ fn bench_brute_force(c: &mut Criterion) {
     group.finish();
 }
 
-/// Benchmark parallel insert (WIS-9: lock contention reduction)
+/// Benchmark parallel insert (lock contention reduction)
 ///
 /// Measures throughput of `insert_batch_parallel` which benefits from
 /// the `HnswMappings` refactoring (4 locks → 2 locks per insert).

--- a/crates/velesdb-core/benches/recall_perf_validation.rs
+++ b/crates/velesdb-core/benches/recall_perf_validation.rs
@@ -1,10 +1,10 @@
-//! WIS-1 Validation Benchmarks
+//! Recall and performance validation benchmarks
 //!
-//! Validates the acceptance criteria for WIS-1 (HNSW Index):
+//! Validates the HNSW index acceptance criteria:
 //! - Performance < 10ms for 100k vectors search
 //! - Recall > 95% on standard benchmarks
 //!
-//! Run with: `cargo bench --bench wis1_validation`
+//! Run with: `cargo bench --bench recall_perf_validation`
 //!
 //! ## Optimizations
 //!
@@ -140,9 +140,9 @@ fn calculate_recall(hnsw_results: &[ScoredResult], ground_truth: &[u64]) -> f64 
     }
 }
 
-/// WIS-1 Criterion 1: Performance < 10ms for 100k vectors search
+/// Criterion 1: Performance < 10ms for 100k vectors search
 fn bench_100k_search_latency(c: &mut Criterion) {
-    let mut group = c.benchmark_group("wis1_100k_search");
+    let mut group = c.benchmark_group("100k_search");
     group.sample_size(20); // Reduced for stability
 
     let dim = 128;
@@ -190,10 +190,10 @@ fn bench_100k_search_latency(c: &mut Criterion) {
     group.finish();
 }
 
-/// WIS-1 Criterion 2: Recall > 95%
+/// Criterion 2: Recall > 95%
 /// Measures recall by comparing HNSW results to brute-force ground truth.
 fn bench_recall_measurement(c: &mut Criterion) {
-    let mut group = c.benchmark_group("wis1_recall");
+    let mut group = c.benchmark_group("recall");
     group.sample_size(10);
 
     let dim = 128;
@@ -242,7 +242,7 @@ fn bench_recall_measurement(c: &mut Criterion) {
     let avg_recall = total_recall / num_queries as f64;
     println!("\n🎯 Average Recall@{k}: {:.2}%", avg_recall * 100.0);
     println!(
-        "   {} WIS-1 Criterion: Recall > 95%\n",
+        "   {} Criterion: Recall > 95%\n",
         if avg_recall >= 0.95 { "✅" } else { "❌" }
     );
 
@@ -261,7 +261,7 @@ fn bench_recall_measurement(c: &mut Criterion) {
 /// Combined validation for Cosine and Euclidean metrics.
 /// Note: `DotProduct` excluded due to `hnsw_rs` constraint (requires non-negative dot products)
 fn bench_all_metrics(c: &mut Criterion) {
-    let mut group = c.benchmark_group("wis1_all_metrics");
+    let mut group = c.benchmark_group("all_metrics");
     group.sample_size(20);
 
     let dim = 128;
@@ -303,7 +303,7 @@ fn bench_all_metrics(c: &mut Criterion) {
 /// Benchmark recall on 100k vectors (validates HNSW params at scale).
 /// Note: This test is slower due to brute-force ground truth computation.
 fn bench_recall_100k(c: &mut Criterion) {
-    let mut group = c.benchmark_group("wis1_recall_100k");
+    let mut group = c.benchmark_group("recall_100k");
     group.sample_size(10);
 
     let dim = 128;
@@ -346,7 +346,7 @@ fn bench_recall_100k(c: &mut Criterion) {
         avg_recall * 100.0
     );
     println!(
-        "   {} WIS-1 Criterion: Recall > 95%\n",
+        "   {} Criterion: Recall > 95%\n",
         if avg_recall >= 0.95 { "✅" } else { "❌" }
     );
 
@@ -361,7 +361,7 @@ fn bench_recall_100k(c: &mut Criterion) {
 /// Benchmark performance across different vector dimensions.
 /// Tests if performance degrades significantly at higher dimensions.
 fn bench_dimensions(c: &mut Criterion) {
-    let mut group = c.benchmark_group("wis1_dimensions");
+    let mut group = c.benchmark_group("dimensions");
     group.sample_size(10);
 
     let num_vectors = 10_000;

--- a/crates/velesdb-core/benches/velesql_benchmark.rs
+++ b/crates/velesdb-core/benches/velesql_benchmark.rs
@@ -204,7 +204,7 @@ fn bench_realistic_workload(c: &mut Criterion) {
 }
 
 // =============================================================================
-// EXPLAIN Query Plan Benchmarks (WIS-22)
+// EXPLAIN Query Plan Benchmarks
 // =============================================================================
 
 fn bench_explain_simple(c: &mut Criterion) {

--- a/crates/velesdb-core/src/distance_tests.rs
+++ b/crates/velesdb-core/src/distance_tests.rs
@@ -72,7 +72,7 @@ fn test_metric_serialization() {
 }
 
 // =========================================================================
-// TDD Tests for Hamming Distance (WIS-33)
+// TDD Tests for Hamming Distance
 // =========================================================================
 
 #[test]
@@ -115,7 +115,7 @@ fn test_hamming_higher_is_better() {
 }
 
 // =========================================================================
-// TDD Tests for Jaccard Similarity (WIS-33)
+// TDD Tests for Jaccard Similarity
 // =========================================================================
 
 #[test]

--- a/crates/velesdb-core/src/index/hnsw/index_tests.rs
+++ b/crates/velesdb-core/src/index/hnsw/index_tests.rs
@@ -850,7 +850,7 @@ fn test_search_with_rerank_euclidean_metric() {
 }
 
 // =========================================================================
-// WIS-8: Memory Leak Fix Tests
+// Memory Leak Fix Tests
 // Tests for multi-tenant scenarios and proper Drop behavior
 // =========================================================================
 

--- a/crates/velesdb-core/src/metrics_tests.rs
+++ b/crates/velesdb-core/src/metrics_tests.rs
@@ -1,7 +1,7 @@
 //! Tests for metrics module (extracted for maintainability)
 
 // =============================================================================
-// TDD Tests - Written BEFORE implementation (following WIS-77 requirements)
+// TDD Tests - Written BEFORE implementation
 // =============================================================================
 
 use crate::metrics::*;
@@ -336,7 +336,7 @@ fn test_average_metrics_empty() {
 }
 
 // =========================================================================
-// Exact Search Recall Validation (WIS-77 requirement)
+// Exact Search Recall Validation
 // =========================================================================
 
 #[test]
@@ -395,7 +395,7 @@ fn test_recall_at_100() {
 }
 
 // =========================================================================
-// WIS-86: NDCG@k Tests
+// NDCG@k Tests
 // =========================================================================
 
 #[test]
@@ -469,7 +469,7 @@ fn test_ndcg_all_zeros() {
 }
 
 // =========================================================================
-// WIS-86: Hit Rate Tests
+// Hit Rate Tests
 // =========================================================================
 
 #[test]
@@ -530,7 +530,7 @@ fn test_hit_rate_empty() {
 }
 
 // =========================================================================
-// WIS-86: MAP (Mean Average Precision) Tests
+// MAP (Mean Average Precision) Tests
 // =========================================================================
 
 #[test]
@@ -593,7 +593,7 @@ fn test_map_empty() {
 }
 
 // =========================================================================
-// WIS-87: Latency Percentiles Tests
+// Latency Percentiles Tests
 // =========================================================================
 
 #[test]

--- a/crates/velesdb-python/tests/test_velesdb.py
+++ b/crates/velesdb-python/tests/test_velesdb.py
@@ -212,7 +212,7 @@ class TestCollection:
 
 
 class TestNumpySupport:
-    """Tests for NumPy array support (WIS-23)."""
+    """Tests for NumPy array support."""
 
     @_SKIP_NO_NUMPY
     def test_upsert_with_numpy_vector(self, temp_db):
@@ -271,7 +271,7 @@ class TestNumpySupport:
 
 
 class TestTextSearch:
-    """Tests for BM25 text search (WIS-42)."""
+    """Tests for BM25 text search."""
 
     def test_text_search_basic(self, temp_db):
         """Test basic text search functionality."""
@@ -305,7 +305,7 @@ class TestTextSearch:
 
 
 class TestHybridSearch:
-    """Tests for hybrid search combining vector and text (WIS-43)."""
+    """Tests for hybrid search combining vector and text."""
 
     def test_hybrid_search_basic(self, temp_db):
         """Test basic hybrid search functionality."""
@@ -348,7 +348,7 @@ class TestHybridSearch:
 
 
 class TestBatchSearch:
-    """Tests for batch search functionality (WIS-44)."""
+    """Tests for batch search functionality."""
 
     def test_batch_search_basic(self, temp_db):
         """Test basic batch search with multiple queries."""
@@ -402,7 +402,7 @@ class TestBatchSearch:
 
 
 class TestStorageMode:
-    """Tests for storage mode (quantization) support (WIS-45)."""
+    """Tests for storage mode (quantization) support."""
 
     @pytest.mark.parametrize(
         "mode,expected_mode",
@@ -462,7 +462,7 @@ class TestStorageMode:
 
 
 class TestDistanceMetrics:
-    """Tests for all distance metrics including Hamming and Jaccard (WIS-46)."""
+    """Tests for all distance metrics including Hamming and Jaccard."""
 
     def test_hamming_metric(self, temp_db):
         """Test Hamming distance metric."""

--- a/crates/velesdb-wasm/tests/web.rs
+++ b/crates/velesdb-wasm/tests/web.rs
@@ -358,7 +358,7 @@ fn test_with_capacity_constructor() {
 }
 
 // =============================================================================
-// IndexedDB Persistence Tests (TDD - WIS-73)
+// IndexedDB Persistence Tests (TDD)
 // =============================================================================
 
 // Note: These tests require browser environment with IndexedDB support


### PR DESCRIPTION
Removes every internal `WIS-xx` tracker ID from public-facing files.

## Changes (13 files)
- **Comments / docstrings / benches** (10 files): stripped `WIS-xx` references, keeping the descriptive text (e.g. `// WIS-86: NDCG@k Tests` → `// NDCG@k Tests`; `(WIS-12 acceptance criteria)` → `(acceptance criteria)`).
- **Benchmark rename**: `benches/wis1_validation.rs` → `benches/recall_perf_validation.rs` (+ `Cargo.toml` `[[bench]] name`, internal `WIS-1` refs, and `benchmark_group` labels). Compiles (`cargo bench --bench recall_perf_validation --no-run`).
- **CHANGELOG**: removed 17 `(WIS-xx)` tags from historical entries (descriptions preserved; history not otherwise rewritten).

## Deliberately preserved
- The **`@wiscale/…` npm scope** (published package namespace: `@wiscale/velesdb-sdk`, `velesdb-wasm`, `tauri-plugin-velesdb`) — it is the live package name, not a tracker ID.

## Verification
- Repo-wide scan: **zero `WIS-xx` / `wis1` remaining**.
- Renamed bench compiles; `cargo fmt --all --check` clean. Comment/rename-only otherwise — CI to confirm.