### PR TITLE
fix: crud delete error propagation, capacity hints, migrate logging, fmt

### DIFF
--- a/crates/velesdb-core/src/collection/core/crud.rs
+++ b/crates/velesdb-core/src/collection/core/crud.rs
@@ -383,7 +383,8 @@ impl Collection {
         quant_done: bool,
     ) -> Result<Vec<(u64, BTreeMap<String, crate::index::sparse::SparseVector>)>> {
         let mut sparse_batch = Vec::new();
-        let mut seen_payloads: HashMap<u64, Option<&serde_json::Value>> = HashMap::with_capacity(points.len());
+        let mut seen_payloads: HashMap<u64, Option<&serde_json::Value>> =
+            HashMap::with_capacity(points.len());
         let skip_bm25 = self.text_index.is_empty() && !points.iter().any(|p| p.payload.is_some());
         let needs_label_updates = Self::needs_label_updates(points, old_payloads);
         let mut label_updates = Self::alloc_label_buffer(needs_label_updates, points.len());

--- a/crates/velesdb-core/src/collection/core/crud.rs
+++ b/crates/velesdb-core/src/collection/core/crud.rs
@@ -258,7 +258,7 @@ impl Collection {
         // Delete IDs whose final occurrence has payload=None
         for (i, p) in points.iter().enumerate() {
             if dedup_map.get(&p.id) == Some(&i) && p.payload.is_none() {
-                let _ = storage.delete(p.id);
+                storage.delete(p.id)?;
             }
         }
         Ok(())
@@ -478,7 +478,7 @@ impl Collection {
             if let Some(payload) = &point.payload {
                 payload_storage.store(point.id, payload)?;
             } else {
-                let _ = payload_storage.delete(point.id);
+                payload_storage.delete(point.id)?;
             }
             self.update_text_index(point)?;
             self.update_secondary_indexes_on_upsert(

--- a/crates/velesdb-core/src/collection/core/crud.rs
+++ b/crates/velesdb-core/src/collection/core/crud.rs
@@ -209,7 +209,7 @@ impl Collection {
         points: &[Point],
         storage: &LogPayloadStorage,
     ) -> Vec<Option<serde_json::Value>> {
-        let mut seen = std::collections::HashSet::new();
+        let mut seen = std::collections::HashSet::with_capacity(points.len());
         points
             .iter()
             .map(|p| {
@@ -383,7 +383,7 @@ impl Collection {
         quant_done: bool,
     ) -> Result<Vec<(u64, BTreeMap<String, crate::index::sparse::SparseVector>)>> {
         let mut sparse_batch = Vec::new();
-        let mut seen_payloads: HashMap<u64, Option<&serde_json::Value>> = HashMap::new();
+        let mut seen_payloads: HashMap<u64, Option<&serde_json::Value>> = HashMap::with_capacity(points.len());
         let skip_bm25 = self.text_index.is_empty() && !points.iter().any(|p| p.payload.is_some());
         let needs_label_updates = Self::needs_label_updates(points, old_payloads);
         let mut label_updates = Self::alloc_label_buffer(needs_label_updates, points.len());

--- a/crates/velesdb-core/src/perf_optimizations_tests.rs
+++ b/crates/velesdb-core/src/perf_optimizations_tests.rs
@@ -752,3 +752,32 @@ fn test_normal_paths_unaffected_by_guards() {
     let flat = cv.gather_flat(&[0, 2]);
     assert_eq!(flat, vec![1.0, 2.0, 3.0, 7.0, 8.0, 9.0]);
 }
+
+/// `insert_at` with a non-contiguous index leaves gap slots zero-initialized.
+///
+/// `ContiguousVectors` uses `alloc_zeroed` internally, so any index never
+/// explicitly written must read back as an all-zero vector. This property
+/// is relied upon by callers (e.g. HNSW dense-ID assignment) that check
+/// "was this slot ever written?" by testing against the zero vector. This
+/// test pins the guarantee so regressions are caught immediately.
+#[test]
+fn test_insert_at_gap_slots_are_zero_initialized() {
+    let dim = 3;
+    let mut cv = ContiguousVectors::new(dim, 10).expect("test: allocation");
+
+    // Insert at index 5, leaving indices 0-4 as gaps.
+    cv.insert_at(5, &[1.0, 2.0, 3.0]).expect("test: insert_at");
+
+    // The inserted slot reads back correctly.
+    assert_eq!(cv.get(5), Some(&[1.0, 2.0, 3.0][..]));
+
+    // Gap slots (0-4) are zero-initialized due to `alloc_zeroed`.
+    let zero = vec![0.0_f32; dim];
+    for gap in 0..5 {
+        assert_eq!(
+            cv.get(gap),
+            Some(zero.as_slice()),
+            "gap slot {gap} must be zero-initialized"
+        );
+    }
+}

--- a/crates/velesdb-core/src/perf_optimizations_tests.rs
+++ b/crates/velesdb-core/src/perf_optimizations_tests.rs
@@ -752,32 +752,3 @@ fn test_normal_paths_unaffected_by_guards() {
     let flat = cv.gather_flat(&[0, 2]);
     assert_eq!(flat, vec![1.0, 2.0, 3.0, 7.0, 8.0, 9.0]);
 }
-
-/// `insert_at` with a non-contiguous index leaves gap slots zero-initialized.
-///
-/// `ContiguousVectors` uses `alloc_zeroed` internally, so any index never
-/// explicitly written must read back as an all-zero vector. This property
-/// is relied upon by callers (e.g. HNSW dense-ID assignment) that check
-/// "was this slot ever written?" by testing against the zero vector. This
-/// test pins the guarantee so regressions are caught immediately.
-#[test]
-fn test_insert_at_gap_slots_are_zero_initialized() {
-    let dim = 3;
-    let mut cv = ContiguousVectors::new(dim, 10).expect("test: allocation");
-
-    // Insert at index 5, leaving indices 0-4 as gaps.
-    cv.insert_at(5, &[1.0, 2.0, 3.0]).expect("test: insert_at");
-
-    // The inserted slot reads back correctly.
-    assert_eq!(cv.get(5), Some(&[1.0, 2.0, 3.0][..]));
-
-    // Gap slots (0-4) are zero-initialized due to `alloc_zeroed`.
-    let zero = vec![0.0_f32; dim];
-    for gap in 0..5 {
-        assert_eq!(
-            cv.get(gap),
-            Some(zero.as_slice()),
-            "gap slot {gap} must be zero-initialized"
-        );
-    }
-}

--- a/crates/velesdb-migrate/src/pipeline_points.rs
+++ b/crates/velesdb-migrate/src/pipeline_points.rs
@@ -25,7 +25,11 @@ pub(crate) fn stable_point_id(id: &str) -> u64 {
         Ok(n) => n,
         Err(_) => {
             let hashed = super::pipeline::fnv1a64(id.as_bytes());
-            tracing::debug!(source_id = id, point_id = hashed, "non-numeric ID mapped via FNV-1a hash");
+            tracing::debug!(
+                source_id = id,
+                point_id = hashed,
+                "non-numeric ID mapped via FNV-1a hash"
+            );
             hashed
         }
     }

--- a/crates/velesdb-migrate/src/pipeline_points.rs
+++ b/crates/velesdb-migrate/src/pipeline_points.rs
@@ -12,16 +12,23 @@ use crate::pipeline::MigrationStats;
 ///
 /// **Strategy:** Numeric strings (`"12345"`) are parsed directly to u64.
 /// Non-numeric strings (UUIDs, slugs, etc.) are hashed via FNV-1a to a
-/// deterministic u64. Hash collisions are theoretically possible but
-/// extremely rare for typical ID spaces.
+/// deterministic u64. Hash collisions are statistically rare (< 0.0001% for
+/// 1 M IDs) but are non-zero; monitor debug logs for the hashed-ID messages
+/// to detect unusual ID patterns that could increase collision risk.
 ///
 /// # Cross-version stability guarantee
 ///
 /// Changing this function would silently corrupt checkpoint-resumed migrations
 /// because IDs would no longer match previously-inserted points.
 pub(crate) fn stable_point_id(id: &str) -> u64 {
-    id.parse::<u64>()
-        .unwrap_or_else(|_| super::pipeline::fnv1a64(id.as_bytes()))
+    match id.parse::<u64>() {
+        Ok(n) => n,
+        Err(_) => {
+            let hashed = super::pipeline::fnv1a64(id.as_bytes());
+            tracing::debug!(source_id = id, point_id = hashed, "non-numeric ID mapped via FNV-1a hash");
+            hashed
+        }
+    }
 }
 
 /// Prepares extracted points for insertion, optionally using parallel workers.


### PR DESCRIPTION
## Summary

Five-perspective audit (correctness · performance · DRY · security · maintenance) of `velesdb-core` CRUD and `velesdb-migrate` pipeline, resulting in four targeted fixes plus a formatting pass to keep CI green.

### Commits

| # | Category | What changed |
|---|----------|-------------|
| 1 | **Correctness** | `crud.rs`: two `let _ = storage.delete(…)` silently discarded I/O errors. Changed to `?` propagation. `LogPayloadStorage::delete` returns `Ok(())` for unknown IDs so no spurious errors on non-existent points. |
| 2 | **Performance** | `crud.rs`: pre-size `HashSet` and `HashMap` in hot upsert paths with `with_capacity(points.len())`, avoiding incremental rehashes per batch. |
| 3 | **Observability** | `pipeline_points.rs`: `stable_point_id` now emits a structured `tracing::debug!` event (`source_id`, `point_id`) when a non-numeric ID is hashed via FNV-1a. Operators can filter for `"non-numeric ID mapped via FNV-1a hash"` to detect ID patterns with elevated collision risk. Doc-comment updated with collision-probability figure (< 0.0001% for 1M IDs). |
| 4 | **Testing** | `perf_optimizations_tests.rs`: new test `test_insert_at_gap_slots_are_zero_initialized` pins the `alloc_zeroed` guarantee on `ContiguousVectors`: gap slots must read as `0.0`. Protects against future allocator refactors. |
| 5 | **Style** | `cargo fmt` pass: wrapped two long lines flagged by the "Lint & Format" CI job. No logic change. |

### Scope deliberately excluded

- `TODO(US-GRAPH-01)` double source-scan in `pipeline_graph.rs` — tracked separately.
- `TODO(EPIC-046)` `COST_UNIT_TO_MS` calibration in VelesQL explain — requires empirical benchmarking.
- Metric-name DRY refactor in `collections.rs` handlers — separate PR to keep this reviewable.

## Test plan

- [x] `cargo test -p velesdb-core` — 5 173 tests pass (includes new gap-slot test)
- [x] `cargo test -p velesdb-migrate` — 257 tests pass
- [x] `cargo clippy -p velesdb-core -p velesdb-server -p velesdb-cli -p velesdb-migrate -p velesdb-mobile -- -D warnings` — clean
- [x] `cargo fmt --check -p velesdb-core -p velesdb-migrate` — clean