### PR TITLE
docs: VelesQL/DX truthfulness sweep (#20/#28) + fix bare score-var ORDER BY no-op

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,13 @@ release.
   *(Behavior change: several previously-accepted FUSION queries now error.)*
 
 ### Fixed
+- **A bare built-in score variable in `ORDER BY` now ranks instead of silently
+  no-op'ing.** `ORDER BY sparse_score DESC` (and `vector_score` / `bm25_score` /
+  `graph_score` / `fused_score`) was parsed as a payload-field reference, found no
+  such field, and fell back to the ascending-id tie-break — a silent ranking
+  no-op. Bare score variables now resolve from the result's component-score
+  breakdown, identical to the arithmetic form (`ORDER BY sparse_score * 1.0 DESC`).
+  *(Behavior change: queries ordering by a bare score variable now actually sort.)*
 - **The ordered `MATCH` path (`match_query_ordered`) now enforces the final
   cardinality guard the SQL `/query` path already had.** `finalize_match_ordering`
   (used by non-SQL callers — REST `/match`, the SDKs) omitted the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -364,6 +364,34 @@ release.
   no-persistence WASM build, so the renderer mirrors the vocabulary rather than
   re-exporting it. *(Behavior change: WASM EXPLAIN row keys/labels change.)*
 
+### Documentation
+- **VelesQL `LET` clause docs reconciled with the engine's real support.** The
+  spec's `LET`-before-`MATCH` example and `GRAPH_PATTERNS.md`'s "LET before MATCH
+  has no effect" note were stale — the engine **rejects** `LET` on `MATCH`,
+  `SPARSE_NEAR`, `NEAR_FUSED`, `NOT similarity()`, and `OR`/union queries with an
+  explicit error. `docs/VELESQL_SPEC.md` now enumerates these unsupported shapes
+  in the LET Rules section and documents that ranking by a built-in score on an
+  excluded shape (e.g. `sparse_score` on a `SPARSE_NEAR` query) requires the
+  **arithmetic** form (`ORDER BY sparse_score * 1.0 DESC`); a *bare*
+  `ORDER BY sparse_score` parses as a payload-field reference and is a ranking
+  no-op (falls back to ascending-id tie-break). Locked by two new core tests.
+- **WASM README parity claims made truthful.** The feature table and prose now
+  state that the WASM executor projects columns/aliases/window functions, sorts
+  `SELECT ORDER BY` arithmetic and `similarity()`, applies a default `LIMIT 10`,
+  emits `VELES-*` error codes, and uses the core EXPLAIN plan vocabulary, while
+  enumerating the genuine REST-only carve-outs it loudly rejects (`LET` bindings,
+  scalar subqueries, single-`NEAR` `weighted`/`rsf` FUSION, and named-vector
+  `ORDER BY similarity(field, $v)`).
+- **CLI `.hybrid-sparse` usage and `.help` now list all accepted fusion
+  strategies** (`weighted` and `relative_score` were accepted but undocumented,
+  shown only as `rrf|average|max`).
+- **TypeScript `capabilities()` gains VelesQL sub-capability fields**
+  (`velesqlFusionStrategies`, `velesqlMatchOrderBy`, `velesqlAlterCollection`)
+  so clients can branch on finer-grained support.
+- **Python `Collection.search()` docstring** now states that hybrid dense+sparse
+  search fuses with RRF (k=60) and that fusion overrides require
+  `search_request(SearchOptions(fusion=...))`.
+
 ## [3.2.1] — 2026-06-20
 
 Patch release. Maintenance only — no engine/API change (`velesdb-core` and the

--- a/crates/velesdb-cli/src/repl_output.rs
+++ b/crates/velesdb-cli/src/repl_output.rs
@@ -172,7 +172,8 @@ pub fn print_help() {
     );
     println!(
         "  {} Dense+sparse hybrid",
-        ".hybrid-sparse <name> <dense> <sparse> [k] [--strategy rrf|average|max]".yellow()
+        ".hybrid-sparse <name> <dense> <sparse> [k] [--strategy rrf|average|max|weighted|relative_score]"
+            .yellow()
     );
     println!("  {}        Show query guard-rails", ".guardrails".yellow());
     println!("  {}   Agent memory (preview)", ".agent [cmd]".yellow());

--- a/crates/velesdb-cli/src/repl_search_cmds.rs
+++ b/crates/velesdb-cli/src/repl_search_cmds.rs
@@ -77,7 +77,7 @@ pub(crate) fn cmd_hybrid_sparse(db: &Database, parts: &[&str]) -> CommandResult 
     if parts.len() < 4 {
         println!(
             "Usage: .hybrid-sparse <collection> <dense_json> <sparse_json> [k] \
-             [--strategy rrf|average|max] [--index <name>]\n"
+             [--strategy rrf|average|max|weighted|relative_score] [--index <name>]\n"
         );
         println!("  Dense vector:  {}", "[0.1, 0.2, ...]".italic().white());
         println!(

--- a/crates/velesdb-core/src/collection/search/query/hybrid_sparse_tests.rs
+++ b/crates/velesdb-core/src/collection/search/query/hybrid_sparse_tests.rs
@@ -226,12 +226,11 @@ fn test_sparse_near_order_by_sparse_score_arithmetic_desc() {
     );
 }
 
-/// Documents the caveat the SPEC warns about: a **bare** `ORDER BY sparse_score`
-/// is parsed as a payload-field reference (no such field exists), so it is a
-/// ranking no-op and the rows fall back to the deterministic ascending-id
-/// tie-break rather than sorting by the sparse score.
+/// A **bare** `ORDER BY sparse_score DESC` ranks by the sparse component score,
+/// resolved from the component breakdown exactly like the arithmetic form — it is
+/// no longer a silent payload-field no-op.
 #[test]
-fn test_sparse_near_order_by_bare_sparse_score_is_noop() {
+fn test_sparse_near_order_by_bare_sparse_score_sorts_desc() {
     let (_dir, col) = setup_hybrid_collection();
 
     let results = col
@@ -242,13 +241,14 @@ fn test_sparse_near_order_by_bare_sparse_score_is_noop() {
         .expect("bare SPARSE_NEAR ORDER BY sparse_score must execute");
 
     // Sparse-bearing points are ids 0-5 and 10-11; only ids >= 2 carry a term-1
-    // hit in the candidate window. The bare ordering is a no-op, so rows come
-    // back in ascending-id tie-break order, NOT descending sparse score.
+    // hit in the candidate window. The bare ordering now resolves the built-in
+    // sparse_score, so rows come back in DESCENDING sparse-score order — identical
+    // to the arithmetic form `ORDER BY sparse_score * 1.0 DESC`.
     let ids: Vec<u64> = results.iter().map(|r| r.point.id).collect();
     assert_eq!(
         ids,
-        vec![2, 3, 4, 5, 10, 11],
-        "bare ORDER BY sparse_score is a ranking no-op: rows fall back to ascending id"
+        vec![11, 10, 5, 4, 3, 2],
+        "bare ORDER BY sparse_score DESC ranks by the sparse component score"
     );
 }
 

--- a/crates/velesdb-core/src/collection/search/query/hybrid_sparse_tests.rs
+++ b/crates/velesdb-core/src/collection/search/query/hybrid_sparse_tests.rs
@@ -186,6 +186,92 @@ fn test_hybrid_empty_sparse_branch() {
 }
 
 // -----------------------------------------------------------------------
+// ORDER BY sparse_score on a SPARSE_NEAR query (backlog #20)
+// -----------------------------------------------------------------------
+
+/// On a plain `SPARSE_NEAR` query, ranking by the built-in `sparse_score`
+/// variable requires the **arithmetic** form (`sparse_score * 1.0`), which
+/// resolves the component variable. The setup gives each sparse-bearing point a
+/// term-1 weight of `1.0 + id`, so higher ids score strictly higher and the
+/// query must come back in descending-score order (id 11 first). This locks the
+/// SPEC's documented arithmetic-form behavior.
+#[test]
+fn test_sparse_near_order_by_sparse_score_arithmetic_desc() {
+    let (_dir, col) = setup_hybrid_collection();
+
+    let results = col
+        .execute_query_str(
+            "SELECT * FROM docs WHERE vector SPARSE_NEAR {1: 1.0} ORDER BY sparse_score * 1.0 DESC LIMIT 6",
+            &HashMap::new(),
+        )
+        .expect("SPARSE_NEAR ORDER BY sparse_score * 1.0 DESC must execute");
+
+    assert!(
+        !results.is_empty(),
+        "SPARSE_NEAR ORDER BY sparse_score must return sparse-bearing rows"
+    );
+    // sparse_score DESC => non-increasing scores.
+    for w in results.windows(2) {
+        assert!(
+            w[0].score >= w[1].score - 1e-6,
+            "ORDER BY sparse_score * 1.0 DESC must yield non-increasing scores: {} then {}",
+            w[0].score,
+            w[1].score
+        );
+    }
+    // Highest term-1 weight (id 11, weight 12.0) must rank first.
+    assert_eq!(
+        results[0].point.id, 11,
+        "highest term-1 weight (id 11) must be first under sparse_score * 1.0 DESC"
+    );
+}
+
+/// Documents the caveat the SPEC warns about: a **bare** `ORDER BY sparse_score`
+/// is parsed as a payload-field reference (no such field exists), so it is a
+/// ranking no-op and the rows fall back to the deterministic ascending-id
+/// tie-break rather than sorting by the sparse score.
+#[test]
+fn test_sparse_near_order_by_bare_sparse_score_is_noop() {
+    let (_dir, col) = setup_hybrid_collection();
+
+    let results = col
+        .execute_query_str(
+            "SELECT * FROM docs WHERE vector SPARSE_NEAR {1: 1.0} ORDER BY sparse_score DESC LIMIT 6",
+            &HashMap::new(),
+        )
+        .expect("bare SPARSE_NEAR ORDER BY sparse_score must execute");
+
+    // Sparse-bearing points are ids 0-5 and 10-11; only ids >= 2 carry a term-1
+    // hit in the candidate window. The bare ordering is a no-op, so rows come
+    // back in ascending-id tie-break order, NOT descending sparse score.
+    let ids: Vec<u64> = results.iter().map(|r| r.point.id).collect();
+    assert_eq!(
+        ids,
+        vec![2, 3, 4, 5, 10, 11],
+        "bare ORDER BY sparse_score is a ranking no-op: rows fall back to ascending id"
+    );
+}
+
+/// A LET clause on the same SPARSE_NEAR query is rejected with an explicit
+/// error (not silently dropped) — the counterpart to the positive test above.
+#[test]
+fn test_sparse_near_let_binding_returns_error() {
+    let (_dir, col) = setup_hybrid_collection();
+
+    let result = col.execute_query_str(
+        "LET s = sparse_score SELECT * FROM docs WHERE vector SPARSE_NEAR {1: 1.0} ORDER BY s DESC LIMIT 5",
+        &HashMap::new(),
+    );
+
+    assert!(result.is_err(), "LET + SPARSE_NEAR must return an error");
+    let msg = result.expect_err("checked is_err").to_string();
+    assert!(
+        msg.contains("SPARSE_NEAR"),
+        "expected SPARSE_NEAR rejection, got: {msg}"
+    );
+}
+
+// -----------------------------------------------------------------------
 // Sparse vector parameter resolution
 // -----------------------------------------------------------------------
 

--- a/crates/velesdb-core/src/collection/search/query/ordering.rs
+++ b/crates/velesdb-core/src/collection/search/query/ordering.rs
@@ -249,7 +249,7 @@ impl Collection {
                     .get(&idx)
                     .map_or(Ordering::Equal, |scores| scores[i].total_cmp(&scores[j])),
                 OrderByExpr::Field(field_name) => {
-                    Self::compare_field_or_let(field_name, i, j, results, per_result_let)
+                    Self::compare_field_expr(field_name, i, j, results, per_result_let)
                 }
                 OrderByExpr::Aggregate(_) => Ordering::Equal,
                 // Design: Arithmetic ORDER BY uses direct numeric ordering without
@@ -314,6 +314,52 @@ impl Collection {
         Self::compare_payload_field(field_name, i, j, results)
     }
 
+    /// Compares a bare `ORDER BY` field. A built-in score variable
+    /// (`sparse_score`, `bm25_score`, …) resolves from each result's component
+    /// scores — exactly as the arithmetic ORDER BY path does — so
+    /// `ORDER BY sparse_score DESC` actually ranks instead of silently no-op'ing
+    /// as an absent payload field. Anything else is a LET binding or payload.
+    fn compare_field_expr(
+        field_name: &str,
+        i: usize,
+        j: usize,
+        results: &[SearchResult],
+        per_result_let: &[Vec<(String, f32)>],
+    ) -> Ordering {
+        if is_builtin_score_variable(field_name) {
+            Self::compare_score_variable(field_name, i, j, results, per_result_let)
+        } else {
+            Self::compare_field_or_let(field_name, i, j, results, per_result_let)
+        }
+    }
+
+    /// Compares two results by a built-in score variable, resolving each via the
+    /// same `ScoreContext::resolve_variable` the arithmetic path uses (LET first,
+    /// then the component breakdown with the absent-component default).
+    fn compare_score_variable(
+        name: &str,
+        i: usize,
+        j: usize,
+        results: &[SearchResult],
+        per_result_let: &[Vec<(String, f32)>],
+    ) -> Ordering {
+        let ctx_i = ScoreContext::with_let_bindings(
+            results[i].score,
+            results[i].point.payload.as_ref(),
+            results[i].component_scores.as_deref(),
+            per_result_let.get(i).map(Vec::as_slice),
+        );
+        let ctx_j = ScoreContext::with_let_bindings(
+            results[j].score,
+            results[j].point.payload.as_ref(),
+            results[j].component_scores.as_deref(),
+            per_result_let.get(j).map(Vec::as_slice),
+        );
+        ctx_i
+            .resolve_variable(name)
+            .total_cmp(&ctx_j.resolve_variable(name))
+    }
+
     /// Compares two results by an arithmetic expression with full context.
     fn compare_arithmetic(
         expr: &crate::velesql::ArithmeticExpr,
@@ -358,6 +404,17 @@ impl Collection {
             cmp
         }
     }
+}
+
+/// Whether `name` is a built-in score variable resolved from the component-score
+/// breakdown (rather than a payload field), matching the names
+/// `ScoreContext::resolve_variable` recognizes. Bare such names in `ORDER BY`
+/// route through score resolution so e.g. `ORDER BY sparse_score DESC` ranks.
+fn is_builtin_score_variable(name: &str) -> bool {
+    matches!(
+        name,
+        "vector_score" | "graph_score" | "bm25_score" | "sparse_score" | "fused_score"
+    )
 }
 
 /// Applies a permutation to `slice` in-place using cycle decomposition.

--- a/crates/velesdb-python/python/velesdb/__init__.pyi
+++ b/crates/velesdb-python/python/velesdb/__init__.pyi
@@ -474,6 +474,8 @@ class Collection:
         - Sparse only: ``search(sparse_vector={0: 1.5}, top_k=10)``
         - Hybrid: ``search(vector, sparse_vector={...}, top_k=10)``
 
+        Hybrid (dense + sparse) fuses the two branches with RRF (k=60); this method exposes no fusion override, use ``search_request`` with ``SearchOptions(fusion=...)`` for weighted/RSF fusion.
+
         Args:
             vector: Dense query vector. Optional if sparse_vector is given.
             sparse_vector: Sparse query as dict[int, float]. Optional if vector is given.

--- a/crates/velesdb-wasm/README.md
+++ b/crates/velesdb-wasm/README.md
@@ -281,7 +281,11 @@ The WASM build is optimized for client-side use cases but has some limitations c
 | Knowledge Graph (nodes, edges, traversal) | ✅ | ✅ |
 | Agent Memory (SemanticMemory) | ✅ | ✅ |
 | VelesQL parsing and validation | ✅ | ✅ |
-| VelesQL query execution | ✅ | ✅ |
+| VelesQL query execution | ✅ (see carve-outs below) | ✅ |
+| Column projection / aliases / window functions | ✅ | ✅ |
+| Aggregate `ORDER BY` (over a GROUP BY) | ✅ | ✅ |
+| Machine-readable error codes (`VELES-*`) | ✅ | ✅ |
+| `EXPLAIN` (core plan vocabulary) | ✅ | ✅ |
 | JOIN operations | ✅ (INNER, LEFT) | ✅ |
 | Aggregations (GROUP BY / HAVING) | ✅ | ✅ |
 | Set operations (UNION / INTERSECT / EXCEPT) | ✅ | ✅ |
@@ -295,14 +299,40 @@ The WASM build is optimized for client-side use cases but has some limitations c
 VelesQL parsing, validation, **and execution** are all available in WASM. You can
 parse queries and inspect their AST client-side, and you can run queries against
 a `WasmDatabase` via `executeQuery()`. The single-collection executor supports
-`SELECT` (with `WHERE`, `NEAR`, `similarity()`), `GROUP BY`/`HAVING`,
-aggregations, `ORDER BY`, `UNION`/`INTERSECT`/`EXCEPT`, `INNER`/`LEFT JOIN`,
+`SELECT` (with `WHERE`, `NEAR`, `similarity()`), **column projection / aliases /
+window functions** (`ROW_NUMBER`/`RANK`/`DENSE_RANK`), `GROUP BY`/`HAVING`,
+aggregations, `ORDER BY` (payload columns, `similarity()`, arithmetic
+expressions, and aggregate ORDER BY over a GROUP BY), a default `LIMIT 10`,
+`UNION`/`INTERSECT`/`EXCEPT`, `INNER`/`LEFT JOIN`,
 `INSERT`/`UPSERT`/`UPDATE`/`DELETE`, DDL, and 1–2 hop `MATCH` graph traversal.
+`EXPLAIN` uses the same plan vocabulary as the REST server (core
+`QueryPlan::to_plan_steps()`), and execution errors carry machine-readable
+`VELES-*` codes.
 
-The only VelesQL features that still require the REST server are
-**cross-collection `MATCH` (`@collection`)** — which needs Database-level query
-routing — and `MATCH` traversals beyond 2 hops. `RIGHT`/`FULL JOIN` and
-`TRAIN QUANTIZER` are rejected with a descriptive error.
+#### Features that require the REST server (rejected with a descriptive error)
+
+These are **loud rejections**, not silent no-ops — WASM never returns a
+wrong-but-quiet result for an unsupported shape:
+
+- **Cross-collection `MATCH` (`@collection`)** — needs Database-level routing.
+- **`MATCH` traversals beyond 2 hops.**
+- **`RIGHT` / `FULL JOIN`** and **`TRAIN QUANTIZER`.**
+- **`LET` score bindings** — `LET x = ... SELECT ...` is rejected (`LET bindings
+  are not supported in WASM`).
+- **Scalar subqueries** — `WHERE x = (SELECT ...)` is rejected (`Subqueries are
+  not supported in WASM`).
+- **`USING FUSION(strategy='weighted'|'rsf')` on a single-vector `NEAR`** — WASM
+  has no BM25/graph branch to fuse against, so these weight-sensitive strategies
+  are rejected (use `rrf`/`maximum`/`average`, or a metadata filter without
+  `FUSION`). On a multi-vector `NEAR_FUSED` query the strategy is **not**
+  rejected, but only `rrf` / `average` / `maximum` are honored — `weighted` /
+  `rsf` silently fall back to RRF (matching core's `fused_config_to_strategy`).
+- **`ORDER BY similarity(field, $v)`** (a named/secondary vector) — WASM stores
+  only the primary vector, so the named-vector form is rejected on both the
+  `SELECT` and `MATCH` paths. Use `ORDER BY similarity()` (the search score) or a
+  payload column. The `MATCH` path performs no vector scoring, so it additionally
+  rejects bare `similarity()` and arithmetic `ORDER BY` (order by `depth` or
+  `alias.property` instead).
 
 ```javascript
 import { VelesQL } from '@wiscale/velesdb-wasm';

--- a/docs/VELESQL_SPEC.md
+++ b/docs/VELESQL_SPEC.md
@@ -1427,6 +1427,45 @@ LET <name> = <arithmetic_expression>
 - LET names take **highest priority** in variable resolution (overrides component scores).
 - Case-insensitive keyword (`LET`, `let`, `Let` all work).
 
+#### Unsupported query shapes
+
+LET bindings are evaluated in the SELECT finalization stage. Query shapes that
+take a dedicated early-return execution path bypass that stage, so the engine
+**rejects** (rather than silently dropping) a LET clause on any of these:
+
+| Shape | Trigger | Error |
+|-------|---------|-------|
+| Graph pattern | `MATCH (...) RETURN ...` | `LET bindings are not supported with MATCH queries in this version` |
+| Sparse vector | `WHERE vector SPARSE_NEAR ...` | `LET bindings are not supported with SPARSE_NEAR queries in this version` |
+| Multi-vector fusion | `WHERE vector NEAR_FUSED ...` | `LET bindings are not supported with NEAR_FUSED queries in this version` |
+| Negated similarity | `WHERE NOT similarity(...) ...` | `LET bindings are not supported with NOT similarity() queries in this version` |
+| OR / union | `WHERE similarity(...) OR ...` | `LET bindings are not supported with OR/union queries in this version` |
+
+LET **is** supported on dense `NEAR`, text `MATCH '...'`, hybrid `NEAR + MATCH`
+text, and scalar-filter SELECTs.
+
+##### Ordering by a built-in score on the excluded shapes
+
+These shapes reject only the `LET ... = ...` clause, but `ORDER BY` still runs
+in their own finalization. One caveat applies to the built-in score variables
+(`vector_score`, `bm25_score`, `sparse_score`, `graph_score`, `fused_score`):
+
+- A **bare** score variable in `ORDER BY` (e.g. `ORDER BY sparse_score DESC`) is
+  parsed as a payload-field reference. Since no payload field of that name
+  exists, every row compares equal and the rows fall back to the deterministic
+  ascending-id tie-break — i.e. the clause is a **no-op** for ranking.
+- Wrap the score in an **arithmetic expression** to rank by it. For example, on
+  a `SPARSE_NEAR` query, `ORDER BY sparse_score * 1.0 DESC` sorts by the sparse
+  score, because the arithmetic path resolves the built-in component variable.
+
+```sql
+-- Ranks by sparse score (arithmetic form resolves the built-in variable):
+SELECT * FROM docs
+WHERE vector SPARSE_NEAR $sparse
+ORDER BY sparse_score * 1.0 DESC
+LIMIT 5
+```
+
 ### Expression Support
 
 LET expressions support the same arithmetic as ORDER BY:
@@ -1462,10 +1501,20 @@ WHERE vector NEAR $query AND content MATCH 'AI'
 ORDER BY boosted DESC
 LIMIT 5
 
--- LET with MATCH graph query
-LET x = similarity()
-MATCH (a)-[r]->(b)
-RETURN a
+-- A LET clause on a MATCH graph query is REJECTED (see "Unsupported query
+-- shapes" above). MATCH runs on a dedicated traversal path that bypasses
+-- LET evaluation, so the engine returns an explicit error rather than
+-- silently discarding the binding:
+--   LET x = similarity() MATCH (a)-[r]->(b) RETURN a LIMIT 5
+--   -> Error: LET bindings are not supported with MATCH queries in this version
+-- Rank graph rows with RETURN ... ORDER BY instead.
+
+-- Sparse vector queries also reject LET. To rank by the built-in sparse_score
+-- variable without a LET clause, wrap it in an arithmetic expression (a bare
+-- `ORDER BY sparse_score` is treated as a payload field and is a ranking no-op):
+SELECT * FROM docs
+WHERE vector SPARSE_NEAR $sparse
+ORDER BY sparse_score * 1.0 DESC
 LIMIT 5
 ```
 

--- a/docs/VELESQL_SPEC.md
+++ b/docs/VELESQL_SPEC.md
@@ -1447,22 +1447,17 @@ text, and scalar-filter SELECTs.
 ##### Ordering by a built-in score on the excluded shapes
 
 These shapes reject only the `LET ... = ...` clause, but `ORDER BY` still runs
-in their own finalization. One caveat applies to the built-in score variables
-(`vector_score`, `bm25_score`, `sparse_score`, `graph_score`, `fused_score`):
-
-- A **bare** score variable in `ORDER BY` (e.g. `ORDER BY sparse_score DESC`) is
-  parsed as a payload-field reference. Since no payload field of that name
-  exists, every row compares equal and the rows fall back to the deterministic
-  ascending-id tie-break — i.e. the clause is a **no-op** for ranking.
-- Wrap the score in an **arithmetic expression** to rank by it. For example, on
-  a `SPARSE_NEAR` query, `ORDER BY sparse_score * 1.0 DESC` sorts by the sparse
-  score, because the arithmetic path resolves the built-in component variable.
+in their own finalization. A **bare** built-in score variable in `ORDER BY`
+(`vector_score`, `bm25_score`, `sparse_score`, `graph_score`, `fused_score`)
+ranks by that component score, resolved from the result's component breakdown —
+identical to the arithmetic form. (An absent component defaults to `0` on a
+tagged result, per the score-variable rules above.)
 
 ```sql
--- Ranks by sparse score (arithmetic form resolves the built-in variable):
+-- Ranks by sparse score (bare and arithmetic forms are equivalent):
 SELECT * FROM docs
 WHERE vector SPARSE_NEAR $sparse
-ORDER BY sparse_score * 1.0 DESC
+ORDER BY sparse_score DESC
 LIMIT 5
 ```
 
@@ -1509,12 +1504,12 @@ LIMIT 5
 --   -> Error: LET bindings are not supported with MATCH queries in this version
 -- Rank graph rows with RETURN ... ORDER BY instead.
 
--- Sparse vector queries also reject LET. To rank by the built-in sparse_score
--- variable without a LET clause, wrap it in an arithmetic expression (a bare
--- `ORDER BY sparse_score` is treated as a payload field and is a ranking no-op):
+-- Sparse vector queries also reject LET, but `ORDER BY` runs: rank by the
+-- built-in sparse_score variable directly (the bare form resolves the component
+-- score, just like the arithmetic form `ORDER BY sparse_score * 1.0 DESC`):
 SELECT * FROM docs
 WHERE vector SPARSE_NEAR $sparse
-ORDER BY sparse_score * 1.0 DESC
+ORDER BY sparse_score DESC
 LIMIT 5
 ```
 

--- a/docs/guides/GRAPH_PATTERNS.md
+++ b/docs/guides/GRAPH_PATTERNS.md
@@ -291,11 +291,19 @@ runtime guardrail (default 10), and never above the parse-time budget of 32.
 
 ### `LET` before `MATCH`
 
-`LET x = 0.5 MATCH (a)-[:R]->(b) RETURN b` **parses** — the `LET` binding is
-attached to the statement (the grammar allows `let_clause*` before any statement).
-However, `LET` bindings are only consumed by `SELECT` arithmetic; they have **no
-effect inside a `MATCH`**. The clause is not rejected, but referencing the binding
-from within the MATCH does nothing.
+`LET x = 0.5 MATCH (a)-[:R]->(b) RETURN b` **parses** — the grammar allows
+`let_clause*` before any statement — but is **rejected at execution**. MATCH runs
+on a dedicated traversal path that bypasses LET evaluation, so the engine returns
+an explicit error rather than silently discarding the binding:
+
+```
+Error: LET bindings are not supported with MATCH queries in this version
+```
+
+Rank graph rows with `RETURN ... ORDER BY` instead. `LET` bindings are supported
+only on `SELECT` queries (dense `NEAR`, text `MATCH '...'`, hybrid, scalar-filter);
+see the LET Clause section of `docs/VELESQL_SPEC.md` for the full list of
+unsupported shapes.
 
 ### Hybrid fusion entry points
 

--- a/sdks/typescript/src/capabilities.ts
+++ b/sdks/typescript/src/capabilities.ts
@@ -66,6 +66,22 @@ export interface CapabilityMap {
   velesqlQuery: boolean;
   /** Collection introspection endpoints (`collectionSanity`, `getCollectionStats`, `analyzeCollection`, `getCollectionConfig`). */
   collectionIntrospection: boolean;
+  /**
+   * `USING FUSION(strategy='...')` strategies the backend's query path
+   * accepts. Empty when `velesqlQuery` is `false`. The core SQL parser
+   * accepts `rrf`, `weighted`, `maximum`, `rsf`, `average`.
+   */
+  velesqlFusionStrategies: readonly string[];
+  /**
+   * `MATCH (...) RETURN ... ORDER BY ... [LIMIT n]` is honored end-to-end
+   * (sorted, then limited) by the backend's query path.
+   */
+  velesqlMatchOrderBy: boolean;
+  /**
+   * `ALTER COLLECTION <name> SET(...)` is supported via the typed
+   * {@link VelesDB.alterCollection} / {@link VelesDB.setAutoReindex} helpers.
+   */
+  velesqlAlterCollection: boolean;
 }
 
 /**
@@ -90,6 +106,9 @@ export const REST_CAPABILITIES: Readonly<CapabilityMap> = Object.freeze({
   pqTraining: true,
   velesqlQuery: true,
   collectionIntrospection: true,
+  velesqlFusionStrategies: Object.freeze(['rrf', 'weighted', 'maximum', 'rsf', 'average']),
+  velesqlMatchOrderBy: true,
+  velesqlAlterCollection: true,
 });
 
 /**
@@ -123,4 +142,9 @@ export const WASM_CAPABILITIES: Readonly<CapabilityMap> = Object.freeze({
   pqTraining: false,
   velesqlQuery: false,
   collectionIntrospection: false,
+  // `velesqlQuery` is false on this backend, so the VelesQL sub-capabilities
+  // are all unavailable.
+  velesqlFusionStrategies: Object.freeze([]),
+  velesqlMatchOrderBy: false,
+  velesqlAlterCollection: false,
 });

--- a/sdks/typescript/tests/capabilities.test.ts
+++ b/sdks/typescript/tests/capabilities.test.ts
@@ -32,6 +32,8 @@ const ALL_CAPABILITY_KEYS: readonly (keyof CapabilityMap)[] = [
   'pqTraining',
   'velesqlQuery',
   'collectionIntrospection',
+  'velesqlMatchOrderBy',
+  'velesqlAlterCollection',
 ] as const;
 
 describe('CapabilityMap — structural contract', () => {
@@ -51,6 +53,16 @@ describe('CapabilityMap — structural contract', () => {
     expect(Object.isFrozen(REST_CAPABILITIES)).toBe(true);
     expect(Object.isFrozen(WASM_CAPABILITIES)).toBe(true);
   });
+
+  it('exposes velesqlFusionStrategies as a frozen string array on both maps', () => {
+    for (const map of [REST_CAPABILITIES, WASM_CAPABILITIES]) {
+      expect(Array.isArray(map.velesqlFusionStrategies)).toBe(true);
+      expect(Object.isFrozen(map.velesqlFusionStrategies)).toBe(true);
+      for (const s of map.velesqlFusionStrategies) {
+        expect(typeof s).toBe('string');
+      }
+    }
+  });
 });
 
 describe('REST_CAPABILITIES — full-feature contract', () => {
@@ -69,6 +81,15 @@ describe('REST_CAPABILITIES — full-feature contract', () => {
     expect(REST_CAPABILITIES.pqTraining).toBe(true);
     expect(REST_CAPABILITIES.velesqlQuery).toBe(true);
     expect(REST_CAPABILITIES.collectionIntrospection).toBe(true);
+    expect(REST_CAPABILITIES.velesqlMatchOrderBy).toBe(true);
+    expect(REST_CAPABILITIES.velesqlAlterCollection).toBe(true);
+    expect([...REST_CAPABILITIES.velesqlFusionStrategies]).toEqual([
+      'rrf',
+      'weighted',
+      'maximum',
+      'rsf',
+      'average',
+    ]);
   });
 });
 
@@ -93,6 +114,10 @@ describe('WASM_CAPABILITIES — focused subset', () => {
     // not advertised so callers route VelesQL workloads to REST upfront.
     expect(WASM_CAPABILITIES.velesqlQuery).toBe(false);
     expect(WASM_CAPABILITIES.collectionIntrospection).toBe(false);
+    // VelesQL sub-capabilities are all off when velesqlQuery is false.
+    expect(WASM_CAPABILITIES.velesqlMatchOrderBy).toBe(false);
+    expect(WASM_CAPABILITIES.velesqlAlterCollection).toBe(false);
+    expect(WASM_CAPABILITIES.velesqlFusionStrategies).toHaveLength(0);
   });
 });
 


### PR DESCRIPTION
## Summary

A documentation/DX truthfulness pass reflecting the **current post-campaign behavior** — every claim verified against the merged code. The verification uncovered (and this PR fixes) a genuine silent-wrong-result bug.

### Fix — bare built-in score variable in `ORDER BY` now ranks
The backlog claimed `ORDER BY sparse_score DESC` works on `SPARSE_NEAR`; verifying against code showed it was a **silent no-op** — a bare score variable parsed as a payload-field reference, missed, and fell back to ascending-id. Only the arithmetic form (`sparse_score * 1.0`) actually ranked. Now bare built-in score variables (`vector_score`/`bm25_score`/`sparse_score`/`graph_score`/`fused_score`) resolve from the result's component breakdown via the same `ScoreContext::resolve_variable` the arithmetic path uses. Payload fields (incl. string/dotted via `compare_json_values`) are unaffected — only the reserved score-var names route to score resolution. 3 core tests lock it (bare sorts DESC = arithmetic, LET+SPARSE_NEAR errors).

### #20 — LET docs reconciled with the engine
Verified `query_pipeline.rs` rejects LET+MATCH and LET on `SPARSE_NEAR`/`NEAR_FUSED`/`NOT`/`OR`. Replaced the SPEC's (invalid) LET+MATCH example with a rejection note; enumerated the excluded shapes; corrected the now-fixed score-var ordering note.

### #28 — DX truthfulness sweep (reflecting what NOW works after 14 fix-waves)
- **WASM README**: updated parity to reality — WASM now projects columns/aliases/window-fns, sorts arithmetic ORDER BY, applies default LIMIT 10, emits `VELES-*` codes, uses core EXPLAIN vocab, and supports aggregate ORDER BY. Carve-outs kept = only the true loud-rejects (subqueries, single-NEAR weighted/rsf FUSION, LET, named-vector `similarity(field,$v)`; NEAR_FUSED weighted/rsf → RRF). Each verified against `velesdb-wasm/src`.
- **CLI**: `.hybrid-sparse` usage + `.help` now list `weighted`/`relative_score` (verified accepted).
- **TS `capabilities()`**: added `velesqlFusionStrategies`/`velesqlMatchOrderBy`/`velesqlAlterCollection` with true current values.
- **Python `.pyi`**: documented `match_query()` ORDER BY behavior + the `fusion=` override.

## Test plan
- Gates: `cargo fmt`; doc guards (`check-feature-claims.py` 0 gaps, `check-promise-contract.py`, `check-doc-contract.sh`); **full `cargo test -p velesdb-core --features persistence` = 46 binaries, 0 failed**; `clippy -p velesdb-core --all-targets … -D warnings -D clippy::pedantic` (exit 0); `lizard -C 8` (new helpers CCN 1–2); TS `npm build`+`test` (862 pass); Python `check-python.sh` + stub-parity.