### PR TITLE
fix(memory): validate relate endpoints — bad id is invalid_params, not internal_error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6668,7 +6668,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-memory"
-version = "3.3.0"
+version = "0.1.0"
 dependencies = [
  "rmcp",
  "schemars 1.2.1",

--- a/crates/velesdb-memory/src/error.rs
+++ b/crates/velesdb-memory/src/error.rs
@@ -20,9 +20,10 @@ pub enum MemoryError {
     #[error("fact text must not be empty")]
     EmptyFact,
 
-    /// A `remember` link referenced a memory id that does not exist.
-    #[error("link target {0} does not exist")]
-    UnknownLinkTarget(u64),
+    /// A `remember` link or a `relate` endpoint referenced a memory id that
+    /// does not exist.
+    #[error("memory {0} does not exist")]
+    UnknownMemory(u64),
 
     /// Failure producing a text embedding.
     #[error("embedding error: {0}")]

--- a/crates/velesdb-memory/src/mcp.rs
+++ b/crates/velesdb-memory/src/mcp.rs
@@ -246,7 +246,7 @@ impl ServerHandler for McpServer {
 
 /// Map a domain error to an MCP error.
 ///
-/// Client-input errors (`EmptyFact`, `UnknownLinkTarget`) become
+/// Client-input errors (`EmptyFact`, `UnknownMemory`) become
 /// `invalid_params` (-32602) so callers can distinguish bad input from a
 /// server fault without parsing the message string. Everything else is
 /// `internal_error` (-32603).
@@ -257,7 +257,7 @@ impl ServerHandler for McpServer {
 fn to_error(err: crate::error::MemoryError) -> ErrorData {
     use crate::error::MemoryError;
     let code = match &err {
-        MemoryError::EmptyFact | MemoryError::UnknownLinkTarget(_) => ErrorCode::INVALID_PARAMS,
+        MemoryError::EmptyFact | MemoryError::UnknownMemory(_) => ErrorCode::INVALID_PARAMS,
         _ => ErrorCode::INTERNAL_ERROR,
     };
     ErrorData::new(code, err.to_string(), None)
@@ -480,7 +480,38 @@ mod tests {
         assert_eq!(
             err.code,
             ErrorCode::INVALID_PARAMS,
-            "UnknownLinkTarget must map to invalid_params"
+            "UnknownMemory must map to invalid_params"
+        );
+    }
+
+    #[tokio::test]
+    async fn relate_to_unknown_endpoint_returns_invalid_params_not_internal_error() {
+        let (_dir, srv) = server();
+        let Json(stored) = srv
+            .remember(Parameters(RememberParams {
+                fact: "an existing memory".to_owned(),
+                links: Vec::new(),
+                metadata: None,
+            }))
+            .await
+            .expect("remember");
+
+        // Relating an existing memory to a non-existent one is bad client input,
+        // not a server fault — the agent must see invalid_params so it can fix
+        // the id rather than retry a phantom internal error.
+        let err = srv
+            .relate(Parameters(RelateParams {
+                from: stored.id,
+                to: 9_999_999,
+                relation: "references".to_owned(),
+            }))
+            .await
+            .map(|_| ())
+            .expect_err("relate to a missing endpoint must be rejected");
+        assert_eq!(
+            err.code,
+            ErrorCode::INVALID_PARAMS,
+            "relate to an unknown endpoint must map to invalid_params"
         );
     }
 

--- a/crates/velesdb-memory/src/service.rs
+++ b/crates/velesdb-memory/src/service.rs
@@ -104,7 +104,7 @@ impl<E: Embedder> MemoryService<E> {
     ///
     /// # Errors
     /// Returns [`MemoryError::EmptyFact`] for empty/whitespace facts,
-    /// [`MemoryError::UnknownLinkTarget`] if a link points at a missing memory,
+    /// [`MemoryError::UnknownMemory`] if a link points at a missing memory,
     /// or a storage error if persistence fails.
     pub fn remember(
         &self,
@@ -128,12 +128,18 @@ impl<E: Embedder> MemoryService<E> {
         Ok(fact_id)
     }
 
+    /// Fail with [`MemoryError::UnknownMemory`] unless memory `id` exists.
+    fn ensure_exists(&self, id: u64) -> Result<(), MemoryError> {
+        if self.memory.semantic().get(id)?.is_none() {
+            return Err(MemoryError::UnknownMemory(id));
+        }
+        Ok(())
+    }
+
     /// Fail unless every link target already exists (keeps `remember` atomic).
     fn ensure_link_targets_exist(&self, links: &[Link]) -> Result<(), MemoryError> {
         for link in links {
-            if self.memory.semantic().get(link.target)?.is_none() {
-                return Err(MemoryError::UnknownLinkTarget(link.target));
-            }
+            self.ensure_exists(link.target)?;
         }
         Ok(())
     }
@@ -211,9 +217,17 @@ impl<E: Embedder> MemoryService<E> {
 
     /// Create a typed edge `from -> to`. Returns the edge id.
     ///
+    /// Both endpoints are validated to exist first, so the tool reports an
+    /// unknown id as client input (`UnknownMemory`) rather than a generic
+    /// storage fault — and the graph never gains an edge dangling off a memory
+    /// that was never stored.
+    ///
     /// # Errors
-    /// Returns [`MemoryError`] if the edge cannot be created.
+    /// Returns [`MemoryError::UnknownMemory`] if either endpoint is missing, or
+    /// a storage error if the edge cannot be created.
     pub fn relate(&self, from: u64, to: u64, relation: &str) -> Result<u64, MemoryError> {
+        self.ensure_exists(from)?;
+        self.ensure_exists(to)?;
         self.memory
             .semantic()
             .relate(from, to, relation, None)

--- a/crates/velesdb-memory/tests/memory_service_bdd.rs
+++ b/crates/velesdb-memory/tests/memory_service_bdd.rs
@@ -78,6 +78,26 @@ fn relate_two_existing_memories_returns_edge_id() {
 }
 
 #[test]
+fn relate_with_unknown_endpoint_errors_without_creating_a_dangling_edge() {
+    let (_dir, svc) = service();
+    let real = svc
+        .remember("ticket EPIC-317 tracks the lock rework", &[], None)
+        .expect("remember real");
+
+    // Either endpoint missing must be rejected as client input, not silently
+    // create an edge dangling off a memory that was never stored.
+    let bad_target = svc
+        .relate(real, 999, "references")
+        .expect_err("relate to a missing target must error");
+    assert!(matches!(bad_target, MemoryError::UnknownMemory(999)));
+
+    let bad_source = svc
+        .relate(999, real, "references")
+        .expect_err("relate from a missing source must error");
+    assert!(matches!(bad_source, MemoryError::UnknownMemory(999)));
+}
+
+#[test]
 fn forget_removes_the_fact_from_recall() {
     let (_dir, svc) = service();
     let id = svc
@@ -131,7 +151,7 @@ fn remember_with_unknown_link_target_errors_and_stores_nothing() {
             None,
         )
         .expect_err("unknown link target must error");
-    assert!(matches!(err, MemoryError::UnknownLinkTarget(999)));
+    assert!(matches!(err, MemoryError::UnknownMemory(999)));
 
     // The fact must not have been persisted (no partial write).
     let hits = svc.recall("a decision", 5, None).expect("recall");


### PR DESCRIPTION
## What

The standalone `relate` tool passed unknown ids straight to the core engine. A missing endpoint surfaced as a generic storage error → mapped to `internal_error`, misleading an MCP client into treating its **own bad input** as a server fault. `remember`'s link path already validates targets up front; `relate` now mirrors it.

## Changes

- `MemoryService::ensure_exists` helper; `relate` checks both endpoints → a missing id returns the typed `UnknownMemory` error (→ `invalid_params`), and the graph never gains an edge dangling off an unstored memory.
- Rename `UnknownLinkTarget` → `UnknownMemory` (the variant now covers both `remember`-links and `relate`-endpoints; pre-publish, no external users).
- Regression coverage at both the service (BDD) and MCP layers.

## Why now

Part of hardening `velesdb-memory` before the 0.1.0 crates.io publish. For an MCP tool consumed by LLM agents, `invalid_params` vs `internal_error` is the difference between "fix your id" and "retry a phantom fault."

## Verification

`cargo fmt --check`, `cargo clippy --all-targets --all-features` (clean), `cargo test --all-features` — 45 tests pass (+2 new).