### PR TITLE
refactor: review-pass cleanups (dead params + stale B001 docs)

### DIFF
--- a/conformance/velesql_executor_cases.json
+++ b/conformance/velesql_executor_cases.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "description": "Executor-level VelesQL conformance: asserts result ROWS / COUNTS / ORDERING, not just that a query parses. Golden ids are derived from velesdb-core (the source of truth); other executors (WASM, CLI) must reproduce the same result set for the same dataset+query. Shared read-only dataset; ordering is on unique payload fields so results are deterministic. `cases` must pass; `known_bugs` carry the CORRECT expectation for a confirmed core bug and are checked only by the #[ignore]d reproducer test until fixed.",
+  "description": "Executor-level VelesQL conformance: asserts result ROWS / COUNTS / ORDERING, not just that a query parses. Golden ids are derived from velesdb-core (the source of truth); other executors (WASM, CLI) must reproduce the same result set for the same dataset+query. Shared read-only dataset; ordering is on unique payload fields so results are deterministic. `cases` must pass; `known_bugs` carry the expected result for a former core bug that is now FIXED — the regression-lock test (test_velesql_executor_known_bugs) runs un-ignored and must keep passing.",
   "dataset": {
     "collection": "docs",
     "dimension": 4,
@@ -50,7 +50,7 @@
       "id": "B001",
       "query": "SELECT * FROM docs WHERE year >= 2019 ORDER BY year DESC LIMIT 2",
       "expect_ids": [4, 2],
-      "note": "BUG: scalar ORDER BY <column> + LIMIT applies the LIMIT before the sort on the bounded top-k path (observed [2,1] = first two by id, then sorted). This contradicts KNOWN_LIMITATIONS.md #9 ('Results are identical to the unbounded path'). The bounded top-k optimization only honors similarity() ordering, not scalar ORDER BY. expect_ids holds the CORRECT result; un-ignore test_velesql_executor_known_bugs once fixed."
+      "note": "REGRESSION LOCK (fixed): scalar ORDER BY <column> + LIMIT previously applied the LIMIT before the sort on the bounded top-k path (returned [2,1] instead of [4,2]); the bounded path now equals the unbounded path truncated to k, per KNOWN_LIMITATIONS.md #9. expect_ids is the correct, currently-asserted result."
     }
   ]
 }

--- a/crates/velesdb-cli/tests/velesql_executor_conformance.rs
+++ b/crates/velesdb-cli/tests/velesql_executor_conformance.rs
@@ -21,13 +21,13 @@
 //!
 //! # known_bugs (B001)
 //!
-//! The CLI delegates SELECT execution to `velesdb-core::Database::execute_query`,
-//! so it reproduces the core B001 bug verbatim (`ORDER BY <column> + LIMIT`
-//! applies the LIMIT before the sort on the bounded top-k path — observed
-//! `[2, 1]` instead of the correct `[4, 2]`). The B001 reproducer is therefore
-//! `#[ignore]`d here, mirroring `test_velesql_executor_known_bugs` in core; the
-//! fixture's `expect_ids` carries the CORRECT result so the test can be
-//! un-ignored to lock the fix once core is patched.
+//! B001 was the core bug where `ORDER BY <column> + LIMIT` applied the LIMIT
+//! before the sort on the bounded top-k path (observed `[2, 1]` instead of the
+//! correct `[4, 2]`). It is now fixed in `velesdb-core`, and the CLI delegates
+//! SELECT execution to `velesdb-core::Database::execute_query`, so it inherits
+//! the fix. `test_cli_velesql_executor_known_bugs` asserts the corrected golden
+//! result directly (no `#[ignore]`), mirroring `test_velesql_executor_known_bugs`
+//! in core, and locks the fix against regression.
 
 use std::path::{Path, PathBuf};
 

--- a/crates/velesdb-core/src/collection/search/query/early_return.rs
+++ b/crates/velesdb-core/src/collection/search/query/early_return.rs
@@ -80,8 +80,7 @@ impl Collection {
         if extracted.is_not_similarity_query {
             return self.run_not_similarity_early(&early_ctx, limit).map(Some);
         }
-        self.run_union_early(&early_ctx, cond, params, limit)
-            .map(Some)
+        self.run_union_early(&early_ctx, limit).map(Some)
     }
 
     /// Runs the union early-return path (EPIC-044 US-002: similarity() OR metadata).
@@ -92,8 +91,6 @@ impl Collection {
     fn run_union_early(
         &self,
         early: &EarlyReturnCtx<'_>,
-        cond: &crate::velesql::Condition,
-        params: &std::collections::HashMap<String, serde_json::Value>,
         limit: usize,
     ) -> Result<Vec<SearchResult>> {
         let mut graph_cache = super::where_eval::GraphMatchEvalCache::default();
@@ -103,7 +100,7 @@ impl Collection {
             limit
         };
         self.execute_early_return_query(
-            |s| s.execute_union_query(cond, params, execution_limit),
+            |s| s.execute_union_query(early.cond, early.params, execution_limit),
             early,
             &mut graph_cache,
         )


### PR DESCRIPTION
## Summary

Cleanups from a review & simplify pass over the parity-remediation work merged in #1127. The review found the code clean and well-engineered; only three safe, behavior-preserving items were worth applying:

1. **`early_return.rs`** — `run_union_early` took `cond`/`params` as parameters that its `EarlyReturnCtx` already carries (`early.cond`/`early.params` are the same references the sole caller passes). Drops the two redundant parameters and reads them from the context.
2. **`cli/tests/velesql_executor_conformance.rs`** + **`conformance/velesql_executor_cases.json`** — the B001 `known_bugs` notes still described B001 as a *live* bug behind an `#[ignore]`d reproducer. It is fixed (in #1127) and the reproducers run **un-ignored as regression locks**; the wording is updated to match.

No behaviour change. Executor conformance (core + CLI) and the 34 union tests are green; core `clippy -D pedantic` + `fmt --check` clean.
