### PR TITLE
fix(ci): make pre-commit hook executable and bash-3.2 portable

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -19,8 +19,11 @@ GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 NC='\033[0m' # No Color
 
-# Check if we have staged Rust files
-mapfile -t STAGED_RS_FILES < <(git diff --cached --name-only --diff-filter=ACM | grep '\.rs$' || true)
+# Check if we have staged Rust files (portable: macOS ships bash 3.2, no mapfile)
+STAGED_RS_FILES=()
+while IFS= read -r _rs_file; do
+    [ -n "$_rs_file" ] && STAGED_RS_FILES+=("$_rs_file")
+done < <(git diff --cached --name-only --diff-filter=ACM | grep '\.rs$' || true)
 
 if [ ${#STAGED_RS_FILES[@]} -eq 0 ]; then
     echo -e "${YELLOW}⚠️  No Rust files staged, skipping Rust checks${NC}"


### PR DESCRIPTION
The repo's local quality gate has been silently dead. Two bugs:

1. **Not executable** — `.githooks/pre-commit` is tracked `100644` while `core.hooksPath=.githooks`, so git ignores it (`hint: hook ignored because it's not set as executable`). The fmt/clippy/test/secrets gate never fires on commit for anyone who clones.
2. **bash-4-ism** — once made executable it crashes on macOS: it uses `mapfile` (bash 4+) and macOS ships bash 3.2, so under `set -e` the hook dies with `mapfile: command not found`.

### Fix
- Flip tracked mode `100644 → 100755`.
- Replace `mapfile -t ARR < <(...)` with a portable `while IFS= read -r` loop (works in bash 3.2 and 4+). No behavior change otherwise.

### Verify
Ran the hook directly under macOS bash 3.2: no staged `.rs` → skips Rust checks, secrets check passes, exit 0. The commit on this branch itself went through the now-live hook.