### PR TITLE
docs(memory): document Codex CLI and opencode MCP setup

### DIFF
--- a/crates/velesdb-memory/README.md
+++ b/crates/velesdb-memory/README.md
@@ -123,6 +123,33 @@ claude mcp add velesdb-memory \
 } } }
 ```
 
+**Codex CLI** — `codex mcp add`, or a `[mcp_servers.*]` table in `~/.codex/config.toml`
+
+```bash
+codex mcp add velesdb-memory \
+  --env VELESDB_MEMORY_PATH="$HOME/.velesdb-memory" \
+  -- /path/to/velesdb-memory
+```
+
+```toml
+# equivalent ~/.codex/config.toml entry
+[mcp_servers.velesdb-memory]
+command = "/path/to/velesdb-memory"
+args = []
+env = { VELESDB_MEMORY_PATH = "/home/you/.velesdb-memory" }
+```
+
+**opencode** — `opencode.json` (per project) or `~/.config/opencode/opencode.json` (global)
+
+```json
+{ "mcp": { "velesdb-memory": {
+  "type": "local",
+  "command": ["/path/to/velesdb-memory"],
+  "enabled": true,
+  "environment": { "VELESDB_MEMORY_PATH": "/home/you/.velesdb-memory" }
+} } }
+```
+
 ## Using the tools
 
 Once configured, your agent discovers the five tools automatically (via MCP


### PR DESCRIPTION
## What

Adds **Codex CLI** and **opencode** to the "Configure your client" section of `crates/velesdb-memory/README.md`, alongside the existing Claude Code / Cursor / Cline / Zed entries.

These are the two extra MCP clients the maintainer runs locally; every supported client now has a copy-pasteable stdio config.

## Details

- **Codex** — `codex mcp add` helper (most reliable path) plus the equivalent `[mcp_servers.velesdb-memory]` table in `~/.codex/config.toml`.
- **opencode** — `opencode.json` `mcp` block (`type: local`, `command` array, `environment`).

Formats verified against the official docs: [opencode MCP](https://opencode.ai/docs/mcp-servers) and [Codex MCP](https://developers.openai.com/codex/mcp).

## Scope

Docs-only. No code changes.