### PR TITLE
fix(index): reject invalid hnsw alpha at the API boundaries

### DIFF
--- a/crates/tauri-plugin-velesdb/src/commands.rs
+++ b/crates/tauri-plugin-velesdb/src/commands.rs
@@ -63,6 +63,9 @@ pub async fn create_collection<R: Runtime>(
         .with_db(|db| {
             if has_advanced_params(&request) {
                 let hnsw_params = build_hnsw_params(&request, storage_mode);
+                // Reject out-of-range tunables (e.g. hnsw_alpha < 1.0 or
+                // non-finite) before creating the collection.
+                hnsw_params.validate()?;
                 db.create_vector_collection_with_params(
                     &request.name,
                     request.dimension,

--- a/crates/velesdb-core/src/index/hnsw/params.rs
+++ b/crates/velesdb-core/src/index/hnsw/params.rs
@@ -47,10 +47,12 @@ pub struct HnswParams {
     pub alpha: f32,
 }
 
-// Eq is safe because alpha values are always finite: they come from
-// `default_alpha()` (1.2), `with_alpha()` (caller-chosen), or serde
-// deserialization which rejects NaN/Inf for f32. No code path produces
-// NaN, so reflexivity (a == a) always holds.
+// Eq is sound because `alpha` is finite in every supported path: the preset
+// constructors and `default_alpha()` produce 1.2, JSON deserialization cannot
+// carry NaN/Inf, and any `alpha` arriving from untrusted public input
+// (REST/Python/Tauri) is rejected by [`HnswParams::validate`] before the params
+// reach the engine. Embedders that build the struct directly via its public
+// fields are responsible for passing a finite value, as with any `pub` float.
 impl Eq for HnswParams {}
 
 impl Default for HnswParams {
@@ -284,6 +286,28 @@ impl HnswParams {
     #[must_use]
     pub const fn with_alpha(self, alpha: f32) -> Self {
         Self { alpha, ..self }
+    }
+
+    /// Validates parameters that can originate from untrusted public input
+    /// (REST, Python, Tauri) before they reach the engine.
+    ///
+    /// `alpha` must be finite and `>= 1.0` — the valid VAMANA range. Values
+    /// below 1.0 under-diversify the graph and silently degrade recall, while
+    /// non-finite values (`NaN`/`inf`) would break the [`Eq`] invariant. Valid
+    /// alpha (the default 1.2 and anything `>= 1.0`) passes unchanged, so this
+    /// is a no-op on every well-formed configuration.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`crate::error::Error::Config`] when `alpha` is out of range.
+    pub fn validate(&self) -> crate::error::Result<()> {
+        if !self.alpha.is_finite() || self.alpha < 1.0 {
+            return Err(crate::error::Error::Config(format!(
+                "hnsw alpha must be finite and >= 1.0 (VAMANA range), got {}",
+                self.alpha
+            )));
+        }
+        Ok(())
     }
 }
 

--- a/crates/velesdb-core/src/index/hnsw/params_tests.rs
+++ b/crates/velesdb-core/src/index/hnsw/params_tests.rs
@@ -438,3 +438,41 @@ fn test_hnsw_params_alpha_backward_compat_missing_field() {
         params.alpha
     );
 }
+
+#[test]
+fn test_validate_accepts_valid_alpha() {
+    // The default and any alpha in the valid VAMANA range (>= 1.0) must pass
+    // unchanged — validate() is a no-op on well-formed configs.
+    for alpha in [1.0_f32, 1.2, 2.0, 10.0] {
+        let params = HnswParams::auto(768).with_alpha(alpha);
+        assert!(
+            params.validate().is_ok(),
+            "alpha {alpha} is in range and must validate"
+        );
+    }
+}
+
+#[test]
+fn test_validate_rejects_alpha_below_one() {
+    // alpha < 1.0 under-diversifies the graph and silently degrades recall.
+    for alpha in [0.99_f32, 0.5, 0.0, -1.0] {
+        let params = HnswParams::auto(768).with_alpha(alpha);
+        let err = params.validate().expect_err("alpha < 1.0 must be rejected");
+        assert!(
+            matches!(err, crate::error::Error::Config(_)),
+            "expected Config error for alpha {alpha}, got {err:?}"
+        );
+    }
+}
+
+#[test]
+fn test_validate_rejects_non_finite_alpha() {
+    // Non-finite alpha (NaN/Inf) would break the Eq invariant; reject it.
+    for alpha in [f32::NAN, f32::INFINITY, f32::NEG_INFINITY] {
+        let params = HnswParams::auto(768).with_alpha(alpha);
+        assert!(
+            params.validate().is_err(),
+            "non-finite alpha {alpha} must be rejected"
+        );
+    }
+}

--- a/crates/velesdb-python/src/database.rs
+++ b/crates/velesdb-python/src/database.rs
@@ -173,7 +173,7 @@ impl Database {
         // Compute the dispatch plan under the GIL — cheap.
         let plan = if let Some(opts) = hnsw {
             CreatePlan::Full {
-                hnsw_params: opts.to_hnsw_params(),
+                hnsw_params: opts.to_hnsw_params()?,
                 pq_rescore_oversampling: opts.pq_rescore_oversampling,
             }
         } else {

--- a/crates/velesdb-python/src/options.rs
+++ b/crates/velesdb-python/src/options.rs
@@ -178,15 +178,22 @@ impl HnswOptions {
 impl HnswOptions {
     /// Materializes this options dataclass into a concrete
     /// [`HnswParams`] by filling in defaults for any unset field.
-    pub(crate) fn to_hnsw_params(&self) -> HnswParams {
+    ///
+    /// Rejects an out-of-range `alpha` (must be finite and `>= 1.0`) with a
+    /// `ValueError`, mirroring the REST and Tauri boundaries.
+    pub(crate) fn to_hnsw_params(&self) -> PyResult<HnswParams> {
         let base = HnswParams::default();
-        HnswParams {
+        let params = HnswParams {
             max_connections: self.m.unwrap_or(base.max_connections),
             ef_construction: self.ef_construction.unwrap_or(base.ef_construction),
             max_elements: self.max_elements.unwrap_or(base.max_elements),
             alpha: self.alpha.unwrap_or(base.alpha),
             storage_mode: base.storage_mode,
-        }
+        };
+        params
+            .validate()
+            .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
+        Ok(params)
     }
 
     /// Shared conversion from a concrete [`HnswParams`] to a fully-

--- a/crates/velesdb-python/tests/test_options.py
+++ b/crates/velesdb-python/tests/test_options.py
@@ -76,6 +76,22 @@ def test_hnsw_options_create_collection_round_trip(tmp_db_path):
     assert col is not None
 
 
+@pytest.mark.parametrize("bad_alpha", [0.5, 0.0, -1.0, float("nan"), float("inf")])
+def test_hnsw_options_create_collection_rejects_invalid_alpha(tmp_db_path, bad_alpha):
+    # alpha must be finite and >= 1.0 (valid VAMANA range); an out-of-range
+    # value from Python must raise ValueError at create_collection, not silently
+    # build a recall-degrading or NaN-bearing index.
+    db = Database(str(tmp_db_path))
+    with pytest.raises(ValueError):
+        db.create_collection("bad", dimension=4, hnsw=HnswOptions(alpha=bad_alpha))
+
+
+def test_hnsw_options_create_collection_accepts_valid_alpha(tmp_db_path):
+    db = Database(str(tmp_db_path))
+    col = db.create_collection("ok", dimension=4, hnsw=HnswOptions(alpha=1.5))
+    assert col is not None
+
+
 # ---------------------------------------------------------------------------
 # LimitsOptions — nominal + edge
 # ---------------------------------------------------------------------------

--- a/crates/velesdb-server/src/handlers/collections.rs
+++ b/crates/velesdb-server/src/handlers/collections.rs
@@ -154,6 +154,11 @@ fn create_vector_collection(
     let base_result = if let Some(hnsw_params) =
         build_hnsw_params_override(req, dimension, storage_mode)
     {
+        // Reject out-of-range tunables (e.g. hnsw_alpha < 1.0 or non-finite)
+        // before any collection is created on disk.
+        hnsw_params
+            .validate()
+            .map_err(|e| error_response(StatusCode::BAD_REQUEST, e.to_string()))?;
         state.db.create_vector_collection_with_params(
             &req.name,
             dimension,


### PR DESCRIPTION
Closes #1014.

## Problem

`alpha` (VAMANA neighbor diversification) was user-settable but **unvalidated** on every public input path — REST `hnsw_alpha`, Python `HnswOptions.alpha`, Tauri `hnsw_alpha`. Two harmful inputs were silently accepted:

- **`alpha < 1.0`** — under-diversifies the graph and silently **degrades recall** (valid VAMANA range is `>= 1.0`; default `1.2`).
- **non-finite `alpha`** (`NaN`/`Inf`, reachable from Python `float('nan')`) — breaks the `impl Eq for HnswParams` "no NaN" invariant.

Surfaced during the 2026-06-05 Rust audit. (The audit's original "clamp `alpha <= 1.0`" suggestion was inverted and would have breached the recall gate — that part was correctly rejected; this is the genuine orthogonal gap.)

## Fix

- **`HnswParams::validate()`** — single source of truth: `alpha` must be finite and `>= 1.0`, else `Error::Config`. Valid alpha passes unchanged -> **no-op on every well-formed config**.
- Called at all three public boundaries: **REST -> 400**, **Python -> `ValueError`**, **Tauri -> config error**. Core `with_alpha`/constructors keep their infallible signatures (used internally with valid constants only).
- Corrects the previously-misleading `impl Eq` safety comment.

Deliberately **not** clamping (silent coercion hides user error) and **not** breaking the public `const fn with_alpha` signature.

## Tests
- Core unit tests (`params_tests.rs`): cover `< 1.0`, `0`, negative, `NaN`, `Inf`, and valid (`1.0`/`1.2`/`2.0`/`10.0`).
- Python (`test_options.py`): parametrized test asserts `create_collection` raises `ValueError` for each invalid alpha, plus a valid-alpha happy path.

## Validation
- `cargo fmt --check` clean, `clippy -D warnings -D pedantic` on core/server/tauri clean, python `-D warnings` clean.
- `index::hnsw` **555 passed**; recall gate intact (accurate>=99, balanced>=95, fast>=90, perfect=100) — confirms `validate()` is a no-op on the search path.

_Note: the local DRY hook flags only pre-existing baseline duplication in untouched files (benches/fixtures/generated `__init__.py`); this change introduces none._