### PR TITLE
fix(server): node_ids string serialization + string sources (u64 precision)

### DIFF
--- a/crates/velesdb-server/src/handlers/graph/types.rs
+++ b/crates/velesdb-server/src/handlers/graph/types.rs
@@ -173,7 +173,9 @@ fn default_direction() -> String {
 /// Response containing all node IDs in the graph.
 #[derive(Debug, Serialize, ToSchema)]
 pub struct NodeListResponse {
-    /// List of node IDs.
+    /// List of node IDs (serialized as strings to preserve u64 precision in JS).
+    #[serde(serialize_with = "serde_id::serialize_ids_as_strings")]
+    #[cfg_attr(feature = "openapi", schema(schema_with = serde_id::ids_array_schema))]
     pub node_ids: Vec<u64>,
     /// Total count of nodes.
     pub count: usize,
@@ -200,7 +202,10 @@ pub struct NodePayloadResponse {
 /// Request for parallel multi-source BFS traversal.
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct ParallelTraverseRequest {
-    /// Source node IDs to start traversal from.
+    /// Source node IDs to start traversal from (accepts strings or numbers so
+    /// JS clients can send precision-safe u64 IDs above `Number.MAX_SAFE_INTEGER`).
+    #[serde(deserialize_with = "serde_id::deserialize_ids_from_string_or_number")]
+    #[cfg_attr(feature = "openapi", schema(schema_with = serde_id::ids_array_schema))]
     pub sources: Vec<u64>,
     /// Maximum traversal depth.
     #[serde(default = "default_max_depth")]
@@ -358,5 +363,34 @@ mod tests {
         };
         let json = serde_json::to_value(&event).unwrap();
         assert_eq!(json["path"], serde_json::json!(["9007199254740993"]));
+    }
+
+    /// Node-list ids above 2^53 must serialize as a JSON string array.
+    #[test]
+    fn test_node_list_ids_serialized_as_strings() {
+        let above_safe = (1_u64 << 53) + 1;
+        let response = NodeListResponse {
+            node_ids: vec![1, above_safe],
+            count: 2,
+        };
+        let json = serde_json::to_value(&response).unwrap();
+        assert_eq!(
+            json["node_ids"],
+            serde_json::json!(["1", "9007199254740993"])
+        );
+    }
+
+    /// Parallel-traverse sources must deserialize from BOTH strings and numbers.
+    #[test]
+    fn test_parallel_sources_accepts_strings_and_numbers() {
+        let from_strings: ParallelTraverseRequest =
+            serde_json::from_value(serde_json::json!({ "sources": ["9007199254740993", "2"] }))
+                .expect("string sources must deserialize");
+        assert_eq!(from_strings.sources, vec![(1_u64 << 53) + 1, 2]);
+
+        let from_numbers: ParallelTraverseRequest =
+            serde_json::from_value(serde_json::json!({ "sources": [3, 4] }))
+                .expect("numeric sources must still deserialize");
+        assert_eq!(from_numbers.sources, vec![3, 4]);
     }
 }

--- a/crates/velesdb-server/tests/match_api_tests.rs
+++ b/crates/velesdb-server/tests/match_api_tests.rs
@@ -23,10 +23,13 @@ fn test_match_request_json_format() {
 /// Test response JSON format with projected properties.
 #[test]
 fn test_match_response_json_format() {
+    // Binding values are emitted as STRINGS over the wire (u64 ids are
+    // serialized via serde_id to avoid JS Number.MAX_SAFE_INTEGER precision
+    // loss). This fixture mirrors that real shape.
     let response = json!({
         "results": [
             {
-                "bindings": {"doc": 123, "author": 456},
+                "bindings": {"doc": "123", "author": "456"},
                 "score": 0.95,
                 "depth": 1,
                 "projected": {
@@ -44,7 +47,10 @@ fn test_match_response_json_format() {
     assert_eq!(results.len(), 1);
 
     let first = &results[0];
-    assert!(first["bindings"]["doc"].as_u64().is_some());
+    assert!(
+        first["bindings"]["doc"].as_str().is_some(),
+        "binding ids are serialized as strings (JS precision safety)"
+    );
     assert!(first["score"].as_f64().is_some());
     assert_eq!(first["projected"]["author.name"], "John Doe");
 }

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -4324,11 +4324,16 @@
           "node_ids": {
             "type": "array",
             "items": {
-              "type": "integer",
-              "format": "int64",
-              "minimum": 0
-            },
-            "description": "List of node IDs."
+              "oneOf": [
+                {
+                  "type": "integer",
+                  "format": "int64"
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            }
           }
         }
       },
@@ -4421,11 +4426,16 @@
           "sources": {
             "type": "array",
             "items": {
-              "type": "integer",
-              "format": "int64",
-              "minimum": 0
-            },
-            "description": "Source node IDs to start traversal from."
+              "oneOf": [
+                {
+                  "type": "integer",
+                  "format": "int64"
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            }
           }
         }
       },

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -3038,10 +3038,10 @@ components:
         node_ids:
           type: array
           items:
-            type: integer
-            format: int64
-            minimum: 0
-          description: List of node IDs.
+            oneOf:
+            - type: integer
+              format: int64
+            - type: string
     NodePayloadResponse:
       type: object
       description: Response for a node payload retrieval.
@@ -3126,10 +3126,10 @@ components:
         sources:
           type: array
           items:
-            type: integer
-            format: int64
-            minimum: 0
-          description: Source node IDs to start traversal from.
+            oneOf:
+            - type: integer
+              format: int64
+            - type: string
     PointRequest:
       type: object
       description: A point in an upsert request.

--- a/sdks/typescript/src/backends/missing-endpoints.ts
+++ b/sdks/typescript/src/backends/missing-endpoints.ts
@@ -325,12 +325,13 @@ export async function listNodes(
   transport: BaseTransport,
   collection: string
 ): Promise<ListNodesResponse> {
-  const response = await transport.requestJson<{ node_ids: number[]; count: number }>(
-    'GET',
-    `${collectionPath(collection)}/graph/nodes`
-  );
+  const response = await transport.requestJson<{
+    node_ids: Array<number | string>;
+    count: number;
+  }>('GET', `${collectionPath(collection)}/graph/nodes`);
   throwOnError(response, `Collection '${collection}'`);
   const data = response.data!;
+  // Pass node ids through unchanged (string|number) — no lossy Number() coercion.
   return { nodeIds: data.node_ids, count: data.count };
 }
 

--- a/sdks/typescript/src/types/endpoints.ts
+++ b/sdks/typescript/src/types/endpoints.ts
@@ -46,8 +46,8 @@ export interface GuardRailsConfigResponse {
 
 /** Options for `listNodes`. */
 export interface ListNodesResponse {
-  /** Node IDs in insertion order. */
-  nodeIds: number[];
+  /** Node IDs in insertion order (string|number to preserve u64 precision). */
+  nodeIds: GraphNodeId[];
   /** Total count -- matches `nodeIds.length`. */
   count: number;
 }


### PR DESCRIPTION
Follow-up to #1030, found by the post-merge audit — closes the remaining u64-precision gaps.

- **`NodeListResponse.node_ids`** (GET /graph/nodes): now serialized as strings (was raw numbers → >2^53 precision loss in JS).
- **`ParallelTraverseRequest.sources`**: now deserializes from string OR number (was number-only — asymmetric with `TraverseRequest.source`), so JS clients can send precision-safe u64 ids.
- **TS**: `ListNodesResponse.nodeIds` → `GraphNodeId[]`; listNodes backend passes ids through (no lossy `Number()`).
- **OpenAPI** snapshots regenerated (drift-clean).
- Fixed the stale `match_api_tests` fixture that asserted numeric `bindings` (real wire shape is strings since #1030).

**Tests**: node_ids→strings + parallel-sources-accepts-both serde tests; clippy pedantic clean; `tsc --noEmit` clean; 729 TS tests green.