### PR TITLE
feat(core/agent): SemanticMemory metadata, filtered query & dead-code removal [EPIC-010]

### DIFF
--- a/crates/velesdb-core/src/agent/memory.rs
+++ b/crates/velesdb-core/src/agent/memory.rs
@@ -52,9 +52,6 @@ pub struct AgentMemory {
     episodic: EpisodicMemory,
     procedural: ProceduralMemory,
     ttl: Arc<MemoryTtl>,
-    #[allow(dead_code)]
-    // Reason: temporal_index will be used for time-based queries in future implementation
-    temporal_index: Arc<TemporalIndex>,
     eviction_config: EvictionConfig,
     snapshot_manager: Option<SnapshotManager>,
 }
@@ -83,14 +80,13 @@ impl AgentMemory {
     /// Returns an error when one of the underlying memory subsystems cannot be initialized.
     pub fn with_dimension(db: Arc<Database>, dimension: usize) -> Result<Self, AgentMemoryError> {
         let ttl = Arc::new(MemoryTtl::new());
-        let temporal_index = Arc::new(TemporalIndex::new());
 
         let semantic = SemanticMemory::new(Arc::clone(&db), dimension, Arc::clone(&ttl))?;
         let episodic = EpisodicMemory::new(
             Arc::clone(&db),
             dimension,
             Arc::clone(&ttl),
-            Arc::clone(&temporal_index),
+            Arc::new(TemporalIndex::new()),
         )?;
         let procedural = ProceduralMemory::new(Arc::clone(&db), dimension, Arc::clone(&ttl))?;
 
@@ -100,7 +96,6 @@ impl AgentMemory {
             episodic,
             procedural,
             ttl,
-            temporal_index,
             eviction_config: EvictionConfig::default(),
             snapshot_manager: None,
         })

--- a/crates/velesdb-core/src/agent/semantic_memory.rs
+++ b/crates/velesdb-core/src/agent/semantic_memory.rs
@@ -1,11 +1,11 @@
 //! Semantic Memory - Long-term knowledge storage (US-002)
 //!
 //! Stores facts and knowledge as vectors with similarity search.
-//! Each fact has an ID, content text, and embedding vector.
+//! Each fact has an ID, content text, embedding vector, and optional metadata.
 
 use crate::{Database, Point};
 use parking_lot::RwLock;
-use serde_json::json;
+use serde_json::{Map, Value};
 use std::collections::HashSet;
 use std::sync::Arc;
 
@@ -73,12 +73,72 @@ impl SemanticMemory {
     /// Returns an error when embedding dimension is invalid, collection access fails,
     /// or persistence fails.
     pub fn store(&self, id: u64, content: &str, embedding: &[f32]) -> Result<(), AgentMemoryError> {
-        memory_helpers::validate_dimension(self.dimension, embedding.len())?;
+        self.store_internal(id, content, embedding, None)
+    }
 
+    /// Stores a semantic memory point with additional metadata fields.
+    ///
+    /// `content` always wins: if `metadata` contains a `"content"` key, it is
+    /// overwritten by the `content` parameter.
+    ///
+    /// # Errors
+    ///
+    /// Returns the same errors as [`Self::store`].
+    pub fn store_with_metadata(
+        &self,
+        id: u64,
+        content: &str,
+        embedding: &[f32],
+        metadata: &Map<String, Value>,
+    ) -> Result<(), AgentMemoryError> {
+        self.store_internal(id, content, embedding, Some(metadata))
+    }
+
+    /// Updates payload fields of an existing fact without changing its embedding.
+    ///
+    /// Only facts that are tracked and not expired are updated. Any key in
+    /// `updates` is merged into the existing payload; `content` may be updated
+    /// through this method, but the vector is left untouched.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AgentMemoryError::NotFound`] when the id is unknown or expired.
+    /// Returns other errors when collection access or persistence fails.
+    pub fn update_metadata(
+        &self,
+        id: u64,
+        updates: &Map<String, Value>,
+    ) -> Result<(), AgentMemoryError> {
+        if self.ttl.is_expired(MemoryKind::Semantic, id) || !self.stored_ids.read().contains(&id) {
+            return Err(AgentMemoryError::NotFound(id.to_string()));
+        }
         let collection = memory_helpers::get_collection(&self.db, &self.collection_name)?;
-        let point = Point::new(id, embedding.to_vec(), Some(json!({"content": content})));
-        memory_helpers::upsert_points(&collection, vec![point])?;
+        let Some(point) = collection.get(&[id]).into_iter().flatten().next() else {
+            return Err(AgentMemoryError::NotFound(id.to_string()));
+        };
+        let payload = merge_payload(point.payload, updates)?;
+        memory_helpers::upsert_points(
+            &collection,
+            vec![Point::new(id, point.vector, Some(payload))],
+        )?;
+        Ok(())
+    }
 
+    fn store_internal(
+        &self,
+        id: u64,
+        content: &str,
+        embedding: &[f32],
+        metadata: Option<&Map<String, Value>>,
+    ) -> Result<(), AgentMemoryError> {
+        memory_helpers::validate_dimension(self.dimension, embedding.len())?;
+        let collection = memory_helpers::get_collection(&self.db, &self.collection_name)?;
+        let point = Point::new(
+            id,
+            embedding.to_vec(),
+            Some(build_payload(content, metadata)),
+        );
+        memory_helpers::upsert_points(&collection, vec![point])?;
         self.stored_ids.write().insert(id);
         Ok(())
     }
@@ -172,6 +232,47 @@ impl SemanticMemory {
             .collect())
     }
 
+    /// Queries semantic memory with a payload filter and optional offset pagination.
+    ///
+    /// Results are ranked by vector similarity, filtered against `filter` (all
+    /// key-value pairs must match), TTL-expired points are excluded, and
+    /// `offset` leading results are skipped before taking `k`.
+    ///
+    /// The internal fetch budget is generous to survive both TTL eviction and
+    /// filter miss-rates; when the collection has very few matching entries the
+    /// returned slice may be shorter than `k`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when embedding dimension is invalid or collection access fails.
+    pub fn query_filtered(
+        &self,
+        query_embedding: &[f32],
+        k: usize,
+        filter: &Map<String, Value>,
+        offset: usize,
+    ) -> Result<Vec<(u64, f32, String)>, AgentMemoryError> {
+        // over-fetch to absorb TTL evictions + payload filter misses + offset
+        let need = k.saturating_add(offset);
+        let fetch_k = need
+            .saturating_add(self.ttl.expired_count(MemoryKind::Semantic))
+            .saturating_mul(2)
+            .max(need.saturating_add(8));
+
+        memory_helpers::validate_dimension(self.dimension, query_embedding.len())?;
+        let collection = memory_helpers::get_collection(&self.db, &self.collection_name)?;
+        let raw = memory_helpers::search_collection(&collection, query_embedding, fetch_k)?;
+
+        Ok(raw
+            .into_iter()
+            .filter(|r| !self.ttl.is_expired(MemoryKind::Semantic, r.point.id))
+            .filter(|r| payload_matches(&r.point, filter))
+            .skip(offset)
+            .take(k)
+            .map(|r| (r.point.id, r.score, extract_content(&r.point)))
+            .collect())
+    }
+
     /// Stores multiple semantic memory points in one batch.
     ///
     /// Each tuple is `(id, content, embedding)`. All embeddings are
@@ -193,7 +294,7 @@ impl SemanticMemory {
             points.push(Point::new(
                 *id,
                 embedding.to_vec(),
-                Some(json!({ "content": content })),
+                Some(build_payload(content, None)),
             ));
         }
 
@@ -326,13 +427,57 @@ impl SemanticMemory {
     }
 }
 
+/// Builds the payload `Value` from `content` and optional extra metadata.
+///
+/// `content` is always inserted last so it wins over any `"content"` key
+/// present in `metadata`.
+fn build_payload(content: &str, metadata: Option<&Map<String, Value>>) -> Value {
+    let mut map = metadata.cloned().unwrap_or_default();
+    map.insert("content".to_string(), Value::String(content.to_string()));
+    Value::Object(map)
+}
+
+/// Merges `updates` into an existing point payload, returning the new payload.
+///
+/// A missing payload starts from an empty object. Errors when the existing
+/// payload is present but not a JSON object.
+fn merge_payload(
+    existing: Option<Value>,
+    updates: &Map<String, Value>,
+) -> Result<Value, AgentMemoryError> {
+    let mut payload = existing.unwrap_or_else(|| Value::Object(Map::new()));
+    let obj = payload
+        .as_object_mut()
+        .ok_or_else(|| AgentMemoryError::IoError("corrupt payload".to_string()))?;
+    for (k, v) in updates {
+        obj.insert(k.clone(), v.clone());
+    }
+    Ok(payload)
+}
+
+/// Returns `true` when every key-value pair in `filter` matches the point payload.
+///
+/// An empty filter matches all points. A point with no payload only matches an
+/// empty filter.
+fn payload_matches(point: &Point, filter: &Map<String, Value>) -> bool {
+    if filter.is_empty() {
+        return true;
+    }
+    let Some(obj) = point.payload.as_ref().and_then(Value::as_object) else {
+        return false;
+    };
+    filter
+        .iter()
+        .all(|(k, v)| obj.get(k).is_some_and(|pv| pv == v))
+}
+
 /// Extracts the `content` string from a point's payload, or `""` when absent.
 fn extract_content(point: &Point) -> String {
     point
         .payload
         .as_ref()
         .and_then(|p| p.get("content"))
-        .and_then(serde_json::Value::as_str)
+        .and_then(Value::as_str)
         .unwrap_or("")
         .to_string()
 }

--- a/crates/velesdb-core/src/agent/semantic_memory_tests.rs
+++ b/crates/velesdb-core/src/agent/semantic_memory_tests.rs
@@ -404,6 +404,174 @@ mod tests {
         assert!(sm.store_batch(&facts).is_err());
     }
 
+    // ── #1044: store_with_metadata / update_metadata / query_filtered ───────────
+
+    #[test]
+    fn test_store_with_metadata_persists_extra_fields() {
+        let dir = tempdir().unwrap();
+        let db = Arc::new(Database::open(dir.path()).unwrap());
+        let sm = make_semantic(Arc::clone(&db));
+
+        let emb = vec![1.0_f32, 0.0, 0.0, 0.0];
+        let mut meta = serde_json::Map::new();
+        meta.insert("tag".to_string(), serde_json::json!("science"));
+        sm.store_with_metadata(1, "Photosynthesis", &emb, &meta)
+            .unwrap();
+
+        let results = sm.query(&emb, 1).unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].0, 1);
+        // content field still set correctly
+        assert!(results[0].2.contains("Photosynthesis"));
+    }
+
+    #[test]
+    fn test_store_with_metadata_content_wins_on_collision() {
+        let dir = tempdir().unwrap();
+        let db = Arc::new(Database::open(dir.path()).unwrap());
+        let sm = make_semantic(Arc::clone(&db));
+
+        let emb = vec![1.0_f32, 0.0, 0.0, 0.0];
+        let mut meta = serde_json::Map::new();
+        // caller tries to inject a different content via metadata
+        meta.insert(
+            "content".to_string(),
+            serde_json::json!("should be overwritten"),
+        );
+        sm.store_with_metadata(1, "canonical content", &emb, &meta)
+            .unwrap();
+
+        let results = sm.query(&emb, 1).unwrap();
+        assert_eq!(results[0].2, "canonical content", "content param must win");
+    }
+
+    #[test]
+    fn test_update_metadata_merges_fields() {
+        let dir = tempdir().unwrap();
+        let db = Arc::new(Database::open(dir.path()).unwrap());
+        let sm = make_semantic(Arc::clone(&db));
+
+        let emb = vec![1.0_f32, 0.0, 0.0, 0.0];
+        sm.store(1, "original", &emb).unwrap();
+
+        let mut updates = serde_json::Map::new();
+        updates.insert("tag".to_string(), serde_json::json!("updated"));
+        sm.update_metadata(1, &updates).unwrap();
+
+        // content field must still be present after update
+        let results = sm.query(&emb, 1).unwrap();
+        assert_eq!(results.len(), 1);
+        assert!(results[0].2.contains("original"));
+    }
+
+    #[test]
+    fn test_update_metadata_unknown_id_errors() {
+        let dir = tempdir().unwrap();
+        let db = Arc::new(Database::open(dir.path()).unwrap());
+        let sm = make_semantic(Arc::clone(&db));
+
+        let updates = serde_json::Map::new();
+        assert!(
+            sm.update_metadata(9999, &updates).is_err(),
+            "unknown id must return NotFound"
+        );
+    }
+
+    #[test]
+    fn test_update_metadata_expired_id_errors() {
+        let dir = tempdir().unwrap();
+        let db = Arc::new(Database::open(dir.path()).unwrap());
+        let ttl = Arc::new(super::super::ttl::MemoryTtl::new());
+        let sm = SemanticMemory::new(Arc::clone(&db), 4, Arc::clone(&ttl)).expect("init failed");
+
+        let emb = vec![1.0_f32, 0.0, 0.0, 0.0];
+        sm.store(1, "fact", &emb).unwrap();
+        ttl.set_ttl(MemoryKind::Semantic, 1, 0); // immediate expiry
+
+        let updates = serde_json::Map::new();
+        assert!(
+            sm.update_metadata(1, &updates).is_err(),
+            "expired id must return NotFound"
+        );
+    }
+
+    #[test]
+    fn test_query_filtered_matches_tag() {
+        let dir = tempdir().unwrap();
+        let db = Arc::new(Database::open(dir.path()).unwrap());
+        let sm = make_semantic(Arc::clone(&db));
+
+        let emb = vec![1.0_f32, 0.0, 0.0, 0.0];
+        let mut meta_a = serde_json::Map::new();
+        meta_a.insert("category".to_string(), serde_json::json!("physics"));
+        let mut meta_b = serde_json::Map::new();
+        meta_b.insert("category".to_string(), serde_json::json!("biology"));
+
+        sm.store_with_metadata(1, "gravity", &emb, &meta_a).unwrap();
+        sm.store_with_metadata(2, "photosynthesis", &emb, &meta_b)
+            .unwrap();
+
+        let mut filter = serde_json::Map::new();
+        filter.insert("category".to_string(), serde_json::json!("physics"));
+
+        let results = sm.query_filtered(&emb, 5, &filter, 0).unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].0, 1);
+    }
+
+    #[test]
+    fn test_query_filtered_skips_expired() {
+        let dir = tempdir().unwrap();
+        let db = Arc::new(Database::open(dir.path()).unwrap());
+        let ttl = Arc::new(super::super::ttl::MemoryTtl::new());
+        let sm = SemanticMemory::new(Arc::clone(&db), 4, Arc::clone(&ttl)).expect("init failed");
+
+        let emb = vec![1.0_f32, 0.0, 0.0, 0.0];
+        let mut meta = serde_json::Map::new();
+        meta.insert("kind".to_string(), serde_json::json!("test"));
+
+        sm.store_with_metadata(1, "live fact", &emb, &meta).unwrap();
+        sm.store_with_metadata(2, "expired fact", &emb, &meta)
+            .unwrap();
+        ttl.set_ttl(MemoryKind::Semantic, 2, 0); // expire id=2
+
+        let mut filter = serde_json::Map::new();
+        filter.insert("kind".to_string(), serde_json::json!("test"));
+
+        let results = sm.query_filtered(&emb, 5, &filter, 0).unwrap();
+        assert_eq!(results.len(), 1, "expired point must be excluded");
+        assert_eq!(results[0].0, 1);
+    }
+
+    #[test]
+    fn test_query_filtered_with_offset() {
+        let dir = tempdir().unwrap();
+        let db = Arc::new(Database::open(dir.path()).unwrap());
+        let sm = make_semantic(Arc::clone(&db));
+
+        let e1 = vec![1.0_f32, 0.0, 0.0, 0.0];
+        let e2 = vec![0.99_f32, 0.14, 0.0, 0.0];
+        let e3 = vec![0.98_f32, 0.20, 0.0, 0.0];
+
+        let mut meta = serde_json::Map::new();
+        meta.insert("grp".to_string(), serde_json::json!("x"));
+
+        sm.store_with_metadata(1, "best", &e1, &meta).unwrap();
+        sm.store_with_metadata(2, "second", &e2, &meta).unwrap();
+        sm.store_with_metadata(3, "third", &e3, &meta).unwrap();
+
+        let mut filter = serde_json::Map::new();
+        filter.insert("grp".to_string(), serde_json::json!("x"));
+
+        // offset=1 skips the top result, so second-best appears first
+        let paged = sm.query_filtered(&e1, 2, &filter, 1).unwrap();
+        assert_eq!(paged.len(), 2, "should get the 2nd and 3rd results");
+        assert!(
+            paged.iter().all(|r| r.0 != 1),
+            "top result must be skipped by offset"
+        );
+    }
+
     // ── #1049: edge-case / robustness tests ─────────────────────────────────────
 
     #[test]


### PR DESCRIPTION
## Summary

Closes the last two open code items from EPIC-010 (Semantic Memory Audit 2026-06-07).

### Commit 1 — `feat(core/agent)`: SemanticMemory completeness — metadata & filtered query **[closes #1044]**

The three missing surface items from issue #1044:

| New method | What it does |
|---|---|
| `store_with_metadata(id, content, embedding, metadata)` | Stores a fact with arbitrary extra payload fields; `content` always wins over any `"content"` key in metadata |
| `update_metadata(id, updates)` | Patches existing point payload **in-place** without touching the embedding; respects TTL (`NotFound` on expired/unknown id) |
| `query_filtered(embedding, k, filter, offset)` | Vector search with payload predicate + offset pagination; TTL-expired points excluded via over-fetch budget `= 2×(need + expired_count)`, floored at `need + 8` |

DRY/clean-code refactors in the same commit:
- Private `store_internal()` eliminates duplicated validate/upsert/track code shared by `store()` and `store_with_metadata()`
- `build_payload()` — single place that composes `{content, …metadata}` (used by `store_internal` and `store_batch`)
- `payload_matches()` — payload predicate centralised for `query_filtered`
- `store_batch()` now uses `build_payload()` instead of an inline `json!()` call

8 new unit tests in `semantic_memory_tests.rs`:
- `test_store_with_metadata_persists_extra_fields`
- `test_store_with_metadata_content_wins_on_collision`
- `test_update_metadata_merges_fields`
- `test_update_metadata_unknown_id_errors`
- `test_update_metadata_expired_id_errors`
- `test_query_filtered_matches_tag`
- `test_query_filtered_skips_expired`
- `test_query_filtered_with_offset`

Every function: NLOC ≤ 50, cyclomatic complexity ≤ 8. All 163 agent-memory tests pass; `cargo clippy -- -D warnings` clean.

### Commit 2 — `fix(core/agent)`: remove dead `temporal_index` field **[closes #1049]**

`AgentMemory` held an `Arc<TemporalIndex>` with `#[allow(dead_code)]` and a speculative comment ("will be used for future implementation" — YAGNI). `EpisodicMemory` already owns its own `Arc` reference; `AgentMemory` never accessed the field. Fix: move the freshly-constructed `Arc` directly into `EpisodicMemory::new()` and drop the struct field. Public `TemporalIndex` re-export in `memory.rs` is unchanged.

---

### Issues resolved by previous PRs (#1054 / #1055) — recommend closing

A pre-merge audit confirmed the following acceptance criteria are **fully met** in the current `develop` HEAD:

| Issue | Status |
|---|---|
| **#1043** fix(core): TTL serialize/A2 documented; store_with_ttl(0) eager-delete/A3; auto_expire uses `get_expired()` not `expire()`/A4; all 4 tests present in `memory_tests.rs` | ✅ Resolved |
| **#1042** docs(agent-memory): `AGENT_MEMORY.md:87` says TS=REST; API table has TypeScript column; WASM error "Use REST backend" matches docs | ✅ Resolved |
| **#1047** feat(sdk-ts): README has `createCollection` before `storeFact`; `dimension` documented as advisory; `recordEvent`/`learnProcedure` return IDs; `deleteMemory` exists; reserved keys spread after user metadata | ✅ Resolved |
| **#1048** docs(sdk-ts): TypeScript column present in availability table; `SearchResult`/score/TTL documented at lines 739–751; standalone `SemanticMemory` limitations documented at lines 753–756 | ✅ Resolved |

---

## Test plan

- [x] `cargo test -p velesdb-core --features persistence --lib agent -- --test-threads=1` — 163 tests, 0 failures
- [x] `cargo clippy --workspace --all-targets --features persistence,gpu,update-check --exclude velesdb-python -- -D warnings -D clippy::pedantic` — clean
- [x] `cargo fmt --all --check` — clean
- [x] New methods verified against quality bar: NLOC ≤ 50, complexity ≤ 8, no `.unwrap()`/`.expect()` in production paths, `parking_lot` only, tests runnable with `--test-threads=1`

> **EPIC-010** Semantic Memory Audit
