### PR TITLE
feat(tauri): forward collection lifecycle events via DatabaseObserver

### DIFF
--- a/crates/tauri-plugin-velesdb/src/commands.rs
+++ b/crates/tauri-plugin-velesdb/src/commands.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::missing_errors_doc, deprecated)]
 
 use crate::error::{CommandError, Error};
-use crate::events::{emit_collection_created, emit_collection_deleted, emit_collection_updated};
+use crate::events::emit_collection_updated;
 use crate::helpers::{
     map_core_results, metric_to_string, parse_filter, parse_fusion_strategy, parse_metric,
     parse_storage_mode, require_collection, storage_mode_to_string, timed_search_response,
@@ -52,7 +52,7 @@ pub(crate) const fn has_advanced_params(request: &CreateCollectionRequest) -> bo
 /// Creates a new collection.
 #[command]
 pub async fn create_collection<R: Runtime>(
-    app: AppHandle<R>,
+    _app: AppHandle<R>,
     state: State<'_, VelesDbState>,
     request: CreateCollectionRequest,
 ) -> std::result::Result<CollectionInfo, CommandError> {
@@ -92,14 +92,13 @@ pub async fn create_collection<R: Runtime>(
         })
         .map_err(CommandError::from)?;
 
-    emit_collection_created(&app, &request.name);
     Ok(result)
 }
 
 /// Creates a metadata-only collection (no vectors, just payloads).
 #[command]
 pub async fn create_metadata_collection<R: Runtime>(
-    app: AppHandle<R>,
+    _app: AppHandle<R>,
     state: State<'_, VelesDbState>,
     request: CreateMetadataCollectionRequest,
 ) -> std::result::Result<CollectionInfo, CommandError> {
@@ -116,14 +115,13 @@ pub async fn create_metadata_collection<R: Runtime>(
         })
         .map_err(CommandError::from)?;
 
-    emit_collection_created(&app, &request.name);
     Ok(result)
 }
 
 /// Deletes a collection.
 #[command]
 pub async fn delete_collection<R: Runtime>(
-    app: AppHandle<R>,
+    _app: AppHandle<R>,
     state: State<'_, VelesDbState>,
     name: String,
 ) -> std::result::Result<(), CommandError> {
@@ -134,7 +132,6 @@ pub async fn delete_collection<R: Runtime>(
         })
         .map_err(CommandError::from)?;
 
-    emit_collection_deleted(&app, &name);
     Ok(())
 }
 

--- a/crates/tauri-plugin-velesdb/src/commands_graph.rs
+++ b/crates/tauri-plugin-velesdb/src/commands_graph.rs
@@ -4,7 +4,6 @@
 #![allow(clippy::missing_errors_doc)]
 
 use crate::error::{CommandError, Error};
-use crate::events::emit_collection_created;
 use crate::helpers::{parse_metric, require_graph_collection};
 use crate::state::VelesDbState;
 use crate::types::{
@@ -23,7 +22,7 @@ use velesdb_core::GraphSchema;
 /// embeddings are enabled with the given metric.
 #[command]
 pub async fn create_graph_collection<R: Runtime>(
-    app: AppHandle<R>,
+    _app: AppHandle<R>,
     state: State<'_, VelesDbState>,
     request: CreateGraphCollectionRequest,
 ) -> std::result::Result<CollectionInfo, CommandError> {
@@ -51,7 +50,6 @@ pub async fn create_graph_collection<R: Runtime>(
         })
         .map_err(CommandError::from)?;
 
-    emit_collection_created(&app, &request.name);
     Ok(result)
 }
 

--- a/crates/tauri-plugin-velesdb/src/lib.rs
+++ b/crates/tauri-plugin-velesdb/src/lib.rs
@@ -74,6 +74,7 @@ pub mod commands_sparse;
 pub mod error;
 pub mod events;
 pub mod helpers;
+pub mod observer;
 pub mod state;
 pub mod types;
 pub mod types_graph;
@@ -225,7 +226,8 @@ pub fn init_with_path<R: Runtime, P: AsRef<Path>>(path: P) -> TauriPlugin<R> {
     ));
     builder
         .setup(move |app, _api| {
-            let state = VelesDbState::new(db_path.clone());
+            let observer = std::sync::Arc::new(observer::TauriObserver::new(app.clone()));
+            let state = VelesDbState::new_with_observer(db_path.clone(), observer);
             app.manage(state);
             tracing::info!("VelesDB plugin initialized with path: {:?}", db_path);
             Ok(())

--- a/crates/tauri-plugin-velesdb/src/observer.rs
+++ b/crates/tauri-plugin-velesdb/src/observer.rs
@@ -1,0 +1,40 @@
+//! Bridges core [`DatabaseObserver`] lifecycle hooks to Tauri events.
+//!
+//! Injecting a [`TauriObserver`] when the database is opened means collection
+//! create/delete events reach the frontend no matter where they originate in
+//! the core — direct commands, `VelesQL` DDL via the `query` command, or any
+//! future entry path — instead of only the commands that emit manually.
+
+use tauri::{AppHandle, Runtime};
+use velesdb_core::collection::CollectionType;
+use velesdb_core::DatabaseObserver;
+
+use crate::events::{emit_collection_created, emit_collection_deleted};
+
+/// A [`DatabaseObserver`] that forwards collection lifecycle hooks to the
+/// plugin's Tauri event stream.
+///
+/// Generic over the Tauri [`Runtime`]; the generic is erased when the value is
+/// stored as `Arc<dyn DatabaseObserver>` and handed to
+/// [`Database::open_with_observer`](velesdb_core::Database::open_with_observer).
+pub struct TauriObserver<R: Runtime> {
+    app: AppHandle<R>,
+}
+
+impl<R: Runtime> TauriObserver<R> {
+    /// Creates an observer that emits events through the given app handle.
+    #[must_use]
+    pub fn new(app: AppHandle<R>) -> Self {
+        Self { app }
+    }
+}
+
+impl<R: Runtime> DatabaseObserver for TauriObserver<R> {
+    fn on_collection_created(&self, name: &str, _kind: &CollectionType) {
+        emit_collection_created(&self.app, name);
+    }
+
+    fn on_collection_deleted(&self, name: &str) {
+        emit_collection_deleted(&self.app, name);
+    }
+}

--- a/crates/tauri-plugin-velesdb/src/state.rs
+++ b/crates/tauri-plugin-velesdb/src/state.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 
 use parking_lot::RwLock;
 use velesdb_core::agent::AgentMemory;
-use velesdb_core::Database;
+use velesdb_core::{Database, DatabaseObserver};
 
 use crate::error::{Error, Result};
 
@@ -35,6 +35,11 @@ pub struct VelesDbState {
     memory: Arc<RwLock<Option<Arc<AgentMemory>>>>,
     /// Path to the database directory.
     path: PathBuf,
+    /// Optional lifecycle observer injected when the database is opened.
+    ///
+    /// Set by the plugin at setup so collection create/delete events reach the
+    /// frontend regardless of the entry path. `None` falls back to a plain open.
+    observer: Option<Arc<dyn DatabaseObserver>>,
 }
 
 impl VelesDbState {
@@ -49,10 +54,22 @@ impl VelesDbState {
     /// A new `VelesDbState` instance (database not yet opened).
     #[must_use]
     pub fn new(path: PathBuf) -> Self {
+        Self::with_observer(path, None)
+    }
+
+    /// Creates a new plugin state that injects `observer` into the database when
+    /// it is opened, so collection lifecycle events are forwarded to Tauri.
+    #[must_use]
+    pub fn new_with_observer(path: PathBuf, observer: Arc<dyn DatabaseObserver>) -> Self {
+        Self::with_observer(path, Some(observer))
+    }
+
+    fn with_observer(path: PathBuf, observer: Option<Arc<dyn DatabaseObserver>>) -> Self {
         Self {
             db: Arc::new(RwLock::new(None)),
             memory: Arc::new(RwLock::new(None)),
             path,
+            observer,
         }
     }
 
@@ -64,8 +81,11 @@ impl VelesDbState {
     pub fn open(&self) -> Result<()> {
         let mut db_guard = self.db.write();
         if db_guard.is_none() {
-            let db = Arc::new(Database::open(&self.path)?);
-            *db_guard = Some(db);
+            let db = match &self.observer {
+                Some(observer) => Database::open_with_observer(&self.path, Arc::clone(observer))?,
+                None => Database::open(&self.path)?,
+            };
+            *db_guard = Some(Arc::new(db));
             tracing::info!("VelesDB opened at {:?}", self.path);
         }
         Ok(())
@@ -230,6 +250,48 @@ mod tests {
         assert!(result1.is_ok());
         assert!(result2.is_ok());
         assert!(result3.is_ok());
+    }
+
+    /// An observer injected via `new_with_observer` must receive the core's
+    /// collection lifecycle hooks — this is the wiring that lets the Tauri
+    /// plugin forward create/delete events to the frontend.
+    #[test]
+    fn test_injected_observer_receives_lifecycle_hooks() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use velesdb_core::collection::CollectionType;
+        use velesdb_core::DatabaseObserver;
+
+        #[derive(Default)]
+        struct CountingObserver {
+            created: AtomicUsize,
+            deleted: AtomicUsize,
+        }
+        impl DatabaseObserver for CountingObserver {
+            fn on_collection_created(&self, _name: &str, _kind: &CollectionType) {
+                self.created.fetch_add(1, Ordering::SeqCst);
+            }
+            fn on_collection_deleted(&self, _name: &str) {
+                self.deleted.fetch_add(1, Ordering::SeqCst);
+            }
+        }
+
+        // Arrange
+        let dir = tempdir().expect("Failed to create temp dir");
+        let observer = Arc::new(CountingObserver::default());
+        let state = VelesDbState::new_with_observer(dir.path().to_path_buf(), observer.clone());
+
+        // Act - a create then a delete, both through the observed database.
+        state
+            .with_db(|db| {
+                db.create_metadata_collection("docs")?;
+                db.delete_collection("docs")?;
+                Ok(())
+            })
+            .expect("create + delete");
+
+        // Assert - each lifecycle hook fired exactly once.
+        assert_eq!(observer.created.load(Ordering::SeqCst), 1);
+        assert_eq!(observer.deleted.load(Ordering::SeqCst), 1);
     }
 
     /// The persistent handle must be one shared `AgentMemory`, not a fresh


### PR DESCRIPTION
## What

Parity item Q (observer Tauri). The Tauri plugin emitted `velesdb://collection-created` / `-deleted` events only from the handful of commands that called the emit helpers manually — so a collection created through the VelesQL `query` command (or any future path) produced no event.

## Change

- New `observer::TauriObserver<R>`: a `DatabaseObserver` that forwards `on_collection_created` / `on_collection_deleted` to the existing event helpers.
- `VelesDbState::new_with_observer` stores the observer and `open()` routes through `Database::open_with_observer`, so the core's lifecycle hooks drive event emission. Injected at plugin `setup` with the app handle.
- Removed the now-redundant manual `emit_collection_created` / `emit_collection_deleted` calls from `create_collection`, `create_metadata_collection`, `delete_collection` and `create_graph_collection` (avoids double emission). Data-mutation events (upsert / delete points) keep their manual emits — the core has no symmetric auto-hook for them.

## Scope / license

Default-allow only: the observer forwards notifications. **No policy engine** — RBAC/veto-policy stays premium. The core veto hooks (`on_ddl_request` / `on_dml_mutation_request`) are left at their default-allow defaults.

## Tests

`state.rs`: a counting-observer unit test asserts the injected observer receives one `on_collection_created` and one `on_collection_deleted` through a real create+delete. Full plugin suite green (110 lib tests), clippy pedantic clean.