### PR TITLE
feat(wasm): cross-collection @collection enrichment in MATCH

### DIFF
--- a/crates/velesdb-wasm/src/database.rs
+++ b/crates/velesdb-wasm/src/database.rs
@@ -22,7 +22,7 @@ use crate::vector_store::VectorStore;
 // Shared inner store
 // ---------------------------------------------------------------------------
 
-type SharedStore = Rc<RefCell<VectorStore>>;
+pub(crate) type SharedStore = Rc<RefCell<VectorStore>>;
 type SharedGraph = Rc<RefCell<WasmGraphStore>>;
 
 // ---------------------------------------------------------------------------

--- a/crates/velesdb-wasm/src/vector_store.rs
+++ b/crates/velesdb-wasm/src/vector_store.rs
@@ -52,6 +52,17 @@ pub struct VectorStore {
     pub(crate) sparse_index: Option<sparse::SparseIndex>,
 }
 
+impl VectorStore {
+    /// Returns the JSON payload stored for `id`, if the id exists and carries one.
+    ///
+    /// Used by cross-collection MATCH enrichment to merge a referenced
+    /// collection's metadata into graph results by node id.
+    pub(crate) fn payload_for_id(&self, id: u64) -> Option<&serde_json::Value> {
+        let idx = self.ids.iter().position(|&x| x == id)?;
+        self.payloads.get(idx).and_then(Option::as_ref)
+    }
+}
+
 #[wasm_bindgen]
 impl VectorStore {
     /// Creates a new vector store. Metrics: cosine, euclidean, dot, hamming, jaccard.

--- a/crates/velesdb-wasm/src/velesql_graph_unit_tests.rs
+++ b/crates/velesdb-wasm/src/velesql_graph_unit_tests.rs
@@ -110,6 +110,94 @@ fn test_match_1_hop_returns_pairs() {
 }
 
 #[test]
+fn test_match_at_collection_enriches_referenced_node() {
+    let mut db = DatabaseInner::new();
+
+    // A vector collection 'profiles' holds rich payloads keyed by node id.
+    db.create_metadata_collection("profiles")
+        .expect("test: create profiles collection");
+    {
+        let store = db
+            .get_shared_store("profiles")
+            .expect("test: profiles store");
+        crate::store_insert::insert_with_payload(
+            &mut store.borrow_mut(),
+            2,
+            &[],
+            Some(serde_json::json!({"email": "bob@x.io", "tier": "gold"})),
+        );
+    }
+
+    // Default WASM graph 'graph': node 1 (Person) -[HAS]-> node 2 (Profile).
+    for (id, name, labels) in [(1u64, "Alice", vec!["Person"]), (2, "Bob", vec!["Profile"])] {
+        let stmt = InsertNodeStatement {
+            collection: "graph".to_string(),
+            node_id: id,
+            payload: serde_json::json!({"name": name, "labels": labels}),
+        };
+        insert_node(&mut db, &stmt).expect("test: insert node");
+    }
+    let edge = InsertEdgeStatement {
+        collection: "graph".to_string(),
+        edge_id: None,
+        source: 1,
+        target: 2,
+        label: "HAS".to_string(),
+        properties: Vec::new(),
+    };
+    insert_edge(&mut db, &edge, &Params::new()).expect("test: insert edge");
+
+    // The second node references 'profiles' for cross-collection enrichment.
+    let q = parse_match("MATCH (a:Person)-[:HAS]->(b:Profile@profiles) RETURN a, b LIMIT 10");
+    let rows = execute_match(&mut db, &q, &Params::new()).expect("test: match");
+    assert_eq!(rows.len(), 1);
+
+    let data: serde_json::Value =
+        serde_json::from_str(rows[0].data_json_ref()).expect("test: row json");
+    let b = &data["b"];
+    // Cross-collection fields merged into the `b` alias object...
+    assert_eq!(b["email"], serde_json::json!("bob@x.io"));
+    assert_eq!(b["tier"], serde_json::json!("gold"));
+    // ...without clobbering the graph node's own identity.
+    assert_eq!(b["name"], serde_json::json!("Bob"));
+    assert_eq!(b["id"], serde_json::json!(2));
+    // The unannotated anchor `a` gains no cross-collection fields.
+    assert_eq!(data["a"]["name"], serde_json::json!("Alice"));
+    assert!(data["a"].get("email").is_none());
+}
+
+#[test]
+fn test_match_at_collection_missing_collection_is_skipped() {
+    // An @collection pointing at a non-existent vector collection must not
+    // fail the MATCH — the graph results are returned un-enriched.
+    let mut db = DatabaseInner::new();
+    for (id, name, labels) in [(1u64, "Alice", vec!["Person"]), (2, "Bob", vec!["Profile"])] {
+        let stmt = InsertNodeStatement {
+            collection: "graph".to_string(),
+            node_id: id,
+            payload: serde_json::json!({"name": name, "labels": labels}),
+        };
+        insert_node(&mut db, &stmt).expect("test: insert node");
+    }
+    let edge = InsertEdgeStatement {
+        collection: "graph".to_string(),
+        edge_id: None,
+        source: 1,
+        target: 2,
+        label: "HAS".to_string(),
+        properties: Vec::new(),
+    };
+    insert_edge(&mut db, &edge, &Params::new()).expect("test: insert edge");
+
+    let q = parse_match("MATCH (a:Person)-[:HAS]->(b:Profile@nope) RETURN a, b LIMIT 10");
+    let rows = execute_match(&mut db, &q, &Params::new()).expect("test: match still succeeds");
+    assert_eq!(rows.len(), 1);
+    let data: serde_json::Value =
+        serde_json::from_str(rows[0].data_json_ref()).expect("test: row json");
+    assert_eq!(data["b"]["name"], serde_json::json!("Bob"));
+}
+
+#[test]
 fn test_match_rejects_beyond_2_hop() {
     let mut db = DatabaseInner::new();
     let q =

--- a/crates/velesdb-wasm/src/velesql_match.rs
+++ b/crates/velesdb-wasm/src/velesql_match.rs
@@ -8,10 +8,74 @@ use velesdb_core::velesql::{
     Condition, Direction, GraphPattern, MatchClause, NodePattern, Query, RelationshipPattern,
 };
 
-use crate::database::DatabaseInner;
+use crate::database::{DatabaseInner, SharedStore};
 use crate::graph_store::{WasmEdge, WasmGraphNode, WasmGraphStore};
 use crate::velesql_result::QueryResultRow;
 use crate::velesql_value::Params;
+
+/// A resolved `@collection` cross-reference: an aliased node's alias paired
+/// with the store of the collection it references for payload enrichment.
+type CrossRef = (String, SharedStore);
+
+/// Collects `@collection` cross-references from a MATCH clause.
+///
+/// Mirrors core's `enrich_match_results_cross_collection`: only nodes with
+/// **both** an explicit alias and a collection annotation are enriched, and a
+/// reference to a missing collection is silently skipped (the MATCH still
+/// returns its graph results). The referenced collection's store is resolved
+/// once here and reused for every result row.
+///
+/// WASM note: lacking a `FROM` clause, the executor also reuses the *first*
+/// node's `@collection` annotation to pick the graph store (see
+/// [`inferred_graph_store`]). Enrichment therefore applies to any annotated
+/// node that names an existing **vector** collection — in practice the
+/// non-anchor nodes (`b`, `c`); the anchor enriches only when a same-named
+/// vector collection also exists, otherwise its annotation just selects the
+/// graph and the lookup is skipped.
+fn resolve_cross_refs(db: &DatabaseInner, clause: &MatchClause) -> Vec<CrossRef> {
+    clause
+        .patterns
+        .iter()
+        .flat_map(|p| p.nodes.iter())
+        .filter_map(|n| {
+            let alias = n.alias.clone()?;
+            let coll = n.collection.as_deref()?;
+            let store = db.get_shared_store(coll).ok()?;
+            Some((alias, store))
+        })
+        .collect()
+}
+
+/// Merges cross-collection payloads into a freshly built MATCH row.
+///
+/// For each cross-reference, the node id is read back from the alias object's
+/// `id` field (every row builder writes it), the referenced collection's
+/// payload for that id is looked up, and its fields are merged into the alias
+/// object. The graph node's own fields — including the reserved `id`/`labels` —
+/// win on collision, so enrichment never overwrites graph identity.
+fn enrich_row(map: &mut serde_json::Map<String, serde_json::Value>, cross: &[CrossRef]) {
+    for (alias, store) in cross {
+        let Some(id) = map
+            .get(alias)
+            .and_then(|v| v.get("id"))
+            .and_then(serde_json::Value::as_u64)
+        else {
+            continue;
+        };
+        let borrowed = store.borrow();
+        let Some(serde_json::Value::Object(cross_obj)) = borrowed.payload_for_id(id) else {
+            continue;
+        };
+        let Some(serde_json::Value::Object(alias_obj)) = map.get_mut(alias) else {
+            continue;
+        };
+        for (key, value) in cross_obj {
+            alias_obj
+                .entry(key.clone())
+                .or_insert_with(|| value.clone());
+        }
+    }
+}
 
 /// Executes a MATCH query.
 ///
@@ -58,6 +122,7 @@ fn execute_single_node(
 ) -> Result<Vec<QueryResultRow>, String> {
     let node = &pattern.nodes[0];
     let label = first_label(node);
+    let cross = resolve_cross_refs(db, clause);
     let store = inferred_graph_store(db, pattern)?;
     let borrowed = store.borrow();
     let candidates = borrowed.candidate_nodes(label.as_deref());
@@ -74,7 +139,7 @@ fn execute_single_node(
         if (out.len() as u64) >= limit {
             break;
         }
-        out.push(build_match_row_single(node, nid, node_data)?);
+        out.push(build_match_row_single(node, nid, node_data, &cross)?);
     }
     Ok(out)
 }
@@ -91,6 +156,7 @@ fn execute_1_hop(
             pattern.relationships.len()
         ));
     }
+    let cross = resolve_cross_refs(db, clause);
     let store = inferred_graph_store(db, pattern)?;
     let borrowed = store.borrow();
     let ctx = OneHopContext {
@@ -99,6 +165,7 @@ fn execute_1_hop(
         rel: &pattern.relationships[0],
         la: first_label(&pattern.nodes[0]),
         lb: first_label(&pattern.nodes[1]),
+        cross,
     };
     let limit = clause.return_clause.limit.unwrap_or(u64::MAX);
     let mut out = Vec::new();
@@ -125,6 +192,7 @@ struct OneHopContext<'p> {
     rel: &'p RelationshipPattern,
     la: Option<String>,
     lb: Option<String>,
+    cross: Vec<CrossRef>,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -159,9 +227,7 @@ fn expand_one_hop(
         if (out.len() as u64) >= limit {
             return Ok(());
         }
-        out.push(build_match_row_pair(
-            ctx.na, sid, a_node, ctx.nb, other, b_node,
-        )?);
+        out.push(build_match_row_pair(ctx, sid, a_node, other, b_node)?);
     }
     Ok(())
 }
@@ -224,9 +290,10 @@ fn execute_2_hop(
             pattern.relationships.len()
         ));
     }
+    let cross = resolve_cross_refs(db, clause);
     let store = inferred_graph_store(db, pattern)?;
     let borrowed = store.borrow();
-    let ctx = TwoHopContext::new(pattern);
+    let ctx = TwoHopContext::new(pattern, cross);
     let limit = clause.return_clause.limit.unwrap_or(u64::MAX);
     let where_clause = clause.where_clause.as_ref();
     let mut out = Vec::new();
@@ -248,10 +315,11 @@ struct TwoHopContext<'p> {
     lc: Option<String>,
     r1: &'p RelationshipPattern,
     r2: &'p RelationshipPattern,
+    cross: Vec<CrossRef>,
 }
 
 impl<'p> TwoHopContext<'p> {
-    fn new(pattern: &'p GraphPattern) -> Self {
+    fn new(pattern: &'p GraphPattern, cross: Vec<CrossRef>) -> Self {
         Self {
             na: &pattern.nodes[0],
             nb: &pattern.nodes[1],
@@ -261,6 +329,7 @@ impl<'p> TwoHopContext<'p> {
             lc: first_label(&pattern.nodes[2]),
             r1: &pattern.relationships[0],
             r2: &pattern.relationships[1],
+            cross,
         }
     }
 }
@@ -338,7 +407,7 @@ fn expand_from_b(
             return Ok(());
         }
         out.push(build_match_row_triple(
-            ctx.na, a_id, a_node, ctx.nb, b_id, b_node, ctx.nc, c_id, c_node,
+            ctx, a_id, a_node, b_id, b_node, c_id, c_node,
         )?);
     }
     Ok(())
@@ -498,48 +567,48 @@ fn build_match_row_single(
     node: &NodePattern,
     id: u64,
     data: &WasmGraphNode,
+    cross: &[CrossRef],
 ) -> Result<QueryResultRow, String> {
     let alias = node.alias.clone().unwrap_or_else(|| "a".to_string());
     let mut map = serde_json::Map::new();
     map.insert(alias, node_json(id, data));
+    enrich_row(&mut map, cross);
     QueryResultRow::synthetic(serde_json::Value::Object(map))
 }
 
 fn build_match_row_pair(
-    na: &NodePattern,
+    ctx: &OneHopContext<'_>,
     a_id: u64,
     a_data: &WasmGraphNode,
-    nb: &NodePattern,
     b_id: u64,
     b_data: &WasmGraphNode,
 ) -> Result<QueryResultRow, String> {
-    let alias_a = na.alias.clone().unwrap_or_else(|| "a".to_string());
-    let alias_b = nb.alias.clone().unwrap_or_else(|| "b".to_string());
+    let alias_a = ctx.na.alias.clone().unwrap_or_else(|| "a".to_string());
+    let alias_b = ctx.nb.alias.clone().unwrap_or_else(|| "b".to_string());
     let mut map = serde_json::Map::new();
     map.insert(alias_a, node_json(a_id, a_data));
     map.insert(alias_b, node_json(b_id, b_data));
+    enrich_row(&mut map, &ctx.cross);
     QueryResultRow::synthetic(serde_json::Value::Object(map))
 }
 
-#[allow(clippy::too_many_arguments)]
 fn build_match_row_triple(
-    na: &NodePattern,
+    ctx: &TwoHopContext<'_>,
     a_id: u64,
     a_data: &WasmGraphNode,
-    nb: &NodePattern,
     b_id: u64,
     b_data: &WasmGraphNode,
-    nc: &NodePattern,
     c_id: u64,
     c_data: &WasmGraphNode,
 ) -> Result<QueryResultRow, String> {
-    let alias_a = na.alias.clone().unwrap_or_else(|| "a".to_string());
-    let alias_b = nb.alias.clone().unwrap_or_else(|| "b".to_string());
-    let alias_c = nc.alias.clone().unwrap_or_else(|| "c".to_string());
+    let alias_a = ctx.na.alias.clone().unwrap_or_else(|| "a".to_string());
+    let alias_b = ctx.nb.alias.clone().unwrap_or_else(|| "b".to_string());
+    let alias_c = ctx.nc.alias.clone().unwrap_or_else(|| "c".to_string());
     let mut map = serde_json::Map::new();
     map.insert(alias_a, node_json(a_id, a_data));
     map.insert(alias_b, node_json(b_id, b_data));
     map.insert(alias_c, node_json(c_id, c_data));
+    enrich_row(&mut map, &ctx.cross);
     QueryResultRow::synthetic(serde_json::Value::Object(map))
 }
 


### PR DESCRIPTION
## What

Parity item O (I3). The WASM VelesQL MATCH executor parsed `@collection` node annotations but only used the *first* node's annotation to pick the graph store — non-anchor `@collection` annotations were silently ignored, so the cross-collection payload enrichment that core / CLI / REST provide never happened in the browser.

## Change

- `resolve_cross_refs` collects `(alias, store)` for every aliased node carrying a `@collection` annotation, resolving each referenced **vector** collection once (a missing collection is skipped, mirroring core's `enrich_match_results_cross_collection`).
- `enrich_row` merges the referenced collection's payload (looked up by node id) into the alias object; the graph node's own fields — including the reserved `id` / `labels` — win on collision, so graph identity is never overwritten.
- The pair/triple row builders now take their hop `Context` (which carries the cross refs), which also trims their parameter counts.
- `VectorStore::payload_for_id` exposes an internal by-id payload lookup.

## WASM-specific note

WASM has no `FROM` clause, so the executor reuses the first node's `@collection` to select the graph store (`inferred_graph_store`). Enrichment therefore applies to any annotated node naming an existing vector collection — in practice the non-anchor nodes. This is documented on `resolve_cross_refs`. Integration adapters (LangChain/LlamaIndex/Haystack) don't expose MATCH, so `@collection` is moot there — no change needed.

## Tests

Native unit tests cover (1) enrichment of a referenced node merging cross-collection fields without clobbering graph identity, and (2) the missing-collection skip path returning un-enriched results. Full wasm lib suite green (524 tests + 2 new), clippy pedantic clean, `wasm32-unknown-unknown` builds, lizard reports no complexity/param warnings.