### PR TITLE
feat(python): ordered MATCH + honest EXPLAIN + fusion in SearchOptions + set_auto_reindex (#1/#14/#24/#27)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,8 +127,33 @@ release.
   `"VELES-010"`. The code is single-sourced from `velesdb_core::Error::code()`
   (no WASM-local taxonomy); the property is non-enumerable so it does not appear
   in `JSON.stringify(error)`. *(Additive: the `message` text is unchanged.)*
+- **Python `SearchOptions` accepts a `fusion=` strategy for typed hybrid
+  dense+sparse search.** A new optional `fusion: Optional[FusionStrategy]`
+  field (plus a `with_fusion()` builder) is threaded through `search_request`
+  so RSF / weighted hybrid fusion is reachable without raw `USING FUSION` SQL.
+  When omitted (or `None`) the search keeps the historical Reciprocal Rank
+  Fusion (RRF, k=60), so behavior is unchanged for existing callers.
+  *(Additive: new optional field/builder; default preserved.)*
+- **Python `Database.set_auto_reindex(name, enabled)` toggles auto-reindex at
+  runtime.** Routes a validated `ALTER COLLECTION <name> SET (auto_reindex = …)`
+  through the VelesQL DDL executor (persisted), the typed counterpart to running
+  the raw statement via `execute_query`. `Collection.info()` now also reports the
+  current `auto_reindex` flag. *(Additive.)*
 
 ### Fixed
+- **Python `match_query` honors `RETURN ... ORDER BY` and the post-sort
+  `LIMIT`.** The Python bindings now route a non-similarity `MATCH` through the
+  core `match_query_ordered` cost-based planner (the SQL `/query` single source
+  of truth) instead of a bare traversal entry point, so `ORDER BY` + post-sort
+  `LIMIT` rank identically to the SQL path on both `Collection` and
+  `GraphCollection`.
+- **Python `explain()` reports calibrated SELECT plans, real MATCH strategies,
+  and rejects invalid queries.** `Collection.explain` now threads the
+  collection's live indexed-field set and statistics through the core planner,
+  so a SELECT whose `WHERE` targets an indexed field emits an `IndexLookup` node
+  with a calibrated cost, and a MATCH reports a real traversal strategy instead
+  of a bare/zeroed plan. Semantically invalid queries (e.g. a `WHERE` subquery)
+  now raise `ValueError` instead of silently building a plan.
 - **EXPLAIN of a MATCH query now shows the graph traversal and its strategy.**
   `EXPLAIN`/`EXPLAIN ANALYZE` of a MATCH query (REST `/query/explain`, core
   `Database`/`Collection` explain paths) previously emitted a bare empty

--- a/crates/velesdb-python/python/velesdb/__init__.pyi
+++ b/crates/velesdb-python/python/velesdb/__init__.pyi
@@ -194,6 +194,9 @@ class SearchOptions:
             (``conditions``) / ``not`` (``condition``) for composition.
         sparse_index_name: Named sparse index to query.
         include_vectors: Include raw vectors in results (default: False).
+        fusion: Optional :class:`FusionStrategy` applied to hybrid dense+sparse
+            search (both ``vector`` and ``sparse_vector`` set). Defaults to
+            RRF (k=60); has no effect on dense-only or sparse-only searches.
 
     Example:
         >>> cond = {"type": "eq", "field": "lang", "value": "en"}
@@ -207,6 +210,7 @@ class SearchOptions:
     filter: Optional[Dict[str, Any]]
     sparse_index_name: Optional[str]
     include_vectors: bool
+    fusion: Optional["FusionStrategy"]
 
     def __init__(
         self,
@@ -217,6 +221,7 @@ class SearchOptions:
         filter: Optional[Dict[str, Any]] = None,
         sparse_index_name: Optional[str] = None,
         include_vectors: bool = False,
+        fusion: Optional["FusionStrategy"] = None,
     ) -> None: ...
     def with_vector(
         self, vector: Optional[Union[List[float], "np.ndarray"]]
@@ -228,6 +233,7 @@ class SearchOptions:
     def with_filter(self, filter: Optional[Dict[str, Any]]) -> "SearchOptions": ...
     def with_sparse_index_name(self, name: Optional[str]) -> "SearchOptions": ...
     def with_include_vectors(self, include: bool) -> "SearchOptions": ...
+    def with_fusion(self, fusion: Optional["FusionStrategy"]) -> "SearchOptions": ...
 
 
 class SearchResult:
@@ -273,7 +279,7 @@ class Collection:
 
         Returns:
             Dict with name, dimension, metric, storage_mode, point_count,
-            and metadata_only keys.
+            metadata_only, and auto_reindex keys.
         """
         ...
 
@@ -737,11 +743,21 @@ class Collection:
         vector: Optional[Union[List[float], "np.ndarray"]] = None,
         threshold: float = 0.0,
     ) -> List[Dict[str, Any]]:
-        """Execute a MATCH graph query."""
+        """Execute a MATCH graph query.
+
+        ``RETURN ... ORDER BY`` and a post-sort ``LIMIT`` are honored,
+        ranking results identically to the SQL ``execute_query`` path.
+        """
         ...
 
     def explain(self, query_str: str) -> Dict[str, Any]:
-        """Return execution plan for a VelesQL query."""
+        """Return execution plan for a VelesQL query.
+
+        The plan is calibrated with this collection's indexed fields and
+        statistics: a SELECT whose WHERE targets an indexed field shows an
+        ``IndexLookup`` node and a MATCH reports a real traversal strategy.
+        Raises ``ValueError`` for a semantically invalid query.
+        """
         ...
 
     def explain_analyze(
@@ -1069,12 +1085,41 @@ class Database:
     ) -> List[Dict[str, Any]]:
         """Execute a VelesQL query string (SELECT, DDL, DML).
 
+        Supported statements include SELECT, CREATE/DROP COLLECTION,
+        CREATE/DROP INDEX, INSERT/DELETE (rows and edges), and
+        ``ALTER COLLECTION <name> SET (auto_reindex = true|false)``
+        (see :meth:`set_auto_reindex` for a typed helper).
+
+        Hybrid fusion note:
+            Typed hybrid dense+sparse search (``search_request`` with both
+            ``vector`` and ``sparse_vector``) uses Reciprocal Rank Fusion
+            (RRF, k=60) by default. Pass a :class:`FusionStrategy` via
+            ``SearchOptions(fusion=...)`` / ``with_fusion(...)``, or run raw
+            VelesQL with a ``USING FUSION(...)`` clause here, to select another
+            strategy.
+
         Args:
             sql: VelesQL query string.
             params: Optional parameter bindings (e.g., {"$v": [0.1, 0.2]}).
 
         Returns:
             List of result dicts for SELECT queries, empty list for DDL/DML.
+        """
+        ...
+
+    def set_auto_reindex(self, name: str, enabled: bool) -> None:
+        """Toggle automatic re-indexing on a collection at runtime.
+
+        Routes a validated ``ALTER COLLECTION <name> SET (auto_reindex = …)``
+        statement through the VelesQL DDL executor and persists the change.
+
+        Args:
+            name: Collection name.
+            enabled: True to enable auto-reindex, False to disable it.
+
+        Raises:
+            ValueError: If the collection name fails to parse.
+            RuntimeError: If the collection does not exist or the change fails.
         """
         ...
 
@@ -1562,6 +1607,9 @@ class PyGraphCollection:
     ) -> List[Dict[str, Any]]:
         """Execute a MATCH graph traversal query.
 
+        ``RETURN ... ORDER BY`` and a post-sort ``LIMIT`` are honored,
+        ranking results identically to the SQL ``query`` path.
+
         Args:
             query_str: VelesQL MATCH query (Cypher-like syntax)
             params: Query parameters
@@ -1575,6 +1623,9 @@ class PyGraphCollection:
 
     def explain(self, query_str: str) -> Dict[str, Any]:
         """Return query execution plan (EXPLAIN).
+
+        MATCH queries report a real traversal strategy; a semantically
+        invalid query raises ``ValueError``.
 
         Args:
             query_str: VelesQL query string

--- a/crates/velesdb-python/src/collection/mod.rs
+++ b/crates/velesdb-python/src/collection/mod.rs
@@ -117,19 +117,23 @@ impl Collection {
         top_k: usize,
         filter: Option<&Filter>,
         sparse_index_name: Option<&str>,
+        fusion: Option<&CoreFusionStrategy>,
     ) -> PyResult<Vec<SearchResult>> {
         use crate::collection_helpers::core_err;
         use pyo3::exceptions::PyValueError;
 
         let index_name =
             sparse_index_name.unwrap_or(velesdb_core::sparse_index::DEFAULT_SPARSE_INDEX_NAME);
+        // Hybrid dense+sparse honors a caller-supplied fusion strategy
+        // (backlog #24); other paths ignore it. Default preserves RRF k=60.
+        let fusion = fusion.unwrap_or(&DEFAULT_FUSION);
 
         match (dense, sparse, filter) {
             (Some(d), Some(s), Some(f)) => {
                 // No native hybrid_sparse_search_with_filter — run unfiltered then post-filter
                 let mut results = self
                     .inner
-                    .hybrid_sparse_search(&d, &s, top_k, index_name, &DEFAULT_FUSION)
+                    .hybrid_sparse_search(&d, &s, top_k, index_name, fusion)
                     .map_err(core_err)?;
                 results.retain(|r| {
                     r.point
@@ -141,7 +145,7 @@ impl Collection {
             }
             (Some(d), Some(s), None) => self
                 .inner
-                .hybrid_sparse_search(&d, &s, top_k, index_name, &DEFAULT_FUSION)
+                .hybrid_sparse_search(&d, &s, top_k, index_name, fusion)
                 .map_err(core_err),
             (Some(d), None, Some(f)) => self
                 .inner

--- a/crates/velesdb-python/src/collection/mod.rs
+++ b/crates/velesdb-python/src/collection/mod.rs
@@ -177,7 +177,8 @@ impl Collection {
     /// Get collection configuration info.
     ///
     /// Returns:
-    ///     Dict with name, dimension, metric, storage_mode, point_count, and metadata_only
+    ///     Dict with name, dimension, metric, storage_mode, point_count,
+    ///     metadata_only, and auto_reindex
     fn info(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let config = self.inner.config();
         let dict = PyDict::new(py);
@@ -193,6 +194,11 @@ impl Collection {
         );
         let _ = dict.set_item(PyString::intern(py, "point_count"), config.point_count);
         let _ = dict.set_item(PyString::intern(py, "metadata_only"), config.metadata_only);
+        let auto_reindex = config
+            .auto_reindex_config
+            .as_ref()
+            .is_some_and(|c| c.enabled);
+        let _ = dict.set_item(PyString::intern(py, "auto_reindex"), auto_reindex);
         Ok(dict.into_any().unbind())
     }
 

--- a/crates/velesdb-python/src/collection/query.rs
+++ b/crates/velesdb-python/src/collection/query.rs
@@ -45,18 +45,30 @@ pub(crate) fn parse_velesql(query_str: &str) -> PyResult<velesdb_core::velesql::
     })
 }
 
-/// Builds an EXPLAIN dict from a parsed VelesQL query.
+/// Validates a parsed VelesQL query, mapping validation failures to a typed
+/// `ValueError` so EXPLAIN rejects semantically-invalid queries instead of
+/// silently building a plan (mirrors `Database::explain_analyze_query`).
+pub(crate) fn validate_query(parsed: &velesdb_core::velesql::Query) -> PyResult<()> {
+    velesdb_core::velesql::QueryValidator::validate(parsed)
+        .map_err(|e| PyValueError::new_err(e.to_string()))
+}
+
+/// Builds an EXPLAIN dict from a parsed VelesQL query, threading the live
+/// indexed-field set and calibrated collection statistics so the plan emits
+/// `IndexLookup` nodes and a calibrated cost for SELECT, and a real traversal
+/// strategy for MATCH (backlog #14) — mirroring `Database::explain_query`.
 pub(crate) fn build_explain_dict(
     py: Python<'_>,
     parsed: &velesdb_core::velesql::Query,
+    indexed_fields: &std::collections::HashSet<String>,
+    stats: Option<&velesdb_core::collection::stats::CollectionStats>,
 ) -> Py<PyAny> {
-    let plan = if let Some(match_clause) = parsed.match_clause.as_ref() {
-        let stats =
-            velesdb_core::collection::search::query::match_planner::CollectionStats::default();
-        velesdb_core::velesql::QueryPlan::from_match(match_clause, &stats)
-    } else {
-        velesdb_core::velesql::QueryPlan::from_select(&parsed.select)
-    };
+    let plan = velesdb_core::velesql::QueryPlan::from_query_with_all_stats(
+        parsed,
+        indexed_fields,
+        stats,
+        None,
+    );
 
     let dict = PyDict::new(py);
     let _ = dict.set_item(
@@ -337,16 +349,27 @@ impl Collection {
             if let Some(ref qv) = qv {
                 inner.execute_match_with_similarity(&mc, qv, threshold, &p)
             } else {
-                inner.execute_match(&mc, &p)
+                // Route through the cost-based planner so RETURN ORDER BY,
+                // deterministic tie-break, and post-sort LIMIT match the SQL
+                // /query path exactly (backlog #1).
+                inner.match_query_ordered(&mc, &p)
             }
         })
     }
 
     /// Return query execution plan (EXPLAIN).
+    ///
+    /// The plan is calibrated with this collection's live indexed-field set
+    /// and statistics, so a SELECT whose WHERE targets an indexed field shows
+    /// an `IndexLookup` node and a MATCH reports a real traversal strategy.
+    /// Semantically invalid queries raise `ValueError`.
     #[pyo3(signature = (query_str))]
     fn explain(&self, py: Python<'_>, query_str: &str) -> PyResult<Py<PyAny>> {
         let parsed = parse_velesql(query_str)?;
-        Ok(build_explain_dict(py, &parsed))
+        validate_query(&parsed)?;
+        let indexed = self.inner.config().indexed_fields.iter().cloned().collect();
+        let stats = self.inner.analyze().ok();
+        Ok(build_explain_dict(py, &parsed, &indexed, stats.as_ref()))
     }
 
     /// Execute a query with instrumentation and return plan + actual stats (EXPLAIN ANALYZE).

--- a/crates/velesdb-python/src/collection/search.rs
+++ b/crates/velesdb-python/src/collection/search.rs
@@ -83,6 +83,7 @@ impl Collection {
             filter,
             sparse_index_name,
             include_vectors,
+            None,
         );
         self.search_request(py, &opts)
     }
@@ -121,6 +122,7 @@ impl Collection {
         let top_k = opts.top_k;
         let sparse_index_name = opts.sparse_index_name.clone();
         let include_vectors = opts.include_vectors;
+        let fusion = opts.fusion.as_ref().map(FusionStrategy::inner);
 
         // Phase 2: Release GIL during Rust computation
         let results = py.detach(|| {
@@ -130,6 +132,7 @@ impl Collection {
                 top_k,
                 filter_obj.as_ref(),
                 sparse_index_name.as_deref(),
+                fusion.as_ref(),
             )
         })?;
 

--- a/crates/velesdb-python/src/collection/search_options.rs
+++ b/crates/velesdb-python/src/collection/search_options.rs
@@ -29,6 +29,8 @@
 
 use pyo3::prelude::*;
 
+use crate::FusionStrategy;
+
 /// Options for a vector search request.
 ///
 /// Use as the argument to :py:meth:`Collection.search_request` (v1.15+).
@@ -68,6 +70,13 @@ pub struct SearchOptions {
     /// sizes small.
     #[pyo3(get, set)]
     pub include_vectors: bool,
+    /// Optional fusion strategy applied when both ``vector`` and
+    /// ``sparse_vector`` are provided (typed hybrid dense+sparse search).
+    /// When ``None`` the default Reciprocal Rank Fusion (RRF, k=60) is used,
+    /// preserving the historical behavior.  Has no effect on dense-only or
+    /// sparse-only searches.
+    #[pyo3(get, set)]
+    pub fusion: Option<FusionStrategy>,
 }
 
 #[pymethods]
@@ -85,6 +94,8 @@ impl SearchOptions {
     ///     filter: Metadata pre-filter dict.
     ///     sparse_index_name: Named sparse index to query.
     ///     include_vectors: Include raw vectors in results (default: False).
+    ///     fusion: Optional :py:class:`FusionStrategy` for hybrid dense+sparse
+    ///         fusion (default: RRF k=60).
     #[new]
     #[pyo3(signature = (
         vector = None,
@@ -94,6 +105,7 @@ impl SearchOptions {
         filter = None,
         sparse_index_name = None,
         include_vectors = false,
+        fusion = None,
     ))]
     pub fn new(
         vector: Option<Py<PyAny>>,
@@ -102,6 +114,7 @@ impl SearchOptions {
         filter: Option<Py<PyAny>>,
         sparse_index_name: Option<String>,
         include_vectors: bool,
+        fusion: Option<FusionStrategy>,
     ) -> Self {
         Self {
             vector,
@@ -110,6 +123,7 @@ impl SearchOptions {
             filter,
             sparse_index_name,
             include_vectors,
+            fusion,
         }
     }
 
@@ -170,6 +184,14 @@ impl SearchOptions {
     /// Sets whether raw vectors are included in results and returns `self`.
     pub fn with_include_vectors(slf: Py<Self>, py: Python<'_>, include: bool) -> Py<Self> {
         slf.bind(py).borrow_mut().include_vectors = include;
+        slf
+    }
+
+    /// Sets the hybrid dense+sparse fusion strategy and returns `self`.
+    ///
+    /// Pass ``None`` to fall back to the default RRF (k=60).
+    pub fn with_fusion(slf: Py<Self>, py: Python<'_>, fusion: Option<FusionStrategy>) -> Py<Self> {
+        slf.bind(py).borrow_mut().fusion = fusion;
         slf
     }
 }

--- a/crates/velesdb-python/src/database.rs
+++ b/crates/velesdb-python/src/database.rs
@@ -569,10 +569,21 @@ impl Database {
     ///
     /// - ``SELECT … FROM … WHERE …``
     /// - ``CREATE [GRAPH|METADATA] COLLECTION …``
+    /// - ``CREATE INDEX ON <collection> (<field>)`` / ``DROP INDEX …``
+    /// - ``ALTER COLLECTION <name> SET (auto_reindex = true|false)``
+    ///   (see :py:meth:`set_auto_reindex` for a typed helper)
     /// - ``DROP COLLECTION [IF EXISTS] …``
     /// - ``INSERT EDGE INTO …``
     /// - ``DELETE FROM … WHERE …``
     /// - ``DELETE EDGE … FROM …``
+    ///
+    /// Hybrid fusion note:
+    ///     Typed hybrid dense+sparse search (``search_request`` with both
+    ///     ``vector`` and ``sparse_vector``) uses Reciprocal Rank Fusion
+    ///     (RRF, k=60) by default. To choose another strategy, pass a
+    ///     :py:class:`FusionStrategy` via ``SearchOptions(fusion=...)`` /
+    ///     ``with_fusion(...)``, or run raw VelesQL with a
+    ///     ``USING FUSION(...)`` clause through this method.
     ///
     /// Args:
     ///     sql: VelesQL query string.
@@ -628,6 +639,40 @@ impl Database {
             .detach(move || inner.execute_query(&parsed, &rust_params))
             .map_err(core_err)?;
         Ok(search_results_to_multimodel_dicts(py, results))
+    }
+
+    /// Toggle automatic re-indexing on a collection at runtime.
+    ///
+    /// Routes a validated ``ALTER COLLECTION <name> SET (auto_reindex = …)``
+    /// statement through the VelesQL DDL executor and persists the change so
+    /// it survives a restart. This is the typed counterpart to running the
+    /// raw ALTER statement via :py:meth:`execute_query`.
+    ///
+    /// Args:
+    ///     name: Collection name.
+    ///     enabled: ``True`` to enable auto-reindex, ``False`` to disable it.
+    ///
+    /// Raises:
+    ///     ValueError: If the collection name fails to parse.
+    ///     RuntimeError: If the collection does not exist or the change fails.
+    ///
+    /// Example:
+    ///     >>> db.set_auto_reindex("documents", True)
+    ///     >>> db.get_collection("documents").info()["auto_reindex"]
+    ///     True
+    #[pyo3(signature = (name, enabled))]
+    fn set_auto_reindex(&self, py: Python<'_>, name: &str, enabled: bool) -> PyResult<()> {
+        use crate::collection::query::parse_velesql;
+
+        // Backtick-quote the identifier so names with hyphens/spaces parse,
+        // doubling any embedded backtick per the grammar's escaping rule.
+        let quoted = name.replace('`', "``");
+        let sql = format!("ALTER COLLECTION `{quoted}` SET (auto_reindex = {enabled})");
+        let parsed = parse_velesql(&sql)?;
+        let inner = Arc::clone(&self.inner);
+        py.detach(move || inner.execute_query(&parsed, &std::collections::HashMap::new()))
+            .map_err(core_err)?;
+        Ok(())
     }
 
     /// Get an existing graph collection by name.

--- a/crates/velesdb-python/src/graph_collection_query.rs
+++ b/crates/velesdb-python/src/graph_collection_query.rs
@@ -8,7 +8,7 @@ use std::collections::HashMap;
 
 use crate::collection::query::{
     build_explain_analyze_dict, build_explain_dict, convert_params, parse_velesql,
-    run_velesql_match, run_velesql_select, run_velesql_select_ids,
+    run_velesql_match, run_velesql_select, run_velesql_select_ids, validate_query,
 };
 use crate::collection_helpers::core_err;
 use crate::graph_collection::PyGraphCollection;
@@ -85,7 +85,10 @@ impl PyGraphCollection {
             if let Some(ref qv) = qv {
                 inner.execute_match_with_similarity(&mc, qv, threshold, &p)
             } else {
-                inner.execute_match(&mc, &p)
+                // Route through the cost-based planner so RETURN ORDER BY,
+                // deterministic tie-break, and post-sort LIMIT match the SQL
+                // /query path exactly (backlog #1).
+                inner.match_query_ordered(&mc, &p)
             }
         })
     }
@@ -100,7 +103,12 @@ impl PyGraphCollection {
     #[pyo3(signature = (query_str))]
     fn explain(&self, py: Python<'_>, query_str: &str) -> PyResult<Py<PyAny>> {
         let parsed = parse_velesql(query_str)?;
-        Ok(build_explain_dict(py, &parsed))
+        validate_query(&parsed)?;
+        // GraphCollection does not expose the calibrated stats / indexed-field
+        // set publicly; MATCH still reports a real strategy via from_match's
+        // default graph stats.
+        let indexed = std::collections::HashSet::new();
+        Ok(build_explain_dict(py, &parsed, &indexed, None))
     }
 
     /// Execute a query with instrumentation and return plan + actual stats (EXPLAIN ANALYZE).

--- a/crates/velesdb-python/tests/test_velesql_sdk_backlog.py
+++ b/crates/velesdb-python/tests/test_velesql_sdk_backlog.py
@@ -1,0 +1,242 @@
+"""Regression tests for the VelesQL Python SDK backlog (#1, #14, #24, #27).
+
+Each test pins a documented-but-broken behavior so the fix is provable:
+
+- #1  match_query honors RETURN ORDER BY + post-sort LIMIT (was raw order).
+- #14 explain() of an indexed SELECT emits an IndexLookup node, MATCH reports a
+      real strategy, and an invalid query raises.
+- #24 typed hybrid dense+sparse search honors a `fusion=` strategy (was RRF k=60).
+- #27 Database.set_auto_reindex toggles the runtime flag via ALTER COLLECTION.
+"""
+
+import shutil
+import tempfile
+
+import pytest
+
+try:
+    import velesdb
+except ImportError:  # pragma: no cover
+    pytest.skip(
+        "velesdb module not built yet - run 'maturin develop' first",
+        allow_module_level=True,
+    )
+
+
+@pytest.fixture
+def temp_db_path():
+    path = tempfile.mkdtemp(prefix="velesdb_sdk_backlog_")
+    yield path
+    shutil.rmtree(path, ignore_errors=True)
+
+
+# ---------------------------------------------------------------------------
+# #1 — match_query RETURN ORDER BY + post-sort LIMIT
+# ---------------------------------------------------------------------------
+
+
+def test_match_query_orders_and_limits(temp_db_path):
+    """MATCH ... RETURN d ORDER BY d.year DESC LIMIT 10 returns year-DESC top-10.
+
+    More than LIMIT :Doc nodes are seeded with distinct years; the Python
+    binding must rank identically to the SQL /query path (ORDER BY + post-sort
+    LIMIT applied), not return raw traversal order.
+    """
+    db = velesdb.Database(temp_db_path)
+    collection = db.create_collection("docs_order", dimension=2, metric="cosine")
+
+    # 15 nodes, years 2000..2014 — distinct so the DESC order is unambiguous.
+    points = [
+        {
+            "id": i,
+            "vector": [1.0, 0.0],
+            "payload": {"_labels": ["Doc"], "year": 2000 + i},
+        }
+        for i in range(15)
+    ]
+    collection.upsert(points)
+
+    results = collection.match_query(
+        "MATCH (d:Doc) RETURN d ORDER BY d.year DESC LIMIT 10"
+    )
+
+    # Post-sort LIMIT: exactly 10 of the 15 nodes.
+    assert len(results) == 10, f"expected post-sort LIMIT 10, got {len(results)}"
+
+    years = [r["projected"].get("year") or r["bindings"] for r in results]
+    # The top-10 by year DESC are 2014..2005 -> node ids 14..5.
+    ids = [r["node_id"] for r in results]
+    assert ids == list(range(14, 4, -1)), f"expected year-DESC top-10 ids, got {ids}"
+    # Sanity: the dropped tail (years <= 2004) must not appear.
+    assert all(node_id >= 5 for node_id in ids)
+    _ = years  # projected payload is best-effort; ordering is asserted via ids
+
+
+# ---------------------------------------------------------------------------
+# #14 — EXPLAIN: IndexLookup for indexed SELECT, real MATCH strategy, validation
+# ---------------------------------------------------------------------------
+
+
+def _tree_text(tree) -> str:
+    """Flatten an explain tree (string or nested structure) to searchable text."""
+    return repr(tree)
+
+
+def test_explain_select_on_indexed_field_has_index_lookup(temp_db_path):
+    db = velesdb.Database(temp_db_path)
+    db.create_collection("idx_docs", dimension=2, metric="cosine")
+    collection = db.get_collection("idx_docs")
+    collection.upsert(
+        [
+            {"id": i, "vector": [1.0, 0.0], "payload": {"category": "a" if i % 2 else "b"}}
+            for i in range(6)
+        ]
+    )
+
+    # Register a secondary index on the WHERE field via VelesQL DDL.
+    db.execute_query("CREATE INDEX ON idx_docs (category)")
+
+    # Re-fetch so the wrapper observes the freshly registered index set.
+    collection = db.get_collection("idx_docs")
+    explain = collection.explain("SELECT * FROM idx_docs WHERE category = 'a' LIMIT 5")
+
+    text = _tree_text(explain["tree"])
+    assert "IndexLookup" in text, f"expected IndexLookup node, tree was: {text}"
+
+
+def test_explain_match_reports_real_strategy(temp_db_path):
+    db = velesdb.Database(temp_db_path)
+    collection = db.create_collection("match_explain", dimension=2, metric="cosine")
+    collection.upsert(
+        [
+            {"id": i, "vector": [1.0, 0.0], "payload": {"_labels": ["Doc"]}}
+            for i in range(4)
+        ]
+    )
+
+    explain = collection.explain("MATCH (d:Doc) RETURN d LIMIT 5")
+    text = _tree_text(explain["tree"])
+    # A real traversal strategy must surface (GraphFirst / VectorFirst / Parallel
+    # / MatchTraversal), not a bare TableScan mislabeled MATCH.
+    assert any(
+        token in text
+        for token in ("MatchTraversal", "GraphFirst", "VectorFirst", "Parallel")
+    ), f"expected a real MATCH strategy, tree was: {text}"
+
+
+def test_explain_rejects_invalid_query(temp_db_path):
+    db = velesdb.Database(temp_db_path)
+    collection = db.create_collection("explain_invalid", dimension=2, metric="cosine")
+    collection.upsert([{"id": 1, "vector": [1.0, 0.0], "payload": {"amount": 5}}])
+
+    # A query that parses but is semantically invalid (a WHERE subquery, which
+    # VelesQL parses yet rejects at validation) must be rejected by explain()
+    # rather than silently building a plan.
+    with pytest.raises(ValueError):
+        collection.explain(
+            "SELECT * FROM explain_invalid WHERE amount > "
+            "(SELECT AVG(amount) FROM explain_invalid) LIMIT 5"
+        )
+
+
+# ---------------------------------------------------------------------------
+# #24 — typed hybrid dense+sparse honors a fusion strategy
+# ---------------------------------------------------------------------------
+
+
+def _seed_hybrid(collection):
+    # node 1: dense-dominant, weak sparse.   node 2: sparse-dominant, weak dense.
+    # node 3: middling on both. Distinct profiles so the dense vs sparse
+    # branch weighting decides the top result with no rank ties.
+    collection.upsert(
+        [
+            {
+                "id": 1,
+                "vector": [1.0, 0.0, 0.0, 0.0],
+                "sparse_vector": {0: 0.01, 1: 0.01},
+            },
+            {
+                "id": 2,
+                "vector": [0.2, 0.97, 0.0, 0.0],
+                "sparse_vector": {0: 5.0, 1: 5.0},
+            },
+            {
+                "id": 3,
+                "vector": [0.6, 0.6, 0.0, 0.0],
+                "sparse_vector": {0: 0.5, 1: 0.5},
+            },
+        ]
+    )
+
+
+def test_hybrid_fusion_changes_ordering(temp_db_path):
+    db = velesdb.Database(temp_db_path)
+    collection = db.create_collection("hybrid_fusion", dimension=4, metric="cosine")
+    _seed_hybrid(collection)
+
+    dense = [1.0, 0.0, 0.0, 0.0]
+    sparse = {0: 1.0, 1: 1.0}
+
+    # All-dense RSF: dense-dominant node 1 ranks first.
+    dense_opts = velesdb.SearchOptions(
+        vector=dense, sparse_vector=sparse, top_k=3
+    ).with_fusion(velesdb.FusionStrategy.relative_score(1.0, 0.0))
+    dense_first = [r["id"] for r in collection.search_request(dense_opts)][0]
+
+    # All-sparse RSF: sparse-dominant node 2 ranks first.
+    sparse_opts = velesdb.SearchOptions(
+        vector=dense, sparse_vector=sparse, top_k=3
+    ).with_fusion(velesdb.FusionStrategy.relative_score(0.0, 1.0))
+    sparse_first = [r["id"] for r in collection.search_request(sparse_opts)][0]
+
+    assert dense_first == 1, f"all-dense RSF should rank node 1 first, got {dense_first}"
+    assert sparse_first == 2, f"all-sparse RSF should rank node 2 first, got {sparse_first}"
+    # The fusion= strategy demonstrably changes the top result.
+    assert dense_first != sparse_first
+
+
+def test_hybrid_fusion_default_unchanged(temp_db_path):
+    """Omitting fusion= and passing fusion=None both use the default RRF(k=60).
+
+    Asserts the default branch still routes to the same core call (RRF), not
+    that an inherently tie-bearing ranking is bit-stable.
+    """
+    db = velesdb.Database(temp_db_path)
+    collection = db.create_collection("hybrid_default", dimension=4, metric="cosine")
+    _seed_hybrid(collection)
+
+    dense = [1.0, 0.0, 0.0, 0.0]
+    sparse = {0: 1.0, 1: 1.0}
+
+    omitted = sorted(
+        r["id"]
+        for r in collection.search_request(
+            velesdb.SearchOptions(vector=dense, sparse_vector=sparse, top_k=3)
+        )
+    )
+    explicit_none = sorted(
+        r["id"]
+        for r in collection.search_request(
+            velesdb.SearchOptions(vector=dense, sparse_vector=sparse, top_k=3).with_fusion(None)
+        )
+    )
+    # Same candidate set under the default fusion (RRF), regardless of tie order.
+    assert omitted == explicit_none == [1, 2, 3]
+
+
+# ---------------------------------------------------------------------------
+# #27 — Database.set_auto_reindex runtime toggle
+# ---------------------------------------------------------------------------
+
+
+def test_set_auto_reindex_toggles_flag(temp_db_path):
+    db = velesdb.Database(temp_db_path)
+    db.create_collection("reindex_toggle", dimension=2, metric="cosine")
+
+    db.set_auto_reindex("reindex_toggle", True)
+    info_on = db.get_collection("reindex_toggle").info()
+    assert info_on.get("auto_reindex") is True
+
+    db.set_auto_reindex("reindex_toggle", False)
+    info_off = db.get_collection("reindex_toggle").info()
+    assert info_off.get("auto_reindex") is False


### PR DESCRIPTION
## Summary

Closes the Python-SDK half of four backlog items. All `velesdb-python` (PyO3 + `.pyi`); routes through already-merged core methods (no core changes).

### #1 (python) — `match_query` now routes through the canonical ordered planner
The non-similarity `match_query`/graph-match branch now calls core `match_query_ordered` (the single source of truth added in #1210) instead of the bare `execute_match`, so it gets the cost-based planner, guard-rails, and #1b global top-K. (The `vector=` similarity branch keeps `execute_match_with_similarity`, which already orders correctly post-#1210.)

### #14 (python) — honest `explain()`
`build_explain_dict` used `CollectionStats::default()` (zeros) for MATCH and empty stats for SELECT. It now routes through core `from_query_with_all_stats` (added in #1207) with the collection's `config().indexed_fields` + `analyze()` stats and validates via `QueryValidator`. SELECT on an indexed field now emits an `IndexLookup` node + calibrated cost; MATCH reports a real strategy; an invalid query raises.

### #24 — fusion strategy reachable from typed hybrid search
`SearchOptions` gained an optional `fusion` field + `with_fusion()` builder (+ `.pyi`), threaded through `dispatch_search`, replacing the hard-coded `DEFAULT_FUSION` (RRF k=60) on both dense+sparse branches with `fusion.unwrap_or(DEFAULT_FUSION)`. **Purely additive** — default RRF preserved when `fusion` is omitted.

### #27 (python) — runtime `Database.set_auto_reindex`
New `Database.set_auto_reindex(name, enabled)` routes a valid `ALTER COLLECTION … SET (auto_reindex=…)`; `Collection.info()` now surfaces the live flag. Enriched `.pyi`/docstrings to enumerate `ALTER`/`CREATE INDEX` and note typed hybrid fusion is RRF-only unless `USING FUSION` SQL / the new `fusion=` option is used.

## Test plan
- New `tests/test_velesql_sdk_backlog.py` (7 tests). Failing-test-first: 5 failed on baseline (#14 no IndexLookup / no raise; #24 + #27 `AttributeError`), all pass after.
- Gates: `cargo fmt`; `cargo check -p velesdb-python` + `clippy` (clean); **`maturin develop` + full `pytest` = 404 passed / 0 failed** (re-run after rebasing onto the #12 error-code wave — no regression); `.pyi` stub-parity + `check-feature-claims.py` pass; `lizard -C 8` (0 new over budget).

## Notes (honest deviations, tracked)
- #14 used the public `config().indexed_fields` + `analyze()` rather than `indexed_field_names()`/`compute_match_collection_stats()` (those are `pub(crate)`, core was out of scope) — same IndexLookup/calibration/validation outcome. A follow-up could expose them publicly (same gating theme as the WASM/explain follow-up).
- The 5 pre-existing `query.rs`↔`graph_collection_query.rs` method-body clones are untouched (no new duplication).