### PR TITLE
chore(release): make velesdb-memory release-ready (crates.io + binary)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -185,12 +185,12 @@ jobs:
         run: cargo install cargo-deb --locked
 
       - name: Build
-        run: cargo build --release --target ${{ matrix.target }} -p velesdb-cli -p velesdb-server -p velesdb-migrate
+        run: cargo build --release --target ${{ matrix.target }} -p velesdb-cli -p velesdb-server -p velesdb-migrate -p velesdb-memory
 
       - name: Package (Unix)
         if: runner.os != 'Windows'
         run: |
-          mkdir dist && cp target/${{ matrix.target }}/release/velesdb target/${{ matrix.target }}/release/velesdb-server target/${{ matrix.target }}/release/velesdb-migrate dist/ 2>/dev/null || true
+          mkdir dist && cp target/${{ matrix.target }}/release/velesdb target/${{ matrix.target }}/release/velesdb-server target/${{ matrix.target }}/release/velesdb-migrate target/${{ matrix.target }}/release/velesdb-memory dist/ 2>/dev/null || true
           cp README.md LICENSE dist/
           tar -czvf velesdb-${{ matrix.target }}.${{ matrix.ext }} -C dist .
 
@@ -228,7 +228,8 @@ jobs:
       (github.event_name == 'push' || inputs.publish_crates)
     environment: crates-io
     env:
-      CRATES_TO_PUBLISH: "velesdb-core velesdb-server velesdb-cli velesdb-migrate velesdb-mobile tauri-plugin-velesdb"
+      # velesdb-memory is last: it depends on velesdb-core, which is published first.
+      CRATES_TO_PUBLISH: "velesdb-core velesdb-server velesdb-cli velesdb-migrate velesdb-mobile tauri-plugin-velesdb velesdb-memory"
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dtolnay/rust-toolchain@stable # Intentionally unpinned - uses toolchain input

--- a/README.md
+++ b/README.md
@@ -605,6 +605,7 @@ cd examples/ecommerce_recommendation && cargo run --release
 | Demo | Description | Tech |
 |------|-------------|------|
 | [ecommerce_recommendation](examples/ecommerce_recommendation/) | Vector + Graph + ColumnStore (5K products) | Rust |
+| [velesdb-memory](crates/velesdb-memory/) | MCP memory server — the graph answers *why* a decision was made | Rust |
 | [rag-pdf-demo](demos/rag-pdf-demo/) | PDF document Q&A with RAG | Python, FastAPI |
 | [tauri-rag-app](demos/tauri-rag-app/) | Desktop RAG application | Tauri v2, React |
 | [wasm-browser-demo](examples/wasm-browser-demo/) | In-browser vector search | WASM, vanilla JS |

--- a/crates/velesdb-memory/Cargo.toml
+++ b/crates/velesdb-memory/Cargo.toml
@@ -10,6 +10,8 @@ documentation.workspace = true
 authors.workspace = true
 description = "VelesDB-memory: local-first MCP memory server for AI agents (remember/recall/relate/forget/why)."
 readme = "README.md"
+keywords = ["mcp", "agent-memory", "local-first", "knowledge-graph", "ai"]
+categories = ["database", "command-line-utilities"]
 
 [dependencies]
 velesdb-core = { workspace = true, features = ["persistence"] }

--- a/crates/velesdb-memory/README.md
+++ b/crates/velesdb-memory/README.md
@@ -26,7 +26,7 @@ capabilities (`query`, `create_collection`, `upsert`, `traverse`). See
 
 ## See it (offline, one command)
 
-![velesdb-memory wow demo: a vector recall misses the 2-hop ticket; why() reaches it through the graph](media/wow.gif)
+![velesdb-memory wow demo: a vector recall misses the 2-hop ticket; why() reaches it through the graph](https://raw.githubusercontent.com/cyberlife-coder/VelesDB/develop/crates/velesdb-memory/media/wow.gif)
 
 ```bash
 cargo run -p velesdb-memory --example wow_offline


### PR DESCRIPTION
Wires the merged `velesdb-memory` MCP server into the release pipeline so it can
ship like its peers. **No publish happens from this PR** — `release.yml` only
runs on a `v*` tag or manual dispatch with `publish_crates`, both of which need
the maintainer's crates.io token.

## Changes
- **release.yml**
  - `CRATES_TO_PUBLISH` += `velesdb-memory` (appended last; it depends on
    `velesdb-core`, which is published first in the ordered job).
  - Release binary build + Unix packaging now include the `velesdb-memory`
    binary → `cargo install velesdb-memory` and a prebuilt binary in GitHub
    Releases.
- **crates/velesdb-memory/Cargo.toml** — `keywords` (`mcp`, `agent-memory`,
  `local-first`, `knowledge-graph`, `ai`) + `categories` (`database`,
  `command-line-utilities`) for crates.io discovery.
- **crate README** — absolute raw URL for the wow gif so it renders on crates.io.
- **root README** — `velesdb-memory` row under Demos & Examples.

## Verified
`cargo metadata` parses the new keywords/categories; crate builds clean;
`release.yml` is valid YAML. Publish dry-run is deferred to the release job
(velesdb-core must be on crates.io first — same chicken-and-egg the workflow
already documents for the other dependent crates).

## Maintainer follow-up (needs your access)
1. Tag a release (`vX.Y.Z`) or dispatch `release.yml` with `publish_crates=true`
   + crates.io token → `velesdb-memory` lands on crates.io.
2. Submit to MCP registries (official registry, Smithery, Glama, awesome-mcp).