### PR TITLE
feat(python): Collection.enable_streaming for streaming ingestion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6701,6 +6701,7 @@ dependencies = [
  "pyo3",
  "pyo3-build-config 0.28.3",
  "serde_json",
+ "tokio",
  "velesdb-core",
 ]
 

--- a/crates/velesdb-python/Cargo.toml
+++ b/crates/velesdb-python/Cargo.toml
@@ -23,6 +23,10 @@ pyo3 = { version = "0.24", features = ["extension-module", "multiple-pymethods",
 serde_json = { workspace = true }
 numpy = "0.24"
 parking_lot = "0.12"
+# Hosts the background streaming-ingestion drain task (Collection.enable_streaming).
+# The Python process has no ambient Tokio runtime, so the bindings provide a
+# shared multi-thread runtime for the StreamIngester to spawn its drain loop on.
+tokio = { workspace = true }
 
 [features]
 default = ["velesdb-core/default"]

--- a/crates/velesdb-python/src/collection/mutation.rs
+++ b/crates/velesdb-python/src/collection/mutation.rs
@@ -278,6 +278,36 @@ impl Collection {
     ///     >>> count = collection.stream_insert([
     ///     ...     {"id": 1, "vector": [...], "payload": {"key": "value"}}
     ///     ... ])
+    /// Enables streaming ingestion on this collection.
+    ///
+    /// Must be called before `stream_insert`; otherwise stream inserts fail
+    /// with "not configured". Mirrors the REST `/stream/enable` endpoint and
+    /// the Tauri binding. Calling it again replaces the existing ingester.
+    ///
+    /// Args:
+    ///     config: Optional `StreamingIngestConfig`. Defaults to the engine
+    ///         defaults (buffer_size=10000, batch_size=128, flush_interval_ms=50).
+    ///
+    /// Example:
+    ///     >>> collection.enable_streaming(StreamingIngestConfig(batch_size=256))
+    ///     >>> collection.stream_insert([{"id": 1, "vector": [...]}])
+    #[pyo3(signature = (config=None))]
+    fn enable_streaming(&self, config: Option<crate::StreamingIngestConfig>) -> PyResult<()> {
+        let core_config = config.map_or_else(velesdb_core::StreamingConfig::default, |c| {
+            velesdb_core::StreamingConfig {
+                buffer_size: c.buffer_size,
+                batch_size: c.batch_size,
+                flush_interval_ms: c.flush_interval_ms,
+            }
+        });
+        // Spawning the drain task needs an ambient runtime; enter the shared
+        // streaming runtime so the task is scheduled on it and survives this call.
+        let runtime = crate::streaming_runtime::stream_runtime()?;
+        let _guard = runtime.enter();
+        self.inner.enable_streaming(core_config);
+        Ok(())
+    }
+
     #[pyo3(signature = (points))]
     fn stream_insert(
         &self,

--- a/crates/velesdb-python/src/lib.rs
+++ b/crates/velesdb-python/src/lib.rs
@@ -39,6 +39,7 @@ mod graph_collection_query;
 mod graph_store;
 mod options;
 mod streaming_config;
+mod streaming_runtime;
 mod utils;
 mod velesql;
 mod velesql_helpers;

--- a/crates/velesdb-python/src/streaming_runtime.rs
+++ b/crates/velesdb-python/src/streaming_runtime.rs
@@ -1,0 +1,42 @@
+//! Shared Tokio runtime for streaming ingestion.
+//!
+//! [`Collection.enable_streaming`](crate::Collection) creates a core
+//! `StreamIngester` whose background drain task is launched with
+//! `tokio::spawn`, which requires an ambient Tokio runtime. A Python process
+//! has none, so the bindings host a single shared multi-thread runtime here.
+//! Entering it around `enable_streaming` lets the drain task be scheduled; the
+//! task then lives on this runtime — which is intentionally never shut down —
+//! for the lifetime of the process.
+
+use std::sync::OnceLock;
+
+use pyo3::exceptions::PyRuntimeError;
+use pyo3::PyResult;
+use tokio::runtime::Runtime;
+
+/// Returns the process-wide streaming runtime, building it on first use.
+///
+/// Built lazily so importing the extension never spawns runtime threads; they
+/// appear only once streaming is actually enabled. Initialization is serialized
+/// by the caller's GIL, so the build races at most with itself.
+///
+/// # Errors
+///
+/// Returns a `RuntimeError` if the Tokio runtime cannot be created.
+pub(crate) fn stream_runtime() -> PyResult<&'static Runtime> {
+    static RUNTIME: OnceLock<Runtime> = OnceLock::new();
+    if let Some(rt) = RUNTIME.get() {
+        return Ok(rt);
+    }
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .thread_name("velesdb-stream")
+        .build()
+        .map_err(|e| PyRuntimeError::new_err(format!("failed to start streaming runtime: {e}")))?;
+    // First writer wins; a late writer's runtime is dropped immediately. The
+    // GIL serializes callers, so in practice the first call always wins.
+    let _ = RUNTIME.set(rt);
+    RUNTIME
+        .get()
+        .ok_or_else(|| PyRuntimeError::new_err("streaming runtime unavailable"))
+}

--- a/crates/velesdb-python/tests/test_streaming_ingest.py
+++ b/crates/velesdb-python/tests/test_streaming_ingest.py
@@ -1,0 +1,65 @@
+"""End-to-end tests for streaming ingestion (STREAM-2).
+
+`enable_streaming` configures the background micro-batch drain task; it must be
+called before `stream_insert`, which otherwise fails ("not configured"). The
+drain task runs on the bindings' shared Tokio runtime and flushes points into
+the collection asynchronously.
+
+VELESDB_AVAILABLE / pytestmark / temp_db fixture are provided by conftest.py.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+import velesdb
+from velesdb import SearchOptions, StreamingIngestConfig
+
+VELESDB_AVAILABLE = velesdb is not None
+pytestmark = pytest.mark.skipif(not VELESDB_AVAILABLE, reason="velesdb not built")
+
+
+def _wait_until(predicate, timeout_s: float = 3.0, interval_s: float = 0.05) -> bool:
+    """Polls `predicate` until true or the timeout elapses (drain is async)."""
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(interval_s)
+    return predicate()
+
+
+def test_stream_insert_requires_enable_streaming(temp_db):
+    """stream_insert before enable_streaming fails clearly, not silently."""
+    collection = temp_db.create_collection("stream_not_enabled", dimension=4)
+    with pytest.raises(Exception):  # noqa: B017 — binding raises RuntimeError
+        collection.stream_insert([{"id": 1, "vector": [1.0, 0.0, 0.0, 0.0]}])
+
+
+def test_enable_streaming_then_stream_insert_lands_points(temp_db):
+    """After enable_streaming, streamed points are drained and searchable."""
+    collection = temp_db.create_collection("stream_ok", dimension=4, metric="cosine")
+    collection.enable_streaming(StreamingIngestConfig(batch_size=2, flush_interval_ms=10))
+
+    count = collection.stream_insert(
+        [
+            {"id": 1, "vector": [1.0, 0.0, 0.0, 0.0], "payload": {"title": "A"}},
+            {"id": 2, "vector": [0.0, 1.0, 0.0, 0.0], "payload": {"title": "B"}},
+        ]
+    )
+    assert count == 2
+
+    # The drain task flushes asynchronously; wait until the points land.
+    assert _wait_until(lambda: not collection.is_empty()), "streamed points never drained"
+    results = collection.search_request(SearchOptions(vector=[1.0, 0.0, 0.0, 0.0], top_k=1))
+    assert results[0]["id"] == 1
+
+
+def test_enable_streaming_uses_engine_defaults_when_unconfigured(temp_db):
+    """enable_streaming() with no argument applies the engine defaults."""
+    collection = temp_db.create_collection("stream_default", dimension=4)
+    collection.enable_streaming()
+    count = collection.stream_insert([{"id": 7, "vector": [1.0, 0.0, 0.0, 0.0]}])
+    assert count == 1
+    assert _wait_until(lambda: not collection.is_empty()), "default-config drain never ran"


### PR DESCRIPTION
## What

Parity item G (STREAM-2). The Python bindings shipped `StreamingIngestConfig` and `stream_insert`, but no way to **enable** streaming — so `stream_insert` always failed with `"not configured"`. This adds `Collection.enable_streaming(config=None)`, mirroring the REST `/stream/enable` endpoint and the Tauri binding.

## The runtime problem (why this needed more than a method)

Core `enable_streaming` builds a `StreamIngester` whose background drain task is launched with `tokio::spawn`, which requires an ambient Tokio runtime. A Python process has none, so calling it would panic ("no reactor running"). This PR adds a shared multi-thread Tokio runtime (`streaming_runtime`, built lazily, never shut down) and enters it around the call; the spawned drain task then lives on that runtime for the process lifetime. `stream_insert` itself stays synchronous (a channel `try_send`).

## Change

- `streaming_runtime.rs`: process-wide `OnceLock<Runtime>` accessor (no `unwrap`/`expect`; errors surface as `RuntimeError`).
- `Collection.enable_streaming(config=None)`: converts `StreamingIngestConfig` → core `StreamingConfig` (or engine defaults), enters the runtime, enables streaming.
- `tokio` added as a direct dependency of `velesdb-python`.

## Tests

New pytest suite `test_streaming_ingest.py` (runs in the `python-sdk-tests` CI job), verified locally against a `maturin develop` build — **3 passed**:
- enable → `stream_insert` → async drain → point becomes searchable;
- `enable_streaming()` with no config uses engine defaults;
- `stream_insert` before `enable_streaming` raises (not silently dropped).

Note: `velesdb-python` is excluded from the workspace's strict clippy line by design; this crate is exercised via maturin + pytest.