### PR TITLE
feat(velesql): scalar ORDER BY index advisor (EPIC-081 phase 3a)

### DIFF
--- a/crates/velesdb-core/src/collection/core/index_management.rs
+++ b/crates/velesdb-core/src/collection/core/index_management.rs
@@ -114,6 +114,72 @@ impl Collection {
         self.secondary_indexes.read().contains_key(field_name)
     }
 
+    /// Recommends secondary indexes for scalar `ORDER BY <field>` queries
+    /// (EPIC-081 phase 3a, recommendation-only).
+    ///
+    /// Returns one [`OrderByIndexSuggestion`] per field that drove at least
+    /// `min_observations` eligible `ORDER BY <field>` queries down the
+    /// exhaustive path (sorted by descending observation count, then field
+    /// name). The state is derived from the **live** index, so a field whose
+    /// index now fully covers the collection is *resolved* (the fast path fires)
+    /// and is dropped from the advice. Remaining fields carry [`OrderByIndexState`]:
+    /// `Missing` (no secondary index — `CREATE INDEX (<field>)` would enable the
+    /// `O(log n + k)` fast path) or `BuiltButUncovered` (an index exists but does
+    /// not fully cover the collection, so the gap is the data, not a missing
+    /// index). Observation counts are cumulative since the collection was opened
+    /// and do not decay.
+    ///
+    /// Observation-only: this never creates, drops, or mutates an index.
+    ///
+    /// [`OrderByIndexSuggestion`]: crate::collection::order_by_advisor::OrderByIndexSuggestion
+    /// [`OrderByIndexState`]: crate::collection::order_by_advisor::OrderByIndexState
+    #[must_use]
+    pub(crate) fn order_by_index_advice(
+        &self,
+        min_observations: u64,
+    ) -> Vec<crate::collection::order_by_advisor::OrderByIndexSuggestion> {
+        use crate::collection::order_by_advisor::OrderByIndexSuggestion;
+        // Snapshot under the advisor lock, release it before touching the
+        // secondary-index lock so only one lock is ever held at a time.
+        let observed = self.order_by_advisor.read().observed(min_observations);
+        observed
+            .into_iter()
+            .filter_map(|(field, observed_count)| {
+                self.order_by_index_state(&field)
+                    .map(|state| OrderByIndexSuggestion {
+                        field,
+                        observed_count,
+                        state,
+                    })
+            })
+            .collect()
+    }
+
+    /// Live advice state for `field`, derived under one secondary-index read
+    /// lock: `Missing` when no index exists, `BuiltButUncovered` when an index
+    /// exists but does not fully cover the collection, or `None` when an index
+    /// exists *and* fully covers it — in which case the ordered-index fast path
+    /// already serves the field, so there is nothing to advise.
+    fn order_by_index_state(
+        &self,
+        field: &str,
+    ) -> Option<crate::collection::order_by_advisor::OrderByIndexState> {
+        use crate::collection::order_by_advisor::OrderByIndexState;
+        let point_count = self.len();
+        let indexes = self.secondary_indexes.read();
+        match indexes.get(field) {
+            None => Some(OrderByIndexState::Missing),
+            Some(index)
+                if index
+                    .ordered_ids_if_covered(false, 0, point_count)
+                    .is_some() =>
+            {
+                None
+            }
+            Some(_) => Some(OrderByIndexState::BuiltButUncovered),
+        }
+    }
+
     /// Returns the set of payload field names covered by a secondary index
     /// (issue #607).
     ///

--- a/crates/velesdb-core/src/collection/core/lifecycle.rs
+++ b/crates/velesdb-core/src/collection/core/lifecycle.rs
@@ -98,6 +98,9 @@ impl Collection {
             composite_index_manager: Arc::new(RwLock::new(CompositeIndexManager::new())),
             query_pattern_tracker: Arc::new(RwLock::new(QueryPatternTracker::new())),
             index_advisor: Arc::new(RwLock::new(IndexAdvisor::new())),
+            order_by_advisor: Arc::new(RwLock::new(
+                crate::collection::order_by_advisor::OrderByIndexAdvisor::default(),
+            )),
             edge_store: Arc::new(parts.edge_store),
             edge_wal_lock: Arc::new(Mutex::new(())),
             sparse_indexes: Arc::new(RwLock::new(parts.sparse_indexes)),

--- a/crates/velesdb-core/src/collection/mod.rs
+++ b/crates/velesdb-core/src/collection/mod.rs
@@ -25,6 +25,7 @@ pub mod graph;
 mod graph_collection;
 mod graph_collection_query;
 mod metadata_collection;
+pub(crate) mod order_by_advisor;
 pub(crate) mod payload_mirror;
 pub(crate) mod payload_size;
 pub mod query_cost;
@@ -65,6 +66,7 @@ pub use graph::{
 };
 pub use graph_collection::GraphCollection;
 pub use metadata_collection::MetadataCollection;
+pub use order_by_advisor::{OrderByIndexState, OrderByIndexSuggestion};
 pub(crate) use types::Collection;
 pub use types::CollectionType;
 pub(crate) use types::RuntimeLimits;

--- a/crates/velesdb-core/src/collection/order_by_advisor.rs
+++ b/crates/velesdb-core/src/collection/order_by_advisor.rs
@@ -1,0 +1,89 @@
+//! Recommendation-only advisor for scalar `ORDER BY <field>` queries
+//! (EPIC-081 phase 3a).
+//!
+//! Records every query whose shape is eligible for the index-backed
+//! `ORDER BY <field> LIMIT k` fast path (EPIC-081 phase 2) but which fell back
+//! to the exhaustive sort because the sort field has no *fully covering*
+//! secondary index. An operator reads [`order_by_index_advice`] to learn which
+//! fields would benefit from `CREATE INDEX`.
+//!
+//! This advisor is **observation-only**: it never creates, drops, or mutates an
+//! index, and never alters a query result. Auto-creation is intentionally out
+//! of scope — `create_index` re-backfills the index `O(n)`, which on the query
+//! thread would stall the very query that triggered it.
+//!
+//! [`order_by_index_advice`]: crate::VectorCollection::order_by_index_advice
+
+use std::collections::HashMap;
+
+/// Upper bound on the number of distinct fields tracked. `ORDER BY` field names
+/// come from the raw query AST and are not validated to exist, so an
+/// adversarial stream of `ORDER BY <fresh_name> LIMIT k` queries could otherwise
+/// grow the map without bound for the collection's lifetime. This cap is far
+/// above any real schema's count of distinct `ORDER BY` fields; once reached,
+/// further *unseen* fields are dropped (already-tracked fields keep counting).
+const MAX_TRACKED_FIELDS: usize = 1024;
+
+/// Why an eligible `ORDER BY <field>` query could not use the ordered-index
+/// fast path.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OrderByIndexState {
+    /// No secondary index exists on the field. `CREATE INDEX (<field>)` would
+    /// enable the `O(log n + k)` ordered-index fast path.
+    Missing,
+    /// A secondary index exists but does not fully cover the collection (some
+    /// rows lack the field, or hold a non-primitive value), so the fast path
+    /// still declines. The gap is the data, not a missing index — creating
+    /// another index would not help. Surfaced as a distinct state so a
+    /// never-firing index is not invisible.
+    BuiltButUncovered,
+}
+
+/// A single index recommendation for a scalar `ORDER BY` field.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OrderByIndexSuggestion {
+    /// The payload field used in `ORDER BY`.
+    pub field: String,
+    /// How many eligible `ORDER BY <field>` queries fell back to the exhaustive
+    /// path since the collection was opened.
+    pub observed_count: u64,
+    /// Whether an index is missing or present-but-not-covering.
+    pub state: OrderByIndexState,
+}
+
+/// Tracks fall-back observations per field. Cheap: one `HashMap<String, u64>`
+/// guarded by the collection's advisor `RwLock` (lock order position 7).
+#[derive(Debug, Default)]
+pub struct OrderByIndexAdvisor {
+    /// Field name -> count of eligible `ORDER BY` queries that fell back.
+    observations: HashMap<String, u64>,
+}
+
+impl OrderByIndexAdvisor {
+    /// Records one eligible `ORDER BY <field>` query that fell back to the
+    /// exhaustive path. Only ever called from the fast-path decline branch, so
+    /// it never observes a query the route already served. Bounded by
+    /// [`MAX_TRACKED_FIELDS`]: an unseen field past the cap is dropped, but
+    /// already-tracked fields keep counting (`saturating_add` guards the
+    /// physically-unreachable `u64` overflow).
+    pub(crate) fn observe(&mut self, field: &str) {
+        if let Some(count) = self.observations.get_mut(field) {
+            *count = count.saturating_add(1);
+        } else if self.observations.len() < MAX_TRACKED_FIELDS {
+            self.observations.insert(field.to_owned(), 1);
+        }
+    }
+
+    /// Fields observed at least `min_observations` times, with their counts,
+    /// sorted by descending count then field name for deterministic output.
+    pub(crate) fn observed(&self, min_observations: u64) -> Vec<(String, u64)> {
+        let mut out: Vec<(String, u64)> = self
+            .observations
+            .iter()
+            .filter(|&(_, &count)| count >= min_observations)
+            .map(|(field, &count)| (field.clone(), count))
+            .collect();
+        out.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+        out
+    }
+}

--- a/crates/velesdb-core/src/collection/search/query/ordered_index_scan.rs
+++ b/crates/velesdb-core/src/collection/search/query/ordered_index_scan.rs
@@ -44,6 +44,11 @@ impl Collection {
             return Ok(None);
         };
         let Some(page) = self.ordered_index_page(stmt, field) else {
+            // Eligible shape but no covering index → record an advisor
+            // observation (EPIC-081 phase 3a), then fall through unchanged. The
+            // index lock taken by `ordered_index_page` is already released here,
+            // so the brief advisor write lock holds nothing else.
+            self.order_by_advisor.write().observe(field);
             return Ok(None);
         };
 

--- a/crates/velesdb-core/src/collection/types.rs
+++ b/crates/velesdb-core/src/collection/types.rs
@@ -10,6 +10,7 @@ use crate::collection::graph::property_index::{
 use crate::collection::graph::{
     ConcurrentEdgeStore, GraphSchema, LabelIndex, PropertyIndex, RangeIndex,
 };
+use crate::collection::order_by_advisor::OrderByIndexAdvisor;
 use crate::collection::stats::CollectionStats;
 #[cfg(feature = "persistence")]
 use crate::collection::streaming::delta::DeltaBuffer;
@@ -279,6 +280,16 @@ pub(crate) struct Collection {
     ///
     /// Lock order position: **7** (same tier as `property_index` / `range_index`).
     pub(crate) index_advisor: Arc<RwLock<IndexAdvisor>>,
+
+    /// Scalar `ORDER BY <field>` index advisor (EPIC-081 phase 3a).
+    ///
+    /// Records eligible `ORDER BY` queries that fell back to the exhaustive
+    /// sort because the sort field lacks a fully-covering secondary index, so
+    /// an operator can be advised to create one. Recommendation-only — never
+    /// mutates an index or a query result.
+    ///
+    /// Lock order position: **7** (same tier as `index_advisor`).
+    pub(crate) order_by_advisor: Arc<RwLock<OrderByIndexAdvisor>>,
 
     /// Concurrent edge store for knowledge graph relationships (EPIC-015).
     ///

--- a/crates/velesdb-core/src/collection/vector_collection/accessors.rs
+++ b/crates/velesdb-core/src/collection/vector_collection/accessors.rs
@@ -174,6 +174,20 @@ impl VectorCollection {
         self.inner.drop_secondary_index(field_name)
     }
 
+    /// Recommends secondary indexes for scalar `ORDER BY <field>` queries that
+    /// repeatedly fell back to the exhaustive sort (EPIC-081 phase 3a).
+    ///
+    /// Returns one suggestion per field observed at least `min_observations`
+    /// times, sorted by descending observation count then field name. This is
+    /// recommendation-only — it never creates, drops, or mutates an index.
+    #[must_use]
+    pub fn order_by_index_advice(
+        &self,
+        min_observations: u64,
+    ) -> Vec<crate::collection::order_by_advisor::OrderByIndexSuggestion> {
+        self.inner.order_by_index_advice(min_observations)
+    }
+
     /// Returns `true` if a property index exists.
     #[must_use]
     pub fn has_property_index(&self, label: &str, property: &str) -> bool {

--- a/crates/velesdb-core/src/lib.rs
+++ b/crates/velesdb-core/src/lib.rs
@@ -187,6 +187,9 @@ pub use collection::{
     IndexInfo,
     MetadataCollection,
     NodeType,
+    // Ordered-index ORDER BY advisor (EPIC-081 phase 3a)
+    OrderByIndexState,
+    OrderByIndexSuggestion,
     // Scroll cursor (Issue #429)
     ScrollBatch,
     TraversalConfig,

--- a/crates/velesdb-core/tests/ordered_index_advisor.rs
+++ b/crates/velesdb-core/tests/ordered_index_advisor.rs
@@ -1,0 +1,141 @@
+#![cfg(all(test, feature = "persistence"))]
+//! EPIC-081 phase 3a — scalar `ORDER BY <field>` index advisor.
+//!
+//! The advisor records eligible `ORDER BY <field>` queries that fall back to
+//! the exhaustive sort for want of a *fully covering* secondary index, and
+//! **never alters a query result**. These tests pin: recording on the
+//! eligible-but-unindexed shape (`Missing`), the `BuiltButUncovered` state,
+//! behaviour-neutrality, shape-isolation (only `ORDER BY` shapes observed), and
+//! the `min_observations` threshold.
+
+use serde_json::json;
+use std::collections::HashMap;
+use tempfile::TempDir;
+use velesdb_core::{DistanceMetric, OrderByIndexState, Point, StorageMode, VectorCollection};
+
+fn build(rows: &[(u64, i64)]) -> (VectorCollection, TempDir) {
+    let dir = TempDir::new().expect("temp dir");
+    let collection = VectorCollection::create(
+        dir.path().join("docs"),
+        "docs",
+        2,
+        DistanceMetric::Cosine,
+        StorageMode::Full,
+    )
+    .expect("create collection");
+    let points: Vec<Point> = rows
+        .iter()
+        .map(|&(id, year)| Point::new(id, vec![1.0, 0.0], Some(json!({ "year": year }))))
+        .collect();
+    collection.upsert(points).expect("upsert");
+    (collection, dir)
+}
+
+const ROWS: &[(u64, i64)] = &[(1, 2020), (2, 2022), (3, 2021), (4, 2023), (5, 2019)];
+
+fn run(c: &VectorCollection, sql: &str) -> Vec<u64> {
+    c.execute_query_str(sql, &HashMap::new())
+        .expect("query")
+        .iter()
+        .map(|r| r.point.id)
+        .collect()
+}
+
+#[test]
+fn records_missing_index_for_eligible_order_by() {
+    let (c, _d) = build(ROWS);
+    // No index on `year`: the eligible ORDER BY falls back and is recorded.
+    let _ = run(&c, "SELECT * FROM docs ORDER BY year DESC LIMIT 3");
+    let advice = c.order_by_index_advice(1);
+    assert_eq!(advice.len(), 1);
+    assert_eq!(advice[0].field, "year");
+    assert_eq!(advice[0].observed_count, 1);
+    assert_eq!(advice[0].state, OrderByIndexState::Missing);
+}
+
+#[test]
+fn recording_is_behaviour_neutral() {
+    let (c, _d) = build(ROWS);
+    let ids = run(&c, "SELECT * FROM docs ORDER BY year DESC LIMIT 3");
+    // The advisor did not change the result: DESC by year → 2023, 2022, 2021.
+    assert_eq!(ids, vec![4, 2, 3]);
+    // ...and it still recorded the observation.
+    assert_eq!(c.order_by_index_advice(1).len(), 1);
+}
+
+#[test]
+fn covered_fast_path_records_nothing() {
+    let (c, _d) = build(ROWS);
+    c.create_index("year").expect("create_index");
+    let _ = run(&c, "SELECT * FROM docs ORDER BY year DESC LIMIT 3");
+    // The fast path served it → no fall-back, no advice.
+    assert!(c.order_by_index_advice(1).is_empty());
+}
+
+#[test]
+fn non_order_by_query_is_not_recorded() {
+    let (c, _d) = build(ROWS);
+    // No ORDER BY → the ordered-index route is irrelevant and never observed,
+    // now or after later phases broaden eligibility.
+    let _ = run(&c, "SELECT * FROM docs LIMIT 3");
+    assert!(c.order_by_index_advice(1).is_empty());
+}
+
+#[test]
+fn where_clause_currently_not_recorded() {
+    let (c, _d) = build(ROWS);
+    // A WHERE clause disqualifies the phase-2 route before the advisor hook, so
+    // it is not observed today. (EPIC-081 phase 3b — WHERE-filtered top-k —
+    // will make this shape eligible; update this expectation then.)
+    let _ = run(
+        &c,
+        "SELECT * FROM docs WHERE year >= 2021 ORDER BY year DESC LIMIT 2",
+    );
+    assert!(c.order_by_index_advice(1).is_empty());
+}
+
+#[test]
+fn built_but_uncovered_index_is_surfaced() {
+    let (c, _d) = build(&[(1, 2020), (2, 2022)]);
+    c.create_index("year").expect("create_index");
+    // Insert a row missing `year` → coverage breaks → the fast path declines.
+    c.upsert(vec![Point::new(
+        3,
+        vec![1.0, 0.0],
+        Some(json!({ "tag": "x" })),
+    )])
+    .expect("upsert");
+    let _ = run(&c, "SELECT * FROM docs ORDER BY year DESC LIMIT 5");
+    let advice = c.order_by_index_advice(1);
+    assert_eq!(advice.len(), 1);
+    assert_eq!(advice[0].field, "year");
+    assert_eq!(advice[0].state, OrderByIndexState::BuiltButUncovered);
+}
+
+#[test]
+fn resolved_field_drops_out_of_advice() {
+    let (c, _d) = build(ROWS);
+    // Observe a fall-back (no index → Missing).
+    let _ = run(&c, "SELECT * FROM docs ORDER BY year DESC LIMIT 3");
+    assert_eq!(c.order_by_index_advice(1).len(), 1);
+    // Create a fully-covering index: the field is now resolved (the fast path
+    // fires), so the advice — derived from live coverage — drops it.
+    c.create_index("year").expect("create_index");
+    assert!(
+        c.order_by_index_advice(1).is_empty(),
+        "a now-covering index resolves the advice"
+    );
+}
+
+#[test]
+fn min_observations_threshold_filters() {
+    let (c, _d) = build(ROWS);
+    let _ = run(&c, "SELECT * FROM docs ORDER BY year DESC LIMIT 3");
+    let _ = run(&c, "SELECT * FROM docs ORDER BY year ASC LIMIT 3");
+    // Two eligible fall-backs on `year`.
+    assert_eq!(c.order_by_index_advice(2)[0].observed_count, 2);
+    assert!(
+        c.order_by_index_advice(3).is_empty(),
+        "below threshold → no advice"
+    );
+}

--- a/docs/planning/CORE_PARITY_REMEDIATION.md
+++ b/docs/planning/CORE_PARITY_REMEDIATION.md
@@ -85,9 +85,25 @@ path is deterministic by ID, arguably better but a behavior change to ratify); a
 and a perf benchmark showing sub-linear top-k vs the 312 ms/50k baseline. Disable the route entirely for any
 collection containing an id > `u32::MAX` (the bitmap paths can't represent it).
 
-**Phase 3 — broaden (separate, optional).** WHERE-filtered top-k (walk the index in order, apply the
-prefilter, stop at k); multi-column `ORDER BY` (index prunes lead-key groups, secondary sort within each);
-secondary-index snapshotting for auto-persistence; an auto-index advisor for hot `ORDER BY` fields.
+**Phase 3 — broaden (separate, optional).** Four independent sub-items, sequenced as gated PRs (a design
+fan-out found the three perf sub-items each *sound-with-fixes*, never *sound* — see their must-fix lists):
+
+- **3a — auto-index advisor (DONE).** Recommendation-only: `Collection::order_by_advisor` records eligible
+  `ORDER BY <field>` queries that decline the fast path for want of a covering secondary index;
+  `VectorCollection::order_by_index_advice(min)` surfaces them with live-derived state `Missing` /
+  `BuiltButUncovered` (a now-covering field is *resolved* and dropped). Behavior-neutral (never mutates an
+  index or a result), shape-isolated to the eligible `ORDER BY` shape, observations capped. Never
+  auto-creates (a backfill is `O(n)` on the query thread). `tests/ordered_index_advisor.rs`.
+- **3b — WHERE-filtered top-k.** Walk the covering index in sort order, apply the extracted metadata filter
+  per row, stop at offset+limit matches. Single-guard snapshot under one lock + coverage check, release,
+  hydrate+filter. Decline when `point_count > MAX_LIMIT`; selectivity guard via `CostEstimator`; u64 only
+  (no bitmap intersection). Equivalence matrix (NOT/OR/mixed-type/>100k) + perf gate.
+- **3c — multi-column `ORDER BY`.** Lead-key index prunes/orders groups, secondary sort within each. Decline
+  if `len > MAX_LIMIT`; lead-key `JsonValue` Ord must match `compare_json_values`; non-primitive lead value
+  forces fall-through.
+- **3d — secondary-index snapshotting.** Persist the BTree in `flush.rs` ATOMICALLY under the payload write
+  lock; reconcile the coverage denominator for vector collections; reconstruct F64 keys from `u64` bits (no
+  `f64` round-trip); config-persisted indexed-field-names as authority; restart-equivalence + concurrency tests.
 
 ## Artifacts produced by the audit
 - `PARITY_MATRIX.md` (81 capabilities × 13 components) — regenerate via `.claude/skills/core-parity-audit/scripts/gen_matrix.py`.


### PR DESCRIPTION
## Summary

**EPIC-081 phase 3a** — first of the chained phase-3 sub-items: a recommendation-only advisor that tells an operator which scalar `ORDER BY <field>` queries would benefit from a secondary index.

When a query's shape is eligible for the index-backed `ORDER BY <field> LIMIT k` fast path (phase 2) but the sort field has no *fully covering* secondary index, the route declines to the exhaustive sort. This advisor records those fall-backs and exposes them so a `CREATE INDEX` can be recommended.

## Design

- **`OrderByIndexAdvisor`** on `Collection` (lock-order position 7): a bounded `HashMap<field, count>`.
- **Hook** in `try_ordered_index_scan`: records *only* on the eligible-shape + no-covering-index decline branch, **after** the secondary-index lock is released. The fall-through return is byte-identical to before (`Ok(None)` → exhaustive path), so it is **behavior-neutral**, and **shape-isolated** (never fires for WHERE/JOIN/aggregate/window/similarity/multi-column/no-`ORDER BY`).
- **`VectorCollection::order_by_index_advice(min_observations)`** surfaces fields observed ≥ `min` times, sorted by descending count then name, with **live-derived** state:
  - `Missing` — no secondary index (`CREATE INDEX (<field>)` would enable the `O(log n + k)` fast path).
  - `BuiltButUncovered` — an index exists but does not fully cover the collection (the gap is the data).
  - A field whose index now *fully covers* the collection is **resolved** and dropped from the advice.
- **Recommendation-only by design**: never creates/drops/mutates an index — a backfill is `O(n)` and would stall the query thread. Observations are capped at 1024 distinct fields (`ORDER BY` field names are unvalidated query input).

## Verification

- `tests/ordered_index_advisor.rs` — 8 tests: `Missing`, `BuiltButUncovered`, resolved-field drop-out, behavior-neutrality, shape-isolation (no-`ORDER BY` + WHERE), and the `min_observations` threshold.
- Adversarial review (lock ordering / deadlock, behavior-neutrality, hook precision, unbounded growth, state TOCTOU) → must-fix (stale `BuiltButUncovered`) and should-fix (unbounded map) both folded in before this PR.
- `ordered_index_order_by_equivalence` (14, incl. the window-function regression) unaffected; `cargo clippy -p velesdb-core --all-targets -- -D warnings -D clippy::pedantic`, `cargo fmt --check`, and `lizard -C 8 -L 50` all clean.

First of four chained phase-3 sub-items (advisor → WHERE-filtered top-k → multi-column → snapshotting); see `docs/planning/CORE_PARITY_REMEDIATION.md`. Binding parity (REST/Python/TS) for the advice API is a follow-up per the core-source-of-truth rule.
