### PR TITLE
ci: make CI Success satisfiable on root-docs PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ on:
   push:
     branches: [main, develop]
     paths:
+      - '*.md'
       - 'crates/**'
       - 'sdks/typescript/**'
       - 'conformance/**'
@@ -30,6 +31,7 @@ on:
   pull_request:
     branches: [main, develop]
     paths:
+      - '*.md'
       - 'crates/**'
       - 'sdks/typescript/**'
       - 'conformance/**'


### PR DESCRIPTION
**Bug:** root-level markdown (README.md, CHANGELOG.md, ROADMAP.md, ARCHITECTURE.md, …) is not in `ci.yml`'s `paths` filter, so a docs-only PR never triggers `ci.yml`. The required `CI Success` check therefore never reports, and the PR is **permanently BLOCKED** — unmergeable without an admin override. Surfaced by #1088 (a README-only badge fix).

**Fix:** add `'*.md'` (root markdown) to both the `push` and `pull_request` path filters, so CI runs and `CI Success` gates these PRs normally.

This PR touches `.github/workflows/**` (already in the filter), so it triggers CI and is mergeable normally. After merge, #1088 can be rebased and will satisfy CI Success.