### PR TITLE
fix(fusion): SQL USING FUSION(strategy='weighted') honors dense/sparse weights

### DIFF
--- a/crates/velesdb-core/src/collection/search/query/sparse_dispatch.rs
+++ b/crates/velesdb-core/src/collection/search/query/sparse_dispatch.rs
@@ -201,7 +201,18 @@ impl Collection {
                     },
                     FusionStrategyType::Average => crate::fusion::FusionStrategy::Average,
                     FusionStrategyType::Maximum => crate::fusion::FusionStrategy::Maximum,
-                    FusionStrategyType::Weighted => crate::fusion::FusionStrategy::rrf_default(),
+                    FusionStrategyType::Weighted => {
+                        // 'weighted' = weighted Reciprocal Rank Fusion over the two
+                        // branches (branch 0 = dense NEAR, branch 1 = sparse), honoring
+                        // the dense_w/sparse_w from the FUSION clause. Falls back to RRF
+                        // on a validation error (e.g. a negative weight).
+                        let dw = fc.dense_weight.unwrap_or(0.5);
+                        let sw = fc.sparse_weight.unwrap_or(0.5);
+                        #[allow(clippy::cast_precision_loss)]
+                        let k = fc.k.unwrap_or(60) as f32;
+                        crate::fusion::FusionStrategy::weighted_rrf(vec![dw, sw], k)
+                            .unwrap_or_else(|_| crate::fusion::FusionStrategy::rrf_default())
+                    }
                 }
             })
     }

--- a/crates/velesdb-core/tests/bdd/fusion_weighted_bug.rs
+++ b/crates/velesdb-core/tests/bdd/fusion_weighted_bug.rs
@@ -80,15 +80,19 @@ fn test_engine_weighted_validation_rejects_bad_weights() {
     );
 }
 
-/// REGRESSION LOCK — Bug B (`score_fusion/mod.rs:248`).
+/// CHARACTERIZATION LOCK — Bug B (`score_fusion/mod.rs:248`).
 ///
 /// `ScoreFusionMethod::Weighted` uses equal weights (1/n per component), so for
 /// a breakdown with vector_similarity=0.9 and sparse_score=0.3 it computes
 /// 0.9*0.5 + 0.3*0.5 = 0.6 — identical to `Average` = (0.9+0.3)/2 = 0.6.
 ///
-/// CORRECT behavior: a TRUE weighted combiner (e.g. w_vec=0.75, w_sparse=0.25)
-/// would yield 0.9*0.75 + 0.3*0.25 = 0.75, NOT 0.6, and would differ from
-/// Average. This test PASSES against the current buggy equal-weight behavior.
+/// This is a DEAD-PATH defect: `ScoreFusionMethod::Weighted` is never selected
+/// by any query (the live hybrid ranking uses `text.rs` weighted-RRF and the
+/// `FusionStrategy` enum, not this per-result combiner). It is intentionally
+/// left as-is rather than given a speculative per-component weight API for code
+/// nothing currently selects; a TRUE weighted combiner (e.g. w_vec=0.75,
+/// w_sparse=0.25) would yield 0.75, not 0.6. This test pins the current
+/// behavior so any future wiring of this enum has to update it deliberately.
 #[test]
 fn test_score_fusion_weighted_equals_average_bug_b() {
     let breakdown = ScoreBreakdown {
@@ -139,40 +143,53 @@ fn setup_wb_collection(db: &velesdb_core::Database) {
     .expect("test: upsert wb");
 }
 
-/// REGRESSION LOCK — Bug A (`sparse_dispatch.rs:204`).
+/// FIX VERIFICATION — Bug A (`sparse_dispatch.rs`): SQL
+/// `USING FUSION(strategy='weighted', ...)` now routes to weighted Reciprocal
+/// Rank Fusion over the two branches (branch 0 = dense NEAR, branch 1 = sparse),
+/// honoring `dense_w`/`sparse_w` — it no longer silently downgrades to plain RRF
+/// with the weights ignored.
 ///
-/// SQL `USING FUSION(strategy='weighted')` is silently downgraded to
-/// `RRF{k:60}` (the only SQL path reaching the engine fusion). With dense
-/// ranking id1 first and sparse ranking id2 first, RRF is a symmetric tie:
-/// each doc = 1/(60+1) + 1/(60+2) = 0.0325225. We assert the returned scores
-/// equal that RRF value, proving the SQL ran RRF, NOT engine Weighted.
-///
-/// CORRECT behavior: a real 'weighted' SQL strategy would invoke
-/// `FusionStrategy::Weighted` and produce the avg/max/hit combination instead
-/// of an RRF tie. The tie means id order is non-deterministic — we assert
-/// scores only, never id order.
+/// GIVEN id1 leads the dense branch (rank 0) and id2 leads the sparse branch
+/// (rank 0). WITH sparse-heavy weights dense_w=0.1, sparse_w=0.9 and k=60,
+/// weighted RRF (0-based) gives:
+///   id1 = 0.1/(0+60) + 0.9/(1+60) = 0.0164208
+///   id2 = 0.1/(1+60) + 0.9/(0+60) = 0.0166393
+/// so the sparse-dominant id2 wins -> order [2, 1]. Plain RRF would have tied
+/// AND ignored the weights, so this order + the distinct scores prove the fix.
 #[test]
-fn test_sql_weighted_strategy_downgrades_to_rrf_bug_a() {
+fn test_sql_weighted_strategy_honors_branch_weights() {
     let (_dir, db) = create_test_db();
     setup_wb_collection(&db);
 
     let results = execute_sql(
         &db,
         "SELECT * FROM wb WHERE vector NEAR [1.0, 0.0] AND vector SPARSE_NEAR {10: 1.0} \
-         LIMIT 2 USING FUSION(strategy = 'weighted')",
+         LIMIT 2 USING FUSION(strategy = 'weighted', dense_w = 0.1, sparse_w = 0.9)",
     )
     .expect("test: execute hybrid weighted query");
 
+    let ids: Vec<u64> = results.iter().map(|r| r.point.id).collect();
     assert_eq!(
-        results.len(),
-        2,
-        "both docs surface across the two branches"
+        ids,
+        vec![2, 1],
+        "sparse-heavy weights rank the sparse-dominant doc first"
     );
-    for r in &results {
-        assert!(
-            approx_eq(r.score, 0.032_522_5, 1e-4),
-            "Bug A: SQL 'weighted' ran RRF{{60}} -> symmetric tie 0.0325225, got {}",
-            r.score
-        );
-    }
+
+    let score_of = |want: u64| {
+        results
+            .iter()
+            .find(|r| r.point.id == want)
+            .map(|r| r.score)
+            .expect("test: id present in results")
+    };
+    assert!(
+        approx_eq(score_of(2), 0.016_639_3, 1e-5),
+        "id2 weighted-RRF score, got {}",
+        score_of(2)
+    );
+    assert!(
+        approx_eq(score_of(1), 0.016_420_8, 1e-5),
+        "id1 weighted-RRF score, got {}",
+        score_of(1)
+    );
 }


### PR DESCRIPTION
## Fix: SQL `USING FUSION(strategy='weighted')` now honors per-branch weights

Surfaced by the VelesQL conformance pass (#1185). On a dense+sparse hybrid,
`... USING FUSION(strategy='weighted', dense_w=, sparse_w=)` **silently
downgraded to plain `RRF{k:60}`**, discarding the weights the user supplied
(`sparse_dispatch.rs` `resolve_fusion_strategy` mapped `Weighted => rrf_default()`).

### Fix
Route `'weighted'` to **weighted Reciprocal Rank Fusion** over the two branches
(branch 0 = dense `NEAR`, branch 1 = sparse), passing `dense_w`/`sparse_w` and
`k` through to `FusionStrategy::weighted_rrf`. Invalid input (e.g. a negative
weight) falls back to RRF, matching the RSF arm's defensive style.

### Test
`fusion_weighted_bug.rs` Bug-A test flipped from a downgrade-lock to a
fix-verification: with sparse-heavy weights `dense_w=0.1, sparse_w=0.9`, the
sparse-dominant doc now ranks first (`[2, 1]`) with distinct weighted-RRF scores
(id2 0.0166393 > id1 0.0164208) — plain RRF would have tied **and** ignored the
weights.

### Deliberately NOT fixed
The unrelated `ScoreFusionMethod::Weighted == Average` smell
(`score_fusion/mod.rs:248`) is a **dead path** — that per-result combiner is
never selected by any query (live hybrid ranking uses `text.rs` weighted-RRF +
the `FusionStrategy` enum). Giving it a per-component weight API would be
speculative complexity for code nothing selects, so it stays a characterization
lock (doc-comment updated to say so).

Single production line changed (`sparse_dispatch.rs`) + one test. clippy
pedantic (core lib+tests) + fmt clean; fusion/sparse BDD pass.
