### PR TITLE
ci(memory): independent release pipeline on a velesdb-memory-vX.Y.Z tag

### DIFF
--- a/.github/workflows/release-memory.yml
+++ b/.github/workflows/release-memory.yml
@@ -1,0 +1,169 @@
+# Independent release pipeline for the `velesdb-memory` crate.
+#
+# velesdb-memory is versioned on its own 0.x cadence (decoupled from the
+# workspace 3.x line), so it does NOT ride the workspace `vX.Y.Z` tag handled by
+# release.yml. It ships on its own tag instead:
+#
+#     velesdb-memory-vX.Y.Z          (e.g. velesdb-memory-v0.1.0)
+#     velesdb-memory-vX.Y.Z-<pre>    (prerelease; crates.io publish skipped)
+#
+# The tag version must match `crates/velesdb-memory/Cargo.toml` exactly. The
+# crate depends on velesdb-core ^3.3.0, which is already on crates.io, so the
+# package is dry-run validated up front (unlike workspace dependents, which
+# cannot be dry-run before core is published).
+name: Release velesdb-memory
+
+on:
+  push:
+    tags:
+      - 'velesdb-memory-v[0-9]+.[0-9]+.[0-9]+'
+      - 'velesdb-memory-v[0-9]+.[0-9]+.[0-9]+-*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'velesdb-memory version to release (e.g. 0.1.0)'
+        required: true
+        type: string
+      publish_crate:
+        description: 'Publish to crates.io'
+        type: boolean
+        default: true
+
+concurrency:
+  group: release-memory-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  checks: read
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+  RUST_VERSION: '1.89'
+
+jobs:
+  # ===========================================================================
+  # 1. Validate the tag against the crate's own version + packaging
+  # ===========================================================================
+  validate:
+    name: Validate
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      is_prerelease: ${{ steps.version.outputs.is_prerelease }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          shared-key: "release-memory"
+
+      - name: Extract version
+        id: version
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            VERSION="$INPUT_VERSION"
+          else
+            # Tag form: refs/tags/velesdb-memory-vX.Y.Z[-pre]
+            VERSION=${GITHUB_REF#refs/tags/velesdb-memory-v}
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          [[ "$VERSION" == *"-"* ]] && echo "is_prerelease=true" >> "$GITHUB_OUTPUT" || echo "is_prerelease=false" >> "$GITHUB_OUTPUT"
+          echo "Version: $VERSION"
+
+      - name: Verify tag matches crate version
+        env:
+          TAG_VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          CRATE_VERSION=$(python - <<'PY'
+          import tomllib
+          with open('crates/velesdb-memory/Cargo.toml', 'rb') as f:
+              data = tomllib.load(f)
+          print(data['package']['version'])
+          PY
+          )
+          if [ "$CRATE_VERSION" != "$TAG_VERSION" ]; then
+            echo "::error::Tag version ($TAG_VERSION) does not match crates/velesdb-memory/Cargo.toml ($CRATE_VERSION). Bump the crate version and re-tag."
+            exit 1
+          fi
+          echo "✅ velesdb-memory version: $CRATE_VERSION"
+
+      - name: Verify CI passed on tagged commit (REL-06)
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          SHA="${{ github.sha }}"
+          echo "Checking CI status for commit $SHA..."
+          RESULT=$(gh api "repos/${{ github.repository }}/commits/$SHA/check-runs?per_page=100" --paginate \
+            --jq '[.check_runs[] | select(.name == "CI Success")] | first')
+          if [ -z "$RESULT" ] || [ "$RESULT" = "null" ]; then
+            echo "::error::No CI workflow found for commit $SHA. Push to main/develop first to trigger CI, then tag."
+            exit 1
+          fi
+          STATUS=$(echo "$RESULT" | jq -r '.status // empty')
+          CONCLUSION=$(echo "$RESULT" | jq -r '.conclusion // empty')
+          if [ "$STATUS" != "completed" ]; then
+            echo "::error::CI is still running ($STATUS) on commit $SHA. Wait for CI to complete before tagging."
+            exit 1
+          fi
+          if [ "$CONCLUSION" != "success" ]; then
+            echo "::error::CI failed ($CONCLUSION) on commit $SHA. Fix CI before releasing."
+            exit 1
+          fi
+          echo "✅ CI passed on commit $SHA"
+
+      - name: Validate packaging (dry-run)
+        run: |
+          # velesdb-core ^3.3.0 is already on crates.io, so the dependent
+          # velesdb-memory can be fully dry-run packaged here.
+          echo "📦 Dry-run packaging velesdb-memory..."
+          cargo publish --dry-run --locked -p velesdb-memory
+          echo "✅ velesdb-memory packaging validated"
+
+  # ===========================================================================
+  # 2. Publish to crates.io
+  # ===========================================================================
+  publish-crate:
+    name: Publish crates.io
+    runs-on: ubuntu-latest
+    needs: validate
+    if: |
+      needs.validate.outputs.is_prerelease == 'false' &&
+      (github.event_name == 'push' || inputs.publish_crate)
+    environment: crates-io
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          shared-key: "release-memory"
+
+      - name: Publish velesdb-memory
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: |
+          set -euo pipefail
+          echo "📦 Publishing velesdb-memory..."
+          for attempt in 1 2 3; do
+            if cargo publish --locked -p velesdb-memory; then
+              echo "✅ Published velesdb-memory"
+              exit 0
+            fi
+            echo "⚠️ Publish failed (attempt $attempt/3), retrying in 15s..."
+            sleep 15
+          done
+          echo "❌ Failed to publish velesdb-memory after 3 attempts"
+          exit 1
+
+      - name: Verify crates.io version
+        run: |
+          chmod +x scripts/check-crates-io-versions.sh
+          scripts/check-crates-io-versions.sh "${{ needs.validate.outputs.version }}" velesdb-memory

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -229,8 +229,8 @@ jobs:
     environment: crates-io
     env:
       # velesdb-memory is intentionally absent: it is versioned independently
-      # (0.x) and published on its own cadence via `cargo publish -p
-      # velesdb-memory`, so it does not ride the workspace 3.x release tag.
+      # (0.x) and ships on its own `velesdb-memory-vX.Y.Z` tag via
+      # release-memory.yml, so it does not ride the workspace 3.x release tag.
       CRATES_TO_PUBLISH: "velesdb-core velesdb-server velesdb-cli velesdb-migrate velesdb-mobile tauri-plugin-velesdb"
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/crates/velesdb-memory/CHANGELOG.md
+++ b/crates/velesdb-memory/CHANGELOG.md
@@ -1,0 +1,30 @@
+# Changelog — velesdb-memory
+
+All notable changes to the `velesdb-memory` crate are documented here. This
+crate is versioned independently of the VelesDB workspace (0.x cadence) and is
+released on its own `velesdb-memory-vX.Y.Z` tag.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - Unreleased
+
+First release of the local-first MCP memory server for AI agents.
+
+### Added
+- Five MCP tools over stdio mapping onto VelesDB's in-core Agent Memory SDK:
+  `remember`, `recall`, `relate`, `forget`, and `why` (vector recall + multi-hop
+  graph traversal — the connected-subgraph differentiator).
+- Pluggable embeddings: a deterministic, offline `HashEmbedder` by default and an
+  optional on-device `OllamaEmbedder` (`--features ollama`).
+- Structured metadata (ColumnStore facet) with exact-match filtering on `recall`
+  and `why`.
+- Input guards (max fact size, capped recall limit and hop depth) and clean
+  MCP error-code mapping: client-input errors map to `invalid_params`, faults to
+  `internal_error`. `relate` validates both endpoints exist up front, so an
+  unknown id is reported as `invalid_params` (not an internal fault) and the
+  graph never gains an edge dangling off an unstored memory.
+- License boundary by construction: memory semantics only, never raw database
+  capabilities.
+
+[0.1.0]: https://github.com/cyberlife-coder/VelesDB/releases/tag/velesdb-memory-v0.1.0

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -97,8 +97,11 @@ update_cargo_versions() {
     sed -i "s/^version = \".*\"/version = \"$new_version\"/" Cargo.toml
     
     # Mettre à jour les versions dans les crates
+    # velesdb-memory est exclu : il est versionné indépendamment (0.x) et publié
+    # via son propre tag velesdb-memory-vX.Y.Z (release-memory.yml), il ne doit
+    # pas être aligné sur la version 3.x du workspace.
     for cargo_file in crates/*/Cargo.toml; do
-        if [ -f "$cargo_file" ]; then
+        if [ -f "$cargo_file" ] && [ "$cargo_file" != "crates/velesdb-memory/Cargo.toml" ]; then
             sed -i "s/^version = \".*\"/version = \"$new_version\"/" "$cargo_file"
         fi
     done


### PR DESCRIPTION
## Why

`velesdb-memory` is versioned on its own 0.x cadence and was deliberately removed from the workspace publish set (#1235/#1236) — but **nothing actually ships it**. "Publish at the release tag" had no trigger: `release.yml` is hard-wired to a `vX.Y.Z` tag whose `validate` step asserts the tag equals the workspace version (3.3.0), so a 0.1.0 release can't ride it.

This wires the missing path.

## What

- **`release-memory.yml`** — new workflow triggered by `velesdb-memory-vX.Y.Z` tags (+ `workflow_dispatch`). It:
  - extracts the version from the tag and asserts it matches `crates/velesdb-memory/Cargo.toml` (not the workspace);
  - reuses the **REL-06** "CI passed on tagged commit" guard;
  - **dry-run packages** the crate up front — valid here because `velesdb-core ^3.3.0` is already on crates.io (unlike workspace dependents at release time);
  - publishes to crates.io with the same 3-attempt retry and `check-crates-io-versions.sh` verify as the workspace pipeline;
  - drops the gtk/glib apt deps the memory crate doesn't need.
- **`release.yml`** — comment now points at the new tag path instead of "manual `cargo publish`".
- **`CHANGELOG.md`** — the crate had no release-notes anchor; added one (Keep a Changelog).
- **`scripts/release.sh`** — exclude `velesdb-memory` from the bulk version `sed` so a manual workspace bump can't clobber its decoupled 0.1.0.

## Release procedure (after merge)

```
git tag velesdb-memory-v0.1.0 <commit-on-develop-or-main>
git push origin velesdb-memory-v0.1.0
```

Requires the `CARGO_REGISTRY_TOKEN` secret + `crates-io` environment (already used by `release.yml`).

## Verification

Both workflow files validated (YAML parses). The publish/validate steps mirror the proven `release.yml` patterns. No code paths changed.