### PR TITLE
feat(core): persist AutoReindexConfig + StreamingConfig (CollectionConfig schema v1→v2)

### DIFF
--- a/crates/velesdb-core/src/collection/auto_reindex/types.rs
+++ b/crates/velesdb-core/src/collection/auto_reindex/types.rs
@@ -2,6 +2,9 @@
 
 use std::time::Duration;
 
+use serde::{Deserialize, Serialize};
+
+use crate::collection::config_serde::duration_secs;
 use crate::index::hnsw::HnswParams;
 
 /// Reindex state machine states
@@ -86,37 +89,73 @@ pub enum ReindexEvent {
     },
 }
 
-/// Configuration for auto-reindex behavior
-#[derive(Debug, Clone)]
+/// Configuration for auto-reindex behavior.
+///
+/// Persisted into `CollectionConfig` (schema v2+). Each field carries a
+/// serde default matching [`Default`] so a `config.json` written by an older
+/// VelesDB — or one that omits any field — deserializes without error. The
+/// [`cooldown`](Self::cooldown) `Duration` is stored as whole seconds via
+/// [`duration_secs`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AutoReindexConfig {
     /// Enable automatic reindex detection
+    #[serde(default = "default_enabled")]
     pub enabled: bool,
     /// Threshold ratio for triggering reindex (`optimal_m` / `current_m`)
     /// Default: 1.5 (trigger if optimal M is 50% higher than current)
+    #[serde(default = "default_param_divergence_threshold")]
     pub param_divergence_threshold: f64,
     /// Minimum dataset size before considering reindex
     /// Default: `10_000` vectors
+    #[serde(default = "default_min_size_for_reindex")]
     pub min_size_for_reindex: usize,
     /// Maximum acceptable latency regression (%) for rollback
     /// Default: 10.0 (rollback if new index is >10% slower)
+    #[serde(default = "default_max_latency_regression_percent")]
     pub max_latency_regression_percent: f64,
     /// Maximum acceptable recall regression (%) for rollback
     /// Default: 2.0 (rollback if recall drops by >2%)
+    #[serde(default = "default_max_recall_regression_percent")]
     pub max_recall_regression_percent: f64,
     /// Cooldown period between reindex attempts
     /// Default: 1 hour
+    #[serde(with = "duration_secs", default = "default_cooldown")]
     pub cooldown: Duration,
+}
+
+fn default_enabled() -> bool {
+    true
+}
+
+fn default_param_divergence_threshold() -> f64 {
+    1.5
+}
+
+fn default_min_size_for_reindex() -> usize {
+    10_000
+}
+
+fn default_max_latency_regression_percent() -> f64 {
+    10.0
+}
+
+fn default_max_recall_regression_percent() -> f64 {
+    2.0
+}
+
+fn default_cooldown() -> Duration {
+    Duration::from_secs(3600)
 }
 
 impl Default for AutoReindexConfig {
     fn default() -> Self {
         Self {
-            enabled: true,
-            param_divergence_threshold: 1.5,
-            min_size_for_reindex: 10_000,
-            max_latency_regression_percent: 10.0,
-            max_recall_regression_percent: 2.0,
-            cooldown: Duration::from_secs(3600),
+            enabled: default_enabled(),
+            param_divergence_threshold: default_param_divergence_threshold(),
+            min_size_for_reindex: default_min_size_for_reindex(),
+            max_latency_regression_percent: default_max_latency_regression_percent(),
+            max_recall_regression_percent: default_max_recall_regression_percent(),
+            cooldown: default_cooldown(),
         }
     }
 }

--- a/crates/velesdb-core/src/collection/collection_config.rs
+++ b/crates/velesdb-core/src/collection/collection_config.rs
@@ -1,5 +1,6 @@
 //! Collection configuration and schema versioning.
 
+use crate::collection::auto_reindex::AutoReindexConfig;
 use crate::collection::streaming::AsyncIndexBuilderConfig;
 use crate::distance::DistanceMetric;
 use crate::index::hnsw::HnswParams;
@@ -13,7 +14,7 @@ use crate::collection::graph::GraphSchema;
 /// Increment this constant when the persisted format changes in a way that
 /// older VelesDB versions cannot safely read. The `Collection::open()` path
 /// rejects any `schema_version > CURRENT_SCHEMA_VERSION` with a clear error.
-pub const CURRENT_SCHEMA_VERSION: u32 = 1;
+pub const CURRENT_SCHEMA_VERSION: u32 = 2;
 
 /// Returns the default schema version for backward-compatible deserialization.
 ///
@@ -119,6 +120,31 @@ pub struct CollectionConfig {
     /// deserialize to `None` (disabled).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub async_index_builder: Option<AsyncIndexBuilderConfig>,
+
+    /// Auto-reindex configuration (schema v2 — W2).
+    ///
+    /// When `Some`, the [`AutoReindexManager`](crate::collection::auto_reindex::AutoReindexManager)
+    /// is restored automatically on [`Collection::open`](crate::collection::VectorCollection)
+    /// so the policy survives a process restart instead of requiring a manual
+    /// re-attach.
+    ///
+    /// Backward compatible: v1 `config.json` files without this field
+    /// deserialize to `None` (no manager attached).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub auto_reindex_config: Option<AutoReindexConfig>,
+
+    /// Streaming ingestion configuration (schema v2 — STREAM-7).
+    ///
+    /// Describes the persisted shape (channel/batch sizing, flush timing) of
+    /// the streaming pipeline. The live `StreamIngester` is still created on
+    /// demand via `Collection::enable_streaming`; persisting the config lets a
+    /// future open-time hook re-enable streaming without a fresh API call.
+    ///
+    /// Backward compatible: v1 `config.json` files without this field
+    /// deserialize to `None` (streaming not configured).
+    #[cfg(feature = "persistence")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub streaming_config: Option<crate::collection::streaming::StreamingConfig>,
 }
 
 #[cfg(test)]
@@ -143,6 +169,9 @@ mod rescore_config_tests {
             #[cfg(feature = "persistence")]
             deferred_indexing: None,
             async_index_builder: None,
+            auto_reindex_config: None,
+            #[cfg(feature = "persistence")]
+            streaming_config: None,
         }
     }
 

--- a/crates/velesdb-core/src/collection/config_serde.rs
+++ b/crates/velesdb-core/src/collection/config_serde.rs
@@ -1,0 +1,89 @@
+//! Serde helpers for persisting collection-config fields with non-default
+//! on-disk representations.
+//!
+//! The only helper here serializes [`std::time::Duration`] as a whole number
+//! of seconds (`u64`). `serde`'s default `Duration` representation is a
+//! `{ secs, nanos }` struct, which is verbose and couples the on-disk format
+//! to an implementation detail. Persisting seconds keeps `config.json` human
+//! readable and stable across `Duration` internals.
+//!
+//! Sub-second precision is intentionally dropped: every `Duration` carried by
+//! [`AutoReindexConfig`](crate::collection::auto_reindex::AutoReindexConfig)
+//! is a cooldown measured in whole seconds (default: one hour).
+//!
+//! # Usage
+//!
+//! ```ignore
+//! use crate::collection::config_serde::duration_secs;
+//!
+//! #[derive(serde::Serialize, serde::Deserialize)]
+//! struct Config {
+//!     #[serde(with = "duration_secs")]
+//!     cooldown: std::time::Duration,
+//! }
+//! ```
+
+/// Serde module persisting a [`Duration`](std::time::Duration) as `u64` seconds.
+///
+/// Use via `#[serde(with = "crate::collection::config_serde::duration_secs")]`.
+pub mod duration_secs {
+    use serde::{Deserialize, Deserializer, Serializer};
+    use std::time::Duration;
+
+    /// Serializes the duration as its whole-seconds count.
+    ///
+    /// # Errors
+    ///
+    /// Returns `S::Error` if the serializer rejects the `u64` value.
+    pub fn serialize<S: Serializer>(value: &Duration, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_u64(value.as_secs())
+    }
+
+    /// Deserializes a whole-seconds count into a [`Duration`].
+    ///
+    /// # Errors
+    ///
+    /// Returns `D::Error` if the input is not a non-negative integer.
+    pub fn deserialize<'de, D: Deserializer<'de>>(deserializer: D) -> Result<Duration, D::Error> {
+        let secs = u64::deserialize(deserializer)?;
+        Ok(Duration::from_secs(secs))
+    }
+}
+
+#[cfg(test)]
+mod config_serde_tests {
+    use super::duration_secs;
+    use serde::{Deserialize, Serialize};
+    use std::time::Duration;
+
+    #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+    struct Wrapper {
+        #[serde(with = "duration_secs")]
+        cooldown: Duration,
+    }
+
+    #[test]
+    fn config_serde_duration_roundtrip() {
+        let original = Wrapper {
+            cooldown: Duration::from_secs(3600),
+        };
+
+        let json = serde_json::to_string(&original).expect("serialize should succeed");
+        // The on-disk form is a bare integer count of seconds, not a struct.
+        assert_eq!(json, r#"{"cooldown":3600}"#);
+
+        let restored: Wrapper = serde_json::from_str(&json).expect("deserialize should succeed");
+        assert_eq!(restored, original);
+        assert_eq!(restored.cooldown, Duration::from_secs(3600));
+    }
+
+    #[test]
+    fn config_serde_duration_drops_subsecond() {
+        // Sub-second precision is intentionally dropped to whole seconds.
+        let original = Wrapper {
+            cooldown: Duration::from_millis(1500),
+        };
+        let json = serde_json::to_string(&original).expect("serialize should succeed");
+        assert_eq!(json, r#"{"cooldown":1}"#);
+    }
+}

--- a/crates/velesdb-core/src/collection/core/lifecycle.rs
+++ b/crates/velesdb-core/src/collection/core/lifecycle.rs
@@ -315,10 +315,29 @@ impl Collection {
             sparse_indexes,
         });
 
+        collection.restore_auto_reindex_from_config();
+
         #[cfg(feature = "persistence")]
         collection.run_post_open_hooks()?;
 
         Ok(collection)
+    }
+
+    /// Restores the [`AutoReindexManager`](crate::collection::auto_reindex::AutoReindexManager)
+    /// from the persisted `auto_reindex_config` (schema v2 — W2).
+    ///
+    /// No-op when `auto_reindex_config` is `None` (v1 collections or those
+    /// created without an auto-reindex policy). Previously the manager had to
+    /// be re-attached manually after every open
+    /// (see `docs/CORE_WIRING_DEBT.md` entry 2).
+    fn restore_auto_reindex_from_config(&self) {
+        let cfg = self.config.read().auto_reindex_config.clone();
+        if let Some(cfg) = cfg {
+            let manager = Arc::new(crate::collection::auto_reindex::AutoReindexManager::new(
+                cfg,
+            ));
+            self.attach_auto_reindex(manager);
+        }
     }
 
     /// Pre-assemble index recovery: quantizer preinstall + 3-pass

--- a/crates/velesdb-core/src/collection/core/lifecycle_create.rs
+++ b/crates/velesdb-core/src/collection/core/lifecycle_create.rs
@@ -30,6 +30,38 @@ impl Collection {
             .to_string()
     }
 
+    /// Builds a `CollectionConfig` with the fields common to every
+    /// constructor, leaving the per-constructor fields at their `Default`
+    /// (notably `metadata_only`/`graph_schema`/`embedding_dimension`/
+    /// `async_index_builder`). Callers override the differing fields via
+    /// struct-update syntax (`..Self::base_config(..)`).
+    fn base_config(
+        name: String,
+        dimension: usize,
+        metric: DistanceMetric,
+        storage_mode: StorageMode,
+    ) -> CollectionConfig {
+        CollectionConfig {
+            name,
+            dimension,
+            metric,
+            point_count: 0,
+            schema_version: CURRENT_SCHEMA_VERSION,
+            storage_mode,
+            metadata_only: false,
+            graph_schema: None,
+            embedding_dimension: None,
+            pq_rescore_oversampling: Some(4),
+            hnsw_params: None,
+            #[cfg(feature = "persistence")]
+            deferred_indexing: None,
+            async_index_builder: None,
+            auto_reindex_config: None,
+            #[cfg(feature = "persistence")]
+            streaming_config: None,
+        }
+    }
+
     /// Shared init-and-persist pipeline for all `create_*` constructors.
     ///
     /// Validates dimensions (when non-zero), creates the directory, assembles
@@ -70,22 +102,8 @@ impl Collection {
         metric: DistanceMetric,
         storage_mode: StorageMode,
     ) -> Result<Self> {
-        let config = CollectionConfig {
-            name: Self::name_from_path(&path),
-            dimension,
-            metric,
-            point_count: 0,
-            schema_version: CURRENT_SCHEMA_VERSION,
-            storage_mode,
-            metadata_only: false,
-            graph_schema: None,
-            embedding_dimension: None,
-            pq_rescore_oversampling: Some(4),
-            hnsw_params: None,
-            #[cfg(feature = "persistence")]
-            deferred_indexing: None,
-            async_index_builder: None,
-        };
+        let config =
+            Self::base_config(Self::name_from_path(&path), dimension, metric, storage_mode);
         Self::create_from_config(path, config, None)
     }
 
@@ -145,20 +163,9 @@ impl Collection {
         pq_rescore_oversampling: Option<u32>,
     ) -> Result<Self> {
         let config = CollectionConfig {
-            name: Self::name_from_path(&path),
-            dimension,
-            metric,
-            point_count: 0,
-            schema_version: CURRENT_SCHEMA_VERSION,
-            storage_mode,
-            metadata_only: false,
-            graph_schema: None,
-            embedding_dimension: None,
             pq_rescore_oversampling,
             hnsw_params: Some(hnsw_params),
-            #[cfg(feature = "persistence")]
-            deferred_indexing: None,
-            async_index_builder: None,
+            ..Self::base_config(Self::name_from_path(&path), dimension, metric, storage_mode)
         };
         Self::create_from_config(path, config, Some(hnsw_params))
     }
@@ -178,20 +185,13 @@ impl Collection {
         async_builder_config: crate::collection::streaming::AsyncIndexBuilderConfig,
     ) -> Result<Self> {
         let config = CollectionConfig {
-            name: Self::name_from_path(&path),
-            dimension,
-            metric,
-            point_count: 0,
-            schema_version: CURRENT_SCHEMA_VERSION,
-            storage_mode: StorageMode::Full,
-            metadata_only: false,
-            graph_schema: None,
-            embedding_dimension: None,
-            pq_rescore_oversampling: Some(4),
-            hnsw_params: None,
-            #[cfg(feature = "persistence")]
-            deferred_indexing: None,
             async_index_builder: Some(async_builder_config),
+            ..Self::base_config(
+                Self::name_from_path(&path),
+                dimension,
+                metric,
+                StorageMode::Full,
+            )
         };
         Self::create_from_config(path, config, None)
     }
@@ -207,20 +207,13 @@ impl Collection {
     /// Returns an error if the directory cannot be created or the config cannot be saved.
     pub fn create_metadata_only(path: PathBuf, name: &str) -> Result<Self> {
         let config = CollectionConfig {
-            name: name.to_string(),
-            dimension: 0,
-            metric: DistanceMetric::Cosine,
-            point_count: 0,
-            schema_version: CURRENT_SCHEMA_VERSION,
-            storage_mode: StorageMode::Full,
             metadata_only: true,
-            graph_schema: None,
-            embedding_dimension: None,
-            pq_rescore_oversampling: Some(4),
-            hnsw_params: None,
-            #[cfg(feature = "persistence")]
-            deferred_indexing: None,
-            async_index_builder: None,
+            ..Self::base_config(
+                name.to_string(),
+                0,
+                DistanceMetric::Cosine,
+                StorageMode::Full,
+            )
         };
         Self::create_from_config(path, config, None)
     }
@@ -240,20 +233,14 @@ impl Collection {
         metric: DistanceMetric,
     ) -> Result<Self> {
         let config = CollectionConfig {
-            name: name.to_string(),
-            dimension: embedding_dim.unwrap_or(0),
-            metric,
-            point_count: 0,
-            schema_version: CURRENT_SCHEMA_VERSION,
-            storage_mode: StorageMode::Full,
-            metadata_only: false,
             graph_schema: Some(schema),
             embedding_dimension: embedding_dim,
-            pq_rescore_oversampling: Some(4),
-            hnsw_params: None,
-            #[cfg(feature = "persistence")]
-            deferred_indexing: None,
-            async_index_builder: None,
+            ..Self::base_config(
+                name.to_string(),
+                embedding_dim.unwrap_or(0),
+                metric,
+                StorageMode::Full,
+            )
         };
         Self::create_from_config(path, config, None)
     }

--- a/crates/velesdb-core/src/collection/core/lifecycle_tests.rs
+++ b/crates/velesdb-core/src/collection/core/lifecycle_tests.rs
@@ -581,3 +581,111 @@ fn test_incompatible_schema_version_is_not_recoverable() {
         "IncompatibleSchemaVersion must not be recoverable"
     );
 }
+
+/// A v1 `config.json` (no schema_version, no W2/STREAM-7 fields) must
+/// deserialize with defaults: schema_version=1, no auto-reindex, no streaming.
+#[test]
+fn collection_config_backward_compat_v1() {
+    let json = r#"{
+        "name": "v1_collection",
+        "dimension": 64,
+        "metric": "Cosine",
+        "point_count": 7,
+        "storage_mode": "full",
+        "metadata_only": false
+    }"#;
+
+    let cfg: CollectionConfig =
+        serde_json::from_str(json).expect("v1 config must deserialize with defaults");
+
+    assert_eq!(
+        cfg.schema_version, 1,
+        "missing schema_version defaults to 1"
+    );
+    assert!(
+        cfg.auto_reindex_config.is_none(),
+        "v1 config must have no persisted auto-reindex policy"
+    );
+    assert!(
+        cfg.streaming_config.is_none(),
+        "v1 config must have no persisted streaming config"
+    );
+}
+
+/// W2: an attached `AutoReindexManager` is persisted into `config.json` and
+/// restored automatically on `Collection::open` — no manual re-attach needed.
+#[test]
+fn auto_reindex_manager_restored_on_open() {
+    use crate::collection::auto_reindex::{AutoReindexConfig, AutoReindexManager};
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    let temp_dir = tempfile::tempdir().expect("temp dir should be created");
+
+    let collection = Collection::create(PathBuf::from(temp_dir.path()), 4, DistanceMetric::Cosine)
+        .expect("collection should be created");
+
+    // Attach a manager with a non-default, recognizable config.
+    let config = AutoReindexConfig {
+        param_divergence_threshold: 3.25,
+        min_size_for_reindex: 42,
+        cooldown: Duration::from_secs(120),
+        ..AutoReindexConfig::default()
+    };
+    collection.attach_auto_reindex(Arc::new(AutoReindexManager::new(config)));
+    collection
+        .flush()
+        .expect("flush should persist config.json");
+    drop(collection);
+
+    // Reopen — the manager must be restored from the persisted config.
+    let reopened =
+        Collection::open(PathBuf::from(temp_dir.path())).expect("collection should reopen");
+
+    let manager = reopened
+        .auto_reindex_manager()
+        .expect("auto-reindex manager must be restored on open");
+    let restored = manager.config();
+    assert!((restored.param_divergence_threshold - 3.25).abs() < f64::EPSILON);
+    assert_eq!(restored.min_size_for_reindex, 42);
+    assert_eq!(
+        restored.cooldown,
+        Duration::from_secs(120),
+        "Duration cooldown must round-trip as whole seconds"
+    );
+}
+
+/// STREAM-7: a persisted `StreamingConfig` survives a `config.json` reopen.
+#[test]
+fn test_persist_streaming_config_across_reopen() {
+    use crate::collection::streaming::StreamingConfig;
+
+    let temp_dir = tempfile::tempdir().expect("temp dir should be created");
+
+    let collection = Collection::create(PathBuf::from(temp_dir.path()), 4, DistanceMetric::Cosine)
+        .expect("collection should be created");
+
+    // Record a non-default streaming config directly on the persisted config.
+    {
+        let mut cfg = collection.config_write();
+        cfg.streaming_config = Some(StreamingConfig {
+            buffer_size: 2048,
+            batch_size: 64,
+            flush_interval_ms: 25,
+        });
+    }
+    collection
+        .flush()
+        .expect("flush should persist config.json");
+    drop(collection);
+
+    let reopened =
+        Collection::open(PathBuf::from(temp_dir.path())).expect("collection should reopen");
+    let streaming = reopened
+        .config()
+        .streaming_config
+        .expect("streaming config must survive reopen");
+    assert_eq!(streaming.buffer_size, 2048);
+    assert_eq!(streaming.batch_size, 64);
+    assert_eq!(streaming.flush_interval_ms, 25);
+}

--- a/crates/velesdb-core/src/collection/mod.rs
+++ b/crates/velesdb-core/src/collection/mod.rs
@@ -17,6 +17,7 @@
 
 pub mod auto_reindex;
 mod collection_config;
+pub(crate) mod config_serde;
 mod core;
 pub mod diagnostics;
 pub(crate) mod expiry;

--- a/crates/velesdb-core/src/collection/streaming/ingester.rs
+++ b/crates/velesdb-core/src/collection/streaming/ingester.rs
@@ -3,6 +3,7 @@
 use crate::collection::types::Collection;
 use crate::point::Point;
 
+use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use tokio::sync::mpsc;
 use tokio::sync::Notify;
@@ -19,29 +20,44 @@ use tokio::sync::Notify;
 /// | `batch_size`       | 128      |
 /// | `flush_interval_ms`| 50       |
 ///
-/// Future: persist StreamingConfig in CollectionConfig (STREAM-04)
-///
-/// `StreamingConfig` is currently runtime-only. A future pass should
-/// serialize it into `CollectionConfig` so the pipeline is automatically
-/// restored on `Collection::open`.
-#[derive(Debug, Clone)]
+/// Persisted into `CollectionConfig` (schema v2+). The struct only describes
+/// the pipeline shape (sizes/timing); the live `StreamIngester` is still
+/// created on demand via `Collection::enable_streaming`. Each field carries a
+/// serde default matching [`Default`] so an older or partial `config.json`
+/// deserializes without error.
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct StreamingConfig {
     /// Capacity of the bounded mpsc channel (backpressure threshold).
+    #[serde(default = "default_buffer_size")]
     pub buffer_size: usize,
 
     /// Number of points that trigger an immediate micro-batch flush.
+    #[serde(default = "default_batch_size")]
     pub batch_size: usize,
 
     /// Maximum time (ms) before a partial batch is flushed.
+    #[serde(default = "default_flush_interval_ms")]
     pub flush_interval_ms: u64,
+}
+
+fn default_buffer_size() -> usize {
+    10_000
+}
+
+fn default_batch_size() -> usize {
+    128
+}
+
+fn default_flush_interval_ms() -> u64 {
+    50
 }
 
 impl Default for StreamingConfig {
     fn default() -> Self {
         Self {
-            buffer_size: 10_000,
-            batch_size: 128,
-            flush_interval_ms: 50,
+            buffer_size: default_buffer_size(),
+            batch_size: default_batch_size(),
+            flush_interval_ms: default_flush_interval_ms(),
         }
     }
 }

--- a/crates/velesdb-core/src/collection/types.rs
+++ b/crates/velesdb-core/src/collection/types.rs
@@ -473,29 +473,38 @@ impl Collection {
         }
     }
 
-    /// Attaches a runtime-only [`AutoReindexManager`](crate::collection::auto_reindex::AutoReindexManager).
+    /// Attaches an [`AutoReindexManager`](crate::collection::auto_reindex::AutoReindexManager)
+    /// and records its config for persistence (schema v2 — W2).
     ///
     /// Replaces any previously attached manager. The manager is consulted by
     /// the bulk upsert hot path after every successful batch and can be
     /// queried externally via [`Self::auto_reindex_manager`] or
     /// [`Self::check_auto_reindex_divergence`].
     ///
-    /// The attachment is **not persisted**. After a [`Database::open`] the
-    /// caller must re-attach the manager if auto-reindex behavior is desired.
+    /// The manager's config is mirrored into [`CollectionConfig::auto_reindex_config`]
+    /// so the next `save_config` persists it; the manager is then restored
+    /// automatically on the following [`Collection::open`] without a manual
+    /// re-attach.
     pub(crate) fn attach_auto_reindex(
         &self,
         manager: Arc<crate::collection::auto_reindex::AutoReindexManager>,
     ) {
+        // Mirror the policy into the persisted config first (config lock
+        // released before the auto_reindex lock at position 11 is taken).
+        self.config.write().auto_reindex_config = Some(manager.config());
         *self.auto_reindex.write() = Some(manager);
     }
 
     /// Detaches the currently attached auto-reindex manager, if any.
     ///
     /// Subsequent bulk upserts will no longer consult the manager. Returns
-    /// the previously attached manager so callers can drop or reuse it.
+    /// the previously attached manager so callers can drop or reuse it. Also
+    /// clears the persisted [`CollectionConfig::auto_reindex_config`] so a
+    /// subsequent `save_config` does not re-restore it on the next open.
     pub(crate) fn detach_auto_reindex(
         &self,
     ) -> Option<Arc<crate::collection::auto_reindex::AutoReindexManager>> {
+        self.config.write().auto_reindex_config = None;
         self.auto_reindex.write().take()
     }
 

--- a/crates/velesdb-core/src/collection/vector_collection/accessors.rs
+++ b/crates/velesdb-core/src/collection/vector_collection/accessors.rs
@@ -199,12 +199,12 @@ impl VectorCollection {
     }
 
     /// Attaches an [`AutoReindexManager`](crate::collection::auto_reindex::AutoReindexManager)
-    /// to this collection as a runtime-only hook.
+    /// to this collection.
     ///
-    /// The attachment is **not persisted** to `config.json` — callers must
-    /// re-attach after every [`Database::open`](crate::Database::open).
-    /// This intentional design avoids the `Duration` serde round-trip and
-    /// keeps the collection schema version stable.
+    /// The manager's config is mirrored into `config.json` (schema v2) so the
+    /// policy is restored automatically on the next
+    /// [`Database::open`](crate::Database::open) — no manual re-attach is
+    /// required once a subsequent flush has persisted it.
     ///
     /// Once attached, the manager is consulted by the bulk upsert hot
     /// path after every successful `upsert_bulk` call. When the manager

--- a/docs/CORE_WIRING_DEBT.md
+++ b/docs/CORE_WIRING_DEBT.md
@@ -109,31 +109,25 @@ Enterprise tier ships.
 
 ## 2. `AutoReindexConfig.cooldown` — Duration serde round-trip
 
-**Outcome**: **Partially wired** (runtime-only, no persistence).
+**Outcome**: **Wired** (persisted in schema v2 — W2).
 
 **What exists**:
 - `crates/velesdb-core/src/collection/auto_reindex/mod.rs` defines
   `AutoReindexManager` with a policy that uses `std::time::Duration` for
   the cooldown period between reindex triggers.
+- `AutoReindexConfig` now derives `Serialize`/`Deserialize`; its `cooldown`
+  `Duration` round-trips as whole seconds via the custom serde helper in
+  `crates/velesdb-core/src/collection/config_serde.rs` (`duration_secs`).
+- `CollectionConfig.auto_reindex_config: Option<AutoReindexConfig>` persists
+  the policy in `config.json` under schema v2 (`CURRENT_SCHEMA_VERSION = 2`).
+  `VectorCollection::attach_auto_reindex` mirrors the manager's config into
+  this field, and `Collection::open` restores the `AutoReindexManager`
+  automatically (`restore_auto_reindex_from_config`). No manual re-attach is
+  required after a `Database::open` once a flush has persisted the config.
 
-**What is missing**:
-- `CollectionConfig` does NOT currently persist `AutoReindexConfig` to
-  `config.json`. Serializing `Duration` via serde requires either a
-  custom representation (seconds-as-u64) or a schema version bump.
-- The runtime-only attachment **shipped** (re-verified 2026-06-12):
-  users call `VectorCollection::attach_auto_reindex(manager)` after opening
-  the collection. The manager is NOT restored on `Database::open`.
-
-**Why this is intentional**:
-- Keeping `AutoReindexManager` out of the persisted config avoids the
-  schema version bump and the `Duration` serde decision.
-- Runtime-only attachment fits the typical agentic-workflow pattern where
-  the reindex policy is determined at application startup, not at
-  collection creation.
-
-**Future action**: add `serde(with = "serde_duration_secs")` helper and
-persist `AutoReindexConfig` in a future schema version. This is a
-Community-scope enhancement; no enterprise angle.
+**What is missing**: nothing for the persistence gap. The auto-reconstruct
+decision after a divergence event remains caller-driven (out of scope, by
+design — see entry 2 history and `notify_auto_reindex_after_bulk`).
 
 ---
 
@@ -321,7 +315,7 @@ consistency-cleanup PR. Each binding glue must pass that crate's CI line
 | Config | Wired? | Outcome | Effort | Target |
 |---|---|---|---|---|
 | `WalBatchConfig` | No | Transferred to velesdb-premium | 13-17 commits, 3-5 days | Enterprise tier |
-| `AutoReindexConfig` | Runtime-only | Partially wired (attachment API shipped) | 1 commit | Community (schema bump later) |
+| `AutoReindexConfig` | Yes | Wired — persisted in schema v2 (W2) + restored on open | done | Community |
 | `deferred_indexing` / `async_index_builder` | REST-only (no TOML/Python) | RFC pending | Unscoped | Community (future sprint) |
 | `SearchConfig` global defaults | Partial | Consolidation cleanup | 1-2 commits | Community (future sprint) |
 | `LimitsConfig` (3/5 fields) | Partial | Hot-path instrumentation | 2-3 commits | Community (backlog, unscheduled) |


### PR DESCRIPTION
## What
Persists `AutoReindexConfig` and the core streaming config into `CollectionConfig` and bumps the on-disk schema `v1 → v2` (single bump). The `AutoReindexManager` is now auto-restored on `Database::open` (closes `CORE_WIRING_DEBT.md` entry 2, which previously required manual re-attach). `Duration` round-trips as seconds via a `config_serde` helper.

## Backward compatibility
New fields are `#[serde(default, skip_serializing_if = "Option::is_none")]`; a genuine v1 `config.json` (no new fields) loads with defaults. `schema_version > CURRENT_SCHEMA_VERSION` is still rejected. Covered by `collection_config_backward_compat_v1`.

## Tests
`auto_reindex_manager_restored_on_open`, `test_persist_streaming_config_across_reopen`, `config_serde_duration_roundtrip`, backward-compat. Core suite green, clippy pedantic + `--no-default-features` clean. Community-scope (single-writer).