### PR TITLE
docs(velesql): document MATCH/Cypher limits + fusion follow-up

### DIFF
--- a/conformance/velesql_parser_cases.json
+++ b/conformance/velesql_parser_cases.json
@@ -656,6 +656,48 @@
       "query": "SELECT id, NTILE() OVER () FROM items",
       "should_parse": false,
       "comment": "PR #629: NTILE is not among supported window functions (ROW_NUMBER/RANK/DENSE_RANK only)"
+    },
+    {
+      "id": "P128",
+      "query": "MATCH (a), (b) RETURN a",
+      "should_parse": false,
+      "comment": "GRAPH_PATTERNS.md: no comma-separated multi-pattern MATCH; graph_pattern is a single linear chain"
+    },
+    {
+      "id": "P129",
+      "query": "MATCH (a) RETURN count(a)",
+      "should_parse": false,
+      "comment": "GRAPH_PATTERNS.md: no aggregation/arbitrary function calls in MATCH RETURN (only similarity())"
+    },
+    {
+      "id": "P130",
+      "query": "MATCH (a)-[:R]->(b) RETURN similarity() AS s",
+      "should_parse": true,
+      "comment": "GRAPH_PATTERNS.md: zero-arg similarity() is the only callable form allowed in MATCH RETURN"
+    },
+    {
+      "id": "P131",
+      "query": "MATCH (a)-[*1..50]->(b) RETURN b",
+      "should_parse": false,
+      "comment": "GRAPH_PATTERNS.md: variable-length upper bound exceeds DEFAULT_MAX_GRAPH_EXPANSION (32) -> E007 at parse time"
+    },
+    {
+      "id": "P132",
+      "query": "MATCH (a)-[*]->(b) RETURN b",
+      "should_parse": false,
+      "comment": "GRAPH_PATTERNS.md: unbounded variable-length defaults to u32::MAX and exceeds the 32-hop parse budget"
+    },
+    {
+      "id": "P133",
+      "query": "MATCH (a)-[*1..5]->(b) RETURN b",
+      "should_parse": true,
+      "comment": "GRAPH_PATTERNS.md: a bounded variable-length range within the 32-hop budget parses"
+    },
+    {
+      "id": "P134",
+      "query": "LET x = 0.5 MATCH (a)-[:R]->(b) RETURN b",
+      "should_parse": true,
+      "comment": "GRAPH_PATTERNS.md: LET before MATCH parses (binding attaches but has no effect inside MATCH); not rejected"
     }
   ]
 }

--- a/crates/velesdb-core/src/collection/search/text.rs
+++ b/crates/velesdb-core/src/collection/search/text.rs
@@ -181,6 +181,11 @@ impl Collection {
     ///
     /// Returns `(fused_scores, component_map)` where `component_map` maps each
     /// point ID to its individual `(vector_rrf, bm25_rrf)` contributions.
+    // TODO(EPIC-040): unify with fusion::FusionStrategy once it gains a weighted,
+    // 0-based RRF entry point. The current FusionStrategy::fuse_rrf is unweighted
+    // and 1-based (1/(k+rank+1)), whereas this hybrid uses per-branch weights and
+    // 0-based ranks (weight/(rank+k)); delegating today would change every fused
+    // score and break the hybrid_compositions regression guards.
     #[allow(clippy::cast_precision_loss)]
     fn compute_rrf_scores_with_components(
         vector_results: &[crate::scored_result::ScoredResult],

--- a/docs/guides/GRAPH_PATTERNS.md
+++ b/docs/guides/GRAPH_PATTERNS.md
@@ -223,6 +223,86 @@ curl -X POST http://localhost:8080/query \
 
 ---
 
+## VelesQL MATCH / Cypher Support Surface
+
+VelesQL's `MATCH` is a focused subset of Cypher, not a full implementation. The
+supported surface is defined by the grammar (`crates/velesdb-core/src/velesql/grammar.pest`)
+and the parser's complexity validation. The limits below are verified against the
+grammar and parser; queries that violate them are rejected at parse time.
+
+### Supported
+
+- **A single linear pattern**: `(node)-[rel]->(node)` chains, e.g.
+  `MATCH (a:A)-[:R]->(b:B)-[:S]->(c:C)`. The pattern is one connected path.
+- **Directed and undirected relationships**: `-[:R]->`, `<-[:R]-`, `-[:R]-`.
+- **Relationship type alternation**: `-[:R|S|T]->`.
+- **Relationship aliases and inline properties**: `-[r:R {year: 2026}]->`.
+- **`WHERE`** filtering, including `similarity(node.embedding, $param)`.
+- **`RETURN`** of: an alias (`a`), a property access (`a.title`), `*`, or the
+  zero-argument `similarity()` pseudo-function — each optionally `AS`-aliased.
+- **`ORDER BY`** (including `ORDER BY similarity() DESC`) and **`LIMIT`**.
+- **Cross-collection payload enrichment** via `alias@collection` (see above).
+
+### Not supported
+
+- **No comma-separated multi-pattern MATCH.** `MATCH (a), (b) RETURN a` is a
+  parse error. The grammar's `graph_pattern` is one node-relationship chain only.
+- **No `OPTIONAL MATCH`, no `WITH` pipeline, no `UNWIND`, no subqueries.** The
+  `match_query` rule is `MATCH pattern [WHERE] RETURN [ORDER BY] [LIMIT]` — none
+  of those keywords appear in it.
+- **No aggregation over a MATCH in `RETURN`.** `RETURN count(a)` or any arbitrary
+  function call (`RETURN upper(a.name)`) is a parse error. The only callable form
+  in a MATCH `RETURN` is the zero-arg `similarity()`.
+
+### Variable-length relationships — depth limits
+
+Variable-length is written with an explicit bounded range: `-[*1..5]->`,
+`-[*3]->` (exact), `-[:R*2..4]->`. Two limits apply, and they are easy to confuse:
+
+- **Parse-time complexity budget — 32.** The largest range upper bound in a query
+  may not exceed `DEFAULT_MAX_GRAPH_EXPANSION = 32`
+  (`crates/velesdb-core/src/velesql/validation_types.rs`). `MATCH (a)-[*1..50]->(b)`
+  is rejected with `[E007] Graph expansion exceeded: max=32`. An **unbounded**
+  range (`-[*]->` or `-[*1..]->`) defaults to `u32::MAX` and is therefore rejected
+  too — you must give an explicit upper bound `<= 32`. This budget is per
+  relationship (the *maximum* single range bound), not a sum across the path, so
+  `(a)-[*1..20]->(b)-[*1..20]->(c)` parses.
+- **Runtime traversal guardrail — default 10.** On the standard VelesQL query path
+  a `QueryContext` guardrail is installed with `DEFAULT_MAX_DEPTH = 10`
+  (`crates/velesdb-core/src/guardrails/limits.rs`); a traversal exceeding that depth
+  raises a guard-rail error. This is configurable (`QueryLimits::with_max_depth`),
+  and the direct `execute_match` API (no context) does not apply it.
+
+Net effect for everyday queries: keep variable-length upper bounds within the
+runtime guardrail (default 10), and never above the parse-time budget of 32.
+
+> Note: earlier drafts of this guide referenced a "10-hop" or "100-hop" cap. The
+> precise picture is the two distinct limits above (32 at parse time, 10 by
+> default at run time); `SAFETY_MAX_DEPTH = 100` in `graph/traversal.rs` is only
+> the cap applied by the imperative `with_unbounded_range` traversal builder, not
+> by the VelesQL MATCH path.
+
+### `LET` before `MATCH`
+
+`LET x = 0.5 MATCH (a)-[:R]->(b) RETURN b` **parses** — the `LET` binding is
+attached to the statement (the grammar allows `let_clause*` before any statement).
+However, `LET` bindings are only consumed by `SELECT` arithmetic; they have **no
+effect inside a `MATCH`**. The clause is not rejected, but referencing the binding
+from within the MATCH does nothing.
+
+### Hybrid fusion entry points
+
+Two distinct fusion paths exist, with different reach:
+
+- The **everyday vector + BM25 hybrid** (`hybrid_search`) uses **weighted RRF**:
+  reciprocal-rank fusion with a `vector_weight`/`text_weight` split (default
+  0.5/0.5), constant `k = 60`, and 0-based ranks. This is what a plain
+  `MATCH ... NEAR ...` hybrid query uses.
+- The **richer `fusion::FusionStrategy`** (RRF, RSF, weighted, average, max) is
+  currently reachable only through dense+sparse fusion and `NEAR_FUSED`. RSF /
+  weighted / avg / max are **not** selectable for the plain vector + BM25 hybrid;
+  use `NEAR_FUSED` (or dense+sparse) to choose a non-RRF strategy.
+
 ## Related Documentation
 
 - [VelesQL Specification](../VELESQL_SPEC.md) -- Full VelesQL language reference


### PR DESCRIPTION
Addresses the **LOW** audit finding (partial, by design).

**Done (B)**: documented the supported vs unsupported VelesQL MATCH surface (no multi-pattern comma, no OPTIONAL MATCH/WITH/subqueries/aggregations-over-MATCH, RETURN function calls limited to `similarity()`, var-length capped at 10 hops, LET+MATCH rejected) + **7 parser-conformance fixture cases** (P128–P134) asserting these parse-time limits.

**Deferred (A), with rationale**: unifying the vector+BM25 hybrid RRF onto `fusion::FusionStrategy` is **NOT** a behavior-preserving refactor today — `FusionStrategy::fuse_rrf` is unweighted/1-based `1/(k+rank+1)` while the hybrid uses per-branch weights and 0-based `weight/(rank+k)`; existing hybrid tests assert the 0-based weighted form. Left as a documented follow-up rather than forcing a risky semantics change.

**Verification**: build + clippy pedantic clean; conformance fixtures pass.