### PR TITLE
fix(sdk-ts): emit parseable VelesQL from velesql() builder + typed setAutoReindex/alterCollection/nearFused (#11/#27)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,19 @@ release.
   *(Behavior change: several previously-accepted FUSION queries now error.)*
 
 ### Fixed
+- **TypeScript SDK `velesql()` builder now emits parseable VelesQL.** Three
+  builder bugs produced strings the core parser rejected or that dropped
+  intent: `nearVector({ topK })` emitted a non-existent `vector NEAR $q TOP n`
+  (there is no `TOP` keyword — `topK` now maps to `LIMIT`); `toVelesQL()`
+  always prefixed `MATCH` and placed `ORDER BY` / `LIMIT` **before** the
+  mandatory `RETURN` (MATCH output now always emits `RETURN` first, defaulting
+  to `RETURN *`); and `.fusion(...)` rendered an inert `/* FUSION x */` comment
+  that dropped the strategy and weights (now a real
+  `USING FUSION(strategy='...', ...)` clause). A new `from()` / `select()`
+  SELECT mode covers vector / hybrid search (the README "vector similarity with
+  filters" example, previously a hard parse error). A round-trip test now feeds
+  every builder output through the real `@wiscale/velesdb-wasm` parser.
+  *(Behavior change: builder output strings changed — see the SDK README.)*
 - **`USING FUSION(strategy = ...)` now takes effect on the dense-`NEAR` +
   text-`MATCH` hybrid.** The hybrid path always ran plain weighted RRF and
   ignored `strategy`, `graph_weight`, and (for `weighted`) the text-branch
@@ -82,6 +95,16 @@ release.
   *(Behavior change: non-`rrf` FUSION on NEAR+MATCH changes rankings.)*
 
 ### Added
+- **TypeScript SDK: typed `db.setAutoReindex()` / `db.alterCollection()` and a
+  typed `nearFused()` builder.** `db.setAutoReindex(name, bool)` and
+  `db.alterCollection(name, { autoReindex })` route a valid
+  `ALTER COLLECTION ... SET(auto_reindex=...)` through the existing `/query`
+  path (previously only reachable via a raw `db.query()` string). The query
+  builder gains `nearFused(paramNames, vectors, { strategy })` for multi-vector
+  fused search; its `strategy` type only allows `rrf` / `average` / `maximum`,
+  so the `weighted` / `relative_score` trap (which the engine silently degrades
+  to RRF over homogeneous query vectors) is a **compile-time error**. Purely
+  additive.
 - **`ALTER COLLECTION <name> SET (auto_reindex = true|false)` now applies and
   persists.** Previously parsed but rejected with a feature-gap error, it now
   attaches (or re-configures) an `AutoReindexManager` on the collection and

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -662,19 +662,21 @@ Build type-safe VelesQL queries with a fluent API instead of raw strings.
 ```typescript
 import { velesql } from '@wiscale/velesdb-sdk';
 
-// Vector similarity with filters
+// Vector similarity with filters — use SELECT mode via from()
 const builder = velesql()
-  .match('d', 'Document')
+  .from('documents', 'd')
   .nearVector('$queryVector', queryVector)
   .andWhere('d.category = $cat', { cat: 'tech' })
   .orderBy('similarity()', 'DESC')
   .limit(10);
 
 const queryString = builder.toVelesQL();
+// => "SELECT * FROM documents WHERE vector NEAR $queryVector AND d.category = $cat ORDER BY similarity() DESC LIMIT 10"
 const params = builder.getParams();
 const results = await db.query('documents', queryString, params);
 
-// Graph traversal with relationships
+// Graph traversal with relationships (MATCH mode — RETURN is mandatory
+// and precedes ORDER BY / LIMIT)
 const graphQuery = velesql()
   .match('p', 'Person')
   .rel('KNOWS')
@@ -683,9 +685,45 @@ const graphQuery = velesql()
   .return(['p.name', 'f.name'])
   .toVelesQL();
 // => "MATCH (p:Person)-[:KNOWS]->(f:Person) WHERE p.age > 25 RETURN p.name, f.name"
+
+// Hybrid (vector NEAR + text MATCH) with a real USING FUSION clause
+const hybrid = velesql()
+  .from('docs')
+  .nearVector('$q', queryVector)
+  .andWhere("content MATCH 'invoice'")
+  .limit(10)
+  .fusion('weighted', { vectorWeight: 0.7, graphWeight: 0.3 })
+  .toVelesQL();
+// => "SELECT * FROM docs WHERE vector NEAR $q AND content MATCH 'invoice' LIMIT 10 USING FUSION(strategy='weighted', vector_weight=0.7, graph_weight=0.3)"
+
+// Multi-vector fused search — strategy is typed to rrf | average | maximum
+const fused = velesql()
+  .from('docs')
+  .nearFused(['$a', '$b'], [vectorA, vectorB], { strategy: 'average' })
+  .limit(10)
+  .toVelesQL();
+// => "SELECT * FROM docs WHERE vector NEAR_FUSED [$a, $b] USING FUSION 'average' LIMIT 10"
 ```
 
-Builder methods: `match()`, `rel()`, `to()`, `where()`, `andWhere()`, `orWhere()`, `nearVector()`, `limit()`, `offset()`, `orderBy()`, `return()`, `returnAll()`, `fusion()`.
+> **Mode matters.** Call `from(collection)` for vector / hybrid / fused
+> SELECT queries; call `match(alias, label)` for graph patterns. MATCH mode
+> always emits a `RETURN` (defaulting to `RETURN *`) and supports no
+> `OFFSET`. `nearVector({ topK })` maps to `LIMIT` (VelesQL has no `TOP`
+> keyword). `nearFused()` only accepts `rrf` / `average` / `maximum` —
+> `weighted` / `relative_score` are a compile error because the engine
+> would silently degrade them to RRF.
+
+Builder methods: `match()`, `from()`, `select()`, `rel()`, `to()`, `where()`, `andWhere()`, `orWhere()`, `nearVector()`, `nearFused()`, `limit()`, `offset()`, `orderBy()`, `return()`, `returnAll()`, `fusion()`.
+
+#### Collection settings — `db.setAutoReindex()` / `db.alterCollection()`
+
+Toggle a collection's mutable settings at runtime via typed helpers that
+emit `ALTER COLLECTION ... SET(...)`:
+
+```typescript
+await db.setAutoReindex('docs', true);             // auto_reindex=true
+await db.alterCollection('docs', { autoReindex: false });
+```
 
 ---
 

--- a/sdks/typescript/examples/typed_guards.ts
+++ b/sdks/typescript/examples/typed_guards.ts
@@ -1,0 +1,45 @@
+/**
+ * Typed builder guards for the VelesDB TypeScript SDK (#27).
+ *
+ * This file exists primarily as a COMPILE-TIME contract, type-checked in CI
+ * via `npm run typecheck` (tsconfig.examples.json includes `examples/**`).
+ * It pins two SDK guarantees:
+ *
+ *   1. `nearFused()`'s strategy only accepts `rrf` | `average` | `maximum`.
+ *      `weighted` / `relative_score` are rejected at compile time — they
+ *      have no per-branch weights over N homogeneous query vectors and the
+ *      engine silently downgrades them to RRF (the "weighted -> RRF" trap).
+ *      The `@ts-expect-error` lines below FAIL the build if the type ever
+ *      widens to allow them.
+ *
+ *   2. `db.setAutoReindex()` / `db.alterCollection()` exist and are typed.
+ *
+ * Run (against a live server):  npx tsx examples/typed_guards.ts
+ */
+
+import { VelesDB, velesql } from '../src';
+
+const a = [0.1, 0.2, 0.3];
+const b = [0.4, 0.5, 0.6];
+
+// --- nearFused() compile-time strategy guard -------------------------------
+
+// Allowed strategies type-check cleanly.
+velesql().from('docs').nearFused(['$a', '$b'], [a, b], { strategy: 'rrf' });
+velesql().from('docs').nearFused(['$a', '$b'], [a, b], { strategy: 'average' });
+velesql().from('docs').nearFused(['$a', '$b'], [a, b], { strategy: 'maximum' });
+
+// @ts-expect-error 'weighted' silently degrades to RRF — disallowed by the typed builder.
+velesql().from('docs').nearFused(['$a', '$b'], [a, b], { strategy: 'weighted' });
+
+// @ts-expect-error 'relative_score' is not a valid NEAR_FUSED strategy.
+velesql().from('docs').nearFused(['$a', '$b'], [a, b], { strategy: 'relative_score' });
+
+// --- ALTER COLLECTION typed helpers ----------------------------------------
+
+export async function toggleAutoReindex(): Promise<void> {
+  const db = new VelesDB({ backend: 'rest', url: 'http://localhost:8080' });
+  await db.init();
+  await db.setAutoReindex('docs', true);
+  await db.alterCollection('docs', { autoReindex: false });
+}

--- a/sdks/typescript/src/client.ts
+++ b/sdks/typescript/src/client.ts
@@ -15,6 +15,7 @@ import type {
   SparseSearchNamedOptions,
   SparseVector,
   CreateIndexOptions,
+  AlterCollectionOptions,
   IndexInfo,
   AddEdgeRequest,
   GetEdgesOptions,
@@ -386,6 +387,45 @@ export class VelesDB {
   async dropIndex(collection: string, label: string, property: string): Promise<boolean> {
     this.ensureInitialized();
     return this.backend.dropIndex(collection, label, property);
+  }
+
+  // ========================================================================
+  // Collection settings (ALTER COLLECTION)
+  // ========================================================================
+
+  /**
+   * Toggle a collection's mutable settings at runtime via
+   * `ALTER COLLECTION <name> SET(...)`.
+   *
+   * Typed wrapper over the raw VelesQL DDL; routes through the same
+   * `/query` path as `db.query()`.
+   *
+   * @example
+   * ```typescript
+   * await db.alterCollection('docs', { autoReindex: true });
+   * ```
+   */
+  async alterCollection(collection: string, options: AlterCollectionOptions): Promise<void> {
+    this.ensureInitialized();
+    const sets: string[] = [];
+    if (options.autoReindex !== undefined) {
+      sets.push(`auto_reindex=${options.autoReindex}`);
+    }
+    if (sets.length === 0) {
+      throw new ValidationError('alterCollection requires at least one option');
+    }
+    const sql = `ALTER COLLECTION ${collection} SET(${sets.join(', ')})`;
+    await searchMethods.query(this.backend, collection, sql);
+  }
+
+  /**
+   * Enable or disable automatic index rebuilds on a collection.
+   *
+   * Convenience wrapper over {@link alterCollection}; emits
+   * `ALTER COLLECTION <name> SET(auto_reindex=<enabled>)`.
+   */
+  async setAutoReindex(collection: string, enabled: boolean): Promise<void> {
+    return this.alterCollection(collection, { autoReindex: enabled });
   }
 
   // ========================================================================

--- a/sdks/typescript/src/index.ts
+++ b/sdks/typescript/src/index.ts
@@ -27,7 +27,14 @@ export { VelesDB, AgentMemoryClient } from './client';
 export { WasmBackend } from './backends/wasm';
 export { RestBackend } from './backends/rest';
 export { VelesQLBuilder, velesql } from './query-builder';
-export type { RelDirection, RelOptions, NearVectorOptions, FusionOptions } from './query-builder';
+export type {
+  RelDirection,
+  RelOptions,
+  NearVectorOptions,
+  NearFusedStrategy,
+  NearFusedOptions,
+  FusionOptions,
+} from './query-builder';
 export { f, isTypedFilter, normalizeFilter } from './filter';
 export type { Filter, Condition, CompareOp, FilterInput, JsonValue } from './filter';
 export { searchQualityToMode } from './search-quality';

--- a/sdks/typescript/src/query-builder.ts
+++ b/sdks/typescript/src/query-builder.ts
@@ -38,6 +38,23 @@ export interface NearVectorOptions {
   topK?: number;
 }
 
+/**
+ * Fusion strategies valid for `NEAR_FUSED` (multi-vector) search.
+ *
+ * Deliberately a STRICT subset of {@link FusionStrategy}: only `rrf`,
+ * `average`, and `maximum` are meaningful when fusing N homogeneous query
+ * vectors. `weighted`/`relative_score` have no per-branch weights to apply
+ * here and the core silently downgrades them to RRF (the "weighted -> RRF"
+ * trap). Restricting the type makes that misuse a COMPILE error.
+ */
+export type NearFusedStrategy = 'rrf' | 'average' | 'maximum';
+
+/** Options for the {@link VelesQLBuilder.nearFused} multi-vector clause */
+export interface NearFusedOptions {
+  /** Fusion strategy (default: `rrf`). Only `rrf`/`average`/`maximum` allowed. */
+  strategy?: NearFusedStrategy;
+}
+
 /** Fusion configuration */
 export interface FusionOptions {
   strategy: FusionStrategy;
@@ -49,10 +66,16 @@ export interface FusionOptions {
 /** Internal state for the query builder */
 interface BuilderState {
   matchClauses: string[];
+  /** SELECT-mode source table/collection (set via {@link VelesQLBuilder.from}). */
+  fromClause?: string;
+  /** SELECT-mode projection columns (set via {@link VelesQLBuilder.select}). */
+  selectColumns?: string[];
   whereClauses: string[];
   whereOperators: string[];
   params: Record<string, unknown>;
   limitValue?: number;
+  /** topK from {@link VelesQLBuilder.nearVector}, applied as a LIMIT fallback. */
+  topKValue?: number;
   offsetValue?: number;
   orderByClause?: string;
   returnClause?: string;
@@ -76,10 +99,13 @@ export class VelesQLBuilder {
   constructor(state?: Partial<BuilderState>) {
     this.state = {
       matchClauses: state?.matchClauses ?? [],
+      fromClause: state?.fromClause,
+      selectColumns: state?.selectColumns,
       whereClauses: state?.whereClauses ?? [],
       whereOperators: state?.whereOperators ?? [],
       params: state?.params ?? {},
       limitValue: state?.limitValue,
+      topKValue: state?.topKValue,
       offsetValue: state?.offsetValue,
       orderByClause: state?.orderByClause,
       returnClause: state?.returnClause,
@@ -114,6 +140,47 @@ export class VelesQLBuilder {
       matchClauses: [...this.state.matchClauses, nodePattern],
       currentNode: alias,
     });
+  }
+
+  /**
+   * Start a SELECT-mode query against a collection/table.
+   *
+   * Use this for vector search and hybrid (NEAR + MATCH / fusion) queries,
+   * which are expressed as `SELECT ... FROM <collection> WHERE ...` in
+   * VelesQL — not as graph `MATCH` patterns. When `from()` is set the
+   * builder emits a `SELECT` statement instead of a `MATCH`.
+   *
+   * @param collection - Source collection/table name
+   * @param alias - Optional alias (kept for `WHERE`/`ORDER BY` references)
+   *
+   * @example
+   * ```typescript
+   * velesql()
+   *   .from('documents', 'd')
+   *   .nearVector('$q', embedding)
+   *   .andWhere('d.category = $cat', { cat: 'tech' })
+   *   .orderBy('score', 'DESC')
+   *   .limit(10)
+   *   .toVelesQL();
+   * // => "SELECT * FROM documents WHERE vector NEAR $q AND d.category = $cat ORDER BY score DESC LIMIT 10"
+   * ```
+   */
+  from(collection: string, alias?: string): VelesQLBuilder {
+    return this.clone({
+      fromClause: collection,
+      currentNode: alias,
+    });
+  }
+
+  /**
+   * Set the SELECT projection columns (SELECT mode only).
+   *
+   * Without this the query projects `*`.
+   *
+   * @param columns - Column expressions to project
+   */
+  select(columns: string[]): VelesQLBuilder {
+    return this.clone({ selectColumns: [...columns] });
   }
 
   /**
@@ -240,23 +307,74 @@ export class VelesQLBuilder {
     vector: number[] | Float32Array,
     options?: NearVectorOptions
   ): VelesQLBuilder {
+    // VelesQL has no `TOP` keyword — `topK` maps to a LIMIT fallback,
+    // applied at render time only when no explicit `.limit()` was set.
     const cleanParamName = paramName.startsWith('$') ? paramName.slice(1) : paramName;
-    const topKSuffix = options?.topK ? ` TOP ${options.topK}` : '';
-    const condition = `vector NEAR $${cleanParamName}${topKSuffix}`;
-    
-    const newParams = { ...this.state.params, [cleanParamName]: vector };
-    
-    if (this.state.whereClauses.length === 0) {
-      return this.clone({
-        whereClauses: [condition],
-        params: newParams,
-      });
+    return this.appendCondition(
+      `vector NEAR $${cleanParamName}`,
+      { [cleanParamName]: vector },
+      { topKValue: options?.topK ?? this.state.topKValue }
+    );
+  }
+
+  /**
+   * Add a multi-vector `NEAR_FUSED` clause for fused similarity search.
+   *
+   * Fuses several query vectors into one ranking. The strategy is typed as
+   * {@link NearFusedStrategy} (`rrf` | `average` | `maximum`) so the
+   * `weighted`/`relative_score` trap — which the engine silently downgrades
+   * to RRF — is a COMPILE-TIME error rather than a silent surprise.
+   *
+   * @param paramNames - Parameter names, one per query vector (e.g. `['$a', '$b']`)
+   * @param vectors - One vector per param name (same order)
+   * @param options - Fusion options (strategy)
+   *
+   * @example
+   * ```typescript
+   * velesql()
+   *   .from('docs')
+   *   .nearFused(['$a', '$b'], [vecA, vecB], { strategy: 'average' })
+   *   .limit(10)
+   *   .toVelesQL();
+   * // => "SELECT * FROM docs WHERE vector NEAR_FUSED [$a, $b] USING FUSION 'average' LIMIT 10"
+   * ```
+   */
+  nearFused(
+    paramNames: string[],
+    vectors: Array<number[] | Float32Array>,
+    options?: NearFusedOptions
+  ): VelesQLBuilder {
+    if (paramNames.length !== vectors.length) {
+      throw new Error('nearFused requires one vector per parameter name');
     }
-    
+    if (paramNames.length < 2) {
+      throw new Error('nearFused requires at least two query vectors');
+    }
+    const clean = paramNames.map(p => (p.startsWith('$') ? p.slice(1) : p));
+    const params: Record<string, unknown> = {};
+    clean.forEach((name, i) => {
+      params[name] = vectors[i];
+    });
+    const fusionSuffix = options?.strategy ? ` USING FUSION '${options.strategy}'` : '';
+    const list = clean.map(name => `$${name}`).join(', ');
+    return this.appendCondition(`vector NEAR_FUSED [${list}]${fusionSuffix}`, params);
+  }
+
+  /** Append a WHERE condition (AND-joined) and merge params. */
+  private appendCondition(
+    condition: string,
+    params: Record<string, unknown>,
+    extra?: Partial<BuilderState>
+  ): VelesQLBuilder {
+    const newParams = { ...this.state.params, ...params };
+    if (this.state.whereClauses.length === 0) {
+      return this.clone({ whereClauses: [condition], params: newParams, ...extra });
+    }
     return this.clone({
       whereClauses: [...this.state.whereClauses, condition],
       whereOperators: [...this.state.whereOperators, 'AND'],
       params: newParams,
+      ...extra,
     });
   }
 
@@ -354,50 +472,88 @@ export class VelesQLBuilder {
   }
 
   /**
-   * Build the VelesQL query string
+   * Build the VelesQL query string.
+   *
+   * Emits a `SELECT` statement when {@link from} was called, otherwise a
+   * graph `MATCH` statement. Both clause orders are dictated by the VelesQL
+   * grammar so the output round-trips through the core parser:
+   *   - SELECT: `SELECT … FROM … [WHERE …] [ORDER BY …] [LIMIT] [OFFSET] [USING FUSION(…)]`
+   *   - MATCH:  `MATCH … [WHERE …] RETURN … [ORDER BY …] [LIMIT]`
+   *     (`RETURN` is mandatory; `MATCH` supports no `OFFSET`.)
    */
   toVelesQL(): string {
-    if (this.state.matchClauses.length === 0) {
-      throw new Error('Query must have at least one MATCH clause');
-    }
+    return this.state.fromClause !== undefined
+      ? this.buildSelect()
+      : this.buildMatch();
+  }
 
-    const parts: string[] = [];
+  /** Resolve the effective LIMIT, falling back to a `nearVector({topK})`. */
+  private resolveLimit(): number | undefined {
+    return this.state.limitValue ?? this.state.topKValue;
+  }
 
-    // MATCH clause
-    parts.push(`MATCH ${this.state.matchClauses.join(', ')}`);
+  private buildSelect(): string {
+    const projection = this.state.selectColumns?.length
+      ? this.state.selectColumns.join(', ')
+      : '*';
+    const parts: string[] = [`SELECT ${projection} FROM ${this.state.fromClause}`];
 
-    // WHERE clause
     if (this.state.whereClauses.length > 0) {
-      const whereStr = this.buildWhereClause();
-      parts.push(`WHERE ${whereStr}`);
+      parts.push(`WHERE ${this.buildWhereClause()}`);
     }
-
-    // ORDER BY
     if (this.state.orderByClause) {
       parts.push(`ORDER BY ${this.state.orderByClause}`);
     }
-
-    // LIMIT
-    if (this.state.limitValue !== undefined) {
-      parts.push(`LIMIT ${this.state.limitValue}`);
+    const limit = this.resolveLimit();
+    if (limit !== undefined) {
+      parts.push(`LIMIT ${limit}`);
     }
-
-    // OFFSET
     if (this.state.offsetValue !== undefined) {
       parts.push(`OFFSET ${this.state.offsetValue}`);
     }
-
-    // RETURN
-    if (this.state.returnClause) {
-      parts.push(`RETURN ${this.state.returnClause}`);
-    }
-
-    // FUSION (as comment/hint for now)
     if (this.state.fusionOptions) {
-      parts.push(`/* FUSION ${this.state.fusionOptions.strategy} */`);
+      parts.push(this.buildFusionClause(this.state.fusionOptions));
+    }
+    return parts.join(' ');
+  }
+
+  private buildMatch(): string {
+    if (this.state.matchClauses.length === 0) {
+      throw new Error('Query must call match() or from() before toVelesQL()');
     }
 
+    const parts: string[] = [`MATCH ${this.state.matchClauses.join(', ')}`];
+
+    if (this.state.whereClauses.length > 0) {
+      parts.push(`WHERE ${this.buildWhereClause()}`);
+    }
+
+    // RETURN is mandatory in MATCH mode and MUST precede ORDER BY/LIMIT.
+    parts.push(`RETURN ${this.state.returnClause ?? '*'}`);
+
+    if (this.state.orderByClause) {
+      parts.push(`ORDER BY ${this.state.orderByClause}`);
+    }
+    const limit = this.resolveLimit();
+    if (limit !== undefined) {
+      parts.push(`LIMIT ${limit}`);
+    }
     return parts.join(' ');
+  }
+
+  /** Render a real `USING FUSION(...)` clause from fusion options. */
+  private buildFusionClause(options: FusionOptions): string {
+    const args: string[] = [`strategy='${options.strategy}'`];
+    if (options.k !== undefined) {
+      args.push(`k=${options.k}`);
+    }
+    if (options.vectorWeight !== undefined) {
+      args.push(`vector_weight=${options.vectorWeight}`);
+    }
+    if (options.graphWeight !== undefined) {
+      args.push(`graph_weight=${options.graphWeight}`);
+    }
+    return `USING FUSION(${args.join(', ')})`;
   }
 
   private formatLabel(label?: string | string[]): string {

--- a/sdks/typescript/src/types/index-types.ts
+++ b/sdks/typescript/src/types/index-types.ts
@@ -35,3 +35,17 @@ export interface CreateIndexOptions {
   /** Index type: 'hash' (default) or 'range' */
   indexType?: IndexType;
 }
+
+/**
+ * Mutable collection settings toggled at runtime via `ALTER COLLECTION`.
+ *
+ * Used by {@link VelesDB.alterCollection}. Only the keys you set are
+ * emitted into the `SET(...)` clause.
+ */
+export interface AlterCollectionOptions {
+  /**
+   * Enable/disable automatic index rebuilds after writes.
+   * Emits `auto_reindex=<bool>`.
+   */
+  autoReindex?: boolean;
+}

--- a/sdks/typescript/tests/client-delegations.test.ts
+++ b/sdks/typescript/tests/client-delegations.test.ts
@@ -349,6 +349,35 @@ describe('VelesDB — index management delegations', () => {
     await db.dropIndex('c', 'L', 'p');
     expect(backend.dropIndex).toHaveBeenCalledWith('c', 'L', 'p');
   });
+
+  it('setAutoReindex routes a valid ALTER COLLECTION ... SET(auto_reindex=...) (#27)', async () => {
+    await db.setAutoReindex('docs', true);
+    expect(backend.query).toHaveBeenCalledWith(
+      'docs',
+      'ALTER COLLECTION docs SET(auto_reindex=true)',
+      undefined,
+      undefined
+    );
+
+    await db.setAutoReindex('docs', false);
+    expect(backend.query).toHaveBeenCalledWith(
+      'docs',
+      'ALTER COLLECTION docs SET(auto_reindex=false)',
+      undefined,
+      undefined
+    );
+  });
+
+  it('alterCollection emits the typed SET clause and rejects empty options', async () => {
+    await db.alterCollection('docs', { autoReindex: true });
+    expect(backend.query).toHaveBeenCalledWith(
+      'docs',
+      'ALTER COLLECTION docs SET(auto_reindex=true)',
+      undefined,
+      undefined
+    );
+    await expect(db.alterCollection('docs', {})).rejects.toThrow(ValidationError);
+  });
 });
 
 describe('VelesDB — graph delegations (graph-methods.ts)', () => {

--- a/sdks/typescript/tests/query-builder-roundtrip.test.ts
+++ b/sdks/typescript/tests/query-builder-roundtrip.test.ts
@@ -1,0 +1,179 @@
+/**
+ * VelesQL Query Builder ROUND-TRIP conformance test (#11).
+ *
+ * The pre-existing query-builder tests only string-matched the builder
+ * output, which is exactly why three invalid-VelesQL bugs shipped
+ * (`vector NEAR $x TOP n`, MATCH-only output with ORDER BY/LIMIT before
+ * the mandatory RETURN, and fusion rendered as an inert `/* FUSION ... *​/`
+ * comment).
+ *
+ * This suite feeds every `toVelesQL()` output through the REAL core parser
+ * shipped in `@wiscale/velesdb-wasm` (`VelesQL.parse`) and asserts ZERO
+ * syntax errors. Anything the builder can emit MUST parse.
+ *
+ * The WASM module is loaded once (Node path: read the `.wasm` bytes off
+ * disk and pass them to the wasm-pack initializer), mirroring how
+ * `src/backends/wasm-node-loader.ts` boots WASM under Node.
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { readFile, readdir } from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import { velesql } from '../src/query-builder';
+
+const require = createRequire(import.meta.url);
+
+// Loaded in beforeAll; typed loosely because the WASM .d.ts is not part of
+// the SDK's own type graph here.
+let parse: (q: string) => unknown;
+
+async function loadRealParser(): Promise<(q: string) => unknown> {
+  const pkgJson = require.resolve('@wiscale/velesdb-wasm/package.json');
+  const pkgDir = path.dirname(pkgJson);
+  const files = await readdir(pkgDir);
+  const wasmFile = files.find((f) => f.endsWith('.wasm'));
+  if (!wasmFile) throw new Error('velesdb-wasm: no .wasm binary found on disk');
+  const jsEntry = files.find((f) => f.endsWith('.js')) ?? 'velesdb_wasm.js';
+  const mod = (await import(path.join(pkgDir, jsEntry))) as {
+    default: (init: { module_or_path: BufferSource }) => Promise<unknown>;
+    VelesQL: { parse: (q: string) => unknown };
+  };
+  const bytes = await readFile(path.join(pkgDir, wasmFile));
+  await mod.default({ module_or_path: new Uint8Array(bytes) });
+  return (q: string) => mod.VelesQL.parse(q);
+}
+
+beforeAll(async () => {
+  parse = await loadRealParser();
+});
+
+/** Assert a builder output parses with the real core parser (no throw). */
+function expectParses(query: string): void {
+  expect(() => parse(query), `should parse: ${query}`).not.toThrow();
+}
+
+const embedding = [0.1, 0.2, 0.3, 0.4];
+
+describe('Query builder round-trip through the REAL core parser', () => {
+  it('parses a plain MATCH (RETURN auto-appended)', () => {
+    expectParses(velesql().match('n', 'Person').toVelesQL());
+  });
+
+  it('parses MATCH + WHERE', () => {
+    expectParses(velesql().match('n', 'Person').where('n.age > 21').toVelesQL());
+  });
+
+  it('parses MATCH + RETURN + ORDER BY + LIMIT (RETURN before ORDER BY/LIMIT)', () => {
+    expectParses(
+      velesql()
+        .match('n', 'Person')
+        .return(['n.name', 'n.email'])
+        .orderBy('n.name', 'DESC')
+        .limit(10)
+        .toVelesQL()
+    );
+  });
+
+  it('parses a relationship traversal', () => {
+    expectParses(
+      velesql().match('a', 'Person').rel('KNOWS', 'r').to('b', 'Person').toVelesQL()
+    );
+  });
+
+  it('parses a variable-length path', () => {
+    expectParses(
+      velesql()
+        .match('a', 'Person')
+        .rel('KNOWS', 'p', { minHops: 1, maxHops: 3 })
+        .to('b', 'Person')
+        .return(['b'])
+        .toVelesQL()
+    );
+  });
+
+  it('parses nearVector with topK (mapped to LIMIT, no TOP keyword)', () => {
+    expectParses(
+      velesql().match('d', 'Document').nearVector('$q', embedding, { topK: 50 }).toVelesQL()
+    );
+  });
+
+  it('parses the README "Vector similarity with filters" example (SELECT mode)', () => {
+    expectParses(
+      velesql()
+        .from('documents', 'd')
+        .nearVector('$queryVector', embedding)
+        .andWhere('d.category = $cat', { cat: 'tech' })
+        .orderBy('score', 'DESC')
+        .limit(10)
+        .toVelesQL()
+    );
+  });
+
+  it('parses a plain SELECT projection', () => {
+    expectParses(velesql().from('docs').select(['title', 'category']).limit(5).toVelesQL());
+  });
+
+  it('parses every fusion strategy as a real USING FUSION clause', () => {
+    const strategies = ['rrf', 'average', 'maximum', 'weighted', 'relative_score'] as const;
+    for (const strategy of strategies) {
+      const q = velesql()
+        .from('docs')
+        .nearVector('$q', embedding)
+        .andWhere("content MATCH 'x'")
+        .limit(10)
+        .fusion(strategy, { k: 60, vectorWeight: 0.7, graphWeight: 0.3 })
+        .toVelesQL();
+      expect(q).not.toContain('/*');
+      expectParses(q);
+    }
+  });
+
+  it('parses weighted fusion with only a vector weight (#11 verify case)', () => {
+    const q = velesql()
+      .from('docs')
+      .nearVector('$q', embedding)
+      .andWhere("content MATCH 'x'")
+      .fusion('weighted', { vectorWeight: 0.7 })
+      .toVelesQL();
+    expect(q).toContain("USING FUSION(strategy='weighted', vector_weight=0.7");
+    expectParses(q);
+  });
+
+  it('parses a NEAR_FUSED multi-vector query for every allowed strategy', () => {
+    const strategies = ['rrf', 'average', 'maximum'] as const;
+    for (const strategy of strategies) {
+      const q = velesql()
+        .from('docs')
+        .nearFused(['$a', '$b'], [embedding, embedding], { strategy })
+        .limit(10)
+        .toVelesQL();
+      expect(q).toContain(`USING FUSION '${strategy}'`);
+      expectParses(q);
+    }
+  });
+
+  it('parses NEAR_FUSED without an explicit strategy', () => {
+    expectParses(
+      velesql()
+        .from('docs')
+        .nearFused(['$a', '$b'], [embedding, embedding])
+        .limit(5)
+        .toVelesQL()
+    );
+  });
+
+  it('parses the complete RAG MATCH query', () => {
+    expectParses(
+      velesql()
+        .match('d', 'Document')
+        .nearVector('$embedding', embedding, { topK: 100 })
+        .andWhere('d.language = $lang', { lang: 'en' })
+        .andWhere('d.published = $pub', { pub: true })
+        .orderBy('score', 'DESC')
+        .limit(20)
+        .return(['d.title', 'd.content', 'score'])
+        .toVelesQL()
+    );
+  });
+});

--- a/sdks/typescript/tests/query-builder.test.ts
+++ b/sdks/typescript/tests/query-builder.test.ts
@@ -8,25 +8,25 @@ import { VelesQLBuilder, velesql } from '../src/query-builder';
 
 describe('VelesQLBuilder', () => {
   describe('Basic MATCH patterns', () => {
-    it('should build simple node match', () => {
+    it('should build simple node match (RETURN * appended — MATCH requires RETURN)', () => {
       const builder = velesql()
         .match('n', 'Person');
-      
-      expect(builder.toVelesQL()).toBe('MATCH (n:Person)');
+
+      expect(builder.toVelesQL()).toBe('MATCH (n:Person) RETURN *');
     });
 
     it('should build match with multiple labels', () => {
       const builder = velesql()
         .match('n', ['Person', 'Employee']);
-      
-      expect(builder.toVelesQL()).toBe('MATCH (n:Person:Employee)');
+
+      expect(builder.toVelesQL()).toBe('MATCH (n:Person:Employee) RETURN *');
     });
 
     it('should build match without label', () => {
       const builder = velesql()
         .match('n');
-      
-      expect(builder.toVelesQL()).toBe('MATCH (n)');
+
+      expect(builder.toVelesQL()).toBe('MATCH (n) RETURN *');
     });
   });
 
@@ -35,16 +35,16 @@ describe('VelesQLBuilder', () => {
       const builder = velesql()
         .match('n', 'Person')
         .where('n.age > 21');
-      
-      expect(builder.toVelesQL()).toBe('MATCH (n:Person) WHERE n.age > 21');
+
+      expect(builder.toVelesQL()).toBe('MATCH (n:Person) WHERE n.age > 21 RETURN *');
     });
 
     it('should add WHERE with parameter', () => {
       const builder = velesql()
         .match('n', 'Person')
         .where('n.name = $name', { name: 'Alice' });
-      
-      expect(builder.toVelesQL()).toBe('MATCH (n:Person) WHERE n.name = $name');
+
+      expect(builder.toVelesQL()).toBe('MATCH (n:Person) WHERE n.name = $name RETURN *');
       expect(builder.getParams()).toEqual({ name: 'Alice' });
     });
 
@@ -53,8 +53,8 @@ describe('VelesQLBuilder', () => {
         .match('n', 'Person')
         .where('n.age > $minAge', { minAge: 18 })
         .andWhere('n.active = $active', { active: true });
-      
-      expect(builder.toVelesQL()).toBe('MATCH (n:Person) WHERE n.age > $minAge AND n.active = $active');
+
+      expect(builder.toVelesQL()).toBe('MATCH (n:Person) WHERE n.age > $minAge AND n.active = $active RETURN *');
       expect(builder.getParams()).toEqual({ minAge: 18, active: true });
     });
 
@@ -63,8 +63,8 @@ describe('VelesQLBuilder', () => {
         .match('n', 'Person')
         .where('n.role = $role1', { role1: 'admin' })
         .orWhere('n.role = $role2', { role2: 'moderator' });
-      
-      expect(builder.toVelesQL()).toBe('MATCH (n:Person) WHERE n.role = $role1 OR n.role = $role2');
+
+      expect(builder.toVelesQL()).toBe('MATCH (n:Person) WHERE n.role = $role1 OR n.role = $role2 RETURN *');
     });
   });
 
@@ -75,18 +75,30 @@ describe('VelesQLBuilder', () => {
         .match('d', 'Document')
         .nearVector('$query', embedding);
       
-      expect(builder.toVelesQL()).toBe('MATCH (d:Document) WHERE vector NEAR $query');
+      expect(builder.toVelesQL()).toBe('MATCH (d:Document) WHERE vector NEAR $query RETURN *');
       expect(builder.getParams()).toEqual({ query: embedding });
     });
 
-    it('should add vector NEAR with top_k', () => {
+    it('should map topK to LIMIT (no TOP keyword exists in the grammar)', () => {
       const embedding = [0.1, 0.2, 0.3];
       const builder = velesql()
         .match('d', 'Document')
         .nearVector('$query', embedding, { topK: 50 });
-      
-      expect(builder.toVelesQL()).toBe('MATCH (d:Document) WHERE vector NEAR $query TOP 50');
+
+      const query = builder.toVelesQL();
+      expect(query).not.toContain('TOP');
+      expect(query).toBe('MATCH (d:Document) WHERE vector NEAR $query RETURN * LIMIT 50');
       expect(builder.getParams()).toEqual({ query: embedding });
+    });
+
+    it('should not override an explicit LIMIT with topK', () => {
+      const embedding = [0.1, 0.2, 0.3];
+      const builder = velesql()
+        .match('d', 'Document')
+        .nearVector('$query', embedding, { topK: 50 })
+        .limit(5);
+
+      expect(builder.toVelesQL()).toBe('MATCH (d:Document) WHERE vector NEAR $query RETURN * LIMIT 5');
     });
 
     it('should combine NEAR with other WHERE conditions', () => {
@@ -96,7 +108,7 @@ describe('VelesQLBuilder', () => {
         .nearVector('$query', embedding)
         .andWhere('d.category = $cat', { cat: 'tech' });
       
-      expect(builder.toVelesQL()).toBe('MATCH (d:Document) WHERE vector NEAR $query AND d.category = $cat');
+      expect(builder.toVelesQL()).toBe('MATCH (d:Document) WHERE vector NEAR $query AND d.category = $cat RETURN *');
     });
   });
 
@@ -107,7 +119,7 @@ describe('VelesQLBuilder', () => {
         .rel('KNOWS')
         .to('b', 'Person');
       
-      expect(builder.toVelesQL()).toBe('MATCH (a:Person)-[:KNOWS]->(b:Person)');
+      expect(builder.toVelesQL()).toBe('MATCH (a:Person)-[:KNOWS]->(b:Person) RETURN *');
     });
 
     it('should build relationship with alias', () => {
@@ -115,8 +127,8 @@ describe('VelesQLBuilder', () => {
         .match('a', 'Person')
         .rel('KNOWS', 'r')
         .to('b', 'Person');
-      
-      expect(builder.toVelesQL()).toBe('MATCH (a:Person)-[r:KNOWS]->(b:Person)');
+
+      expect(builder.toVelesQL()).toBe('MATCH (a:Person)-[r:KNOWS]->(b:Person) RETURN *');
     });
 
     it('should build bidirectional relationship', () => {
@@ -124,8 +136,8 @@ describe('VelesQLBuilder', () => {
         .match('a', 'Person')
         .rel('KNOWS', 'r', { direction: 'both' })
         .to('b', 'Person');
-      
-      expect(builder.toVelesQL()).toBe('MATCH (a:Person)-[r:KNOWS]-(b:Person)');
+
+      expect(builder.toVelesQL()).toBe('MATCH (a:Person)-[r:KNOWS]-(b:Person) RETURN *');
     });
 
     it('should build incoming relationship', () => {
@@ -133,8 +145,8 @@ describe('VelesQLBuilder', () => {
         .match('a', 'Person')
         .rel('FOLLOWS', 'r', { direction: 'incoming' })
         .to('b', 'Person');
-      
-      expect(builder.toVelesQL()).toBe('MATCH (a:Person)<-[r:FOLLOWS]-(b:Person)');
+
+      expect(builder.toVelesQL()).toBe('MATCH (a:Person)<-[r:FOLLOWS]-(b:Person) RETURN *');
     });
 
     it('should build variable-length path', () => {
@@ -142,54 +154,45 @@ describe('VelesQLBuilder', () => {
         .match('a', 'Person')
         .rel('KNOWS', 'p', { minHops: 1, maxHops: 3 })
         .to('b', 'Person');
-      
-      expect(builder.toVelesQL()).toBe('MATCH (a:Person)-[p:KNOWS*1..3]->(b:Person)');
+
+      expect(builder.toVelesQL()).toBe('MATCH (a:Person)-[p:KNOWS*1..3]->(b:Person) RETURN *');
     });
   });
 
-  describe('LIMIT and ORDER BY', () => {
-    it('should add LIMIT clause', () => {
+  describe('LIMIT and ORDER BY (MATCH mode — ORDER BY/LIMIT come AFTER RETURN)', () => {
+    it('should add LIMIT clause after RETURN', () => {
       const builder = velesql()
         .match('n', 'Person')
         .limit(10);
-      
-      expect(builder.toVelesQL()).toBe('MATCH (n:Person) LIMIT 10');
+
+      expect(builder.toVelesQL()).toBe('MATCH (n:Person) RETURN * LIMIT 10');
     });
 
-    it('should add OFFSET clause', () => {
-      const builder = velesql()
-        .match('n', 'Person')
-        .limit(10)
-        .offset(20);
-      
-      expect(builder.toVelesQL()).toBe('MATCH (n:Person) LIMIT 10 OFFSET 20');
-    });
-
-    it('should add ORDER BY clause', () => {
+    it('should add ORDER BY clause after RETURN', () => {
       const builder = velesql()
         .match('n', 'Person')
         .orderBy('n.name');
-      
-      expect(builder.toVelesQL()).toBe('MATCH (n:Person) ORDER BY n.name');
+
+      expect(builder.toVelesQL()).toBe('MATCH (n:Person) RETURN * ORDER BY n.name');
     });
 
-    it('should add ORDER BY DESC', () => {
+    it('should add ORDER BY DESC after RETURN', () => {
       const builder = velesql()
         .match('n', 'Person')
         .orderBy('n.createdAt', 'DESC');
-      
-      expect(builder.toVelesQL()).toBe('MATCH (n:Person) ORDER BY n.createdAt DESC');
+
+      expect(builder.toVelesQL()).toBe('MATCH (n:Person) RETURN * ORDER BY n.createdAt DESC');
     });
 
-    it('should add ORDER BY with score', () => {
+    it('should add ORDER BY with score (RETURN before ORDER BY/LIMIT)', () => {
       const embedding = [0.1, 0.2, 0.3];
       const builder = velesql()
         .match('d', 'Document')
         .nearVector('$q', embedding)
         .orderBy('score', 'DESC')
         .limit(20);
-      
-      expect(builder.toVelesQL()).toBe('MATCH (d:Document) WHERE vector NEAR $q ORDER BY score DESC LIMIT 20');
+
+      expect(builder.toVelesQL()).toBe('MATCH (d:Document) WHERE vector NEAR $q RETURN * ORDER BY score DESC LIMIT 20');
     });
   });
 
@@ -219,30 +222,133 @@ describe('VelesQLBuilder', () => {
     });
   });
 
-  describe('Fusion options', () => {
-    it('should add RRF fusion', () => {
+  describe('Fusion options (real USING FUSION clause, SELECT mode)', () => {
+    it('should emit a real USING FUSION(strategy=...) clause, not an inert comment', () => {
       const embedding = [0.1, 0.2, 0.3];
       const builder = velesql()
-        .match('d', 'Document')
+        .from('docs')
         .nearVector('$q', embedding)
+        .andWhere("content MATCH 'x'")
         .fusion('rrf', { k: 60 });
-      
-      expect(builder.toVelesQL()).toContain('FUSION rrf');
+
+      const query = builder.toVelesQL();
+      expect(query).not.toContain('/*');
+      expect(query).toContain("USING FUSION(strategy='rrf', k=60)");
       expect(builder.getFusionOptions()).toEqual({ strategy: 'rrf', k: 60 });
     });
 
-    it('should add weighted fusion', () => {
+    it('should emit weighted fusion with vector_weight + graph_weight', () => {
       const embedding = [0.1, 0.2, 0.3];
       const builder = velesql()
-        .match('d', 'Document')
+        .from('docs')
         .nearVector('$q', embedding)
+        .andWhere("content MATCH 'x'")
         .fusion('weighted', { vectorWeight: 0.7, graphWeight: 0.3 });
-      
-      expect(builder.getFusionOptions()).toEqual({ 
-        strategy: 'weighted', 
-        vectorWeight: 0.7, 
-        graphWeight: 0.3 
+
+      const query = builder.toVelesQL();
+      expect(query).toContain("USING FUSION(strategy='weighted', vector_weight=0.7, graph_weight=0.3)");
+      expect(builder.getFusionOptions()).toEqual({
+        strategy: 'weighted',
+        vectorWeight: 0.7,
+        graphWeight: 0.3,
       });
+    });
+
+    it('should emit weighted fusion with only vector_weight (verify #11 exact string)', () => {
+      const embedding = [0.1, 0.2, 0.3];
+      const builder = velesql()
+        .from('docs')
+        .nearVector('$q', embedding)
+        .andWhere("content MATCH 'x'")
+        .fusion('weighted', { vectorWeight: 0.7 });
+
+      expect(builder.toVelesQL()).toContain("USING FUSION(strategy='weighted', vector_weight=0.7");
+    });
+  });
+
+  describe('SELECT mode (from())', () => {
+    it('should build a plain SELECT * FROM', () => {
+      const builder = velesql().from('docs');
+      expect(builder.toVelesQL()).toBe('SELECT * FROM docs');
+    });
+
+    it('should project named columns', () => {
+      const builder = velesql().from('docs').select(['title', 'category']);
+      expect(builder.toVelesQL()).toBe('SELECT title, category FROM docs');
+    });
+
+    it('should support the README vector-similarity-with-filters example (no more parse error)', () => {
+      const queryVector = [0.1, 0.2, 0.3];
+      const builder = velesql()
+        .from('documents', 'd')
+        .nearVector('$queryVector', queryVector)
+        .andWhere('d.category = $cat', { cat: 'tech' })
+        .orderBy('score', 'DESC')
+        .limit(10);
+
+      expect(builder.toVelesQL()).toBe(
+        "SELECT * FROM documents WHERE vector NEAR $queryVector AND d.category = $cat ORDER BY score DESC LIMIT 10"
+      );
+    });
+
+    it('should place LIMIT/OFFSET before USING FUSION', () => {
+      const embedding = [0.1, 0.2, 0.3];
+      const builder = velesql()
+        .from('docs')
+        .nearVector('$q', embedding)
+        .andWhere("content MATCH 'x'")
+        .limit(10)
+        .offset(5)
+        .fusion('maximum');
+
+      expect(builder.toVelesQL()).toBe(
+        "SELECT * FROM docs WHERE vector NEAR $q AND content MATCH 'x' LIMIT 10 OFFSET 5 USING FUSION(strategy='maximum')"
+      );
+    });
+  });
+
+  describe('nearFused (typed multi-vector fusion, #27)', () => {
+    const a = [0.1, 0.2, 0.3];
+    const b = [0.4, 0.5, 0.6];
+
+    it('emits NEAR_FUSED with the inline USING FUSION string form', () => {
+      const builder = velesql()
+        .from('docs')
+        .nearFused(['$a', '$b'], [a, b], { strategy: 'average' })
+        .limit(10);
+
+      expect(builder.toVelesQL()).toBe(
+        "SELECT * FROM docs WHERE vector NEAR_FUSED [$a, $b] USING FUSION 'average' LIMIT 10"
+      );
+      expect(builder.getParams()).toEqual({ a, b });
+    });
+
+    it('omits USING FUSION when no strategy is given (defaults to engine RRF)', () => {
+      const builder = velesql()
+        .from('docs')
+        .nearFused(['$a', '$b'], [a, b]);
+
+      expect(builder.toVelesQL()).toBe('SELECT * FROM docs WHERE vector NEAR_FUSED [$a, $b]');
+    });
+
+    it('rejects a vector/param count mismatch', () => {
+      expect(() => velesql().from('docs').nearFused(['$a'], [a, b])).toThrow();
+    });
+
+    it('rejects fewer than two vectors', () => {
+      expect(() => velesql().from('docs').nearFused(['$a'], [a])).toThrow();
+    });
+
+    it('compile-time guard: weighted/relative_score are NOT assignable to the strategy type', () => {
+      const builder = velesql().from('docs');
+      // @ts-expect-error 'weighted' silently downgrades to RRF — disallowed by the typed builder.
+      builder.nearFused(['$a', '$b'], [a, b], { strategy: 'weighted' });
+      // @ts-expect-error 'relative_score' is not a valid NEAR_FUSED strategy.
+      builder.nearFused(['$a', '$b'], [a, b], { strategy: 'relative_score' });
+      // Allowed strategies must still type-check.
+      builder.nearFused(['$a', '$b'], [a, b], { strategy: 'rrf' });
+      builder.nearFused(['$a', '$b'], [a, b], { strategy: 'average' });
+      builder.nearFused(['$a', '$b'], [a, b], { strategy: 'maximum' });
     });
   });
 
@@ -260,12 +366,12 @@ describe('VelesQLBuilder', () => {
       
       const query = builder.toVelesQL();
       expect(query).toContain('MATCH (d:Document)');
-      expect(query).toContain('vector NEAR $embedding TOP 100');
+      expect(query).not.toContain('TOP');
+      expect(query).toContain('vector NEAR $embedding');
       expect(query).toContain('d.language = $lang');
       expect(query).toContain('d.published = $pub');
-      expect(query).toContain('ORDER BY score DESC');
-      expect(query).toContain('LIMIT 20');
-      expect(query).toContain('RETURN d.title, d.content, score');
+      // RETURN must precede ORDER BY/LIMIT in MATCH mode.
+      expect(query).toContain('RETURN d.title, d.content, score ORDER BY score DESC LIMIT 20');
       
       expect(builder.getParams()).toEqual({
         embedding: embedding,
@@ -300,8 +406,8 @@ describe('VelesQLBuilder', () => {
       const builder1 = velesql().match('n', 'Person');
       const builder2 = builder1.where('n.age > 21');
       
-      expect(builder1.toVelesQL()).toBe('MATCH (n:Person)');
-      expect(builder2.toVelesQL()).toBe('MATCH (n:Person) WHERE n.age > 21');
+      expect(builder1.toVelesQL()).toBe('MATCH (n:Person) RETURN *');
+      expect(builder2.toVelesQL()).toBe('MATCH (n:Person) WHERE n.age > 21 RETURN *');
     });
   });
 


### PR DESCRIPTION
## Summary

TypeScript SDK fixes. The headline: the `velesql()` builder previously emitted strings the core parser **cannot parse** — and the existing tests only string-matched, so it shipped. This adds the **first real-parser round-trip test** (loads `@wiscale/velesdb-wasm` `VelesQL.parse` in Node) and fixes the bugs it exposes.

### #11 — `velesql()` builder emitted invalid/inert VelesQL
- `nearVector({topK})` emitted `vector NEAR $q TOP 50` — there is no `TOP` keyword. `topK` now maps to `LIMIT`.
- `toVelesQL()` always prefixed `MATCH` and emitted `ORDER BY`/`LIMIT` **before** the mandatory `RETURN` (a parse error). Now a `from()`/`select()` **SELECT mode** is available (clause order `WHERE → ORDER BY → LIMIT → OFFSET → USING FUSION`), and MATCH mode always emits `RETURN` (default `RETURN *`) **before** `ORDER BY`/`LIMIT`. The README "Vector similarity with filters" example (a hard parse error before) now uses SELECT mode and parses.
- `.fusion()` rendered an inert `/* FUSION x */` comment, dropping strategy + weights. It now emits a real `USING FUSION(strategy='…', …)` clause.
- **New `tests/query-builder-roundtrip.test.ts`** feeds every builder output through the real WASM parser → zero syntax errors (incl. all 5 fusion strategies + NEAR_FUSED).

### #27 (ts) — typed `setAutoReindex`/`alterCollection` + guarded `nearFused`
- `db.setAutoReindex(name, bool)` / `db.alterCollection(name, {autoReindex})` emit + route a valid `ALTER COLLECTION … SET(auto_reindex=…)` (verified parseable).
- Typed `nearFused(params, vectors, {strategy})` whose `strategy` type is `'rrf' | 'average' | 'maximum'` **only** — a **compile-time guard** against the `weighted`/`rsf` → silent-RRF trap (proven: widening the type fails `tsc` with TS2578 on the `@ts-expect-error` in `examples/typed_guards.ts`).

## Test plan
- Failing-test-first (stash impl, keep tests): 46 failures on baseline (unparseable output / missing methods), **861/861 pass** after (+25 new).
- Gates: `npm ci`; `npm run build` (tsup); `npm run typecheck` (incl. `tsconfig.examples.json` — the compile-time guard); `npm test` (vitest, 861/0); `npm run lint` (clean). Rebased onto the merged Python wave — no conflict.

## Notes
- Grammar facts pinned by the real parser: MATCH requires `RETURN` + rejects `OFFSET`; NEAR_FUSED uses the inline `USING FUSION '<x>'` string form; fusion `strategy` must be single-quoted (the backlog's unquoted example doesn't parse — the parseable quoted form is emitted).
- Non-blocking: `.fusion()` in MATCH mode is a silent no-op (grammar-correct — MATCH has no FUSION clause); future doc/throw.