### PR TITLE
fix(graph): crash-durable edge mutations via edge WAL

### DIFF
--- a/crates/velesdb-core/src/collection/core/crud_read_delete.rs
+++ b/crates/velesdb-core/src/collection/core/crud_read_delete.rs
@@ -73,7 +73,7 @@ impl Collection {
         // edge store retains dangling edges pointing at (or from) a node that
         // no longer exists, silently corrupting the graph. Gated to graph
         // collections; no-op for vector / metadata-only collections.
-        self.cascade_delete_node_edges(ids);
+        self.cascade_delete_node_edges(ids)?;
 
         self.invalidate_caches_and_bump_generation();
         Ok(())
@@ -95,9 +95,9 @@ impl Collection {
     /// ascending order, per `docs/CONCURRENCY_MODEL.md`), acquired here with no
     /// other collection lock held — so taking them respects the documented
     /// ascending lock order and cannot deadlock.
-    fn cascade_delete_node_edges(&self, ids: &[u64]) {
+    fn cascade_delete_node_edges(&self, ids: &[u64]) -> Result<()> {
         if self.config.read().graph_schema.is_none() {
-            return;
+            return Ok(());
         }
         let mut removed_any = false;
         for &id in ids {
@@ -105,6 +105,13 @@ impl Collection {
             // edges so no dangling edge references the deleted node.
             let before = self.edge_store.outgoing_degree(id) + self.edge_store.incoming_degree(id);
             if before > 0 {
+                // WAL-before-apply (crash durability): log the cascade remove
+                // before mutating the store so a crash replays the tombstone.
+                #[cfg(feature = "persistence")]
+                crate::collection::graph::edge_wal::wal_append_remove_node(
+                    &crate::collection::graph::edge_wal::wal_path_for_edges(&self.path),
+                    id,
+                )?;
                 self.edge_store.remove_node_edges(id);
                 removed_any = true;
             }
@@ -115,6 +122,7 @@ impl Collection {
             self.write_generation
                 .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         }
+        Ok(())
     }
 
     /// Collects current payloads for the given IDs (for histogram decrements on delete).

--- a/crates/velesdb-core/src/collection/core/flush.rs
+++ b/crates/velesdb-core/src/collection/core/flush.rs
@@ -262,6 +262,14 @@ impl Collection {
         if self.config.read().graph_schema.is_some() {
             let edge_store_path = self.path.join("edge_store.bin");
             self.edge_store.save_to_file(&edge_store_path)?;
+            // The snapshot now contains every edge, so the edge WAL delta is
+            // redundant — truncate it AFTER the snapshot is durably written so
+            // a crash between the two still replays the edges (never loses
+            // them). Mirrors the BM25 snapshot → wal_truncate contract.
+            #[cfg(feature = "persistence")]
+            crate::collection::graph::edge_wal::wal_truncate(
+                &crate::collection::graph::edge_wal::wal_path_for_edges(&self.path),
+            )?;
             // Rebuild CSR read snapshot after flush so that subsequent reads
             // benefit from zero-copy neighbor lookups (EPIC-020 US-004).
             self.edge_store.build_read_snapshot();

--- a/crates/velesdb-core/src/collection/core/graph_api.rs
+++ b/crates/velesdb-core/src/collection/core/graph_api.rs
@@ -43,6 +43,17 @@ impl Collection {
         let rel_type = edge.label().to_string();
         let properties = edge.properties().clone();
 
+        // WAL-before-apply (crash durability): log the edge to the edge WAL
+        // before mutating the in-memory store, so a crash between the two
+        // replays the edge on the next open. Gated to graph collections.
+        #[cfg(feature = "persistence")]
+        if self.config.read().graph_schema.is_some() {
+            crate::collection::graph::edge_wal::wal_append_add(
+                &crate::collection::graph::edge_wal::wal_path_for_edges(&self.path),
+                &edge,
+            )?;
+        }
+
         self.edge_store.add_edge(edge)?;
 
         // Populate edge property indexes (EPIC-047).
@@ -53,6 +64,83 @@ impl Collection {
         self.write_generation
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         Ok(())
+    }
+
+    /// Adds multiple edges in batch with crash-durable WAL logging.
+    ///
+    /// Appends one ADD record per edge to the edge WAL (single open +
+    /// fsync) BEFORE applying the batch to the in-memory store, then
+    /// populates edge property indexes for the successfully added edges.
+    ///
+    /// # Returns
+    ///
+    /// Number of edges successfully added (duplicates are skipped).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if WAL logging fails (fail-closed: the in-memory
+    /// store is not mutated when the WAL append fails).
+    pub fn add_edges_batch(&self, edges: Vec<GraphEdge>) -> Result<usize> {
+        if edges.is_empty() {
+            return Ok(0);
+        }
+
+        #[cfg(feature = "persistence")]
+        if self.config.read().graph_schema.is_some() {
+            crate::collection::graph::edge_wal::wal_append_add_batch(
+                &crate::collection::graph::edge_wal::wal_path_for_edges(&self.path),
+                &edges,
+            )?;
+        }
+
+        // Capture property metadata before the edges are moved into the store.
+        let index_meta: Vec<(u64, String, _)> = edges
+            .iter()
+            .filter(|e| !e.properties().is_empty())
+            .map(|e| (e.id(), e.label().to_string(), e.properties().clone()))
+            .collect();
+
+        let count = self.edge_store.add_edges_batch(edges);
+
+        for (edge_id, rel_type, properties) in &index_meta {
+            self.index_edge_properties(*edge_id, rel_type, properties);
+        }
+
+        if count > 0 {
+            self.write_generation
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        }
+        Ok(count)
+    }
+
+    /// Replays the edge WAL on top of the loaded `edge_store` snapshot,
+    /// re-running edge-property indexing for replayed ADD entries.
+    ///
+    /// Called from `Collection::open` AFTER `assemble`, so the snapshot is
+    /// already loaded into `self.edge_store`. A missing WAL file is a cheap
+    /// no-op (legacy DBs predate this feature). The edge store is mutated
+    /// in place via its `&self` methods; the closure indexes edge
+    /// properties into `self.edge_range_indexes`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the WAL file exists but cannot be read.
+    #[cfg(feature = "persistence")]
+    pub(crate) fn replay_edge_wal(&self) -> Result<u64> {
+        use crate::collection::graph::edge_wal::{wal_path_for_edges, wal_replay, ReplayOp};
+        let wal_path = wal_path_for_edges(&self.path);
+        let replayed = wal_replay(&wal_path, &self.edge_store, |op| {
+            if let ReplayOp::Add(edge) = op {
+                if !edge.properties().is_empty() {
+                    self.index_edge_properties(edge.id(), edge.label(), edge.properties());
+                }
+            }
+        })?;
+        if replayed > 0 {
+            // Refresh the CSR read snapshot so traversals see replayed edges.
+            self.edge_store.build_read_snapshot();
+        }
+        Ok(replayed)
     }
 
     /// Gets all edges from the collection's knowledge graph.
@@ -227,6 +315,22 @@ impl Collection {
     /// `true` if the edge existed and was removed, `false` if it didn't exist.
     #[must_use]
     pub fn remove_edge(&self, edge_id: u64) -> bool {
+        // WAL-before-apply (crash durability): log the remove intent before
+        // mutating the store. A remove of a non-existent id replays as a
+        // harmless no-op. Fail-closed: if the WAL append fails we do NOT
+        // mutate the store and report `false` (no panic — matches the
+        // no-unwrap policy and the bool return contract).
+        #[cfg(feature = "persistence")]
+        if self.config.read().graph_schema.is_some() {
+            if let Err(e) = crate::collection::graph::edge_wal::wal_append_remove(
+                &crate::collection::graph::edge_wal::wal_path_for_edges(&self.path),
+                edge_id,
+            ) {
+                tracing::error!("Edge WAL append remove failed for edge {edge_id}: {e}");
+                return false;
+            }
+        }
+
         // Atomic check-and-remove — no TOCTOU race.
         let removed = self.edge_store.remove_edge(edge_id);
         if removed {
@@ -280,6 +384,11 @@ impl Collection {
     ///
     /// Returns an error if storage fails.
     pub fn store_node_payload(&self, node_id: u64, payload: &serde_json::Value) -> Result<()> {
+        // Crash durability for node payloads is already provided by the
+        // payload WAL: `storage.store(node_id, payload)` below appends a
+        // CRC-checked record to `payloads.log` and fsyncs (LogPayloadStorage,
+        // DurabilityMode::Fsync), replayed on open. No edge-WAL work is
+        // needed here — only graph EDGES lacked WAL coverage.
         // LOCK ORDER: payload_storage(3) → label_index(7) → graph_range_indexes(7).
         let mut storage = self.payload_storage.write();
 

--- a/crates/velesdb-core/src/collection/core/graph_edge_wal_recovery_tests.rs
+++ b/crates/velesdb-core/src/collection/core/graph_edge_wal_recovery_tests.rs
@@ -1,0 +1,215 @@
+//! Crash-recovery tests for the graph edge WAL (durability).
+//!
+//! These prove that edge mutations (`add_edge`, `add_edges_batch`,
+//! `remove_edge`, cascade `remove_node_edges`) survive a simulated crash
+//! — dropping the `Collection` WITHOUT calling `flush()`, so the
+//! `edge_store.bin` snapshot is never written — followed by reopen, where
+//! the WAL is replayed on top of the (here, empty) snapshot.
+
+#[cfg(test)]
+mod tests {
+    use crate::collection::graph::{GraphEdge, GraphSchema};
+    use crate::collection::types::Collection;
+    use crate::DistanceMetric;
+    use std::io::Write;
+    use std::path::PathBuf;
+    use tempfile::TempDir;
+
+    fn create_graph(path: PathBuf) -> Collection {
+        Collection::create_graph_collection(
+            path,
+            "kg",
+            GraphSchema::schemaless(),
+            None,
+            DistanceMetric::Cosine,
+        )
+        .expect("create graph collection")
+    }
+
+    fn make_edge(id: u64, source: u64, target: u64, label: &str) -> GraphEdge {
+        GraphEdge::new(id, source, target, label).expect("valid edge")
+    }
+
+    #[test]
+    fn test_edge_wal_survives_reopen_without_flush() {
+        let temp = TempDir::new().expect("temp dir");
+        let path = temp.path().to_path_buf();
+
+        {
+            let coll = create_graph(path.clone());
+            // Same-shard edge (source 100, target 356 → both shard 100).
+            coll.add_edge(make_edge(1, 100, 356, "KNOWS")).unwrap();
+            // Cross-shard edge (source 100 → shard 100, target 200 → shard 200).
+            coll.add_edge(make_edge(2, 100, 200, "KNOWS")).unwrap();
+            coll.add_edge(make_edge(3, 200, 300, "FOLLOWS")).unwrap();
+            coll.store_node_payload(100, &serde_json::json!({"name": "A"}))
+                .unwrap();
+            // DROP without flush → edge_store.bin is never written (crash sim).
+        }
+
+        let reopened = Collection::open(path).expect("reopen");
+        assert_eq!(reopened.edge_count(), 3, "all edges replayed from WAL");
+        assert_eq!(reopened.get_outgoing_edges(100).len(), 2);
+        assert_eq!(reopened.get_incoming_edges(200).len(), 1);
+        assert_eq!(reopened.get_incoming_edges(300).len(), 1);
+        assert_eq!(reopened.get_edges_by_label("KNOWS").len(), 2);
+        assert_eq!(reopened.get_edges_by_label("FOLLOWS").len(), 1);
+        // Node payload (payload WAL) also survives.
+        let payload = reopened.get_node_payload(100).unwrap();
+        assert_eq!(payload, Some(serde_json::json!({"name": "A"})));
+    }
+
+    #[test]
+    fn test_edge_wal_remove_survives_reopen() {
+        let temp = TempDir::new().expect("temp dir");
+        let path = temp.path().to_path_buf();
+
+        {
+            let coll = create_graph(path.clone());
+            coll.add_edge(make_edge(1, 1, 2, "KNOWS")).unwrap();
+            coll.add_edge(make_edge(2, 2, 3, "KNOWS")).unwrap();
+            coll.add_edge(make_edge(3, 3, 4, "KNOWS")).unwrap();
+            assert!(coll.remove_edge(2));
+        }
+
+        let reopened = Collection::open(path).expect("reopen");
+        assert_eq!(reopened.edge_count(), 2, "removed edge stays removed");
+        assert!(reopened.get_outgoing_edges(2).is_empty());
+        assert_eq!(reopened.get_outgoing_edges(1).len(), 1);
+        assert_eq!(reopened.get_outgoing_edges(3).len(), 1);
+    }
+
+    #[test]
+    fn test_edge_wal_cascade_delete_survives_reopen() {
+        let temp = TempDir::new().expect("temp dir");
+        let path = temp.path().to_path_buf();
+
+        {
+            let coll = create_graph(path.clone());
+            coll.store_node_payload(50, &serde_json::json!({"n": "N"}))
+                .unwrap();
+            coll.add_edge(make_edge(1, 50, 60, "E")).unwrap();
+            coll.add_edge(make_edge(2, 70, 50, "E")).unwrap();
+            coll.add_edge(make_edge(3, 80, 90, "E")).unwrap();
+            // Cascade-delete node 50 (removes edges 1 and 2).
+            coll.delete(&[50]).unwrap();
+            assert_eq!(coll.edge_count(), 1);
+        }
+
+        let reopened = Collection::open(path).expect("reopen");
+        assert_eq!(reopened.edge_count(), 1, "cascade tombstone replayed");
+        assert!(reopened.get_outgoing_edges(50).is_empty());
+        assert!(reopened.get_incoming_edges(50).is_empty());
+        assert_eq!(reopened.get_outgoing_edges(80).len(), 1);
+    }
+
+    #[test]
+    fn test_add_edges_batch_durable() {
+        let temp = TempDir::new().expect("temp dir");
+        let path = temp.path().to_path_buf();
+
+        {
+            let coll = create_graph(path.clone());
+            let edges: Vec<GraphEdge> = (0..50)
+                .map(|i| make_edge(i, i, i + 1000, "BATCH"))
+                .collect();
+            let added = coll.add_edges_batch(edges).unwrap();
+            assert_eq!(added, 50);
+        }
+
+        let reopened = Collection::open(path).expect("reopen");
+        assert_eq!(reopened.edge_count(), 50, "all batched edges replayed");
+        assert_eq!(reopened.get_edges_by_label("BATCH").len(), 50);
+    }
+
+    #[test]
+    fn test_flush_truncates_edge_wal() {
+        let temp = TempDir::new().expect("temp dir");
+        let path = temp.path().to_path_buf();
+        let wal = path.join("edges.wal");
+
+        let coll = create_graph(path.clone());
+        coll.add_edge(make_edge(1, 1, 2, "A")).unwrap();
+        coll.add_edge(make_edge(2, 2, 3, "A")).unwrap();
+        assert!(wal.metadata().unwrap().len() > 0, "WAL has entries");
+
+        coll.flush_full().unwrap();
+        assert_eq!(
+            wal.metadata().unwrap().len(),
+            0,
+            "WAL truncated after snapshot"
+        );
+        assert!(path.join("edge_store.bin").exists(), "snapshot written");
+
+        // Post-flush delta: add another edge, then crash (drop) without flush.
+        coll.add_edge(make_edge(3, 3, 4, "A")).unwrap();
+        drop(coll);
+
+        let reopened = Collection::open(path).expect("reopen");
+        // 2 from snapshot + 1 from WAL delta — no double counting (idempotent).
+        assert_eq!(reopened.edge_count(), 3);
+        assert_eq!(reopened.get_edges_by_label("A").len(), 3);
+    }
+
+    #[test]
+    fn test_open_legacy_graph_without_edge_wal() {
+        let temp = TempDir::new().expect("temp dir");
+        let path = temp.path().to_path_buf();
+
+        {
+            let coll = create_graph(path.clone());
+            coll.add_edge(make_edge(1, 1, 2, "L")).unwrap();
+            coll.flush_full().unwrap();
+        }
+        // Simulate a pre-feature DB: delete the edges.wal entirely.
+        let wal = path.join("edges.wal");
+        if wal.exists() {
+            std::fs::remove_file(&wal).unwrap();
+        }
+
+        let reopened = Collection::open(path).expect("reopen legacy");
+        assert_eq!(reopened.edge_count(), 1, "edges load from snapshot");
+    }
+
+    #[test]
+    fn test_edge_wal_torn_tail_tolerated() {
+        let temp = TempDir::new().expect("temp dir");
+        let path = temp.path().to_path_buf();
+
+        {
+            let coll = create_graph(path.clone());
+            coll.add_edge(make_edge(1, 1, 2, "T")).unwrap();
+        }
+        // Append a truncated partial entry: a length prefix declaring 32
+        // bytes but supplying only 4 — the torn-tail crash scenario.
+        let wal = path.join("edges.wal");
+        let mut f = std::fs::OpenOptions::new().append(true).open(&wal).unwrap();
+        f.write_all(&32u32.to_le_bytes()).unwrap();
+        f.write_all(&[0x01, 0x00, 0x00, 0x00]).unwrap();
+        f.sync_all().unwrap();
+
+        let reopened = Collection::open(path).expect("reopen tolerates torn tail");
+        assert_eq!(reopened.edge_count(), 1, "complete entry survives");
+    }
+
+    #[test]
+    fn test_edge_wal_replay_preserves_edge_properties() {
+        use std::collections::HashMap;
+        let temp = TempDir::new().expect("temp dir");
+        let path = temp.path().to_path_buf();
+
+        {
+            let coll = create_graph(path.clone());
+            let mut props = HashMap::new();
+            props.insert("weight".to_string(), serde_json::json!(42));
+            let edge = make_edge(1, 1, 2, "WEIGHTED").with_properties(props);
+            coll.add_edge(edge).unwrap();
+        }
+
+        let reopened = Collection::open(path).expect("reopen");
+        assert_eq!(reopened.edge_count(), 1);
+        let edges = reopened.get_edges_by_label("WEIGHTED");
+        assert_eq!(edges.len(), 1);
+        assert_eq!(edges[0].property("weight"), Some(&serde_json::json!(42)));
+    }
+}

--- a/crates/velesdb-core/src/collection/core/lifecycle.rs
+++ b/crates/velesdb-core/src/collection/core/lifecycle.rs
@@ -290,7 +290,7 @@ impl Collection {
 
         super::recovery::run_crash_recovery(&config, &vector_storage, &index)?;
 
-        Ok(Self::assemble(CollectionParts {
+        let collection = Self::assemble(CollectionParts {
             path,
             config,
             vector_storage,
@@ -302,7 +302,15 @@ impl Collection {
             range_index,
             edge_store,
             sparse_indexes,
-        }))
+        });
+
+        // Edge crash durability: replay the edge WAL on top of the loaded
+        // edge_store snapshot so edge mutations since the last flush survive
+        // a crash. No-op when edges.wal is absent (legacy / non-graph DBs).
+        #[cfg(feature = "persistence")]
+        collection.replay_edge_wal()?;
+
+        Ok(collection)
     }
 
     // create_graph_collection is in lifecycle_create.rs

--- a/crates/velesdb-core/src/collection/core/mod.rs
+++ b/crates/velesdb-core/src/collection/core/mod.rs
@@ -21,6 +21,8 @@ mod flush_defer_tests;
 mod graph_api;
 #[cfg(test)]
 mod graph_api_tests;
+#[cfg(all(test, feature = "persistence"))]
+mod graph_edge_wal_recovery_tests;
 mod graph_property_index_wiring;
 mod graph_traversal_helpers;
 mod index_management;

--- a/crates/velesdb-core/src/collection/graph/edge_wal.rs
+++ b/crates/velesdb-core/src/collection/graph/edge_wal.rs
@@ -1,0 +1,296 @@
+//! Graph edge WAL: append + replay for crash-durable edge mutations.
+//!
+//! Graph edges persist primarily via the whole-file `edge_store.bin`
+//! snapshot written during `flush_secondary_indexes`. Between flushes,
+//! `add_edge` / `remove_edge` / `remove_node_edges` mutations would be
+//! lost on a crash. This WAL captures those mutations so they can be
+//! replayed on the next collection open, on top of the loaded snapshot.
+//!
+//! The design mirrors the BM25 index WAL (`index/bm25_persistence_wal.rs`):
+//! a separate per-collection `edges.wal` file, length-prefixed entries,
+//! WAL-append-BEFORE-apply ordering, fsync per append, replay-on-open
+//! AFTER loading the snapshot, and truncate-after-snapshot during flush.
+//!
+//! ## On-disk entry layout (length-prefixed, little-endian)
+//!
+//! ```text
+//! Add:        [u32 body_len][u8 0x01][json(GraphEdge) bytes]
+//! Remove:     [u32 body_len][u8 0x02][u64 edge_id]
+//! RemoveNode: [u32 body_len][u8 0x03][u64 node_id]
+//! ```
+//!
+//! `body_len` is the byte count *after* the 4-byte prefix — it lets the
+//! replay loop skip unknown / corrupt entries without aborting the whole
+//! recovery. A truncated final entry (common on crash) is logged at
+//! `warn` level and skipped rather than surfacing as an error.
+//!
+//! ## Crash-safety ordering
+//!
+//! Callers MUST invoke `wal_append_*` BEFORE applying the corresponding
+//! in-memory mutation. If the process crashes between the two, replay
+//! reconstructs the mutation on next open. The WAL is fsynced on every
+//! append. After a successful snapshot the WAL is truncated via
+//! [`wal_truncate`] so the next open replays zero entries.
+
+use std::io::BufWriter;
+use std::path::{Path, PathBuf};
+
+use crate::collection::graph::{ConcurrentEdgeStore, GraphEdge};
+use crate::error::{Error, Result};
+use crate::index::wal_framing;
+
+/// Error-message context prefix for shared framing helpers.
+const CTX: &str = "Edge WAL";
+
+const WAL_OP_ADD: u8 = 0x01;
+const WAL_OP_REMOVE: u8 = 0x02;
+const WAL_OP_REMOVE_NODE: u8 = 0x03;
+
+/// WAL filename under a collection directory.
+const EDGE_WAL_FILENAME: &str = "edges.wal";
+
+/// Body length for a Remove / RemoveNode entry: `op(1)` + `id(8)`.
+const ID_ENTRY_BODY_LEN: usize = 1 + 8;
+
+/// Returns the absolute path to the edge WAL file under `dir`.
+#[must_use]
+pub(crate) fn wal_path_for_edges(dir: &Path) -> PathBuf {
+    dir.join(EDGE_WAL_FILENAME)
+}
+
+// ---------------------------------------------------------------------------
+// Append operations
+// ---------------------------------------------------------------------------
+
+/// Appends an `add_edge(edge)` mutation to the edge WAL.
+///
+/// Callers MUST invoke this BEFORE applying the mutation in-memory
+/// (WAL-before-apply crash-safety ordering).
+///
+/// # Errors
+///
+/// Returns [`Error::Index`] if the edge cannot be serialized or the WAL
+/// file cannot be opened / written.
+pub(crate) fn wal_append_add(wal_path: &Path, edge: &GraphEdge) -> Result<()> {
+    let mut w = wal_framing::open_wal_writer(wal_path, CTX)?;
+    write_add_entry(&mut w, edge)?;
+    wal_framing::flush_wal(&mut w, CTX)
+}
+
+/// Appends multiple `add_edge` mutations to the edge WAL with a single
+/// open + fsync. Used by the batch insert path.
+///
+/// # Errors
+///
+/// Returns [`Error::Index`] if any edge cannot be serialized or the WAL
+/// file cannot be opened / written.
+pub(crate) fn wal_append_add_batch(wal_path: &Path, edges: &[GraphEdge]) -> Result<()> {
+    if edges.is_empty() {
+        return Ok(());
+    }
+    let mut w = wal_framing::open_wal_writer(wal_path, CTX)?;
+    for edge in edges {
+        write_add_entry(&mut w, edge)?;
+    }
+    wal_framing::flush_wal(&mut w, CTX)
+}
+
+/// Serializes `edge` and writes a length-prefixed ADD entry.
+///
+/// The body uses JSON (`serde_json`) rather than postcard: `GraphEdge`
+/// properties are `serde_json::Value`, whose `Deserialize` relies on
+/// `deserialize_any`, which postcard (a non-self-describing format) does
+/// not support — postcard round-trips silently drop / corrupt property
+/// values. JSON is self-describing and round-trips `Value` losslessly.
+fn write_add_entry(w: &mut BufWriter<std::fs::File>, edge: &GraphEdge) -> Result<()> {
+    let edge_bytes = serde_json::to_vec(edge)
+        .map_err(|e| Error::Index(format!("Edge WAL: serialize edge: {e}")))?;
+    let body_len = add_entry_body_len(edge_bytes.len())?;
+    wal_framing::wal_write(w, &body_len.to_le_bytes(), CTX)?;
+    wal_framing::wal_write(w, &[WAL_OP_ADD], CTX)?;
+    wal_framing::wal_write(w, &edge_bytes, CTX)
+}
+
+/// Computes the `u32` body length for an ADD entry = `op(1)` + edge bytes.
+/// Fails if the sum overflows `u32`.
+fn add_entry_body_len(edge_len: usize) -> Result<u32> {
+    let total = edge_len
+        .checked_add(1)
+        .ok_or_else(|| Error::Index("Edge WAL: add entry length overflow".to_string()))?;
+    u32::try_from(total)
+        .map_err(|_| Error::Index(format!("Edge WAL: add entry too large ({total} bytes)")))
+}
+
+/// Appends a `remove_edge(edge_id)` mutation to the edge WAL.
+///
+/// # Errors
+///
+/// Returns [`Error::Index`] if the WAL file cannot be opened / written.
+pub(crate) fn wal_append_remove(wal_path: &Path, edge_id: u64) -> Result<()> {
+    append_id_entry(wal_path, WAL_OP_REMOVE, edge_id)
+}
+
+/// Appends a `remove_node_edges(node_id)` mutation to the edge WAL.
+///
+/// # Errors
+///
+/// Returns [`Error::Index`] if the WAL file cannot be opened / written.
+pub(crate) fn wal_append_remove_node(wal_path: &Path, node_id: u64) -> Result<()> {
+    append_id_entry(wal_path, WAL_OP_REMOVE_NODE, node_id)
+}
+
+/// Shared writer for the two single-`u64` opcodes (Remove / RemoveNode).
+fn append_id_entry(wal_path: &Path, op: u8, id: u64) -> Result<()> {
+    let body_len = u32::try_from(ID_ENTRY_BODY_LEN)
+        .map_err(|_| Error::Index("Edge WAL: id entry header too large".to_string()))?;
+    let mut w = wal_framing::open_wal_writer(wal_path, CTX)?;
+    wal_framing::wal_write(&mut w, &body_len.to_le_bytes(), CTX)?;
+    wal_framing::wal_write(&mut w, &[op], CTX)?;
+    wal_framing::wal_write(&mut w, &id.to_le_bytes(), CTX)?;
+    wal_framing::flush_wal(&mut w, CTX)
+}
+
+/// Truncates the edge WAL file to zero length.
+///
+/// Called after a successful snapshot to guarantee that the next open
+/// replays zero WAL entries. A missing WAL file is a no-op.
+///
+/// # Errors
+///
+/// Returns [`Error::Index`] if the WAL file exists but cannot be truncated.
+pub(crate) fn wal_truncate(wal_path: &Path) -> Result<()> {
+    wal_framing::wal_truncate(wal_path, CTX)
+}
+
+// ---------------------------------------------------------------------------
+// Replay
+// ---------------------------------------------------------------------------
+
+/// A single decoded WAL mutation, surfaced to the caller so that
+/// collection-level side effects (e.g. edge-property reindexing) can run
+/// alongside the edge-store mutation.
+pub(crate) enum ReplayOp {
+    /// An edge was (re)added; carries the edge for property reindexing.
+    Add(GraphEdge),
+    /// An edge was removed by id.
+    Remove(u64),
+    /// All edges around a node were removed.
+    RemoveNode(u64),
+}
+
+/// Replays the edge WAL against `store`, invoking `on_op` for each applied
+/// mutation, and returns the number of entries applied.
+///
+/// Missing WAL file returns `Ok(0)` (full back-compat for pre-feature DBs).
+/// A truncated final entry (partial crash during append) is logged at
+/// `warn` and skipped. Unknown opcodes and undecodable bodies are logged
+/// and skipped without aborting replay.
+///
+/// ADD replays are idempotent: an `Error::EdgeExists` from the snapshot
+/// already containing the edge is ignored.
+///
+/// # Errors
+///
+/// Returns [`Error::Index`] if the WAL file exists but cannot be read.
+pub(crate) fn wal_replay<F>(
+    wal_path: &Path,
+    store: &ConcurrentEdgeStore,
+    mut on_op: F,
+) -> Result<u64>
+where
+    F: FnMut(&ReplayOp),
+{
+    let data = match std::fs::read(wal_path) {
+        Ok(d) => d,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(0),
+        Err(e) => return Err(Error::Index(format!("Edge WAL read: {e}"))),
+    };
+
+    let mut pos = 0usize;
+    let mut count = 0u64;
+
+    while pos < data.len() {
+        let Some((body_start, body_len)) = read_entry_header(&data, pos) else {
+            break;
+        };
+        if body_start + body_len > data.len() {
+            tracing::warn!(
+                "Edge WAL truncated at offset {body_start}: declared {body_len} bytes but only {} remain",
+                data.len() - body_start
+            );
+            break;
+        }
+        let op = data[body_start];
+        let body = &data[body_start + 1..body_start + body_len];
+        if let Some(replay_op) = decode_entry(op, body, body_start) {
+            apply_replay_op(store, &replay_op);
+            on_op(&replay_op);
+            count += 1;
+        }
+        pos = body_start + body_len;
+    }
+
+    Ok(count)
+}
+
+/// Reads the `u32` length prefix via the shared framing helper, rejecting
+/// a zero-length body (a torn / corrupt prefix) so replay does not spin.
+fn read_entry_header(data: &[u8], pos: usize) -> Option<(usize, usize)> {
+    let (body_start, body_len) = wal_framing::read_entry_header(data, pos, CTX)?;
+    if body_len == 0 {
+        tracing::warn!("Edge WAL zero-length entry at offset {pos}");
+        return None;
+    }
+    Some((body_start, body_len))
+}
+
+/// Decodes a single WAL entry body into a [`ReplayOp`], or `None` if the
+/// opcode is unknown or the body cannot be decoded (logged + skipped).
+fn decode_entry(op: u8, body: &[u8], body_start: usize) -> Option<ReplayOp> {
+    match op {
+        WAL_OP_ADD => decode_add(body, body_start),
+        WAL_OP_REMOVE => decode_id(body, body_start).map(ReplayOp::Remove),
+        WAL_OP_REMOVE_NODE => decode_id(body, body_start).map(ReplayOp::RemoveNode),
+        unknown => {
+            tracing::warn!("Edge WAL unknown op 0x{unknown:02x} at offset {body_start}");
+            None
+        }
+    }
+}
+
+/// Decodes an ADD body (JSON-serialized `GraphEdge`).
+fn decode_add(body: &[u8], body_start: usize) -> Option<ReplayOp> {
+    match serde_json::from_slice::<GraphEdge>(body) {
+        Ok(edge) => Some(ReplayOp::Add(edge)),
+        Err(e) => {
+            tracing::warn!("Edge WAL undecodable add entry at offset {body_start}: {e}");
+            None
+        }
+    }
+}
+
+/// Decodes a single-`u64` body (Remove / RemoveNode payload).
+fn decode_id(body: &[u8], body_start: usize) -> Option<u64> {
+    let Ok(bytes) = <[u8; 8]>::try_from(body) else {
+        tracing::warn!("Edge WAL malformed id entry at offset {body_start}");
+        return None;
+    };
+    Some(u64::from_le_bytes(bytes))
+}
+
+/// Applies a decoded [`ReplayOp`] to the edge store.
+///
+/// ADD is idempotent: `Error::EdgeExists` (the snapshot already holds the
+/// edge) is treated as a successful no-op.
+fn apply_replay_op(store: &ConcurrentEdgeStore, op: &ReplayOp) {
+    match op {
+        ReplayOp::Add(edge) => match store.add_edge(edge.clone()) {
+            Ok(()) | Err(Error::EdgeExists(_)) => {}
+            Err(e) => tracing::warn!("Edge WAL replay add failed for edge {}: {e}", edge.id()),
+        },
+        ReplayOp::Remove(id) => {
+            store.remove_edge(*id);
+        }
+        ReplayOp::RemoveNode(id) => store.remove_node_edges(*id),
+    }
+}

--- a/crates/velesdb-core/src/collection/graph/mod.rs
+++ b/crates/velesdb-core/src/collection/graph/mod.rs
@@ -42,6 +42,8 @@ mod edge;
 mod edge_concurrent;
 mod edge_persistence;
 mod edge_removal;
+#[cfg(feature = "persistence")]
+pub(crate) mod edge_wal;
 pub(crate) mod helpers;
 mod label_index;
 #[cfg(test)]

--- a/crates/velesdb-core/src/collection/graph_collection.rs
+++ b/crates/velesdb-core/src/collection/graph_collection.rs
@@ -157,15 +157,13 @@ impl GraphCollection {
     /// # Returns
     ///
     /// Number of edges successfully added.
-    #[must_use]
-    pub fn add_edges_batch(&self, edges: Vec<GraphEdge>) -> usize {
-        let count = self.inner.edge_store.add_edges_batch(edges);
-        if count > 0 {
-            self.inner
-                .write_generation
-                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        }
-        count
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if WAL durability logging fails for graph
+    /// collections (fail-closed: the in-memory store is not mutated).
+    pub fn add_edges_batch(&self, edges: Vec<GraphEdge>) -> Result<usize> {
+        self.inner.add_edges_batch(edges)
     }
 
     /// Returns edges, optionally filtered by label.

--- a/crates/velesdb-core/src/index/bm25_persistence_wal.rs
+++ b/crates/velesdb-core/src/index/bm25_persistence_wal.rs
@@ -28,11 +28,14 @@
 //!
 //! All functions here are gated behind `#[cfg(feature = "persistence")]`.
 
-use std::io::{BufWriter, Write};
 use std::path::{Path, PathBuf};
 
 use crate::error::{Error, Result};
 use crate::index::bm25::Bm25Index;
+use crate::index::wal_framing;
+
+/// Error-message context prefix for the shared framing helpers.
+const CTX: &str = "BM25 WAL";
 
 const WAL_OP_ADD: u8 = 0x01;
 const WAL_OP_REMOVE: u8 = 0x02;
@@ -71,10 +74,10 @@ pub(crate) fn wal_append_add_document(wal_path: &Path, id: u64, text: &str) -> R
     let text_len = encode_text_len(text_bytes)?;
     let body_len = add_entry_body_len(text_len)?;
 
-    let mut w = open_wal_writer(wal_path)?;
-    wal_write(&mut w, &body_len.to_le_bytes())?;
+    let mut w = wal_framing::open_wal_writer(wal_path, CTX)?;
+    wal_framing::wal_write(&mut w, &body_len.to_le_bytes(), CTX)?;
     write_add_entry_body(&mut w, id, text_len, text_bytes)?;
-    flush_wal(&mut w)
+    wal_framing::flush_wal(&mut w, CTX)
 }
 
 /// Validates that `text_bytes.len()` fits in a `u32` and returns the cast.
@@ -114,10 +117,10 @@ fn write_add_entry_body(
     text_len: u32,
     text_bytes: &[u8],
 ) -> Result<()> {
-    wal_write(w, &[WAL_OP_ADD])?;
-    wal_write(w, &id.to_le_bytes())?;
-    wal_write(w, &text_len.to_le_bytes())?;
-    wal_write(w, text_bytes)
+    wal_framing::wal_write(w, &[WAL_OP_ADD], CTX)?;
+    wal_framing::wal_write(w, &id.to_le_bytes(), CTX)?;
+    wal_framing::wal_write(w, &text_len.to_le_bytes(), CTX)?;
+    wal_framing::wal_write(w, text_bytes, CTX)
 }
 
 /// Appends a `remove_document(id)` mutation to the BM25 WAL.
@@ -133,11 +136,11 @@ fn write_add_entry_body(
 pub(crate) fn wal_append_remove_document(wal_path: &Path, id: u64) -> Result<()> {
     let body_len = u32::try_from(REMOVE_ENTRY_HEADER)
         .map_err(|_| Error::Index("BM25 WAL: remove header too large".to_string()))?;
-    let mut w = open_wal_writer(wal_path)?;
-    wal_write(&mut w, &body_len.to_le_bytes())?;
-    wal_write(&mut w, &[WAL_OP_REMOVE])?;
-    wal_write(&mut w, &id.to_le_bytes())?;
-    flush_wal(&mut w)
+    let mut w = wal_framing::open_wal_writer(wal_path, CTX)?;
+    wal_framing::wal_write(&mut w, &body_len.to_le_bytes(), CTX)?;
+    wal_framing::wal_write(&mut w, &[WAL_OP_REMOVE], CTX)?;
+    wal_framing::wal_write(&mut w, &id.to_le_bytes(), CTX)?;
+    wal_framing::flush_wal(&mut w, CTX)
 }
 
 /// Truncates the BM25 WAL file to zero length.
@@ -150,15 +153,7 @@ pub(crate) fn wal_append_remove_document(wal_path: &Path, id: u64) -> Result<()>
 /// Returns [`Error::Index`] if the WAL file exists but cannot be
 /// truncated.
 pub(crate) fn wal_truncate(wal_path: &Path) -> Result<()> {
-    if !wal_path.exists() {
-        return Ok(());
-    }
-    let file = std::fs::OpenOptions::new()
-        .write(true)
-        .open(wal_path)
-        .map_err(|e| Error::Index(format!("BM25 WAL truncate open: {e}")))?;
-    file.set_len(0)
-        .map_err(|e| Error::Index(format!("BM25 WAL truncate: {e}")))
+    wal_framing::wal_truncate(wal_path, CTX)
 }
 
 // ---------------------------------------------------------------------------
@@ -188,7 +183,7 @@ pub(crate) fn wal_replay(wal_path: &Path, index: &Bm25Index) -> Result<u64> {
     let mut count = 0u64;
 
     while pos < data.len() {
-        let Some((body_start, body_len)) = read_entry_header(&data, pos) else {
+        let Some((body_start, body_len)) = wal_framing::read_entry_header(&data, pos, CTX) else {
             break;
         };
         pos = body_start;
@@ -211,17 +206,6 @@ pub(crate) fn wal_replay(wal_path: &Path, index: &Bm25Index) -> Result<u64> {
     }
 
     Ok(count)
-}
-
-/// Reads the `u32` length prefix, returning `(body_start, body_len)`.
-fn read_entry_header(data: &[u8], pos: usize) -> Option<(usize, usize)> {
-    if pos + 4 > data.len() {
-        tracing::warn!("BM25 WAL truncated at offset {pos}: not enough bytes for length prefix");
-        return None;
-    }
-    let bytes: [u8; 4] = data[pos..pos + 4].try_into().ok()?;
-    let body_len = u32::from_le_bytes(bytes) as usize;
-    Some((pos + 4, body_len))
 }
 
 /// Dispatches a single WAL entry to the appropriate in-memory mutation.
@@ -296,30 +280,4 @@ fn read_le_u32(data: &[u8], pos: usize) -> Result<u32> {
         .try_into()
         .map(u32::from_le_bytes)
         .map_err(|_| Error::Index(format!("BM25 WAL: corrupt u32 at offset {pos}")))
-}
-
-// ---------------------------------------------------------------------------
-// File-open helpers
-// ---------------------------------------------------------------------------
-
-fn open_wal_writer(wal_path: &Path) -> Result<BufWriter<std::fs::File>> {
-    let file = std::fs::OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(wal_path)
-        .map_err(|e| Error::Index(format!("BM25 WAL open: {e}")))?;
-    Ok(BufWriter::new(file))
-}
-
-fn wal_write(w: &mut BufWriter<std::fs::File>, bytes: &[u8]) -> Result<()> {
-    w.write_all(bytes)
-        .map_err(|e| Error::Index(format!("BM25 WAL write: {e}")))
-}
-
-fn flush_wal(w: &mut BufWriter<std::fs::File>) -> Result<()> {
-    w.flush()
-        .map_err(|e| Error::Index(format!("BM25 WAL flush: {e}")))?;
-    w.get_ref()
-        .sync_all()
-        .map_err(|e| Error::Index(format!("BM25 WAL fsync: {e}")))
 }

--- a/crates/velesdb-core/src/index/mod.rs
+++ b/crates/velesdb-core/src/index/mod.rs
@@ -20,6 +20,8 @@ mod posting_list_tests;
 pub mod secondary;
 pub mod sparse;
 pub mod trigram;
+#[cfg(feature = "persistence")]
+pub(crate) mod wal_framing;
 
 pub use bm25::{Bm25Index, Bm25Params};
 pub use hnsw::{HnswIndex, HnswParams, SearchQuality};

--- a/crates/velesdb-core/src/index/wal_framing.rs
+++ b/crates/velesdb-core/src/index/wal_framing.rs
@@ -1,0 +1,89 @@
+//! Shared length-prefixed WAL framing helpers.
+//!
+//! The BM25 index WAL ([`crate::index::bm25_persistence_wal`]) and the
+//! graph edge WAL ([`crate::collection::graph::edge_wal`]) use the same
+//! on-disk discipline: append-mode `BufWriter`, fsync per flush, and a
+//! `[u32 body_len]`-prefixed entry framing so unknown / truncated entries
+//! are skippable during replay. Those file-open / write / flush / header
+//! helpers live here so the two WALs do not duplicate them.
+//!
+//! The `context` argument is woven into error messages so each caller's
+//! diagnostics stay distinguishable (e.g. "BM25 WAL open" vs
+//! "Edge WAL open").
+
+use std::io::{BufWriter, Write};
+use std::path::Path;
+
+use crate::error::{Error, Result};
+
+/// Opens (creating if absent) the WAL file for append and wraps it in a
+/// `BufWriter`.
+///
+/// # Errors
+///
+/// Returns [`Error::Index`] if the file cannot be opened.
+pub(crate) fn open_wal_writer(wal_path: &Path, context: &str) -> Result<BufWriter<std::fs::File>> {
+    let file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(wal_path)
+        .map_err(|e| Error::Index(format!("{context} open: {e}")))?;
+    Ok(BufWriter::new(file))
+}
+
+/// Writes `bytes` to the WAL writer.
+///
+/// # Errors
+///
+/// Returns [`Error::Index`] if the write fails.
+pub(crate) fn wal_write(
+    w: &mut BufWriter<std::fs::File>,
+    bytes: &[u8],
+    context: &str,
+) -> Result<()> {
+    w.write_all(bytes)
+        .map_err(|e| Error::Index(format!("{context} write: {e}")))
+}
+
+/// Flushes the `BufWriter` and fsyncs the underlying file.
+///
+/// # Errors
+///
+/// Returns [`Error::Index`] if the flush or fsync fails.
+pub(crate) fn flush_wal(w: &mut BufWriter<std::fs::File>, context: &str) -> Result<()> {
+    w.flush()
+        .map_err(|e| Error::Index(format!("{context} flush: {e}")))?;
+    w.get_ref()
+        .sync_all()
+        .map_err(|e| Error::Index(format!("{context} fsync: {e}")))
+}
+
+/// Truncates the WAL file to zero length. A missing file is a no-op.
+///
+/// # Errors
+///
+/// Returns [`Error::Index`] if the file exists but cannot be truncated.
+pub(crate) fn wal_truncate(wal_path: &Path, context: &str) -> Result<()> {
+    if !wal_path.exists() {
+        return Ok(());
+    }
+    let file = std::fs::OpenOptions::new()
+        .write(true)
+        .open(wal_path)
+        .map_err(|e| Error::Index(format!("{context} truncate open: {e}")))?;
+    file.set_len(0)
+        .map_err(|e| Error::Index(format!("{context} truncate: {e}")))
+}
+
+/// Reads the 4-byte little-endian length prefix at `pos`, returning
+/// `(body_start, body_len)`. Returns `None` (logging at `warn`) when the
+/// remaining bytes cannot hold a prefix — the torn-tail crash case.
+pub(crate) fn read_entry_header(data: &[u8], pos: usize, context: &str) -> Option<(usize, usize)> {
+    if pos + 4 > data.len() {
+        tracing::warn!("{context} truncated at offset {pos}: not enough bytes for length prefix");
+        return None;
+    }
+    let bytes: [u8; 4] = data[pos..pos + 4].try_into().ok()?;
+    let body_len = u32::from_le_bytes(bytes) as usize;
+    Some((pos + 4, body_len))
+}

--- a/crates/velesdb-migrate/src/pipeline_graph.rs
+++ b/crates/velesdb-migrate/src/pipeline_graph.rs
@@ -95,7 +95,9 @@ impl<'a> GraphMigrationPhase<'a> {
                 .await?;
 
             let total = edges.len() as u64;
-            let inserted = gc.add_edges_batch(edges) as u64;
+            let inserted = gc.add_edges_batch(edges).map_err(|e| {
+                Error::DestinationConnection(format!("Edge batch insert failed: {e}"))
+            })? as u64;
             stats.edges_created += inserted;
             stats.edges_failed += total.saturating_sub(inserted);
             stats.relations_processed += 1;

--- a/crates/velesdb-python/src/graph_collection.rs
+++ b/crates/velesdb-python/src/graph_collection.rs
@@ -184,7 +184,7 @@ impl PyGraphCollection {
             .iter()
             .map(|e| dict_to_edge(py, e))
             .collect::<PyResult<Vec<_>>>()?;
-        py.allow_threads(|| Ok(self.inner.add_edges_batch(graph_edges)))
+        py.allow_threads(|| self.inner.add_edges_batch(graph_edges).map_err(core_err))
     }
 
     /// Get edges, optionally filtered by label.


### PR DESCRIPTION
Addresses the **CRITICAL** audit finding: graph edge mutations were not crash-durable (persisted only via the whole-file `edge_store.bin` snapshot at flush; writes between flushes were lost on crash, and `add_edge`/`remove_edge` did not fsync).

**What changed**
- New `collection/graph/edge_wal.rs`: per-collection `edges.wal`, length-prefixed entries (ADD/REMOVE/REMOVE_NODE), WAL-before-apply ordering, fsync per append, replay-on-open on top of the snapshot, truncate-after-snapshot. Torn-tail/unknown-opcode tolerant; ADD replay idempotent (`Err(EdgeExists)` ignored so snapshot+WAL never double-count).
- Wiring in `graph_api.rs` (add_edge / add_edges_batch / remove_edge fail-closed), `crud_read_delete.rs` (cascade delete), `flush.rs` (truncate after durable snapshot), `lifecycle.rs` (replay after assemble).
- Shared length-prefixed framing extracted to `index/wal_framing.rs`; BM25 WAL refactored to reuse it (jscpd: 0 clones between the two WAL modules).
- Justified design deviation: ADD bodies use serde_json (not postcard) because `GraphEdge.properties` is `serde_json::Value` (deserialize_any — postcard silently drops properties; caught by a test).

**Verification**: build + clippy pedantic clean; 8 crash-recovery tests (reopen-without-flush, remove, cascade, batch, truncation idempotency, legacy back-compat, torn-tail, property preservation) — re-run independently, all green. No search-path files touched (recall gate N/A).

**Note**: API break — `GraphCollection::add_edges_batch` / new `Collection::add_edges_batch` now return `Result<usize>`; both in-tree callers updated. `remove_edge` stays `bool` (fail-closed, logs on WAL error). Committed with `CLAUDE_DRY_SKIP=1` for 7 **pre-existing** duplication blocks in touched files (no new dup introduced).