### PR TITLE
feat(graph): enforce referential integrity + schema in strict mode

### DIFF
--- a/crates/velesdb-core/src/collection/core/graph_api.rs
+++ b/crates/velesdb-core/src/collection/core/graph_api.rs
@@ -12,6 +12,7 @@ use crate::index::VectorIndex;
 use crate::point::{Point, SearchResult};
 use crate::storage::{PayloadStorage, VectorStorage};
 
+use super::graph_property_index_wiring::extract_labels;
 use super::graph_traversal_helpers::{
     bfs_pop, bfs_push, dfs_pop, dfs_push, expand_dfs_neighbors, reconstruct_path,
     traverse_with_frontier, DfsFrontier, TraversalEntry, TraversalParams,
@@ -39,6 +40,11 @@ impl Collection {
     /// collection.add_edge(edge)?;
     /// ```
     pub fn add_edge(&self, edge: GraphEdge) -> Result<()> {
+        // Strict-schema referential integrity: reject before any mutation so a
+        // violation leaves no partial write and does not bump write_generation.
+        // Schemaless collections (the default) short-circuit at zero added cost.
+        self.validate_edge_referential_integrity(&edge)?;
+
         let edge_id = edge.id();
         let rel_type = edge.label().to_string();
         let properties = edge.properties().clone();
@@ -53,6 +59,47 @@ impl Collection {
         self.write_generation
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         Ok(())
+    }
+
+    /// Enforces strict-schema referential integrity for an edge write.
+    ///
+    /// In schemaless mode (the default), this is a no-op and returns
+    /// immediately. In strict mode it verifies that both endpoint nodes exist
+    /// and that the edge type / endpoint types satisfy the declared schema.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::SchemaValidation` if an endpoint node is missing, has no
+    /// `_labels`, or the edge violates the schema's edge-type constraints.
+    fn validate_edge_referential_integrity(&self, edge: &GraphEdge) -> Result<()> {
+        let schema = match self.config.read().graph_schema.clone() {
+            Some(s) if !s.is_schemaless() => s,
+            _ => return Ok(()),
+        };
+
+        let from_type = self.endpoint_node_type(edge.source())?;
+        let to_type = self.endpoint_node_type(edge.target())?;
+        schema.validate_edge_type(edge.label(), &from_type, &to_type)
+    }
+
+    /// Resolves the node type (first `_labels` entry) for a graph node,
+    /// requiring the node to exist and carry a label (strict-mode helper).
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::SchemaValidation` if the node has no stored payload
+    /// (referential integrity violation) or the payload declares no `_labels`.
+    fn endpoint_node_type(&self, node_id: u64) -> Result<String> {
+        let payload = self.payload_storage.read().retrieve(node_id)?;
+        let Some(payload) = payload else {
+            return Err(Error::SchemaValidation(format!(
+                "edge references non-existent node {node_id}"
+            )));
+        };
+        extract_labels(&payload)
+            .into_iter()
+            .next()
+            .ok_or_else(|| Error::SchemaValidation(format!("node {node_id} has no '_labels' type")))
     }
 
     /// Gets all edges from the collection's knowledge graph.

--- a/crates/velesdb-core/src/collection/core/graph_api_tests.rs
+++ b/crates/velesdb-core/src/collection/core/graph_api_tests.rs
@@ -715,4 +715,100 @@ mod tests {
         );
         assert!(!results.is_empty());
     }
+
+    // =========================================================================
+    // Referential integrity + schema enforcement (strict graph schema mode)
+    // =========================================================================
+
+    fn create_strict_graph_collection() -> (Collection, TempDir) {
+        use crate::collection::graph::{EdgeType, GraphSchema, NodeType};
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let schema = GraphSchema::new()
+            .with_node_type(NodeType::new("Person"))
+            .with_node_type(NodeType::new("Company"))
+            .with_edge_type(EdgeType::new("KNOWS", "Person", "Person"));
+        let collection = Collection::create_graph_collection(
+            temp_dir.path().to_path_buf(),
+            "kg_strict",
+            schema,
+            None,
+            DistanceMetric::Cosine,
+        )
+        .expect("Failed to create strict graph collection");
+        (collection, temp_dir)
+    }
+
+    fn store_typed_node(collection: &Collection, id: u64, node_type: &str) {
+        collection
+            .store_node_payload(id, &serde_json::json!({ "_labels": [node_type] }))
+            .expect("store node payload");
+    }
+
+    fn assert_schema_violation(result: crate::error::Result<()>) {
+        match result {
+            Err(crate::error::Error::SchemaValidation(_)) => {}
+            other => panic!("expected SchemaValidation error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_strict_mode_rejects_dangling_edge() {
+        let (collection, _temp) = create_strict_graph_collection();
+        // No node payloads stored: endpoints do not exist.
+        assert_schema_violation(collection.add_edge(make_edge(1, 100, 200, "KNOWS")));
+        assert_eq!(collection.edge_count(), 0, "no partial write on rejection");
+    }
+
+    #[test]
+    fn test_strict_mode_rejects_bad_edge_type() {
+        let (collection, _temp) = create_strict_graph_collection();
+        store_typed_node(&collection, 100, "Person");
+        store_typed_node(&collection, 200, "Person");
+        assert_schema_violation(collection.add_edge(make_edge(1, 100, 200, "UNKNOWN_REL")));
+        assert_eq!(collection.edge_count(), 0);
+    }
+
+    #[test]
+    fn test_strict_mode_rejects_endpoint_type_mismatch() {
+        let (collection, _temp) = create_strict_graph_collection();
+        store_typed_node(&collection, 100, "Person");
+        store_typed_node(&collection, 200, "Company");
+        // KNOWS is Person->Person; target is a Company.
+        assert_schema_violation(collection.add_edge(make_edge(1, 100, 200, "KNOWS")));
+        assert_eq!(collection.edge_count(), 0);
+    }
+
+    #[test]
+    fn test_strict_mode_rejects_node_without_labels() {
+        let (collection, _temp) = create_strict_graph_collection();
+        // Node exists but carries no `_labels` -> type cannot be resolved.
+        collection
+            .store_node_payload(100, &serde_json::json!({ "name": "A" }))
+            .unwrap();
+        store_typed_node(&collection, 200, "Person");
+        assert_schema_violation(collection.add_edge(make_edge(1, 100, 200, "KNOWS")));
+        assert_eq!(collection.edge_count(), 0);
+    }
+
+    #[test]
+    fn test_strict_mode_accepts_valid_edge() {
+        let (collection, _temp) = create_strict_graph_collection();
+        store_typed_node(&collection, 100, "Person");
+        store_typed_node(&collection, 200, "Person");
+        collection
+            .add_edge(make_edge(1, 100, 200, "KNOWS"))
+            .expect("valid edge should be accepted");
+        assert_eq!(collection.edge_count(), 1);
+    }
+
+    #[test]
+    fn test_schemaless_mode_allows_dangling_edge() {
+        // Regression guard: default schemaless path is unchanged — no endpoint
+        // payloads, arbitrary edge label, still accepted.
+        let (collection, _temp) = create_graph_test_collection();
+        collection
+            .add_edge(make_edge(1, 100, 200, "ANY_REL"))
+            .expect("schemaless collection must accept dangling edges");
+        assert_eq!(collection.edge_count(), 1);
+    }
 }

--- a/crates/velesdb-core/src/collection/core/graph_property_index_wiring.rs
+++ b/crates/velesdb-core/src/collection/core/graph_property_index_wiring.rs
@@ -21,7 +21,7 @@ fn edge_index_key(rel_type: &str, property: &str) -> String {
 }
 
 /// Extracts the `_labels` array from a node payload.
-fn extract_labels(payload: &Value) -> Vec<String> {
+pub(crate) fn extract_labels(payload: &Value) -> Vec<String> {
     payload
         .get("_labels")
         .and_then(Value::as_array)

--- a/crates/velesdb-core/src/collection/core/lifecycle_tests.rs
+++ b/crates/velesdb-core/src/collection/core/lifecycle_tests.rs
@@ -389,8 +389,11 @@ fn test_open_without_edge_store_bin_recovers_gracefully() {
     let col_path = temp_dir.path().join("graph_col");
 
     // 1. Create a graph collection, flush to persist config.json, then drop.
+    //    Schemaless: this test exercises edge_store.bin recovery, not strict
+    //    referential-integrity enforcement (which would reject this dangling
+    //    edge with no endpoint node payloads).
     {
-        let schema = GraphSchema::new();
+        let schema = GraphSchema::schemaless();
         let collection = Collection::create_graph_collection(
             col_path.clone(),
             "graph_col",

--- a/crates/velesdb-core/tests/bdd/ddl_lifecycle.rs
+++ b/crates/velesdb-core/tests/bdd/ddl_lifecycle.rs
@@ -362,6 +362,20 @@ fn test_graph_typed_schema_lifecycle() {
         "Should have KNOWS edge type"
     );
 
+    // Insert the typed endpoint nodes first: strict-schema referential
+    // integrity requires both endpoints to exist with a declared type before
+    // an edge can reference them.
+    gc.upsert_node_payload(
+        1,
+        &serde_json::json!({"name": "Alice", "_labels": ["Person"]}),
+    )
+    .expect("test: upsert node 1");
+    gc.upsert_node_payload(
+        2,
+        &serde_json::json!({"name": "Bob", "_labels": ["Person"]}),
+    )
+    .expect("test: upsert node 2");
+
     // INSERT EDGE via SQL
     execute_sql(
         &db,


### PR DESCRIPTION
Addresses the **HIGH** audit finding: `GraphSchema::validate_edge_type`/`validate_node_type` had zero production callers (strict schema was a no-op) and edges could reference non-existent nodes.

**What changed**: `Collection::add_edge` now, **in strict-schema mode only**, validates edge type + endpoint node existence and returns a clear `Error` on violation. **Schemaless (default) behavior is unchanged** (existing collections unaffected).

**Verification**: build + clippy pedantic clean; 6 new strict/schemaless tests; targeted suites green (graph 523, schema 41/37, edge 19).

**Deferred (TODO(EPIC-XXX), documented)**: `add_edges_batch` bulk path not yet validated in strict mode; schemaless dangling-edge warn; `validate_node_type` on INSERT NODE.