### PR TITLE
fix(wasm): overflow-safe bounds checks + chunks_exact in multi_query_search_impl / batch_search_impl

### DIFF
--- a/crates/velesdb-wasm/src/lib_tests.rs
+++ b/crates/velesdb-wasm/src/lib_tests.rs
@@ -283,3 +283,57 @@ fn test_similarity_threshold_logic() {
     assert!((0.8001_f32 - threshold).abs() < 0.001);
     assert!((0.81_f32 - threshold).abs() >= 0.001);
 }
+
+// =============================================================================
+// Bounds-check and overflow safety — validate_multi_vector_len
+//
+// The JsValue-returning search functions are wasm-only and cannot be called
+// from native tests (JsValue::from_str aborts on non-wasm32). The validation
+// logic is extracted into validate_multi_vector_len (returns String errors) so
+// it can be exercised here. The full wasm integration path is covered by the
+// wasm-pack test suite in CI.
+// =============================================================================
+
+#[test]
+fn test_validate_multi_vector_len_length_mismatch() {
+    use super::store_search::validate_multi_vector_len;
+    // 4 floats declared as 2 vectors of dim 4 — expected 8, got 4.
+    let err = validate_multi_vector_len(4, 2, 4);
+    assert!(err.is_err(), "length mismatch must be an error");
+    let msg = err.unwrap_err();
+    assert!(
+        msg.contains("size mismatch"),
+        "error should describe the mismatch: {msg}"
+    );
+}
+
+#[test]
+fn test_validate_multi_vector_len_exact_match() {
+    use super::store_search::validate_multi_vector_len;
+    // 8 floats = 2 vectors × dim 4: valid.
+    let ok = validate_multi_vector_len(8, 2, 4);
+    assert!(ok.is_ok(), "matching lengths must succeed");
+    assert_eq!(ok.unwrap(), 8);
+}
+
+#[test]
+fn test_validate_multi_vector_len_zero_vectors() {
+    use super::store_search::validate_multi_vector_len;
+    // 0 vectors × dim 4 → expected 0 floats.
+    let ok = validate_multi_vector_len(0, 0, 4);
+    assert!(ok.is_ok());
+    assert_eq!(ok.unwrap(), 0);
+}
+
+#[test]
+fn test_validate_multi_vector_len_overflow_returns_error() {
+    use super::store_search::validate_multi_vector_len;
+    // usize::MAX vectors × dimension 2 must overflow checked_mul.
+    let err = validate_multi_vector_len(0, usize::MAX, 2);
+    assert!(err.is_err(), "overflow must be an error");
+    let msg = err.unwrap_err();
+    assert!(
+        msg.to_lowercase().contains("overflow"),
+        "error should mention overflow: {msg}"
+    );
+}

--- a/crates/velesdb-wasm/src/store_search.rs
+++ b/crates/velesdb-wasm/src/store_search.rs
@@ -177,6 +177,26 @@ pub fn hybrid_search_impl(
     scored_triples_to_js(results)
 }
 
+/// Validates that `vectors_len == num_vectors * dimension` without integer
+/// overflow. Returns the expected length on success, a `String` error on
+/// failure so the validation path is testable on native (non-wasm32) targets
+/// without requiring `JsValue`.
+pub(crate) fn validate_multi_vector_len(
+    vectors_len: usize,
+    num_vectors: usize,
+    dimension: usize,
+) -> Result<usize, String> {
+    let expected = num_vectors
+        .checked_mul(dimension)
+        .ok_or_else(|| "Overflow: num_vectors × dimension exceeds usize".to_string())?;
+    if vectors_len != expected {
+        return Err(format!(
+            "Vector array size mismatch: expected {expected}, got {vectors_len}"
+        ));
+    }
+    Ok(expected)
+}
+
 /// Multi-query search with fusion.
 #[allow(clippy::too_many_arguments)]
 pub fn multi_query_search_impl(
@@ -195,20 +215,15 @@ pub fn multi_query_search_impl(
     strategy: &str,
     rrf_k: Option<u32>,
 ) -> Result<JsValue, JsValue> {
-    if vectors.len() != num_vectors * dimension {
-        return Err(JsValue::from_str(&format!(
-            "Vector array size mismatch: expected {}, got {}",
-            num_vectors * dimension,
-            vectors.len()
-        )));
-    }
+    // validate_multi_vector_len uses checked_mul so the length check cannot
+    // overflow; the String error is mapped to JsValue only at the FFI boundary.
+    validate_multi_vector_len(vectors.len(), num_vectors, dimension)
+        .map_err(|e| JsValue::from_str(&e))?;
 
+    // chunks_exact eliminates manual start = i * dimension index arithmetic,
+    // which was a second multiplication that could independently overflow.
     let mut all_results: Vec<Vec<(u64, f32)>> = Vec::with_capacity(num_vectors);
-
-    for i in 0..num_vectors {
-        let start = i * dimension;
-        let query = &vectors[start..start + dimension];
-
+    for query in vectors.chunks_exact(dimension) {
         let mut results = vector_ops::compute_scores(
             query,
             ids,
@@ -221,7 +236,6 @@ pub fn multi_query_search_impl(
             metric,
             storage_mode,
         );
-
         vector_ops::sort_results(&mut results, metric.higher_is_better());
         results.truncate(k * 2);
         all_results.push(results);
@@ -346,26 +360,27 @@ pub fn batch_search_impl(
     metric: crate::DistanceMetric,
     k: usize,
 ) -> Result<JsValue, JsValue> {
-    let mut all_results: Vec<Vec<(u64, f32)>> = Vec::with_capacity(num_vectors);
+    // Validate with the shared overflow-safe helper; the caller
+    // (VectorStore::batch_search) also validates, but batch_search_impl is
+    // pub(crate) and may be called from tests or future code paths directly.
+    validate_multi_vector_len(vectors.len(), num_vectors, dimension)
+        .map_err(|e| JsValue::from_str(&e))?;
 
-    for i in 0..num_vectors {
-        let start = i * dimension;
-        let query = &vectors[start..start + dimension];
-
-        let mut results: Vec<(u64, f32)> = ids
-            .iter()
-            .enumerate()
-            .map(|(idx, &id)| {
-                let v_start = idx * dimension;
-                let v_data = &data[v_start..v_start + dimension];
-                (id, metric.calculate(query, v_data))
-            })
-            .collect();
-
-        vector_ops::sort_results(&mut results, metric.higher_is_better());
-        results.truncate(k);
-        all_results.push(results);
-    }
+    // Use chunks_exact for both the query and store-data iteration, removing
+    // manual start/v_start index arithmetic (potential overflow or off-by-one).
+    let all_results: Vec<Vec<(u64, f32)>> = vectors
+        .chunks_exact(dimension)
+        .map(|query| {
+            let mut results: Vec<(u64, f32)> = ids
+                .iter()
+                .zip(data.chunks_exact(dimension))
+                .map(|(&id, v_data)| (id, metric.calculate(query, v_data)))
+                .collect();
+            vector_ops::sort_results(&mut results, metric.higher_is_better());
+            results.truncate(k);
+            results
+        })
+        .collect();
 
     to_js(&all_results)
 }

--- a/crates/velesdb-wasm/src/vector_store.rs
+++ b/crates/velesdb-wasm/src/vector_store.rs
@@ -448,13 +448,8 @@ impl VectorStore {
             return serde_wasm_bindgen::to_value::<Vec<Vec<(u64, f32)>>>(&vec![])
                 .map_err(|e| JsValue::from_str(&e.to_string()));
         }
-        let expected_len = num_vectors * self.dimension;
-        if vectors.len() != expected_len {
-            return Err(JsValue::from_str(&format!(
-                "Expected {expected_len} floats, got {}",
-                vectors.len()
-            )));
-        }
+        store_search::validate_multi_vector_len(vectors.len(), num_vectors, self.dimension)
+            .map_err(|e| JsValue::from_str(&e))?;
         if self.storage_mode != StorageMode::Full {
             return Err(JsValue::from_str(
                 "batch_search only supports Full storage mode",


### PR DESCRIPTION
## What

Two correctness bugs in `crates/velesdb-wasm/src/store_search.rs` found during the PR review cycle (2026-06-14):

### Bug 1 — `multi_query_search_impl`: unchecked multiplication in bounds validation (overflow UB)

```rust
// Before — overflows usize on wasm32 when num_vectors × dimension > u32::MAX
if vectors.len() != num_vectors * dimension { … }
```

On 32-bit targets (`wasm32-unknown-unknown`, `usize = u32`) large inputs make `num_vectors * dimension` wrap, producing a wrong sentinel that passes validation silently. The function then slices the buffer with the same wrong start indices.

### Bug 2 — `batch_search_impl`: missing bounds check entirely

`batch_search_impl` had **no** length validation. A caller passing `num_vectors=3` with `vectors=[0.0; 4]` and `dimension=4` would attempt `vectors[4..8]` → panic at runtime. The public `batch_search` entry point in `vector_store.rs` validated before calling `batch_search_impl`, but that validation also used unchecked multiplication.

## Fix

- Extract `validate_multi_vector_len(len, num_vectors, dim) -> Result<usize, String>` — uses `checked_mul` so the product is overflow-safe; returns a `String` error that both WASM functions and native unit tests can consume without touching `JsValue`.
- `multi_query_search_impl` delegates to the helper and replaces the manual `for i in 0..num_vectors { let start = i * dimension; … }` loop with `vectors.chunks_exact(dimension)`, removing a **second** unchecked multiplication in the hot path.
- `batch_search_impl` gains the missing bounds check (via the same helper) and uses `chunks_exact` for both query and store-data iteration.
- `VectorStore::batch_search` (public WASM entry point) delegates its length check to `validate_multi_vector_len` — DRY, no duplicate expression.

## Why chunks_exact instead of manual indexing

`chunks_exact(n)` is:
- **Panic-free** for the iteration itself — no `[start..start+dim]` arithmetic that could independently overflow
- **Idiomatic** — standard Rust pattern for fixed-size chunking
- **Cleaner** — eliminates the loop counter `i` whose only role was computing `start`

## Tests (native, no WASM runtime required)

`validate_multi_vector_len` returns `String` errors, so it can be tested in `cargo test --lib`:

| Test | Asserts |
|---|---|
| `test_validate_multi_vector_len_length_mismatch` | 4 floats declared as 2×dim4 → `Err` with "size mismatch" |
| `test_validate_multi_vector_len_exact_match` | 8 floats = 2×dim4 → `Ok(8)` |
| `test_validate_multi_vector_len_zero_vectors` | 0 vectors × dim4 → `Ok(0)` |
| `test_validate_multi_vector_len_overflow_returns_error` | `usize::MAX` × 2 → `Err` with "overflow" (no panic) |

All 4 new tests + 523 existing WASM lib tests pass on native (`cargo test -p velesdb-wasm --no-default-features --lib`).

## Relationship to open PRs

- PR #1107 touches `store_search.rs` for `validate_dimension` only — **different functions**, no conflict.
- No other open PR addresses `multi_query_search_impl`, `batch_search_impl`, or `VectorStore::batch_search`.

## Merge order

This fix is independent of the 7 open PRs and can be merged at any point. When PR #1107 lands, git will merge `validate_dimension` changes and `validate_multi_vector_len`+`chunks_exact` changes cleanly (they are in different functions of the same file).

https://claude.ai/code/session_01GVw6dcSyeaiskrcqfLAmtK
