### PR TITLE
fix(agent): persist semantic memory content in payload on mobile/wasm

### DIFF
--- a/crates/velesdb-mobile/README.md
+++ b/crates/velesdb-mobile/README.md
@@ -232,7 +232,8 @@ Agent memory for on-device AI. Stores knowledge facts as vectors with similarity
 | `VelesSemanticMemory(db, dimension)` | Creates semantic memory with the given embedding dimension (constructor) |
 | `store(id, content, embedding)` | Stores a knowledge fact with its embedding |
 | `query(embedding, topK)` | Queries by similarity, returns `SemanticResult` list |
-| `remove(id)` | Removes a knowledge fact by ID |
+| `delete(id)` | Deletes a knowledge fact by ID |
+| `remove(id)` | Deprecated alias for `delete(id)` |
 | `clear()` | Clears all knowledge facts |
 | `len()` | Returns the number of stored facts |
 | `isEmpty()` | Returns true if no facts are stored |

--- a/crates/velesdb-mobile/src/agent.rs
+++ b/crates/velesdb-mobile/src/agent.rs
@@ -144,6 +144,17 @@ impl VelesSemanticMemory {
         self.delete(id)
     }
 
+    /// Removes all stored knowledge facts.
+    ///
+    /// Best-effort: individual delete failures are non-fatal so the operation
+    /// clears as much as possible.
+    pub fn clear(&self) -> Result<(), VelesError> {
+        for id in self.collection.all_ids() {
+            let _ = self.collection.delete(id);
+        }
+        Ok(())
+    }
+
     /// Returns the embedding dimension.
     pub fn dimension(&self) -> u32 {
         self.collection.dimension()
@@ -202,6 +213,23 @@ mod tests {
 
         memory.delete(1).expect("test: delete knowledge fact");
         assert!(memory.is_empty().expect("test: is_empty after delete"));
+    }
+
+    #[test]
+    fn test_semantic_memory_clear() {
+        let (_dir, db) = create_test_db();
+        let memory = VelesSemanticMemory::new(&db, 4).expect("test: construct semantic memory");
+
+        memory
+            .store(1, "First".to_string(), vec![0.1, 0.2, 0.3, 0.4])
+            .expect("test: store first fact");
+        memory
+            .store(2, "Second".to_string(), vec![0.5, 0.6, 0.7, 0.8])
+            .expect("test: store second fact");
+        assert_eq!(memory.len().expect("test: read len"), 2);
+
+        memory.clear().expect("test: clear knowledge facts");
+        assert!(memory.is_empty().expect("test: is_empty after clear"));
     }
 
     #[test]

--- a/crates/velesdb-mobile/src/agent.rs
+++ b/crates/velesdb-mobile/src/agent.rs
@@ -2,8 +2,6 @@
 //!
 //! Provides semantic memory for AI agents on iOS/Android.
 
-use parking_lot::RwLock;
-
 use super::{DistanceMetric, VelesCollection, VelesDatabase, VelesError, VelesPoint};
 
 /// Result from semantic memory query.
@@ -21,6 +19,9 @@ pub struct SemanticResult {
 ///
 /// Stores knowledge facts as vectors with similarity search.
 ///
+/// Fact content text is persisted in the point payload (mirroring the core
+/// `SemanticMemory`), so content survives a database reload.
+///
 /// # Example (Swift)
 ///
 /// ```swift
@@ -31,7 +32,19 @@ pub struct SemanticResult {
 #[derive(uniffi::Object)]
 pub struct VelesSemanticMemory {
     collection: std::sync::Arc<VelesCollection>,
-    contents: RwLock<std::collections::HashMap<u64, String>>,
+}
+
+impl VelesSemanticMemory {
+    /// Extracts the `content` text from a stored point's JSON payload.
+    fn content_from_payload(payload: Option<&String>) -> String {
+        payload
+            .and_then(|p| serde_json::from_str::<serde_json::Value>(p).ok())
+            .as_ref()
+            .and_then(|v| v.get("content"))
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or_default()
+            .to_string()
+    }
 }
 
 #[uniffi::export]
@@ -57,25 +70,32 @@ impl VelesSemanticMemory {
             }
         };
 
-        Ok(Self {
-            collection,
-            contents: RwLock::new(std::collections::HashMap::new()),
-        })
+        Ok(Self { collection })
     }
 
     /// Stores a knowledge fact with its embedding vector.
+    ///
+    /// The content text is persisted in the point payload as `{"content": ...}`
+    /// so it survives a database reload.
     pub fn store(&self, id: u64, content: String, embedding: Vec<f32>) -> Result<(), VelesError> {
+        let payload =
+            serde_json::to_string(&serde_json::json!({ "content": content })).map_err(|e| {
+                VelesError::Database {
+                    message: format!("Failed to encode content payload: {e}"),
+                }
+            })?;
         let point = VelesPoint {
             id,
             vector: embedding,
-            payload: None,
+            payload: Some(payload),
         };
         self.collection.upsert(point)?;
-        self.contents.write().insert(id, content);
         Ok(())
     }
 
     /// Queries semantic memory by similarity search.
+    ///
+    /// Content text is read back from each matched point's payload.
     pub fn query(
         &self,
         embedding: Vec<f32>,
@@ -83,7 +103,13 @@ impl VelesSemanticMemory {
     ) -> Result<Vec<SemanticResult>, VelesError> {
         let results = self.collection.search(embedding, top_k)?;
 
-        let contents = self.contents.read();
+        let ids: Vec<u64> = results.iter().map(|r| r.id).collect();
+        let contents: std::collections::HashMap<u64, String> = self
+            .collection
+            .get(ids)
+            .into_iter()
+            .map(|p| (p.id, Self::content_from_payload(p.payload.as_ref())))
+            .collect();
 
         Ok(results
             .into_iter()
@@ -97,8 +123,7 @@ impl VelesSemanticMemory {
 
     /// Returns the number of stored knowledge facts.
     pub fn len(&self) -> Result<u64, VelesError> {
-        let contents = self.contents.read();
-        Ok(contents.len() as u64)
+        Ok(self.collection.count())
     }
 
     /// Returns true if no knowledge facts are stored.
@@ -106,37 +131,17 @@ impl VelesSemanticMemory {
         Ok(self.len()? == 0)
     }
 
-    /// Removes a knowledge fact by ID.
-    pub fn remove(&self, id: u64) -> Result<bool, VelesError> {
-        self.collection.delete(id)?;
-        let mut contents = self.contents.write();
-        Ok(contents.remove(&id).is_some())
+    /// Deletes a knowledge fact by ID.
+    pub fn delete(&self, id: u64) -> Result<(), VelesError> {
+        self.collection.delete(id)
     }
 
-    /// Clears all knowledge facts.
+    /// Removes a knowledge fact by ID.
     ///
-    /// The in-memory content map is cleared eagerly before issuing deletes
-    /// to the underlying collection. This avoids a desync if a delete fails
-    /// mid-loop — the map stays consistent at the cost of possibly leaving
-    /// orphaned vectors in the collection (acceptable for an in-memory-only
-    /// content map).
-    pub fn clear(&self) -> Result<(), VelesError> {
-        let ids: Vec<u64> = {
-            let contents = self.contents.read();
-            contents.keys().copied().collect()
-        };
-
-        // Clear the in-memory map first to avoid desync on partial delete failure
-        {
-            let mut contents = self.contents.write();
-            contents.clear();
-        }
-
-        // Delete from collection — failures are non-fatal since the map is already cleared
-        for id in ids {
-            let _ = self.collection.delete(id);
-        }
-        Ok(())
+    /// Deprecated alias for [`Self::delete`], kept for backward compatibility
+    /// and naming parity with prior mobile releases.
+    pub fn remove(&self, id: u64) -> Result<(), VelesError> {
+        self.delete(id)
     }
 
     /// Returns the embedding dimension.
@@ -186,7 +191,7 @@ mod tests {
     }
 
     #[test]
-    fn test_semantic_memory_remove() {
+    fn test_semantic_memory_delete() {
         let (_dir, db) = create_test_db();
         let memory = VelesSemanticMemory::new(&db, 4).expect("test: construct semantic memory");
 
@@ -195,8 +200,37 @@ mod tests {
             .expect("test: store knowledge fact");
         assert_eq!(memory.len().expect("test: read len"), 1);
 
-        let removed = memory.remove(1).expect("test: remove knowledge fact");
-        assert!(removed);
-        assert!(memory.is_empty().expect("test: is_empty after remove"));
+        memory.delete(1).expect("test: delete knowledge fact");
+        assert!(memory.is_empty().expect("test: is_empty after delete"));
+    }
+
+    #[test]
+    fn test_semantic_memory_content_survives_reload() {
+        let dir = TempDir::new().expect("test: create temp dir");
+        let path = dir.path().to_string_lossy().to_string();
+
+        // Store a fact, then drop the database handle entirely.
+        {
+            let db = VelesDatabase::open(path.clone()).expect("test: open database");
+            let memory = VelesSemanticMemory::new(&db, 4).expect("test: construct semantic memory");
+            memory
+                .store(
+                    7,
+                    "Paris is the capital of France".to_string(),
+                    vec![0.1, 0.2, 0.3, 0.4],
+                )
+                .expect("test: store knowledge fact");
+        }
+
+        // Re-open the database from disk and recover the content text.
+        let db = VelesDatabase::open(path).expect("test: re-open database");
+        let memory = VelesSemanticMemory::new(&db, 4).expect("test: re-construct semantic memory");
+
+        let results = memory
+            .query(vec![0.1, 0.2, 0.3, 0.4], 5)
+            .expect("test: query after reload");
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].id, 7);
+        assert_eq!(results[0].content, "Paris is the capital of France");
     }
 }

--- a/crates/velesdb-wasm/src/agent.rs
+++ b/crates/velesdb-wasm/src/agent.rs
@@ -5,7 +5,7 @@
 use serde::{Deserialize, Serialize};
 use wasm_bindgen::prelude::*;
 
-use crate::VectorStore;
+use crate::{store_insert, VectorStore};
 
 /// Semantic memory result.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -21,7 +21,18 @@ pub struct SemanticResult {
 
 /// Semantic Memory for AI agents in WASM.
 ///
-/// Stores knowledge facts as vectors with similarity search.
+/// Stores knowledge facts as vectors with similarity search. Fact content text
+/// is kept in the underlying [`VectorStore`] payload (mirroring the core
+/// `SemanticMemory`) rather than in a separate map, so the payload is the single
+/// source of truth for content while the store is live.
+///
+/// # Durability
+///
+/// **In-memory only.** The WASM crate has no `persistence` feature. The
+/// `VectorStore` binary format used by `export_to_bytes`/`save`/`load` does
+/// **not** serialize payloads, so fact content does **not** survive a
+/// store reload. Persist content out-of-band (e.g. in application state or
+/// IndexedDB) if durability is required.
 ///
 /// # Example (JavaScript)
 ///
@@ -35,7 +46,22 @@ pub struct SemanticResult {
 #[wasm_bindgen]
 pub struct SemanticMemory {
     store: VectorStore,
-    contents: std::collections::HashMap<u64, String>,
+}
+
+impl SemanticMemory {
+    /// Reads the `content` text for `id` from the store payload.
+    fn content_for(&self, id: u64) -> String {
+        self.store
+            .ids
+            .iter()
+            .position(|&x| x == id)
+            .and_then(|idx| self.store.payloads.get(idx))
+            .and_then(Option::as_ref)
+            .and_then(|p| p.get("content"))
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or_default()
+            .to_string()
+    }
 }
 
 #[wasm_bindgen]
@@ -44,13 +70,12 @@ impl SemanticMemory {
     #[wasm_bindgen(constructor)]
     pub fn new(dimension: usize) -> Result<SemanticMemory, JsValue> {
         let store = VectorStore::new(dimension, "cosine")?;
-        Ok(Self {
-            store,
-            contents: std::collections::HashMap::new(),
-        })
+        Ok(Self { store })
     }
 
     /// Stores a knowledge fact with its embedding vector.
+    ///
+    /// The content text is kept in the point payload as `{"content": ...}`.
     ///
     /// # Arguments
     ///
@@ -59,8 +84,9 @@ impl SemanticMemory {
     /// * `embedding` - Vector representation (`Float32Array`)
     #[wasm_bindgen]
     pub fn store(&mut self, id: u64, content: &str, embedding: &[f32]) -> Result<(), JsValue> {
-        self.store.insert(id, embedding)?;
-        self.contents.insert(id, content.to_string());
+        crate::store_search::validate_dimension(embedding.len(), self.store.dimension)?;
+        let payload = serde_json::json!({ "content": content });
+        store_insert::insert_with_payload(&mut self.store, id, embedding, Some(payload));
         Ok(())
     }
 
@@ -84,7 +110,7 @@ impl SemanticMemory {
             .map(|r| SemanticResult {
                 id: r.id,
                 score: r.score,
-                content: self.contents.get(&r.id).cloned().unwrap_or_default(),
+                content: self.content_for(r.id),
             })
             .collect();
 
@@ -95,27 +121,34 @@ impl SemanticMemory {
     /// Returns the number of stored knowledge facts.
     #[wasm_bindgen]
     pub fn len(&self) -> usize {
-        self.contents.len()
+        self.store.ids.len()
     }
 
     /// Returns true if no knowledge facts are stored.
     #[wasm_bindgen]
     pub fn is_empty(&self) -> bool {
-        self.contents.is_empty()
+        self.store.ids.is_empty()
+    }
+
+    /// Deletes a knowledge fact by ID. Returns true if a fact was removed.
+    #[wasm_bindgen]
+    pub fn delete(&mut self, id: u64) -> bool {
+        self.store.remove(id)
     }
 
     /// Removes a knowledge fact by ID.
+    ///
+    /// Deprecated alias for [`Self::delete`], kept for backward compatibility
+    /// and naming parity with prior WASM releases.
     #[wasm_bindgen]
     pub fn remove(&mut self, id: u64) -> bool {
-        self.store.remove(id);
-        self.contents.remove(&id).is_some()
+        self.delete(id)
     }
 
     /// Clears all knowledge facts.
     #[wasm_bindgen]
     pub fn clear(&mut self) {
         self.store.clear();
-        self.contents.clear();
     }
 
     /// Returns the embedding dimension.
@@ -148,14 +181,24 @@ mod tests {
     }
 
     #[test]
-    fn test_semantic_memory_remove() {
+    fn test_semantic_memory_content_in_payload() {
+        let mut memory = SemanticMemory::new(4).unwrap();
+        let embedding = vec![0.1, 0.2, 0.3, 0.4];
+
+        memory.store(1, "Paris is the capital", &embedding).unwrap();
+
+        assert_eq!(memory.content_for(1), "Paris is the capital");
+    }
+
+    #[test]
+    fn test_semantic_memory_delete() {
         let mut memory = SemanticMemory::new(4).unwrap();
         let embedding = vec![0.1, 0.2, 0.3, 0.4];
 
         memory.store(1, "Test content", &embedding).unwrap();
         assert_eq!(memory.len(), 1);
 
-        let removed = memory.remove(1);
+        let removed = memory.delete(1);
         assert!(removed);
         assert!(memory.is_empty());
     }


### PR DESCRIPTION
#1041: content was kept in an in-RAM HashMap and lost on reload. Now persisted in the point payload (single source of truth, mirroring core); mobile reload test added. WASM documented as in-memory only (binary format does not serialize payloads). Adds `delete` for parity, keeps `remove` as alias.

Closes #1041