### PR TITLE
feat(quantization): wire RaBitQ and PQ quantizers end-to-end across restarts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`serialize`/`snapshot`) now capture relation edges and restore them
   (previously a restore silently wiped every relation). Older bare-array
   snapshots still load.
+- **RaBitQ wired end-to-end in the collection query path, restarts included**:
+  collections created with `storage = 'rabitq'` now build the binary-traversal
+  HNSW backend, and `TRAIN QUANTIZER … type = rabitq` installs the trained
+  quantizer into the live index in addition to persisting `rabitq.idx`. On
+  open, `rabitq.idx` is reloaded and every stored vector is re-encoded in
+  NodeId order (O(n·d), same cost class as gap recovery). Vacuum preserves the
+  RaBitQ backend and re-installs the trained quantizer instead of silently
+  downgrading to the Standard f32 backend.
 - **Durable post-hoc TTL setters for agent memory**: Result-returning
   `set_semantic_ttl_durable` / `set_episodic_ttl_durable` /
   `set_procedural_ttl_durable` on `AgentMemory` (and `set_ttl_durable` on each
@@ -63,6 +71,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   sequential-scan debt justifies the build; secondary indexes keep precedence.
 - **CI (#1076)**: full TypeScript SDK vitest suite on every PR; nightly 100K
   recall@10 ≥ 0.95 gate (`perf-gate-e2e` schedule + manual dispatch).
+
+### Fixed
+- **`TRAIN QUANTIZER 'rabitq'` trained an index nothing ever loaded**: the
+  persisted `rabitq.idx` had zero load-path callers, the persisted HNSW meta
+  hardcoded `StorageMode::Full` on save, and the collection load path ignored
+  the storage mode — so after a reopen a RaBitQ collection silently searched
+  f32 forever. `HnswIndex::save` now persists the actual backend mode and the
+  load/open paths honour the collection storage mode and restore the trained
+  quantizer.
+- **PQ persistence round-trip**: `Collection::open` now reloads the trained PQ
+  codebook (`codebook.pq`, plus `rotation.opq` for OPQ) and rebuilds the PQ
+  cache by re-encoding stored vectors (O(n) at open). Previously the codebook
+  saved by `TRAIN QUANTIZER` was never loaded, leaving the ADC rescore path
+  inert after a restart.
+- **Quantization docs honesty**: `docs/guides/QUANTIZATION.md` now states
+  precisely which modes are wired into the collection query path — RaBitQ and
+  PQ end-to-end; SQ8/Binary collection modes maintain caches that no search
+  path consumes (search stays full-precision f32), pending a reduced-memory
+  storage mode.
 
 ## [1.18.0] — 2026-06-07
 

--- a/crates/velesdb-core/src/collection/core/crud_bulk.rs
+++ b/crates/velesdb-core/src/collection/core/crud_bulk.rs
@@ -79,7 +79,12 @@ impl Collection {
             points.iter().map(|p| (p.id, p.vector.as_slice())).collect();
         let sparse_batch = Self::collect_sparse_batch(points);
 
-        let count = if self.async_index_builder.is_some() {
+        // The V2 fast path writes vectors directly into the graph store and
+        // bypasses RaBitQPrecisionHnsw::insert — on a RaBitQ backend that
+        // would desynchronize the positional encoding store from the node
+        // ids. RaBitQ collections always take the standard path.
+        let use_v2 = self.async_index_builder.is_some() && !self.index.is_rabitq_backend();
+        let count = if use_v2 {
             self.upsert_bulk_v2_path(&vector_refs, points, &sparse_batch, fsync)?
         } else {
             self.upsert_bulk_standard_path(&vector_refs, points, &sparse_batch, fsync)?

--- a/crates/velesdb-core/src/collection/core/lifecycle.rs
+++ b/crates/velesdb-core/src/collection/core/lifecycle.rs
@@ -166,15 +166,7 @@ impl Collection {
     ) -> Result<CollectionParts> {
         let vector_storage = Arc::new(RwLock::new(MmapStorage::new(&path, config.dimension)?));
         let payload_storage = Arc::new(RwLock::new(LogPayloadStorage::new(&path)?));
-        let index = if let Some(params) = hnsw_params {
-            Arc::new(HnswIndex::with_params(
-                config.dimension,
-                config.metric,
-                params,
-            )?)
-        } else {
-            Arc::new(HnswIndex::new(config.dimension, config.metric)?)
-        };
+        let index = Arc::new(Self::build_hnsw_index(&config, hnsw_params)?);
         let text_index = Arc::new(Bm25Index::new());
         Ok(CollectionParts::new_with_empty_indexes(
             path,
@@ -184,6 +176,23 @@ impl Collection {
             index,
             text_index,
         ))
+    }
+
+    /// Builds a fresh HNSW index for a collection, honouring the
+    /// collection-level storage mode.
+    ///
+    /// `config.storage_mode` is the source of truth for the index backend:
+    /// it overrides whatever `hnsw_params.storage_mode` carries so a
+    /// `RaBitQ` collection always gets the binary-traversal backend, even
+    /// when the params predate a `TRAIN QUANTIZER 'rabitq'` mode flip.
+    fn build_hnsw_index(
+        config: &CollectionConfig,
+        hnsw_params: Option<crate::index::hnsw::HnswParams>,
+    ) -> Result<HnswIndex> {
+        let mut params =
+            hnsw_params.unwrap_or_else(|| crate::index::hnsw::HnswParams::auto(config.dimension));
+        params.storage_mode = config.storage_mode;
+        HnswIndex::with_params(config.dimension, config.metric, params)
     }
 
     /// Rebuilds the BM25 full-text index from persisted payloads.
@@ -306,17 +315,28 @@ impl Collection {
             sparse_indexes,
         });
 
-        // Edge crash durability: replay the edge WAL on top of the loaded
-        // edge_store snapshot so edge mutations since the last flush survive
-        // a crash. No-op when edges.wal is absent (legacy / non-graph DBs).
         #[cfg(feature = "persistence")]
-        // Snapshot-loaded edges must re-enter the property indexes BEFORE the
-        // WAL replays (replay indexes its own ADDs — running the full pass
-        // after it would double-index the replayed edges).
-        collection.reindex_edge_properties_from_store();
-        collection.replay_edge_wal()?;
+        collection.run_post_open_hooks()?;
 
         Ok(collection)
+    }
+
+    /// Post-open hooks that need a fully assembled collection.
+    ///
+    /// 1. Edge property indexes: snapshot-loaded edges must re-enter the
+    ///    property indexes BEFORE the WAL replays (replay indexes its own
+    ///    ADDs — a full pass after it would double-index replayed edges).
+    /// 2. Edge crash durability: replay the edge WAL on top of the loaded
+    ///    `edge_store` snapshot so edge mutations since the last flush
+    ///    survive a crash. No-op when `edges.wal` is absent.
+    /// 3. Quantizer restore: reload persisted PQ codebook / `RaBitQ` index
+    ///    AFTER crash recovery so every recovered vector is re-encoded.
+    ///    O(n) over stored vectors — same cost class as gap recovery.
+    #[cfg(feature = "persistence")]
+    fn run_post_open_hooks(&self) -> Result<()> {
+        self.reindex_edge_properties_from_store();
+        self.replay_edge_wal()?;
+        self.restore_persisted_quantizers()
     }
 
     // create_graph_collection is in lifecycle_create.rs
@@ -325,21 +345,23 @@ impl Collection {
     ///
     /// When `hnsw.bin` is absent and `config.hnsw_params` is set, the
     /// persisted custom params are honoured so they survive collection reopen.
+    ///
+    /// Both branches honour `config.storage_mode`: the load path upgrades the
+    /// backend to `RaBitQ` when the collection mode requires it (and installs
+    /// `rabitq.idx` when present — see `HnswIndex::load_with_storage_mode`),
+    /// and the create path builds the backend from the collection mode.
     fn load_or_create_hnsw(
         path: &std::path::Path,
         config: &CollectionConfig,
     ) -> Result<Arc<HnswIndex>> {
         if path.join("hnsw.bin").exists() {
-            let idx = HnswIndex::load(path, config.dimension, config.metric)?;
+            let idx = HnswIndex::load_with_storage_mode(path, config.storage_mode)?;
             Ok(Arc::new(idx))
-        } else if let Some(params) = config.hnsw_params {
-            Ok(Arc::new(HnswIndex::with_params(
-                config.dimension,
-                config.metric,
-                params,
-            )?))
         } else {
-            Ok(Arc::new(HnswIndex::new(config.dimension, config.metric)?))
+            Ok(Arc::new(Self::build_hnsw_index(
+                config,
+                config.hnsw_params,
+            )?))
         }
     }
 

--- a/crates/velesdb-core/src/collection/core/lifecycle.rs
+++ b/crates/velesdb-core/src/collection/core/lifecycle.rs
@@ -299,7 +299,7 @@ impl Collection {
         config.point_count =
             super::recovery::reconcile_point_count(&config, &vector_storage, &payload_storage);
 
-        super::recovery::run_crash_recovery(&config, &vector_storage, &index)?;
+        Self::recover_index_state(&path, &config, &vector_storage, &index)?;
 
         let collection = Self::assemble(CollectionParts {
             path,
@@ -319,6 +319,24 @@ impl Collection {
         collection.run_post_open_hooks()?;
 
         Ok(collection)
+    }
+
+    /// Pre-assemble index recovery: quantizer preinstall + gap recovery.
+    ///
+    /// The persisted `RaBitQ` quantizer installs BEFORE gap recovery so the
+    /// recovered vectors re-insert through it — otherwise the lazy training
+    /// threshold (1000 inserts) would preempt the TRAIN QUANTIZER artifact
+    /// with a throwaway quantizer on every reopen of a realistically sized
+    /// collection (the HNSW graph is rebuilt on open).
+    fn recover_index_state(
+        path: &std::path::Path,
+        config: &CollectionConfig,
+        vector_storage: &Arc<RwLock<MmapStorage>>,
+        index: &Arc<HnswIndex>,
+    ) -> Result<()> {
+        #[cfg(feature = "persistence")]
+        super::quantizer_restore::preinstall_persisted_rabitq(path, config.dimension, index)?;
+        super::recovery::run_crash_recovery(config, vector_storage, index)
     }
 
     /// Post-open hooks that need a fully assembled collection.

--- a/crates/velesdb-core/src/collection/core/mod.rs
+++ b/crates/velesdb-core/src/collection/core/mod.rs
@@ -32,6 +32,8 @@ mod lifecycle;
 mod lifecycle_create;
 #[cfg(test)]
 mod lifecycle_tests;
+#[cfg(feature = "persistence")]
+mod quantizer_restore;
 mod recovery;
 #[cfg(all(test, feature = "persistence"))]
 mod recovery_tests;

--- a/crates/velesdb-core/src/collection/core/quantizer_restore.rs
+++ b/crates/velesdb-core/src/collection/core/quantizer_restore.rs
@@ -1,0 +1,147 @@
+//! Quantizer restore at collection open (PQ codebook / `RaBitQ` index).
+//!
+//! `TRAIN QUANTIZER` persists trained artifacts in the collection directory
+//! (`codebook.pq`, `rotation.opq`, `rabitq.idx`); this module reloads them on
+//! [`Collection::open`] so quantized search survives a restart. Without this
+//! step the PQ ADC rescore path and the `RaBitQ` binary-traversal backend
+//! would silently fall back to full-precision f32 search after reopen.
+
+use crate::collection::types::Collection;
+use crate::error::Result;
+use crate::quantization::{PQVector, ProductQuantizer, RaBitQIndex, StorageMode};
+use crate::storage::VectorStorage;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+impl Collection {
+    /// Restores persisted quantizers matching the collection storage mode.
+    ///
+    /// Called once from [`Collection::open`], after crash recovery, so every
+    /// recovered vector is re-encoded. Cost is O(n) over stored vectors when
+    /// a quantizer artifact is present — the same class as gap recovery.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if reading a persisted artifact fails (corrupt
+    /// codebook/index). Encode failures on individual vectors degrade
+    /// gracefully (logged, vector keeps full-precision scoring).
+    pub(crate) fn restore_persisted_quantizers(&self) -> Result<()> {
+        let mode = self.config.read().storage_mode;
+        match mode {
+            StorageMode::ProductQuantization => self.restore_persisted_pq(),
+            StorageMode::RaBitQ => self.restore_persisted_rabitq(),
+            StorageMode::Full | StorageMode::SQ8 | StorageMode::Binary => Ok(()),
+        }
+    }
+
+    /// Restores the persisted PQ codebook (and OPQ rotation) and rebuilds the
+    /// PQ cache by re-encoding every stored vector.
+    ///
+    /// Lock order: `vector_storage` (2) → `pq_cache` (4) → `pq_quantizer` (5),
+    /// acquired sequentially and never inverted.
+    fn restore_persisted_pq(&self) -> Result<()> {
+        if self.pq_quantizer.read().is_some() {
+            return Ok(());
+        }
+        let Some(mut pq) = ProductQuantizer::load_codebook(&self.path)? else {
+            return Ok(());
+        };
+        // codebook.pq serializes the rotation when trained via OPQ; the
+        // standalone rotation.opq artifact covers codebooks saved without it.
+        if pq.rotation.is_none() {
+            pq.rotation = ProductQuantizer::load_rotation(&self.path)?;
+        }
+
+        let cache = self.encode_pq_cache(&pq);
+        tracing::debug!(
+            entries = cache.len(),
+            "restored PQ quantizer from codebook.pq; cache rebuilt on open"
+        );
+        *self.pq_cache.write() = cache;
+        *self.pq_quantizer.write() = Some(pq);
+        Ok(())
+    }
+
+    /// Re-encodes every stored vector with `pq`, returning the rebuilt cache.
+    ///
+    /// Streams id-by-id from mmap storage (no full-dataset materialization).
+    /// Vectors that fail to encode are skipped with a warning — they keep
+    /// their HNSW score in the ADC rescore path (cache-miss semantics).
+    fn encode_pq_cache(&self, pq: &ProductQuantizer) -> HashMap<u64, PQVector> {
+        let storage = self.vector_storage.read();
+        let ids = storage.ids();
+        let mut cache = HashMap::with_capacity(ids.len());
+        for id in ids {
+            let Ok(Some(vector)) = storage.retrieve(id) else {
+                continue;
+            };
+            match pq.quantize(&vector) {
+                Ok(code) => {
+                    cache.insert(id, code);
+                }
+                Err(err) => {
+                    tracing::warn!(id, %err, "PQ re-encode failed on open; keeping HNSW-only scoring");
+                }
+            }
+        }
+        cache
+    }
+
+    /// Installs the persisted `RaBitQ` index into the live HNSW backend.
+    ///
+    /// No-op when a quantizer is already installed (e.g. by the index load
+    /// path), when `rabitq.idx` is absent, or — with a warning — when the
+    /// artifact does not match the collection (wrong dimension or non-RaBitQ
+    /// backend). Search then stays on exact f32 distances, which is correct
+    /// but unaccelerated.
+    fn restore_persisted_rabitq(&self) -> Result<()> {
+        if self.index.is_rabitq_quantizer_trained() {
+            return Ok(());
+        }
+        let Some(rabitq) = RaBitQIndex::load(&self.path)? else {
+            return Ok(());
+        };
+        if rabitq.dimension != self.config.read().dimension {
+            tracing::warn!(
+                rabitq_dim = rabitq.dimension,
+                "rabitq.idx dimension does not match the collection; quantizer not installed"
+            );
+            return Ok(());
+        }
+        let installed = self.index.install_trained_rabitq(Arc::new(rabitq))?;
+        if installed {
+            tracing::debug!("restored RaBitQ quantizer from rabitq.idx; vectors re-encoded");
+        } else {
+            tracing::warn!(
+                "rabitq.idx present but the HNSW backend is not RaBitQ; quantizer not installed"
+            );
+        }
+        Ok(())
+    }
+
+    /// Installs a freshly trained `RaBitQ` quantizer into the live index.
+    ///
+    /// Returns `Ok(true)` when the index backend is `RaBitQ` and the
+    /// quantizer is now active, `Ok(false)` when the backend is Standard
+    /// (training is persisted; the wiring takes effect at the next open).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if re-encoding a stored vector fails.
+    pub(crate) fn install_rabitq_quantizer(&self, rabitq: Arc<RaBitQIndex>) -> Result<bool> {
+        self.index.install_trained_rabitq(rabitq)
+    }
+
+    /// Returns true when the HNSW backend is `RaBitQ` with a trained
+    /// quantizer (test introspection).
+    #[cfg(test)]
+    pub(crate) fn is_rabitq_quantizer_trained(&self) -> bool {
+        self.index.is_rabitq_quantizer_trained()
+    }
+
+    /// Number of entries in the PQ cache (test introspection).
+    #[cfg(test)]
+    pub(crate) fn pq_cache_len(&self) -> usize {
+        self.pq_cache.read().len()
+    }
+}

--- a/crates/velesdb-core/src/collection/core/quantizer_restore.rs
+++ b/crates/velesdb-core/src/collection/core/quantizer_restore.rs
@@ -95,28 +95,7 @@ impl Collection {
     /// backend). Search then stays on exact f32 distances, which is correct
     /// but unaccelerated.
     fn restore_persisted_rabitq(&self) -> Result<()> {
-        if self.index.is_rabitq_quantizer_trained() {
-            return Ok(());
-        }
-        let Some(rabitq) = RaBitQIndex::load(&self.path)? else {
-            return Ok(());
-        };
-        if rabitq.dimension != self.config.read().dimension {
-            tracing::warn!(
-                rabitq_dim = rabitq.dimension,
-                "rabitq.idx dimension does not match the collection; quantizer not installed"
-            );
-            return Ok(());
-        }
-        let installed = self.index.install_trained_rabitq(Arc::new(rabitq))?;
-        if installed {
-            tracing::debug!("restored RaBitQ quantizer from rabitq.idx; vectors re-encoded");
-        } else {
-            tracing::warn!(
-                "rabitq.idx present but the HNSW backend is not RaBitQ; quantizer not installed"
-            );
-        }
-        Ok(())
+        preinstall_persisted_rabitq(&self.path, self.config.read().dimension, &self.index)
     }
 
     /// Installs a freshly trained `RaBitQ` quantizer into the live index.
@@ -144,4 +123,48 @@ impl Collection {
     pub(crate) fn pq_cache_len(&self) -> usize {
         self.pq_cache.read().len()
     }
+}
+
+/// Installs a persisted `rabitq.idx` into `index` when its backend is
+/// `RaBitQ` and no quantizer is active yet.
+///
+/// Called BEFORE gap recovery in `Collection::open` so recovered vectors
+/// re-insert through the persisted quantizer — otherwise the lazy training
+/// threshold (1000 inserts) would preempt the trained artifact with a
+/// throwaway quantizer on every reopen of a realistically sized collection.
+/// Also called as a post-open safety net (idempotent: an already-trained
+/// quantizer short-circuits).
+///
+/// # Errors
+///
+/// Returns an error when reading `rabitq.idx` or re-encoding fails;
+/// dimension mismatches degrade to f32 with a warning instead.
+#[cfg(feature = "persistence")]
+pub(super) fn preinstall_persisted_rabitq(
+    path: &std::path::Path,
+    dimension: usize,
+    index: &crate::index::HnswIndex,
+) -> Result<()> {
+    if index.is_rabitq_quantizer_trained() {
+        return Ok(());
+    }
+    let Some(rabitq) = RaBitQIndex::load(path)? else {
+        return Ok(());
+    };
+    if rabitq.dimension != dimension {
+        tracing::warn!(
+            rabitq_dim = rabitq.dimension,
+            "rabitq.idx dimension does not match the collection; quantizer not installed"
+        );
+        return Ok(());
+    }
+    let installed = index.install_trained_rabitq(Arc::new(rabitq))?;
+    if installed {
+        tracing::debug!("restored RaBitQ quantizer from rabitq.idx; vectors re-encoded");
+    } else {
+        tracing::warn!(
+            "rabitq.idx present but the HNSW backend is not RaBitQ; quantizer not installed"
+        );
+    }
+    Ok(())
 }

--- a/crates/velesdb-core/src/database/database_tests.rs
+++ b/crates/velesdb-core/src/database/database_tests.rs
@@ -743,9 +743,50 @@ fn test_train_rabitq_wiring_survives_reopen() {
     let result_ids: std::collections::HashSet<u64> = results.iter().map(|r| r.point.id).collect();
     let brute_ids = sin_brute_force_top_k(&query_vec, 64, 300, 10);
     let overlap = brute_ids.intersection(&result_ids).count();
+    // Same bar as rabitq_precision_tests: exact-f32 rerank over oversampled
+    // candidates on a small set must be near-perfect; anything lower hides
+    // partial store misalignment.
     assert!(
-        overlap >= 7,
-        "recall@10 vs brute force should be >= 0.7 after reopen, got {overlap}/10"
+        overlap >= 9,
+        "recall@10 vs brute force should be >= 0.9 after reopen, got {overlap}/10"
+    );
+}
+
+/// The persisted TRAIN artifact must survive a reopen even when the
+/// collection exceeds the lazy-training threshold (1000 vectors): gap
+/// recovery re-inserts every vector on open, and without the pre-recovery
+/// install those inserts would lazily train a throwaway quantizer that
+/// preempts `rabitq.idx` (review 2026-06-11 finding 1).
+#[test]
+fn test_train_rabitq_survives_reopen_beyond_lazy_threshold() {
+    let dir = tempdir().unwrap();
+    {
+        let db = Database::open(dir.path()).unwrap();
+        db.create_collection("rbq_large", 32, DistanceMetric::Euclidean)
+            .unwrap();
+        seed_sin_vectors(&db, "rbq_large", 32, 1200);
+        let query = Parser::parse("TRAIN QUANTIZER ON rbq_large WITH (m=4, type=rabitq)").unwrap();
+        db.execute_query(&query, &std::collections::HashMap::new())
+            .unwrap();
+        assert_eq!(db.flush_all(), 0, "flush before reopen must succeed");
+    }
+
+    let db = Database::open(dir.path()).unwrap();
+    let coll = db.resolve_writable_collection("rbq_large").unwrap();
+    assert!(
+        coll.is_rabitq_quantizer_trained(),
+        "the persisted quantizer must be installed before gap recovery"
+    );
+
+    let query_vec = sin_vector(32, 7);
+    let results = coll.search(&query_vec, 10).unwrap();
+    assert_eq!(results.len(), 10);
+    let result_ids: std::collections::HashSet<u64> = results.iter().map(|r| r.point.id).collect();
+    let brute_ids = sin_brute_force_top_k(&query_vec, 32, 1200, 10);
+    let overlap = brute_ids.intersection(&result_ids).count();
+    assert!(
+        overlap >= 9,
+        "recall@10 vs brute force should be >= 0.9 after large reopen, got {overlap}/10"
     );
 }
 

--- a/crates/velesdb-core/src/database/database_tests.rs
+++ b/crates/velesdb-core/src/database/database_tests.rs
@@ -631,6 +631,171 @@ fn test_execute_train_force_retrain_succeeds() {
     assert_eq!(payload["status"], serde_json::json!("trained"));
 }
 
+// ---------------------------------------------------------------------------
+// Quantizer wiring across restarts (RaBitQ + PQ persistence round-trips)
+// ---------------------------------------------------------------------------
+
+/// Builds a sinusoidal vector — spread-out distances, no symmetric ties,
+/// so brute-force/ANN top-k comparisons are stable.
+fn sin_vector(dim: usize, i: usize) -> Vec<f32> {
+    #[allow(clippy::cast_precision_loss)]
+    (0..dim)
+        .map(|d| ((i * dim + d) as f32 * 0.01).sin())
+        .collect()
+}
+
+/// Inserts `count` sinusoidal vectors (ids `0..count`) into a collection.
+fn seed_sin_vectors(db: &Database, name: &str, dim: usize, count: usize) {
+    let coll = db.get_vector_collection(name).unwrap();
+    let points: Vec<Point> = (0..count)
+        .map(|i| Point::new(i as u64, sin_vector(dim, i), Some(serde_json::json!({}))))
+        .collect();
+    coll.upsert(points).unwrap();
+}
+
+/// Brute-force Euclidean top-k ids over the seeded sinusoidal set.
+fn sin_brute_force_top_k(
+    query: &[f32],
+    dim: usize,
+    count: usize,
+    k: usize,
+) -> std::collections::HashSet<u64> {
+    let mut dists: Vec<(u64, f32)> = (0..count)
+        .map(|i| {
+            let v = sin_vector(dim, i);
+            let d: f32 = query.iter().zip(&v).map(|(a, b)| (a - b) * (a - b)).sum();
+            (i as u64, d)
+        })
+        .collect();
+    dists.sort_by(|a, b| a.1.total_cmp(&b.1));
+    dists.into_iter().take(k).map(|(id, _)| id).collect()
+}
+
+/// `TRAIN QUANTIZER 'rabitq'` on a collection created with `storage='rabitq'`
+/// must install the quantizer into the live backend (no restart needed).
+#[test]
+fn test_execute_train_rabitq_installs_into_live_backend() {
+    let dir = tempdir().unwrap();
+    let db = Database::open(dir.path()).unwrap();
+    db.create_collection_with_options(
+        "rbq_live",
+        64,
+        DistanceMetric::Euclidean,
+        StorageMode::RaBitQ,
+    )
+    .unwrap();
+    seed_sin_vectors(&db, "rbq_live", 64, 300);
+
+    let coll = db.resolve_writable_collection("rbq_live").unwrap();
+    assert!(
+        !coll.is_rabitq_quantizer_trained(),
+        "300 inserts stay below the lazy-train threshold"
+    );
+
+    let query = Parser::parse("TRAIN QUANTIZER ON rbq_live WITH (m=4, type=rabitq)").unwrap();
+    db.execute_query(&query, &std::collections::HashMap::new())
+        .unwrap();
+
+    assert!(
+        coll.is_rabitq_quantizer_trained(),
+        "TRAIN must install the quantizer into the live RaBitQ backend"
+    );
+
+    let results = coll.search(&sin_vector(64, 42), 5).unwrap();
+    assert_eq!(
+        results.first().map(|r| r.point.id),
+        Some(42),
+        "self-query must return itself as top-1 through the RaBitQ path"
+    );
+}
+
+/// End-to-end restart wiring: create → insert → TRAIN 'rabitq' → reopen the
+/// Database → the trained quantizer must be restored from `rabitq.idx` and
+/// search must keep recall parity with brute force.
+#[test]
+fn test_train_rabitq_wiring_survives_reopen() {
+    let dir = tempdir().unwrap();
+    {
+        let db = Database::open(dir.path()).unwrap();
+        // Created with the default Full mode: TRAIN flips the config to
+        // RaBitQ and the backend takes effect at the reopen below.
+        db.create_collection("rbq_reopen", 64, DistanceMetric::Euclidean)
+            .unwrap();
+        seed_sin_vectors(&db, "rbq_reopen", 64, 300);
+        let query = Parser::parse("TRAIN QUANTIZER ON rbq_reopen WITH (m=4, type=rabitq)").unwrap();
+        db.execute_query(&query, &std::collections::HashMap::new())
+            .unwrap();
+        assert_eq!(db.flush_all(), 0, "flush before reopen must succeed");
+    }
+
+    let db = Database::open(dir.path()).unwrap();
+    let coll = db.resolve_writable_collection("rbq_reopen").unwrap();
+    assert_eq!(coll.config().storage_mode, StorageMode::RaBitQ);
+    assert!(
+        coll.is_rabitq_quantizer_trained(),
+        "rabitq.idx must be reloaded and installed on open"
+    );
+
+    // Recall parity with brute force (set overlap, not exact scores).
+    let query_vec = sin_vector(64, 42);
+    let results = coll.search(&query_vec, 10).unwrap();
+    assert_eq!(results.len(), 10);
+    let result_ids: std::collections::HashSet<u64> = results.iter().map(|r| r.point.id).collect();
+    let brute_ids = sin_brute_force_top_k(&query_vec, 64, 300, 10);
+    let overlap = brute_ids.intersection(&result_ids).count();
+    assert!(
+        overlap >= 7,
+        "recall@10 vs brute force should be >= 0.7 after reopen, got {overlap}/10"
+    );
+}
+
+/// PQ persistence round-trip: the codebook saved by `TRAIN QUANTIZER` must be
+/// reloaded on open and the PQ cache rebuilt, so the ADC rescore path stays
+/// live after a restart.
+#[test]
+fn test_train_pq_codebook_and_cache_survive_reopen() {
+    let dir = tempdir().unwrap();
+    {
+        let db = Database::open(dir.path()).unwrap();
+        // storage='pq' from creation: inserts lazily train an in-memory
+        // quantizer after 128 points, but only TRAIN persists the codebook —
+        // force=true replaces the lazily trained one.
+        db.create_collection_with_options(
+            "pqc",
+            16,
+            DistanceMetric::Euclidean,
+            StorageMode::ProductQuantization,
+        )
+        .unwrap();
+        seed_sin_vectors(&db, "pqc", 16, 300);
+        let query = Parser::parse("TRAIN QUANTIZER ON pqc WITH (m=4, k=16, force=true)").unwrap();
+        db.execute_query(&query, &std::collections::HashMap::new())
+            .unwrap();
+        assert_eq!(db.flush_all(), 0, "flush before reopen must succeed");
+    }
+
+    let db = Database::open(dir.path()).unwrap();
+    let coll = db.resolve_writable_collection("pqc").unwrap();
+    assert_eq!(coll.config().storage_mode, StorageMode::ProductQuantization);
+    assert!(
+        coll.pq_quantizer_read().is_some(),
+        "codebook.pq must be reloaded on open"
+    );
+    assert_eq!(
+        coll.pq_cache_len(),
+        300,
+        "PQ cache must be rebuilt for every stored vector"
+    );
+
+    // ADC-rescored search still finds the self-query (PQ is lossy: top-10,
+    // not top-1).
+    let results = coll.search(&sin_vector(16, 42), 10).unwrap();
+    assert!(
+        results.iter().any(|r| r.point.id == 42),
+        "self-query must appear in PQ-rescored top-10 after reopen"
+    );
+}
+
 #[test]
 fn test_execute_train_with_sample_limit() {
     let dir = tempdir().unwrap();

--- a/crates/velesdb-core/src/database/training.rs
+++ b/crates/velesdb-core/src/database/training.rs
@@ -168,7 +168,13 @@ impl Database {
         })))
     }
 
-    /// Trains a `RaBitQ` quantizer and persists it.
+    /// Trains a `RaBitQ` quantizer, persists it, and installs it into the
+    /// live index when the collection's HNSW backend is `RaBitQ`.
+    ///
+    /// For collections created with another storage mode the backend is
+    /// Standard: training still persists `rabitq.idx` and flips the config
+    /// below, and the wiring takes effect at the next open (the open path
+    /// rebuilds the backend from the storage mode and reloads `rabitq.idx`).
     fn train_rabitq(
         collection: &crate::collection::Collection,
         vectors: &[Vec<f32>],
@@ -179,6 +185,17 @@ impl Database {
 
         rbq.save(collection.data_path())
             .map_err(|e| Error::TrainingFailed(e.to_string()))?;
+
+        // Live install: re-encodes the collection's vectors (O(n·d)) so
+        // RaBitQ traversal activates without a restart.
+        let installed = collection
+            .install_rabitq_quantizer(std::sync::Arc::new(rbq))
+            .map_err(|e| Error::TrainingFailed(e.to_string()))?;
+        if !installed {
+            tracing::debug!(
+                "RaBitQ trained on a Standard-backend collection; takes effect at next open"
+            );
+        }
 
         // RaBitQ uses default oversampling of 4.
         Self::finalize_pq_config(collection, StorageMode::RaBitQ, 4)?;

--- a/crates/velesdb-core/src/index/hnsw/index/constructors.rs
+++ b/crates/velesdb-core/src/index/hnsw/index/constructors.rs
@@ -138,18 +138,23 @@ impl HnswIndex {
     }
 
     /// Internal constructor with vector storage toggle.
+    ///
+    /// Honours `params.storage_mode`: `RaBitQ` selects the binary-traversal
+    /// backend; every other mode uses the Standard f32 backend (SQ8/Binary
+    /// quantized caches live at the collection layer, not in this index).
     fn with_params_internal(
         dimension: usize,
         metric: DistanceMetric,
         params: HnswParams,
         enable_vector_storage: bool,
     ) -> Result<Self> {
-        let inner = HnswInner::new(
+        let inner = HnswInner::new_with_storage_mode(
             metric,
             params.max_connections,
             params.max_elements,
             params.ef_construction,
             dimension,
+            params.storage_mode,
         )?;
 
         let mappings = ShardedMappings::with_capacity(params.max_elements);
@@ -204,6 +209,10 @@ impl HnswIndex {
 
     /// Loads an HNSW index from disk.
     ///
+    /// Respects the persisted `meta.storage_mode` (a `RaBitQ` index reloads
+    /// with the `RaBitQ` backend) and, when the backend is `RaBitQ`, installs
+    /// the trained quantizer from `<path>/rabitq.idx` if present.
+    ///
     /// # Arguments
     ///
     /// * `path` - Path to the index directory
@@ -218,19 +227,57 @@ impl HnswIndex {
         _dimension: usize,
         _metric: DistanceMetric,
     ) -> std::result::Result<Self, std::io::Error> {
+        Self::load_inner(path.as_ref(), None)
+    }
+
+    /// Loads an HNSW index honouring a collection-level storage mode.
+    ///
+    /// The backend mode is the persisted `meta.storage_mode`, upgraded to
+    /// `RaBitQ` when `desired_mode` requests it. The upgrade covers the case
+    /// where `TRAIN QUANTIZER 'rabitq'` flipped the collection storage mode
+    /// AFTER the last index save (the persisted meta still says `Full`).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the file doesn't exist or is corrupted.
+    pub(crate) fn load_with_storage_mode<P: AsRef<Path>>(
+        path: P,
+        desired_mode: crate::StorageMode,
+    ) -> std::result::Result<Self, std::io::Error> {
+        Self::load_inner(path.as_ref(), Some(desired_mode))
+    }
+
+    /// Shared load pipeline for [`Self::load`] / [`Self::load_with_storage_mode`].
+    ///
+    /// When the resulting backend is `RaBitQ`, the trained quantizer persisted
+    /// at `<path>/rabitq.idx` is installed, re-encoding every loaded vector in
+    /// `NodeId` order — an O(n·d) cost at open, same class as gap recovery.
+    fn load_inner(
+        path: &Path,
+        desired_mode: Option<crate::StorageMode>,
+    ) -> std::result::Result<Self, std::io::Error> {
         use crate::index::hnsw::persistence;
 
-        let path = path.as_ref();
-
         let meta = persistence::load_meta(path)?;
+        let storage_mode = if desired_mode == Some(crate::StorageMode::RaBitQ) {
+            crate::StorageMode::RaBitQ
+        } else {
+            meta.storage_mode
+        };
 
         // Load HNSW graph (caller-specific — see persistence::load_sidecars).
-        let inner = HnswInner::file_load(path, "native_hnsw", meta.metric, meta.dimension)?;
+        let inner = HnswInner::file_load_with_storage_mode(
+            path,
+            "native_hnsw",
+            meta.metric,
+            meta.dimension,
+            storage_mode,
+        )?;
 
         // Mappings + vectors in one shared call (RF-DEDUP #448 Group C).
         let (mappings, vectors, enable_vector_storage) = persistence::load_sidecars(path, &meta)?;
 
-        Ok(Self {
+        let index = Self {
             dimension: meta.dimension,
             metric: meta.metric,
             inner: RwLock::new(ManuallyDrop::new(inner)),
@@ -240,7 +287,32 @@ impl HnswIndex {
             rerank_latency_target_us: AtomicU64::new(0),
             rerank_latency_ema_us: AtomicU64::new(0),
             io_holder: None,
-        })
+        };
+
+        #[cfg(feature = "persistence")]
+        index.install_persisted_rabitq(path)?;
+
+        Ok(index)
+    }
+
+    /// Installs `<path>/rabitq.idx` into the `RaBitQ` backend, when both exist.
+    ///
+    /// No-op for the Standard backend or when the file is absent.
+    #[cfg(feature = "persistence")]
+    fn install_persisted_rabitq(&self, path: &Path) -> std::io::Result<()> {
+        let inner = self.inner.read();
+        if inner.storage_mode() != crate::StorageMode::RaBitQ {
+            return Ok(());
+        }
+        let Some(rabitq) =
+            crate::quantization::RaBitQIndex::load(path).map_err(std::io::Error::other)?
+        else {
+            return Ok(());
+        };
+        inner
+            .install_trained_rabitq(std::sync::Arc::new(rabitq))
+            .map_err(std::io::Error::other)?;
+        Ok(())
     }
 
     /// Saves the HNSW index to disk.
@@ -266,7 +338,11 @@ impl HnswIndex {
         let new_gen = persistence::next_generation(path)?;
 
         // Dump the HNSW graph itself (caller-specific — see persistence::save_sidecars).
-        self.inner.read().file_dump(path, "native_hnsw")?;
+        let storage_mode = {
+            let inner = self.inner.read();
+            inner.file_dump(path, "native_hnsw")?;
+            inner.storage_mode()
+        };
 
         // Graph-generation marker is written IMMEDIATELY after the graph dump
         // and BEFORE the sidecars, so any crash after the graph rename leaves
@@ -275,7 +351,8 @@ impl HnswIndex {
         persistence::save_graph_generation(path, new_gen)?;
 
         // Mappings + vectors + meta in one shared call (RF-DEDUP #448 Group C).
-        // NativeHnsw exclusively uses StorageMode::Full for backward compat.
+        // The actual backend storage mode is persisted so save/load round-trips
+        // (a RaBitQ index reloads with the RaBitQ backend).
         persistence::save_sidecars(
             path,
             &self.mappings,
@@ -284,7 +361,7 @@ impl HnswIndex {
                 dimension: self.dimension,
                 metric: self.metric,
                 enable_vector_storage: self.enable_vector_storage,
-                storage_mode: crate::StorageMode::Full,
+                storage_mode,
                 // `save_sidecars` overwrites this with `new_gen` (#617).
                 generation: 0,
             },
@@ -325,5 +402,29 @@ impl HnswIndex {
     #[must_use]
     pub fn has_vector_storage(&self) -> bool {
         self.enable_vector_storage
+    }
+
+    /// Installs a trained `RaBitQ` quantizer into the live backend.
+    ///
+    /// Returns `Ok(true)` when the backend is `RaBitQ` and the quantizer was
+    /// installed (existing vectors re-encoded in `NodeId` order, O(n·d)),
+    /// `Ok(false)` when the backend is Standard (no-op).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if re-encoding a stored vector fails.
+    #[cfg(feature = "persistence")]
+    pub(crate) fn install_trained_rabitq(
+        &self,
+        rabitq: std::sync::Arc<crate::quantization::RaBitQIndex>,
+    ) -> crate::error::Result<bool> {
+        self.inner.read().install_trained_rabitq(rabitq)
+    }
+
+    /// Returns true when the backend is `RaBitQ` with a trained quantizer.
+    #[cfg(feature = "persistence")]
+    #[must_use]
+    pub(crate) fn is_rabitq_quantizer_trained(&self) -> bool {
+        self.inner.read().is_rabitq_quantizer_trained()
     }
 }

--- a/crates/velesdb-core/src/index/hnsw/index/constructors.rs
+++ b/crates/velesdb-core/src/index/hnsw/index/constructors.rs
@@ -309,6 +309,17 @@ impl HnswIndex {
         else {
             return Ok(());
         };
+        // Warn-and-degrade like the collection-level restore: a stale or
+        // foreign rabitq.idx must not make the index un-openable — search
+        // stays on exact f32 distances instead.
+        if rabitq.dimension != self.dimension {
+            tracing::warn!(
+                rabitq_dim = rabitq.dimension,
+                index_dim = self.dimension,
+                "rabitq.idx dimension mismatch; quantizer not installed"
+            );
+            return Ok(());
+        }
         inner
             .install_trained_rabitq(std::sync::Arc::new(rabitq))
             .map_err(std::io::Error::other)?;
@@ -426,5 +437,10 @@ impl HnswIndex {
     #[must_use]
     pub(crate) fn is_rabitq_quantizer_trained(&self) -> bool {
         self.inner.read().is_rabitq_quantizer_trained()
+    }
+
+    /// Returns `true` when this index runs the `RaBitQ` backend.
+    pub(crate) fn is_rabitq_backend(&self) -> bool {
+        self.inner.read().is_rabitq_backend()
     }
 }

--- a/crates/velesdb-core/src/index/hnsw/index/vacuum.rs
+++ b/crates/velesdb-core/src/index/hnsw/index/vacuum.rs
@@ -118,28 +118,9 @@ impl HnswIndex {
             return Ok(0);
         }
 
-        // 2. Create new HNSW graph with auto-tuned parameters
-        let params = HnswParams::auto(self.dimension);
-        let new_inner = HnswInner::new(
-            self.metric,
-            params.max_connections,
-            count.max(1000), // max_elements with reasonable minimum
-            params.ef_construction,
-            self.dimension,
-        )
-        .map_err(|e| VacuumError::RebuildFailed(e.to_string()))?;
-
-        // 3. Build HNSW insertion references (idx = sequential, matches graph allocation)
-        let refs_for_hnsw: Vec<(&[f32], usize)> = active_vectors
-            .iter()
-            .enumerate()
-            .map(|(idx, (_id, vec))| (vec.as_slice(), idx))
-            .collect();
-
-        // 4. Parallel insert into new HNSW
-        new_inner
-            .parallel_insert(&refs_for_hnsw)
-            .map_err(|e| VacuumError::RebuildFailed(e.to_string()))?;
+        // 2-4. Rebuild a fresh inner index from the active vectors,
+        // preserving the backend storage mode and trained quantizer.
+        let new_inner = self.build_vacuum_replacement(&active_vectors)?;
 
         // 5. Atomic swap (replace old with new)
         {
@@ -174,5 +155,50 @@ impl HnswIndex {
         }
 
         Ok(count)
+    }
+
+    /// Builds the replacement inner index for [`Self::vacuum`].
+    ///
+    /// Creates a new graph with auto-tuned parameters, **preserving the
+    /// current backend storage mode** (a RaBitQ index must not silently
+    /// downgrade to the Standard f32 backend on vacuum), inserts the active
+    /// vectors, and re-installs the trained RaBitQ quantizer when present
+    /// (re-encodes the compacted vectors in NodeId order — without this, a
+    /// vacuumed RaBitQ index would fall back to f32 search until the next
+    /// collection open).
+    fn build_vacuum_replacement(
+        &self,
+        active_vectors: &[(u64, Vec<f32>)],
+    ) -> Result<HnswInner, VacuumError> {
+        let params = HnswParams::auto(self.dimension);
+        let new_inner = HnswInner::new_with_storage_mode(
+            self.metric,
+            params.max_connections,
+            active_vectors.len().max(1000), // max_elements with reasonable minimum
+            params.ef_construction,
+            self.dimension,
+            self.inner.read().storage_mode(),
+        )
+        .map_err(|e| VacuumError::RebuildFailed(e.to_string()))?;
+
+        // Insertion references: idx = sequential, matches graph allocation.
+        let refs_for_hnsw: Vec<(&[f32], usize)> = active_vectors
+            .iter()
+            .enumerate()
+            .map(|(idx, (_id, vec))| (vec.as_slice(), idx))
+            .collect();
+
+        new_inner
+            .parallel_insert(&refs_for_hnsw)
+            .map_err(|e| VacuumError::RebuildFailed(e.to_string()))?;
+
+        #[cfg(feature = "persistence")]
+        if let Some(rabitq) = self.inner.read().rabitq_quantizer() {
+            new_inner
+                .install_trained_rabitq(rabitq)
+                .map_err(|e| VacuumError::RebuildFailed(e.to_string()))?;
+        }
+
+        Ok(new_inner)
     }
 }

--- a/crates/velesdb-core/src/index/hnsw/index/vacuum.rs
+++ b/crates/velesdb-core/src/index/hnsw/index/vacuum.rs
@@ -171,13 +171,19 @@ impl HnswIndex {
         active_vectors: &[(u64, Vec<f32>)],
     ) -> Result<HnswInner, VacuumError> {
         let params = HnswParams::auto(self.dimension);
+        let target_mode = self.inner.read().storage_mode();
+        // Always rebuild through a Standard backend: inserting via a RaBitQ
+        // backend would lazily train a throwaway quantizer at the sample
+        // threshold (then re-encode everything a second time on install) —
+        // and would silently SELF-train an untrained collection from
+        // compaction order. The graph is promoted afterwards.
         let new_inner = HnswInner::new_with_storage_mode(
             self.metric,
             params.max_connections,
             active_vectors.len().max(1000), // max_elements with reasonable minimum
             params.ef_construction,
             self.dimension,
-            self.inner.read().storage_mode(),
+            crate::StorageMode::Full,
         )
         .map_err(|e| VacuumError::RebuildFailed(e.to_string()))?;
 
@@ -192,8 +198,14 @@ impl HnswIndex {
             .parallel_insert(&refs_for_hnsw)
             .map_err(|e| VacuumError::RebuildFailed(e.to_string()))?;
 
+        if target_mode != crate::StorageMode::RaBitQ {
+            return Ok(new_inner);
+        }
+        let new_inner = new_inner.promote_to_rabitq(self.dimension);
         #[cfg(feature = "persistence")]
         if let Some(rabitq) = self.inner.read().rabitq_quantizer() {
+            // Single encode pass with the carried-over quantizer; an
+            // untrained collection stays untrained (no state change).
             new_inner
                 .install_trained_rabitq(rabitq)
                 .map_err(|e| VacuumError::RebuildFailed(e.to_string()))?;

--- a/crates/velesdb-core/src/index/hnsw/index_tests.rs
+++ b/crates/velesdb-core/src/index/hnsw/index_tests.rs
@@ -3299,3 +3299,52 @@ mod full_scan_property_tests {
         }
     }
 }
+
+// =========================================================================
+// RaBitQ storage-mode save/load round-trip (quantization wiring)
+// =========================================================================
+
+/// `save` must persist the actual backend storage mode (not hardcoded Full)
+/// and `load` must rebuild the RaBitQ backend and install `rabitq.idx`.
+#[cfg(feature = "persistence")]
+#[test]
+fn test_hnsw_save_load_roundtrips_rabitq_backend_and_quantizer() {
+    use crate::quantization::{RaBitQIndex, StorageMode};
+
+    let dir = tempfile::tempdir().expect("temp dir");
+    let dim = 32;
+    let mut params = HnswParams::auto(dim);
+    params.storage_mode = StorageMode::RaBitQ;
+    let index = HnswIndex::with_params(dim, DistanceMetric::Euclidean, params).expect("create");
+
+    let vectors: Vec<Vec<f32>> = (0..200)
+        .map(|i| {
+            (0..dim)
+                .map(|d| ((i * dim + d) as f32 * 0.01).sin())
+                .collect()
+        })
+        .collect();
+    for (i, v) in vectors.iter().enumerate() {
+        VectorIndex::insert(&index, i as u64, v);
+    }
+
+    // Persist a trained quantizer next to the index (what TRAIN QUANTIZER does).
+    RaBitQIndex::train(&vectors, 42)
+        .expect("train")
+        .save(dir.path())
+        .expect("save rabitq.idx");
+    index.save(dir.path()).expect("save index");
+
+    let loaded = HnswIndex::load(dir.path(), dim, DistanceMetric::Euclidean).expect("load");
+    assert!(
+        loaded.is_rabitq_quantizer_trained(),
+        "persisted storage mode + rabitq.idx must restore a trained RaBitQ backend"
+    );
+
+    let results = VectorIndex::search(&loaded, &vectors[42], 5);
+    assert_eq!(
+        results.first().map(|r| r.id),
+        Some(42),
+        "self-query must return itself as top-1 after reload"
+    );
+}

--- a/crates/velesdb-core/src/index/hnsw/native/rabitq_precision.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/rabitq_precision.rs
@@ -74,6 +74,13 @@ pub struct RaBitQPrecisionHnsw<D: DistanceEngine> {
     training_sample_size: usize,
     /// Buffer for vectors awaiting quantizer training.
     training_buffer: Mutex<Vec<Vec<f32>>>,
+    /// Serializes quantizer installation/training against in-flight inserts.
+    ///
+    /// Inserts hold it for read across their whole body; `train_rabitq` and
+    /// `install_trained_rabitq` hold it for write, so a store rebuild can
+    /// never miss an insert that already passed the trained-quantizer check
+    /// (which would shift every subsequent positional store entry).
+    install_gate: RwLock<()>,
 }
 
 impl<D: DistanceEngine> RaBitQPrecisionHnsw<D> {
@@ -127,6 +134,7 @@ impl<D: DistanceEngine> RaBitQPrecisionHnsw<D> {
             dimension,
             training_sample_size: 1000.min(max_elements),
             training_buffer: Mutex::new(Vec::with_capacity(1000)),
+            install_gate: RwLock::new(()),
         })
     }
 
@@ -143,6 +151,7 @@ impl<D: DistanceEngine> RaBitQPrecisionHnsw<D> {
             dimension,
             training_sample_size: 1000,
             training_buffer: Mutex::new(Vec::with_capacity(1000)),
+            install_gate: RwLock::new(()),
         }
     }
 
@@ -177,33 +186,59 @@ impl<D: DistanceEngine> RaBitQPrecisionHnsw<D> {
     pub fn insert(&self, vector: &[f32]) -> crate::error::Result<NodeId> {
         debug_assert_eq!(vector.len(), self.dimension);
 
-        let index_guard = self.rabitq_index.read();
-        if let Some(rabitq) = index_guard.as_ref().map(Arc::clone) {
-            // Drop read lock BEFORE encoding — holding it blocks training.
-            drop(index_guard);
-            let encoded = rabitq.encode(vector)?;
-            if let Some(store) = self.rabitq_store.write().as_mut() {
-                store.push(&encoded.bits, encoded.correction);
+        let (node_id, train_due) = {
+            // Hold the install gate (read) for the whole insert so a
+            // concurrent quantizer install/training cannot snapshot the
+            // graph between our trained-check and our graph insert.
+            let _gate = self.install_gate.read();
+            let index_guard = self.rabitq_index.read();
+            if let Some(rabitq) = index_guard.as_ref().map(Arc::clone) {
+                // Drop read lock BEFORE encoding — holding it blocks training.
+                drop(index_guard);
+                (self.insert_encoded(&rabitq, vector)?, false)
+            } else {
+                drop(index_guard);
+                self.insert_training_phase(vector)?
             }
-        } else {
-            drop(index_guard);
-            self.insert_training_phase(vector)?;
+        };
+        // Train OUTSIDE the read gate: train_rabitq takes the gate for
+        // write, which must wait for every in-flight insert (including this
+        // one) to finish.
+        if train_due {
+            self.train_rabitq()?;
         }
+        Ok(node_id)
+    }
 
-        self.inner.insert(vector)
+    /// Trained-path insert: encodes the vector and pushes the encoding while
+    /// HOLDING the store lock across the graph insert, so the positional
+    /// store entry always lands at exactly the assigned `NodeId` even under
+    /// concurrent inserts.
+    fn insert_encoded(&self, rabitq: &RaBitQIndex, vector: &[f32]) -> crate::error::Result<NodeId> {
+        let encoded = rabitq.encode(vector)?;
+        // Lock order: rabitq_store (write) before the inner graph locks —
+        // same relative order as the search path (store.read → vectors.read).
+        let mut store_guard = self.rabitq_store.write();
+        let node_id = self.inner.insert(vector)?;
+        if let Some(store) = store_guard.as_mut() {
+            store.push(&encoded.bits, encoded.correction);
+        }
+        Ok(node_id)
     }
 
     /// Handles insert during the pre-training phase.
     ///
-    /// Buffers the vector and triggers training when the sample size is reached.
-    fn insert_training_phase(&self, vector: &[f32]) -> crate::error::Result<()> {
+    /// Buffers the vector while HOLDING the buffer lock across the graph
+    /// insert so the buffer order equals the `NodeId` order — `train_rabitq`
+    /// builds the positional store from that buffer. Returns the node id and
+    /// whether the training threshold was reached (the caller trains after
+    /// releasing the install gate).
+    fn insert_training_phase(&self, vector: &[f32]) -> crate::error::Result<(NodeId, bool)> {
         let mut buffer = self.training_buffer.lock();
+        let node_id = self.inner.insert(vector)?;
         buffer.push(vector.to_vec());
-        if buffer.len() >= self.training_sample_size {
-            drop(buffer);
-            self.train_rabitq()?;
-        }
-        Ok(())
+        let train_due = buffer.len() >= self.training_sample_size;
+        Ok((node_id, train_due))
     }
 
     /// Searches for k nearest neighbors using `RaBitQ`-precision.
@@ -286,16 +321,18 @@ impl<D: DistanceEngine> RaBitQPrecisionHnsw<D> {
     /// `inner.vectors` while waiting on the store lock (a search thread
     /// holds `rabitq_store.read()` while acquiring `inner.vectors.read()`).
     ///
-    /// An insert that passed the untrained `rabitq_index` check but has not
-    /// reached `inner.insert` yet is not re-encoded; its node falls back to
-    /// exact f32 scoring during traversal — the same window that exists for
-    /// lazy `train_rabitq`.
+    /// The install gate (write) is taken first: every in-flight insert holds
+    /// it for read across its whole body, so the snapshot can never miss an
+    /// insert that already passed the trained-quantizer check — the store is
+    /// positional (entry N = node N) and a single missed push would shift
+    /// every subsequent encoding onto the wrong node.
     ///
     /// # Errors
     ///
     /// Returns an error if encoding any stored vector fails (e.g. dimension
     /// mismatch between the quantizer and this index).
     pub fn install_trained_rabitq(&self, rabitq: Arc<RaBitQIndex>) -> crate::error::Result<()> {
+        let _gate = self.install_gate.write();
         let mut index_guard = self.rabitq_index.write();
         let store = self.encode_all_in_node_order(&rabitq)?;
 
@@ -348,6 +385,10 @@ impl<D: DistanceEngine> RaBitQPrecisionHnsw<D> {
     /// training races.
     #[cfg(feature = "persistence")]
     fn train_rabitq(&self) -> crate::error::Result<()> {
+        // The install gate (write) waits for every in-flight insert, so the
+        // drained buffer is complete and its order equals the NodeId order
+        // (inserts hold the buffer lock across their graph insert).
+        let _gate = self.install_gate.write();
         // Re-check under write lock: another thread may have trained already
         let mut index_guard = self.rabitq_index.write();
         if index_guard.is_some() {

--- a/crates/velesdb-core/src/index/hnsw/native/rabitq_precision.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/rabitq_precision.rs
@@ -251,6 +251,92 @@ impl<D: DistanceEngine> RaBitQPrecisionHnsw<D> {
         }
         Ok(())
     }
+
+    /// Returns the trained `RaBitQ` quantizer, if any.
+    ///
+    /// Used by vacuum/rebuild paths to carry the trained rotation over to a
+    /// freshly built backend via [`Self::install_trained_rabitq`].
+    #[must_use]
+    pub fn trained_quantizer(&self) -> Option<Arc<RaBitQIndex>> {
+        self.rabitq_index.read().clone()
+    }
+
+    /// Installs a pre-trained `RaBitQ` quantizer (e.g. loaded from
+    /// `rabitq.idx` or trained by `TRAIN QUANTIZER`) and re-encodes EVERY
+    /// vector currently in the graph into a fresh store.
+    ///
+    /// Replaces any previously installed quantizer/store (force-retrain
+    /// semantics). The store is rebuilt in `NodeId` order `0..len` because
+    /// `search_layer_rabitq` indexes the store by node id.
+    ///
+    /// # Cost
+    ///
+    /// O(n·d) — one rotation + encode per stored vector. At collection open
+    /// this is the same cost class as HNSW gap recovery.
+    ///
+    /// # Locking
+    ///
+    /// Holds `rabitq_index.write()` for the whole re-encode so concurrent
+    /// inserts (which take `rabitq_index.read()` first) cannot interleave
+    /// store pushes with the rebuild. Inside that critical section the
+    /// vectors snapshot is read and RELEASED before `rabitq_store.write()`
+    /// is taken, preserving the documented order
+    /// `rabitq_index → rabitq_store → training_buffer`
+    /// (see `docs/CONCURRENCY_MODEL.md` §RaBitQ) and never holding
+    /// `inner.vectors` while waiting on the store lock (a search thread
+    /// holds `rabitq_store.read()` while acquiring `inner.vectors.read()`).
+    ///
+    /// An insert that passed the untrained `rabitq_index` check but has not
+    /// reached `inner.insert` yet is not re-encoded; its node falls back to
+    /// exact f32 scoring during traversal — the same window that exists for
+    /// lazy `train_rabitq`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if encoding any stored vector fails (e.g. dimension
+    /// mismatch between the quantizer and this index).
+    pub fn install_trained_rabitq(&self, rabitq: Arc<RaBitQIndex>) -> crate::error::Result<()> {
+        let mut index_guard = self.rabitq_index.write();
+        let store = self.encode_all_in_node_order(&rabitq)?;
+
+        // Store MUST be visible before index — same ordering contract as
+        // train_rabitq (search checks the index first).
+        *self.rabitq_store.write() = Some(store);
+        *index_guard = Some(rabitq);
+
+        // Buffered pre-training vectors are already in `inner` and were
+        // re-encoded above; clear the buffer so it cannot retrain over the
+        // installed quantizer.
+        let mut buffer = self.training_buffer.lock();
+        buffer.clear();
+        buffer.shrink_to_fit();
+        Ok(())
+    }
+
+    /// Encodes every vector in `inner` (`NodeId` order `0..len`) into a
+    /// fresh [`RaBitQVectorStore`].
+    ///
+    /// The vectors read guard is dropped when this returns — callers must
+    /// not assume it is still held.
+    fn encode_all_in_node_order(
+        &self,
+        rabitq: &RaBitQIndex,
+    ) -> crate::error::Result<RaBitQVectorStore> {
+        let vectors_guard = self.inner.vectors.read();
+        let Some(vectors) = vectors_guard.as_ref() else {
+            return Ok(RaBitQVectorStore::new(self.dimension, 1000));
+        };
+        let count = vectors.len();
+        let mut store = RaBitQVectorStore::new(self.dimension, count + 1000);
+        for node_id in 0..count {
+            let Some(vector) = vectors.get(node_id) else {
+                break;
+            };
+            let encoded = rabitq.encode(vector)?;
+            store.push(&encoded.bits, encoded.correction);
+        }
+        Ok(store)
+    }
 }
 
 // --- Private training and search implementation ---

--- a/crates/velesdb-core/src/index/hnsw/native/rabitq_precision_tests.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/rabitq_precision_tests.rs
@@ -138,6 +138,105 @@ fn test_rabitq_precision_insert_after_training() {
 }
 
 // =========================================================================
+// install_trained_rabitq (quantization wiring across restarts)
+// =========================================================================
+
+/// Builds `n` sinusoidal vectors of dimension `dim`.
+#[cfg(feature = "persistence")]
+fn sinusoidal_vectors(n: usize, dim: usize) -> Vec<Vec<f32>> {
+    (0..n)
+        .map(|i| {
+            (0..dim)
+                .map(|j| ((i * dim + j) as f32 * 0.01).sin())
+                .collect()
+        })
+        .collect()
+}
+
+/// Installing a pre-trained quantizer must encode every existing vector
+/// (store rebuilt in NodeId order) and activate RaBitQ search with recall
+/// parity against the f32 baseline.
+#[cfg(feature = "persistence")]
+#[test]
+fn test_install_trained_rabitq_encodes_existing_vectors() {
+    use crate::quantization::RaBitQIndex;
+    use std::collections::HashSet;
+    use std::sync::Arc;
+
+    let (dim, n, k) = (64, 200, 10);
+    let engine = CachedSimdDistance::new(DistanceMetric::Euclidean, dim);
+    let hnsw = RaBitQPrecisionHnsw::new(engine, dim, 16, 200, 1000).expect("test");
+
+    let vectors = sinusoidal_vectors(n, dim);
+    for v in &vectors {
+        hnsw.insert(v).expect("insert");
+    }
+    assert!(!hnsw.is_quantizer_trained(), "below lazy-train threshold");
+
+    let query = &vectors[42];
+    let baseline: HashSet<usize> = hnsw
+        .search(query, k, 100)
+        .iter()
+        .map(|&(id, _)| id)
+        .collect();
+
+    let rabitq = RaBitQIndex::train(&vectors, 42).expect("train");
+    hnsw.install_trained_rabitq(Arc::new(rabitq))
+        .expect("install");
+    assert!(hnsw.is_quantizer_trained());
+
+    let results = hnsw.search(query, k, 100);
+    assert_eq!(results.len(), k);
+    assert_eq!(results[0].0, 42, "self-query must return itself as top-1");
+
+    let ids: HashSet<usize> = results.iter().map(|&(id, _)| id).collect();
+    let overlap = baseline.intersection(&ids).count();
+    #[allow(clippy::cast_precision_loss)]
+    let recall = overlap as f64 / k as f64;
+    assert!(
+        recall >= 0.7,
+        "RaBitQ results should overlap f32 baseline (recall sanity), got {recall:.2}"
+    );
+}
+
+/// Inserts after install must stay aligned with NodeId order: the store was
+/// rebuilt for nodes `0..n`, so node `n` (first post-install insert) must be
+/// encoded at store position `n` and remain searchable.
+#[cfg(feature = "persistence")]
+#[test]
+fn test_install_trained_rabitq_then_insert_keeps_alignment() {
+    use crate::quantization::RaBitQIndex;
+    use std::sync::Arc;
+
+    let (dim, n) = (64, 120);
+    let engine = CachedSimdDistance::new(DistanceMetric::Euclidean, dim);
+    let hnsw = RaBitQPrecisionHnsw::new(engine, dim, 16, 200, 1000).expect("test");
+
+    let vectors = sinusoidal_vectors(n + 30, dim);
+    for v in &vectors[..n] {
+        hnsw.insert(v).expect("insert");
+    }
+
+    let rabitq = RaBitQIndex::train(&vectors[..n], 42).expect("train");
+    hnsw.install_trained_rabitq(Arc::new(rabitq))
+        .expect("install");
+
+    for v in &vectors[n..] {
+        hnsw.insert(v).expect("post-install insert");
+    }
+    assert_eq!(hnsw.len(), n + 30);
+
+    // Self-query on a post-install vector: top-1 must be its own node id.
+    let target = n + 15;
+    let results = hnsw.search(&vectors[target], 5, 100);
+    assert_eq!(
+        results.first().map(|&(id, _)| id),
+        Some(target),
+        "post-install vector must be searchable at its node id"
+    );
+}
+
+// =========================================================================
 // Recall test (EPIC-055)
 // =========================================================================
 

--- a/crates/velesdb-core/src/index/hnsw/native_inner.rs
+++ b/crates/velesdb-core/src/index/hnsw/native_inner.rs
@@ -163,6 +163,36 @@ impl NativeHnswInner {
     /// Returns true when the backend is `RaBitQ` with a trained quantizer.
     #[cfg(feature = "persistence")]
     #[must_use]
+    /// Returns `true` when this index runs the `RaBitQ` backend.
+    pub fn is_rabitq_backend(&self) -> bool {
+        matches!(self.backend, HnswBackend::RaBitQ(_))
+    }
+
+    /// Converts a Standard backend into an (untrained) `RaBitQ` backend.
+    ///
+    /// Vacuum rebuilds insert through a Standard graph so lazy quantizer
+    /// training can never fire mid-rebuild (it would train a throwaway
+    /// quantizer from compaction order); the caller promotes afterwards and
+    /// installs the carried-over quantizer, if any. A backend that is
+    /// already `RaBitQ` is returned unchanged.
+    pub fn promote_to_rabitq(self, dimension: usize) -> Self {
+        match self.backend {
+            HnswBackend::Standard(inner) => {
+                let distance = CachedSimdDistance::new(self.metric, dimension);
+                Self {
+                    backend: HnswBackend::RaBitQ(Box::new(RaBitQPrecisionHnsw::from_inner(
+                        inner, distance, dimension,
+                    ))),
+                    metric: self.metric,
+                }
+            }
+            backend @ HnswBackend::RaBitQ(_) => Self {
+                backend,
+                metric: self.metric,
+            },
+        }
+    }
+
     pub fn is_rabitq_quantizer_trained(&self) -> bool {
         matches!(&self.backend, HnswBackend::RaBitQ(precision) if precision.is_quantizer_trained())
     }

--- a/crates/velesdb-core/src/index/hnsw/native_inner.rs
+++ b/crates/velesdb-core/src/index/hnsw/native_inner.rs
@@ -46,31 +46,6 @@ pub struct NativeHnswInner {
 }
 
 impl NativeHnswInner {
-    /// Creates a new `NativeHnswInner` with the specified metric and parameters.
-    ///
-    /// Uses the default VAMANA alpha (1.2) for neighbor diversification.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if vector storage pre-allocation fails.
-    pub fn new(
-        metric: DistanceMetric,
-        max_connections: usize,
-        max_elements: usize,
-        ef_construction: usize,
-        dimension: usize,
-    ) -> crate::error::Result<Self> {
-        Self::new_with_options(
-            metric,
-            max_connections,
-            max_elements,
-            ef_construction,
-            dimension,
-            crate::StorageMode::Full,
-            DEFAULT_ALPHA,
-        )
-    }
-
     /// Creates a new `NativeHnswInner` with a specific storage mode.
     ///
     /// When `storage_mode` is [`StorageMode::RaBitQ`], the backend uses binary
@@ -79,7 +54,6 @@ impl NativeHnswInner {
     /// # Errors
     ///
     /// Returns an error if vector storage pre-allocation fails.
-    #[allow(dead_code)] // Reason: Convenience constructor — public API surface for callers
     pub fn new_with_storage_mode(
         metric: DistanceMetric,
         max_connections: usize,
@@ -159,6 +133,50 @@ impl NativeHnswInner {
         match &self.backend {
             HnswBackend::Standard(_) => crate::StorageMode::Full,
             HnswBackend::RaBitQ(_) => crate::StorageMode::RaBitQ,
+        }
+    }
+
+    /// Installs a pre-trained `RaBitQ` quantizer into the `RaBitQ` backend,
+    /// re-encoding every stored vector in `NodeId` order.
+    ///
+    /// Returns `Ok(true)` when installed, `Ok(false)` when the backend is
+    /// Standard (no-op — the wiring takes effect at the next open, once the
+    /// backend is rebuilt as `RaBitQ` from the collection storage mode).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if re-encoding a stored vector fails.
+    #[cfg(feature = "persistence")]
+    pub fn install_trained_rabitq(
+        &self,
+        rabitq: std::sync::Arc<crate::quantization::RaBitQIndex>,
+    ) -> crate::error::Result<bool> {
+        match &self.backend {
+            HnswBackend::Standard(_) => Ok(false),
+            HnswBackend::RaBitQ(precision) => {
+                precision.install_trained_rabitq(rabitq)?;
+                Ok(true)
+            }
+        }
+    }
+
+    /// Returns true when the backend is `RaBitQ` with a trained quantizer.
+    #[cfg(feature = "persistence")]
+    #[must_use]
+    pub fn is_rabitq_quantizer_trained(&self) -> bool {
+        matches!(&self.backend, HnswBackend::RaBitQ(precision) if precision.is_quantizer_trained())
+    }
+
+    /// Returns the trained `RaBitQ` quantizer, if any.
+    ///
+    /// Used by vacuum to carry the trained rotation over to the rebuilt
+    /// backend via [`Self::install_trained_rabitq`].
+    #[cfg(feature = "persistence")]
+    #[must_use]
+    pub fn rabitq_quantizer(&self) -> Option<std::sync::Arc<crate::quantization::RaBitQIndex>> {
+        match &self.backend {
+            HnswBackend::Standard(_) => None,
+            HnswBackend::RaBitQ(precision) => precision.trained_quantizer(),
         }
     }
 }
@@ -345,31 +363,12 @@ impl NativeHnswInner {
         }
     }
 
-    /// Loads the HNSW graph from files.
-    ///
-    /// When `storage_mode` is [`StorageMode::RaBitQ`], wraps the loaded graph
-    /// in a `RaBitQPrecisionHnsw`. The quantizer trains lazily after enough
-    /// new vectors are inserted.
-    ///
-    /// # Errors
-    ///
-    /// Returns `io::Error` if file operations fail or data is corrupted.
-    pub fn file_load(
-        path: &Path,
-        basename: &str,
-        metric: DistanceMetric,
-        dimension: usize,
-    ) -> std::io::Result<Self> {
-        let distance = CachedSimdDistance::new(metric, dimension);
-        let inner = NativeHnsw::file_load(path, basename, distance)?;
-
-        Ok(Self {
-            backend: HnswBackend::Standard(inner),
-            metric,
-        })
-    }
-
     /// Loads the HNSW graph with a specific storage mode.
+    ///
+    /// When `storage_mode` is [`crate::StorageMode::RaBitQ`], wraps the
+    /// loaded graph in a `RaBitQPrecisionHnsw`. The quantizer is NOT trained
+    /// here — callers restore a persisted quantizer via
+    /// [`Self::install_trained_rabitq`] or let it train lazily from inserts.
     ///
     /// # Errors
     ///

--- a/crates/velesdb-core/src/index/hnsw/params.rs
+++ b/crates/velesdb-core/src/index/hnsw/params.rs
@@ -34,13 +34,16 @@ pub struct HnswParams {
     pub ef_construction: usize,
     /// Initial capacity (grows automatically if exceeded).
     pub max_elements: usize,
-    /// Vector storage mode (Full, SQ8, or Binary).
+    /// Vector storage mode (Full, SQ8, Binary, PQ, or `RaBitQ`).
     ///
-    /// Note: the collection path currently forces `Full` storage and keeps
-    /// quantized SQ8/Binary representations as an **additional** cache that
-    /// no production search path reads — selecting SQ8 there adds memory
-    /// rather than reducing it. The 4x-reduction figure applies only to a
-    /// backend that stores quantized vectors *instead of* f32.
+    /// `RaBitQ` selects the binary-traversal HNSW backend (32x bandwidth
+    /// reduction during graph traversal, f32 re-ranking), persisted and
+    /// restored across reopens. PQ enables the ADC rescore path once a
+    /// codebook is trained (`TRAIN QUANTIZER`). SQ8/Binary currently keep
+    /// quantized representations as an **additional** cache that no
+    /// production search path reads — selecting them adds memory rather
+    /// than reducing it; the 4x-reduction figure applies only to a backend
+    /// that stores quantized vectors *instead of* f32.
     #[serde(default)]
     pub storage_mode: StorageMode,
     /// VAMANA alpha for neighbor diversification (default: 1.2).

--- a/crates/velesdb-core/src/quantization/mod.rs
+++ b/crates/velesdb-core/src/quantization/mod.rs
@@ -14,10 +14,12 @@
 //!
 //! The figures above describe the quantization primitives themselves. In the
 //! collection query path: `RaBitQ` (binary traversal backend) and PQ (ADC
-//! rescoring) are wired end-to-end, including persistence across reopens.
-//! SQ8/Binary collection modes currently maintain caches that no search path
-//! consumes — collection search stays full-precision f32 for those modes.
-//! See `docs/guides/QUANTIZATION.md`.
+//! rescoring) are wired end-to-end. Persistence across reopens covers
+//! TRAIN-QUANTIZER-produced artifacts (`rabitq.idx`, `codebook.pq`); a PQ
+//! quantizer trained lazily from inserts (no TRAIN statement) is in-memory
+//! only and retrains after a restart. SQ8/Binary collection modes currently
+//! maintain caches that no search path consumes — collection search stays
+//! full-precision f32 for those modes. See `docs/guides/QUANTIZATION.md`.
 
 use std::io;
 

--- a/crates/velesdb-core/src/quantization/mod.rs
+++ b/crates/velesdb-core/src/quantization/mod.rs
@@ -9,6 +9,15 @@
 //! | RAM/vector (768d) | 3 KB | 770 bytes | 96 bytes |
 //! | Cache efficiency | Baseline | ~4x better | ~32x better |
 //! | Recall loss | 0% | ~0.5-1% | ~5-10% |
+//!
+//! ## Engine integration status
+//!
+//! The figures above describe the quantization primitives themselves. In the
+//! collection query path: `RaBitQ` (binary traversal backend) and PQ (ADC
+//! rescoring) are wired end-to-end, including persistence across reopens.
+//! SQ8/Binary collection modes currently maintain caches that no search path
+//! consumes — collection search stays full-precision f32 for those modes.
+//! See `docs/guides/QUANTIZATION.md`.
 
 use std::io;
 

--- a/docs/CONCURRENCY_MODEL.md
+++ b/docs/CONCURRENCY_MODEL.md
@@ -202,6 +202,15 @@ training function uses a **double-check locking** pattern: it first checks
 `rabitq_index` under a read lock, and if training is needed, re-checks
 under a write lock to prevent duplicate training from concurrent threads.
 
+`install_trained_rabitq()` (quantizer restore at open / `TRAIN QUANTIZER`
+live install) follows the same `rabitq_index → rabitq_store →
+training_buffer` order. It holds `rabitq_index.write()` for the whole
+re-encode so concurrent inserts cannot interleave store pushes, and it
+reads the `inner.vectors` snapshot **and releases it** before taking
+`rabitq_store.write()` — never waiting on the store lock while holding
+`vectors` (a search thread holds `rabitq_store.read()` while acquiring
+`inner.vectors.read()`).
+
 ### Store-Before-Index Ordering
 
 When training completes, the store is set BEFORE the index:

--- a/docs/VELESQL_SPEC.md
+++ b/docs/VELESQL_SPEC.md
@@ -2480,6 +2480,15 @@ TRAIN QUANTIZER ON my_collection WITH (m = 8, k = 256);
 - The collection must contain enough vectors (recommended: at least `k`).
 - Re-training overwrites the existing quantizer.
 - OPQ can be enabled via the `type` parameter.
+- Trained quantizers are persisted in the collection directory
+  (`codebook.pq` / `rotation.opq` for PQ/OPQ, `rabitq.idx` for RaBitQ) and
+  restored on database open: the PQ cache and RaBitQ encodings are rebuilt
+  by re-encoding the stored vectors (O(n) at open).
+- `type = rabitq` also installs the trained quantizer into the live index
+  when the collection was created with `storage = 'rabitq'`. For
+  collections created with another storage mode, training persists the
+  index and flips the collection's storage mode; the RaBitQ backend takes
+  effect at the next open.
 
 ---
 

--- a/docs/guides/QUANTIZATION.md
+++ b/docs/guides/QUANTIZATION.md
@@ -19,7 +19,14 @@ La **quantization** permet de réduire la taille des vecteurs en mémoire tout e
 
 ## 🚀 SQ8 : Compression 4x
 
-### Comment ça marche ?
+> **Statut : cache non consommé par la recherche des collections.**
+> Une collection en mode `storage='sq8'` maintient un cache de vecteurs
+> quantifiés SQ8 à l'insertion, mais aucun chemin de recherche ne lit ce
+> cache aujourd'hui : les requêtes s'exécutent en pleine précision f32.
+> Choisir SQ8 au niveau collection AJOUTE donc de la mémoire au lieu d'en
+> réduire, en attendant un mode de stockage à mémoire réduite. Les
+> primitives SQ8 ci-dessous (`QuantizedVector`, distances SIMD) sont, elles,
+> pleinement fonctionnelles pour un usage programmatique direct.
 
 Chaque valeur `f32` (4 octets) est convertie en `u8` (1 octet) :
 
@@ -58,7 +65,12 @@ println!("Mémoire économisée: {}%",
 
 ## ⚡ Binary : Compression 32x
 
-### Comment ça marche ?
+> **Statut : cache non consommé par la recherche des collections.**
+> Comme SQ8 : le mode `storage='binary'` remplit un cache de vecteurs
+> binaires qu'aucun chemin de recherche ne lit (recherche en f32 pleine
+> précision). Pour une compression 32x effective dans le chemin de requête,
+> utiliser RaBitQ. Les primitives `BinaryQuantizedVector` restent
+> utilisables en direct.
 
 Chaque valeur `f32` devient **1 bit** :
 - Valeur ≥ 0 → 1
@@ -129,13 +141,22 @@ TRAIN QUANTIZER ON my_collection WITH (m=8, k=256)
 
 L'entrainement est **explicite** : il ne se declenche pas automatiquement. La collection doit contenir suffisamment de vecteurs (au minimum k vecteurs recommandes).
 
+**Persistance** : `TRAIN QUANTIZER` sauvegarde le codebook (`codebook.pq`,
+plus `rotation.opq` pour OPQ) dans le repertoire de la collection. A la
+reouverture, le codebook est recharge et le cache PQ est reconstruit en
+re-encodant tous les vecteurs stockes (cout O(n) a l'ouverture) — le
+rescoring ADC survit donc aux redemarrages. Note : le quantizer entraine
+paresseusement a l'insertion (mode `storage='pq'` sans `TRAIN QUANTIZER`)
+n'est PAS persiste ; seul `TRAIN QUANTIZER` ecrit le codebook sur disque.
+
 ### Entrainement via Rust
 
 ```rust
 use velesdb_core::quantization::ProductQuantizer;
 
 let pq = ProductQuantizer::train(&vectors, m, k)?;
-// Le quantizer est sauvegarde automatiquement sur disque
+// Persistance explicite (TRAIN QUANTIZER le fait automatiquement) :
+pq.save_codebook(collection_dir)?;
 ```
 
 ### OPQ (Optimized Product Quantization)
@@ -165,13 +186,17 @@ OPQ applique une rotation orthogonale aux vecteurs avant la quantification PQ. C
 
 ## RaBitQ : Randomized Binary Quantization (32x)
 
-> **Statut : non branché dans le chemin de requête des collections.**
-> `TRAIN QUANTIZER 'rabitq'` entraîne et persiste `rabitq.idx`, mais aucun
-> chemin de recherche de collection ne charge cet index aujourd'hui : les
-> recherches continuent sur les vecteurs f32 (les collections forcent le mode
-> de stockage `Full`). Le backend RaBitQ existe au niveau de l'API d'index
-> (`RaBitQPrecisionHnsw`) pour un usage programmatique direct. Les chiffres de
-> recall ci-dessous décrivent cette API, pas une requête `SELECT` standard.
+> **Statut : branché de bout en bout dans le chemin de requête des
+> collections, redémarrages compris.**
+> Une collection créée avec `storage='rabitq'` utilise le backend HNSW à
+> traversée binaire (`RaBitQPrecisionHnsw`). `TRAIN QUANTIZER` avec
+> `type=rabitq` entraîne le quantizer, le persiste dans `rabitq.idx` ET
+> l'installe immédiatement dans l'index vivant (ré-encodage O(n·d) des
+> vecteurs existants). À la réouverture, `rabitq.idx` est rechargé et les
+> vecteurs sont ré-encodés (coût O(n·d) à l'ouverture, même classe que la
+> gap recovery HNSW). Si la collection a été créée avec un autre mode de
+> stockage, l'entraînement persiste l'index et bascule la config ; le
+> backend RaBitQ prend effet à la prochaine ouverture.
 
 ### Comment ca marche ?
 
@@ -240,6 +265,11 @@ Apres:   [0b10100110, ...]      → 768 / 8 = 96 octets
 | **Haute compression + bon recall** | RaBitQ |
 | **Fingerprints/hashes** | Binary |
 | **Donnees correlees** | PQ + OPQ |
+
+> Note : ce tableau compare les methodes en tant que telles. Dans le chemin
+> de requete des collections, seuls **RaBitQ** et **PQ** sont branches
+> aujourd'hui (voir les encarts de statut ci-dessus) — les modes SQ8/Binary
+> y maintiennent des caches que la recherche ne consomme pas encore.
 
 ---
 


### PR DESCRIPTION
## Summary

Closes audit follow-up #4: `TRAIN QUANTIZER 'rabitq'` trained and persisted `rabitq.idx`, but **no search path ever loaded it** — after any restart, searches silently ran full-precision f32 forever. PQ codebooks were persisted but never reloaded either.

## Wiring (first commit)

- **RaBitQ across restarts**: `HnswIndex::load`/`save` honor the persisted `meta.storage_mode` (save previously hardcoded `Full`); `install_trained_rabitq` re-encodes every vector in NodeId order into a fresh positional store (store-before-index visibility) and is invoked from the load path and from `TRAIN QUANTIZER` for live backends. Vacuum preserves the backend and the trained quantizer.
- **PQ across restarts**: `Collection::open` reloads the TRAIN-persisted codebook + rotation and rebuilds `pq_cache` (O(n), after storage recovery) so ADC rescoring stays live.
- **SQ8/Binary honesty**: no fake read path invented — docs now state precisely that those modes maintain caches no search path consumes (full-precision search), pending the reduced-memory storage mode.

## Review hardening (second commit — code review, 7 findings, all fixed)

- **Persisted quantizer wins over lazy training**: the HNSW graph is rebuilt on every open, so for collections ≥1000 vectors the recovery inserts used to lazily train a *throwaway* quantizer that preempted `rabitq.idx` — different rotation every restart, the headline feature silently defeated. The persisted quantizer now installs **before** gap recovery; a 1200-vector reopen test pins it.
- **Positional-store alignment is structural** (entry N = node N): an install gate serializes quantizer install/training against in-flight inserts; trained inserts hold the store lock across the graph insert; pre-training inserts hold the buffer lock across the graph insert. Three silent wrong-node-scoring scenarios eliminated.
- Bulk-upsert V2 fast path (DirectVectorWriter) bypasses the encoding store → RaBitQ collections always take the standard bulk path.
- Vacuum rebuilds through a Standard backend and promotes afterwards: no throwaway mid-rebuild training, no double re-encode, and untrained collections can no longer come out of vacuum silently self-trained.
- `rabitq.idx` dimension mismatch warn-and-degrades at both restore layers (was: failed the whole index load).
- Reopen recall bar raised 0.7 → 0.9; PQ docs no longer overclaim (lazily trained PQ quantizers remain volatile without TRAIN).

## Validation

- Full core suite: **5,844 passed / 0 failed**; recall gate (search path touched): **18/18** incl. ≥0.95 contracts
- clippy pedantic clean; no-default-features + wasm targets clean; unwrap gate clean; lizard CC ≤ 8 / NLOC ≤ 50
- Post-rebase on #1080: 50 RaBitQ + 196 agent tests green (merged post-open hook ordering: edge reindex → WAL replay → quantizer restore)

## Residuals (documented, pre-existing)

- `load_or_create_hnsw` gates on `hnsw.bin`, which nothing writes — collections always rebuild via gap recovery on open (this PR's wiring works in that branch; making reopen load persisted graphs is its own decision/PR).
- `HnswParams.alpha` still not plumbed through `HnswIndex` (pre-existing).
