### PR TITLE
fix(correctness): null-safe filter comparisons + total ordering for all float sorts

### DIFF
--- a/crates/velesdb-core/src/collection/graph/property_index/advisor.rs
+++ b/crates/velesdb-core/src/collection/graph/property_index/advisor.rs
@@ -198,7 +198,7 @@ impl IndexAdvisor {
         suggestions.sort_unstable_by(|a, b| {
             b.priority_score
                 .partial_cmp(&a.priority_score)
-                .unwrap_or(std::cmp::Ordering::Equal)
+                .unwrap_or_else(|| a.priority_score.is_nan().cmp(&b.priority_score.is_nan()))
         });
 
         suggestions

--- a/crates/velesdb-core/src/collection/graph/range_index.rs
+++ b/crates/velesdb-core/src/collection/graph/range_index.rs
@@ -42,15 +42,7 @@ impl Eq for OrderedFloat {}
 
 impl Ord for OrderedFloat {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        self.0.partial_cmp(&other.0).unwrap_or_else(|| {
-            // Handle NaN: NaN sorts after everything
-            match (self.0.is_nan(), other.0.is_nan()) {
-                (true, true) => std::cmp::Ordering::Equal,
-                (true, false) => std::cmp::Ordering::Greater,
-                (false, true) => std::cmp::Ordering::Less,
-                (false, false) => unreachable!(),
-            }
-        })
+        self.0.total_cmp(&other.0)
     }
 }
 

--- a/crates/velesdb-core/src/collection/query_cost/plan_generator.rs
+++ b/crates/velesdb-core/src/collection/query_cost/plan_generator.rs
@@ -182,12 +182,11 @@ impl PlanGenerator {
     /// Selects the best plan based on cost.
     #[must_use]
     pub fn select_best(&self, plans: Vec<CandidatePlan>) -> Option<CandidatePlan> {
-        plans.into_iter().min_by(|a, b| {
-            a.cost
-                .total
-                .partial_cmp(&b.cost.total)
-                .unwrap_or(std::cmp::Ordering::Equal)
-        })
+        // total_cmp: NaN cost (structurally impossible) sorts last so it is
+        // never selected as the minimum-cost plan.
+        plans
+            .into_iter()
+            .min_by(|a, b| a.cost.total.total_cmp(&b.cost.total))
     }
 
     /// Generates and selects the best plan in one step.

--- a/crates/velesdb-core/src/collection/search/mod.rs
+++ b/crates/velesdb-core/src/collection/search/mod.rs
@@ -48,8 +48,9 @@ impl PartialOrd for OrderedFloat {
 
 impl Ord for OrderedFloat {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        self.0
-            .partial_cmp(&other.0)
-            .unwrap_or(std::cmp::Ordering::Equal)
+        // total_cmp gives a true total order: NaN sorts after all finite values.
+        // Callers wrap in Reverse<(OrderedFloat, _)> for a min-heap, so
+        // Reverse(NaN) is the smallest element and is evicted first.
+        self.0.total_cmp(&other.0)
     }
 }

--- a/crates/velesdb-core/src/collection/search/resolve.rs
+++ b/crates/velesdb-core/src/collection/search/resolve.rs
@@ -61,22 +61,27 @@ pub(crate) fn resolve_scored_results(
         .collect()
 }
 
+/// Descending f32 comparator with NaN-last semantics.
+///
+/// `bool::cmp` trick: `a.is_nan().cmp(&b.is_nan())` maps (NaN,finite)→Greater
+/// and (finite,NaN)→Less, placing NaN after all real scores in the sort order.
+#[inline]
+fn cmp_f32_desc_nan_last(a: f32, b: f32) -> std::cmp::Ordering {
+    b.partial_cmp(&a).unwrap_or_else(|| a.is_nan().cmp(&b.is_nan()))
+}
+
 /// Sorts `SearchResult` values by score according to metric direction.
 ///
-/// - `higher_is_better = true`: descending (cosine, dot product)
-/// - `higher_is_better = false`: ascending (euclidean distance)
+/// - `higher_is_better = true`: descending (cosine, dot product), NaN last
+/// - `higher_is_better = false`: ascending (euclidean distance), NaN last
 ///
 /// Uses unstable sort: equal-score tie-breaking order is irrelevant for ranking.
 pub(crate) fn sort_results_by_metric(results: &mut [SearchResult], higher_is_better: bool) {
     results.sort_unstable_by(|a, b| {
         if higher_is_better {
-            b.score
-                .partial_cmp(&a.score)
-                .unwrap_or(std::cmp::Ordering::Equal)
+            cmp_f32_desc_nan_last(a.score, b.score)
         } else {
-            a.score
-                .partial_cmp(&b.score)
-                .unwrap_or(std::cmp::Ordering::Equal)
+            a.score.total_cmp(&b.score)
         }
     });
 }
@@ -87,18 +92,14 @@ pub(crate) fn sort_results_by_metric(results: &mut [SearchResult], higher_is_bet
 pub(crate) fn sort_scored_by_metric(results: &mut [ScoredResult], higher_is_better: bool) {
     results.sort_unstable_by(|a, b| {
         if higher_is_better {
-            b.score
-                .partial_cmp(&a.score)
-                .unwrap_or(std::cmp::Ordering::Equal)
+            cmp_f32_desc_nan_last(a.score, b.score)
         } else {
-            a.score
-                .partial_cmp(&b.score)
-                .unwrap_or(std::cmp::Ordering::Equal)
+            a.score.total_cmp(&b.score)
         }
     });
 }
 
-/// Sorts `SearchResult` values by score descending (higher scores first).
+/// Sorts `SearchResult` values by score descending (higher scores first), NaN last.
 ///
 /// Used for BM25 text search, sparse search, and fusion results where
 /// higher scores always indicate better matches.
@@ -106,11 +107,7 @@ pub(crate) fn sort_scored_by_metric(results: &mut [ScoredResult], higher_is_bett
 /// Uses unstable sort: equal-score tie-breaking order is irrelevant for ranking.
 #[allow(dead_code)] // Reason: BM25/sparse search utility — callers exist in test suite; future SDK wiring pending
 pub(crate) fn sort_results_descending(results: &mut [SearchResult]) {
-    results.sort_unstable_by(|a, b| {
-        b.score
-            .partial_cmp(&a.score)
-            .unwrap_or(std::cmp::Ordering::Equal)
-    });
+    results.sort_unstable_by(|a, b| cmp_f32_desc_nan_last(a.score, b.score));
 }
 
 /// Creates a "sparse index not found" error with consistent formatting.
@@ -183,6 +180,31 @@ mod tests {
     }
 
     // --- sort_results_descending ---
+
+    // NaN scores must sort last in descending mode, not float-undefined.
+    #[test]
+    fn sort_results_by_metric_nan_sorts_last_descending() {
+        let mut results = vec![
+            make_search_result(1, f32::NAN),
+            make_search_result(2, 0.9),
+            make_search_result(3, 0.3),
+        ];
+        sort_results_by_metric(&mut results, true);
+        // Finite scores first, NaN last regardless of insertion order.
+        assert_eq!(results[2].point.id, 1, "NaN score must be last");
+    }
+
+    // NaN distances must sort last in ascending mode (total_cmp: NaN > +∞).
+    #[test]
+    fn sort_results_by_metric_nan_sorts_last_ascending() {
+        let mut results = vec![
+            make_search_result(1, f32::NAN),
+            make_search_result(2, 0.3),
+            make_search_result(3, 0.9),
+        ];
+        sort_results_by_metric(&mut results, false);
+        assert_eq!(results[2].point.id, 1, "NaN distance must be last");
+    }
 
     #[test]
     fn sort_results_descending_always_highest_first() {

--- a/crates/velesdb-core/src/collection/search/resolve.rs
+++ b/crates/velesdb-core/src/collection/search/resolve.rs
@@ -67,7 +67,8 @@ pub(crate) fn resolve_scored_results(
 /// and (finite,NaN)→Less, placing NaN after all real scores in the sort order.
 #[inline]
 fn cmp_f32_desc_nan_last(a: f32, b: f32) -> std::cmp::Ordering {
-    b.partial_cmp(&a).unwrap_or_else(|| a.is_nan().cmp(&b.is_nan()))
+    b.partial_cmp(&a)
+        .unwrap_or_else(|| a.is_nan().cmp(&b.is_nan()))
 }
 
 /// Sorts `SearchResult` values by score according to metric direction.

--- a/crates/velesdb-core/src/collection/stats/histogram.rs
+++ b/crates/velesdb-core/src/collection/stats/histogram.rs
@@ -302,7 +302,7 @@ impl HistogramBuilder {
         if valid.is_empty() {
             return Histogram::default();
         }
-        valid.sort_unstable_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+        valid.sort_unstable_by(f64::total_cmp);
         let distinct = count_distinct(valid);
         let buckets = if distinct == 1 {
             build_single_value_buckets(valid)

--- a/crates/velesdb-core/src/filter/matching.rs
+++ b/crates/velesdb-core/src/filter/matching.rs
@@ -364,6 +364,19 @@ fn haversine_distance_m(lat1: f64, lng1: f64, lat2: f64, lng2: f64) -> f64 {
     EARTH_RADIUS_M * 2.0 * a.sqrt().atan2((1.0 - a).sqrt())
 }
 
+/// Applies a comparison operator to a geo-distance value and threshold.
+fn compare_geo_distance(dist: f64, threshold: f64, op: crate::velesql::CompareOp) -> bool {
+    use crate::velesql::CompareOp;
+    match op {
+        CompareOp::Eq => (dist - threshold).abs() < f64::EPSILON,
+        CompareOp::NotEq => (dist - threshold).abs() >= f64::EPSILON,
+        CompareOp::Gt => dist > threshold,
+        CompareOp::Gte => dist >= threshold,
+        CompareOp::Lt => dist < threshold,
+        CompareOp::Lte => dist <= threshold,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::filter::Condition;
@@ -517,18 +530,5 @@ mod tests {
             value: json!("bob")
         }
         .matches(&p));
-    }
-}
-
-/// Applies a comparison operator to a geo-distance value and threshold.
-fn compare_geo_distance(dist: f64, threshold: f64, op: crate::velesql::CompareOp) -> bool {
-    use crate::velesql::CompareOp;
-    match op {
-        CompareOp::Eq => (dist - threshold).abs() < f64::EPSILON,
-        CompareOp::NotEq => (dist - threshold).abs() >= f64::EPSILON,
-        CompareOp::Gt => dist > threshold,
-        CompareOp::Gte => dist >= threshold,
-        CompareOp::Lt => dist < threshold,
-        CompareOp::Lte => dist <= threshold,
     }
 }

--- a/crates/velesdb-core/src/filter/matching.rs
+++ b/crates/velesdb-core/src/filter/matching.rs
@@ -155,18 +155,14 @@ impl Condition {
             Self::Neq { field, value } => {
                 get_field(payload, field).is_none_or(|v| !values_equal(v, value))
             }
-            Self::Gt { field, value } => {
-                get_field(payload, field).is_some_and(|v| compare_values(v, value) > 0)
-            }
-            Self::Gte { field, value } => {
-                get_field(payload, field).is_some_and(|v| compare_values(v, value) >= 0)
-            }
-            Self::Lt { field, value } => {
-                get_field(payload, field).is_some_and(|v| compare_values(v, value) < 0)
-            }
-            Self::Lte { field, value } => {
-                get_field(payload, field).is_some_and(|v| compare_values(v, value) <= 0)
-            }
+            Self::Gt { field, value } => get_field(payload, field)
+                .is_some_and(|v| compare_values(v, value).is_some_and(std::cmp::Ordering::is_gt)),
+            Self::Gte { field, value } => get_field(payload, field)
+                .is_some_and(|v| compare_values(v, value).is_some_and(std::cmp::Ordering::is_ge)),
+            Self::Lt { field, value } => get_field(payload, field)
+                .is_some_and(|v| compare_values(v, value).is_some_and(std::cmp::Ordering::is_lt)),
+            Self::Lte { field, value } => get_field(payload, field)
+                .is_some_and(|v| compare_values(v, value).is_some_and(std::cmp::Ordering::is_le)),
             Self::In { field, values } => {
                 get_field(payload, field).is_some_and(|v| in_list_matches(v, values))
             }
@@ -238,16 +234,19 @@ fn values_equal(a: &Value, b: &Value) -> bool {
     }
 }
 
-/// Compares two JSON values, returning -1, 0, or 1.
-/// Returns 0 if values are not comparable.
-fn compare_values(a: &Value, b: &Value) -> i32 {
+/// Compares two JSON values for ordering predicates (Gt, Gte, Lt, Lte).
+///
+/// Returns `None` for incompatible types (e.g. Number vs String, any vs Null)
+/// and for NaN number values. Callers must treat `None` as false — matching
+/// SQL three-valued logic where `NULL op X` yields UNKNOWN (not true).
+fn compare_values(a: &Value, b: &Value) -> Option<std::cmp::Ordering> {
     match (a, b) {
-        (Value::Number(a), Value::Number(b)) => match (a.as_f64(), b.as_f64()) {
-            (Some(a), Some(b)) => a.partial_cmp(&b).map_or(0, |ord| ord as i32),
-            _ => 0,
-        },
-        (Value::String(a), Value::String(b)) => a.cmp(b) as i32,
-        _ => 0,
+        (Value::Number(a), Value::Number(b)) => a
+            .as_f64()
+            .zip(b.as_f64())
+            .and_then(|(fa, fb)| fa.partial_cmp(&fb)),
+        (Value::String(a), Value::String(b)) => Some(a.cmp(b)),
+        _ => None,
     }
 }
 
@@ -363,6 +362,75 @@ fn haversine_distance_m(lat1: f64, lng1: f64, lat2: f64, lng2: f64) -> f64 {
     let dlng = lng2 - lng1;
     let a = (dlat / 2.0).sin().powi(2) + lat1.cos() * lat2.cos() * (dlng / 2.0).sin().powi(2);
     EARTH_RADIUS_M * 2.0 * a.sqrt().atan2((1.0 - a).sqrt())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::filter::Condition;
+    use serde_json::json;
+
+    // Null field must never match any ordering predicate — SQL three-valued logic.
+    // Previously compare_values returned 0 for incompatible types, so `null >= N`
+    // and `null <= N` spuriously returned true.
+    #[test]
+    fn null_field_never_matches_ordering_predicates() {
+        let p = json!({"price": null});
+        let n = json!(100);
+        let field = "price".to_string();
+        assert!(!Condition::Gt { field: field.clone(), value: n.clone() }.matches(&p));
+        assert!(!Condition::Gte { field: field.clone(), value: n.clone() }.matches(&p));
+        assert!(!Condition::Lt { field: field.clone(), value: n.clone() }.matches(&p));
+        assert!(!Condition::Lte { field: field.clone(), value: n }.matches(&p));
+    }
+
+    // A boolean field must not match numeric ordering predicates.
+    #[test]
+    fn bool_field_never_matches_numeric_ordering() {
+        let p = json!({"active": true});
+        let n = json!(1);
+        let field = "active".to_string();
+        assert!(!Condition::Gt { field: field.clone(), value: n.clone() }.matches(&p));
+        assert!(!Condition::Gte { field: field.clone(), value: n.clone() }.matches(&p));
+        assert!(!Condition::Lt { field: field.clone(), value: n.clone() }.matches(&p));
+        assert!(!Condition::Lte { field: field.clone(), value: n }.matches(&p));
+    }
+
+    // A string field must not match a numeric operand.
+    #[test]
+    fn string_field_never_matches_number_operand() {
+        let p = json!({"name": "alice"});
+        let n = json!(100);
+        let field = "name".to_string();
+        assert!(!Condition::Gt { field: field.clone(), value: n.clone() }.matches(&p));
+        assert!(!Condition::Gte { field: field.clone(), value: n.clone() }.matches(&p));
+        assert!(!Condition::Lt { field: field.clone(), value: n.clone() }.matches(&p));
+        assert!(!Condition::Lte { field: field.clone(), value: n }.matches(&p));
+    }
+
+    // Numeric ordering works correctly for same-type comparisons.
+    #[test]
+    fn numeric_ordering_same_type() {
+        let p = json!({"price": 50});
+        let f = "price".to_string();
+        assert!(Condition::Gt  { field: f.clone(), value: json!(10) }.matches(&p));
+        assert!(Condition::Gte { field: f.clone(), value: json!(50) }.matches(&p));
+        assert!(!Condition::Gt { field: f.clone(), value: json!(50) }.matches(&p));
+        assert!(Condition::Lt  { field: f.clone(), value: json!(100) }.matches(&p));
+        assert!(Condition::Lte { field: f.clone(), value: json!(50) }.matches(&p));
+        assert!(!Condition::Lt { field: f.clone(), value: json!(50) }.matches(&p));
+    }
+
+    // String ordering works correctly for same-type comparisons.
+    #[test]
+    fn string_ordering_same_type() {
+        let p = json!({"name": "bob"});
+        let f = "name".to_string();
+        assert!(Condition::Gt  { field: f.clone(), value: json!("alice") }.matches(&p));
+        assert!(Condition::Gte { field: f.clone(), value: json!("bob") }.matches(&p));
+        assert!(Condition::Lt  { field: f.clone(), value: json!("charlie") }.matches(&p));
+        assert!(Condition::Lte { field: f.clone(), value: json!("bob") }.matches(&p));
+    }
 }
 
 /// Applies a comparison operator to a geo-distance value and threshold.

--- a/crates/velesdb-core/src/filter/matching.rs
+++ b/crates/velesdb-core/src/filter/matching.rs
@@ -366,7 +366,6 @@ fn haversine_distance_m(lat1: f64, lng1: f64, lat2: f64, lng2: f64) -> f64 {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use crate::filter::Condition;
     use serde_json::json;
 
@@ -378,10 +377,26 @@ mod tests {
         let p = json!({"price": null});
         let n = json!(100);
         let field = "price".to_string();
-        assert!(!Condition::Gt { field: field.clone(), value: n.clone() }.matches(&p));
-        assert!(!Condition::Gte { field: field.clone(), value: n.clone() }.matches(&p));
-        assert!(!Condition::Lt { field: field.clone(), value: n.clone() }.matches(&p));
-        assert!(!Condition::Lte { field: field.clone(), value: n }.matches(&p));
+        assert!(!Condition::Gt {
+            field: field.clone(),
+            value: n.clone()
+        }
+        .matches(&p));
+        assert!(!Condition::Gte {
+            field: field.clone(),
+            value: n.clone()
+        }
+        .matches(&p));
+        assert!(!Condition::Lt {
+            field: field.clone(),
+            value: n.clone()
+        }
+        .matches(&p));
+        assert!(!Condition::Lte {
+            field: field.clone(),
+            value: n
+        }
+        .matches(&p));
     }
 
     // A boolean field must not match numeric ordering predicates.
@@ -390,10 +405,26 @@ mod tests {
         let p = json!({"active": true});
         let n = json!(1);
         let field = "active".to_string();
-        assert!(!Condition::Gt { field: field.clone(), value: n.clone() }.matches(&p));
-        assert!(!Condition::Gte { field: field.clone(), value: n.clone() }.matches(&p));
-        assert!(!Condition::Lt { field: field.clone(), value: n.clone() }.matches(&p));
-        assert!(!Condition::Lte { field: field.clone(), value: n }.matches(&p));
+        assert!(!Condition::Gt {
+            field: field.clone(),
+            value: n.clone()
+        }
+        .matches(&p));
+        assert!(!Condition::Gte {
+            field: field.clone(),
+            value: n.clone()
+        }
+        .matches(&p));
+        assert!(!Condition::Lt {
+            field: field.clone(),
+            value: n.clone()
+        }
+        .matches(&p));
+        assert!(!Condition::Lte {
+            field: field.clone(),
+            value: n
+        }
+        .matches(&p));
     }
 
     // A string field must not match a numeric operand.
@@ -402,10 +433,26 @@ mod tests {
         let p = json!({"name": "alice"});
         let n = json!(100);
         let field = "name".to_string();
-        assert!(!Condition::Gt { field: field.clone(), value: n.clone() }.matches(&p));
-        assert!(!Condition::Gte { field: field.clone(), value: n.clone() }.matches(&p));
-        assert!(!Condition::Lt { field: field.clone(), value: n.clone() }.matches(&p));
-        assert!(!Condition::Lte { field: field.clone(), value: n }.matches(&p));
+        assert!(!Condition::Gt {
+            field: field.clone(),
+            value: n.clone()
+        }
+        .matches(&p));
+        assert!(!Condition::Gte {
+            field: field.clone(),
+            value: n.clone()
+        }
+        .matches(&p));
+        assert!(!Condition::Lt {
+            field: field.clone(),
+            value: n.clone()
+        }
+        .matches(&p));
+        assert!(!Condition::Lte {
+            field: field.clone(),
+            value: n
+        }
+        .matches(&p));
     }
 
     // Numeric ordering works correctly for same-type comparisons.
@@ -413,12 +460,36 @@ mod tests {
     fn numeric_ordering_same_type() {
         let p = json!({"price": 50});
         let f = "price".to_string();
-        assert!(Condition::Gt  { field: f.clone(), value: json!(10) }.matches(&p));
-        assert!(Condition::Gte { field: f.clone(), value: json!(50) }.matches(&p));
-        assert!(!Condition::Gt { field: f.clone(), value: json!(50) }.matches(&p));
-        assert!(Condition::Lt  { field: f.clone(), value: json!(100) }.matches(&p));
-        assert!(Condition::Lte { field: f.clone(), value: json!(50) }.matches(&p));
-        assert!(!Condition::Lt { field: f.clone(), value: json!(50) }.matches(&p));
+        assert!(Condition::Gt {
+            field: f.clone(),
+            value: json!(10)
+        }
+        .matches(&p));
+        assert!(Condition::Gte {
+            field: f.clone(),
+            value: json!(50)
+        }
+        .matches(&p));
+        assert!(!Condition::Gt {
+            field: f.clone(),
+            value: json!(50)
+        }
+        .matches(&p));
+        assert!(Condition::Lt {
+            field: f.clone(),
+            value: json!(100)
+        }
+        .matches(&p));
+        assert!(Condition::Lte {
+            field: f.clone(),
+            value: json!(50)
+        }
+        .matches(&p));
+        assert!(!Condition::Lt {
+            field: f.clone(),
+            value: json!(50)
+        }
+        .matches(&p));
     }
 
     // String ordering works correctly for same-type comparisons.
@@ -426,10 +497,26 @@ mod tests {
     fn string_ordering_same_type() {
         let p = json!({"name": "bob"});
         let f = "name".to_string();
-        assert!(Condition::Gt  { field: f.clone(), value: json!("alice") }.matches(&p));
-        assert!(Condition::Gte { field: f.clone(), value: json!("bob") }.matches(&p));
-        assert!(Condition::Lt  { field: f.clone(), value: json!("charlie") }.matches(&p));
-        assert!(Condition::Lte { field: f.clone(), value: json!("bob") }.matches(&p));
+        assert!(Condition::Gt {
+            field: f.clone(),
+            value: json!("alice")
+        }
+        .matches(&p));
+        assert!(Condition::Gte {
+            field: f.clone(),
+            value: json!("bob")
+        }
+        .matches(&p));
+        assert!(Condition::Lt {
+            field: f.clone(),
+            value: json!("charlie")
+        }
+        .matches(&p));
+        assert!(Condition::Lte {
+            field: f.clone(),
+            value: json!("bob")
+        }
+        .matches(&p));
     }
 }
 

--- a/crates/velesdb-core/src/metrics/retrieval.rs
+++ b/crates/velesdb-core/src/metrics/retrieval.rs
@@ -200,8 +200,10 @@ pub fn ndcg_at_k(relevances: &[f64], k: usize) -> f64 {
     let dcg = compute_dcg(relevances, k);
 
     let mut sorted_relevances = relevances.to_vec();
-    sorted_relevances
-        .sort_unstable_by(|a, b| b.partial_cmp(a).unwrap_or_else(|| a.is_nan().cmp(&b.is_nan())));
+    sorted_relevances.sort_unstable_by(|a, b| {
+        b.partial_cmp(a)
+            .unwrap_or_else(|| a.is_nan().cmp(&b.is_nan()))
+    });
     let idcg = compute_dcg(&sorted_relevances, k);
 
     if idcg == 0.0 {

--- a/crates/velesdb-core/src/metrics/retrieval.rs
+++ b/crates/velesdb-core/src/metrics/retrieval.rs
@@ -201,7 +201,7 @@ pub fn ndcg_at_k(relevances: &[f64], k: usize) -> f64 {
 
     let mut sorted_relevances = relevances.to_vec();
     sorted_relevances
-        .sort_unstable_by(|a, b| b.partial_cmp(a).unwrap_or(std::cmp::Ordering::Equal));
+        .sort_unstable_by(|a, b| b.partial_cmp(a).unwrap_or_else(|| a.is_nan().cmp(&b.is_nan())));
     let idcg = compute_dcg(&sorted_relevances, k);
 
     if idcg == 0.0 {

--- a/crates/velesdb-core/src/velesql/window_evaluator.rs
+++ b/crates/velesdb-core/src/velesql/window_evaluator.rs
@@ -377,7 +377,7 @@ fn compare_json_values(a: &serde_json::Value, b: &serde_json::Value) -> std::cmp
         (serde_json::Value::Null, _) => std::cmp::Ordering::Greater, // NULLs sort last
         (_, serde_json::Value::Null) => std::cmp::Ordering::Less,
         _ => match (a.as_f64(), b.as_f64()) {
-            (Some(fa), Some(fb)) => fa.partial_cmp(&fb).unwrap_or(std::cmp::Ordering::Equal),
+            (Some(fa), Some(fb)) => fa.total_cmp(&fb),
             _ => a.to_string().cmp(&b.to_string()),
         },
     }


### PR DESCRIPTION
## Summary

Three atomic correctness commits addressing issues found during review of PR #1022, with improvements over the original.

---

### Commit 1 — `fix(filter): compare_values returns Option<Ordering> to prevent null false-positives`

**File**: `crates/velesdb-core/src/filter/matching.rs`

**Bug**: `compare_values()` returned `i32`. The catch-all `_ => 0` caused type-mismatched comparisons to silently return `0`:
- `null >= 100` → `true` (0 >= 0)
- `null <= 100` → `true` (0 <= 0)  
- `bool_field >= 0` → `true`

Violated SQL three-valued logic: `NULL op X` must yield UNKNOWN (false in WHERE).

**Fix**: Return type → `Option<Ordering>`. The `_` arm returns `None`. All four call sites use `is_some_and(Ordering::is_gt)` etc. — incompatible types and null comparisons correctly return `false`.

Five regression tests cover: null field, bool/number mismatch, string/number mismatch, same-type numeric ordering, same-type string ordering.

---

### Commit 2 — `refactor(sort): total ordering + consistent NaN-last for all float sorts`

**Files**: 8 production files in `velesdb-core`

**Bug**: `partial_cmp(...).unwrap_or(Ordering::Equal)` violates `Ord` transitivity with NaN, producing non-deterministic `sort_unstable` results.

**Key improvements over PR #1022**:

| Location | Fix | Note vs PR #1022 |
|---|---|---|
| `range_index.rs` `OrderedFloat` (f64) | `total_cmp` | Removes manual NaN match + `unreachable!()` |
| `search/mod.rs` `OrderedFloat` (f32) | `total_cmp` | NaN→max; `Reverse(NaN)` evicted first from heap |
| `stats/histogram.rs` | `f64::total_cmp` method ref | Cleaner, NaN already filtered |
| `window_evaluator.rs` | `total_cmp` | JSON Number cannot be NaN |
| `plan_generator.rs` | `total_cmp` | NaN cost sorts last, never selected |
| `advisor.rs` **BUG FIX** | `unwrap_or_else(\|\| a.is_nan().cmp(&b.is_nan()))` | PR #1022 used `b.total_cmp(&a)` which puts NaN **first** in descending — fixed to NaN-last |
| `search/resolve.rs` | Extract `cmp_f32_desc_nan_last` helper (**DRY**) | PR #1022 expanded 3 sites with a 4-arm match each |
| `metrics/retrieval.rs` | `bool::cmp` idiom | Replaces 4-arm match with one-liner |

The `bool::cmp` trick: `a.is_nan().cmp(&b.is_nan())` → (NaN,finite)=`Greater`, (finite,NaN)=`Less` — NaN-last without a `match` block.

Two NaN regression tests added in `search/resolve.rs`.

---

### Commit 3 — `style(fmt): apply rustfmt + drop unused super::* import in tests`

Pure formatting only — `rustfmt` reformatted struct-literal assertions and sort closures. Removes `use super::*` that was made redundant by explicit imports.

## Test plan

- [x] `cargo check -p velesdb-core --lib` → 0 errors
- [x] `cargo clippy -p velesdb-core --lib -- -D warnings` → 0 warnings
- [x] `cargo fmt --check -p velesdb-core` → clean (no diff)
- [x] `cargo test -p velesdb-core --lib` → all tests pass including 7 new regression tests
- [ ] Manually verify: `null >= 100` filter returns no results
- [ ] Manually verify: vector similarity ranking is stable across repeated calls

## Differences from PR #1022

- `advisor.rs`: PR #1022 introduced a NaN-first regression (NaN sorts **first** in descending with `b.total_cmp(&a)` since NaN is the maximum). Fixed to NaN-last.
- `search/resolve.rs`: DRY extraction instead of expanding each site with verbose 4-arm match blocks.
- `metrics/retrieval.rs`: Same simplification via `bool::cmp` idiom.

_Date: 2026-06-07_

https://claude.ai/code/session_0133sqTzwufVc7Y7jELi2DgZ
