### PR TITLE
fix(velesql): FUSION correctness — honor strategy, reject silent fallbacks (#6/#10/#15/#16/#17)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,9 @@ release.
   - **RSF / Weighted weights are validated.** `strategy='rsf'` whose
     `dense_weight` + `sparse_weight` do not sum to ~1.0 (and any negative
     weight) previously degraded to plain RRF at execution time; they now error
-    at validate-time so `EXPLAIN` and execution agree.
+    at validate-time so `EXPLAIN` and execution agree. On the `NEAR` + `MATCH`
+    `weighted` path a negative `vector_weight` / `graph_weight` was silently
+    clamped to `1.0`; it is now rejected at validate-time as well.
   - **`NEAR_FUSED` rejects `weighted` / `rsf`.** Those strategies are
     ill-defined over N homogeneous query vectors; they previously fell back to
     RRF, discarding the weights silently. They are now rejected.
@@ -49,7 +51,11 @@ release.
   vector-similarity and BM25 streams; `weighted` normalizes
   `vector_weight` / `graph_weight` so `graph_weight` actually weights the BM25
   branch; `rrf` (and unset) keep the prior behavior. `EXPLAIN` reports the
-  strategy that executes.
+  strategy that executes. The same fix now also covers the **anchored**
+  `NEAR` + graph `MATCH` + text `MATCH` hybrid (AND-required graph predicate):
+  it previously always ran RRF over the anchor set, ignoring `strategy` /
+  `graph_weight`; it now honors them while the anchor-restricted result set is
+  unchanged.
   *(Behavior change: non-`rrf` FUSION on NEAR+MATCH changes rankings.)*
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,44 @@ and executable SQL `NEAR_FUSED` fusion) and one new DDL capability. Several
 explicit errors or real values — review the SemVer impact before the next
 release.
 
+### Changed
+- **`USING FUSION` is now validated; misconfigured clauses error instead of
+  silently degrading.** Five correctness flips, all surfaced at validate-time
+  (or parse-time) so the previous silent fallbacks are unreachable:
+  - **Single-branch `USING FUSION` is rejected.** Applying `USING FUSION(...)`
+    to a query with fewer than two fusable branches (e.g. `similarity()`-only,
+    pure `NEAR`, or metadata-only) was a decorative no-op — the clause was
+    threaded through and discarded. It now requires at least two fusable
+    branches (`NEAR` + `MATCH`, `NEAR` + `SPARSE_NEAR`, …) or a single
+    `NEAR_FUSED`, and errors otherwise.
+  - **RSF / Weighted weights are validated.** `strategy='rsf'` whose
+    `dense_weight` + `sparse_weight` do not sum to ~1.0 (and any negative
+    weight) previously degraded to plain RRF at execution time; they now error
+    at validate-time so `EXPLAIN` and execution agree.
+  - **`NEAR_FUSED` rejects `weighted` / `rsf`.** Those strategies are
+    ill-defined over N homogeneous query vectors; they previously fell back to
+    RRF, discarding the weights silently. They are now rejected.
+  - **Unknown fusion strategy names and option keys are rejected.** The SQL
+    parser previously mapped any unknown `strategy=...` to RRF and discarded
+    unknown option keys (`dense_wieght`, …), so a typo silently changed
+    semantics. Unknown names/keys now error at parse-time.
+  - **`relative_score` is accepted as an alias of `rsf`**, and
+    `dense_weight` / `sparse_weight` as long-name aliases of `dense_w` /
+    `sparse_w`. The documented long-name weights are no longer silently dropped
+    (which used to run a 50/50 blend).
+  *(Behavior change: several previously-accepted FUSION queries now error.)*
+
+### Fixed
+- **`USING FUSION(strategy = ...)` now takes effect on the dense-`NEAR` +
+  text-`MATCH` hybrid.** The hybrid path always ran plain weighted RRF and
+  ignored `strategy`, `graph_weight`, and (for `weighted`) the text-branch
+  weighting. `maximum` / `average` / `rsf` now run score-level fusion of the
+  vector-similarity and BM25 streams; `weighted` normalizes
+  `vector_weight` / `graph_weight` so `graph_weight` actually weights the BM25
+  branch; `rrf` (and unset) keep the prior behavior. `EXPLAIN` reports the
+  strategy that executes.
+  *(Behavior change: non-`rrf` FUSION on NEAR+MATCH changes rankings.)*
+
 ### Added
 - **`ALTER COLLECTION <name> SET (auto_reindex = true|false)` now applies and
   persists.** Previously parsed but rejected with a feature-gap error, it now

--- a/crates/velesdb-core/src/collection/search/mod.rs
+++ b/crates/velesdb-core/src/collection/search/mod.rs
@@ -22,6 +22,7 @@ mod sparse;
 #[cfg(test)]
 mod sparse_tests;
 mod text;
+mod text_fusion;
 #[cfg(test)]
 mod text_tests;
 mod vector;

--- a/crates/velesdb-core/src/collection/search/query/execution_paths.rs
+++ b/crates/velesdb-core/src/collection/search/query/execution_paths.rs
@@ -185,25 +185,20 @@ impl Collection {
     ) -> Result<Vec<SearchResult>> {
         if let Some(text_query) = Self::extract_match_query(cond) {
             let fusion = search_opts.fusion_clause.as_ref();
-            #[allow(clippy::cast_possible_truncation)]
-            let vector_weight = fusion.and_then(|fc| fc.vector_weight).map(|w| w as f32);
-            let rrf_k = fusion.and_then(|fc| fc.k);
             // Bug #474: Extract co-occurring metadata filters (e.g. `category = 'tech'`)
-            // before calling hybrid_search. Without this, metadata conditions alongside
-            // MATCH are silently dropped.
-            if let Some(metadata_cond) = Self::extract_metadata_filter(cond) {
-                let filter =
-                    crate::filter::Filter::new(crate::filter::Condition::from(metadata_cond));
-                return self.hybrid_search_with_filter(
-                    vector,
-                    &text_query,
-                    execution_limit,
-                    vector_weight,
-                    &filter,
-                    rrf_k,
-                );
-            }
-            return self.hybrid_search(vector, &text_query, execution_limit, vector_weight, rrf_k);
+            // before fusing. Without this, metadata conditions alongside MATCH
+            // are silently dropped.
+            // Bug #6: route through hybrid_search_with_clause so the FUSION
+            // strategy / graph_weight take effect instead of always running RRF.
+            let filter = Self::extract_metadata_filter(cond)
+                .map(|c| crate::filter::Filter::new(crate::filter::Condition::from(c)));
+            return self.hybrid_search_with_clause(
+                vector,
+                &text_query,
+                execution_limit,
+                fusion,
+                filter.as_ref(),
+            );
         }
         let cbo_search_k = execution_limit
             .saturating_mul(cbo_over_fetch)

--- a/crates/velesdb-core/src/collection/search/query/select_dispatch.rs
+++ b/crates/velesdb-core/src/collection/search/query/select_dispatch.rs
@@ -400,23 +400,15 @@ impl Collection {
             return Ok(None);
         };
 
-        let vector_weight = stmt
-            .fusion_clause
-            .as_ref()
-            .and_then(|fc| fc.vector_weight)
-            .map(|w| {
-                #[allow(clippy::cast_possible_truncation)]
-                let w_f32 = w as f32;
-                w_f32
-            });
-        let rrf_k = stmt.fusion_clause.as_ref().and_then(|fc| fc.k);
-
-        let results = self.hybrid_search_with_anchors(
+        // Route through the strategy-honoring helper so maximum/average/rsf/
+        // weighted are applied to the anchor-restricted streams (#6, anchored).
+        // The anchor set constrains both branches identically, so only the
+        // fusion of the two score streams changes; rrf/unset stays byte-identical.
+        let results = self.hybrid_search_with_anchors_clause(
             vector,
             &text_query,
             limit,
-            vector_weight,
-            rrf_k,
+            stmt.fusion_clause.as_ref(),
             &anchor_ids,
         )?;
         Ok(Some(results))

--- a/crates/velesdb-core/src/collection/search/text.rs
+++ b/crates/velesdb-core/src/collection/search/text.rs
@@ -10,6 +10,11 @@ use crate::storage::{PayloadStorage, VectorStorage};
 use crate::validation::validate_dimension_match;
 use std::collections::HashSet;
 
+/// Anchor-restricted hybrid streams: scored vector branch + `(id, score)` BM25
+/// branch, both confined to the anchor set (shared by the RRF and score-level
+/// anchored hybrid paths).
+type AnchoredHybridStreams = (Vec<crate::scored_result::ScoredResult>, Vec<(u64, f32)>);
+
 /// Resolves `(weight, text_weight, rrf_constant)` from optional caller inputs.
 ///
 /// `vector_weight` defaults to 0.5; `rrf_k` defaults to 60.
@@ -392,12 +397,43 @@ impl Collection {
         rrf_k: Option<u32>,
         anchor_ids: &HashSet<u64>,
     ) -> Result<Vec<SearchResult>> {
+        let (weight, text_weight, rrf_constant) = resolve_rrf_params(vector_weight, rrf_k);
+        let overfetch_k = k.saturating_mul(4).max(k + 10);
+        let (vector_scored, text_results) =
+            self.anchored_hybrid_streams(vector_query, text_query, anchor_ids, overfetch_k)?;
+
+        let (fused_scores, component_map) = Self::compute_rrf_scores_with_components(
+            &vector_scored,
+            &text_results,
+            weight,
+            text_weight,
+            rrf_constant,
+        );
+
+        let scored_ids = Self::top_k_from_scores(fused_scores, k);
+        Ok(self.resolve_scored_ids_with_components(&scored_ids, &component_map))
+    }
+
+    /// Builds the anchor-restricted vector-similarity and BM25 score streams
+    /// shared by the RRF and score-level anchored hybrid paths.
+    ///
+    /// Both branches are confined to `anchor_ids`, so the candidate set is
+    /// identical regardless of the downstream fusion strategy.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the query vector dimension doesn't match.
+    pub(crate) fn anchored_hybrid_streams(
+        &self,
+        vector_query: &[f32],
+        text_query: &str,
+        anchor_ids: &HashSet<u64>,
+        overfetch_k: usize,
+    ) -> Result<AnchoredHybridStreams> {
         let config = self.config.read();
         validate_dimension_match(config.dimension, vector_query.len())?;
         drop(config);
 
-        let (weight, text_weight, rrf_constant) = resolve_rrf_params(vector_weight, rrf_k);
-        let overfetch_k = k.saturating_mul(4).max(k + 10);
         // Vector branch: restrict retrieval to anchor set.
         let anchor_search =
             self.search_near_with_anchor_ids(vector_query, anchor_ids, None, overfetch_k)?;
@@ -413,16 +449,7 @@ impl Collection {
             .filter(|(id, _)| anchor_ids.contains(id))
             .collect();
 
-        let (fused_scores, component_map) = Self::compute_rrf_scores_with_components(
-            &vector_scored,
-            &text_results,
-            weight,
-            text_weight,
-            rrf_constant,
-        );
-
-        let scored_ids = Self::top_k_from_scores(fused_scores, k);
-        Ok(self.resolve_scored_ids_with_components(&scored_ids, &component_map))
+        Ok((vector_scored, text_results))
     }
 
     /// Resolves scored IDs with filter and optional per-component score breakdown.

--- a/crates/velesdb-core/src/collection/search/text_fusion.rs
+++ b/crates/velesdb-core/src/collection/search/text_fusion.rs
@@ -1,0 +1,168 @@
+//! Strategy-aware fusion for the dense-NEAR + text-MATCH hybrid path (#6).
+//!
+//! `hybrid_search` (in `text.rs`) is a fixed weighted-RRF over vector and BM25
+//! ranks. When a query carries `USING FUSION(strategy = ...)` the requested
+//! strategy must actually take effect instead of being silently ignored:
+//!
+//! - `rrf` / unset -> plain weighted RRF (`hybrid_search`).
+//! - `weighted`    -> weighted RRF with `vector_weight`/`graph_weight`
+//!   normalized so `graph_weight` influences the BM25 branch.
+//! - `maximum` / `average` / `rsf` -> score-level fusion of the raw vector
+//!   similarity and BM25 score streams via [`FusionStrategy`].
+
+use crate::collection::types::Collection;
+use crate::error::{Error, Result};
+use crate::fusion::FusionStrategy;
+use crate::point::SearchResult;
+use crate::velesql::{FusionClause, FusionStrategyType};
+
+/// A ranked `(id, score)` stream for one fusion branch.
+type ScoreStream = Vec<(u64, f32)>;
+
+impl Collection {
+    /// Routes a dense-NEAR + text-MATCH hybrid through the requested fusion
+    /// strategy (#6). Falls back to plain weighted RRF when no FUSION clause
+    /// is present or the strategy is `rrf`.
+    pub(crate) fn hybrid_search_with_clause(
+        &self,
+        vector_query: &[f32],
+        text_query: &str,
+        k: usize,
+        fusion: Option<&FusionClause>,
+        filter: Option<&crate::filter::Filter>,
+    ) -> Result<Vec<SearchResult>> {
+        let Some(fc) = fusion else {
+            return self.hybrid_search_default(vector_query, text_query, k, None, filter);
+        };
+        match fc.strategy {
+            FusionStrategyType::Rrf => {
+                let vw = fc.vector_weight.map(cast_weight);
+                self.hybrid_search_default(vector_query, text_query, k, vw, filter)
+            }
+            FusionStrategyType::Weighted => {
+                let vw = normalized_vector_weight(fc);
+                self.hybrid_search_default(vector_query, text_query, k, Some(vw), filter)
+            }
+            FusionStrategyType::Maximum | FusionStrategyType::Average | FusionStrategyType::Rsf => {
+                let strategy = score_fusion_strategy(fc);
+                self.hybrid_search_score_fused(vector_query, text_query, k, &strategy, filter)
+            }
+        }
+    }
+
+    /// Plain weighted-RRF hybrid, honoring an optional metadata filter.
+    fn hybrid_search_default(
+        &self,
+        vector_query: &[f32],
+        text_query: &str,
+        k: usize,
+        vector_weight: Option<f32>,
+        filter: Option<&crate::filter::Filter>,
+    ) -> Result<Vec<SearchResult>> {
+        match filter {
+            Some(f) => {
+                self.hybrid_search_with_filter(vector_query, text_query, k, vector_weight, f, None)
+            }
+            None => self.hybrid_search(vector_query, text_query, k, vector_weight, None),
+        }
+    }
+
+    /// Fuses the raw vector-similarity and BM25 score streams via `strategy`,
+    /// then applies the optional metadata filter post-fusion.
+    fn hybrid_search_score_fused(
+        &self,
+        vector_query: &[f32],
+        text_query: &str,
+        k: usize,
+        strategy: &FusionStrategy,
+        filter: Option<&crate::filter::Filter>,
+    ) -> Result<Vec<SearchResult>> {
+        let candidate_k = k.saturating_mul(2).max(k + 10);
+        let (vector_stream, text_stream) =
+            self.hybrid_score_streams(vector_query, text_query, candidate_k)?;
+        if vector_stream.is_empty() && text_stream.is_empty() {
+            return Ok(Vec::new());
+        }
+        let fused = strategy
+            .fuse(vec![vector_stream, text_stream])
+            .map_err(|e| Error::Config(format!("Fusion error: {e}")))?;
+        let resolved = self.resolve_fused_results(&fused, fused.len());
+        Ok(apply_post_filter(resolved, filter, k))
+    }
+
+    /// Builds the `(id, score)` vector-similarity and BM25 streams used by
+    /// score-level fusion.
+    fn hybrid_score_streams(
+        &self,
+        vector_query: &[f32],
+        text_query: &str,
+        candidate_k: usize,
+    ) -> Result<(ScoreStream, ScoreStream)> {
+        use crate::index::VectorIndex;
+        let metric = {
+            let config = self.config.read();
+            crate::validation::validate_dimension_match(config.dimension, vector_query.len())?;
+            config.metric
+        };
+        let raw = self.index.search(vector_query, candidate_k);
+        let vec_res = self.merge_delta(raw, vector_query, candidate_k, metric);
+        let vector_stream: Vec<(u64, f32)> = vec_res.iter().map(|sr| (sr.id, sr.score)).collect();
+        let text_stream = self.text_index.search(text_query, candidate_k);
+        Ok((vector_stream, text_stream))
+    }
+}
+
+/// Truncates a `f64` fusion weight to `f32`.
+#[allow(clippy::cast_possible_truncation)]
+fn cast_weight(w: f64) -> f32 {
+    w as f32
+}
+
+/// Normalizes `vector_weight` against `graph_weight` so the BM25 branch weight
+/// (`1 - vector_weight` inside `hybrid_search`) reflects `graph_weight` (#6).
+fn normalized_vector_weight(fc: &FusionClause) -> f32 {
+    let vw = fc.vector_weight.map_or(0.5, cast_weight);
+    let gw = fc.graph_weight.map_or(0.5, cast_weight);
+    let total = vw + gw;
+    if total <= 0.0 {
+        return 0.5;
+    }
+    vw / total
+}
+
+/// Builds the score-level `FusionStrategy` for a Maximum/Average/Rsf clause.
+fn score_fusion_strategy(fc: &FusionClause) -> FusionStrategy {
+    match fc.strategy {
+        FusionStrategyType::Maximum => FusionStrategy::Maximum,
+        FusionStrategyType::Rsf => {
+            let dw = fc.dense_weight.unwrap_or(0.5);
+            let sw = fc.sparse_weight.unwrap_or(0.5);
+            // Weights are validate-time checked; the fallback only guards the
+            // unreachable invalid case rather than silently degrading.
+            FusionStrategy::relative_score(dw, sw).unwrap_or(FusionStrategy::RelativeScore {
+                dense_weight: 0.5,
+                sparse_weight: 0.5,
+            })
+        }
+        _ => FusionStrategy::Average,
+    }
+}
+
+/// Applies an optional metadata filter to fused results, truncating to `k`.
+fn apply_post_filter(
+    results: Vec<SearchResult>,
+    filter: Option<&crate::filter::Filter>,
+    k: usize,
+) -> Vec<SearchResult> {
+    let Some(filter) = filter else {
+        return results.into_iter().take(k).collect();
+    };
+    results
+        .into_iter()
+        .filter(|r| match r.point.payload.as_ref() {
+            Some(p) => filter.matches(p),
+            None => false,
+        })
+        .take(k)
+        .collect()
+}

--- a/crates/velesdb-core/src/collection/search/text_fusion.rs
+++ b/crates/velesdb-core/src/collection/search/text_fusion.rs
@@ -50,6 +50,80 @@ impl Collection {
         }
     }
 
+    /// Routes an anchored dense-NEAR + text-MATCH hybrid (graph anchor set)
+    /// through the requested fusion strategy (#6, anchored path).
+    ///
+    /// The anchor-restricted candidate set is identical for every strategy
+    /// (both branches are confined to `anchor_ids`); only the score/rank
+    /// fusion of the two streams changes. Falls back to the existing
+    /// anchored RRF when no FUSION clause is present or the strategy is `rrf`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the query vector dimension doesn't match.
+    pub(crate) fn hybrid_search_with_anchors_clause(
+        &self,
+        vector_query: &[f32],
+        text_query: &str,
+        k: usize,
+        fusion: Option<&FusionClause>,
+        anchor_ids: &std::collections::HashSet<u64>,
+    ) -> Result<Vec<SearchResult>> {
+        let Some(fc) = fusion else {
+            return self.hybrid_search_with_anchors(
+                vector_query,
+                text_query,
+                k,
+                None,
+                None,
+                anchor_ids,
+            );
+        };
+        match fc.strategy {
+            FusionStrategyType::Rrf => {
+                let vw = fc.vector_weight.map(cast_weight);
+                self.hybrid_search_with_anchors(vector_query, text_query, k, vw, fc.k, anchor_ids)
+            }
+            FusionStrategyType::Weighted => {
+                let vw = normalized_vector_weight(fc);
+                self.hybrid_search_with_anchors(
+                    vector_query,
+                    text_query,
+                    k,
+                    Some(vw),
+                    fc.k,
+                    anchor_ids,
+                )
+            }
+            FusionStrategyType::Maximum | FusionStrategyType::Average | FusionStrategyType::Rsf => {
+                let strategy = score_fusion_strategy(fc);
+                self.anchored_hybrid_score_fused(vector_query, text_query, k, &strategy, anchor_ids)
+            }
+        }
+    }
+
+    /// Score-level fusion of the anchor-restricted vector and BM25 streams.
+    fn anchored_hybrid_score_fused(
+        &self,
+        vector_query: &[f32],
+        text_query: &str,
+        k: usize,
+        strategy: &FusionStrategy,
+        anchor_ids: &std::collections::HashSet<u64>,
+    ) -> Result<Vec<SearchResult>> {
+        let overfetch_k = k.saturating_mul(4).max(k + 10);
+        let (vector_scored, text_stream) =
+            self.anchored_hybrid_streams(vector_query, text_query, anchor_ids, overfetch_k)?;
+        let vector_stream: ScoreStream = vector_scored.iter().map(|sr| (sr.id, sr.score)).collect();
+        if vector_stream.is_empty() && text_stream.is_empty() {
+            return Ok(Vec::new());
+        }
+        let fused = strategy
+            .fuse(vec![vector_stream, text_stream])
+            .map_err(|e| Error::Config(format!("Fusion error: {e}")))?;
+        Ok(self.resolve_fused_results(&fused, k))
+    }
+
     /// Plain weighted-RRF hybrid, honoring an optional metadata filter.
     fn hybrid_search_default(
         &self,

--- a/crates/velesdb-core/src/collection/search/text_fusion.rs
+++ b/crates/velesdb-core/src/collection/search/text_fusion.rs
@@ -115,12 +115,7 @@ impl Collection {
         let (vector_scored, text_stream) =
             self.anchored_hybrid_streams(vector_query, text_query, anchor_ids, overfetch_k)?;
         let vector_stream: ScoreStream = vector_scored.iter().map(|sr| (sr.id, sr.score)).collect();
-        if vector_stream.is_empty() && text_stream.is_empty() {
-            return Ok(Vec::new());
-        }
-        let fused = strategy
-            .fuse(vec![vector_stream, text_stream])
-            .map_err(|e| Error::Config(format!("Fusion error: {e}")))?;
+        let fused = fuse_streams(strategy, vector_stream, text_stream)?;
         Ok(self.resolve_fused_results(&fused, k))
     }
 
@@ -154,12 +149,7 @@ impl Collection {
         let candidate_k = k.saturating_mul(2).max(k + 10);
         let (vector_stream, text_stream) =
             self.hybrid_score_streams(vector_query, text_query, candidate_k)?;
-        if vector_stream.is_empty() && text_stream.is_empty() {
-            return Ok(Vec::new());
-        }
-        let fused = strategy
-            .fuse(vec![vector_stream, text_stream])
-            .map_err(|e| Error::Config(format!("Fusion error: {e}")))?;
+        let fused = fuse_streams(strategy, vector_stream, text_stream)?;
         let resolved = self.resolve_fused_results(&fused, fused.len());
         Ok(apply_post_filter(resolved, filter, k))
     }
@@ -190,6 +180,21 @@ impl Collection {
 #[allow(clippy::cast_possible_truncation)]
 fn cast_weight(w: f64) -> f32 {
     w as f32
+}
+
+/// Fuses two `(id, score)` streams via `strategy`, returning an empty list when
+/// both inputs are empty (so callers resolve a uniform result set).
+fn fuse_streams(
+    strategy: &FusionStrategy,
+    vector_stream: ScoreStream,
+    text_stream: ScoreStream,
+) -> Result<ScoreStream> {
+    if vector_stream.is_empty() && text_stream.is_empty() {
+        return Ok(Vec::new());
+    }
+    strategy
+        .fuse(vec![vector_stream, text_stream])
+        .map_err(|e| Error::Config(format!("Fusion error: {e}")))
 }
 
 /// Normalizes `vector_weight` against `graph_weight` so the BM25 branch weight

--- a/crates/velesdb-core/src/velesql/mod.rs
+++ b/crates/velesdb-core/src/velesql/mod.rs
@@ -85,6 +85,7 @@ mod validation;
 mod validation_anchor;
 #[cfg(test)]
 mod validation_anchor_tests;
+mod validation_fusion;
 #[cfg(test)]
 mod validation_parity_tests;
 #[cfg(test)]

--- a/crates/velesdb-core/src/velesql/parser/select/clause_limit_with.rs
+++ b/crates/velesdb-core/src/velesql/parser/select/clause_limit_with.rs
@@ -1,12 +1,13 @@
 //! LIMIT, OFFSET, WITH options, and USING FUSION clause parsing.
 
 use super::super::{extract_identifier, Rule};
+use crate::velesql::error::{ParseError, ParseErrorKind};
 use crate::velesql::Parser;
 
 impl Parser {
     pub(crate) fn parse_using_fusion_clause(
         pair: pest::iterators::Pair<Rule>,
-    ) -> crate::velesql::FusionClause {
+    ) -> Result<crate::velesql::FusionClause, ParseError> {
         let mut clause = crate::velesql::FusionClause {
             strategy: crate::velesql::FusionStrategyType::Rrf,
             k: None,
@@ -18,37 +19,34 @@ impl Parser {
 
         for inner_pair in pair.into_inner() {
             if inner_pair.as_rule() == Rule::fusion_options {
-                Self::parse_fusion_options(inner_pair, &mut clause);
+                Self::parse_fusion_options(inner_pair, &mut clause)?;
             }
         }
 
-        clause
+        Ok(clause)
     }
 
     /// Parses the fusion_options pair, iterating over each fusion_option.
     fn parse_fusion_options(
         pair: pest::iterators::Pair<Rule>,
         clause: &mut crate::velesql::FusionClause,
-    ) {
+    ) -> Result<(), ParseError> {
         for opt_pair in pair.into_inner() {
             if opt_pair.as_rule() == Rule::fusion_option_list {
                 for option in opt_pair.into_inner() {
                     if option.as_rule() == Rule::fusion_option {
-                        Self::apply_fusion_option(option, clause);
+                        Self::apply_fusion_option(option, clause)?;
                     }
                 }
             }
         }
+        Ok(())
     }
 
-    /// Parses a single fusion option key-value pair and applies it to the clause.
-    fn apply_fusion_option(
-        option: pest::iterators::Pair<Rule>,
-        clause: &mut crate::velesql::FusionClause,
-    ) {
+    /// Extracts the `(key, value)` strings of a single fusion option pair.
+    fn extract_fusion_kv(option: pest::iterators::Pair<Rule>) -> (String, String) {
         let mut key = String::new();
         let mut value_str = String::new();
-
         for part in option.into_inner() {
             match part.as_rule() {
                 Rule::identifier => key = extract_identifier(&part).to_lowercase(),
@@ -66,26 +64,64 @@ impl Parser {
                 _ => {}
             }
         }
+        (key, value_str)
+    }
+
+    /// Parses a single fusion option key-value pair and applies it to the clause.
+    ///
+    /// Unknown keys are rejected (a misspelled weight must not silently no-op);
+    /// `dense_weight`/`sparse_weight` are accepted as long-name aliases of
+    /// `dense_w`/`sparse_w`.
+    fn apply_fusion_option(
+        option: pest::iterators::Pair<Rule>,
+        clause: &mut crate::velesql::FusionClause,
+    ) -> Result<(), ParseError> {
+        let (key, value_str) = Self::extract_fusion_kv(option);
 
         match key.as_str() {
-            "strategy" => clause.strategy = Self::parse_fusion_strategy_type(&value_str),
+            "strategy" => clause.strategy = Self::parse_fusion_strategy_type(&value_str)?,
             "k" => clause.k = value_str.parse().ok(),
             "vector_weight" => clause.vector_weight = value_str.parse().ok(),
             "graph_weight" => clause.graph_weight = value_str.parse().ok(),
-            "dense_w" => clause.dense_weight = value_str.parse().ok(),
-            "sparse_w" => clause.sparse_weight = value_str.parse().ok(),
-            _ => {}
+            "dense_w" | "dense_weight" => clause.dense_weight = value_str.parse().ok(),
+            "sparse_w" | "sparse_weight" => clause.sparse_weight = value_str.parse().ok(),
+            other => {
+                return Err(ParseError::new(
+                    ParseErrorKind::SyntaxError,
+                    0,
+                    other.to_string(),
+                    format!(
+                        "Unknown USING FUSION option '{other}'. Valid keys: strategy, k, \
+                         vector_weight, graph_weight, dense_weight, sparse_weight"
+                    ),
+                ));
+            }
         }
+        Ok(())
     }
 
     /// Converts a strategy name string to a `FusionStrategyType`.
-    fn parse_fusion_strategy_type(name: &str) -> crate::velesql::FusionStrategyType {
+    ///
+    /// `relative_score` is accepted as an alias of `rsf`. Unknown strategy
+    /// names are rejected instead of silently falling back to RRF.
+    fn parse_fusion_strategy_type(
+        name: &str,
+    ) -> Result<crate::velesql::FusionStrategyType, ParseError> {
         match name.to_lowercase().as_str() {
-            "weighted" => crate::velesql::FusionStrategyType::Weighted,
-            "maximum" => crate::velesql::FusionStrategyType::Maximum,
-            "rsf" => crate::velesql::FusionStrategyType::Rsf,
-            "average" => crate::velesql::FusionStrategyType::Average,
-            _ => crate::velesql::FusionStrategyType::Rrf,
+            "rrf" => Ok(crate::velesql::FusionStrategyType::Rrf),
+            "weighted" => Ok(crate::velesql::FusionStrategyType::Weighted),
+            "maximum" => Ok(crate::velesql::FusionStrategyType::Maximum),
+            "rsf" | "relative_score" => Ok(crate::velesql::FusionStrategyType::Rsf),
+            "average" => Ok(crate::velesql::FusionStrategyType::Average),
+            other => Err(ParseError::new(
+                ParseErrorKind::SyntaxError,
+                0,
+                other.to_string(),
+                format!(
+                    "Unknown USING FUSION strategy '{other}'. Valid strategies: rrf, weighted, \
+                     maximum, rsf (relative_score), average"
+                ),
+            )),
         }
     }
 }

--- a/crates/velesdb-core/src/velesql/parser/select/mod.rs
+++ b/crates/velesdb-core/src/velesql/parser/select/mod.rs
@@ -171,11 +171,24 @@ impl Parser {
             Rule::group_by_clause => stmt.group_by = Some(Self::parse_group_by_clause(pair)),
             Rule::having_clause => stmt.having = Some(Self::parse_having_clause(pair)?),
             Rule::order_by_clause => stmt.order_by = Some(Self::parse_order_by_clause(pair)?),
+            _ => Self::dispatch_trailing_clause(pair, stmt)?,
+        }
+        Ok(())
+    }
+
+    /// Dispatches the trailing optional clauses (LIMIT, OFFSET, WITH, USING
+    /// FUSION). Split out of `dispatch_optional_clause` to keep both functions
+    /// within the cyclomatic-complexity budget.
+    fn dispatch_trailing_clause(
+        pair: pest::iterators::Pair<Rule>,
+        stmt: &mut SelectStmtBuilder,
+    ) -> Result<(), ParseError> {
+        match pair.as_rule() {
             Rule::limit_clause => stmt.limit = Some(Self::parse_limit_clause(pair)?),
             Rule::offset_clause => stmt.offset = Some(Self::parse_offset_clause(pair)?),
             Rule::with_clause => stmt.with_clause = Some(Self::parse_with_clause(pair)?),
             Rule::using_fusion_clause => {
-                stmt.fusion_clause = Some(Self::parse_using_fusion_clause(pair));
+                stmt.fusion_clause = Some(Self::parse_using_fusion_clause(pair)?);
             }
             _ => {}
         }

--- a/crates/velesdb-core/src/velesql/validation.rs
+++ b/crates/velesdb-core/src/velesql/validation.rs
@@ -73,6 +73,7 @@ impl QueryValidator {
         Self::validate_similarity_context(stmt)?;
         Self::validate_qualified_wildcards(stmt)?;
         Self::validate_vector_group_by(stmt)?;
+        super::validation_fusion::validate_fusion(stmt)?;
         stmt.where_clause.as_ref().map_or(Ok(()), |condition| {
             // V011 anchor rule (explicit and implicit binding, guards
             // G1/G2/G3) lives in `validation_anchor.rs`.

--- a/crates/velesdb-core/src/velesql/validation_fusion.rs
+++ b/crates/velesdb-core/src/velesql/validation_fusion.rs
@@ -60,6 +60,25 @@ fn fusion_error(fragment: impl Into<String>, suggestion: impl Into<String>) -> V
     )
 }
 
+/// Rejects a negative weight pair, labelling the error with `strategy_label`
+/// and naming the offending `weights` (e.g. `"Weighted vector_weight/graph_weight"`).
+/// Generic over the weight float type (`dense`/`sparse` are `f32`,
+/// `vector`/`graph` are `f64`).
+fn reject_negative_pair<T: PartialOrd + Default + Copy>(
+    strategy_label: &str,
+    a: T,
+    b: T,
+    weights: &str,
+) -> Result<(), ValidationError> {
+    if a < T::default() || b < T::default() {
+        return Err(fusion_error(
+            strategy_label,
+            format!("USING FUSION {weights} must be non-negative"),
+        ));
+    }
+    Ok(())
+}
+
 /// Validates the USING FUSION clause (if any) against the WHERE condition.
 pub(super) fn validate_fusion(stmt: &SelectStatement) -> Result<(), ValidationError> {
     let mut counts = BranchCounts::default();
@@ -111,12 +130,12 @@ fn validate_fusion_weights(fc: &super::ast::FusionClause) -> Result<(), Validati
 fn validate_rsf_weights(fc: &super::ast::FusionClause) -> Result<(), ValidationError> {
     let dw = fc.dense_weight.unwrap_or(0.5);
     let sw = fc.sparse_weight.unwrap_or(0.5);
-    if dw < 0.0 || sw < 0.0 {
-        return Err(fusion_error(
-            "USING FUSION(strategy='rsf')",
-            "USING FUSION RSF dense_weight/sparse_weight must be non-negative",
-        ));
-    }
+    reject_negative_pair(
+        "USING FUSION(strategy='rsf')",
+        dw,
+        sw,
+        "RSF dense_weight/sparse_weight",
+    )?;
     if (dw + sw - 1.0).abs() > WEIGHT_SUM_EPSILON {
         return Err(fusion_error(
             "USING FUSION(strategy='rsf')",
@@ -140,20 +159,20 @@ fn validate_rsf_weights(fc: &super::ast::FusionClause) -> Result<(), ValidationE
 fn validate_weighted_weights(fc: &super::ast::FusionClause) -> Result<(), ValidationError> {
     let dw = fc.dense_weight.unwrap_or(0.5);
     let sw = fc.sparse_weight.unwrap_or(0.5);
-    if dw < 0.0 || sw < 0.0 {
-        return Err(fusion_error(
-            "USING FUSION(strategy='weighted')",
-            "USING FUSION Weighted dense_weight/sparse_weight must be non-negative",
-        ));
-    }
+    reject_negative_pair(
+        "USING FUSION(strategy='weighted')",
+        dw,
+        sw,
+        "Weighted dense_weight/sparse_weight",
+    )?;
     let vw = fc.vector_weight.unwrap_or(0.5);
     let gw = fc.graph_weight.unwrap_or(0.5);
-    if vw < 0.0 || gw < 0.0 {
-        return Err(fusion_error(
-            "USING FUSION(strategy='weighted')",
-            "USING FUSION Weighted vector_weight/graph_weight must be non-negative",
-        ));
-    }
+    reject_negative_pair(
+        "USING FUSION(strategy='weighted')",
+        vw,
+        gw,
+        "Weighted vector_weight/graph_weight",
+    )?;
     Ok(())
 }
 

--- a/crates/velesdb-core/src/velesql/validation_fusion.rs
+++ b/crates/velesdb-core/src/velesql/validation_fusion.rs
@@ -1,0 +1,175 @@
+//! USING FUSION semantic validation (bugs #10, #15, #16).
+//!
+//! Separated from `validation.rs` to keep each file under the 500 NLOC limit.
+//! These checks run at validate-time so that misconfigured fusion clauses fail
+//! loudly instead of silently degrading to RRF (or being decorative no-ops):
+//!
+//! - **#16** USING FUSION requires at least two fusable retrieval branches
+//!   (NEAR + MATCH, NEAR + SPARSE_NEAR, …) or a single `NEAR_FUSED`.
+//! - **#10** RSF weights must sum to ~1.0; Weighted weights must be
+//!   non-negative — so the execution-time RRF fallback is unreachable.
+//! - **#15** `NEAR_FUSED` rejects `weighted`/`rsf` (ill-defined over N
+//!   homogeneous query vectors).
+
+use super::ast::{Condition, FusionStrategyType, SelectStatement};
+use super::validation_types::{ValidationError, ValidationErrorKind};
+
+/// Tolerance for the RSF weight-sum check (matches `fusion::strategy`).
+const WEIGHT_SUM_EPSILON: f32 = 0.001;
+
+/// Counts of fusable retrieval branches present in a WHERE condition tree.
+#[derive(Default)]
+struct BranchCounts {
+    near: usize,
+    sparse: usize,
+    text_match: usize,
+    fused: usize,
+}
+
+impl BranchCounts {
+    /// Total fusable branches, treating a `NEAR_FUSED` as already-fused (it
+    /// carries its own multi-vector fusion and counts as one fusable unit).
+    fn fusable_total(&self) -> usize {
+        self.near + self.sparse + self.text_match + self.fused
+    }
+}
+
+/// Walks the condition tree accumulating fusable-branch counts.
+fn count_branches(cond: &Condition, counts: &mut BranchCounts) {
+    match cond {
+        Condition::VectorSearch(_) => counts.near += 1,
+        Condition::SparseVectorSearch(_) => counts.sparse += 1,
+        Condition::Match(_) => counts.text_match += 1,
+        Condition::VectorFusedSearch(_) => counts.fused += 1,
+        Condition::And(l, r) | Condition::Or(l, r) => {
+            count_branches(l, counts);
+            count_branches(r, counts);
+        }
+        Condition::Not(inner) | Condition::Group(inner) => count_branches(inner, counts),
+        _ => {}
+    }
+}
+
+/// Builds a FUSION applicability/misconfiguration validation error (#10/#16).
+fn fusion_error(fragment: impl Into<String>, suggestion: impl Into<String>) -> ValidationError {
+    ValidationError::new(
+        ValidationErrorKind::SimilarityWithoutContext,
+        None,
+        fragment,
+        suggestion,
+    )
+}
+
+/// Validates the USING FUSION clause (if any) against the WHERE condition.
+pub(super) fn validate_fusion(stmt: &SelectStatement) -> Result<(), ValidationError> {
+    let mut counts = BranchCounts::default();
+    if let Some(ref cond) = stmt.where_clause {
+        count_branches(cond, &mut counts);
+    }
+
+    // #15: NEAR_FUSED `weighted`/`rsf` are rejected regardless of the trailing
+    // USING FUSION(...) clause, since the inline FusionConfig carries them.
+    if counts.fused > 0 {
+        validate_near_fused_strategy(stmt)?;
+    }
+
+    let Some(ref fc) = stmt.fusion_clause else {
+        return Ok(());
+    };
+
+    validate_fusion_applicability(&counts)?;
+    validate_fusion_weights(fc)
+}
+
+/// #16: USING FUSION requires at least two fusable branches, or a NEAR_FUSED.
+fn validate_fusion_applicability(counts: &BranchCounts) -> Result<(), ValidationError> {
+    // A single NEAR_FUSED is self-fusing and a valid FUSION target.
+    if counts.fused > 0 {
+        return Ok(());
+    }
+    if counts.fusable_total() >= 2 {
+        return Ok(());
+    }
+    Err(fusion_error(
+        "USING FUSION",
+        "USING FUSION requires at least two fusable branches (e.g. vector NEAR + MATCH, \
+         vector NEAR + SPARSE_NEAR) or a NEAR_FUSED predicate; a single-branch query \
+         has nothing to fuse",
+    ))
+}
+
+/// #10: validates the FUSION clause weight parameters at parse-time.
+fn validate_fusion_weights(fc: &super::ast::FusionClause) -> Result<(), ValidationError> {
+    match fc.strategy {
+        FusionStrategyType::Rsf => validate_rsf_weights(fc),
+        FusionStrategyType::Weighted => validate_weighted_weights(fc),
+        _ => Ok(()),
+    }
+}
+
+/// RSF dense/sparse weights must sum to ~1.0 and be non-negative.
+fn validate_rsf_weights(fc: &super::ast::FusionClause) -> Result<(), ValidationError> {
+    let dw = fc.dense_weight.unwrap_or(0.5);
+    let sw = fc.sparse_weight.unwrap_or(0.5);
+    if dw < 0.0 || sw < 0.0 {
+        return Err(fusion_error(
+            "USING FUSION(strategy='rsf')",
+            "USING FUSION RSF dense_weight/sparse_weight must be non-negative",
+        ));
+    }
+    if (dw + sw - 1.0).abs() > WEIGHT_SUM_EPSILON {
+        return Err(fusion_error(
+            "USING FUSION(strategy='rsf')",
+            format!(
+                "USING FUSION RSF dense_weight + sparse_weight must sum to 1.0 (got {})",
+                dw + sw
+            ),
+        ));
+    }
+    Ok(())
+}
+
+/// Weighted dense/sparse weights must be non-negative.
+fn validate_weighted_weights(fc: &super::ast::FusionClause) -> Result<(), ValidationError> {
+    let dw = fc.dense_weight.unwrap_or(0.5);
+    let sw = fc.sparse_weight.unwrap_or(0.5);
+    if dw < 0.0 || sw < 0.0 {
+        return Err(fusion_error(
+            "USING FUSION(strategy='weighted')",
+            "USING FUSION Weighted dense_weight/sparse_weight must be non-negative",
+        ));
+    }
+    Ok(())
+}
+
+/// #15: rejects `weighted`/`rsf` on a `NEAR_FUSED` predicate.
+fn validate_near_fused_strategy(stmt: &SelectStatement) -> Result<(), ValidationError> {
+    let Some(ref cond) = stmt.where_clause else {
+        return Ok(());
+    };
+    if fused_strategy_is_rejected(cond) {
+        return Err(fusion_error(
+            "NEAR_FUSED USING FUSION 'weighted'/'rsf'",
+            "NEAR_FUSED USING FUSION supports only rrf, average, or maximum; weighted/rsf \
+             are ill-defined over homogeneous query vectors",
+        ));
+    }
+    Ok(())
+}
+
+/// Returns true if any `NEAR_FUSED` in the tree requests weighted/rsf fusion.
+fn fused_strategy_is_rejected(cond: &Condition) -> bool {
+    match cond {
+        Condition::VectorFusedSearch(v) => {
+            matches!(
+                v.fusion.strategy.to_lowercase().as_str(),
+                "weighted" | "rsf"
+            )
+        }
+        Condition::And(l, r) | Condition::Or(l, r) => {
+            fused_strategy_is_rejected(l) || fused_strategy_is_rejected(r)
+        }
+        Condition::Not(inner) | Condition::Group(inner) => fused_strategy_is_rejected(inner),
+        _ => false,
+    }
+}

--- a/crates/velesdb-core/src/velesql/validation_fusion.rs
+++ b/crates/velesdb-core/src/velesql/validation_fusion.rs
@@ -129,7 +129,14 @@ fn validate_rsf_weights(fc: &super::ast::FusionClause) -> Result<(), ValidationE
     Ok(())
 }
 
-/// Weighted dense/sparse weights must be non-negative.
+/// Weighted weights must be non-negative on both the dense/sparse and the
+/// vector/graph (NEAR + MATCH) branches.
+///
+/// The NEAR + MATCH `weighted` path normalizes
+/// `vector_weight / (vector_weight + graph_weight)`, so a negative
+/// `graph_weight` (or `vector_weight`) would otherwise pass validation and be
+/// silently clamped to `1.0` at execution time. Rejecting it here keeps the
+/// execution-time fallback unreachable.
 fn validate_weighted_weights(fc: &super::ast::FusionClause) -> Result<(), ValidationError> {
     let dw = fc.dense_weight.unwrap_or(0.5);
     let sw = fc.sparse_weight.unwrap_or(0.5);
@@ -137,6 +144,14 @@ fn validate_weighted_weights(fc: &super::ast::FusionClause) -> Result<(), Valida
         return Err(fusion_error(
             "USING FUSION(strategy='weighted')",
             "USING FUSION Weighted dense_weight/sparse_weight must be non-negative",
+        ));
+    }
+    let vw = fc.vector_weight.unwrap_or(0.5);
+    let gw = fc.graph_weight.unwrap_or(0.5);
+    if vw < 0.0 || gw < 0.0 {
+        return Err(fusion_error(
+            "USING FUSION(strategy='weighted')",
+            "USING FUSION Weighted vector_weight/graph_weight must be non-negative",
         ));
     }
     Ok(())

--- a/crates/velesdb-core/tests/bdd.rs
+++ b/crates/velesdb-core/tests/bdd.rs
@@ -47,6 +47,8 @@ mod explain_configurable_threshold;
 mod explain_cost_calibrated;
 #[path = "bdd/flush_operations.rs"]
 mod flush_operations;
+#[path = "bdd/fusion_correctness.rs"]
+mod fusion_correctness;
 #[path = "bdd/fusion_rrf_conformance.rs"]
 mod fusion_rrf_conformance;
 #[path = "bdd/fusion_weighted_bug.rs"]

--- a/crates/velesdb-core/tests/bdd/fusion_correctness.rs
+++ b/crates/velesdb-core/tests/bdd/fusion_correctness.rs
@@ -1,0 +1,336 @@
+//! BDD tests for FUSION-correctness fixes (bugs #6, #10, #15, #16, #17).
+//!
+//! Each scenario drives the full pipeline (parse -> validate -> execute /
+//! explain) through the public `Database` API so that validation-time rejects
+//! and execution-time ranking are both exercised exactly as a caller sees them.
+//!
+//! The bugs being locked:
+//! - #6: dense-NEAR + text-MATCH hybrid honors the FUSION `strategy` /
+//!   `graph_weight` instead of always running plain weighted RRF.
+//! - #10: FUSION weights are validated at validate-time (RSF must sum ~1.0,
+//!   Weighted weights must be non-negative); EXPLAIN reports the strategy that
+//!   actually executes.
+//! - #15: NEAR_FUSED rejects `weighted`/`rsf`; the SQL parser maps
+//!   `relative_score` -> Rsf and rejects unknown strategy names.
+//! - #16: FUSION on a single fusable branch is a validate-time error.
+//! - #17: `dense_weight`/`sparse_weight` long-name aliases are honored;
+//!   unknown fusion keys are rejected.
+
+use std::collections::BTreeMap;
+
+use serde_json::json;
+use velesdb_core::sparse_index::SparseVector;
+use velesdb_core::{Database, DistanceMetric, Point};
+
+use super::helpers::{create_test_db, execute_sql};
+
+/// Builds a dim-2 collection 'docs' with text payloads + sparse vectors, used by
+/// the hybrid-fusion scenarios.
+fn setup_hybrid_docs(db: &Database) {
+    db.create_vector_collection("docs", 2, DistanceMetric::Cosine)
+        .expect("test: create docs");
+    let vc = db.get_vector_collection("docs").expect("test: get docs");
+
+    let mut s1 = BTreeMap::new();
+    s1.insert(String::new(), SparseVector::new(vec![(10, 1.0)]));
+    let mut s2 = BTreeMap::new();
+    s2.insert(String::new(), SparseVector::new(vec![(10, 9.0)]));
+
+    vc.upsert(vec![
+        Point {
+            id: 1,
+            vector: vec![1.0, 0.0],
+            payload: Some(json!({"content": "neural networks and learning"})),
+            sparse_vectors: Some(s1),
+        },
+        Point {
+            id: 2,
+            vector: vec![0.0, 1.0],
+            payload: Some(json!({"content": "neural learning systems"})),
+            sparse_vectors: Some(s2),
+        },
+    ])
+    .expect("test: upsert docs");
+}
+
+/// Returns the EXPLAIN fusion-strategy display string for a query.
+fn explain_fusion_strategy(db: &Database, sql: &str) -> String {
+    let query =
+        velesdb_core::velesql::Parser::parse(sql).expect("test: parse explainable fusion query");
+    let plan = db
+        .explain_query(&query)
+        .expect("test: explain fusion query");
+    plan.fusion_info
+        .expect("test: fusion_info present")
+        .strategy
+}
+
+// ============================================================================
+// #6 — strategy keyword honored on dense-NEAR + text-MATCH hybrid
+// ============================================================================
+
+/// `strategy='maximum'` must produce a different ranking than `strategy='rrf'`
+/// on a dense-NEAR + text-MATCH hybrid (previously both ran plain RRF).
+#[test]
+fn bug6_match_hybrid_strategy_changes_ranking() {
+    let (_dir, db) = create_test_db();
+    setup_hybrid_docs(&db);
+
+    let rrf = execute_sql(
+        &db,
+        "SELECT * FROM docs WHERE vector NEAR [1.0, 0.0] AND content MATCH 'learning' \
+         LIMIT 2 USING FUSION(strategy = 'rrf', k = 60)",
+    )
+    .expect("test: rrf hybrid");
+    let maximum = execute_sql(
+        &db,
+        "SELECT * FROM docs WHERE vector NEAR [1.0, 0.0] AND content MATCH 'learning' \
+         LIMIT 2 USING FUSION(strategy = 'maximum')",
+    )
+    .expect("test: maximum hybrid");
+
+    let rrf_scores: Vec<f32> = rrf.iter().map(|r| r.score).collect();
+    let max_scores: Vec<f32> = maximum.iter().map(|r| r.score).collect();
+    assert_ne!(
+        rrf_scores, max_scores,
+        "maximum fusion must produce different scores than rrf"
+    );
+}
+
+/// On the text-hybrid path, `graph_weight` must influence the text branch:
+/// vector_weight=0.7/graph_weight=0.2 differs from graph_weight=0.3.
+#[test]
+fn bug6_graph_weight_affects_text_branch() {
+    let (_dir, db) = create_test_db();
+    setup_hybrid_docs(&db);
+
+    let low = execute_sql(
+        &db,
+        "SELECT * FROM docs WHERE vector NEAR [1.0, 0.0] AND content MATCH 'learning' \
+         LIMIT 2 USING FUSION(strategy = 'weighted', vector_weight = 0.7, graph_weight = 0.2)",
+    )
+    .expect("test: weighted low graph");
+    let high = execute_sql(
+        &db,
+        "SELECT * FROM docs WHERE vector NEAR [1.0, 0.0] AND content MATCH 'learning' \
+         LIMIT 2 USING FUSION(strategy = 'weighted', vector_weight = 0.7, graph_weight = 0.3)",
+    )
+    .expect("test: weighted high graph");
+
+    let low_scores: Vec<f32> = low.iter().map(|r| r.score).collect();
+    let high_scores: Vec<f32> = high.iter().map(|r| r.score).collect();
+    assert_ne!(
+        low_scores, high_scores,
+        "graph_weight must change the text-branch weighting"
+    );
+}
+
+// ============================================================================
+// #10 — validate-time weight checks + honest EXPLAIN
+// ============================================================================
+
+/// RSF with weights that do not sum to ~1.0 must error at validate-time.
+#[test]
+fn bug10_rsf_bad_weight_sum_rejected() {
+    let (_dir, db) = create_test_db();
+    setup_hybrid_docs(&db);
+
+    let err = execute_sql(
+        &db,
+        "SELECT * FROM docs WHERE vector NEAR [1.0, 0.0] AND vector SPARSE_NEAR {10: 1.0} \
+         LIMIT 2 USING FUSION(strategy = 'rsf', dense_w = 0.7, sparse_w = 0.7)",
+    )
+    .expect_err("test: RSF weights not summing to 1.0 must be rejected");
+    assert!(
+        err.to_string().contains("FUSION"),
+        "expected FUSION validation marker, got: {err}"
+    );
+}
+
+/// EXPLAIN of a NEAR+MATCH text-hybrid must report the strategy that actually
+/// executes. After bug #6 the text-hybrid path honors `strategy='maximum'`
+/// (score-level Maximum fusion), so EXPLAIN honestly reports `Maximum` — and a
+/// plain `rrf` clause reports `RRF`. The EXPLAIN display and execution agree.
+#[test]
+fn bug10_explain_text_hybrid_matches_execution() {
+    let (_dir, db) = create_test_db();
+    setup_hybrid_docs(&db);
+
+    let maximum = explain_fusion_strategy(
+        &db,
+        "SELECT * FROM docs WHERE vector NEAR [1.0, 0.0] AND content MATCH 'learning' \
+         LIMIT 2 USING FUSION(strategy = 'maximum')",
+    );
+    assert_eq!(maximum, "Maximum", "EXPLAIN must report executed Maximum");
+
+    let rrf = explain_fusion_strategy(
+        &db,
+        "SELECT * FROM docs WHERE vector NEAR [1.0, 0.0] AND content MATCH 'learning' \
+         LIMIT 2 USING FUSION(strategy = 'rrf', k = 60)",
+    );
+    assert_eq!(rrf, "RRF", "EXPLAIN must report executed RRF");
+}
+
+// ============================================================================
+// #15 — NEAR_FUSED rejects weighted/rsf; relative_score alias; unknown reject
+// ============================================================================
+
+/// `NEAR_FUSED ... USING FUSION 'weighted'` must be a validate-time error.
+#[test]
+fn bug15_near_fused_weighted_rejected() {
+    let (_dir, db) = create_test_db();
+    setup_hybrid_docs(&db);
+
+    let err = execute_sql(
+        &db,
+        "SELECT * FROM docs WHERE vector NEAR_FUSED [[1.0, 0.0], [0.0, 1.0]] \
+         USING FUSION 'weighted' LIMIT 2",
+    )
+    .expect_err("test: NEAR_FUSED weighted must be rejected");
+    assert!(
+        err.to_string().contains("FUSION"),
+        "expected FUSION validation marker, got: {err}"
+    );
+}
+
+/// SQL `strategy='relative_score'` maps to RSF (not silent RRF). With a
+/// dense+sparse hybrid and balanced weights it runs and produces results.
+#[test]
+fn bug15_relative_score_alias_maps_to_rsf() {
+    let (_dir, db) = create_test_db();
+    setup_hybrid_docs(&db);
+
+    let strategy = explain_fusion_strategy(
+        &db,
+        "SELECT * FROM docs WHERE vector NEAR [1.0, 0.0] AND vector SPARSE_NEAR {10: 1.0} \
+         LIMIT 2 USING FUSION(strategy = 'relative_score', dense_w = 0.5, sparse_w = 0.5)",
+    );
+    assert_eq!(
+        strategy, "RSF",
+        "relative_score alias must resolve to RSF, not RRF"
+    );
+}
+
+/// An unknown FUSION strategy name must be rejected, not silently run RRF.
+#[test]
+fn bug15_unknown_strategy_rejected() {
+    let (_dir, db) = create_test_db();
+    setup_hybrid_docs(&db);
+
+    let err = execute_sql(
+        &db,
+        "SELECT * FROM docs WHERE vector NEAR [1.0, 0.0] AND content MATCH 'learning' \
+         LIMIT 2 USING FUSION(strategy = 'nonsense')",
+    )
+    .expect_err("test: unknown strategy must be rejected");
+    assert!(
+        err.to_string().contains("strategy") || err.to_string().contains("FUSION"),
+        "expected unknown-strategy marker, got: {err}"
+    );
+}
+
+// ============================================================================
+// #16 — FUSION on a single fusable branch is a validate-time error
+// ============================================================================
+
+/// `similarity()`-only query with USING FUSION has no second branch -> reject.
+#[test]
+fn bug16_similarity_only_fusion_rejected() {
+    let (_dir, db) = create_test_db();
+    setup_hybrid_docs(&db);
+
+    let err = execute_sql(
+        &db,
+        "SELECT * FROM docs WHERE similarity(vector, [1.0, 0.0]) > 0.5 \
+         LIMIT 2 USING FUSION(strategy = 'maximum')",
+    )
+    .expect_err("test: similarity-only FUSION must be rejected");
+    assert!(
+        err.to_string().contains("FUSION"),
+        "expected FUSION applicability marker, got: {err}"
+    );
+}
+
+/// Pure NEAR (single branch) with USING FUSION -> reject.
+#[test]
+fn bug16_pure_near_fusion_rejected() {
+    let (_dir, db) = create_test_db();
+    setup_hybrid_docs(&db);
+
+    let err = execute_sql(
+        &db,
+        "SELECT * FROM docs WHERE vector NEAR [1.0, 0.0] \
+         LIMIT 2 USING FUSION(strategy = 'rrf', k = 60)",
+    )
+    .expect_err("test: pure NEAR FUSION must be rejected");
+    assert!(
+        err.to_string().contains("FUSION"),
+        "expected FUSION applicability marker, got: {err}"
+    );
+}
+
+/// A genuine two-branch query with USING FUSION still validates and runs.
+#[test]
+fn bug16_two_branch_fusion_allowed() {
+    let (_dir, db) = create_test_db();
+    setup_hybrid_docs(&db);
+
+    let results = execute_sql(
+        &db,
+        "SELECT * FROM docs WHERE vector NEAR [1.0, 0.0] AND content MATCH 'learning' \
+         LIMIT 2 USING FUSION(strategy = 'rrf', k = 60)",
+    )
+    .expect("test: two-branch FUSION must be accepted");
+    assert!(!results.is_empty(), "two-branch fusion must return results");
+}
+
+// ============================================================================
+// #17 — dense_weight/sparse_weight long names + unknown-key reject
+// ============================================================================
+
+/// The documented RSF example with `dense_weight=0.7, sparse_weight=0.3`
+/// resolves those weights (not 50/50) — proven via a sparse-heavy ranking.
+#[test]
+fn bug17_long_name_weights_honored() {
+    let (_dir, db) = create_test_db();
+    setup_hybrid_docs(&db);
+
+    // Strongly dense-favored vs strongly sparse-favored should differ.
+    let dense_heavy = execute_sql(
+        &db,
+        "SELECT * FROM docs WHERE vector NEAR [1.0, 0.0] AND vector SPARSE_NEAR {10: 1.0} \
+         LIMIT 2 USING FUSION(strategy = 'rsf', dense_weight = 0.9, sparse_weight = 0.1)",
+    )
+    .expect("test: dense-heavy rsf");
+    let sparse_heavy = execute_sql(
+        &db,
+        "SELECT * FROM docs WHERE vector NEAR [1.0, 0.0] AND vector SPARSE_NEAR {10: 1.0} \
+         LIMIT 2 USING FUSION(strategy = 'rsf', dense_weight = 0.1, sparse_weight = 0.9)",
+    )
+    .expect("test: sparse-heavy rsf");
+
+    let dense_order: Vec<u64> = dense_heavy.iter().map(|r| r.point.id).collect();
+    let sparse_order: Vec<u64> = sparse_heavy.iter().map(|r| r.point.id).collect();
+    assert_ne!(
+        dense_order, sparse_order,
+        "long-name dense_weight/sparse_weight must influence ranking (not 50/50)"
+    );
+}
+
+/// A misspelled fusion key must be rejected, not silently ignored.
+#[test]
+fn bug17_unknown_fusion_key_rejected() {
+    let (_dir, db) = create_test_db();
+    setup_hybrid_docs(&db);
+
+    let err = execute_sql(
+        &db,
+        "SELECT * FROM docs WHERE vector NEAR [1.0, 0.0] AND vector SPARSE_NEAR {10: 1.0} \
+         LIMIT 2 USING FUSION(strategy = 'rsf', dense_wieght = 0.7, sparse_weight = 0.3)",
+    )
+    .expect_err("test: misspelled fusion key must be rejected");
+    assert!(
+        err.to_string().contains("FUSION") || err.to_string().contains("dense_wieght"),
+        "expected unknown-fusion-key marker, got: {err}"
+    );
+}

--- a/crates/velesdb-core/tests/bdd/fusion_correctness.rs
+++ b/crates/velesdb-core/tests/bdd/fusion_correctness.rs
@@ -171,6 +171,27 @@ fn bug10_explain_text_hybrid_matches_execution() {
     assert_eq!(rrf, "RRF", "EXPLAIN must report executed RRF");
 }
 
+/// A negative `graph_weight` on the weighted NEAR + MATCH path must be
+/// rejected at validate-time instead of being silently clamped (the weighted
+/// vector+text path normalizes `vector_weight/(vector_weight+graph_weight)`, so
+/// a negative `graph_weight` would otherwise pass and degrade to `1.0`).
+#[test]
+fn bug10_weighted_negative_graph_weight_rejected() {
+    let (_dir, db) = create_test_db();
+    setup_hybrid_docs(&db);
+
+    let err = execute_sql(
+        &db,
+        "SELECT * FROM docs WHERE vector NEAR [1.0, 0.0] AND content MATCH 'learning' \
+         LIMIT 2 USING FUSION(strategy = 'weighted', vector_weight = 0.7, graph_weight = -0.2)",
+    )
+    .expect_err("test: negative graph_weight must be rejected");
+    assert!(
+        err.to_string().contains("FUSION"),
+        "expected FUSION validation marker, got: {err}"
+    );
+}
+
 // ============================================================================
 // #15 — NEAR_FUSED rejects weighted/rsf; relative_score alias; unknown reject
 // ============================================================================

--- a/crates/velesdb-core/tests/bdd/graph_vector_hybrid.rs
+++ b/crates/velesdb-core/tests/bdd/graph_vector_hybrid.rs
@@ -416,6 +416,83 @@ fn test_orderby_similarity_without_near_scores_all_anchors() {
 }
 
 // =========================================================================
+// B2. Anchored hybrid (NEAR + graph MATCH + text MATCH) honors FUSION strategy
+// =========================================================================
+
+/// Creates a "notes" collection where every note cites a hub (id 99) and the
+/// text/vector score streams disagree, so RRF rank-fusion and Maximum
+/// score-fusion rank the anchors differently.
+///
+/// | id | vector       | content              | vector rank | bm25 rank |
+/// |----|--------------|----------------------|-------------|-----------|
+/// | 1  | `[1.0, 0.0]` | "learning"           | 1 (closest) | low       |
+/// | 2  | `[0.2, 0.98]`| "learning learning   | low         | 1 (best)  |
+/// |    |              |  learning systems"   |             |           |
+fn setup_anchored_hybrid_notes(db: &Database) {
+    db.create_vector_collection("notes", 2, velesdb_core::DistanceMetric::Cosine)
+        .expect("test: create notes collection");
+    let vc = db
+        .get_vector_collection("notes")
+        .expect("test: get notes collection");
+    vc.upsert(vec![
+        Point::new(1, vec![1.0, 0.0], Some(json!({"content": "learning"}))),
+        Point::new(
+            2,
+            vec![0.2, 0.98],
+            Some(json!({"content": "learning learning learning systems"})),
+        ),
+        // Hub: cited by 1 and 2, matches neither branch strongly.
+        Point::new(99, vec![0.0, 0.01], Some(json!({"content": "hub"}))),
+    ])
+    .expect("test: upsert notes corpus");
+    for (edge_id, source) in [(700u64, 1u64), (701, 2)] {
+        let edge = GraphEdge::new(edge_id, source, 99, "CITES").expect("test: create edge");
+        vc.add_edge(edge).expect("test: add CITES edge");
+    }
+}
+
+/// GIVEN notes whose vector-similarity and BM25 score streams disagree, all
+///       sharing an AND-required graph CITES anchor
+/// WHEN running the anchored hybrid `NEAR + MATCH (graph) + content MATCH`
+///      with `USING FUSION(strategy='maximum')` vs `strategy='rrf'`
+/// THEN the anchored path honors the requested strategy (scores/order differ),
+///      while the predicate-filtered result SET is identical (bug #6, anchored).
+#[test]
+fn test_anchored_hybrid_honors_fusion_strategy() {
+    let (_dir, db) = create_test_db();
+    setup_anchored_hybrid_notes(&db);
+
+    let q = "SELECT * FROM notes AS n \
+             WHERE vector NEAR [1.0, 0.0] AND MATCH (n)-[:CITES]->(h) \
+             AND content MATCH 'learning' LIMIT 10";
+    let rrf = execute_sql(&db, &format!("{q} USING FUSION(strategy = 'rrf', k = 60)"))
+        .expect("anchored rrf hybrid must execute");
+    let maximum = execute_sql(&db, &format!("{q} USING FUSION(strategy = 'maximum')"))
+        .expect("anchored maximum hybrid must execute");
+
+    // The predicate-filtered SET is identical: only nodes citing the hub AND
+    // matching the text (ids 1 and 2; the hub 99 never matches 'learning').
+    assert_eq!(
+        result_ids(&rrf),
+        [1u64, 2].into_iter().collect(),
+        "rrf anchored set must be the citing text-matching notes"
+    );
+    assert_eq!(
+        result_ids(&maximum),
+        result_ids(&rrf),
+        "strategy must not change the anchored predicate-filtered SET"
+    );
+
+    // The fusion strategy must change the ranking/scores (it was ignored before).
+    let rrf_scored: Vec<(u64, f32)> = rrf.iter().map(|r| (r.point.id, r.score)).collect();
+    let max_scored: Vec<(u64, f32)> = maximum.iter().map(|r| (r.point.id, r.score)).collect();
+    assert_ne!(
+        rrf_scored, max_scored,
+        "anchored hybrid must honor strategy='maximum' (different ranking than rrf)"
+    );
+}
+
+// =========================================================================
 // C. Flagship: implicit anchor binding (V011 relaxation, guards G1/G2/G3)
 // =========================================================================
 

--- a/docs/VELESQL_SPEC.md
+++ b/docs/VELESQL_SPEC.md
@@ -777,7 +777,8 @@ literals (`[0.1, 0.2, ...]`).
 | `maximum` | Conservative high-precision | (none) |
 
 Only `rrf`, `average`, and `maximum` are honored. Any other strategy name
-(e.g. `rsf`, `weighted`) falls back to RRF; weight parameters are not read.
+(e.g. `rsf`, `weighted`) is **rejected at validation** — per-branch dense/sparse
+weights are ill-defined over N homogeneous query vectors.
 
 ### Similarity Function (v1.3+)
 
@@ -1508,9 +1509,15 @@ USING FUSION(strategy = 'rrf', k = 60)
 | Strategy | Description | Parameters | Use Case |
 |----------|-------------|------------|----------|
 | `rrf` | Reciprocal Rank Fusion | `k` (default: 60) | Balanced ranking (default) |
-| `weighted` | Weighted combination | `vector_weight`, `graph_weight` | Custom importance |
+| `weighted` | Weighted combination | vector+text: `vector_weight`, `graph_weight`; dense+sparse: `dense_weight`, `sparse_weight` | Custom importance |
 | `maximum` | Take highest score | (none) | Best match wins |
-| `rsf` | Reciprocal Score Fusion | `dense_weight`, `sparse_weight` | Dense + sparse blending |
+| `rsf` | Relative Score Fusion | `dense_weight`, `sparse_weight` (must sum to 1.0) | Dense + sparse blending |
+
+> **USING FUSION requires at least two fusable branches** (e.g. `vector NEAR`
+> + `MATCH`, or `vector NEAR` + `vector SPARSE_NEAR`) or a single `NEAR_FUSED`
+> predicate. Applied to a single-branch query it is rejected at validation.
+> `dense_w`/`sparse_w` are accepted as short aliases of `dense_weight`/`sparse_weight`.
+> Unknown strategy names and unknown option keys are rejected (no silent RRF fallback).
 
 ### Examples
 
@@ -1533,9 +1540,10 @@ SELECT * FROM docs
 WHERE vector NEAR $dense AND vector SPARSE_NEAR $sparse
 LIMIT 10 USING FUSION(strategy = 'rsf', dense_weight = 0.7, sparse_weight = 0.3)
 
--- Maximum score fusion
+-- Maximum score fusion (requires two fusable branches; USING FUSION on a
+-- single-branch query — e.g. similarity()-only or pure NEAR — is rejected)
 SELECT * FROM docs
-WHERE similarity(embedding, $q1) > 0.5
+WHERE vector NEAR $q AND content MATCH 'transformers'
 LIMIT 10 USING FUSION(strategy = 'maximum')
 ```
 
@@ -3074,9 +3082,11 @@ SELECT * FROM docs
 WHERE vector NEAR $dense_query AND vector SPARSE_NEAR $sparse_query
 LIMIT 10 USING FUSION(strategy = 'rrf', k = 60)
 
--- Multi-vector fusion (text + image embeddings) — inline NEAR_FUSED form
+-- Multi-vector fusion (text + image embeddings) — inline NEAR_FUSED form.
+-- NEAR_FUSED supports only rrf, average, or maximum; 'weighted'/'rsf' are
+-- rejected (ill-defined over homogeneous query vectors).
 SELECT * FROM products
-WHERE vector NEAR_FUSED [$text_emb, $image_emb] USING FUSION 'weighted'
+WHERE vector NEAR_FUSED [$text_emb, $image_emb] USING FUSION 'rrf'
 LIMIT 20
 ```
 

--- a/docs/reference/VELESQL_CHEATSHEET.md
+++ b/docs/reference/VELESQL_CHEATSHEET.md
@@ -117,8 +117,9 @@ SELECT * FROM docs
 WHERE vector NEAR $q AND content MATCH 'database'
 LIMIT 10 USING FUSION(strategy = 'weighted', vector_weight = 0.7, graph_weight = 0.3);
 
--- Inline NEAR_FUSED with a bare strategy string (weighted/rsf fall back to RRF).
-SELECT * FROM products WHERE vector NEAR_FUSED [$a, $b] USING FUSION 'weighted' LIMIT 20;
+-- Inline NEAR_FUSED with a bare strategy string (rrf/average/maximum only;
+-- weighted/rsf are rejected). USING FUSION needs >=2 branches or a NEAR_FUSED.
+SELECT * FROM products WHERE vector NEAR_FUSED [$a, $b] USING FUSION 'rrf' LIMIT 20;
 ```
 
 ---


### PR DESCRIPTION
## Summary

Closes five fusion-correctness bugs where a documented `USING FUSION` clause was silently ignored, mis-applied, or degraded to RRF. All fixes live in `velesdb-core` (single source of truth); WASM/SDKs untouched (later waves align them).

### #6 — `USING FUSION(strategy=…)` ignored on dense-NEAR + text-MATCH hybrid
`dispatch_near_with_filter` (and the anchored `try_anchored_hybrid_fetch`) read only `vector_weight`/`k` and always ran weighted RRF, so `maximum`/`average`/`rsf` were no-ops and `graph_weight` had zero effect. Now both the plain and **anchored** NEAR+MATCH paths route through a strategy-aware helper (`hybrid_search_with_clause` / `hybrid_search_with_anchors_clause`): `maximum`/`average`/`rsf` perform score-level `FusionStrategy` fusion; `weighted` normalizes `vector_weight`/`graph_weight` so `graph_weight` weights the BM25 branch. The anchored predicate's filtering set is **unchanged** for every strategy — only the ranking of the two score streams changes (`rrf`/unset is byte-identical to before).

### #10 — EXPLAIN dishonest + weights validated only at execution (silent RRF fallback)
Added validate-time FUSION weight checks (`validation_fusion.rs`): RSF `dense_w`+`sparse_w` must sum to ~1.0 (ε=0.001) and be non-negative; Weighted `dense`/`sparse` **and** `vector`/`graph` weights must be non-negative (a negative `graph_weight` previously slipped through and was silently clamped). This makes the execution-time RRF fallback unreachable, so EXPLAIN now honestly reflects execution.

### #15 — `NEAR_FUSED` `weighted`/`rsf` silently downgraded; SQL ignored `relative_score`
`NEAR_FUSED weighted`/`rsf` (ill-defined over N homogeneous query vectors) now **rejected** at validate-time. SQL parser maps `relative_score`→`Rsf` and **rejects unknown strategy names** instead of silently falling back to RRF.

### #16 — `USING FUSION` on a single-branch query was a decorative no-op
Added applicability validation: `USING FUSION` now requires ≥2 fusable branches (NEAR+MATCH, NEAR+SPARSE_NEAR, …) or a `NEAR_FUSED`; otherwise it errors loudly.

### #17 — Documented `dense_weight`/`sparse_weight` long names dropped (ran 50/50)
Parser now accepts the `dense_weight`/`sparse_weight` aliases **and rejects unknown fusion keys** (no more silent no-op on a misspelled weight). SPEC/parser/executor weight-key names reconciled.

## Test plan
- New BDD `tests/bdd/fusion_correctness.rs` (13 discriminating tests) + anchored-strategy test in `graph_vector_hybrid.rs` — each genuinely **fails pre-fix** (11/12 failed on the base) and passes here.
- Gates: `cargo fmt`; `clippy --all-targets … -D warnings -D clippy::pedantic` (exit 0); `lizard -C 8` (no fn over CCN 8 / NLOC 50); jscpd 0 clones in the new files (extracted `reject_negative_pair` + `fuse_streams` helpers); **full `cargo test -p velesdb-core --features persistence` = 45 binaries, 0 failed**.

## Notes (tracked follow-ups)
- Fusion rejects currently reuse the `V006` (`SimilarityWithoutContext`) error kind — a dedicated FusionError code is folded into the upcoming **errors wave** (#12/#13).
- Docs SPEC/cheatsheet fusion examples corrected to match the now-enforced semantics.

Behavior changes (validate-time rejections, ranking changes) recorded in `CHANGELOG.md [Unreleased]`.