### PR TITLE
docs: fix demo/example/doc veracity issues (post-release audit)

### DIFF
--- a/demos/rag-pdf-demo/README.md
+++ b/demos/rag-pdf-demo/README.md
@@ -230,7 +230,7 @@ Benchmarks measured on Windows 11, Python 3.10, VelesDB 1.11.1 (500 iterations â
 | Qdrant | ~10-50ms | Self-hosted |
 | FAISS | ~1ms | In-memory only |
 
-> **Note**: Run `python benchmark_latency.py` to measure performance on your hardware.
+> **Note**: `benchmark_latency.py` is a legacy REST-era client that targets a running `velesdb-server` on `localhost:8080`; this demo now runs VelesDB embedded (in-process, no server), so the script only works if you separately start a `velesdb-server`.
 
 ## ðŸ§ª Testing
 

--- a/demos/rag-pdf-demo/src/velesdb_client.py
+++ b/demos/rag-pdf-demo/src/velesdb_client.py
@@ -85,7 +85,7 @@ class VelesDBClient:
         Returns:
             Result dict with ``{"deleted": name}``.
         """
-        self._db.drop_collection(name)
+        self._db.delete_collection(name)
         return {"deleted": name}
 
     # ------------------------------------------------------------------

--- a/demos/rag-pdf-demo/tests/test_rag_engine.py
+++ b/demos/rag-pdf-demo/tests/test_rag_engine.py
@@ -1,50 +1,67 @@
-"""Tests for RAG engine module (TDD - tests first)."""
+"""Tests for the RAG engine module.
+
+The engine and its VelesDB client are fully synchronous (the demo uses the
+embedded ``velesdb`` Python bindings, not a REST server), so every test below
+mocks the collaborators with plain ``MagicMock`` and asserts the real
+synchronous return shapes.
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import pytest
-from unittest.mock import AsyncMock, MagicMock, patch
-from pathlib import Path
 
 
 class TestRAGEngine:
     """Test suite for RAG orchestration."""
 
-    @pytest.mark.asyncio
-    async def test_ingest_document(self, sample_pdf_path: Path):
-        """Test document ingestion pipeline."""
+    def test_ingest_document(self, sample_pdf_path: Path):
+        """Ingesting a real PDF embeds its chunks and upserts them to VelesDB."""
         from src.rag_engine import RAGEngine
-        
+
         with patch("src.rag_engine.VelesDBClient") as mock_velesdb, \
              patch("src.rag_engine.EmbeddingService") as mock_embeddings:
-            
-            # Setup mocks - all async methods need AsyncMock
+
+            # The client is synchronous: methods return values directly.
             mock_velesdb_instance = MagicMock()
-            mock_velesdb_instance.collection_exists = AsyncMock(return_value=True)
-            mock_velesdb_instance.create_collection = AsyncMock()
-            mock_velesdb_instance.upsert_points = AsyncMock(return_value={"inserted": 5})
+            # Collection already exists -> create_collection is skipped.
+            mock_velesdb_instance.collection_exists.return_value = True
+            # Empty collection -> _load_existing_documents() returns early.
+            mock_velesdb_instance.get_collection_info.return_value = {
+                "point_count": 0
+            }
+            mock_velesdb_instance.upsert_points.return_value = {"upserted": 5}
             mock_velesdb.return_value = mock_velesdb_instance
-            
+
             mock_embeddings_instance = MagicMock()
-            mock_embeddings_instance.embed_batch.return_value = [[0.1] * 384] * 5
+            # Plenty of embeddings; zip() truncates to the real chunk count.
+            mock_embeddings_instance.embed_batch.return_value = [[0.1] * 384] * 16
             mock_embeddings_instance.dimension = 384
             mock_embeddings.return_value = mock_embeddings_instance
-            
-            engine = RAGEngine()
-            result = await engine.ingest_document(sample_pdf_path)
-            
-            assert result["success"] is True
-            assert result["chunks_created"] > 0
 
-    @pytest.mark.asyncio
-    async def test_search_documents(self):
-        """Test document search."""
+            engine = RAGEngine()
+            result = engine.ingest_document(sample_pdf_path)
+
+            assert result["success"] is True
+            assert result["document_name"] == sample_pdf_path.name
+            assert result["chunks_created"] > 0
+            assert result["pages_processed"] == 2
+            # Existing collection -> no create, but points were upserted.
+            mock_velesdb_instance.create_collection.assert_not_called()
+            mock_velesdb_instance.upsert_points.assert_called_once()
+            # The document is now tracked in the local registry.
+            assert sample_pdf_path.name in engine._documents
+
+    def test_search_documents(self):
+        """Search embeds the query and reformats the client's raw results."""
         from src.rag_engine import RAGEngine
-        
+
         with patch("src.rag_engine.VelesDBClient") as mock_velesdb, \
              patch("src.rag_engine.EmbeddingService") as mock_embeddings:
-            
-            # Setup mocks
+
             mock_velesdb_instance = MagicMock()
-            mock_velesdb_instance.search = AsyncMock(return_value={
+            # Client.search returns {"results": [{"id", "score", "payload"}]}.
+            mock_velesdb_instance.search.return_value = {
                 "results": [
                     {
                         "id": 1,
@@ -52,29 +69,70 @@ class TestRAGEngine:
                         "payload": {
                             "text": "Machine learning is AI",
                             "document_name": "test.pdf",
-                            "page_number": 1
-                        }
+                            "page_number": 1,
+                        },
                     }
                 ]
-            })
+            }
             mock_velesdb.return_value = mock_velesdb_instance
-            
+
             mock_embeddings_instance = MagicMock()
             mock_embeddings_instance.embed.return_value = [0.1] * 384
             mock_embeddings.return_value = mock_embeddings_instance
-            
-            engine = RAGEngine()
-            results = await engine.search("What is machine learning?", top_k=5)
-            
-            assert len(results["results"]) > 0
-            assert abs(results["results"][0]["score"] - 0.95) < 1e-6
-            assert "Machine learning" in results["results"][0]["text"]
 
-    def test_get_documents_list(self):
-        """Test listing indexed documents."""
+            engine = RAGEngine()
+            results = engine.search("What is machine learning?", top_k=5)
+
+            # Engine returns formatted results plus timing metrics.
+            assert len(results["results"]) == 1
+            hit = results["results"][0]
+            assert abs(hit["score"] - 0.95) < 1e-6
+            assert hit["text"] == "Machine learning is AI"
+            assert hit["document_name"] == "test.pdf"
+            assert hit["page_number"] == 1
+            assert "embedding_time_ms" in results
+            assert "search_time_ms" in results
+            # No document filter -> client.search called with filter_=None.
+            _, kwargs = mock_velesdb_instance.search.call_args
+            assert kwargs["filter_"] is None
+            assert kwargs["top_k"] == 5
+
+    def test_search_documents_with_filter(self):
+        """A document_filter is translated into an eq metadata filter."""
         from src.rag_engine import RAGEngine
 
-        with patch("src.rag_engine.VelesDBClient"), patch("src.rag_engine.EmbeddingService"):
+        with patch("src.rag_engine.VelesDBClient") as mock_velesdb, \
+             patch("src.rag_engine.EmbeddingService") as mock_embeddings:
+
+            mock_velesdb_instance = MagicMock()
+            mock_velesdb_instance.search.return_value = {"results": []}
+            mock_velesdb.return_value = mock_velesdb_instance
+
+            mock_embeddings_instance = MagicMock()
+            mock_embeddings_instance.embed.return_value = [0.1] * 384
+            mock_embeddings.return_value = mock_embeddings_instance
+
+            engine = RAGEngine()
+            results = engine.search(
+                "query", top_k=3, document_filter="report.pdf"
+            )
+
+            assert results["results"] == []
+            _, kwargs = mock_velesdb_instance.search.call_args
+            assert kwargs["filter_"] == {
+                "condition": {
+                    "type": "eq",
+                    "field": "document_name",
+                    "value": "report.pdf",
+                }
+            }
+
+    def test_get_documents_list(self):
+        """list_documents returns the values of the local registry."""
+        from src.rag_engine import RAGEngine
+
+        with patch("src.rag_engine.VelesDBClient"), \
+             patch("src.rag_engine.EmbeddingService"):
             engine = RAGEngine()
             # empty store
             assert engine.list_documents() == []
@@ -91,89 +149,82 @@ class TestRAGEngine:
             assert docs[0]["name"] == "test.pdf"
             assert docs[0]["chunks"] == 3
 
-    @pytest.mark.asyncio
-    async def test_delete_document(self):
-        """Test document deletion - should delete all chunks from VelesDB."""
+    def test_delete_document(self):
+        """Deleting a document deletes each tracked chunk via delete_point."""
         from src.rag_engine import RAGEngine
-        
+
         with patch("src.rag_engine.VelesDBClient") as mock_velesdb, \
              patch("src.rag_engine.EmbeddingService") as mock_embeddings:
-            
-            # Setup mocks
+
             mock_velesdb_instance = MagicMock()
-            mock_velesdb_instance.collection_exists = AsyncMock(return_value=True)
-            mock_velesdb_instance.get_collection_info = AsyncMock(return_value={"point_count": 0})
-            mock_velesdb_instance.search = AsyncMock(return_value={"results": []})
-            # delete_point should be called for each chunk
-            mock_velesdb_instance.delete_point = AsyncMock(return_value={"deleted": True})
+            # delete_point is called once per chunk id.
+            mock_velesdb_instance.delete_point.return_value = {"deleted": 1}
             mock_velesdb.return_value = mock_velesdb_instance
-            
+
             mock_embeddings_instance = MagicMock()
             mock_embeddings_instance.dimension = 384
             mock_embeddings.return_value = mock_embeddings_instance
-            
+
             engine = RAGEngine()
-            # Manually add a document to the registry with chunk IDs
+            # Seed the registry with a document and its chunk ids.
             engine._documents["test.pdf"] = {
                 "name": "test.pdf",
                 "pages": 1,
                 "chunks": 3,
-                "chunk_ids": [123, 456, 789]  # Track chunk IDs for deletion
+                "chunk_ids": [123, 456, 789],
             }
-            
-            result = await engine.delete_document("test.pdf")
-            
-            # Should have deleted 3 chunks
+
+            result = engine.delete_document("test.pdf")
+
+            # All three chunks deleted, one delete_point call each.
             assert result["deleted"] == 3
-            # delete_point should have been called 3 times
             assert mock_velesdb_instance.delete_point.call_count == 3
-            # Document should be removed from registry
+            assert result["message"] == "Deleted 3/3 chunks"
+            assert "errors" not in result
+            # Document removed from the registry.
             assert "test.pdf" not in engine._documents
 
-    @pytest.mark.asyncio
-    async def test_delete_nonexistent_document(self):
-        """Test deleting a document that doesn't exist."""
+    def test_delete_nonexistent_document(self):
+        """Deleting an unknown document is a no-op returning 0 deleted."""
         from src.rag_engine import RAGEngine
-        
+
         with patch("src.rag_engine.VelesDBClient") as mock_velesdb, \
              patch("src.rag_engine.EmbeddingService") as mock_embeddings:
-            
+
             mock_velesdb_instance = MagicMock()
-            mock_velesdb_instance.collection_exists = AsyncMock(return_value=True)
-            mock_velesdb_instance.get_collection_info = AsyncMock(return_value={"point_count": 0})
-            mock_velesdb_instance.search = AsyncMock(return_value={"results": []})
             mock_velesdb.return_value = mock_velesdb_instance
-            
+
             mock_embeddings_instance = MagicMock()
             mock_embeddings_instance.dimension = 384
             mock_embeddings.return_value = mock_embeddings_instance
-            
+
             engine = RAGEngine()
-            result = await engine.delete_document("nonexistent.pdf")
-            
-            # Should return 0 deleted
+            result = engine.delete_document("nonexistent.pdf")
+
+            # Unknown document -> 0 deleted, no client call.
             assert result["deleted"] == 0
+            assert result["message"] == "Document not found"
+            mock_velesdb_instance.delete_point.assert_not_called()
 
 
 class TestRAGEngineIntegration:
-    """Integration tests (require VelesDB server)."""
+    """Integration tests (require a populated VelesDB instance)."""
 
     @pytest.mark.skip(reason="Requires running VelesDB server")
-    @pytest.mark.asyncio
-    async def test_full_rag_pipeline(self, sample_pdf_path: Path):
+    def test_full_rag_pipeline(self, sample_pdf_path: Path):
         """Test complete RAG pipeline with real VelesDB."""
         from src.rag_engine import RAGEngine
-        
+
         engine = RAGEngine()
-        
+
         # Ingest
-        ingest_result = await engine.ingest_document(sample_pdf_path)
+        ingest_result = engine.ingest_document(sample_pdf_path)
         assert ingest_result["success"] is True
-        
+
         # Search
-        search_results = await engine.search("What is machine learning?")
-        assert len(search_results) > 0
-        
+        search_results = engine.search("What is machine learning?")
+        assert len(search_results["results"]) > 0
+
         # Delete
-        delete_result = await engine.delete_document(sample_pdf_path.name)
+        delete_result = engine.delete_document(sample_pdf_path.name)
         assert delete_result["deleted"] > 0

--- a/docs/guides/INSTALLATION.md
+++ b/docs/guides/INSTALLATION.md
@@ -136,7 +136,7 @@ results = collection.search_request(velesdb.SearchOptions(vector=query_vector, t
 ```toml
 # Cargo.toml
 [dependencies]
-velesdb-core = "1.14"
+velesdb-core = "3.2"
 ```
 
 ### As CLI Tools
@@ -421,7 +421,7 @@ docker run -v velesdb_data:/data velesdb
 
 ## 📚 Next Steps
 
-- **[Quick Start](../README.md#-your-first-vector-search)** - Your first vector search
+- **[Quick Start](../README.md#getting-started-in-60-seconds)** - Your first vector search
 - **[VelesQL Guide](../VELESQL_SPEC.md)** - SQL-like query language
 - **[API Reference](../reference/api-reference.md)** - REST API documentation
 - **[Benchmarks](../BENCHMARKS.md)** - Performance metrics

--- a/docs/guides/tutorials/MINI_RECOMMENDER.md
+++ b/docs/guides/tutorials/MINI_RECOMMENDER.md
@@ -37,7 +37,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-velesdb-core = "1.14"
+velesdb-core = "3.2"
 serde_json = "1.0"
 tempfile = "3.10"
 ```

--- a/docs/reference/NATIVE_HNSW.md
+++ b/docs/reference/NATIVE_HNSW.md
@@ -22,7 +22,7 @@ No feature flags needed. Native HNSW is the only implementation:
 
 ```toml
 [dependencies]
-velesdb-core = "1.14"
+velesdb-core = "3.2"
 ```
 
 ## API

--- a/examples/README.md
+++ b/examples/README.md
@@ -88,7 +88,7 @@ See [rust/README.md](./rust/README.md) for expected output.
 VelesDB as a single-engine hybrid dense+sparse VectorStore for LangChain:
 
 ```bash
-pip install velesdb langchain-core
+pip install velesdb langchain-velesdb langchain-core
 cd examples/langchain
 python hybrid_search.py
 ```
@@ -100,7 +100,7 @@ See [langchain/README.md](./langchain/README.md) for details.
 VelesDB as a LlamaIndex VectorStore with Product Quantization support:
 
 ```bash
-pip install velesdb llama-index-core
+pip install velesdb llama-index-vector-stores-velesdb llama-index-core
 cd examples/llamaindex
 python hybrid_search.py
 ```
@@ -232,4 +232,4 @@ GROUP BY category
 
 ## License
 
-MIT License
+Example code is provided under the MIT License; the VelesDB engine itself is under the VelesDB Core License 1.0.

--- a/examples/mini_recommender/README.md
+++ b/examples/mini_recommender/README.md
@@ -32,14 +32,14 @@ cargo run
 ✅ Ingested 8 products
 
 🔍 Products similar to ID 101:
-  - Fitness Tracker (score: 0.998) - $59.99
-  - Smart Watch (score: 0.995) - $199.99
-  - Bluetooth Speaker (score: 0.993) - $49.99
+  - Bluetooth Speaker (score: 0.999) - $49.99
+  - Running Shoes X1 (score: 0.997) - $129.99
+  - Yoga Mat Premium (score: 0.993) - $39.99
 
 🎯 Recommendations in 'electronics' under $100.00:
-  - Wireless Headphones Pro (score: 0.969) - $79.99
-  - Fitness Tracker (score: 0.967) - $59.99
-  - Bluetooth Speaker (score: 0.962) - $49.99
+  - Wireless Headphones Pro (score: 0.999) - $79.99
+  - Bluetooth Speaker (score: 0.997) - $49.99
+  - Fitness Tracker (score: 0.962) - $59.99
 
 📝 VelesQL Query Parsing:
   ✅ Similarity search: parses correctly

--- a/examples/node-express-rag/package-lock.json
+++ b/examples/node-express-rag/package-lock.json
@@ -8,7 +8,7 @@
       "name": "node-express-rag",
       "version": "0.1.0",
       "dependencies": {
-        "@wiscale/velesdb-sdk": "2.0.0",
+        "@wiscale/velesdb-sdk": "^3.2.1",
         "express": "^5.2.1",
         "zod": "^3.23.8"
       },
@@ -563,22 +563,22 @@
       }
     },
     "node_modules/@wiscale/velesdb-sdk": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@wiscale/velesdb-sdk/-/velesdb-sdk-2.0.0.tgz",
-      "integrity": "sha512-kg4jRIOdnuK/lRnYQolcHeMzlhqXurkXHo9/L1KWISHW9idexEKVgSfQ+JLIkj92xhLpuEZG690Akn4goA/TBw==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@wiscale/velesdb-sdk/-/velesdb-sdk-3.2.1.tgz",
+      "integrity": "sha512-IAACzyUh3JrA8cUvWM+jIughIpILzVtFQYPThlCpcO67HnYKFbTGO3Mxff4V1WOQtAUV/nS8ekx0iiShI8Q9LA==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@wiscale/velesdb-wasm": "^1.4.1"
+        "@wiscale/velesdb-wasm": "^3.0.0"
       },
       "engines": {
         "node": ">=18.0.0"
       }
     },
     "node_modules/@wiscale/velesdb-wasm": {
-      "version": "1.14.4",
-      "resolved": "https://registry.npmjs.org/@wiscale/velesdb-wasm/-/velesdb-wasm-1.14.4.tgz",
-      "integrity": "sha512-ZhCBcRp08366E05zTk4Q7U7WHc/JhssjwgidJAplonrMtqu/cPMlhsEzf23/UYNK9hvvBofyFF72/vQ1UN8xHw==",
-      "license": "MIT"
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@wiscale/velesdb-wasm/-/velesdb-wasm-3.2.1.tgz",
+      "integrity": "sha512-xJSkPHszopJOwPyexmc8/F53xZc3xqq6sZBzPv9HO+UmfpfDOj5YRFv/QPJJhyvJWL47PYTKhZ42i0QIEgwFAQ==",
+      "license": "SEE LICENSE IN LICENSE"
     },
     "node_modules/accepts": {
       "version": "2.0.0",

--- a/examples/node-express-rag/package.json
+++ b/examples/node-express-rag/package.json
@@ -12,7 +12,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@wiscale/velesdb-sdk": "2.0.0",
+    "@wiscale/velesdb-sdk": "^3.2.1",
     "express": "^5.2.1",
     "zod": "^3.23.8"
   },

--- a/examples/react-wasm-search/package-lock.json
+++ b/examples/react-wasm-search/package-lock.json
@@ -8,7 +8,7 @@
       "name": "react-wasm-search",
       "version": "0.1.0",
       "dependencies": {
-        "@wiscale/velesdb-wasm": "2.0.0",
+        "@wiscale/velesdb-wasm": "^3.2.1",
         "react": "^19.2.7",
         "react-dom": "^19.2.7"
       },
@@ -778,9 +778,9 @@
       }
     },
     "node_modules/@wiscale/velesdb-wasm": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@wiscale/velesdb-wasm/-/velesdb-wasm-2.0.0.tgz",
-      "integrity": "sha512-SFObr98azIRzwoZzj5t5tFVh9MDeZDpP6NIP9wf9UDkaDR1EWatepYnPY4spEQP+KUxzSt8+CsgQh3ytRoPqLQ==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@wiscale/velesdb-wasm/-/velesdb-wasm-3.2.1.tgz",
+      "integrity": "sha512-xJSkPHszopJOwPyexmc8/F53xZc3xqq6sZBzPv9HO+UmfpfDOj5YRFv/QPJJhyvJWL47PYTKhZ42i0QIEgwFAQ==",
       "license": "SEE LICENSE IN LICENSE"
     },
     "node_modules/baseline-browser-mapping": {

--- a/examples/react-wasm-search/package.json
+++ b/examples/react-wasm-search/package.json
@@ -10,7 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@wiscale/velesdb-wasm": "2.0.0",
+    "@wiscale/velesdb-wasm": "^3.2.1",
     "react": "^19.2.7",
     "react-dom": "^19.2.7"
   },

--- a/examples/rust/README.md
+++ b/examples/rust/README.md
@@ -32,38 +32,38 @@ cargo run --bin multimodel_search
 Inserted 5 documents
 
 --- Example 1: Basic Vector Search ---
-  ID: 1, Score: 0.9987, Title: Introduction to Rust
-  ID: 3, Score: 0.9940, Title: Graph Algorithms in Practice
-  ID: 2, Score: 0.9847, Title: Vector Databases Explained
+  ID: 1, Score: 0.1499, Title: Introduction to Rust
+  ID: 5, Score: 0.0867, Title: Building Search Engines
+  ID: 4, Score: 0.0676, Title: Machine Learning with Rust
 
 --- Example 2: VelesQL with Similarity ---
   Found 2 results with category='programming'
-    ID: 1, Score: 0.9987
-    ID: 4, Score: 0.9725
+    ID: 1, Score: 0.1499
+    ID: 4, Score: 0.0676
 
 --- Example 3: ORDER BY Similarity ---
   Results ordered by similarity:
-    ID: 1, Score: 0.9987
-    ID: 3, Score: 0.9940
-    ID: 2, Score: 0.9847
-    ID: 4, Score: 0.9725
-    ID: 5, Score: 0.9431
+    ID: 1, Score: 0.1499
+    ID: 5, Score: 0.0867
+    ID: 4, Score: 0.0676
 
 --- Example 4: Hybrid Search ---
   Hybrid search results (vector + text 'rust'):
-    ID: 1, Score: 0.xxxx, Title: Introduction to Rust
-    ID: 4, Score: 0.xxxx, Title: Machine Learning with Rust
-    ...
+    ID: 1, Score: 0.0167, Title: Introduction to Rust
+    ID: 4, Score: 0.0162, Title: Machine Learning with Rust
+    ID: 5, Score: 0.0115, Title: Building Search Engines
+    ID: 2, Score: 0.0111, Title: Vector Databases Explained
+    ID: 3, Score: 0.0109, Title: Graph Algorithms in Practice
 
 --- Example 5: Text Search ---
   Text search results for 'programming':
-    ID: 1, Score: 0.xxxx, Title: Introduction to Rust
-    ID: 4, Score: 0.xxxx, Title: Machine Learning with Rust
+    ID: 1, Score: 1.2321, Title: Introduction to Rust
+    ID: 4, Score: 0.8337, Title: Machine Learning with Rust
 
 === Example Complete ===
 ```
 
-Exact scores will vary by platform.
+The embeddings are generated from fixed seeds, so the result order and IDs are deterministic; the exact score digits may differ by a small amount across platforms.
 
 ## VelesDB Features Demonstrated
 

--- a/examples/tutorials/image_search_hamming_clip.py
+++ b/examples/tutorials/image_search_hamming_clip.py
@@ -16,7 +16,7 @@ Companion article:
     GitHub:    https://github.com/cyberlife-coder/VelesDB
     Docs:      https://velesdb.com/en/
 
-VelesDB is source-available under the Elastic License 2.0.
+VelesDB is source-available under the VelesDB Core License 1.0.
 GitHub stars welcome: https://github.com/cyberlife-coder/VelesDB
 
 Author: Julien Lange (WiScale France)

--- a/examples/tutorials/velesql_tutorial_complete.py
+++ b/examples/tutorials/velesql_tutorial_complete.py
@@ -10,7 +10,7 @@ GitHub:  https://github.com/cyberlife-coder/VelesDB
 Docs:    https://velesdb.com/en/
 
 Requirements:
-    pip install velesdb==1.11.1 sentence-transformers
+    pip install "velesdb>=3.2,<4" sentence-transformers
 
 This script contains every code example from the article.
 Run it end-to-end to reproduce all results.

--- a/integrations/llamaindex/README.md
+++ b/integrations/llamaindex/README.md
@@ -212,12 +212,12 @@ results = vector_store.query_with_ef(
 
 #### `query_ids(query_embedding, top_k)`
 
-Search returning only node IDs and scores — no payloads transferred.
+Search returning only node IDs — no payloads transferred.
 Faster than `query()` when only IDs are needed (e.g., for post-processing pipelines).
 
 ```python
-hits = vector_store.query_ids(query_embedding=embedding, top_k=50)
-# [{"id": "abc", "score": 0.92}, ...]
+ids = vector_store.query_ids(query_embedding=embedding, top_k=50)
+# ["abc", "def", ...]  -- flat list of node-id strings, ordered by descending similarity
 ```
 
 ### Hybrid Search (Vector + BM25)


### PR DESCRIPTION
A multi-agent **consumer-verification audit** (real venv/cargo/npm installs + builds + runs against the published 3.2.x artifacts) found demos/docs that don't match reality. Fixes below; each was verified by actually running the affected demo.

### Runtime-breaking (a user hits these)
- **rag-pdf-demo**: `VelesDBClient.delete_collection()` called the nonexistent `drop_collection()` → `AttributeError`. Fixed to `delete_collection()`.
- **rag-pdf-demo test suite**: written TDD-first as **async**, but the engine is **synchronous** (embedded, not REST) → `await`-ing sync methods raised `TypeError`. Rewrote `tests/test_rag_engine.py` to sync mocks aligned with the real engine → **18 passed / 1 skipped** (verified with `-p no:asyncio`; no `pytest-asyncio` needed). No `src/` change.
- **examples/README.md**: integration install lines omitted the connector packages → `ModuleNotFoundError`. Added `langchain-velesdb` / `llama-index-vector-stores-velesdb`.

### Stale / wrong (misleads users)
- `docs/guides/INSTALLATION.md`, `MINI_RECOMMENDER.md`, `NATIVE_HNSW.md`: `velesdb-core = "1.14"` (two majors stale) → `"3.2"`; fixed a dead README anchor.
- `examples/rust/README.md` + `examples/mini_recommender/README.md`: replaced **fabricated/placeholder** "Expected Output" blocks (`0.9987`, `0.xxxx`, `...`, wrong product identities) with the **real re-run deterministic output**.
- `examples/node-express-rag` + `examples/react-wasm-search`: bumped `@wiscale/velesdb-sdk` / `velesdb-wasm` from the stale `2.0.0` to `^3.2.1` (lockfiles refreshed; `tsc --noEmit` still green).
- `integrations/llamaindex/README.md`: `query_ids` returns a **flat list of id strings**, not `[{id,score}]` (would `TypeError` if followed). Doc corrected against `search_ops.py`.
- `velesql_tutorial_complete.py`: stale `velesdb==1.11.1` install pin → `>=3.2,<4`.
- `image_search_hamming_clip.py`: license header → **VelesDB Core License 1.0**.
- `examples/README.md`: clarified example code is MIT while the engine is VelesDB Core License 1.0 (each example subdir ships an MIT `LICENSE`).

### Verified OK (no change needed)
All Python example scripts (11+), all 4 Rust examples, the 3 integration stores, and node-express-rag ran/built against the real 3.2.x artifacts. wasm-browser-demo CDN pins self-resolved once wasm 3.2.1 published.

Doc/demo-only — no engine/API/version-string change.