### PR TITLE
ci(quality): enforce the "~9 MB binary" promise with a size gate

### DIFF
--- a/.github/workflows/binary-size.yml
+++ b/.github/workflows/binary-size.yml
@@ -1,0 +1,87 @@
+name: Binary Size Gate
+
+# Verifies the "~9 MB binary" promise the README makes (QUALITY_BAR.md
+# "Additional gates"). The headline figure used to be prose only — nothing
+# measured it, so a heavy dependency could have inflated the binary while the
+# claim went stale. This job builds the stripped release binaries and fails if
+# any exceeds its ceiling (see scripts/check_binary_size.py for the values and
+# the headroom rationale).
+#
+# Note: ceilings carry headroom over the Apple-Silicon headline figure to
+# absorb the Linux x86_64 build delta this CI runner produces. They catch a
+# real regression (a multi-MB dependency, a bundled asset), not exact bytes.
+
+on:
+  push:
+    branches: [develop, main]
+    paths:
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "crates/velesdb-core/**"
+      - "crates/velesdb-server/**"
+      - "crates/velesdb-cli/**"
+      - "crates/velesdb-migrate/**"
+      - "scripts/check_binary_size.py"
+      - ".github/workflows/binary-size.yml"
+  pull_request:
+    branches: [develop, main]
+    paths:
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "crates/velesdb-core/**"
+      - "crates/velesdb-server/**"
+      - "crates/velesdb-cli/**"
+      - "crates/velesdb-migrate/**"
+      - "scripts/check_binary_size.py"
+      - ".github/workflows/binary-size.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: binary-size-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  binary-size:
+    name: Release binaries within ceilings
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # stable
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.11"
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          shared-key: "velesdb-binary-size"
+
+      - name: Build stripped release binaries
+        # Default features = the configuration the published artifacts ship.
+        # `[profile.release]` in Cargo.toml sets strip = true, lto = true.
+        run: cargo build --release -p velesdb-server -p velesdb-cli -p velesdb-migrate
+
+      - name: Check binary sizes against ceilings
+        run: |
+          python scripts/check_binary_size.py --target-dir target/release \
+            | tee binary-size-report.txt
+          {
+            echo "## Binary Size Gate"
+            echo ""
+            echo '```'
+            cat binary-size-report.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload size report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: binary-size-report-${{ github.sha }}
+          path: binary-size-report.txt
+          retention-days: 30

--- a/.github/workflows/binary-size.yml
+++ b/.github/workflows/binary-size.yml
@@ -54,6 +54,8 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # stable
+        with:
+          toolchain: "1.89"
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.11"

--- a/QUALITY_BAR.md
+++ b/QUALITY_BAR.md
@@ -196,6 +196,7 @@ These signals are tracked but do not block release individually:
 | BDD scenario coverage | All VelesQL syntax features | `crates/velesdb-core/tests/bdd/` |
 | Doctest compilation | All `pub fn` doctests compile | `cargo test --doc` in CI |
 | Promise contract sync | All numeric claims in README backed by benchmark commands | `scripts/check-promise-contract.py` in CI |
+| Binary size | `velesdb-server` ≤ 12 MiB, `velesdb` (CLI) ≤ 10 MiB, `velesdb-migrate` ≤ 9 MiB (stripped release) | `scripts/check_binary_size.py` in CI (Binary Size Gate job) |
 | TODO governance | All TODOs in format `// TODO(EPIC-XXX):` | `scripts/check-todo-annotations.py` |
 | RUSTSEC | All advisories tracked or justified in `deny.toml` | `cargo deny check` in CI (Security Audit job) |
 | Untrusted-input hardening | Corrupt/oversized persisted artifacts (HNSW graph, PQ codebook, sparse, BM25, WAL) are rejected at load, not used to size allocations; WAL `Fsync` is durable before ack; config limits validated in loaders + on open | Regression suites: `storage/storage_reliability_tests.rs`, `index/hnsw/persistence_atomicity_tests.rs`, `quantization/pq_tests.rs`, `quantization/rabitq_tests.rs`, `index/sparse/persistence_tests.rs`, `index/bm25_tests.rs`, `config_tests.rs`, `velesql/parser/robustness_tests.rs` (gated by `cargo test`) |

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ VelesDB is a **local-first database for AI agents** that fuses three engines int
 
 > [1] Reproduce: `python benchmarks/velesdb_benchmark.py --recall` (Python SDK path, 10K/384D, WAL fsync on, i9-14900KF reference machine). See [docs/BENCHMARKS.md](docs/BENCHMARKS.md) and [CHANGELOG v1.13.0](CHANGELOG.md).
 > [2] Reproduce: `cargo bench -p velesdb-core --bench column_filter_benchmark`. See [docs/BENCHMARKS.md § 6](docs/BENCHMARKS.md) — at 100K rows: ColumnStore 29.5 us vs JSON scan 3.84 ms (integer equality filter). Micro-benchmark of the ColumnStore filtering API, which now serves `SELECT ... WHERE` metadata filtering through a per-collection payload mirror (built adaptively for scan-heavy workloads) and backs JOIN execution; secondary indexes are used first when they cover the filter.
-> [3] Binary size: `velesdb-server`, stripped release build (9.1 MB stripped local build on Apple Silicon; the published v1.18.0 release artifact is 9.4 MB). Across platforms and binaries (CLI / server / migrate), v1.18.0 release artifacts span 6–13 MB.
+> [3] Binary size: `velesdb-server`, stripped release build — 9.3 MB on Apple Silicon for v3.3.0 (the v1.18.0 release artifact was 9.4 MB). Across platforms and binaries (CLI / server / migrate), release artifacts span 6–13 MB. Enforced in CI: `scripts/check_binary_size.py` (workflow `binary-size.yml`) fails the build if a binary exceeds its ceiling.
 
 All three are queried through **VelesQL** — a single SQL-like language with vector, graph, and columnar extensions:
 

--- a/scripts/check_binary_size.py
+++ b/scripts/check_binary_size.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Verify release binary sizes stay within the advertised ceilings.
+
+The README advertises a "~9 MB binary" (`velesdb-server`, stripped release).
+Until this gate existed, that figure was prose only — nothing measured it, so a
+heavy dependency could have silently inflated the binary while the claim went
+stale. This script measures each release binary and fails if it exceeds its
+ceiling.
+
+Ceilings carry headroom over the current measured size to absorb cross-platform
+variance (CI builds on Linux x86_64; the headline figure was captured on Apple
+Silicon). They are deliberately tight enough to catch a real regression — a new
+multi-MB dependency or an accidentally-bundled asset — not to pin an exact byte
+count. Bump a ceiling consciously, with justification, when a real feature grows
+a binary.
+
+Usage:
+    python scripts/check_binary_size.py [--target-dir target/release]
+"""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import sys
+
+MIB = 1024 * 1024
+
+# (binary file name, ceiling in bytes). `velesdb` is the CLI; `velesdb-server`
+# is the "~9 MB binary" the README headline refers to.
+BINARIES = [
+    ("velesdb-server", 12 * MIB),
+    ("velesdb", 10 * MIB),
+    ("velesdb-migrate", 9 * MIB),
+]
+
+
+def format_row(name: str, size: int, ceiling: int, ok: bool) -> str:
+    mark = "ok" if ok else "OVER"
+    return (
+        f"  [{mark:>4}] {name:<16} {size / MIB:6.2f} MiB "
+        f"(ceiling {ceiling / MIB:.0f} MiB)"
+    )
+
+
+def check(target_dir: pathlib.Path) -> int:
+    failed = []
+    print(f"Binary size gate — measuring {target_dir}/")
+    for name, ceiling in BINARIES:
+        path = target_dir / name
+        if not path.is_file():
+            print(f"  [MISS] {name:<16} not found at {path}")
+            failed.append(f"{name}: missing")
+            continue
+        size = path.stat().st_size
+        ok = size <= ceiling
+        print(format_row(name, size, ceiling, ok))
+        if not ok:
+            failed.append(f"{name}: {size / MIB:.2f} MiB > {ceiling / MIB:.0f} MiB")
+
+    if failed:
+        print("\nBinary size gate FAILED:")
+        for msg in failed:
+            print(f"  - {msg}")
+        return 1
+    print(f"\nBinary size gate passed ({len(BINARIES)} binaries within ceilings).")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Verify release binary sizes.")
+    parser.add_argument(
+        "--target-dir",
+        default="target/release",
+        help="Directory holding the built release binaries (default: target/release)",
+    )
+    args = parser.parse_args()
+    return check(pathlib.Path(args.target_dir))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Turns the README "~9 MB binary" headline from unverified prose into a CI-enforced claim.

## What
- **`scripts/check_binary_size.py`** — measures each stripped release binary against a ceiling, prints a table, fails if any exceeds it.
- **`.github/workflows/binary-size.yml`** — builds `velesdb-server` / `velesdb` (CLI) / `velesdb-migrate` in release and runs the script; path-filtered to Cargo manifests + the relevant crates; writes a step-summary table.
- **README footnote [3]** — refreshed to the v3.3.0 measurement (server 9.3 MB stripped on Apple Silicon) and points at the new gate.
- **QUALITY_BAR.md** — adds the gate to the "Additional gates" table.

## Ceilings & rationale
| Binary | Measured (arm64, stripped) | Ceiling |
|---|---|---|
| `velesdb-server` | 9.33 MiB | 12 MiB |
| `velesdb` (CLI) | 7.45 MiB | 10 MiB |
| `velesdb-migrate` | 6.18 MiB | 9 MiB |

Ceilings carry headroom over the Apple-Silicon measurement to absorb the Linux x86_64 build delta the CI runner produces, while staying tight enough to catch a real regression (a new multi-MB dependency, a bundled asset). They are not exact-byte pins — bump consciously, with justification, when a real feature grows a binary.

## Verification
- `python scripts/check_binary_size.py` → all three within ceilings (server 9.33 / cli 7.45 / migrate 6.18 MiB).
- `scripts/check-promise-contract.py` still passes (22 claims; the pinned `One ~9 MB binary` substring is untouched).
- `[profile.release]` already sets `strip = true`, so `target/release/<bin>` is the canonical stripped size.