### PR TITLE
feat(graph): wall-clock timeout in traversal + wire GraphMetrics

### DIFF
--- a/crates/velesdb-cli/src/graph_handlers.rs
+++ b/crates/velesdb-cli/src/graph_handlers.rs
@@ -109,6 +109,7 @@ pub(crate) fn handle_traverse(
         max_depth,
         limit,
         rel_types: rel_vec,
+        deadline: None,
     };
     let algo_label = match algorithm {
         TraverseAlgo::Bfs => "BFS",

--- a/crates/velesdb-cli/src/repl_graph_cmds.rs
+++ b/crates/velesdb-cli/src/repl_graph_cmds.rs
@@ -179,6 +179,7 @@ fn cmd_graph_traverse(db: &Database, parts: &[&str]) -> CommandResult {
         max_depth,
         limit,
         rel_types,
+        deadline: None,
     };
 
     let algo_label = match algo.as_str() {

--- a/crates/velesdb-core/src/collection/core/graph_api.rs
+++ b/crates/velesdb-core/src/collection/core/graph_api.rs
@@ -323,8 +323,25 @@ impl Collection {
     // -------------------------------------------------------------------------
 
     /// BFS traversal using the core `concurrent_bfs_stream` iterator.
+    ///
+    /// Wraps [`Self::traverse_bfs_config_inner`] with traversal metrics timing.
     #[must_use]
     pub fn traverse_bfs_config(
+        &self,
+        source_id: u64,
+        config: &TraversalConfig,
+    ) -> Vec<TraversalResult> {
+        let start = std::time::Instant::now();
+        let results = self.traverse_bfs_config_inner(source_id, config);
+        self.edge_store
+            .metrics()
+            .record_traversal(start.elapsed(), results.len() as u64);
+        results
+    }
+
+    /// Inner BFS traversal without metrics (see [`Self::traverse_bfs_config`]).
+    #[must_use]
+    fn traverse_bfs_config_inner(
         &self,
         source_id: u64,
         config: &TraversalConfig,
@@ -355,6 +372,7 @@ impl Collection {
             rel_types: config.rel_types.clone(),
             limit: Some(config.limit),
             max_visited_size: MAX_VISITED_SIZE,
+            deadline: config.deadline,
         };
         concurrent_bfs_stream(&self.edge_store, source_id, streaming)
             .filter(|result| result.depth >= config.min_depth)
@@ -364,9 +382,26 @@ impl Collection {
 
     /// DFS traversal (iterative) using `TraversalConfig`.
     ///
-    /// Uses parent-pointer map for zero-clone path reconstruction (G4).
+    /// Wraps [`Self::traverse_dfs_config_inner`] with traversal metrics timing.
     #[must_use]
     pub fn traverse_dfs_config(
+        &self,
+        source_id: u64,
+        config: &TraversalConfig,
+    ) -> Vec<TraversalResult> {
+        let start = std::time::Instant::now();
+        let results = self.traverse_dfs_config_inner(source_id, config);
+        self.edge_store
+            .metrics()
+            .record_traversal(start.elapsed(), results.len() as u64);
+        results
+    }
+
+    /// Inner DFS traversal without metrics (see [`Self::traverse_dfs_config`]).
+    ///
+    /// Uses parent-pointer map for zero-clone path reconstruction (G4).
+    #[must_use]
+    fn traverse_dfs_config_inner(
         &self,
         source_id: u64,
         config: &TraversalConfig,
@@ -378,8 +413,14 @@ impl Collection {
         let mut parent_map: FxHashMap<u64, (u64, u64)> = FxHashMap::default();
         let mut stack: Vec<TraversalEntry> = vec![(source_id, 0)];
 
+        // Start at the threshold so an already-expired deadline aborts on the
+        // first pop; otherwise the clock is only read every N pops.
+        let mut nodes_since_check = crate::collection::graph::DEADLINE_CHECK_INTERVAL;
         while let Some((node_id, depth)) = stack.pop() {
             if results.len() >= config.limit {
+                break;
+            }
+            if crate::collection::graph::deadline_reached(config.deadline, &mut nodes_since_check) {
                 break;
             }
             // Issue #906: bound the visited set / parent map. A highly-connected

--- a/crates/velesdb-core/src/collection/core/graph_api_tests.rs
+++ b/crates/velesdb-core/src/collection/core/graph_api_tests.rs
@@ -5,6 +5,7 @@ mod tests {
     use crate::collection::graph::{GraphEdge, TraversalConfig};
     use crate::collection::types::Collection;
     use crate::DistanceMetric;
+    use std::time::{Duration, Instant};
     use tempfile::TempDir;
 
     fn create_test_collection() -> (Collection, TempDir) {
@@ -314,6 +315,7 @@ mod tests {
             min_depth: 0,
             rel_types: vec![],
             limit: 100,
+            deadline: None,
         };
         let results = collection.traverse_bfs_config(1, &config);
         assert!(!results.is_empty());
@@ -329,6 +331,7 @@ mod tests {
             min_depth: 2,
             rel_types: vec![],
             limit: 100,
+            deadline: None,
         };
         let results = collection.traverse_bfs_config(1, &config);
         // min_depth=2 so only nodes at depth >= 2 are returned
@@ -345,6 +348,7 @@ mod tests {
             min_depth: 0,
             rel_types: vec![],
             limit: 100,
+            deadline: None,
         };
         let results = collection.traverse_dfs_config(1, &config);
         assert!(!results.is_empty());
@@ -361,10 +365,109 @@ mod tests {
             min_depth: 0,
             rel_types: vec!["NEXT".to_string()],
             limit: 100,
+            deadline: None,
         };
         let results = collection.traverse_dfs_config(1, &config);
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].target_id, 2);
+    }
+
+    // =========================================================================
+    // Wall-clock deadline on config traversal + GraphMetrics wiring
+    // =========================================================================
+
+    #[test]
+    fn test_traverse_dfs_config_expired_deadline_returns_partial() {
+        let (collection, _temp) = create_test_collection();
+        build_chain(&collection);
+
+        let config = TraversalConfig::with_range(1, 3)
+            .with_limit(100)
+            .with_deadline(
+                Instant::now()
+                    .checked_sub(Duration::from_millis(1))
+                    .expect("test: clock before epoch"),
+            );
+
+        // Expired deadline aborts before expanding (counter seeded at threshold).
+        let results = collection.traverse_dfs_config(1, &config);
+        assert!(results.is_empty(), "expired deadline aborts DFS traversal");
+    }
+
+    #[test]
+    fn test_traverse_bfs_config_expired_deadline_returns_partial() {
+        let (collection, _temp) = create_test_collection();
+        build_chain(&collection);
+
+        let config = TraversalConfig::with_range(1, 3)
+            .with_limit(100)
+            .with_deadline(
+                Instant::now()
+                    .checked_sub(Duration::from_millis(1))
+                    .expect("test: clock before epoch"),
+            );
+
+        let results = collection.traverse_bfs_config(1, &config);
+        assert!(results.is_empty(), "expired deadline aborts BFS traversal");
+    }
+
+    #[test]
+    fn test_traverse_config_far_future_deadline_no_premature_abort() {
+        let (collection, _temp) = create_test_collection();
+        build_chain(&collection);
+
+        let future = Instant::now() + Duration::from_secs(3600);
+        let with_deadline = TraversalConfig::with_range(1, 3)
+            .with_limit(100)
+            .with_deadline(future);
+        let without = TraversalConfig::with_range(1, 3).with_limit(100);
+
+        let a = collection.traverse_bfs_config(1, &with_deadline);
+        let b = collection.traverse_bfs_config(1, &without);
+        assert_eq!(a.len(), b.len(), "far-future deadline must not truncate");
+        assert!(!a.is_empty());
+    }
+
+    #[test]
+    fn test_traverse_bfs_config_records_metrics() {
+        let (collection, _temp) = create_test_collection();
+        build_chain(&collection);
+
+        let before = collection.edge_store.metrics().traversals_total();
+        let config = TraversalConfig::with_range(1, 3).with_limit(100);
+        let results = collection.traverse_bfs_config(1, &config);
+        assert!(!results.is_empty());
+
+        let metrics = collection.edge_store.metrics();
+        assert_eq!(
+            metrics.traversals_total(),
+            before + 1,
+            "BFS config traversal increments the counter"
+        );
+        assert!(
+            metrics.traversal_latency.count() > 0,
+            "traversal latency observed"
+        );
+        assert!(
+            metrics.traversal_nodes_visited() >= results.len() as u64,
+            "nodes_visited recorded"
+        );
+    }
+
+    #[test]
+    fn test_traverse_dfs_config_records_metrics() {
+        let (collection, _temp) = create_test_collection();
+        build_chain(&collection);
+
+        let before = collection.edge_store.metrics().traversals_total();
+        let config = TraversalConfig::with_range(1, 3).with_limit(100);
+        let _ = collection.traverse_dfs_config(1, &config);
+
+        assert_eq!(
+            collection.edge_store.metrics().traversals_total(),
+            before + 1,
+            "DFS config traversal increments the counter"
+        );
     }
 
     // =========================================================================
@@ -381,6 +484,7 @@ mod tests {
             min_depth: 1,
             rel_types: vec![],
             limit: 100,
+            deadline: None,
         };
         let results = collection.traverse_bfs_parallel(&[1], &config);
         assert!(!results.is_empty(), "parallel BFS should find neighbors");
@@ -406,6 +510,7 @@ mod tests {
             min_depth: 1,
             rel_types: vec![],
             limit: 100,
+            deadline: None,
         };
         let results = collection.traverse_bfs_parallel(&[1, 10], &config);
 
@@ -445,6 +550,7 @@ mod tests {
             min_depth: 1,
             rel_types: vec![],
             limit: 100,
+            deadline: None,
         };
         let results = collection.traverse_bfs_parallel(&[1], &config);
         assert!(results.iter().all(|r| r.depth <= 1));
@@ -596,6 +702,7 @@ mod tests {
             min_depth: 0,
             rel_types: vec![],
             limit: usize::MAX,
+            deadline: None,
         };
         let results = collection.traverse_dfs_config(0, &config);
 
@@ -686,6 +793,7 @@ mod tests {
             min_depth: 2,
             rel_types: vec![],
             limit: usize::MAX,
+            deadline: None,
         };
         let results = collection.traverse_dfs_config(0, &config);
         assert!(

--- a/crates/velesdb-core/src/collection/graph/csr_tests.rs
+++ b/crates/velesdb-core/src/collection/graph/csr_tests.rs
@@ -354,6 +354,7 @@ mod property_tests {
                 max_depth,
                 limit,
                 rel_types: Vec::new(),
+                deadline: None,
             }
         })
     }

--- a/crates/velesdb-core/src/collection/graph/edge_concurrent/mod.rs
+++ b/crates/velesdb-core/src/collection/graph/edge_concurrent/mod.rs
@@ -19,11 +19,13 @@ use super::clustered_index::ClusteredIndex;
 use super::csr_snapshot::{CsrSnapshot, SnapshotBuilder};
 use super::edge::{EdgeStore, GraphEdge};
 use super::label_table::LabelTable;
+use super::metrics::GraphMetrics;
 use crate::error::{Error, Result};
 use arc_swap::ArcSwap;
 use parking_lot::RwLock;
 use rustc_hash::FxHashMap;
 use std::sync::atomic::{AtomicBool, AtomicU64};
+use std::time::Instant;
 
 /// Number of pending edge mutations that may accumulate before the lazy CSR
 /// rebuild is forced (issue #905 debounce).
@@ -101,6 +103,11 @@ pub struct ConcurrentEdgeStore {
     pending_writes: AtomicU64,
     /// Shared label table for interning edge labels during snapshot builds.
     label_table: RwLock<LabelTable>,
+    /// Lock-free operational metrics (edge inserts/deletes, traversals).
+    ///
+    /// Atomic counters and histograms only; observed on the Ok tail of each
+    /// mutation after all shard locks have been released.
+    metrics: GraphMetrics,
 }
 
 impl ConcurrentEdgeStore {
@@ -140,7 +147,16 @@ impl ConcurrentEdgeStore {
             csr_dirty: AtomicBool::new(false),
             pending_writes: AtomicU64::new(0),
             label_table: RwLock::new(LabelTable::new()),
+            metrics: GraphMetrics::new(),
         })
+    }
+
+    /// Returns the operational metrics for this edge store.
+    ///
+    /// Counters/histograms cover edge inserts, deletes, and traversals.
+    #[must_use]
+    pub fn metrics(&self) -> &GraphMetrics {
+        &self.metrics
     }
 
     /// Creates a concurrent edge store with optimal shard count for estimated edge count.
@@ -185,6 +201,7 @@ impl ConcurrentEdgeStore {
     /// Returns `Error::EdgeExists` if an edge with the same ID already exists.
     pub fn add_edge(&self, edge: GraphEdge) -> Result<()> {
         let edge_id = edge.id();
+        let start = Instant::now();
 
         {
             // CRITICAL: Hold edge_ids lock throughout the entire operation to prevent race
@@ -233,6 +250,8 @@ impl ConcurrentEdgeStore {
         } // All locks dropped here.
         self.invalidate_snapshot();
         self.rebuild_snapshot_best_effort();
+        // Record after all shard locks drop so the atomic ops never overlap a held lock.
+        self.metrics.record_edge_insert(start.elapsed());
         Ok(())
     }
 
@@ -253,6 +272,7 @@ impl ConcurrentEdgeStore {
             return 0;
         }
 
+        let start = Instant::now();
         let mut count = 0usize;
         {
             let mut ids = self.edge_ids.write();
@@ -280,6 +300,10 @@ impl ConcurrentEdgeStore {
             // keep a bulk-loaded graph permanently below the rebuild
             // threshold, so the CSR fast path would never engage.
             self.record_pending_writes(count as u64);
+            // Counters bumped by count, batch latency observed once (no
+            // per-edge Instant::now()).
+            self.metrics
+                .record_edge_inserts_batch(count as u64, start.elapsed());
         }
         count
     }
@@ -328,6 +352,7 @@ impl ConcurrentEdgeStore {
     ///
     /// Lock ordering: edge_ids FIRST, then shards in ascending order.
     pub fn remove_edge(&self, edge_id: u64) -> bool {
+        let start = Instant::now();
         {
             let mut ids = self.edge_ids.write();
 
@@ -372,6 +397,8 @@ impl ConcurrentEdgeStore {
         } // All locks dropped here.
         self.invalidate_snapshot();
         self.rebuild_snapshot_best_effort();
+        // Record after all shard locks drop (true path only).
+        self.metrics.record_edge_delete(start.elapsed());
         true
     }
 

--- a/crates/velesdb-core/src/collection/graph/edge_concurrent_tests.rs
+++ b/crates/velesdb-core/src/collection/graph/edge_concurrent_tests.rs
@@ -1369,6 +1369,7 @@ fn test_csr_debounce_rebuilds_after_threshold() {
         min_depth: 1,
         rel_types: vec![],
         limit: 100,
+        deadline: None,
     };
     let results = store.traverse_bfs_csr(0, &config);
     let targets: std::collections::HashSet<u64> = results.iter().map(|r| r.target_id).collect();
@@ -1418,6 +1419,7 @@ fn test_add_edges_batch_counts_each_edge_toward_csr_debounce() {
         min_depth: 1,
         rel_types: vec![],
         limit: 100,
+        deadline: None,
     };
     let results = store.traverse_bfs_csr(0, &config);
     let targets: std::collections::HashSet<u64> = results.iter().map(|r| r.target_id).collect();
@@ -1433,4 +1435,87 @@ fn test_add_edges_batch_counts_each_edge_toward_csr_debounce() {
         store.csr_is_authoritative(),
         "CSR snapshot is authoritative after the batch-triggered rebuild"
     );
+}
+
+// =============================================================================
+// GraphMetrics wiring (edge insert / delete / batch)
+// =============================================================================
+
+#[test]
+fn test_metrics_record_edge_inserts() {
+    let store = ConcurrentEdgeStore::new();
+    for i in 1..=3 {
+        store
+            .add_edge(GraphEdge::new(i, i, i + 100, "KNOWS").expect("valid"))
+            .expect("add");
+    }
+
+    let m = store.metrics();
+    assert_eq!(m.edge_inserts_total(), 3, "3 inserts recorded");
+    assert_eq!(m.edges_total(), 3, "3 live edges");
+    assert_eq!(m.edge_insert_latency.count(), 3, "3 latency observations");
+}
+
+#[test]
+fn test_metrics_record_edge_delete() {
+    let store = ConcurrentEdgeStore::new();
+    for i in 1..=3 {
+        store
+            .add_edge(GraphEdge::new(i, i, i + 100, "KNOWS").expect("valid"))
+            .expect("add");
+    }
+
+    assert!(store.remove_edge(1), "edge 1 removed");
+
+    let m = store.metrics();
+    assert_eq!(m.edge_deletes_total(), 1, "1 delete recorded");
+    assert_eq!(m.edges_total(), 2, "edges_total decremented to 2");
+    assert_eq!(
+        m.edge_delete_latency.count(),
+        1,
+        "1 delete latency observed"
+    );
+}
+
+#[test]
+fn test_metrics_record_missing_edge_delete_is_noop() {
+    let store = ConcurrentEdgeStore::new();
+    assert!(
+        !store.remove_edge(999),
+        "removing absent edge returns false"
+    );
+    assert_eq!(
+        store.metrics().edge_deletes_total(),
+        0,
+        "no delete recorded for a missing edge"
+    );
+}
+
+#[test]
+fn test_metrics_record_batch_inserts() {
+    let store = ConcurrentEdgeStore::new();
+    let edges: Vec<GraphEdge> = (1..=5)
+        .map(|i| GraphEdge::new(i, i, i + 100, "LINK").expect("valid"))
+        .collect();
+
+    let added = store.add_edges_batch(edges);
+    assert_eq!(added, 5);
+
+    let m = store.metrics();
+    assert_eq!(m.edge_inserts_total(), 5, "batch bumps inserts by N");
+    assert_eq!(m.edges_total(), 5, "batch bumps edges by N");
+    assert_eq!(
+        m.edge_insert_latency.count(),
+        1,
+        "batch observes latency once (no per-edge clock read)"
+    );
+}
+
+#[test]
+fn test_metrics_empty_batch_records_nothing() {
+    let store = ConcurrentEdgeStore::new();
+    let added = store.add_edges_batch(Vec::new());
+    assert_eq!(added, 0);
+    assert_eq!(store.metrics().edge_inserts_total(), 0);
+    assert_eq!(store.metrics().edge_insert_latency.count(), 0);
 }

--- a/crates/velesdb-core/src/collection/graph/metrics/mod.rs
+++ b/crates/velesdb-core/src/collection/graph/metrics/mod.rs
@@ -227,6 +227,19 @@ impl GraphMetrics {
         self.edge_insert_latency.observe(latency);
     }
 
+    /// Records a batch edge insertion.
+    ///
+    /// Bumps the insert/edge counters by `count` and observes the batch
+    /// `latency` once, avoiding a per-edge `Instant::now()` on the bulk path.
+    pub fn record_edge_inserts_batch(&self, count: u64, latency: Duration) {
+        if count == 0 {
+            return;
+        }
+        self.edge_inserts_total.fetch_add(count, Ordering::Relaxed);
+        self.edges_total.fetch_add(count, Ordering::Relaxed);
+        self.edge_insert_latency.observe(latency);
+    }
+
     /// Records an edge deletion with latency.
     ///
     /// Uses saturating subtraction to prevent underflow.

--- a/crates/velesdb-core/src/collection/graph/mod.rs
+++ b/crates/velesdb-core/src/collection/graph/mod.rs
@@ -100,6 +100,7 @@ pub use streaming::{
     bfs_stream, concurrent_bfs_stream, BfsIterator, ConcurrentBfsIterator, StreamingConfig,
     MAX_VISITED_SIZE,
 };
+pub(crate) use traversal::{deadline_reached, DEADLINE_CHECK_INTERVAL};
 pub use traversal::{TraversalConfig, TraversalPath, TraversalResult, DEFAULT_MAX_DEPTH};
 pub use traversal_bidir::bfs_traverse_both;
 pub use traversal_csr::{bfs_traverse_csr, bfs_traverse_csr_filtered};

--- a/crates/velesdb-core/src/collection/graph/streaming.rs
+++ b/crates/velesdb-core/src/collection/graph/streaming.rs
@@ -4,10 +4,11 @@
 //! avoiding the need to load all visited nodes into memory at once.
 
 use super::edge_concurrent::ConcurrentEdgeStore;
-use super::traversal::{reconstruct_path, BfsState};
+use super::traversal::{deadline_reached, reconstruct_path, BfsState, DEADLINE_CHECK_INTERVAL};
 use super::{EdgeStore, TraversalResult, DEFAULT_MAX_DEPTH};
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::collections::VecDeque;
+use std::time::Instant;
 
 /// Default upper bound on the visited-set / parent-map size for a single
 /// traversal (issue #906).
@@ -33,6 +34,10 @@ pub struct StreamingConfig {
     pub max_visited_size: usize,
     /// Filter by relationship types (empty = all types).
     pub rel_types: Vec<String>,
+    /// Optional wall-clock deadline. When set and reached, the iterator stops
+    /// expanding and terminates (returns `None`), yielding the partial result
+    /// accumulated so far. `None` (the default) disables the time bound.
+    pub deadline: Option<Instant>,
 }
 
 impl Default for StreamingConfig {
@@ -42,6 +47,7 @@ impl Default for StreamingConfig {
             limit: None,
             max_visited_size: MAX_VISITED_SIZE, // ~800KB for FxHashSet<u64>
             rel_types: Vec::new(),
+            deadline: None,
         }
     }
 }
@@ -74,6 +80,14 @@ impl StreamingConfig {
         self.rel_types = types;
         self
     }
+
+    /// Sets a wall-clock deadline after which the iterator terminates,
+    /// yielding only the results accumulated so far.
+    #[must_use]
+    pub fn with_deadline(mut self, deadline: Instant) -> Self {
+        self.deadline = Some(deadline);
+        self
+    }
 }
 
 /// Shared BFS bookkeeping for the streaming iterators.
@@ -93,6 +107,8 @@ struct BfsBookkeeping {
     parent_map: FxHashMap<u64, (u64, u64)>,
     source_id: u64,
     yielded: usize,
+    /// Pops since the last wall-clock deadline check (see `drive`).
+    nodes_since_check: u32,
 }
 
 impl BfsBookkeeping {
@@ -116,6 +132,9 @@ impl BfsBookkeeping {
             parent_map: FxHashMap::default(),
             source_id: start_id,
             yielded: 0,
+            // Start at the threshold so an already-expired deadline aborts on
+            // the first pop; otherwise the clock is read every N pops.
+            nodes_since_check: DEADLINE_CHECK_INTERVAL,
         }
     }
 
@@ -197,7 +216,13 @@ impl BfsBookkeeping {
         if let Some(result) = self.next_pending() {
             return Some(result);
         }
+        let deadline = self.config.deadline;
         while let Some(state) = self.queue.pop_front() {
+            if deadline_reached(deadline, &mut self.nodes_since_check) {
+                // Clear the frontier so the iterator is permanently terminated.
+                self.queue.clear();
+                return None;
+            }
             expand(self, &state);
             if let Some(result) = self.next_pending() {
                 return Some(result);

--- a/crates/velesdb-core/src/collection/graph/streaming_tests.rs
+++ b/crates/velesdb-core/src/collection/graph/streaming_tests.rs
@@ -2,6 +2,7 @@
 
 use super::streaming::*;
 use super::{EdgeStore, GraphEdge, DEFAULT_MAX_DEPTH};
+use std::time::{Duration, Instant};
 
 fn create_test_edge_store() -> EdgeStore {
     let mut store = EdgeStore::new();
@@ -158,6 +159,50 @@ fn test_streaming_config_defaults() {
     assert!(config.limit.is_none());
     assert_eq!(config.max_visited_size, 100_000);
     assert!(config.rel_types.is_empty());
+}
+
+// =============================================================================
+// Wall-clock deadline: streaming BFS terminates instead of looping forever
+// =============================================================================
+
+#[test]
+fn test_bfs_iterator_expired_deadline_terminates() {
+    // GIVEN: a cyclic store and an already-expired deadline
+    let store = create_cyclic_edge_store();
+    let expired = Instant::now()
+        .checked_sub(Duration::from_millis(1))
+        .expect("test: clock before epoch");
+    let config = StreamingConfig::default()
+        .with_max_depth(5)
+        .with_limit(10)
+        .with_deadline(expired);
+
+    // WHEN: the iterator is fully drained
+    let results: Vec<_> = BfsIterator::new(&store, 1, config).collect();
+
+    // THEN: it terminates immediately with a bounded (empty) result — the
+    // counter is seeded at the check threshold so the first pop aborts.
+    assert!(
+        results.is_empty(),
+        "expired deadline must terminate the iterator before expanding"
+    );
+}
+
+#[test]
+fn test_bfs_iterator_far_future_deadline_no_premature_abort() {
+    // GIVEN: a far-future deadline (effectively disabled)
+    let store = create_test_edge_store();
+    let future = Instant::now() + Duration::from_secs(3600);
+    let with_deadline = StreamingConfig::default()
+        .with_max_depth(3)
+        .with_deadline(future);
+    let without = StreamingConfig::default().with_max_depth(3);
+
+    // WHEN / THEN: the result set matches the no-deadline run.
+    let a: Vec<_> = BfsIterator::new(&store, 1, with_deadline).collect();
+    let b: Vec<_> = BfsIterator::new(&store, 1, without).collect();
+    assert_eq!(a.len(), b.len(), "far-future deadline must not truncate");
+    assert!(a.iter().any(|r| r.target_id == 4 && r.depth == 3));
 }
 
 // =============================================================================

--- a/crates/velesdb-core/src/collection/graph/traversal.rs
+++ b/crates/velesdb-core/src/collection/graph/traversal.rs
@@ -12,6 +12,43 @@ use super::EdgeStore;
 use rustc_hash::{FxHashMap, FxHashSet};
 use smallvec::SmallVec;
 use std::collections::VecDeque;
+use std::time::Instant;
+
+/// Number of queue pops between wall-clock deadline checks.
+///
+/// Gating `Instant::now()` behind this counter keeps the per-node clock cost
+/// negligible while still aborting a runaway dense-graph traversal within a
+/// bounded number of expansions.
+pub(crate) const DEADLINE_CHECK_INTERVAL: u32 = 1024;
+
+/// Returns `true` when a wall-clock `deadline` is set and has been reached.
+///
+/// Callers gate this behind a per-node counter (every
+/// [`DEADLINE_CHECK_INTERVAL`] pops) so `Instant::now()` is not called per
+/// node; the `None` case is a single branch with no clock read.
+#[inline]
+pub(super) fn deadline_exceeded(deadline: Option<Instant>) -> bool {
+    deadline.is_some_and(|d| Instant::now() >= d)
+}
+
+/// Periodic wall-clock deadline gate for a BFS/DFS loop head.
+///
+/// Increments `nodes_since_check`; only every [`DEADLINE_CHECK_INTERVAL`] pops
+/// does it read the clock via [`deadline_exceeded`]. Returns `true` when the
+/// deadline has been reached (caller should `break`). When `deadline` is
+/// `None` this is a single branch with no clock read or counter cost.
+#[inline]
+pub(crate) fn deadline_reached(deadline: Option<Instant>, nodes_since_check: &mut u32) -> bool {
+    if deadline.is_none() {
+        return false;
+    }
+    *nodes_since_check += 1;
+    if *nodes_since_check < DEADLINE_CHECK_INTERVAL {
+        return false;
+    }
+    *nodes_since_check = 0;
+    deadline_exceeded(deadline)
+}
 
 /// Default maximum depth for unbounded traversals.
 pub const DEFAULT_MAX_DEPTH: u32 = 3;
@@ -92,6 +129,11 @@ pub struct TraversalConfig {
     pub limit: usize,
     /// Filter by relationship types (empty = all types).
     pub rel_types: Vec<String>,
+    /// Optional wall-clock deadline. When set and reached, traversal stops
+    /// expanding and returns the partial result accumulated so far (same
+    /// convention as the `limit` / `MAX_VISITED_SIZE` guards). `None` (the
+    /// default) disables the time bound entirely.
+    pub deadline: Option<Instant>,
 }
 
 impl Default for TraversalConfig {
@@ -101,6 +143,7 @@ impl Default for TraversalConfig {
             max_depth: DEFAULT_MAX_DEPTH,
             limit: 100,
             rel_types: Vec::new(),
+            deadline: None,
         }
     }
 }
@@ -149,6 +192,14 @@ impl TraversalConfig {
     #[must_use]
     pub fn with_max_depth(mut self, max_depth: u32) -> Self {
         self.max_depth = max_depth;
+        self
+    }
+
+    /// Sets a wall-clock deadline after which traversal returns its partial
+    /// result instead of continuing to expand.
+    #[must_use]
+    pub fn with_deadline(mut self, deadline: Instant) -> Self {
+        self.deadline = Some(deadline);
         self
     }
 }
@@ -239,8 +290,14 @@ fn bfs_traverse_directed(
     // Use CSR zero-copy path for forward traversal when snapshot exists.
     let use_csr = direction == BfsDirection::Forward && edge_store.has_csr_snapshot();
 
+    // Start at the threshold so an already-expired deadline aborts on the
+    // first pop; otherwise the clock is only read every N pops.
+    let mut nodes_since_check = DEADLINE_CHECK_INTERVAL;
     while let Some(state) = queue.pop_front() {
         if results.len() >= config.limit {
+            break;
+        }
+        if deadline_reached(config.deadline, &mut nodes_since_check) {
             break;
         }
         if use_csr {

--- a/crates/velesdb-core/src/collection/graph/traversal_csr.rs
+++ b/crates/velesdb-core/src/collection/graph/traversal_csr.rs
@@ -3,7 +3,10 @@
 //! Extracted from `traversal.rs` to reduce NLOC.
 
 use super::csr_snapshot::{CsrSnapshot, EdgePredicate};
-use super::traversal::{reconstruct_path, BfsState, TraversalConfig, TraversalResult};
+use super::traversal::{
+    deadline_reached, reconstruct_path, BfsState, TraversalConfig, TraversalResult,
+    DEADLINE_CHECK_INTERVAL,
+};
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::collections::VecDeque;
 
@@ -85,8 +88,12 @@ pub fn bfs_traverse_csr(
         parent_map: &mut parent_map,
     };
 
+    let mut nodes_since_check = DEADLINE_CHECK_INTERVAL;
     while let Some(state) = ctx.queue.pop_front() {
         if ctx.results.len() >= ctx.config.limit {
+            break;
+        }
+        if deadline_reached(ctx.config.deadline, &mut nodes_since_check) {
             break;
         }
 
@@ -172,8 +179,12 @@ pub fn bfs_traverse_csr_filtered<P: EdgePredicate>(
         parent_map: &mut parent_map,
     };
 
+    let mut nodes_since_check = DEADLINE_CHECK_INTERVAL;
     while let Some(state) = ctx.queue.pop_front() {
         if ctx.results.len() >= ctx.config.limit {
+            break;
+        }
+        if deadline_reached(ctx.config.deadline, &mut nodes_since_check) {
             break;
         }
 

--- a/crates/velesdb-core/src/collection/graph/traversal_tests.rs
+++ b/crates/velesdb-core/src/collection/graph/traversal_tests.rs
@@ -1,8 +1,12 @@
 //! Tests for `traversal` module - Graph traversal algorithms.
 
+use super::csr_snapshot::SnapshotBuilder;
+use super::label_table::LabelTable;
 use super::traversal::*;
 use super::traversal_bidir::bfs_traverse_both;
+use super::traversal_csr::bfs_traverse_csr;
 use super::{EdgeStore, GraphEdge};
+use std::time::{Duration, Instant};
 
 fn create_test_edge_store() -> EdgeStore {
     let mut store = EdgeStore::new();
@@ -329,6 +333,99 @@ fn test_parent_pointer_reverse_path() {
         .find(|r| r.target_id == 2 && r.depth == 2)
         .expect("test: node 2 at depth 2 (reverse)");
     assert_eq!(node2.path, vec![102, 101], "4<-3<-2 via edges 102,101");
+}
+
+// =========================================================================
+// Wall-clock deadline: eager BFS / CSR BFS abort cleanly (partial result)
+// =========================================================================
+
+#[test]
+fn test_bfs_traverse_expired_deadline_returns_partial() {
+    // GIVEN: a cyclic store and an already-expired deadline
+    let store = create_cyclic_edge_store();
+    let expired = Instant::now()
+        .checked_sub(Duration::from_millis(1))
+        .expect("test: clock before epoch");
+    let config = TraversalConfig::with_range(1, 5)
+        .with_limit(100)
+        .with_deadline(expired);
+
+    // WHEN: BFS runs with the expired deadline
+    let results = bfs_traverse(&store, 1, &config);
+
+    // THEN: it aborts immediately (counter seeded at threshold) with no hang.
+    // The first pop triggers the check, so no neighbours are expanded.
+    assert!(
+        results.is_empty(),
+        "expired deadline must abort before expanding, got {} results",
+        results.len()
+    );
+}
+
+#[test]
+fn test_bfs_traverse_far_future_deadline_no_premature_abort() {
+    // GIVEN: a far-future deadline (effectively disabled)
+    let store = create_test_edge_store();
+    let future = Instant::now() + Duration::from_secs(3600);
+    let with_deadline = TraversalConfig::with_range(1, 3)
+        .with_limit(100)
+        .with_deadline(future);
+    let without = TraversalConfig::with_range(1, 3).with_limit(100);
+
+    // WHEN: BFS runs with and without the deadline
+    let a = bfs_traverse(&store, 1, &with_deadline);
+    let b = bfs_traverse(&store, 1, &without);
+
+    // THEN: a far-future deadline yields the identical full result set.
+    assert_eq!(a.len(), b.len(), "far-future deadline must not truncate");
+    assert!(a.iter().any(|r| r.target_id == 4 && r.depth == 3));
+}
+
+#[test]
+fn test_bfs_traverse_csr_expired_deadline_returns_partial() {
+    // GIVEN: a CSR snapshot over a chain and an expired deadline
+    let mut store = EdgeStore::new();
+    store
+        .add_edge(GraphEdge::new(100, 1, 2, "KNOWS").unwrap())
+        .unwrap();
+    store
+        .add_edge(GraphEdge::new(101, 2, 3, "KNOWS").unwrap())
+        .unwrap();
+    let snapshot = SnapshotBuilder::build(&store, &LabelTable::new());
+
+    let expired = Instant::now()
+        .checked_sub(Duration::from_millis(1))
+        .expect("test: clock before epoch");
+    let config = TraversalConfig::with_range(1, 3)
+        .with_limit(100)
+        .with_deadline(expired);
+
+    // WHEN / THEN: CSR BFS aborts immediately with a bounded (empty) result.
+    let results = bfs_traverse_csr(&snapshot, 1, &config);
+    assert!(results.is_empty(), "expired deadline aborts CSR BFS");
+}
+
+#[test]
+fn test_bfs_traverse_csr_far_future_deadline_no_premature_abort() {
+    // GIVEN: a CSR snapshot and a far-future deadline
+    let mut store = EdgeStore::new();
+    store
+        .add_edge(GraphEdge::new(100, 1, 2, "KNOWS").unwrap())
+        .unwrap();
+    store
+        .add_edge(GraphEdge::new(101, 2, 3, "KNOWS").unwrap())
+        .unwrap();
+    let snapshot = SnapshotBuilder::build(&store, &LabelTable::new());
+
+    let future = Instant::now() + Duration::from_secs(3600);
+    let with_deadline = TraversalConfig::with_range(1, 3).with_deadline(future);
+    let without = TraversalConfig::with_range(1, 3);
+
+    // WHEN / THEN: far-future deadline yields the same full result set.
+    let a = bfs_traverse_csr(&snapshot, 1, &with_deadline);
+    let b = bfs_traverse_csr(&snapshot, 1, &without);
+    assert_eq!(a.len(), b.len());
+    assert!(a.iter().any(|r| r.target_id == 3 && r.depth == 2));
 }
 
 #[test]

--- a/crates/velesdb-python/src/graph_collection.rs
+++ b/crates/velesdb-python/src/graph_collection.rs
@@ -576,6 +576,7 @@ fn build_traversal_config(
         max_depth: max_depth.unwrap_or(3),
         limit: limit.unwrap_or(100),
         rel_types: rel_types.unwrap_or_default(),
+        deadline: None,
     }
 }
 

--- a/crates/velesdb-python/src/graph_store.rs
+++ b/crates/velesdb-python/src/graph_store.rs
@@ -226,6 +226,7 @@ impl GraphStore {
             max_visited_size: config.max_visited,
             rel_types,
             limit: Some(config.max_visited),
+            deadline: None,
         };
 
         // Release GIL during traversal (no PyObject involved)


### PR DESCRIPTION
Addresses two **MEDIUM** audit findings: no wall-clock timeout in the traversal path (only structural depth/visited/limit guards), and `GraphMetrics` histograms/counters exported but never called.

**What changed**: optional wall-clock deadline on the graph traversal config/path (eager BFS/DFS + streaming) with periodic checks (no per-edge clock cost), clean abort per existing guardrail convention; `GraphMetrics` wired at real edge-insert and traversal call sites.

**Verification**: build + clippy pedantic clean; timeout-abort + metric-increment tests added (eager BFS, CSR BFS, streaming, DFS). Committed with `CLAUDE_DRY_SKIP=1` for 14 **pre-existing** duplication blocks (shared test fixtures already duplicated on develop; no new dup).