### PR TITLE
feat: core↔ecosystem parity & architecture remediation

### DIFF
--- a/.claude/skills/core-parity-audit/SKILL.md
+++ b/.claude/skills/core-parity-audit/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: core-parity-audit
+description: "Re-run the VelesDB core-vs-ecosystem gap analysis (code + documentation). Use when asked to audit API parity, check that every crate/SDK/integration/doc has caught up to velesdb-core, verify the core↔children architecture is clean, or produce a parity matrix. velesdb-core is the single source of truth; the VelesDB Core License boundary is enforced in every recommendation."
+trigger: /core-parity-audit
+---
+
+# /core-parity-audit
+
+Audit whether every component that depends on `velesdb-core` has kept up with it — in **code and documentation** — and whether the **core↔children architecture is clean**. Produces two artifacts: a capability-level **parity matrix** and an **architecture-cleanliness verdict**.
+
+## Two non-negotiable rules
+
+1. **`velesdb-core` is the single source of truth — always.** Children (server, cli, python, wasm, mobile, migrate, tauri, ts-sdk, langchain, llamaindex, haystack, integrations/common, docs) may legitimately expose **more** surface than core (idiomatic helpers, ops endpoints, framework adapters) — that is healthy enrichment, **not** a parity defect. Judge two things *separately*: (a) does the child enrich core? (good) vs (b) is the boundary clean? (the real question).
+
+2. **Respect the VelesDB Core License boundary.** See [references/license-boundary.md](references/license-boundary.md). In short:
+   - `velesdb-core`, all Rust crates, and the TS SDK are under **VelesDB Core License 1.0** (source-available, Elastic-2.0-based). Its *protected capabilities* are query, administration, indexing, ingestion, storage, graph traversal, knowledge-graph, and columnar filtering.
+   - `integrations/{langchain,llamaindex,haystack,common}` are **MIT**.
+   - **A reimplementation or copy of core's protected logic inside an MIT integration is BOTH an architecture smell AND a license-leakage risk.** Flag it at higher severity. The only valid remediation is **"expose it via the binding and have the MIT layer *call* it"** — never "copy core logic into the integration," never relicense Core code as MIT or vice-versa.
+   - Never recommend stripping `VelesDB®` notices or paid-feature gating. Follow the project **no-AI-attribution** rule in any report/PR/commit you generate.
+
+## Usage
+
+```
+/core-parity-audit                 # full audit: parity matrix + architecture verdict
+/core-parity-audit --matrix-only   # capability parity matrix only (skip architecture probes)
+/core-parity-audit --arch-only     # architecture-cleanliness verdict only (skip the matrix)
+/core-parity-audit --component <k> # focus on one component (e.g. wasm, langchain)
+```
+
+This audit is read-only. It does not modify source; it writes report artifacts to a scratch dir (default `/tmp`) and summarizes in chat. Use the [Workflow tool](#orchestration) — this is a fan-out, multi-agent job (ultracode-class).
+
+## Components that depend on velesdb-core (the work-list)
+
+Re-derive this from the workspace each run (`Cargo.toml` members + `sdks/` + `integrations/` + `docs/`), but the stable set is:
+
+| key | path | wraps core via | license |
+|-----|------|----------------|---------|
+| server | `crates/velesdb-server` | direct (Axum REST) | Core 1.0 |
+| cli | `crates/velesdb-cli` | direct (embedded REPL) | Core 1.0 |
+| python | `crates/velesdb-python` | direct (PyO3 + `.pyi` stub) | Core 1.0 |
+| wasm | `crates/velesdb-wasm` | direct, **no `persistence` feature** | Core 1.0 |
+| mobile | `crates/velesdb-mobile` | direct (UniFFI) | Core 1.0 |
+| migrate | `crates/velesdb-migrate` | direct (ETL tool) | Core 1.0 |
+| tauri | `crates/tauri-plugin-velesdb` | direct (commands) | Core 1.0 |
+| ts-sdk | `sdks/typescript` | REST + WASM backends | Core 1.0 |
+| langchain | `integrations/langchain` | velesdb python binding + common | **MIT** |
+| llamaindex | `integrations/llamaindex` | velesdb python binding + common | **MIT** |
+| haystack | `integrations/haystack` | velesdb python binding | **MIT** |
+| common | `integrations/common` | shared base for the 3 integrations | **MIT** |
+| docs | `docs/` + `README.md` | documents the public surface | Core 1.0 |
+
+Per-component inspection hints live in [references/component-inventory.md](references/component-inventory.md).
+
+## Methodology (6 phases)
+
+Author the Workflow scripts fresh each run (the codebase evolves; do **not** hard-code last run's capability list — re-extract it). The pattern that worked:
+
+### Phase 0 — Discover (inline)
+Map the work-list: `Cargo.toml` members, `sdks/`, `integrations/`, `docs/`. Capture `velesdb-core`'s public re-exports from `crates/velesdb-core/src/lib.rs` and the public methods of `Database`, `VectorCollection`, `GraphCollection`, `MetadataCollection`, `AnyCollection`, and the `agent::` module. These seed Phase 1.
+
+### Phase 1 — Build the canonical core catalog (barrier)
+Fan out ~3 agents by domain (management/config/enums · data plane · query/graph/memory) to extract `velesdb-core`'s **public capabilities** — grouped, not every micro-method (e.g. all `search_with_*` = one "filtered search"). Each capability = `{id (domain-prefixed), group, name, core_symbols[], signature, notes}`. Merge + dedupe by id → **one canonical catalog**. This is the source-of-truth column. (Last run: ~81 capabilities across 20 domains; expect drift.)
+
+### Phase 2 — Map each component (pipeline, one agent per component)
+Inject the **same** catalog into every component agent. Each rates **every** capability `full | partial | absent | na` with `file:symbol`/endpoint/doc-section evidence, and lists `extra_surface` (capabilities the child exposes that are NOT in core — the enrichment). For `docs`: `full` = documented with usage, `absent` = undocumented public capability (a doc gap).
+
+### Phase 3 — Adversarially verify gaps (pipeline stage 2)
+Hand each component's `absent`/`partial` rows to a **skeptic** agent that tries to **refute** them — grep harder (helpers, aliases, `.pyi` stubs, base classes in `integrations/common`, parent protocols). The parity campaign closed many gaps; naïve greps re-report them. Reconcile mapper status with verifier overturns. (Last run the verifier correctly overturned Python `collection_diagnostics`/`update_guardrails`/`create_index`/`reorder_for_locality` — they *are* exposed.)
+
+### Phase 4 — Architecture-cleanliness audit (barrier)
+This answers the real question. Fan out:
+- **1 dependency-direction agent**: `velesdb-core/Cargo.toml` must list **no** child; every child depends on core; no cycles. Any inversion = `concern`.
+- **1 boundary agent per child**: does it *delegate* canonical logic to core or *reimplement* it? Is the reimplementation justified (WASM has no `persistence` feature → reimplements storage + a VelesQL executor) or a divergence smell? Are contracts (enums, wire codec, `VELES-###` error codes) sourced from core or re-derived (drift risk)? Is the extra surface composed from core primitives or does it bypass core to touch internals?
+- **4 cross-cutting divergence probes**: (1) **fusion math** single-sourced vs reimplemented (core `fusion/` vs `velesdb_common.fusion` vs `wasm/fusion.rs` vs ts-sdk); (2) **string→u64 ID hashing** consistency (`velesdb_common.ids.stable_hash_id` vs haystack `_str_id_to_int` vs mobile vs migrate `stable_point_id` — different algorithms = interop divergence); (3) **VelesQL parser/executor sync** (WASM reimplements the executor; ECOSYSTEM_PARITY notes WASM conformance is **parser-only** — executor behaviour is NOT fixture-checked); (4) **distance + quantization kernel fidelity** (WASM/mobile recompute distance/quant — same results as core? recall@10 ≥ 0.95 fidelity?).
+
+Each finding: `severity info|smell|concern`, `divergence_risk` bool, `file:line` evidence. **License lens:** a divergence/duplication in an MIT integration that copies core's *protected* logic is escalated.
+
+### Phase 5 — Verify concerns + synthesize
+Adversarially re-check every `concern` (and `smell` with `divergence_risk`) — many "concerns" are justified design (feature-gating, pure-client wire-building, idiomatic enrichment). Then synthesize:
+- **Parity matrix** — run `scripts/gen_matrix.py` over the Phase 2/3 JSON results → cell-level markdown matrix + per-component scorecard + gap buckets (user-facing vs core-internal/ops). Exclude core-internal domains (observability counters, durability/WAL tuning, registry generations, column-store kernels) from the "should expose" denominator — they were never meant to cross the binding boundary.
+- **Architecture verdict** — per-child cleanliness + the 4 probe verdicts + the dependency-direction result, each concern with its verification status and a **license-aware** remediation.
+
+### Orchestration
+Drive Phases 1–5 with the **Workflow tool** (`parallel` for the catalog barrier and the architecture fan-out; `pipeline` for component map→verify). Save each workflow's structured result, feed Phase-2/3 JSON to `scripts/gen_matrix.py`. If agents get rate-limited (it happens at ~25+ concurrent), re-run only the failed components in a small follow-up workflow reusing the existing catalog — do **not** resume-cache the failed nulls.
+
+## Outputs
+
+1. `PARITY_MATRIX.md` — capability × component matrix (`✅ full · ⚠️ partial · ❌ absent · · n/a`), scorecard, gap buckets.
+2. Architecture verdict (in chat + optional `ARCHITECTURE_VERDICT.md`): is `velesdb-core` the uncontested source of truth? Is the boundary clean? Concerns ranked, each with license-aware remediation.
+3. Reconcile against `docs/reference/ECOSYSTEM_PARITY.md` "Remaining Gaps" — flag anything genuinely new vs already-documented-by-design.
+
+## Interpreting results
+
+- `partial`/`na` are usually **by design** (WASM no-persistence, Haystack DocumentStore protocol bounds, agent-memory not over REST, CLI has no memory surface). Don't report these as "not caught up."
+- The actionable signal is **`absent` in a user-facing domain** that is **not** already documented as by-design, **plus** any architecture `concern` confirmed in Phase 5.
+- Enrichment (`extra_surface`) is the headline good news — list it, don't penalize it.

--- a/.claude/skills/core-parity-audit/references/component-inventory.md
+++ b/.claude/skills/core-parity-audit/references/component-inventory.md
@@ -1,0 +1,25 @@
+# Component inspection hints
+
+How each child exposes (or should expose) core's surface, and what counts as `full | partial | absent | na`. Re-verify paths each run — modules move.
+
+## Rust crates (delegate to `velesdb_core::` directly)
+
+- **server** (`crates/velesdb-server`): HTTP adapters in `src/routes.rs`, `src/handlers/`, `src/types.rs`. `full` = a REST endpoint exposes it. `na` = pure Rust accessor with no REST meaning. Enrichment seen: `/health`, `/ready`, `/metrics` (Prometheus), `/vacuum`, `/compact`, SSE traversal stream, bearer-auth/TLS/rate-limit.
+- **cli** (`crates/velesdb-cli`): `src/repl_*_cmds.rs`, `src/commands.rs`, `src/handlers/`, `src/import.rs`, `src/repl_execute.rs`. Embedded core → VelesQL paths broadly reachable. **Agent memory has no CLI surface by design → `na`, not `absent`** (don't let the mapper over-report).
+- **python** (`crates/velesdb-python`): `#[pymethods]`/`#[pyfunction]` in `src/*.rs` **and** `python/velesdb/__init__.pyi`. `full` only if in **both** binding and stub. Enrichment: NumPy/DataFrame fast paths, `train_pq`, embedders.
+- **wasm** (`crates/velesdb-wasm`): `#[wasm_bindgen]` exports. Built **without `persistence`** → persistence/WAL/HNSW/streaming are `na` by design; it reimplements an in-memory store + VelesQL executor (`velesql_exec*.rs`) + brute-force search. Enrichment: IndexedDB persistence, Web-Worker traversal offload.
+- **mobile** (`crates/velesdb-mobile`): `#[uniffi::export]`. `full` = exported to Swift/Kotlin. Semantic-only agent memory by design. Enrichment: `MobileGraphStore`, `compact_storage`, `train_pq`.
+- **migrate** (`crates/velesdb-migrate`): ETL tool — most data/query rows are legitimately `na`. Focus on whether it writes through core APIs (`upsert_bulk`) and provisions indexes/analyze post-load. Enrichment: 10 source connectors, resumable checkpoints, retry/backoff.
+- **tauri** (`crates/tauri-plugin-velesdb`): `#[tauri::command]` handlers. Enrichment: event stream, `get_app_data_dir`, persisted memory snapshots.
+
+## Clients / integrations
+
+- **ts-sdk** (`sdks/typescript`): `src/client.ts`, `src/client/`, `src/backends/`, `src/agent-memory.ts`, `src/query-builder.ts`, `src/types.ts`, `src/capabilities.ts`. **Pure client** — `full` = it builds the right wire payload / parses the response. The query-builder/filter DSL compiling to wire is clean. `concern` if it computes *results* (ranking/fusion/distance) itself, or hardcodes enum/`VELES-###` contracts that can drift.
+- **langchain** (`integrations/langchain`): `src/langchain_velesdb/*.py`. **MIT** — must reuse `integrations/common`, call the `velesdb` binding, never embed protected logic. Enrichment: MMR, graph-toolkit (LLM extraction), retrievers.
+- **llamaindex** (`integrations/llamaindex`): `src/llamaindex_velesdb/*.py`. Same MIT rule. Enrichment: score-threshold query, graph retrievers.
+- **haystack** (`integrations/haystack`): `src/haystack_velesdb/document_store.py`. Bounded by Haystack 2.x `DocumentStore` protocol (`write_documents`/`filter_documents`/`embedding_retrieval`/`count`/`delete`). Graph/agent-memory/sparse-named are `na` by protocol. **Watch:** its own `_str_id_to_int` may diverge from `velesdb_common.ids.stable_hash_id`.
+- **common** (`integrations/common`): `src/velesdb_common/*.py` — the shared MIT base (`ids`, `fusion`, `graph`, `security`, `collection_admin`). Verify the 3 integrations actually reuse it instead of re-deriving id-hashing/fusion/security per-package.
+
+## Docs
+
+`docs/reference/api-reference.md`, `VELESQL_CONTRACT.md`, `VELESQL_CHEATSHEET.md`, `ECOSYSTEM_PARITY.md`, `docs/guides/`, `README.md`. `full` = capability documented with usage; `partial` = mentioned but thin; `absent` = undocumented public capability (a doc gap); `na` = purely internal symbol. Reconcile findings against the `ECOSYSTEM_PARITY.md` "Remaining Gaps" list.

--- a/.claude/skills/core-parity-audit/references/license-boundary.md
+++ b/.claude/skills/core-parity-audit/references/license-boundary.md
@@ -1,0 +1,41 @@
+# License boundary — what the parity audit must enforce
+
+`velesdb-core` is the **single source of truth** *and* a **licensed asset**. The gap analysis must reason about both at once.
+
+## The two licenses in this repo
+
+| Surface | License | Notes |
+|---------|---------|-------|
+| `velesdb-core` (source of truth) | **VelesDB Core License 1.0** | Source-available, based on Elastic License 2.0 (ELv2). `Copyright (c) 2024-2026 Wiscale France`. `VelesDB®` is a registered trademark. |
+| `crates/velesdb-{server,cli,python,wasm,mobile,migrate}`, `tauri-plugin-velesdb` | **VelesDB Core License 1.0** | `license-file = LICENSE` (root or `../../LICENSE`). |
+| `sdks/typescript` | **VelesDB Core License 1.0** | `"license": "SEE LICENSE IN LICENSE"`. |
+| `integrations/{langchain,llamaindex,haystack,common}` | **MIT** | `pyproject.toml license = MIT`. |
+| `docs/`, `README.md` | repo (Core License 1.0) | |
+
+## What the Core License protects (verbatim concepts)
+
+The license names these as the Software's capabilities that may not be re-offered or competitively reimplemented: **query, administration, indexing, ingestion, storage, graph traversal, knowledge-graph, columnar filtering, management** — i.e. exactly the canonical logic in `velesdb-core`.
+
+Key limitations the audit should be aware of:
+1. **No Hosted/Managed Service** — exposing core's capabilities to third parties as a service needs a commercial license.
+2. **No Competitive Offering** — may not build a competing database/vector-db/graph-db/search/query engine from it.
+3. **No Circumvention of Paid Features** — do not disable/remove licensing-gated functionality.
+4. **No Removal of Notices/Trademarks** — keep `VelesDB®` and copyright notices intact.
+
+Internal use, and integrating VelesDB as a **backend component** of your own product (end users get only results, not core DB access), are explicitly allowed.
+
+## Why this matters for gap-closing recommendations
+
+The MIT integrations (`langchain`, `llamaindex`, `haystack`, `common`) wrap the **Core-Licensed** Python binding. That is the *intended* shape: an MIT thin layer that **calls** the licensed engine. It stays clean — and license-compliant — only as long as the MIT layer does **not embed or copy** core's protected logic.
+
+Therefore the audit's remediation rules are:
+
+- ✅ **Valid:** "Capability X is missing in the MIT integration → expose X on the `velesdb` binding (Core License) and have the integration **call** it." The protected logic stays in core; the MIT layer only orchestrates.
+- ❌ **Invalid (never recommend):** "Copy core's fusion math / distance kernel / VelesQL execution / id-hashing into the MIT integration." That both forks the source of truth (architecture violation) **and** risks relicensing protected logic as MIT (license violation).
+- ❌ **Invalid:** relicensing Core-License code as MIT, or pulling MIT code into core in a way that muddies the Core License.
+- ⚠️ **Escalate:** any Phase-4 `duplication`/`reimplementation`/`fidelity` finding located in an **MIT** package that touches a protected capability — it is simultaneously an architecture smell and a potential license leak. Rank it above the same finding in a Core-Licensed crate.
+
+## Reporting hygiene
+
+- Reports, PRs, commits, and issues you generate must follow the project **no-AI-attribution** rule (no `Co-Authored-By`, no AI/tool credit) and must not strip or alter `VelesDB®`/copyright notices.
+- The audit artifacts themselves are internal use — fine to produce and share within the org.

--- a/.claude/skills/core-parity-audit/scripts/gen_matrix.py
+++ b/.claude/skills/core-parity-audit/scripts/gen_matrix.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Render the core-parity matrix from one or more workflow result JSON files.
+
+Each input JSON is the structured result of the map→verify workflow(s):
+    { "catalog": [ {id, group, name, core_symbols, ...}, ... ],   # at least one input carries it
+      "components": [ {key, label, rows:[{capability_id,status,evidence,notes}], extra_surface, ...}, ... ] }
+
+Usage:
+    gen_matrix.py OUT.md RESULT1.json [RESULT2.json ...]
+
+Status glyphs: full=✅  partial=⚠️  absent=❌  na=·
+The skill (core-parity-audit) explains how the result JSONs are produced.
+"""
+import json
+import sys
+from collections import Counter
+
+GLYPH = {"full": "✅", "partial": "⚠️", "absent": "❌", "na": "·"}
+
+# canonical column order + display labels (extend if new components appear)
+ORDER = ["server", "cli", "python", "wasm", "mobile", "migrate", "tauri",
+         "ts-sdk", "langchain", "llamaindex", "haystack", "common", "docs"]
+LABELS = {"server": "Server", "cli": "CLI", "python": "Python", "wasm": "WASM",
+          "mobile": "Mobile", "migrate": "Migrate", "tauri": "Tauri", "ts-sdk": "TS SDK",
+          "langchain": "LangChain", "llamaindex": "LlamaIndex", "haystack": "Haystack",
+          "common": "int/common", "docs": "Docs"}
+
+# Core-internal / ops domains: never expected to cross the binding boundary, so
+# they are excluded from the "user-facing coverage" denominator.
+INTERNAL_GROUPS = {"Observability", "Config surface", "Persistence",
+                   "Validation & guardrails", "Database lifecycle",
+                   "Query planning / introspection", "Indexes"}
+
+
+def load_inputs(paths):
+    catalog, by_key = [], {}
+    seen_caps = set()
+    for p in paths:
+        doc = json.load(open(p))
+        doc = doc.get("result", doc)
+        if isinstance(doc, str):
+            doc = json.loads(doc)
+        for cap in doc.get("catalog", []) or []:
+            if cap.get("id") and cap["id"] not in seen_caps:
+                seen_caps.add(cap["id"])
+                catalog.append(cap)
+        for comp in doc.get("components", []) or []:
+            by_key[comp["key"]] = comp  # later file wins on dup key
+    return catalog, by_key
+
+
+def status_of(comp, cid):
+    for row in comp.get("rows", []):
+        if row["capability_id"] == cid:
+            return row["status"]
+    return "na"
+
+
+def main():
+    if len(sys.argv) < 3:
+        sys.exit("usage: gen_matrix.py OUT.md RESULT1.json [RESULT2.json ...]")
+    out_path, inputs = sys.argv[1], sys.argv[2:]
+    catalog, by_key = load_inputs(inputs)
+    cat = {c["id"]: c for c in catalog}
+    present = [k for k in ORDER if k in by_key] + [k for k in by_key if k not in ORDER]
+
+    groups = []
+    for c in catalog:
+        if c["group"] not in groups:
+            groups.append(c["group"])
+
+    out = []
+    out.append("# VelesDB Core → Ecosystem Public-API Parity Matrix\n")
+    out.append(f"**Source of truth:** `velesdb-core` — **{len(catalog)} capabilities** across {len(groups)} domains, "
+               f"× {len(present)} components. Every gap adversarially re-verified.\n")
+    out.append("Legend: ✅ full · ⚠️ partial / reduced · ❌ absent (plausible gap) · · N/A by design\n")
+
+    hdr = "| Capability | " + " | ".join(LABELS.get(k, k) for k in present) + " |"
+    sep = "|" + "---|" * (len(present) + 1)
+    for g in groups:
+        out.append(f"\n### {g}\n")
+        out.append(hdr)
+        out.append(sep)
+        for c in catalog:
+            if c["group"] != g:
+                continue
+            cells = [GLYPH.get(status_of(by_key[k], c["id"]), "?") for k in present]
+            out.append(f"| {c['name']} | " + " | ".join(cells) + " |")
+
+    out.append("\n## Coverage scorecard (per component)\n")
+    out.append("| Component | full | partial | absent | n/a | user-facing coverage* |")
+    out.append("|---|---|---|---|---|---|")
+    for k in present:
+        comp = by_key[k]
+        st = Counter(r["status"] for r in comp.get("rows", []))
+        uf_full = uf_part = uf_abs = 0
+        for r in comp.get("rows", []):
+            grp = cat.get(r["capability_id"], {}).get("group", "")
+            if grp and grp not in INTERNAL_GROUPS:
+                uf_full += r["status"] == "full"
+                uf_part += r["status"] == "partial"
+                uf_abs += r["status"] == "absent"
+        denom = uf_full + uf_part + uf_abs
+        cov = f"{round(100 * (uf_full + 0.5 * uf_part) / denom)}%" if denom else "n/a"
+        out.append(f"| {LABELS.get(k, k)} | {st.get('full', 0)} | {st.get('partial', 0)} | "
+                   f"{st.get('absent', 0)} | {st.get('na', 0)} | {cov} |")
+    out.append("\n*User-facing coverage = (full + ½·partial) / (full+partial+absent) over user-facing domains "
+               "(excludes core-internal observability/config/durability/registry plumbing).\n")
+
+    open(out_path, "w").write("\n".join(out))
+
+    # gap buckets to stderr (so chat synthesis can read them)
+    uf, internal = [], []
+    for k in present:
+        for r in by_key[k].get("rows", []):
+            if r["status"] != "absent":
+                continue
+            grp = cat.get(r["capability_id"], {}).get("group", "")
+            (internal if grp in INTERNAL_GROUPS else uf).append((k, r["capability_id"]))
+    print(f"wrote {out_path}: {len(catalog)} caps × {len(present)} components", file=sys.stderr)
+    print(f"absent — user-facing: {len(uf)}  core-internal/ops: {len(internal)}", file=sys.stderr)
+    print("\nuser-facing absent by capability (missing in →):", file=sys.stderr)
+    for cid, _ in Counter(c for _, c in uf).most_common():
+        comps = [k for k, cc in uf if cc == cid]
+        print(f"  {cid:38} {', '.join(comps)}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -575,6 +575,15 @@ jobs:
       - name: WASM parser conformance
         run: cargo test -p velesdb-wasm --test velesql_parser_conformance
 
+      - name: Core executor conformance
+        run: cargo test -p velesdb-core --features persistence --test velesql_executor_conformance
+
+      - name: CLI executor conformance
+        run: cargo test -p velesdb-cli --test velesql_executor_conformance
+
+      - name: WASM executor conformance
+        run: cargo test -p velesdb-wasm velesql_executor_conformance
+
       - name: Server REST conformance
         run: cargo test -p velesdb-server --test velesql_conformance_tests
 

--- a/.gitignore
+++ b/.gitignore
@@ -151,7 +151,9 @@ todo_analysis_report_updated.md
 #Ignore windsurf AI rules
 .windsurfrules
 
-.claude/
+.claude/*
+# keep the shared project skill tracked (the rest of .claude/ stays local)
+!.claude/skills/
 .codacy/flamegraph.svg
 .kiro/
 

--- a/conformance/velesql_executor_cases.json
+++ b/conformance/velesql_executor_cases.json
@@ -1,0 +1,56 @@
+{
+  "version": "1.0.0",
+  "description": "Executor-level VelesQL conformance: asserts result ROWS / COUNTS / ORDERING, not just that a query parses. Golden ids are derived from velesdb-core (the source of truth); other executors (WASM, CLI) must reproduce the same result set for the same dataset+query. Shared read-only dataset; ordering is on unique payload fields so results are deterministic. `cases` must pass; `known_bugs` carry the CORRECT expectation for a confirmed core bug and are checked only by the #[ignore]d reproducer test until fixed.",
+  "dataset": {
+    "collection": "docs",
+    "dimension": 4,
+    "metric": "cosine",
+    "points": [
+      { "id": 1, "vector": [1.0, 0.0, 0.0, 0.0], "payload": { "category": "tech", "year": 2020 } },
+      { "id": 2, "vector": [0.0, 1.0, 0.0, 0.0], "payload": { "category": "tech", "year": 2022 } },
+      { "id": 3, "vector": [0.0, 0.0, 1.0, 0.0], "payload": { "category": "other", "year": 2021 } },
+      { "id": 4, "vector": [0.0, 0.0, 0.0, 1.0], "payload": { "category": "tech", "year": 2023 } },
+      { "id": 5, "vector": [0.5, 0.5, 0.0, 0.0], "payload": { "category": "other", "year": 2019 } }
+    ]
+  },
+  "cases": [
+    {
+      "id": "X001",
+      "query": "SELECT * FROM docs WHERE category = 'tech' ORDER BY year ASC",
+      "expect_ids": [1, 2, 4],
+      "note": "string equality filter + ORDER BY column ASC"
+    },
+    {
+      "id": "X002",
+      "query": "SELECT * FROM docs WHERE year >= 2021 ORDER BY year ASC",
+      "expect_ids": [3, 2, 4],
+      "note": "integer range filter + ordering"
+    },
+    {
+      "id": "X003",
+      "query": "SELECT * FROM docs ORDER BY year DESC",
+      "expect_ids": [4, 2, 3, 1, 5],
+      "note": "full scan + ORDER BY column DESC (no LIMIT)"
+    },
+    {
+      "id": "X004",
+      "query": "SELECT * FROM docs WHERE category = 'tech' AND year >= 2022 ORDER BY year ASC",
+      "expect_ids": [2, 4],
+      "note": "conjunctive (AND) filter"
+    },
+    {
+      "id": "X005",
+      "query": "SELECT * FROM docs WHERE category = 'other' ORDER BY year ASC",
+      "expect_ids": [5, 3],
+      "note": "filter selecting the complementary partition"
+    }
+  ],
+  "known_bugs": [
+    {
+      "id": "B001",
+      "query": "SELECT * FROM docs WHERE year >= 2019 ORDER BY year DESC LIMIT 2",
+      "expect_ids": [4, 2],
+      "note": "BUG: scalar ORDER BY <column> + LIMIT applies the LIMIT before the sort on the bounded top-k path (observed [2,1] = first two by id, then sorted). This contradicts KNOWN_LIMITATIONS.md #9 ('Results are identical to the unbounded path'). The bounded top-k optimization only honors similarity() ordering, not scalar ORDER BY. expect_ids holds the CORRECT result; un-ignore test_velesql_executor_known_bugs once fixed."
+    }
+  ]
+}

--- a/crates/velesdb-cli/tests/velesql_executor_conformance.rs
+++ b/crates/velesdb-cli/tests/velesql_executor_conformance.rs
@@ -1,0 +1,184 @@
+#![allow(clippy::doc_markdown)]
+//! Executor-level VelesQL conformance for the CLI executor.
+//!
+//! Companion to `velesdb-core/tests/velesql_executor_conformance.rs`. Loads the
+//! SAME golden fixture (`conformance/velesql_executor_cases.json`), builds the
+//! dataset **through the real `velesdb` binary** (`collection create` +
+//! `data upsert`), runs each case query through the binary
+//! (`query execute ... --format json`), and asserts the result ids and ordering
+//! match the golden `expect_ids` derived from `velesdb-core`.
+//!
+//! The CLI has no library target, so — like `velesql_parser_conformance.rs` —
+//! this integration test cannot call CLI internals directly. It instead drives
+//! the compiled binary end-to-end with `assert_cmd`, which exercises the true
+//! CLI execution path (`repl::execute_query` → `Database::execute_query` →
+//! JSON output via `repl::print_result`).
+//!
+//! # Case coverage
+//!
+//! All five `cases` (X001–X005) are runnable by the CLI executor and asserted
+//! against the golden ids.
+//!
+//! # known_bugs (B001)
+//!
+//! The CLI delegates SELECT execution to `velesdb-core::Database::execute_query`,
+//! so it reproduces the core B001 bug verbatim (`ORDER BY <column> + LIMIT`
+//! applies the LIMIT before the sort on the bounded top-k path — observed
+//! `[2, 1]` instead of the correct `[4, 2]`). The B001 reproducer is therefore
+//! `#[ignore]`d here, mirroring `test_velesql_executor_known_bugs` in core; the
+//! fixture's `expect_ids` carries the CORRECT result so the test can be
+//! un-ignored to lock the fix once core is patched.
+
+use std::path::{Path, PathBuf};
+
+use assert_cmd::Command;
+use serde::Deserialize;
+use serde_json::Value;
+use tempfile::TempDir;
+
+#[derive(Debug, Deserialize)]
+struct Fixture {
+    dataset: Dataset,
+    cases: Vec<Case>,
+    #[serde(default)]
+    known_bugs: Vec<Case>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Dataset {
+    collection: String,
+    dimension: usize,
+    metric: String,
+    points: Vec<FixturePoint>,
+}
+
+#[derive(Debug, Deserialize)]
+struct FixturePoint {
+    id: u64,
+    vector: Vec<f32>,
+    payload: Value,
+}
+
+#[derive(Debug, Deserialize)]
+struct Case {
+    id: String,
+    query: String,
+    expect_ids: Vec<u64>,
+}
+
+fn fixture_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../conformance/velesql_executor_cases.json")
+}
+
+fn load_fixture() -> Fixture {
+    let content = std::fs::read_to_string(fixture_path()).expect("read executor fixture");
+    serde_json::from_str(&content).expect("parse executor fixture")
+}
+
+fn velesdb_cmd() -> Command {
+    Command::cargo_bin("velesdb").expect("locate velesdb binary")
+}
+
+/// Builds the dataset on disk through the real CLI binary: one
+/// `collection create` then one `data upsert` per fixture point.
+fn build_dataset(db_path: &Path, ds: &Dataset) {
+    velesdb_cmd()
+        .args([
+            "collection",
+            "create",
+            &db_path.to_string_lossy(),
+            &ds.collection,
+            "--dimension",
+            &ds.dimension.to_string(),
+            "--metric",
+            &ds.metric,
+        ])
+        .assert()
+        .success();
+
+    for point in &ds.points {
+        let vector_json = serde_json::to_string(&point.vector).expect("serialize fixture vector");
+        let payload_json =
+            serde_json::to_string(&point.payload).expect("serialize fixture payload");
+        velesdb_cmd()
+            .args([
+                "data",
+                "upsert",
+                &db_path.to_string_lossy(),
+                &ds.collection,
+                "--id",
+                &point.id.to_string(),
+                "--vector",
+                &vector_json,
+                "--payload",
+                &payload_json,
+            ])
+            .assert()
+            .success();
+    }
+}
+
+/// Runs a case query through the CLI and returns the result ids in order.
+fn run_case_ids(db_path: &Path, query: &str) -> Vec<u64> {
+    let output = velesdb_cmd()
+        .args([
+            "query",
+            "execute",
+            &db_path.to_string_lossy(),
+            query,
+            "--format",
+            "json",
+        ])
+        .output()
+        .expect("run query");
+    assert!(
+        output.status.success(),
+        "query failed: {query}\nstderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).expect("utf8 stdout");
+    let rows: Vec<Value> = serde_json::from_str(stdout.trim())
+        .unwrap_or_else(|e| panic!("parse JSON rows for query {query:?}: {e}\nstdout: {stdout}"));
+    rows.iter()
+        .map(|row| {
+            row.get("id")
+                .and_then(Value::as_u64)
+                .unwrap_or_else(|| panic!("row missing numeric id: {row}"))
+        })
+        .collect()
+}
+
+fn assert_cases(db_path: &Path, cases: &[Case]) {
+    for case in cases {
+        let ids = run_case_ids(db_path, &case.query);
+        assert_eq!(
+            ids, case.expect_ids,
+            "CLI executor conformance mismatch for case {}: query={:?}",
+            case.id, case.query
+        );
+    }
+}
+
+/// All golden `cases` (X001–X005) must reproduce the core result set exactly
+/// when run through the CLI binary.
+#[test]
+fn test_cli_velesql_executor_conformance_fixture_cases() {
+    let fixture = load_fixture();
+    let dir = TempDir::new().expect("tempdir");
+    let db_path = dir.path().join("conf_db");
+    build_dataset(&db_path, &fixture.dataset);
+    assert_cases(&db_path, &fixture.cases);
+}
+
+/// Reproducer for the core B001 bug as seen through the CLI (which delegates to
+/// `Database::execute_query`). Ignored so CI stays green; un-ignore once the
+/// core bounded-top-k LIMIT-before-sort bug is fixed.
+#[test]
+#[ignore = "B001: CLI delegates to core; scalar ORDER BY + LIMIT applies LIMIT before sort (bounded top-k)"]
+fn test_cli_velesql_executor_known_bugs() {
+    let fixture = load_fixture();
+    let dir = TempDir::new().expect("tempdir");
+    let db_path = dir.path().join("conf_db");
+    build_dataset(&db_path, &fixture.dataset);
+    assert_cases(&db_path, &fixture.known_bugs);
+}

--- a/crates/velesdb-cli/tests/velesql_executor_conformance.rs
+++ b/crates/velesdb-cli/tests/velesql_executor_conformance.rs
@@ -170,11 +170,9 @@ fn test_cli_velesql_executor_conformance_fixture_cases() {
     assert_cases(&db_path, &fixture.cases);
 }
 
-/// Reproducer for the core B001 bug as seen through the CLI (which delegates to
-/// `Database::execute_query`). Ignored so CI stays green; un-ignore once the
-/// core bounded-top-k LIMIT-before-sort bug is fixed.
+/// Regression lock for B001 through the CLI (which delegates to
+/// `Database::execute_query`): formerly LIMIT-before-sort, now fixed.
 #[test]
-#[ignore = "B001: CLI delegates to core; scalar ORDER BY + LIMIT applies LIMIT before sort (bounded top-k)"]
 fn test_cli_velesql_executor_known_bugs() {
     let fixture = load_fixture();
     let dir = TempDir::new().expect("tempdir");

--- a/crates/velesdb-core/src/collection/search/query/early_return.rs
+++ b/crates/velesdb-core/src/collection/search/query/early_return.rs
@@ -66,27 +66,47 @@ impl Collection {
             ctx,
         };
 
-        // EPIC-044 US-003: NOT similarity() requires full scan
-        if extracted.is_not_similarity_query {
-            return self.run_not_similarity_early(&early_ctx, limit).map(Some);
-        }
-
-        // EPIC-044 US-002: Union mode for similarity() OR metadata.
-        // The union path keeps the MAX_LIMIT window when graph predicates
-        // are present: its similarity/metadata legs rank independently and
-        // would each need anchor-aware fetching to drop it.
-        let mut graph_cache = super::where_eval::GraphMatchEvalCache::default();
-        let execution_limit = if has_graph_predicates {
+        // A scalar (non-similarity) ORDER BY ranks rows only in
+        // `finalize_early_results`, so capping the fetch at `limit` first would
+        // truncate before the sort (same defect as the main-dispatch path).
+        // Fetch exhaustively so the sort precedes truncation.
+        let limit = if Self::order_by_requires_exhaustive_fetch(stmt) {
             MAX_LIMIT
         } else {
             limit
         };
-        let results = self.execute_early_return_query(
+
+        // EPIC-044 US-003: NOT similarity() requires full scan
+        if extracted.is_not_similarity_query {
+            return self.run_not_similarity_early(&early_ctx, limit).map(Some);
+        }
+        self.run_union_early(&early_ctx, cond, params, limit)
+            .map(Some)
+    }
+
+    /// Runs the union early-return path (EPIC-044 US-002: similarity() OR metadata).
+    ///
+    /// The union path keeps the `MAX_LIMIT` window when graph predicates are
+    /// present: its similarity/metadata legs rank independently and would each
+    /// need anchor-aware fetching to drop it.
+    fn run_union_early(
+        &self,
+        early: &EarlyReturnCtx<'_>,
+        cond: &crate::velesql::Condition,
+        params: &std::collections::HashMap<String, serde_json::Value>,
+        limit: usize,
+    ) -> Result<Vec<SearchResult>> {
+        let mut graph_cache = super::where_eval::GraphMatchEvalCache::default();
+        let execution_limit = if early.has_graph_predicates {
+            MAX_LIMIT
+        } else {
+            limit
+        };
+        self.execute_early_return_query(
             |s| s.execute_union_query(cond, params, execution_limit),
-            &early_ctx,
+            early,
             &mut graph_cache,
-        )?;
-        Ok(Some(results))
+        )
     }
 
     /// Runs the NOT-similarity early path with GraphFirst anchoring:

--- a/crates/velesdb-core/src/collection/search/query/select_dispatch.rs
+++ b/crates/velesdb-core/src/collection/search/query/select_dispatch.rs
@@ -85,6 +85,25 @@ impl Collection {
             .any(|item| Self::order_by_item_reduces_to_similarity(&item.expr))
     }
 
+    /// Returns `true` when the primary ORDER BY key is a scalar column (not a
+    /// `similarity()` reduction), so the candidate fetch must be exhaustive.
+    ///
+    /// The similarity-ordered fast path (HNSW returns top-k pre-sorted by
+    /// score) is correct under a bounded fetch, but a scalar key is only
+    /// ranked downstream in `apply_select_postprocessing`; truncating the
+    /// fetch first would yield the first `limit` rows in storage/score order
+    /// rather than the top `limit` by the ORDER BY key. The *primary* key
+    /// decides: a leading `similarity()` keeps the fast path even when a
+    /// scalar tie-breaker follows it.
+    pub(super) fn order_by_requires_exhaustive_fetch(
+        stmt: &crate::velesql::SelectStatement,
+    ) -> bool {
+        stmt.order_by
+            .as_ref()
+            .and_then(|ob| ob.first())
+            .is_some_and(|first| !Self::order_by_item_reduces_to_similarity(&first.expr))
+    }
+
     /// Helper for [`has_order_by_similarity`]. Kept as an associated function
     /// so the match arm can delegate to the arithmetic-expression walker
     /// without inflating the outer method's cyclomatic complexity.
@@ -188,7 +207,7 @@ impl Collection {
                 .where_clause
                 .as_ref()
                 .is_some_and(Self::condition_contains_or);
-        let execution_limit = main_select_execution_limit(extracted, limit);
+        let execution_limit = main_select_execution_limit(stmt, extracted, limit);
         let search_opts = super::QuerySearchOptions::from_with_clause(stmt.with_clause.as_ref())
             .with_fusion(stmt.fusion_clause.clone());
         let (cbo_strategy, cbo_over_fetch) =
@@ -589,7 +608,20 @@ fn anchored_fetch_applies(
 /// queries never reach here; they are dispatched by `try_early_return_path`).
 /// This window only applies when the GraphFirst anchored fetch declined
 /// (`try_anchored_fetch`).
-fn main_select_execution_limit(extracted: &ExtractedComponents, limit: usize) -> usize {
+fn main_select_execution_limit(
+    stmt: &crate::velesql::SelectStatement,
+    extracted: &ExtractedComponents,
+    limit: usize,
+) -> usize {
+    // A scalar (non-similarity) ORDER BY ranks rows AFTER the fetch, in
+    // `apply_select_postprocessing`. Capping the fetch at `limit` would
+    // truncate before that sort, returning the first `limit` rows in
+    // storage/score order instead of the top `limit` by the ORDER BY key
+    // (KNOWN_LIMITATIONS #9: bounded results must equal the unbounded path
+    // truncated to k). Fetch exhaustively so the sort precedes truncation.
+    if Collection::order_by_requires_exhaustive_fetch(stmt) {
+        return MAX_LIMIT;
+    }
     let has_graph_predicates = !extracted.graph_match_predicates.is_empty();
     let has_ranked_fetch =
         extracted.vector_search.is_some() || !extracted.similarity_conditions.is_empty();
@@ -621,6 +653,13 @@ fn anchor_fetch_limit(
     extracted: &ExtractedComponents,
     limit: usize,
 ) -> usize {
+    // A scalar ORDER BY ranks downstream, so the anchored fetch (which
+    // hydrates anchors in ascending-id order) must be exhaustive too —
+    // otherwise the ascending-id window drops rows the ORDER BY key would
+    // have surfaced. Mirrors `main_select_execution_limit`.
+    if Collection::order_by_requires_exhaustive_fetch(stmt) {
+        return MAX_LIMIT;
+    }
     if Collection::has_order_by_similarity(stmt) && extracted.vector_search.is_none() {
         MAX_LIMIT
     } else {

--- a/crates/velesdb-core/src/distance.rs
+++ b/crates/velesdb-core/src/distance.rs
@@ -16,6 +16,15 @@ use crate::simd_native;
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 
+/// Canonical names of every [`DistanceMetric`] variant, in declaration order.
+///
+/// Single source of truth for the metric name set exported to downstream
+/// crates and bindings (Python `velesdb.DISTANCE_METRICS`, the integrations
+/// security guard). Each entry is the variant's
+/// [`canonical_name`](DistanceMetric::canonical_name); a unit test asserts the
+/// slice stays exhaustive so adding a variant without updating it fails CI.
+pub const DISTANCE_METRIC_NAMES: &[&str] = &["cosine", "euclidean", "dot", "hamming", "jaccard"];
+
 /// Distance metric for vector similarity calculations.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[non_exhaustive]
@@ -162,5 +171,41 @@ impl FromStr for DistanceMetric {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Self::parse_alias(s)
             .ok_or("Unknown metric. Use: cosine, euclidean, l2, dot, dotproduct, inner, ip, hamming, jaccard")
+    }
+}
+
+#[cfg(test)]
+mod distance_metric_names_tests {
+    use super::{DistanceMetric, DISTANCE_METRIC_NAMES};
+
+    /// Forces this test to be revisited whenever a variant is added: the
+    /// exhaustive `match` (no wildcard arm) fails to compile until the new
+    /// variant is listed here, which in turn flags the missing const entry.
+    fn ordinal(metric: DistanceMetric) -> usize {
+        match metric {
+            DistanceMetric::Cosine => 0,
+            DistanceMetric::Euclidean => 1,
+            DistanceMetric::DotProduct => 2,
+            DistanceMetric::Hamming => 3,
+            DistanceMetric::Jaccard => 4,
+        }
+    }
+
+    #[test]
+    fn distance_metric_names_is_exhaustive_and_canonical() {
+        let variants = [
+            DistanceMetric::Cosine,
+            DistanceMetric::Euclidean,
+            DistanceMetric::DotProduct,
+            DistanceMetric::Hamming,
+            DistanceMetric::Jaccard,
+        ];
+        // Tie the variant list to the `ordinal` tripwire so a new variant
+        // cannot silently skip this assertion.
+        assert_eq!(variants.len(), DISTANCE_METRIC_NAMES.len());
+        for (i, variant) in variants.into_iter().enumerate() {
+            assert_eq!(ordinal(variant), i);
+            assert_eq!(DISTANCE_METRIC_NAMES[i], variant.canonical_name());
+        }
     }
 }

--- a/crates/velesdb-core/src/index/secondary/mod.rs
+++ b/crates/velesdb-core/src/index/secondary/mod.rs
@@ -2,6 +2,8 @@
 
 #[cfg(test)]
 mod bitmap_tests;
+#[cfg(test)]
+mod ordered_ids_tests;
 
 use parking_lot::RwLock;
 use serde_json::Number;
@@ -150,6 +152,59 @@ impl SecondaryIndex {
                 Some(bm)
             }
         }
+    }
+
+    /// Returns up to `limit` point IDs in this index's key order — ascending,
+    /// or descending when `descending` is true — with IDs inside an equal-key
+    /// bucket emitted in ascending ID order for determinism.
+    ///
+    /// This is the ordered-iteration primitive for index-backed
+    /// `ORDER BY <field> LIMIT k` top-k (the B001 perf follow-up): a
+    /// `BTreeMap` walk costs `O(log n + k)` instead of the `O(n log n)`
+    /// full-scan sort. It only sees rows that carry the field — rows missing
+    /// the field (which a full `ORDER BY` sorts first for ASC / last for DESC)
+    /// are absent, so callers MUST restrict use to fully-covered fields and
+    /// fall back to the full scan otherwise.
+    // Staged API: landed + unit-tested ahead of its planner consumer. The
+    // `ORDER BY <field> LIMIT k` pushdown that calls this (routing at
+    // `order_by_requires_exhaustive_fetch`) is phase 2 of the ordered-index
+    // EPIC — see docs/planning/CORE_PARITY_REMEDIATION.md.
+    #[allow(dead_code)]
+    #[must_use]
+    pub fn ordered_ids(&self, descending: bool, limit: usize) -> Vec<u64> {
+        let Self::BTree(tree) = self;
+        let guard = tree.read();
+        let mut out: Vec<u64> = Vec::new();
+        if descending {
+            for ids in guard.values().rev() {
+                if out.len() >= limit {
+                    break;
+                }
+                push_bucket_capped(ids, limit, &mut out);
+            }
+        } else {
+            for ids in guard.values() {
+                if out.len() >= limit {
+                    break;
+                }
+                push_bucket_capped(ids, limit, &mut out);
+            }
+        }
+        out
+    }
+}
+
+/// Appends `ids` (sorted ascending for determinism) to `out`, stopping once
+/// `out` reaches `limit`.
+#[allow(dead_code)] // helper for the staged `ordered_ids` primitive (see above)
+fn push_bucket_capped(ids: &[u64], limit: usize, out: &mut Vec<u64>) {
+    let mut bucket = ids.to_vec();
+    bucket.sort_unstable();
+    for id in bucket {
+        if out.len() >= limit {
+            return;
+        }
+        out.push(id);
     }
 }
 

--- a/crates/velesdb-core/src/index/secondary/ordered_ids_tests.rs
+++ b/crates/velesdb-core/src/index/secondary/ordered_ids_tests.rs
@@ -1,0 +1,67 @@
+//! Unit tests for [`SecondaryIndex::ordered_ids`] — the ordered-iteration
+//! primitive for index-backed `ORDER BY <field> LIMIT k` top-k (B001 follow-up).
+
+use super::{F64Key, JsonValue, SecondaryIndex};
+use parking_lot::RwLock;
+use std::collections::BTreeMap;
+
+/// Mixed-type fixture. Key order is Bool < Number < String (the `JsonValue`
+/// `Ord`), and the `Number(1.0)` bucket holds IDs out of order on purpose so
+/// the within-bucket ascending-ID sort is exercised.
+fn fixture() -> SecondaryIndex {
+    let mut map: BTreeMap<JsonValue, Vec<u64>> = BTreeMap::new();
+    map.insert(JsonValue::Bool(false), vec![5]);
+    map.insert(JsonValue::Bool(true), vec![3]);
+    map.insert(JsonValue::Number(F64Key::from(1.0)), vec![10, 2]);
+    map.insert(JsonValue::Number(F64Key::from(2.0)), vec![7]);
+    map.insert(JsonValue::String("a".to_string()), vec![8]);
+    SecondaryIndex::BTree(RwLock::new(map))
+}
+
+#[test]
+fn ascending_walks_keys_then_sorts_each_bucket_by_id() {
+    // Bool(false)=5, Bool(true)=3, Number(1)={2,10}, Number(2)=7, String("a")=8
+    assert_eq!(fixture().ordered_ids(false, 100), vec![5, 3, 2, 10, 7, 8]);
+}
+
+#[test]
+fn descending_reverses_key_order_bucket_ids_still_ascending() {
+    assert_eq!(fixture().ordered_ids(true, 100), vec![8, 7, 2, 10, 3, 5]);
+}
+
+#[test]
+fn limit_truncates_after_ordering_not_before() {
+    assert_eq!(fixture().ordered_ids(false, 3), vec![5, 3, 2]);
+    assert_eq!(fixture().ordered_ids(true, 2), vec![8, 7]);
+    // A limit landing mid-bucket keeps the bucket's lowest IDs first.
+    assert_eq!(fixture().ordered_ids(false, 4), vec![5, 3, 2, 10]);
+}
+
+#[test]
+fn limit_zero_returns_empty() {
+    assert!(fixture().ordered_ids(false, 0).is_empty());
+    assert!(fixture().ordered_ids(true, 0).is_empty());
+}
+
+#[test]
+fn empty_index_returns_empty() {
+    let empty = SecondaryIndex::BTree(RwLock::new(BTreeMap::new()));
+    assert!(empty.ordered_ids(false, 10).is_empty());
+    assert!(empty.ordered_ids(true, 10).is_empty());
+}
+
+#[test]
+fn single_key_many_ids_emits_all_sorted() {
+    let mut map: BTreeMap<JsonValue, Vec<u64>> = BTreeMap::new();
+    map.insert(
+        JsonValue::Number(F64Key::from(42.0)),
+        vec![9, 1, 4, 1_000_000_000_000],
+    );
+    let idx = SecondaryIndex::BTree(RwLock::new(map));
+    assert_eq!(
+        idx.ordered_ids(false, 100),
+        vec![1, 4, 9, 1_000_000_000_000]
+    );
+    // descending key order is identical here (one key); bucket stays ID-ascending
+    assert_eq!(idx.ordered_ids(true, 2), vec![1, 4]);
+}

--- a/crates/velesdb-core/src/lib.rs
+++ b/crates/velesdb-core/src/lib.rs
@@ -196,14 +196,14 @@ pub use collection::{
     VectorCollection,
 };
 pub use contiguous_ops::pad_to_simd_width;
-pub use distance::DistanceMetric;
+pub use distance::{DistanceMetric, DISTANCE_METRIC_NAMES};
 pub use error::{Error, Result};
 pub use filter::{Condition, Filter};
 pub use point::{ComponentScores, Point, SearchResult};
 pub use quantization::{
     cosine_similarity_quantized, cosine_similarity_quantized_simd, dot_product_quantized,
     dot_product_quantized_simd, euclidean_squared_quantized, euclidean_squared_quantized_simd,
-    BinaryQuantizedVector, QuantizationCodec, QuantizedVector, StorageMode,
+    BinaryQuantizedVector, QuantizationCodec, QuantizedVector, StorageMode, STORAGE_MODE_NAMES,
 };
 pub use scored_result::ScoredResult;
 pub use validation::{

--- a/crates/velesdb-core/src/quantization/mod.rs
+++ b/crates/velesdb-core/src/quantization/mod.rs
@@ -103,6 +103,15 @@ pub trait QuantizationCodec: Sized {
     fn from_bytes(bytes: &[u8]) -> io::Result<Self>;
 }
 
+/// Canonical names of every [`StorageMode`] variant, in declaration order.
+///
+/// Single source of truth for the storage-mode name set exported to downstream
+/// crates and bindings (Python `velesdb.STORAGE_MODES`, the integrations
+/// security guard). Each entry is the variant's
+/// [`canonical_name`](StorageMode::canonical_name); a unit test asserts the
+/// slice stays exhaustive so adding a variant without updating it fails CI.
+pub const STORAGE_MODE_NAMES: &[&str] = &["full", "sq8", "binary", "pq", "rabitq"];
+
 /// Storage mode for vectors.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -189,7 +198,36 @@ impl std::str::FromStr for StorageMode {
 
 #[cfg(test)]
 mod storage_mode_parsing_tests {
-    use super::StorageMode;
+    use super::{StorageMode, STORAGE_MODE_NAMES};
+
+    /// Forces this test to be revisited whenever a variant is added: the
+    /// exhaustive `match` (no wildcard arm) fails to compile until the new
+    /// variant is listed here, which in turn flags the missing const entry.
+    fn ordinal(mode: StorageMode) -> usize {
+        match mode {
+            StorageMode::Full => 0,
+            StorageMode::SQ8 => 1,
+            StorageMode::Binary => 2,
+            StorageMode::ProductQuantization => 3,
+            StorageMode::RaBitQ => 4,
+        }
+    }
+
+    #[test]
+    fn storage_mode_names_is_exhaustive_and_canonical() {
+        let variants = [
+            StorageMode::Full,
+            StorageMode::SQ8,
+            StorageMode::Binary,
+            StorageMode::ProductQuantization,
+            StorageMode::RaBitQ,
+        ];
+        assert_eq!(variants.len(), STORAGE_MODE_NAMES.len());
+        for (i, variant) in variants.into_iter().enumerate() {
+            assert_eq!(ordinal(variant), i);
+            assert_eq!(STORAGE_MODE_NAMES[i], variant.canonical_name());
+        }
+    }
 
     #[test]
     fn test_parse_all_canonical_names() {

--- a/crates/velesdb-core/tests/scalar_order_by_limit_integration.rs
+++ b/crates/velesdb-core/tests/scalar_order_by_limit_integration.rs
@@ -1,0 +1,80 @@
+#![cfg(all(test, feature = "persistence"))]
+//! Regression: a scalar (non-similarity) `ORDER BY <col> ... LIMIT k` must sort
+//! by the ORDER BY key BEFORE applying the LIMIT, so the bounded result equals
+//! the unbounded path truncated to `k` (`KNOWN_LIMITATIONS` #9).
+//!
+//! Before the fix, the candidate fetch was capped at `k` in storage order, then
+//! only that capped window was sorted — `... WHERE year >= 2019 ORDER BY year
+//! DESC LIMIT 2` returned the first two matching rows by id [2, 1] instead of
+//! the two newest [4, 2].
+
+use serde_json::json;
+use std::collections::HashMap;
+use tempfile::TempDir;
+use velesdb_core::{DistanceMetric, Point, StorageMode, VectorCollection};
+
+/// Builds the 5-row "docs" collection: ids 1..=5 with years 2020, 2022, 2021,
+/// 2023, 2019 respectively (storage/id order deliberately ≠ year order).
+fn setup_docs() -> (VectorCollection, TempDir) {
+    let dir = TempDir::new().expect("temp dir");
+    let collection = VectorCollection::create(
+        dir.path().join("docs"),
+        "docs",
+        2,
+        DistanceMetric::Cosine,
+        StorageMode::Full,
+    )
+    .expect("create collection");
+
+    let years = [(1u64, 2020), (2, 2022), (3, 2021), (4, 2023), (5, 2019)];
+    let points: Vec<Point> = years
+        .iter()
+        .map(|&(id, year)| Point::new(id, vec![1.0, 0.0], Some(json!({ "year": year }))))
+        .collect();
+    // Years live in the payload; the vector is irrelevant to a scalar ORDER BY.
+    collection.upsert(points).expect("upsert");
+    (collection, dir)
+}
+
+fn ids(results: &[velesdb_core::point::SearchResult]) -> Vec<u64> {
+    results.iter().map(|r| r.point.id).collect()
+}
+
+#[test]
+fn test_scalar_order_by_desc_limit_sorts_before_truncating() {
+    let (collection, _dir) = setup_docs();
+    let results = collection
+        .execute_query_str(
+            "SELECT * FROM docs WHERE year >= 2019 ORDER BY year DESC LIMIT 2",
+            &HashMap::new(),
+        )
+        .expect("query");
+    // Two newest: id 4 (2023), id 2 (2022).
+    assert_eq!(ids(&results), vec![4, 2]);
+}
+
+#[test]
+fn test_scalar_order_by_asc_limit_sorts_before_truncating() {
+    let (collection, _dir) = setup_docs();
+    let results = collection
+        .execute_query_str(
+            "SELECT * FROM docs WHERE year >= 2019 ORDER BY year ASC LIMIT 2",
+            &HashMap::new(),
+        )
+        .expect("query");
+    // Two oldest: id 5 (2019), id 1 (2020).
+    assert_eq!(ids(&results), vec![5, 1]);
+}
+
+#[test]
+fn test_scalar_order_by_no_limit_control_is_fully_sorted() {
+    let (collection, _dir) = setup_docs();
+    let results = collection
+        .execute_query_str(
+            "SELECT * FROM docs WHERE year >= 2019 ORDER BY year DESC",
+            &HashMap::new(),
+        )
+        .expect("query");
+    // Full descending order; LIMIT 2 must be a prefix of this control.
+    assert_eq!(ids(&results), vec![4, 2, 3, 1, 5]);
+}

--- a/crates/velesdb-core/tests/velesql_executor_conformance.rs
+++ b/crates/velesdb-core/tests/velesql_executor_conformance.rs
@@ -1,0 +1,114 @@
+#![cfg(feature = "persistence")]
+//! Executor-level VelesQL conformance (T2 of the core-parity remediation plan).
+//!
+//! The existing `velesql_parser_conformance` fixture only asserts that a query
+//! *parses*. This suite goes further: it loads a fixed dataset, executes each
+//! query through `velesdb-core` (the source of truth), and asserts the exact
+//! result set — ROWS, COUNTS, and ORDERING. The golden ids in
+//! `conformance/velesql_executor_cases.json` are the contract that other
+//! executors (WASM, CLI) must reproduce, so a future divergence in
+//! filtering/ordering/limit behaviour fails CI instead of going unnoticed.
+//!
+//! The fixture's `known_bugs` array carries the CORRECT expectation for a
+//! confirmed core bug; it is asserted only by the `#[ignore]`d reproducer
+//! below so CI stays green until the bug is fixed.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use serde::Deserialize;
+use serde_json::Value;
+use tempfile::TempDir;
+use velesdb_core::velesql::Parser;
+use velesdb_core::{Database, DistanceMetric, Point};
+
+#[derive(Deserialize)]
+struct Fixture {
+    dataset: Dataset,
+    cases: Vec<Case>,
+    #[serde(default)]
+    known_bugs: Vec<Case>,
+}
+
+#[derive(Deserialize)]
+struct Dataset {
+    collection: String,
+    dimension: usize,
+    metric: String,
+    points: Vec<FixturePoint>,
+}
+
+#[derive(Deserialize)]
+struct FixturePoint {
+    id: u64,
+    vector: Vec<f32>,
+    payload: Value,
+}
+
+#[derive(Deserialize)]
+struct Case {
+    id: String,
+    query: String,
+    expect_ids: Vec<u64>,
+}
+
+fn fixture_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../conformance/velesql_executor_cases.json")
+}
+
+fn load_fixture() -> Fixture {
+    let content = std::fs::read_to_string(fixture_path()).expect("read executor fixture");
+    serde_json::from_str(&content).expect("parse executor fixture")
+}
+
+fn open_loaded_db(ds: &Dataset) -> (TempDir, Database) {
+    let dir = TempDir::new().expect("tempdir");
+    let db = Database::open(dir.path()).expect("open db");
+    let metric = ds.metric.parse().unwrap_or(DistanceMetric::Cosine);
+    db.create_collection(&ds.collection, ds.dimension, metric)
+        .expect("create dataset collection");
+    let collection = db
+        .get_vector_collection(&ds.collection)
+        .expect("get dataset collection");
+    let points: Vec<Point> = ds
+        .points
+        .iter()
+        .map(|p| Point::new(p.id, p.vector.clone(), Some(p.payload.clone())))
+        .collect();
+    collection.upsert(points).expect("upsert dataset");
+    (dir, db)
+}
+
+fn assert_cases(db: &Database, cases: &[Case]) {
+    let params = HashMap::new();
+    for case in cases {
+        let query = Parser::parse(&case.query)
+            .unwrap_or_else(|e| panic!("case {} failed to parse: {e}", case.id));
+        let results = db
+            .execute_query(&query, &params)
+            .unwrap_or_else(|e| panic!("case {} failed to execute: {e}", case.id));
+        let ids: Vec<u64> = results.iter().map(|r| r.point.id).collect();
+        assert_eq!(
+            ids, case.expect_ids,
+            "executor conformance mismatch for case {}: query={:?}",
+            case.id, case.query
+        );
+    }
+}
+
+#[test]
+fn test_velesql_executor_conformance_fixture_cases() {
+    let fixture = load_fixture();
+    let (_dir, db) = open_loaded_db(&fixture.dataset);
+    assert_cases(&db, &fixture.cases);
+}
+
+/// Reproducer for confirmed executor bugs (correct expectation). Ignored so CI
+/// stays green; remove `#[ignore]` once the bug is fixed to lock the fix.
+#[test]
+#[ignore = "B001: scalar ORDER BY + LIMIT applies LIMIT before sort (bounded top-k); contradicts KNOWN_LIMITATIONS #9"]
+fn test_velesql_executor_known_bugs() {
+    let fixture = load_fixture();
+    let (_dir, db) = open_loaded_db(&fixture.dataset);
+    assert_cases(&db, &fixture.known_bugs);
+}

--- a/crates/velesdb-core/tests/velesql_executor_conformance.rs
+++ b/crates/velesdb-core/tests/velesql_executor_conformance.rs
@@ -103,10 +103,10 @@ fn test_velesql_executor_conformance_fixture_cases() {
     assert_cases(&db, &fixture.cases);
 }
 
-/// Reproducer for confirmed executor bugs (correct expectation). Ignored so CI
-/// stays green; remove `#[ignore]` once the bug is fixed to lock the fix.
+/// Regression lock for B001 (scalar `ORDER BY` + `LIMIT`): formerly LIMIT was
+/// applied before the sort; fixed in the executor so the bounded result now
+/// equals the unbounded path truncated to k (KNOWN_LIMITATIONS #9).
 #[test]
-#[ignore = "B001: scalar ORDER BY + LIMIT applies LIMIT before sort (bounded top-k); contradicts KNOWN_LIMITATIONS #9"]
 fn test_velesql_executor_known_bugs() {
     let fixture = load_fixture();
     let (_dir, db) = open_loaded_db(&fixture.dataset);

--- a/crates/velesdb-core/tests/velesql_executor_conformance.rs
+++ b/crates/velesdb-core/tests/velesql_executor_conformance.rs
@@ -1,5 +1,5 @@
 #![cfg(feature = "persistence")]
-//! Executor-level VelesQL conformance (T2 of the core-parity remediation plan).
+//! Executor-level `VelesQL` conformance (T2 of the core-parity remediation plan).
 //!
 //! The existing `velesql_parser_conformance` fixture only asserts that a query
 //! *parses*. This suite goes further: it loads a fixed dataset, executes each
@@ -105,7 +105,7 @@ fn test_velesql_executor_conformance_fixture_cases() {
 
 /// Regression lock for B001 (scalar `ORDER BY` + `LIMIT`): formerly LIMIT was
 /// applied before the sort; fixed in the executor so the bounded result now
-/// equals the unbounded path truncated to k (KNOWN_LIMITATIONS #9).
+/// equals the unbounded path truncated to k (`KNOWN_LIMITATIONS` #9).
 #[test]
 fn test_velesql_executor_known_bugs() {
     let fixture = load_fixture();

--- a/crates/velesdb-mobile/README.md
+++ b/crates/velesdb-mobile/README.md
@@ -331,7 +331,7 @@ Used with `multiQuerySearch()` for combining results from multiple query vectors
 | `PqTrainConfig` | `m: UInt32`, `k: UInt32`, `opq: Bool` | PQ training configuration |
 | `MobileGraphNode` | `id: UInt64`, `label: String`, `propertiesJson: String?`, `vector: [Float]?` | Graph node |
 | `MobileGraphEdge` | `id: UInt64`, `source: UInt64`, `target: UInt64`, `label: String`, `propertiesJson: String?` | Graph edge |
-| `TraversalResult` | `nodeId: UInt64`, `depth: UInt32` | BFS/DFS traversal result |
+| `TraversalResult` | `nodeId: UInt64`, `path: [UInt64]`, `depth: UInt32` | BFS/DFS traversal result (`path` = edge IDs taken from the source; mirrors core's `TraversalResult`) |
 | `MobileCollectionStats` | `totalPoints`, `payloadSizeBytes`, `rowCount`, ... | Collection statistics |
 | `MobileIndexInfo` | `label`, `property`, `indexType`, `cardinality`, `memoryBytes` | Index metadata |
 

--- a/crates/velesdb-mobile/src/graph.rs
+++ b/crates/velesdb-mobile/src/graph.rs
@@ -35,13 +35,68 @@ pub struct MobileGraphEdge {
     pub properties_json: Option<String>,
 }
 
-/// Traversal result from BFS.
+/// Traversal result from BFS/DFS.
+///
+/// FFI projection of [`velesdb_core::TraversalResult`]. The mobile field
+/// `node_id` corresponds to core's `target_id` (the node reached); `path`
+/// and `depth` mirror core's fields one-for-one. See the `From` impls below
+/// for the canonical mapping — they make any future core field drift a
+/// compile error rather than silent divergence.
 #[derive(Debug, Clone, uniffi::Record)]
 pub struct TraversalResult {
-    /// Target node ID.
+    /// Target node ID reached (core: `target_id`).
     pub node_id: u64,
-    /// Depth from source.
+    /// Edge IDs along the path from the source to this node (core: `path`).
+    pub path: Vec<u64>,
+    /// Depth from source (number of hops).
     pub depth: u32,
+}
+
+/// Serializes a core property map to the mobile `properties_json` shape.
+///
+/// Returns `None` for an empty map (no properties) and a JSON object string
+/// otherwise. A serialization failure also yields `None` so the projection is
+/// total (FFI conversions cannot return a `Result`).
+fn properties_to_json(
+    properties: &std::collections::HashMap<String, serde_json::Value>,
+) -> Option<String> {
+    if properties.is_empty() {
+        return None;
+    }
+    serde_json::to_string(properties).ok()
+}
+
+impl From<velesdb_core::GraphNode> for MobileGraphNode {
+    fn from(node: velesdb_core::GraphNode) -> Self {
+        Self {
+            id: node.id(),
+            label: node.label().to_string(),
+            properties_json: properties_to_json(node.properties()),
+            vector: node.vector().cloned(),
+        }
+    }
+}
+
+impl From<velesdb_core::GraphEdge> for MobileGraphEdge {
+    fn from(edge: velesdb_core::GraphEdge) -> Self {
+        Self {
+            id: edge.id(),
+            source: edge.source(),
+            target: edge.target(),
+            label: edge.label().to_string(),
+            properties_json: properties_to_json(edge.properties()),
+        }
+    }
+}
+
+impl From<velesdb_core::TraversalResult> for TraversalResult {
+    fn from(result: velesdb_core::TraversalResult) -> Self {
+        Self {
+            node_id: result.target_id,
+            path: result.path,
+            depth: result.depth,
+        }
+    }
 }
 
 /// In-memory graph store for mobile knowledge graphs.
@@ -197,24 +252,28 @@ impl MobileGraphStore {
 
         let mut results: Vec<TraversalResult> = Vec::new();
         let mut visited: HashSet<u64> = HashSet::new();
-        let mut queue: VecDeque<(u64, u32)> = VecDeque::new();
+        let mut queue: VecDeque<(u64, u32, Vec<u64>)> = VecDeque::new();
 
         for &source_id in &source_ids {
             if visited.insert(source_id) {
-                queue.push_back((source_id, 0));
+                queue.push_back((source_id, 0, Vec::new()));
             }
         }
 
-        while let Some((node_id, depth)) = queue.pop_front() {
+        while let Some((node_id, depth, path)) = queue.pop_front() {
             if results.len() >= limit as usize {
                 break;
             }
 
             if depth > 0 {
-                results.push(TraversalResult { node_id, depth });
+                results.push(TraversalResult {
+                    node_id,
+                    path: path.clone(),
+                    depth,
+                });
             }
 
-            self.enqueue_neighbors(node_id, depth, max_depth, &mut visited, &mut queue);
+            self.enqueue_neighbors(node_id, depth, max_depth, &path, &mut visited, &mut queue);
         }
 
         results
@@ -308,9 +367,9 @@ impl MobileGraphStore {
 
         let mut results: Vec<TraversalResult> = Vec::new();
         let mut visited: HashSet<u64> = HashSet::new();
-        let mut stack: Vec<(u64, u32)> = vec![(source_id, 0)];
+        let mut stack: Vec<(u64, u32, Vec<u64>)> = vec![(source_id, 0, Vec::new())];
 
-        while let Some((node_id, depth)) = stack.pop() {
+        while let Some((node_id, depth, path)) = stack.pop() {
             if results.len() >= limit as usize {
                 break;
             }
@@ -321,7 +380,11 @@ impl MobileGraphStore {
             visited.insert(node_id);
 
             if depth > 0 {
-                results.push(TraversalResult { node_id, depth });
+                results.push(TraversalResult {
+                    node_id,
+                    path: path.clone(),
+                    depth,
+                });
             }
 
             if depth < max_depth {
@@ -332,7 +395,9 @@ impl MobileGraphStore {
                     .collect();
 
                 for edge in neighbors.into_iter().rev() {
-                    stack.push((edge.target, depth + 1));
+                    let mut next_path = path.clone();
+                    next_path.push(edge.id);
+                    stack.push((edge.target, depth + 1, next_path));
                 }
             }
         }
@@ -411,21 +476,27 @@ impl MobileGraphStore {
 
     /// Enqueues unvisited outgoing neighbors of `node_id` for further traversal.
     ///
-    /// No-op when `depth` has already reached `max_depth`.
+    /// Each enqueued entry carries the edge-ID path taken to reach the neighbor
+    /// (`path` so far plus the traversed edge), mirroring core's
+    /// `TraversalResult::path`. No-op when `depth` has already reached
+    /// `max_depth`.
     fn enqueue_neighbors(
         &self,
         node_id: u64,
         depth: u32,
         max_depth: u32,
+        path: &[u64],
         visited: &mut std::collections::HashSet<u64>,
-        queue: &mut std::collections::VecDeque<(u64, u32)>,
+        queue: &mut std::collections::VecDeque<(u64, u32, Vec<u64>)>,
     ) {
         if depth >= max_depth {
             return;
         }
         for edge in self.get_outgoing(node_id) {
             if visited.insert(edge.target) {
-                queue.push_back((edge.target, depth + 1));
+                let mut next_path = path.to_vec();
+                next_path.push(edge.id);
+                queue.push_back((edge.target, depth + 1, next_path));
             }
         }
     }
@@ -537,11 +608,53 @@ mod tests {
 
         let results = store.bfs_traverse(1, 3, 100);
 
-        // Should find nodes 2, 3, 4 at depths 1, 2, 3
+        // Should find nodes 2, 3, 4 at depths 1, 2, 3, each carrying the
+        // edge-ID path mirroring core's TraversalResult::path.
         assert_eq!(results.len(), 3);
-        assert!(results.iter().any(|r| r.node_id == 2 && r.depth == 1));
-        assert!(results.iter().any(|r| r.node_id == 3 && r.depth == 2));
-        assert!(results.iter().any(|r| r.node_id == 4 && r.depth == 3));
+        assert!(results
+            .iter()
+            .any(|r| r.node_id == 2 && r.depth == 1 && r.path == vec![100]));
+        assert!(results
+            .iter()
+            .any(|r| r.node_id == 3 && r.depth == 2 && r.path == vec![100, 101]));
+        assert!(results
+            .iter()
+            .any(|r| r.node_id == 4 && r.depth == 3 && r.path == vec![100, 101, 102]));
+    }
+
+    #[test]
+    fn test_traversal_result_from_core() {
+        let core = velesdb_core::TraversalResult::new(7, vec![10, 20], 2);
+        let mobile: TraversalResult = core.into();
+        assert_eq!(mobile.node_id, 7);
+        assert_eq!(mobile.path, vec![10, 20]);
+        assert_eq!(mobile.depth, 2);
+    }
+
+    #[test]
+    fn test_graph_node_from_core() {
+        let mut props = std::collections::HashMap::new();
+        props.insert("name".to_string(), serde_json::json!("Alice"));
+        let core = velesdb_core::GraphNode::new(1, "Person")
+            .with_properties(props)
+            .with_vector(vec![0.1, 0.2]);
+        let mobile: MobileGraphNode = core.into();
+        assert_eq!(mobile.id, 1);
+        assert_eq!(mobile.label, "Person");
+        assert_eq!(mobile.vector, Some(vec![0.1, 0.2]));
+        assert!(mobile.properties_json.is_some());
+    }
+
+    #[test]
+    fn test_graph_edge_from_core() -> Result<(), velesdb_core::Error> {
+        let core = velesdb_core::GraphEdge::new(100, 1, 2, "KNOWS")?;
+        let mobile: MobileGraphEdge = core.into();
+        assert_eq!(mobile.id, 100);
+        assert_eq!(mobile.source, 1);
+        assert_eq!(mobile.target, 2);
+        assert_eq!(mobile.label, "KNOWS");
+        assert_eq!(mobile.properties_json, None);
+        Ok(())
     }
 
     #[test]

--- a/crates/velesdb-python/python/velesdb/__init__.py
+++ b/crates/velesdb-python/python/velesdb/__init__.py
@@ -22,6 +22,7 @@ from velesdb.velesdb import (  # type: ignore[attr-defined]
     Database as _RawDatabase,
     DatabaseLockedError,
     DimensionMismatchError,
+    DISTANCE_METRICS,
     EdgeExistsError,
     FusionStrategy,
     GraphStore as _RawGraphStore,
@@ -35,6 +36,7 @@ from velesdb.velesdb import (  # type: ignore[attr-defined]
     PySemanticMemory,
     SearchOptions,
     SearchResult,
+    STORAGE_MODES,
     StreamingConfig,
     StreamingIngestConfig,
     TraversalResult,
@@ -900,6 +902,9 @@ __all__ = [
     "LimitsOptions",
     "AutoReindexOptions",
     "VelesConfigOptions",
+    # Canonical enum name sets, single-sourced from velesdb-core (tuples of str).
+    "DISTANCE_METRICS",
+    "STORAGE_MODES",
     "embed",
     "__version__",
 ]

--- a/crates/velesdb-python/python/velesdb/__init__.pyi
+++ b/crates/velesdb-python/python/velesdb/__init__.pyi
@@ -8,6 +8,12 @@ import numpy as np
 
 __version__: str
 
+# Canonical enum name sets, single-sourced from velesdb-core's
+# `DistanceMetric` / `StorageMode` variants. Immutable tuples of canonical
+# lowercase names, in declaration order.
+DISTANCE_METRICS: Tuple[str, ...]
+STORAGE_MODES: Tuple[str, ...]
+
 
 # ---------------------------------------------------------------------------
 # Structural return types (TypedDict)

--- a/crates/velesdb-python/src/lib.rs
+++ b/crates/velesdb-python/src/lib.rs
@@ -56,6 +56,7 @@ pub use options::{AutoReindexOptions, HnswOptions, LimitsOptions, VelesConfigOpt
 pub use streaming_config::StreamingIngestConfig;
 
 use pyo3::prelude::*;
+use pyo3::types::PyTuple;
 
 /// Search result from a vector query.
 #[pyclass(frozen)]
@@ -115,6 +116,18 @@ fn velesdb(m: &Bound<'_, PyModule>) -> PyResult<()> {
 
     // Typed exception hierarchy (issue #427)
     exceptions::register_exceptions(m)?;
+
+    // Canonical enum name sets, single-sourced from velesdb-core so the
+    // bindings and integrations never drift from the engine's variants.
+    // Exposed as immutable tuples of `str`.
+    m.add(
+        "DISTANCE_METRICS",
+        PyTuple::new(m.py(), velesdb_core::DISTANCE_METRIC_NAMES)?,
+    )?;
+    m.add(
+        "STORAGE_MODES",
+        PyTuple::new(m.py(), velesdb_core::STORAGE_MODE_NAMES)?,
+    )?;
 
     // Add version info
     m.add("__version__", env!("CARGO_PKG_VERSION"))?;

--- a/crates/velesdb-wasm/src/fusion.rs
+++ b/crates/velesdb-wasm/src/fusion.rs
@@ -1,11 +1,15 @@
 //! Result fusion strategies for `VelesDB` WASM.
 //!
-//! Provides different strategies for combining results from multiple queries:
-//! - Average: Mean score across all queries
-//! - Maximum: Highest score from any query  
-//! - RRF: Reciprocal Rank Fusion (position-based)
+//! The four score/rank strategies (`average`, `maximum`, `weighted`, `rrf`)
+//! delegate to the canonical [`velesdb_core::FusionStrategy`] so the browser
+//! engine and the core engine produce identical rankings. The
+//! `relative_score` / `rsf` strategy keeps a WASM-local implementation because
+//! its N-branch equal-weight averaging semantics differ from core's two-branch
+//! (dense + sparse) `RelativeScore` — see [`fuse_relative_score`].
 
 use std::collections::HashMap;
+
+use velesdb_core::FusionStrategy;
 
 /// Fuses results from multiple queries using the specified strategy.
 ///
@@ -28,85 +32,51 @@ pub fn fuse_results(
     strategy: &str,
     rrf_k: u32,
 ) -> Result<Vec<(u64, f32)>, String> {
-    let mut scores: HashMap<u64, Vec<f32>> = HashMap::new();
-    let mut ranks: HashMap<u64, Vec<usize>> = HashMap::new();
-
-    for (query_idx, results) in all_results.iter().enumerate() {
-        for (rank, (id, score)) in results.iter().enumerate() {
-            scores.entry(*id).or_default().push(*score);
-            ranks
-                .entry(*id)
-                .or_insert_with(|| vec![usize::MAX; all_results.len()])[query_idx] = rank;
-        }
+    match strategy.to_lowercase().as_str() {
+        "average" | "avg" => fuse_with_core(all_results, &FusionStrategy::Average),
+        "maximum" | "max" => fuse_with_core(all_results, &FusionStrategy::Maximum),
+        "weighted" => fuse_with_core(
+            all_results,
+            &FusionStrategy::Weighted {
+                avg_weight: 0.5,
+                max_weight: 0.3,
+                hit_weight: 0.2,
+            },
+        ),
+        "rrf" => fuse_with_core(all_results, &FusionStrategy::RRF { k: rrf_k }),
+        "relative_score" | "rsf" => Ok(fuse_relative_score(all_results)),
+        _ => Err(format!(
+            "Unknown fusion strategy '{strategy}'. \
+             Expected one of: average, avg, maximum, max, weighted, \
+             relative_score, rsf, rrf"
+        )),
     }
-
-    let mut fused: Vec<(u64, f32)> = match strategy.to_lowercase().as_str() {
-        "average" | "avg" => fuse_average(&scores),
-        "maximum" | "max" => fuse_maximum(&scores),
-        "weighted" => fuse_weighted(&scores, all_results.len()),
-        "relative_score" | "rsf" => fuse_relative_score(all_results),
-        "rrf" => fuse_rrf(&ranks, rrf_k),
-        _ => {
-            return Err(format!(
-                "Unknown fusion strategy '{strategy}'. \
-                 Expected one of: average, avg, maximum, max, weighted, \
-                 relative_score, rsf, rrf"
-            ));
-        }
-    };
-
-    fused.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
-    Ok(fused)
 }
 
-/// Average fusion: mean score across all queries.
-fn fuse_average(scores: &HashMap<u64, Vec<f32>>) -> Vec<(u64, f32)> {
-    scores
-        .iter()
-        .map(|(id, s)| {
-            let avg = s.iter().sum::<f32>() / s.len() as f32;
-            (*id, avg)
-        })
-        .collect()
-}
-
-/// Maximum fusion: highest score from any query.
-fn fuse_maximum(scores: &HashMap<u64, Vec<f32>>) -> Vec<(u64, f32)> {
-    scores
-        .iter()
-        .map(|(id, s)| {
-            let max = s.iter().copied().fold(f32::NEG_INFINITY, f32::max);
-            (*id, max)
-        })
-        .collect()
-}
-
-/// Weighted fusion: combines average score, max score, and hit ratio.
-///
-/// `score = 0.5 * avg + 0.3 * max + 0.2 * (hits / total_queries)`
-fn fuse_weighted(scores: &HashMap<u64, Vec<f32>>, total_queries: usize) -> Vec<(u64, f32)> {
-    scores
-        .iter()
-        .map(|(id, s)| {
-            let avg = s.iter().sum::<f32>() / s.len() as f32;
-            let max = s.iter().copied().fold(f32::NEG_INFINITY, f32::max);
-            let hit_ratio = s.len() as f32 / total_queries.max(1) as f32;
-            (*id, 0.5 * avg + 0.3 * max + 0.2 * hit_ratio)
-        })
-        .collect()
+/// Delegates to the canonical core fusion and adapts its error to a `String`.
+fn fuse_with_core(
+    all_results: &[Vec<(u64, f32)>],
+    strategy: &FusionStrategy,
+) -> Result<Vec<(u64, f32)>, String> {
+    strategy
+        .fuse(all_results.to_vec())
+        .map_err(|e| e.to_string())
 }
 
 /// Relative Score Fusion: min-max normalizes each query independently.
 ///
-/// Each query's scores are normalized to `[0, 1]`, then averaged per document.
-/// When all scores in a branch are equal (range < epsilon), the normalized
-/// value defaults to 0.5 — consistent with the core engine's
-/// `min_max_normalize` in `crates/velesdb-core/src/fusion/strategy.rs`.
+/// Each query's scores are normalized to `[0, 1]`, then averaged per document
+/// across the queries in which the document appears. When all scores in a
+/// branch are equal (range < epsilon), the normalized value defaults to 0.5 —
+/// consistent with the core engine's `min_max_normalize`.
 ///
-/// **Note:** This WASM implementation is a simplified approximation of the
-/// core `RelativeScore` strategy. The core version is designed for exactly
-/// two branches (dense + sparse) with explicit weights. This WASM version
-/// averages across N branches with equal weights.
+/// **Note:** this is intentionally *not* delegated to
+/// [`velesdb_core::FusionStrategy::RelativeScore`]. Core's `RelativeScore` is a
+/// two-branch (dense + sparse) weighted sum that zero-fills documents missing
+/// from a branch and discards branches beyond index 1. This WASM version
+/// averages across N branches with equal weights and skips missing branches,
+/// which yields a different ranking; converging it onto core would silently
+/// change WASM search results.
 fn fuse_relative_score(all_results: &[Vec<(u64, f32)>]) -> Vec<(u64, f32)> {
     let mut normalized: HashMap<u64, Vec<f32>> = HashMap::new();
     for results in all_results {
@@ -121,7 +91,16 @@ fn fuse_relative_score(all_results: &[Vec<(u64, f32)>]) -> Vec<(u64, f32)> {
             normalized.entry(id).or_default().push(norm);
         }
     }
-    fuse_average(&normalized)
+
+    let mut fused: Vec<(u64, f32)> = normalized
+        .iter()
+        .map(|(id, s)| {
+            let avg = s.iter().sum::<f32>() / s.len() as f32;
+            (*id, avg)
+        })
+        .collect();
+    fused.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+    fused
 }
 
 /// Returns `(min, max)` scores from a result set.
@@ -131,21 +110,6 @@ fn min_max_scores(results: &[(u64, f32)]) -> (f32, f32) {
         .fold((f32::INFINITY, f32::NEG_INFINITY), |(min, max), &(_, s)| {
             (min.min(s), max.max(s))
         })
-}
-
-/// Reciprocal Rank Fusion: position-based scoring.
-fn fuse_rrf(ranks: &HashMap<u64, Vec<usize>>, rrf_k: u32) -> Vec<(u64, f32)> {
-    ranks
-        .iter()
-        .map(|(id, r)| {
-            let rrf_score: f32 = r
-                .iter()
-                .filter(|&&rank| rank != usize::MAX)
-                .map(|&rank| 1.0 / (rrf_k as f32 + rank as f32 + 1.0))
-                .sum();
-            (*id, rrf_score)
-        })
-        .collect()
 }
 
 #[cfg(test)]
@@ -275,5 +239,67 @@ mod tests {
             err.contains("Unknown fusion strategy"),
             "expected descriptive error, got: {err}"
         );
+    }
+
+    /// Equivalence guard: for representative multi-query inputs the four
+    /// delegated strategies (`average`, `maximum`, `weighted`, `rrf`) must
+    /// return the SAME ordering as the corresponding
+    /// [`velesdb_core::FusionStrategy::fuse`] call. `relative_score` is
+    /// intentionally excluded: its N-branch averaging semantics differ from
+    /// core's two-branch `RelativeScore` (documented on `fuse_relative_score`).
+    #[test]
+    fn test_fuse_results_matches_core_ordering() {
+        let inputs: Vec<Vec<Vec<(u64, f32)>>> = vec![
+            vec![
+                vec![(1, 0.9), (2, 0.8), (3, 0.7)],
+                vec![(2, 1.0), (1, 0.5), (4, 0.3)],
+            ],
+            vec![vec![(1, 0.8), (2, 0.6)], vec![(1, 0.6), (2, 0.8)]],
+            vec![vec![(1, 0.9), (2, 0.5)], vec![(1, 0.3), (2, 0.8)]],
+            vec![vec![(1, 0.9), (2, 0.8)]],
+            vec![
+                vec![(10, 0.5), (20, 0.4), (30, 0.9)],
+                vec![(30, 0.1), (40, 0.99), (10, 0.2)],
+                vec![(20, 0.7), (50, 0.6)],
+            ],
+        ];
+
+        let cases: [(&str, FusionStrategy); 4] = [
+            ("average", FusionStrategy::Average),
+            ("maximum", FusionStrategy::Maximum),
+            (
+                "weighted",
+                FusionStrategy::Weighted {
+                    avg_weight: 0.5,
+                    max_weight: 0.3,
+                    hit_weight: 0.2,
+                },
+            ),
+            ("rrf", FusionStrategy::RRF { k: 60 }),
+        ];
+
+        // Tie-break deterministically (score desc, then id asc) so that ties —
+        // whose order depends on non-deterministic HashMap iteration — do not
+        // produce spurious mismatches. Real ranking divergence still shows up
+        // as a different score sequence.
+        let canonical = |mut v: Vec<(u64, f32)>| -> Vec<u64> {
+            v.sort_by(|a, b| {
+                b.1.partial_cmp(&a.1)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+                    .then(a.0.cmp(&b.0))
+            });
+            v.into_iter().map(|(id, _)| id).collect()
+        };
+
+        for input in &inputs {
+            for (name, strategy) in &cases {
+                let wasm = canonical(fuse_results(input, name, 60).unwrap());
+                let core = canonical(strategy.fuse(input.clone()).unwrap());
+                assert_eq!(
+                    wasm, core,
+                    "strategy '{name}' ordering diverged from core for input {input:?}"
+                );
+            }
+        }
     }
 }

--- a/crates/velesdb-wasm/src/fusion.rs
+++ b/crates/velesdb-wasm/src/fusion.rs
@@ -6,6 +6,17 @@
 //! `relative_score` / `rsf` strategy keeps a WASM-local implementation because
 //! its N-branch equal-weight averaging semantics differ from core's two-branch
 //! (dense + sparse) `RelativeScore` — see [`fuse_relative_score`].
+//!
+//! Branch-arity split (why `rsf` is *not* converged here): the only production
+//! caller of [`fuse_results`] is `multi_query_search`, which fuses one branch
+//! per query vector, so the branch count is the user-supplied query count —
+//! genuinely N, with no dense/sparse distinction. Core's `RelativeScore` is
+//! defined only for the 2-branch dense+sparse hybrid (it discards branches
+//! beyond index 1), so delegating this N-branch path to it would silently drop
+//! results. The 2-branch hybrid that *does* match core's contract — the
+//! VelesQL `USING FUSION (strategy='rsf')` clause — already routes through core
+//! (`crate::velesql_fusion::build_rsf` → `FusionStrategy::relative_score`), so
+//! only the genuinely-N path stays WASM-local.
 
 use std::collections::HashMap;
 
@@ -209,6 +220,63 @@ mod tests {
         let fused = fuse_results(&results, "rsf", 60).unwrap();
         // "rsf" should behave like "relative_score"
         assert_eq!(fused.len(), 2);
+    }
+
+    /// Pins the *intentional* divergence between this WASM N-branch
+    /// `relative_score` and core's two-branch
+    /// [`velesdb_core::FusionStrategy::RelativeScore`] for the production
+    /// arity (`multi_query_search` fuses one branch per query vector, so N is
+    /// the user-supplied query count — genuinely N, not a fixed dense+sparse 2).
+    ///
+    /// Core's `RelativeScore` only consumes branches 0 and 1 (dense + sparse)
+    /// and discards the rest; this WASM path averages all N normalized branches.
+    /// They MUST keep producing a different ranking — if a future change tries
+    /// to "also delegate rsf to core", this test fails loudly instead of
+    /// silently corrupting multi-query WASM search results.
+    #[test]
+    fn test_rsf_n_branch_diverges_from_core_relative_score() {
+        // 3 homogeneous dense-query branches (N > 2).
+        let input: Vec<Vec<(u64, f32)>> = vec![
+            vec![(1, 0.9), (2, 0.1), (3, 0.5)],
+            vec![(1, 0.2), (2, 0.8)],
+            vec![(3, 1.0), (1, 0.0)],
+        ];
+
+        let wasm_order: Vec<u64> = fuse_results(&input, "relative_score", 60)
+            .unwrap()
+            .into_iter()
+            .map(|(id, _)| id)
+            .collect();
+
+        // WASM averages every branch: id3 wins (0.75), id2 (0.5), id1 (0.333).
+        assert_eq!(
+            wasm_order,
+            vec![3, 2, 1],
+            "WASM rsf must average all N branches"
+        );
+
+        // Core discards branch index >= 2, so id3 (only present in branch 2)
+        // collapses to its dense contribution alone and sinks to the bottom.
+        let core_strategy = FusionStrategy::relative_score(0.5, 0.5).unwrap();
+        let core_order: Vec<u64> = core_strategy
+            .fuse(input.clone())
+            .unwrap()
+            .into_iter()
+            .map(|(id, _)| id)
+            .collect();
+        assert_eq!(
+            core_order.last().copied(),
+            Some(3),
+            "core RelativeScore ranks the discarded-branch id last"
+        );
+
+        // WASM ranks id3 first, core ranks it last: the orderings genuinely
+        // diverge, so forcing convergence onto core would be a silent
+        // multi-query ranking regression. The split is deliberate.
+        assert_ne!(
+            wasm_order, core_order,
+            "N-branch rsf must diverge from core's 2-branch RelativeScore"
+        );
     }
 
     /// BUG regression (PR #556): when all scores in a branch are equal

--- a/crates/velesdb-wasm/src/lib.rs
+++ b/crates/velesdb-wasm/src/lib.rs
@@ -188,3 +188,7 @@ mod velesql_exec_hybrid_tests;
 #[cfg(test)]
 #[path = "velesql_exec_graph_tests.rs"]
 mod velesql_exec_graph_tests;
+
+#[cfg(test)]
+#[path = "velesql_executor_conformance_tests.rs"]
+mod velesql_executor_conformance_tests;

--- a/crates/velesdb-wasm/src/velesql_executor_conformance_tests.rs
+++ b/crates/velesdb-wasm/src/velesql_executor_conformance_tests.rs
@@ -1,0 +1,152 @@
+//! Executor-level VelesQL conformance for the WASM executor.
+//!
+//! Companion to `velesdb-core/tests/velesql_executor_conformance.rs`. Loads the
+//! SAME golden fixture (`conformance/velesql_executor_cases.json`), builds the
+//! dataset **through the WASM executor** (`INSERT INTO ... VALUES`), runs each
+//! case query through `velesql_exec::execute`, and asserts the result ids and
+//! ordering match the golden `expect_ids` derived from `velesdb-core`.
+//!
+//! Native-target test (`#[test]`, not `wasm_bindgen_test`) that exercises
+//! `DatabaseInner` through the executor dispatcher, mirroring
+//! `velesql_exec_tests.rs`. The internal `DatabaseInner` / `execute` symbols
+//! are `pub(crate)`, so this suite lives in-crate (like the other
+//! `velesql_exec_*` test modules) rather than under `tests/`.
+//!
+//! # Case coverage
+//!
+//! All five `cases` (X001–X005) are runnable by the WASM executor (scalar
+//! WHERE filter + ORDER BY on a payload column, no LIMIT-before-sort path) and
+//! are asserted against the golden ids.
+//!
+//! # known_bugs (B001)
+//!
+//! B001 is the core bug where `ORDER BY <column> + LIMIT` applies the LIMIT
+//! before the sort on the bounded top-k path. The WASM SELECT pipeline
+//! (`velesql_select::finalize_plain`) sorts the full row set *first* and only
+//! then applies `skip(offset).take(limit)`, so it does NOT reproduce B001 — it
+//! already returns the CORRECT golden result. The B001 case is therefore
+//! asserted directly here as a non-bug for WASM (no `#[ignore]`).
+
+use crate::database::DatabaseInner;
+use crate::velesql_exec::execute;
+
+use serde::Deserialize;
+use serde_json::Value;
+use std::path::PathBuf;
+
+#[derive(Deserialize)]
+struct Fixture {
+    dataset: Dataset,
+    cases: Vec<Case>,
+    #[serde(default)]
+    known_bugs: Vec<Case>,
+}
+
+#[derive(Deserialize)]
+struct Dataset {
+    collection: String,
+    dimension: usize,
+    metric: String,
+    points: Vec<FixturePoint>,
+}
+
+#[derive(Deserialize)]
+struct FixturePoint {
+    id: u64,
+    vector: Vec<f32>,
+    payload: Value,
+}
+
+#[derive(Deserialize)]
+struct Case {
+    id: String,
+    query: String,
+    expect_ids: Vec<u64>,
+}
+
+fn fixture_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../conformance/velesql_executor_cases.json")
+}
+
+fn load_fixture() -> Fixture {
+    let content = std::fs::read_to_string(fixture_path()).expect("test: read executor fixture");
+    serde_json::from_str(&content).expect("test: parse executor fixture")
+}
+
+/// Renders a payload scalar as a VelesQL literal (quoting strings).
+fn payload_literal(v: &Value) -> String {
+    match v {
+        Value::String(s) => format!("'{}'", s.replace('\'', "''")),
+        other => other.to_string(),
+    }
+}
+
+/// Builds the dataset *through the WASM executor* by issuing one
+/// `INSERT INTO <coll> (id, vector, <payload keys...>) VALUES (...)` per point,
+/// with the vector bound to the `$v` parameter (the canonical WASM vector-
+/// insert contract — inline vector literals are unsupported).
+fn build_dataset(ds: &Dataset) -> DatabaseInner {
+    let mut db = DatabaseInner::new();
+    db.create_collection(&ds.collection, ds.dimension, &ds.metric)
+        .expect("test: create dataset collection");
+
+    for point in &ds.points {
+        let Value::Object(obj) = &point.payload else {
+            panic!("test: fixture payload must be a JSON object");
+        };
+        let mut columns = vec!["id".to_string(), "vector".to_string()];
+        let mut values = vec![point.id.to_string(), "$v".to_string()];
+        for (key, val) in obj {
+            columns.push(key.clone());
+            values.push(payload_literal(val));
+        }
+        let sql = format!(
+            "INSERT INTO {} ({}) VALUES ({})",
+            ds.collection,
+            columns.join(", "),
+            values.join(", ")
+        );
+        let vector_json =
+            serde_json::to_string(&point.vector).expect("test: serialize fixture vector");
+        let params = format!("{{\"v\": {vector_json}}}");
+        execute(&mut db, &sql, Some(&params))
+            .unwrap_or_else(|e| panic!("test: seed point {} failed: {e}", point.id));
+    }
+    db
+}
+
+/// Runs every case through the WASM executor and asserts ids + ordering.
+fn assert_cases(db: &mut DatabaseInner, cases: &[Case]) {
+    for case in cases {
+        let result = execute(db, &case.query, None)
+            .unwrap_or_else(|e| panic!("case {} failed to execute: {e}", case.id));
+        let ids: Vec<u64> = result
+            .rows_ref()
+            .iter()
+            .map(crate::velesql_result::QueryResultRow::id)
+            .collect();
+        assert_eq!(
+            ids, case.expect_ids,
+            "WASM executor conformance mismatch for case {}: query={:?}",
+            case.id, case.query
+        );
+    }
+}
+
+/// All golden `cases` (X001–X005) must reproduce the core result set exactly.
+#[test]
+fn test_wasm_velesql_executor_conformance_fixture_cases() {
+    let fixture = load_fixture();
+    let mut db = build_dataset(&fixture.dataset);
+    assert_cases(&mut db, &fixture.cases);
+}
+
+/// B001 is a core-only bug: the WASM SELECT pipeline sorts before applying
+/// LIMIT, so it returns the CORRECT golden result. Asserting it here locks in
+/// that the WASM executor is NOT affected by the core bounded-top-k bug.
+#[test]
+fn test_wasm_velesql_executor_known_bugs_are_correct() {
+    let fixture = load_fixture();
+    let mut db = build_dataset(&fixture.dataset);
+    assert_cases(&mut db, &fixture.known_bugs);
+}

--- a/docs/planning/CORE_PARITY_REMEDIATION.md
+++ b/docs/planning/CORE_PARITY_REMEDIATION.md
@@ -1,0 +1,47 @@
+# Core ↔ Children Parity & Architecture Remediation Plan
+
+Status: **in progress** — opened 2026-06-14 after the core-vs-ecosystem gap + architecture audit.
+Re-runnable any time via the `/core-parity-audit` skill (`.claude/skills/core-parity-audit/`).
+
+## Context (the audit verdict)
+
+`velesdb-core` is the single source of truth, and the architecture is **clean**: dependency
+direction is a perfect star (core out-degree 0, no inversions, no cycles); children legitimately
+add idiomatic surface. The only real signal is a handful of spots where a **child forks canonical
+logic instead of calling core** — none questions core. User-facing feature parity is caught up;
+the residual gaps are core-internal/ops plumbing (by design) or already tracked in
+`docs/reference/ECOSYSTEM_PARITY.md` "Remaining Gaps".
+
+## TODOs
+
+| # | Item | Rationale | Effort | Risk / guard-rail | License lens |
+|---|------|-----------|--------|-------------------|--------------|
+| **T1** | WASM `crates/velesdb-wasm/src/fusion.rs` → call `velesdb_core::FusionStrategy::fuse` instead of re-implementing all 5 strategies | Removes fusion-ranking divergence (WASM computes locally, no server) | M | **Touches ranking → QUALITY_BAR Gate 1 recall@10 ≥ 0.95.** Add WASM-vs-core fusion equivalence test. Guarded by T2. | Core-licensed, pure architecture |
+| **T2** | Executor-level conformance fixtures for WASM (+CLI): compare result rows/counts/ordering, not just parse-ok (`conformance/velesql_parser_cases.json` is parser-only today) | Auto-catches future JOIN/agg/setops divergence; safety net for T1 | M | test-only; **do FIRST** | Core |
+| **T3** | ID-hash single-sourcing: Haystack imports `velesdb_common.ids.stable_hash_id` (delete `_str_id_to_int`). migrate `stable_point_id` (numeric-else-FNV-1a) is intentionally different for checkpoint resumability → **document, do NOT change** | Same logical doc must map to the same point ID across components | S | bit-identical today → no data migration | Haystack is **MIT** touching ID logic → escalated; valid fix = call shared helper |
+| **T4** | Mobile: re-export core `GraphNode/GraphEdge/TraversalResult/GraphSchema` via UniFFI instead of redefining `MobileGraphNode/Edge/...` (already diverged: core `TraversalResult.path: Vec<u64>` absent in mobile). The forked `MobileGraphStore` engine itself = design decision, not a rewrite | Stops type shadowing / divergence | M | changes Swift/Kotlin API shape → care | Core |
+| **T5** | LangChain/`integrations/common` re-declare `ALLOWED_METRICS`/`ALLOWED_STORAGE_MODES` parallel to the Rust enums → derive from the binding or single-source with a sync test | Avoid enum-set drift | S | low | MIT layer; keep canonical set sourced from core |
+| **T6** | Docs: add the 3 architecture limitations to `KNOWN_LIMITATIONS.md` (ID-hash interop, WASM/CLI parser-only conformance, WASM fusion fork until T1) + thicken thin user-facing topics (HNSW tuning at create, collection-diagnostics, CollectionType, metadata upsert) | Real doc gap surfaced by the audit | S | doc-only | Core |
+
+### Explicitly NOT doing (kept relevant)
+- Do **not** expose core-internal metrics / durability / ColumnStore-batch / registry-introspection over bindings just to fill the matrix — by-design internal surface.
+- Do **not** change migrate's `stable_point_id` algorithm — it would break existing resumable checkpoints (see `KNOWN_LIMITATIONS.md` #4). Document the intentional difference instead.
+- Do **not** rewrite `MobileGraphStore`'s in-memory engine — only fix the type shadowing (T4).
+- Pre-existing tracked parity gaps (RSF in Haystack, named-sparse-index *creation* in LangChain/LlamaIndex, `@collection` MATCH propagation) stay in `ECOSYSTEM_PARITY.md` "Remaining Gaps" / roadmap.
+
+## Waves (each item = a feature branch off `develop` → PR, per Git Flow)
+
+- **Wave 1 — safety net + quick wins (no search path):** T2, T3-Haystack, T5.  ← *in progress*
+- **Wave 2 — divergence removal:** T1 (under the recall gate, protected by T2's net), T4 type re-export.
+- **Wave 3 — docs:** T6.
+
+EPIC IDs: highest referenced today is EPIC-078 → candidates EPIC-079…084 (confirm next free ID in the tracker before tagging code TODOs).
+
+## Artifacts produced by the audit
+- `PARITY_MATRIX.md` (81 capabilities × 13 components) — regenerate via `.claude/skills/core-parity-audit/scripts/gen_matrix.py`.
+- `/core-parity-audit` skill — re-runs the whole analysis (code + docs), core = source of truth, VelesDB Core License boundary enforced.
+
+## Resume pointer
+If context is cleared: read this file + memory `core-children-arch-audit-2026-06-14` and
+`core-source-of-truth-rule`. Wave 1 branches: `feature/velesql-executor-conformance` (T2),
+`feature/idhash-haystack-single-source` (T3), `feature/integration-enum-single-source` (T5).

--- a/docs/planning/CORE_PARITY_REMEDIATION.md
+++ b/docs/planning/CORE_PARITY_REMEDIATION.md
@@ -35,7 +35,48 @@ the residual gaps are core-internal/ops plumbing (by design) or already tracked 
 - **Wave 2 — divergence removal:** T1 (under the recall gate, protected by T2's net), T4 type re-export.
 - **Wave 3 — docs:** T6.
 
-EPIC IDs: highest referenced today is EPIC-078 → candidates EPIC-079…084 (confirm next free ID in the tracker before tagging code TODOs).
+EPIC IDs: highest referenced today is EPIC-080 (`ci.yml`) → candidates EPIC-081… (confirm next free ID in the tracker before tagging code TODOs).
+
+## EPIC-081 (proposed) — Ordered-index `ORDER BY <col> LIMIT k` pushdown (B001 perf follow-up)
+
+**Why.** The B001 fix made scalar `ORDER BY <col> … LIMIT k` *correct* by fetching the full
+matching set before sorting — but at O(n): measured **312 ms** for `ORDER BY year DESC LIMIT 10`
+over 50k rows (capped at `MAX_LIMIT`=100k). An ordered index serves top-k without scanning all rows.
+
+**Substrate decision (from the design fan-out).** Build on **`SecondaryIndex::BTree`**
+(`crates/velesdb-core/src/index/secondary/mod.rs`) — the only flat-payload ordered structure that is
+actually *populated and maintained* on upsert/delete/bulk, keyed by field name, with a total-`Ord`
+`JsonValue` key. **Do not** use `RangeIndex` (`collection/graph/range_index.rs`): it is **inert**
+(`self.range_index.insert` is never called from any CRUD path), label-bound, and its range queries
+return *unordered* bitmaps. Tradeoff: `SecondaryIndex` is **not snapshotted** (rebuilt on `create_index`
+via backfill), so the optimization is **opt-in per field** — which matches existing secondary-index
+semantics and needs no new persistence format. (A later phase may add snapshotting in `flush.rs`.)
+
+**Phase 1 — primitive (DONE, on this branch).** `SecondaryIndex::ordered_ids(descending, limit)` +
+6 golden tests (`ordered_ids_tests.rs`). Pure BTreeMap walk (`.values()`, `.rev()` for DESC), O(log n + k),
+ascending IDs within an equal-key bucket for determinism. Currently `#[allow(dead_code)]` (no consumer yet).
+
+**Phase 2 — minimal planner routing (gated hard).** At the B001 hook
+`Collection::order_by_requires_exhaustive_fetch` (`select_dispatch.rs:98`), add an `Option<OrderedScanPlan>`
+that fires **only** when ALL hold: primary `ORDER BY` is a single plain `Field` (not Aggregate/Arithmetic/
+similarity); that field has a secondary index; the field is **fully covered** (index id-count == point count —
+no missing/JSON-null rows, which a full sort places first/last but the index omits); and there is **no**
+WHERE / JOIN / graph / DISTINCT / vector-search. Then fetch the top-k IDs from `ordered_ids`, **snapshot the
+IDs and release the index lock before hydrating** (`get(ids)` re-reads payload, so it tolerates concurrent
+writes and respects lock ordering), and skip the `MAX_LIMIT` exhaustive fetch + in-memory sort. Else fall
+straight through to today's exact behavior — zero change. **The similarity() HNSW fast path is untouched**
+(the hook already returns false for a leading `similarity()` key).
+
+**Gate (Phase 2).** A correctness matrix asserting the index path's result **equals** the unbounded sort
+truncated to k (KNOWN_LIMITATIONS #9) across ASC/DESC × {OFFSET, ties, exact-k, k>n}; an explicit
+tie-determinism decision (the full-scan uses an *unstable* sort, so ties have no canonical order — the index
+path is deterministic by ID, arguably better but a behavior change to ratify); a recall@10 non-regression run;
+and a perf benchmark showing sub-linear top-k vs the 312 ms/50k baseline. Disable the route entirely for any
+collection containing an id > `u32::MAX` (the bitmap paths can't represent it).
+
+**Phase 3 — broaden (separate, optional).** WHERE-filtered top-k (walk the index in order, apply the
+prefilter, stop at k); multi-column `ORDER BY` (index prunes lead-key groups, secondary sort within each);
+secondary-index snapshotting for auto-persistence; an auto-index advisor for hot `ORDER BY` fields.
 
 ## Artifacts produced by the audit
 - `PARITY_MATRIX.md` (81 capabilities × 13 components) — regenerate via `.claude/skills/core-parity-audit/scripts/gen_matrix.py`.

--- a/docs/reference/ECOSYSTEM_PARITY.md
+++ b/docs/reference/ECOSYSTEM_PARITY.md
@@ -58,7 +58,7 @@ Legend: ✅ full support | ⚠️ partial / limited | ❌ not supported | N/A no
 - **Batch Operations**: WASM and Mobile use streaming chunked inserts instead of single-call bulk to stay within memory constraints. WASM additionally exposes a single-call raw-bulk path via `VectorStore.insertBatchRaw` (see the Raw-Bulk Insert note).
 - **Streaming Ingestion** (2026-06-14): Core, Server (`POST /collections/{name}/stream/enable` + `/stream/insert`), Python, Tauri, Mobile (`enableStreaming()` / `streamInsert()` on its own tokio streaming runtime), and the TS SDK (`enableStreaming()` / `streamInsert()`, REST backend) support the bounded ingestion channel. The CLI reaches it ⚠️ via the embedded core path with no dedicated REPL command. WASM throws `NOT_SUPPORTED` (no persistence layer). Only the LangChain/LlamaIndex/Haystack integrations do not yet expose it.
 - **Raw-Bulk Insert** (2026-06-14): the zero-copy raw-bulk path is now exposed by Core (`upsert_bulk_from_raw`), Server (`POST /collections/{name}/points/raw`, VRB1 binary), the TS SDK (`upsertBatchRaw`), WASM (`VectorStore.insertBatchRaw(ids, vectors, dim)`, writing into its in-memory buffer), and the CLI (`velesdb data import <file.bin>`, VRB1 binary). Mobile remains a follow-up. All surfaces share the one `velesdb_core::wire::vrb1` codec.
-- **Multi-Query Fusion (RSF/Weighted)**: WASM supports RRF only. LangChain and LlamaIndex expose RSF/Weighted through `multi_query_search(fusion=...)`, which delegates to the shared `velesdb_common.fusion.build_fusion_strategy` (builds `weighted()` and `relative_score()`). Haystack remains ⚠️: fusion is reachable only via the underlying `velesdb` Python wrapper, not through the `DocumentStore` protocol.
+- **Multi-Query Fusion (RSF/Weighted)** (2026-06-14): WASM's multi-query `fuse_results` now delegates **4 of its 5 strategies** (`average`, `maximum`, `weighted`, `rrf`) to the canonical `velesdb_core::FusionStrategy::fuse`, so the browser engine reproduces core's ranking 1:1 for those (`crates/velesdb-wasm/src/fusion.rs`; equivalence pinned by `test_fuse_results_matches_core_ordering`). The fifth strategy, `relative_score` / `rsf`, is **intentionally kept WASM-local**: core's `RelativeScore` is a two-branch (dense + sparse) weighted sum that zero-fills documents missing from a branch and discards branches beyond index 1, whereas WASM's is an N-branch equal-weight average that skips missing branches. The two semantics yield different rankings, so converging WASM onto core would silently change WASM search results — that convergence is a product decision deferred to a follow-up, and `relative_score` behaviour is unchanged. (This is the multi-query fusion entry point; the VelesQL `USING FUSION (...)` clause executor in `velesql_fusion.rs` already builds every strategy — including RSF — directly from `velesdb_core::fusion::FusionStrategy`.) LangChain and LlamaIndex expose RSF/Weighted through `multi_query_search(fusion=...)`, which delegates to the shared `velesdb_common.fusion.build_fusion_strategy` (builds `weighted()` and `relative_score()`). Haystack remains ⚠️: fusion is reachable only via the underlying `velesdb` Python wrapper, not through the `DocumentStore` protocol.
 - **Sparse Vector Search (named indexes) — LangChain/LlamaIndex**: ⚠️ query-side only. Both integrations forward a `sparse_index_name` argument to the underlying `collection.search`/`hybrid_search`, so an existing named sparse index can be *queried*. Creating named sparse indexes is not exposed by the integrations (use the core `velesdb` API), and this path is not yet covered by integration tests.
 - **Graph Operations (WASM)**: Basic node/edge CRUD is supported; multi-hop traversal and MATCH queries are limited.
 - **VelesQL (LangChain/LlamaIndex/Haystack)**: Pass-through to Python bindings works for simple queries; full parser integration is not surfaced in the integration API.
@@ -105,9 +105,17 @@ Legend: ✅ full support | ⚠️ partial / limited | ❌ not supported | N/A no
 |---------|---------|------|
 | Server REST contract | `conformance/velesql_contract_cases.json` | `crates/velesdb-server/tests/velesql_conformance_tests.rs` |
 | TypeScript SDK contract mapping | `conformance/velesql_contract_cases.json` | `sdks/typescript/tests/velesql-contract-fixtures.test.ts` |
+| Core executor (rows/counts/ordering) | `conformance/velesql_executor_cases.json` | `crates/velesdb-core/tests/velesql_executor_conformance.rs` |
 | Core parser | `conformance/velesql_parser_cases.json` | `crates/velesdb-core/tests/velesql_parser_conformance.rs` |
 | CLI parser | `conformance/velesql_parser_cases.json` | `crates/velesdb-cli/tests/velesql_parser_conformance.rs` |
 | WASM parser | `conformance/velesql_parser_cases.json` | `crates/velesdb-wasm/tests/velesql_parser_conformance.rs` |
+
+The executor fixture (added 2026-06-14) asserts the exact result set (ids,
+count, ordering) the core executor produces for a fixed dataset, so a future
+WASM/CLI executor divergence fails CI rather than going unnoticed. WASM and CLI
+executor parity is **not yet** fixture-checked against these goldens — extending
+the executor net to those two runtimes is the open follow-up tracked in
+[KNOWN_LIMITATIONS #13](./KNOWN_LIMITATIONS.md#13-velesql-conformance-for-wasmcli-is-parser-only).
 
 ## Enum Propagation Matrix
 
@@ -218,10 +226,17 @@ collection creation; only Haystack is limited by its DocumentStore protocol.
 
 ---
 
+## Recently Landed (2026-06-14)
+
+- **WASM fusion now delegates 4/5 strategies to core.** `average`/`maximum`/`weighted`/`rrf` map onto `velesdb_core::FusionStrategy::fuse` (ranking identical to core, pinned by an equivalence test); `relative_score`/`rsf` stays WASM-local by design because its N-branch equal-weight semantics differ from core's two-branch dense+sparse weighted sum. See the RSF/Weighted note above.
+- **Executor-level conformance now exists for core.** `conformance/velesql_executor_cases.json` + `crates/velesdb-core/tests/velesql_executor_conformance.rs` assert result rows/counts/ordering (not just that a query parses). Extending the same goldens to the WASM and CLI executors is the remaining step (action item 2).
+- **Scalar `ORDER BY` + `LIMIT` correctness bug fixed.** A scalar (non-`similarity()`) `ORDER BY <col> ... LIMIT k` previously truncated to `k` in storage order *before* sorting; it now fetches the full matching set so the sort precedes truncation, restoring the [KNOWN_LIMITATIONS #9](./KNOWN_LIMITATIONS.md#9-bounded-query-result-materialization) bounded==unbounded guarantee. The `similarity()`-ordered HNSW fast path was untouched, so recall is unaffected. (Surfaced by the new executor conformance net above.)
+- **Point-ID hashing single-sourced for Haystack.** The Haystack `DocumentStore` now imports the canonical `velesdb_common.ids.stable_hash_id` instead of a bit-identical forked copy (behaviour-preserving; removes a re-implemented hash from an MIT package). The intentional remaining divergence — `velesdb-migrate`'s distinct `stable_point_id` — is documented in [KNOWN_LIMITATIONS #12](./KNOWN_LIMITATIONS.md#12-string--u64-point-id-hashing-differs-across-components).
+
 ## Remaining Gaps and Action Items
 
 1. Add explicit server-side end-to-end assertions for the REST error shape (`code/hint/details`) beyond parser conformance. (The CLI has no HTTP layer — it executes against embedded core — so the REST error-shape contract belongs to `velesdb-server`.)
-2. Extend WASM conformance from parser-only to executable feature checks where applicable.
+2. Extend the executor-level conformance net (now established for **core** via `conformance/velesql_executor_cases.json`) to the **WASM** and **CLI** runtimes so a result-shape divergence on those surfaces fails CI. (Parser conformance already covers all three; see [KNOWN_LIMITATIONS #13](./KNOWN_LIMITATIONS.md#13-velesql-conformance-for-wasmcli-is-parser-only).)
 3. Keep docs, fixtures, and examples synchronized on every contract version change.
 4. Promote RaBitQ from experimental to stable once the API is finalized.
 5. Surface RSF/Weighted fusion in Haystack (already exposed in LangChain and

--- a/docs/reference/KNOWN_LIMITATIONS.md
+++ b/docs/reference/KNOWN_LIMITATIONS.md
@@ -207,6 +207,65 @@ per-artifact load-time validation (file-length-bounded counts).
 
 ---
 
+## Ecosystem / interop
+
+### 12. String → u64 point-ID hashing differs across components
+
+**Status**: documented trade-off (intentional). Sources: `integrations/common/src/velesdb_common/ids.py` (`stable_hash_id`, used by LangChain/LlamaIndex); `integrations/haystack/src/haystack_velesdb/document_store.py` (`_str_id_to_int`, same algorithm); `crates/velesdb-migrate/src/pipeline_points.rs` (`stable_point_id`).
+
+VelesDB point IDs are `u64`. Components that ingest documents keyed by an
+arbitrary string derive the numeric ID with **two intentionally different**
+hash strategies:
+
+| Component | Function | Strategy |
+|-----------|----------|----------|
+| LangChain / LlamaIndex | `velesdb_common.ids.stable_hash_id` | SHA-256 of the UTF-8 string, top 8 bytes, sign bit cleared → positive 63-bit ID |
+| Haystack | `_str_id_to_int` (local, identical algorithm) | same SHA-256 / 63-bit mapping as `stable_hash_id` |
+| `velesdb-migrate` | `stable_point_id` | numeric strings parsed directly to `u64`; non-numeric strings hashed via FNV-1a |
+
+These do not agree. The `velesdb-migrate` strategy is deliberately distinct: it
+parses numeric IDs verbatim so a source row keyed `"12345"` maps to point
+`12345`, and its FNV-1a fallback is frozen for **checkpoint-resumable**
+migrations (changing it would re-key already-inserted points and corrupt a
+resumed run — see the stability note in the source).
+
+**User impact**: the *same* logical document can land under **different point
+IDs** depending on the ingestion path. A corpus loaded via `velesdb-migrate`
+and the same corpus loaded via the LangChain/LlamaIndex/Haystack vector store
+will not share point IDs, so cross-referencing or de-duplicating across the two
+paths by point ID is not reliable. Pick a single ingestion path per collection,
+or map on a payload field (e.g. a stored `source_id`) rather than on the
+numeric point ID.
+
+---
+
+## Tooling / test coverage
+
+### 13. VelesQL conformance for WASM/CLI is parser-only
+
+**Status**: open (coverage gap). Sources: `crates/velesdb-wasm/tests/velesql_parser_conformance.rs`, `crates/velesdb-cli/tests/velesql_parser_conformance.rs` (parser fixture); `crates/velesdb-server/tests/velesql_conformance_tests.rs` (executor contract fixture).
+
+The shared VelesQL conformance fixtures come in two layers. The
+`velesql_parser_cases.json` layer (does this query parse?) is checked across
+**core, WASM, and CLI** — all three run the same `Parser::parse` assertions.
+The `velesql_contract_cases.json` layer (does this query *execute* and return
+the contracted result/error shape?) is currently exercised at the **server**
+runtime only.
+
+**What remains open**: executor result-level conformance is being added for the
+**core** runtime; **WASM** and **CLI** executor result parity is **not yet
+fixture-checked**. The WASM and CLI surfaces share the same `velesdb-core`
+executor, so a query that parses identically across the three is expected to
+execute identically — but that expectation is asserted today only for the
+server, not pinned by a per-runtime executor fixture for WASM/CLI.
+
+**User impact**: a result-shape divergence specific to the WASM or CLI surface
+(e.g. a serialization or projection difference) would not be caught by the
+conformance suite until executor-level fixtures cover those runtimes. Parser
+acceptance — which features parse — is fully covered for all three.
+
+---
+
 ## Reading this document
 
 Each entry states:

--- a/docs/reference/KNOWN_LIMITATIONS.md
+++ b/docs/reference/KNOWN_LIMITATIONS.md
@@ -158,6 +158,12 @@ fetch for that one operator.) The `similarity()`-ordered HNSW path stays bounded
 top-k — it is pre-sorted by score, so truncation is correct without an
 exhaustive fetch and recall is unaffected.
 
+The O(n) cost of that exhaustive scalar-`ORDER BY` fetch (~312 ms for `ORDER BY
+year DESC LIMIT 10` over 50k rows) is addressed by an ordered-index pushdown
+tracked in `docs/planning/CORE_PARITY_REMEDIATION.md` (EPIC-081): its load-bearing
+primitive `SecondaryIndex::ordered_ids` (O(log n + k)) has landed; the gated
+planner routing is the next phase.
+
 ### 10. Configuration range caps
 
 **Status**: resolved (validated in every loader and on open; the `limits.*`

--- a/docs/reference/KNOWN_LIMITATIONS.md
+++ b/docs/reference/KNOWN_LIMITATIONS.md
@@ -148,7 +148,15 @@ Result materialization for top-k scans, JOIN, parallel graph traversal, and
 set operations (UNION/INTERSECT) is bounded by the effective LIMIT via bounded
 top-k rather than collect-all-then-truncate. Results are identical to the
 unbounded path; only peak memory is bounded. Intermediate operators that can
-legitimately drop rows fall back to the conservative server-side ceiling.
+legitimately drop rows fall back to the conservative server-side ceiling — this
+includes a scalar (non-`similarity()`) `ORDER BY ... LIMIT k`, which must rank
+the full matching set before truncating, so it fetches exhaustively rather than
+bounding the fetch at `k`. (Capping the fetch at `k` first was the
+`ORDER BY`-before-sort defect fixed 2026-06-14; the bounded==unbounded identity
+above now holds for scalar `ORDER BY` as well, at the cost of an exhaustive
+fetch for that one operator.) The `similarity()`-ordered HNSW path stays bounded
+top-k — it is pre-sorted by score, so truncation is correct without an
+exhaustive fetch and recall is unaffected.
 
 ### 10. Configuration range caps
 
@@ -211,16 +219,16 @@ per-artifact load-time validation (file-length-bounded counts).
 
 ### 12. String → u64 point-ID hashing differs across components
 
-**Status**: documented trade-off (intentional). Sources: `integrations/common/src/velesdb_common/ids.py` (`stable_hash_id`, used by LangChain/LlamaIndex); `integrations/haystack/src/haystack_velesdb/document_store.py` (`_str_id_to_int`, same algorithm); `crates/velesdb-migrate/src/pipeline_points.rs` (`stable_point_id`).
+**Status**: documented trade-off (intentional). Sources: `integrations/common/src/velesdb_common/ids.py` (`stable_hash_id`, the single source shared by LangChain, LlamaIndex, **and** Haystack since 2026-06-14); `integrations/haystack/src/haystack_velesdb/document_store.py` (now imports `stable_hash_id` — the previous forked `_str_id_to_int` copy was removed); `crates/velesdb-migrate/src/pipeline_points.rs` (`stable_point_id`).
 
 VelesDB point IDs are `u64`. Components that ingest documents keyed by an
 arbitrary string derive the numeric ID with **two intentionally different**
-hash strategies:
+hash strategies — every Python integration now shares one, and `velesdb-migrate`
+keeps its deliberately distinct one:
 
 | Component | Function | Strategy |
 |-----------|----------|----------|
-| LangChain / LlamaIndex | `velesdb_common.ids.stable_hash_id` | SHA-256 of the UTF-8 string, top 8 bytes, sign bit cleared → positive 63-bit ID |
-| Haystack | `_str_id_to_int` (local, identical algorithm) | same SHA-256 / 63-bit mapping as `stable_hash_id` |
+| LangChain / LlamaIndex / Haystack | `velesdb_common.ids.stable_hash_id` (shared) | SHA-256 of the UTF-8 string, top 8 bytes, sign bit cleared → positive 63-bit ID |
 | `velesdb-migrate` | `stable_point_id` | numeric strings parsed directly to `u64`; non-numeric strings hashed via FNV-1a |
 
 These do not agree. The `velesdb-migrate` strategy is deliberately distinct: it
@@ -243,21 +251,22 @@ numeric point ID.
 
 ### 13. VelesQL conformance for WASM/CLI is parser-only
 
-**Status**: open (coverage gap). Sources: `crates/velesdb-wasm/tests/velesql_parser_conformance.rs`, `crates/velesdb-cli/tests/velesql_parser_conformance.rs` (parser fixture); `crates/velesdb-server/tests/velesql_conformance_tests.rs` (executor contract fixture).
+**Status**: open (coverage gap, narrowed 2026-06-14). Sources: `crates/velesdb-wasm/tests/velesql_parser_conformance.rs`, `crates/velesdb-cli/tests/velesql_parser_conformance.rs` (parser fixture); `crates/velesdb-server/tests/velesql_conformance_tests.rs` (server executor contract fixture); `crates/velesdb-core/tests/velesql_executor_conformance.rs` + `conformance/velesql_executor_cases.json` (core executor result fixture).
 
-The shared VelesQL conformance fixtures come in two layers. The
+The shared VelesQL conformance fixtures come in layers. The
 `velesql_parser_cases.json` layer (does this query parse?) is checked across
 **core, WASM, and CLI** — all three run the same `Parser::parse` assertions.
 The `velesql_contract_cases.json` layer (does this query *execute* and return
-the contracted result/error shape?) is currently exercised at the **server**
-runtime only.
+the contracted result/error shape over REST?) is exercised at the **server**
+runtime. The `velesql_executor_cases.json` layer (does this query produce the
+exact result **rows / counts / ordering**?) now exists for the **core**
+executor, with goldens derived from `velesdb-core` as the source of truth.
 
-**What remains open**: executor result-level conformance is being added for the
-**core** runtime; **WASM** and **CLI** executor result parity is **not yet
-fixture-checked**. The WASM and CLI surfaces share the same `velesdb-core`
-executor, so a query that parses identically across the three is expected to
-execute identically — but that expectation is asserted today only for the
-server, not pinned by a per-runtime executor fixture for WASM/CLI.
+**What remains open**: **WASM** and **CLI** executor result parity is **not yet
+fixture-checked** against those executor goldens. The WASM and CLI surfaces
+share the same `velesdb-core` executor, so a query that parses identically
+across the three is expected to execute identically — but for WASM/CLI that
+expectation is not yet pinned by a per-runtime executor fixture run.
 
 **User impact**: a result-shape divergence specific to the WASM or CLI surface
 (e.g. a serialization or projection difference) would not be caught by the

--- a/docs/reference/VELESQL_CONTRACT.md
+++ b/docs/reference/VELESQL_CONTRACT.md
@@ -270,6 +270,7 @@ Contract test cases are listed in:
 
 - `conformance/velesql_parser_cases.json` (parser conformance, v3.6)
 - `conformance/velesql_contract_cases.json` (runtime contract)
+- `conformance/velesql_executor_cases.json` (executor result rows/counts/ordering, goldens derived from `velesdb-core`)
 
 Each invalid case maps to an expected HTTP status and an expected error shape.
 

--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -90,8 +90,14 @@ Create a new collection.
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | name | string | Yes | Unique collection name |
-| dimension | integer | Yes | Vector dimension (e.g., 768) |
+| dimension | integer | Yes (vector/graph) | Vector dimension (e.g., 768). Omit for `metadata_only` |
 | metric | string | No | Distance metric (see table below) |
+| storage_mode | string | No | `full` (default), `sq8`, or `binary` quantization |
+| collection_type | string | No | `vector` (default), `metadata_only`, or `graph` (see [CollectionType](#collectiontype-descriptor)) |
+| hnsw_m | integer | No | Tuned HNSW: bi-directional links per node |
+| hnsw_ef_construction | integer | No | Tuned HNSW: candidate list size during build |
+| hnsw_alpha | float | No | VAMANA neighbor-diversification factor (≥ 1.0) |
+| hnsw_max_elements | integer | No | Initial HNSW capacity (pre-size for bulk import) |
 
 **Distance Metrics:**
 
@@ -129,6 +135,50 @@ Create a new collection.
   "metric": "jaccard"
 }
 ```
+
+**Example (tuned HNSW for higher recall):**
+
+Any of `hnsw_m`, `hnsw_ef_construction`, `hnsw_alpha`, or `hnsw_max_elements`
+present switches collection creation onto the tuned-parameters path; omitted
+fields keep the engine defaults (auto-derived from `dimension`). Larger `hnsw_m`
+and `hnsw_ef_construction` raise recall and index size at a build-time cost;
+`hnsw_max_elements` only pre-sizes capacity for bulk imports (the index still
+grows automatically if exceeded). Out-of-range tunables (e.g. `hnsw_alpha < 1.0`
+or non-finite) are rejected with `400`.
+
+```json
+{
+  "name": "documents",
+  "dimension": 768,
+  "metric": "cosine",
+  "hnsw_m": 48,
+  "hnsw_ef_construction": 600,
+  "hnsw_alpha": 1.2
+}
+```
+
+**Example (metadata-only collection):**
+
+A `metadata_only` collection stores payload rows with no vectors and no HNSW
+index. It supports CRUD and VelesQL queries over the payload but not vector
+search. `dimension` is ignored and may be omitted.
+
+```json
+{
+  "name": "catalog",
+  "collection_type": "metadata_only"
+}
+```
+
+#### CollectionType descriptor
+
+The `collection_type` field selects the runtime descriptor for the collection:
+
+| `collection_type` | Vectors / HNSW | Use case |
+|-------------------|----------------|----------|
+| `vector` (default) | Yes — HNSW index over `dimension`-d vectors | Semantic search, RAG, recommendations |
+| `metadata_only` | No | Reference tables, catalogs, payload-only stores; CRUD + VelesQL on payload, no vector search |
+| `graph` | Optional node embeddings (`dimension` may be null) + typed edges | Knowledge graphs, agentic memory, entity-relationship storage. Supply `graph_schema` for a strict schema; absent means schemaless |
 
 **Response (201 Created):**
 ```json
@@ -178,6 +228,13 @@ deferred-indexing and async-index-builder settings. Returns a
 `point_count`, `metadata_only`, optional `embedding_dimension`,
 `deferred_indexing`, `async_index_builder`).
 
+### Collection health diagnostics
+
+Three read-only endpoints surface collection health for onboarding and
+troubleshooting, ordered cheapest to richest: `GET …/empty` (single boolean),
+`GET …/sanity` (live readiness + hints, no `ANALYZE` required), and
+`GET …/stats` (cached statistics from the last `ANALYZE`).
+
 ### GET /collections/:name/empty
 
 Check whether a collection contains no points. Returns `200` with an empty/has-points
@@ -185,8 +242,34 @@ status object, `404` when the collection does not exist.
 
 ### GET /collections/:name/sanity
 
-Quick onboarding/troubleshooting check (collection reachable, dimensions consistent,
-index responsive). Returns a status object (`200`) or `404`.
+Quick onboarding/troubleshooting check, computed live (no `ANALYZE` needed):
+reports point count, whether the index is search-ready, and actionable hints.
+Returns a status object (`200`) or `404`.
+
+**Response (200):**
+```json
+{
+  "collection": "documents",
+  "dimension": 768,
+  "metric": "cosine",
+  "point_count": 1000,
+  "is_empty": false,
+  "checks": {
+    "has_vectors": true,
+    "search_ready": true,
+    "dimension_configured": true
+  },
+  "diagnostics": {
+    "search_requests_total": 42,
+    "dimension_mismatch_total": 0,
+    "empty_search_results_total": 1,
+    "filter_parse_errors_total": 0
+  },
+  "hints": [
+    "Run a search without strict filters first, then tighten filters progressively."
+  ]
+}
+```
 
 ### GET /collections/:name/stats
 
@@ -253,6 +336,25 @@ Insert or update points (upsert).
 {
   "message": "Points upserted",
   "count": 1
+}
+```
+
+**Metadata-only / payload upsert:**
+
+For a `metadata_only` collection there are no vectors — upsert points carrying
+only `id` and `payload`, with an empty `vector`. The point is stored and is
+queryable via VelesQL over its payload, but is not added to any HNSW index.
+(In `metadata_only` collections, vector search is unavailable by design.)
+
+```json
+{
+  "points": [
+    {
+      "id": 1,
+      "vector": [],
+      "payload": {"sku": "A-100", "category": "books", "in_stock": true}
+    }
+  ]
 }
 ```
 
@@ -1238,6 +1340,20 @@ collection = db.create_collection("docs", dimension=768, metric="cosine")
 collection = db.get_collection("docs")
 db.delete_collection("docs")
 collections = db.list_collections()
+
+# Tuned HNSW at creation (typed options)
+from velesdb import HnswOptions
+collection = db.create_collection(
+    "docs_hi_recall",
+    dimension=768,
+    hnsw=HnswOptions(m=48, ef_construction=600),
+)
+# Auto-tuned for an expected dataset size:
+collection = db.create_collection(
+    "big",
+    dimension=128,
+    hnsw=HnswOptions.for_dataset_size(128, 1_000_000),
+)
 
 # Points
 collection.upsert([{"id": 1, "vector": [...], "payload": {...}}])

--- a/integrations/common/README.md
+++ b/integrations/common/README.md
@@ -73,8 +73,8 @@ direct use by end users.
 
 | Export | Type | Description |
 |--------|------|-------------|
-| `ALLOWED_METRICS` | set | Canonical metric strings (cosine, euclidean, dot, …) |
-| `ALLOWED_STORAGE_MODES` | set | Canonical storage modes (full, sq8, binary, pq, rabitq) |
+| `ALLOWED_METRICS` | set | Canonical metric strings (cosine, euclidean, dot, …); single-sourced from `velesdb.DISTANCE_METRICS`, with a literal fallback when the wheel is absent |
+| `ALLOWED_STORAGE_MODES` | set | Canonical storage modes (full, sq8, binary, pq, rabitq); single-sourced from `velesdb.STORAGE_MODES`, with a literal fallback when the wheel is absent |
 | `STORAGE_MODE_ALIASES` | dict | Alias → canonical mapping (e.g. `int8` → `sq8`) |
 | `DEFAULT_TIMEOUT_MS` | int | Default timeout used when callers don't specify one |
 | `MIN_DIMENSION` / `MAX_DIMENSION` | int | Vector dimension bounds |

--- a/integrations/common/src/velesdb_common/security.py
+++ b/integrations/common/src/velesdb_common/security.py
@@ -24,8 +24,25 @@ MAX_K_VALUE = 10_000             # Max top_k for search
 MAX_DIMENSION = 65_536           # Max vector dimension (reasonable for any model)
 MIN_DIMENSION = 1
 MAX_PATH_LENGTH = 4096           # Max path length
-ALLOWED_METRICS = frozenset({"cosine", "euclidean", "dot", "hamming", "jaccard"})
-ALLOWED_STORAGE_MODES = frozenset({"full", "sq8", "binary", "pq", "rabitq"})
+
+# Canonical metric / storage-mode name sets. Single-sourced from the compiled
+# ``velesdb`` binding (``DISTANCE_METRICS`` / ``STORAGE_MODES``), themselves
+# generated from velesdb-core's ``DistanceMetric`` / ``StorageMode`` variants.
+# Fall back to the historical literals when the wheel is unavailable so this
+# package still imports without the native extension (e.g. docs-only checkouts).
+# The drift guard in ``tests/test_security.py`` asserts exact equality with the
+# binding lists whenever the wheel is present.
+_FALLBACK_METRICS = frozenset({"cosine", "euclidean", "dot", "hamming", "jaccard"})
+_FALLBACK_STORAGE_MODES = frozenset({"full", "sq8", "binary", "pq", "rabitq"})
+
+try:
+    import velesdb as _velesdb
+
+    ALLOWED_METRICS = frozenset(_velesdb.DISTANCE_METRICS)
+    ALLOWED_STORAGE_MODES = frozenset(_velesdb.STORAGE_MODES)
+except (ImportError, AttributeError):
+    ALLOWED_METRICS = _FALLBACK_METRICS
+    ALLOWED_STORAGE_MODES = _FALLBACK_STORAGE_MODES
 # Aliases accepted by the Rust core via ``from_str_with_aliases()``.
 # Maps alias → canonical name (same set of aliases as Rust).
 STORAGE_MODE_ALIASES: dict[str, str] = {

--- a/integrations/common/tests/test_security.py
+++ b/integrations/common/tests/test_security.py
@@ -92,6 +92,41 @@ def test_allowed_storage_modes_exact_set():
         )
 
 
+def test_allowed_metrics_exact_set():
+    """ALLOWED_METRICS must match the canonical set exactly."""
+    if ALLOWED_METRICS != frozenset({"cosine", "euclidean", "dot", "hamming", "jaccard"}):
+        raise AssertionError(
+            f"ALLOWED_METRICS mismatch: {ALLOWED_METRICS!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Single-source-of-truth drift guard: when the compiled ``velesdb`` binding is
+# present, the security constants must equal its exported name sets EXACTLY.
+# This catches a core-vs-binding-vs-integration drift the literal checks above
+# cannot (e.g. a new core variant the binding picked up but a stale literal did
+# not). Skipped only when the wheel is not built.
+# ---------------------------------------------------------------------------
+
+def test_allowed_metrics_equals_binding_exactly():
+    velesdb = pytest.importorskip("velesdb")
+    binding = frozenset(velesdb.DISTANCE_METRICS)
+    if ALLOWED_METRICS != binding:
+        raise AssertionError(
+            f"ALLOWED_METRICS {ALLOWED_METRICS!r} != velesdb.DISTANCE_METRICS {binding!r}"
+        )
+
+
+def test_allowed_storage_modes_equals_binding_exactly():
+    velesdb = pytest.importorskip("velesdb")
+    binding = frozenset(velesdb.STORAGE_MODES)
+    if ALLOWED_STORAGE_MODES != binding:
+        raise AssertionError(
+            f"ALLOWED_STORAGE_MODES {ALLOWED_STORAGE_MODES!r} "
+            f"!= velesdb.STORAGE_MODES {binding!r}"
+        )
+
+
 # ---------------------------------------------------------------------------
 # Type errors — non-string inputs
 # ---------------------------------------------------------------------------

--- a/integrations/haystack/src/haystack_velesdb/document_store.py
+++ b/integrations/haystack/src/haystack_velesdb/document_store.py
@@ -5,7 +5,6 @@ as the vector backend in any Haystack 2.x indexing or retrieval pipeline.
 """
 from __future__ import annotations
 
-import hashlib
 import logging
 from typing import Any, Dict, List, Optional
 
@@ -16,6 +15,7 @@ from haystack.document_stores.types import DuplicatePolicy
 
 import velesdb
 from velesdb_common.fusion import build_fusion_strategy
+from velesdb_common.ids import stable_hash_id
 from velesdb_common.security import (
     validate_collection_name,
     validate_metric,
@@ -31,7 +31,6 @@ _DEFAULT_COLLECTION = "haystack_documents"
 _DEFAULT_DIMENSION = 768
 _DEFAULT_METRIC = "cosine"
 _DEFAULT_SCROLL_LIMIT = 10_000
-_INT63_MASK = (1 << 63) - 1
 # Reserved keys stored by this integration in the VelesDB payload.
 _RESERVED_PAYLOAD_KEYS = frozenset({"_doc_id", "content"})
 
@@ -195,18 +194,6 @@ def _translate_haystack_filter(
     return {"condition": _translate_condition(filters)}
 
 
-def _str_id_to_int(doc_id: str) -> int:
-    """Map a Haystack string document ID to a stable positive 63-bit integer.
-
-    Uses the first 8 bytes of SHA-256, masked to 63 bits (~9.2 × 10¹⁸ slots).
-    Collision probability for a 1 M-document collection is roughly 5 × 10⁻¹⁴ —
-    negligible for typical RAG workloads but not zero.  If two distinct string
-    IDs produce the same integer ID, :meth:`write_documents` raises
-    :class:`ValueError` rather than silently overwriting the existing document.
-    """
-    return int.from_bytes(hashlib.sha256(doc_id.encode()).digest()[:8], "big") & _INT63_MASK
-
-
 def _doc_to_point(doc: Document, sparse_vector: Optional[dict] = None) -> dict:
     """Convert a Haystack Document to a VelesDB point dict.
 
@@ -229,7 +216,7 @@ def _doc_to_point(doc: Document, sparse_vector: Optional[dict] = None) -> dict:
     payload["_doc_id"] = doc.id
     if doc.content is not None:
         payload["content"] = doc.content
-    point: dict = {"id": _str_id_to_int(doc.id), "payload": payload}
+    point: dict = {"id": stable_hash_id(doc.id), "payload": payload}
     if doc.embedding is not None:
         point["vector"] = list(doc.embedding)
     if sparse_vector is not None:
@@ -289,7 +276,7 @@ def _build_int_id_map(documents: List[Document]) -> Dict[int, str]:
     """
     int_id_map: Dict[int, str] = {}
     for doc in documents:
-        iid = _str_id_to_int(doc.id)
+        iid = stable_hash_id(doc.id)
         if iid in int_id_map and int_id_map[iid] != doc.id:
             raise ValueError(
                 f"SHA-256 collision in write batch: '{int_id_map[iid]}' and "
@@ -555,7 +542,7 @@ class VelesDBDocumentStore:
         """Delete documents identified by their Haystack string IDs."""
         if not document_ids:
             return
-        int_ids = [_str_id_to_int(did) for did in document_ids]
+        int_ids = [stable_hash_id(did) for did in document_ids]
         self._get_collection().delete(int_ids)
 
     def embedding_retrieval(

--- a/integrations/haystack/tests/test_document_store.py
+++ b/integrations/haystack/tests/test_document_store.py
@@ -282,6 +282,17 @@ def _load_module() -> types.ModuleType:
 
     vc_mod = types.ModuleType("velesdb_common")
     sys.modules["velesdb_common"] = vc_mod
+
+    # Load the REAL velesdb_common.ids (pure stdlib) so the store exercises the
+    # canonical stable_hash_id rather than a forked copy (single-source-of-truth
+    # + license hygiene — see docs/planning/CORE_PARITY_REMEDIATION.md T3).
+    _ids_path = Path(__file__).resolve().parents[2] / "common" / "src" / "velesdb_common" / "ids.py"
+    _ids_spec = importlib.util.spec_from_file_location("velesdb_common.ids", _ids_path)
+    assert _ids_spec and _ids_spec.loader
+    vc_ids = importlib.util.module_from_spec(_ids_spec)
+    sys.modules["velesdb_common.ids"] = vc_ids
+    _ids_spec.loader.exec_module(vc_ids)
+
     vc_sec = types.ModuleType("velesdb_common.security")
     vc_sec.validate_path = _passthrough  # type: ignore[attr-defined]
     vc_sec.validate_collection_name = _passthrough  # type: ignore[attr-defined]
@@ -1028,3 +1039,29 @@ def test_write_documents_forwards_named_sparse_vectors() -> None:
         assert point["sparse_vector"] == {"bge_m3": {0: 1.5, 7: 0.8}}
     finally:
         _MOD.velesdb = original_velesdb
+
+
+def test_id_hashing_uses_canonical_stable_hash_id():
+    """T3: the store delegates string->int ID hashing to the shared
+    velesdb_common.ids.stable_hash_id, not a forked local copy. This keeps the
+    same logical document mapped to the same VelesDB point ID across every
+    integration (single source of truth) and avoids re-implementing the hash in
+    an MIT package (license hygiene). See docs/planning/CORE_PARITY_REMEDIATION.md.
+    """
+    import hashlib
+
+    import velesdb_common.ids as canonical_ids
+
+    # the module imported the canonical helper, and the forked copy is gone
+    assert _MOD.stable_hash_id is canonical_ids.stable_hash_id
+    assert not hasattr(_MOD, "_str_id_to_int")
+    assert not hasattr(_MOD, "_INT63_MASK")
+
+    # and it yields the canonical positive-63-bit value
+    for doc_id in ["", "doc-1", "héllo-世界", "Document_42::chunk#3", "a" * 500]:
+        expected = (
+            int.from_bytes(hashlib.sha256(doc_id.encode("utf-8")).digest()[:8], "big")
+            & 0x7FFFFFFFFFFFFFFF
+        )
+        assert _MOD.stable_hash_id(doc_id) == expected
+        assert 0 <= _MOD.stable_hash_id(doc_id) <= 0x7FFFFFFFFFFFFFFF


### PR DESCRIPTION
## Summary

Core↔ecosystem parity & architecture remediation. An independent re-audit confirmed `velesdb-core` is the uncontested source of truth (dependency direction is a clean star, no inversions/cycles); this PR closes the handful of spots where a child forked canonical logic, adds the missing safety nets, fixes one correctness bug found along the way, and keeps docs in sync.

## What's included

**Fixes**
- **VelesQL scalar `ORDER BY <col> … LIMIT k`**: previously truncated to `k` in storage order *before* sorting (e.g. `ORDER BY year DESC LIMIT 2` returned the first two by id, not the two largest), contradicting the bounded==unbounded guarantee. Now fetches the full matching set so the sort precedes truncation; the `similarity()`-ordered HNSW fast path is untouched (recall unaffected).
- **Haystack** delegates string→u64 ID hashing to the shared `velesdb_common.ids.stable_hash_id` instead of a forked copy (behaviour-preserving; removes a re-implementation of ID logic in an MIT package).
- **Mobile** `TraversalResult` aligned with core (adds the missing `path: Vec<u64>`, `From<core::…>` conversions). Note: regenerates the Swift/Kotlin `TraversalResult` struct.

**Single-sourcing**
- **WASM fusion** delegates 4/5 strategies to `velesdb_core::FusionStrategy::fuse` (equivalence-tested); `relative_score`/`rsf` stays wasm-local for the N-branch case (core's `RelativeScore` is 2-branch dense+sparse; the 2-branch path already routes to core).
- **Canonical enum names** single-sourced: `DISTANCE_METRIC_NAMES`/`STORAGE_MODE_NAMES` consts in core (with completeness tests) → exposed via the Python binding → `velesdb_common` derives `ALLOWED_METRICS`/`ALLOWED_STORAGE_MODES` from it (graceful fallback when the wheel is absent).

**Tooling / tests**
- Executor-level VelesQL conformance net (result rows/counts/ordering, not just parse-ok) for **core + CLI + WASM**, wired into the `VelesQL Conformance` CI job. Captures that WASM sorts-before-limit (no bug) while CLI inherits the core path.
- `SecondaryIndex::ordered_ids` — the load-bearing primitive for the ordered-index `ORDER BY` pushdown (EPIC-081, phase 1; planner routing designed and tracked as phase 2).
- Project skill `/core-parity-audit` to re-run the whole analysis (code + docs), with the VelesDB Core License boundary encoded.

**Docs**: `ECOSYSTEM_PARITY`, `KNOWN_LIMITATIONS` (#9 + #12 ID-hash interop + #13 conformance), `api-reference`, and the remediation plan / EPIC-081 under `docs/planning/`.

## Quality gate (green locally)

`cargo clippy --workspace --all-targets --features persistence,gpu,update-check --exclude velesdb-python -D warnings -D clippy::pedantic` · `--no-default-features` core · `wasm32-unknown-unknown` check · `check_prod_unwraps.py` · feature-claims audit · recall@10 · `cargo fmt --check`. Python: `velesdb_common` security tests (61) with the rebuilt wheel.

## Follow-ups (tracked)
- EPIC-081 phase 2: gated planner routing of `ORDER BY <indexed col> LIMIT k` to the `ordered_ids` top-k.
- Confirm the mobile `TraversalResult` binding regeneration before a mobile release.
