### PR TITLE
feat(velesql): executable scalar subqueries in WHERE/HAVING + DML (#21)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,21 @@ release.
   so the `weighted` / `relative_score` trap (which the engine silently degrades
   to RRF over homogeneous query vectors) is a **compile-time error**. Purely
   additive.
+- **Scalar subqueries are now executable end-to-end (EPIC-039).** A
+  `(SELECT ...)` in a `WHERE`/`HAVING` predicate or an `INSERT`/`UPDATE` value is
+  executed and substituted as a literal before the outer query runs, instead of
+  being rejected at validation with `V010`. The inner SELECT must return exactly
+  one row and one column: 0 rows resolve to `NULL` (a comparison against `NULL`
+  is never true), and more than one row or column errors with a clear
+  cardinality message (`VELES-010`). Aggregate subqueries
+  (`(SELECT AVG(amount) FROM t)`), single-column row projections
+  (`(SELECT amount FROM t WHERE id = 1)`), `BETWEEN`/`IN`/`CONTAINS` value
+  positions, and `INSERT`/`UPDATE` values are all supported; nesting is bounded
+  at 8 levels. Resolution lives in `velesdb-core`, so the REST `/query` endpoint
+  and the CLI REPL gain it for free (both route through
+  `Database::execute_query`). **Correlated** subqueries (whose inner `WHERE`
+  references an outer column) remain rejected at validation with `V010`. WASM,
+  which has a separate executor, still rejects subqueries.
 - **`ALTER COLLECTION <name> SET (auto_reindex = true|false)` now applies and
   persists.** Previously parsed but rejected with a feature-gap error, it now
   attaches (or re-configures) an `AutoReindexManager` on the collection and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,12 +133,18 @@ release.
   cardinality message (`VELES-010`). Aggregate subqueries
   (`(SELECT AVG(amount) FROM t)`), single-column row projections
   (`(SELECT amount FROM t WHERE id = 1)`), `BETWEEN`/`IN`/`CONTAINS` value
-  positions, and `INSERT`/`UPDATE` values are all supported; nesting is bounded
-  at 8 levels. Resolution lives in `velesdb-core`, so the REST `/query` endpoint
-  and the CLI REPL gain it for free (both route through
-  `Database::execute_query`). **Correlated** subqueries (whose inner `WHERE`
-  references an outer column) remain rejected at validation with `V010`. WASM,
-  which has a separate executor, still rejects subqueries.
+  positions, `INSERT`/`UPDATE` values, and **`UPDATE`/`DELETE` `WHERE`**
+  predicates are all supported; nesting is bounded at 8 levels.
+  `UPDATE … WHERE col > (SELECT … )` and `DELETE … WHERE id = (SELECT … )` now
+  resolve the subquery to a literal *before* the mutation runs (previously the
+  predicate silently saw `NULL` and matched no rows). A subquery whose inner
+  `WHERE` filters on a **payload path** (e.g. `… WHERE meta.cat = 5`) is a plain
+  payload filter, not a correlation, so it executes instead of being wrongly
+  rejected. Resolution lives in `velesdb-core`, so the REST `/query` endpoint and
+  the CLI REPL gain it for free (both route through `Database::execute_query`).
+  **Correlated** subqueries (whose inner `WHERE` references one of the *outer*
+  query's tables/aliases) remain rejected at validation with `V010`. WASM, which
+  has a separate executor, still rejects subqueries.
 - **`ALTER COLLECTION <name> SET (auto_reindex = true|false)` now applies and
   persists.** Previously parsed but rejected with a feature-gap error, it now
   attaches (or re-configures) an `AutoReindexManager` on the collection and

--- a/crates/velesdb-core/src/database/mod.rs
+++ b/crates/velesdb-core/src/database/mod.rs
@@ -34,6 +34,7 @@ mod query_engine_agg;
 mod query_engine_dml;
 mod query_join;
 mod stats;
+mod subquery_resolver;
 mod training;
 mod vector_ops;
 

--- a/crates/velesdb-core/src/database/query_engine.rs
+++ b/crates/velesdb-core/src/database/query_engine.rs
@@ -250,6 +250,12 @@ impl Database {
         query: &crate::velesql::Query,
         params: &std::collections::HashMap<String, serde_json::Value>,
     ) -> Result<Vec<SearchResult>> {
+        // Resolve scalar subqueries (EPIC-039) into literals *before* validation
+        // so the validator and every downstream path see a subquery-free AST.
+        if let Some(rewritten) = self.resolve_subqueries(query, params)? {
+            return self.execute_query(&rewritten, params);
+        }
+
         crate::velesql::QueryValidator::validate(query).map_err(|e| Error::Query(e.to_string()))?;
 
         if let Some(results) = self.dispatch_non_select(query, params)? {

--- a/crates/velesdb-core/src/database/query_engine_agg.rs
+++ b/crates/velesdb-core/src/database/query_engine_agg.rs
@@ -30,6 +30,11 @@ impl Database {
         query: &crate::velesql::Query,
         params: &HashMap<String, serde_json::Value>,
     ) -> Result<serde_json::Value> {
+        // Resolve scalar subqueries (EPIC-039) in WHERE/HAVING before validation
+        // so the aggregate engine sees a subquery-free AST.
+        if let Some(rewritten) = self.resolve_subqueries(query, params)? {
+            return self.execute_aggregate(&rewritten, params);
+        }
         crate::velesql::QueryValidator::validate(query).map_err(|e| Error::Query(e.to_string()))?;
         let name = aggregate_target_collection(query, params)?;
         let collection = self

--- a/crates/velesdb-core/src/database/subquery_resolver.rs
+++ b/crates/velesdb-core/src/database/subquery_resolver.rs
@@ -49,22 +49,27 @@ impl Database {
             return Ok(None);
         }
         let mut rewritten = query.clone();
-        self.rewrite_query_subqueries(&mut rewritten, params, 0)?;
+        let scope = query.select.outer_table_scope();
+        self.rewrite_query_subqueries(&mut rewritten, params, 0, &scope)?;
         Ok(Some(rewritten))
     }
 
     /// Rewrites all subquery leaves of `query` in place at recursion `depth`.
+    ///
+    /// `outer_tables` are the names a nested subquery would have to reference to
+    /// be genuinely correlated (and so left for the validator to reject).
     fn rewrite_query_subqueries(
         &self,
         query: &mut Query,
         params: &HashMap<String, serde_json::Value>,
         depth: u32,
+        outer_tables: &[&str],
     ) -> Result<()> {
         if let Some(cond) = query.select.where_clause.as_mut() {
-            self.rewrite_condition(cond, params, depth)?;
+            self.rewrite_condition(cond, params, depth, outer_tables)?;
         }
         if let Some(having) = query.select.having.as_mut() {
-            self.rewrite_having(having, params, depth)?;
+            self.rewrite_having(having, params, depth, outer_tables)?;
         }
         if let Some(dml) = query.dml.as_mut() {
             self.rewrite_dml(dml, params, depth)?;
@@ -78,16 +83,17 @@ impl Database {
         cond: &mut Condition,
         params: &HashMap<String, serde_json::Value>,
         depth: u32,
+        outer_tables: &[&str],
     ) -> Result<()> {
         match cond {
             Condition::And(l, r) | Condition::Or(l, r) => {
-                self.rewrite_condition(l, params, depth)?;
-                self.rewrite_condition(r, params, depth)
+                self.rewrite_condition(l, params, depth, outer_tables)?;
+                self.rewrite_condition(r, params, depth, outer_tables)
             }
             Condition::Group(inner) | Condition::Not(inner) => {
-                self.rewrite_condition(inner, params, depth)
+                self.rewrite_condition(inner, params, depth, outer_tables)
             }
-            other => self.rewrite_leaf_condition(other, params, depth),
+            other => self.rewrite_leaf_condition(other, params, depth, outer_tables),
         }
     }
 
@@ -97,15 +103,20 @@ impl Database {
         cond: &mut Condition,
         params: &HashMap<String, serde_json::Value>,
         depth: u32,
+        outer_tables: &[&str],
     ) -> Result<()> {
         match cond {
-            Condition::Comparison(c) => self.rewrite_value(&mut c.value, params, depth),
-            Condition::Between(c) => {
-                self.rewrite_value(&mut c.low, params, depth)?;
-                self.rewrite_value(&mut c.high, params, depth)
+            Condition::Comparison(c) => {
+                self.rewrite_value(&mut c.value, params, depth, outer_tables)
             }
-            Condition::In(c) => self.rewrite_values(&mut c.values, params, depth),
-            Condition::Contains(c) => self.rewrite_values(&mut c.values, params, depth),
+            Condition::Between(c) => {
+                self.rewrite_value(&mut c.low, params, depth, outer_tables)?;
+                self.rewrite_value(&mut c.high, params, depth, outer_tables)
+            }
+            Condition::In(c) => self.rewrite_values(&mut c.values, params, depth, outer_tables),
+            Condition::Contains(c) => {
+                self.rewrite_values(&mut c.values, params, depth, outer_tables)
+            }
             _ => Ok(()),
         }
     }
@@ -116,14 +127,17 @@ impl Database {
         having: &mut HavingClause,
         params: &HashMap<String, serde_json::Value>,
         depth: u32,
+        outer_tables: &[&str],
     ) -> Result<()> {
         for cond in &mut having.conditions {
-            self.rewrite_value(&mut cond.value, params, depth)?;
+            self.rewrite_value(&mut cond.value, params, depth, outer_tables)?;
         }
         Ok(())
     }
 
-    /// Substitutes subquery values in INSERT/UPSERT rows and UPDATE assignments.
+    /// Substitutes subquery values in INSERT/UPSERT rows, UPDATE assignments,
+    /// and UPDATE/DELETE `WHERE` clauses. DML value/`WHERE` subqueries are scoped
+    /// to the DML target table.
     fn rewrite_dml(
         &self,
         dml: &mut DmlStatement,
@@ -133,32 +147,41 @@ impl Database {
         match dml {
             DmlStatement::Insert(s) | DmlStatement::Upsert(s) => {
                 for row in &mut s.rows {
-                    self.rewrite_values(row, params, depth)?;
+                    self.rewrite_values(row, params, depth, &[s.table.as_str()])?;
                 }
                 Ok(())
             }
             DmlStatement::Update(s) => {
+                let scope = [s.table.as_str()];
                 for assignment in &mut s.assignments {
-                    self.rewrite_value(&mut assignment.value, params, depth)?;
+                    self.rewrite_value(&mut assignment.value, params, depth, &scope)?;
+                }
+                if let Some(cond) = s.where_clause.as_mut() {
+                    self.rewrite_condition(cond, params, depth, &scope)?;
                 }
                 Ok(())
+            }
+            DmlStatement::Delete(s) => {
+                self.rewrite_condition(&mut s.where_clause, params, depth, &[s.table.as_str()])
             }
             _ => Ok(()),
         }
     }
 
-    /// Substitutes a single value if it is a scalar (non-correlated) subquery.
+    /// Substitutes a single value if it is a scalar subquery that is *not*
+    /// genuinely correlated against `outer_tables`.
     ///
-    /// Literals are left untouched; correlated subqueries are also left in place
-    /// so the validator rejects them with the canonical V010 message.
+    /// Literals are left untouched; genuinely correlated subqueries are also left
+    /// in place so the validator rejects them with the canonical V010 message.
     fn rewrite_value(
         &self,
         value: &mut Value,
         params: &HashMap<String, serde_json::Value>,
         depth: u32,
+        outer_tables: &[&str],
     ) -> Result<()> {
         if let Value::Subquery(subquery) = value {
-            if subquery.correlations.is_empty() {
+            if !subquery.references_outer_table(outer_tables) {
                 *value = self.execute_scalar_subquery(subquery, params, depth)?;
             }
         }
@@ -171,9 +194,10 @@ impl Database {
         values: &mut [Value],
         params: &HashMap<String, serde_json::Value>,
         depth: u32,
+        outer_tables: &[&str],
     ) -> Result<()> {
         for value in values {
-            self.rewrite_value(value, params, depth)?;
+            self.rewrite_value(value, params, depth, outer_tables)?;
         }
         Ok(())
     }
@@ -191,8 +215,16 @@ impl Database {
             )));
         }
         let mut inner = Query::from_select(subquery.select.clone());
-        // Resolve nested subqueries first (depth-bounded recursion).
-        self.rewrite_query_subqueries(&mut inner, params, depth + 1)?;
+        // Resolve nested subqueries first (depth-bounded recursion). A nested
+        // subquery is correlated only against this inner query's own scope.
+        let inner_scope: Vec<String> = inner
+            .select
+            .outer_table_scope()
+            .iter()
+            .map(|s| (*s).to_string())
+            .collect();
+        let inner_scope: Vec<&str> = inner_scope.iter().map(String::as_str).collect();
+        self.rewrite_query_subqueries(&mut inner, params, depth + 1, &inner_scope)?;
         self.run_scalar_subquery(&inner, params)
     }
 
@@ -219,11 +251,12 @@ impl Database {
 /// to reject (V010), and excluding them here keeps `resolve_subqueries` from
 /// returning `Some` (and recursing) when nothing is actually resolvable.
 fn query_has_resolvable_subquery(query: &Query) -> bool {
+    let scope = query.select.outer_table_scope();
     let where_resolvable = query
         .select
         .where_clause
         .as_ref()
-        .is_some_and(condition_has_resolvable_subquery);
+        .is_some_and(|c| condition_has_resolvable_subquery(c, &scope));
     where_resolvable
         || having_has_resolvable_subquery(query)
         || dml_has_resolvable_subquery(query.dml.as_ref())
@@ -234,20 +267,31 @@ fn having_has_resolvable_subquery(query: &Query) -> bool {
     query.has_having_subquery() && !query.has_correlated_having_subquery()
 }
 
-/// Returns `true` if a condition carries a scalar (non-correlated) subquery.
-fn condition_has_resolvable_subquery(cond: &Condition) -> bool {
-    cond.has_subquery() && !cond.has_correlated_subquery()
+/// Returns `true` if a condition carries a scalar subquery that is *not*
+/// genuinely correlated against `outer_tables` (and so can be resolved).
+fn condition_has_resolvable_subquery(cond: &Condition, outer_tables: &[&str]) -> bool {
+    cond.has_subquery() && !cond.has_correlated_subquery(outer_tables)
 }
 
-/// Returns `true` if an INSERT/UPSERT row or UPDATE assignment carries a scalar
-/// (non-correlated) subquery. DML subqueries cannot be correlated (no outer row
-/// scope), so any subquery here is resolvable.
+/// Returns `true` if a DML statement carries a scalar (non-correlated) subquery
+/// in an INSERT/UPSERT row, an UPDATE assignment, or an UPDATE/DELETE `WHERE`
+/// clause. Value-position DML subqueries cannot be correlated (no outer row
+/// scope); `WHERE`-clause subqueries must be non-correlated to be resolvable.
 fn dml_has_resolvable_subquery(dml: Option<&DmlStatement>) -> bool {
     match dml {
         Some(DmlStatement::Insert(s) | DmlStatement::Upsert(s)) => {
             s.rows.iter().any(|row| row.iter().any(Value::is_subquery))
         }
-        Some(DmlStatement::Update(s)) => s.assignments.iter().any(|a| a.value.is_subquery()),
+        Some(DmlStatement::Update(s)) => {
+            let scope = [s.table.as_str()];
+            s.assignments.iter().any(|a| a.value.is_subquery())
+                || s.where_clause
+                    .as_ref()
+                    .is_some_and(|c| condition_has_resolvable_subquery(c, &scope))
+        }
+        Some(DmlStatement::Delete(s)) => {
+            condition_has_resolvable_subquery(&s.where_clause, &[s.table.as_str()])
+        }
         _ => false,
     }
 }

--- a/crates/velesdb-core/src/database/subquery_resolver.rs
+++ b/crates/velesdb-core/src/database/subquery_resolver.rs
@@ -1,0 +1,347 @@
+//! Scalar subquery resolution (EPIC-039).
+//!
+//! A scalar subquery `(SELECT AVG(amount) FROM t)` in a `WHERE`/`HAVING`
+//! predicate — or an `INSERT`/`UPDATE` value — is *parsed* as a
+//! [`Value::Subquery`](crate::velesql::Value::Subquery) leaf. Before the outer
+//! query is validated and executed, this module walks the AST, executes each
+//! inner `SELECT`, reduces it to a single row / single column scalar, and
+//! substitutes the resulting literal in place. The downstream filter,
+//! aggregation, and DML paths then see only literals.
+//!
+//! Cardinality contract:
+//! - **> 1 row** or **> 1 column** -> [`Error::Query`] with a cardinality message.
+//! - **0 rows** -> `NULL` (a comparison against `NULL` is never true).
+//!
+//! Correlated subqueries (those that reference an outer column) are **not**
+//! supported and are rejected with a clear message.
+
+use std::collections::HashMap;
+
+use crate::velesql::{
+    Condition, DmlStatement, HavingClause, Query, SelectColumns, Subquery, Value,
+};
+use crate::{Error, Result};
+
+use super::Database;
+
+/// Maximum scalar-subquery nesting depth. Guards against runaway recursion on
+/// deeply (or pathologically) nested subqueries.
+const MAX_SUBQUERY_DEPTH: u32 = 8;
+
+impl Database {
+    /// Resolves every **scalar (non-correlated)** subquery in `query`, returning
+    /// a rewritten clone when at least one such subquery was present, or `None`
+    /// when there is nothing to resolve (the common path — no clone, no work).
+    ///
+    /// Correlated subqueries are intentionally left in place so the validator
+    /// rejects them with the canonical V010 message; they are not resolvable.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Query`] if a subquery violates the one-row/one-column
+    /// cardinality contract or its inner SELECT fails.
+    pub(super) fn resolve_subqueries(
+        &self,
+        query: &Query,
+        params: &HashMap<String, serde_json::Value>,
+    ) -> Result<Option<Query>> {
+        if !query_has_resolvable_subquery(query) {
+            return Ok(None);
+        }
+        let mut rewritten = query.clone();
+        self.rewrite_query_subqueries(&mut rewritten, params, 0)?;
+        Ok(Some(rewritten))
+    }
+
+    /// Rewrites all subquery leaves of `query` in place at recursion `depth`.
+    fn rewrite_query_subqueries(
+        &self,
+        query: &mut Query,
+        params: &HashMap<String, serde_json::Value>,
+        depth: u32,
+    ) -> Result<()> {
+        if let Some(cond) = query.select.where_clause.as_mut() {
+            self.rewrite_condition(cond, params, depth)?;
+        }
+        if let Some(having) = query.select.having.as_mut() {
+            self.rewrite_having(having, params, depth)?;
+        }
+        if let Some(dml) = query.dml.as_mut() {
+            self.rewrite_dml(dml, params, depth)?;
+        }
+        Ok(())
+    }
+
+    /// Walks a WHERE condition tree, substituting subquery leaves with scalars.
+    fn rewrite_condition(
+        &self,
+        cond: &mut Condition,
+        params: &HashMap<String, serde_json::Value>,
+        depth: u32,
+    ) -> Result<()> {
+        match cond {
+            Condition::And(l, r) | Condition::Or(l, r) => {
+                self.rewrite_condition(l, params, depth)?;
+                self.rewrite_condition(r, params, depth)
+            }
+            Condition::Group(inner) | Condition::Not(inner) => {
+                self.rewrite_condition(inner, params, depth)
+            }
+            other => self.rewrite_leaf_condition(other, params, depth),
+        }
+    }
+
+    /// Substitutes subquery values carried directly by a leaf condition.
+    fn rewrite_leaf_condition(
+        &self,
+        cond: &mut Condition,
+        params: &HashMap<String, serde_json::Value>,
+        depth: u32,
+    ) -> Result<()> {
+        match cond {
+            Condition::Comparison(c) => self.rewrite_value(&mut c.value, params, depth),
+            Condition::Between(c) => {
+                self.rewrite_value(&mut c.low, params, depth)?;
+                self.rewrite_value(&mut c.high, params, depth)
+            }
+            Condition::In(c) => self.rewrite_values(&mut c.values, params, depth),
+            Condition::Contains(c) => self.rewrite_values(&mut c.values, params, depth),
+            _ => Ok(()),
+        }
+    }
+
+    /// Substitutes subquery thresholds in a HAVING clause.
+    fn rewrite_having(
+        &self,
+        having: &mut HavingClause,
+        params: &HashMap<String, serde_json::Value>,
+        depth: u32,
+    ) -> Result<()> {
+        for cond in &mut having.conditions {
+            self.rewrite_value(&mut cond.value, params, depth)?;
+        }
+        Ok(())
+    }
+
+    /// Substitutes subquery values in INSERT/UPSERT rows and UPDATE assignments.
+    fn rewrite_dml(
+        &self,
+        dml: &mut DmlStatement,
+        params: &HashMap<String, serde_json::Value>,
+        depth: u32,
+    ) -> Result<()> {
+        match dml {
+            DmlStatement::Insert(s) | DmlStatement::Upsert(s) => {
+                for row in &mut s.rows {
+                    self.rewrite_values(row, params, depth)?;
+                }
+                Ok(())
+            }
+            DmlStatement::Update(s) => {
+                for assignment in &mut s.assignments {
+                    self.rewrite_value(&mut assignment.value, params, depth)?;
+                }
+                Ok(())
+            }
+            _ => Ok(()),
+        }
+    }
+
+    /// Substitutes a single value if it is a scalar (non-correlated) subquery.
+    ///
+    /// Literals are left untouched; correlated subqueries are also left in place
+    /// so the validator rejects them with the canonical V010 message.
+    fn rewrite_value(
+        &self,
+        value: &mut Value,
+        params: &HashMap<String, serde_json::Value>,
+        depth: u32,
+    ) -> Result<()> {
+        if let Value::Subquery(subquery) = value {
+            if subquery.correlations.is_empty() {
+                *value = self.execute_scalar_subquery(subquery, params, depth)?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Substitutes every subquery in a slice of values.
+    fn rewrite_values(
+        &self,
+        values: &mut [Value],
+        params: &HashMap<String, serde_json::Value>,
+        depth: u32,
+    ) -> Result<()> {
+        for value in values {
+            self.rewrite_value(value, params, depth)?;
+        }
+        Ok(())
+    }
+
+    /// Executes one inner SELECT and reduces it to a scalar [`Value`].
+    fn execute_scalar_subquery(
+        &self,
+        subquery: &Subquery,
+        params: &HashMap<String, serde_json::Value>,
+        depth: u32,
+    ) -> Result<Value> {
+        if depth >= MAX_SUBQUERY_DEPTH {
+            return Err(Error::Query(format!(
+                "scalar subquery nesting exceeds the maximum depth of {MAX_SUBQUERY_DEPTH}"
+            )));
+        }
+        let mut inner = Query::from_select(subquery.select.clone());
+        // Resolve nested subqueries first (depth-bounded recursion).
+        self.rewrite_query_subqueries(&mut inner, params, depth + 1)?;
+        self.run_scalar_subquery(&inner, params)
+    }
+
+    /// Runs a subquery-free inner SELECT and extracts its single scalar value.
+    fn run_scalar_subquery(
+        &self,
+        inner: &Query,
+        params: &HashMap<String, serde_json::Value>,
+    ) -> Result<Value> {
+        if inner.select.is_aggregation_query() {
+            let json = self.execute_aggregate(inner, params)?;
+            return scalar_from_aggregate(&json);
+        }
+        let column = projected_subquery_column(&inner.select)?;
+        let results = self.execute_query(inner, params)?;
+        scalar_from_rows(&results, &column)
+    }
+}
+
+/// Returns `true` if any WHERE/HAVING/DML site of `query` carries a **scalar
+/// (non-correlated)** subquery that this module can resolve.
+///
+/// Correlated subqueries are excluded: they are left in place for the validator
+/// to reject (V010), and excluding them here keeps `resolve_subqueries` from
+/// returning `Some` (and recursing) when nothing is actually resolvable.
+fn query_has_resolvable_subquery(query: &Query) -> bool {
+    let where_resolvable = query
+        .select
+        .where_clause
+        .as_ref()
+        .is_some_and(condition_has_resolvable_subquery);
+    where_resolvable
+        || having_has_resolvable_subquery(query)
+        || dml_has_resolvable_subquery(query.dml.as_ref())
+}
+
+/// Returns `true` if `query` has a scalar (non-correlated) HAVING subquery.
+fn having_has_resolvable_subquery(query: &Query) -> bool {
+    query.has_having_subquery() && !query.has_correlated_having_subquery()
+}
+
+/// Returns `true` if a condition carries a scalar (non-correlated) subquery.
+fn condition_has_resolvable_subquery(cond: &Condition) -> bool {
+    cond.has_subquery() && !cond.has_correlated_subquery()
+}
+
+/// Returns `true` if an INSERT/UPSERT row or UPDATE assignment carries a scalar
+/// (non-correlated) subquery. DML subqueries cannot be correlated (no outer row
+/// scope), so any subquery here is resolvable.
+fn dml_has_resolvable_subquery(dml: Option<&DmlStatement>) -> bool {
+    match dml {
+        Some(DmlStatement::Insert(s) | DmlStatement::Upsert(s)) => {
+            s.rows.iter().any(|row| row.iter().any(Value::is_subquery))
+        }
+        Some(DmlStatement::Update(s)) => s.assignments.iter().any(|a| a.value.is_subquery()),
+        _ => false,
+    }
+}
+
+/// Identifies the single projected column of a non-aggregate scalar subquery.
+///
+/// A scalar subquery must project exactly one column; `SELECT *` and multi-
+/// column projections violate the one-column cardinality contract.
+fn projected_subquery_column(select: &crate::velesql::SelectStatement) -> Result<String> {
+    match &select.columns {
+        SelectColumns::Columns(cols) if cols.len() == 1 => Ok(cols[0].name.clone()),
+        _ => Err(Error::Query(
+            "scalar subquery must select exactly one column (e.g. \
+             (SELECT amount FROM t WHERE ...) or an aggregate like (SELECT AVG(amount) FROM t))"
+                .to_string(),
+        )),
+    }
+}
+
+/// Extracts the single scalar of an aggregate result object (e.g. `{"avg_amount": 30.0}`).
+fn scalar_from_aggregate(json: &serde_json::Value) -> Result<Value> {
+    let obj = json
+        .as_object()
+        .ok_or_else(|| Error::Query("scalar subquery aggregate did not return an object".into()))?;
+    if obj.len() != 1 {
+        return Err(Error::Query(
+            "scalar subquery must return exactly one column".to_string(),
+        ));
+    }
+    let only = obj
+        .values()
+        .next()
+        .ok_or_else(|| Error::Query("scalar subquery aggregate returned no column".to_string()))?;
+    json_to_value(only)
+}
+
+/// Extracts the single scalar of a row-projection subquery, enforcing the
+/// one-row contract and returning `NULL` for an empty result.
+fn scalar_from_rows(results: &[crate::SearchResult], column: &str) -> Result<Value> {
+    match results {
+        [] => Ok(Value::Null),
+        [single] => {
+            let cell = single
+                .point
+                .payload
+                .as_ref()
+                .and_then(|p| nested_payload_value(p, column))
+                .unwrap_or(&serde_json::Value::Null);
+            json_to_value(cell)
+        }
+        _ => Err(Error::Query(format!(
+            "scalar subquery returned {} rows but must return at most one row",
+            results.len()
+        ))),
+    }
+}
+
+/// Resolves a dot-separated payload path (e.g. `meta.amount`) to its JSON cell.
+fn nested_payload_value<'a>(
+    payload: &'a serde_json::Value,
+    path: &str,
+) -> Option<&'a serde_json::Value> {
+    let mut current = payload;
+    for part in path.split('.') {
+        current = current.as_object()?.get(part)?;
+    }
+    Some(current)
+}
+
+/// Converts a resolved JSON scalar into a `VelesQL` [`Value`] literal.
+fn json_to_value(json: &serde_json::Value) -> Result<Value> {
+    match json {
+        serde_json::Value::Null => Ok(Value::Null),
+        serde_json::Value::Bool(b) => Ok(Value::Boolean(*b)),
+        serde_json::Value::String(s) => Ok(Value::String(s.clone())),
+        serde_json::Value::Number(n) => number_to_value(n),
+        serde_json::Value::Array(_) | serde_json::Value::Object(_) => Err(Error::Query(
+            "scalar subquery column resolved to a non-scalar (array/object) value".to_string(),
+        )),
+    }
+}
+
+/// Converts a JSON number to the narrowest `VelesQL` numeric [`Value`].
+fn number_to_value(n: &serde_json::Number) -> Result<Value> {
+    if let Some(i) = n.as_i64() {
+        return Ok(Value::Integer(i));
+    }
+    if let Some(u) = n.as_u64() {
+        return Ok(Value::UnsignedInteger(u));
+    }
+    if let Some(f) = n.as_f64() {
+        return Ok(Value::Float(f));
+    }
+    Err(Error::Query(
+        "scalar subquery returned an unrepresentable number".to_string(),
+    ))
+}

--- a/crates/velesdb-core/src/velesql/ast/aggregation.rs
+++ b/crates/velesdb-core/src/velesql/ast/aggregation.rs
@@ -86,12 +86,14 @@ impl HavingClause {
         self.conditions.iter().any(|cond| cond.value.is_subquery())
     }
 
-    /// Returns `true` if any HAVING threshold value is a **correlated** subquery.
+    /// Returns `true` if any HAVING threshold value is a subquery **genuinely
+    /// correlated** against `outer_tables` (referencing one of the outer query's
+    /// tables/aliases).
     #[must_use]
-    pub fn has_correlated_subquery(&self) -> bool {
+    pub fn has_correlated_subquery(&self, outer_tables: &[&str]) -> bool {
         self.conditions
             .iter()
-            .any(|cond| cond.value.is_correlated_subquery())
+            .any(|cond| cond.value.is_correlated_subquery_with(outer_tables))
     }
 }
 

--- a/crates/velesdb-core/src/velesql/ast/aggregation.rs
+++ b/crates/velesdb-core/src/velesql/ast/aggregation.rs
@@ -85,6 +85,14 @@ impl HavingClause {
     pub fn has_subquery(&self) -> bool {
         self.conditions.iter().any(|cond| cond.value.is_subquery())
     }
+
+    /// Returns `true` if any HAVING threshold value is a **correlated** subquery.
+    #[must_use]
+    pub fn has_correlated_subquery(&self) -> bool {
+        self.conditions
+            .iter()
+            .any(|cond| cond.value.is_correlated_subquery())
+    }
 }
 
 /// A single HAVING condition.

--- a/crates/velesdb-core/src/velesql/ast/condition.rs
+++ b/crates/velesdb-core/src/velesql/ast/condition.rs
@@ -298,32 +298,37 @@ impl Condition {
     }
 
     /// Returns `true` if this condition (or any nested sub-condition) compares
-    /// against a **correlated** subquery (one referencing an outer column).
+    /// against a subquery that is **genuinely correlated** against `outer_tables`
+    /// (its inner WHERE references one of the outer query's tables/aliases).
     ///
-    /// Scalar (non-correlated) subqueries are executable and resolved before the
-    /// outer query runs; correlated ones are rejected by validation.
+    /// Scalar (non-correlated) subqueries — including those whose inner WHERE
+    /// merely filters on a payload path like `meta.cat` — are executable and
+    /// resolved before the outer query runs; correlated ones are rejected by
+    /// validation.
     #[must_use]
-    pub fn has_correlated_subquery(&self) -> bool {
-        self.leaf_has_correlated_subquery()
+    pub fn has_correlated_subquery(&self, outer_tables: &[&str]) -> bool {
+        self.leaf_has_correlated_subquery(outer_tables)
             || match self {
                 Self::And(l, r) | Self::Or(l, r) => {
-                    l.has_correlated_subquery() || r.has_correlated_subquery()
+                    l.has_correlated_subquery(outer_tables)
+                        || r.has_correlated_subquery(outer_tables)
                 }
-                Self::Group(inner) | Self::Not(inner) => inner.has_correlated_subquery(),
+                Self::Group(inner) | Self::Not(inner) => {
+                    inner.has_correlated_subquery(outer_tables)
+                }
                 _ => false,
             }
     }
 
     /// Returns `true` if a value compared directly in this condition is a
-    /// correlated subquery (no nested logical operators).
-    fn leaf_has_correlated_subquery(&self) -> bool {
+    /// subquery correlated against `outer_tables` (no nested logical operators).
+    fn leaf_has_correlated_subquery(&self, outer_tables: &[&str]) -> bool {
+        let is_corr = |v: &Value| v.is_correlated_subquery_with(outer_tables);
         match self {
-            Self::Comparison(c) => c.value.is_correlated_subquery(),
-            Self::Between(c) => [&c.low, &c.high]
-                .into_iter()
-                .any(Value::is_correlated_subquery),
-            Self::In(c) => c.values.iter().any(Value::is_correlated_subquery),
-            Self::Contains(c) => c.values.iter().any(Value::is_correlated_subquery),
+            Self::Comparison(c) => is_corr(&c.value),
+            Self::Between(c) => [&c.low, &c.high].into_iter().any(&is_corr),
+            Self::In(c) => c.values.iter().any(&is_corr),
+            Self::Contains(c) => c.values.iter().any(&is_corr),
             _ => false,
         }
     }

--- a/crates/velesdb-core/src/velesql/ast/condition.rs
+++ b/crates/velesdb-core/src/velesql/ast/condition.rs
@@ -297,6 +297,37 @@ impl Condition {
             }
     }
 
+    /// Returns `true` if this condition (or any nested sub-condition) compares
+    /// against a **correlated** subquery (one referencing an outer column).
+    ///
+    /// Scalar (non-correlated) subqueries are executable and resolved before the
+    /// outer query runs; correlated ones are rejected by validation.
+    #[must_use]
+    pub fn has_correlated_subquery(&self) -> bool {
+        self.leaf_has_correlated_subquery()
+            || match self {
+                Self::And(l, r) | Self::Or(l, r) => {
+                    l.has_correlated_subquery() || r.has_correlated_subquery()
+                }
+                Self::Group(inner) | Self::Not(inner) => inner.has_correlated_subquery(),
+                _ => false,
+            }
+    }
+
+    /// Returns `true` if a value compared directly in this condition is a
+    /// correlated subquery (no nested logical operators).
+    fn leaf_has_correlated_subquery(&self) -> bool {
+        match self {
+            Self::Comparison(c) => c.value.is_correlated_subquery(),
+            Self::Between(c) => [&c.low, &c.high]
+                .into_iter()
+                .any(Value::is_correlated_subquery),
+            Self::In(c) => c.values.iter().any(Value::is_correlated_subquery),
+            Self::Contains(c) => c.values.iter().any(Value::is_correlated_subquery),
+            _ => false,
+        }
+    }
+
     /// Returns `true` if a value compared directly in this condition (ignoring
     /// nested logical operators) is a subquery.
     ///

--- a/crates/velesdb-core/src/velesql/ast/mod.rs
+++ b/crates/velesdb-core/src/velesql/ast/mod.rs
@@ -89,6 +89,25 @@ pub struct Query {
 }
 
 impl Query {
+    /// Wraps a bare [`SelectStatement`] into a plain SELECT [`Query`].
+    ///
+    /// Used to execute the inner SELECT of a scalar subquery (EPIC-039), which
+    /// the parser stores as a `SelectStatement` rather than a full `Query`.
+    #[must_use]
+    pub fn from_select(select: SelectStatement) -> Self {
+        Self {
+            let_bindings: Vec::new(),
+            select,
+            compound: None,
+            match_clause: None,
+            dml: None,
+            train: None,
+            ddl: None,
+            introspection: None,
+            admin: None,
+        }
+    }
+
     /// Returns true if this is a MATCH query.
     #[must_use]
     pub fn is_match_query(&self) -> bool {
@@ -142,14 +161,10 @@ impl Query {
         matches!(self.dml, Some(DmlStatement::SelectEdges(_)))
     }
 
-    /// Returns `true` if any HAVING threshold value — in the main SELECT or
-    /// in compound operands (UNION/INTERSECT/EXCEPT) — is a scalar subquery.
-    ///
-    /// HAVING thresholds are not part of the WHERE condition tree, so
-    /// [`Condition::has_subquery`] never visits them; V010 validation checks
-    /// both.
-    #[must_use]
-    pub fn has_having_subquery(&self) -> bool {
+    /// Iterates every HAVING clause of the query — the main SELECT plus every
+    /// compound operand (UNION/INTERSECT/EXCEPT). HAVING thresholds live outside
+    /// the WHERE condition tree, so callers that walk WHERE must check these too.
+    fn having_clauses(&self) -> impl Iterator<Item = &HavingClause> {
         let compound_stmts = self
             .compound
             .iter()
@@ -157,7 +172,20 @@ impl Query {
         std::iter::once(&self.select)
             .chain(compound_stmts)
             .filter_map(|stmt| stmt.having.as_ref())
-            .any(HavingClause::has_subquery)
+    }
+
+    /// Returns `true` if any HAVING threshold value is a scalar subquery.
+    #[must_use]
+    pub fn has_having_subquery(&self) -> bool {
+        self.having_clauses().any(HavingClause::has_subquery)
+    }
+
+    /// Returns `true` if any HAVING threshold is a **correlated** subquery
+    /// (rejected by validation).
+    #[must_use]
+    pub fn has_correlated_having_subquery(&self) -> bool {
+        self.having_clauses()
+            .any(HavingClause::has_correlated_subquery)
     }
 
     /// Returns true if this is an INSERT NODE query.

--- a/crates/velesdb-core/src/velesql/ast/mod.rs
+++ b/crates/velesdb-core/src/velesql/ast/mod.rs
@@ -93,19 +93,11 @@ impl Query {
     ///
     /// Used to execute the inner SELECT of a scalar subquery (EPIC-039), which
     /// the parser stores as a `SelectStatement` rather than a full `Query`.
+    /// Alias of [`Self::new_select`] for call-site readability at the subquery
+    /// boundary.
     #[must_use]
     pub fn from_select(select: SelectStatement) -> Self {
-        Self {
-            let_bindings: Vec::new(),
-            select,
-            compound: None,
-            match_clause: None,
-            dml: None,
-            train: None,
-            ddl: None,
-            introspection: None,
-            admin: None,
-        }
+        Self::new_select(select)
     }
 
     /// Returns true if this is a MATCH query.
@@ -162,30 +154,35 @@ impl Query {
     }
 
     /// Iterates every HAVING clause of the query — the main SELECT plus every
-    /// compound operand (UNION/INTERSECT/EXCEPT). HAVING thresholds live outside
-    /// the WHERE condition tree, so callers that walk WHERE must check these too.
-    fn having_clauses(&self) -> impl Iterator<Item = &HavingClause> {
+    /// compound operand (UNION/INTERSECT/EXCEPT) — paired with its owning
+    /// statement (whose FROM/aliases scope any correlated subquery). HAVING
+    /// thresholds live outside the WHERE condition tree, so callers that walk
+    /// WHERE must check these too.
+    fn having_clauses(&self) -> impl Iterator<Item = (&SelectStatement, &HavingClause)> {
         let compound_stmts = self
             .compound
             .iter()
             .flat_map(|c| c.operations.iter().map(|(_, stmt)| stmt));
         std::iter::once(&self.select)
             .chain(compound_stmts)
-            .filter_map(|stmt| stmt.having.as_ref())
+            .filter_map(|stmt| stmt.having.as_ref().map(|h| (stmt, h)))
     }
 
     /// Returns `true` if any HAVING threshold value is a scalar subquery.
     #[must_use]
     pub fn has_having_subquery(&self) -> bool {
-        self.having_clauses().any(HavingClause::has_subquery)
+        self.having_clauses()
+            .any(|(_, having)| having.has_subquery())
     }
 
-    /// Returns `true` if any HAVING threshold is a **correlated** subquery
-    /// (rejected by validation).
+    /// Returns `true` if any HAVING threshold is a subquery **genuinely
+    /// correlated** against its owning SELECT's tables/aliases (rejected by
+    /// validation). A HAVING subquery that only filters on a payload path is
+    /// resolvable, not correlated.
     #[must_use]
     pub fn has_correlated_having_subquery(&self) -> bool {
         self.having_clauses()
-            .any(HavingClause::has_correlated_subquery)
+            .any(|(stmt, having)| having.has_correlated_subquery(&stmt.outer_table_scope()))
     }
 
     /// Returns true if this is an INSERT NODE query.

--- a/crates/velesdb-core/src/velesql/ast/select.rs
+++ b/crates/velesdb-core/src/velesql/ast/select.rs
@@ -353,6 +353,19 @@ pub struct SimilarityOrderBy {
 }
 
 impl SelectStatement {
+    /// Returns the table names and aliases visible as *outer* scope for a nested
+    /// subquery: the `FROM` collection plus any `FROM`/JOIN aliases.
+    ///
+    /// A subquery's inner WHERE is only **correlated** when it references one of
+    /// these names; a dotted payload path whose prefix is not in this set is a
+    /// plain payload filter, not a correlation (EPIC-039).
+    #[must_use]
+    pub fn outer_table_scope(&self) -> Vec<&str> {
+        std::iter::once(self.from.as_str())
+            .chain(self.from_alias.iter().map(String::as_str))
+            .collect()
+    }
+
     /// Returns an empty `SelectStatement` with all fields at their defaults.
     ///
     /// Used by [`crate::velesql::Query::new_dml`],

--- a/crates/velesdb-core/src/velesql/ast/values.rs
+++ b/crates/velesdb-core/src/velesql/ast/values.rs
@@ -85,6 +85,27 @@ pub struct Subquery {
     pub correlations: Vec<CorrelatedColumn>,
 }
 
+impl Subquery {
+    /// Returns `true` if this subquery is **genuinely correlated** against the
+    /// given outer table names/aliases.
+    ///
+    /// Parsing records a candidate [`CorrelatedColumn`] for every dotted inner
+    /// field whose prefix differs from the subquery's own `FROM`. But VelesQL
+    /// dotted fields are payload paths (`meta.amount`), not table-qualified
+    /// columns, so a candidate is only a *real* outer reference when its prefix
+    /// matches a table/alias visible in the outer query (e.g. `docs.id` where the
+    /// outer query is `... FROM docs ...`). Payload paths whose prefix is not an
+    /// outer table (e.g. `meta.cat`) are therefore **not** correlated.
+    #[must_use]
+    pub fn references_outer_table(&self, outer_tables: &[&str]) -> bool {
+        self.correlations.iter().any(|c| {
+            outer_tables
+                .iter()
+                .any(|t| t.eq_ignore_ascii_case(&c.outer_table))
+        })
+    }
+}
+
 /// A correlated column reference in a subquery (EPIC-039).
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct CorrelatedColumn {
@@ -175,6 +196,14 @@ impl Value {
     #[must_use]
     pub fn is_correlated_subquery(&self) -> bool {
         matches!(self, Self::Subquery(sq) if !sq.correlations.is_empty())
+    }
+
+    /// Returns `true` if this value is a subquery that is **genuinely
+    /// correlated** against `outer_tables` (its inner WHERE references one of the
+    /// outer query's tables/aliases). See [`Subquery::references_outer_table`].
+    #[must_use]
+    pub fn is_correlated_subquery_with(&self, outer_tables: &[&str]) -> bool {
+        matches!(self, Self::Subquery(sq) if sq.references_outer_table(outer_tables))
     }
 
     /// Converts this VelesQL value to a JSON value.

--- a/crates/velesdb-core/src/velesql/ast/values.rs
+++ b/crates/velesdb-core/src/velesql/ast/values.rs
@@ -158,11 +158,23 @@ impl IntervalValue {
 impl Value {
     /// Returns `true` if this value is a subquery.
     ///
-    /// Subqueries parse but are not yet executable; callers use this to reject
-    /// them before they silently evaluate to `Value::Null`.
+    /// Scalar (non-correlated) subqueries are executed and substituted before
+    /// the outer query runs (EPIC-039); callers use this to locate the leaves
+    /// that need resolution.
     #[must_use]
     pub fn is_subquery(&self) -> bool {
         matches!(self, Self::Subquery(_))
+    }
+
+    /// Returns `true` if this value is a **correlated** subquery (one that
+    /// references an outer column).
+    ///
+    /// Correlated subqueries are not yet executable; validation rejects them
+    /// while accepting scalar (non-correlated) subqueries, which the executor
+    /// resolves into literals.
+    #[must_use]
+    pub fn is_correlated_subquery(&self) -> bool {
+        matches!(self, Self::Subquery(sq) if !sq.correlations.is_empty())
     }
 
     /// Converts this VelesQL value to a JSON value.

--- a/crates/velesdb-core/src/velesql/validation.rs
+++ b/crates/velesdb-core/src/velesql/validation.rs
@@ -511,8 +511,8 @@ fn requires_select_validation(query: &Query) -> bool {
 /// rejected here so it never silently evaluates to NULL.
 fn reject_subqueries(query: &Query) -> Result<(), ValidationError> {
     let in_where = where_clauses(query)
-        .into_iter()
-        .any(Condition::has_correlated_subquery);
+        .iter()
+        .any(|(scope, cond)| cond.has_correlated_subquery(scope));
     if in_where || query.has_correlated_having_subquery() {
         return Err(ValidationError::new(
             ValidationErrorKind::SubqueryNotExecutable,
@@ -525,28 +525,44 @@ fn reject_subqueries(query: &Query) -> Result<(), ValidationError> {
     Ok(())
 }
 
-/// Collects every WHERE clause in the query: the main SELECT, compound
-/// operands (UNION/INTERSECT/EXCEPT), and DML statements (UPDATE/DELETE/SELECT EDGES).
-fn where_clauses(query: &Query) -> Vec<&Condition> {
-    let mut clauses: Vec<&Condition> = query.select.where_clause.as_ref().into_iter().collect();
+/// Collects every WHERE clause in the query — the main SELECT, compound operands
+/// (UNION/INTERSECT/EXCEPT), and DML statements (UPDATE/DELETE/SELECT EDGES) —
+/// each paired with its **outer-table scope** (the names a nested subquery would
+/// have to reference to be correlated).
+fn where_clauses(query: &Query) -> Vec<(Vec<&str>, &Condition)> {
+    let mut clauses: Vec<(Vec<&str>, &Condition)> = query
+        .select
+        .where_clause
+        .as_ref()
+        .map(|c| (query.select.outer_table_scope(), c))
+        .into_iter()
+        .collect();
     if let Some(ref compound) = query.compound {
-        clauses.extend(
-            compound
-                .operations
-                .iter()
-                .filter_map(|(_, stmt)| stmt.where_clause.as_ref()),
-        );
+        clauses.extend(compound.operations.iter().filter_map(|(_, stmt)| {
+            stmt.where_clause
+                .as_ref()
+                .map(|c| (stmt.outer_table_scope(), c))
+        }));
     }
     clauses.extend(dml_where_clauses(query.dml.as_ref()));
     clauses
 }
 
-/// Returns the optional WHERE clauses carried by a DML statement.
-fn dml_where_clauses(dml: Option<&DmlStatement>) -> Vec<&Condition> {
+/// Returns the WHERE clauses carried by a DML statement, each paired with the
+/// target table as its outer-table scope.
+fn dml_where_clauses(dml: Option<&DmlStatement>) -> Vec<(Vec<&str>, &Condition)> {
     match dml {
-        Some(DmlStatement::Update(u)) => u.where_clause.iter().collect(),
-        Some(DmlStatement::Delete(d)) => vec![&d.where_clause],
-        Some(DmlStatement::SelectEdges(s)) => s.where_clause.iter().collect(),
+        Some(DmlStatement::Update(u)) => u
+            .where_clause
+            .iter()
+            .map(|c| (vec![u.table.as_str()], c))
+            .collect(),
+        Some(DmlStatement::Delete(d)) => vec![(vec![d.table.as_str()], &d.where_clause)],
+        Some(DmlStatement::SelectEdges(s)) => s
+            .where_clause
+            .iter()
+            .map(|c| (vec![s.collection.as_str()], c))
+            .collect(),
         _ => Vec::new(),
     }
 }

--- a/crates/velesdb-core/src/velesql/validation.rs
+++ b/crates/velesdb-core/src/velesql/validation.rs
@@ -502,23 +502,24 @@ fn requires_select_validation(query: &Query) -> bool {
         && !query.is_admin_query()
 }
 
-/// Rejects subqueries appearing in any WHERE or HAVING clause of the query.
+/// Rejects **correlated** subqueries in any WHERE or HAVING clause.
 ///
-/// Subqueries are parsed but not yet executed: left unchecked, a predicate like
-/// `WHERE price > (SELECT AVG(price) FROM products)` silently evaluates to NULL,
-/// yielding wrong/empty results (or a silently no-op UPDATE) instead of an error.
-/// `HAVING COUNT(*) > (SELECT ...)` would likewise silently filter every group.
+/// Scalar (non-correlated) subqueries are now executed and substituted as
+/// literals before validation runs (EPIC-039), so a well-formed predicate like
+/// `WHERE price > (SELECT AVG(price) FROM products)` is accepted. A *correlated*
+/// subquery (one referencing an outer column) is not yet executable and is
+/// rejected here so it never silently evaluates to NULL.
 fn reject_subqueries(query: &Query) -> Result<(), ValidationError> {
     let in_where = where_clauses(query)
         .into_iter()
-        .any(Condition::has_subquery);
-    if in_where || query.has_having_subquery() {
+        .any(Condition::has_correlated_subquery);
+    if in_where || query.has_correlated_having_subquery() {
         return Err(ValidationError::new(
             ValidationErrorKind::SubqueryNotExecutable,
             None,
             "subquery",
-            "Compute the value separately and pass it as a literal or $parameter, \
-             or rewrite the predicate without a subquery",
+            "correlated subqueries (referencing an outer column) are not supported; \
+             rewrite the predicate without a reference to the outer query",
         ));
     }
     Ok(())

--- a/crates/velesdb-core/src/velesql/validation_tests.rs
+++ b/crates/velesdb-core/src/velesql/validation_tests.rs
@@ -1440,11 +1440,12 @@ fn test_validation_error_kind_message_invalid_let() {
 }
 
 // ============================================================================
-// FU-2: Subqueries parse but are not executable (V010)
+// FU-2: Scalar subqueries are executable (EPIC-039); correlated ones are not.
 //
-// A WHERE-clause subquery parses, then silently evaluates to NULL during
-// filtering (wrong/empty results, or a silently no-op UPDATE). Validation
-// must reject it instead.
+// A scalar (non-correlated) WHERE/HAVING subquery is resolved to a literal
+// before validation, so validation now ACCEPTS it. A *correlated* subquery
+// (referencing an outer column) is still rejected with V010 because it is not
+// yet executable.
 // ============================================================================
 
 fn validate_sql(sql: &str) -> Result<(), ValidationError> {
@@ -1453,43 +1454,40 @@ fn validate_sql(sql: &str) -> Result<(), ValidationError> {
 }
 
 fn assert_subquery_rejected(sql: &str) {
-    let err = validate_sql(sql).expect_err("subquery WHERE clause should be rejected");
+    let err = validate_sql(sql).expect_err("correlated subquery should be rejected");
     assert_eq!(err.kind, ValidationErrorKind::SubqueryNotExecutable);
 }
 
 #[test]
-fn test_scalar_subquery_in_where_is_rejected() {
-    assert_subquery_rejected(
-        "SELECT * FROM products WHERE price > (SELECT AVG(price) FROM products) LIMIT 10",
-    );
+fn test_scalar_subquery_in_where_is_accepted() {
+    // Non-correlated: resolved before validation, so validation passes.
+    assert!(validate_sql(
+        "SELECT * FROM products WHERE price > (SELECT AVG(price) FROM products) LIMIT 10"
+    )
+    .is_ok());
 }
 
 #[test]
-fn test_between_subquery_in_where_is_rejected() {
-    assert_subquery_rejected(
-        "SELECT * FROM docs WHERE id BETWEEN (SELECT AVG(id) FROM docs) AND 100 LIMIT 10",
-    );
+fn test_between_scalar_subquery_in_where_is_accepted() {
+    assert!(validate_sql(
+        "SELECT * FROM docs WHERE id BETWEEN (SELECT AVG(id) FROM other) AND 100 LIMIT 10"
+    )
+    .is_ok());
 }
 
 #[test]
-fn test_subquery_nested_in_and_is_rejected() {
-    assert_subquery_rejected(
-        "SELECT * FROM docs WHERE category = 'tech' AND id > (SELECT AVG(id) FROM docs) LIMIT 10",
-    );
+fn test_scalar_subquery_nested_in_and_is_accepted() {
+    assert!(validate_sql(
+        "SELECT * FROM docs WHERE category = 'tech' AND id > (SELECT AVG(id) FROM other) LIMIT 10"
+    )
+    .is_ok());
 }
 
 #[test]
-fn test_update_where_subquery_is_rejected() {
-    // Previously this returned "executed successfully" while matching nothing.
-    assert_subquery_rejected("UPDATE docs SET x = 1 WHERE id > (SELECT AVG(id) FROM docs)");
-}
-
-#[test]
-fn test_subquery_in_compound_operand_is_rejected() {
-    // The subquery sits in the UNION's right-hand SELECT, exercising the
-    // compound-operand branch of where_clauses().
+fn test_correlated_subquery_in_where_is_rejected() {
+    // The inner WHERE references the outer table `docs`, making it correlated.
     assert_subquery_rejected(
-        "SELECT id FROM a WHERE x = 1 UNION SELECT id FROM b WHERE y > (SELECT AVG(z) FROM b)",
+        "SELECT * FROM docs WHERE id > (SELECT AVG(id) FROM sub WHERE docs.id = 5)",
     );
 }
 

--- a/crates/velesdb-core/tests/bdd.rs
+++ b/crates/velesdb-core/tests/bdd.rs
@@ -103,6 +103,8 @@ mod recall_contract_multimetric;
 mod regression;
 #[path = "bdd/scalar_filter_exact.rs"]
 mod scalar_filter_exact;
+#[path = "bdd/scalar_subqueries.rs"]
+mod scalar_subqueries;
 #[path = "bdd/secondary_index_bitmap_in.rs"]
 mod secondary_index_bitmap_in;
 #[path = "bdd/set_operations.rs"]

--- a/crates/velesdb-core/tests/bdd/scalar_subqueries.rs
+++ b/crates/velesdb-core/tests/bdd/scalar_subqueries.rs
@@ -1,0 +1,231 @@
+//! BDD-style end-to-end tests for VelesQL **scalar subqueries** (EPIC-039).
+//!
+//! A scalar subquery `(SELECT AVG(amount) FROM t)` in a WHERE/HAVING predicate
+//! (or an INSERT/UPDATE value) is executed, reduced to a single row / single
+//! column, and substituted as a literal before the outer filter runs.
+//!
+//! These tests exercise the full pipeline: SQL string -> `Parser::parse()` ->
+//! `Database::execute_query()` -> verify results. Data is seeded deterministically
+//! so the resolved scalar is known up front.
+
+use std::collections::HashMap;
+
+use velesdb_core::{velesql::Parser, Database, Point};
+
+use super::helpers::{
+    create_test_db, execute_sql, execute_sql_with_params, payload_f64, result_ids,
+};
+
+/// Seed a 5-row `orders` collection with amounts 10/20/30/40/50.
+///
+/// `AVG(amount)` = 30, `MAX(amount)` = 50, `MIN(amount)` = 10, `COUNT(*)` = 5.
+fn setup_orders(db: &Database) {
+    execute_sql(
+        db,
+        "CREATE COLLECTION orders (dimension = 2, metric = 'cosine')",
+    )
+    .expect("test: create orders");
+
+    let vc = db
+        .get_vector_collection("orders")
+        .expect("test: get orders");
+    let amounts = [10.0_f64, 20.0, 30.0, 40.0, 50.0];
+    let points: Vec<Point> = amounts
+        .iter()
+        .enumerate()
+        .map(|(i, amount)| {
+            let id = u64::try_from(i).expect("test: id fits u64") + 1;
+            Point::new(
+                id,
+                vec![1.0, 0.0],
+                Some(serde_json::json!({ "amount": amount })),
+            )
+        })
+        .collect();
+    vc.upsert(points).expect("test: seed orders");
+}
+
+/// `WHERE amount > (SELECT AVG(amount) FROM orders)` returns the rows above the
+/// average (40, 50) — today this is rejected at validation with V010.
+#[test]
+fn where_scalar_subquery_avg_filters_above_average() {
+    let (_dir, db) = create_test_db();
+    setup_orders(&db);
+
+    let results = execute_sql(
+        &db,
+        "SELECT * FROM orders WHERE amount > (SELECT AVG(amount) FROM orders)",
+    )
+    .expect("scalar subquery WHERE should execute");
+
+    let ids = result_ids(&results);
+    assert_eq!(ids, [4, 5].into_iter().collect(), "ids with amount > 30");
+    for r in &results {
+        assert!(
+            payload_f64(r, "amount").expect("amount present") > 30.0,
+            "every returned row is above the average"
+        );
+    }
+}
+
+/// A plain (non-aggregate) single-row, single-column subquery resolves too:
+/// `WHERE amount >= (SELECT amount FROM orders WHERE amount = 40)`.
+#[test]
+fn where_scalar_subquery_plain_single_row() {
+    let (_dir, db) = create_test_db();
+    setup_orders(&db);
+
+    let results = execute_sql(
+        &db,
+        "SELECT * FROM orders WHERE amount >= (SELECT amount FROM orders WHERE amount = 40)",
+    )
+    .expect("plain scalar subquery WHERE should execute");
+
+    assert_eq!(result_ids(&results), [4, 5].into_iter().collect());
+}
+
+/// A subquery returning more than one row errors with a clear cardinality
+/// message (Error::Query), not a silent wrong result.
+#[test]
+fn where_scalar_subquery_multi_row_errors() {
+    let (_dir, db) = create_test_db();
+    setup_orders(&db);
+
+    let query = Parser::parse("SELECT * FROM orders WHERE amount > (SELECT amount FROM orders)")
+        .expect("parses");
+    let err = db
+        .execute_query(&query, &HashMap::new())
+        .expect_err("multi-row subquery must error");
+    let msg = err.to_string().to_lowercase();
+    assert!(
+        msg.contains("one row") || msg.contains("more than one") || msg.contains("cardinality"),
+        "error message names the cardinality violation: {msg}"
+    );
+}
+
+/// A zero-row subquery resolves to NULL; `amount > NULL` is never true, so the
+/// outer query returns no rows (documented behavior).
+#[test]
+fn where_scalar_subquery_zero_rows_yields_null() {
+    let (_dir, db) = create_test_db();
+    setup_orders(&db);
+
+    let results = execute_sql(
+        &db,
+        "SELECT * FROM orders WHERE amount > (SELECT amount FROM orders WHERE amount = 9999)",
+    )
+    .expect("zero-row subquery resolves to NULL");
+
+    assert!(
+        results.is_empty(),
+        "comparison against NULL yields no rows, got {}",
+        results.len()
+    );
+}
+
+/// A `SELECT *` subquery violates the one-column contract and errors clearly.
+#[test]
+fn where_scalar_subquery_star_projection_errors() {
+    let (_dir, db) = create_test_db();
+    setup_orders(&db);
+
+    let query = Parser::parse(
+        "SELECT * FROM orders WHERE amount > (SELECT * FROM orders WHERE amount = 40)",
+    )
+    .expect("parses");
+    let err = db
+        .execute_query(&query, &HashMap::new())
+        .expect_err("SELECT * subquery must error on the one-column contract");
+    assert!(
+        err.to_string().to_lowercase().contains("one column"),
+        "error names the one-column violation: {err}"
+    );
+}
+
+/// A HAVING scalar subquery on a top-level aggregate query resolves and filters
+/// groups: `HAVING COUNT(*) > (SELECT COUNT(*) ... )`.
+///
+/// Seed: amounts 10/20/30 in category 'a', 40/50 in 'b'. The subquery
+/// `(SELECT COUNT(*) FROM orders WHERE amount > 35)` = 2. `HAVING COUNT(*) >= 2`
+/// keeps only 'a' (3 rows); 'b' (2 rows) is dropped by `> 2`.
+#[test]
+fn having_scalar_subquery_filters_groups() {
+    let (_dir, db) = create_test_db();
+    execute_sql(
+        &db,
+        "CREATE COLLECTION cats (dimension = 2, metric = 'cosine')",
+    )
+    .expect("test: create cats");
+    let vc = db.get_vector_collection("cats").expect("test: get cats");
+    vc.upsert(vec![
+        Point::new(
+            1,
+            vec![1.0, 0.0],
+            Some(serde_json::json!({"cat":"a","amount":10.0})),
+        ),
+        Point::new(
+            2,
+            vec![1.0, 0.0],
+            Some(serde_json::json!({"cat":"a","amount":20.0})),
+        ),
+        Point::new(
+            3,
+            vec![1.0, 0.0],
+            Some(serde_json::json!({"cat":"a","amount":30.0})),
+        ),
+        Point::new(
+            4,
+            vec![1.0, 0.0],
+            Some(serde_json::json!({"cat":"b","amount":40.0})),
+        ),
+        Point::new(
+            5,
+            vec![1.0, 0.0],
+            Some(serde_json::json!({"cat":"b","amount":50.0})),
+        ),
+    ])
+    .expect("test: seed cats");
+
+    let query = Parser::parse(
+        "SELECT cat, COUNT(*) FROM cats GROUP BY cat \
+         HAVING COUNT(*) > (SELECT COUNT(*) FROM cats WHERE amount > 35)",
+    )
+    .expect("parses");
+    let json = db
+        .execute_aggregate(&query, &HashMap::new())
+        .expect("HAVING subquery aggregate should execute");
+
+    let groups = json.as_array().expect("grouped result is an array");
+    assert_eq!(groups.len(), 1, "only category 'a' has > 2 rows: {json}");
+    assert_eq!(groups[0].get("cat").and_then(|v| v.as_str()), Some("a"));
+}
+
+/// An INSERT VALUES scalar subquery resolves before the row is written.
+#[test]
+fn insert_value_scalar_subquery_resolves() {
+    let (_dir, db) = create_test_db();
+    setup_orders(&db);
+
+    // amount := MAX(amount) = 50 for the new id=6 row.
+    let mut params = HashMap::new();
+    params.insert("v".to_string(), serde_json::json!([1.0_f32, 0.0_f32]));
+    execute_sql_with_params(
+        &db,
+        "INSERT INTO orders (id, vector, amount) \
+         VALUES (6, $v, (SELECT MAX(amount) FROM orders))",
+        &params,
+    )
+    .expect("INSERT with scalar subquery value should execute");
+
+    let inserted = execute_sql(&db, "SELECT * FROM orders WHERE amount = 50 LIMIT 100")
+        .expect("read back inserted row");
+    let new_row = inserted
+        .iter()
+        .find(|r| r.point.id == 6)
+        .expect("the new id=6 row exists");
+    assert_eq!(
+        payload_f64(new_row, "amount"),
+        Some(50.0),
+        "amount was filled from MAX(amount)"
+    );
+}

--- a/crates/velesdb-core/tests/bdd/scalar_subqueries.rs
+++ b/crates/velesdb-core/tests/bdd/scalar_subqueries.rs
@@ -229,3 +229,154 @@ fn insert_value_scalar_subquery_resolves() {
         "amount was filled from MAX(amount)"
     );
 }
+
+/// Collect the ids of `orders` rows whose `flagged` payload field is `true`.
+fn flagged_ids(db: &Database) -> std::collections::HashSet<u64> {
+    let rows = execute_sql(db, "SELECT * FROM orders LIMIT 100").expect("read back orders");
+    rows.iter()
+        .filter(|r| {
+            r.point
+                .payload
+                .as_ref()
+                .and_then(|p| p.get("flagged"))
+                .and_then(serde_json::Value::as_bool)
+                == Some(true)
+        })
+        .map(|r| r.point.id)
+        .collect()
+}
+
+/// CRITICAL (backlog-#21): `UPDATE ... SET flagged = true WHERE amount >
+/// (SELECT AVG(amount) FROM orders)` must flag exactly the rows above the
+/// average (40, 50) and leave the others untouched.
+///
+/// On the pre-completion code the WHERE subquery is never substituted, so the
+/// predicate evaluates `amount > NULL` = false and the UPDATE silently matches
+/// nothing — this test FAILS there (empty flagged set) and PASSES once the
+/// subquery is resolved before the UPDATE runs.
+#[test]
+fn update_where_scalar_subquery_flags_above_average() {
+    let (_dir, db) = create_test_db();
+    setup_orders(&db);
+
+    execute_sql(
+        &db,
+        "UPDATE orders SET flagged = true WHERE amount > (SELECT AVG(amount) FROM orders)",
+    )
+    .expect("UPDATE WHERE scalar subquery should execute");
+
+    assert_eq!(
+        flagged_ids(&db),
+        [4, 5].into_iter().collect(),
+        "exactly the rows with amount > AVG(30) were flagged"
+    );
+}
+
+/// DELETE consistency: `DELETE FROM orders WHERE id = (SELECT oid ...)` resolves
+/// the subquery to a literal integer id and deletes exactly that row, rather
+/// than silently no-op'ing or rejecting it.
+///
+/// (`DELETE WHERE id = N` requires an integer literal; an *aggregate* subquery
+/// like `MAX(id)` yields a float and is out of scope here, so the discriminating
+/// subquery is a single-row projection of an integer payload field.)
+#[test]
+fn delete_where_scalar_subquery_resolves_id() {
+    let (_dir, db) = create_test_db();
+    execute_sql(
+        &db,
+        "CREATE COLLECTION orders (dimension = 2, metric = 'cosine')",
+    )
+    .expect("create orders");
+    let vc = db.get_vector_collection("orders").expect("get orders");
+    // Each row carries an integer `oid` payload equal to its point id.
+    let points: Vec<Point> = (1_u64..=4)
+        .map(|id| {
+            Point::new(
+                id,
+                vec![1.0, 0.0],
+                Some(serde_json::json!({ "oid": id, "tag": id })),
+            )
+        })
+        .collect();
+    vc.upsert(points).expect("seed orders");
+
+    // (SELECT oid FROM orders WHERE tag = 3) = 3 -> deletes row id=3.
+    execute_sql(
+        &db,
+        "DELETE FROM orders WHERE id = (SELECT oid FROM orders WHERE tag = 3)",
+    )
+    .expect("DELETE WHERE scalar subquery should execute");
+
+    let remaining = execute_sql(&db, "SELECT * FROM orders LIMIT 100").expect("read back orders");
+    assert_eq!(
+        result_ids(&remaining),
+        [1, 2, 4].into_iter().collect(),
+        "only the row whose oid matched the subquery (id=3) was deleted"
+    );
+}
+
+/// MEDIUM: a subquery whose inner WHERE filters on a dotted **payload path**
+/// (`meta.cat`) is a plain payload filter, not a correlation — it must be
+/// ACCEPTED and executed, not wrongly rejected as correlated (V010).
+#[test]
+fn payload_path_subquery_is_not_correlated() {
+    let (_dir, db) = create_test_db();
+    execute_sql(
+        &db,
+        "CREATE COLLECTION sub (dimension = 2, metric = 'cosine')",
+    )
+    .expect("create sub");
+    let vc = db.get_vector_collection("sub").expect("get sub");
+    // Two rows with meta.cat = 5 (prices 10, 30 -> AVG 20) and one with cat = 1.
+    vc.upsert(vec![
+        Point::new(
+            1,
+            vec![1.0, 0.0],
+            Some(serde_json::json!({"price": 10.0, "meta": {"cat": 5}})),
+        ),
+        Point::new(
+            2,
+            vec![1.0, 0.0],
+            Some(serde_json::json!({"price": 30.0, "meta": {"cat": 5}})),
+        ),
+        Point::new(
+            3,
+            vec![1.0, 0.0],
+            Some(serde_json::json!({"price": 99.0, "meta": {"cat": 1}})),
+        ),
+    ])
+    .expect("seed sub");
+
+    // AVG(price WHERE meta.cat = 5) = 20; outer keeps prices > 20 (id 2 and 3).
+    let results = execute_sql(
+        &db,
+        "SELECT * FROM sub WHERE price > (SELECT AVG(price) FROM sub WHERE meta.cat = 5)",
+    )
+    .expect("payload-path subquery must be accepted and executed, not rejected as correlated");
+
+    assert_eq!(result_ids(&results), [2, 3].into_iter().collect());
+}
+
+/// A genuinely correlated subquery — its inner WHERE references the *outer*
+/// table (`sub.price`) — is still rejected at validation with V010.
+#[test]
+fn genuinely_correlated_subquery_is_still_rejected() {
+    let (_dir, db) = create_test_db();
+    execute_sql(
+        &db,
+        "CREATE COLLECTION sub (dimension = 2, metric = 'cosine')",
+    )
+    .expect("create sub");
+
+    let query = Parser::parse(
+        "SELECT * FROM sub WHERE price > (SELECT AVG(price) FROM inner_t WHERE sub.price = 5)",
+    )
+    .expect("parses");
+    let err = db
+        .execute_query(&query, &HashMap::new())
+        .expect_err("correlated subquery (referencing outer table) must be rejected");
+    assert!(
+        err.to_string().to_lowercase().contains("correlated"),
+        "rejection names the correlation: {err}"
+    );
+}

--- a/crates/velesdb-core/tests/bdd/velesql_reject_conformance.rs
+++ b/crates/velesdb-core/tests/bdd/velesql_reject_conformance.rs
@@ -71,21 +71,24 @@ fn setup_graph(db: &Database) {
 }
 
 // =========================================================================
-// 1. WHERE scalar subquery -> V010 SubqueryNotExecutable
+// 1. WHERE *correlated* subquery -> V010 SubqueryNotExecutable
+//
+// Scalar (non-correlated) subqueries are now executed and substituted as
+// literals (EPIC-039). A correlated subquery (referencing an outer column) is
+// still not executable and must be rejected with V010.
 // =========================================================================
 
 #[test]
-fn scenario_where_scalar_subquery_rejected_with_v010() {
+fn scenario_where_correlated_subquery_rejected_with_v010() {
     let (_dir, db) = create_test_db();
     setup_products(&db);
 
-    // The subquery parses but is not executable; validation must reject it
-    // instead of silently evaluating the predicate to NULL.
     let err = execute_sql(
         &db,
-        "SELECT * FROM products WHERE price > (SELECT AVG(price) FROM products) LIMIT 10",
+        "SELECT * FROM products WHERE price > \
+         (SELECT AVG(price) FROM sub WHERE products.price = 5) LIMIT 10",
     )
-    .expect_err("test: WHERE scalar subquery must be rejected");
+    .expect_err("test: WHERE correlated subquery must be rejected");
     assert!(
         err.to_string().contains("V010"),
         "expected V010 subquery code, got: {err}"

--- a/crates/velesdb-core/tests/bdd/where_params.rs
+++ b/crates/velesdb-core/tests/bdd/where_params.rs
@@ -453,19 +453,36 @@ fn scenario_having_missing_param_errors() {
 }
 
 #[test]
-fn scenario_having_scalar_subquery_rejected_by_validation() {
-    // GIVEN a parsed aggregation query whose HAVING threshold is a subquery
+fn scenario_having_scalar_subquery_accepted_by_validation() {
+    // GIVEN a parsed aggregation query whose HAVING threshold is a scalar
+    // (non-correlated) subquery — now executable (EPIC-039)
     let query = Parser::parse(
         "SELECT category, COUNT(*) FROM products GROUP BY category \
-         HAVING COUNT(*) > (SELECT AVG(stock) FROM products)",
+         HAVING COUNT(*) > (SELECT AVG(stock) FROM other)",
     )
     .expect("test: HAVING subquery must parse");
 
     // WHEN validating it (the same gate the server runs before execution)
-    let result = QueryValidator::validate(&query);
+    // THEN validation accepts it; the executor resolves the scalar before
+    // running the aggregation
+    assert!(
+        QueryValidator::validate(&query).is_ok(),
+        "scalar HAVING subquery must pass validation"
+    );
+}
 
-    // THEN V010 rejects the subquery instead of silently filtering all groups
-    let err = result.expect_err("HAVING subquery must be rejected by validation");
+#[test]
+fn scenario_having_correlated_subquery_rejected_by_validation() {
+    // A correlated HAVING subquery (referencing the outer table) is not yet
+    // executable and must be rejected with V010.
+    let query = Parser::parse(
+        "SELECT category, COUNT(*) FROM products GROUP BY category \
+         HAVING COUNT(*) > (SELECT AVG(stock) FROM sub WHERE products.category = 5)",
+    )
+    .expect("test: HAVING subquery must parse");
+
+    let err = QueryValidator::validate(&query)
+        .expect_err("correlated HAVING subquery must be rejected by validation");
     assert!(
         err.to_string().contains("V010"),
         "error should carry the V010 subquery code, got: {err}"

--- a/crates/velesdb-python/tests/test_velesql_sdk_backlog.py
+++ b/crates/velesdb-python/tests/test_velesql_sdk_backlog.py
@@ -129,13 +129,15 @@ def test_explain_rejects_invalid_query(temp_db_path):
     collection = db.create_collection("explain_invalid", dimension=2, metric="cosine")
     collection.upsert([{"id": 1, "vector": [1.0, 0.0], "payload": {"amount": 5}}])
 
-    # A query that parses but is semantically invalid (a WHERE subquery, which
-    # VelesQL parses yet rejects at validation) must be rejected by explain()
-    # rather than silently building a plan.
+    # A query that parses but is semantically invalid (a *correlated* subquery —
+    # its inner WHERE references the outer table, which VelesQL parses yet rejects
+    # at validation) must be rejected by explain() rather than silently building a
+    # plan. (Plain scalar subqueries are now executable, so a correlated one is
+    # used here as the still-rejected invalid shape.)
     with pytest.raises(ValueError):
         collection.explain(
             "SELECT * FROM explain_invalid WHERE amount > "
-            "(SELECT AVG(amount) FROM explain_invalid) LIMIT 5"
+            "(SELECT AVG(amount) FROM other_t WHERE explain_invalid.amount = 5) LIMIT 5"
         )
 
 

--- a/docs/VELESQL_SPEC.md
+++ b/docs/VELESQL_SPEC.md
@@ -50,7 +50,7 @@ equivalent. Identifiers (collection names, column names) are case-sensitive.
 | DISTINCT modifier | Stable | 3.3 |
 | ILIKE case-insensitive pattern | Stable | 3.3 |
 | FROM / JOIN aliases | Stable (INNER JOIN) | 2.0 |
-| Scalar subqueries | Parsed, then rejected at validation (V010, see below) | 3.2 |
+| Scalar subqueries | Executed and substituted as a literal; correlated ones rejected (V010, see below) | 3.2 |
 | SQL comments (`--`) | Stable | 1.0 |
 | Identifier quoting (backtick, double-quote) | Stable | 1.3 |
 | SHOW COLLECTIONS | Stable | 3.4 |
@@ -926,13 +926,24 @@ the CLI REPL (both route through `Database::execute_query`).
 - Single-column row projection — `(SELECT amount FROM t WHERE id = 1)`.
 - `WHERE`, `HAVING`, `BETWEEN`, `IN (...)`, `CONTAINS (...)` value positions.
 - `INSERT ... VALUES (..., (SELECT MAX(x) FROM t))` and `UPDATE ... SET c = (SELECT ...)`.
+- **`UPDATE ... WHERE` and `DELETE ... WHERE`** predicates — the subquery is
+  resolved to a literal *before* the mutation runs, so
+  `UPDATE t SET flagged = true WHERE amount > (SELECT AVG(amount) FROM t)` updates
+  exactly the matching rows, and `DELETE FROM t WHERE id = (SELECT … )` deletes
+  the resolved id (`DELETE … WHERE id` still requires the resolved value to be an
+  integer).
+- A subquery whose **inner `WHERE` filters on a payload path** — e.g.
+  `(SELECT AVG(price) FROM t WHERE meta.cat = 5)` — is a plain payload filter on
+  the subquery's own collection, **not** a correlation, so it executes normally.
 - Nesting up to 8 levels deep (a deeper nest errors with `VELES-010`).
 
 **Not yet supported (rejected at validation with `V010`):**
 
-- **Correlated subqueries** — a subquery whose inner `WHERE` references an outer
-  column (e.g. `(SELECT AVG(x) FROM s WHERE outer.id = 5)`). Rewrite without the
-  outer reference.
+- **Correlated subqueries** — a subquery whose inner `WHERE` references one of the
+  *outer* query's tables/aliases (e.g. with the outer query `... FROM orders ...`,
+  the inner `(SELECT AVG(x) FROM s WHERE orders.id = 5)`). A dotted reference is
+  only correlated when its prefix names an outer table/alias; a payload path such
+  as `meta.cat` is not. Rewrite without the outer reference.
 
 > **Surface note.** Scalar subqueries are resolved in `velesdb-core`, so the
 > REST `/query` endpoint and the CLI REPL support them. **WASM** uses a separate
@@ -2951,7 +2962,7 @@ VelesQL returns structured errors:
 | BETWEEN | `column BETWEEN low AND high` | `WHERE price BETWEEN 50 AND 200` |
 | LIKE / ILIKE | `column [I]LIKE 'pattern'` | `WHERE title LIKE 'rust%'`, `WHERE name ILIKE '%rust%'` |
 | IS NULL / IS NOT NULL | `column IS [NOT] NULL` | `WHERE email IS NOT NULL` |
-| Scalar subquery ⚠️ parsed, then rejected (V010) | `column op (SELECT … LIMIT 1)` | `WHERE views > (SELECT AVG(views) FROM stats LIMIT 1)` — rejected at validation with V010 (SubqueryNotExecutable) |
+| Scalar subquery | `column op (SELECT … )` | `WHERE views > (SELECT AVG(views) FROM stats)` — executed and substituted as a literal; **correlated** subqueries rejected with V010 (SubqueryNotExecutable) |
 | Graph match predicate | `MATCH (...)` in WHERE | `WHERE MATCH (a:Person)-[:KNOWS]->(b) AND a.id = $u` |
 | GEO_DISTANCE | `GEO_DISTANCE(col, lat, lng) op meters` | `WHERE GEO_DISTANCE(location, 48.8566, 2.3522) < 500` |
 | GEO_BBOX | `GEO_BBOX(col, lat_min, lng_min, lat_max, lng_max)` | `WHERE GEO_BBOX(location, 48.8, 2.3, 48.9, 2.4)` |

--- a/docs/VELESQL_SPEC.md
+++ b/docs/VELESQL_SPEC.md
@@ -895,25 +895,48 @@ SELECT * FROM logs WHERE created_at < NOW() - INTERVAL '30 days'
 
 ### Scalar Subqueries (v3.2+)
 
-> ⚠️ **Parsed but rejected at validation.** A scalar subquery in `WHERE`/`HAVING`
-> is accepted by the grammar (EPIC-039) but is rejected before execution by
-> semantic validation with error code V010 (`SubqueryNotExecutable`, message
-> 'Subqueries are parsed but not yet executable'). Earlier versions silently
-> resolved it to `NULL`; the engine now returns a `ValidationError` instead of
-> producing wrong/empty results. Compute the value in your application and pass it
-> as a bind parameter or literal.
-
-A scalar subquery in WHERE is intended to compare against a computed value from
-another (or the same) collection, returning exactly one row and one column.
+A scalar subquery in `WHERE`/`HAVING` (or an `INSERT`/`UPDATE` value) is
+**executed and substituted as a literal** before the outer query runs
+(EPIC-039). It compares against a value computed from another (or the same)
+collection, and must return **exactly one row and one column**.
 
 ```sql
--- Parsed, but REJECTED at validation with error V010 (SubqueryNotExecutable)
+-- Executes: the subquery resolves to AVG(amount), then the outer filter runs.
 SELECT * FROM orders
 WHERE amount > (SELECT AVG(amount) FROM orders)
 ```
 
 A subquery is enclosed in parentheses and contains a full SELECT statement
-(with optional WHERE, GROUP BY, HAVING, LIMIT).
+(with optional WHERE, GROUP BY, HAVING, LIMIT). It runs through the core query
+engine, so the same query executes identically on the REST `/query` endpoint and
+the CLI REPL (both route through `Database::execute_query`).
+
+**Cardinality contract:**
+
+| Subquery result | Behavior |
+|-----------------|----------|
+| Exactly one row, one column | resolves to that scalar value |
+| **0 rows** | resolves to `NULL` (a comparison against `NULL` is never true, so the outer query returns no matching rows) |
+| **> 1 row** | error `VELES-010` (Query): *returned N rows but must return at most one row* |
+| **> 1 column** (e.g. `SELECT *`, multiple columns) | error `VELES-010` (Query): *must select exactly one column* |
+
+**Supported forms:**
+
+- Aggregate subqueries — `(SELECT AVG(amount) FROM t)`, `COUNT(*)`, `MIN`/`MAX`/`SUM`.
+- Single-column row projection — `(SELECT amount FROM t WHERE id = 1)`.
+- `WHERE`, `HAVING`, `BETWEEN`, `IN (...)`, `CONTAINS (...)` value positions.
+- `INSERT ... VALUES (..., (SELECT MAX(x) FROM t))` and `UPDATE ... SET c = (SELECT ...)`.
+- Nesting up to 8 levels deep (a deeper nest errors with `VELES-010`).
+
+**Not yet supported (rejected at validation with `V010`):**
+
+- **Correlated subqueries** — a subquery whose inner `WHERE` references an outer
+  column (e.g. `(SELECT AVG(x) FROM s WHERE outer.id = 5)`). Rewrite without the
+  outer reference.
+
+> **Surface note.** Scalar subqueries are resolved in `velesdb-core`, so the
+> REST `/query` endpoint and the CLI REPL support them. **WASM** uses a separate
+> executor that does not yet resolve subqueries and still rejects them.
 
 ### Graph Match Predicate in WHERE
 

--- a/docs/reference/VELESQL_CHEATSHEET.md
+++ b/docs/reference/VELESQL_CHEATSHEET.md
@@ -176,8 +176,9 @@ Payload sub-fields use dot paths: `payload.author.name = 'Ada'`.
 
 A `(SELECT ...)` in a value position is executed and substituted as a literal
 before the outer query runs. It must return exactly one row and one column
-(0 rows -> `NULL`; more rows/columns -> `VELES-010`). Correlated subqueries
-(referencing an outer column) are not supported.
+(0 rows -> `NULL`; more rows/columns -> `VELES-010`). A subquery referencing one
+of the outer query's tables/aliases is **correlated** and rejected (V010); a
+dotted **payload path** like `meta.cat` is *not* a correlation.
 
 ```sql
 -- Aggregate subquery in WHERE
@@ -186,9 +187,14 @@ SELECT * FROM orders WHERE amount > (SELECT AVG(amount) FROM orders) LIMIT 10;
 -- Single-column row subquery
 SELECT * FROM orders WHERE amount >= (SELECT amount FROM orders WHERE id = 1);
 
--- HAVING and INSERT/UPDATE value positions also accept a scalar subquery
+-- Payload-path filter inside the subquery (not correlated)
+SELECT * FROM orders WHERE amount > (SELECT AVG(amount) FROM orders WHERE meta.cat = 5);
+
+-- HAVING, INSERT/UPDATE values, and UPDATE/DELETE WHERE accept a scalar subquery
 INSERT INTO orders (id, vector, amount)
 VALUES (6, $v, (SELECT MAX(amount) FROM orders));
+UPDATE orders SET flagged = true WHERE amount > (SELECT AVG(amount) FROM orders);
+DELETE FROM orders WHERE id = (SELECT oid FROM orders WHERE tag = 3);
 ```
 
 Resolved in `velesdb-core`, so REST `/query` and the CLI REPL support it; WASM

--- a/docs/reference/VELESQL_CHEATSHEET.md
+++ b/docs/reference/VELESQL_CHEATSHEET.md
@@ -172,6 +172,30 @@ Payload sub-fields use dot paths: `payload.author.name = 'Ada'`.
 
 ---
 
+## Scalar subqueries
+
+A `(SELECT ...)` in a value position is executed and substituted as a literal
+before the outer query runs. It must return exactly one row and one column
+(0 rows -> `NULL`; more rows/columns -> `VELES-010`). Correlated subqueries
+(referencing an outer column) are not supported.
+
+```sql
+-- Aggregate subquery in WHERE
+SELECT * FROM orders WHERE amount > (SELECT AVG(amount) FROM orders) LIMIT 10;
+
+-- Single-column row subquery
+SELECT * FROM orders WHERE amount >= (SELECT amount FROM orders WHERE id = 1);
+
+-- HAVING and INSERT/UPDATE value positions also accept a scalar subquery
+INSERT INTO orders (id, vector, amount)
+VALUES (6, $v, (SELECT MAX(amount) FROM orders));
+```
+
+Resolved in `velesdb-core`, so REST `/query` and the CLI REPL support it; WASM
+still rejects subqueries.
+
+---
+
 ## Aggregation, grouping & windows
 
 ```sql


### PR DESCRIPTION
## Summary

Implements scalar subqueries end-to-end in `velesdb-core` (EPIC #21) — they parsed but were rejected at validation (`V010`); the SPEC documented them as usable. Core executes them, so REST `/query` + CLI inherit the feature; WASM has a separate executor and **still rejects** (a genuine error, not a silent NULL — verified + documented).

### What works now
- **`WHERE` / `HAVING` scalar subqueries**: `SELECT * FROM orders WHERE amount > (SELECT AVG(amount) FROM orders)`. A new `subquery_resolver` walks the condition tree, executes each inner SELECT through the core engine, reduces it to a scalar, and substitutes it **before** validation/filter/aggregation.
- **DML**: subqueries in `INSERT`/`UPSERT VALUES`, `UPDATE SET`, **and `UPDATE`/`DELETE WHERE`**.
- **Cardinality** (enforced, no holes): 0 rows → `NULL`; exactly 1 row/1 col → the scalar; `>1 row` → `VELES-010` ("must return at most one row"); `>1 column` / `SELECT *` → `VELES-010` ("must select exactly one column"). Nesting bounded at `MAX_SUBQUERY_DEPTH=8`.
- **Correlated subqueries** are clearly rejected (`VELES-010`) — a precise definition (references an *outer* table/alias). A dotted **payload** path (`meta.cat`) is correctly **not** treated as correlated.

### Two defects caught by adversarial review and fixed in this PR
1. **Silent no-op `UPDATE`/`DELETE … WHERE (subquery)`** — `rewrite_dml` initially only handled `SET` assignments, so a `WHERE` subquery passed validation but was never substituted → `col > NULL` = false → the mutation silently matched nothing and reported success. Now resolved in `where_clause` too. Guard test (`update_where_scalar_subquery_flags_above_average`) proven to fail on the pre-fix code (empty set) and pass now (exactly the above-average rows).
2. **False-positive correlated rejection** of valid dotted-payload subqueries — the correlation decision now happens against the real outer FROM/alias scope, so `(SELECT AVG(price) FROM sub WHERE meta.cat = 5)` is accepted while a genuine outer reference is still rejected.

## Test plan
- New `tests/bdd/scalar_subqueries.rs` (11 tests incl. the 4 completion guards), each discriminating (proven fail-on-pre-fix in an isolated worktree).
- Gates: `cargo fmt`; `clippy --all-targets … -D warnings -D clippy::pedantic` (0 warnings); `lizard -C 8` (0 new violations); **full `cargo test -p velesdb-core --features persistence` = 6171 passed / 0 failed**. DRY: cleaned a clone introduced by the feature (`from_select`→`new_select`).
- `VELESQL_SPEC.md` + cheatsheet disclose the **exact** supported/unsupported surface (no over/under-claim); CHANGELOG `[Unreleased]`.

## Notes (tracked, non-blocking)
- Exotic ≥2-level nested correlation referencing the *outermost* table resolves-as-payload rather than rejecting (multi-level correlation is undocumented; no silent no-op).
- Pre-existing `execute_single_select` CCN 9 (untouched, on develop through all prior merges).