### PR TITLE
chore(codacy): exclude CLI src-root files from complexity grading

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -258,6 +258,10 @@ engines:
       - "crates/velesdb-core/src/collection/search/query/join.rs"
 
       # --- CLI / REPL (interactive tool, not production engine) ---
+      # The `**` glob only matches files in sub-directories; src-root files
+      # (license.rs, etc.) need the single-level `*` twin or they slip through
+      # and are graded for complexity despite the CLI-wide exclusion policy.
+      - "crates/velesdb-cli/src/*"
       - "crates/velesdb-cli/src/**"
 
       # --- Examples, benchmarks, fuzz targets ---


### PR DESCRIPTION
## Summary

Fix the lone CLI file still graded B for complexity. Config-only, no code change.

`license.rs` was graded B (complexity 43) while CLI siblings at **higher** complexity are A (`graph.rs` CCN 86 → A, `session.rs` 70 → A, `repl.rs` 60 → A). Root cause: the CLI-wide lizard exclusion `crates/velesdb-cli/src/**` only matches files in *sub-directories*, so src-root files slip through and are graded despite the documented policy that the CLI crate ("interactive tool, not the production engine") is excluded from complexity grading — a policy that already lists `main.rs`/`import.rs`/`repl_commands.rs` explicitly.

Added the single-level `src/*` twin glob so the exclusion covers src-root files consistently. This is a glob-coverage fix that applies the **existing** documented policy uniformly, not new suppression.

### Note on `edge_concurrent/mod.rs`

This file (core, B/87) was also a candidate for round 2 via a write-path module split. That split was **dropped**: it exposed a pre-existing `add_edge` CC-10 (> the project's CC≤8 limit, previously masked by Lizard's adjacent-function merging) and the resulting `mutation.rs` would itself have been borderline-B — i.e. relocating the grade rather than improving it. Not worth the churn. `edge_concurrent` stays B/87 (0 issues; already improved from 82 by the merged cascade split in #1007). The `add_edge` CC-10 is noted as a separate pre-existing smell.

## Verification

- `.codacy.yml` valid YAML; no code touched.
