### PR TITLE
fix(velesql): ordered-index ORDER BY route must decline computed projections

### DIFF
--- a/crates/velesdb-core/src/collection/search/query/ordered_index_scan.rs
+++ b/crates/velesdb-core/src/collection/search/query/ordered_index_scan.rs
@@ -94,7 +94,8 @@ impl Collection {
 /// Eligible shape (all required): the ORDER BY is exactly **one** plain
 /// `Field` key (not Aggregate / Arithmetic / similarity); no WHERE / filter,
 /// no JOIN, no graph MATCH, no vector / similarity / sparse search, no
-/// DISTINCT, no GROUP BY / HAVING, and a plain (non-aggregate) projection.
+/// DISTINCT, no GROUP BY / HAVING, and a plain (non-computed) projection — no
+/// aggregate, window function, `similarity()` score, or qualified wildcard.
 /// Coverage and index existence are verified later via `ordered_ids_if_covered`.
 fn ordered_index_scan_applies<'a>(
     stmt: &'a crate::velesql::SelectStatement,
@@ -111,14 +112,14 @@ fn ordered_index_scan_applies<'a>(
 }
 
 /// Whether the statement carries no clause that changes the result shape
-/// (WHERE / JOIN / DISTINCT / GROUP BY / HAVING / aggregate projection).
+/// (WHERE / JOIN / DISTINCT / GROUP BY / HAVING / computed projection).
 fn plain_query_shape(stmt: &crate::velesql::SelectStatement) -> bool {
     stmt.where_clause.is_none()
         && stmt.joins.is_empty()
         && stmt.distinct == crate::velesql::DistinctMode::None
         && stmt.group_by.is_none()
         && stmt.having.is_none()
-        && !select_has_aggregate(&stmt.columns)
+        && projection_is_plain(&stmt.columns)
 }
 
 /// Whether the extracted components carry no ranked / graph / set-op fetch
@@ -134,13 +135,33 @@ fn plain_fetch_shape(extracted: &ExtractedComponents) -> bool {
         && !extracted.is_not_similarity_query
 }
 
-/// Returns `true` when the projection carries an aggregate function, which
-/// changes the result shape and disqualifies the ordered-index fast path.
-fn select_has_aggregate(columns: &crate::velesql::SelectColumns) -> bool {
+/// Returns `true` when the projection is "plain" — `SELECT *` or a bare column
+/// list — so the fast path reproduces it exactly. The fast path returns its
+/// page directly (`mod.rs`), bypassing the post-processing stage that runs
+/// DISTINCT, **window functions** (`select_dispatch::evaluate`) and similarity
+/// scoring; any *computed* projection (aggregate, window function, `similarity()`
+/// score, or qualified wildcard) needs that bypassed stage and therefore
+/// disqualifies the route. The `Mixed` arm names every field (no `..`) so a
+/// future computed field is a compile error here, not a silently-dropped
+/// projection.
+fn projection_is_plain(columns: &crate::velesql::SelectColumns) -> bool {
     use crate::velesql::SelectColumns;
     match columns {
-        SelectColumns::Aggregations(aggs) => !aggs.is_empty(),
-        SelectColumns::Mixed { aggregations, .. } => !aggregations.is_empty(),
-        _ => false,
+        SelectColumns::All | SelectColumns::Columns(_) => true,
+        SelectColumns::Mixed {
+            columns: _,
+            aggregations,
+            similarity_scores,
+            qualified_wildcards,
+            window_functions,
+        } => {
+            aggregations.is_empty()
+                && similarity_scores.is_empty()
+                && qualified_wildcards.is_empty()
+                && window_functions.is_empty()
+        }
+        SelectColumns::Aggregations(_)
+        | SelectColumns::SimilarityScore(_)
+        | SelectColumns::QualifiedWildcard(_) => false,
     }
 }

--- a/crates/velesdb-core/tests/ordered_index_order_by_equivalence.rs
+++ b/crates/velesdb-core/tests/ordered_index_order_by_equivalence.rs
@@ -299,3 +299,54 @@ fn score_matches_exhaustive_not_just_ids() {
         "plain ORDER BY scan scores 1.0 on the index path"
     );
 }
+
+/// EPIC-081 phase 2 gate hole (regression): a window-function projection over a
+/// plain `ORDER BY <indexed_field> LIMIT k` must NOT take the ordered-index
+/// fast path. The fast path returns the page directly (`mod.rs` `return
+/// Ok(results)`), bypassing window evaluation (`select_dispatch::evaluate`),
+/// which silently drops the injected alias. The gate's `Mixed { aggregations,
+/// .. }` arm ignored `window_functions`, so the route fired and `rn` vanished.
+#[test]
+fn window_function_projection_not_dropped_by_index_path() {
+    let sql = "SELECT id, year, ROW_NUMBER() OVER (ORDER BY year DESC) AS rn \
+               FROM docs ORDER BY year DESC LIMIT 5";
+
+    let rn_by_id = |rs: &[velesdb_core::point::SearchResult]| -> Vec<(u64, Option<u64>)> {
+        rs.iter()
+            .map(|r| {
+                let rn = r
+                    .point
+                    .payload
+                    .as_ref()
+                    .and_then(|p| p.get("rn"))
+                    .and_then(serde_json::Value::as_u64);
+                (r.point.id, rn)
+            })
+            .collect()
+    };
+
+    let (no_index, _d1) = build(ROWS);
+    let exhaustive = no_index
+        .execute_query_str(sql, &HashMap::new())
+        .expect("exhaustive");
+
+    let (with_index, _d2) = build(ROWS);
+    with_index.create_index("year").expect("create_index");
+    let indexed = with_index
+        .execute_query_str(sql, &HashMap::new())
+        .expect("index");
+
+    // The exhaustive path computes rn; the index path must fall back so it does
+    // too — not return rows with the alias missing.
+    assert!(
+        exhaustive
+            .iter()
+            .all(|r| r.point.payload.as_ref().and_then(|p| p.get("rn")).is_some()),
+        "exhaustive path should compute rn"
+    );
+    assert_eq!(
+        rn_by_id(&exhaustive),
+        rn_by_id(&indexed),
+        "window-function alias dropped on the ordered-index fast path"
+    );
+}


### PR DESCRIPTION
## Summary

Correctness fix for the EPIC-081 phase-2 ordered-index `ORDER BY <field> LIMIT k` fast path (shipped in #1136).

The fast path (`Collection::try_ordered_index_scan`) returns its page **directly** (`mod.rs` `return Ok(results)`), bypassing the SELECT post-processing stage that runs DISTINCT, **window functions** (`select_dispatch::evaluate`), and `similarity()` scoring. Its projection gate matched `SelectColumns::Mixed { aggregations, .. }` and the `..` silently ignored the `window_functions`, `similarity_scores`, and `qualified_wildcards` fields.

So a query like:

```sql
SELECT id, year, ROW_NUMBER() OVER (ORDER BY year DESC) AS rn
FROM docs ORDER BY year DESC LIMIT 5
```

over a collection with a fully-covering secondary index on `year` took the index route and **silently dropped the injected `rn` column** — the post-processing stage that computes window values never ran. (Observed: ids matched the exhaustive path, but `rn` was `None` on every row instead of `1..5`.)

## Fix

Replace `select_has_aggregate` with `projection_is_plain`, which the route requires:

- `SELECT *` and bare column lists → eligible.
- `Mixed { .. }` → eligible **only** when `aggregations`, `window_functions`, `similarity_scores`, and `qualified_wildcards` are all empty (degenerates to a plain column list).
- `Aggregations` / `SimilarityScore` / `QualifiedWildcard` → not eligible.

The `Mixed` arm names every field explicitly (no `..`), so any future computed-projection field is a **compile error here** rather than another silently-dropped projection. The change is strictly more conservative: a disqualified shape just falls through to today's exact exhaustive path — zero behavior change for the shapes the route already served.

## Verification

- New regression `tests/ordered_index_order_by_equivalence.rs::window_function_projection_not_dropped_by_index_path` — asserts both paths inject the window alias (fails before this fix, passes after).
- `ordered_index_order_by_equivalence` — all 14 pass.
- All 38 window-function tests (unit + BDD) pass, including window + vector NEAR and qualified-wildcard cases.
- `cargo fmt --all --check`, `cargo clippy -p velesdb-core --all-targets --features persistence -- -D warnings -D clippy::pedantic`, and `lizard -C 8 -L 50` on the changed file — all clean.

Found via an EPIC-081 phase-3 design review; this is the one hole that affects already-shipped code, so it ships on its own.
