### PR TITLE
fix(velesql): apply RETURN ORDER BY + LIMIT on the graph REST /match path

### DIFF
--- a/crates/velesdb-core/src/collection/core/crud_tests.rs
+++ b/crates/velesdb-core/src/collection/core/crud_tests.rs
@@ -1570,3 +1570,115 @@ fn test_full_scan_fallback_filters_by_labels() {
         large_base
     );
 }
+
+/// Builds a single-node `(n:Person)` MATCH clause with `RETURN n ORDER BY n.age`
+/// and an optional LIMIT, mirroring the AST the parser produces.
+#[cfg(test)]
+fn person_order_by_age_clause(descending: bool, limit: Option<u64>) -> crate::velesql::MatchClause {
+    crate::velesql::MatchClause {
+        patterns: vec![crate::velesql::GraphPattern {
+            name: None,
+            nodes: vec![crate::velesql::NodePattern::new()
+                .with_alias("n")
+                .with_label("Person")],
+            relationships: vec![],
+        }],
+        where_clause: None,
+        return_clause: crate::velesql::ReturnClause {
+            items: vec![crate::velesql::ReturnItem {
+                expression: "n".to_string(),
+                alias: None,
+            }],
+            order_by: Some(vec![crate::velesql::OrderByItem {
+                expr: crate::velesql::OrderByExpr::Field("n.age".to_string()),
+                descending,
+            }]),
+            limit,
+        },
+    }
+}
+
+/// Regression (parity backlog #1): the direct `execute_match` entry point — used
+/// by the graph REST `/match` endpoint and the Python/TS SDK bindings — must
+/// apply RETURN `ORDER BY`, not return raw traversal order. Before the fix only
+/// the SQL `/query` pipeline (`finalize_match_results`) ordered MATCH results,
+/// so `/match` and the SDKs silently ignored the clause and returned traversal
+/// order. Ages are scrambled vs id order so any traversal order differs from the
+/// requested age-descending order.
+#[test]
+fn test_execute_match_applies_order_by() {
+    let temp_dir = tempfile::tempdir().expect("temp dir");
+    let collection = Collection::create(PathBuf::from(temp_dir.path()), 4, DistanceMetric::Cosine)
+        .expect("collection");
+
+    let ages = [(1_u64, 30), (2, 10), (3, 50), (4, 20), (5, 40)];
+    let nodes: Vec<Point> = ages
+        .iter()
+        .map(|(id, age)| {
+            Point::new(
+                *id,
+                vec![1.0, 0.0, 0.0, 0.0],
+                Some(serde_json::json!({"_labels": ["Person"], "age": age})),
+            )
+        })
+        .collect();
+    collection.upsert(nodes).expect("upsert Person nodes");
+
+    let params = std::collections::HashMap::new();
+    let results = collection
+        .execute_match(&person_order_by_age_clause(true, Some(100)), &params)
+        .expect("execute_match should succeed");
+
+    let ordered_ids: Vec<u64> = results.iter().map(|r| r.node_id).collect();
+    assert_eq!(
+        ordered_ids,
+        vec![3, 5, 1, 4, 2],
+        "execute_match must order by n.age DESC (ages 50,40,30,20,10), not traversal order"
+    );
+}
+
+/// Regression (parity backlog #1): `execute_match_with_similarity` (the
+/// vector-body `/match` path) must let RETURN `ORDER BY` override the implicit
+/// similarity-score sort. Query vector scores ids 3>2>1, but `ORDER BY n.age
+/// DESC` (ages 50,30,10 -> ids 2,3,1) must win.
+#[test]
+fn test_execute_match_with_similarity_order_by_overrides_score() {
+    let temp_dir = tempfile::tempdir().expect("temp dir");
+    let collection = Collection::create(PathBuf::from(temp_dir.path()), 4, DistanceMetric::Cosine)
+        .expect("collection");
+
+    let rows = [
+        (1_u64, vec![1.0, 0.0, 0.0, 0.0], 10),
+        (2, vec![1.0, 1.0, 0.0, 0.0], 50),
+        (3, vec![1.0, 1.0, 1.0, 0.0], 30),
+    ];
+    let nodes: Vec<Point> = rows
+        .iter()
+        .map(|(id, v, age)| {
+            Point::new(
+                *id,
+                v.clone(),
+                Some(serde_json::json!({"_labels": ["Person"], "age": age})),
+            )
+        })
+        .collect();
+    collection.upsert(nodes).expect("upsert Person nodes");
+
+    let params = std::collections::HashMap::new();
+    let query_vector = vec![1.0, 1.0, 1.0, 1.0];
+    let results = collection
+        .execute_match_with_similarity(
+            &person_order_by_age_clause(true, Some(100)),
+            &query_vector,
+            0.0,
+            &params,
+        )
+        .expect("execute_match_with_similarity should succeed");
+
+    let ordered_ids: Vec<u64> = results.iter().map(|r| r.node_id).collect();
+    assert_eq!(
+        ordered_ids,
+        vec![2, 3, 1],
+        "ORDER BY n.age DESC must override the vector score sort (which would be 3,2,1)"
+    );
+}

--- a/crates/velesdb-core/src/collection/search/query/execution_paths.rs
+++ b/crates/velesdb-core/src/collection/search/query/execution_paths.rs
@@ -12,7 +12,10 @@ impl Collection {
         let anchor_alias = Self::resolve_anchor_alias(predicate, from_aliases)?;
         let clause = Self::build_anchor_match_clause(predicate);
 
-        let matches = self.execute_match(&clause, params)?;
+        // Anchor evaluation needs the full unordered match set (it collects bound
+        // ids into a set), so use the raw primitive rather than the ORDER BY/LIMIT
+        // entry point.
+        let matches = self.execute_match_with_context(&clause, params, None)?;
         let mut ids = HashSet::with_capacity(matches.len());
         for m in matches {
             if let Some(id) = m.bindings.get(&anchor_alias) {

--- a/crates/velesdb-core/src/collection/search/query/match_dispatch.rs
+++ b/crates/velesdb-core/src/collection/search/query/match_dispatch.rs
@@ -195,16 +195,8 @@ impl Collection {
             .inspect_err(|_| self.guard_rails.circuit_breaker.record_failure())?;
 
         let mut sorted = match_results;
-        if let Some(order_by) = match_clause.return_clause.order_by.as_ref() {
-            // Establish a deterministic baseline before the per-column sorts, so
-            // rows equal on every ORDER BY key resolve identically. Only when
-            // ORDER BY is present, so traversal-order output is otherwise kept.
-            sort_match_baseline(&mut sorted);
-            for item in order_by.iter().rev() {
-                self.order_match_results(&mut sorted, &item.expr, item.descending, params)
-                    .inspect_err(|_| self.guard_rails.circuit_breaker.record_failure())?;
-            }
-        }
+        self.apply_match_order_by(&mut sorted, match_clause, params)
+            .inspect_err(|_| self.guard_rails.circuit_breaker.record_failure())?;
 
         let mut results = self
             .match_results_to_search_results(sorted)
@@ -213,8 +205,7 @@ impl Collection {
         ctx.check_cardinality(results.len())
             .map_err(crate::error::Error::from)
             .inspect_err(|_| self.guard_rails.circuit_breaker.record_failure())?;
-        if let Some(limit) = match_clause.return_clause.limit {
-            let limit = usize::try_from(limit).unwrap_or(MAX_LIMIT).min(MAX_LIMIT);
+        if let Some(limit) = match_return_limit(match_clause) {
             results.truncate(limit);
         }
         // Reason: u128->u64 cast; query durations < u64::MAX µs (~585 millennia)
@@ -226,6 +217,40 @@ impl Collection {
         self.guard_rails.circuit_breaker.record_success();
         Ok(results)
     }
+
+    /// Applies RETURN `ORDER BY` (with the deterministic `(node_id, depth, path)`
+    /// tie-break baseline) to raw MATCH results in place. Sorts only when an
+    /// ORDER BY is present, so traversal-order output is otherwise preserved.
+    ///
+    /// Single source of truth shared by the SQL `/query` finalize path and the
+    /// direct `execute_match` / `execute_match_with_similarity` entry points
+    /// (REST `/match`, the SDKs) so every surface orders identically.
+    pub(in crate::collection::search::query) fn apply_match_order_by(
+        &self,
+        results: &mut [super::match_exec::MatchResult],
+        match_clause: &crate::velesql::MatchClause,
+        params: &std::collections::HashMap<String, serde_json::Value>,
+    ) -> Result<()> {
+        if let Some(order_by) = match_clause.return_clause.order_by.as_ref() {
+            sort_match_baseline(results);
+            for item in order_by.iter().rev() {
+                self.order_match_results(results, &item.expr, item.descending, params)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Computes the effective RETURN `LIMIT` for a MATCH query, clamped to the
+/// server-wide `MAX_LIMIT` ceiling. `None` means no LIMIT was specified, so the
+/// caller leaves the result set unbounded (subject only to `MAX_LIMIT` upstream).
+pub(in crate::collection::search::query) fn match_return_limit(
+    match_clause: &crate::velesql::MatchClause,
+) -> Option<usize> {
+    match_clause
+        .return_clause
+        .limit
+        .map(|l| usize::try_from(l).unwrap_or(MAX_LIMIT).min(MAX_LIMIT))
 }
 
 /// Deterministic ORDER BY tie-break baseline keyed by `(node_id, depth, path)` —

--- a/crates/velesdb-core/src/collection/search/query/match_exec/mod.rs
+++ b/crates/velesdb-core/src/collection/search/query/match_exec/mod.rs
@@ -213,12 +213,23 @@ impl Collection {
     ///
     /// Returns an error if the query cannot be executed.
     /// Executes a MATCH query without guard-rail context (backward-compatible entry point).
+    ///
+    /// Direct entry point for the graph REST `/match` endpoint and the SDK
+    /// bindings. Applies RETURN `ORDER BY` and the post-sort `LIMIT` so these
+    /// surfaces match the SQL `/query` pipeline (which finalizes via
+    /// `finalize_match_results`); without it the result would be raw traversal
+    /// order with the ordering clause silently ignored.
     pub fn execute_match(
         &self,
         match_clause: &MatchClause,
         params: &HashMap<String, serde_json::Value>,
     ) -> Result<Vec<MatchResult>> {
-        self.execute_match_with_context(match_clause, params, None)
+        let mut results = self.execute_match_with_context(match_clause, params, None)?;
+        self.apply_match_order_by(&mut results, match_clause, params)?;
+        if let Some(limit) = super::match_dispatch::match_return_limit(match_clause) {
+            results.truncate(limit);
+        }
+        Ok(results)
     }
 
     /// Executes a MATCH query on this collection (EPIC-045 US-002, EPIC-048).

--- a/crates/velesdb-core/src/collection/search/query/match_exec/similarity.rs
+++ b/crates/velesdb-core/src/collection/search/query/match_exec/similarity.rs
@@ -314,7 +314,9 @@ impl Collection {
         similarity_threshold: f32,
         params: &HashMap<String, serde_json::Value>,
     ) -> Result<Vec<MatchResult>> {
-        let results = self.execute_match(match_clause, params)?;
+        // Raw traversal results (no ORDER BY/LIMIT yet): the similarity score is
+        // computed below, then the shared finalize step applies ORDER BY + LIMIT.
+        let results = self.execute_match_with_context(match_clause, params, None)?;
 
         if results.is_empty() {
             return Ok(results);
@@ -345,6 +347,14 @@ impl Collection {
         )?;
 
         Self::sort_by_score(&mut scored_results, higher_is_better);
+
+        // A RETURN ORDER BY (when present) overrides the implicit score sort;
+        // then apply the shared post-sort LIMIT so this vector branch matches
+        // the SQL `/query` pipeline instead of returning score-ordered results.
+        self.apply_match_order_by(&mut scored_results, match_clause, params)?;
+        if let Some(limit) = super::super::match_dispatch::match_return_limit(match_clause) {
+            scored_results.truncate(limit);
+        }
 
         Ok(scored_results)
     }

--- a/crates/velesdb-server/src/handlers/match_query.rs
+++ b/crates/velesdb-server/src/handlers/match_query.rs
@@ -366,4 +366,59 @@ mod tests {
         assert!(json.contains("John Doe"));
         assert!(json.contains("author.name"));
     }
+
+    /// Regression (parity backlog #1): the graph REST `/match` handler must honor
+    /// `RETURN ... ORDER BY`, matching the SQL `/query` pipeline. This exercises
+    /// the exact handler path (`parse_match_clause` -> `execute_match`) that
+    /// previously bypassed the ordering finalize step and returned raw traversal
+    /// order. Ages are scrambled vs id order so traversal order != requested
+    /// age-descending order.
+    #[test]
+    fn test_match_handler_applies_return_order_by() {
+        use velesdb_core::collection::VectorCollection;
+        use velesdb_core::{DistanceMetric, Point, StorageMode};
+
+        let temp = tempfile::tempdir().expect("temp dir");
+        let coll = VectorCollection::create(
+            temp.path().to_path_buf(),
+            "people",
+            4,
+            DistanceMetric::Cosine,
+            StorageMode::default(),
+        )
+        .expect("create collection");
+
+        let ages = [(1_u64, 30), (2, 10), (3, 50), (4, 20), (5, 40)];
+        let points: Vec<Point> = ages
+            .iter()
+            .map(|(id, age)| {
+                Point::new(
+                    *id,
+                    vec![1.0, 0.0, 0.0, 0.0],
+                    Some(serde_json::json!({"_labels": ["Person"], "age": age})),
+                )
+            })
+            .collect();
+        coll.upsert(points).expect("upsert Person nodes");
+
+        let collection = MatchCollection::Vector(coll);
+        let request = MatchQueryRequest {
+            query: "MATCH (n:Person) RETURN n ORDER BY n.age DESC LIMIT 10".to_string(),
+            params: HashMap::new(),
+            vector: None,
+            threshold: None,
+        };
+        let clause = parse_match_clause(&request.query).expect("parse MATCH clause");
+        let results = execute_match(&collection, &clause, &request).expect("execute_match");
+
+        let ids: Vec<u64> = results
+            .iter()
+            .map(|r| *r.bindings.get("n").expect("binding 'n'"))
+            .collect();
+        assert_eq!(
+            ids,
+            vec![3, 5, 1, 4, 2],
+            "/match must honor RETURN ORDER BY n.age DESC (ages 50,40,30,20,10)"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Restores cross-surface parity for `MATCH ... RETURN ... ORDER BY ... LIMIT`. The ordering/limit finalize step (`finalize_match_results`) was reached **only** by the SQL `/query` pipeline. The dedicated graph REST endpoint `POST /collections/{name}/match` and the Python/TS SDK bindings call `execute_match` / `execute_match_with_similarity` directly, which returned **raw traversal order** (or vector-score order) with the `ORDER BY` clause silently ignored. So the same query returned correctly-ordered top-K via `/query` but traversal/score order via `/match`.

This was a verified gap (#1 in the VelesQL completeness audit): the original 8-team review of the MATCH ORDER BY feature scoped core + WASM but never traced the REST server handler layer.

## Fix — one ordering source of truth

- **`match_dispatch.rs`** — extract `apply_match_order_by` (deterministic `(node_id, depth, path)` tie-break baseline + per-column sort) and `match_return_limit`; `finalize_match_results` now delegates to them. **No behavior change to the SQL `/query` path** (byte-equivalent ordering/cardinality/limit sequencing).
- **`match_exec/mod.rs`** — the inner `execute_match` (the entry point REST `/match` + the SDKs delegate to) now applies `ORDER BY` + post-sort `LIMIT` after raw traversal.
- **`match_exec/similarity.rs`** — the vector-body branch reads the raw primitive, then lets `ORDER BY` override the implicit similarity-score sort and applies the `LIMIT`.
- **`execution_paths.rs`** — internal anchor evaluation pinned to the raw primitive (it collects bound ids into a set; order/limit-agnostic).

REST and the Python/TS SDKs are fixed **transitively** — their collection wrappers delegate to these inner methods; **no public signature changes**.

## Tests (each fails pre-fix, passes post-fix)

- `test_execute_match_applies_order_by` — core graph branch (proved raw id-order `[1,2,3,4,5]` pre-fix vs correct `[3,5,1,4,2]`).
- `test_execute_match_with_similarity_order_by_overrides_score` — core vector branch (ORDER BY overrides score sort).
- `test_match_handler_applies_return_order_by` — **server `/match` handler** (`parse_match_clause` → `execute_match`), directly guarding the REST surface that originally broke.

## Validation

- Full `velesdb-core` suite: **6132 passed, 0 failed** (single-threaded).
- `cargo fmt --check` clean; workspace `clippy --all-targets -D warnings -D clippy::pedantic` clean; `wasm32` builds.
- All MATCH / order / hybrid / let / fusion / conformance suites green.

## Scope note

The pre-existing traversal-order early-break (`execute_match_with_context` caps the candidate pool at `LIMIT` before sort — affecting the SQL path identically) is a separate, deeper item tracked for follow-up; this PR establishes surface parity, which is what `/match` was missing.