### PR TITLE
fix(velesql): MATCH ORDER BY returns the global top-K across all strategies + public match_query_ordered (#1/#1b)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,16 @@ release.
   effective `LIMIT`. Previously these were stored and displayed but never applied.
   `timeout_ms` and `rerank` have no execution channel yet, so `\set` now warns
   that they are display-only instead of implying they take effect.
+- **`match_query_ordered` ordered-MATCH entry point on the collection types.**
+  A new public `Collection::match_query_ordered` (re-exported on
+  `VectorCollection` and `GraphCollection`) runs a MATCH clause through the
+  cost-based planner and returns ordered `MatchResult`s with RETURN `ORDER BY`,
+  the deterministic `(node_id, depth, path)` tie-break, and the post-sort
+  `LIMIT` applied — identical to the SQL `/query` path. It is the single source
+  of truth for non-SQL surfaces (REST `/match`, the SDKs) that need ordered
+  graph rows, so they rank identically instead of re-implementing ordering or
+  returning raw traversal order. *(Additive: new method; existing
+  `execute_match` / `execute_match_with_similarity` are unchanged.)*
 
 ### Fixed
 - **EXPLAIN of a MATCH query now shows the graph traversal and its strategy.**
@@ -141,6 +151,18 @@ release.
   They now sort. Aggregates (no `GROUP BY`) and bare aliases are rejected with
   `VELES-018` instead of being silently ignored.
   *(Behavior change: previously-silent queries now sort or error.)*
+- **`MATCH ... ORDER BY ... LIMIT` now returns the GLOBAL top-K.** Traversal
+  early-broke once it had `LIMIT` candidates and only *then* sorted, so an
+  `ORDER BY` LIMIT selected the sorted-top-K of the first-K rows *traversed*
+  rather than the globally ordered set (e.g. `ORDER BY year DESC LIMIT 2` could
+  return the two lowest years that happened to be visited first). When an
+  `ORDER BY` is present, traversal now visits the full candidate set (bounded by
+  the shared `MAX_LIMIT` ceiling and the guard-rails) before sorting and
+  applying the LIMIT; without an `ORDER BY`, the LIMIT-on-traversal-order
+  early-break is preserved. Affects the SQL `/query` path and every surface that
+  finalizes through it.
+  *(Behavior change: `MATCH ORDER BY ... LIMIT` results change when the global
+  top-K differs from the first-K traversed.)*
 - **`NEAR_FUSED` multi-vector fusion now executes via SQL.** It previously parsed
   into a condition with no executor and silently degraded to an unranked full
   scan that ignored the query vectors and `USING FUSION`. A SQL `NEAR_FUSED` now

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -159,8 +159,12 @@ release.
   `ORDER BY` is present, traversal now visits the full candidate set (bounded by
   the shared `MAX_LIMIT` ceiling and the guard-rails) before sorting and
   applying the LIMIT; without an `ORDER BY`, the LIMIT-on-traversal-order
-  early-break is preserved. Affects the SQL `/query` path and every surface that
-  finalizes through it.
+  early-break is preserved. A start-`similarity()` `MATCH` that `ORDER BY`s a
+  non-similarity field — which would otherwise pick the approximate-HNSW
+  `VectorFirst` strategy and rank only a similarity-bounded prefix — now routes
+  to `GraphFirst`'s exact enumeration, so the global top-K holds (deterministically)
+  across all traversal strategies. Affects the SQL `/query` path and every
+  surface that finalizes through it.
   *(Behavior change: `MATCH ORDER BY ... LIMIT` results change when the global
   top-K differs from the first-K traversed.)*
 - **`NEAR_FUSED` multi-vector fusion now executes via SQL.** It previously parsed

--- a/crates/velesdb-core/src/collection/graph_collection_query.rs
+++ b/crates/velesdb-core/src/collection/graph_collection_query.rs
@@ -83,4 +83,23 @@ impl GraphCollection {
             params,
         )
     }
+
+    /// Executes a MATCH query through the cost-based planner, returning ordered
+    /// [`MatchResult`]s with RETURN `ORDER BY`, deterministic tie-break, and
+    /// post-sort LIMIT applied — identical to the SQL `/query` path (backlog #1).
+    ///
+    /// This is the single ordered-MATCH entry point non-SQL surfaces should
+    /// route through so every surface ranks identically.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if a guard-rail pre-check fails, or if traversal,
+    /// ordering, or execution fails.
+    pub fn match_query_ordered(
+        &self,
+        match_clause: &crate::velesql::MatchClause,
+        params: &HashMap<String, serde_json::Value>,
+    ) -> Result<Vec<MatchResult>> {
+        self.inner.match_query_ordered(match_clause, params)
+    }
 }

--- a/crates/velesdb-core/src/collection/search/query/match_dispatch.rs
+++ b/crates/velesdb-core/src/collection/search/query/match_dispatch.rs
@@ -60,6 +60,77 @@ impl Collection {
         params: &std::collections::HashMap<String, serde_json::Value>,
         ctx: &crate::guardrails::QueryContext,
     ) -> Result<Vec<SearchResult>> {
+        let raw = self.dispatch_match_strategy(match_clause, params, ctx)?;
+        self.finalize_match_results(match_clause, raw, ctx, params)
+    }
+
+    /// Public ordered-MATCH entry point: runs the full cost-based planner
+    /// pipeline (guard-rail pre-check, strategy selection, metrics, RETURN
+    /// `ORDER BY` with deterministic tie-break, and post-sort LIMIT) and
+    /// returns ordered [`MatchResult`]s.
+    ///
+    /// This is the SINGLE method non-SQL surfaces (REST `/match`, the Python /
+    /// TypeScript SDKs) should call so they rank identically to the SQL `/query`
+    /// path instead of re-implementing ordering or returning raw traversal order
+    /// (backlog #1). Unlike the backward-compatible [`execute_match`] /
+    /// [`execute_match_with_similarity`] entry points (which run without a
+    /// guard-rail context), this routes through the planner and enforces
+    /// guard-rails.
+    ///
+    /// [`execute_match`]: Self::execute_match
+    /// [`execute_match_with_similarity`]: Self::execute_match_with_similarity
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if a guard-rail pre-check fails, or if traversal,
+    /// ordering, or a guard-rail check during execution fails.
+    pub fn match_query_ordered(
+        &self,
+        match_clause: &crate::velesql::MatchClause,
+        params: &std::collections::HashMap<String, serde_json::Value>,
+    ) -> Result<Vec<super::match_exec::MatchResult>> {
+        self.guard_rails
+            .pre_check("default")
+            .map_err(crate::error::Error::from)?;
+        let ctx = self.guard_rails.create_context();
+        self.dispatch_match_ordered(match_clause, params, &ctx)
+    }
+
+    /// Runs the cost-based MATCH planner and the selected execution strategy,
+    /// returning the ordered, post-sort-LIMITed [`MatchResult`]s **before**
+    /// conversion to [`SearchResult`].
+    ///
+    /// Single source of truth for non-SQL surfaces (REST `/match`, the SDKs)
+    /// that need ordered graph rows: it shares the SAME planner, metrics,
+    /// deterministic tie-break, and post-sort LIMIT as the SQL `/query` path
+    /// ([`dispatch_match_query`](Self::dispatch_match_query)), the only
+    /// difference being the return type (`MatchResult` vs the converted
+    /// `SearchResult`). Without it those surfaces re-implement ordering or
+    /// return raw traversal order (backlog #1).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if traversal, ordering, or a guard-rail check fails.
+    pub(in crate::collection::search::query) fn dispatch_match_ordered(
+        &self,
+        match_clause: &crate::velesql::MatchClause,
+        params: &std::collections::HashMap<String, serde_json::Value>,
+        ctx: &crate::guardrails::QueryContext,
+    ) -> Result<Vec<super::match_exec::MatchResult>> {
+        let raw = self.dispatch_match_strategy(match_clause, params, ctx)?;
+        self.finalize_match_ordering(match_clause, raw, ctx, params)
+    }
+
+    /// Selects and runs the planner strategy, returning RAW (unordered,
+    /// unconverted) [`MatchResult`]s plus recording metrics and the advisor
+    /// query pattern. Shared by the SQL `SearchResult` path and the ordered
+    /// `MatchResult` path so strategy dispatch lives in exactly one place.
+    fn dispatch_match_strategy(
+        &self,
+        match_clause: &crate::velesql::MatchClause,
+        params: &std::collections::HashMap<String, serde_json::Value>,
+        ctx: &crate::guardrails::QueryContext,
+    ) -> Result<Vec<super::match_exec::MatchResult>> {
         let start = std::time::Instant::now();
 
         // W6-A2: Cost-based strategy selection.
@@ -67,30 +138,7 @@ impl Collection {
         let strategy = super::match_planner::MatchQueryPlanner::plan(match_clause, &stats);
         tracing::debug!(strategy = ?strategy, "MATCH execution strategy selected");
 
-        // Dispatch based on strategy.
-        let result = match &strategy {
-            super::match_planner::MatchExecutionStrategy::VectorFirst {
-                similarity_alias,
-                top_k,
-                threshold,
-            } => {
-                let vf_results = self.execute_match_vector_first(
-                    match_clause,
-                    params,
-                    ctx,
-                    similarity_alias,
-                    *top_k,
-                    *threshold,
-                )?;
-                self.finalize_match_results(match_clause, vf_results, ctx, params)
-            }
-            super::match_planner::MatchExecutionStrategy::Parallel {
-                ref vector_hint, ..
-            } => self.execute_match_parallel(match_clause, params, ctx, vector_hint),
-            super::match_planner::MatchExecutionStrategy::GraphFirst { .. } => {
-                self.execute_match_pipeline(match_clause, params, ctx)
-            }
-        };
+        let result = self.run_match_strategy(match_clause, params, ctx, &strategy);
 
         // W6-A3: Record metrics.
         let max_depth = super::match_planner::MatchQueryPlanner::count_hops(match_clause);
@@ -115,18 +163,34 @@ impl Collection {
         result
     }
 
-    /// Executes the MATCH pipeline: traversal, ordering, conversion, and limits.
-    ///
-    /// Factored out of `dispatch_match_query` so metrics recording wraps the
-    /// entire operation cleanly.
-    fn execute_match_pipeline(
+    /// Dispatches to the strategy-specific traversal, returning RAW results.
+    fn run_match_strategy(
         &self,
         match_clause: &crate::velesql::MatchClause,
         params: &std::collections::HashMap<String, serde_json::Value>,
         ctx: &crate::guardrails::QueryContext,
-    ) -> Result<Vec<SearchResult>> {
-        let match_results = self.execute_match_with_context(match_clause, params, Some(ctx))?;
-        self.finalize_match_results(match_clause, match_results, ctx, params)
+        strategy: &super::match_planner::MatchExecutionStrategy,
+    ) -> Result<Vec<super::match_exec::MatchResult>> {
+        match strategy {
+            super::match_planner::MatchExecutionStrategy::VectorFirst {
+                similarity_alias,
+                top_k,
+                threshold,
+            } => self.execute_match_vector_first(
+                match_clause,
+                params,
+                ctx,
+                similarity_alias,
+                *top_k,
+                *threshold,
+            ),
+            super::match_planner::MatchExecutionStrategy::Parallel {
+                ref vector_hint, ..
+            } => self.execute_match_parallel(match_clause, params, ctx, vector_hint),
+            super::match_planner::MatchExecutionStrategy::GraphFirst { .. } => {
+                self.execute_match_with_context(match_clause, params, Some(ctx))
+            }
+        }
     }
 
     /// Executes the Parallel MATCH strategy (Wave 6 Phase D).
@@ -143,7 +207,7 @@ impl Collection {
         params: &std::collections::HashMap<String, serde_json::Value>,
         ctx: &crate::guardrails::QueryContext,
         vector_hint: &super::match_planner::MatchExecutionStrategy,
-    ) -> Result<Vec<SearchResult>> {
+    ) -> Result<Vec<super::match_exec::MatchResult>> {
         // Phase 1: GraphFirst path.
         let graph_results = self.execute_match_with_context(match_clause, params, Some(ctx))?;
 
@@ -175,8 +239,11 @@ impl Collection {
         let higher_is_better = config.metric.higher_is_better();
         drop(config);
 
-        let merged = merge_match_results(graph_results, vector_results, higher_is_better);
-        self.finalize_match_results(match_clause, merged, ctx, params)
+        Ok(merge_match_results(
+            graph_results,
+            vector_results,
+            higher_is_better,
+        ))
     }
 
     /// Applies ORDER BY, conversion to `SearchResult`, cardinality check,
@@ -216,6 +283,35 @@ impl Collection {
             .update_graph_latency(graph_latency_us);
         self.guard_rails.circuit_breaker.record_success();
         Ok(results)
+    }
+
+    /// Applies the timeout guard, RETURN `ORDER BY` (deterministic tie-break),
+    /// and the post-sort LIMIT to raw `MatchResult`s, returning ordered rows
+    /// WITHOUT converting to `SearchResult`.
+    ///
+    /// Shares the exact ordering ([`apply_match_order_by`](Self::apply_match_order_by))
+    /// and LIMIT ([`match_return_limit`]) logic with the SQL `SearchResult`
+    /// finalize path, so the ordered `MatchResult` surface ranks identically.
+    fn finalize_match_ordering(
+        &self,
+        match_clause: &crate::velesql::MatchClause,
+        match_results: Vec<super::match_exec::MatchResult>,
+        ctx: &crate::guardrails::QueryContext,
+        params: &std::collections::HashMap<String, serde_json::Value>,
+    ) -> Result<Vec<super::match_exec::MatchResult>> {
+        ctx.check_timeout()
+            .map_err(crate::error::Error::from)
+            .inspect_err(|_| self.guard_rails.circuit_breaker.record_failure())?;
+
+        let mut sorted = match_results;
+        self.apply_match_order_by(&mut sorted, match_clause, params)
+            .inspect_err(|_| self.guard_rails.circuit_breaker.record_failure())?;
+
+        if let Some(limit) = match_return_limit(match_clause) {
+            sorted.truncate(limit);
+        }
+        self.guard_rails.circuit_breaker.record_success();
+        Ok(sorted)
     }
 
     /// Applies RETURN `ORDER BY` (with the deterministic `(node_id, depth, path)`

--- a/crates/velesdb-core/src/collection/search/query/match_exec/mod.rs
+++ b/crates/velesdb-core/src/collection/search/query/match_exec/mod.rs
@@ -260,10 +260,7 @@ impl Collection {
         // Documented contract (VELESQL_SPEC "Default LIMIT"): MATCH ... RETURN
         // has no implicit LIMIT 10 — results are bounded only by the
         // server-wide MAX_LIMIT ceiling shared with compound queries.
-        let limit = match_clause
-            .return_clause
-            .limit
-            .map_or(super::MAX_LIMIT, |l| l as usize);
+        let limit = traversal_limit(match_clause);
         let mut all_results: Vec<MatchResult> = Vec::new();
         let mut iteration_count: u32 = 0;
         let mut reported_cardinality: usize = 0;
@@ -434,6 +431,25 @@ impl Collection {
         }
         Ok(())
     }
+}
+
+/// Computes the traversal-phase candidate cap for a MATCH clause.
+///
+/// Without a RETURN `ORDER BY`, the LIMIT applies to traversal order, so the
+/// early-break at `return_clause.limit` is correct and stops traversal as soon
+/// as enough rows are collected. WITH an `ORDER BY`, the post-sort LIMIT must
+/// select the GLOBAL top-K, so traversal must visit the full candidate set
+/// (bounded only by the shared `MAX_LIMIT` ceiling and the guard-rails) before
+/// the sort — otherwise the LIMIT would be applied to the first-K-traversed
+/// rows instead of the globally ordered set (backlog #1b).
+fn traversal_limit(match_clause: &MatchClause) -> usize {
+    if match_clause.return_clause.order_by.is_some() {
+        return super::MAX_LIMIT;
+    }
+    match_clause
+        .return_clause
+        .limit
+        .map_or(super::MAX_LIMIT, |l| l as usize)
 }
 
 // Tests moved to match_exec_tests.rs per project rules

--- a/crates/velesdb-core/src/collection/search/query/match_planner.rs
+++ b/crates/velesdb-core/src/collection/search/query/match_planner.rs
@@ -90,39 +90,38 @@ impl MatchQueryPlanner {
     #[must_use]
     pub fn plan(match_clause: &MatchClause, stats: &CollectionStats) -> MatchExecutionStrategy {
         let has_similarity = Self::has_similarity_condition(match_clause.where_clause.as_ref());
-        let similarity_info = Self::extract_similarity_info(match_clause.where_clause.as_ref());
-        let similarity_on_start =
-            Self::is_similarity_on_start(match_clause, similarity_info.as_ref());
         let start_labels = Self::extract_start_labels(match_clause);
         let max_depth = Self::count_hops(match_clause);
-        // Audit 2026-06 F2: VectorFirst (alone or as a Parallel leg) validates
-        // candidates without binding relationship aliases, so `r.prop` would
-        // silently resolve against node payloads. Force GraphFirst whenever
-        // WHERE or RETURN references a relationship alias of the pattern.
-        let edge_alias_referenced = Self::references_relationship_alias(match_clause);
-
-        if has_similarity && similarity_on_start && !edge_alias_referenced {
-            Self::plan_vector_first(match_clause, stats, similarity_info)
-        } else if !has_similarity {
-            MatchExecutionStrategy::GraphFirst {
-                start_labels,
-                max_depth,
-            }
-        } else if !edge_alias_referenced
-            && Self::should_use_parallel(stats, similarity_info.as_ref())
+        // A vector strategy may short-cut ONLY for a start-similarity condition,
+        // and NEVER when:
+        //   * WHERE/RETURN references a relationship alias — VectorFirst validates
+        //     candidates without binding edge aliases, so `r.prop` would silently
+        //     resolve against node payloads (audit 2026-06 F2); or
+        //   * an ORDER BY targets a non-similarity key (payload field, arithmetic,
+        //     aggregate) — VectorFirst's approximate-HNSW, LIMIT-bounded prefix
+        //     cannot yield the global top-K, which only GraphFirst's exact label
+        //     enumeration + post-sort LIMIT guarantees (backlog #1b).
+        if has_similarity
+            && !Self::references_relationship_alias(match_clause)
+            && !order_by_needs_full_candidates(&match_clause.return_clause)
         {
-            Self::plan_parallel(
-                match_clause,
-                stats,
-                similarity_info,
-                start_labels,
-                max_depth,
-            )
-        } else {
-            MatchExecutionStrategy::GraphFirst {
-                start_labels,
-                max_depth,
+            let similarity_info = Self::extract_similarity_info(match_clause.where_clause.as_ref());
+            if Self::is_similarity_on_start(match_clause, similarity_info.as_ref()) {
+                return Self::plan_vector_first(match_clause, stats, similarity_info);
             }
+            if Self::should_use_parallel(stats, similarity_info.as_ref()) {
+                return Self::plan_parallel(
+                    match_clause,
+                    stats,
+                    similarity_info,
+                    start_labels,
+                    max_depth,
+                );
+            }
+        }
+        MatchExecutionStrategy::GraphFirst {
+            start_labels,
+            max_depth,
         }
     }
 
@@ -392,6 +391,27 @@ impl MatchQueryPlanner {
 fn column_targets_alias(column: &str, aliases: &[&str]) -> bool {
     let prefix = column.split('.').next().unwrap_or(column);
     aliases.contains(&prefix)
+}
+
+/// Whether the RETURN `ORDER BY` needs the full WHERE-matching candidate set
+/// rather than the similarity-ranked prefix `VectorFirst` produces.
+///
+/// `VectorFirst` fetches a similarity-top-K subset via approximate HNSW, so it
+/// can only honor an `ORDER BY` that *is* the start-node similarity (its natural
+/// output). An `ORDER BY` on a payload field, arithmetic, or aggregate requires
+/// every WHERE-matching node to be ranked, which only `GraphFirst`'s exact
+/// enumeration guarantees (backlog #1b). `Similarity`/`SimilarityBare` orderings
+/// stay on `VectorFirst` (no perf regression for the canonical top-K).
+fn order_by_needs_full_candidates(return_clause: &crate::velesql::ReturnClause) -> bool {
+    use crate::velesql::OrderByExpr;
+    return_clause.order_by.as_ref().is_some_and(|items| {
+        items.iter().any(|item| {
+            matches!(
+                item.expr,
+                OrderByExpr::Field(_) | OrderByExpr::Aggregate(_) | OrderByExpr::Arithmetic(_)
+            )
+        })
+    })
 }
 
 /// Checks whether an ORDER BY expression targets one of `aliases` (used to keep

--- a/crates/velesdb-core/src/collection/search/query/match_planner_tests.rs
+++ b/crates/velesdb-core/src/collection/search/query/match_planner_tests.rs
@@ -75,6 +75,24 @@ fn test_planner_chooses_vector_first_for_start_similarity() {
 }
 
 #[test]
+fn test_planner_routes_similarity_with_payload_order_by_to_graph_first() {
+    // Backlog #1b: a start-similarity MATCH that ORDER BYs a non-similarity
+    // payload field must use GraphFirst's exact enumeration — VectorFirst's
+    // approximate HNSW prefix cannot answer a global payload ordering.
+    let query = crate::velesql::Parser::parse(
+        "MATCH (a:Person) WHERE similarity(a.embedding, $v) > 0.8 \
+         RETURN a ORDER BY a.year DESC LIMIT 10",
+    )
+    .expect("test: parse similarity + payload ORDER BY");
+    let match_clause = query.match_clause.expect("test: match clause present");
+    let strategy = MatchQueryPlanner::plan(&match_clause, &default_stats());
+    assert!(
+        matches!(strategy, MatchExecutionStrategy::GraphFirst { .. }),
+        "similarity + ORDER BY payload must route to GraphFirst (exact), not VectorFirst"
+    );
+}
+
+#[test]
 fn test_estimate_selectivity() {
     assert!((MatchQueryPlanner::estimate_selectivity(0.9) - 0.1).abs() < 0.01);
     assert!((MatchQueryPlanner::estimate_selectivity(0.5) - 0.5).abs() < 0.01);

--- a/crates/velesdb-core/src/collection/vector_collection/search.rs
+++ b/crates/velesdb-core/src/collection/vector_collection/search.rs
@@ -377,6 +377,23 @@ impl VectorCollection {
             .execute_match_with_similarity(match_clause, query_vector, threshold, params)
     }
 
+    /// Executes a MATCH query through the cost-based planner, returning ordered
+    /// [`MatchResult`](crate::collection::search::query::match_exec::MatchResult)s
+    /// with RETURN `ORDER BY`, deterministic tie-break, and post-sort LIMIT
+    /// applied — identical to the SQL `/query` path (backlog #1).
+    ///
+    /// # Errors
+    ///
+    /// - Returns an error if a guard-rail pre-check fails.
+    /// - Returns an error if traversal, ordering, or execution fails.
+    pub fn match_query_ordered(
+        &self,
+        match_clause: &crate::velesql::MatchClause,
+        params: &std::collections::HashMap<String, serde_json::Value>,
+    ) -> crate::error::Result<Vec<crate::collection::search::query::match_exec::MatchResult>> {
+        self.inner.match_query_ordered(match_clause, params)
+    }
+
     /// Executes an aggregation query (GROUP BY / COUNT / SUM / AVG / MIN / MAX).
     ///
     /// # Errors

--- a/crates/velesdb-core/tests/bdd.rs
+++ b/crates/velesdb-core/tests/bdd.rs
@@ -75,6 +75,8 @@ mod introspection;
 mod join_exact_conformance;
 #[path = "bdd/match_graph_first.rs"]
 mod match_graph_first;
+#[path = "bdd/match_order_by_core.rs"]
+mod match_order_by_core;
 #[path = "bdd/match_order_by_exact.rs"]
 mod match_order_by_exact;
 #[path = "bdd/match_relationship_semantics.rs"]

--- a/crates/velesdb-core/tests/bdd/match_order_by_core.rs
+++ b/crates/velesdb-core/tests/bdd/match_order_by_core.rs
@@ -105,3 +105,66 @@ fn scenario_match_query_ordered_matches_sql_path() {
     );
     assert_eq!(ordered, vec![6u64, 5], "ordered top-2 by year DESC");
 }
+
+// --- A VectorFirst-selecting MATCH under a payload ORDER BY (backlog #1b) ---
+//
+// A start-similarity single-node MATCH would otherwise select the VectorFirst
+// strategy, which fetches only an approximate-HNSW, similarity-ranked prefix —
+// it cannot yield the global top-K under an ORDER BY on a non-similarity field.
+// The planner now routes such queries to GraphFirst's EXACT label enumeration,
+// making the result deterministic (no HNSW recall dependence).
+//
+// Dataset (`vdocs`, 2-dim cosine): vectors fan from 0deg (id 1, best cosine to
+// the query [1,0]) to ~50deg (id 6, worst cosine but still cos>=0.64 > 0.5),
+// while `year` ascends with id. So the global year-DESC top-2 (ids 6, 5 — the
+// least-similar, highest-year) is disjoint from the similarity-top-2 (ids 1, 2).
+
+/// Builds `vdocs`: ids 1..=6, `year = 2000 + id`, vectors fanning 0..~50deg.
+fn setup_vdocs(db: &Database) {
+    db.create_vector_collection("vdocs", 2, velesdb_core::DistanceMetric::Cosine)
+        .expect("test: create vdocs");
+    let vc = db.get_vector_collection("vdocs").expect("test: get vdocs");
+    let points: Vec<Point> = (1..=DOC_COUNT)
+        .map(|id| {
+            #[allow(clippy::cast_precision_loss)]
+            let angle = (id - 1) as f32 * (50.0_f32.to_radians() / (DOC_COUNT - 1) as f32);
+            Point::new(
+                id,
+                vec![angle.cos(), angle.sin()],
+                Some(json!({"_labels": ["Doc"], "year": 2000 + id})),
+            )
+        })
+        .collect();
+    vc.upsert(points).expect("test: upsert vdocs");
+}
+
+fn vdocs_ids(db: &Database, sql: &str) -> Vec<u64> {
+    let mut params = HashMap::new();
+    params.insert("_collection".to_string(), json!("vdocs"));
+    params.insert("q".to_string(), json!([1.0, 0.0]));
+    let query = Parser::parse(sql).expect("test: parse vdocs MATCH");
+    db.execute_query(&query, &params)
+        .expect("test: execute vdocs MATCH")
+        .iter()
+        .map(|r| r.point.id)
+        .collect()
+}
+
+/// #1b (VectorFirst-selecting query): a start-similarity MATCH with an ORDER BY
+/// on the `year` payload must return the GLOBAL year-DESC top-2 (ids 6, 5), not
+/// the year-sort of the similarity-ranked prefix (ids 2, 1).
+#[test]
+fn scenario_similarity_match_order_by_payload_returns_global_top_k() {
+    let (_dir, db) = create_test_db();
+    setup_vdocs(&db);
+    let ids = vdocs_ids(
+        &db,
+        "MATCH (d:Doc) WHERE similarity(d, $q) > 0.5 RETURN d ORDER BY d.year DESC LIMIT 2",
+    );
+    assert_eq!(
+        ids,
+        vec![6u64, 5],
+        "similarity MATCH + ORDER BY year DESC LIMIT 2 must be the GLOBAL top-2, \
+         not the year-sort of the similarity-ranked prefix"
+    );
+}

--- a/crates/velesdb-core/tests/bdd/match_order_by_core.rs
+++ b/crates/velesdb-core/tests/bdd/match_order_by_core.rs
@@ -1,0 +1,107 @@
+//! Core-level regression tests for MATCH `RETURN ... ORDER BY` + post-sort
+//! `LIMIT`, pinning two contracts that surfaces beyond the SQL pipeline depend
+//! on:
+//!
+//! 1. The SQL `/query` path must return the GLOBAL top-K under an ORDER BY, not
+//!    the sorted-top-K of the first-K nodes traversed (backlog #1b). Before the
+//!    fix, `execute_match_with_context` early-broke traversal at
+//!    `return_clause.limit` BEFORE the sort, so the LIMIT was applied to the
+//!    first-K-traversed set instead of the globally ordered one.
+//!
+//! 2. The public ordered-MATCH entry point (`match_query_ordered`, the single
+//!    method later non-SQL surfaces route through) must return the SAME ordered
+//!    ids as the SQL `/query` path (backlog #1 core).
+//!
+//! Dataset (`cdocs`, 2-dim cosine, all `:Doc`): six nodes whose ids ascend with
+//! their `year`, so the label-index traversal order (ascending node id) is the
+//! OPPOSITE of the year-DESC order. Hence the global top-2 by year (ids 6, 5)
+//! is disjoint from the first-2 traversed (ids 1, 2) — the divergence that
+//! exposes the early-break bug.
+
+use std::collections::HashMap;
+
+use serde_json::json;
+use velesdb_core::velesql::Parser;
+use velesdb_core::{Database, Point};
+
+use super::helpers::create_test_db;
+
+/// Number of `:Doc` nodes seeded; chosen so LIMIT 2 ≪ N and the global top-K
+/// is provably disjoint from the first-K-traversed.
+const DOC_COUNT: u64 = 6;
+
+/// Builds `cdocs`: ids 1..=6 with `year = 2000 + id`, all labelled `:Doc`.
+fn setup_core_docs(db: &Database) {
+    db.create_vector_collection("cdocs", 2, velesdb_core::DistanceMetric::Cosine)
+        .expect("test: create cdocs");
+    let vc = db.get_vector_collection("cdocs").expect("test: get cdocs");
+    let points: Vec<Point> = (1..=DOC_COUNT)
+        .map(|id| {
+            Point::new(
+                id,
+                vec![1.0, 0.0],
+                Some(json!({"_labels": ["Doc"], "year": 2000 + id})),
+            )
+        })
+        .collect();
+    vc.upsert(points).expect("test: upsert cdocs");
+}
+
+/// Runs `sql` through the SQL `/query` pipeline against `cdocs`, returning ids.
+fn sql_ids(db: &Database, sql: &str) -> Vec<u64> {
+    let mut params = HashMap::new();
+    params.insert("_collection".to_string(), json!("cdocs"));
+    let query = Parser::parse(sql).expect("test: parse MATCH ORDER BY");
+    db.execute_query(&query, &params)
+        .expect("test: execute MATCH ORDER BY")
+        .iter()
+        .map(|r| r.point.id)
+        .collect()
+}
+
+const ORDER_BY_TOP2: &str = "MATCH (d:Doc) RETURN d ORDER BY d.year DESC LIMIT 2";
+
+/// #1b: the SQL pipeline must return the GLOBAL year-DESC top-2 (ids 6, 5), not
+/// the sorted first-2-traversed (ids 2, 1). The early-break-before-sort bug
+/// returned `[2, 1]`.
+#[test]
+fn scenario_match_order_by_limit_returns_global_top_k() {
+    let (_dir, db) = create_test_db();
+    setup_core_docs(&db);
+    let ids = sql_ids(&db, ORDER_BY_TOP2);
+    assert_eq!(
+        ids,
+        vec![6u64, 5],
+        "ORDER BY year DESC LIMIT 2 must be the GLOBAL top-2, not the \
+         sorted-first-2-traversed"
+    );
+}
+
+/// #1 core: the public `match_query_ordered` entry point must return the SAME
+/// ordered top-K as the SQL `/query` path (single source of truth).
+#[test]
+fn scenario_match_query_ordered_matches_sql_path() {
+    let (_dir, db) = create_test_db();
+    setup_core_docs(&db);
+
+    let sql = sql_ids(&db, ORDER_BY_TOP2);
+
+    let params: HashMap<String, serde_json::Value> = HashMap::new();
+    let match_clause = Parser::parse(ORDER_BY_TOP2)
+        .expect("test: parse")
+        .match_clause
+        .expect("test: MATCH clause present");
+    let vc = db.get_vector_collection("cdocs").expect("test: get cdocs");
+    let ordered: Vec<u64> = vc
+        .match_query_ordered(&match_clause, &params)
+        .expect("test: match_query_ordered")
+        .iter()
+        .map(|r| r.node_id)
+        .collect();
+
+    assert_eq!(
+        ordered, sql,
+        "match_query_ordered must return the same ordered ids as the SQL path"
+    );
+    assert_eq!(ordered, vec![6u64, 5], "ordered top-2 by year DESC");
+}


### PR DESCRIPTION
## Summary

Core-level MATCH `ORDER BY` fixes so every surface (and the upcoming Python wave) gets correct, global top-K ordering through one source of truth.

### #1 (core) — public `match_query_ordered` entry point
Added `Collection::match_query_ordered` (re-exposed on `VectorCollection` + `GraphCollection`) that runs the planner via `dispatch_match_query`/`finalize`, applying `ORDER BY`, deterministic `(node_id, depth, path)` tie-break, and post-sort `LIMIT`, returning an ordered `Vec<MatchResult>`. The SQL and `MatchResult` paths now share **one** strategy/ordering implementation (`dispatch_match_strategy`). This is the single method the later Python wave routes `match_query`/`graph_collection_query` through. (REST `/match` was already routed in #1202.)

### #1b — global top-K, across **all** traversal strategies
1. **GraphFirst**: traversal early-broke at `LIMIT` *before* the sort, so `ORDER BY year DESC LIMIT 2` returned the sorted-top-K of the first-K *traversed*, not the global top-K. Now `traversal_limit()` traverses the full candidate set (bounded by `MAX_LIMIT` + guard-rails) when an `ORDER BY` is present, then sorts + LIMITs; the early-break optimization is preserved when there's no `ORDER BY`.
2. **VectorFirst / Parallel**: a start-`similarity()` MATCH with an `ORDER BY` on a non-similarity key (payload field / arithmetic / aggregate) selected VectorFirst, which fetches only an **approximate-HNSW**, similarity-bounded prefix — so it could not yield the global top-K (and was non-deterministic w.r.t. HNSW recall). The planner now routes such queries to **GraphFirst's exact label enumeration** (`order_by_needs_full_candidates`), giving a deterministic global top-K. `VectorFirst` is **preserved** when ordering by similarity (no perf regression on the canonical top-K).

## Test plan
- Failing-test-first / discriminating:
  - core `scenario_match_order_by_limit_returns_global_top_k`, `scenario_match_query_ordered_matches_sql_path` (GraphFirst #1b + parity)
  - core `scenario_similarity_match_order_by_payload_returns_global_top_k` (VectorFirst-selecting query → GraphFirst → global `[6,5]`, **deterministic**)
  - planner unit `test_planner_routes_similarity_with_payload_order_by_to_graph_first`
- Determinism re-checked: full `bdd` suite run **2×** = 618/0 with the similarity-ORDER-BY test `... ok` both times (no HNSW recall dependence). The existing VectorFirst-for-similarity planner test still passes (no regression).
- Gates: `cargo fmt`; `clippy --all-targets … -D warnings -D clippy::pedantic` (exit 0); `lizard -C 8` (`plan()` refactored CCN 9→6); **full `cargo test -p velesdb-core --features persistence` = 45 binaries, 0 failed**.

CHANGELOG `[Unreleased]` updated. Tracked follow-up: `finalize_match_ordering` omits the `check_cardinality()` guard the SQL `finalize_match_results` has (a non-SQL caller could receive an oversized result).