### PR TITLE
chore(release): bump version to 1.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.17.0] — 2026-06-05
+
 ### Fixed
+- **Payload WAL crash recovery (#1011)**: a crash mid-append no longer leaves a
+  collection unopenable — replay now stops cleanly at a torn-tail record and
+  keeps every prior entry (mirrors the vector WAL's torn-tail policy).
+- **Vector retrieve overflow guard (#1012)**: the copy-path bounds check now
+  uses checked arithmetic so a corrupt near-`usize::MAX` index offset returns an
+  error instead of panicking on the slice.
+- **Hybrid fusion weight validation (#1013)**: `Weighted` / `RelativeScore`
+  weights are now validated on the `fuse()` path, so strategies built directly
+  from server/CLI/SDK request fields can no longer yield unnormalized scores.
+- **HNSW alpha validation (#1015)**: an out-of-range `alpha` (`< 1.0` or
+  non-finite) is now rejected at the REST (`400 Bad Request`), Python
+  (`ValueError`) and Tauri boundaries instead of silently degrading recall or
+  violating the `HnswParams` `Eq` invariant. Valid `alpha` (default `1.2`,
+  anything `>= 1.0`) is unaffected.
 - OpenAPI spec now types point `id` as `string` for `/search`, `/search/ids`,
   `/scroll` and graph result endpoints, matching the on-the-wire format (these
   responses quote the ID to preserve `u64` values above `2^53-1`). Schema-only

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5562,7 +5562,7 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-velesdb"
-version = "1.16.0"
+version = "1.17.0"
 dependencies = [
  "dirs",
  "parking_lot",
@@ -6560,7 +6560,7 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "velesdb-cli"
-version = "1.16.0"
+version = "1.17.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -6585,7 +6585,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-core"
-version = "1.16.0"
+version = "1.17.0"
 dependencies = [
  "arc-swap",
  "bytemuck",
@@ -6640,7 +6640,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-migrate"
-version = "1.16.0"
+version = "1.17.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6668,7 +6668,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-mobile"
-version = "1.16.0"
+version = "1.17.0"
 dependencies = [
  "parking_lot",
  "serde_json",
@@ -6682,7 +6682,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-python"
-version = "1.16.0"
+version = "1.17.0"
 dependencies = [
  "numpy",
  "parking_lot",
@@ -6694,7 +6694,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-server"
-version = "1.16.0"
+version = "1.17.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -6727,7 +6727,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-wasm"
-version = "1.16.0"
+version = "1.17.0"
 dependencies = [
  "getrandom 0.3.4",
  "getrandom 0.4.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "1.16.0"
+version = "1.17.0"
 edition = "2021"
 rust-version = "1.89"
 license-file = "LICENSE"

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM rust:1.96-bookworm AS builder
 
 LABEL maintainer="VelesDB Team <contact@wiscale.fr>"
-LABEL version="1.16.0"
+LABEL version="1.17.0"
 
 WORKDIR /app
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,7 +4,7 @@ This roadmap commits to **what we are building**, **why**, and **when**. It is u
 
 It is intentionally narrow. Items not on this roadmap are tracked as `roadmap` issues but **not committed** until they reach a milestone here.
 
-> **Last updated:** 2026-05-31 — covers v1.16.0 (current) → v1.17.0 horizon.
+> **Last updated:** 2026-05-31 — covers v1.17.0 (current) → v1.17.0 horizon.
 
 ---
 

--- a/benchmarks/Dockerfile.bench
+++ b/benchmarks/Dockerfile.bench
@@ -6,7 +6,7 @@
 FROM debian:bookworm-slim
 
 LABEL maintainer="VelesDB Team <contact@wiscale.fr>"
-LABEL version="1.16.0"
+LABEL version="1.17.0"
 
 WORKDIR /app
 

--- a/benchmarks/Dockerfile.nightly
+++ b/benchmarks/Dockerfile.nightly
@@ -4,7 +4,7 @@
 FROM rust:slim-bookworm AS builder
 
 LABEL maintainer="VelesDB Team <contact@wiscale.fr>"
-LABEL version="1.16.0"
+LABEL version="1.17.0"
 
 WORKDIR /app
 

--- a/benchmarks/Dockerfile.optimized
+++ b/benchmarks/Dockerfile.optimized
@@ -7,7 +7,7 @@
 FROM rust:slim-bookworm AS builder
 
 LABEL maintainer="VelesDB Team <contact@wiscale.fr>"
-LABEL version="1.16.0"
+LABEL version="1.17.0"
 
 WORKDIR /app
 

--- a/crates/tauri-plugin-velesdb/guest-js/package.json
+++ b/crates/tauri-plugin-velesdb/guest-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wiscale/tauri-plugin-velesdb",
-  "version": "1.16.0",
+  "version": "1.17.0",
   "description": "TypeScript bindings for the VelesDB Tauri plugin - Vector search in desktop apps",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/crates/velesdb-python/README.md
+++ b/crates/velesdb-python/README.md
@@ -3,7 +3,7 @@
 [![PyPI](https://img.shields.io/pypi/v/velesdb)](https://pypi.org/project/velesdb/)
 [![Python](https://img.shields.io/pypi/pyversions/velesdb)](https://pypi.org/project/velesdb/)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
-[![Version](https://img.shields.io/badge/version-1.16.0-blue)](https://github.com/cyberlife-coder/VelesDB/releases)
+[![Version](https://img.shields.io/badge/version-1.17.0-blue)](https://github.com/cyberlife-coder/VelesDB/releases)
 
 Python bindings for [VelesDB](https://github.com/cyberlife-coder/VelesDB) — a high-performance vector database for AI applications. The current published wheel is `velesdb` v1.16.0; `numpy>=1.20` ships as a hard runtime dependency since v1.13.8 so a single `pip install velesdb` is sufficient.
 

--- a/crates/velesdb-python/pyproject.toml
+++ b/crates/velesdb-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "velesdb"
-version = "1.16.0"
+version = "1.17.0"
 description = "VelesDB: The Local Vector Database for Python & AI. Microsecond semantic search, zero network latency."
 readme = "README.md"
 license = { text = "MIT" }

--- a/crates/velesdb-server/README.md
+++ b/crates/velesdb-server/README.md
@@ -659,7 +659,7 @@ curl http://localhost:8080/health
 Response:
 
 ```json
-{"status": "ok", "version": "1.16.0"}
+{"status": "ok", "version": "1.17.0"}
 ```
 
 ### `GET /ready` -- Readiness Probe

--- a/demos/rag-pdf-demo/pyproject.toml
+++ b/demos/rag-pdf-demo/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "velesdb-rag-demo"
-version = "1.16.0"
+version = "1.17.0"
 description = "RAG Demo with PDF ingestion using VelesDB for vector storage"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/demos/rag-pdf-demo/src/__init__.py
+++ b/demos/rag-pdf-demo/src/__init__.py
@@ -1,3 +1,3 @@
 """VelesDB RAG Demo - PDF Question Answering System."""
 
-__version__ = "1.16.0"
+__version__ = "1.17.0"

--- a/demos/rag-pdf-demo/src/main.py
+++ b/demos/rag-pdf-demo/src/main.py
@@ -46,7 +46,7 @@ async def lifespan(app: FastAPI):
 app = FastAPI(
     title="VelesDB RAG Demo",
     description="PDF Question Answering with VelesDB vector search",
-    version="1.16.0",
+    version="1.17.0",
     lifespan=lifespan
 )
 

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -1,6 +1,6 @@
 # VelesDB Performance Benchmarks
 
-*Last updated: May 1, 2026 (v1.16.0)*
+*Last updated: May 1, 2026 (v1.17.0)*
 
 ---
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -96,7 +96,7 @@ Expected response:
 ```json
 {
   "status": "ok",
-  "version": "1.16.0"
+  "version": "1.17.0"
 }
 ```
 

--- a/docs/guides/CLI_REPL.md
+++ b/docs/guides/CLI_REPL.md
@@ -1,6 +1,6 @@
 # 💻 CLI & REPL Reference
 
-*Version 1.16.0 — May 2026*
+*Version 1.17.0 — May 2026*
 
 Guide complet pour l'interface en ligne de commande VelesDB et le REPL interactif.
 

--- a/docs/guides/CONFIGURATION.md
+++ b/docs/guides/CONFIGURATION.md
@@ -1,6 +1,6 @@
 # ⚙️ VelesDB Configuration
 
-*Version 1.16.0 — May 2026*
+*Version 1.17.0 — May 2026*
 
 Complete guide for configuring VelesDB via configuration file, environment variables, and runtime parameters.
 
@@ -62,7 +62,7 @@ data_dir = "./data"
 ```toml
 # =============================================================================
 # VelesDB Configuration File
-# Version: 1.16.0
+# Version: 1.17.0
 # =============================================================================
 
 # -----------------------------------------------------------------------------

--- a/docs/guides/GRAPH_PATTERNS.md
+++ b/docs/guides/GRAPH_PATTERNS.md
@@ -1,6 +1,6 @@
 # Graph Patterns Guide
 
-*Version 1.16.0 -- May 2026*
+*Version 1.17.0 -- May 2026*
 
 Practical guide for using VelesQL `MATCH` graph patterns in VelesDB.
 

--- a/docs/guides/INSTALLATION.md
+++ b/docs/guides/INSTALLATION.md
@@ -60,10 +60,10 @@ entry.
 
 ```bash
 # Download
-wget https://github.com/cyberlife-coder/VelesDB/releases/download/v1.16.0/velesdb-1.16.0-amd64.deb
+wget https://github.com/cyberlife-coder/VelesDB/releases/download/v1.16.0/velesdb-1.17.0-amd64.deb
 
 # Install
-sudo dpkg -i velesdb-1.16.0-amd64.deb
+sudo dpkg -i velesdb-1.17.0-amd64.deb
 
 # Verify
 velesdb --version
@@ -160,13 +160,13 @@ GitHub Container Registry, so you don't need to build locally:
 
 ```bash
 # Pull a specific release (recommended for reproducibility)
-docker pull ghcr.io/cyberlife-coder/velesdb:1.16.0
+docker pull ghcr.io/cyberlife-coder/velesdb:1.17.0
 
 # ...or the latest stable release
 docker pull ghcr.io/cyberlife-coder/velesdb:latest
 
 docker run -d --name velesdb -p 8080:8080 -v velesdb_data:/data \
-  ghcr.io/cyberlife-coder/velesdb:1.16.0
+  ghcr.io/cyberlife-coder/velesdb:1.17.0
 ```
 
 ### Build locally

--- a/docs/guides/SEARCH_MODES.md
+++ b/docs/guides/SEARCH_MODES.md
@@ -1,6 +1,6 @@
 # 🎯 Search Modes - Guide de Configuration du Recall
 
-*Version 1.16.0 -- Mai 2026*
+*Version 1.17.0 -- Mai 2026*
 
 Guide complet pour configurer le compromis **recall vs latence** dans VelesDB. Couvre la recherche dense (HNSW), sparse (SPLADE/BM42), et hybride (dense+sparse avec fusion). Comparaison avec les pratiques Milvus, OpenSearch et Qdrant.
 

--- a/docs/guides/SERVER_SECURITY.md
+++ b/docs/guides/SERVER_SECURITY.md
@@ -299,7 +299,7 @@ curl http://localhost:8080/health
 ```json
 {
   "status": "ok",
-  "version": "1.16.0"
+  "version": "1.17.0"
 }
 ```
 

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -11,7 +11,7 @@
       "name": "VelesDB Core License 1.0",
       "url": "https://github.com/cyberlife-coder/VelesDB/blob/main/LICENSE"
     },
-    "version": "1.16.0"
+    "version": "1.17.0"
   },
   "servers": [
     {

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -8,7 +8,7 @@ info:
   license:
     name: VelesDB Core License 1.0
     url: https://github.com/cyberlife-coder/VelesDB/blob/main/LICENSE
-  version: 1.16.0
+  version: 1.17.0
 servers:
 - url: /
   description: Local server

--- a/docs/reference/ARCHITECTURE_DIAGRAMS.md
+++ b/docs/reference/ARCHITECTURE_DIAGRAMS.md
@@ -1,4 +1,4 @@
-# VelesDB Architecture Diagrams — v1.16.0
+# VelesDB Architecture Diagrams — v1.17.0
 
 ## 1. Workspace Dependency Graph
 

--- a/docs/reference/ECOSYSTEM_PARITY.md
+++ b/docs/reference/ECOSYSTEM_PARITY.md
@@ -1,6 +1,6 @@
 # VelesQL Ecosystem Parity Matrix
 
-Last updated: 2026-05-29 (v1.16.0 — Mobile graph collection creation parity correction)
+Last updated: 2026-05-29 (v1.17.0 — Mobile graph collection creation parity correction)
 
 This matrix tracks runtime contract and feature parity across the VelesDB ecosystem.
 

--- a/docs/reference/VELESQL_CONFORMANCE_MATRIX.md
+++ b/docs/reference/VELESQL_CONFORMANCE_MATRIX.md
@@ -4,7 +4,7 @@ This document lists every VelesQL feature with its parser and executor status.
 A feature can be **Parsed** (the grammar + AST accept it) without being
 **Executed** (the query engine acts on it at runtime).
 
-> Last updated: 2026-05-01 (v3.9.0 / VelesDB v1.16.0)
+> Last updated: 2026-05-01 (v3.9.0 / VelesDB v1.17.0)
 
 ## Fully Supported (Parsed AND Executed)
 

--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -53,7 +53,7 @@ Check server health status.
 ```json
 {
   "status": "ok",
-  "version": "1.16.0"
+  "version": "1.17.0"
 }
 ```
 

--- a/examples/wasm-browser-demo/README.md
+++ b/examples/wasm-browser-demo/README.md
@@ -22,7 +22,7 @@ cd crates/velesdb-wasm
 wasm-pack build --target web --out-dir ../../examples/wasm-browser-demo/pkg
 
 # Then update index.html to use the local path instead of CDN:
-# Change: import init from 'https://unpkg.com/@wiscale/velesdb-wasm@1.16.0/velesdb_wasm.js'
+# Change: import init from 'https://unpkg.com/@wiscale/velesdb-wasm@1.17.0/velesdb_wasm.js'
 # To:     import init from './pkg/velesdb_wasm.js'
 ```
 
@@ -80,7 +80,7 @@ Typical results on modern hardware:
 ```html
 <script type="module">
   // If published on npm:
-  // import init, { VectorStore } from 'https://unpkg.com/@wiscale/velesdb-wasm@1.16.0/velesdb_wasm.js';
+  // import init, { VectorStore } from 'https://unpkg.com/@wiscale/velesdb-wasm@1.17.0/velesdb_wasm.js';
   // If built locally with wasm-pack:
   import init, { VectorStore } from './pkg/velesdb_wasm.js';
 

--- a/examples/wasm-browser-demo/index.html
+++ b/examples/wasm-browser-demo/index.html
@@ -171,8 +171,8 @@
         // WASM module - tracks @wiscale/velesdb-wasm@<workspace> with CDN fallback.
         // Bumped by scripts/bump-version.ps1 on every release; if you copy this
         // demo, update the version below to match `@wiscale/velesdb-wasm` on npm.
-        const WASM_CDN_PRIMARY = 'https://unpkg.com/@wiscale/velesdb-wasm@1.16.0/velesdb_wasm.js';
-        const WASM_CDN_FALLBACK = 'https://cdn.jsdelivr.net/npm/@wiscale/velesdb-wasm@1.16.0/velesdb_wasm.js';
+        const WASM_CDN_PRIMARY = 'https://unpkg.com/@wiscale/velesdb-wasm@1.17.0/velesdb_wasm.js';
+        const WASM_CDN_FALLBACK = 'https://cdn.jsdelivr.net/npm/@wiscale/velesdb-wasm@1.17.0/velesdb_wasm.js';
         
         let init, VectorStore;
         

--- a/integrations/common/pyproject.toml
+++ b/integrations/common/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "velesdb-common"
-version = "1.16.0"
+version = "1.17.0"
 description = "Shared utilities for VelesDB Python integrations (internal use)"
 readme = "README.md"
 license = {text = "MIT"}

--- a/integrations/haystack/pyproject.toml
+++ b/integrations/haystack/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "haystack-velesdb"
-version = "1.16.0"
+version = "1.17.0"
 description = "Haystack 2.x DocumentStore for VelesDB: The Local AI Memory Database."
 readme = "README.md"
 license = {text = "MIT"}

--- a/integrations/haystack/src/haystack_velesdb/__init__.py
+++ b/integrations/haystack/src/haystack_velesdb/__init__.py
@@ -3,4 +3,4 @@
 from haystack_velesdb.document_store import VelesDBDocumentStore
 
 __all__ = ["VelesDBDocumentStore"]
-__version__ = "1.16.0"
+__version__ = "1.17.0"

--- a/integrations/langchain/pyproject.toml
+++ b/integrations/langchain/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "langchain-velesdb"
-version = "1.16.0"
+version = "1.17.0"
 description = "LangChain VectorStore for VelesDB: The Local AI Memory Database. Microsecond RAG retrieval."
 readme = "README.md"
 license = {text = "MIT"}

--- a/integrations/langchain/src/langchain_velesdb/__init__.py
+++ b/integrations/langchain/src/langchain_velesdb/__init__.py
@@ -53,4 +53,4 @@ if _HAS_MEMORY:
         "VelesDBSemanticMemory",
         "VelesDBProceduralMemory",
     ])
-__version__ = "1.16.0"
+__version__ = "1.17.0"

--- a/integrations/llamaindex/pyproject.toml
+++ b/integrations/llamaindex/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "llama-index-vector-stores-velesdb"
-version = "1.16.0"
+version = "1.17.0"
 description = "LlamaIndex VectorStore for VelesDB: The Local AI Memory Database. Microsecond RAG retrieval."
 readme = "README.md"
 license = "MIT"

--- a/integrations/llamaindex/src/llamaindex_velesdb/__init__.py
+++ b/integrations/llamaindex/src/llamaindex_velesdb/__init__.py
@@ -46,4 +46,4 @@ if _HAS_MEMORY:
         "VelesDBEpisodicMemory",
         "VelesDBProceduralMemory",
     ])
-__version__ = "1.16.0"
+__version__ = "1.17.0"

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""Bump the workspace version across every policed manifest.
+
+Python port of `bump-version.ps1` (pwsh is unavailable on some maintainer
+machines). The set of files and the per-format patterns are kept in lock-step
+with `check-version-sync.py`, which is the authoritative gate: run this script,
+then run `check-version-sync.py` to prove every location landed on the new
+version.
+
+`docs/openapi.{json,yaml}` are intentionally NOT rewritten here — they are
+generated from the crate version. Regenerate them after bumping Cargo.toml with:
+
+    cargo test -p velesdb-server --features openapi generate_openapi_spec_files -- --test-threads=1
+
+Usage:
+    python3 scripts/bump_version.py 1.17.0
+"""
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+VERSION_RE = r"\d+\.\d+\.\d+"
+
+# (relative_path, format) — mirrors check-version-sync.py TARGETS, minus the two
+# generated OpenAPI specs (regenerated from code, see module docstring).
+TARGETS: "list[tuple[str, str]]" = [
+    ("crates/velesdb-python/pyproject.toml", "toml"),
+    ("crates/tauri-plugin-velesdb/guest-js/package.json", "json"),
+    ("integrations/common/pyproject.toml", "toml"),
+    ("integrations/langchain/pyproject.toml", "toml"),
+    ("integrations/llamaindex/pyproject.toml", "toml"),
+    ("integrations/haystack/pyproject.toml", "toml"),
+    ("integrations/haystack/src/haystack_velesdb/__init__.py", "py_init_version"),
+    ("examples/wasm-browser-demo/index.html", "wasm_cdn_url"),
+    ("docs/guides/CONFIGURATION.md", "doc_toml_header"),
+    ("crates/velesdb-server/README.md", "doc_health_snippet"),
+    ("crates/velesdb-python/README.md", "doc_version_badge"),
+    ("demos/rag-pdf-demo/pyproject.toml", "toml"),
+    ("sdks/typescript/package.json", "json"),
+    ("sdks/typescript/package-lock.json", "json"),
+    ("docs/getting-started.md", "doc_health_snippet"),
+    ("docs/reference/api-reference.md", "doc_health_snippet"),
+    ("docs/guides/SERVER_SECURITY.md", "doc_health_snippet"),
+    ("Dockerfile", "dockerfile_label"),
+    ("benchmarks/Dockerfile.optimized", "dockerfile_label"),
+    ("benchmarks/Dockerfile.nightly", "dockerfile_label"),
+    ("benchmarks/Dockerfile.bench", "dockerfile_label"),
+    ("integrations/langchain/src/langchain_velesdb/__init__.py", "py_init_version"),
+    ("integrations/llamaindex/src/llamaindex_velesdb/__init__.py", "py_init_version"),
+    ("sdks/typescript/README.md", "ts_sdk_banner"),
+    ("ROADMAP.md", "roadmap_current"),
+    ("docs/guides/CLI_REPL.md", "doc_guide_version_header"),
+    ("docs/guides/CONFIGURATION.md", "doc_guide_version_header"),
+    ("docs/guides/GRAPH_PATTERNS.md", "doc_guide_version_header"),
+    ("docs/guides/SEARCH_MODES.md", "doc_guide_version_header"),
+    ("docs/BENCHMARKS.md", "doc_last_updated_version"),
+    ("docs/reference/ECOSYSTEM_PARITY.md", "doc_last_updated_version"),
+    ("docs/reference/VELESQL_CONFORMANCE_MATRIX.md", "doc_last_updated_version"),
+    ("docs/reference/ARCHITECTURE_DIAGRAMS.md", "md_title_version"),
+    ("scripts/dx-timing/scenario_rust.sh", "cargo_pin"),
+    ("scripts/dx-timing/scenario_server.sh", "cargo_pin"),
+    ("docs/guides/INSTALLATION.md", "ghcr_image"),
+    ("demos/rag-pdf-demo/src/__init__.py", "py_init_version"),
+    ("demos/rag-pdf-demo/src/main.py", "fastapi_app_version"),
+    ("examples/wasm-browser-demo/README.md", "wasm_cdn_url"),
+    ("docs/guides/INSTALLATION.md", "deb_release_tag"),
+]
+
+
+def _sub_first(text: str, pattern: str, repl: str, flags: int = 0) -> "tuple[str, int]":
+    """Replace only the first match, returning (new_text, count)."""
+    return re.subn(pattern, repl, text, count=1, flags=flags)
+
+
+def _sub_all(text: str, pattern: str, repl: str, flags: int = 0) -> "tuple[str, int]":
+    return re.subn(pattern, repl, text, flags=flags)
+
+
+def _bump_last_updated(text: str, ver: str) -> "tuple[str, int]":
+    """Rewrite the version on the single `Last updated: ...` stamp line.
+
+    Prefer the disambiguated `VelesDB vX.Y.Z`; otherwise the first `(vX.Y.Z`.
+    """
+    m = re.search(r"Last updated:[^\n]*", text)
+    if not m:
+        return text, 0
+    line = m.group(0)
+    if re.search(r"VelesDB v" + VERSION_RE, line):
+        new_line = re.sub(r"(VelesDB v)" + VERSION_RE, r"\g<1>" + ver, line, count=1)
+    else:
+        new_line = re.sub(r"(\(v)" + VERSION_RE, r"\g<1>" + ver, line, count=1)
+    if new_line == line:
+        return text, 0
+    return text[: m.start()] + new_line + text[m.end():], 1
+
+
+def bump_file(path: Path, fmt: str, ver: str) -> int:
+    """Apply the format-specific rewrite. Returns number of replacements."""
+    text = text0 = path.read_text(encoding="utf-8")
+    ML = re.MULTILINE
+    if fmt == "toml":
+        text, n = _sub_first(text, r'(?m)^(\s*version\s*=\s*")' + VERSION_RE + r'(")', r"\g<1>" + ver + r"\g<2>")
+    elif fmt == "json":
+        text, n = _sub_first(text, r'("version"\s*:\s*")' + VERSION_RE + r'(")', r"\g<1>" + ver + r"\g<2>")
+    elif fmt == "doc_health_snippet":
+        text, n = _sub_first(text, r'("version":\s*")' + VERSION_RE + r'(")', r"\g<1>" + ver + r"\g<2>")
+    elif fmt == "py_init_version":
+        text, n = _sub_first(text, r'(__version__\s*=\s*")' + VERSION_RE + r'(")', r"\g<1>" + ver + r"\g<2>")
+    elif fmt == "wasm_cdn_url":
+        text, n = _sub_all(text, r"(@wiscale/velesdb-wasm@)" + VERSION_RE + r"(/)", r"\g<1>" + ver + r"\g<2>")
+    elif fmt == "doc_toml_header":
+        text, n = _sub_first(text, r"(?m)^(#\s*Version:\s*)" + VERSION_RE, r"\g<1>" + ver)
+    elif fmt == "doc_version_badge":
+        text, n = _sub_first(text, r"(version-)" + VERSION_RE + r"(-blue)", r"\g<1>" + ver + r"\g<2>")
+    elif fmt == "dockerfile_label":
+        text, n = _sub_first(text, r'(?m)^(LABEL\s+version=")[^"]+(")', r"\g<1>" + ver + r"\g<2>")
+    elif fmt == "doc_guide_version_header":
+        text, n = _sub_first(text, r"(?m)^(\*(?:Version|Stable since v) )" + VERSION_RE, r"\g<1>" + ver)
+    elif fmt == "md_title_version":
+        text, n = _sub_first(text, r"(?m)^(#[^\n]*?[—-]\s*v)" + VERSION_RE, r"\g<1>" + ver)
+    elif fmt == "roadmap_current":
+        text, n = _sub_first(text, r"(covers v)" + VERSION_RE + r"( \(current\))", r"\g<1>" + ver + r"\g<2>")
+    elif fmt == "ts_sdk_banner":
+        text, n = _sub_first(text, r"(?m)^(\*\*v)" + VERSION_RE + r"(\*\*)", r"\g<1>" + ver + r"\g<2>")
+    elif fmt == "cargo_pin":
+        text, n = _sub_all(text, r"(velesdb-(?:core|server|cli)@)" + VERSION_RE, r"\g<1>" + ver)
+    elif fmt == "ghcr_image":
+        text, n = _sub_all(text, r"(ghcr\.io/cyberlife-coder/velesdb:)" + VERSION_RE, r"\g<1>" + ver)
+    elif fmt == "fastapi_app_version":
+        text, n = _sub_first(text, r'(\bversion\s*=\s*")' + VERSION_RE + r'(")', r"\g<1>" + ver + r"\g<2>")
+    elif fmt == "deb_release_tag":
+        text, n = _sub_all(text, r"(velesdb-)" + VERSION_RE + r"(-amd64\.deb)", r"\g<1>" + ver + r"\g<2>")
+    elif fmt == "doc_last_updated_version":
+        text, n = _bump_last_updated(text, ver)
+    else:
+        raise RuntimeError(f"Unknown format '{fmt}' for {path}")
+    if n and text != text0:
+        path.write_text(text, encoding="utf-8")
+    return n
+
+
+def bump_cargo_workspace(ver: str) -> int:
+    """Bump `version` inside the [workspace.package] section of root Cargo.toml."""
+    path = REPO_ROOT / "Cargo.toml"
+    text = path.read_text(encoding="utf-8")
+    idx = text.find("[workspace.package]")
+    if idx == -1:
+        raise RuntimeError("No [workspace.package] section in Cargo.toml")
+    head, section = text[:idx], text[idx:]
+    section, n = re.subn(r'(?m)^(version\s*=\s*")[^"]+(")', r"\g<1>" + ver + r"\g<2>", section, count=1)
+    if n:
+        path.write_text(head + section, encoding="utf-8")
+    return n
+
+
+def main() -> int:
+    if len(sys.argv) != 2 or not re.fullmatch(VERSION_RE + r"(-[0-9A-Za-z.]+)?", sys.argv[1]):
+        print("usage: bump_version.py X.Y.Z", file=sys.stderr)
+        return 2
+    ver = sys.argv[1]
+
+    total = bump_cargo_workspace(ver)
+    print(f"  Cargo.toml [workspace.package]: {total} change(s)")
+    for rel, fmt in TARGETS:
+        path = REPO_ROOT / rel
+        if not path.exists():
+            print(f"  SKIP {rel} (missing)")
+            continue
+        n = bump_file(path, fmt, ver)
+        total += n
+        flag = "OK  " if n else "MISS"  # MISS = pattern matched nothing; investigate
+        print(f"  {flag} {rel} [{fmt}]: {n}")
+    print(f"\nBumped {total} location(s) to {ver}.")
+    print("Next: regenerate OpenAPI, refresh Cargo.lock, then run check-version-sync.py.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/dx-timing/scenario_rust.sh
+++ b/scripts/dx-timing/scenario_rust.sh
@@ -41,7 +41,7 @@ RS
 # Pin to the latest released version on crates.io. Bump alongside each
 # workspace release; the timing measurement is meant to track the path a
 # fresh dev hits when they `cargo add velesdb-core` today.
-cargo add --quiet velesdb-core@1.16.0
+cargo add --quiet velesdb-core@1.17.0
 cargo add --quiet serde_json@1
 cargo run --quiet --release
 

--- a/scripts/dx-timing/scenario_server.sh
+++ b/scripts/dx-timing/scenario_server.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 
 START=$(date +%s.%N)
 
-cargo install --quiet --locked velesdb-server@1.16.0
+cargo install --quiet --locked velesdb-server@1.17.0
 
 DATA_DIR=$(mktemp -d -t velesdb_dx_server_XXXX)
 trap 'rm -rf "$DATA_DIR"' EXIT

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -2,7 +2,7 @@
 
 Official TypeScript SDK for [VelesDB](https://github.com/cyberlife-coder/VelesDB) -- the local-first vector database for AI and RAG. Sub-millisecond semantic search in Browser and Node.js.
 
-**v1.16.0** | Node.js >= 18 | Browser (WASM) | MIT License
+**v1.17.0** | Node.js >= 18 | Browser (WASM) | MIT License
 
 ## What's New in v1.16.0
 

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@wiscale/velesdb-sdk",
-  "version": "1.16.0",
+  "version": "1.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wiscale/velesdb-sdk",
-  "version": "1.16.0",
+  "version": "1.17.0",
   "description": "VelesDB TypeScript SDK: The Local Vector Database for AI & RAG. Microsecond semantic search in Browser & Node.js.",
   "main": "dist/index.js",
   "module": "dist/index.mjs",


### PR DESCRIPTION
Version-bump prep for the **1.17.0** release. The actual publish (cut to `main` + tag `v1.17.0`) remains a maintainer step — see **Release steps** below.

## What this does
- Bumps the workspace + **every policed manifest** 1.16.0 → 1.17.0. `check-version-sync.py` is **green across all 35 locations**.
- Regenerates `docs/openapi.{json,yaml}` (info.version 1.17.0) and refreshes `Cargo.lock` (only the 8 `velesdb-*` crate versions change).
- Moves CHANGELOG `[Unreleased]` under a `1.17.0` section + documents the 4 fixes landed since the 1.16.0 tag: #1011 (WAL torn-tail), #1012 (retrieve overflow guard), #1013 (fusion weight validation), #1015 (HNSW alpha validation).
- Adds **`scripts/bump_version.py`** — a Python port of `bump-version.ps1` (pwsh is unavailable on some maintainer machines), validated by `check-version-sync.py`.

## ⚠️ npm was a release behind — root cause + required action
The npm registry `@wiscale/velesdb-sdk` latest is **1.15.0**: the **1.16.0 npm publish failed silently on an expired `NPM_TOKEN`** (already documented in `release.yml` lines 484-487; the job was since hardened to fail loudly). PyPI/crates/docker all shipped 1.16.0 correctly.

**Before tagging v1.17.0**, refresh the **`NPM_TOKEN`** secret (GitHub environment `npm`) — otherwise `publish-npm` fails again (loudly this time). Publishing 1.17.0 makes npm current again; the missing 1.16.0 on npm is a harmless historical gap.

## Release steps (maintainer, after this merges)
1. Refresh the `NPM_TOKEN` secret (environment `npm`).
2. Cut `develop` → `main` (the repo's release flow) and push tag **`v1.17.0`** → `release.yml` publishes crates.io + PyPI + **npm** + GHCR.
3. Back-merge `main` → `develop`.
4. **Post-publish**: bump the npm dependency pins in `examples/react-wasm-search` and `examples/node-express-rag` (currently `1.15.0`) to `1.17.0` — they are `npm ci` consumers and can only pin a version that already exists on the registry (intentionally not policed by `check-version-sync.py`).

## Notes
- The `examples/*` npm pins are deliberately **not** bumped here (would break `propagation-guard.yml` `npm ci` until 1.17.0 is on the registry).
- No source-logic changes; `cargo fmt --check` clean, workspace builds at 1.17.0 (OpenAPI regen compiled `velesdb-server`).