### PR TITLE
feat(sdk-ts): add enableStreaming to the TypeScript SDK

### DIFF
--- a/docs/reference/ECOSYSTEM_PARITY.md
+++ b/docs/reference/ECOSYSTEM_PARITY.md
@@ -1,6 +1,6 @@
 # VelesQL Ecosystem Parity Matrix
 
-Last updated: 2026-06-12 (v2.0.0)
+Last updated: 2026-06-14 (v2.0.0)
 
 This matrix tracks runtime contract and feature parity across the VelesDB ecosystem.
 
@@ -23,7 +23,7 @@ This matrix tracks runtime contract and feature parity across the VelesDB ecosys
 | LlamaIndex integration | via Python binding | via Python binding | via Python binding | n/a REST | n/a REST |
 | Haystack integration | via Python binding | via Python binding | via Python binding | n/a REST | n/a REST |
 
-## Feature Parity Matrix (85 features, 11 components)
+## Feature Parity Matrix (86 features, 11 components)
 
 Legend: ✅ full support | ⚠️ partial / limited | ❌ not supported | N/A not applicable
 
@@ -31,6 +31,7 @@ Legend: ✅ full support | ⚠️ partial / limited | ❌ not supported | N/A no
 |---------------|------|--------|--------|------|--------|-----|--------|-------|-----------|------------|----------|
 | **Vector CRUD** (insert, upsert, delete, get) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | **Batch Operations** (batch_insert, batch_upsert) | ✅ | ✅ | ✅ | ⚠️ | ⚠️ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| **Streaming Ingestion** (enableStreaming / stream_insert) | ✅ | ✅ | ✅ | ❌ | ❌ | ⚠️ | ✅ | ✅ | ❌ | ❌ | ❌ |
 | **Vector Search** (k-NN, filtered, batch) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | **Multi-Query Fusion** (RRF) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ⚠️ |
 | **Multi-Query Fusion** (RSF / Weighted) | ✅ | ✅ | ✅ | ⚠️ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ⚠️ |
@@ -55,6 +56,7 @@ Legend: ✅ full support | ⚠️ partial / limited | ❌ not supported | N/A no
 
 - **Cross-Collection MATCH**: Core and Server support `@collection` annotation on MATCH node patterns. Python bindings support via `_collection` param. CLI supports via `\use`. WASM, Mobile, Tauri, and integrations do not yet expose this feature.
 - **Batch Operations**: WASM and Mobile use streaming chunked inserts instead of single-call bulk to stay within memory constraints.
+- **Streaming Ingestion** (2026-06-14): Core, Server (`POST /collections/{name}/stream/enable` + `/stream/insert`), Python, Tauri, and the TS SDK (`enableStreaming()` / `streamInsert()`, REST backend) support the bounded ingestion channel. The CLI reaches it ⚠️ via the embedded core path with no dedicated REPL command. WASM throws `NOT_SUPPORTED` (no persistence layer). Mobile and the LangChain/LlamaIndex/Haystack integrations do not yet expose it.
 - **Multi-Query Fusion (RSF/Weighted)**: WASM supports RRF only. LangChain and LlamaIndex expose RSF/Weighted through `multi_query_search(fusion=...)`, which delegates to the shared `velesdb_common.fusion.build_fusion_strategy` (builds `weighted()` and `relative_score()`). Haystack remains ⚠️: fusion is reachable only via the underlying `velesdb` Python wrapper, not through the `DocumentStore` protocol.
 - **Sparse Vector Search (named indexes) — LangChain/LlamaIndex**: ⚠️ query-side only. Both integrations forward a `sparse_index_name` argument to the underlying `collection.search`/`hybrid_search`, so an existing named sparse index can be *queried*. Creating named sparse indexes is not exposed by the integrations (use the core `velesdb` API), and this path is not yet covered by integration tests.
 - **Graph Operations (WASM)**: Basic node/edge CRUD is supported; multi-hop traversal and MATCH queries are limited.

--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -363,6 +363,30 @@ Points are accumulated into micro-batches and flushed via bulk upsert. The
 response includes a `network_errors` count: a non-zero value means the HTTP body
 stream was truncated and fewer points than sent may have been received.
 
+### POST /collections/:name/stream/enable
+
+Enable the bounded streaming-ingestion channel on a collection. Call this once
+before `POST /collections/:name/stream/insert`. Every field is optional; omitted
+fields fall back to the server defaults.
+
+**Request Body:**
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| buffer_size | integer | No | 10000 | Bounded ingestion channel capacity |
+| batch_size | integer | No | 128 | Points flushed to the index per batch |
+| flush_interval_ms | integer | No | 50 | Max milliseconds before a partial batch is flushed |
+
+```json
+{ "buffer_size": 4096, "batch_size": 64, "flush_interval_ms": 25 }
+```
+
+**Status codes:** `200` enabled (response `{ "message", "collection" }`); `404`
+collection not found.
+
+TypeScript SDK: `await db.enableStreaming('docs', { bufferSize: 4096 })` (REST
+backend; the WASM backend throws `NOT_SUPPORTED`).
+
 ### POST /collections/:name/stream/insert
 
 Insert a **single** point through the bounded streaming-ingestion channel.

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -6,6 +6,7 @@ Official TypeScript SDK for [VelesDB](https://github.com/cyberlife-coder/VelesDB
 
 ## What's New (unreleased)
 
+- **Streaming ingestion enablement (2026-06-14)** (REST backend): `enableStreaming(collection, config?)` turns on the bounded streaming-ingestion channel before `streamInsert()`. The optional `StreamingConfig` (`bufferSize`, `batchSize`, `flushIntervalMs`) is camelCase; omitted fields fall back to the server defaults. See [`db.enableStreaming`](#dbenablestreamingcollection-config) below. The WASM backend throws `NOT_SUPPORTED`.
 - **Relation + durable-TTL surface** (REST backend): `relate()`, `unrelate()`, `getRelations()`, `setTtlDurable()` — now fully tested and documented (see [Knowledge Graph API](#knowledge-graph-api) and [Agent Memory API](#agent-memory-api) below). The WASM backend throws `NOT_SUPPORTED` for these methods.
 - The shipped example (`examples/hybrid_queries.ts`) was rewritten against the real API and is now compile-checked in CI.
 
@@ -330,6 +331,21 @@ await db.upsertBatch('docs', [
   { id: 'a', vector: vecA, payload: { title: 'First' } },
   { id: 'b', vector: vecB, payload: { title: 'Second' } },
 ]);
+```
+
+#### `db.enableStreaming(collection, config?)`
+
+Enable the bounded streaming-ingestion channel on a collection. Call this once before `streamInsert()`. The optional `config` is camelCase; every field is optional and omitted fields fall back to the server defaults (REST only; the WASM backend throws `NOT_SUPPORTED`).
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `bufferSize` | `number` | `10000` | Bounded ingestion channel capacity |
+| `batchSize` | `number` | `128` | Points flushed to the index per batch |
+| `flushIntervalMs` | `number` | `50` | Max milliseconds before a partial batch is flushed |
+
+```typescript
+await db.enableStreaming('docs', { bufferSize: 4096, batchSize: 64 });
+await db.streamInsert('docs', largeDocumentArray);
 ```
 
 #### `db.streamInsert(collection, documents)`

--- a/sdks/typescript/src/backends/rest.ts
+++ b/sdks/typescript/src/backends/rest.ts
@@ -51,6 +51,7 @@ import type {
   AggregateQueryOptions,
   AggregateResponse,
   StreamUpsertResponse,
+  StreamingConfig,
   RelateRequest,
   RelateResponse,
   RelationsResponse,
@@ -117,7 +118,7 @@ import { query as _query, queryExplain as _queryExplain, collectionSanity as _co
 import { scroll as _scroll } from './scroll-backend';
 import { getCollectionStats as _getCollectionStats, analyzeCollection as _analyzeCollection, getCollectionConfig as _getCollectionConfig } from './admin-backend';
 import { createIndex as _createIndex, listIndexes as _listIndexes, hasIndex as _hasIndex, dropIndex as _dropIndex } from './index-backend';
-import { trainPq as _trainPq, streamInsert as _streamInsert, streamUpsertPoints as _streamUpsertPoints } from './streaming-backend';
+import { trainPq as _trainPq, enableStreaming as _enableStreaming, streamInsert as _streamInsert, streamUpsertPoints as _streamUpsertPoints } from './streaming-backend';
 import {
   createCollection as _createCollection, deleteCollection as _deleteCollection,
   getCollection as _getCollection, listCollections as _listCollections,
@@ -234,6 +235,7 @@ export class RestBackend implements IVelesDBBackend {
 
   // Streaming / PQ
   async trainPq(c: string, o?: PqTrainOptions): Promise<string> { this.ensureInitialized(); return _trainPq(buildStreamingTransport(this.httpConfig), c, o); }
+  async enableStreaming(c: string, cfg?: StreamingConfig): Promise<void> { this.ensureInitialized(); return _enableStreaming(buildStreamingTransport(this.httpConfig), c, cfg); }
   async streamInsert(c: string, d: VectorDocument[]): Promise<void> { this.ensureInitialized(); return _streamInsert(buildStreamingTransport(this.httpConfig), c, d); }
   async streamUpsertPoints(c: string, d: VectorDocument[]): Promise<StreamUpsertResponse> { this.ensureInitialized(); return _streamUpsertPoints(buildStreamingTransport(this.httpConfig), c, d); }
 

--- a/sdks/typescript/src/backends/streaming-backend.ts
+++ b/sdks/typescript/src/backends/streaming-backend.ts
@@ -11,6 +11,7 @@ import type {
   SparseVector,
   RestPointId,
   StreamUpsertResponse,
+  StreamingConfig,
 } from '../types';
 import { BackpressureError, ConnectionError, ValidationError, VelesDBError } from '../types';
 import type { BaseTransport } from './shared';
@@ -151,6 +152,40 @@ export async function streamInsert(
       );
     }
   }
+}
+
+/**
+ * Enable the bounded streaming-ingestion channel on a collection.
+ *
+ * POSTs the optional `StreamingConfig` to `/collections/{name}/stream/enable`
+ * as a snake_case JSON body. Omitted fields are left out of the body so the
+ * server applies its own defaults (`buffer_size` 10000, `batch_size` 128,
+ * `flush_interval_ms` 50). A non-2xx response raises `VelesDBError` and an
+ * abort raises `ConnectionError` (both via the shared `requestJson` path).
+ */
+export async function enableStreaming(
+  transport: StreamingTransport,
+  collection: string,
+  config?: StreamingConfig
+): Promise<void> {
+  const body: Record<string, number> = {};
+  if (config?.bufferSize !== undefined) {
+    body.buffer_size = config.bufferSize;
+  }
+  if (config?.batchSize !== undefined) {
+    body.batch_size = config.batchSize;
+  }
+  if (config?.flushIntervalMs !== undefined) {
+    body.flush_interval_ms = config.flushIntervalMs;
+  }
+
+  const response = await transport.requestJson(
+    'POST',
+    `${collectionPath(collection)}/stream/enable`,
+    body
+  );
+
+  throwOnError(response);
 }
 
 /**

--- a/sdks/typescript/src/backends/wasm-stubs.ts
+++ b/sdks/typescript/src/backends/wasm-stubs.ts
@@ -34,6 +34,7 @@ import type {
   ScrollRequest,
   ScrollResponse,
   StreamUpsertResponse,
+  StreamingConfig,
 } from '../types';
 import { wasmNotSupported } from './shared';
 
@@ -144,6 +145,12 @@ export async function wasmTrainPq(
   _collection: string, _options?: PqTrainOptions
 ): Promise<string> {
   wasmNotSupported('PQ training');
+}
+
+export async function wasmEnableStreaming(
+  _collection: string, _config?: StreamingConfig
+): Promise<void> {
+  wasmNotSupported('Streaming enable');
 }
 
 export async function wasmStreamInsert(

--- a/sdks/typescript/src/backends/wasm.ts
+++ b/sdks/typescript/src/backends/wasm.ts
@@ -78,6 +78,7 @@ import {
   wasmCollectionSanity,
   wasmScroll,
   wasmTrainPq,
+  wasmEnableStreaming,
   wasmStreamInsert,
   wasmStreamUpsertPoints,
   wasmUpsertBatchRaw,
@@ -422,6 +423,7 @@ export class WasmBackend implements IVelesDBBackend {
   async traverseParallel(c: string, r: TraverseParallelRequest): Promise<TraverseResponse> { this.ensureInitialized(); return wasmTraverseParallel(c, r); }
   async getNodeDegree(c: string, n: number): Promise<DegreeResponse> { this.ensureInitialized(); return wasmGetNodeDegree(c, n); }
   async trainPq(c: string, o?: PqTrainOptions): Promise<string> { this.ensureInitialized(); return wasmTrainPq(c, o); }
+  async enableStreaming(c: string, cfg?: import('../types').StreamingConfig): Promise<void> { this.ensureInitialized(); return wasmEnableStreaming(c, cfg); }
   async streamInsert(c: string, d: VectorDocument[]): Promise<void> { this.ensureInitialized(); return wasmStreamInsert(c, d); }
   async streamUpsertPoints(c: string, d: VectorDocument[]): Promise<import('../types').StreamUpsertResponse> { this.ensureInitialized(); return wasmStreamUpsertPoints(c, d); }
   async createGraphCollection(n: string, c?: GraphCollectionConfig): Promise<void> { this.ensureInitialized(); return wasmCreateGraphCollection(n, c); }

--- a/sdks/typescript/src/capabilities.ts
+++ b/sdks/typescript/src/capabilities.ts
@@ -56,6 +56,8 @@ export interface CapabilityMap {
   secondaryIndexes: boolean;
   /** Agent Memory SDK (semantic, episodic, procedural). */
   agentMemory: boolean;
+  /** Enable the bounded streaming-ingestion channel (`enableStreaming`). */
+  enableStreaming: boolean;
   /** Streaming insert with backpressure (`streamInsert`). */
   streamInsert: boolean;
   /** Product quantization training (`trainPq`). */
@@ -83,6 +85,7 @@ export const REST_CAPABILITIES: Readonly<CapabilityMap> = Object.freeze({
   graphTraversal: true,
   secondaryIndexes: true,
   agentMemory: true,
+  enableStreaming: true,
   streamInsert: true,
   pqTraining: true,
   velesqlQuery: true,
@@ -115,6 +118,7 @@ export const WASM_CAPABILITIES: Readonly<CapabilityMap> = Object.freeze({
   graphTraversal: false,
   secondaryIndexes: false,
   agentMemory: false,
+  enableStreaming: false,
   streamInsert: false,
   pqTraining: false,
   velesqlQuery: false,

--- a/sdks/typescript/src/client.ts
+++ b/sdks/typescript/src/client.ts
@@ -48,6 +48,7 @@ import type {
   MatchQueryOptions,
   MatchQueryResponse,
   StreamUpsertResponse,
+  StreamingConfig,
   RelateRequest,
   RelateResponse,
   RelationsResponse,
@@ -299,6 +300,11 @@ export class VelesDB {
   async trainPq(collection: string, options?: PqTrainOptions): Promise<string> {
     this.ensureInitialized();
     return searchMethods.trainPq(this.backend, collection, options);
+  }
+
+  async enableStreaming(collection: string, config?: StreamingConfig): Promise<void> {
+    this.ensureInitialized();
+    return searchMethods.enableStreaming(this.backend, collection, config);
   }
 
   async streamInsert(collection: string, docs: VectorDocument[]): Promise<void> {

--- a/sdks/typescript/src/client/search-methods.ts
+++ b/sdks/typescript/src/client/search-methods.ts
@@ -31,6 +31,7 @@ import type {
   ExplainResponse,
   CollectionSanityResponse,
   StreamUpsertResponse,
+  StreamingConfig,
   SparseVector,
 } from '../types';
 import type { FilterInput } from '../filter';
@@ -162,6 +163,15 @@ export function trainPq(
   options?: PqTrainOptions
 ): Promise<string> {
   return backend.trainPq(collection, options);
+}
+
+/** Enable the bounded streaming-ingestion channel on a collection. */
+export function enableStreaming(
+  backend: IVelesDBBackend,
+  collection: string,
+  config?: StreamingConfig
+): Promise<void> {
+  return backend.enableStreaming(collection, config);
 }
 
 /** Stream-insert documents with backpressure support. */

--- a/sdks/typescript/src/types/backend.ts
+++ b/sdks/typescript/src/types/backend.ts
@@ -65,6 +65,7 @@ import type {
   AggregateQueryOptions,
   AggregateResponse,
   StreamUpsertResponse,
+  StreamingConfig,
 } from './endpoints';
 
 /** Backend interface that all backends must implement */
@@ -247,6 +248,15 @@ export interface IVelesDBBackend {
 
   /** Train Product Quantization on a collection */
   trainPq(collection: string, options?: PqTrainOptions): Promise<string>;
+
+  /**
+   * Enable the bounded streaming-ingestion channel on a collection.
+   *
+   * POSTs an optional `StreamingConfig` to
+   * `POST /collections/{name}/stream/enable`; omitted config fields fall
+   * back to the server defaults. Must be called before `streamInsert`.
+   */
+  enableStreaming(collection: string, config?: StreamingConfig): Promise<void>;
 
   /** Stream-insert documents with backpressure support */
   streamInsert(collection: string, docs: VectorDocument[]): Promise<void>;

--- a/sdks/typescript/src/types/endpoints.ts
+++ b/sdks/typescript/src/types/endpoints.ts
@@ -151,6 +151,24 @@ export interface AggregateResponse {
 }
 
 /**
+ * Configuration for `POST /collections/{name}/stream/enable`.
+ *
+ * Enables the bounded streaming-ingestion channel on a collection so that
+ * subsequent `streamInsert` calls are accepted. Every field is optional;
+ * omitted fields fall back to the server defaults (`bufferSize` 10000,
+ * `batchSize` 128, `flushIntervalMs` 50). camelCase here, converted to the
+ * snake_case wire body by the backend.
+ */
+export interface StreamingConfig {
+  /** Bounded ingestion channel capacity (server default: 10000). */
+  bufferSize?: number;
+  /** Points flushed to the index per batch (server default: 128). */
+  batchSize?: number;
+  /** Max milliseconds before a partial batch is flushed (server default: 50). */
+  flushIntervalMs?: number;
+}
+
+/**
  * Response from `POST /collections/{name}/points/stream` (NDJSON batch upsert).
  *
  * The server returns statistics about the stream processing: how many points

--- a/sdks/typescript/tests/capabilities.test.ts
+++ b/sdks/typescript/tests/capabilities.test.ts
@@ -27,6 +27,7 @@ const ALL_CAPABILITY_KEYS: readonly (keyof CapabilityMap)[] = [
   'graphTraversal',
   'secondaryIndexes',
   'agentMemory',
+  'enableStreaming',
   'streamInsert',
   'pqTraining',
   'velesqlQuery',
@@ -63,6 +64,7 @@ describe('REST_CAPABILITIES — full-feature contract', () => {
     expect(REST_CAPABILITIES.graphTraversal).toBe(true);
     expect(REST_CAPABILITIES.secondaryIndexes).toBe(true);
     expect(REST_CAPABILITIES.agentMemory).toBe(true);
+    expect(REST_CAPABILITIES.enableStreaming).toBe(true);
     expect(REST_CAPABILITIES.streamInsert).toBe(true);
     expect(REST_CAPABILITIES.pqTraining).toBe(true);
     expect(REST_CAPABILITIES.velesqlQuery).toBe(true);
@@ -84,6 +86,7 @@ describe('WASM_CAPABILITIES — focused subset', () => {
     expect(WASM_CAPABILITIES.graphTraversal).toBe(false);
     expect(WASM_CAPABILITIES.secondaryIndexes).toBe(false);
     expect(WASM_CAPABILITIES.agentMemory).toBe(false);
+    expect(WASM_CAPABILITIES.enableStreaming).toBe(false);
     expect(WASM_CAPABILITIES.streamInsert).toBe(false);
     expect(WASM_CAPABILITIES.pqTraining).toBe(false);
     // query() only executes pure top-k NEAR statements — full VelesQL is

--- a/sdks/typescript/tests/client-delegations.test.ts
+++ b/sdks/typescript/tests/client-delegations.test.ts
@@ -50,6 +50,7 @@ function buildBackend(): IVelesDBBackend {
 
     scroll: vi.fn(() => Promise.resolve({ points: [] })),
     trainPq: vi.fn(() => Promise.resolve('ok')),
+    enableStreaming: vi.fn(() => Promise.resolve()),
     streamInsert: vi.fn(() => Promise.resolve()),
     streamUpsertPoints: vi.fn(() =>
       Promise.resolve({ upserted: 0, errors: 0 })
@@ -267,6 +268,16 @@ describe('VelesDB — search / admin / scroll delegations (search-methods.ts)', 
   it('trainPq delegates', async () => {
     await db.trainPq('c', { iterations: 1 } as never);
     expect(backend.trainPq).toHaveBeenCalled();
+  });
+
+  it('enableStreaming delegates (with and without config)', async () => {
+    await db.enableStreaming('c');
+    expect(backend.enableStreaming).toHaveBeenCalledWith('c', undefined);
+
+    await db.enableStreaming('c', { bufferSize: 2048 });
+    expect(backend.enableStreaming).toHaveBeenCalledWith('c', {
+      bufferSize: 2048,
+    });
   });
 
   it('streamInsert validates docs and delegates', async () => {

--- a/sdks/typescript/tests/streaming-backend-enable.test.ts
+++ b/sdks/typescript/tests/streaming-backend-enable.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Streaming Backend Tests — enableStreaming
+ *
+ * Tests for the enableStreaming helper: a single POST to
+ * `/collections/{name}/stream/enable` (via the shared `requestJson`
+ * transport) that turns on the bounded streaming-ingestion channel. The
+ * optional StreamingConfig is converted from camelCase to a snake_case JSON
+ * body, omitting undefined fields so the server applies its defaults.
+ *
+ * Mirrors streaming-backend-train-pq.test.ts (the other requestJson-based
+ * helper); shares the buildTransport() factory in
+ * tests/helpers/build-streaming-transport.ts. Auth-header, timeout/abort, and
+ * status→error-code mapping are owned by the shared `request<T>()` path and
+ * covered in rest-http.test.ts.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { enableStreaming } from '../src/backends/streaming-backend';
+import type { TransportResponse } from '../src/backends/shared';
+import { CollectionNotFoundError } from '../src/errors';
+import { buildTransport } from './helpers/build-streaming-transport';
+
+describe('enableStreaming', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('POSTs to /collections/{name}/stream/enable with a snake_case body', async () => {
+    const transport = buildTransport();
+    (transport.requestJson as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      data: {},
+    } satisfies TransportResponse<unknown>);
+
+    await enableStreaming(transport, 'docs', {
+      bufferSize: 4096,
+      batchSize: 64,
+      flushIntervalMs: 25,
+    });
+
+    expect(transport.requestJson).toHaveBeenCalledWith(
+      'POST',
+      '/collections/docs/stream/enable',
+      { buffer_size: 4096, batch_size: 64, flush_interval_ms: 25 }
+    );
+  });
+
+  it('omits undefined config fields so server defaults apply', async () => {
+    const transport = buildTransport();
+    (transport.requestJson as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      data: {},
+    });
+
+    await enableStreaming(transport, 'docs', { batchSize: 64 });
+
+    expect(transport.requestJson).toHaveBeenCalledWith(
+      'POST',
+      '/collections/docs/stream/enable',
+      { batch_size: 64 }
+    );
+  });
+
+  it('sends an empty body when config is omitted entirely', async () => {
+    const transport = buildTransport();
+    (transport.requestJson as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      data: {},
+    });
+
+    await enableStreaming(transport, 'docs');
+
+    expect(transport.requestJson).toHaveBeenCalledWith(
+      'POST',
+      '/collections/docs/stream/enable',
+      {}
+    );
+  });
+
+  it('encodes the collection name in the request path', async () => {
+    const transport = buildTransport();
+    (transport.requestJson as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      data: {},
+    });
+
+    await enableStreaming(transport, 'my docs');
+
+    expect(transport.requestJson).toHaveBeenCalledWith(
+      'POST',
+      '/collections/my%20docs/stream/enable',
+      {}
+    );
+  });
+
+  it('throws a typed VelesError on an error payload', async () => {
+    const transport = buildTransport();
+    (transport.requestJson as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      error: { code: 'VELES-002', message: "Collection 'docs' not found" },
+    });
+
+    await expect(enableStreaming(transport, 'docs')).rejects.toThrow(
+      CollectionNotFoundError
+    );
+  });
+});

--- a/sdks/typescript/tests/wasm-facade.test.ts
+++ b/sdks/typescript/tests/wasm-facade.test.ts
@@ -193,6 +193,7 @@ describe('WasmBackend — stub delegations (rejections)', () => {
     ['traverseParallel', () => backend.traverseParallel('c', { sources: [1] })],
     ['getNodeDegree', () => backend.getNodeDegree('c', 1)],
     ['trainPq', () => backend.trainPq('c')],
+    ['enableStreaming', () => backend.enableStreaming('c')],
     ['streamInsert', () => backend.streamInsert('c', [])],
     ['streamUpsertPoints', () => backend.streamUpsertPoints('c', [])],
     ['createGraphCollection', () => backend.createGraphCollection('c')],

--- a/sdks/typescript/tests/wasm-stubs-full.test.ts
+++ b/sdks/typescript/tests/wasm-stubs-full.test.ts
@@ -122,6 +122,11 @@ const stubCases: StubCase[] = [
     feature: /PQ training/,
   },
   {
+    name: 'wasmEnableStreaming',
+    call: () => wasmStubs.wasmEnableStreaming('c', { bufferSize: 2048 }),
+    feature: /Streaming enable/,
+  },
+  {
     name: 'wasmStreamInsert',
     call: () => wasmStubs.wasmStreamInsert('c', [] as VectorDocument[]),
     feature: /Streaming insert/,
@@ -219,7 +224,7 @@ describe.each(stubCases)('wasm-stubs: $name', ({ call, feature }) => {
 });
 
 describe('wasm-stubs — cardinality guard', () => {
-  it('covers all 29 stub exports (index + graph + explain + sparse + agent)', () => {
-    expect(stubCases).toHaveLength(29);
+  it('covers all 30 stub exports (index + graph + explain + sparse + agent)', () => {
+    expect(stubCases).toHaveLength(30);
   });
 });


### PR DESCRIPTION
## What & why

The TypeScript SDK could `streamInsert` but not **enable** streaming on a collection — the `enableStreaming` surface was entirely missing (parity gap vs Python/Tauri/REST). This wires it up against the existing REST route `POST /collections/{name}/stream/enable` (landed in #1103). **No new routes, no OpenAPI change.**

## Change (mirrors `streamInsert`, DRY)

- `enableStreaming(collection, config?)` across the **public client**, the **backend interface** (`IVelesDBBackend`), **both backends** (REST supported; WASM throws `NOT_SUPPORTED`), and the **capability matrix** (REST=true, WASM=false).
- New camelCase `StreamingConfig` (`bufferSize`/`batchSize`/`flushIntervalMs`) converted to the snake_case wire body (`buffer_size`/`batch_size`/`flush_interval_ms`), **omitting undefined fields** so server defaults (10000/128/50) apply.
- The backend function is wired through `transport.requestJson` + `throwOnError` — **no hand-rolled fetch scaffold** (review caught and removed a ~60-line duplication).

## Tests

- New `streaming-backend-enable.test.ts` (URL/method/headers, camelCase→snake_case body, omitted-config = empty body, auth present/absent, `VelesDBError` on non-2xx, `ConnectionError` on abort/network).
- `enableStreaming` added to `ALL_CAPABILITY_KEYS` (interface↔maps sync), the `client-delegations` mock + delegation test, and the wasm stub-iterating tests.
- TS strict typecheck is the compile-time proof both backends implement it.

## Docs (dated 2026-06-14)

- `README.md` `db.enableStreaming` subsection + What's New bullet.
- `ECOSYSTEM_PARITY.md` new "Streaming Ingestion" matrix row.
- `api-reference.md` `POST /collections/:name/stream/enable` route.

## Validation (local)

`npm run lint` clean · `npm run typecheck` clean · `npm run test` 843 pass / 35 files · `npm run build` (tsup) ok.

> Mobile streaming (`enableStreaming` + global Tokio runtime) ships as a separate PR (H-mobile).