### PR TITLE
feat(graph,agent): edge-aware MATCH dedup, openCypher var-length list semantics, durable post-hoc TTL setters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **BREAKING (VelesQL) — variable-length relationship aliases bind lists
+  (openCypher semantics)**: `MATCH (a)-[r:T*1..3]->(b)` now binds `r` to the
+  ordered LIST of traversed relationships instead of the last edge.
+  `RETURN r` projects the edge-id list, `RETURN r.prop` projects the
+  positional per-edge value list (previously a scalar — including for the
+  degenerate `*1..1` range), and `WHERE r.prop` uses ANY-element semantics
+  (previously last-edge). Fixed-length aliases (`-[r:T]->`) keep their scalar
+  behavior. Migration: queries templating a `*1..1` range that read `r.prop`
+  as a scalar must read element 0 of the projected list instead.
+- **MATCH row cardinality with aliased parallel edges**: result dedup now
+  includes relationship bindings, so two parallel edges between the same node
+  pair yield one row per ALIASED edge (previously they collapsed to one row).
+  Unaliased patterns (`-[:T]->`) keep the collapsed cardinality. Result
+  payloads now carry `_edge_bindings` / `_edge_paths` alongside `_bindings`
+  so rows are distinguishable by edge identity.
+
+### Added
+- **Durable post-hoc TTL setters for agent memory**: Result-returning
+  `set_semantic_ttl_durable` / `set_episodic_ttl_durable` /
+  `set_procedural_ttl_durable` on `AgentMemory` (and `set_ttl_durable` on each
+  subsystem) persist the expiry to the reserved `_veles_expires_at` payload
+  field so it survives a restart; refreshing an expired or missing id returns
+  `NotFound`. The in-memory `set_*_ttl` setters are now documented as volatile.
+- **ColumnStore in the SELECT WHERE path (#1075)**: adaptive per-collection
+  payload mirror compiles metadata filters to RoaringBitmap scans once
+  sequential-scan debt justifies the build; secondary indexes keep precedence.
+- **CI (#1076)**: full TypeScript SDK vitest suite on every PR; nightly 100K
+  recall@10 ≥ 0.95 gate (`perf-gate-e2e` schedule + manual dispatch).
+
 ## [1.18.0] — 2026-06-07
 
 ### Changed

--- a/crates/velesdb-core/src/agent/episodic_memory.rs
+++ b/crates/velesdb-core/src/agent/episodic_memory.rs
@@ -183,6 +183,28 @@ impl EpisodicMemory {
         Ok(())
     }
 
+    /// Durably sets (or refreshes) the TTL of an existing event.
+    ///
+    /// Unlike `AgentMemory::set_episodic_ttl` (in-memory map only, lost on
+    /// restart), this persists the expiry to the reserved `_veles_expires_at`
+    /// payload field, so it survives a restart. A `ttl_seconds` of 0 expires
+    /// the event immediately.
+    ///
+    /// # Errors
+    ///
+    /// Returns `NotFound` when no event with `event_id` exists, or
+    /// `CollectionError` when persistence fails.
+    pub fn set_ttl_durable(&self, event_id: u64, ttl_seconds: u64) -> Result<(), AgentMemoryError> {
+        memory_helpers::set_ttl_durable(
+            &self.db,
+            &self.collection_name,
+            &self.ttl,
+            MemoryKind::Episodic,
+            event_id,
+            ttl_seconds,
+        )
+    }
+
     /// Returns recent events, optionally filtered by a lower timestamp bound.
     ///
     /// # Errors

--- a/crates/velesdb-core/src/agent/memory.rs
+++ b/crates/velesdb-core/src/agent/memory.rs
@@ -138,19 +138,73 @@ impl AgentMemory {
         &self.procedural
     }
 
-    /// Sets TTL for a semantic memory entry.
+    /// Sets TTL for a semantic memory entry (in-memory only; lost on restart).
+    ///
+    /// Use [`Self::set_semantic_ttl_durable`] to persist the expiry.
     pub fn set_semantic_ttl(&self, id: u64, ttl_seconds: u64) {
         self.ttl.set_ttl(MemoryKind::Semantic, id, ttl_seconds);
     }
 
-    /// Sets TTL for an episodic memory entry.
+    /// Sets TTL for an episodic memory entry (in-memory only; lost on restart).
+    ///
+    /// Use [`Self::set_episodic_ttl_durable`] to persist the expiry.
     pub fn set_episodic_ttl(&self, id: u64, ttl_seconds: u64) {
         self.ttl.set_ttl(MemoryKind::Episodic, id, ttl_seconds);
     }
 
-    /// Sets TTL for a procedural memory entry.
+    /// Sets TTL for a procedural memory entry (in-memory only; lost on restart).
+    ///
+    /// Use [`Self::set_procedural_ttl_durable`] to persist the expiry.
     pub fn set_procedural_ttl(&self, id: u64, ttl_seconds: u64) {
         self.ttl.set_ttl(MemoryKind::Procedural, id, ttl_seconds);
+    }
+
+    /// Durably sets the TTL of an existing semantic fact: the expiry is
+    /// persisted to the reserved `_veles_expires_at` payload field and
+    /// survives a restart.
+    ///
+    /// # Errors
+    ///
+    /// Returns `NotFound` when no fact with `id` exists, or
+    /// `CollectionError` when persistence fails.
+    pub fn set_semantic_ttl_durable(
+        &self,
+        id: u64,
+        ttl_seconds: u64,
+    ) -> Result<(), AgentMemoryError> {
+        self.semantic.set_ttl_durable(id, ttl_seconds)
+    }
+
+    /// Durably sets the TTL of an existing episodic event: the expiry is
+    /// persisted to the reserved `_veles_expires_at` payload field and
+    /// survives a restart.
+    ///
+    /// # Errors
+    ///
+    /// Returns `NotFound` when no event with `id` exists, or
+    /// `CollectionError` when persistence fails.
+    pub fn set_episodic_ttl_durable(
+        &self,
+        id: u64,
+        ttl_seconds: u64,
+    ) -> Result<(), AgentMemoryError> {
+        self.episodic.set_ttl_durable(id, ttl_seconds)
+    }
+
+    /// Durably sets the TTL of an existing procedure: the expiry is
+    /// persisted to the reserved `_veles_expires_at` payload field and
+    /// survives a restart.
+    ///
+    /// # Errors
+    ///
+    /// Returns `NotFound` when no procedure with `id` exists, or
+    /// `CollectionError` when persistence fails.
+    pub fn set_procedural_ttl_durable(
+        &self,
+        id: u64,
+        ttl_seconds: u64,
+    ) -> Result<(), AgentMemoryError> {
+        self.procedural.set_ttl_durable(id, ttl_seconds)
     }
 
     /// Performs automatic expiration of entries that have exceeded their TTL.

--- a/crates/velesdb-core/src/agent/memory_helpers.rs
+++ b/crates/velesdb-core/src/agent/memory_helpers.rs
@@ -311,6 +311,25 @@ pub(super) fn attach_expiry(payload: &mut serde_json::Value, expires_at: Option<
     }
 }
 
+/// Retrieves a point by id, surfacing `NotFound` when it does not exist.
+///
+/// The `collection.get(&[id]) … next()` idiom shared by the agent
+/// read-modify-write flows (`set_ttl_durable`, metadata updates).
+pub(super) fn get_point_or_not_found(
+    collection: &Collection,
+    collection_name: &str,
+    id: u64,
+) -> Result<Point, AgentMemoryError> {
+    collection
+        .get(&[id])
+        .into_iter()
+        .flatten()
+        .next()
+        .ok_or_else(|| {
+            AgentMemoryError::NotFound(format!("memory id {id} not found in {collection_name}"))
+        })
+}
+
 /// Durably sets (or refreshes) the TTL of an existing memory point.
 ///
 /// Unlike `MemoryTtl::set_ttl` (in-memory map only, lost on restart), this
@@ -318,10 +337,23 @@ pub(super) fn attach_expiry(payload: &mut serde_json::Value, expires_at: Option<
 /// an upsert and then updates the in-memory map, so the TTL survives a
 /// restart (it is rebuilt by [`rebuild_ttl_from_payloads`]).
 ///
+/// A `ttl_seconds` of 0 expires the entry immediately; its storage is
+/// reclaimed by the next `auto_expire` sweep. Expired entries are invisible
+/// on every read surface and cannot be resurrected here: refreshing an
+/// already-expired id returns `NotFound`, mirroring `update_metadata`.
+///
+/// # Concurrency
+///
+/// This is a read-modify-write without a cross-call lock (the engine has no
+/// transactions): a concurrent writer to the same id follows last-writer-wins
+/// for the whole point, like the other agent update flows.
+///
 /// # Errors
 ///
-/// Returns `NotFound` when no point with `id` exists, or `CollectionError`
-/// when the collection cannot be resolved or the upsert fails.
+/// Returns `NotFound` when no live point with `id` exists, or
+/// `CollectionError` when the collection cannot be resolved, the stored
+/// payload is not a JSON object (the expiry field cannot be attached), or
+/// the upsert fails.
 pub(super) fn set_ttl_durable(
     db: &Database,
     collection_name: &str,
@@ -331,16 +363,26 @@ pub(super) fn set_ttl_durable(
     ttl_seconds: u64,
 ) -> Result<(), AgentMemoryError> {
     let collection = get_collection(db, collection_name)?;
-    let Some(point) = collection.get(&[id]).into_iter().flatten().next() else {
+    // Expired-but-not-yet-swept entries are invisible on every read surface;
+    // refreshing their TTL would silently resurrect them.
+    if ttl.is_expired(kind, id) {
         return Err(AgentMemoryError::NotFound(format!(
-            "memory id {id} not found in {collection_name}"
+            "memory id {id} is expired in {collection_name}"
         )));
-    };
+    }
+    let point = get_point_or_not_found(&collection, collection_name, id)?;
     let expires_at = super::ttl::MemoryTtl::now().saturating_add(ttl_seconds);
     let mut payload = point
         .payload
         .unwrap_or_else(|| serde_json::Value::Object(serde_json::Map::new()));
     attach_expiry(&mut payload, Some(expires_at));
+    if payload.get(EXPIRES_AT_KEY).is_none() {
+        // attach_expiry is a no-op on non-object payloads — failing loudly
+        // beats returning Ok for a TTL that would silently vanish on restart.
+        return Err(AgentMemoryError::CollectionError(format!(
+            "memory id {id} in {collection_name} has a non-object payload; cannot persist TTL"
+        )));
+    }
     upsert_points(
         &collection,
         vec![Point {

--- a/crates/velesdb-core/src/agent/memory_helpers.rs
+++ b/crates/velesdb-core/src/agent/memory_helpers.rs
@@ -311,6 +311,49 @@ pub(super) fn attach_expiry(payload: &mut serde_json::Value, expires_at: Option<
     }
 }
 
+/// Durably sets (or refreshes) the TTL of an existing memory point.
+///
+/// Unlike `MemoryTtl::set_ttl` (in-memory map only, lost on restart), this
+/// persists the expiry as the reserved [`EXPIRES_AT_KEY`] payload field via
+/// an upsert and then updates the in-memory map, so the TTL survives a
+/// restart (it is rebuilt by [`rebuild_ttl_from_payloads`]).
+///
+/// # Errors
+///
+/// Returns `NotFound` when no point with `id` exists, or `CollectionError`
+/// when the collection cannot be resolved or the upsert fails.
+pub(super) fn set_ttl_durable(
+    db: &Database,
+    collection_name: &str,
+    ttl: &super::ttl::MemoryTtl,
+    kind: super::ttl::MemoryKind,
+    id: u64,
+    ttl_seconds: u64,
+) -> Result<(), AgentMemoryError> {
+    let collection = get_collection(db, collection_name)?;
+    let Some(point) = collection.get(&[id]).into_iter().flatten().next() else {
+        return Err(AgentMemoryError::NotFound(format!(
+            "memory id {id} not found in {collection_name}"
+        )));
+    };
+    let expires_at = super::ttl::MemoryTtl::now().saturating_add(ttl_seconds);
+    let mut payload = point
+        .payload
+        .unwrap_or_else(|| serde_json::Value::Object(serde_json::Map::new()));
+    attach_expiry(&mut payload, Some(expires_at));
+    upsert_points(
+        &collection,
+        vec![Point {
+            id,
+            vector: point.vector,
+            payload: Some(payload),
+            sparse_vectors: point.sparse_vectors,
+        }],
+    )?;
+    ttl.set_expiry(kind, id, expires_at);
+    Ok(())
+}
+
 /// Rebuilds the in-memory TTL map for `kind` from persisted point payloads.
 ///
 /// Called eagerly at subsystem construction (same pattern and cost class as

--- a/crates/velesdb-core/src/agent/procedural_memory.rs
+++ b/crates/velesdb-core/src/agent/procedural_memory.rs
@@ -266,6 +266,32 @@ impl ProceduralMemory {
         Ok(())
     }
 
+    /// Durably sets (or refreshes) the TTL of an existing procedure.
+    ///
+    /// Unlike `AgentMemory::set_procedural_ttl` (in-memory map only, lost on
+    /// restart), this persists the expiry to the reserved `_veles_expires_at`
+    /// payload field, so it survives a restart. A `ttl_seconds` of 0 expires
+    /// the procedure immediately.
+    ///
+    /// # Errors
+    ///
+    /// Returns `NotFound` when no procedure with `procedure_id` exists, or
+    /// `CollectionError` when persistence fails.
+    pub fn set_ttl_durable(
+        &self,
+        procedure_id: u64,
+        ttl_seconds: u64,
+    ) -> Result<(), AgentMemoryError> {
+        memory_helpers::set_ttl_durable(
+            &self.db,
+            &self.collection_name,
+            &self.ttl,
+            MemoryKind::Procedural,
+            procedure_id,
+            ttl_seconds,
+        )
+    }
+
     /// Recalls matching procedures by vector similarity.
     ///
     /// When ACT-R activation decay is configured via

--- a/crates/velesdb-core/src/agent/semantic_memory.rs
+++ b/crates/velesdb-core/src/agent/semantic_memory.rs
@@ -234,6 +234,28 @@ impl SemanticMemory {
         Ok(())
     }
 
+    /// Durably sets (or refreshes) the TTL of an existing fact.
+    ///
+    /// Unlike `AgentMemory::set_semantic_ttl` (in-memory map only, lost on
+    /// restart), this persists the expiry to the reserved `_veles_expires_at`
+    /// payload field, so it survives a restart. A `ttl_seconds` of 0 expires
+    /// the fact immediately.
+    ///
+    /// # Errors
+    ///
+    /// Returns `NotFound` when no fact with `id` exists, or `CollectionError`
+    /// when persistence fails.
+    pub fn set_ttl_durable(&self, id: u64, ttl_seconds: u64) -> Result<(), AgentMemoryError> {
+        memory_helpers::set_ttl_durable(
+            &self.db,
+            &self.collection_name,
+            &self.ttl,
+            MemoryKind::Semantic,
+            id,
+            ttl_seconds,
+        )
+    }
+
     /// Queries semantic memory by vector similarity.
     ///
     /// # Errors

--- a/crates/velesdb-core/src/agent/semantic_memory_tests.rs
+++ b/crates/velesdb-core/src/agent/semantic_memory_tests.rs
@@ -2,6 +2,7 @@
 
 #[cfg(test)]
 mod tests {
+    use super::super::error::AgentMemoryError;
     use super::super::semantic_memory::SemanticMemory;
     use super::super::ttl::{MemoryKind, MemoryTtl};
     use crate::Database;
@@ -667,6 +668,72 @@ mod tests {
         let mut map = serde_json::Map::new();
         map.insert(key.to_string(), value);
         map
+    }
+
+    /// `set_ttl_durable` on an existing fact persists the expiry: after a
+    /// reopen the TTL map is rebuilt from the payload and the fact expires.
+    #[test]
+    fn test_set_ttl_durable_survives_restart() {
+        let dir = tempdir().unwrap();
+        let emb = vec![1.0_f32, 0.0, 0.0, 0.0];
+
+        {
+            let db = Arc::new(Database::open(dir.path()).unwrap());
+            let sm = make_semantic(Arc::clone(&db));
+            sm.store(1, "post-hoc expiring fact", &emb).unwrap();
+            // Post-hoc durable TTL: already elapsed (0 seconds).
+            sm.set_ttl_durable(1, 0).unwrap();
+        }
+
+        let (ttl, sm) = reopen_semantic(dir.path());
+
+        assert!(
+            ttl.get(MemoryKind::Semantic, 1).is_some(),
+            "durable post-hoc TTL must be rebuilt into the TTL map on reopen"
+        );
+        assert!(
+            ttl.is_expired(MemoryKind::Semantic, 1),
+            "a 0-second TTL must be expired after reopen"
+        );
+        assert!(
+            sm.get(1).unwrap().is_none(),
+            "expired fact must be invisible after reopen"
+        );
+    }
+
+    /// `set_ttl_durable` keeps the fact's existing metadata intact and only
+    /// adds the reserved expiry key.
+    #[test]
+    fn test_set_ttl_durable_preserves_existing_metadata() {
+        let dir = tempdir().unwrap();
+        let db = Arc::new(Database::open(dir.path()).unwrap());
+        let sm = make_semantic(Arc::clone(&db));
+        let emb = vec![1.0_f32, 0.0, 0.0, 0.0];
+
+        let meta = meta_one("source", serde_json::json!("chat"));
+        sm.store_with_metadata(1, "fact with metadata", &emb, &meta)
+            .unwrap();
+        sm.set_ttl_durable(1, 3600).unwrap();
+
+        let fact = sm.get(1).unwrap().expect("fact still alive (1h TTL)");
+        assert_eq!(fact.0, "fact with metadata", "content preserved");
+        let results = sm.query(&emb, 5).unwrap();
+        assert!(results.iter().any(|r| r.0 == 1), "fact stays queryable");
+    }
+
+    /// `set_ttl_durable` on a missing id surfaces a `NotFound` error instead
+    /// of silently arming a TTL for a nonexistent fact.
+    #[test]
+    fn test_set_ttl_durable_missing_id_is_not_found() {
+        let dir = tempdir().unwrap();
+        let db = Arc::new(Database::open(dir.path()).unwrap());
+        let sm = make_semantic(Arc::clone(&db));
+
+        let err = sm.set_ttl_durable(999, 60).unwrap_err();
+        assert!(
+            matches!(err, AgentMemoryError::NotFound(_)),
+            "missing id must yield NotFound, got: {err:?}"
+        );
     }
 
     /// A user business field named `expires_at` (subscription, offer, token…)

--- a/crates/velesdb-core/src/agent/semantic_memory_tests.rs
+++ b/crates/velesdb-core/src/agent/semantic_memory_tests.rs
@@ -721,6 +721,28 @@ mod tests {
         assert!(results.iter().any(|r| r.0 == 1), "fact stays queryable");
     }
 
+    /// `set_ttl_durable` on an expired-but-not-yet-swept id must surface
+    /// `NotFound` instead of resurrecting the dead fact with a fresh TTL
+    /// (expired entries are invisible on every read AND write surface).
+    #[test]
+    fn test_set_ttl_durable_expired_id_is_not_found() {
+        let dir = tempdir().unwrap();
+        let db = Arc::new(Database::open(dir.path()).unwrap());
+        let sm = make_semantic(Arc::clone(&db));
+        let emb = vec![1.0_f32, 0.0, 0.0, 0.0];
+
+        sm.store(1, "fact to expire", &emb).unwrap();
+        sm.set_ttl_durable(1, 0).unwrap(); // expires immediately
+        assert!(sm.get(1).unwrap().is_none(), "fact invisible once expired");
+
+        let err = sm.set_ttl_durable(1, 3600).unwrap_err();
+        assert!(
+            matches!(err, AgentMemoryError::NotFound(_)),
+            "refreshing an expired id must not resurrect it, got: {err:?}"
+        );
+        assert!(sm.get(1).unwrap().is_none(), "fact must stay invisible");
+    }
+
     /// `set_ttl_durable` on a missing id surfaces a `NotFound` error instead
     /// of silently arming a TTL for a nonexistent fact.
     #[test]

--- a/crates/velesdb-core/src/collection/search/query/match_dispatch.rs
+++ b/crates/velesdb-core/src/collection/search/query/match_dispatch.rs
@@ -302,10 +302,15 @@ fn collect_condition_predicates(
     }
 }
 
-/// Merges two sets of `MatchResult`s by `node_id` (union semantics).
+/// Merges two sets of `MatchResult`s by `node_id` + compatible bindings
+/// (union semantics).
 ///
-/// When both sets contain the same `node_id`, the result with the *better*
-/// score is kept (higher for similarity metrics, lower for distance metrics).
+/// Rows for the same `node_id` merge only when their bindings are
+/// *compatible* (no alias bound to different values on both sides): the
+/// result with the *better* score is kept (higher for similarity metrics,
+/// lower for distance metrics) and absorbs the loser's missing data. Rows
+/// with conflicting edge bindings stay separate so parallel edges between
+/// the same node pair survive the merge as distinct rows (audit 2026-06).
 /// Results without a score use a sentinel that always loses to real scores.
 ///
 /// The merged output is sorted best-to-worst according to `higher_is_better`.
@@ -316,63 +321,85 @@ fn merge_match_results(
 ) -> Vec<super::match_exec::MatchResult> {
     use std::collections::HashMap;
 
-    let mut by_node: HashMap<u64, super::match_exec::MatchResult> =
+    let mut by_node: HashMap<u64, Vec<super::match_exec::MatchResult>> =
         HashMap::with_capacity(graph_results.len() + vector_results.len());
 
-    for r in graph_results {
-        by_node.insert(r.node_id, r);
-    }
-
-    for r in vector_results {
+    for r in graph_results.into_iter().chain(vector_results) {
         upsert_better_score(&mut by_node, r, higher_is_better);
     }
 
-    let mut merged: Vec<super::match_exec::MatchResult> = by_node.into_values().collect();
+    let mut merged: Vec<super::match_exec::MatchResult> = by_node.into_values().flatten().collect();
     sort_match_results_by_score(&mut merged, higher_is_better);
     merged
 }
 
-/// Inserts `candidate` into `by_node`, keeping whichever entry has the better
-/// score while merging result data from the losing duplicate.
+/// Inserts `candidate` into its node group, merging into the first
+/// binding-compatible entry (better score wins) or appending a new row when
+/// every existing entry conflicts on some alias.
 ///
 /// Audit 2026-06 F2: replacing the whole entry dropped plan-specific data —
 /// a GraphFirst row's `r.*` projection/edge bindings were clobbered by the
 /// VectorFirst candidate for the same `node_id`. The winner keeps its score
 /// but absorbs the bindings/projections it is missing.
 fn upsert_better_score(
-    by_node: &mut std::collections::HashMap<u64, super::match_exec::MatchResult>,
+    by_node: &mut std::collections::HashMap<u64, Vec<super::match_exec::MatchResult>>,
     candidate: super::match_exec::MatchResult,
     higher_is_better: bool,
 ) {
+    let group = by_node.entry(candidate.node_id).or_default();
+    let Some(existing) = group
+        .iter_mut()
+        .find(|entry| bindings_compatible(entry, &candidate))
+    else {
+        group.push(candidate);
+        return;
+    };
+
     let worse_sentinel = if higher_is_better {
         f32::NEG_INFINITY
     } else {
         f32::MAX
     };
-    match by_node.entry(candidate.node_id) {
-        std::collections::hash_map::Entry::Occupied(mut entry) => {
-            let new_score = candidate.score.unwrap_or(worse_sentinel);
-            let old_score = entry.get().score.unwrap_or(worse_sentinel);
-            let new_wins = if higher_is_better {
-                new_score > old_score
-            } else {
-                new_score < old_score
-            };
-            if new_wins {
-                let loser = entry.insert(candidate);
-                merge_missing_result_data(entry.get_mut(), loser);
-            } else {
-                merge_missing_result_data(entry.get_mut(), candidate);
-            }
-        }
-        std::collections::hash_map::Entry::Vacant(entry) => {
-            entry.insert(candidate);
-        }
+    let new_score = candidate.score.unwrap_or(worse_sentinel);
+    let old_score = existing.score.unwrap_or(worse_sentinel);
+    let new_wins = if higher_is_better {
+        new_score > old_score
+    } else {
+        new_score < old_score
+    };
+    if new_wins {
+        let loser = std::mem::replace(existing, candidate);
+        merge_missing_result_data(existing, loser);
+    } else {
+        merge_missing_result_data(existing, candidate);
     }
 }
 
-/// Copies `projected`, `edge_bindings`, and `bindings` entries that the merge
-/// winner lacks from the losing duplicate (winner's own entries take priority).
+/// Whether two results for the same node can merge: no node alias, edge
+/// alias, or variable-length edge path is bound to *different* values on
+/// both sides. Aliases bound on only one side are compatible (the merge
+/// absorbs them); conflicting edge bindings mean distinct parallel-edge rows.
+fn bindings_compatible(
+    a: &super::match_exec::MatchResult,
+    b: &super::match_exec::MatchResult,
+) -> bool {
+    let maps_agree = |x: &std::collections::HashMap<String, u64>,
+                      y: &std::collections::HashMap<String, u64>| {
+        x.iter()
+            .all(|(k, v)| y.get(k).is_none_or(|other| other == v))
+    };
+    let paths_agree = a
+        .edge_paths
+        .iter()
+        .all(|(k, v)| b.edge_paths.get(k).is_none_or(|other| other == v));
+    maps_agree(&a.bindings, &b.bindings)
+        && maps_agree(&a.edge_bindings, &b.edge_bindings)
+        && paths_agree
+}
+
+/// Copies `projected`, `edge_bindings`, `edge_paths`, and `bindings` entries
+/// that the merge winner lacks from the losing duplicate (winner's own
+/// entries take priority).
 fn merge_missing_result_data(
     winner: &mut super::match_exec::MatchResult,
     loser: super::match_exec::MatchResult,
@@ -382,6 +409,9 @@ fn merge_missing_result_data(
     }
     for (key, value) in loser.edge_bindings {
         winner.edge_bindings.entry(key).or_insert(value);
+    }
+    for (key, value) in loser.edge_paths {
+        winner.edge_paths.entry(key).or_insert(value);
     }
     for (key, value) in loser.bindings {
         winner.bindings.entry(key).or_insert(value);

--- a/crates/velesdb-core/src/collection/search/query/match_dispatch.rs
+++ b/crates/velesdb-core/src/collection/search/query/match_dispatch.rs
@@ -302,16 +302,25 @@ fn collect_condition_predicates(
     }
 }
 
-/// Merges two sets of `MatchResult`s by `node_id` + compatible bindings
-/// (union semantics).
+/// Merges the GraphFirst and VectorFirst result sets (union semantics).
 ///
-/// Rows for the same `node_id` merge only when their bindings are
-/// *compatible* (no alias bound to different values on both sides): the
-/// result with the *better* score is kept (higher for similarity metrics,
-/// lower for distance metrics) and absorbs the loser's missing data. Rows
-/// with conflicting edge bindings stay separate so parallel edges between
-/// the same node pair survive the merge as distinct rows (audit 2026-06).
-/// Results without a score use a sentinel that always loses to real scores.
+/// Graph rows are authoritative row identities: the pattern walker already
+/// deduplicates them by full binding signature, so every graph row — one per
+/// aliased parallel edge or distinct edge path — is kept. A vector row is
+/// node-level enrichment: when graph rows exist for its `node_id`, it merges
+/// its (similarity) score and missing data into **every** row of that node
+/// (the score describes the node's embedding, not one edge); otherwise it
+/// stands alone as the node's row (union). The better score wins per row
+/// (higher for similarity metrics, lower for distance metrics); rows without
+/// a score use a sentinel that always loses to real scores.
+///
+/// Audit 2026-06 F2: replacing whole entries dropped plan-specific data — a
+/// GraphFirst row's `r.*` projection/edge bindings were clobbered by the
+/// VectorFirst candidate for the same `node_id`. Enrichment keeps every
+/// graph row and only fills in (or score-overrides) what the vector row
+/// contributes. Review 2026-06-11: enrichment applies to ALL rows of the
+/// node group, so parallel-edge siblings rank by the same node score instead
+/// of one arbitrary row absorbing it.
 ///
 /// The merged output is sorted best-to-worst according to `higher_is_better`.
 fn merge_match_results(
@@ -323,9 +332,21 @@ fn merge_match_results(
 
     let mut by_node: HashMap<u64, Vec<super::match_exec::MatchResult>> =
         HashMap::with_capacity(graph_results.len() + vector_results.len());
+    for row in graph_results {
+        by_node.entry(row.node_id).or_default().push(row);
+    }
 
-    for r in graph_results.into_iter().chain(vector_results) {
-        upsert_better_score(&mut by_node, r, higher_is_better);
+    for candidate in vector_results {
+        match by_node.entry(candidate.node_id) {
+            std::collections::hash_map::Entry::Occupied(mut group) => {
+                for row in group.get_mut() {
+                    enrich_row(row, &candidate, higher_is_better);
+                }
+            }
+            std::collections::hash_map::Entry::Vacant(slot) => {
+                slot.insert(vec![candidate]);
+            }
+        }
     }
 
     let mut merged: Vec<super::match_exec::MatchResult> = by_node.into_values().flatten().collect();
@@ -333,88 +354,54 @@ fn merge_match_results(
     merged
 }
 
-/// Inserts `candidate` into its node group, merging into the first
-/// binding-compatible entry (better score wins) or appending a new row when
-/// every existing entry conflicts on some alias.
+/// Enriches one graph row with a vector candidate for the same node.
 ///
-/// Audit 2026-06 F2: replacing the whole entry dropped plan-specific data —
-/// a GraphFirst row's `r.*` projection/edge bindings were clobbered by the
-/// VectorFirst candidate for the same `node_id`. The winner keeps its score
-/// but absorbs the bindings/projections it is missing.
-fn upsert_better_score(
-    by_node: &mut std::collections::HashMap<u64, Vec<super::match_exec::MatchResult>>,
-    candidate: super::match_exec::MatchResult,
+/// When the candidate's score is better, it replaces the row's score and its
+/// data takes priority on shared keys (e.g. a fresher `similarity()`
+/// projection); otherwise the candidate only fills keys the row lacks.
+fn enrich_row(
+    row: &mut super::match_exec::MatchResult,
+    candidate: &super::match_exec::MatchResult,
     higher_is_better: bool,
 ) {
-    let group = by_node.entry(candidate.node_id).or_default();
-    let Some(existing) = group
-        .iter_mut()
-        .find(|entry| bindings_compatible(entry, &candidate))
-    else {
-        group.push(candidate);
-        return;
-    };
-
     let worse_sentinel = if higher_is_better {
         f32::NEG_INFINITY
     } else {
         f32::MAX
     };
-    let new_score = candidate.score.unwrap_or(worse_sentinel);
-    let old_score = existing.score.unwrap_or(worse_sentinel);
-    let new_wins = if higher_is_better {
-        new_score > old_score
+    let candidate_score = candidate.score.unwrap_or(worse_sentinel);
+    let row_score = row.score.unwrap_or(worse_sentinel);
+    let candidate_wins = if higher_is_better {
+        candidate_score > row_score
     } else {
-        new_score < old_score
+        candidate_score < row_score
     };
-    if new_wins {
-        let loser = std::mem::replace(existing, candidate);
-        merge_missing_result_data(existing, loser);
-    } else {
-        merge_missing_result_data(existing, candidate);
+    if candidate_wins {
+        row.score = candidate.score;
     }
+    merge_map(&mut row.projected, &candidate.projected, candidate_wins);
+    merge_map(&mut row.bindings, &candidate.bindings, candidate_wins);
+    merge_map(
+        &mut row.edge_bindings,
+        &candidate.edge_bindings,
+        candidate_wins,
+    );
+    merge_map(&mut row.edge_paths, &candidate.edge_paths, candidate_wins);
 }
 
-/// Whether two results for the same node can merge: no node alias, edge
-/// alias, or variable-length edge path is bound to *different* values on
-/// both sides. Aliases bound on only one side are compatible (the merge
-/// absorbs them); conflicting edge bindings mean distinct parallel-edge rows.
-fn bindings_compatible(
-    a: &super::match_exec::MatchResult,
-    b: &super::match_exec::MatchResult,
-) -> bool {
-    let maps_agree = |x: &std::collections::HashMap<String, u64>,
-                      y: &std::collections::HashMap<String, u64>| {
-        x.iter()
-            .all(|(k, v)| y.get(k).is_none_or(|other| other == v))
-    };
-    let paths_agree = a
-        .edge_paths
-        .iter()
-        .all(|(k, v)| b.edge_paths.get(k).is_none_or(|other| other == v));
-    maps_agree(&a.bindings, &b.bindings)
-        && maps_agree(&a.edge_bindings, &b.edge_bindings)
-        && paths_agree
-}
-
-/// Copies `projected`, `edge_bindings`, `edge_paths`, and `bindings` entries
-/// that the merge winner lacks from the losing duplicate (winner's own
-/// entries take priority).
-fn merge_missing_result_data(
-    winner: &mut super::match_exec::MatchResult,
-    loser: super::match_exec::MatchResult,
+/// Copies `source` entries into `target`: overwriting on shared keys when
+/// `source_wins`, otherwise only filling keys the target lacks.
+fn merge_map<V: Clone>(
+    target: &mut std::collections::HashMap<String, V>,
+    source: &std::collections::HashMap<String, V>,
+    source_wins: bool,
 ) {
-    for (key, value) in loser.projected {
-        winner.projected.entry(key).or_insert(value);
-    }
-    for (key, value) in loser.edge_bindings {
-        winner.edge_bindings.entry(key).or_insert(value);
-    }
-    for (key, value) in loser.edge_paths {
-        winner.edge_paths.entry(key).or_insert(value);
-    }
-    for (key, value) in loser.bindings {
-        winner.bindings.entry(key).or_insert(value);
+    for (key, value) in source {
+        if source_wins {
+            target.insert(key.clone(), value.clone());
+        } else {
+            target.entry(key.clone()).or_insert_with(|| value.clone());
+        }
     }
 }
 
@@ -656,5 +643,36 @@ mod tests {
             Some(&serde_json::json!(2020)),
             "winner projection must be untouched"
         );
+    }
+
+    /// GIVEN two parallel-edge graph rows for the same node (distinct edge
+    ///   bindings) and one scored vector candidate for that node
+    /// WHEN the Parallel strategy merges the result sets
+    /// THEN BOTH rows survive AND both carry the node-level score (review
+    ///      2026-06-11: enrichment must reach every row of the node group,
+    ///      not the first one found).
+    #[test]
+    fn test_merge_enriches_all_parallel_edge_rows() {
+        let mut g1 = graph_mr_with_edge_data(1);
+        g1.edge_bindings.insert("r".to_string(), 100);
+        let mut g2 = graph_mr_with_edge_data(1);
+        g2.edge_bindings.insert("r".to_string(), 101);
+        let vector = vec![mr(1, Some(0.9))];
+
+        let merged = merge_match_results(vec![g1, g2], vector, true);
+
+        assert_eq!(merged.len(), 2, "both parallel-edge rows must survive");
+        for row in &merged {
+            assert!(
+                (row.score.expect("test: enriched score") - 0.9).abs() < f32::EPSILON,
+                "every row of the node group must carry the node-level score"
+            );
+        }
+        let mut edge_ids: Vec<u64> = merged
+            .iter()
+            .filter_map(|r| r.edge_bindings.get("r").copied())
+            .collect();
+        edge_ids.sort_unstable();
+        assert_eq!(edge_ids, vec![100, 101], "edge identities must be distinct");
     }
 }

--- a/crates/velesdb-core/src/collection/search/query/match_exec/expand.rs
+++ b/crates/velesdb-core/src/collection/search/query/match_exec/expand.rs
@@ -23,7 +23,19 @@ struct Walk<'a, 't> {
     bindings: &'a mut HashMap<String, u64>,
     /// Bound relationship aliases (alias -> traversed edge id).
     edge_bindings: &'a mut HashMap<String, u64>,
+    /// Variable-length relationship aliases (alias -> ordered edge-id list).
+    edge_paths: &'a mut HashMap<String, Vec<u64>>,
     path: &'a mut Vec<u64>,
+}
+
+/// Backtracking record for an edge-alias binding made by `bind_edge_alias`.
+enum EdgeAliasSave {
+    /// The relationship has no alias — nothing to restore.
+    None,
+    /// Fixed-length alias: restore the previous scalar binding (if any).
+    Scalar(String, Option<u64>),
+    /// Variable-length alias: pop the edge id pushed onto the alias's list.
+    PathPushed(String),
 }
 
 impl Collection {
@@ -43,12 +55,14 @@ impl Collection {
             let mut path = Vec::new();
             let mut bindings = start_bindings.clone();
             let mut edge_bindings = HashMap::new();
+            let mut edge_paths = HashMap::new();
             let mut walk = Walk {
                 pattern,
                 edge_store,
                 ctx: &mut *ctx,
                 bindings: &mut bindings,
                 edge_bindings: &mut edge_bindings,
+                edge_paths: &mut edge_paths,
                 path: &mut path,
             };
             self.expand_pattern(&mut walk, *start_id, 0)?;
@@ -125,31 +139,46 @@ impl Collection {
         Ok(())
     }
 
-    /// Binds the relationship alias (if any) to the traversed edge id so
+    /// Binds the relationship alias (if any) to the traversed edge so
     /// `WHERE r.prop` / `RETURN r.prop` resolve against the edge.
     ///
-    /// Returns the alias and its previous value for backtracking. For
-    /// variable-length relationships the alias tracks the most recently
-    /// traversed edge of that segment.
-    fn bind_edge_alias(
-        walk: &mut Walk<'_, '_>,
-        rel_idx: usize,
-        edge_id: u64,
-    ) -> Option<(String, Option<u64>)> {
-        let alias = walk.pattern.relationships[rel_idx].alias.clone()?;
+    /// Fixed-length aliases bind a single edge id. Variable-length aliases
+    /// (`[r*1..3]`) follow openCypher list semantics: each traversed hop is
+    /// appended to the alias's ordered edge-id list.
+    fn bind_edge_alias(walk: &mut Walk<'_, '_>, rel_idx: usize, edge_id: u64) -> EdgeAliasSave {
+        let rel = &walk.pattern.relationships[rel_idx];
+        let Some(alias) = rel.alias.clone() else {
+            return EdgeAliasSave::None;
+        };
+        if rel.range.is_some() {
+            walk.edge_paths
+                .entry(alias.clone())
+                .or_default()
+                .push(edge_id);
+            return EdgeAliasSave::PathPushed(alias);
+        }
         let previous = walk.edge_bindings.insert(alias.clone(), edge_id);
-        Some((alias, previous))
+        EdgeAliasSave::Scalar(alias, previous)
     }
 
     /// Restores a relationship alias binding saved by [`Self::bind_edge_alias`].
-    fn restore_edge_alias(walk: &mut Walk<'_, '_>, saved: Option<(String, Option<u64>)>) {
-        let Some((alias, previous)) = saved else {
-            return;
-        };
-        if let Some(edge_id) = previous {
-            walk.edge_bindings.insert(alias, edge_id);
-        } else {
-            walk.edge_bindings.remove(&alias);
+    fn restore_edge_alias(walk: &mut Walk<'_, '_>, saved: EdgeAliasSave) {
+        match saved {
+            EdgeAliasSave::None => {}
+            EdgeAliasSave::Scalar(alias, Some(edge_id)) => {
+                walk.edge_bindings.insert(alias, edge_id);
+            }
+            EdgeAliasSave::Scalar(alias, None) => {
+                walk.edge_bindings.remove(&alias);
+            }
+            EdgeAliasSave::PathPushed(alias) => {
+                if let Some(list) = walk.edge_paths.get_mut(&alias) {
+                    list.pop();
+                    if list.is_empty() {
+                        walk.edge_paths.remove(&alias);
+                    }
+                }
+            }
         }
     }
 
@@ -181,7 +210,10 @@ impl Collection {
             if !self.evaluate_where_condition(
                 node_id,
                 Some(&*walk.bindings),
-                Some(&*walk.edge_bindings),
+                super::where_eval::EdgeAliasBindings {
+                    scalar: Some(&*walk.edge_bindings),
+                    paths: Some(&*walk.edge_paths),
+                },
                 where_clause,
                 walk.ctx.params,
                 walk.ctx.payload_guard,
@@ -190,7 +222,7 @@ impl Collection {
             }
         }
 
-        let signature = Self::binding_signature(walk.bindings);
+        let signature = Self::binding_signature(walk.bindings, walk.edge_bindings, walk.edge_paths);
         if !walk.ctx.seen_bindings.insert(signature) {
             return Ok(());
         }
@@ -198,9 +230,11 @@ impl Collection {
         let mut result = MatchResult::new(node_id, walk.path.len() as u32, walk.path.clone());
         result.bindings.clone_from(walk.bindings);
         result.edge_bindings.clone_from(walk.edge_bindings);
+        result.edge_paths.clone_from(walk.edge_paths);
         result.projected = self.project_properties(
             walk.bindings,
             walk.edge_bindings,
+            walk.edge_paths,
             &walk.ctx.match_clause.return_clause,
             walk.ctx.payload_guard,
         );
@@ -304,9 +338,30 @@ impl Collection {
         AliasBinding::Inserted(alias.clone())
     }
 
-    fn binding_signature(bindings: &HashMap<String, u64>) -> Vec<(String, u64)> {
-        let mut signature: Vec<(String, u64)> =
-            bindings.iter().map(|(k, v)| (k.clone(), *v)).collect();
+    /// Dedup signature over node bindings, edge bindings, and edge paths.
+    ///
+    /// Edge bindings participate so parallel edges between the same node
+    /// pair yield distinct rows when the relationship is aliased (audit
+    /// 2026-06: parallel edges previously collapsed to one row). Prefixes
+    /// keep node and edge aliases from colliding in the flat key space.
+    fn binding_signature(
+        bindings: &HashMap<String, u64>,
+        edge_bindings: &HashMap<String, u64>,
+        edge_paths: &HashMap<String, Vec<u64>>,
+    ) -> Vec<(String, u64)> {
+        let mut signature: Vec<(String, u64)> = bindings
+            .iter()
+            .map(|(k, v)| (format!("n:{k}"), *v))
+            .collect();
+        signature.extend(edge_bindings.iter().map(|(k, v)| (format!("e:{k}"), *v)));
+        for (alias, edge_ids) in edge_paths {
+            signature.extend(
+                edge_ids
+                    .iter()
+                    .enumerate()
+                    .map(|(i, id)| (format!("p:{alias}:{i}"), *id)),
+            );
+        }
         signature.sort_by(|a, b| a.0.cmp(&b.0));
         signature
     }

--- a/crates/velesdb-core/src/collection/search/query/match_exec/expand.rs
+++ b/crates/velesdb-core/src/collection/search/query/match_exec/expand.rs
@@ -55,7 +55,15 @@ impl Collection {
             let mut path = Vec::new();
             let mut bindings = start_bindings.clone();
             let mut edge_bindings = HashMap::new();
-            let mut edge_paths = HashMap::new();
+            // Pre-seed every variable-length alias with an empty list so a
+            // zero-hop match (`*0..N`) binds `[]` (openCypher) instead of
+            // silently degrading to node-alias resolution.
+            let mut edge_paths: HashMap<String, Vec<u64>> = pattern
+                .relationships
+                .iter()
+                .filter(|rel| rel.range.is_some())
+                .filter_map(|rel| rel.alias.clone().map(|alias| (alias, Vec::new())))
+                .collect();
             let mut walk = Walk {
                 pattern,
                 edge_store,
@@ -151,6 +159,7 @@ impl Collection {
             return EdgeAliasSave::None;
         };
         if rel.range.is_some() {
+            // Entry pre-seeded in traverse_pattern; push this hop's edge.
             walk.edge_paths
                 .entry(alias.clone())
                 .or_default()
@@ -172,11 +181,10 @@ impl Collection {
                 walk.edge_bindings.remove(&alias);
             }
             EdgeAliasSave::PathPushed(alias) => {
+                // Pop only — the entry stays (pre-seeded; an empty list is
+                // the valid zero-hop binding).
                 if let Some(list) = walk.edge_paths.get_mut(&alias) {
                     list.pop();
-                    if list.is_empty() {
-                        walk.edge_paths.remove(&alias);
-                    }
                 }
             }
         }
@@ -342,27 +350,29 @@ impl Collection {
     ///
     /// Edge bindings participate so parallel edges between the same node
     /// pair yield distinct rows when the relationship is aliased (audit
-    /// 2026-06: parallel edges previously collapsed to one row). Prefixes
-    /// keep node and edge aliases from colliding in the flat key space.
+    /// 2026-06: parallel edges previously collapsed to one row). Entries are
+    /// structured `(namespace, alias, hop index, id)` tuples — node (0),
+    /// edge (1), path hop (2) — so alias namespaces cannot collide and no
+    /// per-row string formatting happens on this hot path.
     fn binding_signature(
         bindings: &HashMap<String, u64>,
         edge_bindings: &HashMap<String, u64>,
         edge_paths: &HashMap<String, Vec<u64>>,
-    ) -> Vec<(String, u64)> {
-        let mut signature: Vec<(String, u64)> = bindings
+    ) -> Vec<(u8, String, u64, u64)> {
+        let mut signature: Vec<(u8, String, u64, u64)> = bindings
             .iter()
-            .map(|(k, v)| (format!("n:{k}"), *v))
+            .map(|(k, v)| (0, k.clone(), 0, *v))
             .collect();
-        signature.extend(edge_bindings.iter().map(|(k, v)| (format!("e:{k}"), *v)));
+        signature.extend(edge_bindings.iter().map(|(k, v)| (1, k.clone(), 0, *v)));
         for (alias, edge_ids) in edge_paths {
             signature.extend(
                 edge_ids
                     .iter()
                     .enumerate()
-                    .map(|(i, id)| (format!("p:{alias}:{i}"), *id)),
+                    .map(|(i, id)| (2, alias.clone(), i as u64, *id)),
             );
         }
-        signature.sort_by(|a, b| a.0.cmp(&b.0));
+        signature.sort_unstable();
         signature
     }
 }

--- a/crates/velesdb-core/src/collection/search/query/match_exec/mod.rs
+++ b/crates/velesdb-core/src/collection/search/query/match_exec/mod.rs
@@ -26,7 +26,14 @@ use crate::velesql::{GraphPattern, MatchClause};
 use std::collections::{HashMap, HashSet};
 
 /// Result of a MATCH query traversal.
+///
+/// Relationship aliases live in exactly one of two maps: fixed-length
+/// aliases in `edge_bindings` (scalar edge id), variable-length aliases in
+/// `edge_paths` (ordered edge-id list, possibly empty for zero-hop matches).
+/// Consumers resolving an alias must consult both (see
+/// `where_eval::MatchWhereCtx::edge_targets` for the canonical helper).
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct MatchResult {
     /// Node ID that was matched.
     pub node_id: u64,
@@ -180,7 +187,7 @@ struct TraversalCtx<'a> {
     limit: usize,
     iteration_count: &'a mut u32,
     reported_cardinality: &'a mut usize,
-    seen_bindings: &'a mut HashSet<Vec<(String, u64)>>,
+    seen_bindings: &'a mut HashSet<Vec<(u8, String, u64, u64)>>,
 }
 
 impl Collection {

--- a/crates/velesdb-core/src/collection/search/query/match_exec/mod.rs
+++ b/crates/velesdb-core/src/collection/search/query/match_exec/mod.rs
@@ -38,6 +38,11 @@ pub struct MatchResult {
     pub bindings: HashMap<String, u64>,
     /// Bound relationship aliases from the pattern (alias -> edge_id).
     pub edge_bindings: HashMap<String, u64>,
+    /// Variable-length relationship aliases (alias -> ordered edge-id list).
+    ///
+    /// openCypher list semantics: `MATCH (a)-[r*1..3]->(b)` binds `r` to the
+    /// LIST of traversed relationships, not a single edge.
+    pub edge_paths: HashMap<String, Vec<u64>>,
     /// Similarity score if combined with vector search.
     pub score: Option<f32>,
     /// Projected properties from RETURN clause (EPIC-058 US-007).
@@ -55,6 +60,7 @@ impl MatchResult {
             path,
             bindings: HashMap::new(),
             edge_bindings: HashMap::new(),
+            edge_paths: HashMap::new(),
             score: None,
             projected: HashMap::new(),
         }
@@ -339,7 +345,7 @@ impl Collection {
                 if !self.evaluate_where_condition(
                     *node_id,
                     Some(bindings),
-                    None,
+                    where_eval::EdgeAliasBindings::NONE,
                     where_clause,
                     ctx.params,
                     ctx.payload_guard,
@@ -356,6 +362,7 @@ impl Collection {
             result.bindings.clone_from(bindings);
             result.projected = self.project_properties(
                 bindings,
+                &HashMap::new(),
                 &HashMap::new(),
                 &ctx.match_clause.return_clause,
                 ctx.payload_guard,

--- a/crates/velesdb-core/src/collection/search/query/match_exec/similarity.rs
+++ b/crates/velesdb-core/src/collection/search/query/match_exec/similarity.rs
@@ -244,11 +244,7 @@ impl Collection {
             return;
         };
         if let Some(value) = Self::get_nested_property(payload_map, property) {
-            let key = item
-                .alias
-                .clone()
-                .unwrap_or_else(|| item.expression.clone());
-            projected.insert(key, value.clone());
+            projected.insert(projection_key(item), value.clone());
         }
     }
 
@@ -542,5 +538,19 @@ fn build_match_payload(
         object.insert(key.clone(), value.clone());
     }
     object.insert("_bindings".to_string(), serde_json::json!(result.bindings));
+    // Edge identities make parallel-edge rows (same node bindings, different
+    // edge) and variable-length paths distinguishable by every consumer.
+    if !result.edge_bindings.is_empty() {
+        object.insert(
+            "_edge_bindings".to_string(),
+            serde_json::json!(result.edge_bindings),
+        );
+    }
+    if !result.edge_paths.is_empty() {
+        object.insert(
+            "_edge_paths".to_string(),
+            serde_json::json!(result.edge_paths),
+        );
+    }
     serde_json::Value::Object(object)
 }

--- a/crates/velesdb-core/src/collection/search/query/match_exec/similarity.rs
+++ b/crates/velesdb-core/src/collection/search/query/match_exec/similarity.rs
@@ -17,6 +17,22 @@ use crate::storage::{LogPayloadStorage, PayloadStorage, VectorStorage};
 use crate::validation::validate_dimension_match;
 use std::collections::HashMap;
 
+/// Bundled invariant state for projecting one match result's RETURN items.
+struct ProjectionCtx<'a> {
+    bindings: &'a HashMap<String, u64>,
+    edge_bindings: &'a HashMap<String, u64>,
+    edge_paths: &'a HashMap<String, Vec<u64>>,
+    score: Option<f32>,
+    payload_guard: &'a LogPayloadStorage,
+}
+
+/// Output key of a RETURN item: its `AS` alias, or the raw expression.
+fn projection_key(item: &crate::velesql::ReturnItem) -> String {
+    item.alias
+        .clone()
+        .unwrap_or_else(|| item.expression.clone())
+}
+
 impl Collection {
     /// Projects properties from RETURN clause for a match result (Fix #489).
     ///
@@ -34,12 +50,14 @@ impl Collection {
         &self,
         bindings: &HashMap<String, u64>,
         edge_bindings: &HashMap<String, u64>,
+        edge_paths: &HashMap<String, Vec<u64>>,
         return_clause: &crate::velesql::ReturnClause,
         payload_guard: &LogPayloadStorage,
     ) -> HashMap<String, serde_json::Value> {
         self.project_properties_with_score(
             bindings,
             edge_bindings,
+            edge_paths,
             return_clause,
             None,
             payload_guard,
@@ -56,50 +74,85 @@ impl Collection {
         &self,
         bindings: &HashMap<String, u64>,
         edge_bindings: &HashMap<String, u64>,
+        edge_paths: &HashMap<String, Vec<u64>>,
         return_clause: &crate::velesql::ReturnClause,
         score: Option<f32>,
         payload_guard: &LogPayloadStorage,
     ) -> HashMap<String, serde_json::Value> {
+        let ctx = ProjectionCtx {
+            bindings,
+            edge_bindings,
+            edge_paths,
+            score,
+            payload_guard,
+        };
         let mut projected = HashMap::new();
-
         for item in &return_clause.items {
-            match parse_projection_item(&item.expression) {
-                ProjectionItem::Wildcard => {
-                    Self::project_wildcard(bindings, payload_guard, &mut projected);
+            self.project_return_item(&ctx, item, &mut projected);
+        }
+        projected
+    }
+
+    /// Projects one RETURN item into `projected` according to its shape.
+    fn project_return_item(
+        &self,
+        ctx: &ProjectionCtx<'_>,
+        item: &crate::velesql::ReturnItem,
+        projected: &mut HashMap<String, serde_json::Value>,
+    ) {
+        match parse_projection_item(&item.expression) {
+            ProjectionItem::Wildcard => {
+                Self::project_wildcard(ctx.bindings, ctx.payload_guard, projected);
+            }
+            ProjectionItem::FunctionCall(name) => {
+                if let ("similarity", Some(s)) = (name, ctx.score) {
+                    projected.insert(
+                        "similarity()".to_string(),
+                        serde_json::Value::from(f64::from(s)),
+                    );
                 }
-                ProjectionItem::FunctionCall(name) => {
-                    if name == "similarity" {
-                        if let Some(s) = score {
-                            projected.insert(
-                                "similarity()".to_string(),
-                                serde_json::Value::from(f64::from(s)),
-                            );
-                        }
-                    }
-                }
-                ProjectionItem::PropertyPath { alias, property } => {
-                    // Relationship aliases project from the traversed edge's
-                    // properties (audit 2026-06 F).
-                    if let Some(&edge_id) = edge_bindings.get(alias) {
-                        self.project_edge_property(edge_id, property, item, &mut projected);
-                    } else {
-                        Self::project_property_path(
-                            alias,
-                            property,
-                            item,
-                            bindings,
-                            payload_guard,
-                            &mut projected,
-                        );
-                    }
-                }
-                ProjectionItem::BareAlias(alias) => {
-                    Self::project_bare_alias(alias, bindings, payload_guard, &mut projected);
+            }
+            ProjectionItem::PropertyPath { alias, property } => {
+                self.project_aliased_property(ctx, alias, property, item, projected);
+            }
+            ProjectionItem::BareAlias(alias) => {
+                // A variable-length relationship alias binds a LIST of
+                // relationships (openCypher): project the edge-id list.
+                if let Some(edge_ids) = ctx.edge_paths.get(alias) {
+                    projected.insert(projection_key(item), serde_json::json!(edge_ids));
+                } else {
+                    Self::project_bare_alias(alias, ctx.bindings, ctx.payload_guard, projected);
                 }
             }
         }
+    }
 
-        projected
+    /// Projects a dotted property, dispatching on what the alias binds:
+    /// a fixed-length edge, a variable-length edge list, or a node.
+    fn project_aliased_property(
+        &self,
+        ctx: &ProjectionCtx<'_>,
+        alias: &str,
+        property: &str,
+        item: &crate::velesql::ReturnItem,
+        projected: &mut HashMap<String, serde_json::Value>,
+    ) {
+        // Relationship aliases project from the traversed edge's
+        // properties (audit 2026-06 F).
+        if let Some(&edge_id) = ctx.edge_bindings.get(alias) {
+            self.project_edge_property(edge_id, property, item, projected);
+        } else if let Some(edge_ids) = ctx.edge_paths.get(alias) {
+            self.project_edge_path_property(edge_ids, property, item, projected);
+        } else {
+            Self::project_property_path(
+                alias,
+                property,
+                item,
+                ctx.bindings,
+                ctx.payload_guard,
+                projected,
+            );
+        }
     }
 
     /// Projects a single dotted property (e.g., `r.since`) from a bound
@@ -117,11 +170,30 @@ impl Collection {
         let Some(value) = super::where_eval::edge_property_path(&edge, property) else {
             return;
         };
-        let key = item
-            .alias
-            .clone()
-            .unwrap_or_else(|| item.expression.clone());
-        projected.insert(key, value.clone());
+        projected.insert(projection_key(item), value.clone());
+    }
+
+    /// Projects a dotted property across a variable-length alias's edge list
+    /// as a JSON array, positionally aligned with the traversed path (missing
+    /// properties yield `null`), mirroring openCypher's `[rel IN r | rel.prop]`.
+    fn project_edge_path_property(
+        &self,
+        edge_ids: &[u64],
+        property: &str,
+        item: &crate::velesql::ReturnItem,
+        projected: &mut HashMap<String, serde_json::Value>,
+    ) {
+        let values: Vec<serde_json::Value> = edge_ids
+            .iter()
+            .map(|&edge_id| {
+                self.edge_store
+                    .get_edge(edge_id)
+                    .as_ref()
+                    .and_then(|edge| super::where_eval::edge_property_path(edge, property).cloned())
+                    .unwrap_or(serde_json::Value::Null)
+            })
+            .collect();
+        projected.insert(projection_key(item), serde_json::Value::Array(values));
     }
 
     /// Projects ALL properties from ALL bound nodes into the result (RETURN *).
@@ -315,6 +387,7 @@ impl Collection {
                     result.projected = self.project_properties_with_score(
                         &result.bindings,
                         &result.edge_bindings,
+                        &result.edge_paths,
                         &match_clause.return_clause,
                         Some(score),
                         payload_guard,

--- a/crates/velesdb-core/src/collection/search/query/match_exec/vector_first.rs
+++ b/crates/velesdb-core/src/collection/search/query/match_exec/vector_first.rs
@@ -147,6 +147,7 @@ impl Collection {
         mr.projected = self.project_properties_with_score(
             &mr.bindings,
             &mr.edge_bindings,
+            &mr.edge_paths,
             &match_clause.return_clause,
             Some(candidate.score),
             payload_guard,
@@ -204,7 +205,7 @@ impl Collection {
             self.evaluate_where_condition(
                 node_id,
                 Some(&bindings),
-                None,
+                super::where_eval::EdgeAliasBindings::NONE,
                 cond,
                 params,
                 payload_guard,
@@ -253,7 +254,7 @@ impl Collection {
                 if self.evaluate_where_condition(
                     hit.target_id,
                     Some(&bindings),
-                    None,
+                    super::where_eval::EdgeAliasBindings::NONE,
                     cond,
                     params,
                     payload_guard,

--- a/crates/velesdb-core/src/collection/search/query/match_exec/where_eval.rs
+++ b/crates/velesdb-core/src/collection/search/query/match_exec/where_eval.rs
@@ -137,6 +137,30 @@ struct MatchWhereCtx<'a> {
     payload_guard: &'a LogPayloadStorage,
 }
 
+impl MatchWhereCtx<'_> {
+    /// True when `alias` names a bound relationship alias of either kind
+    /// (fixed-length scalar or variable-length list). The single source of
+    /// truth for "is this an edge alias?" — every consumer must use it so
+    /// scalar and list aliases can never diverge.
+    fn is_edge_alias(&self, alias: &str) -> bool {
+        self.edge_bindings.is_some_and(|m| m.contains_key(alias))
+            || self.edge_paths.is_some_and(|m| m.contains_key(alias))
+    }
+
+    /// Resolves an alias-prefixed column to the edge ids it targets: one id
+    /// for a fixed-length alias, the ordered traversed list for a
+    /// variable-length alias (possibly empty for zero-hop matches).
+    ///
+    /// `None` means the column does not target an edge alias at all.
+    fn edge_targets(&self, column: &str) -> Option<Vec<u64>> {
+        let (alias, _) = column.split_once('.')?;
+        if let Some(&edge_id) = self.edge_bindings.and_then(|m| m.get(alias)) {
+            return Some(vec![edge_id]);
+        }
+        self.edge_paths.and_then(|m| m.get(alias).cloned())
+    }
+}
+
 impl Collection {
     /// Evaluates a WHERE condition against a node's payload (EPIC-045 US-002).
     ///
@@ -249,18 +273,13 @@ impl Collection {
         ctx: &MatchWhereCtx<'_>,
         cmp: &crate::velesql::Comparison,
     ) -> Result<bool> {
-        if let Some(edge_id) = resolve_edge_target(&cmp.column, ctx.edge_bindings) {
-            return self.evaluate_edge_comparison(edge_id, cmp, ctx.params);
-        }
-        // Variable-length alias: ANY traversed edge satisfying the comparison
-        // makes the condition hold (openCypher's `any(rel IN r WHERE ...)`).
-        if let Some(edge_ids) = resolve_edge_path_target(&cmp.column, ctx.edge_paths) {
-            for edge_id in edge_ids {
-                if self.evaluate_edge_comparison(*edge_id, cmp, ctx.params)? {
-                    return Ok(true);
-                }
-            }
-            return Ok(false);
+        // Relationship aliases resolve against edge properties with
+        // ANY-element semantics (openCypher's `any(rel IN r WHERE ...)`);
+        // a fixed-length alias is the one-element case.
+        if let Some(edge_ids) = ctx.edge_targets(&cmp.column) {
+            return self.any_edge(&edge_ids, |this, edge_id| {
+                this.evaluate_edge_comparison(edge_id, cmp, ctx.params)
+            });
         }
 
         let target_id = resolve_target_id(&cmp.column, ctx.bindings, ctx.node_id);
@@ -269,7 +288,7 @@ impl Collection {
             return Ok(false);
         };
 
-        let column_path = strip_alias(&cmp.column, ctx.bindings);
+        let column_path = strip_alias(&cmp.column, &alias_in(ctx.bindings));
         let Some(actual) = Self::json_get_path(&target_payload, column_path) else {
             return Ok(false);
         };
@@ -317,19 +336,11 @@ impl Collection {
         let column = column_of_metadata_condition(condition);
 
         // Audit 2026-06 F: a relationship alias resolves against the EDGE's
-        // properties, not a node payload.
-        if let Some(edge_id) = column.and_then(|col| resolve_edge_target(col, ctx.edge_bindings)) {
-            return self.evaluate_metadata_condition_for_edge(edge_id, condition, ctx);
-        }
-        // Variable-length alias: ANY-element semantics over the edge list.
-        if let Some(edge_ids) = column.and_then(|col| resolve_edge_path_target(col, ctx.edge_paths))
-        {
-            for &edge_id in edge_ids {
-                if self.evaluate_metadata_condition_for_edge(edge_id, condition, ctx)? {
-                    return Ok(true);
-                }
-            }
-            return Ok(false);
+        // properties (ANY-element semantics; fixed-length = one element).
+        if let Some(edge_ids) = column.and_then(|col| ctx.edge_targets(col)) {
+            return self.any_edge(&edge_ids, |this, edge_id| {
+                this.evaluate_metadata_condition_for_edge(edge_id, condition, ctx)
+            });
         }
 
         let target_id = column.map_or(ctx.node_id, |col| {
@@ -340,12 +351,28 @@ impl Collection {
             return Ok(false);
         };
 
-        let rewritten = rewrite_condition_aliases(condition.clone(), ctx.bindings);
+        let rewritten = rewrite_condition_aliases(condition.clone(), &alias_in(ctx.bindings));
         // Resolve parameter placeholders (e.g. `IN ($a, $b)`) before the
         // filter conversion, which would otherwise turn them into NULL.
         let resolved = Self::resolve_condition_params(&rewritten, ctx.params)?;
         let filter_cond: filter::Condition = resolved.into();
         Ok(filter_cond.matches(&payload))
+    }
+
+    /// ANY-element fold over a resolved edge-id list: true when at least one
+    /// edge satisfies `check` (false for an empty list, e.g. zero-hop
+    /// variable-length matches).
+    fn any_edge(
+        &self,
+        edge_ids: &[u64],
+        check: impl Fn(&Self, u64) -> Result<bool>,
+    ) -> Result<bool> {
+        for &edge_id in edge_ids {
+            if check(self, edge_id)? {
+                return Ok(true);
+            }
+        }
+        Ok(false)
     }
 
     /// Mirrors `evaluate_metadata_condition_for_node` for relationship
@@ -365,7 +392,13 @@ impl Collection {
                 .map(|(k, v)| (k.clone(), v.clone()))
                 .collect(),
         );
-        let rewritten = rewrite_condition_aliases(condition.clone(), ctx.edge_bindings);
+        // Strip the alias against the FULL edge-alias namespace (scalar AND
+        // variable-length). Using only the scalar map here left var-length
+        // columns like `r.w` unstripped, so the filter engine resolved them
+        // as nested paths and every IN/BETWEEN/LIKE/IS NULL on a var-length
+        // alias silently matched nothing (review 2026-06-11 finding 1).
+        let rewritten =
+            rewrite_condition_aliases(condition.clone(), &|alias| ctx.is_edge_alias(alias));
         // Resolve parameter placeholders before the filter conversion, which
         // would otherwise turn them into NULL (same hardening as the node path).
         let resolved = Self::resolve_condition_params(&rewritten, ctx.params)?;
@@ -523,23 +556,9 @@ fn resolve_target_id(
         .unwrap_or(default_id)
 }
 
-/// Resolves an alias-prefixed column against bound relationship aliases.
-///
-/// Returns the bound edge id when the column's alias prefix refers to a
-/// relationship alias (e.g. `r.since` with `r` bound by the pattern walker).
-fn resolve_edge_target(column: &str, edge_bindings: Option<&HashMap<String, u64>>) -> Option<u64> {
-    let (alias, _) = column.split_once('.')?;
-    edge_bindings?.get(alias).copied()
-}
-
-/// Resolves an alias-prefixed column against variable-length relationship
-/// aliases, returning the ordered edge-id list bound to the alias.
-fn resolve_edge_path_target<'a>(
-    column: &str,
-    edge_paths: Option<&'a HashMap<String, Vec<u64>>>,
-) -> Option<&'a Vec<u64>> {
-    let (alias, _) = column.split_once('.')?;
-    edge_paths?.get(alias)
+/// Builds an alias-membership predicate over an optional node-bindings map.
+fn alias_in(bindings: Option<&HashMap<String, u64>>) -> impl Fn(&str) -> bool + '_ {
+    move |alias| bindings.is_some_and(|b| b.contains_key(alias))
 }
 
 /// Looks up a (possibly nested) property path on an edge's properties.
@@ -551,20 +570,20 @@ pub(super) fn edge_property_path<'a>(
     Collection::json_get_path(edge.property(first)?, rest)
 }
 
-/// Strips the alias prefix from a column path when the alias exists in bindings.
-fn strip_alias<'a>(column: &'a str, bindings: Option<&HashMap<String, u64>>) -> &'a str {
+/// Strips the alias prefix from a column path when `is_alias` accepts it.
+fn strip_alias<'a>(column: &'a str, is_alias: &dyn Fn(&str) -> bool) -> &'a str {
     match column.split_once('.') {
-        Some((alias, rest)) if bindings.and_then(|b| b.get(alias)).is_some() => rest,
+        Some((alias, rest)) if is_alias(alias) => rest,
         _ => column,
     }
 }
 
 /// Strips the alias prefix from a column name string.
 ///
-/// Returns the bare field path (e.g. `"n.category"` → `"category"`) when the
-/// prefix matches a bound alias, or the original string if no alias matches.
-fn strip_alias_owned(column: &str, bindings: Option<&HashMap<String, u64>>) -> String {
-    strip_alias(column, bindings).to_string()
+/// Returns the bare field path (e.g. `"n.category"` → `"category"`) when
+/// `is_alias` accepts the prefix, or the original string otherwise.
+fn strip_alias_owned(column: &str, is_alias: &dyn Fn(&str) -> bool) -> String {
+    strip_alias(column, is_alias).to_string()
 }
 
 /// Extracts the column name from a metadata condition variant.
@@ -597,45 +616,45 @@ pub(in crate::collection::search::query) fn column_of_metadata_condition(
 /// caller dispatches them before reaching this function.
 fn rewrite_condition_aliases(
     condition: crate::velesql::Condition,
-    bindings: Option<&HashMap<String, u64>>,
+    is_alias: &dyn Fn(&str) -> bool,
 ) -> crate::velesql::Condition {
     use crate::velesql::Condition;
 
     match condition {
         Condition::In(mut ic) => {
-            ic.column = strip_alias_owned(&ic.column, bindings);
+            ic.column = strip_alias_owned(&ic.column, is_alias);
             Condition::In(ic)
         }
         Condition::Between(mut btw) => {
-            btw.column = strip_alias_owned(&btw.column, bindings);
+            btw.column = strip_alias_owned(&btw.column, is_alias);
             Condition::Between(btw)
         }
         Condition::Like(mut lk) => {
-            lk.column = strip_alias_owned(&lk.column, bindings);
+            lk.column = strip_alias_owned(&lk.column, is_alias);
             Condition::Like(lk)
         }
         Condition::IsNull(mut isn) => {
-            isn.column = strip_alias_owned(&isn.column, bindings);
+            isn.column = strip_alias_owned(&isn.column, is_alias);
             Condition::IsNull(isn)
         }
         Condition::Match(mut m) => {
-            m.column = strip_alias_owned(&m.column, bindings);
+            m.column = strip_alias_owned(&m.column, is_alias);
             Condition::Match(m)
         }
         Condition::ContainsText(mut ct) => {
-            ct.column = strip_alias_owned(&ct.column, bindings);
+            ct.column = strip_alias_owned(&ct.column, is_alias);
             Condition::ContainsText(ct)
         }
         Condition::Contains(mut c) => {
-            c.column = strip_alias_owned(&c.column, bindings);
+            c.column = strip_alias_owned(&c.column, is_alias);
             Condition::Contains(c)
         }
         Condition::GeoDistance(mut gd) => {
-            gd.column = strip_alias_owned(&gd.column, bindings);
+            gd.column = strip_alias_owned(&gd.column, is_alias);
             Condition::GeoDistance(gd)
         }
         Condition::GeoBbox(mut gb) => {
-            gb.column = strip_alias_owned(&gb.column, bindings);
+            gb.column = strip_alias_owned(&gb.column, is_alias);
             Condition::GeoBbox(gb)
         }
         // Non-metadata conditions pass through unchanged.

--- a/crates/velesdb-core/src/collection/search/query/match_exec/where_eval.rs
+++ b/crates/velesdb-core/src/collection/search/query/match_exec/where_eval.rs
@@ -101,6 +101,23 @@ pub(super) fn resolve_query_vector(
     }
 }
 
+/// Edge-alias bindings handed to WHERE evaluation: `scalar` holds
+/// fixed-length relationship aliases (alias -> edge id), `paths` holds
+/// variable-length aliases (alias -> ordered edge-id list).
+#[derive(Clone, Copy)]
+pub(crate) struct EdgeAliasBindings<'a> {
+    pub(crate) scalar: Option<&'a HashMap<String, u64>>,
+    pub(crate) paths: Option<&'a HashMap<String, Vec<u64>>>,
+}
+
+impl EdgeAliasBindings<'_> {
+    /// No edge aliases in scope (single-node patterns, candidate probes).
+    pub(crate) const NONE: EdgeAliasBindings<'static> = EdgeAliasBindings {
+        scalar: None,
+        paths: None,
+    };
+}
+
 /// Bundled per-node context for MATCH WHERE evaluation.
 ///
 /// Groups the invariant evaluation state so the recursive condition walk
@@ -112,6 +129,10 @@ struct MatchWhereCtx<'a> {
     /// Bound relationship aliases (alias -> traversed edge id) so `r.prop`
     /// resolves against the EDGE's properties (audit 2026-06 F).
     edge_bindings: Option<&'a HashMap<String, u64>>,
+    /// Variable-length relationship aliases (alias -> ordered edge-id list).
+    /// `r.prop` over a list uses ANY-element semantics: the condition holds
+    /// when at least one traversed edge satisfies it.
+    edge_paths: Option<&'a HashMap<String, Vec<u64>>>,
     params: &'a HashMap<String, serde_json::Value>,
     payload_guard: &'a LogPayloadStorage,
 }
@@ -135,7 +156,7 @@ impl Collection {
         &self,
         node_id: u64,
         bindings: Option<&HashMap<String, u64>>,
-        edge_bindings: Option<&HashMap<String, u64>>,
+        edges: EdgeAliasBindings<'_>,
         condition: &crate::velesql::Condition,
         params: &HashMap<String, serde_json::Value>,
         payload_guard: &LogPayloadStorage,
@@ -143,7 +164,8 @@ impl Collection {
         let ctx = MatchWhereCtx {
             node_id,
             bindings,
-            edge_bindings,
+            edge_bindings: edges.scalar,
+            edge_paths: edges.paths,
             params,
             payload_guard,
         };
@@ -230,6 +252,16 @@ impl Collection {
         if let Some(edge_id) = resolve_edge_target(&cmp.column, ctx.edge_bindings) {
             return self.evaluate_edge_comparison(edge_id, cmp, ctx.params);
         }
+        // Variable-length alias: ANY traversed edge satisfying the comparison
+        // makes the condition hold (openCypher's `any(rel IN r WHERE ...)`).
+        if let Some(edge_ids) = resolve_edge_path_target(&cmp.column, ctx.edge_paths) {
+            for edge_id in edge_ids {
+                if self.evaluate_edge_comparison(*edge_id, cmp, ctx.params)? {
+                    return Ok(true);
+                }
+            }
+            return Ok(false);
+        }
 
         let target_id = resolve_target_id(&cmp.column, ctx.bindings, ctx.node_id);
 
@@ -288,6 +320,16 @@ impl Collection {
         // properties, not a node payload.
         if let Some(edge_id) = column.and_then(|col| resolve_edge_target(col, ctx.edge_bindings)) {
             return self.evaluate_metadata_condition_for_edge(edge_id, condition, ctx);
+        }
+        // Variable-length alias: ANY-element semantics over the edge list.
+        if let Some(edge_ids) = column.and_then(|col| resolve_edge_path_target(col, ctx.edge_paths))
+        {
+            for &edge_id in edge_ids {
+                if self.evaluate_metadata_condition_for_edge(edge_id, condition, ctx)? {
+                    return Ok(true);
+                }
+            }
+            return Ok(false);
         }
 
         let target_id = column.map_or(ctx.node_id, |col| {
@@ -488,6 +530,16 @@ fn resolve_target_id(
 fn resolve_edge_target(column: &str, edge_bindings: Option<&HashMap<String, u64>>) -> Option<u64> {
     let (alias, _) = column.split_once('.')?;
     edge_bindings?.get(alias).copied()
+}
+
+/// Resolves an alias-prefixed column against variable-length relationship
+/// aliases, returning the ordered edge-id list bound to the alias.
+fn resolve_edge_path_target<'a>(
+    column: &str,
+    edge_paths: Option<&'a HashMap<String, Vec<u64>>>,
+) -> Option<&'a Vec<u64>> {
+    let (alias, _) = column.split_once('.')?;
+    edge_paths?.get(alias)
 }
 
 /// Looks up a (possibly nested) property path on an edge's properties.

--- a/crates/velesdb-core/tests/bdd/match_relationship_semantics.rs
+++ b/crates/velesdb-core/tests/bdd/match_relationship_semantics.rs
@@ -607,3 +607,98 @@ fn test_var_length_distinct_paths_are_distinct_rows() {
         "two distinct 2-hop edge paths must yield two rows"
     );
 }
+
+/// WHEN a filter-engine condition (IN) references a var-length alias
+/// THEN ANY-element semantics apply with the alias correctly stripped
+/// (review 2026-06-11 finding 1: IN/BETWEEN/LIKE/IS NULL previously
+/// resolved `r.w` as a nested path and matched nothing).
+#[test]
+fn test_var_length_alias_in_condition_uses_any_semantics() {
+    let (_dir, db) = create_test_db();
+    setup_chain_collection(&db);
+
+    let any_hit = run_match(
+        &db,
+        "MATCH (a:Start)-[r:KNOWS*2..2]->(c) WHERE r.w IN (20, 99) RETURN c LIMIT 10",
+        "chain",
+    );
+    assert_eq!(
+        any_hit.len(),
+        1,
+        "one traversed edge has w=20 → path matches"
+    );
+
+    let no_hit = run_match(
+        &db,
+        "MATCH (a:Start)-[r:KNOWS*2..2]->(c) WHERE r.w IN (98, 99) RETURN c LIMIT 10",
+        "chain",
+    );
+    assert!(no_hit.is_empty(), "no traversed edge is in the list");
+}
+
+/// IS NULL on a var-length alias property: every traversed edge HAS `w`,
+/// so `r.w IS NULL` must reject the path (no edge satisfies it) while
+/// `r.w IS NOT NULL` keeps it.
+#[test]
+fn test_var_length_alias_is_null_semantics() {
+    let (_dir, db) = create_test_db();
+    setup_chain_collection(&db);
+
+    let null_rows = run_match(
+        &db,
+        "MATCH (a:Start)-[r:KNOWS*2..2]->(c) WHERE r.w IS NULL RETURN c LIMIT 10",
+        "chain",
+    );
+    assert!(
+        null_rows.is_empty(),
+        "every traversed edge carries w → IS NULL matches no edge"
+    );
+
+    let not_null_rows = run_match(
+        &db,
+        "MATCH (a:Start)-[r:KNOWS*2..2]->(c) WHERE r.w IS NOT NULL RETURN c LIMIT 10",
+        "chain",
+    );
+    assert_eq!(
+        not_null_rows.len(),
+        1,
+        "edges carry w → IS NOT NULL matches"
+    );
+}
+
+/// Zero-hop variable-length matches bind the alias to an EMPTY list:
+/// RETURN r projects [], and WHERE on the alias matches nothing
+/// (ANY over an empty list is false) instead of degrading to node-payload
+/// resolution.
+#[test]
+fn test_var_length_zero_hop_binds_empty_list() {
+    let (_dir, db) = create_test_db();
+    setup_chain_collection(&db);
+
+    let results = run_match(
+        &db,
+        "MATCH (a:Start)-[r:KNOWS*0..1]->(c) RETURN r LIMIT 10",
+        "chain",
+    );
+    // Zero-hop row (c = a) plus the 1-hop row (c = node 2).
+    assert_eq!(results.len(), 2, "zero-hop and one-hop rows both match");
+    let projections: Vec<serde_json::Value> = results
+        .iter()
+        .filter_map(|r| r.point.payload.as_ref().and_then(|p| p.get("r")).cloned())
+        .collect();
+    assert!(
+        projections.contains(&serde_json::json!([])),
+        "the zero-hop row must project r as an empty list, got {projections:?}"
+    );
+
+    let filtered = run_match(
+        &db,
+        "MATCH (a:Start)-[r:KNOWS*0..1]->(c) WHERE r.w = 10 RETURN c LIMIT 10",
+        "chain",
+    );
+    assert_eq!(
+        filtered.len(),
+        1,
+        "only the 1-hop row can satisfy r.w = 10 (ANY over [] is false)"
+    );
+}

--- a/crates/velesdb-core/tests/bdd/match_relationship_semantics.rs
+++ b/crates/velesdb-core/tests/bdd/match_relationship_semantics.rs
@@ -379,3 +379,231 @@ fn test_match_return_edge_property() {
         results[0].point.payload
     );
 }
+
+// =========================================================================
+// Parallel edges: edge-binding-aware dedup (audit 2026-06 follow-up)
+// =========================================================================
+
+/// GIVEN base: two nodes with TWO parallel `KNOWS` edges 1 -> 2 carrying
+/// different `since` properties.
+fn setup_parallel_edges_collection(db: &Database) {
+    db.create_vector_collection("parallel", 4, velesdb_core::DistanceMetric::Cosine)
+        .expect("test: create parallel collection");
+    let vc = db
+        .get_vector_collection("parallel")
+        .expect("test: get parallel collection");
+
+    vc.upsert(vec![
+        Point::new(1, vec![1.0, 0.0, 0.0, 0.0], Some(json!({"name": "A"}))),
+        Point::new(2, vec![0.0, 1.0, 0.0, 0.0], Some(json!({"name": "B"}))),
+    ])
+    .expect("test: upsert nodes");
+
+    for (edge_id, since) in [(100u64, 2020), (101u64, 2024)] {
+        let mut props = HashMap::new();
+        props.insert("since".to_string(), json!(since));
+        let edge = GraphEdge::new(edge_id, 1, 2, "KNOWS")
+            .expect("test: create parallel edge")
+            .with_properties(props);
+        vc.add_edge(edge).expect("test: add parallel edge");
+    }
+}
+
+/// WHEN two parallel aliased edges connect the same node pair
+/// THEN MATCH returns one row per edge (not one collapsed row).
+#[test]
+fn test_parallel_edges_yield_one_row_per_edge() {
+    let (_dir, db) = create_test_db();
+    setup_parallel_edges_collection(&db);
+
+    let results = run_match(
+        &db,
+        "MATCH (a)-[r:KNOWS]->(b) RETURN r.since LIMIT 10",
+        "parallel",
+    );
+
+    assert_eq!(
+        results.len(),
+        2,
+        "two parallel KNOWS edges must yield two rows"
+    );
+    let mut sinces: Vec<i64> = results
+        .iter()
+        .filter_map(|r| {
+            r.point
+                .payload
+                .as_ref()
+                .and_then(|p| p.get("r.since"))
+                .and_then(serde_json::Value::as_i64)
+        })
+        .collect();
+    sinces.sort_unstable();
+    assert_eq!(
+        sinces,
+        vec![2020, 2024],
+        "each row must project its own edge's property"
+    );
+}
+
+/// WHEN a parallel edge is filtered by an edge property
+/// THEN only the matching edge's row survives.
+#[test]
+fn test_parallel_edges_where_filters_per_edge() {
+    let (_dir, db) = create_test_db();
+    setup_parallel_edges_collection(&db);
+
+    let results = run_match(
+        &db,
+        "MATCH (a)-[r:KNOWS]->(b) WHERE r.since >= 2024 RETURN r.since LIMIT 10",
+        "parallel",
+    );
+
+    assert_eq!(results.len(), 1, "only the 2024 edge passes the filter");
+}
+
+// =========================================================================
+// Variable-length relationship aliases: list semantics (openCypher)
+// =========================================================================
+
+/// GIVEN base: a chain 1 -> 2 -> 3 (both `KNOWS`), node 1 labeled `Start`,
+/// edges carrying `{w: 10}` and `{w: 20}`.
+fn setup_chain_collection(db: &Database) {
+    db.create_vector_collection("chain", 4, velesdb_core::DistanceMetric::Cosine)
+        .expect("test: create chain collection");
+    let vc = db
+        .get_vector_collection("chain")
+        .expect("test: get chain collection");
+
+    vc.upsert(vec![
+        Point::new(
+            1,
+            vec![1.0, 0.0, 0.0, 0.0],
+            Some(json!({"_labels": ["Start"], "name": "A"})),
+        ),
+        Point::new(2, vec![0.0, 1.0, 0.0, 0.0], Some(json!({"name": "B"}))),
+        Point::new(3, vec![0.0, 0.0, 1.0, 0.0], Some(json!({"name": "C"}))),
+    ])
+    .expect("test: upsert chain nodes");
+
+    for (edge_id, src, dst, w) in [(100u64, 1u64, 2u64, 10), (101, 2, 3, 20)] {
+        let mut props = HashMap::new();
+        props.insert("w".to_string(), json!(w));
+        let edge = GraphEdge::new(edge_id, src, dst, "KNOWS")
+            .expect("test: create chain edge")
+            .with_properties(props);
+        vc.add_edge(edge).expect("test: add chain edge");
+    }
+}
+
+/// WHEN a variable-length alias is projected bare
+/// THEN it binds the LIST of traversed edge ids (openCypher list semantics).
+#[test]
+fn test_var_length_alias_projects_edge_id_list() {
+    let (_dir, db) = create_test_db();
+    setup_chain_collection(&db);
+
+    let results = run_match(
+        &db,
+        "MATCH (a:Start)-[r:KNOWS*2..2]->(c) RETURN r LIMIT 10",
+        "chain",
+    );
+
+    assert_eq!(results.len(), 1, "exactly one 2-hop path exists");
+    let projected = results[0]
+        .point
+        .payload
+        .as_ref()
+        .and_then(|p| p.get("r"))
+        .cloned();
+    assert_eq!(
+        projected,
+        Some(json!([100, 101])),
+        "RETURN r on a var-length alias must project the ordered edge-id list"
+    );
+}
+
+/// WHEN a property is projected through a variable-length alias
+/// THEN the projection is the positional list of per-edge values.
+#[test]
+fn test_var_length_alias_projects_property_list() {
+    let (_dir, db) = create_test_db();
+    setup_chain_collection(&db);
+
+    let results = run_match(
+        &db,
+        "MATCH (a:Start)-[r:KNOWS*2..2]->(c) RETURN r.w LIMIT 10",
+        "chain",
+    );
+
+    assert_eq!(results.len(), 1);
+    let projected = results[0]
+        .point
+        .payload
+        .as_ref()
+        .and_then(|p| p.get("r.w"))
+        .cloned();
+    assert_eq!(
+        projected,
+        Some(json!([10, 20])),
+        "RETURN r.w on a var-length alias must project the per-edge value list"
+    );
+}
+
+/// WHEN a WHERE references a var-length alias property
+/// THEN ANY-element semantics apply: one matching edge keeps the row.
+#[test]
+fn test_var_length_alias_where_uses_any_semantics() {
+    let (_dir, db) = create_test_db();
+    setup_chain_collection(&db);
+
+    let any_hit = run_match(
+        &db,
+        "MATCH (a:Start)-[r:KNOWS*2..2]->(c) WHERE r.w = 20 RETURN c LIMIT 10",
+        "chain",
+    );
+    assert_eq!(
+        any_hit.len(),
+        1,
+        "one traversed edge has w=20, so the path must match"
+    );
+
+    let no_hit = run_match(
+        &db,
+        "MATCH (a:Start)-[r:KNOWS*2..2]->(c) WHERE r.w = 99 RETURN c LIMIT 10",
+        "chain",
+    );
+    assert!(
+        no_hit.is_empty(),
+        "no traversed edge has w=99, so the path must not match"
+    );
+}
+
+/// WHEN distinct paths reach the same target through different edge lists
+/// THEN each path is a distinct row (the dedup key includes the edge list).
+#[test]
+fn test_var_length_distinct_paths_are_distinct_rows() {
+    let (_dir, db) = create_test_db();
+    setup_chain_collection(&db);
+    let vc = db
+        .get_vector_collection("chain")
+        .expect("test: get chain collection");
+    // Second 1 -> 2 edge: now TWO 2-hop paths reach node 3.
+    let mut props = HashMap::new();
+    props.insert("w".to_string(), json!(11));
+    let edge = GraphEdge::new(102, 1, 2, "KNOWS")
+        .expect("test: create second 1->2 edge")
+        .with_properties(props);
+    vc.add_edge(edge).expect("test: add second 1->2 edge");
+
+    let results = run_match(
+        &db,
+        "MATCH (a:Start)-[r:KNOWS*2..2]->(c) RETURN r LIMIT 10",
+        "chain",
+    );
+
+    assert_eq!(
+        results.len(),
+        2,
+        "two distinct 2-hop edge paths must yield two rows"
+    );
+}

--- a/docs/VELESQL_SPEC.md
+++ b/docs/VELESQL_SPEC.md
@@ -1634,6 +1634,19 @@ configuration with a `Graph expansion exceeded: max=32` complexity error
 (surfaced directly by `Parser::parse`) — use an explicit bounded range such as
 `*1..32` instead.
 
+**Variable-length alias semantics (openCypher lists).** A relationship alias
+on a ranged pattern (`-[r:TYPE*1..3]->`) binds the **ordered list** of
+traversed relationships, not a single edge:
+
+- `RETURN r` projects the ordered edge-id list (e.g. `[100, 101]`).
+- `RETURN r.prop` projects the positional list of per-edge values
+  (missing properties yield `null`), like openCypher's `[rel IN r | rel.prop]`.
+- `WHERE r.prop = x` uses **ANY-element semantics**: the path matches when at
+  least one traversed edge satisfies the condition (openCypher's
+  `any(rel IN r WHERE rel.prop = x)`).
+- Distinct edge paths to the same target are distinct result rows, and
+  parallel edges between the same node pair yield one row per aliased edge.
+
 ### RETURN Clause
 
 Project fields from matched nodes and relationships:

--- a/docs/VELESQL_SPEC.md
+++ b/docs/VELESQL_SPEC.md
@@ -1646,6 +1646,9 @@ traversed relationships, not a single edge:
   `any(rel IN r WHERE rel.prop = x)`).
 - Distinct edge paths to the same target are distinct result rows, and
   parallel edges between the same node pair yield one row per aliased edge.
+  **Anonymous relationships** (`-[:TYPE]->`) keep the collapsed cardinality —
+  bind an alias when parallel edges must be distinguished (a known divergence
+  from openCypher, which always counts one row per relationship).
 
 ### RETURN Clause
 

--- a/docs/guides/AGENT_MEMORY.md
+++ b/docs/guides/AGENT_MEMORY.md
@@ -577,9 +577,17 @@ use velesdb_core::{Database, agent::AgentMemory};
 let db = Arc::new(Database::open("./agent_data")?);
 let memory = AgentMemory::new(Arc::clone(&db))?;
 
+// In-memory TTLs (fast, but lost on restart):
 memory.set_semantic_ttl(fact_id, 3600);       // 1-hour TTL on a semantic fact
 memory.set_episodic_ttl(event_id, 86_400);    // 24-hour TTL on an event
 memory.set_procedural_ttl(proc_id, 604_800);  // 7-day TTL on a procedure
+
+// Durable TTLs: persisted to the reserved `_veles_expires_at` payload field
+// (like `store_with_ttl`), so they survive a restart. Result-returning —
+// fails with NotFound when the id does not exist.
+memory.set_semantic_ttl_durable(fact_id, 3600)?;
+memory.set_episodic_ttl_durable(event_id, 86_400)?;
+memory.set_procedural_ttl_durable(proc_id, 604_800)?;
 
 // Remove all expired entries (returns an ExpireResult with per-subsystem counts)
 let result = memory.auto_expire()?;


### PR DESCRIPTION
## Summary

Three API-completeness gaps from the 2026-06 audit follow-ups, plus a full code review pass (7 finder angles, 1-vote verify) whose findings are all fixed in the second commit.

### 1. Edge-binding-aware result dedup
Parallel edges between the same node pair collapsed to one MATCH row (the dedup signature covered node bindings only). The signature now includes relationship bindings — one row per **aliased** edge; anonymous relationships keep the collapsed cardinality (documented divergence). Result payloads expose `_edge_bindings` / `_edge_paths` beside `_bindings` so rows are distinguishable by edge identity on every surface.

### 2. openCypher list semantics for variable-length aliases
`[r*1..3]` previously bound the most recent edge. Now: `RETURN r` → ordered edge-id list, `RETURN r.prop` → positional per-edge value list, `WHERE r.prop` → ANY-element semantics, zero-hop matches bind `[]`, distinct edge paths are distinct rows. Edge-alias resolution is unified behind one chokepoint (`MatchWhereCtx::edge_targets` / `is_edge_alias`) so scalar and list aliases can never diverge again — the review found (and the fix covers) a critical bug where IN/BETWEEN/LIKE/IS NULL on var-length aliases matched nothing because the alias was never stripped.

### 3. Durable post-hoc TTL setters
`set_*_ttl` only updated the in-memory map (lost on restart). New Result-returning `set_*_ttl_durable` variants persist the expiry to the reserved `_veles_expires_at` payload key (same contract as `store_with_ttl`), refuse to resurrect expired ids (NotFound), and fail loudly on non-object payloads instead of silently losing durability.

### Parallel-strategy merge redesign (review finding)
Graph rows are authoritative row identities; a vector row enriches **every** row of its node group (score better-wins per row, winner-priority data) or stands alone. Fixes the score-skew where only the first compatible row absorbed the similarity score and parallel-edge siblings sank to the sentinel bottom under ORDER BY/LIMIT.

## Breaking changes (CHANGELOG has migration notes)
- `RETURN r.prop` on ranged aliases (incl. `*1..1`) changes wire type scalar → list.
- `WHERE r.prop` on ranged aliases changes last-edge → ANY-edge semantics.
- Aliased parallel edges change row cardinality (1 → N rows).
- `MatchResult` is now `#[non_exhaustive]`.

## Validation
- Full core suite: **5837 passed / 0 failed** (`--test-threads=1`)
- clippy pedantic clean; no-default-features + wasm32 targets clean; unwrap gate clean
- 19 BDD relationship-semantics tests (9 new), 16 merge unit tests (1 new), 5 durable-TTL tests (5 new)
- lizard: all new/changed functions CC ≤ 8, NLOC ≤ 50

## Follow-ups (tracked, not in this PR)
- REST `/match` handler field exposure for edge bindings (OpenAPI surface change)
- SDK bindings parity for `set_*_ttl_durable` (TS/Python/mobile)
