### PR TITLE
fix: MATCH cardinality-guard parity on the ordered path + WASM aggregate ORDER BY

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,14 @@ release.
   before LIMIT truncation, so a traversal exceeding the configured cardinality
   limit returned an oversized result set where the SQL path rejects it. The
   guard now runs identically on both paths, returning `VELES-027` (`GuardRail`).
+- **WASM aggregate queries now honor `ORDER BY`.** `SELECT cat, COUNT(*) … GROUP
+  BY cat ORDER BY COUNT(*)` (or `ORDER BY` a group key / aggregate alias)
+  returned groups in undefined order on the WASM executor — the aggregate
+  finalize path applied LIMIT without sorting. Grouped rows are now sorted by the
+  ORDER BY key(s) (group-key column or aggregate output column, by alias or
+  default name) before LIMIT, mirroring core's aggregate ORDER BY semantics.
+  Similarity / arithmetic ORDER BY forms (not applicable to grouped rows) are
+  skipped, matching core.
 - **TypeScript SDK `velesql()` builder now emits parseable VelesQL.** Three
   builder bugs produced strings the core parser rejected or that dropped
   intent: `nearVector({ topK })` emitted a non-existent `vector NEAR $q TOP n`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,13 @@ release.
   *(Behavior change: several previously-accepted FUSION queries now error.)*
 
 ### Fixed
+- **The ordered `MATCH` path (`match_query_ordered`) now enforces the final
+  cardinality guard the SQL `/query` path already had.** `finalize_match_ordering`
+  (used by non-SQL callers — REST `/match`, the SDKs) omitted the
+  `check_cardinality()` call that `finalize_match_results` runs after sorting and
+  before LIMIT truncation, so a traversal exceeding the configured cardinality
+  limit returned an oversized result set where the SQL path rejects it. The
+  guard now runs identically on both paths, returning `VELES-027` (`GuardRail`).
 - **TypeScript SDK `velesql()` builder now emits parseable VelesQL.** Three
   builder bugs produced strings the core parser rejected or that dropped
   intent: `nearVector({ topK })` emitted a non-existent `vector NEAR $q TOP n`

--- a/crates/velesdb-core/src/collection/guardrails_integration_tests.rs
+++ b/crates/velesdb-core/src/collection/guardrails_integration_tests.rs
@@ -347,6 +347,42 @@ fn test_match_cardinality_enforced_below_100_iterations() {
 }
 
 #[test]
+fn test_match_query_ordered_cardinality_enforced() {
+    // The ordered MATCH path (`match_query_ordered`, used by non-SQL callers
+    // such as REST `/match` and the SDKs) must enforce the SAME final
+    // cardinality guard as the SQL `execute_query` path. Without it, an
+    // oversized ordered result set would be returned where the SQL path rejects.
+    let dir = TempDir::new().unwrap();
+    let mut col = create_test_collection(&dir);
+
+    // 3 edges: 0→1, 0→2, 0→3 — BFS from 0 yields 3 results.
+    for target in 1u64..=3 {
+        let edge = GraphEdge::new(target * 100, 0, target, "LINKS").expect("edge");
+        col.add_edge(edge).expect("add_edge");
+    }
+
+    let limits = QueryLimits {
+        max_cardinality: 2, // 3 results > 2 → must be rejected
+        ..QueryLimits::default()
+    };
+    col.guard_rails = Arc::new(GuardRails::with_limits(limits));
+
+    let match_clause = Parser::parse("MATCH (a)-[r]->(b) RETURN b ORDER BY depth LIMIT 10;")
+        .expect("parse failed")
+        .match_clause
+        .expect("query should be a MATCH statement");
+    let params = HashMap::new();
+
+    let result = col.match_query_ordered(&match_clause, &params);
+    assert!(
+        result.is_err(),
+        "Cardinality guard-rail should fire for the ordered MATCH path"
+    );
+    let err = result.unwrap_err();
+    assert_eq!(err.code(), "VELES-027");
+}
+
+#[test]
 fn test_per_client_rate_limiting_is_independent() {
     // Each client_id has its own token bucket; exhausting one must not affect others.
     let dir = TempDir::new().unwrap();

--- a/crates/velesdb-core/src/collection/search/query/match_dispatch.rs
+++ b/crates/velesdb-core/src/collection/search/query/match_dispatch.rs
@@ -307,6 +307,12 @@ impl Collection {
         self.apply_match_order_by(&mut sorted, match_clause, params)
             .inspect_err(|_| self.guard_rails.circuit_breaker.record_failure())?;
 
+        // Final cardinality check for MATCH path (EPIC-048 US-003), matching
+        // `finalize_match_results` so the ordered surface rejects oversized
+        // result sets identically to the SQL path.
+        ctx.check_cardinality(sorted.len())
+            .map_err(crate::error::Error::from)
+            .inspect_err(|_| self.guard_rails.circuit_breaker.record_failure())?;
         if let Some(limit) = match_return_limit(match_clause) {
             sorted.truncate(limit);
         }

--- a/crates/velesdb-wasm/src/velesql_aggregate.rs
+++ b/crates/velesdb-wasm/src/velesql_aggregate.rs
@@ -25,7 +25,7 @@ use std::collections::BTreeMap;
 
 use velesdb_core::velesql::{
     AggregateArg, AggregateFunction, AggregateType, CompareOp, DistinctMode, HavingClause,
-    HavingCondition, LogicalOp, SelectColumns, SelectStatement, Value,
+    HavingCondition, LogicalOp, OrderByExpr, SelectColumns, SelectOrderBy, SelectStatement, Value,
 };
 
 use crate::velesql_result::QueryResultRow;
@@ -133,7 +133,7 @@ fn project_for_distinct(
 // --- Aggregation ----------------------------------------------------------
 
 /// Full aggregation pipeline: group rows, compute aggregates, apply HAVING,
-/// serialize each group to a synthetic row.
+/// apply ORDER BY, serialize each group to a synthetic row.
 fn aggregate(
     stmt: &SelectStatement,
     rows: &[ScannedRow<'_>],
@@ -147,7 +147,7 @@ fn aggregate(
     let groups = materialize_groups(&group_cols, rows, &stmt.columns);
     let aggregates = extract_aggregates(&stmt.columns);
     let plain_cols = extract_plain_columns(&stmt.columns);
-    let mut out: Vec<QueryResultRow> = Vec::with_capacity(groups.len());
+    let mut json_rows: Vec<serde_json::Value> = Vec::with_capacity(groups.len());
     for (key, group_rows) in groups {
         if let Some(row) = finalize_group(
             stmt,
@@ -158,10 +158,67 @@ fn aggregate(
             &group_rows,
             params,
         )? {
-            out.push(row);
+            json_rows.push(row);
         }
     }
-    Ok(out)
+    if let Some(order_by) = stmt.order_by.as_deref() {
+        sort_aggregate_rows(&mut json_rows, order_by);
+    }
+    json_rows
+        .into_iter()
+        .map(QueryResultRow::synthetic)
+        .collect()
+}
+
+/// Sorts grouped aggregate rows by the SELECT's ORDER BY, mirroring core's
+/// `Collection::sort_aggregation_results`: each ORDER BY key resolves to a
+/// JSON field on the group row (a group-key column or an aggregate output
+/// column), compared with the same total JSON ordering. Multi-key sort is
+/// stable so equal leading keys preserve earlier-key order. Similarity /
+/// arithmetic ORDER BY forms are not applicable to grouped rows and are
+/// skipped, matching core.
+fn sort_aggregate_rows(rows: &mut [serde_json::Value], order_by: &[SelectOrderBy]) {
+    let keys: Vec<(String, bool)> = order_by
+        .iter()
+        .filter_map(|clause| aggregate_order_key(&clause.expr).map(|k| (k, clause.descending)))
+        .collect();
+    if keys.is_empty() {
+        return;
+    }
+    rows.sort_by(|a, b| compare_aggregate_rows(a, b, &keys));
+}
+
+/// Resolves an ORDER BY expression to the JSON field name used by the
+/// aggregate output row, or `None` for forms that do not apply to grouped
+/// rows (similarity / arithmetic), matching core's `sort_aggregation_results`.
+fn aggregate_order_key(expr: &OrderByExpr) -> Option<String> {
+    match expr {
+        OrderByExpr::Field(name) => Some(name.clone()),
+        OrderByExpr::Aggregate(agg) => Some(
+            agg.alias
+                .clone()
+                .unwrap_or_else(|| aggregate_default_name(agg)),
+        ),
+        _ => None,
+    }
+}
+
+/// Total order over two aggregate rows for the resolved `(field, descending)`
+/// keys, using the same NULL-aware JSON comparator as the plain SELECT and
+/// MATCH ORDER BY paths (`compare_json_with_nulls`) for consistent ordering.
+fn compare_aggregate_rows(
+    a: &serde_json::Value,
+    b: &serde_json::Value,
+    keys: &[(String, bool)],
+) -> std::cmp::Ordering {
+    for (field, descending) in keys {
+        let ord = crate::velesql_orderby::compare_json_with_nulls(a.get(field), b.get(field));
+        let ord = if *descending { ord.reverse() } else { ord };
+        if ord != std::cmp::Ordering::Equal {
+            return ord;
+        }
+    }
+    std::cmp::Ordering::Equal
 }
 
 /// Returns the final row set after partitioning, adding the implicit global
@@ -187,7 +244,7 @@ fn finalize_group(
     aggregates: &[AggregateFunction],
     group_rows: &[ScannedRow<'_>],
     params: &Params,
-) -> Result<Option<QueryResultRow>, String> {
+) -> Result<Option<serde_json::Value>, String> {
     let mut payload = serde_json::Map::new();
     write_group_keys(&mut payload, group_cols, key);
     write_plain_columns(&mut payload, plain_cols, group_rows);
@@ -195,9 +252,7 @@ fn finalize_group(
     if !passes_having(aggregates, stmt.having.as_ref(), group_rows, params)? {
         return Ok(None);
     }
-    Ok(Some(QueryResultRow::synthetic(serde_json::Value::Object(
-        payload,
-    ))?))
+    Ok(Some(serde_json::Value::Object(payload)))
 }
 
 /// Partitions the row set into groups keyed by the GROUP BY columns.

--- a/crates/velesdb-wasm/src/velesql_aggregate_unit_tests.rs
+++ b/crates/velesdb-wasm/src/velesql_aggregate_unit_tests.rs
@@ -5,7 +5,8 @@
 
 use velesdb_core::velesql::{
     AggregateArg, AggregateFunction, AggregateType, Column, CompareOp, DistinctMode, GroupByClause,
-    HavingClause, HavingCondition, SelectColumns, SelectStatement, Value,
+    HavingClause, HavingCondition, OrderByExpr, SelectColumns, SelectOrderBy, SelectStatement,
+    Value,
 };
 
 use crate::velesql_aggregate::{apply, compute_aggregate, needs_aggregation_pipeline, ScannedRow};
@@ -97,6 +98,75 @@ fn test_group_by_count() {
             .any(|j| j.contains("\"cat\":\"b\"") && j.contains("\"n\":1")),
         "expected group cat=b with n=1, got {json:?}"
     );
+}
+
+/// Helper: index of the first row whose JSON contains `needle`.
+fn pos(rows: &[crate::velesql_result::QueryResultRow], needle: &str) -> usize {
+    rows.iter()
+        .position(|r| r.data_json_ref().contains(needle))
+        .unwrap_or_else(|| panic!("expected a row containing {needle}"))
+}
+
+#[test]
+fn test_group_by_order_by_count_desc() {
+    // GROUP BY cat ORDER BY COUNT(*) DESC must return groups in
+    // count-descending order. cat "a" has 3 rows, "b" has 1, "c" has 2.
+    let raw = vec![
+        row(1, 0.0, &serde_json::json!({"cat": "a"})),
+        row(2, 0.0, &serde_json::json!({"cat": "b"})),
+        row(3, 0.0, &serde_json::json!({"cat": "a"})),
+        row(4, 0.0, &serde_json::json!({"cat": "c"})),
+        row(5, 0.0, &serde_json::json!({"cat": "a"})),
+        row(6, 0.0, &serde_json::json!({"cat": "c"})),
+    ];
+    let rows = scanned(&raw);
+    let mut s = base_select();
+    let count_star = AggregateFunction {
+        function_type: AggregateType::Count,
+        argument: AggregateArg::Wildcard,
+        alias: None,
+    };
+    s.columns = SelectColumns::Aggregations(vec![count_star.clone()]);
+    s.group_by = Some(GroupByClause {
+        columns: vec!["cat".to_string()],
+    });
+    s.order_by = Some(vec![SelectOrderBy {
+        expr: OrderByExpr::Aggregate(count_star),
+        descending: true,
+    }]);
+    let out = apply(&s, &rows, &Params::new()).expect("test: agg order by");
+    assert_eq!(out.len(), 3);
+    // Count-descending: a (3) before c (2) before b (1).
+    assert!(pos(&out, "\"cat\":\"a\"") < pos(&out, "\"cat\":\"c\""));
+    assert!(pos(&out, "\"cat\":\"c\"") < pos(&out, "\"cat\":\"b\""));
+}
+
+#[test]
+fn test_group_by_order_by_group_key_asc() {
+    // ORDER BY a group key (cat ASC) must sort groups alphabetically.
+    let raw = vec![
+        row(1, 0.0, &serde_json::json!({"cat": "c"})),
+        row(2, 0.0, &serde_json::json!({"cat": "a"})),
+        row(3, 0.0, &serde_json::json!({"cat": "b"})),
+    ];
+    let rows = scanned(&raw);
+    let mut s = base_select();
+    s.columns = SelectColumns::Aggregations(vec![AggregateFunction {
+        function_type: AggregateType::Count,
+        argument: AggregateArg::Wildcard,
+        alias: Some("n".to_string()),
+    }]);
+    s.group_by = Some(GroupByClause {
+        columns: vec!["cat".to_string()],
+    });
+    s.order_by = Some(vec![SelectOrderBy {
+        expr: OrderByExpr::Field("cat".to_string()),
+        descending: false,
+    }]);
+    let out = apply(&s, &rows, &Params::new()).expect("test: agg order by key");
+    assert_eq!(out.len(), 3);
+    assert!(pos(&out, "\"cat\":\"a\"") < pos(&out, "\"cat\":\"b\""));
+    assert!(pos(&out, "\"cat\":\"b\"") < pos(&out, "\"cat\":\"c\""));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Two correctness follow-ups surfaced during the VelesQL campaign.

### (c) Cardinality guard parity on the ordered MATCH path
`finalize_match_ordering` (the `MatchResult` path used by `match_query_ordered`, which the REST `/match` and SDK surfaces route through) omitted the `ctx.check_cardinality()` call that the SQL path's `finalize_match_results` performs. So a non-SQL caller could receive an oversized result the SQL path would reject. It now runs the **same** guard (after `apply_match_order_by`, before the `LIMIT` truncate) → `VELES-027` (`GuardRail`), matching the SQL path exactly. Discriminating test (`test_match_query_ordered_cardinality_enforced`): proven to return `Ok` without the guard, errors `VELES-027` with it.

### (d) WASM aggregate `ORDER BY`
The WASM aggregate path (`finalize_aggregated` → `velesql_aggregate::apply`) had **no `ORDER BY` support**, so `SELECT cat, COUNT(*) … GROUP BY cat ORDER BY COUNT(*)` returned groups in insertion order. It now sorts the group rows (`sort_aggregate_rows`) by the `ORDER BY` key (group field or aggregate alias / `count(*)` default name) **before** the `LIMIT`, mirroring core's `sort_aggregation_results`. Two discriminating tests (count-desc + group-key-asc) fail on develop, pass here. Verified on the real `wasm32-unknown-unknown` build.

## Test plan
- Gates: `cargo fmt`; `clippy --workspace --all-targets -D warnings -D clippy::pedantic` (exit 0) + `clippy -p velesdb-wasm --no-default-features` (exit 0); `lizard -C 8` (0 over budget); core + wasm targeted tests pass; `cargo check -p velesdb-wasm --no-default-features --target wasm32-unknown-unknown` clean.

## Note (deferred design decision — not in this PR)
A third follow-up — reclassifying the **"too many groups"** / NOT-similarity scan-ceiling rejects from `VELES-009` to a guard-rail code — was **dropped**: `Error::GuardRail` maps to HTTP **503** (`SERVICE_UNAVAILABLE`), which is wrong for a *deterministic* query-resource limit (retrying won't help). The current `VELES-009`/**400** has a slightly-imprecise code but the correct client-error status. A proper fix needs a dedicated *resource-limit* error variant mapping to 4xx (e.g. 413) — a deliberate API-contract decision.