### PR TITLE
feat(bindings): API parity PR-3 — reorder_for_locality + apply_advanced_config (recall-gated)

### DIFF
--- a/crates/velesdb-mobile/src/collection.rs
+++ b/crates/velesdb-mobile/src/collection.rs
@@ -3,8 +3,8 @@
 use velesdb_core::VectorCollection as CoreCollection;
 
 use crate::types::{
-    IndividualSearchRequest, MobileCollectionStats, MobileIndexInfo, MobileQueryLimits,
-    SearchQuality, SearchResult, VelesError, VelesPoint,
+    IndividualSearchRequest, MobileAdvancedConfig, MobileCollectionStats, MobileIndexInfo,
+    MobileQueryLimits, SearchQuality, SearchResult, VelesError, VelesPoint,
 };
 
 // ============================================================================
@@ -502,6 +502,19 @@ impl VelesCollection {
     /// Returns the current query guardrail limits for this collection.
     pub fn guard_rails(&self) -> MobileQueryLimits {
         self.inner.guard_rails().limits().into()
+    }
+
+    /// Applies post-creation overrides to advanced configuration fields
+    /// (`pq_rescore_oversampling`, `deferred_indexing`,
+    /// `async_index_builder`) and persists the updated config. Each `Some`
+    /// field is applied; each `None` field is left unchanged.
+    pub fn apply_advanced_config(&self, config: MobileAdvancedConfig) -> Result<(), VelesError> {
+        self.inner.apply_advanced_config(
+            config.pq_rescore_oversampling.map(Some),
+            config.deferred_indexing.map(|c| Some(c.into())),
+            config.async_index_builder.map(|c| Some(c.into())),
+        )?;
+        Ok(())
     }
 
     /// Returns all point IDs currently present in the collection.

--- a/crates/velesdb-mobile/src/lib.rs
+++ b/crates/velesdb-mobile/src/lib.rs
@@ -59,7 +59,8 @@ pub use collection::VelesCollection;
 pub use graph::{MobileGraphEdge, MobileGraphNode, MobileGraphStore, TraversalResult};
 pub use query::{QueryResult, QueryResultKind, QueryResultRow};
 pub use types::{
-    DistanceMetric, FusionStrategy, IndividualSearchRequest, MobileCollectionStats,
+    DistanceMetric, FusionStrategy, IndividualSearchRequest, MobileAdvancedConfig,
+    MobileAsyncIndexBuilderConfig, MobileCollectionStats, MobileDeferredIndexerConfig,
     MobileIndexInfo, MobileQueryLimits, PqTrainConfig, SearchQuality, SearchResult, StorageMode,
     VelesError, VelesPoint, VelesSparseVector,
 };

--- a/crates/velesdb-mobile/src/lib_tests.rs
+++ b/crates/velesdb-mobile/src/lib_tests.rs
@@ -399,6 +399,63 @@ fn test_collection_guardrails_update_and_read() {
 }
 
 #[test]
+fn test_advanced_config_record_conversions() {
+    let deferred: velesdb_core::collection::streaming::DeferredIndexerConfig =
+        MobileDeferredIndexerConfig {
+            enabled: true,
+            merge_threshold: 512,
+            max_buffer_age_ms: 3000,
+        }
+        .into();
+    assert!(deferred.enabled);
+    assert_eq!(deferred.merge_threshold, 512);
+    assert_eq!(deferred.max_buffer_age_ms, 3000);
+
+    let async_builder: velesdb_core::collection::streaming::AsyncIndexBuilderConfig =
+        MobileAsyncIndexBuilderConfig {
+            merge_threshold: 20_000,
+            segment_count: Some(4),
+        }
+        .into();
+    assert_eq!(async_builder.merge_threshold, 20_000);
+    assert_eq!(async_builder.segment_count, Some(4));
+}
+
+#[test]
+fn test_collection_apply_advanced_config() {
+    let tmp = TempDir::new().unwrap();
+    let path = tmp.path().to_str().unwrap().to_string();
+
+    let db = VelesDatabase::open(path).unwrap();
+    db.create_collection("adv".to_string(), 4, DistanceMetric::Cosine)
+        .unwrap();
+    let col = db.get_collection("adv".to_string()).unwrap().unwrap();
+
+    // All three fields set: must persist without error.
+    col.apply_advanced_config(MobileAdvancedConfig {
+        pq_rescore_oversampling: Some(8),
+        deferred_indexing: Some(MobileDeferredIndexerConfig {
+            enabled: true,
+            merge_threshold: 512,
+            max_buffer_age_ms: 3000,
+        }),
+        async_index_builder: Some(MobileAsyncIndexBuilderConfig {
+            merge_threshold: 20_000,
+            segment_count: None,
+        }),
+    })
+    .unwrap();
+
+    // None fields leave configuration unchanged: also a valid no-op.
+    col.apply_advanced_config(MobileAdvancedConfig {
+        pq_rescore_oversampling: None,
+        deferred_indexing: None,
+        async_index_builder: None,
+    })
+    .unwrap();
+}
+
+#[test]
 fn test_collection_with_json_payload() {
     let tmp = TempDir::new().unwrap();
     let path = tmp.path().to_str().unwrap().to_string();

--- a/crates/velesdb-mobile/src/types.rs
+++ b/crates/velesdb-mobile/src/types.rs
@@ -392,3 +392,63 @@ impl From<MobileQueryLimits> for velesdb_core::guardrails::QueryLimits {
         }
     }
 }
+
+/// Deferred indexing configuration (buffers bulk inserts before merging
+/// into the HNSW index).
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct MobileDeferredIndexerConfig {
+    /// Whether deferred indexing is enabled.
+    pub enabled: bool,
+    /// Number of buffered points before a merge is triggered.
+    pub merge_threshold: u64,
+    /// Maximum buffer age in milliseconds before a forced merge.
+    pub max_buffer_age_ms: u64,
+}
+
+impl From<MobileDeferredIndexerConfig>
+    for velesdb_core::collection::streaming::DeferredIndexerConfig
+{
+    fn from(v: MobileDeferredIndexerConfig) -> Self {
+        Self {
+            enabled: v.enabled,
+            merge_threshold: usize::try_from(v.merge_threshold).unwrap_or(usize::MAX),
+            max_buffer_age_ms: v.max_buffer_age_ms,
+        }
+    }
+}
+
+/// Async index builder configuration (parallel segment construction for
+/// deferred bulk loads).
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct MobileAsyncIndexBuilderConfig {
+    /// Number of buffered points before a segment merge is triggered.
+    pub merge_threshold: u64,
+    /// Number of parallel segments; `None` falls back to the CPU count.
+    pub segment_count: Option<u32>,
+}
+
+impl From<MobileAsyncIndexBuilderConfig>
+    for velesdb_core::collection::streaming::AsyncIndexBuilderConfig
+{
+    fn from(v: MobileAsyncIndexBuilderConfig) -> Self {
+        Self {
+            merge_threshold: usize::try_from(v.merge_threshold).unwrap_or(usize::MAX),
+            segment_count: v.segment_count.map(|s| s as usize),
+        }
+    }
+}
+
+/// Post-creation overrides for advanced collection configuration.
+///
+/// Each field uses `Some` to set the value and `None` to leave it
+/// unchanged. Unlike the Python binding, mobile cannot express the
+/// "clear" state (it maps `None` to "leave unchanged").
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct MobileAdvancedConfig {
+    /// PQ rescore oversampling factor; `None` leaves it unchanged.
+    pub pq_rescore_oversampling: Option<u32>,
+    /// Deferred indexing config; `None` leaves it unchanged.
+    pub deferred_indexing: Option<MobileDeferredIndexerConfig>,
+    /// Async index builder config; `None` leaves it unchanged.
+    pub async_index_builder: Option<MobileAsyncIndexBuilderConfig>,
+}

--- a/crates/velesdb-python/src/collection/mod.rs
+++ b/crates/velesdb-python/src/collection/mod.rs
@@ -27,6 +27,67 @@ use velesdb_core::{
 /// Default fusion strategy when none is specified by the caller.
 const DEFAULT_FUSION: CoreFusionStrategy = CoreFusionStrategy::RRF { k: 60 };
 
+use velesdb_core::collection::streaming::{AsyncIndexBuilderConfig, DeferredIndexerConfig};
+
+/// Extract an optional typed value for `key`, returning `None` when the
+/// key is absent or holds Python `None`.
+fn opt_field<'py, T: FromPyObject<'py>>(
+    dict: &Bound<'py, PyDict>,
+    key: &str,
+) -> PyResult<Option<T>> {
+    match dict.get_item(key)? {
+        Some(v) if !v.is_none() => Ok(Some(v.extract()?)),
+        _ => Ok(None),
+    }
+}
+
+/// Resolve a three-state override for `key`: an absent key leaves the field
+/// unchanged (`None`), an explicit Python `None` clears it (`Some(None)`),
+/// and any other value is built via `build` (`Some(Some(_))`).
+fn three_state<T>(
+    config: &Bound<'_, PyDict>,
+    key: &str,
+    build: impl Fn(&Bound<'_, PyAny>) -> PyResult<T>,
+) -> PyResult<Option<Option<T>>> {
+    match config.get_item(key)? {
+        None => Ok(None),
+        Some(v) if v.is_none() => Ok(Some(None)),
+        Some(v) => Ok(Some(Some(build(&v)?))),
+    }
+}
+
+/// Build a `DeferredIndexerConfig` from a Python dict, overriding only the
+/// keys present on top of the struct defaults.
+fn deferred_from_dict(value: &Bound<'_, PyAny>) -> PyResult<DeferredIndexerConfig> {
+    let dict = value.downcast::<PyDict>()?;
+    let mut cfg = DeferredIndexerConfig::default();
+    if let Some(v) = opt_field(dict, "enabled")? {
+        cfg.enabled = v;
+    }
+    if let Some(v) = opt_field(dict, "merge_threshold")? {
+        cfg.merge_threshold = v;
+    }
+    if let Some(v) = opt_field(dict, "max_buffer_age_ms")? {
+        cfg.max_buffer_age_ms = v;
+    }
+    Ok(cfg)
+}
+
+/// Build an `AsyncIndexBuilderConfig` from a Python dict, overriding only the
+/// keys present on top of the struct defaults. `segment_count` accepts a
+/// Python `None` to fall back to the CPU count.
+fn async_builder_from_dict(value: &Bound<'_, PyAny>) -> PyResult<AsyncIndexBuilderConfig> {
+    let dict = value.downcast::<PyDict>()?;
+    let mut cfg = AsyncIndexBuilderConfig::default();
+    if let Some(v) = opt_field(dict, "merge_threshold")? {
+        cfg.merge_threshold = v;
+    }
+    if dict.get_item("segment_count")?.is_some() {
+        cfg.segment_count = opt_field(dict, "segment_count")?;
+    }
+    Ok(cfg)
+}
+
 /// A vector collection in VelesDB.
 ///
 /// Collections store vectors with optional metadata (payload) and support
@@ -209,6 +270,50 @@ impl Collection {
     fn compact_storage(&self, py: Python<'_>) -> PyResult<usize> {
         use crate::collection_helpers::core_err;
         py.allow_threads(|| self.inner.compact_storage().map_err(core_err))
+    }
+
+    /// Reorder the HNSW adjacency lists and vector storage for cache
+    /// locality, so nodes traversed together during search sit close in
+    /// memory. No-op for collections with fewer than 1000 vectors. Recall
+    /// is preserved — only the physical layout changes.
+    ///
+    /// Best called after a bulk ``upsert`` on a freshly loaded collection,
+    /// before serving queries.
+    ///
+    /// Returns:
+    ///     None
+    fn reorder_for_locality(&self, py: Python<'_>) -> PyResult<()> {
+        use crate::collection_helpers::core_err;
+        py.allow_threads(|| self.inner.reorder_for_locality().map_err(core_err))
+    }
+
+    /// Apply post-creation overrides to advanced configuration fields and
+    /// persist the updated ``config.json``.
+    ///
+    /// Three-state semantics per field: a key **absent** from ``config``
+    /// leaves that field unchanged; a key present with value ``None``
+    /// clears it; a key present with a value sets it.
+    ///
+    /// Args:
+    ///     config: dict with optional keys ``pq_rescore_oversampling``
+    ///         (int or None), ``deferred_indexing`` (dict with keys
+    ///         ``enabled``, ``merge_threshold``, ``max_buffer_age_ms``, or
+    ///         None), ``async_index_builder`` (dict with keys
+    ///         ``merge_threshold``, ``segment_count``, or None).
+    ///
+    /// Returns:
+    ///     None
+    #[pyo3(signature = (config))]
+    fn apply_advanced_config(&self, py: Python<'_>, config: &Bound<'_, PyDict>) -> PyResult<()> {
+        use crate::collection_helpers::core_err;
+        let pq = three_state(config, "pq_rescore_oversampling", |v| v.extract::<u32>())?;
+        let deferred = three_state(config, "deferred_indexing", deferred_from_dict)?;
+        let async_builder = three_state(config, "async_index_builder", async_builder_from_dict)?;
+        py.allow_threads(|| {
+            self.inner
+                .apply_advanced_config(pq, deferred, async_builder)
+                .map_err(core_err)
+        })
     }
 
     /// Get the current query guardrail limits for this collection.

--- a/crates/velesdb-python/tests/test_velesdb.py
+++ b/crates/velesdb-python/tests/test_velesdb.py
@@ -233,6 +233,50 @@ class TestCollection:
         # Live points are unaffected by compaction.
         assert collection.count() == 2
 
+    def test_reorder_for_locality(self, temp_db):
+        """Test reorder_for_locality returns None and preserves points."""
+        collection = temp_db.create_collection("reorder_test", dimension=4)
+        collection.upsert([
+            {"id": i, "vector": [1.0, 0.0, 0.0, 0.0]} for i in range(10)
+        ])
+
+        # No-op below the 1000-vector threshold, but must not raise.
+        assert collection.reorder_for_locality() is None
+        assert collection.count() == 10
+
+    def test_apply_advanced_config_sets_fields(self, temp_db):
+        """Test apply_advanced_config accepts all three advanced fields."""
+        collection = temp_db.create_collection("adv_cfg_test", dimension=4)
+
+        # Mix all three: int, nested dicts. Must not raise and must persist.
+        assert collection.apply_advanced_config({
+            "pq_rescore_oversampling": 8,
+            "deferred_indexing": {
+                "enabled": True,
+                "merge_threshold": 512,
+                "max_buffer_age_ms": 3000,
+            },
+            "async_index_builder": {
+                "merge_threshold": 20000,
+                "segment_count": 4,
+            },
+        }) is None
+
+    def test_apply_advanced_config_clear_and_unchanged(self, temp_db):
+        """Test absent key = unchanged, None value = clear (three-state)."""
+        collection = temp_db.create_collection("adv_cfg_clear", dimension=4)
+
+        # None clears pq rescore; absent keys leave the others unchanged.
+        assert collection.apply_advanced_config(
+            {"pq_rescore_oversampling": None}
+        ) is None
+
+        # segment_count None falls back to CPU count; empty dict is a no-op.
+        assert collection.apply_advanced_config(
+            {"async_index_builder": {"segment_count": None}}
+        ) is None
+        assert collection.apply_advanced_config({}) is None
+
     def test_collection_diagnostics(self, temp_db):
         """Test collection_diagnostics reports index readiness."""
         collection = temp_db.create_collection("diag_test", dimension=4)

--- a/crates/velesdb-server/src/handlers/admin.rs
+++ b/crates/velesdb-server/src/handlers/admin.rs
@@ -227,6 +227,53 @@ pub async fn compact_collection(
     }
 }
 
+/// Reorders the HNSW adjacency lists and vector storage for cache
+/// locality so nodes traversed together during search sit close in
+/// memory (issue #377). No-op for collections with fewer than 1 000
+/// vectors. Recall is preserved — only the physical layout changes.
+///
+/// This is a blocking operation that may involve significant I/O for
+/// large collections.
+#[utoipa::path(
+    post,
+    path = "/collections/{name}/locality/reorder",
+    tag = "collections",
+    params(
+        ("name" = String, Path, description = "Collection name")
+    ),
+    responses(
+        (status = 200, description = "Locality reordered", body = Object),
+        (status = 404, description = "Collection not found", body = ErrorResponse),
+        (status = 500, description = "Reorder failed", body = ErrorResponse)
+    )
+)]
+pub async fn reorder_for_locality(
+    State(state): State<Arc<AppState>>,
+    Path(name): Path<String>,
+) -> impl IntoResponse {
+    let collection = match get_vector_collection_or_404(&state, &name) {
+        Ok(c) => c,
+        Err(resp) => return resp,
+    };
+
+    let result = tokio::task::spawn_blocking(move || collection.reorder_for_locality()).await;
+    match result {
+        Ok(Ok(())) => (
+            StatusCode::OK,
+            Json(serde_json::json!({
+                "message": "Locality reordered",
+                "collection": name
+            })),
+        )
+            .into_response(),
+        Ok(Err(e)) => auto_core_error_response(&e),
+        Err(join_err) => error_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("reorder task panicked: {join_err}"),
+        ),
+    }
+}
+
 /// Analyze a collection, computing and persisting statistics.
 #[utoipa::path(
     post,

--- a/crates/velesdb-server/src/handlers/mod.rs
+++ b/crates/velesdb-server/src/handlers/mod.rs
@@ -27,7 +27,8 @@ pub mod metrics;
 
 pub use admin::{
     analyze_collection, collection_diagnostics, compact_collection, get_collection_config,
-    get_collection_stats, get_guardrails, rebuild_index, update_guardrails, vacuum_collection,
+    get_collection_stats, get_guardrails, rebuild_index, reorder_for_locality, update_guardrails,
+    vacuum_collection,
 };
 pub use collections::{
     collection_sanity, create_collection, delete_collection, flush_collection, get_collection,

--- a/crates/velesdb-server/src/lib.rs
+++ b/crates/velesdb-server/src/lib.rs
@@ -60,9 +60,9 @@ pub use handlers::{
     delete_index, delete_point, explain, flush_collection, get_collection, get_collection_config,
     get_collection_stats, get_guardrails, get_point, get_point_relations, health_check,
     hybrid_search, is_empty, list_collections, list_indexes, match_query, multi_query_search,
-    query, readiness_check, rebuild_index, relate_points, scroll_points, search, search_ids,
-    set_point_ttl, stream_insert, stream_upsert_points, text_search, unrelate_points,
-    update_guardrails, upsert_points, vacuum_collection,
+    query, readiness_check, rebuild_index, relate_points, reorder_for_locality, scroll_points,
+    search, search_ids, set_point_ttl, stream_insert, stream_upsert_points, text_search,
+    unrelate_points, update_guardrails, upsert_points, vacuum_collection,
 };
 
 pub use handlers::graph::{
@@ -164,6 +164,7 @@ pub use handlers::metrics::{health_metrics, prometheus_metrics};
         handlers::admin::rebuild_index,
         handlers::admin::vacuum_collection,
         handlers::admin::compact_collection,
+        handlers::admin::reorder_for_locality,
         handlers::points::bulk_delete_points,
         handlers::points::relations::relate_points,
         handlers::points::relations::unrelate_points,

--- a/crates/velesdb-server/src/routes.rs
+++ b/crates/velesdb-server/src/routes.rs
@@ -19,10 +19,10 @@ use crate::{
     get_node_degree, get_node_edges, get_node_payload, get_point, get_point_relations,
     graph_search, health_check, hybrid_search, is_empty, list_collections, list_indexes,
     list_nodes, match_query, multi_query_search, query, readiness_check, rebuild_index,
-    relate_points, remove_edge, scroll_points, search, search_ids, set_point_ttl, stream_insert,
-    stream_traverse, stream_upsert_points, text_search, traverse_graph, traverse_parallel,
-    unrelate_points, update_guardrails, upsert_node_payload, upsert_points, vacuum_collection,
-    AppState,
+    relate_points, remove_edge, reorder_for_locality, scroll_points, search, search_ids,
+    set_point_ttl, stream_insert, stream_traverse, stream_upsert_points, text_search,
+    traverse_graph, traverse_parallel, unrelate_points, update_guardrails, upsert_node_payload,
+    upsert_points, vacuum_collection, AppState,
 };
 
 /// Core CRUD and admin routes.
@@ -75,6 +75,10 @@ fn core_routes() -> Router<Arc<AppState>> {
         // Maintenance endpoints
         .route("/collections/{name}/vacuum", post(vacuum_collection))
         .route("/collections/{name}/compact", post(compact_collection))
+        .route(
+            "/collections/{name}/locality/reorder",
+            post(reorder_for_locality),
+        )
 }
 
 /// Relation (graph edge) and durable TTL routes (any collection type).

--- a/crates/velesdb-server/tests/admin_endpoints_bdd_tests.rs
+++ b/crates/velesdb-server/tests/admin_endpoints_bdd_tests.rs
@@ -383,6 +383,71 @@ async fn compact_unknown_collection_returns_404() {
 }
 
 // ---------------------------------------------------------------------
+// /locality/reorder — reorder_for_locality
+// ---------------------------------------------------------------------
+
+#[tokio::test]
+async fn reorder_nominal_returns_200() {
+    let temp_dir = TempDir::new().expect("test: temp dir");
+    let app = create_test_app(&temp_dir);
+    seed_collection(app.clone(), 6).await;
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/collections/{TEST_COLLECTION}/locality/reorder"))
+                .body(Body::empty())
+                .expect("test: build reorder request"),
+        )
+        .await
+        .expect("test: reorder request");
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let json = read_json(response).await;
+    assert_eq!(json["message"], "Locality reordered");
+    assert_eq!(json["collection"], TEST_COLLECTION);
+}
+
+#[tokio::test]
+async fn reorder_empty_collection_returns_200() {
+    // Edge: reordering an empty collection is a valid no-op.
+    let temp_dir = TempDir::new().expect("test: temp dir");
+    let app = create_test_app(&temp_dir);
+    seed_collection(app.clone(), 0).await;
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/collections/{TEST_COLLECTION}/locality/reorder"))
+                .body(Body::empty())
+                .expect("test: build reorder request"),
+        )
+        .await
+        .expect("test: reorder request");
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn reorder_unknown_collection_returns_404() {
+    let temp_dir = TempDir::new().expect("test: temp dir");
+    let app = create_test_app(&temp_dir);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/collections/ghost_collection/locality/reorder")
+                .body(Body::empty())
+                .expect("test: build reorder request"),
+        )
+        .await
+        .expect("test: reorder request");
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+// ---------------------------------------------------------------------
 // Cross-endpoint sanity: delete -> vacuum -> compact lifecycle
 // ---------------------------------------------------------------------
 

--- a/crates/velesdb-server/tests/common/mod.rs
+++ b/crates/velesdb-server/tests/common/mod.rs
@@ -16,8 +16,8 @@ use velesdb_server::{
     compact_collection, create_collection, delete_collection, delete_point, explain,
     get_collection, get_collection_config, get_edges, get_node_degree, get_point, health_check,
     hybrid_search, list_collections, multi_query_search, query, readiness_check, rebuild_index,
-    scroll_points, search, search_ids, set_point_ttl, stream_upsert_points, text_search,
-    traverse_graph, upsert_points, vacuum_collection, AppState, OnboardingMetrics,
+    reorder_for_locality, scroll_points, search, search_ids, set_point_ttl, stream_upsert_points,
+    text_search, traverse_graph, upsert_points, vacuum_collection, AppState, OnboardingMetrics,
 };
 
 fn base_routes() -> Router<Arc<AppState>> {
@@ -84,6 +84,10 @@ fn graph_and_maintenance_routes() -> Router<Arc<AppState>> {
         )
         .route("/collections/{name}/vacuum", post(vacuum_collection))
         .route("/collections/{name}/compact", post(compact_collection))
+        .route(
+            "/collections/{name}/locality/reorder",
+            post(reorder_for_locality),
+        )
 }
 
 fn create_app_state(temp_dir: &TempDir) -> Arc<AppState> {

--- a/docs/CORE_WIRING_DEBT.md
+++ b/docs/CORE_WIRING_DEBT.md
@@ -282,10 +282,14 @@ feasibility · target file for the glue):
 - 6.2 `add_edges_batch` — DONE (server `/collections/{name}/graph/edges/batch` route + OpenAPI snapshot + Tauri command; HTTP integration test + Tauri tests).
 - 6.3 `search_ids` — Tauri command DONE (functional gap closed; unit-tested). **Server fast-path moved to PR-4** (grouped with 6.9: conditional hot-path opt, core `search_ids` has no filter param).
 
-**Status — PR-2 `feat/parity-ops-observability`** (branch open):
+**Status — PR-2 `feat/parity-ops-observability`** (MERGED, PR #1098 → develop):
 - 6.6 `collection_diagnostics` — DONE. New core DTO `CollectionDiagnosticsResponse`; server `GET /collections/{name}/diagnostics` route (+ OpenAPI); Python `Database.collection_diagnostics()` → dict. HTTP integration + pytest.
 - 6.7 guardrails get/update — DONE. Server already had it. Added Python (`Database.update_guardrails(dict)` + `collection.guard_rails()` read), Mobile (`MobileQueryLimits` record + `update_guardrails` + `collection.guard_rails`), Tauri (`update_guardrails`/`get_guardrails` commands). Tests on each. Note: `QueryLimits` (runtime) ≠ `LimitsConfig` (creation caps) — separate marshalling.
 - 6.8 auto-reindex lifecycle — DONE. Python `collection.detach_auto_reindex()` + `check_auto_reindex_divergence()` (completes the attach-only state; see entry 2). Pytest.
+
+**Status — PR-3 `feat/parity-recall-gated`** (branch open):
+- 6.4 `reorder_for_locality` — DONE. Server `POST /collections/{name}/locality/reorder` admin route (+ OpenAPI snapshot), Python `collection.reorder_for_locality()`. Server BDD tests (nominal/empty/404) + pytest. Recall-preserving (only physical layout changes); does **not** touch `index/hnsw/`, `simd_native/`, `quantization/`, `fusion/`, or Python result conversion — Gate-1 recall-contract tests (balanced ≥95, accurate ≥99, perfect =100) green.
+- 6.5 `apply_advanced_config` — DONE. Python `collection.apply_advanced_config(dict)` with three-state semantics (absent key=unchanged, `None`=clear, value=set) over `pq_rescore_oversampling` / `deferred_indexing` / `async_index_builder`; Mobile `MobileAdvancedConfig` record (+ `MobileDeferredIndexerConfig` / `MobileAsyncIndexBuilderConfig`) and `collection.apply_advanced_config` (mobile maps `None`→unchanged; cannot express clear). pytest + mobile `#[test]`.
 
 **Explicitly deferred (not worth closing now)**:
 - `stream_insert_batch` / `enable_streaming` / `StreamIngester::*` — async

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1623,6 +1623,59 @@
         }
       }
     },
+    "/collections/{name}/locality/reorder": {
+      "post": {
+        "tags": [
+          "collections"
+        ],
+        "summary": "Reorders the HNSW adjacency lists and vector storage for cache\nlocality so nodes traversed together during search sit close in\nmemory (issue #377). No-op for collections with fewer than 1 000\nvectors. Recall is preserved — only the physical layout changes.",
+        "description": "This is a blocking operation that may involve significant I/O for\nlarge collections.",
+        "operationId": "reorder_for_locality",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "description": "Collection name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Locality reordered",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Collection not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Reorder failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/collections/{name}/match": {
       "post": {
         "tags": [

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1032,6 +1032,45 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+  /collections/{name}/locality/reorder:
+    post:
+      tags:
+      - collections
+      summary: |-
+        Reorders the HNSW adjacency lists and vector storage for cache
+        locality so nodes traversed together during search sit close in
+        memory (issue #377). No-op for collections with fewer than 1 000
+        vectors. Recall is preserved — only the physical layout changes.
+      description: |-
+        This is a blocking operation that may involve significant I/O for
+        large collections.
+      operationId: reorder_for_locality
+      parameters:
+      - name: name
+        in: path
+        description: Collection name
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Locality reordered
+          content:
+            application/json:
+              schema:
+                type: object
+        '404':
+          description: Collection not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Reorder failed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
   /collections/{name}/match:
     post:
       tags:


### PR DESCRIPTION
## Summary

PR-3 of the API-parity campaign (CORE_WIRING_DEBT §6). Closes the two **recall-gated** core→binding gaps with tests on every affected binding.

| Gap | Core fn | Bindings wired |
|-----|---------|----------------|
| 6.4 | `VectorCollection::reorder_for_locality` | **Server** `POST /collections/{name}/locality/reorder` (+ OpenAPI), **Python** `collection.reorder_for_locality()` |
| 6.5 | `VectorCollection::apply_advanced_config` | **Python** `collection.apply_advanced_config(dict)`, **Mobile** `MobileAdvancedConfig` record + `collection.apply_advanced_config` |

### 6.4 — reorder_for_locality
Recall-preserving HNSW/storage layout reorder (issue #377; no-op below 1000 vectors). Server admin route mirrors `compact`/`vacuum`; Python wrapper mirrors `compact_storage`.

### 6.5 — apply_advanced_config (three-state semantics)
Post-creation overrides for `pq_rescore_oversampling` / `deferred_indexing` / `async_index_builder`, persisted to `config.json`. Python dict semantics: **absent key** = leave unchanged, **`None`** = clear, **value** = set — faithfully mapping the core `Option<Option<T>>` contract. Mobile uses a `MobileAdvancedConfig` UniFFI record (+ `MobileDeferredIndexerConfig` / `MobileAsyncIndexBuilderConfig`); mobile maps `None`→unchanged and cannot express the clear state (documented).

## Recall gate (QUALITY_BAR Gate-1)
This diff does **not** touch `index/hnsw/`, `simd_native/`, `quantization/`, `fusion/`, or Python result conversion — it only exposes existing core fns and adds a route. Recall-contract tests pass:
- `recall_contract_balanced_*_gte_95` ✅ · `accurate_gte_99` ✅ · `perfect_eq_100` ✅ · `fast_gte_90` ✅

## Tests
- **Server**: BDD nominal / empty / unknown-404 for `/locality/reorder` (+ test router + OpenAPI snapshot regenerated).
- **Python**: `test_reorder_for_locality`, `test_apply_advanced_config_sets_fields`, `test_apply_advanced_config_clear_and_unchanged` (92/92 suite green).
- **Mobile**: `test_advanced_config_record_conversions`, `test_collection_apply_advanced_config`.

## Validation run locally
`cargo fmt` · clippy pedantic (workspace, -python) clean · core `test_recall` (all green) · server reorder tests (3) · mobile tests (2) · pytest (92) · `check_prod_unwraps` · lizard CCN ≤8 on new code · no-default-features (core + wasm).

Note: a few server test/handler blocks intentionally mirror the existing `compact`/`vacuum` parallel fixtures and the prod↔test router pattern (pre-existing convention).