### PR TITLE
fix(server): route /match + graph handlers through canonical VELES error codes (#13)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,25 @@ explicit errors or real values — review the SemVer impact before the next
 release.
 
 ### Changed
+- **Graph / `MATCH` REST error responses now use the canonical `VELES-XXX`
+  error codes and correct 4xx HTTP statuses instead of bespoke strings and
+  blanket 500s.** `POST /collections/{name}/match` previously hand-rolled
+  invented codes (`COLLECTION_NOT_FOUND`, `PARSE_ERROR`, `EXECUTION_ERROR`,
+  `NOT_MATCH_QUERY`, `INVALID_THRESHOLD`) with a `hint`/`details` body and
+  mapped every execution failure to `500`. It now routes through the shared
+  `auto_core_error_response`, so a missing collection returns `404` +
+  `VELES-002`, a parse error / non-MATCH query / invalid threshold / unbound
+  bind parameter returns `400` + `VELES-010`, etc. The graph edge mutation
+  handlers (`POST .../graph/edges`, `.../graph/edges/batch`) likewise route
+  through it, so a duplicate edge now returns `409` + `VELES-019` instead of a
+  generic `500` string. The search timeout response carries the canonical
+  `VELES-027` code (was the malformed `VELES-QUERY-TIMEOUT`), and the
+  guard-rail rate-limit (`429`) / circuit-breaker (`503`) responses now include
+  the `VELES-027` code in the body (previously `code: null`). *(Behavior change:
+  HTTP status codes for several `/match` and graph-mutation client errors move
+  from `500` to `404`/`400`/`409`; the `code` field values change; the `/match`
+  error body drops the `hint`/`details` fields in favor of the standard
+  `{ "error", "code" }` shape. SemVer-observable for REST consumers.)*
 - **Query-shape and bind-parameter rejections now classify as `VELES-010`
   (`Query`) instead of `VELES-009` (`Config`).** Live query-path failures that
   describe a malformed *query* — an unsupported query shape (multiple

--- a/crates/velesdb-server/src/handlers/graph/handlers.rs
+++ b/crates/velesdb-server/src/handlers/graph/handlers.rs
@@ -10,10 +10,12 @@ use std::sync::Arc;
 use axum::{
     extract::{Path, Query, State},
     http::StatusCode,
+    response::IntoResponse,
     Json,
 };
 use velesdb_core::collection::graph::{GraphEdge, TraversalConfig};
 
+use crate::handlers::helpers::auto_core_error_response;
 use crate::types::ErrorResponse;
 use crate::AppState;
 
@@ -156,22 +158,23 @@ pub async fn add_edge(
     Path(name): Path<String>,
     State(state): State<Arc<AppState>>,
     Json(request): Json<AddEdgeRequest>,
-) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
-    let edge = build_edge(request)?;
+) -> axum::response::Response {
+    let edge = match build_edge(request) {
+        Ok(e) => e,
+        Err(resp) => return resp.into_response(),
+    };
 
-    let coll = graph_preamble(&state, &name)?;
+    let coll = match graph_preamble(&state, &name) {
+        Ok(c) => c,
+        Err(resp) => return resp.into_response(),
+    };
 
-    coll.add_edge(edge).map_err(|e| {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(ErrorResponse {
-                error: format!("Failed to add edge: {e}"),
-                code: None,
-            }),
-        )
-    })?;
-
-    Ok(StatusCode::CREATED)
+    // Route the core error through `auto_core_error_response` so e.g.
+    // `EdgeExists` surfaces as 409 + VELES-019 instead of a generic 500 string.
+    match coll.add_edge(edge) {
+        Ok(()) => StatusCode::CREATED.into_response(),
+        Err(e) => auto_core_error_response(&e),
+    }
 }
 
 /// Converts an [`AddEdgeRequest`] into a core [`GraphEdge`], validating the
@@ -225,26 +228,28 @@ pub async fn add_edges_batch(
     Path(name): Path<String>,
     State(state): State<Arc<AppState>>,
     Json(request): Json<AddEdgesBatchRequest>,
-) -> Result<(StatusCode, Json<AddEdgesBatchResponse>), (StatusCode, Json<ErrorResponse>)> {
-    let edges = request
+) -> axum::response::Response {
+    let edges = match request
         .edges
         .into_iter()
         .map(build_edge)
-        .collect::<Result<Vec<_>, _>>()?;
+        .collect::<Result<Vec<_>, _>>()
+    {
+        Ok(edges) => edges,
+        Err(resp) => return resp.into_response(),
+    };
 
-    let coll = graph_preamble(&state, &name)?;
+    let coll = match graph_preamble(&state, &name) {
+        Ok(c) => c,
+        Err(resp) => return resp.into_response(),
+    };
 
-    let added = coll.add_edges_batch(edges).map_err(|e| {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(ErrorResponse {
-                error: format!("Failed to add edges: {e}"),
-                code: None,
-            }),
-        )
-    })?;
-
-    Ok((StatusCode::CREATED, Json(AddEdgesBatchResponse { added })))
+    // Route the core error through `auto_core_error_response` so e.g.
+    // `EdgeExists` surfaces as 409 + VELES-019 instead of a generic 500 string.
+    match coll.add_edges_batch(edges) {
+        Ok(added) => (StatusCode::CREATED, Json(AddEdgesBatchResponse { added })).into_response(),
+        Err(e) => auto_core_error_response(&e),
+    }
 }
 
 /// Traverse the graph using BFS or DFS from a source node.

--- a/crates/velesdb-server/src/handlers/helpers.rs
+++ b/crates/velesdb-server/src/handlers/helpers.rs
@@ -187,7 +187,10 @@ pub(crate) fn apply_pre_check(
             status,
             Json(ErrorResponse {
                 error: msg,
-                code: None,
+                // Guard-rail violations map to VELES-027 (the core
+                // `Error::GuardRail` code) so SDK clients can discriminate
+                // rate-limit / circuit-breaker rejections by code.
+                code: Some("VELES-027".to_string()),
             }),
         )
             .into_response());
@@ -236,5 +239,30 @@ mod tests {
         };
         let resp = core_error_response(StatusCode::BAD_REQUEST, &err);
         assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    /// Backlog #13(d): a rate-limit pre-check rejection must return 429 with the
+    /// canonical `VELES-027` guard-rail code in the body (previously `code: None`).
+    #[tokio::test]
+    async fn test_apply_pre_check_rate_limit_carries_veles_027() {
+        let limits = velesdb_core::guardrails::QueryLimits {
+            rate_limit_qps: 1,
+            ..Default::default()
+        };
+        let guard_rails = velesdb_core::guardrails::GuardRails::with_limits(limits);
+
+        // First call consumes the only token; the second trips the limiter.
+        guard_rails
+            .pre_check("client")
+            .expect("first pre-check allowed");
+        let response =
+            apply_pre_check(&guard_rails, "client").expect_err("second pre-check must reject");
+
+        assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("read rate-limit body");
+        let json: serde_json::Value = serde_json::from_slice(&body).expect("valid JSON");
+        assert_eq!(json["code"], "VELES-027");
     }
 }

--- a/crates/velesdb-server/src/handlers/match_query.rs
+++ b/crates/velesdb-server/src/handlers/match_query.rs
@@ -6,7 +6,7 @@
 
 use axum::{
     extract::{Path, State},
-    http::StatusCode,
+    response::IntoResponse,
     Json,
 };
 use serde::{Deserialize, Serialize};
@@ -14,8 +14,10 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use utoipa::ToSchema;
 use velesdb_core::api_types::serde_id;
+use velesdb_core::Error;
 
-use crate::types::VELESQL_CONTRACT_VERSION;
+use crate::handlers::helpers::auto_core_error_response;
+use crate::types::{ErrorResponse, VELESQL_CONTRACT_VERSION};
 use crate::AppState;
 
 /// Request body for MATCH query execution.
@@ -71,21 +73,6 @@ pub struct MatchQueryMeta {
     pub velesql_contract_version: String,
 }
 
-/// Error response for MATCH query.
-#[derive(Debug, Serialize, ToSchema)]
-pub struct MatchQueryError {
-    /// Error message.
-    pub error: String,
-    /// Error code.
-    pub code: String,
-    /// Actionable hint for developers.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub hint: Option<String>,
-    /// Optional details for diagnostics.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub details: Option<serde_json::Value>,
-}
-
 /// Execute a MATCH query on a collection.
 ///
 /// # Endpoint
@@ -105,10 +92,13 @@ pub struct MatchQueryError {
 ///
 /// # Errors
 ///
-/// Returns error tuple with status code and JSON error in these cases:
-/// - `404 NOT_FOUND` - Collection not found
-/// - `400 BAD_REQUEST` - Parse error or not a MATCH query
-/// - `500 INTERNAL_SERVER_ERROR` - Execution error
+/// All failures are mapped through the canonical `auto_core_error_response`,
+/// so the JSON body carries the `VELES-XXX` code and the HTTP status is
+/// derived from the core error variant:
+/// - `404 NOT_FOUND` (`VELES-002`) — collection not found
+/// - `400 BAD_REQUEST` (`VELES-010`) — parse error, not a MATCH query,
+///   invalid threshold, or an unbound query parameter
+/// - other core variants map per [`super::helpers::http_status_for_error`]
 #[utoipa::path(
     post,
     path = "/collections/{name}/match",
@@ -117,102 +107,76 @@ pub struct MatchQueryError {
     request_body = MatchQueryRequest,
     responses(
         (status = 200, description = "Match query results", body = MatchQueryResponse),
-        (status = 400, description = "Parse error or invalid query", body = MatchQueryError),
-        (status = 404, description = "Collection not found", body = MatchQueryError),
-        (status = 500, description = "Internal server error", body = MatchQueryError)
+        (status = 400, description = "Parse error or invalid query", body = ErrorResponse),
+        (status = 404, description = "Collection not found", body = ErrorResponse),
+        (status = 500, description = "Internal server error", body = ErrorResponse)
     )
 )]
 pub async fn match_query(
     Path(collection_name): Path<String>,
     State(state): State<Arc<AppState>>,
     Json(request): Json<MatchQueryRequest>,
-) -> Result<Json<MatchQueryResponse>, (StatusCode, Json<MatchQueryError>)> {
+) -> axum::response::Response {
+    match run_match(&state, &collection_name, &request) {
+        Ok(response) => Json(response).into_response(),
+        Err(e) => auto_core_error_response(&e),
+    }
+}
+
+/// Resolve, parse, validate, and execute a MATCH request, surfacing every
+/// failure as a `velesdb_core::Error` so the handler can route it through
+/// `auto_core_error_response` (canonical VELES code + HTTP status).
+fn run_match(
+    state: &AppState,
+    collection_name: &str,
+    request: &MatchQueryRequest,
+) -> Result<MatchQueryResponse, Error> {
     let start = std::time::Instant::now();
 
-    let collection = resolve_match_collection(&state, &collection_name).ok_or_else(|| {
-        mk_match_error(
-            StatusCode::NOT_FOUND,
-            format!("Collection '{}' not found", collection_name),
-            "COLLECTION_NOT_FOUND",
-            "Create the collection first or correct the collection name in the route",
-            Some(serde_json::json!({ "collection": collection_name })),
-        )
-    })?;
+    let collection = resolve_match_collection(state, collection_name)
+        .ok_or_else(|| Error::CollectionNotFound(collection_name.to_string()))?;
 
     let match_clause = parse_match_clause(&request.query)?;
     validate_threshold(request.threshold)?;
 
-    let results = execute_match(&collection, &match_clause, &request)?;
+    let results = execute_match(&collection, &match_clause, request)?;
 
     let count = results.len();
     #[allow(clippy::cast_possible_truncation)]
     let took_ms = start.elapsed().as_millis() as u64;
 
-    Ok(Json(MatchQueryResponse {
+    Ok(MatchQueryResponse {
         results,
         took_ms,
         count,
         meta: MatchQueryMeta {
             velesql_contract_version: VELESQL_CONTRACT_VERSION.to_string(),
         },
-    }))
-}
-
-/// Build a match query error tuple.
-fn mk_match_error(
-    status: StatusCode,
-    error: String,
-    code: &str,
-    hint: &str,
-    details: Option<serde_json::Value>,
-) -> (StatusCode, Json<MatchQueryError>) {
-    (
-        status,
-        Json(MatchQueryError {
-            error,
-            code: code.to_string(),
-            hint: Some(hint.to_string()),
-            details,
-        }),
-    )
+    })
 }
 
 /// Parse a query string and extract the MATCH clause.
-fn parse_match_clause(
-    query_str: &str,
-) -> Result<velesdb_core::velesql::MatchClause, (StatusCode, Json<MatchQueryError>)> {
-    let query = velesdb_core::velesql::Parser::parse(query_str).map_err(|e| {
-        mk_match_error(
-            StatusCode::BAD_REQUEST,
-            format!("Parse error: {}", e),
-            "PARSE_ERROR",
-            "Check MATCH syntax and bound parameters",
-            None,
-        )
-    })?;
-
+///
+/// Both a syntax error and a non-MATCH query are client-side query mistakes,
+/// so they map to `Error::Query` (`VELES-010`, 400).
+fn parse_match_clause(query_str: &str) -> Result<velesdb_core::velesql::MatchClause, Error> {
+    let query = velesdb_core::velesql::Parser::parse(query_str)?;
     query.match_clause.ok_or_else(|| {
-        mk_match_error(
-            StatusCode::BAD_REQUEST,
-            "Query is not a MATCH query".to_string(),
-            "NOT_MATCH_QUERY",
-            "Use MATCH (...) RETURN ... or call /query for SELECT statements",
-            None,
+        Error::Query(
+            "Query is not a MATCH query. Use MATCH (...) RETURN ... \
+             or call /query for SELECT statements."
+                .to_string(),
         )
     })
 }
 
 /// Validate that threshold (if provided) is in [0.0, 1.0].
-fn validate_threshold(threshold: Option<f32>) -> Result<(), (StatusCode, Json<MatchQueryError>)> {
+fn validate_threshold(threshold: Option<f32>) -> Result<(), Error> {
     if let Some(t) = threshold {
         if !(0.0..=1.0).contains(&t) {
-            return Err(mk_match_error(
-                StatusCode::BAD_REQUEST,
-                format!("Invalid threshold: {}. Must be between 0.0 and 1.0", t),
-                "INVALID_THRESHOLD",
-                "Provide threshold in inclusive range [0.0, 1.0]",
-                Some(serde_json::json!({ "threshold": t })),
-            ));
+            return Err(Error::Query(format!(
+                "Invalid threshold: {t}. Must be between 0.0 and 1.0"
+            )));
         }
     }
     Ok(())
@@ -240,7 +204,7 @@ fn execute_match(
     collection: &MatchCollection,
     match_clause: &velesdb_core::velesql::MatchClause,
     request: &MatchQueryRequest,
-) -> Result<Vec<MatchQueryResultItem>, (StatusCode, Json<MatchQueryError>)> {
+) -> Result<Vec<MatchQueryResultItem>, Error> {
     let raw_results = if let Some(ref vector) = request.vector {
         let threshold = request.threshold.unwrap_or(0.0);
         match collection {
@@ -258,27 +222,17 @@ fn execute_match(
         }
     };
 
-    raw_results
-        .map(|results| {
-            results
-                .into_iter()
-                .map(|r| MatchQueryResultItem {
-                    bindings: r.bindings,
-                    score: r.score,
-                    depth: r.depth,
-                    projected: r.projected,
-                })
-                .collect()
-        })
-        .map_err(|e| {
-            mk_match_error(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Execution error: {}", e),
-                "EXECUTION_ERROR",
-                "Validate graph labels/properties and parameter types for this collection",
-                None,
-            )
-        })
+    raw_results.map(|results| {
+        results
+            .into_iter()
+            .map(|r| MatchQueryResultItem {
+                bindings: r.bindings,
+                score: r.score,
+                depth: r.depth,
+                projected: r.projected,
+            })
+            .collect()
+    })
 }
 
 #[cfg(test)]

--- a/crates/velesdb-server/src/handlers/search/pipeline.rs
+++ b/crates/velesdb-server/src/handlers/search/pipeline.rs
@@ -595,7 +595,7 @@ pub(crate) fn timeout_response(collection_name: &str, timeout_ms: u64) -> axum::
                  early; the in-flight query may continue in the background \
                  until completion.",
             ),
-            code: Some("VELES-QUERY-TIMEOUT".to_string()),
+            code: Some("VELES-027".to_string()),
         }),
     )
         .into_response()
@@ -745,5 +745,26 @@ mod parse_fusion_strategy_tests {
                 .unwrap_or_else(|_| panic!("'{alias}' must parse"));
             assert!(matches!(result, velesdb_core::FusionStrategy::RRF { .. }));
         }
+    }
+}
+
+#[cfg(test)]
+mod timeout_response_tests {
+    use super::timeout_response;
+    use axum::http::StatusCode;
+
+    /// Backlog #13(c): the timeout response must carry the canonical
+    /// `VELES-027` guard-rail code, not the malformed `VELES-QUERY-TIMEOUT`
+    /// that lived outside the `VELES-NNN` namespace.
+    #[tokio::test]
+    async fn test_timeout_response_uses_veles_027() {
+        let response = timeout_response("docs", 250);
+        assert_eq!(response.status(), StatusCode::REQUEST_TIMEOUT);
+
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("read timeout body");
+        let json: serde_json::Value = serde_json::from_slice(&body).expect("valid JSON");
+        assert_eq!(json["code"], "VELES-027");
     }
 }

--- a/crates/velesdb-server/src/lib.rs
+++ b/crates/velesdb-server/src/lib.rs
@@ -248,7 +248,6 @@ pub use handlers::metrics::{health_metrics, prometheus_metrics};
             handlers::match_query::MatchQueryResponse,
             handlers::match_query::MatchQueryResultItem,
             handlers::match_query::MatchQueryMeta,
-            handlers::match_query::MatchQueryError,
             handlers::points::BulkDeleteRequest,
             handlers::points::relations::RelateRequest,
             handlers::points::relations::RelateResponse,

--- a/crates/velesdb-server/tests/api_integration.rs
+++ b/crates/velesdb-server/tests/api_integration.rs
@@ -4210,7 +4210,7 @@ async fn test_search_with_generous_timeout_returns_200() {
 }
 
 /// Negative: a search with `timeout_ms: 0` yields an immediate timeout.
-/// The handler must return 408 Request Timeout with a VELES-QUERY-TIMEOUT
+/// The handler must return 408 Request Timeout with the canonical VELES-027
 /// error code, not 200 with the results. The `tokio::time::timeout`
 /// wrapper fires on the very next runtime tick after the worker is
 /// spawned, so this deterministic test will always see the elapsed
@@ -4252,8 +4252,8 @@ async fn test_search_with_zero_timeout_returns_408() {
     let json: Value = serde_json::from_slice(&body).expect("test: parse json");
     assert_eq!(
         json["code"].as_str(),
-        Some("VELES-QUERY-TIMEOUT"),
-        "error code must be VELES-QUERY-TIMEOUT, got: {}",
+        Some("VELES-027"),
+        "timeout error code must be the canonical VELES-027, got: {}",
         json["code"]
     );
     let error_msg = json["error"].as_str().expect("error field");

--- a/crates/velesdb-server/tests/common/mod.rs
+++ b/crates/velesdb-server/tests/common/mod.rs
@@ -15,10 +15,11 @@ use velesdb_server::{
     batch_search, bulk_delete_points, collection_diagnostics, collection_sanity,
     compact_collection, create_collection, delete_collection, delete_point, enable_streaming,
     explain, get_collection, get_collection_config, get_edges, get_node_degree, get_point,
-    health_check, hybrid_search, list_collections, multi_query_search, multi_query_search_ids,
-    query, readiness_check, rebuild_index, reorder_for_locality, scroll_points, search, search_ids,
-    set_point_ttl, stream_insert, stream_upsert_points, text_search, traverse_graph, upsert_points,
-    upsert_points_raw, vacuum_collection, AppState, OnboardingMetrics,
+    health_check, hybrid_search, list_collections, match_query, multi_query_search,
+    multi_query_search_ids, query, readiness_check, rebuild_index, reorder_for_locality,
+    scroll_points, search, search_ids, set_point_ttl, stream_insert, stream_upsert_points,
+    text_search, traverse_graph, upsert_points, upsert_points_raw, vacuum_collection, AppState,
+    OnboardingMetrics,
 };
 
 fn base_routes() -> Router<Arc<AppState>> {
@@ -64,6 +65,7 @@ fn base_routes() -> Router<Arc<AppState>> {
         .route("/collections/{name}/search/text", post(text_search))
         .route("/collections/{name}/search/hybrid", post(hybrid_search))
         .route("/collections/{name}/search/ids", post(search_ids))
+        .route("/collections/{name}/match", post(match_query))
         .route("/query", post(query))
         .route("/aggregate", post(aggregate))
         .route("/query/explain", post(explain))

--- a/crates/velesdb-server/tests/match_api_tests.rs
+++ b/crates/velesdb-server/tests/match_api_tests.rs
@@ -2,16 +2,44 @@
 //!
 //! Tests the hybrid MATCH + similarity + property projection API.
 
-use serde_json::json;
+mod common;
 
-/// Test not MATCH query error response.
-#[test]
-fn test_match_not_match_query_error() {
-    let error = json!({
-        "error": "Query is not a MATCH query",
-        "code": "NOT_MATCH_QUERY",
-        "hint": "Use MATCH (...) RETURN ... or call /query for SELECT statements"
-    });
+use axum::{
+    body::Body,
+    http::{Request, StatusCode},
+};
+use common::{create_graph_collection, create_test_app};
+use serde_json::{json, Value};
+use tempfile::TempDir;
+use tower::ServiceExt;
 
-    assert_eq!(error["code"], "NOT_MATCH_QUERY");
+/// A non-MATCH query (e.g. a SELECT) sent to `/match` is a query-shape client
+/// mistake and now surfaces the canonical `VELES-010` code with a 400 status,
+/// not the former bespoke `NOT_MATCH_QUERY` string.
+#[tokio::test]
+async fn test_match_not_match_query_returns_veles_010() {
+    let temp_dir = TempDir::new().expect("temp dir");
+    let app = create_test_app(&temp_dir);
+    create_graph_collection(&app, "social").await;
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/collections/social/match")
+                .header("Content-Type", "application/json")
+                .body(Body::from(
+                    json!({ "query": "SELECT * FROM social" }).to_string(),
+                ))
+                .expect("build request"),
+        )
+        .await
+        .expect("request");
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("read body");
+    let json: Value = serde_json::from_slice(&body).expect("valid JSON");
+    assert_eq!(json["code"], "VELES-010");
 }

--- a/crates/velesdb-server/tests/match_error_codes_tests.rs
+++ b/crates/velesdb-server/tests/match_error_codes_tests.rs
@@ -1,0 +1,175 @@
+#![allow(clippy::doc_markdown)]
+//! Regression tests for backlog #13: graph/MATCH REST handlers must surface
+//! the canonical `VELES-XXX` error codes and correct 4xx statuses (via
+//! `auto_core_error_response`) instead of invented codes / blanket-500s.
+
+mod common;
+
+use axum::{
+    body::Body,
+    http::{Request, StatusCode},
+};
+use common::{create_graph_collection, create_test_app};
+use serde_json::{json, Value};
+use tempfile::TempDir;
+use tower::ServiceExt;
+
+async fn body_json(response: axum::response::Response) -> Value {
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("read body");
+    serde_json::from_slice(&body).expect("valid JSON")
+}
+
+/// POST /match to a collection that does not exist must return 404 with the
+/// canonical `VELES-002 CollectionNotFound` code (not `COLLECTION_NOT_FOUND`).
+#[tokio::test]
+async fn test_match_missing_collection_returns_veles_002() {
+    let temp_dir = TempDir::new().expect("temp dir");
+    let app = create_test_app(&temp_dir);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/collections/ghost/match")
+                .header("Content-Type", "application/json")
+                .body(Body::from(
+                    json!({ "query": "MATCH (n) RETURN n" }).to_string(),
+                ))
+                .expect("build request"),
+        )
+        .await
+        .expect("request");
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    let json = body_json(response).await;
+    assert_eq!(json["code"], "VELES-002");
+}
+
+/// POST /match whose WHERE references an unbound `$v` parameter must surface
+/// the core `Error::Query` code (`VELES-010` post-#1212) with a 400 status,
+/// not a blanket 500 / invented `EXECUTION_ERROR`. A request `vector` plus a
+/// seeded node routes through `execute_match_with_similarity`, whose WHERE
+/// evaluation resolves `$v` and fails deterministically when it is absent.
+#[tokio::test]
+async fn test_match_missing_param_returns_veles_010() {
+    let temp_dir = TempDir::new().expect("temp dir");
+    let app = create_test_app(&temp_dir);
+    seed_vector_node(&app).await;
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/collections/people/match")
+                .header("Content-Type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "query": "MATCH (a:Person) WHERE similarity(a.vec, $v) > 0.1 RETURN a",
+                        "vector": [1.0, 0.0, 0.0, 0.0]
+                    })
+                    .to_string(),
+                ))
+                .expect("build request"),
+        )
+        .await
+        .expect("request");
+
+    assert_eq!(
+        response.status(),
+        StatusCode::BAD_REQUEST,
+        "missing bind-param is a client error (400), not a server 500"
+    );
+    let json = body_json(response).await;
+    assert_eq!(json["code"], "VELES-010");
+}
+
+/// Creates a `people` vector collection with one labeled `Person` node so the
+/// `/match` similarity WHERE path has a candidate to evaluate.
+async fn seed_vector_node(app: &axum::Router) {
+    let create = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/collections")
+                .header("Content-Type", "application/json")
+                .body(Body::from(
+                    json!({ "name": "people", "dimension": 4, "metric": "cosine" }).to_string(),
+                ))
+                .expect("build create request"),
+        )
+        .await
+        .expect("create request");
+    assert_eq!(create.status(), StatusCode::CREATED);
+
+    let upsert = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/collections/people/points")
+                .header("Content-Type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "points": [{
+                            "id": 1,
+                            "vector": [1.0, 0.0, 0.0, 0.0],
+                            "payload": { "_labels": ["Person"], "vec": [1.0, 0.0, 0.0, 0.0] }
+                        }]
+                    })
+                    .to_string(),
+                ))
+                .expect("build upsert request"),
+        )
+        .await
+        .expect("upsert request");
+    assert_eq!(upsert.status(), StatusCode::OK);
+}
+
+/// Adding an edge whose ID already exists must return 409 Conflict with the
+/// canonical `VELES-019 EdgeExists` code (not a generic 500 string).
+#[tokio::test]
+async fn test_duplicate_edge_returns_veles_019() {
+    let temp_dir = TempDir::new().expect("temp dir");
+    let app = create_test_app(&temp_dir);
+    create_graph_collection(&app, "social").await;
+
+    let edge = json!({
+        "id": 1,
+        "source": 10,
+        "target": 20,
+        "label": "KNOWS"
+    });
+
+    let first = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/collections/social/graph/edges")
+                .header("Content-Type", "application/json")
+                .body(Body::from(edge.to_string()))
+                .expect("build request"),
+        )
+        .await
+        .expect("request");
+    assert_eq!(first.status(), StatusCode::CREATED);
+
+    let dup = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/collections/social/graph/edges")
+                .header("Content-Type", "application/json")
+                .body(Body::from(edge.to_string()))
+                .expect("build request"),
+        )
+        .await
+        .expect("request");
+
+    assert_eq!(dup.status(), StatusCode::CONFLICT);
+    let json = body_json(dup).await;
+    assert_eq!(json["code"], "VELES-019");
+}

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1682,7 +1682,7 @@
           "graph"
         ],
         "summary": "Execute a MATCH query on a collection.",
-        "description": "# Endpoint\n\n`POST /collections/{name}/match`\n\n# Example Request\n\n```json\n{\n  \"query\": \"MATCH (a:Person)-[:KNOWS]->(b) WHERE similarity(a.vec, $v) > 0.8 RETURN a.name\",\n  \"params\": {\n    \"v\": [0.1, 0.2, 0.3]\n  }\n}\n```\n\n# Errors\n\nReturns error tuple with status code and JSON error in these cases:\n- `404 NOT_FOUND` - Collection not found\n- `400 BAD_REQUEST` - Parse error or not a MATCH query\n- `500 INTERNAL_SERVER_ERROR` - Execution error",
+        "description": "# Endpoint\n\n`POST /collections/{name}/match`\n\n# Example Request\n\n```json\n{\n  \"query\": \"MATCH (a:Person)-[:KNOWS]->(b) WHERE similarity(a.vec, $v) > 0.8 RETURN a.name\",\n  \"params\": {\n    \"v\": [0.1, 0.2, 0.3]\n  }\n}\n```\n\n# Errors\n\nAll failures are mapped through the canonical `auto_core_error_response`,\nso the JSON body carries the `VELES-XXX` code and the HTTP status is\nderived from the core error variant:\n- `404 NOT_FOUND` (`VELES-002`) — collection not found\n- `400 BAD_REQUEST` (`VELES-010`) — parse error, not a MATCH query,\n  invalid threshold, or an unbound query parameter\n- other core variants map per [`super::helpers::http_status_for_error`]",
         "operationId": "match_query",
         "parameters": [
           {
@@ -1721,7 +1721,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/MatchQueryError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -1731,7 +1731,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/MatchQueryError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -1741,7 +1741,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/MatchQueryError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -4808,34 +4808,6 @@
             "type": "integer",
             "description": "Total number of indexes.",
             "minimum": 0
-          }
-        }
-      },
-      "MatchQueryError": {
-        "type": "object",
-        "description": "Error response for MATCH query.",
-        "required": [
-          "error",
-          "code"
-        ],
-        "properties": {
-          "code": {
-            "type": "string",
-            "description": "Error code."
-          },
-          "details": {
-            "description": "Optional details for diagnostics."
-          },
-          "error": {
-            "type": "string",
-            "description": "Error message."
-          },
-          "hint": {
-            "type": [
-              "string",
-              "null"
-            ],
-            "description": "Actionable hint for developers."
           }
         }
       },

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1094,10 +1094,13 @@ paths:
 
         # Errors
 
-        Returns error tuple with status code and JSON error in these cases:
-        - `404 NOT_FOUND` - Collection not found
-        - `400 BAD_REQUEST` - Parse error or not a MATCH query
-        - `500 INTERNAL_SERVER_ERROR` - Execution error
+        All failures are mapped through the canonical `auto_core_error_response`,
+        so the JSON body carries the `VELES-XXX` code and the HTTP status is
+        derived from the core error variant:
+        - `404 NOT_FOUND` (`VELES-002`) — collection not found
+        - `400 BAD_REQUEST` (`VELES-010`) — parse error, not a MATCH query,
+          invalid threshold, or an unbound query parameter
+        - other core variants map per [`super::helpers::http_status_for_error`]
       operationId: match_query
       parameters:
       - name: name
@@ -1124,19 +1127,19 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/MatchQueryError'
+                $ref: '#/components/schemas/ErrorResponse'
         '404':
           description: Collection not found
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/MatchQueryError'
+                $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: Internal server error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/MatchQueryError'
+                $ref: '#/components/schemas/ErrorResponse'
   /collections/{name}/points:
     post:
       tags:
@@ -3375,26 +3378,6 @@ components:
           type: integer
           description: Total number of indexes.
           minimum: 0
-    MatchQueryError:
-      type: object
-      description: Error response for MATCH query.
-      required:
-      - error
-      - code
-      properties:
-        code:
-          type: string
-          description: Error code.
-        details:
-          description: Optional details for diagnostics.
-        error:
-          type: string
-          description: Error message.
-        hint:
-          type:
-          - string
-          - 'null'
-          description: Actionable hint for developers.
     MatchQueryMeta:
       type: object
       description: Metadata section for MATCH query responses.

--- a/docs/reference/VELESQL_CONTRACT.md
+++ b/docs/reference/VELESQL_CONTRACT.md
@@ -199,8 +199,18 @@ Current codes:
 - `VELESQL_COLLECTION_NOT_FOUND`
 - `VELESQL_EXECUTION_ERROR`
 - `VELESQL_AGGREGATION_ERROR`
+- `VELESQL_VALIDATION_ERROR`
+- `VELESQL_MUTATION_ERROR`
+- `VELESQL_EXPLAIN_ANALYZE_ERROR`
 
-`/collections/{name}/match` keeps compatibility fields (`error`, `code`) and now also returns `hint` and optional `details`.
+`/collections/{name}/match` no longer emits the bespoke `*_ERROR`
+strings (`COLLECTION_NOT_FOUND` / `PARSE_ERROR` / `EXECUTION_ERROR` / …).
+It now returns the canonical `{ "error", "code" }` body with a
+`VELES-XXX` code (e.g. `VELES-002` for a missing collection, `VELES-010`
+for a parse error or unbound parameter, `VELES-019` for a duplicate
+edge), and the HTTP status is derived from the error variant. Guard-rail
+rejections (rate limit `429`, circuit breaker `503`) and query timeouts
+(`408`) carry the `VELES-027` code.
 
 Syntax errors still use parser-specific payload (`QueryErrorResponse` with `type/message/position/query`).
 


### PR DESCRIPTION
## Summary

Server REST error-handling fixes (#13). Multiple graph/match handlers hand-rolled error responses — invented codes, blanket-500 for client mistakes, a malformed timeout code, guard-rail 429/503 with `code: null`. They now route through the canonical `auto_core_error_response`, so real `VELES-*` codes and correct 4xx statuses survive.

- **`/match`** (`match_query.rs`): rewritten to resolve→parse→validate→execute returning `velesdb_core::Error`, mapped via `auto_core_error_response`. Removed the invented `MatchQueryError` struct + codes (`COLLECTION_NOT_FOUND`/`PARSE_ERROR`/`EXECUTION_ERROR`/…) and the blanket-500. Now: missing collection → **404 + VELES-002**; parse error / non-MATCH query / bad threshold / missing `$v` → **400 + VELES-010**; only genuine internal errors hit 500.
- **Graph mutations** (`graph/handlers.rs`): `add_edge`/`add_edges_batch` route through `auto_core_error_response` → duplicate edge is **409 + VELES-019** (was a generic 500 string).
- **Timeout** (`search/pipeline.rs`): malformed `VELES-QUERY-TIMEOUT` → canonical **VELES-027**.
- **Guard-rail** (`helpers.rs`): rate-limit 429 / circuit-breaker 503 now carry **code `VELES-027`** (was `null`).
- **Docs**: `VELESQL_CONTRACT.md` documents the 3 emitted `VELESQL_*` codes + the canonical `/match` error shape.

> **Codes derived from current core, not the stale backlog.** The backlog #13 predates #1212 (which reclassified bind-param rejects `VELES-009`→`VELES-010`); a missing `$v` now correctly asserts **VELES-010**.

## Test plan
- Failing-test-first (red→green): missing-collection→VELES-002, missing-`$v`→400/VELES-010 (was 500), duplicate-edge→409/VELES-019, timeout→VELES-027, rate-limit→VELES-027. Wired `/collections/{name}/match` into the integration router.
- Gates: `cargo fmt`; `clippy --all-targets … -D warnings -D clippy::pedantic` (exit 0); `lizard -C 8` (0 over budget); **`cargo test -p velesdb-server --features persistence` = 305 + 0 failed** (re-run post-rebase). **OpenAPI regenerated** with the canonical `--features openapi` (only the `MatchQueryError` schema removed) — **drift check `git diff --exit-code` clean**.

**SemVer-observable** (REST status 500→404/400/409, error `code` strings→`VELES-*`, timeout/guard-rail codes) — flagged in CHANGELOG `[Unreleased]`.