### PR TITLE
feat(memory): velesdb-memory MCP server (vector + graph + columnstore)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3536,6 +3536,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pastey"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
+
+[[package]]
 name = "pear"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4454,6 +4460,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "rmcp"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1f571c72940a19d9532fe52dbea8bc9912bf1d766c2970bb824056b86f3f59"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "chrono",
+ "futures",
+ "pastey",
+ "pin-project-lite",
+ "rmcp-macros",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "rmcp-macros"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aad0035b69380782d78ea95b508327e6deaa2235909053e596eea8f27b5e1d5"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "roaring"
 version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4701,7 +4742,7 @@ checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
 dependencies = [
  "dyn-clone",
  "indexmap 1.9.3",
- "schemars_derive",
+ "schemars_derive 0.8.22",
  "serde",
  "serde_json",
  "url",
@@ -4726,8 +4767,10 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
 dependencies = [
+ "chrono",
  "dyn-clone",
  "ref-cast",
+ "schemars_derive 1.2.1",
  "serde",
  "serde_json",
 ]
@@ -4737,6 +4780,18 @@ name = "schemars_derive"
 version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6609,6 +6664,20 @@ dependencies = [
  "wgpu",
  "whoami",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "velesdb-memory"
+version = "3.3.0"
+dependencies = [
+ "rmcp",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "velesdb-core",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6677,6 +6677,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "ureq",
  "velesdb-core",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "crates/velesdb-migrate",
     "crates/velesdb-mobile",
     "crates/tauri-plugin-velesdb",
+    "crates/velesdb-memory",
 ]
 exclude = [
     "demos/tauri-rag-app/src-tauri",

--- a/crates/velesdb-memory/Cargo.toml
+++ b/crates/velesdb-memory/Cargo.toml
@@ -1,0 +1,38 @@
+[package]
+name = "velesdb-memory"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license-file = "../../LICENSE"
+repository.workspace = true
+homepage.workspace = true
+documentation.workspace = true
+authors.workspace = true
+description = "VelesDB-memory: local-first MCP memory server for AI agents (remember/recall/relate/forget/why)."
+
+[dependencies]
+velesdb-core = { workspace = true, features = ["persistence"] }
+thiserror = { workspace = true }
+rmcp = { version = "1.8.0", features = ["server", "macros", "transport-io"] }
+tokio = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+# Pinned to rmcp's schemars (1.2.x) so domain types and MCP DTOs share one
+# JsonSchema derive — no duplicate wire/domain structs.
+schemars = "1"
+
+[dev-dependencies]
+tempfile = "3"
+serde_json = { workspace = true }
+tokio = { workspace = true }
+
+[[bin]]
+name = "velesdb-memory"
+path = "src/main.rs"
+
+[lib]
+name = "velesdb_memory"
+path = "src/lib.rs"
+
+[lints]
+workspace = true

--- a/crates/velesdb-memory/Cargo.toml
+++ b/crates/velesdb-memory/Cargo.toml
@@ -9,6 +9,7 @@ homepage.workspace = true
 documentation.workspace = true
 authors.workspace = true
 description = "VelesDB-memory: local-first MCP memory server for AI agents (remember/recall/relate/forget/why)."
+readme = "README.md"
 
 [dependencies]
 velesdb-core = { workspace = true, features = ["persistence"] }
@@ -20,6 +21,14 @@ serde_json = { workspace = true }
 # Pinned to rmcp's schemars (1.2.x) so domain types and MCP DTOs share one
 # JsonSchema derive — no duplicate wire/domain structs.
 schemars = "1"
+# Optional real-recall backend (off by default). HTTP-only to a local Ollama;
+# `default-features = false` drops TLS to keep the binary small.
+ureq = { version = "2", optional = true, default-features = false }
+
+[features]
+# Real on-device semantic recall via a local Ollama embeddings endpoint. Off by
+# default so the shipped binary stays tiny, zero-dependency, and fully offline.
+ollama = ["dep:ureq"]
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/velesdb-memory/README.md
+++ b/crates/velesdb-memory/README.md
@@ -1,0 +1,111 @@
+# velesdb-memory
+
+**Local-first memory for AI agents — a single MCP server.** Give your coding
+agent durable memory that never leaves your machine: it remembers decisions,
+recalls them semantically, and — the differentiator — **connects** them so it
+can answer *why* a decision was made, not just retrieve look-alike text.
+
+Built on [VelesDB](https://velesdb.com)'s in-core Agent Memory SDK, which fuses
+three engines behind five memory tools:
+
+| Tool       | What it does                                               | Engines |
+|------------|------------------------------------------------------------|---------|
+| `remember` | store a fact, optionally linked + tagged with metadata     | Vector + Graph + ColumnStore |
+| `recall`   | semantic retrieval, optional exact-match metadata filter   | Vector + ColumnStore |
+| `relate`   | create a typed edge between two memories                   | Graph |
+| `forget`   | delete a memory                                            | — |
+| `why`      | recall a decision **+ its connected subgraph** (multi-hop) | Vector + Graph + ColumnStore |
+
+`why` is the wedge: it surfaces related memories (the PR, the ticket, the
+benchmark) reachable through typed links **even when they share no words** with
+your question — exactly what a pure vector search is blind to.
+
+By design the server exposes **memory semantics only** — never raw database
+capabilities (`query`, `create_collection`, `upsert`, `traverse`). See
+[License](#license).
+
+## Install
+
+```bash
+# Default build: tiny, zero-dependency, fully offline.
+cargo build --release -p velesdb-memory
+# → target/release/velesdb-memory
+```
+
+The binary speaks MCP over **stdio**, so client and server run on the same
+machine and the memory never leaves it.
+
+## Configure your client
+
+All clients use the same stdio shape — point `command` at the built binary.
+
+**Claude Code**
+
+```bash
+claude mcp add velesdb-memory \
+  --env VELESDB_MEMORY_PATH="$HOME/.velesdb-memory" \
+  -- /path/to/velesdb-memory
+```
+
+**Cursor** — `~/.cursor/mcp.json` (global) or `.cursor/mcp.json` (per project)
+
+```json
+{ "mcpServers": { "velesdb-memory": {
+  "command": "/path/to/velesdb-memory",
+  "env": { "VELESDB_MEMORY_PATH": "/home/you/.velesdb-memory" }
+} } }
+```
+
+**Cline** — `cline_mcp_settings.json` — same `mcpServers` block as Cursor.
+
+**Zed** — `settings.json`
+
+```json
+{ "context_servers": { "velesdb-memory": {
+  "command": { "path": "/path/to/velesdb-memory", "args": [],
+    "env": { "VELESDB_MEMORY_PATH": "/home/you/.velesdb-memory" } }
+} } }
+```
+
+## Embedding backend
+
+`remember` / `relate` / `why` / `forget` behave the same regardless of the
+embedder — the graph is what makes `why` shine. Only `recall`'s semantic
+quality (and `why`'s seed match) depend on it.
+
+| `VELESDB_MEMORY_EMBEDDER` | Recall quality | Footprint | Needs |
+|---------------------------|----------------|-----------|-------|
+| `hash` (default)          | keyword-ish, deterministic | tiny, **fully offline, zero-dep** | nothing |
+| `ollama`                  | real semantic  | tiny binary + your local model | a running Ollama; build `--features ollama` |
+
+The default keeps the *single tiny offline binary* promise intact. For real
+semantic recall, build with the `ollama` feature and point it at a local model
+— the model runs in your own Ollama, so memory still never leaves the machine:
+
+```bash
+cargo build --release -p velesdb-memory --features ollama
+ollama pull all-minilm
+VELESDB_MEMORY_EMBEDDER=ollama \
+VELESDB_MEMORY_OLLAMA_MODEL=all-minilm \
+  /path/to/velesdb-memory
+```
+
+Env vars: `VELESDB_MEMORY_OLLAMA_URL` (default `http://localhost:11434`),
+`VELESDB_MEMORY_OLLAMA_MODEL` (default `all-minilm`). The embedding dimension is
+probed from the model, so a store is fixed to one embedder — don't switch
+embedders on an existing store.
+
+## License
+
+The distributed binary embeds `velesdb-core` and is therefore governed by the
+**VelesDB Core License 1.0** (source-available): redistribution must keep the
+license and notices, with [velesdb.com](https://velesdb.com) attribution for
+public apps. The wrapper source in this crate is intentionally readable and
+forkable.
+
+**By design, this server exposes memory semantics only** —
+`remember/recall/relate/forget/why`, which return *results*. It never exposes
+raw database capabilities (`query`, `create_collection`, `upsert`, `traverse`).
+Run locally over stdio, you operate the software for yourself: this is the
+license's expressly-permitted **embedded, local-first use** — not a hosted
+service to third parties.

--- a/crates/velesdb-memory/src/embedder.rs
+++ b/crates/velesdb-memory/src/embedder.rs
@@ -1,0 +1,67 @@
+//! Pluggable text → vector embedding.
+//!
+//! The Agent Memory SDK is *bring-your-own-vector*: it never generates
+//! embeddings. This crate mirrors the repo's established pattern (the Python
+//! SDK's `Embedder` protocol, the tauri-rag demo's `fastembed` backend): an
+//! [`Embedder`] trait with a default on-device model and a deterministic,
+//! network-free fallback for tests and air-gapped reproducibility.
+
+/// Turns text into a fixed-dimension embedding vector.
+pub trait Embedder {
+    /// Embedding dimension produced by [`Embedder::embed`].
+    fn dimension(&self) -> usize;
+
+    /// Embed `text` into a vector of length [`Embedder::dimension`].
+    fn embed(&self, text: &str) -> Vec<f32>;
+}
+
+/// Deterministic, network-free embedder (token-hashing into L2-normalized
+/// buckets). Not semantically strong — its purpose is reproducible tests and
+/// offline behavior, exactly like the `fake_embed` used in the repo's
+/// `agent_memory` examples. Swap in a real model (e.g. `fastembed`,
+/// all-MiniLM-L6-v2, 384-dim) for production recall quality.
+#[derive(Debug, Clone)]
+pub struct HashEmbedder {
+    dimension: usize,
+}
+
+impl HashEmbedder {
+    /// Create a [`HashEmbedder`] producing vectors of `dimension` length.
+    /// Use `384` to match the SDK's `DEFAULT_DIMENSION`.
+    #[must_use]
+    pub fn new(dimension: usize) -> Self {
+        Self { dimension }
+    }
+}
+
+impl Embedder for HashEmbedder {
+    fn dimension(&self) -> usize {
+        self.dimension
+    }
+
+    fn embed(&self, text: &str) -> Vec<f32> {
+        let mut vector = vec![0.0_f32; self.dimension];
+        if self.dimension == 0 {
+            return vector;
+        }
+        let modulus = self.dimension as u64;
+        for token in text.split_whitespace() {
+            let bucket = usize::try_from(crate::id::stable_id(token) % modulus).unwrap_or(0);
+            vector[bucket] += 1.0;
+        }
+        velesdb_core::simd_native::normalize_inplace_native(&mut vector);
+        vector
+    }
+}
+
+/// Forward [`Embedder`] through a box, enabling a non-generic
+/// `MemoryService<Box<dyn Embedder + Send + Sync>>` for the MCP server.
+impl<T: Embedder + ?Sized> Embedder for Box<T> {
+    fn dimension(&self) -> usize {
+        (**self).dimension()
+    }
+
+    fn embed(&self, text: &str) -> Vec<f32> {
+        (**self).embed(text)
+    }
+}

--- a/crates/velesdb-memory/src/embedder.rs
+++ b/crates/velesdb-memory/src/embedder.rs
@@ -6,13 +6,31 @@
 //! [`Embedder`] trait with a default on-device model and a deterministic,
 //! network-free fallback for tests and air-gapped reproducibility.
 
+#[cfg(feature = "ollama")]
+use serde::Deserialize;
+
+/// Failure produced by an [`Embedder`] backend (e.g. a network-backed embedder
+/// that cannot reach its model). The in-memory [`HashEmbedder`] never fails.
+#[derive(Debug, thiserror::Error)]
+pub enum EmbedError {
+    /// The embedding backend (network, subprocess, …) returned an error.
+    #[error("embedding backend error: {0}")]
+    Backend(String),
+    /// The backend returned an empty embedding vector.
+    #[error("embedding backend returned an empty vector")]
+    Empty,
+}
+
 /// Turns text into a fixed-dimension embedding vector.
 pub trait Embedder {
     /// Embedding dimension produced by [`Embedder::embed`].
     fn dimension(&self) -> usize;
 
     /// Embed `text` into a vector of length [`Embedder::dimension`].
-    fn embed(&self, text: &str) -> Vec<f32>;
+    ///
+    /// # Errors
+    /// Returns [`EmbedError`] if the backend cannot produce an embedding.
+    fn embed(&self, text: &str) -> Result<Vec<f32>, EmbedError>;
 }
 
 /// Deterministic, network-free embedder (token-hashing into L2-normalized
@@ -39,10 +57,10 @@ impl Embedder for HashEmbedder {
         self.dimension
     }
 
-    fn embed(&self, text: &str) -> Vec<f32> {
+    fn embed(&self, text: &str) -> Result<Vec<f32>, EmbedError> {
         let mut vector = vec![0.0_f32; self.dimension];
         if self.dimension == 0 {
-            return vector;
+            return Ok(vector);
         }
         let modulus = self.dimension as u64;
         for token in text.split_whitespace() {
@@ -50,7 +68,7 @@ impl Embedder for HashEmbedder {
             vector[bucket] += 1.0;
         }
         velesdb_core::simd_native::normalize_inplace_native(&mut vector);
-        vector
+        Ok(vector)
     }
 }
 
@@ -61,7 +79,151 @@ impl<T: Embedder + ?Sized> Embedder for Box<T> {
         (**self).dimension()
     }
 
-    fn embed(&self, text: &str) -> Vec<f32> {
+    fn embed(&self, text: &str) -> Result<Vec<f32>, EmbedError> {
         (**self).embed(text)
+    }
+}
+
+// --- Optional real-recall backend: a local Ollama embeddings endpoint --------
+//
+// Enabled with `--features ollama`. The default build omits this backend (and
+// its HTTP dependency) so the shipped binary stays tiny, zero-dependency, and
+// fully offline. This backend keeps the binary small too: it calls a model the
+// user already runs locally, so the memory still never leaves the machine.
+
+/// Default Ollama base URL.
+#[cfg(feature = "ollama")]
+pub const DEFAULT_OLLAMA_URL: &str = "http://localhost:11434";
+
+/// Default Ollama embedding model (384-dim; `ollama pull all-minilm`).
+#[cfg(feature = "ollama")]
+pub const DEFAULT_OLLAMA_MODEL: &str = "all-minilm";
+
+/// Embeds text through a local Ollama `/api/embeddings` endpoint — real
+/// semantic recall while the model stays on the user's own machine.
+#[cfg(feature = "ollama")]
+#[derive(Debug, Clone)]
+pub struct OllamaEmbedder {
+    base_url: String,
+    model: String,
+    dimension: usize,
+}
+
+#[cfg(feature = "ollama")]
+impl OllamaEmbedder {
+    /// Connect to Ollama at `base_url` using `model`, probing the embedding
+    /// dimension once so it adapts to whatever model is configured.
+    ///
+    /// # Errors
+    /// Returns [`EmbedError`] if Ollama is unreachable or the model does not
+    /// produce embeddings.
+    pub fn new(base_url: impl Into<String>, model: impl Into<String>) -> Result<Self, EmbedError> {
+        let base_url = base_url.into();
+        let model = model.into();
+        let dimension = request_embedding(&base_url, &model, "dimension probe")?.len();
+        if dimension == 0 {
+            return Err(EmbedError::Empty);
+        }
+        Ok(Self {
+            base_url,
+            model,
+            dimension,
+        })
+    }
+}
+
+#[cfg(feature = "ollama")]
+impl Embedder for OllamaEmbedder {
+    fn dimension(&self) -> usize {
+        self.dimension
+    }
+
+    fn embed(&self, text: &str) -> Result<Vec<f32>, EmbedError> {
+        request_embedding(&self.base_url, &self.model, text)
+    }
+}
+
+/// Build the JSON request body for the embeddings endpoint.
+#[cfg(feature = "ollama")]
+fn build_request_body(model: &str, text: &str) -> String {
+    serde_json::json!({ "model": model, "prompt": text }).to_string()
+}
+
+/// Ollama `/api/embeddings` response shape.
+#[cfg(feature = "ollama")]
+#[derive(Deserialize)]
+struct EmbeddingResponse {
+    embedding: Vec<f32>,
+}
+
+/// Parse an embeddings response body into a vector.
+#[cfg(feature = "ollama")]
+fn parse_embedding_response(body: &str) -> Result<Vec<f32>, EmbedError> {
+    let parsed: EmbeddingResponse = serde_json::from_str(body)
+        .map_err(|err| EmbedError::Backend(format!("invalid embeddings response: {err}")))?;
+    if parsed.embedding.is_empty() {
+        return Err(EmbedError::Empty);
+    }
+    Ok(parsed.embedding)
+}
+
+/// Perform one blocking embeddings request against a local Ollama.
+#[cfg(feature = "ollama")]
+fn request_embedding(base_url: &str, model: &str, text: &str) -> Result<Vec<f32>, EmbedError> {
+    let url = format!("{base_url}/api/embeddings");
+    let body = build_request_body(model, text);
+    let response = ureq::post(&url)
+        .set("Content-Type", "application/json")
+        .send_string(&body)
+        .map_err(|err| EmbedError::Backend(format!("ollama request failed: {err}")))?;
+    let payload = response
+        .into_string()
+        .map_err(|err| EmbedError::Backend(format!("reading ollama response failed: {err}")))?;
+    parse_embedding_response(&payload)
+}
+
+#[cfg(all(test, feature = "ollama"))]
+mod ollama_tests {
+    use super::*;
+
+    #[test]
+    fn request_body_carries_model_and_prompt() {
+        let body = build_request_body("all-minilm", "hello world");
+        let json: serde_json::Value = serde_json::from_str(&body).expect("valid json");
+        assert_eq!(json["model"], "all-minilm");
+        assert_eq!(json["prompt"], "hello world");
+    }
+
+    #[test]
+    fn parses_a_well_formed_embedding() {
+        let vector = parse_embedding_response(r#"{"embedding":[0.1,0.2,0.3]}"#).expect("parse");
+        assert_eq!(vector.len(), 3);
+        assert!((vector[0] - 0.1_f32).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn rejects_an_empty_embedding() {
+        let parsed = parse_embedding_response(r#"{"embedding":[]}"#);
+        assert!(matches!(parsed, Err(EmbedError::Empty)));
+    }
+
+    #[test]
+    fn rejects_a_malformed_response() {
+        let parsed = parse_embedding_response(r#"{"oops":true}"#);
+        assert!(matches!(parsed, Err(EmbedError::Backend(_))));
+    }
+
+    #[test]
+    #[ignore = "requires a local Ollama with an embedding model (ollama pull all-minilm)"]
+    fn embeds_through_a_running_ollama() {
+        let embedder = OllamaEmbedder::new(DEFAULT_OLLAMA_URL, DEFAULT_OLLAMA_MODEL)
+            .expect("connect to ollama");
+        let vector = embedder
+            .embed("parking_lot avoids lock poisoning")
+            .expect("embed");
+        assert_eq!(vector.len(), embedder.dimension());
+        assert!(vector
+            .iter()
+            .any(|&component| component.abs() > f32::EPSILON));
     }
 }

--- a/crates/velesdb-memory/src/error.rs
+++ b/crates/velesdb-memory/src/error.rs
@@ -1,0 +1,24 @@
+//! Error type for the memory layer.
+
+use velesdb_core::agent::AgentMemoryError;
+use velesdb_core::Error as CoreError;
+
+/// Errors returned by [`crate::service::MemoryService`].
+#[derive(Debug, thiserror::Error)]
+pub enum MemoryError {
+    /// Failure in the underlying `VelesDB` storage engine.
+    #[error("storage error: {0}")]
+    Storage(#[from] CoreError),
+
+    /// Failure in the Agent Memory SDK.
+    #[error("memory error: {0}")]
+    Memory(#[from] AgentMemoryError),
+
+    /// A fact was empty or whitespace-only.
+    #[error("fact text must not be empty")]
+    EmptyFact,
+
+    /// A `remember` link referenced a memory id that does not exist.
+    #[error("link target {0} does not exist")]
+    UnknownLinkTarget(u64),
+}

--- a/crates/velesdb-memory/src/error.rs
+++ b/crates/velesdb-memory/src/error.rs
@@ -3,6 +3,8 @@
 use velesdb_core::agent::AgentMemoryError;
 use velesdb_core::Error as CoreError;
 
+use crate::embedder::EmbedError;
+
 /// Errors returned by [`crate::service::MemoryService`].
 #[derive(Debug, thiserror::Error)]
 pub enum MemoryError {
@@ -21,4 +23,8 @@ pub enum MemoryError {
     /// A `remember` link referenced a memory id that does not exist.
     #[error("link target {0} does not exist")]
     UnknownLinkTarget(u64),
+
+    /// Failure producing a text embedding.
+    #[error("embedding error: {0}")]
+    Embed(#[from] EmbedError),
 }

--- a/crates/velesdb-memory/src/id.rs
+++ b/crates/velesdb-memory/src/id.rs
@@ -1,0 +1,17 @@
+//! Stable, content-addressed identifier derivation.
+//!
+//! The Agent Memory SDK keys memories by `u64`; the MCP surface addresses facts
+//! by their text content. We derive the id from the engine's own canonical
+//! FNV-1a hash (`velesdb_core::hash_edge_id`) so the wrapper never carries a
+//! duplicate copy of the hash constants. Deterministic ids make `remember`
+//! idempotent: re-remembering identical content updates the fact in place.
+//!
+//! Trade-off: two *distinct* facts whose content hashes to the same value
+//! (probability ≈ 2⁻⁶⁴) would coalesce under one id — an accepted property of
+//! content-addressing, not a bug to guard against.
+
+/// Derive a stable `u64` id from arbitrary text, via the engine's FNV-1a hash.
+#[must_use]
+pub fn stable_id(text: &str) -> u64 {
+    velesdb_core::hash_edge_id(0, 0, text)
+}

--- a/crates/velesdb-memory/src/lib.rs
+++ b/crates/velesdb-memory/src/lib.rs
@@ -1,0 +1,37 @@
+//! # VelesDB-memory
+//!
+//! Local-first **memory** layer for AI agents, exposed through a single MCP
+//! server. This crate is the domain core: it maps five memory operations onto
+//! `VelesDB`'s in-core Agent Memory SDK.
+//!
+//! | Operation  | Meaning                                            |
+//! |------------|----------------------------------------------------|
+//! | `remember` | store a fact (+ optional links to other memories)  |
+//! | `recall`   | semantic retrieval of similar facts                |
+//! | `relate`   | create a typed edge between two memories           |
+//! | `forget`   | delete a memory                                    |
+//! | `why`      | recall + multi-hop graph traversal                 |
+//!
+//! ## License boundary (non-negotiable)
+//!
+//! This crate exposes **memory semantics only** (results), never raw database
+//! capabilities (`query(velesql)`, `create_collection`, `upsert(vectors)`,
+//! `traverse(graph)`). Exposing the raw engine would constitute a "Substantial
+//! Set" of the Software's features and breach the `VelesDB` Core License 1.0
+//! (§1, No Hosted or Managed Service). See `VISION.md` §5 and `PLAN.md` Phase 4A.
+
+pub mod embedder;
+pub mod error;
+pub mod id;
+pub mod mcp;
+pub mod service;
+
+/// Default embedding dimension — the single source of truth, taken from the
+/// SDK's own default so the server, library, and tests never restate the value.
+pub const DEFAULT_DIMENSION: usize = velesdb_core::agent::DEFAULT_DIMENSION;
+
+pub use embedder::{Embedder, HashEmbedder};
+pub use error::MemoryError;
+pub use service::{
+    Explanation, Link, MemoryEdge, MemoryNode, MemoryService, Metadata, Recollection,
+};

--- a/crates/velesdb-memory/src/lib.rs
+++ b/crates/velesdb-memory/src/lib.rs
@@ -30,7 +30,9 @@ pub mod service;
 /// SDK's own default so the server, library, and tests never restate the value.
 pub const DEFAULT_DIMENSION: usize = velesdb_core::agent::DEFAULT_DIMENSION;
 
-pub use embedder::{Embedder, HashEmbedder};
+pub use embedder::{EmbedError, Embedder, HashEmbedder};
+#[cfg(feature = "ollama")]
+pub use embedder::{OllamaEmbedder, DEFAULT_OLLAMA_MODEL, DEFAULT_OLLAMA_URL};
 pub use error::MemoryError;
 pub use service::{
     Explanation, Link, MemoryEdge, MemoryNode, MemoryService, Metadata, Recollection,

--- a/crates/velesdb-memory/src/main.rs
+++ b/crates/velesdb-memory/src/main.rs
@@ -1,0 +1,26 @@
+//! `velesdb-memory` — MCP memory server binary (stdio transport).
+//!
+//! Serves the five memory tools over stdio so any MCP client (Claude Code,
+//! Cursor, Cline, Zed, …) can use it locally. The store never leaves the
+//! machine. Configure the store directory with `VELESDB_MEMORY_PATH`.
+
+use rmcp::ServiceExt;
+use velesdb_memory::mcp::{DynEmbedder, McpServer};
+use velesdb_memory::{HashEmbedder, MemoryService, DEFAULT_DIMENSION};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let store_path = std::env::var("VELESDB_MEMORY_PATH")
+        .unwrap_or_else(|_| "./velesdb-memory-store".to_owned());
+
+    // Deterministic, fully offline embedder by default. Plug a real on-device
+    // model (e.g. fastembed / all-MiniLM-L6-v2, 384-dim) for production recall.
+    let embedder: DynEmbedder = Box::new(HashEmbedder::new(DEFAULT_DIMENSION));
+    let service = MemoryService::open(&store_path, embedder)?;
+
+    let running = McpServer::new(service)
+        .serve((tokio::io::stdin(), tokio::io::stdout()))
+        .await?;
+    running.waiting().await?;
+    Ok(())
+}

--- a/crates/velesdb-memory/src/main.rs
+++ b/crates/velesdb-memory/src/main.rs
@@ -2,7 +2,8 @@
 //!
 //! Serves the five memory tools over stdio so any MCP client (Claude Code,
 //! Cursor, Cline, Zed, …) can use it locally. The store never leaves the
-//! machine. Configure the store directory with `VELESDB_MEMORY_PATH`.
+//! machine. Configure the store directory with `VELESDB_MEMORY_PATH` and the
+//! embedding backend with `VELESDB_MEMORY_EMBEDDER` (`hash` | `ollama`).
 
 use rmcp::ServiceExt;
 use velesdb_memory::mcp::{DynEmbedder, McpServer};
@@ -13,9 +14,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let store_path = std::env::var("VELESDB_MEMORY_PATH")
         .unwrap_or_else(|_| "./velesdb-memory-store".to_owned());
 
-    // Deterministic, fully offline embedder by default. Plug a real on-device
-    // model (e.g. fastembed / all-MiniLM-L6-v2, 384-dim) for production recall.
-    let embedder: DynEmbedder = Box::new(HashEmbedder::new(DEFAULT_DIMENSION));
+    let embedder = build_embedder()?;
     let service = MemoryService::open(&store_path, embedder)?;
 
     let running = McpServer::new(service)
@@ -23,4 +22,34 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .await?;
     running.waiting().await?;
     Ok(())
+}
+
+/// Select the embedding backend from `VELESDB_MEMORY_EMBEDDER`: `hash`
+/// (default) is deterministic and fully offline; `ollama` gives real on-device
+/// semantic recall and requires building with `--features ollama`.
+fn build_embedder() -> Result<DynEmbedder, Box<dyn std::error::Error>> {
+    match std::env::var("VELESDB_MEMORY_EMBEDDER").as_deref() {
+        Ok("ollama") => build_ollama_embedder(),
+        Ok("hash") | Err(_) => Ok(Box::new(HashEmbedder::new(DEFAULT_DIMENSION))),
+        Ok(other) => Err(format!(
+            "unknown VELESDB_MEMORY_EMBEDDER '{other}' (expected 'hash' or 'ollama')"
+        )
+        .into()),
+    }
+}
+
+#[cfg(feature = "ollama")]
+fn build_ollama_embedder() -> Result<DynEmbedder, Box<dyn std::error::Error>> {
+    use velesdb_memory::{OllamaEmbedder, DEFAULT_OLLAMA_MODEL, DEFAULT_OLLAMA_URL};
+
+    let url = std::env::var("VELESDB_MEMORY_OLLAMA_URL")
+        .unwrap_or_else(|_| DEFAULT_OLLAMA_URL.to_owned());
+    let model = std::env::var("VELESDB_MEMORY_OLLAMA_MODEL")
+        .unwrap_or_else(|_| DEFAULT_OLLAMA_MODEL.to_owned());
+    Ok(Box::new(OllamaEmbedder::new(url, model)?))
+}
+
+#[cfg(not(feature = "ollama"))]
+fn build_ollama_embedder() -> Result<DynEmbedder, Box<dyn std::error::Error>> {
+    Err("the 'ollama' embedder requires building with `--features ollama`".into())
 }

--- a/crates/velesdb-memory/src/mcp.rs
+++ b/crates/velesdb-memory/src/mcp.rs
@@ -250,6 +250,21 @@ mod tests {
         (dir, McpServer::new(service))
     }
 
+    /// Run a one-hop `why(DECISION)` through the server, returning the seed
+    /// subgraph's node ids and its edge count.
+    async fn why_one_hop(srv: &McpServer) -> (Vec<u64>, usize) {
+        let Json(why) = srv
+            .why(Parameters(WhyParams {
+                decision: DECISION.to_owned(),
+                max_hops: Some(1),
+                filter: None,
+            }))
+            .await
+            .expect("why");
+        let ids: Vec<u64> = why.nodes.iter().map(|n| n.id).collect();
+        (ids, why.edges.len())
+    }
+
     #[tokio::test]
     async fn remember_then_recall_roundtrips_through_the_server() {
         let (_dir, srv) = server();
@@ -301,18 +316,9 @@ mod tests {
         .await
         .expect("relate");
 
-        let Json(why) = srv
-            .why(Parameters(WhyParams {
-                decision: DECISION.to_owned(),
-                max_hops: Some(1),
-                filter: None,
-            }))
-            .await
-            .expect("why");
-
-        let ids: Vec<u64> = why.nodes.iter().map(|n| n.id).collect();
+        let (ids, edges) = why_one_hop(&srv).await;
         assert!(ids.contains(&decision.id) && ids.contains(&pr.id));
-        assert_eq!(why.edges.len(), 1);
+        assert_eq!(edges, 1);
     }
 
     #[tokio::test]
@@ -365,16 +371,7 @@ mod tests {
             .await
             .expect("remember decision with link");
 
-        let Json(why) = srv
-            .why(Parameters(WhyParams {
-                decision: DECISION.to_owned(),
-                max_hops: Some(1),
-                filter: None,
-            }))
-            .await
-            .expect("why");
-
-        let ids: Vec<u64> = why.nodes.iter().map(|n| n.id).collect();
+        let (ids, _) = why_one_hop(&srv).await;
         assert!(ids.contains(&decision.id) && ids.contains(&pr.id));
     }
 

--- a/crates/velesdb-memory/src/mcp.rs
+++ b/crates/velesdb-memory/src/mcp.rs
@@ -1,0 +1,418 @@
+//! MCP transport: exposes the memory service as MCP tools over stdio.
+//!
+//! Only **memory semantics** are exposed (`remember / recall / relate / forget
+//! / why`) — never raw database capabilities. See [`crate`] docs for the
+//! license boundary this enforces.
+
+use std::sync::Arc;
+
+use rmcp::handler::server::router::tool::ToolRouter;
+use rmcp::handler::server::wrapper::{Json, Parameters};
+use rmcp::model::{Implementation, ServerCapabilities, ServerInfo};
+use rmcp::{tool, tool_handler, tool_router, ErrorData, ServerHandler};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::embedder::Embedder;
+use crate::service::{Explanation, Link, MemoryService, Metadata, Recollection};
+
+/// Default number of memories returned by `recall`.
+const DEFAULT_RECALL_LIMIT: usize = 10;
+/// Default hop budget for `why` traversal.
+const DEFAULT_WHY_HOPS: usize = 2;
+
+/// Boxed embedder so the served type is concrete (the rmcp macros and the
+/// async runtime work most cleanly on a non-generic handler).
+pub type DynEmbedder = Box<dyn Embedder + Send + Sync>;
+
+// --- Tool parameter / result DTOs ------------------------------------------
+//
+// Output shapes reuse the domain types from `crate::service` directly (they
+// derive `Serialize` + `JsonSchema`), so there is no duplicate wire/domain
+// struct. Only request envelopes and small id-results live here.
+
+/// Parameters for the `remember` tool.
+#[derive(Deserialize, JsonSchema)]
+struct RememberParams {
+    /// The fact to store in memory.
+    fact: String,
+    /// Optional typed links from this fact to existing memories.
+    #[serde(default)]
+    links: Vec<Link>,
+    /// Optional structured metadata for later filtering (e.g.
+    /// `{"project": "veles", "author": "julien", "status": "open"}`).
+    metadata: Option<Metadata>,
+}
+
+/// Result of the `remember` tool.
+#[derive(Serialize, JsonSchema)]
+struct RememberResult {
+    /// Stable id assigned to the remembered fact.
+    id: u64,
+}
+
+/// Parameters for the `recall` tool.
+#[derive(Deserialize, JsonSchema)]
+struct RecallParams {
+    /// Natural-language query to match semantically.
+    query: String,
+    /// Maximum number of memories to return (default 10).
+    limit: Option<usize>,
+    /// Optional exact-match metadata filter (e.g.
+    /// `{"project": "veles", "status": "resolved"}`).
+    filter: Option<Metadata>,
+}
+
+/// Result of the `recall` tool.
+#[derive(Serialize, JsonSchema)]
+struct RecallResult {
+    /// Recalled memories, most similar first.
+    memories: Vec<Recollection>,
+}
+
+/// Parameters for the `relate` tool.
+#[derive(Deserialize, JsonSchema)]
+struct RelateParams {
+    /// Source memory id.
+    from: u64,
+    /// Target memory id.
+    to: u64,
+    /// Relationship label.
+    relation: String,
+}
+
+/// Result of the `relate` tool.
+#[derive(Serialize, JsonSchema)]
+struct RelateResult {
+    /// Id of the created edge.
+    edge_id: u64,
+}
+
+/// Parameters for the `forget` tool.
+#[derive(Deserialize, JsonSchema)]
+struct ForgetParams {
+    /// Id of the memory to forget.
+    id: u64,
+}
+
+/// Result of the `forget` tool.
+#[derive(Serialize, JsonSchema)]
+struct ForgetResult {
+    /// Id of the forgotten memory.
+    id: u64,
+}
+
+/// Parameters for the `why` tool.
+#[derive(Deserialize, JsonSchema)]
+struct WhyParams {
+    /// The decision (or fact) to explain.
+    decision: String,
+    /// How many hops of typed links to follow (default 2).
+    max_hops: Option<usize>,
+    /// Optional exact-match metadata filter to scope the seed (e.g.
+    /// `{"project": "veles"}`).
+    filter: Option<Metadata>,
+}
+
+// --- The server ------------------------------------------------------------
+
+/// MCP server wrapping a [`MemoryService`].
+#[derive(Clone)]
+pub struct McpServer {
+    service: Arc<MemoryService<DynEmbedder>>,
+    tool_router: ToolRouter<McpServer>,
+}
+
+#[tool_router]
+impl McpServer {
+    /// Wrap a memory service as an MCP server.
+    #[must_use]
+    pub fn new(service: MemoryService<DynEmbedder>) -> Self {
+        Self {
+            service: Arc::new(service),
+            tool_router: Self::tool_router(),
+        }
+    }
+
+    #[tool(
+        name = "remember",
+        description = "Store a fact in durable local memory. Optionally link it to existing memories (graph) and tag it with structured metadata like project/author/type/status/date (ColumnStore) for later filtering. Returns the fact's stable id."
+    )]
+    async fn remember(
+        &self,
+        Parameters(params): Parameters<RememberParams>,
+    ) -> Result<Json<RememberResult>, ErrorData> {
+        let id = self
+            .service
+            .remember(&params.fact, &params.links, params.metadata.as_ref())
+            .map_err(to_error)?;
+        Ok(Json(RememberResult { id }))
+    }
+
+    #[tool(
+        name = "recall",
+        description = "Recall memories semantically similar to a query (vector), most similar first. Optionally narrow to exact-match metadata via `filter` (ColumnStore), e.g. {\"project\":\"veles\",\"status\":\"resolved\"}."
+    )]
+    async fn recall(
+        &self,
+        Parameters(params): Parameters<RecallParams>,
+    ) -> Result<Json<RecallResult>, ErrorData> {
+        let limit = params.limit.unwrap_or(DEFAULT_RECALL_LIMIT);
+        let memories = self
+            .service
+            .recall(&params.query, limit, params.filter.as_ref())
+            .map_err(to_error)?;
+        Ok(Json(RecallResult { memories }))
+    }
+
+    #[tool(
+        name = "relate",
+        description = "Create a typed link from one memory to another. Returns the edge id."
+    )]
+    async fn relate(
+        &self,
+        Parameters(params): Parameters<RelateParams>,
+    ) -> Result<Json<RelateResult>, ErrorData> {
+        let edge_id = self
+            .service
+            .relate(params.from, params.to, &params.relation)
+            .map_err(to_error)?;
+        Ok(Json(RelateResult { edge_id }))
+    }
+
+    #[tool(name = "forget", description = "Delete a memory by id.")]
+    async fn forget(
+        &self,
+        Parameters(params): Parameters<ForgetParams>,
+    ) -> Result<Json<ForgetResult>, ErrorData> {
+        self.service.forget(params.id).map_err(to_error)?;
+        Ok(Json(ForgetResult { id: params.id }))
+    }
+
+    #[tool(
+        name = "why",
+        description = "Explain a decision: find the best-matching memory (optionally scoped by a metadata `filter`, e.g. the current project) and return the connected subgraph of related memories reachable through typed links — fusing vector, ColumnStore, and graph to surface context a plain similarity search misses."
+    )]
+    async fn why(
+        &self,
+        Parameters(params): Parameters<WhyParams>,
+    ) -> Result<Json<Explanation>, ErrorData> {
+        let max_hops = params.max_hops.unwrap_or(DEFAULT_WHY_HOPS);
+        let explanation = self
+            .service
+            .why(&params.decision, max_hops, params.filter.as_ref())
+            .map_err(to_error)?;
+        Ok(Json(explanation))
+    }
+}
+
+/// `#[tool_handler]` generates `call_tool` / `list_tools` from the router;
+/// `get_info` is overridden so the server identifies itself as `velesdb-memory`
+/// (the macro default falls back to rmcp's own identity). Per-tool guidance
+/// lives in each `#[tool(description = …)]`.
+#[tool_handler(router = self.tool_router)]
+impl ServerHandler for McpServer {
+    fn get_info(&self) -> ServerInfo {
+        let mut info = ServerInfo::default();
+        info.server_info = Implementation::new(env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"));
+        info.capabilities = ServerCapabilities::builder().enable_tools().build();
+        info.instructions = Some(
+            "Local-first memory for AI agents: remember facts, recall them semantically, \
+             relate them, forget them, and ask why a decision was made (connected subgraph)."
+                .to_owned(),
+        );
+        info
+    }
+}
+
+/// Map a domain error to an MCP error.
+///
+/// Takes the error by value so it can be used directly as `.map_err(to_error)`
+/// at every call site (no per-site closure); the error is consumed into its
+/// `Display` form.
+#[allow(clippy::needless_pass_by_value)]
+fn to_error(err: crate::error::MemoryError) -> ErrorData {
+    ErrorData::internal_error(err.to_string(), None)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::embedder::HashEmbedder;
+    use tempfile::TempDir;
+
+    const DECISION: &str = "we chose parking_lot to avoid lock poisoning";
+
+    fn server() -> (TempDir, McpServer) {
+        let dir = TempDir::new().expect("create tempdir");
+        let embedder: DynEmbedder = Box::new(HashEmbedder::new(crate::DEFAULT_DIMENSION));
+        let service = MemoryService::open(dir.path(), embedder).expect("open memory store");
+        (dir, McpServer::new(service))
+    }
+
+    #[tokio::test]
+    async fn remember_then_recall_roundtrips_through_the_server() {
+        let (_dir, srv) = server();
+
+        let Json(stored) = srv
+            .remember(Parameters(RememberParams {
+                fact: DECISION.to_owned(),
+                links: Vec::new(),
+                metadata: None,
+            }))
+            .await
+            .expect("remember");
+        let Json(recalled) = srv
+            .recall(Parameters(RecallParams {
+                query: "parking_lot poisoning".to_owned(),
+                limit: None,
+                filter: None,
+            }))
+            .await
+            .expect("recall");
+
+        assert!(recalled.memories.iter().any(|m| m.id == stored.id));
+    }
+
+    #[tokio::test]
+    async fn why_returns_the_connected_subgraph() {
+        let (_dir, srv) = server();
+        let Json(decision) = srv
+            .remember(Parameters(RememberParams {
+                fact: DECISION.to_owned(),
+                links: Vec::new(),
+                metadata: None,
+            }))
+            .await
+            .expect("remember decision");
+        let Json(pr) = srv
+            .remember(Parameters(RememberParams {
+                fact: "PR #42 swaps the mutex".to_owned(),
+                links: Vec::new(),
+                metadata: None,
+            }))
+            .await
+            .expect("remember pr");
+        srv.relate(Parameters(RelateParams {
+            from: decision.id,
+            to: pr.id,
+            relation: "decided_in".to_owned(),
+        }))
+        .await
+        .expect("relate");
+
+        let Json(why) = srv
+            .why(Parameters(WhyParams {
+                decision: DECISION.to_owned(),
+                max_hops: Some(1),
+                filter: None,
+            }))
+            .await
+            .expect("why");
+
+        let ids: Vec<u64> = why.nodes.iter().map(|n| n.id).collect();
+        assert!(ids.contains(&decision.id) && ids.contains(&pr.id));
+        assert_eq!(why.edges.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn forget_removes_a_memory_through_the_server() {
+        let (_dir, srv) = server();
+        let Json(stored) = srv
+            .remember(Parameters(RememberParams {
+                fact: "ephemeral note about France".to_owned(),
+                links: Vec::new(),
+                metadata: None,
+            }))
+            .await
+            .expect("remember");
+
+        srv.forget(Parameters(ForgetParams { id: stored.id }))
+            .await
+            .expect("forget");
+
+        let Json(recalled) = srv
+            .recall(Parameters(RecallParams {
+                query: "France".to_owned(),
+                limit: None,
+                filter: None,
+            }))
+            .await
+            .expect("recall");
+        assert!(recalled.memories.iter().all(|m| m.id != stored.id));
+    }
+
+    #[tokio::test]
+    async fn remember_links_are_traversable_by_why() {
+        let (_dir, srv) = server();
+        let Json(pr) = srv
+            .remember(Parameters(RememberParams {
+                fact: "PR #99 refactors locks".to_owned(),
+                links: Vec::new(),
+                metadata: None,
+            }))
+            .await
+            .expect("remember pr");
+        let Json(decision) = srv
+            .remember(Parameters(RememberParams {
+                fact: DECISION.to_owned(),
+                links: vec![Link {
+                    target: pr.id,
+                    relation: "decided_in".to_owned(),
+                }],
+                metadata: None,
+            }))
+            .await
+            .expect("remember decision with link");
+
+        let Json(why) = srv
+            .why(Parameters(WhyParams {
+                decision: DECISION.to_owned(),
+                max_hops: Some(1),
+                filter: None,
+            }))
+            .await
+            .expect("why");
+
+        let ids: Vec<u64> = why.nodes.iter().map(|n| n.id).collect();
+        assert!(ids.contains(&decision.id) && ids.contains(&pr.id));
+    }
+
+    #[tokio::test]
+    async fn metadata_and_filter_flow_through_the_server() {
+        let (_dir, srv) = server();
+        let mut veles_meta = Metadata::new();
+        veles_meta.insert("project".to_owned(), serde_json::json!("veles"));
+        let mut acme_meta = Metadata::new();
+        acme_meta.insert("project".to_owned(), serde_json::json!("acme"));
+
+        let Json(kept) = srv
+            .remember(Parameters(RememberParams {
+                fact: "auth bug in login".to_owned(),
+                links: Vec::new(),
+                metadata: Some(veles_meta.clone()),
+            }))
+            .await
+            .expect("remember veles");
+        let Json(dropped) = srv
+            .remember(Parameters(RememberParams {
+                fact: "auth bug in login too".to_owned(),
+                links: Vec::new(),
+                metadata: Some(acme_meta),
+            }))
+            .await
+            .expect("remember acme");
+
+        let Json(recalled) = srv
+            .recall(Parameters(RecallParams {
+                query: "auth bug".to_owned(),
+                limit: None,
+                filter: Some(veles_meta),
+            }))
+            .await
+            .expect("recall filtered");
+
+        assert!(recalled.memories.iter().any(|m| m.id == kept.id));
+        assert!(recalled.memories.iter().all(|m| m.id != dropped.id));
+    }
+}

--- a/crates/velesdb-memory/src/service.rs
+++ b/crates/velesdb-memory/src/service.rs
@@ -117,7 +117,7 @@ impl<E: Embedder> MemoryService<E> {
         }
         self.ensure_link_targets_exist(links)?;
         let fact_id = id::stable_id(fact);
-        let embedding = self.embedder.embed(fact);
+        let embedding = self.embedder.embed(fact)?;
         self.store(fact_id, fact, &embedding, metadata)?;
         for link in links {
             self.memory
@@ -179,7 +179,7 @@ impl<E: Embedder> MemoryService<E> {
         if query.trim().is_empty() {
             return Ok(Vec::new());
         }
-        let embedding = self.embedder.embed(query);
+        let embedding = self.embedder.embed(query)?;
         let hits = self.search(&embedding, k, filter)?;
         Ok(hits
             .into_iter()
@@ -248,7 +248,7 @@ impl<E: Embedder> MemoryService<E> {
         if decision.trim().is_empty() {
             return Ok(Explanation::default());
         }
-        let embedding = self.embedder.embed(decision);
+        let embedding = self.embedder.embed(decision)?;
         let seeds = self.search(&embedding, 1, filter)?;
         let Some((seed_id, _score, seed_content)) = seeds.into_iter().next() else {
             return Ok(Explanation::default());

--- a/crates/velesdb-memory/src/service.rs
+++ b/crates/velesdb-memory/src/service.rs
@@ -1,0 +1,324 @@
+//! The memory service: five operations over the in-core Agent Memory SDK.
+
+use std::collections::HashSet;
+use std::path::Path;
+use std::sync::Arc;
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+use velesdb_core::agent::AgentMemory;
+use velesdb_core::Database;
+
+/// Structured metadata attached to a memory (the `ColumnStore` facet): exact-match
+/// fields like `project`, `author`, `type`, `status`, `date`. `content` and
+/// `_veles_expires_at` are reserved keys.
+pub type Metadata = Map<String, Value>;
+
+use crate::embedder::Embedder;
+use crate::error::MemoryError;
+use crate::id;
+
+/// A typed link from a freshly remembered fact to an existing memory.
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+pub struct Link {
+    /// Id of the memory being linked to.
+    pub target: u64,
+    /// Relationship label (e.g. `"decided_in"`, `"references"`, `"depends_on"`).
+    pub relation: String,
+}
+
+/// One semantically recalled memory.
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct Recollection {
+    /// Stable id of the memory.
+    pub id: u64,
+    /// Similarity score (higher is closer).
+    pub score: f32,
+    /// Stored fact content.
+    pub content: String,
+}
+
+/// A node in an [`Explanation`] subgraph.
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct MemoryNode {
+    /// Stable id of the memory.
+    pub id: u64,
+    /// Stored fact content.
+    pub content: String,
+    /// Distance in hops from the seed memory (the seed is hop `0`).
+    pub hop: usize,
+}
+
+/// A typed edge in an [`Explanation`] subgraph.
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct MemoryEdge {
+    /// Source memory id.
+    pub from: u64,
+    /// Target memory id.
+    pub to: u64,
+    /// Relationship label.
+    pub relation: String,
+}
+
+/// The connected answer to a `why` question: the best-matching seed memory plus
+/// everything reachable from it within a hop budget. This connected subgraph is
+/// the differentiator — it surfaces related memories a purely vector recall is
+/// blind to (no textual similarity required).
+#[derive(Debug, Clone, Default, Serialize, JsonSchema)]
+pub struct Explanation {
+    /// Memories in the subgraph, seed first.
+    pub nodes: Vec<MemoryNode>,
+    /// Typed edges connecting the nodes.
+    pub edges: Vec<MemoryEdge>,
+}
+
+/// Local-first agent memory backed by a single `VelesDB` instance.
+///
+/// Generic over the [`Embedder`] so production can use an on-device model while
+/// tests use a deterministic, network-free one.
+pub struct MemoryService<E: Embedder> {
+    memory: AgentMemory,
+    embedder: E,
+}
+
+impl<E: Embedder> MemoryService<E> {
+    /// Open (or create) a memory store at `path`, using `embedder` for text
+    /// vectorization. The store never leaves this directory.
+    ///
+    /// # Errors
+    /// Returns [`MemoryError`] if the store cannot be opened or the agent
+    /// memory cannot be initialized for the embedder's dimension.
+    pub fn open<P: AsRef<Path>>(path: P, embedder: E) -> Result<Self, MemoryError> {
+        let db = Arc::new(Database::open(path)?);
+        let memory = AgentMemory::with_dimension(db, embedder.dimension())?;
+        Ok(Self { memory, embedder })
+    }
+
+    /// Remember a `fact`, optionally tagging it with structured `metadata`
+    /// (`ColumnStore` facet) and linking it to existing memories (graph facet).
+    /// Returns the stable id of the fact (idempotent on identical content).
+    ///
+    /// Link targets are validated to exist *before* the fact is stored, so a bad
+    /// link never leaves the fact half-written.
+    ///
+    /// # Errors
+    /// Returns [`MemoryError::EmptyFact`] for empty/whitespace facts,
+    /// [`MemoryError::UnknownLinkTarget`] if a link points at a missing memory,
+    /// or a storage error if persistence fails.
+    pub fn remember(
+        &self,
+        fact: &str,
+        links: &[Link],
+        metadata: Option<&Metadata>,
+    ) -> Result<u64, MemoryError> {
+        if fact.trim().is_empty() {
+            return Err(MemoryError::EmptyFact);
+        }
+        self.ensure_link_targets_exist(links)?;
+        let fact_id = id::stable_id(fact);
+        let embedding = self.embedder.embed(fact);
+        self.store(fact_id, fact, &embedding, metadata)?;
+        for link in links {
+            self.memory
+                .semantic()
+                .relate(fact_id, link.target, &link.relation, None)?;
+        }
+        Ok(fact_id)
+    }
+
+    /// Fail unless every link target already exists (keeps `remember` atomic).
+    fn ensure_link_targets_exist(&self, links: &[Link]) -> Result<(), MemoryError> {
+        for link in links {
+            if self.memory.semantic().get(link.target)?.is_none() {
+                return Err(MemoryError::UnknownLinkTarget(link.target));
+            }
+        }
+        Ok(())
+    }
+
+    /// Store a fact with or without metadata.
+    fn store(
+        &self,
+        id: u64,
+        fact: &str,
+        embedding: &[f32],
+        metadata: Option<&Metadata>,
+    ) -> Result<(), MemoryError> {
+        match metadata {
+            Some(meta) => self
+                .memory
+                .semantic()
+                .store_with_metadata(id, fact, embedding, meta)
+                .map_err(MemoryError::from),
+            None => self
+                .memory
+                .semantic()
+                .store(id, fact, embedding)
+                .map_err(MemoryError::from),
+        }
+    }
+
+    /// Recall up to `k` memories semantically similar to `query` (vector facet),
+    /// optionally narrowed to an exact-match metadata `filter` (`ColumnStore`
+    /// facet) — e.g. `{ "project": "veles", "status": "resolved" }`.
+    ///
+    /// The filter is applied *after* vector ranking, so a highly selective
+    /// filter over a large, dissimilar corpus may return fewer than `k` hits
+    /// even when more matches exist further down the ranking — raise `k` if you
+    /// need exhaustive filtered recall.
+    ///
+    /// # Errors
+    /// Returns [`MemoryError`] if the semantic query fails.
+    pub fn recall(
+        &self,
+        query: &str,
+        k: usize,
+        filter: Option<&Metadata>,
+    ) -> Result<Vec<Recollection>, MemoryError> {
+        if query.trim().is_empty() {
+            return Ok(Vec::new());
+        }
+        let embedding = self.embedder.embed(query);
+        let hits = self.search(&embedding, k, filter)?;
+        Ok(hits
+            .into_iter()
+            .map(|(id, score, content)| Recollection { id, score, content })
+            .collect())
+    }
+
+    /// Vector search for up to `k` ids, optionally narrowed by a metadata
+    /// `filter`. Shared by [`Self::recall`] and [`Self::why`].
+    fn search(
+        &self,
+        embedding: &[f32],
+        k: usize,
+        filter: Option<&Metadata>,
+    ) -> Result<Vec<(u64, f32, String)>, MemoryError> {
+        match filter {
+            Some(meta) => self
+                .memory
+                .semantic()
+                .query_filtered(embedding, k, meta, 0)
+                .map_err(MemoryError::from),
+            None => self
+                .memory
+                .semantic()
+                .query(embedding, k)
+                .map_err(MemoryError::from),
+        }
+    }
+
+    /// Create a typed edge `from -> to`. Returns the edge id.
+    ///
+    /// # Errors
+    /// Returns [`MemoryError`] if the edge cannot be created.
+    pub fn relate(&self, from: u64, to: u64, relation: &str) -> Result<u64, MemoryError> {
+        self.memory
+            .semantic()
+            .relate(from, to, relation, None)
+            .map_err(MemoryError::from)
+    }
+
+    /// Forget (delete) the memory with `fact_id`.
+    ///
+    /// # Errors
+    /// Returns [`MemoryError`] if the deletion fails.
+    pub fn forget(&self, fact_id: u64) -> Result<(), MemoryError> {
+        self.memory
+            .semantic()
+            .delete(fact_id)
+            .map_err(MemoryError::from)
+    }
+
+    /// Explain a `decision`: find the best-matching memory (optionally scoped to
+    /// a metadata `filter`, e.g. the current project), then walk its typed links
+    /// up to `max_hops` away — fusing the vector, `ColumnStore`, and graph facets.
+    ///
+    /// Returns an empty [`Explanation`] when nothing matches the decision.
+    ///
+    /// # Errors
+    /// Returns [`MemoryError`] if recall or graph traversal fails.
+    pub fn why(
+        &self,
+        decision: &str,
+        max_hops: usize,
+        filter: Option<&Metadata>,
+    ) -> Result<Explanation, MemoryError> {
+        if decision.trim().is_empty() {
+            return Ok(Explanation::default());
+        }
+        let embedding = self.embedder.embed(decision);
+        let seeds = self.search(&embedding, 1, filter)?;
+        let Some((seed_id, _score, seed_content)) = seeds.into_iter().next() else {
+            return Ok(Explanation::default());
+        };
+        self.traverse(seed_id, seed_content, max_hops)
+    }
+
+    /// Breadth-first walk over outgoing links from `seed_id`, collecting nodes
+    /// and edges up to `max_hops` away.
+    fn traverse(
+        &self,
+        seed_id: u64,
+        seed_content: String,
+        max_hops: usize,
+    ) -> Result<Explanation, MemoryError> {
+        let mut explanation = Explanation {
+            nodes: vec![MemoryNode {
+                id: seed_id,
+                content: seed_content,
+                hop: 0,
+            }],
+            edges: Vec::new(),
+        };
+        let mut visited: HashSet<u64> = HashSet::from([seed_id]);
+        let mut frontier = vec![seed_id];
+        for hop in 1..=max_hops {
+            let mut next = Vec::new();
+            for node_id in frontier.drain(..) {
+                self.expand(node_id, hop, &mut explanation, &mut visited, &mut next)?;
+            }
+            if next.is_empty() {
+                break;
+            }
+            frontier = next;
+        }
+        Ok(explanation)
+    }
+
+    /// Expand a single node: enqueue unseen targets and record edges. An edge is
+    /// only recorded once its target is a resolved node, so the subgraph never
+    /// contains an edge pointing at a node absent from `nodes` (e.g. a forgotten
+    /// target whose edge outlived it).
+    fn expand(
+        &self,
+        node_id: u64,
+        hop: usize,
+        explanation: &mut Explanation,
+        visited: &mut HashSet<u64>,
+        next: &mut Vec<u64>,
+    ) -> Result<(), MemoryError> {
+        for edge in self.memory.semantic().relations(node_id)? {
+            let target = edge.target();
+            if !visited.contains(&target) {
+                let Some((content, _embedding)) = self.memory.semantic().get(target)? else {
+                    continue; // target no longer exists → drop the dangling edge too
+                };
+                visited.insert(target);
+                explanation.nodes.push(MemoryNode {
+                    id: target,
+                    content,
+                    hop,
+                });
+                next.push(target);
+            }
+            explanation.edges.push(MemoryEdge {
+                from: edge.source(),
+                to: target,
+                relation: edge.label().to_owned(),
+            });
+        }
+        Ok(())
+    }
+}

--- a/crates/velesdb-memory/tests/columnstore_bdd.rs
+++ b/crates/velesdb-memory/tests/columnstore_bdd.rs
@@ -8,12 +8,13 @@ mod common;
 
 use common::{meta, service};
 use serde_json::json;
+use tempfile::TempDir;
+use velesdb_memory::{HashEmbedder, MemoryService};
 
-// --- Nominal: vector + `ColumnStore` -----------------------------------------
-
-#[test]
-fn recall_filters_to_the_matching_metadata() {
-    let (_dir, svc) = service();
+/// Seed one `veles`-project and one `acme`-project "auth bug" fact; returns the
+/// service plus the two ids.
+fn seeded_two_projects() -> (TempDir, MemoryService<HashEmbedder>, u64, u64) {
+    let (dir, svc) = service();
     let veles = svc
         .remember(
             "auth bug in the login flow",
@@ -28,6 +29,14 @@ fn recall_filters_to_the_matching_metadata() {
             Some(&meta(&[("project", json!("acme"))])),
         )
         .expect("remember acme");
+    (dir, svc, veles, other)
+}
+
+// --- Nominal: vector + `ColumnStore` -----------------------------------------
+
+#[test]
+fn recall_filters_to_the_matching_metadata() {
+    let (_dir, svc, veles, other) = seeded_two_projects();
 
     let hits = svc
         .recall(
@@ -49,21 +58,7 @@ fn recall_filters_to_the_matching_metadata() {
 
 #[test]
 fn recall_without_filter_returns_all_projects() {
-    let (_dir, svc) = service();
-    let veles = svc
-        .remember(
-            "auth bug in the login flow",
-            &[],
-            Some(&meta(&[("project", json!("veles"))])),
-        )
-        .expect("remember veles");
-    let other = svc
-        .remember(
-            "auth bug in the login flow too",
-            &[],
-            Some(&meta(&[("project", json!("acme"))])),
-        )
-        .expect("remember acme");
+    let (_dir, svc, veles, other) = seeded_two_projects();
 
     let hits = svc
         .recall("auth bug login", 10, None)

--- a/crates/velesdb-memory/tests/columnstore_bdd.rs
+++ b/crates/velesdb-memory/tests/columnstore_bdd.rs
@@ -1,0 +1,212 @@
+//! BDD integration tests for the **`ColumnStore` facet**: structured metadata on
+//! `remember`, exact-match filtering on `recall`, and the three-engine fusion
+//! (vector + `ColumnStore` + graph) on `why`.
+//!
+//! Categories: Nominal (≥60%), Edge (~20%), Negative (≥20%).
+
+mod common;
+
+use common::{meta, service};
+use serde_json::json;
+
+// --- Nominal: vector + `ColumnStore` -----------------------------------------
+
+#[test]
+fn recall_filters_to_the_matching_metadata() {
+    let (_dir, svc) = service();
+    let veles = svc
+        .remember(
+            "auth bug in the login flow",
+            &[],
+            Some(&meta(&[("project", json!("veles"))])),
+        )
+        .expect("remember veles");
+    let other = svc
+        .remember(
+            "auth bug in the login flow too",
+            &[],
+            Some(&meta(&[("project", json!("acme"))])),
+        )
+        .expect("remember acme");
+
+    let hits = svc
+        .recall(
+            "auth bug login",
+            10,
+            Some(&meta(&[("project", json!("veles"))])),
+        )
+        .expect("recall filtered");
+
+    assert!(
+        hits.iter().any(|h| h.id == veles),
+        "the veles fact passes the filter"
+    );
+    assert!(
+        hits.iter().all(|h| h.id != other),
+        "the acme fact is filtered out"
+    );
+}
+
+#[test]
+fn recall_without_filter_returns_all_projects() {
+    let (_dir, svc) = service();
+    let veles = svc
+        .remember(
+            "auth bug in the login flow",
+            &[],
+            Some(&meta(&[("project", json!("veles"))])),
+        )
+        .expect("remember veles");
+    let other = svc
+        .remember(
+            "auth bug in the login flow too",
+            &[],
+            Some(&meta(&[("project", json!("acme"))])),
+        )
+        .expect("remember acme");
+
+    let hits = svc
+        .recall("auth bug login", 10, None)
+        .expect("recall unfiltered");
+
+    let ids: Vec<u64> = hits.iter().map(|h| h.id).collect();
+    assert!(
+        ids.contains(&veles) && ids.contains(&other),
+        "no filter returns both projects"
+    );
+}
+
+#[test]
+fn recall_filters_on_multiple_fields() {
+    let (_dir, svc) = service();
+    let target = svc
+        .remember(
+            "deadlock under contention",
+            &[],
+            Some(&meta(&[
+                ("project", json!("veles")),
+                ("status", json!("resolved")),
+            ])),
+        )
+        .expect("remember target");
+    let _open = svc
+        .remember(
+            "deadlock under contention again",
+            &[],
+            Some(&meta(&[
+                ("project", json!("veles")),
+                ("status", json!("open")),
+            ])),
+        )
+        .expect("remember open");
+
+    let hits = svc
+        .recall(
+            "deadlock contention",
+            10,
+            Some(&meta(&[
+                ("project", json!("veles")),
+                ("status", json!("resolved")),
+            ])),
+        )
+        .expect("recall");
+
+    assert_eq!(
+        hits.len(),
+        1,
+        "only the resolved veles fact matches both fields"
+    );
+    assert_eq!(hits[0].id, target);
+}
+
+// --- Headline: vector + `ColumnStore` + graph fused on `why` -----------------
+
+#[test]
+fn why_fuses_vector_columnstore_and_graph() {
+    let (_dir, svc) = service();
+    // Two near-identical decision chains in different projects.
+    let dec_a = svc
+        .remember(
+            "we picked tokio for the runtime",
+            &[],
+            Some(&meta(&[("project", json!("A"))])),
+        )
+        .expect("remember dec A");
+    let pr_a = svc
+        .remember(
+            "PR A1 wires up tokio",
+            &[],
+            Some(&meta(&[("project", json!("A"))])),
+        )
+        .expect("remember pr A");
+    svc.relate(dec_a, pr_a, "decided_in").expect("relate A");
+
+    let dec_b = svc
+        .remember(
+            "we picked tokio for the runtime",
+            &[],
+            Some(&meta(&[("project", json!("B"))])),
+        )
+        .expect("remember dec B");
+    let pr_b = svc
+        .remember(
+            "PR B1 wires up tokio",
+            &[],
+            Some(&meta(&[("project", json!("B"))])),
+        )
+        .expect("remember pr B");
+    svc.relate(dec_b, pr_b, "decided_in").expect("relate B");
+
+    // Explain, scoped to project A: the `ColumnStore` filter picks the A seed,
+    // the vector matches the decision text, the graph reaches PR A1.
+    let explanation = svc
+        .why(
+            "we picked tokio",
+            1,
+            Some(&meta(&[("project", json!("A"))])),
+        )
+        .expect("why scoped");
+
+    let ids: Vec<u64> = explanation.nodes.iter().map(|n| n.id).collect();
+    assert!(ids.contains(&pr_a), "graph traversal reaches PR A1");
+    assert!(
+        !ids.contains(&dec_b) && !ids.contains(&pr_b),
+        "project B never leaks in"
+    );
+}
+
+// --- Edge / Negative -------------------------------------------------------
+
+#[test]
+fn filter_excludes_memories_stored_without_metadata() {
+    let (_dir, svc) = service();
+    let bare = svc
+        .remember("a fact with no metadata", &[], None)
+        .expect("remember bare");
+
+    let hits = svc
+        .recall("a fact", 10, Some(&meta(&[("project", json!("veles"))])))
+        .expect("recall filtered");
+
+    assert!(
+        hits.iter().all(|h| h.id != bare),
+        "a non-empty filter excludes metadata-less facts"
+    );
+}
+
+#[test]
+fn filter_with_no_match_returns_empty() {
+    let (_dir, svc) = service();
+    svc.remember("auth bug", &[], Some(&meta(&[("project", json!("veles"))])))
+        .expect("remember");
+
+    let hits = svc
+        .recall(
+            "auth bug",
+            10,
+            Some(&meta(&[("project", json!("nonexistent"))])),
+        )
+        .expect("recall");
+
+    assert!(hits.is_empty(), "no fact matches the filter");
+}

--- a/crates/velesdb-memory/tests/common/mod.rs
+++ b/crates/velesdb-memory/tests/common/mod.rs
@@ -1,0 +1,29 @@
+//! Shared helpers for the `velesdb-memory` integration tests.
+//!
+//! Uses the deterministic, network-free `HashEmbedder` so every suite is fully
+//! reproducible and air-gapped (mirrors the repo's `fake_embed` examples).
+#![allow(dead_code)] // Each test binary uses a different subset of these helpers.
+
+use serde_json::Value;
+use tempfile::TempDir;
+use velesdb_memory::{HashEmbedder, MemoryService, Metadata};
+
+/// Embedding dimension matching the SDK's `DEFAULT_DIMENSION`.
+pub const DIM: usize = 384;
+
+/// Open a fresh, isolated memory service backed by a tempdir.
+///
+/// The returned [`TempDir`] must be kept alive for the duration of the test.
+pub fn service() -> (TempDir, MemoryService<HashEmbedder>) {
+    let dir = TempDir::new().expect("create tempdir");
+    let svc = MemoryService::open(dir.path(), HashEmbedder::new(DIM)).expect("open memory store");
+    (dir, svc)
+}
+
+/// Build a [`Metadata`] map from key/value pairs.
+pub fn meta(pairs: &[(&str, Value)]) -> Metadata {
+    pairs
+        .iter()
+        .map(|(k, v)| ((*k).to_owned(), v.clone()))
+        .collect()
+}

--- a/crates/velesdb-memory/tests/memory_service_bdd.rs
+++ b/crates/velesdb-memory/tests/memory_service_bdd.rs
@@ -1,0 +1,153 @@
+//! BDD integration tests for the `remember / recall / relate / forget`
+//! operations of the memory service domain core.
+//!
+//! Categories: Nominal (≥60%), Edge (~20%), Negative (≥20%).
+
+mod common;
+
+use common::service;
+use velesdb_memory::{Link, MemoryError};
+
+// --- Nominal ---------------------------------------------------------------
+
+#[test]
+fn remember_then_recall_returns_the_fact() {
+    let (_dir, svc) = service();
+    let fact = "we chose parking_lot to avoid lock poisoning";
+    let id = svc.remember(fact, &[], None).expect("remember");
+
+    let hits = svc
+        .recall("parking_lot lock poisoning", 5, None)
+        .expect("recall");
+
+    assert!(
+        hits.iter().any(|h| h.id == id),
+        "recalled set should contain the stored fact"
+    );
+}
+
+#[test]
+fn remember_is_idempotent_on_identical_content() {
+    let (_dir, svc) = service();
+    let fact = "VelesDB ships as a single binary";
+    let first = svc.remember(fact, &[], None).expect("first remember");
+    let second = svc.remember(fact, &[], None).expect("second remember");
+
+    assert_eq!(
+        first, second,
+        "identical content must yield the same stable id"
+    );
+}
+
+#[test]
+fn remember_with_links_creates_edges_without_error() {
+    let (_dir, svc) = service();
+    let pr = svc
+        .remember("PR #42 introduces parking_lot", &[], None)
+        .expect("remember target");
+    let decision = svc
+        .remember(
+            "we chose parking_lot to avoid lock poisoning",
+            &[Link {
+                target: pr,
+                relation: "decided_in".to_owned(),
+            }],
+            None,
+        )
+        .expect("remember with link");
+
+    assert_ne!(decision, pr, "distinct facts must have distinct ids");
+}
+
+// --- Edge ------------------------------------------------------------------
+
+#[test]
+fn relate_two_existing_memories_returns_edge_id() {
+    let (_dir, svc) = service();
+    let a = svc
+        .remember("ticket EPIC-317 tracks the lock rework", &[], None)
+        .expect("remember a");
+    let b = svc
+        .remember("benchmark shows no contention regression", &[], None)
+        .expect("remember b");
+
+    let edge = svc.relate(a, b, "references").expect("relate");
+
+    // Edge id is an opaque handle; we only assert the call succeeded and is usable.
+    let _ = edge;
+}
+
+#[test]
+fn forget_removes_the_fact_from_recall() {
+    let (_dir, svc) = service();
+    let id = svc
+        .remember("ephemeral scratch note about France", &[], None)
+        .expect("remember");
+    svc.forget(id).expect("forget");
+
+    let hits = svc.recall("France", 5, None).expect("recall after forget");
+
+    assert!(
+        !hits.iter().any(|h| h.id == id),
+        "forgotten fact must not be recalled"
+    );
+}
+
+// --- Negative --------------------------------------------------------------
+
+#[test]
+fn recall_on_empty_store_is_empty() {
+    let (_dir, svc) = service();
+
+    let hits = svc
+        .recall("anything at all", 10, None)
+        .expect("recall on empty store");
+
+    assert!(hits.is_empty(), "fresh store has nothing to recall");
+}
+
+#[test]
+fn remember_rejects_empty_fact() {
+    let (_dir, svc) = service();
+
+    let err = svc
+        .remember("   ", &[], None)
+        .expect_err("empty fact must be rejected");
+
+    assert!(matches!(err, MemoryError::EmptyFact));
+}
+
+#[test]
+fn remember_with_unknown_link_target_errors_and_stores_nothing() {
+    let (_dir, svc) = service();
+
+    let err = svc
+        .remember(
+            "a decision",
+            &[Link {
+                target: 999,
+                relation: "x".to_owned(),
+            }],
+            None,
+        )
+        .expect_err("unknown link target must error");
+    assert!(matches!(err, MemoryError::UnknownLinkTarget(999)));
+
+    // The fact must not have been persisted (no partial write).
+    let hits = svc.recall("a decision", 5, None).expect("recall");
+    assert!(
+        hits.is_empty(),
+        "a failed link must not leave the fact half-written"
+    );
+}
+
+#[test]
+fn recall_with_empty_query_returns_empty() {
+    let (_dir, svc) = service();
+    svc.remember("some stored fact", &[], None)
+        .expect("remember");
+
+    let hits = svc.recall("   ", 5, None).expect("recall with blank query");
+
+    assert!(hits.is_empty(), "a blank query recalls nothing");
+}

--- a/crates/velesdb-memory/tests/why_bdd.rs
+++ b/crates/velesdb-memory/tests/why_bdd.rs
@@ -1,0 +1,209 @@
+//! BDD integration tests for `why` — the multi-hop explanation path.
+//!
+//! This is the differentiator: `why` returns the *connected subgraph* behind a
+//! decision, surfacing related memories a purely vector recall is blind to.
+//!
+//! Categories: Nominal (≥60%), Edge (~20%), Negative (≥20%).
+
+mod common;
+
+use common::service;
+use tempfile::TempDir;
+use velesdb_memory::{HashEmbedder, Link, MemoryService};
+
+const DECISION: &str = "we chose parking_lot to avoid lock poisoning";
+
+/// Build the canonical chain: decision -[`decided_in`]-> PR -[`tracked_by`]-> ticket.
+/// The ticket wording is deliberately dissimilar to the decision text so that
+/// only the graph (not vector similarity) can reach it.
+fn seeded_chain() -> (TempDir, MemoryService<HashEmbedder>, u64, u64, u64) {
+    let (dir, svc) = service();
+    let decision = svc
+        .remember(DECISION, &[], None)
+        .expect("remember decision");
+    let pr = svc
+        .remember("PR #42 swaps the mutex implementation", &[], None)
+        .expect("remember pr");
+    let ticket = svc
+        .remember("EPIC-317 xyzzy quux frobnicate", &[], None)
+        .expect("remember ticket");
+    svc.relate(decision, pr, "decided_in")
+        .expect("relate decision->pr");
+    svc.relate(pr, ticket, "tracked_by")
+        .expect("relate pr->ticket");
+    (dir, svc, decision, pr, ticket)
+}
+
+// --- Nominal ---------------------------------------------------------------
+
+#[test]
+fn why_returns_the_full_connected_subgraph() {
+    let (_dir, svc, decision, pr, ticket) = seeded_chain();
+
+    let explanation = svc.why(DECISION, 2, None).expect("why");
+
+    let ids: Vec<u64> = explanation.nodes.iter().map(|n| n.id).collect();
+    assert!(
+        ids.contains(&decision),
+        "subgraph must contain the decision"
+    );
+    assert!(ids.contains(&pr), "subgraph must contain the linked PR");
+    assert!(
+        ids.contains(&ticket),
+        "subgraph must contain the 2-hop ticket"
+    );
+    assert_eq!(
+        explanation.edges.len(),
+        2,
+        "two typed edges connect the chain"
+    );
+}
+
+#[test]
+fn why_assigns_hop_distances_from_the_seed() {
+    let (_dir, svc, decision, pr, ticket) = seeded_chain();
+
+    let explanation = svc.why(DECISION, 2, None).expect("why");
+    let hop = |id: u64| explanation.nodes.iter().find(|n| n.id == id).map(|n| n.hop);
+
+    assert_eq!(hop(decision), Some(0), "seed is hop 0");
+    assert_eq!(hop(pr), Some(1), "PR is one hop away");
+    assert_eq!(hop(ticket), Some(2), "ticket is two hops away");
+}
+
+#[test]
+fn why_reaches_what_vector_recall_alone_misses() {
+    let (_dir, svc, _decision, _pr, ticket) = seeded_chain();
+
+    // The best single semantic match for the decision is NOT the ticket:
+    // their wording shares no tokens.
+    let top = svc.recall(DECISION, 1, None).expect("recall");
+    assert!(
+        top.iter().all(|h| h.id != ticket),
+        "vector recall alone misses the ticket"
+    );
+
+    // The graph traversal reaches it anyway.
+    let explanation = svc.why(DECISION, 2, None).expect("why");
+    assert!(
+        explanation.nodes.iter().any(|n| n.id == ticket),
+        "the graph surfaces the connected ticket the vector is blind to"
+    );
+}
+
+// --- Edge ------------------------------------------------------------------
+
+#[test]
+fn why_with_zero_hops_returns_only_the_seed() {
+    let (_dir, svc, decision, _pr, _ticket) = seeded_chain();
+
+    let explanation = svc.why(DECISION, 0, None).expect("why");
+
+    assert_eq!(explanation.nodes.len(), 1, "no traversal at zero hops");
+    assert_eq!(explanation.nodes[0].id, decision);
+    assert!(explanation.edges.is_empty(), "no edges at zero hops");
+}
+
+#[test]
+fn why_stops_at_the_hop_budget() {
+    let (_dir, svc, decision, pr, ticket) = seeded_chain();
+
+    let explanation = svc.why(DECISION, 1, None).expect("why");
+    let ids: Vec<u64> = explanation.nodes.iter().map(|n| n.id).collect();
+
+    assert!(
+        ids.contains(&decision) && ids.contains(&pr),
+        "one hop reaches the PR"
+    );
+    assert!(
+        !ids.contains(&ticket),
+        "one hop must not reach the two-hop ticket"
+    );
+}
+
+#[test]
+fn why_on_isolated_memory_returns_just_that_memory() {
+    let (_dir, svc) = service();
+    let lone = svc
+        .remember("a fact with no relations", &[], None)
+        .expect("remember");
+
+    let explanation = svc.why("a fact with no relations", 3, None).expect("why");
+
+    assert_eq!(explanation.nodes.len(), 1);
+    assert_eq!(explanation.nodes[0].id, lone);
+    assert!(explanation.edges.is_empty());
+}
+
+// --- Negative --------------------------------------------------------------
+
+#[test]
+fn why_on_empty_store_is_empty() {
+    let (_dir, svc) = service();
+
+    let explanation = svc.why("anything", 3, None).expect("why on empty store");
+
+    assert!(explanation.nodes.is_empty(), "no seed, no explanation");
+    assert!(explanation.edges.is_empty());
+}
+
+#[test]
+fn why_via_links_argument_builds_the_same_graph() {
+    // `remember(fact, links)` must produce edges traversable by `why`,
+    // equivalent to explicit `relate` calls.
+    let (_dir, svc) = service();
+    let pr = svc
+        .remember("PR #99 refactors the lock layer", &[], None)
+        .expect("remember pr");
+    let decision = svc
+        .remember(
+            DECISION,
+            &[Link {
+                target: pr,
+                relation: "decided_in".to_owned(),
+            }],
+            None,
+        )
+        .expect("remember decision with link");
+
+    let explanation = svc.why(DECISION, 1, None).expect("why");
+    let ids: Vec<u64> = explanation.nodes.iter().map(|n| n.id).collect();
+
+    assert!(
+        ids.contains(&decision) && ids.contains(&pr),
+        "link arg is traversable by why"
+    );
+}
+
+#[test]
+fn why_drops_edges_to_forgotten_targets() {
+    let (_dir, svc) = service();
+    let decision = svc
+        .remember(DECISION, &[], None)
+        .expect("remember decision");
+    let pr = svc
+        .remember("PR #7 implements the change", &[], None)
+        .expect("remember pr");
+    svc.relate(decision, pr, "decided_in").expect("relate");
+    svc.forget(pr).expect("forget pr");
+
+    let explanation = svc.why(DECISION, 2, None).expect("why");
+
+    let node_ids: std::collections::HashSet<u64> = explanation.nodes.iter().map(|n| n.id).collect();
+    assert!(!node_ids.contains(&pr), "forgotten target is not a node");
+    for edge in &explanation.edges {
+        assert!(
+            node_ids.contains(&edge.from) && node_ids.contains(&edge.to),
+            "every edge endpoint must be a node — no dangling edge to the forgotten target"
+        );
+    }
+}
+
+#[test]
+fn why_on_blank_decision_is_empty() {
+    let (_dir, svc, _decision, _pr, _ticket) = seeded_chain();
+
+    let explanation = svc.why("   ", 2, None).expect("why on blank decision");
+
+    assert!(explanation.nodes.is_empty() && explanation.edges.is_empty());
+}

--- a/crates/velesdb-memory/tests/why_bdd.rs
+++ b/crates/velesdb-memory/tests/why_bdd.rs
@@ -34,6 +34,16 @@ fn seeded_chain() -> (TempDir, MemoryService<HashEmbedder>, u64, u64, u64) {
     (dir, svc, decision, pr, ticket)
 }
 
+/// Node ids of the subgraph `why(DECISION, hops)` returns.
+fn why_ids(svc: &MemoryService<HashEmbedder>, hops: usize) -> Vec<u64> {
+    svc.why(DECISION, hops, None)
+        .expect("why")
+        .nodes
+        .iter()
+        .map(|n| n.id)
+        .collect()
+}
+
 // --- Nominal ---------------------------------------------------------------
 
 #[test]
@@ -108,8 +118,7 @@ fn why_with_zero_hops_returns_only_the_seed() {
 fn why_stops_at_the_hop_budget() {
     let (_dir, svc, decision, pr, ticket) = seeded_chain();
 
-    let explanation = svc.why(DECISION, 1, None).expect("why");
-    let ids: Vec<u64> = explanation.nodes.iter().map(|n| n.id).collect();
+    let ids = why_ids(&svc, 1);
 
     assert!(
         ids.contains(&decision) && ids.contains(&pr),
@@ -166,8 +175,7 @@ fn why_via_links_argument_builds_the_same_graph() {
         )
         .expect("remember decision with link");
 
-    let explanation = svc.why(DECISION, 1, None).expect("why");
-    let ids: Vec<u64> = explanation.nodes.iter().map(|n| n.id).collect();
+    let ids = why_ids(&svc, 1);
 
     assert!(
         ids.contains(&decision) && ids.contains(&pr),

--- a/deny.toml
+++ b/deny.toml
@@ -115,6 +115,11 @@ name = "velesdb-python"
 expression = "LicenseRef-ELv2"
 license-files = []
 
+[[licenses.clarify]]
+name = "velesdb-memory"
+expression = "LicenseRef-ELv2"
+license-files = []
+
 
 [bans]
 multiple-versions = "warn"


### PR DESCRIPTION
## What

A new workspace crate **`velesdb-memory`**: a local-first **MCP server** that gives AI agents durable memory, as a thin Rust-native wrapper over `velesdb-core`'s in-core Agent Memory SDK. Single offline binary (stdio); the store never leaves the machine.

## Why

Makes VelesDB usable as **"the memory layer for AI agents"** from any MCP client (Claude Code, Cursor, Cline, Zed…) without exposing the raw database — the differentiator being `why`, which returns a *connected subgraph* a plain similarity search can't.

## Surface (memory-semantics only)

Five MCP tools mapped onto the three engines:

| Tool | Engine(s) |
|------|-----------|
| `remember(fact, links?, metadata?)` | Vector + Graph + **ColumnStore** |
| `recall(query, limit?, filter?)` | Vector + **ColumnStore** |
| `relate(from, to, type)` | Graph |
| `forget(id)` | — |
| `why(decision, max_hops?, filter?)` | **Vector + ColumnStore + Graph fused** |

No raw `query/storage/graph` is exposed — this keeps community/embedded use inside the **VelesDB Core License 1.0** boundary (no "Substantial Set" of DB capabilities). The MCP wrapper source is permissively licensed; the distributed binary embeds the core and stays under Core License 1.0.

## Design

- **Rust-native** `rmcp` server linked directly to `velesdb-core` (zero IPC, one ~binary, offline-first) rather than a TS server over REST.
- Pluggable `Embedder` trait; default `HashEmbedder` is deterministic and network-free (production plugs an on-device model, e.g. fastembed/all-MiniLM-L6-v2, 384-dim).
- Domain core (`service.rs`) kept separate from the wire DTOs (`mcp.rs`).

## Hardening (from review)

- `remember` validates link targets **before** any write (no half-written fact) and rejects empty facts.
- `why` never emits an edge to a node absent from the subgraph (forgotten targets dropped).
- Blank `recall`/`why` queries short-circuit instead of a degenerate zero-vector search.

## Testing

- **31 tests** (Nominal/Edge/Negative BDD across `memory_service`, `why`, `columnstore`, and MCP-server suites), incl. the three-engine fusion test and the "graph reaches what vector misses" differentiator test.
- `cargo clippy -- -D warnings -D clippy::pedantic` clean, `cargo fmt --check` clean, `cargo-deny` (licenses/advisories/bans) clean.
- End-to-end verified: real MCP stdio handshake, `tools/list`, and `tools/call` against the built binary.