### PR TITLE
feat(velesql): multi-column index-backed ORDER BY top-k (EPIC-081 phase 3c)

### DIFF
--- a/crates/velesdb-core/src/collection/core/index_management.rs
+++ b/crates/velesdb-core/src/collection/core/index_management.rs
@@ -214,6 +214,29 @@ impl Collection {
             .ordered_ids_if_covered(descending, limit, point_count)
     }
 
+    /// Returns the leading lead-key buckets' point IDs (in `descending` key
+    /// order) whose cumulative size first reaches `min_rows`, **only when the
+    /// index fully covers** the collection. Whole buckets, so a caller can
+    /// secondary-sort within each equal-lead-key group. `None` when no such
+    /// index exists or coverage is incomplete.
+    ///
+    /// Backs multi-column `ORDER BY <lead_field>, ...` (EPIC-081 phase 3c). Like
+    /// [`ordered_ids_if_covered`](Self::ordered_ids_if_covered), the IDs are a
+    /// snapshot so the secondary-index lock is released before hydration.
+    #[must_use]
+    pub(crate) fn ordered_prefix_if_covered(
+        &self,
+        field_name: &str,
+        descending: bool,
+        min_rows: usize,
+    ) -> Option<Vec<u64>> {
+        let point_count = self.len();
+        let indexes = self.secondary_indexes.read();
+        indexes
+            .get(field_name)?
+            .ordered_prefix_if_covered(descending, min_rows, point_count)
+    }
+
     /// Looks up matching point IDs for an indexed field value.
     #[must_use]
     pub fn secondary_index_lookup(&self, field_name: &str, value: &JsonValue) -> Option<Vec<u64>> {

--- a/crates/velesdb-core/src/collection/search/query/ordered_index_scan.rs
+++ b/crates/velesdb-core/src/collection/search/query/ordered_index_scan.rs
@@ -61,12 +61,15 @@ impl Collection {
         if !query.let_bindings.is_empty() {
             return Ok(None);
         }
-        let Some((field, filter)) = ordered_index_scan_applies(stmt, extracted) else {
+        let Some(plan) = ordered_index_scan_applies(stmt, extracted) else {
             return Ok(None);
         };
-        let results = match filter {
-            None => self.ordered_index_plain_results(stmt, field),
-            Some(cond) => self.ordered_index_filtered_results(stmt, field, &cond),
+        let results = match plan {
+            ScanPlan::Plain(field) => self.ordered_index_plain_results(stmt, field),
+            ScanPlan::Filtered(field, cond) => {
+                self.ordered_index_filtered_results(stmt, field, &cond)
+            }
+            ScanPlan::MultiKey(lead_field) => self.ordered_index_multikey_results(stmt, lead_field),
         };
         let Some(results) = results else {
             return Ok(None);
@@ -151,6 +154,56 @@ impl Collection {
         Some(self.collect_filtered_page(&ids, &predicate, order_offset(stmt), limit))
     }
 
+    /// Multi-column route (EPIC-081 phase 3c): `ORDER BY <lead_field>, <more…>`
+    /// with no WHERE and all keys plain `Field`. Absorbs whole leading lead-key
+    /// buckets (in lead order) until ≥ offset+limit rows, hydrates them, applies
+    /// the **exact** exhaustive multi-key sort (`apply_order_by`), then OFFSET/
+    /// LIMIT. Equivalent to the exhaustive sort because the lead key dominates
+    /// the total order, so every row outside the leading buckets sorts strictly
+    /// after them — the top page is wholly inside the prefix.
+    ///
+    /// Declines (returns `None`) without observing the advisor above `MAX_LIMIT`;
+    /// observes (a covering index is the missing piece) when the lead field has
+    /// no covering index; and declines if any prefix row was dropped by `get`
+    /// (deleted / TTL-expired — the page could need a trailing-bucket row, so the
+    /// exhaustive path must run, as in the plain route).
+    fn ordered_index_multikey_results(
+        &self,
+        stmt: &crate::velesql::SelectStatement,
+        lead_field: &str,
+    ) -> Option<Vec<SearchResult>> {
+        let point_count = self.len();
+        if point_count > MAX_LIMIT {
+            return None;
+        }
+        let (limit, fetch_limit) = Self::compute_fetch_limit(stmt);
+        let Some(ids) =
+            self.ordered_prefix_if_covered(lead_field, order_descending(stmt), fetch_limit)
+        else {
+            self.order_by_advisor.write().observe(lead_field);
+            return None;
+        };
+        let mut hydrated: Vec<SearchResult> = self
+            .get(&ids)
+            .into_iter()
+            .flatten()
+            .map(|point| SearchResult::new(point, 1.0))
+            .collect();
+        if hydrated.len() != ids.len() {
+            return None;
+        }
+        let order_by = stmt.order_by.as_deref().unwrap_or(&[]);
+        self.apply_order_by(&mut hydrated, order_by, &std::collections::HashMap::new())
+            .ok()?;
+        Some(
+            hydrated
+                .into_iter()
+                .skip(order_offset(stmt))
+                .take(limit)
+                .collect(),
+        )
+    }
+
     /// Hydrates `ids` (already in ORDER BY order) in batches, keeps rows passing
     /// `predicate`, skips the first `offset` matches, and collects up to `limit`
     /// — stopping as soon as the page is full so a broad filter does not hydrate
@@ -201,38 +254,72 @@ fn order_offset(stmt: &crate::velesql::SelectStatement) -> usize {
         .map_or(0, |o| usize::try_from(o).unwrap_or(usize::MAX))
 }
 
-/// Returns `Some((field, filter))` when the query is eligible for the
-/// index-backed `ORDER BY <field> LIMIT k` fast path. `filter` is `Some(cond)`
-/// for the WHERE-filtered route (the pure-metadata predicate, identical to the
-/// one the exhaustive path applies) or `None` for the plain route.
+/// Which index-backed route a query is eligible for (or `None` to decline).
+enum ScanPlan<'a> {
+    /// Single plain `Field` ORDER BY, no WHERE.
+    Plain(&'a str),
+    /// Single plain `Field` ORDER BY + pure-metadata WHERE (the predicate is the
+    /// same one the exhaustive path applies).
+    Filtered(&'a str, Condition),
+    /// Multi-key ORDER BY — 2+ plain `Field` keys, no WHERE — on the covering
+    /// lead field. Carries the lead field; the full key list is read from `stmt`.
+    MultiKey(&'a str),
+}
+
+/// Returns the route a query is eligible for, or `None` to fall through.
 ///
-/// Eligible shape (all required): the ORDER BY is exactly **one** plain `Field`
-/// key (not Aggregate / Arithmetic / similarity); no JOIN, no DISTINCT, no
-/// GROUP BY / HAVING, and a plain (non-computed) projection — no aggregate,
-/// window function, `similarity()` score, or qualified wildcard. The only WHERE
-/// permitted is a pure-metadata filter; any vector / similarity / sparse / graph
-/// MATCH / union / NOT-similarity fetch declines. Coverage and index existence
-/// are verified later via `ordered_ids_if_covered`.
+/// Eligible shape (all required): the ORDER BY keys are all plain `Field`s (the
+/// lead key always; every key for the multi-column route); no JOIN, no DISTINCT,
+/// no GROUP BY / HAVING, and a plain (non-computed) projection — no aggregate,
+/// window function, `similarity()` score, or qualified wildcard; no vector /
+/// similarity / sparse / graph MATCH / union / NOT-similarity fetch. A
+/// pure-metadata WHERE is allowed only for the single-key route; multi-key with
+/// a WHERE declines (handled by the exhaustive path). Coverage and index
+/// existence are verified later via the `*_if_covered` primitives.
 fn ordered_index_scan_applies<'a>(
     stmt: &'a crate::velesql::SelectStatement,
     extracted: &ExtractedComponents,
-) -> Option<(&'a str, Option<Condition>)> {
-    let single_field = match stmt.order_by.as_deref() {
-        Some([only]) => match &only.expr {
-            crate::velesql::OrderByExpr::Field(name) => name.as_str(),
-            _ => return None,
-        },
+) -> Option<ScanPlan<'a>> {
+    let keys = stmt.order_by.as_deref()?;
+    let lead_field = match keys.first()?.expr {
+        crate::velesql::OrderByExpr::Field(ref name) => name.as_str(),
         _ => return None,
     };
     if !plain_query_shape(stmt) {
         return None;
     }
-    let filter = match route_metadata_filter(stmt, extracted) {
-        MetadataRoute::Decline => return None,
-        MetadataRoute::Plain => None,
-        MetadataRoute::Filtered(cond) => Some(cond),
-    };
-    Some((single_field, filter))
+    let filter = route_metadata_filter(stmt, extracted);
+    if keys.len() == 1 {
+        single_key_plan(lead_field, filter)
+    } else {
+        multi_key_plan(lead_field, keys, &filter)
+    }
+}
+
+/// Single-key route: plain or pure-metadata-filtered on the lead field.
+fn single_key_plan(lead_field: &str, filter: MetadataRoute) -> Option<ScanPlan<'_>> {
+    match filter {
+        MetadataRoute::Decline => None,
+        MetadataRoute::Plain => Some(ScanPlan::Plain(lead_field)),
+        MetadataRoute::Filtered(cond) => Some(ScanPlan::Filtered(lead_field, cond)),
+    }
+}
+
+/// Multi-key route: every key must be a plain `Field`, and there must be no
+/// WHERE (a filtered multi-key sort is left to the exhaustive path for now).
+fn multi_key_plan<'a>(
+    lead_field: &'a str,
+    keys: &[crate::velesql::SelectOrderBy],
+    filter: &MetadataRoute,
+) -> Option<ScanPlan<'a>> {
+    let all_fields = keys
+        .iter()
+        .all(|k| matches!(k.expr, crate::velesql::OrderByExpr::Field(_)));
+    if all_fields && matches!(filter, MetadataRoute::Plain) {
+        Some(ScanPlan::MultiKey(lead_field))
+    } else {
+        None
+    }
 }
 
 /// Outcome of classifying a SELECT's WHERE for the ordered-index route.

--- a/crates/velesdb-core/src/index/secondary/mod.rs
+++ b/crates/velesdb-core/src/index/secondary/mod.rs
@@ -200,6 +200,34 @@ impl SecondaryIndex {
         }
         Some(walk_ordered(&guard, descending, limit))
     }
+
+    /// Returns the point IDs of the leading lead-key buckets (in `descending`
+    /// key order) whose cumulative size first reaches `min_rows`, **only when
+    /// the index fully covers** `point_count`. Whole buckets are absorbed (never
+    /// cut mid-bucket), IDs ascending within a bucket; all IDs are returned when
+    /// the whole index holds fewer than `min_rows`. `None` when coverage is
+    /// incomplete.
+    ///
+    /// Backs multi-column `ORDER BY <lead_field>, ...` (EPIC-081 phase 3c): the
+    /// lead key dominates the total order, so after a full multi-key sort the top
+    /// `min_rows` rows lie entirely within these leading buckets — the caller
+    /// hydrates them, applies the exhaustive multi-key sort, then OFFSET/LIMIT.
+    /// The coverage check and the walk share one read lock (TOCTOU-safe).
+    #[must_use]
+    pub fn ordered_prefix_if_covered(
+        &self,
+        descending: bool,
+        min_rows: usize,
+        point_count: usize,
+    ) -> Option<Vec<u64>> {
+        let Self::BTree(tree) = self;
+        let guard = tree.read();
+        let covered: usize = guard.values().map(Vec::len).sum();
+        if covered != point_count {
+            return None;
+        }
+        Some(walk_whole_buckets(&guard, descending, min_rows))
+    }
 }
 
 /// Walks the B-tree in key order (ascending, or descending when `descending`)
@@ -220,6 +248,35 @@ fn walk_ordered(tree: &BTreeMap<JsonValue, Vec<u64>>, descending: bool, limit: u
         collect(&mut tree.values().rev());
     } else {
         collect(&mut tree.values());
+    }
+    out
+}
+
+/// Walks the B-tree in key order (ascending, or descending when `descending`)
+/// absorbing WHOLE buckets (IDs ascending within) until the accumulated count
+/// first reaches `min_rows`. Check-then-absorb, so `min_rows == 0` touches no
+/// bucket and the result holds complete leading buckets — never a partial one,
+/// which a multi-key secondary sort requires.
+fn walk_whole_buckets(
+    tree: &BTreeMap<JsonValue, Vec<u64>>,
+    descending: bool,
+    min_rows: usize,
+) -> Vec<u64> {
+    let mut out: Vec<u64> = Vec::new();
+    let mut absorb = |buckets: &mut dyn Iterator<Item = &Vec<u64>>| {
+        for ids in buckets {
+            if out.len() >= min_rows {
+                break;
+            }
+            let mut bucket = ids.clone();
+            bucket.sort_unstable();
+            out.extend(bucket);
+        }
+    };
+    if descending {
+        absorb(&mut tree.values().rev());
+    } else {
+        absorb(&mut tree.values());
     }
     out
 }

--- a/crates/velesdb-core/tests/ordered_index_multikey.rs
+++ b/crates/velesdb-core/tests/ordered_index_multikey.rs
@@ -1,0 +1,207 @@
+#![cfg(all(test, feature = "persistence"))]
+//! EPIC-081 phase 3c — multi-column `ORDER BY` equivalence.
+//!
+//! `ORDER BY <lead_field>, <more…>` on a covering lead-field index walks whole
+//! leading lead-key buckets (in lead order) until ≥ k rows, then applies the
+//! exhaustive multi-key sort. For a fixed dataset the SAME query must return an
+//! identical id-sequence with or without the index. Covers ASC/DESC lead,
+//! secondary direction, OFFSET, ties on both keys, heterogeneous lead types
+//! (Bool/Number/String — the index `JsonValue` Ord must match
+//! `compare_json_values`), k>n, the uncovered-lead fall-back, the
+//! multi-key+WHERE decline, and TTL-expired rows.
+
+use serde_json::json;
+use std::collections::HashMap;
+use tempfile::TempDir;
+use velesdb_core::{DistanceMetric, Point, StorageMode, VectorCollection};
+
+fn mk(dir: &TempDir) -> VectorCollection {
+    VectorCollection::create(
+        dir.path().join("docs"),
+        "docs",
+        2,
+        DistanceMetric::Cosine,
+        StorageMode::Full,
+    )
+    .expect("create collection")
+}
+
+fn ids(rs: &[velesdb_core::point::SearchResult]) -> Vec<u64> {
+    rs.iter().map(|r| r.point.id).collect()
+}
+
+/// Runs `sql` on a fresh collection without any index (exhaustive) and on a
+/// second with `create_index(lead)` (the multi-key index path); returns
+/// `(exhaustive_ids, index_ids)`.
+fn run_both(points: &[Point], lead: &str, sql: &str) -> (Vec<u64>, Vec<u64>) {
+    let da = TempDir::new().expect("dir");
+    let a = mk(&da);
+    a.upsert(points.to_vec()).expect("upsert");
+    let exhaustive = ids(&a
+        .execute_query_str(sql, &HashMap::new())
+        .expect("exhaustive"));
+
+    let db = TempDir::new().expect("dir");
+    let b = mk(&db);
+    b.upsert(points.to_vec()).expect("upsert");
+    b.create_index(lead).expect("create_index");
+    let indexed = ids(&b.execute_query_str(sql, &HashMap::new()).expect("index"));
+
+    (exhaustive, indexed)
+}
+
+/// cat ∈ {a, b}; (a,2021) is a two-key tie across ids 3 & 5.
+fn cat_year_rows() -> Vec<Point> {
+    vec![
+        Point::new(1, vec![1.0, 0.0], Some(json!({ "cat": "a", "year": 2020 }))),
+        Point::new(2, vec![1.0, 0.0], Some(json!({ "cat": "b", "year": 2022 }))),
+        Point::new(3, vec![1.0, 0.0], Some(json!({ "cat": "a", "year": 2021 }))),
+        Point::new(4, vec![1.0, 0.0], Some(json!({ "cat": "b", "year": 2021 }))),
+        Point::new(5, vec![1.0, 0.0], Some(json!({ "cat": "a", "year": 2021 }))),
+    ]
+}
+
+#[test]
+fn lead_asc_secondary_desc_full_matches_exhaustive() {
+    let (exhaustive, indexed) = run_both(
+        &cat_year_rows(),
+        "cat",
+        "SELECT * FROM docs ORDER BY cat ASC, year DESC LIMIT 5",
+    );
+    assert_eq!(exhaustive, indexed);
+    // cat a: year desc 2021(3),2021(5),2020(1); cat b: 2022(2),2021(4) → [3,5,1,2,4].
+    assert_eq!(indexed, vec![3, 5, 1, 2, 4]);
+}
+
+#[test]
+fn lead_asc_prunes_trailing_bucket_for_topk() {
+    let (exhaustive, indexed) = run_both(
+        &cat_year_rows(),
+        "cat",
+        "SELECT * FROM docs ORDER BY cat ASC, year DESC LIMIT 2",
+    );
+    assert_eq!(exhaustive, indexed);
+    // LIMIT 2 needs only bucket `a` (3 rows): [3, 5]. Bucket `b` is pruned.
+    assert_eq!(indexed, vec![3, 5]);
+}
+
+#[test]
+fn lead_desc_secondary_asc_matches_exhaustive() {
+    let (exhaustive, indexed) = run_both(
+        &cat_year_rows(),
+        "cat",
+        "SELECT * FROM docs ORDER BY cat DESC, year ASC LIMIT 5",
+    );
+    assert_eq!(exhaustive, indexed);
+    // cat b: year asc 2021(4),2022(2); cat a: 2020(1),2021(3),2021(5) → [4,2,1,3,5].
+    assert_eq!(indexed, vec![4, 2, 1, 3, 5]);
+}
+
+#[test]
+fn offset_matches_exhaustive() {
+    let (exhaustive, indexed) = run_both(
+        &cat_year_rows(),
+        "cat",
+        "SELECT * FROM docs ORDER BY cat ASC, year DESC LIMIT 2 OFFSET 1",
+    );
+    assert_eq!(exhaustive, indexed);
+    // Full [3,5,1,2,4]; skip 1, take 2 → [5, 1].
+    assert_eq!(indexed, vec![5, 1]);
+}
+
+#[test]
+fn heterogeneous_lead_types_match_exhaustive() {
+    // Mixed lead-key types: the index JsonValue Ord (Bool < Number < String)
+    // must agree with compare_json_values for the prefix to be the right buckets.
+    let points = vec![
+        Point::new(
+            1,
+            vec![1.0, 0.0],
+            Some(json!({ "cat": true, "year": 2020 })),
+        ),
+        Point::new(2, vec![1.0, 0.0], Some(json!({ "cat": 5, "year": 2021 }))),
+        Point::new(3, vec![1.0, 0.0], Some(json!({ "cat": "x", "year": 2022 }))),
+        Point::new(
+            4,
+            vec![1.0, 0.0],
+            Some(json!({ "cat": true, "year": 2019 })),
+        ),
+        Point::new(5, vec![1.0, 0.0], Some(json!({ "cat": 5, "year": 2023 }))),
+    ];
+    let (exhaustive, indexed) = run_both(
+        &points,
+        "cat",
+        "SELECT * FROM docs ORDER BY cat ASC, year DESC LIMIT 5",
+    );
+    assert_eq!(exhaustive, indexed);
+    // Bool true: 2020(1),2019(4); Number 5: 2023(5),2021(2); String "x": 2022(3).
+    assert_eq!(indexed, vec![1, 4, 5, 2, 3]);
+}
+
+#[test]
+fn k_greater_than_n_matches_exhaustive() {
+    let (exhaustive, indexed) = run_both(
+        &cat_year_rows(),
+        "cat",
+        "SELECT * FROM docs ORDER BY cat ASC, year DESC LIMIT 100",
+    );
+    assert_eq!(exhaustive, indexed);
+    assert_eq!(indexed.len(), 5);
+}
+
+#[test]
+fn uncovered_lead_falls_back_and_matches_exhaustive() {
+    // id 9 lacks the lead field `cat` → coverage breaks → the multi-key route
+    // declines and the exhaustive sort runs (placing the missing-cat row first
+    // for ASC). Both paths must agree.
+    let mut points = cat_year_rows();
+    points.push(Point::new(9, vec![1.0, 0.0], Some(json!({ "year": 2099 }))));
+    let (exhaustive, indexed) = run_both(
+        &points,
+        "cat",
+        "SELECT * FROM docs ORDER BY cat ASC, year DESC LIMIT 6",
+    );
+    assert_eq!(exhaustive, indexed);
+    // Missing cat sorts first (None < any): 9, then a-group [3,5,1], then b [2,4].
+    assert_eq!(indexed, vec![9, 3, 5, 1, 2, 4]);
+}
+
+#[test]
+fn multikey_with_where_declines_but_stays_correct() {
+    // Multi-key + WHERE is not routed (decline → exhaustive); result still correct
+    // and identical with or without the index.
+    let (exhaustive, indexed) = run_both(
+        &cat_year_rows(),
+        "cat",
+        "SELECT * FROM docs WHERE year >= 2021 ORDER BY cat ASC, year DESC LIMIT 5",
+    );
+    assert_eq!(exhaustive, indexed);
+    // year>=2021 → a:{2021(3),2021(5)}, b:{2022(2),2021(4)}; cat asc, year desc → [3,5,2,4].
+    assert_eq!(indexed, vec![3, 5, 2, 4]);
+}
+
+#[test]
+fn expired_row_in_prefix_falls_back_and_matches_exhaustive() {
+    // A TTL-expired row in the lead-key prefix is dropped by get(); the route
+    // declines (the page could need a trailing-bucket row) so the exhaustive
+    // path runs. id 3 (cat a, 2021) is expired.
+    let points = vec![
+        Point::new(1, vec![1.0, 0.0], Some(json!({ "cat": "a", "year": 2020 }))),
+        Point::new(2, vec![1.0, 0.0], Some(json!({ "cat": "b", "year": 2022 }))),
+        Point::new(
+            3,
+            vec![1.0, 0.0],
+            Some(json!({ "cat": "a", "year": 2021, "_veles_expires_at": 1 })),
+        ),
+        Point::new(4, vec![1.0, 0.0], Some(json!({ "cat": "b", "year": 2021 }))),
+        Point::new(5, vec![1.0, 0.0], Some(json!({ "cat": "a", "year": 2019 }))),
+    ];
+    let (exhaustive, indexed) = run_both(
+        &points,
+        "cat",
+        "SELECT * FROM docs ORDER BY cat ASC, year DESC LIMIT 4",
+    );
+    assert_eq!(exhaustive, indexed);
+    // id3 expired & dropped; live cat a: 2020(1),2019(5); cat b: 2022(2),2021(4) → [1,5,2,4].
+    assert_eq!(indexed, vec![1, 5, 2, 4]);
+}

--- a/docs/planning/CORE_PARITY_REMEDIATION.md
+++ b/docs/planning/CORE_PARITY_REMEDIATION.md
@@ -104,9 +104,17 @@ fan-out found the three perf sub-items each *sound-with-fixes*, never *sound* �
   TTL-expired-row regression in `tests/ordered_index_order_by_equivalence.rs`. Also fixed a latent phase-2
   divergence the review surfaced: the plain route now backfills past deleted/TTL-expired rows (or declines)
   instead of returning a short/misaligned page.
-- **3c — multi-column `ORDER BY`.** Lead-key index prunes/orders groups, secondary sort within each. Decline
-  if `len > MAX_LIMIT`; lead-key `JsonValue` Ord must match `compare_json_values`; non-primitive lead value
-  forces fall-through.
+- **3c — multi-column `ORDER BY` (DONE).** `ORDER BY <lead>, <more…>` (2+ plain `Field` keys, no WHERE) on a
+  covering lead index: `SecondaryIndex::ordered_prefix_if_covered` absorbs whole leading lead-key buckets
+  (check-then-absorb) until ≥ offset+limit rows, then `Collection::apply_order_by` runs the **exact**
+  exhaustive multi-key sort over the prefix + OFFSET/LIMIT. Correct because the lead key dominates the
+  comparator (every trailing-bucket row sorts strictly after the prefix). The index `JsonValue` Ord
+  (`Bool<Number<String`, f64 `total_cmp`) matches `compare_json_values`, so heterogeneous primitive lead
+  types are safe; non-primitive / non-f64 lead values aren't indexed → coverage breaks → fall-through.
+  Declines above `MAX_LIMIT`, on multi-key+WHERE, on any non-`Field` key, and (like the plain route) when a
+  deleted/TTL-expired row sits in the prefix. Gate refactored to a `ScanPlan` enum.
+  `tests/ordered_index_multikey.rs` (9). Adversarial review: SHIP (830+ equivalence assertions + a 700-case
+  fuzz, no divergence).
 - **3d — secondary-index snapshotting.** Persist the BTree in `flush.rs` ATOMICALLY under the payload write
   lock; reconcile the coverage denominator for vector collections; reconstruct F64 keys from `u64` bits (no
   `f64` round-trip); config-persisted indexed-field-names as authority; restart-equivalence + concurrency tests.


### PR DESCRIPTION
## Summary

**EPIC-081 phase 3c** — extends the index-backed `ORDER BY` route to **multi-column** `ORDER BY <lead_field>, <more…>` (2+ plain `Field` keys, no WHERE) when the **lead** field has a fully-covering secondary index. Third of the chained phase-3 sub-items (after #1141 advisor, #1142 WHERE-filtered).

## Algorithm

`SecondaryIndex::ordered_prefix_if_covered` walks the lead-key B-tree in lead order, **absorbing whole buckets** (check-then-absorb — never cuts a bucket, so a lead-key tie-group is never split) until the accumulated count first reaches `offset+limit`. The route hydrates that prefix, applies the **exact** exhaustive multi-key sort (`Collection::apply_order_by` — same comparator + ascending-id tie-break), then OFFSET/LIMIT.

**Why it's equivalent to the exhaustive sort:** the lead key is column 0 of the comparator (decided first), so every row *outside* the leading buckets sorts strictly *after* every row inside them. The top `[offset, offset+limit)` window therefore lies wholly within the prefix — sorting the prefix and slicing equals sorting everything and slicing.

## Gating (else fall through unchanged)

- all `ORDER BY` keys are plain `Field` (a non-`Field` secondary key declines);
- **no WHERE** (a filtered multi-key sort is left to the exhaustive path for now);
- no JOIN / DISTINCT / GROUP BY / HAVING / computed projection / vector / similarity / sparse / graph / union;
- `point_count ≤ MAX_LIMIT`;
- the lead field is **fully covered** — the index `JsonValue` Ord (`Bool < Number < String`, f64 `total_cmp`, str/bool cmp) matches `compare_json_values`, so heterogeneous primitive lead types are correct; non-primitive (`Null`/`Array`/`Object`) and non-`f64` numbers aren't indexed → coverage breaks → fall-through;
- like the plain route, a deleted / TTL-expired row in the prefix → decline to exhaustive.

The advisor (3a) observes only when a covering lead index is the missing piece. The gate was refactored into a `ScanPlan` enum (`Plain` / `Filtered` / `MultiKey`) with `single_key_plan` / `multi_key_plan` helpers.

## Verification

- `tests/ordered_index_multikey.rs` — 9 equivalence tests: ASC/DESC lead × secondary direction, top-k bucket pruning, OFFSET, **heterogeneous lead types** (Bool/Number/String), k>n, uncovered-lead fall-back, multi-key+WHERE decline, TTL-expired-in-prefix.
- **Adversarial review verdict: SHIP** — 830+ equivalence assertions + a 700-case randomized fuzz over all direction/offset/limit/tie combinations, with the fast path confirmed firing (not vacuously declining); no divergence found across all 7 attack classes (dominance, Ord agreement incl. signed-zero/u64-collision, DESC + mixed secondary direction, subset-sort purity, OFFSET+ties boundary, TTL backfill, gate leaks).
- `cargo clippy -p velesdb-core --all-targets -- -D warnings -D clippy::pedantic`, `cargo fmt --check`, `lizard -C 8 -L 50` — all clean.

Last remaining sub-item: **ph3d** secondary-index snapshotting (persistence; heaviest/riskiest), per `docs/planning/CORE_PARITY_REMEDIATION.md`.
