### PR TITLE
fix(velesql): route GROUP BY/aggregate queries through the aggregate engine in the CLI

### DIFF
--- a/crates/velesdb-cli/src/repl_execute.rs
+++ b/crates/velesdb-cli/src/repl_execute.rs
@@ -55,6 +55,13 @@ pub fn execute_query(
         });
     }
 
+    // Aggregation (GROUP BY / COUNT / SUM / ...) routes through the dedicated
+    // aggregate engine; the standard SELECT projection path returns empty rows
+    // for aggregate columns, so without this the REPL would print raw rows.
+    if !parsed.is_match_query() && parsed.select.is_aggregation_query() {
+        return run_aggregation_query(db, &parsed, active_collection, start);
+    }
+
     let kind = query_kind(&parsed);
 
     let results = if parsed.is_match_query() {
@@ -106,20 +113,73 @@ fn route_match_query(
     parsed: &velesdb_core::velesql::Query,
     active_collection: Option<&str>,
 ) -> Result<Vec<velesdb_core::SearchResult>> {
+    let params = params_with_active_collection(
+        parsed,
+        active_collection,
+        "MATCH queries require an active collection. Use: .use <collection_name>",
+    )?;
+    db.execute_query(parsed, &params)
+        .map_err(|e| anyhow::anyhow!("Query error: {e}"))
+}
+
+/// Builds the params map for a query, injecting the active collection as the
+/// `_collection` key when the query has no explicit `FROM` (the REPL selects the
+/// target via `.use <collection>`). `requires_msg` is the error shown when no
+/// active collection is set.
+fn params_with_active_collection(
+    parsed: &velesdb_core::velesql::Query,
+    active_collection: Option<&str>,
+    requires_msg: &str,
+) -> Result<HashMap<String, serde_json::Value>> {
     let mut params = HashMap::new();
     if parsed.select.from.is_empty() {
-        let col_name = active_collection.ok_or_else(|| {
-            anyhow::anyhow!(
-                "MATCH queries require an active collection. Use: .use <collection_name>"
-            )
-        })?;
+        let col_name = active_collection.ok_or_else(|| anyhow::anyhow!("{requires_msg}"))?;
         params.insert(
             "_collection".to_string(),
             serde_json::Value::String(col_name.to_string()),
         );
     }
-    db.execute_query(parsed, &params)
-        .map_err(|e| anyhow::anyhow!("Query error: {e}"))
+    Ok(params)
+}
+
+/// Routes a `GROUP BY` / scalar-aggregate SELECT through the aggregate engine and
+/// renders the JSON result (object or array-of-groups) into display rows.
+fn run_aggregation_query(
+    db: &Database,
+    parsed: &velesdb_core::velesql::Query,
+    active_collection: Option<&str>,
+    start: Instant,
+) -> Result<QueryResult> {
+    let params = params_with_active_collection(
+        parsed,
+        active_collection,
+        "Aggregation queries require an active collection. Use: .use <collection_name>",
+    )?;
+    let value = db
+        .execute_aggregate(parsed, &params)
+        .map_err(|e| anyhow::anyhow!("Query error: {e}"))?;
+    Ok(QueryResult {
+        rows: aggregate_value_to_rows(value),
+        duration_ms: start.elapsed().as_secs_f64() * 1000.0,
+        kind: QueryKind::Select,
+    })
+}
+
+/// Converts the JSON from [`Database::execute_aggregate`] into display rows: a
+/// top-level array yields one row per group; any other value is a single row.
+fn aggregate_value_to_rows(value: serde_json::Value) -> Vec<HashMap<String, serde_json::Value>> {
+    match value {
+        serde_json::Value::Array(items) => items.into_iter().map(json_object_to_row).collect(),
+        other => vec![json_object_to_row(other)],
+    }
+}
+
+/// Flattens a JSON object into a display row; non-objects map to a `value` cell.
+fn json_object_to_row(value: serde_json::Value) -> HashMap<String, serde_json::Value> {
+    match value {
+        serde_json::Value::Object(map) => map.into_iter().collect(),
+        other => HashMap::from([("value".to_string(), other)]),
+    }
 }
 
 /// Convert a single [`velesdb_core::SearchResult`] into a display row.
@@ -166,3 +226,7 @@ pub(crate) fn contains_param_vector(condition: &velesdb_core::velesql::Condition
         _ => false,
     }
 }
+
+#[cfg(test)]
+#[path = "repl_execute_tests.rs"]
+mod repl_execute_tests;

--- a/crates/velesdb-cli/src/repl_execute_tests.rs
+++ b/crates/velesdb-cli/src/repl_execute_tests.rs
@@ -1,0 +1,68 @@
+//! Tests for the REPL query-execution path (`repl_execute`).
+
+use tempfile::TempDir;
+use velesdb_core::{Database, DistanceMetric, Point};
+
+use crate::repl_execute::execute_query;
+
+/// Regression (parity backlog #2): the REPL must route `GROUP BY` / aggregate
+/// queries through the aggregate engine, not return raw rows. Previously
+/// `execute_query` only forked match-vs-`Database::execute_query`, and the
+/// standard SELECT projection returns empty rows for aggregate columns — so
+/// `COUNT`/`GROUP BY`/`HAVING` were silently ignored in the REPL.
+#[test]
+fn test_execute_query_routes_group_by_having_aggregation() {
+    let dir = TempDir::new().expect("temp dir");
+    let db = Database::open(dir.path()).expect("open db");
+    db.create_collection("orders", 2, DistanceMetric::Cosine)
+        .expect("create collection");
+
+    let coll = db
+        .get_vector_collection("orders")
+        .expect("vector collection");
+    coll.upsert(vec![
+        Point::new(
+            1,
+            vec![1.0, 0.0],
+            Some(serde_json::json!({"category": "a"})),
+        ),
+        Point::new(
+            2,
+            vec![0.0, 1.0],
+            Some(serde_json::json!({"category": "a"})),
+        ),
+        Point::new(
+            3,
+            vec![1.0, 1.0],
+            Some(serde_json::json!({"category": "b"})),
+        ),
+    ])
+    .expect("upsert");
+
+    let result = execute_query(
+        &db,
+        "SELECT category, COUNT(*) AS n FROM orders GROUP BY category HAVING COUNT(*) > 1",
+        None,
+    )
+    .expect("aggregation query should succeed");
+
+    // Only category 'a' (2 rows) clears HAVING COUNT(*) > 1; 'b' (1 row) drops.
+    // Pre-fix the REPL returned all 3 raw rows with no aggregate column.
+    assert_eq!(
+        result.rows.len(),
+        1,
+        "expected exactly one aggregated group, got {:?}",
+        result.rows
+    );
+    let row = &result.rows[0];
+    assert_eq!(
+        row.get("category"),
+        Some(&serde_json::json!("a")),
+        "group key must be category 'a'; row={row:?}"
+    );
+    assert_eq!(
+        row.get("n").and_then(serde_json::Value::as_u64),
+        Some(2),
+        "COUNT(*) for category 'a' must be 2; row={row:?}"
+    );
+}

--- a/crates/velesdb-core/src/database/mod.rs
+++ b/crates/velesdb-core/src/database/mod.rs
@@ -30,6 +30,7 @@ mod join_pushdown;
 mod metadata_ops;
 mod persistence;
 mod query_engine;
+mod query_engine_agg;
 mod query_engine_dml;
 mod query_join;
 mod stats;

--- a/crates/velesdb-core/src/database/query_engine_agg.rs
+++ b/crates/velesdb-core/src/database/query_engine_agg.rs
@@ -1,0 +1,59 @@
+//! Database-level aggregation entry point.
+//!
+//! Extracted from `query_engine.rs` (file NLOC budget) so every surface — the
+//! server `/query` handler, the CLI REPL, and future SDK consumers — can route
+//! `GROUP BY` / scalar-aggregate queries through one method instead of each
+//! re-implementing collection resolution.
+
+use std::collections::HashMap;
+
+use super::Database;
+use crate::{Error, Result};
+
+impl Database {
+    /// Executes a `GROUP BY` / scalar-aggregate SELECT, returning the aggregate
+    /// result as JSON (a single object for scalar aggregates, an array of group
+    /// objects for `GROUP BY`).
+    ///
+    /// The target collection is resolved from the query's `FROM` clause, falling
+    /// back to a `"_collection"` key in `params` (the convention the REPL/SDK use
+    /// to inject the active collection). Callers should gate on
+    /// [`crate::velesql::SelectStatement::is_aggregation_query`] — non-aggregate
+    /// SELECTs belong on [`Database::execute_query`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if validation fails, the collection cannot be resolved,
+    /// or aggregation execution fails.
+    pub fn execute_aggregate(
+        &self,
+        query: &crate::velesql::Query,
+        params: &HashMap<String, serde_json::Value>,
+    ) -> Result<serde_json::Value> {
+        crate::velesql::QueryValidator::validate(query).map_err(|e| Error::Query(e.to_string()))?;
+        let name = aggregate_target_collection(query, params)?;
+        let collection = self
+            .get_any_collection(&name)
+            .ok_or(Error::CollectionNotFound(name))?;
+        collection.execute_aggregate(query, params)
+    }
+}
+
+/// Resolves the target collection name for an aggregation query: the `FROM`
+/// clause, else a `"_collection"` param, else a guidance error.
+fn aggregate_target_collection(
+    query: &crate::velesql::Query,
+    params: &HashMap<String, serde_json::Value>,
+) -> Result<String> {
+    if !query.select.from.is_empty() {
+        return Ok(query.select.from.clone());
+    }
+    if let Some(serde_json::Value::String(name)) = params.get("_collection") {
+        return Ok(name.clone());
+    }
+    Err(Error::Query(
+        "aggregation query requires a target collection. Use SELECT ... FROM \
+         <collection> ... GROUP BY, or pass {\"_collection\": \"name\"} in params."
+            .to_string(),
+    ))
+}

--- a/crates/velesdb-core/src/database/query_engine_tests.rs
+++ b/crates/velesdb-core/src/database/query_engine_tests.rs
@@ -250,3 +250,62 @@ fn test_join_row_budget_order_by_uses_ceiling() {
     let budget = Database::join_row_budget(&select, &PushdownAnalysis::default());
     assert_eq!(budget, JOIN_ROW_CEILING);
 }
+
+// =========================================================================
+// Database::execute_aggregate (single-source aggregation entry)
+// =========================================================================
+
+/// `Database::execute_aggregate` resolves the target collection from the
+/// `_collection` param when the query has no explicit `FROM` (the convention the
+/// CLI REPL and SDKs use to inject the active collection), and runs GROUP BY.
+#[test]
+fn test_execute_aggregate_resolves_collection_via_param() {
+    let dir = tempdir().unwrap();
+    let db = Database::open(dir.path()).unwrap();
+    db.create_collection("orders", 2, DistanceMetric::Cosine)
+        .unwrap();
+    let coll = db.get_vector_collection("orders").unwrap();
+    let points: Vec<Point> = [(10, "x"), (11, "x"), (12, "y"), (13, "y")]
+        .into_iter()
+        .map(|(id, cat)| {
+            Point::new(
+                id,
+                vec![1.0, 0.0],
+                Some(serde_json::json!({ "category": cat })),
+            )
+        })
+        .collect();
+    coll.upsert(points).unwrap();
+
+    // Parse with FROM (the grammar requires it), then clear it to simulate the
+    // programmatic / REPL convention of supplying the target via `_collection`.
+    let mut query =
+        Parser::parse("SELECT category, COUNT(*) AS n FROM orders GROUP BY category").unwrap();
+    query.select.from = String::new();
+    let mut params = std::collections::HashMap::new();
+    params.insert(
+        "_collection".to_string(),
+        serde_json::Value::String("orders".to_string()),
+    );
+
+    let value = db.execute_aggregate(&query, &params).unwrap();
+    let groups = value
+        .as_array()
+        .expect("GROUP BY returns an array of groups");
+    assert_eq!(groups.len(), 2, "two category groups (a, b); got {value:?}");
+}
+
+/// `Database::execute_aggregate` surfaces a `CollectionNotFound` error for an
+/// unresolved target rather than silently returning an empty result.
+#[test]
+fn test_execute_aggregate_unknown_collection_errors() {
+    let dir = tempdir().unwrap();
+    let db = Database::open(dir.path()).unwrap();
+    let query = Parser::parse("SELECT COUNT(*) AS n FROM ghost").unwrap();
+    let params = std::collections::HashMap::new();
+    let err = db.execute_aggregate(&query, &params).unwrap_err();
+    assert!(
+        matches!(err, crate::Error::CollectionNotFound(_)),
+        "expected CollectionNotFound, got {err:?}"
+    );
+}

--- a/crates/velesdb-core/src/velesql/ast/select.rs
+++ b/crates/velesdb-core/src/velesql/ast/select.rs
@@ -377,4 +377,31 @@ impl SelectStatement {
             fusion_clause: None,
         }
     }
+
+    /// Returns `true` when this SELECT must run through the aggregation engine
+    /// (scalar aggregates or `GROUP BY`) rather than the row-projection path.
+    ///
+    /// `NEAR ... GROUP BY` (vector-search grouping) is post-processed inside the
+    /// standard execute path, not the aggregate engine, so it returns `false`.
+    /// Single source of truth shared by the server `/query` handler and the CLI
+    /// REPL so every surface routes aggregation identically.
+    #[must_use]
+    pub fn is_aggregation_query(&self) -> bool {
+        let has_aggs = match &self.columns {
+            SelectColumns::Aggregations(_) => true,
+            SelectColumns::Mixed { aggregations, .. } => !aggregations.is_empty(),
+            _ => false,
+        };
+        let is_agg_query = has_aggs || self.group_by.is_some();
+        if is_agg_query && self.group_by.is_some() {
+            let has_vector_near = self
+                .where_clause
+                .as_ref()
+                .is_some_and(Condition::has_vector_search);
+            if has_vector_near {
+                return false;
+            }
+        }
+        is_agg_query
+    }
 }

--- a/crates/velesdb-server/src/handlers/query/aggregation.rs
+++ b/crates/velesdb-server/src/handlers/query/aggregation.rs
@@ -5,7 +5,7 @@
 
 use axum::{http::StatusCode, response::IntoResponse, Json};
 use std::sync::Arc;
-use velesdb_core::velesql::{Query, SelectColumns};
+use velesdb_core::velesql::Query;
 
 use crate::handlers::helpers::notify_query_timing;
 use crate::types::{
@@ -14,32 +14,6 @@ use crate::types::{
 use crate::AppState;
 
 use super::velesql_helpers::{parse_and_validate, velesql_collection_not_found, velesql_error};
-
-/// Returns `true` if the query contains aggregation functions or GROUP BY,
-/// but NOT if it's a vector-search GROUP BY (which is handled as post-processing
-/// in `execute_query`, not `execute_aggregate`).
-pub(crate) fn is_aggregation_query(select: &velesdb_core::velesql::SelectStatement) -> bool {
-    let has_aggs = match &select.columns {
-        SelectColumns::Aggregations(_) => true,
-        SelectColumns::Mixed { aggregations, .. } => !aggregations.is_empty(),
-        _ => false,
-    };
-    let is_agg_query = has_aggs || select.group_by.is_some();
-
-    // Vector-search GROUP BY (NEAR + GROUP BY) is handled as post-processing
-    // inside execute_query, not execute_aggregate. Route it to the standard path.
-    if is_agg_query {
-        let has_vector_near = select
-            .where_clause
-            .as_ref()
-            .is_some_and(velesdb_core::velesql::Condition::has_vector_search);
-        if has_vector_near && select.group_by.is_some() {
-            return false;
-        }
-    }
-
-    is_agg_query
-}
 
 fn aggregation_result_count(result: &serde_json::Value) -> usize {
     match result {
@@ -157,7 +131,7 @@ pub async fn aggregate(
         }
     };
 
-    if parsed.is_match_query() || !is_aggregation_query(&parsed.select) {
+    if parsed.is_match_query() || !parsed.select.is_aggregation_query() {
         state.operational_metrics.inc_errors();
         return velesql_error(
             StatusCode::UNPROCESSABLE_ENTITY,

--- a/crates/velesdb-server/src/handlers/query/mod.rs
+++ b/crates/velesdb-server/src/handlers/query/mod.rs
@@ -23,7 +23,7 @@ use crate::types::{
 };
 use crate::AppState;
 
-use aggregation::{execute_aggregation_query, is_aggregation_query};
+use aggregation::execute_aggregation_query;
 use explain::condition_has_vector_search;
 use velesql_helpers::{parse_and_validate, velesql_collection_not_found, velesql_error};
 
@@ -109,7 +109,7 @@ pub async fn query(
     };
 
     // BUG-1 FIX: Detect aggregation queries and route to execute_aggregate
-    if is_aggregation_query(&parsed.select) {
+    if parsed.select.is_aggregation_query() {
         return execute_aggregation_query(&state, &collection_name, &parsed, &req.params, start);
     }
 
@@ -385,7 +385,7 @@ pub fn detect_query_type(query: &Query) -> QueryType {
         return QueryType::Graph;
     }
 
-    if is_aggregation_query(&query.select) {
+    if query.select.is_aggregation_query() {
         return QueryType::Aggregation;
     }
 


### PR DESCRIPTION
## Summary

The CLI REPL's `execute_query` only forked **match vs `Database::execute_query`** and never detected aggregation. So `GROUP BY` / `COUNT` / `SUM` / `AVG` / `HAVING` queries fell through the standard SELECT projection path — which returns an **empty row** for aggregate columns — and the REPL printed raw rows instead of aggregated results. (Backlog #2 from the VelesQL completeness audit; same *surface drift* root cause as the merged `/match` fix #1202 — aggregation logic lived only behind the server handler.)

## Fix — one aggregation source of truth

- **`velesql/ast/select.rs`** — lift `is_aggregation_query` out of the server handler into core as `SelectStatement::is_aggregation_query()`. The server now calls the method (removes the duplicate fn + its now-dead `SelectColumns` import). `NEAR ... GROUP BY` still returns `false` (post-processed on the standard path).
- **`database/query_engine_agg.rs`** (new) — `Database::execute_aggregate(query, params) -> serde_json::Value`: validate, resolve the target collection from `FROM` or the `_collection` param (mirroring the MATCH path), then delegate to the collection's `execute_aggregate`. New file keeps `query_engine.rs` under the file-NLOC budget.
- **`cli/repl_execute.rs`** — `execute_query` routes aggregation through `Database::execute_aggregate` and renders the JSON (single object, or array-of-groups) into display rows. Extracted a shared `params_with_active_collection` helper used by **both** the match and aggregate paths (DRY).

The server `/query` and `/aggregate` handlers are unchanged in behavior — they now call the lifted core method.

## Tests (the CLI one fails pre-fix)

- `test_execute_query_routes_group_by_having_aggregation` (CLI) — `SELECT category, COUNT(*) AS n FROM orders GROUP BY category HAVING COUNT(*) > 1` over `{a,a,b}` returns **exactly one** group `{category: a, n: 2}`. **Pre-fix: 3 raw rows** (verified by neutralizing the routing).
- `test_execute_aggregate_resolves_collection_via_param` (core) — resolution via the `_collection` param with no `FROM`.
- `test_execute_aggregate_unknown_collection_errors` (core) — `CollectionNotFound` rather than a silent empty result.

## Validation

- Full `velesdb-core` suite: **6134 passed, 0 failed** (single-threaded).
- Server aggregation/query suites, core aggregation/select/group_by, full CLI suite: green.
- `cargo fmt --check` clean; workspace `clippy --all-targets -D warnings -D clippy::pedantic` clean; `wasm32` builds.

## Scope note

WASM and mobile share the same `Database::execute_query` root cause but on their own code paths (WASM has a separate `velesql_select` pipeline) — tracked as a follow-up (backlog #3 touches the same WASM render path).