### PR TITLE
fix(cli): error on $param queries, add query execute --collection, apply session settings (#18/#19)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,17 @@ release.
   both counters are 0. The `node_stats` heuristic time/row fields and the
   `VELESQL_SPEC` are relabeled so the estimated values are no longer presented as
   measured/actual. *(Additive: the field is appended to `actual_stats`.)*
+- **CLI `query execute` accepts `--collection`/`-c`.** A bare `MATCH` (or any
+  query without a `FROM` clause) can now target a collection from the one-shot
+  `velesdb query execute <db> "..." --collection <name>` command, mirroring the
+  REST `/query` collection field. Previously such queries failed with the
+  REPL-only "use a collection" error and no way to specify one.
+- **CLI REPL now applies session settings to queries.** `\set mode` /
+  `\set ef_search` are injected into a vector query's `WITH(...)` options before
+  execution (an inline `WITH(...)` always wins), and `\set max_results` caps the
+  effective `LIMIT`. Previously these were stored and displayed but never applied.
+  `timeout_ms` and `rerank` have no execution channel yet, so `\set` now warns
+  that they are display-only instead of implying they take effect.
 
 ### Fixed
 - **EXPLAIN of a MATCH query now shows the graph traversal and its strategy.**
@@ -85,6 +96,13 @@ release.
   `Parallel`), and the Database/Collection explain paths thread the live graph
   `CollectionStats` so the chosen strategy reflects the actual graph shape.
   *(Behavior change: the EXPLAIN plan steps for MATCH queries change.)*
+- **CLI `$parameter` vector queries now error instead of silently succeeding.**
+  A REPL/`query execute` `SELECT`/`MATCH` whose `WHERE` references a `$param`
+  vector (unsupplyable from the CLI) used to print a yellow note and return zero
+  rows with a success exit code, so scripts treated it as an empty result. It now
+  returns an error (red message, non-zero exit) while keeping the guidance to use
+  literal vectors or the REST API.
+  *(Behavior change: such CLI queries now exit non-zero.)*
 - **Unpopulated built-in score variables now default to `0`, not the primary
   score.** In `ORDER BY`/`LET` arithmetic, a built-in score component absent from
   a result's component breakdown (e.g. `bm25_score` on a `NEAR`-only query) used

--- a/crates/velesdb-cli/src/commands.rs
+++ b/crates/velesdb-cli/src/commands.rs
@@ -364,6 +364,11 @@ pub enum QueryCommands {
         /// `VelesQL` query to execute
         query: String,
 
+        /// Target collection for queries without a FROM clause (e.g. bare MATCH),
+        /// mirroring the REST `/query` collection field
+        #[arg(short, long)]
+        collection: Option<String>,
+
         /// Output format (table, json)
         #[arg(short, long, default_value = "table")]
         format: String,

--- a/crates/velesdb-cli/src/main.rs
+++ b/crates/velesdb-cli/src/main.rs
@@ -218,8 +218,9 @@ fn dispatch_query_cmd(action: QueryCommands) -> anyhow::Result<()> {
         QueryCommands::Execute {
             path,
             query,
+            collection,
             format,
-        } => dispatch_query(&path, &query, &format),
+        } => dispatch_query(&path, &query, collection.as_deref(), &format),
         QueryCommands::Search {
             path,
             collection,
@@ -253,9 +254,18 @@ fn dispatch_query_cmd(action: QueryCommands) -> anyhow::Result<()> {
 }
 
 /// Handles the `query` subcommand inline (trivial delegation).
-fn dispatch_query(path: &std::path::Path, query: &str, format: &str) -> anyhow::Result<()> {
+///
+/// `collection` targets queries without a `FROM` clause (e.g. a bare MATCH),
+/// mirroring the REST `/query` collection field. One-shot `query execute` has no
+/// REPL session, so no session settings are applied.
+fn dispatch_query(
+    path: &std::path::Path,
+    query: &str,
+    collection: Option<&str>,
+    format: &str,
+) -> anyhow::Result<()> {
     let db = velesdb_core::Database::open(path)?;
-    let result = repl::execute_query(&db, query, None)?;
+    let result = repl::execute_query(&db, query, collection, None)?;
     repl::print_result(&result, format);
     Ok(())
 }

--- a/crates/velesdb-cli/src/main_tests.rs
+++ b/crates/velesdb-cli/src/main_tests.rs
@@ -178,3 +178,45 @@ fn test_progress_explicit_false_disables() {
         "false",
     ]));
 }
+
+// =========================================================================
+// query execute --collection (parity backlog #18b): a bare MATCH in
+// `query execute` must be able to pick a target collection, mirroring the
+// REST /query collection body field.
+// =========================================================================
+
+fn parse_query_execute_collection(args: &[&str]) -> Option<String> {
+    match Cli::try_parse_from(args)
+        .expect("query execute args should parse")
+        .command
+    {
+        Commands::QueryCmd {
+            action: QueryCommands::Execute { collection, .. },
+        } => collection,
+        _ => panic!("expected `query execute`"),
+    }
+}
+
+#[test]
+fn test_query_execute_collection_defaults_none() {
+    assert_eq!(
+        parse_query_execute_collection(&["velesdb", "query", "execute", "db", "SELECT * FROM t"]),
+        None
+    );
+}
+
+#[test]
+fn test_query_execute_collection_flag() {
+    assert_eq!(
+        parse_query_execute_collection(&[
+            "velesdb",
+            "query",
+            "execute",
+            "db",
+            "MATCH (a)-[:KNOWS]->(b) RETURN a, b LIMIT 10",
+            "--collection",
+            "g",
+        ]),
+        Some("g".to_string())
+    );
+}

--- a/crates/velesdb-cli/src/repl.rs
+++ b/crates/velesdb-cli/src/repl.rs
@@ -182,7 +182,12 @@ fn handle_dot_command(db: &Database, line: &str, config: &mut ReplConfig) -> Loo
 
 /// Execute a `VelesQL` query line and print its result or error.
 fn run_query(db: &Database, line: &str, config: &ReplConfig) {
-    match execute_query(db, line, config.session.active_collection()) {
+    match execute_query(
+        db,
+        line,
+        config.session.active_collection(),
+        Some(&config.session),
+    ) {
         Ok(result) => {
             let fmt = match config.format {
                 OutputFormat::Table => "table",
@@ -205,13 +210,16 @@ fn run_query(db: &Database, line: &str, config: &ReplConfig) {
 
 /// Execute a `VelesQL` query and return results.
 ///
-/// Delegates to [`crate::repl_execute::execute_query`].
+/// Delegates to [`crate::repl_execute::execute_query`]. `session` is `Some` in
+/// the interactive REPL (so `\set` settings are applied) and `None` for one-shot
+/// `query execute` (no session).
 pub fn execute_query(
     db: &Database,
     query: &str,
     active_collection: Option<&str>,
+    session: Option<&SessionSettings>,
 ) -> Result<QueryResult> {
-    crate::repl_execute::execute_query(db, query, active_collection)
+    crate::repl_execute::execute_query(db, query, active_collection, session)
 }
 
 /// Print query results in the specified format

--- a/crates/velesdb-cli/src/repl_config_cmds.rs
+++ b/crates/velesdb-cli/src/repl_config_cmds.rs
@@ -70,10 +70,28 @@ pub(crate) fn cmd_set(config: &mut ReplConfig, parts: &[&str]) -> CommandResult 
     let key = parts[1];
     let value = parts[2];
     match config.session.set(key, value) {
-        Ok(()) => println!("{} = {}\n", key.cyan(), value.green()),
+        Ok(()) => {
+            println!("{} = {}", key.cyan(), value.green());
+            warn_if_unwired(key);
+            println!();
+        }
         Err(e) => return CommandResult::Error(e),
     }
     CommandResult::Continue
+}
+
+/// Warns that a stored setting is display-only because it has no channel into
+/// `Database::execute_query` yet, so `\set` does not silently claim it applies.
+fn warn_if_unwired(key: &str) {
+    if crate::session::is_unwired_setting(key) {
+        println!(
+            "{}",
+            format!(
+                "Note: '{key}' is recorded but not yet applied to query execution (display-only)."
+            )
+            .yellow()
+        );
+    }
 }
 
 pub(crate) fn cmd_show(config: &ReplConfig, parts: &[&str]) -> CommandResult {

--- a/crates/velesdb-cli/src/repl_execute.rs
+++ b/crates/velesdb-cli/src/repl_execute.rs
@@ -3,12 +3,12 @@
 //! Extracted from `repl.rs` to keep module size under 500 NLOC.
 
 use anyhow::Result;
-use colored::Colorize;
 use instant::Instant;
 use std::collections::HashMap;
 use velesdb_core::Database;
 
 use crate::repl::{QueryKind, QueryResult};
+use crate::session::SessionSettings;
 
 /// Execute a `VelesQL` query and return results.
 ///
@@ -21,16 +21,25 @@ pub fn execute_query(
     db: &Database,
     query: &str,
     active_collection: Option<&str>,
+    session: Option<&SessionSettings>,
 ) -> Result<QueryResult> {
     let start = Instant::now();
 
     // Parse the query
-    let parsed = velesdb_core::velesql::Parser::parse(query)
+    let mut parsed = velesdb_core::velesql::Parser::parse(query)
         .map_err(|e| anyhow::anyhow!("Parse error: {}", e.message))?;
 
     // $parameter vectors can't be supplied from the REPL (use the REST API).
+    // Returning Err (not Ok-empty) makes the REPL print a red error and scripts
+    // exit non-zero instead of silently treating 0 rows as success.
     if has_param_vector(&parsed) {
-        return Ok(param_vector_unsupported_result(start));
+        return Err(param_vector_unsupported_error());
+    }
+
+    // Apply REPL session settings (mode/ef_search into the AST WITH-options,
+    // max_results as a LIMIT cap). Inline overrides always win.
+    if let Some(session) = session {
+        apply_session_settings(&mut parsed, session);
     }
 
     // Aggregation (GROUP BY / COUNT / SUM / ...) routes through the dedicated
@@ -41,6 +50,58 @@ pub fn execute_query(
     }
 
     run_row_query(db, &parsed, active_collection, start)
+}
+
+/// Applies REPL session settings to a parsed query before execution.
+///
+/// `mode` and an explicit `ef_search` are injected into the SELECT `WITH`
+/// options (only when not already present — an inline `WITH(...)` always wins),
+/// and `max_results` caps the effective `LIMIT`. Match/aggregate queries are not
+/// touched (those clauses only steer the vector-search pipeline).
+pub fn apply_session_settings(
+    parsed: &mut velesdb_core::velesql::Query,
+    session: &SessionSettings,
+) {
+    if parsed.is_match_query() {
+        return;
+    }
+    inject_session_with_options(&mut parsed.select, session);
+    cap_limit_to_max_results(&mut parsed.select, session.max_results());
+}
+
+/// Injects the session `mode`/`ef_search` into the SELECT `WITH` options,
+/// preserving any inline override (inline wins).
+fn inject_session_with_options(
+    select: &mut velesdb_core::velesql::SelectStatement,
+    session: &SessionSettings,
+) {
+    use velesdb_core::velesql::{WithClause, WithValue};
+
+    let with = select.with_clause.get_or_insert_with(WithClause::new);
+    if with.get_mode().is_none() {
+        with.options.push(velesdb_core::velesql::WithOption {
+            key: "mode".to_string(),
+            value: WithValue::String(session.mode_str()),
+        });
+    }
+    if let Some(ef) = session.ef_search() {
+        if with.get_ef_search().is_none() {
+            with.options.push(velesdb_core::velesql::WithOption {
+                key: "ef_search".to_string(),
+                value: WithValue::Integer(i64::try_from(ef).unwrap_or(i64::MAX)),
+            });
+        }
+    }
+}
+
+/// Caps the effective `LIMIT` at the session `max_results`: a missing `LIMIT`
+/// becomes `max_results`, and a larger explicit `LIMIT` is reduced to it.
+fn cap_limit_to_max_results(
+    select: &mut velesdb_core::velesql::SelectStatement,
+    max_results: usize,
+) {
+    let cap = max_results as u64;
+    select.limit = Some(select.limit.map_or(cap, |l| l.min(cap)));
 }
 
 /// Returns `true` when a SELECT or MATCH `WHERE` references a `$parameter`
@@ -58,19 +119,14 @@ fn has_param_vector(parsed: &velesdb_core::velesql::Query) -> bool {
             .is_some_and(contains_param_vector)
 }
 
-/// The placeholder result shown when a query needs a `$parameter` vector the
-/// REPL cannot supply.
-fn param_vector_unsupported_result(start: Instant) -> QueryResult {
-    println!(
-        "{}",
-        "Note: Vector search with $parameter requires REST API. Use literal vectors or metadata-only queries."
-            .yellow()
-    );
-    QueryResult {
-        rows: Vec::new(),
-        duration_ms: start.elapsed().as_secs_f64() * 1000.0,
-        kind: QueryKind::Select,
-    }
+/// The error returned when a query needs a `$parameter` vector the REPL cannot
+/// supply. Surfaced as an `Err` so the REPL prints it red and scripts exit
+/// non-zero rather than seeing an empty (silently-successful) result.
+fn param_vector_unsupported_error() -> anyhow::Error {
+    anyhow::anyhow!(
+        "Vector search with $parameter requires the REST API. \
+         Use literal vectors or metadata-only queries."
+    )
 }
 
 /// Runs a row-returning query (MATCH, plain SELECT, or DML/DDL) and builds the

--- a/crates/velesdb-cli/src/repl_execute_tests.rs
+++ b/crates/velesdb-cli/src/repl_execute_tests.rs
@@ -4,6 +4,27 @@ use tempfile::TempDir;
 use velesdb_core::{Database, DistanceMetric, Point};
 
 use crate::repl_execute::execute_query;
+use crate::session::SessionSettings;
+
+/// Opens a fresh database with a single `docs` collection seeded with `n`
+/// 2-D points, used by the projection/limit/param regression tests.
+fn seed_docs(dir: &TempDir, n: u64) -> Database {
+    let db = Database::open(dir.path()).expect("open db");
+    db.create_collection("docs", 2, DistanceMetric::Cosine)
+        .expect("create collection");
+    let coll = db.get_vector_collection("docs").expect("vector collection");
+    let points: Vec<Point> = (1..=n)
+        .map(|i| {
+            Point::new(
+                i,
+                vec![1.0, i as f32],
+                Some(serde_json::json!({"category": "x"})),
+            )
+        })
+        .collect();
+    coll.upsert(points).expect("upsert");
+    db
+}
 
 /// Regression (parity backlog #2): the REPL must route `GROUP BY` / aggregate
 /// queries through the aggregate engine, not return raw rows. Previously
@@ -42,6 +63,7 @@ fn test_execute_query_routes_group_by_having_aggregation() {
     let result = execute_query(
         &db,
         "SELECT category, COUNT(*) AS n FROM orders GROUP BY category HAVING COUNT(*) > 1",
+        None,
         None,
     )
     .expect("aggregation query should succeed");
@@ -85,7 +107,7 @@ fn test_execute_query_projects_selected_columns() {
     .expect("upsert");
 
     let result =
-        execute_query(&db, "SELECT category FROM docs", None).expect("select should succeed");
+        execute_query(&db, "SELECT category FROM docs", None, None).expect("select should succeed");
 
     assert_eq!(result.rows.len(), 1, "one matching row");
     let row = &result.rows[0];
@@ -101,5 +123,114 @@ fn test_execute_query_projects_selected_columns() {
     assert!(
         !row.contains_key("id") && !row.contains_key("score"),
         "id/score must not be auto-appended for an explicit column list; row={row:?}"
+    );
+}
+
+/// Regression (parity backlog #18a): a `$parameter` vector query the REPL cannot
+/// supply must return `Err` (red error, non-zero exit), not `Ok(empty)` which
+/// scripts silently treat as success. The helpful message text is preserved.
+#[test]
+fn test_param_vector_query_errors_instead_of_empty_ok() {
+    let dir = TempDir::new().expect("temp dir");
+    let db = seed_docs(&dir, 3);
+
+    let result = execute_query(
+        &db,
+        "SELECT * FROM docs WHERE vector NEAR $q LIMIT 5",
+        None,
+        None,
+    );
+
+    let err = result.expect_err("a $parameter vector query must error, not return empty Ok");
+    assert!(
+        err.to_string().contains("$parameter"),
+        "the error must keep the helpful $parameter message; got: {err}"
+    );
+}
+
+/// Regression (parity backlog #19): setting `ef_search=512` in the session must
+/// inject `ef_search=512` into the AST WITH-options before execution.
+#[test]
+fn test_session_ef_search_injected_into_ast() {
+    let mut session = SessionSettings::new();
+    session.set("ef_search", "512").expect("set ef_search");
+
+    let mut parsed =
+        velesdb_core::velesql::Parser::parse("SELECT * FROM docs WHERE vector NEAR [1.0, 2.0]")
+            .expect("parse");
+    crate::repl_execute::apply_session_settings(&mut parsed, &session);
+
+    let with = parsed
+        .select
+        .with_clause
+        .as_ref()
+        .expect("session ef_search must add a WITH clause");
+    assert_eq!(
+        with.get_ef_search(),
+        Some(512),
+        "session ef_search must reach the AST WITH-options"
+    );
+}
+
+/// Regression (parity backlog #19): an inline `WITH(ef_search=N)` must win over
+/// the session value (the session injects only when no inline override exists).
+#[test]
+fn test_inline_ef_search_wins_over_session() {
+    let mut session = SessionSettings::new();
+    session.set("ef_search", "512").expect("set ef_search");
+
+    let mut parsed = velesdb_core::velesql::Parser::parse(
+        "SELECT * FROM docs WHERE vector NEAR [1.0, 2.0] WITH(ef_search=64)",
+    )
+    .expect("parse");
+    crate::repl_execute::apply_session_settings(&mut parsed, &session);
+
+    let with = parsed.select.with_clause.as_ref().expect("inline WITH");
+    assert_eq!(
+        with.get_ef_search(),
+        Some(64),
+        "inline WITH(ef_search) must win over the session value"
+    );
+}
+
+/// Regression (parity backlog #19): `max_results` caps the effective LIMIT. A
+/// query with no LIMIT and a session `max_results=2` must return at most 2 rows.
+#[test]
+fn test_session_max_results_caps_limit() {
+    let dir = TempDir::new().expect("temp dir");
+    let db = seed_docs(&dir, 5);
+    let mut session = SessionSettings::new();
+    session.set("max_results", "2").expect("set max_results");
+
+    let result = execute_query(&db, "SELECT category FROM docs", None, Some(&session))
+        .expect("select should succeed");
+
+    assert!(
+        result.rows.len() <= 2,
+        "max_results=2 must cap the result count; got {} rows",
+        result.rows.len()
+    );
+}
+
+/// Regression (parity backlog #19): `\set` on an unwired key (`timeout_ms`,
+/// `rerank`) must warn that the setting is display-only, instead of silently
+/// claiming success.
+#[test]
+fn test_unwired_set_keys_are_flagged() {
+    assert!(
+        crate::session::is_unwired_setting("timeout_ms"),
+        "timeout_ms has no channel into Database::execute_query and must warn"
+    );
+    assert!(
+        crate::session::is_unwired_setting("rerank"),
+        "rerank has no channel into Database::execute_query and must warn"
+    );
+    assert!(
+        !crate::session::is_unwired_setting("ef_search"),
+        "ef_search IS wired and must not warn"
+    );
+    assert!(
+        !crate::session::is_unwired_setting("max_results"),
+        "max_results IS wired and must not warn"
     );
 }

--- a/crates/velesdb-cli/src/session.rs
+++ b/crates/velesdb-cli/src/session.rs
@@ -51,11 +51,30 @@ impl SessionSettings {
         self.mode
     }
 
+    /// Returns the current mode as the `WITH(mode=...)` string the core parser
+    /// understands (`fast`/`balanced`/`accurate`/`perfect`/`autotune`/`custom:<ef>`/
+    /// `adaptive:<min>:<max>`), so the session mode can be injected into a query.
+    #[must_use]
+    pub fn mode_str(&self) -> String {
+        format_quality(self.mode)
+    }
+
+    /// Gets the explicitly-set ef_search override, if any.
+    ///
+    /// `None` means "use the mode default"; the session only injects an explicit
+    /// `ef_search` into a query's WITH clause, leaving the mode to drive the rest.
+    #[must_use]
+    pub fn ef_search(&self) -> Option<usize> {
+        self.ef_search
+    }
+
     /// Gets the effective ef_search value.
     ///
-    /// Uses a default `k=10` for the quality profile's ef calculation.
+    /// Uses a default `k=10` for the quality profile's ef calculation. The query
+    /// path injects the explicit [`Self::ef_search`] override and lets the `mode`
+    /// drive the rest, so this resolved value is used only in tests.
     #[must_use]
-    #[allow(dead_code)] // Reason: public API for session-aware query execution (used in tests)
+    #[allow(dead_code)] // Reason: resolved ef preview for tests; query path injects the explicit override + mode
     pub fn effective_ef_search(&self) -> usize {
         self.ef_search.unwrap_or_else(|| self.mode.ef_search(10))
     }
@@ -76,7 +95,6 @@ impl SessionSettings {
 
     /// Gets max results.
     #[must_use]
-    #[allow(dead_code)] // Reason: public API for session-aware query execution (used in tests)
     pub fn max_results(&self) -> usize {
         self.max_results
     }
@@ -270,6 +288,20 @@ fn parse_parameterized_mode(value: &str) -> Result<SearchQuality, String> {
         "Invalid mode '{value}'. Valid: fast, balanced, accurate, \
          perfect, autotune, custom:<ef>, adaptive:<min>:<max>"
     ))
+}
+
+/// Returns `true` for settings that `\set` stores and displays but that have no
+/// channel into `Database::execute_query` today, so the REPL warns they are
+/// display-only rather than silently claiming they affect queries.
+///
+/// `mode`, `ef_search` and `max_results` ARE wired (injected into the query AST
+/// / applied as a LIMIT cap); `timeout_ms` and `rerank` are not.
+#[must_use]
+pub fn is_unwired_setting(key: &str) -> bool {
+    matches!(
+        key.to_lowercase().as_str(),
+        "timeout_ms" | "timeout" | "rerank"
+    )
 }
 
 fn parse_bool(value: &str) -> Result<bool, String> {


### PR DESCRIPTION
## Summary

Two CLI correctness/UX fixes in the `velesdb-cli` crate.

### #18 — CLI swallowed `$param` vector queries; bare MATCH couldn't pick a collection
- A `$param` vector query previously printed a yellow Note and returned `Ok(empty)`, so the REPL said "No results." and scripts exited **0**. It now returns `Err(...)` (helpful message preserved) → red error, **non-zero exit**.
- `velesdb query execute` hard-coded `active_collection = None`, so a bare MATCH hit the REPL-only "use a collection" error. Added an optional `--collection/-c` arg to `QueryCommands::Execute`, threaded through to execution (mirrors the REST `/query` collection field). Verified end-to-end: bare MATCH runs with `--collection`, errors without.

### #19 — CLI session settings were displayed but never applied
`\set` stored mode/ef_search/rerank/timeout_ms/max_results but only `active_collection` reached execution. Now `SessionSettings` is threaded into `execute_query` and:
- **ef_search / mode** are injected into the SELECT `WITH`-options **only when there's no inline override** (inline `WITH(ef_search=…)` wins), consumed by the existing `QuerySearchOptions::from_with_clause` core entry point — so they genuinely change execution.
- **max_results** caps the effective `LIMIT`.
- **timeout_ms / rerank** have no channel into `Database::execute_query` today, so `\set` now **warns** they're display-only instead of silently claiming success (no faking).
- Obsolete `#[allow(dead_code)]` removed from the now-wired accessors.

## Test plan
- Failing-test-first (proven fail-to-compile/fail on base, pass here): `test_param_vector_query_errors_instead_of_empty_ok`, `test_session_ef_search_injected_into_ast`, `test_inline_ef_search_wins_over_session`, `test_session_max_results_caps_limit`, `test_unwired_set_keys_are_flagged`, `test_query_execute_collection_flag`.
- Gates: `cargo fmt`; `clippy --all-targets … -D warnings -D clippy::pedantic` (exit 0); `lizard -C 8` (one pre-existing CCN-11 `SessionSettings::set` untouched, flagged); **`cargo test -p velesdb-cli` = 210 tests, 0 failed**; `cargo check --tests` clean.

CHANGELOG `[Unreleased]` updated.