### PR TITLE
feat(agent,graph): agent-memory graph dimension — relate() API, first-class edge durability on every collection type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `similarity()` cascades, text/hybrid fusion) keep the bounded window,
   now documented per shape. Anchor sets are evaluated once and shared with
   the exact WHERE post-filter.
+- **Agent memory graph dimension — relate() API**: each memory subsystem
+  (semantic/episodic/procedural) gains `relate(from, to, rel_type, props)`,
+  `relations(id)` and `unrelate(edge_id)`. Relation edges are typed,
+  WAL-durable, reject expired/missing endpoints, and cascade away when a
+  memory is deleted — `MATCH (m)-[:RELATES_TO]->(f)` is now executable over
+  agent memory, completing the flagship NEAR + MATCH + scalar query
+  end-to-end. Under the hood, the graph dimension is now first-class on
+  every collection type: edge WAL durability, the flush-time snapshot +
+  WAL compaction, and delete-cascade are unconditional (previously gated to
+  graph collections — vector-collection edges silently vanished on restart
+  and the WAL never compacted); edge property indexes are rebuilt from the
+  snapshot on open (previously lost after compaction, graph collections
+  included); edge WAL appends are ordered with their store apply so replay
+  resolves id collisions exactly like live execution; and memory snapshots
+  (`serialize`/`snapshot`) now capture relation edges and restore them
+  (previously a restore silently wiped every relation). Older bare-array
+  snapshots still load.
 - **Durable post-hoc TTL setters for agent memory**: Result-returning
   `set_semantic_ttl_durable` / `set_episodic_ttl_durable` /
   `set_procedural_ttl_durable` on `AgentMemory` (and `set_ttl_durable` on each

--- a/crates/velesdb-core/src/agent/episodic_memory.rs
+++ b/crates/velesdb-core/src/agent/episodic_memory.rs
@@ -23,6 +23,8 @@ pub struct EpisodicMemory {
     dimension: usize,
     ttl: Arc<MemoryTtl>,
     temporal_index: Arc<TemporalIndex>,
+    /// Edge-id allocator for [`Self::relate`] (seeded past existing edges).
+    next_edge_id: std::sync::atomic::AtomicU64,
 }
 
 impl EpisodicMemory {
@@ -69,12 +71,18 @@ impl EpisodicMemory {
             MemoryKind::Episodic,
         )?;
 
+        let next_edge_id = memory_helpers::seed_edge_counter(&memory_helpers::get_collection(
+            &db,
+            &collection_name,
+        )?);
+
         Ok(Self {
             collection_name,
             db,
             dimension: actual_dimension,
             ttl,
             temporal_index,
+            next_edge_id,
         })
     }
     fn rebuild_temporal_index(
@@ -203,6 +211,73 @@ impl EpisodicMemory {
             event_id,
             ttl_seconds,
         )
+    }
+
+    /// Relates two live events with a typed, durable graph edge (e.g.
+    /// `CAUSED`, `FOLLOWED`); see `SemanticMemory::relate` for semantics.
+    ///
+    /// # Errors
+    ///
+    /// Returns `NotFound` when either endpoint is missing or expired, or
+    /// `CollectionError` when the edge write fails.
+    pub fn relate(
+        &self,
+        from_id: u64,
+        to_id: u64,
+        rel_type: &str,
+        properties: Option<&serde_json::Map<String, serde_json::Value>>,
+    ) -> Result<u64, AgentMemoryError> {
+        let collection = memory_helpers::get_collection(&self.db, &self.collection_name)?;
+        for id in [from_id, to_id] {
+            memory_helpers::ensure_live(
+                &collection,
+                &self.collection_name,
+                &self.ttl,
+                MemoryKind::Episodic,
+                id,
+            )?;
+        }
+        let edge_id = memory_helpers::add_relation_edge(
+            &collection,
+            &self.next_edge_id,
+            (from_id, to_id),
+            rel_type,
+            properties,
+        )?;
+        // Close the check-then-add window: an endpoint deleted concurrently
+        // (its cascade may have run before our edge landed) must not leave a
+        // dangling, WAL-durable edge behind.
+        memory_helpers::verify_relation_endpoints(&collection, edge_id, (from_id, to_id))?;
+        Ok(edge_id)
+    }
+
+    /// Returns the outgoing relations of an event.
+    ///
+    /// # Errors
+    ///
+    /// Returns `CollectionError` when the collection cannot be resolved.
+    pub fn relations(
+        &self,
+        id: u64,
+    ) -> Result<Vec<crate::collection::graph::GraphEdge>, AgentMemoryError> {
+        let collection = memory_helpers::get_collection(&self.db, &self.collection_name)?;
+        // Expired entries are invisible on every read surface — edges whose
+        // target has expired (but is not yet swept) are hidden too.
+        Ok(collection
+            .get_outgoing_edges(id)
+            .into_iter()
+            .filter(|edge| !self.ttl.is_expired(MemoryKind::Episodic, edge.target()))
+            .collect())
+    }
+
+    /// Removes a relation edge created by [`Self::relate`].
+    ///
+    /// # Errors
+    ///
+    /// Returns `CollectionError` when the collection cannot be resolved.
+    pub fn unrelate(&self, edge_id: u64) -> Result<bool, AgentMemoryError> {
+        let collection = memory_helpers::get_collection(&self.db, &self.collection_name)?;
+        Ok(collection.remove_edge(edge_id))
     }
 
     /// Returns recent events, optionally filtered by a lower timestamp bound.

--- a/crates/velesdb-core/src/agent/memory_helpers.rs
+++ b/crates/velesdb-core/src/agent/memory_helpers.rs
@@ -53,7 +53,7 @@ pub(super) fn open_or_create_collection(
     collection_name: &str,
     dimension: usize,
 ) -> Result<usize, AgentMemoryError> {
-    if let Some(collection) = db.get_vector_collection(collection_name) {
+    let actual_dimension = if let Some(collection) = db.get_vector_collection(collection_name) {
         let existing_dim = collection.config().dimension;
         if existing_dim != dimension {
             return Err(AgentMemoryError::DimensionMismatch {
@@ -61,11 +61,12 @@ pub(super) fn open_or_create_collection(
                 actual: dimension,
             });
         }
-        Ok(existing_dim)
+        existing_dim
     } else {
         db.create_collection(collection_name, dimension, DistanceMetric::Cosine)?;
-        Ok(dimension)
-    }
+        dimension
+    };
+    Ok(actual_dimension)
 }
 
 /// Loads all IDs from an existing collection into a `HashSet`.
@@ -95,16 +96,39 @@ pub(super) fn rebuild_stored_ids(stored_ids: &RwLock<HashSet<u64>>, points: &[Po
     }
 }
 
-/// Serializes points from a collection using the given ID set.
+/// Snapshot payload: memory points plus the relation edges between them.
+///
+/// Older snapshots were a bare `Vec<Point>` JSON array; `deserialize` keeps
+/// reading those (no edges). New snapshots serialize this envelope so
+/// relations survive a serialize → restore round-trip.
+#[derive(serde::Serialize, serde::Deserialize)]
+struct MemorySnapshot {
+    points: Vec<Point>,
+    #[serde(default)]
+    edges: Vec<crate::collection::graph::GraphEdge>,
+}
+
+/// Serializes points (and the relation edges connecting them) from a
+/// collection using the given ID set.
 pub(super) fn serialize_points(
     collection: &Collection,
     ids: &[u64],
 ) -> Result<Vec<u8>, AgentMemoryError> {
     let points: Vec<_> = collection.get(ids).into_iter().flatten().collect();
-    serde_json::to_vec(&points).map_err(|e| AgentMemoryError::IoError(e.to_string()))
+    let id_set: HashSet<u64> = points.iter().map(|p| p.id).collect();
+    // Only edges whose BOTH endpoints are part of the snapshot are
+    // meaningful after a restore.
+    let edges: Vec<_> = collection
+        .get_all_edges()
+        .into_iter()
+        .filter(|e| id_set.contains(&e.source()) && id_set.contains(&e.target()))
+        .collect();
+    serde_json::to_vec(&MemorySnapshot { points, edges })
+        .map_err(|e| AgentMemoryError::IoError(e.to_string()))
 }
 
-/// Deserializes points from bytes and replaces the collection contents.
+/// Deserializes a snapshot and replaces the collection contents — points AND
+/// relation edges (the clear's delete-cascade removes the previous edges).
 ///
 /// Returns the deserialized points so callers can rebuild their own indexes.
 pub(super) fn deserialize_into_collection(
@@ -115,13 +139,25 @@ pub(super) fn deserialize_into_collection(
         return Ok(None);
     }
 
-    let points: Vec<Point> =
-        serde_json::from_slice(data).map_err(|e| AgentMemoryError::IoError(e.to_string()))?;
+    let snapshot: MemorySnapshot = serde_json::from_slice(data)
+        .or_else(|_| {
+            // Backward compatibility: pre-graph snapshots are a bare array.
+            serde_json::from_slice::<Vec<Point>>(data).map(|points| MemorySnapshot {
+                points,
+                edges: Vec::new(),
+            })
+        })
+        .map_err(|e| AgentMemoryError::IoError(e.to_string()))?;
 
     clear_collection(collection)?;
-    upsert_points(collection, points.clone())?;
+    upsert_points(collection, snapshot.points.clone())?;
+    if !snapshot.edges.is_empty() {
+        collection
+            .add_edges_batch(snapshot.edges)
+            .map_err(|e| AgentMemoryError::CollectionError(e.to_string()))?;
+    }
 
-    Ok(Some(points))
+    Ok(Some(snapshot.points))
 }
 
 /// Deletes points by ID from a collection.
@@ -311,6 +347,88 @@ pub(super) fn attach_expiry(payload: &mut serde_json::Value, expires_at: Option<
     }
 }
 
+/// Verifies that a memory id refers to a live (non-expired, existing) point
+/// and returns it.
+///
+/// Expired-but-not-yet-swept entries are invisible on every read surface;
+/// write surfaces (TTL refresh, relate) must reject them the same way.
+pub(super) fn ensure_live(
+    collection: &Collection,
+    collection_name: &str,
+    ttl: &super::ttl::MemoryTtl,
+    kind: super::ttl::MemoryKind,
+    id: u64,
+) -> Result<Point, AgentMemoryError> {
+    if ttl.is_expired(kind, id) {
+        return Err(AgentMemoryError::NotFound(format!(
+            "memory id {id} is expired in {collection_name}"
+        )));
+    }
+    get_point_or_not_found(collection, collection_name, id)
+}
+
+/// Seeds a relation edge-id counter past every existing edge id.
+///
+/// One pass over the edge-id registry (no edge cloning).
+pub(super) fn seed_edge_counter(collection: &Collection) -> std::sync::atomic::AtomicU64 {
+    let next = collection
+        .max_edge_id()
+        .map_or(1, |max| max.saturating_add(1));
+    std::sync::atomic::AtomicU64::new(next)
+}
+
+/// Adds a relation edge between two memory points, allocating a fresh edge
+/// id from `next_edge_id` (skipping ids taken by direct graph writes; the
+/// `EdgeExists` retry covers the residual allocation race).
+pub(super) fn add_relation_edge(
+    collection: &Collection,
+    next_edge_id: &std::sync::atomic::AtomicU64,
+    endpoints: (u64, u64),
+    rel_type: &str,
+    properties: Option<&serde_json::Map<String, serde_json::Value>>,
+) -> Result<u64, AgentMemoryError> {
+    let (from_id, to_id) = endpoints;
+    loop {
+        let edge_id = next_edge_id.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        if collection.edge_exists(edge_id) {
+            continue; // taken by a direct graph write — no junk WAL entry
+        }
+        let mut edge = crate::collection::graph::GraphEdge::new(edge_id, from_id, to_id, rel_type)
+            .map_err(|e| AgentMemoryError::CollectionError(e.to_string()))?;
+        if let Some(props) = properties {
+            let map: std::collections::HashMap<String, serde_json::Value> =
+                props.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
+            edge = edge.with_properties(map);
+        }
+        match collection.add_edge(edge) {
+            Ok(()) => return Ok(edge_id),
+            // Lost the residual allocation race — try the next id.
+            Err(crate::error::Error::EdgeExists(_)) => {}
+            Err(e) => return Err(AgentMemoryError::CollectionError(e.to_string())),
+        }
+    }
+}
+
+/// Compensates the `relate()` check-then-add window: when an endpoint was
+/// deleted between `ensure_live` and the edge write, the cascade may have
+/// already run — remove the freshly written edge instead of leaving it
+/// dangling forever.
+pub(super) fn verify_relation_endpoints(
+    collection: &Collection,
+    edge_id: u64,
+    endpoints: (u64, u64),
+) -> Result<(), AgentMemoryError> {
+    let (from_id, to_id) = endpoints;
+    let alive = collection.get(&[from_id, to_id]);
+    if alive.iter().flatten().count() == 2 {
+        return Ok(());
+    }
+    let _ = collection.remove_edge(edge_id);
+    Err(AgentMemoryError::NotFound(format!(
+        "a relation endpoint ({from_id} or {to_id}) was deleted concurrently"
+    )))
+}
+
 /// Retrieves a point by id, surfacing `NotFound` when it does not exist.
 ///
 /// The `collection.get(&[id]) … next()` idiom shared by the agent
@@ -365,12 +483,7 @@ pub(super) fn set_ttl_durable(
     let collection = get_collection(db, collection_name)?;
     // Expired-but-not-yet-swept entries are invisible on every read surface;
     // refreshing their TTL would silently resurrect them.
-    if ttl.is_expired(kind, id) {
-        return Err(AgentMemoryError::NotFound(format!(
-            "memory id {id} is expired in {collection_name}"
-        )));
-    }
-    let point = get_point_or_not_found(&collection, collection_name, id)?;
+    let point = ensure_live(&collection, collection_name, ttl, kind, id)?;
     let expires_at = super::ttl::MemoryTtl::now().saturating_add(ttl_seconds);
     let mut payload = point
         .payload

--- a/crates/velesdb-core/src/agent/procedural_memory.rs
+++ b/crates/velesdb-core/src/agent/procedural_memory.rs
@@ -97,6 +97,8 @@ pub struct ProceduralMemory {
     /// ACT-R decay exponent `d` for passive confidence decay at recall time.
     /// `None` disables decay (default — backward-compatible behaviour).
     activation_decay_exponent: Option<f32>,
+    /// Edge-id allocator for [`Self::relate`] (seeded past existing edges).
+    next_edge_id: std::sync::atomic::AtomicU64,
 }
 
 impl ProceduralMemory {
@@ -137,6 +139,11 @@ impl ProceduralMemory {
             MemoryKind::Procedural,
         )?;
 
+        let next_edge_id = memory_helpers::seed_edge_counter(&memory_helpers::get_collection(
+            &db,
+            &collection_name,
+        )?);
+
         Ok(Self {
             collection_name,
             db,
@@ -145,6 +152,7 @@ impl ProceduralMemory {
             reinforcement_strategy: Arc::new(FixedRate::default()),
             stored_ids,
             activation_decay_exponent: None,
+            next_edge_id,
         })
     }
 
@@ -290,6 +298,73 @@ impl ProceduralMemory {
             procedure_id,
             ttl_seconds,
         )
+    }
+
+    /// Relates two live procedures with a typed, durable graph edge (e.g.
+    /// `DEPENDS_ON`, `REFINES`); see `SemanticMemory::relate` for semantics.
+    ///
+    /// # Errors
+    ///
+    /// Returns `NotFound` when either endpoint is missing or expired, or
+    /// `CollectionError` when the edge write fails.
+    pub fn relate(
+        &self,
+        from_id: u64,
+        to_id: u64,
+        rel_type: &str,
+        properties: Option<&serde_json::Map<String, serde_json::Value>>,
+    ) -> Result<u64, AgentMemoryError> {
+        let collection = memory_helpers::get_collection(&self.db, &self.collection_name)?;
+        for id in [from_id, to_id] {
+            memory_helpers::ensure_live(
+                &collection,
+                &self.collection_name,
+                &self.ttl,
+                MemoryKind::Procedural,
+                id,
+            )?;
+        }
+        let edge_id = memory_helpers::add_relation_edge(
+            &collection,
+            &self.next_edge_id,
+            (from_id, to_id),
+            rel_type,
+            properties,
+        )?;
+        // Close the check-then-add window: an endpoint deleted concurrently
+        // (its cascade may have run before our edge landed) must not leave a
+        // dangling, WAL-durable edge behind.
+        memory_helpers::verify_relation_endpoints(&collection, edge_id, (from_id, to_id))?;
+        Ok(edge_id)
+    }
+
+    /// Returns the outgoing relations of a procedure.
+    ///
+    /// # Errors
+    ///
+    /// Returns `CollectionError` when the collection cannot be resolved.
+    pub fn relations(
+        &self,
+        id: u64,
+    ) -> Result<Vec<crate::collection::graph::GraphEdge>, AgentMemoryError> {
+        let collection = memory_helpers::get_collection(&self.db, &self.collection_name)?;
+        // Expired entries are invisible on every read surface — edges whose
+        // target has expired (but is not yet swept) are hidden too.
+        Ok(collection
+            .get_outgoing_edges(id)
+            .into_iter()
+            .filter(|edge| !self.ttl.is_expired(MemoryKind::Procedural, edge.target()))
+            .collect())
+    }
+
+    /// Removes a relation edge created by [`Self::relate`].
+    ///
+    /// # Errors
+    ///
+    /// Returns `CollectionError` when the collection cannot be resolved.
+    pub fn unrelate(&self, edge_id: u64) -> Result<bool, AgentMemoryError> {
+        let collection = memory_helpers::get_collection(&self.db, &self.collection_name)?;
+        Ok(collection.remove_edge(edge_id))
     }
 
     /// Recalls matching procedures by vector similarity.

--- a/crates/velesdb-core/src/agent/semantic_memory.rs
+++ b/crates/velesdb-core/src/agent/semantic_memory.rs
@@ -23,6 +23,8 @@ pub struct SemanticMemory {
     dimension: usize,
     ttl: Arc<MemoryTtl>,
     stored_ids: RwLock<HashSet<u64>>,
+    /// Edge-id allocator for [`Self::relate`] (seeded past existing edges).
+    next_edge_id: std::sync::atomic::AtomicU64,
 }
 
 impl SemanticMemory {
@@ -65,12 +67,18 @@ impl SemanticMemory {
             MemoryKind::Semantic,
         )?;
 
+        let next_edge_id = memory_helpers::seed_edge_counter(&memory_helpers::get_collection(
+            &db,
+            &collection_name,
+        )?);
+
         Ok(Self {
             collection_name,
             db,
             dimension,
             ttl,
             stored_ids,
+            next_edge_id,
         })
     }
 
@@ -134,13 +142,17 @@ impl SemanticMemory {
         id: u64,
         updates: &Map<String, Value>,
     ) -> Result<(), AgentMemoryError> {
-        if self.ttl.is_expired(MemoryKind::Semantic, id) || !self.stored_ids.read().contains(&id) {
+        if !self.stored_ids.read().contains(&id) {
             return Err(AgentMemoryError::NotFound(id.to_string()));
         }
         let collection = memory_helpers::get_collection(&self.db, &self.collection_name)?;
-        let Some(point) = collection.get(&[id]).into_iter().flatten().next() else {
-            return Err(AgentMemoryError::NotFound(id.to_string()));
-        };
+        let point = memory_helpers::ensure_live(
+            &collection,
+            &self.collection_name,
+            &self.ttl,
+            MemoryKind::Semantic,
+            id,
+        )?;
         let payload = merge_payload(point.payload, updates)?;
         memory_helpers::upsert_points(
             &collection,
@@ -254,6 +266,78 @@ impl SemanticMemory {
             id,
             ttl_seconds,
         )
+    }
+
+    /// Relates two live facts with a typed, durable graph edge
+    /// (`MATCH (a)-[:REL_TYPE]->(b)` becomes executable over this memory).
+    ///
+    /// Returns the allocated edge id. Edges are WAL-persisted and cascade
+    /// away when either endpoint memory is deleted.
+    ///
+    /// # Errors
+    ///
+    /// Returns `NotFound` when either endpoint is missing or expired, or
+    /// `CollectionError` when the edge write fails.
+    pub fn relate(
+        &self,
+        from_id: u64,
+        to_id: u64,
+        rel_type: &str,
+        properties: Option<&serde_json::Map<String, serde_json::Value>>,
+    ) -> Result<u64, AgentMemoryError> {
+        let collection = memory_helpers::get_collection(&self.db, &self.collection_name)?;
+        for id in [from_id, to_id] {
+            memory_helpers::ensure_live(
+                &collection,
+                &self.collection_name,
+                &self.ttl,
+                MemoryKind::Semantic,
+                id,
+            )?;
+        }
+        let edge_id = memory_helpers::add_relation_edge(
+            &collection,
+            &self.next_edge_id,
+            (from_id, to_id),
+            rel_type,
+            properties,
+        )?;
+        // Close the check-then-add window: an endpoint deleted concurrently
+        // (its cascade may have run before our edge landed) must not leave a
+        // dangling, WAL-durable edge behind.
+        memory_helpers::verify_relation_endpoints(&collection, edge_id, (from_id, to_id))?;
+        Ok(edge_id)
+    }
+
+    /// Returns the outgoing relations of a fact (edges it points from).
+    ///
+    /// # Errors
+    ///
+    /// Returns `CollectionError` when the collection cannot be resolved.
+    pub fn relations(
+        &self,
+        id: u64,
+    ) -> Result<Vec<crate::collection::graph::GraphEdge>, AgentMemoryError> {
+        let collection = memory_helpers::get_collection(&self.db, &self.collection_name)?;
+        // Expired entries are invisible on every read surface — edges whose
+        // target has expired (but is not yet swept) are hidden too.
+        Ok(collection
+            .get_outgoing_edges(id)
+            .into_iter()
+            .filter(|edge| !self.ttl.is_expired(MemoryKind::Semantic, edge.target()))
+            .collect())
+    }
+
+    /// Removes a relation edge created by [`Self::relate`].
+    ///
+    /// Returns `true` when the edge existed and was removed.
+    ///
+    /// # Errors
+    ///
+    /// Returns `CollectionError` when the collection cannot be resolved.
+    pub fn unrelate(&self, edge_id: u64) -> Result<bool, AgentMemoryError> {
+        let collection = memory_helpers::get_collection(&self.db, &self.collection_name)?;
+        Ok(collection.remove_edge(edge_id))
     }
 
     /// Queries semantic memory by vector similarity.

--- a/crates/velesdb-core/src/agent/semantic_memory_tests.rs
+++ b/crates/velesdb-core/src/agent/semantic_memory_tests.rs
@@ -758,6 +758,251 @@ mod tests {
         );
     }
 
+    // ── Graph dimension: relate / relations / unrelate ─────────────────────
+
+    /// relate() creates a typed edge between two live facts; relations()
+    /// exposes it; unrelate() removes it.
+    #[test]
+    fn test_relate_relations_unrelate_roundtrip() {
+        let dir = tempdir().unwrap();
+        let db = Arc::new(Database::open(dir.path()).unwrap());
+        let sm = make_semantic(Arc::clone(&db));
+        let emb = vec![1.0_f32, 0.0, 0.0, 0.0];
+        sm.store(1, "context", &emb).unwrap();
+        sm.store(2, "fact", &emb).unwrap();
+
+        let props = meta_one("weight", serde_json::json!(0.9));
+        let edge_id = sm.relate(1, 2, "RELATES_TO", Some(&props)).unwrap();
+
+        let rels = sm.relations(1).unwrap();
+        assert_eq!(rels.len(), 1);
+        assert_eq!(rels[0].id(), edge_id);
+        assert_eq!(rels[0].target(), 2);
+        assert_eq!(rels[0].label(), "RELATES_TO");
+        assert_eq!(rels[0].property("weight"), Some(&serde_json::json!(0.9)));
+
+        assert!(sm.unrelate(edge_id).unwrap(), "edge must be removed");
+        assert!(sm.relations(1).unwrap().is_empty());
+    }
+
+    /// relate() refuses missing and expired endpoints (write surfaces must
+    /// not resurrect or dangle).
+    #[test]
+    fn test_relate_rejects_missing_and_expired_endpoints() {
+        let dir = tempdir().unwrap();
+        let db = Arc::new(Database::open(dir.path()).unwrap());
+        let sm = make_semantic(Arc::clone(&db));
+        let emb = vec![1.0_f32, 0.0, 0.0, 0.0];
+        sm.store(1, "context", &emb).unwrap();
+
+        let err = sm.relate(1, 999, "RELATES_TO", None).unwrap_err();
+        assert!(matches!(err, AgentMemoryError::NotFound(_)));
+
+        sm.store(2, "ephemeral", &emb).unwrap();
+        sm.set_ttl_durable(2, 0).unwrap(); // expires immediately
+        let err = sm.relate(1, 2, "RELATES_TO", None).unwrap_err();
+        assert!(matches!(err, AgentMemoryError::NotFound(_)));
+    }
+
+    /// Deleting a memory cascades to its relation edges (no dangling edges).
+    #[test]
+    fn test_delete_memory_cascades_relations() {
+        let dir = tempdir().unwrap();
+        let db = Arc::new(Database::open(dir.path()).unwrap());
+        let sm = make_semantic(Arc::clone(&db));
+        let emb = vec![1.0_f32, 0.0, 0.0, 0.0];
+        sm.store(1, "context", &emb).unwrap();
+        sm.store(2, "fact", &emb).unwrap();
+        sm.relate(1, 2, "RELATES_TO", None).unwrap();
+
+        sm.delete(2).unwrap();
+        assert!(
+            sm.relations(1).unwrap().is_empty(),
+            "deleting the target memory must cascade away the edge"
+        );
+    }
+
+    /// Relations survive a restart (edge WAL) and the edge-id allocator
+    /// reseeds past persisted edges.
+    #[test]
+    fn test_relations_survive_restart_without_id_collision() {
+        let dir = tempdir().unwrap();
+        let emb = vec![1.0_f32, 0.0, 0.0, 0.0];
+        let first_edge;
+        {
+            let db = Arc::new(Database::open(dir.path()).unwrap());
+            let sm = make_semantic(Arc::clone(&db));
+            sm.store(1, "context", &emb).unwrap();
+            sm.store(2, "fact", &emb).unwrap();
+            first_edge = sm.relate(1, 2, "RELATES_TO", None).unwrap();
+        }
+
+        let (_ttl, sm) = reopen_semantic(dir.path());
+        let rels = sm.relations(1).unwrap();
+        assert_eq!(rels.len(), 1, "edge must survive the restart (edge WAL)");
+        assert_eq!(rels[0].id(), first_edge);
+
+        sm.store(3, "another fact", &emb).unwrap();
+        let second_edge = sm.relate(1, 3, "SUPPORTS", None).unwrap();
+        assert_ne!(
+            second_edge, first_edge,
+            "reseeded allocator must not collide with persisted edges"
+        );
+        assert_eq!(sm.relations(1).unwrap().len(), 2);
+    }
+
+    /// Snapshot round-trip preserves relations: serialize captures the edges
+    /// between snapshotted memories and restore re-adds them (review
+    /// 2026-06-11: restore previously wiped every relation via the cascade).
+    #[test]
+    fn test_snapshot_roundtrip_preserves_relations() {
+        let dir = tempdir().unwrap();
+        let db = Arc::new(Database::open(dir.path()).unwrap());
+        let sm = make_semantic(Arc::clone(&db));
+        let emb = vec![1.0_f32, 0.0, 0.0, 0.0];
+        sm.store(1, "ctx", &emb).unwrap();
+        sm.store(2, "fact", &emb).unwrap();
+        let edge_id = sm.relate(1, 2, "RELATES_TO", None).unwrap();
+
+        let snapshot = sm.serialize().unwrap();
+        // Mutate after the snapshot: unrelate + add a new relation.
+        sm.unrelate(edge_id).unwrap();
+        sm.store(3, "other", &emb).unwrap();
+        sm.relate(1, 3, "SUPPORTS", None).unwrap();
+
+        sm.deserialize(&snapshot).unwrap();
+
+        let rels = sm.relations(1).unwrap();
+        assert_eq!(rels.len(), 1, "restore must bring back the snapshot edge");
+        assert_eq!(rels[0].target(), 2);
+        assert_eq!(rels[0].label(), "RELATES_TO");
+    }
+
+    /// Pre-graph snapshots (bare point arrays) still load — without edges.
+    #[test]
+    fn test_legacy_bare_array_snapshot_still_loads() {
+        let dir = tempdir().unwrap();
+        let db = Arc::new(Database::open(dir.path()).unwrap());
+        let sm = make_semantic(Arc::clone(&db));
+        let emb = vec![1.0_f32, 0.0, 0.0, 0.0];
+        sm.store(1, "ctx", &emb).unwrap();
+
+        // Simulate an old snapshot: a bare JSON array of points.
+        let points: Vec<crate::Point> = vec![crate::Point::new(
+            7,
+            emb.clone(),
+            Some(serde_json::json!({"content": "legacy"})),
+        )];
+        let legacy = serde_json::to_vec(&points).unwrap();
+
+        sm.deserialize(&legacy).unwrap();
+        assert!(sm.get(7).unwrap().is_some(), "legacy snapshot points load");
+        assert!(sm.relations(7).unwrap().is_empty());
+    }
+
+    /// flush() compacts the edge WAL into the snapshot for memory (vector)
+    /// collections too, and edges survive the reopen via the snapshot
+    /// (review 2026-06-11: the WAL previously grew forever and a torn tail
+    /// permanently broke edge durability).
+    #[test]
+    fn test_flush_compacts_edge_wal_and_edges_survive_reopen() {
+        let dir = tempdir().unwrap();
+        let emb = vec![1.0_f32, 0.0, 0.0, 0.0];
+        {
+            let db = Arc::new(Database::open(dir.path()).unwrap());
+            let sm = make_semantic(Arc::clone(&db));
+            sm.store(1, "ctx", &emb).unwrap();
+            sm.store(2, "fact", &emb).unwrap();
+            sm.relate(1, 2, "RELATES_TO", None).unwrap();
+            db.flush_all();
+        }
+
+        let collection_dir = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(Result::ok)
+            .find(|e| e.file_name().to_string_lossy().starts_with("_semantic"))
+            .expect("semantic collection dir")
+            .path();
+        assert!(
+            collection_dir.join("edge_store.bin").exists(),
+            "flush must snapshot the edge store for memory collections"
+        );
+        let wal_len = std::fs::metadata(collection_dir.join("edges.wal")).map_or(0, |m| m.len());
+        assert_eq!(wal_len, 0, "flush must truncate the compacted edge WAL");
+
+        let (_ttl, sm) = reopen_semantic(dir.path());
+        assert_eq!(
+            sm.relations(1).unwrap().len(),
+            1,
+            "edges must survive reopen via the snapshot"
+        );
+    }
+
+    /// relations() hides edges whose endpoint has expired (read invisibility
+    /// extends to the graph surface).
+    #[test]
+    fn test_relations_hide_expired_endpoints() {
+        let dir = tempdir().unwrap();
+        let db = Arc::new(Database::open(dir.path()).unwrap());
+        let sm = make_semantic(Arc::clone(&db));
+        let emb = vec![1.0_f32, 0.0, 0.0, 0.0];
+        sm.store(1, "ctx", &emb).unwrap();
+        sm.store(2, "ephemeral fact", &emb).unwrap();
+        sm.relate(1, 2, "RELATES_TO", None).unwrap();
+
+        sm.set_ttl_durable(2, 0).unwrap(); // expires immediately
+        assert!(
+            sm.relations(1).unwrap().is_empty(),
+            "edges to expired endpoints must be invisible"
+        );
+    }
+
+    /// THE mission query: vector NEAR + graph MATCH + scalar metadata over
+    /// agent memory, end-to-end through the VelesQL bridge.
+    #[test]
+    fn test_mission_query_near_match_scalar_over_memory() {
+        let dir = tempdir().unwrap();
+        let db = Arc::new(Database::open(dir.path()).unwrap());
+        let memory = crate::agent::AgentMemory::with_dimension(Arc::clone(&db), 4)
+            .expect("test: AgentMemory::with_dimension");
+        let sm = memory.semantic();
+
+        let close = vec![1.0_f32, 0.0, 0.0, 0.0];
+        let far = vec![0.0_f32, 1.0, 0.0, 0.0];
+        let tech = meta_one("category", serde_json::json!("tech"));
+        let bio = meta_one("category", serde_json::json!("bio"));
+
+        // ctx(1) relates to fact(2); ctx(3) has no relations; ctx(4) wrong category.
+        sm.store_with_metadata(1, "ctx about rust", &close, &tech)
+            .unwrap();
+        sm.store_with_metadata(2, "fact: rust is fast", &close, &tech)
+            .unwrap();
+        sm.store_with_metadata(3, "ctx unrelated", &close, &tech)
+            .unwrap();
+        sm.store_with_metadata(4, "ctx other domain", &far, &bio)
+            .unwrap();
+        sm.relate(1, 2, "RELATES_TO", None).unwrap();
+        sm.relate(4, 2, "RELATES_TO", None).unwrap();
+
+        let mut params = std::collections::HashMap::new();
+        params.insert("q".to_string(), serde_json::json!([1.0, 0.0, 0.0, 0.0]));
+        let results = memory
+            .query_semantic(
+                "SELECT * FROM memory AS m \
+                 WHERE vector NEAR $q AND category = 'tech' \
+                 AND MATCH (m)-[:RELATES_TO]->(f) LIMIT 5",
+                &params,
+            )
+            .unwrap();
+
+        let ids: Vec<u64> = results.iter().map(|r| r.point.id).collect();
+        assert_eq!(
+            ids,
+            vec![1],
+            "only ctx 1 is tech AND relates to a fact; got {ids:?}"
+        );
+    }
+
     /// A user business field named `expires_at` (subscription, offer, token…)
     /// stored via `store_with_metadata` must stay plain metadata: visible in
     /// session AND after a reopen, never rebuilt into the durable TTL map.

--- a/crates/velesdb-core/src/collection/core/crud_read_delete.rs
+++ b/crates/velesdb-core/src/collection/core/crud_read_delete.rs
@@ -71,8 +71,9 @@ impl Collection {
 
         // Issue #900: deleting a node must cascade to its edges. Otherwise the
         // edge store retains dangling edges pointing at (or from) a node that
-        // no longer exists, silently corrupting the graph. Gated to graph
-        // collections; no-op for vector / metadata-only collections.
+        // no longer exists, silently corrupting the graph. First-class on
+        // every collection type (agent-memory relations live on vector
+        // collections); collections without edges return immediately.
         self.cascade_delete_node_edges(ids)?;
 
         self.bump_generation_with_mirror_deletes(ids);
@@ -81,9 +82,9 @@ impl Collection {
 
     /// Removes every edge connected to each deleted node id (issue #900).
     ///
-    /// Only graph collections own a populated edge store; for vector and
-    /// metadata-only collections this is a cheap config check followed by an
-    /// early return.
+    /// First-class on every collection type: any collection whose edge store
+    /// holds edges cascades; empty stores (the common case) return after one
+    /// cheap emptiness check.
     ///
     /// # Lock ordering
     ///
@@ -96,7 +97,10 @@ impl Collection {
     /// other collection lock held — so taking them respects the documented
     /// ascending lock order and cannot deadlock.
     fn cascade_delete_node_edges(&self, ids: &[u64]) -> Result<()> {
-        if self.config.read().graph_schema.is_none() {
+        // Cascade whenever edges exist — the graph dimension is first-class
+        // on every collection type (agent-memory relations live on vector
+        // collections). Empty stores (the common case) return immediately.
+        if self.edge_store.is_empty() {
             return Ok(());
         }
         let mut removed_any = false;
@@ -107,6 +111,8 @@ impl Collection {
             if before > 0 {
                 // WAL-before-apply (crash durability): log the cascade remove
                 // before mutating the store so a crash replays the tombstone.
+                // The WAL lock spans append + apply (see `add_edge`).
+                let _wal_guard = self.edge_wal_lock.lock();
                 #[cfg(feature = "persistence")]
                 crate::collection::graph::edge_wal::wal_append_remove_node(
                     &crate::collection::graph::edge_wal::wal_path_for_edges(&self.path),

--- a/crates/velesdb-core/src/collection/core/flush.rs
+++ b/crates/velesdb-core/src/collection/core/flush.rs
@@ -258,9 +258,14 @@ impl Collection {
         let range_index_path = self.path.join("range_index.bin");
         self.range_index.read().save_to_file(&range_index_path)?;
 
-        // Save EdgeStore for graph collections (BUG-1: was never persisted)
-        if self.config.read().graph_schema.is_some() {
-            let edge_store_path = self.path.join("edge_store.bin");
+        // Save the EdgeStore snapshot for ANY collection that uses the graph
+        // dimension (edges now WAL-persist on every collection type, so the
+        // snapshot + truncate compaction must follow them — otherwise the
+        // edge WAL grows without bound and a torn tail never heals). The
+        // `edge_store.bin exists` arm keeps persisting deletions down to an
+        // empty store.
+        let edge_store_path = self.path.join("edge_store.bin");
+        if !self.edge_store.is_empty() || edge_store_path.exists() {
             self.edge_store.save_to_file(&edge_store_path)?;
             // The snapshot now contains every edge, so the edge WAL delta is
             // redundant — truncate it AFTER the snapshot is durably written so

--- a/crates/velesdb-core/src/collection/core/graph_api.rs
+++ b/crates/velesdb-core/src/collection/core/graph_api.rs
@@ -51,14 +51,21 @@ impl Collection {
 
         // WAL-before-apply (crash durability): log the edge to the edge WAL
         // before mutating the in-memory store, so a crash between the two
-        // replays the edge on the next open. Gated to graph collections.
+        // replays the edge on the next open. Unconditional: the append only
+        // happens when an edge IS written, so collections that never use the
+        // graph dimension pay nothing — and edges on vector collections
+        // (e.g. agent-memory relations) are as durable as on graph ones.
+        //
+        // The WAL lock spans append + apply so the WAL order always equals
+        // the store-apply order (replay must resolve id collisions exactly
+        // like live execution) and concurrent appends can never interleave
+        // a multi-write entry.
+        let _wal_guard = self.edge_wal_lock.lock();
         #[cfg(feature = "persistence")]
-        if self.config.read().graph_schema.is_some() {
-            crate::collection::graph::edge_wal::wal_append_add(
-                &crate::collection::graph::edge_wal::wal_path_for_edges(&self.path),
-                &edge,
-            )?;
-        }
+        crate::collection::graph::edge_wal::wal_append_add(
+            &crate::collection::graph::edge_wal::wal_path_for_edges(&self.path),
+            &edge,
+        )?;
 
         self.edge_store.add_edge(edge)?;
 
@@ -99,13 +106,15 @@ impl Collection {
             self.validate_edge_referential_integrity(edge)?;
         }
 
+        // Unconditional WAL (see add_edge): writing edges implies wanting
+        // them back after a restart, whatever the collection type. The WAL
+        // lock spans append + apply (see add_edge).
+        let _wal_guard = self.edge_wal_lock.lock();
         #[cfg(feature = "persistence")]
-        if self.config.read().graph_schema.is_some() {
-            crate::collection::graph::edge_wal::wal_append_add_batch(
-                &crate::collection::graph::edge_wal::wal_path_for_edges(&self.path),
-                &edges,
-            )?;
-        }
+        crate::collection::graph::edge_wal::wal_append_add_batch(
+            &crate::collection::graph::edge_wal::wal_path_for_edges(&self.path),
+            &edges,
+        )?;
 
         // Capture property metadata before the edges are moved into the store.
         let index_meta: Vec<(u64, String, _)> = edges
@@ -370,20 +379,25 @@ impl Collection {
     /// `true` if the edge existed and was removed, `false` if it didn't exist.
     #[must_use]
     pub fn remove_edge(&self, edge_id: u64) -> bool {
+        // Cheap pre-check: a remove of a non-existent id must not create or
+        // grow the WAL with junk tombstones (a racing remove between this
+        // check and the append still replays as a harmless no-op).
+        if !self.edge_store.contains_edge(edge_id) {
+            return false;
+        }
         // WAL-before-apply (crash durability): log the remove intent before
-        // mutating the store. A remove of a non-existent id replays as a
-        // harmless no-op. Fail-closed: if the WAL append fails we do NOT
+        // mutating the store. Fail-closed: if the WAL append fails we do NOT
         // mutate the store and report `false` (no panic — matches the
-        // no-unwrap policy and the bool return contract).
+        // no-unwrap policy and the bool return contract). Unconditional for
+        // the same reason as add_edge; the WAL lock spans append + apply.
+        let _wal_guard = self.edge_wal_lock.lock();
         #[cfg(feature = "persistence")]
-        if self.config.read().graph_schema.is_some() {
-            if let Err(e) = crate::collection::graph::edge_wal::wal_append_remove(
-                &crate::collection::graph::edge_wal::wal_path_for_edges(&self.path),
-                edge_id,
-            ) {
-                tracing::error!("Edge WAL append remove failed for edge {edge_id}: {e}");
-                return false;
-            }
+        if let Err(e) = crate::collection::graph::edge_wal::wal_append_remove(
+            &crate::collection::graph::edge_wal::wal_path_for_edges(&self.path),
+            edge_id,
+        ) {
+            tracing::error!("Edge WAL append remove failed for edge {edge_id}: {e}");
+            return false;
         }
 
         // Atomic check-and-remove — no TOCTOU race.
@@ -399,6 +413,31 @@ impl Collection {
     #[must_use]
     pub fn edge_count(&self) -> usize {
         self.edge_store.len()
+    }
+
+    /// Returns the highest edge id in the graph, if any (no edge cloning).
+    pub(crate) fn max_edge_id(&self) -> Option<u64> {
+        self.edge_store.max_edge_id()
+    }
+
+    /// Returns `true` when an edge with `edge_id` exists.
+    pub(crate) fn edge_exists(&self, edge_id: u64) -> bool {
+        self.edge_store.contains_edge(edge_id)
+    }
+
+    /// Rebuilds edge property indexes from edges already in the store.
+    ///
+    /// Called on open AFTER the edge snapshot is loaded and BEFORE the edge
+    /// WAL replays (replay indexes its own ADDs), so snapshot-loaded edge
+    /// properties become queryable again — previously they were only ever
+    /// indexed at write time and silently lost once the WAL was truncated
+    /// into the snapshot.
+    pub(crate) fn reindex_edge_properties_from_store(&self) {
+        for edge in self.edge_store.all_edges() {
+            if !edge.properties().is_empty() {
+                self.index_edge_properties(edge.id(), edge.label(), edge.properties());
+            }
+        }
     }
 
     // -------------------------------------------------------------------------

--- a/crates/velesdb-core/src/collection/core/lifecycle.rs
+++ b/crates/velesdb-core/src/collection/core/lifecycle.rs
@@ -99,6 +99,7 @@ impl Collection {
             query_pattern_tracker: Arc::new(RwLock::new(QueryPatternTracker::new())),
             index_advisor: Arc::new(RwLock::new(IndexAdvisor::new())),
             edge_store: Arc::new(parts.edge_store),
+            edge_wal_lock: Arc::new(Mutex::new(())),
             sparse_indexes: Arc::new(RwLock::new(parts.sparse_indexes)),
             secondary_indexes: Arc::new(RwLock::new(HashMap::new())),
             payload_mirror: Arc::new(crate::collection::payload_mirror::PayloadMirror::default()),
@@ -309,6 +310,10 @@ impl Collection {
         // edge_store snapshot so edge mutations since the last flush survive
         // a crash. No-op when edges.wal is absent (legacy / non-graph DBs).
         #[cfg(feature = "persistence")]
+        // Snapshot-loaded edges must re-enter the property indexes BEFORE the
+        // WAL replays (replay indexes its own ADDs — running the full pass
+        // after it would double-index the replayed edges).
+        collection.reindex_edge_properties_from_store();
         collection.replay_edge_wal()?;
 
         Ok(collection)

--- a/crates/velesdb-core/src/collection/graph/edge_concurrent/query.rs
+++ b/crates/velesdb-core/src/collection/graph/edge_concurrent/query.rs
@@ -128,6 +128,14 @@ impl ConcurrentEdgeStore {
 
     /// Checks if an edge with the given ID exists.
     #[must_use]
+    /// Returns the highest edge id in the store, if any.
+    ///
+    /// O(edges) over the id registry — no edge cloning.
+    pub fn max_edge_id(&self) -> Option<u64> {
+        self.edge_ids.read().keys().max().copied()
+    }
+
+    /// Returns `true` when an edge with `edge_id` exists.
     pub fn contains_edge(&self, edge_id: u64) -> bool {
         self.edge_ids.read().contains_key(&edge_id)
     }

--- a/crates/velesdb-core/src/collection/types.rs
+++ b/crates/velesdb-core/src/collection/types.rs
@@ -237,6 +237,16 @@ pub(crate) struct Collection {
     /// Lock order position **8** is now managed internally by `ConcurrentEdgeStore`.
     pub(super) edge_store: Arc<ConcurrentEdgeStore>,
 
+    /// Serializes edge-WAL append + edge-store apply pairs so the WAL order
+    /// always equals the apply order (replay resolves id collisions exactly
+    /// like live execution) and concurrent appends cannot interleave one
+    /// entry's bytes.
+    ///
+    /// Lock order position: **7c** — acquired with no other collection lock
+    /// held; the edge store's internal `edge_ids → shards` chain is acquired
+    /// while holding it.
+    pub(super) edge_wal_lock: Arc<Mutex<()>>,
+
     /// Named sparse inverted indexes for sparse vector search (EPIC-062).
     /// Key is the sparse vector name (e.g., `""` for default, `"title"`, `"body"`).
     pub(super) sparse_indexes: Arc<RwLock<BTreeMap<String, SparseInvertedIndex>>>,

--- a/docs/STORAGE_FORMAT.md
+++ b/docs/STORAGE_FORMAT.md
@@ -27,8 +27,8 @@ collection_directory/
 ├── native_vectors.bin   # HNSW vector payload sidecar (when vector storage enabled)
 ├── native_hnsw.gen      # HNSW save-generation marker
 ├── native_hnsw.*        # HNSW graph dump files
-├── edge_store.bin       # Graph edge store (whole-file snapshot, graph collections)
-├── edges.wal            # Graph edge WAL (graph collections)
+├── edge_store.bin       # Graph edge store (whole-file snapshot, any collection with edges)
+├── edges.wal            # Graph edge WAL (any collection that writes edges)
 ├── property_index.bin   # Graph property index (graph collections)
 ├── bm25.snapshot        # BM25 full-text index snapshot (when text-indexed)
 ├── bm25.wal             # BM25 WAL (when text-indexed)

--- a/docs/guides/AGENT_MEMORY.md
+++ b/docs/guides/AGENT_MEMORY.md
@@ -593,6 +593,38 @@ memory.set_procedural_ttl_durable(proc_id, 604_800)?;
 let result = memory.auto_expire()?;
 ```
 
+### Graph dimension: relating memories
+
+Each subsystem can link its memories with typed, durable graph edges —
+making `MATCH` patterns executable over agent memory:
+
+```rust
+// ctx (1) relates to fact (2); edges are WAL-persisted and cascade away
+// when either memory is deleted. Endpoints must be live (not expired).
+let edge_id = memory.semantic().relate(1, 2, "RELATES_TO", None)?;
+let edges = memory.semantic().relations(1)?;   // outgoing edges of 1
+memory.semantic().unrelate(edge_id)?;          // remove one relation
+
+// The flagship hybrid query now executes end-to-end:
+let results = memory.query_semantic(
+    "SELECT * FROM memory AS m \
+     WHERE vector NEAR $q AND category = 'tech' \
+     AND MATCH (m)-[:RELATES_TO]->(f) LIMIT 5",
+    &params,
+)?;
+```
+
+Relations are per-subsystem (edges live inside each memory collection).
+They are durable on two paths: the edge WAL in the collection directory
+(compacted into `edge_store.bin` at flush), and subsystem snapshots —
+`serialize`/`snapshot` capture the relation edges between snapshotted
+memories and restore them with the points.
+
+Expiry note: `relations()` hides edges whose endpoint has expired. The
+VelesQL `MATCH` bridge filters expired ids from the *result* rows; an
+expired endpoint deeper in a pattern stops matching once `auto_expire`
+sweeps it.
+
 ### Configuration (Python)
 
 ```python


### PR DESCRIPTION
## Summary

Completes the audit's mission-query gap (follow-up #3): agent memory had no graph dimension — `MATCH (m)-[:RELATES_TO]->(f)` over memory was not executable, and the engine's edge durability/cascade machinery was gated to graph collections (vector-collection edges silently vanished on restart).

## Agent memory API

- **`relate(from, to, rel_type, props)`** on each subsystem (semantic/episodic/procedural): typed, WAL-durable relation edges — registry-seeded id allocation with collision-skip, live-endpoint gates (expired/missing → `NotFound`), and post-add endpoint verification that removes the edge when an endpoint was deleted concurrently (no dangling, WAL-durable edges).
- **`relations(id)`** (expired endpoints filtered — read invisibility extends to the graph surface) and **`unrelate(edge_id)`**.
- **Snapshots carry relations**: `serialize`/`deserialize` capture the edges between snapshotted memories and restore them (previously a restore silently wiped every relation — found by the code review). Legacy bare-array snapshots still load.
- The flagship query now runs end-to-end (pinned by `test_mission_query_near_match_scalar_over_memory`):
```sql
SELECT * FROM memory AS m
WHERE vector NEAR $q AND category = 'tech'
AND MATCH (m)-[:RELATES_TO]->(f) LIMIT 5
```
…and rides the GraphFirst anchored fetch from #1079 (exhaustive retrieval).

## Engine: graph dimension first-class on every collection type

- Edge WAL appends unconditional (the append only fires when an edge IS written — zero cost otherwise).
- Flush-time edge snapshot + WAL truncation unconditional: the WAL no longer grows without bound and a torn tail heals at the next flush (review finding: it previously **permanently** broke durability for vector collections).
- Delete-cascade (#900) gates on edge-store emptiness instead of the schema.
- **Edge property indexes rebuilt from the snapshot on open** — previously write-time-only and silently lost after WAL compaction (pre-existing gap, graph collections included).
- A per-collection `edge_wal_lock` (rank 7c) spans every WAL append + store apply pair: WAL order ≡ apply order (replay resolves id collisions exactly like live execution) and entries can't interleave.
- `remove_edge` pre-checks existence (no junk tombstones); `ConcurrentEdgeStore::max_edge_id()` replaces O(E) edge cloning.

## Validation

- Full core suite: **5,846 passed / 0 failed**; post-rebase: 196 agent + 52 graph BDD green, clippy pedantic clean
- code review (2 agents, 15 findings) — all fixed with 9 new regression tests
- All new functions CC ≤ 8, NLOC ≤ 50

## Follow-ups (tracked)

- REST/SDK parity for `relate()`/`relations()`/`unrelate()` (core-only today; bindings expose `query_semantic` and snapshots, which now round-trip edges correctly)
- VelesQL MATCH-bridge expiry boundary documented (expired endpoints stop matching after `auto_expire`)
