### PR TITLE
fix(graph): write snapshot files atomically (tmp + fsync + rename)

### DIFF
--- a/crates/velesdb-core/src/collection/graph/helpers.rs
+++ b/crates/velesdb-core/src/collection/graph/helpers.rs
@@ -33,7 +33,13 @@ pub(crate) trait PostcardPersistence: Serialize + DeserializeOwned + Sized {
         postcard::from_bytes(bytes)
     }
 
-    /// Saves this value to a file.
+    /// Saves this value to a file **atomically**.
+    ///
+    /// Serializes to a sibling `*.tmp` file, fsyncs it, then renames it over the
+    /// target. On the same filesystem `rename` is atomic, so a crash mid-write
+    /// leaves the *previous* good snapshot intact rather than a torn file that
+    /// `load_from_file` would reject (and callers would fall back to an empty
+    /// store, losing data). Mirrors the durability the WAL already provides.
     ///
     /// # Errors
     ///
@@ -42,7 +48,7 @@ pub(crate) trait PostcardPersistence: Serialize + DeserializeOwned + Sized {
         let bytes = self
             .to_bytes()
             .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
-        std::fs::write(path, bytes)
+        crate::storage::atomic_write::atomic_write(path, &bytes)
     }
 
     /// Loads a value from a file.
@@ -109,5 +115,46 @@ mod tests {
         let (l, p) = make_label_prop_key("", "");
         assert_eq!(l, "");
         assert_eq!(p, "");
+    }
+
+    #[derive(serde::Serialize, serde::Deserialize, PartialEq, Debug)]
+    struct Sample {
+        ids: Vec<u64>,
+    }
+    impl PostcardPersistence for Sample {}
+
+    #[test]
+    fn test_atomic_save_round_trips_and_leaves_no_temp() {
+        let dir = tempfile::TempDir::new().expect("test: temp dir");
+        let path = dir.path().join("snapshot.bin");
+        let value = Sample {
+            ids: vec![1, 2, 9_007_199_254_740_993],
+        };
+
+        value.save_to_file(&path).expect("test: save");
+        // No leftover temp file after a successful atomic save.
+        assert!(
+            !path.with_extension("tmp").exists(),
+            "the .tmp sibling must be renamed away, not left behind"
+        );
+        let loaded = Sample::load_from_file(&path).expect("test: load");
+        assert_eq!(loaded, value);
+    }
+
+    #[test]
+    fn test_atomic_save_overwrites_existing_snapshot() {
+        let dir = tempfile::TempDir::new().expect("test: temp dir");
+        let path = dir.path().join("snapshot.bin");
+
+        Sample { ids: vec![1] }
+            .save_to_file(&path)
+            .expect("test: first save");
+        let second = Sample {
+            ids: vec![10, 20, 30],
+        };
+        second.save_to_file(&path).expect("test: overwrite save");
+
+        assert_eq!(Sample::load_from_file(&path).expect("test: load"), second);
+        assert!(!path.with_extension("tmp").exists());
     }
 }

--- a/crates/velesdb-core/src/index/bm25_persistence.rs
+++ b/crates/velesdb-core/src/index/bm25_persistence.rs
@@ -28,12 +28,11 @@
 //! See issue #618 for the Devin learning that motivates this
 //! fail-fast contract.
 
-use std::io::Write;
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicU64, Ordering};
 
 use crate::error::{Error, Result};
 use crate::index::bm25::{Bm25Index, Bm25Snapshot};
+use crate::storage::atomic_write::atomic_write;
 
 /// Snapshot filename under a collection directory.
 pub(crate) const BM25_SNAPSHOT_FILENAME: &str = "bm25.snapshot";
@@ -85,42 +84,5 @@ pub(crate) fn load_snapshot(dir: &Path) -> Result<Option<Bm25Index>> {
     Ok(Some(Bm25Index::from_snapshot(snapshot)?))
 }
 
-// ---------------------------------------------------------------------------
-// Atomic write (write-tmp-fsync-rename)
-// ---------------------------------------------------------------------------
-
-/// Process-wide counter to produce unique tmp suffixes even when two
-/// threads race to save the same snapshot.
-static TMP_COUNTER: AtomicU64 = AtomicU64::new(0);
-
-/// Writes `data` to `final_path` atomically: stage to a uniquely-named
-/// tmp file in the same directory, flush + fsync, then rename over.
-///
-/// Mirrors the pattern in `index::hnsw::persistence::atomic_write`. The
-/// tmp suffix combines PID, thread ID and a monotonically-increasing
-/// counter to avoid collisions under concurrent saves.
-fn atomic_write(final_path: &Path, data: &[u8]) -> std::io::Result<()> {
-    let seq = TMP_COUNTER.fetch_add(1, Ordering::Relaxed);
-    let pid = std::process::id();
-    let tid = std::thread::current().id();
-
-    let file_name = final_path.file_name().unwrap_or_default().to_string_lossy();
-    let tmp_name = format!("{file_name}.tmp.{pid}.{tid:?}.{seq}");
-    let tmp_path = final_path.with_file_name(&tmp_name);
-
-    let result = atomic_write_inner(&tmp_path, final_path, data);
-    if result.is_err() {
-        // Best-effort cleanup — ignore any follow-up error.
-        let _ = std::fs::remove_file(&tmp_path);
-    }
-    result
-}
-
-fn atomic_write_inner(tmp_path: &Path, final_path: &Path, data: &[u8]) -> std::io::Result<()> {
-    let file = std::fs::File::create(tmp_path)?;
-    let mut writer = std::io::BufWriter::new(file);
-    writer.write_all(data)?;
-    writer.flush()?;
-    writer.get_ref().sync_all()?;
-    std::fs::rename(tmp_path, final_path)
-}
+// Atomic snapshot writes use the shared `crate::storage::atomic_write` helper
+// (write-tmp + fsync + rename), so the crash-safety logic lives in one place.

--- a/crates/velesdb-core/src/index/hnsw/persistence.rs
+++ b/crates/velesdb-core/src/index/hnsw/persistence.rs
@@ -23,10 +23,9 @@
 //!   (generation=0) accepted on load.
 
 use crate::distance::DistanceMetric;
+use crate::storage::atomic_write::atomic_write;
 use std::collections::HashMap;
-use std::io::Write;
 use std::path::Path;
-use std::sync::atomic::{AtomicU64, Ordering};
 
 /// HNSW index metadata as stored on disk.
 ///
@@ -227,44 +226,8 @@ pub(crate) fn load_vectors(path: &Path) -> std::io::Result<HnswVectorsData> {
     })
 }
 
-/// Writes `data` to a unique temp file, fsyncs, then renames to `final_path`.
-///
-/// This provides crash-safe persistence: readers always see either the
-/// previous complete file or the new complete file, never a torn write.
-///
-/// Each call generates a unique temporary filename using process ID, thread ID,
-/// and a global counter to prevent races both within a process (concurrent
-/// threads) and across processes sharing the same data directory.
-fn atomic_write(final_path: &Path, data: &[u8]) -> std::io::Result<()> {
-    static COUNTER: AtomicU64 = AtomicU64::new(0);
-    let seq = COUNTER.fetch_add(1, Ordering::Relaxed);
-    let pid = std::process::id();
-    let tid = std::thread::current().id();
-
-    // Build temp file in the same directory as the target, with a unique suffix
-    // derived from PID + thread ID + global counter to avoid concurrent-write
-    // races both intra-process and cross-process.
-    let file_name = final_path.file_name().unwrap_or_default().to_string_lossy();
-    let tmp_name = format!("{file_name}.tmp.{pid}.{tid:?}.{seq}");
-    let tmp_path = final_path.with_file_name(&tmp_name);
-
-    let result = atomic_write_inner(&tmp_path, final_path, data);
-    if result.is_err() {
-        // Best-effort cleanup of the temp file on failure.
-        let _ = std::fs::remove_file(&tmp_path);
-    }
-    result
-}
-
-/// Inner write-fsync-rename step for [`atomic_write`].
-fn atomic_write_inner(tmp_path: &Path, final_path: &Path, data: &[u8]) -> std::io::Result<()> {
-    let file = std::fs::File::create(tmp_path)?;
-    let mut writer = std::io::BufWriter::new(file);
-    writer.write_all(data)?;
-    writer.flush()?;
-    writer.get_ref().sync_all()?;
-    std::fs::rename(tmp_path, final_path)
-}
+// Crash-safe persistence (write-tmp + fsync + rename) is provided by the shared
+// `crate::storage::atomic_write` helper, imported above.
 
 /// Loads vectors from disk, disabling vector storage gracefully when the file
 /// is missing (e.g., index was saved in fast-insert mode before vectors existed).

--- a/crates/velesdb-core/src/storage/atomic_write.rs
+++ b/crates/velesdb-core/src/storage/atomic_write.rs
@@ -1,0 +1,84 @@
+//! Atomic file write: serialize to a unique sibling temp file, fsync, then
+//! rename over the target.
+//!
+//! Shared by every durable snapshot writer (HNSW, BM25, and the graph postcard
+//! snapshots — `EdgeStore` / `PropertyIndex` / `RangeIndex`) so the crash-safety
+//! guarantee lives in exactly one place instead of being re-implemented per
+//! module.
+
+use std::io::Write;
+use std::path::Path;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// Process-global counter making temp file names unique within a process.
+static TMP_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+/// Writes `data` to `final_path` atomically.
+///
+/// Serializes to a uniquely-named sibling temp file (same directory → same
+/// filesystem, so the `rename` is atomic and cannot fail with `EXDEV`), fsyncs
+/// it, then renames it over the target. A crash mid-write leaves the *previous*
+/// good file intact rather than a torn file. The temp file is best-effort
+/// removed if any step fails.
+///
+/// The temp name embeds PID + thread id + a process-global counter so
+/// concurrent writers (intra- and inter-process) never collide on it.
+///
+/// # Errors
+///
+/// Returns an error if creating, writing, or fsyncing the temp file fails, or
+/// if the final rename fails.
+pub(crate) fn atomic_write(final_path: &Path, data: &[u8]) -> std::io::Result<()> {
+    let seq = TMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let pid = std::process::id();
+    let tid = std::thread::current().id();
+    let file_name = final_path.file_name().unwrap_or_default().to_string_lossy();
+    let tmp_path = final_path.with_file_name(format!("{file_name}.tmp.{pid}.{tid:?}.{seq}"));
+
+    let result = atomic_write_inner(&tmp_path, final_path, data);
+    if result.is_err() {
+        // Best-effort cleanup of the temp file on failure.
+        let _ = std::fs::remove_file(&tmp_path);
+    }
+    result
+}
+
+fn atomic_write_inner(tmp_path: &Path, final_path: &Path, data: &[u8]) -> std::io::Result<()> {
+    let file = std::fs::File::create(tmp_path)?;
+    let mut writer = std::io::BufWriter::new(file);
+    writer.write_all(data)?;
+    writer.flush()?;
+    writer.get_ref().sync_all()?; // durable before the rename swaps it in
+    std::fs::rename(tmp_path, final_path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::atomic_write;
+
+    #[test]
+    fn test_atomic_write_round_trips_and_leaves_no_temp() {
+        let dir = tempfile::TempDir::new().expect("test: temp dir");
+        let path = dir.path().join("snap.bin");
+
+        atomic_write(&path, b"hello").expect("test: write");
+        assert_eq!(std::fs::read(&path).expect("test: read"), b"hello");
+
+        // No stray temp files remain after a successful write.
+        let leftovers: Vec<_> = std::fs::read_dir(dir.path())
+            .expect("test: read dir")
+            .filter_map(std::result::Result::ok)
+            .filter(|e| e.file_name().to_string_lossy().contains(".tmp."))
+            .collect();
+        assert!(leftovers.is_empty(), "no .tmp files should remain");
+    }
+
+    #[test]
+    fn test_atomic_write_overwrites_existing() {
+        let dir = tempfile::TempDir::new().expect("test: temp dir");
+        let path = dir.path().join("snap.bin");
+        atomic_write(&path, b"first").expect("test: first");
+        atomic_write(&path, b"second").expect("test: overwrite");
+        assert_eq!(std::fs::read(&path).expect("test: read"), b"second");
+    }
+}

--- a/crates/velesdb-core/src/storage/mod.rs
+++ b/crates/velesdb-core/src/storage/mod.rs
@@ -15,6 +15,7 @@
 #![allow(clippy::doc_markdown)] // Storage docs include API and platform identifiers.
 
 pub mod async_ops;
+pub(crate) mod atomic_write;
 mod compaction;
 mod guard;
 mod histogram;


### PR DESCRIPTION
Closes the last open item from the post-merge audit (noted on #1026): graph `.bin` snapshots were written non-atomically.

**Gap**: `PostcardPersistence::save_to_file` used `std::fs::write` — a crash mid-write torns the snapshot; on reopen `load_from_file` rejects it and callers fall back to an empty store, losing data written before the last flush. Affects EdgeStore, PropertyIndex, RangeIndex (all use this helper).

**Fix**: serialize to a sibling `*.tmp`, `sync_all()`, then `rename` over the target (atomic on the same filesystem) — a crash leaves the previous good snapshot intact.

**Tests**: atomic round-trip leaves no `.tmp`; overwrite replaces cleanly; persistence suites green (helpers 6, persistence 50, range 26, property 49, edge-WAL recovery 8); clippy pedantic clean.