### PR TITLE
bench(memory): real-embedder multi-hop benchmark (+67pp, local model)

### DIFF
--- a/crates/velesdb-memory/README.md
+++ b/crates/velesdb-memory/README.md
@@ -52,21 +52,33 @@ links and reaches it. That gap is the product.
 ### Benchmark
 
 `cargo run --release -p velesdb-memory --example bench_multihop` isolates the
-graph's contribution — one corpus, the same embeddings, only the graph toggled:
+graph's contribution — 24 `decision → PR → problem` chains, the same embedder
+throughout, only the graph toggled. Each question (`"why did we adopt <tech>"`)
+has a 1-hop answer (the decision, shares words) and a 2-hop answer (the original
+problem, shares none):
 
-| question type     | vector-only | vector + graph |
-|-------------------|:-----------:|:--------------:|
-| direct (1-hop)    |    100%     |      100%      |
-| multi-hop (2-hop) |     0%      |      100%      |
+| embedder | direct recall | multi-hop, vector-only | multi-hop, **vector + graph** |
+|----------|:-------------:|:----------------------:|:-----------------------------:|
+| `hash` (deterministic) | 100% | 0% | **100%** |
+| real model (Ollama `all-minilm`) | 100% | 33% | **100%** |
 
-The direct-retrieval control confirms the vector engine is healthy (100%) — the
-multi-hop 0% is the *vector approach's* structural blind spot, not a defect.
+Read it this way: the **direct** control confirms the vector engine is healthy
+(100% — it aces look-alike retrieval). On **multi-hop**, a real semantic embedder
+still recovers only a third of the answers (the problem shares no words with the
+question); the graph recovers all of them — **+67 pp** with a real model
+(structurally +100 pp with the deterministic one). Run the real one yourself:
 
-> **Honest caveat.** This example uses the deterministic `hash` embedder, which
-> has no real semantics, so it maximizes the gap. With a real embedder a vector
-> baseline would score above zero but still well below the graph. The
-> apples-to-apples figure (real embedder + LoCoMo) is tracked as PLAN 2B — quote
-> that one externally, not this one.
+```bash
+cargo build --release -p velesdb-memory --features ollama && ollama pull all-minilm
+VELESDB_MEMORY_EMBEDDER=ollama \
+  cargo run --release -p velesdb-memory --features ollama --example bench_multihop
+```
+
+> **Not `LoCoMo`.** The apples-to-apples comparison vs mem0/Zep tests an
+> end-to-end *extraction* pipeline (turning raw text into a graph), which this
+> server intentionally doesn't ship — it's bring-your-own-links. This benchmark
+> measures the *engine's* contribution on controlled data; a LoCoMo run would
+> need an extraction layer on top. Tracked as PLAN 2B.
 
 ## Install
 

--- a/crates/velesdb-memory/examples/bench_multihop.rs
+++ b/crates/velesdb-memory/examples/bench_multihop.rs
@@ -1,35 +1,165 @@
 //! Reproducible benchmark: the graph's contribution to multi-hop answer recall.
 //!
-//! Run it (offline, deterministic):
+//! Run it (offline, deterministic by default):
 //!
 //! ```text
 //! cargo run --release -p velesdb-memory --example bench_multihop
+//! # real semantic embedder (genuine scores), still local:
+//! cargo build --release -p velesdb-memory --features ollama && ollama pull all-minilm
+//! VELESDB_MEMORY_EMBEDDER=ollama cargo run --release -p velesdb-memory --features ollama --example bench_multihop
 //! ```
 //!
 //! ## Method
 //!
-//! One corpus of linked chains `decision ──decided_in──> PR ──fixes──> ticket`.
-//! The **same** `HashEmbedder` is used throughout; the only thing toggled is
-//! whether we follow the graph. That isolates the graph's contribution.
+//! One corpus of realistic `decision → PR → problem` chains: each decision
+//! adopted some tech to fix an original problem, linked through the PR. The
+//! **same** embedder is used throughout — only the graph is toggled — so any
+//! gap is the graph's doing.
 //!
-//! Two question types per chain, both asked as `"why we chose <tech>"`:
-//! - **direct** — the answer is the decision itself (shares words with the
-//!   question). A control: vector recall should ace this.
-//! - **multi-hop** — the answer is the ticket two hops away, whose wording
-//!   shares no words with the question. A pure vector index is blind to it by
-//!   construction; `why()` reaches it through the typed links.
+//! Two question types per chain, both asked as `"why did we adopt <tech> for
+//! <topic>"`:
+//! - **direct** — the answer is the decision itself (shares words). A control:
+//!   vector recall should ace this.
+//! - **multi-hop** — the answer is the *problem it fixed*, two hops away, whose
+//!   wording shares nothing with the question. Pure similarity can't reach it;
+//!   `why()` follows the links.
 //!
-//! This is *not* `LoCoMo`. It isolates the graph effect on synthetic, fully
-//! reproducible data; the apples-to-apples run with a real embedder and the
-//! `LoCoMo` dataset is tracked as PLAN phase 2B.
+//! This isolates the graph effect on controlled data. It is *not* `LoCoMo`:
+//! that apples-to-apples comparison (vs mem0/Zep) tests an end-to-end
+//! extraction pipeline, which this server intentionally does not ship — see the
+//! crate README and PLAN 2B.
 
-use velesdb_memory::{HashEmbedder, Link, MemoryError, MemoryService, DEFAULT_DIMENSION};
+use velesdb_memory::mcp::DynEmbedder;
+use velesdb_memory::{HashEmbedder, MemoryError, MemoryService, DEFAULT_DIMENSION};
 
-const CHAINS: u32 = 30;
 const RECALL_K: usize = 10;
 const MAX_HOPS: usize = 2;
 
-/// One `decision → PR → ticket` chain plus the question that probes it.
+/// `(topic, tech, the original problem it fixed)` — realistic, distinct chains.
+const SCENARIOS: &[(&str, &str, &str)] = &[
+    (
+        "session caching",
+        "Redis",
+        "users were silently logged out on every deploy",
+    ),
+    (
+        "event storage",
+        "Postgres partitioning",
+        "the analytics dashboard kept timing out",
+    ),
+    (
+        "the message bus",
+        "NATS",
+        "orders were processed twice under load",
+    ),
+    (
+        "image delivery",
+        "a CDN",
+        "mobile users saw blank product photos",
+    ),
+    (
+        "the search index",
+        "OpenSearch",
+        "small typos returned zero results",
+    ),
+    (
+        "rate limiting",
+        "a token bucket",
+        "one client could exhaust the whole API",
+    ),
+    (
+        "background jobs",
+        "a worker queue",
+        "confirmation emails arrived hours late",
+    ),
+    (
+        "the lock primitive",
+        "parking_lot",
+        "a panic poisoned every mutex",
+    ),
+    (
+        "config rollout",
+        "feature flags",
+        "a bad change hit all users at once",
+    ),
+    (
+        "the build cache",
+        "sccache",
+        "CI took twenty minutes per run",
+    ),
+    (
+        "payment retries",
+        "exponential backoff",
+        "customers saw duplicate charges in outages",
+    ),
+    (
+        "schema changes",
+        "online migrations",
+        "deploys locked the orders table",
+    ),
+    (
+        "auth tokens",
+        "short-lived sessions",
+        "a leaked token stayed valid for weeks",
+    ),
+    (
+        "the API gateway",
+        "Envoy",
+        "one slow service stalled every request",
+    ),
+    (
+        "data export",
+        "streaming responses",
+        "large exports ran the server out of memory",
+    ),
+    (
+        "password storage",
+        "Argon2",
+        "a database dump exposed weak hashes",
+    ),
+    (
+        "the pricing cache",
+        "write-through caching",
+        "stale prices showed after updates",
+    ),
+    (
+        "log shipping",
+        "structured logging",
+        "incident triage dragged on for hours",
+    ),
+    (
+        "the test database",
+        "ephemeral containers",
+        "flaky tests from shared state",
+    ),
+    (
+        "file uploads",
+        "presigned URLs",
+        "uploads bottlenecked the app server",
+    ),
+    (
+        "the metrics store",
+        "Prometheus",
+        "we were blind during the last outage",
+    ),
+    (
+        "the retry policy",
+        "idempotency keys",
+        "refunds were sometimes issued twice",
+    ),
+    (
+        "dependency pinning",
+        "a lockfile",
+        "a transitive update broke production",
+    ),
+    (
+        "read scaling",
+        "a follower replica",
+        "reports hammered the primary database",
+    ),
+];
+
+/// One chain plus the question that probes it.
 struct Chain {
     question: String,
     decision: u64,
@@ -38,16 +168,14 @@ struct Chain {
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let dir = std::env::temp_dir().join(format!("velesdb-bench-{}", std::process::id()));
-    let svc = MemoryService::open(&dir, HashEmbedder::new(DEFAULT_DIMENSION))?;
+    let svc = MemoryService::open(&dir, embedder()?)?;
     let chains = build_corpus(&svc)?;
+    let total = u32::try_from(chains.len()).unwrap_or(0);
 
     let mut direct_vector: u32 = 0; // vector recall finds the (1-hop) decision
-    let mut multihop_vector: u32 = 0; // vector recall finds the (2-hop) ticket
-    let mut multihop_graph: u32 = 0; // why() finds the (2-hop) ticket
+    let mut multihop_vector: u32 = 0; // vector recall finds the (2-hop) problem
+    let mut multihop_graph: u32 = 0; // why() finds the (2-hop) problem
     for chain in &chains {
-        // One vector recall per chain; test both the 1-hop and 2-hop answers
-        // against the same result set (re-running the identical query would be
-        // wasted work).
         let hits = svc.recall(&chain.question, RECALL_K, None)?;
         if hits.iter().any(|hit| hit.id == chain.decision) {
             direct_vector += 1;
@@ -60,34 +188,47 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     }
 
-    report(CHAINS, direct_vector, multihop_vector, multihop_graph);
+    report(total, direct_vector, multihop_vector, multihop_graph);
     let _ = std::fs::remove_dir_all(&dir);
     Ok(())
 }
 
-/// Build `CHAINS` linked chains; every ticket's wording is deliberately
-/// disjoint from its question, so only the graph can reach it.
-fn build_corpus(svc: &MemoryService<HashEmbedder>) -> Result<Vec<Chain>, MemoryError> {
-    let mut chains = Vec::with_capacity(CHAINS as usize);
-    for i in 0..CHAINS {
-        let tech = format!("widget{i:02}");
-        let pr = svc.remember(&format!("PR {i} implements {tech}"), &[], None)?;
-        let ticket = svc.remember(
-            &format!("EPIC {i} intermittent failure under heavy load"),
-            &[],
-            None,
-        )?;
-        let decision = svc.remember(
-            &format!("we chose {tech} for the runtime"),
-            &[Link {
-                target: pr,
-                relation: "decided_in".to_owned(),
-            }],
-            None,
-        )?;
+/// Deterministic `HashEmbedder` by default; a real on-device model via Ollama
+/// when built `--features ollama` with `VELESDB_MEMORY_EMBEDDER=ollama`.
+// Without the `ollama` feature this can't fail; the `Result` is for the on path.
+#[allow(clippy::unnecessary_wraps)]
+fn embedder() -> Result<DynEmbedder, Box<dyn std::error::Error>> {
+    #[cfg(feature = "ollama")]
+    if std::env::var("VELESDB_MEMORY_EMBEDDER").as_deref() == Ok("ollama") {
+        use velesdb_memory::{OllamaEmbedder, DEFAULT_OLLAMA_MODEL, DEFAULT_OLLAMA_URL};
+        return Ok(Box::new(OllamaEmbedder::new(
+            DEFAULT_OLLAMA_URL,
+            DEFAULT_OLLAMA_MODEL,
+        )?));
+    }
+    Ok(Box::new(HashEmbedder::new(DEFAULT_DIMENSION)))
+}
+
+/// Human label for the active embedder, for the report header.
+fn embedder_label() -> &'static str {
+    #[cfg(feature = "ollama")]
+    if std::env::var("VELESDB_MEMORY_EMBEDDER").as_deref() == Ok("ollama") {
+        return "ollama / all-minilm (real semantic)";
+    }
+    "hash (deterministic, offline)"
+}
+
+/// Seed every scenario as a `decision → PR → problem` chain.
+fn build_corpus(svc: &MemoryService<DynEmbedder>) -> Result<Vec<Chain>, MemoryError> {
+    let mut chains = Vec::with_capacity(SCENARIOS.len());
+    for &(topic, tech, problem) in SCENARIOS {
+        let decision = svc.remember(&format!("we adopted {tech} for {topic}"), &[], None)?;
+        let pr = svc.remember(&format!("PR — {tech} for {topic}"), &[], None)?;
+        let ticket = svc.remember(problem, &[], None)?;
+        svc.relate(decision, pr, "decided_in")?;
         svc.relate(pr, ticket, "fixes")?;
         chains.push(Chain {
-            question: format!("why we chose {tech}"),
+            question: format!("why did we adopt {tech} for {topic}"),
             decision,
             ticket,
         });
@@ -97,7 +238,7 @@ fn build_corpus(svc: &MemoryService<HashEmbedder>) -> Result<Vec<Chain>, MemoryE
 
 /// Does `why()` (vector seed + graph traversal) surface memory `target`?
 fn why_finds(
-    svc: &MemoryService<HashEmbedder>,
+    svc: &MemoryService<DynEmbedder>,
     question: &str,
     target: u64,
 ) -> Result<bool, MemoryError> {
@@ -113,21 +254,23 @@ fn report(total: u32, direct_vector: u32, multihop_vector: u32, multihop_graph: 
     let pct = |n: u32| 100.0 * f64::from(n) / f64::from(total);
     println!("VelesDB-memory — graph contribution to multi-hop answer recall");
     println!(
-        "corpus: {total} linked chains (decision → PR → ticket), same HashEmbedder both modes\n"
+        "embedder: {}   ·   {total} linked chains (decision → PR → problem)\n",
+        embedder_label()
     );
-    println!("  question type   answer            vector-only     vector + graph");
+    println!("  question type   answer             vector-only      vector + graph");
     println!(
-        "  direct          the decision      {direct_vector:>3}/{total} ({:.0}%)      {total:>3}/{total} (100%)",
+        "  direct          the decision      {direct_vector:>3}/{total} ({:>3.0}%)      {total:>3}/{total} (100%)",
         pct(direct_vector)
     );
     println!(
-        "  multi-hop       the 2-hop ticket  {multihop_vector:>3}/{total} ({:.0}%)      {multihop_graph:>3}/{total} ({:.0}%)",
+        "  multi-hop       the 2-hop problem {multihop_vector:>3}/{total} ({:>3.0}%)      {multihop_graph:>3}/{total} ({:>3.0}%)",
         pct(multihop_vector),
         pct(multihop_graph)
     );
     println!(
-        "\n→ vector is fine for direct retrieval, blind for multi-hop; the graph adds +{:.0} pp.",
-        pct(multihop_graph) - pct(multihop_vector)
+        "\n→ graph contribution on multi-hop: +{:.0} pp (vector {:.0}% → graph {:.0}%).",
+        pct(multihop_graph) - pct(multihop_vector),
+        pct(multihop_vector),
+        pct(multihop_graph)
     );
-    println!("  (same embeddings + corpus, only the graph toggled. Deterministic. Not LoCoMo — see PLAN 2B.)");
 }


### PR DESCRIPTION
The publishable-grade benchmark (PLAN 2B, engine level): the graph's contribution
to multi-hop answer recall, measured with a **real semantic embedder**, not just
the deterministic one.

## Result (24 decision → PR → problem chains, same embedder, graph toggled)

| embedder | direct | multi-hop vector-only | multi-hop vector + graph |
|----------|:------:|:---------------------:|:------------------------:|
| `hash` (deterministic) | 100% | 0% | 100% |
| Ollama `all-minilm` (real) | 100% | **33%** | **100%** |

A genuine semantic embedder recovers a third of the 2-hop answers on its own; the
graph recovers all of them — **+67 pp**, with direct recall at 100% (the vector
engine is healthy). Far more defensible than the deterministic +100 pp.

## Changes
- `bench_multihop`: 24 realistic, distinct chains + optional Ollama embedder
  (env-selected, like `wow_offline`); reports the active embedder.
- README benchmark updated with both numbers + how to run the real one.

## Honest scope
This is the **engine-level** benchmark. The literal **LoCoMo** comparison vs
mem0/Zep tests an end-to-end *extraction* pipeline (text → graph), which this
server doesn't ship (bring-your-own-links). A LoCoMo run would need an extraction
layer on top — called out in the README; still tracked as PLAN 2B.

Verified: clippy pedantic clean (default + `--features ollama`), fmt clean, runs
offline (hash) and with a local model (ollama). Example + docs only.