### PR TITLE
fix(wasm): machine-readable error codes + EXPLAIN aligned to core plan-step vocabulary (#22/#23)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -223,6 +223,21 @@ release.
   / `average` keep ranking the (now hard-filtered) vector results.
   *(Behavior change: WASM fused single-`NEAR` queries drop WHERE-failing rows;
   weighted/rsf single-branch fusion errors.)*
+- **WASM `EXPLAIN` now uses the core plan vocabulary.** The browser EXPLAIN
+  renderer emitted divergent node labels (`Scan`, `NestedLoopJoin`,
+  `LimitOffset`, `GraphPatternMatch`) under `{step, node, detail}` keys that did
+  not match the REST `/query/explain` taxonomy. Rows now carry the same wire keys
+  as the REST `ExplainStep` (`step`, `operation`, `description`, `estimated_rows`,
+  `estimation_method`) and the same `operation` vocabulary as core's
+  `PlanStep::rest_operation()` (`VectorSearch`, `FullScan`, `Filter`,
+  `{Type}Join`, `GroupBy`, `Aggregate`, `Sort`, `Limit`, `Offset`,
+  `MatchTraversal`); the leading scan carries an `estimated_rows` row-count hint.
+  WASM-only concerns with no core plan node (`FUSION`, `DISTINCT`) fold into a
+  step's description rather than inventing an out-of-taxonomy operation. Core's
+  `to_plan_steps()` itself is `persistence`-gated and unreachable from the
+  no-persistence WASM build, so the renderer mirrors the vocabulary rather than
+  re-exporting it. *(Behavior change: WASM EXPLAIN row keys/labels change.)*
+
 ## [3.2.1] — 2026-06-20
 
 Patch release. Maintenance only — no engine/API change (`velesdb-core` and the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,15 @@ release.
   graph rows, so they rank identically instead of re-implementing ordering or
   returning raw traversal order. *(Additive: new method; existing
   `execute_match` / `execute_match_with_similarity` are unchanged.)*
+- **WASM errors now carry a machine-readable `code`.** Browser rejections were
+  bare `Error(message)` strings, so clients could not narrow them — contradicting
+  `ERROR_CODES.md`, which promises an `error.code` on every client surface. A
+  dimension-mismatch search now rejects with a structured `Error` whose
+  non-enumerable `code` property is `"VELES-004"`, an invalid collection name
+  with `"VELES-034"`, and a `VelesQL` parse failure (`VelesQL.parse`) with
+  `"VELES-010"`. The code is single-sourced from `velesdb_core::Error::code()`
+  (no WASM-local taxonomy); the property is non-enumerable so it does not appear
+  in `JSON.stringify(error)`. *(Additive: the `message` text is unchanged.)*
 
 ### Fixed
 - **EXPLAIN of a MATCH query now shows the graph traversal and its strategy.**
@@ -214,7 +223,6 @@ release.
   / `average` keep ranking the (now hard-filtered) vector results.
   *(Behavior change: WASM fused single-`NEAR` queries drop WHERE-failing rows;
   weighted/rsf single-branch fusion errors.)*
-
 ## [3.2.1] — 2026-06-20
 
 Patch release. Maintenance only — no engine/API change (`velesdb-core` and the

--- a/crates/velesdb-wasm/src/database.rs
+++ b/crates/velesdb-wasm/src/database.rs
@@ -17,6 +17,7 @@ use crate::graph_store::WasmGraphStore;
 use crate::parsing;
 use crate::store_new;
 use crate::vector_store::VectorStore;
+use crate::wasm_error::WasmError;
 
 // ---------------------------------------------------------------------------
 // Shared inner store
@@ -70,10 +71,12 @@ impl DatabaseInner {
     ///
     /// Without this, the lifecycle methods only ran a `HashMap` existence
     /// check, silently accepting names core would reject (path traversal,
-    /// reserved device names, forbidden characters). Mapped to a `String`
-    /// error for native-target testability.
-    fn validate_name(name: &str) -> Result<(), String> {
-        velesdb_core::validate_collection_name(name).map_err(|e| e.to_string())
+    /// reserved device names, forbidden characters). Returns a structured
+    /// [`WasmError`] carrying core's `VELES-034` code instead of pre-flattening
+    /// to a bare string (backlog #22), so the FFI layer can surface
+    /// `error.code` to browser clients.
+    pub(crate) fn validate_name(name: &str) -> Result<(), WasmError> {
+        velesdb_core::validate_collection_name(name).map_err(WasmError::from)
     }
 
     pub(crate) fn create_collection(
@@ -99,7 +102,7 @@ impl DatabaseInner {
         metric: &str,
         mode: crate::StorageMode,
     ) -> Result<(), String> {
-        Self::validate_name(name)?;
+        Self::validate_name(name).map_err(|e| e.message().to_owned())?;
         if self.collections.contains_key(name) {
             return Err(format!("Collection '{name}' already exists"));
         }
@@ -130,7 +133,7 @@ impl DatabaseInner {
     /// that does not require vector similarity search. Mirrors the Mobile
     /// bindings surface (`create_metadata_collection`).
     pub(crate) fn create_metadata_collection(&mut self, name: &str) -> Result<(), String> {
-        Self::validate_name(name)?;
+        Self::validate_name(name).map_err(|e| e.message().to_owned())?;
         if self.collections.contains_key(name) {
             return Err(format!("Collection '{name}' already exists"));
         }
@@ -258,6 +261,10 @@ impl WasmDatabase {
         dimension: usize,
         metric: &str,
     ) -> Result<(), JsValue> {
+        // Validate the name through the structured path first so an invalid
+        // name surfaces `error.code === "VELES-034"` to JS (backlog #22);
+        // remaining failures (metric, already-exists) keep their string form.
+        DatabaseInner::validate_name(name).map_err(WasmError::into_js_value)?;
         self.inner
             .create_collection(name, dimension, metric)
             .map_err(|e| JsValue::from_str(&e))
@@ -273,6 +280,7 @@ impl WasmDatabase {
     /// Returns an error if the collection already exists.
     #[wasm_bindgen(js_name = createMetadataCollection)]
     pub fn create_metadata_collection(&mut self, name: &str) -> Result<(), JsValue> {
+        DatabaseInner::validate_name(name).map_err(WasmError::into_js_value)?;
         self.inner
             .create_metadata_collection(name)
             .map_err(|e| JsValue::from_str(&e))

--- a/crates/velesdb-wasm/src/lib.rs
+++ b/crates/velesdb-wasm/src/lib.rs
@@ -99,6 +99,7 @@ mod velesql_similarity;
 mod velesql_update;
 mod velesql_value;
 mod velesql_where;
+mod wasm_error;
 
 pub use agent::SemanticMemory;
 pub use database::{WasmCollectionHandle, WasmDatabase};

--- a/crates/velesdb-wasm/src/store_search.rs
+++ b/crates/velesdb-wasm/src/store_search.rs
@@ -2,6 +2,7 @@
 //!
 //! Provides search functionality extracted from the main store.
 
+use crate::wasm_error::WasmError;
 use crate::{fusion, text_search, vector_ops, DistanceMetric, StorageMode};
 use serde::Serialize;
 use wasm_bindgen::JsValue;
@@ -47,15 +48,24 @@ pub(crate) fn sort_scored_triples<T>(results: &mut [(u64, f32, T)], higher_is_be
     }
 }
 
-/// Validates query dimension matches store dimension.
+/// Validates query dimension matches store dimension, returning a structured
+/// [`WasmError`] (carrying `VELES-004`) on mismatch.
 ///
-/// Delegates the check to core's [`velesdb_core::validate_dimension_match`]
-/// (single source of truth) and maps its error to a `JsValue` at the FFI
-/// boundary, instead of re-implementing the comparison locally.
+/// Single source of truth for the dimension check: delegates to core's
+/// [`velesdb_core::validate_dimension_match`] and preserves the core error's
+/// machine-readable `code` instead of pre-flattening it to a bare string
+/// (backlog #22). The `wasm32` FFI wrapper [`validate_dimension`] renders this
+/// as a structured JS `Error`.
+#[inline]
+pub fn validate_dimension_structured(query_len: usize, store_dim: usize) -> Result<(), WasmError> {
+    velesdb_core::validate_dimension_match(store_dim, query_len).map_err(WasmError::from)
+}
+
+/// FFI wrapper over [`validate_dimension_structured`] that renders the
+/// structured error as a JS `Error` with a non-enumerable `code` property.
 #[inline]
 pub fn validate_dimension(query_len: usize, store_dim: usize) -> Result<(), JsValue> {
-    velesdb_core::validate_dimension_match(store_dim, query_len)
-        .map_err(|e| JsValue::from_str(&e.to_string()))
+    validate_dimension_structured(query_len, store_dim).map_err(WasmError::into_js_value)
 }
 
 /// Validates that a flat multi-vector buffer holds exactly

--- a/crates/velesdb-wasm/src/velesql.rs
+++ b/crates/velesdb-wasm/src/velesql.rs
@@ -32,12 +32,7 @@ impl VelesQL {
     pub fn parse(query: &str) -> Result<ParsedQuery, JsValue> {
         velesdb_core::velesql::Parser::parse(query)
             .map(|q| ParsedQuery { inner: q })
-            .map_err(|e| {
-                JsValue::from_str(&format!(
-                    "VelesQL syntax error at position {}: {} (near '{}')",
-                    e.position, e.message, e.fragment
-                ))
-            })
+            .map_err(|e| crate::wasm_error::WasmError::from(e).into_js_value())
     }
 
     /// Validate a `VelesQL` query without full parsing.

--- a/crates/velesdb-wasm/src/velesql_explain.rs
+++ b/crates/velesdb-wasm/src/velesql_explain.rs
@@ -4,6 +4,22 @@
 //! human-readable plan. This module walks the parsed AST and produces one
 //! row per logical pipeline step, returning them as synthetic rows so the
 //! JavaScript caller can render them in an "explain plan" table.
+//!
+//! # Vocabulary parity with core (backlog #23)
+//!
+//! The core `QueryPlan::to_plan_steps()` / `PlanStep::rest_operation()` plan
+//! emitter — the single source of truth used by the REST `/query/explain`
+//! endpoint — lives behind the `persistence` feature, which WASM never
+//! enables (it pulls in `tokio`/`memmap2`/`rayon`). It is therefore
+//! unreachable from this crate. Rather than re-export divergent labels, the
+//! step rows below emit the SAME wire keys as the REST `ExplainStep`
+//! (`step`, `operation`, `description`, `estimated_rows`, `estimation_method`)
+//! and the SAME `operation` vocabulary as
+//! [`PlanStepKind`](velesdb_core::velesql) /`rest_operation` —
+//! `VectorSearch`, `FullScan`, `Filter`, `{Type}Join`, `GroupBy`, `Aggregate`,
+//! `Sort`, `Limit`, `Offset`, `MatchTraversal`. WASM-only concerns with no core
+//! plan node (FUSION, DISTINCT) are folded into a step's description instead of
+//! inventing an out-of-taxonomy `operation`.
 
 use velesdb_core::velesql::{Query, SelectStatement};
 
@@ -16,20 +32,48 @@ pub(crate) fn explain(db: &DatabaseInner, query: &Query) -> Result<Vec<QueryResu
     steps
         .into_iter()
         .enumerate()
-        .map(|(i, step)| {
-            let payload = serde_json::json!({
-                "step": i + 1,
-                "node": step.node,
-                "detail": step.detail,
-            });
-            QueryResultRow::synthetic(payload)
-        })
+        .map(|(i, step)| QueryResultRow::synthetic(step.to_json(i + 1)))
         .collect()
 }
 
+/// One EXPLAIN row, mirroring the REST `ExplainStep` wire shape.
 struct PlanStep {
-    node: String,
-    detail: String,
+    /// Core `rest_operation()` taxonomy string (e.g. `FullScan`, `Filter`).
+    operation: String,
+    description: String,
+    estimated_rows: Option<usize>,
+    estimation_method: Option<&'static str>,
+}
+
+impl PlanStep {
+    /// Serializes the row with the REST `ExplainStep` keys, omitting the
+    /// optional estimate fields when absent (matching core's `skip_if_none`).
+    fn to_json(&self, step: usize) -> serde_json::Value {
+        let mut map = serde_json::Map::new();
+        map.insert("step".to_string(), serde_json::json!(step));
+        map.insert("operation".to_string(), serde_json::json!(self.operation));
+        map.insert(
+            "description".to_string(),
+            serde_json::json!(self.description),
+        );
+        if let Some(rows) = self.estimated_rows {
+            map.insert("estimated_rows".to_string(), serde_json::json!(rows));
+        }
+        if let Some(method) = self.estimation_method {
+            map.insert("estimation_method".to_string(), serde_json::json!(method));
+        }
+        serde_json::Value::Object(map)
+    }
+
+    /// Builds a step with no row estimate (most non-scan operations).
+    fn plain(operation: impl Into<String>, description: impl Into<String>) -> Self {
+        Self {
+            operation: operation.into(),
+            description: description.into(),
+            estimated_rows: None,
+            estimation_method: None,
+        }
+    }
 }
 
 fn plan_steps(db: &DatabaseInner, query: &Query) -> Vec<PlanStep> {
@@ -40,24 +84,16 @@ fn plan_steps(db: &DatabaseInner, query: &Query) -> Vec<PlanStep> {
         return explain_dml(dml);
     }
     if query.ddl.is_some() {
-        return vec![PlanStep {
-            node: "DDL".to_string(),
-            detail: "Schema change — no scan involved.".to_string(),
-        }];
+        return vec![PlanStep::plain(
+            "FullScan",
+            "Schema change (DDL) — no scan involved.",
+        )];
     }
     explain_select(db, &query.select, query)
 }
 
 fn explain_select(db: &DatabaseInner, stmt: &SelectStatement, query: &Query) -> Vec<PlanStep> {
-    let mut steps = Vec::new();
-    steps.push(PlanStep {
-        node: "Scan".to_string(),
-        detail: format!(
-            "Scan {} ({} rows)",
-            stmt.from,
-            row_count_hint(db, &stmt.from)
-        ),
-    });
+    let mut steps = vec![scan_step(db, stmt)];
     append_join_steps(&mut steps, db, stmt);
     append_filter_step(&mut steps, stmt);
     append_group_steps(&mut steps, stmt);
@@ -66,131 +102,152 @@ fn explain_select(db: &DatabaseInner, stmt: &SelectStatement, query: &Query) -> 
     steps
 }
 
+/// Builds the leading scan step: `VectorSearch` when the WHERE carries a NEAR
+/// clause (mirroring core's vector-search node), otherwise `FullScan`.
+fn scan_step(db: &DatabaseInner, stmt: &SelectStatement) -> PlanStep {
+    let rows = row_count_hint(db, &stmt.from);
+    let has_vector = stmt
+        .where_clause
+        .as_ref()
+        .is_some_and(velesdb_core::velesql::Condition::has_vector_search);
+    let (operation, description) = if has_vector {
+        (
+            "VectorSearch",
+            "ANN search using NEAR clause (brute-force in WASM)".to_string(),
+        )
+    } else {
+        ("FullScan", format!("Scan collection '{}'", stmt.from))
+    };
+    PlanStep {
+        operation: operation.to_string(),
+        description,
+        estimated_rows: Some(rows),
+        estimation_method: Some("row count"),
+    }
+}
+
 fn append_join_steps(steps: &mut Vec<PlanStep>, db: &DatabaseInner, stmt: &SelectStatement) {
     for join in &stmt.joins {
         let right_count = row_count_hint(db, &join.table);
-        steps.push(PlanStep {
-            node: "NestedLoopJoin".to_string(),
-            detail: format!(
-                "{:?} JOIN {} ({right_count} rows) ON equality",
-                join.join_type, join.table
+        // `{Type}Join` reproduces core `rest_operation()` for a Join node.
+        steps.push(PlanStep::plain(
+            format!("{:?}Join", join.join_type),
+            format!(
+                "Join with '{}' ({right_count} rows) ON equality",
+                join.table
             ),
-        });
+        ));
     }
 }
 
 fn append_filter_step(steps: &mut Vec<PlanStep>, stmt: &SelectStatement) {
-    if let Some(cond) = &stmt.where_clause {
-        steps.push(PlanStep {
-            node: "Filter".to_string(),
-            detail: format!("WHERE {cond:?}"),
-        });
+    if stmt.where_clause.is_some() {
+        steps.push(PlanStep::plain("Filter", "Apply WHERE clause predicates"));
     }
 }
 
 fn append_group_steps(steps: &mut Vec<PlanStep>, stmt: &SelectStatement) {
     if stmt.group_by.is_some() {
-        steps.push(PlanStep {
-            node: "GroupBy".to_string(),
-            detail: "Hash-group rows by GROUP BY columns.".to_string(),
-        });
+        steps.push(PlanStep::plain(
+            "GroupBy",
+            "Group rows by specified columns",
+        ));
+    }
+    if stmt.is_aggregation_query() {
+        steps.push(PlanStep::plain(
+            "Aggregate",
+            "Compute aggregate functions (COUNT, SUM, etc.)",
+        ));
     }
     if stmt.having.is_some() {
-        steps.push(PlanStep {
-            node: "HavingFilter".to_string(),
-            detail: "Filter groups on HAVING predicate.".to_string(),
-        });
+        // HAVING has no dedicated core plan node; it is a predicate filter over
+        // grouped rows, so it surfaces as a `Filter` within the taxonomy.
+        steps.push(PlanStep::plain(
+            "Filter",
+            "Filter groups on HAVING predicate",
+        ));
     }
 }
 
 fn append_post_scan_steps(steps: &mut Vec<PlanStep>, stmt: &SelectStatement) {
+    if stmt.order_by.is_some() {
+        steps.push(PlanStep::plain("Sort", sort_description(stmt)));
+    }
+    append_pagination_steps(steps, stmt);
+}
+
+/// Sort description, folding the WASM-only DISTINCT/FUSION notes in (neither has
+/// a dedicated core plan node, so they are not standalone operations).
+fn sort_description(stmt: &SelectStatement) -> String {
+    let mut desc = "Sort results by ORDER BY clause".to_string();
     if stmt.fusion_clause.is_some() {
-        steps.push(PlanStep {
-            node: "FusionCombine".to_string(),
-            detail: "Fuse ranked branches (RRF / weighted).".to_string(),
-        });
+        desc.push_str(" (after FUSION combine)");
     }
     if matches!(stmt.distinct, velesdb_core::velesql::DistinctMode::All) {
-        steps.push(PlanStep {
-            node: "Distinct".to_string(),
-            detail: "Deduplicate rows by projected columns.".to_string(),
-        });
+        desc.push_str(" (DISTINCT applied)");
     }
-    if stmt.order_by.is_some() {
-        steps.push(PlanStep {
-            node: "Sort".to_string(),
-            detail: "Sort by ORDER BY keys.".to_string(),
-        });
-    }
-    if stmt.limit.is_some() || stmt.offset.is_some() {
-        steps.push(PlanStep {
-            node: "LimitOffset".to_string(),
-            detail: format!(
-                "LIMIT={} OFFSET={}",
-                stmt.limit.unwrap_or(u64::MAX),
-                stmt.offset.unwrap_or(0),
-            ),
-        });
+    desc
+}
+
+/// Emits `Limit` (folding any OFFSET into its description) or a standalone
+/// `Offset`, mirroring core's pagination folding.
+fn append_pagination_steps(steps: &mut Vec<PlanStep>, stmt: &SelectStatement) {
+    match (stmt.limit, stmt.offset) {
+        (Some(limit), offset) => {
+            let off = offset.unwrap_or(0);
+            let mut step = PlanStep::plain("Limit", format!("Apply LIMIT {limit} OFFSET {off}"));
+            step.estimated_rows = usize::try_from(limit).ok();
+            steps.push(step);
+        }
+        (None, Some(offset)) => {
+            steps.push(PlanStep::plain(
+                "Offset",
+                format!("Skip {offset} rows (OFFSET)"),
+            ));
+        }
+        (None, None) => {}
     }
 }
 
 fn append_compound_steps(steps: &mut Vec<PlanStep>, query: &Query) {
     if let Some(compound) = &query.compound {
         for (op, _) in &compound.operations {
-            steps.push(PlanStep {
-                node: format!("{op:?}"),
-                detail: "Combine with right-hand SELECT.".to_string(),
-            });
+            // Set operations have no dedicated core plan node; surface them as a
+            // Filter-class combine to stay within the taxonomy.
+            steps.push(PlanStep::plain(
+                "Filter",
+                format!("Combine with right-hand SELECT ({op:?})"),
+            ));
         }
     }
 }
 
 fn explain_dml(dml: &velesdb_core::velesql::DmlStatement) -> Vec<PlanStep> {
     use velesdb_core::velesql::DmlStatement;
-    let (label, detail) = match dml {
-        DmlStatement::Insert(s) => (
-            "Insert",
-            format!("INSERT INTO {} {} row(s)", s.table, s.rows.len()),
-        ),
-        DmlStatement::Upsert(s) => (
-            "Upsert",
-            format!("UPSERT INTO {} {} row(s)", s.table, s.rows.len()),
-        ),
-        DmlStatement::Update(s) => ("Update", format!("UPDATE {}", s.table)),
-        DmlStatement::Delete(s) => ("Delete", format!("DELETE FROM {}", s.table)),
-        DmlStatement::InsertEdge(s) => ("InsertEdge", format!("INSERT EDGE INTO {}", s.collection)),
-        DmlStatement::DeleteEdge(s) => ("DeleteEdge", format!("DELETE EDGE FROM {}", s.collection)),
-        DmlStatement::SelectEdges(s) => {
-            ("SelectEdges", format!("SELECT EDGES FROM {}", s.collection))
-        }
-        DmlStatement::InsertNode(s) => ("InsertNode", format!("INSERT NODE INTO {}", s.collection)),
-        _ => ("Dml", "Unsupported DML variant".to_string()),
+    // DML has no read-plan vocabulary in core; surface a single FullScan-class
+    // row whose description names the mutation.
+    let description = match dml {
+        DmlStatement::Insert(s) => format!("INSERT INTO {} {} row(s)", s.table, s.rows.len()),
+        DmlStatement::Upsert(s) => format!("UPSERT INTO {} {} row(s)", s.table, s.rows.len()),
+        DmlStatement::Update(s) => format!("UPDATE {}", s.table),
+        DmlStatement::Delete(s) => format!("DELETE FROM {}", s.table),
+        DmlStatement::InsertEdge(s) => format!("INSERT EDGE INTO {}", s.collection),
+        DmlStatement::DeleteEdge(s) => format!("DELETE EDGE FROM {}", s.collection),
+        DmlStatement::SelectEdges(s) => format!("SELECT EDGES FROM {}", s.collection),
+        DmlStatement::InsertNode(s) => format!("INSERT NODE INTO {}", s.collection),
+        _ => "Unsupported DML variant".to_string(),
     };
-    vec![PlanStep {
-        node: label.to_string(),
-        detail,
-    }]
+    vec![PlanStep::plain("FullScan", description)]
 }
 
 fn explain_match(clause: &velesdb_core::velesql::MatchClause) -> Vec<PlanStep> {
-    vec![
-        PlanStep {
-            node: "GraphPatternMatch".to_string(),
-            detail: format!(
-                "Match {} node pattern(s), {} relationship(s)",
-                clause.patterns.iter().map(|p| p.nodes.len()).sum::<usize>(),
-                clause
-                    .patterns
-                    .iter()
-                    .map(|p| p.relationships.len())
-                    .sum::<usize>()
-            ),
-        },
-        PlanStep {
-            node: "Return".to_string(),
-            detail: format!("Return {} item(s)", clause.return_clause.items.len()),
-        },
-    ]
+    let node_count: usize = clause.patterns.iter().map(|p| p.nodes.len()).sum();
+    let rel_count: usize = clause.patterns.iter().map(|p| p.relationships.len()).sum();
+    vec![PlanStep::plain(
+        "MatchTraversal",
+        format!("Graph traversal: {node_count} node pattern(s), {rel_count} relationship(s), RETURN {} item(s)",
+            clause.return_clause.items.len()),
+    )]
 }
 
 fn row_count_hint(db: &DatabaseInner, name: &str) -> usize {
@@ -200,57 +257,5 @@ fn row_count_hint(db: &DatabaseInner, name: &str) -> usize {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use velesdb_core::velesql::Parser;
-
-    #[test]
-    fn test_explain_plain_select() {
-        let mut db = DatabaseInner::new();
-        db.create_metadata_collection("t").expect("test: create");
-        let q = Parser::parse("SELECT * FROM t WHERE x = 1 LIMIT 5").expect("test: parse");
-        let rows = explain(&db, &q).expect("test: explain");
-        assert!(rows.len() >= 3);
-        assert!(rows[0].data_json_ref().contains("Scan"));
-    }
-
-    #[test]
-    fn test_explain_group_by_has_groupby_step() {
-        let mut db = DatabaseInner::new();
-        db.create_metadata_collection("t").expect("test: create");
-        let q = Parser::parse("SELECT cat, COUNT(*) FROM t GROUP BY cat").expect("test: parse");
-        let rows = explain(&db, &q).expect("test: explain");
-        let joined = rows
-            .iter()
-            .map(crate::velesql_result::QueryResultRow::data_json_ref)
-            .collect::<Vec<_>>()
-            .join("\n");
-        assert!(joined.contains("GroupBy"));
-    }
-
-    #[test]
-    fn test_explain_ddl_has_ddl_node() {
-        let db = DatabaseInner::new();
-        let q = Parser::parse("CREATE COLLECTION v (dimension = 4, metric = 'cosine')")
-            .expect("test: parse");
-        let rows = explain(&db, &q).expect("test: explain");
-        assert_eq!(rows.len(), 1);
-        assert!(rows[0].data_json_ref().contains("DDL"));
-    }
-
-    #[test]
-    fn test_explain_dml_insert_node() {
-        let db = DatabaseInner::new();
-        let q = Parser::parse("INSERT NODE INTO kg (id = 1, payload = '{}')").expect("test: parse");
-        let rows = explain(&db, &q).expect("test: explain");
-        assert!(rows[0].data_json_ref().contains("InsertNode"));
-    }
-
-    #[test]
-    fn test_explain_match_has_pattern_step() {
-        let db = DatabaseInner::new();
-        let q = Parser::parse("MATCH (a:Person) RETURN a LIMIT 5").expect("test: parse");
-        let rows = explain(&db, &q).expect("test: explain");
-        assert!(rows[0].data_json_ref().contains("GraphPatternMatch"));
-    }
-}
+#[path = "velesql_explain_tests.rs"]
+mod tests;

--- a/crates/velesdb-wasm/src/velesql_explain_tests.rs
+++ b/crates/velesdb-wasm/src/velesql_explain_tests.rs
@@ -1,0 +1,160 @@
+//! Native-target tests for the WASM EXPLAIN plan emitter (backlog #23).
+//!
+//! Asserts the emitted `operation` vocabulary is a strict subset of core's
+//! `PlanStep::rest_operation()` taxonomy and that the REST `ExplainStep` wire
+//! keys (`step`, `operation`, `description`, `estimated_rows`) are present.
+
+use super::*;
+use velesdb_core::velesql::Parser;
+
+/// The exact set of `operation` strings core's `PlanStep::rest_operation()`
+/// can emit (`{Type}Join` expands per join type). Mirrored here because the
+/// core `explain` module is `persistence`-gated and unreachable from WASM.
+const CORE_OPERATIONS: &[&str] = &[
+    "VectorSearch",
+    "FullScan",
+    "IndexLookup",
+    "Filter",
+    "InnerJoin",
+    "LeftJoin",
+    "RightJoin",
+    "FullJoin",
+    "GroupBy",
+    "Aggregate",
+    "Sort",
+    "Limit",
+    "Offset",
+    "MatchTraversal",
+];
+
+fn rows_json(db: &DatabaseInner, sql: &str) -> Vec<serde_json::Value> {
+    let q = Parser::parse(sql).expect("test: parse");
+    explain(db, &q)
+        .expect("test: explain")
+        .iter()
+        .map(|r| serde_json::from_str(r.data_json_ref()).expect("test: row json"))
+        .collect()
+}
+
+fn assert_operations_in_taxonomy(rows: &[serde_json::Value]) {
+    for row in rows {
+        let op = row["operation"].as_str().expect("test: operation key");
+        assert!(
+            CORE_OPERATIONS.contains(&op),
+            "operation '{op}' is not in the core rest_operation() taxonomy"
+        );
+        assert!(row["step"].is_number(), "row must carry a step number");
+        assert!(
+            row["description"].is_string(),
+            "row must carry a description"
+        );
+    }
+}
+
+#[test]
+fn select_where_limit_offset_uses_core_vocabulary() {
+    let mut db = DatabaseInner::new();
+    db.create_metadata_collection("t").expect("test: create");
+    let rows = rows_json(&db, "SELECT * FROM t WHERE x = 1 LIMIT 5 OFFSET 2");
+    assert_operations_in_taxonomy(&rows);
+
+    let ops: Vec<&str> = rows
+        .iter()
+        .map(|r| r["operation"].as_str().unwrap())
+        .collect();
+    assert_eq!(ops.first(), Some(&"FullScan"));
+    assert!(ops.contains(&"Filter"));
+    assert!(ops.contains(&"Limit"));
+    // OFFSET is folded into the Limit step (mirrors core); no standalone Offset.
+    assert!(!ops.contains(&"Offset"));
+}
+
+#[test]
+fn scan_row_carries_estimated_rows() {
+    let mut db = DatabaseInner::new();
+    db.create_metadata_collection("t").expect("test: create");
+    let rows = rows_json(&db, "SELECT * FROM t WHERE x = 1 LIMIT 5");
+    let scan = &rows[0];
+    assert_eq!(scan["operation"], "FullScan");
+    assert!(
+        scan["estimated_rows"].is_number(),
+        "scan row must carry estimated_rows, got: {scan}"
+    );
+    assert_eq!(scan["estimation_method"], "row count");
+}
+
+#[test]
+fn near_query_emits_vector_search() {
+    let mut db = DatabaseInner::new();
+    db.create_collection("v", 4, "cosine")
+        .expect("test: create");
+    let rows = rows_json(&db, "SELECT * FROM v WHERE vector NEAR $q LIMIT 3");
+    assert_eq!(rows[0]["operation"], "VectorSearch");
+    assert_operations_in_taxonomy(&rows);
+}
+
+#[test]
+fn group_by_emits_groupby_and_aggregate() {
+    let mut db = DatabaseInner::new();
+    db.create_metadata_collection("t").expect("test: create");
+    let rows = rows_json(&db, "SELECT cat, COUNT(*) FROM t GROUP BY cat");
+    let ops: Vec<&str> = rows
+        .iter()
+        .map(|r| r["operation"].as_str().unwrap())
+        .collect();
+    assert!(ops.contains(&"GroupBy"));
+    assert!(ops.contains(&"Aggregate"));
+    assert_operations_in_taxonomy(&rows);
+}
+
+#[test]
+fn join_emits_typed_join_operation() {
+    let mut db = DatabaseInner::new();
+    db.create_metadata_collection("orders")
+        .expect("test: create");
+    db.create_metadata_collection("products")
+        .expect("test: create");
+    let rows = rows_json(
+        &db,
+        "SELECT * FROM orders JOIN products ON orders.product_id = products.id",
+    );
+    let ops: Vec<&str> = rows
+        .iter()
+        .map(|r| r["operation"].as_str().unwrap())
+        .collect();
+    assert!(
+        ops.contains(&"InnerJoin"),
+        "expected InnerJoin, got: {ops:?}"
+    );
+    assert_operations_in_taxonomy(&rows);
+}
+
+#[test]
+fn match_query_emits_match_traversal() {
+    let db = DatabaseInner::new();
+    let rows = rows_json(&db, "MATCH (a:Person) RETURN a LIMIT 5");
+    assert_eq!(rows[0]["operation"], "MatchTraversal");
+    assert_operations_in_taxonomy(&rows);
+}
+
+#[test]
+fn ddl_stays_within_taxonomy() {
+    let db = DatabaseInner::new();
+    let rows = rows_json(
+        &db,
+        "CREATE COLLECTION v (dimension = 4, metric = 'cosine')",
+    );
+    assert_eq!(rows.len(), 1);
+    assert_operations_in_taxonomy(&rows);
+}
+
+#[test]
+fn dml_insert_node_stays_within_taxonomy() {
+    let db = DatabaseInner::new();
+    let rows = rows_json(&db, "INSERT NODE INTO kg (id = 1, payload = '{}')");
+    assert_operations_in_taxonomy(&rows);
+    assert!(rows[0]["description"]
+        .as_str()
+        .unwrap()
+        .contains("INSERT NODE"));
+}

--- a/crates/velesdb-wasm/src/wasm_error.rs
+++ b/crates/velesdb-wasm/src/wasm_error.rs
@@ -1,0 +1,105 @@
+//! Structured error surface for the WASM bindings (backlog #22).
+//!
+//! Browser clients cannot narrow a bare `JsValue::from_str(message)` string —
+//! [`docs/reference/ERROR_CODES.md`] promises an `error.code` (`VELES-XXX`) on
+//! every client surface, yet the WASM layer historically pre-flattened every
+//! core error to its `Display` string, dropping the machine-readable code.
+//!
+//! [`WasmError`] carries both the human-readable message and the canonical
+//! `velesdb_core::Error::code()` string, and renders a structured JS `Error`
+//! (a real `js_sys::Error` with a non-enumerable `code` property) at the FFI
+//! boundary. The code is single-sourced from core — this module never invents
+//! its own taxonomy.
+
+use velesdb_core::velesql::ParseError;
+use velesdb_core::Error as CoreError;
+
+/// A WASM-boundary error carrying a machine-readable `VELES-XXX` code.
+///
+/// Built from a `velesdb_core::Error` (or a `velesql::ParseError`) so the
+/// `code` is always the core's single source of truth. Holds owned `String`s
+/// for native-target testability; the `wasm32` build converts to a structured
+/// JS `Error` via [`WasmError::into_js_value`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct WasmError {
+    message: String,
+    code: &'static str,
+}
+
+impl WasmError {
+    /// The machine-readable `VELES-XXX` error code (single-sourced from core).
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub(crate) fn code(&self) -> &'static str {
+        self.code
+    }
+
+    /// The human-readable error message.
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub(crate) fn message(&self) -> &str {
+        &self.message
+    }
+
+    /// Renders a structured JS `Error` whose `code` property is the
+    /// `VELES-XXX` code. The property is defined as non-enumerable so it does
+    /// not pollute `JSON.stringify(error)` yet stays readable as `error.code`.
+    #[cfg(target_arch = "wasm32")]
+    pub(crate) fn into_js_value(self) -> wasm_bindgen::JsValue {
+        use wasm_bindgen::JsValue;
+        let err = js_sys::Error::new(&self.message);
+        let descriptor = js_sys::Object::new();
+        // `Object.defineProperty` is a safe wrapper; a failed `set` degrades to
+        // a plain Error rather than panicking, so the results are discarded.
+        let _ = js_sys::Reflect::set(
+            &descriptor,
+            &JsValue::from_str("value"),
+            &JsValue::from_str(self.code),
+        );
+        let _ = js_sys::Reflect::set(
+            &descriptor,
+            &JsValue::from_str("enumerable"),
+            &JsValue::FALSE,
+        );
+        let _ = js_sys::Reflect::set(&descriptor, &JsValue::from_str("writable"), &JsValue::FALSE);
+        js_sys::Object::define_property(&err, &JsValue::from_str("code"), &descriptor);
+        err.into()
+    }
+
+    /// Native-target fallback: `js_sys::Error`/`Object.defineProperty` have no
+    /// JS runtime off `wasm32`, so the error degrades to a flat string carrying
+    /// both the code and the message. The structured `code` is asserted in
+    /// native tests via [`WasmError::code`]; the real JS `Error` is produced
+    /// only in the browser build above.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub(crate) fn into_js_value(self) -> wasm_bindgen::JsValue {
+        wasm_bindgen::JsValue::from_str(&format!("[{}] {}", self.code, self.message))
+    }
+}
+
+impl From<CoreError> for WasmError {
+    fn from(err: CoreError) -> Self {
+        Self {
+            code: err.code(),
+            message: err.to_string(),
+        }
+    }
+}
+
+impl From<ParseError> for WasmError {
+    /// A parse failure surfaces as a query error (`VELES-010`) to match the
+    /// client contract in `ERROR_CODES.md`, while keeping the rich position /
+    /// fragment detail in the message.
+    fn from(err: ParseError) -> Self {
+        let message = format!(
+            "VelesQL syntax error at position {}: {} (near '{}')",
+            err.position, err.message, err.fragment
+        );
+        Self {
+            code: CoreError::from(err).code(),
+            message,
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "wasm_error_tests.rs"]
+mod tests;

--- a/crates/velesdb-wasm/src/wasm_error_tests.rs
+++ b/crates/velesdb-wasm/src/wasm_error_tests.rs
@@ -1,0 +1,61 @@
+//! Native-target tests for the structured WASM error surface (backlog #22).
+//!
+//! `wasm32` rejections cross the FFI boundary as a `js_sys::Error` whose `code`
+//! property carries the `VELES-XXX` code; these native tests inspect the
+//! pre-FFI [`WasmError`] (same data) so the code mapping is locked without a
+//! browser. The values are single-sourced from `velesdb_core::Error::code()`.
+
+use super::WasmError;
+use velesdb_core::velesql::Parser;
+use velesdb_core::Error as CoreError;
+
+#[test]
+fn dimension_mismatch_carries_veles_004() {
+    let err =
+        velesdb_core::validate_dimension_match(768, 384).expect_err("test: 768 != 384 must reject");
+    let wasm: WasmError = err.into();
+    assert_eq!(wasm.code(), "VELES-004");
+    assert!(wasm.message().contains("dimension"));
+}
+
+#[test]
+fn invalid_collection_name_carries_veles_034() {
+    let err = velesdb_core::validate_collection_name("../etc/passwd")
+        .expect_err("test: path-traversal name must reject");
+    let wasm: WasmError = err.into();
+    assert_eq!(wasm.code(), "VELES-034");
+}
+
+#[test]
+fn parse_error_carries_veles_010() {
+    let err = Parser::parse("SELEC * FROM docs").expect_err("test: bad keyword must reject");
+    let wasm: WasmError = err.into();
+    assert_eq!(wasm.code(), "VELES-010");
+    assert!(wasm.message().contains("position"));
+}
+
+#[test]
+fn search_path_dimension_check_carries_veles_004() {
+    // The structured check is the single source feeding every `search*` FFI
+    // method's `validate_dimension`; a 4-d store queried with a 2-d vector
+    // must reject with the machine-readable VELES-004.
+    let err = crate::store_search::validate_dimension_structured(2, 4)
+        .expect_err("test: 2 != 4 must reject");
+    assert_eq!(err.code(), "VELES-004");
+}
+
+#[test]
+fn create_collection_validates_name_with_veles_034() {
+    // The inner create path flattens the structured error to a string, but the
+    // structured code is preserved on the validation single source itself.
+    let err = crate::database::DatabaseInner::validate_name("../escape")
+        .expect_err("test: traversal name must reject");
+    assert_eq!(err.code(), "VELES-034");
+}
+
+#[test]
+fn core_error_code_is_preserved_verbatim() {
+    let err = CoreError::CollectionNotFound("missing".to_string());
+    let wasm: WasmError = err.into();
+    assert_eq!(wasm.code(), "VELES-002");
+}


### PR DESCRIPTION
## Summary

Two WASM parity EPICs bringing the browser surface in line with the documented contracts.

### #22 — WASM errors now carry a machine-readable `code`
Browser rejections were bare `Error(message)` strings, so clients couldn't narrow them — contradicting `ERROR_CODES.md` which promises `error.code` on every client surface. New `wasm_error::WasmError { message, code }` is built `From<velesdb_core::Error>` (`code = err.code()`, **single-sourced** — no WASM-local taxonomy) and `From<ParseError>` (→ `VELES-010`). `into_js_value()` builds a real `js_sys::Error` with a **non-enumerable** `code` property (readable as `error.code`, absent from `JSON.stringify`). Routed the bare-string sites: dimension mismatch → `VELES-004`, invalid collection name → `VELES-034` (no more `e.to_string()` pre-flatten in `validate_name`), `VelesQL.parse` → `VELES-010`.

### #23 — WASM EXPLAIN aligned to the core plan-step vocabulary
The hand-rolled WASM EXPLAIN emitted `{step, node, detail}` rows with a divergent vocabulary (`Scan`/`NestedLoopJoin`/`LimitOffset`/`GraphPatternMatch`). It now emits the **REST `ExplainStep` keys** `{step, operation, description, estimated_rows, estimation_method}` with operations strictly a subset of the core `PlanStepKind`/`rest_operation` taxonomy (`VectorSearch`/`FullScan`/`Filter`/`{Type}Join`/`GroupBy`/`Aggregate`/`Sort`/`Limit`/`Offset`/`MatchTraversal`).

> **Single-source note:** the preferred approach (re-base on `QueryPlan::from_select(&stmt).to_plan_steps()`) is **not reachable from WASM** — the entire `velesql::explain` module (incl. `to_plan_steps`, `PlanStepKind`, the `From<&PlanStep> for ExplainStep` impl) is `#[cfg(feature = "persistence")]`, which the no-persistence WASM build never enables (verified by a wasm32 compile probe). So WASM mirrors the core string taxonomy in-crate. **Recommended follow-up:** expose a no-persistence `to_plan_steps` so WASM/mobile can literally delegate (same gating issue as `projection::project_results`).

## Test plan
- Failing-test-first: `wasm_error_tests.rs` (6 tests, VELES-004/034/010/002) — proven unsatisfiable before the helper; `velesql_explain_tests.rs` (8+ tests) — the old `{step,node,detail}` emitter fails the new key/vocab assertions.
- Gates: `cargo fmt`; `clippy -p velesdb-wasm --all-targets --no-default-features -D warnings -D clippy::pedantic` (exit 0); `cargo check -p velesdb-wasm --no-default-features --target wasm32-unknown-unknown` (clean, real `js_sys::Error` FFI path); `lizard -C 8` (0 new over budget; jscpd: 0 new clones); **`cargo test -p velesdb-wasm` = 585/0**.

CHANGELOG `[Unreleased]` updated. Out of named scope (noted): a few WASM-only structural rejections (`vector_store.rs` raw-buffer/multi-vector guards) have no corresponding core `VELES` code, so they stay descriptive.