### PR TITLE
fix(query): make JOIN bitmap pre-filter a guaranteed superset (NEQ/NOT IN/u32)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,6 @@ todo_analysis_report_updated.md
 #Ignore vscode AI rules
 .github\instructions\codacy.instructions.md
 *.egg-info/
+
+# Local git worktrees (e.g. agent/worktree-isolated work)
+.worktrees/

--- a/crates/velesdb-core/src/collection/core/index_management.rs
+++ b/crates/velesdb-core/src/collection/core/index_management.rs
@@ -173,15 +173,17 @@ impl Collection {
             crate::filter::Condition::Eq { field, value } => {
                 Self::bitmap_for_eq_field(indexes, field, value)
             }
-            crate::filter::Condition::Neq { field, value } => {
-                // NEQ = universe - eq_matches
-                // Build the universe from all keys in the index for this field,
-                // then subtract the matching IDs. If the value doesn't exist in
-                // the index, eq_bitmap defaults to empty — every indexed ID matches.
-                let universe = Self::bitmap_universe_for_field(indexes, field)?;
-                let eq_bitmap =
-                    Self::bitmap_for_eq_field(indexes, field, value).unwrap_or_default();
-                Some(universe - eq_bitmap)
+            crate::filter::Condition::Neq { .. } => {
+                // NEQ cannot be safely pre-filtered from this index. A `universe
+                // - eq` complement would be built from `all_ids_bitmap`, which
+                // only contains points that HAVE a primitive value for the field
+                // — but NEQ semantics also match points where the field is
+                // ABSENT (see `Condition::Neq` in filter::matching, which is true
+                // for a missing field). Those points are not in the universe, so
+                // the complement is a strict subset and a bitmap-only caller
+                // (e.g. the JOIN pre-filter) would drop them. Return `None` to
+                // force a correct full-scan + post-filter.
+                None
             }
             crate::filter::Condition::Gt { field, value }
             | crate::filter::Condition::Gte { field, value }
@@ -205,18 +207,6 @@ impl Collection {
         }
     }
 
-    /// Builds a universe bitmap containing ALL IDs indexed for a given field.
-    fn bitmap_universe_for_field(
-        indexes: &std::sync::Arc<
-            parking_lot::RwLock<std::collections::HashMap<String, SecondaryIndex>>,
-        >,
-        field: &str,
-    ) -> Option<roaring::RoaringBitmap> {
-        let guard = indexes.read();
-        let index = guard.get(field)?;
-        Some(index.all_ids_bitmap())
-    }
-
     /// Looks up a single equality field in the secondary indexes.
     fn bitmap_for_eq_field(
         indexes: &std::sync::Arc<
@@ -228,11 +218,10 @@ impl Collection {
         let key = JsonValue::from_json(value)?;
         let guard = indexes.read();
         let index = guard.get(field)?;
-        let bm = index.to_bitmap(&key);
-        if bm.is_empty() {
-            return Some(bm); // Empty bitmap = no matches (valid pre-filter)
-        }
-        Some(bm)
+        // `None` here means an indexed ID exceeded u32::MAX (incomplete bitmap);
+        // propagate it so the caller falls back to a full scan. An empty bitmap
+        // is a valid "no matches" pre-filter and is returned as-is.
+        index.to_bitmap(&key)
     }
 
     /// Builds a bitmap for `IN(field, values)` by unioning per-value B-tree lookups.
@@ -258,29 +247,28 @@ impl Collection {
         let mut acc = roaring::RoaringBitmap::new();
         for v in values {
             if let Some(key) = JsonValue::from_json(v) {
-                acc |= index.to_bitmap(&key);
+                // Propagate `None` (id > u32::MAX) so the whole IN falls back to scan.
+                acc |= index.to_bitmap(&key)?;
             }
         }
         Some(acc)
     }
 
-    /// Handles `Condition::Not` by pattern-matching the inner condition.
+    /// `Not` conditions cannot be safely pre-filtered from this index.
     ///
-    /// Currently only `Not { In { field, values } }` is supported — computes
-    /// `universe - in_bitmap`. All other `Not` variants return `None`.
+    /// Like NEQ, a `universe - in` complement is built from `all_ids_bitmap`,
+    /// which omits points whose field is absent — yet `NOT IN` matches those
+    /// absent-field points. The complement would be a strict subset, so a
+    /// bitmap-only caller (e.g. the JOIN pre-filter) would drop real matches.
+    /// Always return `None` to force a correct full-scan + post-filter.
+    #[allow(clippy::unnecessary_wraps)] // Reason: uniform Option return for bitmap_from_condition dispatch
     fn bitmap_for_not_in(
-        indexes: &std::sync::Arc<
+        _indexes: &std::sync::Arc<
             parking_lot::RwLock<std::collections::HashMap<String, SecondaryIndex>>,
         >,
-        inner: &crate::filter::Condition,
+        _inner: &crate::filter::Condition,
     ) -> Option<roaring::RoaringBitmap> {
-        if let crate::filter::Condition::In { field, values } = inner {
-            let universe = Self::bitmap_universe_for_field(indexes, field)?;
-            let in_bm = Self::bitmap_for_in_field(indexes, field, values).unwrap_or_default();
-            Some(universe - in_bm)
-        } else {
-            None
-        }
+        None
     }
 
     /// Builds a range bitmap for Gt/Gte/Lt/Lte using `SecondaryIndex::range_bitmap`.
@@ -304,7 +292,7 @@ impl Collection {
             crate::filter::Condition::Lte { .. } => (Bound::Unbounded, Bound::Included(&key)),
             _ => return None,
         };
-        Some(index.range_bitmap(from, to))
+        index.range_bitmap(from, to)
     }
 
     /// Intersects bitmaps from AND-ed conditions.

--- a/crates/velesdb-core/src/collection/core/index_management_tests.rs
+++ b/crates/velesdb-core/src/collection/core/index_management_tests.rs
@@ -599,7 +599,7 @@ mod tests {
     }
 
     #[test]
-    fn test_build_prefilter_bitmap_neq_uses_universe_subtraction() {
+    fn test_build_prefilter_bitmap_neq_returns_none() {
         let (collection, _temp) = create_test_collection();
         collection
             .create_index("category")
@@ -625,13 +625,13 @@ mod tests {
             field: "category".to_string(),
             value: serde_json::Value::String("tech".to_string()),
         });
-        let bitmap = collection.build_prefilter_bitmap(&filter);
-        assert!(bitmap.is_some(), "Neq should return Some (universe - eq)");
-        let bm = bitmap.unwrap();
-        // Universe = {1,2,5,7,10}, eq("tech") = {1,5,10}, NEQ = {2,7}
-        assert_eq!(bm.len(), 2, "Neq should exclude tech points");
-        assert!(bm.contains(2));
-        assert!(bm.contains(7));
+        // NEQ is no longer pre-filtered: a `universe - eq` complement built from
+        // the index omits points whose `category` field is ABSENT, yet NEQ
+        // matches those points. Returning `None` forces a correct full scan.
+        assert!(
+            collection.build_prefilter_bitmap(&filter).is_none(),
+            "NEQ must return None (field-absent points would be dropped otherwise)"
+        );
     }
 
     // =========================================================================
@@ -913,13 +913,13 @@ mod tests {
             field: "category".to_string(),
             values: vec![serde_json::Value::String("tech".to_string())],
         });
-        let bitmap = collection.build_prefilter_bitmap(&filter);
-        assert!(bitmap.is_some());
-        let bm = bitmap.unwrap();
-        // large_id should be silently skipped
-        assert_eq!(bm.len(), 2);
-        assert!(bm.contains(1));
-        assert!(bm.contains(5));
+        // An ID above u32::MAX cannot live in the bitmap. Rather than silently
+        // skip it (a bitmap-only caller would drop a real match), the builder
+        // returns None so the caller falls back to a full scan.
+        assert!(
+            collection.build_prefilter_bitmap(&filter).is_none(),
+            "IN with an id > u32::MAX must return None (incomplete bitmap)"
+        );
     }
 
     // =========================================================================
@@ -927,7 +927,7 @@ mod tests {
     // =========================================================================
 
     #[test]
-    fn test_not_in_bitmap_returns_universe_minus_in() {
+    fn test_not_in_bitmap_returns_none() {
         // GIVEN: index with tech=[1,5,10], science=[2,7], art=[3]
         let (collection, _temp) = create_test_collection();
         collection
@@ -945,16 +945,14 @@ mod tests {
                 ],
             }),
         });
-        let bitmap = collection.build_prefilter_bitmap(&filter);
 
-        // THEN: universe={1,2,3,5,7,10}, IN={1,2,5,7,10}, NOT IN={3}
+        // THEN: NOT IN cannot be safely pre-filtered. A `universe - in` complement
+        // built from the index omits field-absent points, which NOT IN matches —
+        // so the builder returns None and the caller falls back to a full scan.
         assert!(
-            bitmap.is_some(),
-            "NOT IN on indexed field should produce bitmap"
+            collection.build_prefilter_bitmap(&filter).is_none(),
+            "NOT IN must return None (field-absent points would be dropped otherwise)"
         );
-        let bm = bitmap.unwrap();
-        assert_eq!(bm.len(), 1);
-        assert!(bm.contains(3), "only art ID=3 should remain");
     }
 
     #[test]
@@ -973,7 +971,7 @@ mod tests {
     }
 
     #[test]
-    fn test_not_in_empty_list_returns_universe() {
+    fn test_not_in_empty_list_returns_none() {
         // GIVEN: index with tech=[1,5,10], science=[2,7], art=[3]
         let (collection, _temp) = create_test_collection();
         collection
@@ -988,22 +986,17 @@ mod tests {
                 values: vec![],
             }),
         });
-        let bitmap = collection.build_prefilter_bitmap(&filter);
 
-        // THEN: universe - empty = full universe {1,2,3,5,7,10}
-        assert!(bitmap.is_some(), "NOT IN () should return full universe");
-        let bm = bitmap.unwrap();
-        assert_eq!(bm.len(), 6);
-        assert!(bm.contains(1));
-        assert!(bm.contains(2));
-        assert!(bm.contains(3));
-        assert!(bm.contains(5));
-        assert!(bm.contains(7));
-        assert!(bm.contains(10));
+        // THEN: all `Not` conditions return None now (full-scan fallback). The
+        // post-filter evaluates the predicate correctly, including field-absent rows.
+        assert!(
+            collection.build_prefilter_bitmap(&filter).is_none(),
+            "NOT IN () must return None (conservative scan fallback)"
+        );
     }
 
     #[test]
-    fn test_not_in_all_values_returns_empty() {
+    fn test_not_in_all_values_returns_none() {
         // GIVEN: index with tech=[1,5,10], science=[2,7], art=[3]
         let (collection, _temp) = create_test_collection();
         collection
@@ -1022,13 +1015,11 @@ mod tests {
                 ],
             }),
         });
-        let bitmap = collection.build_prefilter_bitmap(&filter);
 
-        // THEN: universe - universe = empty
-        assert!(bitmap.is_some(), "NOT IN (all) should return Some(empty)");
+        // THEN: None (scan fallback) — the post-filter yields the empty set.
         assert!(
-            bitmap.unwrap().is_empty(),
-            "excluding all values => empty bitmap"
+            collection.build_prefilter_bitmap(&filter).is_none(),
+            "NOT IN (all) must return None (conservative scan fallback)"
         );
     }
 

--- a/crates/velesdb-core/src/database/database_helpers.rs
+++ b/crates/velesdb-core/src/database/database_helpers.rs
@@ -141,10 +141,14 @@ impl Database {
     ///
     /// When the pushed-down `filter` references secondary-indexed fields,
     /// `build_prefilter_bitmap` resolves it to a Roaring bitmap of candidate IDs,
-    /// avoiding the O(N) `all_ids()` scan. The bitmap is an exact-or-superset
-    /// candidate set: `point_matches_filter` still runs on every returned point,
-    /// so results are identical to the scan path. Falls back to `all_ids()` when
-    /// no index can resolve the predicate (`None`).
+    /// avoiding the O(N) `all_ids()` scan. The bitmap is a guaranteed SUPERSET of
+    /// the matches — `point_matches_filter` re-checks every returned point, so
+    /// results are identical to the scan path. The superset guarantee holds
+    /// because `build_prefilter_bitmap` returns `None` (forcing the `all_ids()`
+    /// fallback) for any predicate it cannot resolve completely: `!=` / `NOT IN`
+    /// (whose matches include field-absent points the index does not store) and
+    /// any field carrying an ID above `u32::MAX` (unrepresentable in the bitmap).
+    /// Falls back to `all_ids()` whenever no index can resolve the predicate.
     fn join_candidate_ids(
         collection: &crate::collection::Collection,
         filter: &crate::Filter,

--- a/crates/velesdb-core/src/index/secondary/bitmap_tests.rs
+++ b/crates/velesdb-core/src/index/secondary/bitmap_tests.rs
@@ -20,7 +20,7 @@ mod tests {
         let key = JsonValue::String("tech".to_string());
         let index = make_btree_index(vec![(key.clone(), vec![1, 5, 42])]);
 
-        let bm = index.to_bitmap(&key);
+        let bm = index.to_bitmap(&key).expect("test: ids within u32 range");
         assert_eq!(bm.len(), 3);
         assert!(bm.contains(1));
         assert!(bm.contains(5));
@@ -33,21 +33,41 @@ mod tests {
         let missing = JsonValue::String("science".to_string());
         let index = make_btree_index(vec![(key, vec![1, 2, 3])]);
 
-        let bm = index.to_bitmap(&missing);
+        let bm = index
+            .to_bitmap(&missing)
+            .expect("test: ids within u32 range");
         assert!(bm.is_empty());
     }
 
     #[test]
-    fn test_to_bitmap_skips_ids_exceeding_u32_max() {
+    fn test_to_bitmap_returns_none_when_id_exceeds_u32_max() {
         let key = JsonValue::String("mixed".to_string());
         let large_id = u64::from(u32::MAX) + 1;
         let index = make_btree_index(vec![(key.clone(), vec![10, large_id, 20])]);
 
-        let bm = index.to_bitmap(&key);
-        // Only u32-representable IDs should be in the bitmap
-        assert_eq!(bm.len(), 2);
-        assert!(bm.contains(10));
-        assert!(bm.contains(20));
+        // An ID above u32::MAX cannot be represented in the Roaring bitmap.
+        // Rather than silently drop it (which would make a bitmap-only caller
+        // miss a real match), `to_bitmap` must signal incompleteness via `None`
+        // so the caller falls back to a full scan.
+        assert!(
+            index.to_bitmap(&key).is_none(),
+            "bitmap must be None (incomplete) when an ID exceeds u32::MAX"
+        );
+    }
+
+    #[test]
+    fn test_range_bitmap_returns_none_when_id_exceeds_u32_max() {
+        use std::ops::Bound;
+        let key = JsonValue::Number(crate::index::secondary::F64Key::from(5.0));
+        let large_id = u64::from(u32::MAX) + 7;
+        let index = make_btree_index(vec![(key, vec![large_id])]);
+
+        assert!(
+            index
+                .range_bitmap(Bound::Unbounded, Bound::Unbounded)
+                .is_none(),
+            "range bitmap must be None when an in-range ID exceeds u32::MAX"
+        );
     }
 
     #[test]
@@ -55,7 +75,7 @@ mod tests {
         let key = JsonValue::String("empty".to_string());
         let index = make_btree_index(vec![(key.clone(), vec![])]);
 
-        let bm = index.to_bitmap(&key);
+        let bm = index.to_bitmap(&key).expect("test: ids within u32 range");
         assert!(bm.is_empty());
     }
 
@@ -64,7 +84,7 @@ mod tests {
         let key = JsonValue::Number(crate::index::secondary::F64Key::from(42.0));
         let index = make_btree_index(vec![(key.clone(), vec![100, 200])]);
 
-        let bm = index.to_bitmap(&key);
+        let bm = index.to_bitmap(&key).expect("test: ids within u32 range");
         assert_eq!(bm.len(), 2);
         assert!(bm.contains(100));
         assert!(bm.contains(200));
@@ -75,7 +95,7 @@ mod tests {
         let key = JsonValue::Bool(true);
         let index = make_btree_index(vec![(key.clone(), vec![7, 13])]);
 
-        let bm = index.to_bitmap(&key);
+        let bm = index.to_bitmap(&key).expect("test: ids within u32 range");
         assert_eq!(bm.len(), 2);
         assert!(bm.contains(7));
         assert!(bm.contains(13));
@@ -105,7 +125,9 @@ mod tests {
         let key30 = JsonValue::Number(crate::index::secondary::F64Key::from(30.0));
 
         // (30, +inf) => IDs 4, 5
-        let bm = index.range_bitmap(Bound::Excluded(&key30), Bound::Unbounded);
+        let bm = index
+            .range_bitmap(Bound::Excluded(&key30), Bound::Unbounded)
+            .expect("test: ids within u32 range");
         assert_eq!(bm.len(), 2);
         assert!(bm.contains(4));
         assert!(bm.contains(5));
@@ -118,7 +140,9 @@ mod tests {
         let key30 = JsonValue::Number(crate::index::secondary::F64Key::from(30.0));
 
         // [30, +inf) => IDs 3, 4, 5
-        let bm = index.range_bitmap(Bound::Included(&key30), Bound::Unbounded);
+        let bm = index
+            .range_bitmap(Bound::Included(&key30), Bound::Unbounded)
+            .expect("test: ids within u32 range");
         assert_eq!(bm.len(), 3);
         assert!(bm.contains(3));
         assert!(bm.contains(4));
@@ -132,7 +156,9 @@ mod tests {
         let key30 = JsonValue::Number(crate::index::secondary::F64Key::from(30.0));
 
         // (-inf, 30) => IDs 1, 2
-        let bm = index.range_bitmap(Bound::Unbounded, Bound::Excluded(&key30));
+        let bm = index
+            .range_bitmap(Bound::Unbounded, Bound::Excluded(&key30))
+            .expect("test: ids within u32 range");
         assert_eq!(bm.len(), 2);
         assert!(bm.contains(1));
         assert!(bm.contains(2));
@@ -145,7 +171,9 @@ mod tests {
         let key30 = JsonValue::Number(crate::index::secondary::F64Key::from(30.0));
 
         // (-inf, 30] => IDs 1, 2, 3
-        let bm = index.range_bitmap(Bound::Unbounded, Bound::Included(&key30));
+        let bm = index
+            .range_bitmap(Bound::Unbounded, Bound::Included(&key30))
+            .expect("test: ids within u32 range");
         assert_eq!(bm.len(), 3);
         assert!(bm.contains(1));
         assert!(bm.contains(2));
@@ -160,7 +188,9 @@ mod tests {
         let key40 = JsonValue::Number(crate::index::secondary::F64Key::from(40.0));
 
         // [20, 40] => IDs 2, 3, 4
-        let bm = index.range_bitmap(Bound::Included(&key20), Bound::Included(&key40));
+        let bm = index
+            .range_bitmap(Bound::Included(&key20), Bound::Included(&key40))
+            .expect("test: ids within u32 range");
         assert_eq!(bm.len(), 3);
         assert!(bm.contains(2));
         assert!(bm.contains(3));
@@ -174,7 +204,9 @@ mod tests {
         let key999 = JsonValue::Number(crate::index::secondary::F64Key::from(999.0));
 
         // (999, +inf) => empty
-        let bm = index.range_bitmap(Bound::Excluded(&key999), Bound::Unbounded);
+        let bm = index
+            .range_bitmap(Bound::Excluded(&key999), Bound::Unbounded)
+            .expect("test: ids within u32 range");
         assert!(bm.is_empty());
     }
 
@@ -184,12 +216,14 @@ mod tests {
         let index = make_price_index();
 
         // (-inf, +inf) => all IDs
-        let bm = index.range_bitmap(Bound::Unbounded, Bound::Unbounded);
+        let bm = index
+            .range_bitmap(Bound::Unbounded, Bound::Unbounded)
+            .expect("test: ids within u32 range");
         assert_eq!(bm.len(), 5);
     }
 
     #[test]
-    fn test_range_bitmap_skips_u64_overflow() {
+    fn test_range_bitmap_none_when_in_range_id_overflows_u32() {
         use std::ops::Bound;
         let large_id = u64::from(u32::MAX) + 1;
         let index = make_btree_index(vec![
@@ -202,12 +236,24 @@ mod tests {
                 vec![2],
             ),
         ]);
-        let key5 = JsonValue::Number(crate::index::secondary::F64Key::from(5.0));
+        let low_bound = JsonValue::Number(crate::index::secondary::F64Key::from(5.0));
 
-        // (5, +inf) => IDs 1, 2 (large_id skipped)
-        let bm = index.range_bitmap(Bound::Excluded(&key5), Bound::Unbounded);
-        assert_eq!(bm.len(), 2);
-        assert!(bm.contains(1));
+        // (5, +inf) spans key 10 whose posting list contains an id > u32::MAX.
+        // The range bitmap cannot represent it, so it must signal `None`
+        // (incomplete) instead of silently dropping the high id.
+        assert!(
+            index
+                .range_bitmap(Bound::Excluded(&low_bound), Bound::Unbounded)
+                .is_none(),
+            "range bitmap must be None when any in-range id overflows u32"
+        );
+
+        // A sub-range that excludes the overflowing posting list stays exact.
+        let above_overflow_bound = JsonValue::Number(crate::index::secondary::F64Key::from(15.0));
+        let bm = index
+            .range_bitmap(Bound::Excluded(&above_overflow_bound), Bound::Unbounded)
+            .expect("test: ids within u32 range");
+        assert_eq!(bm.len(), 1);
         assert!(bm.contains(2));
     }
 }

--- a/crates/velesdb-core/src/index/secondary/mod.rs
+++ b/crates/velesdb-core/src/index/secondary/mod.rs
@@ -106,18 +106,21 @@ pub(crate) enum SecondaryIndex {
 impl SecondaryIndex {
     /// Returns a [`RoaringBitmap`] of all point IDs matching the given value.
     ///
-    /// The bitmap is built on-the-fly from the B-tree leaf. Returns an empty
-    /// bitmap when the value has no entries. Callers should check
-    /// [`RoaringBitmap::is_empty`] before using the result as a pre-filter.
+    /// The bitmap is built on-the-fly from the B-tree leaf. Returns
+    /// `Some(empty)` when the value has no entries (a valid "no matches"
+    /// pre-filter). Returns `None` when any matching ID exceeds [`u32::MAX`] and
+    /// therefore cannot be represented in the bitmap — signalling an
+    /// **incomplete** result so callers fall back to a full scan rather than
+    /// silently dropping the high ID (correctness over the optimization).
     #[must_use]
-    pub fn to_bitmap(&self, value: &JsonValue) -> roaring::RoaringBitmap {
+    pub fn to_bitmap(&self, value: &JsonValue) -> Option<roaring::RoaringBitmap> {
         match self {
             Self::BTree(tree) => {
                 let guard = tree.read();
-                guard
-                    .get(value)
-                    .map(|ids| ids_to_bitmap(ids))
-                    .unwrap_or_default()
+                match guard.get(value) {
+                    Some(ids) => ids_to_bitmap(ids),
+                    None => Some(roaring::RoaringBitmap::new()),
+                }
             }
         }
     }
@@ -126,47 +129,25 @@ impl SecondaryIndex {
     /// the given range bounds.
     ///
     /// Uses `BTreeMap::range()` for efficient ordered iteration. This powers
-    /// Gt, Gte, Lt, Lte, and BETWEEN pre-filters. Returns an empty bitmap
-    /// when no keys fall within the range.
+    /// Gt, Gte, Lt, Lte, and BETWEEN pre-filters. Returns `Some(empty)` when no
+    /// keys fall within the range, and `None` when any in-range ID exceeds
+    /// [`u32::MAX`] (incomplete — callers must fall back to a full scan).
     #[must_use]
     pub fn range_bitmap(
         &self,
         from: Bound<&JsonValue>,
         to: Bound<&JsonValue>,
-    ) -> roaring::RoaringBitmap {
+    ) -> Option<roaring::RoaringBitmap> {
         match self {
             Self::BTree(tree) => {
                 let guard = tree.read();
                 let mut bm = roaring::RoaringBitmap::new();
                 for ids in guard.range((from, to)).map(|(_, v)| v) {
                     for &id in ids {
-                        if let Ok(id32) = u32::try_from(id) {
-                            bm.insert(id32);
-                        }
+                        bm.insert(u32::try_from(id).ok()?);
                     }
                 }
-                bm
-            }
-        }
-    }
-
-    /// Returns a [`RoaringBitmap`] containing ALL point IDs in this index.
-    ///
-    /// Used as the "universe" for NEQ operations: `NEQ(field, value) = universe - EQ(field, value)`.
-    #[must_use]
-    pub fn all_ids_bitmap(&self) -> roaring::RoaringBitmap {
-        match self {
-            Self::BTree(tree) => {
-                let guard = tree.read();
-                let mut bm = roaring::RoaringBitmap::new();
-                for ids in guard.values() {
-                    for &id in ids {
-                        if let Ok(id32) = u32::try_from(id) {
-                            bm.insert(id32);
-                        }
-                    }
-                }
-                bm
+                Some(bm)
             }
         }
     }
@@ -174,15 +155,14 @@ impl SecondaryIndex {
 
 /// Converts a slice of `u64` point IDs into a [`RoaringBitmap`].
 ///
-/// `RoaringBitmap` stores `u32` values. IDs exceeding `u32::MAX` are silently
-/// skipped because the bitmap is a best-effort optimization hint — the
-/// post-filter still catches all matches.
-fn ids_to_bitmap(ids: &[u64]) -> roaring::RoaringBitmap {
+/// `RoaringBitmap` stores `u32` values. Returns `None` if any ID exceeds
+/// [`u32::MAX`]: the bitmap would silently omit that ID, so callers that fetch
+/// only the bitmap's IDs (e.g. the JOIN pre-filter) would drop a real match.
+/// Signalling `None` forces those callers to fall back to a full scan.
+fn ids_to_bitmap(ids: &[u64]) -> Option<roaring::RoaringBitmap> {
     let mut bm = roaring::RoaringBitmap::new();
     for &id in ids {
-        if let Ok(id32) = u32::try_from(id) {
-            bm.insert(id32);
-        }
+        bm.insert(u32::try_from(id).ok()?);
     }
-    bm
+    Some(bm)
 }

--- a/crates/velesdb-core/tests/pushdown_join_e2e_tests.rs
+++ b/crates/velesdb-core/tests/pushdown_join_e2e_tests.rs
@@ -641,3 +641,75 @@ fn test_indexed_join_empty_bitmap_returns_empty() {
         "no review has rating 999; empty bitmap must yield empty JOIN"
     );
 }
+
+/// GIVEN: a review row MISSING the `rating` field, with `rating` indexed
+/// WHEN: a `!=` (NEQ) predicate runs on the indexed field
+/// THEN: the indexed path returns the SAME rows as the unindexed scan path,
+///       INCLUDING the field-absent row.
+///
+/// Regression: NEQ used to be pre-filtered as `universe - eq` where `universe`
+/// came from the secondary index, which only stores points that HAVE a value
+/// for the field. NEQ semantics also match field-absent rows, so the bitmap was
+/// a strict subset and the JOIN (which fetches only bitmap ids) dropped them.
+/// `build_prefilter_bitmap` now returns `None` for NEQ/NOT IN, forcing the
+/// correct full-scan + post-filter.
+#[test]
+fn test_indexed_join_neq_includes_field_absent_rows() {
+    fn setup(index: bool) -> (TempDir, Database) {
+        let (dir, db) = create_test_db();
+        execute_sql(
+            &db,
+            "CREATE COLLECTION products (dimension = 4, metric = 'cosine');",
+        )
+        .expect("test: CREATE products");
+        let products = db
+            .get_vector_collection("products")
+            .expect("test: get products");
+        products
+            .upsert(vec![
+                Point::new(1, vec![1.0, 0.0, 0.0, 0.0], Some(json!({"category": "a"}))),
+                Point::new(2, vec![0.0, 1.0, 0.0, 0.0], Some(json!({"category": "a"}))),
+                Point::new(3, vec![0.0, 0.0, 1.0, 0.0], Some(json!({"category": "b"}))),
+            ])
+            .expect("test: upsert products");
+
+        execute_sql(&db, "CREATE METADATA COLLECTION reviews;").expect("test: CREATE reviews");
+        let reviews = db
+            .get_metadata_collection("reviews")
+            .expect("test: get reviews");
+        reviews
+            .upsert(vec![
+                Point::metadata_only(1, json!({"rating": 5, "reviewer": "Alice"})),
+                Point::metadata_only(2, json!({"rating": 3, "reviewer": "Bob"})),
+                // id=3 deliberately has NO `rating` field.
+                Point::metadata_only(3, json!({"reviewer": "Charlie"})),
+            ])
+            .expect("test: upsert reviews");
+        if index {
+            execute_sql(&db, "CREATE INDEX ON reviews (rating)").expect("test: CREATE INDEX");
+        }
+        (dir, db)
+    }
+
+    let sql = "SELECT * FROM products \
+               JOIN reviews ON products.id = reviews.id \
+               WHERE reviews.rating != 5 \
+               LIMIT 10";
+
+    let (_di, db_indexed) = setup(true);
+    let indexed = execute_sql(&db_indexed, sql).expect("test: indexed NEQ JOIN");
+    let (_ds, db_scan) = setup(false);
+    let scan = execute_sql(&db_scan, sql).expect("test: scan NEQ JOIN");
+
+    assert_eq!(
+        result_ids(&indexed),
+        result_ids(&scan),
+        "indexed NEQ path must equal scan path (field-absent rows included)"
+    );
+    // rating != 5: Bob(id=2, rating=3) and Charlie(id=3, rating absent); Alice(id=1, rating=5) excluded.
+    assert_eq!(
+        result_ids(&indexed),
+        HashSet::from([2, 3]),
+        "NEQ must include the field-absent row (id=3)"
+    );
+}


### PR DESCRIPTION
Follow-up correctness fix to #1029, found by the post-merge audit.

**Bug**: the cross-collection JOIN fetches only `build_prefilter_bitmap` candidate ids, so the bitmap must be a SUPERSET of matches. It wasn't for:
1. `!=` / `NOT IN` — `universe - eq` omits field-absent points (which `!=`/`NOT IN` match) → indexed JOIN dropped those rows vs the scan path.
2. IDs > `u32::MAX` — silently skipped from the u32 Roaring bitmap → dropped real matches.

**Fix**: `Neq`/`Not` now return `None` (correct full-scan + post-filter); `SecondaryIndex::{to_bitmap,range_bitmap}` + `ids_to_bitmap` return `Option`, signalling `None` on u32 overflow instead of silently dropping ids. Removed the now-unused `universe` helpers.

**Tests**: NEQ+field-absent JOIN regression (indexed == scan, includes the absent-field row); u32-overflow→None unit tests; updated prior tests that locked in the old unsound complement.

**Validation**: clippy pedantic clean; index_management (48) + bitmap (15) + bitmap_prefilter_integration (5) + match_prefilter_e2e (8) green; **recall@10 = 0.9740** (unchanged — the change only makes the pre-filter more conservative).
