### PR TITLE
fix(fusion): validate weights on the fuse path

### DIFF
--- a/crates/velesdb-core/src/fusion/strategy.rs
+++ b/crates/velesdb-core/src/fusion/strategy.rs
@@ -171,13 +171,13 @@ impl FusionStrategy {
                 avg_weight,
                 max_weight,
                 hit_weight,
-            } => Ok(Self::fuse_weighted(
+            } => Self::fuse_weighted(
                 results,
                 *avg_weight,
                 *max_weight,
                 *hit_weight,
                 total_queries,
-            )),
+            ),
             Self::RelativeScore {
                 dense_weight,
                 sparse_weight,
@@ -279,6 +279,13 @@ impl FusionStrategy {
     }
 
     /// Weighted fusion: combination of avg, max, and hit ratio.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the weights are negative or do not sum to 1.0
+    /// (within 0.001 tolerance). Validation runs here as well as in the
+    /// `weighted()` constructor so that direct enum-literal construction
+    /// (e.g. from server/CLI request fields) cannot bypass it.
     #[allow(clippy::cast_precision_loss)]
     // Reason: total_queries and scores.len() are small counts (number of
     // queries/hits per document); both fit exactly in f32.
@@ -288,7 +295,10 @@ impl FusionStrategy {
         max_weight: f32,
         hit_weight: f32,
         total_queries: usize,
-    ) -> Vec<(u64, f32)> {
+    ) -> Result<Vec<(u64, f32)>, FusionError> {
+        validate_non_negative(&[avg_weight, max_weight, hit_weight])?;
+        validate_weight_sum(avg_weight + max_weight + hit_weight)?;
+
         let total_q = total_queries as f32;
 
         let mut fused: Vec<(u64, f32)> = Self::collect_doc_scores(results)
@@ -304,7 +314,7 @@ impl FusionStrategy {
             .collect();
 
         Self::sort_descending(&mut fused);
-        fused
+        Ok(fused)
     }
 
     /// Relative Score Fusion: per-branch min-max normalization + weighted sum.
@@ -313,11 +323,21 @@ impl FusionStrategy {
     /// If more branches are provided, only the first two are used; the extras
     /// are silently discarded. A warning is emitted so callers can detect the
     /// accidental multi-branch case during development.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the weights are negative or do not sum to 1.0
+    /// (within 0.001 tolerance). Validation runs here as well as in the
+    /// `relative_score()` constructor so that direct enum-literal construction
+    /// (e.g. from server/CLI request fields) cannot bypass it.
     fn fuse_relative_score(
         results: &[Vec<(u64, f32)>],
         dense_weight: f32,
         sparse_weight: f32,
     ) -> Result<Vec<(u64, f32)>, FusionError> {
+        validate_non_negative(&[dense_weight, sparse_weight])?;
+        validate_weight_sum(dense_weight + sparse_weight)?;
+
         if results.len() > 2 {
             tracing::warn!(
                 branch_count = results.len(),

--- a/crates/velesdb-core/src/fusion/strategy_tests.rs
+++ b/crates/velesdb-core/src/fusion/strategy_tests.rs
@@ -1,6 +1,6 @@
 //! Tests for `FusionStrategy` implementations.
 
-use super::strategy::FusionStrategy;
+use super::strategy::{FusionError, FusionStrategy};
 
 // =============================================================================
 // Test helpers
@@ -522,6 +522,67 @@ fn test_rsf_validation_negative_weight() {
 fn test_rsf_validation_sum_not_one() {
     let result = FusionStrategy::relative_score(0.3, 0.3);
     assert!(result.is_err());
+}
+
+#[test]
+fn test_weighted_fuse_rejects_invalid_weight_sum_from_literal() {
+    // Direct enum-literal construction bypasses `FusionStrategy::weighted()`,
+    // so the validating constructor cannot guard against unnormalized weights.
+    // The fuse path must reject a weight sum that is not 1.0.
+    let strategy = FusionStrategy::Weighted {
+        avg_weight: 0.9,
+        max_weight: 0.9,
+        hit_weight: 0.9,
+    };
+    let results = vec![vec![(1_u64, 1.0_f32)]];
+    let result = strategy.fuse(results);
+    assert!(
+        matches!(result, Err(FusionError::InvalidWeightSum { .. })),
+        "Weighted fuse must reject weights that do not sum to 1.0, got {result:?}"
+    );
+}
+
+#[test]
+fn test_weighted_fuse_rejects_negative_weight_from_literal() {
+    let strategy = FusionStrategy::Weighted {
+        avg_weight: -0.5,
+        max_weight: 0.75,
+        hit_weight: 0.75,
+    };
+    let results = vec![vec![(1_u64, 1.0_f32)]];
+    let result = strategy.fuse(results);
+    assert!(
+        matches!(result, Err(FusionError::NegativeWeight { .. })),
+        "Weighted fuse must reject negative weights, got {result:?}"
+    );
+}
+
+#[test]
+fn test_rsf_fuse_rejects_invalid_weight_sum_from_literal() {
+    let strategy = FusionStrategy::RelativeScore {
+        dense_weight: 0.3,
+        sparse_weight: 0.3,
+    };
+    let results = vec![vec![(1_u64, 1.0_f32)], vec![(2_u64, 1.0_f32)]];
+    let result = strategy.fuse(results);
+    assert!(
+        matches!(result, Err(FusionError::InvalidWeightSum { .. })),
+        "RelativeScore fuse must reject weights that do not sum to 1.0, got {result:?}"
+    );
+}
+
+#[test]
+fn test_rsf_fuse_rejects_negative_weight_from_literal() {
+    let strategy = FusionStrategy::RelativeScore {
+        dense_weight: -0.1,
+        sparse_weight: 1.1,
+    };
+    let results = vec![vec![(1_u64, 1.0_f32)], vec![(2_u64, 1.0_f32)]];
+    let result = strategy.fuse(results);
+    assert!(
+        matches!(result, Err(FusionError::NegativeWeight { .. })),
+        "RelativeScore fuse must reject negative weights, got {result:?}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Problem

`FusionStrategy::weighted()` and `FusionStrategy::relative_score()` are validating constructors that reject negative weights and weights that do not sum to 1.0. But the `Weighted` and `RelativeScore` enum variants can be built directly as struct literals, bypassing that validation.

This is not hypothetical — every real entry point does exactly that:

- `velesdb-server` `handlers/search/multi.rs` and `pipeline.rs` build `Weighted`/`RelativeScore` straight from request fields (`req.avg_weight`, `req.dense_weight`, …)
- `velesdb-cli` `repl_search_cmds.rs` and `handlers/search.rs`
- `tauri-plugin-velesdb` `helpers.rs`
- `velesdb-mobile` `types.rs`

Unvalidated, user-supplied weights flow straight into `fuse()`, yielding unnormalized or even negative fused scores (e.g. weights `0.9/0.9/0.9` produce a fused score of `2.7`; a negative dense weight produces a negative score).

## Fix

Move the existing `validate_non_negative` + `validate_weight_sum` checks onto the fuse path:

- `fuse_weighted` now returns `Result<_, FusionError>` and validates up front.
- `fuse_relative_score` validates up front (it already returned `Result`).

The public `fuse()` signature is unchanged (it already returned `Result<_, FusionError>`), so no caller API breaks. The constructors keep their early validation; this is a defensive second gate at the point of use, with identical semantics (0.001 tolerance).

## Tests

Four new failing-first tests in `fusion/strategy_tests.rs`, each constructing the strategy via the bypassing enum literal:

- `test_weighted_fuse_rejects_invalid_weight_sum_from_literal`
- `test_weighted_fuse_rejects_negative_weight_from_literal`
- `test_rsf_fuse_rejects_invalid_weight_sum_from_literal`
- `test_rsf_fuse_rejects_negative_weight_from_literal`

All confirmed to fail before the fix (returned unnormalized `Ok(...)`) and pass after.

## Validation

- `cargo fmt --all` — clean
- `cargo clippy -p velesdb-core --all-targets --features persistence -- -D warnings -D clippy::pedantic` — clean
- `cargo test -p velesdb-core --features persistence --lib fusion -- --test-threads=1` — 89 passed
- `cargo test -p velesdb-core --features persistence test_recall -- --test-threads=1` — pass (fusion is in the search path; no recall impact, valid inputs unchanged)
- `scripts/check_prod_unwraps.py` — PASSED