### PR TITLE
fix(wasm): overflow-safe multi-vector length check via checked_mul

### DIFF
--- a/crates/velesdb-wasm/src/lib_tests.rs
+++ b/crates/velesdb-wasm/src/lib_tests.rs
@@ -329,3 +329,35 @@ fn test_wasm_sparse_search_no_index_error() {
         "error should mention the missing sparse index"
     );
 }
+
+// =============================================================================
+// validate_multi_vector_len — overflow-safe flat multi-vector length check
+// =============================================================================
+
+#[test]
+fn test_validate_multi_vector_len_ok() {
+    // 3 vectors x 4 dims = 12 floats: the validated expected length is returned.
+    let expected =
+        store_search::validate_multi_vector_len(12, 3, 4).expect("test: 12 == 3 * 4 is valid");
+    assert_eq!(expected, 12);
+}
+
+#[test]
+fn test_validate_multi_vector_len_mismatch() {
+    // A buffer shorter than num_vectors * dimension is rejected.
+    let err = store_search::validate_multi_vector_len(10, 3, 4)
+        .expect_err("test: 10 != 3 * 4 must error");
+    assert!(
+        err.contains("expected 12"),
+        "error names the expected length"
+    );
+}
+
+#[test]
+fn test_validate_multi_vector_len_overflow() {
+    // num_vectors * dimension that wraps usize is rejected up front rather than
+    // spoofing the length check (the wasm32 32-bit overflow guard).
+    let err = store_search::validate_multi_vector_len(0, usize::MAX, 2)
+        .expect_err("test: usize::MAX * 2 overflows");
+    assert!(err.contains("overflow"), "error flags the overflow");
+}

--- a/crates/velesdb-wasm/src/store_search.rs
+++ b/crates/velesdb-wasm/src/store_search.rs
@@ -58,6 +58,29 @@ pub fn validate_dimension(query_len: usize, store_dim: usize) -> Result<(), JsVa
         .map_err(|e| JsValue::from_str(&e.to_string()))
 }
 
+/// Validates that a flat multi-vector buffer holds exactly
+/// `num_vectors * dimension` floats, using a checked multiplication.
+///
+/// On `wasm32`, `usize` is 32-bit, so an unchecked `num_vectors * dimension`
+/// can wrap and spoof the length comparison — admitting an out-of-bounds slice
+/// when the per-vector chunks are later read. `checked_mul` rejects the
+/// overflow up front. Returns the validated expected length on success.
+pub fn validate_multi_vector_len(
+    actual_len: usize,
+    num_vectors: usize,
+    dimension: usize,
+) -> Result<usize, String> {
+    let expected = num_vectors.checked_mul(dimension).ok_or_else(|| {
+        "Vector array size overflow: num_vectors * dimension exceeds usize".to_string()
+    })?;
+    if actual_len != expected {
+        return Err(format!(
+            "Vector array size mismatch: expected {expected}, got {actual_len}"
+        ));
+    }
+    Ok(expected)
+}
+
 /// Basic vector search.
 #[allow(clippy::too_many_arguments)]
 pub fn search(
@@ -195,20 +218,12 @@ pub fn multi_query_search_impl(
     strategy: &str,
     rrf_k: Option<u32>,
 ) -> Result<JsValue, JsValue> {
-    if vectors.len() != num_vectors * dimension {
-        return Err(JsValue::from_str(&format!(
-            "Vector array size mismatch: expected {}, got {}",
-            num_vectors * dimension,
-            vectors.len()
-        )));
-    }
+    validate_multi_vector_len(vectors.len(), num_vectors, dimension)
+        .map_err(|e| JsValue::from_str(&e))?;
 
     let mut all_results: Vec<Vec<(u64, f32)>> = Vec::with_capacity(num_vectors);
 
-    for i in 0..num_vectors {
-        let start = i * dimension;
-        let query = &vectors[start..start + dimension];
-
+    for query in vectors.chunks_exact(dimension) {
         let mut results = vector_ops::compute_scores(
             query,
             ids,
@@ -348,10 +363,7 @@ pub fn batch_search_impl(
 ) -> Result<JsValue, JsValue> {
     let mut all_results: Vec<Vec<(u64, f32)>> = Vec::with_capacity(num_vectors);
 
-    for i in 0..num_vectors {
-        let start = i * dimension;
-        let query = &vectors[start..start + dimension];
-
+    for query in vectors.chunks_exact(dimension) {
         let mut results: Vec<(u64, f32)> = ids
             .iter()
             .enumerate()

--- a/crates/velesdb-wasm/src/vector_store.rs
+++ b/crates/velesdb-wasm/src/vector_store.rs
@@ -473,13 +473,8 @@ impl VectorStore {
             return serde_wasm_bindgen::to_value::<Vec<Vec<(u64, f32)>>>(&vec![])
                 .map_err(|e| JsValue::from_str(&e.to_string()));
         }
-        let expected_len = num_vectors * self.dimension;
-        if vectors.len() != expected_len {
-            return Err(JsValue::from_str(&format!(
-                "Expected {expected_len} floats, got {}",
-                vectors.len()
-            )));
-        }
+        store_search::validate_multi_vector_len(vectors.len(), num_vectors, self.dimension)
+            .map_err(|e| JsValue::from_str(&e))?;
         if self.storage_mode != StorageMode::Full {
             return Err(JsValue::from_str(
                 "batch_search only supports Full storage mode",


### PR DESCRIPTION
## What

`multi_query_search_impl` and `VectorStore::batch_search` validated the flat multi-vector buffer with an unchecked `num_vectors * dimension`. On `wasm32` (`usize` is 32-bit) that product can wrap, spoof the length comparison, and admit an out-of-bounds per-vector slice downstream.

## Change

- New `store_search::validate_multi_vector_len(actual_len, num_vectors, dimension)` using `checked_mul`; rejects the overflow up front and returns the validated expected length.
- Shared across both call sites (DRY — replaces the duplicated manual length block in `batch_search`).
- Iterate the flat buffer with `chunks_exact(dimension)` instead of manual `start..start+dimension` indexing in both impls.
- Native unit tests cover ok / mismatch / overflow.

## Notes

- Severity is low: the public entry points already guard length, so the path is not reachable via the JS API today, and triggering the wrap needs a >16 GB buffer (unrealistic in a browser). This is defensive hardening of the internal helpers.
- Supersedes #1108 (same underlying fix, reauthored to satisfy the CLA / contributor authorship requirements).
- Part of the parity campaign; wasm-only, disjoint from the open server/CLI PRs.