### PR TITLE
fix(python): complete the .pyi stub surface + automatic class-parity guard

### DIFF
--- a/crates/velesdb-python/python/velesdb/__init__.pyi
+++ b/crates/velesdb-python/python/velesdb/__init__.pyi
@@ -1161,6 +1161,40 @@ class Database:
 
 
 # =============================================================================
+# VelesDB Errors
+# =============================================================================
+
+class VelesDBError(Exception):
+    """Base class for all VelesDB-specific exceptions."""
+    ...
+
+
+class DimensionMismatchError(VelesDBError):
+    """Raised when a vector's dimension does not match the collection."""
+    ...
+
+
+class CollectionNotFoundError(VelesDBError):
+    """Raised when the named collection does not exist."""
+    ...
+
+
+class CollectionExistsError(VelesDBError):
+    """Raised when creating a collection whose name already exists."""
+    ...
+
+
+class EdgeExistsError(VelesDBError):
+    """Raised when adding a graph edge whose ID already exists."""
+    ...
+
+
+class DatabaseLockedError(VelesDBError):
+    """Raised when the database is already locked by another handle or process."""
+    ...
+
+
+# =============================================================================
 # VelesQL Classes
 # =============================================================================
 
@@ -1194,6 +1228,11 @@ class ParsedStatement:
     def has_distinct(self) -> bool: ...
     def has_joins(self) -> bool: ...
     def has_fusion(self) -> bool: ...
+    def has_having(self) -> bool: ...
+    def is_ddl(self) -> bool: ...
+    def is_dml(self) -> bool: ...
+    def is_delete(self) -> bool: ...
+    def is_insert_edge(self) -> bool: ...
     @property
     def join_count(self) -> int: ...
 
@@ -1251,6 +1290,21 @@ class TraversalResult:
     edge_id: int
 
 
+class StreamingIngestConfig:
+    """Configuration for streaming ingestion (``Collection.enable_streaming``)."""
+
+    buffer_size: int
+    batch_size: int
+    flush_interval_ms: int
+
+    def __init__(
+        self,
+        buffer_size: int = 10000,
+        batch_size: int = 128,
+        flush_interval_ms: int = 50,
+    ) -> None: ...
+
+
 class GraphStore:
     """In-memory graph store for knowledge graph operations."""
 
@@ -1275,6 +1329,28 @@ class GraphStore:
     def traverse_bfs_streaming(
         self, start_node: int, config: StreamingConfig
     ) -> List[TraversalResult]: ...
+
+    def traverse_bfs(
+        self,
+        *,
+        source: int,
+        max_depth: int = 3,
+        limit: int = 10000,
+        relationship_types: Optional[List[str]] = None,
+    ) -> List[TraversalResult]:
+        """Run a BFS traversal from ``source`` (keyword-only arguments)."""
+        ...
+
+    def traverse_dfs(
+        self,
+        *,
+        source: int,
+        max_depth: int = 3,
+        limit: int = 10000,
+        relationship_types: Optional[List[str]] = None,
+    ) -> List[TraversalResult]:
+        """Run a DFS traversal from ``source`` (keyword-only arguments)."""
+        ...
 
     def remove_edge(self, edge_id: int) -> None: ...
     def edge_count(self) -> int: ...
@@ -1685,6 +1761,10 @@ class GraphCollection(PyGraphCollection):
 
     def __enter__(self) -> "GraphCollection":
         """Context manager entry — returns ``self``."""
+        ...
+
+    def close(self) -> None:
+        """Flush and release the underlying graph collection."""
         ...
 
 

--- a/crates/velesdb-python/tests/test_stub_parity.py
+++ b/crates/velesdb-python/tests/test_stub_parity.py
@@ -1,13 +1,24 @@
-"""Regression guard: the ``__init__.pyi`` type stub must declare the
-documented compatibility surface so typed callers (mypy/pyright) do not see
-false "attribute does not exist" errors for methods that exist at runtime.
+"""Regression guard: the ``__init__.pyi`` type stub must keep up with the
+runtime surface so typed callers (mypy/pyright) do not see false "attribute
+does not exist" errors for things that exist at runtime.
 
-This test parses the stub with :mod:`ast` only — it does not import the
-compiled extension, so it runs anywhere pytest collects it.
+Two complementary checks:
+
+* ``test_compatibility_stub_surface_matches_runtime`` is a *curated*, AST-only
+  check (no import needed) for the compatibility aliases and call shapes that
+  are easy to forget. Method coverage is curated on purpose: the facade classes
+  (``GraphStore``, ``GraphCollection``, ``Collection``) delegate via
+  ``__getattr__``, so an exhaustive ``dir()`` diff would be brittle — it cannot
+  see delegated members and would flag inherited ones.
+* ``test_every_exported_class_is_declared_in_stub`` imports the compiled module
+  and is *fully automatic*: every class in ``velesdb.__all__`` must have a stub
+  class, so a newly exported class can never silently miss the stub.
 """
 
 import ast
 from pathlib import Path
+
+import pytest
 
 
 STUB_PATH = Path(__file__).parents[1] / "python" / "velesdb" / "__init__.pyi"
@@ -37,9 +48,22 @@ def test_compatibility_stub_surface_matches_runtime() -> None:
     expected = {
         "FusionStrategy": {"rsf"},
         "Database": {"get_collections"},
-        "GraphStore": {"get_outgoing_edges", "get_incoming_edges", "has_edge"},
+        "GraphStore": {
+            "get_outgoing_edges",
+            "get_incoming_edges",
+            "has_edge",
+            "traverse_bfs",
+            "traverse_dfs",
+        },
         "PyGraphCollection": {"get_outgoing_edges", "get_incoming_edges", "upsert_node"},
-        "GraphCollection": {"add_node", "bfs", "dfs", "has_edge"},
+        "GraphCollection": {"add_node", "bfs", "dfs", "has_edge", "close"},
+        "ParsedStatement": {
+            "is_ddl",
+            "is_dml",
+            "is_delete",
+            "is_insert_edge",
+            "has_having",
+        },
         "AgentMemory": {"rollback"},
     }
 
@@ -60,3 +84,20 @@ def test_compatibility_stub_surface_matches_runtime() -> None:
         missing.append("FusionStrategy.weighted overloads")
 
     assert missing == [], f"type stub drifted from runtime: {missing}"
+
+
+def test_every_exported_class_is_declared_in_stub() -> None:
+    """Every class in ``velesdb.__all__`` must have a matching stub class.
+
+    This is the automatic half of the guard: it needs the compiled extension,
+    so it is skipped when the module is not built (e.g. a docs-only checkout).
+    """
+    import inspect
+
+    velesdb = pytest.importorskip("velesdb")
+    exported = getattr(velesdb, "__all__", None) or dir(velesdb)
+    exported_classes = {
+        name for name in exported if inspect.isclass(getattr(velesdb, name, None))
+    }
+    missing = sorted(exported_classes - set(_classes()))
+    assert missing == [], f"exported classes missing from the type stub: {missing}"


### PR DESCRIPTION
## Why

#1123 synced the obvious compatibility aliases into `__init__.pyi`, but its
guard was a hand-written allowlist. Introspecting the **compiled module**
against the stub revealed more genuine drift — classes and methods that exist
at runtime but were undeclared, so typed callers (mypy/pyright) still saw false
"attribute does not exist" / "unknown class" errors.

## What's added to the stub

| Kind | Symbols |
|---|---|
| Exception classes | `VelesDBError` (base) + `DimensionMismatchError`, `CollectionNotFoundError`, `CollectionExistsError`, `EdgeExistsError`, `DatabaseLockedError` — `VelesQLSyntaxError`/`VelesQLParameterError` were already stubbed, so this is a consistency gap |
| Config class | `StreamingIngestConfig` (`Collection.enable_streaming`) |
| Facade methods | `GraphStore.traverse_bfs` / `traverse_dfs`, `GraphCollection.close` |
| VelesQL inspectors | `ParsedStatement.is_ddl` / `is_dml` / `is_delete` / `is_insert_edge` / `has_having` |

Every signature was checked against its binding (`exceptions.rs`,
`streaming_config.rs`, `velesql.rs`) or the `__init__.py` facade.

## Stronger guard

`test_stub_parity.py` gains an **import-based** check that asserts every class
in `velesdb.__all__` is declared in the stub — fully automatic, so a newly
exported class can never silently miss the stub again (verified: removing any
class from the stub makes it fail). It `importorskip`s the extension so a
docs-only checkout still collects.

Method-level coverage stays a *curated* AST check on purpose: the facade
classes (`GraphStore`, `GraphCollection`, `Collection`) delegate via
`__getattr__`, so an exhaustive `dir()` diff would be brittle — it cannot see
delegated members and would flag inherited ones.

## Verification

- `__init__.pyi` parses; both guard tests pass against the built extension.
- Pure-stub change — no runtime code touched.