### PR TITLE
fix(velesql): honest EXPLAIN — real MATCH traversal plan + approximate-counter flag (#14/#26)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,8 +65,26 @@ release.
   persists the policy, so the setting survives a restart (restored on the next
   open). Setting `false` keeps the policy attached but disabled, preserving any
   configured thresholds. Unknown options and non-bool values still error.
+- **EXPLAIN ANALYZE now flags approximate graph-traversal counters.** The REST
+  `actual_stats` object carries a new machine-readable boolean
+  `traversal_counters_approximate` (mirroring `node_stats.estimated`): `true`
+  when `nodes_visited` / `edges_traversed` are strategy-dependent approximations
+  (a lower bound — `VectorFirst` undercounts via its `limit(1)` BFS frontier,
+  `Parallel` double-counts shared nodes), `false` for non-graph queries where
+  both counters are 0. The `node_stats` heuristic time/row fields and the
+  `VELESQL_SPEC` are relabeled so the estimated values are no longer presented as
+  measured/actual. *(Additive: the field is appended to `actual_stats`.)*
 
 ### Fixed
+- **EXPLAIN of a MATCH query now shows the graph traversal and its strategy.**
+  `EXPLAIN`/`EXPLAIN ANALYZE` of a MATCH query (REST `/query/explain`, core
+  `Database`/`Collection` explain paths) previously emitted a bare empty
+  `TableScan` mislabeled `MATCH` because the plan builder never routed MATCH
+  clauses through the traversal planner. The plan now carries a `MatchTraversal`
+  step with a real, non-empty strategy (`GraphFirst` / `VectorFirst` /
+  `Parallel`), and the Database/Collection explain paths thread the live graph
+  `CollectionStats` so the chosen strategy reflects the actual graph shape.
+  *(Behavior change: the EXPLAIN plan steps for MATCH queries change.)*
 - **Unpopulated built-in score variables now default to `0`, not the primary
   score.** In `ORDER BY`/`LET` arithmetic, a built-in score component absent from
   a result's component breakdown (e.g. `bm25_score` on a `NEAR`-only query) used

--- a/crates/velesdb-core/src/api_types/responses_explain.rs
+++ b/crates/velesdb-core/src/api_types/responses_explain.rs
@@ -52,6 +52,14 @@ pub struct ExplainResponse {
 }
 
 /// Actual execution statistics for EXPLAIN ANALYZE responses.
+///
+/// `actual_rows`, `actual_time_ms`, and `loops` are measured. The graph
+/// traversal counters `nodes_visited` / `edges_traversed` are **strategy-
+/// dependent approximations** (a lower bound, not an exact figure):
+/// `VectorFirst` undercounts via its `limit(1)` existence-BFS frontier and
+/// `Parallel` double-counts a node touched by both legs. The
+/// `traversal_counters_approximate` flag exposes this honesty contract in a
+/// machine-readable form (backlog #26), mirroring [`NodeStatsResponse::estimated`].
 #[derive(Debug, Serialize)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 pub struct ActualStatsResponse {
@@ -61,10 +69,16 @@ pub struct ActualStatsResponse {
     pub actual_time_ms: f64,
     /// Number of loop iterations.
     pub loops: u64,
-    /// Number of nodes visited (for graph traversal).
+    /// Approximate number of nodes visited during MATCH graph traversal.
+    /// See `traversal_counters_approximate`; 0 for non-graph queries.
     pub nodes_visited: u64,
-    /// Number of edges traversed.
+    /// Approximate number of edges traversed during MATCH graph traversal.
+    /// See `traversal_counters_approximate`; 0 for non-graph queries.
     pub edges_traversed: u64,
+    /// When `true`, `nodes_visited` and `edges_traversed` are strategy-dependent
+    /// approximations (a lower bound), not exact measured counts. Always `false`
+    /// for non-graph queries, where both counters are 0.
+    pub traversal_counters_approximate: bool,
 }
 
 #[cfg(feature = "persistence")]
@@ -76,6 +90,9 @@ impl From<&crate::velesql::ActualStats> for ActualStatsResponse {
             loops: s.loops,
             nodes_visited: s.nodes_visited,
             edges_traversed: s.edges_traversed,
+            // Graph traversal counters are only present (and only approximate)
+            // when a MATCH query actually walked the graph (backlog #26).
+            traversal_counters_approximate: s.nodes_visited > 0 || s.edges_traversed > 0,
         }
     }
 }

--- a/crates/velesdb-core/src/collection/search/query/match_dispatch.rs
+++ b/crates/velesdb-core/src/collection/search/query/match_dispatch.rs
@@ -26,7 +26,7 @@ impl Collection {
     /// from the live collection data structures for cost-based strategy selection.
     // Reason: usize->f64 casts are for cost-estimation ratios, not precise calculations.
     #[allow(clippy::cast_precision_loss)]
-    fn compute_match_collection_stats(&self) -> super::match_planner::CollectionStats {
+    pub(crate) fn compute_match_collection_stats(&self) -> super::match_planner::CollectionStats {
         let total_nodes = self.len();
         let total_edges = self.edge_store.len();
         let avg_degree = if total_nodes > 0 {

--- a/crates/velesdb-core/src/collection/search/query/query_pipeline.rs
+++ b/crates/velesdb-core/src/collection/search/query/query_pipeline.rs
@@ -377,10 +377,13 @@ impl Collection {
     ) -> Result<crate::velesql::ExplainOutput> {
         use crate::velesql::{build_leaf_node_stats, ActualStats, ExplainOutput, QueryPlan};
 
-        // Use from_query() (not from_select/from_match) to include LET bindings,
-        // keeping the plan consistent with the Database-level explain path.
+        // Thread the live indexed-field set and (for MATCH) the real graph
+        // CollectionStats so the plan emits IndexLookup / a MatchTraversal node
+        // with a calibrated strategy instead of a bare TableScan (backlog #14).
         // Cache fields are unavailable at the Collection level and remain None.
-        let plan = QueryPlan::from_query(query);
+        let indexed = self.indexed_field_names();
+        let match_stats = self.compute_match_collection_stats();
+        let plan = QueryPlan::from_query_with_all_stats(query, &indexed, None, Some(&match_stats));
 
         let start = std::time::Instant::now();
         let (results, nodes, edges) = self.execute_query_counted(query, params)?;

--- a/crates/velesdb-core/src/database/collection_ops.rs
+++ b/crates/velesdb-core/src/database/collection_ops.rs
@@ -200,6 +200,27 @@ impl Database {
         std::collections::HashSet::new()
     }
 
+    /// Returns the live graph `CollectionStats` (node/edge counts, average
+    /// degree, label selectivity) for the named collection, used by the
+    /// `MatchQueryPlanner` to choose a traversal strategy in EXPLAIN of a
+    /// MATCH query (backlog #14). `None` when the collection does not exist.
+    #[must_use]
+    pub(crate) fn match_stats_for(
+        &self,
+        name: &str,
+    ) -> Option<crate::collection::search::query::match_planner::CollectionStats> {
+        if let Some(vc) = self.vector_colls.read().get(name) {
+            return Some(vc.inner.compute_match_collection_stats());
+        }
+        if let Some(gc) = self.graph_colls.read().get(name) {
+            return Some(gc.inner.compute_match_collection_stats());
+        }
+        if let Some(mc) = self.metadata_colls.read().get(name) {
+            return Some(mc.inner.compute_match_collection_stats());
+        }
+        None
+    }
+
     /// Returns the analyze generation for a named collection, if it exists
     /// (issue #608).
     ///

--- a/crates/velesdb-core/src/database/query_engine.rs
+++ b/crates/velesdb-core/src/database/query_engine.rs
@@ -192,7 +192,19 @@ impl Database {
         let primary = &query.select.from;
         let core_stats = self.get_collection_stats(primary).ok().flatten();
         let indexed = self.indexed_fields_for(primary);
-        crate::velesql::QueryPlan::from_query_with_stats(query, &indexed, core_stats.as_ref())
+        // For MATCH queries thread the live graph CollectionStats so the
+        // MatchTraversal strategy reflects the real graph shape (backlog #14).
+        let match_stats = query
+            .match_clause
+            .is_some()
+            .then(|| self.match_stats_for(primary))
+            .flatten();
+        crate::velesql::QueryPlan::from_query_with_all_stats(
+            query,
+            &indexed,
+            core_stats.as_ref(),
+            match_stats.as_ref(),
+        )
     }
 
     /// Executes a query with instrumentation and returns both plan and actual stats.

--- a/crates/velesdb-core/src/velesql/explain/plan_builder.rs
+++ b/crates/velesdb-core/src/velesql/explain/plan_builder.rs
@@ -109,10 +109,33 @@ impl QueryPlan {
         indexed_fields: &HashSet<String>,
         stats: Option<&CoreCollectionStats>,
     ) -> Self {
-        // MATCH and compound queries have no implicit default LIMIT.
-        let implicit_limit = query.match_clause.is_none() && query.compound.is_none();
-        let mut plan =
-            Self::build_select_plan(&query.select, indexed_fields, stats, implicit_limit);
+        Self::from_query_with_all_stats(query, indexed_fields, stats, None)
+    }
+
+    /// Creates a full query plan from a `Query`, threading both calibrated
+    /// `CoreCollectionStats` (SELECT cost estimation) and graph
+    /// `CollectionStats` (MATCH traversal-strategy selection).
+    ///
+    /// MATCH queries route through [`Self::from_match`] so the EXPLAIN/exec
+    /// path emits a `MatchTraversal` node with a real strategy instead of a
+    /// bare `TableScan` mislabeled MATCH (backlog #14). `match_stats` is `None`
+    /// on the pure-AST path (default graph stats); the Database layer supplies
+    /// the live graph stats from `compute_match_collection_stats`.
+    #[must_use]
+    pub fn from_query_with_all_stats(
+        query: &crate::velesql::ast::Query,
+        indexed_fields: &HashSet<String>,
+        stats: Option<&CoreCollectionStats>,
+        match_stats: Option<&CollectionStats>,
+    ) -> Self {
+        let mut plan = if let Some(ref match_clause) = query.match_clause {
+            let default_stats = CollectionStats::default();
+            Self::from_match(match_clause, match_stats.unwrap_or(&default_stats))
+        } else {
+            // Compound queries have no implicit default LIMIT either.
+            let implicit_limit = query.compound.is_none();
+            Self::build_select_plan(&query.select, indexed_fields, stats, implicit_limit)
+        };
         plan.let_bindings = Self::format_let_bindings(&query.let_bindings);
         plan
     }

--- a/crates/velesdb-core/src/velesql/explain_tests.rs
+++ b/crates/velesdb-core/src/velesql/explain_tests.rs
@@ -1206,6 +1206,31 @@ fn test_match_query_plan_has_no_implicit_limit() {
     );
 }
 
+#[test]
+fn test_match_query_from_query_emits_traversal_with_strategy() {
+    // Backlog #14: from_query (the EXPLAIN/exec path) must route a MATCH query
+    // through the traversal planner, not produce a bare TableScan mislabeled
+    // MATCH. The plan must carry a MatchTraversal step with a non-empty strategy.
+    let query =
+        crate::velesql::Parser::parse("MATCH (a)-[:KNOWS]->(b) RETURN b LIMIT 5").expect("parse");
+    let plan = QueryPlan::from_query(&query);
+
+    let steps = plan.to_plan_steps();
+    let traversal = steps
+        .iter()
+        .find(|s| s.operation == PlanStepKind::MatchTraversal)
+        .unwrap_or_else(|| panic!("expected a MatchTraversal step, got: {steps:?}"));
+    assert!(
+        traversal.description.len() > "Graph traversal: ".len(),
+        "traversal strategy must be non-empty: {}",
+        traversal.description
+    );
+    assert!(
+        !steps.iter().any(|s| s.operation == PlanStepKind::TableScan),
+        "MATCH plan must not contain a TableScan: {steps:?}"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // to_plan_steps(): single-sourced structured EXPLAIN steps (C11)
 // ---------------------------------------------------------------------------

--- a/crates/velesdb-server/tests/api_integration.rs
+++ b/crates/velesdb-server/tests/api_integration.rs
@@ -3357,6 +3357,88 @@ async fn test_explain_match_query_surfaces_traversal_with_strategy() {
     );
 }
 
+#[tokio::test]
+async fn test_explain_analyze_match_flags_approximate_traversal_counters() {
+    // Backlog #26: EXPLAIN ANALYZE of a MATCH query must carry a machine-readable
+    // boolean flag declaring that the traversal counters are approximate.
+    let temp_dir = TempDir::new().unwrap();
+    let app = create_test_app(&temp_dir);
+
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/collections")
+                .header("Content-Type", "application/json")
+                .body(Body::from(
+                    json!({ "name": "explain_match_analyze", "dimension": 4, "metric": "cosine" })
+                        .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::CREATED);
+
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/collections/explain_match_analyze/points")
+                .header("Content-Type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "points": [
+                            {"id": 1, "vector": [1.0, 0.0, 0.0, 0.0], "payload": {"_labels": ["Doc"], "title": "a"}},
+                            {"id": 2, "vector": [0.0, 1.0, 0.0, 0.0], "payload": {"_labels": ["Doc"], "title": "b"}}
+                        ]
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/query/explain")
+                .header("Content-Type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "query": "MATCH (d:Doc) RETURN d LIMIT 5",
+                        "analyze": true,
+                        "params": {"_collection": "explain_match_analyze"}
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: Value = serde_json::from_slice(&body).unwrap();
+    let actual_stats = &json["actual_stats"];
+    assert!(
+        actual_stats.is_object(),
+        "EXPLAIN ANALYZE must return actual_stats: {json}"
+    );
+    assert_eq!(
+        actual_stats["traversal_counters_approximate"],
+        Value::Bool(true),
+        "MATCH traversal counters must be flagged approximate: {actual_stats}"
+    );
+}
+
 // ============================================================================
 // GuardRails — rate limit (429)
 // ============================================================================

--- a/crates/velesdb-server/tests/api_integration.rs
+++ b/crates/velesdb-server/tests/api_integration.rs
@@ -3310,6 +3310,53 @@ async fn test_explain_hybrid_vector_filter_surfaces_filter_step() {
     }
 }
 
+#[tokio::test]
+async fn test_explain_match_query_surfaces_traversal_with_strategy() {
+    // Backlog #14: EXPLAIN of a MATCH query must surface a MatchTraversal step
+    // with a non-empty strategy, not a bare TableScan mislabeled MATCH.
+    let temp_dir = TempDir::new().unwrap();
+    let app = create_test_app(&temp_dir);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/query/explain")
+                .header("Content-Type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "query": "MATCH (a)-[:KNOWS]->(b) RETURN b LIMIT 5"
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["query_type"], "MATCH");
+
+    let steps = json["plan"].as_array().unwrap();
+    let traversal = steps
+        .iter()
+        .find(|s| s["operation"] == "MatchTraversal")
+        .unwrap_or_else(|| panic!("expected a MatchTraversal step, got: {steps:?}"));
+    let desc = traversal["description"].as_str().unwrap();
+    assert!(
+        desc.starts_with("Graph traversal: ") && desc.len() > "Graph traversal: ".len(),
+        "traversal strategy must be non-empty: {desc}"
+    );
+    assert!(
+        !steps.iter().any(|s| s["operation"] == "TableScan"),
+        "MATCH EXPLAIN must not contain a TableScan: {steps:?}"
+    );
+}
+
 // ============================================================================
 // GuardRails — rate limit (429)
 // ============================================================================

--- a/docs/VELESQL_SPEC.md
+++ b/docs/VELESQL_SPEC.md
@@ -1975,6 +1975,7 @@ The result includes the estimated plan (identical to `EXPLAIN`) plus:
 | `loops` | u64 | Number of execution iterations (always 1) |
 | `nodes_visited` | u64 | For MATCH queries, an approximate (best-effort, lower-bound) graph-traversal node count (start nodes examined + nodes reached by following edges); 0 for non-MATCH queries |
 | `edges_traversed` | u64 | For MATCH queries, an approximate (best-effort, lower-bound) count of edges followed during traversal; 0 for non-MATCH queries |
+| `traversal_counters_approximate` | bool | `true` when `nodes_visited` / `edges_traversed` are strategy-dependent approximations (a lower bound), not exact measured counts; `false` for non-graph queries where both counters are 0. |
 
 > **Note:** `nodes_visited` / `edges_traversed` are an **approximate, best-effort
 > lower bound** on the graph traversal across all MATCH strategies — not exact
@@ -2005,10 +2006,11 @@ for how the planner attaches it.
 | Field | Type | Description |
 |-------|------|-------------|
 | `node_label` | string | Plan node type (e.g. "VectorSearch", "Filter") |
-| `actual_time_ms` | f64 | Estimated wall-clock time for this node |
-| `actual_rows_in` | u64 | Rows entering this node |
-| `actual_rows_out` | u64 | Rows leaving this node |
+| `actual_time_ms` | f64 | **Estimated** (not measured) wall-clock time for this node, derived by distributing the plan-global `actual_time_ms` across nodes via fixed weight fractions. Heuristic until per-node instrumentation lands (#467). |
+| `actual_rows_in` | u64 | **Estimated** (heuristic) rows entering this node, not a measured count. |
+| `actual_rows_out` | u64 | **Estimated** (heuristic) rows leaving this node, not a measured count. |
 | `loops` | u64 | Loop iterations for this node |
+| `estimated` | bool | Always `true` until instrumented timing lands (#467): the `actual_*` row/time values above are heuristic estimates, not real per-node measurements. The `actual_` prefix is kept for API stability. |
 
 **Filter plan fields (v3.9+):**
 

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3392,13 +3392,14 @@
     "schemas": {
       "ActualStatsResponse": {
         "type": "object",
-        "description": "Actual execution statistics for EXPLAIN ANALYZE responses.",
+        "description": "Actual execution statistics for EXPLAIN ANALYZE responses.\n\n`actual_rows`, `actual_time_ms`, and `loops` are measured. The graph\ntraversal counters `nodes_visited` / `edges_traversed` are **strategy-\ndependent approximations** (a lower bound, not an exact figure):\n`VectorFirst` undercounts via its `limit(1)` existence-BFS frontier and\n`Parallel` double-counts a node touched by both legs. The\n`traversal_counters_approximate` flag exposes this honesty contract in a\nmachine-readable form (backlog #26), mirroring [`NodeStatsResponse::estimated`].",
         "required": [
           "actual_rows",
           "actual_time_ms",
           "loops",
           "nodes_visited",
-          "edges_traversed"
+          "edges_traversed",
+          "traversal_counters_approximate"
         ],
         "properties": {
           "actual_rows": {
@@ -3415,7 +3416,7 @@
           "edges_traversed": {
             "type": "integer",
             "format": "int64",
-            "description": "Number of edges traversed.",
+            "description": "Approximate number of edges traversed during MATCH graph traversal.\nSee `traversal_counters_approximate`; 0 for non-graph queries.",
             "minimum": 0
           },
           "loops": {
@@ -3427,8 +3428,12 @@
           "nodes_visited": {
             "type": "integer",
             "format": "int64",
-            "description": "Number of nodes visited (for graph traversal).",
+            "description": "Approximate number of nodes visited during MATCH graph traversal.\nSee `traversal_counters_approximate`; 0 for non-graph queries.",
             "minimum": 0
+          },
+          "traversal_counters_approximate": {
+            "type": "boolean",
+            "description": "When `true`, `nodes_visited` and `edges_traversed` are strategy-dependent\napproximations (a lower bound), not exact measured counts. Always `false`\nfor non-graph queries, where both counters are 0."
           }
         }
       },

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2233,13 +2233,23 @@ components:
   schemas:
     ActualStatsResponse:
       type: object
-      description: Actual execution statistics for EXPLAIN ANALYZE responses.
+      description: |-
+        Actual execution statistics for EXPLAIN ANALYZE responses.
+
+        `actual_rows`, `actual_time_ms`, and `loops` are measured. The graph
+        traversal counters `nodes_visited` / `edges_traversed` are **strategy-
+        dependent approximations** (a lower bound, not an exact figure):
+        `VectorFirst` undercounts via its `limit(1)` existence-BFS frontier and
+        `Parallel` double-counts a node touched by both legs. The
+        `traversal_counters_approximate` flag exposes this honesty contract in a
+        machine-readable form (backlog #26), mirroring [`NodeStatsResponse::estimated`].
       required:
       - actual_rows
       - actual_time_ms
       - loops
       - nodes_visited
       - edges_traversed
+      - traversal_counters_approximate
       properties:
         actual_rows:
           type: integer
@@ -2253,7 +2263,9 @@ components:
         edges_traversed:
           type: integer
           format: int64
-          description: Number of edges traversed.
+          description: |-
+            Approximate number of edges traversed during MATCH graph traversal.
+            See `traversal_counters_approximate`; 0 for non-graph queries.
           minimum: 0
         loops:
           type: integer
@@ -2263,8 +2275,16 @@ components:
         nodes_visited:
           type: integer
           format: int64
-          description: Number of nodes visited (for graph traversal).
+          description: |-
+            Approximate number of nodes visited during MATCH graph traversal.
+            See `traversal_counters_approximate`; 0 for non-graph queries.
           minimum: 0
+        traversal_counters_approximate:
+          type: boolean
+          description: |-
+            When `true`, `nodes_visited` and `edges_traversed` are strategy-dependent
+            approximations (a lower bound), not exact measured counts. Always `false`
+            for non-graph queries, where both counters are 0.
     AddEdgeRequest:
       type: object
       description: Request to add an edge to the graph.


### PR DESCRIPTION
## Summary

Two EXPLAIN-honesty fixes in `velesdb-core` + `velesdb-server` (Python EXPLAIN wiring folds into the later Python wave via the new core entry point).

### #14 — REST/core EXPLAIN of a MATCH query was degraded (bare TableScan mislabeled MATCH)
`from_query_with_stats` only ever called `build_select_plan` and never read `query.match_clause`, so a MATCH produced an empty `TableScan` with no `MatchTraversal`/strategy. Now `from_query_with_stats` delegates to a new `from_query_with_all_stats` that **branches on `match_clause`** and builds via `from_match` (emitting a real `MatchTraversal` node with a non-empty strategy: GraphFirst/VectorFirst/Parallel). Real graph `CollectionStats` are threaded from `Database::build_plan_with_stats` (new `Database::match_stats_for` → `Collection::compute_match_collection_stats`, now `pub(crate)`), and `Collection::explain_analyze_query` no longer passes `from_query` with no stats. `from_query_with_all_stats(query, indexed_fields, core_stats, match_stats)` is the core entry point the Python wave will call.

### #26 — EXPLAIN ANALYZE traversal counters labeled `actual_*` are heuristic approximations with no machine-readable flag
`nodes_visited`/`edges_traversed` are strategy-dependent approximations (VectorFirst undercounts via `limit(1)` existence-BFS; Parallel double-counts). Added a machine-readable `traversal_counters_approximate: bool` to `ActualStatsResponse`, set in the `From<&ActualStats>` impl (mirroring `NodeStatsResponse::estimated`), ported the honesty doc onto the DTO, and relabeled `docs/VELESQL_SPEC.md` so heuristic counts are no longer called "actual/measured". OpenAPI regenerated.

## Test plan
- Failing-test-first (proven fail-on-base, pass-here):
  - core `velesql::explain_tests::test_match_query_from_query_emits_traversal_with_strategy`
  - server `test_explain_match_query_surfaces_traversal_with_strategy`, `test_explain_analyze_match_flags_approximate_traversal_counters`
- Gates: `cargo fmt`; `clippy --all-targets … -D warnings -D clippy::pedantic` (exit 0); `lizard -C 8` (no new violations — two pre-existing warnings left untouched per repo policy); **core `cargo test -p velesdb-core --features persistence` = 5208/0; server api_integration + lib = 0 failed**.
- **OpenAPI Drift Check verified locally with the exact CI command** (`cargo test -p velesdb-server --features openapi generate_openapi_spec_files`) → `git diff --exit-code` clean (additive: only the new field).

Behavior changes recorded in `CHANGELOG.md [Unreleased]`.