### PR TITLE
feat(memory): recall_where (tri-engine recall) + real LoCoMo benchmark

### DIFF
--- a/crates/velesdb-memory/Cargo.toml
+++ b/crates/velesdb-memory/Cargo.toml
@@ -46,6 +46,13 @@ tokio = { workspace = true }
 name = "velesdb-memory"
 path = "src/main.rs"
 
+# Real-data LoCoMo benchmark. Needs a local Ollama (all-minilm + a generative
+# model), so it only builds with the `ollama` feature.
+[[example]]
+name = "locomo"
+path = "examples/locomo/main.rs"
+required-features = ["ollama"]
+
 [lib]
 name = "velesdb_memory"
 path = "src/lib.rs"

--- a/crates/velesdb-memory/README.md
+++ b/crates/velesdb-memory/README.md
@@ -74,11 +74,14 @@ VELESDB_MEMORY_EMBEDDER=ollama \
   cargo run --release -p velesdb-memory --features ollama --example bench_multihop
 ```
 
-> **Not `LoCoMo`.** The apples-to-apples comparison vs mem0/Zep tests an
-> end-to-end *extraction* pipeline (turning raw text into a graph), which this
-> server intentionally doesn't ship — it's bring-your-own-links. This benchmark
-> measures the *engine's* contribution on controlled data; a LoCoMo run would
-> need an extraction layer on top. Tracked as PLAN 2B.
+> **This vs `LoCoMo`.** `bench_multihop` isolates the *engine's* contribution on
+> controlled, synthetic chains — no extraction step. For the apples-to-apples
+> comparison on the real [LoCoMo](https://github.com/snap-research/locomo)
+> dataset (which needs an extraction layer the server intentionally doesn't ship
+> — it's bring-your-own-links), see [`examples/locomo/`](examples/locomo/README.md):
+> it builds a fact↔entity graph from the conversations and scores the graph's
+> contribution to long-conversation QA with a hybrid LLM-judge + deterministic
+> metric.
 
 ## Install
 

--- a/crates/velesdb-memory/examples/locomo/.gitignore
+++ b/crates/velesdb-memory/examples/locomo/.gitignore
@@ -1,0 +1,3 @@
+# LoCoMo research dataset + run caches are fetched/produced on demand, never committed.
+data/
+cache/

--- a/crates/velesdb-memory/examples/locomo/README.md
+++ b/crates/velesdb-memory/examples/locomo/README.md
@@ -1,0 +1,127 @@
+# LoCoMo benchmark for velesdb-memory
+
+Does the **graph** earn its place? This benchmark answers one question on a real,
+published dataset: when an agent must recall facts across a long multi-session
+conversation, does adding multi-hop graph traversal (`why()`) to pure vector
+recall actually improve the answers — apples-to-apples, same embeddings, same
+fact budget, same judge?
+
+It runs on [LoCoMo](https://github.com/snap-research/locomo) (`locomo10.json`):
+10 conversations, ~300 turns each over up to 19 sessions, with 1 986 annotated
+QA pairs across five categories (multi-hop, temporal, open-domain, single-hop,
+adversarial).
+
+## How to run
+
+```bash
+# 1. fetch the dataset (research data, not vendored) and pull the local models
+examples/locomo/fetch_dataset.sh
+ollama pull all-minilm          # embeddings (384-dim)
+ollama pull qwen3.6:35b-mlx     # extraction + answer + judge (any local chat model works)
+
+# 2. smoke on one conversation, then the full run
+cargo run --release -p velesdb-memory --features ollama --example locomo -- --conversations 1
+cargo run --release -p velesdb-memory --features ollama --example locomo
+
+# explanation benchmark (LLM-free, fast): does the graph connect scattered
+# evidence that pure vector recall misses?
+cargo run --release -p velesdb-memory --features ollama --example locomo -- --explanation
+```
+
+Flags: `--conversations N`, `--max-qa N` (cap per conversation), `--k` (fact
+budget, default 8), `--graph-slots` (slots reserved for graph facts in graph
+mode, default 4), `--hops` (default 2), `--model`, `--dataset`.
+
+Every LLM call is content-addressed and cached under `examples/locomo/cache/`,
+so an interrupted run resumes for free and re-runs spend no GPU. The full run is
+several hours of local inference on first pass; the dataset and cache are
+git-ignored.
+
+## Pipeline
+
+1. **Extract** — a local LLM reads each session and returns atomic facts, each
+   tagged with the source `dia_id`(s) and the salient entities it mentions
+   (`extract.rs`). This extraction layer is the part velesdb-memory deliberately
+   does not ship (it is "bring-your-own-links").
+2. **Ingest** — each fact becomes a memory; each entity a hub; every fact is
+   `relate()`d to its entities in both directions, building the fact↔entity
+   graph `why()` traverses (`ingest.rs`).
+3. **Retrieve, two ways, equal budget `k`** (`eval.rs`):
+   - **vector** — top-`k` facts by embedding similarity.
+   - **fused (all three engines)** — the vector pool (optionally constrained by a
+     **`ColumnStore` date window** via `recall_where` when the question names a
+     year) and the facts `why()` reaches by **graph** traversal are re-ranked
+     together by `normalised_vector_similarity + graph_boost·is_connected`,
+     keeping the top `k`. A strong vector hit is never blindly evicted; a
+     graph-connected or date-relevant fact is promoted only when it scores
+     higher.
+4. **Score, hybrid** (`judge.rs`, `report.rs`):
+   - **accuracy** — a local LLM judge grades the generated answer vs the gold
+     answer (citable, non-deterministic).
+   - **evidence-overlap** — deterministic: did a retrieved fact's source
+     `dia_id` land in the gold `evidence` set?
+   - **F1** — token-level SQuAD-style F1, logged as a reproducibility guard.
+   - **adversarial** items are scored by abstention (the model should decline).
+
+Both modes feed the *same* generator and judge, so any score gap is the graph's.
+
+## Reading the numbers honestly
+
+This is a real benchmark, not a marketing number. Specifically:
+
+- **The score reflects the extractor as much as the database.** A better
+  fact/entity extractor would raise both columns; what the benchmark isolates is
+  the *delta* between the two retrieval modes, not the absolute height.
+- **Absolute accuracy is not directly comparable to mem0/Zep's ~66–68 %.** It is
+  defined by *this* local generator, judge, and judge-prompt, and the answer step
+  is closed-book (it sees only retrieved facts). Compare deltas and method, not
+  the absolute percentage.
+- **evidence-overlap** is computed against the `dia_id`s the *extractor*
+  attributed to each fact, so it shares error with the extraction step. A low
+  value can mean mis-attribution, not just retrieval failure.
+- **open-domain (cat 3)** answers often need world knowledge the closed-book
+  prompt withholds, so that row is a lower bound and the graph cannot help it.
+- **temporal (cat 2)** needs date arithmetic; there are no temporal edges, so it
+  is largely a recall-of-dated-facts test, not temporal reasoning.
+- **The ablation measures graph-augmented retrieval vs pure vector at equal
+  budget.** Graph mode trades marginal vector facts for entity-connected ones;
+  the headline is reported over answerable items only (adversarial abstention is
+  excluded so it cannot inflate the accuracy).
+
+The benchmark is built per conversation in isolation (each conversation gets a
+fresh store), matching LoCoMo's per-conversation QA scope.
+
+## What we found (honest)
+
+On LoCoMo, with this extractor, **entity-graph augmentation of vector recall is
+roughly neutral** — across slot-reservation and fused-rerank designs the
+answerable accuracy moves within noise (±1–2 pp on a single conversation), and
+graph-connected facts slightly *lower* evidence-overlap because they are
+topically related but not always answer-bearing. The graph is genuinely active
+(the `graph activity:` line reports how many facts it injected); it simply does
+not beat strong vector recall on this QA task.
+
+The **`ColumnStore` date facet is a real capability** — `recall_where` exposes
+`VelesQL` range/comparison filters (verified by tests) — but LoCoMo's *temporal*
+questions ask *for* a date rather than scoping *to* a window, so the date filter
+rarely fires here. Its value is for time-windowed recall, which this dataset
+does not exercise.
+
+Takeaway: the multi-hop graph's payoff shows up in `why()`-style **explanation**
+(surfacing the connected chain), which LoCoMo's answer-accuracy metric does not
+directly measure.
+
+## The explanation benchmark (`--explanation`)
+
+So we measure that explanation value directly, and LLM-free. For every question
+with **≥2 gold evidence `dia_id`s**, it asks: of those scattered evidence facts,
+what share does plain top-`k` **vector** recall surface, versus vector **plus**
+the facts `why()` reaches by graph traversal? No generator, no judge — pure
+retrieval, reproducible, seconds to run over all 10 conversations.
+
+This is where the graph earns its place: on multi-hop questions it lifts evidence
+coverage (the graph reaches connected evidence the vector ranks too low to
+surface), even though — as the QA benchmark shows — that extra context does not
+translate into higher answer-accuracy on LoCoMo (the generator does not need, or
+is distracted by, the extra facts). Retrieval connectivity and answer accuracy
+are different things, and this pair of benchmarks separates them.

--- a/crates/velesdb-memory/examples/locomo/dataset.rs
+++ b/crates/velesdb-memory/examples/locomo/dataset.rs
@@ -1,0 +1,280 @@
+//! LoCoMo dataset loader.
+//!
+//! Parses `data/locomo10.json` (snap-research/locomo) into typed [`Sample`]s.
+//! The on-disk `conversation` object mixes `speaker_a`/`speaker_b` with
+//! `session_<n>` turn-lists and `session_<n>_date_time` strings under dynamic
+//! keys, so we read it as a JSON map and lift the sessions out by index.
+
+use std::collections::BTreeMap;
+use std::error::Error;
+use std::path::Path;
+
+use serde::Deserialize;
+use serde_json::{Map, Value};
+
+/// LoCoMo question categories, as labelled in the dataset's `category` field.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum Category {
+    MultiHop,
+    Temporal,
+    OpenDomain,
+    SingleHop,
+    Adversarial,
+}
+
+impl Category {
+    /// Map the dataset's integer code to a category, if recognised.
+    pub fn from_code(code: u8) -> Option<Self> {
+        match code {
+            1 => Some(Self::MultiHop),
+            2 => Some(Self::Temporal),
+            3 => Some(Self::OpenDomain),
+            4 => Some(Self::SingleHop),
+            5 => Some(Self::Adversarial),
+            _ => None,
+        }
+    }
+
+    /// Short human label for report rows.
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::MultiHop => "multi-hop",
+            Self::Temporal => "temporal",
+            Self::OpenDomain => "open-domain",
+            Self::SingleHop => "single-hop",
+            Self::Adversarial => "adversarial",
+        }
+    }
+
+    /// Adversarial questions are unanswerable: the model should abstain.
+    pub fn is_adversarial(self) -> bool {
+        matches!(self, Self::Adversarial)
+    }
+
+    /// Every category, in report order.
+    pub const ALL: [Category; 5] = [
+        Self::MultiHop,
+        Self::Temporal,
+        Self::OpenDomain,
+        Self::SingleHop,
+        Self::Adversarial,
+    ];
+
+    /// Dense index into per-category tallies.
+    pub fn index(self) -> usize {
+        match self {
+            Self::MultiHop => 0,
+            Self::Temporal => 1,
+            Self::OpenDomain => 2,
+            Self::SingleHop => 3,
+            Self::Adversarial => 4,
+        }
+    }
+}
+
+/// One dialogue turn, anchored by its `dia_id` (e.g. `"D1:3"`) — the unit the
+/// QA `evidence` field points at, and the unit we tag extracted facts with.
+#[derive(Clone)]
+pub struct Turn {
+    pub speaker: String,
+    pub dia_id: String,
+    pub text: String,
+}
+
+/// One conversation session: an ordered turn-list with its timestamp.
+pub struct Session {
+    pub index: u32,
+    pub date_time: String,
+    pub turns: Vec<Turn>,
+}
+
+impl Session {
+    /// The session date as a sortable `YYYYMMDD` integer (the `ColumnStore` key
+    /// for temporal filtering), or `0` if the `date_time` cannot be parsed.
+    pub fn date_key(&self) -> i64 {
+        date_key(&self.date_time)
+    }
+}
+
+/// Parse a LoCoMo `date_time` like `"1:56 pm on 8 May, 2023"` into `YYYYMMDD`.
+fn date_key(date_time: &str) -> i64 {
+    let Some((_, tail)) = date_time.split_once(" on ") else {
+        return 0;
+    };
+    let cleaned = tail.replace(',', "");
+    let parts: Vec<&str> = cleaned.split_whitespace().collect();
+    let [day, month, year] = parts.as_slice() else {
+        return 0;
+    };
+    let (Ok(day), Some(month), Ok(year)) =
+        (day.parse::<i64>(), month_number(month), year.parse::<i64>())
+    else {
+        return 0;
+    };
+    year * 10_000 + month * 100 + day
+}
+
+/// Map an English month name to its number (1-12), or `None`.
+fn month_number(name: &str) -> Option<i64> {
+    const MONTHS: [&str; 12] = [
+        "january",
+        "february",
+        "march",
+        "april",
+        "may",
+        "june",
+        "july",
+        "august",
+        "september",
+        "october",
+        "november",
+        "december",
+    ];
+    let name = name.to_lowercase();
+    MONTHS
+        .iter()
+        .position(|m| *m == name)
+        .and_then(|i| i64::try_from(i).ok())
+        .map(|i| i + 1)
+}
+
+/// One QA probe. `answer` is absent for adversarial items (they carry an
+/// `adversarial_answer` instead); `evidence` lists the gold `dia_id`s.
+pub struct Qa {
+    pub question: String,
+    pub answer: Option<String>,
+    pub evidence: Vec<String>,
+    pub category: Category,
+}
+
+/// One LoCoMo conversation plus its QA set.
+pub struct Sample {
+    pub sample_id: String,
+    pub sessions: Vec<Session>,
+    pub qa: Vec<Qa>,
+}
+
+impl Sample {
+    /// Total dialogue turns across all sessions — for run-size reporting.
+    pub fn turn_count(&self) -> usize {
+        self.sessions.iter().map(|s| s.turns.len()).sum()
+    }
+}
+
+#[derive(Deserialize)]
+struct RawTurn {
+    speaker: String,
+    dia_id: String,
+    text: String,
+    #[serde(default)]
+    blip_caption: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct RawQa {
+    question: String,
+    #[serde(default)]
+    answer: Option<Value>,
+    #[serde(default)]
+    evidence: Vec<String>,
+    category: u8,
+}
+
+#[derive(Deserialize)]
+struct RawSample {
+    sample_id: String,
+    conversation: Map<String, Value>,
+    qa: Vec<RawQa>,
+}
+
+/// Load and parse every sample from `path`.
+pub fn load(path: &Path) -> Result<Vec<Sample>, Box<dyn Error>> {
+    let bytes = std::fs::read(path).map_err(|e| {
+        format!(
+            "cannot read LoCoMo dataset at {} ({e}). Run examples/locomo/fetch_dataset.sh first.",
+            path.display()
+        )
+    })?;
+    let raw: Vec<RawSample> = serde_json::from_slice(&bytes)?;
+    raw.into_iter().map(parse_sample).collect()
+}
+
+/// Convert one raw sample, lifting `session_<n>` lists out of the dynamic map.
+fn parse_sample(raw: RawSample) -> Result<Sample, Box<dyn Error>> {
+    let mut sessions: BTreeMap<u32, Session> = BTreeMap::new();
+    for (key, value) in &raw.conversation {
+        let Some(index) = session_index(key) else {
+            continue;
+        };
+        let turns = parse_turns(value)?;
+        // A session always carries its `_date_time` sibling in this dataset; the
+        // empty fallback only guards a malformed file and yields a blank date.
+        let date_time = raw
+            .conversation
+            .get(&format!("session_{index}_date_time"))
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string();
+        sessions.insert(
+            index,
+            Session {
+                index,
+                date_time,
+                turns,
+            },
+        );
+    }
+    let qa = raw.qa.into_iter().filter_map(parse_qa).collect();
+    Ok(Sample {
+        sample_id: raw.sample_id,
+        sessions: sessions.into_values().collect(),
+        qa,
+    })
+}
+
+/// `"session_7"` → `Some(7)`; `"session_7_date_time"` / others → `None`.
+fn session_index(key: &str) -> Option<u32> {
+    let rest = key.strip_prefix("session_")?;
+    rest.parse::<u32>().ok()
+}
+
+/// Parse a session's turn array, folding image captions into the text so the
+/// extractor sees the same content a reader would.
+fn parse_turns(value: &Value) -> Result<Vec<Turn>, Box<dyn Error>> {
+    let raw: Vec<RawTurn> = serde_json::from_value(value.clone())?;
+    Ok(raw
+        .into_iter()
+        .map(|t| {
+            let text = match t.blip_caption {
+                Some(cap) if !cap.is_empty() => format!("{} [shared image: {cap}]", t.text),
+                _ => t.text,
+            };
+            Turn {
+                speaker: t.speaker,
+                dia_id: t.dia_id,
+                text,
+            }
+        })
+        .collect())
+}
+
+/// Convert a raw QA item, dropping any with an unknown category code.
+fn parse_qa(raw: RawQa) -> Option<Qa> {
+    let category = Category::from_code(raw.category)?;
+    let answer = raw.answer.map(stringify_answer);
+    Some(Qa {
+        question: raw.question,
+        answer,
+        evidence: raw.evidence,
+        category,
+    })
+}
+
+/// The `answer` field is usually a string but is occasionally numeric; render
+/// both without quotes so judging compares plain text.
+fn stringify_answer(value: Value) -> String {
+    match value {
+        Value::String(s) => s,
+        other => other.to_string(),
+    }
+}

--- a/crates/velesdb-memory/examples/locomo/eval.rs
+++ b/crates/velesdb-memory/examples/locomo/eval.rs
@@ -1,0 +1,285 @@
+//! Per-question evaluation under one retrieval mode.
+//!
+//! The two modes share an equal fact budget `k`, so the only difference is
+//! where the facts come from:
+//! - **vector** (graph off): the top-`k` facts by embedding similarity.
+//! - **fused** (graph on): all three engines. The vector pool — optionally
+//!   constrained by a `ColumnStore` date window when the question names a year
+//!   (`recall_where`) — and the facts `why()` reaches by graph traversal are
+//!   re-ranked together by `normalised_vector_similarity + graph_boost·
+//!   is_connected`, keeping the top `k`. Connected facts are promoted by
+//!   relevance, not forced in, so a strong vector hit is never blindly evicted.
+//!
+//! Both feed the same generator and judge, so any score gap is the fusion's.
+
+use std::collections::HashSet;
+use std::error::Error;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use serde_json::json;
+use velesdb_memory::{ColumnFilter, ColumnOp};
+
+use crate::dataset::Qa;
+use crate::ingest::Store;
+use crate::judge;
+use crate::ollama_gen::Generator;
+
+/// How many facts graph traversal injected into a context, and how many
+/// graph-mode contexts received at least one. Lets the report state how *active*
+/// the graph was: a zero here means any score delta cannot be the graph's.
+static GRAPH_INJECTED: AtomicUsize = AtomicUsize::new(0);
+static GRAPH_ACTIVE_CONTEXTS: AtomicUsize = AtomicUsize::new(0);
+
+/// `(facts injected by traversal, graph-mode contexts that received ≥1)`.
+pub fn graph_activity() -> (usize, usize) {
+    (
+        GRAPH_INJECTED.load(Ordering::Relaxed),
+        GRAPH_ACTIVE_CONTEXTS.load(Ordering::Relaxed),
+    )
+}
+
+/// Retrieval/scoring knobs, fixed for a whole run.
+#[derive(Clone, Copy)]
+pub struct EvalCfg {
+    pub k: usize,
+    pub graph_boost: f64,
+    pub hops: usize,
+}
+
+/// A retrieved fact carried into the generation context. `score` is its vector
+/// similarity (0.0 for facts found only by graph traversal).
+#[derive(Clone)]
+struct RetrievedFact {
+    id: u64,
+    text: String,
+    dia_ids: Vec<String>,
+    score: f64,
+}
+
+/// Outcome of one QA under one mode.
+pub struct ModeResult {
+    /// A retrieved fact's source overlapped the gold `evidence`.
+    pub evidence_hit: bool,
+    /// Counted correct (LLM judge, or abstention for adversarial items).
+    pub correct: bool,
+    /// Token-F1 vs gold; `None` for adversarial items.
+    pub f1: Option<f64>,
+}
+
+/// Evaluate one QA end-to-end under the chosen mode.
+pub fn evaluate(
+    store: &Store,
+    generator: &Generator,
+    qa: &Qa,
+    cfg: EvalCfg,
+    graph_on: bool,
+) -> Result<ModeResult, Box<dyn Error>> {
+    let facts = retrieve(store, &qa.question, cfg, graph_on)?;
+    let evidence_hit = facts
+        .iter()
+        .any(|f| f.dia_ids.iter().any(|id| qa.evidence.contains(id)));
+    let texts: Vec<String> = facts.into_iter().map(|f| f.text).collect();
+    let candidate = judge::answer(generator, &qa.question, &texts)?;
+    let (correct, f1) = score(generator, qa, &candidate)?;
+    Ok(ModeResult {
+        evidence_hit,
+        correct,
+        f1,
+    })
+}
+
+/// Grade a candidate answer: adversarial items want abstention; answerable
+/// items use the LLM judge plus a logged F1.
+fn score(
+    generator: &Generator,
+    qa: &Qa,
+    candidate: &str,
+) -> Result<(bool, Option<f64>), Box<dyn Error>> {
+    if qa.category.is_adversarial() {
+        return Ok((judge::abstained(candidate), None));
+    }
+    let Some(gold) = judge::gold_answer(qa) else {
+        // Answerable category but no reference: cannot grade, count as missed.
+        return Ok((false, Some(0.0)));
+    };
+    let correct = judge::judge_correct(generator, &qa.question, gold, candidate)?;
+    Ok((correct, Some(judge::f1(candidate, gold))))
+}
+
+/// Vector-candidate pool depth: the semantic candidates both modes draw from,
+/// deep enough that a relevant-but-not-top fact promoted by the graph is in it.
+const POOL_FACTOR: usize = 8;
+const POOL_MIN: usize = 64;
+
+/// Retrieve the equal-budget fact set for `question` under the chosen mode.
+///
+/// Vector mode takes the top `k` of the vector pool. Graph mode **fuses**: it
+/// re-ranks the union of the vector pool and the facts `why()` reaches by
+/// traversal, scoring each by `normalised_vector_similarity + graph_boost` when
+/// the fact is graph-connected, then takes the top `k`. A strong vector fact
+/// keeps its place; a graph-connected fact only displaces it when the boost
+/// lifts it higher — so multi-hop facts surface without evicting good vector
+/// hits, the failure of plain slot-reservation.
+fn retrieve(
+    store: &Store,
+    question: &str,
+    cfg: EvalCfg,
+    graph_on: bool,
+) -> Result<Vec<RetrievedFact>, Box<dyn Error>> {
+    if !graph_on {
+        // Vector-only baseline: no ColumnStore predicate, no graph.
+        let pool = vector_pool(store, question, pool_size(cfg.k), &[])?;
+        return Ok(pool.into_iter().take(cfg.k).collect());
+    }
+    // Fused mode: a ColumnStore date window when the question is time-scoped,
+    // plus graph traversal — all three engines.
+    let filters = temporal_filters(question);
+    let pool = vector_pool(store, question, pool_size(cfg.k), &filters)?;
+    let reached = graph_reached(store, question, cfg.hops)?;
+    Ok(fuse(pool, &reached, cfg))
+}
+
+/// A `ColumnStore` date window derived from a year named in the question (e.g.
+/// "...in 2023"), so a time-scoped question is constrained to facts from that
+/// year. Empty when the question names no year — most LoCoMo temporal questions
+/// ask *for* a date rather than scoping *to* one, so this fires rarely.
+fn temporal_filters(question: &str) -> Vec<ColumnFilter> {
+    let Some(year) = find_year(question) else {
+        return Vec::new();
+    };
+    let low = year * 10_000;
+    vec![
+        ColumnFilter {
+            field: "ts".to_string(),
+            op: ColumnOp::Ge,
+            value: json!(low),
+        },
+        ColumnFilter {
+            field: "ts".to_string(),
+            op: ColumnOp::Le,
+            value: json!(low + 9_999),
+        },
+    ]
+}
+
+/// The first plausible calendar year (1990-2099) named in `question`.
+fn find_year(question: &str) -> Option<i64> {
+    question
+        .split(|c: char| !c.is_ascii_digit())
+        .filter_map(|token| token.parse::<i64>().ok())
+        .find(|year| (1990..=2099).contains(year))
+}
+
+/// Pool size: a deep candidate set, never below [`POOL_MIN`].
+fn pool_size(k: usize) -> usize {
+    k.saturating_mul(POOL_FACTOR).max(POOL_MIN)
+}
+
+/// The top-`want` fact memories by vector similarity, in score order, each
+/// carrying its similarity (entity hubs filtered out, oversampling to survive
+/// the filter).
+fn vector_pool(
+    store: &Store,
+    question: &str,
+    want: usize,
+    filters: &[ColumnFilter],
+) -> Result<Vec<RetrievedFact>, Box<dyn Error>> {
+    let oversample = want.saturating_mul(2).saturating_add(16);
+    let hits = if filters.is_empty() {
+        store.svc.recall(question, oversample, None)?
+    } else {
+        store.svc.recall_where(question, oversample, filters)?
+    };
+    let mut out = Vec::with_capacity(want);
+    for hit in hits {
+        if store.is_fact(hit.id) {
+            out.push(RetrievedFact {
+                id: hit.id,
+                text: hit.content,
+                dia_ids: store.dia_ids(hit.id).to_vec(),
+                score: f64::from(hit.score),
+            });
+            if out.len() == want {
+                break;
+            }
+        }
+    }
+    Ok(out)
+}
+
+/// The facts `why()` reaches by traversal (hop ≥ 1) from the question's best
+/// vector seed. Their text comes from the traversal itself, so a fact the vector
+/// pool never ranked — the very thing pure similarity misses — can still fuse
+/// in. Vector score is 0: their relevance is the graph boost alone.
+fn graph_reached(
+    store: &Store,
+    question: &str,
+    hops: usize,
+) -> Result<Vec<RetrievedFact>, Box<dyn Error>> {
+    let explanation = store.svc.why(question, hops, None)?;
+    Ok(explanation
+        .nodes
+        .into_iter()
+        .filter(|node| node.hop >= 1 && store.is_fact(node.id))
+        .map(|node| RetrievedFact {
+            id: node.id,
+            dia_ids: store.dia_ids(node.id).to_vec(),
+            text: node.content,
+            score: 0.0,
+        })
+        .collect())
+}
+
+/// Fuse vector and graph: re-rank `pool ∪ reached` by
+/// `normalised_vector_similarity + graph_boost·is_connected`, take the top `k`.
+/// Equal budget, no blind eviction.
+fn fuse(pool: Vec<RetrievedFact>, reached: &[RetrievedFact], cfg: EvalCfg) -> Vec<RetrievedFact> {
+    let connected: HashSet<u64> = reached.iter().map(|f| f.id).collect();
+    let vector_top: HashSet<u64> = pool.iter().take(cfg.k).map(|f| f.id).collect();
+    let max_score = pool
+        .iter()
+        .map(|f| f.score)
+        .fold(f64::MIN, f64::max)
+        .max(f64::EPSILON);
+
+    let mut candidates: Vec<RetrievedFact> = pool;
+    let present: HashSet<u64> = candidates.iter().map(|f| f.id).collect();
+    candidates.extend(reached.iter().filter(|f| !present.contains(&f.id)).cloned());
+
+    candidates.sort_by(|a, b| {
+        fused_score(b, &connected, max_score, cfg)
+            .total_cmp(&fused_score(a, &connected, max_score, cfg))
+    });
+    candidates.truncate(cfg.k);
+    record_injection(
+        candidates
+            .iter()
+            .filter(|f| !vector_top.contains(&f.id))
+            .count(),
+    );
+    candidates
+}
+
+/// `normalised_vector_similarity + graph_boost` when the fact is graph-connected.
+fn fused_score(
+    fact: &RetrievedFact,
+    connected: &HashSet<u64>,
+    max_score: f64,
+    cfg: EvalCfg,
+) -> f64 {
+    let boost = if connected.contains(&fact.id) {
+        cfg.graph_boost
+    } else {
+        0.0
+    };
+    fact.score / max_score + boost
+}
+
+/// Tally how many of the chosen facts the graph promoted in (i.e. that were not
+/// already in the vector top-`k`). Zero ⇒ the graph changed nothing here.
+fn record_injection(injected: usize) {
+    if injected > 0 {
+        GRAPH_INJECTED.fetch_add(injected, Ordering::Relaxed);
+        GRAPH_ACTIVE_CONTEXTS.fetch_add(1, Ordering::Relaxed);
+    }
+}

--- a/crates/velesdb-memory/examples/locomo/explain.rs
+++ b/crates/velesdb-memory/examples/locomo/explain.rs
@@ -1,0 +1,172 @@
+//! LLM-free measurement of the graph's *explanation* value.
+//!
+//! LoCoMo's answer-accuracy cannot isolate the multi-hop graph's real strength:
+//! connecting evidence that lies scattered across sessions. Here we measure it
+//! directly. For every question with ≥2 gold `evidence` `dia_id`s we ask: of
+//! those evidence facts, what fraction does plain top-`k` **vector** recall
+//! surface, versus vector **plus** the facts `why()` reaches by graph traversal?
+//! No generator, no judge — just retrieval, so it runs over all conversations in
+//! seconds and the number is fully reproducible.
+
+use std::collections::HashSet;
+use std::error::Error;
+
+use crate::dataset::{Category, Qa};
+use crate::eval::EvalCfg;
+use crate::ingest::Store;
+
+/// Coverage tallies for one category.
+#[derive(Clone, Copy, Default)]
+struct Coverage {
+    /// Multi-evidence questions seen.
+    n: u32,
+    /// Sum of per-question vector-only evidence coverage (0..=1).
+    vector_sum: f64,
+    /// Sum of per-question vector+graph evidence coverage (0..=1).
+    fused_sum: f64,
+    /// Questions where the graph covered evidence the vector missed.
+    graph_helped: u32,
+}
+
+impl Coverage {
+    fn add(&mut self, vector: f64, fused: f64) {
+        self.n += 1;
+        self.vector_sum += vector;
+        self.fused_sum += fused;
+        if fused > vector + f64::EPSILON {
+            self.graph_helped += 1;
+        }
+    }
+
+    fn merge(self, other: Self) -> Self {
+        Self {
+            n: self.n + other.n,
+            vector_sum: self.vector_sum + other.vector_sum,
+            fused_sum: self.fused_sum + other.fused_sum,
+            graph_helped: self.graph_helped + other.graph_helped,
+        }
+    }
+}
+
+/// Per-category evidence-coverage report for the explanation benchmark.
+#[derive(Default)]
+pub struct ExplainReport {
+    cells: [Coverage; 5],
+}
+
+impl ExplainReport {
+    /// Measure one question and fold it in (multi-evidence questions only).
+    pub fn record(&mut self, store: &Store, qa: &Qa, cfg: EvalCfg) -> Result<(), Box<dyn Error>> {
+        if qa.evidence.len() < 2 {
+            return Ok(());
+        }
+        let evidence: HashSet<&str> = qa.evidence.iter().map(String::as_str).collect();
+        let vector = coverage(&vector_dia_ids(store, qa, cfg.k)?, &evidence);
+        let mut fused_ids = vector_dia_ids(store, qa, cfg.k)?;
+        fused_ids.extend(graph_dia_ids(store, qa, cfg.hops)?);
+        let fused = coverage(&fused_ids, &evidence);
+        self.cells[qa.category.index()].add(vector, fused);
+        Ok(())
+    }
+
+    /// Print the coverage table and the headline graph lift.
+    pub fn print(&self, cfg: EvalCfg, samples: usize) {
+        println!(
+            "\nVelesDB-memory — LoCoMo explanation benchmark (graph connects scattered evidence)"
+        );
+        println!(
+            "embedder: ollama / all-minilm   ·   {samples} conversation(s)   ·   \
+multi-evidence questions only, k={}, {} hops\n",
+            cfg.k, cfg.hops
+        );
+        println!(
+            "  {:<13}{:>5}   {:>10} {:>10} {:>9}",
+            "category", "n", "vector-cov", "fused-cov", "graph+"
+        );
+        for category in Category::ALL {
+            self.print_row(category.label(), self.cells[category.index()]);
+        }
+        let total = self
+            .cells
+            .iter()
+            .fold(Coverage::default(), |a, c| a.merge(*c));
+        self.print_row("ALL", total);
+        println!(
+            "\n→ evidence coverage: vector {:.0}% → +graph {:.0}% ({:+.0} pp)   ·   \
+graph completed missing evidence on {}/{} questions",
+            pct(total.vector_sum, total.n),
+            pct(total.fused_sum, total.n),
+            pct(total.fused_sum, total.n) - pct(total.vector_sum, total.n),
+            total.graph_helped,
+            total.n,
+        );
+        println!("  (coverage = share of a question's gold evidence dia_ids present in the retrieved facts)");
+    }
+
+    fn print_row(&self, label: &str, cell: Coverage) {
+        println!(
+            "  {:<13}{:>5}   {:>9.0}% {:>9.0}% {:>9}",
+            label,
+            cell.n,
+            pct(cell.vector_sum, cell.n),
+            pct(cell.fused_sum, cell.n),
+            cell.graph_helped,
+        );
+    }
+}
+
+/// The `dia_id`s covered by the top-`k` vector facts for `qa`.
+fn vector_dia_ids(store: &Store, qa: &Qa, k: usize) -> Result<HashSet<String>, Box<dyn Error>> {
+    let hits = store
+        .svc
+        .recall(&qa.question, k.saturating_mul(3).saturating_add(8), None)?;
+    let mut ids = HashSet::new();
+    let mut facts = 0;
+    for hit in hits {
+        if !store.is_fact(hit.id) {
+            continue;
+        }
+        ids.extend(store.dia_ids(hit.id).iter().cloned());
+        facts += 1;
+        if facts == k {
+            break;
+        }
+    }
+    Ok(ids)
+}
+
+/// The `dia_id`s covered by facts `why()` reaches by traversal (hop ≥ 1).
+fn graph_dia_ids(store: &Store, qa: &Qa, hops: usize) -> Result<HashSet<String>, Box<dyn Error>> {
+    let explanation = store.svc.why(&qa.question, hops, None)?;
+    let mut ids = HashSet::new();
+    for node in explanation.nodes {
+        if node.hop >= 1 && store.is_fact(node.id) {
+            ids.extend(store.dia_ids(node.id).iter().cloned());
+        }
+    }
+    Ok(ids)
+}
+
+/// Fraction of `evidence` present in `covered` (0..=1).
+fn coverage(covered: &HashSet<String>, evidence: &HashSet<&str>) -> f64 {
+    let hit = evidence.iter().filter(|id| covered.contains(**id)).count();
+    ratio(hit, evidence.len())
+}
+
+/// `num / den` as a fraction, guarding a zero denominator.
+fn ratio(num: usize, den: usize) -> f64 {
+    if den == 0 {
+        return 0.0;
+    }
+    let num = u32::try_from(num).unwrap_or(u32::MAX);
+    let den = u32::try_from(den).unwrap_or(u32::MAX);
+    f64::from(num) / f64::from(den)
+}
+
+/// Mean of a coverage sum as a percentage.
+fn pct(sum: f64, n: u32) -> f64 {
+    if n == 0 {
+        return 0.0;
+    }
+    100.0 * sum / f64::from(n)
+}

--- a/crates/velesdb-memory/examples/locomo/extract.rs
+++ b/crates/velesdb-memory/examples/locomo/extract.rs
@@ -1,0 +1,162 @@
+//! The extraction layer velesdb-memory intentionally does not ship.
+//!
+//! A local LLM reads each session and returns atomic facts, every fact tagged
+//! with the source `dia_id`s (so retrieval can be scored against the gold
+//! `evidence`) and the salient entities it mentions (so ingestion can wire the
+//! fact↔entity graph that `why()` later traverses). Honesty note: the benchmark
+//! score reflects this extractor as much as the database.
+
+use std::collections::HashSet;
+use std::error::Error;
+
+use serde::Deserialize;
+
+use crate::dataset::{Sample, Session};
+use crate::ollama_gen::Generator;
+use crate::parse::json_slice;
+
+/// One extracted, graph-ready fact.
+#[derive(Clone)]
+pub struct Fact {
+    pub text: String,
+    pub dia_ids: Vec<String>,
+    pub entities: Vec<String>,
+    /// Session date as a sortable `YYYYMMDD` key (the `ColumnStore` facet).
+    pub ts: i64,
+}
+
+#[derive(Deserialize)]
+struct RawFact {
+    fact: String,
+    #[serde(default)]
+    dia_ids: Vec<String>,
+    #[serde(default)]
+    entities: Vec<String>,
+}
+
+/// Extract facts for every session of `sample`, in order. Cached per session by
+/// the generator, so re-runs and resumes cost no GPU.
+pub fn extract_sample(generator: &Generator, sample: &Sample) -> Result<Vec<Fact>, Box<dyn Error>> {
+    let speakers = speaker_names(sample);
+    let mut facts = Vec::new();
+    for session in &sample.sessions {
+        facts.extend(extract_session(
+            generator,
+            &sample.sample_id,
+            session,
+            &speakers,
+        )?);
+    }
+    Ok(facts)
+}
+
+/// The lowercased set of speaker names in the conversation. They are excluded as
+/// graph entities: as the two ever-present participants they would otherwise
+/// become mega-hubs linking almost every fact, so a traversal through them would
+/// reach "all facts about this person" and drown the multi-hop signal in noise.
+fn speaker_names(sample: &Sample) -> HashSet<String> {
+    sample
+        .sessions
+        .iter()
+        .flat_map(|s| s.turns.iter())
+        .map(|t| t.speaker.to_lowercase())
+        .collect()
+}
+
+/// Extract and sanitise the facts of a single session.
+fn extract_session(
+    generator: &Generator,
+    sample_id: &str,
+    session: &Session,
+    speakers: &HashSet<String>,
+) -> Result<Vec<Fact>, Box<dyn Error>> {
+    if session.turns.is_empty() {
+        return Ok(Vec::new());
+    }
+    let valid_ids: HashSet<&str> = session.turns.iter().map(|t| t.dia_id.as_str()).collect();
+    let prompt = build_prompt(sample_id, session, speakers);
+    let reply = generator.generate(&prompt)?;
+    let Some(raw) = json_slice::<Vec<RawFact>>(&reply) else {
+        // Surface the drop rather than silently undercounting the graph.
+        eprintln!(
+            "        warning: {sample_id} session {} returned unparseable JSON; 0 facts",
+            session.index
+        );
+        return Ok(Vec::new());
+    };
+    let ts = session.date_key();
+    Ok(raw
+        .into_iter()
+        .filter_map(|r| sanitise(r, &valid_ids, speakers, ts))
+        .collect())
+}
+
+/// Keep a fact only if it has text and at least one real, in-session `dia_id`;
+/// drop hallucinated ids, speaker-name entities, and entities that collapse to
+/// nothing. Tags the fact with its session timestamp `ts`.
+fn sanitise(
+    raw: RawFact,
+    valid_ids: &HashSet<&str>,
+    speakers: &HashSet<String>,
+    ts: i64,
+) -> Option<Fact> {
+    let text = raw.fact.trim().to_string();
+    if text.is_empty() {
+        return None;
+    }
+    let dia_ids: Vec<String> = raw
+        .dia_ids
+        .into_iter()
+        .filter(|id| valid_ids.contains(id.as_str()))
+        .collect();
+    if dia_ids.is_empty() {
+        return None;
+    }
+    let mut seen = HashSet::new();
+    let entities: Vec<String> = raw
+        .entities
+        .into_iter()
+        .map(|e| e.trim().to_lowercase())
+        .filter(|e| e.len() >= 3 && !speakers.contains(e) && seen.insert(e.clone()))
+        .collect();
+    Some(Fact {
+        text,
+        dia_ids,
+        entities,
+        ts,
+    })
+}
+
+/// Build the extraction prompt: numbered dialogue plus a strict JSON contract.
+fn build_prompt(sample_id: &str, session: &Session, speakers: &HashSet<String>) -> String {
+    use std::fmt::Write as _;
+    let mut dialogue = String::new();
+    for turn in &session.turns {
+        // Writing to a String is infallible; the result is intentionally ignored.
+        let _ = writeln!(
+            dialogue,
+            "[{}] {}: {}",
+            turn.dia_id, turn.speaker, turn.text
+        );
+    }
+    let mut names: Vec<&str> = speakers.iter().map(String::as_str).collect();
+    names.sort_unstable();
+    format!(
+        "You are building a memory graph from a conversation (sample {sample_id}, \
+session {idx}, dated {date}). The speakers are {names}.\n\n\
+Dialogue (each line is [dia_id] speaker: text):\n{dialogue}\n\
+Extract the atomic, standalone facts a person would remember. Rewrite each as a \
+self-contained sentence (resolve pronouns to names; keep absolute dates). For \
+each fact also list 1-4 key TOPICS it concerns: the recurring subjects, \
+activities, events, interests, plans, places, organisations, or named people \
+OTHER than the speakers that a later question might reference. Use short, \
+canonical, lowercase noun phrases (e.g. \"adoption\", \"charity race\", \
+\"therapy\", \"new job\") so the same topic recurs as the SAME tag across \
+sessions. Never use the speakers' own names or generic filler as a topic.\n\n\
+Return ONLY a JSON array, no prose, each item exactly:\n\
+{{\"fact\": string, \"dia_ids\": [string], \"entities\": [string]}}",
+        idx = session.index,
+        date = session.date_time,
+        names = names.join(" and "),
+    )
+}

--- a/crates/velesdb-memory/examples/locomo/fetch_dataset.sh
+++ b/crates/velesdb-memory/examples/locomo/fetch_dataset.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Fetch the LoCoMo research dataset (snap-research/locomo) into ./data.
+# The dataset is NOT vendored: it is research data with its own terms, and at
+# ~2.8 MB it would only bloat the crate. Run this once before the benchmark.
+set -euo pipefail
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+dest="$here/data/locomo10.json"
+url="https://raw.githubusercontent.com/snap-research/locomo/main/data/locomo10.json"
+mkdir -p "$here/data"
+if [[ -s "$dest" ]]; then
+  echo "locomo10.json already present ($(wc -c <"$dest") bytes) — skipping."
+  exit 0
+fi
+echo "Downloading LoCoMo dataset → $dest"
+curl -fsSL -o "$dest" "$url"
+echo "Done ($(wc -c <"$dest") bytes)."

--- a/crates/velesdb-memory/examples/locomo/ingest.rs
+++ b/crates/velesdb-memory/examples/locomo/ingest.rs
@@ -1,0 +1,133 @@
+//! Build the memory store from extracted facts.
+//!
+//! Each fact becomes a memory tagged with its source `dia_id`s. Each salient
+//! entity becomes a hub memory, and every fact is `relate()`d to its entities
+//! with an `about` edge. That fact↔entity graph is exactly what `why()` walks:
+//! seed a fact by vector similarity, hop to its entities, reach sibling facts a
+//! pure vector search would never surface.
+
+use std::collections::{HashMap, HashSet};
+use std::error::Error;
+
+use serde_json::{Map, Value};
+use velesdb_memory::mcp::DynEmbedder;
+use velesdb_memory::MemoryService;
+
+use crate::extract::Fact;
+
+/// The ingested store: the service plus a fact-id → source-`dia_id`s index
+/// (entity hubs are excluded from it, so retrieval can skip them).
+pub struct Store {
+    pub svc: MemoryService<DynEmbedder>,
+    facts: HashMap<u64, Vec<String>>,
+}
+
+impl Store {
+    /// True when `id` is a fact memory (not an entity hub).
+    pub fn is_fact(&self, id: u64) -> bool {
+        self.facts.contains_key(&id)
+    }
+
+    /// The source `dia_id`s of a fact, or empty for non-facts.
+    pub fn dia_ids(&self, id: u64) -> &[String] {
+        self.facts.get(&id).map_or(&[], Vec::as_slice)
+    }
+}
+
+/// Ingest `facts` into a fresh service, wiring the fact↔entity graph.
+pub fn build(svc: MemoryService<DynEmbedder>, facts: &[Fact]) -> Result<Store, Box<dyn Error>> {
+    let mut store = Store {
+        svc,
+        facts: HashMap::new(),
+    };
+    let mut entity_ids: HashMap<String, u64> = HashMap::new();
+    let mut edges: HashSet<(u64, u64)> = HashSet::new();
+
+    for fact in facts {
+        let fid = remember_fact(&store.svc, fact)?;
+        record_fact(&mut store, fid, fact);
+        wire_entities(&store.svc, &mut entity_ids, &mut edges, fid, &fact.entities)?;
+    }
+    report_density(facts, &entity_ids);
+    Ok(store)
+}
+
+/// Print how connectable the graph is: only entities shared by ≥2 facts can
+/// carry a multi-hop traversal, so a near-zero "shared" count explains a graph
+/// that contributes nothing — the structure, not the query, is the limit.
+fn report_density(facts: &[Fact], entity_ids: &HashMap<String, u64>) {
+    let mut degree: HashMap<&str, u32> = HashMap::new();
+    for fact in facts {
+        for entity in &fact.entities {
+            *degree.entry(entity.as_str()).or_insert(0) += 1;
+        }
+    }
+    let shared = degree.values().filter(|&&d| d >= 2).count();
+    eprintln!(
+        "        graph: {} entities ({shared} shared by ≥2 facts)",
+        entity_ids.len()
+    );
+}
+
+/// Link a fact to each of its entities with a deduplicated edge in *both*
+/// directions. `why()` only follows outgoing edges, so the fact→entity edge
+/// alone leaves entity hubs as dead ends; the entity→fact edge is what lets a
+/// traversal hop from one fact, through a shared entity, to its sibling facts —
+/// the multi-hop path the benchmark measures.
+fn wire_entities(
+    svc: &MemoryService<DynEmbedder>,
+    entity_ids: &mut HashMap<String, u64>,
+    edges: &mut HashSet<(u64, u64)>,
+    fid: u64,
+    entities: &[String],
+) -> Result<(), Box<dyn Error>> {
+    for entity in entities {
+        let eid = entity_hub(svc, entity_ids, entity)?;
+        if edges.insert((fid, eid)) {
+            svc.relate(fid, eid, "about")?;
+        }
+        if edges.insert((eid, fid)) {
+            svc.relate(eid, fid, "mentions")?;
+        }
+    }
+    Ok(())
+}
+
+/// Remember one fact with its `dia_id`s in metadata; dedup is by fact text
+/// (the service keys memories on a stable hash of the content).
+fn remember_fact(svc: &MemoryService<DynEmbedder>, fact: &Fact) -> Result<u64, Box<dyn Error>> {
+    let mut meta = Map::new();
+    let ids: Vec<Value> = fact.dia_ids.iter().cloned().map(Value::String).collect();
+    meta.insert("dia_ids".to_string(), Value::Array(ids));
+    // The ColumnStore facet: the session date, range-queryable via recall_where.
+    if fact.ts != 0 {
+        meta.insert("ts".to_string(), Value::from(fact.ts));
+    }
+    Ok(svc.remember(&fact.text, &[], Some(&meta))?)
+}
+
+/// Index a fact id, merging `dia_id`s when the same fact text recurs.
+fn record_fact(store: &mut Store, fid: u64, fact: &Fact) {
+    let dia_ids = store.facts.entry(fid).or_default();
+    for id in &fact.dia_ids {
+        if !dia_ids.contains(id) {
+            dia_ids.push(id.clone());
+        }
+    }
+}
+
+/// Get or create the hub memory for `entity`, caching its id.
+fn entity_hub(
+    svc: &MemoryService<DynEmbedder>,
+    entity_ids: &mut HashMap<String, u64>,
+    entity: &str,
+) -> Result<u64, Box<dyn Error>> {
+    if let Some(&id) = entity_ids.get(entity) {
+        return Ok(id);
+    }
+    let mut meta = Map::new();
+    meta.insert("kind".to_string(), Value::String("entity".to_string()));
+    let id = svc.remember(&format!("Entity: {entity}"), &[], Some(&meta))?;
+    entity_ids.insert(entity.to_string(), id);
+    Ok(id)
+}

--- a/crates/velesdb-memory/examples/locomo/judge.rs
+++ b/crates/velesdb-memory/examples/locomo/judge.rs
@@ -1,0 +1,136 @@
+//! Answer generation and hybrid scoring.
+//!
+//! Hybrid, as chosen for this benchmark: a local LLM judge gives a citable
+//! correctness verdict, and a deterministic token-F1 is logged beside it as a
+//! reproducibility guard. Adversarial (unanswerable) items are scored by
+//! abstention — the model should say it cannot answer — and skip both the LLM
+//! judge and F1.
+
+use std::error::Error;
+
+use crate::dataset::Qa;
+use crate::ollama_gen::Generator;
+use crate::parse::{normalize, tokens};
+
+const ABSTAIN: &str = "NO_ANSWER";
+
+/// Generate a concise answer from the retrieved fact texts, or the abstain
+/// token when the facts don't contain the answer.
+pub fn answer(
+    generator: &Generator,
+    question: &str,
+    facts: &[String],
+) -> Result<String, Box<dyn Error>> {
+    let context = if facts.is_empty() {
+        "(no facts retrieved)".to_string()
+    } else {
+        facts
+            .iter()
+            .map(|f| format!("- {f}"))
+            .collect::<Vec<_>>()
+            .join("\n")
+    };
+    let prompt = format!(
+        "Answer the question using ONLY the memory facts below. If the facts do \
+not contain the answer, reply exactly {ABSTAIN}. Be concise: a few words, no \
+explanation.\n\nFacts:\n{context}\n\nQuestion: {question}\nAnswer:"
+    );
+    generator.generate(&prompt)
+}
+
+/// True when the model declined to answer (the correct move on adversarial QA).
+/// Matched on the leading token, not a substring, so a real answer that merely
+/// contains the words "no answer" is not mistaken for an abstention.
+pub fn abstained(model_answer: &str) -> bool {
+    let norm = normalize(model_answer);
+    if norm.is_empty() || norm == "no answer" {
+        return true;
+    }
+    let head: String = norm
+        .chars()
+        .take_while(|c| c.is_alphanumeric() || *c == '_')
+        .collect();
+    head == ABSTAIN.to_lowercase()
+}
+
+/// LLM-judge verdict for an answerable question: does the candidate convey the
+/// reference answer's information? Returns `false` on an abstention.
+pub fn judge_correct(
+    generator: &Generator,
+    question: &str,
+    gold: &str,
+    candidate: &str,
+) -> Result<bool, Box<dyn Error>> {
+    if abstained(candidate) {
+        return Ok(false);
+    }
+    let prompt = format!(
+        "You are grading a question-answering system. Decide if the candidate \
+answer conveys the same information as the reference answer (a superset is \
+fine; extra correct detail is fine). Reply with exactly one word: CORRECT or \
+INCORRECT.\n\nQuestion: {question}\nReference answer: {gold}\nCandidate answer: \
+{candidate}\nVerdict:"
+    );
+    let verdict = normalize(&generator.generate(&prompt)?);
+    // Compare the leading word so "incorrect" never matches "correct" by
+    // substring, and a stray verbose reply still grades on its first verdict word.
+    let head: String = verdict
+        .chars()
+        .take_while(char::is_ascii_alphabetic)
+        .collect();
+    Ok(head == "correct")
+}
+
+/// Token-level F1 (SQuAD-style multiset overlap) between candidate and gold;
+/// 0.0 for an abstention.
+pub fn f1(candidate: &str, gold: &str) -> f64 {
+    if abstained(candidate) {
+        return 0.0;
+    }
+    let cand = tokens(candidate);
+    let gold = tokens(gold);
+    if cand.is_empty() || gold.is_empty() {
+        return 0.0;
+    }
+    let overlap = multiset_overlap(&cand, &gold);
+    if overlap == 0 {
+        return 0.0;
+    }
+    let precision = ratio(overlap, cand.len());
+    let recall = ratio(overlap, gold.len());
+    2.0 * precision * recall / (precision + recall)
+}
+
+/// `num / den` as `f64`, widening through `u32` (token counts never approach
+/// its range; the `unwrap_or` clamp is a belt-and-braces guard, not expected).
+fn ratio(num: usize, den: usize) -> f64 {
+    let num = u32::try_from(num).unwrap_or(u32::MAX);
+    let den = u32::try_from(den).unwrap_or(u32::MAX);
+    if den == 0 {
+        return 0.0;
+    }
+    f64::from(num) / f64::from(den)
+}
+
+/// Sum over shared tokens of `min(count_in_a, count_in_b)` — true multiset
+/// intersection size, so repeated words count only as often as both contain.
+fn multiset_overlap(a: &[String], b: &[String]) -> usize {
+    let mut counts: std::collections::HashMap<&str, i32> = std::collections::HashMap::new();
+    for token in a {
+        *counts.entry(token).or_insert(0) += 1;
+    }
+    let mut overlap = 0usize;
+    for token in b {
+        let slot = counts.entry(token).or_insert(0);
+        if *slot > 0 {
+            *slot -= 1;
+            overlap += 1;
+        }
+    }
+    overlap
+}
+
+/// Reference answer text for scoring, if the item is answerable.
+pub fn gold_answer(qa: &Qa) -> Option<&str> {
+    qa.answer.as_deref()
+}

--- a/crates/velesdb-memory/examples/locomo/main.rs
+++ b/crates/velesdb-memory/examples/locomo/main.rs
@@ -1,0 +1,258 @@
+//! Real LoCoMo benchmark for velesdb-memory: does the graph improve answer
+//! recall over pure vector search, apples-to-apples (same embeddings, same
+//! fact budget, same judge)?
+//!
+//! ```text
+//! # one-time: fetch the dataset + pull the local models
+//! examples/locomo/fetch_dataset.sh
+//! ollama pull all-minilm && ollama pull qwen3.6:35b-mlx
+//!
+//! # smoke (1 conversation), then the full run (all 10):
+//! cargo run --release -p velesdb-memory --features ollama --example locomo -- --conversations 1
+//! cargo run --release -p velesdb-memory --features ollama --example locomo
+//! # LLM-free explanation benchmark (does the graph connect scattered evidence?):
+//! cargo run --release -p velesdb-memory --features ollama --example locomo -- --explanation
+//! ```
+//!
+//! Pipeline: extract facts from each session with a local LLM (tagged with the
+//! gold `dia_id`s and session timestamp), ingest them as a fact↔entity graph,
+//! then answer every QA twice — vector-only vs a tri-engine fusion (vector +
+//! graph traversal + `ColumnStore` date window) — and score with a hybrid LLM
+//! judge plus deterministic evidence-overlap and token-F1. `--explanation` runs
+//! a separate, generator-free measure of the graph's evidence-connecting value.
+//! Each conversation is benchmarked in isolation; the score reflects the
+//! extractor too.
+
+mod dataset;
+mod eval;
+mod explain;
+mod extract;
+mod ingest;
+mod judge;
+mod ollama_gen;
+mod parse;
+mod report;
+
+use std::error::Error;
+use std::path::PathBuf;
+
+use velesdb_memory::mcp::DynEmbedder;
+use velesdb_memory::{MemoryService, OllamaEmbedder, DEFAULT_OLLAMA_MODEL, DEFAULT_OLLAMA_URL};
+
+use dataset::Sample;
+use eval::EvalCfg;
+use explain::ExplainReport;
+use ingest::Store;
+use ollama_gen::Generator;
+use report::Report;
+
+/// Parsed command-line configuration.
+struct Args {
+    dataset: PathBuf,
+    conversations: usize,
+    max_qa: usize,
+    model: String,
+    /// Run the LLM-free explanation benchmark instead of the QA eval.
+    explanation: bool,
+    cfg: EvalCfg,
+}
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let args = Args::parse()?;
+    let samples = dataset::load(&args.dataset)?;
+    let take = args.conversations.min(samples.len());
+    let cache = manifest_dir().join("examples/locomo/cache");
+    let generator = Generator::new(&args.model, cache)?;
+    if args.explanation {
+        run_explanation(&generator, &samples, take, &args)
+    } else {
+        run_eval(&generator, &samples, take, &args)
+    }
+}
+
+/// The QA benchmark: vector vs fused retrieval, answered and judged per category.
+fn run_eval(
+    generator: &Generator,
+    samples: &[Sample],
+    take: usize,
+    args: &Args,
+) -> Result<(), Box<dyn Error>> {
+    let mut report = Report::default();
+    let mut total_facts = 0usize;
+    for (position, sample) in samples.iter().take(take).enumerate() {
+        let (store, facts) = prepare(generator, sample, position, take)?;
+        let qa_take = qa_limit(args.max_qa, sample.qa.len());
+        for (done, qa) in sample.qa.iter().take(qa_take).enumerate() {
+            let off = eval::evaluate(&store, generator, qa, args.cfg, false)?;
+            let on = eval::evaluate(&store, generator, qa, args.cfg, true)?;
+            report.record(qa.category, false, &off);
+            report.record(qa.category, true, &on);
+            if (done + 1) % 20 == 0 {
+                eprintln!("        {}/{} QA evaluated", done + 1, qa_take);
+            }
+        }
+        finish(store, position);
+        total_facts += facts;
+    }
+    report.print(args.cfg, generator.model(), take, total_facts);
+    let (injected, contexts) = eval::graph_activity();
+    println!(
+        "graph activity: traversal injected {injected} fact(s) across {contexts} graph-mode context(s)"
+    );
+    Ok(())
+}
+
+/// The LLM-free explanation benchmark: does the graph connect scattered evidence?
+fn run_explanation(
+    generator: &Generator,
+    samples: &[Sample],
+    take: usize,
+    args: &Args,
+) -> Result<(), Box<dyn Error>> {
+    let mut report = ExplainReport::default();
+    for (position, sample) in samples.iter().take(take).enumerate() {
+        let (store, _facts) = prepare(generator, sample, position, take)?;
+        for qa in sample
+            .qa
+            .iter()
+            .take(qa_limit(args.max_qa, sample.qa.len()))
+        {
+            report.record(&store, qa, args.cfg)?;
+        }
+        finish(store, position);
+    }
+    report.print(args.cfg, take);
+    Ok(())
+}
+
+/// Extract and ingest one conversation; returns its store and fact count.
+fn prepare(
+    generator: &Generator,
+    sample: &Sample,
+    position: usize,
+    total: usize,
+) -> Result<(Store, usize), Box<dyn Error>> {
+    eprintln!(
+        "[{}/{}] sample {} — {} sessions, {} turns, {} QA: extracting…",
+        position + 1,
+        total,
+        sample.sample_id,
+        sample.sessions.len(),
+        sample.turn_count(),
+        sample.qa.len(),
+    );
+    let facts = extract::extract_sample(generator, sample)?;
+    let store = ingest::build(open_service(position)?, &facts)?;
+    eprintln!("        {} facts ingested", facts.len());
+    Ok((store, facts.len()))
+}
+
+/// Drop a conversation's store and wipe its directory.
+fn finish(store: Store, position: usize) {
+    drop(store);
+    cleanup(position);
+}
+
+/// Open a fresh, isolated service for conversation `position`. The store dir is
+/// wiped first so a crashed prior run can never leak stale facts into the run.
+fn open_service(position: usize) -> Result<MemoryService<DynEmbedder>, Box<dyn Error>> {
+    cleanup(position);
+    let embedder: DynEmbedder = Box::new(OllamaEmbedder::new(
+        DEFAULT_OLLAMA_URL,
+        DEFAULT_OLLAMA_MODEL,
+    )?);
+    Ok(MemoryService::open(store_dir(position), embedder)?)
+}
+
+/// Per-conversation on-disk store path (wiped before and after use).
+fn store_dir(position: usize) -> PathBuf {
+    std::env::temp_dir().join(format!("velesdb-locomo-{}-{position}", std::process::id()))
+}
+
+/// Remove a conversation's store directory, ignoring absence.
+fn cleanup(position: usize) {
+    let _ = std::fs::remove_dir_all(store_dir(position));
+}
+
+/// `max_qa == 0` means "all"; otherwise cap.
+fn qa_limit(max_qa: usize, available: usize) -> usize {
+    if max_qa == 0 {
+        available
+    } else {
+        max_qa.min(available)
+    }
+}
+
+/// The crate manifest directory, for resolving the default dataset and cache.
+fn manifest_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+impl Default for Args {
+    fn default() -> Self {
+        Self {
+            dataset: manifest_dir().join("examples/locomo/data/locomo10.json"),
+            conversations: 10,
+            max_qa: 0,
+            model: String::new(),
+            explanation: false,
+            cfg: EvalCfg {
+                // Gentle: the graph nudges, rarely evicting a strong vector hit.
+                // On LoCoMo the graph is ~neutral; higher boosts only hurt more.
+                k: 8,
+                graph_boost: 0.15,
+                hops: 2,
+            },
+        }
+    }
+}
+
+impl Args {
+    /// Parse `--flag value` arguments over the defaults.
+    fn parse() -> Result<Self, Box<dyn Error>> {
+        let mut args = Args::default();
+        let raw: Vec<String> = std::env::args().skip(1).collect();
+        let mut i = 0;
+        while i < raw.len() {
+            let flag = &raw[i];
+            if flag == "--explanation" {
+                args.explanation = true;
+                i += 1;
+                continue;
+            }
+            let value = raw
+                .get(i + 1)
+                .ok_or_else(|| format!("{flag} needs a value"))?;
+            args.set(flag, value)?;
+            i += 2;
+        }
+        if args.cfg.k == 0 {
+            return Err("--k must be at least 1".into());
+        }
+        Ok(args)
+    }
+
+    /// Apply one `--flag value` pair (string/float flags here, ints delegated).
+    fn set(&mut self, flag: &str, value: &str) -> Result<(), Box<dyn Error>> {
+        match flag {
+            "--model" => self.model = value.to_string(),
+            "--dataset" => self.dataset = PathBuf::from(value),
+            "--graph-boost" => self.cfg.graph_boost = value.parse()?,
+            _ => self.set_numeric(flag, value)?,
+        }
+        Ok(())
+    }
+
+    /// Apply an integer `--flag value` pair.
+    fn set_numeric(&mut self, flag: &str, value: &str) -> Result<(), Box<dyn Error>> {
+        let n: usize = value.parse()?;
+        match flag {
+            "--conversations" => self.conversations = n,
+            "--max-qa" => self.max_qa = n,
+            "--k" => self.cfg.k = n,
+            "--hops" => self.cfg.hops = n,
+            other => return Err(format!("unknown argument: {other}").into()),
+        }
+        Ok(())
+    }
+}

--- a/crates/velesdb-memory/examples/locomo/ollama_gen.rs
+++ b/crates/velesdb-memory/examples/locomo/ollama_gen.rs
@@ -1,0 +1,151 @@
+//! Local generative client for a running Ollama (`/api/generate`).
+//!
+//! Used for both fact extraction and answer judging with a local model
+//! (default `qwen3.6:35b-mlx`). Every call is content-addressed and cached on
+//! disk: an interrupted multi-hour run resumes for free, and re-runs spend no
+//! GPU. `think` is disabled and `temperature` pinned to 0 for stable output.
+
+use std::error::Error;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
+
+const DEFAULT_MODEL: &str = "qwen3.6:35b-mlx";
+const OLLAMA_URL: &str = "http://localhost:11434/api/generate";
+const ATTEMPTS: u32 = 3;
+
+/// Per-process counter making temp-file names unique, so two runs sharing a
+/// cache dir never write the same `.tmp` and race the rename.
+static TMP_SEQ: AtomicU64 = AtomicU64::new(0);
+
+/// A cached, deterministic text generator backed by local Ollama.
+pub struct Generator {
+    model: String,
+    cache_dir: PathBuf,
+    agent: ureq::Agent,
+}
+
+impl Generator {
+    /// Build a generator. `model` falls back to [`DEFAULT_MODEL`] when empty;
+    /// `cache_dir` is created if missing.
+    pub fn new(model: &str, cache_dir: PathBuf) -> Result<Self, Box<dyn Error>> {
+        fs::create_dir_all(&cache_dir)?;
+        let model = if model.is_empty() {
+            DEFAULT_MODEL.to_string()
+        } else {
+            model.to_string()
+        };
+        let agent = ureq::AgentBuilder::new()
+            .timeout(Duration::from_secs(300))
+            .build();
+        Ok(Self {
+            model,
+            cache_dir,
+            agent,
+        })
+    }
+
+    /// The active model name, for report headers.
+    pub fn model(&self) -> &str {
+        &self.model
+    }
+
+    /// Generate text for `prompt`, served from cache when seen before. An empty
+    /// cached entry is treated as a miss, so a transient blank reply is never
+    /// trusted as a permanent answer.
+    pub fn generate(&self, prompt: &str) -> Result<String, Box<dyn Error>> {
+        let key = self.key(prompt);
+        let path = self.cache_dir.join(format!("{key}.txt"));
+        if let Ok(cached) = fs::read_to_string(&path) {
+            if !cached.trim().is_empty() {
+                return Ok(cached);
+            }
+        }
+        let answer = self.call(prompt)?;
+        if !answer.trim().is_empty() {
+            self.store(&key, &path, &answer)?;
+        }
+        Ok(answer)
+    }
+
+    /// Atomically persist `answer`: write a process-unique temp file, then
+    /// rename it over `path`, so a killed run never leaves a half-written entry.
+    fn store(&self, key: &str, path: &Path, answer: &str) -> Result<(), Box<dyn Error>> {
+        let seq = TMP_SEQ.fetch_add(1, Ordering::Relaxed);
+        let tmp = self
+            .cache_dir
+            .join(format!("{key}.{}.{seq}.tmp", std::process::id()));
+        fs::write(&tmp, answer)?;
+        fs::rename(&tmp, path)?;
+        Ok(())
+    }
+
+    /// POST to Ollama with bounded retries; returns the trimmed `response`.
+    /// The body is serialised with `serde_json` and sent as a raw string so the
+    /// crate's `ureq` can keep `default-features = false` (no bundled TLS/json),
+    /// leaving the shipped server binary tiny.
+    fn call(&self, prompt: &str) -> Result<String, Box<dyn Error>> {
+        let body = serde_json::json!({
+            "model": self.model,
+            "prompt": prompt,
+            "stream": false,
+            "think": false,
+            "options": { "temperature": 0 },
+        })
+        .to_string();
+        let mut last: Box<dyn Error> = "no attempt made".into();
+        for attempt in 1..=ATTEMPTS {
+            let request = self
+                .agent
+                .post(OLLAMA_URL)
+                .set("Content-Type", "application/json");
+            match request.send_string(&body) {
+                Ok(resp) => return parse_response(resp),
+                Err(e) => last = ureq_error(attempt, &e).into(),
+            }
+        }
+        Err(last)
+    }
+
+    /// Content-addressed cache key over model + prompt (stable across runs).
+    fn key(&self, prompt: &str) -> String {
+        let mut hash = fnv1a(self.model.as_bytes());
+        hash = fnv1a_continue(hash, b"\0");
+        hash = fnv1a_continue(hash, prompt.as_bytes());
+        format!("{hash:016x}")
+    }
+}
+
+/// Pull the `response` string out of Ollama's JSON envelope.
+fn parse_response(resp: ureq::Response) -> Result<String, Box<dyn Error>> {
+    let raw = resp.into_string()?;
+    let value: serde_json::Value = serde_json::from_str(&raw)?;
+    let text = value
+        .get("response")
+        .and_then(serde_json::Value::as_str)
+        .ok_or("Ollama reply had no `response` field")?;
+    Ok(text.trim().to_string())
+}
+
+/// Flatten a `ureq` error into a labelled message for the retry log.
+fn ureq_error(attempt: u32, error: &ureq::Error) -> String {
+    format!("Ollama request failed (attempt {attempt}/{ATTEMPTS}): {error}")
+}
+
+const FNV_OFFSET: u64 = 0xcbf2_9ce4_8422_2325;
+const FNV_PRIME: u64 = 0x0000_0100_0000_01b3;
+
+/// FNV-1a over a single byte slice — a stable, dependency-free cache hash.
+fn fnv1a(bytes: &[u8]) -> u64 {
+    fnv1a_continue(FNV_OFFSET, bytes)
+}
+
+/// Continue an FNV-1a hash with more bytes.
+fn fnv1a_continue(mut hash: u64, bytes: &[u8]) -> u64 {
+    for &byte in bytes {
+        hash ^= u64::from(byte);
+        hash = hash.wrapping_mul(FNV_PRIME);
+    }
+    hash
+}

--- a/crates/velesdb-memory/examples/locomo/parse.rs
+++ b/crates/velesdb-memory/examples/locomo/parse.rs
@@ -1,0 +1,81 @@
+//! Tolerant JSON extraction from model output.
+//!
+//! Local models usually honour "return only JSON", but occasionally wrap it in
+//! ```` ```json ```` fences or a sentence. We slice out the first balanced JSON
+//! array/object so a stray wrapper never fails a whole session.
+
+use serde::de::DeserializeOwned;
+
+/// Parse `text` into `T`, first slicing out the outermost JSON array/object.
+pub fn json_slice<T: DeserializeOwned>(text: &str) -> Option<T> {
+    let slice = balanced_slice(text)?;
+    serde_json::from_str::<T>(slice).ok()
+}
+
+/// Return the substring spanning the first balanced `[..]` or `{..}`, honouring
+/// string literals and escapes so brackets inside quotes don't miscount.
+fn balanced_slice(text: &str) -> Option<&str> {
+    let bytes = text.as_bytes();
+    let start = bytes.iter().position(|&b| b == b'[' || b == b'{')?;
+    let open = bytes[start];
+    let close = if open == b'[' { b']' } else { b'}' };
+    let mut depth = 0u32;
+    let mut in_string = false;
+    let mut escaped = false;
+    for (offset, &byte) in bytes[start..].iter().enumerate() {
+        if in_string {
+            in_string = step_string(&mut escaped, byte);
+        } else if scan_structural(byte, open, close, &mut in_string, &mut depth) {
+            return Some(&text[start..=start + offset]);
+        }
+    }
+    None
+}
+
+/// Advance the structural scan for one out-of-string byte; returns `true` once
+/// the outermost bracket has just closed (`depth` back to zero).
+fn scan_structural(byte: u8, open: u8, close: u8, in_string: &mut bool, depth: &mut u32) -> bool {
+    if byte == b'"' {
+        *in_string = true;
+    } else if byte == open {
+        *depth += 1;
+    } else if byte == close {
+        *depth = depth.saturating_sub(1);
+        return *depth == 0;
+    }
+    false
+}
+
+/// Advance the in-string escape state for one byte; returns whether the scanner
+/// is still inside the string literal afterwards.
+fn step_string(escaped: &mut bool, byte: u8) -> bool {
+    match (*escaped, byte) {
+        (true, _) => {
+            *escaped = false;
+            true
+        }
+        (false, b'\\') => {
+            *escaped = true;
+            true
+        }
+        (false, b'"') => false,
+        (false, _) => true,
+    }
+}
+
+/// Lowercased, whitespace-collapsed form for case-insensitive matching.
+pub fn normalize(text: &str) -> String {
+    text.split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .to_lowercase()
+}
+
+/// Token set for F1 scoring: lowercased alphanumeric words, punctuation dropped.
+pub fn tokens(text: &str) -> Vec<String> {
+    text.to_lowercase()
+        .split(|c: char| !c.is_alphanumeric())
+        .filter(|w| !w.is_empty())
+        .map(str::to_string)
+        .collect()
+}

--- a/crates/velesdb-memory/examples/locomo/report.rs
+++ b/crates/velesdb-memory/examples/locomo/report.rs
@@ -1,0 +1,166 @@
+//! Result aggregation and the final report.
+//!
+//! Tallies accuracy (LLM judge), evidence-recall (deterministic), and mean F1
+//! per category, for the vector-only and vector+graph modes side by side, then
+//! prints the headline graph contribution.
+
+use crate::dataset::Category;
+use crate::eval::{EvalCfg, ModeResult};
+
+/// Running totals for one (mode, category) cell.
+#[derive(Clone, Copy, Default)]
+struct Cell {
+    n: u32,
+    evidence: u32,
+    correct: u32,
+    f1_sum: f64,
+    f1_n: u32,
+}
+
+impl Cell {
+    fn add(&mut self, result: &ModeResult) {
+        self.n += 1;
+        self.evidence += u32::from(result.evidence_hit);
+        self.correct += u32::from(result.correct);
+        if let Some(f1) = result.f1 {
+            self.f1_sum += f1;
+            self.f1_n += 1;
+        }
+    }
+
+    fn merge(&self, other: &Cell) -> Cell {
+        Cell {
+            n: self.n + other.n,
+            evidence: self.evidence + other.evidence,
+            correct: self.correct + other.correct,
+            f1_sum: self.f1_sum + other.f1_sum,
+            f1_n: self.f1_n + other.f1_n,
+        }
+    }
+
+    fn accuracy(self) -> f64 {
+        pct(self.correct, self.n)
+    }
+
+    fn evidence_overlap(self) -> f64 {
+        pct(self.evidence, self.n)
+    }
+
+    fn mean_f1(self) -> f64 {
+        if self.f1_n == 0 {
+            return f64::NAN;
+        }
+        self.f1_sum / f64::from(self.f1_n)
+    }
+}
+
+/// Per-category tallies for both retrieval modes.
+#[derive(Default)]
+pub struct Report {
+    off: [Cell; 5],
+    on: [Cell; 5],
+}
+
+impl Report {
+    /// Record one QA outcome under one mode.
+    pub fn record(&mut self, category: Category, graph_on: bool, result: &ModeResult) {
+        let cells = if graph_on {
+            &mut self.on
+        } else {
+            &mut self.off
+        };
+        cells[category.index()].add(result);
+    }
+
+    /// Print the full comparison table and the headline delta.
+    pub fn print(&self, cfg: EvalCfg, model: &str, samples: usize, facts: usize) {
+        println!("\nVelesDB-memory — LoCoMo benchmark (graph contribution)");
+        println!(
+            "judge/extractor: {model}   ·   embedder: ollama / all-minilm   ·   \
+{samples} conversation(s), {facts} extracted facts"
+        );
+        println!(
+            "retrieval budget k={}  (graph mode: fused vector+graph rerank, boost {:.2}, {} hops)\n",
+            cfg.k, cfg.graph_boost, cfg.hops
+        );
+        println!(
+            "  {:<13}{:>5}   {:^21}   {:^21}",
+            "", "n", "vector-only", "vector + graph"
+        );
+        println!(
+            "  {:<13}{:>5}   {:>6} {:>6} {:>6}   {:>6} {:>6} {:>6}",
+            "category", "", "acc", "ev", "f1", "acc", "ev", "f1"
+        );
+        for category in Category::ALL {
+            print_row(
+                category.label(),
+                self.off[category.index()],
+                self.on[category.index()],
+            );
+        }
+        let off_total = answerable(&self.off);
+        let on_total = answerable(&self.on);
+        print_row("answerable", off_total, on_total);
+        print_headline(off_total, on_total);
+    }
+}
+
+/// One category (or total) row: accuracy / evidence-overlap / F1 per mode.
+fn print_row(label: &str, off: Cell, on: Cell) {
+    println!(
+        "  {:<13}{:>5}   {:>5.0}% {:>5.0}% {:>6}   {:>5.0}% {:>5.0}% {:>6}",
+        label,
+        off.n,
+        off.accuracy(),
+        off.evidence_overlap(),
+        fmt_f1(off.mean_f1()),
+        on.accuracy(),
+        on.evidence_overlap(),
+        fmt_f1(on.mean_f1()),
+    );
+}
+
+/// The bottom-line fusion (graph + `ColumnStore`) contribution, over answerable
+/// items only — adversarial items are scored by abstention, so folding them in
+/// would mix an abstention rate into the accuracy and obscure the effect.
+fn print_headline(off: Cell, on: Cell) {
+    println!(
+        "\n→ fusion contribution (answerable only): accuracy {:.0}% → {:.0}% ({:+.0} pp)   ·   \
+evidence-overlap {:.0}% → {:.0}% ({:+.0} pp)",
+        off.accuracy(),
+        on.accuracy(),
+        on.accuracy() - off.accuracy(),
+        off.evidence_overlap(),
+        on.evidence_overlap(),
+        on.evidence_overlap() - off.evidence_overlap(),
+    );
+    println!(
+        "  (acc = LLM-judge accuracy; ev = evidence-overlap, ≥1 retrieved fact whose \
+source ∈ gold evidence; f1 = mean token-F1.\n   adversarial acc = abstention rate, \
+shown per-row but excluded from the answerable total and headline.)"
+    );
+}
+
+/// Sum the answerable categories (everything but adversarial) into one total.
+fn answerable(cells: &[Cell; 5]) -> Cell {
+    Category::ALL
+        .iter()
+        .filter(|c| !c.is_adversarial())
+        .fold(Cell::default(), |acc, c| acc.merge(&cells[c.index()]))
+}
+
+/// Percentage with a guarded zero denominator.
+fn pct(num: u32, den: u32) -> f64 {
+    if den == 0 {
+        return 0.0;
+    }
+    100.0 * f64::from(num) / f64::from(den)
+}
+
+/// Render a mean-F1 cell, blanking the not-applicable adversarial case.
+fn fmt_f1(value: f64) -> String {
+    if value.is_nan() {
+        return "  -  ".to_string();
+    }
+    format!("{value:.2}")
+}

--- a/crates/velesdb-memory/src/error.rs
+++ b/crates/velesdb-memory/src/error.rs
@@ -28,4 +28,9 @@ pub enum MemoryError {
     /// Failure producing a text embedding.
     #[error("embedding error: {0}")]
     Embed(#[from] EmbedError),
+
+    /// A fused-recall filter referenced a field name that is not a plain
+    /// identifier (alphanumeric/underscore).
+    #[error("invalid filter field: {0}")]
+    InvalidFilter(String),
 }

--- a/crates/velesdb-memory/src/lib.rs
+++ b/crates/velesdb-memory/src/lib.rs
@@ -36,5 +36,6 @@ pub use embedder::{EmbedError, Embedder, HashEmbedder};
 pub use embedder::{OllamaEmbedder, DEFAULT_OLLAMA_MODEL, DEFAULT_OLLAMA_URL};
 pub use error::MemoryError;
 pub use service::{
-    Explanation, Link, MemoryEdge, MemoryNode, MemoryService, Metadata, Recollection,
+    ColumnFilter, ColumnOp, Explanation, Link, MemoryEdge, MemoryNode, MemoryService, Metadata,
+    Recollection,
 };

--- a/crates/velesdb-memory/src/mcp.rs
+++ b/crates/velesdb-memory/src/mcp.rs
@@ -14,7 +14,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::embedder::Embedder;
-use crate::service::{Explanation, Link, MemoryService, Metadata, Recollection};
+use crate::service::{ColumnFilter, Explanation, Link, MemoryService, Metadata, Recollection};
 
 /// Default number of memories returned by `recall`.
 const DEFAULT_RECALL_LIMIT: usize = 10;
@@ -74,6 +74,21 @@ struct RecallParams {
 struct RecallResult {
     /// Recalled memories, most similar first.
     memories: Vec<Recollection>,
+}
+
+/// Parameters for the `recall_where` tool.
+#[derive(Deserialize, JsonSchema)]
+struct RecallWhereParams {
+    /// Natural-language query to match semantically.
+    query: String,
+    /// Maximum number of memories to return (default 10).
+    limit: Option<usize>,
+    /// Structured `ColumnStore` predicates (ranges/comparisons) ANDed together,
+    /// e.g. a date window `[{"field":"ts","op":"ge","value":20230101},
+    /// {"field":"ts","op":"le","value":20231231}]`. Each `op` is one of
+    /// `eq`/`ne`/`lt`/`le`/`gt`/`ge`.
+    #[serde(default)]
+    filters: Vec<ColumnFilter>,
 }
 
 /// Parameters for the `relate` tool.
@@ -182,6 +197,25 @@ impl McpServer {
     }
 
     #[tool(
+        name = "recall_where",
+        description = "Fused recall: semantically similar memories (vector) constrained by structured ColumnStore predicates over metadata — ranges and comparisons, not just equality. Each filter is {field, op (eq/ne/lt/le/gt/ge), value}, ANDed. Use for time-windowed or numeric-scoped recall, e.g. facts about a topic with `ts` in a date range. Most similar first."
+    )]
+    async fn recall_where(
+        &self,
+        Parameters(params): Parameters<RecallWhereParams>,
+    ) -> Result<Json<RecallResult>, ErrorData> {
+        let limit = params
+            .limit
+            .unwrap_or(DEFAULT_RECALL_LIMIT)
+            .min(MAX_RECALL_LIMIT);
+        let memories = self
+            .service
+            .recall_where(&params.query, limit, &params.filters)
+            .map_err(to_error)?;
+        Ok(Json(RecallResult { memories }))
+    }
+
+    #[tool(
         name = "relate",
         description = "Create a typed link from one memory to another. Returns the edge id."
     )]
@@ -257,7 +291,9 @@ impl ServerHandler for McpServer {
 fn to_error(err: crate::error::MemoryError) -> ErrorData {
     use crate::error::MemoryError;
     let code = match &err {
-        MemoryError::EmptyFact | MemoryError::UnknownMemory(_) => ErrorCode::INVALID_PARAMS,
+        MemoryError::EmptyFact | MemoryError::UnknownMemory(_) | MemoryError::InvalidFilter(_) => {
+            ErrorCode::INVALID_PARAMS
+        }
         _ => ErrorCode::INTERNAL_ERROR,
     };
     ErrorData::new(code, err.to_string(), None)
@@ -267,6 +303,7 @@ fn to_error(err: crate::error::MemoryError) -> ErrorData {
 mod tests {
     use super::*;
     use crate::embedder::HashEmbedder;
+    use crate::service::ColumnOp;
     use tempfile::TempDir;
 
     const DECISION: &str = "we chose parking_lot to avoid lock poisoning";
@@ -441,7 +478,72 @@ mod tests {
         assert!(recalled.memories.iter().all(|m| m.id != dropped.id));
     }
 
+    /// Build a `{"ts": <n>}` metadata map.
+    fn ts_meta(ts: i64) -> Metadata {
+        let mut meta = Metadata::new();
+        meta.insert("ts".to_owned(), serde_json::json!(ts));
+        meta
+    }
+
+    #[tokio::test]
+    async fn recall_where_filters_by_range_through_the_server() {
+        let (_dir, srv) = server();
+        for (fact, ts) in [
+            ("kickoff in january", 20_230_115),
+            ("kickoff in june", 20_230_615),
+        ] {
+            srv.remember(Parameters(RememberParams {
+                fact: fact.to_owned(),
+                links: Vec::new(),
+                metadata: Some(ts_meta(ts)),
+            }))
+            .await
+            .expect("remember");
+        }
+
+        let Json(res) = srv
+            .recall_where(Parameters(RecallWhereParams {
+                query: "kickoff".to_owned(),
+                limit: None,
+                filters: vec![ColumnFilter {
+                    field: "ts".to_owned(),
+                    op: ColumnOp::Ge,
+                    value: serde_json::json!(20_230_601),
+                }],
+            }))
+            .await
+            .expect("recall_where");
+
+        assert!(
+            res.memories.iter().any(|m| m.content.contains("june")),
+            "the june fact is within the ts range"
+        );
+        assert!(
+            res.memories.iter().all(|m| !m.content.contains("january")),
+            "the january fact is below the ts range and excluded"
+        );
+    }
+
     // --- Error-code mapping -------------------------------------------------
+
+    #[tokio::test]
+    async fn recall_where_invalid_field_returns_invalid_params() {
+        let (_dir, srv) = server();
+        let err = srv
+            .recall_where(Parameters(RecallWhereParams {
+                query: "anything".to_owned(),
+                limit: None,
+                filters: vec![ColumnFilter {
+                    field: "ts; DROP TABLE".to_owned(),
+                    op: ColumnOp::Ge,
+                    value: serde_json::json!(1),
+                }],
+            }))
+            .await
+            .map(|_| ())
+            .expect_err("a non-identifier filter field must be rejected");
+        assert_eq!(err.code, ErrorCode::INVALID_PARAMS);
+    }
 
     #[tokio::test]
     async fn empty_fact_returns_invalid_params_not_internal_error() {

--- a/crates/velesdb-memory/src/mcp.rs
+++ b/crates/velesdb-memory/src/mcp.rs
@@ -83,7 +83,7 @@ struct RecallWhereParams {
     query: String,
     /// Maximum number of memories to return (default 10).
     limit: Option<usize>,
-    /// Structured `ColumnStore` predicates (ranges/comparisons) ANDed together,
+    /// Structured `ColumnStore` predicates (ranges/comparisons) combined with AND,
     /// e.g. a date window `[{"field":"ts","op":"ge","value":20230101},
     /// {"field":"ts","op":"le","value":20231231}]`. Each `op` is one of
     /// `eq`/`ne`/`lt`/`le`/`gt`/`ge`.

--- a/crates/velesdb-memory/src/service.rs
+++ b/crates/velesdb-memory/src/service.rs
@@ -1,14 +1,14 @@
 //! The memory service: five operations over the in-core Agent Memory SDK.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::path::Path;
 use std::sync::Arc;
 
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use serde_json::{Map, Value};
+use serde_json::{json, Map, Value};
 use velesdb_core::agent::AgentMemory;
-use velesdb_core::Database;
+use velesdb_core::{Database, SearchResult};
 
 /// Structured metadata attached to a memory (the `ColumnStore` facet): exact-match
 /// fields like `project`, `author`, `type`, `status`, `date`. `content` and
@@ -37,6 +37,53 @@ pub struct Recollection {
     pub score: f32,
     /// Stored fact content.
     pub content: String,
+}
+
+/// Comparison operator for a [`ColumnFilter`] in [`MemoryService::recall_where`].
+#[derive(Debug, Clone, Copy, Deserialize, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum ColumnOp {
+    /// `=`
+    Eq,
+    /// `!=`
+    Ne,
+    /// `<`
+    Lt,
+    /// `<=`
+    Le,
+    /// `>`
+    Gt,
+    /// `>=`
+    Ge,
+}
+
+impl ColumnOp {
+    /// The `VelesQL` operator token.
+    fn as_sql(self) -> &'static str {
+        match self {
+            Self::Eq => "=",
+            Self::Ne => "!=",
+            Self::Lt => "<",
+            Self::Le => "<=",
+            Self::Gt => ">",
+            Self::Ge => ">=",
+        }
+    }
+}
+
+/// A structured predicate over a memory's metadata column, for the fused
+/// vector+`ColumnStore` recall [`MemoryService::recall_where`]. Unlike the
+/// exact-match filter on [`MemoryService::recall`], this supports ranges and
+/// comparisons (e.g. `timestamp >= …`), so temporal and numeric facets become
+/// queryable, not just equal-matchable.
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+pub struct ColumnFilter {
+    /// Metadata field name (alphanumeric/underscore).
+    pub field: String,
+    /// Comparison operator.
+    pub op: ColumnOp,
+    /// Value to compare against (numbers, strings, booleans).
+    pub value: Value,
 }
 
 /// A node in an [`Explanation`] subgraph.
@@ -215,6 +262,70 @@ impl<E: Embedder> MemoryService<E> {
         }
     }
 
+    /// Fused recall: semantic `NEAR` search combined with structured
+    /// `ColumnStore` predicates over metadata columns — ranges and comparisons,
+    /// not just the equality of [`Self::recall`]. One query spanning the vector
+    /// and column facets (e.g. "most similar facts **with `timestamp` in this
+    /// window**"), which a vector-only or equality-only recall cannot express.
+    ///
+    /// Filter *values* are bound as query parameters (never interpolated), so
+    /// they cannot inject; filter *field names* are validated to be plain
+    /// identifiers. Results come back in similarity order.
+    ///
+    /// # Errors
+    /// Returns [`MemoryError::InvalidFilter`] if a filter field is not a plain
+    /// identifier, [`MemoryError::Embed`] if the query cannot be embedded, or a
+    /// storage error if the query fails. An empty query or `k == 0` yields `[]`.
+    pub fn recall_where(
+        &self,
+        query: &str,
+        k: usize,
+        filters: &[ColumnFilter],
+    ) -> Result<Vec<Recollection>, MemoryError> {
+        let query = query.trim();
+        if query.is_empty() || k == 0 {
+            return Ok(Vec::new());
+        }
+        let embedding = self.embedder.embed(query)?;
+        let (sql, params) = self.build_fused_query(&embedding, k, filters)?;
+        let results = self
+            .memory
+            .query_semantic(&sql, &params)
+            .map_err(MemoryError::from)?;
+        Ok(results.iter().map(to_recollection).collect())
+    }
+
+    /// Build the `VelesQL` for [`Self::recall_where`]: a `NEAR` predicate plus
+    /// one bound parameter per filter, against the semantic collection.
+    fn build_fused_query(
+        &self,
+        embedding: &[f32],
+        k: usize,
+        filters: &[ColumnFilter],
+    ) -> Result<(String, HashMap<String, Value>), MemoryError> {
+        use std::fmt::Write as _;
+        let mut params: HashMap<String, Value> = HashMap::new();
+        params.insert("q".to_string(), json!(embedding));
+        let mut predicate = String::from("vector NEAR $q");
+        for (index, filter) in filters.iter().enumerate() {
+            validate_field(&filter.field)?;
+            let key = format!("p{index}");
+            // Field is a validated identifier; the value is bound, never inlined.
+            let _ = write!(
+                predicate,
+                " AND {} {} ${key}",
+                filter.field,
+                filter.op.as_sql()
+            );
+            params.insert(key, filter.value.clone());
+        }
+        let sql = format!(
+            "SELECT * FROM {} WHERE {predicate} LIMIT {k}",
+            self.memory.semantic().collection_name()
+        );
+        Ok((sql, params))
+    }
+
     /// Create a typed edge `from -> to`. Returns the edge id.
     ///
     /// Both endpoints are validated to exist first, so the tool reports an
@@ -335,5 +446,34 @@ impl<E: Embedder> MemoryService<E> {
             });
         }
         Ok(())
+    }
+}
+
+/// Map a core search result to a [`Recollection`], lifting the fact text out of
+/// the reserved `content` payload key.
+fn to_recollection(result: &SearchResult) -> Recollection {
+    let content = result
+        .point
+        .payload
+        .as_ref()
+        .and_then(|payload| payload.get("content"))
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_owned();
+    Recollection {
+        id: result.point.id,
+        score: result.score,
+        content,
+    }
+}
+
+/// Accept only plain identifier field names, so a filter field can be safely
+/// placed into the query text (its value is always a bound parameter).
+fn validate_field(field: &str) -> Result<(), MemoryError> {
+    let valid = !field.is_empty() && field.chars().all(|c| c.is_ascii_alphanumeric() || c == '_');
+    if valid {
+        Ok(())
+    } else {
+        Err(MemoryError::InvalidFilter(field.to_owned()))
     }
 }

--- a/crates/velesdb-memory/src/service.rs
+++ b/crates/velesdb-memory/src/service.rs
@@ -309,6 +309,7 @@ impl<E: Embedder> MemoryService<E> {
         let mut predicate = String::from("vector NEAR $q");
         for (index, filter) in filters.iter().enumerate() {
             validate_field(&filter.field)?;
+            validate_scalar(&filter.value)?;
             let key = format!("p{index}");
             // Field is a validated identifier; the value is bound, never inlined.
             let _ = write!(
@@ -467,13 +468,30 @@ fn to_recollection(result: &SearchResult) -> Recollection {
     }
 }
 
-/// Accept only plain identifier field names, so a filter field can be safely
-/// placed into the query text (its value is always a bound parameter).
+/// Accept only plain, non-reserved identifier field names, so a filter field
+/// can be safely placed into the query text (its value is always a bound
+/// parameter). Rejects the reserved system columns the docs promise are off
+/// limits: `content` (the fact payload) and any `_veles_`-prefixed engine key
+/// (e.g. durable TTL).
 fn validate_field(field: &str) -> Result<(), MemoryError> {
-    let valid = !field.is_empty() && field.chars().all(|c| c.is_ascii_alphanumeric() || c == '_');
-    if valid {
+    let plain = !field.is_empty() && field.chars().all(|c| c.is_ascii_alphanumeric() || c == '_');
+    let reserved = field == "content" || field.starts_with("_veles_");
+    if plain && !reserved {
         Ok(())
     } else {
         Err(MemoryError::InvalidFilter(field.to_owned()))
+    }
+}
+
+/// Reject non-scalar filter values. Only strings, numbers, and booleans can be
+/// compared against a `ColumnStore` column; binding an array/object/null would
+/// fail deep in the query engine and surface as an opaque internal error instead
+/// of a clear client-input error.
+fn validate_scalar(value: &Value) -> Result<(), MemoryError> {
+    match value {
+        Value::String(_) | Value::Number(_) | Value::Bool(_) => Ok(()),
+        _ => Err(MemoryError::InvalidFilter(format!(
+            "value must be a string, number, or boolean, got {value}"
+        ))),
     }
 }

--- a/crates/velesdb-memory/tests/columnstore_bdd.rs
+++ b/crates/velesdb-memory/tests/columnstore_bdd.rs
@@ -296,3 +296,50 @@ fn recall_where_rejects_non_identifier_field() {
         .expect_err("a non-identifier field must be rejected");
     assert!(matches!(err, MemoryError::InvalidFilter(_)));
 }
+
+#[test]
+fn recall_where_rejects_reserved_field() {
+    let (_dir, svc, _) = seeded_timestamps();
+    // Reserved system columns the docs promise are off limits.
+    for reserved in ["content", "_veles_expires_at", "_veles_hub"] {
+        let err = svc
+            .recall_where(
+                "project",
+                10,
+                &[ColumnFilter {
+                    field: reserved.to_string(),
+                    op: ColumnOp::Eq,
+                    value: json!(1),
+                }],
+            )
+            .expect_err("a reserved field must be rejected");
+        assert!(
+            matches!(err, MemoryError::InvalidFilter(_)),
+            "reserved field {reserved} must be InvalidFilter"
+        );
+    }
+}
+
+#[test]
+fn recall_where_rejects_non_scalar_value() {
+    let (_dir, svc, _) = seeded_timestamps();
+    // An array/object/null value can't be compared against a column; it must be
+    // a clear client-input error (InvalidFilter), not an opaque internal error.
+    for bad in [json!([1, 2, 3]), json!({"x": 1}), json!(null)] {
+        let err = svc
+            .recall_where(
+                "project",
+                10,
+                &[ColumnFilter {
+                    field: "ts".to_string(),
+                    op: ColumnOp::Eq,
+                    value: bad.clone(),
+                }],
+            )
+            .expect_err("a non-scalar value must be rejected");
+        assert!(
+            matches!(err, MemoryError::InvalidFilter(_)),
+            "non-scalar value {bad} must be InvalidFilter"
+        );
+    }
+}

--- a/crates/velesdb-memory/tests/columnstore_bdd.rs
+++ b/crates/velesdb-memory/tests/columnstore_bdd.rs
@@ -9,7 +9,7 @@ mod common;
 use common::{meta, service};
 use serde_json::json;
 use tempfile::TempDir;
-use velesdb_memory::{HashEmbedder, MemoryService};
+use velesdb_memory::{ColumnFilter, ColumnOp, HashEmbedder, MemoryError, MemoryService};
 
 /// Seed one `veles`-project and one `acme`-project "auth bug" fact; returns the
 /// service plus the two ids.
@@ -204,4 +204,95 @@ fn filter_with_no_match_returns_empty() {
         .expect("recall");
 
     assert!(hits.is_empty(), "no fact matches the filter");
+}
+
+// --- Nominal: fused vector + `ColumnStore` range (recall_where) ---------------
+
+/// Seed three "project kickoff" facts at ascending `ts` timestamps.
+fn seeded_timestamps() -> (TempDir, MemoryService<HashEmbedder>, [u64; 3]) {
+    let (dir, svc) = service();
+    let early = svc
+        .remember(
+            "project kickoff meeting",
+            &[],
+            Some(&meta(&[("ts", json!(100))])),
+        )
+        .expect("remember early");
+    let mid = svc
+        .remember(
+            "project kickoff follow-up",
+            &[],
+            Some(&meta(&[("ts", json!(200))])),
+        )
+        .expect("remember mid");
+    let late = svc
+        .remember(
+            "project kickoff retrospective",
+            &[],
+            Some(&meta(&[("ts", json!(300))])),
+        )
+        .expect("remember late");
+    (dir, svc, [early, mid, late])
+}
+
+#[test]
+fn recall_where_filters_by_numeric_range() {
+    let (_dir, svc, [early, mid, late]) = seeded_timestamps();
+
+    let hits = svc
+        .recall_where(
+            "project kickoff",
+            10,
+            &[ColumnFilter {
+                field: "ts".to_string(),
+                op: ColumnOp::Ge,
+                value: json!(200),
+            }],
+        )
+        .expect("recall_where range");
+
+    let ids: Vec<u64> = hits.iter().map(|h| h.id).collect();
+    assert!(
+        ids.contains(&mid) && ids.contains(&late),
+        "ts >= 200 facts present"
+    );
+    assert!(!ids.contains(&early), "ts = 100 fact excluded by the range");
+    assert!(
+        hits.iter().all(|h| !h.content.is_empty()),
+        "content is lifted from payload"
+    );
+}
+
+// --- Edge: empty query / zero budget ------------------------------------------
+
+#[test]
+fn recall_where_empty_query_or_zero_k_is_empty() {
+    let (_dir, svc, _) = seeded_timestamps();
+    assert!(svc
+        .recall_where("   ", 10, &[])
+        .expect("blank query")
+        .is_empty());
+    assert!(svc
+        .recall_where("project", 0, &[])
+        .expect("zero k")
+        .is_empty());
+}
+
+// --- Negative: an unsafe field name is rejected, not interpolated --------------
+
+#[test]
+fn recall_where_rejects_non_identifier_field() {
+    let (_dir, svc, _) = seeded_timestamps();
+    let err = svc
+        .recall_where(
+            "project",
+            10,
+            &[ColumnFilter {
+                field: "ts; DROP TABLE".to_string(),
+                op: ColumnOp::Ge,
+                value: json!(1),
+            }],
+        )
+        .expect_err("a non-identifier field must be rejected");
+    assert!(matches!(err, MemoryError::InvalidFilter(_)));
 }


### PR DESCRIPTION
Two logical blocks on `develop`. The first commit (public API) reviews cleanly on its own.

## A — `recall_where`: fused vector + ColumnStore filtered recall  (commit cc3b1a14)
Exposes the previously **sealed** ColumnStore range/comparison power through the shipped crate's public API:
- `MemoryService::recall_where(query, k, &[ColumnFilter])` — fuses vector recall with ColumnStore predicates via VelesQL `query_semantic`, values bound as params, field names validated.
- `ColumnFilter` / `ColumnOp`, `MemoryError::InvalidFilter` (mapped to MCP `INVALID_PARAMS`), `recall_where` MCP tool, re-exports.
- BDD + MCP tests. **Semver-relevant** (public API surface) — review this commit independently.

## B — Real LoCoMo benchmark  (commit 0efea885)
`examples/locomo/` (gated `required-features=["ollama"]`): dataset loader → per-session LLM fact extraction (tagged with gold `dia_id`s + topical entities) → bidirectional fact↔entity graph ingest → two equal-budget eval modes (vector vs vector+graph+column) → hybrid LLM-judge + deterministic evidence/F1 score. Plus an LLM-free `--explanation` mode measuring multi-hop evidence coverage. Dataset + per-call caches are fetched/produced on demand and gitignored.

### Honest results (don't oversell)
- **QA accuracy:** vector ≈35% on conv-26; entity-graph augmentation is **neutral-to-negative** (graph-connected facts are topically related but not answer-bearing → distractors). `graph_boost` defaulted to a gentle 0.15.
- **Explanation (`--explanation`):** multi-hop evidence coverage **42% → 49% (+7pp)** — this is where the graph's real wedge shows; LoCoMo's accuracy metric doesn't capture it.
- ColumnStore is real + tested, but LoCoMo temporal Qs ask *for* a date rather than *scoping* a window, so the date filter rarely fires.

## Verification
`cargo test -p velesdb-memory` → 46 passed · `cargo clippy -p velesdb-memory --all-targets -- -D warnings` clean · `cargo fmt --check` clean.
A full 10-conversation baseline run is in progress for the official headline numbers (the conclusion above won't change).