### PR TITLE
refactor(migrate+sdk/ts): drop dead allow(deprecated), DRY JSON parsing, tighten TS types

### DIFF
--- a/crates/velesdb-migrate/src/pipeline_graph.rs
+++ b/crates/velesdb-migrate/src/pipeline_graph.rs
@@ -177,14 +177,9 @@ fn build_edge(
     let key = format!("{from_node_id}-{to_node_id}-{}", relation.edge_label);
     let id = crate::pipeline::fnv1a64(key.as_bytes());
 
-    let edge =
-        match velesdb_core::GraphEdge::new(id, from_node_id, to_node_id, &relation.edge_label) {
-            Ok(e) => e,
-            Err(e) => {
-                warn!("Failed to create edge {}: {}", id, e);
-                return None;
-            }
-        };
+    let edge = velesdb_core::GraphEdge::new(id, from_node_id, to_node_id, &relation.edge_label)
+        .inspect_err(|e| warn!("Failed to create edge {}: {}", id, e))
+        .ok()?;
 
     Some(attach_weight(edge, point, relation))
 }
@@ -194,19 +189,16 @@ fn attach_weight(
     point: &crate::connectors::ExtractedPoint,
     relation: &RelationConfig,
 ) -> velesdb_core::GraphEdge {
-    let weight_col = match relation.weight_column {
-        Some(ref col) => col,
-        None => return edge,
+    let Some(weight_col) = &relation.weight_column else {
+        return edge;
     };
-
-    let weight = match point.payload.get(weight_col).and_then(|v| v.as_f64()) {
-        Some(w) => w,
-        None => return edge,
+    let Some(weight) = point.payload.get(weight_col).and_then(|v| v.as_f64()) else {
+        return edge;
     };
-
-    let mut props = std::collections::HashMap::new();
-    props.insert("weight".to_string(), serde_json::json!(weight));
-    edge.with_properties(props)
+    edge.with_properties(std::collections::HashMap::from([(
+        "weight".to_string(),
+        serde_json::json!(weight),
+    )]))
 }
 
 fn value_to_id_str(value: &serde_json::Value) -> Option<String> {

--- a/crates/velesdb-migrate/src/pipeline_points.rs
+++ b/crates/velesdb-migrate/src/pipeline_points.rs
@@ -143,7 +143,6 @@ pub(crate) fn load_prepared_batch(
     continue_on_error: bool,
     stats: &mut MigrationStats,
 ) -> Result<bool> {
-    #[allow(deprecated)] // TODO(MIGRATE-01): migrate to get_vector_collection()
     let collection = db
         .get_vector_collection(collection_name)
         .ok_or_else(|| Error::DestinationConnection("Collection not found".to_string()))?;

--- a/sdks/typescript/src/backends/crud-backend.ts
+++ b/sdks/typescript/src/backends/crud-backend.ts
@@ -20,6 +20,7 @@ import {
   returnNullOnNotFound,
   collectionPath,
   toNumberArray,
+  safeJsonParse,
 } from './shared';
 
 /** Minimal transport interface for CRUD operations. */
@@ -441,7 +442,7 @@ async function sendRawBulk(
 
 /** Parse a raw-bulk HTTP response into the inserted count, throwing on error. */
 async function parseRawBulkResponse(response: Response): Promise<number> {
-  const data = await response.json().catch(() => ({}));
+  const data = await safeJsonParse(response);
   if (!response.ok) {
     const code = typeof data.code === 'string' ? data.code : `HTTP_${response.status}`;
     const message = typeof data.error === 'string' ? data.error : `HTTP ${response.status}`;

--- a/sdks/typescript/src/backends/query-backend.ts
+++ b/sdks/typescript/src/backends/query-backend.ts
@@ -130,13 +130,12 @@ export async function query(
 
   throwOnError(response, `Collection '${collection}'`);
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const rawData = response.data as any;
-  if (rawData && Object.prototype.hasOwnProperty.call(rawData, 'result')) {
+  const rawData = response.data; // Record<string, unknown> | undefined
+  if (rawData != null && Object.prototype.hasOwnProperty.call(rawData, 'result')) {
     return {
       result: rawData.result as Record<string, unknown> | unknown[],
       stats: {
-        executionTimeMs: rawData.timing_ms ?? 0,
+        executionTimeMs: (rawData.timing_ms as number | undefined) ?? 0,
         strategy: 'aggregation',
         scannedNodes: 0,
       },
@@ -145,11 +144,11 @@ export async function query(
 
   // v3.0.0: Results are projected rows — shape depends on SELECT clause.
   return {
-    results: (rawData?.results ?? []) as Record<string, unknown>[],
+    results: ((rawData?.results ?? []) as Record<string, unknown>[]),
     stats: {
-      executionTimeMs: rawData?.timing_ms ?? 0,
+      executionTimeMs: (rawData?.timing_ms as number | undefined) ?? 0,
       strategy: 'select',
-      scannedNodes: rawData?.rows_returned ?? 0,
+      scannedNodes: (rawData?.rows_returned as number | undefined) ?? 0,
     },
   };
 }

--- a/sdks/typescript/src/backends/rest-http.ts
+++ b/sdks/typescript/src/backends/rest-http.ts
@@ -9,6 +9,7 @@
 import type { SparseVector } from '../types';
 import { ConnectionError } from '../types';
 import type { TransportResponse, BaseTransport } from './shared';
+import { safeJsonParse } from './shared';
 import type { CrudTransport, RawBulkTransport } from './crud-backend';
 import { parseRestPointId, sparseVectorToRestFormat } from './crud-backend';
 import type { SearchTransport } from './search-backend';
@@ -110,7 +111,7 @@ export async function request<T>(
       signal: controller.signal,
     });
     clearTimeout(timeoutId);
-    const data = await response.json().catch(() => ({}));
+    const data = await safeJsonParse(response);
     if (!response.ok) {
       const ep = extractErrorPayload(data);
       return { error: {
@@ -118,7 +119,7 @@ export async function request<T>(
         message: ep.message ?? `HTTP ${response.status}`,
       }};
     }
-    return { data };
+    return { data: data as unknown as T };
   } catch (error) {
     clearTimeout(timeoutId);
     wrapCatchError(error);

--- a/sdks/typescript/src/backends/search-backend.ts
+++ b/sdks/typescript/src/backends/search-backend.ts
@@ -37,8 +37,7 @@ export async function search(
 ): Promise<SearchResult[]> {
   const queryVector = toNumberArray(query);
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const body: Record<string, any> = {
+  const body: Record<string, unknown> = {
     vector: queryVector,
     top_k: options?.k ?? 10,
     filter: options?.filter,
@@ -211,8 +210,7 @@ export async function sparseSearchNamed(
   indexName: string,
   options?: SparseSearchNamedOptions
 ): Promise<SearchResult[]> {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const body: Record<string, any> = {
+  const body: Record<string, unknown> = {
     sparse_vectors: { [indexName]: transport.sparseToRest(query) },
     sparse_index: indexName,
     top_k: options?.k ?? 10,

--- a/sdks/typescript/src/backends/shared.ts
+++ b/sdks/typescript/src/backends/shared.ts
@@ -248,6 +248,30 @@ export function validateCollectionName(name: string): void {
 }
 
 // ---------------------------------------------------------------------------
+// HTTP helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a fetch `Response` body as JSON, returning an empty object `{}`
+ * on parse failure.
+ *
+ * Used at HTTP error-body extraction sites where a malformed or absent body
+ * (e.g. a 504 gateway response with no JSON payload) must not mask the
+ * original HTTP error code. Callers always narrow individual properties
+ * before use (`typeof data.code === 'string'`), so the empty-object fallback
+ * is safe.
+ *
+ * @since 2026-06-15
+ */
+export async function safeJsonParse(
+  response: Response
+): Promise<Record<string, unknown>> {
+  // response.json() returns Promise<any>; the catch arm guarantees we
+  // always resolve to a plain object, never reject.
+  return response.json().catch(() => ({}));
+}
+
+// ---------------------------------------------------------------------------
 // Vector helpers
 // ---------------------------------------------------------------------------
 

--- a/sdks/typescript/src/backends/streaming-backend.ts
+++ b/sdks/typescript/src/backends/streaming-backend.ts
@@ -20,6 +20,7 @@ import {
   collectionPath,
   toNumberArray,
   validateCollectionName,
+  safeJsonParse,
 } from './shared';
 
 /** Minimal transport interface for streaming operations. */
@@ -90,8 +91,7 @@ export async function streamInsert(
     const restId = transport.parseRestPointId(doc.id);
     const vector = toNumberArray(doc.vector);
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const body: Record<string, any> = {
+    const body: Record<string, unknown> = {
       id: restId,
       vector,
       payload: doc.payload ?? null,
@@ -128,7 +128,7 @@ export async function streamInsert(
       }
 
       if (!response.ok && response.status !== 202) {
-        const data = await response.json().catch(() => ({}));
+        const data = await safeJsonParse(response);
         const errorPayload = transport.extractErrorPayload(data);
         throw new VelesDBError(
           errorPayload.message ?? `HTTP ${response.status}`,
@@ -232,8 +232,7 @@ export async function streamUpsertPoints(
     const restId = requireSafeRangeId(transport.parseRestPointId(doc.id));
     const vector = toNumberArray(doc.vector);
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const point: Record<string, any> = {
+    const point: Record<string, unknown> = {
       id: restId,
       vector,
       payload: doc.payload ?? null,
@@ -274,7 +273,7 @@ export async function streamUpsertPoints(
     }
 
     if (!response.ok) {
-      const data = await response.json().catch(() => ({}));
+      const data = await safeJsonParse(response);
       const errorPayload = transport.extractErrorPayload(data);
       throw new VelesDBError(
         errorPayload.message ?? `HTTP ${response.status}`,
@@ -282,7 +281,7 @@ export async function streamUpsertPoints(
       );
     }
 
-    const data = await response.json().catch(() => ({}));
+    const data = await safeJsonParse(response);
     return {
       message: typeof data.message === 'string' ? data.message : 'Stream processed',
       inserted: typeof data.inserted === 'number' ? data.inserted : 0,


### PR DESCRIPTION
## Summary

Targeted quality sweep — pure refactors, no behaviour change, no new dependencies. Supersedes the original sweep proposal (#1137).

### Rust (`velesdb-migrate`)

- **`pipeline_points.rs`** — remove the lone `#[allow(deprecated)]` left after the `get_vector_collection()` migration was already completed (a dead suppressor with nothing left to suppress).
- **`pipeline_graph.rs`** — `attach_weight` replaces two `match … return` guards with `let…else` and builds the single-entry weight map with `HashMap::from([…])` (drops a `mut`); `build_edge` folds its four-line error `match` into `Result::inspect_err(…).ok()?`.

### TypeScript SDK (`sdks/typescript`)

- **`shared.ts`** — add `safeJsonParse(response): Promise<Record<string, unknown>>` consolidating the `.json().catch(() => ({}))` pattern used at 5 HTTP error-body sites.
- **`crud-backend.ts` · `rest-http.ts` · `streaming-backend.ts`** — route the 5 sites through `safeJsonParse`.
- **`query-backend.ts`** — drop the `as any` cast on `response.data` (the generic `requestJson<Record<string, unknown>>` already types it) in favour of explicit scalar casts.
- **`search-backend.ts` · `streaming-backend.ts`** — `Record<string, any>` → `Record<string, unknown>` on 4 write-only request bodies, removing the `eslint-disable` suppressions.

## Verification

- `cargo fmt --all --check` — clean
- `cargo clippy -p velesdb-migrate --all-targets -- -D warnings -D clippy::pedantic` — clean
- `cargo test -p velesdb-migrate` — 15 passed
- `sdks/typescript`: `npm run typecheck` clean, `npm test` 839 passed, `npm run lint` 0 errors / 0 warnings

MSRV note: `let…else` (Rust 1.65) and `inspect_err` (1.76) are both within the workspace MSRV 1.89.
