### PR TITLE
fix: DRY SSE serialization helper + warn on silent fusion fallbacks

### DIFF
--- a/crates/velesdb-core/src/collection/search/query/sparse_dispatch.rs
+++ b/crates/velesdb-core/src/collection/search/query/sparse_dispatch.rs
@@ -202,16 +202,15 @@ impl Collection {
                     FusionStrategyType::Rsf => {
                         let dw = fc.dense_weight.unwrap_or(0.5);
                         let sw = fc.sparse_weight.unwrap_or(0.5);
-                        crate::fusion::FusionStrategy::relative_score(dw, sw)
-                            .unwrap_or_else(|e| {
-                                warn!(
-                                    dense_weight = dw,
-                                    sparse_weight = sw,
-                                    error = %e,
-                                    "RSF fusion strategy invalid; falling back to RRF"
-                                );
-                                crate::fusion::FusionStrategy::rrf_default()
-                            })
+                        crate::fusion::FusionStrategy::relative_score(dw, sw).unwrap_or_else(|e| {
+                            warn!(
+                                dense_weight = dw,
+                                sparse_weight = sw,
+                                error = %e,
+                                "RSF fusion strategy invalid; falling back to RRF"
+                            );
+                            crate::fusion::FusionStrategy::rrf_default()
+                        })
                     }
                     FusionStrategyType::Rrf => crate::fusion::FusionStrategy::RRF {
                         k: fc.k.unwrap_or(60),
@@ -227,8 +226,8 @@ impl Collection {
                         let sw = fc.sparse_weight.unwrap_or(0.5);
                         #[allow(clippy::cast_precision_loss)]
                         let k = fc.k.unwrap_or(60) as f32;
-                        crate::fusion::FusionStrategy::weighted_rrf(vec![dw, sw], k)
-                            .unwrap_or_else(|e| {
+                        crate::fusion::FusionStrategy::weighted_rrf(vec![dw, sw], k).unwrap_or_else(
+                            |e| {
                                 warn!(
                                     dense_weight = dw,
                                     sparse_weight = sw,
@@ -237,7 +236,8 @@ impl Collection {
                                     "Weighted RRF fusion strategy invalid; falling back to RRF"
                                 );
                                 crate::fusion::FusionStrategy::rrf_default()
-                            })
+                            },
+                        )
                     }
                 }
             })

--- a/crates/velesdb-core/src/collection/search/query/sparse_dispatch.rs
+++ b/crates/velesdb-core/src/collection/search/query/sparse_dispatch.rs
@@ -5,6 +5,7 @@
 //! filtering, result finalization, and fusion strategy resolution.
 
 use super::{distinct, Collection, ExtractedComponents, Result, SearchResult, MAX_LIMIT};
+use tracing::warn;
 
 impl Collection {
     /// Dispatches sparse-only or hybrid dense+sparse search.
@@ -202,7 +203,15 @@ impl Collection {
                         let dw = fc.dense_weight.unwrap_or(0.5);
                         let sw = fc.sparse_weight.unwrap_or(0.5);
                         crate::fusion::FusionStrategy::relative_score(dw, sw)
-                            .unwrap_or_else(|_| crate::fusion::FusionStrategy::rrf_default())
+                            .unwrap_or_else(|e| {
+                                warn!(
+                                    dense_weight = dw,
+                                    sparse_weight = sw,
+                                    error = %e,
+                                    "RSF fusion strategy invalid; falling back to RRF"
+                                );
+                                crate::fusion::FusionStrategy::rrf_default()
+                            })
                     }
                     FusionStrategyType::Rrf => crate::fusion::FusionStrategy::RRF {
                         k: fc.k.unwrap_or(60),
@@ -219,7 +228,16 @@ impl Collection {
                         #[allow(clippy::cast_precision_loss)]
                         let k = fc.k.unwrap_or(60) as f32;
                         crate::fusion::FusionStrategy::weighted_rrf(vec![dw, sw], k)
-                            .unwrap_or_else(|_| crate::fusion::FusionStrategy::rrf_default())
+                            .unwrap_or_else(|e| {
+                                warn!(
+                                    dense_weight = dw,
+                                    sparse_weight = sw,
+                                    k,
+                                    error = %e,
+                                    "Weighted RRF fusion strategy invalid; falling back to RRF"
+                                );
+                                crate::fusion::FusionStrategy::rrf_default()
+                            })
                     }
                 }
             })

--- a/crates/velesdb-server/src/handlers/graph/stream.rs
+++ b/crates/velesdb-server/src/handlers/graph/stream.rs
@@ -30,6 +30,7 @@ use axum::{
 use futures::stream::{self, Stream};
 use std::convert::Infallible;
 use std::time::Instant;
+use tracing::warn;
 
 use std::sync::Arc;
 
@@ -151,6 +152,18 @@ fn build_sse_events(
     }
 }
 
+/// Serializes an SSE event payload to JSON, logging a warning if serialization fails.
+///
+/// All current event types contain only primitives and are practically infallible.
+/// The fallback exists as a safety net: it emits a well-formed JSON error object
+/// rather than the misleading `"{}"` that would silently mask a real schema bug.
+fn serialize_sse_event<T: serde::Serialize>(event: &T, event_type: &str) -> String {
+    serde_json::to_string(event).unwrap_or_else(|e| {
+        warn!(event_type, error = %e, "SSE event serialization failed; sending error fallback");
+        r#"{"error":"internal: event serialization failed"}"#.to_string()
+    })
+}
+
 fn build_success_events(
     results: Vec<TraversalResultItem>,
     start_time: Instant,
@@ -169,7 +182,7 @@ fn build_success_events(
             depth: item.depth,
             path: item.path,
         };
-        let event_data = serde_json::to_string(&node_event).unwrap_or_else(|_| "{}".to_string());
+        let event_data = serialize_sse_event(&node_event, "node");
         events.push(Ok(Event::default().event("node").data(event_data)));
 
         if (i + 1) % STATS_INTERVAL == 0 {
@@ -177,8 +190,7 @@ fn build_success_events(
                 nodes_visited: i + 1,
                 elapsed_ms: elapsed_ms(start_time),
             };
-            let stats_data =
-                serde_json::to_string(&stats_event).unwrap_or_else(|_| "{}".to_string());
+            let stats_data = serialize_sse_event(&stats_event, "stats");
             events.push(Ok(Event::default().event("stats").data(stats_data)));
         }
     }
@@ -188,7 +200,7 @@ fn build_success_events(
         max_depth_reached: max_depth,
         elapsed_ms: elapsed_ms(start_time),
     };
-    let done_data = serde_json::to_string(&done_event).unwrap_or_else(|_| "{}".to_string());
+    let done_data = serialize_sse_event(&done_event, "done");
     events.push(Ok(Event::default().event("done").data(done_data)));
 
     events
@@ -196,7 +208,7 @@ fn build_success_events(
 
 fn build_error_events(error: String) -> Vec<Result<Event, Infallible>> {
     let error_event = StreamErrorEvent { error };
-    let error_data = serde_json::to_string(&error_event).unwrap_or_else(|_| "{}".to_string());
+    let error_data = serialize_sse_event(&error_event, "error");
     vec![Ok(Event::default().event("error").data(error_data))]
 }
 


### PR DESCRIPTION
## Summary

Two targeted code-quality fixes identified during the code sweep (2026-06-23):

### Fix 1 — `stream.rs`: Extract `serialize_sse_event` DRY helper

**Problem**: 4 identical `serde_json::to_string(&x).unwrap_or_else(|_| "{}".to_string())` patterns across `build_success_events` and `build_error_events`.
- DRY violation: same logic copy-pasted 4 times
- Wrong fallback for error events: `"{}"` (empty object) silently discards the error payload the client needs
- Silent failure: no log output when serialization falls back, making bugs invisible in production

**Fix**: Single `serialize_sse_event<T: Serialize>(event, event_type)` helper that:
- Returns a well-formed `{"error":"internal: event serialization failed"}` fallback (not `"{}"`)
- Emits `tracing::warn!` with `event_type` and the serde error for operator visibility

### Fix 2 — `sparse_dispatch.rs`: Log warning on RSF / Weighted RRF fusion fallback

**Problem**: When `FUSION RSF` or `FUSION WEIGHTED` clause weights fail validation (e.g. negative weight), the code silently substitutes RRF with no log output. The user's requested strategy is ignored with zero observability.

**Fix**: Both `unwrap_or_else` fallback closures now emit `tracing::warn!` recording the requested `dense_weight`, `sparse_weight`, `k`, and the validation error before substituting RRF.

## Test plan

- [ ] `cargo check -p velesdb-server -p velesdb-core` — clean (verified locally)
- [ ] Existing unit tests in `stream.rs` and `sparse_dispatch.rs` continue to pass
- [ ] No functional change to SSE event output for the happy path (serialization of primitive-only structs is infallible)
- [ ] Fusion strategy selection is unchanged for valid weights; warning fires only on invalid input


https://claude.ai/code/session_01HCXgm83RbG6QjkGPKMFhe9
