### PR TITLE
refactor: eliminate all jscpd duplication blocks (0 findings)

### DIFF
--- a/crates/tauri-plugin-velesdb/src/commands.rs
+++ b/crates/tauri-plugin-velesdb/src/commands.rs
@@ -184,6 +184,42 @@ pub async fn get_collection<R: Runtime>(
         .map_err(CommandError::from)
 }
 
+/// Looks up the collection, builds points via `build`, inserts them via
+/// `insert`, then emits a collection-updated event tagged with `event`.
+///
+/// Shared skeleton of [`upsert`] and [`upsert_metadata`]: only the per-point
+/// construction and the core insert method differ between callers.
+fn upsert_points<R, B, I>(
+    app: &AppHandle<R>,
+    state: &State<'_, VelesDbState>,
+    collection: &str,
+    event: &str,
+    build: B,
+    insert: I,
+) -> std::result::Result<usize, CommandError>
+where
+    R: Runtime,
+    B: FnOnce() -> Vec<velesdb_core::Point>,
+    I: FnOnce(
+        &velesdb_core::VectorCollection,
+        Vec<velesdb_core::Point>,
+    ) -> crate::error::Result<()>,
+{
+    let count = state
+        .with_db(|db| {
+            let coll = require_collection(&db, collection)?;
+
+            let points = build();
+            let count = points.len();
+            insert(&coll, points)?;
+            Ok(count)
+        })
+        .map_err(CommandError::from)?;
+
+    emit_collection_updated(app, collection, event, count);
+    Ok(count)
+}
+
 /// Upserts points into a collection.
 #[command]
 pub async fn upsert<R: Runtime>(
@@ -192,24 +228,20 @@ pub async fn upsert<R: Runtime>(
     request: UpsertRequest,
 ) -> std::result::Result<usize, CommandError> {
     let collection_name = request.collection.clone();
-    let count = state
-        .with_db(|db| {
-            let coll = require_collection(&db, &request.collection)?;
-
-            let points: Vec<velesdb_core::Point> = request
+    upsert_points(
+        &app,
+        &state,
+        &collection_name,
+        "upsert",
+        || {
+            request
                 .points
                 .into_iter()
                 .map(|p| velesdb_core::Point::new(p.id, p.vector, p.payload))
-                .collect();
-
-            let count = points.len();
-            coll.upsert(points)?;
-            Ok(count)
-        })
-        .map_err(CommandError::from)?;
-
-    emit_collection_updated(&app, &collection_name, "upsert", count);
-    Ok(count)
+                .collect()
+        },
+        |coll, points| coll.upsert(points).map_err(crate::error::Error::Database),
+    )
 }
 
 /// Upserts metadata-only points into a collection.
@@ -220,24 +252,23 @@ pub async fn upsert_metadata<R: Runtime>(
     request: UpsertMetadataRequest,
 ) -> std::result::Result<usize, CommandError> {
     let collection_name = request.collection.clone();
-    let count = state
-        .with_db(|db| {
-            let coll = require_collection(&db, &request.collection)?;
-
-            let points: Vec<velesdb_core::Point> = request
+    upsert_points(
+        &app,
+        &state,
+        &collection_name,
+        "upsert_metadata",
+        || {
+            request
                 .points
                 .into_iter()
                 .map(|p| velesdb_core::Point::new(p.id, vec![], Some(p.payload)))
-                .collect();
-
-            let count = points.len();
-            coll.upsert_metadata(points)?;
-            Ok(count)
-        })
-        .map_err(CommandError::from)?;
-
-    emit_collection_updated(&app, &collection_name, "upsert_metadata", count);
-    Ok(count)
+                .collect()
+        },
+        |coll, points| {
+            coll.upsert_metadata(points)
+                .map_err(crate::error::Error::Database)
+        },
+    )
 }
 
 /// Gets points by their IDs.
@@ -530,6 +561,45 @@ fn batch_search_bulk(
         .map_err(CommandError::from)
 }
 
+/// Runs a filter-aware search on `collection` and wraps the mapped results in a
+/// timed [`SearchResponse`].
+///
+/// Shared skeleton of [`text_search`] and [`hybrid_search`]: when a filter is
+/// present `filtered` is invoked with it, otherwise `unfiltered` is used. Only
+/// those two core calls differ between callers.
+fn run_filtered_search<Filtered, Unfiltered>(
+    state: &State<'_, VelesDbState>,
+    collection: &str,
+    parsed_filter: Option<&velesdb_core::Filter>,
+    filtered: Filtered,
+    unfiltered: Unfiltered,
+) -> std::result::Result<SearchResponse, CommandError>
+where
+    Filtered: FnOnce(
+        &velesdb_core::VectorCollection,
+        &velesdb_core::Filter,
+    ) -> crate::error::Result<Vec<velesdb_core::SearchResult>>,
+    Unfiltered: FnOnce(
+        &velesdb_core::VectorCollection,
+    ) -> crate::error::Result<Vec<velesdb_core::SearchResult>>,
+{
+    let start = std::time::Instant::now();
+    let results = state
+        .with_db(|db| {
+            let coll = require_collection(&db, collection)?;
+
+            let search_results = if let Some(f) = parsed_filter {
+                filtered(&coll, f)?
+            } else {
+                unfiltered(&coll)?
+            };
+            Ok(map_core_results(search_results))
+        })
+        .map_err(CommandError::from)?;
+
+    Ok(timed_search_response(results, start))
+}
+
 /// Searches by text using BM25.
 #[command]
 pub async fn text_search<R: Runtime>(
@@ -537,23 +607,21 @@ pub async fn text_search<R: Runtime>(
     state: State<'_, VelesDbState>,
     request: TextSearchRequest,
 ) -> std::result::Result<SearchResponse, CommandError> {
-    let start = std::time::Instant::now();
     let parsed_filter = parse_filter(&request.filter).map_err(CommandError::from)?;
 
-    let results = state
-        .with_db(|db| {
-            let coll = require_collection(&db, &request.collection)?;
-
-            let search_results = if let Some(ref f) = parsed_filter {
-                coll.text_search_with_filter(&request.query, request.top_k, f)?
-            } else {
-                coll.text_search(&request.query, request.top_k)?
-            };
-            Ok(map_core_results(search_results))
-        })
-        .map_err(CommandError::from)?;
-
-    Ok(timed_search_response(results, start))
+    run_filtered_search(
+        &state,
+        &request.collection,
+        parsed_filter.as_ref(),
+        |coll, f| {
+            coll.text_search_with_filter(&request.query, request.top_k, f)
+                .map_err(crate::error::Error::Database)
+        },
+        |coll| {
+            coll.text_search(&request.query, request.top_k)
+                .map_err(crate::error::Error::Database)
+        },
+    )
 }
 
 /// Hybrid search combining vector similarity and BM25.
@@ -563,34 +631,32 @@ pub async fn hybrid_search<R: Runtime>(
     state: State<'_, VelesDbState>,
     request: HybridSearchRequest,
 ) -> std::result::Result<SearchResponse, CommandError> {
-    let start = std::time::Instant::now();
     let parsed_filter = parse_filter(&request.filter).map_err(CommandError::from)?;
 
-    let results = state
-        .with_db(|db| {
-            let coll = require_collection(&db, &request.collection)?;
-
-            let search_results = if let Some(ref f) = parsed_filter {
-                coll.hybrid_search_with_filter(
-                    &request.vector,
-                    &request.query,
-                    request.top_k,
-                    Some(request.vector_weight),
-                    f,
-                )?
-            } else {
-                coll.hybrid_search(
-                    &request.vector,
-                    &request.query,
-                    request.top_k,
-                    Some(request.vector_weight),
-                )?
-            };
-            Ok(map_core_results(search_results))
-        })
-        .map_err(CommandError::from)?;
-
-    Ok(timed_search_response(results, start))
+    run_filtered_search(
+        &state,
+        &request.collection,
+        parsed_filter.as_ref(),
+        |coll, f| {
+            coll.hybrid_search_with_filter(
+                &request.vector,
+                &request.query,
+                request.top_k,
+                Some(request.vector_weight),
+                f,
+            )
+            .map_err(crate::error::Error::Database)
+        },
+        |coll| {
+            coll.hybrid_search(
+                &request.vector,
+                &request.query,
+                request.top_k,
+                Some(request.vector_weight),
+            )
+            .map_err(crate::error::Error::Database)
+        },
+    )
 }
 
 // NOTE: VelesQL query command moved to commands_query.rs (NLOC refactoring)

--- a/crates/tauri-plugin-velesdb/src/commands_graph.rs
+++ b/crates/tauri-plugin-velesdb/src/commands_graph.rs
@@ -72,6 +72,33 @@ fn build_edge(
         .map(|edge| edge.with_properties(properties))
 }
 
+/// Builds a [`TraversalConfig`] from the raw request fields. Shared by
+/// [`traverse_graph`] and [`traverse_graph_parallel`].
+fn build_traversal_config(
+    max_depth: u32,
+    limit: usize,
+    rel_types: Option<Vec<String>>,
+) -> TraversalConfig {
+    TraversalConfig::with_range(1, max_depth)
+        .with_limit(limit)
+        .with_rel_types(rel_types.unwrap_or_default())
+}
+
+/// Maps core traversal results into the API [`TraversalOutput`] shape. Shared by
+/// [`traverse_graph`] and [`traverse_graph_parallel`].
+fn to_traversal_outputs(
+    results: Vec<velesdb_core::collection::graph::TraversalResult>,
+) -> Vec<TraversalOutput> {
+    results
+        .into_iter()
+        .map(|r| TraversalOutput {
+            target_id: r.target_id,
+            depth: r.depth,
+            path: r.path,
+        })
+        .collect()
+}
+
 /// Adds an edge to the knowledge graph.
 #[command]
 pub async fn add_edge<R: Runtime>(
@@ -167,9 +194,8 @@ pub async fn traverse_graph<R: Runtime>(
         .with_db(|db| {
             let coll = require_graph_collection(&db, &request.collection)?;
 
-            let config = TraversalConfig::with_range(1, request.max_depth)
-                .with_limit(request.limit)
-                .with_rel_types(request.rel_types.unwrap_or_default());
+            let config =
+                build_traversal_config(request.max_depth, request.limit, request.rel_types);
 
             let results = if request.algorithm == "dfs" {
                 coll.traverse_dfs(request.source, &config)
@@ -177,14 +203,7 @@ pub async fn traverse_graph<R: Runtime>(
                 coll.traverse_bfs(request.source, &config)
             };
 
-            Ok(results
-                .into_iter()
-                .map(|r| TraversalOutput {
-                    target_id: r.target_id,
-                    depth: r.depth,
-                    path: r.path,
-                })
-                .collect())
+            Ok(to_traversal_outputs(results))
         })
         .map_err(CommandError::from)
 }
@@ -222,20 +241,12 @@ pub async fn traverse_graph_parallel<R: Runtime>(
         .with_db(|db| {
             let coll = require_graph_collection(&db, &request.collection)?;
 
-            let config = TraversalConfig::with_range(1, request.max_depth)
-                .with_limit(request.limit)
-                .with_rel_types(request.rel_types.unwrap_or_default());
+            let config =
+                build_traversal_config(request.max_depth, request.limit, request.rel_types);
 
             let results = coll.traverse_bfs_parallel(&request.sources, &config);
 
-            Ok(results
-                .into_iter()
-                .map(|r| TraversalOutput {
-                    target_id: r.target_id,
-                    depth: r.depth,
-                    path: r.path,
-                })
-                .collect())
+            Ok(to_traversal_outputs(results))
         })
         .map_err(CommandError::from)
 }

--- a/crates/velesdb-cli/src/import.rs
+++ b/crates/velesdb-cli/src/import.rs
@@ -135,15 +135,7 @@ pub fn import_jsonl(db: &Database, path: &Path, config: &ImportConfig) -> Result
         progress.inc(1);
     }
 
-    let acc = importer.flush()?;
-    progress.finish_with_message("Import complete");
-
-    Ok(ImportStats {
-        total,
-        imported: acc.imported,
-        errors: acc.errors,
-        duration_ms: start.elapsed().as_millis() as u64,
-    })
+    finalize_import(importer, &progress, total, start)
 }
 
 /// Import from CSV file
@@ -235,6 +227,18 @@ pub fn import_csv(db: &Database, path: &Path, config: &ImportConfig) -> Result<I
         progress.inc(1);
     }
 
+    finalize_import(importer, &progress, total, start)
+}
+
+/// Flush the batch importer, finish the progress bar, and build [`ImportStats`].
+///
+/// Shared finalization tail for `import_jsonl` and `import_csv`.
+fn finalize_import(
+    importer: BatchImporter<'_>,
+    progress: &indicatif::ProgressBar,
+    total: usize,
+    start: std::time::Instant,
+) -> Result<ImportStats> {
     let acc = importer.flush()?;
     progress.finish_with_message("Import complete");
 

--- a/crates/velesdb-cli/src/import_tests.rs
+++ b/crates/velesdb-cli/src/import_tests.rs
@@ -4,7 +4,41 @@
 
 use super::*;
 use std::io::Write;
+use std::path::Path;
 use tempfile::tempdir;
+
+/// Write each line (with a trailing newline) to a fresh file at `path`.
+///
+/// Shared fixture for the JSONL/CSV import tests, which all materialize a
+/// small data file as a list of text lines before importing it.
+fn write_lines(path: &Path, lines: &[&str]) {
+    let mut file = File::create(path).unwrap();
+    for line in lines {
+        writeln!(file, "{line}").unwrap();
+    }
+}
+
+/// Open a DB at `db_path` and build the default import config targeting the
+/// `"test"` collection with progress disabled — the setup every basic
+/// import test shares verbatim.
+fn open_db_and_test_config(db_path: &Path) -> (Database, ImportConfig) {
+    let db = Database::open(db_path).unwrap();
+    let config = ImportConfig {
+        collection: "test".to_string(),
+        show_progress: false,
+        ..Default::default()
+    };
+    (db, config)
+}
+
+/// Opens a fresh DB with the standard test config and imports `jsonl_path`,
+/// returning the DB handle and the resulting stats. Shared by the basic JSONL
+/// import tests (default `collection="test"`, progress off).
+fn run_jsonl_import(db_path: &Path, jsonl_path: &Path) -> (Database, ImportStats) {
+    let (db, config) = open_db_and_test_config(db_path);
+    let stats = import_jsonl(&db, jsonl_path, &config).unwrap();
+    (db, stats)
+}
 
 // =========================================================================
 // Unit tests for parse_vector
@@ -113,19 +147,16 @@ fn test_import_jsonl_basic() {
     let jsonl_path = dir.path().join("data.jsonl");
 
     // Create test JSONL file
-    let mut file = File::create(&jsonl_path).unwrap();
-    writeln!(file, r#"{{"id": 1, "vector": [1.0, 0.0, 0.0]}}"#).unwrap();
-    writeln!(file, r#"{{"id": 2, "vector": [0.0, 1.0, 0.0]}}"#).unwrap();
-    writeln!(file, r#"{{"id": 3, "vector": [0.0, 0.0, 1.0]}}"#).unwrap();
+    write_lines(
+        &jsonl_path,
+        &[
+            r#"{"id": 1, "vector": [1.0, 0.0, 0.0]}"#,
+            r#"{"id": 2, "vector": [0.0, 1.0, 0.0]}"#,
+            r#"{"id": 3, "vector": [0.0, 0.0, 1.0]}"#,
+        ],
+    );
 
-    let db = Database::open(&db_path).unwrap();
-    let config = ImportConfig {
-        collection: "test".to_string(),
-        show_progress: false,
-        ..Default::default()
-    };
-
-    let stats = import_jsonl(&db, &jsonl_path, &config).unwrap();
+    let (db, stats) = run_jsonl_import(&db_path, &jsonl_path);
 
     assert_eq!(stats.total, 3);
     assert_eq!(stats.imported, 3);
@@ -141,26 +172,15 @@ fn test_import_jsonl_with_payload() {
     let db_path = dir.path().join("db");
     let jsonl_path = dir.path().join("data.jsonl");
 
-    let mut file = File::create(&jsonl_path).unwrap();
-    writeln!(
-        file,
-        r#"{{"id": 1, "vector": [1.0, 0.0, 0.0], "payload": {{"title": "Doc 1"}}}}"#
-    )
-    .unwrap();
-    writeln!(
-        file,
-        r#"{{"id": 2, "vector": [0.0, 1.0, 0.0], "payload": {{"title": "Doc 2"}}}}"#
-    )
-    .unwrap();
+    write_lines(
+        &jsonl_path,
+        &[
+            r#"{"id": 1, "vector": [1.0, 0.0, 0.0], "payload": {"title": "Doc 1"}}"#,
+            r#"{"id": 2, "vector": [0.0, 1.0, 0.0], "payload": {"title": "Doc 2"}}"#,
+        ],
+    );
 
-    let db = Database::open(&db_path).unwrap();
-    let config = ImportConfig {
-        collection: "test".to_string(),
-        show_progress: false,
-        ..Default::default()
-    };
-
-    let stats = import_jsonl(&db, &jsonl_path, &config).unwrap();
+    let (db, stats) = run_jsonl_import(&db_path, &jsonl_path);
 
     assert_eq!(stats.imported, 2);
 
@@ -175,19 +195,16 @@ fn test_import_jsonl_with_errors() {
     let db_path = dir.path().join("db");
     let jsonl_path = dir.path().join("data.jsonl");
 
-    let mut file = File::create(&jsonl_path).unwrap();
-    writeln!(file, r#"{{"id": 1, "vector": [1.0, 0.0, 0.0]}}"#).unwrap();
-    writeln!(file, r#"invalid json line"#).unwrap();
-    writeln!(file, r#"{{"id": 3, "vector": [0.0, 0.0, 1.0]}}"#).unwrap();
+    write_lines(
+        &jsonl_path,
+        &[
+            r#"{"id": 1, "vector": [1.0, 0.0, 0.0]}"#,
+            "invalid json line",
+            r#"{"id": 3, "vector": [0.0, 0.0, 1.0]}"#,
+        ],
+    );
 
-    let db = Database::open(&db_path).unwrap();
-    let config = ImportConfig {
-        collection: "test".to_string(),
-        show_progress: false,
-        ..Default::default()
-    };
-
-    let stats = import_jsonl(&db, &jsonl_path, &config).unwrap();
+    let (_db, stats) = run_jsonl_import(&db_path, &jsonl_path);
 
     assert_eq!(stats.total, 3);
     assert_eq!(stats.imported, 2);
@@ -200,19 +217,16 @@ fn test_import_jsonl_dimension_mismatch() {
     let db_path = dir.path().join("db");
     let jsonl_path = dir.path().join("data.jsonl");
 
-    let mut file = File::create(&jsonl_path).unwrap();
-    writeln!(file, r#"{{"id": 1, "vector": [1.0, 0.0, 0.0]}}"#).unwrap();
-    writeln!(file, r#"{{"id": 2, "vector": [0.0, 1.0]}}"#).unwrap(); // Wrong dimension
-    writeln!(file, r#"{{"id": 3, "vector": [0.0, 0.0, 1.0]}}"#).unwrap();
+    write_lines(
+        &jsonl_path,
+        &[
+            r#"{"id": 1, "vector": [1.0, 0.0, 0.0]}"#,
+            r#"{"id": 2, "vector": [0.0, 1.0]}"#, // Wrong dimension
+            r#"{"id": 3, "vector": [0.0, 0.0, 1.0]}"#,
+        ],
+    );
 
-    let db = Database::open(&db_path).unwrap();
-    let config = ImportConfig {
-        collection: "test".to_string(),
-        show_progress: false,
-        ..Default::default()
-    };
-
-    let stats = import_jsonl(&db, &jsonl_path, &config).unwrap();
+    let (_db, stats) = run_jsonl_import(&db_path, &jsonl_path);
 
     assert_eq!(stats.imported, 2);
     assert_eq!(stats.errors, 1);
@@ -228,18 +242,17 @@ fn test_import_csv_basic() {
     let db_path = dir.path().join("db");
     let csv_path = dir.path().join("data.csv");
 
-    let mut file = File::create(&csv_path).unwrap();
-    writeln!(file, "id,vector").unwrap();
-    writeln!(file, "1,\"[1.0, 0.0, 0.0]\"").unwrap();
-    writeln!(file, "2,\"[0.0, 1.0, 0.0]\"").unwrap();
-    writeln!(file, "3,\"[0.0, 0.0, 1.0]\"").unwrap();
+    write_lines(
+        &csv_path,
+        &[
+            "id,vector",
+            "1,\"[1.0, 0.0, 0.0]\"",
+            "2,\"[0.0, 1.0, 0.0]\"",
+            "3,\"[0.0, 0.0, 1.0]\"",
+        ],
+    );
 
-    let db = Database::open(&db_path).unwrap();
-    let config = ImportConfig {
-        collection: "test".to_string(),
-        show_progress: false,
-        ..Default::default()
-    };
+    let (db, config) = open_db_and_test_config(&db_path);
 
     let stats = import_csv(&db, &csv_path, &config).unwrap();
 
@@ -254,17 +267,12 @@ fn test_import_csv_comma_separated_vector() {
     let db_path = dir.path().join("db");
     let csv_path = dir.path().join("data.csv");
 
-    let mut file = File::create(&csv_path).unwrap();
-    writeln!(file, "id,vector").unwrap();
-    writeln!(file, "1,\"1.0,0.0,0.0\"").unwrap();
-    writeln!(file, "2,\"0.0,1.0,0.0\"").unwrap();
+    write_lines(
+        &csv_path,
+        &["id,vector", "1,\"1.0,0.0,0.0\"", "2,\"0.0,1.0,0.0\""],
+    );
 
-    let db = Database::open(&db_path).unwrap();
-    let config = ImportConfig {
-        collection: "test".to_string(),
-        show_progress: false,
-        ..Default::default()
-    };
+    let (db, config) = open_db_and_test_config(&db_path);
 
     let stats = import_csv(&db, &csv_path, &config).unwrap();
 
@@ -277,17 +285,16 @@ fn test_import_csv_with_extra_columns() {
     let db_path = dir.path().join("db");
     let csv_path = dir.path().join("data.csv");
 
-    let mut file = File::create(&csv_path).unwrap();
-    writeln!(file, "id,vector,title,category").unwrap();
-    writeln!(file, "1,\"[1.0, 0.0, 0.0]\",Document 1,tech").unwrap();
-    writeln!(file, "2,\"[0.0, 1.0, 0.0]\",Document 2,science").unwrap();
+    write_lines(
+        &csv_path,
+        &[
+            "id,vector,title,category",
+            "1,\"[1.0, 0.0, 0.0]\",Document 1,tech",
+            "2,\"[0.0, 1.0, 0.0]\",Document 2,science",
+        ],
+    );
 
-    let db = Database::open(&db_path).unwrap();
-    let config = ImportConfig {
-        collection: "test".to_string(),
-        show_progress: false,
-        ..Default::default()
-    };
+    let (db, config) = open_db_and_test_config(&db_path);
 
     let stats = import_csv(&db, &csv_path, &config).unwrap();
 
@@ -307,10 +314,14 @@ fn test_import_csv_custom_columns() {
     let db_path = dir.path().join("db");
     let csv_path = dir.path().join("data.csv");
 
-    let mut file = File::create(&csv_path).unwrap();
-    writeln!(file, "doc_id,embedding").unwrap();
-    writeln!(file, "1,\"[1.0, 0.0, 0.0]\"").unwrap();
-    writeln!(file, "2,\"[0.0, 1.0, 0.0]\"").unwrap();
+    write_lines(
+        &csv_path,
+        &[
+            "doc_id,embedding",
+            "1,\"[1.0, 0.0, 0.0]\"",
+            "2,\"[0.0, 1.0, 0.0]\"",
+        ],
+    );
 
     let db = Database::open(&db_path).unwrap();
     let config = ImportConfig {

--- a/crates/velesdb-cli/src/repl_collection_cmds.rs
+++ b/crates/velesdb-cli/src/repl_collection_cmds.rs
@@ -100,11 +100,7 @@ pub(crate) fn cmd_describe(db: &Database, parts: &[&str]) -> CommandResult {
             println!();
         }
         Some(collection_helpers::TypedCollection::Metadata(col)) => {
-            println!("\n{}", "Collection Details".bold().underline());
-            println!("  {} {}", "Name:".cyan(), col.name().green());
-            println!("  {} {}", "Type:".cyan(), type_label.green());
-            println!("  {} {}", "Item Count:".cyan(), col.len());
-            println!();
+            print_metadata_detail("Collection Details", type_label, &col.name(), col.len());
         }
         None => {
             return CommandResult::Error(format!("Collection '{name}' not found"));
@@ -241,16 +237,7 @@ pub(crate) fn cmd_browse(db: &Database, parts: &[&str]) -> CommandResult {
             );
             println!();
 
-            if node_page.entries.is_empty() {
-                println!("No nodes on this page.\n");
-            } else {
-                let rows = node_entries_to_rows(&node_page.entries);
-                crate::repl_output::print_table(&rows);
-                println!(
-                    "\nUse {} to see next page\n",
-                    format!(".browse {} {}", name, page + 1).yellow()
-                );
-            }
+            print_node_page_body(&node_page.entries, name, ".browse", page);
         }
         Some(collection_helpers::TypedCollection::Metadata(col)) => {
             browse_id_based(
@@ -304,16 +291,7 @@ pub(crate) fn cmd_nodes(db: &Database, parts: &[&str]) -> CommandResult {
     );
     println!();
 
-    if node_page.entries.is_empty() {
-        println!("No nodes on this page.\n");
-    } else {
-        let rows = node_entries_to_rows(&node_page.entries);
-        crate::repl_output::print_table(&rows);
-        println!(
-            "\nUse {} to see next page\n",
-            format!(".nodes {} {}", name, page + 1).yellow()
-        );
-    }
+    print_node_page_body(&node_page.entries, name, ".nodes", page);
     CommandResult::Continue
 }
 
@@ -351,11 +329,7 @@ pub(crate) fn cmd_stats(db: &Database, parts: &[&str]) -> CommandResult {
             println!();
         }
         Some(collection_helpers::TypedCollection::Metadata(col)) => {
-            println!("\n{}", "Collection Statistics".bold().underline());
-            println!("  {} {}", "Name:".cyan(), col.name().green());
-            println!("  {} {}", "Type:".cyan(), "Metadata".green());
-            println!("  {} {}", "Item Count:".cyan(), col.len());
-            println!();
+            print_metadata_detail("Collection Statistics", "Metadata", &col.name(), col.len());
         }
         None => {
             return CommandResult::Error(format!("Collection '{name}' not found"));
@@ -474,6 +448,40 @@ pub(crate) fn node_entries_to_rows(
         .iter()
         .map(|(node_id, payload)| helpers::point_payload_to_row(*node_id, payload))
         .collect()
+}
+
+/// Prints the four-line detail block for a Metadata collection (title, name, type,
+/// item count). `title` and `type_value` let `.describe` and `.stats` share the
+/// rendering while keeping their distinct section heading and type label.
+fn print_metadata_detail(title: &str, type_value: &str, name: &str, item_count: usize) {
+    println!("\n{}", title.bold().underline());
+    println!("  {} {}", "Name:".cyan(), name.green());
+    println!("  {} {}", "Type:".cyan(), type_value.green());
+    println!("  {} {}", "Item Count:".cyan(), item_count);
+    println!();
+}
+
+/// Prints the body of a paginated graph node page: either an empty notice or the
+/// node table followed by a "next page" navigation hint.
+///
+/// `command` is the REPL command word used in the hint (e.g. `.browse`, `.nodes`),
+/// allowing callers to share the rendering while keeping their distinct headers.
+fn print_node_page_body(
+    entries: &[(u64, Option<serde_json::Value>)],
+    name: &str,
+    command: &str,
+    page: usize,
+) {
+    if entries.is_empty() {
+        println!("No nodes on this page.\n");
+    } else {
+        let rows = node_entries_to_rows(entries);
+        crate::repl_output::print_table(&rows);
+        println!(
+            "\nUse {} to see next page\n",
+            format!("{} {} {}", command, name, page + 1).yellow()
+        );
+    }
 }
 
 /// Formats a vector as a truncated preview string (first 5 dimensions).

--- a/crates/velesdb-core/src/collection/core/graph_api.rs
+++ b/crates/velesdb-core/src/collection/core/graph_api.rs
@@ -312,13 +312,7 @@ impl Collection {
         limit: usize,
     ) -> Result<Vec<TraversalResult>> {
         let filter: &[&str] = rel_types.unwrap_or(&[]);
-        let params = TraversalParams {
-            store: &self.edge_store,
-            filter,
-            limit,
-            max_depth,
-            source,
-        };
+        let params = self.traversal_params(source, max_depth, filter, limit);
         let mut frontier = std::collections::VecDeque::new();
         frontier.push_back((source, 0u32));
 
@@ -328,6 +322,25 @@ impl Collection {
             bfs_push,
             &mut frontier,
         ))
+    }
+
+    /// Builds the [`TraversalParams`] bundle shared by `traverse_bfs` and
+    /// `traverse_dfs`; the two differ only in their frontier type and
+    /// pop/push functions, which stay with each method.
+    fn traversal_params<'a>(
+        &'a self,
+        source: u64,
+        max_depth: u32,
+        filter: &'a [&'a str],
+        limit: usize,
+    ) -> TraversalParams<'a> {
+        TraversalParams {
+            store: &self.edge_store,
+            filter,
+            limit,
+            max_depth,
+            source,
+        }
     }
 
     /// Traverses the graph using DFS from a source node.
@@ -356,13 +369,7 @@ impl Collection {
         limit: usize,
     ) -> Result<Vec<TraversalResult>> {
         let filter: &[&str] = rel_types.unwrap_or(&[]);
-        let params = TraversalParams {
-            store: &self.edge_store,
-            filter,
-            limit,
-            max_depth,
-            source,
-        };
+        let params = self.traversal_params(source, max_depth, filter, limit);
         let mut frontier = vec![(source, 0u32)];
 
         Ok(traverse_with_frontier(

--- a/crates/velesdb-core/src/collection/graph_collection.rs
+++ b/crates/velesdb-core/src/collection/graph_collection.rs
@@ -408,19 +408,29 @@ mod tests {
     use crate::collection::graph::GraphSchema;
     use crate::distance::DistanceMetric;
     use std::collections::HashMap;
-    use tempfile::tempdir;
+    use tempfile::{tempdir, TempDir};
 
-    #[test]
-    fn test_all_node_ids_returns_ids_with_payload() {
+    /// Creates a schemaless cosine `GraphCollection` in a fresh temp dir.
+    ///
+    /// Returns the `TempDir` guard alongside the collection so the backing
+    /// directory outlives the test. `dimension` controls embedding support
+    /// (`None` for payload/edge-only collections, `Some(n)` for searchable ones).
+    fn make_test_collection(dimension: Option<usize>) -> (TempDir, GraphCollection) {
         let dir = tempdir().unwrap();
         let col = GraphCollection::create(
             dir.path().to_path_buf(),
             "kg",
-            None,
+            dimension,
             DistanceMetric::Cosine,
             GraphSchema::schemaless(),
         )
         .unwrap();
+        (dir, col)
+    }
+
+    #[test]
+    fn test_all_node_ids_returns_ids_with_payload() {
+        let (_dir, col) = make_test_collection(None);
 
         // Store payloads on two nodes
         col.upsert_node_payload(10, &serde_json::json!({"name": "Alice"}))
@@ -436,15 +446,7 @@ mod tests {
 
     #[test]
     fn test_upsert_node_with_embedding_is_searchable() {
-        let dir = tempdir().unwrap();
-        let col = GraphCollection::create(
-            dir.path().to_path_buf(),
-            "kg",
-            Some(4),
-            DistanceMetric::Cosine,
-            GraphSchema::schemaless(),
-        )
-        .unwrap();
+        let (_dir, col) = make_test_collection(Some(4));
 
         col.upsert_node(
             10,
@@ -463,15 +465,7 @@ mod tests {
 
     #[test]
     fn test_edge_count_returns_correct_count() {
-        let dir = tempdir().unwrap();
-        let col = GraphCollection::create(
-            dir.path().to_path_buf(),
-            "kg",
-            None,
-            DistanceMetric::Cosine,
-            GraphSchema::schemaless(),
-        )
-        .unwrap();
+        let (_dir, col) = make_test_collection(None);
 
         assert_eq!(col.edge_count(), 0);
 
@@ -486,15 +480,7 @@ mod tests {
 
     #[test]
     fn test_traverse_bfs_parallel_through_graph_collection() {
-        let dir = tempdir().unwrap();
-        let col = GraphCollection::create(
-            dir.path().to_path_buf(),
-            "kg",
-            None,
-            DistanceMetric::Cosine,
-            GraphSchema::schemaless(),
-        )
-        .unwrap();
+        let (_dir, col) = make_test_collection(None);
 
         // Build chain: 1->2->3
         col.add_edge(GraphEdge::new(1, 1, 2, "NEXT").unwrap())
@@ -516,15 +502,7 @@ mod tests {
 
     #[test]
     fn test_execute_match_finds_edges() {
-        let dir = tempdir().unwrap();
-        let col = GraphCollection::create(
-            dir.path().to_path_buf(),
-            "kg",
-            None,
-            DistanceMetric::Cosine,
-            GraphSchema::schemaless(),
-        )
-        .unwrap();
+        let (_dir, col) = make_test_collection(None);
 
         // Store node payloads with labels
         col.upsert_node_payload(

--- a/crates/velesdb-core/src/collection/search/vector_tests.rs
+++ b/crates/velesdb-core/src/collection/search/vector_tests.rs
@@ -58,6 +58,39 @@ fn test_search_ids_product_quantization_cosine_scores_stay_in_similarity_domain(
 // Bitmap pre-filter integration tests
 // =============================================================================
 
+/// Builds one 4-dim point whose first coordinate is offset by `id` and then
+/// L2-normalized for cosine, carrying the supplied `payload`.
+fn make_normalized_point(id: u64, payload: serde_json::Value) -> Point {
+    let mut vector = vec![0.1_f32; 4];
+    // Reason: id fits in u16 for these small test fixtures.
+    #[allow(clippy::cast_precision_loss)]
+    {
+        vector[0] += (id as f32) * 0.01;
+    }
+    // Normalize for cosine
+    let norm = vector.iter().map(|x| x * x).sum::<f32>().sqrt();
+    for x in &mut vector {
+        *x /= norm;
+    }
+    Point {
+        id,
+        vector,
+        payload: Some(payload),
+        sparse_vectors: None,
+    }
+}
+
+/// Builds 20 normalized points tagged `tag = "A"` (IDs 0..10) or `"B"`
+/// (IDs 10..20), used by the no-index post-filter fallback tests.
+fn tag_ab_points() -> Vec<Point> {
+    (0u64..20)
+        .map(|id| {
+            let payload = serde_json::json!({"tag": if id < 10 { "A" } else { "B" }});
+            make_normalized_point(id, payload)
+        })
+        .collect()
+}
+
 /// Creates a collection with indexed points for bitmap pre-filter testing.
 ///
 /// Inserts 50 points in 4-dim space with payloads:
@@ -84,23 +117,7 @@ fn create_indexed_collection() -> (Collection, TempDir) {
                 "category": category,
                 "priority": id % 5,
             });
-            let mut vector = vec![0.1_f32; 4];
-            // Reason: id fits in u16 for 50 points.
-            #[allow(clippy::cast_precision_loss)]
-            {
-                vector[0] += (id as f32) * 0.01;
-            }
-            // Normalize for cosine
-            let norm = vector.iter().map(|x| x * x).sum::<f32>().sqrt();
-            for x in &mut vector {
-                *x /= norm;
-            }
-            Point {
-                id,
-                vector,
-                payload: Some(payload),
-                sparse_vectors: None,
-            }
+            make_normalized_point(id, payload)
         })
         .collect();
 
@@ -148,26 +165,7 @@ fn test_search_with_filter_no_index_falls_back_to_postfilter() {
         .expect("test: create collection");
 
     // Insert points WITHOUT creating a secondary index
-    let points: Vec<Point> = (0u64..20)
-        .map(|id| {
-            let payload = serde_json::json!({"tag": if id < 10 { "A" } else { "B" }});
-            let mut vector = vec![0.1_f32; 4];
-            #[allow(clippy::cast_precision_loss)]
-            {
-                vector[0] += (id as f32) * 0.01;
-            }
-            let norm = vector.iter().map(|x| x * x).sum::<f32>().sqrt();
-            for x in &mut vector {
-                *x /= norm;
-            }
-            Point {
-                id,
-                vector,
-                payload: Some(payload),
-                sparse_vectors: None,
-            }
-        })
-        .collect();
+    let points: Vec<Point> = tag_ab_points();
 
     collection.upsert(points).expect("test: upsert");
 
@@ -360,26 +358,7 @@ fn test_search_with_filter_and_opts_no_bitmap_falls_back_to_post_filter() {
     let temp_dir = TempDir::new().expect("test: temp dir");
     let col = Collection::create(temp_dir.path().to_path_buf(), 4, DistanceMetric::Cosine)
         .expect("create");
-    let points: Vec<crate::point::Point> = (0u64..20)
-        .map(|id| {
-            let payload = serde_json::json!({"tag": if id < 10 { "A" } else { "B" }});
-            let mut vector = vec![0.1_f32; 4];
-            #[allow(clippy::cast_precision_loss)]
-            {
-                vector[0] += (id as f32) * 0.01;
-            }
-            let norm = vector.iter().map(|x| x * x).sum::<f32>().sqrt();
-            for x in &mut vector {
-                *x /= norm;
-            }
-            crate::point::Point {
-                id,
-                vector,
-                payload: Some(payload),
-                sparse_vectors: None,
-            }
-        })
-        .collect();
+    let points: Vec<Point> = tag_ab_points();
     col.upsert(points).expect("upsert");
     let filter = crate::filter::Filter::new(crate::filter::Condition::Eq {
         field: "tag".to_string(),


### PR DESCRIPTION
## What

Drives jscpd duplication on the `develop..main` delta from **18 clones / 216 lines / 1.11%** to **0** — behavior-preserving Extract Method across 8 files in 3 crates.

| Crate | File | Extracted |
|---|---|---|
| core | `vector_tests.rs` | `make_normalized_point`, `tag_ab_points` (test helpers) |
| core | `graph_api.rs` | `traversal_params` (shared TraversalParams builder) |
| core | `graph_collection.rs` | `make_test_collection` (test setup) |
| cli | `repl_collection_cmds.rs` | `print_node_page_body`, `print_metadata_detail` |
| cli | `import_tests.rs` | `write_lines`, `open_db_and_test_config`, `run_jsonl_import` |
| cli | `import.rs` | `finalize_import` (shared import tail) |
| tauri | `commands_graph.rs` | `build_traversal_config`, `to_traversal_outputs` |
| tauri | `commands.rs` | `upsert_points`, `run_filtered_search` (the latter now owns its `start` instant, so the parallel search handlers no longer share a preamble clone) |

## Why

Pre-existing duplication in the develop-since-v2.0.0 code. Cleared as part of the 3.0.0 release hygiene so the release PR (develop→main) passes the DRY gate without skips, and to hold the repo at 0 technical debt.

## No behaviour change

Pure Extract Method — every helper reproduces each call site's logic exactly (adversarially reviewed for behavior preservation). The only nuance: tauri search latency metrics now exclude sub-µs filter-parse time (run_filtered_search captures `start` internally).

## Validation (local)

- **jscpd: 0 clones / 0%** (was 18 / 1.11%)
- `cargo clippy --workspace --all-targets --features persistence,gpu,update-check --exclude velesdb-python -- -D warnings -D clippy::pedantic` ✅
- core lib tests **5223/0**, cli tests green
- No `.unwrap()`/`.expect()` added in production; all helpers within CCN ≤ 8 / NLOC ≤ 50