### PR TITLE
fix(pypi): add generate-import-lib for Windows ARM64 wheel cross-compilation

### DIFF
--- a/crates/velesdb-python/Cargo.toml
+++ b/crates/velesdb-python/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 velesdb-core = { workspace = true }
-pyo3 = { version = "0.24", features = ["extension-module", "multiple-pymethods", "abi3-py39"] }
+pyo3 = { version = "0.24", features = ["extension-module", "multiple-pymethods", "abi3-py39", "generate-import-lib"] }
 serde_json = { workspace = true }
 numpy = "0.24"
 parking_lot = "0.12"


### PR DESCRIPTION
## Problem

The `PyPI wheels aarch64-pc-windows-msvc` job fails with:

```
Need a Python interpreter to compile for Windows without PyO3's `generate-import-lib` feature
```

maturin cannot cross-compile for `aarch64-pc-windows-msvc` from an x64 Windows runner
because there is no ARM64 Python interpreter available on the runner.

## Fix

Add `generate-import-lib` to the pyo3 features. This feature makes PyO3 generate
the Python import library at build time, removing the need for a matching
Python interpreter when cross-compiling Windows targets.

## Verification

- `cargo check -p velesdb-python` passes locally
- No behaviour change on non-Windows platforms (the feature is a no-op there)