### PR TITLE
fix(sdk-ts): make procedural memory recallable + agent-memory DX and docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **BREAKING (TypeScript SDK) — `ProceduralPattern.embedding` is now required
+  (#1039)**: procedural patterns were stored without a vector, so procedural
+  recall (a pure vector search) could never return them. Patterns now persist
+  their `embedding` as the point vector and the field is required on the
+  `ProceduralPattern` type. Migration: pass your model's embedding when learning
+  a procedure, exactly as you already do for semantic and episodic memory.
+
 ## [1.17.0] — 2026-06-05
 
 ### Added

--- a/docs/guides/AGENT_MEMORY.md
+++ b/docs/guides/AGENT_MEMORY.md
@@ -21,7 +21,8 @@ Complete guide for using VelesDB's Agent Memory SDK. Covers the three memory sub
 11. [Performance & Limits](#performance--limits)
 12. [Thread Safety & Concurrency](#thread-safety--concurrency)
 13. [Rust API](#rust-api)
-14. [FAQ](#faq)
+14. [TypeScript / JavaScript (REST)](#typescript--javascript-rest)
+15. [FAQ](#faq)
 
 ---
 
@@ -83,7 +84,7 @@ memory.episodic     # -> EpisodicMemory
 memory.procedural   # -> ProceduralMemory
 ```
 
-> **Note**: `AgentMemory` works in **embedded mode** (same process). It is not accessible via the VelesDB REST API server.
+> **Note**: The **Python and Rust** `AgentMemory` runs in **embedded mode** (same process), shown above. The **TypeScript/JavaScript SDK** accesses agent memory **over REST** against a running `velesdb-server` instead — see [TypeScript / JavaScript (REST)](#typescript--javascript-rest) below. The two share the same three memory subsystems but differ in transport.
 
 ### File Structure Created
 
@@ -673,30 +674,93 @@ memory.load_latest_snapshot()?;
 
 ### API Availability by Binding
 
-| Method | Python | Rust |
-|--------|--------|------|
-| `semantic.store()` | Yes | Yes |
-| `semantic.query()` | Yes | Yes |
-| `semantic.delete()` | Yes | Yes |
-| `episodic.record()` | Yes | Yes |
-| `episodic.recent()` | Yes | Yes |
-| `episodic.recall_similar()` | Yes | Yes |
-| `episodic.older_than()` | Yes | Yes |
-| `episodic.delete()` | Yes | Yes |
-| `procedural.learn()` | Yes | Yes |
-| `procedural.recall()` | Yes | Yes |
-| `procedural.reinforce()` | Yes | Yes |
-| `procedural.list_all()` | Yes | Yes |
-| `procedural.delete()` | Yes | Yes |
-| TTL management | No | Yes |
-| Snapshots | No | Yes |
+The **Python** and **Rust** bindings run embedded; the **TypeScript** SDK is
+REST-backed (`db.agentMemory(...)`, methods named `storeFact` / `searchFacts` /
+`recordEvent` / `recallEvents` / `learnProcedure` / `recallProcedures` /
+`deleteMemory`). The TS facade covers vector store + similarity recall over the
+three subsystems; temporal/confidence-only queries, reinforcement, TTL, and
+snapshots are embedded-only.
+
+| Method | Python | Rust | TypeScript (REST) |
+|--------|--------|------|-------------------|
+| `semantic.store()` | Yes | Yes | Yes (`storeFact`) |
+| `semantic.query()` | Yes | Yes | Yes (`searchFacts`) |
+| `semantic.delete()` | Yes | Yes | Yes (`deleteMemory`) |
+| `episodic.record()` | Yes | Yes | Yes (`recordEvent`, returns id) |
+| `episodic.recent()` | Yes | Yes | No (no temporal query) |
+| `episodic.recall_similar()` | Yes | Yes | Yes (`recallEvents`) |
+| `episodic.older_than()` | Yes | Yes | No |
+| `episodic.delete()` | Yes | Yes | Yes (`deleteMemory`) |
+| `procedural.learn()` | Yes | Yes | Yes (`learnProcedure`, returns id) |
+| `procedural.recall()` | Yes | Yes | Yes (`recallProcedures`) |
+| `procedural.reinforce()` | Yes | Yes | No |
+| `procedural.list_all()` | Yes | Yes | No |
+| `procedural.delete()` | Yes | Yes | Yes (`deleteMemory`) |
+| TTL management | No | Yes | No |
+| Snapshots | No | Yes | No |
+
+---
+
+## TypeScript / JavaScript (REST)
+
+The TypeScript/JavaScript SDK (`@wiscale/velesdb-sdk`) accesses agent memory
+**over REST** against a running `velesdb-server`. There is no embedded engine in
+JS; the three memory subsystems are stored as filtered points in regular
+collections you create yourself.
+
+```typescript
+import { VelesDB } from '@wiscale/velesdb-sdk';
+
+const db = new VelesDB({ backend: 'rest', url: 'http://localhost:8080' });
+await db.init();
+
+// Create the backing collection FIRST — the facade does not auto-create it.
+// The dimension must match your embedding model; cosine is typical.
+await db.createCollection('knowledge', { dimension: 384, metric: 'cosine' });
+
+const memory = db.agentMemory({ dimension: 384 });
+
+// Store / recall (embeddings are caller-supplied — no auto-embed)
+await memory.storeFact('knowledge', { id: 1, text: 'fact', embedding });
+const facts = await memory.searchFacts('knowledge', queryEmbedding, 5);
+
+// record/learn return the generated point id
+const eventId = await memory.recordEvent('events', {
+  eventType: 'user_query', data: {}, embedding,
+});
+const procId = await memory.learnProcedure('procedures', {
+  name: 'deploy', steps: ['build', 'push'], embedding,
+});
+
+// delete works for any memory type
+await memory.deleteMemory('procedures', procId);
+```
+
+Each recall returns `SearchResult[]` = `{ id, score, payload?, vector? }`:
+
+- **`score`** is cosine similarity in `[0, 1]` for a `cosine` collection;
+  higher is more similar.
+- **Embeddings are caller-supplied** — no auto-embedding; each `embedding`
+  length must equal the collection dimension.
+- **`procedural.learn()` requires an embedding** in the TS SDK so the pattern is
+  recallable by similarity search.
+- The **`dimension`** passed to `db.agentMemory({ dimension })` is advisory
+  (readable via `memory.dimension`); the collection's own dimension governs
+  storage and search.
+- **TTL and snapshots are not exposed over REST** — they are embedded-only
+  (Rust). When used, TTL durations are in **seconds**.
+
+> **Standalone `SemanticMemory`.** If you use a standalone in-memory
+> `SemanticMemory` (without a backing `Database`), it has **no auto-snapshot and
+> no auto-load**, and any TTL is enforced **in memory only** — entries are not
+> persisted and expiry state is lost on restart.
 
 ---
 
 ## FAQ
 
 **Q: Does the SDK work via the REST API?**
-No. Agent Memory is an embedded SDK -- it runs in your process. The underlying collections (`_semantic_memory`, etc.) are visible on disk but not exposed via REST endpoints.
+It depends on the binding. The **Python and Rust** Agent Memory runs **embedded** in your process — the underlying embedded collections (`_semantic_memory`, etc.) are visible on disk but are not the REST surface. The **TypeScript/JavaScript** SDK is **REST-only**: it accesses agent memory over HTTP against a running `velesdb-server`, storing each memory type as filtered points in a collection you create yourself. See [TypeScript / JavaScript (REST)](#typescript--javascript-rest).
 
 **Q: Can I change the dimension after creation?**
 No. The dimension is fixed when the collection is created. If you switch embedding models, create a new database.
@@ -711,7 +775,7 @@ Yes. VelesDB uses a Write-Ahead Log (WAL) with fsync. Data is durable as soon as
 Yes. Multiple `AgentMemory` instances on the same `Database` share the same collections. Useful for multi-threading.
 
 **Q: Does the SDK work in WASM or on mobile?**
-Not currently. The SDK requires the `persistence` feature (mmap, filesystem), which is disabled for WASM. Mobile support is possible via native bindings but not yet documented.
+The **embedded** SDK (Python/Rust) requires the `persistence` feature (mmap, filesystem), which is disabled for WASM, so embedded agent memory does not run in-browser. The browser/WASM build of the TypeScript SDK does not support agent memory either (`capabilities().agentMemory` is `false` for the WASM backend). To use agent memory from JavaScript, point the SDK at a `velesdb-server` over **REST** (`backend: 'rest'`). Mobile support is possible via native bindings but not yet documented.
 
 **Q: How do I migrate from another memory system?**
 Export your data (text + embeddings) and import via `semantic.store()` / `episodic.record()` / `procedural.learn()`. There is no automated migration tool.

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -772,7 +772,21 @@ const result = await db.trainPq('embeddings', {
 
 ### Agent Memory API
 
-The Agent Memory API provides three memory types for AI agents, built on top of VelesDB's vector and graph storage.
+The Agent Memory API provides three memory types for AI agents, built on top of
+VelesDB's vector storage. In the TypeScript/JavaScript SDK it is accessed **over
+REST** against a running `velesdb-server` (the Python and Rust bindings use the
+embedded engine instead).
+
+> **You must create the collection first.** The TS facade does **not**
+> auto-create a collection for you. Create it with the dimension that matches
+> your embedding model and the metric you want (`'cosine'` is the usual choice
+> for normalized text embeddings), then call `storeFact` / `recordEvent` /
+> `learnProcedure` against that same collection name.
+
+> **Embeddings are caller-supplied.** There is no auto-embedding: every
+> `embedding` you pass must come from your own embedding model (see
+> [Embedding helper](#embedding-helper)) and its length must equal the
+> collection dimension.
 
 ```typescript
 import { VelesDB } from '@wiscale/velesdb-sdk';
@@ -780,13 +794,39 @@ import { VelesDB } from '@wiscale/velesdb-sdk';
 const db = new VelesDB({ backend: 'rest', url: 'http://localhost:8080' });
 await db.init();
 
+// 1. Create the backing collection FIRST (nothing auto-creates it).
+//    The dimension must match your embedding model; cosine is typical.
+await db.createCollection('knowledge', { dimension: 384, metric: 'cosine' });
+
+// 2. Open the agent-memory facade.
 const memory = db.agentMemory({ dimension: 384 });
+
+// 3. Store and recall (embedding is your own model's output, length 384).
+await memory.storeFact('knowledge', {
+  id: 1,
+  text: 'VelesDB uses HNSW for vector indexing',
+  embedding: factEmbedding,
+});
+const facts = await memory.searchFacts('knowledge', queryEmbedding, 5);
 ```
+
+Each recall method returns `SearchResult[]`:
+
+```typescript
+// SearchResult = { id: number; score: number; payload?: Record<string, unknown>; vector?: number[] }
+```
+
+- `score` is the cosine similarity in `[0, 1]` (for a `cosine` collection);
+  higher means more similar.
+- `payload` carries the stored fields (`text`, `event_type`, `name`, `steps`,
+  plus your metadata). The reserved keys `_memory_type` / `text` /
+  `event_type` / `timestamp` / `name` / `steps` always take precedence over
+  caller `metadata`/`data` of the same name, so they cannot be clobbered.
 
 #### Semantic Memory (facts and knowledge)
 
 ```typescript
-// Store a fact
+// Store a fact (id is caller-assigned; reusing an id upserts)
 await memory.storeFact('knowledge', {
   id: 1,
   text: 'VelesDB uses HNSW for vector indexing',
@@ -801,12 +841,11 @@ const facts = await memory.searchFacts('knowledge', queryEmbedding, 5);
 #### Episodic Memory (events and experiences)
 
 ```typescript
-// Record an event
-await memory.recordEvent('events', {
+// Record an event — returns the generated point id
+const eventId = await memory.recordEvent('events', {
   eventType: 'user_query',
   data: { query: 'How does HNSW work?', response: '...' },
   embedding: eventEmbedding,
-  metadata: { timestamp: Date.now() }
 });
 
 // Recall similar events
@@ -816,16 +855,34 @@ const events = await memory.recallEvents('events', queryEmbedding, 5);
 #### Procedural Memory (learned patterns)
 
 ```typescript
-// Store a procedure
-await memory.learnProcedure('procedures', {
+// Store a procedure — embedding is required so the pattern is recallable,
+// and the generated point id is returned
+const procId = await memory.learnProcedure('procedures', {
   name: 'deploy-to-prod',
   steps: ['Run tests', 'Build artifacts', 'Push to registry', 'Deploy'],
+  embedding: procedureEmbedding,
   metadata: { lastUsed: Date.now() }
 });
 
 // Find matching procedures
 const procs = await memory.recallProcedures('procedures', queryEmbedding, 3);
 ```
+
+#### Deleting memories
+
+```typescript
+// Works for facts, events, and procedures — returns true if a point was removed
+await memory.deleteMemory('procedures', procId);
+```
+
+> **`dimension` is advisory.** `db.agentMemory({ dimension })` records a hint you
+> can read back via `memory.dimension`, but it does **not** create or size any
+> collection — the collection's own dimension (set at `createCollection`)
+> governs storage and search, and your embeddings must match it.
+
+> **TTL & snapshots.** Per-entry TTL (in **seconds**) and versioned snapshots are
+> exposed by the embedded Rust API only; the REST-backed TypeScript facade does
+> not surface them. See the [Agent Memory guide](../../docs/guides/AGENT_MEMORY.md).
 
 ---
 

--- a/sdks/typescript/src/agent-memory.ts
+++ b/sdks/typescript/src/agent-memory.ts
@@ -23,7 +23,16 @@ export class AgentMemoryClient {
     private readonly config?: AgentMemoryConfig
   ) {}
 
-  /** Configured embedding dimension (default: 384) */
+  /**
+   * Advisory embedding dimension passed at construction (default: 384).
+   *
+   * This value is **not** enforced and does not create or size any
+   * collection — the dimension that actually governs storage and search
+   * is the one fixed when the collection was created
+   * (`db.createCollection(name, { dimension, metric: 'cosine' })`).
+   * Embeddings you pass to `storeFact` / `recordEvent` / `learnProcedure`
+   * must match that collection dimension.
+   */
   get dimension(): number {
     return this.config?.dimension ?? 384;
   }
@@ -38,8 +47,8 @@ export class AgentMemoryClient {
     return this.backend.searchSemanticMemory(collection, embedding, k);
   }
 
-  /** Record an episodic event */
-  async recordEvent(collection: string, event: EpisodicEvent): Promise<void> {
+  /** Record an episodic event. Returns the generated point ID. */
+  async recordEvent(collection: string, event: EpisodicEvent): Promise<number> {
     return this.backend.recordEpisodicEvent(collection, event);
   }
 
@@ -48,13 +57,18 @@ export class AgentMemoryClient {
     return this.backend.recallEpisodicEvents(collection, embedding, k);
   }
 
-  /** Store a procedural pattern */
-  async learnProcedure(collection: string, pattern: ProceduralPattern): Promise<void> {
+  /** Store a procedural pattern. Returns the generated point ID. */
+  async learnProcedure(collection: string, pattern: ProceduralPattern): Promise<number> {
     return this.backend.storeProceduralPattern(collection, pattern);
   }
 
   /** Match procedural patterns */
   async recallProcedures(collection: string, embedding: number[], k = 5): Promise<SearchResult[]> {
     return this.backend.matchProceduralPatterns(collection, embedding, k);
+  }
+
+  /** Delete a memory entry (fact, event, or procedure) by its point ID. */
+  async deleteMemory(collection: string, id: number): Promise<boolean> {
+    return this.backend.delete(collection, id);
   }
 }

--- a/sdks/typescript/src/backends/agent-memory-backend.ts
+++ b/sdks/typescript/src/backends/agent-memory-backend.ts
@@ -81,9 +81,11 @@ export async function storeSemanticFact(
         id: entry.id,
         vector: entry.embedding,
         payload: {
+          // Caller metadata is spread first so the reserved keys below
+          // (`_memory_type`, `text`) always win and cannot be clobbered.
+          ...entry.metadata,
           _memory_type: 'semantic',
           text: entry.text,
-          ...entry.metadata,
         },
       }],
     }
@@ -105,7 +107,7 @@ export async function recordEpisodicEvent(
   transport: AgentMemoryTransport,
   collection: string,
   event: EpisodicEvent
-): Promise<void> {
+): Promise<number> {
   const id = generateUniqueId();
 
   const response = await transport.requestJson(
@@ -116,17 +118,21 @@ export async function recordEpisodicEvent(
         id,
         vector: event.embedding,
         payload: {
+          // Caller-supplied data/metadata is spread first so the reserved
+          // keys below (`_memory_type`, `event_type`, `timestamp`) always
+          // win and cannot be clobbered.
+          ...event.data,
+          ...event.metadata,
           _memory_type: 'episodic',
           event_type: event.eventType,
           timestamp: new Date().toISOString(),
-          ...event.data,
-          ...event.metadata,
         },
       }],
     }
   );
 
   throwOnError(response);
+  return id;
 }
 
 export async function recallEpisodicEvents(
@@ -142,7 +148,7 @@ export async function storeProceduralPattern(
   transport: AgentMemoryTransport,
   collection: string,
   pattern: ProceduralPattern
-): Promise<void> {
+): Promise<number> {
   const id = generateUniqueId();
 
   const response = await transport.requestJson(
@@ -151,17 +157,22 @@ export async function storeProceduralPattern(
     {
       points: [{
         id,
+        vector: pattern.embedding,
         payload: {
+          // Caller metadata is spread first so the reserved keys below
+          // (`_memory_type`, `name`, `steps`) always win and cannot be
+          // clobbered.
+          ...pattern.metadata,
           _memory_type: 'procedural',
           name: pattern.name,
           steps: pattern.steps,
-          ...pattern.metadata,
         },
       }],
     }
   );
 
   throwOnError(response);
+  return id;
 }
 
 export async function matchProceduralPatterns(

--- a/sdks/typescript/src/backends/rest.ts
+++ b/sdks/typescript/src/backends/rest.ts
@@ -223,8 +223,8 @@ export class RestBackend implements IVelesDBBackend {
   // Agent Memory
   async storeSemanticFact(c: string, e: SemanticEntry): Promise<void> { this.ensureInitialized(); return _storeSemanticFact(buildAgentMemoryTransport(this.httpConfig, (col, emb, opts) => this.search(col, emb, opts)), c, e); }
   async searchSemanticMemory(c: string, e: number[], k = 5): Promise<SearchResult[]> { this.ensureInitialized(); return _searchSemanticMemory(buildAgentMemoryTransport(this.httpConfig, (col, emb, opts) => this.search(col, emb, opts)), c, e, k); }
-  async recordEpisodicEvent(c: string, e: EpisodicEvent): Promise<void> { this.ensureInitialized(); return _recordEpisodicEvent(buildAgentMemoryTransport(this.httpConfig, (col, emb, opts) => this.search(col, emb, opts)), c, e); }
+  async recordEpisodicEvent(c: string, e: EpisodicEvent): Promise<number> { this.ensureInitialized(); return _recordEpisodicEvent(buildAgentMemoryTransport(this.httpConfig, (col, emb, opts) => this.search(col, emb, opts)), c, e); }
   async recallEpisodicEvents(c: string, e: number[], k = 5): Promise<SearchResult[]> { this.ensureInitialized(); return _recallEpisodicEvents(buildAgentMemoryTransport(this.httpConfig, (col, emb, opts) => this.search(col, emb, opts)), c, e, k); }
-  async storeProceduralPattern(c: string, p: ProceduralPattern): Promise<void> { this.ensureInitialized(); return _storeProceduralPattern(buildAgentMemoryTransport(this.httpConfig, (col, emb, opts) => this.search(col, emb, opts)), c, p); }
+  async storeProceduralPattern(c: string, p: ProceduralPattern): Promise<number> { this.ensureInitialized(); return _storeProceduralPattern(buildAgentMemoryTransport(this.httpConfig, (col, emb, opts) => this.search(col, emb, opts)), c, p); }
   async matchProceduralPatterns(c: string, e: number[], k = 5): Promise<SearchResult[]> { this.ensureInitialized(); return _matchProceduralPatterns(buildAgentMemoryTransport(this.httpConfig, (col, emb, opts) => this.search(col, emb, opts)), c, e, k); }
 }

--- a/sdks/typescript/src/backends/wasm-stubs.ts
+++ b/sdks/typescript/src/backends/wasm-stubs.ts
@@ -206,7 +206,7 @@ export async function wasmSearchSemanticMemory(
 
 export async function wasmRecordEpisodicEvent(
   _collection: string, _event: EpisodicEvent
-): Promise<void> {
+): Promise<number> {
   wasmNotSupported('Agent memory');
 }
 
@@ -218,7 +218,7 @@ export async function wasmRecallEpisodicEvents(
 
 export async function wasmStoreProceduralPattern(
   _collection: string, _pattern: ProceduralPattern
-): Promise<void> {
+): Promise<number> {
   wasmNotSupported('Agent memory');
 }
 

--- a/sdks/typescript/src/backends/wasm.ts
+++ b/sdks/typescript/src/backends/wasm.ts
@@ -420,9 +420,9 @@ export class WasmBackend implements IVelesDBBackend {
   async searchIds(c: string, q: number[] | Float32Array, o?: SearchOptions): Promise<Array<{ id: number; score: number }>> { this.ensureInitialized(); return wasmSearchIds(c, q, o); }
   async storeSemanticFact(c: string, e: SemanticEntry): Promise<void> { this.ensureInitialized(); return wasmStoreSemanticFact(c, e); }
   async searchSemanticMemory(c: string, e: number[], k?: number): Promise<SearchResult[]> { this.ensureInitialized(); return wasmSearchSemanticMemory(c, e, k); }
-  async recordEpisodicEvent(c: string, e: EpisodicEvent): Promise<void> { this.ensureInitialized(); return wasmRecordEpisodicEvent(c, e); }
+  async recordEpisodicEvent(c: string, e: EpisodicEvent): Promise<number> { this.ensureInitialized(); return wasmRecordEpisodicEvent(c, e); }
   async recallEpisodicEvents(c: string, e: number[], k?: number): Promise<SearchResult[]> { this.ensureInitialized(); return wasmRecallEpisodicEvents(c, e, k); }
-  async storeProceduralPattern(c: string, p: ProceduralPattern): Promise<void> { this.ensureInitialized(); return wasmStoreProceduralPattern(c, p); }
+  async storeProceduralPattern(c: string, p: ProceduralPattern): Promise<number> { this.ensureInitialized(); return wasmStoreProceduralPattern(c, p); }
   async matchProceduralPatterns(c: string, e: number[], k?: number): Promise<SearchResult[]> { this.ensureInitialized(); return wasmMatchProceduralPatterns(c, e, k); }
 
   // Wave 4 stubs

--- a/sdks/typescript/src/types/agent.ts
+++ b/sdks/typescript/src/types/agent.ts
@@ -39,6 +39,14 @@ export interface ProceduralPattern {
   name: string;
   /** Ordered steps */
   steps: string[];
+  /**
+   * Embedding vector for the pattern.
+   *
+   * Required so that `matchProceduralPatterns` (a vector search) can
+   * recall the pattern — a point stored without a vector is invisible
+   * to similarity search.
+   */
+  embedding: number[];
   /** Optional metadata */
   metadata?: Record<string, unknown>;
 }

--- a/sdks/typescript/src/types/backend.ts
+++ b/sdks/typescript/src/types/backend.ts
@@ -275,8 +275,8 @@ export interface IVelesDBBackend {
     k?: number
   ): Promise<SearchResult[]>;
 
-  /** Record an episodic event */
-  recordEpisodicEvent(collection: string, event: EpisodicEvent): Promise<void>;
+  /** Record an episodic event. Returns the generated point ID. */
+  recordEpisodicEvent(collection: string, event: EpisodicEvent): Promise<number>;
 
   /** Recall episodic events */
   recallEpisodicEvents(
@@ -285,8 +285,8 @@ export interface IVelesDBBackend {
     k?: number
   ): Promise<SearchResult[]>;
 
-  /** Store a procedural pattern */
-  storeProceduralPattern(collection: string, pattern: ProceduralPattern): Promise<void>;
+  /** Store a procedural pattern. Returns the generated point ID. */
+  storeProceduralPattern(collection: string, pattern: ProceduralPattern): Promise<number>;
 
   /** Match procedural patterns */
   matchProceduralPatterns(

--- a/sdks/typescript/tests/agent-memory.test.ts
+++ b/sdks/typescript/tests/agent-memory.test.ts
@@ -1,8 +1,13 @@
 /**
- * Agent Memory SDK Tests (Issues #6, #7 from PR 306)
+ * Agent Memory SDK Tests
  *
- * - #6: storeProceduralPattern must NOT send a vector field
- * - #7: generateUniqueId() must produce unique IDs under rapid-fire calls
+ * - #1039: storeProceduralPattern MUST send the pattern embedding as the
+ *   point vector, otherwise matchProceduralPatterns (a vector search)
+ *   can never recall it.
+ * - #1047: recordEvent/learnProcedure return the generated point ID; the
+ *   facade exposes a delete method; reserved payload keys cannot be
+ *   clobbered by caller metadata.
+ * - generateUniqueId() must produce unique IDs under rapid-fire calls.
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
@@ -92,16 +97,18 @@ describe('Agent Memory REST methods', () => {
     vi.restoreAllMocks();
   });
 
-  describe('storeProceduralPattern (Issue #6)', () => {
-    it('should NOT include a vector field in the request body', async () => {
+  describe('storeProceduralPattern (Issue #1039)', () => {
+    it('should store the pattern embedding as the point vector', async () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,
         json: () => Promise.resolve({}),
       });
 
-      await backend.storeProceduralPattern('patterns', {
+      const embedding = [0.1, 0.2, 0.3];
+      const id = await backend.storeProceduralPattern('patterns', {
         name: 'deploy',
         steps: ['build', 'test', 'push'],
+        embedding,
         metadata: { env: 'prod' },
       });
 
@@ -109,13 +116,36 @@ describe('Agent Memory REST methods', () => {
       const body = JSON.parse(mockFetch.mock.calls[0][1].body);
       const point = body.points[0];
 
-      // vector must be absent
-      expect(point).not.toHaveProperty('vector');
+      // vector must be the supplied embedding so vector search can recall it
+      expect(point.vector).toEqual(embedding);
       // payload must still be present
       expect(point.payload._memory_type).toBe('procedural');
       expect(point.payload.name).toBe('deploy');
       expect(point.payload.steps).toEqual(['build', 'test', 'push']);
       expect(point.payload.env).toBe('prod');
+      // store returns the generated point ID
+      expect(point.id).toBe(id);
+    });
+  });
+
+  describe('reserved payload keys (Issue #1047)', () => {
+    it('should not let caller metadata clobber reserved keys', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({}),
+      });
+
+      await backend.storeProceduralPattern('patterns', {
+        name: 'real-name',
+        steps: ['a'],
+        embedding: [0.1],
+        metadata: { _memory_type: 'hacked', name: 'spoofed', steps: ['evil'] },
+      });
+
+      const point = JSON.parse(mockFetch.mock.calls[0][1].body).points[0];
+      expect(point.payload._memory_type).toBe('procedural');
+      expect(point.payload.name).toBe('real-name');
+      expect(point.payload.steps).toEqual(['a']);
     });
   });
 
@@ -162,16 +192,52 @@ describe('Agent Memory REST methods', () => {
       await backend.storeProceduralPattern('patterns', {
         name: 'a',
         steps: ['1'],
+        embedding: [0.1],
       });
       await backend.storeProceduralPattern('patterns', {
         name: 'b',
         steps: ['2'],
+        embedding: [0.2],
       });
 
       const id1 = JSON.parse(mockFetch.mock.calls[0][1].body).points[0].id;
       const id2 = JSON.parse(mockFetch.mock.calls[1][1].body).points[0].id;
 
       expect(id1).not.toBe(id2);
+    });
+  });
+
+  describe('learn -> recall round-trip (Issue #1039)', () => {
+    it('should recall a stored procedural pattern via vector search', async () => {
+      const embedding = [0.1, 0.2, 0.3];
+
+      // 1. learnProcedure -> store point (with vector)
+      mockFetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({}) });
+      const id = await backend.storeProceduralPattern('patterns', {
+        name: 'deploy',
+        steps: ['build', 'push'],
+        embedding,
+      });
+
+      const stored = JSON.parse(mockFetch.mock.calls[0][1].body).points[0];
+      expect(stored.vector).toEqual(embedding);
+
+      // 2. matchProceduralPatterns -> vector search returns the stored point
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({
+          results: [
+            { id, score: 1.0, payload: { _memory_type: 'procedural', name: 'deploy' } },
+          ],
+        }),
+      });
+
+      const matches = await backend.matchProceduralPatterns('patterns', embedding, 5);
+
+      // Before the fix the point had no vector and search returned [].
+      expect(matches).toHaveLength(1);
+      expect(matches[0].id).toBe(id);
+      expect(matches[0].payload?.name).toBe('deploy');
     });
   });
 });

--- a/sdks/typescript/tests/client-delegations.test.ts
+++ b/sdks/typescript/tests/client-delegations.test.ts
@@ -447,4 +447,12 @@ describe('VelesDB — agent memory factory', () => {
     const db = new VelesDB({ backend: 'wasm' });
     expect(() => db.agentMemory()).toThrow(ValidationError);
   });
+
+  it('deleteMemory delegates to backend.delete and returns its result', async () => {
+    const { db, backend } = setup();
+    const mem = db.agentMemory();
+    const result = await mem.deleteMemory('facts', 42);
+    expect(backend.delete).toHaveBeenCalledWith('facts', 42);
+    expect(result).toBe(true);
+  });
 });


### PR DESCRIPTION
- #1039: procedural patterns now stored WITH their embedding vector so `recallProcedures` works (was always empty). Breaking: `embedding` becomes required on `ProceduralPattern`.
- #1042: corrects the REST-vs-embedded contradiction in `AGENT_MEMORY.md`.
- #1047: README quickstart creates the collection first; ids returned from record/learn; `deleteMemory` added; reserved payload keys protected.
- #1048: documents SearchResult/score/TTL/no-auto-embed and the no-auto-snapshot limitation; adds TS column to the API table.

npm build + 731 tests pass.

Closes #1039, #1042, #1047, #1048