### PR TITLE
feat(mobile): add enableStreaming + streamInsert to the mobile SDK

### DIFF
--- a/crates/velesdb-mobile/README.md
+++ b/crates/velesdb-mobile/README.md
@@ -1,5 +1,7 @@
 # VelesDB Mobile
 
+_Last updated: 2026-06-14._
+
 Native bindings for **iOS** (Swift) and **Android** (Kotlin) via [UniFFI](https://mozilla.github.io/uniffi-rs/).
 
 VelesDB Mobile brings microsecond vector search to edge devices - perfect for on-device AI, semantic search, and RAG applications.
@@ -173,6 +175,8 @@ cargo run -p velesdb-mobile --bin uniffi-bindgen -- generate \
 | `upsert(point)` | Inserts or updates a single point |
 | `upsertBatch(points)` | Batch insert/update (faster for bulk operations) |
 | `upsertWithSparse(point, sparseVector)` | Inserts a point with an associated sparse vector |
+| `enableStreaming(config)` | Enables streaming ingestion (config optional; defaults bufferSize=10000, batchSize=128, flushIntervalMs=50) |
+| `streamInsert(points)` | Queues a batch of points for streaming ingestion; returns the count queued |
 | `delete(id)` | Deletes a point by ID |
 | `get(ids)` | Gets points by their IDs (missing IDs silently skipped) |
 | `getById(id)` | Gets a single point by ID (returns nil/null if not found) |

--- a/crates/velesdb-mobile/src/collection.rs
+++ b/crates/velesdb-mobile/src/collection.rs
@@ -4,8 +4,8 @@ use velesdb_core::VectorCollection as CoreCollection;
 
 use crate::types::{
     IndividualSearchRequest, MobileAdvancedConfig, MobileCollectionDiagnostics,
-    MobileCollectionStats, MobileIndexInfo, MobileQueryLimits, SearchQuality, SearchResult,
-    VelesError, VelesPoint,
+    MobileCollectionStats, MobileIndexInfo, MobileQueryLimits, MobileStreamingConfig,
+    SearchQuality, SearchResult, VelesError, VelesPoint,
 };
 
 // ============================================================================
@@ -85,15 +85,7 @@ impl VelesCollection {
     ///
     /// * `point` - The point to upsert
     pub fn upsert(&self, point: VelesPoint) -> Result<(), VelesError> {
-        let payload = point
-            .payload
-            .map(|s| serde_json::from_str(&s))
-            .transpose()
-            .map_err(|e| VelesError::Database {
-                message: format!("Invalid JSON payload: {e}"),
-            })?;
-
-        let core_point = velesdb_core::Point::new(point.id, point.vector, payload);
+        let core_point = parse_point(point)?;
         self.inner.upsert(vec![core_point])?;
         Ok(())
     }
@@ -104,19 +96,8 @@ impl VelesCollection {
     ///
     /// * `points` - Points to upsert
     pub fn upsert_batch(&self, points: Vec<VelesPoint>) -> Result<(), VelesError> {
-        let core_points: Result<Vec<velesdb_core::Point>, VelesError> = points
-            .into_iter()
-            .map(|p| {
-                let payload = p
-                    .payload
-                    .map(|s| serde_json::from_str(&s))
-                    .transpose()
-                    .map_err(|e| VelesError::Database {
-                        message: format!("Invalid JSON payload: {e}"),
-                    })?;
-                Ok(velesdb_core::Point::new(p.id, p.vector, payload))
-            })
-            .collect();
+        let core_points: Result<Vec<velesdb_core::Point>, VelesError> =
+            points.into_iter().map(parse_point).collect();
 
         self.inner.upsert(core_points?)?;
         Ok(())
@@ -487,6 +468,56 @@ impl VelesCollection {
 
     // multi_query_search and multi_query_search_with_filter are in collection_sparse.rs
 
+    /// Enables streaming ingestion on this collection.
+    ///
+    /// Must be called before [`stream_insert`](Self::stream_insert); otherwise
+    /// stream inserts fail with "not configured". Calling it again replaces the
+    /// existing ingester.
+    ///
+    /// # Arguments
+    ///
+    /// * `config` - Optional [`MobileStreamingConfig`]. `None` uses the engine
+    ///   defaults (`buffer_size=10000`, `batch_size=128`, `flush_interval_ms=50`).
+    pub fn enable_streaming(
+        &self,
+        config: Option<MobileStreamingConfig>,
+    ) -> Result<(), VelesError> {
+        let core_config = config.map_or_else(velesdb_core::StreamingConfig::default, |c| {
+            velesdb_core::StreamingConfig {
+                buffer_size: usize::try_from(c.buffer_size).unwrap_or(usize::MAX),
+                batch_size: usize::try_from(c.batch_size).unwrap_or(usize::MAX),
+                flush_interval_ms: c.flush_interval_ms,
+            }
+        });
+        // Spawning the drain task needs an ambient runtime; enter the shared
+        // streaming runtime so the task is scheduled on it and survives this call.
+        let rt = crate::streaming_runtime::stream_runtime()?;
+        let _guard = rt.enter();
+        self.inner.enable_streaming(core_config);
+        Ok(())
+    }
+
+    /// Queues a batch of points for streaming ingestion.
+    ///
+    /// Requires [`enable_streaming`](Self::enable_streaming) to have been called
+    /// first. Returns the number of points successfully queued.
+    ///
+    /// # Arguments
+    ///
+    /// * `points` - Points to queue for ingestion
+    pub fn stream_insert(&self, points: Vec<VelesPoint>) -> Result<u64, VelesError> {
+        let core_points: Result<Vec<velesdb_core::Point>, VelesError> =
+            points.into_iter().map(parse_point).collect();
+
+        let queued =
+            self.inner
+                .stream_insert_batch(core_points?)
+                .map_err(|e| VelesError::Database {
+                    message: format!("Stream insert failed (buffer full or not configured): {e}"),
+                })?;
+        Ok(u64::try_from(queued).unwrap_or(u64::MAX))
+    }
+
     /// Flushes collection data to durable storage.
     pub fn flush(&self) -> Result<(), VelesError> {
         self.inner.flush()?;
@@ -589,6 +620,18 @@ impl VelesCollection {
     pub fn diagnostics(&self) -> MobileCollectionDiagnostics {
         self.inner.diagnostics().into()
     }
+}
+
+/// Converts a [`VelesPoint`] into a core point, parsing the optional JSON payload.
+fn parse_point(p: VelesPoint) -> Result<velesdb_core::Point, VelesError> {
+    let payload = p
+        .payload
+        .map(|s| serde_json::from_str(&s))
+        .transpose()
+        .map_err(|e| VelesError::Database {
+            message: format!("Invalid JSON payload: {e}"),
+        })?;
+    Ok(velesdb_core::Point::new(p.id, p.vector, payload))
 }
 
 // Sparse vector operations are in collection_sparse.rs

--- a/crates/velesdb-mobile/src/lib.rs
+++ b/crates/velesdb-mobile/src/lib.rs
@@ -52,6 +52,7 @@ mod collection;
 mod collection_sparse;
 mod graph;
 mod query;
+mod streaming_runtime;
 mod types;
 
 pub use agent::{SemanticResult, VelesSemanticMemory};
@@ -61,8 +62,9 @@ pub use query::{QueryResult, QueryResultKind, QueryResultRow};
 pub use types::{
     DistanceMetric, FusionStrategy, IndividualSearchRequest, MobileAdvancedConfig,
     MobileAsyncIndexBuilderConfig, MobileCollectionDiagnostics, MobileCollectionStats,
-    MobileDeferredIndexerConfig, MobileIndexInfo, MobileQueryLimits, PqTrainConfig, SearchQuality,
-    SearchResult, StorageMode, VelesError, VelesPoint, VelesSparseVector,
+    MobileDeferredIndexerConfig, MobileIndexInfo, MobileQueryLimits, MobileStreamingConfig,
+    PqTrainConfig, SearchQuality, SearchResult, StorageMode, VelesError, VelesPoint,
+    VelesSparseVector,
 };
 
 use std::sync::Arc;

--- a/crates/velesdb-mobile/src/lib_tests.rs
+++ b/crates/velesdb-mobile/src/lib_tests.rs
@@ -1125,3 +1125,44 @@ fn test_collection_analyze_and_get_stats() {
     assert!(snapshot.total_points >= 2);
     assert!(snapshot.field_stats_count >= 1 || snapshot.column_stats_count >= 1);
 }
+
+// =========================================================================
+// Streaming ingestion tests
+// =========================================================================
+
+#[test]
+fn test_streaming_enable_and_insert_roundtrip() {
+    let tmp = TempDir::new().unwrap();
+    let path = tmp.path().to_str().unwrap().to_string();
+
+    let db = VelesDatabase::open(path).unwrap();
+    db.create_collection("stream_rt".to_string(), 4, DistanceMetric::Cosine)
+        .unwrap();
+    let col = db.get_collection("stream_rt".to_string()).unwrap().unwrap();
+
+    // enable with engine defaults
+    col.enable_streaming(None).unwrap();
+    // re-enable with an explicit config (replaces the ingester)
+    col.enable_streaming(Some(MobileStreamingConfig {
+        buffer_size: 256,
+        batch_size: 32,
+        flush_interval_ms: 10,
+    }))
+    .unwrap();
+
+    let queued = col
+        .stream_insert(vec![
+            VelesPoint {
+                id: 1,
+                vector: vec![1.0, 0.0, 0.0, 0.0],
+                payload: Some(r#"{"k":"v"}"#.to_string()),
+            },
+            VelesPoint {
+                id: 2,
+                vector: vec![0.0, 1.0, 0.0, 0.0],
+                payload: None,
+            },
+        ])
+        .unwrap();
+    assert_eq!(queued, 2);
+}

--- a/crates/velesdb-mobile/src/streaming_runtime.rs
+++ b/crates/velesdb-mobile/src/streaming_runtime.rs
@@ -1,0 +1,44 @@
+//! Shared Tokio runtime for streaming ingestion.
+//!
+//! [`VelesCollection::enable_streaming`](crate::VelesCollection) creates a core
+//! `StreamIngester` whose background drain task is launched with
+//! `tokio::spawn`, which requires an ambient Tokio runtime. A mobile host has
+//! none, so the bindings host a single shared multi-thread runtime here.
+//! Entering it around `enable_streaming` lets the drain task be scheduled; the
+//! task then lives on this runtime — which is intentionally never shut down —
+//! for the lifetime of the process.
+
+use std::sync::OnceLock;
+
+use tokio::runtime::Runtime;
+
+use crate::types::VelesError;
+
+/// Returns the process-wide streaming runtime, building it on first use.
+///
+/// Built lazily so loading the library never spawns runtime threads; they
+/// appear only once streaming is actually enabled. Initialization uses
+/// first-writer-wins via [`OnceLock::set`], so the build races at most with
+/// itself.
+///
+/// # Errors
+///
+/// Returns [`VelesError::Database`] if the Tokio runtime cannot be created.
+pub(crate) fn stream_runtime() -> Result<&'static Runtime, VelesError> {
+    static RUNTIME: OnceLock<Runtime> = OnceLock::new();
+    if let Some(rt) = RUNTIME.get() {
+        return Ok(rt);
+    }
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .thread_name("velesdb-stream")
+        .build()
+        .map_err(|e| VelesError::Database {
+            message: format!("failed to start streaming runtime: {e}"),
+        })?;
+    // First writer wins; a late writer's runtime is dropped immediately.
+    let _ = RUNTIME.set(rt);
+    RUNTIME.get().ok_or_else(|| VelesError::Database {
+        message: "streaming runtime unavailable".to_string(),
+    })
+}

--- a/crates/velesdb-mobile/src/types.rs
+++ b/crates/velesdb-mobile/src/types.rs
@@ -480,6 +480,22 @@ impl From<MobileAsyncIndexBuilderConfig>
     }
 }
 
+/// Configuration for streaming ingestion on a collection.
+///
+/// FFI mirror of [`velesdb_core::StreamingConfig`]. Fields are `u64` for
+/// portable mapping to Swift/Kotlin; they are narrowed to `usize`/`u64` when
+/// converted to the core type. Engine defaults are `buffer_size=10000`,
+/// `batch_size=128`, `flush_interval_ms=50`.
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct MobileStreamingConfig {
+    /// Capacity of the bounded channel (backpressure threshold). Default 10000.
+    pub buffer_size: u64,
+    /// Number of points that trigger an immediate micro-batch flush. Default 128.
+    pub batch_size: u64,
+    /// Maximum time (ms) before a partial batch is flushed. Default 50.
+    pub flush_interval_ms: u64,
+}
+
 /// Post-creation overrides for advanced collection configuration.
 ///
 /// Each field uses `Some` to set the value and `None` to leave it


### PR DESCRIPTION
## What & why

The mobile UniFFI SDK had **no streaming surface at all** (`grep -i stream` on `crates/velesdb-mobile/src` → zero hits) while Core/Server/Python/Tauri/TS all expose it. This adds it, mirroring the **Python** pattern (mobile, like Python, has no ambient Tokio runtime — unlike Tauri).

## Change

- **New `streaming_runtime.rs`** — process-wide shared multi-thread Tokio runtime via `OnceLock`, first-writer-wins, returns `Result<&'static Runtime, VelesError>` (no `.unwrap()/.expect()`). Ported from the Python `streaming_runtime.rs`.
- **`MobileStreamingConfig`** `uniffi::Record` (`buffer_size`/`batch_size`/`flush_interval_ms` as `u64`, documented engine defaults 10000/128/50 — matches the core `StreamingConfig` SSOT).
- **`VelesCollection::enable_streaming(config?)`** — builds the core config, enters the shared runtime (`let _guard = rt.enter()`) before `inner.enable_streaming` so the spawned drain task survives.
- **`VelesCollection::stream_insert(points)`** — feeds the channel (without it `enable_streaming` is inert); maps `BackpressureError` → `VelesError::Database`.
- **DRY**: payload parsing centralized in one `parse_point` helper, also adopted by the pre-existing `upsert`/`upsert_batch` (removed 2 inline copies).

## Tests & docs

- `lib_tests.rs::test_streaming_enable_and_insert_roundtrip` (enable None + Some + a `stream_insert` round-trip asserting the queued count).
- `README.md` method table + dated (2026-06-14).

## Validation (local)

- `cargo clippy -p velesdb-mobile --all-targets -- -D warnings -D clippy::pedantic` — clean
- `cargo check -p velesdb-mobile` (the propagation-guard CI gate) — compiles
- `cargo test -p velesdb-mobile -- --test-threads=1` — 103 pass
- `check_prod_unwraps.py` — pass; all fns CC ≤ 8 / NLOC ≤ 50

## Note on `--no-default-features`

`cargo check -p velesdb-mobile --no-default-features` does not compile — this is **pre-existing** (25 errors on the prior `develop` tip): the entire mobile API depends on `velesdb-core/default` (persistence), and the crate has no `persistence` feature of its own. It is not a CI gate for this crate. The new methods therefore are not `cfg`-gated, matching the Python binding they mirror.