### PR TITLE
feat(query): GraphFirst anchored fetch — exhaustive hybrid retrieval for AND-required MATCH predicates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   so rows are distinguishable by edge identity.
 
 ### Added
+- **GraphFirst anchored fetch — exhaustive hybrid retrieval**: `MATCH (...)`
+  predicates that are AND-required by a SELECT WHERE clause are now evaluated
+  FIRST; retrieval happens within their anchor sets and is exhaustive (a
+  matching row is returned no matter how it ranks globally). Covers
+  `vector NEAR` (exact scoring up to 10K anchors, bitmap-filtered HNSW
+  beyond), metadata-only, sparse-only (per-id index filter, exact at LIMIT),
+  and `NOT similarity()` shapes. Residual shapes (OR/NOT-wrapped predicates,
+  `similarity()` cascades, text/hybrid fusion) keep the bounded window,
+  now documented per shape. Anchor sets are evaluated once and shared with
+  the exact WHERE post-filter.
 - **Durable post-hoc TTL setters for agent memory**: Result-returning
   `set_semantic_ttl_durable` / `set_episodic_ttl_durable` /
   `set_procedural_ttl_durable` on `AgentMemory` (and `set_ttl_durable` on each

--- a/crates/velesdb-core/src/collection/search/query/early_return.rs
+++ b/crates/velesdb-core/src/collection/search/query/early_return.rs
@@ -58,12 +58,6 @@ impl Collection {
         };
 
         let has_graph_predicates = !extracted.graph_match_predicates.is_empty();
-        let execution_limit = if has_graph_predicates {
-            MAX_LIMIT
-        } else {
-            limit
-        };
-
         let early_ctx = EarlyReturnCtx {
             stmt,
             params,
@@ -74,39 +68,97 @@ impl Collection {
 
         // EPIC-044 US-003: NOT similarity() requires full scan
         if extracted.is_not_similarity_query {
-            let results = self.execute_early_return_query(
-                |s| s.execute_not_similarity_query(cond, params, execution_limit),
-                &early_ctx,
-            )?;
-            return Ok(Some(results));
+            return self.run_not_similarity_early(&early_ctx, limit).map(Some);
         }
 
-        // EPIC-044 US-002: Union mode for similarity() OR metadata
+        // EPIC-044 US-002: Union mode for similarity() OR metadata.
+        // The union path keeps the MAX_LIMIT window when graph predicates
+        // are present: its similarity/metadata legs rank independently and
+        // would each need anchor-aware fetching to drop it.
+        let mut graph_cache = super::where_eval::GraphMatchEvalCache::default();
+        let execution_limit = if has_graph_predicates {
+            MAX_LIMIT
+        } else {
+            limit
+        };
         let results = self.execute_early_return_query(
             |s| s.execute_union_query(cond, params, execution_limit),
             &early_ctx,
+            &mut graph_cache,
         )?;
         Ok(Some(results))
     }
 
+    /// Runs the NOT-similarity early path with GraphFirst anchoring:
+    /// AND-required MATCH predicates restrict the scan to their anchor set,
+    /// making the fetch exact at `limit` instead of a MAX_LIMIT window.
+    fn run_not_similarity_early(
+        &self,
+        early: &EarlyReturnCtx<'_>,
+        limit: usize,
+    ) -> Result<Vec<SearchResult>> {
+        let mut graph_cache = super::where_eval::GraphMatchEvalCache::default();
+        let anchors = if early.has_graph_predicates {
+            self.compute_required_anchor_ids(
+                early.cond,
+                early.params,
+                &early.stmt.from_alias,
+                &mut graph_cache,
+            )?
+        } else {
+            None
+        };
+        let execution_limit = if early.has_graph_predicates && anchors.is_none() {
+            MAX_LIMIT
+        } else {
+            limit
+        };
+        self.execute_early_return_query(
+            |s| {
+                s.execute_not_similarity_query_over(
+                    early.cond,
+                    early.params,
+                    execution_limit,
+                    anchors.as_ref(),
+                )
+            },
+            early,
+            &mut graph_cache,
+        )
+    }
+
     /// Executes an early-return query path with guard-rail checks and post-processing.
+    ///
+    /// `graph_cache` carries anchor sets a GraphFirst prefilter already
+    /// computed, so the exact post-filter never re-runs the traversals.
     pub(super) fn execute_early_return_query(
         &self,
         execute_fn: impl FnOnce(&Self) -> Result<Vec<SearchResult>>,
         early: &EarlyReturnCtx<'_>,
+        graph_cache: &mut super::where_eval::GraphMatchEvalCache,
     ) -> Result<Vec<SearchResult>> {
         let mut results =
             execute_fn(self).inspect_err(|_| self.guard_rails.circuit_breaker.record_failure())?;
         if early.has_graph_predicates {
             results = self
-                .apply_where_condition_to_results(
+                .apply_where_condition_to_results_with_cache(
                     results,
                     early.cond,
                     early.params,
                     &early.stmt.from_alias,
+                    graph_cache,
                 )
                 .inspect_err(|_| self.guard_rails.circuit_breaker.record_failure())?;
         }
+        self.finalize_early_results(results, early)
+    }
+
+    /// DISTINCT / ORDER BY / OFFSET / LIMIT post-processing for early paths.
+    fn finalize_early_results(
+        &self,
+        mut results: Vec<SearchResult>,
+        early: &EarlyReturnCtx<'_>,
+    ) -> Result<Vec<SearchResult>> {
         // Bug #475: Apply DISTINCT before ORDER BY (same as finalize_query_results path).
         if early.stmt.distinct == crate::velesql::DistinctMode::All {
             results = super::distinct::apply_distinct(results, &early.stmt.columns);

--- a/crates/velesdb-core/src/collection/search/query/graph_prefilter.rs
+++ b/crates/velesdb-core/src/collection/search/query/graph_prefilter.rs
@@ -1,0 +1,244 @@
+//! GraphFirst anchor-id prefiltering for SELECT graph predicates.
+//!
+//! A `MATCH (...)` predicate that is AND-required by the WHERE clause admits
+//! only rows whose id is in the predicate's anchor set. Evaluating those
+//! predicates FIRST turns hybrid retrieval exhaustive:
+//!
+//! - **NEAR + MATCH**: selective anchor sets are scored exactly against the
+//!   query vector (provably exhaustive); large ones become a `RoaringBitmap`
+//!   pushed into filtered HNSW — either way the top-k is found *within* the
+//!   graph matches instead of hoping they appear inside a bounded over-fetch
+//!   window.
+//! - **Unranked + MATCH**: the anchor set IS the candidate set — hydrate it
+//!   directly instead of scanning a `MAX_LIMIT` window.
+//! - **Sparse + MATCH**: the anchor set feeds the sparse index's per-id
+//!   filter, so the fetch is exact at `limit` (see `hybrid_sparse.rs`).
+//!
+//! Predicates under `OR`/`NOT` are not required and contribute no prefilter;
+//! those query shapes keep the post-filter execution. The exact WHERE
+//! post-filter always runs afterwards (with the warmed predicate cache, so
+//! anchor sets are never evaluated twice).
+
+use super::where_eval::GraphMatchEvalCache;
+use crate::collection::types::Collection;
+use crate::error::Result;
+use crate::point::SearchResult;
+use crate::velesql::{Condition, GraphMatchPredicate};
+use std::collections::HashSet;
+
+/// How many anchor ids are hydrated per `get` batch on the unranked path.
+const ANCHOR_HYDRATION_CHUNK: usize = 1024;
+
+/// Anchor sets up to this size are scored exactly against the query vector
+/// (exhaustive); larger sets fall back to the bitmap-filtered HNSW path.
+/// Matches the order of magnitude of the GraphFirst scan cap.
+const ANCHORED_EXACT_SCORE_MAX: usize = 10_000;
+
+/// Collects graph predicates that are AND-required by `cond`: every result
+/// row must satisfy them. Predicates under `Or`/`Not` are skipped (a row may
+/// match without them).
+pub(super) fn collect_required_graph_predicates(cond: &Condition) -> Vec<&GraphMatchPredicate> {
+    let mut out = Vec::new();
+    collect_required(cond, &mut out);
+    out
+}
+
+fn collect_required<'a>(cond: &'a Condition, out: &mut Vec<&'a GraphMatchPredicate>) {
+    match cond {
+        Condition::GraphMatch(predicate) => out.push(predicate),
+        Condition::And(left, right) => {
+            collect_required(left, out);
+            collect_required(right, out);
+        }
+        Condition::Group(inner) => collect_required(inner, out),
+        _ => {}
+    }
+}
+
+impl Collection {
+    /// Evaluates the AND-required graph predicates of `cond` and returns the
+    /// intersection of their anchor sets, warming `cache` so the exact WHERE
+    /// post-filter reuses the same sets without re-running the traversals.
+    ///
+    /// Returns `Ok(None)` when no predicate is AND-required (nothing to
+    /// prefilter with). An empty set is meaningful: the query provably has
+    /// no results.
+    pub(super) fn compute_required_anchor_ids(
+        &self,
+        cond: &Condition,
+        params: &std::collections::HashMap<String, serde_json::Value>,
+        from_aliases: &[String],
+        cache: &mut GraphMatchEvalCache,
+    ) -> Result<Option<HashSet<u64>>> {
+        let predicates = collect_required_graph_predicates(cond);
+        let Some((first, rest)) = predicates.split_first() else {
+            return Ok(None);
+        };
+        let mut anchors = cache
+            .get_or_compute(self, first, params, from_aliases)?
+            .clone();
+        for predicate in rest {
+            if anchors.is_empty() {
+                break;
+            }
+            let ids = cache.get_or_compute(self, predicate, params, from_aliases)?;
+            anchors.retain(|id| ids.contains(id));
+        }
+        Ok(Some(anchors))
+    }
+
+    /// Anchored NEAR: returns the top-`limit` vector neighbors *within* the
+    /// anchor set.
+    ///
+    /// Selective anchor sets (≤ [`ANCHORED_EXACT_SCORE_MAX`]) are scored
+    /// exactly — every anchor's vector is hydrated and ranked, so retrieval
+    /// is provably exhaustive (the HNSW bitmap mechanism only post-filters a
+    /// bounded candidate pool and can miss anchors ranked far from the
+    /// query). Larger anchor sets use the bitmap path with adaptive retry:
+    /// at that density the window bias is negligible and exact scoring
+    /// would cost more than it saves.
+    pub(super) fn search_near_with_anchor_ids(
+        &self,
+        vector: &[f32],
+        anchor_ids: &HashSet<u64>,
+        filter_condition: Option<&Condition>,
+        limit: usize,
+    ) -> Result<Vec<SearchResult>> {
+        if anchor_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+        let metric = self.validate_query_and_read_metric(vector)?;
+        let metadata_filter = filter_condition
+            .and_then(Self::extract_metadata_filter)
+            .map(|c| crate::filter::Filter::new(crate::filter::Condition::from(c)));
+
+        if anchor_ids.len() <= ANCHORED_EXACT_SCORE_MAX {
+            return Ok(self.score_anchors_exact(
+                vector,
+                anchor_ids,
+                metadata_filter.as_ref(),
+                limit,
+                metric.higher_is_better(),
+            ));
+        }
+        self.search_anchors_bitmap(vector, anchor_ids, metadata_filter, limit, metric)
+    }
+
+    /// Bitmap-filtered HNSW search over a large anchor set (adaptive retry
+    /// in `search_with_quality_and_bitmap` compensates the post-hoc filter).
+    fn search_anchors_bitmap(
+        &self,
+        vector: &[f32],
+        anchor_ids: &HashSet<u64>,
+        metadata_filter: Option<crate::filter::Filter>,
+        limit: usize,
+        metric: crate::distance::DistanceMetric,
+    ) -> Result<Vec<SearchResult>> {
+        let mut bitmap = roaring::RoaringBitmap::new();
+        for &id in anchor_ids {
+            if let Ok(id32) = u32::try_from(id) {
+                bitmap.insert(id32);
+            }
+        }
+        if let Some(meta_bitmap) = metadata_filter
+            .as_ref()
+            .and_then(|f| self.build_prefilter_bitmap(f))
+        {
+            bitmap &= meta_bitmap;
+        }
+
+        // Residual (non-indexed) metadata conditions are applied after the
+        // fetch — oversample for them; pure graph prefilters need no slack.
+        let candidates_k = metadata_filter
+            .as_ref()
+            .map_or(limit, |f| {
+                super::super::vector_filter::compute_oversampled_k(limit, f)
+            })
+            .min(super::MAX_LIMIT);
+        let index_results = self.index.search_with_quality_and_bitmap(
+            vector,
+            candidates_k,
+            crate::SearchQuality::default(),
+            &bitmap,
+        )?;
+        let index_results = self.merge_delta(index_results, vector, candidates_k, metric);
+
+        let pass_all =
+            crate::filter::Filter::new(crate::filter::Condition::And { conditions: vec![] });
+        let filter = metadata_filter.unwrap_or(pass_all);
+        Ok(self.filter_and_hydrate(index_results, &filter, limit, metric.higher_is_better()))
+    }
+
+    /// Exact anchored scoring: hydrates every anchor, applies the metadata
+    /// filter, scores against `query`, and returns the polarity-sorted
+    /// top-`limit`. Exhaustive by construction.
+    fn score_anchors_exact(
+        &self,
+        query: &[f32],
+        anchor_ids: &HashSet<u64>,
+        metadata_filter: Option<&crate::filter::Filter>,
+        limit: usize,
+        higher_is_better: bool,
+    ) -> Vec<SearchResult> {
+        let mut ids: Vec<u64> = anchor_ids.iter().copied().collect();
+        ids.sort_unstable();
+
+        let mut scored = Vec::new();
+        for chunk in ids.chunks(ANCHOR_HYDRATION_CHUNK) {
+            for point in self.get(chunk).into_iter().flatten() {
+                let payload = point.payload.clone().unwrap_or(serde_json::Value::Null);
+                if metadata_filter.is_some_and(|f| !f.matches(&payload)) {
+                    continue;
+                }
+                let score = self.compute_metric_score(&point.vector, query);
+                scored.push(SearchResult::new(point, score));
+            }
+        }
+        if higher_is_better {
+            scored.sort_unstable_by(|a, b| b.score.total_cmp(&a.score));
+        } else {
+            scored.sort_unstable_by(|a, b| a.score.total_cmp(&b.score));
+        }
+        scored.truncate(limit);
+        scored
+    }
+
+    /// Anchored unranked fetch: hydrates the anchor set in deterministic
+    /// (ascending id) order, applies the full WHERE per candidate, and stops
+    /// at `limit` — replacing the `MAX_LIMIT` scan window with an exact,
+    /// exhaustive fetch (the anchors are the only possible matches).
+    pub(super) fn fetch_anchor_candidates(
+        &self,
+        anchor_ids: &HashSet<u64>,
+        cond: &Condition,
+        params: &std::collections::HashMap<String, serde_json::Value>,
+        from_aliases: &[String],
+        cache: &mut GraphMatchEvalCache,
+        limit: usize,
+    ) -> Result<Vec<SearchResult>> {
+        let mut ids: Vec<u64> = anchor_ids.iter().copied().collect();
+        ids.sort_unstable();
+
+        let mut results = Vec::new();
+        for chunk in ids.chunks(ANCHOR_HYDRATION_CHUNK) {
+            for point in self.get(chunk).into_iter().flatten() {
+                if results.len() >= limit {
+                    return Ok(results);
+                }
+                let passes = self.evaluate_where_condition_for_record(
+                    cond,
+                    point.id,
+                    point.payload.as_ref(),
+                    Some(&point.vector),
+                    params,
+                    from_aliases,
+                    cache,
+                )?;
+                if passes {
+                    results.push(SearchResult::new(point, 1.0));
+                }
+            }
+        }
+        Ok(results)
+    }
+}

--- a/crates/velesdb-core/src/collection/search/query/hybrid_sparse.rs
+++ b/crates/velesdb-core/src/collection/search/query/hybrid_sparse.rs
@@ -166,17 +166,33 @@ impl Collection {
     // ------------------------------------------------------------------
 
     /// Execute a sparse-only search, optionally filtered by payload conditions.
-    ///
-    /// # Lock ordering
-    ///
-    /// `payload_storage(3)` is acquired before `sparse_indexes(9)` to respect
-    /// the canonical lock order defined in `docs/CONCURRENCY_MODEL.md`.
     pub(crate) fn execute_sparse_search(
         &self,
         svs: &SparseVectorSearch,
         params: &std::collections::HashMap<String, serde_json::Value>,
         filter_condition: Option<&Condition>,
         limit: usize,
+    ) -> Result<Vec<SearchResult>> {
+        self.execute_sparse_search_in_anchors(svs, params, filter_condition, limit, None)
+    }
+
+    /// Execute a sparse-only search, optionally filtered by payload
+    /// conditions and/or restricted to a GraphFirst anchor-id set.
+    ///
+    /// With `anchors`, the sparse index's per-id filter makes the fetch
+    /// exact at `limit` *within* the graph matches — no over-fetch window.
+    ///
+    /// # Lock ordering
+    ///
+    /// `payload_storage(3)` is acquired before `sparse_indexes(9)` to respect
+    /// the canonical lock order defined in `docs/CONCURRENCY_MODEL.md`.
+    pub(crate) fn execute_sparse_search_in_anchors(
+        &self,
+        svs: &SparseVectorSearch,
+        params: &std::collections::HashMap<String, serde_json::Value>,
+        filter_condition: Option<&Condition>,
+        limit: usize,
+        anchors: Option<&std::collections::HashSet<u64>>,
     ) -> Result<Vec<SearchResult>> {
         let query_vec = Self::resolve_sparse_vector(&svs.vector, params)?;
         let index_name = svs
@@ -189,22 +205,14 @@ impl Collection {
             .and_then(Self::extract_metadata_filter)
             .map(|cond| crate::filter::Filter::new(crate::filter::Condition::from(cond)));
 
-        // LOCK ORDER: payload_storage(3) before sparse_indexes(9).
-        let results = if let Some(ref filter) = metadata_filter {
-            let payload_storage = self.payload_storage.read(); // lock 3
-            let indexes = self.sparse_indexes.read(); // lock 9
-            let index = indexes
-                .get(index_name)
-                .ok_or_else(|| resolve::sparse_index_not_found(index_name))?;
-            let filter_fn = |id: u64| {
-                let payload = payload_storage.retrieve(id).ok().flatten();
-                let p = payload.as_ref().unwrap_or(&serde_json::Value::Null);
-                filter.matches(p)
-            };
-            let r = sparse_search_filtered(index, &query_vec, limit, Some(&filter_fn));
-            drop(indexes);
-            drop(payload_storage);
-            r
+        let results = if metadata_filter.is_some() || anchors.is_some() {
+            self.sparse_search_with_id_filter(
+                index_name,
+                &query_vec,
+                limit,
+                metadata_filter.as_ref(),
+                anchors,
+            )?
         } else {
             let indexes = self.sparse_indexes.read(); // lock 9 only (no payload needed)
             let index = indexes
@@ -216,6 +224,47 @@ impl Collection {
         };
 
         Ok(self.resolve_sparse_results(&results, limit))
+    }
+
+    /// Runs a sparse search with a per-id filter combining anchor membership
+    /// and the metadata payload filter.
+    ///
+    /// # Lock ordering
+    ///
+    /// `payload_storage(3)` is acquired before `sparse_indexes(9)` to respect
+    /// the canonical lock order defined in `docs/CONCURRENCY_MODEL.md`.
+    fn sparse_search_with_id_filter(
+        &self,
+        index_name: &str,
+        query_vec: &SparseVector,
+        limit: usize,
+        metadata_filter: Option<&crate::filter::Filter>,
+        anchors: Option<&std::collections::HashSet<u64>>,
+    ) -> Result<Vec<crate::sparse_index::ScoredDoc>> {
+        let payload_storage = metadata_filter.map(|_| self.payload_storage.read()); // lock 3
+        let indexes = self.sparse_indexes.read(); // lock 9
+        let index = indexes
+            .get(index_name)
+            .ok_or_else(|| resolve::sparse_index_not_found(index_name))?;
+        let filter_fn = |id: u64| {
+            if anchors.is_some_and(|a| !a.contains(&id)) {
+                return false;
+            }
+            match (metadata_filter, &payload_storage) {
+                (Some(filter), Some(storage)) => {
+                    let payload = storage.retrieve(id).ok().flatten();
+                    let p = payload.as_ref().unwrap_or(&serde_json::Value::Null);
+                    filter.matches(p)
+                }
+                _ => true,
+            }
+        };
+        Ok(sparse_search_filtered(
+            index,
+            query_vec,
+            limit,
+            Some(&filter_fn),
+        ))
     }
 
     // ------------------------------------------------------------------

--- a/crates/velesdb-core/src/collection/search/query/mod.rs
+++ b/crates/velesdb-core/src/collection/search/query/mod.rs
@@ -43,6 +43,7 @@ mod execution_paths;
 mod extraction;
 #[cfg(test)]
 mod extraction_tests;
+mod graph_prefilter;
 mod hybrid_sparse;
 #[cfg(test)]
 mod hybrid_sparse_tests;

--- a/crates/velesdb-core/src/collection/search/query/select_dispatch.rs
+++ b/crates/velesdb-core/src/collection/search/query/select_dispatch.rs
@@ -188,49 +188,110 @@ impl Collection {
                 .where_clause
                 .as_ref()
                 .is_some_and(Self::condition_contains_or);
-        // The bounded over-fetch window only makes sense when the fetch is
-        // RANKED (vector NEAR or similarity() threshold): "rows ranked beyond
-        // the window" is a meaningful trade-off there. The metadata/scan
-        // paths fetch in storage order — capping them would silently drop
-        // graph matches depending on insertion order, so they keep the
-        // exhaustive MAX_LIMIT window (sparse queries never reach here; they
-        // are dispatched by `try_early_return_path`).
-        let has_ranked_fetch =
-            extracted.vector_search.is_some() || !extracted.similarity_conditions.is_empty();
-        let execution_limit = match (has_graph_predicates, has_ranked_fetch) {
-            (true, true) => graph_overfetch_limit(limit),
-            (true, false) => MAX_LIMIT,
-            (false, _) => limit,
-        };
+        let execution_limit = main_select_execution_limit(extracted, limit);
         let search_opts = super::QuerySearchOptions::from_with_clause(stmt.with_clause.as_ref())
             .with_fusion(stmt.fusion_clause.clone());
         let first_similarity = extracted.similarity_conditions.first().cloned();
         let (cbo_strategy, cbo_over_fetch) =
             self.compute_cbo_strategy(stmt, extracted.filter_condition.as_ref(), limit);
 
-        let mut results = self
-            .dispatch_vector_query(
-                extracted.vector_search.as_ref(),
-                first_similarity.as_ref(),
-                &extracted.similarity_conditions,
-                extracted.filter_condition.as_ref(),
-                execution_limit,
-                skip_metadata_prefilter_for_graph_or,
-                &search_opts,
-                cbo_strategy,
-                cbo_over_fetch,
-            )
-            .inspect_err(|_| self.guard_rails.circuit_breaker.record_failure())?;
+        // GraphFirst by anchor ids: AND-required MATCH predicates are
+        // evaluated FIRST so retrieval is exhaustive within the graph
+        // matches instead of bounded by an over-fetch window. The cache
+        // carries the computed anchor sets into the exact post-filter.
+        let mut graph_cache = super::where_eval::GraphMatchEvalCache::default();
+        let anchored = self.try_anchored_fetch(stmt, params, extracted, limit, &mut graph_cache)?;
+
+        let mut results = match anchored {
+            Some(results) => results,
+            None => self
+                .dispatch_vector_query(
+                    extracted.vector_search.as_ref(),
+                    first_similarity.as_ref(),
+                    &extracted.similarity_conditions,
+                    extracted.filter_condition.as_ref(),
+                    execution_limit,
+                    skip_metadata_prefilter_for_graph_or,
+                    &search_opts,
+                    cbo_strategy,
+                    cbo_over_fetch,
+                )
+                .inspect_err(|_| self.guard_rails.circuit_breaker.record_failure())?,
+        };
 
         if has_graph_predicates {
-            if let Some(cond) = stmt.where_clause.as_ref() {
-                results = self
-                    .apply_where_condition_to_results(results, cond, params, &stmt.from_alias)
-                    .inspect_err(|_| self.guard_rails.circuit_breaker.record_failure())?;
-            }
+            results = self.post_filter_graph_where(stmt, params, results, &mut graph_cache)?;
         }
 
         Ok(results)
+    }
+
+    /// Applies the exact WHERE post-filter when graph predicates are present,
+    /// reusing the warmed anchor cache.
+    fn post_filter_graph_where(
+        &self,
+        stmt: &crate::velesql::SelectStatement,
+        params: &std::collections::HashMap<String, serde_json::Value>,
+        results: Vec<SearchResult>,
+        graph_cache: &mut super::where_eval::GraphMatchEvalCache,
+    ) -> Result<Vec<SearchResult>> {
+        let Some(cond) = stmt.where_clause.as_ref() else {
+            return Ok(results);
+        };
+        self.apply_where_condition_to_results_with_cache(
+            results,
+            cond,
+            params,
+            &stmt.from_alias,
+            graph_cache,
+        )
+        .inspect_err(|_| self.guard_rails.circuit_breaker.record_failure())
+    }
+
+    /// Attempts the GraphFirst anchored fetch for the main SELECT path.
+    ///
+    /// Applicable when the WHERE clause AND-requires at least one MATCH
+    /// predicate and the fetch is either plain NEAR or unranked — the
+    /// similarity()-cascade and BM25 text-fusion shapes keep their dedicated
+    /// scoring pipelines (the post-filter window applies there).
+    ///
+    /// Returns `Ok(None)` to fall through to the regular dispatch.
+    fn try_anchored_fetch(
+        &self,
+        stmt: &crate::velesql::SelectStatement,
+        params: &std::collections::HashMap<String, serde_json::Value>,
+        extracted: &ExtractedComponents,
+        limit: usize,
+        graph_cache: &mut super::where_eval::GraphMatchEvalCache,
+    ) -> Result<Option<Vec<SearchResult>>> {
+        let Some(cond) = stmt.where_clause.as_ref() else {
+            return Ok(None);
+        };
+        if !anchored_fetch_applies(extracted, cond) {
+            return Ok(None);
+        }
+        let Some(anchor_ids) =
+            self.compute_required_anchor_ids(cond, params, &stmt.from_alias, graph_cache)?
+        else {
+            return Ok(None);
+        };
+        let results = match extracted.vector_search.as_ref() {
+            Some(vector) => self.search_near_with_anchor_ids(
+                vector,
+                &anchor_ids,
+                extracted.filter_condition.as_ref(),
+                limit,
+            )?,
+            None => self.fetch_anchor_candidates(
+                &anchor_ids,
+                cond,
+                params,
+                &stmt.from_alias,
+                graph_cache,
+                limit,
+            )?,
+        };
+        Ok(Some(results))
     }
 
     /// Analyzes JOIN pushdown opportunities (EPIC-031 US-006).
@@ -390,6 +451,39 @@ impl Collection {
 /// storage order, so a capped window would silently drop graph matches based
 /// on insertion order (those paths keep `MAX_LIMIT`, the pre-existing
 /// behavior).
+/// Whether the GraphFirst anchored fetch covers this query shape: graph
+/// predicates present, and no similarity() cascade or BM25 text-MATCH
+/// fusion (those keep their dedicated scoring pipelines).
+fn anchored_fetch_applies(
+    extracted: &ExtractedComponents,
+    cond: &crate::velesql::Condition,
+) -> bool {
+    !extracted.graph_match_predicates.is_empty()
+        && extracted.similarity_conditions.is_empty()
+        && Collection::extract_match_query(cond).is_none()
+}
+
+/// Fetch window for the main SELECT path.
+///
+/// The bounded over-fetch window only makes sense when the fetch is RANKED
+/// (vector NEAR or similarity() threshold): "rows ranked beyond the window"
+/// is a meaningful trade-off there. The metadata/scan paths fetch in storage
+/// order — capping them would silently drop graph matches depending on
+/// insertion order, so they keep the exhaustive MAX_LIMIT window (sparse
+/// queries never reach here; they are dispatched by `try_early_return_path`).
+/// This window only applies when the GraphFirst anchored fetch declined
+/// (`try_anchored_fetch`).
+fn main_select_execution_limit(extracted: &ExtractedComponents, limit: usize) -> usize {
+    let has_graph_predicates = !extracted.graph_match_predicates.is_empty();
+    let has_ranked_fetch =
+        extracted.vector_search.is_some() || !extracted.similarity_conditions.is_empty();
+    match (has_graph_predicates, has_ranked_fetch) {
+        (true, true) => graph_overfetch_limit(limit),
+        (true, false) => MAX_LIMIT,
+        (false, _) => limit,
+    }
+}
+
 fn graph_overfetch_limit(limit: usize) -> usize {
     const GRAPH_OVERFETCH_CAP: usize = 10_000;
     limit.max(limit.saturating_mul(10).min(GRAPH_OVERFETCH_CAP))

--- a/crates/velesdb-core/src/collection/search/query/similarity_filter.rs
+++ b/crates/velesdb-core/src/collection/search/query/similarity_filter.rs
@@ -10,6 +10,13 @@ use crate::error::Result;
 use crate::point::{Point, SearchResult};
 use crate::storage::{PayloadStorage, VectorStorage};
 
+/// Inverted-similarity threshold bundle for the NOT-similarity scan.
+struct NotSimilarityThreshold {
+    op: crate::velesql::CompareOp,
+    value: f32,
+    higher_is_better: bool,
+}
+
 impl Collection {
     /// Filter search results by similarity threshold.
     ///
@@ -87,16 +94,28 @@ impl Collection {
     ///
     /// **Performance Warning**: This requires scanning ALL documents.
     /// Always use with LIMIT for acceptable performance.
-    pub(crate) fn execute_not_similarity_query(
+    /// With `candidates` (GraphFirst anchor ids), only those ids are
+    /// scanned, so the fetch is exact at `limit` within the graph matches;
+    /// `None` scans the whole collection.
+    pub(crate) fn execute_not_similarity_query_over(
         &self,
         condition: &crate::velesql::Condition,
         params: &std::collections::HashMap<String, serde_json::Value>,
         limit: usize,
+        candidates: Option<&std::collections::HashSet<u64>>,
     ) -> Result<Vec<SearchResult>> {
         let (sim_field, sim_vec, sim_op, sim_threshold) =
             self.extract_not_similarity_condition(condition, params)?;
 
-        let total_count = self.vector_storage.read().ids().len();
+        let all_ids = match candidates {
+            Some(ids) => {
+                let mut sorted: Vec<u64> = ids.iter().copied().collect();
+                sorted.sort_unstable();
+                sorted
+            }
+            None => self.vector_storage.read().ids(),
+        };
+        let total_count = all_ids.len();
         Self::guard_not_similarity_scan(total_count)?;
         Self::warn_large_scan(total_count, limit);
 
@@ -109,39 +128,64 @@ impl Collection {
         #[allow(clippy::cast_precision_loss, clippy::cast_possible_truncation)]
         let threshold_f32 = sim_threshold as f32;
         let mut results = Vec::new();
-        let all_ids = self.vector_storage.read().ids();
 
+        let threshold = NotSimilarityThreshold {
+            op: sim_op,
+            value: threshold_f32,
+            higher_is_better,
+        };
         for id in all_ids {
-            let Some(vector) = self.retrieve_vector_for_scan(id, &sim_field) else {
-                continue;
-            };
-            let score = self.compute_metric_score(&vector, &sim_vec);
-
-            let excluded = Self::compare_similarity(score, threshold_f32, sim_op, higher_is_better);
-            if excluded {
-                continue;
-            }
-
-            let payload = self.payload_storage.read().retrieve(id).ok().flatten();
-            if !Self::passes_metadata_filter(filter.as_ref(), payload.as_ref()) {
-                continue;
-            }
-
-            results.push(SearchResult::new(
-                Point {
-                    id,
-                    vector,
-                    payload,
-                    sparse_vectors: None,
-                },
-                score,
-            ));
-            if results.len() >= limit {
-                break;
+            if let Some(result) = self.eval_not_similarity_candidate(
+                id,
+                &sim_field,
+                &sim_vec,
+                &threshold,
+                filter.as_ref(),
+            ) {
+                results.push(result);
+                if results.len() >= limit {
+                    break;
+                }
             }
         }
 
         Ok(results)
+    }
+
+    /// Evaluates one candidate id for the NOT-similarity scan: returns the
+    /// hydrated result when it passes both the inverted similarity threshold
+    /// and the metadata filter.
+    fn eval_not_similarity_candidate(
+        &self,
+        id: u64,
+        sim_field: &str,
+        sim_vec: &[f32],
+        threshold: &NotSimilarityThreshold,
+        filter: Option<&crate::filter::Filter>,
+    ) -> Option<SearchResult> {
+        let vector = self.retrieve_vector_for_scan(id, sim_field)?;
+        let score = self.compute_metric_score(&vector, sim_vec);
+        if Self::compare_similarity(
+            score,
+            threshold.value,
+            threshold.op,
+            threshold.higher_is_better,
+        ) {
+            return None; // excluded by the NOT-similarity threshold
+        }
+        let payload = self.payload_storage.read().retrieve(id).ok().flatten();
+        if !Self::passes_metadata_filter(filter, payload.as_ref()) {
+            return None;
+        }
+        Some(SearchResult::new(
+            Point {
+                id,
+                vector,
+                payload,
+                sparse_vectors: None,
+            },
+            score,
+        ))
     }
 
     /// Compares a similarity score against a threshold using the given operator.

--- a/crates/velesdb-core/src/collection/search/query/sparse_dispatch.rs
+++ b/crates/velesdb-core/src/collection/search/query/sparse_dispatch.rs
@@ -18,21 +18,85 @@ impl Collection {
         ctx: &crate::guardrails::QueryContext,
     ) -> Result<Vec<SearchResult>> {
         let has_graph_predicates = !extracted.graph_match_predicates.is_empty();
-        let execution_limit = if has_graph_predicates {
-            MAX_LIMIT
-        } else {
-            limit
-        };
+
+        // GraphFirst by anchor ids (sparse-only): AND-required MATCH
+        // predicates restrict the sparse fetch via the index's per-id
+        // filter, so retrieval is exact at `limit` within the graph matches
+        // instead of post-filtering a MAX_LIMIT window. Hybrid dense+sparse
+        // keeps the window: its fusion legs rank independently.
+        let mut graph_cache = super::where_eval::GraphMatchEvalCache::default();
+        let anchors = self.sparse_anchor_prefilter(stmt, params, extracted, &mut graph_cache)?;
 
         let mut results =
-            self.execute_sparse_or_hybrid(stmt, extracted, svs, params, execution_limit)?;
+            self.fetch_sparse_results(stmt, params, extracted, svs, limit, anchors.as_ref())?;
 
         if has_graph_predicates {
-            results = self.filter_by_graph_predicates(stmt, params, results)?;
+            results = self.filter_by_graph_predicates_with_cache(
+                stmt,
+                params,
+                results,
+                &mut graph_cache,
+            )?;
         }
 
         self.check_guardrails_and_record(ctx, results.len())?;
         self.finalize_sparse_results(stmt, params, results)
+    }
+
+    /// Fetches sparse/hybrid results: anchored exact fetch when a GraphFirst
+    /// anchor set is available, MAX_LIMIT window fetch otherwise.
+    fn fetch_sparse_results(
+        &self,
+        stmt: &crate::velesql::SelectStatement,
+        params: &std::collections::HashMap<String, serde_json::Value>,
+        extracted: &ExtractedComponents,
+        svs: &crate::velesql::SparseVectorSearch,
+        limit: usize,
+        anchors: Option<&std::collections::HashSet<u64>>,
+    ) -> Result<Vec<SearchResult>> {
+        let Some(anchor_ids) = anchors else {
+            let execution_limit = if extracted.graph_match_predicates.is_empty() {
+                limit
+            } else {
+                MAX_LIMIT
+            };
+            return self.execute_sparse_or_hybrid(stmt, extracted, svs, params, execution_limit);
+        };
+        self.execute_sparse_search_in_anchors(
+            svs,
+            params,
+            extracted.filter_condition.as_ref(),
+            limit,
+            Some(anchor_ids),
+        )
+        .inspect_err(|_| self.guard_rails.circuit_breaker.record_failure())
+    }
+
+    /// Computes the GraphFirst anchor set for a sparse-only fetch.
+    ///
+    /// Returns `None` for hybrid dense+sparse queries and for residual
+    /// conditions the in-fetch filter cannot cover (text MATCH,
+    /// similarity()) — those drop rows after the fetch and keep the window.
+    fn sparse_anchor_prefilter(
+        &self,
+        stmt: &crate::velesql::SelectStatement,
+        params: &std::collections::HashMap<String, serde_json::Value>,
+        extracted: &ExtractedComponents,
+        graph_cache: &mut super::where_eval::GraphMatchEvalCache,
+    ) -> Result<Option<std::collections::HashSet<u64>>> {
+        if extracted.graph_match_predicates.is_empty()
+            || extracted.vector_search.is_some()
+            || !extracted.similarity_conditions.is_empty()
+        {
+            return Ok(None);
+        }
+        let Some(cond) = stmt.where_clause.as_ref() else {
+            return Ok(None);
+        };
+        if Self::extract_match_query(cond).is_some() {
+            return Ok(None);
+        }
+        self.compute_required_anchor_ids(cond, params, &stmt.from_alias, graph_cache)
     }
 
     /// Executes either a sparse-only or hybrid dense+sparse search.
@@ -66,16 +130,25 @@ impl Collection {
         }
     }
 
-    /// Applies graph-predicate WHERE filtering to results.
-    fn filter_by_graph_predicates(
+    /// Applies graph-predicate WHERE filtering to results, reusing the
+    /// caller's evaluation cache so prefiltered anchor sets are not
+    /// re-evaluated.
+    fn filter_by_graph_predicates_with_cache(
         &self,
         stmt: &crate::velesql::SelectStatement,
         params: &std::collections::HashMap<String, serde_json::Value>,
         results: Vec<SearchResult>,
+        cache: &mut super::where_eval::GraphMatchEvalCache,
     ) -> Result<Vec<SearchResult>> {
         match stmt.where_clause.as_ref() {
             Some(cond) => self
-                .apply_where_condition_to_results(results, cond, params, &stmt.from_alias)
+                .apply_where_condition_to_results_with_cache(
+                    results,
+                    cond,
+                    params,
+                    &stmt.from_alias,
+                    cache,
+                )
                 .inspect_err(|_| self.guard_rails.circuit_breaker.record_failure()),
             None => Ok(results),
         }

--- a/crates/velesdb-core/src/collection/search/query/where_eval.rs
+++ b/crates/velesdb-core/src/collection/search/query/where_eval.rs
@@ -24,7 +24,7 @@ pub(crate) struct GraphMatchEvalCache {
 }
 
 impl GraphMatchEvalCache {
-    fn get_or_compute(
+    pub(super) fn get_or_compute(
         &mut self,
         collection: &Collection,
         predicate: &GraphMatchPredicate,
@@ -124,6 +124,26 @@ impl Collection {
         from_aliases: &[String],
     ) -> Result<Vec<SearchResult>> {
         let mut cache = GraphMatchEvalCache::default();
+        self.apply_where_condition_to_results_with_cache(
+            results,
+            condition,
+            params,
+            from_aliases,
+            &mut cache,
+        )
+    }
+
+    /// Like [`Self::apply_where_condition_to_results`], reusing a caller's
+    /// evaluation cache — graph anchor sets computed by a GraphFirst
+    /// prefilter are not re-evaluated for the exact post-filter pass.
+    pub(crate) fn apply_where_condition_to_results_with_cache(
+        &self,
+        results: Vec<SearchResult>,
+        condition: &Condition,
+        params: &std::collections::HashMap<String, serde_json::Value>,
+        from_aliases: &[String],
+        cache: &mut GraphMatchEvalCache,
+    ) -> Result<Vec<SearchResult>> {
         let requires_vector = Self::condition_requires_vector_eval(condition);
         let mut filtered = Vec::with_capacity(results.len());
 
@@ -140,7 +160,7 @@ impl Collection {
                 vector,
                 params,
                 from_aliases,
-                &mut cache,
+                cache,
             )? {
                 filtered.push(result);
             }

--- a/crates/velesdb-core/src/velesql/planner.rs
+++ b/crates/velesdb-core/src/velesql/planner.rs
@@ -39,9 +39,12 @@ pub use crate::velesql::query_stats::QueryStats;
 /// This is the planner's *intent*; the executor realizes it only partially:
 /// on the SELECT path (`execution_paths.rs`), `GraphFirst` selects a
 /// full-scan-then-score realization for metadata filters and every other
-/// variant (including `Parallel`) is executed as `VectorFirst`; graph
-/// predicates in SELECT WHERE are always applied as a post-filter over the
-/// vector candidates. On the top-level MATCH path (`match_dispatch.rs`),
+/// variant (including `Parallel`) is executed as `VectorFirst`. Graph
+/// predicates in SELECT WHERE that are AND-required take the GraphFirst
+/// anchored fetch (`graph_prefilter.rs`) independently of this strategy —
+/// anchor sets are evaluated first and retrieval is exhaustive within them;
+/// only OR/NOT-wrapped predicates remain post-filters over the fetch
+/// window. On the top-level MATCH path (`match_dispatch.rs`),
 /// `Parallel` runs `GraphFirst` and `VectorFirst` **sequentially** and merges
 /// the result sets (true parallelism is a future optimization).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/velesdb-core/tests/bdd.rs
+++ b/crates/velesdb-core/tests/bdd.rs
@@ -39,6 +39,8 @@ mod explain_cost_calibrated;
 mod flush_operations;
 #[path = "bdd/geo_distance.rs"]
 mod geo_distance;
+#[path = "bdd/graph_anchor_prefilter.rs"]
+mod graph_anchor_prefilter;
 #[path = "bdd/graph_queries.rs"]
 mod graph_queries;
 #[path = "bdd/graph_vector_hybrid.rs"]

--- a/crates/velesdb-core/tests/bdd/graph_anchor_prefilter.rs
+++ b/crates/velesdb-core/tests/bdd/graph_anchor_prefilter.rs
@@ -1,0 +1,207 @@
+//! BDD tests for GraphFirst anchor-id prefiltering (audit 2026-06 follow-up).
+//!
+//! Contract under test: when a `MATCH (...)` predicate is AND-required by
+//! the WHERE clause, retrieval is **exhaustive within the graph matches** —
+//! a matching row is found even when it ranks far outside the bounded
+//! over-fetch window that the post-filter execution would have fetched.
+//! Predicates under `OR` keep the post-filter semantics unchanged.
+
+use std::collections::HashMap;
+
+use serde_json::json;
+use velesdb_core::{Database, GraphEdge, Point, SearchResult};
+
+use super::helpers::create_test_db;
+
+const ROWS: u64 = 30;
+
+/// Parses and executes `sql` against `collection` with a `$q` vector param.
+fn run_query(
+    db: &Database,
+    sql: &str,
+    collection: &str,
+    vector: Option<&[f32]>,
+) -> Vec<SearchResult> {
+    let query = velesdb_core::velesql::Parser::parse(sql).expect("test: parse query");
+    let mut params = HashMap::new();
+    params.insert(
+        "_collection".to_string(),
+        serde_json::Value::String(collection.to_string()),
+    );
+    if let Some(v) = vector {
+        params.insert("q".to_string(), json!(v));
+    }
+    db.execute_query(&query, &params)
+        .expect("test: execute query")
+}
+
+/// GIVEN base: 30 points whose similarity to `[1,0,0,0]` strictly decreases
+/// with id; ONLY the vector-distant nodes 27 and 28 carry an outgoing
+/// `CITES` edge (and a `flagged` payload marker mirroring the edge set).
+fn setup_far_anchor_collection(db: &Database) {
+    db.create_vector_collection("far", 4, velesdb_core::DistanceMetric::Cosine)
+        .expect("test: create far collection");
+    let vc = db
+        .get_vector_collection("far")
+        .expect("test: get far collection");
+
+    let mut points = Vec::new();
+    for i in 0..ROWS {
+        // Angle from the query grows with i → similarity strictly decreases.
+        #[allow(clippy::cast_precision_loss)]
+        let off = (i as f32) * 0.2;
+        points.push(Point::new(
+            i,
+            vec![1.0, off, 0.0, 0.0],
+            Some(json!({"idx": i, "flagged": i == 27 || i == 28})),
+        ));
+    }
+    points.push(Point::new(
+        100,
+        vec![-1.0, 0.0, 0.0, 0.5],
+        Some(json!({"target": true})),
+    ));
+    vc.upsert(points).expect("test: upsert");
+
+    for (edge_id, source) in [(900u64, 27u64), (901, 28)] {
+        let edge = GraphEdge::new(edge_id, source, 100, "CITES").expect("test: create edge");
+        vc.add_edge(edge).expect("test: add edge");
+    }
+}
+
+/// WHEN the only graph-matching nodes rank ~28th by similarity and LIMIT is 1
+/// (over-fetch window = 10) THEN the anchored NEAR fetch still finds the best
+/// graph match — retrieval is exhaustive within the anchors, not bounded by
+/// the window.
+#[test]
+fn test_near_match_finds_anchor_beyond_overfetch_window() {
+    let (_dir, db) = create_test_db();
+    setup_far_anchor_collection(&db);
+
+    let results = run_query(
+        &db,
+        "SELECT * FROM far AS d WHERE vector NEAR $q AND MATCH (d)-[:CITES]->(x) LIMIT 1",
+        "far",
+        Some(&[1.0, 0.0, 0.0, 0.0]),
+    );
+
+    assert_eq!(results.len(), 1, "the graph match must be found");
+    assert_eq!(
+        results[0].point.id, 27,
+        "node 27 is the most similar of the two anchors"
+    );
+}
+
+/// Metadata + MATCH without NEAR: the anchored fetch returns exactly the
+/// rows satisfying both, without scanning a bounded window.
+#[test]
+fn test_metadata_and_match_anchored_fetch_is_exact() {
+    let (_dir, db) = create_test_db();
+    setup_far_anchor_collection(&db);
+
+    let results = run_query(
+        &db,
+        "SELECT * FROM far AS d WHERE idx >= 28 AND MATCH (d)-[:CITES]->(x) LIMIT 10",
+        "far",
+        None,
+    );
+
+    let ids: Vec<u64> = results.iter().map(|r| r.point.id).collect();
+    assert_eq!(
+        ids,
+        vec![28],
+        "only node 28 satisfies idx >= 28 AND the edge"
+    );
+}
+
+/// OR-wrapped MATCH keeps post-filter semantics: rows matching EITHER side
+/// are returned (no prefilter may narrow an OR).
+#[test]
+fn test_or_wrapped_match_keeps_union_semantics() {
+    let (_dir, db) = create_test_db();
+    setup_far_anchor_collection(&db);
+
+    let results = run_query(
+        &db,
+        "SELECT * FROM far AS d WHERE idx = 3 OR MATCH (d)-[:CITES]->(x) LIMIT 10",
+        "far",
+        None,
+    );
+
+    let mut ids: Vec<u64> = results.iter().map(|r| r.point.id).collect();
+    ids.sort_unstable();
+    assert_eq!(
+        ids,
+        vec![3, 27, 28],
+        "OR must keep both the metadata match and the graph matches"
+    );
+}
+
+/// Sparse + MATCH: anchors feed the sparse index's per-id filter, so the
+/// anchor docs are returned ranked by sparse score even when non-anchor
+/// docs dominate the global sparse ranking at this LIMIT.
+#[test]
+fn test_sparse_match_returns_anchors_beyond_global_ranking() {
+    let (_dir, db) = create_test_db();
+    db.create_vector_collection("sp", 4, velesdb_core::DistanceMetric::Cosine)
+        .expect("test: create sp collection");
+    let vc = db
+        .get_vector_collection("sp")
+        .expect("test: get sp collection");
+
+    // Sparse weight on term 1 decreases with id: docs 1..3 dominate the
+    // global sparse ranking; only doc 5 (weakest) has the edge.
+    let mut points = Vec::new();
+    for i in 1..=5u64 {
+        #[allow(clippy::cast_precision_loss)]
+        let weight = 10.0 - i as f32;
+        let mut sparse = std::collections::BTreeMap::new();
+        sparse.insert(
+            String::new(),
+            velesdb_core::sparse_index::SparseVector::new(vec![(1, weight)]),
+        );
+        points.push(Point {
+            id: i,
+            vector: vec![1.0, 0.0, 0.0, 0.0],
+            payload: Some(json!({"idx": i})),
+            sparse_vectors: Some(sparse),
+        });
+    }
+    vc.upsert(points).expect("test: upsert");
+    let edge = GraphEdge::new(900, 5, 1, "CITES").expect("test: create edge");
+    vc.add_edge(edge).expect("test: add edge");
+
+    let results = run_query(
+        &db,
+        "SELECT * FROM sp AS d WHERE vector SPARSE_NEAR {1: 1.0} AND MATCH (d)-[:CITES]->(x) LIMIT 1",
+        "sp",
+        None,
+    );
+
+    assert_eq!(results.len(), 1, "the graph-matching doc must be found");
+    assert_eq!(
+        results[0].point.id, 5,
+        "doc 5 is the only anchor — it must be returned despite ranking last globally"
+    );
+}
+
+/// NOT-similarity + MATCH: the scan is restricted to the anchor set and the
+/// fetch is exact at LIMIT.
+#[test]
+fn test_not_similarity_match_scans_only_anchors() {
+    let (_dir, db) = create_test_db();
+    setup_far_anchor_collection(&db);
+
+    // Both anchors (27, 28) are dissimilar enough to pass NOT similarity > 0.99.
+    let results = run_query(
+        &db,
+        "SELECT * FROM far AS d WHERE NOT similarity(vector, $q) > 0.99 \
+         AND MATCH (d)-[:CITES]->(x) LIMIT 10",
+        "far",
+        Some(&[1.0, 0.0, 0.0, 0.0]),
+    );
+
+    let mut ids: Vec<u64> = results.iter().map(|r| r.point.id).collect();
+    ids.sort_unstable();
+    assert_eq!(ids, vec![27, 28], "exactly the anchor rows pass");
+}

--- a/docs/VELESQL_SPEC.md
+++ b/docs/VELESQL_SPEC.md
@@ -935,17 +935,24 @@ WHERE category = 'tech' AND MATCH (ctx)-[:REL]->(x)
 LIMIT 10
 ```
 
-**Execution note (over-fetch window).** When a graph predicate is combined with
-a ranked fetch (`vector NEAR` or a `similarity()` threshold), the engine
-over-fetches vector candidates before applying the graph filter: it retrieves
-up to `max(LIMIT, min(LIMIT × 10, 10 000))` candidates and keeps those that
-satisfy the pattern. Rows that match the graph pattern but rank beyond this
-candidate window are not returned. If the graph filter is highly selective,
-increase `LIMIT` to widen the window. Without a ranked fetch (graph predicate
-alone, or combined with metadata filters only), the engine instead scans up to
-100 000 candidates in storage order before applying the graph filter: results
-are exhaustive for collections up to 100 000 points; beyond that bound,
-pattern-matching rows are not returned (unchanged from previous releases).
+**Execution note (GraphFirst anchored fetch).** When every `MATCH (...)`
+predicate is AND-required by the WHERE clause (not wrapped in `OR`/`NOT`),
+the engine evaluates the graph patterns FIRST and fetches *within* their
+anchor sets — retrieval is then **exhaustive**: a matching row is returned no
+matter how it ranks globally. This covers `vector NEAR` (anchor sets up to
+10 000 ids are scored exactly; larger ones go through the bitmap-filtered
+HNSW path), metadata-only fetches (the anchors are hydrated directly),
+sparse-only fetches (anchors feed the sparse index's per-id filter), and
+`NOT similarity()` scans (restricted to the anchors).
+
+**Execution note (over-fetch window, residual shapes).** Query shapes that
+cannot use the anchored fetch keep the windowed execution: graph predicates
+under `OR`/`NOT`, combinations with a `similarity()` threshold cascade, BM25
+text `MATCH` fusion, or hybrid dense+sparse fusion. There, a ranked fetch
+retrieves up to `max(LIMIT, min(LIMIT × 10, 10 000))` candidates and keeps
+those that satisfy the pattern (rows ranked beyond the window are not
+returned — increase `LIMIT` to widen it); unranked shapes scan up to 100 000
+candidates in storage order.
 
 ### Vector Search with Filters
 

--- a/docs/reference/VELESQL_CONTRACT.md
+++ b/docs/reference/VELESQL_CONTRACT.md
@@ -72,13 +72,15 @@ Rules:
   `FROM`/`JOIN` clauses declare aliases, the anchor alias must be one of them.
   Violations fail validation with error code `V011`. When `FROM` has no alias,
   any anchor alias is accepted.
-- Execution note: combined with `vector NEAR` (or a `similarity()` threshold),
-  graph predicates are applied as a filter over an over-fetched candidate
-  window of `max(LIMIT, min(LIMIT × 10, 10 000))` ranked vector candidates;
-  pattern-matching rows ranked beyond that window are not returned. Without a
-  ranked fetch, the candidate scan is bounded at 100 000 points (storage
-  order); collections larger than that may miss pattern-matching rows beyond
-  the bound (unchanged from previous releases).
+- Execution note: graph predicates that are AND-required by the WHERE clause
+  take the GraphFirst anchored fetch — the pattern is evaluated first and
+  retrieval is exhaustive within its anchor set (NEAR, metadata-only,
+  sparse-only and `NOT similarity()` shapes). Residual shapes (predicates
+  under `OR`/`NOT`, `similarity()` cascades, BM25 text-`MATCH` fusion, hybrid
+  dense+sparse fusion) keep the windowed execution: a ranked fetch filters an
+  over-fetched window of `max(LIMIT, min(LIMIT × 10, 10 000))` candidates
+  (rows ranked beyond it are not returned); unranked shapes scan up to
+  100 000 points in storage order.
 
 Success response shape:
 


### PR DESCRIPTION
## Summary

Realizes the planner's GraphFirst intent for SELECT graph predicates (audit 2026-06 follow-up #2). Previously, `MATCH (...)` predicates in SELECT WHERE were always a **post-filter over a bounded fetch window** (10×LIMIT capped at 10K for ranked fetches; a 100K storage-order scan otherwise): graph-matching rows ranked beyond the window were silently missing, and unranked paths hydrated up to 100K candidates.

## How it works (`collection/search/query/graph_prefilter.rs`)

Predicates **AND-required** by the WHERE clause (not under `OR`/`NOT`) are evaluated FIRST; the fetch happens within the intersection of their anchor sets — exhaustive by construction:

| Shape | Anchored fetch |
|-------|----------------|
| `vector NEAR` + MATCH | ≤10K anchors: **exact scoring** of the anchor set (the HNSW bitmap mechanism only post-filters a bounded candidate pool, so exact scoring is the only provably exhaustive option for selective predicates); >10K: bitmap-filtered HNSW with adaptive retry |
| metadata / unranked + MATCH | anchors ARE the candidates — chunked deterministic hydration with the full WHERE per candidate and early exit (replaces the MAX_LIMIT scan) |
| sparse-only + MATCH | anchor set feeds the sparse index's per-id filter — **exact at LIMIT** |
| `NOT similarity()` + MATCH | scan restricted to the anchor set |

Anchor sets are computed once into the `GraphMatchEvalCache` and shared with the exact WHERE post-filter (`apply_where_condition_to_results_with_cache`) — traversals never run twice. Empty anchor intersection short-circuits to zero results (provably correct).

**Residual shapes keep the windowed execution, each documented**: OR/NOT-wrapped predicates, `similarity()` cascades, BM25 text-`MATCH` fusion, hybrid dense+sparse fusion, and the union early path (its legs rank independently and would each need anchor-aware fetching).

## Headline proof test

`test_near_match_finds_anchor_beyond_overfetch_window`: 30 points, the only graph-matching nodes rank ~28th by similarity, LIMIT 1 (window = 10). The old execution returns 0 rows; the anchored fetch returns the best graph match. Plus: exact unranked fetch, OR-union semantics preserved, sparse anchor beyond global ranking, NOT-similarity anchored scan.

## Docs

VELESQL_SPEC + VELESQL_CONTRACT execution notes rewritten (anchored fetch vs residual window, per shape); planner `ExecutionStrategy` rustdoc unstaled; CHANGELOG.

## Validation

- Full core suite: **5828 passed / 0 failed**; post-rebase on #1078: clippy pedantic clean, all 52 graph BDD + 19 relationship-semantics tests green
- All new functions CC ≤ 8, NLOC ≤ 50 (lizard-verified)
- Search path (HNSW internals/SIMD/quantization) untouched — `search_with_quality_and_bitmap` was pre-existing

## Follow-ups (documented in code)

Union-path and hybrid dense+sparse anchor-aware legs; ORDER BY similarity() cascade anchoring.