### PR TITLE
fix(storage): guard retrieve copy path against offset overflow

### DIFF
--- a/crates/velesdb-core/src/storage/mmap/vector_io.rs
+++ b/crates/velesdb-core/src/storage/mmap/vector_io.rs
@@ -253,14 +253,23 @@ impl VectorStorage for MmapStorage {
         let mmap = self.mmap.read();
         let vector_size = self.dimension * std::mem::size_of::<f32>();
 
-        if offset + vector_size > mmap.len() {
+        // Use checked arithmetic so a corrupt near-`usize::MAX` index offset
+        // cannot wrap past the bound check and panic on the slice below
+        // (mirrors `validate_offset` on the zero-copy `retrieve_ref` path).
+        let end = offset.checked_add(vector_size).ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "Offset arithmetic overflow while reading vector",
+            )
+        })?;
+        if end > mmap.len() {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
                 "Offset out of bounds",
             ));
         }
 
-        let bytes = &mmap[offset..offset + vector_size];
+        let bytes = &mmap[offset..end];
         Ok(Some(bytes_to_vector(bytes, self.dimension)))
     }
 

--- a/crates/velesdb-core/src/storage/tests.rs
+++ b/crates/velesdb-core/src/storage/tests.rs
@@ -383,6 +383,25 @@ fn test_retrieve_ref_returns_invalid_data_on_misaligned_offset() {
     }
 }
 
+#[test]
+fn test_retrieve_returns_invalid_data_on_overflowing_offset() {
+    let dir = tempdir().unwrap();
+    let mut storage = MmapStorage::new(dir.path(), 3).unwrap();
+    storage.store(1, &[1.0, 2.0, 3.0]).unwrap();
+
+    // Inject a corrupted, near-usize::MAX offset. On the copy path
+    // `offset + vector_size` wraps, slipping past an unchecked bound check
+    // and panicking on the subsequent slice. `retrieve` must return Err.
+    let vector_size = 3 * std::mem::size_of::<f32>();
+    storage.index.insert(42, usize::MAX - vector_size + 1);
+
+    let result = storage.retrieve(42);
+    match result {
+        Err(err) => assert_eq!(err.kind(), std::io::ErrorKind::InvalidData),
+        Ok(_) => panic!("overflowing offset must not succeed"),
+    }
+}
+
 // =========================================================================
 // TS-CORE-004: Compaction Tests
 // =========================================================================


### PR DESCRIPTION
## Problem

`crates/velesdb-core/src/storage/mmap/vector_io.rs` — the `retrieve()` copy path used an UNCHECKED `offset + vector_size` in its bound check (`if offset + vector_size > mmap.len()`), whereas the zero-copy `retrieve_ref()` path validates the same arithmetic with the `checked_add`-based `validate_offset` helper.

On a corrupt index whose stored offset is near `usize::MAX`, `offset + vector_size` wraps to a small value, slips past the bound check, and then `&mmap[offset..offset + vector_size]` panics (out-of-bounds slice / add overflow) instead of returning an `Err`. The offset is read straight from the on-disk index, so a corrupt index makes the panic reachable.

## Fix

Use `checked_add` on the copy path, mirroring `validate_offset` on the zero-copy path: a corrupt offset now returns `Err(io::ErrorKind::InvalidData)` instead of panicking. Surgical — only the bound check in `retrieve()` changed; no new alignment constraint is introduced (the copy path does no pointer casts).

## Tests

- Added `test_retrieve_returns_invalid_data_on_overflowing_offset` (TDD): injects a near-`usize::MAX` offset into the index and asserts `retrieve` returns `Err(InvalidData)`. Confirmed it panics before the fix (`attempt to add with overflow` at vector_io.rs:256) and passes after.

## Validation

- `cargo fmt --all` clean
- `cargo clippy -p velesdb-core --all-targets --features persistence -- -D warnings -D clippy::pedantic` clean
- `cargo test -p velesdb-core --features persistence --lib storage:: -- --test-threads=1` → 252 passed, 0 failed