### PR TITLE
Release 3.2.0

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,44 @@
+#!/bin/bash
+# =============================================================================
+# VelesDB-Core Commit-msg Hook — garde-fou anti-attribution IA
+# =============================================================================
+# Rejette tout commit attribué à un assistant IA (règle CLAUDE.md #5) :
+#   - auteur dont le nom ou l'email contient "claude" ou "anthropic"
+#   - message contenant un trailer "Co-Authored-By: …(Claude|Anthropic)…",
+#     une ligne "Claude-Session:", ou une mention "Generated with …Claude".
+#
+# Filet de sécurité LOCAL (commits CLI). Le guard CI "Git Flow" couvre les
+# commits poussés depuis d'autres environnements (ex. sessions cloud).
+#
+# Pour activer : git config core.hooksPath .githooks
+# =============================================================================
+
+set -e
+
+RED='\033[0;31m'
+NC='\033[0m'
+
+msg_file="$1"
+
+# 1. Identité de l'auteur (nom <email> timestamp)
+author="$(git var GIT_AUTHOR_IDENT 2>/dev/null || true)"
+if printf '%s' "$author" | grep -qiE 'anthropic|claude'; then
+    echo -e "${RED}❌ Commit refusé : auteur attribué à une IA → ${author}${NC}" >&2
+    echo -e "${RED}   Règle CLAUDE.md #5 (aucune attribution IA). Corrige l'auteur :${NC}" >&2
+    echo    "     git config user.name  'cyberlife-coder'" >&2
+    echo    "     git config user.email '174732281+cyberlife-coder@users.noreply.github.com'" >&2
+    exit 1
+fi
+
+# 2. Trailers IA dans le message de commit.
+# Ancré en début de ligne : un vrai trailer est en colonne 0 (dernier
+# paragraphe), ce qui évite de bloquer une prose qui *mentionne* ces motifs
+# (ex. ce hook, ou de la doc sur la règle).
+if grep -qiE '^[[:space:]]*Co-Authored-By:.*(claude|anthropic)|^[[:space:]]*Claude-Session:|🤖[[:space:]]*Generated with|Generated with \[Claude' "$msg_file"; then
+    echo -e "${RED}❌ Commit refusé : attribution IA dans le message (CLAUDE.md #5).${NC}" >&2
+    echo -e "${RED}   Retire les lignes 'Co-Authored-By: Claude…', 'Claude-Session:'${NC}" >&2
+    echo -e "${RED}   et '🤖 Generated with …'.${NC}" >&2
+    exit 1
+fi
+
+exit 0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to VelesDB will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [3.2.0] — 2026-06-20
+
+Minor release. Single-sources the server `EXPLAIN` plan onto `velesdb-core`
+(the source of truth) and adds the supporting public API. Additive: the REST
+response shape and `docs/openapi.{json,yaml}` are unchanged.
 
 ### Changed
 - **REST `EXPLAIN` single-sourced from core.** `POST /query/explain` no longer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `VectorSearch` step's `estimated_rows` is now `null` (it previously echoed
   the query `LIMIT`). The limit estimate is still reported on the `Limit` step,
   where it is unambiguous.
+- A `vector NEAR` query that also carries a non-vector `WHERE` predicate (e.g.
+  `vector NEAR $v AND price > 100`) now surfaces a dedicated `Filter` step in the
+  REST/CLI `EXPLAIN` plan. The prior AST reconstruction suppressed it (its
+  `has_filter` flag was `false` whenever a vector search was present), yielding
+  `[VectorSearch, Limit]`; the single-sourced plan reports the filter that
+  actually runs, `[VectorSearch, Filter, Limit]`.
 
 ### Added
 - `velesdb_core::velesql::QueryPlan::to_plan_steps() -> Vec<PlanStep>` — the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,47 @@ All notable changes to VelesDB will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- **REST `EXPLAIN` single-sourced from core.** `POST /query/explain` no longer
+  reconstructs the plan from the parsed AST; it now maps the engine's canonical
+  query plan via the new `velesdb_core::velesql::QueryPlan::to_plan_steps()` —
+  the same `PlanNode` tree the CLI `.explain` renders. The response **shape**
+  (keys/structure) and the `operation` vocabulary are unchanged (`FullScan`,
+  `{Type}Join`, `Filter`, `GroupBy`, `Aggregate`, `Sort`, `Limit`, ... are all
+  preserved), and `docs/openapi.{json,yaml}` are unchanged. The `features` and
+  `estimated_cost` response objects remain server-derived (single-sourcing them
+  is a follow-up).
+- **CLI/Python `EXPLAIN` now shows `JOIN` / `GROUP BY` / aggregation / `ORDER BY`
+  steps.** The core `PlanNode` tree gained `Join`, `GroupBy`, `Aggregate`, and
+  `Sort` nodes, so `QueryPlan::to_tree()` now renders them (previously only the
+  REST view surfaced these). Filter row estimates flow natively from the plan,
+  removing the prior server-side estimation merge.
+- The `VectorSearch` step's `estimated_rows` is now `null` (it previously echoed
+  the query `LIMIT`). The limit estimate is still reported on the `Limit` step,
+  where it is unambiguous.
+
+### Added
+- `velesdb_core::velesql::QueryPlan::to_plan_steps() -> Vec<PlanStep>` — the
+  canonical, structured EXPLAIN step list (with `PlanStep`/`PlanStepKind` and the
+  `PlanStep::rest_operation()` wire mapping), single-sourced with `to_tree()`.
+
+### Fixed
+- An indexed-equality predicate may now surface an `IndexLookup` step in REST
+  `EXPLAIN`, which the prior AST reconstruction never emitted.
+- A query with `OFFSET` but no `LIMIT` (compound/`MATCH`) now surfaces a proper
+  `Offset` step instead of the previous degenerate `Apply LIMIT 0 OFFSET N`.
+
+> Known follow-ups (deliberately out of scope, recorded for future work):
+> - The pre-existing in-response inconsistency between `plan[].operation`
+>   (`FullScan`) and `node_stats[].node_label` (`TableScan`) is left as-is;
+>   reconciling it is a breaking relabel deferred behind the SemVer boundary.
+> - `velesdb-wasm` keeps its own AST-walking `EXPLAIN` renderer with an
+>   independent vocabulary (`Scan`, `NestedLoopJoin`, `GraphPatternMatch`, ...):
+>   the core `QueryPlan`/`to_plan_steps` machinery is `persistence`-gated and
+>   unavailable in the no-persistence WASM build, so full convergence is deferred.
+
 ## [3.1.0] — 2026-06-20
 
 Minor release. Single-sources several ecosystem components onto `velesdb-core`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5523,7 +5523,7 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-velesdb"
-version = "3.1.0"
+version = "3.2.0"
 dependencies = [
  "dirs",
  "parking_lot",
@@ -6517,7 +6517,7 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "velesdb-cli"
-version = "3.1.0"
+version = "3.2.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -6542,7 +6542,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-core"
-version = "3.1.0"
+version = "3.2.0"
 dependencies = [
  "arc-swap",
  "bytemuck",
@@ -6597,7 +6597,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-migrate"
-version = "3.1.0"
+version = "3.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6625,7 +6625,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-mobile"
-version = "3.1.0"
+version = "3.2.0"
 dependencies = [
  "parking_lot",
  "serde_json",
@@ -6639,7 +6639,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-python"
-version = "3.1.0"
+version = "3.2.0"
 dependencies = [
  "numpy",
  "parking_lot",
@@ -6652,7 +6652,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-server"
-version = "3.1.0"
+version = "3.2.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -6685,7 +6685,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-wasm"
-version = "3.1.0"
+version = "3.2.0"
 dependencies = [
  "getrandom 0.3.4",
  "getrandom 0.4.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "3.1.0"
+version = "3.2.0"
 edition = "2021"
 rust-version = "1.89"
 license-file = "LICENSE"
@@ -77,7 +77,7 @@ base64 = "0.22"
 smallvec = { version = "1", features = ["serde"] }
 
 # Internal workspace crates
-velesdb-core = { path = "crates/velesdb-core", version = "3.1.0", default-features = false }
+velesdb-core = { path = "crates/velesdb-core", version = "3.2.0", default-features = false }
 
 [profile.release]
 lto = true

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM rust:1.96-bookworm AS builder
 
 LABEL maintainer="VelesDB Team <contact@wiscale.fr>"
-LABEL version="3.1.0"
+LABEL version="3.2.0"
 
 WORKDIR /app
 
@@ -25,7 +25,7 @@ RUN cargo build --release --bin velesdb-server
 FROM debian:bookworm-slim
 
 LABEL maintainer="VelesDB Team <contact@wiscale.fr>"
-LABEL version="3.1.0"
+LABEL version="3.2.0"
 
 WORKDIR /app
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,7 +4,7 @@ This roadmap commits to **what we are building**, **why**, and **when**. It is u
 
 It is intentionally narrow. Items not on this roadmap are tracked as `roadmap` issues but **not committed** until they reach a milestone here.
 
-> **Last updated:** 2026-06-12 — covers v3.1.0 (current) → v1.19 horizon.
+> **Last updated:** 2026-06-12 — covers v3.2.0 (current) → v1.19 horizon.
 
 ---
 

--- a/benchmarks/Dockerfile.bench
+++ b/benchmarks/Dockerfile.bench
@@ -6,7 +6,7 @@
 FROM debian:bookworm-slim
 
 LABEL maintainer="VelesDB Team <contact@wiscale.fr>"
-LABEL version="3.1.0"
+LABEL version="3.2.0"
 
 WORKDIR /app
 

--- a/benchmarks/Dockerfile.nightly
+++ b/benchmarks/Dockerfile.nightly
@@ -4,7 +4,7 @@
 FROM rust:slim-bookworm AS builder
 
 LABEL maintainer="VelesDB Team <contact@wiscale.fr>"
-LABEL version="3.1.0"
+LABEL version="3.2.0"
 
 WORKDIR /app
 
@@ -29,7 +29,7 @@ RUN cargo build --release --bin velesdb-server
 FROM debian:bookworm-slim
 
 LABEL maintainer="VelesDB Team <contact@wiscale.fr>"
-LABEL version="3.1.0"
+LABEL version="3.2.0"
 
 WORKDIR /app
 

--- a/benchmarks/Dockerfile.optimized
+++ b/benchmarks/Dockerfile.optimized
@@ -7,7 +7,7 @@
 FROM rust:slim-bookworm AS builder
 
 LABEL maintainer="VelesDB Team <contact@wiscale.fr>"
-LABEL version="3.1.0"
+LABEL version="3.2.0"
 
 WORKDIR /app
 
@@ -49,7 +49,7 @@ RUN cargo build --release --bin velesdb-server \
 FROM debian:bookworm-slim
 
 LABEL maintainer="VelesDB Team <contact@wiscale.fr>"
-LABEL version="3.1.0"
+LABEL version="3.2.0"
 
 WORKDIR /app
 

--- a/crates/tauri-plugin-velesdb/guest-js/package.json
+++ b/crates/tauri-plugin-velesdb/guest-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wiscale/tauri-plugin-velesdb",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "TypeScript bindings for the VelesDB Tauri plugin - Vector search in desktop apps",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/crates/velesdb-core/src/agent/episodic_memory.rs
+++ b/crates/velesdb-core/src/agent/episodic_memory.rs
@@ -227,28 +227,17 @@ impl EpisodicMemory {
         rel_type: &str,
         properties: Option<&serde_json::Map<String, serde_json::Value>>,
     ) -> Result<u64, AgentMemoryError> {
-        let collection = memory_helpers::get_collection(&self.db, &self.collection_name)?;
-        for id in [from_id, to_id] {
-            memory_helpers::ensure_live(
-                &collection,
-                &self.collection_name,
-                &self.ttl,
-                MemoryKind::Episodic,
-                id,
-            )?;
-        }
-        let edge_id = memory_helpers::add_relation_edge(
-            &collection,
-            &self.next_edge_id,
-            (from_id, to_id),
+        memory_helpers::relate_memory_points(
+            &self.db,
+            &self.collection_name,
+            from_id,
+            to_id,
             rel_type,
             properties,
-        )?;
-        // Close the check-then-add window: an endpoint deleted concurrently
-        // (its cascade may have run before our edge landed) must not leave a
-        // dangling, WAL-durable edge behind.
-        memory_helpers::verify_relation_endpoints(&collection, edge_id, (from_id, to_id))?;
-        Ok(edge_id)
+            &self.ttl,
+            MemoryKind::Episodic,
+            &self.next_edge_id,
+        )
     }
 
     /// Returns the outgoing relations of an event.
@@ -260,14 +249,13 @@ impl EpisodicMemory {
         &self,
         id: u64,
     ) -> Result<Vec<crate::collection::graph::GraphEdge>, AgentMemoryError> {
-        let collection = memory_helpers::get_collection(&self.db, &self.collection_name)?;
-        // Expired entries are invisible on every read surface — edges whose
-        // target has expired (but is not yet swept) are hidden too.
-        Ok(collection
-            .get_outgoing_edges(id)
-            .into_iter()
-            .filter(|edge| !self.ttl.is_expired(MemoryKind::Episodic, edge.target()))
-            .collect())
+        memory_helpers::relations_of(
+            &self.db,
+            &self.collection_name,
+            id,
+            &self.ttl,
+            MemoryKind::Episodic,
+        )
     }
 
     /// Removes a relation edge created by [`Self::relate`].
@@ -276,8 +264,7 @@ impl EpisodicMemory {
     ///
     /// Returns `CollectionError` when the collection cannot be resolved.
     pub fn unrelate(&self, edge_id: u64) -> Result<bool, AgentMemoryError> {
-        let collection = memory_helpers::get_collection(&self.db, &self.collection_name)?;
-        Ok(collection.remove_edge(edge_id))
+        memory_helpers::unrelate_edge(&self.db, &self.collection_name, edge_id)
     }
 
     /// Returns recent events, optionally filtered by a lower timestamp bound.

--- a/crates/velesdb-core/src/agent/episodic_memory.rs
+++ b/crates/velesdb-core/src/agent/episodic_memory.rs
@@ -228,15 +228,17 @@ impl EpisodicMemory {
         properties: Option<&serde_json::Map<String, serde_json::Value>>,
     ) -> Result<u64, AgentMemoryError> {
         memory_helpers::relate_memory_points(
-            &self.db,
-            &self.collection_name,
+            &memory_helpers::MemorySubsystem {
+                db: &self.db,
+                collection_name: &self.collection_name,
+                ttl: &self.ttl,
+                kind: MemoryKind::Episodic,
+                next_edge_id: &self.next_edge_id,
+            },
             from_id,
             to_id,
             rel_type,
             properties,
-            &self.ttl,
-            MemoryKind::Episodic,
-            &self.next_edge_id,
         )
     }
 

--- a/crates/velesdb-core/src/agent/memory_helpers.rs
+++ b/crates/velesdb-core/src/agent/memory_helpers.rs
@@ -379,9 +379,20 @@ pub(super) fn seed_edge_counter(collection: &Collection) -> std::sync::atomic::A
     std::sync::atomic::AtomicU64::new(next)
 }
 
+/// Maximum number of edge-ID allocation attempts before giving up.
+///
+/// Each iteration either succeeds or advances the counter by one, so
+/// this caps the worst-case number of counter increments. Exhaustion
+/// indicates an unusually dense pre-existing edge space (e.g. a
+/// corrupted counter seed) and is surfaced as a `CollectionError`.
+const MAX_EDGE_ID_RETRIES: u32 = 1_000;
+
 /// Adds a relation edge between two memory points, allocating a fresh edge
 /// id from `next_edge_id` (skipping ids taken by direct graph writes; the
 /// `EdgeExists` retry covers the residual allocation race).
+///
+/// Returns `CollectionError` when [`MAX_EDGE_ID_RETRIES`] consecutive ids
+/// are all already taken — this should never happen in practice.
 pub(super) fn add_relation_edge(
     collection: &Collection,
     next_edge_id: &std::sync::atomic::AtomicU64,
@@ -390,7 +401,7 @@ pub(super) fn add_relation_edge(
     properties: Option<&serde_json::Map<String, serde_json::Value>>,
 ) -> Result<u64, AgentMemoryError> {
     let (from_id, to_id) = endpoints;
-    loop {
+    for _ in 0..MAX_EDGE_ID_RETRIES {
         let edge_id = next_edge_id.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         if collection.edge_exists(edge_id) {
             continue; // taken by a direct graph write — no junk WAL entry
@@ -409,6 +420,10 @@ pub(super) fn add_relation_edge(
             Err(e) => return Err(AgentMemoryError::CollectionError(e.to_string())),
         }
     }
+    Err(AgentMemoryError::CollectionError(
+        "edge id allocation exhausted after too many retries (possible id-space corruption)"
+            .to_string(),
+    ))
 }
 
 /// Compensates the `relate()` check-then-add window: when an endpoint was
@@ -572,6 +587,82 @@ pub(super) fn execute_velesql(
         .into_iter()
         .filter(|r| !ttl.is_expired(kind, r.point.id))
         .collect())
+}
+
+/// Adds a durable relation edge between two live memory points.
+///
+/// This is the shared implementation for `SemanticMemory::relate`,
+/// `EpisodicMemory::relate`, and `ProceduralMemory::relate`. The `kind`
+/// parameter scopes liveness checks to the owning subsystem so an expired
+/// semantic id never matches a live episodic id with the same number.
+///
+/// # Errors
+///
+/// Returns `NotFound` when either endpoint is missing or expired, or
+/// `CollectionError` when the edge write fails.
+pub(super) fn relate_memory_points(
+    db: &Database,
+    collection_name: &str,
+    from_id: u64,
+    to_id: u64,
+    rel_type: &str,
+    properties: Option<&serde_json::Map<String, serde_json::Value>>,
+    ttl: &super::ttl::MemoryTtl,
+    kind: super::ttl::MemoryKind,
+    next_edge_id: &std::sync::atomic::AtomicU64,
+) -> Result<u64, AgentMemoryError> {
+    let collection = get_collection(db, collection_name)?;
+    for id in [from_id, to_id] {
+        ensure_live(&collection, collection_name, ttl, kind, id)?;
+    }
+    let edge_id = add_relation_edge(&collection, next_edge_id, (from_id, to_id), rel_type, properties)?;
+    // Close the check-then-add window: an endpoint deleted concurrently
+    // (its cascade may have run before our edge landed) must not leave a
+    // dangling, WAL-durable edge behind.
+    verify_relation_endpoints(&collection, edge_id, (from_id, to_id))?;
+    Ok(edge_id)
+}
+
+/// Returns the outgoing relation edges of a memory point, filtering out edges
+/// whose target is TTL-expired in the given subsystem.
+///
+/// Shared by `SemanticMemory::relations`, `EpisodicMemory::relations`, and
+/// `ProceduralMemory::relations`.
+///
+/// # Errors
+///
+/// Returns `CollectionError` when the collection cannot be resolved.
+pub(super) fn relations_of(
+    db: &Database,
+    collection_name: &str,
+    id: u64,
+    ttl: &super::ttl::MemoryTtl,
+    kind: super::ttl::MemoryKind,
+) -> Result<Vec<crate::collection::graph::GraphEdge>, AgentMemoryError> {
+    let collection = get_collection(db, collection_name)?;
+    Ok(collection
+        .get_outgoing_edges(id)
+        .into_iter()
+        .filter(|edge| !ttl.is_expired(kind, edge.target()))
+        .collect())
+}
+
+/// Removes a relation edge from a memory collection.
+///
+/// Returns `true` when the edge existed and was removed. Shared by
+/// `SemanticMemory::unrelate`, `EpisodicMemory::unrelate`, and
+/// `ProceduralMemory::unrelate`.
+///
+/// # Errors
+///
+/// Returns `CollectionError` when the collection cannot be resolved.
+pub(super) fn unrelate_edge(
+    db: &Database,
+    collection_name: &str,
+    edge_id: u64,
+) -> Result<bool, AgentMemoryError> {
+    let collection = get_collection(db, collection_name)?;
+    Ok(collection.remove_edge(edge_id))
 }
 
 #[cfg(test)]

--- a/crates/velesdb-core/src/agent/memory_helpers.rs
+++ b/crates/velesdb-core/src/agent/memory_helpers.rs
@@ -13,19 +13,16 @@ use std::collections::HashSet;
 
 use super::error::AgentMemoryError;
 
-/// Reserved payload key carrying the durable expiry timestamp (epoch seconds).
+/// Canonical durable TTL payload key — re-exported from [`crate::collection::expiry`].
 ///
 /// Written by the `*_with_ttl` store paths so a TTL survives a process
 /// restart: the in-memory [`MemoryTtl`](super::ttl::MemoryTtl) map is just a
 /// cache rebuilt from this field at subsystem construction. Payloads without
 /// this key (or with a non-u64 value) have no TTL.
 ///
-/// The key is namespaced (`_veles_` prefix, like the `_semantic_memory`
-/// system collections) so a user metadata field named `expires_at` — a common
-/// business field — is never interpreted as a TTL. User-facing metadata paths
-/// (`SemanticMemory::store_with_metadata` / `update_metadata`) strip this
-/// reserved key, mirroring how the `content` parameter owns `content`.
-pub(super) const EXPIRES_AT_KEY: &str = "_veles_expires_at";
+/// The key is namespaced (`_veles_` prefix) so a user metadata field named
+/// `expires_at` — a common business field — is never interpreted as a TTL.
+pub(super) use crate::collection::expiry::EXPIRES_AT_KEY;
 
 /// Looks up a `Collection` by name, returning an `AgentMemoryError` if absent.
 pub(super) fn get_collection(db: &Database, name: &str) -> Result<Collection, AgentMemoryError> {

--- a/crates/velesdb-core/src/agent/memory_helpers.rs
+++ b/crates/velesdb-core/src/agent/memory_helpers.rs
@@ -616,7 +616,13 @@ pub(super) fn relate_memory_points(
     for id in [from_id, to_id] {
         ensure_live(&collection, collection_name, ttl, kind, id)?;
     }
-    let edge_id = add_relation_edge(&collection, next_edge_id, (from_id, to_id), rel_type, properties)?;
+    let edge_id = add_relation_edge(
+        &collection,
+        next_edge_id,
+        (from_id, to_id),
+        rel_type,
+        properties,
+    )?;
     // Close the check-then-add window: an endpoint deleted concurrently
     // (its cascade may have run before our edge landed) must not leave a
     // dangling, WAL-durable edge behind.

--- a/crates/velesdb-core/src/agent/memory_helpers.rs
+++ b/crates/velesdb-core/src/agent/memory_helpers.rs
@@ -586,6 +586,19 @@ pub(super) fn execute_velesql(
         .collect())
 }
 
+/// Borrowed handle to a memory subsystem's storage and TTL state.
+///
+/// Bundles the per-subsystem context — database, collection name, TTL map,
+/// [`MemoryKind`](super::ttl::MemoryKind), and edge-ID allocator — so the
+/// relation helpers keep small signatures.
+pub(super) struct MemorySubsystem<'a> {
+    pub db: &'a Database,
+    pub collection_name: &'a str,
+    pub ttl: &'a super::ttl::MemoryTtl,
+    pub kind: super::ttl::MemoryKind,
+    pub next_edge_id: &'a std::sync::atomic::AtomicU64,
+}
+
 /// Adds a durable relation edge between two live memory points.
 ///
 /// This is the shared implementation for `SemanticMemory::relate`,
@@ -597,28 +610,26 @@ pub(super) fn execute_velesql(
 ///
 /// Returns `NotFound` when either endpoint is missing or expired, or
 /// `CollectionError` when the edge write fails.
-// All 9 parameters carry distinct roles: (db, collection), (from, to) endpoints,
-// edge (rel_type, properties), and TTL context (ttl, kind, next_edge_id).
-// Grouping them into a struct would add indirection without clarity.
-#[allow(clippy::too_many_arguments)]
 pub(super) fn relate_memory_points(
-    db: &Database,
-    collection_name: &str,
+    subsystem: &MemorySubsystem<'_>,
     from_id: u64,
     to_id: u64,
     rel_type: &str,
     properties: Option<&serde_json::Map<String, serde_json::Value>>,
-    ttl: &super::ttl::MemoryTtl,
-    kind: super::ttl::MemoryKind,
-    next_edge_id: &std::sync::atomic::AtomicU64,
 ) -> Result<u64, AgentMemoryError> {
-    let collection = get_collection(db, collection_name)?;
+    let collection = get_collection(subsystem.db, subsystem.collection_name)?;
     for id in [from_id, to_id] {
-        ensure_live(&collection, collection_name, ttl, kind, id)?;
+        ensure_live(
+            &collection,
+            subsystem.collection_name,
+            subsystem.ttl,
+            subsystem.kind,
+            id,
+        )?;
     }
     let edge_id = add_relation_edge(
         &collection,
-        next_edge_id,
+        subsystem.next_edge_id,
         (from_id, to_id),
         rel_type,
         properties,

--- a/crates/velesdb-core/src/agent/memory_helpers.rs
+++ b/crates/velesdb-core/src/agent/memory_helpers.rs
@@ -597,6 +597,10 @@ pub(super) fn execute_velesql(
 ///
 /// Returns `NotFound` when either endpoint is missing or expired, or
 /// `CollectionError` when the edge write fails.
+// All 9 parameters carry distinct roles: (db, collection), (from, to) endpoints,
+// edge (rel_type, properties), and TTL context (ttl, kind, next_edge_id).
+// Grouping them into a struct would add indirection without clarity.
+#[allow(clippy::too_many_arguments)]
 pub(super) fn relate_memory_points(
     db: &Database,
     collection_name: &str,

--- a/crates/velesdb-core/src/agent/procedural_memory.rs
+++ b/crates/velesdb-core/src/agent/procedural_memory.rs
@@ -315,15 +315,17 @@ impl ProceduralMemory {
         properties: Option<&serde_json::Map<String, serde_json::Value>>,
     ) -> Result<u64, AgentMemoryError> {
         memory_helpers::relate_memory_points(
-            &self.db,
-            &self.collection_name,
+            &memory_helpers::MemorySubsystem {
+                db: &self.db,
+                collection_name: &self.collection_name,
+                ttl: &self.ttl,
+                kind: MemoryKind::Procedural,
+                next_edge_id: &self.next_edge_id,
+            },
             from_id,
             to_id,
             rel_type,
             properties,
-            &self.ttl,
-            MemoryKind::Procedural,
-            &self.next_edge_id,
         )
     }
 

--- a/crates/velesdb-core/src/agent/procedural_memory.rs
+++ b/crates/velesdb-core/src/agent/procedural_memory.rs
@@ -314,28 +314,17 @@ impl ProceduralMemory {
         rel_type: &str,
         properties: Option<&serde_json::Map<String, serde_json::Value>>,
     ) -> Result<u64, AgentMemoryError> {
-        let collection = memory_helpers::get_collection(&self.db, &self.collection_name)?;
-        for id in [from_id, to_id] {
-            memory_helpers::ensure_live(
-                &collection,
-                &self.collection_name,
-                &self.ttl,
-                MemoryKind::Procedural,
-                id,
-            )?;
-        }
-        let edge_id = memory_helpers::add_relation_edge(
-            &collection,
-            &self.next_edge_id,
-            (from_id, to_id),
+        memory_helpers::relate_memory_points(
+            &self.db,
+            &self.collection_name,
+            from_id,
+            to_id,
             rel_type,
             properties,
-        )?;
-        // Close the check-then-add window: an endpoint deleted concurrently
-        // (its cascade may have run before our edge landed) must not leave a
-        // dangling, WAL-durable edge behind.
-        memory_helpers::verify_relation_endpoints(&collection, edge_id, (from_id, to_id))?;
-        Ok(edge_id)
+            &self.ttl,
+            MemoryKind::Procedural,
+            &self.next_edge_id,
+        )
     }
 
     /// Returns the outgoing relations of a procedure.
@@ -347,14 +336,13 @@ impl ProceduralMemory {
         &self,
         id: u64,
     ) -> Result<Vec<crate::collection::graph::GraphEdge>, AgentMemoryError> {
-        let collection = memory_helpers::get_collection(&self.db, &self.collection_name)?;
-        // Expired entries are invisible on every read surface — edges whose
-        // target has expired (but is not yet swept) are hidden too.
-        Ok(collection
-            .get_outgoing_edges(id)
-            .into_iter()
-            .filter(|edge| !self.ttl.is_expired(MemoryKind::Procedural, edge.target()))
-            .collect())
+        memory_helpers::relations_of(
+            &self.db,
+            &self.collection_name,
+            id,
+            &self.ttl,
+            MemoryKind::Procedural,
+        )
     }
 
     /// Removes a relation edge created by [`Self::relate`].
@@ -363,8 +351,7 @@ impl ProceduralMemory {
     ///
     /// Returns `CollectionError` when the collection cannot be resolved.
     pub fn unrelate(&self, edge_id: u64) -> Result<bool, AgentMemoryError> {
-        let collection = memory_helpers::get_collection(&self.db, &self.collection_name)?;
-        Ok(collection.remove_edge(edge_id))
+        memory_helpers::unrelate_edge(&self.db, &self.collection_name, edge_id)
     }
 
     /// Recalls matching procedures by vector similarity.

--- a/crates/velesdb-core/src/agent/semantic_memory.rs
+++ b/crates/velesdb-core/src/agent/semantic_memory.rs
@@ -286,15 +286,17 @@ impl SemanticMemory {
         properties: Option<&serde_json::Map<String, serde_json::Value>>,
     ) -> Result<u64, AgentMemoryError> {
         memory_helpers::relate_memory_points(
-            &self.db,
-            &self.collection_name,
+            &memory_helpers::MemorySubsystem {
+                db: &self.db,
+                collection_name: &self.collection_name,
+                ttl: &self.ttl,
+                kind: MemoryKind::Semantic,
+                next_edge_id: &self.next_edge_id,
+            },
             from_id,
             to_id,
             rel_type,
             properties,
-            &self.ttl,
-            MemoryKind::Semantic,
-            &self.next_edge_id,
         )
     }
 

--- a/crates/velesdb-core/src/agent/semantic_memory.rs
+++ b/crates/velesdb-core/src/agent/semantic_memory.rs
@@ -285,28 +285,17 @@ impl SemanticMemory {
         rel_type: &str,
         properties: Option<&serde_json::Map<String, serde_json::Value>>,
     ) -> Result<u64, AgentMemoryError> {
-        let collection = memory_helpers::get_collection(&self.db, &self.collection_name)?;
-        for id in [from_id, to_id] {
-            memory_helpers::ensure_live(
-                &collection,
-                &self.collection_name,
-                &self.ttl,
-                MemoryKind::Semantic,
-                id,
-            )?;
-        }
-        let edge_id = memory_helpers::add_relation_edge(
-            &collection,
-            &self.next_edge_id,
-            (from_id, to_id),
+        memory_helpers::relate_memory_points(
+            &self.db,
+            &self.collection_name,
+            from_id,
+            to_id,
             rel_type,
             properties,
-        )?;
-        // Close the check-then-add window: an endpoint deleted concurrently
-        // (its cascade may have run before our edge landed) must not leave a
-        // dangling, WAL-durable edge behind.
-        memory_helpers::verify_relation_endpoints(&collection, edge_id, (from_id, to_id))?;
-        Ok(edge_id)
+            &self.ttl,
+            MemoryKind::Semantic,
+            &self.next_edge_id,
+        )
     }
 
     /// Returns the outgoing relations of a fact (edges it points from).
@@ -318,14 +307,13 @@ impl SemanticMemory {
         &self,
         id: u64,
     ) -> Result<Vec<crate::collection::graph::GraphEdge>, AgentMemoryError> {
-        let collection = memory_helpers::get_collection(&self.db, &self.collection_name)?;
-        // Expired entries are invisible on every read surface — edges whose
-        // target has expired (but is not yet swept) are hidden too.
-        Ok(collection
-            .get_outgoing_edges(id)
-            .into_iter()
-            .filter(|edge| !self.ttl.is_expired(MemoryKind::Semantic, edge.target()))
-            .collect())
+        memory_helpers::relations_of(
+            &self.db,
+            &self.collection_name,
+            id,
+            &self.ttl,
+            MemoryKind::Semantic,
+        )
     }
 
     /// Removes a relation edge created by [`Self::relate`].
@@ -336,8 +324,7 @@ impl SemanticMemory {
     ///
     /// Returns `CollectionError` when the collection cannot be resolved.
     pub fn unrelate(&self, edge_id: u64) -> Result<bool, AgentMemoryError> {
-        let collection = memory_helpers::get_collection(&self.db, &self.collection_name)?;
-        Ok(collection.remove_edge(edge_id))
+        memory_helpers::unrelate_edge(&self.db, &self.collection_name, edge_id)
     }
 
     /// Queries semantic memory by vector similarity.

--- a/crates/velesdb-core/src/api_types/responses_explain.rs
+++ b/crates/velesdb-core/src/api_types/responses_explain.rs
@@ -141,6 +141,20 @@ pub struct ExplainStep {
     pub estimation_method: Option<String>,
 }
 
+#[cfg(feature = "persistence")]
+impl From<&crate::velesql::PlanStep> for ExplainStep {
+    #[allow(clippy::cast_possible_truncation)]
+    fn from(s: &crate::velesql::PlanStep) -> Self {
+        Self {
+            step: s.step,
+            operation: s.rest_operation(),
+            description: s.description.clone(),
+            estimated_rows: s.estimated_rows.map(|r| r as usize),
+            estimation_method: s.estimation_method.clone(),
+        }
+    }
+}
+
 /// Estimated cost metrics for the query.
 #[derive(Debug, Serialize)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]

--- a/crates/velesdb-core/src/collection/expiry.rs
+++ b/crates/velesdb-core/src/collection/expiry.rs
@@ -8,7 +8,13 @@
 //! this filter so TTL rebuild and snapshots still see unswept points.
 
 /// Reserved payload key carrying the durable expiry timestamp (epoch seconds).
-pub(crate) const EXPIRES_AT_KEY: &str = "_veles_expires_at";
+///
+/// A point whose payload carries this key (value: `u64` epoch seconds) is
+/// considered expired once `expires_at <= now`. This key is namespaced with a
+/// `_veles_` prefix so it never collides with user-defined payload fields.
+/// External crates (e.g. the REST server) should reference this constant
+/// rather than hardcoding the string literal.
+pub const EXPIRES_AT_KEY: &str = "_veles_expires_at";
 
 /// Returns the current Unix time in seconds (0 if the clock predates epoch).
 pub(crate) fn now_unix_secs() -> u64 {

--- a/crates/velesdb-core/src/collection/graph/metrics/mod.rs
+++ b/crates/velesdb-core/src/collection/graph/metrics/mod.rs
@@ -190,18 +190,11 @@ impl GraphMetrics {
     /// more times than `record_node_insert`.
     pub fn record_node_delete(&self) {
         self.node_deletes_total.fetch_add(1, Ordering::Relaxed);
-        // Saturating sub: load, compute, compare-exchange loop
-        loop {
-            let current = self.nodes_total.load(Ordering::Relaxed);
-            let new_val = current.saturating_sub(1);
-            if self
-                .nodes_total
-                .compare_exchange_weak(current, new_val, Ordering::Relaxed, Ordering::Relaxed)
-                .is_ok()
-            {
-                break;
-            }
-        }
+        self.nodes_total
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |x| {
+                Some(x.saturating_sub(1))
+            })
+            .ok();
     }
 
     /// Returns total node count.
@@ -245,18 +238,11 @@ impl GraphMetrics {
     /// Uses saturating subtraction to prevent underflow.
     pub fn record_edge_delete(&self, latency: Duration) {
         self.edge_deletes_total.fetch_add(1, Ordering::Relaxed);
-        // Saturating sub to prevent underflow
-        loop {
-            let current = self.edges_total.load(Ordering::Relaxed);
-            let new_val = current.saturating_sub(1);
-            if self
-                .edges_total
-                .compare_exchange_weak(current, new_val, Ordering::Relaxed, Ordering::Relaxed)
-                .is_ok()
-            {
-                break;
-            }
-        }
+        self.edges_total
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |x| {
+                Some(x.saturating_sub(1))
+            })
+            .ok();
         self.edge_delete_latency.observe(latency);
     }
 

--- a/crates/velesdb-core/src/collection/mod.rs
+++ b/crates/velesdb-core/src/collection/mod.rs
@@ -58,6 +58,7 @@ mod set_operations_execution_tests;
 
 pub use any_collection::AnyCollection;
 pub use collection_config::{CollectionConfig, CURRENT_SCHEMA_VERSION};
+pub use expiry::EXPIRES_AT_KEY;
 pub use core::{IndexInfo, ScrollBatch, MAX_DIMENSION, MIN_DIMENSION};
 pub use diagnostics::{CollectionDiagnostics, IndexHealth};
 pub use graph::{

--- a/crates/velesdb-core/src/collection/mod.rs
+++ b/crates/velesdb-core/src/collection/mod.rs
@@ -58,9 +58,9 @@ mod set_operations_execution_tests;
 
 pub use any_collection::AnyCollection;
 pub use collection_config::{CollectionConfig, CURRENT_SCHEMA_VERSION};
-pub use expiry::EXPIRES_AT_KEY;
 pub use core::{IndexInfo, ScrollBatch, MAX_DIMENSION, MIN_DIMENSION};
 pub use diagnostics::{CollectionDiagnostics, IndexHealth};
+pub use expiry::EXPIRES_AT_KEY;
 pub use graph::{
     ConcurrentEdgeStore, EdgeStore, EdgeType, GraphEdge, GraphNode, GraphSchema, NodeType,
     PropertyIndex, RangeIndex, TraversalConfig, TraversalPath, TraversalResult, ValueType,

--- a/crates/velesdb-core/src/collection/search/query/match_metrics.rs
+++ b/crates/velesdb-core/src/collection/search/query/match_metrics.rs
@@ -108,18 +108,8 @@ impl MatchMetrics {
     fn record_depth(&self, depth: u32) {
         self.depth_sum
             .fetch_add(u64::from(depth), Ordering::Relaxed);
-        let mut current_max = self.max_depth_reached.load(Ordering::Relaxed);
-        while u64::from(depth) > current_max {
-            match self.max_depth_reached.compare_exchange_weak(
-                current_max,
-                u64::from(depth),
-                Ordering::Relaxed,
-                Ordering::Relaxed,
-            ) {
-                Ok(_) => break,
-                Err(actual) => current_max = actual,
-            }
-        }
+        self.max_depth_reached
+            .fetch_max(u64::from(depth), Ordering::Relaxed);
     }
 
     /// Returns the average latency in milliseconds.

--- a/crates/velesdb-core/src/lib.rs
+++ b/crates/velesdb-core/src/lib.rs
@@ -197,6 +197,8 @@ pub use collection::{
     TraversalResult,
     ValueType,
     VectorCollection,
+    // Durable TTL payload key (shared across all collection types and external crates)
+    EXPIRES_AT_KEY,
 };
 pub use contiguous_ops::pad_to_simd_width;
 pub use distance::{DistanceMetric, CONDITION_TYPE_NAMES, DISTANCE_METRIC_NAMES};

--- a/crates/velesdb-core/src/metrics/guardrails.rs
+++ b/crates/velesdb-core/src/metrics/guardrails.rs
@@ -37,18 +37,7 @@ impl TraversalMetrics {
             .fetch_add(edges_scanned, Ordering::Relaxed);
 
         // Update max depth if this traversal went deeper
-        let mut current_max = self.max_depth_reached.load(Ordering::Relaxed);
-        while depth > current_max {
-            match self.max_depth_reached.compare_exchange_weak(
-                current_max,
-                depth,
-                Ordering::Relaxed,
-                Ordering::Relaxed,
-            ) {
-                Ok(_) => break,
-                Err(actual) => current_max = actual,
-            }
-        }
+        self.max_depth_reached.fetch_max(depth, Ordering::Relaxed);
     }
 
     /// Exports traversal metrics in Prometheus format.

--- a/crates/velesdb-core/src/metrics/operational.rs
+++ b/crates/velesdb-core/src/metrics/operational.rs
@@ -124,23 +124,13 @@ impl OperationalMetrics {
 
     /// Decrements active connections.
     ///
-    /// Uses a CAS loop to saturate at 0, preventing underflow wrap to `u64::MAX`.
+    /// Uses `fetch_update` to saturate at 0, preventing underflow wrap to `u64::MAX`.
     pub fn dec_connections(&self) {
-        // BUG-3 FIX: Use CAS loop to prevent underflow
-        loop {
-            let current = self.active_connections.load(Ordering::Relaxed);
-            if current == 0 {
-                return; // Already at 0, don't underflow
-            }
-            if self
-                .active_connections
-                .compare_exchange_weak(current, current - 1, Ordering::Relaxed, Ordering::Relaxed)
-                .is_ok()
-            {
-                return;
-            }
-            // CAS failed, retry
-        }
+        self.active_connections
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |x| {
+                Some(x.saturating_sub(1))
+            })
+            .ok();
     }
 
     /// Exports metrics in Prometheus text format.

--- a/crates/velesdb-core/src/storage/histogram.rs
+++ b/crates/velesdb-core/src/storage/histogram.rs
@@ -54,7 +54,7 @@ impl LockFreeHistogram {
         }
     }
 
-    /// Records a value in microseconds. Wait-free operation.
+    /// Records a value in microseconds. Lock-free operation.
     #[inline]
     pub fn record(&self, value_us: u64) {
         let bucket = Self::bucket_for(value_us);
@@ -62,33 +62,8 @@ impl LockFreeHistogram {
         self.count.fetch_add(1, Ordering::Relaxed);
         self.sum.fetch_add(value_us, Ordering::Relaxed);
 
-        // Update min (CAS loop)
-        let mut current_min = self.min.load(Ordering::Relaxed);
-        while value_us < current_min {
-            match self.min.compare_exchange_weak(
-                current_min,
-                value_us,
-                Ordering::Relaxed,
-                Ordering::Relaxed,
-            ) {
-                Ok(_) => break,
-                Err(actual) => current_min = actual,
-            }
-        }
-
-        // Update max (CAS loop)
-        let mut current_max = self.max.load(Ordering::Relaxed);
-        while value_us > current_max {
-            match self.max.compare_exchange_weak(
-                current_max,
-                value_us,
-                Ordering::Relaxed,
-                Ordering::Relaxed,
-            ) {
-                Ok(_) => break,
-                Err(actual) => current_max = actual,
-            }
-        }
+        self.min.fetch_min(value_us, Ordering::Relaxed);
+        self.max.fetch_max(value_us, Ordering::Relaxed);
     }
 
     /// Returns the bucket index for a value (log2 scale).

--- a/crates/velesdb-core/src/velesql/cost_estimator/plan_cost.rs
+++ b/crates/velesdb-core/src/velesql/cost_estimator/plan_cost.rs
@@ -29,7 +29,12 @@ impl CostEstimator<'_> {
                 let c = self.estimate_plan_cost(n);
                 Cost::new(acc.io_cost + c.io_cost, acc.cpu_cost + c.cpu_cost)
             }),
-            PlanNode::Limit(_) | PlanNode::Offset(_) => self.estimate_limit_offset_cost(),
+            PlanNode::Limit(_)
+            | PlanNode::Offset(_)
+            | PlanNode::Join(_)
+            | PlanNode::GroupBy(_)
+            | PlanNode::Aggregate(_)
+            | PlanNode::Sort(_) => self.estimate_limit_offset_cost(),
         }
     }
 

--- a/crates/velesdb-core/src/velesql/explain/formatter.rs
+++ b/crates/velesdb-core/src/velesql/explain/formatter.rs
@@ -119,30 +119,43 @@ impl QueryPlan {
             PlanNode::MatchTraversal(mt) => {
                 Self::render_match_traversal_node(mt, output, prefix, connector, &child_prefix);
             }
-            PlanNode::Join(j) => Self::render_leaf_with_child(
-                output,
-                (prefix, &child_prefix, connector),
-                &format!("{}Join", j.join_type),
-                ("Table", &j.table),
-            ),
+            PlanNode::Join(_)
+            | PlanNode::GroupBy(_)
+            | PlanNode::Aggregate(_)
+            | PlanNode::Sort(_) => {
+                Self::render_post_filter_node(node, output, (prefix, &child_prefix, connector));
+            }
+        }
+    }
+
+    /// Renders a post-filter node (Join/GroupBy/Aggregate/Sort) as a label plus
+    /// one child line. Split out of [`Self::render_node`] to keep it small.
+    fn render_post_filter_node(node: &PlanNode, output: &mut String, frame: (&str, &str, &str)) {
+        match node {
+            PlanNode::Join(j) => {
+                Self::render_leaf_with_child(
+                    output,
+                    frame,
+                    &format!("{}Join", j.join_type),
+                    ("Table", &j.table),
+                );
+            }
             PlanNode::GroupBy(g) => Self::render_leaf_with_child(
                 output,
-                (prefix, &child_prefix, connector),
+                frame,
                 "GroupBy",
                 ("Columns", &format!("[{}]", g.columns.join(", "))),
             ),
             PlanNode::Aggregate(a) => Self::render_leaf_with_child(
                 output,
-                (prefix, &child_prefix, connector),
+                frame,
                 "Aggregate",
                 ("Functions", &format!("[{}]", a.functions.join(", "))),
             ),
-            PlanNode::Sort(s) => Self::render_leaf_with_child(
-                output,
-                (prefix, &child_prefix, connector),
-                "Sort",
-                ("Keys", &s.keys.join(", ")),
-            ),
+            PlanNode::Sort(s) => {
+                Self::render_leaf_with_child(output, frame, "Sort", ("Keys", &s.keys.join(", ")));
+            }
+            _ => {}
         }
     }
 

--- a/crates/velesdb-core/src/velesql/explain/formatter.rs
+++ b/crates/velesdb-core/src/velesql/explain/formatter.rs
@@ -119,7 +119,48 @@ impl QueryPlan {
             PlanNode::MatchTraversal(mt) => {
                 Self::render_match_traversal_node(mt, output, prefix, connector, &child_prefix);
             }
+            PlanNode::Join(j) => Self::render_leaf_with_child(
+                output,
+                (prefix, &child_prefix, connector),
+                &format!("{}Join", j.join_type),
+                ("Table", &j.table),
+            ),
+            PlanNode::GroupBy(g) => Self::render_leaf_with_child(
+                output,
+                (prefix, &child_prefix, connector),
+                "GroupBy",
+                ("Columns", &format!("[{}]", g.columns.join(", "))),
+            ),
+            PlanNode::Aggregate(a) => Self::render_leaf_with_child(
+                output,
+                (prefix, &child_prefix, connector),
+                "Aggregate",
+                ("Functions", &format!("[{}]", a.functions.join(", "))),
+            ),
+            PlanNode::Sort(s) => Self::render_leaf_with_child(
+                output,
+                (prefix, &child_prefix, connector),
+                "Sort",
+                ("Keys", &s.keys.join(", ")),
+            ),
         }
+    }
+
+    /// Renders a simple "label + single child line" node into the tree output.
+    ///
+    /// Shared by the Join/GroupBy/Aggregate/Sort arms. `frame` carries the
+    /// `(prefix, child_prefix, connector)` layout strings; `child` is the
+    /// `(key, value)` of the single child line.
+    fn render_leaf_with_child(
+        output: &mut String,
+        frame: (&str, &str, &str),
+        label: &str,
+        child: (&str, &str),
+    ) {
+        let (prefix, child_prefix, connector) = frame;
+        let (key, value) = child;
+        let _ = writeln!(output, "{prefix}{connector}{label}");
+        let _ = writeln!(output, "{child_prefix}└─ {key}: {value}");
     }
 
     /// Renders a `Filter` plan node into the tree output.

--- a/crates/velesdb-core/src/velesql/explain/mod.rs
+++ b/crates/velesdb-core/src/velesql/explain/mod.rs
@@ -16,6 +16,7 @@ mod filter_strategy;
 mod formatter;
 mod node_stats;
 mod plan_builder;
+mod step;
 mod types;
 
 pub(crate) use filter_strategy::strip_vector_predicates;

--- a/crates/velesdb-core/src/velesql/explain/node_stats.rs
+++ b/crates/velesdb-core/src/velesql/explain/node_stats.rs
@@ -78,6 +78,8 @@ pub(super) fn node_cost(node: &PlanNode) -> f64 {
         PlanNode::Limit(_) | PlanNode::Offset(_) => 0.001,
         PlanNode::TableScan(_) => 1.0,
         PlanNode::IndexLookup(_) => 0.0001, // O(1) lookup is very fast
+        PlanNode::Join(_) => 0.1,           // cross-store probe is the costliest post-scan op
+        PlanNode::GroupBy(_) | PlanNode::Aggregate(_) | PlanNode::Sort(_) => 0.02,
         PlanNode::Sequence(nodes) => nodes.iter().map(node_cost).sum(),
         PlanNode::MatchTraversal(mt) => {
             // Cost depends on depth and strategy
@@ -104,6 +106,10 @@ fn node_label_and_weight(node: &PlanNode) -> (&'static str, f64) {
         PlanNode::Filter(_) => ("Filter", 0.03),
         PlanNode::Limit(_) => ("Limit", 0.01),
         PlanNode::Offset(_) => ("Offset", 0.01),
+        PlanNode::Join(_) => ("Join", 0.05),
+        PlanNode::GroupBy(_) => ("GroupBy", 0.02),
+        PlanNode::Aggregate(_) => ("Aggregate", 0.02),
+        PlanNode::Sort(_) => ("Sort", 0.02),
         PlanNode::Sequence(_) => ("Sequence", 0.0),
     }
 }

--- a/crates/velesdb-core/src/velesql/explain/plan_builder.rs
+++ b/crates/velesdb-core/src/velesql/explain/plan_builder.rs
@@ -9,8 +9,9 @@ use super::filter_strategy::{estimate_filter_stats, resolve_filter_strategy};
 use super::formatter;
 use super::node_stats;
 use super::types::{
-    FilterPlan, FilterStrategy, FusionInfo, IndexLookupPlan, IndexType, LimitPlan,
-    MatchTraversalPlan, OffsetPlan, PlanNode, QueryPlan, TableScanPlan, VectorSearchPlan,
+    AggregatePlan, FilterPlan, FilterStrategy, FusionInfo, GroupByPlan, IndexLookupPlan, IndexType,
+    JoinPlanNode, LimitPlan, MatchTraversalPlan, OffsetPlan, PlanNode, QueryPlan, SortPlan,
+    TableScanPlan, VectorSearchPlan,
 };
 use crate::collection::search::query::match_planner::{
     CollectionStats, MatchExecutionStrategy, MatchQueryPlanner,
@@ -78,8 +79,9 @@ impl QueryPlan {
             stmt,
             has_vector_search,
             stats,
-            implicit_limit,
         );
+        Self::append_post_filter_nodes(&mut nodes, stmt);
+        Self::push_pagination_nodes(&mut nodes, stmt, implicit_limit);
 
         let mut plan = Self::assemble_plan_with_stats(
             nodes,
@@ -307,7 +309,6 @@ impl QueryPlan {
         stmt: &SelectStatement,
         has_vector_search: bool,
         stats: Option<&CoreCollectionStats>,
-        implicit_limit: bool,
     ) -> FilterStrategy {
         let mut filter_strategy = FilterStrategy::None;
 
@@ -341,12 +342,67 @@ impl QueryPlan {
             }));
         }
 
+        filter_strategy
+    }
+
+    /// Appends post-filter pipeline nodes (JOIN, GROUP BY, aggregation, ORDER
+    /// BY) in the order they execute, mirroring the previous server-side
+    /// reconstruction so the single-sourced plan is step-compatible.
+    fn append_post_filter_nodes(nodes: &mut Vec<PlanNode>, stmt: &SelectStatement) {
+        for join in &stmt.joins {
+            nodes.push(PlanNode::Join(JoinPlanNode {
+                join_type: format!("{:?}", join.join_type),
+                table: join.table.clone(),
+            }));
+        }
+        if let Some(ref group_by) = stmt.group_by {
+            nodes.push(PlanNode::GroupBy(GroupByPlan {
+                columns: group_by.columns.clone(),
+            }));
+        }
+        let functions = Self::aggregate_function_names(&stmt.columns);
+        if !functions.is_empty() {
+            nodes.push(PlanNode::Aggregate(AggregatePlan { functions }));
+        }
+        if let Some(ref order_by) = stmt.order_by {
+            let keys = order_by
+                .iter()
+                .map(|o| {
+                    let (col, dir) = o.to_display_pair();
+                    format!("{col} {dir}")
+                })
+                .collect();
+            nodes.push(PlanNode::Sort(SortPlan { keys }));
+        }
+    }
+
+    /// Returns the aggregate function names in SELECT-list order, or an empty
+    /// vec when the projection has no aggregates.
+    fn aggregate_function_names(columns: &crate::velesql::ast::SelectColumns) -> Vec<String> {
+        use crate::velesql::ast::SelectColumns;
+        let aggregations = match columns {
+            SelectColumns::Aggregations(aggs) => aggs.as_slice(),
+            SelectColumns::Mixed { aggregations, .. } => aggregations.as_slice(),
+            _ => &[],
+        };
+        aggregations
+            .iter()
+            .map(|a| format!("{:?}", a.function_type))
+            .collect()
+    }
+
+    /// Appends the OFFSET (when present) and LIMIT pagination nodes last, so the
+    /// pipeline order is scan → filter → joins → group → aggregate → sort →
+    /// offset → limit.
+    fn push_pagination_nodes(
+        nodes: &mut Vec<PlanNode>,
+        stmt: &SelectStatement,
+        implicit_limit: bool,
+    ) {
         if let Some(offset) = stmt.offset {
             nodes.push(PlanNode::Offset(OffsetPlan { count: offset }));
         }
         Self::push_limit_node(nodes, stmt, implicit_limit);
-
-        filter_strategy
     }
 
     /// Pushes the Limit node for a statement.

--- a/crates/velesdb-core/src/velesql/explain/step.rs
+++ b/crates/velesdb-core/src/velesql/explain/step.rs
@@ -1,0 +1,186 @@
+//! Flattened, structured EXPLAIN step emission.
+//!
+//! [`QueryPlan::to_plan_steps`] walks the same [`PlanNode`] tree that
+//! [`QueryPlan::to_tree`](super::formatter) renders, producing the canonical
+//! structured step list consumed by the REST `/query/explain` endpoint. Both
+//! the text tree and this step list derive from one source of truth — the plan
+//! tree — so the server no longer reconstructs steps from the raw AST.
+
+use super::types::{
+    FilterPlan, JoinPlanNode, LimitPlan, PlanNode, PlanStep, PlanStepKind, QueryPlan,
+};
+
+use PlanStepKind as Kind;
+
+const VECTOR_DESC: &str = "ANN search using HNSW index with NEAR clause";
+const FILTER_DESC: &str = "Apply WHERE clause predicates";
+const GROUP_DESC: &str = "Group rows by specified columns";
+const AGGREGATE_DESC: &str = "Compute aggregate functions (COUNT, SUM, etc.)";
+const SORT_DESC: &str = "Sort results by ORDER BY clause";
+
+impl QueryPlan {
+    /// Flattens the plan tree into ordered, structured EXPLAIN steps.
+    ///
+    /// When the plan has a `LIMIT`, a standalone `OFFSET` node is folded into
+    /// that `LIMIT` step's description (`... OFFSET n`), matching the historical
+    /// flat step list. A query with `OFFSET` but no `LIMIT` (compound/MATCH)
+    /// instead surfaces a dedicated `Offset` step.
+    #[must_use]
+    pub fn to_plan_steps(&self) -> Vec<PlanStep> {
+        let mut flat = Vec::new();
+        Self::flatten_nodes(&self.root, &mut flat);
+        let offset = pagination_offset(&flat);
+        let has_limit = flat.iter().any(|n| matches!(n, PlanNode::Limit(_)));
+
+        let mut steps = Vec::new();
+        for node in flat {
+            if let Some(step) = step_for_node(node, steps.len() + 1, offset, has_limit) {
+                steps.push(step);
+            }
+        }
+        steps
+    }
+
+    /// Collects nodes in pipeline order, expanding nested `Sequence` nodes.
+    fn flatten_nodes<'a>(node: &'a PlanNode, out: &mut Vec<&'a PlanNode>) {
+        match node {
+            PlanNode::Sequence(children) => {
+                for child in children {
+                    Self::flatten_nodes(child, out);
+                }
+            }
+            other => out.push(other),
+        }
+    }
+}
+
+impl PlanStep {
+    /// Maps the step kind to the exact REST `operation` wire string.
+    ///
+    /// The vocabulary is preserved verbatim (e.g. `TableScan` → `"FullScan"`,
+    /// `Join` → `"{Type}Join"`) so the `/query/explain` contract is additive.
+    #[must_use]
+    pub fn rest_operation(&self) -> String {
+        match self.operation {
+            Kind::VectorSearch => "VectorSearch".to_string(),
+            Kind::TableScan => "FullScan".to_string(),
+            Kind::IndexLookup => "IndexLookup".to_string(),
+            Kind::Filter => "Filter".to_string(),
+            Kind::Join => format!("{}Join", self.join_type.as_deref().unwrap_or_default()),
+            Kind::GroupBy => "GroupBy".to_string(),
+            Kind::Aggregate => "Aggregate".to_string(),
+            Kind::Sort => "Sort".to_string(),
+            Kind::Limit => "Limit".to_string(),
+            Kind::Offset => "Offset".to_string(),
+            Kind::MatchTraversal => "MatchTraversal".to_string(),
+        }
+    }
+}
+
+/// Returns the OFFSET count to fold into the Limit step (0 when absent).
+fn pagination_offset(flat: &[&PlanNode]) -> u64 {
+    flat.iter()
+        .find_map(|n| match n {
+            PlanNode::Offset(o) => Some(o.count),
+            _ => None,
+        })
+        .unwrap_or(0)
+}
+
+/// Builds the structured step for a single leaf node.
+///
+/// Returns `None` for `Sequence` (flattened away) and for a standalone `Offset`
+/// when the plan also has a `LIMIT` (the offset is folded into the Limit step).
+/// An `Offset` with no `LIMIT` becomes its own `Offset` step.
+fn step_for_node(node: &PlanNode, step: usize, offset: u64, has_limit: bool) -> Option<PlanStep> {
+    let built = match node {
+        PlanNode::Sequence(_) => return None,
+        PlanNode::Offset(_) if has_limit => return None, // folded into the Limit step
+        PlanNode::Offset(o) => plain(
+            step,
+            Kind::Offset,
+            format!("Skip {} rows (OFFSET)", o.count),
+        ),
+        PlanNode::VectorSearch(_) => plain(step, Kind::VectorSearch, VECTOR_DESC.to_string()),
+        PlanNode::TableScan(ts) => plain(
+            step,
+            Kind::TableScan,
+            format!("Scan collection '{}'", ts.collection),
+        ),
+        PlanNode::IndexLookup(il) => plain(
+            step,
+            Kind::IndexLookup,
+            format!(
+                "Property index lookup {}.{} = {}",
+                il.label, il.property, il.value
+            ),
+        ),
+        PlanNode::GroupBy(_) => plain(step, Kind::GroupBy, GROUP_DESC.to_string()),
+        PlanNode::Aggregate(_) => plain(step, Kind::Aggregate, AGGREGATE_DESC.to_string()),
+        PlanNode::Sort(_) => plain(step, Kind::Sort, SORT_DESC.to_string()),
+        PlanNode::MatchTraversal(mt) => plain(
+            step,
+            Kind::MatchTraversal,
+            format!("Graph traversal: {}", mt.strategy),
+        ),
+        PlanNode::Filter(f) => filter_step(step, f),
+        PlanNode::Join(j) => join_step(step, j),
+        PlanNode::Limit(l) => limit_step(step, l, offset),
+    };
+    Some(built)
+}
+
+/// Builds a step with no join type, estimate, or estimation method.
+fn plain(step: usize, operation: PlanStepKind, description: String) -> PlanStep {
+    PlanStep {
+        step,
+        operation,
+        join_type: None,
+        description,
+        estimated_rows: None,
+        estimation_method: None,
+    }
+}
+
+/// Builds a `Filter` step, carrying the core plan's native row estimate.
+fn filter_step(step: usize, filter: &FilterPlan) -> PlanStep {
+    PlanStep {
+        step,
+        operation: Kind::Filter,
+        join_type: None,
+        description: FILTER_DESC.to_string(),
+        estimated_rows: filter.estimated_rows,
+        estimation_method: filter.estimation_method.clone(),
+    }
+}
+
+/// Builds a `Join` step, carrying the join-type label for the wire string.
+fn join_step(step: usize, join: &JoinPlanNode) -> PlanStep {
+    PlanStep {
+        step,
+        operation: Kind::Join,
+        join_type: Some(join.join_type.clone()),
+        description: format!("Join with '{}'", join.table),
+        estimated_rows: None,
+        estimation_method: None,
+    }
+}
+
+/// Builds a `Limit` step, folding any `OFFSET` into its description.
+fn limit_step(step: usize, limit: &LimitPlan, offset: u64) -> PlanStep {
+    PlanStep {
+        step,
+        operation: Kind::Limit,
+        join_type: None,
+        description: limit_description(limit, offset),
+        estimated_rows: Some(limit.count),
+        estimation_method: None,
+    }
+}
+
+/// Formats the LIMIT step description, folding OFFSET in (matches the prior
+/// server template `Apply LIMIT N (default) OFFSET M`).
+fn limit_description(limit: &LimitPlan, offset: u64) -> String {
+    let marker = if limit.is_default { " (default)" } else { "" };
+    format!("Apply LIMIT {}{marker} OFFSET {offset}", limit.count)
+}

--- a/crates/velesdb-core/src/velesql/explain/types.rs
+++ b/crates/velesdb-core/src/velesql/explain/types.rs
@@ -65,6 +65,14 @@ pub enum PlanNode {
     Sequence(Vec<PlanNode>),
     /// MATCH graph traversal (EPIC-046 US-004).
     MatchTraversal(MatchTraversalPlan),
+    /// Cross-store JOIN operation.
+    Join(JoinPlanNode),
+    /// GROUP BY aggregation grouping.
+    GroupBy(GroupByPlan),
+    /// Aggregate function computation (COUNT, SUM, ...).
+    Aggregate(AggregatePlan),
+    /// ORDER BY sort operation.
+    Sort(SortPlan),
 }
 
 /// Vector search plan details.
@@ -147,6 +155,37 @@ pub struct MatchTraversalPlan {
     pub has_similarity: bool,
     /// Similarity threshold (if any).
     pub similarity_threshold: Option<f32>,
+}
+
+/// Cross-store JOIN plan details.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct JoinPlanNode {
+    /// Join type label (`Inner`, `Left`, `Right`, `Full`) preserved verbatim
+    /// from the parsed `JoinType` so the REST wire string stays `{Type}Join`.
+    pub join_type: String,
+    /// Table/store being joined.
+    pub table: String,
+}
+
+/// GROUP BY plan details.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct GroupByPlan {
+    /// Columns the rows are grouped by.
+    pub columns: Vec<String>,
+}
+
+/// Aggregate-computation plan details.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct AggregatePlan {
+    /// Aggregate function names in SELECT-list order (e.g. `Count`, `Sum`).
+    pub functions: Vec<String>,
+}
+
+/// ORDER BY sort plan details.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SortPlan {
+    /// Sort keys as `"column DIRECTION"` display pairs (e.g. `price DESC`).
+    pub keys: Vec<String>,
 }
 
 /// Fusion strategy info for EXPLAIN output (issue #471).
@@ -349,4 +388,62 @@ pub enum FilterStrategy {
     PreFilter,
     /// Post-filtering: filter after vector search (low selectivity).
     PostFilter,
+}
+
+/// Logical operation of a flattened EXPLAIN [`PlanStep`].
+///
+/// This is the canonical, single-sourced step vocabulary derived from the
+/// [`PlanNode`] tree. [`PlanStep::rest_operation`](crate::velesql::PlanStep)
+/// maps each kind to the exact REST `operation` wire string.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum PlanStepKind {
+    /// ANN vector search.
+    VectorSearch,
+    /// Full collection scan (no index).
+    TableScan,
+    /// Property index lookup.
+    IndexLookup,
+    /// Metadata filter.
+    Filter,
+    /// Cross-store join.
+    Join,
+    /// GROUP BY grouping.
+    GroupBy,
+    /// Aggregate computation.
+    Aggregate,
+    /// ORDER BY sort.
+    Sort,
+    /// LIMIT (with folded OFFSET) pagination.
+    Limit,
+    /// OFFSET skip (rendered standalone only when no Limit folds it).
+    Offset,
+    /// MATCH graph traversal.
+    MatchTraversal,
+}
+
+/// A flattened, structured EXPLAIN plan step.
+///
+/// Produced by [`QueryPlan::to_plan_steps`](crate::velesql::QueryPlan) — the
+/// single source of truth for both the REST `/query/explain` step list and any
+/// other structured consumer. The text tree ([`QueryPlan::to_tree`]) and this
+/// step list both derive from the same [`PlanNode`] tree.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PlanStep {
+    /// 1-based step number in pipeline order.
+    pub step: usize,
+    /// Logical operation kind.
+    pub operation: PlanStepKind,
+    /// Join type label (`Inner`/`Left`/...), set only for [`PlanStepKind::Join`]
+    /// so `rest_operation` can reproduce the `{Type}Join` wire string.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub join_type: Option<String>,
+    /// Human-readable description of what the step does.
+    pub description: String,
+    /// Estimated rows produced, when known.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub estimated_rows: Option<u64>,
+    /// How the row estimate was produced (`"histogram"`, `"cardinality"`, ...).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub estimation_method: Option<String>,
 }

--- a/crates/velesdb-core/src/velesql/explain_tests.rs
+++ b/crates/velesdb-core/src/velesql/explain_tests.rs
@@ -1345,6 +1345,77 @@ fn test_plan_steps_standalone_offset_without_limit() {
 }
 
 #[test]
+fn test_plan_steps_hybrid_vector_filter_emits_filter_step() {
+    // A vector NEAR query carrying a non-vector predicate surfaces a Filter step
+    // (the prior AST reconstruction suppressed it whenever a vector search ran).
+    let steps = plan_steps_for("SELECT * FROM docs WHERE vector NEAR $v AND price > 100 LIMIT 10");
+    let ops: Vec<PlanStepKind> = steps.iter().map(|s| s.operation).collect();
+    assert!(ops.contains(&PlanStepKind::VectorSearch), "{ops:?}");
+    assert!(
+        ops.contains(&PlanStepKind::Filter),
+        "filter step expected: {ops:?}"
+    );
+    assert!(ops.contains(&PlanStepKind::Limit), "{ops:?}");
+}
+
+#[test]
+fn test_rest_operation_wire_strings_client_visible() {
+    // Lock the wire strings the prior pass left unguarded (TableScan/Limit/Offset/
+    // Join are already covered elsewhere).
+    let mk = |op: PlanStepKind| PlanStep {
+        step: 1,
+        operation: op,
+        join_type: None,
+        description: String::new(),
+        estimated_rows: None,
+        estimation_method: None,
+    };
+    assert_eq!(
+        mk(PlanStepKind::VectorSearch).rest_operation(),
+        "VectorSearch"
+    );
+    assert_eq!(
+        mk(PlanStepKind::IndexLookup).rest_operation(),
+        "IndexLookup"
+    );
+    assert_eq!(mk(PlanStepKind::Filter).rest_operation(), "Filter");
+    assert_eq!(
+        mk(PlanStepKind::MatchTraversal).rest_operation(),
+        "MatchTraversal"
+    );
+}
+
+#[test]
+fn test_to_tree_multi_column_order_by_keys_in_order() {
+    let query = crate::velesql::Parser::parse("SELECT * FROM docs ORDER BY a ASC, b DESC LIMIT 5")
+        .expect("parse multi-column ORDER BY");
+    let tree = QueryPlan::from_query(&query).to_tree();
+    assert!(tree.contains("Sort"), "{tree}");
+    assert!(
+        tree.contains("Keys: a ASC, b DESC"),
+        "multi-column sort keys must keep grammar order: {tree}"
+    );
+}
+
+#[test]
+fn test_explain_step_from_plan_step_preserves_filter_estimate() {
+    // Exercises the api_types From<&PlanStep> conversion (otherwise untested):
+    // the Filter step's native estimate + method must survive to the REST DTO.
+    let ps = PlanStep {
+        step: 2,
+        operation: PlanStepKind::Filter,
+        join_type: None,
+        description: "Apply WHERE clause predicates".to_string(),
+        estimated_rows: Some(42),
+        estimation_method: Some("histogram".to_string()),
+    };
+    let es = crate::api_types::ExplainStep::from(&ps);
+    assert_eq!(es.operation, "Filter");
+    assert_eq!(es.estimated_rows, Some(42));
+    assert_eq!(es.estimation_method.as_deref(), Some("histogram"));
+}
+
+#[test]
 fn test_compound_query_plan_has_no_implicit_limit() {
     let query = crate::velesql::Parser::parse("SELECT * FROM a UNION SELECT * FROM b")
         .expect("parse compound query");

--- a/crates/velesdb-core/src/velesql/explain_tests.rs
+++ b/crates/velesdb-core/src/velesql/explain_tests.rs
@@ -1206,6 +1206,144 @@ fn test_match_query_plan_has_no_implicit_limit() {
     );
 }
 
+// ---------------------------------------------------------------------------
+// to_plan_steps(): single-sourced structured EXPLAIN steps (C11)
+// ---------------------------------------------------------------------------
+
+fn plan_steps_for(query: &str) -> Vec<PlanStep> {
+    let parsed = crate::velesql::Parser::parse(query).expect("parse query");
+    QueryPlan::from_query(&parsed).to_plan_steps()
+}
+
+#[test]
+fn test_plan_steps_scan_maps_to_fullscan_wire_string() {
+    let steps = plan_steps_for("SELECT * FROM docs");
+    let first = steps.first().expect("at least one step");
+    assert_eq!(first.operation, PlanStepKind::TableScan);
+    // REST vocabulary is preserved: TableScan kind renders as "FullScan".
+    assert_eq!(first.rest_operation(), "FullScan");
+}
+
+#[test]
+fn test_plan_steps_default_limit_step() {
+    let steps = plan_steps_for("SELECT * FROM docs");
+    let limit = steps
+        .iter()
+        .find(|s| s.operation == PlanStepKind::Limit)
+        .expect("a Limit step");
+    assert_eq!(limit.rest_operation(), "Limit");
+    assert_eq!(limit.estimated_rows, Some(10));
+    assert!(
+        limit.description.contains("LIMIT 10 (default)"),
+        "default limit description: {}",
+        limit.description
+    );
+}
+
+#[test]
+fn test_plan_steps_offset_is_folded_into_limit() {
+    let steps = plan_steps_for("SELECT * FROM docs LIMIT 5 OFFSET 20");
+    assert!(
+        steps.iter().all(|s| s.operation != PlanStepKind::Offset),
+        "OFFSET must be folded into the Limit step, not emitted standalone"
+    );
+    let limit = steps
+        .iter()
+        .find(|s| s.operation == PlanStepKind::Limit)
+        .expect("a Limit step");
+    assert_eq!(limit.estimated_rows, Some(5));
+    assert!(
+        limit.description.contains("LIMIT 5") && limit.description.contains("OFFSET 20"),
+        "limit step folds offset: {}",
+        limit.description
+    );
+}
+
+#[test]
+fn test_plan_steps_join_preserves_typed_wire_string() {
+    let steps = plan_steps_for("SELECT * FROM orders JOIN customers ON orders.cid = customers.id");
+    let join = steps
+        .iter()
+        .find(|s| s.operation == PlanStepKind::Join)
+        .expect("a Join step");
+    // Default JOIN is INNER; wire string stays "{Type}Join" -> "InnerJoin".
+    assert_eq!(join.rest_operation(), "InnerJoin");
+}
+
+#[test]
+fn test_plan_steps_group_aggregate_sort_pipeline_order() {
+    let steps = plan_steps_for(
+        "SELECT category, COUNT(*) FROM docs GROUP BY category ORDER BY COUNT(*) DESC LIMIT 5",
+    );
+    let kinds: Vec<PlanStepKind> = steps.iter().map(|s| s.operation).collect();
+    for expected in [
+        PlanStepKind::GroupBy,
+        PlanStepKind::Aggregate,
+        PlanStepKind::Sort,
+        PlanStepKind::Limit,
+    ] {
+        assert!(
+            kinds.contains(&expected),
+            "missing {expected:?} in {kinds:?}"
+        );
+    }
+    // Pipeline order: group -> aggregate -> sort -> limit.
+    let pos = |k: PlanStepKind| kinds.iter().position(|x| *x == k).expect("kind present");
+    assert!(pos(PlanStepKind::GroupBy) < pos(PlanStepKind::Aggregate));
+    assert!(pos(PlanStepKind::Aggregate) < pos(PlanStepKind::Sort));
+    assert!(pos(PlanStepKind::Sort) < pos(PlanStepKind::Limit));
+}
+
+#[test]
+fn test_plan_steps_vector_search_estimated_rows_is_none() {
+    // The VectorSearch step no longer echoes the LIMIT; the estimate is on the
+    // Limit step, where it is unambiguous.
+    let steps = plan_steps_for("SELECT * FROM docs WHERE vector NEAR $v LIMIT 10");
+    let vs = steps
+        .iter()
+        .find(|s| s.operation == PlanStepKind::VectorSearch)
+        .expect("a VectorSearch step");
+    assert_eq!(vs.estimated_rows, None);
+    let limit = steps
+        .iter()
+        .find(|s| s.operation == PlanStepKind::Limit)
+        .expect("a Limit step");
+    assert_eq!(limit.estimated_rows, Some(10));
+}
+
+#[test]
+fn test_plan_steps_standalone_offset_without_limit() {
+    // A plan with OFFSET but no LIMIT (compound/MATCH shape) surfaces a
+    // dedicated Offset step rather than folding into a nonexistent Limit.
+    let plan = QueryPlan {
+        root: PlanNode::Sequence(vec![
+            PlanNode::TableScan(TableScanPlan {
+                collection: "docs".to_string(),
+            }),
+            PlanNode::Offset(OffsetPlan { count: 7 }),
+        ]),
+        estimated_cost_ms: 1.0,
+        index_used: None,
+        filter_strategy: FilterStrategy::None,
+        with_options: vec![],
+        let_bindings: vec![],
+        fusion_info: None,
+        cache_hit: None,
+        plan_reuse_count: None,
+    };
+    let steps = plan.to_plan_steps();
+    let offset = steps
+        .iter()
+        .find(|s| s.operation == PlanStepKind::Offset)
+        .expect("a standalone Offset step");
+    assert_eq!(offset.rest_operation(), "Offset");
+    assert!(offset.description.contains('7'), "{}", offset.description);
+    assert!(
+        steps.iter().all(|s| s.operation != PlanStepKind::Limit),
+        "no Limit step should be present"
+    );
+}
+
 #[test]
 fn test_compound_query_plan_has_no_implicit_limit() {
     let query = crate::velesql::Parser::parse("SELECT * FROM a UNION SELECT * FROM b")

--- a/crates/velesdb-core/src/velesql/mod.rs
+++ b/crates/velesdb-core/src/velesql/mod.rs
@@ -269,9 +269,10 @@ pub(crate) use explain::strip_vector_predicates;
 #[cfg(feature = "persistence")]
 pub use explain::{
     build_leaf_node_stats, fallback_selectivity_threshold, set_fallback_selectivity_threshold,
-    ActualStats, ExplainOutput, FeedbackCalibration, FilterPlan, FilterStrategy, FusionInfo,
-    IndexLookupPlan, IndexType, LimitPlan, MatchTraversalPlan, NodeStats, OffsetPlan, PlanNode,
-    QueryPlan, TableScanPlan, VectorSearchPlan, DEFAULT_FALLBACK_SELECTIVITY_THRESHOLD,
+    ActualStats, AggregatePlan, ExplainOutput, FeedbackCalibration, FilterPlan, FilterStrategy,
+    FusionInfo, GroupByPlan, IndexLookupPlan, IndexType, JoinPlanNode, LimitPlan,
+    MatchTraversalPlan, NodeStats, OffsetPlan, PlanNode, PlanStep, PlanStepKind, QueryPlan,
+    SortPlan, TableScanPlan, VectorSearchPlan, DEFAULT_FALLBACK_SELECTIVITY_THRESHOLD,
 };
 pub use parser::match_clause;
 pub use parser::Parser;

--- a/crates/velesdb-python/README.md
+++ b/crates/velesdb-python/README.md
@@ -3,7 +3,7 @@
 [![PyPI](https://img.shields.io/pypi/v/velesdb)](https://pypi.org/project/velesdb/)
 [![Python](https://img.shields.io/pypi/pyversions/velesdb)](https://pypi.org/project/velesdb/)
 [![License](https://img.shields.io/badge/license-VelesDB_Core_1.0-blue)](./LICENSE)
-[![Version](https://img.shields.io/badge/version-3.1.0-blue)](https://github.com/cyberlife-coder/VelesDB/releases)
+[![Version](https://img.shields.io/badge/version-3.2.0-blue)](https://github.com/cyberlife-coder/VelesDB/releases)
 
 Python bindings for [VelesDB](https://github.com/cyberlife-coder/VelesDB) — a high-performance vector database for AI applications. The current published wheel is `velesdb` v2.0.0; `numpy>=1.20` ships as a hard runtime dependency since v1.13.8 so a single `pip install velesdb` is sufficient.
 

--- a/crates/velesdb-python/pyproject.toml
+++ b/crates/velesdb-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "velesdb"
-version = "3.1.0"
+version = "3.2.0"
 description = "VelesDB: The Local Vector Database for Python & AI. Microsecond semantic search, zero network latency."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/crates/velesdb-server/README.md
+++ b/crates/velesdb-server/README.md
@@ -659,7 +659,7 @@ curl http://localhost:8080/health
 Response:
 
 ```json
-{"status": "ok", "version": "3.1.0"}
+{"status": "ok", "version": "3.2.0"}
 ```
 
 ### `GET /ready` -- Readiness Probe
@@ -673,13 +673,13 @@ curl http://localhost:8080/ready
 Response (ready):
 
 ```json
-{"status": "ready", "version": "3.1.0"}
+{"status": "ready", "version": "3.2.0"}
 ```
 
 Response (not ready):
 
 ```json
-{"status": "not_ready", "version": "3.1.0"}
+{"status": "not_ready", "version": "3.2.0"}
 ```
 
 ### Kubernetes Example

--- a/crates/velesdb-server/src/handlers/points/relations.rs
+++ b/crates/velesdb-server/src/handlers/points/relations.rs
@@ -23,8 +23,7 @@ use crate::AppState;
 
 use super::super::helpers::{error_response, get_collection_or_404};
 
-/// Reserved payload key carrying the durable expiry timestamp (epoch seconds).
-const EXPIRES_AT_KEY: &str = "_veles_expires_at";
+use velesdb_core::EXPIRES_AT_KEY;
 
 /// Request body for `POST /collections/{name}/relations`.
 #[derive(Debug, Deserialize, ToSchema)]
@@ -141,7 +140,14 @@ pub async fn relate_points(
     }
 }
 
+/// Maximum collision retries before giving up on edge-ID allocation.
+const MAX_EDGE_RETRIES: u32 = 1_000;
+
 /// Assigns a collision-free edge ID and inserts the edge, retrying on `EdgeExists`.
+///
+/// Returns an `INTERNAL_SERVER_ERROR` response when [`MAX_EDGE_RETRIES`]
+/// consecutive IDs are all taken — this indicates a corrupted ID-space seed and
+/// should never occur in practice.
 #[allow(clippy::result_large_err)]
 fn insert_edge_with_retry(
     coll: &velesdb_core::collection::AnyCollection,
@@ -149,7 +155,7 @@ fn insert_edge_with_retry(
     properties: std::collections::HashMap<String, serde_json::Value>,
 ) -> Result<u64, axum::response::Response> {
     let mut next_id = coll.max_edge_id().map_or(1, |m| m.saturating_add(1));
-    loop {
+    for _ in 0..MAX_EDGE_RETRIES {
         if coll.edge_exists(next_id) {
             next_id = next_id.saturating_add(1);
             continue;
@@ -176,6 +182,10 @@ fn insert_edge_with_retry(
             }
         }
     }
+    Err(error_response(
+        StatusCode::INTERNAL_SERVER_ERROR,
+        "edge id allocation exhausted after too many retries".to_string(),
+    ))
 }
 
 /// Remove a relation edge by ID.

--- a/crates/velesdb-server/src/handlers/query/explain.rs
+++ b/crates/velesdb-server/src/handlers/query/explain.rs
@@ -2,7 +2,7 @@
 
 use axum::{extract::State, response::IntoResponse, Json};
 use std::sync::Arc;
-use velesdb_core::velesql::{Condition, SelectColumns, DEFAULT_SELECT_LIMIT};
+use velesdb_core::velesql::{Condition, QueryPlan, SelectColumns};
 
 use crate::types::{
     ActualStatsResponse, ExplainCost, ExplainFeatures, ExplainRequest, ExplainResponse,
@@ -54,6 +54,21 @@ pub async fn explain(
     explain_plan_only(&state, &req, &parsed)
 }
 
+/// Computes the EXPLAIN preamble shared by the plan-only and ANALYZE paths:
+/// detected query features, estimated cost, and the query-type label.
+fn explain_preamble(
+    parsed: &velesdb_core::velesql::Query,
+) -> (ExplainFeatures, ExplainCost, &'static str) {
+    let features = detect_explain_features(&parsed.select);
+    let estimated_cost = estimate_cost(features.has_vector_search);
+    let query_type = if parsed.is_match_query() {
+        "MATCH"
+    } else {
+        "SELECT"
+    };
+    (features, estimated_cost, query_type)
+}
+
 /// Build an EXPLAIN-only response (no execution).
 fn explain_plan_only(
     state: &AppState,
@@ -61,24 +76,15 @@ fn explain_plan_only(
     parsed: &velesdb_core::velesql::Query,
 ) -> axum::response::Response {
     let select = &parsed.select;
-    let features = detect_explain_features(select);
-    let mut plan = build_explain_plan(parsed, &features);
-    let estimated_cost = estimate_cost(features.has_vector_search);
-    let query_type = if parsed.is_match_query() {
-        "MATCH"
-    } else {
-        "SELECT"
-    };
+    let (features, estimated_cost, query_type) = explain_preamble(parsed);
 
-    let (cache_hit, plan_reuse_count) =
-        state
-            .db
-            .explain_query(parsed)
-            .ok()
-            .map_or((None, None), |qp| {
-                merge_core_estimation(&mut plan, &qp);
-                (qp.cache_hit, qp.plan_reuse_count)
-            });
+    // Single-sourced from core: the plan steps come from the canonical
+    // `QueryPlan`, not a server-side AST reconstruction. The DB-less fallback
+    // keeps EXPLAIN working when the collection cannot be resolved.
+    let (plan, cache_hit, plan_reuse_count) = match state.db.explain_query(parsed) {
+        Ok(qp) => (core_plan_steps(&qp), qp.cache_hit, qp.plan_reuse_count),
+        Err(_) => (core_plan_steps(&QueryPlan::from_query(parsed)), None, None),
+    };
 
     Json(ExplainResponse {
         query: req.query.clone(),
@@ -104,22 +110,15 @@ fn explain_with_analyze(
     parsed: &velesdb_core::velesql::Query,
 ) -> axum::response::Response {
     let select = &parsed.select;
-    let features = detect_explain_features(select);
-    let mut plan = build_explain_plan(parsed, &features);
-    let estimated_cost = estimate_cost(features.has_vector_search);
-    let query_type = if parsed.is_match_query() {
-        "MATCH"
-    } else {
-        "SELECT"
-    };
+    let (features, estimated_cost, query_type) = explain_preamble(parsed);
 
     let output = match run_analyze_query(state, parsed, &req.params) {
         Ok(o) => o,
         Err(resp) => return *resp,
     };
 
-    // Merge core estimation metadata into server plan (graceful: already have output).
-    merge_core_estimation(&mut plan, &output.plan);
+    // Single-sourced from core: steps derive from the executed plan.
+    let plan = core_plan_steps(&output.plan);
 
     let (actual_stats_resp, actual_time, node_stats_resp) = extract_analyze_stats(&output);
 
@@ -213,163 +212,12 @@ fn detect_explain_features(select: &velesdb_core::velesql::SelectStatement) -> E
     }
 }
 
-/// Build the execution plan steps for an EXPLAIN response.
-fn build_explain_plan(
-    parsed: &velesdb_core::velesql::Query,
-    features: &ExplainFeatures,
-) -> Vec<ExplainStep> {
-    let select = &parsed.select;
-    let mut plan = Vec::new();
-    let mut step_num = 1;
-
-    plan.push(build_source_step(select, features, step_num));
-    step_num += 1;
-
-    append_filter_and_join_steps(select, features, &mut plan, &mut step_num);
-    append_aggregation_steps(features, &mut plan, &mut step_num);
-    // MATCH and compound queries have no implicit default LIMIT.
-    let implicit_limit = parsed.match_clause.is_none() && parsed.compound.is_none();
-    append_pagination_step(select, &mut plan, step_num, implicit_limit);
-
-    plan
-}
-
-fn build_source_step(
-    select: &velesdb_core::velesql::SelectStatement,
-    features: &ExplainFeatures,
-    step_num: usize,
-) -> ExplainStep {
-    if features.has_vector_search {
-        ExplainStep {
-            step: step_num,
-            operation: "VectorSearch".to_string(),
-            description: "ANN search using HNSW index with NEAR clause".to_string(),
-            estimated_rows: select.limit.map(|l| l as usize),
-            estimation_method: None,
-        }
-    } else {
-        ExplainStep {
-            step: step_num,
-            operation: "FullScan".to_string(),
-            description: format!("Scan collection '{}'", select.from),
-            estimated_rows: None,
-            estimation_method: None,
-        }
-    }
-}
-
-fn append_filter_and_join_steps(
-    select: &velesdb_core::velesql::SelectStatement,
-    features: &ExplainFeatures,
-    plan: &mut Vec<ExplainStep>,
-    step_num: &mut usize,
-) {
-    if features.has_filter {
-        plan.push(ExplainStep {
-            step: *step_num,
-            operation: "Filter".to_string(),
-            description: "Apply WHERE clause predicates".to_string(),
-            estimated_rows: None,
-            estimation_method: None,
-        });
-        *step_num += 1;
-    }
-
-    for join in &select.joins {
-        plan.push(ExplainStep {
-            step: *step_num,
-            operation: format!("{:?}Join", join.join_type),
-            description: format!("Join with '{}'", join.table),
-            estimated_rows: None,
-            estimation_method: None,
-        });
-        *step_num += 1;
-    }
-}
-
-fn append_aggregation_steps(
-    features: &ExplainFeatures,
-    plan: &mut Vec<ExplainStep>,
-    step_num: &mut usize,
-) {
-    if features.has_group_by {
-        plan.push(ExplainStep {
-            step: *step_num,
-            operation: "GroupBy".to_string(),
-            description: "Group rows by specified columns".to_string(),
-            estimated_rows: None,
-            estimation_method: None,
-        });
-        *step_num += 1;
-    }
-
-    if features.has_aggregation {
-        plan.push(ExplainStep {
-            step: *step_num,
-            operation: "Aggregate".to_string(),
-            description: "Compute aggregate functions (COUNT, SUM, etc.)".to_string(),
-            estimated_rows: None,
-            estimation_method: None,
-        });
-        *step_num += 1;
-    }
-
-    if features.has_order_by {
-        plan.push(ExplainStep {
-            step: *step_num,
-            operation: "Sort".to_string(),
-            description: "Sort results by ORDER BY clause".to_string(),
-            estimated_rows: None,
-            estimation_method: None,
-        });
-        *step_num += 1;
-    }
-}
-
-/// Appends the LIMIT/OFFSET step.
+/// Maps a core [`QueryPlan`] into the REST [`ExplainStep`] list.
 ///
-/// Plain SELECT statements (`implicit_limit == true`) without an explicit
-/// LIMIT surface the engine default ([`DEFAULT_SELECT_LIMIT`]) so the plan
-/// matches what execution actually returns. MATCH and compound queries
-/// (`implicit_limit == false`) have no implicit limit.
-fn append_pagination_step(
-    select: &velesdb_core::velesql::SelectStatement,
-    plan: &mut Vec<ExplainStep>,
-    step_num: usize,
-    implicit_limit: bool,
-) {
-    let Some((limit, is_default)) = resolve_pagination_limit(select, implicit_limit) else {
-        return;
-    };
-    let marker = if is_default { " (default)" } else { "" };
-    let estimated_rows = (select.limit.is_some() || is_default).then_some(limit as usize);
-    plan.push(ExplainStep {
-        step: step_num,
-        operation: "Limit".to_string(),
-        description: format!(
-            "Apply LIMIT {limit}{marker} OFFSET {}",
-            select.offset.unwrap_or(0)
-        ),
-        estimated_rows,
-        estimation_method: None,
-    });
-}
-
-/// Resolves the effective LIMIT for the pagination step.
-///
-/// Returns `(limit, is_default)`, or `None` when no step should be emitted
-/// (no LIMIT, no OFFSET, and no implicit default — MATCH/compound queries).
-fn resolve_pagination_limit(
-    select: &velesdb_core::velesql::SelectStatement,
-    implicit_limit: bool,
-) -> Option<(u64, bool)> {
-    match select.limit {
-        Some(limit) => Some((limit, false)),
-        None if implicit_limit => Some((DEFAULT_SELECT_LIMIT, true)),
-        // OFFSET without LIMIT on a no-default query keeps the LIMIT 0 display.
-        None if select.offset.is_some() => Some((0, false)),
-        None => None,
-    }
+/// The plan steps are single-sourced from `velesdb-core` (`to_plan_steps`),
+/// so the server no longer reconstructs them from the parsed AST.
+fn core_plan_steps(plan: &QueryPlan) -> Vec<ExplainStep> {
+    plan.to_plan_steps().iter().map(ExplainStep::from).collect()
 }
 
 /// Estimate execution cost based on query features.
@@ -403,38 +251,5 @@ pub(super) fn condition_has_vector_search(cond: &Condition) -> bool {
         }
         Condition::Group(inner) | Condition::Not(inner) => condition_has_vector_search(inner),
         _ => false,
-    }
-}
-
-// ---------------------------------------------------------------------------
-// Core plan merge helpers (Task 2.2)
-// ---------------------------------------------------------------------------
-
-/// Recursively extracts the first `FilterPlan` from a core `PlanNode` tree.
-fn extract_filter_plan(
-    node: &velesdb_core::velesql::PlanNode,
-) -> Option<&velesdb_core::velesql::FilterPlan> {
-    match node {
-        velesdb_core::velesql::PlanNode::Filter(fp) => Some(fp),
-        velesdb_core::velesql::PlanNode::Sequence(nodes) => {
-            nodes.iter().find_map(extract_filter_plan)
-        }
-        _ => None,
-    }
-}
-
-/// Merges core `FilterPlan` estimation data into server `ExplainStep` entries.
-///
-/// Copies `estimated_rows` and `estimation_method` from the core plan's
-/// `FilterPlan` into every server step whose `operation` is `"Filter"`.
-#[allow(clippy::cast_possible_truncation)]
-fn merge_core_estimation(plan: &mut [ExplainStep], core_plan: &velesdb_core::velesql::QueryPlan) {
-    if let Some(fp) = extract_filter_plan(&core_plan.root) {
-        for step in plan.iter_mut() {
-            if step.operation == "Filter" {
-                step.estimated_rows = fp.estimated_rows.map(|r| r as usize);
-                step.estimation_method = fp.estimation_method.clone();
-            }
-        }
     }
 }

--- a/crates/velesdb-server/tests/api_integration.rs
+++ b/crates/velesdb-server/tests/api_integration.rs
@@ -3184,6 +3184,71 @@ async fn test_explain_select_without_limit_exposes_default_limit_step() {
     );
 }
 
+#[tokio::test]
+async fn test_explain_group_by_order_by_steps_preserved() {
+    let temp_dir = TempDir::new().unwrap();
+    let app = create_test_app(&temp_dir);
+
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/collections")
+                .header("Content-Type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "name": "explain_agg",
+                        "dimension": 4,
+                        "metric": "cosine"
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::CREATED);
+
+    // GROUP BY + aggregate + ORDER BY: the single-sourced plan (core
+    // `to_plan_steps`) must still surface the GroupBy/Aggregate/Sort steps the
+    // server previously reconstructed from the AST (additive preservation).
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/query/explain")
+                .header("Content-Type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "query": "SELECT category, COUNT(*) FROM explain_agg GROUP BY category ORDER BY COUNT(*) DESC LIMIT 5"
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: Value = serde_json::from_slice(&body).unwrap();
+    let ops: Vec<&str> = json["plan"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter_map(|step| step["operation"].as_str())
+        .collect();
+    for expected in ["GroupBy", "Aggregate", "Sort", "Limit"] {
+        assert!(
+            ops.contains(&expected),
+            "single-sourced plan must keep the {expected} step: {ops:?}"
+        );
+    }
+}
+
 // ============================================================================
 // GuardRails — rate limit (429)
 // ============================================================================

--- a/crates/velesdb-server/tests/api_integration.rs
+++ b/crates/velesdb-server/tests/api_integration.rs
@@ -3249,6 +3249,67 @@ async fn test_explain_group_by_order_by_steps_preserved() {
     }
 }
 
+#[tokio::test]
+async fn test_explain_hybrid_vector_filter_surfaces_filter_step() {
+    let temp_dir = TempDir::new().unwrap();
+    let app = create_test_app(&temp_dir);
+
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/collections")
+                .header("Content-Type", "application/json")
+                .body(Body::from(
+                    json!({ "name": "explain_hybrid", "dimension": 4, "metric": "cosine" })
+                        .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::CREATED);
+
+    // A vector NEAR query with a scalar predicate must surface BOTH a
+    // VectorSearch and a Filter step (single-sourced from the core plan; the
+    // old AST reconstruction suppressed the Filter whenever a vector ran).
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/query/explain")
+                .header("Content-Type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "query": "SELECT * FROM explain_hybrid WHERE category = 'tech' AND vector NEAR $v LIMIT 10"
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: Value = serde_json::from_slice(&body).unwrap();
+    let ops: Vec<&str> = json["plan"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter_map(|step| step["operation"].as_str())
+        .collect();
+    for expected in ["VectorSearch", "Filter", "Limit"] {
+        assert!(
+            ops.contains(&expected),
+            "hybrid vector+filter plan must include {expected}: {ops:?}"
+        );
+    }
+}
+
 // ============================================================================
 // GuardRails — rate limit (429)
 // ============================================================================

--- a/demos/rag-pdf-demo/pyproject.toml
+++ b/demos/rag-pdf-demo/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "velesdb-rag-demo"
-version = "3.1.0"
+version = "3.2.0"
 description = "RAG Demo with PDF ingestion using VelesDB for vector storage"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/demos/rag-pdf-demo/src/__init__.py
+++ b/demos/rag-pdf-demo/src/__init__.py
@@ -1,3 +1,3 @@
 """VelesDB RAG Demo - PDF Question Answering System."""
 
-__version__ = "3.1.0"
+__version__ = "3.2.0"

--- a/demos/rag-pdf-demo/src/main.py
+++ b/demos/rag-pdf-demo/src/main.py
@@ -46,7 +46,7 @@ async def lifespan(app: FastAPI):
 app = FastAPI(
     title="VelesDB RAG Demo",
     description="PDF Question Answering with VelesDB vector search",
-    version="3.1.0",
+    version="3.2.0",
     lifespan=lifespan
 )
 

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -1,6 +1,6 @@
 # VelesDB Performance Benchmarks
 
-*Last updated: June 20, 2026 (VelesDB v3.1.0). Figures are re-validated at each release only when re-measured — each section carries its own measurement date and machine; this stamp tracks the document revision, not a fresh measurement.*
+*Last updated: June 20, 2026 (VelesDB v3.2.0). Figures are re-validated at each release only when re-measured — each section carries its own measurement date and machine; this stamp tracks the document revision, not a fresh measurement.*
 
 ---
 

--- a/docs/VELESQL_SPEC.md
+++ b/docs/VELESQL_SPEC.md
@@ -1868,6 +1868,17 @@ tree now explicitly surfaces the similarity-as-predicate routing decision
 (see **Order by Similarity** above) — the `VectorSearch` node appears even
 though the SQL text has no `NEAR`.
 
+#### REST plan single-sourced from core (next minor release)
+
+The REST `/query/explain` step list is now produced directly from the engine
+plan via `QueryPlan::to_plan_steps()`, the same `PlanNode` tree the CLI
+`.explain` renders — it is no longer reconstructed from the parsed AST. The
+wire `operation` vocabulary is unchanged (additive): a full scan still reports
+`FullScan` and joins still report `{Type}Join`. As a side effect, `GROUP BY`,
+aggregation, `ORDER BY`, and `JOIN` steps now also appear in the CLI/Python
+`to_tree()` output (previously only the REST view surfaced them), and an
+indexed-equality predicate may surface an `IndexLookup` step.
+
 Returns a single row with:
 
 | Field | Type | Description |

--- a/docs/VELESQL_SPEC.md
+++ b/docs/VELESQL_SPEC.md
@@ -2,7 +2,7 @@
 
 > SQL-like query language for vector + graph + column-store search in VelesDB.
 
-**Version**: 3.10.0 | **Last Updated**: 2026-06-20 (VelesDB v3.1.0)
+**Version**: 3.10.0 | **Last Updated**: 2026-06-20 (VelesDB v3.2.0)
 
 ---
 
@@ -1868,7 +1868,7 @@ tree now explicitly surfaces the similarity-as-predicate routing decision
 (see **Order by Similarity** above) — the `VectorSearch` node appears even
 though the SQL text has no `NEAR`.
 
-#### REST plan single-sourced from core (next minor release)
+#### v3.2.0 — REST plan single-sourced from core
 
 The REST `/query/explain` step list is now produced directly from the engine
 plan via `QueryPlan::to_plan_steps()`, the same `PlanNode` tree the CLI

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -96,7 +96,7 @@ Expected response:
 ```json
 {
   "status": "ok",
-  "version": "3.1.0"
+  "version": "3.2.0"
 }
 ```
 

--- a/docs/guides/CLI_REPL.md
+++ b/docs/guides/CLI_REPL.md
@@ -1,6 +1,6 @@
 # 💻 CLI & REPL Reference
 
-*Version 3.1.0 — 2026-06-12*
+*Version 3.2.0 — 2026-06-12*
 
 Complete guide to the VelesDB command-line interface and the interactive REPL.
 
@@ -36,7 +36,7 @@ cargo build --release -p velesdb-cli
 
 ```bash
 velesdb --version
-# velesdb 3.1.0
+# velesdb 3.2.0
 ```
 
 ---
@@ -269,7 +269,7 @@ velesdb> \info
 ┌─────────────────────┬────────────────────┐
 │ Property            │ Value              │
 ├─────────────────────┼────────────────────┤
-│ Version             │ 3.1.0              │
+│ Version             │ 3.2.0              │
 │ Data directory      │ ./data             │
 │ Collections         │ 3                  │
 │ Total vectors       │ 125,000            │
@@ -342,7 +342,7 @@ Session settings are **not persisted** across REPL sessions. To persist them, us
 ```
 $ velesdb repl ./my_db
 
-VelesDB v3.1.0 - Interactive REPL
+VelesDB v3.2.0 - Interactive REPL
 Type \help for help, \quit to exit.
 
 velesdb> \show

--- a/docs/guides/CONFIGURATION.md
+++ b/docs/guides/CONFIGURATION.md
@@ -1,6 +1,6 @@
 # ⚙️ VelesDB Configuration
 
-*Version 3.1.0 — May 2026*
+*Version 3.2.0 — May 2026*
 
 Complete guide for configuring VelesDB via configuration file, environment variables, and runtime parameters.
 
@@ -62,7 +62,7 @@ data_dir = "./data"
 ```toml
 # =============================================================================
 # VelesDB Configuration File
-# Version: 3.1.0
+# Version: 3.2.0
 # =============================================================================
 
 # -----------------------------------------------------------------------------

--- a/docs/guides/GRAPH_PATTERNS.md
+++ b/docs/guides/GRAPH_PATTERNS.md
@@ -1,6 +1,6 @@
 # Graph Patterns Guide
 
-*Version 3.1.0 -- May 2026*
+*Version 3.2.0 -- May 2026*
 
 Practical guide for using VelesQL `MATCH` graph patterns in VelesDB.
 

--- a/docs/guides/INSTALLATION.md
+++ b/docs/guides/INSTALLATION.md
@@ -60,10 +60,10 @@ entry.
 
 ```bash
 # Download
-wget https://github.com/cyberlife-coder/VelesDB/releases/download/v3.1.0/velesdb-3.1.0-amd64.deb
+wget https://github.com/cyberlife-coder/VelesDB/releases/download/v3.2.0/velesdb-3.2.0-amd64.deb
 
 # Install
-sudo dpkg -i velesdb-3.1.0-amd64.deb
+sudo dpkg -i velesdb-3.2.0-amd64.deb
 
 # Verify
 velesdb --version
@@ -160,13 +160,13 @@ GitHub Container Registry, so you don't need to build locally:
 
 ```bash
 # Pull a specific release (recommended for reproducibility)
-docker pull ghcr.io/cyberlife-coder/velesdb:3.1.0
+docker pull ghcr.io/cyberlife-coder/velesdb:3.2.0
 
 # ...or the latest stable release
 docker pull ghcr.io/cyberlife-coder/velesdb:latest
 
 docker run -d --name velesdb -p 8080:8080 -v velesdb_data:/data \
-  ghcr.io/cyberlife-coder/velesdb:3.1.0
+  ghcr.io/cyberlife-coder/velesdb:3.2.0
 ```
 
 ### Build locally

--- a/docs/guides/SEARCH_MODES.md
+++ b/docs/guides/SEARCH_MODES.md
@@ -1,6 +1,6 @@
 # 🎯 Search Modes - Recall Configuration Guide
 
-*Version 3.1.0 -- 2026-06-12*
+*Version 3.2.0 -- 2026-06-12*
 
 Complete guide to configuring the **recall vs latency** trade-off in VelesDB. Covers dense search (HNSW), sparse search (SPLADE/BM42), and hybrid search (dense+sparse with fusion). Includes a comparison with Milvus, OpenSearch, and Qdrant practices.
 

--- a/docs/guides/SERVER_SECURITY.md
+++ b/docs/guides/SERVER_SECURITY.md
@@ -299,7 +299,7 @@ curl http://localhost:8080/health
 ```json
 {
   "status": "ok",
-  "version": "3.1.0"
+  "version": "3.2.0"
 }
 ```
 
@@ -318,7 +318,7 @@ curl http://localhost:8080/ready
 ```json
 {
   "status": "ready",
-  "version": "3.1.0"
+  "version": "3.2.0"
 }
 ```
 
@@ -327,7 +327,7 @@ curl http://localhost:8080/ready
 ```json
 {
   "status": "not_ready",
-  "version": "3.1.0"
+  "version": "3.2.0"
 }
 ```
 

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3443,16 +3443,10 @@
         ],
         "properties": {
           "id": {
-            "oneOf": [
-              {
-                "type": "integer",
-                "format": "int64"
-              },
-              {
-                "type": "string"
-              }
-            ],
-            "description": "Point ID. Accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss."
+            "type": "integer",
+            "format": "int64",
+            "description": "Edge ID.",
+            "minimum": 0
           },
           "label": {
             "type": "string",
@@ -3462,28 +3456,16 @@
             "description": "Edge properties."
           },
           "source": {
-            "oneOf": [
-              {
-                "type": "integer",
-                "format": "int64"
-              },
-              {
-                "type": "string"
-              }
-            ],
-            "description": "Point ID. Accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss."
+            "type": "integer",
+            "format": "int64",
+            "description": "Source node ID.",
+            "minimum": 0
           },
           "target": {
-            "oneOf": [
-              {
-                "type": "integer",
-                "format": "int64"
-              },
-              {
-                "type": "string"
-              }
-            ],
-            "description": "Point ID. Accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss."
+            "type": "integer",
+            "format": "int64",
+            "description": "Target node ID.",
+            "minimum": 0
           }
         }
       },
@@ -4049,8 +4031,10 @@
         ],
         "properties": {
           "id": {
-            "type": "string",
-            "description": "Edge ID."
+            "type": "integer",
+            "format": "int64",
+            "description": "Edge ID.",
+            "minimum": 0
           },
           "label": {
             "type": "string",
@@ -4060,12 +4044,16 @@
             "description": "Edge properties."
           },
           "source": {
-            "type": "string",
-            "description": "Source node ID."
+            "type": "integer",
+            "format": "int64",
+            "description": "Source node ID.",
+            "minimum": 0
           },
           "target": {
-            "type": "string",
-            "description": "Target node ID."
+            "type": "integer",
+            "format": "int64",
+            "description": "Target node ID.",
+            "minimum": 0
           }
         }
       },
@@ -4503,8 +4491,10 @@
         ],
         "properties": {
           "id": {
-            "type": "string",
-            "description": "Node ID."
+            "type": "integer",
+            "format": "int64",
+            "description": "Node ID.",
+            "minimum": 0
           },
           "payload": {
             "description": "Node payload (if any)."
@@ -4931,16 +4921,14 @@
         "properties": {
           "bindings": {
             "type": "object",
+            "description": "Variable bindings from pattern matching.",
             "additionalProperties": {
-              "oneOf": [
-                {
-                  "type": "integer",
-                  "format": "int64"
-                },
-                {
-                  "type": "string"
-                }
-              ]
+              "type": "integer",
+              "format": "int64",
+              "minimum": 0
+            },
+            "propertyNames": {
+              "type": "string"
             }
           },
           "depth": {
@@ -5062,16 +5050,11 @@
           "node_ids": {
             "type": "array",
             "items": {
-              "oneOf": [
-                {
-                  "type": "integer",
-                  "format": "int64"
-                },
-                {
-                  "type": "string"
-                }
-              ]
-            }
+              "type": "integer",
+              "format": "int64",
+              "minimum": 0
+            },
+            "description": "List of node IDs (serialized as strings to preserve u64 precision in JS)."
           }
         }
       },
@@ -5083,8 +5066,10 @@
         ],
         "properties": {
           "node_id": {
-            "type": "string",
-            "description": "Node ID."
+            "type": "integer",
+            "format": "int64",
+            "description": "Node ID.",
+            "minimum": 0
           },
           "payload": {
             "description": "Stored payload (null if none)."
@@ -5164,16 +5149,11 @@
           "sources": {
             "type": "array",
             "items": {
-              "oneOf": [
-                {
-                  "type": "integer",
-                  "format": "int64"
-                },
-                {
-                  "type": "string"
-                }
-              ]
-            }
+              "type": "integer",
+              "format": "int64",
+              "minimum": 0
+            },
+            "description": "Source node IDs to start traversal from (accepts strings or numbers so\nJS clients can send precision-safe u64 IDs above `Number.MAX_SAFE_INTEGER`)."
           }
         }
       },
@@ -5378,28 +5358,16 @@
             "description": "Relationship type label (e.g. `\"KNOWS\"`, `\"RELATED_TO\"`)."
           },
           "source": {
-            "oneOf": [
-              {
-                "type": "integer",
-                "format": "int64"
-              },
-              {
-                "type": "string"
-              }
-            ],
-            "description": "Point ID. Accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss."
+            "type": "integer",
+            "format": "int64",
+            "description": "Source point ID.",
+            "minimum": 0
           },
           "target": {
-            "oneOf": [
-              {
-                "type": "integer",
-                "format": "int64"
-              },
-              {
-                "type": "string"
-              }
-            ],
-            "description": "Point ID. Accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss."
+            "type": "integer",
+            "format": "int64",
+            "description": "Target point ID.",
+            "minimum": 0
           }
         }
       },
@@ -5411,8 +5379,10 @@
         ],
         "properties": {
           "edge_id": {
-            "type": "string",
-            "description": "Allocated edge ID."
+            "type": "integer",
+            "format": "int64",
+            "description": "Allocated edge ID.",
+            "minimum": 0
           }
         }
       },
@@ -5428,8 +5398,10 @@
         ],
         "properties": {
           "id": {
-            "type": "string",
-            "description": "Edge ID."
+            "type": "integer",
+            "format": "int64",
+            "description": "Edge ID.",
+            "minimum": 0
           },
           "properties": {
             "description": "Edge properties (null when empty)."
@@ -5439,12 +5411,16 @@
             "description": "Relationship type label."
           },
           "source": {
-            "type": "string",
-            "description": "Source point ID."
+            "type": "integer",
+            "format": "int64",
+            "description": "Source point ID.",
+            "minimum": 0
           },
           "target": {
-            "type": "string",
-            "description": "Target point ID."
+            "type": "integer",
+            "format": "int64",
+            "description": "Target point ID.",
+            "minimum": 0
           }
         }
       },
@@ -5832,22 +5808,19 @@
             "minimum": 0
           },
           "id": {
-            "type": "string",
-            "description": "Target node ID."
+            "type": "integer",
+            "format": "int64",
+            "description": "Target node ID.",
+            "minimum": 0
           },
           "path": {
             "type": "array",
             "items": {
-              "oneOf": [
-                {
-                  "type": "integer",
-                  "format": "int64"
-                },
-                {
-                  "type": "string"
-                }
-              ]
-            }
+              "type": "integer",
+              "format": "int64",
+              "minimum": 0
+            },
+            "description": "Path of edge IDs taken to reach this node."
           }
         }
       },
@@ -5921,20 +5894,17 @@
           "path": {
             "type": "array",
             "items": {
-              "oneOf": [
-                {
-                  "type": "integer",
-                  "format": "int64"
-                },
-                {
-                  "type": "string"
-                }
-              ]
-            }
+              "type": "integer",
+              "format": "int64",
+              "minimum": 0
+            },
+            "description": "Path taken (list of edge IDs)."
           },
           "target_id": {
-            "type": "string",
-            "description": "Target node ID reached."
+            "type": "integer",
+            "format": "int64",
+            "description": "Target node ID reached.",
+            "minimum": 0
           }
         }
       },
@@ -5985,16 +5955,10 @@
             "description": "Filter by relationship types (empty = all types)."
           },
           "source": {
-            "oneOf": [
-              {
-                "type": "integer",
-                "format": "int64"
-              },
-              {
-                "type": "string"
-              }
-            ],
-            "description": "Point ID. Accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss."
+            "type": "integer",
+            "format": "int64",
+            "description": "Source node ID to start traversal from.",
+            "minimum": 0
           },
           "strategy": {
             "type": "string",

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -11,7 +11,7 @@
       "name": "VelesDB Core License 1.0",
       "url": "https://github.com/cyberlife-coder/VelesDB/blob/main/LICENSE"
     },
-    "version": "3.1.0"
+    "version": "3.2.0"
   },
   "servers": [
     {

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3443,10 +3443,16 @@
         ],
         "properties": {
           "id": {
-            "type": "integer",
-            "format": "int64",
-            "description": "Edge ID.",
-            "minimum": 0
+            "oneOf": [
+              {
+                "type": "integer",
+                "format": "int64"
+              },
+              {
+                "type": "string"
+              }
+            ],
+            "description": "Point ID. Accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss."
           },
           "label": {
             "type": "string",
@@ -3456,16 +3462,28 @@
             "description": "Edge properties."
           },
           "source": {
-            "type": "integer",
-            "format": "int64",
-            "description": "Source node ID.",
-            "minimum": 0
+            "oneOf": [
+              {
+                "type": "integer",
+                "format": "int64"
+              },
+              {
+                "type": "string"
+              }
+            ],
+            "description": "Point ID. Accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss."
           },
           "target": {
-            "type": "integer",
-            "format": "int64",
-            "description": "Target node ID.",
-            "minimum": 0
+            "oneOf": [
+              {
+                "type": "integer",
+                "format": "int64"
+              },
+              {
+                "type": "string"
+              }
+            ],
+            "description": "Point ID. Accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss."
           }
         }
       },
@@ -4031,10 +4049,8 @@
         ],
         "properties": {
           "id": {
-            "type": "integer",
-            "format": "int64",
-            "description": "Edge ID.",
-            "minimum": 0
+            "type": "string",
+            "description": "Edge ID."
           },
           "label": {
             "type": "string",
@@ -4044,16 +4060,12 @@
             "description": "Edge properties."
           },
           "source": {
-            "type": "integer",
-            "format": "int64",
-            "description": "Source node ID.",
-            "minimum": 0
+            "type": "string",
+            "description": "Source node ID."
           },
           "target": {
-            "type": "integer",
-            "format": "int64",
-            "description": "Target node ID.",
-            "minimum": 0
+            "type": "string",
+            "description": "Target node ID."
           }
         }
       },
@@ -4491,10 +4503,8 @@
         ],
         "properties": {
           "id": {
-            "type": "integer",
-            "format": "int64",
-            "description": "Node ID.",
-            "minimum": 0
+            "type": "string",
+            "description": "Node ID."
           },
           "payload": {
             "description": "Node payload (if any)."
@@ -4921,14 +4931,16 @@
         "properties": {
           "bindings": {
             "type": "object",
-            "description": "Variable bindings from pattern matching.",
             "additionalProperties": {
-              "type": "integer",
-              "format": "int64",
-              "minimum": 0
-            },
-            "propertyNames": {
-              "type": "string"
+              "oneOf": [
+                {
+                  "type": "integer",
+                  "format": "int64"
+                },
+                {
+                  "type": "string"
+                }
+              ]
             }
           },
           "depth": {
@@ -5050,11 +5062,16 @@
           "node_ids": {
             "type": "array",
             "items": {
-              "type": "integer",
-              "format": "int64",
-              "minimum": 0
-            },
-            "description": "List of node IDs (serialized as strings to preserve u64 precision in JS)."
+              "oneOf": [
+                {
+                  "type": "integer",
+                  "format": "int64"
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            }
           }
         }
       },
@@ -5066,10 +5083,8 @@
         ],
         "properties": {
           "node_id": {
-            "type": "integer",
-            "format": "int64",
-            "description": "Node ID.",
-            "minimum": 0
+            "type": "string",
+            "description": "Node ID."
           },
           "payload": {
             "description": "Stored payload (null if none)."
@@ -5149,11 +5164,16 @@
           "sources": {
             "type": "array",
             "items": {
-              "type": "integer",
-              "format": "int64",
-              "minimum": 0
-            },
-            "description": "Source node IDs to start traversal from (accepts strings or numbers so\nJS clients can send precision-safe u64 IDs above `Number.MAX_SAFE_INTEGER`)."
+              "oneOf": [
+                {
+                  "type": "integer",
+                  "format": "int64"
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            }
           }
         }
       },
@@ -5358,16 +5378,28 @@
             "description": "Relationship type label (e.g. `\"KNOWS\"`, `\"RELATED_TO\"`)."
           },
           "source": {
-            "type": "integer",
-            "format": "int64",
-            "description": "Source point ID.",
-            "minimum": 0
+            "oneOf": [
+              {
+                "type": "integer",
+                "format": "int64"
+              },
+              {
+                "type": "string"
+              }
+            ],
+            "description": "Point ID. Accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss."
           },
           "target": {
-            "type": "integer",
-            "format": "int64",
-            "description": "Target point ID.",
-            "minimum": 0
+            "oneOf": [
+              {
+                "type": "integer",
+                "format": "int64"
+              },
+              {
+                "type": "string"
+              }
+            ],
+            "description": "Point ID. Accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss."
           }
         }
       },
@@ -5379,10 +5411,8 @@
         ],
         "properties": {
           "edge_id": {
-            "type": "integer",
-            "format": "int64",
-            "description": "Allocated edge ID.",
-            "minimum": 0
+            "type": "string",
+            "description": "Allocated edge ID."
           }
         }
       },
@@ -5398,10 +5428,8 @@
         ],
         "properties": {
           "id": {
-            "type": "integer",
-            "format": "int64",
-            "description": "Edge ID.",
-            "minimum": 0
+            "type": "string",
+            "description": "Edge ID."
           },
           "properties": {
             "description": "Edge properties (null when empty)."
@@ -5411,16 +5439,12 @@
             "description": "Relationship type label."
           },
           "source": {
-            "type": "integer",
-            "format": "int64",
-            "description": "Source point ID.",
-            "minimum": 0
+            "type": "string",
+            "description": "Source point ID."
           },
           "target": {
-            "type": "integer",
-            "format": "int64",
-            "description": "Target point ID.",
-            "minimum": 0
+            "type": "string",
+            "description": "Target point ID."
           }
         }
       },
@@ -5808,19 +5832,22 @@
             "minimum": 0
           },
           "id": {
-            "type": "integer",
-            "format": "int64",
-            "description": "Target node ID.",
-            "minimum": 0
+            "type": "string",
+            "description": "Target node ID."
           },
           "path": {
             "type": "array",
             "items": {
-              "type": "integer",
-              "format": "int64",
-              "minimum": 0
-            },
-            "description": "Path of edge IDs taken to reach this node."
+              "oneOf": [
+                {
+                  "type": "integer",
+                  "format": "int64"
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            }
           }
         }
       },
@@ -5894,17 +5921,20 @@
           "path": {
             "type": "array",
             "items": {
-              "type": "integer",
-              "format": "int64",
-              "minimum": 0
-            },
-            "description": "Path taken (list of edge IDs)."
+              "oneOf": [
+                {
+                  "type": "integer",
+                  "format": "int64"
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            }
           },
           "target_id": {
-            "type": "integer",
-            "format": "int64",
-            "description": "Target node ID reached.",
-            "minimum": 0
+            "type": "string",
+            "description": "Target node ID reached."
           }
         }
       },
@@ -5955,10 +5985,16 @@
             "description": "Filter by relationship types (empty = all types)."
           },
           "source": {
-            "type": "integer",
-            "format": "int64",
-            "description": "Source node ID to start traversal from.",
-            "minimum": 0
+            "oneOf": [
+              {
+                "type": "integer",
+                "format": "int64"
+              },
+              {
+                "type": "string"
+              }
+            ],
+            "description": "Point ID. Accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss."
           },
           "strategy": {
             "type": "string",

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -8,7 +8,7 @@ info:
   license:
     name: VelesDB Core License 1.0
     url: https://github.com/cyberlife-coder/VelesDB/blob/main/LICENSE
-  version: 3.1.0
+  version: 3.2.0
 servers:
 - url: /
   description: Local server

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2275,25 +2275,28 @@ components:
       - label
       properties:
         id:
-          type: integer
-          format: int64
-          description: Edge ID.
-          minimum: 0
+          oneOf:
+          - type: integer
+            format: int64
+          - type: string
+          description: Point ID. Accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss.
         label:
           type: string
           description: Edge label (relationship type).
         properties:
           description: Edge properties.
         source:
-          type: integer
-          format: int64
-          description: Source node ID.
-          minimum: 0
+          oneOf:
+          - type: integer
+            format: int64
+          - type: string
+          description: Point ID. Accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss.
         target:
-          type: integer
-          format: int64
-          description: Target node ID.
-          minimum: 0
+          oneOf:
+          - type: integer
+            format: int64
+          - type: string
+          description: Point ID. Accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss.
     AddEdgesBatchRequest:
       type: object
       description: Request to add multiple edges in one batched operation.
@@ -2773,25 +2776,19 @@ components:
       - properties
       properties:
         id:
-          type: integer
-          format: int64
+          type: string
           description: Edge ID.
-          minimum: 0
         label:
           type: string
           description: Edge label (relationship type).
         properties:
           description: Edge properties.
         source:
-          type: integer
-          format: int64
+          type: string
           description: Source node ID.
-          minimum: 0
         target:
-          type: integer
-          format: int64
+          type: string
           description: Target node ID.
-          minimum: 0
     EdgesResponse:
       type: object
       description: Response containing edges.
@@ -3124,10 +3121,8 @@ components:
       - score
       properties:
         id:
-          type: integer
-          format: int64
+          type: string
           description: Node ID.
-          minimum: 0
         payload:
           description: Node payload (if any).
         score:
@@ -3453,13 +3448,11 @@ components:
       properties:
         bindings:
           type: object
-          description: Variable bindings from pattern matching.
           additionalProperties:
-            type: integer
-            format: int64
-            minimum: 0
-          propertyNames:
-            type: string
+            oneOf:
+            - type: integer
+              format: int64
+            - type: string
         depth:
           type: integer
           format: int32
@@ -3553,10 +3546,10 @@ components:
         node_ids:
           type: array
           items:
-            type: integer
-            format: int64
-            minimum: 0
-          description: List of node IDs (serialized as strings to preserve u64 precision in JS).
+            oneOf:
+            - type: integer
+              format: int64
+            - type: string
     NodePayloadResponse:
       type: object
       description: Response for a node payload retrieval.
@@ -3564,10 +3557,8 @@ components:
       - node_id
       properties:
         node_id:
-          type: integer
-          format: int64
+          type: string
           description: Node ID.
-          minimum: 0
         payload:
           description: Stored payload (null if none).
     NodeStatsResponse:
@@ -3643,12 +3634,10 @@ components:
         sources:
           type: array
           items:
-            type: integer
-            format: int64
-            minimum: 0
-          description: |-
-            Source node IDs to start traversal from (accepts strings or numbers so
-            JS clients can send precision-safe u64 IDs above `Number.MAX_SAFE_INTEGER`).
+            oneOf:
+            - type: integer
+              format: int64
+            - type: string
     PointRequest:
       type: object
       description: A point in an upsert request.
@@ -3812,15 +3801,17 @@ components:
           type: string
           description: Relationship type label (e.g. `"KNOWS"`, `"RELATED_TO"`).
         source:
-          type: integer
-          format: int64
-          description: Source point ID.
-          minimum: 0
+          oneOf:
+          - type: integer
+            format: int64
+          - type: string
+          description: Point ID. Accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss.
         target:
-          type: integer
-          format: int64
-          description: Target point ID.
-          minimum: 0
+          oneOf:
+          - type: integer
+            format: int64
+          - type: string
+          description: Point ID. Accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss.
     RelateResponse:
       type: object
       description: Response body for `POST /collections/{name}/relations`.
@@ -3828,10 +3819,8 @@ components:
       - edge_id
       properties:
         edge_id:
-          type: integer
-          format: int64
+          type: string
           description: Allocated edge ID.
-          minimum: 0
     RelationEdge:
       type: object
       description: A single relation edge in a response.
@@ -3843,25 +3832,19 @@ components:
       - properties
       properties:
         id:
-          type: integer
-          format: int64
+          type: string
           description: Edge ID.
-          minimum: 0
         properties:
           description: Edge properties (null when empty).
         rel_type:
           type: string
           description: Relationship type label.
         source:
-          type: integer
-          format: int64
+          type: string
           description: Source point ID.
-          minimum: 0
         target:
-          type: integer
-          format: int64
+          type: string
           description: Target point ID.
-          minimum: 0
     RelationsResponse:
       type: object
       description: Response body for `GET /collections/{name}/points/{id}/relations`.
@@ -4140,17 +4123,15 @@ components:
           description: Depth from source.
           minimum: 0
         id:
-          type: integer
-          format: int64
+          type: string
           description: Target node ID.
-          minimum: 0
         path:
           type: array
           items:
-            type: integer
-            format: int64
-            minimum: 0
-          description: Path of edge IDs taken to reach this node.
+            oneOf:
+            - type: integer
+              format: int64
+            - type: string
     StreamStatsEvent:
       type: object
       description: 'SSE event: Periodic statistics update.'
@@ -4206,15 +4187,13 @@ components:
         path:
           type: array
           items:
-            type: integer
-            format: int64
-            minimum: 0
-          description: Path taken (list of edge IDs).
+            oneOf:
+            - type: integer
+              format: int64
+            - type: string
         target_id:
-          type: integer
-          format: int64
+          type: string
           description: Target node ID reached.
-          minimum: 0
     TraversalStats:
       type: object
       description: Statistics from traversal operation.
@@ -4252,10 +4231,11 @@ components:
             type: string
           description: Filter by relationship types (empty = all types).
         source:
-          type: integer
-          format: int64
-          description: Source node ID to start traversal from.
-          minimum: 0
+          oneOf:
+          - type: integer
+            format: int64
+          - type: string
+          description: Point ID. Accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss.
         strategy:
           type: string
           description: 'Traversal strategy: "bfs" or "dfs".'

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2275,28 +2275,25 @@ components:
       - label
       properties:
         id:
-          oneOf:
-          - type: integer
-            format: int64
-          - type: string
-          description: Point ID. Accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss.
+          type: integer
+          format: int64
+          description: Edge ID.
+          minimum: 0
         label:
           type: string
           description: Edge label (relationship type).
         properties:
           description: Edge properties.
         source:
-          oneOf:
-          - type: integer
-            format: int64
-          - type: string
-          description: Point ID. Accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss.
+          type: integer
+          format: int64
+          description: Source node ID.
+          minimum: 0
         target:
-          oneOf:
-          - type: integer
-            format: int64
-          - type: string
-          description: Point ID. Accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss.
+          type: integer
+          format: int64
+          description: Target node ID.
+          minimum: 0
     AddEdgesBatchRequest:
       type: object
       description: Request to add multiple edges in one batched operation.
@@ -2776,19 +2773,25 @@ components:
       - properties
       properties:
         id:
-          type: string
+          type: integer
+          format: int64
           description: Edge ID.
+          minimum: 0
         label:
           type: string
           description: Edge label (relationship type).
         properties:
           description: Edge properties.
         source:
-          type: string
+          type: integer
+          format: int64
           description: Source node ID.
+          minimum: 0
         target:
-          type: string
+          type: integer
+          format: int64
           description: Target node ID.
+          minimum: 0
     EdgesResponse:
       type: object
       description: Response containing edges.
@@ -3121,8 +3124,10 @@ components:
       - score
       properties:
         id:
-          type: string
+          type: integer
+          format: int64
           description: Node ID.
+          minimum: 0
         payload:
           description: Node payload (if any).
         score:
@@ -3448,11 +3453,13 @@ components:
       properties:
         bindings:
           type: object
+          description: Variable bindings from pattern matching.
           additionalProperties:
-            oneOf:
-            - type: integer
-              format: int64
-            - type: string
+            type: integer
+            format: int64
+            minimum: 0
+          propertyNames:
+            type: string
         depth:
           type: integer
           format: int32
@@ -3546,10 +3553,10 @@ components:
         node_ids:
           type: array
           items:
-            oneOf:
-            - type: integer
-              format: int64
-            - type: string
+            type: integer
+            format: int64
+            minimum: 0
+          description: List of node IDs (serialized as strings to preserve u64 precision in JS).
     NodePayloadResponse:
       type: object
       description: Response for a node payload retrieval.
@@ -3557,8 +3564,10 @@ components:
       - node_id
       properties:
         node_id:
-          type: string
+          type: integer
+          format: int64
           description: Node ID.
+          minimum: 0
         payload:
           description: Stored payload (null if none).
     NodeStatsResponse:
@@ -3634,10 +3643,12 @@ components:
         sources:
           type: array
           items:
-            oneOf:
-            - type: integer
-              format: int64
-            - type: string
+            type: integer
+            format: int64
+            minimum: 0
+          description: |-
+            Source node IDs to start traversal from (accepts strings or numbers so
+            JS clients can send precision-safe u64 IDs above `Number.MAX_SAFE_INTEGER`).
     PointRequest:
       type: object
       description: A point in an upsert request.
@@ -3801,17 +3812,15 @@ components:
           type: string
           description: Relationship type label (e.g. `"KNOWS"`, `"RELATED_TO"`).
         source:
-          oneOf:
-          - type: integer
-            format: int64
-          - type: string
-          description: Point ID. Accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss.
+          type: integer
+          format: int64
+          description: Source point ID.
+          minimum: 0
         target:
-          oneOf:
-          - type: integer
-            format: int64
-          - type: string
-          description: Point ID. Accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss.
+          type: integer
+          format: int64
+          description: Target point ID.
+          minimum: 0
     RelateResponse:
       type: object
       description: Response body for `POST /collections/{name}/relations`.
@@ -3819,8 +3828,10 @@ components:
       - edge_id
       properties:
         edge_id:
-          type: string
+          type: integer
+          format: int64
           description: Allocated edge ID.
+          minimum: 0
     RelationEdge:
       type: object
       description: A single relation edge in a response.
@@ -3832,19 +3843,25 @@ components:
       - properties
       properties:
         id:
-          type: string
+          type: integer
+          format: int64
           description: Edge ID.
+          minimum: 0
         properties:
           description: Edge properties (null when empty).
         rel_type:
           type: string
           description: Relationship type label.
         source:
-          type: string
+          type: integer
+          format: int64
           description: Source point ID.
+          minimum: 0
         target:
-          type: string
+          type: integer
+          format: int64
           description: Target point ID.
+          minimum: 0
     RelationsResponse:
       type: object
       description: Response body for `GET /collections/{name}/points/{id}/relations`.
@@ -4123,15 +4140,17 @@ components:
           description: Depth from source.
           minimum: 0
         id:
-          type: string
+          type: integer
+          format: int64
           description: Target node ID.
+          minimum: 0
         path:
           type: array
           items:
-            oneOf:
-            - type: integer
-              format: int64
-            - type: string
+            type: integer
+            format: int64
+            minimum: 0
+          description: Path of edge IDs taken to reach this node.
     StreamStatsEvent:
       type: object
       description: 'SSE event: Periodic statistics update.'
@@ -4187,13 +4206,15 @@ components:
         path:
           type: array
           items:
-            oneOf:
-            - type: integer
-              format: int64
-            - type: string
+            type: integer
+            format: int64
+            minimum: 0
+          description: Path taken (list of edge IDs).
         target_id:
-          type: string
+          type: integer
+          format: int64
           description: Target node ID reached.
+          minimum: 0
     TraversalStats:
       type: object
       description: Statistics from traversal operation.
@@ -4231,11 +4252,10 @@ components:
             type: string
           description: Filter by relationship types (empty = all types).
         source:
-          oneOf:
-          - type: integer
-            format: int64
-          - type: string
-          description: Point ID. Accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss.
+          type: integer
+          format: int64
+          description: Source node ID to start traversal from.
+          minimum: 0
         strategy:
           type: string
           description: 'Traversal strategy: "bfs" or "dfs".'

--- a/docs/reference/ARCHITECTURE_DIAGRAMS.md
+++ b/docs/reference/ARCHITECTURE_DIAGRAMS.md
@@ -1,4 +1,4 @@
-# VelesDB Architecture Diagrams — v3.1.0
+# VelesDB Architecture Diagrams — v3.2.0
 
 ## 1. Workspace Dependency Graph
 

--- a/docs/reference/ECOSYSTEM_PARITY.md
+++ b/docs/reference/ECOSYSTEM_PARITY.md
@@ -1,6 +1,6 @@
 # VelesQL Ecosystem Parity Matrix
 
-Last updated: 2026-06-20 (v3.1.0)
+Last updated: 2026-06-20 (v3.2.0)
 
 This matrix tracks runtime contract and feature parity across the VelesDB ecosystem.
 

--- a/docs/reference/VELESQL_CHEATSHEET.md
+++ b/docs/reference/VELESQL_CHEATSHEET.md
@@ -1,7 +1,7 @@
 # VelesQL Cheat Sheet
 
 > **Date:** 2026-06-03
-> **VelesDB version:** 3.1.0
+> **VelesDB version:** 3.2.0
 > See the full specification in [`docs/VELESQL_SPEC.md`](../VELESQL_SPEC.md).
 
 > Every `sql` block below is **parsed** against the real grammar by an automated

--- a/docs/reference/VELESQL_CONFORMANCE_MATRIX.md
+++ b/docs/reference/VELESQL_CONFORMANCE_MATRIX.md
@@ -4,7 +4,7 @@ This document lists every VelesQL feature with its parser and executor status.
 A feature can be **Parsed** (the grammar + AST accept it) without being
 **Executed** (the query engine acts on it at runtime).
 
-> Last updated: 2026-06-20 (v3.10.0 / VelesDB v3.1.0)
+> Last updated: 2026-06-20 (v3.10.0 / VelesDB v3.2.0)
 
 ## Fully Supported (Parsed AND Executed)
 

--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -57,7 +57,7 @@ Check server health status.
 ```json
 {
   "status": "ok",
-  "version": "3.1.0"
+  "version": "3.2.0"
 }
 ```
 

--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -1010,13 +1010,6 @@ the engine's query plan (the same plan the CLI `.explain` renders):
     },
     {
       "step": 2,
-      "operation": "Filter",
-      "description": "Apply WHERE clause predicates",
-      "estimated_rows": 42,
-      "estimation_method": "histogram"
-    },
-    {
-      "step": 3,
       "operation": "Limit",
       "description": "Apply LIMIT 10 OFFSET 0",
       "estimated_rows": 10
@@ -1028,9 +1021,14 @@ the engine's query plan (the same plan the CLI `.explain` renders):
     "selectivity": 0.01,
     "complexity": "O(log n)"
   },
-  "features": { "has_vector_search": true, "has_filter": true }
+  "features": { "has_vector_search": true, "has_filter": false }
 }
 ```
+
+A non-vector `WHERE` predicate (e.g. `... vector NEAR $v AND price > 100 ...`)
+adds a `Filter` step between `VectorSearch` and `Limit`, carrying
+`estimated_rows` and `estimation_method` (`"histogram"`/`"cardinality"`) when
+collection statistics are available.
 
 Set `"analyze": true` to execute the query and add `actual_time_ms`,
 `actual_stats`, and per-node `node_stats` to the response.

--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -994,28 +994,58 @@ Analyze query execution plan without running the query.
 }
 ```
 
-**Response:**
+**Response:** the plan is a flat, ordered list of steps, single-sourced from
+the engine's query plan (the same plan the CLI `.explain` renders):
 ```json
 {
-  "plan": {
-    "type": "VectorSearch",
-    "collection": "docs",
-    "metric": "cosine",
-    "limit": 10,
-    "estimated_cost": 0.05,
-    "children": []
+  "query": "SELECT * FROM docs WHERE vector NEAR $v LIMIT 10",
+  "query_type": "SELECT",
+  "collection": "docs",
+  "plan": [
+    {
+      "step": 1,
+      "operation": "VectorSearch",
+      "description": "ANN search using HNSW index with NEAR clause",
+      "estimated_rows": null
+    },
+    {
+      "step": 2,
+      "operation": "Filter",
+      "description": "Apply WHERE clause predicates",
+      "estimated_rows": 42,
+      "estimation_method": "histogram"
+    },
+    {
+      "step": 3,
+      "operation": "Limit",
+      "description": "Apply LIMIT 10 OFFSET 0",
+      "estimated_rows": 10
+    }
+  ],
+  "estimated_cost": {
+    "uses_index": true,
+    "index_name": "HNSW",
+    "selectivity": 0.01,
+    "complexity": "O(log n)"
   },
-  "timing_ms": 0.12
+  "features": { "has_vector_search": true, "has_filter": true }
 }
 ```
 
-**Plan Node Types:**
-- `TableScan` - Full collection scan
+Set `"analyze": true` to execute the query and add `actual_time_ms`,
+`actual_stats`, and per-node `node_stats` to the response.
+
+**`operation` values:**
+- `FullScan` - full collection scan (no index)
 - `VectorSearch` - HNSW approximate nearest neighbor
-- `IndexLookup` - Property index lookup
-- `Filter` - Post-search filtering
-- `Limit` - Result limiting
-- `Offset` - Result offsetting
+- `IndexLookup` - property index lookup
+- `Filter` - metadata filtering
+- `{Type}Join` - cross-store join (`InnerJoin`, `LeftJoin`, `RightJoin`, `FullJoin`)
+- `GroupBy` - GROUP BY grouping
+- `Aggregate` - aggregate computation (COUNT, SUM, ...)
+- `Sort` - ORDER BY sort
+- `Limit` - result limiting (folds OFFSET into its description)
+- `MatchTraversal` - MATCH graph traversal
 
 ---
 

--- a/examples/wasm-browser-demo/README.md
+++ b/examples/wasm-browser-demo/README.md
@@ -22,7 +22,7 @@ cd crates/velesdb-wasm
 wasm-pack build --target web --out-dir ../../examples/wasm-browser-demo/pkg
 
 # Then update index.html to use the local path instead of CDN:
-# Change: import init from 'https://unpkg.com/@wiscale/velesdb-wasm@3.1.0/velesdb_wasm.js'
+# Change: import init from 'https://unpkg.com/@wiscale/velesdb-wasm@3.2.0/velesdb_wasm.js'
 # To:     import init from './pkg/velesdb_wasm.js'
 ```
 
@@ -80,7 +80,7 @@ Typical results on modern hardware:
 ```html
 <script type="module">
   // If published on npm:
-  // import init, { VectorStore } from 'https://unpkg.com/@wiscale/velesdb-wasm@3.1.0/velesdb_wasm.js';
+  // import init, { VectorStore } from 'https://unpkg.com/@wiscale/velesdb-wasm@3.2.0/velesdb_wasm.js';
   // If built locally with wasm-pack:
   import init, { VectorStore } from './pkg/velesdb_wasm.js';
 

--- a/examples/wasm-browser-demo/index.html
+++ b/examples/wasm-browser-demo/index.html
@@ -171,8 +171,8 @@
         // WASM module - tracks @wiscale/velesdb-wasm@<workspace> with CDN fallback.
         // Bumped by scripts/bump-version.ps1 on every release; if you copy this
         // demo, update the version below to match `@wiscale/velesdb-wasm` on npm.
-        const WASM_CDN_PRIMARY = 'https://unpkg.com/@wiscale/velesdb-wasm@3.1.0/velesdb_wasm.js';
-        const WASM_CDN_FALLBACK = 'https://cdn.jsdelivr.net/npm/@wiscale/velesdb-wasm@3.1.0/velesdb_wasm.js';
+        const WASM_CDN_PRIMARY = 'https://unpkg.com/@wiscale/velesdb-wasm@3.2.0/velesdb_wasm.js';
+        const WASM_CDN_FALLBACK = 'https://cdn.jsdelivr.net/npm/@wiscale/velesdb-wasm@3.2.0/velesdb_wasm.js';
         
         let init, VectorStore;
         

--- a/integrations/common/pyproject.toml
+++ b/integrations/common/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "velesdb-common"
-version = "3.1.0"
+version = "3.2.0"
 description = "Shared utilities for VelesDB Python integrations (internal use)"
 readme = "README.md"
 license = {text = "MIT"}

--- a/integrations/haystack/pyproject.toml
+++ b/integrations/haystack/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "haystack-velesdb"
-version = "3.1.0"
+version = "3.2.0"
 description = "Haystack 2.x DocumentStore for VelesDB: The Local AI Memory Database."
 readme = "README.md"
 license = {text = "MIT"}

--- a/integrations/haystack/src/haystack_velesdb/__init__.py
+++ b/integrations/haystack/src/haystack_velesdb/__init__.py
@@ -3,4 +3,4 @@
 from haystack_velesdb.document_store import VelesDBDocumentStore
 
 __all__ = ["VelesDBDocumentStore"]
-__version__ = "3.1.0"
+__version__ = "3.2.0"

--- a/integrations/langchain/pyproject.toml
+++ b/integrations/langchain/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "langchain-velesdb"
-version = "3.1.0"
+version = "3.2.0"
 description = "LangChain VectorStore for VelesDB: The Local AI Memory Database. Microsecond RAG retrieval."
 readme = "README.md"
 license = {text = "MIT"}

--- a/integrations/langchain/src/langchain_velesdb/__init__.py
+++ b/integrations/langchain/src/langchain_velesdb/__init__.py
@@ -53,4 +53,4 @@ if _HAS_MEMORY:
         "VelesDBSemanticMemory",
         "VelesDBProceduralMemory",
     ])
-__version__ = "3.1.0"
+__version__ = "3.2.0"

--- a/integrations/llamaindex/pyproject.toml
+++ b/integrations/llamaindex/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "llama-index-vector-stores-velesdb"
-version = "3.1.0"
+version = "3.2.0"
 description = "LlamaIndex VectorStore for VelesDB: The Local AI Memory Database. Microsecond RAG retrieval."
 readme = "README.md"
 license = "MIT"

--- a/integrations/llamaindex/src/llamaindex_velesdb/__init__.py
+++ b/integrations/llamaindex/src/llamaindex_velesdb/__init__.py
@@ -57,4 +57,4 @@ if _HAS_MEMORY:
         "VelesDBChatMemory",
         "VelesDBProceduralMemory",
     ])
-__version__ = "3.1.0"
+__version__ = "3.2.0"

--- a/scripts/dx-timing/scenario_rust.sh
+++ b/scripts/dx-timing/scenario_rust.sh
@@ -41,7 +41,7 @@ RS
 # Pin to the latest released version on crates.io. Bump alongside each
 # workspace release; the timing measurement is meant to track the path a
 # fresh dev hits when they `cargo add velesdb-core` today.
-cargo add --quiet velesdb-core@3.1.0
+cargo add --quiet velesdb-core@3.2.0
 cargo add --quiet serde_json@1
 cargo run --quiet --release
 

--- a/scripts/dx-timing/scenario_server.sh
+++ b/scripts/dx-timing/scenario_server.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 
 START=$(date +%s.%N)
 
-cargo install --quiet --locked velesdb-server@3.1.0
+cargo install --quiet --locked velesdb-server@3.2.0
 
 DATA_DIR=$(mktemp -d -t velesdb_dx_server_XXXX)
 trap 'rm -rf "$DATA_DIR"' EXIT

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -2,7 +2,7 @@
 
 Official TypeScript SDK for [VelesDB](https://github.com/cyberlife-coder/VelesDB) -- the local-first vector database for AI and RAG. Sub-millisecond semantic search in Browser and Node.js.
 
-**v3.1.0** | Node.js >= 18 | Browser (WASM) | VelesDB Core License 1.0
+**v3.2.0** | Node.js >= 18 | Browser (WASM) | VelesDB Core License 1.0
 
 ## What's New (unreleased)
 

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wiscale/velesdb-sdk",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wiscale/velesdb-sdk",
-      "version": "3.1.0",
+      "version": "3.2.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@wiscale/velesdb-wasm": "^2.0.0"

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wiscale/velesdb-sdk",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "VelesDB TypeScript SDK: The Local Vector Database for AI & RAG. Microsecond semantic search in Browser & Node.js.",
   "main": "dist/index.js",
   "module": "dist/index.mjs",


### PR DESCRIPTION
**Minor release 3.2.0.**

Bundles everything merged to `develop` since v3.1.0:
- **C11 — EXPLAIN single-sourced onto `velesdb-core`** (PR #1173 + #1174 hardening): the server EXPLAIN now consumes the canonical `QueryPlan` via the new `QueryPlan::to_plan_steps()` instead of reconstructing the plan from the AST. **Additive public API** (`PlanStep`/`PlanStepKind`, 4 new `PlanNode` variants); the REST response shape and `docs/openapi.{json,yaml}` are **unchanged**. Validated under 7 review angles + 2 adversarial review passes.
- anti-AI-attribution `commit-msg` hook (#1171) + core code-quality refactor (#1172).

### Release prep
- `bump_version.py 3.2.0` (60 locations) + `cargo update -w` (Cargo.lock → 3.2.0)
- regenerated `docs/openapi.{json,yaml}` → 3.2.0
- `CHANGELOG [Unreleased]` → `[3.2.0]`; `check-version-sync.py`: **all versions match**

SemVer: MINOR — additive Rust public API, no on-disk format change. EXPLAIN behavior changes (Filter step for hybrid vector+scalar queries, VectorSearch `estimated_rows` now null, standalone Offset step) are corrective and documented in the CHANGELOG.