### PR TITLE
chore(sdk): track the velesdb-wasm 3.x line in the TypeScript SDK

### DIFF
--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.2.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@wiscale/velesdb-wasm": "^2.0.0"
+        "@wiscale/velesdb-wasm": "^3.0.0"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -1873,9 +1873,9 @@
       }
     },
     "node_modules/@wiscale/velesdb-wasm": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@wiscale/velesdb-wasm/-/velesdb-wasm-2.0.0.tgz",
-      "integrity": "sha512-SFObr98azIRzwoZzj5t5tFVh9MDeZDpP6NIP9wf9UDkaDR1EWatepYnPY4spEQP+KUxzSt8+CsgQh3ytRoPqLQ==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@wiscale/velesdb-wasm/-/velesdb-wasm-3.2.0.tgz",
+      "integrity": "sha512-LxX4m2IfB+DmfWq3jJkqwTXQAQwTb2yhrJns1e/Qhs2muX2auKZW7q3bsZRQ+enPuf/q4GX0fY78ZLgWZ/0fnw==",
       "license": "SEE LICENSE IN LICENSE"
     },
     "node_modules/acorn": {

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -69,7 +69,7 @@
     "vitest": "^4.0.16"
   },
   "dependencies": {
-    "@wiscale/velesdb-wasm": "^2.0.0"
+    "@wiscale/velesdb-wasm": "^3.0.0"
   },
   "engines": {
     "node": ">=18.0.0"


### PR DESCRIPTION
## Problem
`@wiscale/velesdb-sdk@3.x` declared `@wiscale/velesdb-wasm: ^2.0.0`, so a consumer of the 3.x SDK pulled the **wasm 2.x** runtime, not the matching 3.x. Root cause: `bump_version.py` only rewrites the wasm **CDN-URL** form, never the SDK `package.json` **dependency range**, so it has been frozen at `^2.0.0` since the wasm 1→2 major.

Surfaced by the 3.2.0 post-release consumer verification.

## Verified safe before changing
- **wasm 2.0.0 → 3.2.0 public API is purely additive** (`.d.ts` diff): only new methods `insertBatchRaw` / `search_sparse`; **zero removals**; **identical JS exports**. The "3.0 major" was a workspace version-sync, not an API break.
- The SDK consumes wasm via its own `WasmModule` mirror type + wave4 stubs, not the wasm `.d.ts` directly.
- With wasm pinned to 3.2.0: **`tsc` typecheck ✓, `tsup` build ✓, full vitest suite ✓ (836 tests / 35 files)**.

## Change
`^2.0.0` → `^3.0.0` + lockfile refresh (wasm → 3.2.0). Covers the entire 3.x line; no source change.

## Follow-up (next MAJOR only)
Teach `bump_version.py` / `check-version-sync.py` to track this dependency range so a future 3.x→4.x bump can't reintroduce the skew. Out of scope here (touches release-critical scripts; `^3.0.0` already covers all of 3.x). Not a 3.2.1 — nothing is broken on the published 3.2.0.