### PR TITLE
test(conformance): pin full VelesqlErrorResponse shape in server fixture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -224,6 +224,17 @@ release.
   through the VelesQL DDL executor (persisted), the typed counterpart to running
   the raw statement via `execute_query`. `Collection.info()` now also reports the
   current `auto_reindex` flag. *(Additive.)*
+- **VelesQL conformance fixture pins the full `VelesqlErrorResponse` shape.**
+  Conformance cases C002 (`VELESQL_MISSING_COLLECTION`), C003
+  (`VELESQL_COLLECTION_NOT_FOUND`), and C007 (`VELESQL_AGGREGATION_ERROR`) now
+  assert all four fields of the semantic error body (`code`, `message`, `hint`,
+  `details`), not just the `code`. The server conformance test loop in
+  `crates/velesdb-server/tests/velesql_conformance_tests.rs` deserializes the
+  three new optional fields from the JSON fixture and asserts them when present.
+  Parse errors (`QueryErrorResponse`, cases C004/C013) retain their own
+  parser-specific shape and are not extended. Closes
+  `ECOSYSTEM_PARITY.md` action item 1. *(Additive: fixture and test only; no
+  server behaviour changed.)*
 
 ### Fixed
 - **Python `match_query` honors `RETURN ... ORDER BY` and the post-sort

--- a/conformance/velesql_contract_cases.json
+++ b/conformance/velesql_contract_cases.json
@@ -25,7 +25,10 @@
         "params": {}
       },
       "expected_status": 422,
-      "expected_error_code": "VELESQL_MISSING_COLLECTION"
+      "expected_error_code": "VELESQL_MISSING_COLLECTION",
+      "expected_error_message": "MATCH query via /query requires `collection` in request body",
+      "expected_error_hint": "Add `collection` to the /query JSON body or use /collections/{name}/match",
+      "expected_error_details": { "field": "collection", "endpoint": "/query", "query_type": "MATCH" }
     },
     {
       "id": "C003",
@@ -38,7 +41,10 @@
         "params": { "v": [1.0, 0.0, 0.0, 0.0] }
       },
       "expected_status": 404,
-      "expected_error_code": "VELESQL_COLLECTION_NOT_FOUND"
+      "expected_error_code": "VELESQL_COLLECTION_NOT_FOUND",
+      "expected_error_message": "Collection 'docs_missing_conformance' not found",
+      "expected_error_hint": "Create the collection first or correct the collection name",
+      "expected_error_details": { "collection": "docs_missing_conformance" }
     },
     {
       "id": "C004",
@@ -90,7 +96,10 @@
         "params": {}
       },
       "expected_status": 422,
-      "expected_error_code": "VELESQL_AGGREGATION_ERROR"
+      "expected_error_code": "VELESQL_AGGREGATION_ERROR",
+      "expected_error_message": "Only aggregation queries are accepted on /aggregate",
+      "expected_error_hint": "Use /query for row/search/graph queries; use /aggregate for GROUP BY/aggregate workloads.",
+      "expected_error_details": { "endpoint": "/aggregate" }
     },
     {
       "id": "C008",

--- a/crates/velesdb-server/tests/velesql_conformance_tests.rs
+++ b/crates/velesdb-server/tests/velesql_conformance_tests.rs
@@ -29,6 +29,12 @@ struct ConformanceCase {
     body: Value,
     expected_status: u16,
     expected_error_code: Option<String>,
+    /// Assert `error.message` in `VelesqlErrorResponse` semantic errors.
+    expected_error_message: Option<String>,
+    /// Assert `error.hint` in `VelesqlErrorResponse` semantic errors.
+    expected_error_hint: Option<String>,
+    /// Assert `error.details` in `VelesqlErrorResponse` semantic errors (exact match).
+    expected_error_details: Option<Value>,
     expect_contract_meta: Option<bool>,
 }
 
@@ -140,6 +146,32 @@ async fn test_velesql_contract_conformance_fixture_cases() {
                 json["error"]["code"],
                 error_code.as_str(),
                 "case {} returned unexpected error code",
+                case.id
+            );
+        }
+
+        if let Some(msg) = &case.expected_error_message {
+            assert_eq!(
+                json["error"]["message"],
+                msg.as_str(),
+                "case {} returned unexpected error message",
+                case.id
+            );
+        }
+
+        if let Some(hint) = &case.expected_error_hint {
+            assert_eq!(
+                json["error"]["hint"],
+                hint.as_str(),
+                "case {} returned unexpected error hint",
+                case.id
+            );
+        }
+
+        if let Some(details) = &case.expected_error_details {
+            assert_eq!(
+                json["error"]["details"], *details,
+                "case {} returned unexpected error details",
                 case.id
             );
         }

--- a/docs/reference/ECOSYSTEM_PARITY.md
+++ b/docs/reference/ECOSYSTEM_PARITY.md
@@ -1,6 +1,6 @@
 # VelesQL Ecosystem Parity Matrix
 
-Last updated: 2026-06-20 (v3.2.1)
+Last updated: 2026-06-24 (v3.2.1)
 
 This matrix tracks runtime contract and feature parity across the VelesDB ecosystem.
 
@@ -241,7 +241,7 @@ collection creation; only Haystack is limited by its DocumentStore protocol.
 
 ## Remaining Gaps and Action Items
 
-1. Add explicit server-side end-to-end assertions for the REST error shape (`code/hint/details`) beyond parser conformance. (The CLI has no HTTP layer — it executes against embedded core — so the REST error-shape contract belongs to `velesdb-server`.)
+1. ✅ **Done (2026-06-24).** Explicit server-side assertions for the full REST `VelesqlErrorResponse` shape (`code`/`message`/`hint`/`details`) are now enforced in `crates/velesdb-server/tests/velesql_conformance_tests.rs` via the shared fixture. Cases C002 (`VELESQL_MISSING_COLLECTION`), C003 (`VELESQL_COLLECTION_NOT_FOUND`), and C007 (`VELESQL_AGGREGATION_ERROR`) each assert all four fields, pinning the complete error body contract for the `/query` and `/aggregate` semantic-error paths. Parse errors (`QueryErrorResponse`) retain their own parser-specific shape and are tested separately by C004/C013 (status code only, by design — the parser error format is defined at `E0XX` layer). (The CLI has no HTTP layer — it executes against embedded core — so this contract belongs exclusively to `velesdb-server`.)
 2. ✅ **Done (2026-06-20).** The executor-level conformance net now covers **core, WASM, and CLI** — all three run `conformance/velesql_executor_cases.json`, including scalar WHERE filters, single- and multi-column ORDER BY, the ascending-id tie-break, and bounded top-k. See [KNOWN_LIMITATIONS #13](./KNOWN_LIMITATIONS.md#13-velesql-executor-conformance-core-wasm-cli) (resolved).
 3. Keep docs, fixtures, and examples synchronized on every contract version change.
 4. Promote RaBitQ from experimental to stable once the API is finalized.


### PR DESCRIPTION
## Summary

- Extends the VelesQL conformance fixture (`conformance/velesql_contract_cases.json`) so cases C002, C003, and C007 assert all four fields of the semantic error body: `code`, `message`, `hint`, and `details`.
- Extends the server conformance test (`crates/velesdb-server/tests/velesql_conformance_tests.rs`) to deserialise and assert the new fixture fields — any drift in error wording or shape is now caught at CI time.
- Closes ECOSYSTEM_PARITY.md action item 1: *"Explicit server-side assertions for the full REST `VelesqlErrorResponse` shape"*.
- Updates `docs/reference/ECOSYSTEM_PARITY.md` and `CHANGELOG.md` accordingly.

All values were sourced directly from the Rust handler source (`velesql_helpers.rs`, `mod.rs`, `aggregation.rs`) to prevent fixture/code drift.

Replaces #1220 (closed — branch had an invalid Git Flow prefix).

## Test plan

- [ ] `cargo fmt --all -- --check` passes (fixed rustfmt style on `assert_eq!` details args)
- [ ] `cargo test -p velesdb-server -- velesql_conformance` passes
- [ ] Git Flow check passes (`test/*` prefix → `develop`)
- [ ] CLA signed


https://claude.ai/code/session_01NrGmMpHJriXBF5PnP9pbte
