### PR TITLE
docs: use the correct LlamaIndex PyPI package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -507,7 +507,7 @@ Ship AI features without a server. VelesDB embeds directly into Tauri, iOS, and 
 | **Mobile** | [velesdb-mobile](crates/velesdb-mobile) — iOS (Swift) & Android (Kotlin) | [Build instructions](docs/guides/INSTALLATION.md#-mobile-iosandroid) |
 | **Desktop** | [tauri-plugin](crates/tauri-plugin-velesdb) — Tauri v2 AI-powered apps | `cargo add tauri-plugin-velesdb` |
 | **LangChain** | [langchain-velesdb](integrations/langchain) — Official VectorStore | [From source](integrations/langchain/README.md) |
-| **LlamaIndex** | [llamaindex-velesdb](integrations/llamaindex) — Document indexing | [From source](integrations/llamaindex/README.md) |
+| **LlamaIndex** | [llama-index-vector-stores-velesdb](integrations/llamaindex) — Document indexing | [From source](integrations/llamaindex/README.md) |
 | **Haystack** | [haystack-velesdb](integrations/haystack) — Haystack 2.x DocumentStore | [From source](integrations/haystack/README.md) |
 | **Migration** | [velesdb-migrate](crates/velesdb-migrate) — From Qdrant, Pinecone, Supabase | `cargo install velesdb-migrate` |
 

--- a/docs/WHY_VELESDB.md
+++ b/docs/WHY_VELESDB.md
@@ -103,7 +103,7 @@ See [BENCHMARKS.md](./BENCHMARKS.md) for detailed numbers and methodology.
 | iOS / Android | `velesdb-mobile` (UniFFI) | Stable |
 | Tauri Desktop | `tauri-plugin-velesdb` | Stable |
 | LangChain | `langchain-velesdb` | Stable |
-| LlamaIndex | `llamaindex-velesdb` | Stable |
+| LlamaIndex | `llama-index-vector-stores-velesdb` | Stable |
 
 ---
 

--- a/integrations/llamaindex/README.md
+++ b/integrations/llamaindex/README.md
@@ -338,7 +338,7 @@ Source: `benchmarks/baseline.json`.
 
 ## Agent Memory (optional)
 
-`llamaindex-velesdb` re-exports three agent-memory wrappers around VelesDB's
+`llama-index-vector-stores-velesdb` re-exports three agent-memory wrappers around VelesDB's
 native memory subsystems. They are imported lazily — if the underlying
 `velesdb` native extension isn't installed, the import becomes a no-op and
 the symbols are exposed as `None`.

--- a/integrations/llamaindex/tests/test_e2e_advanced.py
+++ b/integrations/llamaindex/tests/test_e2e_advanced.py
@@ -41,7 +41,7 @@ except ImportError:
 
 pytestmark = pytest.mark.skipif(
     not VELESDB_LLAMAINDEX_AVAILABLE,
-    reason="llamaindex-velesdb not installed",
+    reason="llama-index-vector-stores-velesdb not installed",
 )
 
 _DIM = 64


### PR DESCRIPTION
The install docs referenced **`llamaindex-velesdb`**, which **does not exist on PyPI** (`pip install llamaindex-velesdb` → 404). The published distribution is **`llama-index-vector-stores-velesdb`** (confirmed against PyPI 3.2.0 and the package's own `pyproject.toml` `name`).

A user following these docs to install the LlamaIndex integration would hit a 404.

### Changed (4 install-context references → correct name)
- `README.md` (integrations table)
- `docs/WHY_VELESDB.md` (integrations table)
- `integrations/llamaindex/README.md` (re-exports sentence)
- `integrations/llamaindex/tests/test_e2e_advanced.py` (skip-reason string)

Surfaced by the **3.2.0 post-release consumer verification** (which install-tested all published artifacts — the release itself is healthy; this is a pre-existing doc-name bug, unrelated to the release).