### PR TITLE
test: raise new-code coverage ≥80% + fix SonarCloud python coverage-scope (v3.0.1 prep)

### DIFF
--- a/crates/tauri-plugin-velesdb/Cargo.toml
+++ b/crates/tauri-plugin-velesdb/Cargo.toml
@@ -29,6 +29,10 @@ velesdb-core = { workspace = true }
 [dev-dependencies]
 tempfile = "3.14"
 toml = "1.1"
+# `test` feature unlocks `tauri::test::{mock_builder, mock_context, noop_assets}`
+# and `MockRuntime`, used by command integration tests to build an
+# `App<MockRuntime>` and exercise the `#[command]` handlers directly.
+tauri = { version = "2.11", default-features = false, features = ["test"] }
 
 [features]
 default = ["velesdb-core/default"]

--- a/crates/tauri-plugin-velesdb/tests/command_handlers.rs
+++ b/crates/tauri-plugin-velesdb/tests/command_handlers.rs
@@ -1,0 +1,916 @@
+//! Integration coverage for the Tauri `#[command]` handlers in `commands.rs`,
+//! `commands_graph.rs`, and the lifecycle `observer.rs`.
+//!
+//! The handlers take `AppHandle<R>` + `State<'_, VelesDbState>` arguments that
+//! can only exist inside a Tauri `App`. These tests build a real
+//! `App<MockRuntime>` (via `tauri::test`), `manage` a `VelesDbState` rooted in a
+//! tempdir, and drive each async command directly through
+//! `tauri::async_runtime::block_on` — covering both success and error paths
+//! (missing collection, wrong collection kind, invalid config) which the
+//! existing `*_tests.rs` DTO/serde unit tests do not reach.
+//!
+//! Requires the `persistence` feature (the core search/streaming paths the
+//! commands call are persistence-gated).
+#![cfg(feature = "persistence")]
+
+use std::sync::Arc;
+
+use tauri::test::{mock_builder, mock_context, noop_assets};
+use tauri::{App, AppHandle, Manager, State};
+
+use tauri::Runtime;
+use tauri_plugin_velesdb::commands::{
+    add_edge, batch_search, compact_storage, create_collection, create_graph_collection,
+    create_metadata_collection, delete_collection, delete_points, enable_streaming, flush,
+    get_collection, get_edges, get_guardrails, get_node_degree, get_points, hybrid_search,
+    is_empty, list_collections, multi_query_search, scroll_collection, search, search_ids,
+    stream_insert, text_search, traverse_graph, update_guardrails, upsert, upsert_metadata,
+};
+use tauri_plugin_velesdb::observer::TauriObserver;
+use tauri_plugin_velesdb::types::{
+    AddEdgeRequest, BatchSearchRequest, CreateCollectionRequest, CreateGraphCollectionRequest,
+    CreateMetadataCollectionRequest, DeletePointsRequest, EnableStreamingRequest, GetEdgesRequest,
+    GetNodeDegreeRequest, GetPointsRequest, GuardrailLimits, HybridSearchRequest,
+    IndividualSearchRequest, MetadataPointInput, MultiQuerySearchRequest, PointInput,
+    ScrollRequest, SearchRequest, StreamInsertRequest, TextSearchRequest, TraverseGraphRequest,
+    UpsertMetadataRequest, UpsertRequest,
+};
+use tauri_plugin_velesdb::VelesDbState;
+
+const DIM: usize = 4;
+
+/// Builds an `App<MockRuntime>` managing a `VelesDbState` rooted in `dir`.
+fn mock_app(dir: &std::path::Path) -> App<tauri::test::MockRuntime> {
+    let app = mock_builder()
+        .build(mock_context(noop_assets()))
+        .expect("build mock app");
+    let state = VelesDbState::new(dir.to_path_buf());
+    app.manage(state);
+    app
+}
+
+/// Convenience: run an async command future to completion.
+fn run<F: std::future::Future>(fut: F) -> F::Output {
+    tauri::async_runtime::block_on(fut)
+}
+
+fn handle<R: Runtime>(app: &App<R>) -> AppHandle<R> {
+    app.handle().clone()
+}
+
+fn st<R: Runtime>(app: &App<R>) -> State<'_, VelesDbState> {
+    app.state::<VelesDbState>()
+}
+
+fn vector_collection_request(name: &str) -> CreateCollectionRequest {
+    serde_json::from_value(serde_json::json!({
+        "name": name,
+        "dimension": DIM,
+    }))
+    .expect("deserialize create request")
+}
+
+/// Builds the on-wire filter JSON (`{"condition": {"type": "eq", ...}}`) the
+/// frontend sends and that `parse_filter` → `Filter::from_json_value` expects.
+fn eq_filter(field: &str, value: &str) -> serde_json::Value {
+    serde_json::json!({"condition": {"type": "eq", "field": field, "value": value}})
+}
+
+// `vector`/`payload` are moved into the `json!` macro; clippy's pedantic
+// pass-by-value lint can't see through the macro, so silence it here.
+#[allow(clippy::needless_pass_by_value)]
+fn point(id: u64, vector: Vec<f32>, payload: serde_json::Value) -> PointInput {
+    serde_json::from_value(serde_json::json!({
+        "id": id,
+        "vector": vector,
+        "payload": payload,
+    }))
+    .expect("deserialize point")
+}
+
+/// Creates a vector collection and upserts four text-rich points so vector,
+/// text (BM25, populated automatically from string payloads), and hybrid
+/// searches all have data to return.
+fn seed_vector_collection(app: &App<tauri::test::MockRuntime>, name: &str) {
+    let created = run(create_collection(
+        handle(app),
+        st(app),
+        vector_collection_request(name),
+    ))
+    .expect("create_collection");
+    assert_eq!(created.name, name);
+    assert_eq!(created.dimension, DIM);
+
+    let points = vec![
+        point(
+            1,
+            vec![1.0, 0.0, 0.0, 0.0],
+            serde_json::json!({"title": "rust programming language", "category": "tech"}),
+        ),
+        point(
+            2,
+            vec![0.0, 1.0, 0.0, 0.0],
+            serde_json::json!({"title": "python programming tutorial", "category": "tech"}),
+        ),
+        point(
+            3,
+            vec![0.0, 0.0, 1.0, 0.0],
+            serde_json::json!({"title": "football world cup", "category": "sports"}),
+        ),
+        point(
+            4,
+            vec![0.5, 0.5, 0.0, 0.0],
+            serde_json::json!({"title": "rust web framework", "category": "tech"}),
+        ),
+    ];
+    let inserted = run(upsert(
+        handle(app),
+        st(app),
+        UpsertRequest {
+            collection: name.to_string(),
+            points,
+        },
+    ))
+    .expect("upsert");
+    assert_eq!(inserted, 4);
+}
+
+// ===========================================================================
+// Collection lifecycle commands
+// ===========================================================================
+
+#[test]
+fn create_list_get_delete_collection_roundtrip() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let app = mock_app(dir.path());
+
+    seed_vector_collection(&app, "docs");
+
+    // list_collections sees it with the right shape.
+    let listed = run(list_collections(handle(&app), st(&app))).expect("list");
+    assert!(listed.iter().any(|c| c.name == "docs" && c.count == 4));
+
+    // get_collection returns matching info.
+    let info = run(get_collection(handle(&app), st(&app), "docs".to_string())).expect("get");
+    assert_eq!(info.dimension, DIM);
+    assert_eq!(info.count, 4);
+
+    // is_empty is false after seeding.
+    assert!(!run(is_empty(handle(&app), st(&app), "docs".to_string())).expect("is_empty"));
+
+    // flush + compact_storage succeed on a real collection.
+    run(flush(handle(&app), st(&app), "docs".to_string())).expect("flush");
+    let _freed =
+        run(compact_storage(handle(&app), st(&app), "docs".to_string())).expect("compact_storage");
+
+    // delete_collection removes it; subsequent get_collection errors.
+    run(delete_collection(
+        handle(&app),
+        st(&app),
+        "docs".to_string(),
+    ))
+    .expect("delete");
+    let err = run(get_collection(handle(&app), st(&app), "docs".to_string()))
+        .expect_err("missing collection should error");
+    assert_eq!(err.code, "VELES-002");
+}
+
+#[test]
+fn create_collection_with_advanced_params_validates() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let app = mock_app(dir.path());
+
+    // hnswM triggers the advanced-params path (build_hnsw_params + validate).
+    let req: CreateCollectionRequest = serde_json::from_value(serde_json::json!({
+        "name": "tuned",
+        "dimension": DIM,
+        "hnswM": 32,
+        "hnswEfConstruction": 200,
+    }))
+    .expect("deserialize");
+    let info = run(create_collection(handle(&app), st(&app), req)).expect("create tuned");
+    assert_eq!(info.name, "tuned");
+
+    // An out-of-range alpha is rejected by hnsw_params.validate().
+    let bad: CreateCollectionRequest = serde_json::from_value(serde_json::json!({
+        "name": "bad",
+        "dimension": DIM,
+        "hnswAlpha": 0.1,
+    }))
+    .expect("deserialize");
+    assert!(run(create_collection(handle(&app), st(&app), bad)).is_err());
+}
+
+#[test]
+fn create_collection_invalid_metric_errors() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let app = mock_app(dir.path());
+    let mut req = vector_collection_request("x");
+    req.metric = "not_a_metric".to_string();
+    let err = run(create_collection(handle(&app), st(&app), req)).expect_err("bad metric");
+    assert_eq!(err.code, "INVALID_CONFIG");
+}
+
+#[test]
+fn create_metadata_collection_and_upsert_metadata() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let app = mock_app(dir.path());
+
+    // create_metadata_collection reports the metadata-only shape.
+    let info = run(create_metadata_collection(
+        handle(&app),
+        st(&app),
+        CreateMetadataCollectionRequest {
+            name: "meta".to_string(),
+        },
+    ))
+    .expect("create metadata");
+    assert_eq!(info.storage_mode, "metadata_only");
+
+    let m_point: MetadataPointInput = serde_json::from_value(serde_json::json!({
+        "id": 1,
+        "payload": {"name": "alice"},
+    }))
+    .expect("deserialize metadata point");
+
+    // upsert_metadata goes through `require_collection`, which only accepts
+    // vector collections — so a metadata-only target is rejected (error path).
+    let rejected = run(upsert_metadata(
+        handle(&app),
+        st(&app),
+        UpsertMetadataRequest {
+            collection: "meta".to_string(),
+            points: vec![m_point],
+        },
+    ))
+    .expect_err("metadata-only collection is not a vector collection");
+    assert_eq!(rejected.code, "INVALID_CONFIG");
+
+    // The success path: metadata-only points (no vector) into a vector
+    // collection exercises the `coll.upsert_metadata` branch.
+    seed_vector_collection(&app, "docs");
+    let m_point2: MetadataPointInput = serde_json::from_value(serde_json::json!({
+        "id": 99,
+        "payload": {"name": "bob"},
+    }))
+    .expect("deserialize metadata point");
+    let n = run(upsert_metadata(
+        handle(&app),
+        st(&app),
+        UpsertMetadataRequest {
+            collection: "docs".to_string(),
+            points: vec![m_point2],
+        },
+    ))
+    .expect("upsert_metadata into vector collection");
+    assert_eq!(n, 1);
+}
+
+// ===========================================================================
+// Point + search commands (success + error paths)
+// ===========================================================================
+
+#[test]
+fn get_and_delete_points() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let app = mock_app(dir.path());
+    seed_vector_collection(&app, "docs");
+
+    let fetched = run(get_points(
+        handle(&app),
+        st(&app),
+        GetPointsRequest {
+            collection: "docs".to_string(),
+            ids: vec![1, 999],
+        },
+    ))
+    .expect("get_points");
+    assert_eq!(fetched.len(), 2);
+    assert!(fetched[0].is_some(), "id 1 exists");
+    assert!(fetched[1].is_none(), "id 999 missing");
+
+    run(delete_points(
+        handle(&app),
+        st(&app),
+        DeletePointsRequest {
+            collection: "docs".to_string(),
+            ids: vec![1],
+        },
+    ))
+    .expect("delete_points");
+
+    let after = run(get_points(
+        handle(&app),
+        st(&app),
+        GetPointsRequest {
+            collection: "docs".to_string(),
+            ids: vec![1],
+        },
+    ))
+    .expect("get_points after delete");
+    assert!(after[0].is_none(), "id 1 deleted");
+}
+
+#[test]
+fn search_plain_filtered_and_quality() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let app = mock_app(dir.path());
+    seed_vector_collection(&app, "docs");
+
+    // Plain vector search.
+    let plain = run(search(
+        handle(&app),
+        st(&app),
+        SearchRequest {
+            collection: "docs".to_string(),
+            vector: vec![1.0, 0.0, 0.0, 0.0],
+            top_k: 3,
+            filter: None,
+            quality: None,
+        },
+    ))
+    .expect("search plain");
+    assert!(!plain.results.is_empty());
+
+    // Quality mode (persistence path: dispatch_quality_search → search_with_quality).
+    let quality = run(search(
+        handle(&app),
+        st(&app),
+        SearchRequest {
+            collection: "docs".to_string(),
+            vector: vec![1.0, 0.0, 0.0, 0.0],
+            top_k: 2,
+            filter: None,
+            quality: Some("accurate".to_string()),
+        },
+    ))
+    .expect("search quality");
+    assert!(!quality.results.is_empty());
+
+    // Filtered search (search_with_filter path).
+    let filtered = run(search(
+        handle(&app),
+        st(&app),
+        SearchRequest {
+            collection: "docs".to_string(),
+            vector: vec![0.5, 0.5, 0.0, 0.0],
+            top_k: 10,
+            filter: Some(eq_filter("category", "sports")),
+            quality: None,
+        },
+    ))
+    .expect("search filtered");
+    for r in &filtered.results {
+        assert_eq!(r.id, 3, "only the sports doc matches the filter");
+    }
+}
+
+#[test]
+fn search_missing_collection_and_bad_quality_error() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let app = mock_app(dir.path());
+    seed_vector_collection(&app, "docs");
+
+    let missing = run(search(
+        handle(&app),
+        st(&app),
+        SearchRequest {
+            collection: "ghost".to_string(),
+            vector: vec![1.0, 0.0, 0.0, 0.0],
+            top_k: 1,
+            filter: None,
+            quality: None,
+        },
+    ))
+    .expect_err("missing collection");
+    assert_eq!(missing.code, "VELES-002");
+
+    let bad_quality = run(search(
+        handle(&app),
+        st(&app),
+        SearchRequest {
+            collection: "docs".to_string(),
+            vector: vec![1.0, 0.0, 0.0, 0.0],
+            top_k: 1,
+            filter: None,
+            quality: Some("nonsense".to_string()),
+        },
+    ))
+    .expect_err("invalid quality mode");
+    assert_eq!(bad_quality.code, "INVALID_CONFIG");
+}
+
+#[test]
+fn search_ids_optimized_and_filtered_paths() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let app = mock_app(dir.path());
+    seed_vector_collection(&app, "docs");
+
+    // No filter, no quality → optimized search_ids path.
+    let ids = run(search_ids(
+        handle(&app),
+        st(&app),
+        SearchRequest {
+            collection: "docs".to_string(),
+            vector: vec![1.0, 0.0, 0.0, 0.0],
+            top_k: 2,
+            filter: None,
+            quality: None,
+        },
+    ))
+    .expect("search_ids optimized");
+    assert!(!ids.is_empty());
+
+    // Filter present → falls back to full search then project_search_ids.
+    let filtered_ids = run(search_ids(
+        handle(&app),
+        st(&app),
+        SearchRequest {
+            collection: "docs".to_string(),
+            vector: vec![0.0, 0.0, 1.0, 0.0],
+            top_k: 10,
+            filter: Some(eq_filter("category", "sports")),
+            quality: None,
+        },
+    ))
+    .expect("search_ids filtered");
+    for hit in &filtered_ids {
+        assert_eq!(hit.id, 3);
+    }
+}
+
+#[test]
+fn batch_search_bulk_and_per_query_quality() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let app = mock_app(dir.path());
+    seed_vector_collection(&app, "docs");
+
+    let plain_searches: Vec<IndividualSearchRequest> = serde_json::from_value(serde_json::json!([
+        {"vector": [1.0, 0.0, 0.0, 0.0], "topK": 2},
+        {"vector": [0.0, 1.0, 0.0, 0.0], "topK": 1},
+    ]))
+    .expect("deserialize searches");
+    let bulk = run(batch_search(
+        handle(&app),
+        st(&app),
+        BatchSearchRequest {
+            collection: "docs".to_string(),
+            searches: plain_searches,
+        },
+    ))
+    .expect("batch_search bulk");
+    assert_eq!(bulk.len(), 2);
+    assert!(bulk[1].results.len() <= 1, "second query honors topK=1");
+
+    // A per-query quality flips to the per-query dispatch branch.
+    let quality_searches: Vec<IndividualSearchRequest> =
+        serde_json::from_value(serde_json::json!([
+            {"vector": [1.0, 0.0, 0.0, 0.0], "topK": 2, "quality": "fast"},
+        ]))
+        .expect("deserialize quality searches");
+    let per_query = run(batch_search(
+        handle(&app),
+        st(&app),
+        BatchSearchRequest {
+            collection: "docs".to_string(),
+            searches: quality_searches,
+        },
+    ))
+    .expect("batch_search per-query");
+    assert_eq!(per_query.len(), 1);
+}
+
+#[test]
+fn text_and_hybrid_search_filtered_and_unfiltered() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let app = mock_app(dir.path());
+    seed_vector_collection(&app, "docs");
+
+    // Unfiltered BM25 text search finds the two rust docs.
+    let text = run(text_search(
+        handle(&app),
+        st(&app),
+        TextSearchRequest {
+            collection: "docs".to_string(),
+            query: "rust".to_string(),
+            top_k: 10,
+            filter: None,
+        },
+    ))
+    .expect("text_search");
+    let text_ids: Vec<u64> = text.results.iter().map(|r| r.id).collect();
+    assert!(text_ids.contains(&1) && text_ids.contains(&4));
+
+    // Filtered text search restricts to tech.
+    let text_filtered = run(text_search(
+        handle(&app),
+        st(&app),
+        TextSearchRequest {
+            collection: "docs".to_string(),
+            query: "rust".to_string(),
+            top_k: 10,
+            filter: Some(eq_filter("category", "tech")),
+        },
+    ))
+    .expect("text_search filtered");
+    assert!(!text_filtered.results.is_empty());
+
+    // Hybrid search (unfiltered + filtered branches).
+    let hybrid = run(hybrid_search(
+        handle(&app),
+        st(&app),
+        HybridSearchRequest {
+            collection: "docs".to_string(),
+            vector: vec![1.0, 0.0, 0.0, 0.0],
+            query: "rust".to_string(),
+            top_k: 5,
+            vector_weight: 0.5,
+            filter: None,
+        },
+    ))
+    .expect("hybrid_search");
+    assert!(!hybrid.results.is_empty());
+
+    let hybrid_filtered = run(hybrid_search(
+        handle(&app),
+        st(&app),
+        HybridSearchRequest {
+            collection: "docs".to_string(),
+            vector: vec![1.0, 0.0, 0.0, 0.0],
+            query: "rust".to_string(),
+            top_k: 5,
+            vector_weight: 0.7,
+            filter: Some(eq_filter("category", "tech")),
+        },
+    ))
+    .expect("hybrid_search filtered");
+    assert!(!hybrid_filtered.results.is_empty());
+}
+
+#[test]
+fn multi_query_search_fuses_results() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let app = mock_app(dir.path());
+    seed_vector_collection(&app, "docs");
+
+    let response = run(multi_query_search(
+        handle(&app),
+        st(&app),
+        MultiQuerySearchRequest {
+            collection: "docs".to_string(),
+            vectors: vec![vec![1.0, 0.0, 0.0, 0.0], vec![0.0, 1.0, 0.0, 0.0]],
+            top_k: 3,
+            fusion: "rrf".to_string(),
+            fusion_params: Some(serde_json::json!({"k": 30})),
+            filter: None,
+        },
+    ))
+    .expect("multi_query_search");
+    assert!(!response.results.is_empty());
+
+    // Unknown fusion strategy is a config error.
+    let bad = run(multi_query_search(
+        handle(&app),
+        st(&app),
+        MultiQuerySearchRequest {
+            collection: "docs".to_string(),
+            vectors: vec![vec![1.0, 0.0, 0.0, 0.0]],
+            top_k: 1,
+            fusion: "nope".to_string(),
+            fusion_params: None,
+            filter: None,
+        },
+    ))
+    .expect_err("bad fusion");
+    assert_eq!(bad.code, "INVALID_CONFIG");
+}
+
+#[test]
+fn scroll_collection_paginates() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let app = mock_app(dir.path());
+    seed_vector_collection(&app, "docs");
+
+    let first = run(scroll_collection(
+        handle(&app),
+        st(&app),
+        ScrollRequest {
+            collection: "docs".to_string(),
+            cursor: None,
+            batch_size: 2,
+            filter: None,
+        },
+    ))
+    .expect("scroll first page");
+    assert!(first.points.len() <= 2);
+
+    // Filtered scroll only returns the sports doc.
+    let filtered = run(scroll_collection(
+        handle(&app),
+        st(&app),
+        ScrollRequest {
+            collection: "docs".to_string(),
+            cursor: None,
+            batch_size: 100,
+            filter: Some(eq_filter("category", "sports")),
+        },
+    ))
+    .expect("scroll filtered");
+    for p in &filtered.points {
+        assert_eq!(p.id, 3);
+    }
+}
+
+// ===========================================================================
+// Guardrails commands
+// ===========================================================================
+
+#[test]
+fn update_then_get_guardrails() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let app = mock_app(dir.path());
+    seed_vector_collection(&app, "docs");
+
+    let limits = GuardrailLimits {
+        max_depth: 7,
+        max_cardinality: 1234,
+        memory_limit_bytes: 4096,
+        timeout_ms: 500,
+        rate_limit_qps: 42,
+        circuit_failure_threshold: 3,
+        circuit_recovery_seconds: 30,
+    };
+    run(update_guardrails(handle(&app), st(&app), limits)).expect("update_guardrails");
+
+    let got =
+        run(get_guardrails(handle(&app), st(&app), "docs".to_string())).expect("get_guardrails");
+    assert_eq!(got.max_depth, 7);
+    assert_eq!(got.timeout_ms, 500);
+}
+
+// ===========================================================================
+// Streaming commands (persistence-only)
+// ===========================================================================
+
+#[test]
+fn enable_streaming_then_stream_insert() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let app = mock_app(dir.path());
+    seed_vector_collection(&app, "docs");
+
+    // stream_insert before enabling streaming errors (backpressure / not configured).
+    let not_ready = run(stream_insert(
+        handle(&app),
+        st(&app),
+        StreamInsertRequest {
+            collection: "docs".to_string(),
+            points: vec![point(10, vec![0.1, 0.2, 0.3, 0.4], serde_json::json!({}))],
+        },
+    ));
+    assert!(
+        not_ready.is_err(),
+        "stream_insert without enable should error"
+    );
+
+    run(enable_streaming(
+        handle(&app),
+        st(&app),
+        EnableStreamingRequest {
+            collection: "docs".to_string(),
+            buffer_size: Some(256),
+            batch_size: Some(8),
+            flush_interval_ms: Some(10),
+        },
+    ))
+    .expect("enable_streaming");
+
+    let inserted = run(stream_insert(
+        handle(&app),
+        st(&app),
+        StreamInsertRequest {
+            collection: "docs".to_string(),
+            points: vec![
+                point(11, vec![0.1, 0.2, 0.3, 0.4], serde_json::json!({"k": "v"})),
+                point(12, vec![0.4, 0.3, 0.2, 0.1], serde_json::json!({"k": "w"})),
+            ],
+        },
+    ))
+    .expect("stream_insert after enable");
+    assert_eq!(inserted, 2);
+}
+
+// ===========================================================================
+// Knowledge graph commands
+// ===========================================================================
+
+#[test]
+fn graph_create_add_edges_traverse_degree() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let app = mock_app(dir.path());
+
+    let info = run(create_graph_collection(
+        handle(&app),
+        st(&app),
+        CreateGraphCollectionRequest {
+            name: "kg".to_string(),
+            dimension: None,
+            metric: "cosine".to_string(),
+            graph_schema: None,
+        },
+    ))
+    .expect("create_graph_collection");
+    assert_eq!(info.storage_mode, "graph");
+
+    // Add a single edge with properties.
+    run(add_edge(
+        handle(&app),
+        st(&app),
+        AddEdgeRequest {
+            collection: "kg".to_string(),
+            id: 1,
+            source: 10,
+            target: 20,
+            label: "KNOWS".to_string(),
+            properties: Some(serde_json::json!({"weight": 0.9})),
+        },
+    ))
+    .expect("add_edge");
+    run(add_edge(
+        handle(&app),
+        st(&app),
+        AddEdgeRequest {
+            collection: "kg".to_string(),
+            id: 2,
+            source: 20,
+            target: 30,
+            label: "KNOWS".to_string(),
+            properties: None,
+        },
+    ))
+    .expect("add_edge 2");
+
+    // get_edges by source.
+    let outgoing = run(get_edges(
+        handle(&app),
+        st(&app),
+        GetEdgesRequest {
+            collection: "kg".to_string(),
+            label: None,
+            source: Some(10),
+            target: None,
+        },
+    ))
+    .expect("get_edges source");
+    assert_eq!(outgoing.len(), 1);
+    assert_eq!(outgoing[0].target, 20);
+
+    // get_edges by label.
+    let by_label = run(get_edges(
+        handle(&app),
+        st(&app),
+        GetEdgesRequest {
+            collection: "kg".to_string(),
+            label: Some("KNOWS".to_string()),
+            source: None,
+            target: None,
+        },
+    ))
+    .expect("get_edges label");
+    assert_eq!(by_label.len(), 2);
+
+    // Node degree of node 20: one in (10->20), one out (20->30).
+    let degree = run(get_node_degree(
+        handle(&app),
+        st(&app),
+        GetNodeDegreeRequest {
+            collection: "kg".to_string(),
+            node_id: 20,
+        },
+    ))
+    .expect("get_node_degree");
+    assert_eq!(degree.in_degree, 1);
+    assert_eq!(degree.out_degree, 1);
+
+    // BFS traversal from node 10 reaches 20 (and 30 at depth 2).
+    let bfs = run(traverse_graph(
+        handle(&app),
+        st(&app),
+        TraverseGraphRequest {
+            collection: "kg".to_string(),
+            source: 10,
+            max_depth: 2,
+            limit: 10,
+            algorithm: "bfs".to_string(),
+            rel_types: None,
+        },
+    ))
+    .expect("traverse_graph bfs");
+    let reached: Vec<u64> = bfs.iter().map(|t| t.target_id).collect();
+    assert!(reached.contains(&20));
+
+    // DFS branch.
+    let dfs = run(traverse_graph(
+        handle(&app),
+        st(&app),
+        TraverseGraphRequest {
+            collection: "kg".to_string(),
+            source: 10,
+            max_depth: 2,
+            limit: 10,
+            algorithm: "dfs".to_string(),
+            rel_types: Some(vec!["KNOWS".to_string()]),
+        },
+    ))
+    .expect("traverse_graph dfs");
+    assert!(!dfs.is_empty());
+}
+
+#[test]
+fn graph_create_with_embeddings_and_missing_collection_error() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let app = mock_app(dir.path());
+
+    // dimension set → create_graph_collection_with_embeddings branch.
+    let info = run(create_graph_collection(
+        handle(&app),
+        st(&app),
+        CreateGraphCollectionRequest {
+            name: "kg_emb".to_string(),
+            dimension: Some(DIM),
+            metric: "cosine".to_string(),
+            graph_schema: None,
+        },
+    ))
+    .expect("create_graph_collection with embeddings");
+    assert_eq!(info.dimension, DIM);
+
+    // add_edge on a non-existent graph collection errors.
+    let err = run(add_edge(
+        handle(&app),
+        st(&app),
+        AddEdgeRequest {
+            collection: "ghost".to_string(),
+            id: 1,
+            source: 1,
+            target: 2,
+            label: "X".to_string(),
+            properties: None,
+        },
+    ))
+    .expect_err("missing graph collection");
+    assert_eq!(err.code, "VELES-002");
+}
+
+#[test]
+fn create_graph_collection_invalid_schema_errors() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let app = mock_app(dir.path());
+    let err = run(create_graph_collection(
+        handle(&app),
+        st(&app),
+        CreateGraphCollectionRequest {
+            name: "kg_bad".to_string(),
+            dimension: None,
+            metric: "cosine".to_string(),
+            graph_schema: Some(serde_json::json!("not-a-schema-object")),
+        },
+    ))
+    .expect_err("invalid schema");
+    assert_eq!(err.code, "INVALID_CONFIG");
+}
+
+// ===========================================================================
+// Lifecycle observer (observer.rs)
+// ===========================================================================
+
+#[test]
+fn tauri_observer_forwards_lifecycle_hooks_to_app() {
+    // A managed state built with `new_with_observer` and a `TauriObserver`
+    // exercises the observer's `on_collection_created` / `on_collection_deleted`
+    // hooks (they emit Tauri events through the app handle) end-to-end via the
+    // create/delete command path.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let app = mock_builder()
+        .build(mock_context(noop_assets()))
+        .expect("build app");
+    let observer = Arc::new(TauriObserver::new(app.handle().clone()));
+    let state = VelesDbState::new_with_observer(dir.path().to_path_buf(), observer);
+    app.manage(state);
+
+    // create then delete drives both observer hooks (emit_collection_created /
+    // emit_collection_deleted) without panicking on the mock runtime.
+    let info = run(create_collection(
+        handle(&app),
+        st(&app),
+        vector_collection_request("observed"),
+    ))
+    .expect("create observed");
+    assert_eq!(info.name, "observed");
+
+    run(delete_collection(
+        handle(&app),
+        st(&app),
+        "observed".to_string(),
+    ))
+    .expect("delete observed");
+}

--- a/crates/tauri-plugin-velesdb/tests/command_handlers.rs
+++ b/crates/tauri-plugin-velesdb/tests/command_handlers.rs
@@ -12,6 +12,7 @@
 //! Requires the `persistence` feature (the core search/streaming paths the
 //! commands call are persistence-gated).
 #![cfg(feature = "persistence")]
+#![allow(clippy::too_many_lines)] // verbose end-to-end command-handler setup
 
 use std::sync::Arc;
 

--- a/crates/velesdb-cli/src/repl_collection_cmds.rs
+++ b/crates/velesdb-cli/src/repl_collection_cmds.rs
@@ -581,3 +581,7 @@ fn print_scroll_results(points: &[velesdb_core::Point], name: &str, next_cursor:
         None => println!("\n  {}\n", "Iteration complete.".green()),
     }
 }
+
+#[cfg(test)]
+#[path = "repl_collection_cmds_tests.rs"]
+mod repl_collection_cmds_tests;

--- a/crates/velesdb-cli/src/repl_collection_cmds_tests.rs
+++ b/crates/velesdb-cli/src/repl_collection_cmds_tests.rs
@@ -1,0 +1,403 @@
+//! Unit tests for `repl_collection_cmds` — command dispatch, error/usage paths,
+//! and the 3.0.0 display helpers (`index_health_label`, `print_metadata_detail`,
+//! `print_node_page_body`, `node_entries_to_rows`, `vector_preview`).
+//!
+//! These exercise the private helpers directly (sibling-module access) plus the
+//! `pub(crate)` `cmd_*` entry points by asserting on the returned
+//! [`CommandResult`], which the binary-spawning e2e suite cannot reach for the
+//! usage / not-found / empty-health branches.
+
+use tempfile::TempDir;
+use velesdb_core::{Database, DistanceMetric, GraphEdge, GraphSchema, Point};
+
+use super::{
+    cmd_browse, cmd_count, cmd_describe, cmd_diagnostics, cmd_nodes, cmd_sample, cmd_schema,
+    cmd_scroll, cmd_stats, index_health_label, node_entries_to_rows, print_metadata_detail,
+    print_node_page_body, vector_preview,
+};
+use crate::repl_commands::CommandResult;
+
+// =============================================================================
+// Fixtures
+// =============================================================================
+
+fn empty_db() -> (Database, TempDir) {
+    let dir = TempDir::new().unwrap();
+    let db = Database::open(dir.path()).unwrap();
+    (db, dir)
+}
+
+fn vector_db(name: &str, dim: usize, points: u64) -> (Database, TempDir) {
+    let (db, dir) = empty_db();
+    db.create_vector_collection(name, dim, DistanceMetric::Cosine)
+        .unwrap();
+    if points > 0 {
+        let col = db.get_vector_collection(name).unwrap();
+        for i in 1..=points {
+            #[allow(clippy::cast_precision_loss)]
+            let v: Vec<f32> = (0..dim).map(|j| (i as f32 + j as f32) / 10.0).collect();
+            col.upsert(vec![Point {
+                id: i,
+                vector: v,
+                payload: Some(serde_json::json!({"label": format!("v{i}")})),
+                sparse_vectors: None,
+            }])
+            .unwrap();
+        }
+    }
+    (db, dir)
+}
+
+fn graph_db(name: &str) -> (Database, TempDir) {
+    let (db, dir) = empty_db();
+    db.create_graph_collection(name, GraphSchema::schemaless())
+        .unwrap();
+    let col = db.get_graph_collection(name).unwrap();
+    col.add_edge(GraphEdge::new(1, 10, 11, "LINKS").unwrap())
+        .unwrap();
+    col.upsert_node_payload(10, &serde_json::json!({"name": "n10"}))
+        .unwrap();
+    col.flush().unwrap();
+    (db, dir)
+}
+
+fn metadata_db(name: &str, items: u64) -> (Database, TempDir) {
+    let (db, dir) = empty_db();
+    db.create_metadata_collection(name).unwrap();
+    if items > 0 {
+        let col = db.get_metadata_collection(name).unwrap();
+        let pts: Vec<Point> = (1..=items)
+            .map(|i| Point::metadata_only(i, serde_json::json!({"title": format!("t{i}")})))
+            .collect();
+        col.upsert(pts).unwrap();
+    }
+    (db, dir)
+}
+
+fn is_continue(r: &CommandResult) -> bool {
+    matches!(r, CommandResult::Continue)
+}
+
+fn error_msg(r: &CommandResult) -> Option<&str> {
+    match r {
+        CommandResult::Error(m) => Some(m.as_str()),
+        _ => None,
+    }
+}
+
+// =============================================================================
+// index_health_label — all variants (L378-382)
+// =============================================================================
+
+#[test]
+fn test_index_health_label_healthy() {
+    use velesdb_core::collection::IndexHealth;
+    let (label, detail) = index_health_label(&IndexHealth::Healthy);
+    assert_eq!(label, "healthy");
+    assert!(detail.is_none());
+}
+
+#[test]
+fn test_index_health_label_empty() {
+    use velesdb_core::collection::IndexHealth;
+    let (label, detail) = index_health_label(&IndexHealth::Empty);
+    assert_eq!(label, "empty");
+    assert!(detail.is_none());
+}
+
+#[test]
+fn test_index_health_label_needs_rebuild_carries_reason() {
+    use velesdb_core::collection::IndexHealth;
+    let (label, detail) = index_health_label(&IndexHealth::NeedsRebuild("corrupt".into()));
+    assert_eq!(label, "needs_rebuild");
+    assert_eq!(detail.as_deref(), Some("corrupt"));
+}
+
+// =============================================================================
+// print_metadata_detail (L456) — must not panic, shared by .describe / .stats
+// =============================================================================
+
+#[test]
+fn test_print_metadata_detail_runs() {
+    print_metadata_detail("Collection Details", "Metadata", "catalog", 42);
+    print_metadata_detail("Collection Statistics", "Metadata", "empty", 0);
+}
+
+// =============================================================================
+// print_node_page_body — empty branch (L476) and non-empty branch
+// =============================================================================
+
+#[test]
+fn test_print_node_page_body_empty_branch() {
+    let empty: Vec<(u64, Option<serde_json::Value>)> = Vec::new();
+    // Empty entries hit the "No nodes on this page." branch.
+    print_node_page_body(&empty, "kg", ".nodes", 99);
+}
+
+#[test]
+fn test_print_node_page_body_non_empty_branch() {
+    let entries = vec![
+        (10u64, Some(serde_json::json!({"name": "a"}))),
+        (20u64, None),
+    ];
+    print_node_page_body(&entries, "kg", ".browse", 1);
+}
+
+// =============================================================================
+// node_entries_to_rows (L444)
+// =============================================================================
+
+#[test]
+fn test_node_entries_to_rows_maps_id_and_payload() {
+    let entries = vec![(7u64, Some(serde_json::json!({"k": "v"}))), (8u64, None)];
+    let rows = node_entries_to_rows(&entries);
+    assert_eq!(rows.len(), 2);
+    // The id column is always populated by point_payload_to_row.
+    assert!(rows[0].contains_key("id"));
+    assert!(rows[1].contains_key("id"));
+}
+
+#[test]
+fn test_node_entries_to_rows_empty() {
+    let rows = node_entries_to_rows(&[]);
+    assert!(rows.is_empty());
+}
+
+// =============================================================================
+// vector_preview (L488) — truncated vs. full
+// =============================================================================
+
+#[test]
+fn test_vector_preview_truncates_long_vector() {
+    let v: Vec<f32> = (0..10).map(|i| i as f32).collect();
+    let preview = vector_preview(&v);
+    assert!(preview.contains("... (10 dims)"), "got: {preview}");
+}
+
+#[test]
+fn test_vector_preview_short_vector_no_ellipsis() {
+    let preview = vector_preview(&[1.0, 2.0]);
+    assert!(!preview.contains("..."), "got: {preview}");
+    assert!(!preview.contains("dims"), "got: {preview}");
+}
+
+// =============================================================================
+// cmd_diagnostics — usage (L342-344), not-found (L349), empty-health (L379)
+// =============================================================================
+
+#[test]
+fn test_cmd_diagnostics_missing_arg_is_usage_continue() {
+    let (db, _d) = empty_db();
+    // Only the command word, no collection name -> prints Usage, returns Continue.
+    assert!(is_continue(&cmd_diagnostics(&db, &[".diagnostics"])));
+}
+
+#[test]
+fn test_cmd_diagnostics_unknown_collection_errors() {
+    let (db, _d) = empty_db();
+    let res = cmd_diagnostics(&db, &[".diagnostics", "ghost"]);
+    assert!(error_msg(&res).unwrap().contains("ghost"));
+}
+
+#[test]
+fn test_cmd_diagnostics_empty_collection_continue() {
+    // 0 points -> diagnostics reports IndexHealth::Empty, exercising the "empty"
+    // label arm of index_health_label inside cmd_diagnostics.
+    let (db, _d) = vector_db("vecs", 4, 0);
+    assert!(is_continue(&cmd_diagnostics(
+        &db,
+        &[".diagnostics", "vecs"]
+    )));
+}
+
+#[test]
+fn test_cmd_diagnostics_populated_collection_continue() {
+    let (db, _d) = vector_db("vecs", 4, 3);
+    assert!(is_continue(&cmd_diagnostics(
+        &db,
+        &[".diagnostics", "vecs"]
+    )));
+}
+
+// =============================================================================
+// cmd_describe — Metadata branch (L103 -> print_metadata_detail) + others
+// =============================================================================
+
+#[test]
+fn test_cmd_describe_missing_arg_usage() {
+    let (db, _d) = empty_db();
+    assert!(is_continue(&cmd_describe(&db, &[".describe"])));
+}
+
+#[test]
+fn test_cmd_describe_metadata_uses_shared_detail() {
+    let (db, _d) = metadata_db("catalog", 4);
+    assert!(is_continue(&cmd_describe(&db, &[".describe", "catalog"])));
+}
+
+#[test]
+fn test_cmd_describe_vector_and_graph_continue() {
+    let (db, _d) = vector_db("vecs", 4, 2);
+    assert!(is_continue(&cmd_describe(&db, &[".describe", "vecs"])));
+    let (gdb, _g) = graph_db("kg");
+    assert!(is_continue(&cmd_describe(&gdb, &[".describe", "kg"])));
+}
+
+#[test]
+fn test_cmd_describe_unknown_errors() {
+    let (db, _d) = empty_db();
+    assert!(error_msg(&cmd_describe(&db, &[".describe", "nope"]))
+        .unwrap()
+        .contains("nope"));
+}
+
+// =============================================================================
+// cmd_stats — Metadata branch (L332 -> print_metadata_detail) + usage
+// =============================================================================
+
+#[test]
+fn test_cmd_stats_missing_arg_usage() {
+    let (db, _d) = empty_db();
+    assert!(is_continue(&cmd_stats(&db, &[".stats"])));
+}
+
+#[test]
+fn test_cmd_stats_metadata_branch() {
+    let (db, _d) = metadata_db("catalog", 3);
+    assert!(is_continue(&cmd_stats(&db, &[".stats", "catalog"])));
+}
+
+#[test]
+fn test_cmd_stats_unknown_errors() {
+    let (db, _d) = empty_db();
+    assert!(error_msg(&cmd_stats(&db, &[".stats", "nope"])).is_some());
+}
+
+// =============================================================================
+// cmd_schema / cmd_count / cmd_sample — usage + not-found branches
+// =============================================================================
+
+#[test]
+fn test_cmd_schema_usage_metadata_and_unknown() {
+    let (db, _d) = metadata_db("meta", 1);
+    assert!(is_continue(&cmd_schema(&db, &[".schema"])));
+    assert!(is_continue(&cmd_schema(&db, &[".schema", "meta"])));
+    assert!(error_msg(&cmd_schema(&db, &[".schema", "ghost"])).is_some());
+}
+
+#[test]
+fn test_cmd_count_usage_and_branches() {
+    let (db, _d) = metadata_db("meta", 2);
+    assert!(is_continue(&cmd_count(&db, &[".count"])));
+    assert!(is_continue(&cmd_count(&db, &[".count", "meta"])));
+    assert!(error_msg(&cmd_count(&db, &[".count", "ghost"])).is_some());
+}
+
+#[test]
+fn test_cmd_sample_usage_graph_and_empty_rows() {
+    let (db, _d) = graph_db("kg");
+    assert!(is_continue(&cmd_sample(&db, &[".sample"])));
+    // Graph branch produces node rows.
+    assert!(is_continue(&cmd_sample(&db, &[".sample", "kg", "5"])));
+    // Empty metadata collection -> print_sample_rows "No records found." branch.
+    let (mdb, _m) = metadata_db("meta", 0);
+    assert!(is_continue(&cmd_sample(&mdb, &[".sample", "meta"])));
+    assert!(error_msg(&cmd_sample(&db, &[".sample", "ghost"])).is_some());
+}
+
+// =============================================================================
+// cmd_browse — usage, graph out-of-range page (empty body), not-found
+// =============================================================================
+
+#[test]
+fn test_cmd_browse_usage_and_graph_empty_page() {
+    let (db, _d) = graph_db("kg");
+    assert!(is_continue(&cmd_browse(&db, &[".browse"])));
+    // Page far beyond the data -> graph node page is empty -> "No nodes on this page."
+    assert!(is_continue(&cmd_browse(&db, &[".browse", "kg", "99"])));
+}
+
+#[test]
+fn test_cmd_browse_metadata_empty_records() {
+    // 0 items -> browse_id_based renders "No records on this page."
+    let (db, _d) = metadata_db("meta", 0);
+    assert!(is_continue(&cmd_browse(&db, &[".browse", "meta", "1"])));
+}
+
+#[test]
+fn test_cmd_browse_unknown_errors() {
+    let (db, _d) = empty_db();
+    assert!(error_msg(&cmd_browse(&db, &[".browse", "ghost"])).is_some());
+}
+
+// =============================================================================
+// cmd_nodes — usage, non-graph error, out-of-range empty page (L476 via .nodes)
+// =============================================================================
+
+#[test]
+fn test_cmd_nodes_usage_and_non_graph_error() {
+    let (db, _d) = vector_db("vecs", 4, 1);
+    assert!(is_continue(&cmd_nodes(&db, &[".nodes"])));
+    // Vector collection is not a graph -> error.
+    assert!(error_msg(&cmd_nodes(&db, &[".nodes", "vecs"])).is_some());
+}
+
+#[test]
+fn test_cmd_nodes_graph_out_of_range_empty_body() {
+    let (db, _d) = graph_db("kg");
+    // Valid graph but page beyond data -> empty-node-page body branch.
+    assert!(is_continue(&cmd_nodes(&db, &[".nodes", "kg", "99"])));
+}
+
+// =============================================================================
+// cmd_scroll — usage, invalid batch_size (0 & non-numeric), invalid cursor,
+// not-found, and a successful scroll.
+// =============================================================================
+
+#[test]
+fn test_cmd_scroll_usage_branch() {
+    let (db, _d) = empty_db();
+    assert!(is_continue(&cmd_scroll(&db, &[".scroll"])));
+}
+
+#[test]
+fn test_cmd_scroll_zero_batch_size_errors() {
+    let (db, _d) = vector_db("vecs", 4, 1);
+    let res = cmd_scroll(&db, &[".scroll", "vecs", "0"]);
+    assert!(error_msg(&res).unwrap().contains("batch_size"));
+}
+
+#[test]
+fn test_cmd_scroll_non_numeric_batch_size_errors() {
+    let (db, _d) = vector_db("vecs", 4, 1);
+    let res = cmd_scroll(&db, &[".scroll", "vecs", "abc"]);
+    assert!(error_msg(&res).unwrap().contains("batch_size"));
+}
+
+#[test]
+fn test_cmd_scroll_invalid_cursor_errors() {
+    let (db, _d) = vector_db("vecs", 4, 1);
+    let res = cmd_scroll(&db, &[".scroll", "vecs", "10", "notanid"]);
+    assert!(error_msg(&res).unwrap().contains("cursor"));
+}
+
+#[test]
+fn test_cmd_scroll_unknown_collection_errors() {
+    let (db, _d) = empty_db();
+    assert!(error_msg(&cmd_scroll(&db, &[".scroll", "ghost"]))
+        .unwrap()
+        .contains("ghost"));
+}
+
+#[test]
+fn test_cmd_scroll_success_continue() {
+    let (db, _d) = vector_db("vecs", 4, 3);
+    assert!(is_continue(&cmd_scroll(&db, &[".scroll", "vecs", "2"])));
+}
+
+#[test]
+fn test_cmd_scroll_empty_collection_no_points() {
+    // 0 points exercises print_scroll_results "No points found." branch.
+    let (db, _d) = vector_db("vecs", 4, 0);
+    assert!(is_continue(&cmd_scroll(&db, &[".scroll", "vecs"])));
+}

--- a/crates/velesdb-core/src/collection/graph_collection.rs
+++ b/crates/velesdb-core/src/collection/graph_collection.rs
@@ -548,4 +548,151 @@ mod tests {
         );
         assert_eq!(results[0].node_id, 20, "target should be Bob (id=20)");
     }
+
+    #[test]
+    fn test_has_edge_and_remove_edge() {
+        let (_dir, col) = make_test_collection(None);
+        assert!(!col.has_edge(7), "unknown edge id is absent");
+
+        col.add_edge(GraphEdge::new(7, 10, 20, "KNOWS").unwrap())
+            .unwrap();
+        assert!(col.has_edge(7), "edge present after add");
+
+        assert!(col.remove_edge(7), "removing an existing edge returns true");
+        assert!(!col.has_edge(7), "edge gone after remove");
+        assert!(!col.remove_edge(7), "removing a missing edge returns false");
+    }
+
+    #[test]
+    fn test_upsert_node_without_vector_stores_payload_only() {
+        // No embeddings: the `None`-vector branch delegates to upsert_node_payload.
+        let (_dir, col) = make_test_collection(None);
+        col.upsert_node(42, &serde_json::json!({"name": "Carol"}), None)
+            .unwrap();
+        assert_eq!(
+            col.get_node_payload(42).unwrap(),
+            Some(serde_json::json!({"name": "Carol"}))
+        );
+        assert!(col.all_node_ids().contains(&42));
+        assert!(!col.has_embeddings(), "no embeddings without a dimension");
+    }
+
+    #[test]
+    fn test_get_edges_filtered_by_label() {
+        let (_dir, col) = make_test_collection(None);
+        col.add_edge(GraphEdge::new(1, 10, 20, "KNOWS").unwrap())
+            .unwrap();
+        col.add_edge(GraphEdge::new(2, 20, 30, "LIKES").unwrap())
+            .unwrap();
+        col.add_edge(GraphEdge::new(3, 30, 40, "KNOWS").unwrap())
+            .unwrap();
+
+        let knows = col.get_edges(Some("KNOWS"));
+        assert_eq!(knows.len(), 2, "two KNOWS edges");
+        assert!(knows.iter().all(|e| e.label() == "KNOWS"));
+
+        let all = col.get_edges(None);
+        assert_eq!(all.len(), 3, "three edges total");
+    }
+
+    #[test]
+    fn test_node_degree_and_directional_edges() {
+        let (_dir, col) = make_test_collection(None);
+        col.add_edge(GraphEdge::new(1, 10, 20, "NEXT").unwrap())
+            .unwrap();
+        col.add_edge(GraphEdge::new(2, 30, 20, "NEXT").unwrap())
+            .unwrap();
+        col.add_edge(GraphEdge::new(3, 20, 40, "NEXT").unwrap())
+            .unwrap();
+
+        // Node 20: 2 incoming (from 10, 30), 1 outgoing (to 40).
+        assert_eq!(col.node_degree(20), (2, 1));
+        assert_eq!(col.get_incoming(20).len(), 2);
+        let outgoing = col.get_outgoing(20);
+        assert_eq!(outgoing.len(), 1);
+        assert_eq!(outgoing[0].target(), 40);
+    }
+
+    #[test]
+    fn test_delete_removes_node_payload() {
+        let (_dir, col) = make_test_collection(None);
+        col.upsert_node_payload(10, &serde_json::json!({"k": 1}))
+            .unwrap();
+        col.upsert_node_payload(20, &serde_json::json!({"k": 2}))
+            .unwrap();
+        assert_eq!(col.all_node_ids().len(), 2);
+
+        col.delete(&[10]).unwrap();
+        assert!(col.get(&[10])[0].is_none(), "deleted node is gone");
+        assert!(
+            !col.all_node_ids().contains(&10),
+            "deleted node leaves the id set"
+        );
+        assert!(col.get_node_payload(20).unwrap().is_some(), "node 20 stays");
+    }
+
+    #[test]
+    fn test_scroll_batch_paginates_embedded_nodes() {
+        // scroll_batch iterates the point (vector) store, so use embeddings.
+        let (_dir, col) = make_test_collection(Some(2));
+        for id in [1u64, 2, 3] {
+            col.upsert_node(id, &serde_json::json!({"id": id}), Some(vec![1.0, 0.0]))
+                .unwrap();
+        }
+        assert!(!col.is_empty());
+        assert_eq!(col.len(), 3);
+
+        let first = col.scroll_batch(None, 2, None).unwrap();
+        assert_eq!(first.points.len(), 2, "first page has 2 of 3 nodes");
+        let cursor = first.next_cursor.expect("non-empty page yields a cursor");
+        let second = col.scroll_batch(Some(cursor), 2, None).unwrap();
+        assert_eq!(second.points.len(), 1, "second page has the last node");
+        // A page past the end returns no points (and therefore no cursor).
+        let tail_cursor = second.next_cursor.expect("page yields a cursor");
+        let third = col.scroll_batch(Some(tail_cursor), 2, None).unwrap();
+        assert!(third.points.is_empty(), "no points past the end");
+        assert!(third.next_cursor.is_none(), "empty page yields no cursor");
+
+        // batch_size 0 is rejected.
+        assert!(col.scroll_batch(None, 0, None).is_err());
+    }
+
+    #[test]
+    fn test_flush_and_flush_full_succeed() {
+        let (_dir, col) = make_test_collection(None);
+        col.upsert_node_payload(1, &serde_json::json!({"k": 1}))
+            .unwrap();
+        col.add_edge(GraphEdge::new(1, 1, 2, "NEXT").unwrap())
+            .unwrap();
+        col.flush().expect("fast-path flush succeeds");
+        col.flush_full().expect("full durability flush succeeds");
+    }
+
+    #[test]
+    fn test_reopen_recovers_edges_and_payloads() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().to_path_buf();
+        {
+            let col = GraphCollection::create(
+                path.clone(),
+                "kg",
+                None,
+                DistanceMetric::Cosine,
+                GraphSchema::schemaless(),
+            )
+            .unwrap();
+            col.upsert_node_payload(1, &serde_json::json!({"name": "A"}))
+                .unwrap();
+            col.add_edge(GraphEdge::new(5, 1, 2, "NEXT").unwrap())
+                .unwrap();
+            col.flush_full().unwrap();
+        }
+        let reopened = GraphCollection::open(path).unwrap();
+        assert_eq!(reopened.name(), "kg");
+        assert!(reopened.has_edge(5), "edge survives reopen");
+        assert_eq!(
+            reopened.get_node_payload(1).unwrap(),
+            Some(serde_json::json!({"name": "A"}))
+        );
+    }
 }

--- a/crates/velesdb-core/src/collection/payload_size.rs
+++ b/crates/velesdb-core/src/collection/payload_size.rs
@@ -82,4 +82,18 @@ mod tests {
         assert!(serde_json::to_writer(&mut over, &value).is_err());
         assert!(over.exceeded());
     }
+
+    /// Writing exactly `cap` bytes is allowed; the cap trips strictly above it.
+    /// Exercises the boundary of the `written > cap` test, then `flush`.
+    #[test]
+    fn boundary_at_cap_and_flush_are_noops() {
+        let mut counter = BoundedCounter::new(5);
+        assert_eq!(counter.write(b"hello").expect("at cap"), 5);
+        assert!(!counter.exceeded(), "exactly cap bytes does not trip");
+        // One more byte tips it over.
+        assert!(counter.write(b"!").is_err());
+        assert!(counter.exceeded());
+        // flush is a no-op that always succeeds.
+        assert!(counter.flush().is_ok());
+    }
 }

--- a/crates/velesdb-core/src/wire/vrb1.rs
+++ b/crates/velesdb-core/src/wire/vrb1.rs
@@ -282,4 +282,47 @@ mod tests {
             other => panic!("expected LengthMismatch, got {other:?}"),
         }
     }
+
+    /// A `count`/`dim` pair whose declared body length overflows `usize` is
+    /// rejected with `Overflow`, not a panic, before any allocation. The body is
+    /// only the 16-byte header; `count`/`dim` are crafted directly so the
+    /// `count * dim * 4` product blows past `usize::MAX`.
+    #[test]
+    fn overflow_count_dim_rejected() {
+        let mut body = Vec::with_capacity(HEADER_LEN);
+        body.extend_from_slice(MAGIC);
+        body.extend_from_slice(&u32::MAX.to_le_bytes()); // count
+        body.extend_from_slice(&u32::MAX.to_le_bytes()); // dim
+        body.push(ID_WIDTH);
+        body.extend_from_slice(&[0u8; 3]);
+        assert_eq!(decode(&body), Err(VrbError::Overflow));
+    }
+
+    /// Every `VrbError` variant renders a distinct, non-empty `Display` string,
+    /// and the type is usable as a `std::error::Error`.
+    #[test]
+    fn error_display_and_trait_cover_all_variants() {
+        let cases: [VrbError; 6] = [
+            VrbError::TooShort { got: 3 },
+            VrbError::BadMagic,
+            VrbError::BadIdWidth(4),
+            VrbError::ReservedNotZero,
+            VrbError::Overflow,
+            VrbError::LengthMismatch {
+                got: 10,
+                expected: 16,
+            },
+        ];
+        let rendered: Vec<String> = cases.iter().map(ToString::to_string).collect();
+        assert!(rendered.iter().all(|s| !s.is_empty()));
+        // Distinct messages per variant.
+        let unique: std::collections::HashSet<&String> = rendered.iter().collect();
+        assert_eq!(unique.len(), cases.len());
+        // A couple of pinned substrings so a future message change is visible.
+        assert!(rendered[0].contains("too short"));
+        assert!(rendered[2].contains("id_width 4"));
+        // Usable through the std error trait object.
+        let err: &dyn std::error::Error = &cases[1];
+        assert_eq!(err.to_string(), "bad magic: expected b\"VRB1\"");
+    }
 }

--- a/crates/velesdb-core/tests/coverage_ordered_index_scan_branches.rs
+++ b/crates/velesdb-core/tests/coverage_ordered_index_scan_branches.rs
@@ -1,0 +1,184 @@
+#![cfg(all(test, feature = "persistence"))]
+//! Coverage: ordered-index `ORDER BY [WHERE] LIMIT k` decline branches.
+//!
+//! The equivalence suite (`ordered_index_order_by_equivalence`,
+//! `ordered_index_multikey`) pins the *common* covered/uncovered cases. These
+//! tests target the remaining decline branches of
+//! `collection/search/query/ordered_index_scan.rs`:
+//!
+//! * the filtered route declining when the WHERE is **too selective** for the
+//!   ordered-index walk to beat the exhaustive bitmap prefilter, *without*
+//!   observing the advisor (the covering index is present, so it is not a gap);
+//! * the filtered page short-circuiting on `LIMIT 0`;
+//! * the route declining a WHERE that yields no usable metadata filter
+//!   (`CONTAINS_TEXT` on a sort field is a metadata predicate; a `similarity()`
+//!   WHERE is a non-metadata fetch).
+//!
+//! Every case asserts the indexed path returns the **same** rows as the
+//! exhaustive path, so a decline is proven correct, and where possible uses the
+//! ORDER BY index advisor as an observable signal of which branch fired.
+
+use serde_json::json;
+use std::collections::HashMap;
+use tempfile::TempDir;
+use velesdb_core::{DistanceMetric, Point, StorageMode, VectorCollection};
+
+fn mk(dir: &TempDir) -> VectorCollection {
+    VectorCollection::create(
+        dir.path().join("docs"),
+        "docs",
+        2,
+        DistanceMetric::Cosine,
+        StorageMode::Full,
+    )
+    .expect("create collection")
+}
+
+fn ids(rs: &[velesdb_core::point::SearchResult]) -> Vec<u64> {
+    rs.iter().map(|r| r.point.id).collect()
+}
+
+/// Rows with a unique `year` per id (high cardinality) so an equality filter on
+/// `year` is highly selective, plus a `tag` text field for `CONTAINS_TEXT`.
+fn distinct_year_rows() -> Vec<Point> {
+    (0..20u32)
+        .map(|i| {
+            Point::new(
+                u64::from(i) + 1,
+                vec![1.0, 0.0],
+                Some(json!({ "year": 2000 + i64::from(i), "tag": format!("doc-{i}") })),
+            )
+        })
+        .collect()
+}
+
+/// Runs `sql` on a fresh no-index collection (exhaustive) and on a fresh
+/// indexed collection (`create_index(field)`), returning `(exhaustive, indexed)`
+/// id sequences plus the indexed collection so the caller can inspect advice.
+fn run_both(
+    points: &[Point],
+    field: &str,
+    sql: &str,
+) -> (Vec<u64>, Vec<u64>, VectorCollection, TempDir) {
+    let da = TempDir::new().expect("dir");
+    let a = mk(&da);
+    a.upsert(points.to_vec()).expect("upsert exhaustive");
+    let exhaustive = ids(&a
+        .execute_query_str(sql, &HashMap::new())
+        .expect("exhaustive query"));
+
+    let db = TempDir::new().expect("dir");
+    let b = mk(&db);
+    b.upsert(points.to_vec()).expect("upsert indexed");
+    b.create_index(field).expect("create_index");
+    assert!(b.has_secondary_index(field), "index must exist");
+    let indexed = ids(&b
+        .execute_query_str(sql, &HashMap::new())
+        .expect("indexed query"));
+
+    (exhaustive, indexed, b, db)
+}
+
+/// A highly-selective equality WHERE on a covered field declines the filtered
+/// route via the selectivity gate (`MIN_FILTERED_ROUTE_SELECTIVITY`). The route
+/// must NOT observe the advisor (the covering index is present, so a covering
+/// index is not the missing piece) yet still return the exhaustive result.
+#[test]
+fn highly_selective_equality_declines_without_observing() {
+    let sql = "SELECT * FROM docs WHERE year = 2005 ORDER BY year DESC LIMIT 5";
+    let (exhaustive, indexed, indexed_col, _d) = run_both(&distinct_year_rows(), "year", sql);
+
+    assert_eq!(exhaustive, indexed, "selectivity decline must stay correct");
+    // year = 2005 → id 6 only.
+    assert_eq!(indexed, vec![6]);
+    // The covering index IS present; the route declined purely on selectivity,
+    // so it must not record the field as wanting an index.
+    assert!(
+        indexed_col.order_by_index_advice(1).is_empty(),
+        "selectivity decline must not observe the advisor (index already covers)"
+    );
+}
+
+/// A `CONTAINS_TEXT` predicate is a metadata filter (selectivity heuristic
+/// 0.05 < 0.1), so the filtered route also declines on selectivity. It must
+/// stay correct and, again, not observe the advisor.
+#[test]
+fn contains_text_filter_declines_without_observing() {
+    let sql = "SELECT * FROM docs WHERE tag CONTAINS_TEXT 'doc-3' ORDER BY year ASC LIMIT 5";
+    let (exhaustive, indexed, indexed_col, _d) = run_both(&distinct_year_rows(), "year", sql);
+
+    assert_eq!(
+        exhaustive, indexed,
+        "CONTAINS_TEXT decline must stay correct"
+    );
+    // tag = "doc-3" (substring "doc-3") → id 4 only (year 2003).
+    assert_eq!(indexed, vec![4]);
+    assert!(
+        indexed_col.order_by_index_advice(1).is_empty(),
+        "selectivity decline must not observe the advisor"
+    );
+}
+
+/// `LIMIT 0` under a broad (route-eligible) WHERE drives the filtered page's
+/// `limit == 0` short-circuit. Both paths must return zero rows.
+#[test]
+fn filtered_route_limit_zero_returns_empty() {
+    let sql = "SELECT * FROM docs WHERE year >= 2000 ORDER BY year DESC LIMIT 0";
+    let (exhaustive, indexed, _col, _d) = run_both(&distinct_year_rows(), "year", sql);
+
+    assert!(exhaustive.is_empty(), "exhaustive LIMIT 0 is empty");
+    assert_eq!(exhaustive, indexed, "LIMIT 0 must match on both paths");
+}
+
+/// A broad WHERE (`>= 2000`, selectivity 1.0) with LIMIT > 0 *does* take the
+/// filtered route through `collect_filtered_page`; the indexed result must equal
+/// the exhaustive filter→sort→limit. Sibling to the LIMIT 0 case so the page
+/// builder is exercised both empty and non-empty.
+#[test]
+fn filtered_route_broad_where_matches_exhaustive() {
+    let sql = "SELECT * FROM docs WHERE year >= 2000 ORDER BY year DESC LIMIT 3";
+    let (exhaustive, indexed, _col, _d) = run_both(&distinct_year_rows(), "year", sql);
+
+    assert_eq!(
+        exhaustive, indexed,
+        "broad-filter route must match exhaustive"
+    );
+    // DESC: 2019→20, 2018→19, 2017→18.
+    assert_eq!(indexed, vec![20, 19, 18]);
+}
+
+/// A vector-similarity WHERE is a non-metadata fetch, so the ordered-index route
+/// declines outright (it never classifies as a metadata filter). The ORDER BY
+/// still applies on the exhaustive path; both paths must agree on the rows.
+#[test]
+fn similarity_where_is_not_routed_and_matches_exhaustive() {
+    let sql = "SELECT * FROM docs WHERE similarity([1.0, 0.0]) > 0.0 ORDER BY year DESC LIMIT 3";
+    let da = TempDir::new().expect("dir");
+    let a = mk(&da);
+    a.upsert(distinct_year_rows()).expect("upsert exhaustive");
+    let exhaustive = a.execute_query_str(sql, &HashMap::new());
+
+    let db = TempDir::new().expect("dir");
+    let b = mk(&db);
+    b.upsert(distinct_year_rows()).expect("upsert indexed");
+    b.create_index("year").expect("create_index");
+    let indexed = b.execute_query_str(sql, &HashMap::new());
+
+    match (exhaustive, indexed) {
+        (Ok(ex), Ok(idx)) => {
+            // The non-metadata fetch declines the ordered-index route on the
+            // indexed collection; both collections run the same (ranked) path,
+            // so the returned id sets must be identical.
+            let mut ex_ids = ids(&ex);
+            let mut idx_ids = ids(&idx);
+            ex_ids.sort_unstable();
+            idx_ids.sort_unstable();
+            assert_eq!(ex_ids, idx_ids, "similarity WHERE must match across paths");
+        }
+        (Err(_), Err(_)) => {
+            // Both paths reject the shape identically — also acceptable: the
+            // point is that the index does not change behaviour.
+        }
+        (ex, idx) => panic!("index changed similarity-WHERE behaviour: {ex:?} vs {idx:?}"),
+    }
+}

--- a/crates/velesdb-migrate/src/pipeline_graph.rs
+++ b/crates/velesdb-migrate/src/pipeline_graph.rs
@@ -239,6 +239,13 @@ mod tests {
         }
     }
 
+    fn make_weighted_relation(from: &str, label: &str, weight_col: &str) -> RelationConfig {
+        RelationConfig {
+            weight_column: Some(weight_col.to_string()),
+            ..make_relation(from, label)
+        }
+    }
+
     #[test]
     fn test_build_edge_string_fk() {
         let point = make_point("doc-1", serde_json::json!({"author_id": "auth-42"}));
@@ -304,5 +311,74 @@ mod tests {
             e2.id(),
             "Different edge labels must produce different IDs"
         );
+    }
+
+    #[test]
+    fn test_build_edge_attaches_numeric_weight_property() {
+        // GIVEN: a relation with a weight_column whose value is numeric
+        let point = make_point(
+            "doc-1",
+            serde_json::json!({"author_id": "auth-42", "score": 0.75}),
+        );
+        let relation = make_weighted_relation("author_id", "AUTHORED_BY", "score");
+
+        // WHEN: build_edge runs the weighted branch of attach_weight
+        let edge = build_edge(&point, &relation).expect("test: edge should be Some");
+
+        // THEN: the weight is attached as an edge property
+        let weight = edge
+            .property("weight")
+            .expect("test: weight property should be present");
+        assert_eq!(weight, &serde_json::json!(0.75));
+    }
+
+    #[test]
+    fn test_build_edge_attaches_integer_weight_as_f64() {
+        // GIVEN: a relation whose weight column holds a JSON integer
+        let point = make_point("doc-9", serde_json::json!({"ref_id": "tgt-9", "rank": 3}));
+        let relation = make_weighted_relation("ref_id", "LINKS_TO", "rank");
+
+        // WHEN: build_edge runs (integer is coerced via as_f64)
+        let edge = build_edge(&point, &relation).expect("test: edge should be Some");
+
+        // THEN: the integer weight is stored as a float
+        let weight = edge
+            .property("weight")
+            .expect("test: weight property should be present");
+        assert_eq!(
+            weight.as_f64().expect("test: weight should be numeric"),
+            3.0
+        );
+    }
+
+    #[test]
+    fn test_build_edge_weight_column_missing_value_skips_property() {
+        // GIVEN: a weight_column configured but absent from the point payload
+        let point = make_point("doc-2", serde_json::json!({"author_id": "auth-7"}));
+        let relation = make_weighted_relation("author_id", "AUTHORED_BY", "score");
+
+        // WHEN: build_edge runs the second early-return branch of attach_weight
+        let edge = build_edge(&point, &relation).expect("test: edge should be Some");
+
+        // THEN: no weight property is attached and properties stay empty
+        assert!(edge.property("weight").is_none());
+        assert!(edge.properties().is_empty());
+    }
+
+    #[test]
+    fn test_build_edge_weight_non_numeric_skips_property() {
+        // GIVEN: a weight_column present but holding a non-numeric (string) value
+        let point = make_point(
+            "doc-3",
+            serde_json::json!({"author_id": "auth-8", "score": "high"}),
+        );
+        let relation = make_weighted_relation("author_id", "AUTHORED_BY", "score");
+
+        // WHEN: build_edge runs (as_f64 returns None for a string)
+        let edge = build_edge(&point, &relation).expect("test: edge should be Some");
+
+        // THEN: the non-numeric value is ignored, no weight property attached
+        assert!(edge.property("weight").is_none());
+        assert!(edge.properties().is_empty());
     }
 }

--- a/crates/velesdb-mobile/tests/coverage_native.rs
+++ b/crates/velesdb-mobile/tests/coverage_native.rs
@@ -1,0 +1,203 @@
+//! Native coverage tests for under-exercised 3.0.0 mobile binding paths.
+//!
+//! These exercise the uniffi-exported methods directly as plain Rust:
+//! - `MobileGraphStore::dfs_traverse` (visited dedup, path tracking, depth/limit
+//!   cutoffs) — previously only `bfs_traverse` was tested.
+//! - `VelesCollection::stream_insert` not-configured error branch.
+//! - `parse_point` invalid-JSON error branch (via `upsert`).
+//! - `MobileCollectionDiagnostics` `From` `NeedsRebuild` arm.
+
+use tempfile::TempDir;
+use velesdb_mobile::{
+    DistanceMetric, MobileCollectionDiagnostics, MobileGraphEdge, MobileGraphNode,
+    MobileGraphStore, VelesDatabase, VelesPoint,
+};
+
+/// Builds a graph store with nodes 1..=`count` and the given KNOWS edges.
+///
+/// Each edge tuple is `(edge_id, source, target)`.
+fn graph_with(count: u64, edges: &[(u64, u64, u64)]) -> std::sync::Arc<MobileGraphStore> {
+    let store = MobileGraphStore::new();
+    for id in 1..=count {
+        store.add_node(MobileGraphNode {
+            id,
+            label: "Person".to_string(),
+            properties_json: None,
+            vector: None,
+        });
+    }
+    for &(id, source, target) in edges {
+        store
+            .add_edge(MobileGraphEdge {
+                id,
+                source,
+                target,
+                label: "KNOWS".to_string(),
+                properties_json: None,
+            })
+            .expect("edge insert should succeed");
+    }
+    store
+}
+
+#[test]
+fn dfs_traverse_chain_tracks_depth_and_path() {
+    // Chain 1 -> 2 -> 3 -> 4 via edges 100, 101, 102.
+    let store = graph_with(4, &[(100, 1, 2), (101, 2, 3), (102, 3, 4)]);
+
+    let results = store.dfs_traverse(1, 3, 100);
+
+    // Source itself is not emitted (depth 0 skipped); 2/3/4 each carry the
+    // accumulated edge-ID path mirroring core's TraversalResult::path.
+    assert_eq!(results.len(), 3);
+    assert!(results
+        .iter()
+        .any(|r| r.node_id == 2 && r.depth == 1 && r.path == vec![100]));
+    assert!(results
+        .iter()
+        .any(|r| r.node_id == 3 && r.depth == 2 && r.path == vec![100, 101]));
+    assert!(results
+        .iter()
+        .any(|r| r.node_id == 4 && r.depth == 3 && r.path == vec![100, 101, 102]));
+}
+
+#[test]
+fn dfs_traverse_respects_max_depth() {
+    // Chain 1 -> 2 -> 3 -> 4, but cap depth at 2: node 4 must not be reached.
+    let store = graph_with(4, &[(100, 1, 2), (101, 2, 3), (102, 3, 4)]);
+
+    let results = store.dfs_traverse(1, 2, 100);
+
+    assert_eq!(results.len(), 2);
+    assert!(results.iter().all(|r| r.depth <= 2));
+    assert!(results.iter().all(|r| r.node_id != 4));
+}
+
+#[test]
+fn dfs_traverse_respects_limit() {
+    // Star: 1 -> {2,3,4,5}. Limit to 2 results.
+    let store = graph_with(5, &[(100, 1, 2), (101, 1, 3), (102, 1, 4), (103, 1, 5)]);
+
+    let results = store.dfs_traverse(1, 1, 2);
+
+    assert_eq!(results.len(), 2);
+}
+
+#[test]
+fn dfs_traverse_dedups_visited_in_diamond() {
+    // Diamond: 1 -> 2, 1 -> 3, 2 -> 4, 3 -> 4. Node 4 has two paths in but the
+    // visited-set must emit it exactly once (exercises the `visited.contains`
+    // skip branch).
+    let store = graph_with(4, &[(100, 1, 2), (101, 1, 3), (102, 2, 4), (103, 3, 4)]);
+
+    let results = store.dfs_traverse(1, 3, 100);
+
+    let node4_hits = results.iter().filter(|r| r.node_id == 4).count();
+    assert_eq!(node4_hits, 1, "node 4 must be visited exactly once");
+    // 2, 3 and 4 reachable; source 1 excluded.
+    let mut reached: Vec<u64> = results.iter().map(|r| r.node_id).collect();
+    reached.sort_unstable();
+    assert_eq!(reached, vec![2, 3, 4]);
+}
+
+#[test]
+fn dfs_traverse_isolated_source_yields_nothing() {
+    // Source with no outgoing edges: the depth<max_depth neighbor block runs
+    // but finds nothing, so the result set is empty.
+    let store = graph_with(3, &[(100, 2, 3)]);
+
+    let results = store.dfs_traverse(1, 3, 100);
+
+    assert!(results.is_empty());
+}
+
+#[test]
+fn stream_insert_without_enable_returns_error() {
+    let tmp = TempDir::new().expect("tempdir");
+    let path = tmp.path().to_str().expect("path utf8").to_string();
+
+    let db = VelesDatabase::open(path).expect("open db");
+    db.create_collection("no_stream".to_string(), 4, DistanceMetric::Cosine)
+        .expect("create collection");
+    let col = db
+        .get_collection("no_stream".to_string())
+        .expect("get collection")
+        .expect("collection present");
+
+    // No enable_streaming(): the not-configured branch must surface as an error
+    // with the binding's "buffer full or not configured" message.
+    let result = col.stream_insert(vec![VelesPoint {
+        id: 1,
+        vector: vec![1.0, 0.0, 0.0, 0.0],
+        payload: None,
+    }]);
+
+    let err = result.expect_err("stream_insert without enable must fail");
+    let velesdb_mobile::VelesError::Database { message } = err else {
+        panic!("expected VelesError::Database, got {err:?}");
+    };
+    assert!(
+        message.contains("not configured") || message.contains("Stream insert failed"),
+        "unexpected error message: {message}"
+    );
+}
+
+#[test]
+fn upsert_with_invalid_json_payload_errors() {
+    let tmp = TempDir::new().expect("tempdir");
+    let path = tmp.path().to_str().expect("path utf8").to_string();
+
+    let db = VelesDatabase::open(path).expect("open db");
+    db.create_collection("bad_payload".to_string(), 4, DistanceMetric::Cosine)
+        .expect("create collection");
+    let col = db
+        .get_collection("bad_payload".to_string())
+        .expect("get collection")
+        .expect("collection present");
+
+    // Malformed JSON in the payload must hit parse_point's error branch.
+    let result = col.upsert(VelesPoint {
+        id: 1,
+        vector: vec![1.0, 0.0, 0.0, 0.0],
+        payload: Some("{not valid json".to_string()),
+    });
+
+    let err = result.expect_err("invalid JSON payload must fail");
+    let velesdb_mobile::VelesError::Database { message } = err else {
+        panic!("expected VelesError::Database, got {err:?}");
+    };
+    assert!(
+        message.contains("Invalid JSON payload"),
+        "unexpected error message: {message}"
+    );
+    // The bad upsert must not have committed a point.
+    assert_eq!(col.count(), 0);
+}
+
+#[test]
+fn diagnostics_maps_needs_rebuild_branch() {
+    // The core from_collection() path only ever yields Empty/Healthy, so the
+    // NeedsRebuild arm of the mobile From impl is exercised by constructing the
+    // core diagnostics directly with that health state.
+    let core = velesdb_core::collection::CollectionDiagnostics {
+        has_vectors: true,
+        search_ready: false,
+        dimension_configured: true,
+        point_count: 7,
+        index_health: velesdb_core::collection::IndexHealth::NeedsRebuild(
+            "schema changed".to_string(),
+        ),
+    };
+
+    let mobile: MobileCollectionDiagnostics = core.into();
+
+    assert_eq!(mobile.index_health, "needs_rebuild");
+    assert_eq!(
+        mobile.index_health_detail,
+        Some("schema changed".to_string())
+    );
+    assert!(mobile.has_vectors);
+    assert!(!mobile.search_ready);
+    assert!(mobile.dimension_configured);
+    assert_eq!(mobile.point_count, 7);
+}

--- a/crates/velesdb-server/tests/coverage_handlers.rs
+++ b/crates/velesdb-server/tests/coverage_handlers.rs
@@ -48,6 +48,19 @@ async fn read_json(response: axum::response::Response) -> Value {
     serde_json::from_slice(&body).expect("test: valid JSON")
 }
 
+/// Asserts a 400 response carrying the `build_edge` properties-shape error.
+async fn assert_properties_shape_error(resp: axum::response::Response) {
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    let json = read_json(resp).await;
+    assert!(
+        json["error"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("Properties must be an object or null"),
+        "expected the properties-shape error, got {json:?}"
+    );
+}
+
 /// Creates a 4-d cosine collection named `name` and seeds two points so
 /// fusion actually has candidates to rank.
 async fn seed_vector_collection(app: &axum::Router, name: &str) {
@@ -257,15 +270,7 @@ async fn test_add_edge_invalid_properties_returns_400() {
     )
     .await;
 
-    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
-    let json = read_json(resp).await;
-    assert!(
-        json["error"]
-            .as_str()
-            .unwrap_or_default()
-            .contains("Properties must be an object or null"),
-        "expected the properties-shape error, got {json:?}"
-    );
+    assert_properties_shape_error(resp).await;
 }
 
 #[tokio::test]
@@ -288,15 +293,7 @@ async fn test_add_edges_batch_invalid_properties_returns_400() {
     )
     .await;
 
-    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
-    let json = read_json(resp).await;
-    assert!(
-        json["error"]
-            .as_str()
-            .unwrap_or_default()
-            .contains("Properties must be an object or null"),
-        "expected the properties-shape error, got {json:?}"
-    );
+    assert_properties_shape_error(resp).await;
 }
 
 /// A `null` properties value is explicitly allowed and must succeed (201),

--- a/crates/velesdb-server/tests/coverage_handlers.rs
+++ b/crates/velesdb-server/tests/coverage_handlers.rs
@@ -1,0 +1,324 @@
+#![allow(clippy::doc_markdown)]
+//! Coverage-focused handler tests for VelesDB 3.0.0 new code paths.
+//!
+//! Targets previously-uncovered branches in:
+//! - `handlers/search/multi.rs` — fusion-strategy parsing (every arm),
+//!   per-vector dimension validation (the indexed 400), and the
+//!   rate-limited (429) preamble path shared by `/search/multi` and
+//!   `/search/multi/ids`.
+//! - `handlers/graph/handlers.rs` — `build_edge` rejection of non-object
+//!   /non-null `properties` (400) for both the single-edge and batch
+//!   endpoints.
+//!
+//! These mirror the existing integration-test harness in
+//! `tests/common/mod.rs` (oneshot against a router backed by a temp
+//! `Database`).
+
+mod common;
+
+use axum::{
+    body::Body,
+    http::{Request, StatusCode},
+};
+use common::{create_graph_collection, create_test_app, create_test_app_with_state};
+use serde_json::{json, Value};
+use tempfile::TempDir;
+use tower::ServiceExt;
+
+/// POST helper: builds a JSON request and runs it against a clone of the app.
+async fn post(app: &axum::Router, uri: &str, body: Value) -> axum::response::Response {
+    app.clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(uri)
+                .header("Content-Type", "application/json")
+                .body(Body::from(body.to_string()))
+                .expect("test: build request"),
+        )
+        .await
+        .expect("test: request failed")
+}
+
+/// Reads the response body as JSON.
+async fn read_json(response: axum::response::Response) -> Value {
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("test: read body");
+    serde_json::from_slice(&body).expect("test: valid JSON")
+}
+
+/// Creates a 4-d cosine collection named `name` and seeds two points so
+/// fusion actually has candidates to rank.
+async fn seed_vector_collection(app: &axum::Router, name: &str) {
+    let resp = post(
+        app,
+        "/collections",
+        json!({"name": name, "dimension": 4, "metric": "cosine"}),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::CREATED, "test setup: create");
+
+    let resp = post(
+        app,
+        &format!("/collections/{name}/points"),
+        json!({
+            "points": [
+                {"id": 1, "vector": [1.0, 0.0, 0.0, 0.0]},
+                {"id": 2, "vector": [0.0, 1.0, 0.0, 0.0]}
+            ]
+        }),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::OK, "test setup: upsert");
+}
+
+// ============================================================================
+// multi.rs — parse_fusion_strategy: every valid arm returns 200
+// ============================================================================
+
+#[tokio::test]
+async fn test_multi_query_search_all_valid_strategies_ok() {
+    let temp_dir = TempDir::new().expect("temp dir");
+    let app = create_test_app(&temp_dir);
+    seed_vector_collection(&app, "fusion_ok").await;
+
+    // Covers each match arm of `parse_fusion_strategy` including aliases.
+    for strategy in [
+        "average",
+        "avg",
+        "maximum",
+        "max",
+        "rrf",
+        "weighted",
+        "relative_score",
+        "rsf",
+    ] {
+        let resp = post(
+            &app,
+            "/collections/fusion_ok/search/multi",
+            json!({
+                "vectors": [[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0]],
+                "top_k": 2,
+                "strategy": strategy
+            }),
+        )
+        .await;
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "strategy '{strategy}' must return 200"
+        );
+    }
+}
+
+// ============================================================================
+// multi.rs — parse_fusion_strategy: unknown strategy -> 400 (the `_` arm)
+// ============================================================================
+
+#[tokio::test]
+async fn test_multi_query_search_invalid_strategy_returns_400() {
+    let temp_dir = TempDir::new().expect("temp dir");
+    let app = create_test_app(&temp_dir);
+    seed_vector_collection(&app, "fusion_bad").await;
+
+    let resp = post(
+        &app,
+        "/collections/fusion_bad/search/multi",
+        json!({
+            "vectors": [[1.0, 0.0, 0.0, 0.0]],
+            "top_k": 2,
+            "strategy": "definitely_not_a_strategy"
+        }),
+    )
+    .await;
+
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    let json = read_json(resp).await;
+    assert!(
+        json["error"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("Invalid strategy"),
+        "expected an 'Invalid strategy' error, got {json:?}"
+    );
+}
+
+/// The ids-only endpoint shares `prepare_multi_query`, so the unknown
+/// strategy must also be rejected there.
+#[tokio::test]
+async fn test_multi_query_search_ids_invalid_strategy_returns_400() {
+    let temp_dir = TempDir::new().expect("temp dir");
+    let app = create_test_app(&temp_dir);
+    seed_vector_collection(&app, "fusion_bad_ids").await;
+
+    let resp = post(
+        &app,
+        "/collections/fusion_bad_ids/search/multi/ids",
+        json!({
+            "vectors": [[1.0, 0.0, 0.0, 0.0]],
+            "top_k": 2,
+            "strategy": "nope"
+        }),
+    )
+    .await;
+
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+// ============================================================================
+// multi.rs — validate_query_vectors: wrong dimension reports the index
+// ============================================================================
+
+#[tokio::test]
+async fn test_multi_query_search_wrong_dimension_reports_index() {
+    let temp_dir = TempDir::new().expect("temp dir");
+    let app = create_test_app(&temp_dir);
+    seed_vector_collection(&app, "dim_mismatch").await;
+
+    // First vector matches dim=4; the second (index 1) is dim=2 -> 400.
+    let resp = post(
+        &app,
+        "/collections/dim_mismatch/search/multi",
+        json!({
+            "vectors": [[1.0, 0.0, 0.0, 0.0], [1.0, 0.0]],
+            "top_k": 2,
+            "strategy": "rrf"
+        }),
+    )
+    .await;
+
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    let json = read_json(resp).await;
+    assert!(
+        json["error"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("index 1"),
+        "expected the offending vector index in the message, got {json:?}"
+    );
+}
+
+// ============================================================================
+// multi.rs — rate-limited preamble path (429) shared by both endpoints
+// ============================================================================
+
+#[tokio::test]
+async fn test_multi_query_search_rate_limited_returns_429() {
+    let temp_dir = TempDir::new().expect("temp dir");
+    let (app, state) = create_test_app_with_state(&temp_dir);
+    seed_vector_collection(&app, "multi_rl").await;
+
+    // Exhaust the per-client token bucket for the default ("anonymous")
+    // client so the next request trips `apply_pre_check` in
+    // `prepare_multi_query`.
+    let collection = state
+        .db
+        .get_vector_collection("multi_rl")
+        .expect("collection exists after seeding");
+    collection.guard_rails().rate_limiter.exhaust("anonymous");
+
+    let resp = post(
+        &app,
+        "/collections/multi_rl/search/multi",
+        json!({
+            "vectors": [[1.0, 0.0, 0.0, 0.0]],
+            "top_k": 2,
+            "strategy": "rrf"
+        }),
+    )
+    .await;
+
+    assert_eq!(resp.status(), StatusCode::TOO_MANY_REQUESTS);
+}
+
+// ============================================================================
+// graph/handlers.rs — build_edge rejects non-object / non-null properties
+// ============================================================================
+
+#[tokio::test]
+async fn test_add_edge_invalid_properties_returns_400() {
+    let temp_dir = TempDir::new().expect("temp dir");
+    let app = create_test_app(&temp_dir);
+    create_graph_collection(&app, "edge_props").await;
+
+    // `properties` is an array, which is neither an object nor null:
+    // hits the `build_edge` 400 branch before any collection mutation.
+    let resp = post(
+        &app,
+        "/collections/edge_props/graph/edges",
+        json!({
+            "id": 1,
+            "source": 10,
+            "target": 20,
+            "label": "KNOWS",
+            "properties": [1, 2, 3]
+        }),
+    )
+    .await;
+
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    let json = read_json(resp).await;
+    assert!(
+        json["error"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("Properties must be an object or null"),
+        "expected the properties-shape error, got {json:?}"
+    );
+}
+
+#[tokio::test]
+async fn test_add_edges_batch_invalid_properties_returns_400() {
+    let temp_dir = TempDir::new().expect("temp dir");
+    let app = create_test_app(&temp_dir);
+    create_graph_collection(&app, "batch_props").await;
+
+    // The batch path maps `build_edge` over every edge; a single edge with
+    // a string `properties` value must fail the whole batch with a 400.
+    let resp = post(
+        &app,
+        "/collections/batch_props/graph/edges/batch",
+        json!({
+            "edges": [
+                {"id": 1, "source": 10, "target": 20, "label": "KNOWS", "properties": {}},
+                {"id": 2, "source": 20, "target": 30, "label": "KNOWS", "properties": "oops"}
+            ]
+        }),
+    )
+    .await;
+
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    let json = read_json(resp).await;
+    assert!(
+        json["error"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("Properties must be an object or null"),
+        "expected the properties-shape error, got {json:?}"
+    );
+}
+
+/// A `null` properties value is explicitly allowed and must succeed (201),
+/// exercising the `Value::Null` arm of `build_edge`.
+#[tokio::test]
+async fn test_add_edge_null_properties_ok() {
+    let temp_dir = TempDir::new().expect("temp dir");
+    let app = create_test_app(&temp_dir);
+    create_graph_collection(&app, "edge_null_props").await;
+
+    let resp = post(
+        &app,
+        "/collections/edge_null_props/graph/edges",
+        json!({
+            "id": 1,
+            "source": 10,
+            "target": 20,
+            "label": "KNOWS",
+            "properties": null
+        }),
+    )
+    .await;
+
+    assert_eq!(resp.status(), StatusCode::CREATED);
+}

--- a/crates/velesdb-wasm/src/coverage_v3_tests.rs
+++ b/crates/velesdb-wasm/src/coverage_v3_tests.rs
@@ -1,0 +1,278 @@
+//! Native coverage tests for VelesDB 3.0.0 WASM paths.
+//!
+//! These exercise the native-callable Rust bodies behind the
+//! `#[wasm_bindgen]` surface without touching the `JsValue` serialization
+//! paths (which panic off-`wasm32`). They target previously-uncovered
+//! branches in `vector_store.rs`, `sparse.rs`, `store_search` delegation,
+//! `database.rs` (`WasmCollectionHandle`), and `velesql_match.rs`
+//! (`enrich_row` skip branches).
+
+use velesdb_core::velesql::{InsertEdgeStatement, InsertNodeStatement, Parser, Query};
+
+use crate::database::{DatabaseInner, WasmDatabase};
+use crate::sparse::SparseIndex;
+use crate::store_insert::insert_with_payload;
+use crate::store_new::create_store;
+use crate::velesql_graph::{execute_match, insert_edge, insert_node};
+use crate::velesql_value::Params;
+use crate::{DistanceMetric, StorageMode};
+
+// =========================================================================
+// SparseIndex::search_scored — native scoring kernel branches
+// (sparse.rs ~L166-202; covers the k==0 and length-mismatch guards plus the
+//  DAAT accumulation + top-k ranking path)
+// =========================================================================
+
+#[test]
+fn test_sparse_index_search_scored_ranks_by_dot_product() {
+    let mut index = SparseIndex::new();
+    index
+        .insert(1, &[10, 20, 30], &[1.0, 0.5, 0.3])
+        .expect("test: insert 1");
+    index
+        .insert(2, &[10, 40], &[0.8, 1.2])
+        .expect("test: insert 2");
+    index
+        .insert(3, &[20, 30, 50], &[0.9, 0.7, 0.4])
+        .expect("test: insert 3");
+    index
+        .insert(4, &[10, 20], &[0.3, 1.5])
+        .expect("test: insert 4");
+
+    // query = {10: 1.0, 20: 1.0}:
+    //   doc 4 -> 0.3 + 1.5 = 1.8 (top)
+    //   doc 1 -> 1.0 + 0.5 = 1.5
+    //   doc 3 -> 0.9
+    //   doc 2 -> 0.8
+    let results = index
+        .search_scored(&[10, 20], &[1.0, 1.0], 10)
+        .expect("test: search_scored on populated index");
+    assert_eq!(results.len(), 4, "all four docs touch the query terms");
+    assert_eq!(results[0].doc_id(), 4, "doc 4 (1.8) ranks first");
+    assert_eq!(results[1].doc_id(), 1, "doc 1 (1.5) ranks second");
+}
+
+#[test]
+fn test_sparse_index_search_scored_truncates_to_k() {
+    let mut index = SparseIndex::new();
+    index.insert(1, &[1], &[3.0]).expect("test: insert 1");
+    index.insert(2, &[1], &[2.0]).expect("test: insert 2");
+    index.insert(3, &[1], &[1.0]).expect("test: insert 3");
+
+    let results = index
+        .search_scored(&[1], &[1.0], 2)
+        .expect("test: search_scored truncates");
+    assert_eq!(results.len(), 2, "k=2 caps the result list");
+    assert_eq!(results[0].doc_id(), 1, "highest weight first");
+    assert_eq!(results[1].doc_id(), 2, "second highest next");
+}
+
+#[test]
+fn test_sparse_index_search_scored_k_zero_returns_empty() {
+    // sparse.rs L179-181: k == 0 short-circuits to an empty result vector
+    // before any accumulation work.
+    let mut index = SparseIndex::new();
+    index.insert(1, &[10], &[1.0]).expect("test: insert");
+    let results = index
+        .search_scored(&[10], &[1.0], 0)
+        .expect("test: k=0 is a valid empty query");
+    assert!(results.is_empty(), "k=0 yields no results");
+}
+
+#[test]
+fn test_sparse_index_search_scored_length_mismatch_errors() {
+    // sparse.rs L172-178: query indices/values length disagreement is
+    // rejected before scoring with a descriptive error.
+    let index = SparseIndex::new();
+    let err = index
+        .search_scored(&[10, 20], &[1.0], 5)
+        .expect_err("test: 2 indices vs 1 value must error");
+    assert!(
+        err.contains("indices/values length mismatch"),
+        "error should describe the mismatch, got: {err}"
+    );
+}
+
+#[test]
+fn test_sparse_index_search_scored_no_matching_terms_is_empty() {
+    // A query whose terms are absent from every posting list accumulates
+    // nothing and returns an empty ranking (no error).
+    let mut index = SparseIndex::new();
+    index
+        .insert(1, &[10, 20], &[1.0, 1.0])
+        .expect("test: insert");
+    let results = index
+        .search_scored(&[999], &[1.0], 5)
+        .expect("test: unknown term is a valid empty query");
+    assert!(results.is_empty(), "absent query term matches nothing");
+}
+
+// =========================================================================
+// VectorStore::search_sparse_scored — delegate behind search_sparse
+// (vector_store.rs ~L366-367 / L628-639; exercises the k==0 and
+//  length-mismatch propagation from the underlying kernel)
+// =========================================================================
+
+#[test]
+fn test_vector_store_search_sparse_scored_k_zero() {
+    let mut store = create_store(4, DistanceMetric::Cosine, StorageMode::Full);
+    store
+        .sparse_insert(1, &[10, 20], &[1.0, 1.0])
+        .expect("test: sparse_insert");
+    let results = store
+        .search_sparse_scored(&[10], &[1.0], 0)
+        .expect("test: k=0 is valid");
+    assert!(
+        results.is_empty(),
+        "k=0 yields no results through the store"
+    );
+}
+
+#[test]
+fn test_vector_store_search_sparse_scored_mismatch_propagates() {
+    let mut store = create_store(4, DistanceMetric::Cosine, StorageMode::Full);
+    store
+        .sparse_insert(1, &[10, 20], &[1.0, 1.0])
+        .expect("test: sparse_insert");
+    let err = store
+        .search_sparse_scored(&[10, 20, 30], &[1.0], 5)
+        .expect_err("test: 3 indices vs 1 value must error through the store");
+    assert!(
+        err.contains("length mismatch"),
+        "store should surface the kernel's mismatch error, got: {err}"
+    );
+}
+
+// =========================================================================
+// VectorStore::insert_batch_raw — wasm-bindgen method, native happy path
+// (vector_store.rs ~L609-617; success branch never builds a JsValue)
+// =========================================================================
+
+#[test]
+fn test_vector_store_insert_batch_raw_method_happy_path() {
+    let mut store = create_store(3, DistanceMetric::Euclidean, StorageMode::Full);
+    let ids = [7u64, 8, 9];
+    let vectors = [
+        1.0, 0.0, 0.0, // id 7
+        0.0, 1.0, 0.0, // id 8
+        0.0, 0.0, 1.0, // id 9
+    ];
+    store
+        .insert_batch_raw(&ids, &vectors, 3)
+        .expect("test: raw bulk insert through the wasm method body");
+    assert_eq!(store.ids, vec![7, 8, 9]);
+    assert_eq!(store.data.len(), 9);
+    assert_eq!(&store.data[3..6], &[0.0, 1.0, 0.0]);
+}
+
+// =========================================================================
+// WasmCollectionHandle::insert_batch_raw — handle delegate, native happy path
+// (database.rs ~L416-425; resolves a handle from WasmDatabase and bulk-inserts)
+// =========================================================================
+
+#[test]
+fn test_collection_handle_insert_batch_raw_happy_path() {
+    let mut db = WasmDatabase::new();
+    db.create_collection("vecs", 2, "cosine")
+        .expect("test: create collection (native success branch)");
+    let handle = db
+        .get_collection("vecs")
+        .expect("test: get_collection success branch builds no JsValue");
+
+    handle
+        .insert_batch_raw(&[100u64, 101], &[1.0, 0.0, 0.0, 1.0], 2)
+        .expect("test: handle bulk insert through borrow_mut");
+    assert_eq!(handle.len(), 2, "both rows landed in the shared store");
+
+    // The insert is visible through a freshly resolved handle (shared Rc).
+    let handle2 = db.get_collection("vecs").expect("test: second handle");
+    assert_eq!(handle2.len(), 2, "second handle sees the same store");
+    assert_eq!(handle2.dimension(), 2);
+    assert!(!handle2.is_empty());
+}
+
+// =========================================================================
+// enrich_row — cross-collection MATCH enrichment skip branches
+// (velesql_match.rs ~L66-67: payload_for_id missing / non-object → continue)
+// =========================================================================
+
+fn parse_match(sql: &str) -> Query {
+    Parser::parse(sql).expect("test: parse")
+}
+
+fn seed_has_edge(db: &mut DatabaseInner) {
+    for (id, name, labels) in [(1u64, "Alice", vec!["Person"]), (2, "Bob", vec!["Profile"])] {
+        let stmt = InsertNodeStatement {
+            collection: "graph".to_string(),
+            node_id: id,
+            payload: serde_json::json!({"name": name, "labels": labels}),
+        };
+        insert_node(db, &stmt).expect("test: insert node");
+    }
+    let edge = InsertEdgeStatement {
+        collection: "graph".to_string(),
+        edge_id: None,
+        source: 1,
+        target: 2,
+        label: "HAS".to_string(),
+        properties: Vec::new(),
+    };
+    insert_edge(db, &edge, &Params::new()).expect("test: insert edge");
+}
+
+#[test]
+fn test_enrich_row_skips_when_referenced_id_absent() {
+    // The @collection exists (cross-ref resolves), but it holds NO payload
+    // for the matched node id. payload_for_id(id) returns None → the
+    // enrichment loop hits `continue` and the row stays un-enriched.
+    let mut db = DatabaseInner::new();
+    // Referenced collection exists but is empty (no id=2 payload).
+    db.create_metadata_collection("profiles")
+        .expect("test: create profiles");
+    seed_has_edge(&mut db);
+
+    let q = parse_match("MATCH (a:Person)-[:HAS]->(b:Profile@profiles) RETURN a, b LIMIT 10");
+    let rows = execute_match(&mut db, &q, &Params::new()).expect("test: match still succeeds");
+    assert_eq!(rows.len(), 1);
+    let data: serde_json::Value =
+        serde_json::from_str(rows[0].data_json_ref()).expect("test: row json");
+    // Graph identity is intact; no cross fields were merged.
+    assert_eq!(data["b"]["name"], serde_json::json!("Bob"));
+    assert_eq!(data["b"]["id"], serde_json::json!(2));
+    assert!(
+        data["b"].get("email").is_none(),
+        "absent referenced payload must not enrich the row"
+    );
+}
+
+#[test]
+fn test_enrich_row_skips_when_referenced_payload_not_object() {
+    // The @collection holds a payload for id=2, but it is a JSON STRING, not
+    // an object. The `Some(Value::Object(..))` else-branch fires → continue,
+    // leaving the row un-enriched without panicking.
+    let mut db = DatabaseInner::new();
+    db.create_metadata_collection("profiles")
+        .expect("test: create profiles");
+    {
+        let store = db
+            .get_shared_store("profiles")
+            .expect("test: profiles store");
+        insert_with_payload(
+            &mut store.borrow_mut(),
+            2,
+            &[],
+            Some(serde_json::json!("scalar-not-an-object")),
+        );
+    }
+    seed_has_edge(&mut db);
+
+    let q = parse_match("MATCH (a:Person)-[:HAS]->(b:Profile@profiles) RETURN a, b LIMIT 10");
+    let rows = execute_match(&mut db, &q, &Params::new()).expect("test: match still succeeds");
+    assert_eq!(rows.len(), 1);
+    let data: serde_json::Value =
+        serde_json::from_str(rows[0].data_json_ref()).expect("test: row json");
+    assert_eq!(data["b"]["name"], serde_json::json!("Bob"));
+    assert_eq!(data["b"]["id"], serde_json::json!(2));
+    // A non-object referenced payload merges nothing.
+    assert!(data["b"].as_object().expect("test: b is object").len() <= 3);
+}

--- a/crates/velesdb-wasm/src/lib.rs
+++ b/crates/velesdb-wasm/src/lib.rs
@@ -192,3 +192,7 @@ mod velesql_exec_graph_tests;
 #[cfg(test)]
 #[path = "velesql_executor_conformance_tests.rs"]
 mod velesql_executor_conformance_tests;
+
+#[cfg(test)]
+#[path = "coverage_v3_tests.rs"]
+mod coverage_v3_tests;

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -49,5 +49,12 @@ sonar.tests=crates/velesdb-core/tests,crates/velesdb-server/tests,crates/velesdb
 # genericCoverage route expected XML and is not used.
 sonar.rust.lcov.reportPaths=lcov.info
 
+# Coverage exclusions. `velesdb-python` is `--exclude`d from the cargo llvm-cov
+# run (its pyo3 code is exercised by the pytest suite, not by `cargo test`, so it
+# has no LCOV data). It must therefore also be excluded from coverage measurement
+# here, otherwise SonarCloud counts its lines as 0%-covered and understates the
+# real coverage. (It stays in `sonar.sources` for issue/quality analysis.)
+sonar.coverage.exclusions=**/velesdb-python/**
+
 # Duplication exclusions (test and benchmark code is intentionally repetitive)
 sonar.cpd.exclusions=**/*_tests.rs,**/tests/**,**/benches/**,conformance/**


### PR DESCRIPTION
## What

Closes the SonarCloud quality-gate failure on `main` (new-code coverage 79.4% < 80%) two ways:

1. **Config fix (root cause):** `sonar.coverage.exclusions=**/velesdb-python/**`. CI generates coverage with `cargo llvm-cov --exclude velesdb-python` (pyo3 code is tested via **pytest**, not cargo, so it has no LCOV data), but `velesdb-python/src` was still in `sonar.sources` → SonarCloud counted its 1,209 new Rust lines as 0%-covered. Measured workspace coverage (CI scope) is actually **~81.7%**.

2. **Genuine new tests (+~2,600 lines across 7 crates)** for the under-covered 3.0.0 code, written natively and each verified `cargo test -p <crate>`:
   - **tauri-plugin**: 18 tests driving the `#[command]` handlers through a real `App<MockRuntime>` (`tauri::test`) — the biggest gap (`commands.rs`/`commands_graph.rs`/`observer.rs`).
   - **core**: VRB1 error `Display`/overflow guard, payload-size boundary, graph delegates, ordered-index decline branches.
   - **server**: multi-query fusion strategies + dim-mismatch + rate-limit + graph edge-property 400 paths.
   - **wasm**: native coverage for sparse / raw-bulk / cross-collection MATCH.
   - **mobile**: dfs traversal + binding error paths.
   - **cli**: repl command dispatch + display helpers. **migrate**: weighted-relation edge build.

Genuinely unreachable arms (variants behind `#[non_exhaustive]`, WAL-failure paths, wasm-only `JsValue` serialization, runtime-build-failure arms) are documented, not faked.

## Validation (local)
- clippy `--workspace --all-targets -D warnings -D clippy::pedantic` (excl python) ✅
- all new tests compile + pass; **jscpd 0 clones**; fmt clean
- No production logic changed (tests + 1 sonar config line)

Prep for the **3.0.1** patch release.