### PR TITLE
feat(bindings): API parity PR-1 — compact_storage, batch graph edges, search_ids

### DIFF
--- a/crates/tauri-plugin-velesdb/build.rs
+++ b/crates/tauri-plugin-velesdb/build.rs
@@ -24,6 +24,7 @@ const COMMANDS: &[&str] = &[
     "get_collection",
     "is_empty",
     "flush",
+    "compact_storage",
     "scroll_collection",
     // Point operations
     "upsert",
@@ -32,6 +33,7 @@ const COMMANDS: &[&str] = &[
     "delete_points",
     // Search operations
     "search",
+    "search_ids",
     "batch_search",
     "text_search",
     "hybrid_search",
@@ -73,6 +75,7 @@ const COMMANDS: &[&str] = &[
     // Knowledge Graph
     "create_graph_collection",
     "add_edge",
+    "add_edges_batch",
     "get_edges",
     "traverse_graph",
     "get_node_degree",

--- a/crates/tauri-plugin-velesdb/permissions/autogenerated/commands/add_edges_batch.toml
+++ b/crates/tauri-plugin-velesdb/permissions/autogenerated/commands/add_edges_batch.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-add-edges-batch"
+description = "Enables the add_edges_batch command without any pre-configured scope."
+commands.allow = ["add_edges_batch"]
+
+[[permission]]
+identifier = "deny-add-edges-batch"
+description = "Denies the add_edges_batch command without any pre-configured scope."
+commands.deny = ["add_edges_batch"]

--- a/crates/tauri-plugin-velesdb/permissions/autogenerated/commands/compact_storage.toml
+++ b/crates/tauri-plugin-velesdb/permissions/autogenerated/commands/compact_storage.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-compact-storage"
+description = "Enables the compact_storage command without any pre-configured scope."
+commands.allow = ["compact_storage"]
+
+[[permission]]
+identifier = "deny-compact-storage"
+description = "Denies the compact_storage command without any pre-configured scope."
+commands.deny = ["compact_storage"]

--- a/crates/tauri-plugin-velesdb/permissions/autogenerated/commands/search_ids.toml
+++ b/crates/tauri-plugin-velesdb/permissions/autogenerated/commands/search_ids.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-search-ids"
+description = "Enables the search_ids command without any pre-configured scope."
+commands.allow = ["search_ids"]
+
+[[permission]]
+identifier = "deny-search-ids"
+description = "Denies the search_ids command without any pre-configured scope."
+commands.deny = ["search_ids"]

--- a/crates/tauri-plugin-velesdb/permissions/autogenerated/reference.md
+++ b/crates/tauri-plugin-velesdb/permissions/autogenerated/reference.md
@@ -11,12 +11,14 @@ Default permissions for VelesDB plugin - allows all database operations
 - `allow-get-collection`
 - `allow-is-empty`
 - `allow-flush`
+- `allow-compact-storage`
 - `allow-scroll-collection`
 - `allow-upsert`
 - `allow-upsert-metadata`
 - `allow-get-points`
 - `allow-delete-points`
 - `allow-search`
+- `allow-search-ids`
 - `allow-batch-search`
 - `allow-text-search`
 - `allow-hybrid-search`
@@ -60,6 +62,7 @@ Default permissions for VelesDB plugin - allows all database operations
 - `allow-memory-query-procedural`
 - `allow-create-graph-collection`
 - `allow-add-edge`
+- `allow-add-edges-batch`
 - `allow-get-edges`
 - `allow-traverse-graph`
 - `allow-get-node-degree`
@@ -106,6 +109,32 @@ Denies the add_edge command without any pre-configured scope.
 <tr>
 <td>
 
+`velesdb:allow-add-edges-batch`
+
+</td>
+<td>
+
+Enables the add_edges_batch command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`velesdb:deny-add-edges-batch`
+
+</td>
+<td>
+
+Denies the add_edges_batch command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
 `velesdb:allow-batch-search`
 
 </td>
@@ -125,6 +154,32 @@ Enables the batch_search command without any pre-configured scope.
 <td>
 
 Denies the batch_search command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`velesdb:allow-compact-storage`
+
+</td>
+<td>
+
+Enables the compact_storage command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`velesdb:deny-compact-storage`
+
+</td>
+<td>
+
+Denies the compact_storage command without any pre-configured scope.
 
 </td>
 </tr>
@@ -1295,6 +1350,32 @@ Enables the search command without any pre-configured scope.
 <td>
 
 Denies the search command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`velesdb:allow-search-ids`
+
+</td>
+<td>
+
+Enables the search_ids command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`velesdb:deny-search-ids`
+
+</td>
+<td>
+
+Denies the search_ids command without any pre-configured scope.
 
 </td>
 </tr>

--- a/crates/tauri-plugin-velesdb/permissions/default.toml
+++ b/crates/tauri-plugin-velesdb/permissions/default.toml
@@ -20,6 +20,7 @@ permissions = [
     "allow-get-collection",
     "allow-is-empty",
     "allow-flush",
+    "allow-compact-storage",
     "allow-scroll-collection",
     # Point operations
     "allow-upsert",
@@ -28,6 +29,7 @@ permissions = [
     "allow-delete-points",
     # Search operations
     "allow-search",
+    "allow-search-ids",
     "allow-batch-search",
     "allow-text-search",
     "allow-hybrid-search",
@@ -77,6 +79,7 @@ permissions = [
     # Knowledge Graph
     "allow-create-graph-collection",
     "allow-add-edge",
+    "allow-add-edges-batch",
     "allow-get-edges",
     "allow-traverse-graph",
     "allow-get-node-degree",
@@ -97,6 +100,7 @@ permissions = [
     "allow-get-points",
     "allow-scroll-collection",
     "allow-search",
+    "allow-search-ids",
     "allow-batch-search",
     "allow-text-search",
     "allow-hybrid-search",
@@ -119,6 +123,7 @@ permissions = [
 description = "Search-only permissions - no collection management"
 permissions = [
     "allow-search",
+    "allow-search-ids",
     "allow-text-search",
     "allow-hybrid-search",
 ]

--- a/crates/tauri-plugin-velesdb/permissions/schemas/schema.json
+++ b/crates/tauri-plugin-velesdb/permissions/schemas/schema.json
@@ -307,6 +307,18 @@
           "markdownDescription": "Denies the add_edge command without any pre-configured scope."
         },
         {
+          "description": "Enables the add_edges_batch command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-add-edges-batch",
+          "markdownDescription": "Enables the add_edges_batch command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the add_edges_batch command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-add-edges-batch",
+          "markdownDescription": "Denies the add_edges_batch command without any pre-configured scope."
+        },
+        {
           "description": "Enables the batch_search command without any pre-configured scope.",
           "type": "string",
           "const": "allow-batch-search",
@@ -317,6 +329,18 @@
           "type": "string",
           "const": "deny-batch-search",
           "markdownDescription": "Denies the batch_search command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the compact_storage command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-compact-storage",
+          "markdownDescription": "Enables the compact_storage command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the compact_storage command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-compact-storage",
+          "markdownDescription": "Denies the compact_storage command without any pre-configured scope."
         },
         {
           "description": "Enables the create_collection command without any pre-configured scope.",
@@ -859,6 +883,18 @@
           "markdownDescription": "Denies the search command without any pre-configured scope."
         },
         {
+          "description": "Enables the search_ids command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-search-ids",
+          "markdownDescription": "Enables the search_ids command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the search_ids command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-search-ids",
+          "markdownDescription": "Denies the search_ids command without any pre-configured scope."
+        },
+        {
           "description": "Enables the semantic_delete command without any pre-configured scope.",
           "type": "string",
           "const": "allow-semantic-delete",
@@ -1051,10 +1087,10 @@
           "markdownDescription": "Denies the upsert_metadata command without any pre-configured scope."
         },
         {
-          "description": "Default permissions for VelesDB plugin - allows all database operations\n#### This default permission set includes:\n\n- `allow-create-collection`\n- `allow-create-metadata-collection`\n- `allow-delete-collection`\n- `allow-list-collections`\n- `allow-get-collection`\n- `allow-is-empty`\n- `allow-flush`\n- `allow-scroll-collection`\n- `allow-upsert`\n- `allow-upsert-metadata`\n- `allow-get-points`\n- `allow-delete-points`\n- `allow-search`\n- `allow-batch-search`\n- `allow-text-search`\n- `allow-hybrid-search`\n- `allow-multi-query-search`\n- `allow-query`\n- `allow-sparse-search`\n- `allow-hybrid-sparse-search`\n- `allow-sparse-upsert`\n- `allow-train-pq`\n- `allow-stream-insert`\n- `allow-semantic-store`\n- `allow-semantic-store-with-ttl`\n- `allow-semantic-query`\n- `allow-semantic-delete`\n- `allow-semantic-dimension`\n- `allow-semantic-serialize`\n- `allow-semantic-deserialize`\n- `allow-episodic-record`\n- `allow-episodic-recent`\n- `allow-episodic-recall-similar`\n- `allow-episodic-older-than`\n- `allow-episodic-delete`\n- `allow-episodic-serialize`\n- `allow-episodic-deserialize`\n- `allow-procedural-learn`\n- `allow-procedural-recall`\n- `allow-procedural-reinforce`\n- `allow-procedural-list-all`\n- `allow-procedural-delete`\n- `allow-procedural-serialize`\n- `allow-procedural-deserialize`\n- `allow-memory-set-ttl`\n- `allow-memory-auto-expire`\n- `allow-memory-evict-low-confidence`\n- `allow-memory-snapshot`\n- `allow-memory-load-latest-snapshot`\n- `allow-memory-load-snapshot-version`\n- `allow-memory-list-snapshot-versions`\n- `allow-memory-query-semantic`\n- `allow-memory-query-episodic`\n- `allow-memory-query-procedural`\n- `allow-create-graph-collection`\n- `allow-add-edge`\n- `allow-get-edges`\n- `allow-traverse-graph`\n- `allow-get-node-degree`\n- `allow-traverse-graph-parallel`\n- `allow-create-index`\n- `allow-drop-index`\n- `allow-list-indexes`",
+          "description": "Default permissions for VelesDB plugin - allows all database operations\n#### This default permission set includes:\n\n- `allow-create-collection`\n- `allow-create-metadata-collection`\n- `allow-delete-collection`\n- `allow-list-collections`\n- `allow-get-collection`\n- `allow-is-empty`\n- `allow-flush`\n- `allow-compact-storage`\n- `allow-scroll-collection`\n- `allow-upsert`\n- `allow-upsert-metadata`\n- `allow-get-points`\n- `allow-delete-points`\n- `allow-search`\n- `allow-search-ids`\n- `allow-batch-search`\n- `allow-text-search`\n- `allow-hybrid-search`\n- `allow-multi-query-search`\n- `allow-query`\n- `allow-sparse-search`\n- `allow-hybrid-sparse-search`\n- `allow-sparse-upsert`\n- `allow-train-pq`\n- `allow-stream-insert`\n- `allow-semantic-store`\n- `allow-semantic-store-with-ttl`\n- `allow-semantic-query`\n- `allow-semantic-delete`\n- `allow-semantic-dimension`\n- `allow-semantic-serialize`\n- `allow-semantic-deserialize`\n- `allow-episodic-record`\n- `allow-episodic-recent`\n- `allow-episodic-recall-similar`\n- `allow-episodic-older-than`\n- `allow-episodic-delete`\n- `allow-episodic-serialize`\n- `allow-episodic-deserialize`\n- `allow-procedural-learn`\n- `allow-procedural-recall`\n- `allow-procedural-reinforce`\n- `allow-procedural-list-all`\n- `allow-procedural-delete`\n- `allow-procedural-serialize`\n- `allow-procedural-deserialize`\n- `allow-memory-set-ttl`\n- `allow-memory-auto-expire`\n- `allow-memory-evict-low-confidence`\n- `allow-memory-snapshot`\n- `allow-memory-load-latest-snapshot`\n- `allow-memory-load-snapshot-version`\n- `allow-memory-list-snapshot-versions`\n- `allow-memory-query-semantic`\n- `allow-memory-query-episodic`\n- `allow-memory-query-procedural`\n- `allow-create-graph-collection`\n- `allow-add-edge`\n- `allow-add-edges-batch`\n- `allow-get-edges`\n- `allow-traverse-graph`\n- `allow-get-node-degree`\n- `allow-traverse-graph-parallel`\n- `allow-create-index`\n- `allow-drop-index`\n- `allow-list-indexes`",
           "type": "string",
           "const": "default",
-          "markdownDescription": "Default permissions for VelesDB plugin - allows all database operations\n#### This default permission set includes:\n\n- `allow-create-collection`\n- `allow-create-metadata-collection`\n- `allow-delete-collection`\n- `allow-list-collections`\n- `allow-get-collection`\n- `allow-is-empty`\n- `allow-flush`\n- `allow-scroll-collection`\n- `allow-upsert`\n- `allow-upsert-metadata`\n- `allow-get-points`\n- `allow-delete-points`\n- `allow-search`\n- `allow-batch-search`\n- `allow-text-search`\n- `allow-hybrid-search`\n- `allow-multi-query-search`\n- `allow-query`\n- `allow-sparse-search`\n- `allow-hybrid-sparse-search`\n- `allow-sparse-upsert`\n- `allow-train-pq`\n- `allow-stream-insert`\n- `allow-semantic-store`\n- `allow-semantic-store-with-ttl`\n- `allow-semantic-query`\n- `allow-semantic-delete`\n- `allow-semantic-dimension`\n- `allow-semantic-serialize`\n- `allow-semantic-deserialize`\n- `allow-episodic-record`\n- `allow-episodic-recent`\n- `allow-episodic-recall-similar`\n- `allow-episodic-older-than`\n- `allow-episodic-delete`\n- `allow-episodic-serialize`\n- `allow-episodic-deserialize`\n- `allow-procedural-learn`\n- `allow-procedural-recall`\n- `allow-procedural-reinforce`\n- `allow-procedural-list-all`\n- `allow-procedural-delete`\n- `allow-procedural-serialize`\n- `allow-procedural-deserialize`\n- `allow-memory-set-ttl`\n- `allow-memory-auto-expire`\n- `allow-memory-evict-low-confidence`\n- `allow-memory-snapshot`\n- `allow-memory-load-latest-snapshot`\n- `allow-memory-load-snapshot-version`\n- `allow-memory-list-snapshot-versions`\n- `allow-memory-query-semantic`\n- `allow-memory-query-episodic`\n- `allow-memory-query-procedural`\n- `allow-create-graph-collection`\n- `allow-add-edge`\n- `allow-get-edges`\n- `allow-traverse-graph`\n- `allow-get-node-degree`\n- `allow-traverse-graph-parallel`\n- `allow-create-index`\n- `allow-drop-index`\n- `allow-list-indexes`"
+          "markdownDescription": "Default permissions for VelesDB plugin - allows all database operations\n#### This default permission set includes:\n\n- `allow-create-collection`\n- `allow-create-metadata-collection`\n- `allow-delete-collection`\n- `allow-list-collections`\n- `allow-get-collection`\n- `allow-is-empty`\n- `allow-flush`\n- `allow-compact-storage`\n- `allow-scroll-collection`\n- `allow-upsert`\n- `allow-upsert-metadata`\n- `allow-get-points`\n- `allow-delete-points`\n- `allow-search`\n- `allow-search-ids`\n- `allow-batch-search`\n- `allow-text-search`\n- `allow-hybrid-search`\n- `allow-multi-query-search`\n- `allow-query`\n- `allow-sparse-search`\n- `allow-hybrid-sparse-search`\n- `allow-sparse-upsert`\n- `allow-train-pq`\n- `allow-stream-insert`\n- `allow-semantic-store`\n- `allow-semantic-store-with-ttl`\n- `allow-semantic-query`\n- `allow-semantic-delete`\n- `allow-semantic-dimension`\n- `allow-semantic-serialize`\n- `allow-semantic-deserialize`\n- `allow-episodic-record`\n- `allow-episodic-recent`\n- `allow-episodic-recall-similar`\n- `allow-episodic-older-than`\n- `allow-episodic-delete`\n- `allow-episodic-serialize`\n- `allow-episodic-deserialize`\n- `allow-procedural-learn`\n- `allow-procedural-recall`\n- `allow-procedural-reinforce`\n- `allow-procedural-list-all`\n- `allow-procedural-delete`\n- `allow-procedural-serialize`\n- `allow-procedural-deserialize`\n- `allow-memory-set-ttl`\n- `allow-memory-auto-expire`\n- `allow-memory-evict-low-confidence`\n- `allow-memory-snapshot`\n- `allow-memory-load-latest-snapshot`\n- `allow-memory-load-snapshot-version`\n- `allow-memory-list-snapshot-versions`\n- `allow-memory-query-semantic`\n- `allow-memory-query-episodic`\n- `allow-memory-query-procedural`\n- `allow-create-graph-collection`\n- `allow-add-edge`\n- `allow-add-edges-batch`\n- `allow-get-edges`\n- `allow-traverse-graph`\n- `allow-get-node-degree`\n- `allow-traverse-graph-parallel`\n- `allow-create-index`\n- `allow-drop-index`\n- `allow-list-indexes`"
         }
       ]
     }

--- a/crates/tauri-plugin-velesdb/src/commands.rs
+++ b/crates/tauri-plugin-velesdb/src/commands.rs
@@ -17,9 +17,9 @@ pub use crate::types::{
 };
 use crate::types::{
     BatchSearchRequest, CollectionInfo, CreateCollectionRequest, CreateMetadataCollectionRequest,
-    DeletePointsRequest, GetPointsRequest, HybridSearchRequest, MultiQuerySearchRequest,
-    PointOutput, ScrollRequest, ScrollResponse, SearchRequest, SearchResponse, TextSearchRequest,
-    TrainPqRequest, UpsertMetadataRequest, UpsertRequest,
+    DeletePointsRequest, GetPointsRequest, HybridSearchRequest, IdScoreOutput,
+    MultiQuerySearchRequest, PointOutput, ScrollRequest, ScrollResponse, SearchRequest,
+    SearchResponse, TextSearchRequest, TrainPqRequest, UpsertMetadataRequest, UpsertRequest,
 };
 use tauri::{command, AppHandle, Runtime, State};
 
@@ -358,6 +358,43 @@ pub async fn search<R: Runtime>(
     Ok(timed_search_response(results, start))
 }
 
+/// k-NN search returning only IDs and scores (no payloads).
+///
+/// Uses the optimized core `search_ids` path when no filter is supplied,
+/// which skips payload hydration. When a filter is present, falls back to
+/// filtered search and projects the results to IDs + scores.
+#[command]
+pub async fn search_ids<R: Runtime>(
+    _app: AppHandle<R>,
+    state: State<'_, VelesDbState>,
+    request: SearchRequest,
+) -> std::result::Result<Vec<IdScoreOutput>, CommandError> {
+    let parsed_filter = parse_filter(&request.filter).map_err(CommandError::from)?;
+    state
+        .with_db(|db| {
+            let coll = require_collection(&db, &request.collection)?;
+            let scored: Vec<IdScoreOutput> = if let Some(ref f) = parsed_filter {
+                coll.search_with_filter(&request.vector, request.top_k, f)?
+                    .into_iter()
+                    .map(|r| IdScoreOutput {
+                        id: r.point.id,
+                        score: r.score,
+                    })
+                    .collect()
+            } else {
+                coll.search_ids(&request.vector, request.top_k)?
+                    .into_iter()
+                    .map(|r| IdScoreOutput {
+                        id: r.id,
+                        score: r.score,
+                    })
+                    .collect()
+            };
+            Ok(scored)
+        })
+        .map_err(CommandError::from)
+}
+
 /// Batch search for multiple query vectors.
 ///
 /// When any individual search specifies a `quality` mode, each search is
@@ -552,6 +589,23 @@ pub async fn flush<R: Runtime>(
             let coll = require_collection(&db, &name)?;
             coll.flush()?;
             Ok(())
+        })
+        .map_err(CommandError::from)
+}
+
+/// Compacts on-disk storage for a collection, reclaiming space from deleted
+/// vectors. Returns the number of bytes reclaimed.
+#[command]
+pub async fn compact_storage<R: Runtime>(
+    _app: AppHandle<R>,
+    state: State<'_, VelesDbState>,
+    name: String,
+) -> std::result::Result<u64, CommandError> {
+    state
+        .with_db(|db| {
+            let coll = require_collection(&db, &name)?;
+            let freed = coll.compact_storage()?;
+            Ok(u64::try_from(freed).unwrap_or(u64::MAX))
         })
         .map_err(CommandError::from)
 }

--- a/crates/tauri-plugin-velesdb/src/commands.rs
+++ b/crates/tauri-plugin-velesdb/src/commands.rs
@@ -286,6 +286,30 @@ pub async fn delete_points<R: Runtime>(
         .map_err(CommandError::from)
 }
 
+/// Parsed quality argument: a real [`velesdb_core::SearchQuality`] with
+/// `persistence`, otherwise the unit type (quality unsupported).
+#[cfg(feature = "persistence")]
+type QualityArg<'a> = Option<&'a velesdb_core::SearchQuality>;
+#[cfg(not(feature = "persistence"))]
+type QualityArg<'a> = Option<&'a ()>;
+
+/// Runs a vector search honoring filter precedence then quality, returning full
+/// results. Shared by [`search`] and [`search_ids`]. Filter takes precedence
+/// (known limitation #457: quality ignored when a filter is present).
+fn search_full(
+    coll: &velesdb_core::VectorCollection,
+    request: &SearchRequest,
+    filter: Option<&velesdb_core::Filter>,
+    quality: QualityArg<'_>,
+) -> crate::error::Result<Vec<velesdb_core::SearchResult>> {
+    if let Some(f) = filter {
+        coll.search_with_filter(&request.vector, request.top_k, f)
+            .map_err(crate::error::Error::Database)
+    } else {
+        dispatch_quality_search(coll, &request.vector, request.top_k, quality)
+    }
+}
+
 /// Dispatches a single search with optional quality mode.
 ///
 /// When quality is `Some`, delegates to `search_with_quality`;
@@ -338,19 +362,12 @@ pub async fn search<R: Runtime>(
     let results = state
         .with_db(|db| {
             let coll = require_collection(&db, &request.collection)?;
-
-            // Filter takes precedence (known limitation #457: quality ignored
-            // when filter is present). Quality dispatch only when no filter.
-            let search_results = if let Some(ref f) = parsed_filter {
-                coll.search_with_filter(&request.vector, request.top_k, f)?
-            } else {
-                dispatch_quality_search(
-                    &coll,
-                    &request.vector,
-                    request.top_k,
-                    parsed_quality.as_ref(),
-                )?
-            };
+            let search_results = search_full(
+                &coll,
+                &request,
+                parsed_filter.as_ref(),
+                parsed_quality.as_ref(),
+            )?;
             Ok(map_core_results(search_results))
         })
         .map_err(CommandError::from)?;
@@ -358,11 +375,24 @@ pub async fn search<R: Runtime>(
     Ok(timed_search_response(results, start))
 }
 
+/// Projects full search results down to ID + score pairs.
+fn project_search_ids(results: Vec<velesdb_core::SearchResult>) -> Vec<IdScoreOutput> {
+    results
+        .into_iter()
+        .map(|r| IdScoreOutput {
+            id: r.point.id,
+            score: r.score,
+        })
+        .collect()
+}
+
 /// k-NN search returning only IDs and scores (no payloads).
 ///
-/// Uses the optimized core `search_ids` path when no filter is supplied,
-/// which skips payload hydration. When a filter is present, falls back to
-/// filtered search and projects the results to IDs + scores.
+/// Uses the optimized core `search_ids` path when neither a filter nor a
+/// `quality` mode is supplied, which skips payload hydration. When a filter is
+/// present (precedence, known limitation #457: quality ignored), or a `quality`
+/// mode is requested, falls back to the corresponding full search and projects
+/// the results to IDs + scores.
 #[command]
 pub async fn search_ids<R: Runtime>(
     _app: AppHandle<R>,
@@ -370,18 +400,18 @@ pub async fn search_ids<R: Runtime>(
     request: SearchRequest,
 ) -> std::result::Result<Vec<IdScoreOutput>, CommandError> {
     let parsed_filter = parse_filter(&request.filter).map_err(CommandError::from)?;
+    #[cfg(feature = "persistence")]
+    let parsed_quality = parse_search_quality(&request.quality).map_err(CommandError::from)?;
+    #[cfg(not(feature = "persistence"))]
+    let parsed_quality: Option<()> = None;
+
     state
         .with_db(|db| {
             let coll = require_collection(&db, &request.collection)?;
-            let scored: Vec<IdScoreOutput> = if let Some(ref f) = parsed_filter {
-                coll.search_with_filter(&request.vector, request.top_k, f)?
-                    .into_iter()
-                    .map(|r| IdScoreOutput {
-                        id: r.point.id,
-                        score: r.score,
-                    })
-                    .collect()
-            } else {
+            // Optimized id-only path only when no filter and no quality; both
+            // require the full search that hydrates results before projecting.
+            let scored: Vec<IdScoreOutput> = if parsed_filter.is_none() && parsed_quality.is_none()
+            {
                 coll.search_ids(&request.vector, request.top_k)?
                     .into_iter()
                     .map(|r| IdScoreOutput {
@@ -389,6 +419,13 @@ pub async fn search_ids<R: Runtime>(
                         score: r.score,
                     })
                     .collect()
+            } else {
+                project_search_ids(search_full(
+                    &coll,
+                    &request,
+                    parsed_filter.as_ref(),
+                    parsed_quality.as_ref(),
+                )?)
             };
             Ok(scored)
         })

--- a/crates/tauri-plugin-velesdb/src/commands_graph.rs
+++ b/crates/tauri-plugin-velesdb/src/commands_graph.rs
@@ -8,9 +8,9 @@ use crate::events::emit_collection_created;
 use crate::helpers::{parse_metric, require_graph_collection};
 use crate::state::VelesDbState;
 use crate::types::{
-    AddEdgeRequest, CollectionInfo, CreateGraphCollectionRequest, EdgeOutput, GetEdgesRequest,
-    GetNodeDegreeRequest, NodeDegreeOutput, TraversalOutput, TraverseGraphParallelRequest,
-    TraverseGraphRequest,
+    AddEdgeRequest, AddEdgesBatchRequest, CollectionInfo, CreateGraphCollectionRequest, EdgeOutput,
+    GetEdgesRequest, GetNodeDegreeRequest, NodeDegreeOutput, TraversalOutput,
+    TraverseGraphParallelRequest, TraverseGraphRequest,
 };
 use tauri::{command, AppHandle, Runtime, State};
 use velesdb_core::collection::graph::TraversalConfig;
@@ -55,6 +55,25 @@ pub async fn create_graph_collection<R: Runtime>(
     Ok(result)
 }
 
+/// Builds a core [`GraphEdge`](velesdb_core::GraphEdge) from raw edge fields,
+/// validating the edge and normalizing properties. Shared by [`add_edge`] and
+/// [`add_edges_batch`].
+fn build_edge(
+    id: u64,
+    source: u64,
+    target: u64,
+    label: &str,
+    properties: Option<serde_json::Value>,
+) -> std::result::Result<velesdb_core::GraphEdge, Error> {
+    let properties: std::collections::HashMap<String, serde_json::Value> = match properties {
+        Some(serde_json::Value::Object(map)) => map.into_iter().collect(),
+        _ => std::collections::HashMap::new(),
+    };
+    velesdb_core::GraphEdge::new(id, source, target, label)
+        .map_err(|e| Error::InvalidConfig(e.to_string()))
+        .map(|edge| edge.with_properties(properties))
+}
+
 /// Adds an edge to the knowledge graph.
 #[command]
 pub async fn add_edge<R: Runtime>(
@@ -65,26 +84,41 @@ pub async fn add_edge<R: Runtime>(
     state
         .with_db(|db| {
             let coll = require_graph_collection(&db, &request.collection)?;
-
-            // Convert properties to HashMap
-            let properties: std::collections::HashMap<String, serde_json::Value> =
-                match request.properties {
-                    Some(serde_json::Value::Object(map)) => map.into_iter().collect(),
-                    _ => std::collections::HashMap::new(),
-                };
-
-            let edge = velesdb_core::GraphEdge::new(
+            let edge = build_edge(
                 request.id,
                 request.source,
                 request.target,
                 &request.label,
-            )
-            .map_err(|e| Error::InvalidConfig(e.to_string()))?
-            .with_properties(properties);
-
+                request.properties,
+            )?;
             coll.add_edge(edge)
                 .map_err(|e| Error::InvalidConfig(e.to_string()))?;
             Ok(())
+        })
+        .map_err(CommandError::from)
+}
+
+/// Adds multiple edges to the knowledge graph in one batched operation.
+///
+/// Returns the number of edges inserted.
+#[command]
+pub async fn add_edges_batch<R: Runtime>(
+    _app: AppHandle<R>,
+    state: State<'_, VelesDbState>,
+    request: AddEdgesBatchRequest,
+) -> std::result::Result<u64, CommandError> {
+    state
+        .with_db(|db| {
+            let coll = require_graph_collection(&db, &request.collection)?;
+            let edges = request
+                .edges
+                .into_iter()
+                .map(|e| build_edge(e.id, e.source, e.target, &e.label, e.properties))
+                .collect::<std::result::Result<Vec<_>, _>>()?;
+            let added = coll
+                .add_edges_batch(edges)
+                .map_err(|e| Error::InvalidConfig(e.to_string()))?;
+            Ok(u64::try_from(added).unwrap_or(u64::MAX))
         })
         .map_err(CommandError::from)
 }
@@ -206,4 +240,28 @@ pub async fn traverse_graph_parallel<R: Runtime>(
                 .collect())
         })
         .map_err(CommandError::from)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::build_edge;
+
+    #[test]
+    fn test_build_edge_with_object_properties() {
+        let edge = build_edge(1, 10, 20, "KNOWS", Some(serde_json::json!({"weight": 0.5})))
+            .expect("valid edge");
+        assert_eq!(edge.id(), 1);
+        assert_eq!(edge.source(), 10);
+        assert_eq!(edge.target(), 20);
+        assert_eq!(edge.label(), "KNOWS");
+    }
+
+    #[test]
+    fn test_build_edge_null_and_non_object_properties_default_empty() {
+        // Null and non-object property payloads normalize to no properties
+        // rather than erroring.
+        assert!(build_edge(2, 1, 2, "L", None).is_ok());
+        assert!(build_edge(3, 1, 2, "L", Some(serde_json::Value::Null)).is_ok());
+        assert!(build_edge(4, 1, 2, "L", Some(serde_json::json!("scalar"))).is_ok());
+    }
 }

--- a/crates/tauri-plugin-velesdb/src/commands_tests.rs
+++ b/crates/tauri-plugin-velesdb/src/commands_tests.rs
@@ -831,3 +831,35 @@ fn test_scroll_response_no_next_cursor() {
     // next_cursor should be skipped when None
     assert!(!json.contains("nextCursor"));
 }
+
+#[test]
+fn test_add_edges_batch_request_deserialize() {
+    use crate::types::AddEdgesBatchRequest;
+    let req: AddEdgesBatchRequest = serde_json::from_str(
+        r#"{
+            "collection": "kg",
+            "edges": [
+                {"id": 1, "source": 10, "target": 20, "label": "KNOWS"},
+                {"id": 2, "source": 20, "target": 30, "label": "WROTE",
+                 "properties": {"weight": 0.5}}
+            ]
+        }"#,
+    )
+    .unwrap();
+    assert_eq!(req.collection, "kg");
+    assert_eq!(req.edges.len(), 2);
+    assert_eq!(req.edges[0].label, "KNOWS");
+    assert_eq!(req.edges[1].target, 30);
+    assert!(req.edges[1].properties.is_some());
+    // Properties default to None when omitted.
+    assert!(req.edges[0].properties.is_none());
+}
+
+#[test]
+fn test_id_score_output_serialize() {
+    use crate::types::IdScoreOutput;
+    let out = IdScoreOutput { id: 7, score: 0.42 };
+    let json = serde_json::to_string(&out).unwrap();
+    assert!(json.contains("\"id\":7"));
+    assert!(json.contains("\"score\":0.42"));
+}

--- a/crates/tauri-plugin-velesdb/src/lib.rs
+++ b/crates/tauri-plugin-velesdb/src/lib.rs
@@ -136,6 +136,9 @@ macro_rules! velesdb_invoke_handler {
 ///     .expect("error while running tauri application");
 /// ```
 #[must_use]
+// The body is a flat command-registration list (trivial cyclomatic complexity);
+// the line count grows linearly with the number of exposed commands.
+#[allow(clippy::too_many_lines)]
 pub fn init_with_path<R: Runtime, P: AsRef<Path>>(path: P) -> TauriPlugin<R> {
     let db_path = path.as_ref().to_path_buf();
 
@@ -151,6 +154,7 @@ pub fn init_with_path<R: Runtime, P: AsRef<Path>>(path: P) -> TauriPlugin<R> {
             commands::get_points,
             commands::delete_points,
             commands::search,
+            commands::search_ids,
             commands::batch_search,
             commands::text_search,
             commands::hybrid_search,
@@ -158,6 +162,7 @@ pub fn init_with_path<R: Runtime, P: AsRef<Path>>(path: P) -> TauriPlugin<R> {
             commands_query::query,
             commands::is_empty,
             commands::flush,
+            commands::compact_storage,
             commands::scroll_collection,
             // Sparse vector commands
             commands_sparse::sparse_search,
@@ -201,6 +206,7 @@ pub fn init_with_path<R: Runtime, P: AsRef<Path>>(path: P) -> TauriPlugin<R> {
             // Knowledge Graph commands (EPIC-015 US-001)
             commands_graph::create_graph_collection,
             commands_graph::add_edge,
+            commands_graph::add_edges_batch,
             commands_graph::get_edges,
             commands_graph::traverse_graph,
             commands_graph::get_node_degree,

--- a/crates/tauri-plugin-velesdb/src/types.rs
+++ b/crates/tauri-plugin-velesdb/src/types.rs
@@ -477,6 +477,16 @@ pub struct SearchResponse {
     pub timing_ms: f64,
 }
 
+/// A single ID + score result returned by the `search_ids` command.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct IdScoreOutput {
+    /// Matched point ID.
+    pub id: u64,
+    /// Relevance score.
+    pub score: f32,
+}
+
 // ============================================================================
 // Default value functions (Tauri-specific)
 // ============================================================================

--- a/crates/tauri-plugin-velesdb/src/types_graph.rs
+++ b/crates/tauri-plugin-velesdb/src/types_graph.rs
@@ -49,6 +49,33 @@ pub struct AddEdgeRequest {
     pub properties: Option<serde_json::Value>,
 }
 
+/// A single edge inside a batched insert request.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BatchEdgeInput {
+    /// Edge ID.
+    pub id: u64,
+    /// Source node ID.
+    pub source: u64,
+    /// Target node ID.
+    pub target: u64,
+    /// Edge label (relationship type).
+    pub label: String,
+    /// Optional edge properties.
+    #[serde(default)]
+    pub properties: Option<serde_json::Value>,
+}
+
+/// Request to add multiple edges to the knowledge graph in one operation.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AddEdgesBatchRequest {
+    /// Collection name.
+    pub collection: String,
+    /// Edges to insert.
+    pub edges: Vec<BatchEdgeInput>,
+}
+
 /// Request to get edges from the knowledge graph.
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/crates/velesdb-mobile/src/collection.rs
+++ b/crates/velesdb-mobile/src/collection.rs
@@ -492,6 +492,13 @@ impl VelesCollection {
         Ok(())
     }
 
+    /// Compacts on-disk storage, reclaiming space left by deleted vectors.
+    ///
+    /// Returns the number of bytes reclaimed.
+    pub fn compact_storage(&self) -> Result<u64, VelesError> {
+        Ok(u64::try_from(self.inner.compact_storage()?).unwrap_or(u64::MAX))
+    }
+
     /// Returns all point IDs currently present in the collection.
     pub fn all_ids(&self) -> Vec<u64> {
         self.inner.all_ids()

--- a/crates/velesdb-mobile/src/lib_tests.rs
+++ b/crates/velesdb-mobile/src/lib_tests.rs
@@ -342,6 +342,36 @@ fn test_collection_delete() {
 }
 
 #[test]
+fn test_collection_compact_storage() {
+    let tmp = TempDir::new().unwrap();
+    let path = tmp.path().to_str().unwrap().to_string();
+
+    let db = VelesDatabase::open(path).unwrap();
+    db.create_collection("compact_test".to_string(), 4, DistanceMetric::Cosine)
+        .unwrap();
+    let col = db
+        .get_collection("compact_test".to_string())
+        .unwrap()
+        .unwrap();
+
+    for id in 0..5u64 {
+        col.upsert(VelesPoint {
+            id,
+            vector: vec![1.0, 0.0, 0.0, 0.0],
+            payload: None,
+        })
+        .unwrap();
+    }
+    col.delete(0).unwrap();
+    col.delete(1).unwrap();
+
+    // Compaction must succeed and return the reclaimed byte count; live
+    // points are unaffected.
+    let _freed = col.compact_storage().unwrap();
+    assert_eq!(col.count(), 3);
+}
+
+#[test]
 fn test_collection_with_json_payload() {
     let tmp = TempDir::new().unwrap();
     let path = tmp.path().to_str().unwrap().to_string();

--- a/crates/velesdb-python/src/collection/mod.rs
+++ b/crates/velesdb-python/src/collection/mod.rs
@@ -202,6 +202,15 @@ impl Collection {
         py.allow_threads(|| self.inner.flush_full().map_err(core_err))
     }
 
+    /// Compact on-disk storage, reclaiming space left by deleted vectors.
+    ///
+    /// Returns:
+    ///     int: Number of bytes reclaimed.
+    fn compact_storage(&self, py: Python<'_>) -> PyResult<usize> {
+        use crate::collection_helpers::core_err;
+        py.allow_threads(|| self.inner.compact_storage().map_err(core_err))
+    }
+
     /// Check if a secondary index exists on a payload field.
     ///
     /// Args:

--- a/crates/velesdb-python/tests/test_velesdb.py
+++ b/crates/velesdb-python/tests/test_velesdb.py
@@ -217,6 +217,22 @@ class TestCollection:
         collection.upsert([{"id": 1, "vector": [1.0, 0.0, 0.0, 0.0]}])
         collection.flush()  # Should not raise
 
+    def test_compact_storage(self, temp_db):
+        """Test compact_storage reclaims space and returns a byte count."""
+        collection = temp_db.create_collection("compact_test", dimension=4)
+
+        collection.upsert([
+            {"id": i, "vector": [1.0, 0.0, 0.0, 0.0]} for i in range(5)
+        ])
+        collection.delete([0, 1, 2])
+
+        freed = collection.compact_storage()
+        assert isinstance(freed, int)
+        assert freed >= 0
+
+        # Live points are unaffected by compaction.
+        assert collection.count() == 2
+
 
 class TestNumpySupport:
     """Tests for NumPy array support."""

--- a/crates/velesdb-server/src/handlers/graph/handlers.rs
+++ b/crates/velesdb-server/src/handlers/graph/handlers.rs
@@ -18,8 +18,8 @@ use crate::types::ErrorResponse;
 use crate::AppState;
 
 use super::types::{
-    AddEdgeRequest, DegreeResponse, EdgeQueryParams, EdgeResponse, EdgesResponse, TraversalStats,
-    TraverseRequest, TraverseResponse,
+    AddEdgeRequest, AddEdgesBatchRequest, AddEdgesBatchResponse, DegreeResponse, EdgeQueryParams,
+    EdgeResponse, EdgesResponse, TraversalStats, TraverseRequest, TraverseResponse,
 };
 
 /// Shared graph preamble: record metric and resolve collection.
@@ -157,6 +157,28 @@ pub async fn add_edge(
     State(state): State<Arc<AppState>>,
     Json(request): Json<AddEdgeRequest>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
+    let edge = build_edge(request)?;
+
+    let coll = graph_preamble(&state, &name)?;
+
+    coll.add_edge(edge).map_err(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse {
+                error: format!("Failed to add edge: {e}"),
+                code: None,
+            }),
+        )
+    })?;
+
+    Ok(StatusCode::CREATED)
+}
+
+/// Converts an [`AddEdgeRequest`] into a core [`GraphEdge`], validating the
+/// properties shape and edge fields. Shared by [`add_edge`] and
+/// [`add_edges_batch`].
+#[allow(clippy::result_large_err)]
+fn build_edge(request: AddEdgeRequest) -> Result<GraphEdge, (StatusCode, Json<ErrorResponse>)> {
     let properties: std::collections::HashMap<String, serde_json::Value> = match request.properties
     {
         serde_json::Value::Object(map) => map.into_iter().collect(),
@@ -183,20 +205,46 @@ pub async fn add_edge(
             )
         })?
         .with_properties(properties);
+    Ok(edge)
+}
+
+/// Add multiple edges to a collection's graph in one batched operation.
+#[utoipa::path(
+    post,
+    path = "/collections/{name}/graph/edges/batch",
+    request_body = AddEdgesBatchRequest,
+    responses(
+        (status = 201, description = "Edges added successfully", body = AddEdgesBatchResponse),
+        (status = 400, description = "Invalid request", body = ErrorResponse),
+        (status = 404, description = "Collection not found", body = ErrorResponse),
+        (status = 500, description = "Internal server error", body = ErrorResponse)
+    ),
+    tag = "graph"
+)]
+pub async fn add_edges_batch(
+    Path(name): Path<String>,
+    State(state): State<Arc<AppState>>,
+    Json(request): Json<AddEdgesBatchRequest>,
+) -> Result<(StatusCode, Json<AddEdgesBatchResponse>), (StatusCode, Json<ErrorResponse>)> {
+    let edges = request
+        .edges
+        .into_iter()
+        .map(build_edge)
+        .collect::<Result<Vec<_>, _>>()?;
 
     let coll = graph_preamble(&state, &name)?;
 
-    coll.add_edge(edge).map_err(|e| {
+    let added = coll.add_edges_batch(edges).map_err(|e| {
         (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(ErrorResponse {
-                error: format!("Failed to add edge: {e}"),
+                error: format!("Failed to add edges: {e}"),
                 code: None,
             }),
         )
     })?;
 
-    Ok(StatusCode::CREATED)
+    Ok((StatusCode::CREATED, Json(AddEdgesBatchResponse { added })))
 }
 
 /// Traverse the graph using BFS or DFS from a source node.

--- a/crates/velesdb-server/src/handlers/graph/mod.rs
+++ b/crates/velesdb-server/src/handlers/graph/mod.rs
@@ -10,7 +10,7 @@ pub mod stream;
 pub mod types;
 
 // Re-export public API — original handlers
-pub use handlers::{add_edge, get_edges, get_node_degree, traverse_graph};
+pub use handlers::{add_edge, add_edges_batch, get_edges, get_node_degree, traverse_graph};
 // Re-export public API — extended handlers (parity)
 pub use handlers_extended::{
     get_edge_count, get_node_edges, get_node_payload, graph_search, list_nodes, remove_edge,
@@ -19,11 +19,11 @@ pub use handlers_extended::{
 pub use stream::stream_traverse;
 #[allow(unused_imports)]
 pub use types::{
-    AddEdgeRequest, DegreeResponse, EdgeCountResponse, EdgeQueryParams, EdgeResponse,
-    EdgesResponse, GraphSearchRequest, GraphSearchResponse, GraphSearchResultItem,
-    NodeEdgeQueryParams, NodeListResponse, NodePayloadResponse, ParallelTraverseRequest,
-    StreamDoneEvent, StreamErrorEvent, StreamNodeEvent, StreamStatsEvent, StreamTraverseParams,
-    TraversalResultItem, TraversalStats, TraverseRequest, TraverseResponse,
+    AddEdgeRequest, AddEdgesBatchRequest, AddEdgesBatchResponse, DegreeResponse, EdgeCountResponse,
+    EdgeQueryParams, EdgeResponse, EdgesResponse, GraphSearchRequest, GraphSearchResponse,
+    GraphSearchResultItem, NodeEdgeQueryParams, NodeListResponse, NodePayloadResponse,
+    ParallelTraverseRequest, StreamDoneEvent, StreamErrorEvent, StreamNodeEvent, StreamStatsEvent,
+    StreamTraverseParams, TraversalResultItem, TraversalStats, TraverseRequest, TraverseResponse,
     UpsertNodePayloadRequest,
 };
 

--- a/crates/velesdb-server/src/handlers/graph/types.rs
+++ b/crates/velesdb-server/src/handlers/graph/types.rs
@@ -143,6 +143,20 @@ pub struct AddEdgeRequest {
     pub properties: serde_json::Value,
 }
 
+/// Request to add multiple edges in one batched operation.
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct AddEdgesBatchRequest {
+    /// Edges to insert.
+    pub edges: Vec<AddEdgeRequest>,
+}
+
+/// Response for a batched edge insertion.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct AddEdgesBatchResponse {
+    /// Number of edges inserted.
+    pub added: usize,
+}
+
 // ============================================================================
 // Edge Count, Node List, Node Payload, Parallel Traversal, Graph Search
 // ============================================================================

--- a/crates/velesdb-server/src/handlers/graph/types.rs
+++ b/crates/velesdb-server/src/handlers/graph/types.rs
@@ -153,7 +153,9 @@ pub struct AddEdgesBatchRequest {
 /// Response for a batched edge insertion.
 #[derive(Debug, Serialize, ToSchema)]
 pub struct AddEdgesBatchResponse {
-    /// Number of edges inserted.
+    /// Number of edges actually inserted. May be less than the number submitted:
+    /// edges whose ID already exists (in the request or the graph) are silently
+    /// skipped. Compare against the request length to detect skipped duplicates.
     pub added: usize,
 }
 

--- a/crates/velesdb-server/src/handlers/mod.rs
+++ b/crates/velesdb-server/src/handlers/mod.rs
@@ -49,9 +49,10 @@ pub use search::{
 // Graph handlers (EPIC-016) - exported via lib.rs
 #[allow(unused_imports)]
 pub use graph::{
-    add_edge, get_edge_count, get_edges, get_node_degree, get_node_edges, get_node_payload,
-    graph_search, list_nodes, remove_edge, traverse_graph, traverse_parallel, upsert_node_payload,
-    DegreeResponse, TraversalResultItem, TraversalStats, TraverseRequest, TraverseResponse,
+    add_edge, add_edges_batch, get_edge_count, get_edges, get_node_degree, get_node_edges,
+    get_node_payload, graph_search, list_nodes, remove_edge, traverse_graph, traverse_parallel,
+    upsert_node_payload, DegreeResponse, TraversalResultItem, TraversalStats, TraverseRequest,
+    TraverseResponse,
 };
 
 // Metrics handlers - conditional on prometheus feature

--- a/crates/velesdb-server/src/lib.rs
+++ b/crates/velesdb-server/src/lib.rs
@@ -66,9 +66,9 @@ pub use handlers::{
 };
 
 pub use handlers::graph::{
-    add_edge, get_edge_count, get_edges, get_node_degree, get_node_edges, get_node_payload,
-    graph_search, list_nodes, remove_edge, stream_traverse, traverse_graph, traverse_parallel,
-    upsert_node_payload, DegreeResponse, EdgeCountResponse, GraphSearchRequest,
+    add_edge, add_edges_batch, get_edge_count, get_edges, get_node_degree, get_node_edges,
+    get_node_payload, graph_search, list_nodes, remove_edge, stream_traverse, traverse_graph,
+    traverse_parallel, upsert_node_payload, DegreeResponse, EdgeCountResponse, GraphSearchRequest,
     GraphSearchResponse, NodeEdgeQueryParams, NodeListResponse, NodePayloadResponse,
     ParallelTraverseRequest, StreamDoneEvent, StreamNodeEvent, StreamStatsEvent,
     StreamTraverseParams, TraversalResultItem, TraversalStats, TraverseRequest, TraverseResponse,
@@ -147,6 +147,7 @@ pub use handlers::metrics::{health_metrics, prometheus_metrics};
         handlers::indexes::delete_index,
         handlers::graph::handlers::get_edges,
         handlers::graph::handlers::add_edge,
+        handlers::graph::handlers::add_edges_batch,
         handlers::graph::handlers_extended::remove_edge,
         handlers::graph::handlers_extended::get_edge_count,
         handlers::graph::handlers_extended::list_nodes,
@@ -220,6 +221,8 @@ pub use handlers::metrics::{health_metrics, prometheus_metrics};
             handlers::graph::TraversalStats,
             handlers::graph::DegreeResponse,
             handlers::graph::AddEdgeRequest,
+            handlers::graph::AddEdgesBatchRequest,
+            handlers::graph::AddEdgesBatchResponse,
             handlers::graph::EdgesResponse,
             handlers::graph::EdgeResponse,
             handlers::graph::EdgeCountResponse,

--- a/crates/velesdb-server/src/routes.rs
+++ b/crates/velesdb-server/src/routes.rs
@@ -12,9 +12,9 @@ use axum::{
 };
 
 use crate::{
-    add_edge, aggregate, analyze_collection, batch_search, bulk_delete_points, collection_sanity,
-    compact_collection, create_collection, create_index, delete_collection, delete_index,
-    delete_point, explain, flush_collection, get_collection, get_collection_config,
+    add_edge, add_edges_batch, aggregate, analyze_collection, batch_search, bulk_delete_points,
+    collection_sanity, compact_collection, create_collection, create_index, delete_collection,
+    delete_index, delete_point, explain, flush_collection, get_collection, get_collection_config,
     get_collection_stats, get_edge_count, get_edges, get_guardrails, get_node_degree,
     get_node_edges, get_node_payload, get_point, get_point_relations, graph_search, health_check,
     hybrid_search, is_empty, list_collections, list_indexes, list_nodes, match_query,
@@ -116,6 +116,10 @@ fn graph_routes() -> Router<Arc<AppState>> {
         .route(
             "/collections/{name}/graph/edges",
             get(get_edges).post(add_edge),
+        )
+        .route(
+            "/collections/{name}/graph/edges/batch",
+            post(add_edges_batch),
         )
         .route(
             "/collections/{name}/graph/edges/{edge_id}",

--- a/crates/velesdb-server/tests/api_integration.rs
+++ b/crates/velesdb-server/tests/api_integration.rs
@@ -1955,6 +1955,58 @@ async fn test_graph_add_edge() {
 }
 
 #[tokio::test]
+async fn test_graph_add_edges_batch() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let app = create_test_app(&temp_dir);
+
+    create_graph_collection(&app, "test").await;
+
+    // Insert three edges in one batched request.
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/collections/test/graph/edges/batch")
+                .header("Content-Type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "edges": [
+                            {"id": 1, "source": 100, "target": 200, "label": "KNOWS"},
+                            {"id": 2, "source": 200, "target": 300, "label": "KNOWS"},
+                            {"id": 3, "source": 100, "target": 300, "label": "WROTE",
+                             "properties": {"weight": 0.5}}
+                        ]
+                    })
+                    .to_string(),
+                ))
+                .expect("Failed to build request"),
+        )
+        .await
+        .expect("Request failed");
+
+    assert_eq!(response.status(), StatusCode::CREATED);
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("read body");
+    let json: serde_json::Value = serde_json::from_slice(&body).expect("parse json");
+    assert_eq!(json["added"], 3);
+
+    // The batched edges are retrievable.
+    let get = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/collections/test/graph/edges?label=KNOWS")
+                .body(Body::empty())
+                .expect("Failed to build request"),
+        )
+        .await
+        .expect("Request failed");
+    assert_eq!(get.status(), StatusCode::OK);
+}
+
+#[tokio::test]
 async fn test_graph_get_edges_by_label() {
     let temp_dir = TempDir::new().expect("Failed to create temp dir");
     let app = create_test_app(&temp_dir);

--- a/crates/velesdb-server/tests/common/mod.rs
+++ b/crates/velesdb-server/tests/common/mod.rs
@@ -10,7 +10,7 @@ use tempfile::TempDir;
 
 use velesdb_core::Database;
 use velesdb_server::{
-    add_edge, aggregate,
+    add_edge, add_edges_batch, aggregate,
     auth::{auth_middleware, AuthState},
     batch_search, bulk_delete_points, collection_sanity, compact_collection, create_collection,
     delete_collection, delete_point, explain, get_collection, get_collection_config, get_edges,
@@ -63,6 +63,10 @@ fn graph_and_maintenance_routes() -> Router<Arc<AppState>> {
         .route(
             "/collections/{name}/graph/edges",
             get(get_edges).post(add_edge),
+        )
+        .route(
+            "/collections/{name}/graph/edges/batch",
+            post(add_edges_batch),
         )
         .route("/collections/{name}/graph/traverse", post(traverse_graph))
         .route(

--- a/docs/CORE_WIRING_DEBT.md
+++ b/docs/CORE_WIRING_DEBT.md
@@ -229,6 +229,78 @@ hot-path cost is <1%.
 
 ---
 
+## 6. Binding API-parity wiring gaps (core fns not exposed in embedded bindings)
+
+**Outcome**: **Partially wired** — backlog below, prioritised P1–P3.
+
+This entry records the result of a full core→binding API-parity audit
+(re-verified 2026-06-13 against `develop` post-#1094, with `file:line`
+evidence for every cell). The audit replaced an earlier informal matrix
+that was substantially inaccurate — most of its "missing in Python /
+nowhere" claims were **false**: `velesdb-python` already exposes
+`search_with_ef`, `search_ids`, `search_batch_parallel`,
+`multi_query_search`, `multi_query_search_ids`, `sparse_search`,
+`hybrid_sparse_search`, `execute_match_with_similarity`, `flush_full`,
+`upsert_bulk_from_raw`, `is_delta_active`, `explain_analyze_query`,
+`GraphCollection::add_edges_batch`/`delete`/`remove_edge` natively. The
+genuine, worth-closing gaps that survived verification are below.
+
+**Audit ground rules** (why some "gaps" are *not* listed as debt):
+- **WASM** links `velesdb-core` with `persistence` OFF and reimplements
+  its own in-memory engine. Every persistence/runtime-gated core method is
+  therefore **N/A** in WASM, not a closeable gap (only the three
+  non-gated `validate_*` free-fns are real — see 6.11).
+- **Mobile / Tauri / WASM graph stores** are standalone in-memory stores
+  that wrap nothing in core; their graph rows are partial-via-VelesQL, by
+  design.
+- `MetadataCollection::search` is a structural no-op (metadata collections
+  have no vector index) — use `text_search`/VelesQL. Documented, not debt.
+- `velesdb-server` is the source of truth for `execute_aggregate`,
+  `rebuild_index`, `compact_storage`, `apply_advanced_config`,
+  `update_guardrails`, `explain_analyze_query`, `push_to_delta_if_active` —
+  the TS SDK merely forwards to native server routes.
+
+**What is missing** (backlog — each row: core fn · surfaces lacking it ·
+feasibility · target file for the glue):
+
+| # | Core fn | Missing in | Pri | Feasibility | Glue lands in |
+|---|---------|-----------|-----|-------------|---------------|
+| 6.1 | `VectorCollection::compact_storage` | python, mobile, tauri | P1 | moderate (run under `allow_threads`/`spawn_blocking`) | `velesdb-python/src/collection/mod.rs` (mirror `flush_full`); `velesdb-mobile/src/collection.rs` |
+| 6.2 | `GraphCollection::add_edges_batch` (typed route/cmd) | rest, tauri | P1 | trivial | `velesdb-server/src/handlers/` (new `/graph/edges/batch`); `tauri-plugin-velesdb/src/lib.rs` |
+| 6.3 | `VectorCollection::search_ids` (true core path) | rest, tauri | P2 | trivial (server route reuses generic search + strips payloads; never calls core `search_ids`) | `velesdb-server/src/handlers/search/mod.rs:344` (route to core fn when no payloads requested); tauri command |
+| 6.4 | `VectorCollection::reorder_for_locality` | python, rest, tauri, mobile, ts (**nowhere**) | P2 | moderate — **recall-gated** (QUALITY_BAR Gate 1) | server admin route first (next to `compact_storage`/`rebuild_index`), then `velesdb-python/src/collection/mod.rs` |
+| 6.5 | `VectorCollection::apply_advanced_config` | python, mobile, tauri | P2 | moderate — config marshalling across FFI; recall-adjacent (PQ/HNSW) | `velesdb-python/src/collection/` (py-dict→`AdvancedConfig`); mobile UniFFI record |
+| 6.6 | `AnyCollection::diagnostics` / `Database::collection_diagnostics` (typed) | python, rest-typed, tauri, mobile | P2 | moderate — define serializable diagnostics DTO once | server `/collections/{name}/diagnostics`; `velesdb-python/src/database.rs` (returns dict) |
+| 6.7 | `Database::update_guardrails` + `VectorCollection::guard_rails` (read) | python, mobile, tauri | P2 | moderate — limits struct marshalling | `velesdb-python/src/database.rs`; mobile `lib.rs` |
+| 6.8 | `detach_auto_reindex` / `check_auto_reindex_divergence` | python (only `attach`), all others | P2 | moderate — store manager handle on wrapper. **See entry 2** | `velesdb-python/src/collection/` (same wrapper as `attach_auto_reindex`) |
+| 6.9 | `VectorCollection::search_batch_parallel` | rest, tauri, mobile | P2 | moderate — server batch route funnels through serial kernel; needs a parallel branch flag | `velesdb-server/src/handlers/search/` (batch handler) |
+| 6.10 | `VectorCollection::multi_query_search_ids` | rest, tauri, mobile, ts | P3 | trivial — id-only variant of broadly-exposed `multi_query_search` | server `search/multi.rs` (ids-only mode); TS `search-backend.ts` |
+| 6.11 | `validate_collection_name` / `validate_dimension` / `validate_dimension_match` (free-fns) | every binding re-implements them | P3 | trivial — consistency, not a feature | re-export + replace local validators in python `lib.rs`, server validation, ts `client/validation.ts` |
+
+**Status — PR-1 `feat/parity-embedded-ops`** (branch open):
+- 6.1 `compact_storage` — DONE (Python, Mobile, Tauri; each with a unit test).
+- 6.2 `add_edges_batch` — DONE (server `/collections/{name}/graph/edges/batch` route + OpenAPI snapshot + Tauri command; HTTP integration test + Tauri tests).
+- 6.3 `search_ids` — Tauri command DONE (functional gap closed; unit-tested). **Server fast-path moved to PR-4** (grouped with 6.9: conditional hot-path opt, core `search_ids` has no filter param).
+
+**Explicitly deferred (not worth closing now)**:
+- `stream_insert_batch` / `enable_streaming` / `StreamIngester::*` — async
+  runtime + channel-handle lifetime across PyO3/UniFFI is **hard** and
+  low-demand vs `upsert_bulk`. WASM N/A (no async fs). P3, defer.
+- Observer plane (`open_with_observer[_and_config]`, `notify_upsert`,
+  `notify_query`) — marshalling a Rust callback trait object across FFI;
+  feasible only in Python (PyO3 closures), awkward/niche elsewhere. P3,
+  defer. Only `velesdb-server` wires the notify hooks (its metrics).
+- `upsert_bulk_from_raw` beyond Python — REST/TS already have JSON
+  `upsert_bulk`; the zero-copy raw path needs a flat-buffer wire format
+  for marginal benefit. Keep Python/NumPy-only.
+
+**Future action**: schedule 6.1–6.3 (P1 + trivial-P2) as one embedded-ops
+PR; gate 6.4/6.5 behind a recall-validation run (Gate 1); 6.10/6.11 as a
+consistency-cleanup PR. Each binding glue must pass that crate's CI line
+(no `.unwrap()`, complexity ≤8, clippy pedantic).
+
+---
+
 ## Summary table
 
 | Config | Wired? | Outcome | Effort | Target |
@@ -238,6 +310,7 @@ hot-path cost is <1%.
 | `deferred_indexing` / `async_index_builder` | REST-only (no TOML/Python) | RFC pending | Unscoped | Community (future sprint) |
 | `SearchConfig` global defaults | Partial | Consolidation cleanup | 1-2 commits | Community (future sprint) |
 | `LimitsConfig` (3/5 fields) | Partial | Hot-path instrumentation | 2-3 commits | Community (backlog, unscheduled) |
+| Binding API-parity gaps (6.1–6.11) | Partial | P1–P3 backlog (see §6) | 3 PRs (embedded-ops / recall-gated / consistency) | Community |
 
 ## Conventions
 

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3237,7 +3237,7 @@
         "properties": {
           "added": {
             "type": "integer",
-            "description": "Number of edges inserted.",
+            "description": "Number of edges actually inserted. May be less than the number submitted:\nedges whose ID already exists (in the request or the graph) are silently\nskipped. Compare against the request length to detect skipped duplicates.",
             "minimum": 0
           }
         }

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -602,6 +602,77 @@
         }
       }
     },
+    "/collections/{name}/graph/edges/batch": {
+      "post": {
+        "tags": [
+          "graph"
+        ],
+        "summary": "Add multiple edges to a collection's graph in one batched operation.",
+        "operationId": "add_edges_batch",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AddEdgesBatchRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Edges added successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AddEdgesBatchResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Collection not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/collections/{name}/graph/edges/count": {
       "get": {
         "tags": [
@@ -3138,6 +3209,36 @@
               }
             ],
             "description": "Point ID. Accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss."
+          }
+        }
+      },
+      "AddEdgesBatchRequest": {
+        "type": "object",
+        "description": "Request to add multiple edges in one batched operation.",
+        "required": [
+          "edges"
+        ],
+        "properties": {
+          "edges": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AddEdgeRequest"
+            },
+            "description": "Edges to insert."
+          }
+        }
+      },
+      "AddEdgesBatchResponse": {
+        "type": "object",
+        "description": "Response for a batched edge insertion.",
+        "required": [
+          "added"
+        ],
+        "properties": {
+          "added": {
+            "type": "integer",
+            "description": "Number of edges inserted.",
+            "minimum": 0
           }
         }
       },

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2123,7 +2123,10 @@ components:
       properties:
         added:
           type: integer
-          description: Number of edges inserted.
+          description: |-
+            Number of edges actually inserted. May be less than the number submitted:
+            edges whose ID already exists (in the request or the graph) are silently
+            skipped. Compare against the request length to detect skipped duplicates.
           minimum: 0
     AggregationResponse:
       type: object

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -377,6 +377,49 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+  /collections/{name}/graph/edges/batch:
+    post:
+      tags:
+      - graph
+      summary: Add multiple edges to a collection's graph in one batched operation.
+      operationId: add_edges_batch
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AddEdgesBatchRequest'
+        required: true
+      responses:
+        '201':
+          description: Edges added successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AddEdgesBatchResponse'
+        '400':
+          description: Invalid request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Collection not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
   /collections/{name}/graph/edges/count:
     get:
       tags:
@@ -2061,6 +2104,27 @@ components:
             format: int64
           - type: string
           description: Point ID. Accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss.
+    AddEdgesBatchRequest:
+      type: object
+      description: Request to add multiple edges in one batched operation.
+      required:
+      - edges
+      properties:
+        edges:
+          type: array
+          items:
+            $ref: '#/components/schemas/AddEdgeRequest'
+          description: Edges to insert.
+    AddEdgesBatchResponse:
+      type: object
+      description: Response for a batched edge insertion.
+      required:
+      - added
+      properties:
+        added:
+          type: integer
+          description: Number of edges inserted.
+          minimum: 0
     AggregationResponse:
       type: object
       description: Response from `VelesQL` aggregation query execution.


### PR DESCRIPTION
## API-parity campaign — PR-1 (embedded ops)

First of four PRs closing the verified core→binding API-parity gaps in `docs/CORE_WIRING_DEBT.md` §6. The backlog was produced by an 8-agent ground-truth verification of an earlier (substantially inaccurate) gap matrix — most of its "Python missing/nowhere" claims were false; only the §6 rows are real gaps.

### Gaps closed
| Gap | Surfaces wired | Notes |
|-----|----------------|-------|
| 6.1 `compact_storage` | Python, Mobile, Tauri | Server already exposed it. Reclaims on-disk space from deleted vectors; returns freed bytes. Runs off the GIL (Python) / on `with_db` (Tauri). |
| 6.2 `GraphCollection::add_edges_batch` | Server route + Tauri command | New `POST /collections/{name}/graph/edges/batch` (OpenAPI snapshot regenerated) + Tauri `add_edges_batch`. Avoids per-edge WAL/flush overhead. Shared `build_edge` helper factored out of `add_edge`. |
| 6.3 `search_ids` | Tauri command | id+score without payload hydration. **Server fast-path deferred to PR-4** (grouped with `search_batch_parallel`: core `search_ids` has no filter param → conditional hot-path opt). |

### Tests (one per affected binding — no future regression)
- **Python**: `test_compact_storage` (pytest)
- **Mobile**: `test_collection_compact_storage`
- **Tauri**: `build_edge` unit tests, `AddEdgesBatchRequest` deserialize, `IdScoreOutput` serialize, command-permission sync tests
- **Server**: `test_graph_add_edges_batch` HTTP integration test

### Verification
- `cargo clippy -p velesdb-server -p tauri-plugin-velesdb -p velesdb-mobile --features persistence,openapi -- -D warnings -D clippy::pedantic` — clean
- All four binding test suites pass; OpenAPI drift snapshot regenerated
- **velesdb-core untouched** (no recall-path changes)

Next: PR-2 (ops/observability — diagnostics, guardrails, auto-reindex lifecycle).