### PR TITLE
refactor(migrate): single-source distance-metric canonicalization from core

### DIFF
--- a/crates/velesdb-migrate/src/config.rs
+++ b/crates/velesdb-migrate/src/config.rs
@@ -244,6 +244,13 @@ pub struct DestinationConfig {
 }
 
 /// Distance metric for `VelesDB`.
+///
+/// This enum is the migrate TOML config schema. Its accepted spellings and
+/// aliases are backward-compatibility surface and must not change. The mapping
+/// to the core type is authoritative-from-core: each variant exposes its
+/// core-canonical name via [`DistanceMetric::core_name`] and the [`From`] impl
+/// resolves it through [`velesdb_core::DistanceMetric::parse_alias`] (the
+/// single source of truth) instead of a hand-maintained match.
 #[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum DistanceMetric {
@@ -261,7 +268,40 @@ pub enum DistanceMetric {
     Jaccard,
 }
 
+impl DistanceMetric {
+    /// Core-canonical name accepted by
+    /// [`velesdb_core::DistanceMetric::parse_alias`].
+    #[must_use]
+    pub const fn core_name(self) -> &'static str {
+        match self {
+            Self::Cosine => "cosine",
+            Self::Euclidean => "euclidean",
+            Self::Dot => "dot",
+            Self::Hamming => "hamming",
+            Self::Jaccard => "jaccard",
+        }
+    }
+}
+
+impl From<DistanceMetric> for velesdb_core::DistanceMetric {
+    fn from(m: DistanceMetric) -> Self {
+        // Authoritative-from-core: every `core_name` is a known core alias, so
+        // this is infallible. The `Cosine` fallback keeps the conversion total
+        // without an `unwrap`; a `core_name` regression is caught by the unit
+        // tests (`test_distance_metric_aliases_deserialize_and_map_to_core`).
+        velesdb_core::DistanceMetric::parse_alias(m.core_name())
+            .unwrap_or(velesdb_core::DistanceMetric::Cosine)
+    }
+}
+
 /// Storage mode for `VelesDB`.
+///
+/// This enum is the migrate TOML config schema. Its accepted spellings and
+/// aliases are backward-compatibility surface and must not change. The mapping
+/// to the core type is authoritative-from-core: each variant exposes its
+/// core-canonical name via [`StorageMode::core_name`] and the [`From`] impl
+/// resolves it through [`velesdb_core::StorageMode::parse_alias`] (the single
+/// source of truth) instead of a hand-maintained match.
 #[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum StorageMode {
@@ -278,6 +318,32 @@ pub enum StorageMode {
     /// `RaBitQ`: 1-bit with rotation + scalar correction. 32x compression.
     #[serde(alias = "rabitq")]
     RaBitQ,
+}
+
+impl StorageMode {
+    /// Core-canonical name accepted by
+    /// [`velesdb_core::StorageMode::parse_alias`].
+    #[must_use]
+    pub const fn core_name(self) -> &'static str {
+        match self {
+            Self::Full => "full",
+            Self::SQ8 => "sq8",
+            Self::Binary => "binary",
+            Self::Pq => "pq",
+            Self::RaBitQ => "rabitq",
+        }
+    }
+}
+
+impl From<StorageMode> for velesdb_core::StorageMode {
+    fn from(m: StorageMode) -> Self {
+        // Authoritative-from-core: every `core_name` is a known core alias, so
+        // this is infallible. The `Full` fallback keeps the conversion total
+        // without an `unwrap`; a `core_name` regression is caught by the unit
+        // tests (`test_storage_mode_aliases_deserialize_and_map_to_core`).
+        velesdb_core::StorageMode::parse_alias(m.core_name())
+            .unwrap_or(velesdb_core::StorageMode::Full)
+    }
 }
 
 /// Migration options.
@@ -501,5 +567,94 @@ options:
         let config: MigrationConfig = serde_yaml::from_str(yaml).unwrap();
         assert_eq!(config.destination.dimension, 768);
         assert_eq!(config.options.batch_size, 500);
+    }
+
+    /// Backward-compatibility guard: every TOML spelling/alias accepted before
+    /// the core-mapping was routed through `velesdb_core` must still
+    /// deserialize AND map to the same core variant.
+    #[test]
+    fn test_distance_metric_aliases_deserialize_and_map_to_core() {
+        let cases: &[(&str, DistanceMetric, velesdb_core::DistanceMetric)] = &[
+            (
+                "cosine",
+                DistanceMetric::Cosine,
+                velesdb_core::DistanceMetric::Cosine,
+            ),
+            (
+                "euclidean",
+                DistanceMetric::Euclidean,
+                velesdb_core::DistanceMetric::Euclidean,
+            ),
+            (
+                "dot",
+                DistanceMetric::Dot,
+                velesdb_core::DistanceMetric::DotProduct,
+            ),
+            (
+                "DotProduct",
+                DistanceMetric::Dot,
+                velesdb_core::DistanceMetric::DotProduct,
+            ),
+            (
+                "dot_product",
+                DistanceMetric::Dot,
+                velesdb_core::DistanceMetric::DotProduct,
+            ),
+            (
+                "hamming",
+                DistanceMetric::Hamming,
+                velesdb_core::DistanceMetric::Hamming,
+            ),
+            (
+                "jaccard",
+                DistanceMetric::Jaccard,
+                velesdb_core::DistanceMetric::Jaccard,
+            ),
+        ];
+        for (spelling, expected_cfg, expected_core) in cases {
+            let parsed: DistanceMetric = serde_json::from_value(serde_json::json!(spelling))
+                .unwrap_or_else(|e| panic!("alias '{spelling}' must still deserialize: {e}"));
+            assert!(
+                matches!(
+                    (parsed, *expected_cfg),
+                    (DistanceMetric::Cosine, DistanceMetric::Cosine)
+                        | (DistanceMetric::Euclidean, DistanceMetric::Euclidean)
+                        | (DistanceMetric::Dot, DistanceMetric::Dot)
+                        | (DistanceMetric::Hamming, DistanceMetric::Hamming)
+                        | (DistanceMetric::Jaccard, DistanceMetric::Jaccard)
+                ),
+                "alias '{spelling}' deserialized to the wrong config variant"
+            );
+            assert_eq!(
+                velesdb_core::DistanceMetric::from(parsed),
+                *expected_core,
+                "alias '{spelling}' mapped to the wrong core metric"
+            );
+        }
+    }
+
+    /// Backward-compatibility guard for storage-mode TOML spellings/aliases.
+    #[test]
+    fn test_storage_mode_aliases_deserialize_and_map_to_core() {
+        let cases: &[(&str, velesdb_core::StorageMode)] = &[
+            ("full", velesdb_core::StorageMode::Full),
+            ("sq8", velesdb_core::StorageMode::SQ8),
+            ("binary", velesdb_core::StorageMode::Binary),
+            ("pq", velesdb_core::StorageMode::ProductQuantization),
+            (
+                "product_quantization",
+                velesdb_core::StorageMode::ProductQuantization,
+            ),
+            ("rabitq", velesdb_core::StorageMode::RaBitQ),
+        ];
+        for (spelling, expected_core) in cases {
+            let parsed: StorageMode = serde_json::from_value(serde_json::json!(spelling))
+                .unwrap_or_else(|e| panic!("alias '{spelling}' must still deserialize: {e}"));
+            assert_eq!(
+                velesdb_core::StorageMode::from(parsed),
+                *expected_core,
+                "alias '{spelling}' mapped to the wrong core storage mode"
+            );
+        }
     }
 }

--- a/crates/velesdb-migrate/src/pipeline.rs
+++ b/crates/velesdb-migrate/src/pipeline.rs
@@ -391,23 +391,11 @@ async fn apply_checkpoint_state(
 }
 
 fn map_core_metric(m: crate::config::DistanceMetric) -> velesdb_core::DistanceMetric {
-    match m {
-        crate::config::DistanceMetric::Cosine => velesdb_core::DistanceMetric::Cosine,
-        crate::config::DistanceMetric::Euclidean => velesdb_core::DistanceMetric::Euclidean,
-        crate::config::DistanceMetric::Dot => velesdb_core::DistanceMetric::DotProduct,
-        crate::config::DistanceMetric::Hamming => velesdb_core::DistanceMetric::Hamming,
-        crate::config::DistanceMetric::Jaccard => velesdb_core::DistanceMetric::Jaccard,
-    }
+    m.into()
 }
 
 fn map_core_storage_mode(m: crate::config::StorageMode) -> velesdb_core::StorageMode {
-    match m {
-        crate::config::StorageMode::Full => velesdb_core::StorageMode::Full,
-        crate::config::StorageMode::SQ8 => velesdb_core::StorageMode::SQ8,
-        crate::config::StorageMode::Binary => velesdb_core::StorageMode::Binary,
-        crate::config::StorageMode::Pq => velesdb_core::StorageMode::ProductQuantization,
-        crate::config::StorageMode::RaBitQ => velesdb_core::StorageMode::RaBitQ,
-    }
+    m.into()
 }
 
 async fn open_destination_db(
@@ -509,32 +497,26 @@ pub(crate) fn fnv1a64(bytes: &[u8]) -> u64 {
 }
 
 /// Normalises a source-reported metric label into its canonical lowercase
-/// identifier (matches `velesdb_core::DistanceMetric::from_str` aliases).
+/// identifier.
+///
+/// Delegates to [`velesdb_core::DistanceMetric::parse_alias`] — the single
+/// source of truth for metric aliases — so this crate cannot drift from the
+/// core vocabulary. Connectors already normalise their vendor-specific labels
+/// into the core vocabulary before populating `SourceSchema.metric`.
 ///
 /// Returns `None` when the label is empty or unknown — unknown values are
 /// intentionally preserved verbatim to [`check_metric_fidelity`] so the
 /// mismatch error carries the original string for diagnostics.
 fn canonicalise_source_metric(raw: &str) -> Option<&'static str> {
-    match raw.trim().to_ascii_lowercase().as_str() {
-        "cosine" | "cos" | "cosinesimilarity" => Some("cosine"),
-        "euclidean" | "euclid" | "l2" | "l2_distance" => Some("euclidean"),
-        "dot" | "dotproduct" | "ip" | "inner_product" => Some("dot"),
-        "hamming" => Some("hamming"),
-        "jaccard" => Some("jaccard"),
-        _ => None,
-    }
+    velesdb_core::DistanceMetric::parse_alias(raw).map(velesdb_core::DistanceMetric::canonical_name)
 }
 
 /// Returns the canonical lowercase string for a destination
 /// `DistanceMetric` selected in `MigrationConfig`.
 fn canonicalise_dest_metric(metric: crate::config::DistanceMetric) -> &'static str {
-    match metric {
-        crate::config::DistanceMetric::Cosine => "cosine",
-        crate::config::DistanceMetric::Euclidean => "euclidean",
-        crate::config::DistanceMetric::Dot => "dot",
-        crate::config::DistanceMetric::Hamming => "hamming",
-        crate::config::DistanceMetric::Jaccard => "jaccard",
-    }
+    // Single-sourced through the core type so the destination label always
+    // matches the core canonical name used on the source side.
+    velesdb_core::DistanceMetric::from(metric).canonical_name()
 }
 
 /// Verifies that the metric reported by the source (when present)


### PR DESCRIPTION
## What (core-parity audit B4 + B5)
- **B4:** `canonicalise_source_metric()` was a hand-maintained alias table whose doc claimed parity with `DistanceMetric::parse_alias` but had drifted. Now delegates to `velesdb_core::DistanceMetric::parse_alias(raw).map(canonical_name)`, preserving the None-on-unknown diagnostic contract.
- **B5:** kept `config::DistanceMetric`/`StorageMode` as the **backward-compatible TOML schema** (no serde spelling/alias changes) but removed the second source of truth — each enum now resolves the core type via `From<config::X>` impls that route through core's own `parse_alias`, instead of hand-rolled match arms.

## Behavior change
TOML config format **unchanged**; destination mapping output byte-identical. Migrate-only source aliases never emitted by any connector (`cos`, `euclid`, `l2_distance`, ...) no longer resolve (return None); core aliases the old table lacked (`l2`, `ip`) now do. Connectors normalize labels before this path, so migrations are unaffected. Added 2 alias-compat tests pinning every accepted TOML alias.

## Verification
`cargo test -p velesdb-migrate` all green (incl. 2 new tests) · clippy pedantic clean.