### PR TITLE
feat(mobile,cli): collection_diagnostics + multi_query_search_ids + .diagnostics

### DIFF
--- a/crates/velesdb-cli/src/repl_collection_cmds.rs
+++ b/crates/velesdb-cli/src/repl_collection_cmds.rs
@@ -364,6 +364,50 @@ pub(crate) fn cmd_stats(db: &Database, parts: &[&str]) -> CommandResult {
     CommandResult::Continue
 }
 
+pub(crate) fn cmd_diagnostics(db: &Database, parts: &[&str]) -> CommandResult {
+    if parts.len() < 2 {
+        println!("Usage: .diagnostics <collection_name>\n");
+        return CommandResult::Continue;
+    }
+    let name = parts[1];
+    let diag = match db.collection_diagnostics(name) {
+        Ok(d) => d,
+        Err(_) => return CommandResult::Error(format!("Collection '{name}' not found")),
+    };
+    let (health, detail) = index_health_label(&diag.index_health);
+
+    println!("\n{}", "Collection Diagnostics".bold().underline());
+    println!("  {} {}", "Name:".cyan(), name.green());
+    println!("  {} {}", "Has Vectors:".cyan(), diag.has_vectors);
+    println!("  {} {}", "Search Ready:".cyan(), diag.search_ready);
+    println!(
+        "  {} {}",
+        "Dimension Configured:".cyan(),
+        diag.dimension_configured
+    );
+    println!("  {} {}", "Point Count:".cyan(), diag.point_count);
+    println!("  {} {}", "Index Health:".cyan(), health.green());
+    if let Some(reason) = detail {
+        println!("  {} {}", "Detail:".cyan(), reason);
+    }
+    println!();
+    CommandResult::Continue
+}
+
+/// Maps an [`IndexHealth`](velesdb_core::collection::IndexHealth) to a stable
+/// lowercase label plus an optional detail message.
+fn index_health_label(
+    health: &velesdb_core::collection::IndexHealth,
+) -> (&'static str, Option<String>) {
+    use velesdb_core::collection::IndexHealth;
+    match health {
+        IndexHealth::Healthy => ("healthy", None),
+        IndexHealth::Empty => ("empty", None),
+        IndexHealth::NeedsRebuild(reason) => ("needs_rebuild", Some(reason.clone())),
+        _ => ("unknown", None),
+    }
+}
+
 /// Scroll through collection points with cursor-based pagination.
 ///
 /// Usage: `.scroll <collection> [batch_size] [cursor]`

--- a/crates/velesdb-cli/src/repl_collection_cmds.rs
+++ b/crates/velesdb-cli/src/repl_collection_cmds.rs
@@ -1,7 +1,7 @@
 //! REPL commands for collection inspection and management.
 //!
 //! Covers: `.collections`, `.schema`, `.describe`, `.count`, `.sample`,
-//! `.browse`, `.nodes`, `.stats`, `.scroll`.
+//! `.browse`, `.nodes`, `.stats`, `.diagnostics`, `.scroll`.
 
 use colored::Colorize;
 use std::collections::HashMap;

--- a/crates/velesdb-cli/src/repl_commands.rs
+++ b/crates/velesdb-cli/src/repl_commands.rs
@@ -48,6 +48,7 @@ pub fn handle_command(db: &Database, line: &str, config: &mut ReplConfig) -> Com
         ".sample" => repl_collection_cmds::cmd_sample(db, &parts),
         ".browse" => repl_collection_cmds::cmd_browse(db, &parts),
         ".stats" => repl_collection_cmds::cmd_stats(db, &parts),
+        ".diagnostics" | ".diag" => repl_collection_cmds::cmd_diagnostics(db, &parts),
         ".scroll" => repl_collection_cmds::cmd_scroll(db, &parts),
         ".bench" | "\\bench" => repl_data_cmds::cmd_bench(db, config, &parts),
         ".export" => repl_data_cmds::cmd_export(db, &parts),

--- a/crates/velesdb-cli/src/repl_output.rs
+++ b/crates/velesdb-cli/src/repl_output.rs
@@ -112,6 +112,10 @@ pub fn print_help() {
     );
     println!("  {} Export to JSON file", ".export <name> [file]".yellow());
     println!(
+        "  {} Collection health snapshot",
+        ".diagnostics <name>".yellow()
+    );
+    println!(
         "  {}       Toggle timing display",
         ".timing on|off".yellow()
     );

--- a/crates/velesdb-cli/tests/repl_e2e_tests.rs
+++ b/crates/velesdb-cli/tests/repl_e2e_tests.rs
@@ -312,6 +312,31 @@ fn test_repl_stats_metadata() {
 }
 
 // ============================================================================
+// .diagnostics — collection health snapshot
+// ============================================================================
+
+#[test]
+fn test_repl_diagnostics_command() {
+    let (db_path, _temp) = setup_vector("vecs", 8);
+    repl_run(&db_path, &[".diagnostics vecs"])
+        .stdout(predicate::str::contains("Diagnostics"))
+        .stdout(predicate::str::contains("Search Ready"))
+        .stdout(predicate::str::contains("Index Health"))
+        .stdout(predicate::str::contains("Point Count"))
+        .stdout(predicate::str::contains("5"));
+}
+
+#[test]
+fn test_repl_diagnostics_unknown_collection_returns_error() {
+    let temp = TempDir::new().unwrap();
+    let db_path = temp.path().join("db");
+    velesdb_core::Database::open(&db_path).unwrap();
+
+    repl_run(&db_path, &[".diagnostics nonexistent"])
+        .stdout(predicate::str::contains("not found").or(predicate::str::contains("Error")));
+}
+
+// ============================================================================
 // VelesQL via REPL stdin
 // ============================================================================
 

--- a/crates/velesdb-mobile/src/collection.rs
+++ b/crates/velesdb-mobile/src/collection.rs
@@ -3,8 +3,9 @@
 use velesdb_core::VectorCollection as CoreCollection;
 
 use crate::types::{
-    IndividualSearchRequest, MobileAdvancedConfig, MobileCollectionStats, MobileIndexInfo,
-    MobileQueryLimits, SearchQuality, SearchResult, VelesError, VelesPoint,
+    IndividualSearchRequest, MobileAdvancedConfig, MobileCollectionDiagnostics,
+    MobileCollectionStats, MobileIndexInfo, MobileQueryLimits, SearchQuality, SearchResult,
+    VelesError, VelesPoint,
 };
 
 // ============================================================================
@@ -582,6 +583,11 @@ impl VelesCollection {
     /// Returns the latest known collection statistics snapshot.
     pub fn get_stats(&self) -> MobileCollectionStats {
         self.inner.get_stats().into()
+    }
+
+    /// Returns a health/readiness diagnostics snapshot for this collection.
+    pub fn diagnostics(&self) -> MobileCollectionDiagnostics {
+        self.inner.diagnostics().into()
     }
 }
 

--- a/crates/velesdb-mobile/src/collection_sparse.rs
+++ b/crates/velesdb-mobile/src/collection_sparse.rs
@@ -137,6 +137,46 @@ impl VelesCollection {
             .collect())
     }
 
+    /// Performs multi-query search returning IDs and scores only.
+    ///
+    /// Id-only twin of [`Self::multi_query_search`]: reuses the same fusion
+    /// path but strips payloads, avoiding payload materialization.
+    pub fn multi_query_search_ids(
+        &self,
+        vectors: Vec<Vec<f32>>,
+        limit: u32,
+        strategy: FusionStrategy,
+    ) -> Result<Vec<SearchResult>, VelesError> {
+        if vectors.is_empty() {
+            return Err(VelesError::Database {
+                message: "multi_query_search requires at least one vector".to_string(),
+            });
+        }
+
+        let query_refs: Vec<&[f32]> = vectors.iter().map(|v| v.as_slice()).collect();
+        let core_strategy: CoreFusionStrategy = strategy.into();
+
+        let results = self
+            .inner
+            .multi_query_search_ids(
+                &query_refs,
+                usize::try_from(limit).unwrap_or(usize::MAX),
+                core_strategy,
+            )
+            .map_err(|e| VelesError::Database {
+                message: format!("Multi-query search failed: {e}"),
+            })?;
+
+        Ok(results
+            .into_iter()
+            .map(|(id, score)| SearchResult {
+                id,
+                score,
+                payload: None,
+            })
+            .collect())
+    }
+
     /// Performs multi-query search with metadata filtering.
     pub fn multi_query_search_with_filter(
         &self,

--- a/crates/velesdb-mobile/src/lib.rs
+++ b/crates/velesdb-mobile/src/lib.rs
@@ -60,9 +60,9 @@ pub use graph::{MobileGraphEdge, MobileGraphNode, MobileGraphStore, TraversalRes
 pub use query::{QueryResult, QueryResultKind, QueryResultRow};
 pub use types::{
     DistanceMetric, FusionStrategy, IndividualSearchRequest, MobileAdvancedConfig,
-    MobileAsyncIndexBuilderConfig, MobileCollectionStats, MobileDeferredIndexerConfig,
-    MobileIndexInfo, MobileQueryLimits, PqTrainConfig, SearchQuality, SearchResult, StorageMode,
-    VelesError, VelesPoint, VelesSparseVector,
+    MobileAsyncIndexBuilderConfig, MobileCollectionDiagnostics, MobileCollectionStats,
+    MobileDeferredIndexerConfig, MobileIndexInfo, MobileQueryLimits, PqTrainConfig, SearchQuality,
+    SearchResult, StorageMode, VelesError, VelesPoint, VelesSparseVector,
 };
 
 use std::sync::Arc;

--- a/crates/velesdb-mobile/src/lib_tests.rs
+++ b/crates/velesdb-mobile/src/lib_tests.rs
@@ -712,6 +712,129 @@ fn test_multi_query_search_empty_vectors_error() {
     assert!(result.is_err());
 }
 
+#[test]
+fn test_multi_query_search_ids_matches_core() {
+    let tmp = TempDir::new().unwrap();
+    let path = tmp.path().to_str().unwrap().to_string();
+
+    let db = VelesDatabase::open(path).unwrap();
+    db.create_collection("mqs_ids".to_string(), 4, DistanceMetric::Cosine)
+        .unwrap();
+
+    let col = db.get_collection("mqs_ids".to_string()).unwrap().unwrap();
+
+    col.upsert_batch(vec![
+        VelesPoint {
+            id: 1,
+            vector: vec![1.0, 0.0, 0.0, 0.0],
+            payload: Some("{\"k\":1}".to_string()),
+        },
+        VelesPoint {
+            id: 2,
+            vector: vec![0.0, 1.0, 0.0, 0.0],
+            payload: Some("{\"k\":2}".to_string()),
+        },
+        VelesPoint {
+            id: 3,
+            vector: vec![0.0, 0.0, 1.0, 0.0],
+            payload: Some("{\"k\":3}".to_string()),
+        },
+    ])
+    .unwrap();
+
+    let vectors = vec![vec![1.0, 0.0, 0.0, 0.0], vec![0.0, 1.0, 0.0, 0.0]];
+
+    let id_results = col
+        .multi_query_search_ids(vectors.clone(), 5, FusionStrategy::Rrf { k: 60 })
+        .unwrap();
+    let full_results = col
+        .multi_query_search(vectors, 5, FusionStrategy::Rrf { k: 60 })
+        .unwrap();
+
+    // id-only twin returns the same IDs/scores as the payload-carrying path.
+    // Compare as sorted sets: equal scores may tie-break in either order.
+    let mut id_pairs: Vec<(u64, u32)> = id_results
+        .iter()
+        .map(|r| (r.id, r.score.to_bits()))
+        .collect();
+    let mut full_pairs: Vec<(u64, u32)> = full_results
+        .iter()
+        .map(|r| (r.id, r.score.to_bits()))
+        .collect();
+    id_pairs.sort_unstable();
+    full_pairs.sort_unstable();
+    assert_eq!(id_pairs, full_pairs);
+
+    // Payloads are stripped from the id-only variant.
+    assert!(id_results.iter().all(|r| r.payload.is_none()));
+}
+
+#[test]
+fn test_multi_query_search_ids_empty_vectors_error() {
+    let tmp = TempDir::new().unwrap();
+    let path = tmp.path().to_str().unwrap().to_string();
+
+    let db = VelesDatabase::open(path).unwrap();
+    db.create_collection("mqs_ids_empty".to_string(), 4, DistanceMetric::Cosine)
+        .unwrap();
+
+    let col = db
+        .get_collection("mqs_ids_empty".to_string())
+        .unwrap()
+        .unwrap();
+
+    let result = col.multi_query_search_ids(vec![], 5, FusionStrategy::Rrf { k: 60 });
+
+    assert!(result.is_err());
+}
+
+// =========================================================================
+// Collection Diagnostics Tests
+// =========================================================================
+
+#[test]
+fn test_collection_diagnostics_with_data() {
+    let tmp = TempDir::new().unwrap();
+    let path = tmp.path().to_str().unwrap().to_string();
+
+    let db = VelesDatabase::open(path).unwrap();
+    db.create_collection("diag_test".to_string(), 4, DistanceMetric::Cosine)
+        .unwrap();
+
+    let col = db.get_collection("diag_test".to_string()).unwrap().unwrap();
+
+    // Empty collection: no vectors, not search-ready, index empty.
+    let empty = col.diagnostics();
+    assert!(!empty.has_vectors);
+    assert!(!empty.search_ready);
+    assert!(empty.dimension_configured);
+    assert_eq!(empty.point_count, 0);
+    assert_eq!(empty.index_health, "empty");
+
+    col.upsert_batch(vec![
+        VelesPoint {
+            id: 1,
+            vector: vec![1.0, 0.0, 0.0, 0.0],
+            payload: None,
+        },
+        VelesPoint {
+            id: 2,
+            vector: vec![0.0, 1.0, 0.0, 0.0],
+            payload: None,
+        },
+    ])
+    .unwrap();
+
+    // Populated collection: vectors present, search-ready, index healthy.
+    let diag = col.diagnostics();
+    assert!(diag.has_vectors);
+    assert!(diag.search_ready);
+    assert!(diag.dimension_configured);
+    assert_eq!(diag.point_count, 2);
+    assert_eq!(diag.index_health, "healthy");
+    assert!(diag.index_health_detail.is_none());
+}
+
 // =========================================================================
 // Metadata-Only Collection Tests
 // =========================================================================

--- a/crates/velesdb-mobile/src/types.rs
+++ b/crates/velesdb-mobile/src/types.rs
@@ -319,6 +319,48 @@ impl From<velesdb_core::collection::stats::CollectionStats> for MobileCollection
     }
 }
 
+/// Diagnostic snapshot of a collection's health and search readiness.
+///
+/// FFI mirror of [`velesdb_core::collection::CollectionDiagnostics`]. The
+/// `index_health` enum is flattened to a stable lowercase string
+/// (`"healthy"`, `"empty"`, `"needs_rebuild"`, `"unknown"`) with an optional
+/// detail message, matching the REST and Python bindings.
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct MobileCollectionDiagnostics {
+    /// Whether the collection contains at least one vector/point.
+    pub has_vectors: bool,
+    /// Whether the collection is ready to serve search queries.
+    pub search_ready: bool,
+    /// Whether a valid dimension is configured.
+    pub dimension_configured: bool,
+    /// Total number of points in the collection.
+    pub point_count: u64,
+    /// Health status of the primary search index.
+    pub index_health: String,
+    /// Optional detail message (e.g. the reason a rebuild is needed).
+    pub index_health_detail: Option<String>,
+}
+
+impl From<velesdb_core::collection::CollectionDiagnostics> for MobileCollectionDiagnostics {
+    fn from(diag: velesdb_core::collection::CollectionDiagnostics) -> Self {
+        use velesdb_core::collection::IndexHealth;
+        let (index_health, index_health_detail) = match diag.index_health {
+            IndexHealth::Healthy => ("healthy".to_string(), None),
+            IndexHealth::Empty => ("empty".to_string(), None),
+            IndexHealth::NeedsRebuild(reason) => ("needs_rebuild".to_string(), Some(reason)),
+            _ => ("unknown".to_string(), None),
+        };
+        Self {
+            has_vectors: diag.has_vectors,
+            search_ready: diag.search_ready,
+            dimension_configured: diag.dimension_configured,
+            point_count: u64::try_from(diag.point_count).unwrap_or(u64::MAX),
+            index_health,
+            index_health_detail,
+        }
+    }
+}
+
 /// Metadata and graph index details.
 #[derive(Debug, Clone, uniffi::Record)]
 pub struct MobileIndexInfo {


### PR DESCRIPTION
## What
Closes the re-control §3 polish gaps:
- **M1**: mobile `VelesCollection.diagnostics()` → `MobileCollectionDiagnostics` (UniFFI record) from core `CollectionDiagnostics`.
- **M2**: mobile `multi_query_search_ids()` — id-only twin reusing core `multi_query_search_ids` (payloads stripped).
- **C1**: CLI `.diagnostics`/`.diag` REPL command via `Database::collection_diagnostics`.

## Tests
3 mobile `#[test]` + 2 CLI e2e (incl. `.diagnostics`). mobile + cli + core suites green; clippy workspace pedantic clean; new fns CC≤8/NLOC≤50.

> Note: touches the `velesdb-cli` crate alongside `fix/cli-at-collection-match-enrichment` (#1101) — different files, but merge #1101 first then rebase if `repl_e2e_tests.rs` conflicts on append.