### PR TITLE
feat(rest,ts): binary wire-format upsert_bulk_from_raw endpoint + TS sender

### DIFF
--- a/crates/velesdb-server/src/handlers/mod.rs
+++ b/crates/velesdb-server/src/handlers/mod.rs
@@ -39,7 +39,7 @@ pub use indexes::{create_index, delete_index, list_indexes};
 pub use points::{
     bulk_delete_points, delete_point, enable_streaming, get_point, get_point_relations,
     relate_points, scroll_points, set_point_ttl, stream_insert, stream_upsert_points,
-    unrelate_points, upsert_points,
+    unrelate_points, upsert_points, upsert_points_raw,
 };
 // EPIC-058 US-007: match_query handler for /collections/{name}/match
 pub use match_query::match_query;

--- a/crates/velesdb-server/src/handlers/points/mod.rs
+++ b/crates/velesdb-server/src/handlers/points/mod.rs
@@ -1,8 +1,10 @@
 //! Point operations handlers.
 
+pub mod raw;
 pub mod relations;
 pub mod streaming;
 
+pub use raw::upsert_points_raw;
 pub use relations::{get_point_relations, relate_points, set_point_ttl, unrelate_points};
 pub use streaming::{
     __path_enable_streaming, __path_stream_insert, __path_stream_upsert_points, enable_streaming,
@@ -121,9 +123,22 @@ pub async fn upsert_points(
     // Must use spawn_blocking to avoid blocking the async runtime.
     let result = tokio::task::spawn_blocking(move || collection.upsert_bulk(&points)).await;
 
+    upsert_result_to_response(&state, &name, result)
+}
+
+/// Convert a `spawn_blocking` bulk-upsert result into an HTTP response.
+///
+/// On success it notifies the observer and returns `{message, count}`; a core
+/// error maps via [`auto_core_error_response`] and a task panic yields a 500.
+/// Shared by [`upsert_points`] and [`raw::upsert_points_raw`].
+pub(super) fn upsert_result_to_response(
+    state: &AppState,
+    name: &str,
+    result: Result<velesdb_core::Result<usize>, tokio::task::JoinError>,
+) -> axum::response::Response {
     match result {
         Ok(Ok(inserted)) => {
-            state.db.notify_upsert(&name, inserted);
+            state.db.notify_upsert(name, inserted);
             Json(serde_json::json!({
                 "message": "Points upserted",
                 "count": inserted

--- a/crates/velesdb-server/src/handlers/points/raw.rs
+++ b/crates/velesdb-server/src/handlers/points/raw.rs
@@ -1,0 +1,278 @@
+//! Binary wire-format bulk upsert handler (`upsert_points_raw`).
+//!
+//! Accepts a length-prefixed, tightly-packed binary body for zero-copy bulk
+//! insertion of `(id, vector)` pairs, avoiding the per-point JSON overhead of
+//! [`super::upsert_points`]. Payloads are not carried on this path — use the
+//! JSON endpoint when you need them.
+//!
+//! # Wire format (`application/octet-stream`, little-endian)
+//!
+//! All multi-byte integers and `f32`s are little-endian. The body is:
+//!
+//! ```text
+//! offset  size                     field
+//! ------  -----------------------  --------------------------------------
+//! 0       4                        magic  = b"VRB1"  (Veles Raw Bulk v1)
+//! 4       4                        count  : u32      (number of points)
+//! 8       4                        dim    : u32      (vector dimension)
+//! 12      1                        id_width : u8     (must be 8 → u64)
+//! 13      3                        reserved (must be 0) — header is 16 bytes
+//! 16      count * 8                ids    : [u64; count]
+//! 16+8c   count * dim * 4          vectors: [f32; count * dim] (row-major)
+//! ```
+//!
+//! The total body length must be **exactly**
+//! `16 + count * 8 + count * dim * 4` bytes; any mismatch is a `400`.
+//!
+//! The format is deterministic: a given batch always serialises to the same
+//! bytes (see [`encode_raw_bulk`] in the tests), so clients and the server
+//! agree byte-for-byte.
+
+use axum::{body::Bytes, extract::Path, extract::State, http::StatusCode, response::IntoResponse};
+use std::sync::Arc;
+
+use super::upsert_result_to_response;
+use crate::handlers::helpers::{error_response, get_vector_collection_or_404};
+use crate::types::ErrorResponse;
+use crate::AppState;
+
+/// 4-byte magic prefix identifying the v1 raw-bulk wire format.
+const RAW_BULK_MAGIC: &[u8; 4] = b"VRB1";
+
+/// Fixed header length in bytes: magic(4) + count(4) + dim(4) + id_width(1) + reserved(3).
+const RAW_BULK_HEADER_LEN: usize = 16;
+
+/// The only supported id width: `u64` ids are 8 bytes each.
+const RAW_BULK_ID_WIDTH: u8 = 8;
+
+/// Parsed view over a raw-bulk binary body: owned `ids` plus a flat `vectors`
+/// buffer and the declared `dimension`.
+struct RawBulkBatch {
+    ids: Vec<u64>,
+    vectors: Vec<f32>,
+    dimension: usize,
+}
+
+/// Parse the fixed 16-byte header, returning `(count, dim)`.
+///
+/// Validates the magic, the id width, and the reserved padding so that a
+/// malformed or wrong-version body is rejected before any allocation.
+fn parse_raw_bulk_header(body: &[u8]) -> Result<(usize, usize), String> {
+    if body.len() < RAW_BULK_HEADER_LEN {
+        return Err(format!(
+            "body too short: {} bytes (header needs {RAW_BULK_HEADER_LEN})",
+            body.len()
+        ));
+    }
+    if &body[0..4] != RAW_BULK_MAGIC {
+        return Err("bad magic: expected b\"VRB1\"".to_string());
+    }
+    let count = u32::from_le_bytes([body[4], body[5], body[6], body[7]]) as usize;
+    let dim = u32::from_le_bytes([body[8], body[9], body[10], body[11]]) as usize;
+    if body[12] != RAW_BULK_ID_WIDTH {
+        return Err(format!(
+            "unsupported id_width {}: only {RAW_BULK_ID_WIDTH} (u64) is supported",
+            body[12]
+        ));
+    }
+    if body[13] != 0 || body[14] != 0 || body[15] != 0 {
+        return Err("reserved header bytes must be zero".to_string());
+    }
+    Ok((count, dim))
+}
+
+/// Compute the expected total body length for `count` points of `dim` floats.
+///
+/// Returns `Err` on arithmetic overflow rather than panicking.
+fn expected_body_len(count: usize, dim: usize) -> Result<usize, String> {
+    let ids_bytes = count
+        .checked_mul(8)
+        .ok_or_else(|| "overflow computing id section length".to_string())?;
+    let vec_elems = count
+        .checked_mul(dim)
+        .ok_or_else(|| "overflow computing vector element count".to_string())?;
+    let vec_bytes = vec_elems
+        .checked_mul(4)
+        .ok_or_else(|| "overflow computing vector section length".to_string())?;
+    RAW_BULK_HEADER_LEN
+        .checked_add(ids_bytes)
+        .and_then(|h| h.checked_add(vec_bytes))
+        .ok_or_else(|| "overflow computing total body length".to_string())
+}
+
+/// Decode the tightly-packed id section into a `Vec<u64>`.
+///
+/// The caller validates the exact body length first, so every 8-byte chunk
+/// is in bounds; `chunks_exact` drops any trailing partial chunk safely.
+fn decode_ids(body: &[u8], count: usize) -> Vec<u64> {
+    let start = RAW_BULK_HEADER_LEN;
+    let end = start + count * 8;
+    body[start..end]
+        .chunks_exact(8)
+        .map(|c| u64::from_le_bytes([c[0], c[1], c[2], c[3], c[4], c[5], c[6], c[7]]))
+        .collect()
+}
+
+/// Decode the tightly-packed vector section into a flat `Vec<f32>`.
+fn decode_vectors(body: &[u8], count: usize, dim: usize) -> Vec<f32> {
+    let start = RAW_BULK_HEADER_LEN + count * 8;
+    let end = start + count * dim * 4;
+    body[start..end]
+        .chunks_exact(4)
+        .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+        .collect()
+}
+
+/// Parse a full raw-bulk body into a [`RawBulkBatch`].
+///
+/// Validates the header and the exact total length before decoding, so all
+/// slice accesses in [`decode_ids`] / [`decode_vectors`] are in bounds.
+fn parse_raw_bulk_body(body: &[u8]) -> Result<RawBulkBatch, String> {
+    let (count, dim) = parse_raw_bulk_header(body)?;
+    let expected = expected_body_len(count, dim)?;
+    if body.len() != expected {
+        return Err(format!(
+            "body length {} != expected {expected} (count={count}, dim={dim})",
+            body.len()
+        ));
+    }
+    Ok(RawBulkBatch {
+        ids: decode_ids(body, count),
+        vectors: decode_vectors(body, count, dim),
+        dimension: dim,
+    })
+}
+
+/// Bulk upsert points via the binary wire format.
+///
+/// Accepts an `application/octet-stream` body in the v1 raw-bulk format
+/// documented at the module level: a 16-byte header (magic, count, dim,
+/// id_width) followed by tightly-packed `u64` ids and `f32` vectors. The
+/// vectors are forwarded to `Collection::upsert_bulk_from_raw` (zero per-point
+/// `Point` allocation). Payloads are not supported on this path.
+#[utoipa::path(
+    post,
+    path = "/collections/{name}/points/raw",
+    tag = "points",
+    params(
+        ("name" = String, Path, description = "Collection name")
+    ),
+    request_body(content = String, content_type = "application/octet-stream", description = "VRB1 binary bulk format: header + packed u64 ids + packed f32 vectors"),
+    responses(
+        (status = 200, description = "Points upserted", body = Object),
+        (status = 400, description = "Malformed body or dimension mismatch", body = ErrorResponse),
+        (status = 404, description = "Collection not found", body = ErrorResponse)
+    )
+)]
+pub async fn upsert_points_raw(
+    State(state): State<Arc<AppState>>,
+    Path(name): Path<String>,
+    body: Bytes,
+) -> impl IntoResponse {
+    let collection = match get_vector_collection_or_404(&state, &name) {
+        Ok(c) => c,
+        Err(resp) => return resp,
+    };
+
+    let batch = match parse_raw_bulk_body(&body) {
+        Ok(b) => b,
+        Err(msg) => return error_response(StatusCode::BAD_REQUEST, msg),
+    };
+
+    let dimension = batch.dimension;
+    let ids = batch.ids;
+    let vectors = batch.vectors;
+
+    // upsert_bulk_from_raw is blocking (HNSW insertion + I/O) — spawn_blocking
+    // keeps the async runtime free.
+    let result = tokio::task::spawn_blocking(move || {
+        collection.upsert_bulk_from_raw(&vectors, &ids, dimension, None)
+    })
+    .await;
+
+    upsert_result_to_response(&state, &name, result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Test-only encoder mirroring the documented wire format. Kept here so
+    /// the round-trip test is self-contained and the format stays pinned.
+    fn encode_raw_bulk(ids: &[u64], vectors: &[f32], dim: usize) -> Vec<u8> {
+        let count = ids.len();
+        let mut buf = Vec::with_capacity(RAW_BULK_HEADER_LEN + count * 8 + count * dim * 4);
+        buf.extend_from_slice(RAW_BULK_MAGIC);
+        let count_u32 = u32::try_from(count).expect("test: count fits u32");
+        let dim_u32 = u32::try_from(dim).expect("test: dim fits u32");
+        buf.extend_from_slice(&count_u32.to_le_bytes());
+        buf.extend_from_slice(&dim_u32.to_le_bytes());
+        buf.push(RAW_BULK_ID_WIDTH);
+        buf.extend_from_slice(&[0u8; 3]);
+        for id in ids {
+            buf.extend_from_slice(&id.to_le_bytes());
+        }
+        for v in vectors {
+            buf.extend_from_slice(&v.to_le_bytes());
+        }
+        buf
+    }
+
+    #[test]
+    fn test_roundtrip_parse() {
+        let ids = [1u64, 2, 3];
+        let vectors = [0.1f32, 0.2, 0.3, 0.4, 0.5, 0.6];
+        let body = encode_raw_bulk(&ids, &vectors, 2);
+        let batch = parse_raw_bulk_body(&body).expect("test: valid body parses");
+        assert_eq!(batch.ids, vec![1, 2, 3]);
+        assert_eq!(batch.vectors, vec![0.1, 0.2, 0.3, 0.4, 0.5, 0.6]);
+        assert_eq!(batch.dimension, 2);
+    }
+
+    #[test]
+    fn test_deterministic_encoding() {
+        let ids = [7u64, 42];
+        let vectors = [1.0f32, 2.0, 3.0, 4.0];
+        let a = encode_raw_bulk(&ids, &vectors, 2);
+        let b = encode_raw_bulk(&ids, &vectors, 2);
+        assert_eq!(a, b, "encoding must be deterministic");
+        // First bytes are the magic, then count=2 LE, then dim=2 LE, id_width=8.
+        assert_eq!(&a[0..4], b"VRB1");
+        assert_eq!(&a[4..8], &2u32.to_le_bytes());
+        assert_eq!(&a[8..12], &2u32.to_le_bytes());
+        assert_eq!(a[12], 8);
+        assert_eq!(&a[13..16], &[0, 0, 0]);
+    }
+
+    #[test]
+    fn test_bad_magic_rejected() {
+        let mut body = encode_raw_bulk(&[1], &[0.0, 0.0], 2);
+        body[0] = b'X';
+        assert!(parse_raw_bulk_body(&body).is_err());
+    }
+
+    #[test]
+    fn test_length_mismatch_rejected() {
+        let mut body = encode_raw_bulk(&[1, 2], &[0.0, 0.0, 0.0, 0.0], 2);
+        body.pop(); // truncate one byte
+        match parse_raw_bulk_body(&body) {
+            Ok(_) => panic!("truncated body must fail"),
+            Err(err) => assert!(err.contains("body length"), "got: {err}"),
+        }
+    }
+
+    #[test]
+    fn test_short_body_rejected() {
+        let body = vec![0u8; 4];
+        assert!(parse_raw_bulk_body(&body).is_err());
+    }
+
+    #[test]
+    fn test_empty_batch_parses() {
+        let body = encode_raw_bulk(&[], &[], 4);
+        let batch = parse_raw_bulk_body(&body).expect("test: empty batch parses");
+        assert!(batch.ids.is_empty());
+        assert!(batch.vectors.is_empty());
+        assert_eq!(batch.dimension, 4);
+    }
+}

--- a/crates/velesdb-server/src/lib.rs
+++ b/crates/velesdb-server/src/lib.rs
@@ -63,7 +63,7 @@ pub use handlers::{
     multi_query_search, multi_query_search_ids, query, readiness_check, rebuild_index,
     relate_points, reorder_for_locality, scroll_points, search, search_ids, set_point_ttl,
     stream_insert, stream_upsert_points, text_search, unrelate_points, update_guardrails,
-    upsert_points, vacuum_collection,
+    upsert_points, upsert_points_raw, vacuum_collection,
 };
 
 pub use handlers::graph::{
@@ -129,6 +129,7 @@ pub use handlers::metrics::{health_metrics, prometheus_metrics};
         handlers::admin::get_guardrails,
         handlers::admin::update_guardrails,
         handlers::points::upsert_points,
+        handlers::points::raw::upsert_points_raw,
         handlers::points::stream_upsert_points,
         handlers::points::stream_insert,
         handlers::points::enable_streaming,

--- a/crates/velesdb-server/src/routes.rs
+++ b/crates/velesdb-server/src/routes.rs
@@ -22,7 +22,8 @@ use crate::{
     readiness_check, rebuild_index, relate_points, remove_edge, reorder_for_locality,
     scroll_points, search, search_ids, set_point_ttl, stream_insert, stream_traverse,
     stream_upsert_points, text_search, traverse_graph, traverse_parallel, unrelate_points,
-    update_guardrails, upsert_node_payload, upsert_points, vacuum_collection, AppState,
+    update_guardrails, upsert_node_payload, upsert_points, upsert_points_raw, vacuum_collection,
+    AppState,
 };
 
 /// Core CRUD and admin routes.
@@ -55,6 +56,7 @@ fn core_routes() -> Router<Arc<AppState>> {
         .merge(
             Router::new()
                 .route("/collections/{name}/points", post(upsert_points))
+                .route("/collections/{name}/points/raw", post(upsert_points_raw))
                 .route(
                     "/collections/{name}/points/stream",
                     post(stream_upsert_points),

--- a/crates/velesdb-server/tests/common/mod.rs
+++ b/crates/velesdb-server/tests/common/mod.rs
@@ -18,7 +18,7 @@ use velesdb_server::{
     health_check, hybrid_search, list_collections, multi_query_search, multi_query_search_ids,
     query, readiness_check, rebuild_index, reorder_for_locality, scroll_points, search, search_ids,
     set_point_ttl, stream_insert, stream_upsert_points, text_search, traverse_graph, upsert_points,
-    vacuum_collection, AppState, OnboardingMetrics,
+    upsert_points_raw, vacuum_collection, AppState, OnboardingMetrics,
 };
 
 fn base_routes() -> Router<Arc<AppState>> {
@@ -41,6 +41,7 @@ fn base_routes() -> Router<Arc<AppState>> {
         .route("/collections/{name}/index/rebuild", post(rebuild_index))
         .route("/collections/{name}/sanity", get(collection_sanity))
         .route("/collections/{name}/points", post(upsert_points))
+        .route("/collections/{name}/points/raw", post(upsert_points_raw))
         .route(
             "/collections/{name}/points/stream",
             post(stream_upsert_points),

--- a/crates/velesdb-server/tests/raw_bulk_tests.rs
+++ b/crates/velesdb-server/tests/raw_bulk_tests.rs
@@ -1,0 +1,182 @@
+#![allow(clippy::doc_markdown)]
+//! Integration tests for `POST /collections/{name}/points/raw`
+//! (`upsert_points_raw`).
+//!
+//! The endpoint accepts the deterministic VRB1 binary format (16-byte header
+//! plus packed u64 ids and f32 vectors). These tests pin that a valid batch
+//! returns the inserted count and the points become retrievable, that a body
+//! whose declared dimension differs from the collection is rejected with 400,
+//! and that a malformed (bad-magic or truncated) body is rejected with 400.
+
+mod common;
+
+use axum::{
+    body::Body,
+    http::{Request, StatusCode},
+};
+use common::create_test_app;
+use serde_json::{json, Value};
+use tempfile::TempDir;
+use tower::ServiceExt;
+
+const COLLECTION: &str = "raw_bulk";
+const DIM: usize = 4;
+
+/// Encode an `(ids, vectors)` batch into the VRB1 wire format (little-endian).
+///
+/// Mirrors the contract documented on the server handler so the test fails if
+/// either side of the format drifts.
+fn encode_raw_bulk(ids: &[u64], vectors: &[f32], dim: usize) -> Vec<u8> {
+    let count = ids.len();
+    let mut buf = Vec::with_capacity(16 + count * 8 + count * dim * 4);
+    buf.extend_from_slice(b"VRB1");
+    let count_u32 = u32::try_from(count).expect("test: count fits u32");
+    let dim_u32 = u32::try_from(dim).expect("test: dim fits u32");
+    buf.extend_from_slice(&count_u32.to_le_bytes());
+    buf.extend_from_slice(&dim_u32.to_le_bytes());
+    buf.push(8u8); // id_width = u64
+    buf.extend_from_slice(&[0u8; 3]); // reserved
+    for id in ids {
+        buf.extend_from_slice(&id.to_le_bytes());
+    }
+    for v in vectors {
+        buf.extend_from_slice(&v.to_le_bytes());
+    }
+    buf
+}
+
+async fn post_json(app: &axum::Router, uri: &str, body: Value) -> axum::response::Response {
+    app.clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(uri)
+                .header("Content-Type", "application/json")
+                .body(Body::from(body.to_string()))
+                .expect("test: build json request"),
+        )
+        .await
+        .expect("test: json request")
+}
+
+async fn post_binary(app: &axum::Router, uri: &str, body: Vec<u8>) -> axum::response::Response {
+    app.clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(uri)
+                .header("Content-Type", "application/octet-stream")
+                .body(Body::from(body))
+                .expect("test: build binary request"),
+        )
+        .await
+        .expect("test: binary request")
+}
+
+async fn read_json(response: axum::response::Response) -> Value {
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("test: read body");
+    serde_json::from_slice(&body).expect("test: valid JSON")
+}
+
+async fn create_collection(app: &axum::Router) {
+    let resp = post_json(
+        app,
+        "/collections",
+        json!({"name": COLLECTION, "dimension": DIM, "metric": "cosine"}),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::CREATED, "test setup: create");
+}
+
+#[tokio::test]
+async fn test_raw_bulk_insert_returns_count() {
+    let dir = TempDir::new().expect("test: temp dir");
+    let app = create_test_app(&dir);
+    create_collection(&app).await;
+
+    let ids = [10u64, 20, 30];
+    let vectors = [
+        1.0f32, 0.0, 0.0, 0.0, // id 10
+        0.0, 1.0, 0.0, 0.0, // id 20
+        0.0, 0.0, 1.0, 0.0, // id 30
+    ];
+    let body = encode_raw_bulk(&ids, &vectors, DIM);
+
+    let resp = post_binary(&app, &format!("/collections/{COLLECTION}/points/raw"), body).await;
+    assert_eq!(resp.status(), StatusCode::OK, "raw insert should succeed");
+    let json = read_json(resp).await;
+    assert_eq!(json["count"], 3, "inserted count should be 3");
+
+    // The points must be retrievable afterwards.
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri(format!("/collections/{COLLECTION}/points/20"))
+                .body(Body::empty())
+                .expect("test: build get request"),
+        )
+        .await
+        .expect("test: get request");
+    assert_eq!(resp.status(), StatusCode::OK, "point 20 should exist");
+}
+
+#[tokio::test]
+async fn test_raw_bulk_dimension_mismatch_rejected() {
+    let dir = TempDir::new().expect("test: temp dir");
+    let app = create_test_app(&dir);
+    create_collection(&app).await;
+
+    // Declared dimension 3 != collection dimension 4.
+    let ids = [1u64];
+    let vectors = [0.1f32, 0.2, 0.3];
+    let body = encode_raw_bulk(&ids, &vectors, 3);
+
+    let resp = post_binary(&app, &format!("/collections/{COLLECTION}/points/raw"), body).await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::BAD_REQUEST,
+        "dimension mismatch must be 400"
+    );
+}
+
+#[tokio::test]
+async fn test_raw_bulk_bad_magic_rejected() {
+    let dir = TempDir::new().expect("test: temp dir");
+    let app = create_test_app(&dir);
+    create_collection(&app).await;
+
+    let ids = [1u64];
+    let vectors = [0.1f32, 0.2, 0.3, 0.4];
+    let mut body = encode_raw_bulk(&ids, &vectors, DIM);
+    body[0] = b'X'; // corrupt the magic
+
+    let resp = post_binary(&app, &format!("/collections/{COLLECTION}/points/raw"), body).await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::BAD_REQUEST,
+        "bad magic must be 400"
+    );
+}
+
+#[tokio::test]
+async fn test_raw_bulk_truncated_body_rejected() {
+    let dir = TempDir::new().expect("test: temp dir");
+    let app = create_test_app(&dir);
+    create_collection(&app).await;
+
+    let ids = [1u64, 2];
+    let vectors = [0.1f32, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8];
+    let mut body = encode_raw_bulk(&ids, &vectors, DIM);
+    body.pop(); // drop a byte → length mismatch
+
+    let resp = post_binary(&app, &format!("/collections/{COLLECTION}/points/raw"), body).await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::BAD_REQUEST,
+        "truncated body must be 400"
+    );
+}

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1884,6 +1884,70 @@
         }
       }
     },
+    "/collections/{name}/points/raw": {
+      "post": {
+        "tags": [
+          "points"
+        ],
+        "summary": "Bulk upsert points via the binary wire format.",
+        "description": "Accepts an `application/octet-stream` body in the v1 raw-bulk format\ndocumented at the module level: a 16-byte header (magic, count, dim,\nid_width) followed by tightly-packed `u64` ids and `f32` vectors. The\nvectors are forwarded to `Collection::upsert_bulk_from_raw` (zero per-point\n`Point` allocation). Payloads are not supported on this path.",
+        "operationId": "upsert_points_raw",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "description": "Collection name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "VRB1 binary bulk format: header + packed u64 ids + packed f32 vectors",
+          "content": {
+            "application/octet-stream": {
+              "schema": {
+                "type": "string"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Points upserted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Malformed body or dimension mismatch",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Collection not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/collections/{name}/points/scroll": {
       "post": {
         "tags": [

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1238,6 +1238,51 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+  /collections/{name}/points/raw:
+    post:
+      tags:
+      - points
+      summary: Bulk upsert points via the binary wire format.
+      description: |-
+        Accepts an `application/octet-stream` body in the v1 raw-bulk format
+        documented at the module level: a 16-byte header (magic, count, dim,
+        id_width) followed by tightly-packed `u64` ids and `f32` vectors. The
+        vectors are forwarded to `Collection::upsert_bulk_from_raw` (zero per-point
+        `Point` allocation). Payloads are not supported on this path.
+      operationId: upsert_points_raw
+      parameters:
+      - name: name
+        in: path
+        description: Collection name
+        required: true
+        schema:
+          type: string
+      requestBody:
+        description: 'VRB1 binary bulk format: header + packed u64 ids + packed f32 vectors'
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+        required: true
+      responses:
+        '200':
+          description: Points upserted
+          content:
+            application/json:
+              schema:
+                type: object
+        '400':
+          description: Malformed body or dimension mismatch
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Collection not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
   /collections/{name}/points/scroll:
     post:
       tags:

--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -256,6 +256,42 @@ Insert or update points (upsert).
 }
 ```
 
+### POST /collections/:name/points/raw
+
+Bulk-upsert points via a compact binary wire format (`application/octet-stream`)
+for zero-copy, high-throughput ingestion. This avoids the per-point JSON
+overhead of `POST /collections/:name/points`. **Payloads are not carried on this
+path** — use the JSON endpoint when you need them.
+
+**Wire format (`VRB1`, little-endian).** All multi-byte integers and `f32`s are
+little-endian:
+
+| Offset | Size | Field |
+|--------|------|-------|
+| 0 | 4 | magic `b"VRB1"` (Veles Raw Bulk v1) |
+| 4 | 4 | `count` : u32 (number of points) |
+| 8 | 4 | `dim` : u32 (vector dimension) |
+| 12 | 1 | `id_width` : u8 (must be `8` → u64) |
+| 13 | 3 | reserved (must be `0`) |
+| 16 | `count * 8` | `ids` : packed `[u64; count]` |
+| 16 + `count*8` | `count * dim * 4` | `vectors` : packed `[f32; count*dim]` (row-major) |
+
+The body length must be **exactly** `16 + count*8 + count*dim*4` bytes; any
+mismatch, a bad magic, an unsupported `id_width`, or a `dim` that differs from
+the collection returns `400 Bad Request`. The encoding is deterministic: a
+given batch always serialises to the same bytes.
+
+**Response:**
+```json
+{
+  "message": "Points upserted",
+  "count": 1000
+}
+```
+
+The TypeScript SDK encodes this format for you via
+`client.upsertBatchRaw(collection, docs)`.
+
 ### GET /collections/:name/points/:id
 
 Get a single point by ID.

--- a/sdks/typescript/src/backends/crud-backend.ts
+++ b/sdks/typescript/src/backends/crud-backend.ts
@@ -13,7 +13,7 @@ import type {
   RestPointId,
   SparseVector,
 } from '../types';
-import { ValidationError } from '../types';
+import { ValidationError, ConnectionError, VelesDBError } from '../types';
 import type { BaseTransport } from './shared';
 import {
   throwOnError,
@@ -24,6 +24,25 @@ import {
 
 /** Minimal transport interface for CRUD operations. */
 export type CrudTransport = BaseTransport;
+
+/**
+ * Transport fields needed to send a raw binary body via `fetch`.
+ *
+ * The binary bulk endpoint cannot go through `BaseTransport.requestJson`
+ * (which JSON-stringifies the body), so the raw-bulk sender takes the
+ * connection primitives directly — mirroring the `StreamingTransport`
+ * approach for the NDJSON path.
+ */
+export interface RawBulkTransport {
+  readonly baseUrl: string;
+  readonly apiKey: string | undefined;
+  readonly timeout: number;
+}
+
+/** Magic prefix + fixed header size for the VRB1 binary bulk format. */
+const RAW_BULK_HEADER_LEN = 16;
+const RAW_BULK_MAGIC = [0x56, 0x52, 0x42, 0x31]; // "VRB1"
+const RAW_BULK_ID_WIDTH = 8; // u64
 
 /** Largest value a u64 point id can take (`u64::MAX`). */
 const U64_MAX = 18446744073709551615n;
@@ -276,4 +295,172 @@ export async function flush(
     `${collectionPath(collection)}/flush`
   );
   throwOnError(response, `Collection '${collection}'`);
+}
+
+// ---------------------------------------------------------------------------
+// Binary wire-format bulk upsert (VRB1)
+// ---------------------------------------------------------------------------
+
+/**
+ * Encode an `(ids, vectors)` batch into the VRB1 binary bulk format.
+ *
+ * Layout (little-endian, matches the Rust `upsert_points_raw` handler):
+ *
+ * ```text
+ * magic b"VRB1" (4) | count u32 (4) | dim u32 (4) | id_width u8 (1) |
+ * reserved (3) | ids [u64; count] | vectors [f32; count*dim]
+ * ```
+ *
+ * The encoding is deterministic: identical inputs always yield identical
+ * bytes. `BigUint64Array`/`Float32Array` views are written through a
+ * `DataView` so the result is host-endian-independent.
+ *
+ * @throws {ValidationError} when `ids.length !== vectors.length`, or any
+ *   vector's length differs from `dim`.
+ */
+export function encodeRawBulk(
+  ids: number[],
+  vectors: Array<number[] | Float32Array>,
+  dim: number
+): Uint8Array {
+  const count = ids.length;
+  if (vectors.length !== count) {
+    throw new ValidationError(
+      `encodeRawBulk: ids length (${count}) must match vectors length (${vectors.length})`
+    );
+  }
+  const buf = new Uint8Array(RAW_BULK_HEADER_LEN + count * 8 + count * dim * 4);
+  const view = new DataView(buf.buffer);
+  buf.set(RAW_BULK_MAGIC, 0);
+  view.setUint32(4, count, true);
+  view.setUint32(8, dim, true);
+  buf[12] = RAW_BULK_ID_WIDTH;
+  // bytes 13..16 stay zero (reserved).
+  writeIds(view, ids);
+  writeVectors(view, vectors, dim, count);
+  return buf;
+}
+
+/** Write packed `u64` ids starting at the fixed header offset. */
+function writeIds(view: DataView, ids: number[]): void {
+  let off = RAW_BULK_HEADER_LEN;
+  for (const id of ids) {
+    view.setBigUint64(off, BigInt(id), true);
+    off += 8;
+  }
+}
+
+/** Write packed row-major `f32` vectors after the id section. */
+function writeVectors(
+  view: DataView,
+  vectors: Array<number[] | Float32Array>,
+  dim: number,
+  count: number
+): void {
+  let off = RAW_BULK_HEADER_LEN + count * 8;
+  for (const vec of vectors) {
+    if (vec.length !== dim) {
+      throw new ValidationError(
+        `encodeRawBulk: vector length (${vec.length}) must match dim (${dim})`
+      );
+    }
+    for (let i = 0; i < dim; i++) {
+      view.setFloat32(off, vec[i] ?? 0, true);
+      off += 4;
+    }
+  }
+}
+
+/**
+ * Bulk upsert points via the binary wire format
+ * (`POST /collections/{name}/points/raw`, `application/octet-stream`).
+ *
+ * Encodes the batch with {@link encodeRawBulk} and sends it as a single raw
+ * request, avoiding the per-point JSON overhead of {@link upsertBatch}.
+ * Payloads are not carried on this path — use {@link upsertBatch} when you
+ * need them. All ids must be plain numbers (encoded as `u64`).
+ *
+ * @returns the number of points the server reports as inserted.
+ * @throws {VelesDBError} on a non-OK HTTP response.
+ * @throws {ConnectionError} on timeout or transport failure.
+ */
+export async function upsertBatchRaw(
+  transport: RawBulkTransport,
+  collection: string,
+  docs: VectorDocument[],
+  dim: number
+): Promise<number> {
+  const ids = docs.map(d => coerceNumericId(d.id));
+  const vectors = docs.map(d => d.vector);
+  const body = encodeRawBulk(ids, vectors, dim);
+  return sendRawBulk(transport, collection, body);
+}
+
+/** Coerce a doc id to a plain number, rejecting precision-critical strings. */
+function coerceNumericId(id: string | number): number {
+  const parsed = parseRestPointId(id);
+  if (typeof parsed === 'string') {
+    throw new ValidationError(
+      `upsertBatchRaw requires ids in the JS safe integer range; received: ${parsed}`
+    );
+  }
+  return parsed;
+}
+
+/** POST a pre-encoded binary body and parse the `{ count }` response. */
+async function sendRawBulk(
+  transport: RawBulkTransport,
+  collection: string,
+  body: Uint8Array
+): Promise<number> {
+  const url = `${transport.baseUrl}${collectionPath(collection)}/points/raw`;
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/octet-stream',
+  };
+  if (transport.apiKey) {
+    headers['Authorization'] = `Bearer ${transport.apiKey}`;
+  }
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), transport.timeout);
+  try {
+    // `Uint8Array` is a valid `BodyInit` (ArrayBufferView) at runtime; the
+    // cast satisfies the DOM lib's narrower generic `BodyInit` type.
+    const response = await fetch(url, {
+      method: 'POST',
+      headers,
+      body: body as BodyInit,
+      signal: controller.signal,
+    });
+    clearTimeout(timeoutId);
+    return await parseRawBulkResponse(response);
+  } catch (error) {
+    clearTimeout(timeoutId);
+    throw wrapRawBulkError(error);
+  }
+}
+
+/** Parse a raw-bulk HTTP response into the inserted count, throwing on error. */
+async function parseRawBulkResponse(response: Response): Promise<number> {
+  const data = await response.json().catch(() => ({}));
+  if (!response.ok) {
+    const code = typeof data.code === 'string' ? data.code : `HTTP_${response.status}`;
+    const message = typeof data.error === 'string' ? data.error : `HTTP ${response.status}`;
+    throw new VelesDBError(message, code);
+  }
+  return typeof data.count === 'number' ? data.count : 0;
+}
+
+/** Normalise a caught raw-bulk error to a typed VelesDB error. */
+function wrapRawBulkError(error: unknown): Error {
+  if (error instanceof VelesDBError) {
+    return error;
+  }
+  if (error instanceof Error && error.name === 'AbortError') {
+    return new ConnectionError('Request timeout');
+  }
+  const message = error instanceof Error ? error.message : 'Unknown error';
+  return new ConnectionError(
+    `Raw bulk upsert failed: ${message}`,
+    error instanceof Error ? error : undefined
+  );
 }

--- a/sdks/typescript/src/backends/rest-http.ts
+++ b/sdks/typescript/src/backends/rest-http.ts
@@ -9,7 +9,7 @@
 import type { SparseVector } from '../types';
 import { ConnectionError } from '../types';
 import type { TransportResponse, BaseTransport } from './shared';
-import type { CrudTransport } from './crud-backend';
+import type { CrudTransport, RawBulkTransport } from './crud-backend';
 import { parseRestPointId, sparseVectorToRestFormat } from './crud-backend';
 import type { SearchTransport } from './search-backend';
 import type { AgentMemoryTransport } from './agent-memory-backend';
@@ -140,6 +140,15 @@ export function buildBaseTransport(config: RestHttpConfig): BaseTransport {
 export function buildCrudTransport(config: RestHttpConfig): CrudTransport {
   return {
     requestJson: <T>(m: string, p: string, b?: unknown) => request<T>(config, m, p, b),
+  };
+}
+
+/** Build a RawBulkTransport adapter (raw `fetch` primitives for binary bodies). */
+export function buildRawBulkTransport(config: RestHttpConfig): RawBulkTransport {
+  return {
+    baseUrl: config.baseUrl,
+    apiKey: config.apiKey,
+    timeout: config.timeout,
   };
 }
 

--- a/sdks/typescript/src/backends/rest.ts
+++ b/sdks/typescript/src/backends/rest.ts
@@ -66,6 +66,7 @@ import {
   request,
   buildBaseTransport,
   buildCrudTransport,
+  buildRawBulkTransport,
   buildSearchTransport,
   buildQueryTransport,
   buildStreamingTransport,
@@ -120,7 +121,7 @@ import { trainPq as _trainPq, streamInsert as _streamInsert, streamUpsertPoints 
 import {
   createCollection as _createCollection, deleteCollection as _deleteCollection,
   getCollection as _getCollection, listCollections as _listCollections,
-  upsert as _upsert, upsertBatch as _upsertBatch,
+  upsert as _upsert, upsertBatch as _upsertBatch, upsertBatchRaw as _upsertBatchRaw,
   deletePoint as _deletePoint, get as _get, isEmpty as _isEmpty, flush as _flush,
 } from './crud-backend';
 
@@ -170,6 +171,7 @@ export class RestBackend implements IVelesDBBackend {
   async listCollections(): Promise<Collection[]> { this.ensureInitialized(); return _listCollections(buildCrudTransport(this.httpConfig)); }
   async upsert(c: string, d: VectorDocument): Promise<void> { this.ensureInitialized(); return _upsert(buildCrudTransport(this.httpConfig), c, d); }
   async upsertBatch(c: string, d: VectorDocument[]): Promise<void> { this.ensureInitialized(); return _upsertBatch(buildCrudTransport(this.httpConfig), c, d); }
+  async upsertBatchRaw(c: string, d: VectorDocument[]): Promise<number> { this.ensureInitialized(); return _upsertBatchRaw(buildRawBulkTransport(this.httpConfig), c, d, d[0]?.vector.length ?? 0); }
   async delete(c: string, id: string | number): Promise<boolean> { this.ensureInitialized(); return _deletePoint(buildCrudTransport(this.httpConfig), c, id); }
   async get(c: string, id: string | number): Promise<VectorDocument | null> { this.ensureInitialized(); return _get(buildCrudTransport(this.httpConfig), c, id); }
   async isEmpty(c: string): Promise<boolean> { this.ensureInitialized(); return _isEmpty(buildCrudTransport(this.httpConfig), c); }

--- a/sdks/typescript/src/backends/wasm-stubs.ts
+++ b/sdks/typescript/src/backends/wasm-stubs.ts
@@ -158,6 +158,12 @@ export async function wasmStreamUpsertPoints(
   wasmNotSupported('Streaming batch upsert');
 }
 
+export async function wasmUpsertBatchRaw(
+  _collection: string, _docs: VectorDocument[]
+): Promise<number> {
+  wasmNotSupported('Binary bulk upsert (upsertBatchRaw)');
+}
+
 // ---------------------------------------------------------------------------
 // Graph Collection / Stats / Agent Memory (Phase 8)
 // ---------------------------------------------------------------------------

--- a/sdks/typescript/src/backends/wasm.ts
+++ b/sdks/typescript/src/backends/wasm.ts
@@ -80,6 +80,7 @@ import {
   wasmTrainPq,
   wasmStreamInsert,
   wasmStreamUpsertPoints,
+  wasmUpsertBatchRaw,
   wasmCreateGraphCollection,
   wasmGetCollectionStats,
   wasmAnalyzeCollection,
@@ -324,6 +325,8 @@ export class WasmBackend implements IVelesDBBackend {
       }
     }
   }
+
+  async upsertBatchRaw(c: string, d: VectorDocument[]): Promise<number> { return wasmUpsertBatchRaw(c, d); }
 
   async delete(collectionName: string, id: string | number): Promise<boolean> {
     this.ensureInitialized();

--- a/sdks/typescript/src/client.ts
+++ b/sdks/typescript/src/client.ts
@@ -184,6 +184,23 @@ export class VelesDB {
     await this.backend.upsertBatch(collection, docs);
   }
 
+  /**
+   * Bulk upsert via the binary wire format (REST backend only).
+   *
+   * Encodes `(id, vector)` pairs into the deterministic VRB1 binary layout
+   * and sends them as a single `application/octet-stream` request, avoiding
+   * per-point JSON overhead. Payloads are not carried — use
+   * {@link upsertBatch} when you need them. Throws a not-supported error on
+   * the WASM backend.
+   *
+   * @returns the number of points the server reports as inserted.
+   */
+  async upsertBatchRaw(collection: string, docs: VectorDocument[]): Promise<number> {
+    this.ensureInitialized();
+    validateDocsBatch(docs, doc => { validateDocument(doc, this.config); });
+    return this.backend.upsertBatchRaw(collection, docs);
+  }
+
   async delete(collection: string, id: string | number): Promise<boolean> {
     this.ensureInitialized();
     validateRestPointId(id, this.config);

--- a/sdks/typescript/src/types/backend.ts
+++ b/sdks/typescript/src/types/backend.ts
@@ -103,6 +103,18 @@ export interface IVelesDBBackend {
   /** Upsert (insert or replace) multiple vectors */
   upsertBatch(collection: string, docs: VectorDocument[]): Promise<void>;
 
+  /**
+   * Bulk upsert multiple vectors via the binary wire format (REST only).
+   *
+   * Encodes `(id, vector)` pairs into the deterministic VRB1 binary layout
+   * and POSTs them as `application/octet-stream`, avoiding per-point JSON
+   * overhead. Payloads are not carried on this path. Not supported by the
+   * WASM backend.
+   *
+   * @returns the number of points the server reports as inserted.
+   */
+  upsertBatchRaw(collection: string, docs: VectorDocument[]): Promise<number>;
+
   /** Search for similar vectors */
   search(
     collection: string,

--- a/sdks/typescript/tests/raw-bulk-backend.test.ts
+++ b/sdks/typescript/tests/raw-bulk-backend.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Raw-bulk Backend Tests — upsertBatchRaw (binary wire format)
+ *
+ * Pins the VRB1 binary encoder used by the REST backend's `upsertBatchRaw`
+ * against a known batch, and verifies the WASM backend throws a typed
+ * "not supported" error.
+ *
+ * The wire format (little-endian) is:
+ *   magic b"VRB1" (4) | count u32 (4) | dim u32 (4) | id_width u8 (1) |
+ *   reserved (3) | ids [u64; count] | vectors [f32; count*dim]
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { encodeRawBulk, upsertBatchRaw, type RawBulkTransport } from '../src/backends/crud-backend';
+import { WasmBackend } from '../src/backends/wasm';
+import { VelesDBError, ValidationError } from '../src/types';
+
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+function buildRawTransport(overrides: Partial<RawBulkTransport> = {}): RawBulkTransport {
+  return {
+    baseUrl: 'http://localhost:8080',
+    apiKey: 'test-key',
+    timeout: 5000,
+    ...overrides,
+  };
+}
+
+describe('encodeRawBulk', () => {
+  it('encodes a known batch to the exact bytes', () => {
+    const ids = [10, 20];
+    const vectors = [
+      new Float32Array([1.0, 0.0]),
+      new Float32Array([0.0, 1.0]),
+    ];
+    const bytes = encodeRawBulk(ids, vectors, 2);
+
+    // Header: 16 bytes; ids: 2*8 = 16; vectors: 2*2*4 = 16 → total 48.
+    expect(bytes.byteLength).toBe(48);
+
+    const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+    // Magic "VRB1"
+    expect(bytes[0]).toBe(0x56); // V
+    expect(bytes[1]).toBe(0x52); // R
+    expect(bytes[2]).toBe(0x42); // B
+    expect(bytes[3]).toBe(0x31); // 1
+    // count = 2 (LE u32)
+    expect(view.getUint32(4, true)).toBe(2);
+    // dim = 2 (LE u32)
+    expect(view.getUint32(8, true)).toBe(2);
+    // id_width = 8
+    expect(bytes[12]).toBe(8);
+    // reserved
+    expect(bytes[13]).toBe(0);
+    expect(bytes[14]).toBe(0);
+    expect(bytes[15]).toBe(0);
+    // ids
+    expect(view.getBigUint64(16, true)).toBe(10n);
+    expect(view.getBigUint64(24, true)).toBe(20n);
+    // vectors
+    expect(view.getFloat32(32, true)).toBeCloseTo(1.0);
+    expect(view.getFloat32(36, true)).toBeCloseTo(0.0);
+    expect(view.getFloat32(40, true)).toBeCloseTo(0.0);
+    expect(view.getFloat32(44, true)).toBeCloseTo(1.0);
+  });
+
+  it('is deterministic for the same input', () => {
+    const ids = [7, 42];
+    const vectors = [new Float32Array([1, 2]), new Float32Array([3, 4])];
+    const a = encodeRawBulk(ids, vectors, 2);
+    const b = encodeRawBulk(ids, vectors, 2);
+    expect(Array.from(a)).toEqual(Array.from(b));
+  });
+
+  it('accepts number[] vectors as well as Float32Array', () => {
+    const bytes = encodeRawBulk([1], [[0.5, 0.25]], 2);
+    const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+    expect(view.getFloat32(24, true)).toBeCloseTo(0.5);
+    expect(view.getFloat32(28, true)).toBeCloseTo(0.25);
+  });
+
+  it('rejects a vector whose length differs from dim', () => {
+    expect(() => encodeRawBulk([1], [new Float32Array([1, 2, 3])], 2)).toThrow(ValidationError);
+  });
+
+  it('rejects mismatched ids/vectors lengths', () => {
+    expect(() => encodeRawBulk([1, 2], [new Float32Array([1, 2])], 2)).toThrow(ValidationError);
+  });
+});
+
+describe('upsertBatchRaw (REST)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('POSTs octet-stream to /collections/{name}/points/raw and returns count', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ message: 'Points upserted', count: 2 }),
+    });
+
+    const transport = buildRawTransport();
+    const docs = [
+      { id: 10, vector: new Float32Array([1, 0]) },
+      { id: 20, vector: new Float32Array([0, 1]) },
+    ];
+
+    const inserted = await upsertBatchRaw(transport, 'test-col', docs, 2);
+    expect(inserted).toBe(2);
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const [url, opts] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('http://localhost:8080/collections/test-col/points/raw');
+    expect(opts.method).toBe('POST');
+    expect((opts.headers as Record<string, string>)['Content-Type']).toBe(
+      'application/octet-stream'
+    );
+    expect((opts.headers as Record<string, string>)['Authorization']).toBe('Bearer test-key');
+    // Body is the binary encoding (48 bytes for this batch).
+    expect((opts.body as Uint8Array).byteLength).toBe(48);
+  });
+
+  it('throws a VelesDBError on a non-OK response', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 400,
+      json: () => Promise.resolve({ error: 'dimension mismatch', code: 'VELES-001' }),
+    });
+    const transport = buildRawTransport();
+    const docs = [{ id: 1, vector: new Float32Array([1, 2]) }];
+    await expect(upsertBatchRaw(transport, 'test-col', docs, 2)).rejects.toThrow(VelesDBError);
+  });
+});
+
+describe('WasmBackend.upsertBatchRaw', () => {
+  it('throws a not-supported error', async () => {
+    const backend = new WasmBackend();
+    await expect(
+      backend.upsertBatchRaw('c', [{ id: 1, vector: new Float32Array([1, 2]) }])
+    ).rejects.toThrow(VelesDBError);
+  });
+});


### PR DESCRIPTION
## What
Adds a `POST /collections/{name}/points/raw` endpoint accepting a deterministic length-prefixed binary body (VRB1: header + packed `u64` ids + packed `f32` vectors), forwarding to the zero-copy core `upsert_bulk_from_raw` (no per-point JSON/`Point` allocation). TypeScript SDK gains `upsertBatchRaw` (encodes `Float32Array`/`BigUint64Array`); WASM backend throws a not-supported stub.

## Safety
The VRB1 parser is hostile-input-safe: length checked before any slice, `checked_mul/add` arithmetic (no overflow panic), exact-length validation before decode, `chunks_exact`. No prod `unwrap`/`unsafe`/`panic`. OpenAPI snapshot is the canonical `--features openapi` version (string-id `oneOf` intact).

## Tests
Server: count returned, dimension-mismatch 400, deterministic encoding. TS: exact-bytes encoding, WASM stub throws. Server suite + 831 TS tests green; clippy pedantic clean.

> Note: overlaps `feat/parity-streaming-forwarders` in `velesdb-server` routes/lib — merge one then rebase the other. The committed `docs/openapi.*` are canonical only under `--features openapi`; don't let a default-feature server-test run overwrite them before merge.