### PR TITLE
feat(column-store): wire typed/bitmap filters into the SELECT WHERE path via an adaptive payload mirror

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ VelesDB removes the US provider from the chain entirely. One Rust binary, local-
 | Custom glue code + 3 query languages | **VelesQL** — one language for everything |
 | 3 deployments, 3 configs, 3 backups | **6 MB binary** — works offline, air-gapped |
 
-> *¹ ColumnStore filtering API micro-benchmark, integer equality: 130x at 100K rows, 55x at 10K rows — see [docs/BENCHMARKS.md § 6](docs/BENCHMARKS.md). `SELECT ... WHERE` metadata filtering currently runs on secondary indexes + JSON payload filters (see [2] below).*
+> *¹ ColumnStore filtering API micro-benchmark, integer equality: 130x at 100K rows, 55x at 10K rows — see [docs/BENCHMARKS.md § 6](docs/BENCHMARKS.md). `SELECT ... WHERE` metadata filtering uses secondary indexes when available, and an adaptive ColumnStore payload mirror for scan-heavy filters (see [2] below).*
 
 ---
 ## What is VelesDB?
@@ -80,7 +80,7 @@ VelesDB is a **local-first database for AI agents** that fuses three engines int
 | **ColumnStore** | Structured metadata filtering (typed columns) | **130x** faster than JSON scanning [2] |
 
 > [1] Reproduce: `python benchmarks/velesdb_benchmark.py --recall` (Python SDK path, 10K/384D, WAL fsync on, i9-14900KF reference machine). See [docs/BENCHMARKS.md](docs/BENCHMARKS.md) and [CHANGELOG v1.13.0](CHANGELOG.md).
-> [2] Reproduce: `cargo bench -p velesdb-core --bench column_filter_benchmark`. See [docs/BENCHMARKS.md § 6](docs/BENCHMARKS.md) — at 100K rows: ColumnStore 29.5 us vs JSON scan 3.84 ms (integer equality filter). Micro-benchmark of the ColumnStore filtering API; `SELECT ... WHERE` metadata filtering currently runs on secondary indexes + JSON payload filters (the ColumnStore engine backs JOIN execution).
+> [2] Reproduce: `cargo bench -p velesdb-core --bench column_filter_benchmark`. See [docs/BENCHMARKS.md § 6](docs/BENCHMARKS.md) — at 100K rows: ColumnStore 29.5 us vs JSON scan 3.84 ms (integer equality filter). Micro-benchmark of the ColumnStore filtering API, which now serves `SELECT ... WHERE` metadata filtering through a per-collection payload mirror (built adaptively for scan-heavy workloads) and backs JOIN execution; secondary indexes are used first when they cover the filter.
 
 All three are queried through **VelesQL** — a single SQL-like language with vector, graph, and columnar extensions:
 
@@ -395,9 +395,12 @@ filtering API is **130x faster** than JSON scanning at 100K rows
 JSON scan: 3.84 ms @ 100K    →    ColumnStore: 29.5 us @ 100K (130x faster)
 ```
 
-Today the ColumnStore engine backs `JOIN` execution. `SELECT ... WHERE`
-metadata filtering runs on secondary indexes + JSON payload filters, with
-pre-filter or post-filter chosen automatically by the query planner:
+The ColumnStore engine backs `JOIN` execution and serves `SELECT ... WHERE`
+metadata filtering through a per-collection payload mirror: top-level scalar
+payload fields are mirrored into typed columns, and filters compile to
+RoaringBitmap scans. The mirror is built adaptively — only after sequential
+scans have cost more than one full pass — so point lookups keep their fast
+path; secondary indexes are still consulted first when they cover the filter:
 
 ```sql
 SELECT * FROM products

--- a/crates/velesdb-core/src/collection/core/crud.rs
+++ b/crates/velesdb-core/src/collection/core/crud.rs
@@ -54,7 +54,7 @@ impl Collection {
         // new in one atomic cycle. See `apply_histogram_replace_dedup`.
         self.apply_histogram_replace_dedup(&points, &old_payloads);
 
-        self.invalidate_caches_and_bump_generation();
+        self.bump_generation_with_mirror_upserts(&points);
         Ok(())
     }
 
@@ -450,7 +450,7 @@ impl Collection {
         // atomic cycle. See `apply_histogram_replace_dedup`.
         self.apply_histogram_replace_dedup(&points, &old_payloads_for_hist);
 
-        self.invalidate_caches_and_bump_generation();
+        self.bump_generation_with_mirror_upserts(&points);
         Ok(())
     }
 }

--- a/crates/velesdb-core/src/collection/core/crud_bulk.rs
+++ b/crates/velesdb-core/src/collection/core/crud_bulk.rs
@@ -193,7 +193,7 @@ impl Collection {
         // Incremental histogram maintenance (Bug #47 + Bug #49): dedup by id
         // so only the final payload counts, then atomic decrement + increment.
         self.apply_histogram_replace_dedup(points, old_payloads);
-        self.invalidate_caches_and_bump_generation();
+        self.bump_generation_with_mirror_upserts(points);
         Ok(())
     }
 

--- a/crates/velesdb-core/src/collection/core/crud_indexing.rs
+++ b/crates/velesdb-core/src/collection/core/crud_indexing.rs
@@ -244,8 +244,31 @@ impl Collection {
     }
 
     /// Invalidates stats cache and bumps write generation.
+    ///
+    /// Also drops the payload mirror: any mutation path that does not
+    /// explicitly maintain the mirror must invalidate it so stale columnar
+    /// data can never serve queries (it is rebuilt lazily on demand).
     pub(super) fn invalidate_caches_and_bump_generation(&self) {
         *self.cached_stats.lock() = None;
+        self.payload_mirror.invalidate();
+        self.write_generation
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    /// Like [`Self::invalidate_caches_and_bump_generation`], but keeps the
+    /// payload mirror warm by applying the upserted points incrementally.
+    pub(super) fn bump_generation_with_mirror_upserts(&self, points: &[crate::point::Point]) {
+        *self.cached_stats.lock() = None;
+        self.payload_mirror.apply_upserts(points);
+        self.write_generation
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    /// Like [`Self::invalidate_caches_and_bump_generation`], but keeps the
+    /// payload mirror warm by tombstoning the deleted ids incrementally.
+    pub(super) fn bump_generation_with_mirror_deletes(&self, ids: &[u64]) {
+        *self.cached_stats.lock() = None;
+        self.payload_mirror.apply_deletes(ids);
         self.write_generation
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     }

--- a/crates/velesdb-core/src/collection/core/crud_read_delete.rs
+++ b/crates/velesdb-core/src/collection/core/crud_read_delete.rs
@@ -75,7 +75,7 @@ impl Collection {
         // collections; no-op for vector / metadata-only collections.
         self.cascade_delete_node_edges(ids)?;
 
-        self.invalidate_caches_and_bump_generation();
+        self.bump_generation_with_mirror_deletes(ids);
         Ok(())
     }
 

--- a/crates/velesdb-core/src/collection/core/graph_api.rs
+++ b/crates/velesdb-core/src/collection/core/graph_api.rs
@@ -470,6 +470,10 @@ impl Collection {
         // Populate graph property indexes (EPIC-047).
         self.index_node_properties(node_id, payload);
 
+        // Node payload writes bypass the upsert mirror hooks — drop the
+        // payload mirror so it can never serve stale columnar data.
+        self.payload_mirror.invalidate();
+
         // Bump write generation so any cached plan for this collection is
         // invalidated on the next query (CACHE-01).
         self.write_generation

--- a/crates/velesdb-core/src/collection/core/lifecycle.rs
+++ b/crates/velesdb-core/src/collection/core/lifecycle.rs
@@ -101,6 +101,7 @@ impl Collection {
             edge_store: Arc::new(parts.edge_store),
             sparse_indexes: Arc::new(RwLock::new(parts.sparse_indexes)),
             secondary_indexes: Arc::new(RwLock::new(HashMap::new())),
+            payload_mirror: Arc::new(crate::collection::payload_mirror::PayloadMirror::default()),
             guard_rails: Arc::new(GuardRails::default()),
             query_planner: Arc::new(QueryPlanner::new()),
             query_cache: Arc::new(QueryCache::new(256)),

--- a/crates/velesdb-core/src/collection/mod.rs
+++ b/crates/velesdb-core/src/collection/mod.rs
@@ -23,6 +23,7 @@ pub mod graph;
 mod graph_collection;
 mod graph_collection_query;
 mod metadata_collection;
+pub(crate) mod payload_mirror;
 pub mod query_cost;
 pub mod search;
 pub mod stats;

--- a/crates/velesdb-core/src/collection/payload_mirror/mirror_tests.rs
+++ b/crates/velesdb-core/src/collection/payload_mirror/mirror_tests.rs
@@ -1,0 +1,214 @@
+//! Integration tests: payload mirror behavior through the Collection API.
+//!
+//! Validates the adaptive build (scan-debt trigger), result parity with the
+//! sequential JSON scan path, incremental maintenance on upsert/delete, and
+//! the invalidation safety net.
+
+#![allow(clippy::cast_precision_loss)]
+
+use crate::collection::payload_mirror::MIRROR_MIN_ROWS;
+use crate::collection::types::Collection;
+use crate::distance::DistanceMetric;
+use crate::point::Point;
+use std::collections::HashMap;
+use tempfile::TempDir;
+
+const ROWS: usize = 300;
+
+fn make_point(i: usize) -> Point {
+    Point {
+        id: i as u64,
+        vector: vec![i as f32 / ROWS as f32, 0.5, 0.25, 1.0],
+        payload: Some(serde_json::json!({
+            "category": format!("cat{}", i % 3),
+            "price": i,
+            "active": i.is_multiple_of(2),
+        })),
+        sparse_vectors: None,
+    }
+}
+
+fn setup_collection() -> (TempDir, Collection) {
+    let dir = TempDir::new().expect("tempdir");
+    let path = dir.path().join("mirror_col");
+    let col = Collection::create(path, 4, DistanceMetric::Cosine).expect("create collection");
+    col.upsert((0..ROWS).map(make_point)).expect("upsert");
+    (dir, col)
+}
+
+fn query_ids(col: &Collection, query: &str) -> Vec<u64> {
+    let params = HashMap::new();
+    let mut ids: Vec<u64> = col
+        .execute_query_str(query, &params)
+        .expect("query succeeds")
+        .into_iter()
+        .map(|r| r.point.id)
+        .collect();
+    ids.sort_unstable();
+    ids
+}
+
+fn mirror_built(col: &Collection) -> bool {
+    col.payload_mirror.state.read().is_some()
+}
+
+#[test]
+fn test_mirror_builds_after_scan_debt_and_preserves_results() {
+    let (_dir, col) = setup_collection();
+    let query = "SELECT * FROM c WHERE category = 'cat1' AND price >= 30 LIMIT 500";
+
+    // First query takes the sequential scan path and accrues scan debt.
+    let scan_ids = query_ids(&col, query);
+    assert!(!mirror_built(&col), "mirror must not build on first scan");
+    assert!(col.payload_mirror.scan_debt() >= ROWS as u64);
+
+    // Second query crosses the debt threshold, builds the mirror, and must
+    // return exactly the same rows.
+    let mirror_ids = query_ids(&col, query);
+    assert!(mirror_built(&col), "mirror builds once debt covers a scan");
+    assert_eq!(scan_ids, mirror_ids);
+
+    let expected: Vec<u64> = (0..ROWS as u64)
+        .filter(|i| i % 3 == 1 && *i >= 30)
+        .collect();
+    assert_eq!(mirror_ids, expected);
+}
+
+#[test]
+fn test_mirror_parity_across_operators() {
+    let (_dir, col) = setup_collection();
+    let queries = [
+        "SELECT * FROM c WHERE price BETWEEN 10 AND 20 LIMIT 500",
+        "SELECT * FROM c WHERE category != 'cat0' AND price < 12 LIMIT 500",
+        "SELECT * FROM c WHERE category IN ('cat0', 'cat2') AND price <= 9 LIMIT 500",
+        "SELECT * FROM c WHERE active = true AND price > 290 LIMIT 500",
+        "SELECT * FROM c WHERE category = 'cat1' OR price >= 297 LIMIT 500",
+        "SELECT * FROM c WHERE NOT (category = 'cat1') AND price < 7 LIMIT 500",
+    ];
+
+    // Scan-path ground truth (mirror not yet built).
+    let ground_truth: Vec<Vec<u64>> = queries.iter().map(|q| query_ids(&col, q)).collect();
+
+    // Force the mirror and re-run every query.
+    col.build_payload_mirror();
+    assert!(mirror_built(&col));
+    for (query, expected) in queries.iter().zip(&ground_truth) {
+        let got = query_ids(&col, query);
+        assert_eq!(&got, expected, "mirror parity for {query}");
+    }
+}
+
+#[test]
+fn test_mirror_stays_in_sync_after_upsert_and_delete() {
+    let (_dir, col) = setup_collection();
+    col.build_payload_mirror();
+    let query = "SELECT * FROM c WHERE category = 'fresh' LIMIT 500";
+    assert!(query_ids(&col, query).is_empty());
+
+    // Upsert a new point and retag an existing one.
+    let mut fresh = make_point(1000);
+    fresh.payload = Some(serde_json::json!({"category": "fresh", "price": 1}));
+    let mut retagged = make_point(5);
+    retagged.payload = Some(serde_json::json!({"category": "fresh", "price": 2}));
+    col.upsert(vec![fresh, retagged]).expect("upsert");
+
+    assert!(mirror_built(&col), "incremental hook keeps the mirror warm");
+    assert_eq!(query_ids(&col, query), vec![5, 1000]);
+
+    // Delete one of them; the tombstone must hide it immediately.
+    col.delete(&[5]).expect("delete");
+    assert!(mirror_built(&col));
+    assert_eq!(query_ids(&col, query), vec![1000]);
+
+    // The retagged point must no longer match its old category.
+    let old = query_ids(
+        &col,
+        "SELECT * FROM c WHERE category = 'cat2' AND price = 5 LIMIT 10",
+    );
+    assert!(old.is_empty());
+}
+
+#[test]
+fn test_unsupported_conditions_fall_back_with_correct_results() {
+    let (_dir, col) = setup_collection();
+    col.build_payload_mirror();
+
+    // LIKE is not columnar-eligible — must fall back and stay correct.
+    let ids = query_ids(
+        &col,
+        "SELECT * FROM c WHERE category LIKE 'cat1%' AND price < 10 LIMIT 500",
+    );
+    let expected: Vec<u64> = (0..10u64).filter(|i| i % 3 == 1).collect();
+    assert_eq!(ids, expected);
+}
+
+#[test]
+fn test_small_collections_never_build_a_mirror() {
+    let dir = TempDir::new().expect("tempdir");
+    let path = dir.path().join("small_col");
+    let col = Collection::create(path, 4, DistanceMetric::Cosine).expect("create collection");
+    let small = MIRROR_MIN_ROWS / 2;
+    col.upsert((0..small).map(make_point)).expect("upsert");
+
+    let query = "SELECT * FROM c WHERE category = 'cat1' LIMIT 500";
+    for _ in 0..4 {
+        let ids = query_ids(&col, query);
+        assert_eq!(ids.len(), small.div_ceil(3));
+    }
+    assert!(!mirror_built(&col), "below MIRROR_MIN_ROWS, never build");
+}
+
+#[test]
+fn test_mixed_type_field_falls_back_with_correct_results() {
+    let (_dir, col) = setup_collection();
+    // Poison "price" with a string value on one row.
+    let mut odd = make_point(42);
+    odd.payload = Some(serde_json::json!({"category": "cat0", "price": "n/a"}));
+    col.upsert(vec![odd]).expect("upsert");
+    col.build_payload_mirror();
+
+    // Numeric Eq on the mixed-type field: the mirror answers from the Float
+    // column (exact for numeric rows); the string row can never match a
+    // numeric literal in JSON semantics either.
+    let ids = query_ids(&col, "SELECT * FROM c WHERE price = 41 LIMIT 10");
+    assert_eq!(ids, vec![41]);
+
+    // String Eq must fall back (ineligible) and still find the odd row.
+    let ids = query_ids(&col, "SELECT * FROM c WHERE price = 'n/a' LIMIT 10");
+    assert_eq!(ids, vec![42]);
+}
+
+#[test]
+fn test_metadata_only_collection_uses_mirror() {
+    let dir = TempDir::new().expect("tempdir");
+    let path = dir.path().join("meta_col");
+    let col = Collection::create_metadata_only(path, "meta").expect("create collection");
+    let points: Vec<Point> = (0..ROWS)
+        .map(|i| Point {
+            id: i as u64,
+            vector: vec![],
+            payload: Some(serde_json::json!({"kind": format!("k{}", i % 5), "rank": i})),
+            sparse_vectors: None,
+        })
+        .collect();
+    col.upsert(points).expect("upsert");
+
+    let query = "SELECT * FROM c WHERE kind = 'k3' AND rank > 200 LIMIT 500";
+    let scan_ids = query_ids(&col, query);
+    let _ = query_ids(&col, query); // crosses the debt threshold
+    assert!(mirror_built(&col), "metadata-only collections build too");
+    let mirror_ids = query_ids(&col, query);
+    assert_eq!(scan_ids, mirror_ids);
+
+    // upsert_metadata path keeps the mirror in sync.
+    col.upsert(vec![Point {
+        id: 9999,
+        vector: vec![],
+        payload: Some(serde_json::json!({"kind": "k3", "rank": 999})),
+        sparse_vectors: None,
+    }])
+    .expect("upsert");
+    assert!(mirror_built(&col));
+    let after = query_ids(&col, query);
+    assert!(after.contains(&9999));
+}

--- a/crates/velesdb-core/src/collection/payload_mirror/mod.rs
+++ b/crates/velesdb-core/src/collection/payload_mirror/mod.rs
@@ -1,0 +1,330 @@
+//! Per-collection columnar mirror of payload scalars.
+//!
+//! Wires the `ColumnStore` typed/bitmap filter engine into the production
+//! `SELECT ... WHERE` path. The mirror stores every top-level scalar payload
+//! field in columnar form (numbers as `f64`, strings interned, bools) and
+//! answers metadata filters with `RoaringBitmap` scans instead of per-row
+//! JSON parsing.
+//!
+//! # Adaptive build
+//!
+//! The mirror is **not** built eagerly: building costs one full payload scan,
+//! which would penalize collections that never run scan-heavy filters. Each
+//! full sequential JSON scan records its row count as *scan debt*; once the
+//! accumulated debt exceeds one full-scan-equivalent, the next metadata query
+//! builds the mirror and subsequent filters run columnar. Limit-k queries
+//! that early-exit after a few rows never accumulate enough debt to trigger
+//! a build, so they keep their fast path.
+//!
+//! # Consistency model
+//!
+//! The invariant is *mirror present ⇒ in sync with payload storage*:
+//!
+//! - The main mutation paths (`upsert`, `upsert_metadata`, `upsert_bulk`,
+//!   `delete`) maintain the mirror incrementally via
+//!   `bump_generation_with_mirror_upserts` / `..._deletes`.
+//! - Every other mutation path funnels through
+//!   `invalidate_caches_and_bump_generation`, which drops the mirror, so a
+//!   future write path can never serve stale columnar data — at worst it
+//!   costs a lazy rebuild.
+//!
+//! False positives from the bitmap are removed by the JSON post-filter
+//! (`scan_ids_with_filter`); the translation layer (`translate`) is designed
+//! so false negatives are impossible (strict type-match eligibility).
+
+use crate::column_store::{ColumnStore, ColumnType, ColumnValue};
+use crate::point::Point;
+use crate::storage::{PayloadStorage, VectorStorage};
+use parking_lot::RwLock;
+use roaring::RoaringBitmap;
+use rustc_hash::{FxHashMap, FxHashSet};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+mod translate;
+
+#[cfg(test)]
+mod mirror_tests;
+#[cfg(test)]
+mod translate_tests;
+
+/// Collections below this size never build a mirror — sequential scans on
+/// tiny collections are already microsecond-scale.
+pub(crate) const MIRROR_MIN_ROWS: usize = 256;
+
+/// Maximum number of payload fields mirrored as columns. Fields beyond the
+/// cap are tracked in `uncolumnized` and fall back to the JSON filter.
+const MAX_MIRROR_COLUMNS: usize = 64;
+
+/// Tombstone ratio above which the mirror is dropped and rebuilt lazily
+/// (compaction by reconstruction).
+const BLOAT_MIN_ROWS: usize = 4096;
+
+/// Columnar mirror handle owned by a `Collection`.
+///
+/// Lock order position: **1b** — the lazy build holds the state write lock
+/// while acquiring `vector_storage` (2) and `payload_storage` (3) read locks,
+/// in ascending order. Mutation hooks and queries acquire the state lock with
+/// no other collection lock held.
+#[derive(Default)]
+pub(crate) struct PayloadMirror {
+    state: RwLock<Option<MirrorState>>,
+    scan_debt: AtomicU64,
+}
+
+/// Outcome of a mirror probe for a filter condition.
+pub(crate) enum MirrorAnswer {
+    /// Candidate point ids (superset of matches; caller must post-filter).
+    Ids(Vec<u64>),
+    /// The condition cannot be answered from columnar data — fall back.
+    Unsupported,
+    /// The mirror has not been built (or was invalidated).
+    NotBuilt,
+}
+
+/// Built mirror: a `ColumnStore` plus point-id ↔ row-index mappings.
+#[derive(Default)]
+pub(super) struct MirrorState {
+    pub(super) store: ColumnStore,
+    /// row index → point id (append-only, parallel to column length).
+    pub(super) row_ids: Vec<u64>,
+    /// point id → live row index.
+    pub(super) id_rows: FxHashMap<u64, u32>,
+    /// Live (non-tombstoned) row indices; complement base for NOT / `!=`.
+    pub(super) live: RoaringBitmap,
+    /// Scalar fields seen but not mirrored (column cap reached) — conditions
+    /// on these fields must fall back to the JSON filter.
+    pub(super) uncolumnized: FxHashSet<String>,
+}
+
+impl MirrorState {
+    /// Tombstones the previous row for `id` (if any) and appends a new row.
+    ///
+    /// Returns `false` when the row index space (`u32`) is exhausted, which
+    /// poisons the mirror (caller drops the state).
+    pub(super) fn upsert_row(&mut self, id: u64, payload: Option<&serde_json::Value>) -> bool {
+        self.tombstone(id);
+        let Ok(row_idx) = u32::try_from(self.store.row_count()) else {
+            return false;
+        };
+        let cells = self.collect_cells(payload);
+        let cell_refs: Vec<(&str, ColumnValue)> = cells
+            .iter()
+            .map(|(name, value)| (name.as_str(), value.clone()))
+            .collect();
+        self.store.push_row_unchecked(&cell_refs);
+        self.row_ids.push(id);
+        self.id_rows.insert(id, row_idx);
+        self.live.insert(row_idx);
+        true
+    }
+
+    /// Tombstones the row for `id`, if present.
+    pub(super) fn tombstone(&mut self, id: u64) {
+        if let Some(row_idx) = self.id_rows.remove(&id) {
+            self.store.tombstone_row(row_idx as usize);
+            self.live.remove(row_idx);
+        }
+    }
+
+    /// Extracts mirrored cells from a payload's top-level scalar fields.
+    ///
+    /// Non-scalar values (arrays, objects, nulls) and dotted keys produce no
+    /// cell — `push_row_unchecked` stores null for absent columns, matching
+    /// the JSON filter's "missing field never matches" semantics. Cells whose
+    /// type conflicts with the existing column are nulled by `push_typed`.
+    fn collect_cells(&mut self, payload: Option<&serde_json::Value>) -> Vec<(String, ColumnValue)> {
+        let Some(serde_json::Value::Object(map)) = payload else {
+            return Vec::new();
+        };
+        let mut cells = Vec::with_capacity(map.len());
+        for (key, value) in map {
+            // `get_field` splits on '.', so dotted keys are unreachable by
+            // the JSON filter — never mirror them.
+            if key.contains('.') {
+                continue;
+            }
+            let Some((col_type, cell)) = self.scalar_cell(value) else {
+                continue;
+            };
+            if self.ensure_column(key, &col_type) {
+                cells.push((key.clone(), cell));
+            }
+        }
+        cells
+    }
+
+    /// Maps a scalar JSON value to its mirror column type and cell value.
+    ///
+    /// All numbers map to `Float` because the JSON filter compares numbers
+    /// as `f64` (`values_equal` / `compare_values`), making the `f64` mirror
+    /// exactly as faithful as the JSON path itself.
+    fn scalar_cell(&mut self, value: &serde_json::Value) -> Option<(ColumnType, ColumnValue)> {
+        match value {
+            serde_json::Value::Number(n) => n
+                .as_f64()
+                .map(|f| (ColumnType::Float, ColumnValue::Float(f))),
+            serde_json::Value::String(s) => Some((
+                ColumnType::String,
+                ColumnValue::String(self.store.string_table_mut().intern(s)),
+            )),
+            serde_json::Value::Bool(b) => Some((ColumnType::Bool, ColumnValue::Bool(*b))),
+            _ => None,
+        }
+    }
+
+    /// Ensures a column exists for `key`, honoring the column cap.
+    ///
+    /// Returns `true` when the field is mirrored (column exists or was
+    /// created); `false` when capped out (field recorded as uncolumnized).
+    fn ensure_column(&mut self, key: &str, col_type: &ColumnType) -> bool {
+        if self.store.get_column(key).is_some() {
+            return true;
+        }
+        if self.uncolumnized.contains(key) {
+            return false;
+        }
+        if self.store.column_names().count() >= MAX_MIRROR_COLUMNS {
+            self.uncolumnized.insert(key.to_string());
+            return false;
+        }
+        self.store.add_column_backfilled(key, col_type);
+        true
+    }
+
+    /// Whether tombstones dominate the store (time to compact via rebuild).
+    fn is_bloated(&self) -> bool {
+        let total = self.store.row_count();
+        total > BLOAT_MIN_ROWS && self.live.len().saturating_mul(2) < total as u64
+    }
+}
+
+impl PayloadMirror {
+    /// Drops the mirror; it will be rebuilt lazily when scan debt warrants it.
+    pub(crate) fn invalidate(&self) {
+        *self.state.write() = None;
+    }
+
+    /// Records rows visited by a full sequential JSON scan.
+    pub(crate) fn add_scan_debt(&self, rows: u64) {
+        self.scan_debt.fetch_add(rows, Ordering::Relaxed);
+    }
+
+    pub(crate) fn scan_debt(&self) -> u64 {
+        self.scan_debt.load(Ordering::Relaxed)
+    }
+
+    /// Applies an upsert batch incrementally (no-op when not built).
+    ///
+    /// Intra-batch duplicate ids resolve to last-writer-wins because each
+    /// `upsert_row` tombstones the previous row for the same id.
+    pub(crate) fn apply_upserts(&self, points: &[Point]) {
+        let mut guard = self.state.write();
+        let mut healthy = true;
+        if let Some(state) = guard.as_mut() {
+            for point in points {
+                if !state.upsert_row(point.id, point.payload.as_ref()) {
+                    healthy = false;
+                    break;
+                }
+            }
+            healthy = healthy && !state.is_bloated();
+        } else {
+            return;
+        }
+        if !healthy {
+            *guard = None;
+        }
+    }
+
+    /// Applies a delete batch incrementally (no-op when not built).
+    pub(crate) fn apply_deletes(&self, ids: &[u64]) {
+        let mut guard = self.state.write();
+        if let Some(state) = guard.as_mut() {
+            for &id in ids {
+                state.tombstone(id);
+            }
+        }
+    }
+
+    /// Translates a filter condition to candidate point ids via columnar scans.
+    pub(crate) fn candidate_ids(&self, condition: &crate::filter::Condition) -> MirrorAnswer {
+        let guard = self.state.read();
+        let Some(state) = guard.as_ref() else {
+            return MirrorAnswer::NotBuilt;
+        };
+        match translate::condition_bitmap(state, condition) {
+            Some(eval) => MirrorAnswer::Ids(
+                eval.bits
+                    .iter()
+                    .filter_map(|row_idx| state.row_ids.get(row_idx as usize).copied())
+                    .collect(),
+            ),
+            None => MirrorAnswer::Unsupported,
+        }
+    }
+}
+
+impl crate::collection::types::Collection {
+    /// Probes the payload mirror for candidate ids, building it first when
+    /// enough full-scan debt has accumulated.
+    ///
+    /// Returns `None` when the condition is unsupported or the mirror is not
+    /// (yet) worth building — the caller falls back to the JSON scan path.
+    pub(crate) fn mirror_candidate_ids(
+        &self,
+        condition: &crate::filter::Condition,
+    ) -> Option<Vec<u64>> {
+        match self.payload_mirror.candidate_ids(condition) {
+            MirrorAnswer::Ids(ids) => return Some(ids),
+            MirrorAnswer::Unsupported => return None,
+            MirrorAnswer::NotBuilt => {}
+        }
+        if !self.mirror_build_due() {
+            return None;
+        }
+        self.build_payload_mirror();
+        match self.payload_mirror.candidate_ids(condition) {
+            MirrorAnswer::Ids(ids) => Some(ids),
+            MirrorAnswer::Unsupported | MirrorAnswer::NotBuilt => None,
+        }
+    }
+
+    /// Whether accumulated scan debt justifies the one-off build cost.
+    fn mirror_build_due(&self) -> bool {
+        let rows = self.config.read().point_count;
+        rows >= MIRROR_MIN_ROWS && self.payload_mirror.scan_debt() >= rows as u64
+    }
+
+    /// Builds the mirror from storage under the mirror write lock.
+    ///
+    /// LOCK ORDER: `payload_mirror` (1b) → `vector_storage` (2) →
+    /// `payload_storage` (3), ascending. Mutation hooks acquire the mirror
+    /// lock with no other collection lock held, so concurrent writers block
+    /// here during the build and re-apply their batch afterwards (idempotent),
+    /// keeping the mirror complete.
+    pub(crate) fn build_payload_mirror(&self) {
+        let mut guard = self.payload_mirror.state.write();
+        if guard.is_some() {
+            return; // another query won the build race
+        }
+        let vector_ids = {
+            let vectors = self.vector_storage.read();
+            vectors.ids()
+        };
+        let payload_storage = self.payload_storage.read();
+        let mut state = MirrorState::default();
+        let mut seen: FxHashSet<u64> = FxHashSet::default();
+        for id in vector_ids.into_iter().chain(payload_storage.ids()) {
+            if !seen.insert(id) {
+                continue;
+            }
+            let payload = payload_storage.retrieve(id).ok().flatten();
+            if !state.upsert_row(id, payload.as_ref()) {
+                return; // u32 row space exhausted — leave mirror unbuilt
+            }
+        }
+        drop(payload_storage);
+        self.payload_mirror.scan_debt.store(0, Ordering::Relaxed);
+        *guard = Some(state);
+    }
+}

--- a/crates/velesdb-core/src/collection/payload_mirror/translate.rs
+++ b/crates/velesdb-core/src/collection/payload_mirror/translate.rs
@@ -1,0 +1,247 @@
+//! Translation of canonical filter conditions into `ColumnStore` bitmaps.
+//!
+//! # Soundness contract
+//!
+//! The caller post-filters candidates with `Filter::matches`, so **false
+//! positives are harmless but false negatives are not**. Every bitmap
+//! returned here must therefore contain *at least* every live row the JSON
+//! filter would match. Leaves achieve this by being *exact* replicas of the
+//! `filter::matching` semantics (same `f64` epsilon equality, same
+//! cross-type-never-matches rules), enforced through strict eligibility:
+//!
+//! - A leaf is only translated when the literal's JSON type matches the
+//!   mirrored column's type. Cross-type comparisons are `false` in JSON
+//!   semantics for rows of the column's type, but rows holding a value of
+//!   *another* type are stored as nulls in the mirror and could still match
+//!   in JSON — those leaves return `None` (fall back to the JSON scan).
+//! - A field with no column and never seen as a scalar provably matches
+//!   nothing (`get_field` misses or hits a non-scalar) — exact empty bitmap.
+//! - Fields capped out of the mirror (`uncolumnized`) return `None`.
+//!
+//! Inexact (superset) results only arise from `And` branches whose siblings
+//! were untranslatable; `exact` tracks this so `Not`/`Neq` complements are
+//! only ever taken over exact operands (a complemented superset would lose
+//! matches — a false negative).
+
+use super::MirrorState;
+use crate::column_store::TypedColumn;
+use crate::filter::Condition;
+use roaring::RoaringBitmap;
+
+/// A translated condition: matching live rows plus exactness.
+pub(super) struct Eval {
+    pub(super) bits: RoaringBitmap,
+    /// `true` when `bits` is exactly the JSON-filter match set; required for
+    /// complement operations (`Not`, `Neq`).
+    pub(super) exact: bool,
+}
+
+impl Eval {
+    fn exact(bits: RoaringBitmap) -> Self {
+        Self { bits, exact: true }
+    }
+
+    fn empty() -> Self {
+        Self::exact(RoaringBitmap::new())
+    }
+}
+
+/// Mirror column classification for a condition field.
+enum FieldCol {
+    Float,
+    Str,
+    Bool,
+    /// No column and never seen as a top-level scalar: the JSON filter can
+    /// only see a missing field or a non-scalar value there.
+    Absent,
+}
+
+/// Translates a condition tree into a bitmap of candidate live rows.
+///
+/// Returns `None` when the condition (or a structurally required branch)
+/// cannot be answered from columnar data.
+pub(super) fn condition_bitmap(state: &MirrorState, cond: &Condition) -> Option<Eval> {
+    match cond {
+        Condition::Eq { field, value } => leaf_eq(state, field, value),
+        Condition::Neq { field, value } => {
+            let eq = leaf_eq(state, field, value)?;
+            complement(state, &eq)
+        }
+        Condition::Gt { field, value } => leaf_ord(state, field, value, std::cmp::Ordering::is_gt),
+        Condition::Gte { field, value } => leaf_ord(state, field, value, std::cmp::Ordering::is_ge),
+        Condition::Lt { field, value } => leaf_ord(state, field, value, std::cmp::Ordering::is_lt),
+        Condition::Lte { field, value } => leaf_ord(state, field, value, std::cmp::Ordering::is_le),
+        Condition::In { field, values } => leaf_in(state, field, values),
+        Condition::And { conditions } => and_bitmap(state, conditions),
+        Condition::Or { conditions } => or_bitmap(state, conditions),
+        Condition::Not { condition } => {
+            let inner = condition_bitmap(state, condition)?;
+            complement(state, &inner)
+        }
+        _ => None,
+    }
+}
+
+/// Complements an exact eval over the live-row set; refuses inexact input.
+fn complement(state: &MirrorState, eval: &Eval) -> Option<Eval> {
+    eval.exact.then(|| Eval::exact(&state.live - &eval.bits))
+}
+
+/// AND: intersect translatable branches; untranslatable branches widen the
+/// result to a superset (`exact = false`), which the post-filter narrows.
+fn and_bitmap(state: &MirrorState, conditions: &[Condition]) -> Option<Eval> {
+    if conditions.is_empty() {
+        // `And { [] }` is the engine-handled identity: matches everything.
+        return Some(Eval::exact(state.live.clone()));
+    }
+    let mut acc: Option<RoaringBitmap> = None;
+    let mut exact = true;
+    for cond in conditions {
+        match condition_bitmap(state, cond) {
+            Some(eval) => {
+                exact &= eval.exact;
+                acc = Some(match acc {
+                    Some(bits) => bits & eval.bits,
+                    None => eval.bits,
+                });
+            }
+            None => exact = false,
+        }
+    }
+    acc.map(|bits| Eval { bits, exact })
+}
+
+/// OR: every branch must translate, otherwise matches could be lost.
+fn or_bitmap(state: &MirrorState, conditions: &[Condition]) -> Option<Eval> {
+    let mut acc = RoaringBitmap::new();
+    let mut exact = true;
+    for cond in conditions {
+        let eval = condition_bitmap(state, cond)?;
+        exact &= eval.exact;
+        acc |= eval.bits;
+    }
+    Some(Eval { bits: acc, exact })
+}
+
+/// Classifies a condition field against the mirror schema.
+///
+/// Returns `None` when the field must fall back to the JSON filter
+/// (dotted path, capped-out field, or unexpected column kind).
+fn classify_field(state: &MirrorState, field: &str) -> Option<FieldCol> {
+    if field.contains('.') {
+        return None; // nested paths are not mirrored
+    }
+    match state.store.get_column(field) {
+        Some(TypedColumn::Float(_)) => Some(FieldCol::Float),
+        Some(TypedColumn::String(_)) => Some(FieldCol::Str),
+        Some(TypedColumn::Bool(_)) => Some(FieldCol::Bool),
+        Some(_) => None,
+        None if state.uncolumnized.contains(field) => None,
+        None => Some(FieldCol::Absent),
+    }
+}
+
+/// Equality leaf. Eligible only for type-matched scalar literals; replicates
+/// `values_equal` exactly (epsilon equality for numbers, interned equality
+/// for strings).
+fn leaf_eq(state: &MirrorState, field: &str, value: &serde_json::Value) -> Option<Eval> {
+    let col = classify_field(state, field)?;
+    let bits = match (col, value) {
+        (FieldCol::Absent, v) if is_scalar(v) => RoaringBitmap::new(),
+        (FieldCol::Float, serde_json::Value::Number(n)) => {
+            let lit = n.as_f64()?;
+            state
+                .store
+                .filter_float_bitmap(field, move |v| (v - lit).abs() < f64::EPSILON)
+        }
+        (FieldCol::Str, serde_json::Value::String(s)) => {
+            state.store.filter_eq_string_bitmap(field, s)
+        }
+        (FieldCol::Bool, serde_json::Value::Bool(b)) => {
+            state.store.filter_bool_eq_bitmap(field, *b)
+        }
+        _ => return None,
+    };
+    Some(Eval::exact(bits))
+}
+
+/// Ordering leaf. JSON ordering (`compare_values`) only ever compares
+/// Number/Number or String/String; all other combinations match nothing.
+fn leaf_ord(
+    state: &MirrorState,
+    field: &str,
+    value: &serde_json::Value,
+    holds: impl Fn(std::cmp::Ordering) -> bool,
+) -> Option<Eval> {
+    let col = classify_field(state, field)?;
+    match (col, value) {
+        // Non-orderable literal types compare to nothing, on any column.
+        (_, v) if !v.is_number() && !v.is_string() => Some(Eval::empty()),
+        (FieldCol::Absent, _) => Some(Eval::empty()),
+        (FieldCol::Float, serde_json::Value::Number(n)) => {
+            let lit = n.as_f64()?;
+            let bits = state
+                .store
+                .filter_float_bitmap(field, move |v| v.partial_cmp(&lit).is_some_and(&holds));
+            Some(Eval::exact(bits))
+        }
+        // String ordering (lexicographic) and cross-type leaves fall back.
+        _ => None,
+    }
+}
+
+/// IN leaf. Eligible only when every list value matches the column type —
+/// a single off-type value could match rows the mirror stored as null.
+fn leaf_in(state: &MirrorState, field: &str, values: &[serde_json::Value]) -> Option<Eval> {
+    let col = classify_field(state, field)?;
+    if values.is_empty() {
+        return Some(Eval::empty());
+    }
+    let bits = match col {
+        // Missing fields never match IN, whatever the list contains.
+        FieldCol::Absent => RoaringBitmap::new(),
+        FieldCol::Float => {
+            let lits: Vec<f64> = values
+                .iter()
+                .map(serde_json::Value::as_f64)
+                .collect::<Option<Vec<f64>>>()?;
+            state.store.filter_float_bitmap(field, move |v| {
+                lits.iter().any(|lit| (v - lit).abs() < f64::EPSILON)
+            })
+        }
+        FieldCol::Str => {
+            let strs: Vec<&str> = values
+                .iter()
+                .map(serde_json::Value::as_str)
+                .collect::<Option<Vec<&str>>>()?;
+            state.store.filter_in_string_bitmap(field, &strs)
+        }
+        FieldCol::Bool => bool_in_bitmap(state, field, values)?,
+    };
+    Some(Eval::exact(bits))
+}
+
+/// IN over a bool column: union of the (at most two) distinct values.
+fn bool_in_bitmap(
+    state: &MirrorState,
+    field: &str,
+    values: &[serde_json::Value],
+) -> Option<RoaringBitmap> {
+    let bools: Vec<bool> = values
+        .iter()
+        .map(serde_json::Value::as_bool)
+        .collect::<Option<Vec<bool>>>()?;
+    let mut bits = RoaringBitmap::new();
+    if bools.contains(&true) {
+        bits |= state.store.filter_bool_eq_bitmap(field, true);
+    }
+    if bools.contains(&false) {
+        bits |= state.store.filter_bool_eq_bitmap(field, false);
+    }
+    Some(bits)
+}
+
+/// Whether a JSON value is a mirrorable scalar (number, string, bool).
+fn is_scalar(value: &serde_json::Value) -> bool {
+    value.is_number() || value.is_string() || value.is_boolean()
+}

--- a/crates/velesdb-core/src/collection/payload_mirror/translate_tests.rs
+++ b/crates/velesdb-core/src/collection/payload_mirror/translate_tests.rs
@@ -1,0 +1,371 @@
+//! Unit tests for the condition → bitmap translation layer.
+//!
+//! The contract under test: returned bitmaps must never miss a row the JSON
+//! filter would match (false negatives forbidden); `exact` must only be true
+//! when the bitmap is precisely the JSON match set.
+
+use super::translate::condition_bitmap;
+use super::MirrorState;
+use crate::filter::Condition;
+use serde_json::json;
+
+/// Builds a mirror with rows:
+/// 0: {category: "tech",   price: 10,   active: true}
+/// 1: {category: "bio",    price: 20.5, active: false}
+/// 2: {category: "tech",   price: 30}
+/// 3: {price: "not-a-number"}            (type conflict on price)
+/// 4: `{tags: ["a"], meta: {"x": 1}}`      (non-scalars only)
+/// 5: no payload
+fn sample_state() -> MirrorState {
+    let mut state = MirrorState::default();
+    assert!(state.upsert_row(
+        0,
+        Some(&json!({"category": "tech", "price": 10, "active": true}))
+    ));
+    assert!(state.upsert_row(
+        1,
+        Some(&json!({"category": "bio", "price": 20.5, "active": false}))
+    ));
+    assert!(state.upsert_row(2, Some(&json!({"category": "tech", "price": 30}))));
+    assert!(state.upsert_row(3, Some(&json!({"price": "not-a-number"}))));
+    assert!(state.upsert_row(4, Some(&json!({"tags": ["a"], "meta": {"x": 1}}))));
+    assert!(state.upsert_row(5, None));
+    state
+}
+
+fn rows(eval: &super::translate::Eval) -> Vec<u32> {
+    eval.bits.iter().collect()
+}
+
+#[test]
+fn eq_string_matches_exact_rows() {
+    let state = sample_state();
+    let cond = Condition::Eq {
+        field: "category".into(),
+        value: json!("tech"),
+    };
+    let eval = condition_bitmap(&state, &cond).expect("supported");
+    assert_eq!(rows(&eval), vec![0, 2]);
+    assert!(eval.exact);
+}
+
+#[test]
+fn eq_number_uses_epsilon_semantics() {
+    let state = sample_state();
+    let cond = Condition::Eq {
+        field: "price".into(),
+        value: json!(20.5),
+    };
+    let eval = condition_bitmap(&state, &cond).expect("supported");
+    assert_eq!(rows(&eval), vec![1]);
+    assert!(eval.exact);
+}
+
+#[test]
+fn eq_bool_matches() {
+    let state = sample_state();
+    let cond = Condition::Eq {
+        field: "active".into(),
+        value: json!(true),
+    };
+    let eval = condition_bitmap(&state, &cond).expect("supported");
+    assert_eq!(rows(&eval), vec![0]);
+    assert!(eval.exact);
+}
+
+#[test]
+fn eq_absent_field_is_exact_empty() {
+    let state = sample_state();
+    let cond = Condition::Eq {
+        field: "nonexistent".into(),
+        value: json!("x"),
+    };
+    let eval = condition_bitmap(&state, &cond).expect("supported");
+    assert!(eval.bits.is_empty());
+    assert!(eval.exact);
+}
+
+#[test]
+fn eq_on_array_only_field_is_exact_empty() {
+    // "tags" exists only as an array → never mirrored as a column; a scalar
+    // Eq can never match it in JSON semantics either.
+    let state = sample_state();
+    let cond = Condition::Eq {
+        field: "tags".into(),
+        value: json!("a"),
+    };
+    let eval = condition_bitmap(&state, &cond).expect("supported");
+    assert!(eval.bits.is_empty());
+    assert!(eval.exact);
+}
+
+#[test]
+fn dotted_field_falls_back() {
+    let state = sample_state();
+    let cond = Condition::Eq {
+        field: "meta.x".into(),
+        value: json!(1),
+    };
+    assert!(condition_bitmap(&state, &cond).is_none());
+}
+
+#[test]
+fn type_mismatched_literal_falls_back() {
+    // price column is Float, but row 3 holds a string — a string literal
+    // could match that null-mirrored row, so the leaf must fall back.
+    let state = sample_state();
+    let cond = Condition::Eq {
+        field: "price".into(),
+        value: json!("not-a-number"),
+    };
+    assert!(condition_bitmap(&state, &cond).is_none());
+}
+
+#[test]
+fn ordering_on_numbers_matches_compare_values() {
+    let state = sample_state();
+    let cond = Condition::Gte {
+        field: "price".into(),
+        value: json!(20),
+    };
+    let eval = condition_bitmap(&state, &cond).expect("supported");
+    // Row 3 holds a string price (null cell) and must not match.
+    assert_eq!(rows(&eval), vec![1, 2]);
+    assert!(eval.exact);
+}
+
+#[test]
+fn ordering_with_bool_literal_is_exact_empty() {
+    // JSON compare_values never orders against a Bool → no row matches.
+    let state = sample_state();
+    let cond = Condition::Gt {
+        field: "price".into(),
+        value: json!(true),
+    };
+    let eval = condition_bitmap(&state, &cond).expect("supported");
+    assert!(eval.bits.is_empty());
+    assert!(eval.exact);
+}
+
+#[test]
+fn string_ordering_falls_back() {
+    let state = sample_state();
+    let cond = Condition::Gt {
+        field: "category".into(),
+        value: json!("a"),
+    };
+    assert!(condition_bitmap(&state, &cond).is_none());
+}
+
+#[test]
+fn neq_complements_over_live_rows() {
+    let state = sample_state();
+    let cond = Condition::Neq {
+        field: "category".into(),
+        value: json!("tech"),
+    };
+    let eval = condition_bitmap(&state, &cond).expect("supported");
+    // JSON Neq matches rows where the field differs OR is missing.
+    assert_eq!(rows(&eval), vec![1, 3, 4, 5]);
+    assert!(eval.exact);
+}
+
+#[test]
+fn neq_excludes_tombstoned_rows() {
+    let mut state = sample_state();
+    state.tombstone(5);
+    let cond = Condition::Neq {
+        field: "category".into(),
+        value: json!("tech"),
+    };
+    let eval = condition_bitmap(&state, &cond).expect("supported");
+    assert_eq!(rows(&eval), vec![1, 3, 4]);
+}
+
+#[test]
+fn in_list_on_strings_and_numbers() {
+    let state = sample_state();
+    let cond = Condition::In {
+        field: "category".into(),
+        values: vec![json!("bio"), json!("nope")],
+    };
+    let eval = condition_bitmap(&state, &cond).expect("supported");
+    assert_eq!(rows(&eval), vec![1]);
+
+    let cond = Condition::In {
+        field: "price".into(),
+        values: vec![json!(10), json!(30)],
+    };
+    let eval = condition_bitmap(&state, &cond).expect("supported");
+    assert_eq!(rows(&eval), vec![0, 2]);
+    assert!(eval.exact);
+}
+
+#[test]
+fn in_list_with_mixed_types_falls_back() {
+    let state = sample_state();
+    let cond = Condition::In {
+        field: "price".into(),
+        values: vec![json!(10), json!("not-a-number")],
+    };
+    assert!(condition_bitmap(&state, &cond).is_none());
+}
+
+#[test]
+fn empty_in_list_is_exact_empty() {
+    let state = sample_state();
+    let cond = Condition::In {
+        field: "category".into(),
+        values: vec![],
+    };
+    let eval = condition_bitmap(&state, &cond).expect("supported");
+    assert!(eval.bits.is_empty());
+    assert!(eval.exact);
+}
+
+#[test]
+fn and_with_unsupported_branch_is_inexact_superset() {
+    let state = sample_state();
+    let cond = Condition::And {
+        conditions: vec![
+            Condition::Eq {
+                field: "category".into(),
+                value: json!("tech"),
+            },
+            Condition::Like {
+                field: "category".into(),
+                pattern: "%ech".into(),
+            },
+        ],
+    };
+    let eval = condition_bitmap(&state, &cond).expect("supported branch present");
+    assert_eq!(rows(&eval), vec![0, 2]); // superset from the Eq branch
+    assert!(!eval.exact);
+}
+
+#[test]
+fn empty_and_is_identity_over_live_rows() {
+    let state = sample_state();
+    let cond = Condition::And { conditions: vec![] };
+    let eval = condition_bitmap(&state, &cond).expect("identity");
+    assert_eq!(rows(&eval), vec![0, 1, 2, 3, 4, 5]);
+    assert!(eval.exact);
+}
+
+#[test]
+fn or_with_unsupported_branch_falls_back() {
+    let state = sample_state();
+    let cond = Condition::Or {
+        conditions: vec![
+            Condition::Eq {
+                field: "category".into(),
+                value: json!("tech"),
+            },
+            Condition::Like {
+                field: "category".into(),
+                pattern: "%bio".into(),
+            },
+        ],
+    };
+    assert!(condition_bitmap(&state, &cond).is_none());
+}
+
+#[test]
+fn or_unions_branches() {
+    let state = sample_state();
+    let cond = Condition::Or {
+        conditions: vec![
+            Condition::Eq {
+                field: "category".into(),
+                value: json!("bio"),
+            },
+            Condition::Gt {
+                field: "price".into(),
+                value: json!(25),
+            },
+        ],
+    };
+    let eval = condition_bitmap(&state, &cond).expect("supported");
+    assert_eq!(rows(&eval), vec![1, 2]);
+    assert!(eval.exact);
+}
+
+#[test]
+fn not_over_inexact_falls_back() {
+    let state = sample_state();
+    let cond = Condition::Not {
+        condition: Box::new(Condition::And {
+            conditions: vec![
+                Condition::Eq {
+                    field: "category".into(),
+                    value: json!("tech"),
+                },
+                Condition::Like {
+                    field: "category".into(),
+                    pattern: "%x".into(),
+                },
+            ],
+        }),
+    };
+    assert!(condition_bitmap(&state, &cond).is_none());
+}
+
+#[test]
+fn not_over_exact_complements() {
+    let state = sample_state();
+    let cond = Condition::Not {
+        condition: Box::new(Condition::In {
+            field: "category".into(),
+            values: vec![json!("tech")],
+        }),
+    };
+    let eval = condition_bitmap(&state, &cond).expect("supported");
+    assert_eq!(rows(&eval), vec![1, 3, 4, 5]);
+    assert!(eval.exact);
+}
+
+#[test]
+fn upsert_same_id_is_last_writer_wins() {
+    let mut state = MirrorState::default();
+    assert!(state.upsert_row(7, Some(&json!({"category": "old"}))));
+    assert!(state.upsert_row(7, Some(&json!({"category": "new"}))));
+    assert_eq!(state.live.len(), 1);
+
+    let old = Condition::Eq {
+        field: "category".into(),
+        value: json!("old"),
+    };
+    let eval = condition_bitmap(&state, &old).expect("supported");
+    assert!(eval.bits.is_empty());
+
+    let new = Condition::Eq {
+        field: "category".into(),
+        value: json!("new"),
+    };
+    let eval = condition_bitmap(&state, &new).expect("supported");
+    assert_eq!(eval.bits.len(), 1);
+}
+
+#[test]
+fn column_cap_routes_overflow_fields_to_fallback() {
+    let mut state = MirrorState::default();
+    let mut payload = serde_json::Map::new();
+    for i in 0..70 {
+        payload.insert(format!("field{i:02}"), json!(i));
+    }
+    assert!(state.upsert_row(1, Some(&serde_json::Value::Object(payload))));
+    assert_eq!(state.store.column_names().count(), 64);
+    assert_eq!(state.uncolumnized.len(), 6);
+
+    let capped_field = state
+        .uncolumnized
+        .iter()
+        .next()
+        .expect("capped field exists")
+        .clone();
+    let cond = Condition::Eq {
+        field: capped_field,
+        value: json!(1),
+    };
+    assert!(condition_bitmap(&state, &cond).is_none());
+}

--- a/crates/velesdb-core/src/collection/search/query/execution_paths.rs
+++ b/crates/velesdb-core/src/collection/search/query/execution_paths.rs
@@ -225,7 +225,14 @@ impl Collection {
             tracing::debug!("dispatch_metadata_only: indexed path succeeded");
             return indexed;
         }
-        tracing::debug!("dispatch_metadata_only: indexed path returned None, trying BM25");
+        tracing::debug!("dispatch_metadata_only: indexed path returned None, trying mirror");
+
+        // ColumnStore payload mirror: typed columnar bitmap scan when no
+        // secondary index covers the condition. Built adaptively once enough
+        // full-scan debt accumulates (see collection/payload_mirror).
+        if let Some(mirror_results) = self.try_mirror_filter(&filter, execution_limit) {
+            return mirror_results;
+        }
 
         // Try BM25 text search for LIKE conditions before falling back to full scan.
         // When a LIKE pattern contains a word-like substring (e.g. `%google%`),
@@ -259,6 +266,34 @@ impl Collection {
         }
         // Too many bitmap hits — fall through to scan with early exit
         None
+    }
+
+    /// Attempts a `ColumnStore` payload-mirror scan for the filter.
+    ///
+    /// The mirror returns a candidate id superset from typed columnar
+    /// bitmaps; `scan_ids_with_filter` post-filters with the JSON filter,
+    /// so results are exactly those of the sequential scan path. Candidates
+    /// are hydrated in chunks so broad matches (e.g. `!=` over most rows)
+    /// stay memory-bounded and benefit from early exit at the limit.
+    ///
+    /// Returns `None` when the mirror is not built (insufficient scan debt),
+    /// or the condition is not answerable from columnar data.
+    fn try_mirror_filter(
+        &self,
+        filter: &crate::filter::Filter,
+        execution_limit: usize,
+    ) -> Option<Vec<SearchResult>> {
+        const HYDRATION_CHUNK: usize = 1024;
+        let candidate_ids = self.mirror_candidate_ids(&filter.condition)?;
+        let mut results = Vec::new();
+        for chunk in candidate_ids.chunks(HYDRATION_CHUNK) {
+            let remaining = execution_limit.saturating_sub(results.len());
+            if remaining == 0 {
+                break;
+            }
+            results.extend(self.scan_ids_with_filter(chunk, filter, remaining));
+        }
+        Some(results)
     }
 
     /// Attempts to accelerate a LIKE condition using the BM25 text index.

--- a/crates/velesdb-core/src/collection/search/query/similarity_filter.rs
+++ b/crates/velesdb-core/src/collection/search/query/similarity_filter.rs
@@ -281,7 +281,20 @@ impl Collection {
             vector_ids
         };
 
-        Self::collect_filtered_scan(&*payload_storage, &*vector_storage, ids, filter, limit)
+        // Record rows actually visited as payload-mirror scan debt: once the
+        // debt exceeds one full-scan-equivalent, the next metadata query
+        // builds the columnar mirror and skips this fallback entirely.
+        let mut scanned: u64 = 0;
+        let counted_ids = ids.into_iter().inspect(|_| scanned += 1);
+        let results = Self::collect_filtered_scan(
+            &*payload_storage,
+            &*vector_storage,
+            counted_ids,
+            filter,
+            limit,
+        );
+        self.payload_mirror.add_scan_debt(scanned);
+        results
     }
 
     /// Shared scan body: iterates `ids`, hydrates each matching point, and

--- a/crates/velesdb-core/src/collection/types.rs
+++ b/crates/velesdb-core/src/collection/types.rs
@@ -136,6 +136,7 @@ impl CollectionType {
 //
 // Canonical order (acquire lower numbers first):
 //   1. config
+//   1b. payload_mirror   (held while acquiring 2 and 3 during the lazy build)
 //   2. vector_storage
 //   3. payload_storage
 //   4. sq8_cache / binary_cache / pq_cache  (any order among themselves)
@@ -242,6 +243,15 @@ pub(crate) struct Collection {
 
     /// Secondary indexes for metadata payload fields.
     pub(super) secondary_indexes: Arc<RwLock<HashMap<String, SecondaryIndex>>>,
+
+    /// Columnar mirror of top-level scalar payload fields (`ColumnStore`).
+    ///
+    /// Lazily built when full-scan debt warrants it; consulted by
+    /// `dispatch_metadata_filter` before the JSON scan fallback.
+    /// Lock order position: **1b** — held while acquiring `vector_storage`
+    /// (2) and `payload_storage` (3) during the lazy build; mutation hooks
+    /// and queries acquire it with no other collection lock held.
+    pub(crate) payload_mirror: Arc<crate::collection::payload_mirror::PayloadMirror>,
 
     /// Guard-rails for query execution (EPIC-048).
     pub(crate) guard_rails: Arc<GuardRails>,

--- a/crates/velesdb-core/src/column_store/filter.rs
+++ b/crates/velesdb-core/src/column_store/filter.rs
@@ -35,9 +35,26 @@ fn scan_int_column(
         .collect()
 }
 
-/// Scans an integer column, returning a `RoaringBitmap` of matching indices.
+/// Scans a typed column slice, returning a `RoaringBitmap` of indices where
+/// `predicate(val)` is true. Excludes deleted rows.
 ///
 /// Indices >= `u32::MAX` are safely skipped (not truncated).
+fn scan_cells_bitmap<T: Copy>(
+    cells: &[Option<T>],
+    deleted_rows: &rustc_hash::FxHashSet<usize>,
+    predicate: impl Fn(T) -> bool,
+) -> RoaringBitmap {
+    cells
+        .iter()
+        .enumerate()
+        .filter_map(|(idx, v)| match v {
+            Some(val) if predicate(*val) && !deleted_rows.contains(&idx) => u32::try_from(idx).ok(),
+            _ => None,
+        })
+        .collect()
+}
+
+/// Scans an integer column, returning a `RoaringBitmap` of matching indices.
 fn scan_int_column_bitmap(
     store: &ColumnStore,
     column: &str,
@@ -46,15 +63,27 @@ fn scan_int_column_bitmap(
     let Some(TypedColumn::Int(col)) = store.columns.get(column) else {
         return RoaringBitmap::new();
     };
-    col.iter()
-        .enumerate()
-        .filter_map(|(idx, v)| match v {
-            Some(val) if predicate(*val) && !store.deleted_rows.contains(&idx) => {
-                u32::try_from(idx).ok()
-            }
-            _ => None,
-        })
-        .collect()
+    scan_cells_bitmap(col, &store.deleted_rows, predicate)
+}
+
+/// Scans a float column, returning a `RoaringBitmap` of matching indices.
+fn scan_float_column_bitmap(
+    store: &ColumnStore,
+    column: &str,
+    predicate: impl Fn(f64) -> bool,
+) -> RoaringBitmap {
+    let Some(TypedColumn::Float(col)) = store.columns.get(column) else {
+        return RoaringBitmap::new();
+    };
+    scan_cells_bitmap(col, &store.deleted_rows, predicate)
+}
+
+/// Scans a bool column, returning a `RoaringBitmap` of rows equal to `value`.
+fn scan_bool_column_bitmap(store: &ColumnStore, column: &str, value: bool) -> RoaringBitmap {
+    let Some(TypedColumn::Bool(col)) = store.columns.get(column) else {
+        return RoaringBitmap::new();
+    };
+    scan_cells_bitmap(col, &store.deleted_rows, |v| v == value)
 }
 
 /// Scans a string column for rows whose interned id matches `target_id`.
@@ -86,16 +115,7 @@ fn scan_string_column_bitmap(
     let Some(TypedColumn::String(col)) = store.columns.get(column) else {
         return RoaringBitmap::new();
     };
-    col.iter()
-        .enumerate()
-        .filter_map(|(idx, v)| {
-            if *v == Some(target_id) && !store.deleted_rows.contains(&idx) {
-                u32::try_from(idx).ok()
-            } else {
-                None
-            }
-        })
-        .collect()
+    scan_cells_bitmap(col, &store.deleted_rows, |id| id == target_id)
 }
 
 impl ColumnStore {
@@ -230,6 +250,26 @@ impl ColumnStore {
     #[must_use]
     pub fn filter_range_int_bitmap(&self, column: &str, low: i64, high: i64) -> RoaringBitmap {
         scan_int_column_bitmap(self, column, |v| v > low && v < high)
+    }
+
+    /// Filters a float column by an arbitrary predicate, returning a bitmap.
+    ///
+    /// Excludes deleted rows. Indices >= `u32::MAX` are safely skipped.
+    /// Used by the payload mirror, which stores all JSON numbers as `f64`
+    /// to mirror the JSON filter's numeric comparison semantics.
+    pub(crate) fn filter_float_bitmap(
+        &self,
+        column: &str,
+        predicate: impl Fn(f64) -> bool,
+    ) -> RoaringBitmap {
+        scan_float_column_bitmap(self, column, predicate)
+    }
+
+    /// Filters a bool column by equality, returning a bitmap.
+    ///
+    /// Excludes deleted rows. Indices >= `u32::MAX` are safely skipped.
+    pub(crate) fn filter_bool_eq_bitmap(&self, column: &str, value: bool) -> RoaringBitmap {
+        scan_bool_column_bitmap(self, column, value)
     }
 
     /// Combines two filter results using AND.

--- a/crates/velesdb-core/src/column_store/mod.rs
+++ b/crates/velesdb-core/src/column_store/mod.rs
@@ -7,9 +7,10 @@
 //!
 //! - Maintain 50M+ items/sec filter throughput at 100k items (vs 19M/s with
 //!   JSON) — measured by the `column_filter_benchmark` micro-benchmark of
-//!   this module's filtering API; the `SELECT ... WHERE` query path does not
-//!   currently invoke these typed filters (it uses secondary indexes + JSON
-//!   payload filters; the `ColumnStore` backs JOIN execution)
+//!   this module's filtering API. The `SELECT ... WHERE` query path invokes
+//!   these typed filters through the per-collection payload mirror
+//!   (`collection::payload_mirror`), built adaptively for scan-heavy
+//!   workloads; the `ColumnStore` also backs JOIN execution.
 //! - Cache-friendly sequential memory access
 //! - Support for common filter operations: Eq, Gt, Lt, In, Range
 //!
@@ -169,6 +170,32 @@ impl ColumnStore {
             ColumnType::GeoPoint => TypedColumn::new_geopoint(0),
         };
         self.columns.insert(name.to_string(), column);
+    }
+
+    /// Adds a column after rows already exist, backfilling nulls so the new
+    /// column stays aligned with `row_count` (required by the per-collection
+    /// payload mirror, whose schema evolves as new fields appear).
+    pub(crate) fn add_column_backfilled(&mut self, name: &str, col_type: &ColumnType) {
+        self.add_column(name, col_type);
+        if let Some(column) = self.columns.get_mut(name) {
+            for _ in 0..self.row_count {
+                column.push_null();
+            }
+        }
+    }
+
+    /// Tombstones a row by index without requiring the primary-key machinery.
+    ///
+    /// Used by the payload mirror, which maps point ids to row indices
+    /// externally (`u64` ids do not fit the `i64` primary-key API).
+    pub(crate) fn tombstone_row(&mut self, row_idx: usize) {
+        if row_idx >= self.row_count {
+            return;
+        }
+        self.deleted_rows.insert(row_idx);
+        if let Ok(idx) = u32::try_from(row_idx) {
+            self.deletion_bitmap.insert(idx);
+        }
     }
 
     /// Returns the total number of rows in the store (including deleted/tombstoned rows).

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -198,6 +198,11 @@ Local measurement (i9-14900KF, 10K vectors, 384D): upsert throughput ~808 vec/s 
 
 ## 6. ColumnStore Filtering
 
+Micro-benchmarks of the ColumnStore filtering API (`column_filter_benchmark`).
+This API serves `SELECT ... WHERE` metadata filtering through the adaptive
+per-collection payload mirror (`collection/payload_mirror`) and backs JOIN
+execution.
+
 #### String Equality Filter (`filter_eq_string`, measured 2026-03-19)
 
 | Scale | ColumnStore | JSON Scan | Speedup |

--- a/docs/reference/ARCHITECTURE.md
+++ b/docs/reference/ARCHITECTURE.md
@@ -144,9 +144,9 @@ VelesDB core architecture is explicitly **hybrid by design**:
   - `WITH` (max_groups, group_limit)
 
 #### Filter Engine
-- ColumnStore-based filtering
+- ColumnStore-based filtering (adaptive per-collection payload mirror in the `SELECT ... WHERE` path)
 - RoaringBitmap for set operations
-- Up to 130x faster than JSON filtering
+- Up to 130x faster than JSON filtering (filtering-API micro-benchmark)
 
 #### Aggregation Engine (EPIC-017/018)
 - Streaming aggregation executor

--- a/docs/reference/promise-contract.json
+++ b/docs/reference/promise-contract.json
@@ -144,7 +144,7 @@
       "file": "README.md",
       "must_contain": "100K rows",
       "validation_command": "cargo bench -p velesdb-core --bench column_filter_benchmark",
-      "source": "README.md ColumnStore 130x speedup baseline. Footnote *¹ scopes the claim: filtering-API micro-benchmark, integer equality, 130x at 100K rows / 55x at 10K rows (docs/BENCHMARKS.md section 6); no 1M-row measurement exists.",
+      "source": "README.md ColumnStore 130x speedup baseline. Footnote *¹ scopes the claim: filtering-API micro-benchmark, integer equality, 130x at 100K rows / 55x at 10K rows (docs/BENCHMARKS.md section 6); no 1M-row measurement exists. The filtering API serves SELECT WHERE via the adaptive payload mirror (collection/payload_mirror).",
       "last_updated": "2026-06-10"
     }
   ]


### PR DESCRIPTION
## Summary

Closes the biggest gap from the 2026-06 deep audit: **the ColumnStore — the third engine of the mission — had no production caller in the query path.** `SELECT ... WHERE` ran on secondary indexes + per-row JSON payload matching, and the documented 130x columnar speedup only existed in a micro-benchmark with no caller.

This PR wires the ColumnStore typed/bitmap filter engine into the production WHERE path through a per-collection **payload mirror** (`crates/velesdb-core/src/collection/payload_mirror/`).

## How it works

- **Columnar mirror**: top-level scalar payload fields are mirrored into typed columns (numbers as `f64`, strings interned, bools). WHERE conditions compile to `RoaringBitmap` scans (`Eq`/`Neq`/`Gt`/`Gte`/`Lt`/`Lte`/`IN`/`BETWEEN`/`AND`/`OR`/`NOT`).
- **Adaptive build**: every full sequential JSON scan records its row count as *scan debt*; the mirror is built only once debt exceeds one full-scan-equivalent (and the collection has ≥ 256 rows). Limit-k early-exit scans never trigger a build, so point lookups keep their fast path. Candidate hydration is chunked (1024) with early exit at the limit.
- **Soundness**: leaves translate only under strict type-match eligibility, replicating `filter::matching` semantics exactly (incl. `f64` epsilon equality) — **false negatives are impossible by construction**; the existing JSON post-filter removes false positives. Complements (`NOT`, `!=`) are only taken over exact operands. Unsupported shapes (LIKE, geo, arrays, dotted paths, cross-type literals, capped-out fields) fall back to the existing paths.
- **Consistency**: `upsert` / `upsert_metadata` / `upsert_bulk` / `delete` maintain the mirror incrementally; **every other mutation path funnels through `invalidate_caches_and_bump_generation`, which now drops the mirror** — a future write path can never serve stale columnar data, at worst it costs a lazy rebuild. `store_node_payload` invalidates explicitly. New lock rank **1b** documented in `types.rs` and followed by the build path (mirror → vector_storage → payload_storage, ascending).
- **Precedence preserved**: secondary-index bitmap and indexed paths still run first; the mirror replaces only the full-JSON-scan fallback (and the fragile BM25-LIKE heuristic when it can answer).

## ColumnStore engine additions

- `add_column_backfilled` — schema evolution after rows exist (null backfill keeps columns aligned)
- `tombstone_row` — row tombstoning for u64 point ids without the i64 primary-key machinery
- closure-based `Float`/`Bool` bitmap scans, deduplicated with the existing Int/String scans through a shared `scan_cells_bitmap` helper

## Docs

README (130x claim now scoped to the wired reality), BENCHMARKS §6, reference ARCHITECTURE filter engine, promise-contract source note, `column_store` module header.

## Validation

- **30 new tests**: translation soundness (eligibility, exactness, complements, tombstones, column cap, mixed types) + collection-level behavior (adaptive build trigger, scan-path parity across operators, incremental upsert/delete sync, fallback correctness, metadata-only collections, sub-threshold collections never build)
- Full core suite: **5823 passed / 0 failed** (`--test-threads=1`)
- `cargo clippy --all-targets -D warnings -D clippy::pedantic`: clean
- `cargo check --no-default-features` + WASM target: clean
- lizard: all new functions CC ≤ 8, NLOC ≤ 50
- Search path (HNSW/SIMD/quantization/fusion) untouched — no recall impact

## Follow-ups (separate branches, in flight)

GraphFirst anchor-ids prefilter into filtered HNSW; agent-memory graph dimension; quantization wiring; CI vitest + scheduled 100K recall.