### PR TITLE
chore(memory): decouple to 0.1.0 for independent crates.io release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -228,8 +228,10 @@ jobs:
       (github.event_name == 'push' || inputs.publish_crates)
     environment: crates-io
     env:
-      # velesdb-memory is last: it depends on velesdb-core, which is published first.
-      CRATES_TO_PUBLISH: "velesdb-core velesdb-server velesdb-cli velesdb-migrate velesdb-mobile tauri-plugin-velesdb velesdb-memory"
+      # velesdb-memory is intentionally absent: it is versioned independently
+      # (0.x) and published on its own cadence via `cargo publish -p
+      # velesdb-memory`, so it does not ride the workspace 3.x release tag.
+      CRATES_TO_PUBLISH: "velesdb-core velesdb-server velesdb-cli velesdb-migrate velesdb-mobile tauri-plugin-velesdb"
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dtolnay/rust-toolchain@stable # Intentionally unpinned - uses toolchain input

--- a/crates/velesdb-memory/Cargo.toml
+++ b/crates/velesdb-memory/Cargo.toml
@@ -1,6 +1,8 @@
 [package]
 name = "velesdb-memory"
-version.workspace = true
+# Independent of the workspace version: velesdb-memory is a young MCP wrapper
+# with its own release cadence, decoupled from the core engine's 3.x line.
+version = "0.1.0"
 edition.workspace = true
 rust-version.workspace = true
 license-file = "../../LICENSE"
@@ -12,6 +14,9 @@ description = "VelesDB-memory: local-first MCP memory server for AI agents (reme
 readme = "README.md"
 keywords = ["mcp", "agent-memory", "local-first", "knowledge-graph", "ai"]
 categories = ["database", "command-line-utilities"]
+# The demo gif is served from the repo via raw.githubusercontent in the README;
+# shipping it in the .crate would only add dead weight to every download.
+exclude = ["media/"]
 
 [dependencies]
 velesdb-core = { workspace = true, features = ["persistence"] }


### PR DESCRIPTION
## Why

velesdb-memory is ready for its **first crates.io publish**, but the workspace is at 3.3.0 (already published for velesdb-core). Riding the workspace version would (a) imply the young MCP wrapper is as mature as the core engine, and (b) force a full workspace re-release just to ship it. So we decouple it.

## Changes

- **`crates/velesdb-memory/Cargo.toml`**: `version.workspace = true` → `version = "0.1.0"`.
- **`.github/workflows/release.yml`**: remove velesdb-memory from `CRATES_TO_PUBLISH`. It is now published on its own cadence via `cargo publish -p velesdb-memory`, so it no longer rides the workspace `v3.x` tag (which would also break the post-publish version-verify step, since that expects every listed crate at the tag version). The binary is still built and attached to GH releases.
- **`exclude = ["media/"]`**: the 490K demo gif is served from the repo via raw.githubusercontent in the README; bundling it only bloats every `.crate` download.

## Verification

`cargo publish --dry-run -p velesdb-memory` → packages cleanly (0 media files), compiles `velesdb-memory v0.1.0` against the published `velesdb-core v3.3.0`, upload simulated OK.

## Publish step (maintainer)

After merge, from a logged-in checkout (`cargo login`):

```bash
cargo publish -p velesdb-memory
```

No tag needed — decoupled from the workspace release.