### PR TITLE
ci: reject AI-attributed commits and consolidate the tool identity

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -27,7 +27,7 @@ jobs:
           path-to-signatures: signatures/cla.json
           path-to-document: https://github.com/cyberlife-coder/velesdb/blob/develop/CONTRIBUTING.md#contributor-license-agreement-cla
           branch: develop
-          allowlist: cyberlife-coder,dependabot[bot],github-actions[bot],noreply@anthropic.com
+          allowlist: cyberlife-coder,dependabot[bot],github-actions[bot]
           lock-pullrequest-aftermerge: false
           custom-notsigned-prcomment: |
             Thank you for your contribution to VelesDB!

--- a/.github/workflows/pr-governance.yml
+++ b/.github/workflows/pr-governance.yml
@@ -45,7 +45,7 @@ jobs:
             case "$src" in
               feature/*|feat/*|fix/*|bugfix/*|refactor/*|chore/*) return 0 ;;
               docs/*|style/*|perf/*|test/*|build/*|ci/*) return 0 ;;
-              dependabot/*|claude/*) return 0 ;;
+              dependabot/*) return 0 ;;
               *) return 1 ;;
             esac
           }
@@ -97,3 +97,21 @@ jobs:
             echo "::error::Branch is behind origin/${BASE_REF}. Rebase/merge ${BASE_REF} before opening this PR."
             exit 1
           fi
+
+      - name: Reject AI-attributed commits
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          # Commits introduced by this PR must be authored as the human
+          # maintainer, with no AI/assistant identity or attribution trailers.
+          git fetch origin "${BASE_REF}" --depth=200
+          range="origin/${BASE_REF}..HEAD"
+          ident=$(git log "$range" --format='%H %an <%ae> | %cn <%ce>' | grep -iE 'claude|anthropic' || true)
+          trailers=$(git log "$range" --format='%B' | grep -iE 'co-authored-by:.*(claude|anthropic)|generated with.*claude|claude\.ai/code|🤖' || true)
+          if [ -n "$ident" ] || [ -n "$trailers" ]; then
+            echo "::error::AI attribution is not allowed. Re-author commits as the maintainer and strip any Co-Authored-By / Generated-with / 🤖 trailers."
+            [ -n "$ident" ] && { echo "Offending author/committer identity:"; echo "$ident"; }
+            [ -n "$trailers" ] && { echo "Offending message lines:"; echo "$trailers"; }
+            exit 1
+          fi
+          echo "OK: no AI attribution in PR commits."

--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,5 @@
+# Consolidate the historical AI-tool committer identity onto the maintainer so
+# `git shortlog`, `git blame --use-mailmap`, and GitHub's contributor graph
+# attribute those commits to the human maintainer. Going forward, AI-attributed
+# commits are rejected by the PR governance check (.github/workflows/pr-governance.yml).
+cyberlife-coder <174732281+cyberlife-coder@users.noreply.github.com> <noreply@anthropic.com>


### PR DESCRIPTION
Prevents AI/tool attribution from entering the history going forward, and tidies the existing record — no history rewrite.

## Changes

- **`pr-governance.yml`** — new "Reject AI-attributed commits" step: fails a PR if any of its commits is authored/committed by the AI tool identity, or carries an attribution trailer (`Co-Authored-By` / `Generated with` / 🤖 / session URL) in the message.
- **Reverse the prior allowance** (commit `996aa9bb`): drop the tool address from the `cla.yml` allowlist, and remove the `claude/*` prefix from the Git Flow branch rules.
- **`.mailmap`** — maps the historical tool committer identity onto the maintainer, so `git shortlog`, `git blame --use-mailmap`, and GitHub's contributor graph attribute those commits to the maintainer (the contributor list no longer lists the tool).

## Notes

- No commits rewritten, nothing force-pushed — fully additive.
- Individual historical commit pages still show the old author (that needs a history rewrite, intentionally not done); aggregated views are corrected by `.mailmap`.
- The guard checks only the commits a PR introduces (`origin/<base>..HEAD`), so it never flags historical commits.