### PR TITLE
fix(mobile): carry canonical VELES-### error code through the binding

### DIFF
--- a/crates/velesdb-mobile/src/agent.rs
+++ b/crates/velesdb-mobile/src/agent.rs
@@ -64,9 +64,9 @@ impl VelesSemanticMemory {
                     DistanceMetric::Cosine,
                 )?;
                 db.get_collection(collection_name.to_string())?
-                    .ok_or(VelesError::Database {
-                        message: "Failed to retrieve collection after creation".to_string(),
-                    })?
+                    .ok_or(VelesError::database(
+                        "Failed to retrieve collection after creation".to_string(),
+                    ))?
             }
         };
 
@@ -78,12 +78,8 @@ impl VelesSemanticMemory {
     /// The content text is persisted in the point payload as `{"content": ...}`
     /// so it survives a database reload.
     pub fn store(&self, id: u64, content: String, embedding: Vec<f32>) -> Result<(), VelesError> {
-        let payload =
-            serde_json::to_string(&serde_json::json!({ "content": content })).map_err(|e| {
-                VelesError::Database {
-                    message: format!("Failed to encode content payload: {e}"),
-                }
-            })?;
+        let payload = serde_json::to_string(&serde_json::json!({ "content": content }))
+            .map_err(|e| VelesError::database(format!("Failed to encode content payload: {e}")))?;
         let point = VelesPoint {
             id,
             vector: embedding,

--- a/crates/velesdb-mobile/src/collection.rs
+++ b/crates/velesdb-mobile/src/collection.rs
@@ -184,9 +184,7 @@ impl VelesCollection {
         let results = self
             .inner
             .text_search(&query, usize::try_from(limit).unwrap_or(usize::MAX))
-            .map_err(|e| VelesError::Database {
-                message: format!("Text search failed: {e}"),
-            })?;
+            .map_err(|e| VelesError::database(format!("Text search failed: {e}")))?;
 
         Ok(results
             .into_iter()
@@ -252,10 +250,8 @@ impl VelesCollection {
         filter_json: String,
     ) -> Result<Vec<SearchResult>, VelesError> {
         // Parse filter JSON
-        let filter: velesdb_core::Filter =
-            serde_json::from_str(&filter_json).map_err(|e| VelesError::Database {
-                message: format!("Invalid filter JSON: {e}"),
-            })?;
+        let filter: velesdb_core::Filter = serde_json::from_str(&filter_json)
+            .map_err(|e| VelesError::database(format!("Invalid filter JSON: {e}")))?;
 
         let results = self.inner.search_with_filter(
             &vector,
@@ -294,8 +290,8 @@ impl VelesCollection {
                 s.filter
                     .as_ref()
                     .map(|f_json| {
-                        serde_json::from_str(f_json).map_err(|e| VelesError::Database {
-                            message: format!("Invalid filter JSON in batch: {e}"),
+                        serde_json::from_str(f_json).map_err(|e| {
+                            VelesError::database(format!("Invalid filter JSON in batch: {e}"))
                         })
                     })
                     .transpose()
@@ -343,10 +339,8 @@ impl VelesCollection {
         limit: u32,
         filter_json: String,
     ) -> Result<Vec<SearchResult>, VelesError> {
-        let filter: velesdb_core::Filter =
-            serde_json::from_str(&filter_json).map_err(|e| VelesError::Database {
-                message: format!("Invalid filter JSON: {e}"),
-            })?;
+        let filter: velesdb_core::Filter = serde_json::from_str(&filter_json)
+            .map_err(|e| VelesError::database(format!("Invalid filter JSON: {e}")))?;
 
         let results = self
             .inner
@@ -355,9 +349,7 @@ impl VelesCollection {
                 usize::try_from(limit).unwrap_or(usize::MAX),
                 &filter,
             )
-            .map_err(|e| VelesError::Database {
-                message: format!("Text search with filter failed: {e}"),
-            })?;
+            .map_err(|e| VelesError::database(format!("Text search with filter failed: {e}")))?;
 
         Ok(results
             .into_iter()
@@ -386,10 +378,8 @@ impl VelesCollection {
         vector_weight: f32,
         filter_json: String,
     ) -> Result<Vec<SearchResult>, VelesError> {
-        let filter: velesdb_core::Filter =
-            serde_json::from_str(&filter_json).map_err(|e| VelesError::Database {
-                message: format!("Invalid filter JSON: {e}"),
-            })?;
+        let filter: velesdb_core::Filter = serde_json::from_str(&filter_json)
+            .map_err(|e| VelesError::database(format!("Invalid filter JSON: {e}")))?;
 
         let results = self.inner.hybrid_search_with_filter(
             &vector,
@@ -434,27 +424,21 @@ impl VelesCollection {
         params_json: Option<String>,
     ) -> Result<Vec<SearchResult>, VelesError> {
         // Parse the VelesQL query
-        let parsed =
-            velesdb_core::velesql::Parser::parse(&query_str).map_err(|e| VelesError::Database {
-                message: format!("VelesQL parse error: {}", e.message),
-            })?;
+        let parsed = velesdb_core::velesql::Parser::parse(&query_str)
+            .map_err(|e| VelesError::database(format!("VelesQL parse error: {}", e.message)))?;
 
         // Parse params from JSON if provided
         let params: std::collections::HashMap<String, serde_json::Value> = params_json
             .map(|json| serde_json::from_str(&json))
             .transpose()
-            .map_err(|e| VelesError::Database {
-                message: format!("Invalid params JSON: {e}"),
-            })?
+            .map_err(|e| VelesError::database(format!("Invalid params JSON: {e}")))?
             .unwrap_or_default();
 
         // Execute the query
-        let results =
-            self.inner
-                .execute_query(&parsed, &params)
-                .map_err(|e| VelesError::Database {
-                    message: format!("Query execution failed: {e}"),
-                })?;
+        let results = self
+            .inner
+            .execute_query(&parsed, &params)
+            .map_err(|e| VelesError::database(format!("Query execution failed: {e}")))?;
 
         Ok(results
             .into_iter()
@@ -509,12 +493,11 @@ impl VelesCollection {
         let core_points: Result<Vec<velesdb_core::Point>, VelesError> =
             points.into_iter().map(parse_point).collect();
 
-        let queued =
-            self.inner
-                .stream_insert_batch(core_points?)
-                .map_err(|e| VelesError::Database {
-                    message: format!("Stream insert failed (buffer full or not configured): {e}"),
-                })?;
+        let queued = self.inner.stream_insert_batch(core_points?).map_err(|e| {
+            VelesError::database(format!(
+                "Stream insert failed (buffer full or not configured): {e}"
+            ))
+        })?;
         Ok(u64::try_from(queued).unwrap_or(u64::MAX))
     }
 
@@ -628,9 +611,7 @@ fn parse_point(p: VelesPoint) -> Result<velesdb_core::Point, VelesError> {
         .payload
         .map(|s| serde_json::from_str(&s))
         .transpose()
-        .map_err(|e| VelesError::Database {
-            message: format!("Invalid JSON payload: {e}"),
-        })?;
+        .map_err(|e| VelesError::database(format!("Invalid JSON payload: {e}")))?;
     Ok(velesdb_core::Point::new(p.id, p.vector, payload))
 }
 

--- a/crates/velesdb-mobile/src/collection_sparse.rs
+++ b/crates/velesdb-mobile/src/collection_sparse.rs
@@ -36,9 +36,7 @@ impl VelesCollection {
                 usize::try_from(limit).unwrap_or(usize::MAX),
                 &idx_name,
             )
-            .map_err(|e| VelesError::Database {
-                message: format!("Sparse search failed: {e}"),
-            })?;
+            .map_err(|e| VelesError::database(format!("Sparse search failed: {e}")))?;
 
         Ok(results
             .into_iter()
@@ -85,9 +83,7 @@ impl VelesCollection {
                 &idx_name,
                 &strategy,
             )
-            .map_err(|e| VelesError::Database {
-                message: format!("Hybrid sparse search failed: {e}"),
-            })?;
+            .map_err(|e| VelesError::database(format!("Hybrid sparse search failed: {e}")))?;
 
         Ok(results
             .into_iter()
@@ -107,9 +103,9 @@ impl VelesCollection {
         strategy: FusionStrategy,
     ) -> Result<Vec<SearchResult>, VelesError> {
         if vectors.is_empty() {
-            return Err(VelesError::Database {
-                message: "multi_query_search requires at least one vector".to_string(),
-            });
+            return Err(VelesError::database(
+                "multi_query_search requires at least one vector".to_string(),
+            ));
         }
 
         let query_refs: Vec<&[f32]> = vectors.iter().map(|v| v.as_slice()).collect();
@@ -123,9 +119,7 @@ impl VelesCollection {
                 core_strategy,
                 None,
             )
-            .map_err(|e| VelesError::Database {
-                message: format!("Multi-query search failed: {e}"),
-            })?;
+            .map_err(|e| VelesError::database(format!("Multi-query search failed: {e}")))?;
 
         Ok(results
             .into_iter()
@@ -148,9 +142,9 @@ impl VelesCollection {
         strategy: FusionStrategy,
     ) -> Result<Vec<SearchResult>, VelesError> {
         if vectors.is_empty() {
-            return Err(VelesError::Database {
-                message: "multi_query_search requires at least one vector".to_string(),
-            });
+            return Err(VelesError::database(
+                "multi_query_search requires at least one vector".to_string(),
+            ));
         }
 
         let query_refs: Vec<&[f32]> = vectors.iter().map(|v| v.as_slice()).collect();
@@ -163,9 +157,7 @@ impl VelesCollection {
                 usize::try_from(limit).unwrap_or(usize::MAX),
                 core_strategy,
             )
-            .map_err(|e| VelesError::Database {
-                message: format!("Multi-query search failed: {e}"),
-            })?;
+            .map_err(|e| VelesError::database(format!("Multi-query search failed: {e}")))?;
 
         Ok(results
             .into_iter()
@@ -186,15 +178,13 @@ impl VelesCollection {
         filter_json: String,
     ) -> Result<Vec<SearchResult>, VelesError> {
         if vectors.is_empty() {
-            return Err(VelesError::Database {
-                message: "multi_query_search requires at least one vector".to_string(),
-            });
+            return Err(VelesError::database(
+                "multi_query_search requires at least one vector".to_string(),
+            ));
         }
 
-        let filter: velesdb_core::Filter =
-            serde_json::from_str(&filter_json).map_err(|e| VelesError::Database {
-                message: format!("Invalid filter JSON: {e}"),
-            })?;
+        let filter: velesdb_core::Filter = serde_json::from_str(&filter_json)
+            .map_err(|e| VelesError::database(format!("Invalid filter JSON: {e}")))?;
 
         let query_refs: Vec<&[f32]> = vectors.iter().map(|v| v.as_slice()).collect();
         let core_strategy: CoreFusionStrategy = strategy.into();
@@ -207,9 +197,7 @@ impl VelesCollection {
                 core_strategy,
                 Some(&filter),
             )
-            .map_err(|e| VelesError::Database {
-                message: format!("Multi-query search failed: {e}"),
-            })?;
+            .map_err(|e| VelesError::database(format!("Multi-query search failed: {e}")))?;
 
         Ok(results
             .into_iter()
@@ -236,9 +224,7 @@ impl VelesCollection {
             .payload
             .map(|s| serde_json::from_str(&s))
             .transpose()
-            .map_err(|e| VelesError::Database {
-                message: format!("Invalid JSON payload: {e}"),
-            })?;
+            .map_err(|e| VelesError::database(format!("Invalid JSON payload: {e}")))?;
 
         let core_sv = Self::to_core_sparse_vector(&sparse_vector);
         let mut sparse_map = std::collections::BTreeMap::new();

--- a/crates/velesdb-mobile/src/graph.rs
+++ b/crates/velesdb-mobile/src/graph.rs
@@ -143,9 +143,10 @@ impl MobileGraphStore {
         let mut incoming = self.incoming.write();
 
         if edges.contains_key(&edge.id) {
-            return Err(crate::VelesError::Database {
-                message: format!("Edge with ID {} already exists", edge.id),
-            });
+            return Err(crate::VelesError::database(format!(
+                "Edge with ID {} already exists",
+                edge.id
+            )));
         }
 
         let source = edge.source;

--- a/crates/velesdb-mobile/src/lib.rs
+++ b/crates/velesdb-mobile/src/lib.rs
@@ -293,9 +293,7 @@ impl VelesDatabase {
         let empty_params = HashMap::new();
         self.inner
             .execute_query(&query, &empty_params)
-            .map_err(|e| VelesError::Database {
-                message: format!("PQ training failed: {e}"),
-            })?;
+            .map_err(|e| VelesError::database(format!("PQ training failed: {e}")))?;
 
         Ok("PQ training complete".to_string())
     }
@@ -336,20 +334,16 @@ impl VelesDatabase {
         sql: String,
         params_json: Option<String>,
     ) -> Result<QueryResult, VelesError> {
-        let parsed =
-            velesdb_core::velesql::Parser::parse(&sql).map_err(|e| VelesError::Database {
-                message: format!("VelesQL parse error: {}", e.message),
-            })?;
+        let parsed = velesdb_core::velesql::Parser::parse(&sql)
+            .map_err(|e| VelesError::database(format!("VelesQL parse error: {}", e.message)))?;
 
         let params = query::parse_params(params_json)?;
         let kind = query::classify_query(&parsed);
 
-        let core_results =
-            self.inner
-                .execute_query(&parsed, &params)
-                .map_err(|e| VelesError::Database {
-                    message: format!("Query execution failed: {e}"),
-                })?;
+        let core_results = self
+            .inner
+            .execute_query(&parsed, &params)
+            .map_err(|e| VelesError::database(format!("Query execution failed: {e}")))?;
 
         let rows: Result<Vec<QueryResultRow>, VelesError> =
             core_results.iter().map(query::to_result_row).collect();

--- a/crates/velesdb-mobile/src/query.rs
+++ b/crates/velesdb-mobile/src/query.rs
@@ -110,11 +110,8 @@ pub(crate) fn to_result_row(
         }
     }
 
-    let data_json = serde_json::to_string(&serde_json::Value::Object(map)).map_err(|e| {
-        VelesError::Database {
-            message: format!("Failed to serialize row to JSON: {e}"),
-        }
-    })?;
+    let data_json = serde_json::to_string(&serde_json::Value::Object(map))
+        .map_err(|e| VelesError::database(format!("Failed to serialize row to JSON: {e}")))?;
 
     Ok(QueryResultRow {
         id: result.point.id,
@@ -144,9 +141,8 @@ pub(crate) fn parse_params(
 ) -> Result<HashMap<String, serde_json::Value>, VelesError> {
     params_json
         .map(|json| {
-            serde_json::from_str(&json).map_err(|e| VelesError::Database {
-                message: format!("Invalid params JSON: {e}"),
-            })
+            serde_json::from_str(&json)
+                .map_err(|e| VelesError::database(format!("Invalid params JSON: {e}")))
         })
         .transpose()
         .map(Option::unwrap_or_default)

--- a/crates/velesdb-mobile/src/query_tests.rs
+++ b/crates/velesdb-mobile/src/query_tests.rs
@@ -283,7 +283,7 @@ fn test_execute_query_invalid_sql_returns_error() {
     assert!(result.is_err(), "invalid SQL should return an error");
     let err = result.expect_err("test: error expected");
     match err {
-        VelesError::Database { message } => {
+        VelesError::Database { message, .. } => {
             assert!(
                 message.contains("parse error"),
                 "error should mention parse error, got: {message}"

--- a/crates/velesdb-mobile/src/streaming_runtime.rs
+++ b/crates/velesdb-mobile/src/streaming_runtime.rs
@@ -33,12 +33,10 @@ pub(crate) fn stream_runtime() -> Result<&'static Runtime, VelesError> {
         .enable_all()
         .thread_name("velesdb-stream")
         .build()
-        .map_err(|e| VelesError::Database {
-            message: format!("failed to start streaming runtime: {e}"),
-        })?;
+        .map_err(|e| VelesError::database(format!("failed to start streaming runtime: {e}")))?;
     // First writer wins; a late writer's runtime is dropped immediately.
     let _ = RUNTIME.set(rt);
-    RUNTIME.get().ok_or_else(|| VelesError::Database {
-        message: "streaming runtime unavailable".to_string(),
-    })
+    RUNTIME
+        .get()
+        .ok_or_else(|| VelesError::database("streaming runtime unavailable".to_string()))
 }

--- a/crates/velesdb-mobile/src/types.rs
+++ b/crates/velesdb-mobile/src/types.rs
@@ -13,8 +13,17 @@ use velesdb_core::FusionStrategy as CoreFusionStrategy;
 #[derive(Debug, thiserror::Error, uniffi::Error)]
 pub enum VelesError {
     /// Database operation failed.
-    #[error("Database error: {message}")]
-    Database { message: String },
+    ///
+    /// `code` carries the canonical core taxonomy code (e.g. `"VELES-006"`)
+    /// when the error originated in `velesdb-core`, or an empty string for
+    /// binding-level failures (JSON parsing, runtime setup) that have no core
+    /// code. `recoverable` mirrors core's [`velesdb_core::Error::is_recoverable`].
+    #[error("[{code}] Database error: {message}")]
+    Database {
+        message: String,
+        code: String,
+        recoverable: bool,
+    },
 
     /// Collection operation failed.
     #[error("Collection error: {message}")]
@@ -25,8 +34,26 @@ pub enum VelesError {
     DimensionMismatch { expected: u32, actual: u32 },
 }
 
+impl VelesError {
+    /// Constructs a binding-level `Database` error with no core taxonomy code.
+    ///
+    /// Use for failures that originate in the mobile binding itself (JSON
+    /// parsing, runtime creation, configuration) rather than in `velesdb-core`.
+    /// Binding-level errors are treated as recoverable.
+    #[must_use]
+    pub fn database(message: String) -> Self {
+        VelesError::Database {
+            message,
+            code: String::new(),
+            recoverable: true,
+        }
+    }
+}
+
 impl From<velesdb_core::Error> for VelesError {
     fn from(err: velesdb_core::Error) -> Self {
+        let code = err.code().to_string();
+        let recoverable = err.is_recoverable();
         match err {
             velesdb_core::Error::DimensionMismatch { expected, actual } =>
             {
@@ -44,6 +71,8 @@ impl From<velesdb_core::Error> for VelesError {
             },
             other => VelesError::Database {
                 message: other.to_string(),
+                code,
+                recoverable,
             },
         }
     }
@@ -509,4 +538,47 @@ pub struct MobileAdvancedConfig {
     pub deferred_indexing: Option<MobileDeferredIndexerConfig>,
     /// Async index builder config; `None` leaves it unchanged.
     pub async_index_builder: Option<MobileAsyncIndexBuilderConfig>,
+}
+
+#[cfg(test)]
+mod error_tests {
+    use super::VelesError;
+
+    #[test]
+    fn core_error_carries_canonical_code_and_recoverability() {
+        // A core Storage error (VELES-006) is recoverable.
+        let err: VelesError = velesdb_core::Error::Storage("disk full".to_string()).into();
+        let VelesError::Database {
+            code, recoverable, ..
+        } = err
+        else {
+            panic!("expected VelesError::Database, got {err:?}");
+        };
+        assert_eq!(code, "VELES-006");
+        assert!(recoverable);
+
+        // An IndexCorrupted error (VELES-008) is non-recoverable.
+        let err: VelesError = velesdb_core::Error::IndexCorrupted("bad header".to_string()).into();
+        let VelesError::Database {
+            code, recoverable, ..
+        } = err
+        else {
+            panic!("expected VelesError::Database, got {err:?}");
+        };
+        assert_eq!(code, "VELES-008");
+        assert!(!recoverable);
+    }
+
+    #[test]
+    fn binding_level_error_has_no_core_code() {
+        let err = VelesError::database("bad JSON".to_string());
+        let VelesError::Database {
+            code, recoverable, ..
+        } = err
+        else {
+            panic!("expected VelesError::Database, got {err:?}");
+        };
+        assert!(code.is_empty());
+        assert!(recoverable);
+    }
 }

--- a/crates/velesdb-mobile/tests/coverage_native.rs
+++ b/crates/velesdb-mobile/tests/coverage_native.rs
@@ -133,7 +133,7 @@ fn stream_insert_without_enable_returns_error() {
     }]);
 
     let err = result.expect_err("stream_insert without enable must fail");
-    let velesdb_mobile::VelesError::Database { message } = err else {
+    let velesdb_mobile::VelesError::Database { message, .. } = err else {
         panic!("expected VelesError::Database, got {err:?}");
     };
     assert!(
@@ -163,7 +163,7 @@ fn upsert_with_invalid_json_payload_errors() {
     });
 
     let err = result.expect_err("invalid JSON payload must fail");
-    let velesdb_mobile::VelesError::Database { message } = err else {
+    let velesdb_mobile::VelesError::Database { message, .. } = err else {
         panic!("expected VelesError::Database, got {err:?}");
     };
     assert!(


### PR DESCRIPTION
## What (core-parity audit B6)
The mobile `From<velesdb_core::Error>` funneled most variants into a catch-all `VelesError::Database`, dropping core's stable 36-variant VELES-### taxonomy (`Error::code()`, `is_recoverable()`).

- `VelesError::Database` now carries `code: String` (canonical core code, e.g. `VELES-006`, or `""` for binding-level errors) and `recoverable: bool`; `Display` prepends `[{code}] `.
- Binding-level errors (JSON parse, runtime setup, validation) honestly map to an empty code rather than inventing one.

## Behavior change
UniFFI surface change: Swift/Kotlin consumers of the `Database` error gain **additive** `code`/`recoverable` accessors; `Display` now shows `[code]`. Existing typed variants unchanged.

## Verification
`cargo test -p velesdb-mobile` green · clippy pedantic clean.