### PR TITLE
fix(agent): harden semantic-memory TTL, expiry and add CRUD helpers

### DIFF
--- a/crates/velesdb-core/src/agent/memory.rs
+++ b/crates/velesdb-core/src/agent/memory.rs
@@ -172,7 +172,13 @@ impl AgentMemory {
     ///
     /// Returns an error when consolidation operations fail.
     pub fn auto_expire(&self) -> Result<ExpireResult, AgentMemoryError> {
-        let expired_ids = self.ttl.expire();
+        // Read expired ids WITHOUT dropping their TTL entries yet. The entry is
+        // removed (via the subsystem `delete`, which calls `ttl.remove`) only
+        // after the point is actually deleted, so a failed delete leaves the TTL
+        // entry intact and the id is retried on the next `auto_expire`. This
+        // preserves the expiry invariant: a tracked-expired id is never forgotten
+        // while its point still exists.
+        let expired_ids = self.ttl.get_expired();
         let mut result = ExpireResult::default();
 
         for id in &expired_ids {

--- a/crates/velesdb-core/src/agent/memory_helpers.rs
+++ b/crates/velesdb-core/src/agent/memory_helpers.rs
@@ -209,10 +209,16 @@ pub(super) fn search_filtered(
 ) -> Result<Vec<crate::SearchResult>, AgentMemoryError> {
     validate_dimension(dimension, query_embedding.len())?;
     let collection = get_collection(db, collection_name)?;
-    let results = search_collection(&collection, query_embedding, k)?;
+    // Over-fetch so that expired-but-not-yet-deleted points evicted by the
+    // post-search TTL filter do not shrink the result set below `k`. Expired
+    // ids occupy at most `expired_count` of the top-k slots, so fetching
+    // `k + expired_count` and then filtering guarantees up to `k` live results.
+    let fetch_k = k.saturating_add(ttl.expired_count());
+    let results = search_collection(&collection, query_embedding, fetch_k)?;
     Ok(results
         .into_iter()
         .filter(|r| !ttl.is_expired(r.point.id))
+        .take(k)
         .collect())
 }
 

--- a/crates/velesdb-core/src/agent/semantic_memory.rs
+++ b/crates/velesdb-core/src/agent/semantic_memory.rs
@@ -85,6 +85,12 @@ impl SemanticMemory {
 
     /// Stores a semantic memory point and assigns a TTL.
     ///
+    /// A `ttl_seconds` of `0` means "expire immediately": rather than persisting
+    /// a live point that then occupies an index slot until the next
+    /// `auto_expire`, the point is eagerly removed (and any pre-existing point
+    /// for `id` deleted). The embedding is still dimension-validated so callers
+    /// get the same error contract as a real store.
+    ///
     /// # Errors
     ///
     /// Returns the same errors as [`Self::store`].
@@ -95,6 +101,10 @@ impl SemanticMemory {
         embedding: &[f32],
         ttl_seconds: u64,
     ) -> Result<(), AgentMemoryError> {
+        if ttl_seconds == 0 {
+            memory_helpers::validate_dimension(self.dimension, embedding.len())?;
+            return self.delete(id);
+        }
         self.store(id, content, embedding)?;
         self.ttl.set_ttl(id, ttl_seconds);
         Ok(())
@@ -123,17 +133,106 @@ impl SemanticMemory {
         Ok(results
             .into_iter()
             .map(|r| {
-                let content = r
-                    .point
-                    .payload
-                    .as_ref()
-                    .and_then(|p| p.get("content"))
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("")
-                    .to_string();
+                let content = extract_content(&r.point);
                 (r.point.id, r.score, content)
             })
             .collect())
+    }
+
+    /// Stores multiple semantic memory points in one batch.
+    ///
+    /// Each tuple is `(id, content, embedding)`. All embeddings are
+    /// dimension-validated before any write occurs.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when any embedding dimension is invalid, collection
+    /// access fails, or persistence fails.
+    pub fn store_batch(&self, facts: &[(u64, &str, &[f32])]) -> Result<(), AgentMemoryError> {
+        let mut points = Vec::with_capacity(facts.len());
+        for (id, content, embedding) in facts {
+            memory_helpers::validate_dimension(self.dimension, embedding.len())?;
+            points.push(Point::new(
+                *id,
+                embedding.to_vec(),
+                Some(json!({ "content": content })),
+            ));
+        }
+
+        let collection = memory_helpers::get_collection(&self.db, &self.collection_name)?;
+        memory_helpers::upsert_points(&collection, points)?;
+
+        let mut ids = self.stored_ids.write();
+        for (id, _, _) in facts {
+            ids.insert(*id);
+        }
+        Ok(())
+    }
+
+    /// Retrieves a fact's content and embedding by id.
+    ///
+    /// Returns `None` when the id is unknown or has expired.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when collection access fails.
+    pub fn get(&self, id: u64) -> Result<Option<(String, Vec<f32>)>, AgentMemoryError> {
+        if self.ttl.is_expired(id) {
+            return Ok(None);
+        }
+        let collection = memory_helpers::get_collection(&self.db, &self.collection_name)?;
+        let Some(point) = collection.get(&[id]).into_iter().flatten().next() else {
+            return Ok(None);
+        };
+        Ok(Some((extract_content(&point), point.vector.clone())))
+    }
+
+    /// Lists all live (non-expired) tracked facts as `(id, content)` pairs.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when collection access fails.
+    pub fn list_all(&self) -> Result<Vec<(u64, String)>, AgentMemoryError> {
+        let collection = memory_helpers::get_collection(&self.db, &self.collection_name)?;
+        let all_ids: Vec<u64> = self.stored_ids.read().iter().copied().collect();
+
+        Ok(collection
+            .get(&all_ids)
+            .into_iter()
+            .flatten()
+            .filter(|p| !self.ttl.is_expired(p.id))
+            .map(|p| (p.id, extract_content(&p)))
+            .collect())
+    }
+
+    /// Returns the number of tracked facts.
+    #[must_use]
+    pub fn count(&self) -> usize {
+        self.stored_ids.read().len()
+    }
+
+    /// Returns `true` when no facts are tracked.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.stored_ids.read().is_empty()
+    }
+
+    /// Removes all facts and their tracking entries.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when collection access or deletion fails.
+    pub fn clear(&self) -> Result<(), AgentMemoryError> {
+        let collection = memory_helpers::get_collection(&self.db, &self.collection_name)?;
+        let ids: Vec<u64> = self.stored_ids.read().iter().copied().collect();
+        if !ids.is_empty() {
+            memory_helpers::delete_from_collection(&collection, &ids)?;
+        }
+        for id in &ids {
+            self.ttl.remove(*id);
+        }
+        self.stored_ids.write().clear();
+        Ok(())
     }
 
     /// Deletes a semantic memory point by id.
@@ -152,6 +251,18 @@ impl SemanticMemory {
     }
 
     /// Serializes semantic memory points for snapshot persistence.
+    ///
+    /// # TTL limitation
+    ///
+    /// The returned bytes contain only the stored points (id, embedding,
+    /// content) and intentionally **omit TTL state**. TTL is tracked in a single
+    /// `MemoryTtl` map shared across the semantic, episodic, and procedural
+    /// subsystems (see [`AgentMemory`](crate::agent::AgentMemory)), so it cannot
+    /// be partitioned per subsystem here. TTL is persisted and restored globally
+    /// by [`AgentMemory::snapshot`](crate::agent::AgentMemory::snapshot) /
+    /// `restore_state`. Calling [`Self::deserialize`] in isolation therefore
+    /// restores facts but not their expiry; use the snapshot manager for a full
+    /// round-trip including TTL.
     ///
     /// # Errors
     ///
@@ -174,4 +285,15 @@ impl SemanticMemory {
             &self.stored_ids,
         )
     }
+}
+
+/// Extracts the `content` string from a point's payload, or `""` when absent.
+fn extract_content(point: &Point) -> String {
+    point
+        .payload
+        .as_ref()
+        .and_then(|p| p.get("content"))
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("")
+        .to_string()
 }

--- a/crates/velesdb-core/src/agent/semantic_memory.rs
+++ b/crates/velesdb-core/src/agent/semantic_memory.rs
@@ -144,6 +144,11 @@ impl SemanticMemory {
     /// Each tuple is `(id, content, embedding)`. All embeddings are
     /// dimension-validated before any write occurs.
     ///
+    /// This is best-effort, not transactional: if `upsert_points` fails partway
+    /// the already-persisted points are kept and `stored_ids` is left untouched
+    /// (it is only updated after a fully successful upsert), matching the
+    /// single-`store` behaviour.
+    ///
     /// # Errors
     ///
     /// Returns an error when any embedding dimension is invalid, collection

--- a/crates/velesdb-core/src/agent/semantic_memory_tests.rs
+++ b/crates/velesdb-core/src/agent/semantic_memory_tests.rs
@@ -204,4 +204,278 @@ mod tests {
         let results = sm.query(&emb, 5).unwrap();
         assert_eq!(results.len(), 1);
     }
+
+    // ── #1040: expired top-k point must not shrink results below k ──────────────
+
+    #[test]
+    fn test_expired_topk_point_freed_slot_filled_by_live_point() {
+        let dir = tempdir().unwrap();
+        let db = Arc::new(Database::open(dir.path()).unwrap());
+        // Shared TTL so we can mark an already-persisted live point as expired
+        // without physically deleting it (the bug shape: expired-but-present).
+        let ttl = Arc::new(MemoryTtl::new());
+        let sm = SemanticMemory::new(Arc::clone(&db), 4, Arc::clone(&ttl)).unwrap();
+
+        let q = vec![1.0_f32, 0.0, 0.0, 0.0];
+        let near = vec![0.99_f32, 0.14, 0.0, 0.0];
+        // id=1 is the absolute best match and physically present, but expired.
+        sm.store(1, "expired best match", &q).unwrap();
+        ttl.set_ttl(1, 0); // expires immediately, point still persisted
+        sm.store(2, "live runner up", &near).unwrap();
+
+        // Asking for k=1 must still return the live point, not an empty result.
+        let results = sm.query(&q, 1).unwrap();
+        assert_eq!(
+            results.len(),
+            1,
+            "live point must fill the slot freed by the expired top-k point"
+        );
+        assert_eq!(results[0].0, 2);
+    }
+
+    // ── #1043(a): TTL-bearing serialize roundtrip ───────────────────────────────
+
+    #[test]
+    fn test_serialize_omits_ttl_facts_survive_roundtrip() {
+        let dir1 = tempdir().unwrap();
+        let db1 = Arc::new(Database::open(dir1.path()).unwrap());
+        let ttl = Arc::new(MemoryTtl::new());
+        let sm1 = SemanticMemory::new(Arc::clone(&db1), 4, Arc::clone(&ttl)).unwrap();
+
+        let emb = vec![1.0_f32, 0.0, 0.0, 0.0];
+        sm1.store_with_ttl(10, "fact with ttl", &emb, 9_999)
+            .unwrap();
+        assert!(ttl.get(10).is_some(), "TTL entry tracked before serialize");
+
+        let bytes = sm1.serialize().unwrap();
+
+        // Restore into a fresh subsystem with an independent TTL map.
+        let dir2 = tempdir().unwrap();
+        let db2 = Arc::new(Database::open(dir2.path()).unwrap());
+        let ttl2 = Arc::new(MemoryTtl::new());
+        let sm2 = SemanticMemory::new(Arc::clone(&db2), 4, Arc::clone(&ttl2)).unwrap();
+        sm2.deserialize(&bytes).unwrap();
+
+        // The fact survives the per-subsystem roundtrip.
+        let results = sm2.query(&emb, 5).unwrap();
+        assert!(results.iter().any(|r| r.0 == 10));
+        // Documented limitation: TTL is NOT carried by per-subsystem serialize.
+        assert!(
+            ttl2.get(10).is_none(),
+            "per-subsystem serialize intentionally omits TTL state"
+        );
+    }
+
+    // ── #1043(b): ttl=0 physical removal ────────────────────────────────────────
+
+    #[test]
+    fn test_store_with_ttl_zero_does_not_persist_point() {
+        let dir = tempdir().unwrap();
+        let db = Arc::new(Database::open(dir.path()).unwrap());
+        let sm = make_semantic(Arc::clone(&db));
+
+        let emb = vec![1.0_f32, 0.0, 0.0, 0.0];
+        sm.store_with_ttl(7, "ephemeral", &emb, 0).unwrap();
+
+        // Not tracked and not physically present.
+        assert_eq!(sm.count(), 0);
+        assert!(sm.get(7).unwrap().is_none());
+    }
+
+    #[test]
+    fn test_store_with_ttl_zero_evicts_preexisting_point() {
+        let dir = tempdir().unwrap();
+        let db = Arc::new(Database::open(dir.path()).unwrap());
+        let sm = make_semantic(Arc::clone(&db));
+
+        let emb = vec![1.0_f32, 0.0, 0.0, 0.0];
+        sm.store(7, "live", &emb).unwrap();
+        assert_eq!(sm.count(), 1);
+
+        // ttl=0 over an existing id removes it physically.
+        sm.store_with_ttl(7, "replace-then-expire", &emb, 0)
+            .unwrap();
+        assert_eq!(sm.count(), 0);
+        assert!(sm.get(7).unwrap().is_none());
+    }
+
+    #[test]
+    fn test_store_with_ttl_zero_dimension_mismatch_rejected() {
+        let dir = tempdir().unwrap();
+        let db = Arc::new(Database::open(dir.path()).unwrap());
+        let sm = make_semantic(Arc::clone(&db));
+
+        let bad = vec![1.0_f32]; // dim = 1, expected 4
+        assert!(sm.store_with_ttl(1, "bad", &bad, 0).is_err());
+    }
+
+    // ── #1044: list_all / get / count / is_empty / clear / store_batch ──────────
+
+    #[test]
+    fn test_count_and_is_empty() {
+        let dir = tempdir().unwrap();
+        let db = Arc::new(Database::open(dir.path()).unwrap());
+        let sm = make_semantic(Arc::clone(&db));
+        assert!(sm.is_empty());
+        assert_eq!(sm.count(), 0);
+
+        sm.store(1, "a", &[1.0, 0.0, 0.0, 0.0]).unwrap();
+        assert!(!sm.is_empty());
+        assert_eq!(sm.count(), 1);
+    }
+
+    #[test]
+    fn test_get_returns_content_and_embedding() {
+        let dir = tempdir().unwrap();
+        let db = Arc::new(Database::open(dir.path()).unwrap());
+        let sm = make_semantic(Arc::clone(&db));
+
+        let emb = vec![0.0_f32, 1.0, 0.0, 0.0];
+        sm.store(3, "hello", &emb).unwrap();
+
+        let (content, vector) = sm.get(3).unwrap().expect("fact present");
+        assert_eq!(content, "hello");
+        assert_eq!(vector, emb);
+        assert!(sm.get(404).unwrap().is_none());
+    }
+
+    #[test]
+    fn test_list_all_returns_live_facts() {
+        let dir = tempdir().unwrap();
+        let db = Arc::new(Database::open(dir.path()).unwrap());
+        let sm = make_semantic(Arc::clone(&db));
+
+        sm.store(1, "first", &[1.0, 0.0, 0.0, 0.0]).unwrap();
+        sm.store(2, "second", &[0.0, 1.0, 0.0, 0.0]).unwrap();
+
+        let mut listed = sm.list_all().unwrap();
+        listed.sort_by_key(|(id, _)| *id);
+        assert_eq!(
+            listed,
+            vec![(1, "first".to_string()), (2, "second".to_string())]
+        );
+    }
+
+    #[test]
+    fn test_clear_removes_all_facts() {
+        let dir = tempdir().unwrap();
+        let db = Arc::new(Database::open(dir.path()).unwrap());
+        let sm = make_semantic(Arc::clone(&db));
+
+        sm.store(1, "a", &[1.0, 0.0, 0.0, 0.0]).unwrap();
+        sm.store(2, "b", &[0.0, 1.0, 0.0, 0.0]).unwrap();
+        sm.clear().unwrap();
+
+        assert!(sm.is_empty());
+        assert!(sm.list_all().unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_store_batch_inserts_all() {
+        let dir = tempdir().unwrap();
+        let db = Arc::new(Database::open(dir.path()).unwrap());
+        let sm = make_semantic(Arc::clone(&db));
+
+        let e1 = vec![1.0_f32, 0.0, 0.0, 0.0];
+        let e2 = vec![0.0_f32, 1.0, 0.0, 0.0];
+        let facts: Vec<(u64, &str, &[f32])> =
+            vec![(1, "one", e1.as_slice()), (2, "two", e2.as_slice())];
+        sm.store_batch(&facts).unwrap();
+
+        assert_eq!(sm.count(), 2);
+        assert_eq!(sm.get(1).unwrap().unwrap().0, "one");
+        assert_eq!(sm.get(2).unwrap().unwrap().0, "two");
+    }
+
+    #[test]
+    fn test_store_batch_rejects_dimension_mismatch() {
+        let dir = tempdir().unwrap();
+        let db = Arc::new(Database::open(dir.path()).unwrap());
+        let sm = make_semantic(Arc::clone(&db));
+
+        let good = vec![1.0_f32, 0.0, 0.0, 0.0];
+        let bad = vec![1.0_f32]; // wrong dim
+        let facts: Vec<(u64, &str, &[f32])> =
+            vec![(1, "ok", good.as_slice()), (2, "bad", bad.as_slice())];
+        assert!(sm.store_batch(&facts).is_err());
+    }
+
+    // ── #1049: edge-case / robustness tests ─────────────────────────────────────
+
+    #[test]
+    fn test_delete_unknown_id_is_ok() {
+        let dir = tempdir().unwrap();
+        let db = Arc::new(Database::open(dir.path()).unwrap());
+        let sm = make_semantic(Arc::clone(&db));
+        assert!(sm.delete(12345).is_ok());
+    }
+
+    #[test]
+    fn test_deserialize_malformed_bytes_errors() {
+        let dir = tempdir().unwrap();
+        let db = Arc::new(Database::open(dir.path()).unwrap());
+        let sm = make_semantic(Arc::clone(&db));
+
+        // Non-empty, not valid JSON for Vec<Point>.
+        let garbage = vec![0xFF_u8, 0x00, 0x42, 0x13];
+        assert!(sm.deserialize(&garbage).is_err());
+    }
+
+    #[test]
+    fn test_deserialize_replaces_not_merges() {
+        let dir1 = tempdir().unwrap();
+        let db1 = Arc::new(Database::open(dir1.path()).unwrap());
+        let sm1 = make_semantic(Arc::clone(&db1));
+        sm1.store(10, "snapshot fact", &[1.0, 0.0, 0.0, 0.0])
+            .unwrap();
+        let bytes = sm1.serialize().unwrap();
+
+        let dir2 = tempdir().unwrap();
+        let db2 = Arc::new(Database::open(dir2.path()).unwrap());
+        let sm2 = make_semantic(Arc::clone(&db2));
+        // Pre-existing fact that must NOT survive the deserialize.
+        sm2.store(99, "preexisting fact", &[0.0, 1.0, 0.0, 0.0])
+            .unwrap();
+
+        sm2.deserialize(&bytes).unwrap();
+
+        let ids: Vec<u64> = sm2
+            .list_all()
+            .unwrap()
+            .into_iter()
+            .map(|(id, _)| id)
+            .collect();
+        assert_eq!(ids, vec![10], "deserialize must replace, not merge");
+    }
+
+    #[test]
+    fn test_concurrent_store_query_delete() {
+        use std::thread;
+
+        let dir = tempdir().unwrap();
+        let db = Arc::new(Database::open(dir.path()).unwrap());
+        let sm = Arc::new(make_semantic(Arc::clone(&db)));
+
+        let mut handles = Vec::new();
+        for t in 0..4u64 {
+            let sm = Arc::clone(&sm);
+            handles.push(thread::spawn(move || {
+                let emb = vec![1.0_f32, 0.0, 0.0, 0.0];
+                for i in 0..25u64 {
+                    let id = t * 100 + i;
+                    sm.store(id, "c", &emb).unwrap();
+                    let _ = sm.query(&emb, 3).unwrap();
+                    if i % 2 == 0 {
+                        sm.delete(id).unwrap();
+                    }
+                }
+            }));
+        }
+        for h in handles {
+            h.join().expect("worker thread panicked");
+        }
+
+        // Half of each thread's writes were deleted: 4 threads * 12 survivors.
+        assert_eq!(sm.count(), 4 * 12);
+    }
 }

--- a/crates/velesdb-core/src/agent/ttl.rs
+++ b/crates/velesdb-core/src/agent/ttl.rs
@@ -69,17 +69,6 @@ impl MemoryTtl {
         self.entries.write().insert(id, entry);
     }
 
-    /// Sets a TTL with a specific creation timestamp.
-    ///
-    /// Useful for entries that were created in the past.
-    pub fn set_ttl_with_created_at(&self, id: u64, ttl_seconds: u64, created_at: u64) {
-        let entry = TtlEntry {
-            expires_at: created_at.saturating_add(ttl_seconds),
-            created_at,
-        };
-        self.entries.write().insert(id, entry);
-    }
-
     /// Removes TTL tracking for an entry.
     pub fn remove(&self, id: u64) {
         self.entries.write().remove(&id);
@@ -97,20 +86,14 @@ impl MemoryTtl {
             .collect()
     }
 
-    /// Returns IDs of entries older than the specified age.
+    /// Returns the number of currently-expired tracked entries.
     ///
-    /// # Arguments
-    ///
-    /// * `max_age_seconds` - Maximum age in seconds
+    /// Used by the search path to over-fetch enough candidates so that
+    /// filtering out expired-but-not-yet-deleted points still yields up to `k`
+    /// live results.
     #[must_use]
-    pub fn get_older_than(&self, max_age_seconds: u64) -> Vec<u64> {
-        let cutoff = Self::now().saturating_sub(max_age_seconds);
-        self.entries
-            .read()
-            .iter()
-            .filter(|(_, entry)| entry.created_at < cutoff)
-            .map(|(&id, _)| id)
-            .collect()
+    pub fn expired_count(&self) -> usize {
+        self.get_expired().len()
     }
 
     /// Removes expired entries from tracking and returns their IDs.
@@ -161,15 +144,6 @@ impl MemoryTtl {
     /// Clears all TTL entries.
     pub fn clear(&self) {
         self.entries.write().clear();
-    }
-
-    /// Merges entries from another `MemoryTtl` instance.
-    pub fn merge_from(&self, other: &MemoryTtl) {
-        let other_entries = other.entries.read();
-        let mut self_entries = self.entries.write();
-        for (&id, entry) in other_entries.iter() {
-            self_entries.insert(id, entry.clone());
-        }
     }
 
     /// Replaces all entries with those from another `MemoryTtl` instance.

--- a/crates/velesdb-core/src/agent/ttl.rs
+++ b/crates/velesdb-core/src/agent/ttl.rs
@@ -93,7 +93,12 @@ impl MemoryTtl {
     /// live results.
     #[must_use]
     pub fn expired_count(&self) -> usize {
-        self.get_expired().len()
+        let now = Self::now();
+        self.entries
+            .read()
+            .values()
+            .filter(|entry| entry.expires_at <= now)
+            .count()
     }
 
     /// Removes expired entries from tracking and returns their IDs.

--- a/crates/velesdb-core/src/agent/ttl_tests.rs
+++ b/crates/velesdb-core/src/agent/ttl_tests.rs
@@ -74,20 +74,6 @@ mod tests {
     }
 
     #[test]
-    fn test_memory_ttl_merge_from() {
-        let ttl1 = MemoryTtl::new();
-        ttl1.set_ttl(1, 3600);
-
-        let ttl2 = MemoryTtl::new();
-        ttl2.set_ttl(2, 7200);
-
-        ttl1.merge_from(&ttl2);
-
-        assert!(ttl1.get(1).is_some());
-        assert!(ttl1.get(2).is_some());
-    }
-
-    #[test]
     fn test_memory_ttl_replace_from() {
         let ttl1 = MemoryTtl::new();
         ttl1.set_ttl(1, 3600);

--- a/crates/velesdb-core/src/agent/ttl_tests.rs
+++ b/crates/velesdb-core/src/agent/ttl_tests.rs
@@ -40,6 +40,18 @@ mod tests {
     }
 
     #[test]
+    fn test_memory_ttl_expired_count() {
+        let ttl = MemoryTtl::new();
+        ttl.set_ttl(1, 0);
+        ttl.set_ttl(2, 0);
+        ttl.set_ttl(3, 3600);
+
+        std::thread::sleep(std::time::Duration::from_millis(10));
+        assert_eq!(ttl.expired_count(), 2);
+        assert_eq!(ttl.expired_count(), ttl.get_expired().len());
+    }
+
+    #[test]
     fn test_memory_ttl_expire() {
         let ttl = MemoryTtl::new();
         ttl.set_ttl(1, 0);


### PR DESCRIPTION
- #1040: TTL filter applied before top-k truncation (over-fetch by expired_count) so live results are not dropped.
- #1043: per-subsystem serialize TTL semantics documented + tested; `store_with_ttl(..,0)` eager-deletes instead of shadow-persisting; `auto_expire` no longer drops the TTL entry on a failed delete.
- #1044 (partial): adds `list_all`/`get`/`count`/`is_empty`/`clear`/`store_batch` with tests. Metadata/tags + filtered query remain.
- #1049: tests for unknown-id delete, malformed deserialize, replace-not-merge, concurrency; removes dead MemoryTtl methods.

clippy pedantic clean, 161 agent tests pass.

Closes #1040, #1043, #1049