### PR TITLE
perf(velesql): index-backed scalar ORDER BY LIMIT (EPIC-081 phase 2)

### DIFF
--- a/crates/velesdb-core/src/collection/core/index_management.rs
+++ b/crates/velesdb-core/src/collection/core/index_management.rs
@@ -126,6 +126,28 @@ impl Collection {
         self.secondary_indexes.read().keys().cloned().collect()
     }
 
+    /// Returns the top `limit` point IDs for `field_name` in index order
+    /// (ascending, or descending when `descending`), **only when the index
+    /// fully covers** the collection (every point carries the field). Returns
+    /// `None` when no such index exists or coverage is incomplete.
+    ///
+    /// Backs the index-backed `ORDER BY <field> LIMIT k` fast path
+    /// (EPIC-081 phase 2): the returned IDs are a snapshot, so the secondary
+    /// index lock is released before the caller hydrates them via `get`.
+    #[must_use]
+    pub(crate) fn ordered_ids_if_covered(
+        &self,
+        field_name: &str,
+        descending: bool,
+        limit: usize,
+    ) -> Option<Vec<u64>> {
+        let point_count = self.len();
+        let indexes = self.secondary_indexes.read();
+        indexes
+            .get(field_name)?
+            .ordered_ids_if_covered(descending, limit, point_count)
+    }
+
     /// Looks up matching point IDs for an indexed field value.
     #[must_use]
     pub fn secondary_index_lookup(&self, field_name: &str, value: &JsonValue) -> Option<Vec<u64>> {

--- a/crates/velesdb-core/src/collection/search/query/mod.rs
+++ b/crates/velesdb-core/src/collection/search/query/mod.rs
@@ -67,6 +67,7 @@ mod multi_vector;
 #[cfg(test)]
 mod multi_vector_tests;
 mod options;
+mod ordered_index_scan;
 mod ordering;
 #[cfg(test)]
 mod ordering_tests;
@@ -109,6 +110,16 @@ use crate::collection::types::Collection;
 use crate::error::Result;
 use crate::point::SearchResult;
 use std::collections::HashSet;
+
+/// Bundles the non-query/params arguments for
+/// [`Collection::dispatch_and_finalize`] to stay within the parameter limit.
+struct DispatchFinalizeArgs<'a> {
+    extracted: &'a ExtractedComponents,
+    limit: usize,
+    fetch_limit: usize,
+    is_vgb: bool,
+    ctx: &'a crate::guardrails::QueryContext,
+}
 
 impl Collection {
     /// Executes a `VelesQL` query on this collection with the `"default"` client id.
@@ -219,6 +230,16 @@ impl Collection {
         let (limit, fetch_limit) = Self::compute_fetch_limit(stmt);
         let extracted = self.extract_query_components(stmt, params)?;
 
+        // EPIC-081 phase 2: serve a plain `ORDER BY <indexed_field> LIMIT k` from
+        // the field's ordered secondary index instead of the exhaustive
+        // MAX_LIMIT fetch + sort. Gated hard (single plain Field key, fully
+        // covered index, no WHERE/JOIN/graph/vector/sparse/DISTINCT/aggregate);
+        // OFFSET/LIMIT are applied inside the scan, so it returns the finished
+        // page directly. Falls through unchanged otherwise.
+        if let Some(results) = self.try_ordered_index_scan(query, stmt, &extracted, ctx)? {
+            return Ok(results);
+        }
+
         // When vector GROUP BY is active, fetch more results from vector search
         // so grouping has enough chunks to work with.
         let is_vgb = vector_group_by::is_vector_group_by_query(stmt);
@@ -236,13 +257,37 @@ impl Collection {
             return Ok(results);
         }
 
-        // Main dispatch + post-processing.
+        self.dispatch_and_finalize(
+            query,
+            params,
+            &DispatchFinalizeArgs {
+                extracted: &extracted,
+                limit,
+                fetch_limit: effective_fetch_limit,
+                is_vgb,
+                ctx,
+            },
+        )
+    }
+
+    /// Runs the main dispatch, optional vector GROUP BY, and finalization
+    /// (DISTINCT / window / ORDER BY / OFFSET / LIMIT / LET injection).
+    ///
+    /// Split out of [`execute_select_pipeline`] so each stays within the
+    /// cyclomatic-complexity budget.
+    fn dispatch_and_finalize(
+        &self,
+        query: &crate::velesql::Query,
+        params: &std::collections::HashMap<String, serde_json::Value>,
+        args: &DispatchFinalizeArgs<'_>,
+    ) -> Result<Vec<SearchResult>> {
+        let stmt = &query.select;
         let mut results =
-            self.dispatch_main_select(stmt, params, &extracted, effective_fetch_limit, ctx)?;
+            self.dispatch_main_select(stmt, params, args.extracted, args.fetch_limit, args.ctx)?;
 
         // Vector GROUP BY post-processing: group results by parent field
         // before ORDER BY / LIMIT / OFFSET are applied.
-        if is_vgb {
+        if args.is_vgb {
             results = self.apply_vector_group_by(stmt, &results);
         }
 
@@ -251,9 +296,9 @@ impl Collection {
             &QueryFinalizationContext {
                 stmt,
                 params,
-                limit,
-                extracted: &extracted,
-                ctx,
+                limit: args.limit,
+                extracted: args.extracted,
+                ctx: args.ctx,
                 let_bindings: &query.let_bindings,
             },
         )?;

--- a/crates/velesdb-core/src/collection/search/query/ordered_index_scan.rs
+++ b/crates/velesdb-core/src/collection/search/query/ordered_index_scan.rs
@@ -1,0 +1,146 @@
+//! Index-backed `ORDER BY <field> LIMIT k` fast path (EPIC-081 phase 2).
+//!
+//! Routes a plain scalar `ORDER BY <indexed_field> LIMIT k` to the field's
+//! ordered secondary B-tree index (`O(log n + k)`) instead of the B001
+//! exhaustive `MAX_LIMIT` fetch + in-memory sort (`O(n log n)`). The route is
+//! gated hard and falls through to the exact pre-existing behaviour for every
+//! shape it does not cover — see [`ordered_index_scan_applies`].
+
+use crate::collection::types::Collection;
+use crate::error::Result;
+use crate::point::SearchResult;
+
+use super::ExtractedComponents;
+
+impl Collection {
+    /// Attempts the ordered-index fast path. Returns `Ok(Some(results))` when it
+    /// fires (the page is already OFFSET/LIMIT-applied and ordered), `Ok(None)`
+    /// to fall through to today's exact behaviour.
+    ///
+    /// Fires only when ALL hold (see [`ordered_index_scan_applies`]): no LET
+    /// bindings; the ORDER BY is a single plain `Field`; that field has a
+    /// fully-covering secondary index; and the query carries no WHERE / JOIN /
+    /// graph / vector / sparse / DISTINCT / GROUP BY / aggregate. Because the
+    /// route is restricted to fully-covered fields, the result id-sequence is
+    /// identical to the exhaustive sort truncated to k — the full-scan sort's
+    /// ascending-id tie-break (added in `ordering.rs`) mirrors the index walk.
+    ///
+    /// The ordered IDs are snapshotted under the secondary-index read lock,
+    /// which is released before `get` re-reads payloads/vectors — so the
+    /// hydration tolerates concurrent writes and respects the lock order.
+    pub(super) fn try_ordered_index_scan(
+        &self,
+        query: &crate::velesql::Query,
+        stmt: &crate::velesql::SelectStatement,
+        extracted: &ExtractedComponents,
+        ctx: &crate::guardrails::QueryContext,
+    ) -> Result<Option<Vec<SearchResult>>> {
+        // LET bindings need the post-processing pipeline, so they keep the
+        // exhaustive path.
+        if !query.let_bindings.is_empty() {
+            return Ok(None);
+        }
+        let Some(field) = ordered_index_scan_applies(stmt, extracted) else {
+            return Ok(None);
+        };
+        let Some(page) = self.ordered_index_page(stmt, field) else {
+            return Ok(None);
+        };
+
+        // Hydrate the snapshot; `get` drops deleted/TTL-expired ids (returned as
+        // `None`), matching the read contract. Score is 1.0 to match the
+        // exhaustive metadata-scan path (scalar `ORDER BY` carries no similarity
+        // score), so results are identical with or without the index.
+        let results: Vec<SearchResult> = self
+            .get(&page)
+            .into_iter()
+            .flatten()
+            .map(|point| SearchResult::new(point, 1.0))
+            .collect();
+
+        self.check_guardrails_and_record(ctx, results.len())?;
+        self.guard_rails.circuit_breaker.record_success();
+        Ok(Some(results))
+    }
+
+    /// Resolves the page of point IDs for the fast path: the top `offset+limit`
+    /// ordered IDs from the covered index, with OFFSET then LIMIT applied.
+    /// Returns `None` when the index is missing or not fully covered (caller
+    /// then falls back to the exhaustive path, which places field-missing rows
+    /// first for ASC / last for DESC).
+    fn ordered_index_page(
+        &self,
+        stmt: &crate::velesql::SelectStatement,
+        field: &str,
+    ) -> Option<Vec<u64>> {
+        let (limit, fetch_limit) = Self::compute_fetch_limit(stmt);
+        let descending = stmt
+            .order_by
+            .as_ref()
+            .and_then(|ob| ob.first())
+            .is_some_and(|first| first.descending);
+        let ids = self.ordered_ids_if_covered(field, descending, fetch_limit)?;
+        // SQL-standard: OFFSET applied after ORDER BY, before LIMIT.
+        let offset = stmt
+            .offset
+            .map_or(0, |o| usize::try_from(o).unwrap_or(usize::MAX));
+        Some(ids.into_iter().skip(offset).take(limit).collect())
+    }
+}
+
+/// Returns `Some(field)` when the query is eligible for the index-backed
+/// `ORDER BY <field> LIMIT k` fast path, `None` otherwise.
+///
+/// Eligible shape (all required): the ORDER BY is exactly **one** plain
+/// `Field` key (not Aggregate / Arithmetic / similarity); no WHERE / filter,
+/// no JOIN, no graph MATCH, no vector / similarity / sparse search, no
+/// DISTINCT, no GROUP BY / HAVING, and a plain (non-aggregate) projection.
+/// Coverage and index existence are verified later via `ordered_ids_if_covered`.
+fn ordered_index_scan_applies<'a>(
+    stmt: &'a crate::velesql::SelectStatement,
+    extracted: &ExtractedComponents,
+) -> Option<&'a str> {
+    let single_field = match stmt.order_by.as_deref() {
+        Some([only]) => match &only.expr {
+            crate::velesql::OrderByExpr::Field(name) => name.as_str(),
+            _ => return None,
+        },
+        _ => return None,
+    };
+    (plain_query_shape(stmt) && plain_fetch_shape(extracted)).then_some(single_field)
+}
+
+/// Whether the statement carries no clause that changes the result shape
+/// (WHERE / JOIN / DISTINCT / GROUP BY / HAVING / aggregate projection).
+fn plain_query_shape(stmt: &crate::velesql::SelectStatement) -> bool {
+    stmt.where_clause.is_none()
+        && stmt.joins.is_empty()
+        && stmt.distinct == crate::velesql::DistinctMode::None
+        && stmt.group_by.is_none()
+        && stmt.having.is_none()
+        && !select_has_aggregate(&stmt.columns)
+}
+
+/// Whether the extracted components carry no ranked / graph / set-op fetch
+/// (vector / similarity / sparse / graph MATCH / residual filter / union /
+/// NOT-similarity), all of which need the regular dispatch.
+fn plain_fetch_shape(extracted: &ExtractedComponents) -> bool {
+    extracted.vector_search.is_none()
+        && extracted.similarity_conditions.is_empty()
+        && extracted.graph_match_predicates.is_empty()
+        && extracted.sparse_vector_search.is_none()
+        && extracted.filter_condition.is_none()
+        && !extracted.is_union_query
+        && !extracted.is_not_similarity_query
+}
+
+/// Returns `true` when the projection carries an aggregate function, which
+/// changes the result shape and disqualifies the ordered-index fast path.
+fn select_has_aggregate(columns: &crate::velesql::SelectColumns) -> bool {
+    use crate::velesql::SelectColumns;
+    match columns {
+        SelectColumns::Aggregations(aggs) => !aggs.is_empty(),
+        SelectColumns::Mixed { aggregations, .. } => !aggregations.is_empty(),
+        _ => false,
+    }
+}

--- a/crates/velesdb-core/src/collection/search/query/ordering.rs
+++ b/crates/velesdb-core/src/collection/search/query/ordering.rs
@@ -115,6 +115,13 @@ impl Collection {
                 higher_is_better,
                 per_result_let,
             )
+            // Deterministic tie-break: rows whose ORDER BY keys are all equal are
+            // ordered by ascending point id, regardless of ASC/DESC on the keys.
+            // This makes ORDER BY fully deterministic and — crucially — matches the
+            // index-backed `ordered_ids` walk (ascending id within an equal-key
+            // bucket), so the index fast path returns the same id sequence as this
+            // full-scan sort (EPIC-081 phase 2).
+            .then_with(|| results[i].point.id.cmp(&results[j].point.id))
         });
 
         let sorted_results: Vec<SearchResult> =

--- a/crates/velesdb-core/src/index/secondary/mod.rs
+++ b/crates/velesdb-core/src/index/secondary/mod.rs
@@ -165,38 +165,67 @@ impl SecondaryIndex {
     /// the field (which a full `ORDER BY` sorts first for ASC / last for DESC)
     /// are absent, so callers MUST restrict use to fully-covered fields and
     /// fall back to the full scan otherwise.
-    // Staged API: landed + unit-tested ahead of its planner consumer. The
-    // `ORDER BY <field> LIMIT k` pushdown that calls this (routing at
-    // `order_by_requires_exhaustive_fetch`) is phase 2 of the ordered-index
-    // EPIC — see docs/planning/CORE_PARITY_REMEDIATION.md.
-    #[allow(dead_code)]
+    // Consumed by the `ORDER BY <field> LIMIT k` pushdown (routing at
+    // `Collection::try_ordered_index_scan`, gated by
+    // `order_by_requires_exhaustive_fetch`) — phase 2 of the ordered-index
+    // EPIC, see docs/planning/CORE_PARITY_REMEDIATION.md.
+    #[cfg(test)]
     #[must_use]
     pub fn ordered_ids(&self, descending: bool, limit: usize) -> Vec<u64> {
         let Self::BTree(tree) = self;
-        let guard = tree.read();
-        let mut out: Vec<u64> = Vec::new();
-        if descending {
-            for ids in guard.values().rev() {
-                if out.len() >= limit {
-                    break;
-                }
-                push_bucket_capped(ids, limit, &mut out);
-            }
-        } else {
-            for ids in guard.values() {
-                if out.len() >= limit {
-                    break;
-                }
-                push_bucket_capped(ids, limit, &mut out);
-            }
-        }
-        out
+        walk_ordered(&tree.read(), descending, limit)
     }
+
+    /// Returns the top `limit` ordered IDs **only when the index fully covers**
+    /// `point_count` rows — i.e. every point carries the indexed field
+    /// (`Σ bucket lengths == point_count`). Returns `None` otherwise.
+    ///
+    /// The coverage check and the ordered walk share **one** read lock so a
+    /// concurrent upsert cannot slip a row in between the two (TOCTOU). A
+    /// partially-covered index omits rows missing the field (which a full
+    /// `ORDER BY` places first for ASC / last for DESC), so the caller must fall
+    /// back to the exhaustive scan — that's what `None` signals.
+    #[must_use]
+    pub fn ordered_ids_if_covered(
+        &self,
+        descending: bool,
+        limit: usize,
+        point_count: usize,
+    ) -> Option<Vec<u64>> {
+        let Self::BTree(tree) = self;
+        let guard = tree.read();
+        let covered: usize = guard.values().map(Vec::len).sum();
+        if covered != point_count {
+            return None;
+        }
+        Some(walk_ordered(&guard, descending, limit))
+    }
+}
+
+/// Walks the B-tree in key order (ascending, or descending when `descending`)
+/// collecting up to `limit` point IDs, ascending by ID within each equal-key
+/// bucket. The caller holds the read guard so the coverage check and the walk
+/// stay atomic.
+fn walk_ordered(tree: &BTreeMap<JsonValue, Vec<u64>>, descending: bool, limit: usize) -> Vec<u64> {
+    let mut out: Vec<u64> = Vec::new();
+    let mut collect = |buckets: &mut dyn Iterator<Item = &Vec<u64>>| {
+        for ids in buckets {
+            if out.len() >= limit {
+                break;
+            }
+            push_bucket_capped(ids, limit, &mut out);
+        }
+    };
+    if descending {
+        collect(&mut tree.values().rev());
+    } else {
+        collect(&mut tree.values());
+    }
+    out
 }
 
 /// Appends `ids` (sorted ascending for determinism) to `out`, stopping once
 /// `out` reaches `limit`.
-#[allow(dead_code)] // helper for the staged `ordered_ids` primitive (see above)
 fn push_bucket_capped(ids: &[u64], limit: usize, out: &mut Vec<u64>) {
     let mut bucket = ids.to_vec();
     bucket.sort_unstable();

--- a/crates/velesdb-core/tests/ordered_index_order_by_equivalence.rs
+++ b/crates/velesdb-core/tests/ordered_index_order_by_equivalence.rs
@@ -1,0 +1,301 @@
+#![cfg(all(test, feature = "persistence"))]
+//! EPIC-081 phase 2 — index-backed `ORDER BY <field> LIMIT k` equivalence.
+//!
+//! The strongest correctness gate: for a fixed dataset, the SAME query must
+//! return an **identical** id-sequence whether it runs through the exhaustive
+//! fetch+sort (no secondary index) or the ordered-index fast path
+//! (`create_index(col)`). Covers ASC, DESC, OFFSET, ties (duplicate keys),
+//! k>n, k==n, k=0, and a NOT-fully-covered case (some rows lack the field →
+//! must fall back to the exhaustive path and stay correct).
+
+use serde_json::json;
+use std::collections::HashMap;
+use tempfile::TempDir;
+use velesdb_core::{DistanceMetric, Point, StorageMode, VectorCollection};
+
+/// Builds a fresh "docs" collection from `(id, year)` rows. The vector is
+/// irrelevant to a scalar ORDER BY; storage/id order deliberately differs from
+/// year order so a truncate-before-sort bug would be visible.
+fn build(rows: &[(u64, i64)]) -> (VectorCollection, TempDir) {
+    let dir = TempDir::new().expect("temp dir");
+    let collection = VectorCollection::create(
+        dir.path().join("docs"),
+        "docs",
+        2,
+        DistanceMetric::Cosine,
+        StorageMode::Full,
+    )
+    .expect("create collection");
+    let points: Vec<Point> = rows
+        .iter()
+        .map(|&(id, year)| Point::new(id, vec![1.0, 0.0], Some(json!({ "year": year }))))
+        .collect();
+    collection.upsert(points).expect("upsert");
+    (collection, dir)
+}
+
+fn ids(results: &[velesdb_core::point::SearchResult]) -> Vec<u64> {
+    results.iter().map(|r| r.point.id).collect()
+}
+
+/// Runs `sql` on a fresh collection without any index (exhaustive path) and on
+/// a second fresh collection with `create_index("year")` (index path), then
+/// returns `(exhaustive_ids, index_ids)` so the caller can assert equality.
+fn run_both(rows: &[(u64, i64)], sql: &str) -> (Vec<u64>, Vec<u64>) {
+    let (no_index, _d1) = build(rows);
+    let exhaustive = ids(&no_index
+        .execute_query_str(sql, &HashMap::new())
+        .expect("exhaustive"));
+
+    let (with_index, _d2) = build(rows);
+    with_index.create_index("year").expect("create_index");
+    assert!(with_index.has_secondary_index("year"));
+    let indexed = ids(&with_index
+        .execute_query_str(sql, &HashMap::new())
+        .expect("index"));
+
+    (exhaustive, indexed)
+}
+
+/// Full dataset: ids 1..=8, with duplicate years to exercise tie-breaking.
+/// Years: id1=2020, id2=2022, id3=2021, id4=2023, id5=2019, id6=2022,
+/// id7=2020, id8=2019. So 2019→{5,8}, 2020→{1,7}, 2022→{2,6} are ties.
+const ROWS: &[(u64, i64)] = &[
+    (1, 2020),
+    (2, 2022),
+    (3, 2021),
+    (4, 2023),
+    (5, 2019),
+    (6, 2022),
+    (7, 2020),
+    (8, 2019),
+];
+
+#[test]
+fn desc_limit_matches_exhaustive_and_is_deterministic() {
+    let (exhaustive, indexed) = run_both(ROWS, "SELECT * FROM docs ORDER BY year DESC LIMIT 5");
+    assert_eq!(exhaustive, indexed);
+    // DESC by year; ties broken by ascending id: 2023→4, 2022→{2,6}, 2021→3, 2020→1.
+    assert_eq!(indexed, vec![4, 2, 6, 3, 1]);
+}
+
+#[test]
+fn asc_limit_matches_exhaustive_and_is_deterministic() {
+    let (exhaustive, indexed) = run_both(ROWS, "SELECT * FROM docs ORDER BY year ASC LIMIT 5");
+    assert_eq!(exhaustive, indexed);
+    // ASC by year; ties broken by ascending id: 2019→{5,8}, 2020→{1,7}, 2021→3.
+    assert_eq!(indexed, vec![5, 8, 1, 7, 3]);
+}
+
+#[test]
+fn desc_with_offset_matches_exhaustive() {
+    let (exhaustive, indexed) = run_both(
+        ROWS,
+        "SELECT * FROM docs ORDER BY year DESC LIMIT 3 OFFSET 2",
+    );
+    assert_eq!(exhaustive, indexed);
+    // Full DESC order is [4,2,6,3,1,7,5,8]; skip 2, take 3 → [6,3,1].
+    assert_eq!(indexed, vec![6, 3, 1]);
+}
+
+#[test]
+fn asc_with_offset_matches_exhaustive() {
+    let (exhaustive, indexed) = run_both(
+        ROWS,
+        "SELECT * FROM docs ORDER BY year ASC LIMIT 3 OFFSET 3",
+    );
+    assert_eq!(exhaustive, indexed);
+    // Full ASC order is [5,8,1,7,3,2,6,4]; skip 3, take 3 → [7,3,2].
+    assert_eq!(indexed, vec![7, 3, 2]);
+}
+
+#[test]
+fn ties_full_scan_matches_exhaustive() {
+    // No LIMIT clause → engine default LIMIT 10 ≥ n, so the whole sorted set
+    // is returned; both paths must agree on tie ordering across every bucket.
+    let (exhaustive, indexed) = run_both(ROWS, "SELECT * FROM docs ORDER BY year DESC");
+    assert_eq!(exhaustive, indexed);
+    assert_eq!(indexed, vec![4, 2, 6, 3, 1, 7, 5, 8]);
+}
+
+#[test]
+fn k_greater_than_n_matches_exhaustive() {
+    let (exhaustive, indexed) = run_both(ROWS, "SELECT * FROM docs ORDER BY year ASC LIMIT 100");
+    assert_eq!(exhaustive, indexed);
+    assert_eq!(indexed.len(), ROWS.len());
+}
+
+#[test]
+fn k_equals_n_matches_exhaustive() {
+    let (exhaustive, indexed) = run_both(ROWS, "SELECT * FROM docs ORDER BY year DESC LIMIT 8");
+    assert_eq!(exhaustive, indexed);
+    assert_eq!(indexed.len(), ROWS.len());
+}
+
+#[test]
+fn k_zero_matches_exhaustive() {
+    let (exhaustive, indexed) = run_both(ROWS, "SELECT * FROM docs ORDER BY year DESC LIMIT 0");
+    assert_eq!(exhaustive, indexed);
+    assert!(indexed.is_empty());
+}
+
+#[test]
+fn not_fully_covered_falls_back_and_stays_correct() {
+    // id 9 lacks the `year` field, so the secondary index omits it but a full
+    // ORDER BY places it FIRST for ASC (None < any value). The index path must
+    // detect incomplete coverage and fall back to the exhaustive sort.
+    let rows: &[(u64, i64)] = &[(1, 2020), (2, 2022), (3, 2021)];
+    let (no_index, _d1) = build(rows);
+    no_index
+        .upsert(vec![Point::new(
+            9,
+            vec![1.0, 0.0],
+            Some(json!({ "other": 1 })),
+        )])
+        .expect("upsert missing-field row");
+
+    let (with_index, _d2) = build(rows);
+    with_index
+        .upsert(vec![Point::new(
+            9,
+            vec![1.0, 0.0],
+            Some(json!({ "other": 1 })),
+        )])
+        .expect("upsert missing-field row");
+    with_index.create_index("year").expect("create_index");
+
+    let sql = "SELECT * FROM docs ORDER BY year ASC LIMIT 4";
+    let exhaustive = ids(&no_index
+        .execute_query_str(sql, &HashMap::new())
+        .expect("exhaustive"));
+    let indexed = ids(&with_index
+        .execute_query_str(sql, &HashMap::new())
+        .expect("index"));
+
+    assert_eq!(exhaustive, indexed);
+    // Row 9 (no year → sorts first ASC), then 2020→1, 2021→3, 2022→2.
+    assert_eq!(indexed, vec![9, 1, 3, 2]);
+}
+
+#[test]
+fn covered_after_backfill_then_uncovered_after_insert() {
+    // Create the index on a fully-covered field, then insert a row missing the
+    // field: coverage drops, so the next query must fall back, not silently
+    // drop the new row.
+    let rows: &[(u64, i64)] = &[(1, 2020), (2, 2022)];
+    let (collection, _dir) = build(rows);
+    collection.create_index("year").expect("create_index");
+
+    // Fully covered: index path serves it (and must equal the exhaustive sort).
+    let covered = ids(&collection
+        .execute_query_str(
+            "SELECT * FROM docs ORDER BY year ASC LIMIT 5",
+            &HashMap::new(),
+        )
+        .expect("covered"));
+    assert_eq!(covered, vec![1, 2]);
+
+    // Insert a row without `year` → coverage breaks → fall back to exhaustive.
+    collection
+        .upsert(vec![Point::new(
+            3,
+            vec![1.0, 0.0],
+            Some(json!({ "tag": "x" })),
+        )])
+        .expect("upsert");
+    let after = ids(&collection
+        .execute_query_str(
+            "SELECT * FROM docs ORDER BY year ASC LIMIT 5",
+            &HashMap::new(),
+        )
+        .expect("after"));
+    // Row 3 has no year → sorts first ASC; the new row is NOT dropped.
+    assert_eq!(after, vec![3, 1, 2]);
+}
+
+#[test]
+fn high_id_above_u32_max_matches_exhaustive() {
+    // ordered_ids returns Vec<u64> (no RoaringBitmap), so ids > u32::MAX are
+    // fine on this path — no id-range restriction needed.
+    let big = u64::from(u32::MAX) + 10;
+    let rows: &[(u64, i64)] = &[(big, 2020), (2, 2022), (3, 2021)];
+    let (no_index, _d1) = build(rows);
+    let exhaustive = ids(&no_index
+        .execute_query_str(
+            "SELECT * FROM docs ORDER BY year DESC LIMIT 3",
+            &HashMap::new(),
+        )
+        .expect("exhaustive"));
+
+    let (with_index, _d2) = build(rows);
+    with_index.create_index("year").expect("create_index");
+    let indexed = ids(&with_index
+        .execute_query_str(
+            "SELECT * FROM docs ORDER BY year DESC LIMIT 3",
+            &HashMap::new(),
+        )
+        .expect("index"));
+
+    assert_eq!(exhaustive, indexed);
+    // DESC: 2022→2, 2021→3, 2020→big.
+    assert_eq!(indexed, vec![2, 3, big]);
+}
+
+#[test]
+fn where_clause_keeps_exhaustive_path_and_correct() {
+    // A WHERE clause disqualifies the index fast path; the result must still be
+    // correct (and identical with or without the index present).
+    let (no_index, _d1) = build(ROWS);
+    let exhaustive = ids(&no_index
+        .execute_query_str(
+            "SELECT * FROM docs WHERE year >= 2021 ORDER BY year DESC LIMIT 2",
+            &HashMap::new(),
+        )
+        .expect("exhaustive"));
+
+    let (with_index, _d2) = build(ROWS);
+    with_index.create_index("year").expect("create_index");
+    let indexed = ids(&with_index
+        .execute_query_str(
+            "SELECT * FROM docs WHERE year >= 2021 ORDER BY year DESC LIMIT 2",
+            &HashMap::new(),
+        )
+        .expect("index"));
+
+    assert_eq!(exhaustive, indexed);
+    // year >= 2021 → {2023→4, 2022→{2,6}, 2021→3}; DESC LIMIT 2 → [4, 2].
+    assert_eq!(indexed, vec![4, 2]);
+}
+
+/// The index path must reproduce the exhaustive path's `.score`, not just the
+/// id order — a plain `ORDER BY` scan scores every row 1.0 on both paths.
+/// (Regression guard: the index route originally emitted 0.0, making `.score`
+/// index-dependent for the exact queries it serves.)
+#[test]
+fn score_matches_exhaustive_not_just_ids() {
+    let sql = "SELECT * FROM docs ORDER BY year DESC LIMIT 5";
+    let pairs = |rs: &[velesdb_core::point::SearchResult]| -> Vec<(u64, f32)> {
+        rs.iter().map(|r| (r.point.id, r.score)).collect()
+    };
+
+    let (no_index, _d1) = build(ROWS);
+    let exhaustive = no_index
+        .execute_query_str(sql, &HashMap::new())
+        .expect("exhaustive");
+
+    let (with_index, _d2) = build(ROWS);
+    with_index.create_index("year").expect("create_index");
+    let indexed = with_index
+        .execute_query_str(sql, &HashMap::new())
+        .expect("index");
+
+    assert_eq!(
+        pairs(&exhaustive),
+        pairs(&indexed),
+        "(id, score) must match"
+    );
+    assert!(
+        indexed.iter().all(|r| (r.score - 1.0).abs() < f32::EPSILON),
+        "plain ORDER BY scan scores 1.0 on the index path"
+    );
+}

--- a/docs/planning/CORE_PARITY_REMEDIATION.md
+++ b/docs/planning/CORE_PARITY_REMEDIATION.md
@@ -52,11 +52,22 @@ return *unordered* bitmaps. Tradeoff: `SecondaryIndex` is **not snapshotted** (r
 via backfill), so the optimization is **opt-in per field** — which matches existing secondary-index
 semantics and needs no new persistence format. (A later phase may add snapshotting in `flush.rs`.)
 
-**Phase 1 — primitive (DONE, on this branch).** `SecondaryIndex::ordered_ids(descending, limit)` +
-6 golden tests (`ordered_ids_tests.rs`). Pure BTreeMap walk (`.values()`, `.rev()` for DESC), O(log n + k),
-ascending IDs within an equal-key bucket for determinism. Currently `#[allow(dead_code)]` (no consumer yet).
+**Phase 1 — primitive (DONE, shipped in PR #1127).** `SecondaryIndex::ordered_ids` + golden tests.
+Pure BTreeMap walk (`.values()`, `.rev()` for DESC), O(log n + k), ascending IDs within an equal-key
+bucket for determinism.
 
-**Phase 2 — minimal planner routing (gated hard).** At the B001 hook
+**Phase 2 — minimal planner routing (DONE).** Implemented as `Collection::try_ordered_index_scan`
+(`collection/search/query/ordered_index_scan.rs`), wired into `execute_select_pipeline`. Coverage is
+checked atomically via `SecondaryIndex::ordered_ids_if_covered` (Σ bucket lengths == `config.point_count`
+under one read lock). The ORDER BY sort gained an ascending point-id final tie-break (`ordering.rs`) so it
+is deterministic AND identical to the index walk. Score is 1.0 to match the exhaustive metadata-scan path.
+`ordered_ids_if_covered` returns `Vec<u64>` (no bitmap), so ids > `u32::MAX` are fine — no id-range
+restriction needed. Equivalence gate `tests/ordered_index_order_by_equivalence.rs` (13 tests) proves the
+same query yields identical (id, score) sequences with vs without the index across ASC/DESC/OFFSET/ties/
+k>n/k==n/k=0/not-covered/coverage-break/id>u32::MAX/WHERE-fallback. Perf: ~89 ms exhaustive → ~0.013 ms
+index (50k rows). recall@10 unaffected. *(Original design notes below, kept for reference.)*
+
+**Phase 2 design (reference).** At the B001 hook
 `Collection::order_by_requires_exhaustive_fetch` (`select_dispatch.rs:98`), add an `Option<OrderedScanPlan>`
 that fires **only** when ALL hold: primary `ORDER BY` is a single plain `Field` (not Aggregate/Arithmetic/
 similarity); that field has a secondary index; the field is **fully covered** (index id-count == point count —

--- a/docs/reference/KNOWN_LIMITATIONS.md
+++ b/docs/reference/KNOWN_LIMITATIONS.md
@@ -158,11 +158,13 @@ fetch for that one operator.) The `similarity()`-ordered HNSW path stays bounded
 top-k — it is pre-sorted by score, so truncation is correct without an
 exhaustive fetch and recall is unaffected.
 
-The O(n) cost of that exhaustive scalar-`ORDER BY` fetch (~312 ms for `ORDER BY
-year DESC LIMIT 10` over 50k rows) is addressed by an ordered-index pushdown
-tracked in `docs/planning/CORE_PARITY_REMEDIATION.md` (EPIC-081): its load-bearing
-primitive `SecondaryIndex::ordered_ids` (O(log n + k)) has landed; the gated
-planner routing is the next phase.
+The O(n) cost of that exhaustive scalar-`ORDER BY` fetch is removed by the
+ordered-index pushdown (EPIC-081, `docs/planning/CORE_PARITY_REMEDIATION.md`):
+when the single `ORDER BY` field has a fully-covering secondary index and the
+query has no WHERE/JOIN/graph/similarity, the engine serves the top-k from the
+index in O(log n + k) (`create_index(field)` to opt in) — ~89 ms → ~0.013 ms for
+that 50k-row query — with identical results to the exhaustive path. Queries
+without a covering index keep the exhaustive scalar-`ORDER BY` behaviour above.
 
 ### 10. Configuration range caps
 


### PR DESCRIPTION
## API-parity campaign — PR-2 (ops / observability)

Second of four PRs closing the verified gaps in `docs/CORE_WIRING_DEBT.md` §6.

> **Stacked on #1096** (`feat/parity-embedded-ops`) to avoid conflicts in shared registration files (server `lib.rs`, tauri `lib.rs`/`build.rs`, OpenAPI). **Base will be retargeted to `develop` once #1096 merges.** Review the PR-2 commit (`215092e8`) only.

### Gaps closed
| Gap | Surfaces wired | Notes |
|-----|----------------|-------|
| 6.6 `collection_diagnostics` | Server route + Python | New canonical DTO `CollectionDiagnosticsResponse` in core `api_types`; `GET /collections/{name}/diagnostics` (+OpenAPI); Python `Database.collection_diagnostics() -> dict`. |
| 6.7 guardrails get/update | Python, Mobile, Tauri | Server already had it. `QueryLimits` (runtime) is distinct from `LimitsConfig` (creation caps) → own marshalling per surface. Mobile gets a `MobileQueryLimits` UniFFI record. |
| 6.8 auto-reindex lifecycle | Python | `detach_auto_reindex()` + `check_auto_reindex_divergence()` complete the previously attach-only surface (cross-ref CORE_WIRING_DEBT entry 2). |

### Tests (one per affected binding)
- **Server**: `test_collection_diagnostics` HTTP integration
- **Python**: diagnostics, guardrails round-trip, auto-reindex lifecycle
- **Mobile**: `test_collection_guardrails_update_and_read`
- **Tauri**: `GuardrailLimits` conversion roundtrip + camelCase deserialize

### Verification
- clippy pedantic clean on core/server/mobile/tauri (`persistence,openapi`)
- Server 79 · Python 87 · Mobile 97 · Tauri 106 — all pass; OpenAPI snapshot regenerated
- Core change is a pure additive serde DTO (no logic / no recall path)

Next: PR-3 (recall-gated — `reorder_for_locality`, `apply_advanced_config`).
