### PR TITLE
feat(python,server): expose DatabaseObserver lifecycle callbacks to Python + server e2e

### DIFF
--- a/crates/velesdb-python/python/velesdb/__init__.py
+++ b/crates/velesdb-python/python/velesdb/__init__.py
@@ -595,8 +595,31 @@ class Database:
         self,
         path: str,
         config: VelesConfigOptions | None = None,
+        observer: Any | None = None,
     ) -> None:
-        self._inner = _RawDatabase(path, config)
+        """Open or create a database.
+
+        Args:
+            path: Directory path for database storage.
+            config: Optional :class:`VelesConfigOptions` applied at open time.
+            observer: Optional callable invoked on collection lifecycle
+                events as ``observer(event, **fields)``. ``event`` is one of
+                ``"collection_created"`` (fields ``name``, ``kind``, where
+                ``kind`` is ``"vector"``/``"metadata"``/``"graph"``/``"unknown"``),
+                ``"collection_deleted"`` (``name``), ``"upsert"``
+                (``collection``, ``point_count``), or ``"query"``
+                (``collection``, ``duration_us``). The observer is immutable
+                once the database is opened and cannot veto operations;
+                exceptions it raises are swallowed.
+
+                Caveat: in the embedded Python SDK only
+                ``collection_created`` / ``collection_deleted`` fire, as they
+                originate in the core engine. ``upsert`` / ``query`` are
+                emitted only by callers that explicitly call
+                ``notify_upsert`` / ``notify_query`` — in this ecosystem that
+                is the REST server, not embedded usage.
+        """
+        self._inner = _RawDatabase(path, config, observer)
 
     def __getattr__(self, name: str) -> Any:
         return getattr(self._inner, name)

--- a/crates/velesdb-python/src/database.rs
+++ b/crates/velesdb-python/src/database.rs
@@ -9,11 +9,12 @@ use crate::agent;
 use crate::collection::Collection;
 use crate::collection_helpers::core_err;
 use crate::graph_collection::{PyGraphCollection, PyGraphSchema};
+use crate::observer::PyObserver;
 use crate::options::{AutoReindexOptions, HnswOptions, VelesConfigOptions};
 use crate::utils::{self, parse_metric, parse_storage_mode};
 
 use velesdb_core::collection::auto_reindex::AutoReindexManager;
-use velesdb_core::{CollectionType, Database as CoreDatabase, GraphSchema};
+use velesdb_core::{CollectionType, Database as CoreDatabase, DatabaseObserver, GraphSchema};
 
 /// The full set of guardrail fields. `update_guardrails` is an explicit full
 /// replacement (matching the Mobile/Tauri typed structs), so the supplied dict
@@ -48,6 +49,24 @@ fn validate_guardrail_keys(obj: &serde_json::Map<String, serde_json::Value>) -> 
         }
     }
     Ok(())
+}
+
+/// Opens the core database, branching across the optional config and observer.
+///
+/// Extracted from [`Database::new`] so the constructor stays within the
+/// cyclomatic-complexity budget: the four config × observer combinations would
+/// otherwise inflate `new`. Runs off the GIL (called inside `allow_threads`).
+fn open_core(
+    path: &std::path::Path,
+    config: Option<velesdb_core::config::VelesConfig>,
+    observer: Option<Arc<dyn DatabaseObserver>>,
+) -> velesdb_core::Result<CoreDatabase> {
+    match (config, observer) {
+        (Some(cfg), Some(obs)) => CoreDatabase::open_with_observer_and_config(path, obs, cfg),
+        (Some(cfg), None) => CoreDatabase::open_with_config(path, cfg),
+        (None, Some(obs)) => CoreDatabase::open_with_observer(path, obs),
+        (None, None) => CoreDatabase::open(path),
+    }
 }
 
 /// VelesDB Database - the main entry point for interacting with VelesDB.
@@ -91,6 +110,22 @@ impl Database {
     ///     path: Directory path for database storage.
     ///     config: Optional typed configuration (limits, etc.) applied
     ///         at open time. See :class:`VelesConfigOptions`.
+    ///     observer: Optional callable invoked on collection lifecycle
+    ///         events. Called as ``observer(event, **fields)`` where
+    ///         ``event`` is one of ``"collection_created"``,
+    ///         ``"collection_deleted"``, ``"upsert"``, or ``"query"``:
+    ///
+    ///         - ``collection_created`` → ``name``, ``kind``
+    ///           (``"vector"``/``"metadata"``/``"graph"``/``"unknown"``)
+    ///         - ``collection_deleted`` → ``name``
+    ///         - ``upsert`` → ``collection``, ``point_count``
+    ///         - ``query`` → ``collection``, ``duration_us``
+    ///
+    ///         The observer is immutable once the database is opened
+    ///         (there is no post-open setter). Exceptions raised inside
+    ///         the callback are swallowed so they never break a core
+    ///         operation. This is a notify-only hook — it cannot veto
+    ///         operations.
     ///
     /// Returns:
     ///     Database instance
@@ -101,9 +136,20 @@ impl Database {
     ///     >>> from velesdb import VelesConfigOptions, LimitsOptions
     ///     >>> cfg = VelesConfigOptions(limits=LimitsOptions(max_collections=50))
     ///     >>> db = velesdb.Database("./tenant1", config=cfg)
+    ///     >>> # With a lifecycle observer:
+    ///     >>> events = []
+    ///     >>> db = velesdb.Database(
+    ///     ...     "./audited",
+    ///     ...     observer=lambda event, **f: events.append((event, f)),
+    ///     ... )
     #[new]
-    #[pyo3(signature = (path, config = None))]
-    fn new(py: Python<'_>, path: &str, config: Option<VelesConfigOptions>) -> PyResult<Self> {
+    #[pyo3(signature = (path, config = None, observer = None))]
+    fn new(
+        py: Python<'_>,
+        path: &str,
+        config: Option<VelesConfigOptions>,
+        observer: Option<Py<PyAny>>,
+    ) -> PyResult<Self> {
         // Open the database off the GIL. Opening walks the WAL, rebuilds
         // any in-memory state, and mmaps vector/edge files — on a multi-
         // million-vector directory this easily reaches multi-second
@@ -111,13 +157,16 @@ impl Database {
         // Python thread. PyO3 ≥0.20 allows `py: Python<'_>` as the first
         // parameter of a `#[new]` constructor, which is exactly what we
         // need to call `allow_threads` here.
+        //
+        // The observer's `Py<PyAny>` is `Send`, so it can be captured by the
+        // `'static` open closure; building the `PyObserver` stays off-GIL.
         let path_buf = PathBuf::from(path);
         let path_clone = path_buf.clone();
+        let core_config = config.map(|cfg| cfg.to_core());
+        let core_observer: Option<Arc<dyn DatabaseObserver>> =
+            observer.map(|cb| Arc::new(PyObserver::new(cb)) as Arc<dyn DatabaseObserver>);
         let db = py
-            .allow_threads(move || match config {
-                Some(cfg) => CoreDatabase::open_with_config(&path_clone, cfg.to_core()),
-                None => CoreDatabase::open(&path_clone),
-            })
+            .allow_threads(move || open_core(&path_clone, core_config, core_observer))
             .map_err(core_err)?;
         Ok(Self {
             inner: Arc::new(db),

--- a/crates/velesdb-python/src/lib.rs
+++ b/crates/velesdb-python/src/lib.rs
@@ -37,6 +37,7 @@ mod graph;
 mod graph_collection;
 mod graph_collection_query;
 mod graph_store;
+mod observer;
 mod options;
 mod streaming_config;
 mod streaming_runtime;

--- a/crates/velesdb-python/src/observer.rs
+++ b/crates/velesdb-python/src/observer.rs
@@ -1,0 +1,116 @@
+//! `PyObserver` — bridges core [`DatabaseObserver`] lifecycle hooks to a single
+//! Python callable.
+//!
+//! The Python SDK exposes only the four *notify* callbacks (create/delete/
+//! upsert/query). The two veto hooks (`on_ddl_request` / `on_dml_mutation_request`)
+//! keep the trait's default-allow behavior and are intentionally **not** exposed —
+//! policy/RBAC enforcement is out of scope for the open SDK.
+//!
+//! # GIL safety
+//!
+//! Core fires every callback *after* dropping the collection write guard, so
+//! re-acquiring the GIL here cannot deadlock the core-lock against the GIL.
+//! Each callback still swallows any [`PyErr`] (logged, never propagated) and
+//! never panics — the [`DatabaseObserver`] contract forbids panicking.
+
+use pyo3::prelude::*;
+use pyo3::types::PyDict;
+use velesdb_core::collection::CollectionType;
+use velesdb_core::DatabaseObserver;
+
+/// A [`DatabaseObserver`] that forwards lifecycle events to one Python callable.
+///
+/// The callback is invoked as `callback(event, **fields)`, where `event` is one
+/// of `"collection_created"`, `"collection_deleted"`, `"upsert"`, or `"query"`,
+/// and the keyword fields carry the event payload:
+///
+/// | event                | keyword fields              |
+/// |----------------------|-----------------------------|
+/// | `collection_created` | `name`, `kind`              |
+/// | `collection_deleted` | `name`                      |
+/// | `upsert`             | `collection`, `point_count` |
+/// | `query`              | `collection`, `duration_us` |
+///
+/// `kind` is one of `"vector"`, `"metadata"`, `"graph"`, or `"unknown"`
+/// (the last guards against a future [`CollectionType`] variant).
+pub struct PyObserver {
+    /// User-supplied Python callable. `Py<PyAny>` is `Send + Sync`, satisfying
+    /// the `DatabaseObserver: Send + Sync` bound.
+    cb: Py<PyAny>,
+}
+
+impl PyObserver {
+    /// Wraps a Python callable as a core observer.
+    pub fn new(cb: Py<PyAny>) -> Self {
+        Self { cb }
+    }
+
+    /// Invokes the callback as `callback(event, **fields)`, swallowing any
+    /// `PyErr` so an observer side effect can never break a core operation.
+    ///
+    /// Takes the already-held GIL token `py` so callers acquire the GIL exactly
+    /// once per event (build the `PyDict`, then dispatch under the same token).
+    fn dispatch(&self, py: Python<'_>, event: &str, fields: &Bound<'_, PyDict>) {
+        if let Err(err) = self.cb.bind(py).call((event,), Some(fields)) {
+            eprintln!("[velesdb] observer callback '{event}' raised; ignoring: {err}");
+        }
+    }
+}
+
+/// Maps a [`CollectionType`] to a stable kind string. The `_` arm keeps this
+/// total against the `#[non_exhaustive]` enum — it must never panic.
+fn collection_kind(kind: &CollectionType) -> &'static str {
+    match kind {
+        CollectionType::Vector { .. } => "vector",
+        CollectionType::MetadataOnly => "metadata",
+        CollectionType::Graph { .. } => "graph",
+        _ => "unknown",
+    }
+}
+
+impl DatabaseObserver for PyObserver {
+    fn on_collection_created(&self, name: &str, kind: &CollectionType) {
+        let kind = collection_kind(kind);
+        Python::with_gil(|py| {
+            let fields = PyDict::new(py);
+            if fields.set_item("name", name).is_err() || fields.set_item("kind", kind).is_err() {
+                return;
+            }
+            self.dispatch(py, "collection_created", &fields);
+        });
+    }
+
+    fn on_collection_deleted(&self, name: &str) {
+        Python::with_gil(|py| {
+            let fields = PyDict::new(py);
+            if fields.set_item("name", name).is_err() {
+                return;
+            }
+            self.dispatch(py, "collection_deleted", &fields);
+        });
+    }
+
+    fn on_upsert(&self, collection: &str, point_count: usize) {
+        Python::with_gil(|py| {
+            let fields = PyDict::new(py);
+            if fields.set_item("collection", collection).is_err()
+                || fields.set_item("point_count", point_count).is_err()
+            {
+                return;
+            }
+            self.dispatch(py, "upsert", &fields);
+        });
+    }
+
+    fn on_query(&self, collection: &str, duration_us: u64) {
+        Python::with_gil(|py| {
+            let fields = PyDict::new(py);
+            if fields.set_item("collection", collection).is_err()
+                || fields.set_item("duration_us", duration_us).is_err()
+            {
+                return;
+            }
+            self.dispatch(py, "query", &fields);
+        });
+    }
+}

--- a/crates/velesdb-python/tests/test_observer.py
+++ b/crates/velesdb-python/tests/test_observer.py
@@ -1,0 +1,114 @@
+"""Tests for the Database lifecycle observer (item P).
+
+A single Python callable passed as ``Database(path, observer=cb)`` is invoked
+as ``cb(event, **fields)`` on collection lifecycle events. The ``temp_db``
+fixture opens without an observer, so these tests build their own ``Database``
+with one attached.
+
+Scope note: ``collection_created`` / ``collection_deleted`` fire directly from
+the core engine, so they reach the embedded Python SDK. The ``upsert`` /
+``query`` events are emitted by callers that measure and call
+``notify_upsert`` / ``notify_query`` — in this ecosystem that is the REST
+server, whose end-to-end wiring is covered by
+``crates/velesdb-server/tests/observer_lifecycle_tests.rs``.
+"""
+
+import shutil
+import tempfile
+
+import pytest
+
+try:
+    from velesdb import Database
+
+    VELESDB_AVAILABLE = True
+except (ImportError, AttributeError):
+    VELESDB_AVAILABLE = False
+    Database = None  # type: ignore[assignment,misc]
+
+pytestmark = pytest.mark.skipif(
+    not VELESDB_AVAILABLE,
+    reason="VelesDB Python bindings not installed. Run: maturin develop",
+)
+
+DIM = 4
+
+
+class Recorder:
+    """Collects every observer invocation as ``(event, fields)`` tuples."""
+
+    def __init__(self):
+        self.events = []
+
+    def __call__(self, event, **fields):
+        self.events.append((event, fields))
+
+    def events_of(self, name):
+        return [fields for event, fields in self.events if event == name]
+
+
+@pytest.fixture
+def observed_db():
+    """Yield ``(db, recorder)`` for a fresh database opened with an observer."""
+    temp_dir = tempfile.mkdtemp()
+    recorder = Recorder()
+    db = Database(temp_dir, observer=recorder)
+    yield db, recorder
+    shutil.rmtree(temp_dir, ignore_errors=True)
+
+
+def test_collection_created_event(observed_db):
+    db, recorder = observed_db
+    db.create_collection("docs", dimension=DIM)
+
+    created = recorder.events_of("collection_created")
+    assert len(created) == 1
+    assert created[0]["name"] == "docs"
+    assert created[0]["kind"] == "vector"
+
+
+def test_metadata_collection_kind(observed_db):
+    db, recorder = observed_db
+    db.create_metadata_collection("catalog")
+
+    created = recorder.events_of("collection_created")
+    assert len(created) == 1
+    assert created[0]["name"] == "catalog"
+    assert created[0]["kind"] == "metadata"
+
+
+def test_collection_deleted_event(observed_db):
+    db, recorder = observed_db
+    db.create_collection("docs", dimension=DIM)
+    db.delete_collection("docs")
+
+    deleted = recorder.events_of("collection_deleted")
+    assert len(deleted) == 1
+    assert deleted[0]["name"] == "docs"
+
+
+def test_observer_exception_does_not_break_operation():
+    """A raising observer must never propagate into the core operation."""
+    temp_dir = tempfile.mkdtemp()
+    try:
+
+        def boom(event, **fields):
+            raise RuntimeError("observer should be isolated")
+
+        db = Database(temp_dir, observer=boom)
+        # Must succeed despite the observer raising on the created event.
+        db.create_collection("docs", dimension=DIM)
+        assert "docs" in db.list_collections()
+    finally:
+        shutil.rmtree(temp_dir, ignore_errors=True)
+
+
+def test_no_observer_is_optional():
+    """Omitting the observer keeps the constructor working unchanged."""
+    temp_dir = tempfile.mkdtemp()
+    try:
+        db = Database(temp_dir)
+        db.create_collection("docs", dimension=DIM)
+        assert "docs" in db.list_collections()
+    finally:
+        shutil.rmtree(temp_dir, ignore_errors=True)

--- a/crates/velesdb-server/tests/common/mod.rs
+++ b/crates/velesdb-server/tests/common/mod.rs
@@ -98,8 +98,7 @@ fn graph_and_maintenance_routes() -> Router<Arc<AppState>> {
         )
 }
 
-fn create_app_state(temp_dir: &TempDir) -> Arc<AppState> {
-    let db = Database::open(temp_dir.path()).expect("Failed to open database");
+fn app_state_from_db(db: Database) -> Arc<AppState> {
     Arc::new(AppState {
         db,
         onboarding_metrics: OnboardingMetrics::default(),
@@ -113,9 +112,26 @@ fn create_app_state(temp_dir: &TempDir) -> Arc<AppState> {
     })
 }
 
+fn create_app_state(temp_dir: &TempDir) -> Arc<AppState> {
+    app_state_from_db(Database::open(temp_dir.path()).expect("Failed to open database"))
+}
+
 /// Helper to create test app with all routes (no auth).
 pub fn create_test_app(temp_dir: &TempDir) -> Router {
     base_routes().with_state(create_app_state(temp_dir))
+}
+
+/// Helper to create a test app whose database is opened with the given
+/// [`DatabaseObserver`](velesdb_core::DatabaseObserver), so the lifecycle
+/// notify hooks (`on_collection_created`/`on_collection_deleted`/`on_upsert`/
+/// `on_query`) fire through the server's handlers.
+pub fn create_test_app_with_observer(
+    temp_dir: &TempDir,
+    observer: Arc<dyn velesdb_core::DatabaseObserver>,
+) -> Router {
+    let db =
+        Database::open_with_observer(temp_dir.path(), observer).expect("Failed to open database");
+    base_routes().with_state(app_state_from_db(db))
 }
 
 /// Helper to create test app and return the shared state for direct manipulation.

--- a/crates/velesdb-server/tests/observer_lifecycle_tests.rs
+++ b/crates/velesdb-server/tests/observer_lifecycle_tests.rs
@@ -1,0 +1,133 @@
+//! End-to-end coverage for item P: a [`DatabaseObserver`] injected when the
+//! server's database is opened must receive the lifecycle *notify* hooks as
+//! real HTTP requests flow through the handlers.
+//!
+//! Each assertion proves a distinct piece of wiring is live:
+//! - `POST /collections`              → `on_collection_created`
+//! - `POST /collections/{name}/points` → `on_upsert` (`points/mod.rs`)
+//! - `POST /collections/{name}/search` → `on_query`  (`search/pipeline.rs`)
+//! - `DELETE /collections/{name}`     → `on_collection_deleted`
+
+mod common;
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use axum::{
+    body::Body,
+    http::{Request, StatusCode},
+};
+use common::create_test_app_with_observer;
+use serde_json::{json, Value};
+use tempfile::TempDir;
+use tower::ServiceExt;
+use velesdb_core::collection::CollectionType;
+use velesdb_core::DatabaseObserver;
+
+const COLLECTION: &str = "observed";
+const DIM: usize = 4;
+const QUERY: [f32; DIM] = [1.0, 0.5, 0.25, 0.1];
+
+/// Counts each notify hook independently. Mirrors the Tauri-side counting
+/// observer; uses `AtomicUsize` because callbacks may fire from any thread.
+#[derive(Default)]
+struct CountingObserver {
+    created: AtomicUsize,
+    deleted: AtomicUsize,
+    upsert: AtomicUsize,
+    query: AtomicUsize,
+}
+
+impl DatabaseObserver for CountingObserver {
+    fn on_collection_created(&self, _name: &str, _kind: &CollectionType) {
+        self.created.fetch_add(1, Ordering::SeqCst);
+    }
+    fn on_collection_deleted(&self, _name: &str) {
+        self.deleted.fetch_add(1, Ordering::SeqCst);
+    }
+    fn on_upsert(&self, _collection: &str, _point_count: usize) {
+        self.upsert.fetch_add(1, Ordering::SeqCst);
+    }
+    fn on_query(&self, _collection: &str, _duration_us: u64) {
+        self.query.fetch_add(1, Ordering::SeqCst);
+    }
+}
+
+async fn post(app: &axum::Router, uri: &str, body: Value) -> StatusCode {
+    app.clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(uri)
+                .header("Content-Type", "application/json")
+                .body(Body::from(body.to_string()))
+                .expect("test: build POST request"),
+        )
+        .await
+        .expect("test: POST request")
+        .status()
+}
+
+async fn delete(app: &axum::Router, uri: &str) -> StatusCode {
+    app.clone()
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri(uri)
+                .body(Body::empty())
+                .expect("test: build DELETE request"),
+        )
+        .await
+        .expect("test: DELETE request")
+        .status()
+}
+
+#[tokio::test]
+async fn observer_receives_full_lifecycle() {
+    let dir = TempDir::new().expect("test: dir");
+    let observer = Arc::new(CountingObserver::default());
+    let app = create_test_app_with_observer(&dir, observer.clone());
+
+    // create → on_collection_created
+    let status = post(
+        &app,
+        "/collections",
+        json!({"name": COLLECTION, "dimension": DIM, "metric": "cosine"}),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED, "create");
+    assert_eq!(
+        observer.created.load(Ordering::SeqCst),
+        1,
+        "on_collection_created"
+    );
+
+    // upsert → on_upsert (points/mod.rs notify_upsert)
+    let status = post(
+        &app,
+        &format!("/collections/{COLLECTION}/points"),
+        json!({"points": [{"id": 1, "vector": QUERY, "payload": {"k": "v"}}]}),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "upsert");
+    assert!(observer.upsert.load(Ordering::SeqCst) >= 1, "on_upsert");
+
+    // search → on_query (search/pipeline.rs notify_query)
+    let status = post(
+        &app,
+        &format!("/collections/{COLLECTION}/search"),
+        json!({"vector": QUERY, "top_k": 1}),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "search");
+    assert!(observer.query.load(Ordering::SeqCst) >= 1, "on_query");
+
+    // delete → on_collection_deleted
+    let status = delete(&app, &format!("/collections/{COLLECTION}")).await;
+    assert_eq!(status, StatusCode::OK, "delete");
+    assert_eq!(
+        observer.deleted.load(Ordering::SeqCst),
+        1,
+        "on_collection_deleted"
+    );
+}

--- a/docs/CORE_WIRING_DEBT.md
+++ b/docs/CORE_WIRING_DEBT.md
@@ -304,14 +304,25 @@ feasibility · target file for the glue):
 - 6.10 `multi_query_search_ids` — DONE. Server `POST /collections/{name}/search/multi/ids` (+ OpenAPI) calls core `multi_query_search_ids` (rejects filters — the kernel has no filter param); TS `multiQuerySearchIds` across `search-backend.ts` → REST/WASM backends (WASM = not-supported stub, mirroring `searchIds`) → `Backend` interface → client. Server parity + filter-rejection + 404 tests; TS backend tests.
 - 6.11 `validate_*` free-fn dedup — **VERIFIED no-op (no real gap).** The matrix row was overstated: no binding re-implements these. Core already re-exports `validate_collection_name` / `validate_dimension` / `validate_dimension_match` from the crate root (`lib.rs`); Python relies on core validation via error-mapping (no local validators in `lib.rs`); the server only matches the `InvalidCollectionName` *error* variant (no local name/dimension validator); TS is client-only and has no `validateCollectionName` / `validateDimension`. Nothing to consolidate.
 
+**Status — Observer plane** (item P, 2026-06-14): **DONE for Python + server
+e2e.** Python `Database(path, observer=cb)` injects a `PyObserver` that bridges
+the four core *notify* hooks to one callable `cb(event, **fields)` — events
+`collection_created` (`name`, `kind`), `collection_deleted` (`name`), `upsert`
+(`collection`, `point_count`), `query` (`collection`, `duration_us`). In the
+embedded SDK only `collection_created`/`collection_deleted` fire (the core
+emits them directly); `upsert`/`query` are emitted by callers that measure and
+call `notify_upsert`/`notify_query` — that is the REST server, now covered
+end-to-end by `crates/velesdb-server/tests/observer_lifecycle_tests.rs` (a
+`CountingObserver` injected via `Database::open_with_observer` asserts all four
+hooks across create/upsert/search/delete). The two **veto** hooks
+(`on_ddl_request`/`on_dml_mutation_request`) stay trait-default (allow) and are
+intentionally **not** exposed — no policy/RBAC engine in the open SDK. WASM is
+architecturally N/A; TypeScript-REST (SSE/WS) and Mobile remain deferred.
+
 **Explicitly deferred (not worth closing now)**:
 - `stream_insert_batch` / `enable_streaming` / `StreamIngester::*` — async
   runtime + channel-handle lifetime across PyO3/UniFFI is **hard** and
   low-demand vs `upsert_bulk`. WASM N/A (no async fs). P3, defer.
-- Observer plane (`open_with_observer[_and_config]`, `notify_upsert`,
-  `notify_query`) — marshalling a Rust callback trait object across FFI;
-  feasible only in Python (PyO3 closures), awkward/niche elsewhere. P3,
-  defer. Only `velesdb-server` wires the notify hooks (its metrics).
 - `upsert_bulk_from_raw` beyond Python — REST/TS already have JSON
   `upsert_bulk`; the zero-copy raw path needs a flat-buffer wire format
   for marginal benefit. Keep Python/NumPy-only.


### PR DESCRIPTION
## What & why

The observer plane (`DatabaseObserver`) was wired in core + Tauri (#1110) but **not exposed to Python**, and the server's `notify_*` hooks had no end-to-end proof. This closes the Python gap and adds the e2e proof (`CORE_WIRING_DEBT.md` listed the observer plane as deferred).

## Change

- **`PyObserver`** (new) bridges a single Python callable to the **four lifecycle NOTIFY hooks** (`collection_created`/`collection_deleted`/`upsert`/`query`), invoked as `cb(event, **fields)`. GIL-safe (one `Python::with_gil` per event), `#[non_exhaustive]`-safe `kind` mapping, **PyErr swallowed — never panics** (trait contract).
- **No policy engine:** the two veto hooks keep the trait default-allow and are **not exposed** (RBAC stays premium).
- **Registration = constructor kwarg** `Database(path, config=None, observer=None)` (core observer is immutable post-open); the `__init__.py` adapter forwards it. `Database::new` stays CCN ≤ 8 via an `open_core` helper.
- **Server e2e**: a counting observer injected via the new `create_test_app_with_observer` helper proves all four hooks fire across create/upsert/search/delete.

## Tests & docs

- Server e2e test + `test_observer.py` (5 cases). `CORE_WIRING_DEBT.md` observer line → done, dated 2026-06-14.

## Scope note (honest)

In the **embedded** Python SDK only `collection_created`/`collection_deleted` fire organically; `upsert`/`query` are emitted only by the **REST server** handlers (proven by the e2e test). Auto-firing them from the Python `Collection` would require threading `Arc<CoreDatabase>` into every collection — out of this PR's surgical scope; documented.

## Validation (local)

`cargo clippy -p velesdb-server … -D clippy::pedantic` clean · `cargo check -p velesdb-python` ok · server e2e passes · `maturin develop` + `pytest` 5/5 · `check_prod_unwraps.py` pass.

> Observer for wasm (N/A) / ts-rest (RFC) / mobile (deferred) remain out of scope.