### PR TITLE
fix(velesql): three ORDER BY silent-wrong-result bugs (nested payload, named-vector similarity, score-var defaults)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,28 @@ release.
   configured thresholds. Unknown options and non-bool values still error.
 
 ### Fixed
+- **Unpopulated built-in score variables now default to `0`, not the primary
+  score.** In `ORDER BY`/`LET` arithmetic, a built-in score component absent from
+  a result's component breakdown (e.g. `bm25_score` on a `NEAR`-only query) used
+  to resolve to the fused/primary `search_score` instead of `0`, so a hybrid
+  formula like `0.7 * vector_score + 0.3 * bm25_score` evaluated to the full
+  vector score rather than `0.7 ×` it. Tagged results now default an absent
+  component to `0` (per `VELESQL_SPEC`); untagged legacy results keep the
+  `search_score` fallback. `graph_score` (never populated) is reserved and
+  resolves to `0` on tagged results.
+  *(Behavior change: hybrid `ORDER BY`/`LET` scores using an unpopulated
+  component change ranking.)*
+- **`ORDER BY similarity(field, $v)` now scores the named vector field.** The
+  `SELECT`-side `ORDER BY similarity(image_vec, $q)` ignored the field and always
+  scored the default vector, so rows were ranked by the wrong vector. It now
+  resolves each row's named payload vector (missing/length-mismatched vectors
+  sort last, matching the `MATCH`-side convention).
+  *(Behavior change: queries ordering by a named/secondary vector re-rank.)*
+- **`ORDER BY` on a nested/dotted payload field now sorts.** `ORDER BY meta.source`
+  did a flat top-level lookup, so every row compared equal and the sort was a
+  silent no-op. Dotted paths now walk nested objects (consistent with
+  projection/filter/aggregation).
+  *(Behavior change: previously-unsorted queries now sort.)*
 - **`EXPLAIN ANALYZE` reports real graph traversal counters.** `nodes_visited`
   and `edges_traversed` for `MATCH` queries were a fabricated proxy equal to the
   result-row count; they now report the actual walk — edges followed and nodes

--- a/crates/velesdb-core/src/collection/search/query/component_scores_tests.rs
+++ b/crates/velesdb-core/src/collection/search/query/component_scores_tests.rs
@@ -73,26 +73,30 @@ fn test_resolve_variable_falls_back_to_search_score() {
     );
 }
 
-/// Edge: component scores present but variable not in the list -> fallback.
+/// Edge: component scores present but variable not in the list -> defaults to 0.
+/// Bug #7: on a TAGGED result an absent built-in component defaults to 0.0 (per
+/// VELESQL_SPEC), NOT the primary search_score — otherwise `bm25_score` on a
+/// NEAR-only query would leak the vector score into hybrid formulas.
 #[test]
-fn test_resolve_variable_missing_component_falls_back() {
+fn test_resolve_variable_missing_component_defaults_to_zero() {
     let components: smallvec::SmallVec<[(&'static str, f32); 4]> =
         smallvec::smallvec![("vector_score", 0.9_f32),];
     let ctx = ScoreContext::with_components(0.65, None, Some(&components));
 
-    // bm25_score not in components -> should fall back to search_score
+    // bm25_score not in a tagged component set -> defaults to 0.0
     let expr = ArithmeticExpr::Variable("bm25_score".to_string());
     let val = evaluate_arithmetic(&expr, &ctx);
 
     assert!(
-        (val - 0.65).abs() < 1e-5,
-        "Missing component should fall back to search_score (0.65), got {val}"
+        val.abs() < 1e-6,
+        "Missing component on a tagged result must default to 0.0, got {val}"
     );
 }
 
-/// Edge: empty component_scores vec treated like None.
+/// Edge: empty (but `Some`) component_scores still counts as tagged, so an
+/// absent built-in defaults to 0.0 rather than the primary search_score.
 #[test]
-fn test_resolve_variable_empty_components_falls_back() {
+fn test_resolve_variable_empty_components_default_to_zero() {
     let components: smallvec::SmallVec<[(&'static str, f32); 4]> = smallvec::smallvec![];
     let ctx = ScoreContext::with_components(0.80, None, Some(&components));
 
@@ -100,8 +104,47 @@ fn test_resolve_variable_empty_components_falls_back() {
     let val = evaluate_arithmetic(&expr, &ctx);
 
     assert!(
-        (val - 0.80).abs() < 1e-5,
-        "Empty components should fall back to search_score (0.80), got {val}"
+        val.abs() < 1e-6,
+        "Absent component on a tagged (empty) result must default to 0.0, got {val}"
+    );
+}
+
+/// Bug #7 regression: when component_scores is Some (result was tagged), an
+/// absent built-in component must resolve to 0.0, NOT the primary search_score.
+/// `0.7 * vector_score + 0.3 * bm25_score` on a NEAR-only result (no bm25
+/// component) must equal `0.7 * vector_score`, per VELESQL_SPEC (defaults to 0).
+#[test]
+fn test_absent_builtin_component_resolves_to_zero_when_tagged() {
+    let components: smallvec::SmallVec<[(&'static str, f32); 4]> =
+        smallvec::smallvec![("vector_score", 0.9_f32),];
+    let ctx = ScoreContext::with_components(0.9, None, Some(&components));
+
+    // bm25_score absent from a tagged result => 0.0.
+    let expr = ArithmeticExpr::Variable("bm25_score".to_string());
+    let val = evaluate_arithmetic(&expr, &ctx);
+    assert!(
+        val.abs() < 1e-6,
+        "absent bm25_score on a tagged result must be 0.0, got {val}"
+    );
+
+    // 0.7 * vector_score + 0.3 * bm25_score == 0.7 * 0.9 == 0.63 (NOT 0.9).
+    let weighted = ArithmeticExpr::BinaryOp {
+        left: Box::new(ArithmeticExpr::BinaryOp {
+            left: Box::new(ArithmeticExpr::Literal(0.7)),
+            op: ArithmeticOp::Mul,
+            right: Box::new(ArithmeticExpr::Variable("vector_score".to_string())),
+        }),
+        op: ArithmeticOp::Add,
+        right: Box::new(ArithmeticExpr::BinaryOp {
+            left: Box::new(ArithmeticExpr::Literal(0.3)),
+            op: ArithmeticOp::Mul,
+            right: Box::new(ArithmeticExpr::Variable("bm25_score".to_string())),
+        }),
+    };
+    let w = evaluate_arithmetic(&weighted, &ctx);
+    assert!(
+        (w - 0.63).abs() < 1e-5,
+        "0.7*vector_score + 0.3*bm25_score must be 0.63 (bm25 defaults to 0), got {w}"
     );
 }
 

--- a/crates/velesdb-core/src/collection/search/query/ordering.rs
+++ b/crates/velesdb-core/src/collection/search/query/ordering.rs
@@ -12,6 +12,27 @@ use crate::point::SearchResult;
 use crate::velesql::{ArithmeticExpr, ArithmeticOp};
 use std::cmp::Ordering;
 
+/// Looks up a (possibly dotted) field path inside a JSON payload.
+///
+/// A bare name (`"source"`) is a top-level lookup; a dotted path
+/// (`"meta.source"`) walks nested objects segment by segment. Returns `None`
+/// when any segment is missing or a non-object is traversed. Shared by ORDER BY
+/// field comparison and score-variable payload resolution so both honor the same
+/// nested-path semantics as projection/filter/aggregation.
+fn get_nested_payload<'a>(
+    payload: &'a serde_json::Value,
+    path: &str,
+) -> Option<&'a serde_json::Value> {
+    let mut current = payload;
+    for segment in path.split('.') {
+        match current {
+            serde_json::Value::Object(map) => current = map.get(segment)?,
+            _ => return None,
+        }
+    }
+    Some(current)
+}
+
 /// Compare two JSON values for sorting with total ordering.
 ///
 /// Ordering priority (ascending): Null < Bool < Number < String < Array < Object
@@ -156,10 +177,8 @@ impl Collection {
             match &ob.expr {
                 OrderByExpr::Similarity(sim) => {
                     let order_vec = Self::resolve_vector(&sim.vector, params)?;
-                    let scores: Vec<f32> = results
-                        .iter()
-                        .map(|r| self.compute_metric_score(&r.point.vector, &order_vec))
-                        .collect();
+                    let scores =
+                        self.similarity_scores_for_field(results, &sim.field, &order_vec)?;
                     map.insert(idx, scores);
                 }
                 OrderByExpr::SimilarityBare => {
@@ -171,6 +190,45 @@ impl Collection {
             }
         }
         Ok(map)
+    }
+
+    /// Scores every result row against `order_vec` using the vector selected by
+    /// `field`: the default vector when `field == "vector"`, otherwise the named
+    /// payload vector for that row's point id (multi-vector support, P1-A).
+    ///
+    /// A row whose named vector is missing, `None`, or length-mismatched scores
+    /// as least similar (mirroring the MATCH-side `ORDER BY similarity()`): the
+    /// metric-appropriate worst key — `NEG_INFINITY` for higher-is-better
+    /// metrics, `INFINITY` (largest distance) for lower-is-better metrics — so it
+    /// sorts last under DESC regardless of metric.
+    fn similarity_scores_for_field(
+        &self,
+        results: &[SearchResult],
+        field: &str,
+        order_vec: &[f32],
+    ) -> Result<Vec<f32>> {
+        let worst = if self.config.read().metric.higher_is_better() {
+            f32::NEG_INFINITY
+        } else {
+            f32::INFINITY
+        };
+        results
+            .iter()
+            .map(|r| {
+                let vec: std::borrow::Cow<[f32]> = if field == "vector" {
+                    std::borrow::Cow::Borrowed(&r.point.vector)
+                } else {
+                    match self.get_vector_for_field(r.point.id, field)? {
+                        Some(v) => std::borrow::Cow::Owned(v),
+                        None => return Ok(worst),
+                    }
+                };
+                if vec.len() != order_vec.len() || vec.is_empty() {
+                    return Ok(worst);
+                }
+                Ok(self.compute_metric_score(&vec, order_vec))
+            })
+            .collect()
     }
 
     /// Compares two result indices across all ORDER BY columns.
@@ -227,12 +285,12 @@ impl Collection {
             .point
             .payload
             .as_ref()
-            .and_then(|p| p.get(field_name));
+            .and_then(|p| get_nested_payload(p, field_name));
         let val_j = results[j]
             .point
             .payload
             .as_ref()
-            .and_then(|p| p.get(field_name));
+            .and_then(|p| get_nested_payload(p, field_name));
         compare_json_values(val_i, val_j)
     }
 
@@ -419,11 +477,17 @@ impl<'a> ScoreContext<'a> {
     /// Resolution priority:
     /// 1. LET bindings (highest — user-defined score aliases).
     /// 2. Built-in component scores (`vector_score`, `bm25_score`, etc.).
-    /// 3. `search_score` (fused/primary score) for built-in names.
+    /// 3. For a built-in absent from a *tagged* result (component_scores `Some`),
+    ///    the component defaults to `0.0` (per VELESQL_SPEC); on an *untagged*
+    ///    result (component_scores `None`) it falls back to `search_score`.
     /// 4. Payload fields for non-built-in names.
     ///
     /// `fused_score` and `similarity` always resolve to `search_score` (they
     /// represent the combined result, not an individual component).
+    ///
+    /// `graph_score` is reserved: it is never populated as a component, so it
+    /// resolves to `0.0` on tagged results (and to `search_score` only on the
+    /// legacy untagged path).
     fn resolve_variable(&self, name: &str) -> f32 {
         // Priority 1: LET bindings override everything.
         if let Some(val) = self.lookup_let_binding(name) {
@@ -432,11 +496,24 @@ impl<'a> ScoreContext<'a> {
         match name {
             // fused_score and similarity always use the primary fused score.
             "fused_score" | "similarity" => self.search_score,
-            // Component-aware built-ins: check component_scores first.
-            "vector_score" | "graph_score" | "bm25_score" | "sparse_score" => {
-                self.lookup_component(name).unwrap_or(self.search_score)
-            }
+            // Component-aware built-ins: a tagged result (component_scores Some)
+            // defaults an absent component to 0.0; only the untagged legacy path
+            // falls back to the primary search_score.
+            "vector_score" | "graph_score" | "bm25_score" | "sparse_score" => self
+                .lookup_component(name)
+                .unwrap_or_else(|| self.absent_component_default()),
             _ => self.resolve_payload_variable(name),
+        }
+    }
+
+    /// Default for a built-in component absent from this result: `0.0` when the
+    /// result carries a component breakdown (`component_scores` is `Some`),
+    /// otherwise the primary `search_score` (legacy untagged compatibility).
+    fn absent_component_default(&self) -> f32 {
+        if self.component_scores.is_some() {
+            0.0
+        } else {
+            self.search_score
         }
     }
 
@@ -459,7 +536,7 @@ impl<'a> ScoreContext<'a> {
     /// Resolves a variable name from the payload.
     fn resolve_payload_variable(&self, name: &str) -> f32 {
         self.payload
-            .and_then(|p| p.get(name))
+            .and_then(|p| get_nested_payload(p, name))
             .and_then(serde_json::Value::as_f64)
             .map_or(0.0, |v| {
                 #[allow(clippy::cast_possible_truncation)]

--- a/crates/velesdb-core/src/collection/search/query/ordering_tests.rs
+++ b/crates/velesdb-core/src/collection/search/query/ordering_tests.rs
@@ -563,6 +563,108 @@ mod tests {
             );
         }
 
+        /// Bug #4 regression: ORDER BY a nested/dotted payload field must sort.
+        /// Previously `compare_payload_field` did a flat lookup, so `meta.source`
+        /// compared Equal for every row and the sort was a silent no-op.
+        #[test]
+        fn test_order_by_nested_payload_field_sorts() {
+            let dir = tempfile::tempdir().expect("temp dir");
+            let col = Collection::create(PathBuf::from(dir.path()), 4, DistanceMetric::Cosine)
+                .expect("create collection");
+
+            let points = vec![
+                Point {
+                    id: 1,
+                    vector: vec![1.0, 0.0, 0.0, 0.0],
+                    payload: Some(serde_json::json!({"meta": {"source": "charlie"}})),
+                    sparse_vectors: None,
+                },
+                Point {
+                    id: 2,
+                    vector: vec![0.9, 0.1, 0.0, 0.0],
+                    payload: Some(serde_json::json!({"meta": {"source": "bravo"}})),
+                    sparse_vectors: None,
+                },
+                Point {
+                    id: 3,
+                    vector: vec![0.8, 0.2, 0.0, 0.0],
+                    payload: Some(serde_json::json!({"meta": {"source": "alpha"}})),
+                    sparse_vectors: None,
+                },
+            ];
+            col.upsert(points).expect("upsert");
+
+            let query = "SELECT * FROM t ORDER BY meta.source ASC LIMIT 10";
+            let parsed = Parser::parse(query).expect("parse");
+            let params = HashMap::new();
+            let results = col.execute_query(&parsed, &params).expect("execute");
+
+            let ids: Vec<u64> = results.iter().map(|r| r.point.id).collect();
+            // alpha(id 3) < bravo(id 2) < charlie(id 1)
+            assert_eq!(
+                ids,
+                vec![3, 2, 1],
+                "ORDER BY nested payload meta.source ASC must sort, got {ids:?}"
+            );
+        }
+
+        /// Bug #5 regression: ORDER BY similarity(named_field, $v) must score the
+        /// NAMED payload vector, not the default vector. Multiple rows survive the
+        /// WHERE filter so the ORDER BY of the survivors is what is under test; the
+        /// `image_vec` ranking is deliberately the REVERSE of the default-vector
+        /// ranking, so a default-vector sort would invert the expected order.
+        #[test]
+        fn test_order_by_similarity_named_vector_field() {
+            let dir = tempfile::tempdir().expect("temp dir");
+            let col = Collection::create(PathBuf::from(dir.path()), 4, DistanceMetric::Cosine)
+                .expect("create collection");
+
+            // For $q = [1,0,0,0]:
+            //   image_vec cosine: id1=0.6, id2=0.8, id3=1.0  (image ranking 3>2>1)
+            //   default cosine:   id1=1.0, id2=0.8, id3=0.6  (default ranking 1>2>3)
+            // All three clear the > 0.5 image_vec filter, so the survivor set is
+            // {1,2,3} and only the ORDER BY decides the sequence.
+            let points = vec![
+                Point {
+                    id: 1,
+                    vector: vec![1.0, 0.0, 0.0, 0.0],
+                    payload: Some(serde_json::json!({"image_vec": [0.6, 0.8, 0.0, 0.0]})),
+                    sparse_vectors: None,
+                },
+                Point {
+                    id: 2,
+                    vector: vec![0.8, 0.6, 0.0, 0.0],
+                    payload: Some(serde_json::json!({"image_vec": [0.8, 0.6, 0.0, 0.0]})),
+                    sparse_vectors: None,
+                },
+                Point {
+                    id: 3,
+                    vector: vec![0.6, 0.8, 0.0, 0.0],
+                    payload: Some(serde_json::json!({"image_vec": [1.0, 0.0, 0.0, 0.0]})),
+                    sparse_vectors: None,
+                },
+            ];
+            col.upsert(points).expect("upsert");
+
+            let mut params = HashMap::new();
+            params.insert("q".to_string(), serde_json::json!([1.0, 0.0, 0.0, 0.0]));
+
+            let query = "SELECT * FROM t WHERE similarity(image_vec, $q) > 0.5 \
+                         ORDER BY similarity(image_vec, $q) DESC LIMIT 10";
+            let parsed = Parser::parse(query).expect("parse");
+            let results = col.execute_query(&parsed, &params).expect("execute");
+            let by_image: Vec<u64> = results.iter().map(|r| r.point.id).collect();
+
+            // image_vec similarity DESC => 3 (1.0) > 2 (0.8) > 1 (0.6).
+            // A default-vector sort would yield 1 > 2 > 3 (the reverse).
+            assert_eq!(
+                by_image,
+                vec![3, 2, 1],
+                "ORDER BY similarity(image_vec,$q) must rank by the NAMED vector \
+                 (3,2,1), got {by_image:?}"
+            );
+        }
+
         /// EPIC-042: Integration test for arithmetic ORDER BY with execute_query.
         /// Verifies that `ORDER BY 0.7 * similarity() + 0.3 * priority DESC`
         /// returns results sorted by the weighted combination.


### PR DESCRIPTION
## Summary

Fixes three silent-wrong-result bugs in the VelesQL ORDER BY pipeline, all rooted in `velesdb-core/src/collection/search/query/ordering.rs`. Each is implemented failing-test-first.

### #4 — `ORDER BY` a nested/dotted payload field silently no-op'd
`compare_payload_field` did a flat `p.get(field_name)` with no `.`-splitting, so `ORDER BY meta.source` compared `Equal` for every row → the sort was a no-op. Added one shared `get_nested_payload(payload, path)` helper (splits on `.`) and call it from **both** `compare_payload_field` and `resolve_payload_variable`, fixing the bug **and** removing a duplicate flat-lookup copy (helps the `<2%` dup gate). `grammar.pest` untouched (dotted-identifier arithmetic is a separate EPIC).

### #5 — `ORDER BY similarity(field, $v)` ignored the named vector field
The `OrderByExpr::Similarity` arm hardcoded `compute_metric_score(&r.point.vector, …)` and never read `sim.field`, so with a named/secondary vector the sort scored the **wrong** vector. Now resolves the per-row vector via the named field (`get_vector_for_field`, `Cow`); missing/`None`/length-mismatch fall back to the metric-aware worst key (`NEG_INFINITY` if `higher_is_better` else `+INFINITY`), mirroring the MATCH-side convention.

### #7 — Unpopulated built-in score variables resolved to the primary score instead of 0
`resolve_variable` returned `lookup_component(name).unwrap_or(self.search_score)`, so on a NEAR-only query `bm25_score` leaked the vector score and `0.7*vector_score + 0.3*bm25_score` evaluated to `v` instead of the documented `0.7*v` (SPEC: "defaults to 0"). Now: when `component_scores` is `Some` (tagged result), an absent built-in → `0.0`; only the legacy untagged (`None`) path keeps the `search_score` fallback. `graph_score` documented as reserved/0 on tagged results.

**Behavior change (#7)** is user-visible and recorded in `CHANGELOG.md [Unreleased]`.

## Test plan
- New tests assert **ordering/ranking** (not just row count) and each genuinely **fails on develop, passes here**:
  - `test_order_by_nested_payload_field_sorts`
  - `test_order_by_similarity_named_vector_field`
  - `test_absent_builtin_component_resolves_to_zero_when_tagged`
- Two pre-existing tests that asserted the old (wrong) #7 behavior updated to the corrected default-0 contract.
- Gates: `cargo fmt`, `clippy --all-targets … -D warnings -D clippy::pedantic` (clean), `lizard -C 8` (max CCN 7 / NLOC 37), full `cargo test -p velesdb-core --features persistence -- --test-threads=1` = **45 binaries, 0 failed**.
- Not search/index/SIMD/quantization/fusion hot path → recall@10 gate not triggered.