### PR TITLE
docs: reconcile parity-campaign matrix, wiring-debt status, and roadmap (2026-06-14)

### DIFF
--- a/docs/CORE_WIRING_DEBT.md
+++ b/docs/CORE_WIRING_DEBT.md
@@ -1,8 +1,9 @@
 # Core Wiring Debt
 
-> **Last updated**: 2026-06-12 — inventory re-verified against the code on
+> **Last updated**: 2026-06-14 — inventory re-verified against the code on
 > this date (entries 1, 2, 3, and 5 re-checked at their call sites; entry 4
-> is a qualitative single-source-of-truth cleanup and unchanged).
+> is a qualitative single-source-of-truth cleanup and unchanged; §5
+> `LimitsConfig` runtime enforcement and the §6 Observer plane re-checked).
 
 This document lists configuration structures and subsystems that exist in
 `velesdb-core` but are **not yet fully wired** to the user-facing runtime.
@@ -304,6 +305,14 @@ feasibility · target file for the glue):
 - 6.10 `multi_query_search_ids` — DONE. Server `POST /collections/{name}/search/multi/ids` (+ OpenAPI) calls core `multi_query_search_ids` (rejects filters — the kernel has no filter param); TS `multiQuerySearchIds` across `search-backend.ts` → REST/WASM backends (WASM = not-supported stub, mirroring `searchIds`) → `Backend` interface → client. Server parity + filter-rejection + 404 tests; TS backend tests.
 - 6.11 `validate_*` free-fn dedup — **VERIFIED no-op (no real gap).** The matrix row was overstated: no binding re-implements these. Core already re-exports `validate_collection_name` / `validate_dimension` / `validate_dimension_match` from the crate root (`lib.rs`); Python relies on core validation via error-mapping (no local validators in `lib.rs`); the server only matches the `InvalidCollectionName` *error* variant (no local name/dimension validator); TS is client-only and has no `validateCollectionName` / `validateDimension`. Nothing to consolidate.
 
+**Status — Wave 1 PR-L** (`feat/parity-mobile-cli-diagnostics`, MERGED #1106,
+2026-06-14): 6.6 mobile `diagnostics` DONE (`collection.rs:620`); 6.10 mobile
+`multi_query_search_ids` DONE (`collection_sparse.rs:144`); CLI `.diagnostics`
+REPL command added (`repl_collection_cmds.rs`). Still open after PR-L: 6.9
+`search_batch_parallel` on mobile (mobile batch still routes through
+`search_batch_with_filters`) and all three diagnostics / multi_query /
+search_batch_parallel surfaces on Tauri.
+
 **Status — Observer plane** (item P, 2026-06-14): **DONE for Python + server
 e2e.** Python `Database(path, observer=cb)` injects a `PyObserver` that bridges
 the four core *notify* hooks to one callable `cb(event, **fields)` — events
@@ -319,10 +328,22 @@ hooks across create/upsert/search/delete). The two **veto** hooks
 intentionally **not** exposed — no policy/RBAC engine in the open SDK. WASM is
 architecturally N/A; TypeScript-REST (SSE/WS) and Mobile remain deferred.
 
+**Streaming ingestion (`stream_insert_batch` / `enable_streaming` /
+`StreamIngester::*`) — DONE across the first-party bindings (2026-06-14).** The
+async-runtime + channel-handle-lifetime concern was solved by giving each
+binding a process-wide tokio streaming runtime that the drain task is scheduled
+on: Python (`velesdb-python/src/streaming_runtime.rs` + `collection/mutation.rs`
+`enable_streaming`/`stream_insert`) and Mobile/UniFFI
+(`velesdb-mobile/src/streaming_runtime.rs` +
+`collection.rs:481`/`:508`), alongside Server
+(`POST /collections/{name}/stream/enable` + `/stream/insert`), the TS SDK
+(`enableStreaming()`/`streamInsert()`, REST backend) and Tauri. WASM is N/A (no
+async fs / persistence layer; throws `NOT_SUPPORTED`). The CLI reaches it ⚠️ via
+the embedded core path with no dedicated REPL command. Only the
+LangChain/LlamaIndex/Haystack integrations do not yet expose it. See
+`docs/reference/ECOSYSTEM_PARITY.md` (Streaming Ingestion row).
+
 **Explicitly deferred (not worth closing now)**:
-- `stream_insert_batch` / `enable_streaming` / `StreamIngester::*` — async
-  runtime + channel-handle lifetime across PyO3/UniFFI is **hard** and
-  low-demand vs `upsert_bulk`. WASM N/A (no async fs). P3, defer.
 - `upsert_bulk_from_raw` beyond Python — REST/TS already have JSON
   `upsert_bulk`; the zero-copy raw path needs a flat-buffer wire format
   for marginal benefit. Keep Python/NumPy-only.

--- a/docs/planning/PARITY_CAMPAIGN_ROADMAP.md
+++ b/docs/planning/PARITY_CAMPAIGN_ROADMAP.md
@@ -1,0 +1,99 @@
+# VelesDB Parity Campaign — Executable Roadmap
+
+> **Directive**: close **every community-scope** gap, defer nothing, subject to
+> (a) the VelesDB Core License boundary and (b) genuine technical feasibility.
+> Generated 2026-06-13 from a re-control audit (verification workflow) +
+> per-item feasibility design workflow against `develop@7a6153aa`.
+
+## Re-control verdict
+
+The 4-PR API-parity campaign (#1096/#1098/#1099/#1100) was **verified real** —
+23 Python methods, all REST routes, mobile/tauri/TS surfaces confirmed by
+`file:line` with **zero false positives**. The old informal matrix is obsolete.
+**One functional regression escaped** the docs: the CLI silently dropped
+`@collection` cross-collection MATCH enrichment → **fixed in PR-A**.
+
+## License boundary (PASS gate)
+
+🔒 **Premium — never touched here**: `WalBatchConfig` concurrent-writer
+same-collection; RBAC; SSO; Audit Logging; Multi-Tenancy; Encryption at Rest;
+Snapshots; GPU acceleration. Key nuance: **single-writer streaming ingestion is
+community** (allowed); only concurrent-writer-same-collection is premium.
+Observer PRs ship the veto *hook* with a default-allow `DefaultObserver` and **no
+policy engine** (RBAC stays premium).
+
+## Excluded (correctly, not dodged)
+
+- `6-observer-wasm` — architectural N/A (WASM never instantiates `core::Database`).
+- `6-observer-typescript-rest` — needs an SSE/WS server feature (future RFC), not a parity gap.
+- `6-observer-mobile` — feasible via UniFFI callback interface but ~40 commits, low demand → later/premium.
+- `6-raw-bulk-mobile` — follow-up after PR-J proves the wire format.
+- `I4` cross-collection `similarity()` in WHERE — undesigned new feature, recall-gated; separate epic.
+
+## PR roadmap (dependency-ordered)
+
+| PR | Title | Items | Risk / gate | Depends |
+|----|-------|-------|-------------|---------|
+| **A** ✅ | fix(cli): route `@collection` MATCH through `Database::execute_query` | C0 | done, green | — |
+| **B** ✅ | feat(core): persist AutoReindexConfig + StreamingConfig; schema v1→v2 | W2, STREAM-7 | backward-compat test | — |
+| ~~**C**~~ DROPPED | ~~feat(core): wire `deferred_indexing`/`async_index_builder` into VelesConfig TOML~~ | W3 | — | — |
+| **D** ✅ | refactor(search): SearchConfig SSOT via `effective_ef_search` | W4 | **RECALL Gate 1**, solo | — |
+| **E** ✅ | feat(core): enforce LimitsConfig 3 fields, <1% bench | W5 | **benchmark**, after D (shares vector.rs) | D |
+| **F** ✅ | feat(streaming): StreamingConfig + delta CAS + Tauri/REST enable_streaming | STREAM-1/4/5/9 | standard | — |
+| **G** ✅ | feat(python): enable_streaming via pyo3-asyncio | STREAM-2 | pyo3-asyncio | F |
+| **H** ✅ | feat(ts,mobile): enableStreaming SDK + mobile wrapper | STREAM-6/3 | TS strict | F/G |
+| **I** | feat(streaming): WAL bypass via WriteMode | STREAM-8 | **crash-recovery parity**, optional | G |
+| **J** ✅ | feat(rest,ts): binary wire-format `upsert_bulk_from_raw` | raw-bulk rest+ts | document contract | — |
+| **K** | feat(wasm,cli): raw-bulk typed-array + CLI ingest | raw-bulk wasm+cli | wasm no-default-features | — |
+| **L** ✅ | feat(mobile): diagnostics + multi_query_search_ids; feat(cli): `.diagnostics` | M1, M2, C1 | standard (C1 after A) | A (CLI) |
+| **M** ✅ | feat(wasm): sparse_search + validate dedup | M3 | wasm check, after K | K |
+| **N** ✅ | feat(integrations): Haystack fusion + named-sparse creation (LC/LI/Haystack) | I1, I2 | py integration tests | — |
+| **O** ✅ | feat(wasm,integrations): `@collection` MATCH propagation | I3 | net-new WASM wiring | — |
+| **P** ✅ | feat(observer): Python PyO3 lifecycle callbacks + server e2e | observer python+server | done 2026-06-14; **GIL safety**, default-allow | — |
+| **Q** ✅ | feat(observer): Tauri event-based lifecycle notifications | observer tauri | no policy engine | — |
+
+## C — DROPPED (not a real parity gap)
+
+Re-scoped 2026-06-14 against the code: `deferred_indexing` / `async_index_builder`
+are already per-collection `CollectionConfig` fields, configurable via
+`apply_advanced_config` / create-with-options. There is **no checked-in gap doc**
+backing C (no `CORE_WIRING_DEBT.md`; `ECOSYSTEM_PARITY.md` doesn't list it — it
+came only from the generated roadmap). Crucially, the global `VelesConfig` (TOML)
+does **not** drive per-collection creation today (only `limits` are read;
+`hnsw`/`search` are already inert there), so adding these fields to `VelesConfig`
+would be either cosmetic/inert or require a new "VelesConfig as per-collection
+defaults" architecture — beyond a parity fix. Dropped with maintainer sign-off.
+
+## I — DEFERRED (no real parity gap, gate logically impossible)
+
+Re-scoped 2026-06-14 against the code: STREAM-8 "WAL bypass via WriteMode" has no
+closeable gap. The `WriteMode{Api,Streaming}` enum is dead-code provenance —
+`pub(crate)` and unused (`collection/streaming/ingester.rs`, doc-commented
+"currently unused"). The real durability bypass already exists and is tested:
+`storage::DurabilityMode::None` (`storage/log_payload.rs`), threaded through
+`LogPayloadStorage::new_with_durability` — it is simply not surfaced as a
+user-facing knob by design (a durability downgrade is a footgun). There is no
+checked-in gap doc backing I, and its "crash-recovery parity" gate is logically
+impossible: a mode whose contract is "may lose the WAL tail on crash" cannot be
+asserted to match a durable-recovery baseline. Deferred with maintainer sign-off.
+
+## Execution batches (worktree-isolated)
+
+- **Batch 0 (blocking)**: PR-A ✅ done.
+- **Batch 1 (parallel, disjoint files)**: B, F, J, L, N, P, Q.
+- **Batch 2 (after Batch 1)**: C←B, G←F, K, O.
+- **Batch 3 (serialized — recall/file collisions)**: D (solo, recall) → E (after D); H←F/G; M←K.
+- **Batch 4 (optional/hard, last)**: I (only with crash-recovery proof).
+
+### Must-serialize collisions
+- `collection/search/vector.rs` → D then E
+- `collection/collection_config.rs` + `lifecycle.rs` → B then C
+- `velesdb-wasm/src/{lib,vector_store}.rs` → K then M
+- streaming config type → F → G → H
+
+## Documentation actions (from re-control drift)
+
+1. `ECOSYSTEM_PARITY.md:56` — CLI `@collection` claim true once PR-A lands.
+2. `ECOSYSTEM_PARITY.md:220` action item 1 — relabel (CLI has no HTTP layer; REST error-shape belongs to server).
+3. `CORE_WIRING_DEBT.md:298` (6.11) — soften "verified no-op": WASM reimplements `validate_dimension` + doesn't enforce `validate_collection_name`.
+4. `CORE_WIRING_DEBT.md` §6 rows 6.6/6.9/6.10 — note surfaces still missing (mobile/tauri) before PR-L closes them.

--- a/docs/reference/ECOSYSTEM_PARITY.md
+++ b/docs/reference/ECOSYSTEM_PARITY.md
@@ -31,7 +31,7 @@ Legend: ✅ full support | ⚠️ partial / limited | ❌ not supported | N/A no
 |---------------|------|--------|--------|------|--------|-----|--------|-------|-----------|------------|----------|
 | **Vector CRUD** (insert, upsert, delete, get) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | **Batch Operations** (batch_insert, batch_upsert) | ✅ | ✅ | ✅ | ⚠️ | ⚠️ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| **Streaming Ingestion** (enableStreaming / stream_insert) | ✅ | ✅ | ✅ | ❌ | ❌ | ⚠️ | ✅ | ✅ | ❌ | ❌ | ❌ |
+| **Streaming Ingestion** (enableStreaming / stream_insert) | ✅ | ✅ | ✅ | ❌ | ✅ | ⚠️ | ✅ | ✅ | ❌ | ❌ | ❌ |
 | **Vector Search** (k-NN, filtered, batch) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | **Multi-Query Fusion** (RRF) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ⚠️ |
 | **Multi-Query Fusion** (RSF / Weighted) | ✅ | ✅ | ✅ | ⚠️ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ⚠️ |
@@ -56,7 +56,7 @@ Legend: ✅ full support | ⚠️ partial / limited | ❌ not supported | N/A no
 
 - **Cross-Collection MATCH**: Core and Server support `@collection` annotation on MATCH node patterns. Python bindings support via `_collection` param. CLI supports via `\use`. WASM, Mobile, Tauri, and integrations do not yet expose this feature.
 - **Batch Operations**: WASM and Mobile use streaming chunked inserts instead of single-call bulk to stay within memory constraints.
-- **Streaming Ingestion** (2026-06-14): Core, Server (`POST /collections/{name}/stream/enable` + `/stream/insert`), Python, Tauri, and the TS SDK (`enableStreaming()` / `streamInsert()`, REST backend) support the bounded ingestion channel. The CLI reaches it ⚠️ via the embedded core path with no dedicated REPL command. WASM throws `NOT_SUPPORTED` (no persistence layer). Mobile and the LangChain/LlamaIndex/Haystack integrations do not yet expose it.
+- **Streaming Ingestion** (2026-06-14): Core, Server (`POST /collections/{name}/stream/enable` + `/stream/insert`), Python, Tauri, Mobile (`enableStreaming()` / `streamInsert()` on its own tokio streaming runtime), and the TS SDK (`enableStreaming()` / `streamInsert()`, REST backend) support the bounded ingestion channel. The CLI reaches it ⚠️ via the embedded core path with no dedicated REPL command. WASM throws `NOT_SUPPORTED` (no persistence layer). Only the LangChain/LlamaIndex/Haystack integrations do not yet expose it.
 - **Multi-Query Fusion (RSF/Weighted)**: WASM supports RRF only. LangChain and LlamaIndex expose RSF/Weighted through `multi_query_search(fusion=...)`, which delegates to the shared `velesdb_common.fusion.build_fusion_strategy` (builds `weighted()` and `relative_score()`). Haystack remains ⚠️: fusion is reachable only via the underlying `velesdb` Python wrapper, not through the `DocumentStore` protocol.
 - **Sparse Vector Search (named indexes) — LangChain/LlamaIndex**: ⚠️ query-side only. Both integrations forward a `sparse_index_name` argument to the underlying `collection.search`/`hybrid_search`, so an existing named sparse index can be *queried*. Creating named sparse indexes is not exposed by the integrations (use the core `velesdb` API), and this path is not yet covered by integration tests.
 - **Graph Operations (WASM)**: Basic node/edge CRUD is supported; multi-hop traversal and MATCH queries are limited.
@@ -219,7 +219,7 @@ collection creation; only Haystack is limited by its DocumentStore protocol.
 
 ## Remaining Gaps and Action Items
 
-1. Add explicit CLI end-to-end assertions for REST error shape (`code/hint/details`) beyond parser conformance.
+1. Add explicit server-side end-to-end assertions for the REST error shape (`code/hint/details`) beyond parser conformance. (The CLI has no HTTP layer — it executes against embedded core — so the REST error-shape contract belongs to `velesdb-server`.)
 2. Extend WASM conformance from parser-only to executable feature checks where applicable.
 3. Keep docs, fixtures, and examples synchronized on every contract version change.
 4. Promote RaBitQ from experimental to stable once the API is finalized.


### PR DESCRIPTION
Final documentation sweep closing out the parity campaign (no code changes).

## Changes

- **`ECOSYSTEM_PARITY.md`** — Streaming Ingestion row: **Mobile** now supported (`enableStreaming`/`streamInsert` on its own tokio runtime, #1116). Action item #1 retargeted to the **server** (the CLI has no HTTP layer — it executes against embedded core, so the REST error-shape contract belongs to `velesdb-server`).
- **`CORE_WIRING_DEBT.md`** — header date refreshed; added the Wave-1 PR-L closure note (mobile `diagnostics`/`multi_query_search_ids`, CLI `.diagnostics`) with the remaining surfaces (mobile `search_batch_parallel`, Tauri); streaming removed from the deferred list (now shipped across the first-party bindings).
- **`PARITY_CAMPAIGN_ROADMAP.md`** (newly tracked) — done-markers on all merged rows; item I documented as deferred (WAL bypass via `WriteMode` is a dead-code placeholder; the real `DurabilityMode::None` bypass exists but is unexposed by design, and a crash-recovery parity gate is unachievable).