### PR TITLE
feat(graph): honor full MATCH pattern semantics in VelesQL + align REST/SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,7 +371,9 @@ RETURN author.name, doc.title
 ORDER BY similarity() DESC LIMIT 5
 ```
 
-Cross-collection MATCH with `@collection` annotation:
+Cross-collection MATCH with `@collection` annotation — traversal runs on the
+primary collection's edge store; `@collection` enriches the matched node's
+payload from another collection (it is not a distributed cross-graph traversal):
 
 ```sql
 MATCH (p:Product@products)-[:STORED_IN]->(inv:Inventory@inventory)

--- a/crates/velesdb-cli/src/helpers.rs
+++ b/crates/velesdb-cli/src/helpers.rs
@@ -87,14 +87,11 @@ impl<'a> BatchImporter<'a> {
 pub fn create_progress_bar(total: usize, show: bool) -> ProgressBar {
     if show {
         let pb = ProgressBar::new(total as u64);
-        pb.set_style(
-            ProgressStyle::default_bar()
-                .template(
-                    "{spinner:.green} [{elapsed_precise}] [{bar:40.cyan/blue}] {pos}/{len} ({eta})",
-                )
-                .expect("hardcoded progress bar template is valid")
-                .progress_chars("#>-"),
-        );
+        if let Ok(style) = ProgressStyle::default_bar().template(
+            "{spinner:.green} [{elapsed_precise}] [{bar:40.cyan/blue}] {pos}/{len} ({eta})",
+        ) {
+            pb.set_style(style.progress_chars("#>-"));
+        }
         pb
     } else {
         ProgressBar::hidden()

--- a/crates/velesdb-cli/src/repl_graph_cmds.rs
+++ b/crates/velesdb-cli/src/repl_graph_cmds.rs
@@ -59,6 +59,25 @@ fn resolve_graph_collection(
         .ok_or_else(|| CommandResult::Error(format!("Graph collection '{name}' not found")))
 }
 
+/// Resolves the `<collection> <node_id>` argument prefix shared by node-scoped
+/// `.graph` subcommands. Prints `usage` and returns `Err(Continue)` when fewer
+/// than `min_arity` arguments are supplied; otherwise propagates any
+/// resolve/parse error.
+fn resolve_collection_and_node(
+    db: &Database,
+    parts: &[&str],
+    min_arity: usize,
+    usage: &str,
+) -> Result<(velesdb_core::GraphCollection, u64), CommandResult> {
+    if parts.len() < min_arity {
+        println!("{usage}\n");
+        return Err(CommandResult::Continue);
+    }
+    let col = resolve_graph_collection(db, parts, 2)?;
+    let node_id = parse_node_id(parts, 3)?;
+    Ok((col, node_id))
+}
+
 fn cmd_graph_add_edge(db: &Database, parts: &[&str]) -> CommandResult {
     if parts.len() < 7 {
         println!("Usage: .graph add-edge <collection> <id> <source> <target> <label>\n");
@@ -118,15 +137,12 @@ fn cmd_graph_edges(db: &Database, parts: &[&str]) -> CommandResult {
 }
 
 fn cmd_graph_degree(db: &Database, parts: &[&str]) -> CommandResult {
-    if parts.len() < 4 {
-        println!("Usage: .graph degree <collection> <node_id>\n");
-        return CommandResult::Continue;
-    }
-    let col = match resolve_graph_collection(db, parts, 2) {
-        Ok(c) => c,
-        Err(r) => return r,
-    };
-    let node_id: u64 = match parse_node_id(parts, 3) {
+    let (col, node_id) = match resolve_collection_and_node(
+        db,
+        parts,
+        4,
+        "Usage: .graph degree <collection> <node_id>",
+    ) {
         Ok(v) => v,
         Err(r) => return r,
     };
@@ -137,15 +153,12 @@ fn cmd_graph_degree(db: &Database, parts: &[&str]) -> CommandResult {
 }
 
 fn cmd_graph_traverse(db: &Database, parts: &[&str]) -> CommandResult {
-    if parts.len() < 4 {
-        println!("Usage: .graph traverse <collection> <source> [--algo bfs|dfs] [--depth N] [--limit N] [--rel-types X,Y]\n");
-        return CommandResult::Continue;
-    }
-    let col = match resolve_graph_collection(db, parts, 2) {
-        Ok(c) => c,
-        Err(r) => return r,
-    };
-    let source: u64 = match parse_node_id(parts, 3) {
+    let (col, source) = match resolve_collection_and_node(
+        db,
+        parts,
+        4,
+        "Usage: .graph traverse <collection> <source> [--algo bfs|dfs] [--depth N] [--limit N] [--rel-types X,Y]",
+    ) {
         Ok(v) => v,
         Err(r) => return r,
     };
@@ -183,15 +196,12 @@ fn cmd_graph_traverse(db: &Database, parts: &[&str]) -> CommandResult {
 }
 
 fn cmd_graph_neighbors(db: &Database, parts: &[&str]) -> CommandResult {
-    if parts.len() < 4 {
-        println!("Usage: .graph neighbors <collection> <node_id> [--direction in|out|both]\n");
-        return CommandResult::Continue;
-    }
-    let col = match resolve_graph_collection(db, parts, 2) {
-        Ok(c) => c,
-        Err(r) => return r,
-    };
-    let node_id: u64 = match parse_node_id(parts, 3) {
+    let (col, node_id) = match resolve_collection_and_node(
+        db,
+        parts,
+        4,
+        "Usage: .graph neighbors <collection> <node_id> [--direction in|out|both]",
+    ) {
         Ok(v) => v,
         Err(r) => return r,
     };
@@ -329,15 +339,12 @@ fn cmd_graph_search(db: &Database, parts: &[&str]) -> CommandResult {
 }
 
 fn cmd_graph_store_payload(db: &Database, parts: &[&str]) -> CommandResult {
-    if parts.len() < 5 {
-        println!("Usage: .graph store-payload <collection> <node_id> <json_payload>\n");
-        return CommandResult::Continue;
-    }
-    let col = match resolve_graph_collection(db, parts, 2) {
-        Ok(c) => c,
-        Err(r) => return r,
-    };
-    let node_id: u64 = match parse_node_id(parts, 3) {
+    let (col, node_id) = match resolve_collection_and_node(
+        db,
+        parts,
+        5,
+        "Usage: .graph store-payload <collection> <node_id> <json_payload>",
+    ) {
         Ok(v) => v,
         Err(r) => return r,
     };
@@ -362,27 +369,23 @@ fn cmd_graph_store_payload(db: &Database, parts: &[&str]) -> CommandResult {
 }
 
 fn cmd_graph_get_payload(db: &Database, parts: &[&str]) -> CommandResult {
-    if parts.len() < 4 {
-        println!("Usage: .graph get-payload <collection> <node_id>\n");
-        return CommandResult::Continue;
-    }
-    let col = match resolve_graph_collection(db, parts, 2) {
-        Ok(c) => c,
-        Err(r) => return r,
-    };
-    let node_id: u64 = match parse_node_id(parts, 3) {
+    let (col, node_id) = match resolve_collection_and_node(
+        db,
+        parts,
+        4,
+        "Usage: .graph get-payload <collection> <node_id>",
+    ) {
         Ok(v) => v,
         Err(r) => return r,
     };
 
     match col.get_node_payload(node_id) {
         Ok(Some(val)) => {
-            // SAFETY invariant: serde_json::Value always serializes successfully.
-            println!(
-                "{}",
-                serde_json::to_string_pretty(&val)
-                    .expect("invariant: serde_json::Value serializes")
-            );
+            let json = match serde_json::to_string_pretty(&val) {
+                Ok(json) => json,
+                Err(e) => return CommandResult::Error(format!("{e}")),
+            };
+            println!("{json}");
         }
         Ok(None) => println!("null"),
         Err(e) => return CommandResult::Error(format!("{e}")),

--- a/crates/velesdb-core/src/collection/core/crud_bulk.rs
+++ b/crates/velesdb-core/src/collection/core/crud_bulk.rs
@@ -9,7 +9,7 @@
 //! and `AsyncIndexBuilder` defers HNSW construction for higher throughput.
 
 use crate::collection::types::Collection;
-use crate::error::Result;
+use crate::error::{Error, Result};
 use crate::index::hnsw::direct_writer::DirectVectorWriter;
 use crate::point::Point;
 use crate::storage::VectorStorage;
@@ -106,10 +106,11 @@ impl Collection {
         sparse_batch: &BTreeMap<String, Vec<(u64, crate::index::sparse::SparseVector)>>,
         fsync: bool,
     ) -> Result<usize> {
-        let aib = self
-            .async_index_builder
-            .as_ref()
-            .expect("invariant: caller checked async_index_builder.is_some()");
+        let Some(aib) = self.async_index_builder.as_ref() else {
+            return Err(Error::Config(
+                "bulk v2 path requires async index builder".to_string(),
+            ));
+        };
 
         // Collect pre-batch payloads before overwriting — used for histogram decrements.
         let old_payloads = {
@@ -142,14 +143,7 @@ impl Collection {
         }
 
         let count = vector_refs.len();
-        self.config.write().point_count = self.vector_storage.read().len();
-        self.apply_sparse_batch_bulk(sparse_batch)?;
-
-        // Incremental histogram maintenance (Bug #47 + Bug #49): dedup by id
-        // so only the final payload counts, then atomic decrement + increment.
-        self.apply_histogram_replace_dedup(points, &old_payloads);
-
-        self.invalidate_caches_and_bump_generation();
+        self.finalize_bulk_upsert(points, &old_payloads, sparse_batch)?;
 
         // Track inserts for periodic HNSW save (Issue #423 Component 3).
         #[allow(clippy::cast_possible_truncation)]
@@ -180,17 +174,27 @@ impl Collection {
         self.store_vectors_and_payloads_inner(vector_refs, points, fsync)?;
 
         let inserted = self.bulk_index_or_defer(vector_refs);
-        self.config.write().point_count = self.vector_storage.read().len();
-
-        self.apply_sparse_batch_bulk(sparse_batch)?;
-
-        // Incremental histogram maintenance (Bug #47 + Bug #49): dedup by id
-        // so only the final payload counts, then atomic decrement + increment.
-        self.apply_histogram_replace_dedup(points, &old_payloads);
-
-        self.invalidate_caches_and_bump_generation();
+        self.finalize_bulk_upsert(points, &old_payloads, sparse_batch)?;
 
         Ok(inserted)
+    }
+
+    /// Post-write bookkeeping shared by the V2 and standard bulk paths:
+    /// refreshes the point count, applies the sparse batch, replaces payload
+    /// histograms (dedup by id), and invalidates caches.
+    fn finalize_bulk_upsert(
+        &self,
+        points: &[Point],
+        old_payloads: &[Option<serde_json::Value>],
+        sparse_batch: &BTreeMap<String, Vec<(u64, crate::index::sparse::SparseVector)>>,
+    ) -> Result<()> {
+        self.config.write().point_count = self.vector_storage.read().len();
+        self.apply_sparse_batch_bulk(sparse_batch)?;
+        // Incremental histogram maintenance (Bug #47 + Bug #49): dedup by id
+        // so only the final payload counts, then atomic decrement + increment.
+        self.apply_histogram_replace_dedup(points, old_payloads);
+        self.invalidate_caches_and_bump_generation();
+        Ok(())
     }
 
     /// Writes vectors and payloads with configurable fsync behavior.

--- a/crates/velesdb-core/src/collection/core/crud_indexing.rs
+++ b/crates/velesdb-core/src/collection/core/crud_indexing.rs
@@ -209,10 +209,9 @@ impl Collection {
                     crate::index::sparse::persistence::wal_path_for_name(&self.path, name);
                 cached = Some((name, wal_path));
             }
-            let wal_path = &cached
-                .as_ref()
-                .expect("cache populated on first iteration")
-                .1;
+            let Some((_, wal_path)) = cached.as_ref() else {
+                continue;
+            };
             crate::index::sparse::persistence::wal_append_upsert(wal_path, point_id, sv)?;
         }
         Ok(())

--- a/crates/velesdb-core/src/collection/graph/edge_concurrent/mod.rs
+++ b/crates/velesdb-core/src/collection/graph/edge_concurrent/mod.rs
@@ -108,11 +108,12 @@ impl ConcurrentEdgeStore {
     ///
     /// Uses `DEFAULT_NUM_SHARDS` (compile-time constant > 0), so this
     /// constructor cannot fail in practice.
-    #[allow(clippy::missing_panics_doc)] // Invariant: DEFAULT_NUM_SHARDS > 0
     #[must_use]
     pub fn new() -> Self {
-        // DEFAULT_NUM_SHARDS is a compile-time constant > 0, so this cannot fail.
-        Self::with_shards(DEFAULT_NUM_SHARDS).expect("invariant: DEFAULT_NUM_SHARDS > 0")
+        match Self::with_shards(DEFAULT_NUM_SHARDS) {
+            Ok(store) => store,
+            Err(_) => unreachable!("DEFAULT_NUM_SHARDS must be greater than zero"),
+        }
     }
 
     /// Creates a new concurrent edge store with a specific number of shards.
@@ -145,7 +146,6 @@ impl ConcurrentEdgeStore {
     /// Creates a concurrent edge store with optimal shard count for estimated edge count.
     ///
     /// **FLAG-6: Uses integer bit manipulation for ceiling log2.**
-    #[allow(clippy::missing_panics_doc)] // Invariant: optimal_shards >= 1 (clamped)
     #[must_use]
     pub fn with_estimated_edges(estimated_edges: usize) -> Self {
         let optimal_shards = if estimated_edges < MIN_EDGES_PER_SHARD {
@@ -159,8 +159,10 @@ impl ConcurrentEdgeStore {
             };
             (1usize << power_of_2).clamp(1, MAX_SHARDS)
         };
-        // optimal_shards is always >= 1 (clamped above), so this cannot fail.
-        Self::with_shards(optimal_shards).expect("invariant: optimal_shards >= 1")
+        match Self::with_shards(optimal_shards) {
+            Ok(store) => store,
+            Err(_) => unreachable!("optimal_shards must be greater than zero"),
+        }
     }
 
     /// Returns the shard index for a given node ID.

--- a/crates/velesdb-core/src/collection/graph/streaming.rs
+++ b/crates/velesdb-core/src/collection/graph/streaming.rs
@@ -76,6 +76,180 @@ impl StreamingConfig {
     }
 }
 
+/// Shared BFS bookkeeping for the streaming iterators.
+///
+/// Owns the traversal frontier, the visited set (with overflow handling), the
+/// rel-type filter, the parent-pointer map, and the pending-result buffer. Both
+/// [`BfsIterator`] and [`ConcurrentBfsIterator`] delegate per-edge processing
+/// and result pumping here, so the filter/visit/record logic lives in exactly
+/// one place regardless of the underlying edge store.
+struct BfsBookkeeping {
+    config: StreamingConfig,
+    queue: VecDeque<BfsState>,
+    visited: FxHashSet<u64>,
+    rel_types_set: FxHashSet<String>,
+    visited_overflow: bool,
+    pending_results: VecDeque<TraversalResult>,
+    parent_map: FxHashMap<u64, (u64, u64)>,
+    source_id: u64,
+    yielded: usize,
+}
+
+impl BfsBookkeeping {
+    /// Seeds the frontier and visited set with `start_id`.
+    fn new(start_id: u64, config: StreamingConfig) -> Self {
+        let rel_types_set: FxHashSet<String> = config.rel_types.iter().cloned().collect();
+        let mut visited = FxHashSet::default();
+        visited.insert(start_id);
+        let mut queue = VecDeque::new();
+        queue.push_back(BfsState {
+            node_id: start_id,
+            depth: 0,
+        });
+        Self {
+            config,
+            queue,
+            visited,
+            rel_types_set,
+            visited_overflow: false,
+            pending_results: VecDeque::new(),
+            parent_map: FxHashMap::default(),
+            source_id: start_id,
+            yielded: 0,
+        }
+    }
+
+    /// Checks whether `label` passes the rel-type filter (empty filter = all).
+    #[inline]
+    fn label_passes_filter(&self, label: &str) -> bool {
+        self.rel_types_set.is_empty() || self.rel_types_set.contains(label)
+    }
+
+    /// Records a visited target, handling overflow when the visited set exceeds
+    /// `max_visited_size`. Returns `true` if the target should be processed.
+    #[inline]
+    fn try_visit(&mut self, target: u64) -> bool {
+        if self.visited_overflow {
+            return true;
+        }
+        if self.visited.contains(&target) {
+            return false;
+        }
+        if self.visited.len() >= self.config.max_visited_size {
+            self.visited_overflow = true;
+            self.visited.clear();
+            return true;
+        }
+        self.visited.insert(target);
+        true
+    }
+
+    /// Processes one candidate edge: applies the rel-type (when `label` is
+    /// `Some`), depth, and visited filters, then on acceptance records the
+    /// parent pointer, enqueues the target, and buffers a pending result.
+    fn process_candidate(
+        &mut self,
+        parent_id: u64,
+        target: u64,
+        edge_id: u64,
+        parent_depth: u32,
+        label: Option<&str>,
+    ) {
+        if let Some(label) = label {
+            if !self.label_passes_filter(label) {
+                return;
+            }
+        }
+        let new_depth = parent_depth + 1;
+        if new_depth > self.config.max_depth {
+            return;
+        }
+        if !self.try_visit(target) {
+            return;
+        }
+        self.parent_map.insert(target, (parent_id, edge_id));
+        if new_depth < self.config.max_depth {
+            self.queue.push_back(BfsState {
+                node_id: target,
+                depth: new_depth,
+            });
+        }
+        let path = reconstruct_path(target, self.source_id, &self.parent_map);
+        self.pending_results
+            .push_back(TraversalResult::new(target, path, new_depth));
+    }
+
+    /// Pops the next buffered result, incrementing the yielded counter.
+    #[inline]
+    fn next_pending(&mut self) -> Option<TraversalResult> {
+        let result = self.pending_results.pop_front()?;
+        self.yielded += 1;
+        Some(result)
+    }
+
+    /// Pumps the BFS: yields any buffered result, otherwise expands queued
+    /// nodes (via `expand`) until one yields. `expand` supplies the edge-store
+    /// access, keeping this driver independent of the store type.
+    fn drive(&mut self, mut expand: impl FnMut(&mut Self, &BfsState)) -> Option<TraversalResult> {
+        if self.config.limit.is_some_and(|limit| self.yielded >= limit) {
+            return None;
+        }
+        if let Some(result) = self.next_pending() {
+            return Some(result);
+        }
+        while let Some(state) = self.queue.pop_front() {
+            expand(self, &state);
+            if let Some(result) = self.next_pending() {
+                return Some(result);
+            }
+        }
+        None
+    }
+}
+
+/// Expands a node over the CSR zero-copy path (contiguous `&[u64]` neighbours).
+fn expand_csr(edge_store: &EdgeStore, core: &mut BfsBookkeeping, state: &BfsState) {
+    let Some(snapshot) = edge_store.csr_snapshot() else {
+        return;
+    };
+    let targets = snapshot.neighbors(state.node_id);
+    let edge_ids = snapshot.edge_ids(state.node_id);
+    for (i, (&target, &eid)) in targets.iter().zip(edge_ids.iter()).enumerate() {
+        let label = snapshot.label_at(state.node_id, i);
+        core.process_candidate(state.node_id, target, eid, state.depth, label);
+    }
+}
+
+/// Expands a node over the legacy `EdgeStore` path (owned `GraphEdge` values).
+fn expand_legacy(edge_store: &EdgeStore, core: &mut BfsBookkeeping, state: &BfsState) {
+    for edge in edge_store.get_outgoing(state.node_id) {
+        core.process_candidate(
+            state.node_id,
+            edge.target(),
+            edge.id(),
+            state.depth,
+            Some(edge.label()),
+        );
+    }
+}
+
+/// Expands a node over a [`ConcurrentEdgeStore`] (per-shard locked reads).
+fn expand_concurrent(
+    edge_store: &ConcurrentEdgeStore,
+    core: &mut BfsBookkeeping,
+    state: &BfsState,
+) {
+    for edge in &edge_store.get_outgoing(state.node_id) {
+        core.process_candidate(
+            state.node_id,
+            edge.target(),
+            edge.id(),
+            state.depth,
+            Some(edge.label()),
+        );
+    }
+}
+
 /// Streaming BFS iterator that yields results lazily.
 ///
 /// This iterator provides memory-bounded traversal by:
@@ -108,60 +282,23 @@ impl StreamingConfig {
 /// ```
 pub struct BfsIterator<'a> {
     edge_store: &'a EdgeStore,
-    queue: VecDeque<BfsState>,
-    visited: FxHashSet<u64>,
-    config: StreamingConfig,
-    /// Pre-built set for O(1) relationship-type filtering without per-edge allocation.
-    /// Empty when no filter is configured (all edge types accepted).
-    rel_types_set: FxHashSet<String>,
-    yielded: usize,
-    visited_overflow: bool,
-    /// Buffer for pending results from current node being processed.
-    /// This ensures all edges from a node are yielded before moving to next node.
-    pending_results: VecDeque<TraversalResult>,
-    /// Parent-pointer map: target_node -> (parent_node, edge_id).
-    /// Replaces per-state path cloning with O(visited_nodes) memory.
-    parent_map: FxHashMap<u64, (u64, u64)>,
-    /// Source node ID for path reconstruction.
-    source_id: u64,
+    core: BfsBookkeeping,
 }
 
 impl<'a> BfsIterator<'a> {
     /// Creates a new BFS iterator starting from the given node.
     #[must_use]
     pub fn new(edge_store: &'a EdgeStore, start_id: u64, config: StreamingConfig) -> Self {
-        // Pre-build FxHashSet from Vec<String> once, not per-edge.
-        let rel_types_set: FxHashSet<String> = config.rel_types.iter().cloned().collect();
-
-        let mut iter = Self {
+        Self {
             edge_store,
-            queue: VecDeque::new(),
-            visited: FxHashSet::default(),
-            config,
-            rel_types_set,
-            yielded: 0,
-            visited_overflow: false,
-            pending_results: VecDeque::new(),
-            parent_map: FxHashMap::default(),
-            source_id: start_id,
-        };
-        iter.init_first_level(start_id);
-        iter
-    }
-
-    /// Seeds the BFS queue and visited set with the start node.
-    fn init_first_level(&mut self, start_id: u64) {
-        self.visited.insert(start_id);
-        self.queue.push_back(BfsState {
-            node_id: start_id,
-            depth: 0,
-        });
+            core: BfsBookkeeping::new(start_id, config),
+        }
     }
 
     /// Returns the number of results yielded so far.
     #[must_use]
     pub fn yielded_count(&self) -> usize {
-        self.yielded
+        self.core.yielded
     }
 
     /// Returns true if the visited set has overflowed its limit.
@@ -170,110 +307,13 @@ impl<'a> BfsIterator<'a> {
     /// may be visited multiple times.
     #[must_use]
     pub fn is_visited_overflow(&self) -> bool {
-        self.visited_overflow
+        self.core.visited_overflow
     }
 
     /// Returns the current size of the visited set.
     #[must_use]
     pub fn visited_size(&self) -> usize {
-        self.visited.len()
-    }
-
-    /// Checks whether the given label passes the rel-type filter.
-    ///
-    /// Empty filter = accept all labels.
-    #[inline]
-    fn label_passes_filter(&self, label: &str) -> bool {
-        self.rel_types_set.is_empty() || self.rel_types_set.contains(label)
-    }
-
-    /// Records a visited target, handling overflow when the visited set
-    /// exceeds `max_visited_size`.
-    ///
-    /// Returns `true` if the target should be processed (not already visited).
-    #[inline]
-    fn try_visit(&mut self, target: u64) -> bool {
-        if self.visited_overflow {
-            return true;
-        }
-        if self.visited.contains(&target) {
-            return false;
-        }
-        if self.visited.len() >= self.config.max_visited_size {
-            self.visited_overflow = true;
-            self.visited.clear();
-            return true;
-        }
-        self.visited.insert(target);
-        true
-    }
-
-    /// Processes outgoing edges using CSR zero-copy path.
-    ///
-    /// Uses `CsrSnapshot` for contiguous `&[u64]` access to target IDs,
-    /// edge IDs, and interned labels — no `GraphEdge` cloning.
-    /// Uses parent-pointer insertion instead of path cloning.
-    fn expand_node_csr(&mut self, state: &BfsState) {
-        let snapshot = self
-            .edge_store
-            .csr_snapshot()
-            .expect("invariant: CSR snapshot checked before calling expand_node_csr");
-        let targets = snapshot.neighbors(state.node_id);
-        let edge_ids = snapshot.edge_ids(state.node_id);
-
-        for (i, (&target, &eid)) in targets.iter().zip(edge_ids.iter()).enumerate() {
-            let new_depth = state.depth + 1;
-            if new_depth > self.config.max_depth {
-                continue;
-            }
-            if let Some(label) = snapshot.label_at(state.node_id, i) {
-                if !self.label_passes_filter(label) {
-                    continue;
-                }
-            }
-            if !self.try_visit(target) {
-                continue;
-            }
-            self.parent_map.insert(target, (state.node_id, eid));
-            if new_depth < self.config.max_depth {
-                self.queue.push_back(BfsState {
-                    node_id: target,
-                    depth: new_depth,
-                });
-            }
-            let path = reconstruct_path(target, self.source_id, &self.parent_map);
-            self.pending_results
-                .push_back(TraversalResult::new(target, path, new_depth));
-        }
-    }
-
-    /// Processes outgoing edges using the legacy path (clones `GraphEdge`).
-    /// Uses parent-pointer insertion instead of path cloning.
-    fn expand_node_legacy(&mut self, state: &BfsState) {
-        let edges = self.edge_store.get_outgoing(state.node_id);
-        for edge in edges {
-            if !self.label_passes_filter(edge.label()) {
-                continue;
-            }
-            let target = edge.target();
-            let new_depth = state.depth + 1;
-            if new_depth > self.config.max_depth {
-                continue;
-            }
-            if !self.try_visit(target) {
-                continue;
-            }
-            self.parent_map.insert(target, (state.node_id, edge.id()));
-            if new_depth < self.config.max_depth {
-                self.queue.push_back(BfsState {
-                    node_id: target,
-                    depth: new_depth,
-                });
-            }
-            let path = reconstruct_path(target, self.source_id, &self.parent_map);
-            self.pending_results
-                .push_back(TraversalResult::new(target, path, new_depth));
-        }
+        self.core.visited.len()
     }
 }
 
@@ -281,36 +321,15 @@ impl Iterator for BfsIterator<'_> {
     type Item = TraversalResult;
 
     fn next(&mut self) -> Option<Self::Item> {
-        // Check limit
-        if let Some(limit) = self.config.limit {
-            if self.yielded >= limit {
-                return None;
-            }
-        }
-
-        // First, yield any pending results from previous node processing
-        if let Some(result) = self.pending_results.pop_front() {
-            self.yielded += 1;
-            return Some(result);
-        }
-
-        // Process nodes from queue until we have results to yield
-        while let Some(state) = self.queue.pop_front() {
-            // Dispatch: CSR zero-copy path when snapshot exists, legacy otherwise.
-            if self.edge_store.has_csr_snapshot() {
-                self.expand_node_csr(&state);
+        let edge_store = self.edge_store;
+        // Dispatch: CSR zero-copy path when a snapshot exists, legacy otherwise.
+        self.core.drive(|core, state| {
+            if edge_store.has_csr_snapshot() {
+                expand_csr(edge_store, core, state);
             } else {
-                self.expand_node_legacy(&state);
+                expand_legacy(edge_store, core, state);
             }
-
-            // After processing all edges from this node, yield first pending result if any
-            if let Some(result) = self.pending_results.pop_front() {
-                self.yielded += 1;
-                return Some(result);
-            }
-        }
-
-        None
+        })
     }
 }
 
@@ -337,17 +356,7 @@ pub fn bfs_stream(
 /// Uses parent-pointer map for zero-clone path reconstruction.
 pub struct ConcurrentBfsIterator<'a> {
     edge_store: &'a ConcurrentEdgeStore,
-    queue: VecDeque<BfsState>,
-    visited: FxHashSet<u64>,
-    config: StreamingConfig,
-    rel_types_set: FxHashSet<String>,
-    yielded: usize,
-    visited_overflow: bool,
-    pending_results: VecDeque<TraversalResult>,
-    /// Parent-pointer map: target_node -> (parent_node, edge_id).
-    parent_map: FxHashMap<u64, (u64, u64)>,
-    /// Source node ID for path reconstruction.
-    source_id: u64,
+    core: BfsBookkeeping,
 }
 
 impl<'a> ConcurrentBfsIterator<'a> {
@@ -358,95 +367,9 @@ impl<'a> ConcurrentBfsIterator<'a> {
         start_id: u64,
         config: StreamingConfig,
     ) -> Self {
-        let mut visited = FxHashSet::default();
-        visited.insert(start_id);
-
-        let mut queue = VecDeque::new();
-        queue.push_back(BfsState {
-            node_id: start_id,
-            depth: 0,
-        });
-
-        let rel_types_set: FxHashSet<String> = config.rel_types.iter().cloned().collect();
-
         Self {
             edge_store,
-            queue,
-            visited,
-            config,
-            rel_types_set,
-            yielded: 0,
-            visited_overflow: false,
-            pending_results: VecDeque::new(),
-            parent_map: FxHashMap::default(),
-            source_id: start_id,
-        }
-    }
-}
-
-impl ConcurrentBfsIterator<'_> {
-    /// Checks whether the given label passes the rel-type filter.
-    ///
-    /// Empty filter = accept all labels.
-    #[inline]
-    fn label_passes_filter(&self, label: &str) -> bool {
-        self.rel_types_set.is_empty() || self.rel_types_set.contains(label)
-    }
-
-    /// Records a visited target, handling overflow when the visited set
-    /// exceeds `max_visited_size`.
-    ///
-    /// Returns `true` if the target should be processed (not already visited).
-    #[inline]
-    fn try_visit(&mut self, target: u64) -> bool {
-        if self.visited_overflow {
-            return true;
-        }
-        if self.visited.contains(&target) {
-            return false;
-        }
-        if self.visited.len() >= self.config.max_visited_size {
-            self.visited_overflow = true;
-            self.visited.clear();
-            return true;
-        }
-        self.visited.insert(target);
-        true
-    }
-
-    /// Expands a single BFS node: filters edges, records parent pointers,
-    /// enqueues unvisited targets, and buffers pending results.
-    fn expand_node(&mut self, state: &BfsState) {
-        let edges = self.edge_store.get_outgoing(state.node_id);
-
-        for edge in &edges {
-            if !self.label_passes_filter(edge.label()) {
-                continue;
-            }
-
-            let target = edge.target();
-            let new_depth = state.depth + 1;
-
-            if new_depth > self.config.max_depth {
-                continue;
-            }
-
-            if !self.try_visit(target) {
-                continue;
-            }
-
-            self.parent_map.insert(target, (state.node_id, edge.id()));
-
-            if new_depth < self.config.max_depth {
-                self.queue.push_back(BfsState {
-                    node_id: target,
-                    depth: new_depth,
-                });
-            }
-
-            let path = reconstruct_path(target, self.source_id, &self.parent_map);
-            self.pending_results
-                .push_back(TraversalResult::new(target, path, new_depth));
+            core: BfsBookkeeping::new(start_id, config),
         }
     }
 }
@@ -455,27 +378,9 @@ impl Iterator for ConcurrentBfsIterator<'_> {
     type Item = TraversalResult;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if let Some(limit) = self.config.limit {
-            if self.yielded >= limit {
-                return None;
-            }
-        }
-
-        if let Some(result) = self.pending_results.pop_front() {
-            self.yielded += 1;
-            return Some(result);
-        }
-
-        while let Some(state) = self.queue.pop_front() {
-            self.expand_node(&state);
-
-            if let Some(result) = self.pending_results.pop_front() {
-                self.yielded += 1;
-                return Some(result);
-            }
-        }
-
-        None
+        let edge_store = self.edge_store;
+        self.core
+            .drive(|core, state| expand_concurrent(edge_store, core, state))
     }
 }
 

--- a/crates/velesdb-core/src/collection/graph/traversal.rs
+++ b/crates/velesdb-core/src/collection/graph/traversal.rs
@@ -297,9 +297,9 @@ fn process_bfs_csr(
     queue: &mut VecDeque<BfsState>,
     parent_map: &mut FxHashMap<u64, (u64, u64)>,
 ) {
-    let snapshot = edge_store
-        .csr_snapshot()
-        .expect("invariant: CSR snapshot checked before calling process_bfs_csr");
+    let Some(snapshot) = edge_store.csr_snapshot() else {
+        return;
+    };
     let targets = snapshot.neighbors(state.node_id);
     let edge_ids = snapshot.edge_ids(state.node_id);
 

--- a/crates/velesdb-core/src/collection/search/query/match_exec/expand.rs
+++ b/crates/velesdb-core/src/collection/search/query/match_exec/expand.rs
@@ -1,0 +1,269 @@
+//! Recursive pattern-walker for MATCH traversal (EPIC-045 US-002).
+//!
+//! Split out of `match_exec/mod.rs` to keep each file under the 500 NLOC bar.
+//! Holds the per-relationship expansion engine: relationship ordering,
+//! direction, multi-type, multi-hop / variable-length, and binding acceptance.
+
+use super::{AliasBinding, MatchResult, TraversalCtx};
+use crate::collection::graph::GraphEdge;
+use crate::collection::types::Collection;
+use crate::error::{Error, Result};
+use crate::velesql::{Direction, GraphPattern, RelationshipPattern};
+use std::collections::HashMap;
+
+/// Ambient state threaded through a single pattern walk.
+///
+/// Bundling the invariant pattern/edge-store references with the mutable
+/// traversal context, bindings, and path keeps the recursive walker functions
+/// well under the argument-count limit (they previously took 12 parameters).
+struct Walk<'a, 't> {
+    pattern: &'a GraphPattern,
+    edge_store: &'a crate::collection::graph::ConcurrentEdgeStore,
+    ctx: &'a mut TraversalCtx<'t>,
+    bindings: &'a mut HashMap<String, u64>,
+    path: &'a mut Vec<u64>,
+}
+
+impl Collection {
+    /// Traverses a single graph pattern via BFS for each start node.
+    pub(super) fn traverse_pattern(
+        &self,
+        pattern: &GraphPattern,
+        start_nodes: &[(u64, HashMap<String, u64>)],
+        edge_store: &crate::collection::graph::ConcurrentEdgeStore,
+        ctx: &mut TraversalCtx<'_>,
+    ) -> Result<()> {
+        for (start_id, start_bindings) in start_nodes {
+            if ctx.all_results.len() >= ctx.limit {
+                break;
+            }
+
+            let mut path = Vec::new();
+            let mut bindings = start_bindings.clone();
+            let mut walk = Walk {
+                pattern,
+                edge_store,
+                ctx: &mut *ctx,
+                bindings: &mut bindings,
+                path: &mut path,
+            };
+            self.expand_pattern(&mut walk, *start_id, 0)?;
+        }
+        Ok(())
+    }
+
+    fn expand_pattern(
+        &self,
+        walk: &mut Walk<'_, '_>,
+        current_id: u64,
+        rel_idx: usize,
+    ) -> Result<()> {
+        if rel_idx >= walk.pattern.relationships.len() {
+            return self.accept_pattern_match(walk, current_id);
+        }
+        self.expand_relationship(walk, current_id, rel_idx, 0)
+    }
+
+    fn expand_relationship(
+        &self,
+        walk: &mut Walk<'_, '_>,
+        current_id: u64,
+        rel_idx: usize,
+        hops: u32,
+    ) -> Result<()> {
+        let (min_hops, max_hops) = walk.pattern.relationships[rel_idx].range.unwrap_or((1, 1));
+        if hops >= min_hops {
+            self.try_bind_next_node(walk, current_id, rel_idx)?;
+        }
+        if hops >= max_hops || walk.ctx.all_results.len() >= walk.ctx.limit {
+            return Ok(());
+        }
+        let edges = Self::matching_edges(
+            walk.edge_store,
+            current_id,
+            &walk.pattern.relationships[rel_idx],
+        );
+        for edge in edges {
+            self.follow_edge(walk, current_id, &edge, rel_idx, hops)?;
+        }
+        Ok(())
+    }
+
+    fn follow_edge(
+        &self,
+        walk: &mut Walk<'_, '_>,
+        current_id: u64,
+        edge: &GraphEdge,
+        rel_idx: usize,
+        hops: u32,
+    ) -> Result<()> {
+        if walk.ctx.all_results.len() >= walk.ctx.limit
+            || !Self::edge_matches(edge, &walk.pattern.relationships[rel_idx])
+        {
+            return Ok(());
+        }
+        let next_id = Self::edge_next_node(edge, current_id);
+        walk.path.push(edge.id());
+        *walk.ctx.iteration_count += 1;
+        let depth = walk.path.len() as u32;
+        self.check_depth_and_periodic_guardrails(depth, walk.ctx)?;
+        self.expand_relationship(walk, next_id, rel_idx, hops.saturating_add(1))?;
+        walk.path.pop();
+        Ok(())
+    }
+
+    fn try_bind_next_node(
+        &self,
+        walk: &mut Walk<'_, '_>,
+        node_id: u64,
+        rel_idx: usize,
+    ) -> Result<()> {
+        let Some(node) = walk.pattern.nodes.get(rel_idx + 1) else {
+            return Ok(());
+        };
+        if !Self::node_matches_bound_pattern(node_id, node, walk.ctx.payload_guard) {
+            return Ok(());
+        }
+        let inserted = Self::bind_node_alias(walk.bindings, node, node_id);
+        let (AliasBinding::Unchanged | AliasBinding::Inserted(_)) = inserted else {
+            return Ok(());
+        };
+        self.expand_pattern(walk, node_id, rel_idx + 1)?;
+        if let AliasBinding::Inserted(alias) = inserted {
+            walk.bindings.remove(&alias);
+        }
+        Ok(())
+    }
+
+    fn accept_pattern_match(&self, walk: &mut Walk<'_, '_>, node_id: u64) -> Result<()> {
+        if let Some(where_clause) = walk.ctx.match_clause.where_clause.as_ref() {
+            if !self.evaluate_where_condition(
+                node_id,
+                Some(&*walk.bindings),
+                where_clause,
+                walk.ctx.params,
+                walk.ctx.payload_guard,
+            )? {
+                return Ok(());
+            }
+        }
+
+        let signature = Self::binding_signature(walk.bindings);
+        if !walk.ctx.seen_bindings.insert(signature) {
+            return Ok(());
+        }
+
+        let mut result = MatchResult::new(node_id, walk.path.len() as u32, walk.path.clone());
+        result.bindings.clone_from(walk.bindings);
+        result.projected = self.project_properties(
+            walk.bindings,
+            &walk.ctx.match_clause.return_clause,
+            walk.ctx.payload_guard,
+        );
+        walk.ctx.all_results.push(result);
+        Ok(())
+    }
+
+    fn check_depth_and_periodic_guardrails(
+        &self,
+        depth: u32,
+        ctx: &mut TraversalCtx<'_>,
+    ) -> Result<()> {
+        if let Some(guardrail) = ctx.guardrail {
+            guardrail
+                .check_depth(depth)
+                .map_err(|e| Error::GuardRail(e.to_string()))?;
+        }
+        self.check_periodic_guardrails(
+            ctx.guardrail,
+            *ctx.iteration_count,
+            ctx.all_results,
+            ctx.reported_cardinality,
+        )
+    }
+
+    fn matching_edges(
+        edge_store: &crate::collection::graph::ConcurrentEdgeStore,
+        node_id: u64,
+        rel: &RelationshipPattern,
+    ) -> Vec<GraphEdge> {
+        match rel.direction {
+            Direction::Outgoing => Self::typed_edges(edge_store, node_id, rel, true),
+            Direction::Incoming => Self::typed_edges(edge_store, node_id, rel, false),
+            Direction::Both => {
+                let mut edges = Self::typed_edges(edge_store, node_id, rel, true);
+                edges.extend(Self::typed_edges(edge_store, node_id, rel, false));
+                edges
+            }
+        }
+    }
+
+    fn typed_edges(
+        edge_store: &crate::collection::graph::ConcurrentEdgeStore,
+        node_id: u64,
+        rel: &RelationshipPattern,
+        outgoing: bool,
+    ) -> Vec<GraphEdge> {
+        if rel.types.is_empty() {
+            return if outgoing {
+                edge_store.get_outgoing(node_id)
+            } else {
+                edge_store.get_incoming(node_id)
+            };
+        }
+        rel.types
+            .iter()
+            .flat_map(|label| {
+                if outgoing {
+                    edge_store.get_outgoing_by_label(node_id, label)
+                } else {
+                    edge_store.get_incoming_by_label(node_id, label)
+                }
+            })
+            .collect()
+    }
+
+    fn edge_matches(edge: &GraphEdge, rel: &RelationshipPattern) -> bool {
+        if !rel.types.is_empty() && !rel.types.iter().any(|t| t == edge.label()) {
+            return false;
+        }
+        rel.properties.iter().all(|(key, expected)| {
+            edge.property(key)
+                .is_some_and(|v| Self::values_match(expected, v))
+        })
+    }
+
+    fn edge_next_node(edge: &GraphEdge, current_id: u64) -> u64 {
+        if edge.source() == current_id {
+            edge.target()
+        } else {
+            edge.source()
+        }
+    }
+
+    fn bind_node_alias(
+        bindings: &mut HashMap<String, u64>,
+        node: &crate::velesql::NodePattern,
+        node_id: u64,
+    ) -> AliasBinding {
+        let Some(alias) = node.alias.as_ref() else {
+            return AliasBinding::Unchanged;
+        };
+        if let Some(existing) = bindings.get(alias) {
+            return if *existing == node_id {
+                AliasBinding::Unchanged
+            } else {
+                AliasBinding::Conflict
+            };
+        }
+        bindings.insert(alias.clone(), node_id);
+        AliasBinding::Inserted(alias.clone())
+    }
+
+    fn binding_signature(bindings: &HashMap<String, u64>) -> Vec<(String, u64)> {
+        let mut signature: Vec<(String, u64)> =
+            bindings.iter().map(|(k, v)| (k.clone(), *v)).collect();
+        signature.sort_by(|a, b| a.0.cmp(&b.0));
+        signature
+    }
+}

--- a/crates/velesdb-core/src/collection/search/query/match_exec/mod.rs
+++ b/crates/velesdb-core/src/collection/search/query/match_exec/mod.rs
@@ -11,19 +11,19 @@
 #![allow(clippy::cast_precision_loss)]
 #![allow(clippy::cast_possible_truncation)]
 
+mod expand;
 mod index_prefilter;
 mod similarity;
 mod start_nodes;
 mod vector_first;
 mod where_eval;
 
-use crate::collection::graph::{concurrent_bfs_stream, StreamingConfig};
 use crate::collection::types::Collection;
 use crate::error::{Error, Result};
 use crate::guardrails::QueryContext;
 use crate::storage::LogPayloadStorage;
 use crate::velesql::{GraphPattern, MatchClause};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 /// Result of a MATCH query traversal.
 #[derive(Debug, Clone)]
@@ -70,6 +70,12 @@ impl MatchResult {
         self.projected = projected;
         self
     }
+}
+
+enum AliasBinding {
+    Unchanged,
+    Inserted(String),
+    Conflict,
 }
 
 /// A parsed RETURN clause projection item (Fix #489).
@@ -161,11 +167,11 @@ struct TraversalCtx<'a> {
     params: &'a HashMap<String, serde_json::Value>,
     payload_guard: &'a LogPayloadStorage,
     guardrail: Option<&'a QueryContext>,
-    seen_pairs: &'a mut std::collections::HashSet<(u64, u64)>,
     all_results: &'a mut Vec<MatchResult>,
     limit: usize,
     iteration_count: &'a mut u32,
     reported_cardinality: &'a mut usize,
+    seen_bindings: &'a mut HashSet<Vec<(String, u64)>>,
 }
 
 impl Collection {
@@ -300,106 +306,13 @@ impl Collection {
             params,
             payload_guard,
             guardrail: ctx,
-            seen_pairs: &mut seen_pairs,
             all_results,
             limit,
             iteration_count,
             reported_cardinality,
+            seen_bindings: &mut HashSet::new(),
         };
         self.traverse_pattern(pattern, &start_nodes, edge_store, &mut trav_ctx)
-    }
-
-    /// Traverses a single graph pattern via BFS for each start node.
-    fn traverse_pattern(
-        &self,
-        pattern: &GraphPattern,
-        start_nodes: &[(u64, HashMap<String, u64>)],
-        edge_store: &crate::collection::graph::ConcurrentEdgeStore,
-        ctx: &mut TraversalCtx<'_>,
-    ) -> Result<()> {
-        let max_depth = Self::compute_max_depth(pattern);
-        let rel_types = Self::extract_rel_types(pattern);
-
-        for (start_id, start_bindings) in start_nodes {
-            if ctx.all_results.len() >= ctx.limit {
-                break;
-            }
-
-            let config = StreamingConfig::default()
-                .with_limit(ctx.limit.saturating_sub(ctx.all_results.len()))
-                .with_max_depth(max_depth)
-                .with_rel_types(rel_types.clone());
-
-            for traversal_result in concurrent_bfs_stream(edge_store, *start_id, config) {
-                if ctx.all_results.len() >= ctx.limit {
-                    break;
-                }
-
-                *ctx.iteration_count += 1;
-                self.check_periodic_guardrails(
-                    ctx.guardrail,
-                    *ctx.iteration_count,
-                    ctx.all_results,
-                    ctx.reported_cardinality,
-                )?;
-
-                self.accept_traversal_hit(
-                    *start_id,
-                    &traversal_result,
-                    start_bindings,
-                    pattern,
-                    ctx,
-                )?;
-            }
-        }
-        Ok(())
-    }
-
-    /// Evaluates a single BFS hit: guard-rails, WHERE filter, dedup, and projection.
-    ///
-    /// Uses the pre-acquired `payload_guard` from the traversal context
-    /// to avoid per-node lock acquisitions.
-    fn accept_traversal_hit(
-        &self,
-        start_id: u64,
-        traversal_result: &crate::collection::graph::TraversalResult,
-        start_bindings: &HashMap<String, u64>,
-        pattern: &GraphPattern,
-        ctx: &mut TraversalCtx<'_>,
-    ) -> Result<()> {
-        let match_result = self.build_traversal_match_result(
-            traversal_result,
-            start_bindings,
-            pattern,
-            ctx.guardrail,
-        )?;
-
-        if let Some(ref where_clause) = ctx.match_clause.where_clause {
-            if !self.evaluate_where_condition(
-                traversal_result.target_id,
-                Some(&match_result.bindings),
-                where_clause,
-                ctx.params,
-                ctx.payload_guard,
-            )? {
-                return Ok(());
-            }
-        }
-
-        let pair = (start_id, traversal_result.target_id);
-        if !ctx.seen_pairs.insert(pair) {
-            return Ok(());
-        }
-
-        let mut final_result = match_result;
-        final_result.projected = self.project_properties(
-            &final_result.bindings,
-            &ctx.match_clause.return_clause,
-            ctx.payload_guard,
-        );
-
-        ctx.all_results.push(final_result);
-        Ok(())
     }
 
     /// Collects results for single-node patterns (no relationships).
@@ -469,38 +382,6 @@ impl Collection {
             *reported_cardinality = all_results.len();
         }
         Ok(())
-    }
-
-    /// Builds a `MatchResult` from a traversal result with bindings and depth check.
-    #[allow(clippy::unused_self)]
-    fn build_traversal_match_result(
-        &self,
-        traversal_result: &crate::collection::graph::TraversalResult,
-        start_bindings: &HashMap<String, u64>,
-        pattern: &GraphPattern,
-        ctx: Option<&QueryContext>,
-    ) -> Result<MatchResult> {
-        let mut match_result = MatchResult::new(
-            traversal_result.target_id,
-            traversal_result.depth,
-            traversal_result.path.clone(),
-        );
-        match_result.bindings.clone_from(start_bindings);
-
-        if let Some(ctx) = ctx {
-            ctx.check_depth(traversal_result.depth)
-                .map_err(|e| Error::GuardRail(e.to_string()))?;
-        }
-
-        if let Some(target_pattern) = pattern.nodes.get(traversal_result.depth as usize) {
-            if let Some(ref alias) = target_pattern.alias {
-                match_result
-                    .bindings
-                    .insert(alias.clone(), traversal_result.target_id);
-            }
-        }
-
-        Ok(match_result)
     }
 }
 

--- a/crates/velesdb-core/src/collection/search/query/match_exec/similarity.rs
+++ b/crates/velesdb-core/src/collection/search/query/match_exec/similarity.rs
@@ -389,11 +389,13 @@ impl Collection {
         let mut results = Vec::new();
 
         for mr in match_results {
-            // Get vector and payload for the node
             let vector = vector_storage
                 .retrieve(mr.node_id)?
                 .unwrap_or_else(Vec::new);
-            let payload = payload_storage.retrieve(mr.node_id).ok().flatten();
+            let payload = Some(build_match_payload(
+                payload_storage.retrieve(mr.node_id).ok().flatten(),
+                &mr,
+            ));
 
             let point = crate::Point {
                 id: mr.node_id,
@@ -410,4 +412,25 @@ impl Collection {
 
         Ok(results)
     }
+}
+
+fn build_match_payload(
+    base_payload: Option<serde_json::Value>,
+    result: &MatchResult,
+) -> serde_json::Value {
+    let mut object = match base_payload {
+        Some(serde_json::Value::Object(map)) => map,
+        Some(value) => {
+            let mut map = serde_json::Map::new();
+            map.insert("_payload".to_string(), value);
+            map
+        }
+        None => serde_json::Map::new(),
+    };
+
+    for (key, value) in &result.projected {
+        object.insert(key.clone(), value.clone());
+    }
+    object.insert("_bindings".to_string(), serde_json::json!(result.bindings));
+    serde_json::Value::Object(object)
 }

--- a/crates/velesdb-core/src/collection/search/query/match_exec/start_nodes.rs
+++ b/crates/velesdb-core/src/collection/search/query/match_exec/start_nodes.rs
@@ -6,7 +6,7 @@
 use crate::collection::types::Collection;
 use crate::error::{Error, Result};
 use crate::storage::{PayloadStorage, VectorStorage};
-use crate::velesql::GraphPattern;
+use crate::velesql::{GraphPattern, NodePattern};
 use std::collections::HashMap;
 
 impl Collection {
@@ -145,9 +145,9 @@ impl Collection {
     }
 
     /// Returns true if a node matches the label and property filters of a pattern.
-    fn node_matches_pattern(
+    pub(super) fn node_matches_pattern(
         id: u64,
-        node: &crate::velesql::NodePattern,
+        node: &NodePattern,
         needs_payload: bool,
         payload_storage: &crate::storage::LogPayloadStorage,
     ) -> bool {
@@ -161,6 +161,22 @@ impl Collection {
         }
         node.properties.is_empty()
             || Self::node_matches_properties(payload_opt.as_ref(), &node.properties)
+    }
+
+    /// Returns true if a bound node satisfies its pattern.
+    ///
+    /// `@collection` annotations are resolved after traversal by the database
+    /// enrichment layer, so they do not change traversal scope here.
+    pub(super) fn node_matches_bound_pattern(
+        id: u64,
+        node: &NodePattern,
+        payload_storage: &crate::storage::LogPayloadStorage,
+    ) -> bool {
+        if node.collection.is_some() {
+            return true;
+        }
+        let needs_payload = !node.properties.is_empty() || !node.labels.is_empty();
+        Self::node_matches_pattern(id, node, needs_payload, payload_storage)
     }
 
     /// Builds a `(node_id, bindings)` pair for a start node.

--- a/crates/velesdb-core/src/collection/search/query/query_pipeline.rs
+++ b/crates/velesdb-core/src/collection/search/query/query_pipeline.rs
@@ -231,10 +231,9 @@ impl Collection {
         stmt: &crate::velesql::SelectStatement,
         results: &[SearchResult],
     ) -> Vec<SearchResult> {
-        let group_by = stmt
-            .group_by
-            .as_ref()
-            .expect("invariant: execute_vector_group_by_query requires stmt.group_by.is_some()");
+        let Some(group_by) = stmt.group_by.as_ref() else {
+            return results.to_vec();
+        };
         let aggregations = Self::extract_aggregations(&stmt.columns);
         let limit_hint = stmt.limit.map(|l| usize::try_from(l).unwrap_or(MAX_LIMIT));
         let config = vector_group_by::VectorGroupByConfig {

--- a/crates/velesdb-core/src/database/database_helpers.rs
+++ b/crates/velesdb-core/src/database/database_helpers.rs
@@ -104,18 +104,10 @@ impl Database {
         point: &crate::Point,
         filter: Option<&crate::Filter>,
     ) -> bool {
-        let Some(filter) = filter else {
-            return true;
-        };
-
-        let mut obj = point
-            .payload
-            .as_ref()
-            .and_then(serde_json::Value::as_object)
-            .cloned()
-            .unwrap_or_default();
-        obj.insert("id".to_string(), serde_json::json!(point.id));
-        filter.matches(&serde_json::Value::Object(obj))
+        match filter {
+            Some(filter) => Self::point_matches_filter(point, filter),
+            None => true,
+        }
     }
 
     /// Builds a `ColumnStore` from a collection, filtering points by pushed-down conditions.
@@ -162,7 +154,9 @@ impl Database {
         filters: &[crate::velesql::Condition],
     ) -> crate::velesql::Condition {
         let mut iter = filters.iter().cloned();
-        let first = iter.next().expect("filters is non-empty");
+        let Some(first) = iter.next() else {
+            unreachable!("caller must pass at least one filter");
+        };
         iter.fold(first, |acc, c| {
             crate::velesql::Condition::And(Box::new(acc), Box::new(c))
         })

--- a/crates/velesdb-core/src/index/bm25_persistence_wal.rs
+++ b/crates/velesdb-core/src/index/bm25_persistence_wal.rs
@@ -96,8 +96,8 @@ fn encode_text_len(text_bytes: &[u8]) -> Result<u32> {
 /// overflows `u32`.
 #[inline]
 fn add_entry_body_len(text_len: u32) -> Result<u32> {
-    let header =
-        u32::try_from(ADD_ENTRY_HEADER).expect("ADD_ENTRY_HEADER fits in u32 (compile-time)");
+    let header = u32::try_from(ADD_ENTRY_HEADER)
+        .map_err(|_| Error::Index("BM25 WAL: add header too large".to_string()))?;
     header.checked_add(text_len).ok_or_else(|| {
         Error::Index(format!(
             "BM25 WAL: entry too large (text_len={text_len}) to fit in u32 prefix"
@@ -131,8 +131,8 @@ fn write_add_entry_body(
 /// written.
 #[inline]
 pub(crate) fn wal_append_remove_document(wal_path: &Path, id: u64) -> Result<()> {
-    // Fits in a `u32` by construction — constant header size = 9.
-    let body_len = u32::try_from(REMOVE_ENTRY_HEADER).expect("REMOVE_ENTRY_HEADER <= u32::MAX");
+    let body_len = u32::try_from(REMOVE_ENTRY_HEADER)
+        .map_err(|_| Error::Index("BM25 WAL: remove header too large".to_string()))?;
     let mut w = open_wal_writer(wal_path)?;
     wal_write(&mut w, &body_len.to_le_bytes())?;
     wal_write(&mut w, &[WAL_OP_REMOVE])?;

--- a/crates/velesdb-core/src/index/hnsw/native/dual_precision.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/dual_precision.rs
@@ -165,10 +165,10 @@ impl<D: DistanceEngine> DualPrecisionHnsw<D> {
 
         // Train on accumulated samples
         let refs: Vec<&[f32]> = self.training_buffer.iter().map(Vec::as_slice).collect();
-        // Training buffer is guarded by `is_empty()` check above, so this cannot fail.
-        let quantizer = Arc::new(
-            ScalarQuantizer::train(&refs).expect("invariant: training_buffer is non-empty"),
-        );
+        let Ok(trained) = ScalarQuantizer::train(&refs) else {
+            return;
+        };
+        let quantizer = Arc::new(trained);
 
         // Create quantized store and quantize all existing vectors
         let mut store = QuantizedVectorStore::new(Arc::clone(&quantizer), self.inner.len() + 1000);

--- a/crates/velesdb-core/src/velesql/parser/select/clause_projection.rs
+++ b/crates/velesdb-core/src/velesql/parser/select/clause_projection.rs
@@ -74,7 +74,7 @@ impl SelectItemAccumulator {
 
     /// Converts when exactly one item type is present.
     /// Falls back to `Mixed` for multi-element similarity/wildcard.
-    fn into_single_type(self) -> SelectColumns {
+    fn into_single_type(mut self) -> SelectColumns {
         if !self.columns.is_empty() {
             return SelectColumns::Columns(self.columns);
         }
@@ -82,20 +82,14 @@ impl SelectItemAccumulator {
             return SelectColumns::Aggregations(self.aggregations);
         }
         if self.similarity_scores.len() == 1 {
-            return SelectColumns::SimilarityScore(
-                self.similarity_scores
-                    .into_iter()
-                    .next()
-                    .expect("checked len==1"),
-            );
+            if let Some(score) = self.similarity_scores.pop() {
+                return SelectColumns::SimilarityScore(score);
+            }
         }
         if self.qualified_wildcards.len() == 1 {
-            return SelectColumns::QualifiedWildcard(
-                self.qualified_wildcards
-                    .into_iter()
-                    .next()
-                    .expect("checked len==1"),
-            );
+            if let Some(wildcard) = self.qualified_wildcards.pop() {
+                return SelectColumns::QualifiedWildcard(wildcard);
+            }
         }
         // Multiple similarity scores, wildcards, or window functions without other types -> Mixed
         SelectColumns::Mixed {

--- a/crates/velesdb-core/tests/bdd/cross_collection.rs
+++ b/crates/velesdb-core/tests/bdd/cross_collection.rs
@@ -339,6 +339,13 @@ fn test_cross_collection_match_enrichment() {
                 !res.is_empty(),
                 "Cross-collection MATCH should return results"
             );
+            let payload = res[0]
+                .point
+                .payload
+                .as_ref()
+                .expect("test: enriched payload should exist");
+            assert_eq!(payload.get("w.price"), Some(&json!(99.99)));
+            assert_eq!(payload.get("w.stock"), Some(&json!(50)));
         }
         Err(e) => {
             let msg = e.to_string();

--- a/crates/velesdb-core/tests/bdd/match_graph_first.rs
+++ b/crates/velesdb-core/tests/bdd/match_graph_first.rs
@@ -26,9 +26,9 @@
 //!
 //! | Category | Count | Share |
 //! |----------|-------|-------|
-//! | Nominal  |   3   |  50%  |
-//! | Edge     |   2   |  33%  |
-//! | Negative |   1   |  17%  |
+//! | Nominal  |  10   |  77%  |
+//! | Edge     |   2   |  15%  |
+//! | Negative |   1   |   8%  |
 
 use std::collections::HashMap;
 
@@ -115,6 +115,55 @@ fn setup_graph_first_collection(db: &Database) {
     vc.add_edge(edge).expect("test: add edge 1->2 CITES");
 }
 
+fn setup_ordered_pattern_collection(db: &Database) {
+    db.create_vector_collection("patterns", 4, velesdb_core::DistanceMetric::Cosine)
+        .expect("test: create patterns collection");
+    let vc = db
+        .get_vector_collection("patterns")
+        .expect("test: get patterns collection");
+
+    vc.upsert(vec![
+        Point::new(
+            10,
+            vec![1.0, 0.0, 0.0, 0.0],
+            Some(json!({"_labels": ["Step"], "name": "start"})),
+        ),
+        Point::new(
+            11,
+            vec![0.0, 1.0, 0.0, 0.0],
+            Some(json!({"_labels": ["Step"], "name": "wrong-middle"})),
+        ),
+        Point::new(
+            12,
+            vec![0.0, 0.0, 1.0, 0.0],
+            Some(json!({"_labels": ["Step"], "name": "end"})),
+        ),
+        Point::new(
+            13,
+            vec![0.0, 0.0, 0.0, 1.0],
+            Some(json!({"_labels": ["Step"], "name": "right-middle"})),
+        ),
+        Point::new(
+            14,
+            vec![0.5, 0.5, 0.0, 0.0],
+            Some(json!({"_labels": ["Other"], "name": "wrong-label"})),
+        ),
+    ])
+    .expect("test: upsert patterns");
+
+    for (id, source, target, label) in [
+        (201, 10, 11, "R2"),
+        (202, 11, 12, "R1"),
+        (203, 10, 13, "R1"),
+        (204, 13, 12, "R2"),
+        (205, 10, 14, "R1"),
+        (206, 14, 12, "R2"),
+    ] {
+        vc.add_edge(GraphEdge::new(id, source, target, label).expect("test: edge"))
+            .expect("test: add edge");
+    }
+}
+
 /// Builds a params map with only the `_collection` routing key.
 fn collection_param(collection: &str) -> HashMap<String, serde_json::Value> {
     let mut params = HashMap::new();
@@ -149,6 +198,13 @@ fn assert_graph_first_planned(sql: &str) {
         matches!(strategy, MatchExecutionStrategy::GraphFirst { .. }),
         "planner must select GraphFirst for '{sql}', got: {strategy:?}"
     );
+}
+
+fn payload_field<'a>(
+    result: &'a velesdb_core::SearchResult,
+    key: &str,
+) -> Option<&'a serde_json::Value> {
+    result.point.payload.as_ref()?.get(key)
 }
 
 // =========================================================================
@@ -191,6 +247,207 @@ fn test_match_graph_first_basic_traversal_returns_connected_pair() {
     assert!(
         !ids.contains(&3) && !ids.contains(&4),
         "isolated Documents 3 and 4 must not appear as traversal targets, got: {ids:?}"
+    );
+}
+
+#[test]
+fn test_match_graph_first_enforces_relationship_order_and_node_labels() {
+    let (_dir, db) = create_test_db();
+    setup_ordered_pattern_collection(&db);
+
+    let sql = "MATCH (a:Step)-[:R1]->(b:Step)-[:R2]->(c:Step) \
+               RETURN a, b, c LIMIT 10";
+    let query = velesdb_core::velesql::Parser::parse(sql).expect("test: parse ordered MATCH");
+    let results = db
+        .execute_query(&query, &collection_param("patterns"))
+        .expect("test: ordered MATCH should succeed");
+
+    assert_eq!(results.len(), 1, "only the ordered Step path should match");
+    assert_eq!(results[0].point.id, 12);
+    assert_eq!(
+        payload_field(&results[0], "b.name"),
+        Some(&json!("right-middle")),
+        "intermediate binding must be the R1 then R2 Step node"
+    );
+    assert_eq!(
+        payload_field(&results[0], "_bindings").and_then(|v| v.get("b")),
+        Some(&json!(13)),
+        "bindings must retain the intermediate node alias"
+    );
+}
+
+#[test]
+fn test_match_graph_first_rejects_wrong_relationship_order() {
+    let (_dir, db) = create_test_db();
+    setup_ordered_pattern_collection(&db);
+
+    let sql = "MATCH (a:Step)-[:R2]->(b:Step)-[:R2]->(c:Step) \
+               RETURN a, b, c LIMIT 10";
+    let query = velesdb_core::velesql::Parser::parse(sql).expect("test: parse wrong order MATCH");
+    let results = db
+        .execute_query(&query, &collection_param("patterns"))
+        .expect("test: wrong order MATCH should execute");
+
+    assert!(
+        results.is_empty(),
+        "flattened relationship labels must not create a false multi-hop match"
+    );
+}
+
+#[test]
+fn test_match_graph_first_supports_incoming_direction() {
+    let (_dir, db) = create_test_db();
+    setup_graph_first_collection(&db);
+
+    let sql = "MATCH (ref:Reference)<-[:CITES]-(doc:Document) \
+               RETURN doc, ref LIMIT 10";
+    let query = velesdb_core::velesql::Parser::parse(sql).expect("test: parse incoming MATCH");
+    let results = db
+        .execute_query(&query, &collection_param("papers"))
+        .expect("test: incoming MATCH should succeed");
+
+    assert_eq!(results.len(), 1);
+    assert_eq!(
+        payload_field(&results[0], "_bindings").and_then(|v| v.get("doc")),
+        Some(&json!(1))
+    );
+    assert_eq!(
+        payload_field(&results[0], "_bindings").and_then(|v| v.get("ref")),
+        Some(&json!(2))
+    );
+}
+
+#[test]
+fn test_match_graph_first_variable_length_binds_terminal_node() {
+    let (_dir, db) = create_test_db();
+    setup_ordered_pattern_collection(&db);
+
+    let sql = "MATCH (a:Step)-[*1..2]->(c:Step) RETURN a, c LIMIT 10";
+    let query =
+        velesdb_core::velesql::Parser::parse(sql).expect("test: parse variable length MATCH");
+    let results = db
+        .execute_query(&query, &collection_param("patterns"))
+        .expect("test: variable length MATCH should succeed");
+
+    let terminal_ids: std::collections::HashSet<u64> =
+        results.iter().map(|result| result.point.id).collect();
+    assert!(
+        terminal_ids.contains(&12),
+        "variable-length traversal must bind the terminal Step node"
+    );
+}
+
+/// Collects the `(a, b)` binding pairs from `_bindings` across all results.
+fn binding_pairs(
+    results: &[velesdb_core::SearchResult],
+    first: &str,
+    second: &str,
+) -> std::collections::HashSet<(u64, u64)> {
+    results
+        .iter()
+        .filter_map(|r| {
+            let b = payload_field(r, "_bindings")?;
+            Some((b.get(first)?.as_u64()?, b.get(second)?.as_u64()?))
+        })
+        .collect()
+}
+
+#[test]
+fn test_match_graph_first_undirected_traverses_both_directions() {
+    let (_dir, db) = create_test_db();
+    setup_ordered_pattern_collection(&db);
+
+    let sql = "MATCH (a:Step)-[:R2]-(b:Step) RETURN a, b LIMIT 20";
+    let query = velesdb_core::velesql::Parser::parse(sql).expect("test: parse undirected MATCH");
+    let results = db
+        .execute_query(&query, &collection_param("patterns"))
+        .expect("test: undirected MATCH should succeed");
+
+    let pairs = binding_pairs(&results, "a", "b");
+    // R2 edges between Step nodes: 10->11 and 13->12. Undirected `-[:R2]-` must
+    // bind BOTH orientations of each (the reverse pairs are impossible directed).
+    assert!(
+        pairs.contains(&(10, 11)) && pairs.contains(&(11, 10)),
+        "undirected R2 must bind the 10/11 edge both ways, got: {pairs:?}"
+    );
+    assert!(
+        pairs.contains(&(13, 12)) && pairs.contains(&(12, 13)),
+        "undirected R2 must bind the 13/12 edge both ways, got: {pairs:?}"
+    );
+    assert_eq!(
+        pairs.len(),
+        4,
+        "exactly the two Step R2 edges, each in both directions, got: {pairs:?}"
+    );
+}
+
+#[test]
+fn test_match_graph_first_multi_type_relationship_matches_either() {
+    let (_dir, db) = create_test_db();
+    setup_ordered_pattern_collection(&db);
+
+    let sql = "MATCH (a:Step)-[:R1|R2]->(b:Step) RETURN a, b LIMIT 20";
+    let query = velesdb_core::velesql::Parser::parse(sql).expect("test: parse multi-type MATCH");
+    let results = db
+        .execute_query(&query, &collection_param("patterns"))
+        .expect("test: multi-type MATCH should succeed");
+
+    let pairs = binding_pairs(&results, "a", "b");
+    // From node 10 the union of types must surface BOTH the R2 edge (10->11)
+    // and the R1 edge (10->13).
+    assert!(
+        pairs.contains(&(10, 11)),
+        "R2 edge 10->11 must match via the multi-type relationship, got: {pairs:?}"
+    );
+    assert!(
+        pairs.contains(&(10, 13)),
+        "R1 edge 10->13 must match via the multi-type relationship, got: {pairs:?}"
+    );
+    // Outgoing R1|R2 Step->Step edges: 10->11, 10->13, 11->12, 13->12
+    // (10->14 excluded: node 14 is :Other).
+    assert_eq!(
+        pairs.len(),
+        4,
+        "exactly the four Step->Step R1/R2 edges, got: {pairs:?}"
+    );
+}
+
+#[test]
+fn test_match_graph_first_intermediate_node_property_filters() {
+    let (_dir, db) = create_test_db();
+    setup_ordered_pattern_collection(&db);
+
+    // Node 13 ("right-middle") is the only R1-reachable Step with an outgoing R2.
+    let matching = "MATCH (a:Step)-[:R1]->(b:Step {name: 'right-middle'})-[:R2]->(c:Step) \
+                    RETURN a, b, c LIMIT 10";
+    let query = velesdb_core::velesql::Parser::parse(matching).expect("test: parse matching MATCH");
+    let results = db
+        .execute_query(&query, &collection_param("patterns"))
+        .expect("test: intermediate-property MATCH should succeed");
+
+    assert_eq!(
+        results.len(),
+        1,
+        "only the right-middle path satisfies the intermediate property"
+    );
+    assert_eq!(
+        payload_field(&results[0], "_bindings").and_then(|v| v.get("b")),
+        Some(&json!(13)),
+        "intermediate binding must be the property-matched node"
+    );
+
+    // Same shape, non-existent intermediate property: the predicate on the
+    // bound intermediate node must reject the otherwise-valid 10->13->12 path.
+    let mismatch = "MATCH (a:Step)-[:R1]->(b:Step {name: 'no-such-name'})-[:R2]->(c:Step) \
+                    RETURN a, b, c LIMIT 10";
+    let query = velesdb_core::velesql::Parser::parse(mismatch).expect("test: parse mismatch MATCH");
+    let results = db
+        .execute_query(&query, &collection_param("patterns"))
+        .expect("test: mismatch MATCH should execute");
+    assert!(
+        results.is_empty(),
+        "an intermediate-node property predicate must filter the path, got {} rows",
+        results.len()
     );
 }
 

--- a/crates/velesdb-server/src/handlers/match_query.rs
+++ b/crates/velesdb-server/src/handlers/match_query.rs
@@ -126,18 +126,15 @@ pub async fn match_query(
 ) -> Result<Json<MatchQueryResponse>, (StatusCode, Json<MatchQueryError>)> {
     let start = std::time::Instant::now();
 
-    let collection = state
-        .db
-        .get_vector_collection(&collection_name)
-        .ok_or_else(|| {
-            mk_match_error(
-                StatusCode::NOT_FOUND,
-                format!("Collection '{}' not found", collection_name),
-                "COLLECTION_NOT_FOUND",
-                "Create the collection first or correct the collection name in the route",
-                Some(serde_json::json!({ "collection": collection_name })),
-            )
-        })?;
+    let collection = resolve_match_collection(&state, &collection_name).ok_or_else(|| {
+        mk_match_error(
+            StatusCode::NOT_FOUND,
+            format!("Collection '{}' not found", collection_name),
+            "COLLECTION_NOT_FOUND",
+            "Create the collection first or correct the collection name in the route",
+            Some(serde_json::json!({ "collection": collection_name })),
+        )
+    })?;
 
     let match_clause = parse_match_clause(&request.query)?;
     validate_threshold(request.threshold)?;
@@ -218,17 +215,44 @@ fn validate_threshold(threshold: Option<f32>) -> Result<(), (StatusCode, Json<Ma
     Ok(())
 }
 
-/// Execute a MATCH query, dispatching to similarity or plain variant.
+enum MatchCollection {
+    Vector(velesdb_core::collection::VectorCollection),
+    Graph(velesdb_core::collection::GraphCollection),
+}
+
+fn resolve_match_collection(state: &AppState, name: &str) -> Option<MatchCollection> {
+    state
+        .db
+        .get_vector_collection(name)
+        .map(MatchCollection::Vector)
+        .or_else(|| {
+            state
+                .db
+                .get_graph_collection(name)
+                .map(MatchCollection::Graph)
+        })
+}
+
 fn execute_match(
-    collection: &velesdb_core::collection::VectorCollection,
+    collection: &MatchCollection,
     match_clause: &velesdb_core::velesql::MatchClause,
     request: &MatchQueryRequest,
 ) -> Result<Vec<MatchQueryResultItem>, (StatusCode, Json<MatchQueryError>)> {
     let raw_results = if let Some(ref vector) = request.vector {
         let threshold = request.threshold.unwrap_or(0.0);
-        collection.execute_match_with_similarity(match_clause, vector, threshold, &request.params)
+        match collection {
+            MatchCollection::Vector(coll) => {
+                coll.execute_match_with_similarity(match_clause, vector, threshold, &request.params)
+            }
+            MatchCollection::Graph(coll) => {
+                coll.execute_match_with_similarity(match_clause, vector, threshold, &request.params)
+            }
+        }
     } else {
-        collection.execute_match(match_clause, &request.params)
+        match collection {
+            MatchCollection::Vector(coll) => coll.execute_match(match_clause, &request.params),
+            MatchCollection::Graph(coll) => coll.execute_match(match_clause, &request.params),
+        }
     };
 
     raw_results

--- a/crates/velesdb-server/src/handlers/query/mod.rs
+++ b/crates/velesdb-server/src/handlers/query/mod.rs
@@ -255,28 +255,7 @@ fn execute_mutation_query(
     match state.db.execute_query(parsed, params) {
         Ok(results) => {
             let coll_name = extract_mutation_collection_name(parsed);
-            notify_query_timing(state, &coll_name, start);
-            let elapsed = start.elapsed();
-            let timing_ms = elapsed.as_secs_f64() * 1000.0;
-            #[allow(clippy::cast_possible_truncation)]
-            // Reason: timing_ms is always < u64::MAX (query durations < 585 millennia)
-            let took_ms = timing_ms.round() as u64;
-            state
-                .query_duration_histogram
-                .observe(elapsed.as_secs_f64());
-            let projected = projection::project_results(&results, &parsed.select.columns);
-            let rows_returned = projected.len();
-            Json(QueryResponse {
-                results: projected,
-                timing_ms,
-                took_ms,
-                rows_returned,
-                meta: QueryResponseMeta {
-                    velesql_contract_version: VELESQL_CONTRACT_VERSION.to_string(),
-                    count: rows_returned,
-                },
-            })
-            .into_response()
+            build_query_response(state, &coll_name, start, results, &parsed.select.columns)
         }
         Err(e) => {
             state.operational_metrics.inc_errors();
@@ -329,19 +308,11 @@ fn execute_standard_query(
     req: &QueryRequest,
 ) -> Result<Vec<velesdb_core::SearchResult>, axum::response::Response> {
     let execute_result = if parsed.is_match_query() {
-        // MATCH queries need a collection instance for execute_query.
-        // Route through typed registries: vector → graph → metadata.
-        if let Some(vc) = state.db.get_vector_collection(collection_name) {
-            vc.execute_query(parsed, &req.params)
-        } else if let Some(gc) = state.db.get_graph_collection(collection_name) {
-            gc.execute_query(parsed, &req.params)
-        } else if let Some(mc) = state.db.get_metadata_collection(collection_name) {
-            mc.execute_query(parsed, &req.params)
-        } else {
-            Err(velesdb_core::Error::CollectionNotFound(
-                collection_name.to_string(),
-            ))
-        }
+        let mut params = req.params.clone();
+        params
+            .entry("_collection".to_string())
+            .or_insert_with(|| serde_json::json!(collection_name));
+        state.db.execute_query(parsed, &params)
     } else {
         state.db.execute_query(parsed, &req.params)
     };

--- a/crates/velesdb-server/src/main.rs
+++ b/crates/velesdb-server/src/main.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::doc_markdown)]
 //! `VelesDB` Server - REST API for the `VelesDB` vector database.
 
-use axum::{middleware::Next, Router};
+use axum::{http::HeaderValue, middleware::Next, Router};
 use clap::Parser;
 use std::future::IntoFuture;
 use std::net::SocketAddr;
@@ -134,10 +134,10 @@ async fn deprecation_header(
 ) -> axum::response::Response {
     let mut response = next.run(request).await;
     let headers = response.headers_mut();
-    headers.insert("deprecation", "true".parse().expect("static header value"));
+    headers.insert("deprecation", HeaderValue::from_static("true"));
     headers.insert(
         "x-api-deprecated",
-        "Use /v1/ prefix".parse().expect("static header value"),
+        HeaderValue::from_static("Use /v1/ prefix"),
     );
     response
 }
@@ -206,10 +206,11 @@ fn warn_if_exposed(host: &str) {
 async fn sigterm() {
     #[cfg(unix)]
     {
-        tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
-            .expect("failed to install SIGTERM handler")
-            .recv()
-            .await;
+        if let Ok(mut signal) =
+            tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+        {
+            signal.recv().await;
+        }
     }
     #[cfg(not(unix))]
     std::future::pending::<()>().await;

--- a/crates/velesdb-wasm/src/serialization.rs
+++ b/crates/velesdb-wasm/src/serialization.rs
@@ -30,9 +30,9 @@ pub fn export_to_bytes(store: &VectorStore) -> Vec<u8> {
     bytes.push(1);
 
     // Dimension
-    // Reason: WASM vector dimensions are always < 100K (model constraints), safely < u32::MAX
-    let dim_u32 = u32::try_from(store.dimension)
-        .expect("dimension fits in u32: WASM model dimensions are always well below 2^32");
+    let Ok(dim_u32) = u32::try_from(store.dimension) else {
+        return Vec::new();
+    };
     bytes.extend_from_slice(&dim_u32.to_le_bytes());
 
     // Metric
@@ -40,9 +40,9 @@ pub fn export_to_bytes(store: &VectorStore) -> Vec<u8> {
     bytes.push(metric_byte);
 
     // Vector count
-    // Reason: WASM memory limits (4GB) prevent > u64::MAX vectors anyway
-    let count_u64 =
-        u64::try_from(count).expect("count fits in u64: usize <= u64 on all WASM targets");
+    let Ok(count_u64) = u64::try_from(count) else {
+        return Vec::new();
+    };
     bytes.extend_from_slice(&count_u64.to_le_bytes());
 
     // Data

--- a/crates/velesdb-wasm/src/velesql_orderby.rs
+++ b/crates/velesdb-wasm/src/velesql_orderby.rs
@@ -122,12 +122,10 @@ fn compare_json_with_nulls(
         (true, true) => Ordering::Equal,
         (true, false) => Ordering::Greater,
         (false, true) => Ordering::Less,
-        (false, false) => {
-            // Safe to unwrap: both are Some and non-null per the match arms.
-            let l = left.expect("left is non-null here");
-            let r = right.expect("right is non-null here");
-            json_values_cmp(l, r).unwrap_or(Ordering::Equal)
-        }
+        (false, false) => match (left, right) {
+            (Some(l), Some(r)) => json_values_cmp(l, r).unwrap_or(Ordering::Equal),
+            _ => Ordering::Equal,
+        },
     }
 }
 

--- a/docs/guides/GRAPH_PATTERNS.md
+++ b/docs/guides/GRAPH_PATTERNS.md
@@ -98,7 +98,7 @@ MATCH only sees edges in the current collection's edge store. If edges were crea
 
 ### 3. Expecting cross-collection traversal
 
-MATCH is scoped to a single collection. It does not join across collections. **Fix**: store all relevant points and edges in one collection, or use the direct graph API to query each collection separately and merge results in application code.
+MATCH traversal is scoped to the primary collection. `@collection` annotations can enrich bound node payloads from another collection after traversal, but they do not make edges span multiple graph stores. **Fix**: keep edges in the primary graph collection, then use `alias@collection` for payload enrichment when needed.
 
 ### 4. Label mismatch (case-sensitive)
 
@@ -113,7 +113,7 @@ Labels are case-sensitive. `"Product"` and `"product"` are different labels. Ens
 | **Scope** | Single collection | Single `GraphCollection` |
 | **Query style** | Declarative (SQL-like) | Imperative (method calls) |
 | **Vector + graph fusion** | Built-in (`similarity()` in WHERE) | Manual (search + traverse separately) |
-| **Cross-collection** | Not supported | Possible via application code |
+| **Cross-collection** | Payload enrichment via `@collection` | Possible via application code |
 
 **Use MATCH when**: you need graph patterns combined with vector similarity or metadata filtering in a single query within one collection.
 

--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -676,16 +676,26 @@ Analyze query execution plan without running the query.
 
 ## Graph API
 
-### POST /collections/:name/graph/nodes
+### GET /collections/:name/graph/nodes
 
-Add nodes to the knowledge graph.
+List node IDs present in a graph collection.
+
+**Response:**
+```json
+{
+  "node_ids": [1, 2, 3],
+  "count": 3
+}
+```
+
+### PUT /collections/:name/graph/nodes/:id/payload
+
+Create or replace the JSON payload attached to a graph node.
 
 **Request Body:**
 ```json
 {
-  "nodes": [
-    {"id": "doc1", "label": "Document", "properties": {"title": "AI Guide"}}
-  ]
+  "payload": {"_labels": ["Document"], "title": "AI Guide"}
 }
 ```
 
@@ -696,11 +706,15 @@ Add edges between nodes.
 **Request Body:**
 ```json
 {
-  "edges": [
-    {"source": "doc1", "target": "author1", "label": "AUTHORED_BY", "properties": {}}
-  ]
+  "id": 100,
+  "source": 1,
+  "target": 2,
+  "label": "AUTHORED_BY",
+  "properties": {"year": 2026}
 }
 ```
+
+`id`, `source`, and `target` accept either JSON numbers or strings. Responses serialize graph IDs as strings to preserve full `u64` precision in JavaScript clients.
 
 ### POST /collections/:name/graph/traverse
 
@@ -710,31 +724,30 @@ Traverse the graph using BFS or DFS.
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| start_node | string | Yes | Starting node ID |
-| direction | string | No | `outgoing`, `incoming`, or `both` (default) |
+| source | integer/string | Yes | Starting node ID |
+| strategy | string | No | `bfs` or `dfs` (default: `bfs`) |
 | max_depth | integer | No | Maximum traversal depth (default: 3) |
-| edge_filter | string | No | Filter edges by label |
+| limit | integer | No | Maximum number of results (default: 100) |
+| rel_types | array[string] | No | Filter by relationship labels |
 
 **Example:**
 ```json
 {
-  "start_node": "doc1",
-  "direction": "outgoing",
+  "source": 1,
+  "strategy": "bfs",
   "max_depth": 2,
-  "edge_filter": "AUTHORED_BY"
+  "rel_types": ["AUTHORED_BY"]
 }
 ```
 
 **Response:**
 ```json
 {
-  "nodes": [
-    {"id": "doc1", "label": "Document", "depth": 0},
-    {"id": "author1", "label": "Person", "depth": 1}
+  "results": [
+    {"target_id": "2", "depth": 1, "path": [100]}
   ],
-  "edges": [
-    {"source": "doc1", "target": "author1", "label": "AUTHORED_BY"}
-  ]
+  "has_more": false,
+  "stats": {"visited": 1, "depth_reached": 1}
 }
 ```
 

--- a/scripts/check_prod_unwraps.py
+++ b/scripts/check_prod_unwraps.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 """
-Detect `.unwrap()` calls in production Rust code.
+Detect `.unwrap()` and `.expect(...)` calls in production Rust code.
 
-Scans all workspace crate `src/` directories for `.unwrap()` in production code.
+Scans all workspace crate `src/` directories for fallible panics in production code.
 Skips test code, comments, and doc examples.
 
 Exit code 0 = clean, 1 = violations found.
@@ -14,7 +14,7 @@ import re
 import sys
 from pathlib import Path
 
-UNWRAP_RE = re.compile(r"\.unwrap\(\)")
+PANIC_RE = re.compile(r"\.(unwrap|expect)\s*\(")
 
 SCAN_DIRS = [
     Path("crates/velesdb-core/src"),
@@ -38,7 +38,7 @@ def is_production_file(path: Path) -> bool:
 
 
 def scan_file(path: Path) -> list[tuple[int, str]]:
-    """Return list of (line_number, line_text) with .unwrap() in production code."""
+    """Return list of (line_number, line_text) with fallible panics."""
     try:
         lines = path.read_text(encoding="utf-8").splitlines()
     except Exception:
@@ -87,7 +87,7 @@ def scan_file(path: Path) -> list[tuple[int, str]]:
                 in_cfg_test = False
             continue
 
-        if UNWRAP_RE.search(line):
+        if PANIC_RE.search(line):
             violations.append((line_no, stripped))
 
     return violations
@@ -107,16 +107,19 @@ def main() -> int:
                 all_violations.append(f"{path}:{line_no}: {text}")
 
     if all_violations:
-        print(f"FAILED: found {len(all_violations)} .unwrap() call(s) in production code:")
+        print(
+            f"FAILED: found {len(all_violations)} .unwrap()/.expect() call(s) "
+            "in production code:"
+        )
         for v in all_violations:
             print(f"  {v}")
         print(
-            "\nUse ? / .expect(\"reason\") / .unwrap_or() / match instead.",
+            "\nUse ? / unwrap_or() / match instead.",
             file=sys.stderr,
         )
         return 1
 
-    print("PASSED: no .unwrap() in production code.")
+    print("PASSED: no .unwrap()/.expect() in production code.")
     return 0
 
 

--- a/sdks/typescript/src/backends/graph-backend.ts
+++ b/sdks/typescript/src/backends/graph-backend.ts
@@ -48,10 +48,8 @@ export async function addEdge(
  * `id`/`source`/`target` arrive as **strings** because the server's
  * `EdgeResponse` struct uses `serialize_id_as_string` to avoid
  * JavaScript `Number.MAX_SAFE_INTEGER` precision loss on u64 values.
- * The `toGraphEdge` helper coerces them back to the `number` shape
- * declared on the public `GraphEdge` interface (PR #586 fix applied
- * to the pre-existing `getEdges` wrapper for consistency with the
- * `getNodeEdges` fix landed earlier in the same PR).
+ * The `toGraphEdge` helper preserves string IDs so u64 values above
+ * `Number.MAX_SAFE_INTEGER` remain exact in JavaScript.
  */
 interface EdgeWire {
   id: number | string;
@@ -62,14 +60,42 @@ interface EdgeWire {
 }
 
 function toGraphEdge(e: EdgeWire): GraphEdge {
-  const toNum = (v: number | string): number =>
-    typeof v === 'string' ? Number(v) : v;
   return {
-    id: toNum(e.id),
-    source: toNum(e.source),
-    target: toNum(e.target),
+    id: e.id,
+    source: e.source,
+    target: e.target,
     label: e.label,
     properties: e.properties,
+  };
+}
+
+/**
+ * Raw wire shape of a traverse / traverse-parallel response.
+ *
+ * `target_id` and `path` arrive as `number | string` to preserve u64 node IDs
+ * above `Number.MAX_SAFE_INTEGER` (see {@link EdgeWire}).
+ */
+interface TraverseWire {
+  results: Array<{ target_id: number | string; depth: number; path: Array<number | string> }>;
+  next_cursor: string | null;
+  has_more: boolean;
+  stats: { visited: number; depth_reached: number };
+}
+
+/** Maps a raw traverse wire response to the public {@link TraverseResponse}. */
+function toTraverseResponse(data: TraverseWire): TraverseResponse {
+  return {
+    results: data.results.map(r => ({
+      targetId: r.target_id,
+      depth: r.depth,
+      path: r.path,
+    })),
+    nextCursor: data.next_cursor ?? undefined,
+    hasMore: data.has_more,
+    stats: {
+      visited: data.stats.visited,
+      depthReached: data.stats.depth_reached,
+    },
   };
 }
 
@@ -95,12 +121,7 @@ export async function traverseGraph(
   collection: string,
   request: TraverseRequest
 ): Promise<TraverseResponse> {
-  const response = await transport.requestJson<{
-    results: Array<{ target_id: number; depth: number; path: number[] }>;
-    next_cursor: string | null;
-    has_more: boolean;
-    stats: { visited: number; depth_reached: number };
-  }>(
+  const response = await transport.requestJson<TraverseWire>(
     'POST',
     `${collectionPath(collection)}/graph/traverse`,
     {
@@ -115,20 +136,7 @@ export async function traverseGraph(
 
   throwOnError(response, `Collection '${collection}'`);
 
-  const data = response.data!;
-  return {
-    results: data.results.map(r => ({
-      targetId: r.target_id,
-      depth: r.depth,
-      path: r.path,
-    })),
-    nextCursor: data.next_cursor ?? undefined,
-    hasMore: data.has_more,
-    stats: {
-      visited: data.stats.visited,
-      depthReached: data.stats.depth_reached,
-    },
-  };
+  return toTraverseResponse(response.data!);
 }
 
 export async function getNodeDegree(
@@ -170,12 +178,7 @@ export async function traverseParallel(
   collection: string,
   request: TraverseParallelRequest
 ): Promise<TraverseResponse> {
-  const response = await transport.requestJson<{
-    results: Array<{ target_id: number; depth: number; path: number[] }>;
-    next_cursor: string | null;
-    has_more: boolean;
-    stats: { visited: number; depth_reached: number };
-  }>(
+  const response = await transport.requestJson<TraverseWire>(
     'POST',
     `${collectionPath(collection)}/graph/traverse/parallel`,
     {
@@ -188,18 +191,5 @@ export async function traverseParallel(
 
   throwOnError(response, `Collection '${collection}'`);
 
-  const data = response.data!;
-  return {
-    results: data.results.map(r => ({
-      targetId: r.target_id,
-      depth: r.depth,
-      path: r.path,
-    })),
-    nextCursor: data.next_cursor ?? undefined,
-    hasMore: data.has_more,
-    stats: {
-      visited: data.stats.visited,
-      depthReached: data.stats.depth_reached,
-    },
-  };
+  return toTraverseResponse(response.data!);
 }

--- a/sdks/typescript/src/backends/missing-endpoints.ts
+++ b/sdks/typescript/src/backends/missing-endpoints.ts
@@ -341,10 +341,8 @@ export async function listNodes(
  * `EdgeResponse` struct uses `#[serde(serialize_with =
  * "serde_id::serialize_id_as_string")]` to avoid JavaScript's
  * `Number.MAX_SAFE_INTEGER` (2^53-1) precision loss on u64 values.
- * The `idToNumber` helper coerces them back to the `number` shape
- * declared on the public `GraphEdge` interface; callers that need
- * u64-safe IDs should migrate to the TypeScript `bigint` surface
- * (tracked as a follow-up for Sprint 3+ streaming API commit).
+ * The mapper preserves string IDs so u64 values above
+ * `Number.MAX_SAFE_INTEGER` remain exact in JavaScript.
  */
 interface EdgeWire {
   id: number | string;
@@ -354,15 +352,8 @@ interface EdgeWire {
   properties?: Record<string, unknown>;
 }
 
-/**
- * Coerce a wire-format node/edge ID (which may arrive as a string
- * because of `serialize_id_as_string`) into the `number` shape
- * declared on the public `GraphEdge` interface. IDs above
- * `Number.MAX_SAFE_INTEGER` (2^53-1) will lose precision — this is
- * an accepted limitation of the current `id: number` contract.
- */
-function idToNumber(id: number | string): number {
-  return typeof id === 'string' ? Number(id) : id;
+function idToGraphId(id: number | string): number | string {
+  return id;
 }
 
 /**
@@ -389,9 +380,9 @@ export async function getNodeEdges(
   throwOnError(response, `Collection '${collection}'`);
 
   return (response.data?.edges ?? []).map((e) => ({
-    id: idToNumber(e.id),
-    source: idToNumber(e.source),
-    target: idToNumber(e.target),
+    id: e.id,
+    source: e.source,
+    target: e.target,
     label: e.label,
     properties: e.properties,
   }));
@@ -410,7 +401,7 @@ export async function getNodePayload(
   throwOnError(response, `Collection '${collection}'`);
   const data = response.data!;
   return {
-    nodeId: idToNumber(data.node_id),
+    nodeId: idToGraphId(data.node_id),
     payload: data.payload,
   };
 }
@@ -459,7 +450,7 @@ export async function graphSearch(
   throwOnError(response, `Collection '${collection}'`);
   const items: GraphSearchResultItem[] = (response.data?.results ?? []).map(
     (r) => ({
-      id: idToNumber(r.id),
+      id: idToGraphId(r.id),
       score: r.score,
       payload: r.payload,
     })

--- a/sdks/typescript/src/client/graph-methods.ts
+++ b/sdks/typescript/src/client/graph-methods.ts
@@ -12,6 +12,7 @@ import type {
   AddEdgeRequest,
   GetEdgesOptions,
   GraphEdge,
+  GraphNodeId,
   TraverseRequest,
   TraverseParallelRequest,
   TraverseResponse,
@@ -28,6 +29,10 @@ import type {
 import { ValidationError } from '../types';
 import { requireNonEmptyString } from './validation';
 
+function isGraphNodeId(value: unknown): value is GraphNodeId {
+  return typeof value === 'number' || typeof value === 'string';
+}
+
 /** Add an edge to the collection's knowledge graph. */
 export function addEdge(
   backend: IVelesDBBackend,
@@ -38,8 +43,8 @@ export function addEdge(
     throw new ValidationError('Edge label is required and must be a string');
   }
 
-  if (typeof edge.source !== 'number' || typeof edge.target !== 'number') {
-    throw new ValidationError('Edge source and target must be numbers');
+  if (!isGraphNodeId(edge.source) || !isGraphNodeId(edge.target)) {
+    throw new ValidationError('Edge source and target must be numbers or strings');
   }
 
   return backend.addEdge(collection, edge);
@@ -60,8 +65,8 @@ export function traverseGraph(
   collection: string,
   request: TraverseRequest
 ): Promise<TraverseResponse> {
-  if (typeof request.source !== 'number') {
-    throw new ValidationError('Source node ID must be a number');
+  if (!isGraphNodeId(request.source)) {
+    throw new ValidationError('Source node ID must be a number or string');
   }
 
   if (request.strategy && !['bfs', 'dfs'].includes(request.strategy)) {
@@ -79,6 +84,9 @@ export function traverseParallel(
 ): Promise<TraverseResponse> {
   if (!Array.isArray(request.sources) || request.sources.length === 0) {
     throw new ValidationError('At least one source node ID is required');
+  }
+  if (!request.sources.every(isGraphNodeId)) {
+    throw new ValidationError('Source node IDs must be numbers or strings');
   }
 
   return backend.traverseParallel(collection, request);

--- a/sdks/typescript/src/types/endpoints.ts
+++ b/sdks/typescript/src/types/endpoints.ts
@@ -6,6 +6,8 @@
  * @packageDocumentation
  */
 
+import type { GraphNodeId } from './graph';
+
 // ============================================================================
 // Additional endpoint types (Sprint 2 Wave 4 -- S2-NEW-10)
 // ============================================================================
@@ -61,7 +63,7 @@ export interface GetNodeEdgesOptions {
 /** Result of `GET /collections/{name}/graph/nodes/{id}/payload`. */
 export interface NodePayloadResponse {
   /** Node ID. */
-  nodeId: number;
+  nodeId: GraphNodeId;
   /** Stored payload -- `null` if no payload has been set. */
   payload: Record<string, unknown> | null;
 }
@@ -77,7 +79,7 @@ export interface GraphSearchRequest {
 /** Single result item from `graphSearch`. */
 export interface GraphSearchResultItem {
   /** Node ID. */
-  id: number;
+  id: GraphNodeId;
   /** Similarity score. */
   score: number;
   /** Optional node payload (mirror of `GraphSearchResultItem.payload`). */

--- a/sdks/typescript/src/types/graph.ts
+++ b/sdks/typescript/src/types/graph.ts
@@ -11,14 +11,17 @@ import type { DistanceMetric } from './core';
 // Knowledge Graph Types (EPIC-016 US-041)
 // ============================================================================
 
+/** Graph node/edge ID. Large u64 IDs may be returned as strings to preserve precision. */
+export type GraphNodeId = number | string;
+
 /** Graph edge representing a relationship between nodes */
 export interface GraphEdge {
   /** Unique edge ID */
-  id: number;
+  id: GraphNodeId;
   /** Source node ID */
-  source: number;
+  source: GraphNodeId;
   /** Target node ID */
-  target: number;
+  target: GraphNodeId;
   /** Edge label (relationship type, e.g., "KNOWS", "FOLLOWS") */
   label: string;
   /** Edge properties */
@@ -49,7 +52,7 @@ export interface GetEdgesOptions {
 /** Request for graph traversal (EPIC-016 US-050) */
 export interface TraverseRequest {
   /** Source node ID to start traversal from */
-  source: number;
+  source: GraphNodeId;
   /** Traversal strategy: 'bfs' or 'dfs' */
   strategy?: 'bfs' | 'dfs';
   /** Maximum traversal depth */
@@ -65,7 +68,7 @@ export interface TraverseRequest {
 /** Request for multi-source parallel BFS traversal */
 export interface TraverseParallelRequest {
   /** Source node IDs to start traversal from */
-  sources: number[];
+  sources: GraphNodeId[];
   /** Maximum traversal depth */
   maxDepth?: number;
   /** Maximum number of results to return */
@@ -77,11 +80,11 @@ export interface TraverseParallelRequest {
 /** A single traversal result item */
 export interface TraversalResultItem {
   /** Target node ID reached */
-  targetId: number;
+  targetId: GraphNodeId;
   /** Depth of traversal (number of hops from source) */
   depth: number;
   /** Path taken (list of edge IDs) */
-  path: number[];
+  path: GraphNodeId[];
 }
 
 /** Statistics from traversal operation */

--- a/sdks/typescript/tests/client-delegations.test.ts
+++ b/sdks/typescript/tests/client-delegations.test.ts
@@ -331,11 +331,11 @@ describe('VelesDB — graph delegations (graph-methods.ts)', () => {
     ).rejects.toThrow(ValidationError);
   });
 
-  it('addEdge rejects non-numeric source/target', async () => {
+  it('addEdge rejects invalid source/target ids', async () => {
     await expect(
       db.addEdge('c', {
         id: 1,
-        source: 'a' as unknown as number,
+        source: {} as never,
         target: 20,
         label: 'L',
       })
@@ -344,7 +344,7 @@ describe('VelesDB — graph delegations (graph-methods.ts)', () => {
       db.addEdge('c', {
         id: 1,
         source: 10,
-        target: 'a' as unknown as number,
+        target: {} as never,
         label: 'L',
       })
     ).rejects.toThrow(ValidationError);
@@ -370,12 +370,12 @@ describe('VelesDB — graph delegations (graph-methods.ts)', () => {
     expect(backend.createGraphCollection).toHaveBeenCalled();
   });
 
-  it('traverseGraph rejects invalid strategy and non-numeric source', async () => {
+  it('traverseGraph rejects invalid strategy and source id', async () => {
     await expect(
       db.traverseGraph('c', { source: 1, strategy: 'bad' as never })
     ).rejects.toThrow(ValidationError);
     await expect(
-      db.traverseGraph('c', { source: 'x' as unknown as number })
+      db.traverseGraph('c', { source: {} as never })
     ).rejects.toThrow(ValidationError);
   });
 

--- a/sdks/typescript/tests/client.test.ts
+++ b/sdks/typescript/tests/client.test.ts
@@ -388,8 +388,8 @@ describe('VelesDB Client', () => {
           .rejects.toThrow(ValidationError);
       });
 
-      it('should validate source and target are numbers', async () => {
-        await expect(db.addEdge('test', { id: 1, source: 'a' as any, target: 200, label: 'KNOWS' }))
+      it('should validate source and target are graph IDs', async () => {
+        await expect(db.addEdge('test', { id: 1, source: {} as any, target: 200, label: 'KNOWS' }))
           .rejects.toThrow(ValidationError);
       });
 

--- a/sdks/typescript/tests/graph-backend.test.ts
+++ b/sdks/typescript/tests/graph-backend.test.ts
@@ -157,13 +157,30 @@ describe('getEdges', () => {
 
     expect(edges).toEqual([
       {
-        id: 42,
-        source: 10,
-        target: 20,
+        id: '42',
+        source: '10',
+        target: '20',
         label: 'KNOWS',
         properties: { k: 1 },
       },
     ]);
+  });
+
+  it('preserves graph ids above Number.MAX_SAFE_INTEGER', async () => {
+    const transport = buildTransport();
+    const largeId = '9007199254740993';
+    (transport.requestJson as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      data: {
+        edges: [{ id: largeId, source: largeId, target: '9007199254740995', label: 'KNOWS' }],
+        count: 1,
+      },
+    });
+
+    const edges = await getEdges(transport, 'kg');
+
+    expect(edges[0].id).toBe(largeId);
+    expect(edges[0].source).toBe(largeId);
+    expect(edges[0].target).toBe('9007199254740995');
   });
 
   it('passes through numeric ids unchanged', async () => {

--- a/sdks/typescript/tests/missing-endpoints.test.ts
+++ b/sdks/typescript/tests/missing-endpoints.test.ts
@@ -32,6 +32,27 @@ function lastCall(): { url: string; method: string; body?: Record<string, unknow
   return { url, method: init?.method as string, body };
 }
 
+/**
+ * Queues a guardrails wire response with sensible defaults; pass `overrides`
+ * to vary only the fields a test cares about.
+ */
+function mockGuardrailsResponse(overrides: Record<string, number> = {}): void {
+  mockFetch.mockResolvedValueOnce({
+    ok: true,
+    json: () =>
+      Promise.resolve({
+        max_depth: 10,
+        max_cardinality: 100_000,
+        memory_limit_bytes: 104_857_600,
+        timeout_ms: 30_000,
+        rate_limit_qps: 100,
+        circuit_failure_threshold: 5,
+        circuit_recovery_seconds: 30,
+        ...overrides,
+      }),
+  });
+}
+
 // ============================================================================
 // Admin endpoints
 // ============================================================================
@@ -74,19 +95,7 @@ describe('getGuardrails', () => {
   });
 
   it('GETs /guardrails and maps snake_case → camelCase', async () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: () =>
-        Promise.resolve({
-          max_depth: 10,
-          max_cardinality: 100_000,
-          memory_limit_bytes: 104_857_600,
-          timeout_ms: 30_000,
-          rate_limit_qps: 100,
-          circuit_failure_threshold: 5,
-          circuit_recovery_seconds: 30,
-        }),
-    });
+    mockGuardrailsResponse();
 
     const cfg = await backend.getGuardrails();
     expect(lastCall().method).toBe('GET');
@@ -109,19 +118,7 @@ describe('updateGuardrails', () => {
   });
 
   it('PUTs only the supplied fields as snake_case', async () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: () =>
-        Promise.resolve({
-          max_depth: 15,
-          max_cardinality: 100_000,
-          memory_limit_bytes: 104_857_600,
-          timeout_ms: 30_000,
-          rate_limit_qps: 200,
-          circuit_failure_threshold: 5,
-          circuit_recovery_seconds: 30,
-        }),
-    });
+    mockGuardrailsResponse({ max_depth: 15, rate_limit_qps: 200 });
 
     const updated = await backend.updateGuardrails({
       maxDepth: 15,
@@ -136,19 +133,7 @@ describe('updateGuardrails', () => {
   });
 
   it('omits unset fields entirely from the PUT body', async () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: () =>
-        Promise.resolve({
-          max_depth: 10,
-          max_cardinality: 100_000,
-          memory_limit_bytes: 104_857_600,
-          timeout_ms: 30_000,
-          rate_limit_qps: 100,
-          circuit_failure_threshold: 5,
-          circuit_recovery_seconds: 30,
-        }),
-    });
+    mockGuardrailsResponse();
 
     await backend.updateGuardrails({});
     expect(lastCall().body).toEqual({});
@@ -448,13 +433,7 @@ describe('getNodeEdges', () => {
     expect(edges[0].label).toBe('KNOWS');
   });
 
-  it('coerces string-typed IDs from serialize_id_as_string back to number', async () => {
-    // The server's `EdgeResponse` struct uses
-    // `#[serde(serialize_with = "serde_id::serialize_id_as_string")]`
-    // on `id`/`source`/`target`, so the wire format carries strings
-    // even though the TS `GraphEdge` interface declares `id: number`.
-    // This guards against the regression where the raw string would
-    // leak into the public API (PR #586 Devin 4th-wave scan finding).
+  it('preserves string-typed IDs from serialize_id_as_string', async () => {
     mockFetch.mockResolvedValueOnce({
       ok: true,
       json: () =>
@@ -474,12 +453,9 @@ describe('getNodeEdges', () => {
 
     const edges = await backend.getNodeEdges('kg', 10);
     expect(edges).toHaveLength(1);
-    expect(typeof edges[0].id).toBe('number');
-    expect(edges[0].id).toBe(42);
-    expect(typeof edges[0].source).toBe('number');
-    expect(edges[0].source).toBe(10);
-    expect(typeof edges[0].target).toBe('number');
-    expect(edges[0].target).toBe(20);
+    expect(edges[0].id).toBe('42');
+    expect(edges[0].source).toBe('10');
+    expect(edges[0].target).toBe('20');
     expect(edges[0].properties).toEqual({ since: '2020' });
   });
 
@@ -500,7 +476,7 @@ describe('getNodePayload', () => {
     backend = await initBackend();
   });
 
-  it('GETs /graph/nodes/{id}/payload and coerces node_id string → number', async () => {
+  it('GETs /graph/nodes/{id}/payload and preserves node_id string', async () => {
     // Server uses `serialize_id_as_string` so `node_id` arrives as a string.
     mockFetch.mockResolvedValueOnce({
       ok: true,
@@ -513,8 +489,7 @@ describe('getNodePayload', () => {
 
     const result = await backend.getNodePayload('kg', 42);
     expect(lastCall().url).toContain('/graph/nodes/42/payload');
-    expect(typeof result.nodeId).toBe('number');
-    expect(result.nodeId).toBe(42);
+    expect(result.nodeId).toBe('42');
     expect(result.payload).toEqual({ name: 'Alice' });
   });
 
@@ -555,7 +530,7 @@ describe('graphSearch', () => {
     backend = await initBackend();
   });
 
-  it('POSTs vector + top_k to /graph/search and maps id → number', async () => {
+  it('POSTs vector + top_k to /graph/search and preserves id strings', async () => {
     mockFetch.mockResolvedValueOnce({
       ok: true,
       json: () =>
@@ -578,12 +553,11 @@ describe('graphSearch', () => {
     expect(call.body?.vector).toEqual([0.1, 0.2, 0.3]);
     expect(call.body?.top_k).toBe(5);
     expect(res.results).toHaveLength(2);
-    expect(res.results[0].id).toBe(10);
-    expect(typeof res.results[0].id).toBe('number');
+    expect(res.results[0].id).toBe('10');
     expect(res.results[0].score).toBe(0.92);
     // Payload must round-trip (not dropped by the mapper).
     expect(res.results[0].payload).toEqual({ name: 'Alice' });
-    expect(res.results[1].id).toBe(20);
+    expect(res.results[1].id).toBe('20');
     expect(res.results[1].payload).toBeUndefined();
   });
 


### PR DESCRIPTION
> Supersedes #1023 (renamed branch `codex/graph-audit` → `feat/graph-match-semantics` to satisfy the Git Flow branch-name rule). Identical commit.

## Summary

Reworks the VelesQL MATCH executor and the surrounding REST/SDK/doc surface so graph-first queries behave exactly as declared, per the revalidated graph plan. Followed by a DRY pass extracting shared helpers so no changed file carries a >10-line clone.

## Changes

**Core MATCH executor (`match_exec`)**
- Recursive per-relationship engine (`traverse_pattern → expand_relationship → follow_edge → try_bind_next_node → accept_pattern_match`) enforcing relationship order (`R1 -> R2`), per-node labels/properties, direction (incoming/outgoing/undirected), multiple types, multi-hop and variable-length (`*min..max`), RETURN projections and complete bindings.
- Dedup on the full binding signature (not `(start,target)`), so distinct paths sharing endpoints are no longer collapsed.
- Walker split into `match_exec/expand.rs` to keep both files under the 500 NLOC bar (`mod.rs` 260, `expand.rs` 285).

**`@collection`** — kept as post-traversal payload enrichment on the primary collection (not a distributed cross-graph traversal); projected fields + `_bindings` surface on results so cross-collection MATCH enriches correctly.

**REST** — `/collections/{name}/match` aligned with `/query` via typed vector-then-graph dispatch; top-level MATCH routes through `execute_query` so projections/bindings/`_bindings`/enriched fields survive.

**SDK (TypeScript)** — u64 graph IDs carried as `string | number` end to end; lossy `Number()` coercions removed.

**Docs** — corrected api-reference graph endpoints/shapes, GRAPH_PATTERNS, and the README `@collection` example to match real behavior.

**Quality** — `check_prod_unwraps.py` now also blocks `.expect()` in production; flagged call sites rewritten to fallible handling.

**DRY** — shared `BfsBookkeeping` (both streaming iterators delegate via a `drive` closure), `finalize_bulk_upsert` shared by V2/standard bulk paths, `matches_update_filter` delegating to `point_matches_filter`, mutation handler reusing `build_query_response`, `resolve_collection_and_node` backing the node-scoped `.graph` REPL commands, plus shared TS traverse-mapping and guardrails-fixture helpers.

## Tests

Added MATCH coverage for relationship order, incoming direction, undirected traversal, multi-type relationships, variable-length, and property predicates on intermediate bound nodes.

## Validation

- `clippy` pedantic `-D warnings` (workspace) — clean
- Full core suite (37 binaries) — green, 0 failures
- `recall@10 = 0.9740` (100K balanced gate)
- OpenAPI drift-clean
- 729 TypeScript SDK tests green
- jscpd DRY check passes with no skip