### PR TITLE
refactor(core)!: mark public config structs #[non_exhaustive] (v3 prep)

### DIFF
--- a/crates/tauri-plugin-velesdb/src/commands.rs
+++ b/crates/tauri-plugin-velesdb/src/commands.rs
@@ -830,11 +830,11 @@ pub(crate) fn streaming_config_from_request(
     request: &EnableStreamingRequest,
 ) -> velesdb_core::StreamingConfig {
     let base = velesdb_core::StreamingConfig::default();
-    velesdb_core::StreamingConfig {
-        buffer_size: request.buffer_size.unwrap_or(base.buffer_size),
-        batch_size: request.batch_size.unwrap_or(base.batch_size),
-        flush_interval_ms: request.flush_interval_ms.unwrap_or(base.flush_interval_ms),
-    }
+    velesdb_core::StreamingConfig::new(
+        request.buffer_size.unwrap_or(base.buffer_size),
+        request.batch_size.unwrap_or(base.batch_size),
+        request.flush_interval_ms.unwrap_or(base.flush_interval_ms),
+    )
 }
 
 /// Enables streaming ingestion on a collection.

--- a/crates/velesdb-core/src/collection/auto_reindex/types.rs
+++ b/crates/velesdb-core/src/collection/auto_reindex/types.rs
@@ -96,7 +96,11 @@ pub enum ReindexEvent {
 /// VelesDB — or one that omits any field — deserializes without error. The
 /// [`cooldown`](Self::cooldown) `Duration` is stored as whole seconds via
 /// [`duration_secs`].
+///
+/// `#[non_exhaustive]`: build from [`AutoReindexConfig::default`] and adjust
+/// fields so future additions stay backward compatible for downstream crates.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct AutoReindexConfig {
     /// Enable automatic reindex detection
     #[serde(default = "default_enabled")]

--- a/crates/velesdb-core/src/collection/collection_config.rs
+++ b/crates/velesdb-core/src/collection/collection_config.rs
@@ -33,7 +33,13 @@ fn default_pq_rescore_oversampling() -> Option<u32> {
 }
 
 /// Metadata for a collection.
+///
+/// `#[non_exhaustive]`: new fields are added over time (schema-versioned and
+/// serde-defaulted), so external crates must obtain a `CollectionConfig` via
+/// the `VectorCollection::create*` constructors / `Collection::config()` rather
+/// than a struct literal — this keeps future field additions non-breaking.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct CollectionConfig {
     /// Name of the collection.
     pub name: String,

--- a/crates/velesdb-core/src/collection/streaming/ingester.rs
+++ b/crates/velesdb-core/src/collection/streaming/ingester.rs
@@ -26,6 +26,7 @@ use tokio::sync::Notify;
 /// serde default matching [`Default`] so an older or partial `config.json`
 /// deserializes without error.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct StreamingConfig {
     /// Capacity of the bounded mpsc channel (backpressure threshold).
     #[serde(default = "default_buffer_size")]
@@ -58,6 +59,21 @@ impl Default for StreamingConfig {
             buffer_size: default_buffer_size(),
             batch_size: default_batch_size(),
             flush_interval_ms: default_flush_interval_ms(),
+        }
+    }
+}
+
+impl StreamingConfig {
+    /// Constructs a config from explicit pipeline parameters.
+    ///
+    /// Provided because the struct is `#[non_exhaustive]` (future fields use
+    /// serde defaults), so downstream crates cannot use a struct literal.
+    #[must_use]
+    pub fn new(buffer_size: usize, batch_size: usize, flush_interval_ms: u64) -> Self {
+        Self {
+            buffer_size,
+            batch_size,
+            flush_interval_ms,
         }
     }
 }

--- a/crates/velesdb-core/src/config.rs
+++ b/crates/velesdb-core/src/config.rs
@@ -206,8 +206,12 @@ pub mod server {
 pub use server::{LoggingConfig, ServerConfig, StorageConfig};
 
 /// Limits configuration section.
+///
+/// `#[non_exhaustive]`: build from [`LimitsConfig::default`] and adjust fields
+/// so future limits stay backward compatible for downstream crates.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
+#[non_exhaustive]
 pub struct LimitsConfig {
     /// Maximum vector dimensions.
     pub max_dimensions: usize,

--- a/crates/velesdb-core/tests/auto_reindex_bdd.rs
+++ b/crates/velesdb-core/tests/auto_reindex_bdd.rs
@@ -46,11 +46,9 @@ fn create_collection(db: &Database, name: &str) -> VectorCollection {
 /// Builds a manager with a tight `min_size_for_reindex = 1` so divergence
 /// checks fire even on small test collections.
 fn manager_with_min_size(min_size: usize) -> Arc<AutoReindexManager> {
-    let config = AutoReindexConfig {
-        enabled: true,
-        min_size_for_reindex: min_size,
-        ..AutoReindexConfig::default()
-    };
+    let mut config = AutoReindexConfig::default();
+    config.enabled = true;
+    config.min_size_for_reindex = min_size;
     Arc::new(AutoReindexManager::new(config))
 }
 
@@ -184,11 +182,9 @@ fn disabled_manager_reports_no_reindex() {
     let (_dir, db) = temp_database();
     let coll = create_collection(&db, "docs");
 
-    let config = AutoReindexConfig {
-        enabled: false,
-        min_size_for_reindex: 1,
-        ..AutoReindexConfig::default()
-    };
+    let mut config = AutoReindexConfig::default();
+    config.enabled = false;
+    config.min_size_for_reindex = 1;
     let manager = Arc::new(AutoReindexManager::new(config));
     coll.attach_auto_reindex(manager);
 
@@ -212,12 +208,10 @@ fn cooldown_window_blocks_immediate_re_trigger() {
     let (_dir, db) = temp_database();
     let coll = create_collection(&db, "docs");
 
-    let config = AutoReindexConfig {
-        enabled: true,
-        min_size_for_reindex: 1,
-        cooldown: Duration::from_secs(3600),
-        ..AutoReindexConfig::default()
-    };
+    let mut config = AutoReindexConfig::default();
+    config.enabled = true;
+    config.min_size_for_reindex = 1;
+    config.cooldown = Duration::from_secs(3600);
     let manager = Arc::new(AutoReindexManager::new(config));
     coll.attach_auto_reindex(Arc::clone(&manager));
 

--- a/crates/velesdb-mobile/src/collection.rs
+++ b/crates/velesdb-mobile/src/collection.rs
@@ -483,11 +483,11 @@ impl VelesCollection {
         config: Option<MobileStreamingConfig>,
     ) -> Result<(), VelesError> {
         let core_config = config.map_or_else(velesdb_core::StreamingConfig::default, |c| {
-            velesdb_core::StreamingConfig {
-                buffer_size: usize::try_from(c.buffer_size).unwrap_or(usize::MAX),
-                batch_size: usize::try_from(c.batch_size).unwrap_or(usize::MAX),
-                flush_interval_ms: c.flush_interval_ms,
-            }
+            velesdb_core::StreamingConfig::new(
+                usize::try_from(c.buffer_size).unwrap_or(usize::MAX),
+                usize::try_from(c.batch_size).unwrap_or(usize::MAX),
+                c.flush_interval_ms,
+            )
         });
         // Spawning the drain task needs an ambient runtime; enter the shared
         // streaming runtime so the task is scheduled on it and survives this call.

--- a/crates/velesdb-python/src/collection/mutation.rs
+++ b/crates/velesdb-python/src/collection/mutation.rs
@@ -298,11 +298,7 @@ impl Collection {
     #[pyo3(signature = (config=None))]
     fn enable_streaming(&self, config: Option<crate::StreamingIngestConfig>) -> PyResult<()> {
         let core_config = config.map_or_else(velesdb_core::StreamingConfig::default, |c| {
-            velesdb_core::StreamingConfig {
-                buffer_size: c.buffer_size,
-                batch_size: c.batch_size,
-                flush_interval_ms: c.flush_interval_ms,
-            }
+            velesdb_core::StreamingConfig::new(c.buffer_size, c.batch_size, c.flush_interval_ms)
         });
         // Spawning the drain task needs an ambient runtime; enter the shared
         // streaming runtime so the task is scheduled on it and survives this call.

--- a/crates/velesdb-python/src/options.rs
+++ b/crates/velesdb-python/src/options.rs
@@ -289,18 +289,19 @@ impl LimitsOptions {
 
 impl LimitsOptions {
     pub(crate) fn to_core(&self) -> CoreLimitsConfig {
-        let base = CoreLimitsConfig::default();
-        CoreLimitsConfig {
-            max_dimensions: self.max_dimensions.unwrap_or(base.max_dimensions),
-            max_vectors_per_collection: self
-                .max_vectors_per_collection
-                .unwrap_or(base.max_vectors_per_collection),
-            max_collections: self.max_collections.unwrap_or(base.max_collections),
-            max_payload_size: self.max_payload_size.unwrap_or(base.max_payload_size),
-            max_perfect_mode_vectors: self
-                .max_perfect_mode_vectors
-                .unwrap_or(base.max_perfect_mode_vectors),
-        }
+        // `CoreLimitsConfig` is `#[non_exhaustive]`; build from `Default` and
+        // override each field (struct literal is disallowed outside velesdb-core).
+        let mut cfg = CoreLimitsConfig::default();
+        cfg.max_dimensions = self.max_dimensions.unwrap_or(cfg.max_dimensions);
+        cfg.max_vectors_per_collection = self
+            .max_vectors_per_collection
+            .unwrap_or(cfg.max_vectors_per_collection);
+        cfg.max_collections = self.max_collections.unwrap_or(cfg.max_collections);
+        cfg.max_payload_size = self.max_payload_size.unwrap_or(cfg.max_payload_size);
+        cfg.max_perfect_mode_vectors = self
+            .max_perfect_mode_vectors
+            .unwrap_or(cfg.max_perfect_mode_vectors);
+        cfg
     }
 }
 
@@ -412,14 +413,17 @@ impl AutoReindexOptions {
 
 impl AutoReindexOptions {
     pub(crate) fn to_core(&self) -> CoreAutoReindexConfig {
-        CoreAutoReindexConfig {
-            enabled: self.enabled,
-            param_divergence_threshold: self.param_divergence_threshold,
-            min_size_for_reindex: self.min_size_for_reindex,
-            max_latency_regression_percent: self.max_latency_regression_percent,
-            max_recall_regression_percent: self.max_recall_regression_percent,
-            cooldown: Duration::from_secs(self.cooldown_secs),
-        }
+        // `CoreAutoReindexConfig` is `#[non_exhaustive]`; build from its
+        // `Default` and override each field (struct literal is disallowed
+        // outside velesdb-core).
+        let mut cfg = CoreAutoReindexConfig::default();
+        cfg.enabled = self.enabled;
+        cfg.param_divergence_threshold = self.param_divergence_threshold;
+        cfg.min_size_for_reindex = self.min_size_for_reindex;
+        cfg.max_latency_regression_percent = self.max_latency_regression_percent;
+        cfg.max_recall_regression_percent = self.max_recall_regression_percent;
+        cfg.cooldown = Duration::from_secs(self.cooldown_secs);
+        cfg
     }
 }
 


### PR DESCRIPTION
## What

Marks the public config family in `velesdb-core` as `#[non_exhaustive]` so future field additions are no longer SemVer-breaking:
- `CollectionConfig`, `LimitsConfig`, `AutoReindexConfig`, ingester `StreamingConfig`
- adds `StreamingConfig::new(...)` for downstream construction
- migrates child construction sites (tauri, mobile, python) and the `auto_reindex_bdd` integration test off struct literals (now disallowed cross-crate)

## Why (the breaking change that motivates 3.0.0)

Since v2.0.0, `CollectionConfig` (re-exported, all-pub-fields, no constructor) gained 3 public fields. For a non-`#[non_exhaustive]` struct that breaks external struct-literal construction. An adversarial SemVer audit of `v2.0.0..develop` confirmed this is the **only** hard API break (bindings/REST/storage all additive). Hardening the config family now (in the major) ends the recurring hazard.

## No behaviour change

Configs are built with identical field values; this is purely a construction-API/visibility change. `git diff` touches only 9 files (4 structs + child construction sites + 1 test).

## Validation (local, all green)

- clippy `--workspace --all-targets ... --exclude velesdb-python -D warnings -D clippy::pedantic` (no `field_reassign_with_default` — suppressed for cross-crate non_exhaustive)
- `cargo check -p velesdb-python`; `--test auto_reindex_bdd` 10/10; core `--no-default-features`; wasm32

Part of 3.0.0 prep; the version bump + CHANGELOG + publish follow as the gated release step.