### PR TITLE
docs: fix payload key text→content, accurate standalone-memory note, Rust new_from_db limits

### DIFF
--- a/crates/velesdb-core/src/agent/semantic_memory.rs
+++ b/crates/velesdb-core/src/agent/semantic_memory.rs
@@ -28,7 +28,19 @@ pub struct SemanticMemory {
 impl SemanticMemory {
     const COLLECTION_NAME: &'static str = "_semantic_memory";
 
-    /// Creates or opens semantic memory.
+    /// Creates or opens semantic memory with an **independent** in-memory TTL.
+    ///
+    /// # Standalone Limitations
+    ///
+    /// The [`MemoryTtl`] allocated here is not shared with any snapshot
+    /// mechanism: TTL entries live in memory only and are **lost on restart**.
+    /// [`Self::serialize`] / [`Self::deserialize`] carry stored points but
+    /// intentionally omit TTL state (see [`Self::serialize`] for the full
+    /// contract).
+    ///
+    /// For full TTL persistence and snapshot support, create an
+    /// [`AgentMemory`](super::AgentMemory) instead — it owns the shared
+    /// `MemoryTtl`, snapshot manager, and all three subsystems.
     ///
     /// # Errors
     ///

--- a/docs/guides/AGENT_MEMORY.md
+++ b/docs/guides/AGENT_MEMORY.md
@@ -831,6 +831,14 @@ memory.snapshot()?;
 memory.load_latest_snapshot()?;
 ```
 
+> **Using `SemanticMemory` directly.** `SemanticMemory::new_from_db()` (and
+> its Python/Rust counterparts) allocates a fresh in-memory `MemoryTtl` that
+> is **not** backed by a snapshot mechanism: TTL entries are **lost on
+> restart** and `serialize`/`deserialize` carry stored points but intentionally
+> omit TTL state. For full snapshot and TTL persistence, use `AgentMemory`
+> and call `snapshot()` / `load_latest_snapshot()` (see
+> [Snapshots & Restore](#snapshots--restore)).
+
 ### API Availability by Binding
 
 The **Python** and **Rust** bindings run embedded; the **TypeScript** SDK is
@@ -908,12 +916,7 @@ Each recall returns `SearchResult[]` = `{ id, score, payload?, vector? }`:
   (readable via `memory.dimension`); the collection's own dimension governs
   storage and search.
 - **TTL and snapshots are not exposed over REST** — they are embedded-only
-  (Rust). When used, TTL durations are in **seconds**.
-
-> **Standalone `SemanticMemory`.** If you use a standalone in-memory
-> `SemanticMemory` (without a backing `Database`), it has **no auto-snapshot and
-> no auto-load**, and any TTL is enforced **in memory only** — entries are not
-> persisted and expiry state is lost on restart.
+  (Rust/Python). When used from Rust or Python, TTL durations are in **seconds**.
 
 ---
 

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -818,10 +818,13 @@ Each recall method returns `SearchResult[]`:
 
 - `score` is the cosine similarity in `[0, 1]` (for a `cosine` collection);
   higher means more similar.
-- `payload` carries the stored fields (`text`, `event_type`, `name`, `steps`,
-  plus your metadata). The reserved keys `_memory_type` / `text` /
+- `payload` carries the stored fields (`content` for semantic text,
+  `event_type` / `timestamp` for episodic, `name` / `steps` for procedural,
+  plus your metadata). The reserved payload keys `_memory_type` / `content` /
   `event_type` / `timestamp` / `name` / `steps` always take precedence over
   caller `metadata`/`data` of the same name, so they cannot be clobbered.
+  Note: the `SemanticEntry.text` input field is stored as `content` in the
+  payload — `result.payload?.content` is the fact text on recall.
 
 #### Semantic Memory (facts and knowledge)
 


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Closes remaining open items from the EPIC-010 agent-memory audit (2026-06-07).

### Changes

**`sdks/typescript/README.md`** — fixes #1047 D7
- Corrected the reserved payload keys list: semantic text is stored under `content`, not `text` (`SemanticEntry.text` → `payload.content`). Added a note that `result.payload?.content` holds the fact text on recall.
- Previous wording could lead callers to protect the wrong metadata key.

**`docs/guides/AGENT_MEMORY.md`** — fixes #1048 E4
- Added an accurate callout in the **Rust API** section explaining that `SemanticMemory::new_from_db()` allocates an independent in-memory `MemoryTtl` with no snapshot backing — TTL entries are lost on restart.
- Removed an inaccurate note from the TypeScript section that said "without a backing Database" (impossible: `SemanticMemory` always requires `Arc<Database>`).
- Clarified "embedded-only (Rust)" → "embedded-only (Rust/Python)" for TTL/snapshot note.

**`crates/velesdb-core/src/agent/semantic_memory.rs`** — fixes #1048 E4
- Added `# Standalone Limitations` doc section to `new_from_db()` describing in-memory-only TTL and missing snapshot, and directing callers to `AgentMemory` for full persistence.

### Verification

All four EPIC-010 audit issues are now fully addressed:
- **#1042** — REST-vs-embedded contradiction: already resolved in previous commits; doc is consistent throughout.
- **#1043** — TTL serialize/store_with_ttl/auto_expire bugs: already fixed + tests added in previous commits.
- **#1047** — TypeScript DX (createCollection, advisory dimension, return IDs, delete, reserved keys): all items addressed; this PR closes D7 (payload key name).
- **#1048** — TS API column, SearchResult docs, SemanticMemory standalone note: all items addressed; this PR closes E4 (doc + code).

## Test plan

- [ ] `cargo doc --no-deps -p velesdb-core` — rustdoc on `new_from_db` renders without warnings
- [ ] Review `docs/guides/AGENT_MEMORY.md` Rust API section — new callout is accurate and well-placed
- [ ] Review `sdks/typescript/README.md` payload section — `content` is the correct key for semantic text recall

**Date**: 2026-06-10

https://claude.ai/code/session_014XBJZF2Hn9rHmaJw88F5q1
EOF
)
