### PR TITLE
fix(security): add input-bounds limits [superseded — see fix/input-bounds-limits]

### DIFF
--- a/crates/velesdb-core/src/api_types/requests.rs
+++ b/crates/velesdb-core/src/api_types/requests.rs
@@ -142,13 +142,21 @@ pub enum SparseVectorInput {
     Dict(BTreeMap<String, f32>),
 }
 
+/// Maximum non-zero entries (NNZ) allowed in a single sparse vector.
+///
+/// Prevents memory amplification: a 100 MB JSON body of sparse indices/values
+/// can decompress to a much larger in-memory `Vec<(u32, f32)>`. Sparse NLP
+/// embeddings (SPLADE, BM25) typically have < 1 K NNZ; 65 536 gives a 60× headroom
+/// over typical workloads while bounding worst-case allocation to ~512 KB per vector.
+pub const MAX_SPARSE_NNZ: usize = 65_536;
+
 impl SparseVectorInput {
     /// Converts this input into a core `SparseVector`, validating at the API boundary.
     ///
     /// # Errors
     ///
     /// Returns a descriptive error string on mismatched lengths, non-finite values,
-    /// or dict keys that cannot be parsed as `u32`.
+    /// NNZ exceeding [`MAX_SPARSE_NNZ`], or dict keys that cannot be parsed as `u32`.
     pub fn into_sparse_vector(self) -> Result<crate::sparse_index::SparseVector, String> {
         match self {
             Self::Parallel { indices, values } => Self::convert_parallel(indices, values),
@@ -160,6 +168,12 @@ impl SparseVectorInput {
         indices: Vec<u32>,
         values: Vec<f32>,
     ) -> Result<crate::sparse_index::SparseVector, String> {
+        if indices.len() > MAX_SPARSE_NNZ {
+            return Err(format!(
+                "Sparse vector too large: {} non-zero entries (max {MAX_SPARSE_NNZ})",
+                indices.len()
+            ));
+        }
         if indices.len() != values.len() {
             return Err(format!(
                 "Sparse vector indices/values length mismatch: {} indices vs {} values",
@@ -181,6 +195,12 @@ impl SparseVectorInput {
     fn convert_dict(
         map: BTreeMap<String, f32>,
     ) -> Result<crate::sparse_index::SparseVector, String> {
+        if map.len() > MAX_SPARSE_NNZ {
+            return Err(format!(
+                "Sparse vector too large: {} non-zero entries (max {MAX_SPARSE_NNZ})",
+                map.len()
+            ));
+        }
         let mut pairs = Vec::with_capacity(map.len());
         for (key, value) in map {
             if !value.is_finite() {
@@ -529,4 +549,63 @@ pub struct GuardRailsConfigRequest {
     /// Circuit breaker: recovery time in seconds.
     #[cfg_attr(feature = "openapi", schema(example = 30))]
     pub circuit_recovery_seconds: Option<u64>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sparse_parallel_rejects_oversized_nnz() {
+        let n = MAX_SPARSE_NNZ + 1;
+        let err = SparseVectorInput::Parallel {
+            indices: vec![0u32; n],
+            values: vec![1.0f32; n],
+        }
+        .into_sparse_vector()
+        .unwrap_err();
+        assert!(err.contains("too large"), "expected size error, got: {err}");
+    }
+
+    #[test]
+    fn sparse_dict_rejects_oversized_nnz() {
+        let map: BTreeMap<String, f32> = (0..=MAX_SPARSE_NNZ)
+            .map(|i| (i.to_string(), 1.0))
+            .collect();
+        let err = SparseVectorInput::Dict(map).into_sparse_vector().unwrap_err();
+        assert!(err.contains("too large"), "expected size error, got: {err}");
+    }
+
+    #[test]
+    fn sparse_parallel_accepts_max_nnz() {
+        let n = MAX_SPARSE_NNZ;
+        let sv = SparseVectorInput::Parallel {
+            indices: (0..n as u32).collect(),
+            values: vec![1.0f32; n],
+        }
+        .into_sparse_vector();
+        assert!(sv.is_ok());
+    }
+
+    #[test]
+    fn sparse_parallel_rejects_length_mismatch() {
+        let err = SparseVectorInput::Parallel {
+            indices: vec![0, 1],
+            values: vec![1.0],
+        }
+        .into_sparse_vector()
+        .unwrap_err();
+        assert!(err.contains("mismatch"), "expected mismatch error, got: {err}");
+    }
+
+    #[test]
+    fn sparse_parallel_rejects_non_finite_value() {
+        let err = SparseVectorInput::Parallel {
+            indices: vec![0],
+            values: vec![f32::NAN],
+        }
+        .into_sparse_vector()
+        .unwrap_err();
+        assert!(err.contains("not finite"), "expected finite error, got: {err}");
+    }
 }

--- a/crates/velesdb-server/src/handlers/points/mod.rs
+++ b/crates/velesdb-server/src/handlers/points/mod.rs
@@ -87,6 +87,14 @@ fn merge_named_sparse_vectors(
     Ok(())
 }
 
+/// Maximum number of points in a single JSON upsert request.
+///
+/// Consistent with `MAX_BULK_DELETE_SIZE` and `MAX_SCROLL_BATCH_SIZE`.
+/// The 100 MB body limit on the route already bounds bytes; this constant
+/// bounds the point *count* to prevent memory amplification from metadata-only
+/// or tiny-vector collections where 100 MB of JSON can represent millions of points.
+const MAX_UPSERT_BATCH_SIZE: usize = 100_000;
+
 /// Upsert points to a collection.
 #[utoipa::path(
     post,
@@ -99,7 +107,7 @@ fn merge_named_sparse_vectors(
     responses(
         (status = 200, description = "Points upserted", body = Object),
         (status = 404, description = "Collection not found", body = ErrorResponse),
-        (status = 400, description = "Invalid request", body = ErrorResponse)
+        (status = 400, description = "Invalid request or batch too large", body = ErrorResponse)
     )
 )]
 pub async fn upsert_points(
@@ -107,6 +115,16 @@ pub async fn upsert_points(
     Path(name): Path<String>,
     Json(req): Json<UpsertPointsRequest>,
 ) -> impl IntoResponse {
+    if req.points.len() > MAX_UPSERT_BATCH_SIZE {
+        return error_response(
+            StatusCode::BAD_REQUEST,
+            format!(
+                "Batch too large: {} points (max {MAX_UPSERT_BATCH_SIZE})",
+                req.points.len()
+            ),
+        );
+    }
+
     let collection = match get_vector_collection_or_404(&state, &name) {
         Ok(c) => c,
         Err(resp) => return resp,
@@ -416,5 +434,31 @@ pub async fn bulk_delete_points(
             StatusCode::INTERNAL_SERVER_ERROR,
             format!("bulk_delete task panicked: {join_err}"),
         ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn upsert_batch_constant_matches_expected_value() {
+        assert_eq!(MAX_UPSERT_BATCH_SIZE, 100_000);
+    }
+
+    #[test]
+    fn scroll_batch_constant_matches_expected_value() {
+        assert_eq!(MAX_SCROLL_BATCH_SIZE, 10_000);
+    }
+
+    #[test]
+    fn bulk_delete_batch_constant_matches_expected_value() {
+        assert_eq!(MAX_BULK_DELETE_SIZE, 10_000);
+    }
+
+    #[test]
+    fn upsert_batch_limit_is_larger_than_delete_limit() {
+        // Upsert is intentionally higher: ingestion workloads need larger batches.
+        assert!(MAX_UPSERT_BATCH_SIZE > MAX_BULK_DELETE_SIZE);
     }
 }

--- a/crates/velesdb-server/src/handlers/points/raw.rs
+++ b/crates/velesdb-server/src/handlers/points/raw.rs
@@ -13,7 +13,7 @@ use axum::{body::Bytes, extract::Path, extract::State, http::StatusCode, respons
 use std::sync::Arc;
 use velesdb_core::wire::vrb1;
 
-use super::upsert_result_to_response;
+use super::{upsert_result_to_response, MAX_UPSERT_BATCH_SIZE};
 use crate::handlers::helpers::{error_response, get_vector_collection_or_404};
 use crate::types::ErrorResponse;
 use crate::AppState;
@@ -53,6 +53,16 @@ pub async fn upsert_points_raw(
         Ok(b) => b,
         Err(err) => return error_response(StatusCode::BAD_REQUEST, err.to_string()),
     };
+
+    if batch.ids.len() > MAX_UPSERT_BATCH_SIZE {
+        return error_response(
+            StatusCode::BAD_REQUEST,
+            format!(
+                "Batch too large: {} points (max {MAX_UPSERT_BATCH_SIZE})",
+                batch.ids.len()
+            ),
+        );
+    }
 
     let dimension = batch.dimension;
     let ids = batch.ids;

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1789,7 +1789,7 @@
             }
           },
           "400": {
-            "description": "Invalid request",
+            "description": "Invalid request or batch too large",
             "content": {
               "application/json": {
                 "schema": {
@@ -3443,16 +3443,10 @@
         ],
         "properties": {
           "id": {
-            "oneOf": [
-              {
-                "type": "integer",
-                "format": "int64"
-              },
-              {
-                "type": "string"
-              }
-            ],
-            "description": "Point ID. Accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss."
+            "type": "integer",
+            "format": "int64",
+            "description": "Edge ID.",
+            "minimum": 0
           },
           "label": {
             "type": "string",
@@ -3462,28 +3456,16 @@
             "description": "Edge properties."
           },
           "source": {
-            "oneOf": [
-              {
-                "type": "integer",
-                "format": "int64"
-              },
-              {
-                "type": "string"
-              }
-            ],
-            "description": "Point ID. Accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss."
+            "type": "integer",
+            "format": "int64",
+            "description": "Source node ID.",
+            "minimum": 0
           },
           "target": {
-            "oneOf": [
-              {
-                "type": "integer",
-                "format": "int64"
-              },
-              {
-                "type": "string"
-              }
-            ],
-            "description": "Point ID. Accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss."
+            "type": "integer",
+            "format": "int64",
+            "description": "Target node ID.",
+            "minimum": 0
           }
         }
       },
@@ -4049,8 +4031,10 @@
         ],
         "properties": {
           "id": {
-            "type": "string",
-            "description": "Edge ID."
+            "type": "integer",
+            "format": "int64",
+            "description": "Edge ID.",
+            "minimum": 0
           },
           "label": {
             "type": "string",
@@ -4060,12 +4044,16 @@
             "description": "Edge properties."
           },
           "source": {
-            "type": "string",
-            "description": "Source node ID."
+            "type": "integer",
+            "format": "int64",
+            "description": "Source node ID.",
+            "minimum": 0
           },
           "target": {
-            "type": "string",
-            "description": "Target node ID."
+            "type": "integer",
+            "format": "int64",
+            "description": "Target node ID.",
+            "minimum": 0
           }
         }
       },
@@ -4503,8 +4491,10 @@
         ],
         "properties": {
           "id": {
-            "type": "string",
-            "description": "Node ID."
+            "type": "integer",
+            "format": "int64",
+            "description": "Node ID.",
+            "minimum": 0
           },
           "payload": {
             "description": "Node payload (if any)."
@@ -4931,16 +4921,14 @@
         "properties": {
           "bindings": {
             "type": "object",
+            "description": "Variable bindings from pattern matching.",
             "additionalProperties": {
-              "oneOf": [
-                {
-                  "type": "integer",
-                  "format": "int64"
-                },
-                {
-                  "type": "string"
-                }
-              ]
+              "type": "integer",
+              "format": "int64",
+              "minimum": 0
+            },
+            "propertyNames": {
+              "type": "string"
             }
           },
           "depth": {
@@ -5062,16 +5050,11 @@
           "node_ids": {
             "type": "array",
             "items": {
-              "oneOf": [
-                {
-                  "type": "integer",
-                  "format": "int64"
-                },
-                {
-                  "type": "string"
-                }
-              ]
-            }
+              "type": "integer",
+              "format": "int64",
+              "minimum": 0
+            },
+            "description": "List of node IDs (serialized as strings to preserve u64 precision in JS)."
           }
         }
       },
@@ -5083,8 +5066,10 @@
         ],
         "properties": {
           "node_id": {
-            "type": "string",
-            "description": "Node ID."
+            "type": "integer",
+            "format": "int64",
+            "description": "Node ID.",
+            "minimum": 0
           },
           "payload": {
             "description": "Stored payload (null if none)."
@@ -5164,16 +5149,11 @@
           "sources": {
             "type": "array",
             "items": {
-              "oneOf": [
-                {
-                  "type": "integer",
-                  "format": "int64"
-                },
-                {
-                  "type": "string"
-                }
-              ]
-            }
+              "type": "integer",
+              "format": "int64",
+              "minimum": 0
+            },
+            "description": "Source node IDs to start traversal from (accepts strings or numbers so\nJS clients can send precision-safe u64 IDs above `Number.MAX_SAFE_INTEGER`)."
           }
         }
       },
@@ -5378,28 +5358,16 @@
             "description": "Relationship type label (e.g. `\"KNOWS\"`, `\"RELATED_TO\"`)."
           },
           "source": {
-            "oneOf": [
-              {
-                "type": "integer",
-                "format": "int64"
-              },
-              {
-                "type": "string"
-              }
-            ],
-            "description": "Point ID. Accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss."
+            "type": "integer",
+            "format": "int64",
+            "description": "Source point ID.",
+            "minimum": 0
           },
           "target": {
-            "oneOf": [
-              {
-                "type": "integer",
-                "format": "int64"
-              },
-              {
-                "type": "string"
-              }
-            ],
-            "description": "Point ID. Accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss."
+            "type": "integer",
+            "format": "int64",
+            "description": "Target point ID.",
+            "minimum": 0
           }
         }
       },
@@ -5411,8 +5379,10 @@
         ],
         "properties": {
           "edge_id": {
-            "type": "string",
-            "description": "Allocated edge ID."
+            "type": "integer",
+            "format": "int64",
+            "description": "Allocated edge ID.",
+            "minimum": 0
           }
         }
       },
@@ -5428,8 +5398,10 @@
         ],
         "properties": {
           "id": {
-            "type": "string",
-            "description": "Edge ID."
+            "type": "integer",
+            "format": "int64",
+            "description": "Edge ID.",
+            "minimum": 0
           },
           "properties": {
             "description": "Edge properties (null when empty)."
@@ -5439,12 +5411,16 @@
             "description": "Relationship type label."
           },
           "source": {
-            "type": "string",
-            "description": "Source point ID."
+            "type": "integer",
+            "format": "int64",
+            "description": "Source point ID.",
+            "minimum": 0
           },
           "target": {
-            "type": "string",
-            "description": "Target point ID."
+            "type": "integer",
+            "format": "int64",
+            "description": "Target point ID.",
+            "minimum": 0
           }
         }
       },
@@ -5832,22 +5808,19 @@
             "minimum": 0
           },
           "id": {
-            "type": "string",
-            "description": "Target node ID."
+            "type": "integer",
+            "format": "int64",
+            "description": "Target node ID.",
+            "minimum": 0
           },
           "path": {
             "type": "array",
             "items": {
-              "oneOf": [
-                {
-                  "type": "integer",
-                  "format": "int64"
-                },
-                {
-                  "type": "string"
-                }
-              ]
-            }
+              "type": "integer",
+              "format": "int64",
+              "minimum": 0
+            },
+            "description": "Path of edge IDs taken to reach this node."
           }
         }
       },
@@ -5921,20 +5894,17 @@
           "path": {
             "type": "array",
             "items": {
-              "oneOf": [
-                {
-                  "type": "integer",
-                  "format": "int64"
-                },
-                {
-                  "type": "string"
-                }
-              ]
-            }
+              "type": "integer",
+              "format": "int64",
+              "minimum": 0
+            },
+            "description": "Path taken (list of edge IDs)."
           },
           "target_id": {
-            "type": "string",
-            "description": "Target node ID reached."
+            "type": "integer",
+            "format": "int64",
+            "description": "Target node ID reached.",
+            "minimum": 0
           }
         }
       },
@@ -5985,16 +5955,10 @@
             "description": "Filter by relationship types (empty = all types)."
           },
           "source": {
-            "oneOf": [
-              {
-                "type": "integer",
-                "format": "int64"
-              },
-              {
-                "type": "string"
-              }
-            ],
-            "description": "Point ID. Accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss."
+            "type": "integer",
+            "format": "int64",
+            "description": "Source node ID to start traversal from.",
+            "minimum": 0
           },
           "strategy": {
             "type": "string",

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1164,7 +1164,7 @@ paths:
               schema:
                 type: object
         '400':
-          description: Invalid request
+          description: Invalid request or batch too large
           content:
             application/json:
               schema:
@@ -2275,28 +2275,25 @@ components:
       - label
       properties:
         id:
-          oneOf:
-          - type: integer
-            format: int64
-          - type: string
-          description: Point ID. Accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss.
+          type: integer
+          format: int64
+          description: Edge ID.
+          minimum: 0
         label:
           type: string
           description: Edge label (relationship type).
         properties:
           description: Edge properties.
         source:
-          oneOf:
-          - type: integer
-            format: int64
-          - type: string
-          description: Point ID. Accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss.
+          type: integer
+          format: int64
+          description: Source node ID.
+          minimum: 0
         target:
-          oneOf:
-          - type: integer
-            format: int64
-          - type: string
-          description: Point ID. Accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss.
+          type: integer
+          format: int64
+          description: Target node ID.
+          minimum: 0
     AddEdgesBatchRequest:
       type: object
       description: Request to add multiple edges in one batched operation.
@@ -2776,19 +2773,25 @@ components:
       - properties
       properties:
         id:
-          type: string
+          type: integer
+          format: int64
           description: Edge ID.
+          minimum: 0
         label:
           type: string
           description: Edge label (relationship type).
         properties:
           description: Edge properties.
         source:
-          type: string
+          type: integer
+          format: int64
           description: Source node ID.
+          minimum: 0
         target:
-          type: string
+          type: integer
+          format: int64
           description: Target node ID.
+          minimum: 0
     EdgesResponse:
       type: object
       description: Response containing edges.
@@ -3121,8 +3124,10 @@ components:
       - score
       properties:
         id:
-          type: string
+          type: integer
+          format: int64
           description: Node ID.
+          minimum: 0
         payload:
           description: Node payload (if any).
         score:
@@ -3448,11 +3453,13 @@ components:
       properties:
         bindings:
           type: object
+          description: Variable bindings from pattern matching.
           additionalProperties:
-            oneOf:
-            - type: integer
-              format: int64
-            - type: string
+            type: integer
+            format: int64
+            minimum: 0
+          propertyNames:
+            type: string
         depth:
           type: integer
           format: int32
@@ -3546,10 +3553,10 @@ components:
         node_ids:
           type: array
           items:
-            oneOf:
-            - type: integer
-              format: int64
-            - type: string
+            type: integer
+            format: int64
+            minimum: 0
+          description: List of node IDs (serialized as strings to preserve u64 precision in JS).
     NodePayloadResponse:
       type: object
       description: Response for a node payload retrieval.
@@ -3557,8 +3564,10 @@ components:
       - node_id
       properties:
         node_id:
-          type: string
+          type: integer
+          format: int64
           description: Node ID.
+          minimum: 0
         payload:
           description: Stored payload (null if none).
     NodeStatsResponse:
@@ -3634,10 +3643,12 @@ components:
         sources:
           type: array
           items:
-            oneOf:
-            - type: integer
-              format: int64
-            - type: string
+            type: integer
+            format: int64
+            minimum: 0
+          description: |-
+            Source node IDs to start traversal from (accepts strings or numbers so
+            JS clients can send precision-safe u64 IDs above `Number.MAX_SAFE_INTEGER`).
     PointRequest:
       type: object
       description: A point in an upsert request.
@@ -3801,17 +3812,15 @@ components:
           type: string
           description: Relationship type label (e.g. `"KNOWS"`, `"RELATED_TO"`).
         source:
-          oneOf:
-          - type: integer
-            format: int64
-          - type: string
-          description: Point ID. Accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss.
+          type: integer
+          format: int64
+          description: Source point ID.
+          minimum: 0
         target:
-          oneOf:
-          - type: integer
-            format: int64
-          - type: string
-          description: Point ID. Accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss.
+          type: integer
+          format: int64
+          description: Target point ID.
+          minimum: 0
     RelateResponse:
       type: object
       description: Response body for `POST /collections/{name}/relations`.
@@ -3819,8 +3828,10 @@ components:
       - edge_id
       properties:
         edge_id:
-          type: string
+          type: integer
+          format: int64
           description: Allocated edge ID.
+          minimum: 0
     RelationEdge:
       type: object
       description: A single relation edge in a response.
@@ -3832,19 +3843,25 @@ components:
       - properties
       properties:
         id:
-          type: string
+          type: integer
+          format: int64
           description: Edge ID.
+          minimum: 0
         properties:
           description: Edge properties (null when empty).
         rel_type:
           type: string
           description: Relationship type label.
         source:
-          type: string
+          type: integer
+          format: int64
           description: Source point ID.
+          minimum: 0
         target:
-          type: string
+          type: integer
+          format: int64
           description: Target point ID.
+          minimum: 0
     RelationsResponse:
       type: object
       description: Response body for `GET /collections/{name}/points/{id}/relations`.
@@ -4123,15 +4140,17 @@ components:
           description: Depth from source.
           minimum: 0
         id:
-          type: string
+          type: integer
+          format: int64
           description: Target node ID.
+          minimum: 0
         path:
           type: array
           items:
-            oneOf:
-            - type: integer
-              format: int64
-            - type: string
+            type: integer
+            format: int64
+            minimum: 0
+          description: Path of edge IDs taken to reach this node.
     StreamStatsEvent:
       type: object
       description: 'SSE event: Periodic statistics update.'
@@ -4187,13 +4206,15 @@ components:
         path:
           type: array
           items:
-            oneOf:
-            - type: integer
-              format: int64
-            - type: string
+            type: integer
+            format: int64
+            minimum: 0
+          description: Path taken (list of edge IDs).
         target_id:
-          type: string
+          type: integer
+          format: int64
           description: Target node ID reached.
+          minimum: 0
     TraversalStats:
       type: object
       description: Statistics from traversal operation.
@@ -4231,11 +4252,10 @@ components:
             type: string
           description: Filter by relationship types (empty = all types).
         source:
-          oneOf:
-          - type: integer
-            format: int64
-          - type: string
-          description: Point ID. Accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss.
+          type: integer
+          format: int64
+          description: Source node ID to start traversal from.
+          minimum: 0
         strategy:
           type: string
           description: 'Traversal strategy: "bfs" or "dfs".'


### PR DESCRIPTION
## Summary

Adds missing point-count and sparse-NNZ guards, consistent with the existing `MAX_SCROLL_BATCH_SIZE` (10 K) and `MAX_BULK_DELETE_SIZE` (10 K) limits, on the two ingest paths that had none.

### `MAX_UPSERT_BATCH_SIZE = 100 000`

- Enforced in **JSON upsert** (`POST /collections/{name}/points`) — checked before `build_points_from_request`, returns `400 BAD_REQUEST` with a clear message.
- Enforced in **binary VRB1 raw upsert** (`POST /collections/{name}/points/raw`) — checked after `vrb1::decode`, same response.
- Ingestion workloads legitimately need larger batches than read/delete (hence 100 K vs 10 K), but without any limit a metadata-only or tiny-vector corpus can fit millions of rows in a single 100 MB body, causing unbounded memory growth during deserialization and HNSW insertion.

### `MAX_SPARSE_NNZ = 65 536` — in `velesdb-core::api_types::requests`

- Checked in `SparseVectorInput::convert_parallel` and `convert_dict` before the `Vec<(u32, f32)>` allocation.
- SPLADE / BM25 embeddings typically have < 1 K NNZ; 64 K gives 60× real-world headroom while bounding worst-case heap use to ~512 KB per sparse vector. Without this a single parallel-format sparse vector with every entry set costs 100 MB / (2 bytes per JSON char × 2 entries per pair) ≈ 25 M NNZ → ~200 MB heap.

### OpenAPI spec sync

Also regenerates `docs/openapi.json` / `docs/openapi.yaml` which had pre-existing drift: edge/node ID schemas and the `400` description on the JSON upsert endpoint.

## Test plan

- [x] `cargo check --package velesdb-server --package velesdb-core` — clean
- [x] `cargo test --package velesdb-server --lib` — 148 passed, 0 failed
- [x] `cargo test --package velesdb-core --lib api_types` — 81 passed, 0 failed
- [x] New tests: `handlers::points::tests` (constant-value sanity + ordering invariant)
- [x] New tests: `api_types::requests::tests` (oversized-NNZ rejection × 2, max-NNZ acceptance, length-mismatch, non-finite rejection)

## Security impact (2026-06-22)

| Path | Before | After |
|------|--------|-------|
| `POST /points` JSON | ∞ points | 100 000 |
| `POST /points/raw` VRB1 | ∞ points | 100 000 |
| Sparse NNZ | ∞ | 65 536 |
| `POST /points/scroll` | 10 000 (existing) | unchanged |
| `POST /points/delete` | 10 000 (existing) | unchanged |


https://claude.ai/code/session_01ESgTviGUEHaB8DkAPZi6ZQ
