### PR TITLE
fix(python): sync .pyi type stubs with the runtime compatibility surface

### DIFF
--- a/crates/velesdb-python/python/velesdb/__init__.pyi
+++ b/crates/velesdb-python/python/velesdb/__init__.pyi
@@ -88,6 +88,7 @@ class FusionStrategy:
         ...
 
     @staticmethod
+    @overload
     def weighted(
         avg_weight: float,
         max_weight: float,
@@ -106,6 +107,29 @@ class FusionStrategy:
         ...
 
     @staticmethod
+    @overload
+    def weighted(weights: Dict[str, float]) -> "FusionStrategy":
+        """Create a Weighted fusion strategy from a ``{"avg"/"max"/"hit": w}`` dict."""
+        ...
+
+    @staticmethod
+    @overload
+    def weighted(max_weight: float, hit_weight: float) -> "FusionStrategy":
+        """Legacy two-argument form: ``avg_weight`` is derived from the remainder."""
+        ...
+
+    @staticmethod
+    @overload
+    def weighted(
+        avg_weight: None = None,
+        *,
+        max_weight: float,
+        hit_weight: float,
+    ) -> "FusionStrategy":
+        """Legacy keyword form: ``avg_weight`` is derived from the remainder."""
+        ...
+
+    @staticmethod
     def relative_score(dense_weight: float, sparse_weight: float) -> "FusionStrategy":
         """Create a Relative Score Fusion (RSF) strategy for hybrid dense+sparse search.
 
@@ -116,6 +140,11 @@ class FusionStrategy:
         Raises:
             ValueError: If weights are invalid
         """
+        ...
+
+    @staticmethod
+    def rsf(dense_weight: float = 0.5, sparse_weight: float = 0.5) -> "FusionStrategy":
+        """Short alias for :meth:`relative_score` (``USING FUSION rsf`` in VelesQL)."""
         ...
 
 
@@ -975,6 +1004,10 @@ class Database:
         """
         ...
 
+    def get_collections(self) -> List[str]:
+        """Compatibility alias for :meth:`list_collections`."""
+        ...
+
     def delete_collection(self, name: str) -> None:
         """Delete a collection.
 
@@ -1000,7 +1033,7 @@ class Database:
         dimension: Optional[int] = None,
         metric: str = "cosine",
         schema: Optional["PyGraphSchema"] = None,
-    ) -> "PyGraphCollection":
+    ) -> "GraphCollection":
         """Create a new persistent graph collection.
 
         Args:
@@ -1014,7 +1047,7 @@ class Database:
         """
         ...
 
-    def get_graph_collection(self, name: str) -> Optional["PyGraphCollection"]:
+    def get_graph_collection(self, name: str) -> Optional["GraphCollection"]:
         """Get an existing graph collection by name.
 
         Returns:
@@ -1234,7 +1267,9 @@ class GraphStore:
 
     def get_edges_by_label(self, label: str) -> List[GraphEdgeDict]: ...
     def get_outgoing(self, node_id: int) -> List[GraphEdgeDict]: ...
+    def get_outgoing_edges(self, node_id: int) -> List[GraphEdgeDict]: ...
     def get_incoming(self, node_id: int) -> List[GraphEdgeDict]: ...
+    def get_incoming_edges(self, node_id: int) -> List[GraphEdgeDict]: ...
     def get_outgoing_by_label(self, node_id: int, label: str) -> List[GraphEdgeDict]: ...
 
     def traverse_bfs_streaming(
@@ -1243,6 +1278,7 @@ class GraphStore:
 
     def remove_edge(self, edge_id: int) -> None: ...
     def edge_count(self) -> int: ...
+    def has_edge(self, edge_id: int) -> bool: ...
 
 
 class PyGraphSchema:
@@ -1323,8 +1359,16 @@ class PyGraphCollection:
         """Get outgoing edges from a node."""
         ...
 
+    def get_outgoing_edges(self, node_id: int) -> List[GraphEdgeDict]:
+        """Compatibility alias for :meth:`get_outgoing`."""
+        ...
+
     def get_incoming(self, node_id: int) -> List[GraphEdgeDict]:
         """Get incoming edges to a node."""
+        ...
+
+    def get_incoming_edges(self, node_id: int) -> List[GraphEdgeDict]:
+        """Compatibility alias for :meth:`get_incoming`."""
         ...
 
     def edge_count(self) -> int:
@@ -1342,6 +1386,15 @@ class PyGraphCollection:
         API and the rest of the Python surface (which uses `upsert`
         everywhere).
         """
+        ...
+
+    def upsert_node(
+        self,
+        node_id: int,
+        payload: Dict[str, Any],
+        vector: Optional[List[float]] = None,
+    ) -> None:
+        """Upsert a node's payload, optionally with an embedding vector."""
         ...
 
     def get_node_payload(self, node_id: int) -> Optional[Dict[str, Any]]:
@@ -1537,6 +1590,10 @@ class PyGraphCollection:
         """
         ...
 
+    def has_edge(self, edge_id: int) -> bool:
+        """Return True when an edge with the given ID exists."""
+        ...
+
     def __contains__(self, node_id: int) -> bool:
         """Membership test: ``node_id in graph`` (true if node has a payload)."""
         ...
@@ -1554,6 +1611,80 @@ class PyGraphCollection:
 
         Idempotent — safe to call multiple times.
         """
+        ...
+
+
+class GraphCollection(PyGraphCollection):
+    """Python compatibility wrapper returned by the graph-collection helpers.
+
+    Returned by :meth:`Database.create_graph_collection` and
+    :meth:`Database.get_graph_collection`. Unknown attributes delegate to the
+    underlying :class:`PyGraphCollection`; the members below are the
+    facade-specific overrides and convenience aliases.
+    """
+
+    @overload
+    def add_edge(self, edge: Dict[str, Any]) -> None:
+        """Add an edge from the canonical dict shape."""
+        ...
+
+    @overload
+    def add_edge(
+        self,
+        edge_id: int,
+        *,
+        source: int,
+        target: int,
+        label: str = "RELATED_TO",
+        properties: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Add an edge using the explicit-id legacy shape."""
+        ...
+
+    @overload
+    def add_edge(
+        self,
+        source: int,
+        target: int,
+        label: str = "RELATED_TO",
+        weight: Any = None,
+    ) -> None:
+        """Add an edge using the legacy no-id positional shape."""
+        ...
+
+    def add_node(
+        self,
+        node_id: int,
+        payload: Optional[Dict[str, Any]] = None,
+        vector: Optional[List[float]] = None,
+    ) -> None:
+        """Compatibility alias for :meth:`upsert_node`."""
+        ...
+
+    def bfs(
+        self,
+        start_id: int,
+        max_depth: int = 3,
+        limit: int = 100,
+    ) -> List[TraversalResultDict]:
+        """Compatibility alias for :meth:`traverse_bfs`."""
+        ...
+
+    def dfs(
+        self,
+        start_id: int,
+        max_depth: int = 3,
+        limit: int = 100,
+    ) -> List[TraversalResultDict]:
+        """Compatibility alias for :meth:`traverse_dfs`."""
+        ...
+
+    def has_edge(self, edge_id: int) -> bool:
+        """Return True when an edge with the given ID exists."""
+        ...
+
+    def __enter__(self) -> "GraphCollection":
+        """Context manager entry — returns ``self``."""
         ...
 
 
@@ -1910,6 +2041,10 @@ class AgentMemory:
 
     def load_snapshot_version(self, version: int) -> None:
         """Load a specific snapshot version, restoring all subsystems."""
+        ...
+
+    def rollback(self, version: int) -> None:
+        """Compatibility alias for :meth:`load_snapshot_version`."""
         ...
 
     def list_snapshot_versions(self) -> List[int]:

--- a/crates/velesdb-python/tests/test_stub_parity.py
+++ b/crates/velesdb-python/tests/test_stub_parity.py
@@ -1,0 +1,62 @@
+"""Regression guard: the ``__init__.pyi`` type stub must declare the
+documented compatibility surface so typed callers (mypy/pyright) do not see
+false "attribute does not exist" errors for methods that exist at runtime.
+
+This test parses the stub with :mod:`ast` only — it does not import the
+compiled extension, so it runs anywhere pytest collects it.
+"""
+
+import ast
+from pathlib import Path
+
+
+STUB_PATH = Path(__file__).parents[1] / "python" / "velesdb" / "__init__.pyi"
+
+
+def _classes() -> dict[str, ast.ClassDef]:
+    module = ast.parse(STUB_PATH.read_text())
+    return {
+        node.name: node
+        for node in module.body
+        if isinstance(node, ast.ClassDef)
+    }
+
+
+def _methods(classes: dict[str, ast.ClassDef], class_name: str) -> set[str]:
+    return {
+        node.name
+        for node in classes[class_name].body
+        if isinstance(node, ast.FunctionDef)
+    }
+
+
+def test_compatibility_stub_surface_matches_runtime() -> None:
+    """Documented compatibility APIs must be declared in the type stub."""
+    classes = _classes()
+
+    expected = {
+        "FusionStrategy": {"rsf"},
+        "Database": {"get_collections"},
+        "GraphStore": {"get_outgoing_edges", "get_incoming_edges", "has_edge"},
+        "PyGraphCollection": {"get_outgoing_edges", "get_incoming_edges", "upsert_node"},
+        "GraphCollection": {"add_node", "bfs", "dfs", "has_edge"},
+        "AgentMemory": {"rollback"},
+    }
+
+    missing: list[str] = []
+    for class_name, method_names in expected.items():
+        assert class_name in classes, f"type stub is missing class {class_name!r}"
+        missing.extend(
+            f"{class_name}.{name}"
+            for name in sorted(method_names - _methods(classes, class_name))
+        )
+
+    weighted_overloads = [
+        node
+        for node in classes["FusionStrategy"].body
+        if isinstance(node, ast.FunctionDef) and node.name == "weighted"
+    ]
+    if len(weighted_overloads) < 4:
+        missing.append("FusionStrategy.weighted overloads")
+
+    assert missing == [], f"type stub drifted from runtime: {missing}"


### PR DESCRIPTION
## Problem

The PyO3 bindings and the `__init__.py` compatibility facade expose a number of
aliases and call shapes that were **never mirrored in the `__init__.pyi` type
stub**. Typed Python callers (mypy / pyright) therefore got false
*"attribute does not exist"* errors for methods that work perfectly at runtime —
e.g. `db.get_collections()`, `FusionStrategy.rsf(...)`, `memory.rollback(...)`,
`GraphCollection`, and the graph edge aliases. The earlier API-parity campaign
updated the `.py` facade and the Rust bindings but left the stub behind.

## Fix

Sync `__init__.pyi` with the verified runtime surface (no runtime code changes):

- `FusionStrategy.rsf`, plus the dict / legacy 2-arg / legacy kwargs `weighted()`
  forms as `@overload`s (the previous single 3-required-arg signature was itself
  inaccurate — the binding is `weighted(avg_weight=None, max_weight=None, hit_weight=None)`).
- `Database.get_collections`; `create_graph_collection` / `get_graph_collection`
  now return `GraphCollection` (the facade actually returned) rather than the raw
  `PyGraphCollection`.
- `GraphStore` & `PyGraphCollection`: `get_outgoing_edges`, `get_incoming_edges`,
  `has_edge`, `upsert_node`.
- The `GraphCollection` facade class (`add_node` / `bfs` / `dfs` / `has_edge` /
  `add_edge` overloads / `__enter__`), modelled as a `PyGraphCollection` subclass
  to express the `__getattr__` delegation.
- `AgentMemory.rollback`.

Each added declaration was checked against its real binding
(`fusion.rs`, `database.rs`, `agent.rs`, `graph_collection.rs`, `graph_store.rs`)
and the `__init__.py` facade.

## Guard

`tests/test_stub_parity.py` is an AST-only check (no compiled-extension import)
that fails if the stub drifts from the documented runtime surface again. It is
**red on `develop`** (10 missing symbols incl. the absent `GraphCollection`
class) and **green** with this change.