### PR TITLE
refactor(core): single-source graph edge-id derivation (wire::hash_edge_id)

### DIFF
--- a/crates/velesdb-core/src/database/ddl_executor_tests.rs
+++ b/crates/velesdb-core/src/database/ddl_executor_tests.rs
@@ -1,6 +1,5 @@
 //! Tests for DDL and extended DML executor (Phase 5).
 
-use super::dml_executor::hash_edge_id;
 use super::*;
 use crate::velesql::{
     AlterCollectionStatement, CompareOp, Comparison, Condition, CreateCollectionKind,
@@ -9,6 +8,7 @@ use crate::velesql::{
     InsertEdgeStatement, Query, SchemaDefinition, SelectEdgesStatement, Value,
     VectorCollectionParams,
 };
+use crate::wire::hash_edge_id;
 use tempfile::tempdir;
 
 // =========================================================================

--- a/crates/velesdb-core/src/database/dml_executor.rs
+++ b/crates/velesdb-core/src/database/dml_executor.rs
@@ -144,7 +144,7 @@ fn build_graph_edge(
 ) -> Result<crate::collection::GraphEdge> {
     let edge_id = stmt
         .edge_id
-        .unwrap_or_else(|| hash_edge_id(stmt.source, stmt.target, &stmt.label));
+        .unwrap_or_else(|| crate::wire::hash_edge_id(stmt.source, stmt.target, &stmt.label));
     let edge = crate::collection::GraphEdge::new(edge_id, stmt.source, stmt.target, &stmt.label)?;
 
     if stmt.properties.is_empty() {
@@ -152,44 +152,6 @@ fn build_graph_edge(
     }
     let props = resolve_edge_properties(&stmt.properties)?;
     Ok(edge.with_properties(props))
-}
-
-/// Generates a deterministic edge ID from (source, target, label) using FNV-1a.
-///
-/// # Determinism
-///
-/// The same (source, target, label) triple always produces the same ID.
-/// This means re-inserting the same edge without an explicit `id` is
-/// idempotent (overwrites the existing edge). To create multiple edges
-/// with the same (source, target, label), provide explicit `id` values
-/// in the SQL:
-///
-/// ```sql
-/// INSERT EDGE INTO kg (id = 100, source = 1, target = 2, label = 'KNOWS');
-/// INSERT EDGE INTO kg (id = 101, source = 1, target = 2, label = 'KNOWS');
-/// ```
-pub(super) fn hash_edge_id(source: u64, target: u64, label: &str) -> u64 {
-    // FNV-1a offset basis and prime for u64
-    const OFFSET_BASIS: u64 = 0xcbf2_9ce4_8422_2325;
-    const FNV_PRIME: u64 = 0x0100_0000_01b3;
-
-    let mut hash = OFFSET_BASIS;
-    // Mix source bytes
-    for byte in source.to_le_bytes() {
-        hash ^= u64::from(byte);
-        hash = hash.wrapping_mul(FNV_PRIME);
-    }
-    // Mix target bytes
-    for byte in target.to_le_bytes() {
-        hash ^= u64::from(byte);
-        hash = hash.wrapping_mul(FNV_PRIME);
-    }
-    // Mix label bytes
-    for byte in label.as_bytes() {
-        hash ^= u64::from(*byte);
-        hash = hash.wrapping_mul(FNV_PRIME);
-    }
-    hash
 }
 
 /// Resolves AST `Value` properties into a `HashMap<String, serde_json::Value>`.

--- a/crates/velesdb-core/src/lib.rs
+++ b/crates/velesdb-core/src/lib.rs
@@ -213,6 +213,9 @@ pub use validation::{
     validate_collection_name, validate_dimension, validate_dimension_match,
     MAX_COLLECTION_NAME_LENGTH, MAX_DIMENSION, MIN_DIMENSION,
 };
+// Canonical cross-engine edge-id derivation (FNV-1a over raw LE bytes).
+// Lives in `wire` so persistence-free targets (WASM) can delegate to it.
+pub use wire::hash_edge_id;
 
 #[cfg(feature = "persistence")]
 pub use column_store::{

--- a/crates/velesdb-core/src/wire/mod.rs
+++ b/crates/velesdb-core/src/wire/mod.rs
@@ -4,3 +4,39 @@
 //! dependency, so they compile on every target (including `wasm32`).
 
 pub mod vrb1;
+
+/// Generates a deterministic graph-edge ID from (source, target, label) using
+/// FNV-1a over the raw little-endian bytes of `source` and `target` followed by
+/// the UTF-8 bytes of `label`.
+///
+/// This is the canonical edge-id derivation shared across every `VelesDB` engine
+/// (core executor, WASM, migrate). Hashing the raw bytes — never a
+/// formatted/decimal string with separators — keeps the result stable and
+/// identical across crates, so the same logical edge always maps to the same
+/// id. Re-inserting that edge without an explicit `id` is therefore idempotent
+/// (it overwrites the existing edge); supply explicit `id` values to create
+/// multiple edges sharing the same (source, target, label) triple.
+///
+/// It lives in `wire` (persistence-free, `wasm32`-safe) so binding crates that
+/// build core without the `persistence` feature can still delegate to it.
+#[must_use]
+pub fn hash_edge_id(source: u64, target: u64, label: &str) -> u64 {
+    // FNV-1a offset basis and prime for u64
+    const OFFSET_BASIS: u64 = 0xcbf2_9ce4_8422_2325;
+    const FNV_PRIME: u64 = 0x0100_0000_01b3;
+
+    let mut hash = OFFSET_BASIS;
+    for byte in source.to_le_bytes() {
+        hash ^= u64::from(byte);
+        hash = hash.wrapping_mul(FNV_PRIME);
+    }
+    for byte in target.to_le_bytes() {
+        hash ^= u64::from(byte);
+        hash = hash.wrapping_mul(FNV_PRIME);
+    }
+    for byte in label.as_bytes() {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(FNV_PRIME);
+    }
+    hash
+}

--- a/crates/velesdb-migrate/src/pipeline_graph.rs
+++ b/crates/velesdb-migrate/src/pipeline_graph.rs
@@ -174,8 +174,10 @@ fn build_edge(
     let fk_str = value_to_id_str(fk_value)?;
     let to_node_id = stable_point_id(&fk_str);
 
-    let key = format!("{from_node_id}-{to_node_id}-{}", relation.edge_label);
-    let id = crate::pipeline::fnv1a64(key.as_bytes());
+    // Delegate to core's canonical edge-id derivation (FNV-1a over the raw
+    // LE bytes of source, target, label) so the same logical edge gets the
+    // same id as every other VelesDB engine.
+    let id = velesdb_core::hash_edge_id(from_node_id, to_node_id, &relation.edge_label);
 
     let edge = velesdb_core::GraphEdge::new(id, from_node_id, to_node_id, &relation.edge_label)
         .inspect_err(|e| warn!("Failed to create edge {}: {}", id, e))

--- a/crates/velesdb-wasm/src/graph_store.rs
+++ b/crates/velesdb-wasm/src/graph_store.rs
@@ -10,7 +10,8 @@
 //!
 //! - Nodes: `id (u64)` → optional JSON payload, optional label list.
 //! - Edges: append-only `Vec`, each entry `(id, source, target, label,
-//!   payload)`. Edge ids are monotonic counters starting at 1.
+//!   payload)`. Auto-assigned edge ids derive from core's canonical
+//!   `hash_edge_id(source, target, label)` so they match every other engine.
 //!
 //! Contention is not a concern because WASM is single-threaded.
 
@@ -46,7 +47,6 @@ pub struct WasmGraphNode {
 pub(crate) struct WasmGraphStore {
     nodes: HashMap<u64, WasmGraphNode>,
     edges: Vec<WasmEdge>,
-    next_edge_id: u64,
 }
 
 impl WasmGraphStore {
@@ -55,7 +55,6 @@ impl WasmGraphStore {
         Self {
             nodes: HashMap::new(),
             edges: Vec::new(),
-            next_edge_id: 1,
         }
     }
 
@@ -95,7 +94,9 @@ impl WasmGraphStore {
     // --- Edges -------------------------------------------------------------
 
     /// Inserts a directed edge. If `explicit_id` is `Some`, uses it; else
-    /// assigns the next monotonic id. Returns the final edge id.
+    /// derives the id via core's canonical [`velesdb_core::hash_edge_id`]
+    /// over (source, target, label) so the same logical edge matches the id
+    /// produced by every other VelesDB engine. Returns the final edge id.
     ///
     /// # Errors
     ///
@@ -103,8 +104,6 @@ impl WasmGraphStore {
     /// store. Without this check, `delete_edge_by_id(n)` would delete every
     /// duplicate at once — a data-integrity risk for user SQL like
     /// `INSERT EDGE (id = 1, ...)` executed twice (Devin Review Finding J).
-    /// Auto-assigned ids (via `next_edge_id`) are always unique by
-    /// construction and never fail this check.
     pub(crate) fn insert_edge(
         &mut self,
         explicit_id: Option<u64>,
@@ -121,17 +120,10 @@ impl WasmGraphStore {
             }
         }
         let id = explicit_id.unwrap_or_else(|| {
-            let next = self.next_edge_id;
-            self.next_edge_id = self.next_edge_id.saturating_add(1);
-            next
+            // Delegate to core's canonical edge-id derivation so the same
+            // logical edge gets the same id across every VelesDB engine.
+            velesdb_core::hash_edge_id(source, target, &label)
         });
-        if let Some(eid) = explicit_id {
-            // Keep `next_edge_id` ahead of any explicit id so future
-            // implicit inserts don't collide.
-            if eid >= self.next_edge_id {
-                self.next_edge_id = eid.saturating_add(1);
-            }
-        }
         self.edges.push(WasmEdge {
             id,
             source,
@@ -192,13 +184,12 @@ impl WasmGraphStore {
         }
     }
 
-    /// Removes every node and edge and resets the edge-id counter.
+    /// Removes every node and edge from the store.
     /// Used by `TRUNCATE COLLECTION` so the surrounding collection name
     /// keeps its identity but the graph data is wiped.
     pub(crate) fn clear(&mut self) {
         self.nodes.clear();
         self.edges.clear();
-        self.next_edge_id = 1;
     }
 }
 
@@ -219,7 +210,7 @@ mod tests {
     }
 
     #[test]
-    fn test_insert_edge_assigns_sequential_ids() {
+    fn test_insert_edge_auto_id_matches_core_canonical_hash() {
         let mut g = WasmGraphStore::new();
         let a = g
             .insert_edge(None, 1, 2, "KNOWS".to_string(), None)
@@ -227,7 +218,11 @@ mod tests {
         let b = g
             .insert_edge(None, 2, 3, "KNOWS".to_string(), None)
             .expect("test: insert b");
-        assert_eq!(a + 1, b);
+        // Auto-assigned ids come from core's canonical derivation, so the
+        // same (source, target, label) triple yields the same id everywhere.
+        assert_eq!(a, velesdb_core::hash_edge_id(1, 2, "KNOWS"));
+        assert_eq!(b, velesdb_core::hash_edge_id(2, 3, "KNOWS"));
+        assert_ne!(a, b, "distinct triples must yield distinct ids");
     }
 
     #[test]
@@ -276,14 +271,16 @@ mod tests {
     }
 
     #[test]
-    fn test_explicit_edge_id_updates_counter() {
+    fn test_auto_id_is_independent_of_prior_explicit_id() {
         let mut g = WasmGraphStore::new();
         g.insert_edge(Some(100), 1, 2, "X".to_string(), None)
             .expect("test: explicit id");
+        // A following auto insert derives its id from its own triple, not
+        // from any monotonic counter influenced by the explicit id.
         let next = g
             .insert_edge(None, 2, 3, "Y".to_string(), None)
             .expect("test: next");
-        assert_eq!(next, 101);
+        assert_eq!(next, velesdb_core::hash_edge_id(2, 3, "Y"));
     }
 
     // --- Finding J: duplicate explicit edge id rejection -----------------
@@ -306,8 +303,9 @@ mod tests {
 
     #[test]
     fn test_insert_edge_with_auto_assigned_id_never_collides() {
-        // Auto-assigned ids are monotonic; even after an explicit id bumps
-        // `next_edge_id`, subsequent `None` inserts keep succeeding.
+        // Auto-assigned ids derive from the canonical (source, target, label)
+        // hash; distinct triples yield distinct ids, so mixing one explicit
+        // edge with several distinct auto edges stays collision-free.
         let mut g = WasmGraphStore::new();
         g.insert_edge(Some(42), 1, 2, "KNOWS".to_string(), None)
             .expect("test: explicit");

--- a/crates/velesdb-wasm/src/velesql_exec_graph_tests.rs
+++ b/crates/velesdb-wasm/src/velesql_exec_graph_tests.rs
@@ -129,14 +129,21 @@ fn test_select_edges_filter_by_label() {
 fn test_delete_edge_by_id_returns_deletion() {
     let mut db = DatabaseInner::new();
     seed_graph(&mut db);
-    let r = execute(&mut db, "DELETE EDGE 1 FROM graph", None).expect("test: delete edge");
+    // The Alice->Bob edge auto-assigns the canonical (source, target, label) id.
+    let alice_bob = velesdb_core::hash_edge_id(1, 2, "KNOWS");
+    let r = execute(
+        &mut db,
+        &format!("DELETE EDGE {alice_bob} FROM graph"),
+        None,
+    )
+    .expect("test: delete edge");
     assert_eq!(r.kind(), "deletion");
     let after =
         execute(&mut db, "SELECT EDGES FROM graph", None).expect("test: edges after delete");
     assert_eq!(
         after.row_count(),
         1,
-        "exactly one edge must remain after deleting edge id 1"
+        "exactly one edge must remain after deleting the Alice->Bob edge"
     );
     let rows = after.rows_json();
     assert!(

--- a/crates/velesdb-wasm/src/velesql_graph_unit_tests.rs
+++ b/crates/velesdb-wasm/src/velesql_graph_unit_tests.rs
@@ -21,6 +21,28 @@ fn parse_match(sql: &str) -> Query {
     Parser::parse(sql).expect("test: parse")
 }
 
+/// Seeds the default 'graph' with node 1 (Alice:Person) -[HAS]-> node 2
+/// (Bob:Profile), used by the @collection enrichment MATCH tests.
+fn seed_person_profile_graph(db: &mut DatabaseInner) {
+    for (id, name, labels) in [(1u64, "Alice", vec!["Person"]), (2, "Bob", vec!["Profile"])] {
+        let stmt = InsertNodeStatement {
+            collection: "graph".to_string(),
+            node_id: id,
+            payload: serde_json::json!({"name": name, "labels": labels}),
+        };
+        insert_node(db, &stmt).expect("test: insert node");
+    }
+    let edge = InsertEdgeStatement {
+        collection: "graph".to_string(),
+        edge_id: None,
+        source: 1,
+        target: 2,
+        label: "HAS".to_string(),
+        properties: Vec::new(),
+    };
+    insert_edge(db, &edge, &Params::new()).expect("test: insert edge");
+}
+
 #[test]
 fn test_insert_node_creates_entry() {
     let mut db = DatabaseInner::new();
@@ -55,7 +77,8 @@ fn test_delete_edge_removes_entry() {
     insert_edge(&mut db, &ins, &Params::new()).expect("test: insert");
     let del = DeleteEdgeStatement {
         collection: "kg".to_string(),
-        edge_id: 1,
+        // Auto-assigned edge id = core's canonical (source, target, label) hash.
+        edge_id: velesdb_core::hash_edge_id(1, 2, "KNOWS"),
     };
     let n = delete_edge(&mut db, &del).expect("test: delete");
     assert_eq!(n, 1);
@@ -129,23 +152,7 @@ fn test_match_at_collection_enriches_referenced_node() {
     }
 
     // Default WASM graph 'graph': node 1 (Person) -[HAS]-> node 2 (Profile).
-    for (id, name, labels) in [(1u64, "Alice", vec!["Person"]), (2, "Bob", vec!["Profile"])] {
-        let stmt = InsertNodeStatement {
-            collection: "graph".to_string(),
-            node_id: id,
-            payload: serde_json::json!({"name": name, "labels": labels}),
-        };
-        insert_node(&mut db, &stmt).expect("test: insert node");
-    }
-    let edge = InsertEdgeStatement {
-        collection: "graph".to_string(),
-        edge_id: None,
-        source: 1,
-        target: 2,
-        label: "HAS".to_string(),
-        properties: Vec::new(),
-    };
-    insert_edge(&mut db, &edge, &Params::new()).expect("test: insert edge");
+    seed_person_profile_graph(&mut db);
 
     // The second node references 'profiles' for cross-collection enrichment.
     let q = parse_match("MATCH (a:Person)-[:HAS]->(b:Profile@profiles) RETURN a, b LIMIT 10");
@@ -171,23 +178,7 @@ fn test_match_at_collection_missing_collection_is_skipped() {
     // An @collection pointing at a non-existent vector collection must not
     // fail the MATCH — the graph results are returned un-enriched.
     let mut db = DatabaseInner::new();
-    for (id, name, labels) in [(1u64, "Alice", vec!["Person"]), (2, "Bob", vec!["Profile"])] {
-        let stmt = InsertNodeStatement {
-            collection: "graph".to_string(),
-            node_id: id,
-            payload: serde_json::json!({"name": name, "labels": labels}),
-        };
-        insert_node(&mut db, &stmt).expect("test: insert node");
-    }
-    let edge = InsertEdgeStatement {
-        collection: "graph".to_string(),
-        edge_id: None,
-        source: 1,
-        target: 2,
-        label: "HAS".to_string(),
-        properties: Vec::new(),
-    };
-    insert_edge(&mut db, &edge, &Params::new()).expect("test: insert edge");
+    seed_person_profile_graph(&mut db);
 
     let q = parse_match("MATCH (a:Person)-[:HAS]->(b:Profile@nope) RETURN a, b LIMIT 10");
     let rows = execute_match(&mut db, &q, &Params::new()).expect("test: match still succeeds");


### PR DESCRIPTION
## What (core-parity audit A2)
Auto-assigned graph edge IDs diverged across engines for the same logical edge: WASM used a monotonic counter, migrate hashed the decimal string `{from}-{to}-{label}` (with separators), core used FNV-1a over raw LE-bytes. Same edge → different id → broken idempotency/dedup across engines.

- Moved core's canonical derivation into `velesdb_core::wire::hash_edge_id(source, target, label)` — **byte-identical algorithm**, now `pub` and `wasm32`-safe (in `wire`, not the persistence-gated collection module), re-exported at crate root.
- Core executor, WASM `graph_store`, and migrate `pipeline_graph` all delegate to it. Removed WASM's dead `next_edge_id` counter.

## Behavior change
**Core edge ids are UNCHANGED** (same algorithm, relocated). WASM & migrate auto-assigned edge ids now match core — the intended correctness fix. Explicit edge ids unaffected. Tests asserting the old monotonic behavior were updated.

## Verification
core graph 622/0 + dml ok (–test-threads=1) · wasm 541/0 · migrate all green · clippy pedantic clean (core+wasm+migrate) · no-default-features + wasm32 ok.