### PR TITLE
fix(velesql): align WASM SELECT projection, ORDER BY, and single-NEAR FUSION with core (#3b/#8/#9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,6 +138,38 @@ release.
   parsed and silently degraded to a non-fused scan; these shapes are now
   rejected.
   *(Behavior change: previously-silent degraded queries now error.)*
+- **WASM `SELECT` now projects columns, aliases, and window functions.** A
+  plain/vector `SELECT` in the browser runtime always returned `id` + `score` +
+  the full payload, ignoring the projection list: `SELECT category` returned
+  every field, `SELECT title AS name` kept `title`, and
+  `ROW_NUMBER()/RANK() OVER (...)` columns were dropped entirely. The finalize
+  path now runs core's window evaluator before sorting and projects each row by
+  the parsed `SELECT` list (id-precedence, dotted-path lookup, alias handling,
+  similarity-score materialization), matching the REST surface.
+  *(Behavior change: WASM `SELECT` rows now carry only the requested columns.)*
+- **WASM `SELECT ORDER BY` arithmetic now sorts, and a LIMIT-less `SELECT`
+  defaults to 10 rows.** `ORDER BY (price - 2 * score)` (and other arithmetic /
+  score-variable expressions) used to map to a no-op `Equal` comparison, so rows
+  came back in scan order; they now evaluate the formula per row (mirroring
+  core's arithmetic semantics, division-by-zero → 0). `ORDER BY
+  similarity(field, $v)` against a named vector — which WASM does not store —
+  and aggregate `ORDER BY` outside aggregation are now **rejected loudly**
+  instead of silently no-op'ing (parity with the MATCH path). A `SELECT` with no
+  `LIMIT` now caps at `DEFAULT_SELECT_LIMIT` (10) like every other surface,
+  rather than returning every row.
+  *(Behavior change: WASM ORDER BY re-orders / errors, and unbounded SELECTs cap
+  at 10.)*
+- **WASM single-vector `NEAR` + `USING FUSION` no longer leaks filtered rows.**
+  A `vector NEAR $v AND <metadata> USING FUSION(...)` query fused the real vector
+  ranking against a synthetic constant-`1.0` payload branch and returned the
+  fused UNION, so rows failing the `WHERE` metadata predicate leaked into the
+  result (and `weighted`/`rsf` rankings were meaningless). The metadata predicate
+  is now applied as a **hard filter** (parity with core), so only matching rows
+  survive; `weighted` / `rsf` over a single-vector `NEAR` (which has no second
+  scored branch in WASM) are **rejected** with a clear error. `rrf` / `maximum`
+  / `average` keep ranking the (now hard-filtered) vector results.
+  *(Behavior change: WASM fused single-`NEAR` queries drop WHERE-failing rows;
+  weighted/rsf single-branch fusion errors.)*
 
 ## [3.2.1] — 2026-06-20
 

--- a/crates/velesdb-wasm/src/lib.rs
+++ b/crates/velesdb-wasm/src/lib.rs
@@ -90,6 +90,7 @@ mod velesql_logic;
 mod velesql_match;
 mod velesql_match_orderby;
 mod velesql_orderby;
+mod velesql_project;
 mod velesql_result;
 mod velesql_scan;
 mod velesql_select;
@@ -186,6 +187,10 @@ mod velesql_exec_join_tests;
 #[cfg(test)]
 #[path = "velesql_exec_hybrid_tests.rs"]
 mod velesql_exec_hybrid_tests;
+
+#[cfg(test)]
+#[path = "velesql_exec_behavior_tests.rs"]
+mod velesql_exec_behavior_tests;
 
 #[cfg(test)]
 #[path = "velesql_exec_graph_tests.rs"]

--- a/crates/velesdb-wasm/src/velesql_exec.rs
+++ b/crates/velesdb-wasm/src/velesql_exec.rs
@@ -18,7 +18,9 @@
 //! | `UNION [ALL] / INTERSECT / EXCEPT`          | full             |
 //! | `JOIN` (INNER, LEFT) + `ON ...=...`         | full             |
 //! | `WHERE similarity(v, $q) > t`               | full             |
-//! | `FUSION` (rrf, weighted, maximum)           | full             |
+//! | `FUSION` over `NEAR_FUSED` (rrf/max/avg)    | full             |
+//! | `FUSION` over single-vector `NEAR` (rrf)    | metadata = hard filter; clause is a no-op |
+//! | `FUSION` weighted / rsf over single `NEAR`  | **rejected** (no second scored branch) |
 //! | `INSERT / UPSERT INTO coll (…) VALUES`      | full             |
 //! | `UPDATE coll SET … WHERE …`                 | full             |
 //! | `DELETE FROM coll WHERE …`                  | full             |

--- a/crates/velesdb-wasm/src/velesql_exec_behavior_tests.rs
+++ b/crates/velesdb-wasm/src/velesql_exec_behavior_tests.rs
@@ -1,0 +1,175 @@
+//! Behavior-parity tests for the WASM VelesQL executor (backlog #3b/#8/#9).
+//!
+//! These pin WASM SELECT semantics to velesdb-core's single source of truth:
+//!
+//! - **#3b** — column projection, `AS` aliases, and window functions on plain /
+//!   vector SELECT (every SELECT previously returned the full payload).
+//! - **#8** — `ORDER BY` arithmetic / `similarity(field, $v)` (previously a
+//!   silent scan-order no-op) and the default `SELECT` LIMIT (previously
+//!   unbounded).
+//!
+//! The #9 single-branch FUSION regression lives in `velesql_exec_hybrid_tests`
+//! alongside the other FUSION coverage.
+
+use crate::database::DatabaseInner;
+use crate::velesql_exec::execute;
+
+/// Parses every row in a `QueryResult` into a JSON object vector.
+fn rows_as_objects(result: &crate::velesql_result::QueryResult) -> Vec<serde_json::Value> {
+    let json = result.rows_json();
+    serde_json::from_str(&json).expect("test: rows_json must be a JSON array")
+}
+
+fn db_with_docs() -> DatabaseInner {
+    let mut db = DatabaseInner::new();
+    db.create_metadata_collection("docs").expect("test: create");
+    execute(
+        &mut db,
+        "INSERT INTO docs (id, category, title) VALUES \
+         (1, 'tech', 'Alpha'), (2, 'food', 'Bravo'), (3, 'tech', 'Charlie')",
+        None,
+    )
+    .expect("test: seed docs");
+    db
+}
+
+fn db_with_vectors() -> DatabaseInner {
+    let mut db = DatabaseInner::new();
+    db.create_collection("vecs", 4, "cosine")
+        .expect("test: create");
+    for (id, v, price) in [
+        (1u64, "[1.0, 0.0, 0.0, 0.0]", 10.0),
+        (2, "[0.9, 0.1, 0.0, 0.0]", 5.0),
+        (3, "[0.0, 1.0, 0.0, 0.0]", 30.0),
+        (4, "[0.0, 0.0, 1.0, 0.0]", 1.0),
+    ] {
+        execute(
+            &mut db,
+            &format!(
+                "INSERT INTO vecs (id, vector, price, cat) VALUES ({id}, $v, {price}, 'tech')"
+            ),
+            Some(&format!("{{\"v\": {v}}}")),
+        )
+        .expect("test: seed");
+    }
+    db
+}
+
+// =========================================================================
+// #3b — projection / aliases / window functions
+// =========================================================================
+
+#[test]
+fn test_select_single_column_projects_only_that_column() {
+    let mut db = db_with_docs();
+    let r = execute(&mut db, "SELECT category FROM docs", None).expect("test: select");
+    let rows = rows_as_objects(&r);
+    assert_eq!(rows.len(), 3);
+    for row in &rows {
+        let obj = row.as_object().expect("test: object");
+        assert_eq!(
+            obj.keys().collect::<Vec<_>>(),
+            vec!["category"],
+            "row must contain ONLY the projected column, got {obj:?}"
+        );
+    }
+}
+
+#[test]
+fn test_select_alias_renames_column() {
+    let mut db = db_with_docs();
+    let r = execute(&mut db, "SELECT title AS name FROM docs", None).expect("test: select");
+    let rows = rows_as_objects(&r);
+    assert_eq!(rows.len(), 3);
+    for row in &rows {
+        let obj = row.as_object().expect("test: object");
+        assert!(obj.contains_key("name"), "alias `name` must be present");
+        assert!(
+            !obj.contains_key("title"),
+            "original `title` must be dropped"
+        );
+    }
+}
+
+#[test]
+fn test_select_window_function_includes_rank_column() {
+    let mut db = db_with_vectors();
+    let r = execute(
+        &mut db,
+        "SELECT cat, ROW_NUMBER() OVER (ORDER BY price) AS rn FROM vecs",
+        None,
+    )
+    .expect("test: window");
+    let rows = rows_as_objects(&r);
+    assert_eq!(rows.len(), 4);
+    for row in &rows {
+        let obj = row.as_object().expect("test: object");
+        assert!(obj.contains_key("rn"), "window alias `rn` must be present");
+    }
+    // The smallest price (id=4, price=1.0) must rank 1.
+    let ranks: Vec<u64> = rows
+        .iter()
+        .map(|r| r["rn"].as_u64().expect("test: rn u64"))
+        .collect();
+    assert!(ranks.contains(&1) && ranks.contains(&4));
+}
+
+// =========================================================================
+// #8 — ORDER BY arithmetic / similarity + default LIMIT
+// =========================================================================
+
+#[test]
+fn test_select_without_limit_caps_at_default() {
+    let mut db = DatabaseInner::new();
+    db.create_metadata_collection("big").expect("test: create");
+    for i in 1u64..=25 {
+        execute(
+            &mut db,
+            &format!("INSERT INTO big (id, n) VALUES ({i}, {i})"),
+            None,
+        )
+        .expect("test: seed");
+    }
+    let r = execute(&mut db, "SELECT * FROM big", None).expect("test: select");
+    assert_eq!(
+        r.row_count(),
+        10,
+        "a LIMIT-less SELECT must cap at DEFAULT_SELECT_LIMIT (10), not return all 25"
+    );
+}
+
+#[test]
+fn test_order_by_arithmetic_sorts_by_formula() {
+    let mut db = db_with_vectors();
+    // price - 2*score ASC. With $q=[1,0,0,0]: score≈[1,2:0.994,3:0,4:0].
+    // key = price - 2*score:
+    //   id1: 10 - 2.0   = 8.0
+    //   id2: 5  - 1.989 = 3.011
+    //   id3: 30 - 0     = 30
+    //   id4: 1  - 0     = 1
+    // ASC order: id4 (1) < id2 (3.011) < id1 (8) < id3 (30)
+    let r = execute(
+        &mut db,
+        "SELECT * FROM vecs WHERE vector NEAR $q ORDER BY (price - 2 * score) ASC",
+        Some(r#"{"q": [1.0, 0.0, 0.0, 0.0]}"#),
+    )
+    .expect("test: arithmetic order");
+    let ids: Vec<u64> = (0..r.row_count() as usize)
+        .map(|i| r.row(i).expect("test: row").id())
+        .collect();
+    assert_eq!(ids, vec![4, 2, 1, 3], "rows must be in the formula order");
+}
+
+#[test]
+fn test_order_by_similarity_named_field_rejected_loudly() {
+    // WASM has no named/secondary vectors. `ORDER BY similarity(image_vec, $q)`
+    // cannot be evaluated and must reject loudly (parity with the MATCH path),
+    // never silently return scan order.
+    let mut db = db_with_vectors();
+    let err = execute(
+        &mut db,
+        "SELECT * FROM vecs WHERE vector NEAR $q ORDER BY similarity(image_vec, $q) DESC",
+        Some(r#"{"q": [1.0, 0.0, 0.0, 0.0]}"#),
+    );
+    assert!(err.is_err(), "named-vector similarity ORDER BY must error");
+}

--- a/crates/velesdb-wasm/src/velesql_exec_hybrid_tests.rs
+++ b/crates/velesdb-wasm/src/velesql_exec_hybrid_tests.rs
@@ -65,7 +65,7 @@ fn test_similarity_combined_with_payload_filter() {
 // =========================================================================
 
 #[test]
-fn test_fusion_rrf_returns_ranked_results() {
+fn test_fusion_rrf_applies_metadata_as_hard_filter() {
     let mut db = db_with_vectors();
     let r = execute(
         &mut db,
@@ -73,17 +73,53 @@ fn test_fusion_rrf_returns_ranked_results() {
         Some(r#"{"q": [1.0, 0.0, 0.0, 0.0]}"#),
     )
     .expect("test: rrf fusion");
-    // RRF fuses the union of the NEAR branch (all ids) and the cat='a' payload branch.
+    // #9(b): a single-vector NEAR has no real second scored branch, so the
+    // metadata predicate `cat='a'` is a HARD filter (parity with core), not a
+    // soft fusion branch. Only cat='a' rows survive; the previous UNION-leak
+    // (4 rows) is gone.
     assert_eq!(
         r.row_count(),
-        4,
-        "RRF fuses the union of the NEAR branch (all ids) and the cat='a' payload branch"
+        2,
+        "metadata predicate is a hard filter under single-vector NEAR fusion"
     );
     let ids: Vec<u64> = (0..r.row_count() as usize)
         .map(|i| r.row(i).expect("test: row").id())
         .collect();
-    for id in [1u64, 2, 3, 4] {
-        assert!(ids.contains(&id), "fused result must contain id {id}");
+    assert!(ids.contains(&1) && ids.contains(&2));
+    assert!(!ids.contains(&3) && !ids.contains(&4));
+}
+
+#[test]
+fn test_weighted_fusion_single_branch_does_not_leak_filtered_rows() {
+    // #9: `vector NEAR $v AND cat='tech' USING FUSION(weighted)` over a
+    // single-vector NEAR has no real second scored branch. The result must
+    // contain ONLY cat='tech' rows (no WHERE-failing leak) and never extra
+    // rows polluted by a constant-1.0 fusion branch — or error loudly.
+    let mut db = db_with_vectors();
+    let result = execute(
+        &mut db,
+        "SELECT * FROM vecs WHERE vector NEAR $q AND cat = 'a' LIMIT 10 \
+         USING FUSION (strategy = 'weighted', vector_weight = 0.7, graph_weight = 0.3)",
+        Some(r#"{"q": [1.0, 0.0, 0.0, 0.0]}"#),
+    );
+    match result {
+        Ok(r) => {
+            let ids: Vec<u64> = (0..r.row_count() as usize)
+                .map(|i| r.row(i).expect("test: row").id())
+                .collect();
+            assert!(
+                ids.iter().all(|id| *id == 1 || *id == 2),
+                "only cat='a' rows (1, 2) may appear, got {ids:?}"
+            );
+            assert!(
+                !ids.contains(&3) && !ids.contains(&4),
+                "cat='b' rows must not leak through fusion"
+            );
+        }
+        Err(msg) => assert!(
+            msg.to_lowercase().contains("fusion"),
+            "rejection must name fusion, got: {msg}"
+        ),
     }
 }
 

--- a/crates/velesdb-wasm/src/velesql_orderby.rs
+++ b/crates/velesdb-wasm/src/velesql_orderby.rs
@@ -1,72 +1,102 @@
-//! ORDER BY expansion for the WASM VelesQL executor (S4-13).
+//! ORDER BY execution for the WASM VelesQL executor (S4-13, #8).
 //!
 //! Supports ordering on any payload column (not just `id` / `score`),
-//! multi-key sort, ASC/DESC per key, and explicit null handling:
-//! nulls sort last in ASC and first in DESC (matches Postgres default).
+//! multi-key sort, ASC/DESC per key, explicit null handling (nulls sort last
+//! in ASC and first in DESC, matching Postgres default), and arithmetic
+//! expressions over the per-row score + payload.
 //!
-//! The row set passed in is a list of `(sort_keys, final_row)` pairs built
-//! by the caller (`velesql_select`), so this module is pure sorting and
-//! does not touch the row-building logic.
+//! Sorting operates on core [`SearchResult`] values so the same rows can be
+//! projected through velesdb-core's projection engine afterwards (#3b). The
+//! arithmetic evaluator mirrors core's `ordering::evaluate_arithmetic`: score
+//! variables resolve to the row's search score, payload variables to their
+//! numeric value (0.0 when missing/non-numeric), and division by zero yields
+//! 0.0.
+//!
+//! Genuinely unevaluable forms — `similarity(field, $v)` against a named
+//! vector, which WASM does not store, and aggregate ORDER BY outside an
+//! aggregation pipeline — are **rejected loudly** rather than silently
+//! degrading to scan order, matching the MATCH path (#8a).
 
 use std::cmp::Ordering;
 
-use velesdb_core::velesql::{OrderByExpr, SelectOrderBy, SelectStatement};
+use velesdb_core::point::SearchResult;
+use velesdb_core::velesql::{
+    ArithmeticExpr, ArithmeticOp, OrderByExpr, SelectOrderBy, SelectStatement,
+};
 
-use crate::velesql_result::QueryResultRow;
 use crate::velesql_value::json_values_cmp;
 
-/// A row bundled with the JSON values used to compute its ORDER BY keys.
-///
-/// The outer code builds one `SortableRow` per result row; this module only
-/// sorts them according to the ORDER BY spec.
-pub(crate) struct SortableRow {
-    /// Point id — used for `ORDER BY id`.
-    pub id: u64,
-    /// Similarity / relevance score — used for `ORDER BY similarity()` /
-    /// `ORDER BY score`.
-    pub score: f32,
-    /// Payload — used for arbitrary column sorts.
-    pub payload: Option<serde_json::Value>,
-    /// The serialized row to return to the caller after sorting.
-    pub row: QueryResultRow,
-}
+/// Maximum recursion depth for arithmetic evaluation (mirrors core's
+/// `MAX_ARITHMETIC_DEPTH`).
+const MAX_ARITHMETIC_DEPTH: u8 = 64;
 
-/// Sorts a row set in place according to the SELECT's ORDER BY clause.
+/// Sorts a result set in place according to the SELECT's ORDER BY clause.
 ///
-/// Does nothing when the statement has no ORDER BY. Invalid expressions
-/// (e.g. aggregate / arithmetic / similarity with explicit args) fall back
-/// to stable no-op sort so the executor never fails silently on shape.
-pub(crate) fn sort_rows(stmt: &SelectStatement, rows: &mut [SortableRow]) {
+/// Returns `Err` for ORDER BY shapes WASM cannot evaluate (named-vector
+/// `similarity(field, $v)` or aggregate expressions outside aggregation), so
+/// the executor fails loud instead of returning scan order (#8a).
+pub(crate) fn sort_rows(stmt: &SelectStatement, rows: &mut [SearchResult]) -> Result<(), String> {
     let Some(specs) = stmt.order_by.as_ref() else {
-        return;
+        return Ok(());
     };
     if specs.is_empty() {
-        return;
+        return Ok(());
     }
+    validate_order_by(specs)?;
     rows.sort_by(|a, b| compare_rows(a, b, specs));
+    Ok(())
+}
+
+/// Rejects ORDER BY expressions WASM cannot evaluate before sorting begins.
+fn validate_order_by(specs: &[SelectOrderBy]) -> Result<(), String> {
+    for spec in specs {
+        match &spec.expr {
+            OrderByExpr::Similarity(_) => {
+                return Err(
+                    "ORDER BY similarity(field, $vec) is not supported in WASM: named/secondary \
+                     vectors are not stored. Use ORDER BY similarity() (the search score) or a \
+                     payload column."
+                        .to_string(),
+                );
+            }
+            OrderByExpr::Aggregate(_) => {
+                return Err(
+                    "ORDER BY aggregate is only valid in an aggregation (GROUP BY) query"
+                        .to_string(),
+                );
+            }
+            OrderByExpr::Field(_) | OrderByExpr::SimilarityBare | OrderByExpr::Arithmetic(_) => {}
+            // `OrderByExpr` is non_exhaustive: any future variant is unproven
+            // on the WASM surface, so reject rather than silently no-op.
+            _ => return Err("ORDER BY expression is not supported in WASM".to_string()),
+        }
+    }
+    Ok(())
 }
 
 /// Strict total order used by `sort_by` over a multi-key ORDER BY.
-fn compare_rows(a: &SortableRow, b: &SortableRow, specs: &[SelectOrderBy]) -> Ordering {
+fn compare_rows(a: &SearchResult, b: &SearchResult, specs: &[SelectOrderBy]) -> Ordering {
     for spec in specs {
         let ord = compare_with_spec(a, b, spec);
         if ord != Ordering::Equal {
             return ord;
         }
     }
-    Ordering::Equal
+    // Deterministic tie-break by ascending id, matching core's ORDER BY.
+    a.point.id.cmp(&b.point.id)
 }
 
-fn compare_with_spec(a: &SortableRow, b: &SortableRow, spec: &SelectOrderBy) -> Ordering {
+fn compare_with_spec(a: &SearchResult, b: &SearchResult, spec: &SelectOrderBy) -> Ordering {
     let ord = match &spec.expr {
         OrderByExpr::Field(name) => compare_field(a, b, name),
         OrderByExpr::SimilarityBare => compare_scores(a, b),
-        OrderByExpr::Similarity(_) | OrderByExpr::Aggregate(_) | OrderByExpr::Arithmetic(_) => {
-            // These expressions aren't materialized in WASM — treat them as
-            // equal so the comparison degrades to a stable no-op rather than
-            // producing a misleading order.
-            Ordering::Equal
+        OrderByExpr::Arithmetic(expr) => {
+            let va = eval_arithmetic(expr, a);
+            let vb = eval_arithmetic(expr, b);
+            compare_f32(va, vb)
         }
+        // Similarity / Aggregate were rejected by `validate_order_by`; treat
+        // as equal defensively (the non_exhaustive enum may add variants).
         _ => Ordering::Equal,
     };
     if spec.descending {
@@ -77,41 +107,116 @@ fn compare_with_spec(a: &SortableRow, b: &SortableRow, spec: &SelectOrderBy) -> 
 }
 
 /// Compares a pair of rows by the given column. `id` and `score` are
-/// resolved from their dedicated struct fields.
-fn compare_field(a: &SortableRow, b: &SortableRow, name: &str) -> Ordering {
+/// resolved from their dedicated fields; everything else from the payload.
+fn compare_field(a: &SearchResult, b: &SearchResult, name: &str) -> Ordering {
     if name == "id" {
-        return a.id.cmp(&b.id);
+        return a.point.id.cmp(&b.point.id);
     }
     if name == "score" {
         return compare_scores(a, b);
     }
-    let va = extract_payload_field(a.payload.as_ref(), name);
-    let vb = extract_payload_field(b.payload.as_ref(), name);
+    let va = extract_payload_field(a, name);
+    let vb = extract_payload_field(b, name);
     compare_json_with_nulls(va.as_ref(), vb.as_ref())
 }
 
-/// Compares two f32 scores (NaN-safe, NaN sorts last in ASC).
-fn compare_scores(a: &SortableRow, b: &SortableRow) -> Ordering {
-    match (a.score.is_nan(), b.score.is_nan()) {
+/// Compares two rows by search score (NaN-safe, NaN sorts last in ASC).
+fn compare_scores(a: &SearchResult, b: &SearchResult) -> Ordering {
+    compare_f32(a.score, b.score)
+}
+
+/// NaN-safe f32 comparison (NaN sorts last in ASC).
+fn compare_f32(a: f32, b: f32) -> Ordering {
+    match (a.is_nan(), b.is_nan()) {
         (true, true) => Ordering::Equal,
-        (true, false) => Ordering::Greater, // NaN last
+        (true, false) => Ordering::Greater,
         (false, true) => Ordering::Less,
-        (false, false) => a.score.partial_cmp(&b.score).unwrap_or(Ordering::Equal),
+        (false, false) => a.partial_cmp(&b).unwrap_or(Ordering::Equal),
     }
 }
 
-/// Pulls a column from the payload (supports dot-nested paths via filter).
-fn extract_payload_field(
-    payload: Option<&serde_json::Value>,
-    column: &str,
-) -> Option<serde_json::Value> {
-    payload.and_then(|p| crate::filter::get_nested_field(p, column).cloned())
+/// Pulls a column from the payload (supports dot-nested paths).
+fn extract_payload_field(result: &SearchResult, column: &str) -> Option<serde_json::Value> {
+    result
+        .point
+        .payload
+        .as_ref()
+        .and_then(|p| crate::filter::get_nested_field(p, column).cloned())
+}
+
+/// Evaluates an arithmetic ORDER BY expression for a single row, mirroring
+/// core's `ordering::evaluate_arithmetic` semantics.
+fn eval_arithmetic(expr: &ArithmeticExpr, result: &SearchResult) -> f32 {
+    eval_arithmetic_inner(expr, result, 0)
+}
+
+fn eval_arithmetic_inner(expr: &ArithmeticExpr, result: &SearchResult, depth: u8) -> f32 {
+    if depth >= MAX_ARITHMETIC_DEPTH {
+        return 0.0;
+    }
+    match expr {
+        #[allow(clippy::cast_possible_truncation)]
+        ArithmeticExpr::Literal(v) => *v as f32,
+        ArithmeticExpr::Variable(name) => resolve_variable(name, result),
+        // Only bare similarity() reaches arithmetic (validation rejects the
+        // named form); it resolves to the row search score.
+        ArithmeticExpr::Similarity(_) => result.score,
+        ArithmeticExpr::BinaryOp { left, op, right } => {
+            let l = eval_arithmetic_inner(left, result, depth + 1);
+            let r = eval_arithmetic_inner(right, result, depth + 1);
+            apply_op(*op, l, r)
+        }
+        // `ArithmeticExpr` is non_exhaustive; an unknown future variant has no
+        // defined WASM semantics, so contribute a neutral 0.0 to the sort key.
+        _ => 0.0,
+    }
+}
+
+/// Applies a binary arithmetic operator; division by zero yields 0.0.
+fn apply_op(op: ArithmeticOp, l: f32, r: f32) -> f32 {
+    match op {
+        ArithmeticOp::Add => l + r,
+        ArithmeticOp::Sub => l - r,
+        ArithmeticOp::Mul => l * r,
+        ArithmeticOp::Div => {
+            if r == 0.0 {
+                0.0
+            } else {
+                l / r
+            }
+        }
+        // `ArithmeticOp` is non_exhaustive; a future operator has no defined
+        // WASM semantics, so fall back to the left operand rather than guess.
+        _ => l,
+    }
+}
+
+/// Resolves a variable name to a numeric value for arithmetic ORDER BY.
+///
+/// Score built-ins (`score`, `similarity`, `vector_score`, …) resolve to the
+/// row search score — WASM scores only the primary vector, so absent
+/// component scores fall back to the search score (core's legacy/untagged
+/// path). Any other name is a payload field (0.0 when missing/non-numeric).
+fn resolve_variable(name: &str, result: &SearchResult) -> f32 {
+    match name {
+        "score" | "similarity" | "fused_score" | "vector_score" | "graph_score" | "bm25_score"
+        | "sparse_score" => result.score,
+        _ => extract_payload_field(result, name)
+            .as_ref()
+            .and_then(serde_json::Value::as_f64)
+            .map_or(0.0, |v| {
+                #[allow(clippy::cast_possible_truncation)]
+                {
+                    v as f32
+                }
+            }),
+    }
 }
 
 /// Postgres-style NULL ordering: null sorts AFTER non-null in ASC. Since we
-/// always compute ASC first and then reverse for DESC via the outer
-/// `compare_with_spec`, producing "null > non-null" here gives the correct
-/// "NULLS LAST in ASC" / "NULLS FIRST in DESC" behaviour.
+/// always compute ASC first and reverse for DESC via `compare_with_spec`,
+/// producing "null > non-null" here gives "NULLS LAST in ASC" / "NULLS FIRST
+/// in DESC".
 ///
 /// Shared with the MATCH `ORDER BY` path (`velesql_match_orderby`) so node and
 /// row ordering apply identical NULL semantics.
@@ -135,15 +240,11 @@ pub(crate) fn compare_json_with_nulls(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use velesdb_core::velesql::{OrderByExpr, SelectOrderBy};
+    use velesdb_core::point::Point;
+    use velesdb_core::velesql::{ArithmeticExpr, ArithmeticOp, OrderByExpr, SelectOrderBy};
 
-    fn mk(id: u64, score: f32, payload: serde_json::Value) -> SortableRow {
-        SortableRow {
-            id,
-            score,
-            payload: Some(payload),
-            row: QueryResultRow::synthetic(serde_json::json!({"id": id})).expect("test: row"),
-        }
+    fn mk(id: u64, score: f32, payload: serde_json::Value) -> SearchResult {
+        SearchResult::new(Point::new(id, Vec::new(), Some(payload)), score)
     }
 
     fn by_field(name: &str, desc: bool) -> Vec<SelectOrderBy> {
@@ -153,6 +254,12 @@ mod tests {
         }]
     }
 
+    fn sort(stmt_order: Vec<SelectOrderBy>, rows: &mut [SearchResult]) {
+        let mut stmt = SelectStatement::empty();
+        stmt.order_by = Some(stmt_order);
+        sort_rows(&stmt, rows).expect("test: sort");
+    }
+
     #[test]
     fn test_sort_by_id_asc() {
         let mut rows = vec![
@@ -160,40 +267,21 @@ mod tests {
             mk(1, 0.0, serde_json::json!({})),
             mk(2, 0.0, serde_json::json!({})),
         ];
-        let mut stmt = velesdb_core::velesql::SelectStatement::empty();
-        stmt.order_by = Some(by_field("id", false));
-        sort_rows(&stmt, &mut rows);
-        assert_eq!(rows[0].id, 1);
-        assert_eq!(rows[2].id, 3);
+        sort(by_field("id", false), &mut rows);
+        assert_eq!(rows[0].point.id, 1);
+        assert_eq!(rows[2].point.id, 3);
     }
 
     #[test]
-    fn test_sort_by_id_desc() {
-        let mut rows = vec![
-            mk(3, 0.0, serde_json::json!({})),
-            mk(1, 0.0, serde_json::json!({})),
-            mk(2, 0.0, serde_json::json!({})),
-        ];
-        let mut stmt = velesdb_core::velesql::SelectStatement::empty();
-        stmt.order_by = Some(by_field("id", true));
-        sort_rows(&stmt, &mut rows);
-        assert_eq!(rows[0].id, 3);
-        assert_eq!(rows[2].id, 1);
-    }
-
-    #[test]
-    fn test_sort_by_payload_column() {
+    fn test_sort_by_payload_column_desc() {
         let mut rows = vec![
             mk(1, 0.0, serde_json::json!({"price": 20})),
             mk(2, 0.0, serde_json::json!({"price": 10})),
             mk(3, 0.0, serde_json::json!({"price": 30})),
         ];
-        let mut stmt = velesdb_core::velesql::SelectStatement::empty();
-        stmt.order_by = Some(by_field("price", false));
-        sort_rows(&stmt, &mut rows);
-        assert_eq!(rows[0].id, 2);
-        assert_eq!(rows[1].id, 1);
-        assert_eq!(rows[2].id, 3);
+        sort(by_field("price", true), &mut rows);
+        assert_eq!(rows[0].point.id, 3);
+        assert_eq!(rows[2].point.id, 2);
     }
 
     #[test]
@@ -203,50 +291,9 @@ mod tests {
             mk(2, 0.0, serde_json::json!({})),
             mk(3, 0.0, serde_json::json!({"x": 1})),
         ];
-        let mut stmt = velesdb_core::velesql::SelectStatement::empty();
-        stmt.order_by = Some(by_field("x", false));
-        sort_rows(&stmt, &mut rows);
-        assert_eq!(rows[0].id, 3); // x=1
-        assert_eq!(rows[1].id, 1); // x=5
-        assert_eq!(rows[2].id, 2); // null last
-    }
-
-    #[test]
-    fn test_sort_nulls_first_desc() {
-        let mut rows = vec![
-            mk(1, 0.0, serde_json::json!({"x": 5})),
-            mk(2, 0.0, serde_json::json!({})),
-            mk(3, 0.0, serde_json::json!({"x": 1})),
-        ];
-        let mut stmt = velesdb_core::velesql::SelectStatement::empty();
-        stmt.order_by = Some(by_field("x", true));
-        sort_rows(&stmt, &mut rows);
-        assert_eq!(rows[0].id, 2); // null first in DESC
-    }
-
-    #[test]
-    fn test_sort_multi_key() {
-        let mut rows = vec![
-            mk(1, 0.0, serde_json::json!({"cat": "a", "p": 10})),
-            mk(2, 0.0, serde_json::json!({"cat": "a", "p": 5})),
-            mk(3, 0.0, serde_json::json!({"cat": "b", "p": 1})),
-        ];
-        let mut stmt = velesdb_core::velesql::SelectStatement::empty();
-        stmt.order_by = Some(vec![
-            SelectOrderBy {
-                expr: OrderByExpr::Field("cat".to_string()),
-                descending: false,
-            },
-            SelectOrderBy {
-                expr: OrderByExpr::Field("p".to_string()),
-                descending: true,
-            },
-        ]);
-        sort_rows(&stmt, &mut rows);
-        // cat=a first, then p DESC: (a, 10) < (a, 5) < (b, 1)
-        assert_eq!(rows[0].id, 1);
-        assert_eq!(rows[1].id, 2);
-        assert_eq!(rows[2].id, 3);
+        sort(by_field("x", false), &mut rows);
+        assert_eq!(rows[0].point.id, 3);
+        assert_eq!(rows[2].point.id, 2);
     }
 
     #[test]
@@ -256,13 +303,64 @@ mod tests {
             mk(2, 0.9, serde_json::json!({})),
             mk(3, 0.5, serde_json::json!({})),
         ];
-        let mut stmt = velesdb_core::velesql::SelectStatement::empty();
+        sort(
+            vec![SelectOrderBy {
+                expr: OrderByExpr::SimilarityBare,
+                descending: true,
+            }],
+            &mut rows,
+        );
+        assert_eq!(rows[0].point.id, 2);
+        assert_eq!(rows[2].point.id, 1);
+    }
+
+    #[test]
+    fn test_sort_by_arithmetic_formula() {
+        // ORDER BY (price - 2*score) ASC.
+        let expr = ArithmeticExpr::BinaryOp {
+            left: Box::new(ArithmeticExpr::Variable("price".to_string())),
+            op: ArithmeticOp::Sub,
+            right: Box::new(ArithmeticExpr::BinaryOp {
+                left: Box::new(ArithmeticExpr::Literal(2.0)),
+                op: ArithmeticOp::Mul,
+                right: Box::new(ArithmeticExpr::Variable("score".to_string())),
+            }),
+        };
+        let mut rows = vec![
+            mk(1, 1.0, serde_json::json!({"price": 10})), // 10 - 2 = 8
+            mk(2, 0.0, serde_json::json!({"price": 1})),  // 1
+            mk(3, 0.0, serde_json::json!({"price": 30})), // 30
+        ];
+        sort(
+            vec![SelectOrderBy {
+                expr: OrderByExpr::Arithmetic(expr),
+                descending: false,
+            }],
+            &mut rows,
+        );
+        assert_eq!(rows[0].point.id, 2); // 1
+        assert_eq!(rows[1].point.id, 1); // 8
+        assert_eq!(rows[2].point.id, 3); // 30
+    }
+
+    #[test]
+    fn test_sort_named_similarity_is_rejected() {
+        use velesdb_core::velesql::{SimilarityOrderBy, VectorExpr};
+        let mut rows = vec![mk(1, 0.5, serde_json::json!({}))];
+        let mut stmt = SelectStatement::empty();
         stmt.order_by = Some(vec![SelectOrderBy {
-            expr: OrderByExpr::SimilarityBare,
+            expr: OrderByExpr::Similarity(SimilarityOrderBy {
+                field: "image_vec".to_string(),
+                vector: VectorExpr::Parameter("q".to_string()),
+            }),
             descending: true,
         }]);
-        sort_rows(&stmt, &mut rows);
-        assert_eq!(rows[0].id, 2);
-        assert_eq!(rows[2].id, 1);
+        let err = sort_rows(&stmt, &mut rows);
+        assert!(err.is_err());
+    }
+
+    #[test]
+    fn test_division_by_zero_yields_zero() {
+        assert_eq!(apply_op(ArithmeticOp::Div, 5.0, 0.0), 0.0);
     }
 }

--- a/crates/velesdb-wasm/src/velesql_project.rs
+++ b/crates/velesdb-wasm/src/velesql_project.rs
@@ -1,0 +1,261 @@
+//! Column projection + window-function bridge for the WASM SELECT pipeline (#3b).
+//!
+//! Mirrors velesdb-core's projection engine so `SELECT col`, `SELECT col AS
+//! alias`, `SELECT *`, and window functions behave identically to the REST
+//! surface — instead of always emitting `id + score + full payload`:
+//!
+//! - [`to_search_results`] adapts the WASM `OwnedScanRow` triples into core
+//!   [`SearchResult`] values (the type the window evaluator and the projection
+//!   logic consume).
+//! - [`inject_window_functions`] runs core's
+//!   [`velesdb_core::velesql::window_evaluator::evaluate`], which injects each
+//!   window alias (`ROW_NUMBER`/`RANK`/`DENSE_RANK`) into the row payload
+//!   **before** ORDER BY/projection, matching the core pipeline position.
+//! - [`project`] reproduces `projection::project_single`'s column extraction.
+//!   That function lives in `velesdb_core::collection`, which is gated behind
+//!   the `persistence` feature WASM never enables, so it cannot be called
+//!   directly; this module mirrors its semantics field-for-field to keep the
+//!   output identical (`id`-precedence, dotted-path lookup, alias handling,
+//!   similarity-score materialization, window-alias dedup).
+
+use velesdb_core::point::{Point, SearchResult};
+use velesdb_core::velesql::{
+    Column, SelectColumns, SelectStatement, SimilarityScoreExpr, WindowFunction,
+};
+
+use crate::velesql_result::QueryResultRow;
+use crate::velesql_scan::OwnedScanRow;
+
+type JsonMap = serde_json::Map<String, serde_json::Value>;
+
+/// Adapts scanned `(id, score, payload)` triples into core [`SearchResult`]s.
+///
+/// The vector is left empty: the WASM finalize path has already scored every
+/// row, and neither projection nor window evaluation reads `point.vector`.
+pub(crate) fn to_search_results(rows: Vec<OwnedScanRow>) -> Vec<SearchResult> {
+    rows.into_iter()
+        .map(|(id, score, payload)| SearchResult::new(Point::new(id, Vec::new(), payload), score))
+        .collect()
+}
+
+/// Runs core window evaluation, injecting window-function aliases into each
+/// row payload before ORDER BY / projection. No-op when the SELECT has none.
+pub(crate) fn inject_window_functions(
+    stmt: &SelectStatement,
+    results: &mut [SearchResult],
+) -> Result<(), String> {
+    let Some(window_functions) = extract_window_functions(&stmt.columns) else {
+        return Ok(());
+    };
+    velesdb_core::velesql::window_evaluator::evaluate(results, window_functions)
+        .map_err(|e| format!("Window function evaluation failed: {e}"))
+}
+
+/// Returns the window functions in a `SELECT` list, if any (mirrors core's
+/// `Collection::extract_window_functions`).
+fn extract_window_functions(columns: &SelectColumns) -> Option<&[WindowFunction]> {
+    match columns {
+        SelectColumns::Mixed {
+            window_functions, ..
+        } if !window_functions.is_empty() => Some(window_functions),
+        _ => None,
+    }
+}
+
+/// Projects each result by the SELECT column list, preserving the real `id` /
+/// `score` for the JS getters.
+pub(crate) fn project(
+    stmt: &SelectStatement,
+    results: &[SearchResult],
+) -> Result<Vec<QueryResultRow>, String> {
+    results
+        .iter()
+        .map(|result| {
+            let row = project_single(result, &stmt.columns);
+            QueryResultRow::from_projected(result.point.id, result.score, &row)
+        })
+        .collect()
+}
+
+/// Projects one result into a JSON row — mirror of `projection::project_single`.
+fn project_single(result: &SearchResult, columns: &SelectColumns) -> serde_json::Value {
+    match columns {
+        SelectColumns::All | SelectColumns::QualifiedWildcard(_) => project_wildcard(result),
+        SelectColumns::Columns(cols) => project_columns(result, cols),
+        SelectColumns::SimilarityScore(expr) => project_similarity_only(result, expr),
+        // Aggregations are handled by the aggregation pipeline, not here.
+        SelectColumns::Aggregations(_) => serde_json::Value::Object(JsonMap::new()),
+        SelectColumns::Mixed {
+            columns,
+            similarity_scores,
+            qualified_wildcards,
+            window_functions,
+            ..
+        } => project_mixed(
+            result,
+            columns,
+            similarity_scores,
+            qualified_wildcards,
+            window_functions,
+        ),
+        // `SelectColumns` is non_exhaustive; an unknown future variant falls
+        // back to the wildcard shape (id + payload) rather than dropping rows.
+        _ => project_wildcard(result),
+    }
+}
+
+/// `SELECT *` / `alias.*`: `{id, ...payload}` (excludes the score).
+fn project_wildcard(result: &SearchResult) -> serde_json::Value {
+    let mut map = JsonMap::new();
+    insert_wildcard_fields(&mut map, result, &[]);
+    serde_json::Value::Object(map)
+}
+
+/// `SELECT col1, col2 [AS alias]`: only the named fields.
+fn project_columns(result: &SearchResult, columns: &[Column]) -> serde_json::Value {
+    let mut map = JsonMap::new();
+    insert_named_columns(&mut map, result, columns);
+    serde_json::Value::Object(map)
+}
+
+/// `SELECT similarity() [AS alias]`: the score only.
+fn project_similarity_only(result: &SearchResult, expr: &SimilarityScoreExpr) -> serde_json::Value {
+    let mut map = JsonMap::new();
+    let key = expr.alias.as_deref().unwrap_or("similarity");
+    map.insert(key.to_string(), score_value(result));
+    serde_json::Value::Object(map)
+}
+
+/// Mixed projection: qualified wildcards + columns + similarity scores +
+/// window functions (window aliases were injected into the payload upstream).
+fn project_mixed(
+    result: &SearchResult,
+    columns: &[Column],
+    similarity_scores: &[SimilarityScoreExpr],
+    qualified_wildcards: &[String],
+    window_functions: &[WindowFunction],
+) -> serde_json::Value {
+    let mut map = JsonMap::new();
+    let window_aliases: Vec<&str> = window_functions.iter().map(window_alias).collect();
+    if !qualified_wildcards.is_empty() {
+        insert_wildcard_fields(&mut map, result, &window_aliases);
+    }
+    insert_named_columns(&mut map, result, columns);
+    for expr in similarity_scores {
+        let key = expr.alias.as_deref().unwrap_or("similarity");
+        map.insert(key.to_string(), score_value(result));
+    }
+    for wf in window_functions {
+        let alias = window_alias(wf);
+        let value = payload_field(result, alias).unwrap_or(serde_json::Value::Null);
+        map.insert(alias.to_string(), value);
+    }
+    serde_json::Value::Object(map)
+}
+
+/// Inserts `id` + every payload field, skipping any key shadowed by a
+/// window-function alias.
+fn insert_wildcard_fields(map: &mut JsonMap, result: &SearchResult, skip: &[&str]) {
+    map.insert("id".to_string(), serde_json::Value::from(result.point.id));
+    if let Some(serde_json::Value::Object(payload)) = result.point.payload.as_ref() {
+        for (k, v) in payload {
+            if k != "id" && !skip.contains(&k.as_str()) {
+                map.insert(k.clone(), v.clone());
+            }
+        }
+    }
+}
+
+/// Inserts each named column under its alias (or its own name).
+fn insert_named_columns(map: &mut JsonMap, result: &SearchResult, columns: &[Column]) {
+    for col in columns {
+        let key = col.alias.as_deref().unwrap_or(&col.name);
+        map.insert(key.to_string(), extract_field_value(result, &col.name));
+    }
+}
+
+/// Extracts a field value (supporting dotted paths); `id` takes precedence
+/// over any payload `id`.
+fn extract_field_value(result: &SearchResult, field_path: &str) -> serde_json::Value {
+    if field_path == "id" {
+        return serde_json::Value::from(result.point.id);
+    }
+    payload_field(result, field_path).unwrap_or(serde_json::Value::Null)
+}
+
+/// Looks up a (possibly dotted) payload field.
+fn payload_field(result: &SearchResult, path: &str) -> Option<serde_json::Value> {
+    let payload = result.point.payload.as_ref()?;
+    crate::filter::get_nested_field(payload, path).cloned()
+}
+
+/// The materialized search score as a JSON number.
+fn score_value(result: &SearchResult) -> serde_json::Value {
+    serde_json::Value::from(f64::from(result.score))
+}
+
+/// The output alias of a window function.
+fn window_alias(wf: &WindowFunction) -> &str {
+    wf.alias
+        .as_deref()
+        .unwrap_or_else(|| wf.function_type.default_alias())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rows() -> Vec<OwnedScanRow> {
+        vec![
+            (1, 0.9, Some(serde_json::json!({"cat": "a", "title": "X"}))),
+            (2, 0.5, Some(serde_json::json!({"cat": "b", "title": "Y"}))),
+        ]
+    }
+
+    #[test]
+    fn test_to_search_results_preserves_id_score_payload() {
+        let results = to_search_results(rows());
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0].point.id, 1);
+        assert!((results[0].score - 0.9).abs() < f32::EPSILON);
+        assert_eq!(results[1].point.payload.as_ref().unwrap()["cat"], "b");
+    }
+
+    #[test]
+    fn test_project_specific_columns_only() {
+        let mut stmt = SelectStatement::empty();
+        stmt.columns = SelectColumns::Columns(vec![velesdb_core::velesql::Column::new("cat")]);
+        let results = to_search_results(rows());
+        let out = project(&stmt, &results).expect("test: project");
+        let body: serde_json::Value =
+            serde_json::from_str(out[0].data_json_ref()).expect("test: json");
+        let obj = body.as_object().expect("test: obj");
+        assert_eq!(obj.keys().collect::<Vec<_>>(), vec!["cat"]);
+        // Real id/score are preserved on the row handle even though the body
+        // only carries the projected column.
+        assert_eq!(out[0].id(), 1);
+    }
+
+    #[test]
+    fn test_project_alias_renames() {
+        let mut stmt = SelectStatement::empty();
+        stmt.columns = SelectColumns::Columns(vec![velesdb_core::velesql::Column::with_alias(
+            "title", "name",
+        )]);
+        let results = to_search_results(rows());
+        let out = project(&stmt, &results).expect("test: project");
+        let body: serde_json::Value =
+            serde_json::from_str(out[0].data_json_ref()).expect("test: json");
+        assert!(body.get("name").is_some());
+        assert!(body.get("title").is_none());
+    }
+
+    #[test]
+    fn test_inject_window_functions_noop_without_window() {
+        let stmt = SelectStatement::empty();
+        let mut results = to_search_results(rows());
+        inject_window_functions(&stmt, &mut results).expect("test: noop");
+        // Payload untouched.
+        assert_eq!(results[0].point.payload.as_ref().unwrap()["cat"], "a");
+    }
+}

--- a/crates/velesdb-wasm/src/velesql_result.rs
+++ b/crates/velesdb-wasm/src/velesql_result.rs
@@ -85,10 +85,12 @@ impl QueryResultRow {
 }
 
 impl QueryResultRow {
-    /// Builds a row from the core primitives.
+    /// Builds a row by merging the full payload at top level.
     ///
-    /// Never leaks its arguments on the JS side — the JSON is formed inside
-    /// the constructor.
+    /// Superseded in production by [`from_projected`](Self::from_projected),
+    /// which emits exactly the SELECT columns (#3b); retained as a test-only
+    /// constructor for the set-operation and result-shape suites.
+    #[cfg(test)]
     pub(crate) fn build(
         id: u64,
         score: f32,
@@ -106,6 +108,29 @@ impl QueryResultRow {
         }
         let data_json = serde_json::to_string(&serde_json::Value::Object(map))
             .map_err(|e| format!("Failed to serialize row to JSON: {e}"))?;
+        Ok(Self {
+            id,
+            score,
+            data_json,
+        })
+    }
+
+    /// Builds a row from a core projection result, preserving the real `id`
+    /// and `score` for the JS getters while exposing only the projected
+    /// columns in `data_json`.
+    ///
+    /// Used by the plain-SELECT pipeline after
+    /// [`velesdb_core::collection::search::query::projection::project_results`]
+    /// has reduced the payload to exactly the requested columns (#3b). Unlike
+    /// [`build`](Self::build), this does NOT re-merge the full payload — the
+    /// projected object is the authoritative row body.
+    pub(crate) fn from_projected(
+        id: u64,
+        score: f32,
+        projected: &serde_json::Value,
+    ) -> Result<Self, String> {
+        let data_json = serde_json::to_string(projected)
+            .map_err(|e| format!("Failed to serialize projected row to JSON: {e}"))?;
         Ok(Self {
             id,
             score,

--- a/crates/velesdb-wasm/src/velesql_select.rs
+++ b/crates/velesdb-wasm/src/velesql_select.rs
@@ -23,7 +23,8 @@ use crate::database::DatabaseInner;
 use crate::vector_ops;
 use crate::velesql_aggregate;
 use crate::velesql_fusion;
-use crate::velesql_orderby::{self, SortableRow};
+use crate::velesql_orderby;
+use crate::velesql_project;
 use crate::velesql_result::QueryResultRow;
 use crate::velesql_scan::OwnedScanRow;
 use crate::velesql_similarity::{self, SimilarityEvaluator};
@@ -159,19 +160,6 @@ impl WhereFilters {
             params,
         )
     }
-
-    /// Returns `true` if this filter set has no `similarity()` predicate.
-    ///
-    /// Used by the fusion path to short-circuit `collect_vector_rows`'
-    /// post-filter: when fusion has already applied the residual WHERE
-    /// via `fusion_branch_from_residual` AND there is no similarity leaf
-    /// to re-evaluate, the post-filter is fully redundant and can be
-    /// skipped (Devin Review Finding Q). The non-fusion path must still
-    /// apply the post-filter — this accessor is only consulted under a
-    /// fusion-active branch.
-    fn has_no_similarity(&self) -> bool {
-        self.eval.is_none()
-    }
 }
 
 // --- Vector NEAR ---------------------------------------------------------
@@ -192,15 +180,11 @@ fn execute_vector_search(
     let residual_without_vector = strip_vector_search(stmt.where_clause.as_ref());
     let filters = WhereFilters::build(db, stmt, params, Some(residual_without_vector.clone()))?;
 
-    // Finding Q: when fusion is active AND the filter set has no
-    // similarity predicate to re-evaluate row-wise, the residual WHERE
-    // has already been applied by `fusion_branch_from_residual` — the
-    // post-filter in `collect_vector_rows` would duplicate that work.
-    // We skip it by passing `None` for the filter set in that case.
-    // The non-fusion path (and fusion + similarity) still applies
-    // `filters.passes()` so correctness is preserved.
-    let mut fusion_residual_already_applied = false;
+    // #9: a single-vector NEAR has no real second scored branch. Mirror core,
+    // where a `NEAR + metadata` query applies the metadata predicate as a HARD
+    // filter and the FUSION clause is structurally inapplicable.
     if let Some(clause) = &stmt.fusion_clause {
+        reject_single_branch_weighted_fusion(clause)?;
         scored = apply_fusion(
             &scored,
             clause,
@@ -208,13 +192,35 @@ fn execute_vector_search(
             filters.residual.as_ref(),
             params,
         )?;
-        fusion_residual_already_applied = filters.has_no_similarity();
     }
 
-    if fusion_residual_already_applied {
-        collect_vector_rows_unfiltered(&scored, &borrowed)
-    } else {
-        collect_vector_rows(&scored, &borrowed, &filters, params)
+    // #9(b): ALWAYS enforce the metadata residual as a final filter. The old
+    // `fusion_residual_already_applied` short-circuit returned the fused UNION
+    // verbatim, leaking rows that fail the WHERE predicate (the synthetic
+    // payload branch scored them 1.0). `collect_vector_rows` re-applies
+    // `filters.passes()`, so WHERE-failing rows are dropped — matching core's
+    // hard-filter semantics.
+    collect_vector_rows(&scored, &borrowed, &filters, params)
+}
+
+/// Rejects weight-sensitive fusion strategies (`weighted` / `rsf`) on a
+/// single-vector NEAR. WASM has no BM25/graph branch to fuse against, so these
+/// strategies would otherwise fuse the real vector ranking against a synthetic
+/// constant-1.0 branch — meaningless rankings. `rrf` / `maximum` / `average`
+/// preserve the vector order under a constant second branch and are left as a
+/// (now hard-filtered) no-op for demo parity (#9a).
+fn reject_single_branch_weighted_fusion(
+    clause: &velesdb_core::velesql::FusionClause,
+) -> Result<(), String> {
+    use velesdb_core::velesql::FusionStrategyType;
+    match clause.strategy {
+        FusionStrategyType::Weighted | FusionStrategyType::Rsf => Err(
+            "USING FUSION(strategy='weighted'|'rsf') requires two scored branches; a \
+             single-vector NEAR has none in WASM (no BM25/graph scoring). Use a \
+             metadata filter without FUSION, or 'rrf'."
+                .to_string(),
+        ),
+        _ => Ok(()),
     }
 }
 
@@ -401,37 +407,49 @@ fn finalize_aggregated(
         .map(|(id, score, p)| (*id, *score, p.as_ref()))
         .collect();
     let out = velesql_aggregate::apply(stmt, &scanned, params)?;
-    Ok(apply_limit_offset(stmt, out))
+    // Aggregation output is not row-capped by core: a LIMIT-less GROUP BY
+    // returns every group. Pass `u64::MAX` so the default-10 SELECT cap
+    // never silently truncates group rows.
+    Ok(apply_limit_offset(stmt, out, u64::MAX))
 }
 
+/// Finalizes a non-aggregated SELECT: window functions, ORDER BY, column
+/// projection (including `AS` aliases), then OFFSET/LIMIT.
+///
+/// Routed through velesdb-core's single source of truth — `window_evaluator`
+/// injects window aliases into the payload, `velesql_orderby::sort_rows`
+/// evaluates arithmetic / rejects unevaluable ORDER BY forms, and
+/// `projection::project_results` materializes exactly the SELECT columns. This
+/// replaced the old path that always emitted `id + score + full payload`,
+/// dropping projection, aliases, and window functions (#3b).
 fn finalize_plain(
     stmt: &SelectStatement,
     rows: Vec<OwnedScanRow>,
 ) -> Result<Vec<QueryResultRow>, String> {
-    // INVARIANT: `QueryResultRow::build` only fails on serde_json encoding
-    // errors, which cannot occur here (all inputs are typed primitives and
-    // already-validated JSON payloads). We still propagate the error via
-    // `?` rather than `.expect()` (Devin Review Finding N) so a future
-    // change to the payload representation fails cleanly.
-    let mut sortable: Vec<SortableRow> = rows
-        .into_iter()
-        .map(|(id, score, payload)| {
-            QueryResultRow::build(id, score, payload.as_ref()).map(|row| SortableRow {
-                id,
-                score,
-                payload,
-                row,
-            })
-        })
-        .collect::<Result<_, _>>()?;
-    velesql_orderby::sort_rows(stmt, &mut sortable);
-    let rows: Vec<QueryResultRow> = sortable.into_iter().map(|s| s.row).collect();
-    Ok(apply_limit_offset(stmt, rows))
+    let mut results = velesql_project::to_search_results(rows);
+    velesql_project::inject_window_functions(stmt, &mut results)?;
+    velesql_orderby::sort_rows(stmt, &mut results)?;
+    let projected = velesql_project::project(stmt, &results)?;
+    Ok(apply_limit_offset(
+        stmt,
+        projected,
+        velesdb_core::velesql::DEFAULT_SELECT_LIMIT,
+    ))
 }
 
-fn apply_limit_offset(stmt: &SelectStatement, rows: Vec<QueryResultRow>) -> Vec<QueryResultRow> {
+/// Applies OFFSET/LIMIT, using `default_limit` when the statement omits LIMIT.
+///
+/// Mirror of core (`query_pipeline.rs`): a LIMIT-less plain SELECT defaults to
+/// `DEFAULT_SELECT_LIMIT` (10), not "every row" — previously WASM used
+/// `u64::MAX`, diverging from every other surface (#8b). Aggregation passes
+/// `u64::MAX` so a LIMIT-less GROUP BY still returns every group.
+fn apply_limit_offset(
+    stmt: &SelectStatement,
+    rows: Vec<QueryResultRow>,
+    default_limit: u64,
+) -> Vec<QueryResultRow> {
     let offset = usize::try_from(stmt.offset.unwrap_or(0)).unwrap_or(usize::MAX);
-    let limit = usize::try_from(stmt.limit.unwrap_or(u64::MAX)).unwrap_or(usize::MAX);
+    let limit = usize::try_from(stmt.limit.unwrap_or(default_limit)).unwrap_or(usize::MAX);
     rows.into_iter().skip(offset).take(limit).collect()
 }
 


### PR DESCRIPTION
## Summary

Three WASM silent-wrong-result bugs where the in-browser engine diverged from core. All fixes mirror core semantics (single source of truth).

### #3b — WASM `SELECT` ignored column projection (returned full payload; dropped `AS` aliases + window functions)
`finalize_plain` merged the whole payload and never read `stmt.columns`. It now runs core's genuine `window_evaluator::evaluate` (injects `ROW_NUMBER`/`RANK` before sort), then projects each row by the parsed `SelectColumns`. `SELECT category` → `{category}` only; `SELECT title AS name` → `{name}`; window aliases appear.

> **Architecture note:** core's `projection::project_results` lives under `velesdb_core::collection`, which is gated behind the `persistence` feature that WASM never enables — so it is genuinely unreachable cross-crate. `window_evaluator` (under `velesql/`, ungated) **is** reused directly; `project_single`'s JSON-shaping is mirrored field-for-field in `velesql_project.rs` (verified identical: id-precedence, dotted-path, aliases, similarity-score, window dedup). A follow-up could move `project_results` outside the `persistence` gate for a literal shared call.

### #8 — WASM `ORDER BY similarity/arithmetic` silently no-op'd + no default `LIMIT`
`compare_with_spec` mapped Similarity/Arithmetic/Aggregate → `Ordering::Equal` (scan order, no error). Now arithmetic `ORDER BY` is evaluated per row (mirroring core `ordering::evaluate_arithmetic`); `similarity(field,$v)` and aggregate-outside-aggregation are **rejected loudly** (parity with the MATCH path), no more silent scan-order. A `LIMIT`-less plain `SELECT` now caps at `DEFAULT_SELECT_LIMIT` (10), matching core (was `u64::MAX` = all rows).

### #9 — WASM `USING FUSION(weighted/rsf)` fused against a constant-1.0 branch + leaked `WHERE`-failing rows
WASM has no BM25/graph branch, so weighted/rsf fused the real vector ranking against a constant `1.0` → meaningless. Now weighted/rsf on a single-vector `NEAR` is **rejected** with a clear error. Removed the `fusion_residual_already_applied` short-circuit so the metadata residual is **always enforced as a hard filter** (core parity — no leaked rows). Capability matrix corrected.

## Test plan
- New `velesql_exec_behavior_tests.rs` + a #9 fusion test — 7 tests proven fail-on-base, pass here (full payload leak, dropped alias, dropped window col, no default LIMIT, scan-order arithmetic, silent similarity no-op, fusion row-leak).
- Gates: `cargo fmt`; `clippy -p velesdb-wasm --all-targets --no-default-features -D warnings -D clippy::pedantic` (exit 0); `cargo check -p velesdb-wasm --no-default-features --target wasm32-unknown-unknown` (clean); `lizard -C 8` (0 over budget); **`cargo test -p velesdb-wasm` = 569/0**.

CHANGELOG `[Unreleased]` updated. Out of scope (tracked): WASM aggregate `ORDER BY COUNT(*)` (separate gap), WASM EXPLAIN vocab (#23) and error codes (#22) → follow-up WASM PR.