### PR TITLE
perf/refactor(migrate): reduce allocations and eliminate code duplication in connectors

### DIFF
--- a/crates/velesdb-migrate/src/connectors/common.rs
+++ b/crates/velesdb-migrate/src/connectors/common.rs
@@ -248,23 +248,28 @@ pub fn extract_payload_from_object(
     excluded_fields: &[&str],
     included_fields: &[String],
 ) -> HashMap<String, Value> {
-    let mut payload = HashMap::new();
+    let Value::Object(map) = source else {
+        return HashMap::new();
+    };
+    extract_payload_from_hashmap(map, excluded_fields, included_fields)
+}
 
-    if let Value::Object(map) = source {
-        for (key, val) in map {
-            // Skip excluded fields
-            if excluded_fields.iter().any(|f| f == key) {
-                continue;
-            }
-            // If included_fields is specified, only include those
-            if !included_fields.is_empty() && !included_fields.contains(key) {
-                continue;
-            }
-            payload.insert(key.clone(), val.clone());
-        }
-    }
-
-    payload
+/// Extracts payload fields from a pre-parsed `HashMap<String, Value>`.
+///
+/// Identical filtering semantics to [`extract_payload_from_object`] but
+/// operates directly on a `HashMap`, avoiding a round-trip through
+/// `serde_json::Value::Object` when the caller already has the map form.
+pub fn extract_payload_from_hashmap<'a>(
+    source: impl IntoIterator<Item = (&'a String, &'a Value)>,
+    excluded_fields: &[&str],
+    included_fields: &[String],
+) -> HashMap<String, Value> {
+    source
+        .into_iter()
+        .filter(|(key, _)| !excluded_fields.iter().any(|f| *f == key.as_str()))
+        .filter(|(key, _)| included_fields.is_empty() || included_fields.contains(key))
+        .map(|(k, v)| (k.clone(), v.clone()))
+        .collect()
 }
 
 /// Detects the JSON type as a string for schema detection.

--- a/crates/velesdb-migrate/src/connectors/common.rs
+++ b/crates/velesdb-migrate/src/connectors/common.rs
@@ -266,7 +266,7 @@ pub fn extract_payload_from_hashmap<'a>(
 ) -> HashMap<String, Value> {
     source
         .into_iter()
-        .filter(|(key, _)| !excluded_fields.iter().any(|f| *f == key.as_str()))
+        .filter(|(key, _)| !excluded_fields.contains(&key.as_str()))
         .filter(|(key, _)| included_fields.is_empty() || included_fields.contains(key))
         .map(|(k, v)| (k.clone(), v.clone()))
         .collect()

--- a/crates/velesdb-migrate/src/connectors/elasticsearch.rs
+++ b/crates/velesdb-migrate/src/connectors/elasticsearch.rs
@@ -186,13 +186,7 @@ impl ElasticsearchConnector {
     /// will skip validation for this source rather than blocking
     /// migration.
     async fn fetch_field_similarity(&self) -> Option<String> {
-        let base = self.config.url.trim_end_matches('/');
-        let index_path = if self.config.index.starts_with('/') {
-            self.config.index.clone()
-        } else {
-            format!("/{}", self.config.index)
-        };
-        let url = format!("{base}{index_path}/_mapping");
+        let url = self.build_index_url("_mapping");
 
         let resp = match self.build_get_request(&url).send().await {
             Ok(r) => r,

--- a/crates/velesdb-migrate/src/connectors/pinecone.rs
+++ b/crates/velesdb-migrate/src/connectors/pinecone.rs
@@ -61,8 +61,9 @@ impl PineconeConnector {
     fn control_plane_url(&self) -> String {
         self.config
             .base_url
-            .clone()
-            .unwrap_or_else(|| "https://api.pinecone.io".to_string())
+            .as_deref()
+            .unwrap_or("https://api.pinecone.io")
+            .to_string()
     }
 
     /// Data-plane base URL (list, fetch, stats).

--- a/crates/velesdb-migrate/src/connectors/redis.rs
+++ b/crates/velesdb-migrate/src/connectors/redis.rs
@@ -10,9 +10,9 @@ use std::sync::Arc;
 use tokio::sync::Mutex;
 
 use crate::config::RedisConfig;
-#[cfg(test)]
-use crate::connectors::common::extract_payload_from_object;
-use crate::connectors::common::{build_numeric_offset_batch, parse_vector_from_json};
+use crate::connectors::common::{
+    build_numeric_offset_batch, extract_payload_from_hashmap, parse_vector_from_json,
+};
 use crate::connectors::{ExtractedBatch, ExtractedPoint, FieldInfo, SourceConnector, SourceSchema};
 use crate::error::{Error, Result};
 
@@ -87,13 +87,7 @@ impl RedisConnector {
         &self,
         attrs: &HashMap<String, serde_json::Value>,
     ) -> HashMap<String, serde_json::Value> {
-        let obj =
-            serde_json::Value::Object(attrs.iter().map(|(k, v)| (k.clone(), v.clone())).collect());
-        extract_payload_from_object(
-            &obj,
-            &[&self.config.vector_field],
-            &self.config.payload_fields,
-        )
+        extract_payload_from_hashmap(attrs, &[&self.config.vector_field], &self.config.payload_fields)
     }
 
     /// Opens a multiplexed async Redis connection with optional AUTH.
@@ -474,11 +468,7 @@ fn build_payload(
     attrs: &HashMap<String, serde_json::Value>,
     vector_field: &str,
 ) -> HashMap<String, serde_json::Value> {
-    attrs
-        .iter()
-        .filter(|(k, _)| k.as_str() != vector_field)
-        .map(|(k, v)| (k.clone(), v.clone()))
-        .collect()
+    extract_payload_from_hashmap(attrs, &[vector_field], &[])
 }
 
 /// Parses a `FT.INFO` RESP response to extract `num_docs` and field definitions.

--- a/crates/velesdb-migrate/src/connectors/redis.rs
+++ b/crates/velesdb-migrate/src/connectors/redis.rs
@@ -656,7 +656,7 @@ fn find_string_after(parts: &[redis::Value], key: &str) -> Option<String> {
 /// Extracts a `String` from a `redis::Value::BulkString`.
 fn extract_bulk_string(value: &redis::Value) -> Option<String> {
     match value {
-        redis::Value::BulkString(bytes) => String::from_utf8(bytes.clone()).ok(),
+        redis::Value::BulkString(bytes) => std::str::from_utf8(bytes).ok().map(str::to_owned),
         redis::Value::SimpleString(s) => Some(s.clone()),
         // Some Redis versions return status strings.
         _ => None,
@@ -677,8 +677,8 @@ fn resp_value_to_json(value: &redis::Value) -> serde_json::Value {
         redis::Value::BulkString(bytes) => {
             // Preserve the original string type — do not coerce "42" to 42 or
             // "true" to true, as that would silently corrupt metadata (e.g. zip codes).
-            match String::from_utf8(bytes.clone()) {
-                Ok(s) => serde_json::Value::String(s),
+            match std::str::from_utf8(bytes) {
+                Ok(s) => serde_json::Value::String(s.to_owned()),
                 Err(_) => serde_json::Value::String(format!("<binary:{} bytes>", bytes.len())),
             }
         }


### PR DESCRIPTION
## Summary

Three atomic improvements to the `velesdb-migrate` crate, all following Rust 2026 best practices (zero unnecessary allocations, DRY, no behaviour changes).

### Commit 1 — `perf(migrate): avoid Vec<u8> clone in RESP string extraction`

`extract_bulk_string` and `resp_value_to_json` in `redis.rs` called `String::from_utf8(bytes.clone())`, which allocates a full copy of the byte slice before discovering whether it is valid UTF-8. On the error path that allocation was immediately discarded.

**Fix:** use `std::str::from_utf8(bytes)` — zero allocation on the rejection path; only `str::to_owned()` allocates when the bytes are valid UTF-8, which is the case that produces the returned `String` anyway.

### Commit 2 — `refactor(migrate): DRY payload extraction via extract_payload_from_hashmap`

`build_payload` in `redis.rs` and `extract_payload_from_object` in `common.rs` both filter and clone key-value pairs into an owned `HashMap` — duplicated logic with a subtle cost in the test helper path:

- `extract_payload` (test helper) wrapped the `HashMap` in a `serde_json::Value::Object`, cloning every entry **twice** — once to build the Object, once inside `extract_payload_from_object`.

**Fix:** add `extract_payload_from_hashmap` to `common.rs` that accepts any `IntoIterator<Item = (&String, &Value)>` (directly covering the HashMap case). `extract_payload_from_object` becomes a thin wrapper. `build_payload` and the test helper both delegate: one clone pass instead of two in the test path.

Clippy `manual_contains` lint that arose from the new iterator (use `slice.contains(&x)` rather than `.iter().any(|f| f == x)`) fixed in the same commit.

### Commit 3 — `refactor(migrate): eliminate duplicate index-URL logic and Option clone`

Two cleanups found during the connector sweep:

1. **Elasticsearch** — `fetch_field_similarity` manually reproduced the exact same 7-line URL-building logic already in `build_index_url` (trim trailing slash, handle leading-slash index names, concat action suffix). Replace the duplicate block with `self.build_index_url("_mapping")`.

2. **Pinecone** — `control_plane_url` called `self.config.base_url.clone().unwrap_or_else(…)`, cloning the entire `Option<String>` before unwrapping it. Use `as_deref().unwrap_or(…).to_string()` — the `Some` path borrows the existing heap string, the `None` path returns a static default: one allocation either way instead of two.

## Test plan

- [x] `cargo test -p velesdb-migrate --features redis-source` — 15/15 pass (includes Elasticsearch, Pinecone, Qdrant, Supabase, JSON e2e, dry-run, checkpoint resume, sparse vectors, pagination, error paths)
- [x] `cargo clippy -p velesdb-migrate --all-targets -- -D warnings` — clean
- [x] `cargo check --workspace --exclude tauri-plugin-velesdb` — clean
- [x] No behaviour changes — all public APIs unchanged, all test assertions unchanged


https://claude.ai/code/session_01VHvYgJZxpb77o5qtHL7y3P
