### PR TITLE
refactor(core): eliminate redundant allocations in hot write paths

### DIFF
--- a/crates/velesdb-core/src/collection/payload_mirror/mod.rs
+++ b/crates/velesdb-core/src/collection/payload_mirror/mod.rs
@@ -107,11 +107,7 @@ impl MirrorState {
             return false;
         };
         let cells = self.collect_cells(payload);
-        let cell_refs: Vec<(&str, ColumnValue)> = cells
-            .iter()
-            .map(|(name, value)| (name.as_str(), value.clone()))
-            .collect();
-        self.store.push_row_unchecked(&cell_refs);
+        self.store.push_row_unchecked(&cells);
         self.row_ids.push(id);
         self.id_rows.insert(id, row_idx);
         self.live.insert(row_idx);
@@ -128,11 +124,15 @@ impl MirrorState {
 
     /// Extracts mirrored cells from a payload's top-level scalar fields.
     ///
+    /// Keys are borrowed directly from `payload` so the caller can pass the
+    /// result straight to `push_row_unchecked` without an intermediate Vec or
+    /// any `String` / `ColumnValue` clones.
+    ///
     /// Non-scalar values (arrays, objects, nulls) and dotted keys produce no
     /// cell — `push_row_unchecked` stores null for absent columns, matching
     /// the JSON filter's "missing field never matches" semantics. Cells whose
     /// type conflicts with the existing column are nulled by `push_typed`.
-    fn collect_cells(&mut self, payload: Option<&serde_json::Value>) -> Vec<(String, ColumnValue)> {
+    fn collect_cells<'p>(&mut self, payload: Option<&'p serde_json::Value>) -> Vec<(&'p str, ColumnValue)> {
         let Some(serde_json::Value::Object(map)) = payload else {
             return Vec::new();
         };
@@ -147,7 +147,7 @@ impl MirrorState {
                 continue;
             };
             if self.ensure_column(key, &col_type) {
-                cells.push((key.clone(), cell));
+                cells.push((key.as_str(), cell));
             }
         }
         cells

--- a/crates/velesdb-core/src/collection/payload_mirror/mod.rs
+++ b/crates/velesdb-core/src/collection/payload_mirror/mod.rs
@@ -132,7 +132,10 @@ impl MirrorState {
     /// cell — `push_row_unchecked` stores null for absent columns, matching
     /// the JSON filter's "missing field never matches" semantics. Cells whose
     /// type conflicts with the existing column are nulled by `push_typed`.
-    fn collect_cells<'p>(&mut self, payload: Option<&'p serde_json::Value>) -> Vec<(&'p str, ColumnValue)> {
+    fn collect_cells<'p>(
+        &mut self,
+        payload: Option<&'p serde_json::Value>,
+    ) -> Vec<(&'p str, ColumnValue)> {
         let Some(serde_json::Value::Object(map)) = payload else {
             return Vec::new();
         };

--- a/crates/velesdb-core/src/storage/mmap/wal_replay.rs
+++ b/crates/velesdb-core/src/storage/mmap/wal_replay.rs
@@ -268,11 +268,7 @@ fn validate_first_delete_crc(reader: &mut BufReader<File>) -> bool {
         return false;
     }
 
-    let mut frame = Vec::with_capacity(1 + 8);
-    frame.push(2u8);
-    frame.extend_from_slice(&id_bytes);
-
-    crc32_hash(&frame) == u32::from_le_bytes(stored_crc)
+    delete_frame_crc(id_bytes) == u32::from_le_bytes(stored_crc)
 }
 
 // ---------------------------------------------------------------------------
@@ -397,6 +393,16 @@ fn is_at_tail(reader: &mut BufReader<File>, file_len: u64) -> io::Result<bool> {
     Ok(reader.stream_position()? >= file_len)
 }
 
+/// Computes the CRC32 of a delete frame `[op=2, id...]` using a stack buffer —
+/// avoids a heap allocation for the single-use 9-byte frame.
+#[inline]
+fn delete_frame_crc(id_bytes: [u8; 8]) -> u32 {
+    let mut frame = [0u8; 9];
+    frame[0] = 2u8;
+    frame[1..].copy_from_slice(&id_bytes);
+    crc32_hash(&frame)
+}
+
 /// Computes the CRC32 of a store frame and compares it with `stored_crc`.
 fn store_crc_matches(
     id_bytes: [u8; 8],
@@ -503,11 +509,7 @@ fn replay_delete(
         return Ok(EntryOutcome::Stop);
     }
 
-    let mut frame = Vec::with_capacity(1 + 8);
-    frame.push(2u8);
-    frame.extend_from_slice(&id_bytes);
-
-    if crc32_hash(&frame) == u32::from_le_bytes(stored_crc) {
+    if delete_frame_crc(id_bytes) == u32::from_le_bytes(stored_crc) {
         let id = u64::from_le_bytes(id_bytes);
         index.remove(id);
         touched_ids.push(id);

--- a/crates/velesdb-core/src/velesql/validation_anchor.rs
+++ b/crates/velesdb-core/src/velesql/validation_anchor.rs
@@ -36,16 +36,19 @@ pub(super) fn walk_graph_match_anchors(
 /// G2 pre-pass: node aliases referenced by two or more distinct graph
 /// predicates of the WHERE tree.
 fn collect_shared_pattern_aliases(condition: &Condition) -> HashSet<String> {
-    let mut counts = HashMap::new();
+    let mut counts: HashMap<&str, usize> = HashMap::new();
     accumulate_pattern_aliases(condition, &mut counts);
     counts
         .into_iter()
-        .filter_map(|(alias, predicates)| (predicates >= 2).then_some(alias))
+        .filter_map(|(alias, predicates)| (predicates >= 2).then_some(alias.to_string()))
         .collect()
 }
 
 /// Counts, per node alias, how many graph predicates reference it.
-fn accumulate_pattern_aliases(condition: &Condition, counts: &mut HashMap<String, usize>) {
+/// Keys borrow from the AST nodes so no String allocations are needed during
+/// the counting phase; owned strings are produced only for aliases that make
+/// the final shared set.
+fn accumulate_pattern_aliases<'c>(condition: &'c Condition, counts: &mut HashMap<&'c str, usize>) {
     match condition {
         Condition::GraphMatch(predicate) => {
             let aliases: HashSet<&str> = predicate
@@ -55,7 +58,7 @@ fn accumulate_pattern_aliases(condition: &Condition, counts: &mut HashMap<String
                 .filter_map(|node| node.alias.as_deref())
                 .collect();
             for alias in aliases {
-                *counts.entry(alias.to_string()).or_insert(0) += 1;
+                *counts.entry(alias).or_insert(0) += 1;
             }
         }
         Condition::And(l, r) | Condition::Or(l, r) => {


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Full review of PR #1083 (CI-green, 40 commits) identified three concrete allocation-waste patterns on hot paths. This PR fixes them atomically with zero behaviour change.

### Changes (2026-06-12)

#### 1. `wal_replay.rs` — zero-alloc delete-frame CRC (DRY + perf)

**Before:** Both `validate_first_delete_crc` and `replay_delete` independently built the same 9-byte delete frame using `Vec::with_capacity(1 + 8)` — one heap allocation each, duplicated code.

**After:** Extracted `delete_frame_crc(id_bytes: [u8; 8]) -> u32` that writes into a `[u8; 9]` stack buffer. Zero heap allocation, single source of truth.

```rust
// before (×2 in the file)
let mut frame = Vec::with_capacity(1 + 8);
frame.push(2u8);
frame.extend_from_slice(&id_bytes);
crc32_hash(&frame) == u32::from_le_bytes(stored_crc)

// after
delete_frame_crc(id_bytes) == u32::from_le_bytes(stored_crc)
```

#### 2. `payload_mirror/mod.rs` — eliminate double-Vec in `upsert_row` (perf)

`upsert_row` is called on every point insert/update to keep the columnar mirror in sync. **Before:** `collect_cells` returned `Vec<(String, ColumnValue)>`, then a second `cell_refs: Vec<(&str, ColumnValue)>` was built with N `String::clone()` + N `ColumnValue::clone()` calls before passing to `push_row_unchecked`.

**After:** `collect_cells<'p>` borrows keys directly from the payload JSON map (`&'p str`), returning `Vec<(&'p str, ColumnValue)>` — the same type `push_row_unchecked` already accepts. One Vec, zero extra clones.

```rust
// before: two Vecs, N String clones, N ColumnValue clones
let cells = self.collect_cells(payload);          // Vec<(String, ColumnValue)>
let cell_refs = cells.iter()
    .map(|(n, v)| (n.as_str(), v.clone()))
    .collect::<Vec<_>>();
self.store.push_row_unchecked(&cell_refs);

// after: one Vec, no clones
let cells = self.collect_cells(payload);          // Vec<(&str, ColumnValue)>
self.store.push_row_unchecked(&cells);
```

#### 3. `validation_anchor.rs` — `&str` keys in alias counting phase (perf)

`accumulate_pattern_aliases` counted node aliases across MATCH predicates using `HashMap<String, usize>`, calling `alias.to_string()` for every alias node — even though the final shared set typically contains zero or one alias per query.

**After:** Uses `HashMap<&str, usize>` borrowing from the AST. `String` allocation deferred to `then_some(alias.to_string())` in the filter, only for aliases that actually appear ≥2 times.

---

## Validation

- `cargo test -p velesdb-core --lib`: **5 176 passed, 0 failed** (2026-06-12)
- `cargo clippy -p velesdb-core --lib`: **0 warnings** (pedantic clean)
- All changes are purely mechanical refactors — no logic, no API surface, no test changes needed.

## Test plan

- [x] `cargo test -p velesdb-core --lib` — 5 176 / 0
- [x] `cargo clippy -p velesdb-core --lib` — clean
- [x] `cargo build -p velesdb-core` — clean

https://claude.ai/code/session_01WJ1ZhDiJhzQ7hsuBD5ygni
EOF
)
