### PR TITLE
feat(wasm): VectorStore::search_sparse + validate_* dedup

### DIFF
--- a/crates/velesdb-wasm/src/database.rs
+++ b/crates/velesdb-wasm/src/database.rs
@@ -66,6 +66,16 @@ impl DatabaseInner {
         self.graphs.get(name).map(Rc::clone)
     }
 
+    /// Applies core's collection-name syntax rules (single source of truth).
+    ///
+    /// Without this, the lifecycle methods only ran a `HashMap` existence
+    /// check, silently accepting names core would reject (path traversal,
+    /// reserved device names, forbidden characters). Mapped to a `String`
+    /// error for native-target testability.
+    fn validate_name(name: &str) -> Result<(), String> {
+        velesdb_core::validate_collection_name(name).map_err(|e| e.to_string())
+    }
+
     pub(crate) fn create_collection(
         &mut self,
         name: &str,
@@ -89,6 +99,7 @@ impl DatabaseInner {
         metric: &str,
         mode: crate::StorageMode,
     ) -> Result<(), String> {
+        Self::validate_name(name)?;
         if self.collections.contains_key(name) {
             return Err(format!("Collection '{name}' already exists"));
         }
@@ -119,6 +130,7 @@ impl DatabaseInner {
     /// that does not require vector similarity search. Mirrors the Mobile
     /// bindings surface (`create_metadata_collection`).
     pub(crate) fn create_metadata_collection(&mut self, name: &str) -> Result<(), String> {
+        Self::validate_name(name)?;
         if self.collections.contains_key(name) {
             return Err(format!("Collection '{name}' already exists"));
         }

--- a/crates/velesdb-wasm/src/database_tests.rs
+++ b/crates/velesdb-wasm/src/database_tests.rs
@@ -141,6 +141,26 @@ fn test_create_with_invalid_metric_returns_error() {
 }
 
 #[test]
+fn test_wasm_validate_collection_name_reserved() {
+    // Collection creation must apply core's name-syntax validation, not just
+    // an existence check. A Windows reserved device name and a path-traversal
+    // name are both rejected before any store is allocated.
+    let mut db = DatabaseInner::new();
+    for bad in ["CON", "../evil", "a/b", "", "-leading"] {
+        let err = db.create_collection(bad, 4, "cosine");
+        assert!(err.is_err(), "name '{bad}' must be rejected");
+    }
+    assert_eq!(
+        db.collection_count(),
+        0,
+        "no collection should be added when the name is invalid"
+    );
+    // The same gate applies to metadata-only collections.
+    assert!(db.create_metadata_collection("NUL").is_err());
+    assert_eq!(db.collection_count(), 0);
+}
+
+#[test]
 fn test_delete_missing_returns_error() {
     let mut db = DatabaseInner::new();
     let err = db.delete_collection("ghost");

--- a/crates/velesdb-wasm/src/lib_tests.rs
+++ b/crates/velesdb-wasm/src/lib_tests.rs
@@ -283,3 +283,49 @@ fn test_similarity_threshold_logic() {
     assert!((0.8001_f32 - threshold).abs() < 0.001);
     assert!((0.81_f32 - threshold).abs() >= 0.001);
 }
+
+// =============================================================================
+// VectorStore::search_sparse — query the store's pre-built sparse index
+// =============================================================================
+
+#[test]
+fn test_wasm_sparse_search_basic() {
+    // A pre-built in-memory sparse index returns ranked doc ids for a known
+    // query. Uses the native-testable scored entry point (the wasm-bindgen
+    // method serializes to JsValue, which panics off-wasm32).
+    let mut store = store_new::create_store(4, DistanceMetric::Cosine, StorageMode::Full);
+    store
+        .sparse_insert(1, &[10, 20, 30], &[1.0, 0.5, 0.3])
+        .expect("test: sparse_insert doc 1");
+    store
+        .sparse_insert(2, &[10, 40], &[0.8, 1.2])
+        .expect("test: sparse_insert doc 2");
+    store
+        .sparse_insert(3, &[20, 30, 50], &[0.9, 0.7, 0.4])
+        .expect("test: sparse_insert doc 3");
+    store
+        .sparse_insert(4, &[10, 20], &[0.3, 1.5])
+        .expect("test: sparse_insert doc 4");
+
+    // query = {10: 1.0, 20: 1.0}
+    // Doc 1: 1.5, Doc 2: 0.8, Doc 3: 0.9, Doc 4: 1.8
+    let results = store
+        .search_sparse_scored(&[10, 20], &[1.0, 1.0], 10)
+        .expect("test: search_sparse on a populated index");
+
+    assert_eq!(results[0].doc_id(), 4, "doc 4 (score 1.8) ranks first");
+    assert_eq!(results[1].doc_id(), 1, "doc 1 (score 1.5) ranks second");
+}
+
+#[test]
+fn test_wasm_sparse_search_no_index_error() {
+    // Querying a store with no sparse index returns an error (parity with
+    // core's sparse_search, which errors when the index does not exist).
+    let store = store_new::create_store(4, DistanceMetric::Cosine, StorageMode::Full);
+    let err = store.search_sparse_scored(&[10, 20], &[1.0, 1.0], 10);
+    assert!(err.is_err(), "search_sparse without an index must error");
+    assert!(
+        err.unwrap_err().contains("sparse index"),
+        "error should mention the missing sparse index"
+    );
+}

--- a/crates/velesdb-wasm/src/sparse.rs
+++ b/crates/velesdb-wasm/src/sparse.rs
@@ -8,10 +8,19 @@ use std::collections::BTreeMap;
 use wasm_bindgen::prelude::*;
 
 /// Result from sparse search.
-#[derive(Serialize, Deserialize)]
-struct SparseSearchResult {
+#[derive(Debug, Serialize, Deserialize)]
+pub(crate) struct SparseSearchResult {
     doc_id: u64,
     score: f32,
+}
+
+impl SparseSearchResult {
+    /// Returns the document id of this result. Test-only accessor used to
+    /// assert ranking order; the wasm path serializes the fields directly.
+    #[cfg(test)]
+    pub(crate) fn doc_id(&self) -> u64 {
+        self.doc_id
+    }
 }
 
 /// A sparse vector: sorted parallel arrays of term indices and weights.
@@ -142,17 +151,33 @@ impl SparseIndex {
         query_values: &[f32],
         k: usize,
     ) -> Result<JsValue, JsValue> {
+        let results = self
+            .search_scored(query_indices, query_values, k)
+            .map_err(|e| JsValue::from_str(&e))?;
+        serde_wasm_bindgen::to_value(&results)
+            .map_err(|e| JsValue::from_str(&format!("Serialization error: {e}")))
+    }
+
+    /// Native-testable scoring kernel shared by [`Self::search`] and the
+    /// `VectorStore::search_sparse` delegate.
+    ///
+    /// Performs DAAT (Document-At-A-Time) accumulation and top-`k` extraction
+    /// without touching `JsValue`, so it can be exercised off-`wasm32`.
+    pub(crate) fn search_scored(
+        &self,
+        query_indices: &[u32],
+        query_values: &[f32],
+        k: usize,
+    ) -> Result<Vec<SparseSearchResult>, String> {
         if query_indices.len() != query_values.len() {
-            return Err(JsValue::from_str(&format!(
+            return Err(format!(
                 "query indices/values length mismatch: {} vs {}",
                 query_indices.len(),
                 query_values.len()
-            )));
+            ));
         }
         if k == 0 {
-            let empty: Vec<SparseSearchResult> = Vec::new();
-            return serde_wasm_bindgen::to_value(&empty)
-                .map_err(|e| JsValue::from_str(&e.to_string()));
+            return Ok(Vec::new());
         }
 
         // DAAT (Document-At-A-Time) accumulation using a hash map.
@@ -173,9 +198,7 @@ impl SparseIndex {
             .collect();
         results.sort_by(|a, b| b.score.total_cmp(&a.score));
         results.truncate(k);
-
-        serde_wasm_bindgen::to_value(&results)
-            .map_err(|e| JsValue::from_str(&format!("Serialization error: {e}")))
+        Ok(results)
     }
 
     /// Returns the number of documents in the index.

--- a/crates/velesdb-wasm/src/store_search.rs
+++ b/crates/velesdb-wasm/src/store_search.rs
@@ -48,14 +48,14 @@ pub(crate) fn sort_scored_triples<T>(results: &mut [(u64, f32, T)], higher_is_be
 }
 
 /// Validates query dimension matches store dimension.
+///
+/// Delegates the check to core's [`velesdb_core::validate_dimension_match`]
+/// (single source of truth) and maps its error to a `JsValue` at the FFI
+/// boundary, instead of re-implementing the comparison locally.
 #[inline]
 pub fn validate_dimension(query_len: usize, store_dim: usize) -> Result<(), JsValue> {
-    if query_len != store_dim {
-        return Err(JsValue::from_str(&format!(
-            "Query dimension mismatch: expected {store_dim}, got {query_len}"
-        )));
-    }
-    Ok(())
+    velesdb_core::validate_dimension_match(store_dim, query_len)
+        .map_err(|e| JsValue::from_str(&e.to_string()))
 }
 
 /// Basic vector search.

--- a/crates/velesdb-wasm/src/vector_store.rs
+++ b/crates/velesdb-wasm/src/vector_store.rs
@@ -340,6 +340,31 @@ impl VectorStore {
         )
     }
 
+    /// Sparse k-NN search over the store's pre-built sparse index.
+    ///
+    /// Unlike [`sparse_search`](Self::sparse_search) — which returns an empty
+    /// result set when no sparse data has been inserted — this method mirrors
+    /// the core `sparse_search` contract and returns an **error** when the
+    /// store has no sparse index, so callers can distinguish "index missing"
+    /// from "no matches". Scoring is delegated unchanged to the
+    /// recall-verified [`sparse::SparseIndex`] kernel.
+    ///
+    /// Returns a JSON array of `{doc_id, score}` objects sorted by score
+    /// descending, truncated to `k`.
+    #[wasm_bindgen]
+    pub fn search_sparse(
+        &self,
+        query_indices: &[u32],
+        query_values: &[f32],
+        k: usize,
+    ) -> Result<JsValue, JsValue> {
+        let results = self
+            .search_sparse_scored(query_indices, query_values, k)
+            .map_err(|e| JsValue::from_str(&e))?;
+        serde_wasm_bindgen::to_value(&results)
+            .map_err(|e| JsValue::from_str(&format!("Serialization error: {e}")))
+    }
+
     /// VelesQL-style query returning multi-model results (EPIC-031 US-009).
     ///
     /// Returns results in `HybridResult` format with `node_id`, `vector_score`,
@@ -569,5 +594,27 @@ impl VectorStore {
             self.payloads.push(None);
         }
         Ok(())
+    }
+}
+
+// Native-testable internals (not part of the wasm-bindgen surface).
+impl VectorStore {
+    /// Scoring entry point behind [`search_sparse`](Self::search_sparse).
+    ///
+    /// Returns an error when no sparse index has been built (parity with the
+    /// core `sparse_search` contract); otherwise delegates scoring to the
+    /// [`sparse::SparseIndex`] kernel. Returns `String` errors and plain
+    /// result structs so it can be exercised off-`wasm32`.
+    pub(crate) fn search_sparse_scored(
+        &self,
+        query_indices: &[u32],
+        query_values: &[f32],
+        k: usize,
+    ) -> Result<Vec<sparse::SparseSearchResult>, String> {
+        let idx = self
+            .sparse_index
+            .as_ref()
+            .ok_or_else(|| "sparse index not found: insert sparse vectors first".to_string())?;
+        idx.search_scored(query_indices, query_values, k)
     }
 }


### PR DESCRIPTION
## What
- **M3**: WASM `VectorStore::search_sparse` queries a pre-built in-memory `SparseIndex` (errors when none exists), parity with core `sparse_search`. Pure delegation — scoring factored into a shared `search_scored`, no reimplemented ranking.
- Drift fixes from the re-control: `store_search` now delegates to core `validate_dimension_match` (was a local reimplementation), and collection creation applies core `validate_collection_name` (was a bare existence check).

WASM is brute-force (no HNSW) and persistence-off, so the core Recall Gate 1 is N/A here.

## Tests
`test_wasm_sparse_search_basic`, `_no_index_error`, `test_wasm_validate_collection_name_reserved`. 528 wasm tests green; `--no-default-features` wasm32 check + clippy pedantic clean; added fns max CC 6/NLOC 32.