### PR TITLE
feat(bindings): API parity PR-4 — search consistency (batch_parallel, search_ids, multi_query_search_ids)

### DIFF
--- a/crates/velesdb-server/src/handlers/mod.rs
+++ b/crates/velesdb-server/src/handlers/mod.rs
@@ -44,7 +44,8 @@ pub use points::{
 pub use match_query::match_query;
 pub use query::{aggregate, explain, query};
 pub use search::{
-    batch_search, hybrid_search, multi_query_search, search, search_ids, text_search,
+    batch_search, hybrid_search, multi_query_search, multi_query_search_ids, search, search_ids,
+    text_search,
 };
 
 // Graph handlers (EPIC-016) - exported via lib.rs

--- a/crates/velesdb-server/src/handlers/search/batch.rs
+++ b/crates/velesdb-server/src/handlers/search/batch.rs
@@ -75,7 +75,7 @@ pub async fn batch_search(
     let queries: Vec<&[f32]> = req.searches.iter().map(|s| s.vector.as_slice()).collect();
     let max_top_k = req.searches.iter().map(|s| s.top_k).max().unwrap_or(10);
 
-    let batch_result = collection.search_batch_with_filters(&queries, max_top_k, &filters);
+    let batch_result = run_batch_search(&collection, &queries, max_top_k, &filters);
     record_circuit_breaker(&collection, &batch_result);
 
     let all_results = match batch_result {
@@ -87,6 +87,23 @@ pub async fn batch_search(
     };
 
     finish_batch_search(&state, &name, start, all_results)
+}
+
+/// Dispatch a batch search to the throughput-optimized parallel kernel when no
+/// query carries a filter, falling back to the per-query filtered kernel
+/// otherwise. Both paths share the same HNSW traversal, so results are
+/// identical for the unfiltered case — only the rayon parallelism differs.
+fn run_batch_search(
+    collection: &velesdb_core::collection::VectorCollection,
+    queries: &[&[f32]],
+    max_top_k: usize,
+    filters: &[Option<velesdb_core::Filter>],
+) -> velesdb_core::Result<Vec<Vec<velesdb_core::SearchResult>>> {
+    if filters.iter().all(Option::is_none) {
+        collection.search_batch_parallel(queries, max_top_k)
+    } else {
+        collection.search_batch_with_filters(queries, max_top_k, filters)
+    }
 }
 
 /// Record timing metrics and build the final batch response envelope.

--- a/crates/velesdb-server/src/handlers/search/mod.rs
+++ b/crates/velesdb-server/src/handlers/search/mod.rs
@@ -21,8 +21,9 @@ use crate::AppState;
 
 use super::helpers::{apply_pre_check, extract_client_id, get_vector_collection_or_404};
 use pipeline::{
-    execute_search_request, finish_search_ids_with_cb, finish_search_with_cb,
-    finish_search_with_status, parse_optional_filter, timeout_response, validate_query_dimension,
+    execute_dense_search_ids, execute_search_request, finish_search_ids_with_cb,
+    finish_search_with_cb, finish_search_with_status, ids_fast_path_eligible,
+    parse_optional_filter, timeout_response, validate_query_dimension,
 };
 use workers::{run_blocking_search, run_search_with_optional_timeout};
 
@@ -31,7 +32,9 @@ pub use batch::__path_batch_search;
 pub use batch::batch_search;
 #[allow(unused_imports)]
 pub use multi::__path_multi_query_search;
-pub use multi::multi_query_search;
+#[allow(unused_imports)]
+pub use multi::__path_multi_query_search_ids;
+pub use multi::{multi_query_search, multi_query_search_ids};
 
 /// Shared search preamble: record onboarding metric and resolve collection.
 ///
@@ -159,6 +162,24 @@ fn execute_search_with_cb_owned(
     collection: &VectorCollection,
     req: &mut SearchRequest,
 ) -> Result<velesdb_core::Result<Vec<velesdb_core::SearchResult>>, axum::response::Response> {
+    execute_with_cb(state, name, collection, req)
+}
+
+/// Owned-request variant for `/search/ids`: takes the `search_ids` fast path
+/// (no payload hydration) for plain dense requests, otherwise falls back to
+/// the generic pipeline. Records a circuit-breaker failure on a hard error so
+/// both paths stay consistent with [`execute_with_cb`].
+#[allow(clippy::result_large_err)]
+fn execute_search_ids_with_cb_owned(
+    state: &AppState,
+    name: &str,
+    collection: &VectorCollection,
+    req: &mut SearchRequest,
+) -> Result<velesdb_core::Result<Vec<velesdb_core::SearchResult>>, axum::response::Response> {
+    if ids_fast_path_eligible(req) {
+        return execute_dense_search_ids(state, name, collection, req)
+            .inspect_err(|_| collection.guard_rails().circuit_breaker.record_failure());
+    }
     execute_with_cb(state, name, collection, req)
 }
 
@@ -372,7 +393,7 @@ pub async fn search_ids(
 
     let execution = run_search_with_optional_timeout(timeout_ms, move || {
         let mut owned_req = req;
-        execute_search_with_cb_owned(
+        execute_search_ids_with_cb_owned(
             &state_for_work,
             &name_for_work,
             &collection_for_work,

--- a/crates/velesdb-server/src/handlers/search/multi.rs
+++ b/crates/velesdb-server/src/handlers/search/multi.rs
@@ -8,10 +8,13 @@ use axum::{
 };
 use std::sync::Arc;
 
-use crate::types::{ErrorResponse, MultiQuerySearchRequest, SearchResponse};
+use crate::types::{ErrorResponse, MultiQuerySearchRequest, SearchIdsResponse, SearchResponse};
 use crate::AppState;
 
-use super::pipeline::{finish_search_with_cb, parse_filter_or_400, validate_query_dimension};
+use super::pipeline::{
+    finish_search_ids_with_cb, finish_search_with_cb, id_score_results, parse_filter_or_400,
+    validate_query_dimension,
+};
 use super::workers::run_blocking_search;
 use crate::handlers::helpers::{apply_pre_check, extract_client_id, get_vector_collection_or_404};
 
@@ -79,6 +82,45 @@ fn validate_query_vectors(
     Ok(())
 }
 
+/// Shared preamble for the multi-query handlers: records metrics, resolves the
+/// collection, enforces guard rails, parses the fusion strategy, and validates
+/// every query vector's dimension. Returns the collection and strategy on
+/// success, or the appropriate error response.
+#[allow(clippy::result_large_err)]
+fn prepare_multi_query(
+    state: &AppState,
+    headers: &axum::http::HeaderMap,
+    name: &str,
+    req: &MultiQuerySearchRequest,
+) -> Result<
+    (
+        velesdb_core::collection::VectorCollection,
+        velesdb_core::FusionStrategy,
+    ),
+    axum::response::Response,
+> {
+    state.onboarding_metrics.record_search_request();
+
+    let collection = get_vector_collection_or_404(state, name)?;
+
+    // Record query type only after confirming the collection exists, so
+    // 404s do not inflate queries_total or vector_queries.
+    state.operational_metrics.record_vector_query();
+
+    let client_id = extract_client_id(headers);
+    if let Err(resp) = apply_pre_check(collection.guard_rails(), &client_id) {
+        state.operational_metrics.inc_rate_limited();
+        return Err(resp);
+    }
+
+    let strategy = parse_fusion_strategy(req, state)?;
+
+    let expected_dimension = collection.config().dimension;
+    validate_query_vectors(state, name, expected_dimension, &req.vectors)?;
+
+    Ok((collection, strategy))
+}
+
 /// Multi-query search with fusion strategies.
 #[utoipa::path(
     post,
@@ -92,40 +134,17 @@ fn validate_query_vectors(
         (status = 500, description = "Internal server error", body = ErrorResponse)
     )
 )]
-#[allow(clippy::too_many_lines, clippy::result_large_err)]
+#[allow(clippy::result_large_err)]
 pub async fn multi_query_search(
     State(state): State<Arc<AppState>>,
     headers: axum::http::HeaderMap,
     Path(name): Path<String>,
     Json(req): Json<MultiQuerySearchRequest>,
 ) -> impl IntoResponse {
-    state.onboarding_metrics.record_search_request();
-
-    let collection: velesdb_core::collection::VectorCollection =
-        match get_vector_collection_or_404(&state, &name) {
-            Ok(c) => c,
-            Err(resp) => return resp,
-        };
-
-    // Record query type only after confirming the collection exists, so
-    // 404s do not inflate queries_total or vector_queries.
-    state.operational_metrics.record_vector_query();
-
-    let client_id = extract_client_id(&headers);
-    if let Err(resp) = apply_pre_check(collection.guard_rails(), &client_id) {
-        state.operational_metrics.inc_rate_limited();
-        return resp;
-    }
-
-    let strategy = match parse_fusion_strategy(&req, &state) {
-        Ok(s) => s,
+    let (collection, strategy) = match prepare_multi_query(&state, &headers, &name, &req) {
+        Ok(v) => v,
         Err(resp) => return resp,
     };
-
-    let expected_dimension = collection.config().dimension;
-    if let Err(resp) = validate_query_vectors(&state, &name, expected_dimension, &req.vectors) {
-        return resp;
-    }
 
     // Parse the optional metadata filter. We need to materialise the
     // `Filter` before starting the stopwatch so that a malformed filter
@@ -173,4 +192,73 @@ pub async fn multi_query_search(
     };
 
     finish_search_with_cb(&state, &name, start, &collection, search_result)
+}
+
+/// Multi-query fusion search returning only ids and scores (no payloads).
+///
+/// Faster than `/search/multi` when payloads are not needed: the core
+/// `multi_query_search_ids` kernel skips payload hydration. Metadata filters
+/// are not supported here — use `/search/multi` for filtered fusion.
+#[utoipa::path(
+    post,
+    path = "/collections/{name}/search/multi/ids",
+    tag = "search",
+    params(("name" = String, Path, description = "Collection name")),
+    request_body = MultiQuerySearchRequest,
+    responses(
+        (status = 200, description = "Multi-query ids-only results", body = SearchIdsResponse),
+        (status = 400, description = "Invalid request", body = ErrorResponse),
+        (status = 404, description = "Collection not found", body = ErrorResponse)
+    )
+)]
+#[allow(clippy::result_large_err)]
+pub async fn multi_query_search_ids(
+    State(state): State<Arc<AppState>>,
+    headers: axum::http::HeaderMap,
+    Path(name): Path<String>,
+    Json(req): Json<MultiQuerySearchRequest>,
+) -> impl IntoResponse {
+    let (collection, strategy) = match prepare_multi_query(&state, &headers, &name, &req) {
+        Ok(v) => v,
+        Err(resp) => return resp,
+    };
+
+    // The ids-only fusion kernel has no filter parameter. Reject filters
+    // explicitly rather than silently returning unfiltered results.
+    if req.filter.is_some() {
+        state.operational_metrics.inc_errors();
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse {
+                error: "Metadata filters are not supported on /search/multi/ids; \
+                        use /search/multi for filtered multi-query search."
+                    .to_string(),
+                code: None,
+            }),
+        )
+            .into_response();
+    }
+
+    let start = std::time::Instant::now();
+    let collection_for_work = collection.clone();
+    let vectors = req.vectors;
+    let top_k = req.top_k;
+
+    let work_result = run_blocking_search(move || {
+        let query_refs: Vec<&[f32]> = vectors.iter().map(Vec::as_slice).collect();
+        Ok(collection_for_work
+            .multi_query_search_ids(&query_refs, top_k, strategy)
+            .map(id_score_results))
+    })
+    .await;
+
+    let search_result = match work_result {
+        Ok(inner) => inner,
+        Err(resp) => {
+            state.operational_metrics.inc_errors();
+            return resp;
+        }
+    };
+
+    finish_search_ids_with_cb(&state, &name, start, &collection, search_result)
 }

--- a/crates/velesdb-server/src/handlers/search/pipeline.rs
+++ b/crates/velesdb-server/src/handlers/search/pipeline.rs
@@ -259,6 +259,73 @@ pub(crate) fn execute_dense_search(
     Ok(result)
 }
 
+/// Builds payload-less [`SearchResult`]s from id/score pairs.
+///
+/// Used by the ids-only fast paths (`search_ids`, `multi_query_search_ids`) so
+/// they can reuse the standard `finish_search_ids*` machinery without
+/// hydrating payloads that the caller will discard.
+pub(crate) fn id_score_results(
+    pairs: impl IntoIterator<Item = (u64, f32)>,
+) -> Vec<velesdb_core::SearchResult> {
+    pairs
+        .into_iter()
+        .map(|(id, score)| {
+            velesdb_core::SearchResult::new(
+                velesdb_core::Point::without_payload(id, Vec::new()),
+                score,
+            )
+        })
+        .collect()
+}
+
+/// Returns `true` when `req` carries any sparse query payload.
+fn has_sparse_input(req: &SearchRequest) -> bool {
+    req.sparse_vector.is_some() || req.sparse_vectors.as_ref().is_some_and(|m| !m.is_empty())
+}
+
+/// Whether an ids-only request can take the `search_ids` fast path.
+///
+/// Eligible requests are plain dense kNN — no filter, sparse payload,
+/// `ef_search` override, or quality `mode` — i.e. exactly the inputs that
+/// reach `collection.search()` in [`execute_dense_search`]. Both `search` and
+/// `search_ids` run the same HNSW traversal, so the fast path returns an
+/// identical id/score ranking; any other shape falls back to the generic
+/// pipeline to stay correct.
+pub(crate) fn ids_fast_path_eligible(req: &SearchRequest) -> bool {
+    !req.vector.is_empty()
+        && req.filter.is_none()
+        && req.ef_search.is_none()
+        && !has_sparse_input(req)
+        && req
+            .mode
+            .as_ref()
+            .and_then(|m| mode_to_search_quality(m))
+            .is_none()
+}
+
+/// Ids-only fast path: runs `search_ids` (HNSW traversal without payload
+/// hydration) for requests deemed eligible by [`ids_fast_path_eligible`].
+///
+/// # Errors
+///
+/// Returns a 400 response when the query dimension does not match.
+#[allow(clippy::result_large_err)]
+pub(crate) fn execute_dense_search_ids(
+    state: &AppState,
+    name: &str,
+    collection: &VectorCollection,
+    req: &SearchRequest,
+) -> Result<velesdb_core::Result<Vec<velesdb_core::SearchResult>>, axum::response::Response> {
+    let expected_dimension = collection.config().dimension;
+    if let Err(error) = validate_query_dimension(state, name, expected_dimension, &req.vector) {
+        return Err((StatusCode::BAD_REQUEST, Json(error)).into_response());
+    }
+    let result = collection
+        .search_ids(&req.vector, req.top_k)
+        .map(|scored| id_score_results(scored.into_iter().map(|s| (s.id, s.score))));
+    Ok(result)
+}
+
 /// Search mode classification used by [`execute_search_request`] to
 /// dispatch to the appropriate search backend.
 ///

--- a/crates/velesdb-server/src/lib.rs
+++ b/crates/velesdb-server/src/lib.rs
@@ -60,9 +60,10 @@ pub use handlers::{
     delete_index, delete_point, explain, flush_collection, get_collection, get_collection_config,
     get_collection_stats, get_guardrails, get_point, get_point_relations, health_check,
     hybrid_search, is_empty, list_collections, list_indexes, match_query, multi_query_search,
-    query, readiness_check, rebuild_index, relate_points, reorder_for_locality, scroll_points,
-    search, search_ids, set_point_ttl, stream_insert, stream_upsert_points, text_search,
-    unrelate_points, update_guardrails, upsert_points, vacuum_collection,
+    multi_query_search_ids, query, readiness_check, rebuild_index, relate_points,
+    reorder_for_locality, scroll_points, search, search_ids, set_point_ttl, stream_insert,
+    stream_upsert_points, text_search, unrelate_points, update_guardrails, upsert_points,
+    vacuum_collection,
 };
 
 pub use handlers::graph::{
@@ -136,6 +137,7 @@ pub use handlers::metrics::{health_metrics, prometheus_metrics};
         handlers::search::search,
         handlers::search::batch_search,
         handlers::search::multi_query_search,
+        handlers::search::multi_query_search_ids,
         handlers::search::text_search,
         handlers::search::hybrid_search,
         handlers::search::search_ids,

--- a/crates/velesdb-server/src/routes.rs
+++ b/crates/velesdb-server/src/routes.rs
@@ -18,9 +18,9 @@ use crate::{
     get_collection_config, get_collection_stats, get_edge_count, get_edges, get_guardrails,
     get_node_degree, get_node_edges, get_node_payload, get_point, get_point_relations,
     graph_search, health_check, hybrid_search, is_empty, list_collections, list_indexes,
-    list_nodes, match_query, multi_query_search, query, readiness_check, rebuild_index,
-    relate_points, remove_edge, reorder_for_locality, scroll_points, search, search_ids,
-    set_point_ttl, stream_insert, stream_traverse, stream_upsert_points, text_search,
+    list_nodes, match_query, multi_query_search, multi_query_search_ids, query, readiness_check,
+    rebuild_index, relate_points, remove_edge, reorder_for_locality, scroll_points, search,
+    search_ids, set_point_ttl, stream_insert, stream_traverse, stream_upsert_points, text_search,
     traverse_graph, traverse_parallel, unrelate_points, update_guardrails, upsert_node_payload,
     upsert_points, vacuum_collection, AppState,
 };
@@ -102,6 +102,10 @@ fn search_routes() -> Router<Arc<AppState>> {
         .route("/collections/{name}/search", post(search))
         .route("/collections/{name}/search/batch", post(batch_search))
         .route("/collections/{name}/search/multi", post(multi_query_search))
+        .route(
+            "/collections/{name}/search/multi/ids",
+            post(multi_query_search_ids),
+        )
         .route("/collections/{name}/search/text", post(text_search))
         .route("/collections/{name}/search/hybrid", post(hybrid_search))
         .route("/collections/{name}/search/ids", post(search_ids))

--- a/crates/velesdb-server/tests/common/mod.rs
+++ b/crates/velesdb-server/tests/common/mod.rs
@@ -15,9 +15,10 @@ use velesdb_server::{
     batch_search, bulk_delete_points, collection_diagnostics, collection_sanity,
     compact_collection, create_collection, delete_collection, delete_point, explain,
     get_collection, get_collection_config, get_edges, get_node_degree, get_point, health_check,
-    hybrid_search, list_collections, multi_query_search, query, readiness_check, rebuild_index,
-    reorder_for_locality, scroll_points, search, search_ids, set_point_ttl, stream_upsert_points,
-    text_search, traverse_graph, upsert_points, vacuum_collection, AppState, OnboardingMetrics,
+    hybrid_search, list_collections, multi_query_search, multi_query_search_ids, query,
+    readiness_check, rebuild_index, reorder_for_locality, scroll_points, search, search_ids,
+    set_point_ttl, stream_upsert_points, text_search, traverse_graph, upsert_points,
+    vacuum_collection, AppState, OnboardingMetrics,
 };
 
 fn base_routes() -> Router<Arc<AppState>> {
@@ -53,6 +54,10 @@ fn base_routes() -> Router<Arc<AppState>> {
         .route("/collections/{name}/search", post(search))
         .route("/collections/{name}/search/batch", post(batch_search))
         .route("/collections/{name}/search/multi", post(multi_query_search))
+        .route(
+            "/collections/{name}/search/multi/ids",
+            post(multi_query_search_ids),
+        )
         .route("/collections/{name}/search/text", post(text_search))
         .route("/collections/{name}/search/hybrid", post(hybrid_search))
         .route("/collections/{name}/search/ids", post(search_ids))

--- a/crates/velesdb-server/tests/parity_consistency_tests.rs
+++ b/crates/velesdb-server/tests/parity_consistency_tests.rs
@@ -1,0 +1,295 @@
+#![allow(clippy::doc_markdown)]
+//! Consistency parity tests for API-parity PR-4 (gaps 6.9, 6.3-server, 6.10):
+//!
+//! - `POST /collections/{name}/search/ids`        — `search_ids` fast path
+//! - `POST /collections/{name}/search/batch`      — `search_batch_parallel`
+//! - `POST /collections/{name}/search/multi/ids`  — `multi_query_search_ids`
+//!
+//! Each new ids-only / parallel path must return the SAME ranking as the
+//! full-result endpoint it optimizes — these tests pin that equivalence so a
+//! future divergence (a recall regression) fails CI. Coverage mixes nominal
+//! parity (~60%), an edge fallback (filtered ids search), and negatives
+//! (filter rejection, unknown collection).
+
+mod common;
+
+use axum::{
+    body::Body,
+    http::{Request, StatusCode},
+};
+use common::create_test_app;
+use serde_json::{json, Value};
+use tempfile::TempDir;
+use tower::ServiceExt;
+
+const COLLECTION: &str = "parity_consistency";
+const DIM: usize = 4;
+const QUERY: [f32; DIM] = [1.0, 0.5, 0.25, 0.1];
+const QUERY2: [f32; DIM] = [6.0, 2.5, 1.25, 0.5];
+
+async fn post(app: &axum::Router, uri: &str, body: Value) -> axum::response::Response {
+    app.clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(uri)
+                .header("Content-Type", "application/json")
+                .body(Body::from(body.to_string()))
+                .expect("test: build request"),
+        )
+        .await
+        .expect("test: request")
+}
+
+async fn read_json(response: axum::response::Response) -> Value {
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("test: read body");
+    serde_json::from_slice(&body).expect("test: valid JSON")
+}
+
+/// Create the collection and seed six deterministic points with even/odd
+/// `bucket` payloads (even => ids 1, 3, 5).
+async fn seed(app: &axum::Router) {
+    let resp = post(
+        app,
+        "/collections",
+        json!({"name": COLLECTION, "dimension": DIM, "metric": "cosine"}),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::CREATED, "test setup: create");
+
+    let points: Vec<Value> = (0..6u64)
+        .map(|i| {
+            #[allow(clippy::cast_precision_loss)]
+            let f = i as f32;
+            json!({
+                "id": i + 1,
+                "vector": [1.0 + f, 0.5 * f, 0.25 * f, 0.1 * f],
+                "payload": {"bucket": if i % 2 == 0 { "even" } else { "odd" }},
+            })
+        })
+        .collect();
+    let resp = post(
+        app,
+        &format!("/collections/{COLLECTION}/points"),
+        json!({ "points": points }),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::OK, "test setup: seed");
+}
+
+/// Extract `(id, score)` pairs from a `{results:[{id,score,...}]}` body.
+///
+/// Ids are serialized as strings (u64 precision-safe for JS clients), so we
+/// keep them as `String` for comparison.
+fn id_score_pairs(json: &Value) -> Vec<(String, f64)> {
+    json["results"]
+        .as_array()
+        .expect("test: results array")
+        .iter()
+        .map(|r| {
+            (
+                r["id"].as_str().expect("test: id is a string").to_string(),
+                r["score"].as_f64().expect("test: score"),
+            )
+        })
+        .collect()
+}
+
+fn eq_filter(field: &str, value: &str) -> Value {
+    json!({ "condition": { "type": "eq", "field": field, "value": value } })
+}
+
+// ---------------------------------------------------------------------
+// 6.3-server — /search/ids fast path
+// ---------------------------------------------------------------------
+
+#[tokio::test]
+async fn search_ids_matches_search_ranking() {
+    let dir = TempDir::new().expect("test: dir");
+    let app = create_test_app(&dir);
+    seed(&app).await;
+
+    let req = json!({ "vector": QUERY, "top_k": 4 });
+    let full = read_json(
+        post(
+            &app,
+            &format!("/collections/{COLLECTION}/search"),
+            req.clone(),
+        )
+        .await,
+    )
+    .await;
+    let ids =
+        read_json(post(&app, &format!("/collections/{COLLECTION}/search/ids"), req).await).await;
+
+    let full_pairs = id_score_pairs(&full);
+    assert_eq!(full_pairs.len(), 4, "expected top_k results from /search");
+    assert_eq!(
+        full_pairs,
+        id_score_pairs(&ids),
+        "search_ids fast path must match /search ranking and scores exactly"
+    );
+
+    // The ids endpoint must not hydrate payloads.
+    let first = &ids["results"][0];
+    assert!(
+        first.get("payload").is_none(),
+        "/search/ids must not include payloads"
+    );
+}
+
+#[tokio::test]
+async fn search_ids_with_filter_falls_back_and_filters() {
+    let dir = TempDir::new().expect("test: dir");
+    let app = create_test_app(&dir);
+    seed(&app).await;
+
+    // A filtered ids request is ineligible for the fast path and falls back to
+    // the generic pipeline, which honours the filter.
+    let req = json!({ "vector": QUERY, "top_k": 6, "filter": eq_filter("bucket", "even") });
+    let resp = post(&app, &format!("/collections/{COLLECTION}/search/ids"), req).await;
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let pairs = id_score_pairs(&read_json(resp).await);
+    assert!(
+        !pairs.is_empty(),
+        "filtered ids search should return matches"
+    );
+    for (id, _) in &pairs {
+        assert!(
+            ["1", "3", "5"].contains(&id.as_str()),
+            "filter must exclude odd-bucket ids, got {id}"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------
+// 6.9 — /search/batch parallel path
+// ---------------------------------------------------------------------
+
+#[tokio::test]
+async fn batch_search_parallel_matches_individual_search() {
+    let dir = TempDir::new().expect("test: dir");
+    let app = create_test_app(&dir);
+    seed(&app).await;
+
+    // No filters => batch takes the parallel kernel; results must match the
+    // serial per-query search exactly.
+    let single = |q: [f32; DIM]| {
+        let app = app.clone();
+        async move {
+            let body = read_json(
+                post(
+                    &app,
+                    &format!("/collections/{COLLECTION}/search"),
+                    json!({ "vector": q, "top_k": 3 }),
+                )
+                .await,
+            )
+            .await;
+            id_score_pairs(&body)
+        }
+    };
+    let s1 = single(QUERY).await;
+    let s2 = single(QUERY2).await;
+
+    let batch = read_json(
+        post(
+            &app,
+            &format!("/collections/{COLLECTION}/search/batch"),
+            json!({ "searches": [
+                { "vector": QUERY, "top_k": 3 },
+                { "vector": QUERY2, "top_k": 3 },
+            ] }),
+        )
+        .await,
+    )
+    .await;
+
+    let results = batch["results"].as_array().expect("test: batch results");
+    assert_eq!(results.len(), 2);
+    assert_eq!(id_score_pairs(&results[0]), s1, "batch query 0 must match");
+    assert_eq!(id_score_pairs(&results[1]), s2, "batch query 1 must match");
+}
+
+// ---------------------------------------------------------------------
+// 6.10 — /search/multi/ids
+// ---------------------------------------------------------------------
+
+#[tokio::test]
+async fn multi_query_search_ids_matches_multi_query_search() {
+    let dir = TempDir::new().expect("test: dir");
+    let app = create_test_app(&dir);
+    seed(&app).await;
+
+    let req = json!({ "vectors": [QUERY, QUERY2], "top_k": 3, "strategy": "rrf" });
+    let full = read_json(
+        post(
+            &app,
+            &format!("/collections/{COLLECTION}/search/multi"),
+            req.clone(),
+        )
+        .await,
+    )
+    .await;
+    let ids = read_json(
+        post(
+            &app,
+            &format!("/collections/{COLLECTION}/search/multi/ids"),
+            req,
+        )
+        .await,
+    )
+    .await;
+
+    assert_eq!(
+        id_score_pairs(&full),
+        id_score_pairs(&ids),
+        "multi_query_search_ids must match multi_query_search fused ranking"
+    );
+    assert!(
+        ids["results"][0].get("payload").is_none(),
+        "/search/multi/ids must not include payloads"
+    );
+}
+
+#[tokio::test]
+async fn multi_query_search_ids_rejects_filter() {
+    let dir = TempDir::new().expect("test: dir");
+    let app = create_test_app(&dir);
+    seed(&app).await;
+
+    let req = json!({
+        "vectors": [QUERY],
+        "top_k": 3,
+        "strategy": "rrf",
+        "filter": eq_filter("bucket", "even"),
+    });
+    let resp = post(
+        &app,
+        &format!("/collections/{COLLECTION}/search/multi/ids"),
+        req,
+    )
+    .await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::BAD_REQUEST,
+        "filters are unsupported on the ids-only fusion endpoint"
+    );
+}
+
+#[tokio::test]
+async fn multi_query_search_ids_unknown_collection_returns_404() {
+    let dir = TempDir::new().expect("test: dir");
+    let app = create_test_app(&dir);
+
+    let resp = post(
+        &app,
+        "/collections/missing/search/multi/ids",
+        json!({ "vectors": [QUERY], "top_k": 3, "strategy": "rrf" }),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}

--- a/docs/CORE_WIRING_DEBT.md
+++ b/docs/CORE_WIRING_DEBT.md
@@ -277,7 +277,7 @@ feasibility · target file for the glue):
 | 6.10 | `VectorCollection::multi_query_search_ids` | rest, tauri, mobile, ts | P3 | trivial — id-only variant of broadly-exposed `multi_query_search` | server `search/multi.rs` (ids-only mode); TS `search-backend.ts` |
 | 6.11 | `validate_collection_name` / `validate_dimension` / `validate_dimension_match` (free-fns) | every binding re-implements them | P3 | trivial — consistency, not a feature | re-export + replace local validators in python `lib.rs`, server validation, ts `client/validation.ts` |
 
-**Status — PR-1 `feat/parity-embedded-ops`** (branch open):
+**Status — PR-1 `feat/parity-embedded-ops`** (MERGED, PR #1096 → develop):
 - 6.1 `compact_storage` — DONE (Python, Mobile, Tauri; each with a unit test).
 - 6.2 `add_edges_batch` — DONE (server `/collections/{name}/graph/edges/batch` route + OpenAPI snapshot + Tauri command; HTTP integration test + Tauri tests).
 - 6.3 `search_ids` — Tauri command DONE (functional gap closed; unit-tested). **Server fast-path moved to PR-4** (grouped with 6.9: conditional hot-path opt, core `search_ids` has no filter param).
@@ -287,9 +287,15 @@ feasibility · target file for the glue):
 - 6.7 guardrails get/update — DONE. Server already had it. Added Python (`Database.update_guardrails(dict)` + `collection.guard_rails()` read), Mobile (`MobileQueryLimits` record + `update_guardrails` + `collection.guard_rails`), Tauri (`update_guardrails`/`get_guardrails` commands). Tests on each. Note: `QueryLimits` (runtime) ≠ `LimitsConfig` (creation caps) — separate marshalling.
 - 6.8 auto-reindex lifecycle — DONE. Python `collection.detach_auto_reindex()` + `check_auto_reindex_divergence()` (completes the attach-only state; see entry 2). Pytest.
 
-**Status — PR-3 `feat/parity-recall-gated`** (branch open):
+**Status — PR-3 `feat/parity-recall-gated`** (MERGED, PR #1099 → develop):
 - 6.4 `reorder_for_locality` — DONE. Server `POST /collections/{name}/locality/reorder` admin route (+ OpenAPI snapshot), Python `collection.reorder_for_locality()`. Server BDD tests (nominal/empty/404) + pytest. Recall-preserving (only physical layout changes); does **not** touch `index/hnsw/`, `simd_native/`, `quantization/`, `fusion/`, or Python result conversion — Gate-1 recall-contract tests (balanced ≥95, accurate ≥99, perfect =100) green.
 - 6.5 `apply_advanced_config` — DONE. Python `collection.apply_advanced_config(dict)` with three-state semantics (absent key=unchanged, `None`=clear, value=set) over `pq_rescore_oversampling` / `deferred_indexing` / `async_index_builder`; Mobile `MobileAdvancedConfig` record (+ `MobileDeferredIndexerConfig` / `MobileAsyncIndexBuilderConfig`) and `collection.apply_advanced_config` (mobile maps `None`→unchanged; cannot express clear). pytest + mobile `#[test]`.
+
+**Status — PR-4 `feat/parity-consistency`** (the final campaign PR):
+- 6.9 `search_batch_parallel` — DONE. Server `/search/batch` dispatches to `search_batch_parallel` (rayon, no-filter throughput path) when no query carries a filter, else `search_batch_with_filters`. Same HNSW traversal, so the unfiltered case is identical to serial. Parity test (`parity_consistency_tests.rs`) pins batch == per-query `/search`.
+- 6.3-server `search_ids` true core path — DONE. `/search/ids` now calls core `search_ids` (skips payload hydration) for plain dense requests (no filter/sparse/`ef_search`/quality `mode`); any other shape falls back to the generic pipeline. `search()` and `search_ids()` share `search_ids_with_adc_if_pq`, so the fast path's id/score ranking is identical — pinned by a `/search` vs `/search/ids` parity test. (Tauri `search_ids` command already landed in PR-1.)
+- 6.10 `multi_query_search_ids` — DONE. Server `POST /collections/{name}/search/multi/ids` (+ OpenAPI) calls core `multi_query_search_ids` (rejects filters — the kernel has no filter param); TS `multiQuerySearchIds` across `search-backend.ts` → REST/WASM backends (WASM = not-supported stub, mirroring `searchIds`) → `Backend` interface → client. Server parity + filter-rejection + 404 tests; TS backend tests.
+- 6.11 `validate_*` free-fn dedup — **VERIFIED no-op (no real gap).** The matrix row was overstated: no binding re-implements these. Core already re-exports `validate_collection_name` / `validate_dimension` / `validate_dimension_match` from the crate root (`lib.rs`); Python relies on core validation via error-mapping (no local validators in `lib.rs`); the server only matches the `InvalidCollectionName` *error* variant (no local name/dimension validator); TS is client-only and has no `validateCollectionName` / `validateDimension`. Nothing to consolidate.
 
 **Explicitly deferred (not worth closing now)**:
 - `stream_insert_batch` / `enable_streaming` / `StreamIngester::*` — async
@@ -319,7 +325,7 @@ consistency-cleanup PR. Each binding glue must pass that crate's CI line
 | `deferred_indexing` / `async_index_builder` | REST-only (no TOML/Python) | RFC pending | Unscoped | Community (future sprint) |
 | `SearchConfig` global defaults | Partial | Consolidation cleanup | 1-2 commits | Community (future sprint) |
 | `LimitsConfig` (3/5 fields) | Partial | Hot-path instrumentation | 2-3 commits | Community (backlog, unscheduled) |
-| Binding API-parity gaps (6.1–6.11) | Partial | P1–P3 backlog (see §6) | 3 PRs (embedded-ops / recall-gated / consistency) | Community |
+| Binding API-parity gaps (6.1–6.11) | DONE | Closed via 4 PRs #1096/#1098/#1099 + consistency (6.11 = verified no-gap); see §6 | 4 PRs (embedded-ops / ops-observability / recall-gated / consistency) | Community |
 
 ## Conventions
 

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -2727,6 +2727,69 @@
         }
       }
     },
+    "/collections/{name}/search/multi/ids": {
+      "post": {
+        "tags": [
+          "search"
+        ],
+        "summary": "Multi-query fusion search returning only ids and scores (no payloads).",
+        "description": "Faster than `/search/multi` when payloads are not needed: the core\n`multi_query_search_ids` kernel skips payload hydration. Metadata filters\nare not supported here — use `/search/multi` for filtered fusion.",
+        "operationId": "multi_query_search_ids",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "description": "Collection name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MultiQuerySearchRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Multi-query ids-only results",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SearchIdsResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Collection not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/collections/{name}/search/text": {
       "post": {
         "tags": [

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1784,6 +1784,48 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+  /collections/{name}/search/multi/ids:
+    post:
+      tags:
+      - search
+      summary: Multi-query fusion search returning only ids and scores (no payloads).
+      description: |-
+        Faster than `/search/multi` when payloads are not needed: the core
+        `multi_query_search_ids` kernel skips payload hydration. Metadata filters
+        are not supported here — use `/search/multi` for filtered fusion.
+      operationId: multi_query_search_ids
+      parameters:
+      - name: name
+        in: path
+        description: Collection name
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MultiQuerySearchRequest'
+        required: true
+      responses:
+        '200':
+          description: Multi-query ids-only results
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SearchIdsResponse'
+        '400':
+          description: Invalid request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Collection not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
   /collections/{name}/search/text:
     post:
       tags:

--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -628,6 +628,29 @@ Execute multiple vector queries and merge results using Reciprocal Rank Fusion (
 
 ---
 
+### POST /collections/:name/search/multi/ids
+
+Same fusion as `/search/multi`, but returns only ids and scores (no payloads).
+Lighter on the server (skips payload hydration). Metadata filters are **not**
+supported on this endpoint — use `/search/multi` for filtered fusion.
+
+**Request Body:** identical to `/search/multi` (`vectors`, `top_k`, `strategy`,
+and the fusion params), minus `filter`.
+
+**Response:**
+```json
+{
+  "results": [
+    {"id": "1", "score": 0.0312},
+    {"id": "2", "score": 0.0298}
+  ]
+}
+```
+
+SDK: `client.multiQuerySearchIds(collection, vectors, options)` (TypeScript).
+
+---
+
 ## VelesQL Query
 
 ### POST /query

--- a/sdks/typescript/src/backends/rest.ts
+++ b/sdks/typescript/src/backends/rest.ts
@@ -101,7 +101,8 @@ import {
 import {
   search as _search, searchBatch as _searchBatch,
   textSearch as _textSearch, hybridSearch as _hybridSearch,
-  multiQuerySearch as _multiQuerySearch, searchIds as _searchIds,
+  multiQuerySearch as _multiQuerySearch,
+  multiQuerySearchIds as _multiQuerySearchIds, searchIds as _searchIds,
   sparseSearchNamed as _sparseSearchNamed,
 } from './search-backend';
 import {
@@ -198,6 +199,7 @@ export class RestBackend implements IVelesDBBackend {
   async textSearch(c: string, q: string, o?: { k?: number; filter?: FilterInput }): Promise<SearchResult[]> { this.ensureInitialized(); return _textSearch(buildSearchTransport(this.httpConfig), c, q, o); }
   async hybridSearch(c: string, v: number[] | Float32Array, t: string, o?: { k?: number; vectorWeight?: number; filter?: FilterInput }): Promise<SearchResult[]> { this.ensureInitialized(); return _hybridSearch(buildSearchTransport(this.httpConfig), c, v, t, o); }
   async multiQuerySearch(c: string, v: Array<number[] | Float32Array>, o?: MultiQuerySearchOptions): Promise<SearchResult[]> { this.ensureInitialized(); return _multiQuerySearch(buildSearchTransport(this.httpConfig), c, v, o); }
+  async multiQuerySearchIds(c: string, v: Array<number[] | Float32Array>, o?: MultiQuerySearchOptions): Promise<Array<{ id: number; score: number }>> { this.ensureInitialized(); return _multiQuerySearchIds(buildSearchTransport(this.httpConfig), c, v, o); }
   async searchIds(c: string, q: number[] | Float32Array, o?: SearchOptions): Promise<Array<{ id: number; score: number }>> { this.ensureInitialized(); return _searchIds(buildSearchTransport(this.httpConfig), c, q, o); }
   async sparseSearchNamed(c: string, q: import('../types').SparseVector, idx: string, o?: import('../types').SparseSearchNamedOptions): Promise<SearchResult[]> { this.ensureInitialized(); return _sparseSearchNamed(buildSearchTransport(this.httpConfig), c, q, idx, o); }
 

--- a/sdks/typescript/src/backends/search-backend.ts
+++ b/sdks/typescript/src/backends/search-backend.ts
@@ -3,7 +3,7 @@
  *
  * Extracted from rest.ts to keep file size manageable.
  * Implements: search, searchBatch, textSearch, hybridSearch,
- * multiQuerySearch, and searchIds.
+ * multiQuerySearch, multiQuerySearchIds, and searchIds.
  */
 
 import type {
@@ -163,6 +163,40 @@ export async function multiQuerySearch(
       filter: options?.filter,
     }
   );
+
+  throwOnError(response, `Collection '${collection}'`);
+
+  return response.data?.results ?? [];
+}
+
+/**
+ * Multi-query fusion search returning only IDs and scores (no payloads).
+ *
+ * Lighter than {@link multiQuerySearch} when payloads are not needed — the
+ * server skips payload hydration. Metadata filters are not supported on this
+ * endpoint; use {@link multiQuerySearch} for filtered fusion.
+ */
+export async function multiQuerySearchIds(
+  transport: SearchTransport,
+  collection: string,
+  vectors: Array<number[] | Float32Array>,
+  options?: MultiQuerySearchOptions
+): Promise<Array<{ id: number; score: number }>> {
+  const formattedVectors = vectors.map(toNumberArray);
+
+  const response = await transport.requestJson<{
+    results: Array<{ id: number; score: number }>;
+  }>('POST', `${collectionPath(collection)}/search/multi/ids`, {
+    vectors: formattedVectors,
+    top_k: options?.k ?? 10,
+    strategy: options?.fusion ?? 'rrf',
+    rrf_k: options?.fusionParams?.k ?? 60,
+    avg_weight: options?.fusionParams?.avgWeight,
+    max_weight: options?.fusionParams?.maxWeight,
+    hit_weight: options?.fusionParams?.hitWeight,
+    dense_weight: options?.fusionParams?.denseWeight,
+    sparse_weight: options?.fusionParams?.sparseWeight,
+  });
 
   throwOnError(response, `Collection '${collection}'`);
 

--- a/sdks/typescript/src/backends/wasm-stubs.ts
+++ b/sdks/typescript/src/backends/wasm-stubs.ts
@@ -30,6 +30,7 @@ import type {
   SearchResult,
   VectorDocument,
   SearchOptions,
+  MultiQuerySearchOptions,
   ScrollRequest,
   ScrollResponse,
   StreamUpsertResponse,
@@ -191,6 +192,14 @@ export async function wasmSearchIds(
   _options?: SearchOptions
 ): Promise<Array<{ id: number; score: number }>> {
   wasmNotSupported('searchIds');
+}
+
+export async function wasmMultiQuerySearchIds(
+  _collection: string,
+  _vectors: Array<number[] | Float32Array>,
+  _options?: MultiQuerySearchOptions
+): Promise<Array<{ id: number; score: number }>> {
+  wasmNotSupported('multiQuerySearchIds');
 }
 
 export async function wasmStoreSemanticFact(

--- a/sdks/typescript/src/backends/wasm.ts
+++ b/sdks/typescript/src/backends/wasm.ts
@@ -85,6 +85,7 @@ import {
   wasmAnalyzeCollection,
   wasmGetCollectionConfig,
   wasmSearchIds,
+  wasmMultiQuerySearchIds,
   wasmStoreSemanticFact,
   wasmSearchSemanticMemory,
   wasmRecordEpisodicEvent,
@@ -425,6 +426,7 @@ export class WasmBackend implements IVelesDBBackend {
   async analyzeCollection(c: string): Promise<CollectionStatsResponse> { this.ensureInitialized(); return wasmAnalyzeCollection(c); }
   async getCollectionConfig(c: string): Promise<CollectionConfigResponse> { this.ensureInitialized(); return wasmGetCollectionConfig(c); }
   async searchIds(c: string, q: number[] | Float32Array, o?: SearchOptions): Promise<Array<{ id: number; score: number }>> { this.ensureInitialized(); return wasmSearchIds(c, q, o); }
+  async multiQuerySearchIds(c: string, v: Array<number[] | Float32Array>, o?: MultiQuerySearchOptions): Promise<Array<{ id: number; score: number }>> { this.ensureInitialized(); return wasmMultiQuerySearchIds(c, v, o); }
   async storeSemanticFact(c: string, e: SemanticEntry): Promise<void> { this.ensureInitialized(); return wasmStoreSemanticFact(c, e); }
   async searchSemanticMemory(c: string, e: number[], k?: number): Promise<SearchResult[]> { this.ensureInitialized(); return wasmSearchSemanticMemory(c, e, k); }
   async recordEpisodicEvent(c: string, e: EpisodicEvent): Promise<string> { this.ensureInitialized(); return wasmRecordEpisodicEvent(c, e); }

--- a/sdks/typescript/src/client.ts
+++ b/sdks/typescript/src/client.ts
@@ -242,6 +242,12 @@ export class VelesDB {
     return searchMethods.multiQuerySearch(this.backend, collection, vectors, options);
   }
 
+  /** Multi-query fusion search returning only IDs and scores (no payloads). */
+  async multiQuerySearchIds(collection: string, vectors: Array<number[] | Float32Array>, options?: MultiQuerySearchOptions): Promise<Array<{ id: number; score: number }>> {
+    this.ensureInitialized();
+    return searchMethods.multiQuerySearchIds(this.backend, collection, vectors, options);
+  }
+
   /**
    * Pure sparse search against a named sparse index.
    *

--- a/sdks/typescript/src/client/search-methods.ts
+++ b/sdks/typescript/src/client/search-methods.ts
@@ -137,6 +137,24 @@ export function multiQuerySearch(
   return backend.multiQuerySearch(collection, vectors, options);
 }
 
+/** Multi-query fusion search returning only IDs and scores (no payloads). */
+export function multiQuerySearchIds(
+  backend: IVelesDBBackend,
+  collection: string,
+  vectors: Array<number[] | Float32Array>,
+  options?: MultiQuerySearchOptions
+): Promise<Array<{ id: number; score: number }>> {
+  if (!Array.isArray(vectors) || vectors.length === 0) {
+    throw new ValidationError('Vectors must be a non-empty array');
+  }
+
+  for (const v of vectors) {
+    requireVector(v, 'Each vector');
+  }
+
+  return backend.multiQuerySearchIds(collection, vectors, options);
+}
+
 /** Train Product Quantization on a collection. */
 export function trainPq(
   backend: IVelesDBBackend,

--- a/sdks/typescript/src/types/backend.ts
+++ b/sdks/typescript/src/types/backend.ts
@@ -167,6 +167,13 @@ export interface IVelesDBBackend {
     options?: MultiQuerySearchOptions
   ): Promise<SearchResult[]>;
 
+  /** Multi-query fusion search returning only IDs and scores */
+  multiQuerySearchIds(
+    collection: string,
+    vectors: Array<number[] | Float32Array>,
+    options?: MultiQuerySearchOptions
+  ): Promise<Array<{ id: number; score: number }>>;
+
   /** Check if collection is empty */
   isEmpty(collection: string): Promise<boolean>;
 

--- a/sdks/typescript/tests/search-backend.test.ts
+++ b/sdks/typescript/tests/search-backend.test.ts
@@ -2,8 +2,8 @@
  * Search Backend Tests (#598)
  *
  * Covers `src/backends/search-backend.ts`: search, searchBatch,
- * textSearch, hybridSearch, multiQuerySearch, searchIds,
- * sparseSearchNamed. Exercises
+ * textSearch, hybridSearch, multiQuerySearch, multiQuerySearchIds,
+ * searchIds, sparseSearchNamed. Exercises
  * body shape (top_k, filter, include_vectors, fusion params), vector
  * normalisation (Float32Array → number[]), sparse-vector routing via
  * `transport.sparseToRest`, the `searchQualityToMode` integration, and
@@ -17,6 +17,7 @@ import {
   textSearch,
   hybridSearch,
   multiQuerySearch,
+  multiQuerySearchIds,
   searchIds,
   sparseSearchNamed,
   type SearchTransport,
@@ -431,6 +432,73 @@ describe('multiQuerySearch', () => {
 
     await expect(
       multiQuerySearch(transport, 'missing', [[0.1]])
+    ).rejects.toThrow(CollectionNotFoundError);
+  });
+});
+
+describe('multiQuerySearchIds', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('POSTs to /search/multi/ids with defaults strategy=rrf and rrf_k=60', async () => {
+    const transport = buildTransport();
+    (transport.requestJson as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      data: { results: [{ id: 1, score: 0.9 }] },
+    });
+
+    const result = await multiQuerySearchIds(transport, 'docs', [[0.1], [0.2]]);
+
+    const call = (transport.requestJson as ReturnType<typeof vi.fn>).mock
+      .calls[0]!;
+    expect(call[1]).toBe('/collections/docs/search/multi/ids');
+    const body = call[2] as Record<string, unknown>;
+    expect(body.strategy).toBe('rrf');
+    expect(body.rrf_k).toBe(60);
+    expect(body.top_k).toBe(10);
+    expect(body.vectors).toEqual([[0.1], [0.2]]);
+    // ids-only endpoint must not forward a filter.
+    expect(body.filter).toBeUndefined();
+    expect(result).toEqual([{ id: 1, score: 0.9 }]);
+  });
+
+  it('forwards fusion / fusionParams and normalises Float32Array vectors', async () => {
+    const transport = buildTransport();
+    (transport.requestJson as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      data: { results: [] },
+    });
+
+    await multiQuerySearchIds(
+      transport,
+      'docs',
+      [new Float32Array([0.1]), [0.2]],
+      { k: 5, fusion: 'avg', fusionParams: { avgWeight: 0.3, maxWeight: 0.7, hitWeight: 0.5 } }
+    );
+
+    const body = (transport.requestJson as ReturnType<typeof vi.fn>).mock
+      .calls[0]![2] as Record<string, unknown>;
+    expect(body.strategy).toBe('avg');
+    expect(body.top_k).toBe(5);
+    expect(body.avg_weight).toBe(0.3);
+    expect(Array.isArray(body.vectors)).toBe(true);
+  });
+
+  it('returns [] when data.results is missing', async () => {
+    const transport = buildTransport();
+    (transport.requestJson as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      { data: {} } as TransportResponse<unknown>
+    );
+
+    const result = await multiQuerySearchIds(transport, 'docs', [[0.1]]);
+    expect(result).toEqual([]);
+  });
+
+  it('throws CollectionNotFoundError on VELES-002', async () => {
+    const transport = buildTransport();
+    (transport.requestJson as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      typedError()
+    );
+
+    await expect(
+      multiQuerySearchIds(transport, 'missing', [[0.1]])
     ).rejects.toThrow(CollectionNotFoundError);
   });
 });


### PR DESCRIPTION
Final PR of the API-parity campaign (PR-1 #1096, PR-2 #1098, PR-3 #1099 already merged). Closes the remaining core→binding gaps in `docs/CORE_WIRING_DEBT.md` §6.

## What

- **6.9 `search_batch_parallel`** — server `/search/batch` dispatches to the rayon parallel kernel when no query carries a filter, else the per-query filtered kernel. Same HNSW traversal ⇒ unfiltered case is identical to serial, just faster.
- **6.3-server `search_ids` true core path** — `/search/ids` now calls core `search_ids` (skips payload hydration) for plain dense requests (no filter / sparse / `ef_search` / quality `mode`); any other shape falls back to the generic pipeline. `search` and `search_ids` share `search_ids_with_adc_if_pq`, so the fast path's id/score ranking is **identical** by construction. (Tauri `search_ids` command shipped in PR-1.)
- **6.10 `multi_query_search_ids`** — server `POST /collections/{name}/search/multi/ids` (+ OpenAPI) and TS `multiQuerySearchIds` wired end-to-end (`search-backend` → REST/WASM backends → `Backend` interface → `client`). WASM = not-supported stub, mirroring `searchIds`. Filters are rejected (the ids-only fusion kernel has no filter parameter).
- **6.11 `validate_*` dedup** — **verified non-gap.** No binding re-implements the core free-fns: Python relies on core validation via error-mapping, the server only matches the `InvalidCollectionName` *error* variant, TS is client-only. Core already re-exports them from the crate root. Documented; no code change. (Another overstated matrix row, consistent with this campaign's founding audit.)

## Recall safety

No `velesdb-core` search modules touched — this PR only routes the server through **existing** core functions that are the canonical recall-equivalent variants of `search`/`search_batch`/`multi_query_search`. Parity tests pin each new ids-only / parallel path to its full-result counterpart so any future divergence (a recall regression) fails CI.

## Tests

- `crates/velesdb-server/tests/parity_consistency_tests.rs` (new): `/search/ids` == `/search`, `/search/batch` (parallel) == per-query `/search`, `/search/multi/ids` == `/search/multi` fused ranking, plus filter-rejection and 404 negatives.
- `sdks/typescript/tests/search-backend.test.ts`: `multiQuerySearchIds` body shape, fusion params, no-filter, error routing.
- OpenAPI snapshots regenerated (`openapi-drift` clean).

Pre-push line green locally: `cargo fmt`, `cargo clippy --workspace … -D warnings -D clippy::pedantic`, full `velesdb-server` test suite, no-default-features + wasm checks, full TS suite (823) + lint + build.