### PR TITLE
chore(codacy): revert ineffective CLI src-root glob twin

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -258,10 +258,6 @@ engines:
       - "crates/velesdb-core/src/collection/search/query/join.rs"
 
       # --- CLI / REPL (interactive tool, not production engine) ---
-      # The `**` glob only matches files in sub-directories; src-root files
-      # (license.rs, etc.) need the single-level `*` twin or they slip through
-      # and are graded for complexity despite the CLI-wide exclusion policy.
-      - "crates/velesdb-cli/src/*"
       - "crates/velesdb-cli/src/**"
 
       # --- Examples, benchmarks, fuzz targets ---


### PR DESCRIPTION
Reverts the `crates/velesdb-cli/src/*` lizard-exclude twin added in #1009. It was a no-op: Codacy re-analyzed `develop` at the merge commit and `license.rs` stayed B (complexity 43), so its penalty originates outside the lizard `exclude_paths`. Removing the dead lines + the over-claiming comment keeps the config honest. `license.rs` remains B (0 issues, CLI tool file) by acceptance — consistent with how its higher-complexity CLI peers (graph.rs CCN 86) are graded A.

Config-only; YAML validated.