### PR TITLE
fix(storage): tolerate torn-tail in payload WAL replay

### DIFF
--- a/crates/velesdb-core/src/storage/log_payload.rs
+++ b/crates/velesdb-core/src/storage/log_payload.rs
@@ -214,7 +214,12 @@ impl LogPayloadStorage {
             let Some(entry) = WalEntry::read(&mut reader_buf, pos)? else {
                 break;
             };
-            pos = entry.apply(&mut index, &mut reader_buf, end_pos)?;
+            // `None` signals a torn tail (crash mid-append): stop cleanly,
+            // keeping every entry replayed so far.
+            let Some(next_pos) = entry.apply(&mut index, &mut reader_buf, end_pos)? else {
+                break;
+            };
+            pos = next_pos;
         }
 
         Ok(index)

--- a/crates/velesdb-core/src/storage/log_payload_tests.rs
+++ b/crates/velesdb-core/src/storage/log_payload_tests.rs
@@ -1,6 +1,7 @@
 //! Tests for `log_payload` module
 
 use super::log_payload::{DurabilityMode, LogPayloadStorage, SNAPSHOT_MAGIC, SNAPSHOT_VERSION};
+use super::log_payload_io::CRC_STORE_MARKER;
 use super::traits::PayloadStorage;
 
 use serde_json::json;
@@ -817,4 +818,92 @@ fn test_store_batch_deferred_empty() {
         .expect("test: empty deferred batch");
 
     assert_eq!(storage.ids().len(), 0);
+}
+
+// -------------------------------------------------------------------------
+// Crash recovery: torn-tail tolerance.
+//
+// A crash mid-append leaves a partially-written final record in the payload
+// WAL. Replay must stop cleanly at that tail and keep every prior entry — it
+// must NOT abort the whole collection open, which would make the data
+// unreachable after a perfectly survivable crash. Mirrors the vector WAL's
+// `#898` torn-tail policy (`storage::mmap::wal_replay`).
+// -------------------------------------------------------------------------
+
+/// Appends raw bytes to an existing payload WAL, simulating a crash that left a
+/// partially-written final record on disk.
+fn append_raw_to_wal(wal_path: &std::path::Path, bytes: &[u8]) {
+    use std::io::Write;
+    let mut f = std::fs::OpenOptions::new()
+        .append(true)
+        .open(wal_path)
+        .expect("open WAL for append");
+    f.write_all(bytes).expect("append torn-tail bytes");
+    f.sync_all().expect("sync torn-tail");
+}
+
+/// Stores ids 1..=3 with full durability, then drops the storage to close the
+/// WAL. Returns the temp dir (kept alive by the caller) so a torn tail can be
+/// appended and the collection reopened.
+fn storage_with_three_entries() -> TempDir {
+    let temp = TempDir::new().expect("temp dir");
+    let mut storage = LogPayloadStorage::new_with_durability(temp.path(), DurabilityMode::Fsync)
+        .expect("create storage");
+    for i in 1..=3 {
+        storage.store(i, &json!({ "id": i })).expect("store");
+    }
+    drop(storage);
+    temp
+}
+
+#[test]
+fn test_torn_tail_truncated_header_recovers_prior_entries() {
+    // Crash after the marker byte but before the full 8-byte id was written:
+    // a 1-byte marker plus a partial id. Reopen must stop at the tail and keep
+    // entries 1..=3 rather than propagating the `UnexpectedEof`.
+    let temp = storage_with_three_entries();
+    let wal_path = temp.path().join("payloads.log");
+    append_raw_to_wal(&wal_path, &[CRC_STORE_MARKER, 0xAA, 0xBB, 0xCC]);
+
+    let storage =
+        LogPayloadStorage::new(temp.path()).expect("torn header must not fail collection open");
+
+    let mut ids = storage.ids();
+    ids.sort_unstable();
+    assert_eq!(
+        ids,
+        vec![1, 2, 3],
+        "prior entries must survive a torn header"
+    );
+    assert_eq!(
+        storage.retrieve(2).expect("retrieve"),
+        Some(json!({ "id": 2 })),
+        "a pre-crash payload must still be readable after torn-tail recovery"
+    );
+}
+
+#[test]
+fn test_torn_tail_declared_length_past_eof_recovers_prior_entries() {
+    // Crash after writing marker + id + length field but before the payload:
+    // the declared length runs past EOF. This used to return `InvalidData` and
+    // abort the open; replay must instead stop cleanly and drop only the torn
+    // record (id 42 was never durably written).
+    let temp = storage_with_three_entries();
+    let wal_path = temp.path().join("payloads.log");
+
+    let mut torn = vec![CRC_STORE_MARKER];
+    torn.extend_from_slice(&42u64.to_le_bytes()); // id
+    torn.extend_from_slice(&1_000_000u32.to_le_bytes()); // length far past EOF, no payload
+    append_raw_to_wal(&wal_path, &torn);
+
+    let storage = LogPayloadStorage::new(temp.path())
+        .expect("oversized length on the last record must not fail collection open");
+
+    let mut ids = storage.ids();
+    ids.sort_unstable();
+    assert_eq!(
+        ids,
+        vec![1, 2, 3],
+        "a torn record must drop only itself, never prior entries"
+    );
 }

--- a/crates/velesdb-core/src/storage/wal_entry.rs
+++ b/crates/velesdb-core/src/storage/wal_entry.rs
@@ -11,6 +11,15 @@
 //! marker values, preserving backward-compatible reading of older entries.
 //! No separate schema-version header is needed because the per-entry
 //! marker already encodes the wire format.
+//!
+//! ## Torn-tail policy
+//!
+//! A crash mid-append leaves a partially-written final record. Because the WAL
+//! is append-only and replayed sequentially, a truncation can only ever be the
+//! last record. [`WalEntry::read`] / [`WalEntry::apply`] therefore signal such a
+//! tail by returning `Ok(None)` instead of an error, so the caller stops replay
+//! cleanly and keeps every prior entry rather than failing the collection open.
+//! This mirrors the vector WAL's `#898` policy (`storage::mmap::wal_replay`).
 
 use super::log_payload_io::{
     compute_delete_crc, compute_store_crc, CRC_DELETE_MARKER, CRC_STORE_MARKER,
@@ -44,7 +53,10 @@ impl WalEntry {
         }
 
         let mut id_bytes = [0u8; 8];
-        reader.read_exact(&mut id_bytes)?;
+        if reader.read_exact(&mut id_bytes).is_err() {
+            // Torn tail: crashed after the marker but before the full id.
+            return Ok(None);
+        }
         let id = u64::from_le_bytes(id_bytes);
         let pos_after_header = pos + 1 + 8;
 
@@ -70,6 +82,10 @@ impl WalEntry {
 
     /// Applies this entry to the index, returning the new file position.
     ///
+    /// Returns `Ok(None)` for a torn tail (a record truncated by a crash
+    /// mid-append) so the caller stops replay cleanly; see the module-level
+    /// torn-tail policy.
+    ///
     /// `wal_end` is the logical end of the WAL being replayed; it bounds the
     /// declared payload length so a corrupt length field cannot drive an
     /// unbounded allocation (#897/#898).
@@ -78,10 +94,10 @@ impl WalEntry {
         index: &mut FxHashMap<u64, u64>,
         reader: &mut BufReader<File>,
         wal_end: u64,
-    ) -> io::Result<u64> {
+    ) -> io::Result<Option<u64>> {
         match self.op {
             WalOp::Store { id } => self.apply_store(id, index, reader, wal_end),
-            WalOp::Delete { id } => self.apply_delete(id, index, reader),
+            WalOp::Delete { id } => Ok(self.apply_delete(id, index, reader)),
         }
     }
 
@@ -91,22 +107,24 @@ impl WalEntry {
         index: &mut FxHashMap<u64, u64>,
         reader: &mut BufReader<File>,
         wal_end: u64,
-    ) -> io::Result<u64> {
+    ) -> io::Result<Option<u64>> {
         let len_offset = self.pos_after_header;
         let mut len_bytes = [0u8; 4];
-        reader.read_exact(&mut len_bytes)?;
+        if reader.read_exact(&mut len_bytes).is_err() {
+            // Torn tail: crashed after the id but before the full length field.
+            return Ok(None);
+        }
         let payload_len = u64::from(u32::from_le_bytes(len_bytes));
 
         // OOM guard (#897/#898): the payload (plus the 4-byte CRC for v2
-        // records) cannot extend past the WAL end. Reject before allocating.
+        // records) cannot extend past the WAL end. A length running past EOF is
+        // a torn tail (crashed before the payload landed) — stop cleanly rather
+        // than failing the open, and never allocate the oversized buffer.
         let payload_start = self.pos_after_header + 4;
         let crc_bytes = u64::from(self.has_crc) * 4;
         let max_payload = wal_end.saturating_sub(payload_start);
         if payload_len.saturating_add(crc_bytes) > max_payload {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                "WAL payload length exceeds remaining file",
-            ));
+            return Ok(None);
         }
 
         let end_pos = if self.has_crc {
@@ -119,7 +137,7 @@ impl WalEntry {
             self.pos_after_header + 4 + payload_len
         };
 
-        Ok(end_pos)
+        Ok(Some(end_pos))
     }
 
     fn apply_store_with_crc(
@@ -157,10 +175,13 @@ impl WalEntry {
         id: u64,
         index: &mut FxHashMap<u64, u64>,
         reader: &mut BufReader<File>,
-    ) -> io::Result<u64> {
+    ) -> Option<u64> {
         if self.has_crc {
             let mut crc_bytes = [0u8; 4];
-            reader.read_exact(&mut crc_bytes)?;
+            if reader.read_exact(&mut crc_bytes).is_err() {
+                // Torn tail: crashed after the id but before the CRC.
+                return None;
+            }
             let stored_crc = u32::from_le_bytes(crc_bytes);
             let computed_crc = compute_delete_crc(id);
 
@@ -173,10 +194,10 @@ impl WalEntry {
                 );
             }
 
-            Ok(self.pos_after_header + 4)
+            Some(self.pos_after_header + 4)
         } else {
             index.remove(&id);
-            Ok(self.pos_after_header)
+            Some(self.pos_after_header)
         }
     }
 }

--- a/crates/velesdb-core/src/storage/wal_recovery_tests.rs
+++ b/crates/velesdb-core/src/storage/wal_recovery_tests.rs
@@ -21,12 +21,19 @@
 //!
 //! `LogPayloadStorage::new()` → `load_snapshot()` (if exists) → `replay_wal_from()`
 //!
-//! `replay_wal_from()` iterates WAL entries:
-//! - Reads marker (1B) — `read_exact` failure → break (tolerant at entry boundary)
-//! - Reads id (8B) — failure → propagated as error
-//! - marker=1/0xC3 → reads len (4B), payload; if 0xC3, reads + verifies CRC32
-//! - marker=2/0xC4 → removes from index; if 0xC4, reads + verifies CRC32
-//! - unknown marker → returns `InvalidData` error
+//! `replay_wal_from()` iterates WAL entries. A crash mid-append can only
+//! truncate the *last* record, so any truncation (a short id/len/payload/crc
+//! field, or a declared length running past EOF) is treated as a torn tail:
+//! replay stops cleanly and keeps every prior entry rather than failing the
+//! collection open (mirrors the vector WAL's `#898` policy):
+//! - Reads marker (1B) — `read_exact` failure → clean stop at entry boundary
+//! - Reads id (8B) — failure → torn tail → clean stop
+//! - marker=1/0xC3 → reads len (4B), payload; if 0xC3, reads + verifies CRC32.
+//!   A truncated len/payload/crc or an over-EOF declared length → clean stop
+//! - marker=2/0xC4 → removes from index; if 0xC4, reads + verifies CRC32;
+//!   a truncated crc → clean stop
+//! - unknown marker → returns `InvalidData` error (genuine corruption: a torn
+//!   tail cannot produce a wrong marker byte under sequential append)
 //! - CRC mismatch → entry skipped (not inserted/deleted), warning logged
 //!
 //! # Snapshot Format
@@ -861,34 +868,43 @@ fn test_crc_entries_survive_snapshot_cycle() {
 // ===========================================================================
 
 #[test]
-fn test_898_replay_rejects_oversized_payload_length_no_huge_alloc() {
-    // Legacy store entry whose declared length is 4 GiB but with no payload:
-    // replay must reject it (not allocate 4 GiB), without panicking.
+fn test_898_replay_tolerates_oversized_payload_length_as_torn_tail() {
+    // Legacy store entry whose declared length is 4 GiB but with no payload —
+    // the exact shape a crash leaves after writing the length field. The OOM
+    // guard must still short-circuit BEFORE allocating 4 GiB (the #898 security
+    // property), but replay now treats the record as a torn tail: the open
+    // succeeds and the bogus record is dropped rather than aborting recovery.
     let mut wal = vec![1u8];
     wal.extend_from_slice(&1u64.to_le_bytes());
     wal.extend_from_slice(&u32::MAX.to_le_bytes()); // bogus 4 GiB length
                                                     // no payload bytes follow
 
-    let result = open_storage_with_wal(&wal);
-    assert!(
-        result.is_err(),
-        "oversized declared payload length must be rejected as corrupt"
+    let (_dir, storage) =
+        open_storage_with_wal(&wal).expect("oversized length must be tolerated as a torn tail");
+    assert_eq!(
+        storage.ids().len(),
+        0,
+        "the torn record must be dropped, leaving an empty index"
     );
 }
 
 #[test]
-fn test_898_replay_rejects_oversized_crc_payload_no_huge_alloc() {
+fn test_898_replay_tolerates_oversized_crc_payload_as_torn_tail() {
     // CRC-framed store entry declaring an impossibly large payload length.
+    // Same contract: no huge allocation, and the torn record is dropped while
+    // the open succeeds.
     let mut wal = Vec::new();
     wal.push(0xC3u8);
     wal.extend_from_slice(&1u64.to_le_bytes());
     wal.extend_from_slice(&u32::MAX.to_le_bytes());
     // no payload / crc follow
 
-    let result = open_storage_with_wal(&wal);
-    assert!(
-        result.is_err(),
-        "oversized CRC payload length must be rejected before allocation"
+    let (_dir, storage) =
+        open_storage_with_wal(&wal).expect("oversized CRC length must be tolerated as a torn tail");
+    assert_eq!(
+        storage.ids().len(),
+        0,
+        "the torn record must be dropped, leaving an empty index"
     );
 }
 


### PR DESCRIPTION
## Problem

A crash mid-append leaves a partially-written final record in the payload WAL (`payloads.log`). Replay previously **propagated** the resulting error and aborted `LogPayloadStorage::new`, making the collection **unopenable** after an otherwise survivable crash:

- a truncated `id`/`len`/`payload`/`crc` field → `UnexpectedEof`, or
- a declared length running past EOF → the OOM-guard `InvalidData` ("WAL payload length exceeds remaining file").

Since `store()` appends through a `BufWriter` with no single-syscall atomicity, this torn tail is the normal outcome of a crash during a payload write. The **vector** WAL already handles this (`storage::mmap::wal_replay`, #898); the payload WAL did not — an asymmetry surfaced by a Rust audit of the storage hotspot.

## Fix

Mirror the vector WAL's #898 torn-tail policy. Because the WAL is append-only and replayed sequentially, **any truncation can only be the last record**, so `WalEntry::read`/`apply` now signal it via `Ok(None)` and replay **stops cleanly, keeping every prior entry**.

- The OOM guard still short-circuits **before any allocation** (the security property of #897/#898 is preserved).
- An **unknown marker byte remains a hard error** — a torn tail cannot produce a wrong marker under sequential append, so it indicates genuine corruption.
- `apply_delete` no longer has an error path, so its return type drops the `io::Result` wrapper (satisfies `clippy::pedantic`).

## Tests

- **New** (`log_payload_tests`): `test_torn_tail_truncated_header_recovers_prior_entries` and `test_torn_tail_declared_length_past_eof_recovers_prior_entries` — both fail on `develop`, pass here, and assert prior entries (and their payloads) survive.
- **Realigned** the two #898 OOM tests, which asserted the now-removed `Err` disposition rather than the security-relevant "no huge allocation" property; they now assert the open succeeds and the torn record is dropped.
- Full storage suite: **253 passed**; fmt + `clippy --all-targets -D warnings -D clippy::pedantic` clean; core `--no-default-features` checks.