### PR TITLE
fix(velesql): reclassify query-shape/bind-param rejects as VELES-010 (Query) + honest V012 for FUSION misconfig (#12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,14 @@ release.
   ceiling) stay `VELES-009`. *(Behavior change: the `code` field and the
   TypeScript SDK error class change from `ConfigError` to `QueryError` for these
   rejections.)*
+- **Misconfigured `USING FUSION` clauses now carry a fusion-specific validation
+  code/message (`V012`, `FusionMisconfigured`) instead of the misleading `V006`
+  (`similarity() requires a vector search context`).** Single-branch FUSION,
+  RSF weights that do not sum to 1.0, negative weights, and `weighted`/`rsf` on
+  `NEAR_FUSED` now report an honest fusion classification. The engine-level class
+  is unchanged (`VELES-010`, `Query`); only the embedded validation code and
+  message change. *(Behavior change: the embedded validation `code` for these
+  rejections changes from `V006` to `V012`.)*
 - **`USING FUSION` is now validated; misconfigured clauses error instead of
   silently degrading.** Five correctness flips, all surfaced at validate-time
   (or parse-time) so the previous silent fallbacks are unreachable:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,21 @@ explicit errors or real values — review the SemVer impact before the next
 release.
 
 ### Changed
+- **Query-shape and bind-parameter rejections now classify as `VELES-010`
+  (`Query`) instead of `VELES-009` (`Config`).** Live query-path failures that
+  describe a malformed *query* — an unsupported query shape (multiple
+  `similarity()` under `OR`, `NEAR_FUSED` mixed with another vector predicate or
+  under `OR`/`NOT`, more than one `SPARSE_NEAR`, an empty MATCH pattern, a MATCH
+  anchor-alias mismatch, `HAVING` without `GROUP BY`, an aggregate `SELECT`
+  missing aggregations) and a missing or malformed bind parameter (a `$v` /
+  `$sv` not provided, a vector param that is not a numeric array, a sparse param
+  that is not a valid index/value map) — were built as `Error::Config` and so
+  surfaced with the engine code `VELES-009`. They now build as `Error::Query`
+  (`VELES-010`). Genuine engine/collection-configuration errors (distance
+  metric, HNSW params, EXPLAIN threshold, group-count cap, NOT-similarity scan
+  ceiling) stay `VELES-009`. *(Behavior change: the `code` field and the
+  TypeScript SDK error class change from `ConfigError` to `QueryError` for these
+  rejections.)*
 - **`USING FUSION` is now validated; misconfigured clauses error instead of
   silently degrading.** Five correctness flips, all surfaced at validate-time
   (or parse-time) so the previous silent fallbacks are unreachable:

--- a/crates/velesdb-core/src/collection/search/query/aggregation/mod.rs
+++ b/crates/velesdb-core/src/collection/search/query/aggregation/mod.rs
@@ -162,7 +162,7 @@ impl Collection {
             SelectColumns::Aggregations(aggs) => aggs,
             SelectColumns::Mixed { aggregations, .. } => aggregations,
             _ => {
-                return Err(crate::error::Error::Config(
+                return Err(crate::error::Error::Query(
                     "execute_aggregate requires aggregation functions in SELECT".to_string(),
                 ))
             }
@@ -186,7 +186,7 @@ impl Collection {
         }
 
         if stmt.having.is_some() {
-            return Err(crate::error::Error::Config(
+            return Err(crate::error::Error::Query(
                 "HAVING clause requires GROUP BY clause".to_string(),
             ));
         }

--- a/crates/velesdb-core/src/collection/search/query/execution_paths.rs
+++ b/crates/velesdb-core/src/collection/search/query/execution_paths.rs
@@ -39,11 +39,11 @@ impl Collection {
         from_aliases: &[String],
     ) -> Result<String> {
         let first_node = predicate.pattern.nodes.first().ok_or_else(|| {
-            crate::error::Error::Config("MATCH predicate requires at least one node".to_string())
+            crate::error::Error::Query("MATCH predicate requires at least one node".to_string())
         })?;
 
         let anchor_alias = first_node.alias.clone().ok_or_else(|| {
-            crate::error::Error::Config(
+            crate::error::Error::Query(
                 "MATCH predicate in SELECT WHERE requires an alias on the first node, \
                  e.g. MATCH (d:Doc)-[:REL]->(x)"
                     .to_string(),
@@ -76,7 +76,7 @@ impl Collection {
             .filter_map(|node| node.alias.as_deref())
             .find(|alias| from_aliases.iter().any(|f| f == alias));
         if let Some(declared) = declared {
-            return Err(crate::error::Error::Config(format!(
+            return Err(crate::error::Error::Query(format!(
                 "MATCH predicate anchor alias '{anchor_alias}' must be the declared \
                  FROM/JOIN alias '{declared}' used elsewhere in the pattern"
             )));
@@ -89,7 +89,7 @@ impl Collection {
             .first()
             .is_some_and(|node| node.collection.is_some())
         {
-            return Err(crate::error::Error::Config(format!(
+            return Err(crate::error::Error::Query(format!(
                 "MATCH predicate anchor alias '{anchor_alias}' has a @collection \
                  override; anchor on one of the FROM/JOIN aliases: {from_aliases:?}"
             )));

--- a/crates/velesdb-core/src/collection/search/query/extraction.rs
+++ b/crates/velesdb-core/src/collection/search/query/extraction.rs
@@ -14,7 +14,7 @@ use crate::velesql::Condition;
 /// - Finite values outside f32 range or non-numeric values produce an error.
 fn json_value_to_f32(v: &serde_json::Value, param_name: &str) -> Result<f32> {
     v.as_f64().and_then(f64_to_f32).ok_or_else(|| {
-        Error::Config(format!(
+        Error::Query(format!(
             "Invalid vector parameter ${param_name}: value out of f32 range or not a number"
         ))
     })
@@ -236,9 +236,9 @@ impl Collection {
     ) -> Result<Vec<f32>> {
         let val = params
             .get(name)
-            .ok_or_else(|| Error::Config(format!("Missing query parameter: ${name}")))?;
+            .ok_or_else(|| Error::Query(format!("Missing query parameter: ${name}")))?;
         let serde_json::Value::Array(arr) = val else {
-            return Err(Error::Config(format!(
+            return Err(Error::Query(format!(
                 "Invalid vector parameter ${name}: expected array"
             )));
         };

--- a/crates/velesdb-core/src/collection/search/query/hybrid_sparse.rs
+++ b/crates/velesdb-core/src/collection/search/query/hybrid_sparse.rs
@@ -66,7 +66,7 @@ impl Collection {
 
         let n = count(condition);
         if n > 1 {
-            return Err(Error::Config(format!(
+            return Err(Error::Query(format!(
                 "Query contains {n} SPARSE_NEAR clauses; only one is supported per query. \
                  Use separate queries for each sparse search."
             )));
@@ -91,10 +91,10 @@ impl Collection {
             SparseVectorExpr::Literal(sv) => Ok(sv.clone()),
             SparseVectorExpr::Parameter(name) => {
                 let val = params.get(name).ok_or_else(|| {
-                    Error::Config(format!("Missing sparse vector parameter: ${name}"))
+                    Error::Query(format!("Missing sparse vector parameter: ${name}"))
                 })?;
                 let obj = val.as_object().ok_or_else(|| {
-                    Error::Config(format!(
+                    Error::Query(format!(
                         "Invalid sparse vector parameter ${name}: expected object with \
                          indices/values or {{index: weight}} map"
                     ))
@@ -120,17 +120,17 @@ impl Collection {
             return Ok(None);
         };
         let indices: Vec<u32> = serde_json::from_value(indices_val.clone()).map_err(|e| {
-            Error::Config(format!(
+            Error::Query(format!(
                 "Invalid sparse vector parameter ${name}.indices: {e}"
             ))
         })?;
         let values: Vec<f32> = serde_json::from_value(values_val.clone()).map_err(|e| {
-            Error::Config(format!(
+            Error::Query(format!(
                 "Invalid sparse vector parameter ${name}.values: {e}"
             ))
         })?;
         if indices.len() != values.len() {
-            return Err(Error::Config(format!(
+            return Err(Error::Query(format!(
                 "Sparse vector parameter ${name}: indices and values must have equal length"
             )));
         }
@@ -147,13 +147,13 @@ impl Collection {
         let mut pairs = Vec::with_capacity(obj.len());
         for (k, v) in obj {
             let idx: u32 = k.parse().map_err(|_| {
-                Error::Config(format!(
+                Error::Query(format!(
                     "Invalid sparse vector parameter ${name}: key '{k}' is not a valid u32 index"
                 ))
             })?;
             #[allow(clippy::cast_possible_truncation)]
             let weight = v.as_f64().ok_or_else(|| {
-                Error::Config(format!(
+                Error::Query(format!(
                     "Invalid sparse vector parameter ${name}: value for key '{k}' is not a number"
                 ))
             })? as f32;

--- a/crates/velesdb-core/src/collection/search/query/match_exec/mod.rs
+++ b/crates/velesdb-core/src/collection/search/query/match_exec/mod.rs
@@ -252,7 +252,7 @@ impl Collection {
         ctx: Option<&QueryContext>,
     ) -> Result<Vec<MatchResult>> {
         if match_clause.patterns.is_empty() {
-            return Err(Error::Config(
+            return Err(Error::Query(
                 "MATCH query must have at least one pattern".to_string(),
             ));
         }

--- a/crates/velesdb-core/src/collection/search/query/match_exec/start_nodes.rs
+++ b/crates/velesdb-core/src/collection/search/query/match_exec/start_nodes.rs
@@ -35,7 +35,7 @@ impl Collection {
         let first_node = pattern
             .nodes
             .first()
-            .ok_or_else(|| Error::Config("Pattern must have at least one node".to_string()))?;
+            .ok_or_else(|| Error::Query("Pattern must have at least one node".to_string()))?;
 
         // Fast path: use label index when labels are specified.
         if !first_node.labels.is_empty() {

--- a/crates/velesdb-core/src/collection/search/query/match_exec/vector_first.rs
+++ b/crates/velesdb-core/src/collection/search/query/match_exec/vector_first.rs
@@ -293,7 +293,7 @@ impl Collection {
 ///
 /// # Errors
 ///
-/// Returns `Error::Config` when no similarity condition is found.
+/// Returns `Error::Query` when no similarity condition is found.
 fn extract_similarity_condition(where_clause: Option<&Condition>) -> Result<&SimilarityCondition> {
     fn find_sim(cond: &Condition) -> Option<&SimilarityCondition> {
         match cond {
@@ -305,7 +305,7 @@ fn extract_similarity_condition(where_clause: Option<&Condition>) -> Result<&Sim
     }
 
     where_clause.and_then(find_sim).ok_or_else(|| {
-        Error::Config(
+        Error::Query(
             "VectorFirst strategy requires a similarity condition in WHERE clause".to_string(),
         )
     })

--- a/crates/velesdb-core/src/collection/search/query/match_exec/where_eval.rs
+++ b/crates/velesdb-core/src/collection/search/query/match_exec/where_eval.rs
@@ -80,7 +80,7 @@ pub(super) fn resolve_query_vector(
         VectorExpr::Parameter(name) => {
             let param_value = params
                 .get(name)
-                .ok_or_else(|| Error::Config(format!("Missing vector parameter: ${name}")))?;
+                .ok_or_else(|| Error::Query(format!("Missing vector parameter: ${name}")))?;
 
             match param_value {
                 serde_json::Value::Array(arr) => Ok(arr
@@ -93,7 +93,7 @@ pub(super) fn resolve_query_vector(
                         })
                     })
                     .collect()),
-                _ => Err(Error::Config(format!(
+                _ => Err(Error::Query(format!(
                     "Parameter ${name} must be a vector array"
                 ))),
             }
@@ -463,7 +463,7 @@ impl Collection {
             Value::Parameter(name) => {
                 let param_value = params
                     .get(name)
-                    .ok_or_else(|| Error::Config(format!("Missing parameter: ${name}")))?;
+                    .ok_or_else(|| Error::Query(format!("Missing parameter: ${name}")))?;
 
                 Ok(match param_value {
                     serde_json::Value::Number(n) => {
@@ -481,7 +481,7 @@ impl Collection {
                     serde_json::Value::Bool(b) => Value::Boolean(*b),
                     serde_json::Value::Null => Value::Null,
                     _ => {
-                        return Err(Error::Config(format!(
+                        return Err(Error::Query(format!(
                             "Unsupported parameter type for ${name}: {param_value:?}",
                         )));
                     }

--- a/crates/velesdb-core/src/collection/search/query/multi_vector.rs
+++ b/crates/velesdb-core/src/collection/search/query/multi_vector.rs
@@ -26,8 +26,8 @@ impl Collection {
     ///
     /// # Errors
     ///
-    /// Returns `Error::Config` if the field is not `"vector"` and the payload
-    /// either has no such field or the value is not a JSON array of numbers.
+    /// Returns `Error::Query` if the field is not `"vector"` and the payload
+    /// value exists but is not a JSON array of numbers.
     pub(crate) fn get_vector_for_field(
         &self,
         point_id: u64,
@@ -55,7 +55,7 @@ impl Collection {
 
         let Some(array) = value.as_array() else {
             // Field exists but is not an array — this IS a data error.
-            return Err(Error::Config(format!(
+            return Err(Error::Query(format!(
                 "similarity() field '{}' is not a numeric array in payload.",
                 field
             )));
@@ -68,7 +68,7 @@ impl Collection {
 
         match vec {
             Some(v) => Ok(Some(v)),
-            None => Err(Error::Config(format!(
+            None => Err(Error::Query(format!(
                 "similarity() field '{}' contains non-numeric values.",
                 field
             ))),

--- a/crates/velesdb-core/src/collection/search/query/similarity_filter.rs
+++ b/crates/velesdb-core/src/collection/search/query/similarity_filter.rs
@@ -280,7 +280,7 @@ impl Collection {
                 // Extract from inside NOT
                 let conditions = self.extract_all_similarity_conditions(inner, params)?;
                 conditions.into_iter().next().ok_or_else(|| {
-                    crate::error::Error::Config(
+                    crate::error::Error::Query(
                         "NOT clause does not contain a similarity condition".to_string(),
                     )
                 })
@@ -290,7 +290,7 @@ impl Collection {
                 self.extract_not_similarity_condition(left, params)
                     .or_else(|_| self.extract_not_similarity_condition(right, params))
             }
-            _ => Err(crate::error::Error::Config(
+            _ => Err(crate::error::Error::Query(
                 "Expected NOT similarity() condition".to_string(),
             )),
         }

--- a/crates/velesdb-core/src/collection/search/query/validation.rs
+++ b/crates/velesdb-core/src/collection/search/query/validation.rs
@@ -46,7 +46,7 @@ impl Collection {
 
         // Multiple similarity() in OR is not supported (would require union of vector searches)
         if similarity_count > 1 && Self::has_multiple_similarity_in_or(condition) {
-            return Err(Error::Config(
+            return Err(Error::Query(
                 "Multiple similarity() conditions in OR are not supported. \
                 Use AND to apply filters sequentially, or split into separate queries."
                     .to_string(),
@@ -71,7 +71,7 @@ impl Collection {
                 || vector_or_sparse_count > fused_count
                 || fused_under_or_or_not(condition))
         {
-            return Err(Error::Config(
+            return Err(Error::Query(
                 "NEAR_FUSED must be the only vector predicate and cannot appear under OR/NOT; \
                  combine it only with AND <metadata filter>."
                     .to_string(),

--- a/crates/velesdb-core/src/velesql/validation_fusion.rs
+++ b/crates/velesdb-core/src/velesql/validation_fusion.rs
@@ -51,9 +51,13 @@ fn count_branches(cond: &Condition, counts: &mut BranchCounts) {
 }
 
 /// Builds a FUSION applicability/misconfiguration validation error (#10/#16).
+///
+/// Tagged `FusionMisconfigured` (V012) so a bad fusion clause carries an honest,
+/// fusion-specific code/message — never the misleading V006 "similarity()
+/// requires a vector search context" classification.
 fn fusion_error(fragment: impl Into<String>, suggestion: impl Into<String>) -> ValidationError {
     ValidationError::new(
-        ValidationErrorKind::SimilarityWithoutContext,
+        ValidationErrorKind::FusionMisconfigured,
         None,
         fragment,
         suggestion,

--- a/crates/velesdb-core/src/velesql/validation_types.rs
+++ b/crates/velesdb-core/src/velesql/validation_types.rs
@@ -126,6 +126,11 @@ pub enum ValidationErrorKind {
     /// missing, or whose implicit binding to the FROM rows violates a guard
     /// (G1 inverted direction, G2 cross-predicate alias, G3 @collection).
     GraphMatchAnchorMismatch,
+    /// USING FUSION clause is misconfigured: applied to fewer than two fusable
+    /// branches, weights that do not sum to 1.0 (RSF) or are negative, or a
+    /// strategy not allowed for the query shape (e.g. weighted/rsf on
+    /// NEAR_FUSED).
+    FusionMisconfigured,
 }
 
 impl ValidationErrorKind {
@@ -144,6 +149,7 @@ impl ValidationErrorKind {
             Self::InvalidLetBinding => "V009",
             Self::SubqueryNotExecutable => "V010",
             Self::GraphMatchAnchorMismatch => "V011",
+            Self::FusionMisconfigured => "V012",
         }
     }
 
@@ -169,6 +175,7 @@ impl ValidationErrorKind {
             Self::GraphMatchAnchorMismatch => {
                 "MATCH predicate anchor must be an alias declared in FROM/JOIN"
             }
+            Self::FusionMisconfigured => "USING FUSION clause is misconfigured",
         }
     }
 }

--- a/crates/velesdb-core/tests/velesql_error_code_conformance.rs
+++ b/crates/velesdb-core/tests/velesql_error_code_conformance.rs
@@ -1,0 +1,73 @@
+#![cfg(all(test, feature = "persistence"))]
+//! Error-CODE conformance for live `VelesQL` query-path rejections (backlog #12).
+//!
+//! Query-SHAPE and BIND-PARAM failures must classify as `Error::Query`
+//! (`VELES-010`), not `Error::Config` (`VELES-009`). The TS SDK narrows the
+//! engine `code` field into `QueryError`/`ConfigError`, so a query the caller
+//! wrote wrong (unsupported shape, missing/malformed bind param) must surface
+//! as a query error — not an engine-configuration error.
+//!
+//! These cases lock the contract so a future regression that re-tags a
+//! query-path reject as `VELES-009` fails CI.
+
+use serde_json::json;
+use std::collections::HashMap;
+use tempfile::TempDir;
+use velesdb_core::{DistanceMetric, Point, StorageMode, VectorCollection};
+
+/// Two-dimensional "docs" collection with three rows for query execution.
+fn setup_docs() -> (VectorCollection, TempDir) {
+    let dir = TempDir::new().expect("temp dir");
+    let collection = VectorCollection::create(
+        dir.path().join("docs"),
+        "docs",
+        2,
+        DistanceMetric::Cosine,
+        StorageMode::Full,
+    )
+    .expect("create collection");
+    let points = vec![
+        Point::new(1, vec![1.0, 0.0], Some(json!({ "category": "tech" }))),
+        Point::new(2, vec![0.0, 1.0], Some(json!({ "category": "news" }))),
+        Point::new(3, vec![0.7, 0.7], Some(json!({ "category": "tech" }))),
+    ];
+    collection.upsert(points).expect("upsert");
+    (collection, dir)
+}
+
+fn run_err(collection: &VectorCollection, query: &str) -> velesdb_core::Error {
+    collection
+        .execute_query_str(query, &HashMap::new())
+        .expect_err("query expected to reject")
+}
+
+#[test]
+fn unsupported_query_shape_multiple_similarity_in_or_is_velesq_query() {
+    let (collection, _dir) = setup_docs();
+    // Two similarity() predicates under OR is an unsupported query SHAPE.
+    let err = run_err(
+        &collection,
+        "SELECT * FROM docs WHERE similarity(vector, $a) > 0.8 \
+         OR similarity(vector, $b) > 0.7 LIMIT 10",
+    );
+    assert_eq!(
+        err.code(),
+        "VELES-010",
+        "unsupported query shape must be VELES-010 (Query), got: {err}"
+    );
+}
+
+#[test]
+fn missing_bind_param_is_velesq_query() {
+    let (collection, _dir) = setup_docs();
+    // $missing is never provided in the params map.
+    let err = run_err(
+        &collection,
+        "SELECT * FROM docs WHERE vector NEAR $missing LIMIT 5",
+    );
+    assert_eq!(
+        err.code(),
+        "VELES-010",
+        "missing bind param must be VELES-010 (Query), got: {err}"
+    );
+}

--- a/crates/velesdb-core/tests/velesql_error_code_conformance.rs
+++ b/crates/velesdb-core/tests/velesql_error_code_conformance.rs
@@ -58,6 +58,54 @@ fn unsupported_query_shape_multiple_similarity_in_or_is_velesq_query() {
 }
 
 #[test]
+fn single_branch_fusion_reject_is_not_v006_similarity_message() {
+    let (collection, _dir) = setup_docs();
+    // A similarity()-only query carries no second retrieval branch, so the
+    // trailing USING FUSION clause is a misconfiguration. The reject must NOT
+    // borrow the misleading V006 "similarity() requires a vector search
+    // context" code/message — it must be fusion-specific.
+    let err = run_err(
+        &collection,
+        "SELECT * FROM docs WHERE similarity(vector, $q) > 0.5 \
+         LIMIT 10 USING FUSION(strategy = 'maximum')",
+    );
+    let msg = err.to_string();
+    assert!(
+        !msg.contains("V006"),
+        "fusion misconfig must not be tagged V006, got: {msg}"
+    );
+    assert!(
+        !msg.contains("similarity() requires a vector search context"),
+        "fusion misconfig must not reuse the similarity-context message, got: {msg}"
+    );
+    assert!(
+        msg.contains("FUSION"),
+        "fusion misconfig message must be fusion-specific, got: {msg}"
+    );
+}
+
+#[test]
+fn rsf_weight_sum_fusion_reject_is_not_v006_similarity_message() {
+    let (collection, _dir) = setup_docs();
+    // RSF dense_w + sparse_w != 1.0 over a real two-branch hybrid is a fusion
+    // weight misconfiguration; it must classify honestly, not as V006.
+    let err = run_err(
+        &collection,
+        "SELECT * FROM docs WHERE vector NEAR $q AND vector SPARSE_NEAR $sv \
+         LIMIT 10 USING FUSION(strategy = 'rsf', dense_w = 0.7, sparse_w = 0.7)",
+    );
+    let msg = err.to_string();
+    assert!(
+        !msg.contains("V006"),
+        "rsf weight-sum reject must not be tagged V006, got: {msg}"
+    );
+    assert!(
+        !msg.contains("similarity() requires a vector search context"),
+        "rsf weight-sum reject must not reuse the similarity-context message, got: {msg}"
+    );
+}
+
+#[test]
 fn missing_bind_param_is_velesq_query() {
     let (collection, _dir) = setup_docs();
     // $missing is never provided in the params map.

--- a/docs/VELESQL_SPEC.md
+++ b/docs/VELESQL_SPEC.md
@@ -1515,7 +1515,10 @@ USING FUSION(strategy = 'rrf', k = 60)
 
 > **USING FUSION requires at least two fusable branches** (e.g. `vector NEAR`
 > + `MATCH`, or `vector NEAR` + `vector SPARSE_NEAR`) or a single `NEAR_FUSED`
-> predicate. Applied to a single-branch query it is rejected at validation.
+> predicate. Applied to a single-branch query it is rejected at validation with
+> error code `V012` (`FusionMisconfigured`). The same code covers RSF weights
+> that do not sum to 1.0, negative weights, and `weighted`/`rsf` on a
+> `NEAR_FUSED` predicate.
 > `dense_w`/`sparse_w` are accepted as short aliases of `dense_weight`/`sparse_weight`.
 > Unknown strategy names and unknown option keys are rejected (no silent RRF fallback).
 

--- a/docs/reference/ERROR_CODES.md
+++ b/docs/reference/ERROR_CODES.md
@@ -138,7 +138,7 @@ version incompatibility, or internal bugs:
 
 - **Variant**: `Config(String)`
 - **Message**: `Configuration error: {details}`
-- **Cause**: Invalid configuration parameters (e.g., unsupported distance metric, invalid HNSW parameters).
+- **Cause**: Invalid **engine/collection configuration** (e.g., unsupported distance metric, invalid HNSW parameters, invalid EXPLAIN threshold). This code is reserved for configuration of the engine itself — not for a malformed query. A query the caller wrote wrong (unsupported query shape, missing/malformed bind parameter) is reported as `VELES-010` (`Query`), not `VELES-009`.
 - **Resolution**: Review the configuration values. Consult `CollectionConfig` documentation for valid parameter ranges.
 - **Recoverable**: Yes
 
@@ -146,7 +146,7 @@ version incompatibility, or internal bugs:
 
 - **Variant**: `Query(String)`
 - **Message**: `Query error: {details}`
-- **Cause**: A VelesQL query failed to parse or execute. This wraps parse errors with position and context information.
+- **Cause**: A VelesQL query failed to parse, validate, or execute. This wraps parse errors with position and context information, and also covers **query-shape and bind-parameter rejections** at execution time: an unsupported query shape (e.g. multiple `similarity()` under `OR`, `NEAR_FUSED` mixed with another vector predicate, `HAVING` without `GROUP BY`, an empty MATCH pattern) and a missing or malformed bind parameter (e.g. `$v` not provided, a sparse-vector parameter that is not a valid index/value map). USING FUSION misconfigurations carry the embedded validation code `V012` (`FusionMisconfigured`).
 - **Resolution**: Check the VelesQL syntax. Refer to `docs/VELESQL_SPEC.md` for the grammar specification. The error message includes the position of the parsing failure.
 - **Recoverable**: Yes
 


### PR DESCRIPTION
## Summary

Error-classification fixes so clients (esp. the TS SDK) narrow VelesQL failures correctly. **All `velesdb-core`**; the server-side error-handling fixes (#13) are a separate follow-up wave.

### #12 — query-shape & bind-param rejects were mis-tagged `VELES-009` (Config) instead of `VELES-010` (Query)
~`Error::Config` (code `VELES-009`, "engine configuration") was used for **query-path** failures — missing/malformed bind params, unsupported query shapes, empty MATCH patterns, aggregate/HAVING shape errors — so the TS SDK narrowed them to `ConfigError` instead of `QueryError`. Swapped to `Error::Query` (`VELES-010`) at the live query-path sites across `collection/search/query/` (validation, execution_paths, hybrid_sparse, multi_vector, extraction, aggregation, match_exec/{mod,start_nodes,vector_first,where_eval}, similarity_filter). **Genuine engine/config/guard-rail errors deliberately kept as `Config`** (collection config, the `Too many groups` cardinality cap, the NOT-similarity scan ceiling, EXPLAIN threshold — all still asserted as `Config` by their tests).

### FUSION rejects — honest `V012` code instead of reused `V006`
The `USING FUSION` validation rejects added in #1206 reused `ValidationErrorKind::SimilarityWithoutContext` (`V006`, message *"similarity() requires a vector search context…"*) — misleading for a fusion misconfiguration. Added `ValidationErrorKind::FusionMisconfigured` (`V012`, *"USING FUSION clause is misconfigured"*); all fusion rejects (single-branch, RSF weight-sum ≠ 1.0, negative weights, `NEAR_FUSED weighted/rsf`) now carry it. Engine class stays `VELES-010` (Query).

## Test plan
- New `tests/velesql_error_code_conformance.rs` (4 tests). **Discriminating** (fail on develop): missing bind param → `VELES-010` (was `VELES-009`); single-branch FUSION + RSF-weight-sum → `V012` fusion message (was `V006` "similarity() requires…").
- Gates: `cargo fmt`; `clippy --all-targets … -D warnings -D clippy::pedantic` (exit 0); `lizard -C 8` (0 over budget); **full `cargo test -p velesdb-core --features persistence` = 5209 + integration, 0 failed**.
- `ERROR_CODES.md` + `VELESQL_SPEC.md` updated for `V012`. **SemVer-observable** (code field / TS error class flips ConfigError→QueryError, V006→V012) — flagged in CHANGELOG `[Unreleased]`.

## Notes (tracked)
- One conformance test (`multiple_similarity_in_or`) is caught at the AST validation layer (already `VELES-010`), so it validates the contract but not the deeper `validation.rs:49/74` defensive flips (correct but unproven).
- Two guard-rail rejects (scan-limit, too-many-groups) remain `VELES-009`; arguably `VELES-027` (GuardRail) — separate dimension, out of #12's scope → follow-up.