### PR TITLE
feat(wasm): add VectorStore.insertBatchRaw flat-buffer raw-bulk insert

### DIFF
--- a/crates/velesdb-wasm/README.md
+++ b/crates/velesdb-wasm/README.md
@@ -94,6 +94,7 @@ class VectorStore {
   insert(id: bigint, vector: Float32Array): void;
   insert_with_payload(id: bigint, vector: Float32Array, payload: object): void;
   insert_batch(batch: Array<[bigint, number[]]>): void;  // Bulk insert
+  insertBatchRaw(ids: BigUint64Array, vectors: Float32Array, dimension: number): void;  // Flat raw-bulk insert (since 2026-06-14)
   search(query: Float32Array, k: number): Array<[bigint, number]>;
   search_with_filter(query: Float32Array, k: number, filter: object): Array<{id, score, payload}>;
   text_search(query: string, k: number, field?: string): Array<{id, score, payload}>;

--- a/crates/velesdb-wasm/src/database.rs
+++ b/crates/velesdb-wasm/src/database.rs
@@ -406,6 +406,24 @@ impl WasmCollectionHandle {
         store.insert(id, vector)
     }
 
+    /// Bulk insert from a flat row-major `vectors` buffer plus parallel `ids`
+    /// (VRB1 raw-bulk contract). No payloads.
+    ///
+    /// # Errors
+    /// Returns an error on dimension mismatch or when
+    /// `vectors.len() != ids.len() * dimension`.
+    #[wasm_bindgen(js_name = insertBatchRaw)]
+    pub fn insert_batch_raw(
+        &self,
+        ids: &[u64],
+        vectors: &[f32],
+        dimension: usize,
+    ) -> Result<(), JsValue> {
+        self.inner
+            .borrow_mut()
+            .insert_batch_raw(ids, vectors, dimension)
+    }
+
     /// k-NN search. Returns `[[id, score], ...]`.
     ///
     /// # Errors

--- a/crates/velesdb-wasm/src/store_insert.rs
+++ b/crates/velesdb-wasm/src/store_insert.rs
@@ -1,6 +1,6 @@
 //! Insert operations for `VectorStore`.
 
-use crate::{StorageMode, VectorStore};
+use crate::{store_search, StorageMode, VectorStore};
 
 #[cfg(test)]
 #[path = "store_insert_tests.rs"]
@@ -70,6 +70,49 @@ pub fn insert_vector(store: &mut VectorStore, id: u64, vector: &[f32]) {
     store.ids.push(id);
     store.payloads.push(None);
     encode_vector(store, vector);
+}
+
+/// Validates a flat raw batch against the store geometry.
+///
+/// Checks that `dimension` matches the store, then delegates the
+/// `checked_mul` overflow guard and `ids.len() * dimension` length check to
+/// [`store_search::validate_multi_vector_len`].
+fn validate_raw_batch(
+    store: &VectorStore,
+    ids: &[u64],
+    vectors: &[f32],
+    dimension: usize,
+) -> Result<(), String> {
+    if dimension != store.dimension {
+        return Err(format!(
+            "dimension mismatch: expected {}, got {dimension}",
+            store.dimension
+        ));
+    }
+    store_search::validate_multi_vector_len(vectors.len(), ids.len(), dimension)?;
+    Ok(())
+}
+
+/// Bulk insert from a flat row-major `vectors` buffer plus parallel `ids`.
+///
+/// Mirrors the VRB1 raw-bulk wire contract (flat `Float32Array` + `u64`
+/// ids + explicit `dimension`). Reuses [`insert_vector`] per row so the
+/// upsert-dedup and per-mode encoding (Full/SQ8/Binary) behave identically
+/// to single insert. No payloads — use `insert_batch` for those.
+pub fn insert_batch_raw(
+    store: &mut VectorStore,
+    ids: &[u64],
+    vectors: &[f32],
+    dimension: usize,
+) -> Result<(), String> {
+    validate_raw_batch(store, ids, vectors, dimension)?;
+    store.ids.reserve(ids.len());
+    store.data.reserve(vectors.len());
+    for (i, &id) in ids.iter().enumerate() {
+        let v = &vectors[i * dimension..(i + 1) * dimension];
+        insert_vector(store, id, v);
+    }
+    Ok(())
 }
 
 /// Inserts a vector with payload.

--- a/crates/velesdb-wasm/src/store_insert_tests.rs
+++ b/crates/velesdb-wasm/src/store_insert_tests.rs
@@ -7,7 +7,7 @@
 //! These tests pin the corrected swap-remove semantics across Full, SQ8
 //! and Binary modes, plus the metadata-only (dimension = 0) edge case.
 
-use crate::store_insert::{insert_vector, insert_with_payload, remove_at_index};
+use crate::store_insert::{insert_batch_raw, insert_vector, insert_with_payload, remove_at_index};
 use crate::store_new::create_store;
 use crate::{DistanceMetric, StorageMode};
 
@@ -237,4 +237,73 @@ fn test_reinsert_same_id_overwrites_and_keeps_alignment() {
     assert_eq!(&store.data[0..2], &[1.0, 1.0]);
     assert_eq!(&store.data[2..4], &[3.0, 3.0]);
     assert_eq!(&store.data[4..6], &[20.0, 20.0]);
+}
+
+// -------------------------------------------------------------------------
+// insert_batch_raw: flat raw-bulk insert (VRB1 contract)
+// -------------------------------------------------------------------------
+
+#[test]
+fn test_insert_batch_raw_happy_path_roundtrip() {
+    let mut store = mk_full_store(4);
+    let ids = [10u64, 11, 12];
+    // 3 vectors, dim 4, row-major.
+    let vectors = [
+        1.0, 0.0, 0.0, 0.0, // id=10
+        0.0, 1.0, 0.0, 0.0, // id=11
+        0.0, 0.0, 1.0, 0.0, // id=12
+    ];
+    insert_batch_raw(&mut store, &ids, &vectors, 4).unwrap();
+
+    assert_eq!(store.ids, vec![10, 11, 12]);
+    assert_eq!(store.data.len(), 12);
+    // Each row lands contiguously in insertion order.
+    assert_eq!(&store.data[0..4], &[1.0, 0.0, 0.0, 0.0]);
+    assert_eq!(&store.data[4..8], &[0.0, 1.0, 0.0, 0.0]);
+    assert_eq!(&store.data[8..12], &[0.0, 0.0, 1.0, 0.0]);
+}
+
+#[test]
+fn test_insert_batch_raw_upserts_existing_id() {
+    let mut store = mk_full_store(2);
+    insert_vector(&mut store, 1, &[9.0, 9.0]);
+    // id=1 already present — raw batch must dedup via insert_vector.
+    insert_batch_raw(&mut store, &[1u64, 2], &[1.0, 1.0, 2.0, 2.0], 2).unwrap();
+    assert_eq!(store.ids.len(), 2);
+    // id=1 is the only element, so its swap-remove truncates, then id=1 is
+    // re-appended with the new data, followed by id=2: ids = [1, 2].
+    assert_eq!(store.ids, vec![1, 2]);
+    // New data overwrote the old [9.0, 9.0] for id=1.
+    assert_eq!(&store.data[0..2], &[1.0, 1.0]);
+    assert_eq!(&store.data[2..4], &[2.0, 2.0]);
+}
+
+#[test]
+fn test_insert_batch_raw_length_mismatch_errors() {
+    let mut store = mk_full_store(4);
+    // 2 ids but only 4 floats (need 8). Must error, leaving the store empty.
+    let err = insert_batch_raw(&mut store, &[1u64, 2], &[1.0, 2.0, 3.0, 4.0], 4).unwrap_err();
+    assert!(err.contains("size mismatch"), "unexpected error: {err}");
+    assert!(store.ids.is_empty());
+    assert!(store.data.is_empty());
+}
+
+#[test]
+fn test_insert_batch_raw_dimension_mismatch_errors() {
+    let mut store = mk_full_store(4);
+    let err = insert_batch_raw(&mut store, &[1u64], &[1.0, 2.0, 3.0], 3).unwrap_err();
+    assert!(
+        err.contains("dimension mismatch"),
+        "unexpected error: {err}"
+    );
+    assert!(store.ids.is_empty());
+}
+
+#[test]
+fn test_insert_batch_raw_overflow_errors() {
+    let mut store = mk_full_store(usize::MAX);
+    // ids.len() * dimension overflows usize -> checked_mul guard rejects.
+    let err = insert_batch_raw(&mut store, &[1u64, 2], &[], usize::MAX).unwrap_err();
+    assert!(err.contains("overflow"), "unexpected error: {err}");
+    assert!(store.ids.is_empty());
 }

--- a/crates/velesdb-wasm/src/vector_store.rs
+++ b/crates/velesdb-wasm/src/vector_store.rs
@@ -601,6 +601,20 @@ impl VectorStore {
         }
         Ok(())
     }
+
+    /// Bulk insert from a flat contiguous `Float32Array` (zero-copy layout),
+    /// mirroring the VRB1 raw-bulk contract: `ids` + flat row-major `vectors`
+    /// + `dimension`. No payloads (use `insert_batch` for those).
+    #[wasm_bindgen(js_name = insertBatchRaw)]
+    pub fn insert_batch_raw(
+        &mut self,
+        ids: &[u64],
+        vectors: &[f32],
+        dimension: usize,
+    ) -> Result<(), JsValue> {
+        store_insert::insert_batch_raw(self, ids, vectors, dimension)
+            .map_err(|e| JsValue::from_str(&e))
+    }
 }
 
 // Native-testable internals (not part of the wasm-bindgen surface).


### PR DESCRIPTION
## What & why

The WASM SDK only had per-vector batch insert (`[[id, Float32Array], ...]`); it lacked the flat-buffer raw-bulk path that REST + the TS SDK already expose (PR #1104). This adds it.

Note: WASM has its own self-contained `VectorStore` (it never instantiates core's `Collection`), so this is **not** a core `upsert_bulk_from_raw` call — it mirrors the same VRB1 wire **contract** (parallel `u64` ids + flat row-major `Float32Array` + explicit `dimension`) and writes into the WASM store's own buffers.

## Change

- `VectorStore.insertBatchRaw(ids, vectors, dimension)` (+ surfaced on `WasmCollectionHandle`) — one bulk copy across the wasm-bindgen boundary instead of decoding N tuples.
- Reuses the existing `insert_vector` encoding path, so Full/SQ8/Binary storage modes and upsert-dedup behave identically to single insert (no encoding reimplemented).
- Replicates core's `checked_mul` overflow guard; validates `dimension` and `vectors.len() == ids.len() * dimension`. No payloads on this path.

## Tests & validation

- 5 unit tests: happy-path round-trip, upsert of an existing id, length-mismatch error, dimension-mismatch error, overflow error.
- `cargo check -p velesdb-wasm --no-default-features --target wasm32-unknown-unknown` (the WASM CI gate) passes; clippy `-D warnings` clean; 532 lib tests + 5 new pass; `check_prod_unwraps.py` passes.

> The CLI half (VRB1 binary `.bin` ingest) ships as a separate PR.