### PR TITLE
Release 3.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to VelesDB will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.2.1] — 2026-06-20
+
+Patch release. Maintenance only — no engine/API change (`velesdb-core` and the
+REST/OpenAPI surface are functionally identical to 3.2.0).
+
+### Fixed
+- **TypeScript SDK pulls the matching WASM runtime.** `@wiscale/velesdb-sdk`
+  now depends on `@wiscale/velesdb-wasm` `^3.0.0` (was `^2.0.0`), so consumers
+  of the 3.x SDK get the 3.x WASM runtime instead of a stale 2.x. The 2.0.0 →
+  3.x WASM API is purely additive, so this is transparent for SDK consumers.
+- **Docs: correct LlamaIndex package name.** The integration is published on
+  PyPI as `llama-index-vector-stores-velesdb`; the docs previously referenced
+  the non-existent `llamaindex-velesdb` (a 404 for anyone following the install
+  instructions).
+
 ## [3.2.0] — 2026-06-20
 
 Minor release. Single-sources the server `EXPLAIN` plan onto `velesdb-core`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5523,7 +5523,7 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-velesdb"
-version = "3.2.0"
+version = "3.2.1"
 dependencies = [
  "dirs",
  "parking_lot",
@@ -6517,7 +6517,7 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "velesdb-cli"
-version = "3.2.0"
+version = "3.2.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -6542,7 +6542,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-core"
-version = "3.2.0"
+version = "3.2.1"
 dependencies = [
  "arc-swap",
  "bytemuck",
@@ -6597,7 +6597,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-migrate"
-version = "3.2.0"
+version = "3.2.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6625,7 +6625,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-mobile"
-version = "3.2.0"
+version = "3.2.1"
 dependencies = [
  "parking_lot",
  "serde_json",
@@ -6639,7 +6639,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-python"
-version = "3.2.0"
+version = "3.2.1"
 dependencies = [
  "numpy",
  "parking_lot",
@@ -6652,7 +6652,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-server"
-version = "3.2.0"
+version = "3.2.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -6685,7 +6685,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-wasm"
-version = "3.2.0"
+version = "3.2.1"
 dependencies = [
  "getrandom 0.3.4",
  "getrandom 0.4.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "3.2.0"
+version = "3.2.1"
 edition = "2021"
 rust-version = "1.89"
 license-file = "LICENSE"
@@ -77,7 +77,7 @@ base64 = "0.22"
 smallvec = { version = "1", features = ["serde"] }
 
 # Internal workspace crates
-velesdb-core = { path = "crates/velesdb-core", version = "3.2.0", default-features = false }
+velesdb-core = { path = "crates/velesdb-core", version = "3.2.1", default-features = false }
 
 [profile.release]
 lto = true

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM rust:1.96-bookworm AS builder
 
 LABEL maintainer="VelesDB Team <contact@wiscale.fr>"
-LABEL version="3.2.0"
+LABEL version="3.2.1"
 
 WORKDIR /app
 
@@ -25,7 +25,7 @@ RUN cargo build --release --bin velesdb-server
 FROM debian:bookworm-slim
 
 LABEL maintainer="VelesDB Team <contact@wiscale.fr>"
-LABEL version="3.2.0"
+LABEL version="3.2.1"
 
 WORKDIR /app
 

--- a/README.md
+++ b/README.md
@@ -507,7 +507,7 @@ Ship AI features without a server. VelesDB embeds directly into Tauri, iOS, and 
 | **Mobile** | [velesdb-mobile](crates/velesdb-mobile) — iOS (Swift) & Android (Kotlin) | [Build instructions](docs/guides/INSTALLATION.md#-mobile-iosandroid) |
 | **Desktop** | [tauri-plugin](crates/tauri-plugin-velesdb) — Tauri v2 AI-powered apps | `cargo add tauri-plugin-velesdb` |
 | **LangChain** | [langchain-velesdb](integrations/langchain) — Official VectorStore | [From source](integrations/langchain/README.md) |
-| **LlamaIndex** | [llamaindex-velesdb](integrations/llamaindex) — Document indexing | [From source](integrations/llamaindex/README.md) |
+| **LlamaIndex** | [llama-index-vector-stores-velesdb](integrations/llamaindex) — Document indexing | [From source](integrations/llamaindex/README.md) |
 | **Haystack** | [haystack-velesdb](integrations/haystack) — Haystack 2.x DocumentStore | [From source](integrations/haystack/README.md) |
 | **Migration** | [velesdb-migrate](crates/velesdb-migrate) — From Qdrant, Pinecone, Supabase | `cargo install velesdb-migrate` |
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,7 +4,7 @@ This roadmap commits to **what we are building**, **why**, and **when**. It is u
 
 It is intentionally narrow. Items not on this roadmap are tracked as `roadmap` issues but **not committed** until they reach a milestone here.
 
-> **Last updated:** 2026-06-12 — covers v3.2.0 (current) → v1.19 horizon.
+> **Last updated:** 2026-06-12 — covers v3.2.1 (current) → v1.19 horizon.
 
 ---
 

--- a/benchmarks/Dockerfile.bench
+++ b/benchmarks/Dockerfile.bench
@@ -6,7 +6,7 @@
 FROM debian:bookworm-slim
 
 LABEL maintainer="VelesDB Team <contact@wiscale.fr>"
-LABEL version="3.2.0"
+LABEL version="3.2.1"
 
 WORKDIR /app
 

--- a/benchmarks/Dockerfile.nightly
+++ b/benchmarks/Dockerfile.nightly
@@ -4,7 +4,7 @@
 FROM rust:slim-bookworm AS builder
 
 LABEL maintainer="VelesDB Team <contact@wiscale.fr>"
-LABEL version="3.2.0"
+LABEL version="3.2.1"
 
 WORKDIR /app
 
@@ -29,7 +29,7 @@ RUN cargo build --release --bin velesdb-server
 FROM debian:bookworm-slim
 
 LABEL maintainer="VelesDB Team <contact@wiscale.fr>"
-LABEL version="3.2.0"
+LABEL version="3.2.1"
 
 WORKDIR /app
 

--- a/benchmarks/Dockerfile.optimized
+++ b/benchmarks/Dockerfile.optimized
@@ -7,7 +7,7 @@
 FROM rust:slim-bookworm AS builder
 
 LABEL maintainer="VelesDB Team <contact@wiscale.fr>"
-LABEL version="3.2.0"
+LABEL version="3.2.1"
 
 WORKDIR /app
 
@@ -49,7 +49,7 @@ RUN cargo build --release --bin velesdb-server \
 FROM debian:bookworm-slim
 
 LABEL maintainer="VelesDB Team <contact@wiscale.fr>"
-LABEL version="3.2.0"
+LABEL version="3.2.1"
 
 WORKDIR /app
 

--- a/crates/tauri-plugin-velesdb/guest-js/package.json
+++ b/crates/tauri-plugin-velesdb/guest-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wiscale/tauri-plugin-velesdb",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "TypeScript bindings for the VelesDB Tauri plugin - Vector search in desktop apps",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/crates/velesdb-python/README.md
+++ b/crates/velesdb-python/README.md
@@ -3,7 +3,7 @@
 [![PyPI](https://img.shields.io/pypi/v/velesdb)](https://pypi.org/project/velesdb/)
 [![Python](https://img.shields.io/pypi/pyversions/velesdb)](https://pypi.org/project/velesdb/)
 [![License](https://img.shields.io/badge/license-VelesDB_Core_1.0-blue)](./LICENSE)
-[![Version](https://img.shields.io/badge/version-3.2.0-blue)](https://github.com/cyberlife-coder/VelesDB/releases)
+[![Version](https://img.shields.io/badge/version-3.2.1-blue)](https://github.com/cyberlife-coder/VelesDB/releases)
 
 Python bindings for [VelesDB](https://github.com/cyberlife-coder/VelesDB) — a high-performance vector database for AI applications. The current published wheel is `velesdb` v2.0.0; `numpy>=1.20` ships as a hard runtime dependency since v1.13.8 so a single `pip install velesdb` is sufficient.
 

--- a/crates/velesdb-python/pyproject.toml
+++ b/crates/velesdb-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "velesdb"
-version = "3.2.0"
+version = "3.2.1"
 description = "VelesDB: The Local Vector Database for Python & AI. Microsecond semantic search, zero network latency."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/crates/velesdb-server/README.md
+++ b/crates/velesdb-server/README.md
@@ -659,7 +659,7 @@ curl http://localhost:8080/health
 Response:
 
 ```json
-{"status": "ok", "version": "3.2.0"}
+{"status": "ok", "version": "3.2.1"}
 ```
 
 ### `GET /ready` -- Readiness Probe
@@ -673,13 +673,13 @@ curl http://localhost:8080/ready
 Response (ready):
 
 ```json
-{"status": "ready", "version": "3.2.0"}
+{"status": "ready", "version": "3.2.1"}
 ```
 
 Response (not ready):
 
 ```json
-{"status": "not_ready", "version": "3.2.0"}
+{"status": "not_ready", "version": "3.2.1"}
 ```
 
 ### Kubernetes Example

--- a/demos/rag-pdf-demo/pyproject.toml
+++ b/demos/rag-pdf-demo/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "velesdb-rag-demo"
-version = "3.2.0"
+version = "3.2.1"
 description = "RAG Demo with PDF ingestion using VelesDB for vector storage"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/demos/rag-pdf-demo/src/__init__.py
+++ b/demos/rag-pdf-demo/src/__init__.py
@@ -1,3 +1,3 @@
 """VelesDB RAG Demo - PDF Question Answering System."""
 
-__version__ = "3.2.0"
+__version__ = "3.2.1"

--- a/demos/rag-pdf-demo/src/main.py
+++ b/demos/rag-pdf-demo/src/main.py
@@ -46,7 +46,7 @@ async def lifespan(app: FastAPI):
 app = FastAPI(
     title="VelesDB RAG Demo",
     description="PDF Question Answering with VelesDB vector search",
-    version="3.2.0",
+    version="3.2.1",
     lifespan=lifespan
 )
 

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -1,6 +1,6 @@
 # VelesDB Performance Benchmarks
 
-*Last updated: June 20, 2026 (VelesDB v3.2.0). Figures are re-validated at each release only when re-measured — each section carries its own measurement date and machine; this stamp tracks the document revision, not a fresh measurement.*
+*Last updated: June 20, 2026 (VelesDB v3.2.1). Figures are re-validated at each release only when re-measured — each section carries its own measurement date and machine; this stamp tracks the document revision, not a fresh measurement.*
 
 ---
 

--- a/docs/VELESQL_SPEC.md
+++ b/docs/VELESQL_SPEC.md
@@ -2,7 +2,7 @@
 
 > SQL-like query language for vector + graph + column-store search in VelesDB.
 
-**Version**: 3.10.0 | **Last Updated**: 2026-06-20 (VelesDB v3.2.0)
+**Version**: 3.10.0 | **Last Updated**: 2026-06-20 (VelesDB v3.2.1)
 
 ---
 

--- a/docs/WHY_VELESDB.md
+++ b/docs/WHY_VELESDB.md
@@ -103,7 +103,7 @@ See [BENCHMARKS.md](./BENCHMARKS.md) for detailed numbers and methodology.
 | iOS / Android | `velesdb-mobile` (UniFFI) | Stable |
 | Tauri Desktop | `tauri-plugin-velesdb` | Stable |
 | LangChain | `langchain-velesdb` | Stable |
-| LlamaIndex | `llamaindex-velesdb` | Stable |
+| LlamaIndex | `llama-index-vector-stores-velesdb` | Stable |
 
 ---
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -96,7 +96,7 @@ Expected response:
 ```json
 {
   "status": "ok",
-  "version": "3.2.0"
+  "version": "3.2.1"
 }
 ```
 

--- a/docs/guides/CLI_REPL.md
+++ b/docs/guides/CLI_REPL.md
@@ -1,6 +1,6 @@
 # 💻 CLI & REPL Reference
 
-*Version 3.2.0 — 2026-06-12*
+*Version 3.2.1 — 2026-06-12*
 
 Complete guide to the VelesDB command-line interface and the interactive REPL.
 
@@ -36,7 +36,7 @@ cargo build --release -p velesdb-cli
 
 ```bash
 velesdb --version
-# velesdb 3.2.0
+# velesdb 3.2.1
 ```
 
 ---
@@ -269,7 +269,7 @@ velesdb> \info
 ┌─────────────────────┬────────────────────┐
 │ Property            │ Value              │
 ├─────────────────────┼────────────────────┤
-│ Version             │ 3.2.0              │
+│ Version             │ 3.2.1              │
 │ Data directory      │ ./data             │
 │ Collections         │ 3                  │
 │ Total vectors       │ 125,000            │
@@ -342,7 +342,7 @@ Session settings are **not persisted** across REPL sessions. To persist them, us
 ```
 $ velesdb repl ./my_db
 
-VelesDB v3.2.0 - Interactive REPL
+VelesDB v3.2.1 - Interactive REPL
 Type \help for help, \quit to exit.
 
 velesdb> \show

--- a/docs/guides/CONFIGURATION.md
+++ b/docs/guides/CONFIGURATION.md
@@ -1,6 +1,6 @@
 # ⚙️ VelesDB Configuration
 
-*Version 3.2.0 — May 2026*
+*Version 3.2.1 — May 2026*
 
 Complete guide for configuring VelesDB via configuration file, environment variables, and runtime parameters.
 
@@ -62,7 +62,7 @@ data_dir = "./data"
 ```toml
 # =============================================================================
 # VelesDB Configuration File
-# Version: 3.2.0
+# Version: 3.2.1
 # =============================================================================
 
 # -----------------------------------------------------------------------------

--- a/docs/guides/GRAPH_PATTERNS.md
+++ b/docs/guides/GRAPH_PATTERNS.md
@@ -1,6 +1,6 @@
 # Graph Patterns Guide
 
-*Version 3.2.0 -- May 2026*
+*Version 3.2.1 -- May 2026*
 
 Practical guide for using VelesQL `MATCH` graph patterns in VelesDB.
 

--- a/docs/guides/INSTALLATION.md
+++ b/docs/guides/INSTALLATION.md
@@ -60,10 +60,10 @@ entry.
 
 ```bash
 # Download
-wget https://github.com/cyberlife-coder/VelesDB/releases/download/v3.2.0/velesdb-3.2.0-amd64.deb
+wget https://github.com/cyberlife-coder/VelesDB/releases/download/v3.2.1/velesdb-3.2.1-amd64.deb
 
 # Install
-sudo dpkg -i velesdb-3.2.0-amd64.deb
+sudo dpkg -i velesdb-3.2.1-amd64.deb
 
 # Verify
 velesdb --version
@@ -160,13 +160,13 @@ GitHub Container Registry, so you don't need to build locally:
 
 ```bash
 # Pull a specific release (recommended for reproducibility)
-docker pull ghcr.io/cyberlife-coder/velesdb:3.2.0
+docker pull ghcr.io/cyberlife-coder/velesdb:3.2.1
 
 # ...or the latest stable release
 docker pull ghcr.io/cyberlife-coder/velesdb:latest
 
 docker run -d --name velesdb -p 8080:8080 -v velesdb_data:/data \
-  ghcr.io/cyberlife-coder/velesdb:3.2.0
+  ghcr.io/cyberlife-coder/velesdb:3.2.1
 ```
 
 ### Build locally

--- a/docs/guides/SEARCH_MODES.md
+++ b/docs/guides/SEARCH_MODES.md
@@ -1,6 +1,6 @@
 # 🎯 Search Modes - Recall Configuration Guide
 
-*Version 3.2.0 -- 2026-06-12*
+*Version 3.2.1 -- 2026-06-12*
 
 Complete guide to configuring the **recall vs latency** trade-off in VelesDB. Covers dense search (HNSW), sparse search (SPLADE/BM42), and hybrid search (dense+sparse with fusion). Includes a comparison with Milvus, OpenSearch, and Qdrant practices.
 

--- a/docs/guides/SERVER_SECURITY.md
+++ b/docs/guides/SERVER_SECURITY.md
@@ -299,7 +299,7 @@ curl http://localhost:8080/health
 ```json
 {
   "status": "ok",
-  "version": "3.2.0"
+  "version": "3.2.1"
 }
 ```
 
@@ -318,7 +318,7 @@ curl http://localhost:8080/ready
 ```json
 {
   "status": "ready",
-  "version": "3.2.0"
+  "version": "3.2.1"
 }
 ```
 
@@ -327,7 +327,7 @@ curl http://localhost:8080/ready
 ```json
 {
   "status": "not_ready",
-  "version": "3.2.0"
+  "version": "3.2.1"
 }
 ```
 

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -11,7 +11,7 @@
       "name": "VelesDB Core License 1.0",
       "url": "https://github.com/cyberlife-coder/VelesDB/blob/main/LICENSE"
     },
-    "version": "3.2.0"
+    "version": "3.2.1"
   },
   "servers": [
     {

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -8,7 +8,7 @@ info:
   license:
     name: VelesDB Core License 1.0
     url: https://github.com/cyberlife-coder/VelesDB/blob/main/LICENSE
-  version: 3.2.0
+  version: 3.2.1
 servers:
 - url: /
   description: Local server

--- a/docs/reference/ARCHITECTURE_DIAGRAMS.md
+++ b/docs/reference/ARCHITECTURE_DIAGRAMS.md
@@ -1,4 +1,4 @@
-# VelesDB Architecture Diagrams — v3.2.0
+# VelesDB Architecture Diagrams — v3.2.1
 
 ## 1. Workspace Dependency Graph
 

--- a/docs/reference/ECOSYSTEM_PARITY.md
+++ b/docs/reference/ECOSYSTEM_PARITY.md
@@ -1,6 +1,6 @@
 # VelesQL Ecosystem Parity Matrix
 
-Last updated: 2026-06-20 (v3.2.0)
+Last updated: 2026-06-20 (v3.2.1)
 
 This matrix tracks runtime contract and feature parity across the VelesDB ecosystem.
 

--- a/docs/reference/VELESQL_CHEATSHEET.md
+++ b/docs/reference/VELESQL_CHEATSHEET.md
@@ -1,7 +1,7 @@
 # VelesQL Cheat Sheet
 
 > **Date:** 2026-06-03
-> **VelesDB version:** 3.2.0
+> **VelesDB version:** 3.2.1
 > See the full specification in [`docs/VELESQL_SPEC.md`](../VELESQL_SPEC.md).
 
 > Every `sql` block below is **parsed** against the real grammar by an automated

--- a/docs/reference/VELESQL_CONFORMANCE_MATRIX.md
+++ b/docs/reference/VELESQL_CONFORMANCE_MATRIX.md
@@ -4,7 +4,7 @@ This document lists every VelesQL feature with its parser and executor status.
 A feature can be **Parsed** (the grammar + AST accept it) without being
 **Executed** (the query engine acts on it at runtime).
 
-> Last updated: 2026-06-20 (v3.10.0 / VelesDB v3.2.0)
+> Last updated: 2026-06-20 (v3.10.0 / VelesDB v3.2.1)
 
 ## Fully Supported (Parsed AND Executed)
 

--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -57,7 +57,7 @@ Check server health status.
 ```json
 {
   "status": "ok",
-  "version": "3.2.0"
+  "version": "3.2.1"
 }
 ```
 

--- a/examples/wasm-browser-demo/README.md
+++ b/examples/wasm-browser-demo/README.md
@@ -22,7 +22,7 @@ cd crates/velesdb-wasm
 wasm-pack build --target web --out-dir ../../examples/wasm-browser-demo/pkg
 
 # Then update index.html to use the local path instead of CDN:
-# Change: import init from 'https://unpkg.com/@wiscale/velesdb-wasm@3.2.0/velesdb_wasm.js'
+# Change: import init from 'https://unpkg.com/@wiscale/velesdb-wasm@3.2.1/velesdb_wasm.js'
 # To:     import init from './pkg/velesdb_wasm.js'
 ```
 
@@ -80,7 +80,7 @@ Typical results on modern hardware:
 ```html
 <script type="module">
   // If published on npm:
-  // import init, { VectorStore } from 'https://unpkg.com/@wiscale/velesdb-wasm@3.2.0/velesdb_wasm.js';
+  // import init, { VectorStore } from 'https://unpkg.com/@wiscale/velesdb-wasm@3.2.1/velesdb_wasm.js';
   // If built locally with wasm-pack:
   import init, { VectorStore } from './pkg/velesdb_wasm.js';
 

--- a/examples/wasm-browser-demo/index.html
+++ b/examples/wasm-browser-demo/index.html
@@ -171,8 +171,8 @@
         // WASM module - tracks @wiscale/velesdb-wasm@<workspace> with CDN fallback.
         // Bumped by scripts/bump-version.ps1 on every release; if you copy this
         // demo, update the version below to match `@wiscale/velesdb-wasm` on npm.
-        const WASM_CDN_PRIMARY = 'https://unpkg.com/@wiscale/velesdb-wasm@3.2.0/velesdb_wasm.js';
-        const WASM_CDN_FALLBACK = 'https://cdn.jsdelivr.net/npm/@wiscale/velesdb-wasm@3.2.0/velesdb_wasm.js';
+        const WASM_CDN_PRIMARY = 'https://unpkg.com/@wiscale/velesdb-wasm@3.2.1/velesdb_wasm.js';
+        const WASM_CDN_FALLBACK = 'https://cdn.jsdelivr.net/npm/@wiscale/velesdb-wasm@3.2.1/velesdb_wasm.js';
         
         let init, VectorStore;
         

--- a/integrations/common/pyproject.toml
+++ b/integrations/common/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "velesdb-common"
-version = "3.2.0"
+version = "3.2.1"
 description = "Shared utilities for VelesDB Python integrations (internal use)"
 readme = "README.md"
 license = {text = "MIT"}

--- a/integrations/haystack/pyproject.toml
+++ b/integrations/haystack/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "haystack-velesdb"
-version = "3.2.0"
+version = "3.2.1"
 description = "Haystack 2.x DocumentStore for VelesDB: The Local AI Memory Database."
 readme = "README.md"
 license = {text = "MIT"}

--- a/integrations/haystack/src/haystack_velesdb/__init__.py
+++ b/integrations/haystack/src/haystack_velesdb/__init__.py
@@ -3,4 +3,4 @@
 from haystack_velesdb.document_store import VelesDBDocumentStore
 
 __all__ = ["VelesDBDocumentStore"]
-__version__ = "3.2.0"
+__version__ = "3.2.1"

--- a/integrations/langchain/pyproject.toml
+++ b/integrations/langchain/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "langchain-velesdb"
-version = "3.2.0"
+version = "3.2.1"
 description = "LangChain VectorStore for VelesDB: The Local AI Memory Database. Microsecond RAG retrieval."
 readme = "README.md"
 license = {text = "MIT"}

--- a/integrations/langchain/src/langchain_velesdb/__init__.py
+++ b/integrations/langchain/src/langchain_velesdb/__init__.py
@@ -53,4 +53,4 @@ if _HAS_MEMORY:
         "VelesDBSemanticMemory",
         "VelesDBProceduralMemory",
     ])
-__version__ = "3.2.0"
+__version__ = "3.2.1"

--- a/integrations/llamaindex/README.md
+++ b/integrations/llamaindex/README.md
@@ -338,7 +338,7 @@ Source: `benchmarks/baseline.json`.
 
 ## Agent Memory (optional)
 
-`llamaindex-velesdb` re-exports three agent-memory wrappers around VelesDB's
+`llama-index-vector-stores-velesdb` re-exports three agent-memory wrappers around VelesDB's
 native memory subsystems. They are imported lazily — if the underlying
 `velesdb` native extension isn't installed, the import becomes a no-op and
 the symbols are exposed as `None`.

--- a/integrations/llamaindex/pyproject.toml
+++ b/integrations/llamaindex/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "llama-index-vector-stores-velesdb"
-version = "3.2.0"
+version = "3.2.1"
 description = "LlamaIndex VectorStore for VelesDB: The Local AI Memory Database. Microsecond RAG retrieval."
 readme = "README.md"
 license = "MIT"

--- a/integrations/llamaindex/src/llamaindex_velesdb/__init__.py
+++ b/integrations/llamaindex/src/llamaindex_velesdb/__init__.py
@@ -57,4 +57,4 @@ if _HAS_MEMORY:
         "VelesDBChatMemory",
         "VelesDBProceduralMemory",
     ])
-__version__ = "3.2.0"
+__version__ = "3.2.1"

--- a/integrations/llamaindex/tests/test_e2e_advanced.py
+++ b/integrations/llamaindex/tests/test_e2e_advanced.py
@@ -41,7 +41,7 @@ except ImportError:
 
 pytestmark = pytest.mark.skipif(
     not VELESDB_LLAMAINDEX_AVAILABLE,
-    reason="llamaindex-velesdb not installed",
+    reason="llama-index-vector-stores-velesdb not installed",
 )
 
 _DIM = 64

--- a/scripts/dx-timing/scenario_rust.sh
+++ b/scripts/dx-timing/scenario_rust.sh
@@ -41,7 +41,7 @@ RS
 # Pin to the latest released version on crates.io. Bump alongside each
 # workspace release; the timing measurement is meant to track the path a
 # fresh dev hits when they `cargo add velesdb-core` today.
-cargo add --quiet velesdb-core@3.2.0
+cargo add --quiet velesdb-core@3.2.1
 cargo add --quiet serde_json@1
 cargo run --quiet --release
 

--- a/scripts/dx-timing/scenario_server.sh
+++ b/scripts/dx-timing/scenario_server.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 
 START=$(date +%s.%N)
 
-cargo install --quiet --locked velesdb-server@3.2.0
+cargo install --quiet --locked velesdb-server@3.2.1
 
 DATA_DIR=$(mktemp -d -t velesdb_dx_server_XXXX)
 trap 'rm -rf "$DATA_DIR"' EXIT

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -2,7 +2,7 @@
 
 Official TypeScript SDK for [VelesDB](https://github.com/cyberlife-coder/VelesDB) -- the local-first vector database for AI and RAG. Sub-millisecond semantic search in Browser and Node.js.
 
-**v3.2.0** | Node.js >= 18 | Browser (WASM) | VelesDB Core License 1.0
+**v3.2.1** | Node.js >= 18 | Browser (WASM) | VelesDB Core License 1.0
 
 ## What's New (unreleased)
 

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.2.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@wiscale/velesdb-wasm": "^2.0.0"
+        "@wiscale/velesdb-wasm": "^3.0.0"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -1873,9 +1873,9 @@
       }
     },
     "node_modules/@wiscale/velesdb-wasm": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@wiscale/velesdb-wasm/-/velesdb-wasm-2.0.0.tgz",
-      "integrity": "sha512-SFObr98azIRzwoZzj5t5tFVh9MDeZDpP6NIP9wf9UDkaDR1EWatepYnPY4spEQP+KUxzSt8+CsgQh3ytRoPqLQ==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@wiscale/velesdb-wasm/-/velesdb-wasm-3.2.0.tgz",
+      "integrity": "sha512-LxX4m2IfB+DmfWq3jJkqwTXQAQwTb2yhrJns1e/Qhs2muX2auKZW7q3bsZRQ+enPuf/q4GX0fY78ZLgWZ/0fnw==",
       "license": "SEE LICENSE IN LICENSE"
     },
     "node_modules/acorn": {

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wiscale/velesdb-sdk",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wiscale/velesdb-sdk",
-      "version": "3.2.0",
+      "version": "3.2.1",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@wiscale/velesdb-wasm": "^3.0.0"

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -69,7 +69,7 @@
     "vitest": "^4.0.16"
   },
   "dependencies": {
-    "@wiscale/velesdb-wasm": "^2.0.0"
+    "@wiscale/velesdb-wasm": "^3.0.0"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wiscale/velesdb-sdk",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "VelesDB TypeScript SDK: The Local Vector Database for AI & RAG. Microsecond semantic search in Browser & Node.js.",
   "main": "dist/index.js",
   "module": "dist/index.mjs",


### PR DESCRIPTION
**Patch release 3.2.1** — ships the two fixes that landed on `develop` after 3.2.0. **No engine/API change** (`velesdb-core` + REST/OpenAPI are functionally identical to 3.2.0).

### Fixed
- **#1178** — `@wiscale/velesdb-sdk` now depends on `@wiscale/velesdb-wasm` `^3.0.0` (was `^2.0.0`). 3.x SDK consumers were pulling the stale 2.x WASM runtime; the 2→3 WASM API is purely additive (verified: `.d.ts` diff additive-only, SDK 836 tests pass against wasm 3.x), so this is transparent.
- **#1177** — docs reference the correct LlamaIndex PyPI name `llama-index-vector-stores-velesdb` (the previously-documented `llamaindex-velesdb` 404s).

### Release prep
- `bump_version.py 3.2.1` (60 locations) + `cargo update -w` + openapi regen → 3.2.1 + SDK lockfile sync + `CHANGELOG [3.2.1]`; `check-version-sync.py`: **all versions match**.

SemVer: PATCH — only a doc-name fix + an SDK dependency-range correction; no public API, behavior, or on-disk format change.