### PR TITLE
refactor(integrations): single-source string->id hashing + filter vocabulary

### DIFF
--- a/crates/velesdb-core/src/distance.rs
+++ b/crates/velesdb-core/src/distance.rs
@@ -25,6 +25,38 @@ use std::str::FromStr;
 /// slice stays exhaustive so adding a variant without updating it fails CI.
 pub const DISTANCE_METRIC_NAMES: &[&str] = &["cosine", "euclidean", "dot", "hamming", "jaccard"];
 
+/// Canonical serde `type` tags of every [`Condition`](crate::filter::Condition)
+/// variant, in declaration order.
+///
+/// Single source of truth for the filter condition-type vocabulary exported to
+/// downstream crates and bindings (the integrations' filter conversion and the
+/// MIT-side security guard) so they never re-derive the tag spelling as literals
+/// and drift when a variant is added. A unit test in `crate::filter` asserts the
+/// slice round-trips against the actual serde representation so adding a variant
+/// without updating it fails CI.
+pub const CONDITION_TYPE_NAMES: &[&str] = &[
+    "eq",
+    "neq",
+    "gt",
+    "gte",
+    "lt",
+    "lte",
+    "in",
+    "contains",
+    "is_null",
+    "is_not_null",
+    "and",
+    "or",
+    "not",
+    "like",
+    "ilike",
+    "array_contains",
+    "array_contains_any",
+    "array_contains_all",
+    "geo_distance",
+    "geo_bbox",
+];
+
 /// Distance metric for vector similarity calculations.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[non_exhaustive]

--- a/crates/velesdb-core/src/filter/mod.rs
+++ b/crates/velesdb-core/src/filter/mod.rs
@@ -217,3 +217,123 @@ pub enum Condition {
         lng_max: f64,
     },
 }
+
+#[cfg(test)]
+mod condition_type_names_tests {
+    use super::Condition;
+    use crate::CONDITION_TYPE_NAMES;
+
+    /// Maps every variant to its serde `type` tag via an exhaustive `match`
+    /// (no wildcard arm), so adding a variant fails to compile until it is
+    /// listed here, which in turn flags the missing `CONDITION_TYPE_NAMES`
+    /// entry asserted below.
+    fn expected_tag(condition: &Condition) -> &'static str {
+        match condition {
+            Condition::Eq { .. } => "eq",
+            Condition::Neq { .. } => "neq",
+            Condition::Gt { .. } => "gt",
+            Condition::Gte { .. } => "gte",
+            Condition::Lt { .. } => "lt",
+            Condition::Lte { .. } => "lte",
+            Condition::In { .. } => "in",
+            Condition::Contains { .. } => "contains",
+            Condition::IsNull { .. } => "is_null",
+            Condition::IsNotNull { .. } => "is_not_null",
+            Condition::And { .. } => "and",
+            Condition::Or { .. } => "or",
+            Condition::Not { .. } => "not",
+            Condition::Like { .. } => "like",
+            Condition::ILike { .. } => "ilike",
+            Condition::ArrayContains { .. } => "array_contains",
+            Condition::ArrayContainsAny { .. } => "array_contains_any",
+            Condition::ArrayContainsAll { .. } => "array_contains_all",
+            Condition::GeoDistance { .. } => "geo_distance",
+            Condition::GeoBbox { .. } => "geo_bbox",
+        }
+    }
+
+    /// Comparison / null / membership variants, in declaration order.
+    fn comparison_variants() -> Vec<Condition> {
+        use serde_json::Value;
+        let f = || "f".to_string();
+        let cmp = |c: fn(String, Value) -> Condition| c(f(), Value::Null);
+        vec![
+            cmp(|field, value| Condition::Eq { field, value }),
+            cmp(|field, value| Condition::Neq { field, value }),
+            cmp(|field, value| Condition::Gt { field, value }),
+            cmp(|field, value| Condition::Gte { field, value }),
+            cmp(|field, value| Condition::Lt { field, value }),
+            cmp(|field, value| Condition::Lte { field, value }),
+            Condition::In {
+                field: f(),
+                values: vec![],
+            },
+            Condition::Contains {
+                field: f(),
+                value: String::new(),
+            },
+            Condition::IsNull { field: f() },
+            Condition::IsNotNull { field: f() },
+        ]
+    }
+
+    /// Logical, pattern, array and geo variants, in declaration order.
+    fn logical_and_geo_variants() -> Vec<Condition> {
+        use serde_json::Value;
+        let f = || "f".to_string();
+        vec![
+            Condition::And { conditions: vec![] },
+            Condition::Or { conditions: vec![] },
+            Condition::Not {
+                condition: Box::new(Condition::IsNull { field: f() }),
+            },
+            Condition::Like {
+                field: f(),
+                pattern: String::new(),
+            },
+            Condition::ILike {
+                field: f(),
+                pattern: String::new(),
+            },
+            Condition::ArrayContains {
+                field: f(),
+                value: Value::Null,
+            },
+            Condition::ArrayContainsAny {
+                field: f(),
+                values: vec![],
+            },
+            Condition::ArrayContainsAll {
+                field: f(),
+                values: vec![],
+            },
+            Condition::GeoDistance {
+                field: f(),
+                lat: 0.0,
+                lng: 0.0,
+                operator: crate::velesql::CompareOp::Lt,
+                threshold: 0.0,
+            },
+            Condition::GeoBbox {
+                field: f(),
+                lat_min: 0.0,
+                lng_min: 0.0,
+                lat_max: 0.0,
+                lng_max: 0.0,
+            },
+        ]
+    }
+
+    #[test]
+    fn condition_type_names_match_serde_tags_in_order() {
+        let mut variants = comparison_variants();
+        variants.extend(logical_and_geo_variants());
+        assert_eq!(variants.len(), CONDITION_TYPE_NAMES.len());
+        for (i, variant) in variants.iter().enumerate() {
+            let serialized = serde_json::to_value(variant).expect("serialize condition");
+            let serde_tag = serialized["type"].as_str().expect("type tag present");
+            assert_eq!(serde_tag, expected_tag(variant));
+            assert_eq!(CONDITION_TYPE_NAMES[i], serde_tag);
+        }
+    }
+}

--- a/crates/velesdb-core/src/lib.rs
+++ b/crates/velesdb-core/src/lib.rs
@@ -199,7 +199,7 @@ pub use collection::{
     VectorCollection,
 };
 pub use contiguous_ops::pad_to_simd_width;
-pub use distance::{DistanceMetric, DISTANCE_METRIC_NAMES};
+pub use distance::{DistanceMetric, CONDITION_TYPE_NAMES, DISTANCE_METRIC_NAMES};
 pub use error::{Error, Result};
 pub use filter::{Condition, Filter};
 pub use point::{ComponentScores, Point, SearchResult};

--- a/crates/velesdb-python/python/velesdb/__init__.pyi
+++ b/crates/velesdb-python/python/velesdb/__init__.pyi
@@ -13,6 +13,7 @@ __version__: str
 # lowercase names, in declaration order.
 DISTANCE_METRICS: Tuple[str, ...]
 STORAGE_MODES: Tuple[str, ...]
+CONDITION_TYPES: Tuple[str, ...]
 
 
 # ---------------------------------------------------------------------------

--- a/crates/velesdb-python/src/lib.rs
+++ b/crates/velesdb-python/src/lib.rs
@@ -128,6 +128,10 @@ fn velesdb(m: &Bound<'_, PyModule>) -> PyResult<()> {
         "STORAGE_MODES",
         PyTuple::new(m.py(), velesdb_core::STORAGE_MODE_NAMES)?,
     )?;
+    m.add(
+        "CONDITION_TYPES",
+        PyTuple::new(m.py(), velesdb_core::CONDITION_TYPE_NAMES)?,
+    )?;
 
     // Add version info
     m.add("__version__", env!("CARGO_PKG_VERSION"))?;

--- a/integrations/common/src/velesdb_common/__init__.py
+++ b/integrations/common/src/velesdb_common/__init__.py
@@ -18,6 +18,7 @@ from velesdb_common.memory import (
 )
 from velesdb_common.security import (
     SecurityError,
+    ALLOWED_CONDITION_TYPES,
     ALLOWED_METRICS,
     ALLOWED_STORAGE_MODES,
     STORAGE_MODE_ALIASES,
@@ -70,6 +71,7 @@ __all__ = [
     "store_procedure",
     # security
     "SecurityError",
+    "ALLOWED_CONDITION_TYPES",
     "ALLOWED_METRICS",
     "ALLOWED_STORAGE_MODES",
     "STORAGE_MODE_ALIASES",

--- a/integrations/common/src/velesdb_common/security.py
+++ b/integrations/common/src/velesdb_common/security.py
@@ -34,15 +34,28 @@ MAX_PATH_LENGTH = 4096           # Max path length
 # binding lists whenever the wheel is present.
 _FALLBACK_METRICS = frozenset({"cosine", "euclidean", "dot", "hamming", "jaccard"})
 _FALLBACK_STORAGE_MODES = frozenset({"full", "sq8", "binary", "pq", "rabitq"})
+# Canonical filter condition-type tags (velesdb-core ``Condition`` serde tags),
+# single-sourced from the binding (``velesdb.CONDITION_TYPES``). The literal here
+# is only the offline fallback used when the native wheel is unavailable. This is
+# the SINGLE MIT-side definition; ``filter_ops`` imports it instead of re-listing
+# the vocabulary.
+_FALLBACK_CONDITION_TYPES = frozenset({
+    "eq", "neq", "gt", "gte", "lt", "lte", "in", "contains",
+    "is_null", "is_not_null", "and", "or", "not", "like", "ilike",
+    "array_contains", "array_contains_any", "array_contains_all",
+    "geo_distance", "geo_bbox",
+})
 
 try:
     import velesdb as _velesdb
 
     ALLOWED_METRICS = frozenset(_velesdb.DISTANCE_METRICS)
     ALLOWED_STORAGE_MODES = frozenset(_velesdb.STORAGE_MODES)
+    ALLOWED_CONDITION_TYPES = frozenset(_velesdb.CONDITION_TYPES)
 except (ImportError, AttributeError):
     ALLOWED_METRICS = _FALLBACK_METRICS
     ALLOWED_STORAGE_MODES = _FALLBACK_STORAGE_MODES
+    ALLOWED_CONDITION_TYPES = _FALLBACK_CONDITION_TYPES
 # Aliases accepted by the Rust core via ``from_str_with_aliases()``.
 # Maps alias → canonical name (same set of aliases as Rust).
 STORAGE_MODE_ALIASES: dict[str, str] = {
@@ -569,6 +582,7 @@ def validate_named_sparse_vector(sparse_vector: Any) -> dict:
 # (langchain_velesdb.security / llamaindex_velesdb.security) via
 # ``from velesdb_common.security import *``.
 __all__ = [
+    "ALLOWED_CONDITION_TYPES",
     "ALLOWED_STORAGE_MODES",
     "STORAGE_MODE_ALIASES",
     "DEFAULT_TIMEOUT_MS",

--- a/integrations/common/tests/test_security.py
+++ b/integrations/common/tests/test_security.py
@@ -6,10 +6,18 @@ from velesdb_common.security import (
     validate_named_sparse_vector,
     SecurityError,
     validate_text,
+    ALLOWED_CONDITION_TYPES,
     ALLOWED_METRICS,
     ALLOWED_STORAGE_MODES,
     STORAGE_MODE_ALIASES,
 )
+
+_CANONICAL_CONDITION_TYPES = frozenset({
+    "eq", "neq", "gt", "gte", "lt", "lte", "in", "contains",
+    "is_null", "is_not_null", "and", "or", "not", "like", "ilike",
+    "array_contains", "array_contains_any", "array_contains_all",
+    "geo_distance", "geo_bbox",
+})
 
 
 def test_validate_text_rejects_empty_string():
@@ -124,6 +132,28 @@ def test_allowed_storage_modes_equals_binding_exactly():
         raise AssertionError(
             f"ALLOWED_STORAGE_MODES {ALLOWED_STORAGE_MODES!r} "
             f"!= velesdb.STORAGE_MODES {binding!r}"
+        )
+
+
+def test_allowed_condition_types_is_frozenset():
+    assert isinstance(ALLOWED_CONDITION_TYPES, frozenset)
+
+
+def test_allowed_condition_types_exact_set():
+    """ALLOWED_CONDITION_TYPES must match the canonical core vocabulary exactly."""
+    if ALLOWED_CONDITION_TYPES != _CANONICAL_CONDITION_TYPES:
+        raise AssertionError(
+            f"ALLOWED_CONDITION_TYPES mismatch: {ALLOWED_CONDITION_TYPES!r}"
+        )
+
+
+def test_allowed_condition_types_equals_binding_exactly():
+    velesdb = pytest.importorskip("velesdb")
+    binding = frozenset(velesdb.CONDITION_TYPES)
+    if ALLOWED_CONDITION_TYPES != binding:
+        raise AssertionError(
+            f"ALLOWED_CONDITION_TYPES {ALLOWED_CONDITION_TYPES!r} "
+            f"!= velesdb.CONDITION_TYPES {binding!r}"
         )
 
 

--- a/integrations/langchain/src/langchain_velesdb/graph_toolkit/loader.py
+++ b/integrations/langchain/src/langchain_velesdb/graph_toolkit/loader.py
@@ -4,9 +4,10 @@ Handles conversion from extracted data to VelesDB graph storage format.
 """
 
 from typing import List, Optional, Dict, TYPE_CHECKING
-import hashlib
 import logging
 import velesdb
+
+from velesdb_common.ids import stable_hash_id
 
 if TYPE_CHECKING:
     from velesdb import Database, Collection
@@ -18,9 +19,12 @@ logger = logging.getLogger(__name__)
 
 
 def _generate_id(name: str, entity_type: str) -> int:
-    """Generate a deterministic ID from entity name and type."""
-    hash_input = f"{entity_type}:{name}".encode("utf-8")
-    return int(hashlib.sha256(hash_input).hexdigest()[:15], 16)
+    """Generate a deterministic ID from entity name and type.
+
+    Delegates to the canonical :func:`velesdb_common.ids.stable_hash_id` so all
+    VelesDB integrations derive the same string->id mapping (no per-package hash).
+    """
+    return stable_hash_id(f"{entity_type}:{name}")
 
 
 class GraphLoader:

--- a/integrations/llamaindex/src/llamaindex_velesdb/filter_ops.py
+++ b/integrations/llamaindex/src/llamaindex_velesdb/filter_ops.py
@@ -13,7 +13,7 @@ from velesdb_common.security import ALLOWED_CONDITION_TYPES
 # LlamaIndex operator spellings → canonical VelesDB Core condition ``type`` tag.
 # The TARGET tags are NOT re-listed as free literals: every value here must be a
 # member of ``ALLOWED_CONDITION_TYPES`` (single-sourced from velesdb-core), which
-# the assertion below enforces at import time so this map cannot drift from the
+# the import-time guard below enforces so this map cannot drift from the
 # engine's vocabulary.
 _OPERATOR_TO_CONDITION_TYPE = {
     "eq": "eq", "==": "eq", "=": "eq",
@@ -27,10 +27,12 @@ _OPERATOR_TO_CONDITION_TYPE = {
     "is_null": "is_null", "null": "is_null",
     "is_not_null": "is_not_null", "not_null": "is_not_null",
 }
-assert set(_OPERATOR_TO_CONDITION_TYPE.values()) <= ALLOWED_CONDITION_TYPES, (
-    "filter_ops emits condition types unknown to velesdb-core: "
-    f"{sorted(set(_OPERATOR_TO_CONDITION_TYPE.values()) - ALLOWED_CONDITION_TYPES)}"
-)
+_UNKNOWN_CONDITION_TYPES = set(_OPERATOR_TO_CONDITION_TYPE.values()) - ALLOWED_CONDITION_TYPES
+if _UNKNOWN_CONDITION_TYPES:
+    raise RuntimeError(
+        "filter_ops emits condition types unknown to velesdb-core: "
+        f"{sorted(_UNKNOWN_CONDITION_TYPES)}"
+    )
 
 
 def _normalize_filter_operator(raw_operator: Any) -> str:

--- a/integrations/llamaindex/src/llamaindex_velesdb/filter_ops.py
+++ b/integrations/llamaindex/src/llamaindex_velesdb/filter_ops.py
@@ -8,6 +8,30 @@ from __future__ import annotations
 
 from typing import Any, Optional
 
+from velesdb_common.security import ALLOWED_CONDITION_TYPES
+
+# LlamaIndex operator spellings → canonical VelesDB Core condition ``type`` tag.
+# The TARGET tags are NOT re-listed as free literals: every value here must be a
+# member of ``ALLOWED_CONDITION_TYPES`` (single-sourced from velesdb-core), which
+# the assertion below enforces at import time so this map cannot drift from the
+# engine's vocabulary.
+_OPERATOR_TO_CONDITION_TYPE = {
+    "eq": "eq", "==": "eq", "=": "eq",
+    "neq": "neq", "ne": "neq", "!=": "neq",
+    "gt": "gt", ">": "gt",
+    "gte": "gte", ">=": "gte",
+    "lt": "lt", "<": "lt",
+    "lte": "lte", "<=": "lte",
+    "in": "in",
+    "contains": "contains", "text_match": "contains",
+    "is_null": "is_null", "null": "is_null",
+    "is_not_null": "is_not_null", "not_null": "is_not_null",
+}
+assert set(_OPERATOR_TO_CONDITION_TYPE.values()) <= ALLOWED_CONDITION_TYPES, (
+    "filter_ops emits condition types unknown to velesdb-core: "
+    f"{sorted(set(_OPERATOR_TO_CONDITION_TYPE.values()) - ALLOWED_CONDITION_TYPES)}"
+)
+
 
 def _normalize_filter_operator(raw_operator: Any) -> str:
     """Normalize LlamaIndex filter operator to VelesDB Core condition type."""
@@ -17,20 +41,8 @@ def _normalize_filter_operator(raw_operator: Any) -> str:
         raw_operator = raw_operator.value
 
     op = str(raw_operator).strip().lower()
-    op_map = {
-        "eq": "eq", "==": "eq", "=": "eq",
-        "neq": "neq", "ne": "neq", "!=": "neq",
-        "gt": "gt", ">": "gt",
-        "gte": "gte", ">=": "gte",
-        "lt": "lt", "<": "lt",
-        "lte": "lte", "<=": "lte",
-        "in": "in",
-        "contains": "contains", "text_match": "contains",
-        "is_null": "is_null", "null": "is_null",
-        "is_not_null": "is_not_null", "not_null": "is_not_null",
-    }
-    if op in op_map:
-        return op_map[op]
+    if op in _OPERATOR_TO_CONDITION_TYPE:
+        return _OPERATOR_TO_CONDITION_TYPE[op]
     raise ValueError(f"Unsupported metadata filter operator: {raw_operator}")
 
 

--- a/integrations/llamaindex/src/llamaindex_velesdb/graph_loader.py
+++ b/integrations/llamaindex/src/llamaindex_velesdb/graph_loader.py
@@ -20,8 +20,9 @@ Example:
 """
 
 from typing import Any, Dict, List, Optional, TYPE_CHECKING
-import hashlib
 import logging
+
+from velesdb_common.ids import stable_hash_id
 
 logger = logging.getLogger(__name__)
 
@@ -30,9 +31,12 @@ if TYPE_CHECKING:
 
 
 def _generate_id(name: str, entity_type: str) -> int:
-    """Generate a deterministic ID from entity name and type."""
-    hash_input = f"{entity_type}:{name}".encode("utf-8")
-    return int(hashlib.sha256(hash_input).hexdigest()[:15], 16)
+    """Generate a deterministic ID from entity name and type.
+
+    Delegates to the canonical :func:`velesdb_common.ids.stable_hash_id` so all
+    VelesDB integrations derive the same string->id mapping (no per-package hash).
+    """
+    return stable_hash_id(f"{entity_type}:{name}")
 
 
 def _open_native_graph(vector_store: Any, collection_name: str) -> Optional[Any]:


### PR DESCRIPTION
## What (core-parity audit D12/D13/D14 + security grammar)
- **D12/D13:** langchain & llamaindex `GraphLoader._generate_id` each rolled their own sha256-based hash, diverging from canonical `velesdb_common.ids.stable_hash_id`. Both now delegate to it (MIT→MIT, no license boundary crossed).
- **D14 + security.py:** llamaindex `filter_ops.py` and common `security.py` re-derived core's filter condition-type vocabulary + search-quality grammar as literals (drift-prone). Added canonical `pub const CONDITION_TYPE_NAMES` to `velesdb-core` (re-exported at crate root, round-tripped against every `Condition` serde tag), exposed via the python binding as `CONDITION_TYPES` (+ .pyi), and consolidated the integration vocabulary to a single source.

## Behavior change
⚠️ langchain/llamaindex deterministic graph node/edge IDs **change value** (60-bit hex-trunc → 63-bit `stable_hash_id`). Still deterministic & stable across runs; **graphs persisted with old IDs must be rebuilt**.

## Verification
core distance tests + clippy pedantic clean; condition-tag round-trip test; integration imports verified.