### PR TITLE
refactor(explain): harden C11 from the 7-angle review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `VectorSearch` step's `estimated_rows` is now `null` (it previously echoed
   the query `LIMIT`). The limit estimate is still reported on the `Limit` step,
   where it is unambiguous.
+- A `vector NEAR` query that also carries a non-vector `WHERE` predicate (e.g.
+  `vector NEAR $v AND price > 100`) now surfaces a dedicated `Filter` step in the
+  REST/CLI `EXPLAIN` plan. The prior AST reconstruction suppressed it (its
+  `has_filter` flag was `false` whenever a vector search was present), yielding
+  `[VectorSearch, Limit]`; the single-sourced plan reports the filter that
+  actually runs, `[VectorSearch, Filter, Limit]`.
 
 ### Added
 - `velesdb_core::velesql::QueryPlan::to_plan_steps() -> Vec<PlanStep>` — the

--- a/crates/velesdb-core/src/velesql/explain/formatter.rs
+++ b/crates/velesdb-core/src/velesql/explain/formatter.rs
@@ -119,30 +119,43 @@ impl QueryPlan {
             PlanNode::MatchTraversal(mt) => {
                 Self::render_match_traversal_node(mt, output, prefix, connector, &child_prefix);
             }
-            PlanNode::Join(j) => Self::render_leaf_with_child(
-                output,
-                (prefix, &child_prefix, connector),
-                &format!("{}Join", j.join_type),
-                ("Table", &j.table),
-            ),
+            PlanNode::Join(_)
+            | PlanNode::GroupBy(_)
+            | PlanNode::Aggregate(_)
+            | PlanNode::Sort(_) => {
+                Self::render_post_filter_node(node, output, (prefix, &child_prefix, connector));
+            }
+        }
+    }
+
+    /// Renders a post-filter node (Join/GroupBy/Aggregate/Sort) as a label plus
+    /// one child line. Split out of [`Self::render_node`] to keep it small.
+    fn render_post_filter_node(node: &PlanNode, output: &mut String, frame: (&str, &str, &str)) {
+        match node {
+            PlanNode::Join(j) => {
+                Self::render_leaf_with_child(
+                    output,
+                    frame,
+                    &format!("{}Join", j.join_type),
+                    ("Table", &j.table),
+                );
+            }
             PlanNode::GroupBy(g) => Self::render_leaf_with_child(
                 output,
-                (prefix, &child_prefix, connector),
+                frame,
                 "GroupBy",
                 ("Columns", &format!("[{}]", g.columns.join(", "))),
             ),
             PlanNode::Aggregate(a) => Self::render_leaf_with_child(
                 output,
-                (prefix, &child_prefix, connector),
+                frame,
                 "Aggregate",
                 ("Functions", &format!("[{}]", a.functions.join(", "))),
             ),
-            PlanNode::Sort(s) => Self::render_leaf_with_child(
-                output,
-                (prefix, &child_prefix, connector),
-                "Sort",
-                ("Keys", &s.keys.join(", ")),
-            ),
+            PlanNode::Sort(s) => {
+                Self::render_leaf_with_child(output, frame, "Sort", ("Keys", &s.keys.join(", ")));
+            }
+            _ => {}
         }
     }
 

--- a/crates/velesdb-core/src/velesql/explain_tests.rs
+++ b/crates/velesdb-core/src/velesql/explain_tests.rs
@@ -1345,6 +1345,77 @@ fn test_plan_steps_standalone_offset_without_limit() {
 }
 
 #[test]
+fn test_plan_steps_hybrid_vector_filter_emits_filter_step() {
+    // A vector NEAR query carrying a non-vector predicate surfaces a Filter step
+    // (the prior AST reconstruction suppressed it whenever a vector search ran).
+    let steps = plan_steps_for("SELECT * FROM docs WHERE vector NEAR $v AND price > 100 LIMIT 10");
+    let ops: Vec<PlanStepKind> = steps.iter().map(|s| s.operation).collect();
+    assert!(ops.contains(&PlanStepKind::VectorSearch), "{ops:?}");
+    assert!(
+        ops.contains(&PlanStepKind::Filter),
+        "filter step expected: {ops:?}"
+    );
+    assert!(ops.contains(&PlanStepKind::Limit), "{ops:?}");
+}
+
+#[test]
+fn test_rest_operation_wire_strings_client_visible() {
+    // Lock the wire strings the prior pass left unguarded (TableScan/Limit/Offset/
+    // Join are already covered elsewhere).
+    let mk = |op: PlanStepKind| PlanStep {
+        step: 1,
+        operation: op,
+        join_type: None,
+        description: String::new(),
+        estimated_rows: None,
+        estimation_method: None,
+    };
+    assert_eq!(
+        mk(PlanStepKind::VectorSearch).rest_operation(),
+        "VectorSearch"
+    );
+    assert_eq!(
+        mk(PlanStepKind::IndexLookup).rest_operation(),
+        "IndexLookup"
+    );
+    assert_eq!(mk(PlanStepKind::Filter).rest_operation(), "Filter");
+    assert_eq!(
+        mk(PlanStepKind::MatchTraversal).rest_operation(),
+        "MatchTraversal"
+    );
+}
+
+#[test]
+fn test_to_tree_multi_column_order_by_keys_in_order() {
+    let query = crate::velesql::Parser::parse("SELECT * FROM docs ORDER BY a ASC, b DESC LIMIT 5")
+        .expect("parse multi-column ORDER BY");
+    let tree = QueryPlan::from_query(&query).to_tree();
+    assert!(tree.contains("Sort"), "{tree}");
+    assert!(
+        tree.contains("Keys: a ASC, b DESC"),
+        "multi-column sort keys must keep grammar order: {tree}"
+    );
+}
+
+#[test]
+fn test_explain_step_from_plan_step_preserves_filter_estimate() {
+    // Exercises the api_types From<&PlanStep> conversion (otherwise untested):
+    // the Filter step's native estimate + method must survive to the REST DTO.
+    let ps = PlanStep {
+        step: 2,
+        operation: PlanStepKind::Filter,
+        join_type: None,
+        description: "Apply WHERE clause predicates".to_string(),
+        estimated_rows: Some(42),
+        estimation_method: Some("histogram".to_string()),
+    };
+    let es = crate::api_types::ExplainStep::from(&ps);
+    assert_eq!(es.operation, "Filter");
+    assert_eq!(es.estimated_rows, Some(42));
+    assert_eq!(es.estimation_method.as_deref(), Some("histogram"));
+}
+
+#[test]
 fn test_compound_query_plan_has_no_implicit_limit() {
     let query = crate::velesql::Parser::parse("SELECT * FROM a UNION SELECT * FROM b")
         .expect("parse compound query");

--- a/crates/velesdb-server/tests/api_integration.rs
+++ b/crates/velesdb-server/tests/api_integration.rs
@@ -3249,6 +3249,67 @@ async fn test_explain_group_by_order_by_steps_preserved() {
     }
 }
 
+#[tokio::test]
+async fn test_explain_hybrid_vector_filter_surfaces_filter_step() {
+    let temp_dir = TempDir::new().unwrap();
+    let app = create_test_app(&temp_dir);
+
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/collections")
+                .header("Content-Type", "application/json")
+                .body(Body::from(
+                    json!({ "name": "explain_hybrid", "dimension": 4, "metric": "cosine" })
+                        .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::CREATED);
+
+    // A vector NEAR query with a scalar predicate must surface BOTH a
+    // VectorSearch and a Filter step (single-sourced from the core plan; the
+    // old AST reconstruction suppressed the Filter whenever a vector ran).
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/query/explain")
+                .header("Content-Type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "query": "SELECT * FROM explain_hybrid WHERE category = 'tech' AND vector NEAR $v LIMIT 10"
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: Value = serde_json::from_slice(&body).unwrap();
+    let ops: Vec<&str> = json["plan"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter_map(|step| step["operation"].as_str())
+        .collect();
+    for expected in ["VectorSearch", "Filter", "Limit"] {
+        assert!(
+            ops.contains(&expected),
+            "hybrid vector+filter plan must include {expected}: {ops:?}"
+        );
+    }
+}
+
 // ============================================================================
 // GuardRails — rate limit (429)
 // ============================================================================

--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -1010,13 +1010,6 @@ the engine's query plan (the same plan the CLI `.explain` renders):
     },
     {
       "step": 2,
-      "operation": "Filter",
-      "description": "Apply WHERE clause predicates",
-      "estimated_rows": 42,
-      "estimation_method": "histogram"
-    },
-    {
-      "step": 3,
       "operation": "Limit",
       "description": "Apply LIMIT 10 OFFSET 0",
       "estimated_rows": 10
@@ -1028,9 +1021,14 @@ the engine's query plan (the same plan the CLI `.explain` renders):
     "selectivity": 0.01,
     "complexity": "O(log n)"
   },
-  "features": { "has_vector_search": true, "has_filter": true }
+  "features": { "has_vector_search": true, "has_filter": false }
 }
 ```
+
+A non-vector `WHERE` predicate (e.g. `... vector NEAR $v AND price > 100 ...`)
+adds a `Filter` step between `VectorSearch` and `Limit`, carrying
+`estimated_rows` and `estimation_method` (`"histogram"`/`"cardinality"`) when
+collection statistics are available.
 
 Set `"analyze": true` to execute the query and add `actual_time_ms`,
 `actual_stats`, and per-node `node_stats` to the response.


### PR DESCRIPTION
Follow-up to **C11** (PR #1173). A deep **7-angle review** (correctness · API design · edge/panic · serde/integrity · cross-binding contract · quality/maintainability · tests/docs, each adversarially verified) found **no correctness, panic-safety, or serialization defects** — the single-sourced plan is sound. It surfaced 2 doc-accuracy gaps + test-coverage holes, fixed here surgically.

## Fixes

**Quality**
- `formatter.rs`: extract the 4 post-filter arms out of `render_node` into `render_post_filter_node` → `render_node` **65 → 47 NLOC** (behavior identical; `formatter.rs` is Codacy-excluded so this was not CI-blocking, but removes a real smell + the reliance on the exclusion).

**Doc accuracy**
- `api-reference.md`: the `/query/explain` example showed a `Filter` step + `has_filter:true` for a **bare** `NEAR` query the engine cannot produce. Corrected to the real `[VectorSearch, Limit]` plan (`has_filter:false`) + a note on when a `Filter` step actually appears.
- `CHANGELOG.md`: document that a **hybrid** `vector NEAR ... AND <scalar>` query now surfaces a `Filter` step — the prior AST reconstruction suppressed it (its `has_filter` was `false` whenever a vector ran), so `[VectorSearch, Limit]` becomes `[VectorSearch, Filter, Limit]`. The new plan reports the filter that actually runs (more accurate; intentional).

**Test hardening** (locks the changed/uncovered contract)
- server golden: hybrid `WHERE <scalar> AND vector NEAR $v` → plan has `VectorSearch` + `Filter` + `Limit`.
- core: `rest_operation()` wire strings for `VectorSearch`/`IndexLookup`/`Filter`/`MatchTraversal` (previously unguarded).
- core: multi-column `ORDER BY a ASC, b DESC` key order in `to_tree()`.
- core: `ExplainStep::from(&PlanStep)` preserves the `Filter` estimate + `estimation_method` (the `From` impl had zero test callers).

## Validation
`fmt` · clippy `-D warnings -D clippy::pedantic` (core+server) clean · **jscpd 0 clones** · lizard (render_node 47, all fns ≤50 NLOC / ≤8 CCN) · core explain **82 tests** + **30** golden/bdd · server **4** explain tests · **openapi zero drift** · `--no-default-features` + `wasm32` build checks pass.

Non-issues confirmed by the review (no change): the `join_type.unwrap_or_default()` empty-prefix is unreachable (`join_step` always sets `Some`); `GroupBy`/`Aggregate`/`Sort` wire strings are already covered end-to-end; the server DB-less fallback is defensive.