### PR TITLE
test(velesql): exact-result conformance — NEAR/metrics/traversal/NOT/fusion/memory (100 tests)

### DIFF
--- a/crates/velesdb-core/tests/bdd.rs
+++ b/crates/velesdb-core/tests/bdd.rs
@@ -2,7 +2,9 @@
 #![allow(
     clippy::cast_precision_loss,
     clippy::uninlined_format_args,
-    clippy::doc_markdown
+    clippy::doc_markdown,
+    clippy::doc_lazy_continuation,
+    clippy::doc_link_with_quotes
 )]
 
 #[path = "bdd/admin_operations.rs"]
@@ -11,10 +13,16 @@ mod admin_operations;
 mod advanced;
 #[path = "bdd/agent_memory.rs"]
 mod agent_memory;
+#[path = "bdd/agent_memory_graph_traversal.rs"]
+mod agent_memory_graph_traversal;
+#[path = "bdd/agent_memory_recall_exact.rs"]
+mod agent_memory_recall_exact;
 #[path = "bdd/aggregation.rs"]
 mod aggregation;
 #[path = "bdd/array_contains.rs"]
 mod array_contains;
+#[path = "bdd/bm25_match_conformance.rs"]
+mod bm25_match_conformance;
 #[path = "bdd/bugfixes.rs"]
 mod bugfixes;
 #[path = "bdd/collection_type_migration.rs"]
@@ -39,6 +47,10 @@ mod explain_configurable_threshold;
 mod explain_cost_calibrated;
 #[path = "bdd/flush_operations.rs"]
 mod flush_operations;
+#[path = "bdd/fusion_rrf_conformance.rs"]
+mod fusion_rrf_conformance;
+#[path = "bdd/fusion_weighted_bug.rs"]
+mod fusion_weighted_bug;
 #[path = "bdd/geo_distance.rs"]
 mod geo_distance;
 #[path = "bdd/graph_anchor_prefilter.rs"]
@@ -51,6 +63,8 @@ mod graph_vector_hybrid;
 mod helpers;
 #[path = "bdd/hybrid_compositions.rs"]
 mod hybrid_compositions;
+#[path = "bdd/hybrid_vector_first_exact.rs"]
+mod hybrid_vector_first_exact;
 #[path = "bdd/index_management.rs"]
 mod index_management;
 #[path = "bdd/introspection.rs"]
@@ -59,8 +73,18 @@ mod introspection;
 mod match_graph_first;
 #[path = "bdd/match_relationship_semantics.rs"]
 mod match_relationship_semantics;
+#[path = "bdd/match_traversal_exact.rs"]
+mod match_traversal_exact;
 #[path = "bdd/match_vector_first.rs"]
 mod match_vector_first;
+#[path = "bdd/metrics_ranking_conformance.rs"]
+mod metrics_ranking_conformance;
+#[path = "bdd/near_exact_ranking.rs"]
+mod near_exact_ranking;
+#[path = "bdd/near_fused_parse_only.rs"]
+mod near_fused_parse_only;
+#[path = "bdd/not_filters_exact.rs"]
+mod not_filters_exact;
 #[path = "bdd/operators.rs"]
 mod operators;
 #[path = "bdd/recall_contract.rs"]
@@ -73,6 +97,8 @@ mod regression;
 mod secondary_index_bitmap_in;
 #[path = "bdd/set_operations.rs"]
 mod set_operations;
+#[path = "bdd/sparse_near_conformance.rs"]
+mod sparse_near_conformance;
 #[path = "bdd/vector_group_by.rs"]
 mod vector_group_by;
 #[path = "bdd/vector_search.rs"]

--- a/crates/velesdb-core/tests/bdd/agent_memory_graph_traversal.rs
+++ b/crates/velesdb-core/tests/bdd/agent_memory_graph_traversal.rs
@@ -1,0 +1,359 @@
+//! BDD tests for the AGENT-MEMORY graph dimension: `relate` / `relations` /
+//! `unrelate` over `SemanticMemory`, plus VelesQL `MATCH` / `NOT MATCH`
+//! traversal over the queryable `_semantic_memory` collection.
+//!
+//! Every test pins an EXACT result computed by hand from a fixed graph:
+//!
+//! ```text
+//!   1 -[:SUPPORTS    {weight: 0.9}]-> 2
+//!   2 -[:SUPPORTS    {weight: 0.4}]-> 3
+//!   1 -[:CONTRADICTS]               -> 4
+//! ```
+//!
+//! `relations(id)` returns OUTGOING edges only. `SELECT * ... WHERE MATCH
+//! (a)-[:REL]->(b)` returns the SOURCE/anchor facts that have a matching
+//! outgoing edge (proven semantics, see `graph_vector_hybrid.rs`); `NOT MATCH`
+//! returns the exact complement among the four stored facts.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+
+use tempfile::TempDir;
+use velesdb_core::agent::AgentMemory;
+use velesdb_core::{velesql::Parser, Database, SearchResult};
+
+use super::helpers::{execute_sql, result_ids};
+
+// ============================================================================
+// Shared setup — the fixed 4-fact memory graph above
+// ============================================================================
+
+/// Builds the canonical graph and returns `(dir, db, memory, edge_id_1_2)`.
+///
+/// Facts 1..=4 are well-separated cosine anchors. Edge ids are explicit so
+/// `unrelate` tests can target one precisely. `weight` properties live on the
+/// two SUPPORTS edges so property-filtered MATCH has ground truth.
+fn setup_memory_graph() -> (TempDir, Arc<Database>, AgentMemory, u64) {
+    let dir = TempDir::new().expect("test: create temp dir");
+    let db = Arc::new(Database::open(dir.path()).expect("test: open database"));
+    let memory = AgentMemory::with_dimension(Arc::clone(&db), 4).expect("test: AgentMemory");
+    let sm = memory.semantic();
+    sm.store(1, "rust is fast", &[1.0, 0.0, 0.0, 0.0])
+        .expect("store 1");
+    sm.store(2, "rust is safe", &[1.0, 0.3, 0.0, 0.0])
+        .expect("store 2");
+    sm.store(3, "go has gc", &[1.0, 0.7, 0.0, 0.0])
+        .expect("store 3");
+    sm.store(4, "rust is slow", &[1.0, 3.0, 0.0, 0.0])
+        .expect("store 4");
+    let mut w9 = serde_json::Map::new();
+    w9.insert("weight".to_string(), serde_json::json!(0.9));
+    let mut w4 = serde_json::Map::new();
+    w4.insert("weight".to_string(), serde_json::json!(0.4));
+    let e12 = sm.relate(1, 2, "SUPPORTS", Some(&w9)).expect("relate 1->2");
+    sm.relate(2, 3, "SUPPORTS", Some(&w4)).expect("relate 2->3");
+    sm.relate(1, 4, "CONTRADICTS", None).expect("relate 1->4");
+    (dir, db, memory, e12)
+}
+
+/// Collects `(target_id, label)` pairs from a slice of edges, order-independent.
+fn edge_targets(edges: &[velesdb_core::GraphEdge]) -> HashSet<(u64, String)> {
+    edges
+        .iter()
+        .map(|e| (e.target(), e.label().to_string()))
+        .collect()
+}
+
+/// Runs a GraphFirst `MATCH` over `_semantic_memory` via the `_collection`
+/// routing param (the path that binds relationship aliases and supports an
+/// in-pattern `WHERE r.prop`). On this path `point.id` is the traversal TARGET.
+fn run_match_on_semantic(db: &Database, sql: &str) -> Vec<SearchResult> {
+    let query = Parser::parse(sql).expect("test: parse MATCH");
+    let mut params = HashMap::new();
+    params.insert(
+        "_collection".to_string(),
+        serde_json::Value::String("_semantic_memory".to_string()),
+    );
+    db.execute_query(&query, &params)
+        .expect("test: execute GraphFirst MATCH over _semantic_memory")
+}
+
+// ============================================================================
+// 1. relations() — exact set of outgoing edges
+// ============================================================================
+
+/// GIVEN fact 1 with outgoing 1-[:SUPPORTS]->2 and 1-[:CONTRADICTS]->4
+/// WHEN `relations(1)` is read
+/// THEN exactly those two outgoing edges are returned (target+label), and the
+///      incoming-only / two-hop edges (2->3) are NOT included — `relations`
+///      is strictly outgoing.
+#[test]
+fn test_relations_returns_exact_outgoing_set_of_fact_1() {
+    let (_dir, _db, memory, _e12) = setup_memory_graph();
+
+    let rels = memory.semantic().relations(1).expect("relations(1)");
+
+    assert_eq!(rels.len(), 2, "fact 1 has exactly two outgoing edges");
+    assert_eq!(
+        edge_targets(&rels),
+        [(2, "SUPPORTS".to_string()), (4, "CONTRADICTS".to_string())]
+            .into_iter()
+            .collect(),
+        "outgoing edges of fact 1 must be SUPPORTS->2 and CONTRADICTS->4"
+    );
+}
+
+/// GIVEN fact 2 with a single outgoing 2-[:SUPPORTS]->3 (and an INCOMING 1->2)
+/// WHEN `relations(2)` is read
+/// THEN only the outgoing edge to 3 appears; the incoming 1->2 edge is excluded.
+#[test]
+fn test_relations_excludes_incoming_edges() {
+    let (_dir, _db, memory, _e12) = setup_memory_graph();
+
+    let rels = memory.semantic().relations(2).expect("relations(2)");
+
+    assert_eq!(rels.len(), 1, "fact 2 has exactly one outgoing edge");
+    assert_eq!(rels[0].target(), 3, "the only outgoing target is fact 3");
+    assert_eq!(rels[0].label(), "SUPPORTS");
+}
+
+/// GIVEN leaf facts 3 and 4 (no outgoing edges)
+/// WHEN `relations(3)` and `relations(4)` are read
+/// THEN both are empty — only incoming edges reach them.
+#[test]
+fn test_relations_of_leaf_facts_are_empty() {
+    let (_dir, _db, memory, _e12) = setup_memory_graph();
+
+    assert!(
+        memory
+            .semantic()
+            .relations(3)
+            .expect("relations(3)")
+            .is_empty(),
+        "fact 3 has no outgoing edges"
+    );
+    assert!(
+        memory
+            .semantic()
+            .relations(4)
+            .expect("relations(4)")
+            .is_empty(),
+        "fact 4 has no outgoing edges"
+    );
+}
+
+// ============================================================================
+// 2. relate -> usable edge_id; unrelate shrinks relations to the exact set
+// ============================================================================
+
+/// GIVEN the edge id returned by `relate(1, 2, SUPPORTS)`
+/// WHEN it is passed to `unrelate`
+/// THEN `unrelate` returns true and `relations(1)` shrinks to exactly the
+///      remaining CONTRADICTS->4 edge (the SUPPORTS->2 edge is gone).
+#[test]
+fn test_unrelate_returns_true_and_relations_shrink_to_exact_set() {
+    let (_dir, _db, memory, e12) = setup_memory_graph();
+    let sm = memory.semantic();
+
+    assert!(sm.unrelate(e12).expect("unrelate e12"), "edge existed");
+
+    let rels = sm.relations(1).expect("relations(1) after unrelate");
+    assert_eq!(rels.len(), 1, "only the CONTRADICTS edge remains on fact 1");
+    assert_eq!(rels[0].target(), 4);
+    assert_eq!(rels[0].label(), "CONTRADICTS");
+}
+
+/// GIVEN an edge id that does not exist
+/// WHEN `unrelate` is called twice on the same SUPPORTS->2 edge
+/// THEN the first call returns true (removed), the second returns false
+///      (already gone) — `unrelate` reports real removal, not a no-op success.
+#[test]
+fn test_unrelate_is_idempotent_reporting_first_true_then_false() {
+    let (_dir, _db, memory, e12) = setup_memory_graph();
+    let sm = memory.semantic();
+
+    assert!(
+        sm.unrelate(e12).expect("first unrelate"),
+        "first removes it"
+    );
+    assert!(
+        !sm.unrelate(e12).expect("second unrelate"),
+        "second call finds nothing to remove"
+    );
+}
+
+// ============================================================================
+// 3 & 4. VelesQL MATCH / NOT MATCH over _semantic_memory
+// ============================================================================
+
+/// GIVEN edges 1-[:SUPPORTS]->2 and 2-[:SUPPORTS]->3
+/// WHEN `SELECT * FROM _semantic_memory WHERE MATCH (a)-[:SUPPORTS]->(b)`
+/// THEN exactly the SOURCE facts with an outgoing SUPPORTS edge are returned:
+///      {1, 2}. Fact 3 (leaf) and fact 4 (only CONTRADICTS) are excluded.
+#[test]
+fn test_match_supports_returns_exact_source_anchor_set() {
+    let (_dir, db, _memory, _e12) = setup_memory_graph();
+
+    let results = execute_sql(
+        &db,
+        "SELECT * FROM _semantic_memory WHERE MATCH (a)-[:SUPPORTS]->(b) LIMIT 20",
+    )
+    .expect("MATCH over _semantic_memory must execute");
+
+    assert_eq!(
+        result_ids(&results),
+        [1u64, 2].into_iter().collect(),
+        "only facts with an outgoing SUPPORTS edge anchor the pattern"
+    );
+}
+
+/// GIVEN the single edge 1-[:CONTRADICTS]->4
+/// WHEN `SELECT * FROM _semantic_memory WHERE MATCH (a)-[:CONTRADICTS]->(b)`
+/// THEN only fact 1 anchors the pattern (it is the sole CONTRADICTS source).
+#[test]
+fn test_match_contradicts_returns_single_source() {
+    let (_dir, db, _memory, _e12) = setup_memory_graph();
+
+    let results = execute_sql(
+        &db,
+        "SELECT * FROM _semantic_memory WHERE MATCH (a)-[:CONTRADICTS]->(b) LIMIT 20",
+    )
+    .expect("CONTRADICTS MATCH must execute");
+
+    assert_eq!(
+        result_ids(&results),
+        [1u64].into_iter().collect(),
+        "fact 1 is the only CONTRADICTS source"
+    );
+}
+
+/// GIVEN the four stored facts and the SUPPORTS sources {1, 2}
+/// WHEN `NOT MATCH (a)-[:SUPPORTS]->(b)` is applied
+/// THEN the result is the EXACT complement {3, 4}: every stored fact appears
+///      in exactly one of MATCH / NOT MATCH, and the two sets are disjoint and
+///      union to all four facts (complement property).
+#[test]
+fn test_not_match_supports_is_exact_complement() {
+    let (_dir, db, _memory, _e12) = setup_memory_graph();
+
+    let matched = result_ids(
+        &execute_sql(
+            &db,
+            "SELECT * FROM _semantic_memory WHERE MATCH (a)-[:SUPPORTS]->(b) LIMIT 20",
+        )
+        .expect("MATCH must execute"),
+    );
+    let unmatched = result_ids(
+        &execute_sql(
+            &db,
+            "SELECT * FROM _semantic_memory WHERE NOT MATCH (a)-[:SUPPORTS]->(b) LIMIT 20",
+        )
+        .expect("NOT MATCH must execute"),
+    );
+
+    assert_eq!(
+        unmatched,
+        [3u64, 4].into_iter().collect(),
+        "NOT MATCH yields the facts without an outgoing SUPPORTS edge"
+    );
+    assert!(
+        matched.is_disjoint(&unmatched),
+        "MATCH and NOT MATCH partitions must be disjoint"
+    );
+    assert_eq!(
+        &matched | &unmatched,
+        [1u64, 2, 3, 4].into_iter().collect(),
+        "MATCH ∪ NOT MATCH must cover every stored fact"
+    );
+}
+
+// ============================================================================
+// 5. relate with properties -> property-filtered MATCH
+// ============================================================================
+
+/// GIVEN edges 1-[:SUPPORTS {weight: 0.9}]->2 and 2-[:SUPPORTS {weight: 0.4}]->3
+/// WHEN a GraphFirst MATCH binds the edge alias `r` and filters `r.weight = 0.9`
+/// THEN exactly the TARGET of the weight=0.9 edge is returned: fact 2 (edge
+///      1->2). The weight=0.4 edge (2->3) is excluded by the edge-property
+///      predicate — proving `r.weight` resolves against the EDGE, not a node.
+#[test]
+fn test_edge_property_filtered_match_selects_target_of_weight_0_9() {
+    let (_dir, db, _memory, _e12) = setup_memory_graph();
+
+    let results = run_match_on_semantic(
+        &db,
+        "MATCH (a)-[r:SUPPORTS]->(b) WHERE r.weight = 0.9 RETURN b LIMIT 20",
+    );
+
+    assert_eq!(
+        result_ids(&results),
+        [2u64].into_iter().collect(),
+        "only the target of the weight=0.9 SUPPORTS edge (1->2) is fact 2"
+    );
+}
+
+/// GIVEN the same weighted SUPPORTS edges (weights 0.9 and 0.4)
+/// WHEN the GraphFirst MATCH filters the edge property `r.weight = 0.4`
+/// THEN exactly the TARGET of the weight=0.4 edge is returned: fact 3 (edge
+///      2->3). The weight=0.9 edge (1->2) is excluded.
+#[test]
+fn test_edge_property_filtered_match_selects_target_of_weight_0_4() {
+    let (_dir, db, _memory, _e12) = setup_memory_graph();
+
+    let results = run_match_on_semantic(
+        &db,
+        "MATCH (a)-[r:SUPPORTS]->(b) WHERE r.weight = 0.4 RETURN b LIMIT 20",
+    );
+
+    assert_eq!(
+        result_ids(&results),
+        [3u64].into_iter().collect(),
+        "only the target of the weight=0.4 SUPPORTS edge (2->3) is fact 3"
+    );
+}
+
+// ============================================================================
+// 6. Deleting an endpoint cascades dangling edges out of relations()
+// ============================================================================
+
+/// GIVEN fact 1 with outgoing SUPPORTS->2 and CONTRADICTS->4
+/// WHEN endpoint fact 2 is deleted
+/// THEN the dangling SUPPORTS->2 edge is cascaded away and `relations(1)`
+///      shrinks to exactly the CONTRADICTS->4 edge — no dangling edge survives.
+#[test]
+fn test_deleting_endpoint_cascades_dangling_edge_out_of_relations() {
+    let (_dir, _db, memory, _e12) = setup_memory_graph();
+    let sm = memory.semantic();
+
+    sm.delete(2).expect("delete fact 2");
+
+    let rels = sm.relations(1).expect("relations(1) after delete");
+    assert_eq!(
+        edge_targets(&rels),
+        [(4, "CONTRADICTS".to_string())].into_iter().collect(),
+        "deleting fact 2 must cascade the SUPPORTS->2 edge away"
+    );
+}
+
+/// GIVEN fact 2 which is BOTH a SUPPORTS target (1->2) and source (2->3)
+/// WHEN fact 2 is deleted
+/// THEN MATCH (a)-[:SUPPORTS]->(b) collapses to the empty set: edge 1->2 lost
+///      its target and edge 2->3 lost its source, so no SUPPORTS edge remains
+///      with both endpoints live.
+#[test]
+fn test_match_supports_empty_after_pivotal_fact_deleted() {
+    let (_dir, db, memory, _e12) = setup_memory_graph();
+
+    memory.semantic().delete(2).expect("delete pivotal fact 2");
+
+    let results = execute_sql(
+        &db,
+        "SELECT * FROM _semantic_memory WHERE MATCH (a)-[:SUPPORTS]->(b) LIMIT 20",
+    )
+    .expect("MATCH after delete must execute");
+
+    assert!(
+        result_ids(&results).is_empty(),
+        "both SUPPORTS edges lost an endpoint; none can anchor a match"
+    );
+}

--- a/crates/velesdb-core/tests/bdd/agent_memory_recall_exact.rs
+++ b/crates/velesdb-core/tests/bdd/agent_memory_recall_exact.rs
@@ -1,0 +1,340 @@
+//! BDD: pin AGENT-MEMORY recall to EXACT results (not just "non-empty").
+//!
+//! These tests fix the precise recall contract of the `AgentMemory` typed API
+//! (`semantic()`, `episodic()`, `procedural()`), which previously was only
+//! asserted loosely. Every scenario states its hand-computed ground truth.
+//!
+//! ## Cosine ground truth (used by the semantic scenarios)
+//!
+//! All semantic facts have the shape `[1.0, off, 0.0, 0.0]` and the query is
+//! `[1, 0, 0, 0]`. Cosine similarity is `dot / (|a||b|) = 1 / sqrt(1 + off^2)`,
+//! which is **strictly decreasing** in `off`. With the well-separated offsets
+//! `{0.0, 0.3, 0.7, 1.2, 3.0}` the exact similarities are:
+//!   off=0.0 -> 1.0000   off=0.3 -> 0.9578   off=0.7 -> 0.8189
+//!   off=1.2 -> 0.6402   off=3.0 -> 0.3162
+//! so the recall order by descending similarity is unambiguously the order of
+//! increasing `off`. The gaps (>= 0.06) are large enough that HNSW reproduces
+//! the exact order.
+
+use std::sync::Arc;
+
+use serde_json::{json, Map, Value};
+use tempfile::TempDir;
+use velesdb_core::agent::AgentMemory;
+use velesdb_core::{velesql::Parser, Database, SearchResult};
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/// Create a `Database` + `AgentMemory` with dimension 4 for test isolation.
+fn setup() -> (TempDir, Arc<Database>, AgentMemory) {
+    let dir = TempDir::new().expect("test: create temp dir");
+    let db = Arc::new(Database::open(dir.path()).expect("test: open database"));
+    let memory = AgentMemory::with_dimension(Arc::clone(&db), 4).expect("test: create AgentMemory");
+    (dir, db, memory)
+}
+
+/// The canonical query vector for all cosine scenarios.
+const Q: [f32; 4] = [1.0, 0.0, 0.0, 0.0];
+
+/// Store the five well-separated cosine facts (see module ground truth).
+/// Returns ids in DECREASING-similarity order so callers can assert against it.
+fn store_five_facts(memory: &AgentMemory) -> [u64; 5] {
+    let facts = [
+        (10_u64, 0.0_f32),
+        (20, 0.3),
+        (30, 0.7),
+        (40, 1.2),
+        (50, 3.0),
+    ];
+    for (id, off) in facts {
+        memory
+            .semantic()
+            .store(id, "fact", &[1.0, off, 0.0, 0.0])
+            .expect("store fact");
+    }
+    [10, 20, 30, 40, 50]
+}
+
+/// Recalled ids in returned (similarity-descending) order.
+fn recalled_ids(rows: &[(u64, f32, String)]) -> Vec<u64> {
+    rows.iter().map(|r| r.0).collect()
+}
+
+/// Execute a `VelesQL` query through `Database::execute_query` (no params).
+fn db_sql(db: &Database, sql: &str) -> Vec<SearchResult> {
+    let query = Parser::parse(sql)
+        .map_err(|e| velesdb_core::Error::Query(e.to_string()))
+        .expect("parse SQL");
+    db.execute_query(&query, &std::collections::HashMap::new())
+        .expect("execute SQL")
+}
+
+// ============================================================================
+// (1) semantic().query -> exact ordered ids + strictly decreasing scores
+// ============================================================================
+
+/// GIVEN five facts at offsets {0.0,0.3,0.7,1.2,3.0} (sims 1.0>0.958>0.819>
+/// 0.640>0.316). WHEN `query([1,0,0,0], 5)`. THEN ids come back in exactly the
+/// decreasing-similarity order [10,20,30,40,50] and scores strictly decrease,
+/// because cosine `1/sqrt(1+off^2)` is monotonic in `off`.
+#[test]
+fn test_semantic_query_exact_order_and_monotonic_scores() {
+    let (_dir, _db, memory) = setup();
+    let expected = store_five_facts(&memory);
+
+    let rows = memory.semantic().query(&Q, 5).expect("query");
+
+    assert_eq!(recalled_ids(&rows), expected.to_vec(), "exact recall order");
+    let scores: Vec<f32> = rows.iter().map(|r| r.1).collect();
+    assert!(
+        scores.windows(2).all(|w| w[0] > w[1]),
+        "scores must strictly decrease: {scores:?}"
+    );
+}
+
+/// GIVEN the same five facts. WHEN `query(q, 3)` (top-k truncation). THEN only
+/// the three most similar survive, in exact order [10,20,30] — the k=3 cut
+/// drops offsets 1.2 and 3.0, the two least similar.
+#[test]
+fn test_semantic_query_topk_truncates_to_exact_prefix() {
+    let (_dir, _db, memory) = setup();
+    store_five_facts(&memory);
+
+    let rows = memory.semantic().query(&Q, 3).expect("query k=3");
+
+    assert_eq!(rows.len(), 3, "k=3 returns exactly 3 rows");
+    assert_eq!(recalled_ids(&rows), vec![10, 20, 30], "top-3 exact prefix");
+}
+
+// ============================================================================
+// (2) query_filtered: exact ids under a metadata filter + offset pagination
+// ============================================================================
+
+/// GIVEN five facts where the three closest (ids 10,20,30) carry
+/// `team="red"` and the two farthest (40,50) carry `team="blue"`. WHEN
+/// `query_filtered(q, 10, {team:red}, 0)`. THEN exactly [10,20,30] in
+/// similarity order — the blue rows are filtered out, the red rows keep their
+/// cosine ranking.
+#[test]
+fn test_query_filtered_honors_metadata_filter_exact() {
+    let (_dir, _db, memory) = setup();
+    let teams = [
+        (10_u64, "red"),
+        (20, "red"),
+        (30, "red"),
+        (40, "blue"),
+        (50, "blue"),
+    ];
+    let offs = [0.0_f32, 0.3, 0.7, 1.2, 3.0];
+    for ((id, team), off) in teams.into_iter().zip(offs) {
+        let mut meta = Map::new();
+        meta.insert("team".to_string(), Value::String(team.to_string()));
+        memory
+            .semantic()
+            .store_with_metadata(id, "fact", &[1.0, off, 0.0, 0.0], &meta)
+            .expect("store with metadata");
+    }
+    let mut filter = Map::new();
+    filter.insert("team".to_string(), json!("red"));
+
+    let rows = memory
+        .semantic()
+        .query_filtered(&Q, 10, &filter, 0)
+        .expect("query_filtered");
+
+    assert_eq!(recalled_ids(&rows), vec![10, 20, 30], "only red, ranked");
+}
+
+/// GIVEN the five facts (no filter). WHEN paginating with k=2: page0 =
+/// offset 0, page1 = offset 2, page2 = offset 4. THEN the pages are exact,
+/// contiguous, non-overlapping slices of the global similarity order
+/// [10,20,30,40,50]: [10,20], [30,40], [50].
+#[test]
+fn test_query_filtered_offset_pagination_exact() {
+    let (_dir, _db, memory) = setup();
+    store_five_facts(&memory);
+    let empty = Map::new();
+
+    let page0 = memory
+        .semantic()
+        .query_filtered(&Q, 2, &empty, 0)
+        .expect("p0");
+    let page1 = memory
+        .semantic()
+        .query_filtered(&Q, 2, &empty, 2)
+        .expect("p1");
+    let page2 = memory
+        .semantic()
+        .query_filtered(&Q, 2, &empty, 4)
+        .expect("p2");
+
+    assert_eq!(recalled_ids(&page0), vec![10, 20], "page 0");
+    assert_eq!(recalled_ids(&page1), vec![30, 40], "page 1");
+    assert_eq!(recalled_ids(&page2), vec![50], "page 2 (tail, 1 row)");
+}
+
+// ============================================================================
+// (3) delete() removes a fact from subsequent recall (recomputed exact set)
+// ============================================================================
+
+/// GIVEN the five facts. WHEN id 20 (the 2nd closest) is deleted and we
+/// re-query top-5. THEN recall is exactly [10,30,40,50]: the surviving four in
+/// unchanged cosine order, with 20 absent — deletion is reflected immediately.
+#[test]
+fn test_delete_removes_fact_from_recall_exact() {
+    let (_dir, _db, memory) = setup();
+    store_five_facts(&memory);
+
+    memory.semantic().delete(20).expect("delete id 20");
+    let rows = memory.semantic().query(&Q, 5).expect("re-query");
+
+    assert_eq!(
+        recalled_ids(&rows),
+        vec![10, 30, 40, 50],
+        "deleted id 20 must be gone, rest keep order"
+    );
+}
+
+// ============================================================================
+// (4) episodic: increasing timestamps -> SQL ORDER BY timestamp DESC exact ids
+// ============================================================================
+
+/// Records three episodic events (ids 1,2,3) at strictly increasing timestamps.
+fn record_three_episodes(memory: &AgentMemory) {
+    memory
+        .episodic()
+        .record(1, "old", 1000, Some(&Q))
+        .expect("rec 1");
+    memory
+        .episodic()
+        .record(2, "mid", 2000, Some(&Q))
+        .expect("rec 2");
+    memory
+        .episodic()
+        .record(3, "new", 3000, Some(&Q))
+        .expect("rec 3");
+}
+
+/// GIVEN three events recorded with strictly increasing timestamps
+/// (1000<2000<3000) under ids 1,2,3. WHEN SQL `ORDER BY timestamp DESC` over
+/// `_episodic_memory`. THEN ids come back newest-first: exactly [3,2,1].
+#[test]
+fn test_episodic_order_by_timestamp_desc_exact_ids() {
+    let (_dir, db, memory) = setup();
+    record_three_episodes(&memory);
+
+    let rows = db_sql(
+        &db,
+        "SELECT * FROM _episodic_memory ORDER BY timestamp DESC LIMIT 10",
+    );
+
+    let ids: Vec<u64> = rows.iter().map(|r| r.point.id).collect();
+    assert_eq!(ids, vec![3, 2, 1], "newest timestamp first");
+}
+
+/// GIVEN the same three events. WHEN SQL `ORDER BY timestamp ASC LIMIT 2`.
+/// THEN exactly the two oldest in ascending order: [1,2].
+#[test]
+fn test_episodic_order_by_timestamp_asc_limit_exact() {
+    let (_dir, db, memory) = setup();
+    record_three_episodes(&memory);
+
+    let rows = db_sql(
+        &db,
+        "SELECT * FROM _episodic_memory ORDER BY timestamp ASC LIMIT 2",
+    );
+
+    let ids: Vec<u64> = rows.iter().map(|r| r.point.id).collect();
+    assert_eq!(ids, vec![1, 2], "two oldest, ascending");
+}
+
+// ============================================================================
+// (5) procedural: learn several -> exact count + confidence-ordered recall
+// ============================================================================
+
+/// GIVEN three procedures learned with confidences {0.9, 0.5, 0.3} at the same
+/// query vector. WHEN SQL `ORDER BY confidence DESC` over `_procedural_memory`.
+/// THEN exactly 3 rows in confidence order [1,2,3] (the ids were assigned in
+/// decreasing-confidence order), proving the stored `confidence` payload is the
+/// sort key.
+#[test]
+fn test_procedural_count_and_confidence_order_exact() {
+    let (_dir, db, memory) = setup();
+    memory
+        .procedural()
+        .learn(1, "high", &["a".to_string()], Some(&Q), 0.9)
+        .expect("learn 1");
+    memory
+        .procedural()
+        .learn(2, "mid", &["b".to_string()], Some(&Q), 0.5)
+        .expect("learn 2");
+    memory
+        .procedural()
+        .learn(3, "low", &["c".to_string()], Some(&Q), 0.3)
+        .expect("learn 3");
+
+    let rows = db_sql(
+        &db,
+        "SELECT * FROM _procedural_memory ORDER BY confidence DESC LIMIT 10",
+    );
+
+    assert_eq!(rows.len(), 3, "exactly 3 procedures stored");
+    let ids: Vec<u64> = rows.iter().map(|r| r.point.id).collect();
+    assert_eq!(ids, vec![1, 2, 3], "highest confidence first");
+}
+
+/// GIVEN two procedures, only id 7 has confidence >= 0.8. WHEN `recall(q, 10,
+/// 0.8)` (min-confidence floor). THEN exactly one match, id 7 — the 0.4-conf
+/// procedure is filtered below the floor.
+#[test]
+fn test_procedural_recall_min_confidence_floor_exact() {
+    let (_dir, _db, memory) = setup();
+    memory
+        .procedural()
+        .learn(7, "strong", &["x".to_string()], Some(&Q), 0.9)
+        .expect("learn strong");
+    memory
+        .procedural()
+        .learn(8, "weak", &["y".to_string()], Some(&Q), 0.4)
+        .expect("learn weak");
+
+    let matches = memory.procedural().recall(&Q, 10, 0.8).expect("recall");
+
+    assert_eq!(matches.len(), 1, "only the >=0.8 procedure survives");
+    assert_eq!(matches[0].id, 7, "id 7 is the strong procedure");
+}
+
+// ============================================================================
+// (6) set_ttl_durable(id,0) + auto_expire -> exact expired count, gone from recall
+// ============================================================================
+
+/// GIVEN five facts; ids 10 and 40 get an immediate durable TTL
+/// (`set_ttl_durable(id, 0)` persists `_veles_expires_at = now`, it does NOT
+/// delete the point). WHEN `auto_expire()` runs after a reopen. THEN
+/// `semantic_expired == 2` (exactly the two TTL'd facts) and recall returns the
+/// surviving three in cosine order [20,30,50].
+#[test]
+fn test_ttl_zero_then_auto_expire_exact_count_and_recall() {
+    let dir = TempDir::new().expect("test: create temp dir");
+    {
+        let db = Arc::new(Database::open(dir.path()).expect("open db"));
+        let memory = AgentMemory::with_dimension(Arc::clone(&db), 4).expect("create AgentMemory");
+        store_five_facts(&memory);
+        memory.semantic().set_ttl_durable(10, 0).expect("ttl 10");
+        memory.semantic().set_ttl_durable(40, 0).expect("ttl 40");
+    }
+
+    let db = Arc::new(Database::open(dir.path()).expect("reopen db"));
+    let memory = AgentMemory::with_dimension(Arc::clone(&db), 4).expect("reopen AgentMemory");
+    let stats = memory.auto_expire().expect("auto_expire");
+
+    assert_eq!(stats.semantic_expired, 2, "exactly ids 10 and 40 expired");
+    let rows = memory.semantic().query(&Q, 5).expect("query survivors");
+    assert_eq!(
+        recalled_ids(&rows),
+        vec![20, 30, 50],
+        "expired 10 & 40 gone, rest keep cosine order"
+    );
+}

--- a/crates/velesdb-core/tests/bdd/bm25_match_conformance.rs
+++ b/crates/velesdb-core/tests/bdd/bm25_match_conformance.rs
@@ -1,0 +1,314 @@
+//! BDD conformance tests for BM25 full-text ranking via `VelesQL` `MATCH`.
+//!
+//! Surface under test: the SQL path `SELECT * FROM <coll> WHERE <col> MATCH
+//! '<query>' LIMIT k`. A pure-`MATCH` query (no `vector NEAR`, no metadata
+//! filter) routes through `Collection::text_search` (see
+//! `collection/search/query/execution_paths.rs:264`), which sets each
+//! `SearchResult.score` to the **raw BM25 score** and tags
+//! `component_scores = [("bm25_score", score)]` (`collection/search/text.rs`
+//! lines 100-117). We therefore read the BM25 score directly off
+//! `result.score`.
+//!
+//! BM25 formula (verified against `index/bm25/bm25.rs`,
+//! `score_document_fast` + `build_idf_cache`):
+//! ```text
+//!   idf(t)   = ln( (N - df + 0.5) / (df + 0.5) + 1.0 )
+//!   len_norm = 1 - b + b * |D| / avgdl
+//!   term     = idf * tf*(k1+1) / (tf + k1*len_norm)
+//!   score(D) = Σ term over query terms
+//! ```
+//! with `k1 = 1.2`, `b = 0.75` (`Bm25Params::default`).
+//!
+//! Tokenizer (verified, `Bm25Index::tokenize`): lowercases, splits on every
+//! non-alphanumeric char, and DROPS tokens of length ≤ 1.
+//!
+//! Whole-payload indexing (verified, `collection/text_utils.rs::extract_text`):
+//! every **string leaf** of the JSON payload is concatenated (space-joined)
+//! and indexed; the `<col>` named in `MATCH` is IGNORED at runtime — only the
+//! query text drives scoring. To keep hand-computed scores exact, the
+//! single-field scenarios use payloads whose only string leaf is `content`.
+
+use serde_json::json;
+use velesdb_core::{Database, DistanceMetric, Point};
+
+use super::helpers::{approx_eq, create_test_db, execute_sql, result_ids};
+
+/// BM25 score epsilon — single-term f32 accumulation, 1e-4 is comfortable.
+const BM25_EPS: f32 = 1e-4;
+
+/// Create a 2-dim cosine vector collection and return its handle.
+fn make_collection(db: &Database, name: &str) {
+    db.create_vector_collection(name, 2, DistanceMetric::Cosine)
+        .expect("test: create vector collection");
+}
+
+/// Upsert `(id, content)` points whose ONLY string leaf is `content`.
+///
+/// Vectors are irrelevant to a pure-`MATCH` query but must satisfy the
+/// declared dimension (2); they are fixed and identical so they cannot
+/// perturb the BM25-only ranking.
+fn upsert_contents(db: &Database, coll: &str, docs: &[(u64, &str)]) {
+    let vc = db
+        .get_vector_collection(coll)
+        .expect("test: collection must exist");
+    let points: Vec<Point> = docs
+        .iter()
+        .map(|(id, content)| Point::new(*id, vec![1.0, 0.0], Some(json!({ "content": content }))))
+        .collect();
+    vc.upsert(points).expect("test: upsert corpus");
+}
+
+/// Fetch a result's raw BM25 score by id (pure-MATCH ⇒ `score` IS the BM25 score).
+fn score_of(results: &[velesdb_core::SearchResult], id: u64) -> f32 {
+    results
+        .iter()
+        .find(|r| r.point.id == id)
+        .map(|r| r.score)
+        .expect("test: expected id present in results")
+}
+
+// =========================================================================
+// Scenario 1 — equal-length docs: term frequency drives ranking
+// =========================================================================
+
+/// GIVEN three equal-length (4-token) docs differing only in tf('rust'):
+///       id1 tf=3, id2 tf=2, id3 tf=1, query 'rust'
+/// WHEN  `WHERE content MATCH 'rust'`
+/// THEN  order is [1,2,3] with scores {1:0.2098, 2:0.1836, 3:0.1335}.
+///
+/// Ground truth (N=3, df=3, avgdl=4, k1=1.2, b=0.75): idf=ln(0.5/3.5+1)≈0.1335;
+/// len_norm=1; term=idf*tf*2.2/(tf+1.2) ⇒ 0.209835 / 0.183606 / 0.133531.
+/// All three scores are strictly distinct ⇒ id order is deterministic.
+#[test]
+fn test_bm25_equal_length_ranks_by_term_frequency() {
+    let (_dir, db) = create_test_db();
+    make_collection(&db, "tf_docs");
+    upsert_contents(
+        &db,
+        "tf_docs",
+        &[
+            (1, "rust rust rust filler"),
+            (2, "rust rust foo bar"),
+            (3, "rust alpha beta gamma"),
+        ],
+    );
+
+    let results = execute_sql(
+        &db,
+        "SELECT * FROM tf_docs WHERE content MATCH 'rust' LIMIT 10",
+    )
+    .expect("test: BM25 MATCH 'rust'");
+
+    let ids: Vec<u64> = results.iter().map(|r| r.point.id).collect();
+    assert_eq!(ids, vec![1, 2, 3], "higher tf ⇒ higher BM25, strict order");
+
+    assert!(
+        approx_eq(score_of(&results, 1), 0.209_835, BM25_EPS),
+        "id1 (tf=3) BM25 = 0.209835, got {}",
+        score_of(&results, 1)
+    );
+    assert!(
+        approx_eq(score_of(&results, 2), 0.183_606, BM25_EPS),
+        "id2 (tf=2) BM25 = 0.183606, got {}",
+        score_of(&results, 2)
+    );
+    assert!(
+        approx_eq(score_of(&results, 3), 0.133_531, BM25_EPS),
+        "id3 (tf=1) BM25 = 0.133531, got {}",
+        score_of(&results, 3)
+    );
+}
+
+// =========================================================================
+// Scenario 2 — length normalization: shorter doc with same tf wins
+// =========================================================================
+
+/// GIVEN two docs each containing 'rust' exactly once but of different length:
+///       id1 length=2, id2 length=9, query 'rust'
+/// WHEN  `WHERE content MATCH 'rust'`
+/// THEN  order is [1,2] with scores {1:0.2465, 2:0.1447}.
+///
+/// Ground truth (N=2, df=2, avgdl=(2+9)/2=5.5): idf=ln(0.5/2.5+1)≈0.1823;
+/// id1 len_norm=1-0.75+0.75*2/5.5≈0.5227 ⇒ 0.246491;
+/// id2 len_norm=1-0.75+0.75*9/5.5≈1.4773 ⇒ 0.144662. Strictly distinct.
+#[test]
+fn test_bm25_length_normalization_favours_shorter_doc() {
+    let (_dir, db) = create_test_db();
+    make_collection(&db, "len_docs");
+    upsert_contents(
+        &db,
+        "len_docs",
+        &[
+            (1, "rust filler"),
+            (2, "rust alpha beta gamma delta epsilon zeta eta theta"),
+        ],
+    );
+
+    let results = execute_sql(
+        &db,
+        "SELECT * FROM len_docs WHERE content MATCH 'rust' LIMIT 10",
+    )
+    .expect("test: BM25 length-norm MATCH 'rust'");
+
+    let ids: Vec<u64> = results.iter().map(|r| r.point.id).collect();
+    assert_eq!(ids, vec![1, 2], "shorter doc (same tf) outranks longer one");
+
+    assert!(
+        approx_eq(score_of(&results, 1), 0.246_491, BM25_EPS),
+        "id1 (len=2) BM25 = 0.246491, got {}",
+        score_of(&results, 1)
+    );
+    assert!(
+        approx_eq(score_of(&results, 2), 0.144_662, BM25_EPS),
+        "id2 (len=9) BM25 = 0.144662, got {}",
+        score_of(&results, 2)
+    );
+}
+
+// =========================================================================
+// Scenario 3 — multi-term query: dual-match outranks single-match
+// =========================================================================
+
+/// GIVEN three 3-token docs, query 'rust systems':
+///       id1 'rust systems rust' (rust tf=2 + systems tf=1, dual match),
+///       id2 'rust alpha beta'    (rust tf=1, single match),
+///       id3 'systems alpha beta' (systems tf=1, single match)
+/// WHEN  `WHERE content MATCH 'rust systems'`
+/// THEN  all three returned ({1,2,3}); id1 ranks first; the two single-match
+///       docs (id2, id3) carry EQUAL scores ⇒ their mutual order is
+///       non-deterministic, so we assert score equality, not id order.
+///
+/// Ground truth (N=3, avgdl=3, df_rust=df_systems=2 ⇒ idf≈0.5108, len_norm=1):
+/// single-term tf=1 score = 0.5108*2.2/2.2 = 0.510826 *... → both = 0.470004;
+/// id1 = rust-term(tf2)+systems-term(tf1) = 0.646255+0.470004 = 1.116259.
+#[test]
+fn test_bm25_multiterm_dual_match_outranks_single_match() {
+    let (_dir, db) = create_test_db();
+    make_collection(&db, "multi_docs");
+    upsert_contents(
+        &db,
+        "multi_docs",
+        &[
+            (1, "rust systems rust"),
+            (2, "rust alpha beta"),
+            (3, "systems alpha beta"),
+        ],
+    );
+
+    let results = execute_sql(
+        &db,
+        "SELECT * FROM multi_docs WHERE content MATCH 'rust systems' LIMIT 10",
+    )
+    .expect("test: BM25 multi-term MATCH");
+
+    assert_eq!(
+        result_ids(&results),
+        std::collections::HashSet::from([1, 2, 3]),
+        "all three docs match at least one query term"
+    );
+    assert_eq!(
+        results[0].point.id, 1,
+        "dual-match doc id=1 must rank first (highest BM25 sum)"
+    );
+
+    let (s1, s2, s3) = (
+        score_of(&results, 1),
+        score_of(&results, 2),
+        score_of(&results, 3),
+    );
+    assert!(
+        approx_eq(s1, 1.116_259, BM25_EPS),
+        "id1 (rust tf2 + systems tf1) BM25 = 1.116259, got {s1}"
+    );
+    // id2 and id3 are symmetric single matches (same tf=1, len=3, df=2).
+    assert!(
+        approx_eq(s2, 0.470_004, BM25_EPS) && approx_eq(s3, 0.470_004, BM25_EPS),
+        "single-match docs id2/id3 each BM25 = 0.470004, got {s2} / {s3}"
+    );
+    assert!(
+        s1 > s2 && s1 > s3,
+        "dual match must strictly outrank single matches: {s1} vs {s2}/{s3}"
+    );
+}
+
+// =========================================================================
+// Scenario 4 — tokenizer + column-name semantics
+// =========================================================================
+
+/// GIVEN id1 has TWO string leaves {title:'unused', content:'a I rust'} and
+///       id2 has only {content:'rust rust'}; the MATCH column is `title`.
+/// WHEN  `WHERE title MATCH 'rust'`
+/// THEN  the column name is IGNORED (whole payload indexed): BOTH docs are
+///       returned, and id2 (tf=2) outranks id1 (tf=1).
+///
+/// Ground truth: extract_text concatenates ALL string leaves ⇒ id1 indexed
+/// text = "unused" + "a I rust"; tokenizer drops len≤1 ('a','i') ⇒ id1 tokens
+/// {unused, rust} (len=2, tf_rust=1); id2 {rust,rust} (len=2, tf_rust=2).
+/// N=2, df_rust=2, avgdl=2 ⇒ id1=0.182322, id2=0.250692 ⇒ id2 first.
+#[test]
+fn test_bm25_match_ignores_column_and_indexes_whole_payload() {
+    let (_dir, db) = create_test_db();
+    make_collection(&db, "col_docs");
+
+    let vc = db
+        .get_vector_collection("col_docs")
+        .expect("test: col_docs must exist");
+    vc.upsert(vec![
+        Point::new(
+            1,
+            vec![1.0, 0.0],
+            Some(json!({ "title": "unused", "content": "a I rust" })),
+        ),
+        Point::new(2, vec![1.0, 0.0], Some(json!({ "content": "rust rust" }))),
+    ])
+    .expect("test: upsert column corpus");
+
+    // Column 'title' is named but ignored at runtime — whole payload is indexed.
+    let results = execute_sql(
+        &db,
+        "SELECT * FROM col_docs WHERE title MATCH 'rust' LIMIT 10",
+    )
+    .expect("test: BM25 MATCH with arbitrary column name");
+
+    let ids: Vec<u64> = results.iter().map(|r| r.point.id).collect();
+    assert_eq!(
+        ids,
+        vec![2, 1],
+        "column ignored: both docs returned; id2 (tf=2) outranks id1 (tf=1)"
+    );
+    assert!(
+        approx_eq(score_of(&results, 2), 0.250_692, BM25_EPS),
+        "id2 (tf=2, len=2) BM25 = 0.250692, got {}",
+        score_of(&results, 2)
+    );
+    assert!(
+        approx_eq(score_of(&results, 1), 0.182_322, BM25_EPS),
+        "id1 (tf=1, len=2) BM25 = 0.182322, got {}",
+        score_of(&results, 1)
+    );
+}
+
+/// GIVEN the same two-doc corpus
+/// WHEN  the query is a single-character token `MATCH 'a'`
+/// THEN  the tokenizer drops the len≤1 token ⇒ empty query ⇒ zero results.
+///
+/// Ground truth: `Bm25Index::tokenize` filters `s.len() > 1`; an all-dropped
+/// query yields `query_terms.is_empty()` ⇒ `search` returns an empty Vec.
+#[test]
+fn test_bm25_single_char_token_is_dropped_yielding_no_results() {
+    let (_dir, db) = create_test_db();
+    make_collection(&db, "drop_docs");
+    upsert_contents(&db, "drop_docs", &[(1, "a I rust"), (2, "rust rust")]);
+
+    let results = execute_sql(
+        &db,
+        "SELECT * FROM drop_docs WHERE content MATCH 'a' LIMIT 10",
+    )
+    .expect("test: BM25 MATCH single-char token");
+
+    assert!(
+        results.is_empty(),
+        "single-char query token 'a' is dropped ⇒ empty query ⇒ no results, got {}",
+        results.len()
+    );
+}

--- a/crates/velesdb-core/tests/bdd/fusion_rrf_conformance.rs
+++ b/crates/velesdb-core/tests/bdd/fusion_rrf_conformance.rs
@@ -1,0 +1,179 @@
+//! Conformance tests for the fusion engine's reciprocal-rank-fusion family.
+//!
+//! Surface = engine API: [`velesdb_core::FusionStrategy::fuse`] over controlled
+//! `(id, score)` branch lists. These pin the EXACT arithmetic of `RRF`
+//! (1-based, unweighted) and `WeightedRRF` (0-based, per-branch weights),
+//! including the fact that the two RRF implementations deliberately differ.
+//!
+//! Determinism note: `fuse` sorts UNSTABLE with no id tie-break, so we only
+//! assert id ORDER for strictly-distinct scores and assert score VALUES via
+//! `approx_eq` everywhere.
+
+use velesdb_core::{FusionError, FusionStrategy};
+
+use super::helpers::approx_eq;
+
+/// The two fixed two-branch inputs used by the RRF / WeightedRRF scenarios.
+/// Branch A ranks docs 10,20,30; branch B ranks docs 20,30,40.
+fn two_branch_input() -> Vec<Vec<(u64, f32)>> {
+    vec![
+        vec![(10, 0.9), (20, 0.8), (30, 0.7)],
+        vec![(20, 0.9), (30, 0.8), (40, 0.7)],
+    ]
+}
+
+/// Look up a single document's fused score in the result list.
+fn score_of(fused: &[(u64, f32)], id: u64) -> f32 {
+    fused
+        .iter()
+        .find(|(d, _)| *d == id)
+        .map(|(_, s)| *s)
+        .expect("test: doc present in fused output")
+}
+
+/// The id order of the fused result list.
+fn order_of(fused: &[(u64, f32)]) -> Vec<u64> {
+    fused.iter().map(|(d, _)| *d).collect()
+}
+
+/// RRF{k=60} is 1-based: score = Σ 1/(60 + rank0 + 1).
+/// Ground truth (f32): doc20=1/61+1/60=0.0325224, doc30=1/62+1/61=0.0320020,
+/// doc10=1/61=0.0163934, doc40=1/63=0.0158730.
+#[test]
+fn rrf_k60_scores_and_order_are_one_based() {
+    let fused = FusionStrategy::RRF { k: 60 }
+        .fuse(two_branch_input())
+        .expect("test: rrf k60 fuse");
+
+    // Strictly-distinct scores -> id order is well defined.
+    assert_eq!(order_of(&fused), vec![20, 30, 10, 40]);
+    assert!(approx_eq(score_of(&fused, 20), 0.032_522_473, 1e-5));
+    assert!(approx_eq(score_of(&fused, 30), 0.032_002_046, 1e-5));
+    assert!(approx_eq(score_of(&fused, 10), 0.016_393_442, 1e-5));
+    assert!(approx_eq(score_of(&fused, 40), 0.015_873_017, 1e-5));
+}
+
+/// RRF{k=1} is still 1-based: score = Σ 1/(1 + rank0 + 1).
+/// Ground truth (f32): doc20=1/2+1/3=0.833333, doc30=1/3+1/4=0.583333,
+/// doc10=1/2=0.5, doc40=1/4=0.25.
+#[test]
+fn rrf_k1_scores_and_order() {
+    let fused = FusionStrategy::RRF { k: 1 }
+        .fuse(two_branch_input())
+        .expect("test: rrf k1 fuse");
+
+    assert_eq!(order_of(&fused), vec![20, 30, 10, 40]);
+    assert!(approx_eq(score_of(&fused, 20), 0.833_333_3, 1e-5));
+    assert!(approx_eq(score_of(&fused, 30), 0.583_333_3, 1e-5));
+    assert!(approx_eq(score_of(&fused, 10), 0.5, 1e-5));
+    assert!(approx_eq(score_of(&fused, 40), 0.25, 1e-5));
+}
+
+/// `rrf_default()` is exactly `RRF{k:60}` — same scores as the k=60 case.
+/// Ground truth: doc20 = 1/61 + 1/60 = 0.0325224 (f32).
+#[test]
+fn rrf_default_equals_k60() {
+    let fused = FusionStrategy::rrf_default()
+        .fuse(two_branch_input())
+        .expect("test: rrf_default fuse");
+
+    assert_eq!(FusionStrategy::rrf_default(), FusionStrategy::RRF { k: 60 });
+    assert!(approx_eq(score_of(&fused, 20), 0.032_522_473, 1e-5));
+}
+
+/// `WeightedRRF` is 0-based: score = Σ weights[i]/(rank0_i + k); with equal
+/// 0.5 weights and k=60 these scores DIFFER from the 1-based `RRF{60}`.
+/// Ground truth (f32): doc20=0.5/61+0.5/60=0.0165301, doc30=0.5/62+0.5/61=0.0162612,
+/// doc10=0.5/60=0.0083333, doc40=0.5/62=0.0080645. Distinct from RRF{60} doc20=0.0325224.
+#[test]
+fn weighted_rrf_is_zero_based_and_differs_from_rrf() {
+    let fused = FusionStrategy::weighted_rrf(vec![0.5, 0.5], 60.0)
+        .expect("test: weighted_rrf ctor")
+        .fuse(two_branch_input())
+        .expect("test: weighted_rrf fuse");
+
+    assert_eq!(order_of(&fused), vec![20, 30, 10, 40]);
+    assert!(approx_eq(score_of(&fused, 20), 0.016_530_056, 1e-6));
+    assert!(approx_eq(score_of(&fused, 30), 0.016_261_237, 1e-6));
+    assert!(approx_eq(score_of(&fused, 10), 0.008_333_334, 1e-6));
+    assert!(approx_eq(score_of(&fused, 40), 0.008_064_516, 1e-6));
+
+    // The 0-based WeightedRRF and the 1-based RRF{60} are genuinely different
+    // formulas: doc20 is 0.0165301 here vs 0.0325224 under RRF{60}.
+    let rrf60 = FusionStrategy::RRF { k: 60 }
+        .fuse(two_branch_input())
+        .expect("test: rrf60 fuse");
+    assert!(!approx_eq(score_of(&fused, 20), score_of(&rrf60, 20), 1e-4));
+}
+
+/// `WeightedRRF` weights bias toward the higher-weighted branch (0-based).
+/// Input: branchA[(1,_),(2,_)] weight 0.9, branchB[(2,_),(1,_)] weight 0.1, k=60.
+/// Ground truth (f32): doc1=0.9/60+0.1/61=0.0166393, doc2=0.9/61+0.1/60=0.0164208;
+/// doc1 wins because it is rank0 in the heavier branch.
+#[test]
+fn weighted_rrf_asymmetric_weights_favor_heavy_branch() {
+    let input = vec![
+        vec![(1u64, 9.0f32), (2, 8.0)],
+        vec![(2u64, 9.0f32), (1, 8.0)],
+    ];
+    let fused = FusionStrategy::weighted_rrf(vec![0.9, 0.1], 60.0)
+        .expect("test: weighted_rrf ctor")
+        .fuse(input)
+        .expect("test: weighted_rrf fuse");
+
+    assert_eq!(order_of(&fused), vec![1, 2]);
+    assert!(approx_eq(score_of(&fused, 1), 0.016_639_344, 1e-6));
+    assert!(approx_eq(score_of(&fused, 2), 0.016_420_765, 1e-6));
+}
+
+/// Validation: a 1-weight `WeightedRRF` fed 2 branches errors at `fuse` with
+/// `WeightCountMismatch` (the ctor does NOT check branch count, only `fuse` does).
+/// Ground truth: `fuse_weighted_rrf` returns `Err(WeightCountMismatch{1,2})`.
+#[test]
+fn weighted_rrf_weight_count_mismatch_errors_at_fuse() {
+    let strategy = FusionStrategy::weighted_rrf(vec![0.5], 60.0).expect("test: 1-weight ctor ok");
+    let err = strategy.fuse(two_branch_input());
+    assert!(matches!(
+        err,
+        Err(FusionError::WeightCountMismatch {
+            weights: 1,
+            branches: 2
+        })
+    ));
+}
+
+/// Validation: a negative weight is rejected by the `weighted_rrf` constructor.
+/// Ground truth: `validate_non_negative` returns `Err(NegativeWeight)` before any fuse.
+#[test]
+fn weighted_rrf_negative_weight_rejected_at_construction() {
+    let result = FusionStrategy::weighted_rrf(vec![-0.1, 1.1], 60.0);
+    assert!(matches!(result, Err(FusionError::NegativeWeight { .. })));
+}
+
+/// Validation: k <= 0 is rejected by the `weighted_rrf` constructor
+/// (k=0 with a rank-0 hit would otherwise produce an infinite score).
+/// Ground truth: `weighted_rrf(vec![0.5,0.5], 0.0)` returns `Err(NegativeWeight{0.0})`.
+#[test]
+fn weighted_rrf_zero_k_rejected_at_construction() {
+    let result = FusionStrategy::weighted_rrf(vec![0.5, 0.5], 0.0);
+    assert!(matches!(result, Err(FusionError::NegativeWeight { .. })));
+}
+
+/// `fuse` on an empty branch list and on all-empty branches yields an empty
+/// result (not an error) regardless of strategy — a degenerate-input guard.
+/// Ground truth: `fuse` returns `Ok(Vec::new())` when no branch has any hit.
+#[test]
+fn rrf_empty_inputs_yield_empty_output() {
+    let empty: Vec<Vec<(u64, f32)>> = Vec::new();
+    let all_empty: Vec<Vec<(u64, f32)>> = vec![Vec::new(), Vec::new()];
+
+    let r1 = FusionStrategy::RRF { k: 60 }
+        .fuse(empty)
+        .expect("test: empty fuse");
+    let r2 = FusionStrategy::RRF { k: 60 }
+        .fuse(all_empty)
+        .expect("test: all-empty fuse");
+
+    assert!(r1.is_empty());
+    assert!(r2.is_empty());
+}

--- a/crates/velesdb-core/tests/bdd/fusion_weighted_bug.rs
+++ b/crates/velesdb-core/tests/bdd/fusion_weighted_bug.rs
@@ -1,0 +1,178 @@
+//! BDD tests for the two "Weighted" fusion bugs plus the correct engine-level
+//! Weighted behavior.
+//!
+//! Two regression locks document live bugs by asserting the CURRENT (buggy)
+//! behavior; their doc-comments state what the CORRECT behavior would be:
+//! - Bug A (`sparse_dispatch.rs:204`): SQL `USING FUSION(strategy='weighted')`
+//!   is silently downgraded to `RRF{k:60}` — it never reaches the engine's
+//!   `FusionStrategy::Weighted`.
+//! - Bug B (`score_fusion/mod.rs:248`): the per-result `ScoreFusionMethod::Weighted`
+//!   combiner uses equal weights, so it is identical to `Average`.
+//!
+//! The first two tests pin the CORRECT engine-level `FusionStrategy::weighted`
+//! ranking + its validation, so the contrast with the bugs is explicit.
+
+use std::collections::BTreeMap;
+
+use serde_json::json;
+use velesdb_core::collection::search::query::score_fusion::{ScoreBreakdown, ScoreFusionMethod};
+use velesdb_core::sparse_index::SparseVector;
+use velesdb_core::{DistanceMetric, FusionStrategy, Point};
+
+use super::helpers::{approx_eq, create_test_db, execute_sql};
+
+/// CORRECT engine-level Weighted fusion: per-doc combined =
+/// avg_w*avg + max_w*max + hit_w*(hits/total_queries).
+///
+/// Ground truth (hand-computed, weights 0.6/0.3/0.1):
+/// branch0=[(1,0.95),(2,0.80)], branch1=[(2,0.95),(1,0.70)].
+/// doc1: avg=(0.95+0.70)/2=0.825, max=0.95, hit=2/2=1.0 ->
+///       0.6*0.825+0.3*0.95+0.1*1.0 = 0.880.
+/// doc2: avg=(0.80+0.95)/2=0.875, max=0.95, hit=1.0 -> 0.910.
+/// Scores are strictly distinct, so id ORDER [2,1] is deterministic.
+#[test]
+fn test_engine_weighted_fusion_correct_ranking() {
+    let strategy = FusionStrategy::weighted(0.6, 0.3, 0.1).expect("test: valid weighted strategy");
+
+    let fused = strategy
+        .fuse(vec![vec![(1, 0.95), (2, 0.80)], vec![(2, 0.95), (1, 0.70)]])
+        .expect("test: fuse weighted");
+
+    let ids: Vec<u64> = fused.iter().map(|(id, _)| *id).collect();
+    assert_eq!(ids, vec![2, 1], "doc2 (0.910) ranks above doc1 (0.880)");
+
+    let score = |target: u64| fused.iter().find(|(id, _)| *id == target).map(|(_, s)| *s);
+    assert!(
+        approx_eq(score(2).expect("test: doc2 present"), 0.910, 1e-4),
+        "doc2 weighted score must be 0.910"
+    );
+    assert!(
+        approx_eq(score(1).expect("test: doc1 present"), 0.880, 1e-4),
+        "doc1 weighted score must be 0.880"
+    );
+}
+
+/// `FusionStrategy::weighted` rejects weights that do not sum to 1.0 and any
+/// negative weight; `fuse` re-validates so direct enum-literal construction
+/// cannot bypass validation.
+///
+/// Ground truth: sum 0.5+0.3+0.3=1.1 (>1.0±0.001) -> Err; a -0.1 weight -> Err;
+/// a literal `Weighted{0.5,0.3,0.3}` fused over a non-empty input -> Err.
+#[test]
+fn test_engine_weighted_validation_rejects_bad_weights() {
+    assert!(
+        FusionStrategy::weighted(0.5, 0.3, 0.3).is_err(),
+        "sum 1.1 must be rejected"
+    );
+    assert!(
+        FusionStrategy::weighted(-0.1, 0.6, 0.5).is_err(),
+        "negative weight must be rejected"
+    );
+
+    let bypass = FusionStrategy::Weighted {
+        avg_weight: 0.5,
+        max_weight: 0.3,
+        hit_weight: 0.3,
+    };
+    assert!(
+        bypass.fuse(vec![vec![(1u64, 0.9f32)]]).is_err(),
+        "fuse must re-validate the literal-constructed bad-sum Weighted"
+    );
+}
+
+/// REGRESSION LOCK — Bug B (`score_fusion/mod.rs:248`).
+///
+/// `ScoreFusionMethod::Weighted` uses equal weights (1/n per component), so for
+/// a breakdown with vector_similarity=0.9 and sparse_score=0.3 it computes
+/// 0.9*0.5 + 0.3*0.5 = 0.6 — identical to `Average` = (0.9+0.3)/2 = 0.6.
+///
+/// CORRECT behavior: a TRUE weighted combiner (e.g. w_vec=0.75, w_sparse=0.25)
+/// would yield 0.9*0.75 + 0.3*0.25 = 0.75, NOT 0.6, and would differ from
+/// Average. This test PASSES against the current buggy equal-weight behavior.
+#[test]
+fn test_score_fusion_weighted_equals_average_bug_b() {
+    let breakdown = ScoreBreakdown {
+        vector_similarity: Some(0.9),
+        sparse_score: Some(0.3),
+        ..Default::default()
+    };
+
+    let weighted = ScoreFusionMethod::Weighted.combine(&breakdown);
+    let average = ScoreFusionMethod::Average.combine(&breakdown);
+
+    assert!(
+        approx_eq(weighted, 0.6, 1e-6),
+        "buggy Weighted combiner yields equal-weight mean 0.6"
+    );
+    assert!(
+        approx_eq(weighted, average, 1e-6),
+        "Bug B: Weighted is indistinguishable from Average"
+    );
+}
+
+/// Builds the dim-2 hybrid collection 'wb' used by the Bug A lock:
+/// id1 dense [1,0] / sparse {10:1.0}; id2 dense [0,1] / sparse {10:9.0}.
+fn setup_wb_collection(db: &velesdb_core::Database) {
+    db.create_vector_collection("wb", 2, DistanceMetric::Cosine)
+        .expect("test: create wb");
+    let vc = db.get_vector_collection("wb").expect("test: get wb");
+
+    let mut sparse1 = BTreeMap::new();
+    sparse1.insert(String::new(), SparseVector::new(vec![(10, 1.0)]));
+    let mut sparse2 = BTreeMap::new();
+    sparse2.insert(String::new(), SparseVector::new(vec![(10, 9.0)]));
+
+    vc.upsert(vec![
+        Point {
+            id: 1,
+            vector: vec![1.0, 0.0],
+            payload: Some(json!({"content": "doc one"})),
+            sparse_vectors: Some(sparse1),
+        },
+        Point {
+            id: 2,
+            vector: vec![0.0, 1.0],
+            payload: Some(json!({"content": "doc two"})),
+            sparse_vectors: Some(sparse2),
+        },
+    ])
+    .expect("test: upsert wb");
+}
+
+/// REGRESSION LOCK — Bug A (`sparse_dispatch.rs:204`).
+///
+/// SQL `USING FUSION(strategy='weighted')` is silently downgraded to
+/// `RRF{k:60}` (the only SQL path reaching the engine fusion). With dense
+/// ranking id1 first and sparse ranking id2 first, RRF is a symmetric tie:
+/// each doc = 1/(60+1) + 1/(60+2) = 0.0325225. We assert the returned scores
+/// equal that RRF value, proving the SQL ran RRF, NOT engine Weighted.
+///
+/// CORRECT behavior: a real 'weighted' SQL strategy would invoke
+/// `FusionStrategy::Weighted` and produce the avg/max/hit combination instead
+/// of an RRF tie. The tie means id order is non-deterministic — we assert
+/// scores only, never id order.
+#[test]
+fn test_sql_weighted_strategy_downgrades_to_rrf_bug_a() {
+    let (_dir, db) = create_test_db();
+    setup_wb_collection(&db);
+
+    let results = execute_sql(
+        &db,
+        "SELECT * FROM wb WHERE vector NEAR [1.0, 0.0] AND vector SPARSE_NEAR {10: 1.0} \
+         LIMIT 2 USING FUSION(strategy = 'weighted')",
+    )
+    .expect("test: execute hybrid weighted query");
+
+    assert_eq!(
+        results.len(),
+        2,
+        "both docs surface across the two branches"
+    );
+    for r in &results {
+        assert!(
+            approx_eq(r.score, 0.032_522_5, 1e-4),
+            "Bug A: SQL 'weighted' ran RRF{{60}} -> symmetric tie 0.0325225, got {}",
+            r.score
+        );
+    }
+}

--- a/crates/velesdb-core/tests/bdd/hybrid_vector_first_exact.rs
+++ b/crates/velesdb-core/tests/bdd/hybrid_vector_first_exact.rs
@@ -1,0 +1,328 @@
+//! BDD tests pinning the EXACT ordered result of vector-first hybrid queries
+//! (NEAR + graph MATCH, with and without a scalar filter).
+//!
+//! `match_vector_first.rs` only asserts membership (`ids.contains(&n)`); these
+//! tests lock the FULL ordered id list and the exact complement set, so any
+//! regression in similarity ranking, graph anchoring, or scalar filtering is
+//! caught — not just a dropped/added row.
+//!
+//! All ground truth is hand-computed from a controlled dataset: vectors are
+//! `[1, off, 0, 0]` with strictly increasing `off`, so cosine similarity to the
+//! query `[1, 0, 0, 0]` strictly DECREASES with `off`. The CITES graph and the
+//! `category` payload are fully enumerated below, so the expected ordered ids
+//! are deterministic.
+
+use serde_json::json;
+use velesdb_core::{Database, GraphEdge, Point};
+
+use super::helpers::{
+    create_test_db, execute_sql, execute_sql_with_params, result_ids, vector_param,
+};
+
+// =========================================================================
+// Module-specific setup
+// =========================================================================
+
+/// Builds the `bibliography` collection (4-dim, cosine).
+///
+/// Vectors are `[1, off, 0, 0]`; cosine similarity to the query `[1, 0, 0, 0]`
+/// strictly DECREASES as `off` increases, so the full similarity order
+/// (descending) of the candidate nodes is `1 > 2 > 3 > 4 > 5`, and the hub
+/// (id 100, vector `[0, 0, 1, 0]`, cosine 0) is the least similar of all.
+///
+/// | id  | off | category | outgoing CITES |
+/// |-----|-----|----------|----------------|
+/// | 1   | 0.0 | physics  | yes (-> 100)   |
+/// | 2   | 0.3 | physics  | no             |
+/// | 3   | 0.7 | biology  | yes (-> 100)   |
+/// | 4   | 1.2 | physics  | yes (-> 100)   |
+/// | 5   | 3.0 | biology  | no             |
+/// | 100 | hub | --       | no             |
+///
+/// Citing nodes = {1, 3, 4}; non-citing nodes = {2, 5, 100}.
+fn setup_bibliography(db: &Database) {
+    db.create_vector_collection("bibliography", 4, velesdb_core::DistanceMetric::Cosine)
+        .expect("test: create bibliography collection");
+    let vc = db
+        .get_vector_collection("bibliography")
+        .expect("test: get bibliography collection");
+
+    vc.upsert(vec![
+        Point::new(
+            1,
+            vec![1.0, 0.0, 0.0, 0.0],
+            Some(json!({"category": "physics"})),
+        ),
+        Point::new(
+            2,
+            vec![1.0, 0.3, 0.0, 0.0],
+            Some(json!({"category": "physics"})),
+        ),
+        Point::new(
+            3,
+            vec![1.0, 0.7, 0.0, 0.0],
+            Some(json!({"category": "biology"})),
+        ),
+        Point::new(
+            4,
+            vec![1.0, 1.2, 0.0, 0.0],
+            Some(json!({"category": "physics"})),
+        ),
+        Point::new(
+            5,
+            vec![1.0, 3.0, 0.0, 0.0],
+            Some(json!({"category": "biology"})),
+        ),
+        Point::new(
+            100,
+            vec![0.0, 0.0, 1.0, 0.0],
+            Some(json!({"category": "hub"})),
+        ),
+    ])
+    .expect("test: upsert bibliography corpus");
+
+    // Only nodes 1, 3, 4 cite the hub. 2 and 5 cite nothing.
+    for (edge_id, source) in [(900u64, 1u64), (901, 3), (902, 4)] {
+        let edge = GraphEdge::new(edge_id, source, 100, "CITES").expect("test: create CITES edge");
+        vc.add_edge(edge).expect("test: add CITES edge");
+    }
+}
+
+/// Collects the ordered ids of a result list (order is meaningful here because
+/// the similarity ranking is unambiguous over well-separated offsets).
+fn ordered_ids(results: &[velesdb_core::SearchResult]) -> Vec<u64> {
+    results.iter().map(|r| r.point.id).collect()
+}
+
+const QUERY: [f32; 4] = [1.0, 0.0, 0.0, 0.0];
+
+// =========================================================================
+// A. NEAR + MATCH (vector-first hybrid) — exact ordered ids
+// =========================================================================
+
+/// GIVEN the bibliography corpus (citing nodes {1,3,4}, sim order 1>2>3>4>5)
+/// WHEN `vector NEAR $v AND MATCH (a)-[:CITES]->(x)`
+/// THEN exactly the citing nodes are returned, ordered by similarity DESC:
+///      the off offsets 0.0 < 0.7 < 1.2 give cosine 1>3>4, so ids = [1, 3, 4].
+#[test]
+fn test_near_and_match_returns_exact_ordered_citing_ids() {
+    let (_dir, db) = create_test_db();
+    setup_bibliography(&db);
+
+    let sql = "SELECT * FROM bibliography AS a \
+               WHERE vector NEAR $v AND MATCH (a)-[:CITES]->(x) LIMIT 10";
+    let results = execute_sql_with_params(&db, sql, &vector_param(&QUERY))
+        .expect("NEAR + MATCH must execute");
+
+    assert_eq!(
+        ordered_ids(&results),
+        vec![1, 3, 4],
+        "only citing nodes {{1,3,4}}, in strict similarity order"
+    );
+    for w in results.windows(2) {
+        assert!(w[0].score >= w[1].score, "scores must be non-increasing");
+    }
+}
+
+/// GIVEN the corpus, with the most similar citing node restricted by LIMIT
+/// WHEN `vector NEAR $v AND MATCH (a)-[:CITES]->(x) LIMIT 1`
+/// THEN only id 1 comes back (off 0.0 is the closest of {1,3,4} to the query).
+#[test]
+fn test_near_and_match_limit_one_keeps_most_similar_citer() {
+    let (_dir, db) = create_test_db();
+    setup_bibliography(&db);
+
+    let sql = "SELECT * FROM bibliography AS a \
+               WHERE vector NEAR $v AND MATCH (a)-[:CITES]->(x) LIMIT 1";
+    let results = execute_sql_with_params(&db, sql, &vector_param(&QUERY))
+        .expect("NEAR + MATCH LIMIT 1 must execute");
+
+    assert_eq!(ordered_ids(&results), vec![1], "best-similarity citer only");
+}
+
+/// GIVEN the corpus, ordered explicitly by similarity DESC with a prefix LIMIT
+/// WHEN `... AND MATCH (a)-[:CITES]->(x) ORDER BY similarity() DESC LIMIT 2`
+/// THEN exactly the top-2 citing nodes: ids [1, 3] (off 0.0 then 0.7; 4 drops).
+#[test]
+fn test_near_match_orderby_similarity_limit_keeps_exact_prefix() {
+    let (_dir, db) = create_test_db();
+    setup_bibliography(&db);
+
+    let sql = "SELECT a.*, similarity() FROM bibliography AS a \
+               WHERE vector NEAR $v AND MATCH (a)-[:CITES]->(x) \
+               ORDER BY similarity() DESC LIMIT 2";
+    let results = execute_sql_with_params(&db, sql, &vector_param(&QUERY))
+        .expect("NEAR + MATCH + ORDER BY similarity() DESC must execute");
+
+    assert_eq!(
+        ordered_ids(&results),
+        vec![1, 3],
+        "top-2 citing nodes by similarity, id 4 truncated by LIMIT"
+    );
+    assert!(
+        results[0].score >= results[1].score,
+        "ORDER BY similarity() DESC must hold"
+    );
+}
+
+// =========================================================================
+// B. NEAR + MATCH + scalar filter (triple hybrid) — exact ordered ids
+// =========================================================================
+
+/// GIVEN the corpus (physics citers = {1,4}; 3 is biology, 2 doesn't cite)
+/// WHEN `vector NEAR $v AND MATCH (a)-[:CITES]->(x) AND category = 'physics'`
+/// THEN exactly ids [1, 4] in similarity order (off 0.0 < 1.2 → 1 before 4).
+#[test]
+fn test_near_match_scalar_physics_returns_exact_ordered_ids() {
+    let (_dir, db) = create_test_db();
+    setup_bibliography(&db);
+
+    let sql = "SELECT * FROM bibliography AS a \
+               WHERE vector NEAR $v AND MATCH (a)-[:CITES]->(x) \
+               AND category = 'physics' LIMIT 10";
+    let results = execute_sql_with_params(&db, sql, &vector_param(&QUERY))
+        .expect("NEAR + MATCH + scalar must execute");
+
+    assert_eq!(
+        ordered_ids(&results),
+        vec![1, 4],
+        "physics citers {{1,4}} in similarity order; biology citer 3 excluded"
+    );
+    for w in results.windows(2) {
+        assert!(w[0].score >= w[1].score, "scores must be non-increasing");
+    }
+}
+
+/// GIVEN the corpus (biology citers = {3} only; 5 is biology but doesn't cite)
+/// WHEN `... AND MATCH (a)-[:CITES]->(x) AND category = 'biology'`
+/// THEN exactly [3]: it is the sole node that is BOTH a citer AND biology.
+#[test]
+fn test_near_match_scalar_biology_returns_single_id() {
+    let (_dir, db) = create_test_db();
+    setup_bibliography(&db);
+
+    let sql = "SELECT * FROM bibliography AS a \
+               WHERE vector NEAR $v AND MATCH (a)-[:CITES]->(x) \
+               AND category = 'biology' LIMIT 10";
+    let results = execute_sql_with_params(&db, sql, &vector_param(&QUERY))
+        .expect("NEAR + MATCH + biology scalar must execute");
+
+    assert_eq!(
+        ordered_ids(&results),
+        vec![3],
+        "id 3 is the only biology citer (5 is biology but cites nothing)"
+    );
+}
+
+// =========================================================================
+// C. NEAR + NOT MATCH — exact complement, by similarity
+// =========================================================================
+
+/// GIVEN the corpus (non-citing nodes = {2, 5, 100})
+/// WHEN `vector NEAR $v AND NOT MATCH (a)-[:CITES]->(x)`
+/// THEN exactly the non-citers, ordered by similarity DESC: id 2 (off 0.3) >
+///      id 5 (off 3.0) > id 100 (cosine 0). This is the exact complement of
+///      the citing set {1,3,4} from `test_near_and_match_*`.
+#[test]
+fn test_near_not_match_returns_exact_complement_by_similarity() {
+    let (_dir, db) = create_test_db();
+    setup_bibliography(&db);
+
+    let sql = "SELECT * FROM bibliography AS a \
+               WHERE vector NEAR $v AND NOT MATCH (a)-[:CITES]->(x) LIMIT 10";
+    let results = execute_sql_with_params(&db, sql, &vector_param(&QUERY))
+        .expect("NEAR + NOT MATCH must execute");
+
+    assert_eq!(
+        ordered_ids(&results),
+        vec![2, 5, 100],
+        "non-citing nodes in similarity order; complement of {{1,3,4}}"
+    );
+    for w in results.windows(2) {
+        assert!(w[0].score >= w[1].score, "scores must be non-increasing");
+    }
+}
+
+/// GIVEN the corpus
+/// WHEN the positive and the negated MATCH are run with the same NEAR
+/// THEN their id sets are disjoint and their union is the whole collection —
+///      proving NOT MATCH is the exact complement of MATCH over the candidates.
+#[test]
+fn test_near_match_and_not_match_partition_the_collection() {
+    let (_dir, db) = create_test_db();
+    setup_bibliography(&db);
+
+    let positive = execute_sql_with_params(
+        &db,
+        "SELECT * FROM bibliography AS a WHERE vector NEAR $v AND MATCH (a)-[:CITES]->(x) LIMIT 10",
+        &vector_param(&QUERY),
+    )
+    .expect("positive MATCH must execute");
+    let negative = execute_sql_with_params(
+        &db,
+        "SELECT * FROM bibliography AS a WHERE vector NEAR $v AND NOT MATCH (a)-[:CITES]->(x) LIMIT 10",
+        &vector_param(&QUERY),
+    )
+    .expect("NOT MATCH must execute");
+
+    let pos = result_ids(&positive);
+    let neg = result_ids(&negative);
+    assert!(
+        pos.is_disjoint(&neg),
+        "MATCH and NOT MATCH must not overlap"
+    );
+    let union: std::collections::HashSet<u64> = pos.union(&neg).copied().collect();
+    assert_eq!(
+        union,
+        [1u64, 2, 3, 4, 5, 100].into_iter().collect(),
+        "MATCH | NOT MATCH must cover every node"
+    );
+}
+
+// =========================================================================
+// D. MATCH (and MATCH + scalar) WITHOUT NEAR — exact set
+// =========================================================================
+
+/// GIVEN the corpus (citing nodes = {1, 3, 4})
+/// WHEN `MATCH (a)-[:CITES]->(x)` with NO NEAR (graph-only retrieval)
+/// THEN the exact citing set {1, 3, 4} is returned (order is graph-scan driven,
+///      so we assert the set, not the order).
+#[test]
+fn test_match_without_near_returns_exact_citing_set() {
+    let (_dir, db) = create_test_db();
+    setup_bibliography(&db);
+
+    let results = execute_sql(
+        &db,
+        "SELECT * FROM bibliography AS a WHERE MATCH (a)-[:CITES]->(x) LIMIT 10",
+    )
+    .expect("MATCH without NEAR must execute");
+
+    assert_eq!(
+        result_ids(&results),
+        [1u64, 3, 4].into_iter().collect(),
+        "exactly the nodes with an outgoing CITES edge"
+    );
+}
+
+/// GIVEN the corpus (physics citers = {1, 4})
+/// WHEN `category = 'physics' AND MATCH (a)-[:CITES]->(x)` with NO NEAR
+/// THEN the exact set {1, 4}: the intersection of physics and the citers.
+#[test]
+fn test_match_scalar_without_near_returns_exact_set() {
+    let (_dir, db) = create_test_db();
+    setup_bibliography(&db);
+
+    let results = execute_sql(
+        &db,
+        "SELECT * FROM bibliography AS a \
+         WHERE category = 'physics' AND MATCH (a)-[:CITES]->(x) LIMIT 10",
+    )
+    .expect("metadata + MATCH without NEAR must execute");
+
+    assert_eq!(
+        result_ids(&results),
+        [1u64, 4].into_iter().collect(),
+        "physics AND citing = {{1,4}} (3 is biology, 2 cites nothing)"
+    );
+}

--- a/crates/velesdb-core/tests/bdd/match_traversal_exact.rs
+++ b/crates/velesdb-core/tests/bdd/match_traversal_exact.rs
@@ -1,0 +1,288 @@
+//! BDD tests pinning variable-length GRAPH TRAVERSAL result-sets EXACTLY.
+//!
+//! These tests fix the contract of var-length MATCH patterns
+//! (`-[:REL*m..n]->`) against a single hand-computed graph, so any regression
+//! in reachability, hop bounds, direction, edge-type union, edge-property
+//! filtering, or negation is caught by an exact assertion.
+//!
+//! Two execution forms are exercised (both verified against the codebase):
+//!
+//! 1. Bare `MATCH (a:Start)-[...]->(c) RETURN c` routed via the `_collection`
+//!    param. Per the MATCH execution contract,
+//!    `SearchResult.point.id == traversal_result.target_id` (the TERMINAL node
+//!    of each branch); the start node lives in the `_bindings` map.
+//! 2. `SELECT * FROM <coll> AS <alias> WHERE NOT MATCH (ctx)-[:REL]->(x)` —
+//!    NOT MATCH returns the FROM rows whose anchor has NO matching outgoing
+//!    edge (the complement of the source set).
+//!
+//! ## The graph (one fixed topology for every test)
+//!
+//! ```text
+//!   (1:Start) -[:KNOWS {w:10}]-> (2) -[:KNOWS {w:20}]-> (3) -[:KNOWS {w:30}]-> (4)
+//!   (1:Start) -[:FRIEND {w:50}]-> (5)
+//! ```
+//!
+//! Edge ids: 100 (1->2), 101 (2->3), 102 (3->4) all KNOWS; 103 (1->5) FRIEND.
+//! Node 1 is the only `Start`-labeled node, so it is the unique anchor.
+//!
+//! KNOWS-reachability from node 1 by hop count:
+//!   * hop 1: {2}      (1->2)
+//!   * hop 2: {3}      (1->2->3)
+//!   * hop 3: {4}      (1->2->3->4)
+//! FRIEND-reachability from node 1: hop 1 = {5}.
+
+use std::collections::HashMap;
+
+use serde_json::json;
+use velesdb_core::{Database, GraphEdge, Point, SearchResult};
+
+use super::helpers::{create_test_db, execute_sql, result_ids};
+
+// =========================================================================
+// Fixed topology + execution helpers
+// =========================================================================
+
+/// Builds the fixed `social` graph described in the module doc-comment.
+fn setup_social_graph(db: &Database) {
+    db.create_vector_collection("social", 4, velesdb_core::DistanceMetric::Cosine)
+        .expect("test: create social collection");
+    let vc = db
+        .get_vector_collection("social")
+        .expect("test: get social collection");
+
+    vc.upsert(vec![
+        Point::new(
+            1,
+            vec![1.0, 0.0, 0.0, 0.0],
+            Some(json!({"_labels": ["Start"], "name": "A"})),
+        ),
+        Point::new(2, vec![0.0, 1.0, 0.0, 0.0], Some(json!({"name": "B"}))),
+        Point::new(3, vec![0.0, 0.0, 1.0, 0.0], Some(json!({"name": "C"}))),
+        Point::new(4, vec![0.0, 0.0, 0.0, 1.0], Some(json!({"name": "D"}))),
+        Point::new(5, vec![1.0, 1.0, 0.0, 0.0], Some(json!({"name": "E"}))),
+    ])
+    .expect("test: upsert social nodes");
+
+    for (edge_id, src, dst, label, w) in [
+        (100u64, 1u64, 2u64, "KNOWS", 10),
+        (101, 2, 3, "KNOWS", 20),
+        (102, 3, 4, "KNOWS", 30),
+        (103, 1, 5, "FRIEND", 50),
+    ] {
+        let mut props = HashMap::new();
+        props.insert("w".to_string(), json!(w));
+        let edge = GraphEdge::new(edge_id, src, dst, label)
+            .expect("test: create social edge")
+            .with_properties(props);
+        vc.add_edge(edge).expect("test: add social edge");
+    }
+}
+
+/// Routes a bare-MATCH query to the `social` collection.
+fn social_param() -> HashMap<String, serde_json::Value> {
+    let mut params = HashMap::new();
+    params.insert("_collection".to_string(), json!("social"));
+    params
+}
+
+/// Parses and executes a bare `MATCH ... RETURN` query against `social`.
+fn run(db: &Database, sql: &str) -> Vec<SearchResult> {
+    let query = velesdb_core::velesql::Parser::parse(sql).expect("test: parse MATCH query");
+    db.execute_query(&query, &social_param())
+        .expect("test: execute MATCH query")
+}
+
+// =========================================================================
+// 1..7. Exact var-length traversal result-sets
+// =========================================================================
+
+/// GIVEN the fixed graph
+/// WHEN matching `(a:Start)-[:KNOWS*1..1]->(c)` from the start anchor (node 1)
+/// THEN the terminal-node set is exactly {2}: node 1 has one KNOWS edge
+///      (1->2), so the only 1-hop KNOWS target is node 2.
+#[test]
+fn test_var_length_one_hop_exact_set() {
+    let (_dir, db) = create_test_db();
+    setup_social_graph(&db);
+
+    let results = run(&db, "MATCH (a:Start)-[:KNOWS*1..1]->(c) RETURN c LIMIT 10");
+
+    assert_eq!(
+        result_ids(&results),
+        [2u64].into_iter().collect(),
+        "the only 1-hop KNOWS target from node 1 is node 2"
+    );
+}
+
+/// GIVEN the fixed graph
+/// WHEN matching `(a:Start)-[:KNOWS*2..2]->(c)`
+/// THEN the terminal-node set is exactly {3}: the unique 2-hop KNOWS path is
+///      1->2->3, so node 3 is the only target (node 2 at hop 1 is excluded).
+#[test]
+fn test_var_length_two_hop_exact_set() {
+    let (_dir, db) = create_test_db();
+    setup_social_graph(&db);
+
+    let results = run(&db, "MATCH (a:Start)-[:KNOWS*2..2]->(c) RETURN c LIMIT 10");
+
+    assert_eq!(
+        result_ids(&results),
+        [3u64].into_iter().collect(),
+        "the only 2-hop KNOWS target from node 1 is node 3 (via 1->2->3)"
+    );
+}
+
+/// GIVEN the fixed graph
+/// WHEN matching `(a:Start)-[:KNOWS*1..3]->(c)`
+/// THEN the terminal-node set is the union over hops 1, 2 and 3:
+///      {2} ∪ {3} ∪ {4} = {2, 3, 4}. FRIEND target node 5 is excluded
+///      (wrong edge type).
+#[test]
+fn test_var_length_one_to_three_hops_exact_union() {
+    let (_dir, db) = create_test_db();
+    setup_social_graph(&db);
+
+    let results = run(&db, "MATCH (a:Start)-[:KNOWS*1..3]->(c) RETURN c LIMIT 10");
+
+    assert_eq!(
+        result_ids(&results),
+        [2u64, 3, 4].into_iter().collect(),
+        "1..3 hop KNOWS reach is {{2,3,4}}; node 5 (FRIEND) is excluded"
+    );
+}
+
+/// GIVEN the fixed graph
+/// WHEN matching the UNDIRECTED `(a:Start)-[:KNOWS*2..2]-(c)`
+/// THEN the terminal-node set is exactly {1, 3}. From node 1, undirected
+///      2-hop KNOWS walks (no edge reused) are 1-2-3 (target 3) and the
+///      back-and-forth 1-2-1 is forbidden by relationship isomorphism; the
+///      only other 2-hop walk that returns to 1 would need a second distinct
+///      edge incident to node 2, which does not exist. With a directed graph
+///      treated undirected, node 1 reaches node 3 forward (1->2->3). Node 1
+///      itself is NOT a valid target (would reuse edge 100). So target = {3}.
+#[test]
+fn test_var_length_undirected_two_hop_exact_set() {
+    let (_dir, db) = create_test_db();
+    setup_social_graph(&db);
+
+    let results = run(&db, "MATCH (a:Start)-[:KNOWS*2..2]-(c) RETURN c LIMIT 10");
+
+    assert_eq!(
+        result_ids(&results),
+        [3u64].into_iter().collect(),
+        "undirected 2-hop KNOWS from node 1 reaches only node 3 (1-2-3); \
+         reusing edge 100 to bounce back to node 1 is forbidden"
+    );
+}
+
+/// GIVEN the fixed graph
+/// WHEN matching `(a:Start)-[r:KNOWS*1..3]->(c) WHERE r.w = 20`
+/// THEN ANY-element semantics keep only paths where some traversed edge has
+///      w=20. Edge 2->3 (id 101) carries w=20. The shortest path containing
+///      it is 1->2->3 (target 3); the 3-hop path 1->2->3->4 (target 4) also
+///      contains it. So the exact target set is {3, 4}.
+#[test]
+fn test_var_length_edge_property_filter_matches() {
+    let (_dir, db) = create_test_db();
+    setup_social_graph(&db);
+
+    let results = run(
+        &db,
+        "MATCH (a:Start)-[r:KNOWS*1..3]->(c) WHERE r.w = 20 RETURN c LIMIT 10",
+    );
+
+    assert_eq!(
+        result_ids(&results),
+        [3u64, 4].into_iter().collect(),
+        "paths containing the w=20 edge (2->3) terminate at nodes 3 and 4"
+    );
+}
+
+/// GIVEN the fixed graph
+/// WHEN matching `(a:Start)-[r:KNOWS*1..3]->(c) WHERE r.w = 999`
+/// THEN no traversed edge carries w=999, so ANY-element semantics reject
+///      every path: the result is empty.
+#[test]
+fn test_var_length_edge_property_filter_empty() {
+    let (_dir, db) = create_test_db();
+    setup_social_graph(&db);
+
+    let results = run(
+        &db,
+        "MATCH (a:Start)-[r:KNOWS*1..3]->(c) WHERE r.w = 999 RETURN c LIMIT 10",
+    );
+
+    assert!(
+        results.is_empty(),
+        "no KNOWS edge carries w=999, so every path is rejected, got {} row(s)",
+        results.len()
+    );
+}
+
+/// GIVEN the fixed graph
+/// WHEN matching the multi-type single-hop `(a:Start)-[:KNOWS|FRIEND*1..1]->(c)`
+/// THEN the union of edge types surfaces BOTH the KNOWS edge (1->2) and the
+///      FRIEND edge (1->5). Exact target set = {2, 5}.
+#[test]
+fn test_var_length_multi_type_union_exact_set() {
+    let (_dir, db) = create_test_db();
+    setup_social_graph(&db);
+
+    let results = run(
+        &db,
+        "MATCH (a:Start)-[:KNOWS|FRIEND*1..1]->(c) RETURN c LIMIT 10",
+    );
+
+    assert_eq!(
+        result_ids(&results),
+        [2u64, 5].into_iter().collect(),
+        "KNOWS|FRIEND 1-hop from node 1 reaches node 2 (KNOWS) and node 5 (FRIEND)"
+    );
+}
+
+/// GIVEN the fixed graph
+/// WHEN excluding the pattern with `NOT MATCH (ctx)-[:KNOWS]->(x)` over all
+///      `social` rows (implicit anchor binds `ctx` to the FROM rows)
+/// THEN only nodes WITHOUT an outgoing KNOWS edge survive. Outgoing KNOWS
+///      sources are {1, 2, 3}; the complement over {1,2,3,4,5} is {4, 5}.
+#[test]
+fn test_not_match_outgoing_knows_complement_set() {
+    let (_dir, db) = create_test_db();
+    setup_social_graph(&db);
+
+    let results = execute_sql(
+        &db,
+        "SELECT * FROM social AS node \
+         WHERE NOT MATCH (ctx)-[:KNOWS]->(x) LIMIT 20",
+    )
+    .expect("NOT MATCH with implicit anchor must execute");
+
+    assert_eq!(
+        result_ids(&results),
+        [4u64, 5].into_iter().collect(),
+        "nodes 4 and 5 are the only ones with NO outgoing KNOWS edge"
+    );
+}
+
+/// GIVEN the fixed graph
+/// WHEN excluding `NOT MATCH (ctx)-[:FRIEND]->(x)` over all `social` rows
+/// THEN only nodes WITHOUT an outgoing FRIEND edge survive. The single FRIEND
+///      source is node 1; the complement over {1,2,3,4,5} is {2, 3, 4, 5}.
+#[test]
+fn test_not_match_outgoing_friend_complement_set() {
+    let (_dir, db) = create_test_db();
+    setup_social_graph(&db);
+
+    let results = execute_sql(
+        &db,
+        "SELECT * FROM social AS node \
+         WHERE NOT MATCH (ctx)-[:FRIEND]->(x) LIMIT 20",
+    )
+    .expect("NOT MATCH with implicit anchor must execute");
+
+    assert_eq!(
+        result_ids(&results),
+        [2u64, 3, 4, 5].into_iter().collect(),
+        "node 1 is the only FRIEND source; its complement is {{2,3,4,5}}"
+    );
+}

--- a/crates/velesdb-core/tests/bdd/metrics_ranking_conformance.rs
+++ b/crates/velesdb-core/tests/bdd/metrics_ranking_conformance.rs
@@ -1,0 +1,328 @@
+//! Exact NEAR-ranking conformance for the three under-tested distance metrics:
+//! `DotProduct`, `Hamming`, and `Jaccard`. Cosine and Euclidean already have
+//! exact-order coverage in `near_exact_ranking.rs`; the recall floor for
+//! Euclidean/DotProduct lives in `recall_contract_multimetric.rs`. NOTHING
+//! previously exercised Hamming or Jaccard through a `VelesQL` query, and
+//! DotProduct had only a statistical recall test (no pinned order).
+//!
+//! Every dataset is tiny and hand-computed so the expected ranked id order and
+//! the user-visible `SearchResult.score` are deterministic ground truth.
+//! Sort directions (authoritative, `distance.rs` `higher_is_better`):
+//!   Hamming  = distance   -> ASCENDING  (lower count first)
+//!   Jaccard  = similarity -> DESCENDING (higher similarity first)
+//!   DotProduct = similarity -> DESCENDING (higher raw dot first)
+
+use velesdb_core::{Database, DistanceMetric, Point};
+
+use super::helpers::{approx_eq, create_test_db, execute_sql_with_params, vector_param};
+
+/// Run `SELECT * FROM <coll> WHERE vector NEAR $v ...` and return (id, score)
+/// pairs in result order.
+fn ranked(db: &Database, sql: &str, query: &[f32]) -> Vec<(u64, f32)> {
+    let params = vector_param(query);
+    let results = execute_sql_with_params(db, sql, &params).expect("test: execute NEAR query");
+    results.iter().map(|r| (r.point.id, r.score)).collect()
+}
+
+/// Just the ids, in result order.
+fn ids(pairs: &[(u64, f32)]) -> Vec<u64> {
+    pairs.iter().map(|(id, _)| *id).collect()
+}
+
+// ============================================================================
+// Hamming — distance, ascending (lower differing-bit count = nearer)
+// ============================================================================
+
+/// Builds a dim-4 binary (0.0/1.0) Hamming collection. Bit = component > 0.5.
+fn setup_hamming(db: &Database) {
+    db.create_vector_collection("ham", 4, DistanceMetric::Hamming)
+        .expect("test: create hamming collection");
+    let vc = db.get_vector_collection("ham").expect("test: get ham");
+    vc.upsert(vec![
+        Point::new(
+            1,
+            vec![1.0, 0.0, 1.0, 0.0],
+            Some(serde_json::json!({"cat": "a"})),
+        ),
+        Point::new(
+            2,
+            vec![1.0, 1.0, 1.0, 1.0],
+            Some(serde_json::json!({"cat": "b"})),
+        ),
+        Point::new(
+            3,
+            vec![0.0, 0.0, 1.0, 0.0],
+            Some(serde_json::json!({"cat": "a"})),
+        ),
+        Point::new(
+            4,
+            vec![0.0, 1.0, 0.0, 1.0],
+            Some(serde_json::json!({"cat": "b"})),
+        ),
+    ])
+    .expect("test: upsert ham");
+}
+
+/// GIVEN q=[1,0,1,0]. Differing-bit counts: id1=0, id3=1, id2=2, id4=4.
+/// THEN NEAR returns ascending-distance order [1,3,2,4] with scores 0,1,2,4.
+#[test]
+fn test_hamming_exact_ascending_order_and_counts() {
+    let (_dir, db) = create_test_db();
+    setup_hamming(&db);
+    let pairs = ranked(
+        &db,
+        "SELECT * FROM ham WHERE vector NEAR $v LIMIT 4",
+        &[1.0, 0.0, 1.0, 0.0],
+    );
+    assert_eq!(
+        ids(&pairs),
+        vec![1, 3, 2, 4],
+        "ascending differing-bit count"
+    );
+    let scores: Vec<f32> = pairs.iter().map(|(_, s)| *s).collect();
+    for (got, want) in scores.iter().zip([0.0, 1.0, 2.0, 4.0]) {
+        assert!(approx_eq(*got, want, 1e-6), "hamming score {got} != {want}");
+    }
+}
+
+/// LIMIT 2 keeps the two smallest counts (id1=0, id3=1) — k applies after sort.
+#[test]
+fn test_hamming_limit_prefix() {
+    let (_dir, db) = create_test_db();
+    setup_hamming(&db);
+    let pairs = ranked(
+        &db,
+        "SELECT * FROM ham WHERE vector NEAR $v LIMIT 2",
+        &[1.0, 0.0, 1.0, 0.0],
+    );
+    assert_eq!(ids(&pairs), vec![1, 3], "two nearest by ascending count");
+}
+
+/// Scores are STRICTLY INCREASING — pins the ascending (distance) direction;
+/// would fail if Hamming were ever sorted as a similarity.
+#[test]
+fn test_hamming_scores_strictly_increasing() {
+    let (_dir, db) = create_test_db();
+    setup_hamming(&db);
+    let pairs = ranked(
+        &db,
+        "SELECT * FROM ham WHERE vector NEAR $v LIMIT 4",
+        &[1.0, 0.0, 1.0, 0.0],
+    );
+    let scores: Vec<f32> = pairs.iter().map(|(_, s)| *s).collect();
+    assert!(
+        scores.windows(2).all(|w| w[0] < w[1]),
+        "ascending: {scores:?}"
+    );
+}
+
+/// NEAR + scalar filter: cat='a' = {id1,id3}; ascending count 0<1 -> [1,3].
+#[test]
+fn test_hamming_near_with_filter() {
+    let (_dir, db) = create_test_db();
+    setup_hamming(&db);
+    let pairs = ranked(
+        &db,
+        "SELECT * FROM ham WHERE vector NEAR $v AND cat = 'a' LIMIT 4",
+        &[1.0, 0.0, 1.0, 0.0],
+    );
+    assert_eq!(
+        ids(&pairs),
+        vec![1, 3],
+        "filtered ascending count over cat='a'"
+    );
+}
+
+// ============================================================================
+// Jaccard — similarity (Ruzicka Σmin/Σmax), descending (higher = nearer)
+// ============================================================================
+
+/// Builds a dim-5 binary (0.0/1.0) Jaccard collection.
+fn setup_jaccard(db: &Database) {
+    db.create_vector_collection("jac", 5, DistanceMetric::Jaccard)
+        .expect("test: create jaccard collection");
+    let vc = db.get_vector_collection("jac").expect("test: get jac");
+    vc.upsert(vec![
+        Point::new(
+            1,
+            vec![1.0, 1.0, 1.0, 1.0, 0.0],
+            Some(serde_json::json!({"cat": "a"})),
+        ),
+        Point::new(
+            2,
+            vec![1.0, 1.0, 1.0, 0.0, 0.0],
+            Some(serde_json::json!({"cat": "b"})),
+        ),
+        Point::new(
+            3,
+            vec![1.0, 1.0, 0.0, 0.0, 1.0],
+            Some(serde_json::json!({"cat": "a"})),
+        ),
+        Point::new(
+            4,
+            vec![0.0, 0.0, 0.0, 0.0, 1.0],
+            Some(serde_json::json!({"cat": "b"})),
+        ),
+    ])
+    .expect("test: upsert jac");
+}
+
+/// GIVEN q=[1,1,1,1,0]. Σmin/Σmax: id1=4/4=1.0, id2=3/4=0.75, id3=2/5=0.40,
+/// id4=0/5=0.0. THEN NEAR returns descending-similarity order [1,2,3,4].
+#[test]
+fn test_jaccard_exact_descending_order_and_similarities() {
+    let (_dir, db) = create_test_db();
+    setup_jaccard(&db);
+    let pairs = ranked(
+        &db,
+        "SELECT * FROM jac WHERE vector NEAR $v LIMIT 4",
+        &[1.0, 1.0, 1.0, 1.0, 0.0],
+    );
+    assert_eq!(
+        ids(&pairs),
+        vec![1, 2, 3, 4],
+        "descending Jaccard similarity"
+    );
+    let scores: Vec<f32> = pairs.iter().map(|(_, s)| *s).collect();
+    for (got, want) in scores.iter().zip([1.0, 0.75, 0.40, 0.0]) {
+        assert!(approx_eq(*got, want, 1e-6), "jaccard score {got} != {want}");
+    }
+}
+
+/// LIMIT 2 keeps the two most similar (id1=1.0, id2=0.75).
+#[test]
+fn test_jaccard_limit_prefix() {
+    let (_dir, db) = create_test_db();
+    setup_jaccard(&db);
+    let pairs = ranked(
+        &db,
+        "SELECT * FROM jac WHERE vector NEAR $v LIMIT 2",
+        &[1.0, 1.0, 1.0, 1.0, 0.0],
+    );
+    assert_eq!(ids(&pairs), vec![1, 2], "two highest Jaccard similarity");
+}
+
+/// Scores STRICTLY DECREASING — pins descending (similarity) direction; would
+/// fail if Jaccard leaked the internal 1-sim distance while keeping desc sort.
+#[test]
+fn test_jaccard_scores_strictly_decreasing() {
+    let (_dir, db) = create_test_db();
+    setup_jaccard(&db);
+    let pairs = ranked(
+        &db,
+        "SELECT * FROM jac WHERE vector NEAR $v LIMIT 4",
+        &[1.0, 1.0, 1.0, 1.0, 0.0],
+    );
+    let scores: Vec<f32> = pairs.iter().map(|(_, s)| *s).collect();
+    assert!(
+        scores.windows(2).all(|w| w[0] > w[1]),
+        "descending: {scores:?}"
+    );
+}
+
+/// NEAR + scalar filter: cat='b' = {id2,id4}; descending sim 0.75>0.0 -> [2,4].
+#[test]
+fn test_jaccard_near_with_filter() {
+    let (_dir, db) = create_test_db();
+    setup_jaccard(&db);
+    let pairs = ranked(
+        &db,
+        "SELECT * FROM jac WHERE vector NEAR $v AND cat = 'b' LIMIT 4",
+        &[1.0, 1.0, 1.0, 1.0, 0.0],
+    );
+    assert_eq!(
+        ids(&pairs),
+        vec![2, 4],
+        "filtered descending sim over cat='b'"
+    );
+}
+
+// ============================================================================
+// DotProduct — similarity, descending (higher raw dot = nearer)
+// ============================================================================
+
+/// Builds a dim-2 NON-normalized DotProduct collection so dot-order differs
+/// from cosine-order (proving the ranking is really raw dot, not cosine).
+fn setup_dot(db: &Database) {
+    db.create_vector_collection("dot", 2, DistanceMetric::DotProduct)
+        .expect("test: create dot collection");
+    let vc = db.get_vector_collection("dot").expect("test: get dot");
+    vc.upsert(vec![
+        Point::new(1, vec![2.0, 0.0], Some(serde_json::json!({"cat": "a"}))),
+        Point::new(2, vec![5.0, 3.0], Some(serde_json::json!({"cat": "b"}))),
+        Point::new(3, vec![0.95, 0.05], Some(serde_json::json!({"cat": "a"}))),
+        Point::new(4, vec![1.0, 4.0], Some(serde_json::json!({"cat": "b"}))),
+    ])
+    .expect("test: upsert dot");
+}
+
+/// GIVEN q=[1,0]. Raw dot: id2=5.0, id1=2.0, id4=1.0, id3=0.95. THEN NEAR
+/// returns descending-dot order [2,1,4,3] with the POSITIVE raw dot as score.
+/// Cosine order would be [1,3,2,4] (id1 first, cosine 1.0) — different at every
+/// position, so this order fails if the engine ever fell back to cosine.
+#[test]
+fn test_dotproduct_exact_descending_order_not_cosine() {
+    let (_dir, db) = create_test_db();
+    setup_dot(&db);
+    let pairs = ranked(
+        &db,
+        "SELECT * FROM dot WHERE vector NEAR $v LIMIT 4",
+        &[1.0, 0.0],
+    );
+    assert_eq!(
+        ids(&pairs),
+        vec![2, 1, 4, 3],
+        "descending raw dot (not cosine)"
+    );
+    let scores: Vec<f32> = pairs.iter().map(|(_, s)| *s).collect();
+    for (got, want) in scores.iter().zip([5.0, 2.0, 1.0, 0.95]) {
+        assert!(approx_eq(*got, want, 1e-5), "dot score {got} != {want}");
+    }
+}
+
+/// LIMIT 1 keeps the largest raw dot (id2=5.0) — cheapest dot-not-cosine guard.
+#[test]
+fn test_dotproduct_top1_is_highest_dot() {
+    let (_dir, db) = create_test_db();
+    setup_dot(&db);
+    let pairs = ranked(
+        &db,
+        "SELECT * FROM dot WHERE vector NEAR $v LIMIT 1",
+        &[1.0, 0.0],
+    );
+    assert_eq!(ids(&pairs), vec![2], "top-1 is the highest raw dot");
+}
+
+/// Scores STRICTLY DECREASING (5.0>2.0>1.0>0.95) — pins descending + positive dot.
+#[test]
+fn test_dotproduct_scores_strictly_decreasing() {
+    let (_dir, db) = create_test_db();
+    setup_dot(&db);
+    let pairs = ranked(
+        &db,
+        "SELECT * FROM dot WHERE vector NEAR $v LIMIT 4",
+        &[1.0, 0.0],
+    );
+    let scores: Vec<f32> = pairs.iter().map(|(_, s)| *s).collect();
+    assert!(
+        scores.windows(2).all(|w| w[0] > w[1]),
+        "descending: {scores:?}"
+    );
+}
+
+/// NEAR + scalar filter: cat='b' = {id2,id4}; descending dot 5.0>1.0 -> [2,4].
+#[test]
+fn test_dotproduct_near_with_filter() {
+    let (_dir, db) = create_test_db();
+    setup_dot(&db);
+    let pairs = ranked(
+        &db,
+        "SELECT * FROM dot WHERE vector NEAR $v AND cat = 'b' LIMIT 4",
+        &[1.0, 0.0],
+    );
+    assert_eq!(
+        ids(&pairs),
+        vec![2, 4],
+        "filtered descending dot over cat='b'"
+    );
+}

--- a/crates/velesdb-core/tests/bdd/near_exact_ranking.rs
+++ b/crates/velesdb-core/tests/bdd/near_exact_ranking.rs
@@ -1,0 +1,335 @@
+//! BDD tests pinning `VelesQL` vector `NEAR` ANN ranking to EXACT golden order.
+//!
+//! These scenarios golden-pin the ordering that today's suite never asserts:
+//! the precise, fully-ordered id sequence returned by `vector NEAR $v`, and
+//! that the accompanying scores strictly decrease. The dataset is engineered
+//! so the exact (brute-force) nearest-neighbour order is also what HNSW must
+//! return, by keeping all points well separated along a single axis.
+//!
+//! Each scenario follows GIVEN (setup data) -> WHEN (execute SQL) -> THEN
+//! (verify exact result), exercising the full pipeline:
+//! SQL string -> `Parser::parse()` -> `Database::execute_query()` -> verify.
+//!
+//! ## Cosine ground truth (query `[1, 0, 0, 0]`, points `[1, off, 0, 0]`)
+//!
+//! cosine = `1 / sqrt(1 + off^2)`, strictly DECREASING in `off`:
+//!
+//! | id | vector            | off | cosine similarity |
+//! |----|-------------------|-----|-------------------|
+//! | 10 | `[1.0, 0.0, 0,0]` | 0.0 | 1.0000            |
+//! | 11 | `[1.0, 0.3, 0,0]` | 0.3 | 0.9578            |
+//! | 12 | `[1.0, 0.7, 0,0]` | 0.7 | 0.8192            |
+//! | 13 | `[1.0, 1.2, 0,0]` | 1.2 | 0.6402            |
+//! | 14 | `[1.0, 3.0, 0,0]` | 3.0 | 0.3162            |
+//! | 15 | `[0.0, 1.0, 0,0]` |  -  | 0.0000 (orthogonal) |
+//!
+//! So the exact full order by descending similarity is `[10, 11, 12, 13, 14, 15]`.
+
+use serde_json::json;
+use velesdb_core::{Database, DistanceMetric, Point};
+
+use super::helpers::{create_test_db, execute_sql_with_params, vector_param};
+
+// =========================================================================
+// Module-specific setup
+// =========================================================================
+
+/// Build a `docs` collection (dim 4, cosine) of 6 well-separated points along
+/// `[1, off, 0, 0]` plus one orthogonal point, with payloads `{"cat","n"}`.
+///
+/// Payloads: ids 10,12,14 -> cat "a"; ids 11,13,15 -> cat "b"; `n` == id.
+fn setup_docs_cosine(db: &Database) {
+    db.create_vector_collection("docs", 4, DistanceMetric::Cosine)
+        .expect("test: create docs collection");
+    let vc = db
+        .get_vector_collection("docs")
+        .expect("test: get docs collection");
+
+    vc.upsert(vec![
+        Point::new(
+            10,
+            vec![1.0, 0.0, 0.0, 0.0],
+            Some(json!({"cat": "a", "n": 10})),
+        ),
+        Point::new(
+            11,
+            vec![1.0, 0.3, 0.0, 0.0],
+            Some(json!({"cat": "b", "n": 11})),
+        ),
+        Point::new(
+            12,
+            vec![1.0, 0.7, 0.0, 0.0],
+            Some(json!({"cat": "a", "n": 12})),
+        ),
+        Point::new(
+            13,
+            vec![1.0, 1.2, 0.0, 0.0],
+            Some(json!({"cat": "b", "n": 13})),
+        ),
+        Point::new(
+            14,
+            vec![1.0, 3.0, 0.0, 0.0],
+            Some(json!({"cat": "a", "n": 14})),
+        ),
+        Point::new(
+            15,
+            vec![0.0, 1.0, 0.0, 0.0],
+            Some(json!({"cat": "b", "n": 15})),
+        ),
+    ])
+    .expect("test: upsert docs corpus");
+}
+
+/// Build a `geo` collection (dim 4, Euclidean) with the SAME geometry as
+/// `setup_docs_cosine`. With query `[1, 0, 0, 0]`, the Euclidean distance to
+/// `[1, off, 0, 0]` is exactly `off`, and to `[0, 1, 0, 0]` is `sqrt(2)`.
+///
+/// Distances strictly increase: 0.0 < 0.3 < 0.7 < 1.2 < sqrt(2)=1.414 < 3.0.
+/// So the nearest-first order is `[20, 21, 22, 23, 25, 24]` (note: orthogonal
+/// id 25 at sqrt(2) overtakes id 24 at off=3.0, unlike the cosine case).
+fn setup_geo_euclidean(db: &Database) {
+    db.create_vector_collection("geo", 4, DistanceMetric::Euclidean)
+        .expect("test: create geo collection");
+    let vc = db
+        .get_vector_collection("geo")
+        .expect("test: get geo collection");
+
+    vc.upsert(vec![
+        Point::new(
+            20,
+            vec![1.0, 0.0, 0.0, 0.0],
+            Some(json!({"cat": "a", "n": 20})),
+        ),
+        Point::new(
+            21,
+            vec![1.0, 0.3, 0.0, 0.0],
+            Some(json!({"cat": "b", "n": 21})),
+        ),
+        Point::new(
+            22,
+            vec![1.0, 0.7, 0.0, 0.0],
+            Some(json!({"cat": "a", "n": 22})),
+        ),
+        Point::new(
+            23,
+            vec![1.0, 1.2, 0.0, 0.0],
+            Some(json!({"cat": "b", "n": 23})),
+        ),
+        Point::new(
+            24,
+            vec![1.0, 3.0, 0.0, 0.0],
+            Some(json!({"cat": "a", "n": 24})),
+        ),
+        Point::new(
+            25,
+            vec![0.0, 1.0, 0.0, 0.0],
+            Some(json!({"cat": "b", "n": 25})),
+        ),
+    ])
+    .expect("test: upsert geo corpus");
+}
+
+/// Run a NEAR query against query vector `[1, 0, 0, 0]`, returning ordered ids.
+fn near_ids(db: &Database, sql: &str) -> Vec<u64> {
+    let results = execute_sql_with_params(db, sql, &vector_param(&[1.0, 0.0, 0.0, 0.0]))
+        .expect("test: NEAR query should succeed");
+    results.iter().map(|r| r.point.id).collect()
+}
+
+// =========================================================================
+// Scenario 1: full NEAR order (LIMIT 6) is the exact descending-similarity order
+// =========================================================================
+
+/// GIVEN the 6 well-separated cosine docs
+/// WHEN `vector NEAR [1,0,0,0] LIMIT 6`
+/// THEN the result is the EXACT order `[10, 11, 12, 13, 14, 15]`, because
+///      cosine = 1/sqrt(1+off^2) strictly decreases with off (1.0 > 0.958 >
+///      0.819 > 0.640 > 0.316 > 0.0), and the points are far enough apart that
+///      HNSW reproduces the brute-force order.
+#[test]
+fn test_near_full_order_limit6() {
+    let (_dir, db) = create_test_db();
+    setup_docs_cosine(&db);
+
+    let ids = near_ids(&db, "SELECT * FROM docs WHERE vector NEAR $v LIMIT 6;");
+
+    assert_eq!(
+        ids,
+        vec![10, 11, 12, 13, 14, 15],
+        "NEAR must return the exact descending-cosine order"
+    );
+}
+
+// =========================================================================
+// Scenario 2: LIMIT 3 returns exactly the top-3 prefix
+// =========================================================================
+
+/// GIVEN the same cosine docs
+/// WHEN `vector NEAR [1,0,0,0] LIMIT 3`
+/// THEN the result is the EXACT top-3 prefix `[10, 11, 12]` (similarities
+///      1.0, 0.958, 0.819 — the three highest), in that order.
+#[test]
+fn test_near_top3_prefix() {
+    let (_dir, db) = create_test_db();
+    setup_docs_cosine(&db);
+
+    let ids = near_ids(&db, "SELECT * FROM docs WHERE vector NEAR $v LIMIT 3;");
+
+    assert_eq!(
+        ids,
+        vec![10, 11, 12],
+        "NEAR LIMIT 3 must return exactly the 3 closest, ordered"
+    );
+}
+
+// =========================================================================
+// Scenario 3: scores are strictly decreasing
+// =========================================================================
+
+/// GIVEN the cosine docs
+/// WHEN `vector NEAR [1,0,0,0] LIMIT 6`
+/// THEN the 6 similarity scores are STRICTLY decreasing (no ties), matching the
+///      hand-computed sequence 1.0 > 0.958 > 0.819 > 0.640 > 0.316 > 0.0.
+#[test]
+fn test_near_scores_strictly_decreasing() {
+    let (_dir, db) = create_test_db();
+    setup_docs_cosine(&db);
+
+    let results = execute_sql_with_params(
+        &db,
+        "SELECT * FROM docs WHERE vector NEAR $v LIMIT 6;",
+        &vector_param(&[1.0, 0.0, 0.0, 0.0]),
+    )
+    .expect("test: NEAR query should succeed");
+
+    let scores: Vec<f32> = results.iter().map(|r| r.score).collect();
+    assert_eq!(scores.len(), 6, "expected 6 scored hits");
+    assert!(
+        scores.windows(2).all(|w| w[0] > w[1]),
+        "scores must be STRICTLY decreasing, got {scores:?}"
+    );
+}
+
+// =========================================================================
+// Scenario 4: NEAR + WHERE cat='b' yields the exact ordered subset
+// =========================================================================
+
+/// GIVEN the cosine docs (cat "b" = ids 11, 13, 15)
+/// WHEN `vector NEAR [1,0,0,0] AND cat = 'b' LIMIT 6`
+/// THEN the result is the EXACT order `[11, 13, 15]` — the cat-"b" rows in the
+///      same descending-cosine order (0.958 > 0.640 > 0.0).
+#[test]
+fn test_near_with_cat_filter_exact_order() {
+    let (_dir, db) = create_test_db();
+    setup_docs_cosine(&db);
+
+    let ids = near_ids(
+        &db,
+        "SELECT * FROM docs WHERE vector NEAR $v AND cat = 'b' LIMIT 6;",
+    );
+
+    assert_eq!(
+        ids,
+        vec![11, 13, 15],
+        "NEAR + cat='b' must keep descending-cosine order over the subset"
+    );
+}
+
+// =========================================================================
+// Scenario 5: NEAR + WHERE n NOT IN (...) drops listed ids, order preserved
+// =========================================================================
+
+/// GIVEN the cosine docs
+/// WHEN `vector NEAR [1,0,0,0] AND n NOT IN (11, 14) LIMIT 6`
+/// THEN the result is the EXACT order `[10, 12, 13, 15]` — the full ordered
+///      sequence `[10,11,12,13,14,15]` with ids 11 and 14 removed, order kept.
+#[test]
+fn test_near_with_not_in_exact_order() {
+    let (_dir, db) = create_test_db();
+    setup_docs_cosine(&db);
+
+    let ids = near_ids(
+        &db,
+        "SELECT * FROM docs WHERE vector NEAR $v AND n NOT IN (11, 14) LIMIT 6;",
+    );
+
+    assert_eq!(
+        ids,
+        vec![10, 12, 13, 15],
+        "NOT IN (11,14) must drop those ids and preserve NEAR order"
+    );
+}
+
+// =========================================================================
+// Scenario 6: NEAR + WHERE NOT (n = top_id) drops the top hit, order preserved
+// =========================================================================
+
+/// GIVEN the cosine docs (top hit is id 10, cosine 1.0)
+/// WHEN `vector NEAR [1,0,0,0] AND NOT (n = 10) LIMIT 6`
+/// THEN the result is the EXACT order `[11, 12, 13, 14, 15]` — the full order
+///      with the single top hit removed and the remaining order preserved.
+#[test]
+fn test_near_with_not_eq_drops_top_hit() {
+    let (_dir, db) = create_test_db();
+    setup_docs_cosine(&db);
+
+    let ids = near_ids(
+        &db,
+        "SELECT * FROM docs WHERE vector NEAR $v AND NOT (n = 10) LIMIT 6;",
+    );
+
+    assert_eq!(
+        ids,
+        vec![11, 12, 13, 14, 15],
+        "NOT (n=10) must drop the top hit and preserve the rest of NEAR order"
+    );
+}
+
+// =========================================================================
+// Scenario 7: Euclidean NEAR full order pins the distance ranking
+// =========================================================================
+
+/// GIVEN the Euclidean geo collection (distance to `[1,0,0,0]` == off for the
+///       on-axis points, sqrt(2)=1.414 for the orthogonal id 25)
+/// WHEN `vector NEAR [1,0,0,0] LIMIT 6`
+/// THEN the result is the EXACT nearest-first order `[20, 21, 22, 23, 25, 24]`:
+///      distances 0.0 < 0.3 < 0.7 < 1.2 < 1.414 < 3.0, so the orthogonal id 25
+///      (1.414) overtakes id 24 (3.0) — the opposite of the cosine case.
+#[test]
+fn test_near_euclidean_full_order() {
+    let (_dir, db) = create_test_db();
+    setup_geo_euclidean(&db);
+
+    let ids = near_ids(&db, "SELECT * FROM geo WHERE vector NEAR $v LIMIT 6;");
+
+    assert_eq!(
+        ids,
+        vec![20, 21, 22, 23, 25, 24],
+        "Euclidean NEAR must return the exact ascending-distance order"
+    );
+}
+
+// =========================================================================
+// Scenario 8: Euclidean NEAR + WHERE cat='a' yields the exact ordered subset
+// =========================================================================
+
+/// GIVEN the Euclidean geo collection (cat "a" = ids 20, 22, 24)
+/// WHEN `vector NEAR [1,0,0,0] AND cat = 'a' LIMIT 6`
+/// THEN the result is the EXACT order `[20, 22, 24]` — the cat-"a" rows in
+///      ascending-distance order (0.0 < 0.7 < 3.0).
+#[test]
+fn test_near_euclidean_with_filter_exact_order() {
+    let (_dir, db) = create_test_db();
+    setup_geo_euclidean(&db);
+
+    let ids = near_ids(
+        &db,
+        "SELECT * FROM geo WHERE vector NEAR $v AND cat = 'a' LIMIT 6;",
+    );
+
+    assert_eq!(
+        ids,
+        vec![20, 22, 24],
+        "Euclidean NEAR + cat='a' must keep ascending-distance order over the subset"
+    );
+}

--- a/crates/velesdb-core/tests/bdd/near_fused_parse_only.rs
+++ b/crates/velesdb-core/tests/bdd/near_fused_parse_only.rs
@@ -1,0 +1,201 @@
+//! BDD tests locking the `NEAR_FUSED` parse-only no-op and contrasting it with
+//! the engine-level multi-vector fusion API.
+//!
+//! Contract under test (two surfaces):
+//!
+//! 1. **VelesQL `NEAR_FUSED` is parse-only.** The grammar
+//!    (`grammar.pest` `vector_fused_search`) and parser
+//!    (`condition_vectors.rs::parse_vector_fused_search`) accept
+//!    `vector NEAR_FUSED [[..],[..]] [USING FUSION ...]` and build a
+//!    `Condition::VectorFusedSearch`, but execution NEVER fuses on it:
+//!    - `extraction.rs::extract_vector_search` has no `VectorFusedSearch` arm
+//!      (`_ => Ok(None)`), so no query vector is ever extracted from it.
+//!    - `where_eval.rs:214` treats `VectorFusedSearch(_) => Ok(true)`, i.e. an
+//!      always-true predicate.
+//!    The net effect: a `SELECT ... WHERE vector NEAR_FUSED [...]` is an
+//!    unranked full scan returning every row, NOT a fusion ranking. These tests
+//!    LOCK that behavior; if `NEAR_FUSED` is ever wired to real fusion they must
+//!    be updated.
+//!
+//! 2. **Multi-vector fusion is engine-API-only.** The same fusion that
+//!    `NEAR_FUSED` *looks* like it should perform is reachable solely through
+//!    `VectorCollection::multi_query_search`, which DOES fuse.
+
+use velesdb_core::{Database, FusionStrategy, Point};
+
+use super::helpers::{create_test_db, result_ids};
+
+/// dim-2 fixture: id1 axis-x, id2 axis-y, id3 the diagonal near both axes.
+/// Inserted in storage order 1,2,3 so an unranked scan yields {1,2,3}.
+fn setup_nf(db: &Database, name: &str) {
+    db.create_vector_collection(name, 2, velesdb_core::DistanceMetric::Cosine)
+        .expect("test: create collection");
+    let vc = db
+        .get_vector_collection(name)
+        .expect("test: get collection");
+    let points = vec![
+        Point::new(1, vec![1.0, 0.0], Some(serde_json::json!({"content": "x"}))),
+        Point::new(2, vec![0.0, 1.0], Some(serde_json::json!({"content": "y"}))),
+        Point::new(
+            3,
+            vec![0.7, 0.7],
+            Some(serde_json::json!({"content": "xy"})),
+        ),
+    ];
+    vc.upsert(points).expect("test: upsert");
+}
+
+// ============================================================================
+// Surface 1 — VelesQL NEAR_FUSED parse-only no-op (regression lock)
+// ============================================================================
+
+/// LOCK: `NEAR_FUSED [[..],[..]]` PARSES into `Condition::VectorFusedSearch`
+/// (grammar `vector_fused_search`; `parse_vector_fused_search`). Ground truth:
+/// `Parser::parse` returns Ok for a well-formed two-vector NEAR_FUSED clause.
+#[test]
+fn near_fused_two_vectors_parses_ok() {
+    let sql = "SELECT * FROM nf WHERE vector NEAR_FUSED [[1.0,0.0],[0.0,1.0]] LIMIT 10";
+    let parsed = velesdb_core::velesql::Parser::parse(sql);
+    assert!(
+        parsed.is_ok(),
+        "NEAR_FUSED with two vectors must parse: {parsed:?}"
+    );
+}
+
+/// LOCK: `NEAR_FUSED []` (empty array) is a PARSE ERROR — the grammar requires
+/// at least one vector (mirrors `negative_edge_tests::test_reject_near_fused_empty_array`).
+/// Ground truth: `Parser::parse` returns Err for an empty NEAR_FUSED array.
+#[test]
+fn near_fused_empty_array_is_parse_error() {
+    let sql = "SELECT * FROM nf WHERE vector NEAR_FUSED [] LIMIT 10";
+    assert!(
+        velesdb_core::velesql::Parser::parse(sql).is_err(),
+        "empty NEAR_FUSED array must fail to parse"
+    );
+}
+
+/// LOCK (the core no-op): a two-vector `NEAR_FUSED` query is an UNRANKED FULL
+/// SCAN, not a fusion ranking — it returns every stored row because
+/// `where_eval.rs:214` evaluates `VectorFusedSearch(_) => Ok(true)` and
+/// `extraction.rs` extracts no query vector from it. Ground truth: with 3
+/// stored points {1,2,3}, the result id-set is exactly {1,2,3}.
+/// CORRECT behavior would be a fused ranking over the two query vectors;
+/// update this test if `NEAR_FUSED` is ever wired to real fusion.
+#[test]
+fn near_fused_returns_unranked_full_scan() {
+    let (_dir, db) = create_test_db();
+    setup_nf(&db, "nf");
+    let results = super::helpers::execute_sql(
+        &db,
+        "SELECT * FROM nf WHERE vector NEAR_FUSED [[1.0,0.0],[0.0,1.0]] LIMIT 10",
+    )
+    .expect("test: execute NEAR_FUSED query");
+    assert_eq!(
+        result_ids(&results),
+        [1u64, 2, 3].into_iter().collect(),
+        "NEAR_FUSED is parse-only: must return all rows as an unranked scan"
+    );
+}
+
+/// LOCK: the parse-only no-op is independent of the `USING FUSION` clause —
+/// supplying `USING FUSION 'rrf'` changes nothing; it is still an unranked
+/// full scan over all rows. Ground truth: result id-set is exactly {1,2,3}.
+#[test]
+fn near_fused_with_using_fusion_clause_still_no_op() {
+    let (_dir, db) = create_test_db();
+    setup_nf(&db, "nf_using");
+    let results = super::helpers::execute_sql(
+        &db,
+        "SELECT * FROM nf_using WHERE vector NEAR_FUSED [[1.0,0.0],[0.0,1.0]] \
+         USING FUSION 'rrf' LIMIT 10",
+    )
+    .expect("test: execute NEAR_FUSED USING FUSION query");
+    assert_eq!(
+        result_ids(&results),
+        [1u64, 2, 3].into_iter().collect(),
+        "USING FUSION does not activate fusion: NEAR_FUSED remains a no-op scan"
+    );
+}
+
+/// LOCK: because `NEAR_FUSED` contributes no ranking, the query is sensitive
+/// ONLY to the scan's row set and `LIMIT`, never to the query vectors. A
+/// completely different pair of query vectors yields the SAME id-set as the
+/// scan above. Ground truth: result id-set is exactly {1,2,3}.
+#[test]
+fn near_fused_ignores_query_vectors() {
+    let (_dir, db) = create_test_db();
+    setup_nf(&db, "nf_ignore");
+    let results = super::helpers::execute_sql(
+        &db,
+        "SELECT * FROM nf_ignore WHERE vector NEAR_FUSED [[0.123,0.999],[0.5,0.5]] LIMIT 10",
+    )
+    .expect("test: execute NEAR_FUSED with unrelated vectors");
+    assert_eq!(
+        result_ids(&results),
+        [1u64, 2, 3].into_iter().collect(),
+        "NEAR_FUSED ranking is a no-op: arbitrary query vectors return the same scan"
+    );
+}
+
+// ============================================================================
+// Surface 2 — engine-API multi-vector fusion DOES fuse (contrast)
+// ============================================================================
+
+/// CONTRAST: multi-vector fusion is reachable ONLY via the engine API
+/// `VectorCollection::multi_query_search`, which DOES fuse. The queries
+/// [0.8,0.6] and [0.6,0.8] both lean toward the diagonal id3=[0.7,0.7], so id3
+/// is the closest point to BOTH (rank 0 in each per-query ranking) while the
+/// axis points id1/id2 lead only their own query. RRF (Σ 1/(k+rank), 1-based)
+/// gives id3 = 1/61+1/61 ≈ 0.03279, beating id1=id2 = 1/62+1/63 ≈ 0.03200
+/// (an orthogonal [1,0]/[0,1] pair would instead let the axis points win by a
+/// hair, since being rank-0 in one list beats rank-1 in both — 1/x convexity).
+/// Ground truth: the top fused result id is 3.
+#[test]
+fn multi_query_search_fuses_top_is_diagonal() {
+    let (_dir, db) = create_test_db();
+    setup_nf(&db, "nf2");
+    let vc = db
+        .get_vector_collection("nf2")
+        .expect("test: get collection");
+    let q0: &[f32] = &[0.8, 0.6];
+    let q1: &[f32] = &[0.6, 0.8];
+    let results = vc
+        .multi_query_search(&[q0, q1], 3, FusionStrategy::RRF { k: 60 }, None)
+        .expect("test: multi_query_search");
+    assert_eq!(
+        results[0].point.id, 3,
+        "diagonal point near both queries must be the top fused result"
+    );
+}
+
+/// CONTRAST: `multi_query_search` returns a genuine ranking of size <= top_k,
+/// not a full scan — and id3 (rank 0 in both diagonal-leaning branches)
+/// outranks the axis points id1/id2. Ground truth: 3 results, id3 first,
+/// {1,2,3} all present.
+#[test]
+fn multi_query_search_returns_ranking_not_scan() {
+    let (_dir, db) = create_test_db();
+    setup_nf(&db, "nf3");
+    let vc = db
+        .get_vector_collection("nf3")
+        .expect("test: get collection");
+    let q0: &[f32] = &[0.8, 0.6];
+    let q1: &[f32] = &[0.6, 0.8];
+    let results = vc
+        .multi_query_search(&[q0, q1], 3, FusionStrategy::RRF { k: 60 }, None)
+        .expect("test: multi_query_search");
+    assert_eq!(
+        results.len(),
+        3,
+        "fusion returns up to top_k ranked results"
+    );
+    assert_eq!(
+        results[0].point.id, 3,
+        "top fused result is the diagonal id3"
+    );
+    assert_eq!(
+        result_ids(&results),
+        [1u64, 2, 3].into_iter().collect(),
+        "all three points are retrieved across the two branches"
+    );
+}

--- a/crates/velesdb-core/tests/bdd/not_filters_exact.rs
+++ b/crates/velesdb-core/tests/bdd/not_filters_exact.rs
@@ -1,0 +1,416 @@
+//! BDD-style end-to-end tests pinning `VelesQL` **NOT** semantics via the
+//! COMPLEMENT PROPERTY: for every negated predicate, the NOT-set must equal
+//! `universe - positive-set` (and we also assert the exact id set).
+//!
+//! Each scenario follows GIVEN (setup data) -> WHEN (execute SQL) -> THEN
+//! (verify results). Tests exercise the full pipeline: SQL string ->
+//! `Parser::parse()` -> `Database::execute_query()` -> verify `SearchResult`s.
+
+use std::collections::HashSet;
+
+use serde_json::json;
+use velesdb_core::{Database, Point};
+
+use super::helpers::{
+    create_test_db, execute_sql, execute_sql_with_params, result_ids, vector_param,
+};
+
+// =========================================================================
+// Module-specific setup
+// =========================================================================
+
+/// Populate an `items` collection (dim 4) where EVERY point has all four
+/// payload fields (`category`, `price`, `tags`, `name`), so the universe is
+/// well-defined and `NOT (p)` partitions it cleanly into matches / non-matches.
+///
+/// Vectors use the `[1.0, off, 0.0, 0.0]` family for ids 1..=5 with `off`
+/// strictly increasing (0.0, 0.3, 0.7, 1.2, 3.0) so cosine similarity to
+/// `[1,0,0,0]` strictly DECREASES (1 > 2 > 3 > 4 > 5); ids 6..=8 are orthogonal
+/// (cosine ~0) so they always rank last under NEAR.
+///
+/// | id | category    | price | tags                  | name    | vector            |
+/// |----|-------------|-------|-----------------------|---------|-------------------|
+/// | 1  | books       | 10    | ["new","sale"]        | apple   | [1.0, 0.0, 0, 0]  |
+/// | 2  | books       | 20    | ["used"]              | apricot | [1.0, 0.3, 0, 0]  |
+/// | 3  | electronics | 30    | ["new"]               | banana  | [1.0, 0.7, 0, 0]  |
+/// | 4  | electronics | 40    | ["sale","clearance"]  | plum    | [1.0, 1.2, 0, 0]  |
+/// | 5  | clothing    | 50    | ["new","clearance"]   | pear    | [1.0, 3.0, 0, 0]  |
+/// | 6  | clothing    | 60    | ["used","vintage"]    | peach   | [0.0, 1.0, 0, 0]  |
+/// | 7  | toys        | 70    | ["new"]               | grape   | [0.0, 0.0, 1, 0]  |
+/// | 8  | toys        | 80    | ["sale"]              | mango   | [0.0, 0.0, 0, 1]  |
+fn setup_items(db: &Database) {
+    execute_sql(
+        db,
+        "CREATE COLLECTION items (dimension = 4, metric = 'cosine');",
+    )
+    .expect("test: CREATE items");
+
+    let vc = db
+        .get_vector_collection("items")
+        .expect("test: get items collection");
+
+    vc.upsert(vec![
+        Point::new(1, vec![1.0, 0.0, 0.0, 0.0], Some(json!({"category": "books", "price": 10, "tags": ["new", "sale"], "name": "apple"}))),
+        Point::new(2, vec![1.0, 0.3, 0.0, 0.0], Some(json!({"category": "books", "price": 20, "tags": ["used"], "name": "apricot"}))),
+        Point::new(3, vec![1.0, 0.7, 0.0, 0.0], Some(json!({"category": "electronics", "price": 30, "tags": ["new"], "name": "banana"}))),
+        Point::new(4, vec![1.0, 1.2, 0.0, 0.0], Some(json!({"category": "electronics", "price": 40, "tags": ["sale", "clearance"], "name": "plum"}))),
+        Point::new(5, vec![1.0, 3.0, 0.0, 0.0], Some(json!({"category": "clothing", "price": 50, "tags": ["new", "clearance"], "name": "pear"}))),
+        Point::new(6, vec![0.0, 1.0, 0.0, 0.0], Some(json!({"category": "clothing", "price": 60, "tags": ["used", "vintage"], "name": "peach"}))),
+        Point::new(7, vec![0.0, 0.0, 1.0, 0.0], Some(json!({"category": "toys", "price": 70, "tags": ["new"], "name": "grape"}))),
+        Point::new(8, vec![0.0, 0.0, 0.0, 1.0], Some(json!({"category": "toys", "price": 80, "tags": ["sale"], "name": "mango"}))),
+    ])
+    .expect("test: upsert items");
+}
+
+/// The full id universe of the `items` collection.
+fn universe() -> HashSet<u64> {
+    (1u64..=8).collect()
+}
+
+/// Run two SQL queries and return their id sets `(positive, negated)`.
+fn run_pair(db: &Database, positive_sql: &str, negated_sql: &str) -> (HashSet<u64>, HashSet<u64>) {
+    let pos = execute_sql(db, positive_sql).expect("test: positive query");
+    let neg = execute_sql(db, negated_sql).expect("test: negated query");
+    (result_ids(&pos), result_ids(&neg))
+}
+
+// =========================================================================
+// Form 1: WHERE n NOT IN (...)
+// =========================================================================
+
+/// GIVEN items, WHEN `category NOT IN ('books','toys')`,
+/// THEN positive set = `category IN ('books','toys')` = {1,2,7,8},
+/// so NOT-set = universe - {1,2,7,8} = {3,4,5,6} (electronics+clothing).
+#[test]
+fn test_not_in_is_complement_of_in() {
+    let (_dir, db) = create_test_db();
+    setup_items(&db);
+
+    let (positive, negated) = run_pair(
+        &db,
+        "SELECT * FROM items WHERE category IN ('books', 'toys') LIMIT 10;",
+        "SELECT * FROM items WHERE category NOT IN ('books', 'toys') LIMIT 10;",
+    );
+
+    assert_eq!(
+        positive,
+        HashSet::from([1, 2, 7, 8]),
+        "IN matches books+toys"
+    );
+    assert_eq!(negated, HashSet::from([3, 4, 5, 6]), "NOT IN = the other 4");
+    assert_eq!(
+        &universe() - &positive,
+        negated,
+        "complement: NOT IN == universe minus IN"
+    );
+}
+
+// =========================================================================
+// Form 2: WHERE NOT (category = 'x')
+// =========================================================================
+
+/// GIVEN items, WHEN `NOT (category = 'electronics')`,
+/// THEN positive `category = 'electronics'` = {3,4},
+/// so NOT-set = universe - {3,4} = {1,2,5,6,7,8}.
+#[test]
+fn test_not_equality_is_complement() {
+    let (_dir, db) = create_test_db();
+    setup_items(&db);
+
+    let (positive, negated) = run_pair(
+        &db,
+        "SELECT * FROM items WHERE category = 'electronics' LIMIT 10;",
+        "SELECT * FROM items WHERE NOT (category = 'electronics') LIMIT 10;",
+    );
+
+    assert_eq!(
+        positive,
+        HashSet::from([3, 4]),
+        "equality matches electronics"
+    );
+    assert_eq!(
+        negated,
+        HashSet::from([1, 2, 5, 6, 7, 8]),
+        "NOT equality = the other 6"
+    );
+    assert_eq!(
+        &universe() - &positive,
+        negated,
+        "complement: NOT (=) == universe minus ="
+    );
+}
+
+// =========================================================================
+// Form 3: WHERE NOT (price BETWEEN a AND b)
+// =========================================================================
+
+/// GIVEN items, WHEN `NOT (price BETWEEN 30 AND 60)` (BETWEEN is inclusive),
+/// THEN positive `price BETWEEN 30 AND 60` = {3,4,5,6} (prices 30,40,50,60),
+/// so NOT-set = universe - {3,4,5,6} = {1,2,7,8} (prices 10,20,70,80).
+#[test]
+fn test_not_between_is_complement() {
+    let (_dir, db) = create_test_db();
+    setup_items(&db);
+
+    let (positive, negated) = run_pair(
+        &db,
+        "SELECT * FROM items WHERE price BETWEEN 30 AND 60 LIMIT 10;",
+        "SELECT * FROM items WHERE NOT (price BETWEEN 30 AND 60) LIMIT 10;",
+    );
+
+    assert_eq!(
+        positive,
+        HashSet::from([3, 4, 5, 6]),
+        "BETWEEN [30,60] inclusive"
+    );
+    assert_eq!(
+        negated,
+        HashSet::from([1, 2, 7, 8]),
+        "NOT BETWEEN = outside range"
+    );
+    assert_eq!(
+        &universe() - &positive,
+        negated,
+        "complement: NOT BETWEEN == universe minus BETWEEN"
+    );
+}
+
+// =========================================================================
+// Form 4: WHERE NOT (tags CONTAINS 'y')
+// =========================================================================
+
+/// GIVEN items where every point has a `tags` array, WHEN
+/// `NOT (tags CONTAINS 'new')`, THEN positive `tags CONTAINS 'new'` =
+/// {1,3,5,7} (tags containing "new"), so NOT-set = universe - {1,3,5,7} =
+/// {2,4,6,8}. Every point has tags, so the complement is total.
+#[test]
+fn test_not_contains_is_complement() {
+    let (_dir, db) = create_test_db();
+    setup_items(&db);
+
+    let (positive, negated) = run_pair(
+        &db,
+        "SELECT * FROM items WHERE tags CONTAINS 'new' LIMIT 10;",
+        "SELECT * FROM items WHERE NOT (tags CONTAINS 'new') LIMIT 10;",
+    );
+
+    assert_eq!(
+        positive,
+        HashSet::from([1, 3, 5, 7]),
+        "tags containing 'new'"
+    );
+    assert_eq!(
+        negated,
+        HashSet::from([2, 4, 6, 8]),
+        "NOT CONTAINS = no 'new' tag"
+    );
+    assert_eq!(
+        &universe() - &positive,
+        negated,
+        "complement: NOT CONTAINS == universe minus CONTAINS"
+    );
+}
+
+// =========================================================================
+// Form 5: WHERE NOT (name LIKE 'p%')
+// =========================================================================
+
+/// GIVEN items, WHEN `NOT (name LIKE 'p%')` (prefix p), THEN positive
+/// `name LIKE 'p%'` = {4,5,6} (plum, pear, peach), so NOT-set = universe -
+/// {4,5,6} = {1,2,3,7,8} (apple, apricot, banana, grape, mango).
+#[test]
+fn test_not_like_prefix_is_complement() {
+    let (_dir, db) = create_test_db();
+    setup_items(&db);
+
+    let (positive, negated) = run_pair(
+        &db,
+        "SELECT * FROM items WHERE name LIKE 'p%' LIMIT 10;",
+        "SELECT * FROM items WHERE NOT (name LIKE 'p%') LIMIT 10;",
+    );
+
+    assert_eq!(
+        positive,
+        HashSet::from([4, 5, 6]),
+        "names starting with 'p'"
+    );
+    assert_eq!(
+        negated,
+        HashSet::from([1, 2, 3, 7, 8]),
+        "NOT LIKE 'p%' = the rest"
+    );
+    assert_eq!(
+        &universe() - &positive,
+        negated,
+        "complement: NOT LIKE == universe minus LIKE"
+    );
+}
+
+// =========================================================================
+// Form 6: De Morgan — NOT (A AND B) == (NOT A) OR (NOT B)
+// =========================================================================
+
+/// GIVEN items, WHEN `NOT (category = 'books' AND price > 15)` vs the De
+/// Morgan equivalent `category != 'books' OR price <= 15`, THEN both yield
+/// the SAME id set. Ground truth: `books AND price>15` = {2} (apricot, 20);
+/// its complement over the universe is {1,3,4,5,6,7,8}. The OR form: NOT books
+/// = {3,4,5,6,7,8}; price<=15 = {1}; union = {1,3,4,5,6,7,8}.
+#[test]
+fn test_not_de_morgan_and_equals_or_form() {
+    let (_dir, db) = create_test_db();
+    setup_items(&db);
+
+    let positive = execute_sql(
+        &db,
+        "SELECT * FROM items WHERE category = 'books' AND price > 15 LIMIT 10;",
+    )
+    .expect("test: positive AND query");
+    let not_form = execute_sql(
+        &db,
+        "SELECT * FROM items WHERE NOT (category = 'books' AND price > 15) LIMIT 10;",
+    )
+    .expect("test: NOT(AND) query");
+    let or_form = execute_sql(
+        &db,
+        "SELECT * FROM items WHERE category != 'books' OR price <= 15 LIMIT 10;",
+    )
+    .expect("test: De Morgan OR query");
+
+    let positive = result_ids(&positive);
+    let not_ids = result_ids(&not_form);
+    assert_eq!(
+        positive,
+        HashSet::from([2]),
+        "books AND price>15 = apricot(20)"
+    );
+    assert_eq!(
+        not_ids,
+        HashSet::from([1, 3, 4, 5, 6, 7, 8]),
+        "NOT(AND) excludes only id 2"
+    );
+    assert_eq!(
+        not_ids,
+        result_ids(&or_form),
+        "De Morgan: NOT(A AND B) == (NOT A) OR (NOT B)"
+    );
+    assert_eq!(
+        &universe() - &positive,
+        not_ids,
+        "complement: NOT(AND) == universe minus (AND)"
+    );
+}
+
+// =========================================================================
+// Form 6b: De Morgan — NOT (A OR B) == (NOT A) AND (NOT B)
+// =========================================================================
+
+/// GIVEN items, WHEN `NOT (category = 'toys' OR price < 30)` vs the De Morgan
+/// equivalent `category != 'toys' AND price >= 30`, THEN both yield the SAME
+/// id set. Ground truth: `toys OR price<30` = toys{7,8} ∪ price<30{1,2} =
+/// {1,2,7,8}; complement = {3,4,5,6}. The AND form: NOT toys = {1,2,3,4,5,6};
+/// price>=30 = {3,4,5,6,7,8}; intersection = {3,4,5,6}.
+#[test]
+fn test_not_de_morgan_or_equals_and_form() {
+    let (_dir, db) = create_test_db();
+    setup_items(&db);
+
+    let positive = execute_sql(
+        &db,
+        "SELECT * FROM items WHERE category = 'toys' OR price < 30 LIMIT 10;",
+    )
+    .expect("test: positive OR query");
+    let not_form = execute_sql(
+        &db,
+        "SELECT * FROM items WHERE NOT (category = 'toys' OR price < 30) LIMIT 10;",
+    )
+    .expect("test: NOT(OR) query");
+    let and_form = execute_sql(
+        &db,
+        "SELECT * FROM items WHERE category != 'toys' AND price >= 30 LIMIT 10;",
+    )
+    .expect("test: De Morgan AND query");
+
+    let positive = result_ids(&positive);
+    let not_ids = result_ids(&not_form);
+    assert_eq!(positive, HashSet::from([1, 2, 7, 8]), "toys OR price<30");
+    assert_eq!(
+        not_ids,
+        HashSet::from([3, 4, 5, 6]),
+        "NOT(OR) = electronics+clothing"
+    );
+    assert_eq!(
+        not_ids,
+        result_ids(&and_form),
+        "De Morgan: NOT(A OR B) == (NOT A) AND (NOT B)"
+    );
+    assert_eq!(
+        &universe() - &positive,
+        not_ids,
+        "complement: NOT(OR) == universe minus (OR)"
+    );
+}
+
+// =========================================================================
+// Form 7: NEAR + WHERE NOT (...) -> exact ordered ids
+// =========================================================================
+
+/// GIVEN items, WHEN `vector NEAR [1,0,0,0] AND NOT (category = 'books')
+/// LIMIT 3`, THEN books {1,2} are excluded; among the remaining cosine-family
+/// points {3,4,5} (vectors [1,off,...] with off 0.7,1.2,3.0) similarity
+/// strictly DECREASES, so they rank 3 > 4 > 5 and all beat the orthogonal
+/// (cosine ~0) points {6,7,8}. With LIMIT 3 the exact ORDERED result is
+/// [3, 4, 5].
+#[test]
+fn test_near_with_not_filter_exact_ordered() {
+    let (_dir, db) = create_test_db();
+    setup_items(&db);
+
+    let results = execute_sql_with_params(
+        &db,
+        "SELECT * FROM items WHERE vector NEAR $v AND NOT (category = 'books') LIMIT 3;",
+        &vector_param(&[1.0, 0.0, 0.0, 0.0]),
+    )
+    .expect("test: NEAR + NOT filter");
+
+    let ids: Vec<u64> = results.iter().map(|r| r.point.id).collect();
+    assert_eq!(
+        ids,
+        vec![3, 4, 5],
+        "NEAR ranks non-books cosine-family by decreasing similarity: 3 > 4 > 5"
+    );
+}
+
+// =========================================================================
+// Form 7b: NEAR + WHERE NOT(...) monotonic similarity scores
+// =========================================================================
+
+/// GIVEN items, WHEN `vector NEAR [1,0,0,0] AND NOT (price BETWEEN 25 AND 100)
+/// LIMIT 2`, THEN positive `price BETWEEN 25 AND 100` = {3,4,5,6,7,8}; the
+/// non-matching set is {1,2} (prices 10,20), both in the cosine family with
+/// off 0.0 and 0.3, so similarity strictly DECREASES: ordered ids [1, 2] and
+/// score[0] > score[1].
+#[test]
+fn test_near_with_not_between_monotonic_scores() {
+    let (_dir, db) = create_test_db();
+    setup_items(&db);
+
+    let results = execute_sql_with_params(
+        &db,
+        "SELECT * FROM items WHERE vector NEAR $v AND NOT (price BETWEEN 25 AND 100) LIMIT 2;",
+        &vector_param(&[1.0, 0.0, 0.0, 0.0]),
+    )
+    .expect("test: NEAR + NOT BETWEEN");
+
+    let ids: Vec<u64> = results.iter().map(|r| r.point.id).collect();
+    assert_eq!(
+        ids,
+        vec![1, 2],
+        "Only ids 1,2 escape the price range; off 0.0 < 0.3"
+    );
+    assert!(
+        results[0].score > results[1].score,
+        "cosine similarity strictly decreases: id1 (off 0.0) > id2 (off 0.3), got {} vs {}",
+        results[0].score,
+        results[1].score
+    );
+}

--- a/crates/velesdb-core/tests/bdd/sparse_near_conformance.rs
+++ b/crates/velesdb-core/tests/bdd/sparse_near_conformance.rs
@@ -1,0 +1,237 @@
+//! BDD conformance for the `SPARSE_NEAR` VelesQL surface.
+//!
+//! Contract under test: `WHERE vector SPARSE_NEAR {..}` ranks documents by the
+//! exact sparse inner product (dot) between the query and each document's
+//! default ("") sparse vector, returns them sorted descending, truncated to
+//! `LIMIT`, and carries the dot product through as `SearchResult::score`.
+//!
+//! Ground-truth ranking is hand-computed and verified against the sparse search
+//! path (`sparse_index/search`): the corpus stays well under
+//! `SMALL_CORPUS_LINEAR_THRESHOLD` (100_000), so every query takes the dense
+//! linear-scan path, which sums `query_weight * doc_weight` per overlapping term
+//! and applies NO `score > 0` filter — negative scores are kept.
+
+use std::collections::BTreeMap;
+
+use serde_json::json;
+use velesdb_core::sparse_index::SparseVector;
+use velesdb_core::{Database, GraphEdge, Point, SearchResult};
+
+use super::helpers::{approx_eq, create_test_db, execute_sql, execute_sql_with_params, result_ids};
+
+/// Float epsilon for sparse dot-product score comparison.
+const EPS: f32 = 1e-5;
+
+/// Builds a default-index ("") sparse vector from `(term, weight)` pairs.
+fn sparse_default(pairs: Vec<(u32, f32)>) -> BTreeMap<String, SparseVector> {
+    let mut map = BTreeMap::new();
+    map.insert(String::new(), SparseVector::new(pairs));
+    map
+}
+
+/// Builds a point carrying only a default sparse vector (dense vector is a
+/// fixed placeholder; SPARSE_NEAR ignores it).
+fn sparse_point(id: u64, pairs: Vec<(u32, f32)>) -> Point {
+    Point {
+        id,
+        vector: vec![1.0, 0.0],
+        payload: Some(json!({ "id": id })),
+        sparse_vectors: Some(sparse_default(pairs)),
+    }
+}
+
+/// GIVEN the `hc` corpus (dim 2), default sparse index:
+///   id1 [(10,5.0),(20,1.0)] · id2 [(10,2.0),(30,4.0)]
+///   id3 [(20,3.0),(30,3.0)] · id4 [(40,9.0)]
+fn setup_hc(db: &Database) {
+    db.create_vector_collection("hc", 2, velesdb_core::DistanceMetric::Cosine)
+        .expect("test: create hc collection");
+    let vc = db.get_vector_collection("hc").expect("test: get hc");
+    vc.upsert(vec![
+        sparse_point(1, vec![(10, 5.0), (20, 1.0)]),
+        sparse_point(2, vec![(10, 2.0), (30, 4.0)]),
+        sparse_point(3, vec![(20, 3.0), (30, 3.0)]),
+        sparse_point(4, vec![(40, 9.0)]),
+    ])
+    .expect("test: upsert hc");
+}
+
+/// Maps results to their `(id, score)` pairs in returned order.
+fn id_scores(results: &[SearchResult]) -> Vec<(u64, f32)> {
+    results.iter().map(|r| (r.point.id, r.score)).collect()
+}
+
+/// WHEN `SPARSE_NEAR {10:1.0,30:2.0} LIMIT 3` THEN docs rank by exact dot:
+/// id2=1*2+2*4=10, id3=2*3=6, id1=1*5=5; id4 has no overlap (absent).
+/// Ground truth: hand-computed inner products; scores strictly distinct so the
+/// (unstable) sort yields a deterministic id order.
+#[test]
+fn test_sparse_near_exact_dot_ranking() {
+    let (_dir, db) = create_test_db();
+    setup_hc(&db);
+
+    let results = execute_sql(
+        &db,
+        "SELECT * FROM hc WHERE vector SPARSE_NEAR {10: 1.0, 30: 2.0} LIMIT 3",
+    )
+    .expect("test: sparse_near literal");
+
+    let got = id_scores(&results);
+    let ids: Vec<u64> = got.iter().map(|(id, _)| *id).collect();
+    assert_eq!(ids, vec![2, 3, 1], "dot ranking id2(10) > id3(6) > id1(5)");
+    assert!(approx_eq(got[0].1, 10.0, EPS), "id2 dot = 1*2+2*4 = 10");
+    assert!(approx_eq(got[1].1, 6.0, EPS), "id3 dot = 2*3 = 6");
+    assert!(approx_eq(got[2].1, 5.0, EPS), "id1 dot = 1*5 = 5");
+    assert!(
+        !result_ids(&results).contains(&4),
+        "id4 shares no term with the query: dot = 0, never scored"
+    );
+}
+
+/// WHEN the same query is capped at `LIMIT 2` THEN only the top two survive the
+/// post-rank truncation. Ground truth: top-k truncation after descending sort.
+#[test]
+fn test_sparse_near_limit_truncates_after_rank() {
+    let (_dir, db) = create_test_db();
+    setup_hc(&db);
+
+    let results = execute_sql(
+        &db,
+        "SELECT * FROM hc WHERE vector SPARSE_NEAR {10: 1.0, 30: 2.0} LIMIT 2",
+    )
+    .expect("test: sparse_near limit 2");
+
+    let ids: Vec<u64> = results.iter().map(|r| r.point.id).collect();
+    assert_eq!(ids, vec![2, 3], "LIMIT 2 keeps only the two highest dots");
+}
+
+/// WHEN the query vector is bound as a `$sv` parameter (shorthand JSON object
+/// `{"10":1.0,"30":2.0}`) THEN ranking is identical to the literal form.
+/// Ground truth: `resolve_sparse_vector` parses an object whose keys are u32
+/// strings and whose values are weights into the same `SparseVector`.
+#[test]
+fn test_sparse_near_param_matches_literal() {
+    let (_dir, db) = create_test_db();
+    setup_hc(&db);
+
+    let mut params = std::collections::HashMap::new();
+    params.insert("sv".to_string(), json!({ "10": 1.0, "30": 2.0 }));
+    let results = execute_sql_with_params(
+        &db,
+        "SELECT * FROM hc WHERE vector SPARSE_NEAR $sv LIMIT 3",
+        &params,
+    )
+    .expect("test: sparse_near param");
+
+    let got = id_scores(&results);
+    let ids: Vec<u64> = got.iter().map(|(id, _)| *id).collect();
+    assert_eq!(
+        ids,
+        vec![2, 3, 1],
+        "param ranking equals the literal ranking"
+    );
+    assert!(approx_eq(got[0].1, 10.0, EPS), "id2 dot = 10");
+    assert!(approx_eq(got[1].1, 6.0, EPS), "id3 dot = 6");
+    assert!(approx_eq(got[2].1, 5.0, EPS), "id1 dot = 5");
+}
+
+/// WHEN the query is bound via the structured `{indices, values}` JSON shape
+/// THEN it resolves to the same sparse vector and ranking as the shorthand.
+/// Ground truth: `try_parse_structured_sparse` zips equal-length arrays.
+#[test]
+fn test_sparse_near_param_structured_shape() {
+    let (_dir, db) = create_test_db();
+    setup_hc(&db);
+
+    let mut params = std::collections::HashMap::new();
+    params.insert(
+        "sv".to_string(),
+        json!({ "indices": [10, 30], "values": [1.0, 2.0] }),
+    );
+    let results = execute_sql_with_params(
+        &db,
+        "SELECT * FROM hc WHERE vector SPARSE_NEAR $sv LIMIT 3",
+        &params,
+    )
+    .expect("test: sparse_near structured param");
+
+    let ids: Vec<u64> = results.iter().map(|r| r.point.id).collect();
+    assert_eq!(
+        ids,
+        vec![2, 3, 1],
+        "structured param yields the same ranking"
+    );
+    assert!(
+        approx_eq(results[0].score, 10.0, EPS),
+        "structured param id2 dot = 10"
+    );
+}
+
+/// WHEN a `MATCH (d)-[:CITES]->(x)` anchor is AND-required, retrieval is
+/// exhaustive *within the graph matches*: only id1 has an outgoing CITES edge,
+/// so it is returned despite ranking 3rd globally (dot 5 < id2 10 < id3 6).
+/// Ground truth: anchor set = {1}; the sparse per-id filter keeps only id1.
+#[test]
+fn test_sparse_near_graph_anchor_narrows_to_edge_source() {
+    let (_dir, db) = create_test_db();
+    setup_hc(&db);
+    let vc = db.get_vector_collection("hc").expect("test: get hc");
+    vc.add_edge(GraphEdge::new(900, 1, 2, "CITES").expect("test: edge"))
+        .expect("test: add edge");
+
+    let results = execute_sql(
+        &db,
+        "SELECT * FROM hc AS d WHERE vector SPARSE_NEAR {10: 1.0, 30: 2.0} \
+         AND MATCH (d)-[:CITES]->(x) LIMIT 1",
+    )
+    .expect("test: sparse_near + anchor");
+
+    assert_eq!(results.len(), 1, "exactly the single anchor is returned");
+    assert_eq!(
+        results[0].point.id, 1,
+        "id1 is the only CITES source; anchor overrides its 3rd-place global rank"
+    );
+    assert!(approx_eq(results[0].score, 5.0, EPS), "id1 dot = 1*5 = 5");
+}
+
+/// WHEN a document carries a NEGATIVE term weight, the sparse path KEEPS its
+/// negative score (no `score > 0` filter exists; `topk_push` admits any doc
+/// while the heap is below k). id5 [(10,-2.0),(50,3.0)] under query {10:1.0}
+/// scores -2.0 and ranks last but is still returned.
+/// Ground truth: id1=5, id2=2, id5=-2; strictly distinct → deterministic order.
+/// VERIFIED: `sparse_index/search/mod.rs` has no positive-score filter; the
+/// `has_negative_weight` branch only changes the search STRATEGY (linear scan),
+/// not result filtering. CORRECT behavior under inner-product semantics is to
+/// keep negatives, so this is a faithful conformance assertion, not a bug lock.
+#[test]
+fn test_sparse_near_keeps_negative_scores() {
+    let (_dir, db) = create_test_db();
+    setup_hc(&db);
+    let vc = db.get_vector_collection("hc").expect("test: get hc");
+    vc.upsert(vec![sparse_point(5, vec![(10, -2.0), (50, 3.0)])])
+        .expect("test: upsert id5");
+
+    let results = execute_sql(
+        &db,
+        "SELECT * FROM hc WHERE vector SPARSE_NEAR {10: 1.0} LIMIT 10",
+    )
+    .expect("test: sparse_near negative");
+
+    let got = id_scores(&results);
+    let ids: Vec<u64> = got.iter().map(|(id, _)| *id).collect();
+    assert_eq!(
+        ids,
+        vec![1, 2, 5],
+        "only docs touching term 10; id5 kept despite score < 0"
+    );
+    assert!(approx_eq(got[0].1, 5.0, EPS), "id1 dot = 1*5 = 5");
+    assert!(approx_eq(got[1].1, 2.0, EPS), "id2 dot = 1*2 = 2");
+    assert!(
+        approx_eq(got[2].1, -2.0, EPS),
+        "id5 dot = 1*(-2) = -2 (negative kept)"
+    );
+    assert!(
+        !result_ids(&results).contains(&3) && !result_ids(&results).contains(&4),
+        "id3/id4 do not contain term 10 → never scored"
+    );
+}


### PR DESCRIPTION
## VelesQL exact-result conformance (100 tests)

Closes the multi-model conformance gaps surfaced by a coverage audit: the suite previously proved the scalar/column engine like a SQL database, but VelesDB's marquee multi-model surface (vector ANN ranking, graph traversal result-sets, fusion, fulltext/sparse ranking, non-Cosine metrics, agent-memory recall) was only parse-tested, membership-checked, or covered by a statistical recall floor — never golden-pinned.

These 12 BDD modules assert **exact** result-sets / ordering / scores on small hand-computed datasets (no `no_panic`-only tests):

| Area | Module |
|---|---|
| NEAR exact ranking, all 5 metrics | `near_exact_ranking`, `metrics_ranking_conformance` (Cosine/Euclidean/DotProduct/**Hamming**/**Jaccard**) |
| Graph traversal (var-length, NOT MATCH) | `match_traversal_exact` |
| Vector+graph+scalar single-statement | `hybrid_vector_first_exact` |
| NOT semantics + De Morgan + complement | `not_filters_exact` |
| Agent memory recall / relate / traverse / TTL | `agent_memory_recall_exact`, `agent_memory_graph_traversal` |
| RRF / WeightedRRF exact scores | `fusion_rrf_conformance` |
| BM25 MATCH exact ranking | `bm25_match_conformance` |
| SPARSE_NEAR exact dot ranking | `sparse_near_conformance` |
| NEAR_FUSED parse-only no-op (lock) | `near_fused_parse_only` |

### Two confirmed fusion-`Weighted` defects (captured as regression locks)
These tests assert the **current** behavior and doc-comment the **correct** behavior, pending a follow-up fix PR:
- **Bug A** — `sparse_dispatch.rs:204`: SQL `USING FUSION(strategy='weighted')` silently downgrades to RRF (weights ignored).
- **Bug B** — `score_fusion/mod.rs:248`: `ScoreFusionMethod::Weighted` is byte-identical to `Average` (weights hardcoded `1/n`).

Everything else (NEAR, all metrics, traversal, NOT, RRF, BM25, sparse, memory) ranks **exactly** as hand-computed — no other defects.

### Validation
100 tests pass single-threaded (`--test-threads=1`); full BDD suite 540 → 552; `clippy --all-targets -D clippy::pedantic` clean; jscpd 0 clones. Test-only — no production code touched.
