### PR TITLE
feat(cli): VRB1 binary raw-bulk import via a shared core codec

### DIFF
--- a/crates/velesdb-cli/README.md
+++ b/crates/velesdb-cli/README.md
@@ -323,6 +323,11 @@ velesdb data import embeddings.csv \
   --id-column doc_id \
   --vector-column embedding
 
+# Import from a VRB1 binary file (.bin / .vrb1) — zero-copy bulk path
+velesdb data import vectors.bin \
+  --database ./data \
+  --collection docs
+
 # Export to JSON (vector collections only)
 velesdb data export ./data documents --output documents.json
 
@@ -349,6 +354,10 @@ Each line must be a valid JSON object with the following fields:
 | `payload` | JSON object | no | Arbitrary JSON metadata |
 
 Lines with mismatched vector dimensions are counted as errors and skipped.
+
+**VRB1 binary format for `data import` (`.bin` / `.vrb1`, since 2026-06-14):**
+
+A `.bin` / `.vrb1` file uses the VRB1 little-endian wire format: a 16-byte header (`b"VRB1"` magic, `u32` count, `u32` dimension, `u8` id width = 8, 3 reserved zero bytes) followed by tightly-packed `u64` ids and row-major `f32` vectors. It feeds the zero-copy bulk path and carries **no payloads** — use `.jsonl` / `.csv` when payloads are needed. The declared dimension sizes a freshly created collection, so `--dimension` is not required for `.bin` imports.
 
 **`data import` flags:**
 

--- a/crates/velesdb-cli/src/handlers/data.rs
+++ b/crates/velesdb-cli/src/handlers/data.rs
@@ -104,8 +104,12 @@ pub fn handle_import(
     let stats = match ext.to_lowercase().as_str() {
         "jsonl" | "ndjson" => import::import_jsonl(&db, file, &config)?,
         "csv" => import::import_csv(&db, file, &config)?,
+        "bin" | "vrb1" => import::import_raw_bulk(&db, file, &config)?,
         _ => {
-            anyhow::bail!("Unsupported file format: {}. Use .csv or .jsonl", ext);
+            anyhow::bail!(
+                "Unsupported file format: {}. Use .csv, .jsonl, or .bin (VRB1)",
+                ext
+            );
         }
     };
 

--- a/crates/velesdb-cli/src/import.rs
+++ b/crates/velesdb-cli/src/import.rs
@@ -246,6 +246,38 @@ pub fn import_csv(db: &Database, path: &Path, config: &ImportConfig) -> Result<I
     })
 }
 
+/// Import from a VRB1 binary file (`.bin` / `.vrb1`).
+///
+/// Reads the whole file, decodes the shared VRB1 wire format, and forwards the
+/// flat ids/vectors to the zero-copy `upsert_bulk_from_raw` path. The declared
+/// dimension in the file is authoritative (it sizes a freshly created
+/// collection). Payloads are not carried by this format — use `.jsonl` / `.csv`
+/// when payloads are needed.
+pub fn import_raw_bulk(db: &Database, path: &Path, config: &ImportConfig) -> Result<ImportStats> {
+    let bytes = std::fs::read(path).context("Failed to read binary file")?;
+    let raw = velesdb_core::wire::vrb1::decode(&bytes)
+        .map_err(|e| anyhow::anyhow!("Invalid VRB1 binary file: {e}"))?;
+
+    let collection = get_or_create_collection(
+        db,
+        &config.collection,
+        raw.dimension,
+        config.metric,
+        config.storage_mode,
+    )?;
+
+    let total = raw.ids.len();
+    let start = std::time::Instant::now();
+    let imported = collection.upsert_bulk_from_raw(&raw.vectors, &raw.ids, raw.dimension, None)?;
+
+    Ok(ImportStats {
+        total,
+        imported,
+        errors: 0,
+        duration_ms: start.elapsed().as_millis() as u64,
+    })
+}
+
 /// Process a single CSV record and push it into the batch importer.
 fn process_csv_record(
     record: &csv::StringRecord,

--- a/crates/velesdb-cli/src/import_tests.rs
+++ b/crates/velesdb-cli/src/import_tests.rs
@@ -327,6 +327,66 @@ fn test_import_csv_custom_columns() {
 }
 
 // =========================================================================
+// Integration tests for VRB1 binary import
+// =========================================================================
+
+#[test]
+fn test_import_raw_bulk_basic() {
+    let dir = tempdir().unwrap();
+    let db_path = dir.path().join("db");
+    let bin_path = dir.path().join("data.bin");
+
+    // Encode a small VRB1 buffer via the shared core codec.
+    let ids = [1u64, 2, 3];
+    let vectors = [
+        1.0f32, 0.0, 0.0, // id 1
+        0.0, 1.0, 0.0, // id 2
+        0.0, 0.0, 1.0, // id 3
+    ];
+    let bytes = velesdb_core::wire::vrb1::encode(&ids, &vectors, 3);
+    std::fs::write(&bin_path, &bytes).unwrap();
+
+    let db = Database::open(&db_path).unwrap();
+    let config = ImportConfig {
+        collection: "test".to_string(),
+        show_progress: false,
+        ..Default::default()
+    };
+
+    let stats = import_raw_bulk(&db, &bin_path, &config).unwrap();
+
+    assert_eq!(stats.total, 3);
+    assert_eq!(stats.imported, 3);
+    assert_eq!(stats.errors, 0);
+
+    // The imported vectors must be searchable.
+    let col = db.get_vector_collection("test").unwrap();
+    assert_eq!(col.len(), 3);
+    let results = col.search(&[1.0, 0.0, 0.0], 1).unwrap();
+    assert_eq!(results[0].point.id, 1);
+}
+
+#[test]
+fn test_import_raw_bulk_invalid_magic() {
+    let dir = tempdir().unwrap();
+    let db_path = dir.path().join("db");
+    let bin_path = dir.path().join("bad.bin");
+
+    let mut bytes = velesdb_core::wire::vrb1::encode(&[1u64], &[0.0f32, 0.0, 0.0], 3);
+    bytes[0] = b'X'; // corrupt the magic
+    std::fs::write(&bin_path, &bytes).unwrap();
+
+    let db = Database::open(&db_path).unwrap();
+    let config = ImportConfig {
+        collection: "test".to_string(),
+        show_progress: false,
+        ..Default::default()
+    };
+
+    assert!(import_raw_bulk(&db, &bin_path, &config).is_err());
+}
+
+// =========================================================================
 // Integration tests for typical usage scenarios
 // =========================================================================
 

--- a/crates/velesdb-core/src/lib.rs
+++ b/crates/velesdb-core/src/lib.rs
@@ -155,6 +155,8 @@ pub mod vector_ref;
 #[cfg(test)]
 mod vector_ref_tests;
 pub mod velesql;
+/// Binary wire formats (VRB1 raw-bulk) — pure, persistence-free, wasm-safe.
+pub mod wire;
 
 #[cfg(all(not(target_arch = "wasm32"), feature = "update-check"))]
 pub use update_check::{check_for_updates, spawn_update_check};

--- a/crates/velesdb-core/src/wire/mod.rs
+++ b/crates/velesdb-core/src/wire/mod.rs
@@ -1,0 +1,6 @@
+//! Binary wire formats shared across the server, CLI, and SDKs.
+//!
+//! These are pure byte (de)serialisers with no storage or persistence
+//! dependency, so they compile on every target (including `wasm32`).
+
+pub mod vrb1;

--- a/crates/velesdb-core/src/wire/vrb1.rs
+++ b/crates/velesdb-core/src/wire/vrb1.rs
@@ -1,0 +1,285 @@
+//! VRB1 ("Veles Raw Bulk v1") binary wire codec.
+//!
+//! A length-prefixed, tightly-packed binary encoding of `(id, vector)` pairs
+//! for zero-copy bulk upsert, avoiding the per-point JSON overhead of the
+//! object endpoints. Payloads are not carried on this path.
+//!
+//! This is the single shared codec used by both the server raw-bulk handler
+//! and the CLI `.bin` importer — neither should re-parse the format itself.
+//!
+//! # Wire format (little-endian)
+//!
+//! ```text
+//! offset  size                     field
+//! ------  -----------------------  --------------------------------------
+//! 0       4                        magic  = b"VRB1"  (Veles Raw Bulk v1)
+//! 4       4                        count  : u32      (number of points)
+//! 8       4                        dim    : u32      (vector dimension)
+//! 12      1                        id_width : u8     (must be 8 → u64)
+//! 13      3                        reserved (must be 0) — header is 16 bytes
+//! 16      count * 8                ids    : [u64; count]
+//! 16+8c   count * dim * 4          vectors: [f32; count * dim] (row-major)
+//! ```
+//!
+//! The total length must be **exactly** `16 + count * 8 + count * dim * 4`
+//! bytes; any mismatch is an error. The encoding is deterministic: a given
+//! batch always serialises to the same bytes (see [`encode`] / [`decode`]).
+
+use std::fmt;
+
+/// 4-byte magic prefix identifying the v1 raw-bulk wire format.
+const MAGIC: &[u8; 4] = b"VRB1";
+
+/// Fixed header length: `magic`(4) + `count`(4) + `dim`(4) + `id_width`(1) + `reserved`(3).
+const HEADER_LEN: usize = 16;
+
+/// The only supported id width: `u64` ids are 8 bytes each.
+const ID_WIDTH: u8 = 8;
+
+/// A decoded VRB1 batch: owned `ids`, a flat row-major `vectors` buffer, and
+/// the declared `dimension`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RawBulk {
+    /// Point ids, in batch order.
+    pub ids: Vec<u64>,
+    /// Flat `f32` buffer of shape `(ids.len(), dimension)`, row-major.
+    pub vectors: Vec<f32>,
+    /// Declared vector dimension.
+    pub dimension: usize,
+}
+
+/// Errors produced while decoding a VRB1 body.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum VrbError {
+    /// Body shorter than the fixed 16-byte header.
+    TooShort {
+        /// Actual body length in bytes.
+        got: usize,
+    },
+    /// First four bytes are not `b"VRB1"`.
+    BadMagic,
+    /// `id_width` byte is not the supported value (8).
+    BadIdWidth(u8),
+    /// One or more reserved header bytes were non-zero.
+    ReservedNotZero,
+    /// Arithmetic overflow while computing the expected body length.
+    Overflow,
+    /// Body length does not match the length implied by `count`/`dim`.
+    LengthMismatch {
+        /// Actual body length in bytes.
+        got: usize,
+        /// Length implied by the header.
+        expected: usize,
+    },
+}
+
+impl fmt::Display for VrbError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::TooShort { got } => {
+                write!(f, "body too short: {got} bytes (header needs {HEADER_LEN})")
+            }
+            Self::BadMagic => write!(f, "bad magic: expected b\"VRB1\""),
+            Self::BadIdWidth(w) => {
+                write!(
+                    f,
+                    "unsupported id_width {w}: only {ID_WIDTH} (u64) is supported"
+                )
+            }
+            Self::ReservedNotZero => write!(f, "reserved header bytes must be zero"),
+            Self::Overflow => write!(f, "overflow computing body length"),
+            Self::LengthMismatch { got, expected } => {
+                write!(f, "body length {got} != expected {expected}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for VrbError {}
+
+/// Parse the fixed 16-byte header, returning `(count, dim)`.
+///
+/// Validates the magic, the id width, and the reserved padding so a malformed
+/// or wrong-version body is rejected before any allocation.
+fn parse_header(body: &[u8]) -> Result<(usize, usize), VrbError> {
+    if body.len() < HEADER_LEN {
+        return Err(VrbError::TooShort { got: body.len() });
+    }
+    if &body[0..4] != MAGIC {
+        return Err(VrbError::BadMagic);
+    }
+    let count = u32::from_le_bytes([body[4], body[5], body[6], body[7]]) as usize;
+    let dim = u32::from_le_bytes([body[8], body[9], body[10], body[11]]) as usize;
+    if body[12] != ID_WIDTH {
+        return Err(VrbError::BadIdWidth(body[12]));
+    }
+    if body[13] != 0 || body[14] != 0 || body[15] != 0 {
+        return Err(VrbError::ReservedNotZero);
+    }
+    Ok((count, dim))
+}
+
+/// Compute the expected total body length for `count` points of `dim` floats.
+///
+/// Returns [`VrbError::Overflow`] on arithmetic overflow rather than panicking.
+fn expected_body_len(count: usize, dim: usize) -> Result<usize, VrbError> {
+    let ids_bytes = count.checked_mul(8).ok_or(VrbError::Overflow)?;
+    let vec_elems = count.checked_mul(dim).ok_or(VrbError::Overflow)?;
+    let vec_bytes = vec_elems.checked_mul(4).ok_or(VrbError::Overflow)?;
+    HEADER_LEN
+        .checked_add(ids_bytes)
+        .and_then(|h| h.checked_add(vec_bytes))
+        .ok_or(VrbError::Overflow)
+}
+
+/// Decode the tightly-packed id section into a `Vec<u64>`.
+///
+/// The caller validates the exact body length first, so every 8-byte chunk is
+/// in bounds; `chunks_exact` drops any trailing partial chunk safely.
+fn decode_ids(body: &[u8], count: usize) -> Vec<u64> {
+    let start = HEADER_LEN;
+    let end = start + count * 8;
+    body[start..end]
+        .chunks_exact(8)
+        .map(|c| u64::from_le_bytes([c[0], c[1], c[2], c[3], c[4], c[5], c[6], c[7]]))
+        .collect()
+}
+
+/// Decode the tightly-packed vector section into a flat `Vec<f32>`.
+fn decode_vectors(body: &[u8], count: usize, dim: usize) -> Vec<f32> {
+    let start = HEADER_LEN + count * 8;
+    let end = start + count * dim * 4;
+    body[start..end]
+        .chunks_exact(4)
+        .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+        .collect()
+}
+
+/// Decode a full VRB1 body into a [`RawBulk`].
+///
+/// Validates the header and the exact total length before decoding, so all
+/// slice accesses in [`decode_ids`] / [`decode_vectors`] are in bounds.
+///
+/// # Errors
+///
+/// Returns a [`VrbError`] for a too-short body, bad magic, unsupported id
+/// width, non-zero reserved bytes, length overflow, or a length mismatch.
+pub fn decode(body: &[u8]) -> Result<RawBulk, VrbError> {
+    let (count, dim) = parse_header(body)?;
+    let expected = expected_body_len(count, dim)?;
+    if body.len() != expected {
+        return Err(VrbError::LengthMismatch {
+            got: body.len(),
+            expected,
+        });
+    }
+    Ok(RawBulk {
+        ids: decode_ids(body, count),
+        vectors: decode_vectors(body, count, dim),
+        dimension: dim,
+    })
+}
+
+/// Encode an `(ids, vectors)` batch into the VRB1 wire format.
+///
+/// The inverse of [`decode`]; `vectors` is a flat row-major buffer of shape
+/// `(ids.len(), dimension)`. The caller is responsible for the invariant
+/// `vectors.len() == ids.len() * dimension`; a mismatch round-trips to a
+/// body that [`decode`] rejects with [`VrbError::LengthMismatch`].
+#[must_use]
+pub fn encode(ids: &[u64], vectors: &[f32], dimension: usize) -> Vec<u8> {
+    let count = ids.len();
+    let mut buf = Vec::with_capacity(HEADER_LEN + count * 8 + vectors.len() * 4);
+    buf.extend_from_slice(MAGIC);
+    // `count`/`dimension` exceeding u32::MAX (~4.3 billion) cannot be held in
+    // memory on this path, so the saturation is unreachable for any encodable
+    // batch and never corrupts a representable one.
+    buf.extend_from_slice(&u32::try_from(count).unwrap_or(u32::MAX).to_le_bytes());
+    buf.extend_from_slice(&u32::try_from(dimension).unwrap_or(u32::MAX).to_le_bytes());
+    buf.push(ID_WIDTH);
+    buf.extend_from_slice(&[0u8; 3]);
+    for id in ids {
+        buf.extend_from_slice(&id.to_le_bytes());
+    }
+    for v in vectors {
+        buf.extend_from_slice(&v.to_le_bytes());
+    }
+    buf
+}
+
+#[cfg(test)]
+#[allow(clippy::float_cmp)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn roundtrip_decode_encode() {
+        let ids = [1u64, 2, 3];
+        let vectors = [0.1f32, 0.2, 0.3, 0.4, 0.5, 0.6];
+        let body = encode(&ids, &vectors, 2);
+        let raw = decode(&body).expect("valid body decodes");
+        assert_eq!(raw.ids, vec![1, 2, 3]);
+        assert_eq!(raw.vectors, vec![0.1, 0.2, 0.3, 0.4, 0.5, 0.6]);
+        assert_eq!(raw.dimension, 2);
+    }
+
+    #[test]
+    fn encode_is_deterministic_and_pinned() {
+        let ids = [7u64, 42];
+        let vectors = [1.0f32, 2.0, 3.0, 4.0];
+        let a = encode(&ids, &vectors, 2);
+        let b = encode(&ids, &vectors, 2);
+        assert_eq!(a, b, "encoding must be deterministic");
+        assert_eq!(&a[0..4], b"VRB1");
+        assert_eq!(&a[4..8], &2u32.to_le_bytes());
+        assert_eq!(&a[8..12], &2u32.to_le_bytes());
+        assert_eq!(a[12], 8);
+        assert_eq!(&a[13..16], &[0, 0, 0]);
+    }
+
+    #[test]
+    fn empty_batch_roundtrips() {
+        let body = encode(&[], &[], 4);
+        let raw = decode(&body).expect("empty batch decodes");
+        assert!(raw.ids.is_empty());
+        assert!(raw.vectors.is_empty());
+        assert_eq!(raw.dimension, 4);
+    }
+
+    #[test]
+    fn bad_magic_rejected() {
+        let mut body = encode(&[1], &[0.0, 0.0], 2);
+        body[0] = b'X';
+        assert_eq!(decode(&body), Err(VrbError::BadMagic));
+    }
+
+    #[test]
+    fn short_body_rejected() {
+        let body = vec![0u8; 4];
+        assert_eq!(decode(&body), Err(VrbError::TooShort { got: 4 }));
+    }
+
+    #[test]
+    fn bad_id_width_rejected() {
+        let mut body = encode(&[1], &[0.0, 0.0], 2);
+        body[12] = 4; // u32 ids unsupported
+        assert_eq!(decode(&body), Err(VrbError::BadIdWidth(4)));
+    }
+
+    #[test]
+    fn reserved_not_zero_rejected() {
+        let mut body = encode(&[1], &[0.0, 0.0], 2);
+        body[13] = 1;
+        assert_eq!(decode(&body), Err(VrbError::ReservedNotZero));
+    }
+
+    #[test]
+    fn length_mismatch_rejected() {
+        let mut body = encode(&[1, 2], &[0.0, 0.0, 0.0, 0.0], 2);
+        body.pop(); // truncate one byte
+        match decode(&body) {
+            Err(VrbError::LengthMismatch { .. }) => {}
+            other => panic!("expected LengthMismatch, got {other:?}"),
+        }
+    }
+}

--- a/crates/velesdb-server/src/handlers/points/raw.rs
+++ b/crates/velesdb-server/src/handlers/points/raw.rs
@@ -5,151 +5,26 @@
 //! [`super::upsert_points`]. Payloads are not carried on this path — use the
 //! JSON endpoint when you need them.
 //!
-//! # Wire format (`application/octet-stream`, little-endian)
-//!
-//! All multi-byte integers and `f32`s are little-endian. The body is:
-//!
-//! ```text
-//! offset  size                     field
-//! ------  -----------------------  --------------------------------------
-//! 0       4                        magic  = b"VRB1"  (Veles Raw Bulk v1)
-//! 4       4                        count  : u32      (number of points)
-//! 8       4                        dim    : u32      (vector dimension)
-//! 12      1                        id_width : u8     (must be 8 → u64)
-//! 13      3                        reserved (must be 0) — header is 16 bytes
-//! 16      count * 8                ids    : [u64; count]
-//! 16+8c   count * dim * 4          vectors: [f32; count * dim] (row-major)
-//! ```
-//!
-//! The total body length must be **exactly**
-//! `16 + count * 8 + count * dim * 4` bytes; any mismatch is a `400`.
-//!
-//! The format is deterministic: a given batch always serialises to the same
-//! bytes (see [`encode_raw_bulk`] in the tests), so clients and the server
-//! agree byte-for-byte.
+//! The wire format (VRB1) and its codec live in the shared
+//! [`velesdb_core::wire::vrb1`] module, so the server and the CLI agree
+//! byte-for-byte without duplicating the parser.
 
 use axum::{body::Bytes, extract::Path, extract::State, http::StatusCode, response::IntoResponse};
 use std::sync::Arc;
+use velesdb_core::wire::vrb1;
 
 use super::upsert_result_to_response;
 use crate::handlers::helpers::{error_response, get_vector_collection_or_404};
 use crate::types::ErrorResponse;
 use crate::AppState;
 
-/// 4-byte magic prefix identifying the v1 raw-bulk wire format.
-const RAW_BULK_MAGIC: &[u8; 4] = b"VRB1";
-
-/// Fixed header length in bytes: magic(4) + count(4) + dim(4) + id_width(1) + reserved(3).
-const RAW_BULK_HEADER_LEN: usize = 16;
-
-/// The only supported id width: `u64` ids are 8 bytes each.
-const RAW_BULK_ID_WIDTH: u8 = 8;
-
-/// Parsed view over a raw-bulk binary body: owned `ids` plus a flat `vectors`
-/// buffer and the declared `dimension`.
-struct RawBulkBatch {
-    ids: Vec<u64>,
-    vectors: Vec<f32>,
-    dimension: usize,
-}
-
-/// Parse the fixed 16-byte header, returning `(count, dim)`.
-///
-/// Validates the magic, the id width, and the reserved padding so that a
-/// malformed or wrong-version body is rejected before any allocation.
-fn parse_raw_bulk_header(body: &[u8]) -> Result<(usize, usize), String> {
-    if body.len() < RAW_BULK_HEADER_LEN {
-        return Err(format!(
-            "body too short: {} bytes (header needs {RAW_BULK_HEADER_LEN})",
-            body.len()
-        ));
-    }
-    if &body[0..4] != RAW_BULK_MAGIC {
-        return Err("bad magic: expected b\"VRB1\"".to_string());
-    }
-    let count = u32::from_le_bytes([body[4], body[5], body[6], body[7]]) as usize;
-    let dim = u32::from_le_bytes([body[8], body[9], body[10], body[11]]) as usize;
-    if body[12] != RAW_BULK_ID_WIDTH {
-        return Err(format!(
-            "unsupported id_width {}: only {RAW_BULK_ID_WIDTH} (u64) is supported",
-            body[12]
-        ));
-    }
-    if body[13] != 0 || body[14] != 0 || body[15] != 0 {
-        return Err("reserved header bytes must be zero".to_string());
-    }
-    Ok((count, dim))
-}
-
-/// Compute the expected total body length for `count` points of `dim` floats.
-///
-/// Returns `Err` on arithmetic overflow rather than panicking.
-fn expected_body_len(count: usize, dim: usize) -> Result<usize, String> {
-    let ids_bytes = count
-        .checked_mul(8)
-        .ok_or_else(|| "overflow computing id section length".to_string())?;
-    let vec_elems = count
-        .checked_mul(dim)
-        .ok_or_else(|| "overflow computing vector element count".to_string())?;
-    let vec_bytes = vec_elems
-        .checked_mul(4)
-        .ok_or_else(|| "overflow computing vector section length".to_string())?;
-    RAW_BULK_HEADER_LEN
-        .checked_add(ids_bytes)
-        .and_then(|h| h.checked_add(vec_bytes))
-        .ok_or_else(|| "overflow computing total body length".to_string())
-}
-
-/// Decode the tightly-packed id section into a `Vec<u64>`.
-///
-/// The caller validates the exact body length first, so every 8-byte chunk
-/// is in bounds; `chunks_exact` drops any trailing partial chunk safely.
-fn decode_ids(body: &[u8], count: usize) -> Vec<u64> {
-    let start = RAW_BULK_HEADER_LEN;
-    let end = start + count * 8;
-    body[start..end]
-        .chunks_exact(8)
-        .map(|c| u64::from_le_bytes([c[0], c[1], c[2], c[3], c[4], c[5], c[6], c[7]]))
-        .collect()
-}
-
-/// Decode the tightly-packed vector section into a flat `Vec<f32>`.
-fn decode_vectors(body: &[u8], count: usize, dim: usize) -> Vec<f32> {
-    let start = RAW_BULK_HEADER_LEN + count * 8;
-    let end = start + count * dim * 4;
-    body[start..end]
-        .chunks_exact(4)
-        .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
-        .collect()
-}
-
-/// Parse a full raw-bulk body into a [`RawBulkBatch`].
-///
-/// Validates the header and the exact total length before decoding, so all
-/// slice accesses in [`decode_ids`] / [`decode_vectors`] are in bounds.
-fn parse_raw_bulk_body(body: &[u8]) -> Result<RawBulkBatch, String> {
-    let (count, dim) = parse_raw_bulk_header(body)?;
-    let expected = expected_body_len(count, dim)?;
-    if body.len() != expected {
-        return Err(format!(
-            "body length {} != expected {expected} (count={count}, dim={dim})",
-            body.len()
-        ));
-    }
-    Ok(RawBulkBatch {
-        ids: decode_ids(body, count),
-        vectors: decode_vectors(body, count, dim),
-        dimension: dim,
-    })
-}
-
 /// Bulk upsert points via the binary wire format.
 ///
-/// Accepts an `application/octet-stream` body in the v1 raw-bulk format
-/// documented at the module level: a 16-byte header (magic, count, dim,
-/// id_width) followed by tightly-packed `u64` ids and `f32` vectors. The
-/// vectors are forwarded to `Collection::upsert_bulk_from_raw` (zero per-point
-/// `Point` allocation). Payloads are not supported on this path.
+/// Accepts an `application/octet-stream` body in the VRB1 raw-bulk format
+/// (a 16-byte header — magic, count, dim, id_width — followed by tightly-packed
+/// `u64` ids and `f32` vectors). The vectors are forwarded to
+/// `Collection::upsert_bulk_from_raw` (zero per-point `Point` allocation).
+/// Payloads are not supported on this path.
 #[utoipa::path(
     post,
     path = "/collections/{name}/points/raw",
@@ -174,9 +49,9 @@ pub async fn upsert_points_raw(
         Err(resp) => return resp,
     };
 
-    let batch = match parse_raw_bulk_body(&body) {
+    let batch = match vrb1::decode(&body) {
         Ok(b) => b,
-        Err(msg) => return error_response(StatusCode::BAD_REQUEST, msg),
+        Err(err) => return error_response(StatusCode::BAD_REQUEST, err.to_string()),
     };
 
     let dimension = batch.dimension;
@@ -191,88 +66,4 @@ pub async fn upsert_points_raw(
     .await;
 
     upsert_result_to_response(&state, &name, result)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    /// Test-only encoder mirroring the documented wire format. Kept here so
-    /// the round-trip test is self-contained and the format stays pinned.
-    fn encode_raw_bulk(ids: &[u64], vectors: &[f32], dim: usize) -> Vec<u8> {
-        let count = ids.len();
-        let mut buf = Vec::with_capacity(RAW_BULK_HEADER_LEN + count * 8 + count * dim * 4);
-        buf.extend_from_slice(RAW_BULK_MAGIC);
-        let count_u32 = u32::try_from(count).expect("test: count fits u32");
-        let dim_u32 = u32::try_from(dim).expect("test: dim fits u32");
-        buf.extend_from_slice(&count_u32.to_le_bytes());
-        buf.extend_from_slice(&dim_u32.to_le_bytes());
-        buf.push(RAW_BULK_ID_WIDTH);
-        buf.extend_from_slice(&[0u8; 3]);
-        for id in ids {
-            buf.extend_from_slice(&id.to_le_bytes());
-        }
-        for v in vectors {
-            buf.extend_from_slice(&v.to_le_bytes());
-        }
-        buf
-    }
-
-    #[test]
-    fn test_roundtrip_parse() {
-        let ids = [1u64, 2, 3];
-        let vectors = [0.1f32, 0.2, 0.3, 0.4, 0.5, 0.6];
-        let body = encode_raw_bulk(&ids, &vectors, 2);
-        let batch = parse_raw_bulk_body(&body).expect("test: valid body parses");
-        assert_eq!(batch.ids, vec![1, 2, 3]);
-        assert_eq!(batch.vectors, vec![0.1, 0.2, 0.3, 0.4, 0.5, 0.6]);
-        assert_eq!(batch.dimension, 2);
-    }
-
-    #[test]
-    fn test_deterministic_encoding() {
-        let ids = [7u64, 42];
-        let vectors = [1.0f32, 2.0, 3.0, 4.0];
-        let a = encode_raw_bulk(&ids, &vectors, 2);
-        let b = encode_raw_bulk(&ids, &vectors, 2);
-        assert_eq!(a, b, "encoding must be deterministic");
-        // First bytes are the magic, then count=2 LE, then dim=2 LE, id_width=8.
-        assert_eq!(&a[0..4], b"VRB1");
-        assert_eq!(&a[4..8], &2u32.to_le_bytes());
-        assert_eq!(&a[8..12], &2u32.to_le_bytes());
-        assert_eq!(a[12], 8);
-        assert_eq!(&a[13..16], &[0, 0, 0]);
-    }
-
-    #[test]
-    fn test_bad_magic_rejected() {
-        let mut body = encode_raw_bulk(&[1], &[0.0, 0.0], 2);
-        body[0] = b'X';
-        assert!(parse_raw_bulk_body(&body).is_err());
-    }
-
-    #[test]
-    fn test_length_mismatch_rejected() {
-        let mut body = encode_raw_bulk(&[1, 2], &[0.0, 0.0, 0.0, 0.0], 2);
-        body.pop(); // truncate one byte
-        match parse_raw_bulk_body(&body) {
-            Ok(_) => panic!("truncated body must fail"),
-            Err(err) => assert!(err.contains("body length"), "got: {err}"),
-        }
-    }
-
-    #[test]
-    fn test_short_body_rejected() {
-        let body = vec![0u8; 4];
-        assert!(parse_raw_bulk_body(&body).is_err());
-    }
-
-    #[test]
-    fn test_empty_batch_parses() {
-        let body = encode_raw_bulk(&[], &[], 4);
-        let batch = parse_raw_bulk_body(&body).expect("test: empty batch parses");
-        assert!(batch.ids.is_empty());
-        assert!(batch.vectors.is_empty());
-        assert_eq!(batch.dimension, 4);
-    }
 }

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1890,7 +1890,7 @@
           "points"
         ],
         "summary": "Bulk upsert points via the binary wire format.",
-        "description": "Accepts an `application/octet-stream` body in the v1 raw-bulk format\ndocumented at the module level: a 16-byte header (magic, count, dim,\nid_width) followed by tightly-packed `u64` ids and `f32` vectors. The\nvectors are forwarded to `Collection::upsert_bulk_from_raw` (zero per-point\n`Point` allocation). Payloads are not supported on this path.",
+        "description": "Accepts an `application/octet-stream` body in the VRB1 raw-bulk format\n(a 16-byte header — magic, count, dim, id_width — followed by tightly-packed\n`u64` ids and `f32` vectors). The vectors are forwarded to\n`Collection::upsert_bulk_from_raw` (zero per-point `Point` allocation).\nPayloads are not supported on this path.",
         "operationId": "upsert_points_raw",
         "parameters": [
           {

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1244,11 +1244,11 @@ paths:
       - points
       summary: Bulk upsert points via the binary wire format.
       description: |-
-        Accepts an `application/octet-stream` body in the v1 raw-bulk format
-        documented at the module level: a 16-byte header (magic, count, dim,
-        id_width) followed by tightly-packed `u64` ids and `f32` vectors. The
-        vectors are forwarded to `Collection::upsert_bulk_from_raw` (zero per-point
-        `Point` allocation). Payloads are not supported on this path.
+        Accepts an `application/octet-stream` body in the VRB1 raw-bulk format
+        (a 16-byte header — magic, count, dim, id_width — followed by tightly-packed
+        `u64` ids and `f32` vectors). The vectors are forwarded to
+        `Collection::upsert_bulk_from_raw` (zero per-point `Point` allocation).
+        Payloads are not supported on this path.
       operationId: upsert_points_raw
       parameters:
       - name: name


### PR DESCRIPTION
## What & why

The CLI could import JSONL/CSV (text) but had no binary raw-bulk ingest, unlike REST/TS (PR #1104). This adds a `.bin`/`.vrb1` import format that ingests the VRB1 binary layout and feeds core's zero-copy `upsert_bulk_from_raw`.

## Change (DRY)

- **One shared codec** `velesdb_core::wire::vrb1` (`decode` + `encode` + `VrbError`) — pure, persistence-free, wasm-safe.
- **Server refactor**: `/points/raw` handler now delegates to the shared codec; its private parser was **removed** (`raw.rs` 278 → 69 lines). Same route, same 400 error shape — the 4 server raw-bulk integration tests pass unchanged.
- **CLI**: a `"bin" | "vrb1"` arm on `handle_import` → `import_raw_bulk` (read file → `vrb1::decode` → `get_or_create_collection` sized by the header dim → `upsert_bulk_from_raw`). No payloads on this path (matches the VRB1 contract).

## Tests & docs

- 8 core codec tests (round-trip, pinned header, empty, bad-magic, short-body, bad-id-width, reserved-not-zero, length-mismatch) + 2 CLI tests (import round-trip + invalid-magic).
- CLI README documents the `.bin`/VRB1 format (header layout, no payloads, dim auto-sized), dated 2026-06-14.
- OpenAPI spec regenerated (handler doc-comment only; no route change).

## Validation (local)

`cargo clippy` pedantic clean on core/server/CLI · core 8/8 · server raw-bulk 4/4 · CLI suite + 2 new green · `cargo check -p velesdb-wasm --no-default-features --target wasm32-unknown-unknown` clean · `check_prod_unwraps.py` passes.

> Completes item K together with the WASM half (#1119). A follow-up reconciles the parity matrix + roadmap.