### PR TITLE
Parity W4 closeout: multi-column ORDER BY/top-k executor conformance (E16) + MobileGraphStore doc (C9)

### DIFF
--- a/conformance/velesql_executor_cases.json
+++ b/conformance/velesql_executor_cases.json
@@ -43,6 +43,36 @@
       "query": "SELECT * FROM docs WHERE category = 'other' ORDER BY year ASC",
       "expect_ids": [5, 3],
       "note": "filter selecting the complementary partition"
+    },
+    {
+      "id": "X006",
+      "query": "SELECT * FROM docs ORDER BY category ASC, year DESC",
+      "expect_ids": [3, 5, 4, 2, 1],
+      "note": "multi-column ORDER BY, mixed directions: 'other' (o<t) before 'tech', year descending within each group"
+    },
+    {
+      "id": "X007",
+      "query": "SELECT * FROM docs ORDER BY category DESC, year ASC",
+      "expect_ids": [1, 2, 4, 5, 3],
+      "note": "multi-column ORDER BY, opposite directions (category DESC, year ASC) — exercises independent per-column direction handling"
+    },
+    {
+      "id": "X008",
+      "query": "SELECT * FROM docs ORDER BY category ASC",
+      "expect_ids": [3, 5, 1, 2, 4],
+      "note": "tie-break lock: rows sharing the ORDER BY key are ordered by ascending point id (matches the index-backed ordered_ids walk, EPIC-081 phase 2)"
+    },
+    {
+      "id": "X009",
+      "query": "SELECT * FROM docs ORDER BY category ASC, year DESC LIMIT 3",
+      "expect_ids": [3, 5, 4],
+      "note": "EPIC-081 bounded top-k over a multi-column ORDER BY: bounded result equals the unbounded sort (X006) truncated to k"
+    },
+    {
+      "id": "X010",
+      "query": "SELECT * FROM docs ORDER BY year ASC LIMIT 3",
+      "expect_ids": [5, 1, 3],
+      "note": "EPIC-081 bounded top-k, ASC direction (complements the DESC regression-lock B001): full year-ASC order [5,1,3,2,4] truncated to k=3"
     }
   ],
   "known_bugs": [

--- a/crates/velesdb-cli/tests/velesql_executor_conformance.rs
+++ b/crates/velesdb-cli/tests/velesql_executor_conformance.rs
@@ -16,8 +16,10 @@
 //!
 //! # Case coverage
 //!
-//! All five `cases` (X001–X005) are runnable by the CLI executor and asserted
-//! against the golden ids.
+//! All ten `cases` (X001–X010) are runnable by the CLI executor and asserted
+//! against the golden ids — scalar WHERE filters, single- and multi-column
+//! ORDER BY, the deterministic ascending-id tie-break, and bounded top-k
+//! (`ORDER BY ... LIMIT k`).
 //!
 //! # known_bugs (B001)
 //!
@@ -159,7 +161,7 @@ fn assert_cases(db_path: &Path, cases: &[Case]) {
     }
 }
 
-/// All golden `cases` (X001–X005) must reproduce the core result set exactly
+/// All golden `cases` (X001–X010) must reproduce the core result set exactly
 /// when run through the CLI binary.
 #[test]
 fn test_cli_velesql_executor_conformance_fixture_cases() {

--- a/crates/velesdb-wasm/src/velesql_executor_conformance_tests.rs
+++ b/crates/velesdb-wasm/src/velesql_executor_conformance_tests.rs
@@ -14,9 +14,12 @@
 //!
 //! # Case coverage
 //!
-//! All five `cases` (X001–X005) are runnable by the WASM executor (scalar
-//! WHERE filter + ORDER BY on a payload column, no LIMIT-before-sort path) and
-//! are asserted against the golden ids.
+//! All ten `cases` (X001–X010) are runnable by the WASM executor (scalar WHERE
+//! filter, single- and multi-column ORDER BY, the ascending-id tie-break, and
+//! bounded top-k) and are asserted against the golden ids. WASM runs its OWN
+//! SELECT/ORDER BY pipeline (`velesql_select`/`velesql_orderby`), independent of
+//! the core executor, so these goldens pin it against the `velesdb-core` result
+//! set rather than assuming shared-executor equivalence.
 //!
 //! # known_bugs (B001)
 //!
@@ -133,7 +136,7 @@ fn assert_cases(db: &mut DatabaseInner, cases: &[Case]) {
     }
 }
 
-/// All golden `cases` (X001–X005) must reproduce the core result set exactly.
+/// All golden `cases` (X001–X010) must reproduce the core result set exactly.
 #[test]
 fn test_wasm_velesql_executor_conformance_fixture_cases() {
     let fixture = load_fixture();

--- a/docs/reference/ECOSYSTEM_PARITY.md
+++ b/docs/reference/ECOSYSTEM_PARITY.md
@@ -106,16 +106,22 @@ Legend: ✅ full support | ⚠️ partial / limited | ❌ not supported | N/A no
 | Server REST contract | `conformance/velesql_contract_cases.json` | `crates/velesdb-server/tests/velesql_conformance_tests.rs` |
 | TypeScript SDK contract mapping | `conformance/velesql_contract_cases.json` | `sdks/typescript/tests/velesql-contract-fixtures.test.ts` |
 | Core executor (rows/counts/ordering) | `conformance/velesql_executor_cases.json` | `crates/velesdb-core/tests/velesql_executor_conformance.rs` |
+| CLI executor (rows/counts/ordering) | `conformance/velesql_executor_cases.json` | `crates/velesdb-cli/tests/velesql_executor_conformance.rs` |
+| WASM executor (rows/counts/ordering) | `conformance/velesql_executor_cases.json` | `crates/velesdb-wasm/src/velesql_executor_conformance_tests.rs` |
 | Core parser | `conformance/velesql_parser_cases.json` | `crates/velesdb-core/tests/velesql_parser_conformance.rs` |
 | CLI parser | `conformance/velesql_parser_cases.json` | `crates/velesdb-cli/tests/velesql_parser_conformance.rs` |
 | WASM parser | `conformance/velesql_parser_cases.json` | `crates/velesdb-wasm/tests/velesql_parser_conformance.rs` |
 
-The executor fixture (added 2026-06-14) asserts the exact result set (ids,
-count, ordering) the core executor produces for a fixed dataset, so a future
-WASM/CLI executor divergence fails CI rather than going unnoticed. WASM and CLI
-executor parity is **not yet** fixture-checked against these goldens — extending
-the executor net to those two runtimes is the open follow-up tracked in
-[KNOWN_LIMITATIONS #13](./KNOWN_LIMITATIONS.md#13-velesql-conformance-for-wasmcli-is-parser-only).
+The executor fixture (added 2026-06-14, extended 2026-06-20) asserts the exact
+result set (ids, count, ordering) each executor produces for a fixed dataset. As
+of 2026-06-20 the **WASM and CLI executors are fixture-checked against the same
+goldens too** — the CLI drives the real binary end-to-end and WASM runs its own
+SELECT/ORDER BY pipeline — so a result-shape divergence on those surfaces fails
+CI rather than going unnoticed. Coverage includes scalar WHERE filters, single-
+and multi-column ORDER BY, the ascending-id tie-break, and bounded top-k
+(`ORDER BY ... LIMIT k`); see
+[KNOWN_LIMITATIONS #13](./KNOWN_LIMITATIONS.md#13-velesql-executor-conformance-core-wasm-cli)
+(resolved).
 
 ## Enum Propagation Matrix
 
@@ -229,14 +235,14 @@ collection creation; only Haystack is limited by its DocumentStore protocol.
 ## Recently Landed (2026-06-14)
 
 - **WASM fusion now delegates 4/5 strategies to core.** `average`/`maximum`/`weighted`/`rrf` map onto `velesdb_core::FusionStrategy::fuse` (ranking identical to core, pinned by an equivalence test); `relative_score`/`rsf` stays WASM-local by design because its N-branch equal-weight semantics differ from core's two-branch dense+sparse weighted sum. See the RSF/Weighted note above.
-- **Executor-level conformance now exists for core.** `conformance/velesql_executor_cases.json` + `crates/velesdb-core/tests/velesql_executor_conformance.rs` assert result rows/counts/ordering (not just that a query parses). Extending the same goldens to the WASM and CLI executors is the remaining step (action item 2).
+- **Executor-level conformance now exists for core.** `conformance/velesql_executor_cases.json` + `crates/velesdb-core/tests/velesql_executor_conformance.rs` assert result rows/counts/ordering (not just that a query parses). Extended to the WASM and CLI executors on 2026-06-20 (action item 2 — now done).
 - **Scalar `ORDER BY` + `LIMIT` correctness bug fixed.** A scalar (non-`similarity()`) `ORDER BY <col> ... LIMIT k` previously truncated to `k` in storage order *before* sorting; it now fetches the full matching set so the sort precedes truncation, restoring the [KNOWN_LIMITATIONS #9](./KNOWN_LIMITATIONS.md#9-bounded-query-result-materialization) bounded==unbounded guarantee. The `similarity()`-ordered HNSW fast path was untouched, so recall is unaffected. (Surfaced by the new executor conformance net above.)
 - **Point-ID hashing single-sourced for Haystack.** The Haystack `DocumentStore` now imports the canonical `velesdb_common.ids.stable_hash_id` instead of a bit-identical forked copy (behaviour-preserving; removes a re-implemented hash from an MIT package). The intentional remaining divergence — `velesdb-migrate`'s distinct `stable_point_id` — is documented in [KNOWN_LIMITATIONS #12](./KNOWN_LIMITATIONS.md#12-string--u64-point-id-hashing-differs-across-components).
 
 ## Remaining Gaps and Action Items
 
 1. Add explicit server-side end-to-end assertions for the REST error shape (`code/hint/details`) beyond parser conformance. (The CLI has no HTTP layer — it executes against embedded core — so the REST error-shape contract belongs to `velesdb-server`.)
-2. Extend the executor-level conformance net (now established for **core** via `conformance/velesql_executor_cases.json`) to the **WASM** and **CLI** runtimes so a result-shape divergence on those surfaces fails CI. (Parser conformance already covers all three; see [KNOWN_LIMITATIONS #13](./KNOWN_LIMITATIONS.md#13-velesql-conformance-for-wasmcli-is-parser-only).)
+2. ✅ **Done (2026-06-20).** The executor-level conformance net now covers **core, WASM, and CLI** — all three run `conformance/velesql_executor_cases.json`, including scalar WHERE filters, single- and multi-column ORDER BY, the ascending-id tie-break, and bounded top-k. See [KNOWN_LIMITATIONS #13](./KNOWN_LIMITATIONS.md#13-velesql-executor-conformance-core-wasm-cli) (resolved).
 3. Keep docs, fixtures, and examples synchronized on every contract version change.
 4. Promote RaBitQ from experimental to stable once the API is finalized.
 5. Surface RSF/Weighted fusion in Haystack (already exposed in LangChain and

--- a/docs/reference/KNOWN_LIMITATIONS.md
+++ b/docs/reference/KNOWN_LIMITATIONS.md
@@ -260,29 +260,64 @@ numeric point ID.
 
 ## Tooling / test coverage
 
-### 13. VelesQL conformance for WASM/CLI is parser-only
+### 13. VelesQL executor conformance (core, WASM, CLI)
 
-**Status**: open (coverage gap, narrowed 2026-06-14). Sources: `crates/velesdb-wasm/tests/velesql_parser_conformance.rs`, `crates/velesdb-cli/tests/velesql_parser_conformance.rs` (parser fixture); `crates/velesdb-server/tests/velesql_conformance_tests.rs` (server executor contract fixture); `crates/velesdb-core/tests/velesql_executor_conformance.rs` + `conformance/velesql_executor_cases.json` (core executor result fixture).
+**Status**: resolved (2026-06-20). Sources: `crates/velesdb-core/tests/velesql_executor_conformance.rs`, `crates/velesdb-cli/tests/velesql_executor_conformance.rs`, `crates/velesdb-wasm/src/velesql_executor_conformance_tests.rs` + the shared `conformance/velesql_executor_cases.json`; parser layer `crates/velesdb-{wasm,cli}/tests/velesql_parser_conformance.rs`; server REST-contract layer `crates/velesdb-server/tests/velesql_conformance_tests.rs`.
 
 The shared VelesQL conformance fixtures come in layers. The
 `velesql_parser_cases.json` layer (does this query parse?) is checked across
-**core, WASM, and CLI** — all three run the same `Parser::parse` assertions.
-The `velesql_contract_cases.json` layer (does this query *execute* and return
-the contracted result/error shape over REST?) is exercised at the **server**
-runtime. The `velesql_executor_cases.json` layer (does this query produce the
-exact result **rows / counts / ordering**?) now exists for the **core**
-executor, with goldens derived from `velesdb-core` as the source of truth.
+**core, WASM, and CLI**. The `velesql_contract_cases.json` layer (does this
+query *execute* and return the contracted result/error shape over REST?) is
+exercised at the **server** runtime. The `velesql_executor_cases.json` layer
+(does this query produce the exact result **rows / counts / ordering**?) is now
+run by all three executors — **core, CLI, and WASM** — with goldens derived from
+`velesdb-core` as the source of truth.
 
-**What remains open**: **WASM** and **CLI** executor result parity is **not yet
-fixture-checked** against those executor goldens. The WASM and CLI surfaces
-share the same `velesdb-core` executor, so a query that parses identically
-across the three is expected to execute identically — but for WASM/CLI that
-expectation is not yet pinned by a per-runtime executor fixture run.
+**Architecture note**: the three executors are *not* the same code path. The CLI
+delegates SELECT execution to `velesdb-core` (`Database::execute_query`), so it
+inherits core behaviour directly. WASM runs its **own** independent SELECT/ORDER
+BY pipeline (`velesql_select` / `velesql_orderby`), sharing only the AST/parser
+with core — which is exactly why a per-runtime executor golden has real value:
+it pins the WASM result set against core rather than assuming shared-executor
+equivalence.
 
-**User impact**: a result-shape divergence specific to the WASM or CLI surface
-(e.g. a serialization or projection difference) would not be caught by the
-conformance suite until executor-level fixtures cover those runtimes. Parser
-acceptance — which features parse — is fully covered for all three.
+**Coverage** (`conformance/velesql_executor_cases.json`, cases X001–X010 plus
+the B001 regression lock): scalar string-equality and integer-range WHERE
+filters, conjunctive (AND) filters, single- and multi-column ORDER BY in mixed
+directions, the deterministic ascending-id tie-break, and bounded top-k
+(`ORDER BY ... LIMIT k`, both ASC and DESC). A result-shape divergence specific
+to the WASM or CLI surface now fails CI rather than going unnoticed.
+
+---
+
+## Bindings / SDK architecture
+
+### 14. `MobileGraphStore` is a deliberate in-memory graph fork
+
+**Status**: documented (by design). Source: `crates/velesdb-mobile/src/graph.rs` (`MobileGraphStore`); core counterparts `crates/velesdb-core/src/collection/graph/edge.rs` (`EdgeStore`) and `crates/velesdb-core/src/collection/graph_collection.rs` (`GraphCollection`). Decision recorded in `docs/planning/CORE_PARITY_REMEDIATION.md` (T4).
+
+The mobile SDK's `MobileGraphStore` is a self-contained, purely in-memory graph
+engine (node/edge maps plus BFS/DFS/degree/label helpers) rather than a delegate
+to `velesdb-core`'s graph runtime. This is an intentional design decision, **not**
+an accidental rewrite: mobile needs a RAM-only graph with no filesystem path,
+WAL, or on-disk payloads, whereas core's `GraphCollection` persists nodes as JSON
+payloads and requires a path. Core today exposes an in-memory `EdgeStore` (edges
++ traversal) but has **no in-memory `GraphNode`-object store** (label + properties
++ vector CRUD), so the node half of `MobileGraphStore` has no core API to delegate
+to.
+
+What *is* single-sourced is the record types: `MobileGraphStore` is pinned to
+core via `From<velesdb_core::GraphNode / GraphEdge / TraversalResult>` conversions
+(`graph.rs`), so any field drift in the core types is a compile error in mobile —
+the type-shadowing risk (the in-scope half of T4) is closed.
+
+**User impact**: none functionally — the mobile graph API behaves as documented.
+The architectural caveat is that mobile graph semantics are maintained
+independently of core's graph engine. Full delegation is gated on core first
+shipping an in-memory `GraphStore` API (node + edge CRUD, label query, cascade
+remove, BFS/DFS); until then, copying core's graph engine into the MIT-licensed
+mobile crate would violate the Core License boundary, so the fork is the correct
+boundary-preserving choice.
 
 ---
 
@@ -290,7 +325,7 @@ acceptance — which features parse — is fully covered for all three.
 
 Each entry states:
 
-- **Status**: open / partial / documented / pre-existing.
+- **Status**: open / partial / documented / resolved / pre-existing.
 - **Source**: the file or line referenced in code.
 - **User impact**: what an operator or integrator actually sees.
 - **Resolution path or workaround** where applicable.


### PR DESCRIPTION
Closes the two **low-risk** deferred items from the 2026-06-19 core-parity audit (W4). The remaining W4 item — C11 (server EXPLAIN single-sourcing) — is invasive (changes the REST `/query/explain` contract) and is intentionally left for a release-boundary PR against a clean tagged baseline.

## E16 — executor conformance: multi-column ORDER BY + bounded top-k

The executor-result conformance net (`conformance/velesql_executor_cases.json`) already runs against **core, CLI, and WASM** (added in `92c49d82`), but the fixture only covered single-column ORDER BY. This adds the missing coverage:

| Case | Query | Golden | What it pins |
|------|-------|--------|--------------|
| X006 | `ORDER BY category ASC, year DESC` | `[3,5,4,2,1]` | multi-column, mixed directions |
| X007 | `ORDER BY category DESC, year ASC` | `[1,2,4,5,3]` | per-column direction handling |
| X008 | `ORDER BY category ASC` | `[3,5,1,2,4]` | deterministic ascending-id tie-break |
| X009 | `ORDER BY category ASC, year DESC LIMIT 3` | `[3,5,4]` | EPIC-081 bounded top-k over multi-column |
| X010 | `ORDER BY year ASC LIMIT 3` | `[5,1,3]` | bounded top-k, ASC (complements B001's DESC lock) |

Goldens derived from `velesdb-core` (source of truth) and **verified green on all three executors** (`--test-threads=1`):
- core `velesql_executor_conformance` — 2/2 ok
- CLI `velesql_executor_conformance` (real binary) — 2/2 ok
- WASM `velesql_executor_conformance` (own `velesql_select`/`velesql_orderby` pipeline) — 2/2 ok

### Stale-doc correction (KNOWN_LIMITATIONS #13 + ECOSYSTEM_PARITY)
The docs (last touched 2026-06-14, the same day the WASM/CLI harnesses landed) still claimed executor conformance was **"parser-only"** for WASM/CLI and that WASM **"shares the same velesdb-core executor."** Both are wrong: the per-runtime harnesses exist, and WASM runs an *independent* SELECT/ORDER BY pipeline (only the CLI delegates to `Database::execute_query`). #13 is now marked **resolved** with the architecture corrected; ECOSYSTEM_PARITY action-item 2 marked done; conformance table gains CLI/WASM executor rows.

## C9 — document MobileGraphStore as a deliberate RAM-only fork (KNOWN_LIMITATIONS #14)

`MobileGraphStore` is an intentional in-memory graph engine, **not** an accidental rewrite (already adjudicated in `CORE_PARITY_REMEDIATION.md` T4: "do not rewrite"). Full delegation to core is blocked by a real capability gap — core has **no in-memory `GraphNode`-object store** (nodes are JSON payloads in a disk-backed `GraphCollection` requiring a path). The type-shadowing risk is already closed via `From<velesdb_core::…>` impls. New #14 documents this and gates future delegation on a core in-memory `GraphStore` API; copying core's engine into the MIT mobile crate would breach the Core License boundary.

## Scope / risk
Test + doc only — **zero production code**. fmt clean, clippy-pedantic clean on `velesdb-wasm` (the one `src` doc-comment changed). jscpd unaffected (scans Rust under `crates/`; JSON fixture is out of scope).