### PR TITLE
refactor(fusion): single-source RRF math from velesdb-core

### DIFF
--- a/crates/tauri-plugin-velesdb/src/commands_sparse.rs
+++ b/crates/tauri-plugin-velesdb/src/commands_sparse.rs
@@ -53,7 +53,7 @@ pub async fn hybrid_sparse_search<R: Runtime>(
             let coll = require_vector_collection(&db, &request.collection)?;
 
             let core_sv = parse_sparse_vector(&request.sparse_vector)?;
-            let strategy = velesdb_core::fusion::FusionStrategy::RRF { k: 60 };
+            let strategy = velesdb_core::fusion::FusionStrategy::rrf_default();
 
             let search_results =
                 coll.hybrid_sparse_search(&request.vector, &core_sv, request.top_k, "", &strategy)?;

--- a/crates/velesdb-wasm/src/sparse.rs
+++ b/crates/velesdb-wasm/src/sparse.rs
@@ -225,24 +225,17 @@ pub fn hybrid_search_fuse(
     let sparse: Vec<(u64, f32)> = serde_wasm_bindgen::from_value(sparse_results)
         .map_err(|e| JsValue::from_str(&format!("Invalid sparse_results: {e}")))?;
 
-    // RRF: score(d) = sum over lists of 1 / (k + rank_in_list)
-    // N-06: rrf_k is a smoothing constant typically in [10, 100]; the precision
-    // loss from u32 → f32 is negligible (< 1 ULP for values < 2^24).
-    let k_f32 = rrf_k as f32;
-    let mut scores: std::collections::HashMap<u64, f32> = std::collections::HashMap::new();
+    // Delegate to the canonical RRF in velesdb-core so the browser engine
+    // reproduces core's ranking 1:1 (single source of truth for fusion math)
+    // instead of re-deriving the formula here.
+    let fused = velesdb_core::FusionStrategy::RRF { k: rrf_k }
+        .fuse(vec![dense, sparse])
+        .map_err(|e| JsValue::from_str(&format!("Fusion error: {e}")))?;
 
-    for (rank, &(doc_id, _)) in dense.iter().enumerate() {
-        *scores.entry(doc_id).or_insert(0.0) += 1.0 / (k_f32 + (rank as f32) + 1.0);
-    }
-    for (rank, &(doc_id, _)) in sparse.iter().enumerate() {
-        *scores.entry(doc_id).or_insert(0.0) += 1.0 / (k_f32 + (rank as f32) + 1.0);
-    }
-
-    let mut results: Vec<SparseSearchResult> = scores
+    let mut results: Vec<SparseSearchResult> = fused
         .into_iter()
         .map(|(doc_id, score)| SparseSearchResult { doc_id, score })
         .collect();
-    results.sort_by(|a, b| b.score.total_cmp(&a.score));
     results.truncate(k);
 
     serde_wasm_bindgen::to_value(&results)


### PR DESCRIPTION
## What

Two stray re-derivations of core's RRF fusion math, surfaced by the core-parity architecture audit, now delegate to `velesdb-core` (the single source of truth for fusion):

- **velesdb-wasm** `sparse.rs::hybrid_search_fuse` re-implemented the RRF formula inline. Now fuses via `FusionStrategy::RRF { k }.fuse(vec![dense, sparse])` — the formula is identical (`1/(k + rank + 1)`, `k: u32`), and core additionally dedups by best rank per list (more robust on malformed input). (audit finding **C10**)
- **tauri-plugin-velesdb** `commands_sparse.rs` hard-coded `FusionStrategy::RRF { k: 60 }`. Now uses `FusionStrategy::rrf_default()` — behavior-preserving (`rrf_default() == RRF { k: 60 }`). (audit finding **B8**)

## Why

Keeps the browser and desktop engines reproducing core's ranking 1:1 and removes two drift-prone copies of a core-owned contract. No behavior change for well-formed inputs.

## Verification

- `cargo test -p velesdb-wasm --lib` → 541 passed / 0 failed (RRF tests included)
- `cargo clippy -p velesdb-wasm -p tauri-plugin-velesdb --all-targets -- -D warnings -D clippy::pedantic` → clean
- `cargo check -p velesdb-wasm --no-default-features --target wasm32-unknown-unknown` → ok
- `cargo test -p tauri-plugin-velesdb` → ok