### PR TITLE
docs(examples): Python wedge quickstart — why() reaches what recall misses

### DIFF
--- a/examples/agent_memory/README.md
+++ b/examples/agent_memory/README.md
@@ -21,11 +21,39 @@ no model download, and no internet.
 
 | File | Language | What it shows | How to run |
 |------|----------|---------------|------------|
+| `wedge_quickstart.py` | Python | **The differentiator:** `MemoryService.why()` reaches a 2-hop memory that plain `recall()` misses. Start here. | `python wedge_quickstart.py` |
 | `agent_loop.py` | Python | Full agent loop: semantic + episodic + procedural, plus a TTL + snapshot cycle. Doubles as a smoke test (prints a trace and exits 0). | `python agent_loop.py` |
 | `snapshot_ttl.rs` | Rust | `velesdb-core` public API: namespaced TTL, `auto_expire`, snapshot save/load round-trip. | `cargo run --bin snapshot_ttl` |
 | `agent_memory.ts` | TypeScript | `db.agentMemory()` SDK facade: `storeFact` / `recordEvent` / `learnProcedure` and their recall counterparts. Needs a running `velesdb-server`. | `npx tsx agent_memory.ts` |
 
-## Python (`agent_loop.py`) — start here
+## The wedge — `why()` (start here)
+
+`wedge_quickstart.py` uses the high-level `MemoryService` (`remember` / `recall` /
+`relate` / `forget` / `why`) and shows the one thing pure vector search can't do:
+
+```bash
+cd crates/velesdb-python && maturin develop && cd -   # or: pip install velesdb
+python examples/agent_memory/wedge_quickstart.py
+```
+
+```text
+recall('why did we choose parking_lot')   [vector similarity only]
+   0.28  we chose parking_lot to avoid lock poisoning after a panic
+   0.16  PR #42 swaps the std Mutex for parking_lot
+   └─ EPIC-317 is nowhere here: it shares no words with the question.
+
+why('why did we choose parking_lot')      [vector seed + graph traversal]
+   hop 0  we chose parking_lot ...
+   hop 1  PR #42 ...
+   hop 2  EPIC-317: intermittent CI hang under load
+   └─ the graph reached the very ticket the decision fixed.
+```
+
+`recall` ranks by resemblance, so the ticket (which shares no words with the
+question) is invisible to it. `why` seeds on the closest memory and walks the
+typed links to reach it. That connected context is the differentiator.
+
+## Python (`agent_loop.py`) — the primitive layer
 
 Self-contained; it is also the smoke test for this directory.
 

--- a/examples/agent_memory/wedge_quickstart.py
+++ b/examples/agent_memory/wedge_quickstart.py
@@ -1,0 +1,61 @@
+"""The wedge in 60 seconds — what `why()` does that plain recall can't.
+
+Offline, deterministic, no API key. Run:
+
+    cd crates/velesdb-python && maturin develop && cd -   # or: pip install velesdb
+    python examples/agent_memory/wedge_quickstart.py
+
+It stores a small decision trail (decision -> PR -> ticket) wired with typed
+links, then asks the same question two ways:
+
+* `recall()` ranks by vector similarity and is blind to the ticket, which shares
+  no words with the question.
+* `why()` seeds on the closest memory and walks the graph, reaching the very
+  ticket the decision fixed.
+
+That gap — connected context a similarity search misses — is the product.
+"""
+
+import tempfile
+
+from velesdb import MemoryService
+
+
+def main() -> None:
+    # "hash" embedder: deterministic, offline, no model download.
+    mem = MemoryService(tempfile.mkdtemp())
+
+    # A decision trail wired with typed links: the decision was made in a PR,
+    # which fixes the original ticket.
+    ticket = mem.remember("EPIC-317: intermittent CI hang under load")
+    pr = mem.remember(
+        "PR #42 swaps the std Mutex for parking_lot",
+        links=[(ticket, "fixes")],
+    )
+    mem.remember(
+        "we chose parking_lot to avoid lock poisoning after a panic",
+        links=[(pr, "decided_in")],
+    )
+
+    question = "why did we choose parking_lot"
+
+    print(f"recall({question!r})   [vector similarity only]")
+    for h in mem.recall(question, k=2):
+        print(f"   {h['score']:.2f}  {h['content']}")
+    recalled = {h["content"] for h in mem.recall(question, k=2)}
+    assert not any("EPIC-317" in c for c in recalled), (
+        "the ticket shares no words with the question, so recall is blind to it"
+    )
+    print("   └─ EPIC-317 is nowhere here: it shares no words with the question.\n")
+
+    print(f"why({question!r})      [vector seed + graph traversal]")
+    explanation = mem.why(question, max_hops=2)
+    for node in explanation["nodes"]:
+        print(f"   hop {node['hop']}  {node['content']}")
+    reached = {node["content"] for node in explanation["nodes"]}
+    assert any("EPIC-317" in c for c in reached), "why() must reach the ticket via the graph"
+    print("   └─ the graph reached the very ticket the decision fixed. That gap is the product.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
A 60-second, offline, deterministic Python demo of the **wedge**, using the new `MemoryService` binding (PR #1242). It's the "see it in 30 seconds" entry point a Python dev runs to understand what `why()` does that mem0/plain vector recall can't.

It wires a decision trail (`decision → PR → ticket`) with typed links, then asks the same question two ways:
- `recall(k=2)` ranks by similarity → returns the decision + PR, **blind** to the ticket (shares no words with the question).
- `why()` seeds on the closest memory and walks the graph → reaches `hop 2  EPIC-317`, the very ticket the decision fixed.

Self-asserting (exits 0), no API key, no model download. Featured at the top of `examples/agent_memory/README.md`.

Verified: runs green against the binding built via `maturin develop` from current develop.