### PR TITLE
fix(agent-memory): close EPIC-010 residual gaps (#1042 #1043 #1047 #1048)

### DIFF
--- a/crates/velesdb-core/src/agent/episodic_memory.rs
+++ b/crates/velesdb-core/src/agent/episodic_memory.rs
@@ -128,7 +128,7 @@ impl EpisodicMemory {
     /// A `ttl_seconds` of `0` means "expire immediately": rather than persisting
     /// a live point that lingers until the next `auto_expire`, the event is
     /// eagerly removed (and any pre-existing point for `event_id` deleted),
-    /// harmonising the behaviour with [`SemanticMemory::store_with_ttl`]. The
+    /// harmonising the behaviour with `SemanticMemory::store_with_ttl`. The
     /// embedding is still dimension-validated so callers get the same error
     /// contract as a real record.
     ///

--- a/crates/velesdb-core/src/agent/episodic_memory_tests.rs
+++ b/crates/velesdb-core/src/agent/episodic_memory_tests.rs
@@ -4,7 +4,7 @@
 mod tests {
     use super::super::episodic_memory::EpisodicMemory;
     use super::super::temporal_index::TemporalIndex;
-    use super::super::ttl::MemoryTtl;
+    use super::super::ttl::{MemoryKind, MemoryTtl};
     use crate::Database;
     use std::sync::Arc;
     use tempfile::tempdir;
@@ -218,7 +218,11 @@ mod tests {
     fn test_record_with_ttl_zero_expires_immediately() {
         let dir = tempdir().unwrap();
         let db = Arc::new(Database::open(dir.path()).unwrap());
-        let ep = make_episodic(Arc::clone(&db));
+        // Build with an explicit shared TTL so the assertion can bypass TTL
+        // filtering and prove *physical* removal (not a shadow-persisted point).
+        let ttl = Arc::new(MemoryTtl::new());
+        let ep = EpisodicMemory::new(db, 4, Arc::clone(&ttl), Arc::new(TemporalIndex::new()))
+            .expect("EpisodicMemory::new failed");
 
         // TTL = 0 seconds: expired as soon as it's set.
         ep.record_with_ttl(42, "ephemeral", 1_000, None, 0).unwrap();
@@ -227,6 +231,14 @@ mod tests {
         assert!(
             events.iter().all(|e| e.0 != 42),
             "TTL-0 event must not appear in recent()"
+        );
+
+        // Clear the TTL entry: a merely TTL-hidden point would now resurface.
+        // get_with_embedding returning None proves the point was physically removed.
+        ttl.remove(MemoryKind::Episodic, 42);
+        assert!(
+            ep.get_with_embedding(42).unwrap().is_none(),
+            "TTL-0 event must be physically removed, not shadow-persisted"
         );
     }
 

--- a/crates/velesdb-core/src/agent/procedural_memory.rs
+++ b/crates/velesdb-core/src/agent/procedural_memory.rs
@@ -208,7 +208,7 @@ impl ProceduralMemory {
     ///
     /// A `ttl_seconds` of `0` means "expire immediately": the procedure is
     /// eagerly removed (and any pre-existing point for `procedure_id` deleted),
-    /// harmonising the behaviour with [`SemanticMemory::store_with_ttl`]. The
+    /// harmonising the behaviour with `SemanticMemory::store_with_ttl`. The
     /// embedding is still dimension-validated so callers get the same error
     /// contract as a real learn.
     ///

--- a/crates/velesdb-core/src/agent/procedural_memory_tests.rs
+++ b/crates/velesdb-core/src/agent/procedural_memory_tests.rs
@@ -4,7 +4,7 @@
 mod tests {
     use super::super::procedural_memory::ProceduralMemory;
     use super::super::reinforcement::FixedRate;
-    use super::super::ttl::MemoryTtl;
+    use super::super::ttl::{MemoryKind, MemoryTtl};
     use crate::Database;
     use std::sync::Arc;
     use tempfile::tempdir;
@@ -237,7 +237,11 @@ mod tests {
     fn test_learn_with_ttl_zero_expires_immediately() {
         let dir = tempdir().unwrap();
         let db = Arc::new(Database::open(dir.path()).unwrap());
-        let pm = make_procedural(Arc::clone(&db));
+        // Build with an explicit shared TTL so the assertion can bypass TTL
+        // filtering and prove *physical* removal (not a shadow-persisted point).
+        let ttl = Arc::new(MemoryTtl::new());
+        let pm =
+            ProceduralMemory::new(db, 4, Arc::clone(&ttl)).expect("ProceduralMemory::new failed");
 
         let emb = vec![1.0_f32, 0.0, 0.0, 0.0];
         pm.learn_with_ttl(77, "ephemeral", &steps(1), Some(&emb), 0.8, 0)
@@ -247,6 +251,16 @@ mod tests {
         assert!(
             all.iter().all(|p| p.id != 77),
             "TTL-0 procedure must not appear in list_all()"
+        );
+
+        // Clear the TTL entry: list_all no longer filters id 77 by expiry, so it
+        // only stays absent if the point was physically removed (stored_ids +
+        // collection), not merely shadow-persisted behind the TTL filter.
+        ttl.remove(MemoryKind::Procedural, 77);
+        let all_after = pm.list_all().unwrap();
+        assert!(
+            all_after.iter().all(|p| p.id != 77),
+            "TTL-0 procedure must be physically removed, not shadow-persisted"
         );
     }
 

--- a/crates/velesdb-core/src/agent/semantic_memory.rs
+++ b/crates/velesdb-core/src/agent/semantic_memory.rs
@@ -28,7 +28,17 @@ pub struct SemanticMemory {
 impl SemanticMemory {
     const COLLECTION_NAME: &'static str = "_semantic_memory";
 
-    /// Creates or opens semantic memory.
+    /// Creates or opens semantic memory with an **independent** in-memory TTL.
+    ///
+    /// # Standalone limitation
+    ///
+    /// The [`MemoryTtl`] allocated here is not shared with any snapshot
+    /// mechanism: TTL entries live in memory only and are **lost on restart**.
+    /// [`Self::serialize`] / [`Self::deserialize`] carry stored points but
+    /// intentionally omit TTL state (see [`Self::serialize`] for the full
+    /// contract). For full TTL persistence and snapshot support, create an
+    /// [`AgentMemory`](crate::agent::AgentMemory) instead — it owns the shared
+    /// `MemoryTtl`, snapshot manager, and all three subsystems.
     ///
     /// # Errors
     ///

--- a/crates/velesdb-core/src/quantization/pq.rs
+++ b/crates/velesdb-core/src/quantization/pq.rs
@@ -337,7 +337,7 @@ impl ProductQuantizer {
     /// (see [`Self::load_codebook`]) before it is used for search. After this
     /// returns `Ok`, the codebook layout matches its declared dimensions and
     /// the rotation matrix (if present) is `dimension * dimension`, so the
-    /// unchecked indexing in [`apply_rotation`](Self::apply_rotation) operates
+    /// unchecked indexing in `apply_rotation` operates
     /// only on in-bounds offsets.
     ///
     /// # Errors

--- a/crates/velesdb-core/src/quantization/pq_persistence.rs
+++ b/crates/velesdb-core/src/quantization/pq_persistence.rs
@@ -90,7 +90,7 @@ impl ProductQuantizer {
     ///
     /// Returns `Error::Io` if deserialization or file I/O fails, or
     /// `Error::IndexCorrupted` if the decoded codebook/rotation is inconsistent
-    /// or the file exceeds [`MAX_PQ_ARTIFACT_BYTES`].
+    /// or the file exceeds `MAX_PQ_ARTIFACT_BYTES`.
     pub fn load_codebook(dir: &std::path::Path) -> Result<Option<Self>, Error> {
         let Some(quantizer): Option<Self> = postcard_load(dir, "codebook.pq", "PQ codebook")?
         else {

--- a/crates/velesdb-core/src/quantization/rabitq.rs
+++ b/crates/velesdb-core/src/quantization/rabitq.rs
@@ -382,9 +382,9 @@ impl RaBitQIndex {
 
     /// Load `RaBitQ` index from `<dir>/rabitq.idx`. Returns `None` if file doesn't exist.
     ///
-    /// The decoded index is validated ([`Self::validate_loaded`]) so a corrupt
+    /// The decoded index is validated (`validate_loaded`) so a corrupt
     /// rotation/centroid is rejected here rather than producing out-of-bounds
-    /// indexing in [`apply_rotation_flat`] during search.
+    /// indexing in `apply_rotation_flat` during search.
     ///
     /// # Errors
     ///

--- a/crates/velesdb-core/src/sparse_index/inverted_index.rs
+++ b/crates/velesdb-core/src/sparse_index/inverted_index.rs
@@ -143,7 +143,7 @@ impl SparseInvertedIndex {
     /// Inserts a batch of sparse vectors while acquiring the mutable lock once.
     ///
     /// Acquires the write lock once for the entire slice, making this significantly
-    /// faster than calling [`insert`] per document in a parallel/bulk context.
+    /// faster than calling `insert` per document in a parallel/bulk context.
     /// Callers building a parallel bulk-import pipeline should chunk their input
     /// and call this method once per chunk rather than calling `insert` per document.
     ///

--- a/crates/velesdb-core/src/velesql/planner.rs
+++ b/crates/velesdb-core/src/velesql/planner.rs
@@ -210,7 +210,7 @@ impl QueryPlanner {
     ///
     /// Called after each vector query with the dataset size, ef_search used,
     /// and the actual wall-clock duration. The feedback loop adjusts
-    /// `ms_per_cost_unit` via EMA with α=0.05 after [`MIN_SAMPLES`] observations.
+    /// `ms_per_cost_unit` via EMA with α=0.05 after `MIN_SAMPLES` observations.
     pub fn record_cbo_feedback(&self, dataset_size: usize, ef_search: usize, actual_ms: f64) {
         self.cbo_feedback.record(dataset_size, ef_search, actual_ms);
     }

--- a/docs/guides/AGENT_MEMORY.md
+++ b/docs/guides/AGENT_MEMORY.md
@@ -831,12 +831,19 @@ memory.snapshot()?;
 memory.load_latest_snapshot()?;
 ```
 
-> **Standalone `SemanticMemory` (embedded Rust / WASM only).** The Rust/WASM
-> crates can construct a standalone in-memory `SemanticMemory` without a backing
-> `Database`. In that mode it has **no auto-snapshot and no auto-load**, and any
-> TTL is enforced **in memory only** — entries are not persisted and expiry state
-> is lost on restart. This standalone constructor is not reachable from the
-> REST-backed TypeScript SDK (which has no in-process engine at all).
+> **Using `SemanticMemory` on its own.** The supported path is `AgentMemory`,
+> which owns the shared `MemoryTtl` and snapshot manager, so TTL and snapshots
+> round-trip across restarts. If you reach for a `SemanticMemory` directly:
+> - **Rust core** — `SemanticMemory::new_from_db(db, dim)` still requires a
+>   backing `Database`, but allocates a *fresh* `MemoryTtl` that is **not** wired
+>   to any snapshot manager; `serialize`/`deserialize` carry stored facts and
+>   intentionally omit TTL state, so expiry is **lost on restart**.
+> - **WASM** — a fully standalone, DB-less `SemanticMemory::new(dim)` exists
+>   (no auto-snapshot, no auto-load, payloads are not serialized).
+> - **Python** has no standalone `SemanticMemory` constructor — it is reachable
+>   only through `AgentMemory.semantic` (shared, snapshot-backed TTL).
+> - **TypeScript** is REST-backed with no in-process engine, so none of this
+>   applies.
 
 ### API Availability by Binding
 

--- a/docs/guides/AGENT_MEMORY.md
+++ b/docs/guides/AGENT_MEMORY.md
@@ -831,6 +831,13 @@ memory.snapshot()?;
 memory.load_latest_snapshot()?;
 ```
 
+> **Standalone `SemanticMemory` (embedded Rust / WASM only).** The Rust/WASM
+> crates can construct a standalone in-memory `SemanticMemory` without a backing
+> `Database`. In that mode it has **no auto-snapshot and no auto-load**, and any
+> TTL is enforced **in memory only** — entries are not persisted and expiry state
+> is lost on restart. This standalone constructor is not reachable from the
+> REST-backed TypeScript SDK (which has no in-process engine at all).
+
 ### API Availability by Binding
 
 The **Python** and **Rust** bindings run embedded; the **TypeScript** SDK is
@@ -840,6 +847,13 @@ REST-backed (`db.agentMemory(...)`, methods named `storeFact` / `searchFacts` /
 three subsystems; temporal/confidence-only queries, reinforcement, TTL, and
 snapshots are embedded-only.
 
+The TypeScript method names diverge from the embedded Python/Rust API
+(`storeFact` vs `store`, `searchFacts` vs `query`, …) **by design**: the TS SDK
+follows JavaScript camelCase conventions and disambiguates the three subsystems
+(`storeFact` / `recordEvent` / `learnProcedure`) on a single REST facade, whereas
+the embedded bindings expose each subsystem as its own object (`semantic.store`,
+`episodic.record`, `procedural.learn`). The mapping below is the source of truth.
+
 | Method | Python | Rust | TypeScript (REST) |
 |--------|--------|------|-------------------|
 | `semantic.store()` | Yes | Yes | Yes (`storeFact`) |
@@ -848,16 +862,16 @@ snapshots are embedded-only.
 | `episodic.record()` | Yes | Yes | Yes (`recordEvent`, returns id) |
 | `episodic.recent()` | Yes | Yes | No (no temporal query) |
 | `episodic.recall_similar()` | Yes | Yes | Yes (`recallEvents`) |
-| `episodic.older_than()` | Yes | Yes | No |
+| `episodic.older_than()` | Yes | Yes | No (no temporal query) |
 | `episodic.delete()` | Yes | Yes | Yes (`deleteMemory`) |
 | `procedural.learn()` | Yes | Yes | Yes (`learnProcedure`, returns id) |
 | `procedural.recall()` | Yes | Yes | Yes (`recallProcedures`) |
-| `procedural.reinforce()` | Yes | Yes | No |
-| `procedural.list_all()` | Yes | Yes | No |
+| `procedural.reinforce()` | Yes | Yes | No (confidence scoring embedded-only) |
+| `procedural.list_all()` | Yes | Yes | No (embedded-only) |
 | `procedural.delete()` | Yes | Yes | Yes (`deleteMemory`) |
-| TTL management (`set_*_ttl`, `store_with_ttl`, `auto_expire`) | Yes | Yes | No |
-| Snapshots (`snapshot`, `load_*_snapshot`, `list_snapshot_versions`) | Yes | Yes | No |
-| VelesQL bridges (`query_semantic` / `query_episodic` / `query_procedural`) | Yes | Yes | No |
+| TTL management (`set_*_ttl`, `store_with_ttl`, `auto_expire`) | Yes | Yes | No (embedded-only) |
+| Snapshots (`snapshot`, `load_*_snapshot`, `list_snapshot_versions`) | Yes | Yes | No (embedded-only) |
+| VelesQL bridges (`query_semantic` / `query_episodic` / `query_procedural`) | Yes | Yes | No (embedded-only) |
 
 ---
 
@@ -908,12 +922,7 @@ Each recall returns `SearchResult[]` = `{ id, score, payload?, vector? }`:
   (readable via `memory.dimension`); the collection's own dimension governs
   storage and search.
 - **TTL and snapshots are not exposed over REST** — they are embedded-only
-  (Rust). When used, TTL durations are in **seconds**.
-
-> **Standalone `SemanticMemory`.** If you use a standalone in-memory
-> `SemanticMemory` (without a backing `Database`), it has **no auto-snapshot and
-> no auto-load**, and any TTL is enforced **in memory only** — entries are not
-> persisted and expiry state is lost on restart.
+  (Python and Rust). When used, TTL durations are in **seconds**.
 
 ---
 

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -818,10 +818,13 @@ Each recall method returns `SearchResult[]`:
 
 - `score` is the cosine similarity in `[0, 1]` (for a `cosine` collection);
   higher means more similar.
-- `payload` carries the stored fields (`text`, `event_type`, `name`, `steps`,
-  plus your metadata). The reserved keys `_memory_type` / `text` /
+- `payload` carries the stored fields (`content` for semantic text,
+  `event_type` / `timestamp` for episodic, `name` / `steps` for procedural,
+  plus your metadata). The reserved payload keys `_memory_type` / `content` /
   `event_type` / `timestamp` / `name` / `steps` always take precedence over
   caller `metadata`/`data` of the same name, so they cannot be clobbered.
+  Note: the `SemanticEntry.text` input field is stored as `content` in the
+  payload — `result.payload?.content` is the fact text on recall.
 
 #### Semantic Memory (facts and knowledge)
 

--- a/sdks/typescript/src/agent-memory.ts
+++ b/sdks/typescript/src/agent-memory.ts
@@ -84,8 +84,13 @@ export class AgentMemoryClient {
     return this.backend.matchProceduralPatterns(collection, embedding, k);
   }
 
-  /** Delete a memory entry (fact, event, or procedure) by its point ID. */
-  async deleteMemory(collection: string, id: number): Promise<boolean> {
+  /**
+   * Delete a memory entry (fact, event, or procedure) by its point ID.
+   *
+   * Accepts the `string` ids returned by `recordEvent` / `learnProcedure`
+   * (u64-safe decimal strings) as well as numeric ids.
+   */
+  async deleteMemory(collection: string, id: string | number): Promise<boolean> {
     return this.backend.delete(collection, id);
   }
 }

--- a/sdks/typescript/src/backends/agent-memory-backend.ts
+++ b/sdks/typescript/src/backends/agent-memory-backend.ts
@@ -87,15 +87,15 @@ export function memoryIdToString(id: number): string {
  * Normalise a caller-provided point id into the numeric u64 the REST wire
  * accepts. Accepts a `string | number`; a string must be a decimal integer.
  *
- * Delegates range/integer validation to {@link parseRestPointId} so the rule
- * ("non-negative integer within the JS safe-integer range") lives in exactly
- * one place. The REST server deserialises point ids as JSON numbers, so ids
- * above `Number.MAX_SAFE_INTEGER` cannot be transmitted and are rejected here
- * rather than silently corrupted.
+ * A thin intent-revealing alias over {@link parseRestPointId}, which owns the
+ * string→number coercion and the range/integer validation ("non-negative
+ * integer within the JS safe-integer range") in exactly one place. The REST
+ * server deserialises point ids as JSON numbers, so ids above
+ * `Number.MAX_SAFE_INTEGER` cannot be transmitted and are rejected rather than
+ * silently corrupted.
  */
 export function resolveWireId(id: string | number): number {
-  const numeric = typeof id === 'string' ? Number(id) : id;
-  return parseRestPointId(numeric);
+  return parseRestPointId(id);
 }
 
 /** Current unix time in **seconds** (floor of epoch-millis / 1000). */

--- a/sdks/typescript/src/backends/crud-backend.ts
+++ b/sdks/typescript/src/backends/crud-backend.ts
@@ -28,8 +28,12 @@ export type CrudTransport = BaseTransport;
 export function parseRestPointId(id: string | number): RestPointId {
   // A decimal-string id (e.g. the u64-safe strings returned by the agent-memory
   // record/learn helpers) is coerced to a number before range validation, so
-  // string and numeric ids share one validation gate.
-  const numeric = typeof id === 'string' ? Number(id) : id;
+  // string and numeric ids share one validation gate. Only a plain run of
+  // digits is accepted — no sign, whitespace, decimal point, exponent, or hex —
+  // so '' / '  ' / '1e3' / '0x10' are rejected instead of silently coercing
+  // (`Number('')` would otherwise become 0).
+  const numeric =
+    typeof id === 'string' ? (/^\d+$/.test(id) ? Number(id) : NaN) : id;
   if (
     typeof numeric !== 'number' ||
     !Number.isFinite(numeric) ||

--- a/sdks/typescript/src/backends/crud-backend.ts
+++ b/sdks/typescript/src/backends/crud-backend.ts
@@ -26,18 +26,22 @@ import {
 export type CrudTransport = BaseTransport;
 
 export function parseRestPointId(id: string | number): RestPointId {
+  // A decimal-string id (e.g. the u64-safe strings returned by the agent-memory
+  // record/learn helpers) is coerced to a number before range validation, so
+  // string and numeric ids share one validation gate.
+  const numeric = typeof id === 'string' ? Number(id) : id;
   if (
-    typeof id !== 'number' ||
-    !Number.isFinite(id) ||
-    id < 0 ||
-    !Number.isInteger(id) ||
-    id > Number.MAX_SAFE_INTEGER
+    typeof numeric !== 'number' ||
+    !Number.isFinite(numeric) ||
+    numeric < 0 ||
+    !Number.isInteger(numeric) ||
+    numeric > Number.MAX_SAFE_INTEGER
   ) {
     throw new ValidationError(
       `REST backend requires numeric u64-compatible IDs in JS safe integer range (0..${Number.MAX_SAFE_INTEGER}). Received: ${String(id)}`
     );
   }
-  return id;
+  return numeric;
 }
 
 export function sparseVectorToRestFormat(sv: SparseVector): Record<string, number> {

--- a/sdks/typescript/src/client/validation.ts
+++ b/sdks/typescript/src/client/validation.ts
@@ -8,6 +8,7 @@
 
 import type { VectorDocument, VelesDBConfig } from '../types';
 import { ValidationError } from '../types';
+import { parseRestPointId } from '../backends/crud-backend';
 
 /** Validate that a value is a non-empty string, throwing with the given label. */
 export function requireNonEmptyString(value: unknown, label: string): void {
@@ -55,19 +56,8 @@ export function validateRestPointId(id: string | number, config: VelesDBConfig):
   if (config.backend !== 'rest') {
     return;
   }
-  // Mirror parseRestPointId (backend layer): a string id is valid only as a
-  // plain run of decimal digits, coerced to a number for the range checks, so
-  // the u64-safe string ids returned by agent memory pass the same gate.
-  const numeric = typeof id === 'string' && /^\d+$/.test(id) ? Number(id) : id;
-  if (
-    typeof numeric !== 'number' ||
-    !Number.isFinite(numeric) ||
-    !Number.isInteger(numeric) ||
-    numeric < 0 ||
-    numeric > Number.MAX_SAFE_INTEGER
-  ) {
-    throw new ValidationError(
-      `REST backend requires numeric u64-compatible document IDs in JS safe integer range (0..${Number.MAX_SAFE_INTEGER})`
-    );
-  }
+  // Delegate to the canonical backend gate so the string→number coercion and
+  // the "non-negative integer within JS safe-integer range" rule for REST point
+  // ids live in exactly one place (it throws `ValidationError` on a bad id).
+  parseRestPointId(id);
 }

--- a/sdks/typescript/src/client/validation.ts
+++ b/sdks/typescript/src/client/validation.ts
@@ -61,6 +61,7 @@ export function validateRestPointId(id: string | number, config: VelesDBConfig):
   const numeric = typeof id === 'string' && /^\d+$/.test(id) ? Number(id) : id;
   if (
     typeof numeric !== 'number' ||
+    !Number.isFinite(numeric) ||
     !Number.isInteger(numeric) ||
     numeric < 0 ||
     numeric > Number.MAX_SAFE_INTEGER

--- a/sdks/typescript/src/client/validation.ts
+++ b/sdks/typescript/src/client/validation.ts
@@ -52,14 +52,18 @@ export function validateDocument(doc: VectorDocument, config: VelesDBConfig): vo
 
 /** Validate that a document ID is a valid REST point ID when using REST backend. */
 export function validateRestPointId(id: string | number, config: VelesDBConfig): void {
+  if (config.backend !== 'rest') {
+    return;
+  }
+  // Mirror parseRestPointId (backend layer): a string id is valid only as a
+  // plain run of decimal digits, coerced to a number for the range checks, so
+  // the u64-safe string ids returned by agent memory pass the same gate.
+  const numeric = typeof id === 'string' && /^\d+$/.test(id) ? Number(id) : id;
   if (
-    config.backend === 'rest' &&
-    (
-      typeof id !== 'number' ||
-      !Number.isInteger(id) ||
-      id < 0 ||
-      id > Number.MAX_SAFE_INTEGER
-    )
+    typeof numeric !== 'number' ||
+    !Number.isInteger(numeric) ||
+    numeric < 0 ||
+    numeric > Number.MAX_SAFE_INTEGER
   ) {
     throw new ValidationError(
       `REST backend requires numeric u64-compatible document IDs in JS safe integer range (0..${Number.MAX_SAFE_INTEGER})`

--- a/sdks/typescript/tests/agent-memory.test.ts
+++ b/sdks/typescript/tests/agent-memory.test.ts
@@ -189,6 +189,27 @@ describe('Agent Memory REST methods', () => {
     });
   });
 
+  describe('delete accepts string ids (Issue #1047)', () => {
+    it('should delete by a decimal-string id (as returned by recordEvent/learnProcedure)', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ deleted: true }),
+      });
+
+      // recordEvent/learnProcedure return ids as strings; the delete path must
+      // accept them and coerce to the numeric REST wire id, not throw.
+      const result = await backend.delete('events', '12345');
+
+      expect(result).toBe(true);
+      const url = mockFetch.mock.calls[0][0] as string;
+      expect(url).toMatch(/\/points\/12345$/);
+    });
+
+    it('should reject a non-integer string id', async () => {
+      await expect(backend.delete('events', '12.5')).rejects.toThrow(/numeric u64/);
+    });
+  });
+
   describe('recordEpisodicEvent (Issue #7)', () => {
     it('should use generateUniqueId instead of Date.now for the point ID', async () => {
       const fixed = 1700000000000;

--- a/sdks/typescript/tests/agent-memory.test.ts
+++ b/sdks/typescript/tests/agent-memory.test.ts
@@ -208,6 +208,14 @@ describe('Agent Memory REST methods', () => {
     it('should reject a non-integer string id', async () => {
       await expect(backend.delete('events', '12.5')).rejects.toThrow(/numeric u64/);
     });
+
+    it('should reject malformed string ids instead of coercing them', async () => {
+      // Number('') / Number('  ') === 0 and Number('1e3') === 1000 — these must
+      // be rejected, not silently treated as a valid id.
+      for (const bad of ['', '   ', '1e3', '0x10', '-5']) {
+        await expect(backend.delete('events', bad)).rejects.toThrow(/numeric u64/);
+      }
+    });
   });
 
   describe('recordEpisodicEvent (Issue #7)', () => {

--- a/sdks/typescript/tests/agent-memory.test.ts
+++ b/sdks/typescript/tests/agent-memory.test.ts
@@ -149,6 +149,44 @@ describe('Agent Memory REST methods', () => {
       expect(point.payload.name).toBe('real-name');
       expect(point.payload.steps).toEqual(['a']);
     });
+
+    it('should not let caller metadata clobber reserved semantic keys', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({}),
+      });
+
+      await backend.storeSemanticFact('facts', {
+        id: 1,
+        text: 'real-fact',
+        embedding: [0.1],
+        metadata: { _memory_type: 'hacked', content: 'spoofed' },
+      });
+
+      const point = JSON.parse(mockFetch.mock.calls[0][1].body).points[0];
+      expect(point.payload._memory_type).toBe('semantic');
+      expect(point.payload.content).toBe('real-fact');
+    });
+
+    it('should not let caller data/metadata clobber reserved episodic keys', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({}),
+      });
+
+      await backend.recordEpisodicEvent('events', {
+        eventType: 'real-event',
+        embedding: [0.1],
+        timestamp: 123,
+        data: { _memory_type: 'hacked', event_type: 'spoofed', timestamp: 999 },
+        metadata: { _memory_type: 'hacked2', event_type: 'spoofed2' },
+      });
+
+      const point = JSON.parse(mockFetch.mock.calls[0][1].body).points[0];
+      expect(point.payload._memory_type).toBe('episodic');
+      expect(point.payload.event_type).toBe('real-event');
+      expect(point.payload.timestamp).toBe(123);
+    });
   });
 
   describe('recordEpisodicEvent (Issue #7)', () => {

--- a/sdks/typescript/tests/client.test.ts
+++ b/sdks/typescript/tests/client.test.ts
@@ -153,6 +153,17 @@ describe('VelesDB Client', () => {
       await expect(db.get('docs', tooLarge)).rejects.toThrow(ValidationError);
       await expect(db.delete('docs', tooLarge)).rejects.toThrow(ValidationError);
     });
+
+    it('accepts decimal-string IDs for get/delete on REST backend (Issue #1047)', async () => {
+      // u64-safe string ids returned by recordEvent/learnProcedure must pass
+      // client validation and delegate to the backend, not be rejected.
+      mockBackend.delete.mockResolvedValue(true);
+      mockBackend.get.mockResolvedValue({ id: 12345, vector: [0.1] });
+
+      await expect(db.delete('docs', '12345')).resolves.toBe(true);
+      expect(mockBackend.delete).toHaveBeenCalledWith('docs', '12345');
+      await expect(db.get('docs', '12345')).resolves.toEqual({ id: 12345, vector: [0.1] });
+    });
   });
 
   describe('operations', () => {

--- a/sdks/typescript/tests/validation.test.ts
+++ b/sdks/typescript/tests/validation.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Tests for client-layer REST point-id validation.
+ *
+ * #1047: `validateRestPointId` guards `db.delete` / `db.get` / upsert on the
+ * REST backend. It must accept the u64-safe decimal-string ids returned by the
+ * agent-memory helpers (consistent with the backend's `parseRestPointId`), and
+ * reject malformed strings rather than silently coercing them.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { validateRestPointId } from '../src/client/validation';
+import { ValidationError } from '../src/types';
+import type { VelesDBConfig } from '../src/types';
+
+const rest = { backend: 'rest', url: 'http://localhost:8080' } as VelesDBConfig;
+const wasm = { backend: 'wasm' } as VelesDBConfig;
+
+describe('validateRestPointId', () => {
+  it('accepts numeric ids in range', () => {
+    expect(() => validateRestPointId(0, rest)).not.toThrow();
+    expect(() => validateRestPointId(12345, rest)).not.toThrow();
+  });
+
+  it('accepts decimal-string ids (as returned by recordEvent/learnProcedure)', () => {
+    expect(() => validateRestPointId('0', rest)).not.toThrow();
+    expect(() => validateRestPointId('12345', rest)).not.toThrow();
+  });
+
+  it('rejects malformed string ids instead of coercing them', () => {
+    for (const bad of ['', '   ', '1e3', '0x10', '-5', '12.5', '12abc']) {
+      expect(() => validateRestPointId(bad, rest)).toThrow(ValidationError);
+    }
+  });
+
+  it('rejects out-of-range and non-integer numbers', () => {
+    expect(() => validateRestPointId(-1, rest)).toThrow(ValidationError);
+    expect(() => validateRestPointId(1.5, rest)).toThrow(ValidationError);
+    expect(() => validateRestPointId(Number.MAX_SAFE_INTEGER + 1, rest)).toThrow(ValidationError);
+  });
+
+  it('skips validation entirely for non-REST backends', () => {
+    expect(() => validateRestPointId('anything', wasm)).not.toThrow();
+    expect(() => validateRestPointId(-1, wasm)).not.toThrow();
+  });
+});

--- a/sdks/typescript/tests/wasm-stubs-full.test.ts
+++ b/sdks/typescript/tests/wasm-stubs-full.test.ts
@@ -180,6 +180,16 @@ const stubCases: StubCase[] = [
     feature: /Agent memory/,
   },
   {
+    name: 'wasmRecallRecentEvents',
+    call: () => wasmStubs.wasmRecallRecentEvents('c', 0),
+    feature: /Agent memory/,
+  },
+  {
+    name: 'wasmRecallOlderThanEvents',
+    call: () => wasmStubs.wasmRecallOlderThanEvents('c', 0),
+    feature: /Agent memory/,
+  },
+  {
     name: 'wasmStoreProceduralPattern',
     call: () =>
       wasmStubs.wasmStoreProceduralPattern('c', {} as ProceduralPattern),
@@ -209,7 +219,7 @@ describe.each(stubCases)('wasm-stubs: $name', ({ call, feature }) => {
 });
 
 describe('wasm-stubs — cardinality guard', () => {
-  it('covers all 27 stub exports (index + graph + explain + sparse + agent)', () => {
-    expect(stubCases).toHaveLength(27);
+  it('covers all 29 stub exports (index + graph + explain + sparse + agent)', () => {
+    expect(stubCases).toHaveLength(29);
   });
 });


### PR DESCRIPTION
## Summary

Closes the four open EPIC-010 agent-memory follow-ups. An audit (per-criterion verify + skeptic challenge) confirmed **most acceptance criteria were already satisfied on `develop`** (PR #1071) and surfaced the **residual gaps** fixed here. A second rigorous re-verification then caught a real runtime bug hidden behind a cosmetic type change (see #1047 below); all 9 residual gaps are now confirmed closed.

### #1042 — docs REST-vs-embedded coherence
- TTL/snapshots labelled `embedded-only (Python and Rust)` (was `(Rust)`, contradicting the rest of the guide).
- API-availability table: every `No` cell now carries a consistent inline reason.

### #1043 — TTL semantics
- A2/A3/A4 were already correct on `develop`. Strengthened the **episodic** and **procedural** `ttl=0` tests to prove *physical* removal (clear the TTL entry, then assert the point is gone) instead of relying on TTL-filtered views.

### #1047 — TS DX
- `deleteMemory` accepts `string | number`, **and the runtime path now honours it**: `parseRestPointId` coerces a decimal-digit string to a number (one shared validation gate for delete/get/upsert/streaming); `resolveWireId` collapses to a thin alias. Malformed strings (`''`, `'  '`, `'1e3'`, `'0x10'`, `'-5'`) are rejected, not silently coerced.
- The client-layer `validateRestPointId` (used by `db.delete`/`db.get`/upsert) was likewise rejecting all strings; aligned it to the same decimal-string contract so the public API is consistent end-to-end.
- Added reserved-key collision tests for **semantic** and **episodic** (procedural already covered).

### #1048 — TS docs
- Documented the camelCase-vs-embedded naming divergence as intentional.
- Relocated the *standalone `SemanticMemory`* note out of the TS/REST section, labelled it embedded Rust/WASM-only (resolves the WASM-FAQ contradiction).
- Covered the two previously-untested WASM agent-memory stubs (`wasmRecallRecentEvents`, `wasmRecallOlderThanEvents`).

## Validation
- `cargo test -p velesdb-core --features persistence` (single-threaded) — green
- `cargo clippy -p velesdb-core --all-targets --features persistence -- -D warnings -D clippy::pedantic` — clean · `cargo fmt --all` — no collateral
- TS: `tsc --noEmit` clean · `eslint src` clean · `vitest run` — **757 passed (32 files)**

Closes #1042, closes #1043, closes #1047, closes #1048.

---

### Audit follow-up (commit 43d872cb)

Review/simplify/fix pass over this PR plus the now-closed #1073 (superseded), reconciled against code ground-truth:

- **Docs accuracy** — `AGENT_MEMORY.md` standalone-`SemanticMemory` note rewritten per binding: only WASM is DB-less; Rust core `new_from_db` needs a `Database` but its `MemoryTtl` is not snapshot-backed (TTL lost on restart); Python only via `AgentMemory`; TS REST-only. `semantic_memory.rs` documents the `new_from_db` TTL limitation. TS README: semantic text is stored under payload key `content` (not `text`).
- **Clean code / DRY** — `validateRestPointId` now delegates to the canonical `parseRestPointId` gate (removed duplicated regex/range logic).
- **Zero-debt sweep** — fixed broken/private rustdoc intra-doc links (agent, quantization, sparse_index, velesql) so the crate documents cleanly under `-D warnings`.

Validation: TS typecheck + 757 tests + eslint green; Rust fmt + clippy pedantic + rustdoc `-D warnings` + agent TTL tests green.

