### PR TITLE
fix(wasm): match core binary-quant sign convention + surface PQ/RaBitQ fallback

### DIFF
--- a/crates/velesdb-wasm/src/lib_tests.rs
+++ b/crates/velesdb-wasm/src/lib_tests.rs
@@ -75,9 +75,10 @@ fn test_sq8_quantization_roundtrip() {
 fn test_binary_packing() {
     let mut store = VectorStore::new_with_mode(8, "hamming", "binary").unwrap();
 
-    // Insert binary vectors
+    // Core convention: value >= 0.0 -> bit 1, value < 0.0 -> bit 0.
+    // First two non-negative, rest negative.
     store
-        .insert(1, &[1.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
+        .insert(1, &[1.0, 1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0])
         .unwrap();
 
     assert_eq!(store.len(), 1);
@@ -91,8 +92,9 @@ fn test_binary_packing() {
 fn test_binary_packing_large() {
     let mut store = VectorStore::new_with_mode(16, "hamming", "binary").unwrap();
 
-    // All ones in first byte, all zeros in second
-    let mut vec = vec![0.0f32; 16];
+    // Core convention: non-negative -> 1, negative -> 0.
+    // First 8 non-negative (bits set), last 8 negative (bits clear).
+    let mut vec = vec![-1.0f32; 16];
     for item in vec.iter_mut().take(8) {
         *item = 1.0;
     }

--- a/crates/velesdb-wasm/src/parsing.rs
+++ b/crates/velesdb-wasm/src/parsing.rs
@@ -44,10 +44,44 @@ pub fn parse_storage_mode(mode: &str) -> Result<StorageMode, JsValue> {
 
 /// Delegates to [`velesdb_core::StorageMode::from_str`] (single source of truth)
 /// and maps to the local WASM `StorageMode` enum.
+///
+/// # PQ / `RaBitQ` fallback
+///
+/// The browser engine has no Product-Quantization codebook training (that
+/// path is `persistence`-gated in core and unavailable in WASM). A request
+/// for `"pq"` or `"rabitq"` is therefore stored using the SQ8 encode/decode
+/// path. This is architecturally justified, but no longer silent: a one-time
+/// `console.warn` is emitted so the caller knows the requested mode was
+/// downgraded.
 fn parse_storage_mode_inner(mode: &str) -> Result<StorageMode, String> {
     let core: velesdb_core::StorageMode = mode.parse()?;
+    warn_if_pq_fallback(core);
     Ok(core_to_wasm_storage_mode(core))
 }
+
+/// Emits a one-time `console.warn` when PQ/`RaBitQ` is requested in WASM,
+/// where it transparently falls back to the SQ8 storage path.
+///
+/// The `console.warn` binding requires a live JS environment, so it is only
+/// invoked on the `wasm32` target. On native (test) builds this is a no-op.
+#[cfg(target_arch = "wasm32")]
+fn warn_if_pq_fallback(core: velesdb_core::StorageMode) {
+    if matches!(
+        core,
+        velesdb_core::StorageMode::ProductQuantization | velesdb_core::StorageMode::RaBitQ
+    ) {
+        web_sys::console::warn_1(&JsValue::from_str(
+            "VelesDB WASM: Product Quantization / RaBitQ is not available in the \
+             browser engine (no codebook training); storing vectors with SQ8 \
+             quantization instead.",
+        ));
+    }
+}
+
+/// Native no-op counterpart of [`warn_if_pq_fallback`]; see the `wasm32`
+/// variant for the browser behavior.
+#[cfg(not(target_arch = "wasm32"))]
+fn warn_if_pq_fallback(_core: velesdb_core::StorageMode) {}
 
 /// Validates a search quality string for API parity with Python and Server SDKs.
 ///

--- a/crates/velesdb-wasm/src/quantization.rs
+++ b/crates/velesdb-wasm/src/quantization.rs
@@ -47,7 +47,8 @@ pub fn dequantize_sq8(data: &[u8], params: Sq8Params) -> Vec<f32> {
 
 /// Packs a vector into binary format (1 bit per dimension).
 ///
-/// Positive values (> 0) become 1, others become 0.
+/// Values `>= 0.0` become 1, values `< 0.0` become 0 — matching the core
+/// `BinaryQuantizedVector` sign convention exactly.
 /// Bits are packed 8 per byte, LSB first.
 pub fn pack_binary(vector: &[f32], dimension: usize, output: &mut Vec<u8>) {
     let bytes_needed = dimension.div_ceil(8);
@@ -55,7 +56,7 @@ pub fn pack_binary(vector: &[f32], dimension: usize, output: &mut Vec<u8>) {
         let mut byte = 0u8;
         for bit in 0..8 {
             let dim_idx = byte_idx * 8 + bit;
-            if dim_idx < dimension && vector[dim_idx] > 0.0 {
+            if dim_idx < dimension && vector[dim_idx] >= 0.0 {
                 byte |= 1 << bit;
             }
         }
@@ -110,7 +111,7 @@ mod tests {
 
     #[test]
     fn test_binary_roundtrip() {
-        let vector = vec![1.0, -0.5, 0.0, 0.1, -1.0, 0.9, 0.0, 0.5, 1.0, -0.1];
+        let vector = vec![1.0, -0.5, 0.0, 0.1, -1.0, 0.9, -0.2, 0.5, 1.0, -0.1];
         let dimension = vector.len();
 
         let mut packed = Vec::new();
@@ -118,15 +119,15 @@ mod tests {
 
         let unpacked = unpack_binary(&packed, dimension);
 
-        // Binary only preserves sign (positive = 1.0, else = 0.0)
-        let expected: Vec<f32> = vector.iter().map(|&v| if v > 0.0 { 1.0 } else { 0.0 }).collect();
+        // Binary only preserves sign: matches core convention (>= 0.0 -> 1.0, else 0.0).
+        let expected: Vec<f32> = vector.iter().map(|&v| if v >= 0.0 { 1.0 } else { 0.0 }).collect();
         assert_eq!(unpacked, expected);
     }
 
     #[test]
     fn test_binary_packing_bits() {
-        // 8 values that should pack into: 0b10101010 = 170
-        let vector = vec![0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0];
+        // Negative values -> 0, non-negative -> 1, packed LSB first into 0b10101010 = 170.
+        let vector = vec![-1.0, 1.0, -1.0, 1.0, -1.0, 1.0, -1.0, 1.0];
         let mut packed = Vec::new();
         pack_binary(&vector, 8, &mut packed);
         assert_eq!(packed.len(), 1);
@@ -134,8 +135,18 @@ mod tests {
     }
 
     #[test]
+    fn test_binary_zero_packs_as_one() {
+        // Core convention: 0.0 is non-negative, so it must pack as bit 1.
+        let vector = vec![0.0, -0.1, 0.0];
+        let mut packed = Vec::new();
+        pack_binary(&vector, 3, &mut packed);
+        let unpacked = unpack_binary(&packed, 3);
+        assert_eq!(unpacked, vec![1.0, 0.0, 1.0]);
+    }
+
+    #[test]
     fn test_binary_dimension_not_multiple_of_8() {
-        let vector = vec![1.0, 0.0, 1.0, 0.0, 1.0]; // 5 dimensions
+        let vector = vec![1.0, -1.0, 1.0, -1.0, 1.0]; // 5 dimensions
         let mut packed = Vec::new();
         pack_binary(&vector, 5, &mut packed);
         assert_eq!(packed.len(), 1); // ceil(5/8) = 1 byte

--- a/crates/velesdb-wasm/src/store_insert.rs
+++ b/crates/velesdb-wasm/src/store_insert.rs
@@ -8,8 +8,12 @@ mod tests;
 
 /// Encodes a vector into the store's buffers based on storage mode.
 ///
-/// This is the single encoding path for all insert operations. SQ8 and
-/// `ProductQuantization` share the same quantization logic.
+/// This is the single encoding path for all insert operations.
+///
+/// `ProductQuantization` and `RaBitQ` deliberately share the SQ8 encode path:
+/// the browser engine has no PQ codebook training, so those modes fall back to
+/// SQ8 quantization. The fallback is surfaced once via `console.warn` at store
+/// creation (see `parsing::parse_storage_mode_inner`), so it is not silent.
 fn encode_vector(store: &mut VectorStore, vector: &[f32]) {
     match store.storage_mode {
         StorageMode::Full => {
@@ -46,13 +50,16 @@ fn encode_sq8(store: &mut VectorStore, vector: &[f32]) {
 }
 
 /// Binary quantization: packs each dimension into a single bit.
+///
+/// Values `>= 0.0` become 1, values `< 0.0` become 0 — matching the core
+/// `BinaryQuantizedVector` sign convention exactly.
 fn encode_binary(store: &mut VectorStore, vector: &[f32]) {
     let bytes_needed = store.dimension.div_ceil(8);
     for byte_idx in 0..bytes_needed {
         let mut byte = 0u8;
         for bit in 0..8 {
             let dim_idx = byte_idx * 8 + bit;
-            if dim_idx < store.dimension && vector[dim_idx] > 0.0 {
+            if dim_idx < store.dimension && vector[dim_idx] >= 0.0 {
                 byte |= 1 << bit;
             }
         }


### PR DESCRIPTION
## What (core-parity audit A1 + A3)
- **A1 (correctness):** WASM binary 1-bit quantization packed `value > 0.0 -> bit 1`, the **opposite** of core's `value >= 0.0 -> bit 1` (`velesdb-core/src/quantization/binary.rs`). Both WASM packing sites (`quantization::pack_binary`, `store_insert::encode_binary`) now match core exactly. Tests that pinned the old convention were corrected; added `test_binary_zero_packs_as_one`.
- **A3 (honesty):** requesting `pq`/`rabitq` storage mode in the browser silently used the SQ8 path. The SQ8 fallback stays (no codebook training in WASM — architecturally justified) but now emits a one-time `console.warn` + carries a doc comment, so it is no longer silent.

## Behavior change
Boundary value `0.0` now sets the bit (matches core). In-memory only — WASM has no persistence, no migration concern.

## Verification
`cargo test -p velesdb-wasm --lib` 541/0 · clippy pedantic clean · wasm32 check ok.