### PR TITLE
chore(python): upgrade pyo3 0.24 → 0.29 (+ numpy 0.29), fix the OOB advisory at root

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2666,15 +2666,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indoc"
-version = "2.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
 name = "infer"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3161,21 +3152,6 @@ dependencies = [
 
 [[package]]
 name = "ndarray"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "882ed72dce9365842bf196bdeedf5055305f11fc8c03dee7bb0194a6cad34841"
-dependencies = [
- "matrixmultiply",
- "num-complex",
- "num-integer",
- "num-traits",
- "portable-atomic",
- "portable-atomic-util",
- "rawpointer",
-]
-
-[[package]]
-name = "ndarray"
 version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "520080814a7a6b4a6e9070823bb24b4531daac8c4627e08ba5de8c5ef2f2752d"
@@ -3318,17 +3294,17 @@ dependencies = [
 
 [[package]]
 name = "numpy"
-version = "0.24.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7cfbf3f0feededcaa4d289fe3079b03659e85c5b5a177f4ba6fb01ab4fb3e39"
+checksum = "6a5b15d63a5ff39e378daed0e1340d3a5964703ea9712eb09a0dc66fade996f4"
 dependencies = [
  "libc",
- "ndarray 0.16.1",
+ "ndarray",
  "num-complex",
  "num-integer",
  "num-traits",
  "pyo3",
- "pyo3-build-config 0.24.2",
+ "pyo3-build-config",
  "rustc-hash 2.1.2",
 ]
 
@@ -4001,58 +3977,43 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.24.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5203598f366b11a02b13aa20cab591229ff0a89fd121a308a5df751d5fc9219"
+checksum = "cd274650b21d4bfc26a0a47587962c1edb425f69287324355cd040c3ea66071c"
 dependencies = [
- "cfg-if",
- "indoc",
  "inventory",
  "libc",
- "memoffset",
  "once_cell",
  "portable-atomic",
- "pyo3-build-config 0.24.2",
+ "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
- "unindent",
 ]
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.24.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99636d423fa2ca130fa5acde3059308006d46f98caac629418e53f7ebb1e9999"
-dependencies = [
- "once_cell",
- "python3-dll-a",
- "target-lexicon 0.13.5",
-]
-
-[[package]]
-name = "pyo3-build-config"
-version = "0.28.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e368e7ddfdeb98c9bca7f8383be1648fd84ab466bf2bc015e94008db6d35611e"
+checksum = "c5e2a7d2f0d013342f295c048ad19237add5154a55b1c5a254c0ec93d4109078"
 dependencies = [
  "target-lexicon 0.13.5",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.24.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78f9cf92ba9c409279bc3305b5409d90db2d2c22392d443a87df3a1adad59e33"
+checksum = "ca85c467da1bbc8d866eea5deff9cf29ea5f7785054a17da36e65bda9c05845b"
 dependencies = [
  "libc",
- "pyo3-build-config 0.24.2",
+ "pyo3-build-config",
 ]
 
 [[package]]
 name = "pyo3-macros"
-version = "0.24.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b999cb1a6ce21f9a6b147dcf1be9ffedf02e0043aec74dc390f3007047cecd9"
+checksum = "9ac53762fd065daa3194dd09337a38bd793a188100fd1a9304c4ab312d901771"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -4062,24 +4023,14 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.24.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "822ece1c7e1012745607d5cf0bcb2874769f0f7cb34c4cde03b9358eb9ef911a"
+checksum = "4ca3a1557399783172dc5bf39cfca835157732532cba56b71d2292161e53b362"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
- "pyo3-build-config 0.24.2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "python3-dll-a"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d80ba7540edb18890d444c5aa8e1f1f99b1bdf26fb26ae383135325f4a36042b"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -6422,12 +6373,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unindent"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
-
-[[package]]
 name = "unit-prefix"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6617,7 +6562,7 @@ dependencies = [
  "libc",
  "loom",
  "memmap2",
- "ndarray 0.17.2",
+ "ndarray",
  "parking_lot",
  "pest",
  "pest_derive",
@@ -6699,7 +6644,7 @@ dependencies = [
  "numpy",
  "parking_lot",
  "pyo3",
- "pyo3-build-config 0.28.3",
+ "pyo3-build-config",
  "serde_json",
  "tokio",
  "velesdb-core",

--- a/crates/velesdb-python/Cargo.toml
+++ b/crates/velesdb-python/Cargo.toml
@@ -19,9 +19,9 @@ crate-type = ["cdylib"]
 
 [dependencies]
 velesdb-core = { workspace = true }
-pyo3 = { version = "0.24", features = ["extension-module", "multiple-pymethods", "abi3-py39", "generate-import-lib"] }
+pyo3 = { version = "0.29", features = ["extension-module", "multiple-pymethods", "abi3-py39", "generate-import-lib"] }
 serde_json = { workspace = true }
-numpy = "0.24"
+numpy = "0.29"
 parking_lot = "0.12"
 # Hosts the background streaming-ingestion drain task (Collection.enable_streaming).
 # The Python process has no ambient Tokio runtime, so the bindings provide a
@@ -35,7 +35,7 @@ update-check = ["velesdb-core/update-check"]
 loom = ["velesdb-core/loom"]
 
 [build-dependencies]
-pyo3-build-config = "0.28"
+pyo3-build-config = "0.29"
 
 [lints]
 workspace = true

--- a/crates/velesdb-python/src/agent.rs
+++ b/crates/velesdb-python/src/agent.rs
@@ -24,7 +24,7 @@ use crate::exceptions::DimensionMismatchError;
 fn procedures_to_pylist(
     py: Python<'_>,
     results: Vec<velesdb_core::agent::ProcedureMatch>,
-) -> PyResult<PyObject> {
+) -> PyResult<Py<PyAny>> {
     let list = pyo3::types::PyList::empty(py);
     for m in results {
         let dict = PyDict::new(py);
@@ -39,7 +39,7 @@ fn procedures_to_pylist(
 }
 
 /// Convert episodic event tuples to a Python list of dicts.
-fn events_to_pylist(py: Python<'_>, events: Vec<(u64, String, i64)>) -> PyResult<PyObject> {
+fn events_to_pylist(py: Python<'_>, events: Vec<(u64, String, i64)>) -> PyResult<Py<PyAny>> {
     let list = pyo3::types::PyList::empty(py);
     for (id, description, timestamp) in events {
         let dict = PyDict::new(py);
@@ -187,7 +187,7 @@ impl AgentMemory {
     ///     ``False`` when no such fact exists (the call is a no-op).
     #[pyo3(signature = (id, ttl_seconds))]
     fn set_semantic_ttl(&self, py: Python<'_>, id: u64, ttl_seconds: u64) -> PyResult<bool> {
-        let exists = py.allow_threads(|| self.core.semantic().get(id).map_err(to_py_err))?;
+        let exists = py.detach(|| self.core.semantic().get(id).map_err(to_py_err))?;
         Ok(
             self.apply_ttl(exists.is_some(), id, ttl_seconds, |c, i, t| {
                 c.set_semantic_ttl(i, t);
@@ -204,7 +204,7 @@ impl AgentMemory {
     ///     ``False`` when no such event exists (the call is a no-op).
     #[pyo3(signature = (id, ttl_seconds))]
     fn set_episodic_ttl(&self, py: Python<'_>, id: u64, ttl_seconds: u64) -> PyResult<bool> {
-        let exists = py.allow_threads(|| {
+        let exists = py.detach(|| {
             self.core
                 .episodic()
                 .get_with_embedding(id)
@@ -226,7 +226,7 @@ impl AgentMemory {
     ///     ``False`` when no such procedure exists (the call is a no-op).
     #[pyo3(signature = (id, ttl_seconds))]
     fn set_procedural_ttl(&self, py: Python<'_>, id: u64, ttl_seconds: u64) -> PyResult<bool> {
-        let exists = py.allow_threads(|| {
+        let exists = py.detach(|| {
             self.core
                 .procedural()
                 .list_all()
@@ -249,7 +249,7 @@ impl AgentMemory {
     ///     KeyError: If no semantic fact with `id` exists.
     #[pyo3(signature = (id, ttl_seconds))]
     fn set_semantic_ttl_durable(&self, py: Python<'_>, id: u64, ttl_seconds: u64) -> PyResult<()> {
-        py.allow_threads(|| {
+        py.detach(|| {
             self.core
                 .set_semantic_ttl_durable(id, ttl_seconds)
                 .map_err(to_py_err)
@@ -267,7 +267,7 @@ impl AgentMemory {
     ///     KeyError: If no event with `id` exists.
     #[pyo3(signature = (id, ttl_seconds))]
     fn set_episodic_ttl_durable(&self, py: Python<'_>, id: u64, ttl_seconds: u64) -> PyResult<()> {
-        py.allow_threads(|| {
+        py.detach(|| {
             self.core
                 .set_episodic_ttl_durable(id, ttl_seconds)
                 .map_err(to_py_err)
@@ -290,7 +290,7 @@ impl AgentMemory {
         id: u64,
         ttl_seconds: u64,
     ) -> PyResult<()> {
-        py.allow_threads(|| {
+        py.detach(|| {
             self.core
                 .set_procedural_ttl_durable(id, ttl_seconds)
                 .map_err(to_py_err)
@@ -305,8 +305,8 @@ impl AgentMemory {
     ///     'consolidation_truncated' bool — True when consolidation hit the
     ///     per-cycle cap and more old episodes remain (call auto_expire again
     ///     to drain them).
-    fn auto_expire(&self, py: Python<'_>) -> PyResult<PyObject> {
-        let result = py.allow_threads(|| self.core.auto_expire().map_err(to_py_err))?;
+    fn auto_expire(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
+        let result = py.detach(|| self.core.auto_expire().map_err(to_py_err))?;
         Ok(expire_result_to_dict(py, &result))
     }
 
@@ -320,7 +320,7 @@ impl AgentMemory {
         py: Python<'_>,
         min_confidence: f32,
     ) -> PyResult<usize> {
-        py.allow_threads(|| {
+        py.detach(|| {
             self.core
                 .evict_low_confidence_procedures(min_confidence)
                 .map_err(to_py_err)
@@ -334,7 +334,7 @@ impl AgentMemory {
     /// Returns:
     ///     The version number of the created snapshot.
     fn snapshot(&self, py: Python<'_>) -> PyResult<u64> {
-        py.allow_threads(|| self.core.snapshot().map_err(to_py_err))
+        py.detach(|| self.core.snapshot().map_err(to_py_err))
     }
 
     /// Loads the most recent snapshot, restoring all memory subsystems.
@@ -342,13 +342,13 @@ impl AgentMemory {
     /// Returns:
     ///     The version number of the loaded snapshot.
     fn load_latest_snapshot(&self, py: Python<'_>) -> PyResult<u64> {
-        py.allow_threads(|| self.core.load_latest_snapshot().map_err(to_py_err))
+        py.detach(|| self.core.load_latest_snapshot().map_err(to_py_err))
     }
 
     /// Loads a specific snapshot version, restoring all memory subsystems.
     #[pyo3(signature = (version))]
     fn load_snapshot_version(&self, py: Python<'_>, version: u64) -> PyResult<()> {
-        py.allow_threads(|| self.core.load_snapshot_version(version).map_err(to_py_err))
+        py.detach(|| self.core.load_snapshot_version(version).map_err(to_py_err))
     }
 
     /// Alias for `load_snapshot_version`.
@@ -361,7 +361,7 @@ impl AgentMemory {
 
     /// Lists all available snapshot version numbers.
     fn list_snapshot_versions(&self, py: Python<'_>) -> PyResult<Vec<u64>> {
-        py.allow_threads(|| self.core.list_snapshot_versions().map_err(to_py_err))
+        py.detach(|| self.core.list_snapshot_versions().map_err(to_py_err))
     }
 
     /// Executes a VelesQL query against the semantic memory collection.
@@ -377,8 +377,8 @@ impl AgentMemory {
         &self,
         py: Python<'_>,
         query_str: &str,
-        params: Option<HashMap<String, PyObject>>,
-    ) -> PyResult<Vec<PyObject>> {
+        params: Option<HashMap<String, Py<PyAny>>>,
+    ) -> PyResult<Vec<Py<PyAny>>> {
         self.run_memory_query(py, query_str, params, |c, sql, p| c.query_semantic(sql, p))
     }
 
@@ -388,8 +388,8 @@ impl AgentMemory {
         &self,
         py: Python<'_>,
         query_str: &str,
-        params: Option<HashMap<String, PyObject>>,
-    ) -> PyResult<Vec<PyObject>> {
+        params: Option<HashMap<String, Py<PyAny>>>,
+    ) -> PyResult<Vec<Py<PyAny>>> {
         self.run_memory_query(py, query_str, params, |c, sql, p| c.query_episodic(sql, p))
     }
 
@@ -399,8 +399,8 @@ impl AgentMemory {
         &self,
         py: Python<'_>,
         query_str: &str,
-        params: Option<HashMap<String, PyObject>>,
-    ) -> PyResult<Vec<PyObject>> {
+        params: Option<HashMap<String, Py<PyAny>>>,
+    ) -> PyResult<Vec<Py<PyAny>>> {
         self.run_memory_query(py, query_str, params, |c, sql, p| {
             c.query_procedural(sql, p)
         })
@@ -434,9 +434,9 @@ impl AgentMemory {
         &self,
         py: Python<'_>,
         query_str: &str,
-        params: Option<HashMap<String, PyObject>>,
+        params: Option<HashMap<String, Py<PyAny>>>,
         execute: F,
-    ) -> PyResult<Vec<PyObject>>
+    ) -> PyResult<Vec<Py<PyAny>>>
     where
         F: FnOnce(
                 &CoreAgentMemory,
@@ -447,14 +447,13 @@ impl AgentMemory {
     {
         let rust_params = convert_params(py, params)?;
         let core = Arc::clone(&self.core);
-        let results =
-            py.allow_threads(|| execute(&core, query_str, &rust_params).map_err(to_py_err))?;
+        let results = py.detach(|| execute(&core, query_str, &rust_params).map_err(to_py_err))?;
         Ok(search_results_to_multimodel_dicts(py, results))
     }
 }
 
 /// Builds a Python dict from an `ExpireResult`.
-fn expire_result_to_dict(py: Python<'_>, r: &velesdb_core::agent::ExpireResult) -> PyObject {
+fn expire_result_to_dict(py: Python<'_>, r: &velesdb_core::agent::ExpireResult) -> Py<PyAny> {
     let dict = PyDict::new(py);
     let _ = dict.set_item(PyString::intern(py, "semantic_expired"), r.semantic_expired);
     let _ = dict.set_item(PyString::intern(py, "episodic_expired"), r.episodic_expired);
@@ -512,7 +511,7 @@ impl PySemanticMemory {
     #[pyo3(signature = (id, content, embedding))]
     fn store(&self, py: Python<'_>, id: u64, content: &str, embedding: Vec<f32>) -> PyResult<()> {
         let content_owned = content.to_string();
-        py.allow_threads(|| {
+        py.detach(|| {
             self.inner()
                 .store(id, &content_owned, &embedding)
                 .map_err(to_py_err)
@@ -542,7 +541,7 @@ impl PySemanticMemory {
         ttl_seconds: u64,
     ) -> PyResult<()> {
         let content_owned = content.to_string();
-        py.allow_threads(|| {
+        py.detach(|| {
             self.inner()
                 .store_with_ttl(id, &content_owned, &embedding, ttl_seconds)
                 .map_err(to_py_err)
@@ -563,9 +562,8 @@ impl PySemanticMemory {
     ///     >>> for r in results:
     ///     ...     print(f"{r['content']} (score: {r['score']:.3f})")
     #[pyo3(signature = (embedding, top_k = 10))]
-    fn query(&self, py: Python<'_>, embedding: Vec<f32>, top_k: usize) -> PyResult<PyObject> {
-        let results =
-            py.allow_threads(|| self.inner().query(&embedding, top_k).map_err(to_py_err))?;
+    fn query(&self, py: Python<'_>, embedding: Vec<f32>, top_k: usize) -> PyResult<Py<PyAny>> {
+        let results = py.detach(|| self.inner().query(&embedding, top_k).map_err(to_py_err))?;
 
         // Phase 3: Build Python objects (GIL held)
         // set_item is infallible on fresh dicts with interned keys and basic Python types.
@@ -589,15 +587,15 @@ impl PySemanticMemory {
     ///     >>> memory.semantic.delete(1)
     #[pyo3(signature = (id,))]
     fn delete(&self, py: Python<'_>, id: u64) -> PyResult<()> {
-        py.allow_threads(|| self.inner().delete(id).map_err(to_py_err))
+        py.detach(|| self.inner().delete(id).map_err(to_py_err))
     }
 
     /// Serializes all stored facts to a bytes blob for snapshotting.
     ///
     /// Returns:
     ///     A `bytes` object that can be passed back to `deserialize`.
-    fn serialize(&self, py: Python<'_>) -> PyResult<PyObject> {
-        let bytes = py.allow_threads(|| self.inner().serialize().map_err(to_py_err))?;
+    fn serialize(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
+        let bytes = py.detach(|| self.inner().serialize().map_err(to_py_err))?;
         Ok(pyo3::types::PyBytes::new(py, &bytes).into())
     }
 
@@ -607,7 +605,7 @@ impl PySemanticMemory {
     ///     data: Bytes previously produced by `serialize()`.
     #[pyo3(signature = (data))]
     fn deserialize(&self, py: Python<'_>, data: Vec<u8>) -> PyResult<()> {
-        py.allow_threads(|| self.inner().deserialize(&data).map_err(to_py_err))
+        py.detach(|| self.inner().deserialize(&data).map_err(to_py_err))
     }
 
     fn __repr__(&self) -> String {
@@ -659,7 +657,7 @@ impl PyEpisodicMemory {
         embedding: Option<Vec<f32>>,
     ) -> PyResult<()> {
         let description_owned = description.to_string();
-        py.allow_threads(|| {
+        py.detach(|| {
             let emb_ref = embedding.as_deref();
             self.inner()
                 .record(event_id, &description_owned, timestamp, emb_ref)
@@ -693,7 +691,7 @@ impl PyEpisodicMemory {
         embedding: Option<Vec<f32>>,
     ) -> PyResult<()> {
         let description_owned = description.to_string();
-        py.allow_threads(|| {
+        py.detach(|| {
             let emb_ref = embedding.as_deref();
             self.inner()
                 .record_with_ttl(
@@ -719,8 +717,8 @@ impl PyEpisodicMemory {
     /// Example:
     ///     >>> events = memory.episodic.recent(limit=5)
     #[pyo3(signature = (limit = 10, since = None))]
-    fn recent(&self, py: Python<'_>, limit: usize, since: Option<i64>) -> PyResult<PyObject> {
-        let results = py.allow_threads(|| self.inner().recent(limit, since).map_err(to_py_err))?;
+    fn recent(&self, py: Python<'_>, limit: usize, since: Option<i64>) -> PyResult<Py<PyAny>> {
+        let results = py.detach(|| self.inner().recent(limit, since).map_err(to_py_err))?;
         events_to_pylist(py, results)
     }
 
@@ -738,8 +736,8 @@ impl PyEpisodicMemory {
         py: Python<'_>,
         embedding: Vec<f32>,
         top_k: usize,
-    ) -> PyResult<PyObject> {
-        let results = py.allow_threads(|| {
+    ) -> PyResult<Py<PyAny>> {
+        let results = py.detach(|| {
             self.inner()
                 .recall_similar(&embedding, top_k)
                 .map_err(to_py_err)
@@ -769,9 +767,8 @@ impl PyEpisodicMemory {
     /// Example:
     ///     >>> old_events = memory.episodic.older_than(before=yesterday, limit=20)
     #[pyo3(signature = (before, limit = 10))]
-    fn older_than(&self, py: Python<'_>, before: i64, limit: usize) -> PyResult<PyObject> {
-        let results =
-            py.allow_threads(|| self.inner().older_than(before, limit).map_err(to_py_err))?;
+    fn older_than(&self, py: Python<'_>, before: i64, limit: usize) -> PyResult<Py<PyAny>> {
+        let results = py.detach(|| self.inner().older_than(before, limit).map_err(to_py_err))?;
         events_to_pylist(py, results)
     }
 
@@ -784,7 +781,7 @@ impl PyEpisodicMemory {
     ///     >>> memory.episodic.delete(1)
     #[pyo3(signature = (event_id,))]
     fn delete(&self, py: Python<'_>, event_id: u64) -> PyResult<()> {
-        py.allow_threads(|| self.inner().delete(event_id).map_err(to_py_err))
+        py.detach(|| self.inner().delete(event_id).map_err(to_py_err))
     }
 
     fn __repr__(&self) -> String {
@@ -837,7 +834,7 @@ impl PyProceduralMemory {
         confidence: f32,
     ) -> PyResult<()> {
         let name_owned = name.to_string();
-        py.allow_threads(|| {
+        py.detach(|| {
             let emb_ref = embedding.as_deref();
             self.inner()
                 .learn(procedure_id, &name_owned, &steps, emb_ref, confidence)
@@ -874,7 +871,7 @@ impl PyProceduralMemory {
         confidence: f32,
     ) -> PyResult<()> {
         let name_owned = name.to_string();
-        py.allow_threads(|| {
+        py.detach(|| {
             let emb_ref = embedding.as_deref();
             self.inner()
                 .learn_with_ttl(
@@ -908,8 +905,8 @@ impl PyProceduralMemory {
         embedding: Vec<f32>,
         top_k: usize,
         min_confidence: f32,
-    ) -> PyResult<PyObject> {
-        let results = py.allow_threads(|| {
+    ) -> PyResult<Py<PyAny>> {
+        let results = py.detach(|| {
             self.inner()
                 .recall(&embedding, top_k, min_confidence)
                 .map_err(to_py_err)
@@ -929,7 +926,7 @@ impl PyProceduralMemory {
     ///     >>> memory.procedural.reinforce(1, success=True)
     #[pyo3(signature = (procedure_id, success))]
     fn reinforce(&self, py: Python<'_>, procedure_id: u64, success: bool) -> PyResult<()> {
-        py.allow_threads(|| {
+        py.detach(|| {
             self.inner()
                 .reinforce(procedure_id, success)
                 .map_err(to_py_err)
@@ -943,8 +940,8 @@ impl PyProceduralMemory {
     ///
     /// Example:
     ///     >>> all_procs = memory.procedural.list_all()
-    fn list_all(&self, py: Python<'_>) -> PyResult<PyObject> {
-        let results = py.allow_threads(|| self.inner().list_all().map_err(to_py_err))?;
+    fn list_all(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
+        let results = py.detach(|| self.inner().list_all().map_err(to_py_err))?;
         procedures_to_pylist(py, results)
     }
 
@@ -957,7 +954,7 @@ impl PyProceduralMemory {
     ///     >>> memory.procedural.delete(1)
     #[pyo3(signature = (procedure_id,))]
     fn delete(&self, py: Python<'_>, procedure_id: u64) -> PyResult<()> {
-        py.allow_threads(|| self.inner().delete(procedure_id).map_err(to_py_err))
+        py.detach(|| self.inner().delete(procedure_id).map_err(to_py_err))
     }
 
     fn __repr__(&self) -> String {

--- a/crates/velesdb-python/src/collection/dataframe.rs
+++ b/crates/velesdb-python/src/collection/dataframe.rs
@@ -18,7 +18,12 @@ impl Collection {
     /// Returns:
     ///     A pandas.DataFrame or polars.DataFrame.
     #[pyo3(signature = (results, *, backend="pandas"))]
-    fn to_dataframe(&self, py: Python<'_>, results: PyObject, backend: &str) -> PyResult<PyObject> {
+    fn to_dataframe(
+        &self,
+        py: Python<'_>,
+        results: Py<PyAny>,
+        backend: &str,
+    ) -> PyResult<Py<PyAny>> {
         let converter = py.import("velesdb.dataframe_converter")?;
         let df = converter.call_method1("to_dataframe", (results, backend))?;
         Ok(df.unbind())
@@ -36,9 +41,9 @@ impl Collection {
     fn query_to_dataframe(
         &self,
         py: Python<'_>,
-        results: PyObject,
+        results: Py<PyAny>,
         backend: &str,
-    ) -> PyResult<PyObject> {
+    ) -> PyResult<Py<PyAny>> {
         let converter = py.import("velesdb.dataframe_converter")?;
         let df = converter.call_method1("query_to_dataframe", (results, backend))?;
         Ok(df.unbind())
@@ -63,7 +68,7 @@ impl Collection {
     fn upsert_from_dataframe(
         &self,
         py: Python<'_>,
-        df: PyObject,
+        df: Py<PyAny>,
         backend: &str,
     ) -> PyResult<usize> {
         let _ = backend; // Backend auto-detected from DataFrame type
@@ -77,7 +82,7 @@ impl Collection {
 
         // Convert DataFrame to point dicts
         let points_list = converter.call_method1("dataframe_to_points", (&df,))?;
-        let points: Vec<std::collections::HashMap<String, PyObject>> = points_list.extract()?;
+        let points: Vec<std::collections::HashMap<String, Py<PyAny>>> = points_list.extract()?;
 
         // Delegate to the appropriate upsert path based on collection type.
         // parse_point_dicts requires a vector field, so metadata-only collections
@@ -97,12 +102,12 @@ impl Collection {
                 core_points.push(velesdb_core::Point::metadata_only(id, payload));
             }
             let count = core_points.len();
-            py.allow_threads(|| self.inner.upsert_metadata(core_points).map_err(core_err))?;
+            py.detach(|| self.inner.upsert_metadata(core_points).map_err(core_err))?;
             Ok(count)
         } else {
             let parsed = crate::collection_helpers::parse_point_dicts(py, &points)?;
             let count = parsed.len();
-            py.allow_threads(|| self.inner.upsert(parsed).map_err(core_err))?;
+            py.detach(|| self.inner.upsert(parsed).map_err(core_err))?;
             Ok(count)
         }
     }

--- a/crates/velesdb-python/src/collection/index.rs
+++ b/crates/velesdb-python/src/collection/index.rs
@@ -14,7 +14,7 @@ impl Collection {
     fn create_property_index(&self, py: Python<'_>, label: &str, property: &str) -> PyResult<()> {
         let label_owned = label.to_string();
         let property_owned = property.to_string();
-        py.allow_threads(|| {
+        py.detach(|| {
             self.inner
                 .create_property_index(&label_owned, &property_owned)
                 .map_err(core_err)
@@ -26,7 +26,7 @@ impl Collection {
     fn create_range_index(&self, py: Python<'_>, label: &str, property: &str) -> PyResult<()> {
         let label_owned = label.to_string();
         let property_owned = property.to_string();
-        py.allow_threads(|| {
+        py.detach(|| {
             self.inner
                 .create_range_index(&label_owned, &property_owned)
                 .map_err(core_err)
@@ -49,9 +49,9 @@ impl Collection {
     ///
     /// Returns:
     ///     List of dicts with keys: label, property, index_type, cardinality, memory_bytes
-    fn list_indexes(&self, py: Python<'_>) -> PyResult<Vec<PyObject>> {
+    fn list_indexes(&self, py: Python<'_>) -> PyResult<Vec<Py<PyAny>>> {
         let indexes = self.inner.list_indexes();
-        let py_indexes: Vec<PyObject> = indexes
+        let py_indexes: Vec<Py<PyAny>> = indexes
             .into_iter()
             .map(|idx| {
                 let dict = PyDict::new(py);
@@ -78,7 +78,7 @@ impl Collection {
     fn drop_index(&self, py: Python<'_>, label: &str, property: &str) -> PyResult<bool> {
         let label_owned = label.to_string();
         let property_owned = property.to_string();
-        py.allow_threads(|| {
+        py.detach(|| {
             self.inner
                 .drop_index(&label_owned, &property_owned)
                 .map_err(core_err)

--- a/crates/velesdb-python/src/collection/mod.rs
+++ b/crates/velesdb-python/src/collection/mod.rs
@@ -31,12 +31,12 @@ use velesdb_core::collection::streaming::{AsyncIndexBuilderConfig, DeferredIndex
 
 /// Extract an optional typed value for `key`, returning `None` when the
 /// key is absent or holds Python `None`.
-fn opt_field<'py, T: FromPyObject<'py>>(
+fn opt_field<'py, T: FromPyObjectOwned<'py>>(
     dict: &Bound<'py, PyDict>,
     key: &str,
 ) -> PyResult<Option<T>> {
     match dict.get_item(key)? {
-        Some(v) if !v.is_none() => Ok(Some(v.extract()?)),
+        Some(v) if !v.is_none() => Ok(Some(v.extract().map_err(Into::into)?)),
         _ => Ok(None),
     }
 }
@@ -59,7 +59,7 @@ fn three_state<T>(
 /// Build a `DeferredIndexerConfig` from a Python dict, overriding only the
 /// keys present on top of the struct defaults.
 fn deferred_from_dict(value: &Bound<'_, PyAny>) -> PyResult<DeferredIndexerConfig> {
-    let dict = value.downcast::<PyDict>()?;
+    let dict = value.cast::<PyDict>()?;
     let mut cfg = DeferredIndexerConfig::default();
     if let Some(v) = opt_field(dict, "enabled")? {
         cfg.enabled = v;
@@ -77,7 +77,7 @@ fn deferred_from_dict(value: &Bound<'_, PyAny>) -> PyResult<DeferredIndexerConfi
 /// keys present on top of the struct defaults. `segment_count` accepts a
 /// Python `None` to fall back to the CPU count.
 fn async_builder_from_dict(value: &Bound<'_, PyAny>) -> PyResult<AsyncIndexBuilderConfig> {
-    let dict = value.downcast::<PyDict>()?;
+    let dict = value.cast::<PyDict>()?;
     let mut cfg = AsyncIndexBuilderConfig::default();
     if let Some(v) = opt_field(dict, "merge_threshold")? {
         cfg.merge_threshold = v;
@@ -174,7 +174,7 @@ impl Collection {
     ///
     /// Returns:
     ///     Dict with name, dimension, metric, storage_mode, point_count, and metadata_only
-    fn info(&self, py: Python<'_>) -> PyResult<PyObject> {
+    fn info(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let config = self.inner.config();
         let dict = PyDict::new(py);
         let _ = dict.set_item(PyString::intern(py, "name"), config.name.as_str());
@@ -251,7 +251,7 @@ impl Collection {
     /// Returns:
     ///     List[int]: All point IDs
     fn all_ids(&self, py: Python<'_>) -> Vec<u64> {
-        py.allow_threads(|| self.inner.all_ids())
+        py.detach(|| self.inner.all_ids())
     }
 
     /// Full durability flush including vectors.idx serialization.
@@ -260,7 +260,7 @@ impl Collection {
     /// For routine persistence, use ``flush()`` instead.
     fn flush_full(&self, py: Python<'_>) -> PyResult<()> {
         use crate::collection_helpers::core_err;
-        py.allow_threads(|| self.inner.flush_full().map_err(core_err))
+        py.detach(|| self.inner.flush_full().map_err(core_err))
     }
 
     /// Compact on-disk storage, reclaiming space left by deleted vectors.
@@ -269,7 +269,7 @@ impl Collection {
     ///     int: Number of bytes reclaimed.
     fn compact_storage(&self, py: Python<'_>) -> PyResult<usize> {
         use crate::collection_helpers::core_err;
-        py.allow_threads(|| self.inner.compact_storage().map_err(core_err))
+        py.detach(|| self.inner.compact_storage().map_err(core_err))
     }
 
     /// Reorder the HNSW adjacency lists and vector storage for cache
@@ -284,7 +284,7 @@ impl Collection {
     ///     None
     fn reorder_for_locality(&self, py: Python<'_>) -> PyResult<()> {
         use crate::collection_helpers::core_err;
-        py.allow_threads(|| self.inner.reorder_for_locality().map_err(core_err))
+        py.detach(|| self.inner.reorder_for_locality().map_err(core_err))
     }
 
     /// Apply post-creation overrides to advanced configuration fields and
@@ -309,7 +309,7 @@ impl Collection {
         let pq = three_state(config, "pq_rescore_oversampling", |v| v.extract::<u32>())?;
         let deferred = three_state(config, "deferred_indexing", deferred_from_dict)?;
         let async_builder = three_state(config, "async_index_builder", async_builder_from_dict)?;
-        py.allow_threads(|| {
+        py.detach(|| {
             self.inner
                 .apply_advanced_config(pq, deferred, async_builder)
                 .map_err(core_err)
@@ -322,7 +322,7 @@ impl Collection {
     ///     dict with keys ``max_depth``, ``max_cardinality``,
     ///     ``memory_limit_bytes``, ``timeout_ms``, ``rate_limit_qps``,
     ///     ``circuit_failure_threshold``, ``circuit_recovery_seconds``.
-    fn guard_rails(&self, py: Python<'_>) -> PyResult<PyObject> {
+    fn guard_rails(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let limits = self.inner.guard_rails().limits();
         let dict = PyDict::new(py);
         dict.set_item("max_depth", limits.max_depth)?;
@@ -355,7 +355,7 @@ impl Collection {
     ///     dict with keys ``should_reindex``, ``current_m``, ``optimal_m``,
     ///     ``ratio`` (and ``reason`` when a reindex is recommended), or
     ///     ``None`` when no auto-reindex manager is attached.
-    fn check_auto_reindex_divergence(&self, py: Python<'_>) -> PyResult<Option<PyObject>> {
+    fn check_auto_reindex_divergence(&self, py: Python<'_>) -> PyResult<Option<Py<PyAny>>> {
         let Some(check) = self.inner.check_auto_reindex_divergence() else {
             return Ok(None);
         };
@@ -407,9 +407,9 @@ impl Collection {
     /// Returns:
     ///     dict: Statistics including row_count, deleted_count, total_size_bytes,
     ///           column_stats, index_stats, etc.
-    fn analyze(&self, py: Python<'_>) -> PyResult<PyObject> {
+    fn analyze(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         use crate::collection_helpers::core_err;
-        let stats = py.allow_threads(|| self.inner.analyze().map_err(core_err))?;
+        let stats = py.detach(|| self.inner.analyze().map_err(core_err))?;
         let json = serde_json::to_value(&stats).map_err(|e| {
             pyo3::exceptions::PyRuntimeError::new_err(format!("Stats serialization failed: {e}"))
         })?;
@@ -446,7 +446,7 @@ impl Collection {
     /// context manager (``with`` statement).
     fn close(&self, py: Python<'_>) -> PyResult<()> {
         use crate::collection_helpers::core_err;
-        py.allow_threads(|| self.inner.flush_full().map_err(core_err))
+        py.detach(|| self.inner.flush_full().map_err(core_err))
     }
 
     /// Context manager entry — returns ``self`` so the collection can be
@@ -461,9 +461,9 @@ impl Collection {
     fn __exit__(
         &self,
         py: Python<'_>,
-        _exc_type: Option<PyObject>,
-        _exc_value: Option<PyObject>,
-        _traceback: Option<PyObject>,
+        _exc_type: Option<Py<PyAny>>,
+        _exc_value: Option<Py<PyAny>>,
+        _traceback: Option<Py<PyAny>>,
     ) -> PyResult<bool> {
         self.close(py)?;
         Ok(false)

--- a/crates/velesdb-python/src/collection/mutation.rs
+++ b/crates/velesdb-python/src/collection/mutation.rs
@@ -12,6 +12,10 @@ use crate::collection_helpers::{
 
 use super::Collection;
 
+/// Optional per-row Python payload dicts for a NumPy bulk upsert: `None` means
+/// "no payloads", otherwise one `Option<dict>` per vector row.
+type NumpyPayloadBatch = Option<Vec<Option<HashMap<String, Py<PyAny>>>>>;
+
 #[pymethods]
 impl Collection {
     /// Creates a secondary index on a payload field for faster filtered queries.
@@ -24,12 +28,12 @@ impl Collection {
     #[pyo3(signature = (field_name))]
     fn create_index(&self, py: Python<'_>, field_name: &str) -> PyResult<()> {
         let name = field_name.to_string();
-        py.allow_threads(|| self.inner.create_index(&name).map_err(core_err))
+        py.detach(|| self.inner.create_index(&name).map_err(core_err))
     }
 
     /// Insert or update vectors in the collection.
     #[pyo3(signature = (points))]
-    fn upsert(&self, py: Python<'_>, points: Vec<HashMap<String, PyObject>>) -> PyResult<usize> {
+    fn upsert(&self, py: Python<'_>, points: Vec<HashMap<String, Py<PyAny>>>) -> PyResult<usize> {
         // Phase 1: Parse all Python dicts (GIL held)
         let core_points = parse_point_dicts(py, &points)?;
         let count = core_points.len();
@@ -37,7 +41,7 @@ impl Collection {
         // Phase 2: Release GIL during core engine work; report DimensionMismatch with
         // the collection name so the error message includes full context.
         let name = self.name.clone();
-        py.allow_threads(|| {
+        py.detach(|| {
             self.inner
                 .upsert(core_points)
                 .map_err(|e| core_err_with_collection(e, &name))
@@ -51,7 +55,7 @@ impl Collection {
     fn upsert_metadata(
         &self,
         py: Python<'_>,
-        points: Vec<HashMap<String, PyObject>>,
+        points: Vec<HashMap<String, Py<PyAny>>>,
     ) -> PyResult<usize> {
         let mut core_points = Vec::with_capacity(points.len());
 
@@ -66,7 +70,7 @@ impl Collection {
         }
 
         let count = core_points.len();
-        py.allow_threads(|| self.inner.upsert_metadata(core_points).map_err(core_err))?;
+        py.detach(|| self.inner.upsert_metadata(core_points).map_err(core_err))?;
 
         Ok(count)
     }
@@ -76,7 +80,7 @@ impl Collection {
     fn upsert_bulk(
         &self,
         py: Python<'_>,
-        points: Vec<HashMap<String, PyObject>>,
+        points: Vec<HashMap<String, Py<PyAny>>>,
     ) -> PyResult<usize> {
         let mut core_points = Vec::with_capacity(points.len());
 
@@ -88,7 +92,7 @@ impl Collection {
         }
 
         let name = self.name.clone();
-        py.allow_threads(|| {
+        py.detach(|| {
             self.inner
                 .upsert_bulk(&core_points)
                 .map_err(|e| core_err_with_collection(e, &name))
@@ -136,7 +140,7 @@ impl Collection {
         py: Python<'_>,
         vectors: numpy::PyReadonlyArray2<f32>,
         ids: Vec<u64>,
-        payloads: Option<Vec<Option<HashMap<String, PyObject>>>>,
+        payloads: NumpyPayloadBatch,
     ) -> PyResult<usize> {
         let array = vectors.as_array();
         let n = array.nrows();
@@ -151,11 +155,11 @@ impl Collection {
         // Convert Python payload dicts to serde_json::Value (GIL required).
         let json_payloads = convert_payloads(py, &payloads)?;
 
-        // Copy the flat data so we can release the GIL (numpy buffer is PyObject-backed).
+        // Copy the flat data so we can release the GIL (numpy buffer is Py<PyAny>-backed).
         let flat_owned: Vec<f32> = flat.to_vec();
         let payloads_ref = json_payloads.as_deref();
 
-        py.allow_threads(|| {
+        py.detach(|| {
             self.inner
                 .upsert_bulk_from_raw(&flat_owned, &ids, dimension, payloads_ref)
                 .map_err(core_err)
@@ -227,7 +231,7 @@ impl Collection {
         let flat_owned: Vec<f32> = flat.to_vec();
         let payload_vec: Vec<Option<serde_json::Value>> = parsed_payloads;
 
-        py.allow_threads(|| {
+        py.detach(|| {
             self.inner
                 .upsert_bulk_from_raw(&flat_owned, &ids, dimension, Some(&payload_vec))
                 .map_err(core_err)
@@ -236,9 +240,9 @@ impl Collection {
 
     /// Get points by their IDs.
     #[pyo3(signature = (ids))]
-    fn get(&self, py: Python<'_>, ids: Vec<u64>) -> PyResult<Vec<Option<PyObject>>> {
+    fn get(&self, py: Python<'_>, ids: Vec<u64>) -> PyResult<Vec<Option<Py<PyAny>>>> {
         // Phase 2: Release GIL during core retrieval
-        let points = py.allow_threads(|| self.inner.get(&ids));
+        let points = py.detach(|| self.inner.get(&ids));
 
         // Phase 3: Convert to Python (GIL held)
         let py_points = points
@@ -251,12 +255,12 @@ impl Collection {
     /// Delete points by their IDs.
     #[pyo3(signature = (ids))]
     fn delete(&self, py: Python<'_>, ids: Vec<u64>) -> PyResult<()> {
-        py.allow_threads(|| self.inner.delete(&ids).map_err(core_err))
+        py.detach(|| self.inner.delete(&ids).map_err(core_err))
     }
 
     /// Flush all pending changes to disk.
     fn flush(&self, py: Python<'_>) -> PyResult<()> {
-        py.allow_threads(|| self.inner.flush().map_err(core_err))
+        py.detach(|| self.inner.flush().map_err(core_err))
     }
 
     /// Insert points via the streaming ingestion channel.
@@ -312,13 +316,13 @@ impl Collection {
     fn stream_insert(
         &self,
         py: Python<'_>,
-        points: Vec<HashMap<String, PyObject>>,
+        points: Vec<HashMap<String, Py<PyAny>>>,
     ) -> PyResult<usize> {
-        // Phase 1: Parse all points while holding the GIL (required for PyObject access)
+        // Phase 1: Parse all points while holding the GIL (required for Py<PyAny> access)
         let parsed = parse_point_dicts(py, &points)?;
 
         // Phase 2: Send entire batch in one call (single lock acquisition), GIL released
-        py.allow_threads(|| {
+        py.detach(|| {
             self.inner.stream_insert_batch(parsed).map_err(|e| {
                 pyo3::exceptions::PyRuntimeError::new_err(format!(
                     "Stream insert failed (buffer full or not configured): {e}"
@@ -329,11 +333,7 @@ impl Collection {
 }
 
 /// Validate that ids and optional payloads lengths match the vector row count.
-fn validate_numpy_lengths(
-    n: usize,
-    ids: &[u64],
-    payloads: &Option<Vec<Option<HashMap<String, PyObject>>>>,
-) -> PyResult<()> {
+fn validate_numpy_lengths(n: usize, ids: &[u64], payloads: &NumpyPayloadBatch) -> PyResult<()> {
     if ids.len() != n {
         return Err(PyValueError::new_err(format!(
             "ids length ({}) must match vectors row count ({n})",
@@ -357,7 +357,7 @@ fn validate_numpy_lengths(
 /// `Some(json_map)` when a dict is present, or `None` for that index.
 fn convert_payloads(
     py: Python<'_>,
-    payloads: &Option<Vec<Option<HashMap<String, PyObject>>>>,
+    payloads: &NumpyPayloadBatch,
 ) -> PyResult<Option<Vec<Option<serde_json::Value>>>> {
     let Some(ref payload_list) = *payloads else {
         return Ok(None);

--- a/crates/velesdb-python/src/collection/query.rs
+++ b/crates/velesdb-python/src/collection/query.rs
@@ -17,7 +17,7 @@ use super::Collection;
 pub(crate) fn match_result_to_dict(
     py: Python<'_>,
     r: velesdb_core::collection::search::query::match_exec::MatchResult,
-) -> PyObject {
+) -> Py<PyAny> {
     let dict = PyDict::new(py);
     let _ = dict.set_item(PyString::intern(py, "node_id"), r.node_id);
     let _ = dict.set_item(PyString::intern(py, "depth"), r.depth);
@@ -49,7 +49,7 @@ pub(crate) fn parse_velesql(query_str: &str) -> PyResult<velesdb_core::velesql::
 pub(crate) fn build_explain_dict(
     py: Python<'_>,
     parsed: &velesdb_core::velesql::Query,
-) -> PyObject {
+) -> Py<PyAny> {
     let plan = if let Some(match_clause) = parsed.match_clause.as_ref() {
         let stats =
             velesdb_core::collection::search::query::match_planner::CollectionStats::default();
@@ -88,7 +88,7 @@ pub(crate) fn build_explain_dict(
 pub(crate) fn build_explain_analyze_dict(
     py: Python<'_>,
     output: &velesdb_core::velesql::ExplainOutput,
-) -> PyObject {
+) -> Py<PyAny> {
     let dict = PyDict::new(py);
 
     // Plan sub-dict (same keys as build_explain_dict)
@@ -129,7 +129,7 @@ pub(crate) fn build_explain_analyze_dict(
     }
 
     // node_stats list
-    let node_dicts: Vec<PyObject> = output
+    let node_dicts: Vec<Py<PyAny>> = output
         .node_stats
         .iter()
         .map(|ns| {
@@ -191,7 +191,7 @@ pub(crate) fn build_explain_analyze_dict(
 pub(crate) fn search_results_to_id_score(
     py: Python<'_>,
     results: Vec<velesdb_core::SearchResult>,
-) -> Vec<PyObject> {
+) -> Vec<Py<PyAny>> {
     let tuples: Vec<(u64, f32)> = results.into_iter().map(|r| (r.point.id, r.score)).collect();
     id_score_pairs_to_dicts(py, tuples)
 }
@@ -199,7 +199,7 @@ pub(crate) fn search_results_to_id_score(
 /// Converts Python params dict to Rust `HashMap<String, serde_json::Value>`.
 pub(crate) fn convert_params(
     py: Python<'_>,
-    params: Option<HashMap<String, PyObject>>,
+    params: Option<HashMap<String, Py<PyAny>>>,
 ) -> PyResult<HashMap<String, serde_json::Value>> {
     params
         .unwrap_or_default()
@@ -216,9 +216,9 @@ pub(crate) fn convert_params(
 pub(crate) fn run_velesql_select<F>(
     py: Python<'_>,
     query_str: &str,
-    params: Option<HashMap<String, PyObject>>,
+    params: Option<HashMap<String, Py<PyAny>>>,
     execute: F,
-) -> PyResult<Vec<PyObject>>
+) -> PyResult<Vec<Py<PyAny>>>
 where
     F: FnOnce(
             &velesdb_core::velesql::Query,
@@ -228,7 +228,7 @@ where
 {
     let parsed = parse_velesql(query_str)?;
     let rust_params = convert_params(py, params)?;
-    let results = py.allow_threads(move || execute(&parsed, &rust_params).map_err(core_err))?;
+    let results = py.detach(move || execute(&parsed, &rust_params).map_err(core_err))?;
     Ok(crate::collection_helpers::search_results_to_multimodel_dicts(py, results))
 }
 
@@ -236,9 +236,9 @@ where
 pub(crate) fn run_velesql_select_ids<F>(
     py: Python<'_>,
     query_str: &str,
-    params: Option<HashMap<String, PyObject>>,
+    params: Option<HashMap<String, Py<PyAny>>>,
     execute: F,
-) -> PyResult<Vec<PyObject>>
+) -> PyResult<Vec<Py<PyAny>>>
 where
     F: FnOnce(
             &velesdb_core::velesql::Query,
@@ -248,7 +248,7 @@ where
 {
     let parsed = parse_velesql(query_str)?;
     let rust_params = convert_params(py, params)?;
-    let results = py.allow_threads(move || execute(&parsed, &rust_params).map_err(core_err))?;
+    let results = py.detach(move || execute(&parsed, &rust_params).map_err(core_err))?;
     Ok(search_results_to_id_score(py, results))
 }
 
@@ -256,10 +256,10 @@ where
 pub(crate) fn run_velesql_match<F>(
     py: Python<'_>,
     query_str: &str,
-    params: Option<HashMap<String, PyObject>>,
-    vector: Option<PyObject>,
+    params: Option<HashMap<String, Py<PyAny>>>,
+    vector: Option<Py<PyAny>>,
     execute: F,
-) -> PyResult<Vec<PyObject>>
+) -> PyResult<Vec<Py<PyAny>>>
 where
     F: FnOnce(
             velesdb_core::velesql::MatchClause,
@@ -277,9 +277,8 @@ where
         .clone();
     let rust_params = convert_params(py, params)?;
     let query_vector = vector.map(|v| extract_vector(py, &v)).transpose()?;
-    let results = py.allow_threads(move || {
-        execute(match_clause, rust_params, query_vector).map_err(core_err)
-    })?;
+    let results =
+        py.detach(move || execute(match_clause, rust_params, query_vector).map_err(core_err))?;
     Ok(results
         .into_iter()
         .map(|r| match_result_to_dict(py, r))
@@ -308,8 +307,8 @@ impl Collection {
         &self,
         py: Python<'_>,
         query_str: &str,
-        params: Option<HashMap<String, PyObject>>,
-    ) -> PyResult<Vec<PyObject>> {
+        params: Option<HashMap<String, Py<PyAny>>>,
+    ) -> PyResult<Vec<Py<PyAny>>> {
         let inner = &self.inner;
         run_velesql_select(py, query_str, params, |q, p| inner.execute_query(q, p))
     }
@@ -329,10 +328,10 @@ impl Collection {
         &self,
         py: Python<'_>,
         query_str: &str,
-        params: Option<HashMap<String, PyObject>>,
-        vector: Option<PyObject>,
+        params: Option<HashMap<String, Py<PyAny>>>,
+        vector: Option<Py<PyAny>>,
         threshold: f32,
-    ) -> PyResult<Vec<PyObject>> {
+    ) -> PyResult<Vec<Py<PyAny>>> {
         let inner = &self.inner;
         run_velesql_match(py, query_str, params, vector, move |mc, p, qv| {
             if let Some(ref qv) = qv {
@@ -345,7 +344,7 @@ impl Collection {
 
     /// Return query execution plan (EXPLAIN).
     #[pyo3(signature = (query_str))]
-    fn explain(&self, py: Python<'_>, query_str: &str) -> PyResult<PyObject> {
+    fn explain(&self, py: Python<'_>, query_str: &str) -> PyResult<Py<PyAny>> {
         let parsed = parse_velesql(query_str)?;
         Ok(build_explain_dict(py, &parsed))
     }
@@ -366,12 +365,12 @@ impl Collection {
         &self,
         py: Python<'_>,
         query_str: &str,
-        params: Option<HashMap<String, PyObject>>,
-    ) -> PyResult<PyObject> {
+        params: Option<HashMap<String, Py<PyAny>>>,
+    ) -> PyResult<Py<PyAny>> {
         let parsed = parse_velesql(query_str)?;
         let rust_params = convert_params(py, params)?;
         let inner = &self.inner;
-        let output = py.allow_threads(move || {
+        let output = py.detach(move || {
             inner
                 .explain_analyze_query(&parsed, &rust_params)
                 .map_err(core_err)
@@ -397,8 +396,8 @@ impl Collection {
         &self,
         py: Python<'_>,
         velesql: &str,
-        params: Option<HashMap<String, PyObject>>,
-    ) -> PyResult<Vec<PyObject>> {
+        params: Option<HashMap<String, Py<PyAny>>>,
+    ) -> PyResult<Vec<Py<PyAny>>> {
         let inner = &self.inner;
         run_velesql_select_ids(py, velesql, params, |q, p| inner.execute_query(q, p))
     }

--- a/crates/velesdb-python/src/collection/scroll.rs
+++ b/crates/velesdb-python/src/collection/scroll.rs
@@ -50,7 +50,7 @@ impl ScrollIterator {
     /// where it can be) and pays for itself many times over by
     /// releasing the GIL for the duration of the page read, which is
     /// the dominant cost of a scroll step.
-    fn __next__(&mut self, py: Python<'_>) -> PyResult<Option<PyObject>> {
+    fn __next__(&mut self, py: Python<'_>) -> PyResult<Option<Py<PyAny>>> {
         if self.exhausted {
             return Ok(None);
         }
@@ -66,7 +66,7 @@ impl ScrollIterator {
         // applies the optional filter. Any resulting `velesdb_core::Error`
         // is routed to the typed Python exception hierarchy by `core_err`.
         let batch = py
-            .allow_threads(move || inner.scroll_batch(cursor, batch_size, filter_owned.as_ref()))
+            .detach(move || inner.scroll_batch(cursor, batch_size, filter_owned.as_ref()))
             .map_err(core_err)?;
 
         if batch.points.is_empty() {
@@ -78,7 +78,7 @@ impl ScrollIterator {
         // Exhaustion is handled via the empty-batch early return above.
         self.cursor = batch.next_cursor;
 
-        let dicts: Vec<PyObject> = batch.points.iter().map(|p| point_to_dict(py, p)).collect();
+        let dicts: Vec<Py<PyAny>> = batch.points.iter().map(|p| point_to_dict(py, p)).collect();
         let py_list = pyo3::types::PyList::new(py, &dicts)?;
 
         if self.as_dataframe {
@@ -112,7 +112,7 @@ impl Collection {
         &self,
         py: Python<'_>,
         batch_size: usize,
-        filter: Option<PyObject>,
+        filter: Option<Py<PyAny>>,
         as_dataframe: bool,
         backend: &str,
     ) -> PyResult<ScrollIterator> {

--- a/crates/velesdb-python/src/collection/search.rs
+++ b/crates/velesdb-python/src/collection/search.rs
@@ -60,13 +60,13 @@ impl Collection {
     fn search(
         &self,
         py: Python<'_>,
-        vector: Option<PyObject>,
-        sparse_vector: Option<PyObject>,
+        vector: Option<Py<PyAny>>,
+        sparse_vector: Option<Py<PyAny>>,
         top_k: usize,
-        filter: Option<PyObject>,
+        filter: Option<Py<PyAny>>,
         sparse_index_name: Option<String>,
         include_vectors: bool,
-    ) -> PyResult<Vec<PyObject>> {
+    ) -> PyResult<Vec<Py<PyAny>>> {
         PyErr::warn(
             py,
             &py.get_type::<PyDeprecationWarning>(),
@@ -104,8 +104,8 @@ impl Collection {
     ///     >>> opts = SearchOptions(vector=my_emb, top_k=20, filter={"lang": "en"})
     ///     >>> results = collection.search_request(opts)
     #[pyo3(signature = (opts))]
-    fn search_request(&self, py: Python<'_>, opts: &SearchOptions) -> PyResult<Vec<PyObject>> {
-        // Phase 1: Parse Python args (GIL held — required for PyObject access)
+    fn search_request(&self, py: Python<'_>, opts: &SearchOptions) -> PyResult<Vec<Py<PyAny>>> {
+        // Phase 1: Parse Python args (GIL held — required for Py<PyAny> access)
         let dense = opts
             .vector
             .as_ref()
@@ -123,7 +123,7 @@ impl Collection {
         let include_vectors = opts.include_vectors;
 
         // Phase 2: Release GIL during Rust computation
-        let results = py.allow_threads(|| {
+        let results = py.detach(|| {
             self.dispatch_search(
                 dense,
                 sparse,
@@ -133,7 +133,7 @@ impl Collection {
             )
         })?;
 
-        // Phase 3: Convert results (GIL held — required for PyObject creation)
+        // Phase 3: Convert results (GIL held — required for Py<PyAny> creation)
         Ok(search_results_to_dicts(py, results, include_vectors))
     }
 
@@ -142,13 +142,13 @@ impl Collection {
     fn search_with_ef(
         &self,
         py: Python<'_>,
-        vector: PyObject,
+        vector: Py<PyAny>,
         top_k: usize,
         ef_search: usize,
-    ) -> PyResult<Vec<PyObject>> {
+    ) -> PyResult<Vec<Py<PyAny>>> {
         let query_vector = extract_vector(py, &vector)?;
 
-        let results = py.allow_threads(|| {
+        let results = py.detach(|| {
             self.inner
                 .search_with_ef(&query_vector, top_k, ef_search)
                 .map_err(core_err)
@@ -169,14 +169,14 @@ impl Collection {
     fn search_with_quality(
         &self,
         py: Python<'_>,
-        vector: PyObject,
+        vector: Py<PyAny>,
         quality: &str,
         top_k: usize,
-    ) -> PyResult<Vec<PyObject>> {
+    ) -> PyResult<Vec<Py<PyAny>>> {
         let query_vector = extract_vector(py, &vector)?;
         let sq = parse_search_quality(quality)?;
 
-        let results = py.allow_threads(|| {
+        let results = py.detach(|| {
             self.inner
                 .search_with_quality(&query_vector, top_k, sq)
                 .map_err(core_err)
@@ -190,12 +190,12 @@ impl Collection {
     fn search_ids(
         &self,
         py: Python<'_>,
-        vector: PyObject,
+        vector: Py<PyAny>,
         top_k: usize,
-    ) -> PyResult<Vec<PyObject>> {
+    ) -> PyResult<Vec<Py<PyAny>>> {
         let query_vector = extract_vector(py, &vector)?;
 
-        let results = py.allow_threads(|| {
+        let results = py.detach(|| {
             self.inner
                 .search_ids(&query_vector, top_k)
                 .map_err(core_err)
@@ -210,17 +210,17 @@ impl Collection {
     fn search_with_filter(
         &self,
         py: Python<'_>,
-        vector: PyObject,
+        vector: Py<PyAny>,
         top_k: usize,
-        filter: Option<PyObject>,
-    ) -> PyResult<Vec<PyObject>> {
+        filter: Option<Py<PyAny>>,
+    ) -> PyResult<Vec<Py<PyAny>>> {
         let query_vector = extract_vector(py, &vector)?;
         let filter_obj = filter
             .map(|f| parse_filter(py, &f))
             .transpose()?
             .ok_or_else(|| PyValueError::new_err("Filter is required for search_with_filter"))?;
 
-        let results = py.allow_threads(|| {
+        let results = py.detach(|| {
             self.inner
                 .search_with_filter(&query_vector, top_k, &filter_obj)
                 .map_err(core_err)
@@ -236,12 +236,12 @@ impl Collection {
         py: Python<'_>,
         query: &str,
         top_k: usize,
-        filter: Option<PyObject>,
-    ) -> PyResult<Vec<PyObject>> {
+        filter: Option<Py<PyAny>>,
+    ) -> PyResult<Vec<Py<PyAny>>> {
         let filter_obj = parse_optional_filter(py, filter)?;
         let query_owned = query.to_string();
 
-        let results = py.allow_threads(|| {
+        let results = py.detach(|| {
             if let Some(f) = filter_obj {
                 self.inner
                     .text_search_with_filter(&query_owned, top_k, &f)
@@ -261,17 +261,17 @@ impl Collection {
     fn hybrid_search(
         &self,
         py: Python<'_>,
-        vector: PyObject,
+        vector: Py<PyAny>,
         query: &str,
         top_k: usize,
         vector_weight: f32,
-        filter: Option<PyObject>,
-    ) -> PyResult<Vec<PyObject>> {
+        filter: Option<Py<PyAny>>,
+    ) -> PyResult<Vec<Py<PyAny>>> {
         let query_vector = extract_vector(py, &vector)?;
         let filter_obj = parse_optional_filter(py, filter)?;
         let query_owned = query.to_string();
 
-        let results = py.allow_threads(|| {
+        let results = py.detach(|| {
             if let Some(f) = filter_obj {
                 self.inner.hybrid_search_with_filter(
                     &query_vector,
@@ -302,11 +302,11 @@ impl Collection {
     fn batch_search(
         &self,
         py: Python<'_>,
-        searches: Vec<HashMap<String, PyObject>>,
-    ) -> PyResult<Vec<Vec<PyObject>>> {
+        searches: Vec<HashMap<String, Py<PyAny>>>,
+    ) -> PyResult<Vec<Vec<Py<PyAny>>>> {
         let parsed = Self::parse_batch_searches(py, &searches)?;
 
-        let results = py.allow_threads(|| self.dispatch_batch_by_top_k(&parsed))?;
+        let results = py.detach(|| self.dispatch_batch_by_top_k(&parsed))?;
 
         Ok(Self::convert_batch_results(py, results))
     }
@@ -316,11 +316,11 @@ impl Collection {
     fn multi_query_search(
         &self,
         py: Python<'_>,
-        vectors: Vec<PyObject>,
+        vectors: Vec<Py<PyAny>>,
         top_k: usize,
         fusion: Option<FusionStrategy>,
-        filter: Option<PyObject>,
-    ) -> PyResult<Vec<PyObject>> {
+        filter: Option<Py<PyAny>>,
+    ) -> PyResult<Vec<Py<PyAny>>> {
         let query_vectors: Vec<Vec<f32>> = vectors
             .iter()
             .map(|v| extract_vector(py, v))
@@ -328,7 +328,7 @@ impl Collection {
         let fusion_strategy = fusion.map_or(DEFAULT_FUSION, |f| f.inner());
         let filter_obj = parse_optional_filter(py, filter)?;
 
-        let results = py.allow_threads(|| {
+        let results = py.detach(|| {
             let query_refs: Vec<&[f32]> = query_vectors.iter().map(|v| v.as_slice()).collect();
             self.inner
                 .multi_query_search(&query_refs, top_k, fusion_strategy, filter_obj.as_ref())
@@ -354,15 +354,15 @@ impl Collection {
     fn search_batch_parallel(
         &self,
         py: Python<'_>,
-        vectors: Vec<PyObject>,
+        vectors: Vec<Py<PyAny>>,
         top_k: usize,
-    ) -> PyResult<Vec<Vec<PyObject>>> {
+    ) -> PyResult<Vec<Vec<Py<PyAny>>>> {
         let query_vectors: Vec<Vec<f32>> = vectors
             .iter()
             .map(|v| extract_vector(py, v))
             .collect::<PyResult<_>>()?;
 
-        let results = py.allow_threads(|| {
+        let results = py.detach(|| {
             let query_refs: Vec<&[f32]> = query_vectors.iter().map(|v| v.as_slice()).collect();
             self.inner
                 .search_batch_parallel(&query_refs, top_k)
@@ -377,17 +377,17 @@ impl Collection {
     fn multi_query_search_ids(
         &self,
         py: Python<'_>,
-        vectors: Vec<PyObject>,
+        vectors: Vec<Py<PyAny>>,
         top_k: usize,
         fusion: Option<FusionStrategy>,
-    ) -> PyResult<Vec<PyObject>> {
+    ) -> PyResult<Vec<Py<PyAny>>> {
         let query_vectors: Vec<Vec<f32>> = vectors
             .iter()
             .map(|v| extract_vector(py, v))
             .collect::<PyResult<_>>()?;
         let fusion_strategy = fusion.map_or(DEFAULT_FUSION, |f| f.inner());
 
-        let results = py.allow_threads(|| {
+        let results = py.detach(|| {
             let query_refs: Vec<&[f32]> = query_vectors.iter().map(|v| v.as_slice()).collect();
             self.inner
                 .multi_query_search_ids(&query_refs, top_k, fusion_strategy)
@@ -407,7 +407,7 @@ impl Collection {
     /// Extracts vector, top_k, and filter from each search dict.
     fn parse_batch_searches(
         py: Python<'_>,
-        searches: &[HashMap<String, PyObject>],
+        searches: &[HashMap<String, Py<PyAny>>],
     ) -> PyResult<Vec<ParsedSearch>> {
         let mut parsed = Vec::with_capacity(searches.len());
         for search_dict in searches {
@@ -515,7 +515,7 @@ impl Collection {
     fn convert_batch_results(
         py: Python<'_>,
         results: Vec<Vec<SearchResult>>,
-    ) -> Vec<Vec<PyObject>> {
+    ) -> Vec<Vec<Py<PyAny>>> {
         results
             .iter()
             .map(|query_results| {
@@ -596,7 +596,7 @@ mod tests {
     /// Initialize the Python interpreter once (idempotent, required by PyO3
     /// error constructors such as `PyValueError::new_err`).
     fn init_python() {
-        pyo3::prepare_freethreaded_python();
+        pyo3::Python::initialize();
     }
 
     // ---- Named modes ----

--- a/crates/velesdb-python/src/collection/search_options.rs
+++ b/crates/velesdb-python/src/collection/search_options.rs
@@ -48,17 +48,17 @@ pub struct SearchOptions {
     /// Dense query vector (list or numpy array). Optional when
     /// ``sparse_vector`` is provided.
     #[pyo3(get, set)]
-    pub vector: Option<PyObject>,
+    pub vector: Option<Py<PyAny>>,
     /// Sparse query as ``dict[int, float]`` or scipy sparse matrix.
     /// Optional when ``vector`` is provided.
     #[pyo3(get, set)]
-    pub sparse_vector: Option<PyObject>,
+    pub sparse_vector: Option<Py<PyAny>>,
     /// Number of results to return (default: 10).
     #[pyo3(get, set)]
     pub top_k: usize,
     /// Optional metadata filter dict.
     #[pyo3(get, set)]
-    pub filter: Option<PyObject>,
+    pub filter: Option<Py<PyAny>>,
     /// Named sparse index to query.  When ``None``, the default (unnamed)
     /// sparse index is used.
     #[pyo3(get, set)]
@@ -96,10 +96,10 @@ impl SearchOptions {
         include_vectors = false,
     ))]
     pub fn new(
-        vector: Option<PyObject>,
-        sparse_vector: Option<PyObject>,
+        vector: Option<Py<PyAny>>,
+        sparse_vector: Option<Py<PyAny>>,
         top_k: usize,
-        filter: Option<PyObject>,
+        filter: Option<Py<PyAny>>,
         sparse_index_name: Option<String>,
         include_vectors: bool,
     ) -> Self {
@@ -134,7 +134,7 @@ impl SearchOptions {
 #[pymethods]
 impl SearchOptions {
     /// Sets the dense query vector and returns `self`.
-    pub fn with_vector(slf: Py<Self>, py: Python<'_>, vector: Option<PyObject>) -> Py<Self> {
+    pub fn with_vector(slf: Py<Self>, py: Python<'_>, vector: Option<Py<PyAny>>) -> Py<Self> {
         slf.bind(py).borrow_mut().vector = vector;
         slf
     }
@@ -143,7 +143,7 @@ impl SearchOptions {
     pub fn with_sparse_vector(
         slf: Py<Self>,
         py: Python<'_>,
-        sparse_vector: Option<PyObject>,
+        sparse_vector: Option<Py<PyAny>>,
     ) -> Py<Self> {
         slf.bind(py).borrow_mut().sparse_vector = sparse_vector;
         slf
@@ -156,7 +156,7 @@ impl SearchOptions {
     }
 
     /// Sets the metadata filter and returns `self`.
-    pub fn with_filter(slf: Py<Self>, py: Python<'_>, filter: Option<PyObject>) -> Py<Self> {
+    pub fn with_filter(slf: Py<Self>, py: Python<'_>, filter: Option<Py<PyAny>>) -> Py<Self> {
         slf.bind(py).borrow_mut().filter = filter;
         slf
     }

--- a/crates/velesdb-python/src/collection_helpers.rs
+++ b/crates/velesdb-python/src/collection_helpers.rs
@@ -156,13 +156,16 @@ pub fn core_err_with_collection(e: velesdb_core::Error, collection_name: &str) -
 ///
 /// Converts the Python dict directly to `serde_json::Value` via [`python_to_json`],
 /// then deserializes into [`Filter`]. This avoids the Python `json.dumps` round-trip.
-pub fn parse_filter(py: Python<'_>, filter: &PyObject) -> PyResult<Filter> {
+pub fn parse_filter(py: Python<'_>, filter: &Py<PyAny>) -> PyResult<Filter> {
     let json_value = crate::utils::python_to_json(py, filter)?;
     Filter::from_json_value(json_value).map_err(PyValueError::new_err)
 }
 
 /// Parse an optional Python filter object.
-pub fn parse_optional_filter(py: Python<'_>, filter: Option<PyObject>) -> PyResult<Option<Filter>> {
+pub fn parse_optional_filter(
+    py: Python<'_>,
+    filter: Option<Py<PyAny>>,
+) -> PyResult<Option<Filter>> {
     match filter {
         Some(f) => Ok(Some(parse_filter(py, &f)?)),
         None => Ok(None),
@@ -171,7 +174,7 @@ pub fn parse_optional_filter(py: Python<'_>, filter: Option<PyObject>) -> PyResu
 
 /// Convert payload to Python object (shared helper to avoid duplication).
 #[inline]
-fn payload_to_python(py: Python<'_>, payload: &Option<serde_json::Value>) -> PyObject {
+fn payload_to_python(py: Python<'_>, payload: &Option<serde_json::Value>) -> Py<PyAny> {
     match payload {
         Some(p) => json_to_python(py, p),
         None => py.None(),
@@ -186,7 +189,7 @@ pub fn search_result_to_dict(
     py: Python<'_>,
     result: &SearchResult,
     include_vectors: bool,
-) -> PyObject {
+) -> Py<PyAny> {
     let dict = PyDict::new(py);
     // PyString::intern reuses the same Python string object across calls
     let _ = dict.set_item(PyString::intern(py, "id"), result.point.id);
@@ -205,7 +208,7 @@ pub fn search_result_to_dict(
 }
 
 /// Convert a `SearchResult` to a multi-model Python dict (EPIC-031).
-pub fn search_result_to_multimodel_dict(py: Python<'_>, result: &SearchResult) -> PyObject {
+pub fn search_result_to_multimodel_dict(py: Python<'_>, result: &SearchResult) -> Py<PyAny> {
     let dict = PyDict::new(py);
     let none = py.None();
     let payload_py = payload_to_python(py, &result.point.payload);
@@ -230,7 +233,7 @@ pub fn search_result_to_multimodel_dict(py: Python<'_>, result: &SearchResult) -
 ///
 /// Omits the `vector` field when empty (e.g., graph collections
 /// without embeddings) to avoid misleading empty arrays.
-pub fn point_to_dict(py: Python<'_>, point: &Point) -> PyObject {
+pub fn point_to_dict(py: Python<'_>, point: &Point) -> Py<PyAny> {
     let dict = PyDict::new(py);
     let _ = dict.set_item(PyString::intern(py, "id"), point.id);
     if !point.vector.is_empty() {
@@ -249,7 +252,7 @@ pub fn search_results_to_dicts(
     py: Python<'_>,
     results: Vec<SearchResult>,
     include_vectors: bool,
-) -> Vec<PyObject> {
+) -> Vec<Py<PyAny>> {
     results
         .into_iter()
         .map(|r| search_result_to_dict(py, &r, include_vectors))
@@ -260,7 +263,7 @@ pub fn search_results_to_dicts(
 pub fn search_results_to_multimodel_dicts(
     py: Python<'_>,
     results: Vec<SearchResult>,
-) -> Vec<PyObject> {
+) -> Vec<Py<PyAny>> {
     results
         .into_iter()
         .map(|r| search_result_to_multimodel_dict(py, &r))
@@ -268,7 +271,7 @@ pub fn search_results_to_multimodel_dicts(
 }
 
 /// Convert a list of (id, score) pairs to Python dicts.
-pub fn id_score_pairs_to_dicts(py: Python<'_>, results: Vec<(u64, f32)>) -> Vec<PyObject> {
+pub fn id_score_pairs_to_dicts(py: Python<'_>, results: Vec<(u64, f32)>) -> Vec<Py<PyAny>> {
     results
         .into_iter()
         .map(|(id, score)| {
@@ -287,7 +290,7 @@ pub fn id_score_pairs_to_dicts(py: Python<'_>, results: Vec<(u64, f32)>) -> Vec<
 /// - A scipy sparse object with a `.toarray()` method (COO/CSR/CSC).
 ///
 /// Returns `PyValueError` if the object is neither format.
-pub fn parse_sparse_vector(py: Python<'_>, obj: &PyObject) -> PyResult<SparseVector> {
+pub fn parse_sparse_vector(py: Python<'_>, obj: &Py<PyAny>) -> PyResult<SparseVector> {
     // Try dict[int, float] first (most common usage pattern).
     if let Ok(dict) = obj.extract::<HashMap<u32, f32>>(py) {
         let pairs: Vec<(u32, f32)> = dict.into_iter().collect();
@@ -339,7 +342,7 @@ pub fn parse_sparse_vector(py: Python<'_>, obj: &PyObject) -> PyResult<SparseVec
 /// Returns `None` if the key is absent from the point dict.
 pub fn parse_sparse_vectors_from_point(
     py: Python<'_>,
-    point_dict: &HashMap<String, PyObject>,
+    point_dict: &HashMap<String, Py<PyAny>>,
 ) -> PyResult<Option<BTreeMap<String, SparseVector>>> {
     let Some(obj) = point_dict.get("sparse_vector") else {
         return Ok(None);
@@ -354,7 +357,7 @@ pub fn parse_sparse_vectors_from_point(
     }
 
     // Try as dict[str, dict[int, float]] -> named sparse vectors.
-    if let Ok(named) = obj.extract::<HashMap<String, PyObject>>(py) {
+    if let Ok(named) = obj.extract::<HashMap<String, Py<PyAny>>>(py) {
         let mut map = BTreeMap::new();
         for (name, inner_obj) in named {
             let sv = parse_sparse_vector(py, &inner_obj)?;
@@ -378,7 +381,7 @@ pub fn parse_sparse_vectors_from_point(
 /// `parse_payload` to avoid duplicating the dict-to-JSON conversion.
 pub fn dict_to_json_map(
     py: Python<'_>,
-    dict: &HashMap<String, PyObject>,
+    dict: &HashMap<String, Py<PyAny>>,
 ) -> PyResult<serde_json::Value> {
     let json_map: serde_json::Map<String, serde_json::Value> = dict
         .iter()
@@ -394,7 +397,7 @@ pub fn dict_to_json_map(
 /// the user can locate the offending item: "Point at index 4237 missing 'id' field".
 pub fn extract_point_id(
     py: Python<'_>,
-    dict: &HashMap<String, PyObject>,
+    dict: &HashMap<String, Py<PyAny>>,
     index: usize,
 ) -> PyResult<u64> {
     dict.get("id")
@@ -405,7 +408,7 @@ pub fn extract_point_id(
 /// Extract the `"vector"` field from a point dict as `Vec<f32>`.
 pub fn extract_point_vector(
     py: Python<'_>,
-    dict: &HashMap<String, PyObject>,
+    dict: &HashMap<String, Py<PyAny>>,
 ) -> PyResult<Vec<f32>> {
     let obj = dict
         .get("vector")
@@ -421,7 +424,7 @@ pub fn extract_point_vector(
 /// Shared by [`Collection::upsert`] and [`Collection::stream_insert`].
 pub fn parse_point_dicts(
     py: Python<'_>,
-    points: &[HashMap<String, PyObject>],
+    points: &[HashMap<String, Py<PyAny>>],
 ) -> PyResult<Vec<Point>> {
     let mut result = Vec::with_capacity(points.len());
     for (index, point_dict) in points.iter().enumerate() {
@@ -434,14 +437,14 @@ pub fn parse_point_dicts(
     Ok(result)
 }
 
-/// Parse an optional payload `PyObject` into a JSON value.
+/// Parse an optional payload `Py<PyAny>` into a JSON value.
 pub fn parse_payload(
     py: Python<'_>,
-    payload_obj: Option<&PyObject>,
+    payload_obj: Option<&Py<PyAny>>,
 ) -> PyResult<Option<serde_json::Value>> {
     match payload_obj {
         Some(p) => {
-            let dict: HashMap<String, PyObject> = p
+            let dict: HashMap<String, Py<PyAny>> = p
                 .extract(py)
                 .map_err(|_| PyValueError::new_err("payload must be a dict[str, Any]"))?;
             Ok(Some(dict_to_json_map(py, &dict)?))
@@ -458,10 +461,10 @@ mod tests {
     /// extract_point_id error message includes the batch index.
     #[test]
     fn test_extract_point_id_missing_includes_index() {
-        pyo3::prepare_freethreaded_python();
-        Python::with_gil(|py| {
+        pyo3::Python::initialize();
+        Python::attach(|py| {
             // Dict with no "id" key — simulates a malformed point at position 4237.
-            let empty: HashMap<String, PyObject> = HashMap::new();
+            let empty: HashMap<String, Py<PyAny>> = HashMap::new();
             let err = extract_point_id(py, &empty, 4237).unwrap_err();
             let msg = err.to_string();
             assert!(
@@ -478,9 +481,9 @@ mod tests {
     /// extract_point_id at index 0 still includes the index in the message.
     #[test]
     fn test_extract_point_id_missing_at_index_zero() {
-        pyo3::prepare_freethreaded_python();
-        Python::with_gil(|py| {
-            let empty: HashMap<String, PyObject> = HashMap::new();
+        pyo3::Python::initialize();
+        Python::attach(|py| {
+            let empty: HashMap<String, Py<PyAny>> = HashMap::new();
             let err = extract_point_id(py, &empty, 0).unwrap_err();
             let msg = err.to_string();
             assert!(

--- a/crates/velesdb-python/src/database.rs
+++ b/crates/velesdb-python/src/database.rs
@@ -166,7 +166,7 @@ impl Database {
         let core_observer: Option<Arc<dyn DatabaseObserver>> =
             observer.map(|cb| Arc::new(PyObserver::new(cb)) as Arc<dyn DatabaseObserver>);
         let db = py
-            .allow_threads(move || open_core(&path_clone, core_config, core_observer))
+            .detach(move || open_core(&path_clone, core_config, core_observer))
             .map_err(core_err)?;
         Ok(Self {
             inner: Arc::new(db),
@@ -276,7 +276,7 @@ impl Database {
         let name_owned = name.to_string();
         let inner = Arc::clone(&self.inner);
         let name_for_closure = name_owned.clone();
-        py.allow_threads(move || match plan {
+        py.detach(move || match plan {
             CreatePlan::Full {
                 hnsw_params,
                 pq_rescore_oversampling,
@@ -389,7 +389,7 @@ impl Database {
         // other Python threads keep running.
         let name_owned = name.to_string();
         let inner = Arc::clone(&self.inner);
-        py.allow_threads(move || inner.delete_collection(&name_owned))
+        py.detach(move || inner.delete_collection(&name_owned))
             .map_err(core_err)
     }
 
@@ -415,7 +415,7 @@ impl Database {
         let name_owned = name.to_string();
         let inner = Arc::clone(&self.inner);
         let name_for_closure = name_owned.clone();
-        py.allow_threads(move || inner.create_metadata_collection(&name_for_closure))
+        py.detach(move || inner.create_metadata_collection(&name_for_closure))
             .map_err(core_err)?;
 
         // Use get_any_collection to get the registered instance (not a disconnected copy).
@@ -543,7 +543,7 @@ impl Database {
         let inner = Arc::clone(&self.inner);
         let name_for_closure = name_owned.clone();
 
-        py.allow_threads(move || {
+        py.detach(move || {
             inner.create_collection_typed(
                 &name_for_closure,
                 &CollectionType::Graph {
@@ -616,8 +616,8 @@ impl Database {
         &self,
         py: Python<'_>,
         sql: &str,
-        params: Option<std::collections::HashMap<String, PyObject>>,
-    ) -> PyResult<Vec<PyObject>> {
+        params: Option<std::collections::HashMap<String, Py<PyAny>>>,
+    ) -> PyResult<Vec<Py<PyAny>>> {
         use crate::collection::query::{convert_params, parse_velesql};
         use crate::collection_helpers::search_results_to_multimodel_dicts;
 
@@ -625,7 +625,7 @@ impl Database {
         let rust_params = convert_params(py, params)?;
         let inner = Arc::clone(&self.inner);
         let results = py
-            .allow_threads(move || inner.execute_query(&parsed, &rust_params))
+            .detach(move || inner.execute_query(&parsed, &rust_params))
             .map_err(core_err)?;
         Ok(search_results_to_multimodel_dicts(py, results))
     }
@@ -668,7 +668,7 @@ impl Database {
     ///     >>> stats = db.analyze_collection("documents")
     ///     >>> print(stats["total_points"])
     #[pyo3(signature = (name))]
-    fn analyze_collection(&self, py: Python<'_>, name: &str) -> PyResult<PyObject> {
+    fn analyze_collection(&self, py: Python<'_>, name: &str) -> PyResult<Py<PyAny>> {
         // `analyze_collection` walks the column store and the index,
         // computing cardinality, size histograms, and graph stats. On
         // a ten-million-row collection it crosses the 1-second mark —
@@ -676,7 +676,7 @@ impl Database {
         let name_owned = name.to_string();
         let inner = Arc::clone(&self.inner);
         let stats = py
-            .allow_threads(move || inner.analyze_collection(&name_owned))
+            .detach(move || inner.analyze_collection(&name_owned))
             .map_err(core_err)?;
         let json = serde_json::to_value(&stats)
             .map_err(|e| PyRuntimeError::new_err(format!("Serialization failed: {e}")))?;
@@ -702,7 +702,7 @@ impl Database {
     ///     >>> if stats is not None:
     ///     ...     print(stats["row_count"])
     #[pyo3(signature = (name))]
-    fn get_collection_stats(&self, py: Python<'_>, name: &str) -> PyResult<Option<PyObject>> {
+    fn get_collection_stats(&self, py: Python<'_>, name: &str) -> PyResult<Option<Py<PyAny>>> {
         // `get_collection_stats` reads the cached stats file from disk
         // when the in-memory cache is cold, so in the worst case it
         // performs a small I/O. Release the GIL so other Python threads
@@ -710,7 +710,7 @@ impl Database {
         let name_owned = name.to_string();
         let inner = Arc::clone(&self.inner);
         let maybe_stats = py
-            .allow_threads(move || inner.get_collection_stats(&name_owned))
+            .detach(move || inner.get_collection_stats(&name_owned))
             .map_err(core_err)?;
         maybe_stats
             .map(|stats| {
@@ -739,12 +739,12 @@ impl Database {
     /// Raises:
     ///     RuntimeError: If the collection does not exist.
     #[pyo3(signature = (name))]
-    fn collection_diagnostics(&self, py: Python<'_>, name: &str) -> PyResult<PyObject> {
+    fn collection_diagnostics(&self, py: Python<'_>, name: &str) -> PyResult<Py<PyAny>> {
         use velesdb_core::collection::IndexHealth;
         let name_owned = name.to_string();
         let inner = Arc::clone(&self.inner);
         let diag = py
-            .allow_threads(move || inner.collection_diagnostics(&name_owned))
+            .detach(move || inner.collection_diagnostics(&name_owned))
             .map_err(core_err)?;
 
         let dict = pyo3::types::PyDict::new(py);
@@ -783,7 +783,7 @@ impl Database {
     /// Raises:
     ///     ValueError: If a field is missing, unknown, or has an invalid value.
     #[pyo3(signature = (limits))]
-    fn update_guardrails(&self, py: Python<'_>, limits: PyObject) -> PyResult<()> {
+    fn update_guardrails(&self, py: Python<'_>, limits: Py<PyAny>) -> PyResult<()> {
         let json = utils::python_to_json(py, &limits)?;
         let obj = json
             .as_object()
@@ -791,7 +791,7 @@ impl Database {
         validate_guardrail_keys(obj)?;
         let parsed: velesdb_core::guardrails::QueryLimits = serde_json::from_value(json)
             .map_err(|e| PyValueError::new_err(format!("invalid guardrails: {e}")))?;
-        py.allow_threads(|| self.inner.update_guardrails(&parsed));
+        py.detach(|| self.inner.update_guardrails(&parsed));
         Ok(())
     }
 }

--- a/crates/velesdb-python/src/database_stats.rs
+++ b/crates/velesdb-python/src/database_stats.rs
@@ -20,7 +20,7 @@ impl Database {
     /// Example:
     ///     >>> stats = db.plan_cache_stats()
     ///     >>> print(stats["hit_rate"])
-    fn plan_cache_stats(&self, py: Python<'_>) -> PyResult<PyObject> {
+    fn plan_cache_stats(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let cache = self.inner().plan_cache();
         let stats = cache.stats();
         let metrics = cache.metrics();

--- a/crates/velesdb-python/src/exceptions.rs
+++ b/crates/velesdb-python/src/exceptions.rs
@@ -99,8 +99,8 @@ mod tests {
     /// DimensionMismatch maps to DimensionMismatchError, not RuntimeError.
     #[test]
     fn test_core_err_dimension_mismatch_type() {
-        pyo3::prepare_freethreaded_python();
-        Python::with_gil(|py| {
+        pyo3::Python::initialize();
+        Python::attach(|py| {
             let err = core_err(velesdb_core::Error::DimensionMismatch {
                 expected: 768,
                 actual: 512,
@@ -116,8 +116,8 @@ mod tests {
     /// DimensionMismatch message includes expected and actual dimensions.
     #[test]
     fn test_core_err_dimension_mismatch_message() {
-        pyo3::prepare_freethreaded_python();
-        Python::with_gil(|py| {
+        pyo3::Python::initialize();
+        Python::attach(|py| {
             let err = core_err(velesdb_core::Error::DimensionMismatch {
                 expected: 768,
                 actual: 512,
@@ -131,8 +131,8 @@ mod tests {
     /// core_err_with_collection embeds the collection name in DimensionMismatch messages.
     #[test]
     fn test_core_err_with_collection_includes_name() {
-        pyo3::prepare_freethreaded_python();
-        Python::with_gil(|py| {
+        pyo3::Python::initialize();
+        Python::attach(|py| {
             let err = core_err_with_collection(
                 velesdb_core::Error::DimensionMismatch {
                     expected: 768,
@@ -154,8 +154,8 @@ mod tests {
     /// CollectionNotFound maps to CollectionNotFoundError.
     #[test]
     fn test_core_err_collection_not_found_type() {
-        pyo3::prepare_freethreaded_python();
-        Python::with_gil(|py| {
+        pyo3::Python::initialize();
+        Python::attach(|py| {
             let err = core_err(velesdb_core::Error::CollectionNotFound("my_col".into()));
             assert!(
                 err.is_instance_of::<CollectionNotFoundError>(py),
@@ -170,8 +170,8 @@ mod tests {
     /// use `except velesdb.VelesDBError` as a catch-all.
     #[test]
     fn test_core_err_fallback_to_veles_db_error() {
-        pyo3::prepare_freethreaded_python();
-        Python::with_gil(|py| {
+        pyo3::Python::initialize();
+        Python::attach(|py| {
             let err = core_err(velesdb_core::Error::Internal("oops".into()));
             assert!(
                 err.is_instance_of::<VelesDBError>(py),
@@ -211,8 +211,8 @@ mod tests {
     /// `CollectionExistsError` exists, carries its message, and inherits from `VelesDBError`.
     #[test]
     fn test_collection_exists_error_hierarchy() {
-        pyo3::prepare_freethreaded_python();
-        Python::with_gil(|py| {
+        pyo3::Python::initialize();
+        Python::attach(|py| {
             let err = raise_instance::<CollectionExistsError>(py, "docs already exists");
             assert!(
                 err.is_instance_of::<VelesDBError>(py),
@@ -229,8 +229,8 @@ mod tests {
     /// `EdgeExistsError` exists, carries its message, and inherits from `VelesDBError`.
     #[test]
     fn test_edge_exists_error_hierarchy() {
-        pyo3::prepare_freethreaded_python();
-        Python::with_gil(|py| {
+        pyo3::Python::initialize();
+        Python::attach(|py| {
             let err = raise_instance::<EdgeExistsError>(py, "edge 42 already present");
             assert!(
                 err.is_instance_of::<VelesDBError>(py),
@@ -243,8 +243,8 @@ mod tests {
     /// `DatabaseLockedError` exists, carries its message, and inherits from `VelesDBError`.
     #[test]
     fn test_database_locked_error_hierarchy() {
-        pyo3::prepare_freethreaded_python();
-        Python::with_gil(|py| {
+        pyo3::Python::initialize();
+        Python::attach(|py| {
             let err = raise_instance::<DatabaseLockedError>(py, "held by pid 1234");
             assert!(
                 err.is_instance_of::<VelesDBError>(py),
@@ -259,8 +259,8 @@ mod tests {
     /// `create_exception!` macros accidentally collapse to the same type.
     #[test]
     fn test_veles_db_error_is_not_a_subclass() {
-        pyo3::prepare_freethreaded_python();
-        Python::with_gil(|py| {
+        pyo3::Python::initialize();
+        Python::attach(|py| {
             let err = raise_instance::<VelesDBError>(py, "plain base error");
             assert!(!err.is_instance_of::<CollectionExistsError>(py));
             assert!(!err.is_instance_of::<EdgeExistsError>(py));
@@ -288,8 +288,8 @@ mod tests {
 
     #[test]
     fn test_core_err_collection_exists_type() {
-        pyo3::prepare_freethreaded_python();
-        Python::with_gil(|py| {
+        pyo3::Python::initialize();
+        Python::attach(|py| {
             let err = core_err(CoreError::CollectionExists("docs".into()));
             assert!(err.is_instance_of::<CollectionExistsError>(py));
             assert!(err.is_instance_of::<VelesDBError>(py));
@@ -299,8 +299,8 @@ mod tests {
 
     #[test]
     fn test_core_err_edge_exists_type() {
-        pyo3::prepare_freethreaded_python();
-        Python::with_gil(|py| {
+        pyo3::Python::initialize();
+        Python::attach(|py| {
             let err = core_err(CoreError::EdgeExists(42));
             assert!(err.is_instance_of::<EdgeExistsError>(py));
             assert!(err.is_instance_of::<VelesDBError>(py));
@@ -310,8 +310,8 @@ mod tests {
 
     #[test]
     fn test_core_err_database_locked_type() {
-        pyo3::prepare_freethreaded_python();
-        Python::with_gil(|py| {
+        pyo3::Python::initialize();
+        Python::attach(|py| {
             let err = core_err(CoreError::DatabaseLocked("pid 1234".into()));
             assert!(err.is_instance_of::<DatabaseLockedError>(py));
             assert!(err.is_instance_of::<VelesDBError>(py));
@@ -321,8 +321,8 @@ mod tests {
 
     #[test]
     fn test_core_err_point_not_found_is_key_error() {
-        pyo3::prepare_freethreaded_python();
-        Python::with_gil(|py| {
+        pyo3::Python::initialize();
+        Python::attach(|py| {
             let err = core_err(CoreError::PointNotFound(7));
             assert!(err.is_instance_of::<PyKeyError>(py));
             assert!(err.value(py).to_string().contains('7'));
@@ -331,8 +331,8 @@ mod tests {
 
     #[test]
     fn test_core_err_edge_not_found_is_key_error() {
-        pyo3::prepare_freethreaded_python();
-        Python::with_gil(|py| {
+        pyo3::Python::initialize();
+        Python::attach(|py| {
             let err = core_err(CoreError::EdgeNotFound(99));
             assert!(err.is_instance_of::<PyKeyError>(py));
             assert!(err.value(py).to_string().contains("99"));
@@ -341,8 +341,8 @@ mod tests {
 
     #[test]
     fn test_core_err_node_not_found_is_key_error() {
-        pyo3::prepare_freethreaded_python();
-        Python::with_gil(|py| {
+        pyo3::Python::initialize();
+        Python::attach(|py| {
             let err = core_err(CoreError::NodeNotFound(11));
             assert!(err.is_instance_of::<PyKeyError>(py));
             assert!(err.value(py).to_string().contains("11"));
@@ -351,8 +351,8 @@ mod tests {
 
     #[test]
     fn test_core_err_invalid_vector_is_value_error() {
-        pyo3::prepare_freethreaded_python();
-        Python::with_gil(|py| {
+        pyo3::Python::initialize();
+        Python::attach(|py| {
             let err = core_err(CoreError::InvalidVector("nan at position 0".into()));
             assert!(err.is_instance_of::<PyValueError>(py));
         });
@@ -360,8 +360,8 @@ mod tests {
 
     #[test]
     fn test_core_err_query_is_value_error() {
-        pyo3::prepare_freethreaded_python();
-        Python::with_gil(|py| {
+        pyo3::Python::initialize();
+        Python::attach(|py| {
             let err = core_err(CoreError::Query("unexpected token".into()));
             assert!(err.is_instance_of::<PyValueError>(py));
         });
@@ -369,8 +369,8 @@ mod tests {
 
     #[test]
     fn test_core_err_config_is_value_error() {
-        pyo3::prepare_freethreaded_python();
-        Python::with_gil(|py| {
+        pyo3::Python::initialize();
+        Python::attach(|py| {
             let err = core_err(CoreError::Config("bad hnsw parameter".into()));
             assert!(err.is_instance_of::<PyValueError>(py));
         });
@@ -378,8 +378,8 @@ mod tests {
 
     #[test]
     fn test_core_err_graph_not_supported_is_value_error() {
-        pyo3::prepare_freethreaded_python();
-        Python::with_gil(|py| {
+        pyo3::Python::initialize();
+        Python::attach(|py| {
             let err = core_err(CoreError::GraphNotSupported("edges disabled".into()));
             assert!(err.is_instance_of::<PyValueError>(py));
         });
@@ -387,8 +387,8 @@ mod tests {
 
     #[test]
     fn test_core_err_invalid_dimension_is_value_error() {
-        pyo3::prepare_freethreaded_python();
-        Python::with_gil(|py| {
+        pyo3::Python::initialize();
+        Python::attach(|py| {
             let err = core_err(CoreError::InvalidDimension {
                 dimension: 0,
                 min: 1,
@@ -400,8 +400,8 @@ mod tests {
 
     #[test]
     fn test_core_err_invalid_collection_name_is_value_error() {
-        pyo3::prepare_freethreaded_python();
-        Python::with_gil(|py| {
+        pyo3::Python::initialize();
+        Python::attach(|py| {
             let err = core_err(CoreError::InvalidCollectionName {
                 name: "../etc/passwd".into(),
                 reason: "path traversal".into(),
@@ -412,8 +412,8 @@ mod tests {
 
     #[test]
     fn test_core_err_overflow_is_overflow_error() {
-        pyo3::prepare_freethreaded_python();
-        Python::with_gil(|py| {
+        pyo3::Python::initialize();
+        Python::attach(|py| {
             let err = core_err(CoreError::Overflow("u64 -> usize".into()));
             assert!(err.is_instance_of::<PyOverflowError>(py));
         });
@@ -421,8 +421,8 @@ mod tests {
 
     #[test]
     fn test_core_err_allocation_failed_is_memory_error() {
-        pyo3::prepare_freethreaded_python();
-        Python::with_gil(|py| {
+        pyo3::Python::initialize();
+        Python::attach(|py| {
             let err = core_err(CoreError::AllocationFailed("16 GiB".into()));
             assert!(err.is_instance_of::<PyMemoryError>(py));
         });
@@ -431,8 +431,8 @@ mod tests {
     /// Storage errors map to VelesDBError so `except velesdb.VelesDBError` catches them.
     #[test]
     fn test_core_err_storage_is_veles_db_error() {
-        pyo3::prepare_freethreaded_python();
-        Python::with_gil(|py| {
+        pyo3::Python::initialize();
+        Python::attach(|py| {
             let err = core_err(CoreError::Storage("disk full".into()));
             assert!(
                 err.is_instance_of::<VelesDBError>(py),
@@ -447,8 +447,8 @@ mod tests {
     /// Internal errors map to VelesDBError (same as Storage, Io, etc.).
     #[test]
     fn test_core_err_internal_is_veles_db_error() {
-        pyo3::prepare_freethreaded_python();
-        Python::with_gil(|py| {
+        pyo3::Python::initialize();
+        Python::attach(|py| {
             let err = core_err(CoreError::Internal("BUG: unreachable".into()));
             assert!(err.is_instance_of::<VelesDBError>(py));
         });
@@ -464,8 +464,8 @@ mod tests {
     /// the mapping in `collection_helpers::core_err` and this test.
     #[test]
     fn test_core_err_mapping_covers_every_code() {
-        pyo3::prepare_freethreaded_python();
-        Python::with_gil(|py| {
+        pyo3::Python::initialize();
+        Python::attach(|py| {
             let cases: Vec<CoreError> = vec![
                 CoreError::CollectionExists("x".into()),
                 CoreError::CollectionNotFound("x".into()),

--- a/crates/velesdb-python/src/fusion.rs
+++ b/crates/velesdb-python/src/fusion.rs
@@ -15,7 +15,7 @@ use velesdb_core::FusionStrategy as CoreFusionStrategy;
 ///     >>> strategy = FusionStrategy.rrf()
 ///     >>> # Weighted fusion
 ///     >>> strategy = FusionStrategy.weighted(avg_weight=0.6, max_weight=0.3, hit_weight=0.1)
-#[pyclass(frozen)]
+#[pyclass(frozen, from_py_object)]
 #[derive(Clone)]
 pub struct FusionStrategy {
     inner: CoreFusionStrategy,
@@ -194,7 +194,7 @@ fn parse_weighted_args(
         };
     };
 
-    if let Ok(weights) = avg_weight.downcast::<PyDict>() {
+    if let Ok(weights) = avg_weight.cast::<PyDict>() {
         if max_weight.is_some() || hit_weight.is_some() {
             return Err(PyValueError::new_err(
                 "FusionStrategy.weighted(dict) cannot be combined with positional weights",

--- a/crates/velesdb-python/src/graph.rs
+++ b/crates/velesdb-python/src/graph.rs
@@ -13,12 +13,12 @@ use velesdb_core::collection::graph::{GraphEdge, GraphNode, TraversalResult};
 /// Parse a Python properties dict into a JSON properties map.
 ///
 /// Used by both [`dict_to_node`] and [`dict_to_edge`] to avoid duplicating
-/// the `PyObject` -> `HashMap<String, serde_json::Value>` conversion.
+/// the `Py<PyAny>` -> `HashMap<String, serde_json::Value>` conversion.
 fn parse_properties(
     py: Python<'_>,
-    props_obj: &PyObject,
+    props_obj: &Py<PyAny>,
 ) -> PyResult<HashMap<String, serde_json::Value>> {
-    let props_dict: HashMap<String, PyObject> = props_obj.extract(py)?;
+    let props_dict: HashMap<String, Py<PyAny>> = props_obj.extract(py)?;
     props_dict
         .into_iter()
         .map(|(k, v)| python_to_json(py, &v).map(|jv| (k, jv)))
@@ -26,7 +26,7 @@ fn parse_properties(
 }
 
 /// Convert a Python dict to a GraphNode.
-pub fn dict_to_node(py: Python<'_>, dict: &HashMap<String, PyObject>) -> PyResult<GraphNode> {
+pub fn dict_to_node(py: Python<'_>, dict: &HashMap<String, Py<PyAny>>) -> PyResult<GraphNode> {
     let id: u64 = dict
         .get("id")
         .ok_or_else(|| PyValueError::new_err("Node missing 'id' field"))?
@@ -57,7 +57,7 @@ pub fn dict_to_node(py: Python<'_>, dict: &HashMap<String, PyObject>) -> PyResul
 }
 
 /// Convert a Python dict to a GraphEdge.
-pub fn dict_to_edge(py: Python<'_>, dict: &HashMap<String, PyObject>) -> PyResult<GraphEdge> {
+pub fn dict_to_edge(py: Python<'_>, dict: &HashMap<String, Py<PyAny>>) -> PyResult<GraphEdge> {
     let id: u64 = dict
         .get("id")
         .ok_or_else(|| PyValueError::new_err("Edge missing 'id' field"))?
@@ -95,7 +95,7 @@ pub fn dict_to_edge(py: Python<'_>, dict: &HashMap<String, PyObject>) -> PyResul
 ///
 /// Uses `PyDict::new()` + `PyString::intern()` for static keys to avoid
 /// repeated string allocation.
-pub fn node_to_dict(py: Python<'_>, node: &GraphNode) -> PyObject {
+pub fn node_to_dict(py: Python<'_>, node: &GraphNode) -> Py<PyAny> {
     let dict = PyDict::new(py);
     let _ = dict.set_item(PyString::intern(py, "id"), node.id());
     let _ = dict.set_item(PyString::intern(py, "label"), node.label());
@@ -121,7 +121,7 @@ pub fn node_to_dict(py: Python<'_>, node: &GraphNode) -> PyObject {
 ///
 /// Uses `PyDict::new()` + `PyString::intern()` for static keys to avoid
 /// repeated string allocation.
-pub fn edge_to_dict(py: Python<'_>, edge: &GraphEdge) -> PyObject {
+pub fn edge_to_dict(py: Python<'_>, edge: &GraphEdge) -> Py<PyAny> {
     let dict = PyDict::new(py);
     let _ = dict.set_item(PyString::intern(py, "id"), edge.id());
     let _ = dict.set_item(PyString::intern(py, "source"), edge.source());
@@ -144,7 +144,7 @@ pub fn edge_to_dict(py: Python<'_>, edge: &GraphEdge) -> PyObject {
 ///
 /// Uses `PyDict::new()` + `PyString::intern()` for static keys to avoid
 /// repeated string allocation.
-pub fn traversal_to_dict(py: Python<'_>, result: &TraversalResult) -> PyObject {
+pub fn traversal_to_dict(py: Python<'_>, result: &TraversalResult) -> Py<PyAny> {
     let dict = PyDict::new(py);
     let _ = dict.set_item(PyString::intern(py, "target_id"), result.target_id);
     let _ = dict.set_item(PyString::intern(py, "path"), result.path.to_vec());
@@ -158,8 +158,8 @@ mod tests {
 
     #[test]
     fn test_dict_to_node_minimal() {
-        pyo3::prepare_freethreaded_python();
-        Python::with_gil(|py| {
+        pyo3::Python::initialize();
+        Python::attach(|py| {
             let mut dict = HashMap::new();
             dict.insert("id".to_string(), 1u64.into_pyobject(py).unwrap().into());
             dict.insert(
@@ -175,8 +175,8 @@ mod tests {
 
     #[test]
     fn test_dict_to_edge_minimal() {
-        pyo3::prepare_freethreaded_python();
-        Python::with_gil(|py| {
+        pyo3::Python::initialize();
+        Python::attach(|py| {
             let mut dict = HashMap::new();
             dict.insert("id".to_string(), 100u64.into_pyobject(py).unwrap().into());
             dict.insert("source".to_string(), 1u64.into_pyobject(py).unwrap().into());
@@ -196,8 +196,8 @@ mod tests {
 
     #[test]
     fn test_dict_to_node_rejects_nan_vector() {
-        pyo3::prepare_freethreaded_python();
-        Python::with_gil(|py| {
+        pyo3::Python::initialize();
+        Python::attach(|py| {
             let mut dict = HashMap::new();
             dict.insert("id".to_string(), 1u64.into_pyobject(py).unwrap().into());
             dict.insert(
@@ -217,8 +217,8 @@ mod tests {
 
     #[test]
     fn test_node_to_dict() {
-        pyo3::prepare_freethreaded_python();
-        Python::with_gil(|py| {
+        pyo3::Python::initialize();
+        Python::attach(|py| {
             let mut props = std::collections::HashMap::new();
             props.insert(
                 "name".to_string(),
@@ -227,7 +227,7 @@ mod tests {
             let node = GraphNode::new(1, "Person").with_properties(props);
 
             let obj = node_to_dict(py, &node);
-            let dict = obj.bind(py).downcast::<PyDict>().unwrap();
+            let dict = obj.bind(py).cast::<PyDict>().unwrap();
             assert!(dict.contains("id").unwrap());
             assert!(dict.contains("label").unwrap());
         });

--- a/crates/velesdb-python/src/graph_collection.rs
+++ b/crates/velesdb-python/src/graph_collection.rs
@@ -25,7 +25,7 @@ use velesdb_core::{GraphCollection, GraphSchema};
 /// Example:
 ///     >>> schema = PyGraphSchema.schemaless()
 ///     >>> schema = PyGraphSchema.strict()
-#[pyclass(name = "GraphSchema", frozen)]
+#[pyclass(name = "GraphSchema", frozen, from_py_object)]
 #[derive(Clone)]
 pub struct PyGraphSchema {
     inner: GraphSchema,
@@ -153,9 +153,9 @@ impl PyGraphCollection {
     ///     ...     "label": "KNOWS", "properties": {"since": 2020}
     ///     ... })
     #[pyo3(signature = (edge))]
-    fn add_edge(&self, py: Python<'_>, edge: HashMap<String, PyObject>) -> PyResult<()> {
+    fn add_edge(&self, py: Python<'_>, edge: HashMap<String, Py<PyAny>>) -> PyResult<()> {
         let graph_edge = dict_to_edge(py, &edge)?;
-        py.allow_threads(|| self.inner.add_edge(graph_edge).map_err(core_err))
+        py.detach(|| self.inner.add_edge(graph_edge).map_err(core_err))
     }
 
     /// Add multiple edges in batch (much faster than calling add_edge in a loop).
@@ -178,13 +178,13 @@ impl PyGraphCollection {
     fn add_edges_batch(
         &self,
         py: Python<'_>,
-        edges: Vec<HashMap<String, PyObject>>,
+        edges: Vec<HashMap<String, Py<PyAny>>>,
     ) -> PyResult<usize> {
         let graph_edges: Vec<velesdb_core::collection::graph::GraphEdge> = edges
             .iter()
             .map(|e| dict_to_edge(py, e))
             .collect::<PyResult<Vec<_>>>()?;
-        py.allow_threads(|| self.inner.add_edges_batch(graph_edges).map_err(core_err))
+        py.detach(|| self.inner.add_edges_batch(graph_edges).map_err(core_err))
     }
 
     /// Get edges, optionally filtered by label.
@@ -199,8 +199,8 @@ impl PyGraphCollection {
     ///     >>> all_edges = graph.get_edges()
     ///     >>> knows_edges = graph.get_edges(label="KNOWS")
     #[pyo3(signature = (label=None))]
-    fn get_edges(&self, py: Python<'_>, label: Option<String>) -> PyResult<Vec<PyObject>> {
-        let edges = py.allow_threads(|| self.inner.get_edges(label.as_deref()));
+    fn get_edges(&self, py: Python<'_>, label: Option<String>) -> PyResult<Vec<Py<PyAny>>> {
+        let edges = py.detach(|| self.inner.get_edges(label.as_deref()));
         Ok(edges.iter().map(|e| edge_to_dict(py, e)).collect())
     }
 
@@ -212,8 +212,8 @@ impl PyGraphCollection {
     /// Returns:
     ///     List of edge dicts
     #[pyo3(signature = (node_id))]
-    fn get_outgoing(&self, py: Python<'_>, node_id: u64) -> PyResult<Vec<PyObject>> {
-        let edges = py.allow_threads(|| self.inner.get_outgoing(node_id));
+    fn get_outgoing(&self, py: Python<'_>, node_id: u64) -> PyResult<Vec<Py<PyAny>>> {
+        let edges = py.detach(|| self.inner.get_outgoing(node_id));
         Ok(edges.iter().map(|e| edge_to_dict(py, e)).collect())
     }
 
@@ -228,7 +228,7 @@ impl PyGraphCollection {
     /// Preserves compatibility with examples that used the explicit
     /// `*_edges` suffix.
     #[pyo3(signature = (node_id))]
-    fn get_outgoing_edges(&self, py: Python<'_>, node_id: u64) -> PyResult<Vec<PyObject>> {
+    fn get_outgoing_edges(&self, py: Python<'_>, node_id: u64) -> PyResult<Vec<Py<PyAny>>> {
         self.get_outgoing(py, node_id)
     }
 
@@ -240,8 +240,8 @@ impl PyGraphCollection {
     /// Returns:
     ///     List of edge dicts
     #[pyo3(signature = (node_id))]
-    fn get_incoming(&self, py: Python<'_>, node_id: u64) -> PyResult<Vec<PyObject>> {
-        let edges = py.allow_threads(|| self.inner.get_incoming(node_id));
+    fn get_incoming(&self, py: Python<'_>, node_id: u64) -> PyResult<Vec<Py<PyAny>>> {
+        let edges = py.detach(|| self.inner.get_incoming(node_id));
         Ok(edges.iter().map(|e| edge_to_dict(py, e)).collect())
     }
 
@@ -250,7 +250,7 @@ impl PyGraphCollection {
     /// Preserves compatibility with examples that used the explicit
     /// `*_edges` suffix.
     #[pyo3(signature = (node_id))]
-    fn get_incoming_edges(&self, py: Python<'_>, node_id: u64) -> PyResult<Vec<PyObject>> {
+    fn get_incoming_edges(&self, py: Python<'_>, node_id: u64) -> PyResult<Vec<Py<PyAny>>> {
         self.get_incoming(py, node_id)
     }
 
@@ -280,9 +280,14 @@ impl PyGraphCollection {
     /// Example:
     ///     >>> graph.upsert_node_payload(10, {"name": "Alice", "age": 30})
     #[pyo3(signature = (node_id, payload))]
-    fn upsert_node_payload(&self, py: Python<'_>, node_id: u64, payload: PyObject) -> PyResult<()> {
+    fn upsert_node_payload(
+        &self,
+        py: Python<'_>,
+        node_id: u64,
+        payload: Py<PyAny>,
+    ) -> PyResult<()> {
         let value = python_to_json(py, &payload)?;
-        py.allow_threads(|| {
+        py.detach(|| {
             self.inner
                 .upsert_node_payload(node_id, &value)
                 .map_err(core_err)
@@ -300,15 +305,15 @@ impl PyGraphCollection {
         &self,
         py: Python<'_>,
         node_id: u64,
-        payload: PyObject,
-        vector: Option<PyObject>,
+        payload: Py<PyAny>,
+        vector: Option<Py<PyAny>>,
     ) -> PyResult<()> {
         let value = python_to_json(py, &payload)?;
         let vector = match vector {
             Some(vector) => Some(extract_vector(py, &vector)?),
             None => None,
         };
-        py.allow_threads(|| {
+        py.detach(|| {
             self.inner
                 .upsert_node(node_id, &value, vector)
                 .map_err(core_err)
@@ -323,8 +328,8 @@ impl PyGraphCollection {
     /// Returns:
     ///     Dict of properties, or None if no payload is stored
     #[pyo3(signature = (node_id))]
-    fn get_node_payload(&self, py: Python<'_>, node_id: u64) -> PyResult<Option<PyObject>> {
-        let value = py.allow_threads(|| self.inner.get_node_payload(node_id).map_err(core_err))?;
+    fn get_node_payload(&self, py: Python<'_>, node_id: u64) -> PyResult<Option<Py<PyAny>>> {
+        let value = py.detach(|| self.inner.get_node_payload(node_id).map_err(core_err))?;
         Ok(value.map(|v| json_to_python(py, &v)))
     }
 
@@ -333,7 +338,7 @@ impl PyGraphCollection {
     /// Returns:
     ///     List of node IDs
     fn all_node_ids(&self, py: Python<'_>) -> Vec<u64> {
-        py.allow_threads(|| self.inner.all_node_ids())
+        py.detach(|| self.inner.all_node_ids())
     }
 
     /// Perform BFS traversal from a source node.
@@ -361,10 +366,10 @@ impl PyGraphCollection {
         limit: Option<usize>,
         rel_types: Option<Vec<String>>,
         relationship_types: Option<Vec<String>>,
-    ) -> PyResult<Vec<PyObject>> {
+    ) -> PyResult<Vec<Py<PyAny>>> {
         let effective_rel_types = rel_types.or(relationship_types);
         let config = build_traversal_config(max_depth, limit, effective_rel_types);
-        let results = py.allow_threads(|| self.inner.traverse_bfs(source_id, &config));
+        let results = py.detach(|| self.inner.traverse_bfs(source_id, &config));
         Ok(results.iter().map(|r| traversal_to_dict(py, r)).collect())
     }
 
@@ -393,10 +398,10 @@ impl PyGraphCollection {
         limit: Option<usize>,
         rel_types: Option<Vec<String>>,
         relationship_types: Option<Vec<String>>,
-    ) -> PyResult<Vec<PyObject>> {
+    ) -> PyResult<Vec<Py<PyAny>>> {
         let effective_rel_types = rel_types.or(relationship_types);
         let config = build_traversal_config(max_depth, limit, effective_rel_types);
-        let results = py.allow_threads(|| self.inner.traverse_dfs(source_id, &config));
+        let results = py.detach(|| self.inner.traverse_dfs(source_id, &config));
         Ok(results.iter().map(|r| traversal_to_dict(py, r)).collect())
     }
 
@@ -426,10 +431,10 @@ impl PyGraphCollection {
         limit: Option<usize>,
         rel_types: Option<Vec<String>>,
         relationship_types: Option<Vec<String>>,
-    ) -> PyResult<Vec<PyObject>> {
+    ) -> PyResult<Vec<Py<PyAny>>> {
         let effective_rel_types = rel_types.or(relationship_types);
         let config = build_traversal_config(max_depth, limit, effective_rel_types);
-        let results = py.allow_threads(|| self.inner.traverse_bfs_parallel(&source_ids, &config));
+        let results = py.detach(|| self.inner.traverse_bfs_parallel(&source_ids, &config));
         Ok(results.iter().map(|r| traversal_to_dict(py, r)).collect())
     }
 
@@ -451,13 +456,13 @@ impl PyGraphCollection {
     fn search_by_embedding(
         &self,
         py: Python<'_>,
-        query: PyObject,
+        query: Py<PyAny>,
         k: Option<usize>,
-    ) -> PyResult<Vec<PyObject>> {
+    ) -> PyResult<Vec<Py<PyAny>>> {
         let vec = extract_vector(py, &query)?;
         let top_k = k.unwrap_or(10);
 
-        let results = py.allow_threads(|| {
+        let results = py.detach(|| {
             self.inner
                 .search_by_embedding(&vec, top_k)
                 .map_err(core_err)
@@ -473,7 +478,7 @@ impl PyGraphCollection {
     ///
     /// Ensures edges, payloads, and indexes are persisted.
     fn flush(&self, py: Python<'_>) -> PyResult<()> {
-        py.allow_threads(|| self.inner.flush().map_err(core_err))
+        py.detach(|| self.inner.flush().map_err(core_err))
     }
 
     /// Returns the total number of edges in the graph.
@@ -489,7 +494,7 @@ impl PyGraphCollection {
     /// Use on graceful shutdown to avoid a full WAL replay on next startup.
     /// For routine persistence, use ``flush()`` instead.
     fn flush_full(&self, py: Python<'_>) -> PyResult<()> {
-        py.allow_threads(|| self.inner.flush_full().map_err(core_err))
+        py.detach(|| self.inner.flush_full().map_err(core_err))
     }
 
     /// Returns the number of points (nodes with payload) in the graph.
@@ -524,8 +529,8 @@ impl PyGraphCollection {
     /// Returns:
     ///     List of point dicts (or None for missing IDs)
     #[pyo3(signature = (ids))]
-    fn get(&self, py: Python<'_>, ids: Vec<u64>) -> PyResult<Vec<Option<PyObject>>> {
-        let points = py.allow_threads(|| self.inner.get(&ids));
+    fn get(&self, py: Python<'_>, ids: Vec<u64>) -> PyResult<Vec<Option<Py<PyAny>>>> {
+        let points = py.detach(|| self.inner.get(&ids));
         let py_points = points
             .into_iter()
             .map(|opt_point| opt_point.map(|p| point_to_dict(py, &p)))
@@ -539,7 +544,7 @@ impl PyGraphCollection {
     ///     ids: List of point IDs to delete
     #[pyo3(signature = (ids))]
     fn delete(&self, py: Python<'_>, ids: Vec<u64>) -> PyResult<()> {
-        py.allow_threads(|| self.inner.delete(&ids).map_err(core_err))
+        py.detach(|| self.inner.delete(&ids).map_err(core_err))
     }
 
     /// Remove a specific edge by its ID.
@@ -551,7 +556,7 @@ impl PyGraphCollection {
     ///     bool: True if the edge existed and was removed
     #[pyo3(signature = (edge_id))]
     fn remove_edge(&self, py: Python<'_>, edge_id: u64) -> bool {
-        py.allow_threads(|| self.inner.remove_edge(edge_id))
+        py.detach(|| self.inner.remove_edge(edge_id))
     }
 
     fn __repr__(&self) -> String {
@@ -584,7 +589,7 @@ impl PyGraphCollection {
     /// :py:meth:`flush_full` but named so graph collections can be used
     /// as a context manager.
     fn close(&self, py: Python<'_>) -> PyResult<()> {
-        py.allow_threads(|| self.inner.flush_full().map_err(core_err))
+        py.detach(|| self.inner.flush_full().map_err(core_err))
     }
 
     /// Context manager entry — returns ``self``.
@@ -598,9 +603,9 @@ impl PyGraphCollection {
     fn __exit__(
         &self,
         py: Python<'_>,
-        _exc_type: Option<PyObject>,
-        _exc_value: Option<PyObject>,
-        _traceback: Option<PyObject>,
+        _exc_type: Option<Py<PyAny>>,
+        _exc_value: Option<Py<PyAny>>,
+        _traceback: Option<Py<PyAny>>,
     ) -> PyResult<bool> {
         self.close(py)?;
         Ok(false)

--- a/crates/velesdb-python/src/graph_collection_query.rs
+++ b/crates/velesdb-python/src/graph_collection_query.rs
@@ -47,8 +47,8 @@ impl PyGraphCollection {
         &self,
         py: Python<'_>,
         query_str: &str,
-        params: Option<HashMap<String, PyObject>>,
-    ) -> PyResult<Vec<PyObject>> {
+        params: Option<HashMap<String, Py<PyAny>>>,
+    ) -> PyResult<Vec<Py<PyAny>>> {
         let inner = &self.inner;
         run_velesql_select(py, query_str, params, |q, p| inner.execute_query(q, p))
     }
@@ -76,10 +76,10 @@ impl PyGraphCollection {
         &self,
         py: Python<'_>,
         query_str: &str,
-        params: Option<HashMap<String, PyObject>>,
-        vector: Option<PyObject>,
+        params: Option<HashMap<String, Py<PyAny>>>,
+        vector: Option<Py<PyAny>>,
         threshold: f32,
-    ) -> PyResult<Vec<PyObject>> {
+    ) -> PyResult<Vec<Py<PyAny>>> {
         let inner = &self.inner;
         run_velesql_match(py, query_str, params, vector, move |mc, p, qv| {
             if let Some(ref qv) = qv {
@@ -98,7 +98,7 @@ impl PyGraphCollection {
     /// Returns:
     ///     Dict with tree, estimated_cost_ms, filter_strategy, index_used
     #[pyo3(signature = (query_str))]
-    fn explain(&self, py: Python<'_>, query_str: &str) -> PyResult<PyObject> {
+    fn explain(&self, py: Python<'_>, query_str: &str) -> PyResult<Py<PyAny>> {
         let parsed = parse_velesql(query_str)?;
         Ok(build_explain_dict(py, &parsed))
     }
@@ -119,12 +119,12 @@ impl PyGraphCollection {
         &self,
         py: Python<'_>,
         query_str: &str,
-        params: Option<HashMap<String, PyObject>>,
-    ) -> PyResult<PyObject> {
+        params: Option<HashMap<String, Py<PyAny>>>,
+    ) -> PyResult<Py<PyAny>> {
         let parsed = parse_velesql(query_str)?;
         let rust_params = convert_params(py, params)?;
         let inner = &self.inner;
-        let output = py.allow_threads(move || {
+        let output = py.detach(move || {
             inner
                 .explain_analyze_query(&parsed, &rust_params)
                 .map_err(core_err)
@@ -145,8 +145,8 @@ impl PyGraphCollection {
         &self,
         py: Python<'_>,
         velesql: &str,
-        params: Option<HashMap<String, PyObject>>,
-    ) -> PyResult<Vec<PyObject>> {
+        params: Option<HashMap<String, Py<PyAny>>>,
+    ) -> PyResult<Vec<Py<PyAny>>> {
         let inner = &self.inner;
         run_velesql_select_ids(py, velesql, params, |q, p| inner.execute_query(q, p))
     }

--- a/crates/velesdb-python/src/graph_store.rs
+++ b/crates/velesdb-python/src/graph_store.rs
@@ -25,7 +25,7 @@ use velesdb_core::collection::graph::{bfs_stream, StreamingConfig as CoreStreami
 /// Example:
 ///     >>> config = StreamingConfig(max_depth=3, max_visited=10000)
 ///     >>> config.relationship_types = ["KNOWS", "FOLLOWS"]
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Clone)]
 pub struct StreamingConfig {
     /// Maximum traversal depth (default: 3).
@@ -53,7 +53,7 @@ impl StreamingConfig {
 }
 
 /// Result of a BFS traversal step.
-#[pyclass(frozen)]
+#[pyclass(frozen, from_py_object)]
 #[derive(Clone)]
 pub struct TraversalResult {
     /// Current depth in the traversal.
@@ -112,9 +112,9 @@ impl GraphStore {
     ///     edge: Dict with keys: id (int), source (int), target (int), label (str),
     ///           properties (dict, optional)
     #[pyo3(signature = (edge))]
-    fn add_edge(&self, py: Python<'_>, edge: HashMap<String, PyObject>) -> PyResult<()> {
+    fn add_edge(&self, py: Python<'_>, edge: HashMap<String, Py<PyAny>>) -> PyResult<()> {
         let graph_edge = dict_to_edge(py, &edge)?;
-        py.allow_threads(|| {
+        py.detach(|| {
             let mut store = self.inner.write();
             store.add_edge(graph_edge).map_err(core_err)
         })
@@ -131,9 +131,9 @@ impl GraphStore {
     /// Note:
     ///     Uses internal label index for O(1) lookup per label.
     #[pyo3(signature = (label))]
-    fn get_edges_by_label(&self, py: Python<'_>, label: &str) -> PyResult<Vec<PyObject>> {
+    fn get_edges_by_label(&self, py: Python<'_>, label: &str) -> PyResult<Vec<Py<PyAny>>> {
         let label_owned = label.to_string();
-        let edges = py.allow_threads(|| {
+        let edges = py.detach(|| {
             let store = self.inner.read();
             store
                 .get_edges_by_label(&label_owned)
@@ -146,8 +146,8 @@ impl GraphStore {
 
     /// Gets outgoing edges from a node.
     #[pyo3(signature = (node_id))]
-    fn get_outgoing(&self, py: Python<'_>, node_id: u64) -> PyResult<Vec<PyObject>> {
-        let edges = py.allow_threads(|| {
+    fn get_outgoing(&self, py: Python<'_>, node_id: u64) -> PyResult<Vec<Py<PyAny>>> {
+        let edges = py.detach(|| {
             let store = self.inner.read();
             store
                 .get_outgoing(node_id)
@@ -160,14 +160,14 @@ impl GraphStore {
 
     /// Alias for `get_outgoing`.
     #[pyo3(signature = (node_id))]
-    fn get_outgoing_edges(&self, py: Python<'_>, node_id: u64) -> PyResult<Vec<PyObject>> {
+    fn get_outgoing_edges(&self, py: Python<'_>, node_id: u64) -> PyResult<Vec<Py<PyAny>>> {
         self.get_outgoing(py, node_id)
     }
 
     /// Gets incoming edges to a node.
     #[pyo3(signature = (node_id))]
-    fn get_incoming(&self, py: Python<'_>, node_id: u64) -> PyResult<Vec<PyObject>> {
-        let edges = py.allow_threads(|| {
+    fn get_incoming(&self, py: Python<'_>, node_id: u64) -> PyResult<Vec<Py<PyAny>>> {
+        let edges = py.detach(|| {
             let store = self.inner.read();
             store
                 .get_incoming(node_id)
@@ -180,7 +180,7 @@ impl GraphStore {
 
     /// Alias for `get_incoming`.
     #[pyo3(signature = (node_id))]
-    fn get_incoming_edges(&self, py: Python<'_>, node_id: u64) -> PyResult<Vec<PyObject>> {
+    fn get_incoming_edges(&self, py: Python<'_>, node_id: u64) -> PyResult<Vec<Py<PyAny>>> {
         self.get_incoming(py, node_id)
     }
 
@@ -191,9 +191,9 @@ impl GraphStore {
         py: Python<'_>,
         node_id: u64,
         label: &str,
-    ) -> PyResult<Vec<PyObject>> {
+    ) -> PyResult<Vec<Py<PyAny>>> {
         let label_owned = label.to_string();
-        let edges = py.allow_threads(|| {
+        let edges = py.detach(|| {
             let store = self.inner.read();
             store
                 .get_outgoing_by_label(node_id, &label_owned)
@@ -241,8 +241,8 @@ impl GraphStore {
             deadline: None,
         };
 
-        // Release GIL during traversal (no PyObject involved)
-        py.allow_threads(|| {
+        // Release GIL during traversal (no Py<PyAny> involved)
+        py.detach(|| {
             let store = self.inner.read();
 
             // FLAG-1 FIX: Use core's BfsIterator instead of re-implementing BFS
@@ -280,7 +280,7 @@ impl GraphStore {
     /// Removes an edge by ID.
     #[pyo3(signature = (edge_id))]
     fn remove_edge(&self, py: Python<'_>, edge_id: u64) -> PyResult<()> {
-        py.allow_threads(|| {
+        py.detach(|| {
             let mut store = self.inner.write();
             store.remove_edge(edge_id);
         });
@@ -289,7 +289,7 @@ impl GraphStore {
 
     /// Returns the number of edges in the store.
     fn edge_count(&self, py: Python<'_>) -> PyResult<usize> {
-        Ok(py.allow_threads(|| {
+        Ok(py.detach(|| {
             let store = self.inner.read();
             store.edge_count()
         }))
@@ -304,7 +304,7 @@ impl GraphStore {
     ///     True if the edge exists, False otherwise.
     #[pyo3(signature = (edge_id))]
     fn has_edge(&self, py: Python<'_>, edge_id: u64) -> PyResult<bool> {
-        Ok(py.allow_threads(|| {
+        Ok(py.detach(|| {
             let store = self.inner.read();
             store.get_edge(edge_id).is_some()
         }))
@@ -319,7 +319,7 @@ impl GraphStore {
     ///     Number of outgoing edges from this node.
     #[pyo3(signature = (node_id))]
     fn out_degree(&self, py: Python<'_>, node_id: u64) -> PyResult<usize> {
-        Ok(py.allow_threads(|| {
+        Ok(py.detach(|| {
             let store = self.inner.read();
             store.get_outgoing(node_id).len()
         }))
@@ -334,7 +334,7 @@ impl GraphStore {
     ///     Number of incoming edges to this node.
     #[pyo3(signature = (node_id))]
     fn in_degree(&self, py: Python<'_>, node_id: u64) -> PyResult<usize> {
-        Ok(py.allow_threads(|| {
+        Ok(py.detach(|| {
             let store = self.inner.read();
             store.get_incoming(node_id).len()
         }))
@@ -364,7 +364,7 @@ impl GraphStore {
         let max_depth = config.max_depth;
         let relationship_types = config.relationship_types.clone();
 
-        py.allow_threads(|| {
+        py.detach(|| {
             let store = self.inner.read();
             Ok(dfs_collect(
                 &store,

--- a/crates/velesdb-python/src/lib.rs
+++ b/crates/velesdb-python/src/lib.rs
@@ -65,7 +65,7 @@ pub struct SearchResult {
     #[pyo3(get)]
     score: f32,
     #[pyo3(get)]
-    payload: PyObject,
+    payload: Py<PyAny>,
 }
 
 /// VelesDB - A high-performance vector database for AI applications.

--- a/crates/velesdb-python/src/observer.rs
+++ b/crates/velesdb-python/src/observer.rs
@@ -71,7 +71,7 @@ fn collection_kind(kind: &CollectionType) -> &'static str {
 impl DatabaseObserver for PyObserver {
     fn on_collection_created(&self, name: &str, kind: &CollectionType) {
         let kind = collection_kind(kind);
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let fields = PyDict::new(py);
             if fields.set_item("name", name).is_err() || fields.set_item("kind", kind).is_err() {
                 return;
@@ -81,7 +81,7 @@ impl DatabaseObserver for PyObserver {
     }
 
     fn on_collection_deleted(&self, name: &str) {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let fields = PyDict::new(py);
             if fields.set_item("name", name).is_err() {
                 return;
@@ -91,7 +91,7 @@ impl DatabaseObserver for PyObserver {
     }
 
     fn on_upsert(&self, collection: &str, point_count: usize) {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let fields = PyDict::new(py);
             if fields.set_item("collection", collection).is_err()
                 || fields.set_item("point_count", point_count).is_err()
@@ -103,7 +103,7 @@ impl DatabaseObserver for PyObserver {
     }
 
     fn on_query(&self, collection: &str, duration_us: u64) {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let fields = PyDict::new(py);
             if fields.set_item("collection", collection).is_err()
                 || fields.set_item("duration_us", duration_us).is_err()

--- a/crates/velesdb-python/src/options.rs
+++ b/crates/velesdb-python/src/options.rs
@@ -47,7 +47,7 @@ use velesdb_core::index::hnsw::HnswParams;
 ///     ...     dimension=128,
 ///     ...     hnsw=HnswOptions.for_dataset_size(128, 1_000_000),
 ///     ... )
-#[pyclass(module = "velesdb")]
+#[pyclass(module = "velesdb", from_py_object)]
 #[derive(Clone, Debug, Default)]
 pub struct HnswOptions {
     /// Maximum connections per node (M parameter). Higher = better
@@ -228,7 +228,7 @@ impl HnswOptions {
 /// - `max_perfect_mode_vectors` — parsed but not yet enforced
 ///
 /// See `docs/CORE_WIRING_DEBT.md` for the enforcement roadmap.
-#[pyclass(module = "velesdb")]
+#[pyclass(module = "velesdb", from_py_object)]
 #[derive(Clone, Debug, Default)]
 pub struct LimitsOptions {
     /// Maximum number of collections in the database. Default: 1000.
@@ -319,7 +319,7 @@ impl LimitsOptions {
 ///
 /// `cooldown_secs` is exposed as an integer (seconds) rather than a
 /// `Duration` to avoid the Python/Rust serde mismatch.
-#[pyclass(module = "velesdb")]
+#[pyclass(module = "velesdb", from_py_object)]
 #[derive(Clone, Debug)]
 pub struct AutoReindexOptions {
     /// Enable auto-reindex divergence detection. Default: `true`.
@@ -437,7 +437,7 @@ impl AutoReindexOptions {
 /// `wal_batch` is intentionally not exposed: the concurrent WAL
 /// writer is a velesdb-premium Enterprise feature. See
 /// `docs/guides/WRITE_CONCURRENCY.md`.
-#[pyclass(module = "velesdb")]
+#[pyclass(module = "velesdb", from_py_object)]
 #[derive(Clone, Debug, Default)]
 pub struct VelesConfigOptions {
     /// Tenant-wide guard-rail limits.

--- a/crates/velesdb-python/src/streaming_config.rs
+++ b/crates/velesdb-python/src/streaming_config.rs
@@ -18,7 +18,7 @@ use pyo3::prelude::*;
 ///     >>> cfg = StreamingIngestConfig(buffer_size=4096, batch_size=256)
 ///     >>> cfg.flush_interval_ms
 ///     50
-#[pyclass(module = "velesdb")]
+#[pyclass(module = "velesdb", from_py_object)]
 #[derive(Clone, Debug)]
 pub struct StreamingIngestConfig {
     /// Capacity of the bounded ingestion channel (backpressure threshold).

--- a/crates/velesdb-python/src/utils.rs
+++ b/crates/velesdb-python/src/utils.rs
@@ -29,7 +29,7 @@ pub fn reject_nan_vector(vector: &[f32]) -> PyResult<()> {
     Ok(())
 }
 
-/// Extracts a vector from a PyObject, supporting both Python lists and NumPy arrays.
+/// Extracts a vector from a Py<PyAny>, supporting both Python lists and NumPy arrays.
 ///
 /// After extraction the vector is validated: NaN values are rejected with a
 /// `PyValueError`.
@@ -44,7 +44,7 @@ pub fn reject_nan_vector(vector: &[f32]) -> PyResult<()> {
 /// # Errors
 /// Returns an error if the object is neither a list nor a numpy array,
 /// or if the extracted vector contains NaN values.
-pub fn extract_vector(py: Python<'_>, obj: &PyObject) -> PyResult<Vec<f32>> {
+pub fn extract_vector(py: Python<'_>, obj: &Py<PyAny>) -> PyResult<Vec<f32>> {
     // Try numpy array first (most common in ML workflows)
     if let Ok(array) = obj.extract::<numpy::PyReadonlyArray1<f32>>(py) {
         let vec = array.as_slice()?.to_vec();
@@ -96,7 +96,7 @@ pub fn parse_storage_mode(mode: &str) -> PyResult<StorageMode> {
 /// # Errors
 ///
 /// Returns `PyValueError` if the Python object type is not JSON-serializable.
-pub fn python_to_json(py: Python<'_>, obj: &PyObject) -> PyResult<serde_json::Value> {
+pub fn python_to_json(py: Python<'_>, obj: &Py<PyAny>) -> PyResult<serde_json::Value> {
     if let Ok(s) = obj.extract::<String>(py) {
         return Ok(serde_json::Value::String(s));
     }
@@ -118,14 +118,14 @@ pub fn python_to_json(py: Python<'_>, obj: &PyObject) -> PyResult<serde_json::Va
     if obj.is_none(py) {
         return Ok(serde_json::Value::Null);
     }
-    if let Ok(list) = obj.extract::<Vec<PyObject>>(py) {
+    if let Ok(list) = obj.extract::<Vec<Py<PyAny>>>(py) {
         let arr: Vec<serde_json::Value> = list
             .iter()
             .map(|item| python_to_json(py, item))
             .collect::<PyResult<_>>()?;
         return Ok(serde_json::Value::Array(arr));
     }
-    if let Ok(dict) = obj.extract::<HashMap<String, PyObject>>(py) {
+    if let Ok(dict) = obj.extract::<HashMap<String, Py<PyAny>>>(py) {
         let map: serde_json::Map<String, serde_json::Value> = dict
             .into_iter()
             .map(|(k, v)| python_to_json(py, &v).map(|jv| (k, jv)))
@@ -143,13 +143,13 @@ pub fn python_to_json(py: Python<'_>, obj: &PyObject) -> PyResult<serde_json::Va
     )))
 }
 
-/// Helper to convert a value to `PyObject` using the `IntoPyObject` trait.
+/// Helper to convert a value to `Py<PyAny>` using the `IntoPyObject` trait.
 ///
 /// Returns `py.None()` on conversion failure instead of panicking,
-/// which preserves the existing `-> PyObject` signature for 18 callers.
+/// which preserves the existing `-> Py<PyAny>` signature for 18 callers.
 /// Failures are logged to help diagnose unexpected `None` values in results.
 #[inline]
-pub fn to_pyobject<'py, T>(py: Python<'py>, value: T) -> PyObject
+pub fn to_pyobject<'py, T>(py: Python<'py>, value: T) -> Py<PyAny>
 where
     T: IntoPyObjectExt<'py>,
 {
@@ -163,7 +163,7 @@ where
 ///
 /// Builds `PyDict`/`PyList` directly instead of going through `HashMap`/`Vec`
 /// intermediaries to avoid unnecessary allocations.
-pub fn json_to_python(py: Python<'_>, value: &serde_json::Value) -> PyObject {
+pub fn json_to_python(py: Python<'_>, value: &serde_json::Value) -> Py<PyAny> {
     use pyo3::types::{PyDict, PyList};
 
     match value {
@@ -180,8 +180,8 @@ pub fn json_to_python(py: Python<'_>, value: &serde_json::Value) -> PyObject {
         }
         serde_json::Value::String(s) => to_pyobject(py, s.as_str()),
         serde_json::Value::Array(arr) => {
-            let items: Vec<PyObject> = arr.iter().map(|v| json_to_python(py, v)).collect();
-            // PyList::new is infallible for Vec<PyObject> items.
+            let items: Vec<Py<PyAny>> = arr.iter().map(|v| json_to_python(py, v)).collect();
+            // PyList::new is infallible for Vec<Py<PyAny>> items.
             let list = PyList::new(py, &items).unwrap_or_else(|_| PyList::empty(py));
             list.into_any().unbind()
         }
@@ -229,10 +229,10 @@ mod tests {
 
     #[test]
     fn test_extract_vector_rejects_nan_list() {
-        pyo3::prepare_freethreaded_python();
-        Python::with_gil(|py| {
+        pyo3::Python::initialize();
+        Python::attach(|py| {
             let list = vec![1.0_f32, f32::NAN, 3.0];
-            let obj: PyObject = list
+            let obj: Py<PyAny> = list
                 .into_pyobject(py)
                 .expect("test: convert Vec<f32> to Python list")
                 .into();
@@ -243,8 +243,8 @@ mod tests {
 
     #[test]
     fn test_parse_metric_cosine() {
-        pyo3::prepare_freethreaded_python();
-        Python::with_gil(|_py| {
+        pyo3::Python::initialize();
+        Python::attach(|_py| {
             assert!(matches!(
                 parse_metric("cosine").expect("test: 'cosine' is a valid metric"),
                 DistanceMetric::Cosine
@@ -259,8 +259,8 @@ mod tests {
 
     #[test]
     fn test_parse_metric_euclidean() {
-        pyo3::prepare_freethreaded_python();
-        Python::with_gil(|_py| {
+        pyo3::Python::initialize();
+        Python::attach(|_py| {
             assert!(matches!(
                 parse_metric("euclidean").expect("test: 'euclidean' is a valid metric"),
                 DistanceMetric::Euclidean
@@ -274,8 +274,8 @@ mod tests {
 
     #[test]
     fn test_parse_metric_dot() {
-        pyo3::prepare_freethreaded_python();
-        Python::with_gil(|_py| {
+        pyo3::Python::initialize();
+        Python::attach(|_py| {
             assert!(matches!(
                 parse_metric("dot").expect("test: 'dot' is a valid metric"),
                 DistanceMetric::DotProduct
@@ -293,8 +293,8 @@ mod tests {
 
     #[test]
     fn test_parse_metric_hamming() {
-        pyo3::prepare_freethreaded_python();
-        Python::with_gil(|_py| {
+        pyo3::Python::initialize();
+        Python::attach(|_py| {
             assert!(matches!(
                 parse_metric("hamming").expect("test: 'hamming' is a valid metric"),
                 DistanceMetric::Hamming
@@ -304,8 +304,8 @@ mod tests {
 
     #[test]
     fn test_parse_metric_jaccard() {
-        pyo3::prepare_freethreaded_python();
-        Python::with_gil(|_py| {
+        pyo3::Python::initialize();
+        Python::attach(|_py| {
             assert!(matches!(
                 parse_metric("jaccard").expect("test: 'jaccard' is a valid metric"),
                 DistanceMetric::Jaccard
@@ -315,16 +315,16 @@ mod tests {
 
     #[test]
     fn test_parse_metric_invalid() {
-        pyo3::prepare_freethreaded_python();
-        Python::with_gil(|_py| {
+        pyo3::Python::initialize();
+        Python::attach(|_py| {
             assert!(parse_metric("invalid").is_err());
         });
     }
 
     #[test]
     fn test_parse_storage_mode_full() {
-        pyo3::prepare_freethreaded_python();
-        Python::with_gil(|_py| {
+        pyo3::Python::initialize();
+        Python::attach(|_py| {
             assert!(matches!(
                 parse_storage_mode("full").expect("test: 'full' is a valid storage mode"),
                 StorageMode::Full
@@ -338,8 +338,8 @@ mod tests {
 
     #[test]
     fn test_parse_storage_mode_sq8() {
-        pyo3::prepare_freethreaded_python();
-        Python::with_gil(|_py| {
+        pyo3::Python::initialize();
+        Python::attach(|_py| {
             assert!(matches!(
                 parse_storage_mode("sq8").expect("test: 'sq8' is a valid storage mode"),
                 StorageMode::SQ8
@@ -353,8 +353,8 @@ mod tests {
 
     #[test]
     fn test_parse_storage_mode_binary() {
-        pyo3::prepare_freethreaded_python();
-        Python::with_gil(|_py| {
+        pyo3::Python::initialize();
+        Python::attach(|_py| {
             assert!(matches!(
                 parse_storage_mode("binary").expect("test: 'binary' is a valid storage mode"),
                 StorageMode::Binary
@@ -368,8 +368,8 @@ mod tests {
 
     #[test]
     fn test_parse_storage_mode_pq() {
-        pyo3::prepare_freethreaded_python();
-        Python::with_gil(|_py| {
+        pyo3::Python::initialize();
+        Python::attach(|_py| {
             assert!(matches!(
                 parse_storage_mode("pq").expect("test: 'pq' is a valid storage mode"),
                 StorageMode::ProductQuantization
@@ -389,8 +389,8 @@ mod tests {
 
     #[test]
     fn test_parse_storage_mode_rabitq() {
-        pyo3::prepare_freethreaded_python();
-        Python::with_gil(|_py| {
+        pyo3::Python::initialize();
+        Python::attach(|_py| {
             assert!(matches!(
                 parse_storage_mode("rabitq").expect("test: 'rabitq' is a valid storage mode"),
                 StorageMode::RaBitQ
@@ -411,8 +411,8 @@ mod tests {
 
     #[test]
     fn test_parse_storage_mode_invalid() {
-        pyo3::prepare_freethreaded_python();
-        Python::with_gil(|_py| {
+        pyo3::Python::initialize();
+        Python::attach(|_py| {
             assert!(parse_storage_mode("invalid").is_err());
         });
     }

--- a/deny.toml
+++ b/deny.toml
@@ -33,21 +33,6 @@ ignore = [
     { id = "RUSTSEC-2025-0098", reason = "unic-ucd-version: tauri transitive, unmaintained" },
     { id = "RUSTSEC-2025-0100", reason = "unic-ucd-ident: tauri transitive, unmaintained" },
 
-    # ── velesdb-python (PyO3) ─────────────────────────────────────────
-    # OOB read in BoundListIterator/BoundTupleIterator nth/nth_back.
-    # velesdb-python never calls nth/nth_back on Python sequence iterators
-    # (verified by grep over crates/velesdb-python/src), so the vulnerable
-    # path is unreachable. The fix lands in pyo3 0.29, but the numpy crate
-    # (required for zero-copy NumPy views) caps at pyo3 0.28 today.
-    # Re-evaluate at every numpy release; drop this ignore once numpy
-    # supports pyo3 >= 0.29.
-    { id = "RUSTSEC-2026-0176", reason = "pyo3 nth/nth_back OOB: code path unreachable from velesdb-python; patched pyo3 0.29 blocked upstream by numpy (max 0.28)" },
-    # `PyCFunction::new_closure` required `Send` but not `Sync`; velesdb-python
-    # never constructs a closure-backed PyCFunction (no `new_closure` call —
-    # verified by grep over crates/), so the data-race path is unreachable.
-    # Same upgrade constraint as 0176: fix is pyo3 >= 0.29, blocked by numpy.
-    { id = "RUSTSEC-2026-0177", reason = "pyo3 new_closure missing Sync bound: velesdb-python never calls PyCFunction::new_closure (verified by grep over crates/), path unreachable; patched pyo3 0.29 blocked upstream by numpy (max 0.28)" },
-
     # ── velesdb-cli transitive ────────────────────────────────────────
     { id = "RUSTSEC-2024-0384", reason = "instant: velesdb-cli transitive (clap/indicatif chain), unmaintained" },
 


### PR DESCRIPTION
## Why

Dependabot flags PyO3 `< 0.29` with a **high-severity** out-of-bounds read
(`PyList::nth`/`nth_back`, RUSTSEC-2026-0176) plus a missing-`Sync` issue on
`new_closure` (RUSTSEC-2026-0177). Both were previously *ignored* in `deny.toml`
as unreachable, because the fix is in pyo3 `0.29` and **rust-numpy used to cap at
pyo3 0.28**. `numpy 0.29` now exists, so the upgrade is unblocked and the
advisories can be fixed at the **root** rather than ignored.

## What

- `pyo3` and `numpy` bumped `0.24 → 0.29` in lockstep (`pyo3-build-config` too).
- The two pyo3 `deny.toml` ignores are removed (`cargo deny check advisories` → `advisories ok`).

### Migration (compiler- and CHANGELOG-driven, behaviour-preserving)

| Change | 0.24 | 0.29 |
|---|---|---|
| GIL token | `Python::with_gil` | `Python::attach` |
| Release GIL | `py.allow_threads(..)` | `py.detach(..)` |
| Interpreter init (tests) | `pyo3::prepare_freethreaded_python()` | `Python::initialize()` |
| Object handle | `PyObject` *(deprecated, off prelude)* | `Py<PyAny>` |
| Downcast | `Bound::downcast` | `Bound::cast` |
| Owned-extract bound | `FromPyObject<'py>` | `FromPyObjectOwned<'py>` |
| Generic `extract()?` | direct | `.map_err(Into::into)?` (assoc. `Error` type) |
| `#[pyclass]` + `Clone` | implicit `FromPyObject` | explicit `from_py_object` opt-in |

Also factored the repeated `Option<Vec<Option<HashMap<String, Py<PyAny>>>>>`
NumPy payload type into a `type` alias (kept clippy `type_complexity` clean).

## Verification

- `cargo check --all-targets` and `cargo clippy --all-targets`: **0 errors, 0 warnings**.
- `cargo fmt --check`: clean.
- `cargo deny check advisories`: **advisories ok** (no pyo3 advisory, no ignore needed).
- `maturin develop`: builds the abi3-py39 extension and links successfully.
- `pytest tests/ -m "not slow"`: **377 passed, 23 skipped**.

No runtime behaviour change — purely an API migration to the patched pyo3 line.