### PR TITLE
refactor(explain): single-source REST plan steps from velesdb-core (C11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,47 @@ All notable changes to VelesDB will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- **REST `EXPLAIN` single-sourced from core.** `POST /query/explain` no longer
+  reconstructs the plan from the parsed AST; it now maps the engine's canonical
+  query plan via the new `velesdb_core::velesql::QueryPlan::to_plan_steps()` —
+  the same `PlanNode` tree the CLI `.explain` renders. The response **shape**
+  (keys/structure) and the `operation` vocabulary are unchanged (`FullScan`,
+  `{Type}Join`, `Filter`, `GroupBy`, `Aggregate`, `Sort`, `Limit`, ... are all
+  preserved), and `docs/openapi.{json,yaml}` are unchanged. The `features` and
+  `estimated_cost` response objects remain server-derived (single-sourcing them
+  is a follow-up).
+- **CLI/Python `EXPLAIN` now shows `JOIN` / `GROUP BY` / aggregation / `ORDER BY`
+  steps.** The core `PlanNode` tree gained `Join`, `GroupBy`, `Aggregate`, and
+  `Sort` nodes, so `QueryPlan::to_tree()` now renders them (previously only the
+  REST view surfaced these). Filter row estimates flow natively from the plan,
+  removing the prior server-side estimation merge.
+- The `VectorSearch` step's `estimated_rows` is now `null` (it previously echoed
+  the query `LIMIT`). The limit estimate is still reported on the `Limit` step,
+  where it is unambiguous.
+
+### Added
+- `velesdb_core::velesql::QueryPlan::to_plan_steps() -> Vec<PlanStep>` — the
+  canonical, structured EXPLAIN step list (with `PlanStep`/`PlanStepKind` and the
+  `PlanStep::rest_operation()` wire mapping), single-sourced with `to_tree()`.
+
+### Fixed
+- An indexed-equality predicate may now surface an `IndexLookup` step in REST
+  `EXPLAIN`, which the prior AST reconstruction never emitted.
+- A query with `OFFSET` but no `LIMIT` (compound/`MATCH`) now surfaces a proper
+  `Offset` step instead of the previous degenerate `Apply LIMIT 0 OFFSET N`.
+
+> Known follow-ups (deliberately out of scope, recorded for future work):
+> - The pre-existing in-response inconsistency between `plan[].operation`
+>   (`FullScan`) and `node_stats[].node_label` (`TableScan`) is left as-is;
+>   reconciling it is a breaking relabel deferred behind the SemVer boundary.
+> - `velesdb-wasm` keeps its own AST-walking `EXPLAIN` renderer with an
+>   independent vocabulary (`Scan`, `NestedLoopJoin`, `GraphPatternMatch`, ...):
+>   the core `QueryPlan`/`to_plan_steps` machinery is `persistence`-gated and
+>   unavailable in the no-persistence WASM build, so full convergence is deferred.
+
 ## [3.1.0] — 2026-06-20
 
 Minor release. Single-sources several ecosystem components onto `velesdb-core`

--- a/crates/velesdb-core/src/api_types/responses_explain.rs
+++ b/crates/velesdb-core/src/api_types/responses_explain.rs
@@ -141,6 +141,20 @@ pub struct ExplainStep {
     pub estimation_method: Option<String>,
 }
 
+#[cfg(feature = "persistence")]
+impl From<&crate::velesql::PlanStep> for ExplainStep {
+    #[allow(clippy::cast_possible_truncation)]
+    fn from(s: &crate::velesql::PlanStep) -> Self {
+        Self {
+            step: s.step,
+            operation: s.rest_operation(),
+            description: s.description.clone(),
+            estimated_rows: s.estimated_rows.map(|r| r as usize),
+            estimation_method: s.estimation_method.clone(),
+        }
+    }
+}
+
 /// Estimated cost metrics for the query.
 #[derive(Debug, Serialize)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]

--- a/crates/velesdb-core/src/velesql/cost_estimator/plan_cost.rs
+++ b/crates/velesdb-core/src/velesql/cost_estimator/plan_cost.rs
@@ -29,7 +29,12 @@ impl CostEstimator<'_> {
                 let c = self.estimate_plan_cost(n);
                 Cost::new(acc.io_cost + c.io_cost, acc.cpu_cost + c.cpu_cost)
             }),
-            PlanNode::Limit(_) | PlanNode::Offset(_) => self.estimate_limit_offset_cost(),
+            PlanNode::Limit(_)
+            | PlanNode::Offset(_)
+            | PlanNode::Join(_)
+            | PlanNode::GroupBy(_)
+            | PlanNode::Aggregate(_)
+            | PlanNode::Sort(_) => self.estimate_limit_offset_cost(),
         }
     }
 

--- a/crates/velesdb-core/src/velesql/explain/formatter.rs
+++ b/crates/velesdb-core/src/velesql/explain/formatter.rs
@@ -119,7 +119,48 @@ impl QueryPlan {
             PlanNode::MatchTraversal(mt) => {
                 Self::render_match_traversal_node(mt, output, prefix, connector, &child_prefix);
             }
+            PlanNode::Join(j) => Self::render_leaf_with_child(
+                output,
+                (prefix, &child_prefix, connector),
+                &format!("{}Join", j.join_type),
+                ("Table", &j.table),
+            ),
+            PlanNode::GroupBy(g) => Self::render_leaf_with_child(
+                output,
+                (prefix, &child_prefix, connector),
+                "GroupBy",
+                ("Columns", &format!("[{}]", g.columns.join(", "))),
+            ),
+            PlanNode::Aggregate(a) => Self::render_leaf_with_child(
+                output,
+                (prefix, &child_prefix, connector),
+                "Aggregate",
+                ("Functions", &format!("[{}]", a.functions.join(", "))),
+            ),
+            PlanNode::Sort(s) => Self::render_leaf_with_child(
+                output,
+                (prefix, &child_prefix, connector),
+                "Sort",
+                ("Keys", &s.keys.join(", ")),
+            ),
         }
+    }
+
+    /// Renders a simple "label + single child line" node into the tree output.
+    ///
+    /// Shared by the Join/GroupBy/Aggregate/Sort arms. `frame` carries the
+    /// `(prefix, child_prefix, connector)` layout strings; `child` is the
+    /// `(key, value)` of the single child line.
+    fn render_leaf_with_child(
+        output: &mut String,
+        frame: (&str, &str, &str),
+        label: &str,
+        child: (&str, &str),
+    ) {
+        let (prefix, child_prefix, connector) = frame;
+        let (key, value) = child;
+        let _ = writeln!(output, "{prefix}{connector}{label}");
+        let _ = writeln!(output, "{child_prefix}└─ {key}: {value}");
     }
 
     /// Renders a `Filter` plan node into the tree output.

--- a/crates/velesdb-core/src/velesql/explain/mod.rs
+++ b/crates/velesdb-core/src/velesql/explain/mod.rs
@@ -16,6 +16,7 @@ mod filter_strategy;
 mod formatter;
 mod node_stats;
 mod plan_builder;
+mod step;
 mod types;
 
 pub(crate) use filter_strategy::strip_vector_predicates;

--- a/crates/velesdb-core/src/velesql/explain/node_stats.rs
+++ b/crates/velesdb-core/src/velesql/explain/node_stats.rs
@@ -78,6 +78,8 @@ pub(super) fn node_cost(node: &PlanNode) -> f64 {
         PlanNode::Limit(_) | PlanNode::Offset(_) => 0.001,
         PlanNode::TableScan(_) => 1.0,
         PlanNode::IndexLookup(_) => 0.0001, // O(1) lookup is very fast
+        PlanNode::Join(_) => 0.1,           // cross-store probe is the costliest post-scan op
+        PlanNode::GroupBy(_) | PlanNode::Aggregate(_) | PlanNode::Sort(_) => 0.02,
         PlanNode::Sequence(nodes) => nodes.iter().map(node_cost).sum(),
         PlanNode::MatchTraversal(mt) => {
             // Cost depends on depth and strategy
@@ -104,6 +106,10 @@ fn node_label_and_weight(node: &PlanNode) -> (&'static str, f64) {
         PlanNode::Filter(_) => ("Filter", 0.03),
         PlanNode::Limit(_) => ("Limit", 0.01),
         PlanNode::Offset(_) => ("Offset", 0.01),
+        PlanNode::Join(_) => ("Join", 0.05),
+        PlanNode::GroupBy(_) => ("GroupBy", 0.02),
+        PlanNode::Aggregate(_) => ("Aggregate", 0.02),
+        PlanNode::Sort(_) => ("Sort", 0.02),
         PlanNode::Sequence(_) => ("Sequence", 0.0),
     }
 }

--- a/crates/velesdb-core/src/velesql/explain/plan_builder.rs
+++ b/crates/velesdb-core/src/velesql/explain/plan_builder.rs
@@ -9,8 +9,9 @@ use super::filter_strategy::{estimate_filter_stats, resolve_filter_strategy};
 use super::formatter;
 use super::node_stats;
 use super::types::{
-    FilterPlan, FilterStrategy, FusionInfo, IndexLookupPlan, IndexType, LimitPlan,
-    MatchTraversalPlan, OffsetPlan, PlanNode, QueryPlan, TableScanPlan, VectorSearchPlan,
+    AggregatePlan, FilterPlan, FilterStrategy, FusionInfo, GroupByPlan, IndexLookupPlan, IndexType,
+    JoinPlanNode, LimitPlan, MatchTraversalPlan, OffsetPlan, PlanNode, QueryPlan, SortPlan,
+    TableScanPlan, VectorSearchPlan,
 };
 use crate::collection::search::query::match_planner::{
     CollectionStats, MatchExecutionStrategy, MatchQueryPlanner,
@@ -78,8 +79,9 @@ impl QueryPlan {
             stmt,
             has_vector_search,
             stats,
-            implicit_limit,
         );
+        Self::append_post_filter_nodes(&mut nodes, stmt);
+        Self::push_pagination_nodes(&mut nodes, stmt, implicit_limit);
 
         let mut plan = Self::assemble_plan_with_stats(
             nodes,
@@ -307,7 +309,6 @@ impl QueryPlan {
         stmt: &SelectStatement,
         has_vector_search: bool,
         stats: Option<&CoreCollectionStats>,
-        implicit_limit: bool,
     ) -> FilterStrategy {
         let mut filter_strategy = FilterStrategy::None;
 
@@ -341,12 +342,67 @@ impl QueryPlan {
             }));
         }
 
+        filter_strategy
+    }
+
+    /// Appends post-filter pipeline nodes (JOIN, GROUP BY, aggregation, ORDER
+    /// BY) in the order they execute, mirroring the previous server-side
+    /// reconstruction so the single-sourced plan is step-compatible.
+    fn append_post_filter_nodes(nodes: &mut Vec<PlanNode>, stmt: &SelectStatement) {
+        for join in &stmt.joins {
+            nodes.push(PlanNode::Join(JoinPlanNode {
+                join_type: format!("{:?}", join.join_type),
+                table: join.table.clone(),
+            }));
+        }
+        if let Some(ref group_by) = stmt.group_by {
+            nodes.push(PlanNode::GroupBy(GroupByPlan {
+                columns: group_by.columns.clone(),
+            }));
+        }
+        let functions = Self::aggregate_function_names(&stmt.columns);
+        if !functions.is_empty() {
+            nodes.push(PlanNode::Aggregate(AggregatePlan { functions }));
+        }
+        if let Some(ref order_by) = stmt.order_by {
+            let keys = order_by
+                .iter()
+                .map(|o| {
+                    let (col, dir) = o.to_display_pair();
+                    format!("{col} {dir}")
+                })
+                .collect();
+            nodes.push(PlanNode::Sort(SortPlan { keys }));
+        }
+    }
+
+    /// Returns the aggregate function names in SELECT-list order, or an empty
+    /// vec when the projection has no aggregates.
+    fn aggregate_function_names(columns: &crate::velesql::ast::SelectColumns) -> Vec<String> {
+        use crate::velesql::ast::SelectColumns;
+        let aggregations = match columns {
+            SelectColumns::Aggregations(aggs) => aggs.as_slice(),
+            SelectColumns::Mixed { aggregations, .. } => aggregations.as_slice(),
+            _ => &[],
+        };
+        aggregations
+            .iter()
+            .map(|a| format!("{:?}", a.function_type))
+            .collect()
+    }
+
+    /// Appends the OFFSET (when present) and LIMIT pagination nodes last, so the
+    /// pipeline order is scan → filter → joins → group → aggregate → sort →
+    /// offset → limit.
+    fn push_pagination_nodes(
+        nodes: &mut Vec<PlanNode>,
+        stmt: &SelectStatement,
+        implicit_limit: bool,
+    ) {
         if let Some(offset) = stmt.offset {
             nodes.push(PlanNode::Offset(OffsetPlan { count: offset }));
         }
         Self::push_limit_node(nodes, stmt, implicit_limit);
-
-        filter_strategy
     }
 
     /// Pushes the Limit node for a statement.

--- a/crates/velesdb-core/src/velesql/explain/step.rs
+++ b/crates/velesdb-core/src/velesql/explain/step.rs
@@ -1,0 +1,186 @@
+//! Flattened, structured EXPLAIN step emission.
+//!
+//! [`QueryPlan::to_plan_steps`] walks the same [`PlanNode`] tree that
+//! [`QueryPlan::to_tree`](super::formatter) renders, producing the canonical
+//! structured step list consumed by the REST `/query/explain` endpoint. Both
+//! the text tree and this step list derive from one source of truth — the plan
+//! tree — so the server no longer reconstructs steps from the raw AST.
+
+use super::types::{
+    FilterPlan, JoinPlanNode, LimitPlan, PlanNode, PlanStep, PlanStepKind, QueryPlan,
+};
+
+use PlanStepKind as Kind;
+
+const VECTOR_DESC: &str = "ANN search using HNSW index with NEAR clause";
+const FILTER_DESC: &str = "Apply WHERE clause predicates";
+const GROUP_DESC: &str = "Group rows by specified columns";
+const AGGREGATE_DESC: &str = "Compute aggregate functions (COUNT, SUM, etc.)";
+const SORT_DESC: &str = "Sort results by ORDER BY clause";
+
+impl QueryPlan {
+    /// Flattens the plan tree into ordered, structured EXPLAIN steps.
+    ///
+    /// When the plan has a `LIMIT`, a standalone `OFFSET` node is folded into
+    /// that `LIMIT` step's description (`... OFFSET n`), matching the historical
+    /// flat step list. A query with `OFFSET` but no `LIMIT` (compound/MATCH)
+    /// instead surfaces a dedicated `Offset` step.
+    #[must_use]
+    pub fn to_plan_steps(&self) -> Vec<PlanStep> {
+        let mut flat = Vec::new();
+        Self::flatten_nodes(&self.root, &mut flat);
+        let offset = pagination_offset(&flat);
+        let has_limit = flat.iter().any(|n| matches!(n, PlanNode::Limit(_)));
+
+        let mut steps = Vec::new();
+        for node in flat {
+            if let Some(step) = step_for_node(node, steps.len() + 1, offset, has_limit) {
+                steps.push(step);
+            }
+        }
+        steps
+    }
+
+    /// Collects nodes in pipeline order, expanding nested `Sequence` nodes.
+    fn flatten_nodes<'a>(node: &'a PlanNode, out: &mut Vec<&'a PlanNode>) {
+        match node {
+            PlanNode::Sequence(children) => {
+                for child in children {
+                    Self::flatten_nodes(child, out);
+                }
+            }
+            other => out.push(other),
+        }
+    }
+}
+
+impl PlanStep {
+    /// Maps the step kind to the exact REST `operation` wire string.
+    ///
+    /// The vocabulary is preserved verbatim (e.g. `TableScan` → `"FullScan"`,
+    /// `Join` → `"{Type}Join"`) so the `/query/explain` contract is additive.
+    #[must_use]
+    pub fn rest_operation(&self) -> String {
+        match self.operation {
+            Kind::VectorSearch => "VectorSearch".to_string(),
+            Kind::TableScan => "FullScan".to_string(),
+            Kind::IndexLookup => "IndexLookup".to_string(),
+            Kind::Filter => "Filter".to_string(),
+            Kind::Join => format!("{}Join", self.join_type.as_deref().unwrap_or_default()),
+            Kind::GroupBy => "GroupBy".to_string(),
+            Kind::Aggregate => "Aggregate".to_string(),
+            Kind::Sort => "Sort".to_string(),
+            Kind::Limit => "Limit".to_string(),
+            Kind::Offset => "Offset".to_string(),
+            Kind::MatchTraversal => "MatchTraversal".to_string(),
+        }
+    }
+}
+
+/// Returns the OFFSET count to fold into the Limit step (0 when absent).
+fn pagination_offset(flat: &[&PlanNode]) -> u64 {
+    flat.iter()
+        .find_map(|n| match n {
+            PlanNode::Offset(o) => Some(o.count),
+            _ => None,
+        })
+        .unwrap_or(0)
+}
+
+/// Builds the structured step for a single leaf node.
+///
+/// Returns `None` for `Sequence` (flattened away) and for a standalone `Offset`
+/// when the plan also has a `LIMIT` (the offset is folded into the Limit step).
+/// An `Offset` with no `LIMIT` becomes its own `Offset` step.
+fn step_for_node(node: &PlanNode, step: usize, offset: u64, has_limit: bool) -> Option<PlanStep> {
+    let built = match node {
+        PlanNode::Sequence(_) => return None,
+        PlanNode::Offset(_) if has_limit => return None, // folded into the Limit step
+        PlanNode::Offset(o) => plain(
+            step,
+            Kind::Offset,
+            format!("Skip {} rows (OFFSET)", o.count),
+        ),
+        PlanNode::VectorSearch(_) => plain(step, Kind::VectorSearch, VECTOR_DESC.to_string()),
+        PlanNode::TableScan(ts) => plain(
+            step,
+            Kind::TableScan,
+            format!("Scan collection '{}'", ts.collection),
+        ),
+        PlanNode::IndexLookup(il) => plain(
+            step,
+            Kind::IndexLookup,
+            format!(
+                "Property index lookup {}.{} = {}",
+                il.label, il.property, il.value
+            ),
+        ),
+        PlanNode::GroupBy(_) => plain(step, Kind::GroupBy, GROUP_DESC.to_string()),
+        PlanNode::Aggregate(_) => plain(step, Kind::Aggregate, AGGREGATE_DESC.to_string()),
+        PlanNode::Sort(_) => plain(step, Kind::Sort, SORT_DESC.to_string()),
+        PlanNode::MatchTraversal(mt) => plain(
+            step,
+            Kind::MatchTraversal,
+            format!("Graph traversal: {}", mt.strategy),
+        ),
+        PlanNode::Filter(f) => filter_step(step, f),
+        PlanNode::Join(j) => join_step(step, j),
+        PlanNode::Limit(l) => limit_step(step, l, offset),
+    };
+    Some(built)
+}
+
+/// Builds a step with no join type, estimate, or estimation method.
+fn plain(step: usize, operation: PlanStepKind, description: String) -> PlanStep {
+    PlanStep {
+        step,
+        operation,
+        join_type: None,
+        description,
+        estimated_rows: None,
+        estimation_method: None,
+    }
+}
+
+/// Builds a `Filter` step, carrying the core plan's native row estimate.
+fn filter_step(step: usize, filter: &FilterPlan) -> PlanStep {
+    PlanStep {
+        step,
+        operation: Kind::Filter,
+        join_type: None,
+        description: FILTER_DESC.to_string(),
+        estimated_rows: filter.estimated_rows,
+        estimation_method: filter.estimation_method.clone(),
+    }
+}
+
+/// Builds a `Join` step, carrying the join-type label for the wire string.
+fn join_step(step: usize, join: &JoinPlanNode) -> PlanStep {
+    PlanStep {
+        step,
+        operation: Kind::Join,
+        join_type: Some(join.join_type.clone()),
+        description: format!("Join with '{}'", join.table),
+        estimated_rows: None,
+        estimation_method: None,
+    }
+}
+
+/// Builds a `Limit` step, folding any `OFFSET` into its description.
+fn limit_step(step: usize, limit: &LimitPlan, offset: u64) -> PlanStep {
+    PlanStep {
+        step,
+        operation: Kind::Limit,
+        join_type: None,
+        description: limit_description(limit, offset),
+        estimated_rows: Some(limit.count),
+        estimation_method: None,
+    }
+}
+
+/// Formats the LIMIT step description, folding OFFSET in (matches the prior
+/// server template `Apply LIMIT N (default) OFFSET M`).
+fn limit_description(limit: &LimitPlan, offset: u64) -> String {
+    let marker = if limit.is_default { " (default)" } else { "" };
+    format!("Apply LIMIT {}{marker} OFFSET {offset}", limit.count)
+}

--- a/crates/velesdb-core/src/velesql/explain/types.rs
+++ b/crates/velesdb-core/src/velesql/explain/types.rs
@@ -65,6 +65,14 @@ pub enum PlanNode {
     Sequence(Vec<PlanNode>),
     /// MATCH graph traversal (EPIC-046 US-004).
     MatchTraversal(MatchTraversalPlan),
+    /// Cross-store JOIN operation.
+    Join(JoinPlanNode),
+    /// GROUP BY aggregation grouping.
+    GroupBy(GroupByPlan),
+    /// Aggregate function computation (COUNT, SUM, ...).
+    Aggregate(AggregatePlan),
+    /// ORDER BY sort operation.
+    Sort(SortPlan),
 }
 
 /// Vector search plan details.
@@ -147,6 +155,37 @@ pub struct MatchTraversalPlan {
     pub has_similarity: bool,
     /// Similarity threshold (if any).
     pub similarity_threshold: Option<f32>,
+}
+
+/// Cross-store JOIN plan details.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct JoinPlanNode {
+    /// Join type label (`Inner`, `Left`, `Right`, `Full`) preserved verbatim
+    /// from the parsed `JoinType` so the REST wire string stays `{Type}Join`.
+    pub join_type: String,
+    /// Table/store being joined.
+    pub table: String,
+}
+
+/// GROUP BY plan details.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct GroupByPlan {
+    /// Columns the rows are grouped by.
+    pub columns: Vec<String>,
+}
+
+/// Aggregate-computation plan details.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct AggregatePlan {
+    /// Aggregate function names in SELECT-list order (e.g. `Count`, `Sum`).
+    pub functions: Vec<String>,
+}
+
+/// ORDER BY sort plan details.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SortPlan {
+    /// Sort keys as `"column DIRECTION"` display pairs (e.g. `price DESC`).
+    pub keys: Vec<String>,
 }
 
 /// Fusion strategy info for EXPLAIN output (issue #471).
@@ -349,4 +388,62 @@ pub enum FilterStrategy {
     PreFilter,
     /// Post-filtering: filter after vector search (low selectivity).
     PostFilter,
+}
+
+/// Logical operation of a flattened EXPLAIN [`PlanStep`].
+///
+/// This is the canonical, single-sourced step vocabulary derived from the
+/// [`PlanNode`] tree. [`PlanStep::rest_operation`](crate::velesql::PlanStep)
+/// maps each kind to the exact REST `operation` wire string.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum PlanStepKind {
+    /// ANN vector search.
+    VectorSearch,
+    /// Full collection scan (no index).
+    TableScan,
+    /// Property index lookup.
+    IndexLookup,
+    /// Metadata filter.
+    Filter,
+    /// Cross-store join.
+    Join,
+    /// GROUP BY grouping.
+    GroupBy,
+    /// Aggregate computation.
+    Aggregate,
+    /// ORDER BY sort.
+    Sort,
+    /// LIMIT (with folded OFFSET) pagination.
+    Limit,
+    /// OFFSET skip (rendered standalone only when no Limit folds it).
+    Offset,
+    /// MATCH graph traversal.
+    MatchTraversal,
+}
+
+/// A flattened, structured EXPLAIN plan step.
+///
+/// Produced by [`QueryPlan::to_plan_steps`](crate::velesql::QueryPlan) — the
+/// single source of truth for both the REST `/query/explain` step list and any
+/// other structured consumer. The text tree ([`QueryPlan::to_tree`]) and this
+/// step list both derive from the same [`PlanNode`] tree.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PlanStep {
+    /// 1-based step number in pipeline order.
+    pub step: usize,
+    /// Logical operation kind.
+    pub operation: PlanStepKind,
+    /// Join type label (`Inner`/`Left`/...), set only for [`PlanStepKind::Join`]
+    /// so `rest_operation` can reproduce the `{Type}Join` wire string.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub join_type: Option<String>,
+    /// Human-readable description of what the step does.
+    pub description: String,
+    /// Estimated rows produced, when known.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub estimated_rows: Option<u64>,
+    /// How the row estimate was produced (`"histogram"`, `"cardinality"`, ...).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub estimation_method: Option<String>,
 }

--- a/crates/velesdb-core/src/velesql/explain_tests.rs
+++ b/crates/velesdb-core/src/velesql/explain_tests.rs
@@ -1206,6 +1206,144 @@ fn test_match_query_plan_has_no_implicit_limit() {
     );
 }
 
+// ---------------------------------------------------------------------------
+// to_plan_steps(): single-sourced structured EXPLAIN steps (C11)
+// ---------------------------------------------------------------------------
+
+fn plan_steps_for(query: &str) -> Vec<PlanStep> {
+    let parsed = crate::velesql::Parser::parse(query).expect("parse query");
+    QueryPlan::from_query(&parsed).to_plan_steps()
+}
+
+#[test]
+fn test_plan_steps_scan_maps_to_fullscan_wire_string() {
+    let steps = plan_steps_for("SELECT * FROM docs");
+    let first = steps.first().expect("at least one step");
+    assert_eq!(first.operation, PlanStepKind::TableScan);
+    // REST vocabulary is preserved: TableScan kind renders as "FullScan".
+    assert_eq!(first.rest_operation(), "FullScan");
+}
+
+#[test]
+fn test_plan_steps_default_limit_step() {
+    let steps = plan_steps_for("SELECT * FROM docs");
+    let limit = steps
+        .iter()
+        .find(|s| s.operation == PlanStepKind::Limit)
+        .expect("a Limit step");
+    assert_eq!(limit.rest_operation(), "Limit");
+    assert_eq!(limit.estimated_rows, Some(10));
+    assert!(
+        limit.description.contains("LIMIT 10 (default)"),
+        "default limit description: {}",
+        limit.description
+    );
+}
+
+#[test]
+fn test_plan_steps_offset_is_folded_into_limit() {
+    let steps = plan_steps_for("SELECT * FROM docs LIMIT 5 OFFSET 20");
+    assert!(
+        steps.iter().all(|s| s.operation != PlanStepKind::Offset),
+        "OFFSET must be folded into the Limit step, not emitted standalone"
+    );
+    let limit = steps
+        .iter()
+        .find(|s| s.operation == PlanStepKind::Limit)
+        .expect("a Limit step");
+    assert_eq!(limit.estimated_rows, Some(5));
+    assert!(
+        limit.description.contains("LIMIT 5") && limit.description.contains("OFFSET 20"),
+        "limit step folds offset: {}",
+        limit.description
+    );
+}
+
+#[test]
+fn test_plan_steps_join_preserves_typed_wire_string() {
+    let steps = plan_steps_for("SELECT * FROM orders JOIN customers ON orders.cid = customers.id");
+    let join = steps
+        .iter()
+        .find(|s| s.operation == PlanStepKind::Join)
+        .expect("a Join step");
+    // Default JOIN is INNER; wire string stays "{Type}Join" -> "InnerJoin".
+    assert_eq!(join.rest_operation(), "InnerJoin");
+}
+
+#[test]
+fn test_plan_steps_group_aggregate_sort_pipeline_order() {
+    let steps = plan_steps_for(
+        "SELECT category, COUNT(*) FROM docs GROUP BY category ORDER BY COUNT(*) DESC LIMIT 5",
+    );
+    let kinds: Vec<PlanStepKind> = steps.iter().map(|s| s.operation).collect();
+    for expected in [
+        PlanStepKind::GroupBy,
+        PlanStepKind::Aggregate,
+        PlanStepKind::Sort,
+        PlanStepKind::Limit,
+    ] {
+        assert!(
+            kinds.contains(&expected),
+            "missing {expected:?} in {kinds:?}"
+        );
+    }
+    // Pipeline order: group -> aggregate -> sort -> limit.
+    let pos = |k: PlanStepKind| kinds.iter().position(|x| *x == k).expect("kind present");
+    assert!(pos(PlanStepKind::GroupBy) < pos(PlanStepKind::Aggregate));
+    assert!(pos(PlanStepKind::Aggregate) < pos(PlanStepKind::Sort));
+    assert!(pos(PlanStepKind::Sort) < pos(PlanStepKind::Limit));
+}
+
+#[test]
+fn test_plan_steps_vector_search_estimated_rows_is_none() {
+    // The VectorSearch step no longer echoes the LIMIT; the estimate is on the
+    // Limit step, where it is unambiguous.
+    let steps = plan_steps_for("SELECT * FROM docs WHERE vector NEAR $v LIMIT 10");
+    let vs = steps
+        .iter()
+        .find(|s| s.operation == PlanStepKind::VectorSearch)
+        .expect("a VectorSearch step");
+    assert_eq!(vs.estimated_rows, None);
+    let limit = steps
+        .iter()
+        .find(|s| s.operation == PlanStepKind::Limit)
+        .expect("a Limit step");
+    assert_eq!(limit.estimated_rows, Some(10));
+}
+
+#[test]
+fn test_plan_steps_standalone_offset_without_limit() {
+    // A plan with OFFSET but no LIMIT (compound/MATCH shape) surfaces a
+    // dedicated Offset step rather than folding into a nonexistent Limit.
+    let plan = QueryPlan {
+        root: PlanNode::Sequence(vec![
+            PlanNode::TableScan(TableScanPlan {
+                collection: "docs".to_string(),
+            }),
+            PlanNode::Offset(OffsetPlan { count: 7 }),
+        ]),
+        estimated_cost_ms: 1.0,
+        index_used: None,
+        filter_strategy: FilterStrategy::None,
+        with_options: vec![],
+        let_bindings: vec![],
+        fusion_info: None,
+        cache_hit: None,
+        plan_reuse_count: None,
+    };
+    let steps = plan.to_plan_steps();
+    let offset = steps
+        .iter()
+        .find(|s| s.operation == PlanStepKind::Offset)
+        .expect("a standalone Offset step");
+    assert_eq!(offset.rest_operation(), "Offset");
+    assert!(offset.description.contains('7'), "{}", offset.description);
+    assert!(
+        steps.iter().all(|s| s.operation != PlanStepKind::Limit),
+        "no Limit step should be present"
+    );
+}
+
 #[test]
 fn test_compound_query_plan_has_no_implicit_limit() {
     let query = crate::velesql::Parser::parse("SELECT * FROM a UNION SELECT * FROM b")

--- a/crates/velesdb-core/src/velesql/mod.rs
+++ b/crates/velesdb-core/src/velesql/mod.rs
@@ -269,9 +269,10 @@ pub(crate) use explain::strip_vector_predicates;
 #[cfg(feature = "persistence")]
 pub use explain::{
     build_leaf_node_stats, fallback_selectivity_threshold, set_fallback_selectivity_threshold,
-    ActualStats, ExplainOutput, FeedbackCalibration, FilterPlan, FilterStrategy, FusionInfo,
-    IndexLookupPlan, IndexType, LimitPlan, MatchTraversalPlan, NodeStats, OffsetPlan, PlanNode,
-    QueryPlan, TableScanPlan, VectorSearchPlan, DEFAULT_FALLBACK_SELECTIVITY_THRESHOLD,
+    ActualStats, AggregatePlan, ExplainOutput, FeedbackCalibration, FilterPlan, FilterStrategy,
+    FusionInfo, GroupByPlan, IndexLookupPlan, IndexType, JoinPlanNode, LimitPlan,
+    MatchTraversalPlan, NodeStats, OffsetPlan, PlanNode, PlanStep, PlanStepKind, QueryPlan,
+    SortPlan, TableScanPlan, VectorSearchPlan, DEFAULT_FALLBACK_SELECTIVITY_THRESHOLD,
 };
 pub use parser::match_clause;
 pub use parser::Parser;

--- a/crates/velesdb-server/src/handlers/query/explain.rs
+++ b/crates/velesdb-server/src/handlers/query/explain.rs
@@ -2,7 +2,7 @@
 
 use axum::{extract::State, response::IntoResponse, Json};
 use std::sync::Arc;
-use velesdb_core::velesql::{Condition, SelectColumns, DEFAULT_SELECT_LIMIT};
+use velesdb_core::velesql::{Condition, QueryPlan, SelectColumns};
 
 use crate::types::{
     ActualStatsResponse, ExplainCost, ExplainFeatures, ExplainRequest, ExplainResponse,
@@ -54,6 +54,21 @@ pub async fn explain(
     explain_plan_only(&state, &req, &parsed)
 }
 
+/// Computes the EXPLAIN preamble shared by the plan-only and ANALYZE paths:
+/// detected query features, estimated cost, and the query-type label.
+fn explain_preamble(
+    parsed: &velesdb_core::velesql::Query,
+) -> (ExplainFeatures, ExplainCost, &'static str) {
+    let features = detect_explain_features(&parsed.select);
+    let estimated_cost = estimate_cost(features.has_vector_search);
+    let query_type = if parsed.is_match_query() {
+        "MATCH"
+    } else {
+        "SELECT"
+    };
+    (features, estimated_cost, query_type)
+}
+
 /// Build an EXPLAIN-only response (no execution).
 fn explain_plan_only(
     state: &AppState,
@@ -61,24 +76,15 @@ fn explain_plan_only(
     parsed: &velesdb_core::velesql::Query,
 ) -> axum::response::Response {
     let select = &parsed.select;
-    let features = detect_explain_features(select);
-    let mut plan = build_explain_plan(parsed, &features);
-    let estimated_cost = estimate_cost(features.has_vector_search);
-    let query_type = if parsed.is_match_query() {
-        "MATCH"
-    } else {
-        "SELECT"
-    };
+    let (features, estimated_cost, query_type) = explain_preamble(parsed);
 
-    let (cache_hit, plan_reuse_count) =
-        state
-            .db
-            .explain_query(parsed)
-            .ok()
-            .map_or((None, None), |qp| {
-                merge_core_estimation(&mut plan, &qp);
-                (qp.cache_hit, qp.plan_reuse_count)
-            });
+    // Single-sourced from core: the plan steps come from the canonical
+    // `QueryPlan`, not a server-side AST reconstruction. The DB-less fallback
+    // keeps EXPLAIN working when the collection cannot be resolved.
+    let (plan, cache_hit, plan_reuse_count) = match state.db.explain_query(parsed) {
+        Ok(qp) => (core_plan_steps(&qp), qp.cache_hit, qp.plan_reuse_count),
+        Err(_) => (core_plan_steps(&QueryPlan::from_query(parsed)), None, None),
+    };
 
     Json(ExplainResponse {
         query: req.query.clone(),
@@ -104,22 +110,15 @@ fn explain_with_analyze(
     parsed: &velesdb_core::velesql::Query,
 ) -> axum::response::Response {
     let select = &parsed.select;
-    let features = detect_explain_features(select);
-    let mut plan = build_explain_plan(parsed, &features);
-    let estimated_cost = estimate_cost(features.has_vector_search);
-    let query_type = if parsed.is_match_query() {
-        "MATCH"
-    } else {
-        "SELECT"
-    };
+    let (features, estimated_cost, query_type) = explain_preamble(parsed);
 
     let output = match run_analyze_query(state, parsed, &req.params) {
         Ok(o) => o,
         Err(resp) => return *resp,
     };
 
-    // Merge core estimation metadata into server plan (graceful: already have output).
-    merge_core_estimation(&mut plan, &output.plan);
+    // Single-sourced from core: steps derive from the executed plan.
+    let plan = core_plan_steps(&output.plan);
 
     let (actual_stats_resp, actual_time, node_stats_resp) = extract_analyze_stats(&output);
 
@@ -213,163 +212,12 @@ fn detect_explain_features(select: &velesdb_core::velesql::SelectStatement) -> E
     }
 }
 
-/// Build the execution plan steps for an EXPLAIN response.
-fn build_explain_plan(
-    parsed: &velesdb_core::velesql::Query,
-    features: &ExplainFeatures,
-) -> Vec<ExplainStep> {
-    let select = &parsed.select;
-    let mut plan = Vec::new();
-    let mut step_num = 1;
-
-    plan.push(build_source_step(select, features, step_num));
-    step_num += 1;
-
-    append_filter_and_join_steps(select, features, &mut plan, &mut step_num);
-    append_aggregation_steps(features, &mut plan, &mut step_num);
-    // MATCH and compound queries have no implicit default LIMIT.
-    let implicit_limit = parsed.match_clause.is_none() && parsed.compound.is_none();
-    append_pagination_step(select, &mut plan, step_num, implicit_limit);
-
-    plan
-}
-
-fn build_source_step(
-    select: &velesdb_core::velesql::SelectStatement,
-    features: &ExplainFeatures,
-    step_num: usize,
-) -> ExplainStep {
-    if features.has_vector_search {
-        ExplainStep {
-            step: step_num,
-            operation: "VectorSearch".to_string(),
-            description: "ANN search using HNSW index with NEAR clause".to_string(),
-            estimated_rows: select.limit.map(|l| l as usize),
-            estimation_method: None,
-        }
-    } else {
-        ExplainStep {
-            step: step_num,
-            operation: "FullScan".to_string(),
-            description: format!("Scan collection '{}'", select.from),
-            estimated_rows: None,
-            estimation_method: None,
-        }
-    }
-}
-
-fn append_filter_and_join_steps(
-    select: &velesdb_core::velesql::SelectStatement,
-    features: &ExplainFeatures,
-    plan: &mut Vec<ExplainStep>,
-    step_num: &mut usize,
-) {
-    if features.has_filter {
-        plan.push(ExplainStep {
-            step: *step_num,
-            operation: "Filter".to_string(),
-            description: "Apply WHERE clause predicates".to_string(),
-            estimated_rows: None,
-            estimation_method: None,
-        });
-        *step_num += 1;
-    }
-
-    for join in &select.joins {
-        plan.push(ExplainStep {
-            step: *step_num,
-            operation: format!("{:?}Join", join.join_type),
-            description: format!("Join with '{}'", join.table),
-            estimated_rows: None,
-            estimation_method: None,
-        });
-        *step_num += 1;
-    }
-}
-
-fn append_aggregation_steps(
-    features: &ExplainFeatures,
-    plan: &mut Vec<ExplainStep>,
-    step_num: &mut usize,
-) {
-    if features.has_group_by {
-        plan.push(ExplainStep {
-            step: *step_num,
-            operation: "GroupBy".to_string(),
-            description: "Group rows by specified columns".to_string(),
-            estimated_rows: None,
-            estimation_method: None,
-        });
-        *step_num += 1;
-    }
-
-    if features.has_aggregation {
-        plan.push(ExplainStep {
-            step: *step_num,
-            operation: "Aggregate".to_string(),
-            description: "Compute aggregate functions (COUNT, SUM, etc.)".to_string(),
-            estimated_rows: None,
-            estimation_method: None,
-        });
-        *step_num += 1;
-    }
-
-    if features.has_order_by {
-        plan.push(ExplainStep {
-            step: *step_num,
-            operation: "Sort".to_string(),
-            description: "Sort results by ORDER BY clause".to_string(),
-            estimated_rows: None,
-            estimation_method: None,
-        });
-        *step_num += 1;
-    }
-}
-
-/// Appends the LIMIT/OFFSET step.
+/// Maps a core [`QueryPlan`] into the REST [`ExplainStep`] list.
 ///
-/// Plain SELECT statements (`implicit_limit == true`) without an explicit
-/// LIMIT surface the engine default ([`DEFAULT_SELECT_LIMIT`]) so the plan
-/// matches what execution actually returns. MATCH and compound queries
-/// (`implicit_limit == false`) have no implicit limit.
-fn append_pagination_step(
-    select: &velesdb_core::velesql::SelectStatement,
-    plan: &mut Vec<ExplainStep>,
-    step_num: usize,
-    implicit_limit: bool,
-) {
-    let Some((limit, is_default)) = resolve_pagination_limit(select, implicit_limit) else {
-        return;
-    };
-    let marker = if is_default { " (default)" } else { "" };
-    let estimated_rows = (select.limit.is_some() || is_default).then_some(limit as usize);
-    plan.push(ExplainStep {
-        step: step_num,
-        operation: "Limit".to_string(),
-        description: format!(
-            "Apply LIMIT {limit}{marker} OFFSET {}",
-            select.offset.unwrap_or(0)
-        ),
-        estimated_rows,
-        estimation_method: None,
-    });
-}
-
-/// Resolves the effective LIMIT for the pagination step.
-///
-/// Returns `(limit, is_default)`, or `None` when no step should be emitted
-/// (no LIMIT, no OFFSET, and no implicit default — MATCH/compound queries).
-fn resolve_pagination_limit(
-    select: &velesdb_core::velesql::SelectStatement,
-    implicit_limit: bool,
-) -> Option<(u64, bool)> {
-    match select.limit {
-        Some(limit) => Some((limit, false)),
-        None if implicit_limit => Some((DEFAULT_SELECT_LIMIT, true)),
-        // OFFSET without LIMIT on a no-default query keeps the LIMIT 0 display.
-        None if select.offset.is_some() => Some((0, false)),
-        None => None,
-    }
+/// The plan steps are single-sourced from `velesdb-core` (`to_plan_steps`),
+/// so the server no longer reconstructs them from the parsed AST.
+fn core_plan_steps(plan: &QueryPlan) -> Vec<ExplainStep> {
+    plan.to_plan_steps().iter().map(ExplainStep::from).collect()
 }
 
 /// Estimate execution cost based on query features.
@@ -403,38 +251,5 @@ pub(super) fn condition_has_vector_search(cond: &Condition) -> bool {
         }
         Condition::Group(inner) | Condition::Not(inner) => condition_has_vector_search(inner),
         _ => false,
-    }
-}
-
-// ---------------------------------------------------------------------------
-// Core plan merge helpers (Task 2.2)
-// ---------------------------------------------------------------------------
-
-/// Recursively extracts the first `FilterPlan` from a core `PlanNode` tree.
-fn extract_filter_plan(
-    node: &velesdb_core::velesql::PlanNode,
-) -> Option<&velesdb_core::velesql::FilterPlan> {
-    match node {
-        velesdb_core::velesql::PlanNode::Filter(fp) => Some(fp),
-        velesdb_core::velesql::PlanNode::Sequence(nodes) => {
-            nodes.iter().find_map(extract_filter_plan)
-        }
-        _ => None,
-    }
-}
-
-/// Merges core `FilterPlan` estimation data into server `ExplainStep` entries.
-///
-/// Copies `estimated_rows` and `estimation_method` from the core plan's
-/// `FilterPlan` into every server step whose `operation` is `"Filter"`.
-#[allow(clippy::cast_possible_truncation)]
-fn merge_core_estimation(plan: &mut [ExplainStep], core_plan: &velesdb_core::velesql::QueryPlan) {
-    if let Some(fp) = extract_filter_plan(&core_plan.root) {
-        for step in plan.iter_mut() {
-            if step.operation == "Filter" {
-                step.estimated_rows = fp.estimated_rows.map(|r| r as usize);
-                step.estimation_method = fp.estimation_method.clone();
-            }
-        }
     }
 }

--- a/crates/velesdb-server/tests/api_integration.rs
+++ b/crates/velesdb-server/tests/api_integration.rs
@@ -3184,6 +3184,71 @@ async fn test_explain_select_without_limit_exposes_default_limit_step() {
     );
 }
 
+#[tokio::test]
+async fn test_explain_group_by_order_by_steps_preserved() {
+    let temp_dir = TempDir::new().unwrap();
+    let app = create_test_app(&temp_dir);
+
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/collections")
+                .header("Content-Type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "name": "explain_agg",
+                        "dimension": 4,
+                        "metric": "cosine"
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::CREATED);
+
+    // GROUP BY + aggregate + ORDER BY: the single-sourced plan (core
+    // `to_plan_steps`) must still surface the GroupBy/Aggregate/Sort steps the
+    // server previously reconstructed from the AST (additive preservation).
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/query/explain")
+                .header("Content-Type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "query": "SELECT category, COUNT(*) FROM explain_agg GROUP BY category ORDER BY COUNT(*) DESC LIMIT 5"
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: Value = serde_json::from_slice(&body).unwrap();
+    let ops: Vec<&str> = json["plan"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter_map(|step| step["operation"].as_str())
+        .collect();
+    for expected in ["GroupBy", "Aggregate", "Sort", "Limit"] {
+        assert!(
+            ops.contains(&expected),
+            "single-sourced plan must keep the {expected} step: {ops:?}"
+        );
+    }
+}
+
 // ============================================================================
 // GuardRails — rate limit (429)
 // ============================================================================

--- a/docs/VELESQL_SPEC.md
+++ b/docs/VELESQL_SPEC.md
@@ -1868,6 +1868,17 @@ tree now explicitly surfaces the similarity-as-predicate routing decision
 (see **Order by Similarity** above) — the `VectorSearch` node appears even
 though the SQL text has no `NEAR`.
 
+#### REST plan single-sourced from core (next minor release)
+
+The REST `/query/explain` step list is now produced directly from the engine
+plan via `QueryPlan::to_plan_steps()`, the same `PlanNode` tree the CLI
+`.explain` renders — it is no longer reconstructed from the parsed AST. The
+wire `operation` vocabulary is unchanged (additive): a full scan still reports
+`FullScan` and joins still report `{Type}Join`. As a side effect, `GROUP BY`,
+aggregation, `ORDER BY`, and `JOIN` steps now also appear in the CLI/Python
+`to_tree()` output (previously only the REST view surfaced them), and an
+indexed-equality predicate may surface an `IndexLookup` step.
+
 Returns a single row with:
 
 | Field | Type | Description |

--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -994,28 +994,58 @@ Analyze query execution plan without running the query.
 }
 ```
 
-**Response:**
+**Response:** the plan is a flat, ordered list of steps, single-sourced from
+the engine's query plan (the same plan the CLI `.explain` renders):
 ```json
 {
-  "plan": {
-    "type": "VectorSearch",
-    "collection": "docs",
-    "metric": "cosine",
-    "limit": 10,
-    "estimated_cost": 0.05,
-    "children": []
+  "query": "SELECT * FROM docs WHERE vector NEAR $v LIMIT 10",
+  "query_type": "SELECT",
+  "collection": "docs",
+  "plan": [
+    {
+      "step": 1,
+      "operation": "VectorSearch",
+      "description": "ANN search using HNSW index with NEAR clause",
+      "estimated_rows": null
+    },
+    {
+      "step": 2,
+      "operation": "Filter",
+      "description": "Apply WHERE clause predicates",
+      "estimated_rows": 42,
+      "estimation_method": "histogram"
+    },
+    {
+      "step": 3,
+      "operation": "Limit",
+      "description": "Apply LIMIT 10 OFFSET 0",
+      "estimated_rows": 10
+    }
+  ],
+  "estimated_cost": {
+    "uses_index": true,
+    "index_name": "HNSW",
+    "selectivity": 0.01,
+    "complexity": "O(log n)"
   },
-  "timing_ms": 0.12
+  "features": { "has_vector_search": true, "has_filter": true }
 }
 ```
 
-**Plan Node Types:**
-- `TableScan` - Full collection scan
+Set `"analyze": true` to execute the query and add `actual_time_ms`,
+`actual_stats`, and per-node `node_stats` to the response.
+
+**`operation` values:**
+- `FullScan` - full collection scan (no index)
 - `VectorSearch` - HNSW approximate nearest neighbor
-- `IndexLookup` - Property index lookup
-- `Filter` - Post-search filtering
-- `Limit` - Result limiting
-- `Offset` - Result offsetting
+- `IndexLookup` - property index lookup
+- `Filter` - metadata filtering
+- `{Type}Join` - cross-store join (`InnerJoin`, `LeftJoin`, `RightJoin`, `FullJoin`)
+- `GroupBy` - GROUP BY grouping
+- `Aggregate` - aggregate computation (COUNT, SUM, ...)
+- `Sort` - ORDER BY sort
+- `Limit` - result limiting (folds OFFSET into its description)
+- `MatchTraversal` - MATCH graph traversal
 
 ---
 


### PR DESCRIPTION
## What & why

Closes the last W4 parity item (**C11**). The server `EXPLAIN` handler reconstructed the plan step list from the parsed **AST**, diverging from the CLI/introspection paths which render the canonical core `QueryPlan`. This makes **velesdb-core the single source of truth** for the EXPLAIN plan.

## Changes

- **core** — add `Sort` / `GroupBy` / `Aggregate` / `Join` `PlanNode` variants + planner emission, so the plan tree models every post-filter operation.
- **core** — add `QueryPlan::to_plan_steps() -> Vec<PlanStep>` (new `step.rs`), with `PlanStep` / `PlanStepKind` and `PlanStep::rest_operation()`. It walks the **same** `PlanNode` tree as `to_tree()` (single source); folds `OFFSET` into the `Limit` step (or emits a standalone `Offset` step when there is no `LIMIT`); carries `Filter` row estimates natively.
- **server** — delete ~170 lines of AST reconstruction (`build_explain_plan` + 7 helpers, `merge_core_estimation`); the handler is now `qp.to_plan_steps().map(ExplainStep::from)`.
- **api_types** — `From<&PlanStep> for ExplainStep` (mirrors the existing `ActualStatsResponse::from` pattern; no dependency inversion — `velesql` does not import `api_types`).
- **docs** — correct the `/query/explain` example in `api-reference.md` (the old recursive `{type, children}` shape was stale), VELESQL_SPEC note, CHANGELOG.

## Contract: additive

`rest_operation()` reproduces the **exact** prior wire strings (`TableScan -> "FullScan"`, `"{Type}Join"`, …), so the response **shape** and `docs/openapi.{json,yaml}` are **unchanged** (zero drift verified). Documented corrective side effects:
- CLI/Python `to_tree()` now show `JOIN` / `GROUP BY` / aggregation / `ORDER BY` steps.
- The `VectorSearch` step's `estimated_rows` is now `null` (the limit estimate stays on the `Limit` step, where it is unambiguous).
- An indexed-equality predicate may surface an `IndexLookup` step.
- `OFFSET` without `LIMIT` now shows an `Offset` step instead of a degenerate `Apply LIMIT 0 OFFSET N`.

**Out of scope (documented follow-ups):** `features`/`estimated_cost` remain server-derived; `velesdb-wasm` keeps its own `persistence`-gated EXPLAIN renderer; the pre-existing `FullScan` (operation) vs `TableScan` (node_label) cosmetic mismatch.

## Validation (local)

- `cargo fmt`; `clippy --workspace --all-targets … -D warnings -D clippy::pedantic` clean
- **jscpd 0 clones**; lizard: every changed function NLOC ≤ 50 & CCN ≤ 8, every file NLOC ≤ 500
- core lib explain **78 tests** (incl. 7 new `to_plan_steps` cases) + **30** planner-golden/bdd-explain
- server **3** `/query/explain` tests (incl. a new GROUP BY/ORDER BY golden); the `FullScan` + `LIMIT 10 (default)` pins pass unedited
- **openapi: zero drift**; `--no-default-features` + `wasm32` build checks pass
- full `cargo test -p velesdb-core --features persistence` green

Reviewed by an adversarial multi-agent pass; all confirmed findings (NLOC blocker, `VectorSearch.estimated_rows` disclosure, false MATCH changelog claim, `OFFSET`-no-`LIMIT` regression, WASM/cost scoping notes) folded into this PR.