### PR TITLE
feat(graph): validate add_edges_batch in strict mode (close referential-integrity hole)

### DIFF
--- a/crates/velesdb-core/src/collection/core/graph_api.rs
+++ b/crates/velesdb-core/src/collection/core/graph_api.rs
@@ -91,6 +91,14 @@ impl Collection {
             return Ok(0);
         }
 
+        // Strict-schema referential integrity: validate the ENTIRE batch before
+        // any mutation (WAL append or store write), so a single violating edge
+        // fails the whole batch with no partial write and no orphaned WAL entry.
+        // Schemaless collections (the default) short-circuit at zero added cost.
+        for edge in &edges {
+            self.validate_edge_referential_integrity(edge)?;
+        }
+
         #[cfg(feature = "persistence")]
         if self.config.read().graph_schema.is_some() {
             crate::collection::graph::edge_wal::wal_append_add_batch(
@@ -431,6 +439,10 @@ impl Collection {
     ///
     /// Returns an error if storage fails.
     pub fn store_node_payload(&self, node_id: u64, payload: &serde_json::Value) -> Result<()> {
+        // TODO(EPIC-015): in strict-schema mode, validate the node's `_labels`
+        // against `GraphSchema::validate_node_type` here (and on INSERT NODE) to
+        // reject undeclared node types. Today only edge writes are validated
+        // (`validate_edge_referential_integrity`); node writes are unchecked.
         // Crash durability for node payloads is already provided by the
         // payload WAL: `storage.store(node_id, payload)` below appends a
         // CRC-checked record to `payloads.log` and fsyncs (LogPayloadStorage,

--- a/crates/velesdb-core/src/collection/core/graph_api_tests.rs
+++ b/crates/velesdb-core/src/collection/core/graph_api_tests.rs
@@ -919,4 +919,63 @@ mod tests {
             .expect("schemaless collection must accept dangling edges");
         assert_eq!(collection.edge_count(), 1);
     }
+
+    #[test]
+    fn test_strict_mode_batch_rejects_dangling_edge() {
+        let (collection, _temp) = create_strict_graph_collection();
+        store_typed_node(&collection, 100, "Person");
+        store_typed_node(&collection, 200, "Person");
+        // First edge is valid, second references non-existent endpoints (300/400).
+        let batch = vec![
+            make_edge(1, 100, 200, "KNOWS"),
+            make_edge(2, 300, 400, "KNOWS"),
+        ];
+        assert_schema_violation(collection.add_edges_batch(batch).map(|_| ()));
+        // Whole batch rejected before any mutation — no partial write.
+        assert_eq!(
+            collection.edge_count(),
+            0,
+            "a violating edge must fail the whole batch with no partial write"
+        );
+    }
+
+    #[test]
+    fn test_strict_mode_batch_rejects_bad_edge_type() {
+        let (collection, _temp) = create_strict_graph_collection();
+        store_typed_node(&collection, 100, "Person");
+        store_typed_node(&collection, 200, "Person");
+        let batch = vec![make_edge(1, 100, 200, "UNKNOWN_REL")];
+        assert_schema_violation(collection.add_edges_batch(batch).map(|_| ()));
+        assert_eq!(collection.edge_count(), 0);
+    }
+
+    #[test]
+    fn test_strict_mode_batch_accepts_valid() {
+        let (collection, _temp) = create_strict_graph_collection();
+        store_typed_node(&collection, 100, "Person");
+        store_typed_node(&collection, 200, "Person");
+        store_typed_node(&collection, 300, "Person");
+        let added = collection
+            .add_edges_batch(vec![
+                make_edge(1, 100, 200, "KNOWS"),
+                make_edge(2, 200, 300, "KNOWS"),
+            ])
+            .expect("valid batch should be accepted in strict mode");
+        assert_eq!(added, 2);
+        assert_eq!(collection.edge_count(), 2);
+    }
+
+    #[test]
+    fn test_schemaless_batch_allows_dangling_edges() {
+        // Regression guard: schemaless batch path unchanged.
+        let (collection, _temp) = create_graph_test_collection();
+        let added = collection
+            .add_edges_batch(vec![
+                make_edge(1, 100, 200, "ANY_REL"),
+                make_edge(2, 300, 400, "OTHER_REL"),
+            ])
+            .expect("schemaless collection must accept dangling edges in batch");
+        assert_eq!(added, 2);
+        assert_eq!(collection.edge_count(), 2);
+    }
 }


### PR DESCRIPTION
Follow-up to #1027, found by the post-merge audit.

**Hole**: `add_edges_batch` (public, reachable via the Python SDK and velesdb-migrate) skipped the strict-schema referential-integrity check that single `add_edge` performs (#1027). A bulk insert into a **strict** graph collection could write dangling / schema-violating edges, defeating the guarantee.

**Fix**: `add_edges_batch` now validates the entire batch (`validate_edge_referential_integrity`) before any WAL append or store write — one violating edge fails the whole batch with no partial write. Schemaless (default) stays a zero-cost no-op. Added `TODO(EPIC-015)` for the remaining deferral (node-type validation on INSERT NODE).

**Tests**: strict batch rejects dangling edge + bad type (edge_count stays 0), strict batch accepts valid, schemaless batch unaffected. clippy pedantic clean; migrate + python callers compile (signature unchanged).
