### PR TITLE
fix(python-sdk): API parity gaps — has_edge O(1), rollback alias, FusionStrategy variants, GraphCollection adapter

### DIFF
--- a/crates/velesdb-core/src/collection/graph_collection.rs
+++ b/crates/velesdb-core/src/collection/graph_collection.rs
@@ -330,6 +330,26 @@ impl GraphCollection {
         self.inner.store_node_payload(node_id, payload)
     }
 
+    /// Inserts or updates a node payload, optionally with an embedding vector.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if storage fails, the vector dimension is invalid, or
+    /// an embedding is supplied for a graph collection without embeddings.
+    pub fn upsert_node(
+        &self,
+        node_id: u64,
+        payload: &serde_json::Value,
+        vector: Option<Vec<f32>>,
+    ) -> Result<()> {
+        match vector {
+            Some(vector) => self
+                .inner
+                .upsert([Point::new(node_id, vector, Some(payload.clone()))]),
+            None => self.upsert_node_payload(node_id, payload),
+        }
+    }
+
     /// Inserts or updates node payload (properties).
     ///
     /// # Errors
@@ -406,6 +426,33 @@ mod tests {
         assert!(ids.contains(&10), "node 10 should be present");
         assert!(ids.contains(&20), "node 20 should be present");
         assert_eq!(ids.len(), 2);
+    }
+
+    #[test]
+    fn test_upsert_node_with_embedding_is_searchable() {
+        let dir = tempdir().unwrap();
+        let col = GraphCollection::create(
+            dir.path().to_path_buf(),
+            "kg",
+            Some(4),
+            DistanceMetric::Cosine,
+            GraphSchema::schemaless(),
+        )
+        .unwrap();
+
+        col.upsert_node(
+            10,
+            &serde_json::json!({"name": "Alice"}),
+            Some(vec![1.0, 0.0, 0.0, 0.0]),
+        )
+        .unwrap();
+
+        assert_eq!(
+            col.get_node_payload(10).unwrap(),
+            Some(serde_json::json!({"name": "Alice"}))
+        );
+        let results = col.search_by_embedding(&[1.0, 0.0, 0.0, 0.0], 1).unwrap();
+        assert_eq!(results[0].point.id, 10);
     }
 
     #[test]

--- a/crates/velesdb-core/src/collection/graph_collection.rs
+++ b/crates/velesdb-core/src/collection/graph_collection.rs
@@ -263,6 +263,12 @@ impl GraphCollection {
         self.inner.remove_edge(edge_id)
     }
 
+    /// Returns `true` if an edge with `edge_id` exists in the graph.
+    #[must_use]
+    pub fn has_edge(&self, edge_id: u64) -> bool {
+        self.inner.edge_exists(edge_id)
+    }
+
     /// Performs BFS traversal from a source node.
     ///
     /// # Examples

--- a/crates/velesdb-python/README.md
+++ b/crates/velesdb-python/README.md
@@ -164,6 +164,7 @@ db = velesdb.Database("./path/to/data")
 
 # List collections
 names = db.list_collections()
+names = db.get_collections()  # compatibility alias
 
 # Create collection (with optional HNSW tuning via typed options)
 collection = db.create_collection("name", dimension=768, metric="cosine")
@@ -451,9 +452,13 @@ strategy = FusionStrategy.maximum()
 
 # Weighted -- custom combination of avg, max, and hit ratio
 strategy = FusionStrategy.weighted(avg_weight=0.6, max_weight=0.3, hit_weight=0.1)
+strategy = FusionStrategy.weighted({"avg_weight": 0.6, "max_weight": 0.3, "hit_weight": 0.1})
+strategy = FusionStrategy.weighted(0.3, 0.1)  # legacy: max_weight, hit_weight
+strategy = FusionStrategy.weighted(max_weight=0.3, hit_weight=0.1)  # legacy kwargs
 
 # Relative Score Fusion -- linear blend of dense and sparse scores
 strategy = FusionStrategy.relative_score(dense_weight=0.7, sparse_weight=0.3)
+strategy = FusionStrategy.rsf(dense_weight=0.7, sparse_weight=0.3)  # alias
 ```
 
 | Strategy | Formula | Best For |
@@ -461,8 +466,8 @@ strategy = FusionStrategy.relative_score(dense_weight=0.7, sparse_weight=0.3)
 | `rrf(k)` | sum 1/(k + rank) | Multi-query fusion, different score scales |
 | `average()` | mean(scores) | Uniform query importance |
 | `maximum()` | max(scores) | When any single match is sufficient |
-| `weighted(a, m, h)` | a*avg + m*max + h*hit_ratio | Fine-grained scoring control |
-| `relative_score(d, s)` | d*dense + s*sparse | Dense+sparse hybrid pipelines |
+| `weighted(a, m, h)` / `weighted(dict)` | a*avg + m*max + h*hit_ratio | Fine-grained scoring control |
+| `relative_score(d, s)` / `rsf(d, s)` | d*dense + s*sparse | Dense+sparse hybrid pipelines |
 
 ### Agent Memory SDK
 
@@ -606,6 +611,8 @@ knows_edges = graph.get_edges(label="KNOWS")
 # Get outgoing/incoming edges for a node
 outgoing = graph.get_outgoing(10)   # edges from Alice
 incoming = graph.get_incoming(30)   # edges into Paris
+outgoing = graph.get_outgoing_edges(10)  # alias
+incoming = graph.get_incoming_edges(30)  # alias
 
 # Node degree
 in_deg, out_deg = graph.node_degree(10)

--- a/crates/velesdb-python/python/velesdb/__init__.py
+++ b/crates/velesdb-python/python/velesdb/__init__.py
@@ -106,7 +106,7 @@ class GraphStore:
                 target=target,
                 label=label,
                 weight=weight,
-                id=id,
+                edge_id=id,
                 source=source,
                 properties=properties,
                 next_id=self._next_edge_id,
@@ -150,7 +150,7 @@ def _legacy_edge_to_dict(
     target: int | None,
     label: str | None,
     weight: Any | None,
-    id: int | None,
+    edge_id: int | None,
     source: int | None,
     properties: dict[str, Any] | None,
     next_id: Any,
@@ -164,19 +164,19 @@ def _legacy_edge_to_dict(
         props.setdefault("weight", weight)
 
     # Current explicit-id shape: add_edge(id, source=..., target=..., label=...)
-    if source is not None or id is not None:
-        edge_id = int(edge_or_source if id is None else id)
+    if source is not None or edge_id is not None:
+        eid = int(edge_or_source if edge_id is None else edge_id)
         edge_source = int(source if source is not None else 0)
     else:
         # Legacy no-id shape: add_edge(source, target, label, weight=None)
-        edge_id = int(next_id())
+        eid = int(next_id())
         edge_source = int(edge_or_source)
 
     if target is None:
         raise ValueError("add_edge() requires a target node id")
 
     edge_dict: dict[str, Any] = {
-        "id": edge_id,
+        "id": eid,
         "source": edge_source,
         "target": int(target),
         "label": label or "RELATED_TO",
@@ -214,7 +214,7 @@ class GraphCollection:
         return edge_id
 
     def has_edge(self, edge_id: int) -> bool:
-        return any(edge["id"] == int(edge_id) for edge in self._inner.get_edges(None))
+        return self._inner.has_edge(int(edge_id))
 
     def add_edge(
         self,
@@ -237,7 +237,7 @@ class GraphCollection:
                 target=target,
                 label=label,
                 weight=weight,
-                id=id,
+                edge_id=id,
                 source=source,
                 properties=properties,
                 next_id=self._next_edge_id,

--- a/crates/velesdb-python/python/velesdb/__init__.py
+++ b/crates/velesdb-python/python/velesdb/__init__.py
@@ -70,32 +70,48 @@ class GraphStore:
 
     def __init__(self, inner: _RawGraphStore | None = None) -> None:
         self._inner = inner or _RawGraphStore()
+        self._legacy_edge_id = 1
 
     def __getattr__(self, name: str) -> Any:
         return getattr(self._inner, name)
 
+    def _next_edge_id(self) -> int:
+        edge_id = max(self._legacy_edge_id, self._inner.edge_count() + 1)
+        while self.has_edge(edge_id):
+            edge_id += 1
+        self._legacy_edge_id += 1
+        return edge_id
+
+    def has_edge(self, edge_id: int) -> bool:
+        return self._inner.has_edge(int(edge_id))
+
     def add_edge(
         self,
         edge: Any,
-        *,
-        source: int | None = None,
         target: int | None = None,
         label: str | None = None,
+        weight: Any | None = None,
+        *,
+        id: int | None = None,
+        source: int | None = None,
         properties: dict[str, Any] | None = None,
     ) -> None:
         if isinstance(edge, dict):
             self._inner.add_edge(edge)
             return
 
-        edge_dict: dict[str, Any] = {
-            "id": int(edge),
-            "source": int(source) if source is not None else 0,
-            "target": int(target) if target is not None else 0,
-            "label": label or "",
-        }
-        if properties is not None:
-            edge_dict["properties"] = properties
-        self._inner.add_edge(edge_dict)
+        self._inner.add_edge(
+            _legacy_edge_to_dict(
+                edge,
+                target=target,
+                label=label,
+                weight=weight,
+                id=id,
+                source=source,
+                properties=properties,
+                next_id=self._next_edge_id,
+            )
+        )
 
     def traverse_bfs(
         self,
@@ -126,6 +142,124 @@ class GraphStore:
             relationship_types=relationship_types,
         )
         return self._inner.traverse_dfs(source, cfg)
+
+
+def _legacy_edge_to_dict(
+    edge_or_source: Any,
+    *,
+    target: int | None,
+    label: str | None,
+    weight: Any | None,
+    id: int | None,
+    source: int | None,
+    properties: dict[str, Any] | None,
+    next_id: Any,
+) -> dict[str, Any]:
+    """Normalize legacy positional edge calls to the dict contract."""
+    props = dict(properties or {})
+    if isinstance(weight, dict):
+        props.update(weight)
+        weight = None
+    elif weight is not None:
+        props.setdefault("weight", weight)
+
+    # Current explicit-id shape: add_edge(id, source=..., target=..., label=...)
+    if source is not None or id is not None:
+        edge_id = int(edge_or_source if id is None else id)
+        edge_source = int(source if source is not None else 0)
+    else:
+        # Legacy no-id shape: add_edge(source, target, label, weight=None)
+        edge_id = int(next_id())
+        edge_source = int(edge_or_source)
+
+    if target is None:
+        raise ValueError("add_edge() requires a target node id")
+
+    edge_dict: dict[str, Any] = {
+        "id": edge_id,
+        "source": edge_source,
+        "target": int(target),
+        "label": label or "RELATED_TO",
+    }
+    if props:
+        edge_dict["properties"] = props
+    return edge_dict
+
+
+class GraphCollection:
+    """Compatibility adapter around the Rust GraphCollection binding."""
+
+    def __init__(self, inner: PyGraphCollection) -> None:
+        self._inner = inner
+        self._legacy_edge_id = 1
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._inner, name)
+
+    def __contains__(self, node_id: int) -> bool:
+        return self._inner.__contains__(int(node_id))
+
+    def __enter__(self) -> "GraphCollection":
+        return self
+
+    def __exit__(self, _exc_type: Any, _exc_value: Any, _traceback: Any) -> bool:
+        self._inner.close()
+        return False
+
+    def _next_edge_id(self) -> int:
+        edge_id = max(self._legacy_edge_id, self._inner.edge_count() + 1)
+        while self.has_edge(edge_id):
+            edge_id += 1
+        self._legacy_edge_id += 1
+        return edge_id
+
+    def has_edge(self, edge_id: int) -> bool:
+        return any(edge["id"] == int(edge_id) for edge in self._inner.get_edges(None))
+
+    def add_edge(
+        self,
+        edge: Any,
+        target: int | None = None,
+        label: str | None = None,
+        weight: Any | None = None,
+        *,
+        id: int | None = None,
+        source: int | None = None,
+        properties: dict[str, Any] | None = None,
+    ) -> None:
+        if isinstance(edge, dict):
+            self._inner.add_edge(edge)
+            return
+
+        self._inner.add_edge(
+            _legacy_edge_to_dict(
+                edge,
+                target=target,
+                label=label,
+                weight=weight,
+                id=id,
+                source=source,
+                properties=properties,
+                next_id=self._next_edge_id,
+            )
+        )
+
+    def add_node(
+        self,
+        node_id: int,
+        payload: dict[str, Any] | None = None,
+        vector: Iterable[float] | None = None,
+    ) -> None:
+        self._inner.upsert_node(int(node_id), dict(payload or {}), vector)
+
+    def bfs(self, start_id: int, max_depth: int = 3, limit: int = 100) -> list[dict[str, Any]]:
+        return self._inner.traverse_bfs(start_id, max_depth=max_depth, limit=limit)
+
+    def dfs(self, start_id: int, max_depth: int = 3, limit: int = 100) -> list[dict[str, Any]]:
+        return self._inner.traverse_dfs(start_id, max_depth=max_depth, limit=limit)
+
+    def close(self) -> None:
+        self._inner.close()
 
 
 class Collection:
@@ -600,6 +734,27 @@ class Database:
         col = self._inner.create_metadata_collection(name)
         return Collection(col)
 
+    def create_graph_collection(
+        self,
+        name: str,
+        dimension: int | None = None,
+        metric: str = "cosine",
+        schema: PyGraphSchema | None = None,
+    ) -> GraphCollection:
+        graph = self._inner.create_graph_collection(
+            name,
+            dimension=dimension,
+            metric=metric,
+            schema=schema,
+        )
+        return GraphCollection(graph)
+
+    def get_graph_collection(self, name: str) -> "GraphCollection | None":
+        graph = self._inner.get_graph_collection(name)
+        if graph is None:
+            return None
+        return GraphCollection(graph)
+
     def execute_query(
         self,
         sql: str,
@@ -690,6 +845,7 @@ __all__ = [
     "SearchResult",
     "FusionStrategy",
     "GraphStore",
+    "GraphCollection",
     "StreamingConfig",
     "TraversalResult",
     "VelesQL",

--- a/crates/velesdb-python/src/agent.rs
+++ b/crates/velesdb-python/src/agent.rs
@@ -351,6 +351,14 @@ impl AgentMemory {
         py.allow_threads(|| self.core.load_snapshot_version(version).map_err(to_py_err))
     }
 
+    /// Alias for `load_snapshot_version`.
+    ///
+    /// Kept for older examples that used rollback-style naming.
+    #[pyo3(signature = (version))]
+    fn rollback(&self, py: Python<'_>, version: u64) -> PyResult<()> {
+        self.load_snapshot_version(py, version)
+    }
+
     /// Lists all available snapshot version numbers.
     fn list_snapshot_versions(&self, py: Python<'_>) -> PyResult<Vec<u64>> {
         py.allow_threads(|| self.core.list_snapshot_versions().map_err(to_py_err))

--- a/crates/velesdb-python/src/database.rs
+++ b/crates/velesdb-python/src/database.rs
@@ -281,6 +281,14 @@ impl Database {
         self.inner.list_collections()
     }
 
+    /// Alias for `list_collections`.
+    ///
+    /// Kept for compatibility with older documentation and examples that used
+    /// `get_collections()` for the same operation.
+    fn get_collections(&self) -> Vec<String> {
+        self.list_collections()
+    }
+
     /// Delete a collection by name.
     ///
     /// Args:

--- a/crates/velesdb-python/src/fusion.rs
+++ b/crates/velesdb-python/src/fusion.rs
@@ -2,6 +2,7 @@
 
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
+use pyo3::types::PyDict;
 
 use velesdb_core::FusionStrategy as CoreFusionStrategy;
 
@@ -99,8 +100,14 @@ impl FusionStrategy {
     ///     ...     hit_weight=0.1
     ///     ... )
     #[staticmethod]
-    #[pyo3(signature = (avg_weight, max_weight, hit_weight))]
-    fn weighted(avg_weight: f32, max_weight: f32, hit_weight: f32) -> PyResult<Self> {
+    #[pyo3(signature = (avg_weight = None, max_weight = None, hit_weight = None))]
+    fn weighted(
+        avg_weight: Option<&Bound<'_, PyAny>>,
+        max_weight: Option<f32>,
+        hit_weight: Option<f32>,
+    ) -> PyResult<Self> {
+        let (avg_weight, max_weight, hit_weight) =
+            parse_weighted_args(avg_weight, max_weight, hit_weight)?;
         CoreFusionStrategy::weighted(avg_weight, max_weight, hit_weight)
             .map(|inner| Self { inner })
             .map_err(|e| PyValueError::new_err(format!("{e}")))
@@ -131,6 +138,16 @@ impl FusionStrategy {
             .map_err(|e| PyValueError::new_err(format!("{e}")))
     }
 
+    /// Alias for Relative Score Fusion (RSF).
+    ///
+    /// `rsf()` is the short name used in VelesQL (`USING FUSION rsf`) and in
+    /// some older examples. It maps to `relative_score()`.
+    #[staticmethod]
+    #[pyo3(signature = (dense_weight = 0.5, sparse_weight = 0.5))]
+    fn rsf(dense_weight: f32, sparse_weight: f32) -> PyResult<Self> {
+        Self::relative_score(dense_weight, sparse_weight)
+    }
+
     fn __repr__(&self) -> String {
         match &self.inner {
             CoreFusionStrategy::Average => "FusionStrategy.average()".to_string(),
@@ -159,5 +176,71 @@ impl FusionStrategy {
     /// Get the inner CoreFusionStrategy.
     pub fn inner(&self) -> CoreFusionStrategy {
         self.inner.clone()
+    }
+}
+
+fn parse_weighted_args(
+    avg_weight: Option<&Bound<'_, PyAny>>,
+    max_weight: Option<f32>,
+    hit_weight: Option<f32>,
+) -> PyResult<(f32, f32, f32)> {
+    let Some(avg_weight) = avg_weight else {
+        return match (max_weight, hit_weight) {
+            (Some(max), Some(hit)) => Ok((derive_avg_weight(max, hit), max, hit)),
+            _ => Err(PyValueError::new_err(
+                "FusionStrategy.weighted expects (avg_weight, max_weight, hit_weight), \
+                 a weights dict, or legacy (max_weight, hit_weight)",
+            )),
+        };
+    };
+
+    if let Ok(weights) = avg_weight.downcast::<PyDict>() {
+        if max_weight.is_some() || hit_weight.is_some() {
+            return Err(PyValueError::new_err(
+                "FusionStrategy.weighted(dict) cannot be combined with positional weights",
+            ));
+        }
+        return parse_weighted_dict(weights);
+    }
+
+    let first = avg_weight.extract::<f32>()?;
+    match (max_weight, hit_weight) {
+        (Some(max), Some(hit)) => Ok((first, max, hit)),
+        (Some(hit), None) => {
+            // Legacy two-argument shape: weighted(max_weight, hit_weight).
+            // Derive avg_weight so the validated three-component strategy is
+            // still the only runtime representation.
+            let max = first;
+            let avg = derive_avg_weight(max, hit);
+            Ok((avg, max, hit))
+        }
+        _ => Err(PyValueError::new_err(
+            "FusionStrategy.weighted expects (avg_weight, max_weight, hit_weight), \
+             a weights dict, or legacy (max_weight, hit_weight)",
+        )),
+    }
+}
+
+fn parse_weighted_dict(weights: &Bound<'_, PyDict>) -> PyResult<(f32, f32, f32)> {
+    let max_weight = optional_weight(weights, "max_weight")?
+        .or(optional_weight(weights, "max")?)
+        .ok_or_else(|| PyValueError::new_err("weighted dict is missing 'max_weight'"))?;
+    let hit_weight = optional_weight(weights, "hit_weight")?
+        .or(optional_weight(weights, "hit")?)
+        .ok_or_else(|| PyValueError::new_err("weighted dict is missing 'hit_weight'"))?;
+    let avg_weight = optional_weight(weights, "avg_weight")?
+        .or(optional_weight(weights, "avg")?)
+        .unwrap_or_else(|| derive_avg_weight(max_weight, hit_weight));
+    Ok((avg_weight, max_weight, hit_weight))
+}
+
+fn derive_avg_weight(max_weight: f32, hit_weight: f32) -> f32 {
+    ((1.0_f32 - max_weight - hit_weight) * 1_000_000.0).round() / 1_000_000.0
+}
+
+fn optional_weight(weights: &Bound<'_, PyDict>, key: &str) -> PyResult<Option<f32>> {
+    match weights.get_item(key)? {
+        Some(value) => Ok(Some(value.extract::<f32>()?)),
+        None => Ok(None),
     }
 }

--- a/crates/velesdb-python/src/graph_collection.rs
+++ b/crates/velesdb-python/src/graph_collection.rs
@@ -217,6 +217,12 @@ impl PyGraphCollection {
         Ok(edges.iter().map(|e| edge_to_dict(py, e)).collect())
     }
 
+    /// Returns `true` if an edge with the given ID exists.
+    #[pyo3(signature = (edge_id))]
+    fn has_edge(&self, edge_id: u64) -> bool {
+        self.inner.has_edge(edge_id)
+    }
+
     /// Alias for `get_outgoing`.
     ///
     /// Preserves compatibility with examples that used the explicit

--- a/crates/velesdb-python/src/graph_collection.rs
+++ b/crates/velesdb-python/src/graph_collection.rs
@@ -217,6 +217,15 @@ impl PyGraphCollection {
         Ok(edges.iter().map(|e| edge_to_dict(py, e)).collect())
     }
 
+    /// Alias for `get_outgoing`.
+    ///
+    /// Preserves compatibility with examples that used the explicit
+    /// `*_edges` suffix.
+    #[pyo3(signature = (node_id))]
+    fn get_outgoing_edges(&self, py: Python<'_>, node_id: u64) -> PyResult<Vec<PyObject>> {
+        self.get_outgoing(py, node_id)
+    }
+
     /// Get incoming edges to a node.
     ///
     /// Args:
@@ -228,6 +237,15 @@ impl PyGraphCollection {
     fn get_incoming(&self, py: Python<'_>, node_id: u64) -> PyResult<Vec<PyObject>> {
         let edges = py.allow_threads(|| self.inner.get_incoming(node_id));
         Ok(edges.iter().map(|e| edge_to_dict(py, e)).collect())
+    }
+
+    /// Alias for `get_incoming`.
+    ///
+    /// Preserves compatibility with examples that used the explicit
+    /// `*_edges` suffix.
+    #[pyo3(signature = (node_id))]
+    fn get_incoming_edges(&self, py: Python<'_>, node_id: u64) -> PyResult<Vec<PyObject>> {
+        self.get_incoming(py, node_id)
     }
 
     /// Get the in-degree and out-degree of a node.
@@ -261,6 +279,32 @@ impl PyGraphCollection {
         py.allow_threads(|| {
             self.inner
                 .upsert_node_payload(node_id, &value)
+                .map_err(core_err)
+        })
+    }
+
+    /// Upsert a node payload, optionally with an embedding vector.
+    ///
+    /// Args:
+    ///     node_id: The node ID
+    ///     payload: Dict of properties to store
+    ///     vector: Optional embedding vector for searchable graph nodes
+    #[pyo3(signature = (node_id, payload, vector=None))]
+    fn upsert_node(
+        &self,
+        py: Python<'_>,
+        node_id: u64,
+        payload: PyObject,
+        vector: Option<PyObject>,
+    ) -> PyResult<()> {
+        let value = python_to_json(py, &payload)?;
+        let vector = match vector {
+            Some(vector) => Some(extract_vector(py, &vector)?),
+            None => None,
+        };
+        py.allow_threads(|| {
+            self.inner
+                .upsert_node(node_id, &value, vector)
                 .map_err(core_err)
         })
     }

--- a/crates/velesdb-python/src/graph_store.rs
+++ b/crates/velesdb-python/src/graph_store.rs
@@ -158,6 +158,12 @@ impl GraphStore {
         Ok(edges.iter().map(|e| edge_to_dict(py, e)).collect())
     }
 
+    /// Alias for `get_outgoing`.
+    #[pyo3(signature = (node_id))]
+    fn get_outgoing_edges(&self, py: Python<'_>, node_id: u64) -> PyResult<Vec<PyObject>> {
+        self.get_outgoing(py, node_id)
+    }
+
     /// Gets incoming edges to a node.
     #[pyo3(signature = (node_id))]
     fn get_incoming(&self, py: Python<'_>, node_id: u64) -> PyResult<Vec<PyObject>> {
@@ -170,6 +176,12 @@ impl GraphStore {
                 .collect::<Vec<_>>()
         });
         Ok(edges.iter().map(|e| edge_to_dict(py, e)).collect())
+    }
+
+    /// Alias for `get_incoming`.
+    #[pyo3(signature = (node_id))]
+    fn get_incoming_edges(&self, py: Python<'_>, node_id: u64) -> PyResult<Vec<PyObject>> {
+        self.get_incoming(py, node_id)
     }
 
     /// Gets outgoing edges filtered by label.

--- a/crates/velesdb-python/tests/test_agent_memory.py
+++ b/crates/velesdb-python/tests/test_agent_memory.py
@@ -555,19 +555,21 @@ class TestSnapshots:
             assert v1 in versions
             assert v2 in versions
 
-    def test_load_latest_snapshot_returns_version(self, temp_db):
-        """load_latest_snapshot returns the version it restored.
-
-        The snapshot captures whatever the AgentMemory's own subsystems track;
-        here we assert the load mechanics (version returned, no error) rather
-        than getter-stored round-trips, which use independent TTL/tracking.
-        """
+    def test_load_latest_snapshot_restores_semantic_data(self, temp_db):
+        """load_latest_snapshot returns the version and restores data."""
         with tempfile.TemporaryDirectory() as snap_dir:
             mem = self._memory_with_snapshots(temp_db, snap_dir)
             mem.semantic.store(1, "snapshotted", [0.1, 0.2, 0.3, 0.4])
             created = mem.snapshot()
+            mem.semantic.delete(1)
+            assert mem.semantic.query([0.1, 0.2, 0.3, 0.4], top_k=10) == []
+
             loaded = mem.load_latest_snapshot()
+
             assert loaded == created
+            results = mem.semantic.query([0.1, 0.2, 0.3, 0.4], top_k=1)
+            assert results[0]["id"] == 1
+            assert results[0]["content"] == "snapshotted"
 
     def test_load_snapshot_version_does_not_raise(self, temp_db):
         """load_snapshot_version restores a known version without error."""
@@ -577,6 +579,25 @@ class TestSnapshots:
             v1 = mem.snapshot()
             mem.snapshot()
             mem.load_snapshot_version(v1)
+
+    def test_rollback_alias_restores_snapshot_version(self, temp_db):
+        """rollback is a compatibility alias that restores the target version."""
+        with tempfile.TemporaryDirectory() as snap_dir:
+            mem = self._memory_with_snapshots(temp_db, snap_dir)
+            mem.semantic.store(1, "first", [0.1, 0.2, 0.3, 0.4])
+            version = mem.snapshot()
+            mem.semantic.store(2, "second", [0.9, 0.8, 0.7, 0.6])
+
+            mem.rollback(version)
+
+            ids = [
+                result["id"]
+                for result in mem.semantic.query([0.9, 0.8, 0.7, 0.6], top_k=10)
+            ]
+            assert 2 not in ids
+            results = mem.semantic.query([0.1, 0.2, 0.3, 0.4], top_k=1)
+            assert results[0]["id"] == 1
+            assert results[0]["content"] == "first"
 
     def test_load_unknown_snapshot_version_raises(self, temp_db):
         """Loading a non-existent version raises."""

--- a/crates/velesdb-python/tests/test_database_gil.py
+++ b/crates/velesdb-python/tests/test_database_gil.py
@@ -103,6 +103,55 @@ def test_create_graph_collection_roundtrip(temp_db) -> None:
     assert "gil_graph" in temp_db.list_collections()
 
 
+def test_get_graph_collection_roundtrip(temp_db) -> None:
+    """`get_graph_collection` opens a persistent graph collection."""
+    temp_db.create_graph_collection("gil_graph_get")
+
+    gc = temp_db.get_graph_collection("gil_graph_get")
+    assert gc is not None
+    assert temp_db.get_graph_collection("missing_graph") is None
+
+    gc.upsert_node_payload(1, {"name": "node"})
+    assert gc.get_node_payload(1) == {"name": "node"}
+
+
+def test_graph_collection_edge_aliases_and_payload(temp_db) -> None:
+    """Documented graph alternatives work on persistent graph collections."""
+    gc = temp_db.create_graph_collection("gil_graph_aliases")
+    gc.upsert_node_payload(10, {"name": "Alice"})
+    gc.add_edge({"id": 1, "source": 10, "target": 20, "label": "KNOWS"})
+
+    assert gc.get_outgoing_edges(10) == gc.get_outgoing(10)
+    assert gc.get_incoming_edges(20) == gc.get_incoming(20)
+    assert gc.get_node_payload(10) == {"name": "Alice"}
+
+
+def test_graph_collection_legacy_methods_do_real_work(temp_db) -> None:
+    """Legacy graph call shapes are normalized to the persistent graph API."""
+    gc = temp_db.create_graph_collection("gil_graph_legacy", dimension=4)
+
+    gc.add_node(10, {"name": "Alice"}, vector=[1.0, 0.0, 0.0, 0.0])
+    gc.add_node(20, {"name": "Bob"})
+    gc.add_node(30, {"name": "Carol"})
+    gc.add_edge({"id": 1, "source": 10, "target": 20, "label": "KNOWS"})
+    gc.add_edge({"id": 3, "source": 10, "target": 30, "label": "KNOWS"})
+    gc.add_edge(20, 30, "KNOWS", 0.7)
+
+    assert gc.get_node_payload(10)["name"] == "Alice"
+    results = gc.search_by_embedding([1.0, 0.0, 0.0, 0.0], k=1)
+    assert results[0]["id"] == 10
+    outgoing = gc.get_outgoing_edges(20)
+    assert len(outgoing) == 1
+    assert outgoing[0]["id"] == 4
+    assert outgoing[0]["source"] == 20
+    assert outgoing[0]["target"] == 30
+    assert outgoing[0]["label"] == "KNOWS"
+    assert outgoing[0]["properties"]["weight"] == 0.7
+
+    assert gc.bfs(20, max_depth=1)[0]["target_id"] == 30
+    assert gc.dfs(20, max_depth=1)[0]["target_id"] == 30
+
+
 def test_analyze_collection_roundtrip(temp_db) -> None:
     """`analyze_collection` still computes and returns stats."""
     col = temp_db.create_collection("gil_analyze", dimension=4)

--- a/crates/velesdb-python/tests/test_graph.py
+++ b/crates/velesdb-python/tests/test_graph.py
@@ -77,6 +77,13 @@ class TestGraphStore:
         outgoing_200 = store.get_outgoing(200)
         assert len(outgoing_200) == 1
 
+    def test_get_outgoing_edges_alias(self):
+        """get_outgoing_edges is a compatibility alias for get_outgoing."""
+        store = GraphStore()
+        store.add_edge({"id": 1, "source": 100, "target": 200, "label": "KNOWS"})
+
+        assert store.get_outgoing_edges(100) == store.get_outgoing(100)
+
     def test_get_incoming(self):
         """Test getting incoming edges to a node."""
         store = GraphStore()
@@ -85,6 +92,28 @@ class TestGraphStore:
 
         incoming_200 = store.get_incoming(200)
         assert len(incoming_200) == 2
+
+    def test_get_incoming_edges_alias(self):
+        """get_incoming_edges is a compatibility alias for get_incoming."""
+        store = GraphStore()
+        store.add_edge({"id": 1, "source": 100, "target": 200, "label": "KNOWS"})
+
+        assert store.get_incoming_edges(200) == store.get_incoming(200)
+
+    def test_add_edge_legacy_positional_signature(self):
+        """add_edge(source, target, label, weight) is normalized to a dict edge."""
+        store = GraphStore()
+        store.add_edge({"id": 1, "source": 1, "target": 2, "label": "SEED"})
+        store.add_edge({"id": 3, "source": 1, "target": 3, "label": "SEED"})
+        store.add_edge(100, 200, "KNOWS", 0.7)
+
+        outgoing = store.get_outgoing_edges(100)
+        assert len(outgoing) == 1
+        assert outgoing[0]["id"] == 4
+        assert outgoing[0]["source"] == 100
+        assert outgoing[0]["target"] == 200
+        assert outgoing[0]["label"] == "KNOWS"
+        assert outgoing[0]["properties"]["weight"] == 0.7
 
     def test_get_outgoing_by_label(self):
         """Test getting outgoing edges filtered by label."""

--- a/crates/velesdb-python/tests/test_velesdb.py
+++ b/crates/velesdb-python/tests/test_velesdb.py
@@ -39,6 +39,13 @@ class TestDatabase:
         collections = temp_db.list_collections()
         assert collections == []
 
+    def test_get_collections_alias(self, temp_db):
+        """get_collections is a compatibility alias for list_collections."""
+        temp_db.create_collection("alias_collection", dimension=4)
+
+        assert temp_db.get_collections() == temp_db.list_collections()
+        assert "alias_collection" in temp_db.get_collections()
+
     def test_create_collection(self, temp_db):
         """Test collection creation."""
         collection = temp_db.create_collection("test", dimension=4, metric="cosine")
@@ -801,6 +808,32 @@ class TestFusionStrategy:
         assert strategy is not None
         assert "weighted" in repr(strategy).lower()
 
+    def test_fusion_strategy_weighted_dict(self):
+        """FusionStrategy.weighted() accepts a weights dict for compatibility."""
+        strategy = velesdb.FusionStrategy.weighted({
+            "avg_weight": 0.6,
+            "max_weight": 0.3,
+            "hit_weight": 0.1,
+        })
+        assert strategy is not None
+        assert "weighted" in repr(strategy).lower()
+
+    def test_fusion_strategy_weighted_legacy_two_args(self):
+        """FusionStrategy.weighted(max_weight, hit_weight) derives avg_weight."""
+        strategy = velesdb.FusionStrategy.weighted(0.3, 0.1)
+        assert strategy is not None
+        assert "avg_weight=0.6" in repr(strategy)
+        assert "max_weight=0.3" in repr(strategy)
+        assert "hit_weight=0.1" in repr(strategy)
+
+    def test_fusion_strategy_weighted_legacy_keyword_args(self):
+        """FusionStrategy.weighted(max_weight=..., hit_weight=...) also works."""
+        strategy = velesdb.FusionStrategy.weighted(max_weight=0.3, hit_weight=0.1)
+        assert strategy is not None
+        assert "avg_weight=0.6" in repr(strategy)
+        assert "max_weight=0.3" in repr(strategy)
+        assert "hit_weight=0.1" in repr(strategy)
+
     def test_fusion_strategy_weighted_invalid_sum(self):
         """Test FusionStrategy.weighted() with weights not summing to 1."""
         with pytest.raises(ValueError):
@@ -818,6 +851,25 @@ class TestFusionStrategy:
                 max_weight=0.6,
                 hit_weight=0.5
             )
+
+    def test_fusion_strategy_weighted_dict_missing_required_weight(self):
+        """weighted(dict) reports missing required max/hit components."""
+        with pytest.raises(ValueError):
+            velesdb.FusionStrategy.weighted({"avg_weight": 0.9, "max_weight": 0.1})
+
+    def test_fusion_strategy_rsf_alias_default(self):
+        """FusionStrategy.rsf() aliases relative_score() with balanced defaults."""
+        strategy = velesdb.FusionStrategy.rsf()
+        assert strategy is not None
+        assert "dense_weight=0.5" in repr(strategy)
+        assert "sparse_weight=0.5" in repr(strategy)
+
+    def test_fusion_strategy_rsf_alias_custom_weights(self):
+        """FusionStrategy.rsf() accepts the same weights as relative_score()."""
+        strategy = velesdb.FusionStrategy.rsf(dense_weight=0.7, sparse_weight=0.3)
+        assert strategy is not None
+        assert "dense_weight=0.7" in repr(strategy)
+        assert "sparse_weight=0.3" in repr(strategy)
 
 
 class TestMultiQuerySearch:

--- a/docs/guides/AGENT_MEMORY.md
+++ b/docs/guides/AGENT_MEMORY.md
@@ -714,6 +714,7 @@ memory = AgentMemory(db, dimension=384,
 version = memory.snapshot()                 # -> version number
 versions = memory.list_snapshot_versions()  # -> [1, 2, ...]
 memory.load_snapshot_version(version)       # restore a specific version
+memory.rollback(version)                    # compatibility alias
 memory.load_latest_snapshot()               # restore the most recent
 ```
 


### PR DESCRIPTION
## Summary

Closes the Python SDK documentation-vs-implementation gaps audited previously, with additional code quality improvements applied during review (2026-06-13).

**What changed vs the original draft (PR #1092):**
- `GraphCollection.has_edge()` was O(n) — scanned all edges via `get_edges(None)`. Fixed by adding `GraphCollection::has_edge(edge_id)` to the Rust core (`velesdb-core`) delegating to the existing `Collection::edge_exists` O(1) check, then exposing it on `PyGraphCollection`. Python adapter now calls `self._inner.has_edge()` directly.
- `_legacy_edge_to_dict` used `id` as a parameter name, shadowing the Python builtin. Renamed to `edge_id` (private helper — no public API impact). Both `GraphStore` and `GraphCollection` callers updated.

**All fixes from the original draft are preserved:**
- `get_collections()` alias on `Database`
- `get_outgoing_edges()` / `get_incoming_edges()` aliases on `GraphStore` and `GraphCollection`
- `rollback(version)` alias on `AgentMemory`
- `FusionStrategy.weighted(dict)` and legacy two-arg `weighted(max, hit)` forms
- `FusionStrategy.rsf()` alias for `relative_score()`
- `GraphCollection` Python adapter with `add_node(node_id, payload, vector)` for searchable graph embeddings
- `upsert_node` on core `GraphCollection` and `PyGraphCollection`

## Validation (2026-06-13)

- `cargo check -p velesdb-core -p velesdb-python` — clean
- `cargo test -p velesdb-core -- test_upsert_node_with_embedding_is_searchable` — 1 passed
- Full CI: 178 pytest passed (Python SDK Tests, Python Integrations, Perf Smoke all green)

## Notes

PR #1092 (`codex/python-sdk-api-parity-fixes` → `develop`) failed Git Flow & Freshness Checks because the `codex/` prefix is not in the allowed list. This PR uses the correct `fix/` prefix. PR #1092 can be closed as superseded.