### PR TITLE
fix: deep audit 2026-06 — flagship hybrid query, WAL durability, quantized ranking, MATCH semantics, agent TTL, SDK honesty

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -16,7 +16,7 @@ VelesDB is a **single-binary, embeddable database** that fuses a **vector index 
 
 | Engine | What it does | Backed by |
 |--------|-------------|-----------|
-| **Vector** | k-nearest-neighbor search over high-dimensional embeddings | Native HNSW + SIMD-accelerated distance kernels (AVX-512, AVX2, NEON, WASM SIMD128) |
+| **Vector** | k-nearest-neighbor search over high-dimensional embeddings | Native HNSW + SIMD-accelerated distance kernels (AVX-512, AVX2, NEON; WASM uses the scalar fallback — SIMD128 kernels planned) |
 | **Graph** | Node/edge storage with BFS/DFS traversal, relationship properties | CSR-snapshot zero-copy traversal, FxHashSet visited sets |
 | **ColumnStore** | Typed metadata filtering (eq, range, IN, BETWEEN, LIKE) at scale | Per-column secondary indexes, RoaringBitmap for set operations |
 
@@ -93,7 +93,7 @@ Here is what happens, end-to-end, in roughly the order it happens. This is the p
 3. **Plan.** The cost-based optimizer (CBO) in `crates/velesdb-core/src/velesql/cost_estimator/` picks an execution strategy. For a vector + filter query, the choice is typically between *pre-filter* (apply the WHERE first then NEAR on the remaining points) and *post-filter* (NEAR first then WHERE on the result). Selectivity statistics drive the choice.
 4. **Cache.** A two-tier LRU plan cache (write-generation invalidated) hits or misses. A hit short-circuits steps 1–3 for repeat queries (~1 µs cache hit).
 5. **Execute.** The plan calls into the index layer:
-   - HNSW search descends the graph, calling SIMD distance kernels (one of AVX-512 / AVX2 / NEON / WASM SIMD128 / scalar) chosen at runtime by `simd_dispatch.rs`.
+   - HNSW search descends the graph, calling SIMD distance kernels (one of AVX-512 / AVX2 / NEON / scalar) chosen at runtime by `simd_dispatch.rs`; WASM dispatches to the scalar fallback (SIMD128 kernels planned).
    - The filter engine applies `date > '2024-01-01'` against the secondary index (RoaringBitmap intersection if multiple predicates).
 6. **Hydrate.** Top-k IDs are resolved to full `Point` records (vector + payload).
 7. **Serialize and return.** Results travel back up through the API layer.
@@ -177,7 +177,7 @@ The areas where VelesDB uses `unsafe` are:
 
 | Area | Why `unsafe` | Documented at |
 |------|-------------|--------------|
-| SIMD intrinsics (AVX2, AVX-512, NEON, WASM SIMD128) | The intrinsics themselves are `unsafe fn` | `crates/velesdb-core/src/simd_native/` (every block annotated `// SAFETY:`) |
+| SIMD intrinsics (AVX2, AVX-512, NEON) | The intrinsics themselves are `unsafe fn` | `crates/velesdb-core/src/simd_native/` (every block annotated `// SAFETY:`) |
 | `mmap` of vector data | Reading `&[f32]` from a memory-mapped file | `crates/velesdb-core/src/storage/mmap.rs` |
 | FFI for UniFFI mobile bindings | C ABI boundary | `crates/velesdb-mobile/` |
 | Compute shader buffer mapping (GPU) | wgpu buffer lifetime | `crates/velesdb-core/src/gpu/` |

--- a/QUALITY_BAR.md
+++ b/QUALITY_BAR.md
@@ -12,7 +12,7 @@ These gates are not aspirational. They are enforced via CI workflows, scripts, a
 
 | # | Gate | Threshold | Enforced by |
 |---|------|-----------|-------------|
-| 1 | **Recall@10** | ≥ 0.95 (10K local) ; ≥ 0.90 (100K CI) | `cargo test test_recall` + GitHub Actions `recall-quality` job |
+| 1 | **Recall@10** | ≥ 0.95 (10K, CI on search-path PRs) ; ≥ 0.90 (100K, manual `#[ignore]` test) | `cargo test test_recall` + `perf-gate-e2e.yml`; 100K floor run manually (see Gate 1) |
 | 2 | **End-to-end search latency p50** | ≤ 450 µs (10K/384D, WAL ON, recall ≥ 96%) | `python benchmarks/velesdb_benchmark.py --recall` + perf-smoke CI gate |
 | 3 | **No `.unwrap()` in production code** | Zero | `scripts/check_prod_unwraps.py` in CI |
 | 4 | **No `unsafe` without `// SAFETY:` comment** | Zero | `scripts/verify_unsafe_safety_template.py` in CI |
@@ -38,18 +38,27 @@ A pull request that breaks any of these gates **cannot be merged**. There are no
 
 - **CI (authoritative):**
   - [`.github/workflows/perf-gate-e2e.yml`](.github/workflows/perf-gate-e2e.yml) gates **recall@10 ≥ 0.95** on the 10K/384D benchmark for every PR touching the search hot path (also gates Gate 2's p50 — same workflow, single source of truth).
-  - The `recall-quality` job in the broader CI pipeline runs the 100K-vector ≥ 0.90 floor on pushes to `develop` and `main`.
+  - The 100K-vector ≥ 0.90 floor is a **manual** gate: the tests in
+    [`crates/velesdb-core/tests/scale_recall_100k.rs`](crates/velesdb-core/tests/scale_recall_100k.rs)
+    are `#[ignore]` (long-running) and are not wired into any CI workflow. Run them with:
+    ```bash
+    cargo test -p velesdb-core --test scale_recall_100k \
+        --features persistence -- --ignored --nocapture --test-threads=1
+    ```
   - The BDD suite enforces **per-metric recall coverage** via [`crates/velesdb-core/tests/bdd/recall_contract_multimetric.rs`](crates/velesdb-core/tests/bdd/recall_contract_multimetric.rs) (Cosine in `recall_contract.rs`, Euclidean and DotProduct in `recall_contract_multimetric.rs`) on every PR.
 
 - **Documented modes:**
 
-  | Mode | ef_search | Recall@10 (measured) |
-  |------|-----------|---------------------|
-  | Fast | 64 | 92.2% |
-  | Balanced (default) | 128 | 98.8% |
-  | Accurate | 512 | 100.0% |
+  | Mode | ef_search (base, current code) | Recall@10 (measured) |
+  |------|-------------------------------|---------------------|
+  | Fast | 96 (`max(96, k×3)`) | 92.2%* |
+  | Balanced (default) | 160 (`max(160, k×5)`) | 98.8%* |
+  | Accurate | 512 (`max(512, k×16)`) | 100.0% |
 
-  Source: `benchmarks/results/2026-02-20-phase-e-report.md`.
+  Source: `benchmarks/results/2026-02-20-phase-e-report.md`; base values from
+  `SearchQuality::ef_search` (`crates/velesdb-core/src/index/hnsw/params.rs`).
+  \* measured at the former Fast=64 / Balanced=128 settings — the current
+  higher bases can only match or improve those figures.
 
 **When this triggers:** any change to `index/hnsw/`, `simd_native/`, `quantization/`, `fusion/`, or result-conversion code in Python bindings.
 
@@ -181,7 +190,7 @@ These signals are tracked but do not block release individually:
 
 | Signal | Threshold | Enforcement |
 |--------|-----------|-------------|
-| Test count | ≥ 7000 (Rust + TS + Py) | Counted in CI summary |
+| Test count | ≥ 7000 (Rust + TS + Py) | Not automated — checked manually from local test runs (no CI job counts tests) |
 | BDD scenario coverage | All VelesQL syntax features | `crates/velesdb-core/tests/bdd/` |
 | Doctest compilation | All `pub fn` doctests compile | `cargo test --doc` in CI |
 | Promise contract sync | All numeric claims in README backed by benchmark commands | `scripts/check-promise-contract.py` in CI |

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
   <a href="https://pypi.org/project/velesdb/"><img src="https://img.shields.io/pypi/v/velesdb.svg" alt="PyPI"></a>
   <a href="https://www.npmjs.com/package/@wiscale/velesdb-sdk"><img src="https://img.shields.io/npm/v/@wiscale/velesdb-sdk.svg" alt="npm"></a>
   <a href="https://app.codacy.com/gh/cyberlife-coder/VelesDB/dashboard"><img src="https://img.shields.io/codacy/coverage/58c73832dd294ba38144856ae69e9cf2?branch=main" alt="Codacy coverage"></a>
-  <img src="https://img.shields.io/badge/tests-8526_(Rust%2BTS%2BPy)-brightgreen" alt="Tests">
+  <img src="https://img.shields.io/badge/tests-9k%2B_(Rust%2BTS%2BPy)-brightgreen" alt="Tests">
   <a href="https://github.com/cyberlife-coder/VelesDB/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-VelesDB_Core_1.0-blue" alt="License"></a>
   <a href="https://github.com/cyberlife-coder/VelesDB"><img src="https://img.shields.io/github/stars/cyberlife-coder/VelesDB?style=flat-square" alt="Stars"></a>
   <a href="https://img.shields.io/badge/contributors-welcome-brightgreen"><img src="https://img.shields.io/badge/contributors-welcome-brightgreen" alt="Contributors Welcome"></a>
@@ -80,7 +80,7 @@ VelesDB is a **local-first database for AI agents** that fuses three engines int
 | **ColumnStore** | Structured metadata filtering (typed columns) | **130x** faster than JSON scanning [2] |
 
 > [1] Reproduce: `python benchmarks/velesdb_benchmark.py --recall` (Python SDK path, 10K/384D, WAL fsync on, i9-14900KF reference machine). See [docs/BENCHMARKS.md](docs/BENCHMARKS.md) and [CHANGELOG v1.13.0](CHANGELOG.md).
-> [2] Reproduce: `cargo bench -p velesdb-core --bench filter_benchmark`. See [docs/BENCHMARKS.md § 6](docs/BENCHMARKS.md) — at 100K rows: ColumnStore 29.5 us vs JSON scan 3.84 ms (integer equality filter).
+> [2] Reproduce: `cargo bench -p velesdb-core --bench column_filter_benchmark`. See [docs/BENCHMARKS.md § 6](docs/BENCHMARKS.md) — at 100K rows: ColumnStore 29.5 us vs JSON scan 3.84 ms (integer equality filter). Micro-benchmark of the ColumnStore filtering API; `SELECT ... WHERE` metadata filtering currently runs on secondary indexes + JSON payload filters (the ColumnStore engine backs JOIN execution).
 
 All three are queried through **VelesQL** — a single SQL-like language with vector, graph, and columnar extensions:
 
@@ -128,7 +128,7 @@ memory.procedural.learn(1, "answer_geography", steps, embedding, confidence=0.8)
 | | **VelesDB** | Chroma | Qdrant | pgvector |
 |---|---|---|---|---|
 | **Architecture** | Unified vector + graph + columnar | Vector only | Vector + payload | Vector extension for PostgreSQL |
-| **Metadata filtering** | **ColumnStore (130x vs JSON)** | JSON scan | JSON payload | SQL (PostgreSQL) |
+| **Metadata filtering** | **Typed ColumnStore [2] + secondary indexes** | JSON scan | JSON payload | SQL (PostgreSQL) |
 | **Deployment** | Embedded / Server / WASM / Mobile | Server (Python) | Server (Rust) | Requires PostgreSQL |
 | **Binary size** | 6 MB | ~500 MB (with deps) | ~50 MB | N/A (PG extension) |
 | **Search latency** | **450us** p50 (10K/384D, WAL ON, recall>=96%) | ~1-5ms | ~1-5ms (in-memory) | ~5-20ms |
@@ -330,7 +330,7 @@ All `cargo bench` commands below are run as `cargo bench -p velesdb-core --bench
 
 ### Distance Metrics
 
-5 metrics with SIMD acceleration (AVX-512, AVX2, NEON, WASM SIMD128):
+5 metrics with SIMD acceleration (AVX-512, AVX2, NEON; WASM currently uses the scalar fallback — SIMD128 kernels are planned):
 
 | Metric | What it measures | Use case | SIMD perf (768D)*² |
 |--------|-----------------|----------|------------------|
@@ -387,19 +387,23 @@ LIMIT 20
 
 ## ColumnStore Engine
 
-Typed columnar storage — the same approach DuckDB and ClickHouse use. **130x faster** than JSON scanning at 100K rows.
+Typed columnar storage — the same approach DuckDB and ClickHouse use. Its
+filtering API is **130x faster** than JSON scanning at 100K rows
+(micro-benchmark: `cargo bench -p velesdb-core --bench column_filter_benchmark`).
 
 ```
 JSON scan: 3.84 ms @ 100K    →    ColumnStore: 29.5 us @ 100K (130x faster)
 ```
+
+Today the ColumnStore engine backs `JOIN` execution. `SELECT ... WHERE`
+metadata filtering runs on secondary indexes + JSON payload filters, with
+pre-filter or post-filter chosen automatically by the query planner:
 
 ```sql
 SELECT * FROM products
 WHERE vector NEAR $query AND in_stock = true AND price < 50.0
 LIMIT 10
 ```
-
-Pre-filter or post-filter automatically optimized by the query planner.
 
 ---
 
@@ -418,7 +422,7 @@ memory.procedural.learn(3, "handle_refund", steps, embedding, confidence=0.9)
 
 ### RAG with Metadata Filtering
 
-Vector search alone returns noise. VelesDB's ColumnStore filters eliminate irrelevant results 130x faster than JSON scanning.
+Vector search alone returns noise. VelesDB combines vector search with metadata filters (secondary indexes + planner-chosen pre/post-filtering) to eliminate irrelevant results.
 
 ```sql
 SELECT * FROM docs

--- a/README.md
+++ b/README.md
@@ -62,11 +62,11 @@ VelesDB removes the US provider from the chain entirely. One Rust binary, local-
 |-------------------------------|------------------------|
 | pgvector for embeddings | **Vector Engine** — 450us p50 end-to-end (10K/384D, WAL ON, recall>=96%) |
 | Neo4j for knowledge graphs | **Graph Engine** — MATCH clause, BFS/DFS |
-| PostgreSQL/DuckDB for metadata | **ColumnStore** — 130x faster than JSON at 100K rows*¹ |
+| PostgreSQL/DuckDB for metadata | **Typed ColumnStore + secondary indexes** — filtering API 130x faster than JSON scanning at 100K rows*¹ |
 | Custom glue code + 3 query languages | **VelesQL** — one language for everything |
 | 3 deployments, 3 configs, 3 backups | **6 MB binary** — works offline, air-gapped |
 
-> *¹ measured on 100K rows; ratio holds within ±5% on 10K–1M rows*
+> *¹ ColumnStore filtering API micro-benchmark, integer equality: 130x at 100K rows, 55x at 10K rows — see [docs/BENCHMARKS.md § 6](docs/BENCHMARKS.md). `SELECT ... WHERE` metadata filtering currently runs on secondary indexes + JSON payload filters (see [2] below).*
 
 ---
 ## What is VelesDB?

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -89,7 +89,7 @@ SIMD and GPU items that are part of the long-term roadmap but **explicitly on ho
 - Profiling on a real workload identifies one as a top-3 bottleneck
 - A community contributor opens a draft PR for one
 
-**What is NOT deferred** (already shipped in v1.13.x): AVX-512 / AVX2 / NEON kernels for f32/f16 cosine·dot·euclidean, WASM SIMD128, GPU SONG 3-stage pipeline (PR #626), GPU `search_auto` wiring (PR #638). Current SIMD coverage matrix in [`docs/reference/NATIVE_HNSW.md`](docs/reference/NATIVE_HNSW.md).
+**What is NOT deferred** (already shipped in v1.13.x): AVX-512 / AVX2 / NEON kernels for f32/f16 cosine·dot·euclidean, GPU SONG 3-stage pipeline (PR #626), GPU `search_auto` wiring (PR #638). WASM SIMD128 kernels remain planned (wasm32 currently uses the scalar fallback). Current SIMD coverage matrix in [`docs/reference/NATIVE_HNSW.md`](docs/reference/NATIVE_HNSW.md).
 
 ---
 

--- a/crates/velesdb-core/src/agent/episodic_memory.rs
+++ b/crates/velesdb-core/src/agent/episodic_memory.rs
@@ -62,6 +62,12 @@ impl EpisodicMemory {
                 Self::rebuild_temporal_index(&collection.inner, &temporal_index);
             }
         }
+        memory_helpers::rebuild_ttl_from_payloads(
+            &db,
+            &collection_name,
+            &ttl,
+            MemoryKind::Episodic,
+        )?;
 
         Ok(Self {
             collection_name,
@@ -105,17 +111,28 @@ impl EpisodicMemory {
         timestamp: i64,
         embedding: Option<&[f32]>,
     ) -> Result<(), AgentMemoryError> {
+        self.record_internal(event_id, description, timestamp, embedding, None)
+    }
+
+    /// Shared store path: persists the event, optionally with a durable
+    /// `expires_at` payload field (epoch seconds) for TTL'd records.
+    fn record_internal(
+        &self,
+        event_id: u64,
+        description: &str,
+        timestamp: i64,
+        embedding: Option<&[f32]>,
+        expires_at: Option<u64>,
+    ) -> Result<(), AgentMemoryError> {
         let vector = memory_helpers::resolve_embedding(self.dimension, embedding)?;
         let collection = memory_helpers::get_collection(&self.db, &self.collection_name)?;
 
-        let point = Point::new(
-            event_id,
-            vector,
-            Some(json!({
-                "description": description,
-                "timestamp": timestamp
-            })),
-        );
+        let mut payload = json!({
+            "description": description,
+            "timestamp": timestamp
+        });
+        memory_helpers::attach_expiry(&mut payload, expires_at);
+        let point = Point::new(event_id, vector, Some(payload));
 
         memory_helpers::upsert_points(&collection, vec![point])?;
         self.temporal_index.insert(event_id, timestamp);
@@ -131,6 +148,10 @@ impl EpisodicMemory {
     /// harmonising the behaviour with `SemanticMemory::store_with_ttl`. The
     /// embedding is still dimension-validated so callers get the same error
     /// contract as a real record.
+    ///
+    /// The expiry is persisted as an `expires_at` (epoch seconds) payload field,
+    /// so the TTL survives a process restart: the in-memory map is rebuilt from
+    /// payloads when the collection is reopened.
     ///
     /// # Errors
     ///
@@ -149,9 +170,16 @@ impl EpisodicMemory {
             }
             return self.delete(event_id);
         }
-        self.record(event_id, description, timestamp, embedding)?;
+        let expires_at = MemoryTtl::now().saturating_add(ttl_seconds);
+        self.record_internal(
+            event_id,
+            description,
+            timestamp,
+            embedding,
+            Some(expires_at),
+        )?;
         self.ttl
-            .set_ttl(MemoryKind::Episodic, event_id, ttl_seconds);
+            .set_expiry(MemoryKind::Episodic, event_id, expires_at);
         Ok(())
     }
 

--- a/crates/velesdb-core/src/agent/episodic_memory.rs
+++ b/crates/velesdb-core/src/agent/episodic_memory.rs
@@ -115,7 +115,7 @@ impl EpisodicMemory {
     }
 
     /// Shared store path: persists the event, optionally with a durable
-    /// `expires_at` payload field (epoch seconds) for TTL'd records.
+    /// `_veles_expires_at` payload field (epoch seconds) for TTL'd records.
     fn record_internal(
         &self,
         event_id: u64,
@@ -149,9 +149,9 @@ impl EpisodicMemory {
     /// embedding is still dimension-validated so callers get the same error
     /// contract as a real record.
     ///
-    /// The expiry is persisted as an `expires_at` (epoch seconds) payload field,
-    /// so the TTL survives a process restart: the in-memory map is rebuilt from
-    /// payloads when the collection is reopened.
+    /// The expiry is persisted as a reserved `_veles_expires_at` (epoch
+    /// seconds) payload field, so the TTL survives a process restart: the
+    /// in-memory map is rebuilt from payloads when the collection is reopened.
     ///
     /// # Errors
     ///

--- a/crates/velesdb-core/src/agent/memory.rs
+++ b/crates/velesdb-core/src/agent/memory.rs
@@ -36,7 +36,7 @@ pub const DEFAULT_DIMENSION: usize = 384;
 /// Unified memory interface for AI agents.
 ///
 /// Provides access to three memory subsystems:
-/// - `semantic`: Long-term knowledge (vector-graph storage)
+/// - `semantic`: Long-term knowledge (vector storage; graph linkage planned)
 /// - `episodic`: Event timeline with temporal context
 /// - `procedural`: Learned patterns and action sequences
 ///

--- a/crates/velesdb-core/src/agent/memory.rs
+++ b/crates/velesdb-core/src/agent/memory.rs
@@ -334,7 +334,8 @@ impl AgentMemory {
     ///
     /// Delegates to `Collection::execute_query_str` on the `_semantic_memory`
     /// collection. Use standard `VelesQL` syntax including `WHERE vector NEAR $v`,
-    /// payload filters, `ORDER BY`, and `WITH` options.
+    /// payload filters, `ORDER BY`, and `WITH` options. TTL-expired entries are
+    /// filtered from the results, matching the native query APIs.
     ///
     /// # Errors
     ///
@@ -349,6 +350,8 @@ impl AgentMemory {
             self.semantic.collection_name(),
             sql,
             params,
+            &self.ttl,
+            MemoryKind::Semantic,
         )
     }
 
@@ -356,7 +359,8 @@ impl AgentMemory {
     ///
     /// Delegates to `Collection::execute_query_str` on the `_episodic_memory`
     /// collection. Supports payload field filters like `WHERE timestamp > N`,
-    /// `ORDER BY timestamp DESC`, and similarity search via `NEAR`.
+    /// `ORDER BY timestamp DESC`, and similarity search via `NEAR`. TTL-expired
+    /// entries are filtered from the results, matching the native query APIs.
     ///
     /// # Errors
     ///
@@ -371,6 +375,8 @@ impl AgentMemory {
             self.episodic.collection_name(),
             sql,
             params,
+            &self.ttl,
+            MemoryKind::Episodic,
         )
     }
 
@@ -378,7 +384,8 @@ impl AgentMemory {
     ///
     /// Delegates to `Collection::execute_query_str` on the `_procedural_memory`
     /// collection. Supports payload field filters like `WHERE confidence > 0.7`,
-    /// `ORDER BY confidence DESC`, and scan queries.
+    /// `ORDER BY confidence DESC`, and scan queries. TTL-expired entries are
+    /// filtered from the results, matching the native query APIs.
     ///
     /// # Errors
     ///
@@ -393,6 +400,8 @@ impl AgentMemory {
             self.procedural.collection_name(),
             sql,
             params,
+            &self.ttl,
+            MemoryKind::Procedural,
         )
     }
 

--- a/crates/velesdb-core/src/agent/memory_helpers.rs
+++ b/crates/velesdb-core/src/agent/memory_helpers.rs
@@ -13,13 +13,19 @@ use std::collections::HashSet;
 
 use super::error::AgentMemoryError;
 
-/// Payload key carrying the durable expiry timestamp (epoch seconds).
+/// Reserved payload key carrying the durable expiry timestamp (epoch seconds).
 ///
 /// Written by the `*_with_ttl` store paths so a TTL survives a process
 /// restart: the in-memory [`MemoryTtl`](super::ttl::MemoryTtl) map is just a
 /// cache rebuilt from this field at subsystem construction. Payloads without
 /// this key (or with a non-u64 value) have no TTL.
-pub(super) const EXPIRES_AT_KEY: &str = "expires_at";
+///
+/// The key is namespaced (`_veles_` prefix, like the `_semantic_memory`
+/// system collections) so a user metadata field named `expires_at` — a common
+/// business field — is never interpreted as a TTL. User-facing metadata paths
+/// (`SemanticMemory::store_with_metadata` / `update_metadata`) strip this
+/// reserved key, mirroring how the `content` parameter owns `content`.
+pub(super) const EXPIRES_AT_KEY: &str = "_veles_expires_at";
 
 /// Looks up a `Collection` by name, returning an `AgentMemoryError` if absent.
 pub(super) fn get_collection(db: &Database, name: &str) -> Result<Collection, AgentMemoryError> {

--- a/crates/velesdb-core/src/agent/memory_helpers.rs
+++ b/crates/velesdb-core/src/agent/memory_helpers.rs
@@ -13,6 +13,14 @@ use std::collections::HashSet;
 
 use super::error::AgentMemoryError;
 
+/// Payload key carrying the durable expiry timestamp (epoch seconds).
+///
+/// Written by the `*_with_ttl` store paths so a TTL survives a process
+/// restart: the in-memory [`MemoryTtl`](super::ttl::MemoryTtl) map is just a
+/// cache rebuilt from this field at subsystem construction. Payloads without
+/// this key (or with a non-u64 value) have no TTL.
+pub(super) const EXPIRES_AT_KEY: &str = "expires_at";
+
 /// Looks up a `Collection` by name, returning an `AgentMemoryError` if absent.
 pub(super) fn get_collection(db: &Database, name: &str) -> Result<Collection, AgentMemoryError> {
     db.get_vector_collection(name)
@@ -287,10 +295,53 @@ pub(super) fn resolve_embedding(
     Ok(embedding.map_or_else(|| vec![0.0; dimension], <[f32]>::to_vec))
 }
 
+/// Inserts the durable [`EXPIRES_AT_KEY`] into a JSON object payload.
+///
+/// No-op when `expires_at` is `None` or the payload is not a JSON object
+/// (the `*_with_ttl` callers always build object payloads).
+pub(super) fn attach_expiry(payload: &mut serde_json::Value, expires_at: Option<u64>) {
+    if let (Some(expiry), Some(obj)) = (expires_at, payload.as_object_mut()) {
+        obj.insert(EXPIRES_AT_KEY.to_string(), serde_json::Value::from(expiry));
+    }
+}
+
+/// Rebuilds the in-memory TTL map for `kind` from persisted point payloads.
+///
+/// Called eagerly at subsystem construction (same pattern and cost class as
+/// the episodic temporal-index rebuild) so that after a restart, `is_expired`,
+/// `expired_count`, and `auto_expire` all see the durable TTLs again. Points
+/// without an [`EXPIRES_AT_KEY`] payload field have no TTL.
+///
+/// # Errors
+///
+/// Returns an error when the collection cannot be resolved.
+pub(super) fn rebuild_ttl_from_payloads(
+    db: &Database,
+    collection_name: &str,
+    ttl: &super::ttl::MemoryTtl,
+    kind: super::ttl::MemoryKind,
+) -> Result<(), AgentMemoryError> {
+    let collection = get_collection(db, collection_name)?;
+    let all_ids = collection.all_ids();
+    for point in collection.get(&all_ids).into_iter().flatten() {
+        let expiry = point
+            .payload
+            .as_ref()
+            .and_then(|p| p.get(EXPIRES_AT_KEY))
+            .and_then(serde_json::Value::as_u64);
+        if let Some(expires_at) = expiry {
+            ttl.set_expiry(kind, point.id, expires_at);
+        }
+    }
+    Ok(())
+}
+
 /// Executes a `VelesQL` query string against a named collection.
 ///
-/// Resolves the collection from the database by name, then delegates to
-/// `Collection::execute_query_str`.
+/// Resolves the collection from the database by name, delegates to
+/// `Collection::execute_query_str`, then filters out TTL-expired points so the
+/// `VelesQL` bridge has the same read semantics as the native query APIs
+/// (expired-but-not-yet-deleted entries are invisible on every read surface).
 ///
 /// # Errors
 ///
@@ -301,11 +352,17 @@ pub(super) fn execute_velesql(
     collection_name: &str,
     sql: &str,
     params: &std::collections::HashMap<String, serde_json::Value>,
+    ttl: &super::ttl::MemoryTtl,
+    kind: super::ttl::MemoryKind,
 ) -> Result<Vec<crate::SearchResult>, AgentMemoryError> {
     let collection = get_collection(db, collection_name)?;
-    collection
+    let results = collection
         .execute_query_str(sql, params)
-        .map_err(AgentMemoryError::DatabaseError)
+        .map_err(AgentMemoryError::DatabaseError)?;
+    Ok(results
+        .into_iter()
+        .filter(|r| !ttl.is_expired(kind, r.point.id))
+        .collect())
 }
 
 #[cfg(test)]

--- a/crates/velesdb-core/src/agent/memory_tests.rs
+++ b/crates/velesdb-core/src/agent/memory_tests.rs
@@ -803,3 +803,81 @@ fn test_reinforce_by_recalled_id_updates_same_procedure() {
         "reinforce(recalled_id) must raise the same procedure's confidence"
     );
 }
+
+// ============================================================================
+// TTL persistence across restart (durable expires_at in payload)
+// ============================================================================
+
+/// A TTL'd entry must remain mortal after dropping and reopening a DB-backed
+/// `AgentMemory` on the same path — no snapshot ritual required. Entries
+/// stored without TTL must survive the reopen untouched.
+#[test]
+fn test_ttl_survives_reopen_all_kinds() {
+    let dir = tempdir().unwrap();
+    let embedding = vec![1.0, 0.0, 0.0, 0.0];
+
+    {
+        let db = Arc::new(Database::open(dir.path()).unwrap());
+        let memory = AgentMemory::with_dimension(Arc::clone(&db), 4).unwrap();
+        memory
+            .semantic()
+            .store_with_ttl(1, "ephemeral fact", &embedding, 1)
+            .unwrap();
+        memory
+            .semantic()
+            .store(2, "durable fact", &embedding)
+            .unwrap();
+        memory
+            .episodic()
+            .record_with_ttl(10, "ephemeral event", 1_700_000_000, Some(&embedding), 1)
+            .unwrap();
+        memory
+            .procedural()
+            .learn_with_ttl(
+                20,
+                "ephemeral proc",
+                &["step".to_string()],
+                Some(&embedding),
+                0.9,
+                1,
+            )
+            .unwrap();
+    }
+
+    // Let the 1-second TTLs lapse, then reopen on the same path.
+    std::thread::sleep(std::time::Duration::from_millis(1200));
+    let db = Arc::new(Database::open(dir.path()).unwrap());
+    let memory = AgentMemory::with_dimension(Arc::clone(&db), 4).unwrap();
+
+    assert!(
+        memory.semantic().get(1).unwrap().is_none(),
+        "TTL'd semantic fact must stay expired after reopen"
+    );
+    let results = memory.semantic().query(&embedding, 10).unwrap();
+    assert!(
+        !results.iter().any(|r| r.0 == 1),
+        "expired semantic fact must be filtered from query after reopen"
+    );
+    assert!(
+        results.iter().any(|r| r.0 == 2),
+        "fact stored without TTL must survive reopen"
+    );
+
+    let recent = memory.episodic().recent(10, None).unwrap();
+    assert!(
+        !recent.iter().any(|e| e.0 == 10),
+        "TTL'd episodic event must stay expired after reopen"
+    );
+
+    let procs = memory.procedural().list_all().unwrap();
+    assert!(
+        !procs.iter().any(|p| p.id == 20),
+        "TTL'd procedure must stay expired after reopen"
+    );
+
+    // The rebuilt TTL map must also drive physical deletion on auto_expire.
+    let stats = memory.auto_expire().unwrap();
+    assert_eq!(stats.semantic_expired, 1, "expired semantic fact deleted");
+    assert_eq!(stats.episodic_expired, 1, "expired episodic event deleted");
+    assert_eq!(stats.procedural_expired, 1, "expired procedure deleted");
+}

--- a/crates/velesdb-core/src/agent/mod.rs
+++ b/crates/velesdb-core/src/agent/mod.rs
@@ -1,7 +1,7 @@
 //! Agent Memory Patterns SDK (EPIC-010)
 //!
 //! Provides unified memory abstractions for AI agents, supporting:
-//! - **Semantic Memory**: Long-term knowledge stored as vector-graph
+//! - **Semantic Memory**: Long-term knowledge stored as vectors (graph linkage planned)
 //! - **Episodic Memory**: Temporal event sequences with context
 //! - **Procedural Memory**: Learned patterns and action sequences
 //!
@@ -19,16 +19,16 @@
 //! use velesdb_core::{Database, agent::AgentMemory};
 //!
 //! let db = Arc::new(Database::open("agent.db")?);
-//! let memory = AgentMemory::new(Arc::clone(&db))?;
+//! let memory = AgentMemory::new(Arc::clone(&db))?; // default dimension 384
 //!
 //! // Store semantic knowledge
-//! memory.semantic().store("Paris is the capital of France", embedding)?;
+//! memory.semantic().store(1, "Paris is the capital of France", &embedding)?;
 //!
-//! // Record an episode
-//! memory.episodic().record("User asked about French geography")?;
+//! // Record an episode (timestamp in epoch seconds, optional embedding)
+//! memory.episodic().record(2, "User asked about French geography", timestamp, Some(&embedding))?;
 //!
-//! // Learn a procedure
-//! memory.procedural().learn("answer_geography", steps)?;
+//! // Learn a procedure (steps, optional embedding, confidence)
+//! memory.procedural().learn(3, "answer_geography", &steps, Some(&embedding), 0.9)?;
 //! ```
 
 mod episodic_memory;

--- a/crates/velesdb-core/src/agent/procedural_memory.rs
+++ b/crates/velesdb-core/src/agent/procedural_memory.rs
@@ -130,6 +130,12 @@ impl ProceduralMemory {
     ) -> Result<Self, AgentMemoryError> {
         let (collection_name, dimension, stored_ids) =
             memory_helpers::init_tracked_memory(&db, Self::COLLECTION_NAME, dimension)?;
+        memory_helpers::rebuild_ttl_from_payloads(
+            &db,
+            &collection_name,
+            &ttl,
+            MemoryKind::Procedural,
+        )?;
 
         Ok(Self {
             collection_name,
@@ -177,6 +183,20 @@ impl ProceduralMemory {
         embedding: Option<&[f32]>,
         confidence: f32,
     ) -> Result<(), AgentMemoryError> {
+        self.learn_internal(procedure_id, name, steps, embedding, confidence, None)
+    }
+
+    /// Shared store path: persists the procedure, optionally with a durable
+    /// `expires_at` payload field (epoch seconds) for TTL'd procedures.
+    fn learn_internal(
+        &self,
+        procedure_id: u64,
+        name: &str,
+        steps: &[String],
+        embedding: Option<&[f32]>,
+        confidence: f32,
+        expires_at: Option<u64>,
+    ) -> Result<(), AgentMemoryError> {
         let vector = memory_helpers::resolve_embedding(self.dimension, embedding)?;
         let collection = memory_helpers::get_collection(&self.db, &self.collection_name)?;
 
@@ -184,20 +204,18 @@ impl ProceduralMemory {
             .duration_since(std::time::UNIX_EPOCH)
             .map_or(0, |d| d.as_secs() as i64);
 
-        let point = Point::new(
-            procedure_id,
-            vector,
-            Some(json!({
-                "name": name,
-                "steps": steps,
-                "confidence": confidence,
-                "usage_count": 0,
-                "created_at": now,
-                "last_used_at": now,
-                "success_count": 0,
-                "failure_count": 0
-            })),
-        );
+        let mut payload = json!({
+            "name": name,
+            "steps": steps,
+            "confidence": confidence,
+            "usage_count": 0,
+            "created_at": now,
+            "last_used_at": now,
+            "success_count": 0,
+            "failure_count": 0
+        });
+        memory_helpers::attach_expiry(&mut payload, expires_at);
+        let point = Point::new(procedure_id, vector, Some(payload));
 
         memory_helpers::upsert_points(&collection, vec![point])?;
         self.stored_ids.write().insert(procedure_id);
@@ -211,6 +229,10 @@ impl ProceduralMemory {
     /// harmonising the behaviour with `SemanticMemory::store_with_ttl`. The
     /// embedding is still dimension-validated so callers get the same error
     /// contract as a real learn.
+    ///
+    /// The expiry is persisted as an `expires_at` (epoch seconds) payload field,
+    /// so the TTL survives a process restart: the in-memory map is rebuilt from
+    /// payloads when the collection is reopened.
     ///
     /// # Errors
     ///
@@ -230,9 +252,17 @@ impl ProceduralMemory {
             }
             return self.delete(procedure_id);
         }
-        self.learn(procedure_id, name, steps, embedding, confidence)?;
+        let expires_at = MemoryTtl::now().saturating_add(ttl_seconds);
+        self.learn_internal(
+            procedure_id,
+            name,
+            steps,
+            embedding,
+            confidence,
+            Some(expires_at),
+        )?;
         self.ttl
-            .set_ttl(MemoryKind::Procedural, procedure_id, ttl_seconds);
+            .set_expiry(MemoryKind::Procedural, procedure_id, expires_at);
         Ok(())
     }
 
@@ -332,20 +362,24 @@ impl ProceduralMemory {
             (state.success_count, state.failure_count + 1)
         };
 
-        let updated_point = Point::new(
-            procedure_id,
-            point.vector.clone(),
-            Some(json!({
-                "name": state.name,
-                "steps": state.steps,
-                "confidence": new_confidence,
-                "usage_count": state.usage_count + 1,
-                "created_at": state.created_at,
-                "last_used_at": now,
-                "success_count": new_success,
-                "failure_count": new_failure
-            })),
-        );
+        let mut payload = json!({
+            "name": state.name,
+            "steps": state.steps,
+            "confidence": new_confidence,
+            "usage_count": state.usage_count + 1,
+            "created_at": state.created_at,
+            "last_used_at": now,
+            "success_count": new_success,
+            "failure_count": new_failure
+        });
+        // Preserve the durable TTL field: reinforcing must not strip expiry.
+        let prior_expiry = point
+            .payload
+            .as_ref()
+            .and_then(|p| p.get(memory_helpers::EXPIRES_AT_KEY))
+            .and_then(serde_json::Value::as_u64);
+        memory_helpers::attach_expiry(&mut payload, prior_expiry);
+        let updated_point = Point::new(procedure_id, point.vector.clone(), Some(payload));
 
         memory_helpers::upsert_points(&collection, vec![updated_point])?;
 

--- a/crates/velesdb-core/src/agent/procedural_memory.rs
+++ b/crates/velesdb-core/src/agent/procedural_memory.rs
@@ -187,7 +187,7 @@ impl ProceduralMemory {
     }
 
     /// Shared store path: persists the procedure, optionally with a durable
-    /// `expires_at` payload field (epoch seconds) for TTL'd procedures.
+    /// `_veles_expires_at` payload field (epoch seconds) for TTL'd procedures.
     fn learn_internal(
         &self,
         procedure_id: u64,
@@ -230,9 +230,9 @@ impl ProceduralMemory {
     /// embedding is still dimension-validated so callers get the same error
     /// contract as a real learn.
     ///
-    /// The expiry is persisted as an `expires_at` (epoch seconds) payload field,
-    /// so the TTL survives a process restart: the in-memory map is rebuilt from
-    /// payloads when the collection is reopened.
+    /// The expiry is persisted as a reserved `_veles_expires_at` (epoch
+    /// seconds) payload field, so the TTL survives a process restart: the
+    /// in-memory map is rebuilt from payloads when the collection is reopened.
     ///
     /// # Errors
     ///

--- a/crates/velesdb-core/src/agent/semantic_memory.rs
+++ b/crates/velesdb-core/src/agent/semantic_memory.rs
@@ -34,7 +34,7 @@ impl SemanticMemory {
     ///
     /// The [`MemoryTtl`] allocated here is not shared with any snapshot
     /// mechanism. TTLs assigned at store time ([`Self::store_with_ttl`]) are
-    /// durable: the expiry is persisted as an `expires_at` payload field and
+    /// durable: the expiry is persisted as a `_veles_expires_at` payload field and
     /// the in-memory map is rebuilt from payloads at construction, so they
     /// survive a restart. TTLs set only in the map (e.g. via
     /// `AgentMemory::set_semantic_ttl`) remain in-memory, and
@@ -93,13 +93,16 @@ impl SemanticMemory {
     /// Returns an error when embedding dimension is invalid, collection access fails,
     /// or persistence fails.
     pub fn store(&self, id: u64, content: &str, embedding: &[f32]) -> Result<(), AgentMemoryError> {
-        self.store_internal(id, content, embedding, None)
+        self.store_internal(id, content, embedding, None, None)
     }
 
     /// Stores a semantic memory point with additional metadata fields.
     ///
     /// `content` always wins: if `metadata` contains a `"content"` key, it is
-    /// overwritten by the `content` parameter.
+    /// overwritten by the `content` parameter. The reserved system key
+    /// `_veles_expires_at` (durable TTL, see [`Self::store_with_ttl`]) is
+    /// likewise stripped from `metadata`; a plain `expires_at` key is ordinary
+    /// business metadata and is stored verbatim.
     ///
     /// # Errors
     ///
@@ -111,14 +114,16 @@ impl SemanticMemory {
         embedding: &[f32],
         metadata: &Map<String, Value>,
     ) -> Result<(), AgentMemoryError> {
-        self.store_internal(id, content, embedding, Some(metadata))
+        self.store_internal(id, content, embedding, Some(metadata), None)
     }
 
     /// Updates payload fields of an existing fact without changing its embedding.
     ///
     /// Only facts that are tracked and not expired are updated. Any key in
     /// `updates` is merged into the existing payload; `content` may be updated
-    /// through this method, but the vector is left untouched.
+    /// through this method, but the vector is left untouched. The reserved
+    /// system key `_veles_expires_at` (durable TTL) is ignored in `updates`
+    /// and preserved from the existing payload.
     ///
     /// # Errors
     ///
@@ -144,20 +149,22 @@ impl SemanticMemory {
         Ok(())
     }
 
+    /// Shared store path. The durable expiry travels through the dedicated
+    /// `expires_at` parameter (written under the reserved
+    /// [`memory_helpers::EXPIRES_AT_KEY`]), never through user `metadata`.
     fn store_internal(
         &self,
         id: u64,
         content: &str,
         embedding: &[f32],
         metadata: Option<&Map<String, Value>>,
+        expires_at: Option<u64>,
     ) -> Result<(), AgentMemoryError> {
         memory_helpers::validate_dimension(self.dimension, embedding.len())?;
         let collection = memory_helpers::get_collection(&self.db, &self.collection_name)?;
-        let point = Point::new(
-            id,
-            embedding.to_vec(),
-            Some(build_payload(content, metadata)),
-        );
+        let mut payload = build_payload(content, metadata);
+        memory_helpers::attach_expiry(&mut payload, expires_at);
+        let point = Point::new(id, embedding.to_vec(), Some(payload));
         memory_helpers::upsert_points(&collection, vec![point])?;
         self.stored_ids.write().insert(id);
         Ok(())
@@ -203,9 +210,9 @@ impl SemanticMemory {
     /// for `id` deleted). The embedding is still dimension-validated so callers
     /// get the same error contract as a real store.
     ///
-    /// The expiry is persisted as an `expires_at` (epoch seconds) payload field,
-    /// so the TTL survives a process restart: the in-memory map is rebuilt from
-    /// payloads when the collection is reopened.
+    /// The expiry is persisted as a reserved `_veles_expires_at` (epoch
+    /// seconds) payload field, so the TTL survives a process restart: the
+    /// in-memory map is rebuilt from payloads when the collection is reopened.
     ///
     /// # Errors
     ///
@@ -222,12 +229,7 @@ impl SemanticMemory {
             return self.delete(id);
         }
         let expires_at = MemoryTtl::now().saturating_add(ttl_seconds);
-        let mut metadata = Map::new();
-        metadata.insert(
-            memory_helpers::EXPIRES_AT_KEY.to_string(),
-            Value::from(expires_at),
-        );
-        self.store_internal(id, content, embedding, Some(&metadata))?;
+        self.store_internal(id, content, embedding, None, Some(expires_at))?;
         self.ttl.set_expiry(MemoryKind::Semantic, id, expires_at);
         Ok(())
     }
@@ -425,7 +427,7 @@ impl SemanticMemory {
     /// # TTL limitation
     ///
     /// The returned bytes contain only the stored points (id, embedding,
-    /// payload — including any durable `expires_at` field) and intentionally
+    /// payload — including any durable `_veles_expires_at` field) and intentionally
     /// **omit the TTL map**. TTL is tracked in a single `MemoryTtl` map shared
     /// across the semantic, episodic, and procedural subsystems (see
     /// [`AgentMemory`](crate::agent::AgentMemory)), so it cannot be partitioned
@@ -433,7 +435,7 @@ impl SemanticMemory {
     /// [`AgentMemory::snapshot`](crate::agent::AgentMemory::snapshot) /
     /// `restore_state`. Calling [`Self::deserialize`] in isolation therefore
     /// restores facts but refreshes the in-memory expiry map only at the next
-    /// construction (payload `expires_at` rebuild); use the snapshot manager
+    /// construction (payload `_veles_expires_at` rebuild); use the snapshot manager
     /// for an immediate full round-trip including TTL.
     ///
     /// # Errors
@@ -462,9 +464,11 @@ impl SemanticMemory {
 /// Builds the payload `Value` from `content` and optional extra metadata.
 ///
 /// `content` is always inserted last so it wins over any `"content"` key
-/// present in `metadata`.
+/// present in `metadata`. The reserved [`memory_helpers::EXPIRES_AT_KEY`] is
+/// stripped: the durable TTL is only ever written by the system store path.
 fn build_payload(content: &str, metadata: Option<&Map<String, Value>>) -> Value {
     let mut map = metadata.cloned().unwrap_or_default();
+    map.remove(memory_helpers::EXPIRES_AT_KEY);
     map.insert("content".to_string(), Value::String(content.to_string()));
     Value::Object(map)
 }
@@ -472,7 +476,9 @@ fn build_payload(content: &str, metadata: Option<&Map<String, Value>>) -> Value 
 /// Merges `updates` into an existing point payload, returning the new payload.
 ///
 /// A missing payload starts from an empty object. Errors when the existing
-/// payload is present but not a JSON object.
+/// payload is present but not a JSON object. The reserved
+/// [`memory_helpers::EXPIRES_AT_KEY`] is skipped so a metadata update can
+/// neither inject nor clobber the durable TTL.
 fn merge_payload(
     existing: Option<Value>,
     updates: &Map<String, Value>,
@@ -482,6 +488,9 @@ fn merge_payload(
         .as_object_mut()
         .ok_or_else(|| AgentMemoryError::IoError("corrupt payload".to_string()))?;
     for (k, v) in updates {
+        if k == memory_helpers::EXPIRES_AT_KEY {
+            continue;
+        }
         obj.insert(k.clone(), v.clone());
     }
     Ok(payload)

--- a/crates/velesdb-core/src/agent/semantic_memory.rs
+++ b/crates/velesdb-core/src/agent/semantic_memory.rs
@@ -33,10 +33,14 @@ impl SemanticMemory {
     /// # Standalone limitation
     ///
     /// The [`MemoryTtl`] allocated here is not shared with any snapshot
-    /// mechanism: TTL entries live in memory only and are **lost on restart**.
+    /// mechanism. TTLs assigned at store time ([`Self::store_with_ttl`]) are
+    /// durable: the expiry is persisted as an `expires_at` payload field and
+    /// the in-memory map is rebuilt from payloads at construction, so they
+    /// survive a restart. TTLs set only in the map (e.g. via
+    /// `AgentMemory::set_semantic_ttl`) remain in-memory, and
     /// [`Self::serialize`] / [`Self::deserialize`] carry stored points but
-    /// intentionally omit TTL state (see [`Self::serialize`] for the full
-    /// contract). For full TTL persistence and snapshot support, create an
+    /// intentionally omit the TTL map (see [`Self::serialize`] for the full
+    /// contract). For full TTL and snapshot support, create an
     /// [`AgentMemory`](crate::agent::AgentMemory) instead — it owns the shared
     /// `MemoryTtl`, snapshot manager, and all three subsystems.
     ///
@@ -54,6 +58,12 @@ impl SemanticMemory {
     ) -> Result<Self, AgentMemoryError> {
         let (collection_name, dimension, stored_ids) =
             memory_helpers::init_tracked_memory(&db, Self::COLLECTION_NAME, dimension)?;
+        memory_helpers::rebuild_ttl_from_payloads(
+            &db,
+            &collection_name,
+            &ttl,
+            MemoryKind::Semantic,
+        )?;
 
         Ok(Self {
             collection_name,
@@ -193,6 +203,10 @@ impl SemanticMemory {
     /// for `id` deleted). The embedding is still dimension-validated so callers
     /// get the same error contract as a real store.
     ///
+    /// The expiry is persisted as an `expires_at` (epoch seconds) payload field,
+    /// so the TTL survives a process restart: the in-memory map is rebuilt from
+    /// payloads when the collection is reopened.
+    ///
     /// # Errors
     ///
     /// Returns the same errors as [`Self::store`].
@@ -207,8 +221,14 @@ impl SemanticMemory {
             memory_helpers::validate_dimension(self.dimension, embedding.len())?;
             return self.delete(id);
         }
-        self.store(id, content, embedding)?;
-        self.ttl.set_ttl(MemoryKind::Semantic, id, ttl_seconds);
+        let expires_at = MemoryTtl::now().saturating_add(ttl_seconds);
+        let mut metadata = Map::new();
+        metadata.insert(
+            memory_helpers::EXPIRES_AT_KEY.to_string(),
+            Value::from(expires_at),
+        );
+        self.store_internal(id, content, embedding, Some(&metadata))?;
+        self.ttl.set_expiry(MemoryKind::Semantic, id, expires_at);
         Ok(())
     }
 
@@ -405,14 +425,16 @@ impl SemanticMemory {
     /// # TTL limitation
     ///
     /// The returned bytes contain only the stored points (id, embedding,
-    /// content) and intentionally **omit TTL state**. TTL is tracked in a single
-    /// `MemoryTtl` map shared across the semantic, episodic, and procedural
-    /// subsystems (see [`AgentMemory`](crate::agent::AgentMemory)), so it cannot
-    /// be partitioned per subsystem here. TTL is persisted and restored globally
-    /// by [`AgentMemory::snapshot`](crate::agent::AgentMemory::snapshot) /
+    /// payload — including any durable `expires_at` field) and intentionally
+    /// **omit the TTL map**. TTL is tracked in a single `MemoryTtl` map shared
+    /// across the semantic, episodic, and procedural subsystems (see
+    /// [`AgentMemory`](crate::agent::AgentMemory)), so it cannot be partitioned
+    /// per subsystem here. TTL is persisted and restored globally by
+    /// [`AgentMemory::snapshot`](crate::agent::AgentMemory::snapshot) /
     /// `restore_state`. Calling [`Self::deserialize`] in isolation therefore
-    /// restores facts but not their expiry; use the snapshot manager for a full
-    /// round-trip including TTL.
+    /// restores facts but refreshes the in-memory expiry map only at the next
+    /// construction (payload `expires_at` rebuild); use the snapshot manager
+    /// for an immediate full round-trip including TTL.
     ///
     /// # Errors
     ///

--- a/crates/velesdb-core/src/agent/semantic_memory_tests.rs
+++ b/crates/velesdb-core/src/agent/semantic_memory_tests.rs
@@ -650,4 +650,149 @@ mod tests {
         // Half of each thread's writes were deleted: 4 threads * 12 survivors.
         assert_eq!(sm.count(), 4 * 12);
     }
+
+    // ── Reserved durable-TTL key: user "expires_at" metadata is business data ──
+
+    /// Reopens the database at `path` into a fresh `SemanticMemory` with its
+    /// own TTL map, mimicking a process restart (payload-driven TTL rebuild).
+    fn reopen_semantic(path: &std::path::Path) -> (Arc<MemoryTtl>, SemanticMemory) {
+        let db = Arc::new(Database::open(path).unwrap());
+        let ttl = Arc::new(MemoryTtl::new());
+        let sm = SemanticMemory::new(db, 4, Arc::clone(&ttl)).unwrap();
+        (ttl, sm)
+    }
+
+    /// Builds a one-entry metadata map.
+    fn meta_one(key: &str, value: serde_json::Value) -> serde_json::Map<String, serde_json::Value> {
+        let mut map = serde_json::Map::new();
+        map.insert(key.to_string(), value);
+        map
+    }
+
+    /// A user business field named `expires_at` (subscription, offer, token…)
+    /// stored via `store_with_metadata` must stay plain metadata: visible in
+    /// session AND after a reopen, never rebuilt into the durable TTL map.
+    #[test]
+    fn test_user_expires_at_metadata_survives_restart() {
+        let dir = tempdir().unwrap();
+        let emb = vec![1.0_f32, 0.0, 0.0, 0.0];
+        let past_epoch = 1_000_000_u64; // long-gone epoch seconds
+
+        {
+            let db = Arc::new(Database::open(dir.path()).unwrap());
+            let sm = make_semantic(Arc::clone(&db));
+            let meta = meta_one("expires_at", serde_json::json!(past_epoch));
+            sm.store_with_metadata(1, "offer expired yesterday", &emb, &meta)
+                .unwrap();
+            assert!(sm.get(1).unwrap().is_some(), "fact visible in session");
+        }
+
+        let (ttl, sm) = reopen_semantic(dir.path());
+
+        assert!(
+            ttl.get(MemoryKind::Semantic, 1).is_none(),
+            "user expires_at metadata must not be rebuilt into the TTL map"
+        );
+        assert!(
+            sm.get(1).unwrap().is_some(),
+            "fact with user expires_at metadata must stay alive after reopen"
+        );
+        let results = sm.query(&emb, 5).unwrap();
+        assert!(results.iter().any(|r| r.0 == 1), "fact must stay queryable");
+
+        // The business field itself is preserved and filterable.
+        let filter = meta_one("expires_at", serde_json::json!(past_epoch));
+        let filtered = sm.query_filtered(&emb, 5, &filter, 0).unwrap();
+        assert_eq!(
+            filtered.len(),
+            1,
+            "user expires_at field must be preserved as metadata"
+        );
+    }
+
+    /// Same collision via `update_metadata`: merging a user `expires_at` into
+    /// an existing fact must not arm a durable TTL at the next reopen.
+    #[test]
+    fn test_update_metadata_user_expires_at_survives_restart() {
+        let dir = tempdir().unwrap();
+        let emb = vec![1.0_f32, 0.0, 0.0, 0.0];
+
+        {
+            let db = Arc::new(Database::open(dir.path()).unwrap());
+            let sm = make_semantic(Arc::clone(&db));
+            sm.store(1, "subscription fact", &emb).unwrap();
+            let updates = meta_one("expires_at", serde_json::json!(1_000_000_u64));
+            sm.update_metadata(1, &updates).unwrap();
+        }
+
+        let (ttl, sm) = reopen_semantic(dir.path());
+
+        assert!(
+            ttl.get(MemoryKind::Semantic, 1).is_none(),
+            "user expires_at update must not be rebuilt into the TTL map"
+        );
+        assert!(
+            sm.get(1).unwrap().is_some(),
+            "fact must stay alive after reopen"
+        );
+    }
+
+    /// The reserved durable-expiry key (`_veles_expires_at`) is stripped from
+    /// user metadata, mirroring how the `content` parameter owns `content`.
+    #[test]
+    fn test_reserved_expiry_key_stripped_from_store_metadata() {
+        let dir = tempdir().unwrap();
+        let emb = vec![1.0_f32, 0.0, 0.0, 0.0];
+
+        {
+            let db = Arc::new(Database::open(dir.path()).unwrap());
+            let sm = make_semantic(Arc::clone(&db));
+            let meta = meta_one("_veles_expires_at", serde_json::json!(1_u64));
+            sm.store_with_metadata(1, "spoof attempt", &emb, &meta)
+                .unwrap();
+        }
+
+        let (ttl, sm) = reopen_semantic(dir.path());
+
+        assert!(
+            ttl.get(MemoryKind::Semantic, 1).is_none(),
+            "reserved key must be stripped at store time"
+        );
+        assert!(sm.get(1).unwrap().is_some());
+    }
+
+    /// `update_metadata` must neither inject nor clobber the reserved durable
+    /// expiry: a legitimate `store_with_ttl` expiry survives a metadata update
+    /// and is rebuilt identically at reopen.
+    #[test]
+    fn test_update_metadata_preserves_legit_durable_ttl() {
+        let dir = tempdir().unwrap();
+        let emb = vec![1.0_f32, 0.0, 0.0, 0.0];
+        let original_expiry;
+
+        {
+            let db = Arc::new(Database::open(dir.path()).unwrap());
+            let ttl = Arc::new(MemoryTtl::new());
+            let sm = SemanticMemory::new(Arc::clone(&db), 4, Arc::clone(&ttl)).unwrap();
+            sm.store_with_ttl(1, "mortal fact", &emb, 9_999).unwrap();
+            original_expiry = ttl
+                .get(MemoryKind::Semantic, 1)
+                .expect("TTL tracked at store time")
+                .expires_at;
+
+            let mut updates = meta_one("tag", serde_json::json!("updated"));
+            updates.insert("_veles_expires_at".to_string(), serde_json::json!(1_u64));
+            sm.update_metadata(1, &updates).unwrap();
+        }
+
+        let (ttl, _sm) = reopen_semantic(dir.path());
+
+        let entry = ttl
+            .get(MemoryKind::Semantic, 1)
+            .expect("durable TTL must survive a metadata update");
+        assert_eq!(
+            entry.expires_at, original_expiry,
+            "reserved key in updates must not clobber the durable expiry"
+        );
+    }
 }

--- a/crates/velesdb-core/src/agent/ttl.rs
+++ b/crates/velesdb-core/src/agent/ttl.rs
@@ -105,10 +105,18 @@ impl MemoryTtl {
     /// * `id` - Entry identifier
     /// * `ttl_seconds` - Time-to-live in seconds from now
     pub fn set_ttl(&self, kind: MemoryKind, id: u64, ttl_seconds: u64) {
-        let now = Self::now();
+        self.set_expiry(kind, id, Self::now().saturating_add(ttl_seconds));
+    }
+
+    /// Sets a TTL entry from a precomputed absolute expiry timestamp.
+    ///
+    /// Used by the durable-TTL write path (which persists `expires_at` in the
+    /// point payload) and by the reopen path that rebuilds this map from
+    /// payloads, so both sides share the exact same expiry instant.
+    pub fn set_expiry(&self, kind: MemoryKind, id: u64, expires_at: u64) {
         let entry = TtlEntry {
-            expires_at: now.saturating_add(ttl_seconds),
-            created_at: now,
+            expires_at,
+            created_at: Self::now(),
         };
         self.entries.write().insert((kind, id), entry);
     }

--- a/crates/velesdb-core/src/agent/ttl.rs
+++ b/crates/velesdb-core/src/agent/ttl.rs
@@ -110,7 +110,7 @@ impl MemoryTtl {
 
     /// Sets a TTL entry from a precomputed absolute expiry timestamp.
     ///
-    /// Used by the durable-TTL write path (which persists `expires_at` in the
+    /// Used by the durable-TTL write path (which persists `_veles_expires_at` in the
     /// point payload) and by the reopen path that rebuilds this map from
     /// payloads, so both sides share the exact same expiry instant.
     pub fn set_expiry(&self, kind: MemoryKind, id: u64, expires_at: u64) {

--- a/crates/velesdb-core/src/agent/velesql_bridge_tests.rs
+++ b/crates/velesdb-core/src/agent/velesql_bridge_tests.rs
@@ -620,4 +620,107 @@ mod tests {
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].point.id, 2);
     }
+
+    // ========================================================================
+    // F. TTL — expired entries are invisible through the VelesQL bridges
+    // ========================================================================
+
+    /// Collects point ids from a result slice.
+    fn result_ids(results: &[crate::SearchResult]) -> Vec<u64> {
+        results.iter().map(|r| r.point.id).collect()
+    }
+
+    #[test]
+    fn test_query_semantic_filters_expired() {
+        let (_dir, _db, memory) = setup_agent_memory();
+
+        memory
+            .semantic()
+            .store(1, "expired fact", &[1.0, 0.0, 0.0, 0.0])
+            .unwrap();
+        memory
+            .semantic()
+            .store(2, "live fact", &[0.0, 1.0, 0.0, 0.0])
+            .unwrap();
+        // TTL of 0 seconds: expires immediately.
+        memory.set_semantic_ttl(1, 0);
+
+        let params = HashMap::new();
+        let results = memory
+            .query_semantic("SELECT * FROM _semantic_memory LIMIT 10", &params)
+            .expect("query_semantic should succeed");
+
+        let ids = result_ids(&results);
+        assert!(
+            !ids.contains(&1),
+            "expired semantic fact must not be returned by the VelesQL bridge"
+        );
+        assert!(ids.contains(&2), "live semantic fact must be returned");
+    }
+
+    #[test]
+    fn test_query_episodic_filters_expired() {
+        let (_dir, _db, memory) = setup_agent_memory();
+
+        memory
+            .episodic()
+            .record(1, "expired event", 1_000_000, Some(&[1.0, 0.0, 0.0, 0.0]))
+            .unwrap();
+        memory
+            .episodic()
+            .record(2, "live event", 2_000_000, Some(&[0.0, 1.0, 0.0, 0.0]))
+            .unwrap();
+        memory.set_episodic_ttl(1, 0);
+
+        let params = HashMap::new();
+        let results = memory
+            .query_episodic("SELECT * FROM _episodic_memory LIMIT 10", &params)
+            .expect("query_episodic should succeed");
+
+        let ids = result_ids(&results);
+        assert!(
+            !ids.contains(&1),
+            "expired episodic event must not be returned by the VelesQL bridge"
+        );
+        assert!(ids.contains(&2), "live episodic event must be returned");
+    }
+
+    #[test]
+    fn test_query_procedural_filters_expired() {
+        let (_dir, _db, memory) = setup_agent_memory();
+
+        memory
+            .procedural()
+            .learn(
+                1,
+                "expired_proc",
+                &["s1".into()],
+                Some(&[1.0, 0.0, 0.0, 0.0]),
+                0.9,
+            )
+            .unwrap();
+        memory
+            .procedural()
+            .learn(
+                2,
+                "live_proc",
+                &["s1".into()],
+                Some(&[0.0, 1.0, 0.0, 0.0]),
+                0.8,
+            )
+            .unwrap();
+        memory.set_procedural_ttl(1, 0);
+
+        let params = HashMap::new();
+        let results = memory
+            .query_procedural("SELECT * FROM _procedural_memory LIMIT 10", &params)
+            .expect("query_procedural should succeed");
+
+        let ids = result_ids(&results);
+        assert!(
+            !ids.contains(&1),
+            "expired procedure must not be returned by the VelesQL bridge"
+        );
+        assert!(ids.contains(&2), "live procedure must be returned");
+    }
 }

--- a/crates/velesdb-core/src/collection/graph/edge.rs
+++ b/crates/velesdb-core/src/collection/graph/edge.rs
@@ -155,6 +155,11 @@ impl EdgeStore {
     /// Pre-allocating reduces memory reallocation overhead when inserting many edges.
     /// With 10M edges, this can reduce peak memory usage by ~2x and improve insert throughput.
     ///
+    /// Note: when accessed through the sharded `ConcurrentEdgeStore`, an edge
+    /// whose endpoints hash to different shards is stored in **both** shards
+    /// (outgoing + incoming halves), which offsets part of that saving — with
+    /// many shards this applies to nearly all edges.
+    ///
     /// # Arguments
     ///
     /// * `expected_edges` - Expected number of edges to store

--- a/crates/velesdb-core/src/collection/graph/mod.rs
+++ b/crates/velesdb-core/src/collection/graph/mod.rs
@@ -14,6 +14,11 @@
 //!
 //! # Example
 //!
+//! Note: `GraphNode`/`Element` are exported value types for programmatic
+//! construction; the query runtime itself persists node data as JSON payloads
+//! (`GraphCollection::upsert_node_payload` / `INSERT NODE`) and MATCH
+//! evaluates against those payloads, not against `GraphNode` instances.
+//!
 //! ```rust,ignore
 //! use velesdb_core::collection::graph::{GraphSchema, NodeType, EdgeType, ValueType, GraphNode, Element};
 //! use std::collections::HashMap;

--- a/crates/velesdb-core/src/collection/graph/node.rs
+++ b/crates/velesdb-core/src/collection/graph/node.rs
@@ -15,6 +15,11 @@ use std::collections::HashMap;
 /// Nodes are distinct from Points in that they have a label (type) and structured
 /// properties, while Points are primarily vector data with metadata.
 ///
+/// Note: this is a construction/value type. The query runtime stores node
+/// data as JSON payloads (`upsert_node_payload` / `INSERT NODE`) and MATCH
+/// evaluates against those payloads; no production query path consumes
+/// `GraphNode` instances directly.
+///
 /// # Example
 ///
 /// ```rust,ignore

--- a/crates/velesdb-core/src/collection/search/mod.rs
+++ b/crates/velesdb-core/src/collection/search/mod.rs
@@ -29,6 +29,8 @@ mod vector;
 mod vector_dispatch_parity_tests;
 mod vector_filter;
 #[cfg(test)]
+mod vector_filter_tests;
+#[cfg(test)]
 mod vector_tests;
 
 // Re-export all search methods via trait implementations

--- a/crates/velesdb-core/src/collection/search/query/aggregation/grouped.rs
+++ b/crates/velesdb-core/src/collection/search/query/aggregation/grouped.rs
@@ -61,7 +61,7 @@ impl Collection {
         let where_clause = stmt.where_clause.as_ref();
         let use_runtime = Self::needs_runtime_where_eval(where_clause);
         let needs_vector_eval = where_clause.is_some_and(Self::condition_requires_vector_eval);
-        let filter = Self::build_static_filter(where_clause, use_runtime, params);
+        let filter = Self::build_static_filter(where_clause, use_runtime, params)?;
         let (columns_vec, has_count_star) = Self::prepare_agg_columns(aggregations);
 
         let payload_storage = self.payload_storage.read();
@@ -110,18 +110,27 @@ impl Collection {
     }
 
     /// Builds a static `Filter` from the WHERE clause when runtime eval is not needed.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when a WHERE parameter placeholder is missing from
+    /// `params` (never silently converts it to `NULL`).
     pub(super) fn build_static_filter(
         where_clause: Option<&crate::velesql::Condition>,
         use_runtime: bool,
         params: &HashMap<String, serde_json::Value>,
-    ) -> Option<crate::filter::Filter> {
+    ) -> Result<Option<crate::filter::Filter>> {
         if use_runtime {
-            return None;
+            return Ok(None);
         }
-        where_clause.map(|cond| {
-            let resolved = Self::resolve_condition_params(cond, params);
-            crate::filter::Filter::new(crate::filter::Condition::from(resolved))
-        })
+        where_clause
+            .map(|cond| {
+                let resolved = Self::resolve_condition_params(cond, params)?;
+                Ok(crate::filter::Filter::new(crate::filter::Condition::from(
+                    resolved,
+                )))
+            })
+            .transpose()
     }
 
     /// Extracts the list of columns to aggregate and whether COUNT(*) is present.

--- a/crates/velesdb-core/src/collection/search/query/aggregation/having.rs
+++ b/crates/velesdb-core/src/collection/search/query/aggregation/having.rs
@@ -214,6 +214,41 @@ impl Collection {
         DEFAULT_MAX_GROUPS
     }
 
+    /// Resolves parameter placeholders in HAVING threshold values.
+    ///
+    /// HAVING thresholds live in [`HavingCondition.value`], outside the WHERE
+    /// condition tree, so the WHERE resolver never visits them. Without this,
+    /// `HAVING COUNT(*) > $n` compares every group against an unresolved
+    /// placeholder and silently filters out all groups — even when `$n` is
+    /// bound.
+    ///
+    /// [`HavingCondition.value`]: crate::velesql::HavingCondition
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when a referenced parameter is missing from `params`
+    /// or has an unsupported type (array/object).
+    pub(super) fn resolve_having_params(
+        having: &HavingClause,
+        params: &HashMap<String, serde_json::Value>,
+    ) -> crate::error::Result<HavingClause> {
+        let conditions = having
+            .conditions
+            .iter()
+            .map(|cond| {
+                Ok(crate::velesql::HavingCondition {
+                    aggregate: cond.aggregate.clone(),
+                    operator: cond.operator,
+                    value: Self::resolve_where_param(&cond.value, params)?,
+                })
+            })
+            .collect::<crate::error::Result<Vec<_>>>()?;
+        Ok(HavingClause {
+            conditions,
+            operators: having.operators.clone(),
+        })
+    }
+
     /// BUG-5 FIX: Resolve parameter placeholders in a condition.
     /// Replaces `Value::Parameter("name")` with the actual value from params `HashMap`.
     ///
@@ -258,10 +293,14 @@ impl Collection {
         Ok(Box::new(Self::resolve_condition_params(cond, params)?))
     }
 
-    /// Resolves parameters in leaf conditions (Comparison, IN, BETWEEN).
+    /// Resolves parameters in leaf conditions (Comparison, IN, BETWEEN,
+    /// CONTAINS / CONTAINS ANY / CONTAINS ALL).
     ///
-    /// Other leaf variants carry no scalar `Value` parameters and are cloned
-    /// unchanged.
+    /// The remaining leaf variants are cloned unchanged: they carry no scalar
+    /// `Value` operands (geo thresholds are `f64` literals, LIKE/MATCH
+    /// patterns are strings, vector parameters are resolved by the vector
+    /// pipeline), except `GraphMatch`, whose pattern properties are evaluated
+    /// by the MATCH engine rather than by this resolver.
     fn resolve_leaf_condition_params(
         cond: &crate::velesql::Condition,
         params: &HashMap<String, serde_json::Value>,
@@ -274,25 +313,36 @@ impl Collection {
                 operator: cmp.operator,
                 value: Self::resolve_where_param(&cmp.value, params)?,
             }),
-            Condition::In(in_cond) => {
-                let resolved_values = in_cond
-                    .values
-                    .iter()
-                    .map(|v| Self::resolve_where_param(v, params))
-                    .collect::<crate::error::Result<Vec<Value>>>()?;
-                Condition::In(crate::velesql::InCondition {
-                    column: in_cond.column.clone(),
-                    values: resolved_values,
-                    negated: in_cond.negated,
-                })
-            }
+            Condition::In(in_cond) => Condition::In(crate::velesql::InCondition {
+                column: in_cond.column.clone(),
+                values: Self::resolve_value_list(&in_cond.values, params)?,
+                negated: in_cond.negated,
+            }),
             Condition::Between(btw) => Condition::Between(crate::velesql::BetweenCondition {
                 column: btw.column.clone(),
                 low: Self::resolve_where_param(&btw.low, params)?,
                 high: Self::resolve_where_param(&btw.high, params)?,
             }),
+            Condition::Contains(contains) => {
+                Condition::Contains(crate::velesql::ContainsCondition {
+                    column: contains.column.clone(),
+                    mode: contains.mode,
+                    values: Self::resolve_value_list(&contains.values, params)?,
+                })
+            }
             // These conditions don't have Value parameters to resolve
             other => other.clone(),
         })
+    }
+
+    /// Resolves every value in a list via [`Self::resolve_where_param`].
+    fn resolve_value_list(
+        values: &[Value],
+        params: &HashMap<String, serde_json::Value>,
+    ) -> crate::error::Result<Vec<Value>> {
+        values
+            .iter()
+            .map(|v| Self::resolve_where_param(v, params))
+            .collect()
     }
 }

--- a/crates/velesdb-core/src/collection/search/query/aggregation/having.rs
+++ b/crates/velesdb-core/src/collection/search/query/aggregation/having.rs
@@ -216,93 +216,83 @@ impl Collection {
 
     /// BUG-5 FIX: Resolve parameter placeholders in a condition.
     /// Replaces `Value::Parameter("name")` with the actual value from params `HashMap`.
+    ///
+    /// Delegates leaf resolution to [`Self::resolve_where_param`] (the single
+    /// strict resolver) so a missing or unsupported parameter is an error,
+    /// never a silent `NULL`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when a referenced parameter is missing from `params`
+    /// or has an unsupported type (array/object).
     pub(crate) fn resolve_condition_params(
         cond: &crate::velesql::Condition,
         params: &HashMap<String, serde_json::Value>,
-    ) -> crate::velesql::Condition {
+    ) -> crate::error::Result<crate::velesql::Condition> {
         use crate::velesql::Condition;
 
         match cond {
-            Condition::Comparison(cmp) => {
-                let resolved_value = Self::resolve_value(&cmp.value, params);
-                Condition::Comparison(crate::velesql::Comparison {
-                    column: cmp.column.clone(),
-                    operator: cmp.operator,
-                    value: resolved_value,
-                })
-            }
+            Condition::And(left, right) => Ok(Condition::And(
+                Self::resolve_boxed_condition(left, params)?,
+                Self::resolve_boxed_condition(right, params)?,
+            )),
+            Condition::Or(left, right) => Ok(Condition::Or(
+                Self::resolve_boxed_condition(left, params)?,
+                Self::resolve_boxed_condition(right, params)?,
+            )),
+            Condition::Not(inner) => Ok(Condition::Not(Self::resolve_boxed_condition(
+                inner, params,
+            )?)),
+            Condition::Group(inner) => Ok(Condition::Group(Self::resolve_boxed_condition(
+                inner, params,
+            )?)),
+            other => Self::resolve_leaf_condition_params(other, params),
+        }
+    }
+
+    /// Boxes the recursive resolution of a nested condition.
+    fn resolve_boxed_condition(
+        cond: &crate::velesql::Condition,
+        params: &HashMap<String, serde_json::Value>,
+    ) -> crate::error::Result<Box<crate::velesql::Condition>> {
+        Ok(Box::new(Self::resolve_condition_params(cond, params)?))
+    }
+
+    /// Resolves parameters in leaf conditions (Comparison, IN, BETWEEN).
+    ///
+    /// Other leaf variants carry no scalar `Value` parameters and are cloned
+    /// unchanged.
+    fn resolve_leaf_condition_params(
+        cond: &crate::velesql::Condition,
+        params: &HashMap<String, serde_json::Value>,
+    ) -> crate::error::Result<crate::velesql::Condition> {
+        use crate::velesql::Condition;
+
+        Ok(match cond {
+            Condition::Comparison(cmp) => Condition::Comparison(crate::velesql::Comparison {
+                column: cmp.column.clone(),
+                operator: cmp.operator,
+                value: Self::resolve_where_param(&cmp.value, params)?,
+            }),
             Condition::In(in_cond) => {
-                let resolved_values: Vec<Value> = in_cond
+                let resolved_values = in_cond
                     .values
                     .iter()
-                    .map(|v| Self::resolve_value(v, params))
-                    .collect();
+                    .map(|v| Self::resolve_where_param(v, params))
+                    .collect::<crate::error::Result<Vec<Value>>>()?;
                 Condition::In(crate::velesql::InCondition {
                     column: in_cond.column.clone(),
                     values: resolved_values,
                     negated: in_cond.negated,
                 })
             }
-            Condition::Between(btw) => {
-                let resolved_low = Self::resolve_value(&btw.low, params);
-                let resolved_high = Self::resolve_value(&btw.high, params);
-                Condition::Between(crate::velesql::BetweenCondition {
-                    column: btw.column.clone(),
-                    low: resolved_low,
-                    high: resolved_high,
-                })
-            }
-            Condition::And(left, right) => Condition::And(
-                Box::new(Self::resolve_condition_params(left, params)),
-                Box::new(Self::resolve_condition_params(right, params)),
-            ),
-            Condition::Or(left, right) => Condition::Or(
-                Box::new(Self::resolve_condition_params(left, params)),
-                Box::new(Self::resolve_condition_params(right, params)),
-            ),
-            Condition::Not(inner) => {
-                Condition::Not(Box::new(Self::resolve_condition_params(inner, params)))
-            }
-            Condition::Group(inner) => {
-                Condition::Group(Box::new(Self::resolve_condition_params(inner, params)))
-            }
+            Condition::Between(btw) => Condition::Between(crate::velesql::BetweenCondition {
+                column: btw.column.clone(),
+                low: Self::resolve_where_param(&btw.low, params)?,
+                high: Self::resolve_where_param(&btw.high, params)?,
+            }),
             // These conditions don't have Value parameters to resolve
             other => other.clone(),
-        }
-    }
-
-    /// Resolve a single Value, substituting Parameter with actual value from params.
-    pub(crate) fn resolve_value(
-        value: &Value,
-        params: &HashMap<String, serde_json::Value>,
-    ) -> Value {
-        match value {
-            Value::Parameter(name) => {
-                if let Some(param_value) = params.get(name) {
-                    // Convert serde_json::Value to VelesQL Value
-                    match param_value {
-                        serde_json::Value::Number(n) => {
-                            if let Some(i) = n.as_i64() {
-                                Value::Integer(i)
-                            } else if let Some(u) = n.as_u64() {
-                                Value::UnsignedInteger(u)
-                            } else if let Some(f) = n.as_f64() {
-                                Value::Float(f)
-                            } else {
-                                Value::Null
-                            }
-                        }
-                        serde_json::Value::String(s) => Value::String(s.clone()),
-                        serde_json::Value::Bool(b) => Value::Boolean(*b),
-                        // Null, arrays, and objects not supported as params
-                        _ => Value::Null,
-                    }
-                } else {
-                    // Parameter not found, keep as null
-                    Value::Null
-                }
-            }
-            other => other.clone(),
-        }
+        })
     }
 }

--- a/crates/velesdb-core/src/collection/search/query/aggregation/mod.rs
+++ b/crates/velesdb-core/src/collection/search/query/aggregation/mod.rs
@@ -151,6 +151,11 @@ impl Collection {
         query: &Query,
         params: &HashMap<String, serde_json::Value>,
     ) -> Result<serde_json::Value> {
+        // Resolve scalar WHERE parameters once (same guard as the SELECT
+        // pipeline) so both the static-filter and runtime-eval paths see
+        // bound values and missing parameters fail loudly.
+        let resolved_query = Self::resolve_query_where_params(query, params)?;
+        let query = resolved_query.as_ref().unwrap_or(query);
         let stmt = &query.select;
 
         let aggregations: &[AggregateFunction] = match &stmt.columns {
@@ -195,7 +200,7 @@ impl Collection {
             Self::condition_contains_graph_match(cond) || Self::condition_requires_vector_eval(cond)
         });
 
-        let filter = Self::build_static_filter(where_clause, use_runtime_where_eval, params);
+        let filter = Self::build_static_filter(where_clause, use_runtime_where_eval, params)?;
         let (columns_vec, has_count_star) = Self::prepare_agg_columns(aggregations);
 
         let payload_storage = self.payload_storage.read();

--- a/crates/velesdb-core/src/collection/search/query/aggregation/mod.rs
+++ b/crates/velesdb-core/src/collection/search/query/aggregation/mod.rs
@@ -169,11 +169,18 @@ impl Collection {
         };
 
         if let Some(ref group_by) = stmt.group_by {
+            // HAVING thresholds are not part of the WHERE condition tree, so
+            // they need their own resolution pass (same loud-failure guard).
+            let having = stmt
+                .having
+                .as_ref()
+                .map(|h| Self::resolve_having_params(h, params))
+                .transpose()?;
             return self.execute_grouped_aggregate(
                 query,
                 aggregations,
                 &group_by.columns,
-                stmt.having.as_ref(),
+                having.as_ref(),
                 params,
             );
         }

--- a/crates/velesdb-core/src/collection/search/query/match_dispatch.rs
+++ b/crates/velesdb-core/src/collection/search/query/match_dispatch.rs
@@ -332,7 +332,13 @@ fn merge_match_results(
     merged
 }
 
-/// Inserts `candidate` into `by_node`, keeping whichever entry has the better score.
+/// Inserts `candidate` into `by_node`, keeping whichever entry has the better
+/// score while merging result data from the losing duplicate.
+///
+/// Audit 2026-06 F2: replacing the whole entry dropped plan-specific data —
+/// a GraphFirst row's `r.*` projection/edge bindings were clobbered by the
+/// VectorFirst candidate for the same `node_id`. The winner keeps its score
+/// but absorbs the bindings/projections it is missing.
 fn upsert_better_score(
     by_node: &mut std::collections::HashMap<u64, super::match_exec::MatchResult>,
     candidate: super::match_exec::MatchResult,
@@ -353,12 +359,32 @@ fn upsert_better_score(
                 new_score < old_score
             };
             if new_wins {
-                entry.insert(candidate);
+                let loser = entry.insert(candidate);
+                merge_missing_result_data(entry.get_mut(), loser);
+            } else {
+                merge_missing_result_data(entry.get_mut(), candidate);
             }
         }
         std::collections::hash_map::Entry::Vacant(entry) => {
             entry.insert(candidate);
         }
+    }
+}
+
+/// Copies `projected`, `edge_bindings`, and `bindings` entries that the merge
+/// winner lacks from the losing duplicate (winner's own entries take priority).
+fn merge_missing_result_data(
+    winner: &mut super::match_exec::MatchResult,
+    loser: super::match_exec::MatchResult,
+) {
+    for (key, value) in loser.projected {
+        winner.projected.entry(key).or_insert(value);
+    }
+    for (key, value) in loser.edge_bindings {
+        winner.edge_bindings.entry(key).or_insert(value);
+    }
+    for (key, value) in loser.bindings {
+        winner.bindings.entry(key).or_insert(value);
     }
 }
 
@@ -524,5 +550,81 @@ mod tests {
     fn test_merge_empty_inputs_euclidean() {
         let merged = merge_match_results(Vec::new(), Vec::new(), false);
         assert!(merged.is_empty());
+    }
+
+    // --- collision data merge (audit 2026-06 cluster F2, finding 5) ---
+
+    /// Builds a GraphFirst-style result: unscored, with edge projection data.
+    fn graph_mr_with_edge_data(node_id: u64) -> MatchResult {
+        let mut r = MatchResult::new(node_id, 1, vec![100]);
+        r.bindings.insert("b".to_string(), node_id);
+        r.edge_bindings.insert("r".to_string(), 100);
+        r.projected
+            .insert("r.since".to_string(), serde_json::json!(2020));
+        r
+    }
+
+    /// GIVEN a GraphFirst result carrying `r.since` projection + edge binding
+    ///   and a scored VectorFirst candidate for the same node without them
+    /// WHEN the candidate wins the score comparison
+    /// THEN the winning score is kept BUT the GraphFirst-only projection,
+    ///      edge bindings, and node bindings survive the merge.
+    #[test]
+    fn test_merge_collision_preserves_graph_edge_data() {
+        let graph = vec![graph_mr_with_edge_data(1)];
+        let vector = vec![mr(1, Some(0.9))];
+
+        let merged = merge_match_results(graph, vector, true);
+
+        assert_eq!(merged.len(), 1);
+        assert!(
+            (merged[0].score.expect("test: should have score") - 0.9).abs() < f32::EPSILON,
+            "the better (vector) score must win"
+        );
+        assert_eq!(
+            merged[0].projected.get("r.since"),
+            Some(&serde_json::json!(2020)),
+            "GraphFirst projection must survive the collision merge"
+        );
+        assert_eq!(
+            merged[0].edge_bindings.get("r"),
+            Some(&100),
+            "GraphFirst edge binding must survive the collision merge"
+        );
+        assert_eq!(
+            merged[0].bindings.get("b"),
+            Some(&1),
+            "GraphFirst node binding must survive the collision merge"
+        );
+    }
+
+    /// GIVEN a scored GraphFirst result that beats the vector candidate
+    /// WHEN the candidate loses the score comparison
+    /// THEN candidate-only data (e.g. its projection keys) still survives.
+    #[test]
+    fn test_merge_collision_preserves_loser_only_keys() {
+        let mut graph = graph_mr_with_edge_data(1);
+        graph.score = Some(0.95);
+        let mut vector = mr(1, Some(0.5));
+        vector
+            .projected
+            .insert("similarity()".to_string(), serde_json::json!(0.5));
+
+        let merged = merge_match_results(vec![graph], vec![vector], true);
+
+        assert_eq!(merged.len(), 1);
+        assert!(
+            (merged[0].score.expect("test: should have score") - 0.95).abs() < f32::EPSILON,
+            "the better (graph) score must win"
+        );
+        assert!(
+            merged[0].projected.contains_key("similarity()"),
+            "loser-only projection keys must survive the collision merge"
+        );
+        assert_eq!(
+            merged[0].projected.get("r.since"),
+            Some(&serde_json::json!(2020)),
+            "winner projection must be untouched"
+        );
     }
 }

--- a/crates/velesdb-core/src/collection/search/query/match_exec/expand.rs
+++ b/crates/velesdb-core/src/collection/search/query/match_exec/expand.rs
@@ -21,6 +21,8 @@ struct Walk<'a, 't> {
     edge_store: &'a crate::collection::graph::ConcurrentEdgeStore,
     ctx: &'a mut TraversalCtx<'t>,
     bindings: &'a mut HashMap<String, u64>,
+    /// Bound relationship aliases (alias -> traversed edge id).
+    edge_bindings: &'a mut HashMap<String, u64>,
     path: &'a mut Vec<u64>,
 }
 
@@ -40,11 +42,13 @@ impl Collection {
 
             let mut path = Vec::new();
             let mut bindings = start_bindings.clone();
+            let mut edge_bindings = HashMap::new();
             let mut walk = Walk {
                 pattern,
                 edge_store,
                 ctx: &mut *ctx,
                 bindings: &mut bindings,
+                edge_bindings: &mut edge_bindings,
                 path: &mut path,
             };
             self.expand_pattern(&mut walk, *start_id, 0)?;
@@ -97,19 +101,56 @@ impl Collection {
         rel_idx: usize,
         hops: u32,
     ) -> Result<()> {
+        // Relationship isomorphism (Cypher semantics): an edge may be
+        // traversed at most once per matched path. `walk.path` is exactly
+        // the in-progress path's edge list (push/pop backtracking below),
+        // so a linear scan gives per-path visited-edge tracking with no
+        // extra state; paths are short (bounded by the pattern's max hops
+        // and the depth guard-rail).
         if walk.ctx.all_results.len() >= walk.ctx.limit
+            || walk.path.contains(&edge.id())
             || !Self::edge_matches(edge, &walk.pattern.relationships[rel_idx])
         {
             return Ok(());
         }
         let next_id = Self::edge_next_node(edge, current_id);
         walk.path.push(edge.id());
+        let saved_alias = Self::bind_edge_alias(walk, rel_idx, edge.id());
         *walk.ctx.iteration_count += 1;
         let depth = walk.path.len() as u32;
         self.check_depth_and_periodic_guardrails(depth, walk.ctx)?;
         self.expand_relationship(walk, next_id, rel_idx, hops.saturating_add(1))?;
+        Self::restore_edge_alias(walk, saved_alias);
         walk.path.pop();
         Ok(())
+    }
+
+    /// Binds the relationship alias (if any) to the traversed edge id so
+    /// `WHERE r.prop` / `RETURN r.prop` resolve against the edge.
+    ///
+    /// Returns the alias and its previous value for backtracking. For
+    /// variable-length relationships the alias tracks the most recently
+    /// traversed edge of that segment.
+    fn bind_edge_alias(
+        walk: &mut Walk<'_, '_>,
+        rel_idx: usize,
+        edge_id: u64,
+    ) -> Option<(String, Option<u64>)> {
+        let alias = walk.pattern.relationships[rel_idx].alias.clone()?;
+        let previous = walk.edge_bindings.insert(alias.clone(), edge_id);
+        Some((alias, previous))
+    }
+
+    /// Restores a relationship alias binding saved by [`Self::bind_edge_alias`].
+    fn restore_edge_alias(walk: &mut Walk<'_, '_>, saved: Option<(String, Option<u64>)>) {
+        let Some((alias, previous)) = saved else {
+            return;
+        };
+        if let Some(edge_id) = previous {
+            walk.edge_bindings.insert(alias, edge_id);
+        } else {
+            walk.edge_bindings.remove(&alias);
+        }
     }
 
     fn try_bind_next_node(
@@ -140,6 +181,7 @@ impl Collection {
             if !self.evaluate_where_condition(
                 node_id,
                 Some(&*walk.bindings),
+                Some(&*walk.edge_bindings),
                 where_clause,
                 walk.ctx.params,
                 walk.ctx.payload_guard,
@@ -155,8 +197,10 @@ impl Collection {
 
         let mut result = MatchResult::new(node_id, walk.path.len() as u32, walk.path.clone());
         result.bindings.clone_from(walk.bindings);
+        result.edge_bindings.clone_from(walk.edge_bindings);
         result.projected = self.project_properties(
             walk.bindings,
+            walk.edge_bindings,
             &walk.ctx.match_clause.return_clause,
             walk.ctx.payload_guard,
         );

--- a/crates/velesdb-core/src/collection/search/query/match_exec/mod.rs
+++ b/crates/velesdb-core/src/collection/search/query/match_exec/mod.rs
@@ -36,6 +36,8 @@ pub struct MatchResult {
     pub path: Vec<u64>,
     /// Bound variables from the pattern (alias -> node_id).
     pub bindings: HashMap<String, u64>,
+    /// Bound relationship aliases from the pattern (alias -> edge_id).
+    pub edge_bindings: HashMap<String, u64>,
     /// Similarity score if combined with vector search.
     pub score: Option<f32>,
     /// Projected properties from RETURN clause (EPIC-058 US-007).
@@ -52,6 +54,7 @@ impl MatchResult {
             depth,
             path,
             bindings: HashMap::new(),
+            edge_bindings: HashMap::new(),
             score: None,
             projected: HashMap::new(),
         }
@@ -336,6 +339,7 @@ impl Collection {
                 if !self.evaluate_where_condition(
                     *node_id,
                     Some(bindings),
+                    None,
                     where_clause,
                     ctx.params,
                     ctx.payload_guard,
@@ -352,6 +356,7 @@ impl Collection {
             result.bindings.clone_from(bindings);
             result.projected = self.project_properties(
                 bindings,
+                &HashMap::new(),
                 &ctx.match_clause.return_clause,
                 ctx.payload_guard,
             );

--- a/crates/velesdb-core/src/collection/search/query/match_exec/mod.rs
+++ b/crates/velesdb-core/src/collection/search/query/match_exec/mod.rs
@@ -16,7 +16,7 @@ mod index_prefilter;
 mod similarity;
 mod start_nodes;
 mod vector_first;
-mod where_eval;
+pub(in crate::collection::search::query) mod where_eval;
 
 use crate::collection::types::Collection;
 use crate::error::{Error, Result};

--- a/crates/velesdb-core/src/collection/search/query/match_exec/similarity.rs
+++ b/crates/velesdb-core/src/collection/search/query/match_exec/similarity.rs
@@ -27,15 +27,23 @@ impl Collection {
     /// - `BareAlias`: all properties from a single bound node
     ///
     /// The caller must pass a pre-acquired `payload_guard` to avoid
-    /// per-node lock acquisitions during traversal.
-    #[allow(clippy::unused_self)] // Method on Collection for API consistency
+    /// per-node lock acquisitions during traversal. `edge_bindings` maps
+    /// relationship aliases to traversed edge ids so `RETURN r.prop`
+    /// projects the EDGE's property (audit 2026-06 F).
     pub(crate) fn project_properties(
         &self,
         bindings: &HashMap<String, u64>,
+        edge_bindings: &HashMap<String, u64>,
         return_clause: &crate::velesql::ReturnClause,
         payload_guard: &LogPayloadStorage,
     ) -> HashMap<String, serde_json::Value> {
-        self.project_properties_with_score(bindings, return_clause, None, payload_guard)
+        self.project_properties_with_score(
+            bindings,
+            edge_bindings,
+            return_clause,
+            None,
+            payload_guard,
+        )
     }
 
     /// Projects properties with an optional similarity score (Fix #489).
@@ -44,10 +52,10 @@ impl Collection {
     /// When `score` is `Some`, `RETURN similarity()` injects it into the
     /// projected map. All other variants work identically to
     /// [`project_properties`].
-    #[allow(clippy::unused_self)] // Method on Collection for API consistency
     pub(crate) fn project_properties_with_score(
         &self,
         bindings: &HashMap<String, u64>,
+        edge_bindings: &HashMap<String, u64>,
         return_clause: &crate::velesql::ReturnClause,
         score: Option<f32>,
         payload_guard: &LogPayloadStorage,
@@ -70,14 +78,20 @@ impl Collection {
                     }
                 }
                 ProjectionItem::PropertyPath { alias, property } => {
-                    Self::project_property_path(
-                        alias,
-                        property,
-                        item,
-                        bindings,
-                        payload_guard,
-                        &mut projected,
-                    );
+                    // Relationship aliases project from the traversed edge's
+                    // properties (audit 2026-06 F).
+                    if let Some(&edge_id) = edge_bindings.get(alias) {
+                        self.project_edge_property(edge_id, property, item, &mut projected);
+                    } else {
+                        Self::project_property_path(
+                            alias,
+                            property,
+                            item,
+                            bindings,
+                            payload_guard,
+                            &mut projected,
+                        );
+                    }
                 }
                 ProjectionItem::BareAlias(alias) => {
                     Self::project_bare_alias(alias, bindings, payload_guard, &mut projected);
@@ -86,6 +100,28 @@ impl Collection {
         }
 
         projected
+    }
+
+    /// Projects a single dotted property (e.g., `r.since`) from a bound
+    /// relationship alias, reading the traversed edge's properties.
+    fn project_edge_property(
+        &self,
+        edge_id: u64,
+        property: &str,
+        item: &crate::velesql::ReturnItem,
+        projected: &mut HashMap<String, serde_json::Value>,
+    ) {
+        let Some(edge) = self.edge_store.get_edge(edge_id) else {
+            return;
+        };
+        let Some(value) = super::where_eval::edge_property_path(&edge, property) else {
+            return;
+        };
+        let key = item
+            .alias
+            .clone()
+            .unwrap_or_else(|| item.expression.clone());
+        projected.insert(key, value.clone());
     }
 
     /// Projects ALL properties from ALL bound nodes into the result (RETURN *).
@@ -278,6 +314,7 @@ impl Collection {
                     result.score = Some(score);
                     result.projected = self.project_properties_with_score(
                         &result.bindings,
+                        &result.edge_bindings,
                         &match_clause.return_clause,
                         Some(score),
                         payload_guard,

--- a/crates/velesdb-core/src/collection/search/query/match_exec/vector_first.rs
+++ b/crates/velesdb-core/src/collection/search/query/match_exec/vector_first.rs
@@ -146,6 +146,7 @@ impl Collection {
         }
         mr.projected = self.project_properties_with_score(
             &mr.bindings,
+            &mr.edge_bindings,
             &match_clause.return_clause,
             Some(candidate.score),
             payload_guard,
@@ -200,7 +201,14 @@ impl Collection {
             if let Some(alias) = pattern.nodes.first().and_then(|n| n.alias.as_ref()) {
                 bindings.insert(alias.clone(), node_id);
             }
-            self.evaluate_where_condition(node_id, Some(&bindings), cond, params, payload_guard)
+            self.evaluate_where_condition(
+                node_id,
+                Some(&bindings),
+                None,
+                cond,
+                params,
+                payload_guard,
+            )
         } else {
             Ok(true)
         }
@@ -245,6 +253,7 @@ impl Collection {
                 if self.evaluate_where_condition(
                     hit.target_id,
                     Some(&bindings),
+                    None,
                     cond,
                     params,
                     payload_guard,

--- a/crates/velesdb-core/src/collection/search/query/match_exec/where_eval.rs
+++ b/crates/velesdb-core/src/collection/search/query/match_exec/where_eval.rs
@@ -165,7 +165,12 @@ impl Collection {
             Condition::Not(inner) => Ok(!self.eval_match_condition(ctx, inner)?),
             Condition::Group(inner) => self.eval_match_condition(ctx, inner),
             Condition::Similarity(sim) => {
-                self.evaluate_similarity_condition(ctx.node_id, sim, ctx.params)
+                // Audit 2026-06 F2: resolve the alias prefix of the similarity
+                // field (e.g. `a.embedding`) against the bound node so the
+                // score is computed on the aliased node, not the traversal
+                // target. Unbound/bare fields keep the previous behaviour.
+                let target_id = resolve_target_id(&sim.field, ctx.bindings, ctx.node_id);
+                self.evaluate_similarity_condition(target_id, sim, ctx.params)
             }
             // Fix #492: metadata conditions converted to filter engine evaluation.
             Condition::In(_)
@@ -514,7 +519,9 @@ fn strip_alias_owned(column: &str, bindings: Option<&HashMap<String, u64>>) -> S
 ///
 /// Returns `Some(&str)` for condition types that carry a `column` field.
 /// Non-metadata variants return `None`.
-fn column_of_metadata_condition(condition: &crate::velesql::Condition) -> Option<&str> {
+pub(in crate::collection::search::query) fn column_of_metadata_condition(
+    condition: &crate::velesql::Condition,
+) -> Option<&str> {
     use crate::velesql::Condition;
     match condition {
         Condition::In(ic) => Some(&ic.column),

--- a/crates/velesdb-core/src/collection/search/query/match_exec/where_eval.rs
+++ b/crates/velesdb-core/src/collection/search/query/match_exec/where_eval.rs
@@ -174,6 +174,7 @@ impl Collection {
                 node_id,
                 bindings,
                 condition,
+                params,
                 payload_guard,
             ),
             // VectorSearch, VectorFusedSearch, SparseVectorSearch, and GraphMatch
@@ -218,11 +219,11 @@ impl Collection {
     /// is resolved to the correct node ID via bindings, and stripped before
     /// building the filter condition so the filter engine sees the bare field
     /// path.
-    #[allow(clippy::unnecessary_wraps)] // Consistent with other evaluate_* methods
     fn evaluate_metadata_condition_for_node(
         node_id: u64,
         bindings: Option<&HashMap<String, u64>>,
         condition: &crate::velesql::Condition,
+        params: &HashMap<String, serde_json::Value>,
         payload_guard: &LogPayloadStorage,
     ) -> Result<bool> {
         // Fix #486: Resolve the target node ID from the condition's column
@@ -237,7 +238,10 @@ impl Collection {
         };
 
         let rewritten = rewrite_condition_aliases(condition.clone(), bindings);
-        let filter_cond: filter::Condition = rewritten.into();
+        // Resolve parameter placeholders (e.g. `IN ($a, $b)`) before the
+        // filter conversion, which would otherwise turn them into NULL.
+        let resolved = Self::resolve_condition_params(&rewritten, params)?;
+        let filter_cond: filter::Condition = resolved.into();
         Ok(filter_cond.matches(&payload))
     }
 

--- a/crates/velesdb-core/src/collection/search/query/match_exec/where_eval.rs
+++ b/crates/velesdb-core/src/collection/search/query/match_exec/where_eval.rs
@@ -4,6 +4,7 @@
 //! Fix #492: metadata conditions (IN, BETWEEN, LIKE, IS NULL) are now evaluated
 //! against node payloads instead of being silently ignored by a catch-all arm.
 
+use crate::collection::graph::GraphEdge;
 use crate::collection::types::Collection;
 use crate::error::{Error, Result};
 use crate::filter;
@@ -100,6 +101,21 @@ pub(super) fn resolve_query_vector(
     }
 }
 
+/// Bundled per-node context for MATCH WHERE evaluation.
+///
+/// Groups the invariant evaluation state so the recursive condition walk
+/// stays within the argument-count and complexity limits (mirrors
+/// `WhereEvalCtx` in the SELECT-side `where_eval`).
+struct MatchWhereCtx<'a> {
+    node_id: u64,
+    bindings: Option<&'a HashMap<String, u64>>,
+    /// Bound relationship aliases (alias -> traversed edge id) so `r.prop`
+    /// resolves against the EDGE's properties (audit 2026-06 F).
+    edge_bindings: Option<&'a HashMap<String, u64>>,
+    params: &'a HashMap<String, serde_json::Value>,
+    payload_guard: &'a LogPayloadStorage,
+}
+
 impl Collection {
     /// Evaluates a WHERE condition against a node's payload (EPIC-045 US-002).
     ///
@@ -112,55 +128,45 @@ impl Collection {
     ///
     /// Fix #492: metadata conditions are now evaluated via the filter engine
     /// instead of being silently ignored by a catch-all arm.
+    ///
+    /// `edge_bindings` maps relationship aliases to traversed edge ids so
+    /// `r.prop` resolves against the EDGE's properties (audit 2026-06 F).
     pub(crate) fn evaluate_where_condition(
         &self,
         node_id: u64,
         bindings: Option<&HashMap<String, u64>>,
+        edge_bindings: Option<&HashMap<String, u64>>,
         condition: &crate::velesql::Condition,
         params: &HashMap<String, serde_json::Value>,
         payload_guard: &LogPayloadStorage,
     ) -> Result<bool> {
+        let ctx = MatchWhereCtx {
+            node_id,
+            bindings,
+            edge_bindings,
+            params,
+            payload_guard,
+        };
+        self.eval_match_condition(&ctx, condition)
+    }
+
+    /// Recursively evaluates a single condition node of a MATCH WHERE tree.
+    fn eval_match_condition(
+        &self,
+        ctx: &MatchWhereCtx<'_>,
+        condition: &crate::velesql::Condition,
+    ) -> Result<bool> {
         use crate::velesql::Condition;
 
         match condition {
-            Condition::Comparison(cmp) => {
-                Self::evaluate_comparison_condition(node_id, bindings, cmp, params, payload_guard)
+            Condition::Comparison(cmp) => self.evaluate_comparison_condition(ctx, cmp),
+            Condition::And(left, right) => self.eval_match_and(ctx, left, right),
+            Condition::Or(left, right) => self.eval_match_or(ctx, left, right),
+            Condition::Not(inner) => Ok(!self.eval_match_condition(ctx, inner)?),
+            Condition::Group(inner) => self.eval_match_condition(ctx, inner),
+            Condition::Similarity(sim) => {
+                self.evaluate_similarity_condition(ctx.node_id, sim, ctx.params)
             }
-            Condition::And(left, right) => {
-                Ok(
-                    self.evaluate_where_condition(node_id, bindings, left, params, payload_guard)?
-                        && self.evaluate_where_condition(
-                            node_id,
-                            bindings,
-                            right,
-                            params,
-                            payload_guard,
-                        )?,
-                )
-            }
-            Condition::Or(left, right) => {
-                Ok(
-                    self.evaluate_where_condition(node_id, bindings, left, params, payload_guard)?
-                        || self.evaluate_where_condition(
-                            node_id,
-                            bindings,
-                            right,
-                            params,
-                            payload_guard,
-                        )?,
-                )
-            }
-            Condition::Not(inner) => Ok(!self.evaluate_where_condition(
-                node_id,
-                bindings,
-                inner,
-                params,
-                payload_guard,
-            )?),
-            Condition::Group(inner) => {
-                self.evaluate_where_condition(node_id, bindings, inner, params, payload_guard)
-            }
-            Condition::Similarity(sim) => self.evaluate_similarity_condition(node_id, sim, params),
             // Fix #492: metadata conditions converted to filter engine evaluation.
             Condition::In(_)
             | Condition::Between(_)
@@ -170,13 +176,7 @@ impl Collection {
             | Condition::ContainsText(_)
             | Condition::Contains(_)
             | Condition::GeoDistance(_)
-            | Condition::GeoBbox(_) => Self::evaluate_metadata_condition_for_node(
-                node_id,
-                bindings,
-                condition,
-                params,
-                payload_guard,
-            ),
+            | Condition::GeoBbox(_) => self.evaluate_metadata_condition_for_node(ctx, condition),
             // VectorSearch, VectorFusedSearch, SparseVectorSearch, and GraphMatch
             // are handled separately in `execute_match_with_similarity`.
             Condition::VectorSearch(_)
@@ -186,27 +186,76 @@ impl Collection {
         }
     }
 
-    /// Evaluates a single comparison condition against a node's payload.
+    /// Evaluates AND with short-circuit: returns false immediately if left is false.
+    fn eval_match_and(
+        &self,
+        ctx: &MatchWhereCtx<'_>,
+        left: &crate::velesql::Condition,
+        right: &crate::velesql::Condition,
+    ) -> Result<bool> {
+        if !self.eval_match_condition(ctx, left)? {
+            return Ok(false);
+        }
+        self.eval_match_condition(ctx, right)
+    }
+
+    /// Evaluates OR with short-circuit: returns true immediately if left is true.
+    fn eval_match_or(
+        &self,
+        ctx: &MatchWhereCtx<'_>,
+        left: &crate::velesql::Condition,
+        right: &crate::velesql::Condition,
+    ) -> Result<bool> {
+        if self.eval_match_condition(ctx, left)? {
+            return Ok(true);
+        }
+        self.eval_match_condition(ctx, right)
+    }
+
+    /// Evaluates a single comparison condition against a node's payload,
+    /// or against the traversed edge's properties when the column alias is
+    /// a bound relationship alias (audit 2026-06 F).
     ///
     /// Uses the pre-acquired `payload_guard` instead of locking per-node.
     fn evaluate_comparison_condition(
-        node_id: u64,
-        bindings: Option<&HashMap<String, u64>>,
+        &self,
+        ctx: &MatchWhereCtx<'_>,
         cmp: &crate::velesql::Comparison,
-        params: &HashMap<String, serde_json::Value>,
-        payload_guard: &LogPayloadStorage,
     ) -> Result<bool> {
-        let target_id = resolve_target_id(&cmp.column, bindings, node_id);
+        if let Some(edge_id) = resolve_edge_target(&cmp.column, ctx.edge_bindings) {
+            return self.evaluate_edge_comparison(edge_id, cmp, ctx.params);
+        }
 
-        let Some(target_payload) = payload_guard.retrieve(target_id).ok().flatten() else {
+        let target_id = resolve_target_id(&cmp.column, ctx.bindings, ctx.node_id);
+
+        let Some(target_payload) = ctx.payload_guard.retrieve(target_id).ok().flatten() else {
             return Ok(false);
         };
 
-        let column_path = strip_alias(&cmp.column, bindings);
+        let column_path = strip_alias(&cmp.column, ctx.bindings);
         let Some(actual) = Self::json_get_path(&target_payload, column_path) else {
             return Ok(false);
         };
 
+        let resolved_value = Self::resolve_where_param(&cmp.value, ctx.params)?;
+        Self::evaluate_comparison(cmp.operator, actual, &resolved_value)
+    }
+
+    /// Evaluates a comparison whose column refers to a bound relationship
+    /// alias (e.g. `r.since = 2020`) against the traversed edge's properties.
+    fn evaluate_edge_comparison(
+        &self,
+        edge_id: u64,
+        cmp: &crate::velesql::Comparison,
+        params: &HashMap<String, serde_json::Value>,
+    ) -> Result<bool> {
+        let Some(edge) = self.edge_store.get_edge(edge_id) else {
+            return Ok(false);
+        };
+        let property = cmp.column.split_once('.').map_or("", |(_, rest)| rest);
+        let Some(actual) = edge_property_path(&edge, property) else {
+            return Ok(false);
+        };
         let resolved_value = Self::resolve_where_param(&cmp.value, params)?;
         Self::evaluate_comparison(cmp.operator, actual, &resolved_value)
     }
@@ -220,27 +269,59 @@ impl Collection {
     /// building the filter condition so the filter engine sees the bare field
     /// path.
     fn evaluate_metadata_condition_for_node(
-        node_id: u64,
-        bindings: Option<&HashMap<String, u64>>,
+        &self,
+        ctx: &MatchWhereCtx<'_>,
         condition: &crate::velesql::Condition,
-        params: &HashMap<String, serde_json::Value>,
-        payload_guard: &LogPayloadStorage,
     ) -> Result<bool> {
         // Fix #486: Resolve the target node ID from the condition's column
         // alias, mirroring what evaluate_comparison_condition does. Without
         // this, `WHERE a.category IN (...)` would evaluate against node_id
         // (the traversal target) instead of the node bound to alias `a`.
-        let target_id = column_of_metadata_condition(condition)
-            .map_or(node_id, |col| resolve_target_id(col, bindings, node_id));
+        let column = column_of_metadata_condition(condition);
 
-        let Some(payload) = payload_guard.retrieve(target_id).ok().flatten() else {
+        // Audit 2026-06 F: a relationship alias resolves against the EDGE's
+        // properties, not a node payload.
+        if let Some(edge_id) = column.and_then(|col| resolve_edge_target(col, ctx.edge_bindings)) {
+            return self.evaluate_metadata_condition_for_edge(edge_id, condition, ctx);
+        }
+
+        let target_id = column.map_or(ctx.node_id, |col| {
+            resolve_target_id(col, ctx.bindings, ctx.node_id)
+        });
+
+        let Some(payload) = ctx.payload_guard.retrieve(target_id).ok().flatten() else {
             return Ok(false);
         };
 
-        let rewritten = rewrite_condition_aliases(condition.clone(), bindings);
+        let rewritten = rewrite_condition_aliases(condition.clone(), ctx.bindings);
         // Resolve parameter placeholders (e.g. `IN ($a, $b)`) before the
         // filter conversion, which would otherwise turn them into NULL.
-        let resolved = Self::resolve_condition_params(&rewritten, params)?;
+        let resolved = Self::resolve_condition_params(&rewritten, ctx.params)?;
+        let filter_cond: filter::Condition = resolved.into();
+        Ok(filter_cond.matches(&payload))
+    }
+
+    /// Mirrors `evaluate_metadata_condition_for_node` for relationship
+    /// aliases: runs the filter engine against the bound edge's properties.
+    fn evaluate_metadata_condition_for_edge(
+        &self,
+        edge_id: u64,
+        condition: &crate::velesql::Condition,
+        ctx: &MatchWhereCtx<'_>,
+    ) -> Result<bool> {
+        let Some(edge) = self.edge_store.get_edge(edge_id) else {
+            return Ok(false);
+        };
+        let payload = serde_json::Value::Object(
+            edge.properties()
+                .iter()
+                .map(|(k, v)| (k.clone(), v.clone()))
+                .collect(),
+        );
+        let rewritten = rewrite_condition_aliases(condition.clone(), ctx.edge_bindings);
+        // Resolve parameter placeholders before the filter conversion, which
+        // would otherwise turn them into NULL (same hardening as the node path).
+        let resolved = Self::resolve_condition_params(&rewritten, ctx.params)?;
         let filter_cond: filter::Condition = resolved.into();
         Ok(filter_cond.matches(&payload))
     }
@@ -367,7 +448,10 @@ impl Collection {
         })
     }
 
-    fn json_get_path<'a>(root: &'a serde_json::Value, path: &str) -> Option<&'a serde_json::Value> {
+    pub(super) fn json_get_path<'a>(
+        root: &'a serde_json::Value,
+        path: &str,
+    ) -> Option<&'a serde_json::Value> {
         if path.is_empty() {
             return Some(root);
         }
@@ -390,6 +474,24 @@ fn resolve_target_id(
         .split_once('.')
         .and_then(|(alias, _)| bindings?.get(alias).copied())
         .unwrap_or(default_id)
+}
+
+/// Resolves an alias-prefixed column against bound relationship aliases.
+///
+/// Returns the bound edge id when the column's alias prefix refers to a
+/// relationship alias (e.g. `r.since` with `r` bound by the pattern walker).
+fn resolve_edge_target(column: &str, edge_bindings: Option<&HashMap<String, u64>>) -> Option<u64> {
+    let (alias, _) = column.split_once('.')?;
+    edge_bindings?.get(alias).copied()
+}
+
+/// Looks up a (possibly nested) property path on an edge's properties.
+pub(super) fn edge_property_path<'a>(
+    edge: &'a GraphEdge,
+    path: &str,
+) -> Option<&'a serde_json::Value> {
+    let (first, rest) = path.split_once('.').map_or((path, ""), |(f, r)| (f, r));
+    Collection::json_get_path(edge.property(first)?, rest)
 }
 
 /// Strips the alias prefix from a column path when the alias exists in bindings.

--- a/crates/velesdb-core/src/collection/search/query/match_planner.rs
+++ b/crates/velesdb-core/src/collection/search/query/match_planner.rs
@@ -95,15 +95,22 @@ impl MatchQueryPlanner {
             Self::is_similarity_on_start(match_clause, similarity_info.as_ref());
         let start_labels = Self::extract_start_labels(match_clause);
         let max_depth = Self::count_hops(match_clause);
+        // Audit 2026-06 F2: VectorFirst (alone or as a Parallel leg) validates
+        // candidates without binding relationship aliases, so `r.prop` would
+        // silently resolve against node payloads. Force GraphFirst whenever
+        // WHERE or RETURN references a relationship alias of the pattern.
+        let edge_alias_referenced = Self::references_relationship_alias(match_clause);
 
-        if has_similarity && similarity_on_start {
+        if has_similarity && similarity_on_start && !edge_alias_referenced {
             Self::plan_vector_first(match_clause, stats, similarity_info)
         } else if !has_similarity {
             MatchExecutionStrategy::GraphFirst {
                 start_labels,
                 max_depth,
             }
-        } else if Self::should_use_parallel(stats, similarity_info.as_ref()) {
+        } else if !edge_alias_referenced
+            && Self::should_use_parallel(stats, similarity_info.as_ref())
+        {
             Self::plan_parallel(
                 match_clause,
                 stats,
@@ -116,6 +123,58 @@ impl MatchQueryPlanner {
                 start_labels,
                 max_depth,
             }
+        }
+    }
+
+    /// Checks whether any WHERE leaf or RETURN/ORDER BY expression references
+    /// a relationship alias declared by the pattern (audit 2026-06 F2).
+    fn references_relationship_alias(match_clause: &MatchClause) -> bool {
+        let aliases: Vec<&str> = match_clause
+            .patterns
+            .iter()
+            .flat_map(|p| p.relationships.iter())
+            .filter_map(|r| r.alias.as_deref())
+            .collect();
+        if aliases.is_empty() {
+            return false;
+        }
+        let where_refs = match_clause
+            .where_clause
+            .as_ref()
+            .is_some_and(|cond| Self::condition_references_alias(cond, &aliases));
+        where_refs || Self::return_clause_references_alias(&match_clause.return_clause, &aliases)
+    }
+
+    /// Checks RETURN items and ORDER BY expressions for alias references.
+    fn return_clause_references_alias(
+        return_clause: &crate::velesql::ReturnClause,
+        aliases: &[&str],
+    ) -> bool {
+        let item_refs = return_clause
+            .items
+            .iter()
+            .any(|item| column_targets_alias(&item.expression, aliases));
+        let order_refs = return_clause.order_by.as_ref().is_some_and(|items| {
+            items
+                .iter()
+                .any(|item| column_targets_alias(&item.expression, aliases))
+        });
+        item_refs || order_refs
+    }
+
+    /// Recursively checks WHERE leaves for columns targeting `aliases`.
+    fn condition_references_alias(condition: &Condition, aliases: &[&str]) -> bool {
+        match condition {
+            Condition::Comparison(cmp) => column_targets_alias(&cmp.column, aliases),
+            Condition::And(left, right) | Condition::Or(left, right) => {
+                Self::condition_references_alias(left, aliases)
+                    || Self::condition_references_alias(right, aliases)
+            }
+            Condition::Not(inner) | Condition::Group(inner) => {
+                Self::condition_references_alias(inner, aliases)
+            }
+            other => super::match_exec::where_eval::column_of_metadata_condition(other)
+                .is_some_and(|column| column_targets_alias(column, aliases)),
         }
     }
 
@@ -326,6 +385,13 @@ impl MatchQueryPlanner {
             }
         }
     }
+}
+
+/// Checks whether a column expression (`r.prop` or bare `r`) targets one of
+/// the pattern's relationship aliases (audit 2026-06 F2).
+fn column_targets_alias(column: &str, aliases: &[&str]) -> bool {
+    let prefix = column.split('.').next().unwrap_or(column);
+    aliases.contains(&prefix)
 }
 
 // Tests moved to match_planner_tests.rs per project rules

--- a/crates/velesdb-core/src/collection/search/query/match_planner_tests.rs
+++ b/crates/velesdb-core/src/collection/search/query/match_planner_tests.rs
@@ -168,3 +168,138 @@ fn test_planner_vector_first_returns_threshold() {
         panic!("expected VectorFirst strategy");
     }
 }
+
+// =========================================================================
+// Audit 2026-06 cluster F2: relationship-alias references force GraphFirst
+// =========================================================================
+
+/// Adds a `r` alias to the pattern relationship of a match clause.
+fn with_rel_alias(mut match_clause: MatchClause) -> MatchClause {
+    match_clause.patterns[0].relationships[0].alias = Some("r".to_string());
+    match_clause
+}
+
+#[test]
+fn test_planner_forces_graph_first_when_where_references_edge_alias() {
+    let mut match_clause = with_rel_alias(make_match_clause(true, Some(10)));
+    let sim = match_clause
+        .where_clause
+        .take()
+        .expect("test: similarity condition");
+    match_clause.where_clause = Some(Condition::And(
+        Box::new(sim),
+        Box::new(Condition::Comparison(crate::velesql::Comparison {
+            column: "r.since".to_string(),
+            operator: CompareOp::Eq,
+            value: crate::velesql::Value::Integer(2020),
+        })),
+    ));
+
+    let strategy = MatchQueryPlanner::plan(&match_clause, &default_stats());
+    assert!(
+        matches!(strategy, MatchExecutionStrategy::GraphFirst { .. }),
+        "WHERE r.since must force GraphFirst (VectorFirst cannot bind edge aliases), got {strategy:?}"
+    );
+}
+
+#[test]
+fn test_planner_forces_graph_first_when_return_references_edge_alias() {
+    let mut match_clause = with_rel_alias(make_match_clause(true, Some(10)));
+    match_clause.return_clause.items = vec![crate::velesql::ReturnItem {
+        expression: "r.since".to_string(),
+        alias: None,
+    }];
+
+    let strategy = MatchQueryPlanner::plan(&match_clause, &default_stats());
+    assert!(
+        matches!(strategy, MatchExecutionStrategy::GraphFirst { .. }),
+        "RETURN r.since must force GraphFirst (VectorFirst cannot bind edge aliases), got {strategy:?}"
+    );
+}
+
+#[test]
+fn test_planner_forces_graph_first_over_parallel_when_edge_alias_referenced() {
+    // similarity on a NON-start alias + large dense stats would pick Parallel;
+    // an edge-alias reference in RETURN must force pure GraphFirst instead.
+    let mut match_clause = with_rel_alias(make_match_clause(true, Some(10)));
+    if let Some(Condition::Similarity(sim)) = match_clause.where_clause.as_mut() {
+        sim.field = "b.embedding".to_string();
+        sim.threshold = 0.85; // > 0.8 so should_use_parallel() is reachable
+    }
+    match_clause.return_clause.items = vec![crate::velesql::ReturnItem {
+        expression: "r.since".to_string(),
+        alias: None,
+    }];
+    let stats = CollectionStats {
+        total_nodes: 50_000,
+        total_edges: 500_000,
+        avg_degree: 10.0,
+        label_count: 10,
+        label_selectivity: 0.1,
+    };
+
+    let strategy = MatchQueryPlanner::plan(&match_clause, &stats);
+    assert!(
+        matches!(strategy, MatchExecutionStrategy::GraphFirst { .. }),
+        "edge-alias reference must force GraphFirst over Parallel \
+         (the VectorFirst leg cannot bind edge aliases), got {strategy:?}"
+    );
+}
+
+#[test]
+fn test_planner_keeps_vector_first_without_edge_alias_reference() {
+    // The relationship HAS an alias, but neither WHERE nor RETURN uses it.
+    let match_clause = with_rel_alias(make_match_clause(true, Some(10)));
+
+    let strategy = MatchQueryPlanner::plan(&match_clause, &default_stats());
+    assert!(
+        matches!(strategy, MatchExecutionStrategy::VectorFirst { .. }),
+        "an unused relationship alias must not disable VectorFirst, got {strategy:?}"
+    );
+}
+
+#[test]
+fn test_planner_node_alias_column_does_not_force_graph_first() {
+    // `b.age` references a NODE alias — VectorFirst handles node aliases.
+    let mut match_clause = with_rel_alias(make_match_clause(true, Some(10)));
+    let sim = match_clause
+        .where_clause
+        .take()
+        .expect("test: similarity condition");
+    match_clause.where_clause = Some(Condition::And(
+        Box::new(sim),
+        Box::new(Condition::Comparison(crate::velesql::Comparison {
+            column: "b.age".to_string(),
+            operator: CompareOp::Gt,
+            value: crate::velesql::Value::Integer(18),
+        })),
+    ));
+
+    let strategy = MatchQueryPlanner::plan(&match_clause, &default_stats());
+    assert!(
+        matches!(strategy, MatchExecutionStrategy::VectorFirst { .. }),
+        "node-alias columns must not force GraphFirst, got {strategy:?}"
+    );
+}
+
+#[test]
+fn test_planner_is_null_on_edge_alias_forces_graph_first() {
+    let mut match_clause = with_rel_alias(make_match_clause(true, Some(10)));
+    let sim = match_clause
+        .where_clause
+        .take()
+        .expect("test: similarity condition");
+    match_clause.where_clause = Some(Condition::And(
+        Box::new(sim),
+        Box::new(Condition::IsNull(crate::velesql::IsNullCondition {
+            column: "r.since".to_string(),
+            is_null: true,
+        })),
+    ));
+
+    let strategy = MatchQueryPlanner::plan(&match_clause, &default_stats());
+    assert!(
+        matches!(strategy, MatchExecutionStrategy::GraphFirst { .. }),
+        "IS NULL on an edge alias must force GraphFirst, got {strategy:?}"
+    );
+}

--- a/crates/velesdb-core/src/collection/search/query/mod.rs
+++ b/crates/velesdb-core/src/collection/search/query/mod.rs
@@ -193,6 +193,12 @@ impl Collection {
             return Ok(results);
         }
 
+        // Resolve scalar WHERE parameters once so every downstream conversion
+        // to a payload Filter sees bound values; a missing parameter errors
+        // here instead of silently degrading to NULL.
+        let resolved_query = Self::resolve_query_where_params(query, params)?;
+        let query = resolved_query.as_ref().unwrap_or(query);
+
         // Phase 2-3: SELECT extraction, early-return, dispatch, and finalization.
         self.execute_select_pipeline(query, params, &ctx)
     }

--- a/crates/velesdb-core/src/collection/search/query/query_pipeline.rs
+++ b/crates/velesdb-core/src/collection/search/query/query_pipeline.rs
@@ -177,6 +177,56 @@ impl Collection {
         Ok(())
     }
 
+    /// Returns a copy of `stmt` with scalar WHERE parameter placeholders
+    /// resolved, or `None` when the statement has no WHERE clause.
+    ///
+    /// Resolving once at pipeline entry guarantees every downstream
+    /// conversion to a payload [`Filter`](crate::filter::Filter) sees bound
+    /// values: without this, `Value::Parameter` silently degrades to JSON
+    /// `null` in `filter::Condition::from`, returning 0 rows without error.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when a referenced parameter is missing or has an
+    /// unsupported type, mirroring the vector-parameter paths.
+    pub(super) fn resolve_stmt_where_params(
+        stmt: &crate::velesql::SelectStatement,
+        params: &std::collections::HashMap<String, serde_json::Value>,
+    ) -> Result<Option<crate::velesql::SelectStatement>> {
+        let Some(cond) = stmt.where_clause.as_ref() else {
+            return Ok(None);
+        };
+        let resolved = Self::resolve_condition_params(cond, params)?;
+        let mut resolved_stmt = stmt.clone();
+        resolved_stmt.where_clause = Some(resolved);
+        Ok(Some(resolved_stmt))
+    }
+
+    /// Returns a copy of `query` with scalar WHERE parameter placeholders
+    /// resolved, or `None` when the query has no WHERE clause.
+    ///
+    /// Convenience wrapper around [`Self::resolve_stmt_where_params`] for
+    /// callers that thread a whole [`Query`](crate::velesql::Query) through
+    /// their pipeline.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when a referenced parameter is missing or has an
+    /// unsupported type.
+    pub(super) fn resolve_query_where_params(
+        query: &crate::velesql::Query,
+        params: &std::collections::HashMap<String, serde_json::Value>,
+    ) -> Result<Option<crate::velesql::Query>> {
+        Ok(
+            Self::resolve_stmt_where_params(&query.select, params)?.map(|select| {
+                crate::velesql::Query {
+                    select,
+                    ..query.clone()
+                }
+            }),
+        )
+    }
+
     /// Extracts all query components from the SELECT statement's WHERE clause.
     pub(super) fn extract_query_components(
         &self,

--- a/crates/velesdb-core/src/collection/search/query/select_dispatch.rs
+++ b/crates/velesdb-core/src/collection/search/query/select_dispatch.rs
@@ -10,7 +10,7 @@ use crate::collection::types::Collection;
 use crate::error::Result;
 use crate::point::SearchResult;
 
-use super::{distinct, pushdown, ExtractedComponents};
+use super::{distinct, pushdown, ExtractedComponents, MAX_LIMIT};
 
 impl Collection {
     /// Computes the CBO execution strategy and over-fetch factor for the query.
@@ -188,10 +188,19 @@ impl Collection {
                 .where_clause
                 .as_ref()
                 .is_some_and(Self::condition_contains_or);
-        let execution_limit = if has_graph_predicates {
-            graph_overfetch_limit(limit)
-        } else {
-            limit
+        // The bounded over-fetch window only makes sense when the fetch is
+        // RANKED (vector NEAR or similarity() threshold): "rows ranked beyond
+        // the window" is a meaningful trade-off there. The metadata/scan
+        // paths fetch in storage order — capping them would silently drop
+        // graph matches depending on insertion order, so they keep the
+        // exhaustive MAX_LIMIT window (sparse queries never reach here; they
+        // are dispatched by `try_early_return_path`).
+        let has_ranked_fetch =
+            extracted.vector_search.is_some() || !extracted.similarity_conditions.is_empty();
+        let execution_limit = match (has_graph_predicates, has_ranked_fetch) {
+            (true, true) => graph_overfetch_limit(limit),
+            (true, false) => MAX_LIMIT,
+            (false, _) => limit,
         };
         let search_opts = super::QuerySearchOptions::from_with_clause(stmt.with_clause.as_ref())
             .with_fusion(stmt.fusion_clause.clone());
@@ -364,9 +373,10 @@ impl Collection {
     }
 }
 
-/// Bounded over-fetch for SELECTs carrying graph MATCH predicates.
+/// Bounded over-fetch for SELECTs combining graph MATCH predicates with a
+/// RANKED fetch (`vector NEAR` or a `similarity()` threshold).
 ///
-/// Graph predicates are evaluated AFTER the vector/metadata fetch
+/// Graph predicates are evaluated AFTER the vector fetch
 /// (`apply_where_condition_to_results`), so the fetch over-samples to leave
 /// the graph filter enough surviving candidates. The previous blanket
 /// `MAX_LIMIT` (100k) hydrated up to 100k points per query and drove the
@@ -375,6 +385,11 @@ impl Collection {
 /// candidates (never below the user limit). Trade-off: graph-matching rows
 /// ranked beyond the over-fetch window are not surfaced; exhaustive
 /// retrieval should pre-filter by graph anchor ids instead.
+///
+/// Unranked metadata/scan fetches must NOT use this bound: they iterate in
+/// storage order, so a capped window would silently drop graph matches based
+/// on insertion order (those paths keep `MAX_LIMIT`, the pre-existing
+/// behavior).
 fn graph_overfetch_limit(limit: usize) -> usize {
     const GRAPH_OVERFETCH_CAP: usize = 10_000;
     limit.max(limit.saturating_mul(10).min(GRAPH_OVERFETCH_CAP))

--- a/crates/velesdb-core/src/collection/search/query/select_dispatch.rs
+++ b/crates/velesdb-core/src/collection/search/query/select_dispatch.rs
@@ -10,7 +10,7 @@ use crate::collection::types::Collection;
 use crate::error::Result;
 use crate::point::SearchResult;
 
-use super::{distinct, pushdown, ExtractedComponents, MAX_LIMIT};
+use super::{distinct, pushdown, ExtractedComponents};
 
 impl Collection {
     /// Computes the CBO execution strategy and over-fetch factor for the query.
@@ -189,7 +189,7 @@ impl Collection {
                 .as_ref()
                 .is_some_and(Self::condition_contains_or);
         let execution_limit = if has_graph_predicates {
-            MAX_LIMIT
+            graph_overfetch_limit(limit)
         } else {
             limit
         };
@@ -362,6 +362,22 @@ impl Collection {
             _ => None,
         }
     }
+}
+
+/// Bounded over-fetch for SELECTs carrying graph MATCH predicates.
+///
+/// Graph predicates are evaluated AFTER the vector/metadata fetch
+/// (`apply_where_condition_to_results`), so the fetch over-samples to leave
+/// the graph filter enough surviving candidates. The previous blanket
+/// `MAX_LIMIT` (100k) hydrated up to 100k points per query and drove the
+/// downstream oversampling clamp into a `min > max` panic for filtered
+/// vector searches. Bound it to 10x the requested limit, capped at 10_000
+/// candidates (never below the user limit). Trade-off: graph-matching rows
+/// ranked beyond the over-fetch window are not surfaced; exhaustive
+/// retrieval should pre-filter by graph anchor ids instead.
+fn graph_overfetch_limit(limit: usize) -> usize {
+    const GRAPH_OVERFETCH_CAP: usize = 10_000;
+    limit.max(limit.saturating_mul(10).min(GRAPH_OVERFETCH_CAP))
 }
 
 /// Injects evaluated LET binding values into each result's payload.

--- a/crates/velesdb-core/src/collection/search/vector_filter.rs
+++ b/crates/velesdb-core/src/collection/search/vector_filter.rs
@@ -4,7 +4,7 @@
 
 // Reason: Numeric casts in selectivity estimation are intentional:
 // - usize->f64 for selectivity ratios: values are small counts
-// - f64->usize for clamped oversampled k: result is bounded to [k+10, 10_000]
+// - f64->usize for clamped oversampled k: result is bounded to [min(k+10, 10_000), 10_000]
 #![allow(clippy::cast_precision_loss)]
 #![allow(clippy::cast_possible_truncation)]
 #![allow(clippy::cast_sign_loss)]
@@ -159,7 +159,16 @@ fn resolve_quality(
     })
 }
 
+/// Hard upper bound on the oversampled HNSW candidate budget.
+const OVERSAMPLE_CAP: f64 = 10_000.0;
+
 /// Computes the oversampled candidate count for filtered search.
+///
+/// The result is bounded to `[min(k + 10, 10_000), 10_000]`: the candidate
+/// budget saturates at the cap for any `k >= 9_990`, so callers requesting
+/// huge `k` (e.g. LIMIT close to `MAX_LIMIT`) get at most 10_000 candidates
+/// instead of panicking — `f64::clamp` asserts `min <= max`, and an
+/// unbounded lower bound of `k + 10` used to violate that for large `k`.
 pub(super) fn compute_oversampled_k(k: usize, filter: &crate::filter::Filter) -> usize {
     // Clamp to a tiny positive value so that a zero-selectivity filter (e.g. empty
     // IN clause) never produces NaN (0.0/0.0 when k=0) or Inf (k>0/0.0). Both would
@@ -169,9 +178,9 @@ pub(super) fn compute_oversampled_k(k: usize, filter: &crate::filter::Filter) ->
     #[allow(clippy::cast_precision_loss)]
     let k_f64 = k as f64;
     #[allow(clippy::cast_precision_loss)]
-    let lower = (k + 10) as f64;
+    let lower = ((k.saturating_add(10)) as f64).min(OVERSAMPLE_CAP);
     #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
-    let clamped = (k_f64 / selectivity).ceil().clamp(lower, 10_000.0) as usize;
+    let clamped = (k_f64 / selectivity).ceil().clamp(lower, OVERSAMPLE_CAP) as usize;
     clamped
 }
 

--- a/crates/velesdb-core/src/collection/search/vector_filter_tests.rs
+++ b/crates/velesdb-core/src/collection/search/vector_filter_tests.rs
@@ -1,0 +1,38 @@
+//! Unit tests for `vector_filter` oversampling computation.
+
+use super::vector_filter::compute_oversampled_k;
+use crate::filter::{Condition, Filter};
+
+fn eq_filter() -> Filter {
+    Filter::new(Condition::Eq {
+        field: "category".to_string(),
+        value: serde_json::json!("science"),
+    })
+}
+
+/// Regression: with `k >= 10_000` the lower bound `(k + 10)` used to exceed
+/// the `10_000` upper cap and `f64::clamp` panicked with `min > max`.
+/// The candidate budget must instead saturate at the cap.
+#[test]
+fn test_compute_oversampled_k_never_panics_at_max_limit() {
+    let k = 100_000;
+    let candidates = compute_oversampled_k(k, &eq_filter());
+    assert_eq!(candidates, 10_000, "budget saturates at the 10_000 cap");
+}
+
+/// Exact boundary: at k = 9_990 the lower bound (k + 10) equals the cap.
+#[test]
+fn test_compute_oversampled_k_boundary_at_cap() {
+    assert_eq!(compute_oversampled_k(9_990, &eq_filter()), 10_000);
+    assert_eq!(compute_oversampled_k(10_000, &eq_filter()), 10_000);
+}
+
+/// Nominal: small k keeps the selectivity-driven oversampling
+/// (`k / 0.1` for an Eq filter), bounded below by `k + 10`.
+#[test]
+fn test_compute_oversampled_k_small_k_unchanged() {
+    // selectivity(Eq) = 0.1 -> 100 / 0.1 = 1000.
+    assert_eq!(compute_oversampled_k(100, &eq_filter()), 1_000);
+    // 5 / 0.1 = 50, above the lower bound (15).
+    assert_eq!(compute_oversampled_k(5, &eq_filter()), 50);
+}

--- a/crates/velesdb-core/src/column_store/mod.rs
+++ b/crates/velesdb-core/src/column_store/mod.rs
@@ -5,7 +5,11 @@
 //!
 //! # Performance Goals
 //!
-//! - Maintain 50M+ items/sec throughput at 100k items (vs 19M/s with JSON)
+//! - Maintain 50M+ items/sec filter throughput at 100k items (vs 19M/s with
+//!   JSON) — measured by the `column_filter_benchmark` micro-benchmark of
+//!   this module's filtering API; the `SELECT ... WHERE` query path does not
+//!   currently invoke these typed filters (it uses secondary indexes + JSON
+//!   payload filters; the `ColumnStore` backs JOIN execution)
 //! - Cache-friendly sequential memory access
 //! - Support for common filter operations: Eq, Gt, Lt, In, Range
 //!

--- a/crates/velesdb-core/src/column_store/primary_key_ops.rs
+++ b/crates/velesdb-core/src/column_store/primary_key_ops.rs
@@ -12,10 +12,15 @@ use super::ColumnStore;
 impl ColumnStore {
     /// Inserts a row with primary key validation and index update.
     ///
+    /// Type checking is **not** enforced on the fresh-insert path: a value
+    /// that does not match the target column type is silently stored as
+    /// NULL (`push_typed` fallback). Use `set_column_value` for validated
+    /// writes.
+    ///
     /// # Errors
     ///
-    /// Returns an error if the primary key is missing, duplicated, or any
-    /// provided value does not match the target column type.
+    /// Returns an error if the primary key is missing or duplicated (when a
+    /// duplicate row is live), or if `GeoPoint` coordinates are out of range.
     pub fn insert_row(
         &mut self,
         values: &[(&str, ColumnValue)],

--- a/crates/velesdb-core/src/column_store/vacuum.rs
+++ b/crates/velesdb-core/src/column_store/vacuum.rs
@@ -54,7 +54,9 @@ impl ColumnStore {
     ///
     /// # Arguments
     ///
-    /// * `_config` - Vacuum configuration (batch_size, sync options)
+    /// * `_config` - Vacuum configuration. **Currently ignored**: the vacuum
+    ///   runs as a single in-memory pass (`batch_size`, `sync`, and
+    ///   `yield_interval_ms` have no effect).
     ///
     /// # Returns
     ///

--- a/crates/velesdb-core/src/database/database_helpers.rs
+++ b/crates/velesdb-core/src/database/database_helpers.rs
@@ -60,6 +60,7 @@ impl Database {
 
     pub(super) fn build_update_filter(
         where_clause: Option<&crate::velesql::Condition>,
+        params: &std::collections::HashMap<String, serde_json::Value>,
     ) -> Result<Option<crate::Filter>> {
         let Some(condition) = where_clause else {
             return Ok(None);
@@ -72,7 +73,10 @@ impl Database {
             ));
         }
 
-        let filter_condition = crate::collection::Collection::extract_metadata_filter(condition)
+        // Resolve parameter placeholders before the filter conversion, which
+        // would otherwise silently turn them into NULL (matching no rows).
+        let resolved = crate::collection::Collection::resolve_condition_params(condition, params)?;
+        let filter_condition = crate::collection::Collection::extract_metadata_filter(&resolved)
             .ok_or_else(|| {
                 Error::Query("UPDATE WHERE produced empty metadata filter".to_string())
             })?;

--- a/crates/velesdb-core/src/database/query_engine.rs
+++ b/crates/velesdb-core/src/database/query_engine.rs
@@ -463,15 +463,8 @@ impl Database {
             return base_collection.execute_query(&single_query, params);
         }
 
-        let analysis = Self::analyze_join_pushdown_for_select(&query.select);
-
+        let analysis = Self::prepare_join_pushdown(&mut single_query, params)?;
         let pushed = analysis.column_store_filters.clone();
-
-        single_query.select.joins.clear();
-        if !pushed.is_empty() {
-            single_query.select.where_clause =
-                Self::strip_pushed_conditions(query.select.where_clause.as_ref(), &pushed);
-        }
 
         let row_budget = Self::join_row_budget(&query.select, &analysis);
 
@@ -493,6 +486,35 @@ impl Database {
         }
 
         Ok(results)
+    }
+
+    /// Resolves WHERE parameters, runs pushdown analysis, and strips pushed
+    /// conditions from the base query (JOIN path of `execute_single_select`).
+    ///
+    /// Parameter placeholders are resolved before the analysis so pushed-down
+    /// filters never silently convert them to NULL at the `ColumnStore` layer
+    /// (the collection pipeline resolves its own copy independently).
+    fn prepare_join_pushdown(
+        single_query: &mut crate::velesql::Query,
+        params: &std::collections::HashMap<String, serde_json::Value>,
+    ) -> Result<crate::collection::search::query::pushdown::PushdownAnalysis> {
+        if let Some(cond) = single_query.select.where_clause.take() {
+            single_query.select.where_clause = Some(
+                crate::collection::Collection::resolve_condition_params(&cond, params)?,
+            );
+        }
+
+        let analysis = Self::analyze_join_pushdown_for_select(&single_query.select);
+
+        let resolved_where = single_query.select.where_clause.clone();
+        single_query.select.joins.clear();
+        if !analysis.column_store_filters.is_empty() {
+            single_query.select.where_clause = Self::strip_pushed_conditions(
+                resolved_where.as_ref(),
+                &analysis.column_store_filters,
+            );
+        }
+        Ok(analysis)
     }
 
     /// Computes the bound on joined rows to materialize.

--- a/crates/velesdb-core/src/database/query_engine_dml.rs
+++ b/crates/velesdb-core/src/database/query_engine_dml.rs
@@ -106,7 +106,7 @@ impl Database {
         let collection = self.resolve_writable_collection(&stmt.table)?;
 
         let assignments = Self::resolve_update_assignments(stmt, params)?;
-        let filter = Self::build_update_filter(stmt.where_clause.as_ref())?;
+        let filter = Self::build_update_filter(stmt.where_clause.as_ref(), params)?;
 
         let all_ids = collection.all_ids();
         let rows = collection.get(&all_ids);

--- a/crates/velesdb-core/src/distance.rs
+++ b/crates/velesdb-core/src/distance.rs
@@ -7,7 +7,9 @@
 //! - **Cosine**: Direct AVX-512/AVX2/NEON intrinsics
 //! - **Euclidean**: Direct native intrinsics with 4-acc unrolling
 //! - **Dot Product**: Direct FMA-optimized intrinsics
-//! - **Hamming (binary)**: POPCNT on packed u64 (48x faster than f32)
+//! - **Hamming (binary)**: `DistanceMetric::calculate` uses the f32 variant
+//!   (0.5 threshold per component); the POPCNT-on-packed-u64 fast path
+//!   (~48x faster) is a separate API consumed by the RaBitQ pipeline
 //! - **Jaccard**: Set similarity with SIMD acceleration
 
 use crate::simd_native;

--- a/crates/velesdb-core/src/distance.rs
+++ b/crates/velesdb-core/src/distance.rs
@@ -9,7 +9,7 @@
 //! - **Dot Product**: Direct FMA-optimized intrinsics
 //! - **Hamming (binary)**: `DistanceMetric::calculate` uses the f32 variant
 //!   (0.5 threshold per component); the POPCNT-on-packed-u64 fast path
-//!   (~48x faster) is a separate API consumed by the RaBitQ pipeline
+//!   (~48x faster) is a separate API consumed by the `RaBitQ` pipeline
 //! - **Jaccard**: Set similarity with SIMD acceleration
 
 use crate::simd_native;

--- a/crates/velesdb-core/src/distance.rs
+++ b/crates/velesdb-core/src/distance.rs
@@ -121,6 +121,9 @@ impl DistanceMetric {
     /// - **Similarity metrics** (`Cosine`, `DotProduct`, `Jaccard`): sorts descending (higher = better)
     /// - **Distance metrics** (`Euclidean`, `Hamming`): sorts ascending (lower = better)
     ///
+    /// Generic over the id type so both external ids (`u64`) and internal
+    /// HNSW node ids (`usize`) can be sorted with the same metric semantics.
+    ///
     /// # Example
     ///
     /// ```rust,ignore
@@ -128,7 +131,7 @@ impl DistanceMetric {
     /// DistanceMetric::Cosine.sort_results(&mut results);
     /// assert_eq!(results[0].0, 1); // Highest similarity first
     /// ```
-    pub fn sort_results(&self, results: &mut [(u64, f32)]) {
+    pub fn sort_results<Id>(&self, results: &mut [(Id, f32)]) {
         if self.higher_is_better() {
             // Similarity metrics: descending order (higher = better)
             results.sort_unstable_by(|a, b| b.1.total_cmp(&a.1));

--- a/crates/velesdb-core/src/index/hnsw/native/dual_precision.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/dual_precision.rs
@@ -274,7 +274,9 @@ impl<D: DistanceEngine> DualPrecisionHnsw<D> {
     /// `self.inner.compute_distance()` returns the raw engine distance, which
     /// may be squared L2 for Euclidean when `D = CachedSimdDistance`. We apply
     /// `transform_score()` to convert to the user-visible metric (e.g. sqrt
-    /// for Euclidean, similarity clamping for Cosine).
+    /// for Euclidean, similarity clamping for Cosine). Transformed scores are
+    /// metric-dependent (higher = better for Cosine/DotProduct), so the final
+    /// sort MUST use the metric's ordering, not a plain ascending sort.
     pub(super) fn rerank_with_exact_f32(
         &self,
         query: &[f32],
@@ -296,7 +298,7 @@ impl<D: DistanceEngine> DualPrecisionHnsw<D> {
             Vec::new()
         };
 
-        reranked.sort_unstable_by(|a, b| a.1.total_cmp(&b.1));
+        self.inner.distance.metric().sort_results(&mut reranked);
         reranked.truncate(k);
         reranked
     }

--- a/crates/velesdb-core/src/index/hnsw/native/dual_precision_tests.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/dual_precision_tests.rs
@@ -397,6 +397,163 @@ fn test_rerank_euclidean_returns_sqrt_not_squared_with_cached_engine() {
     );
 }
 
+// =========================================================================
+// Regression: rerank must sort by METRIC semantics, not ascending raw value.
+// After transform_score, Cosine/DotProduct are similarities (higher =
+// better); an ascending sort + truncate(k) keeps the k WORST candidates.
+// =========================================================================
+
+/// Deterministic pseudo-random unit vector (LCG-seeded).
+///
+/// Unit norm keeps Cosine and DotProduct orderings identical and ensures
+/// the self-query is the unique maximum-similarity result.
+pub(super) fn unit_vector(seed: u64, dim: usize) -> Vec<f32> {
+    let mut state = seed.wrapping_mul(0x9E37_79B9_7F4A_7C15).wrapping_add(1);
+    let mut v: Vec<f32> = (0..dim)
+        .map(|_| {
+            state = state
+                .wrapping_mul(6_364_136_223_846_793_005)
+                .wrapping_add(1_442_695_040_888_963_407);
+            ((state >> 40) as f32 / 8_388_608.0) - 1.0
+        })
+        .collect();
+    let norm = v.iter().map(|x| x * x).sum::<f32>().sqrt();
+    for x in &mut v {
+        *x /= norm;
+    }
+    v
+}
+
+/// Generates `n` random unit vectors with 10 planted neighbors of
+/// `query_id` in the last 10 slots.
+///
+/// The planted neighbors (similarity ~0.91..0.995) are well separated from
+/// the near-orthogonal random background, so the brute-force top-10 is
+/// unambiguous and within reach of coarse quantized traversal.
+pub(super) fn planted_unit_vectors(n: usize, dim: usize, query_id: usize) -> Vec<Vec<f32>> {
+    debug_assert!(query_id < n - 10, "query must not overlap planted slots");
+    let mut vectors: Vec<Vec<f32>> = (0..n).map(|i| unit_vector(i as u64 + 1, dim)).collect();
+    for slot in 0..10 {
+        let noise = unit_vector(1_000 + slot as u64, dim);
+        let eps = 0.1 + 0.04 * slot as f32;
+        let mut v: Vec<f32> = vectors[query_id]
+            .iter()
+            .zip(noise.iter())
+            .map(|(a, b)| a + eps * b)
+            .collect();
+        let norm = v.iter().map(|x| x * x).sum::<f32>().sqrt();
+        for x in &mut v {
+            *x /= norm;
+        }
+        vectors[n - 10 + slot] = v;
+    }
+    vectors
+}
+
+/// Brute-force top-k ids by exact metric similarity/distance.
+///
+/// Sorts independently of production code (explicit branch on
+/// `higher_is_better`) so the assertion is not self-referential.
+pub(super) fn brute_force_top_ids(
+    vectors: &[Vec<f32>],
+    query: &[f32],
+    metric: DistanceMetric,
+    k: usize,
+) -> Vec<usize> {
+    let mut scored: Vec<(usize, f32)> = vectors
+        .iter()
+        .enumerate()
+        .map(|(i, v)| (i, metric.calculate(query, v)))
+        .collect();
+    if metric.higher_is_better() {
+        scored.sort_unstable_by(|a, b| b.1.total_cmp(&a.1));
+    } else {
+        scored.sort_unstable_by(|a, b| a.1.total_cmp(&b.1));
+    }
+    scored.truncate(k);
+    scored.into_iter().map(|(i, _)| i).collect()
+}
+
+/// Asserts the self-query ranks first with maximal similarity and that
+/// recall@k vs brute-force is >= 0.95.
+pub(super) fn assert_top1_and_recall(
+    results: &[(usize, f32)],
+    vectors: &[Vec<f32>],
+    query_id: usize,
+    metric: DistanceMetric,
+    k: usize,
+) {
+    assert!(!results.is_empty(), "search returned no results");
+    assert_eq!(
+        results[0].0, query_id,
+        "self-query must rank first for {metric:?}, got node {} (score {})",
+        results[0].0, results[0].1
+    );
+    assert!(
+        results[0].1 > 0.99,
+        "self-similarity must be maximal for {metric:?}, got {}",
+        results[0].1
+    );
+
+    let expected = brute_force_top_ids(vectors, &vectors[query_id], metric, k);
+    let got: std::collections::HashSet<usize> = results.iter().map(|(id, _)| *id).collect();
+    let overlap = expected.iter().filter(|id| got.contains(id)).count();
+    let recall = overlap as f64 / k as f64;
+    assert!(
+        recall >= 0.95,
+        "recall@{k} vs brute-force must be >= 0.95 for {metric:?}, got {recall:.2}"
+    );
+}
+
+/// Builds a trained SQ8 index over `n` unit vectors and searches with the
+/// self-query, via `search()` (f32 traversal) or `search_with_config()`
+/// (int8 traversal).
+fn run_dual_precision_self_query(metric: DistanceMetric, use_int8_traversal: bool) {
+    let (dim, n, k) = (32, 100, 10);
+    let query_id = 42_usize;
+    let engine = CachedSimdDistance::new(metric, dim);
+    let mut hnsw = DualPrecisionHnsw::new(engine, dim, 16, 200, 1000).expect("test");
+
+    let vectors = planted_unit_vectors(n, dim, query_id);
+    for v in &vectors {
+        hnsw.insert(v).expect("test");
+    }
+    hnsw.force_train_quantizer();
+    assert!(hnsw.is_quantizer_trained());
+
+    let results = if use_int8_traversal {
+        let config = DualPrecisionConfig {
+            min_index_size: 0,
+            ..Default::default()
+        };
+        hnsw.search_with_config(&vectors[query_id], k, 100, &config)
+    } else {
+        hnsw.search(&vectors[query_id], k, 100)
+    };
+
+    assert_top1_and_recall(&results, &vectors, query_id, metric, k);
+}
+
+#[test]
+fn test_dual_precision_cosine_rerank_keeps_best_candidates() {
+    run_dual_precision_self_query(DistanceMetric::Cosine, false);
+}
+
+#[test]
+fn test_dual_precision_dot_product_rerank_keeps_best_candidates() {
+    run_dual_precision_self_query(DistanceMetric::DotProduct, false);
+}
+
+#[test]
+fn test_int8_traversal_cosine_rerank_keeps_best_candidates() {
+    run_dual_precision_self_query(DistanceMetric::Cosine, true);
+}
+
+#[test]
+fn test_int8_traversal_dot_product_rerank_keeps_best_candidates() {
+    run_dual_precision_self_query(DistanceMetric::DotProduct, true);
+}
+
 /// Same regression test for Cosine metric — verifies transform_score clamps
 /// cosine similarity correctly through the dual-precision rerank path.
 #[test]

--- a/crates/velesdb-core/src/index/hnsw/native/rabitq_precision.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/rabitq_precision.rs
@@ -339,6 +339,8 @@ impl<D: DistanceEngine> RaBitQPrecisionHnsw<D> {
     /// Re-ranks candidate node IDs using exact f32 distances.
     ///
     /// RF-DEDUP: Mirrors `DualPrecisionHnsw::rerank_with_exact_f32`.
+    /// Transformed scores are metric-dependent (higher = better for
+    /// Cosine/DotProduct), so the final sort uses the metric's ordering.
     fn rerank_with_exact_f32(
         &self,
         query: &[f32],
@@ -360,7 +362,7 @@ impl<D: DistanceEngine> RaBitQPrecisionHnsw<D> {
             Vec::new()
         };
 
-        reranked.sort_unstable_by(|a, b| a.1.total_cmp(&b.1));
+        self.inner.distance.metric().sort_results(&mut reranked);
         reranked.truncate(k);
         reranked
     }

--- a/crates/velesdb-core/src/index/hnsw/native/rabitq_precision_tests.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/rabitq_precision_tests.rs
@@ -217,6 +217,47 @@ fn test_rabitq_precision_recall_above_threshold() {
 }
 
 // =========================================================================
+// Regression: rerank must sort by METRIC semantics, not ascending raw value.
+// After transform_score, Cosine/DotProduct are similarities (higher =
+// better); an ascending sort + truncate(k) keeps the k WORST candidates.
+// =========================================================================
+
+/// Builds a trained `RaBitQ` index over `n` unit vectors and searches with
+/// the self-query, asserting top-1 identity and recall@k >= 0.95.
+///
+/// Uses 64 dims (vs 32 for SQ8 tests): `RaBitQ` allocates 1 bit per dim,
+/// and 32-bit codes are too coarse to rank near-orthogonal random vectors.
+fn run_rabitq_self_query(metric: DistanceMetric) {
+    use super::dual_precision_tests::{assert_top1_and_recall, planted_unit_vectors};
+
+    let (dim, n, k) = (64, 100, 10);
+    let query_id = 42_usize;
+    let engine = CachedSimdDistance::new(metric, dim);
+    let hnsw = RaBitQPrecisionHnsw::new(engine, dim, 16, 200, 1000).expect("test");
+
+    let vectors = planted_unit_vectors(n, dim, query_id);
+    for v in &vectors {
+        hnsw.insert(v).expect("test");
+    }
+    hnsw.force_train_quantizer().expect("test");
+    assert!(hnsw.is_quantizer_trained());
+
+    let results = hnsw.search(&vectors[query_id], k, 100);
+
+    assert_top1_and_recall(&results, &vectors, query_id, metric, k);
+}
+
+#[test]
+fn test_rabitq_cosine_rerank_keeps_best_candidates() {
+    run_rabitq_self_query(DistanceMetric::Cosine);
+}
+
+#[test]
+fn test_rabitq_dot_product_rerank_keeps_best_candidates() {
+    run_rabitq_self_query(DistanceMetric::DotProduct);
+}
+
+// =========================================================================
 // Regression: transform_score applied
 // =========================================================================
 

--- a/crates/velesdb-core/src/index/hnsw/params.rs
+++ b/crates/velesdb-core/src/index/hnsw/params.rs
@@ -35,7 +35,12 @@ pub struct HnswParams {
     /// Initial capacity (grows automatically if exceeded).
     pub max_elements: usize,
     /// Vector storage mode (Full, SQ8, or Binary).
-    /// SQ8 provides 4x memory reduction with ~1% recall loss.
+    ///
+    /// Note: the collection path currently forces `Full` storage and keeps
+    /// quantized SQ8/Binary representations as an **additional** cache that
+    /// no production search path reads — selecting SQ8 there adds memory
+    /// rather than reducing it. The 4x-reduction figure applies only to a
+    /// backend that stores quantized vectors *instead of* f32.
     #[serde(default)]
     pub storage_mode: StorageMode,
     /// VAMANA alpha for neighbor diversification (default: 1.2).

--- a/crates/velesdb-core/src/storage/compaction.rs
+++ b/crates/velesdb-core/src/storage/compaction.rs
@@ -205,6 +205,53 @@ fn punch_hole_fallback(file: &File, offset: u64, len: u64) -> io::Result<bool> {
     Ok(false) // No disk space reclaimed, only zeroed
 }
 
+/// Serializes a flat `id -> offset` index to `path` with fsync.
+///
+/// Used by `MmapStorage::persist_index_file` for `vectors.idx` and by the
+/// compaction commit protocol to stage the `vectors.idx.tmp` sidecar BEFORE
+/// the data-file swap, so that startup recovery can finish the commit if a
+/// crash lands between the swap and the index promotion (see
+/// [`recover_compaction_artifacts`]).
+pub(super) fn persist_flat_index(path: &Path, index: &FxHashMap<u64, usize>) -> io::Result<()> {
+    let bytes = postcard::to_allocvec(index).map_err(io::Error::other)?;
+    let mut writer = io::BufWriter::new(File::create(path)?);
+    writer.write_all(&bytes)?;
+    writer.flush()?;
+    writer
+        .into_inner()
+        .map_err(std::io::IntoInnerError::into_error)?
+        .sync_all()
+}
+
+/// Promotes the staged index sidecar over `vectors.idx`.
+///
+/// On Unix, `rename` atomically replaces the destination. On other platforms
+/// the destination is removed first; a crash in between leaves the sidecar in
+/// place, which startup recovery promotes (the data swap already committed).
+fn promote_index_sidecar(sidecar: &Path, idx_path: &Path) -> io::Result<()> {
+    #[cfg(not(unix))]
+    if idx_path.exists() {
+        std::fs::remove_file(idx_path)?;
+    }
+    std::fs::rename(sidecar, idx_path)
+}
+
+/// Fsyncs the storage directory so preceding renames are durable (POSIX).
+///
+/// Without this, a power loss could persist the WAL truncation that follows
+/// the compaction commit while rolling back the renames themselves.
+fn sync_dir(dir: &Path) -> io::Result<()> {
+    #[cfg(unix)]
+    {
+        File::open(dir)?.sync_all()
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = dir;
+        Ok(())
+    }
+}
+
 /// Recovers from interrupted compaction on startup.
 ///
 /// Issue #318: On Windows, `atomic_replace()` uses a two-step rename
@@ -216,10 +263,12 @@ fn punch_hole_fallback(file: &File, offset: u64, len: u64) -> io::Result<bool> {
 ///
 /// - `.bak` exists, original missing -> restore from `.bak`
 /// - `.bak` exists, original exists -> remove `.bak` (compaction completed)
-/// - `.new` exists -> remove it (incomplete compaction)
+/// - `vectors.dat.tmp` exists -> the swap (commit point) never happened:
+///   remove it and the staged `vectors.idx.tmp`; the old state is intact
+/// - only `vectors.idx.tmp` exists -> the swap committed but the crash hit
+///   before the index promotion: promote the sidecar to `vectors.idx`
 pub fn recover_compaction_artifacts(data_path: &Path) -> io::Result<()> {
     let bak_path = data_path.with_extension("dat.bak");
-    let new_path = data_path.with_extension("dat.tmp");
 
     // Handle .bak file
     if bak_path.exists() {
@@ -232,9 +281,30 @@ pub fn recover_compaction_artifacts(data_path: &Path) -> io::Result<()> {
         }
     }
 
-    // Handle incomplete .tmp file (new data that was never swapped in)
+    recover_staged_compaction(data_path)
+}
+
+/// Repairs staged compaction files (`vectors.dat.tmp` / `vectors.idx.tmp`).
+fn recover_staged_compaction(data_path: &Path) -> io::Result<()> {
+    let new_path = data_path.with_extension("dat.tmp");
+    let idx_tmp_path = data_path.with_file_name("vectors.idx.tmp");
+
     if new_path.exists() {
+        // Uncommitted compaction: the data swap never happened, so the old
+        // dat/idx/WAL triple is authoritative. Drop both staged files.
         std::fs::remove_file(&new_path)?;
+        if idx_tmp_path.exists() {
+            std::fs::remove_file(&idx_tmp_path)?;
+        }
+    } else if idx_tmp_path.exists() {
+        // The swap committed (vectors.dat.tmp was consumed by the rename) but
+        // the crash hit before the index promotion. Finish the commit so the
+        // on-disk index matches the compacted layout. The stale WAL is left
+        // alone on purpose: replaying it onto the promoted index converges
+        // (store records carry the full vector value, deletes replay in
+        // order), and the normal replay flow truncates it once the recovered
+        // state is durable.
+        promote_index_sidecar(&idx_tmp_path, &data_path.with_file_name("vectors.idx"))?;
     }
 
     Ok(())
@@ -395,33 +465,31 @@ impl CompactionContext<'_> {
 
         drop(mmap);
 
-        // 4. Flush temp file
+        // 4. Make the temp file durable (data via msync, metadata via fsync)
         temp_mmap.flush()?;
         drop(temp_mmap);
+        temp_file.sync_all()?;
         drop(temp_file);
 
-        // 5. Atomic swap: rename temp -> main (cross-platform)
-        let data_path = self.path.join("vectors.dat");
-        atomic_replace(&temp_path, &data_path)?;
+        // 5. Stage the new index sidecar (vectors.idx.tmp, fsynced) BEFORE the
+        // swap, so a crash between the swap and the promotion in step 6 is
+        // repaired by `recover_compaction_artifacts` at the next startup.
+        let idx_tmp_path = self.path.join("vectors.idx.tmp");
+        persist_flat_index(&idx_tmp_path, &new_index)?;
 
-        // 6. Reopen the compacted file
+        // 6. Commit: swap the data file in, promote the staged index, then
+        // truncate the now-obsolete WAL (see `commit_compaction` for the
+        // crash-safety invariant).
+        let data_path = self.path.join("vectors.dat");
+        self.commit_compaction(&temp_path, &idx_tmp_path, &data_path)?;
+
+        // 7. Reopen the compacted file
         let new_data_file = OpenOptions::new().read(true).write(true).open(&data_path)?;
         // SAFETY: `MmapMut::map_mut` requires a writable file sized for mapping.
         // - Condition 1: `new_data_file` is opened read/write after atomic replace.
         // - Condition 2: File contents are fully materialized by the preceding flush/rename flow.
         // SAFETY: Reloading mmap is required to switch storage to compacted bytes.
         let new_mmap = unsafe { MmapMut::map_mut(&new_data_file)? };
-
-        // 7. Write compaction marker to WAL
-        // Crash safety: write WAL compaction marker BEFORE updating in-memory state.
-        // The compacted data file is already atomically in place (step 5). If a crash
-        // occurs after WAL write but before state update, recovery re-derives the
-        // in-memory index from the compacted file.
-        {
-            let mut wal = self.wal.write();
-            wal.write_all(&[4u8])?;
-            wal.flush()?;
-        }
 
         // 8. Update internal state
         // Issue #316: Atomic index swap — replace mmap and index without
@@ -435,6 +503,52 @@ impl CompactionContext<'_> {
         self.next_offset.store(new_offset, Ordering::Release);
 
         Ok(bytes_to_reclaim)
+    }
+
+    /// Commits a built compacted file: atomic data swap, index promotion and
+    /// WAL truncation, all under the WAL lock so no writer can append an
+    /// entry between the swap and the truncation.
+    ///
+    /// # Crash-safety invariant
+    ///
+    /// The rename of `vectors.dat.tmp` -> `vectors.dat` is the single commit
+    /// point. The compacted file plus the staged index fully capture every
+    /// acknowledged write (stores update the mmap before compaction snapshots
+    /// it), so once the swap is durable the prior WAL is obsolete and is
+    /// truncated. Every intermediate crash point is recoverable:
+    /// - before the swap: startup recovery removes both staged files and the
+    ///   old dat/idx/WAL triple is untouched;
+    /// - after the swap, before promotion: recovery promotes the sidecar;
+    ///   replaying the stale WAL onto the promoted index converges because
+    ///   every store record carries the full vector value and deletes replay
+    ///   in order;
+    /// - after promotion, before truncation: same convergent replay.
+    fn commit_compaction(
+        &self,
+        temp_path: &Path,
+        idx_tmp_path: &Path,
+        data_path: &Path,
+    ) -> io::Result<()> {
+        let mut wal = self.wal.write();
+
+        // COMMIT POINT: atomic swap temp -> main (cross-platform).
+        atomic_replace(temp_path, data_path)?;
+
+        // Promote the staged index so vectors.idx matches the new layout.
+        promote_index_sidecar(idx_tmp_path, &self.path.join("vectors.idx"))?;
+
+        // Make both renames durable before the truncation below can hit disk:
+        // a power loss must never persist an empty WAL while rolling back the
+        // renames that committed the compaction.
+        sync_dir(self.path)?;
+
+        // Compaction renders the prior WAL obsolete: truncate it. flush()
+        // first so the BufWriter cannot later re-append buffered stale
+        // entries; the fd is in append mode, so subsequent writes start at
+        // the new EOF (offset 0).
+        wal.flush()?;
+        wal.get_ref().set_len(0)?;
+        wal.get_ref().sync_all()
     }
 
     /// Returns the fragmentation ratio (0.0 = no fragmentation, 1.0 = 100% fragmented).

--- a/crates/velesdb-core/src/storage/compaction.rs
+++ b/crates/velesdb-core/src/storage/compaction.rs
@@ -207,11 +207,13 @@ fn punch_hole_fallback(file: &File, offset: u64, len: u64) -> io::Result<bool> {
 
 /// Serializes a flat `id -> offset` index to `path` with fsync.
 ///
-/// Used by `MmapStorage::persist_index_file` for `vectors.idx` and by the
-/// compaction commit protocol to stage the `vectors.idx.tmp` sidecar BEFORE
-/// the data-file swap, so that startup recovery can finish the commit if a
-/// crash lands between the swap and the index promotion (see
-/// [`recover_compaction_artifacts`]).
+/// The write is in-place (`File::create` truncates first), so this must only
+/// target staging paths that are never load-bearing on their own: the
+/// `vectors.idx.tmp` sidecar staged BEFORE the data-file swap (covered by
+/// [`recover_compaction_artifacts`]) and the `vectors.idx.new` staging file
+/// of [`persist_flat_index_atomic`]. Live `vectors.idx` writes must go
+/// through [`persist_flat_index_atomic`] — a torn in-place rewrite of
+/// `vectors.idx` right after compaction truncated the WAL is unrecoverable.
 pub(super) fn persist_flat_index(path: &Path, index: &FxHashMap<u64, usize>) -> io::Result<()> {
     let bytes = postcard::to_allocvec(index).map_err(io::Error::other)?;
     let mut writer = io::BufWriter::new(File::create(path)?);
@@ -223,11 +225,39 @@ pub(super) fn persist_flat_index(path: &Path, index: &FxHashMap<u64, usize>) -> 
         .sync_all()
 }
 
-/// Promotes the staged index sidecar over `vectors.idx`.
+/// Atomically replaces `path` with a freshly serialized flat index.
+///
+/// Writes to a dedicated `<path>.new` staging file (distinct from the
+/// `vectors.idx.tmp` compaction sidecar, so startup recovery never promotes
+/// it), fsyncs it, renames it over `path`, then fsyncs the directory so the
+/// rename is durable (POSIX). A crash at any point leaves the previous
+/// `path` content intact and readable — unlike the former in-place
+/// `File::create` rewrite, whose truncate-then-write left a 0-byte/torn
+/// `vectors.idx` that bricked `open()` (fatal right after compaction
+/// emptied the WAL).
+pub(super) fn persist_flat_index_atomic(
+    path: &Path,
+    index: &FxHashMap<u64, usize>,
+) -> io::Result<()> {
+    let mut staging = path.as_os_str().to_owned();
+    staging.push(".new");
+    let staging = std::path::PathBuf::from(staging);
+
+    persist_flat_index(&staging, index)?;
+    promote_index_sidecar(&staging, path)?;
+    match path.parent() {
+        Some(dir) if !dir.as_os_str().is_empty() => sync_dir(dir),
+        _ => Ok(()),
+    }
+}
+
+/// Renames a fully written index file over `idx_path`.
 ///
 /// On Unix, `rename` atomically replaces the destination. On other platforms
-/// the destination is removed first; a crash in between leaves the sidecar in
-/// place, which startup recovery promotes (the data swap already committed).
+/// the destination is removed first; a crash in between leaves the source in
+/// place with the destination missing — startup then either promotes a
+/// `vectors.idx.tmp` sidecar (the compaction data swap already committed) or
+/// treats the absent `vectors.idx` as empty and rebuilds it from WAL replay.
 fn promote_index_sidecar(sidecar: &Path, idx_path: &Path) -> io::Result<()> {
     #[cfg(not(unix))]
     if idx_path.exists() {

--- a/crates/velesdb-core/src/storage/compaction_tests.rs
+++ b/crates/velesdb-core/src/storage/compaction_tests.rs
@@ -387,6 +387,173 @@ fn test_backup_file_cleaned_after_successful_compaction() {
     );
 }
 
+#[test]
+#[allow(clippy::cast_precision_loss)]
+fn test_compact_then_crash_preserves_post_compaction_writes() {
+    // Durability finding: compaction must render the prior WAL obsolete.
+    // Post-compaction fsync-acknowledged writes MUST survive a crash, and
+    // pre-compaction WAL entries MUST NOT roll back newer values.
+    let dir = tempdir().expect("tempdir");
+    let dim = 4;
+
+    {
+        let mut storage = storage_with_vectors(dir.path(), dim, &(1..=10).collect::<Vec<_>>());
+        for id in 6..=10u64 {
+            storage.delete(id).expect("delete");
+        }
+        storage.flush().expect("flush");
+
+        let reclaimed = storage.compact().expect("compact");
+        assert!(reclaimed > 0, "compaction should reclaim space");
+
+        // Post-compaction writes: store() under the default Fsync mode syncs
+        // the WAL record before returning, so both are acknowledged-durable.
+        storage.store(100, &[100.0; 4]).expect("store new id");
+        storage.store(1, &[111.0; 4]).expect("update existing id");
+
+        // Crash: drop without flush()/flush_index() — the WAL is the only
+        // durable record of the two writes above.
+    }
+
+    let storage = MmapStorage::new(dir.path(), dim).expect("reopen");
+    assert_eq!(
+        storage.retrieve(100).expect("retrieve"),
+        Some(vec![100.0; 4]),
+        "post-compaction insert must survive a crash (WAL replay)"
+    );
+    assert_eq!(
+        storage.retrieve(1).expect("retrieve"),
+        Some(vec![111.0; 4]),
+        "post-compaction update must not be rolled back by pre-compaction WAL entries"
+    );
+    // Pre-compaction deletes must not resurrect.
+    for id in 6..=10u64 {
+        assert!(
+            storage.retrieve(id).expect("retrieve").is_none(),
+            "pre-compaction deleted id {id} must stay deleted"
+        );
+    }
+}
+
+#[test]
+fn test_compact_truncates_wal() {
+    // Compaction renders the prior WAL obsolete: vectors.wal must be empty
+    // right after compact(), and fresh entries must append from offset 0.
+    let dir = tempdir().expect("tempdir");
+    let dim = 4;
+    let mut storage = storage_with_vectors(dir.path(), dim, &[1, 2, 3, 4]);
+    storage.delete(2).expect("delete");
+    storage.delete(4).expect("delete");
+
+    let wal_path = dir.path().join("vectors.wal");
+    assert!(
+        std::fs::metadata(&wal_path).expect("wal meta").len() > 0,
+        "WAL should contain pre-compaction entries"
+    );
+
+    let reclaimed = storage.compact().expect("compact");
+    assert!(reclaimed > 0);
+    assert_eq!(
+        std::fs::metadata(&wal_path).expect("wal meta").len(),
+        0,
+        "WAL must be truncated by compaction"
+    );
+    // No staged sidecar must linger after a successful commit.
+    assert!(!dir.path().join("vectors.idx.tmp").exists());
+
+    // A post-compaction store (Fsync mode) appends exactly one framed entry
+    // at the start of the truncated WAL: op(1)+id(8)+len(4)+data+crc(4).
+    storage.store(50, &[5.0; 4]).expect("store");
+    let entry_len = 17 + dim * std::mem::size_of::<f32>();
+    assert_eq!(
+        std::fs::metadata(&wal_path).expect("wal meta").len(),
+        u64::try_from(entry_len).expect("fits"),
+        "post-compaction entries must append from offset 0"
+    );
+}
+
+#[test]
+fn test_recover_promotes_staged_index_when_swap_committed() {
+    // Crash window: vectors.dat was swapped (commit point) but the crash hit
+    // before vectors.idx.tmp was promoted. Startup recovery must finish the
+    // commit so ids resolve against the compacted layout, not the stale index.
+    let dir = tempdir().expect("tempdir");
+    let dim = 4;
+    let vector_size = dim * std::mem::size_of::<f32>();
+
+    // Compacted data file: vectors for ids 1 and 3 packed at offsets 0 and 16.
+    let v1 = vec![1.0f32; dim];
+    let v3 = vec![3.0f32; dim];
+    let mut data = vec![0u8; 16 * 1024 * 1024];
+    data[..vector_size].copy_from_slice(crate::storage::vector_bytes::vector_to_bytes(&v1));
+    data[vector_size..2 * vector_size]
+        .copy_from_slice(crate::storage::vector_bytes::vector_to_bytes(&v3));
+    std::fs::write(dir.path().join("vectors.dat"), &data).expect("write dat");
+
+    // Stale pre-compaction index (id 2 still present, old offsets).
+    let mut stale: rustc_hash::FxHashMap<u64, usize> = rustc_hash::FxHashMap::default();
+    stale.insert(1, 0);
+    stale.insert(2, vector_size);
+    stale.insert(3, 2 * vector_size);
+    std::fs::write(
+        dir.path().join("vectors.idx"),
+        postcard::to_allocvec(&stale).expect("serialize"),
+    )
+    .expect("write idx");
+
+    // Staged compacted index awaiting promotion.
+    let mut staged: rustc_hash::FxHashMap<u64, usize> = rustc_hash::FxHashMap::default();
+    staged.insert(1, 0);
+    staged.insert(3, vector_size);
+    std::fs::write(
+        dir.path().join("vectors.idx.tmp"),
+        postcard::to_allocvec(&staged).expect("serialize"),
+    )
+    .expect("write idx.tmp");
+
+    let storage = MmapStorage::new(dir.path(), dim).expect("reopen recovers");
+    assert!(
+        !dir.path().join("vectors.idx.tmp").exists(),
+        "sidecar must be promoted, not left behind"
+    );
+    assert_eq!(storage.retrieve(1).expect("retrieve"), Some(v1));
+    assert_eq!(storage.retrieve(3).expect("retrieve"), Some(v3));
+    assert!(
+        storage.retrieve(2).expect("retrieve").is_none(),
+        "id deleted before compaction must not resurrect from the stale index"
+    );
+    assert_eq!(storage.len(), 2);
+}
+
+#[test]
+fn test_recover_discards_staged_files_when_swap_uncommitted() {
+    // Crash window: both staged files exist but vectors.dat.tmp was never
+    // renamed — the commit never happened. Recovery must drop both staged
+    // files and keep the old state authoritative.
+    let dir = tempdir().expect("tempdir");
+    let dim = 4;
+
+    {
+        let storage = storage_with_vectors(dir.path(), dim, &[1, 2]);
+        drop(storage);
+    }
+    // Reopen once so vectors.idx is persisted via WAL replay, then close.
+    drop(MmapStorage::new(dir.path(), dim).expect("reopen"));
+
+    std::fs::write(dir.path().join("vectors.dat.tmp"), b"half-built").expect("plant dat.tmp");
+    std::fs::write(dir.path().join("vectors.idx.tmp"), b"half-built").expect("plant idx.tmp");
+
+    let storage = MmapStorage::new(dir.path(), dim).expect("reopen");
+    assert!(!dir.path().join("vectors.dat.tmp").exists());
+    assert!(
+        !dir.path().join("vectors.idx.tmp").exists(),
+        "staged index of an uncommitted compaction must be discarded"
+    );
+    assert_eq!(storage.len(), 2);
+    assert!(storage.retrieve(1).expect("retrieve").is_some());
+    assert!(storage.retrieve(2).expect("retrieve").is_some());
+}
+
 // -------------------------------------------------------------------------
 // CompactionContext unit tests (direct construction)
 // -------------------------------------------------------------------------

--- a/crates/velesdb-core/src/storage/hnsw_delta_wal.rs
+++ b/crates/velesdb-core/src/storage/hnsw_delta_wal.rs
@@ -1,8 +1,11 @@
 //! HNSW delta WAL for incremental graph mutation logging.
 //!
 //! Records edge additions, edge removals, and entry point changes as
-//! compact CRC32-framed entries. On recovery, replaying the delta WAL
-//! is O(delta) instead of rebuilding the entire graph O(N*M).
+//! compact CRC32-framed entries. Replaying the delta WAL is O(delta)
+//! instead of rebuilding the entire graph O(N*M).
+//!
+//! **Status:** standalone module — not currently wired into the production
+//! collection recovery path, which re-indexes stored vectors at open.
 //!
 //! ## Wire Format (CRC32-framed)
 //!

--- a/crates/velesdb-core/src/storage/idx_persistence_tests.rs
+++ b/crates/velesdb-core/src/storage/idx_persistence_tests.rs
@@ -1,0 +1,132 @@
+//! Crash-safety tests for `vectors.idx` persistence.
+//!
+//! Audit 2026-06 (cluster C2, finding 3): rewriting `vectors.idx` in place
+//! via `File::create` right after compaction durably truncated the WAL left
+//! a crash window where the index ends up 0-byte/torn with an empty WAL —
+//! the database became permanently unopenable and the vectors unrecoverable.
+//! These tests pin the atomic staged-rename persistence (`vectors.idx.new`)
+//! and the 0-byte-index open hardening.
+
+use super::traits::VectorStorage;
+use super::MmapStorage;
+
+use tempfile::tempdir;
+
+/// Helper: creates a `MmapStorage`, inserts vectors, and returns it.
+fn storage_with_vectors(dir: &std::path::Path, dimension: usize, ids: &[u64]) -> MmapStorage {
+    let mut storage = MmapStorage::new(dir, dimension).expect("create storage");
+    #[allow(clippy::cast_precision_loss)]
+    for &id in ids {
+        let vector: Vec<f32> = (0..dimension).map(|d| id as f32 + d as f32).collect();
+        storage.store(id, &vector).expect("store vector");
+    }
+    storage.flush().expect("flush");
+    storage
+}
+
+#[test]
+fn test_open_with_zero_byte_idx_replays_wal() {
+    // GIVEN the crash footprint of a torn in-place index rewrite from
+    // pre-atomic versions (File::create truncated vectors.idx, the process
+    // died before the write): a 0-byte vectors.idx next to an intact WAL.
+    let dir = tempdir().expect("tempdir");
+    let dim = 4;
+    {
+        let storage = storage_with_vectors(dir.path(), dim, &[1, 2, 3]);
+        drop(storage); // crash: vectors.idx never written by flush_index
+    }
+    std::fs::write(dir.path().join("vectors.idx"), b"").expect("plant 0-byte idx");
+
+    // WHEN reopening
+    let storage = MmapStorage::new(dir.path(), dim)
+        .expect("a 0-byte vectors.idx must be treated as absent, not brick open()");
+
+    // THEN the WAL replay rebuilds every vector.
+    for id in [1u64, 2, 3] {
+        assert!(
+            storage.retrieve(id).expect("retrieve").is_some(),
+            "vector {id} must be recovered from the WAL"
+        );
+    }
+    assert_eq!(storage.len(), 3);
+}
+
+#[test]
+fn test_open_after_compaction_with_torn_idx_does_not_brick() {
+    // GIVEN the exact post-compaction crash footprint of the legacy flow:
+    // compact() committed (vectors.idx promoted, WAL durably empty), then a
+    // redundant in-place File::create rewrite of vectors.idx was interrupted,
+    // leaving a 0-byte index, an empty WAL and no repair artifacts.
+    let dir = tempdir().expect("tempdir");
+    let dim = 4;
+    {
+        let mut storage = storage_with_vectors(dir.path(), dim, &[1, 2, 3, 4]);
+        storage.delete(2).expect("delete");
+        storage.delete(4).expect("delete");
+        assert!(storage.compact().expect("compact") > 0, "must reclaim");
+    }
+    std::fs::write(dir.path().join("vectors.idx"), b"").expect("plant torn idx");
+
+    // WHEN reopening — before the atomic-persist fix this failed InvalidData
+    // forever (unreadable index, empty WAL, nothing for recovery to promote).
+    // THEN open succeeds: the 0-byte file carries no information and is
+    // treated as absent. The fixed write path (staged rename, no rewrite
+    // after the compaction commit) can no longer produce this footprint.
+    let storage = MmapStorage::new(dir.path(), dim).expect("reopen must not brick open()");
+    drop(storage);
+}
+
+#[test]
+fn test_flush_index_writes_through_dedicated_staging_file() {
+    // GIVEN a stale vectors.idx.new left behind by a crash between the
+    // staged write and the rename of a previous index persist.
+    let dir = tempdir().expect("tempdir");
+    let dim = 4;
+    let mut storage = storage_with_vectors(dir.path(), dim, &[1, 2]);
+    let staging = dir.path().join("vectors.idx.new");
+    std::fs::write(&staging, b"stale-partial-write").expect("plant staging file");
+
+    // WHEN the index is persisted.
+    storage.flush_full().expect("flush_full");
+
+    // THEN the staging file was consumed by the atomic rename — proving the
+    // persist goes through vectors.idx.new instead of truncating
+    // vectors.idx in place — and the persisted index is valid on reopen.
+    assert!(
+        !staging.exists(),
+        "vectors.idx must be replaced by renaming the staged vectors.idx.new, \
+         not rewritten in place"
+    );
+    drop(storage);
+    let storage = MmapStorage::new(dir.path(), dim).expect("reopen");
+    assert_eq!(storage.len(), 2);
+}
+
+#[test]
+fn test_kill_between_staged_idx_write_and_rename_keeps_old_idx() {
+    // GIVEN a storage whose vectors.idx is valid and durable.
+    let dir = tempdir().expect("tempdir");
+    let dim = 4;
+    {
+        let mut storage = storage_with_vectors(dir.path(), dim, &[1, 2, 3]);
+        storage.flush_full().expect("flush_full");
+    }
+    // AND a kill between the staged write and the rename: vectors.idx.new
+    // exists (possibly torn), vectors.idx untouched by the interrupted
+    // persist.
+    std::fs::write(dir.path().join("vectors.idx.new"), [0xAB, 0xCD])
+        .expect("plant torn staging file");
+
+    // WHEN reopening.
+    let storage = MmapStorage::new(dir.path(), dim).expect("reopen");
+
+    // THEN the previous index is intact and every vector resolves; the torn
+    // staging file is never promoted.
+    assert_eq!(storage.len(), 3);
+    for id in [1u64, 2, 3] {
+        assert!(
+            storage.retrieve(id).expect("retrieve").is_some(),
+            "vector {id} must resolve through the untouched vectors.idx"
+        );
+    }
+}

--- a/crates/velesdb-core/src/storage/mmap.rs
+++ b/crates/velesdb-core/src/storage/mmap.rs
@@ -306,17 +306,7 @@ impl MmapStorage {
     ///
     /// Shared by [`Self::flush_index`] and WAL replay recovery.
     fn persist_index_file(index_path: &Path, index: &ShardedIndex) -> io::Result<()> {
-        let file = File::create(index_path)?;
-        let mut writer = io::BufWriter::new(file);
-        let flat_index = index.to_hashmap();
-        let bytes = postcard::to_allocvec(&flat_index).map_err(io::Error::other)?;
-        writer.write_all(&bytes)?;
-        writer.flush()?;
-        writer
-            .into_inner()
-            .map_err(std::io::IntoInnerError::into_error)?
-            .sync_all()?;
-        Ok(())
+        compaction::persist_flat_index(index_path, &index.to_hashmap())
     }
 
     // ensure_capacity, reserve_capacity, compact, fragmentation_ratio are in mmap_capacity.rs

--- a/crates/velesdb-core/src/storage/mmap.rs
+++ b/crates/velesdb-core/src/storage/mmap.rs
@@ -226,7 +226,9 @@ impl MmapStorage {
     /// Validates every persisted offset against the backing file size (#898):
     /// a corrupt index entry whose `offset + vector_size` overflows or exceeds
     /// `data_len` would otherwise yield out-of-bounds reads or an inflated
-    /// `next_offset`. Such an index is rejected as corrupt.
+    /// `next_offset`. Such an index is rejected as corrupt. A 0-byte file is
+    /// the one exception: it is the footprint of a torn legacy in-place
+    /// rewrite, carries no information, and is treated as absent.
     fn load_index(
         index_path: &Path,
         dimension: usize,
@@ -237,6 +239,17 @@ impl MmapStorage {
         }
 
         let bytes = std::fs::read(index_path)?;
+        if bytes.is_empty() {
+            // A valid postcard-encoded index is never 0 bytes (even an empty
+            // map serializes to one length byte). A 0-byte vectors.idx is the
+            // footprint of a torn in-place rewrite by pre-atomic-persist
+            // versions and carries no information: treat it as absent so WAL
+            // replay can rebuild, instead of failing open() forever. A
+            // non-empty corrupt file still fails loudly below — it may
+            // witness real corruption that must not be silently discarded.
+            tracing::warn!("vectors.idx is 0 bytes (torn legacy rewrite); rebuilding from WAL");
+            return Ok((ShardedIndex::new(), 0));
+        }
         let flat_index: FxHashMap<u64, usize> = postcard::from_bytes(&bytes)
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
 
@@ -302,11 +315,13 @@ impl MmapStorage {
         Ok((mmap, next_offset))
     }
 
-    /// Serializes the sharded index to `index_path` with fsync.
+    /// Serializes the sharded index to `index_path`, atomically.
     ///
-    /// Shared by [`Self::flush_index`] and WAL replay recovery.
+    /// Shared by [`Self::flush_index`] and WAL replay recovery. Goes through
+    /// a staged `vectors.idx.new` + rename so an interrupted persist can
+    /// never leave a torn `vectors.idx` behind (audit 2026-06, finding 3).
     fn persist_index_file(index_path: &Path, index: &ShardedIndex) -> io::Result<()> {
-        compaction::persist_flat_index(index_path, &index.to_hashmap())
+        compaction::persist_flat_index_atomic(index_path, &index.to_hashmap())
     }
 
     // ensure_capacity, reserve_capacity, compact, fragmentation_ratio are in mmap_capacity.rs

--- a/crates/velesdb-core/src/storage/mmap/wal_replay.rs
+++ b/crates/velesdb-core/src/storage/mmap/wal_replay.rs
@@ -29,6 +29,11 @@
 //!   warning are recorded, and replay continues so later valid entries are
 //!   still recovered. Unknown opcodes mid-stream stop replay (the framing can
 //!   no longer be trusted).
+//!
+//! A bare `0x04` byte is the legacy compaction marker: versions prior to the
+//! WAL-truncating compaction protocol appended it after a successful
+//! compaction. It carries no payload and is skipped so post-compaction
+//! entries written by those versions are still recovered.
 
 use crate::storage::log_payload::crc32_hash;
 use crate::storage::sharded_index::ShardedIndex;
@@ -189,8 +194,15 @@ fn is_crc_framed_wal(wal_path: &Path, file_len: u64) -> io::Result<bool> {
 
     let mut reader = BufReader::new(File::open(wal_path)?);
     let mut op = [0u8; 1];
-    if reader.read_exact(&mut op).is_err() {
-        return Ok(false);
+    // Skip leading legacy compaction markers (bare 0x04 bytes) so a WAL whose
+    // first real record sits behind a marker is still detected as CRC-framed.
+    loop {
+        if reader.read_exact(&mut op).is_err() {
+            return Ok(false);
+        }
+        if op[0] != 4 {
+            break;
+        }
     }
 
     match op[0] {
@@ -272,6 +284,12 @@ fn replay_one_entry(
     match op[0] {
         1 => replay_store(reader, file_len, index, target, next_offset, vector_size),
         2 => replay_delete(reader, file_len, index),
+        // Legacy compaction marker (no payload): written by pre-WAL-truncation
+        // versions after a successful compaction. Skip it and keep replaying so
+        // post-compaction entries are recovered; replaying the entries BEFORE
+        // the marker is convergent against the index those versions persisted
+        // (store records carry the full vector value, deletes replay in order).
+        4 => Ok(EntryOutcome::Applied),
         // Unknown opcode: framing is no longer trustworthy, so stop cleanly. If
         // bytes still follow the opcode this is mid-stream corruption — record
         // it for visibility, mirroring the CRC path; a trailing partial byte is

--- a/crates/velesdb-core/src/storage/mmap_capacity.rs
+++ b/crates/velesdb-core/src/storage/mmap_capacity.rs
@@ -95,7 +95,13 @@ impl MmapStorage {
         if bytes_reclaimed > 0 {
             let data_path = self.path.join("vectors.dat");
             self.data_file = OpenOptions::new().read(true).write(true).open(&data_path)?;
-            self.flush_full()?;
+            // No flush_full() here: `commit_compaction` already synced the
+            // compacted data file before the swap, promoted an identical
+            // fsynced vectors.idx and truncated the WAL. Rewriting
+            // vectors.idx at this point is redundant (`&mut self` excludes
+            // concurrent mutation) and used to reopen the exact crash window
+            // the staged commit closed — a torn index next to an
+            // already-empty WAL is unrecoverable (audit 2026-06, finding 3).
         }
 
         Ok(bytes_reclaimed)

--- a/crates/velesdb-core/src/storage/mod.rs
+++ b/crates/velesdb-core/src/storage/mod.rs
@@ -50,6 +50,8 @@ mod histogram_tests;
 #[cfg(test)]
 mod hnsw_delta_wal_tests;
 #[cfg(test)]
+mod idx_persistence_tests;
+#[cfg(test)]
 mod log_payload_tests;
 #[cfg(test)]
 mod loom_tests;

--- a/crates/velesdb-core/src/storage/mod.rs
+++ b/crates/velesdb-core/src/storage/mod.rs
@@ -11,7 +11,8 @@
 //! - [`VectorSliceGuard`]: Zero-copy vector slice guard
 //! - [`metrics`]: Storage operation metrics (P0 audit - latency monitoring)
 //! - [`async_ops`]: Async wrappers for blocking I/O (EPIC-034/US-001)
-//! - [`hnsw_delta_wal`]: HNSW graph mutation WAL for O(delta) crash recovery
+//! - [`hnsw_delta_wal`]: HNSW graph mutation WAL (standalone module; not wired
+//!   into the collection recovery path, which rebuilds the graph from storage)
 #![allow(clippy::doc_markdown)] // Storage docs include API and platform identifiers.
 
 pub mod async_ops;

--- a/crates/velesdb-core/src/storage/storage_reliability_tests.rs
+++ b/crates/velesdb-core/src/storage/storage_reliability_tests.rs
@@ -275,6 +275,49 @@ fn test_wal_replay_truncates_after_success() {
     );
 }
 
+#[test]
+fn test_legacy_compaction_marker_skipped_mid_stream() {
+    // Pre-fix versions appended a bare 0x04 byte to the WAL after compaction.
+    // Replay must skip it (no payload) and keep going, so post-compaction
+    // entries written by those versions are still recovered.
+    let dir = tempdir().unwrap();
+    let path = dir.path().to_path_buf();
+    let dim = 3;
+
+    let mut wal = crc_store_entry(1, &vec3_bytes([1.0, 2.0, 3.0]));
+    wal.push(4u8); // legacy compaction marker
+    wal.extend_from_slice(&crc_store_entry(2, &vec3_bytes([4.0, 5.0, 6.0])));
+    std::fs::write(path.join("vectors.wal"), &wal).unwrap();
+
+    let storage = MmapStorage::new(&path, dim).unwrap();
+    assert_eq!(storage.retrieve(1).unwrap(), Some(vec![1.0, 2.0, 3.0]));
+    assert_eq!(
+        storage.retrieve(2).unwrap(),
+        Some(vec![4.0, 5.0, 6.0]),
+        "entries after a legacy compaction marker must be replayed"
+    );
+}
+
+#[test]
+fn test_legacy_compaction_marker_leading_byte_detected() {
+    // A WAL whose first byte is the legacy marker must still be detected as
+    // CRC-framed so the entries behind the marker are recovered.
+    let dir = tempdir().unwrap();
+    let path = dir.path().to_path_buf();
+    let dim = 3;
+
+    let mut wal = vec![4u8];
+    wal.extend_from_slice(&crc_store_entry(7, &vec3_bytes([7.0, 8.0, 9.0])));
+    std::fs::write(path.join("vectors.wal"), &wal).unwrap();
+
+    let storage = MmapStorage::new(&path, dim).unwrap();
+    assert_eq!(
+        storage.retrieve(7).unwrap(),
+        Some(vec![7.0, 8.0, 9.0]),
+        "a leading legacy marker must not disable WAL replay"
+    );
+}
+
 // ===========================================================================
 // Issue #318: Windows atomic_replace crash-safety (.bak recovery)
 // ===========================================================================

--- a/crates/velesdb-core/src/velesql/ast/aggregation.rs
+++ b/crates/velesdb-core/src/velesql/ast/aggregation.rs
@@ -76,6 +76,17 @@ pub struct HavingClause {
     pub operators: Vec<LogicalOp>,
 }
 
+impl HavingClause {
+    /// Returns `true` if any HAVING threshold value is a scalar subquery.
+    ///
+    /// Mirrors [`Condition::has_subquery`](super::condition::Condition::has_subquery)
+    /// for HAVING thresholds, which live outside the WHERE condition tree.
+    #[must_use]
+    pub fn has_subquery(&self) -> bool {
+        self.conditions.iter().any(|cond| cond.value.is_subquery())
+    }
+}
+
 /// A single HAVING condition.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct HavingCondition {

--- a/crates/velesdb-core/src/velesql/ast/mod.rs
+++ b/crates/velesdb-core/src/velesql/ast/mod.rs
@@ -142,6 +142,24 @@ impl Query {
         matches!(self.dml, Some(DmlStatement::SelectEdges(_)))
     }
 
+    /// Returns `true` if any HAVING threshold value — in the main SELECT or
+    /// in compound operands (UNION/INTERSECT/EXCEPT) — is a scalar subquery.
+    ///
+    /// HAVING thresholds are not part of the WHERE condition tree, so
+    /// [`Condition::has_subquery`] never visits them; V010 validation checks
+    /// both.
+    #[must_use]
+    pub fn has_having_subquery(&self) -> bool {
+        let compound_stmts = self
+            .compound
+            .iter()
+            .flat_map(|c| c.operations.iter().map(|(_, stmt)| stmt));
+        std::iter::once(&self.select)
+            .chain(compound_stmts)
+            .filter_map(|stmt| stmt.having.as_ref())
+            .any(HavingClause::has_subquery)
+    }
+
     /// Returns true if this is an INSERT NODE query.
     #[must_use]
     pub fn is_insert_node_query(&self) -> bool {

--- a/crates/velesdb-core/src/velesql/bare_alias_tests.rs
+++ b/crates/velesdb-core/src/velesql/bare_alias_tests.rs
@@ -1,0 +1,192 @@
+//! Tests for bare table aliases — `FROM table alias` / `JOIN table alias`
+//! without the `AS` keyword.
+//!
+//! The bare form must be strictly equivalent to the `AS` form (same AST,
+//! same validation semantics, V011 anchor check included), and no clause
+//! keyword following FROM/JOIN may ever be swallowed as an alias.
+
+use crate::velesql::{JoinType, Parser, QueryValidator};
+
+/// README showcase query #2, verbatim (bare FROM alias, no AS).
+const SHOWCASE_QUERY: &str = "SELECT doc.*, similarity() FROM documents doc \
+     WHERE vector NEAR $query AND MATCH (doc)-[:CITES]->(ref) \
+     ORDER BY similarity() DESC";
+
+// =============================================================================
+// Positive: bare alias is equivalent to AS alias
+// =============================================================================
+
+#[test]
+fn test_parse_from_bare_alias_equals_as_alias() {
+    let bare = Parser::parse("SELECT * FROM employees e").expect("bare alias must parse");
+    let with_as = Parser::parse("SELECT * FROM employees AS e").expect("AS alias must parse");
+
+    assert_eq!(bare.select.from, "employees");
+    assert_eq!(bare.select.from, with_as.select.from);
+    assert_eq!(bare.select.from_alias, with_as.select.from_alias);
+    assert!(bare.select.from_alias.contains(&"e".to_string()));
+}
+
+#[test]
+fn test_qualified_wildcard_resolves_bare_alias() {
+    let query = Parser::parse("SELECT doc.* FROM documents doc").expect("must parse");
+    assert_eq!(query.select.from_alias, vec!["doc".to_string()]);
+    QueryValidator::validate(&query).expect("doc.* must resolve against bare alias 'doc'");
+}
+
+#[test]
+fn test_showcase_query_parses_and_validates() {
+    let query = Parser::parse(SHOWCASE_QUERY).expect("showcase query #2 must parse");
+    assert_eq!(query.select.from, "documents");
+    assert_eq!(query.select.from_alias, vec!["doc".to_string()]);
+    assert!(query.select.where_clause.is_some());
+    assert!(query.select.order_by.is_some());
+    QueryValidator::validate(&query).expect("showcase query #2 must validate (V011 anchor = doc)");
+}
+
+#[test]
+fn test_explain_with_bare_alias_parses() {
+    // EXPLAIN wraps a compound_query, so the bare alias must flow through.
+    let query = Parser::parse("EXPLAIN SELECT doc.* FROM documents doc WHERE x = 1")
+        .expect("EXPLAIN over a bare-alias query must parse");
+    assert!(query.introspection.is_some());
+}
+
+#[test]
+fn test_bare_alias_anchor_mismatch_rejected_like_as_alias() {
+    // V011: MATCH anchor must equal a declared alias — bare form included.
+    let sql = "SELECT m.* FROM agent_memory m \
+               WHERE vector NEAR $q AND MATCH (ctx)-[:RELATES_TO]->(fact)";
+    let query = Parser::parse(sql).expect("must parse");
+    let err = QueryValidator::validate(&query).expect_err("anchor 'ctx' must not match alias 'm'");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("ctx"),
+        "error must name the anchor, got: {msg}"
+    );
+}
+
+#[test]
+fn test_keyword_prefixed_identifiers_are_valid_bare_aliases() {
+    // Word boundary: identifiers merely *starting* with a keyword stay usable.
+    let query = Parser::parse("SELECT * FROM docs ordering").expect("must parse");
+    assert_eq!(query.select.from_alias, vec!["ordering".to_string()]);
+
+    let query = Parser::parse("SELECT * FROM docs unions WHERE x = 1").expect("must parse");
+    assert_eq!(query.select.from_alias, vec!["unions".to_string()]);
+
+    // "asset" starts with AS but is a plain identifier, not AS + "set".
+    let query = Parser::parse("SELECT * FROM docs asset WHERE x = 1").expect("must parse");
+    assert_eq!(query.select.from_alias, vec!["asset".to_string()]);
+}
+
+#[test]
+fn test_quoted_identifier_escapes_alias_reservation() {
+    let query = Parser::parse("SELECT * FROM docs `limit` WHERE x = 1").expect("must parse");
+    assert_eq!(query.select.from_alias, vec!["limit".to_string()]);
+}
+
+// =============================================================================
+// Negative: clause keywords must never be swallowed as a bare alias
+// =============================================================================
+
+#[test]
+fn test_clause_keywords_not_swallowed_as_bare_alias() {
+    let cases = [
+        "SELECT * FROM docs WHERE x = 1",
+        "SELECT * FROM docs LIMIT 5",
+        "SELECT * FROM docs ORDER BY x ASC",
+        "SELECT category, COUNT(*) FROM docs GROUP BY category",
+        "SELECT category, COUNT(*) FROM docs GROUP BY category HAVING COUNT(*) > 1",
+        "SELECT * FROM docs OFFSET 10",
+        "SELECT * FROM docs WITH (max_groups = 100)",
+        "SELECT * FROM docs USING FUSION",
+    ];
+    for sql in cases {
+        let query = Parser::parse(sql).unwrap_or_else(|e| panic!("{sql} must parse: {e}"));
+        assert!(
+            query.select.from_alias.is_empty(),
+            "clause keyword swallowed as alias in: {sql}"
+        );
+        assert_eq!(query.select.from, "docs");
+    }
+}
+
+#[test]
+fn test_clauses_still_bound_after_unaliased_from() {
+    let query = Parser::parse("SELECT * FROM docs LIMIT 5").expect("must parse");
+    assert_eq!(query.select.limit, Some(5));
+
+    let query = Parser::parse("SELECT * FROM docs WHERE x = 1").expect("must parse");
+    assert!(query.select.where_clause.is_some());
+
+    let query = Parser::parse("SELECT * FROM docs ORDER BY x ASC").expect("must parse");
+    assert!(query.select.order_by.is_some());
+}
+
+#[test]
+fn test_join_keywords_not_swallowed_as_bare_alias() {
+    let query = Parser::parse("SELECT * FROM docs JOIN tags AS t ON docs.tag_id = t.id")
+        .expect("must parse");
+    assert_eq!(query.select.from_alias, vec!["t".to_string()]);
+    assert_eq!(query.select.joins.len(), 1);
+
+    let query = Parser::parse("SELECT * FROM docs LEFT JOIN tags AS t ON docs.tag_id = t.id")
+        .expect("must parse");
+    assert_eq!(query.select.joins[0].join_type, JoinType::Left);
+
+    let query = Parser::parse("SELECT * FROM docs INNER JOIN tags AS t ON docs.tag_id = t.id")
+        .expect("must parse");
+    assert_eq!(query.select.joins[0].join_type, JoinType::Inner);
+}
+
+#[test]
+fn test_set_operators_not_swallowed_as_bare_alias() {
+    for op in ["UNION", "UNION ALL", "INTERSECT", "EXCEPT"] {
+        let sql = format!("SELECT * FROM a {op} SELECT * FROM b");
+        let query = Parser::parse(&sql).unwrap_or_else(|e| panic!("{sql} must parse: {e}"));
+        assert!(
+            query.select.from_alias.is_empty(),
+            "set operator swallowed as alias in: {sql}"
+        );
+        assert!(query.compound.is_some(), "compound missing in: {sql}");
+    }
+}
+
+#[test]
+fn test_dangling_as_is_not_a_bare_alias() {
+    assert!(
+        Parser::parse("SELECT * FROM docs AS").is_err(),
+        "dangling AS must not be parsed as a bare alias"
+    );
+}
+
+// =============================================================================
+// JOIN: bare alias parity with AS
+// =============================================================================
+
+#[test]
+fn test_join_bare_alias_equals_as_alias() {
+    let bare = Parser::parse("SELECT d.name, t.tag FROM docs d JOIN tags t ON d.tag_id = t.id")
+        .expect("bare JOIN alias must parse");
+    let with_as =
+        Parser::parse("SELECT d.name, t.tag FROM docs AS d JOIN tags AS t ON d.tag_id = t.id")
+            .expect("AS JOIN alias must parse");
+
+    assert_eq!(bare.select.joins[0].alias, Some("t".to_string()));
+    assert_eq!(bare.select.joins[0].table, "tags");
+    assert_eq!(bare.select.from_alias, with_as.select.from_alias);
+}
+
+#[test]
+fn test_join_spec_keywords_not_swallowed_as_bare_alias() {
+    let query =
+        Parser::parse("SELECT * FROM docs JOIN tags ON docs.tag_id = tags.id").expect("must parse");
+    assert_eq!(query.select.joins[0].alias, None, "ON swallowed as alias");
+
+    let query = Parser::parse("SELECT * FROM docs JOIN tags USING (id)").expect("must parse");
+    assert_eq!(
+        query.select.joins[0].alias, None,
+        "USING swallowed as alias"
+    );
+}

--- a/crates/velesdb-core/src/velesql/cache.rs
+++ b/crates/velesdb-core/src/velesql/cache.rs
@@ -1,7 +1,10 @@
 //! Query cache for `VelesQL` parsed queries.
 //!
 //! Provides an LRU cache for parsed AST to avoid re-parsing identical queries.
-//! Typical cache hit rates exceed 90% on repetitive workloads.
+//! Effective on workloads that repeat the **exact same query text**: a hit
+//! requires equality of the original query string, so two formatting variants
+//! of the same query (different whitespace, casing, parameter names) never
+//! share a cache entry.
 
 use parking_lot::RwLock;
 use rustc_hash::FxHashMap;

--- a/crates/velesdb-core/src/velesql/grammar.pest
+++ b/crates/velesdb-core/src/velesql/grammar.pest
@@ -222,11 +222,27 @@ select_stmt = {
 }
 
 // FROM clause with optional alias (EPIC-052 US-003: Self-JOIN support)
-// Supports: FROM table, FROM table AS alias
-// Note: "FROM table alias" without AS is intentionally NOT supported to avoid
-// ambiguity with JOIN keywords. Use "FROM table AS alias" syntax.
+// Supports: FROM table, FROM table AS alias, FROM table alias (bare form).
+// The bare alias is guarded by a negative lookahead on reserved clause
+// starters so a following keyword (WHERE, JOIN, UNION, ...) is never
+// swallowed as an alias. Quoting (`limit`) escapes the reservation.
 from_clause = { identifier ~ from_alias? }
-from_alias = { ^"AS" ~ identifier }
+from_alias = { (as_kw ~ identifier) | bare_alias }
+
+// Word-boundary-safe AS keyword: prevents "asset" from being parsed as
+// AS + "set" (same pattern as collection_kw / flush_full_kw).
+as_kw = @{ ^"AS" ~ !(ASCII_ALPHANUMERIC | "_") }
+
+// Bare (AS-less) table alias: any identifier that is not a reserved clause
+// keyword. Silent so its identifier surfaces directly in from_alias /
+// alias_clause pairs, keeping alias extraction identical for both forms.
+bare_alias = _{ !reserved_alias_kw ~ identifier }
+reserved_alias_kw = @{
+    (^"WHERE" | ^"GROUP" | ^"HAVING" | ^"ORDER" | ^"LIMIT" | ^"OFFSET"
+    | ^"WITH" | ^"USING" | ^"UNION" | ^"INTERSECT" | ^"EXCEPT" | ^"INNER"
+    | ^"LEFT" | ^"RIGHT" | ^"FULL" | ^"OUTER" | ^"JOIN" | ^"ON" | ^"AS")
+    ~ !(ASCII_ALPHANUMERIC | "_")
+}
 
 // DISTINCT modifier (EPIC-052 US-001)
 distinct_modifier = { ^"DISTINCT" }
@@ -258,7 +274,9 @@ join_type = { (^"LEFT" ~ ^"OUTER"?) | (^"RIGHT" ~ ^"OUTER"?) | (^"FULL" ~ ^"OUTE
 join_spec = { on_clause | using_clause }
 on_clause = { ^"ON" ~ join_condition }
 using_clause = { ^"USING" ~ "(" ~ identifier ~ ("," ~ identifier)* ~ ")" }
-alias_clause = { ^"AS" ~ identifier }
+// JOIN alias: AS form or bare form (same reserved-keyword guard as FROM;
+// ON / USING are reserved so the join_spec is never swallowed).
+alias_clause = { (as_kw ~ identifier) | bare_alias }
 join_condition = { column_ref ~ "=" ~ column_ref }
 column_ref = @{ identifier ~ "." ~ identifier }
 

--- a/crates/velesdb-core/src/velesql/mod.rs
+++ b/crates/velesdb-core/src/velesql/mod.rs
@@ -30,6 +30,8 @@ mod aggregator_tests;
 mod ast;
 #[cfg(test)]
 mod ast_tests;
+#[cfg(test)]
+mod bare_alias_tests;
 mod cache;
 #[cfg(test)]
 mod cache_tests;

--- a/crates/velesdb-core/src/velesql/planner.rs
+++ b/crates/velesdb-core/src/velesql/planner.rs
@@ -35,17 +35,29 @@ pub use crate::velesql::cost_estimator::{Cost, CostEstimator, SelectivityMethod}
 pub use crate::velesql::query_stats::QueryStats;
 
 /// Execution strategy for hybrid queries.
+///
+/// This is the planner's *intent*; the executor realizes it only partially:
+/// on the SELECT path (`execution_paths.rs`), `GraphFirst` selects a
+/// full-scan-then-score realization for metadata filters and every other
+/// variant (including `Parallel`) is executed as `VectorFirst`; graph
+/// predicates in SELECT WHERE are always applied as a post-filter over the
+/// vector candidates. On the top-level MATCH path (`match_dispatch.rs`),
+/// `Parallel` runs `GraphFirst` and `VectorFirst` **sequentially** and merges
+/// the result sets (true parallelism is a future optimization).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum ExecutionStrategy {
     /// Execute vector search first, then filter by graph pattern.
     /// Best when graph filter is not very selective (>10% of data).
     VectorFirst,
-    /// Execute graph pattern first, then vector search on candidates.
-    /// Best when graph filter is very selective (<1% of data).
+    /// Intended: execute graph pattern first, then vector search on
+    /// candidates (selective filters, <1% of data). Realized on the SELECT
+    /// path as a full scan scored by vector similarity for metadata filters;
+    /// not realized for SELECT graph predicates (post-filter applies).
     GraphFirst,
-    /// Execute both in parallel and merge results.
-    /// Best for medium selectivity (1-10% of data).
+    /// Intended: execute both sides in parallel and merge (medium
+    /// selectivity, 1-10%). Realized as `VectorFirst` on the SELECT path and
+    /// as sequential GraphFirst + VectorFirst with a merge on the MATCH path.
     Parallel,
 }
 

--- a/crates/velesdb-core/src/velesql/validation.rs
+++ b/crates/velesdb-core/src/velesql/validation.rs
@@ -562,16 +562,17 @@ fn requires_select_validation(query: &Query) -> bool {
         && !query.is_admin_query()
 }
 
-/// Rejects subqueries appearing in any WHERE clause of the query.
+/// Rejects subqueries appearing in any WHERE or HAVING clause of the query.
 ///
 /// Subqueries are parsed but not yet executed: left unchecked, a predicate like
 /// `WHERE price > (SELECT AVG(price) FROM products)` silently evaluates to NULL,
 /// yielding wrong/empty results (or a silently no-op UPDATE) instead of an error.
+/// `HAVING COUNT(*) > (SELECT ...)` would likewise silently filter every group.
 fn reject_subqueries(query: &Query) -> Result<(), ValidationError> {
-    if where_clauses(query)
+    let in_where = where_clauses(query)
         .into_iter()
-        .any(Condition::has_subquery)
-    {
+        .any(Condition::has_subquery);
+    if in_where || query.has_having_subquery() {
         return Err(ValidationError::new(
             ValidationErrorKind::SubqueryNotExecutable,
             None,

--- a/crates/velesdb-core/src/velesql/validation.rs
+++ b/crates/velesdb-core/src/velesql/validation.rs
@@ -72,7 +72,73 @@ impl QueryValidator {
         }
         Self::validate_similarity_context(stmt)?;
         Self::validate_qualified_wildcards(stmt)?;
-        Self::validate_vector_group_by(stmt)
+        Self::validate_vector_group_by(stmt)?;
+        stmt.where_clause.as_ref().map_or(Ok(()), |condition| {
+            Self::walk_graph_match_anchors(condition, &stmt.from_alias)
+        })
+    }
+
+    /// Recursively validates every `GraphMatch` predicate anchor in a SELECT
+    /// WHERE condition tree.
+    ///
+    /// Mirrors the runtime anchor rule (`resolve_anchor_alias` in
+    /// `execution_paths.rs`) so misanchored queries fail at validation time
+    /// with an actionable message instead of mid-execution:
+    /// - the first node of each MATCH pattern must carry an alias;
+    /// - when FROM/JOIN aliases are declared, that alias must be one of them
+    ///   (a bare `FROM table` declares no alias and accepts any anchor).
+    fn walk_graph_match_anchors(
+        condition: &Condition,
+        from_aliases: &[String],
+    ) -> Result<(), ValidationError> {
+        match condition {
+            Condition::GraphMatch(predicate) => {
+                Self::check_graph_match_anchor(predicate, from_aliases)
+            }
+            Condition::And(l, r) | Condition::Or(l, r) => {
+                Self::walk_graph_match_anchors(l, from_aliases)?;
+                Self::walk_graph_match_anchors(r, from_aliases)
+            }
+            Condition::Not(inner) | Condition::Group(inner) => {
+                Self::walk_graph_match_anchors(inner, from_aliases)
+            }
+            _ => Ok(()),
+        }
+    }
+
+    /// Checks a single MATCH predicate's anchor (first node) alias.
+    fn check_graph_match_anchor(
+        predicate: &super::ast::GraphMatchPredicate,
+        from_aliases: &[String],
+    ) -> Result<(), ValidationError> {
+        let anchor = predicate
+            .pattern
+            .nodes
+            .first()
+            .and_then(|node| node.alias.as_deref());
+        let Some(anchor) = anchor else {
+            return Err(ValidationError::new(
+                ValidationErrorKind::GraphMatchAnchorMismatch,
+                None,
+                "MATCH (...)",
+                "MATCH in SELECT WHERE requires an alias on the first node, \
+                 e.g. MATCH (d:Doc)-[:REL]->(x)",
+            ));
+        };
+        if !from_aliases.is_empty() && !from_aliases.iter().any(|a| a == anchor) {
+            return Err(ValidationError::new(
+                ValidationErrorKind::GraphMatchAnchorMismatch,
+                None,
+                format!("MATCH ({anchor})"),
+                format!(
+                    "MATCH anchor alias '{anchor}' must match one of the FROM/JOIN aliases \
+                     {from_aliases:?}. Anchor the pattern on a declared alias, \
+                     e.g. MATCH ({hint})-[:REL]->(x)",
+                    hint = from_aliases[0]
+                ),
+            ));
+        }
+        Ok(())
     }
 
     /// Validates that `similarity()` in SELECT or ORDER BY has a score context.

--- a/crates/velesdb-core/src/velesql/validation_types.rs
+++ b/crates/velesdb-core/src/velesql/validation_types.rs
@@ -122,6 +122,9 @@ pub enum ValidationErrorKind {
     InvalidLetBinding,
     /// Subquery used in a WHERE clause; parsed but not yet executable.
     SubqueryNotExecutable,
+    /// MATCH predicate in SELECT WHERE whose anchor (first node) alias is
+    /// missing or does not match any declared FROM/JOIN alias.
+    GraphMatchAnchorMismatch,
 }
 
 impl ValidationErrorKind {
@@ -139,6 +142,7 @@ impl ValidationErrorKind {
             Self::UnsupportedArithmeticSimilarity => "V008",
             Self::InvalidLetBinding => "V009",
             Self::SubqueryNotExecutable => "V010",
+            Self::GraphMatchAnchorMismatch => "V011",
         }
     }
 
@@ -161,6 +165,9 @@ impl ValidationErrorKind {
             }
             Self::InvalidLetBinding => "LET bindings are not supported with DDL or DML statements",
             Self::SubqueryNotExecutable => "Subqueries are parsed but not yet executable",
+            Self::GraphMatchAnchorMismatch => {
+                "MATCH predicate anchor must be an alias declared in FROM/JOIN"
+            }
         }
     }
 }

--- a/crates/velesdb-core/tests/bdd.rs
+++ b/crates/velesdb-core/tests/bdd.rs
@@ -53,6 +53,8 @@ mod index_management;
 mod introspection;
 #[path = "bdd/match_graph_first.rs"]
 mod match_graph_first;
+#[path = "bdd/match_relationship_semantics.rs"]
+mod match_relationship_semantics;
 #[path = "bdd/match_vector_first.rs"]
 mod match_vector_first;
 #[path = "bdd/operators.rs"]

--- a/crates/velesdb-core/tests/bdd.rs
+++ b/crates/velesdb-core/tests/bdd.rs
@@ -41,6 +41,8 @@ mod flush_operations;
 mod geo_distance;
 #[path = "bdd/graph_queries.rs"]
 mod graph_queries;
+#[path = "bdd/graph_vector_hybrid.rs"]
+mod graph_vector_hybrid;
 #[path = "bdd/helpers.rs"]
 mod helpers;
 #[path = "bdd/hybrid_compositions.rs"]

--- a/crates/velesdb-core/tests/bdd.rs
+++ b/crates/velesdb-core/tests/bdd.rs
@@ -73,5 +73,7 @@ mod vector_group_by;
 mod vector_search;
 #[path = "bdd/where_filters.rs"]
 mod where_filters;
+#[path = "bdd/where_params.rs"]
+mod where_params;
 #[path = "bdd/window_functions.rs"]
 mod window_functions;

--- a/crates/velesdb-core/tests/bdd/agent_memory.rs
+++ b/crates/velesdb-core/tests/bdd/agent_memory.rs
@@ -250,3 +250,47 @@ fn test_agent_memory_show_collections_includes_internal() {
         "SHOW COLLECTIONS should include _procedural_memory, got: {names:?}"
     );
 }
+
+// ============================================================================
+// Durable TTL key — user "expires_at" metadata is business data, not a TTL
+// ============================================================================
+
+/// A semantic fact carrying a user metadata field named `expires_at` (a common
+/// business field: subscription, offer, token…) must never be interpreted as a
+/// durable TTL — only the reserved `_veles_expires_at` system key is.
+#[test]
+fn test_user_expires_at_metadata_is_not_interpreted_as_ttl() {
+    // GIVEN an agent memory holding a fact whose metadata carries a past epoch
+    // under the user key "expires_at"
+    let dir = TempDir::new().expect("test: create temp dir");
+    {
+        let db = Arc::new(Database::open(dir.path()).expect("test: open database"));
+        let memory =
+            AgentMemory::with_dimension(Arc::clone(&db), 4).expect("test: create AgentMemory");
+        let mut meta = serde_json::Map::new();
+        meta.insert("expires_at".to_string(), serde_json::json!(1_000_000_u64));
+        memory
+            .semantic()
+            .store_with_metadata(1, "offer expired yesterday", &[1.0, 0.0, 0.0, 0.0], &meta)
+            .expect("store fact with business expires_at metadata");
+    }
+
+    // WHEN the database is reopened and expired entries are purged
+    let db = Arc::new(Database::open(dir.path()).expect("test: reopen database"));
+    let memory = AgentMemory::with_dimension(Arc::clone(&db), 4).expect("test: reopen AgentMemory");
+    let stats = memory.auto_expire().expect("auto_expire should succeed");
+
+    // THEN the fact is untouched: not expired, still queryable
+    assert_eq!(
+        stats.semantic_expired, 0,
+        "user expires_at metadata must not expire the fact"
+    );
+    let results = memory
+        .semantic()
+        .query(&[1.0, 0.0, 0.0, 0.0], 5)
+        .expect("query semantic memory");
+    assert!(
+        results.iter().any(|r| r.0 == 1),
+        "fact must survive reopen + auto_expire"
+    );
+}

--- a/crates/velesdb-core/tests/bdd/graph_vector_hybrid.rs
+++ b/crates/velesdb-core/tests/bdd/graph_vector_hybrid.rs
@@ -193,7 +193,101 @@ fn test_showcase_bare_from_alias_near_match_executes() {
 }
 
 // =========================================================================
-// B. Negative: anchor alias mismatch is a clear validation error
+// B. Completeness: graph MATCH without NEAR must scan past the ranked
+//    over-fetch window (regression: graph_overfetch_limit applied to
+//    unranked scans made results depend on insertion order)
+// =========================================================================
+
+/// Creates a "library" collection of 2000 points where ONLY the last 50
+/// inserted ids (1951..=2000) carry an outgoing REFS edge (all pointing at
+/// id 1). Every point shares `category = "common"` so a metadata filter
+/// alone does not narrow the candidate set.
+fn setup_large_collection_with_late_edges(db: &Database) {
+    db.create_vector_collection("library", 4, velesdb_core::DistanceMetric::Cosine)
+        .expect("test: create library collection");
+    let vc = db
+        .get_vector_collection("library")
+        .expect("test: get library collection");
+
+    let points: Vec<Point> = (1..=2000u16)
+        .map(|i| {
+            Point::new(
+                u64::from(i),
+                vec![1.0, f32::from(i) * 0.001, 0.0, 0.0],
+                Some(json!({"category": "common"})),
+            )
+        })
+        .collect();
+    vc.upsert(points).expect("test: upsert library corpus");
+
+    for (edge_id, source) in (10_000u64..).zip(1951u64..=2000) {
+        let edge = GraphEdge::new(edge_id, source, 1, "REFS").expect("test: create edge");
+        vc.add_edge(edge).expect("test: add REFS edge");
+    }
+}
+
+/// GIVEN 2000 points where only the 50 last-inserted ids have outgoing edges
+/// WHEN running `SELECT * WHERE MATCH (a)-[:REFS]->(b) LIMIT 10` (no NEAR)
+/// THEN 10 rows are returned — the unranked scan must not stop at the
+///      ranked over-fetch window (100 candidates for LIMIT 10) and silently
+///      drop every match because of insertion order.
+#[test]
+fn test_graph_match_without_near_scans_beyond_overfetch_window() {
+    let (_dir, db) = create_test_db();
+    setup_large_collection_with_late_edges(&db);
+
+    let results = execute_sql(
+        &db,
+        "SELECT * FROM library WHERE MATCH (a)-[:REFS]->(b) LIMIT 10",
+    )
+    .expect("graph MATCH without NEAR must execute");
+
+    assert_eq!(
+        results.len(),
+        10,
+        "LIMIT 10 must be filled: edges on late-inserted ids must be found"
+    );
+    for r in &results {
+        assert!(
+            (1951..=2000).contains(&r.point.id),
+            "only ids with an outgoing REFS edge may match, got {}",
+            r.point.id
+        );
+    }
+}
+
+/// GIVEN the same corpus, where every point matches `category = 'common'`
+/// WHEN combining the metadata filter with a graph MATCH and no NEAR
+/// THEN the metadata fetch window must not be capped at the ranked
+///      over-fetch bound either — 10 rows are returned.
+#[test]
+fn test_metadata_and_graph_match_without_near_scans_beyond_overfetch_window() {
+    let (_dir, db) = create_test_db();
+    setup_large_collection_with_late_edges(&db);
+
+    let results = execute_sql(
+        &db,
+        "SELECT * FROM library \
+         WHERE category = 'common' AND MATCH (a)-[:REFS]->(b) LIMIT 10",
+    )
+    .expect("metadata + graph MATCH without NEAR must execute");
+
+    assert_eq!(
+        results.len(),
+        10,
+        "LIMIT 10 must be filled: metadata fetch must cover the whole collection"
+    );
+    for r in &results {
+        assert!(
+            (1951..=2000).contains(&r.point.id),
+            "only ids with an outgoing REFS edge may match, got {}",
+            r.point.id
+        );
+    }
+}
+
+// =========================================================================
+// C. Negative: anchor alias mismatch is a clear validation error
 // =========================================================================
 
 /// GIVEN an `agent_memory` collection with vectors and RELATES_TO edges

--- a/crates/velesdb-core/tests/bdd/graph_vector_hybrid.rs
+++ b/crates/velesdb-core/tests/bdd/graph_vector_hybrid.rs
@@ -137,6 +137,61 @@ fn test_graph_match_without_from_alias_still_executes() {
     );
 }
 
+/// GIVEN documents with vectors and CITES edges
+/// WHEN running README showcase query #2 verbatim — bare FROM alias, no AS:
+///      `SELECT doc.*, similarity() FROM documents doc
+///       WHERE vector NEAR $query AND MATCH (doc)-[:CITES]->(ref)
+///       ORDER BY similarity() DESC`
+/// THEN it parses, validates (V011 anchor = bare alias `doc`), executes, and
+///      returns exactly the citing documents ordered by similarity DESC —
+///      identical to the `FROM documents AS doc` form.
+#[test]
+fn test_showcase_bare_from_alias_near_match_executes() {
+    let (_dir, db) = create_test_db();
+    db.create_vector_collection("documents", 4, velesdb_core::DistanceMetric::Cosine)
+        .expect("test: create documents collection");
+    let vc = db
+        .get_vector_collection("documents")
+        .expect("test: get documents collection");
+    vc.upsert(vec![
+        Point::new(1, vec![1.0, 0.0, 0.0, 0.0], Some(json!({"title": "A"}))),
+        Point::new(2, vec![0.9, 0.1, 0.0, 0.0], Some(json!({"title": "B"}))),
+        Point::new(3, vec![0.8, 0.2, 0.0, 0.0], Some(json!({"title": "C"}))),
+        Point::new(4, vec![0.7, 0.3, 0.0, 0.0], Some(json!({"title": "D"}))),
+    ])
+    .expect("test: upsert documents");
+    // 1 and 3 cite 2; 2 and 4 cite nothing.
+    for (edge_id, source) in [(300u64, 1u64), (301, 3)] {
+        let edge = GraphEdge::new(edge_id, source, 2, "CITES").expect("test: create edge");
+        vc.add_edge(edge).expect("test: add CITES edge");
+    }
+
+    let bare = "SELECT doc.*, similarity() FROM documents doc \
+                WHERE vector NEAR $query AND MATCH (doc)-[:CITES]->(ref) \
+                ORDER BY similarity() DESC";
+    let mut params = std::collections::HashMap::new();
+    params.insert(
+        "query".to_string(),
+        json!([1.0_f32, 0.0_f32, 0.0_f32, 0.0_f32]),
+    );
+
+    let results =
+        execute_sql_with_params(&db, bare, &params).expect("showcase query #2 must execute");
+
+    let ids: Vec<u64> = results.iter().map(|r| r.point.id).collect();
+    assert_eq!(ids, vec![1, 3], "citing docs only, similarity DESC order");
+    assert!(
+        results[0].score >= results[1].score,
+        "ORDER BY similarity() DESC must hold"
+    );
+
+    // Strict equivalence with the AS form.
+    let with_as = bare.replace("FROM documents doc", "FROM documents AS doc");
+    let as_results = execute_sql_with_params(&db, &with_as, &params).expect("AS form must execute");
+    let as_ids: Vec<u64> = as_results.iter().map(|r| r.point.id).collect();
+    assert_eq!(ids, as_ids, "bare alias must behave exactly like AS alias");
+}
+
 // =========================================================================
 // B. Negative: anchor alias mismatch is a clear validation error
 // =========================================================================

--- a/crates/velesdb-core/tests/bdd/graph_vector_hybrid.rs
+++ b/crates/velesdb-core/tests/bdd/graph_vector_hybrid.rs
@@ -1,0 +1,180 @@
+//! BDD tests for hybrid SELECT queries combining vector NEAR, graph MATCH
+//! predicates, and scalar filters in a single WHERE clause.
+//!
+//! Regression coverage for the production panic where graph predicates forced
+//! `execution_limit = MAX_LIMIT` (100k) and the downstream oversampling clamp
+//! hit `f64::clamp` with `min > max` ("triple hybrid" showcase query), and for
+//! the late runtime-only anchor-alias check that is now a validation error.
+//!
+//! All tests exercise the full pipeline: SQL string -> parse -> validate ->
+//! execute -> verify.
+
+use serde_json::json;
+use velesdb_core::{Database, GraphEdge, Point};
+
+use super::helpers::{create_test_db, execute_sql, execute_sql_with_params, vector_param};
+
+// =========================================================================
+// Module-specific setup
+// =========================================================================
+
+/// Creates an "articles" collection mixing vectors, payloads, and graph edges.
+///
+/// Graph topology (CITES):
+/// ```text
+///   (1)--[:CITES]-->(2)
+///   (3)--[:CITES]-->(2)
+///   (4)--[:CITES]-->(2)
+///   (5)--[:CITES]-->(2)
+///   (2) has no outgoing edge
+/// ```
+///
+/// Vectors (4-dim, cosine), query is `[1, 0, 0, 0]`:
+///
+/// | id | vector            | category | has outgoing CITES |
+/// |----|-------------------|----------|--------------------|
+/// | 1  | `[1.0,0,0,0]`     | science  | yes                |
+/// | 2  | `[0.9,0.1,0,0]`   | science  | no                 |
+/// | 3  | `[0.85,0.15,0,0]` | science  | yes                |
+/// | 4  | `[0.8,0.2,0,0]`   | tech     | yes                |
+/// | 5  | `[0.75,0.25,0,0]` | science  | yes                |
+fn setup_articles_with_edges(db: &Database) {
+    db.create_vector_collection("articles", 4, velesdb_core::DistanceMetric::Cosine)
+        .expect("test: create articles collection");
+    let vc = db
+        .get_vector_collection("articles")
+        .expect("test: get articles collection");
+
+    vc.upsert(vec![
+        Point::new(
+            1,
+            vec![1.0, 0.0, 0.0, 0.0],
+            Some(json!({"category": "science", "title": "Quantum"})),
+        ),
+        Point::new(
+            2,
+            vec![0.9, 0.1, 0.0, 0.0],
+            Some(json!({"category": "science", "title": "Chemistry"})),
+        ),
+        Point::new(
+            3,
+            vec![0.85, 0.15, 0.0, 0.0],
+            Some(json!({"category": "science", "title": "Biology"})),
+        ),
+        Point::new(
+            4,
+            vec![0.8, 0.2, 0.0, 0.0],
+            Some(json!({"category": "tech", "title": "Rust"})),
+        ),
+        Point::new(
+            5,
+            vec![0.75, 0.25, 0.0, 0.0],
+            Some(json!({"category": "science", "title": "Geology"})),
+        ),
+    ])
+    .expect("test: upsert articles corpus");
+
+    for (edge_id, source) in [(100u64, 1u64), (101, 3), (102, 4), (103, 5)] {
+        let edge = GraphEdge::new(edge_id, source, 2, "CITES").expect("test: create edge");
+        vc.add_edge(edge).expect("test: add CITES edge");
+    }
+}
+
+// =========================================================================
+// A. Nominal: triple hybrid (NEAR + graph MATCH + scalar) must not panic
+// =========================================================================
+
+/// GIVEN articles with vectors, categories, and CITES edges
+/// WHEN running the showcase triple-hybrid query
+///      `SELECT a.*, similarity() ... WHERE vector NEAR $v
+///       AND MATCH (a)-[:CITES]->(r) AND category = 'science'
+///       ORDER BY similarity() DESC LIMIT 2`
+/// THEN it returns exactly the top-2 similarity-ordered nodes that satisfy
+///      BOTH the graph predicate and the scalar filter (no panic, LIMIT kept).
+#[test]
+fn test_near_graph_match_scalar_orderby_similarity_respects_limit() {
+    let (_dir, db) = create_test_db();
+    setup_articles_with_edges(&db);
+
+    let sql = "SELECT a.*, similarity() FROM articles AS a \
+               WHERE vector NEAR $v AND MATCH (a)-[:CITES]->(r) AND category = 'science' \
+               ORDER BY similarity() DESC LIMIT 2";
+    let results = execute_sql_with_params(&db, sql, &vector_param(&[1.0, 0.0, 0.0, 0.0]))
+        .expect("triple hybrid NEAR + MATCH + scalar must not fail");
+
+    // Candidates passing graph + scalar filters: 1, 3, 5 (2 lacks an outgoing
+    // edge, 4 is tech). LIMIT 2 keeps the two most similar: 1 then 3.
+    assert_eq!(results.len(), 2, "LIMIT 2 must be respected");
+    assert_eq!(results[0].point.id, 1, "highest similarity first");
+    assert_eq!(results[1].point.id, 3, "second highest similarity");
+    assert!(
+        results[0].score >= results[1].score,
+        "ORDER BY similarity() DESC must hold"
+    );
+}
+
+/// GIVEN the same hybrid corpus
+/// WHEN the graph predicate anchors on the FROM table without an alias
+///      (`FROM articles WHERE MATCH (a)-[:CITES]->(r)`)
+/// THEN the query still executes (anchor check only applies when FROM/JOIN
+///      aliases are declared) and returns only nodes with outgoing edges.
+#[test]
+fn test_graph_match_without_from_alias_still_executes() {
+    let (_dir, db) = create_test_db();
+    setup_articles_with_edges(&db);
+
+    let results = execute_sql(
+        &db,
+        "SELECT * FROM articles WHERE MATCH (a)-[:CITES]->(r) LIMIT 10",
+    )
+    .expect("MATCH anchor on unaliased FROM must keep working");
+
+    let ids: std::collections::HashSet<u64> = results.iter().map(|r| r.point.id).collect();
+    assert_eq!(
+        ids,
+        [1u64, 3, 4, 5].into_iter().collect(),
+        "only nodes with an outgoing CITES edge match"
+    );
+}
+
+// =========================================================================
+// B. Negative: anchor alias mismatch is a clear validation error
+// =========================================================================
+
+/// GIVEN an `agent_memory` collection with vectors and RELATES_TO edges
+/// WHEN running the mission query verbatim, whose MATCH anchors on `ctx`
+///      while the FROM alias is `memory`
+/// THEN the query is rejected with a clear, actionable error naming the
+///      mismatched anchor alias BEFORE any execution (no panic, no results).
+#[test]
+fn test_mission_query_anchor_alias_mismatch_is_clear_error() {
+    let (_dir, db) = create_test_db();
+    db.create_vector_collection("agent_memory", 4, velesdb_core::DistanceMetric::Cosine)
+        .expect("test: create agent_memory");
+    let vc = db
+        .get_vector_collection("agent_memory")
+        .expect("test: get agent_memory");
+    vc.upsert(vec![
+        Point::new(1, vec![1.0, 0.0, 0.0, 0.0], Some(json!({"kind": "fact"}))),
+        Point::new(2, vec![0.9, 0.1, 0.0, 0.0], Some(json!({"kind": "fact"}))),
+    ])
+    .expect("test: upsert agent_memory");
+    let edge = GraphEdge::new(200, 1, 2, "RELATES_TO").expect("test: create edge");
+    vc.add_edge(edge).expect("test: add RELATES_TO edge");
+
+    let sql = "SELECT memory.*, similarity() FROM agent_memory AS memory \
+               WHERE vector NEAR $v AND MATCH (ctx)-[:RELATES_TO]->(fact) AND kind = 'fact' \
+               ORDER BY similarity() DESC LIMIT 10";
+    let err = execute_sql_with_params(&db, sql, &vector_param(&[1.0, 0.0, 0.0, 0.0]))
+        .expect_err("anchor alias 'ctx' does not match FROM alias 'memory'");
+
+    let msg = err.to_string();
+    assert!(
+        msg.contains("ctx"),
+        "error must name the mismatched anchor alias, got: {msg}"
+    );
+    assert!(
+        msg.contains("memory"),
+        "error must list the declared FROM/JOIN aliases, got: {msg}"
+    );
+}

--- a/crates/velesdb-core/tests/bdd/match_relationship_semantics.rs
+++ b/crates/velesdb-core/tests/bdd/match_relationship_semantics.rs
@@ -1,0 +1,267 @@
+//! BDD tests for MATCH relationship semantics (audit 2026-06 finding F).
+//!
+//! Covers two correctness contracts of the MATCH pattern walker:
+//!
+//! 1. **Relationship isomorphism** (Cypher semantics): a single edge may be
+//!    traversed at most once per matched path. Without it, undirected
+//!    (`Both`) and cyclic variable-length patterns fabricate phantom paths
+//!    by bouncing back and forth on the same edge.
+//! 2. **Relationship alias binding**: `-[r:KNOWS]->` must bind `r` to the
+//!    traversed edge so `WHERE r.prop` and `RETURN r.prop` resolve against
+//!    the EDGE's properties, not the target node's payload.
+//!
+//! All tests exercise the full pipeline: SQL string -> parse -> execute.
+
+use std::collections::HashMap;
+
+use serde_json::json;
+use velesdb_core::{Database, GraphEdge, Point, SearchResult};
+
+use super::helpers::create_test_db;
+
+// =========================================================================
+// Module-specific setup
+// =========================================================================
+
+/// Builds a params map with only the `_collection` routing key.
+fn match_collection_param(collection: &str) -> HashMap<String, serde_json::Value> {
+    let mut params = HashMap::new();
+    params.insert(
+        "_collection".to_string(),
+        serde_json::Value::String(collection.to_string()),
+    );
+    params
+}
+
+/// Parses `sql` and executes it against `collection`.
+fn run_match(db: &Database, sql: &str, collection: &str) -> Vec<SearchResult> {
+    let query = velesdb_core::velesql::Parser::parse(sql).expect("test: parse MATCH query");
+    db.execute_query(&query, &match_collection_param(collection))
+        .expect("test: execute MATCH query")
+}
+
+/// GIVEN base: two nodes and a single `KNOWS` edge 1 -> 2 carrying
+/// `{since: 2020}`.
+fn setup_single_edge_collection(db: &Database) {
+    db.create_vector_collection("pair", 4, velesdb_core::DistanceMetric::Cosine)
+        .expect("test: create pair collection");
+    let vc = db
+        .get_vector_collection("pair")
+        .expect("test: get pair collection");
+
+    vc.upsert(vec![
+        Point::new(1, vec![1.0, 0.0, 0.0, 0.0], Some(json!({"name": "A"}))),
+        Point::new(2, vec![0.0, 1.0, 0.0, 0.0], Some(json!({"name": "B"}))),
+    ])
+    .expect("test: upsert nodes");
+
+    let mut props = HashMap::new();
+    props.insert("since".to_string(), json!(2020));
+    let edge = GraphEdge::new(100, 1, 2, "KNOWS")
+        .expect("test: create edge 1->2")
+        .with_properties(props);
+    vc.add_edge(edge).expect("test: add edge 1->2 KNOWS");
+}
+
+/// GIVEN base: a directed triangle 1 -> 2 -> 3 -> 1 (all `KNOWS`), with
+/// node 1 labeled `Start` so it is the only traversal anchor.
+fn setup_triangle_collection(db: &Database) {
+    db.create_vector_collection("triangle", 4, velesdb_core::DistanceMetric::Cosine)
+        .expect("test: create triangle collection");
+    let vc = db
+        .get_vector_collection("triangle")
+        .expect("test: get triangle collection");
+
+    vc.upsert(vec![
+        Point::new(
+            1,
+            vec![1.0, 0.0, 0.0, 0.0],
+            Some(json!({"_labels": ["Start"], "name": "A"})),
+        ),
+        Point::new(2, vec![0.0, 1.0, 0.0, 0.0], Some(json!({"name": "B"}))),
+        Point::new(3, vec![0.0, 0.0, 1.0, 0.0], Some(json!({"name": "C"}))),
+    ])
+    .expect("test: upsert nodes");
+
+    for (id, source, target) in [(101, 1, 2), (102, 2, 3), (103, 3, 1)] {
+        let edge = GraphEdge::new(id, source, target, "KNOWS").expect("test: create edge");
+        vc.add_edge(edge).expect("test: add edge");
+    }
+}
+
+// =========================================================================
+// A. Relationship isomorphism (Bug 1)
+// =========================================================================
+
+/// GIVEN a graph with a single edge 1-[KNOWS]->2
+/// WHEN matching the undirected variable-length pattern `(a)-[:KNOWS*2..2]-(b)`
+/// THEN no path exists: a 2-hop path would have to traverse the only edge
+///      twice (forward then backward), which relationship isomorphism forbids.
+#[test]
+fn test_match_undirected_two_hops_cannot_reuse_single_edge() {
+    let (_dir, db) = create_test_db();
+    setup_single_edge_collection(&db);
+
+    let results = run_match(
+        &db,
+        "MATCH (a)-[:KNOWS*2..2]-(b) RETURN a, b LIMIT 10",
+        "pair",
+    );
+
+    assert!(
+        results.is_empty(),
+        "an edge must be traversed at most once per path; \
+         bouncing 1-2-1 on the same edge fabricated {} phantom result(s)",
+        results.len()
+    );
+}
+
+/// GIVEN a directed triangle 1->2->3->1 (KNOWS)
+/// WHEN matching `(a:Start)-[:KNOWS*3..3]->(b)`
+/// THEN exactly one cycle is found (1->2->3->1, three distinct edges) and
+///      it terminates back on the start node.
+#[test]
+fn test_match_triangle_cycle_found_without_edge_reuse() {
+    let (_dir, db) = create_test_db();
+    setup_triangle_collection(&db);
+
+    let results = run_match(
+        &db,
+        "MATCH (a:Start)-[:KNOWS*3..3]->(b) RETURN a, b LIMIT 10",
+        "triangle",
+    );
+
+    assert_eq!(
+        results.len(),
+        1,
+        "the triangle has exactly one 3-hop cycle from node 1"
+    );
+    assert_eq!(
+        results[0].point.id, 1,
+        "the 3-hop cycle must terminate back on the start node"
+    );
+}
+
+/// GIVEN a directed triangle 1->2->3->1 (KNOWS)
+/// WHEN matching `(a:Start)-[:KNOWS*4..4]->(b)`
+/// THEN no path exists: a 4th hop would have to reuse an already-traversed
+///      edge (1->2->3->1->2 reuses edge 1->2).
+#[test]
+fn test_match_four_hops_on_triangle_requires_distinct_edges() {
+    let (_dir, db) = create_test_db();
+    setup_triangle_collection(&db);
+
+    let results = run_match(
+        &db,
+        "MATCH (a:Start)-[:KNOWS*4..4]->(b) RETURN a, b LIMIT 10",
+        "triangle",
+    );
+
+    assert!(
+        results.is_empty(),
+        "4 hops on a 3-edge triangle must reuse an edge; \
+         relationship isomorphism forbids it, got {} result(s)",
+        results.len()
+    );
+}
+
+// =========================================================================
+// B. Relationship alias binding (Bug 2)
+// =========================================================================
+
+/// GIVEN an edge 1-[KNOWS {since: 2020}]->2
+/// WHEN filtering with `WHERE r.since = 2020`
+/// THEN the pattern matches: `r` resolves to the traversed edge's properties.
+#[test]
+fn test_match_where_edge_property_matches() {
+    let (_dir, db) = create_test_db();
+    setup_single_edge_collection(&db);
+
+    let results = run_match(
+        &db,
+        "MATCH (a)-[r:KNOWS]->(b) WHERE r.since = 2020 RETURN a, b LIMIT 10",
+        "pair",
+    );
+
+    assert_eq!(
+        results.len(),
+        1,
+        "WHERE r.since = 2020 must match the edge property"
+    );
+    assert_eq!(results[0].point.id, 2, "traversal target must be node 2");
+}
+
+/// GIVEN an edge 1-[KNOWS {since: 2020}]->2
+/// WHEN filtering with `WHERE r.since = 1999`
+/// THEN the pattern does not match.
+#[test]
+fn test_match_where_edge_property_rejects_non_matching() {
+    let (_dir, db) = create_test_db();
+    setup_single_edge_collection(&db);
+
+    let results = run_match(
+        &db,
+        "MATCH (a)-[r:KNOWS]->(b) WHERE r.since = 1999 RETURN a, b LIMIT 10",
+        "pair",
+    );
+
+    assert!(
+        results.is_empty(),
+        "WHERE r.since = 1999 must not match an edge with since = 2020"
+    );
+}
+
+/// GIVEN an edge 1-[KNOWS {since: 2020}]->2
+/// WHEN filtering with `WHERE r.since IN (2019, 2020)` (metadata condition)
+/// THEN the pattern matches via the filter-engine path as well.
+#[test]
+fn test_match_where_edge_property_in_list() {
+    let (_dir, db) = create_test_db();
+    setup_single_edge_collection(&db);
+
+    let hit = run_match(
+        &db,
+        "MATCH (a)-[r:KNOWS]->(b) WHERE r.since IN (2019, 2020) RETURN a, b LIMIT 10",
+        "pair",
+    );
+    assert_eq!(hit.len(), 1, "r.since IN (2019, 2020) must match the edge");
+
+    let miss = run_match(
+        &db,
+        "MATCH (a)-[r:KNOWS]->(b) WHERE r.since IN (1998, 1999) RETURN a, b LIMIT 10",
+        "pair",
+    );
+    assert!(
+        miss.is_empty(),
+        "r.since IN (1998, 1999) must not match an edge with since = 2020"
+    );
+}
+
+/// GIVEN an edge 1-[KNOWS {since: 2020}]->2
+/// WHEN projecting `RETURN r.since`
+/// THEN the projected value is the edge property 2020.
+#[test]
+fn test_match_return_edge_property() {
+    let (_dir, db) = create_test_db();
+    setup_single_edge_collection(&db);
+
+    let results = run_match(
+        &db,
+        "MATCH (a)-[r:KNOWS]->(b) RETURN r.since LIMIT 10",
+        "pair",
+    );
+
+    assert_eq!(results.len(), 1, "the single KNOWS edge must match");
+    let projected = results[0]
+        .point
+        .payload
+        .as_ref()
+        .and_then(|p| p.get("r.since"))
+        .and_then(serde_json::Value::as_i64);
+    assert_eq!(
+        projected,
+        Some(2020),
+        "RETURN r.since must project the edge property, got payload: {:?}",
+        results[0].point.payload
+    );
+}

--- a/crates/velesdb-core/tests/bdd/match_relationship_semantics.rs
+++ b/crates/velesdb-core/tests/bdd/match_relationship_semantics.rs
@@ -40,6 +40,20 @@ fn run_match(db: &Database, sql: &str, collection: &str) -> Vec<SearchResult> {
         .expect("test: execute MATCH query")
 }
 
+/// Parses `sql` and executes it with a `$q` vector parameter bound.
+fn run_match_with_vector(
+    db: &Database,
+    sql: &str,
+    collection: &str,
+    vector: &[f32],
+) -> Vec<SearchResult> {
+    let query = velesdb_core::velesql::Parser::parse(sql).expect("test: parse hybrid MATCH query");
+    let mut params = match_collection_param(collection);
+    params.insert("q".to_string(), json!(vector));
+    db.execute_query(&query, &params)
+        .expect("test: execute hybrid MATCH query")
+}
+
 /// GIVEN base: two nodes and a single `KNOWS` edge 1 -> 2 carrying
 /// `{since: 2020}`.
 fn setup_single_edge_collection(db: &Database) {
@@ -234,6 +248,106 @@ fn test_match_where_edge_property_in_list() {
     assert!(
         miss.is_empty(),
         "r.since IN (1998, 1999) must not match an edge with since = 2020"
+    );
+}
+
+// =========================================================================
+// C. Hybrid: similarity() on the start alias + relationship alias
+//    (audit 2026-06 cluster F2 — plan-dependent edge-alias semantics)
+//
+//    `similarity()` on the START alias routes the planner toward
+//    VectorFirst, which does not bind relationship aliases. Whenever the
+//    WHERE or RETURN clause references a relationship alias, the planner
+//    must fall back to GraphFirst so `r.prop` resolves against the EDGE.
+// =========================================================================
+
+/// GIVEN an edge 1-[KNOWS {since: 2020}]->2 and node 1 aligned with `$q`
+/// WHEN filtering with `similarity(a.embedding, $q) > 0.1 AND r.since = 2020`
+/// THEN the row is returned and `r.since` projects the edge property —
+///      identical to the same query without the similarity predicate.
+#[test]
+fn test_match_similarity_with_edge_property_filter_matches() {
+    let (_dir, db) = create_test_db();
+    setup_single_edge_collection(&db);
+
+    let results = run_match_with_vector(
+        &db,
+        "MATCH (a)-[r:KNOWS]->(b) \
+         WHERE similarity(a.embedding, $q) > 0.1 AND r.since = 2020 \
+         RETURN a, r.since LIMIT 10",
+        "pair",
+        &[1.0, 0.0, 0.0, 0.0],
+    );
+
+    assert_eq!(
+        results.len(),
+        1,
+        "similarity(a) AND r.since = 2020 must match the single edge; \
+         the plan must not change edge-alias semantics"
+    );
+    let projected = results[0]
+        .point
+        .payload
+        .as_ref()
+        .and_then(|p| p.get("r.since"))
+        .and_then(serde_json::Value::as_i64);
+    assert_eq!(
+        projected,
+        Some(2020),
+        "RETURN r.since must project the edge property under the hybrid plan, \
+         got payload: {:?}",
+        results[0].point.payload
+    );
+}
+
+/// GIVEN an edge 1-[KNOWS {since: 2020}]->2 and node 1 aligned with `$q`
+/// WHEN filtering with `similarity(a.embedding, $q) > 0.1 AND r.since = 1999`
+/// THEN no row is returned (the edge property does not match).
+#[test]
+fn test_match_similarity_with_edge_property_filter_rejects_non_matching() {
+    let (_dir, db) = create_test_db();
+    setup_single_edge_collection(&db);
+
+    let results = run_match_with_vector(
+        &db,
+        "MATCH (a)-[r:KNOWS]->(b) \
+         WHERE similarity(a.embedding, $q) > 0.1 AND r.since = 1999 \
+         RETURN a, r.since LIMIT 10",
+        "pair",
+        &[1.0, 0.0, 0.0, 0.0],
+    );
+
+    assert!(
+        results.is_empty(),
+        "r.since = 1999 must not match an edge with since = 2020, got {} row(s)",
+        results.len()
+    );
+}
+
+/// GIVEN an edge 1-[KNOWS {since: 2020}]->2 and node 1 aligned with `$q`
+/// WHEN filtering with `similarity(a.embedding, $q) > 0.1 AND r.since IS NULL`
+/// THEN no row is returned: the edge HAS a `since` property. Evaluating
+///      `r.since IS NULL` against a node payload (where the key is absent)
+///      would fabricate a false positive.
+#[test]
+fn test_match_similarity_with_edge_is_null_rejects_existing_property() {
+    let (_dir, db) = create_test_db();
+    setup_single_edge_collection(&db);
+
+    let results = run_match_with_vector(
+        &db,
+        "MATCH (a)-[r:KNOWS]->(b) \
+         WHERE similarity(a.embedding, $q) > 0.1 AND r.since IS NULL \
+         RETURN a, b LIMIT 10",
+        "pair",
+        &[1.0, 0.0, 0.0, 0.0],
+    );
+
+    assert!(
+        results.is_empty(),
+        "r.since IS NULL must be false for an edge carrying since = 2020, \
+         got {} false-positive row(s)",
+        results.len()
     );
 }
 

--- a/crates/velesdb-core/tests/bdd/where_params.rs
+++ b/crates/velesdb-core/tests/bdd/where_params.rs
@@ -1,0 +1,282 @@
+//! BDD-style end-to-end tests for parameter placeholders in WHERE clauses.
+//!
+//! Each scenario follows GIVEN (setup data) -> WHEN (execute SQL with params)
+//! -> THEN (verify results).  Regression coverage for the silent-NULL bug:
+//! `SELECT * FROM products WHERE category = $cat` with `{cat: "x"}` returned
+//! 0 results without any error because `Value::Parameter` was converted to
+//! JSON `null` before the filter ever saw the bound value.  A parameterized
+//! query must return exactly the same rows as its literal equivalent, and a
+//! missing parameter must produce an explicit error, never an empty result.
+
+use std::collections::HashMap;
+
+use serde_json::json;
+use velesdb_core::{Database, Point};
+
+use super::helpers::{create_test_db, execute_sql, execute_sql_with_params, result_ids};
+
+// =========================================================================
+// Module-specific setup
+// =========================================================================
+
+/// Populate a `products` collection for parameterized WHERE testing.
+///
+/// | id | category    | price  | stock |
+/// |----|-------------|--------|-------|
+/// | 1  | electronics | 299.99 | 50    |
+/// | 2  | electronics | 99.99  | 200   |
+/// | 3  | books       | 19.99  | 30    |
+/// | 4  | books       | 29.99  | 0     |
+/// | 5  | clothing    | 49.99  | 100   |
+fn setup_products_collection(db: &Database) {
+    execute_sql(
+        db,
+        "CREATE COLLECTION products (dimension = 4, metric = 'cosine');",
+    )
+    .expect("test: CREATE products");
+
+    let vc = db
+        .get_vector_collection("products")
+        .expect("test: get products collection");
+
+    vc.upsert(vec![
+        Point::new(
+            1,
+            vec![1.0, 0.0, 0.0, 0.0],
+            Some(json!({"category": "electronics", "price": 299.99, "stock": 50})),
+        ),
+        Point::new(
+            2,
+            vec![0.0, 1.0, 0.0, 0.0],
+            Some(json!({"category": "electronics", "price": 99.99, "stock": 200})),
+        ),
+        Point::new(
+            3,
+            vec![0.0, 0.0, 1.0, 0.0],
+            Some(json!({"category": "books", "price": 19.99, "stock": 30})),
+        ),
+        Point::new(
+            4,
+            vec![0.0, 0.0, 0.0, 1.0],
+            Some(json!({"category": "books", "price": 29.99, "stock": 0})),
+        ),
+        Point::new(
+            5,
+            vec![0.5, 0.5, 0.0, 0.0],
+            Some(json!({"category": "clothing", "price": 49.99, "stock": 100})),
+        ),
+    ])
+    .expect("test: upsert products");
+}
+
+fn params_from(pairs: &[(&str, serde_json::Value)]) -> HashMap<String, serde_json::Value> {
+    pairs
+        .iter()
+        .map(|(k, v)| ((*k).to_string(), v.clone()))
+        .collect()
+}
+
+// =========================================================================
+// Scenarios: parameterized WHERE must match the literal equivalent
+// =========================================================================
+
+#[test]
+fn scenario_where_eq_string_param_matches_literal() {
+    // GIVEN a products collection
+    let (_dir, db) = create_test_db();
+    setup_products_collection(&db);
+
+    // WHEN selecting with a literal and with an equivalent parameter
+    let literal = execute_sql(
+        &db,
+        "SELECT * FROM products WHERE category = 'electronics' LIMIT 10",
+    )
+    .expect("test: literal query");
+    let params = params_from(&[("cat", json!("electronics"))]);
+    let parameterized = execute_sql_with_params(
+        &db,
+        "SELECT * FROM products WHERE category = $cat LIMIT 10",
+        &params,
+    )
+    .expect("test: parameterized query");
+
+    // THEN both return exactly ids {1, 2}
+    assert_eq!(result_ids(&literal), [1, 2].into_iter().collect());
+    assert_eq!(
+        result_ids(&parameterized),
+        result_ids(&literal),
+        "parameterized WHERE must return the same rows as the literal query"
+    );
+}
+
+#[test]
+fn scenario_where_in_params_matches_literal() {
+    // GIVEN a products collection
+    let (_dir, db) = create_test_db();
+    setup_products_collection(&db);
+
+    // WHEN filtering with IN over two parameters
+    let params = params_from(&[("a", json!("books")), ("b", json!("clothing"))]);
+    let results = execute_sql_with_params(
+        &db,
+        "SELECT * FROM products WHERE category IN ($a, $b) LIMIT 10",
+        &params,
+    )
+    .expect("test: IN params query");
+
+    // THEN books (3, 4) and clothing (5) are returned
+    assert_eq!(result_ids(&results), [3, 4, 5].into_iter().collect());
+}
+
+#[test]
+fn scenario_where_between_params_matches_literal() {
+    // GIVEN a products collection
+    let (_dir, db) = create_test_db();
+    setup_products_collection(&db);
+
+    // WHEN filtering with BETWEEN over two parameters
+    let params = params_from(&[("lo", json!(20.0)), ("hi", json!(100.0))]);
+    let results = execute_sql_with_params(
+        &db,
+        "SELECT * FROM products WHERE price BETWEEN $lo AND $hi LIMIT 10",
+        &params,
+    )
+    .expect("test: BETWEEN params query");
+
+    // THEN prices 29.99 (4), 49.99 (5), 99.99 (2) are in range
+    assert_eq!(result_ids(&results), [2, 4, 5].into_iter().collect());
+}
+
+#[test]
+fn scenario_where_gt_param_matches_literal() {
+    // GIVEN a products collection
+    let (_dir, db) = create_test_db();
+    setup_products_collection(&db);
+
+    // WHEN filtering with a numeric comparison parameter
+    let params = params_from(&[("min", json!(50.0))]);
+    let results = execute_sql_with_params(
+        &db,
+        "SELECT * FROM products WHERE price > $min LIMIT 10",
+        &params,
+    )
+    .expect("test: > param query");
+
+    // THEN only prices above 50 (ids 1, 2) are returned
+    assert_eq!(result_ids(&results), [1, 2].into_iter().collect());
+}
+
+#[test]
+fn scenario_near_with_scalar_param_filter() {
+    // GIVEN a products collection
+    let (_dir, db) = create_test_db();
+    setup_products_collection(&db);
+
+    // WHEN combining NEAR with a parameterized metadata filter
+    let mut params = params_from(&[("cat", json!("books"))]);
+    params.insert("v".to_string(), json!([0.0, 0.0, 1.0, 0.0]));
+    let results = execute_sql_with_params(
+        &db,
+        "SELECT * FROM products WHERE vector NEAR $v AND category = $cat LIMIT 10",
+        &params,
+    )
+    .expect("test: NEAR + scalar param query");
+
+    // THEN only books (ids 3, 4) survive the metadata filter
+    assert_eq!(result_ids(&results), [3, 4].into_iter().collect());
+}
+
+// =========================================================================
+// Scenarios: missing parameters must error, never return empty results
+// =========================================================================
+
+#[test]
+fn scenario_where_missing_param_errors() {
+    // GIVEN a products collection
+    let (_dir, db) = create_test_db();
+    setup_products_collection(&db);
+
+    // WHEN executing with an unbound parameter
+    let result = execute_sql_with_params(
+        &db,
+        "SELECT * FROM products WHERE category = $cat LIMIT 10",
+        &HashMap::new(),
+    );
+
+    // THEN an explicit missing-parameter error is raised (not an empty result)
+    let err = result.expect_err("missing parameter must be an error, not an empty result set");
+    assert!(
+        err.to_string().contains("Missing parameter"),
+        "error should name the missing parameter, got: {err}"
+    );
+}
+
+#[test]
+fn scenario_where_in_missing_param_errors() {
+    // GIVEN a products collection
+    let (_dir, db) = create_test_db();
+    setup_products_collection(&db);
+
+    // WHEN executing IN with only one of two parameters bound
+    let params = params_from(&[("a", json!("books"))]);
+    let result = execute_sql_with_params(
+        &db,
+        "SELECT * FROM products WHERE category IN ($a, $b) LIMIT 10",
+        &params,
+    );
+
+    // THEN the unbound $b is reported as an error
+    let err = result.expect_err("missing IN parameter must be an error");
+    assert!(
+        err.to_string().contains("Missing parameter"),
+        "error should name the missing parameter, got: {err}"
+    );
+}
+
+// =========================================================================
+// Scenarios: DML UPDATE WHERE with parameters
+// =========================================================================
+
+#[test]
+fn scenario_update_where_param_updates_only_matching_rows() {
+    // GIVEN a products collection
+    let (_dir, db) = create_test_db();
+    setup_products_collection(&db);
+
+    // WHEN updating rows selected by a parameterized WHERE
+    let params = params_from(&[("cat", json!("electronics"))]);
+    let updated = execute_sql_with_params(
+        &db,
+        "UPDATE products SET stock = 0 WHERE category = $cat",
+        &params,
+    )
+    .expect("test: UPDATE with param");
+
+    // THEN exactly the two electronics rows were updated
+    assert_eq!(
+        result_ids(&updated),
+        [1, 2].into_iter().collect(),
+        "UPDATE WHERE category = $cat must touch only matching rows"
+    );
+}
+
+#[test]
+fn scenario_update_where_missing_param_errors() {
+    // GIVEN a products collection
+    let (_dir, db) = create_test_db();
+    setup_products_collection(&db);
+
+    // WHEN updating with an unbound WHERE parameter
+    let result = execute_sql_with_params(
+        &db,
+        "UPDATE products SET stock = 0 WHERE category = $cat",
+        &HashMap::new(),
+    );
+
+    // THEN an explicit missing-parameter error is raised (no rows touched)
+    let err = result.expect_err("missing UPDATE WHERE parameter must be an error");
+    assert!(
+        err.to_string().contains("Missing parameter"),
+        "error should name the missing parameter, got: {err}"
+    );
+}

--- a/crates/velesdb-core/tests/bdd/where_params.rs
+++ b/crates/velesdb-core/tests/bdd/where_params.rs
@@ -11,6 +11,7 @@
 use std::collections::HashMap;
 
 use serde_json::json;
+use velesdb_core::velesql::{Parser, QueryValidator};
 use velesdb_core::{Database, Point};
 
 use super::helpers::{create_test_db, execute_sql, execute_sql_with_params, result_ids};
@@ -21,13 +22,13 @@ use super::helpers::{create_test_db, execute_sql, execute_sql_with_params, resul
 
 /// Populate a `products` collection for parameterized WHERE testing.
 ///
-/// | id | category    | price  | stock |
-/// |----|-------------|--------|-------|
-/// | 1  | electronics | 299.99 | 50    |
-/// | 2  | electronics | 99.99  | 200   |
-/// | 3  | books       | 19.99  | 30    |
-/// | 4  | books       | 29.99  | 0     |
-/// | 5  | clothing    | 49.99  | 100   |
+/// | id | category    | price  | stock | tags              |
+/// |----|-------------|--------|-------|-------------------|
+/// | 1  | electronics | 299.99 | 50    | new, sale         |
+/// | 2  | electronics | 99.99  | 200   | sale              |
+/// | 3  | books       | 19.99  | 30    | new               |
+/// | 4  | books       | 29.99  | 0     | clearance         |
+/// | 5  | clothing    | 49.99  | 100   | sale, clearance   |
 fn setup_products_collection(db: &Database) {
     execute_sql(
         db,
@@ -43,30 +44,56 @@ fn setup_products_collection(db: &Database) {
         Point::new(
             1,
             vec![1.0, 0.0, 0.0, 0.0],
-            Some(json!({"category": "electronics", "price": 299.99, "stock": 50})),
+            Some(
+                json!({"category": "electronics", "price": 299.99, "stock": 50,
+                "tags": ["new", "sale"]}),
+            ),
         ),
         Point::new(
             2,
             vec![0.0, 1.0, 0.0, 0.0],
-            Some(json!({"category": "electronics", "price": 99.99, "stock": 200})),
+            Some(
+                json!({"category": "electronics", "price": 99.99, "stock": 200,
+                "tags": ["sale"]}),
+            ),
         ),
         Point::new(
             3,
             vec![0.0, 0.0, 1.0, 0.0],
-            Some(json!({"category": "books", "price": 19.99, "stock": 30})),
+            Some(json!({"category": "books", "price": 19.99, "stock": 30,
+                "tags": ["new"]})),
         ),
         Point::new(
             4,
             vec![0.0, 0.0, 0.0, 1.0],
-            Some(json!({"category": "books", "price": 29.99, "stock": 0})),
+            Some(json!({"category": "books", "price": 29.99, "stock": 0,
+                "tags": ["clearance"]})),
         ),
         Point::new(
             5,
             vec![0.5, 0.5, 0.0, 0.0],
-            Some(json!({"category": "clothing", "price": 49.99, "stock": 100})),
+            Some(json!({"category": "clothing", "price": 49.99, "stock": 100,
+                "tags": ["sale", "clearance"]})),
         ),
     ])
     .expect("test: upsert products");
+}
+
+/// Execute a `VelesQL` aggregation query (GROUP BY/HAVING) with bind params.
+///
+/// Aggregation queries return `serde_json::Value` rather than
+/// `Vec<SearchResult>`, so they go through `VectorCollection::execute_aggregate`.
+fn execute_aggregate_sql_with_params(
+    db: &Database,
+    sql: &str,
+    params: &HashMap<String, serde_json::Value>,
+) -> velesdb_core::Result<serde_json::Value> {
+    let query = Parser::parse(sql).map_err(|e| velesdb_core::Error::Query(e.to_string()))?;
+    let collection_name = &query.select.from;
+    let vc = db
+        .get_vector_collection(collection_name)
+        .ok_or_else(|| velesdb_core::Error::CollectionNotFound(collection_name.clone()))?;
+    vc.execute_aggregate(&query, params)
 }
 
 fn params_from(pairs: &[(&str, serde_json::Value)]) -> HashMap<String, serde_json::Value> {
@@ -278,5 +305,169 @@ fn scenario_update_where_missing_param_errors() {
     assert!(
         err.to_string().contains("Missing parameter"),
         "error should name the missing parameter, got: {err}"
+    );
+}
+
+// =========================================================================
+// Scenarios: CONTAINS / CONTAINS ANY with parameters
+// =========================================================================
+
+#[test]
+fn scenario_where_contains_param_matches_literal() {
+    // GIVEN a products collection with array tags
+    let (_dir, db) = create_test_db();
+    setup_products_collection(&db);
+
+    // WHEN selecting with a literal CONTAINS and the parameterized equivalent
+    let literal = execute_sql(
+        &db,
+        "SELECT * FROM products WHERE tags CONTAINS 'sale' LIMIT 10",
+    )
+    .expect("test: literal CONTAINS query");
+    let params = params_from(&[("tag", json!("sale"))]);
+    let parameterized = execute_sql_with_params(
+        &db,
+        "SELECT * FROM products WHERE tags CONTAINS $tag LIMIT 10",
+        &params,
+    )
+    .expect("test: parameterized CONTAINS query");
+
+    // THEN both return exactly the 'sale' tagged rows {1, 2, 5}
+    assert_eq!(result_ids(&literal), [1, 2, 5].into_iter().collect());
+    assert_eq!(
+        result_ids(&parameterized),
+        result_ids(&literal),
+        "CONTAINS $tag must return the same rows as the literal query"
+    );
+}
+
+#[test]
+fn scenario_where_contains_any_params_matches_literal() {
+    // GIVEN a products collection with array tags
+    let (_dir, db) = create_test_db();
+    setup_products_collection(&db);
+
+    // WHEN filtering with CONTAINS ANY over two parameters
+    let literal = execute_sql(
+        &db,
+        "SELECT * FROM products WHERE tags CONTAINS ANY ('new', 'clearance') LIMIT 10",
+    )
+    .expect("test: literal CONTAINS ANY query");
+    let params = params_from(&[("a", json!("new")), ("b", json!("clearance"))]);
+    let parameterized = execute_sql_with_params(
+        &db,
+        "SELECT * FROM products WHERE tags CONTAINS ANY ($a, $b) LIMIT 10",
+        &params,
+    )
+    .expect("test: parameterized CONTAINS ANY query");
+
+    // THEN both return rows tagged 'new' or 'clearance' {1, 3, 4, 5}
+    assert_eq!(result_ids(&literal), [1, 3, 4, 5].into_iter().collect());
+    assert_eq!(
+        result_ids(&parameterized),
+        result_ids(&literal),
+        "CONTAINS ANY ($a, $b) must return the same rows as the literal query"
+    );
+}
+
+#[test]
+fn scenario_where_contains_missing_param_errors() {
+    // GIVEN a products collection with array tags
+    let (_dir, db) = create_test_db();
+    setup_products_collection(&db);
+
+    // WHEN executing CONTAINS with an unbound parameter
+    let result = execute_sql_with_params(
+        &db,
+        "SELECT * FROM products WHERE tags CONTAINS $tag LIMIT 10",
+        &HashMap::new(),
+    );
+
+    // THEN an explicit missing-parameter error is raised (not an empty result)
+    let err = result.expect_err("missing CONTAINS parameter must be an error");
+    assert!(
+        err.to_string().contains("Missing parameter"),
+        "error should name the missing parameter, got: {err}"
+    );
+}
+
+// =========================================================================
+// Scenarios: HAVING with parameters and subqueries
+// =========================================================================
+
+#[test]
+fn scenario_having_count_param_matches_literal() {
+    // GIVEN a products collection (electronics: 2, books: 2, clothing: 1)
+    let (_dir, db) = create_test_db();
+    setup_products_collection(&db);
+
+    // WHEN filtering groups with a literal HAVING and the parameterized equivalent
+    let literal = execute_aggregate_sql_with_params(
+        &db,
+        "SELECT category, COUNT(*) FROM products GROUP BY category \
+         HAVING COUNT(*) > 1 ORDER BY category",
+        &HashMap::new(),
+    )
+    .expect("test: literal HAVING query");
+    let params = params_from(&[("n", json!(1))]);
+    let parameterized = execute_aggregate_sql_with_params(
+        &db,
+        "SELECT category, COUNT(*) FROM products GROUP BY category \
+         HAVING COUNT(*) > $n ORDER BY category",
+        &params,
+    )
+    .expect("test: parameterized HAVING query");
+
+    // THEN both keep exactly the two groups with more than one row
+    let literal_groups = literal.as_array().expect("test: literal array");
+    assert_eq!(
+        literal_groups.len(),
+        2,
+        "HAVING COUNT(*) > 1 should keep 2 groups, got {literal}"
+    );
+    assert_eq!(
+        parameterized, literal,
+        "HAVING COUNT(*) > $n must keep the same groups as the literal query"
+    );
+}
+
+#[test]
+fn scenario_having_missing_param_errors() {
+    // GIVEN a products collection
+    let (_dir, db) = create_test_db();
+    setup_products_collection(&db);
+
+    // WHEN executing HAVING with an unbound parameter
+    let result = execute_aggregate_sql_with_params(
+        &db,
+        "SELECT category, COUNT(*) FROM products GROUP BY category HAVING COUNT(*) > $n",
+        &HashMap::new(),
+    );
+
+    // THEN an explicit missing-parameter error is raised (not an empty result)
+    let err = result.expect_err("missing HAVING parameter must be an error, not zero groups");
+    assert!(
+        err.to_string().contains("Missing parameter"),
+        "error should name the missing parameter, got: {err}"
+    );
+}
+
+#[test]
+fn scenario_having_scalar_subquery_rejected_by_validation() {
+    // GIVEN a parsed aggregation query whose HAVING threshold is a subquery
+    let query = Parser::parse(
+        "SELECT category, COUNT(*) FROM products GROUP BY category \
+         HAVING COUNT(*) > (SELECT AVG(stock) FROM products)",
+    )
+    .expect("test: HAVING subquery must parse");
+
+    // WHEN validating it (the same gate the server runs before execution)
+    let result = QueryValidator::validate(&query);
+
+    // THEN V010 rejects the subquery instead of silently filtering all groups
+    let err = result.expect_err("HAVING subquery must be rejected by validation");
+    assert!(
+        err.to_string().contains("V010"),
+        "error should carry the V010 subquery code, got: {err}"
     );
 }

--- a/crates/velesdb-core/tests/velesql_spec_corrected_examples.rs
+++ b/crates/velesdb-core/tests/velesql_spec_corrected_examples.rs
@@ -1,0 +1,100 @@
+//! Anti-drift guard for the `docs/VELESQL_SPEC.md` examples corrected during
+//! the 2026-06 documentation alignment sweep.
+//!
+//! `velesql_cheatsheet_docs.rs` parses the cheat sheet wholesale; the spec is
+//! too large and contains deliberate pseudo-grammar fragments, so this guard
+//! pins the *corrected* statements verbatim instead. If the grammar regresses
+//! on one of them — or starts accepting a form the spec documents as invalid —
+//! the spec must be revisited.
+
+use velesdb_core::velesql::{Parser, QueryValidator, ValidationConfig};
+
+/// Statements that the spec now shows and that must keep parsing AND
+/// passing semantic validation with the default configuration.
+const CORRECTED_EXAMPLES: &[&str] = &[
+    // LET + SELECT * (spec "LET Bindings" / "Hybrid Search" examples; the
+    // former `SELECT *, binding AS alias` form is not valid syntax).
+    "LET relevance = 0.7 * vector_score + 0.3 * bm25_score\n\
+     SELECT * FROM documents\n\
+     WHERE vector NEAR $query AND content MATCH 'machine learning'\n\
+     ORDER BY relevance DESC LIMIT 10",
+    // Window ORDER BY on a column (not on an aggregate expression).
+    "SELECT author, year, COUNT(*) AS papers,\n\
+     DENSE_RANK() OVER (PARTITION BY author ORDER BY year DESC) AS recency_rank\n\
+     FROM publications GROUP BY author, year",
+    // Graph predicate anchored on the FROM alias (rule V011).
+    "SELECT * FROM docs AS d\n\
+     WHERE category = 'tech' AND MATCH (d)-[:REL]->(x)\n\
+     LIMIT 10",
+    // Bounded variable-length range at the documented cap.
+    "MATCH (src)-[:LINKS*1..32]->(dst) RETURN dst LIMIT 10",
+    // Plain EXPLAIN remains a parsed statement.
+    "EXPLAIN SELECT * FROM docs WHERE vector NEAR $v AND category = 'tech' LIMIT 10",
+];
+
+/// Forms the spec now documents as invalid; they must keep failing to parse.
+const DOCUMENTED_PARSE_REJECTS: &[&str] = &[
+    // `SELECT *, expr` is not in the grammar (select_list is `*` XOR a list).
+    "SELECT *, relevance AS score FROM documents LIMIT 10",
+    // EXPLAIN ANALYZE is an API-level mode, not a parsed statement.
+    "EXPLAIN ANALYZE SELECT * FROM docs WHERE vector NEAR $v LIMIT 10",
+    // Window ORDER BY only accepts columns or similarity().
+    "SELECT author, COUNT(*) AS papers,\n\
+     DENSE_RANK() OVER (PARTITION BY author ORDER BY COUNT(*) DESC) AS r\n\
+     FROM publications GROUP BY author",
+];
+
+#[test]
+fn corrected_spec_examples_parse_and_validate() {
+    for statement in CORRECTED_EXAMPLES {
+        let query = Parser::parse(statement)
+            .unwrap_or_else(|e| panic!("spec example failed to parse:\n  {statement}\n  {e:?}"));
+        QueryValidator::validate(&query)
+            .unwrap_or_else(|e| panic!("spec example failed validation:\n  {statement}\n  {e:?}"));
+        QueryValidator::enforce_query_complexity(&query, statement, &ValidationConfig::default())
+            .unwrap_or_else(|e| {
+                panic!("spec example exceeded complexity budget:\n  {statement}\n  {e:?}")
+            });
+    }
+}
+
+#[test]
+fn documented_invalid_forms_still_fail_to_parse() {
+    for statement in DOCUMENTED_PARSE_REJECTS {
+        assert!(
+            Parser::parse(statement).is_err(),
+            "spec documents this form as invalid but it now parses:\n  {statement}"
+        );
+    }
+}
+
+#[test]
+fn unbounded_ranges_are_rejected_at_validation() {
+    // `*` and `*2..` map to an open upper bound; the complexity budget
+    // (DEFAULT_MAX_GRAPH_EXPANSION = 32) rejects them inside Parser::parse.
+    for statement in [
+        "MATCH (src)-[:LINKS*]->(dst) RETURN dst LIMIT 10",
+        "MATCH (src)-[:LINKS*2..]->(dst) RETURN dst LIMIT 10",
+    ] {
+        let err = Parser::parse(statement)
+            .expect_err("spec documents open-ended ranges as rejected, but parse accepted");
+        assert!(
+            format!("{err:?}").contains("Graph expansion"),
+            "expected a 'Graph expansion' complexity error for:\n  {statement}\n  got: {err:?}"
+        );
+    }
+}
+
+#[test]
+fn anchor_alias_mismatch_is_rejected_with_v011() {
+    let statement = "SELECT * FROM docs AS d\n\
+         WHERE category = 'tech' AND MATCH (ctx)-[:REL]->(x)\n\
+         LIMIT 10";
+    let query = Parser::parse(statement).expect("anchor-mismatch example must parse");
+    let err = QueryValidator::validate(&query)
+        .expect_err("spec documents anchor mismatch as a V011 validation error");
+    assert!(
+        format!("{err:?}").contains("V011") || format!("{err}").contains("V011"),
+        "expected a V011 error, got: {err:?}"
+    );
+}

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -144,14 +144,13 @@ No dedicated hybrid benchmark suite exists yet. Performance can be estimated fro
 | Dense HNSW search (k=10, 768D) | ~47 µs | hnsw_benchmark |
 | Sparse search (top-10, 10K) | ~57.6 µs | sparse_benchmark::top10_10k_corpus |
 | RRF fusion overhead | negligible (score merging) | -- |
-| **Estimated hybrid total** | **~0.12 ms** | Dense + Sparse + fusion (v1.13.0) |
+
+End-to-end hybrid latency has **not been measured**: there is no hybrid
+benchmark target in `crates/velesdb-core/benches/`, so no end-to-end number
+is claimed. The component micro-benchmarks above suggest the total is
+dominated by the sparse branch.
 
 The RRF fusion step is a simple score merge with no distance computation, so hybrid latency is dominated by the sparse search branch. For workloads where sparse search is the bottleneck, the MaxScore optimization provides early termination on high-selectivity queries.
-
-To run a hybrid search benchmark when available:
-```bash
-cargo bench -p velesdb-core --bench hybrid_benchmark -- --noplot
-```
 
 ---
 

--- a/docs/CONCURRENCY_MODEL.md
+++ b/docs/CONCURRENCY_MODEL.md
@@ -112,17 +112,20 @@ When multiple locks are needed, acquire them in this order:
 
 ### Global Lock Order (HNSW + Storage)
 
-For HNSW index operations that touch vector storage, columnar metadata,
-graph layers, and neighbor lists, the global lock acquisition order is:
+For HNSW index operations that touch the GPU snapshot cache, vector storage,
+the PDX columnar layout, graph layers, and neighbor lists, the global lock
+acquisition order is:
 
 ```
-vectors (rank 10) → columnar (rank 15) → layers (rank 20) → neighbors (rank 30)
+gpu_vectors_snapshot (rank 5) → vectors (rank 10) → columnar (rank 15)
+    → layers (rank 20) → neighbors (rank 30)
 ```
 
 | Lock | Rank | Component | Notes |
 |------|------|-----------|-------|
-| `vectors` | 10 | `ShardedVectors` / `ContiguousVectors` | Acquired first in upsert and search paths |
-| `columnar` | 15 | `ColumnStore` / typed columns | Metadata columns, acquired after vectors |
+| `gpu_vectors_snapshot` | 5 | GPU flat-vector snapshot cache (`Mutex`) | Acquired before `vectors` in the GPU path (`gpu` feature); writers release `vectors` before reacquiring it to invalidate |
+| `vectors` | 10 | `ShardedVectors` / `ContiguousVectors` | Acquired first among the core HNSW locks in upsert and search paths |
+| `columnar` | 15 | `ColumnarVectors` (PDX block-columnar layout of the HNSW vectors) | SIMD-parallel distance layout, acquired after vectors |
 | `layers` | 20 | HNSW layer structure (`RwLock`) | Global graph topology |
 | `neighbors` | 30 | Per-node neighbor lists (`RwLock`) | Fine-grained, acquired last |
 

--- a/docs/STORAGE_FORMAT.md
+++ b/docs/STORAGE_FORMAT.md
@@ -120,6 +120,13 @@ Maps vector IDs to file offsets in the data file.
 └─────────────────────────────────────────────────────────────────┘
 ```
 
+The file is always replaced atomically: a persist writes a fsynced
+`vectors.idx.new` staging file, renames it over `vectors.idx` and fsyncs the
+directory (POSIX), so a crash mid-persist leaves the previous index intact.
+A 0-byte `vectors.idx` (torn in-place rewrite by older versions) is treated
+as absent and the index is rebuilt from WAL replay; any other unreadable
+index fails `open()` as corrupt.
+
 ## Vector WAL (vectors.wal)
 
 Write-Ahead Log for vector durability.
@@ -325,20 +332,33 @@ those versions are still recovered.
 ## Compaction (vectors.dat)
 
 `compact()` rewrites `vectors.dat` without deleted holes, under a staged
-commit protocol executed while holding the WAL lock:
+commit protocol. The staging step (1) runs under the caller's exclusive
+write access to the storage; the WAL lock is held only for the commit
+(steps 2–4), so no writer can append an entry between the data swap and the
+WAL truncation:
 
-1. The compacted data is written to `vectors.dat.tmp` and fsynced; the
-   matching rebuilt index is staged as a fsynced sidecar `vectors.idx.tmp`.
-2. **Commit point**: `vectors.dat.tmp` atomically replaces `vectors.dat`.
+1. *Staging (storage write exclusivity, no WAL lock)*: the compacted data is
+   written to `vectors.dat.tmp` and fsynced; the matching rebuilt index is
+   staged as a fsynced sidecar `vectors.idx.tmp`.
+2. **Commit point** *(WAL lock held from here through step 4)*:
+   `vectors.dat.tmp` atomically replaces `vectors.dat`.
 3. The staged sidecar is promoted onto `vectors.idx` and the directory is
    fsynced (POSIX) so the renames are durable.
 4. The WAL is flushed and **truncated** (`set_len(0)` + fsync) — compaction
    renders all prior WAL entries obsolete.
 
+The promoted `vectors.idx` is the final on-disk index of the compaction:
+no rewrite of it follows the commit. Outside compaction, every
+`vectors.idx` persist (flush, WAL-replay recovery) is itself atomic — staged
+as a fsynced `vectors.idx.new`, renamed over `vectors.idx`, directory
+fsynced — so no crash can leave a torn index next to the truncated WAL.
+
 Crash recovery of a partial compaction: a leftover `vectors.dat.tmp` means the
 commit never happened, so both staged files are discarded (the old state is
 authoritative); a leftover `vectors.idx.tmp` alone means the swap committed,
-so the sidecar is promoted. A non-truncated WAL replayed over the compacted
+so the sidecar is promoted. A leftover `vectors.idx.new` is never promoted
+(it may be torn; the current `vectors.idx`, or WAL replay, is authoritative).
+A non-truncated WAL replayed over the compacted
 file converges, because every STORE record carries the full vector value and
 deletes replay in order.
 

--- a/docs/STORAGE_FORMAT.md
+++ b/docs/STORAGE_FORMAT.md
@@ -16,13 +16,23 @@ VelesDB persists data in a binary format optimized for:
 
 ```
 collection_directory/
-├── config.json         # Collection configuration (JSON)
-├── vectors.bin         # Memory-mapped vector data
-├── vectors.idx         # Vector ID → offset index
-├── vectors.wal         # Vector WAL for durability
-├── payloads.log        # Append-only payload WAL
-├── payloads.snapshot   # Payload index snapshot (optional)
-└── hnsw.bin            # HNSW index (optional)
+├── config.json          # Collection configuration (JSON)
+├── vectors.dat          # Memory-mapped vector data
+├── vectors.idx          # Vector ID → offset index
+├── vectors.wal          # Vector WAL for durability
+├── payloads.log         # Append-only payload WAL
+├── payloads.snapshot    # Payload index snapshot (optional)
+├── native_meta.bin      # HNSW metadata sidecar (dimension, metric, generation)
+├── native_mappings.bin  # HNSW id ↔ internal-index mappings sidecar
+├── native_vectors.bin   # HNSW vector payload sidecar (when vector storage enabled)
+├── native_hnsw.gen      # HNSW save-generation marker
+├── native_hnsw.*        # HNSW graph dump files
+├── edge_store.bin       # Graph edge store (whole-file snapshot, graph collections)
+├── edges.wal            # Graph edge WAL (graph collections)
+├── property_index.bin   # Graph property index (graph collections)
+├── bm25.snapshot        # BM25 full-text index snapshot (when text-indexed)
+├── bm25.wal             # BM25 WAL (when text-indexed)
+└── sparse[-name].{wal,idx,terms,meta}  # Sparse index files (when sparse-indexed)
 ```
 
 ## Configuration File (config.json)
@@ -61,7 +71,7 @@ The `schema_version` field tracks the on-disk format version for forward-compati
 
 This field is validated at collection load time (`Collection::open()`). When a newer VelesDB writes a collection with a higher schema version, older binaries refuse to open it rather than silently corrupting data. The current schema version is defined as `CURRENT_SCHEMA_VERSION = 1` in `crates/velesdb-core/src/collection/types.rs`.
 
-## Vector Storage (vectors.bin)
+## Vector Storage (vectors.dat)
 
 ### Architecture
 
@@ -117,12 +127,20 @@ Write-Ahead Log for vector durability.
 ### WAL Entry Format
 
 ```
-┌─────────────────────────────────────────────────────────────────┐
-│                       WAL ENTRY                                  │
-├──────────┬──────────┬──────────────────────────────────────────┤
-│ Type (1B)│ ID (8B)  │ Data (dimension × 4 bytes)               │
-└──────────┴──────────┴──────────────────────────────────────────┘
+STORE entry:
+┌──────────┬──────────┬──────────┬─────────────────────┬───────────┐
+│ Op (1B)  │ ID (8B)  │ Len (4B) │ Data (Len bytes)    │ CRC32 (4B)│
+│ 0x01     │ u64 LE   │ u32 LE   │ [f32; dimension] LE │ u32 LE    │
+└──────────┴──────────┴──────────┴─────────────────────┴───────────┘
+
+DELETE entry:
+┌──────────┬──────────┬───────────┐
+│ Op (1B)  │ ID (8B)  │ CRC32 (4B)│
+│ 0x02     │ u64 LE   │ u32 LE    │
+└──────────┴──────────┴───────────┘
 ```
+
+The CRC32 covers all preceding fields of the record (`op + id [+ len + data]`).
 
 ### WAL Entry Types
 
@@ -130,6 +148,7 @@ Write-Ahead Log for vector durability.
 |------|-------|-------------|
 | STORE | 0x01 | Vector insertion/update |
 | DELETE | 0x02 | Vector deletion |
+| Legacy compaction marker | 0x04 | Bare byte appended after compaction by earlier versions; carries no payload and is skipped on replay |
 
 ### CRC32 Framing and Bounded Lengths
 
@@ -151,24 +170,34 @@ authoritative for that data).
 
 ## Payload Storage (payloads.log)
 
-Append-only log for JSON payloads.
+Append-only log for JSON payloads. Records are CRC32-protected.
 
 ### Log Entry Format
 
 ```
-┌─────────────────────────────────────────────────────────────────┐
-│                      LOG ENTRY                                   │
-├──────────┬──────────┬──────────┬────────────────────────────────┤
-│ Type (1B)│ ID (8B)  │ Len (4B) │ JSON Data (variable)           │
-└──────────┴──────────┴──────────┴────────────────────────────────┘
+STORE entry:
+┌──────────┬──────────┬──────────┬─────────────────────┬───────────┐
+│ Type (1B)│ ID (8B)  │ Len (4B) │ JSON Data (Len B)   │ CRC32 (4B)│
+│ 0xC3     │ u64 LE   │ u32 LE   │ UTF-8 JSON          │ u32 LE    │
+└──────────┴──────────┴──────────┴─────────────────────┴───────────┘
+
+DELETE entry:
+┌──────────┬──────────┬───────────┐
+│ Type (1B)│ ID (8B)  │ CRC32 (4B)│
+│ 0xC4     │ u64 LE   │ u32 LE    │
+└──────────┴──────────┴───────────┘
 ```
+
+The CRC32 covers all preceding fields of the record.
 
 ### Entry Types
 
 | Type | Value | Description |
 |------|-------|-------------|
-| STORE | 0x01 | Payload insertion/update |
-| DELETE | 0x02 | Payload deletion (tombstone) |
+| STORE | 0xC3 | CRC-protected payload insertion/update |
+| DELETE | 0xC4 | CRC-protected payload deletion (tombstone) |
+| Legacy STORE | 0x01 | Pre-CRC store record (read-compat only) |
+| Legacy DELETE | 0x02 | Pre-CRC delete record (read-compat only) |
 
 ## Payload Snapshot (payloads.snapshot)
 
@@ -240,13 +269,13 @@ All multi-byte integers are stored in **little-endian** format.
 │     │                                                            │
 │     └─── CRC FAIL ► Replay entire payloads.log                   │
 │                                                                  │
-│  3. Load vectors.idx + vectors.bin                               │
+│  3. Load vectors.idx + vectors.dat                               │
 │     │                                                            │
 │     ▼                                                            │
 │  4. Replay vectors.wal (crash-safe order, see below)             │
 │     │                                                            │
 │     ▼                                                            │
-│  5. Load/rebuild HNSW index (load-time validation, see below)    │
+│  5. Create HNSW index (see note below)                           │
 │     │                                                            │
 │     ▼                                                            │
 │  6. Gap detection: compare storage IDs vs HNSW IDs               │
@@ -254,10 +283,15 @@ All multi-byte integers are stored in **little-endian** format.
 │     ├─── Counts match ──► No gap (O(1) fast path)                │
 │     │                                                            │
 │     └─── Gap found ────► Re-index missing vectors into HNSW      │
-│                          (crash during deferred merge recovery)   │
 │                                                                  │
 └─────────────────────────────────────────────────────────────────┘
 ```
+
+> **Note on step 5.** `Collection::open()` only loads a persisted HNSW index
+> when a legacy `hnsw.bin` file is present — a file current versions never
+> write. The `native_*` sidecars written at flush time are therefore not
+> reloaded on this path: in practice the collection starts with an empty HNSW
+> index and step 6 re-indexes all stored vectors (O(N) rebuild at open).
 
 ### Crash-safe WAL replay ordering
 
@@ -283,7 +317,30 @@ Replay distinguishes two failure shapes:
 | **Mid-stream corruption** | A CRC failure followed by further validly framed records (bit-rot / tampering). | Skip the bad record, emit a metric + warning, and continue replaying the later valid entries. |
 
 An unknown opcode mid-stream is treated as a torn tail (framing is no longer
-trustworthy), so replay stops rather than fabricating further entries.
+trustworthy), so replay stops rather than fabricating further entries. One
+exception: a bare `0x04` byte (the legacy compaction marker written by earlier
+versions) is recognized and skipped so post-compaction entries written by
+those versions are still recovered.
+
+## Compaction (vectors.dat)
+
+`compact()` rewrites `vectors.dat` without deleted holes, under a staged
+commit protocol executed while holding the WAL lock:
+
+1. The compacted data is written to `vectors.dat.tmp` and fsynced; the
+   matching rebuilt index is staged as a fsynced sidecar `vectors.idx.tmp`.
+2. **Commit point**: `vectors.dat.tmp` atomically replaces `vectors.dat`.
+3. The staged sidecar is promoted onto `vectors.idx` and the directory is
+   fsynced (POSIX) so the renames are durable.
+4. The WAL is flushed and **truncated** (`set_len(0)` + fsync) — compaction
+   renders all prior WAL entries obsolete.
+
+Crash recovery of a partial compaction: a leftover `vectors.dat.tmp` means the
+commit never happened, so both staged files are discarded (the old state is
+authoritative); a leftover `vectors.idx.tmp` alone means the swap committed,
+so the sidecar is promoted. A non-truncated WAL replayed over the compacted
+file converges, because every STORE record carries the full vector value and
+deletes replay in order.
 
 ## Versioning
 
@@ -326,7 +383,7 @@ VelesDB handles corruption gracefully:
 | Mid-stream WAL CRC failure | Skip the bad record, emit a metric, continue replaying later valid entries |
 | Invalid snapshot CRC | Fall back to full WAL replay |
 | Missing files | Return explicit error |
-| Bitflip in data | Detected via checksum (if enabled) |
+| Bitflip in vector data (`vectors.dat`) | **Not detected** — the raw vector file carries no checksum; CRC32 protection covers WAL records and snapshots only |
 | Out-of-range length/count field | Rejected at load (`InvalidData`); never used to size an allocation |
 
 See `tests/crash_recovery/corruption.rs` for comprehensive corruption tests.

--- a/docs/VELESQL_SPEC.md
+++ b/docs/VELESQL_SPEC.md
@@ -1875,8 +1875,8 @@ The result includes the estimated plan (identical to `EXPLAIN`) plus:
 | `actual_rows` | u64 | Number of rows returned by execution |
 | `actual_time_ms` | f64 | Wall-clock execution time in milliseconds |
 | `loops` | u64 | Number of execution iterations (always 1) |
-| `nodes_visited` | u64 | Graph nodes visited (0 for non-MATCH queries) |
-| `edges_traversed` | u64 | Graph edges traversed (0 for non-MATCH queries) |
+| `nodes_visited` | u64 | For MATCH queries, currently set to the result row count (not a real traversal counter); 0 for non-MATCH queries |
+| `edges_traversed` | u64 | For MATCH queries, currently set to the result row count (not a real traversal counter); 0 for non-MATCH queries |
 
 **`feedback_calibration` fields (v1.15.0+, EXPLAIN ANALYZE only):**
 

--- a/docs/VELESQL_SPEC.md
+++ b/docs/VELESQL_SPEC.md
@@ -110,8 +110,8 @@ The SELECT statement is the primary way to query data from collections.
 ```sql
 [LET <name> = <expr> ...]
 SELECT [DISTINCT] <columns> [, <window_fn>() OVER (...) [AS <alias>] ...]
-FROM <collection> [AS <alias>]
-[JOIN <collection2> [AS <alias>] ON <condition> | USING (<column>)]
+FROM <collection> [[AS] <alias>]
+[JOIN <collection2> [[AS] <alias>] ON <condition> | USING (<column>)]
 [WHERE <conditions>]
 [GROUP BY <columns>]
 [HAVING <aggregate_condition>]
@@ -228,7 +228,11 @@ FROM docs WHERE vector NEAR $v ORDER BY similarity() DESC LIMIT 5
 ## FROM Clause
 
 Specify the source collection. An optional alias enables shorter column references
-and is required for self-joins.
+and is required for self-joins. The `AS` keyword is optional: `FROM documents d`
+and `FROM documents AS d` are strictly equivalent. A bare alias may not be a
+reserved clause keyword (`WHERE`, `GROUP`, `HAVING`, `ORDER`, `LIMIT`, `OFFSET`,
+`WITH`, `USING`, `UNION`, `INTERSECT`, `EXCEPT`, `INNER`, `LEFT`, `RIGHT`,
+`FULL`, `OUTER`, `JOIN`, `ON`, `AS`); quote it (`` `limit` ``) to use one anyway.
 
 ```sql
 -- Simple
@@ -236,6 +240,9 @@ SELECT * FROM my_collection
 
 -- With alias
 SELECT * FROM documents AS d
+
+-- Bare alias (no AS) — identical semantics
+SELECT * FROM documents d
 
 -- Alias used in column references
 SELECT d.title, d.category FROM documents AS d WHERE d.price > 50
@@ -251,8 +258,8 @@ Combine data from multiple collections.
 
 ```sql
 SELECT <columns>
-FROM <table1> [AS <alias1>]
-[INNER | LEFT | RIGHT | FULL] JOIN <table2> [AS <alias2>]
+FROM <table1> [[AS] <alias1>]
+[INNER | LEFT | RIGHT | FULL] JOIN <table2> [[AS] <alias2>]
   ON <alias1>.<col> = <alias2>.<col>
 ```
 
@@ -2577,8 +2584,10 @@ parameterized vector search and `MATCH` normally.
 
 ### Divergences from standard SQL
 
-- **Table aliases require `AS`**: `FROM docs AS d`, not `FROM docs d` (the
-  no-`AS` form is intentionally rejected to avoid ambiguity with `JOIN`).
+- **Bare table aliases reserve clause keywords**: `FROM docs d` and
+  `FROM docs AS d` are both accepted and equivalent, but a bare alias may not
+  be a clause keyword (`WHERE`, `LIMIT`, `JOIN`, `UNION`, ...) — quote it with
+  backticks to use one anyway.
 - **`vector` and `score` are reserved keywords**, not free payload field names —
   `vector NEAR ...` and `score` in aggregates/ordering refer to the query vector
   and the computed similarity score.

--- a/docs/VELESQL_SPEC.md
+++ b/docs/VELESQL_SPEC.md
@@ -84,6 +84,8 @@ equivalent. Identifiers (collection names, column names) are case-sensitive.
 - Conformance test matrix: `docs/reference/VELESQL_CONFORMANCE_MATRIX.md`.
 - Recommended developer syntax for mixed filters:
   `SELECT ... FROM <collection> WHERE ... AND MATCH (...)`.
+  When `FROM` declares an alias, the MATCH anchor must reuse it (rule V011 —
+  see [Graph Match Predicate in WHERE](#graph-match-predicate-in-where)).
 
 ---
 
@@ -914,6 +916,32 @@ LIMIT 10
 This filters rows that participate in the specified graph pattern, combined with
 any other scalar conditions.
 
+**Anchor alias rule (V011).** The first node of the pattern (the *anchor*) must
+carry an alias. When the `FROM` clause (or a `JOIN`) declares an alias, the
+anchor alias must be one of those declared aliases — the pattern is anchored on
+the rows of that table. When `FROM` has no alias, any anchor alias is accepted.
+Violations are rejected at validation time with error code `V011`
+(`MATCH predicate anchor must be an alias declared in FROM/JOIN`):
+
+```sql
+-- OK: anchor 'd' matches the FROM alias
+SELECT * FROM docs AS d
+WHERE category = 'tech' AND MATCH (d)-[:REL]->(x)
+LIMIT 10
+
+-- Rejected with V011: anchor 'ctx' does not match FROM alias 'd'
+SELECT * FROM docs AS d
+WHERE category = 'tech' AND MATCH (ctx)-[:REL]->(x)
+LIMIT 10
+```
+
+**Execution note (over-fetch window).** When a graph predicate is combined with
+`vector NEAR`, the engine over-fetches vector candidates before applying the
+graph filter: it retrieves up to `max(LIMIT, min(LIMIT × 10, 10 000))`
+candidates and keeps those that satisfy the pattern. Rows that match the graph
+pattern but rank beyond this candidate window are not returned. If the graph
+filter is highly selective, increase `LIMIT` to widen the window.
+
 ### Vector Search with Filters
 
 Combine vector search with any number of metadata filters:
@@ -1319,8 +1347,10 @@ Available variables: `vector_score`, `bm25_score`, `graph_score`, `sparse_score`
 
 ```sql
 -- RAG scoring: blend vector similarity with text relevance
+-- (the evaluated binding 'relevance' is injected into each row's payload;
+--  note that `SELECT *, expr` is not valid syntax — use `*` or an explicit list)
 LET relevance = 0.7 * vector_score + 0.3 * bm25_score
-SELECT *, relevance AS score
+SELECT *
 FROM documents
 WHERE vector NEAR $query AND content MATCH 'machine learning'
 ORDER BY relevance DESC
@@ -1579,18 +1609,25 @@ Relationships connect nodes with direction and optional type/range:
 -[r:TYPE1|TYPE2]->               -- Multiple relationship types
 -[*1..3]->                       -- Variable-length (1 to 3 hops)
 -[r:TYPE *2..5]->                -- Named with type and range
--[*]->                           -- Any length
 ```
 
 #### Range Specification
 
-| Syntax | Meaning |
-|--------|---------|
-| `*1..3` | Between 1 and 3 hops |
-| `*..5` | Up to 5 hops |
-| `*2..` | At least 2 hops |
-| `*3` | Exactly 3 hops |
-| `*` | Any number of hops |
+| Syntax | Meaning | Executable |
+|--------|---------|------------|
+| `*1..3` | Between 1 and 3 hops | Yes |
+| `*..5` | Up to 5 hops (lower bound defaults to 1) | Yes |
+| `*3` | Exactly 3 hops | Yes |
+| `*2..` | At least 2 hops, open-ended | Parses, **rejected at validation** |
+| `*` | Any number of hops | Parses, **rejected at validation** |
+
+**Hop bound.** The maximum hop count of any range is capped by the validator at
+`DEFAULT_MAX_GRAPH_EXPANSION = 32` (configurable via
+`ValidationConfig::max_graph_expansion`). Open-ended forms (`*`, `*2..`) map to
+an unbounded upper limit and are therefore always rejected under the default
+configuration with a `Graph expansion exceeded: max=32` complexity error
+(surfaced directly by `Parser::parse`) — use an explicit bounded range such as
+`*1..32` instead.
 
 ### RETURN Clause
 
@@ -1800,10 +1837,22 @@ estimated plan and actual execution statistics side-by-side. Unlike `EXPLAIN`
 > **Caution:** EXPLAIN ANALYZE executes the query. Use with care on write
 > queries (INSERT, UPDATE, DELETE) as they will modify data.
 
-#### Syntax
+#### Invocation
 
-```sql
-EXPLAIN ANALYZE <query>
+`EXPLAIN ANALYZE` is **not a parsed VelesQL statement** — the grammar only
+accepts `EXPLAIN <select-query>`. ANALYZE mode is requested at the API level:
+
+- REST: `POST /query/explain` with `"analyze": true` in the request body.
+- Rust API: `Database::explain_analyze_query(...)` /
+  `Collection::explain_analyze_query(...)`.
+
+```json
+POST /query/explain
+{
+  "query": "SELECT * FROM docs WHERE vector NEAR $v LIMIT 10",
+  "params": { "v": [0.1, 0.2, 0.3] },
+  "analyze": true
+}
 ```
 
 #### Return Fields
@@ -1865,15 +1914,17 @@ When histogram data is available, `Filter` plan nodes include additional fields:
 
 #### Examples
 
-```sql
--- Analyze a vector search query
-EXPLAIN ANALYZE SELECT * FROM docs WHERE vector NEAR $v LIMIT 10
+Queries to analyze are passed in the `query` field of `/query/explain` with
+`"analyze": true` (the `EXPLAIN` keyword itself must not be part of the string):
 
--- Analyze a filtered query
-EXPLAIN ANALYZE SELECT * FROM products WHERE category = 'tech' AND price > 50 LIMIT 20
+```json
+// Analyze a vector search query
+{ "query": "SELECT * FROM docs WHERE vector NEAR $v LIMIT 10",
+  "params": { "v": [0.1, 0.2] }, "analyze": true }
 
--- Analyze a graph traversal
-EXPLAIN ANALYZE MATCH (a:Person)-[:KNOWS]->(b) RETURN a.name, b.name LIMIT 10
+// Analyze a filtered query
+{ "query": "SELECT * FROM products WHERE category = 'tech' AND price > 50 LIMIT 20",
+  "analyze": true }
 ```
 
 After ≥ 10 vector queries against the same collection, the EMA feedback
@@ -2893,9 +2944,10 @@ SELECT * FROM docs
 WHERE vector NEAR $query AND content MATCH 'neural networks'
 LIMIT 10 USING FUSION(strategy = 'rrf', k = 60)
 
--- With custom scoring weights
+-- With custom scoring weights (the evaluated binding 'score' is injected
+-- into each row's payload; `SELECT *, expr` is not valid syntax)
 LET score = 0.7 * vector_score + 0.3 * bm25_score
-SELECT *, score AS relevance
+SELECT *
 FROM documents
 WHERE vector NEAR $query AND content MATCH 'transformer'
 ORDER BY score DESC
@@ -3140,11 +3192,13 @@ DESCRIBE documents
 
 -- View query execution plan without running
 EXPLAIN SELECT * FROM docs WHERE vector NEAR $v AND category = 'tech' LIMIT 10
-
--- Run with instrumentation: get the plan + actual rows / time / per-node stats
--- (v1.15.0+: also returns feedback_calibration once the EMA loop is warm)
-EXPLAIN ANALYZE SELECT * FROM docs WHERE vector NEAR $v AND category = 'tech' LIMIT 10
 ```
+
+For instrumented execution (plan + actual rows / time / per-node stats,
+plus `feedback_calibration` once the EMA loop is warm), use
+`POST /query/explain` with `"analyze": true` — see
+[EXPLAIN ANALYZE](#explain-analyze-v38) above (`EXPLAIN ANALYZE` is not a
+parsed statement).
 
 ### Window Functions
 
@@ -3156,9 +3210,10 @@ FROM articles
 WHERE vector NEAR $query
 LIMIT 50
 
--- Dense rank by an aggregated metric per author
+-- Dense rank per author by publication year (window ORDER BY accepts
+-- columns or similarity(), not aggregate expressions like COUNT(*))
 SELECT author, year, COUNT(*) AS papers,
-       DENSE_RANK() OVER (PARTITION BY author ORDER BY COUNT(*) DESC) AS productivity_rank
+       DENSE_RANK() OVER (PARTITION BY author ORDER BY year DESC) AS recency_rank
 FROM publications
 GROUP BY author, year
 ```

--- a/docs/VELESQL_SPEC.md
+++ b/docs/VELESQL_SPEC.md
@@ -936,11 +936,16 @@ LIMIT 10
 ```
 
 **Execution note (over-fetch window).** When a graph predicate is combined with
-`vector NEAR`, the engine over-fetches vector candidates before applying the
-graph filter: it retrieves up to `max(LIMIT, min(LIMIT × 10, 10 000))`
-candidates and keeps those that satisfy the pattern. Rows that match the graph
-pattern but rank beyond this candidate window are not returned. If the graph
-filter is highly selective, increase `LIMIT` to widen the window.
+a ranked fetch (`vector NEAR` or a `similarity()` threshold), the engine
+over-fetches vector candidates before applying the graph filter: it retrieves
+up to `max(LIMIT, min(LIMIT × 10, 10 000))` candidates and keeps those that
+satisfy the pattern. Rows that match the graph pattern but rank beyond this
+candidate window are not returned. If the graph filter is highly selective,
+increase `LIMIT` to widen the window. Without a ranked fetch (graph predicate
+alone, or combined with metadata filters only), the engine instead scans up to
+100 000 candidates in storage order before applying the graph filter: results
+are exhaustive for collections up to 100 000 points; beyond that bound,
+pattern-matching rows are not returned (unchanged from previous releases).
 
 ### Vector Search with Filters
 

--- a/docs/guides/AGENT_MEMORY.md
+++ b/docs/guides/AGENT_MEMORY.md
@@ -605,7 +605,8 @@ stats = memory.auto_expire()
 ### Behavior
 
 - Expired entries are **filtered from results** on every read surface: the native queries (query, recent, recall) and the `AgentMemory` VelesQL bridges (`query_semantic` / `query_episodic` / `query_procedural`)
-- TTLs assigned at store time (`store_with_ttl` / `record_with_ttl` / `learn_with_ttl`) are **durable**: the expiry is persisted as an `expires_at` (epoch seconds) payload field and the TTL map is rebuilt from payloads when the database is reopened, so TTL'd entries stay mortal across restarts — no snapshot required. TTLs set after the fact via `set_*_ttl` live in memory and persist only through snapshots
+- TTLs assigned at store time (`store_with_ttl` / `record_with_ttl` / `learn_with_ttl`) are **durable**: the expiry is persisted as a reserved `_veles_expires_at` (epoch seconds) payload field and the TTL map is rebuilt from payloads when the database is reopened, so TTL'd entries stay mortal across restarts — no snapshot required. TTLs set after the fact via `set_*_ttl` live in memory and persist only through snapshots
+- `_veles_expires_at` is a **reserved system key**: `store_with_metadata` and `update_metadata` strip it from user metadata, so it can only be written by the `*_with_ttl` store paths. A plain `expires_at` metadata field is ordinary business data — it is stored, filterable, and never interpreted as a TTL
 - `auto_expire()` **physically deletes** expired entries and returns per-subsystem counts
 - Old episodic events can be **consolidated** into semantic memory (configurable via `EvictionConfig`); the migrated fact is stored under a **fresh** semantic id on collision, so consolidation never overwrites an existing semantic fact (see [Snapshots & Restore](#snapshots--restore))
 
@@ -847,8 +848,9 @@ memory.load_latest_snapshot()?;
 >   backing `Database`, but allocates a *fresh* `MemoryTtl` that is **not** wired
 >   to any snapshot manager; `serialize`/`deserialize` carry stored facts and
 >   intentionally omit the TTL map. TTLs assigned via `store_with_ttl` persist
->   their `expires_at` in the point payload and are rebuilt at reopen, so
->   store-time expiry **survives restarts**; map-only TTLs do not.
+>   their expiry in the reserved `_veles_expires_at` payload field and are
+>   rebuilt at reopen, so store-time expiry **survives restarts**; map-only
+>   TTLs do not.
 > - **WASM** — a fully standalone, DB-less `SemanticMemory::new(dim)` exists
 >   (no auto-snapshot, no auto-load, payloads are not serialized).
 > - **Python** has no standalone `SemanticMemory` constructor — it is reachable

--- a/docs/guides/AGENT_MEMORY.md
+++ b/docs/guides/AGENT_MEMORY.md
@@ -604,7 +604,8 @@ stats = memory.auto_expire()
 
 ### Behavior
 
-- Expired entries are **filtered from results** (query, recent, recall)
+- Expired entries are **filtered from results** on every read surface: the native queries (query, recent, recall) and the `AgentMemory` VelesQL bridges (`query_semantic` / `query_episodic` / `query_procedural`)
+- TTLs assigned at store time (`store_with_ttl` / `record_with_ttl` / `learn_with_ttl`) are **durable**: the expiry is persisted as an `expires_at` (epoch seconds) payload field and the TTL map is rebuilt from payloads when the database is reopened, so TTL'd entries stay mortal across restarts — no snapshot required. TTLs set after the fact via `set_*_ttl` live in memory and persist only through snapshots
 - `auto_expire()` **physically deletes** expired entries and returns per-subsystem counts
 - Old episodic events can be **consolidated** into semantic memory (configurable via `EvictionConfig`); the migrated fact is stored under a **fresh** semantic id on collision, so consolidation never overwrites an existing semantic fact (see [Snapshots & Restore](#snapshots--restore))
 
@@ -837,7 +838,9 @@ memory.load_latest_snapshot()?;
 > - **Rust core** — `SemanticMemory::new_from_db(db, dim)` still requires a
 >   backing `Database`, but allocates a *fresh* `MemoryTtl` that is **not** wired
 >   to any snapshot manager; `serialize`/`deserialize` carry stored facts and
->   intentionally omit TTL state, so expiry is **lost on restart**.
+>   intentionally omit the TTL map. TTLs assigned via `store_with_ttl` persist
+>   their `expires_at` in the point payload and are rebuilt at reopen, so
+>   store-time expiry **survives restarts**; map-only TTLs do not.
 > - **WASM** — a fully standalone, DB-less `SemanticMemory::new(dim)` exists
 >   (no auto-snapshot, no auto-load, payloads are not serialized).
 > - **Python** has no standalone `SemanticMemory` constructor — it is reachable

--- a/docs/guides/AGENT_MEMORY.md
+++ b/docs/guides/AGENT_MEMORY.md
@@ -745,13 +745,18 @@ decay setting yet.
 
 ### Throughput
 
-| Operation | Latency | Note |
-|-----------|---------|------|
-| `semantic.store()` | ~50 us | HNSW upsert |
-| `semantic.query()` | ~500 us (10K facts) | HNSW search k=10 |
-| `episodic.recent()` | ~10 us | B-tree index O(log N) |
-| `episodic.recall_similar()` | ~500 us (10K events) | HNSW search |
-| `procedural.recall()` | ~500 us (1K procs) | HNSW + confidence filter |
+> **Order-of-magnitude estimates, not measurements.** There is no agent-memory
+> benchmark in `crates/velesdb-core/benches/`; the figures below are derived
+> from the cost class of the underlying operation (HNSW search/upsert, B-tree
+> lookup) and should be treated as rough guidance only.
+
+| Operation | Estimated latency | Note |
+|-----------|------------------|------|
+| `semantic.store()` | tens of µs | HNSW upsert |
+| `semantic.query()` | hundreds of µs (10K facts) | HNSW search k=10 |
+| `episodic.recent()` | ~10 µs | B-tree index O(log N) |
+| `episodic.recall_similar()` | hundreds of µs (10K events) | HNSW search |
+| `procedural.recall()` | hundreds of µs (1K procs) | HNSW + confidence filter |
 
 ### Recommended Limits
 
@@ -774,7 +779,10 @@ decay setting yet.
 
 - `AgentMemory` is **thread-safe**: uses `Arc<Database>` + `parking_lot::RwLock`
 - Multiple threads can **read** simultaneously (query, recent, recall)
-- **Writes** (store, record, learn, reinforce) are serialized
+- Individual **storage writes** (store, record, learn) are serialized by the
+  underlying locks. Read-modify-write operations (`reinforce`,
+  `store_unique`, `snapshot`) are **not atomic**: two concurrent calls on the
+  same id can interleave between the read and the write (last writer wins)
 - No deadlock risk (deterministic lock ordering)
 
 ```python
@@ -954,13 +962,15 @@ Yes. VelesDB uses a Write-Ahead Log (WAL) with fsync. Data is durable as soon as
 Yes. Multiple `AgentMemory` instances on the same `Database` share the same collections. Useful for multi-threading.
 
 **Q: Does the SDK work in WASM or on mobile?**
-The **embedded** SDK (Python/Rust) requires the `persistence` feature (mmap, filesystem), which is disabled for WASM, so embedded agent memory does not run in-browser. The browser/WASM build of the TypeScript SDK does not support agent memory either (`capabilities().agentMemory` is `false` for the WASM backend). To use agent memory from JavaScript, point the SDK at a `velesdb-server` over **REST** (`backend: 'rest'`). Mobile support is possible via native bindings but not yet documented.
+The **embedded** SDK (Python/Rust) requires the `persistence` feature (mmap, filesystem), which is disabled for WASM, so embedded agent memory does not run in-browser. The browser/WASM build of the TypeScript SDK does not support agent memory either (`capabilities().agentMemory` is `false` for the WASM backend). To use agent memory from JavaScript, point the SDK at a `velesdb-server` over **REST** (`backend: 'rest'`).
+
+On **mobile** (iOS/Android via UniFFI, `velesdb-mobile`), a semantic-only surface ships as `VelesSemanticMemory`: `new(db, dimension)` (backed by a `_semantic_memory` collection), `store(id, content, embedding)`, `query(embedding, top_k)`, `len()`, `is_empty()`, `delete(id)`. Episodic/procedural memory, TTL, and snapshots are not exposed on mobile.
 
 **Q: How do I migrate from another memory system?**
 Export your data (text + embeddings) and import via `semantic.store()` / `episodic.record()` / `procedural.learn()`. There is no automated migration tool.
 
 **Q: Is this production-ready?**
-Yes. The SDK is covered end-to-end by Rust and Python test suites, including concurrent access, snapshot round-trips, TTL expiration, and reinforcement strategies.
+Yes. The SDK is covered end-to-end by Rust and Python test suites, including snapshot round-trips, TTL expiration (including across restarts), and reinforcement strategies. Concurrent access is exercised by a smoke test; see the Thread Safety section above for the atomicity caveats on read-modify-write operations.
 
 ---
 

--- a/docs/guides/PYTHON_PERFORMANCE.md
+++ b/docs/guides/PYTHON_PERFORMANCE.md
@@ -37,9 +37,12 @@ call — it compounds quickly when you issue thousands of queries per second.
 
 ### Use `upsert_bulk_numpy()` for batch inserts
 
-`upsert_bulk_numpy()` uses a zero-copy path: the flat `f32` buffer from the numpy
-array is passed directly to the core engine, eliminating per-row `Vec<f32>`
-allocations. For 100 000 vectors at 768D this avoids ~293 MB of intermediate copies.
+`upsert_bulk_numpy()` reads the flat `f32` buffer from the numpy array in place
+(no per-row conversion), then makes **one** contiguous copy of it so the GIL can
+be released while the core engine inserts. This replaces 100 000 small per-row
+`Vec<f32>` allocations with a single bulk copy — far fewer allocator round-trips
+and Python-object conversions, though the transient copy itself still costs
+`n × dimension × 4` bytes (~293 MB for 100 000 × 768D) until the call returns.
 
 ```python
 import numpy as np
@@ -86,7 +89,7 @@ your data is shaped, not by intuition.
 |--------|-------------|-----------------|-------------|
 | `upsert([{...}, ...])` | List of point dicts | List + dict + Vec | Small ad-hoc inserts, payload-heavy data, < 100 points |
 | `upsert_bulk([{...}, ...])` | List of point dicts | Vec only (no per-row PyDict→struct) | Medium batches without numpy already in memory |
-| `upsert_bulk_numpy(arr, ids)` | numpy `(n, dim)` float32 + ids | **Zero-copy** flat buffer | Large numpy-native pipelines (embeddings, model output) |
+| `upsert_bulk_numpy(arr, ids)` | numpy `(n, dim)` float32 + ids | **One flat-buffer copy** (no per-row copies) | Large numpy-native pipelines (embeddings, model output) |
 
 **Throughput rule of thumb on a 384D collection** (i9-class CPU, fresh collection,
 no payload):
@@ -95,11 +98,12 @@ no payload):
 |--------|----------------|--------------------------------------|
 | `upsert` (list of dicts) | ~5 000 vec/s | +~600 MB (list + dict + Vec copies) |
 | `upsert_bulk` (list of dicts) | ~12 000 vec/s | +~300 MB (Vec copies only) |
-| `upsert_bulk_numpy` | ~17 000 vec/s | +~7 MB (zero-copy, only the per-batch ids vec) |
+| `upsert_bulk_numpy` | ~17 000 vec/s | + one transient flat-buffer copy (`n × dim × 4` bytes, ~293 MB per 100K @ 768D, freed when the call returns) |
 
-For a 100 000-vector batch at 768D, `upsert_bulk_numpy` saves roughly 293 MB of
-intermediate copies compared to the list-of-dicts paths. The savings grow
-linearly with `n × dimension`.
+Compared to the list-of-dicts paths, `upsert_bulk_numpy` eliminates all
+per-row Python-object conversions and `Vec` allocations; the remaining cost is
+a single bulk copy of the flat buffer (made so the GIL can be released during
+the insert). Chunking (below) bounds that transient copy.
 
 **Memory tuning when batches are very large (> 50 000):** chunk into 5 000-row
 sub-batches. The total throughput is identical (~17 000 vec/s) but peak RSS
@@ -372,7 +376,7 @@ for i, vec in enumerate(vectors):
 points = [{"id": i, "vector": vectors[i].tolist()} for i in range(N)]
 collection.upsert_bulk(points)
 
-# Fast: zero-copy path, GIL released for the entire insert
+# Fast: no per-row copies (single flat-buffer copy), GIL released for the insert
 ids = list(range(N))
 collection.upsert_bulk_numpy(vectors, ids)
 ```

--- a/docs/guides/QUANTIZATION.md
+++ b/docs/guides/QUANTIZATION.md
@@ -165,6 +165,14 @@ OPQ applique une rotation orthogonale aux vecteurs avant la quantification PQ. C
 
 ## RaBitQ : Randomized Binary Quantization (32x)
 
+> **Statut : non branché dans le chemin de requête des collections.**
+> `TRAIN QUANTIZER 'rabitq'` entraîne et persiste `rabitq.idx`, mais aucun
+> chemin de recherche de collection ne charge cet index aujourd'hui : les
+> recherches continuent sur les vecteurs f32 (les collections forcent le mode
+> de stockage `Full`). Le backend RaBitQ existe au niveau de l'API d'index
+> (`RaBitQPrecisionHnsw`) pour un usage programmatique direct. Les chiffres de
+> recall ci-dessous décrivent cette API, pas une requête `SELECT` standard.
+
 ### Comment ca marche ?
 
 RaBitQ combine la compression binaire (1-bit par dimension) avec une **rotation orthogonale aleatoire** qui preserve les distances. Contrairement a la quantification binaire naive, la rotation orthogonale distribue l'information de maniere plus uniforme sur tous les bits.

--- a/docs/reference/ARCHITECTURE.md
+++ b/docs/reference/ARCHITECTURE.md
@@ -58,8 +58,8 @@ VelesDB core architecture is explicitly **hybrid by design**:
 │  │  Cosine  │  Euclidean  │  Dot Product  │  Hamming  │  Jaccard   │   │
 │  │  (33.1ns)│   (22.5ns)  │    (19.8ns)   │  (35.8ns) │   (35.1ns) │   │
 │  │                                                                  │   │
-│  │  AVX2/AVX-512 │ WASM SIMD128 │ ARM64 NEON │ Auto-vectorization │   │
-│  │               │              │ (simd_neon)│     Fallback       │   │
+│  │  AVX2/AVX-512 │ ARM64 NEON │ Scalar fallback (incl. WASM —    │   │
+│  │               │ (simd_neon)│ SIMD128 planned)                 │   │
 │  └─────────────────────────────────────────────────────────────────┘   │
 │                                                                          │
 └────────────────────────────────────┬────────────────────────────────────┘
@@ -93,7 +93,7 @@ VelesDB core architecture is explicitly **hybrid by design**:
 
 #### velesdb-wasm
 - WebAssembly module for browser/Node.js
-- SIMD128 optimized distance calculations
+- Scalar distance calculations (SIMD128 kernels planned)
 - IndexedDB persistence via binary export/import
 - ~50KB gzipped
 
@@ -269,7 +269,7 @@ VelesDB core architecture is explicitly **hybrid by design**:
 **SIMD Strategy**:
 1. **Native (x86_64)**: AVX2/AVX-512 via `core::arch` intrinsics with 4-accumulator ILP
 2. **Native (aarch64)**: NEON 128-bit with 1-acc/4-acc variants
-3. **WASM**: SIMD128 (128-bit vectors)
+3. **WASM**: scalar fallback (SIMD128 kernels planned; `wasm32` dispatches to `SimdLevel::Scalar`)
 4. **Fallback**: Scalar with loop unrolling
 
 ### 6. Storage Layer
@@ -311,8 +311,9 @@ Query Vector
          │
          ▼
 ┌─────────────────┐
-│  Filter Engine  │ (if filters present)
-│  (ColumnStore)  │
+│  Filter Engine  │ (if filters present:
+│ (secondary idx +│  secondary indexes + JSON
+│  JSON filters)  │  payload filters)
 └────────┬────────┘
          │
          ▼
@@ -464,8 +465,8 @@ LIMIT 20 USING FUSION(strategy='rrf', k=60)
 | Windows x86_64 | ✅ Full | AVX2 | 100% |
 | macOS x86_64 | ✅ Full | AVX2 | 100% |
 | **macOS ARM64** | ✅ Full | **NEON** | **~90%** |
-| WASM (Browser) | ✅ Full | SIMD128 | ~70% |
-| WASM (Node.js) | ✅ Full | SIMD128 | ~70% |
+| WASM (Browser) | ✅ Full | Scalar (SIMD128 planned) | ~70% |
+| WASM (Node.js) | ✅ Full | Scalar (SIMD128 planned) | ~70% |
 | **iOS (ARM64)** | ✅ Full | NEON | ~90% |
 | **Android (ARM64)** | ✅ Full | NEON | ~90% |
 | **Android (ARMv7)** | ✅ Full | Fallback | ~70% |

--- a/docs/reference/ARCHITECTURE_DIAGRAMS.md
+++ b/docs/reference/ARCHITECTURE_DIAGRAMS.md
@@ -200,7 +200,7 @@ graph LR
         MAC_A[macOS aarch64<br/>NEON]
         IOS[iOS aarch64<br/>NEON]
         ANDROID[Android<br/>arm64/armv7/x86_64]
-        BROWSER[Browser<br/>WASM SIMD128]
+        BROWSER[Browser<br/>WASM scalar - SIMD128 planned]
     end
 
     subgraph "Crates"

--- a/docs/reference/SIMD_PERFORMANCE.md
+++ b/docs/reference/SIMD_PERFORMANCE.md
@@ -32,7 +32,7 @@ The `simd_native` module provides hand-tuned SIMD implementations using `core::a
 | **x86_64 AVX-512** | simd_native | 512-bit 2/4-acc | ~38-42ns |
 | **x86_64 AVX2** | simd_native | 256-bit 2/4-acc | ~40-82ns |
 | **aarch64** | simd_native | NEON 128-bit | ~60-100ns |
-| **WASM** | wide_simd | SIMD128 | ~80-120ns |
+| **WASM** | scalar fallback (SIMD128 planned) | Native Rust | see Fallback |
 | **Fallback** | Scalar | Native Rust | ~150-200ns |
 
 ### Tiered Dispatch Strategy (EPIC-077)

--- a/docs/reference/VELESQL_CHEATSHEET.md
+++ b/docs/reference/VELESQL_CHEATSHEET.md
@@ -182,9 +182,10 @@ FROM items;
 ## Joins & set operations
 
 ```sql
--- INNER JOIN across collections (alias requires AS).
+-- INNER JOIN across collections (AS is optional: `docs d` == `docs AS d`).
 -- The joined (right) table must be matched on its primary key `id`.
 SELECT d.name, t.tag FROM docs AS d JOIN tags AS t ON d.tag_id = t.id;
+SELECT d.name, t.tag FROM docs d JOIN tags t ON d.tag_id = t.id;
 
 -- Set operations
 SELECT * FROM a UNION SELECT * FROM b;
@@ -236,4 +237,6 @@ FLUSH FULL docs;
 | Max payload size | configurable (`limits.max_payload_size`) |
 
 > Reserved words: `vector` and `score` are language keywords, not free payload
-> field names. Table aliases require `AS` (`FROM docs AS d`, not `FROM docs d`).
+> field names. Table aliases accept both forms: `FROM docs AS d` and
+> `FROM docs d`. A bare alias may not be a clause keyword (`WHERE`, `LIMIT`,
+> `ORDER`, ...); quote it with backticks to use one anyway.

--- a/docs/reference/VELESQL_CHEATSHEET.md
+++ b/docs/reference/VELESQL_CHEATSHEET.md
@@ -139,6 +139,11 @@ RETURN dst LIMIT 100;
 SELECT * FROM docs
 WHERE category = 'tech' AND MATCH (d:Doc)-[:REL]->(x)
 LIMIT 10;
+
+-- With a FROM alias, the MATCH anchor must reuse it (validation rule V011)
+SELECT * FROM docs AS d
+WHERE category = 'tech' AND MATCH (d)-[:REL]->(x)
+LIMIT 10;
 ```
 
 ---

--- a/docs/reference/VELESQL_CONTRACT.md
+++ b/docs/reference/VELESQL_CONTRACT.md
@@ -68,6 +68,14 @@ Rules:
 - For graph-only execution, `/collections/{name}/match` remains supported.
 - `SELECT ... WHERE ... AND MATCH (...)` is supported and does not require
   `collection` in body when `FROM <collection>` is present.
+- The MATCH anchor (first node of the pattern) must carry an alias; when the
+  `FROM`/`JOIN` clauses declare aliases, the anchor alias must be one of them.
+  Violations fail validation with error code `V011`. When `FROM` has no alias,
+  any anchor alias is accepted.
+- Execution note: combined with `vector NEAR`, graph predicates are applied as
+  a filter over an over-fetched candidate window of
+  `max(LIMIT, min(LIMIT × 10, 10 000))` vector candidates; pattern-matching
+  rows ranked beyond that window are not returned.
 
 Success response shape:
 

--- a/docs/reference/VELESQL_CONTRACT.md
+++ b/docs/reference/VELESQL_CONTRACT.md
@@ -72,10 +72,13 @@ Rules:
   `FROM`/`JOIN` clauses declare aliases, the anchor alias must be one of them.
   Violations fail validation with error code `V011`. When `FROM` has no alias,
   any anchor alias is accepted.
-- Execution note: combined with `vector NEAR`, graph predicates are applied as
-  a filter over an over-fetched candidate window of
-  `max(LIMIT, min(LIMIT × 10, 10 000))` vector candidates; pattern-matching
-  rows ranked beyond that window are not returned.
+- Execution note: combined with `vector NEAR` (or a `similarity()` threshold),
+  graph predicates are applied as a filter over an over-fetched candidate
+  window of `max(LIMIT, min(LIMIT × 10, 10 000))` ranked vector candidates;
+  pattern-matching rows ranked beyond that window are not returned. Without a
+  ranked fetch, the candidate scan is bounded at 100 000 points (storage
+  order); collections larger than that may miss pattern-matching rows beyond
+  the bound (unchanged from previous releases).
 
 Success response shape:
 

--- a/docs/reference/promise-contract.json
+++ b/docs/reference/promise-contract.json
@@ -32,7 +32,7 @@
       "id": "core_readme_columnstore_claim",
       "file": "crates/velesdb-core/README.md",
       "must_contain": "ColumnStore filtering",
-      "validation_command": "cargo bench -p velesdb-core --bench filter_benchmark"
+      "validation_command": "cargo bench -p velesdb-core --bench column_filter_benchmark"
     },
     {
       "id": "readme_simd_dot_product_latency",
@@ -94,7 +94,7 @@
       "id": "readme_columnstore_130x_claim",
       "file": "README.md",
       "must_contain": "130x faster",
-      "validation_command": "cargo bench -p velesdb-core --bench filter_benchmark",
+      "validation_command": "cargo bench -p velesdb-core --bench column_filter_benchmark",
       "source": "README.md: JSON scan 3.84ms vs ColumnStore 29.5us at 100K rows",
       "last_updated": "2026-04-13"
     },
@@ -143,7 +143,7 @@
       "id": "readme_columnstore_speedup_baseline_rows",
       "file": "README.md",
       "must_contain": "100K rows",
-      "validation_command": "cargo bench -p velesdb-core --bench filter_benchmark",
+      "validation_command": "cargo bench -p velesdb-core --bench column_filter_benchmark",
       "source": "README.md ColumnStore 130x speedup baseline. Footnote *¹ documents holding range (10K-1M rows within ±5%).",
       "last_updated": "2026-05-01"
     }

--- a/docs/reference/promise-contract.json
+++ b/docs/reference/promise-contract.json
@@ -144,8 +144,8 @@
       "file": "README.md",
       "must_contain": "100K rows",
       "validation_command": "cargo bench -p velesdb-core --bench column_filter_benchmark",
-      "source": "README.md ColumnStore 130x speedup baseline. Footnote *¹ documents holding range (10K-1M rows within ±5%).",
-      "last_updated": "2026-05-01"
+      "source": "README.md ColumnStore 130x speedup baseline. Footnote *¹ scopes the claim: filtering-API micro-benchmark, integer equality, 130x at 100K rows / 55x at 10K rows (docs/BENCHMARKS.md section 6); no 1M-row measurement exists.",
+      "last_updated": "2026-06-10"
     }
   ]
 }

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -537,6 +537,13 @@ Get detailed collection configuration (dimension, metric, storage mode, point co
 
 Execute a VelesQL query. Supports SELECT, WHERE, vector NEAR, GROUP BY, HAVING, ORDER BY, JOIN, UNION/INTERSECT/EXCEPT, and USING FUSION.
 
+> **Backend support:** full VelesQL execution requires the **REST backend** (`velesdb-server`).
+> The WASM backend only executes pure top-k vector queries of the form
+> `SELECT * FROM <collection> WHERE <column> NEAR $param [LIMIT n]` and throws a
+> `NOT_SUPPORTED` error for anything else (WHERE predicates, JOIN, GROUP BY, MATCH,
+> set operations, FUSION) instead of silently ignoring clauses. Accordingly,
+> `db.capabilities().velesqlQuery` is `false` on WASM.
+
 ```typescript
 // Vector similarity search
 const result = await db.query(

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -545,7 +545,8 @@ Execute a VelesQL query. Supports SELECT, WHERE, vector NEAR, GROUP BY, HAVING, 
 
 > **Backend support:** full VelesQL execution requires the **REST backend** (`velesdb-server`).
 > The WASM backend only executes pure top-k vector queries of the form
-> `SELECT * FROM <collection> WHERE <column> NEAR $param [LIMIT n]` and throws a
+> `SELECT * FROM <collection> WHERE vector NEAR $param [LIMIT n]` (`vector` is the
+> grammar keyword, not a column name) and throws a
 > `NOT_SUPPORTED` error for anything else (WHERE predicates, JOIN, GROUP BY, MATCH,
 > set operations, FUSION) instead of silently ignoring clauses. Accordingly,
 > `db.capabilities().velesqlQuery` is `false` on WASM.

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -30,7 +30,7 @@ Official TypeScript SDK for [VelesDB](https://github.com/cyberlife-coder/VelesDB
 ### Previous (v1.13.0)
 
 - **WASM VelesQL executor** -- full browser-side VelesQL execution: SELECT/INSERT/UPDATE/DELETE/DDL + aggregations (COUNT/SUM/AVG/MIN/MAX) + GROUP BY/HAVING/UNION/INTERSECT/EXCEPT/JOIN/FUSION/MATCH 1-2 hops + NOT De Morgan distribution
-- **TS SDK coverage raised to 94%** -- 423 tests, per-file thresholds codified in `vitest.config.ts`
+- **TS SDK coverage raised** -- per-file thresholds codified in `vitest.config.ts` (423 tests as of v1.13.0; the vitest suite has since grown past 770 cases). Note: the suite runs locally via `npm test` and is not currently executed in CI
 - **SIFT1M standardized ANN benchmark** -- fvecs/ivecs loader + Criterion ef sweep on the INRIA TEXMEX dataset, feature-gated behind `--features bench-sift1m`
 - **Security hardening** -- `validateCollectionName()` helper on TS SDK prevents VelesQL injection in `trainPq`
 - **API consistency** -- `streamInsert` now serializes `payload: null` explicitly (matches `streamUpsertPoints`)

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -160,7 +160,13 @@ const queryVector = new Float32Array(1536).fill(0.1);
 const results = await db.search('products', queryVector, { k: 10 });
 ```
 
-> **REST backend note:** Document IDs must be numeric integers in the range `0..Number.MAX_SAFE_INTEGER`. String IDs are only supported with the WASM backend.
+> **REST backend note:** Document IDs must be non-negative `u64` integers. Pass a JS
+> number in the range `0..Number.MAX_SAFE_INTEGER`, or a decimal string for the full
+> `u64` range — string ids above 2^53-1 (up to `18446744073709551615`) are kept
+> verbatim on the wire, so the ids returned by `recordEvent`/`learnProcedure`
+> round-trip through `get`/`delete` without precision loss. Exception: the NDJSON
+> bulk endpoint (`streamUpsertPoints`) only accepts safe-range numeric ids.
+> Arbitrary (non-numeric) string IDs are only supported with the WASM backend.
 
 > **Versioned routes:** The REST backend uses `/v1/` as the canonical route prefix
 > (e.g. `POST /v1/collections/{name}/search`). Legacy routes without the prefix

--- a/sdks/typescript/src/backends/agent-memory-backend.ts
+++ b/sdks/typescript/src/backends/agent-memory-backend.ts
@@ -15,6 +15,7 @@ import type {
   ProceduralPattern,
   EpisodicRecord,
 } from '../types';
+import { ValidationError } from '../types';
 import type { BaseTransport } from './shared';
 import { throwOnError, collectionPath } from './shared';
 import { parseRestPointId } from './crud-backend';
@@ -79,22 +80,36 @@ export function _resetIdState(): void {
  * precision loss — matching the project's documented string-id convention for
  * u64 (see `/search/scroll`, graph node/edge ids).
  */
-export function memoryIdToString(id: number): string {
+export function memoryIdToString(id: number | string): string {
   return String(id);
 }
 
+/** Largest value a u64 point id can take (`u64::MAX`). */
+const U64_MAX = 18446744073709551615n;
+
 /**
- * Normalise a caller-provided point id into the numeric u64 the REST wire
- * accepts. Accepts a `string | number`; a string must be a decimal integer.
+ * Normalise a caller-provided point id into the form the REST wire accepts.
  *
- * A thin intent-revealing alias over {@link parseRestPointId}, which owns the
- * string→number coercion and the range/integer validation ("non-negative
- * integer within the JS safe-integer range") in exactly one place. The REST
- * server deserialises point ids as JSON numbers, so ids above
- * `Number.MAX_SAFE_INTEGER` cannot be transmitted and are rejected rather than
- * silently corrupted.
+ * Numbers and decimal strings within the JS safe-integer range are funnelled
+ * through {@link parseRestPointId}, which owns the string→number coercion and
+ * the "non-negative integer" validation in exactly one place. Decimal strings
+ * above `Number.MAX_SAFE_INTEGER` (2^53-1) are forwarded verbatim as strings:
+ * since #1004 the server deserialises point ids from either JSON numbers or
+ * strings (`serde_id::deserialize_id_from_string_or_number`), so a string id
+ * survives the JavaScript boundary without precision loss. Strings beyond
+ * `u64::MAX` and non-decimal inputs are rejected.
  */
-export function resolveWireId(id: string | number): number {
+export function resolveWireId(id: string | number): string | number {
+  if (typeof id === 'string' && /^\d+$/.test(id)) {
+    const big = BigInt(id);
+    if (big > U64_MAX) {
+      throw new ValidationError(`Point id exceeds u64::MAX (${U64_MAX}): ${id}`);
+    }
+    if (big > BigInt(Number.MAX_SAFE_INTEGER)) {
+      // Precision-critical id — keep the exact decimal string on the wire.
+      return id;
+    }
+  }
   return parseRestPointId(id);
 }
 

--- a/sdks/typescript/src/backends/agent-memory-backend.ts
+++ b/sdks/typescript/src/backends/agent-memory-backend.ts
@@ -15,7 +15,6 @@ import type {
   ProceduralPattern,
   EpisodicRecord,
 } from '../types';
-import { ValidationError } from '../types';
 import type { BaseTransport } from './shared';
 import { throwOnError, collectionPath } from './shared';
 import { parseRestPointId } from './crud-backend';
@@ -69,7 +68,8 @@ export function _resetIdState(): void {
 }
 
 // ---------------------------------------------------------------------------
-// String <-> u64 id boundary (single source of truth)
+// String <-> u64 id boundary (inbound validation lives in `parseRestPointId`,
+// the single gate shared with the CRUD backend and the client layer)
 // ---------------------------------------------------------------------------
 
 /**
@@ -82,35 +82,6 @@ export function _resetIdState(): void {
  */
 export function memoryIdToString(id: number | string): string {
   return String(id);
-}
-
-/** Largest value a u64 point id can take (`u64::MAX`). */
-const U64_MAX = 18446744073709551615n;
-
-/**
- * Normalise a caller-provided point id into the form the REST wire accepts.
- *
- * Numbers and decimal strings within the JS safe-integer range are funnelled
- * through {@link parseRestPointId}, which owns the string→number coercion and
- * the "non-negative integer" validation in exactly one place. Decimal strings
- * above `Number.MAX_SAFE_INTEGER` (2^53-1) are forwarded verbatim as strings:
- * since #1004 the server deserialises point ids from either JSON numbers or
- * strings (`serde_id::deserialize_id_from_string_or_number`), so a string id
- * survives the JavaScript boundary without precision loss. Strings beyond
- * `u64::MAX` and non-decimal inputs are rejected.
- */
-export function resolveWireId(id: string | number): string | number {
-  if (typeof id === 'string' && /^\d+$/.test(id)) {
-    const big = BigInt(id);
-    if (big > U64_MAX) {
-      throw new ValidationError(`Point id exceeds u64::MAX (${U64_MAX}): ${id}`);
-    }
-    if (big > BigInt(Number.MAX_SAFE_INTEGER)) {
-      // Precision-critical id — keep the exact decimal string on the wire.
-      return id;
-    }
-  }
-  return parseRestPointId(id);
 }
 
 /** Current unix time in **seconds** (floor of epoch-millis / 1000). */
@@ -132,7 +103,7 @@ export async function storeSemanticFact(
     `${collectionPath(collection)}/points`,
     {
       points: [{
-        id: resolveWireId(entry.id),
+        id: parseRestPointId(entry.id),
         vector: entry.embedding,
         payload: {
           // Caller metadata is spread first so the reserved keys below
@@ -164,7 +135,7 @@ export async function recordEpisodicEvent(
   collection: string,
   event: EpisodicEvent
 ): Promise<string> {
-  const id = event.id !== undefined ? resolveWireId(event.id) : generateUniqueId();
+  const id = event.id !== undefined ? parseRestPointId(event.id) : generateUniqueId();
   const timestamp = event.timestamp ?? nowUnixSeconds();
 
   const response = await transport.requestJson(
@@ -208,7 +179,7 @@ export async function storeProceduralPattern(
   collection: string,
   pattern: ProceduralPattern
 ): Promise<string> {
-  const id = pattern.id !== undefined ? resolveWireId(pattern.id) : generateUniqueId();
+  const id = pattern.id !== undefined ? parseRestPointId(pattern.id) : generateUniqueId();
 
   const response = await transport.requestJson(
     'POST',

--- a/sdks/typescript/src/backends/crud-backend.ts
+++ b/sdks/typescript/src/backends/crud-backend.ts
@@ -25,27 +25,58 @@ import {
 /** Minimal transport interface for CRUD operations. */
 export type CrudTransport = BaseTransport;
 
+/** Largest value a u64 point id can take (`u64::MAX`). */
+const U64_MAX = 18446744073709551615n;
+
+/**
+ * Coerce a decimal-string id for the shared gate in {@link parseRestPointId}.
+ *
+ * Only a plain run of digits is accepted — no sign, whitespace, decimal
+ * point, exponent, or hex — so '' / '  ' / '1e3' / '0x10' map to `NaN`
+ * (rejected by the caller) instead of silently coercing (`Number('')` would
+ * otherwise become 0). Digit-strings within the JS safe-integer range become
+ * numbers; digit-strings in (2^53-1, u64::MAX] are returned verbatim so the
+ * exact decimal value survives the JavaScript boundary without precision
+ * loss. Digit-strings above `u64::MAX` map to `NaN` (rejected).
+ */
+function coerceDecimalStringId(id: string): number | string {
+  if (!/^\d+$/.test(id)) return NaN;
+  const big = BigInt(id);
+  if (big > U64_MAX) return NaN;
+  return big > BigInt(Number.MAX_SAFE_INTEGER) ? id : Number(id);
+}
+
+/**
+ * Single validation gate for REST point ids — used by the CRUD/streaming
+ * backends, the client layer (`validateRestPointId`) and the agent-memory
+ * helpers.
+ *
+ * Numeric ids must be non-negative integers within the JS safe-integer range.
+ * Decimal-string ids (e.g. the u64-safe strings returned by the agent-memory
+ * record/learn helpers) are coerced to numbers when exactly representable and
+ * kept as verbatim strings above 2^53-1: since #1004 the server deserialises
+ * point ids in request bodies from either JSON numbers or strings, and path
+ * params (`/points/{id}`) parse the full u64 range, so every id that
+ * `storeFact` / `recordEvent` / `learnProcedure` accepts round-trips through
+ * `get` / `delete` symmetrically.
+ */
 export function parseRestPointId(id: string | number): RestPointId {
-  // A decimal-string id (e.g. the u64-safe strings returned by the agent-memory
-  // record/learn helpers) is coerced to a number before range validation, so
-  // string and numeric ids share one validation gate. Only a plain run of
-  // digits is accepted — no sign, whitespace, decimal point, exponent, or hex —
-  // so '' / '  ' / '1e3' / '0x10' are rejected instead of silently coercing
-  // (`Number('')` would otherwise become 0).
-  const numeric =
-    typeof id === 'string' ? (/^\d+$/.test(id) ? Number(id) : NaN) : id;
+  const coerced = typeof id === 'string' ? coerceDecimalStringId(id) : id;
+  if (typeof coerced === 'string') {
+    // Precision-critical decimal string — keep it verbatim on the wire.
+    return coerced;
+  }
   if (
-    typeof numeric !== 'number' ||
-    !Number.isFinite(numeric) ||
-    numeric < 0 ||
-    !Number.isInteger(numeric) ||
-    numeric > Number.MAX_SAFE_INTEGER
+    !Number.isFinite(coerced) ||
+    coerced < 0 ||
+    !Number.isInteger(coerced) ||
+    coerced > Number.MAX_SAFE_INTEGER
   ) {
     throw new ValidationError(
-      `REST backend requires numeric u64-compatible IDs in JS safe integer range (0..${Number.MAX_SAFE_INTEGER}). Received: ${String(id)}`
+      `REST backend requires numeric u64-compatible IDs: a non-negative integer in the JS safe integer range (0..${Number.MAX_SAFE_INTEGER}) or a decimal string up to u64::MAX (${U64_MAX}). Received: ${String(id)}`
     );
   }
-  return numeric;
+  return coerced;
 }
 
 export function sparseVectorToRestFormat(sv: SparseVector): Record<string, number> {

--- a/sdks/typescript/src/backends/streaming-backend.ts
+++ b/sdks/typescript/src/backends/streaming-backend.ts
@@ -12,7 +12,7 @@ import type {
   RestPointId,
   StreamUpsertResponse,
 } from '../types';
-import { BackpressureError, ConnectionError, VelesDBError } from '../types';
+import { BackpressureError, ConnectionError, ValidationError, VelesDBError } from '../types';
 import type { BaseTransport } from './shared';
 import {
   throwOnError,
@@ -154,6 +154,24 @@ export async function streamInsert(
 }
 
 /**
+ * Reject precision-critical string ids on the NDJSON bulk path.
+ *
+ * The `/points/stream` endpoint deserialises each line into core `Point`,
+ * whose id is a plain JSON-number u64 (no string-or-number deserialiser), so
+ * a string id (> 2^53-1, kept verbatim by `parseRestPointId`) must fail fast
+ * here instead of being forwarded and counted as `malformed` by the server.
+ */
+function requireSafeRangeId(restId: RestPointId): number {
+  if (typeof restId === 'string') {
+    throw new ValidationError(
+      `streamUpsertPoints requires ids in the JS safe integer range (0..${Number.MAX_SAFE_INTEGER}); ` +
+        `use upsert/upsertBatch for string ids above it. Received: ${restId}`
+    );
+  }
+  return restId;
+}
+
+/**
  * Batch upsert points via the NDJSON streaming endpoint.
  *
  * Sends all documents as a single `application/x-ndjson` POST to
@@ -176,7 +194,7 @@ export async function streamUpsertPoints(
   docs: VectorDocument[]
 ): Promise<StreamUpsertResponse> {
   const ndjsonLines = docs.map(doc => {
-    const restId = transport.parseRestPointId(doc.id);
+    const restId = requireSafeRangeId(transport.parseRestPointId(doc.id));
     const vector = toNumberArray(doc.vector);
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/sdks/typescript/src/backends/wasm-search.ts
+++ b/sdks/typescript/src/backends/wasm-search.ts
@@ -286,10 +286,62 @@ export async function wasmMultiQuerySearch(
 // Query (VelesQL over WASM)
 // ---------------------------------------------------------------------------
 
+/**
+ * The only VelesQL shape the WASM backend can execute faithfully: a pure
+ * top-k NEAR scan — `SELECT * FROM <collection> WHERE <column> NEAR $param
+ * [LIMIT n]` (case-insensitive, optional trailing semicolon).
+ *
+ * `VectorStore.query()` is a brute-force k-NN that evaluates no other
+ * clause. Anything else (WHERE predicates, JOIN, GROUP BY, MATCH, set
+ * operations, FUSION, …) must be rejected loudly instead of silently
+ * dropping clauses and returning unfiltered neighbours.
+ */
+const PURE_NEAR_QUERY =
+  /^\s*select\s+\*\s+from\s+([a-z_]\w*)\s+where\s+[a-z_]\w*\s+near\s+\$([a-z_]\w*)\s*(?:limit\s+(\d+))?\s*;?\s*$/i;
+
+interface PureNearQuery {
+  /** Collection named in the FROM clause. */
+  from: string;
+  /** Name of the `$param` holding the query embedding. */
+  param: string;
+  /** `LIMIT n` value when present. */
+  limit?: number;
+}
+
+/** Parse `queryString` against the pure-NEAR shape or throw `NOT_SUPPORTED`. */
+function parsePureNearQuery(queryString: string): PureNearQuery {
+  const match = PURE_NEAR_QUERY.exec(queryString);
+  if (!match) {
+    throw new VelesDBError(
+      'The WASM backend only executes pure top-k NEAR queries of the form ' +
+        '"SELECT * FROM <collection> WHERE <column> NEAR $param [LIMIT n]". ' +
+        'WHERE predicates, JOIN, GROUP BY, MATCH, set operations and FUSION ' +
+        'are not evaluated in WASM — use the REST backend (velesdb-server) ' +
+        `for full VelesQL. Received: ${queryString}`,
+      'NOT_SUPPORTED'
+    );
+  }
+  const parsed: PureNearQuery = { from: match[1]!, param: match[2]! };
+  if (match[3] !== undefined) {
+    parsed.limit = Number(match[3]);
+  }
+  return parsed;
+}
+
+/** Resolve top-k: `LIMIT` from the query wins, then `params.k`, then 10. */
+function resolveQueryK(limit: number | undefined, requestedK: unknown): number {
+  if (limit !== undefined) {
+    return limit;
+  }
+  return typeof requestedK === 'number' && Number.isInteger(requestedK) && requestedK > 0
+    ? requestedK
+    : 10;
+}
+
 export async function wasmQuery(
   ctx: WasmContext,
   collectionName: string,
-  _queryString: string,
+  queryString: string,
   params?: Record<string, unknown>,
   _options?: QueryOptions
 ): Promise<QueryApiResponse> {
@@ -297,18 +349,21 @@ export async function wasmQuery(
   if (!collection) {
     throw new NotFoundError(`Collection '${collectionName}'`);
   }
-  const paramsVector = params?.q;
-  if (!Array.isArray(paramsVector) && !(paramsVector instanceof Float32Array)) {
+  const parsed = parsePureNearQuery(queryString);
+  if (parsed.from !== collectionName) {
     throw new VelesDBError(
-      'WASM query() expects params.q to contain the query embedding vector.',
+      `Query targets collection '${parsed.from}' but was executed against '${collectionName}'.`,
       'BAD_REQUEST'
     );
   }
-  const requestedK = params?.k;
-  const k =
-    typeof requestedK === 'number' && Number.isInteger(requestedK) && requestedK > 0
-      ? requestedK
-      : 10;
+  const paramsVector = params?.[parsed.param];
+  if (!Array.isArray(paramsVector) && !(paramsVector instanceof Float32Array)) {
+    throw new VelesDBError(
+      `WASM query() expects params.${parsed.param} to contain the query embedding vector.`,
+      'BAD_REQUEST'
+    );
+  }
+  const k = resolveQueryK(parsed.limit, params?.k);
   const raw: Record<string, unknown>[] = collection.store.query(
     paramsVector instanceof Float32Array ? paramsVector : new Float32Array(paramsVector),
     k

--- a/sdks/typescript/src/backends/wasm-search.ts
+++ b/sdks/typescript/src/backends/wasm-search.ts
@@ -288,8 +288,14 @@ export async function wasmMultiQuerySearch(
 
 /**
  * The only VelesQL shape the WASM backend can execute faithfully: a pure
- * top-k NEAR scan — `SELECT * FROM <collection> WHERE <column> NEAR $param
+ * top-k NEAR scan — `SELECT * FROM <collection> WHERE vector NEAR $param
  * [LIMIT n]` (case-insensitive, optional trailing semicolon).
+ *
+ * `vector` is the literal keyword from the grammar
+ * (`vector_search = { ^"vector" ~ ^"NEAR" ~ vector_value }`), not a column
+ * name — any other identifier left of NEAR is a parse error on
+ * velesdb-server, so it must be rejected here too or the query would work
+ * in WASM and break on REST.
  *
  * `VectorStore.query()` is a brute-force k-NN that evaluates no other
  * clause. Anything else (WHERE predicates, JOIN, GROUP BY, MATCH, set
@@ -297,7 +303,7 @@ export async function wasmMultiQuerySearch(
  * dropping clauses and returning unfiltered neighbours.
  */
 const PURE_NEAR_QUERY =
-  /^\s*select\s+\*\s+from\s+([a-z_]\w*)\s+where\s+[a-z_]\w*\s+near\s+\$([a-z_]\w*)\s*(?:limit\s+(\d+))?\s*;?\s*$/i;
+  /^\s*select\s+\*\s+from\s+([a-z_]\w*)\s+where\s+vector\s+near\s+\$([a-z_]\w*)\s*(?:limit\s+(\d+))?\s*;?\s*$/i;
 
 interface PureNearQuery {
   /** Collection named in the FROM clause. */
@@ -314,7 +320,7 @@ function parsePureNearQuery(queryString: string): PureNearQuery {
   if (!match) {
     throw new VelesDBError(
       'The WASM backend only executes pure top-k NEAR queries of the form ' +
-        '"SELECT * FROM <collection> WHERE <column> NEAR $param [LIMIT n]". ' +
+        '"SELECT * FROM <collection> WHERE vector NEAR $param [LIMIT n]". ' +
         'WHERE predicates, JOIN, GROUP BY, MATCH, set operations and FUSION ' +
         'are not evaluated in WASM — use the REST backend (velesdb-server) ' +
         `for full VelesQL. Received: ${queryString}`,

--- a/sdks/typescript/src/capabilities.ts
+++ b/sdks/typescript/src/capabilities.ts
@@ -100,7 +100,7 @@ export const REST_CAPABILITIES: Readonly<CapabilityMap> = Object.freeze({
  * of `wasmNotSupported()` throw sites.
  *
  * `velesqlQuery` is `false`: `query()` only executes pure top-k NEAR
- * statements (`SELECT * FROM <collection> WHERE <column> NEAR $param
+ * statements (`SELECT * FROM <collection> WHERE vector NEAR $param
  * [LIMIT n]`) and throws `NOT_SUPPORTED` for any other VelesQL clause
  * (WHERE predicates, JOIN, GROUP BY, MATCH, set operations, FUSION),
  * so full VelesQL is not advertised.

--- a/sdks/typescript/src/capabilities.ts
+++ b/sdks/typescript/src/capabilities.ts
@@ -93,11 +93,17 @@ export const REST_CAPABILITIES: Readonly<CapabilityMap> = Object.freeze({
  * Capability map for the WASM backend.
  *
  * The WASM build ships a focused subset: the dense / text / hybrid /
- * multi-query search paths plus VelesQL execution. Everything that
- * relies on persistent on-disk structures (secondary indexes, graph,
- * streaming, PQ training, agent memory, introspection, sparse
- * inverted index) is explicitly `false`. See `backends/wasm-stubs.ts`
- * for the exact set of `wasmNotSupported()` throw sites.
+ * multi-query search paths. Everything that relies on persistent
+ * on-disk structures (secondary indexes, graph, streaming, PQ
+ * training, agent memory, introspection, sparse inverted index) is
+ * explicitly `false`. See `backends/wasm-stubs.ts` for the exact set
+ * of `wasmNotSupported()` throw sites.
+ *
+ * `velesqlQuery` is `false`: `query()` only executes pure top-k NEAR
+ * statements (`SELECT * FROM <collection> WHERE <column> NEAR $param
+ * [LIMIT n]`) and throws `NOT_SUPPORTED` for any other VelesQL clause
+ * (WHERE predicates, JOIN, GROUP BY, MATCH, set operations, FUSION),
+ * so full VelesQL is not advertised.
  */
 export const WASM_CAPABILITIES: Readonly<CapabilityMap> = Object.freeze({
   vectorSearch: true,
@@ -111,6 +117,6 @@ export const WASM_CAPABILITIES: Readonly<CapabilityMap> = Object.freeze({
   agentMemory: false,
   streamInsert: false,
   pqTraining: false,
-  velesqlQuery: true,
+  velesqlQuery: false,
   collectionIntrospection: false,
 });

--- a/sdks/typescript/src/client/validation.ts
+++ b/sdks/typescript/src/client/validation.ts
@@ -56,8 +56,9 @@ export function validateRestPointId(id: string | number, config: VelesDBConfig):
   if (config.backend !== 'rest') {
     return;
   }
-  // Delegate to the canonical backend gate so the string→number coercion and
-  // the "non-negative integer within JS safe-integer range" rule for REST point
-  // ids live in exactly one place (it throws `ValidationError` on a bad id).
+  // Delegate to the canonical backend gate so the id rules — non-negative
+  // integers in the JS safe-integer range, plus verbatim decimal strings up to
+  // u64::MAX — live in exactly one place (it throws `ValidationError` on a
+  // bad id).
   parseRestPointId(id);
 }

--- a/sdks/typescript/src/types/core.ts
+++ b/sdks/typescript/src/types/core.ts
@@ -17,8 +17,15 @@ export type SearchQuality = 'fast' | 'balanced' | 'accurate' | 'perfect' | 'auto
 /** Backend type for VelesDB connection */
 export type BackendType = 'wasm' | 'rest';
 
-/** Numeric point ID required by velesdb-server REST API (`u64`). */
-export type RestPointId = number;
+/**
+ * Point ID accepted by the velesdb-server REST API (`u64`).
+ *
+ * Ids within the JS safe-integer range are numbers; decimal-string ids above
+ * `Number.MAX_SAFE_INTEGER` (2^53-1) stay verbatim strings so the full u64
+ * range survives the JavaScript boundary without precision loss (the server
+ * deserialises both forms since #1004).
+ */
+export type RestPointId = number | string;
 
 /** Configuration options for VelesDB client */
 export interface VelesDBConfig {

--- a/sdks/typescript/tests/agent-memory.test.ts
+++ b/sdks/typescript/tests/agent-memory.test.ts
@@ -391,13 +391,48 @@ describe('Agent Memory REST methods', () => {
       expect(id).toBe(big);
     });
 
-    it('rejects a caller id beyond 2^53 rather than silently corrupting it', async () => {
-      // 2^53 + 1 cannot be represented exactly as a JS number; the REST wire
-      // only accepts JSON numbers, so this must throw, not lose precision.
-      const tooBig = '9007199254740993';
+    it('forwards a caller string id beyond 2^53 as a string rather than corrupting it', async () => {
+      mockFetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({}) });
+
+      // 2^53 + 1 cannot be represented exactly as a JS number. Since #1004
+      // the server deserialises point ids from JSON strings too, so the id
+      // is forwarded verbatim as a string — precision-safe — instead of
+      // being rejected.
+      const beyondSafe = '9007199254740993';
+      const id = await backend.storeProceduralPattern('patterns', {
+        id: beyondSafe, name: 'p', steps: ['a'], embedding: [0.1],
+      });
+
+      const point = JSON.parse(mockFetch.mock.calls[0][1].body).points[0];
+      expect(point.id).toBe(beyondSafe); // string on the wire — no precision loss
+      expect(id).toBe(beyondSafe);
+    });
+
+    it('forwards u64::MAX as a string id', async () => {
+      mockFetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({}) });
+
+      const u64Max = '18446744073709551615';
+      const id = await backend.recordEpisodicEvent('events', {
+        id: u64Max, eventType: 'x', embedding: [0.1], data: {},
+      });
+
+      const point = JSON.parse(mockFetch.mock.calls[0][1].body).points[0];
+      expect(point.id).toBe(u64Max);
+      expect(id).toBe(u64Max);
+    });
+
+    it('rejects a string id beyond u64::MAX', async () => {
       await expect(
         backend.storeProceduralPattern('patterns', {
-          id: tooBig, name: 'p', steps: ['a'], embedding: [0.1],
+          id: '18446744073709551616', name: 'p', steps: ['a'], embedding: [0.1],
+        })
+      ).rejects.toThrow();
+    });
+
+    it('still rejects a numeric id beyond 2^53 (not exactly representable)', async () => {
+      await expect(
+        backend.storeProceduralPattern('patterns', {
+          id: Number.MAX_SAFE_INTEGER + 2, name: 'p', steps: ['a'], embedding: [0.1],
         })
       ).rejects.toThrow();
     });

--- a/sdks/typescript/tests/agent-memory.test.ts
+++ b/sdks/typescript/tests/agent-memory.test.ts
@@ -216,6 +216,43 @@ describe('Agent Memory REST methods', () => {
         await expect(backend.delete('events', bad)).rejects.toThrow(/numeric u64/);
       }
     });
+
+    it('round-trips an id beyond 2^53: recordEvent then delete by the returned string id', async () => {
+      mockFetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({}) });
+
+      // store accepts ids up to u64::MAX as decimal strings; the very same
+      // string handed back to the caller must be deletable, otherwise the
+      // memory is write-only over (2^53, u64::MAX].
+      const u64Max = '18446744073709551615';
+      const id = await backend.recordEpisodicEvent('events', {
+        id: u64Max, eventType: 'x', embedding: [0.1], data: {},
+      });
+      expect(id).toBe(u64Max);
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ deleted: true }),
+      });
+      const result = await backend.delete('events', id);
+
+      expect(result).toBe(true);
+      const url = mockFetch.mock.calls[1][0] as string;
+      // The exact decimal string travels verbatim in the path param.
+      expect(url).toMatch(/\/points\/18446744073709551615$/);
+    });
+
+    it('should get a point by a string id beyond 2^53 via the verbatim path param', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ id: '18446744073709551615', vector: [0.1] }),
+      });
+
+      const doc = await backend.get('events', '18446744073709551615');
+
+      expect(doc).not.toBeNull();
+      const url = mockFetch.mock.calls[0][0] as string;
+      expect(url).toMatch(/\/points\/18446744073709551615$/);
+    });
   });
 
   describe('recordEpisodicEvent (Issue #7)', () => {

--- a/sdks/typescript/tests/capabilities.test.ts
+++ b/sdks/typescript/tests/capabilities.test.ts
@@ -71,15 +71,14 @@ describe('REST_CAPABILITIES — full-feature contract', () => {
 });
 
 describe('WASM_CAPABILITIES — focused subset', () => {
-  it('supports the core search paths + VelesQL execution', () => {
+  it('supports the core search paths', () => {
     expect(WASM_CAPABILITIES.vectorSearch).toBe(true);
     expect(WASM_CAPABILITIES.textSearch).toBe(true);
     expect(WASM_CAPABILITIES.hybridSearch).toBe(true);
     expect(WASM_CAPABILITIES.multiQuerySearch).toBe(true);
-    expect(WASM_CAPABILITIES.velesqlQuery).toBe(true);
   });
 
-  it('does NOT support persistent / graph / streaming features', () => {
+  it('does NOT support persistent / graph / streaming / VelesQL features', () => {
     expect(WASM_CAPABILITIES.sparseSearch).toBe(false);
     expect(WASM_CAPABILITIES.scroll).toBe(false);
     expect(WASM_CAPABILITIES.graphTraversal).toBe(false);
@@ -87,6 +86,9 @@ describe('WASM_CAPABILITIES — focused subset', () => {
     expect(WASM_CAPABILITIES.agentMemory).toBe(false);
     expect(WASM_CAPABILITIES.streamInsert).toBe(false);
     expect(WASM_CAPABILITIES.pqTraining).toBe(false);
+    // query() only executes pure top-k NEAR statements — full VelesQL is
+    // not advertised so callers route VelesQL workloads to REST upfront.
+    expect(WASM_CAPABILITIES.velesqlQuery).toBe(false);
     expect(WASM_CAPABILITIES.collectionIntrospection).toBe(false);
   });
 });

--- a/sdks/typescript/tests/streaming-backend.test.ts
+++ b/sdks/typescript/tests/streaming-backend.test.ts
@@ -12,7 +12,8 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { streamUpsertPoints } from '../src/backends/streaming-backend';
-import { BackpressureError, ConnectionError, VelesDBError } from '../src/types';
+import { parseRestPointId } from '../src/backends/crud-backend';
+import { BackpressureError, ConnectionError, ValidationError, VelesDBError } from '../src/types';
 import { buildTransport } from './helpers/build-streaming-transport';
 
 const mockFetch = vi.fn();
@@ -66,6 +67,21 @@ describe('streamUpsertPoints', () => {
     expect(lines.length).toBe(2);
     expect(JSON.parse(lines[0]!)).toEqual({ id: 1, vector: [1.0, 0.0, 0.0], payload: { title: 'A' } });
     expect(JSON.parse(lines[1]!)).toEqual({ id: 2, vector: [0.0, 1.0, 0.0], payload: { title: 'B' } });
+  });
+
+  it('rejects string ids beyond 2^53 client-side (NDJSON Point ids are plain u64 numbers)', async () => {
+    // The /points/stream endpoint deserialises each line into core `Point`,
+    // whose id is a plain JSON-number u64 (no string-or-number deserialiser).
+    // A precision-critical string id must therefore fail fast here instead of
+    // being forwarded and silently counted as `malformed` by the server.
+    const transport = buildTransport({ parseRestPointId });
+
+    await expect(
+      streamUpsertPoints(transport, 'test-col', [
+        { id: '18446744073709551615', vector: [1.0, 0.0, 0.0] },
+      ])
+    ).rejects.toThrow(ValidationError);
+    expect(mockFetch).not.toHaveBeenCalled();
   });
 
   it('should omit Authorization header when no apiKey', async () => {

--- a/sdks/typescript/tests/validation.test.ts
+++ b/sdks/typescript/tests/validation.test.ts
@@ -26,6 +26,17 @@ describe('validateRestPointId', () => {
     expect(() => validateRestPointId('12345', rest)).not.toThrow();
   });
 
+  it('accepts decimal-string ids above 2^53 up to u64::MAX (store/delete symmetry)', () => {
+    // recordEvent/learnProcedure accept and return these ids; delete/get must
+    // accept the very same strings or the memory becomes write-only.
+    expect(() => validateRestPointId('9007199254740993', rest)).not.toThrow();
+    expect(() => validateRestPointId('18446744073709551615', rest)).not.toThrow();
+  });
+
+  it('rejects decimal-string ids beyond u64::MAX', () => {
+    expect(() => validateRestPointId('18446744073709551616', rest)).toThrow(ValidationError);
+  });
+
   it('rejects malformed string ids instead of coercing them', () => {
     for (const bad of ['', '   ', '1e3', '0x10', '-5', '12.5', '12abc']) {
       expect(() => validateRestPointId(bad, rest)).toThrow(ValidationError);

--- a/sdks/typescript/tests/wasm-search.test.ts
+++ b/sdks/typescript/tests/wasm-search.test.ts
@@ -459,6 +459,11 @@ describe('wasmQuery — VelesQL faithfulness guard', () => {
     ['UNION', 'SELECT * FROM docs UNION SELECT * FROM archived'],
     ['FUSION', "SELECT * FROM docs LIMIT 20 USING FUSION(strategy = 'rrf', k = 60)"],
     ['inline NEAR literal', 'SELECT * FROM docs WHERE vector NEAR [0.1, 0.2]'],
+    // The pest grammar only admits the literal `vector` keyword left of NEAR
+    // (`vector_search = { ^"vector" ~ ^"NEAR" ~ vector_value }`); a column
+    // identifier is a guaranteed parse error on velesdb-server, so accepting
+    // it in WASM would recreate the WASM-works/REST-breaks divergence.
+    ['column identifier NEAR', 'SELECT * FROM docs WHERE embedding NEAR $q LIMIT 5'],
   ])('rejects %s queries with NOT_SUPPORTED instead of raw k-NN', async (_label, sql) => {
     const query = vi.fn(() => []);
     const store = buildStore({ query });
@@ -506,7 +511,7 @@ describe('wasmQuery — VelesQL faithfulness guard', () => {
     const store = buildStore({ query });
     const ctx = buildCtx('docs', store);
 
-    await wasmQuery(ctx, 'docs', 'SELECT * FROM docs WHERE embedding NEAR $vec', {
+    await wasmQuery(ctx, 'docs', 'SELECT * FROM docs WHERE vector NEAR $vec', {
       vec: [0.1, 0.2],
     });
     expect(query).toHaveBeenLastCalledWith(expect.any(Float32Array), 10);

--- a/sdks/typescript/tests/wasm-search.test.ts
+++ b/sdks/typescript/tests/wasm-search.test.ts
@@ -377,10 +377,12 @@ describe('wasmQuery', () => {
     );
   });
 
+  const PURE_NEAR = 'SELECT * FROM docs WHERE vector NEAR $q';
+
   it('throws BAD_REQUEST when params.q is not a vector', async () => {
     const ctx = buildCtx('docs', buildStore());
-    await expect(wasmQuery(ctx, 'docs', 'q', {})).rejects.toThrow(VelesDBError);
-    await expect(wasmQuery(ctx, 'docs', 'q', {})).rejects.toThrow(
+    await expect(wasmQuery(ctx, 'docs', PURE_NEAR, {})).rejects.toThrow(VelesDBError);
+    await expect(wasmQuery(ctx, 'docs', PURE_NEAR, {})).rejects.toThrow(
       /params\.q/
     );
   });
@@ -390,10 +392,10 @@ describe('wasmQuery', () => {
     const store = buildStore({ query });
     const ctx = buildCtx('docs', store);
 
-    await wasmQuery(ctx, 'docs', 'q', { q: [0.1, 0.2] });
+    await wasmQuery(ctx, 'docs', PURE_NEAR, { q: [0.1, 0.2] });
     expect(query).toHaveBeenCalledWith(expect.any(Float32Array), 10);
 
-    await wasmQuery(ctx, 'docs', 'q', {
+    await wasmQuery(ctx, 'docs', PURE_NEAR, {
       q: new Float32Array([0.1, 0.2]),
       k: 5,
     });
@@ -405,13 +407,13 @@ describe('wasmQuery', () => {
     const store = buildStore({ query });
     const ctx = buildCtx('docs', store);
 
-    await wasmQuery(ctx, 'docs', 'q', { q: [0.1, 0.2], k: -5 });
+    await wasmQuery(ctx, 'docs', PURE_NEAR, { q: [0.1, 0.2], k: -5 });
     expect(query).toHaveBeenLastCalledWith(expect.any(Float32Array), 10);
 
-    await wasmQuery(ctx, 'docs', 'q', { q: [0.1, 0.2], k: 3.5 });
+    await wasmQuery(ctx, 'docs', PURE_NEAR, { q: [0.1, 0.2], k: 3.5 });
     expect(query).toHaveBeenLastCalledWith(expect.any(Float32Array), 10);
 
-    await wasmQuery(ctx, 'docs', 'q', { q: [0.1, 0.2], k: 0 });
+    await wasmQuery(ctx, 'docs', PURE_NEAR, { q: [0.1, 0.2], k: 0 });
     expect(query).toHaveBeenLastCalledWith(expect.any(Float32Array), 10);
   });
 
@@ -420,10 +422,104 @@ describe('wasmQuery', () => {
     const store = buildStore({ query: vi.fn(() => raw) });
     const ctx = buildCtx('docs', store);
 
-    const out = await wasmQuery(ctx, 'docs', 'q', { q: [0.1, 0.2] });
+    const out = await wasmQuery(ctx, 'docs', PURE_NEAR, { q: [0.1, 0.2] });
     expect(out.results).toBe(raw);
     expect(out.stats.strategy).toBe('wasm-query');
     expect(out.stats.scannedNodes).toBe(2);
     expect(out.stats.executionTimeMs).toBe(0);
+  });
+});
+
+describe('wasmQuery — VelesQL faithfulness guard', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('never silently drops a WHERE filter: rejects and does not run raw k-NN', async () => {
+    const query = vi.fn(() => [{ id: 1 }, { id: 2 }]);
+    const store = buildStore({ query });
+    const ctx = buildCtx('docs', store);
+
+    const err: unknown = await wasmQuery(
+      ctx,
+      'docs',
+      "SELECT * FROM docs WHERE category='tech' AND vector NEAR $q",
+      { q: [0.1, 0.2] }
+    ).catch((e: unknown) => e);
+
+    expect(err).toBeInstanceOf(VelesDBError);
+    expect((err as VelesDBError).code).toBe('NOT_SUPPORTED');
+    expect((err as VelesDBError).message).toMatch(/REST/);
+    expect(query).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['JOIN', 'SELECT * FROM docs JOIN other ON docs.id = other.id WHERE vector NEAR $q'],
+    ['GROUP BY', 'SELECT category, COUNT(*) FROM docs GROUP BY category'],
+    ['MATCH', 'SELECT * FROM docs MATCH (a)-[:LINKS]->(b) WHERE vector NEAR $q'],
+    ['ORDER BY', 'SELECT * FROM docs WHERE vector NEAR $q ORDER BY id'],
+    ['UNION', 'SELECT * FROM docs UNION SELECT * FROM archived'],
+    ['FUSION', "SELECT * FROM docs LIMIT 20 USING FUSION(strategy = 'rrf', k = 60)"],
+    ['inline NEAR literal', 'SELECT * FROM docs WHERE vector NEAR [0.1, 0.2]'],
+  ])('rejects %s queries with NOT_SUPPORTED instead of raw k-NN', async (_label, sql) => {
+    const query = vi.fn(() => []);
+    const store = buildStore({ query });
+    const ctx = buildCtx('docs', store);
+
+    const err: unknown = await wasmQuery(ctx, 'docs', sql, { q: [0.1, 0.2] }).catch(
+      (e: unknown) => e
+    );
+
+    expect(err).toBeInstanceOf(VelesDBError);
+    expect((err as VelesDBError).code).toBe('NOT_SUPPORTED');
+    expect(query).not.toHaveBeenCalled();
+  });
+
+  it('rejects a query whose FROM targets a different collection', async () => {
+    const query = vi.fn(() => []);
+    const store = buildStore({ query });
+    const ctx = buildCtx('docs', store);
+
+    const err: unknown = await wasmQuery(
+      ctx,
+      'docs',
+      'SELECT * FROM other WHERE vector NEAR $q',
+      { q: [0.1, 0.2] }
+    ).catch((e: unknown) => e);
+
+    expect(err).toBeInstanceOf(VelesDBError);
+    expect((err as VelesDBError).code).toBe('BAD_REQUEST');
+    expect(query).not.toHaveBeenCalled();
+  });
+
+  it('executes a pure NEAR query, LIMIT driving k', async () => {
+    const query = vi.fn(() => []);
+    const store = buildStore({ query });
+    const ctx = buildCtx('docs', store);
+
+    await wasmQuery(ctx, 'docs', 'SELECT * FROM docs WHERE vector NEAR $q LIMIT 3', {
+      q: [0.1, 0.2],
+    });
+    expect(query).toHaveBeenLastCalledWith(expect.any(Float32Array), 3);
+  });
+
+  it('reads the embedding from the parameter named in the query', async () => {
+    const query = vi.fn(() => []);
+    const store = buildStore({ query });
+    const ctx = buildCtx('docs', store);
+
+    await wasmQuery(ctx, 'docs', 'SELECT * FROM docs WHERE embedding NEAR $vec', {
+      vec: [0.1, 0.2],
+    });
+    expect(query).toHaveBeenLastCalledWith(expect.any(Float32Array), 10);
+  });
+
+  it('is case-insensitive and tolerates a trailing semicolon', async () => {
+    const query = vi.fn(() => []);
+    const store = buildStore({ query });
+    const ctx = buildCtx('docs', store);
+
+    await wasmQuery(ctx, 'docs', 'select * from docs where vector near $q limit 2;', {
+      q: [0.1, 0.2],
+    });
+    expect(query).toHaveBeenLastCalledWith(expect.any(Float32Array), 2);
   });
 });


### PR DESCRIPTION
## Context

Full-depth audit of the codebase against the project mission ("Vector + Graph + ColumnStore unified under VelesQL, high-performance agent memory"). The audit traced the flagship hybrid query — `SELECT m.*, similarity() FROM mem AS m WHERE vector NEAR $e AND MATCH (m)-[:RELATES_TO]->(f) AND session_id = $s ORDER BY similarity() DESC LIMIT 10` — end-to-end and found it **panicked deterministically in production** (reachable via a single REST request), plus four more critical correctness/durability bugs. Every fix below was developed test-first: a red test reproducing the exact failure, then the minimal fix, then the full gate suite. A second code review pass over the resulting diff surfaced 13 more issues (6 high), all remediated here as well.

## Critical fixes

**Hybrid NEAR + graph MATCH + scalar filter (the flagship query)**
- `compute_oversampled_k` could call `f64::clamp(min > max)` and panic whenever graph predicates forced `k = MAX_LIMIT` (`vector_filter.rs`). Now capped and panic-free for any `k`, with direct unit coverage.
- Graph predicates no longer blindly force a 100k over-fetch on ranked vector paths: bounded window `max(LIMIT, min(LIMIT*10, 10_000))`. Unranked scan paths (graph predicate without NEAR/similarity) keep the previous `MAX_LIMIT` semantics — review caught that the bounded window silently dropped matches there (insertion-order dependent results).
- The MATCH anchor-alias rule (anchor must be a FROM/JOIN alias) is now validated at validation time with a clear, actionable error (**V011**) instead of a late runtime `Error::Config`. Rule documented in SPEC/CONTRACT/cheatsheet.
- New BDD suite `graph_vector_hybrid.rs` covers the triple combination end-to-end, including the verbatim mission query and LIMIT semantics.

**Parameters silently degraded to NULL**
- `WHERE col = $p` (and IN/BETWEEN/comparisons) in plain SELECT/UPDATE pipelines converted `$p` to JSON `null` → 0 rows, no error. Parameters are now resolved strictly before filter conversion on every path; a missing parameter is a loud error, never an empty result.
- Review pass extended the same guarantee to `CONTAINS / CONTAINS ANY / CONTAINS ALL $p` and to `HAVING agg > $n`; `HAVING agg > (SELECT …)` is now rejected by V010 like everywhere else.

**WAL durability across compaction**
- `compact()` wrote a raw `0x04` byte into `vectors.wal`; replay stopped at the unknown opcode and then truncated the WAL — destroying fsync-acknowledged writes made after compaction, and pre-compaction entries could replay onto post-compaction offsets (silent rollback). Compaction now commits via staged artifacts and truncates the WAL under the WAL lock; legacy `0x04` markers are skipped on replay.
- Review pass closed the residual window: `vectors.idx` is no longer rewritten in place right after the WAL truncate (a crash there bricked the store — 0-byte idx + empty WAL). All index persists are now atomic (tmp + fsync + rename + dir fsync).
- New crash-simulation tests: store → compact → store → crash → reopen.

**Quantized search returned the k WORST candidates**
- Dual-precision/RaBitQ rerank converted distances to similarity then sorted ascending — a cosine index queried with its own vector returned the least similar points. Sorting now follows metric semantics (shared `sort_scored_results`), with per-backend × per-metric self-recall tests and the recall contract suite green (accurate ≥0.99, balanced ≥0.95).

**Graph MATCH semantics (Cypher relationship isomorphism)**
- The multi-hop walker reused the same edge within one path (phantom paths on cycles/`Both` patterns, combinatorial blowup on dense graphs). Per-path visited-edge set with proper backtracking now enforces relationship isomorphism.
- `WHERE r.prop` / `RETURN r.prop` read the target *node* payload instead of the edge — relationship aliases now bind to traversed edges. Review pass made this effective under **VectorFirst** too (the planner now forces GraphFirst when the WHERE/RETURN references a relationship alias) and fixed the Parallel-merge clobbering GraphFirst projections.

**Agent memory TTL**
- TTLs lived only in memory: after a restart every TTL'd entry became immortal, and VelesQL bridges returned expired entries that the native API filtered. TTLs now persist via a reserved, namespaced payload key (rebuilt on reopen), bridges filter expired entries consistently, and the reserved key is protected from user metadata collisions (review caught that a user-supplied `expires_at` business field would have become a destructive durable TTL).

**TypeScript SDK (WASM backend honesty + u64 ids)**
- `query()` ignored the VelesQL string entirely and ran raw k-NN — `WHERE category='tech' AND vector NEAR $q` silently returned unfiltered results while `capabilities()` advertised `velesqlQuery: true`. The WASM backend now executes only the exact pure `vector NEAR` shape it can honor and rejects everything else with a clear `NOT_SUPPORTED` error; capabilities and README tell the truth.
- Decimal-string ids up to `u64::MAX` are now symmetric across store/get/delete (they were write-only after the precision fix).

## Feature

- `FROM documents doc` — bare table aliases (without `AS`) in FROM/JOIN, with reserved-keyword protection so no clause keyword is ever swallowed as an alias. Includes a latent-bug fix: `FROM docs asset` used to parse as `AS "set"` (missing word boundary on `AS`). The README's second flagship query now parses and executes verbatim (e2e BDD).

## Documentation truth pass (32 items)

Docs now describe the code as it is: STORAGE_FORMAT.md rewritten to on-disk reality (real WAL record framing with CRC32, payload markers, compaction protocol, dead `hnsw.bin` gate), WASM "SIMD128" claims retracted everywhere (scalar fallback, SIMD128 planned), QUALITY_BAR's 100K recall gate described as the manual `#[ignore]` suite it is, 130x ColumnStore claim scoped to its real micro-benchmark with a working repro command, unverifiable latency numbers removed or labeled, V011/over-fetch/hop-cap semantics documented, non-parsing SPEC examples fixed and pinned by a new anti-drift test harness (`velesql_spec_corrected_examples.rs`), lock-order table aligned with `locking.rs`, agent-memory claims aligned (RMW atomicity caveat, mobile API documented).

## Validation

- `cargo fmt` / `clippy --workspace --all-targets -D warnings -D clippy::pedantic`: clean
- `cargo test -p velesdb-core --features persistence -- --test-threads=1`: **5793 passed / 0 failed**
- Recall contract (Gate 1): 6/6 (accurate ≥0.99, balanced ≥0.95, fast ≥0.90, perfect =100, multi-metric)
- Doc-tests 46/0 · `check_prod_unwraps` PASSED · `check-promise-contract` 19/19 · `--no-default-features` + wasm32 checks OK
- TypeScript SDK: vitest 778/778, eslint clean, tsc clean

## Out of scope — proposed follow-ups

1. **ColumnStore is dead code in the WHERE path**: typed/bitmap filters have no production caller; the real path is JSON `Filter` + secondary indexes. Wiring it in is the single biggest perf opportunity toward the "three engines" promise.
2. **GraphFirst by anchor-ids for SELECT graph predicates**: evaluate graph predicates first and push a RoaringBitmap prefilter into filtered HNSW (mechanism exists) for exhaustive hybrid retrieval beyond the over-fetch window; same treatment for the residual 100k over-fetch in `sparse_dispatch.rs` / `early_return.rs`.
3. **Agent memory graph dimension**: memory collections are pure vector collections; `MATCH (ctx)-[:RELATES_TO]->(fact)` over `agent_memory` needs a graph schema + a `relate()` API to be executable.
4. **Quantization wiring**: `TRAIN QUANTIZER 'rabitq'` trains and persists but no search path loads it; collections force `StorageMode::Full`; SQ8/Binary caches are written but never read.
5. **CI**: run the TypeScript SDK vitest suite in CI; consider a scheduled 100K recall job.
6. Result-returning `set_*_ttl` variants for durable post-hoc TTL updates; edge-binding-aware result dedup (parallel edges currently collapse to one row); list semantics for variable-length relationship aliases.

