### PR TITLE
fix(server): serialize u64 traversal path / MATCH bindings as strings

### DIFF
--- a/crates/velesdb-core/src/api_types/mod.rs
+++ b/crates/velesdb-core/src/api_types/mod.rs
@@ -9,6 +9,8 @@ mod responses;
 mod responses_explain;
 pub mod serde_id;
 #[cfg(test)]
+mod serde_id_collection_tests;
+#[cfg(test)]
 mod tests;
 
 pub use requests::*;

--- a/crates/velesdb-core/src/api_types/serde_id.rs
+++ b/crates/velesdb-core/src/api_types/serde_id.rs
@@ -22,7 +22,7 @@
 //! ```
 
 use serde::de::{self, Unexpected, Visitor};
-use serde::{Deserializer, Serializer};
+use serde::{Deserialize, Deserializer, Serializer};
 use std::fmt;
 
 /// Serializes a `u64` as a JSON string to prevent JavaScript precision loss.
@@ -64,6 +64,18 @@ pub fn deserialize_id_from_string_or_number<'de, D: Deserializer<'de>>(
 #[cfg(feature = "openapi")]
 #[must_use]
 pub fn id_input_schema() -> utoipa::openapi::schema::OneOfBuilder {
+    id_oneof().description(Some(
+        "Point ID. Accepts a JSON integer (native form) or a string; use a \
+         string for u64 values above 2^53-1 to avoid JavaScript precision loss.",
+    ))
+}
+
+/// Shared `int | string` oneOf used by all ID schema helpers.
+///
+/// An ID is emitted as a string on the wire (precision-safe) but accepted as
+/// either an integer or a string on input.
+#[cfg(feature = "openapi")]
+fn id_oneof() -> utoipa::openapi::schema::OneOfBuilder {
     use utoipa::openapi::schema::{KnownFormat, ObjectBuilder, OneOfBuilder, SchemaFormat, Type};
     OneOfBuilder::new()
         .item(
@@ -72,10 +84,100 @@ pub fn id_input_schema() -> utoipa::openapi::schema::OneOfBuilder {
                 .format(Some(SchemaFormat::KnownFormat(KnownFormat::Int64))),
         )
         .item(ObjectBuilder::new().schema_type(Type::String))
-        .description(Some(
-            "Point ID. Accepts a JSON integer (native form) or a string; use a \
-             string for u64 values above 2^53-1 to avoid JavaScript precision loss.",
-        ))
+}
+
+/// `OpenAPI` schema for an array of IDs whose elements accept an integer or a
+/// string (precision-safe), mirroring [`serialize_ids_as_strings`].
+///
+/// Apply with
+/// `#[cfg_attr(feature = "openapi", schema(schema_with = serde_id::ids_array_schema))]`.
+#[cfg(feature = "openapi")]
+#[must_use]
+pub fn ids_array_schema() -> utoipa::openapi::schema::ArrayBuilder {
+    utoipa::openapi::schema::ArrayBuilder::new().items(id_oneof())
+}
+
+/// `OpenAPI` schema for a map whose values are IDs accepting an integer or a
+/// string (precision-safe), mirroring [`serialize_id_map_as_strings`].
+///
+/// Apply with
+/// `#[cfg_attr(feature = "openapi", schema(schema_with = serde_id::id_map_schema))]`.
+#[cfg(feature = "openapi")]
+#[must_use]
+pub fn id_map_schema() -> utoipa::openapi::schema::ObjectBuilder {
+    use utoipa::openapi::schema::Schema;
+    utoipa::openapi::schema::ObjectBuilder::new()
+        .additional_properties(Some(Schema::OneOf(id_oneof().build())))
+}
+
+/// Serializes a slice of `u64` IDs as an array of JSON strings.
+///
+/// Emits `["1","2"]` instead of `[1,2]` to keep IDs above 2^53-1 precise in
+/// JavaScript. Usable as `serialize_with` for a `Vec<u64>` field.
+///
+/// # Errors
+///
+/// Returns `S::Error` if the serializer rejects the sequence.
+pub fn serialize_ids_as_strings<S: Serializer>(
+    values: &[u64],
+    serializer: S,
+) -> Result<S::Ok, S::Error> {
+    serializer.collect_seq(values.iter().map(u64::to_string))
+}
+
+/// Serializes a `HashMap<String, u64>` as a JSON object whose values are
+/// strings, keeping IDs above 2^53-1 precise in JavaScript.
+///
+/// Emits `{"k":"1"}` instead of `{"k":1}`.
+///
+/// # Errors
+///
+/// Returns `S::Error` if the serializer rejects the map.
+#[allow(clippy::implicit_hasher)] // applied to a concrete `HashMap<String, u64>` field
+pub fn serialize_id_map_as_strings<S: Serializer>(
+    map: &std::collections::HashMap<String, u64>,
+    serializer: S,
+) -> Result<S::Ok, S::Error> {
+    serializer.collect_map(map.iter().map(|(k, v)| (k, v.to_string())))
+}
+
+/// Deserializes a `Vec<u64>` whose elements may be JSON strings or numbers.
+///
+/// Accepts `["1","2"]` and `[1,2]` for backward compatibility.
+///
+/// # Errors
+///
+/// Returns `D::Error` if any element is not a valid u64 string or number.
+pub fn deserialize_ids_from_string_or_number<'de, D: Deserializer<'de>>(
+    deserializer: D,
+) -> Result<Vec<u64>, D::Error> {
+    let fields = Vec::<IdField>::deserialize(deserializer)?;
+    Ok(fields.into_iter().map(|f| f.0).collect())
+}
+
+/// Deserializes a `HashMap<String, u64>` whose values may be JSON strings or
+/// numbers.
+///
+/// Accepts `{"k":"1"}` and `{"k":1}` for backward compatibility.
+///
+/// # Errors
+///
+/// Returns `D::Error` if any value is not a valid u64 string or number.
+pub fn deserialize_id_map_from_string_or_number<'de, D: Deserializer<'de>>(
+    deserializer: D,
+) -> Result<std::collections::HashMap<String, u64>, D::Error> {
+    let fields = std::collections::HashMap::<String, IdField>::deserialize(deserializer)?;
+    Ok(fields.into_iter().map(|(k, f)| (k, f.0)).collect())
+}
+
+/// Newtype reusing [`deserialize_id_from_string_or_number`] so collection
+/// deserializers (`Vec`, `HashMap`) stay trivial and complexity-safe.
+struct IdField(u64);
+
+impl<'de> serde::Deserialize<'de> for IdField {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        deserialize_id_from_string_or_number(deserializer).map(IdField)
+    }
 }
 
 /// Serializes an `Option<u64>` as a JSON string when `Some`, or `null` when `None`.

--- a/crates/velesdb-core/src/api_types/serde_id_collection_tests.rs
+++ b/crates/velesdb-core/src/api_types/serde_id_collection_tests.rs
@@ -1,0 +1,78 @@
+//! Tests for collection-typed (`Vec<u64>`, `HashMap<String, u64>`) ID serde
+//! helpers in [`super::serde_id`] guarding JS precision safety.
+
+use super::serde_id;
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use std::collections::HashMap;
+
+const ABOVE_SAFE: u64 = (1_u64 << 53) + 1; // 9_007_199_254_740_993
+
+#[derive(Serialize, Deserialize)]
+struct Ids {
+    #[serde(
+        serialize_with = "serde_id::serialize_ids_as_strings",
+        deserialize_with = "serde_id::deserialize_ids_from_string_or_number"
+    )]
+    ids: Vec<u64>,
+}
+
+#[derive(Serialize, Deserialize)]
+struct IdMap {
+    #[serde(
+        serialize_with = "serde_id::serialize_id_map_as_strings",
+        deserialize_with = "serde_id::deserialize_id_map_from_string_or_number"
+    )]
+    map: HashMap<String, u64>,
+}
+
+#[test]
+fn serialize_ids_as_strings_above_max_safe_integer() {
+    let value = Ids {
+        ids: vec![42, ABOVE_SAFE],
+    };
+    let json = serde_json::to_value(&value).unwrap();
+    assert_eq!(json["ids"], json!(["42", "9007199254740993"]));
+}
+
+#[test]
+fn serialize_id_map_as_strings_above_max_safe_integer() {
+    let value = IdMap {
+        map: HashMap::from([("doc".to_string(), ABOVE_SAFE)]),
+    };
+    let json = serde_json::to_value(&value).unwrap();
+    assert_eq!(json["map"]["doc"], json!("9007199254740993"));
+}
+
+#[test]
+fn deserialize_ids_accepts_strings_and_numbers() {
+    let from_strings: Ids = serde_json::from_value(json!({ "ids": ["1", "2"] })).unwrap();
+    assert_eq!(from_strings.ids, vec![1, 2]);
+    let from_numbers: Ids = serde_json::from_value(json!({ "ids": [1, 2] })).unwrap();
+    assert_eq!(from_numbers.ids, vec![1, 2]);
+}
+
+#[test]
+fn deserialize_id_map_accepts_string_and_number_values() {
+    let from_string: IdMap = serde_json::from_value(json!({ "map": { "a": "1" } })).unwrap();
+    assert_eq!(from_string.map.get("a"), Some(&1));
+    let from_number: IdMap = serde_json::from_value(json!({ "map": { "a": 1 } })).unwrap();
+    assert_eq!(from_number.map.get("a"), Some(&1));
+}
+
+#[test]
+fn empty_collections_round_trip() {
+    let ids = Ids { ids: vec![] };
+    let ids_json = serde_json::to_value(&ids).unwrap();
+    assert_eq!(ids_json["ids"], json!([]));
+    let ids_back: Ids = serde_json::from_value(ids_json).unwrap();
+    assert!(ids_back.ids.is_empty());
+
+    let map = IdMap {
+        map: HashMap::new(),
+    };
+    let map_json = serde_json::to_value(&map).unwrap();
+    assert_eq!(map_json["map"], json!({}));
+    let map_back: IdMap = serde_json::from_value(map_json).unwrap();
+    assert!(map_back.map.is_empty());
+}

--- a/crates/velesdb-server/src/handlers/graph/types.rs
+++ b/crates/velesdb-server/src/handlers/graph/types.rs
@@ -16,6 +16,8 @@ pub struct TraversalResultItem {
     /// Depth of traversal (number of hops from source).
     pub depth: u32,
     /// Path taken (list of edge IDs).
+    #[serde(serialize_with = "serde_id::serialize_ids_as_strings")]
+    #[cfg_attr(feature = "openapi", schema(schema_with = serde_id::ids_array_schema))]
     pub path: Vec<u64>,
 }
 
@@ -296,6 +298,8 @@ pub struct StreamNodeEvent {
     /// Depth from source.
     pub depth: u32,
     /// Path of edge IDs taken to reach this node.
+    #[serde(serialize_with = "serde_id::serialize_ids_as_strings")]
+    #[cfg_attr(feature = "openapi", schema(schema_with = serde_id::ids_array_schema))]
     pub path: Vec<u64>,
 }
 
@@ -324,4 +328,35 @@ pub struct StreamDoneEvent {
 pub struct StreamErrorEvent {
     /// Error message.
     pub error: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Path edge IDs above 2^53 must serialize as a JSON string array.
+    #[test]
+    fn test_traversal_path_serialized_as_strings() {
+        let above_safe = (1_u64 << 53) + 1; // 9_007_199_254_740_993
+        let item = TraversalResultItem {
+            target_id: 2,
+            depth: 1,
+            path: vec![above_safe],
+        };
+        let json = serde_json::to_value(&item).unwrap();
+        assert_eq!(json["path"], serde_json::json!(["9007199254740993"]));
+    }
+
+    /// Streamed node path edge IDs above 2^53 must serialize as strings.
+    #[test]
+    fn test_stream_node_event_path_serialized_as_strings() {
+        let above_safe = (1_u64 << 53) + 1;
+        let event = StreamNodeEvent {
+            id: 1,
+            depth: 1,
+            path: vec![above_safe],
+        };
+        let json = serde_json::to_value(&event).unwrap();
+        assert_eq!(json["path"], serde_json::json!(["9007199254740993"]));
+    }
 }

--- a/crates/velesdb-server/src/handlers/match_query.rs
+++ b/crates/velesdb-server/src/handlers/match_query.rs
@@ -13,6 +13,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::Arc;
 use utoipa::ToSchema;
+use velesdb_core::api_types::serde_id;
 
 use crate::types::VELESQL_CONTRACT_VERSION;
 use crate::AppState;
@@ -37,6 +38,8 @@ pub struct MatchQueryRequest {
 #[derive(Debug, Serialize, ToSchema)]
 pub struct MatchQueryResultItem {
     /// Variable bindings from pattern matching.
+    #[serde(serialize_with = "serde_id::serialize_id_map_as_strings")]
+    #[cfg_attr(feature = "openapi", schema(schema_with = serde_id::id_map_schema))]
     pub bindings: HashMap<String, u64>,
     /// Similarity score (if similarity() was used).
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -313,6 +316,31 @@ mod tests {
         let json = serde_json::to_string(&response).unwrap();
         assert!(json.contains("bindings"));
         assert!(json.contains("0.95"));
+    }
+
+    #[test]
+    fn test_match_query_bindings_serialized_as_strings() {
+        let above_safe = (1_u64 << 53) + 1; // 9_007_199_254_740_993
+        let response = MatchQueryResponse {
+            results: vec![MatchQueryResultItem {
+                bindings: HashMap::from([("a".to_string(), above_safe)]),
+                score: None,
+                depth: 0,
+                projected: HashMap::new(),
+            }],
+            took_ms: 0,
+            count: 1,
+            meta: MatchQueryMeta {
+                velesql_contract_version: VELESQL_CONTRACT_VERSION.to_string(),
+            },
+        };
+
+        let json = serde_json::to_value(&response).unwrap();
+        assert_eq!(
+            json["results"][0]["bindings"]["a"],
+            serde_json::json!("9007199254740993"),
+            "binding IDs must serialize as JSON strings for JS precision safety"
+        );
     }
 
     #[test]

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -4193,14 +4193,16 @@
         "properties": {
           "bindings": {
             "type": "object",
-            "description": "Variable bindings from pattern matching.",
             "additionalProperties": {
-              "type": "integer",
-              "format": "int64",
-              "minimum": 0
-            },
-            "propertyNames": {
-              "type": "string"
+              "oneOf": [
+                {
+                  "type": "integer",
+                  "format": "int64"
+                },
+                {
+                  "type": "string"
+                }
+              ]
             }
           },
           "depth": {
@@ -4964,11 +4966,16 @@
           "path": {
             "type": "array",
             "items": {
-              "type": "integer",
-              "format": "int64",
-              "minimum": 0
-            },
-            "description": "Path of edge IDs taken to reach this node."
+              "oneOf": [
+                {
+                  "type": "integer",
+                  "format": "int64"
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            }
           }
         }
       },
@@ -5042,11 +5049,16 @@
           "path": {
             "type": "array",
             "items": {
-              "type": "integer",
-              "format": "int64",
-              "minimum": 0
-            },
-            "description": "Path taken (list of edge IDs)."
+              "oneOf": [
+                {
+                  "type": "integer",
+                  "format": "int64"
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            }
           },
           "target_id": {
             "type": "string",

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2940,13 +2940,11 @@ components:
       properties:
         bindings:
           type: object
-          description: Variable bindings from pattern matching.
           additionalProperties:
-            type: integer
-            format: int64
-            minimum: 0
-          propertyNames:
-            type: string
+            oneOf:
+            - type: integer
+              format: int64
+            - type: string
         depth:
           type: integer
           format: int32
@@ -3522,10 +3520,10 @@ components:
         path:
           type: array
           items:
-            type: integer
-            format: int64
-            minimum: 0
-          description: Path of edge IDs taken to reach this node.
+            oneOf:
+            - type: integer
+              format: int64
+            - type: string
     StreamStatsEvent:
       type: object
       description: 'SSE event: Periodic statistics update.'
@@ -3581,10 +3579,10 @@ components:
         path:
           type: array
           items:
-            type: integer
-            format: int64
-            minimum: 0
-          description: Path taken (list of edge IDs).
+            oneOf:
+            - type: integer
+              format: int64
+            - type: string
         target_id:
           type: string
           description: Target node ID reached.

--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -621,7 +621,7 @@ Execute collection-scoped graph `MATCH` queries.
 {
   "results": [
     {
-      "bindings": {"doc": 123, "author": 456},
+      "bindings": {"doc": "123", "author": "456"},
       "score": 0.95,
       "depth": 1,
       "projected": {"author.name": "John Doe"}
@@ -744,7 +744,7 @@ Traverse the graph using BFS or DFS.
 ```json
 {
   "results": [
-    {"target_id": "2", "depth": 1, "path": [100]}
+    {"target_id": "2", "depth": 1, "path": ["100"]}
   ],
   "has_more": false,
   "stats": {"visited": 1, "depth_reached": 1}

--- a/sdks/typescript/src/backends/missing-endpoints.ts
+++ b/sdks/typescript/src/backends/missing-endpoints.ts
@@ -189,7 +189,7 @@ export async function aggregate(
 /** Raw wire shape of `POST /collections/{name}/match`. */
 interface MatchQueryResponseWire {
   results: Array<{
-    bindings: Record<string, number>;
+    bindings: Record<string, number | string>;
     score?: number;
     depth: number;
     projected?: Record<string, unknown>;

--- a/sdks/typescript/src/types/endpoints.ts
+++ b/sdks/typescript/src/types/endpoints.ts
@@ -121,7 +121,7 @@ export interface MatchQueryResponse {
 /** Single row of a `MatchQueryResponse`. */
 export interface MatchQueryResultItem {
   /** Variable-binding map from the MATCH pattern. */
-  bindings: Record<string, number>;
+  bindings: Record<string, GraphNodeId>;
   /** Similarity score, present only when `similarity()` was used. */
   score?: number;
   /** Traversal depth reached to produce this row. */


### PR DESCRIPTION
Addresses the **LOW** audit finding: node/edge IDs serialize as strings over REST (JS precision), but `TraversalResultItem.path` (`Vec<u64>`) and MATCH `bindings` values were emitted as JSON numbers — precision loss for IDs > 2^53.

**What changed**: `path` and MATCH `bindings` values now serialize as strings (extended `serde_id` with Vec/HashMap-value helpers), deserialization stays string-or-number tolerant. TS SDK types aligned; `docs/reference/api-reference.md` examples updated; **OpenAPI snapshots regenerated** (drift-clean).

**Verification**: build + clippy pedantic clean (core + server); 5 core serde unit tests + server round-trip tests; `tsc --noEmit` exit 0; openapi-drift clean.