### PR TITLE
perf(memory): index the filtered recall path (recall_where prefilters, no O(n) scan)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6734,6 +6734,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "velesdb-core",
+ "velesdb-memory",
 ]
 
 [[package]]

--- a/crates/velesdb-core/Cargo.toml
+++ b/crates/velesdb-core/Cargo.toml
@@ -189,6 +189,10 @@ name = "filter_benchmark"
 harness = false
 
 [[bench]]
+name = "recall_where_scaling_benchmark"
+harness = false
+
+[[bench]]
 name = "velesql_benchmark"
 harness = false
 

--- a/crates/velesdb-core/benches/recall_where_scaling_benchmark.rs
+++ b/crates/velesdb-core/benches/recall_where_scaling_benchmark.rs
@@ -1,0 +1,134 @@
+//! Criterion benchmark for the **filtered semantic recall** path (`recall_where`).
+//!
+//! `recall_where` issues a `vector NEAR $q AND <field> <op> $v` query, which the
+//! planner runs one of two ways:
+//! - **Post-filter (no index):** oversample HNSW, then linearly scan candidate
+//!   payloads — work grows O(n) with the collection, so a selective filter that
+//!   prunes to a handful of rows still pays for the whole collection.
+//! - **Bitmap prefilter (indexed):** resolve the predicate to an id bitmap from
+//!   the secondary B-tree index first, so search cost tracks the *matching* set,
+//!   not the collection size.
+//!
+//! Until P3, the agent's `_semantic_memory` collection never created the index,
+//! so `recall_where` always took the O(n) post-filter path. This benchmark
+//! contrasts the two at a fixed, selective range filter as the collection grows:
+//! the indexed series should stay roughly flat while the post-filter series
+//! climbs with `n`.
+//!
+//! Run with: `cargo bench --bench recall_where_scaling_benchmark`
+
+#![allow(
+    clippy::cast_precision_loss,
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss
+)]
+
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use serde_json::json;
+use velesdb_core::filter::{Condition, Filter};
+use velesdb_core::{DistanceMetric, Point, StorageMode, VectorCollection};
+
+/// Vector dimensionality (small — this bench is about filter strategy, not ANN).
+const DIM: usize = 16;
+/// Collection sizes to sweep; the post-filter cost should climb with these.
+const SIZES: &[u64] = &[2_000, 10_000, 50_000];
+/// Number of rows the range filter keeps, independent of collection size, so
+/// selectivity tightens as `n` grows — exactly where O(n) post-filtering hurts.
+const MATCHING_ROWS: u64 = 100;
+
+/// Deterministic unit vector for a given id.
+fn make_vector(id: u64) -> Vec<f32> {
+    let mut v: Vec<f32> = (0..DIM)
+        .map(|d| ((id as f32) * 0.13 + (d as f32) * 0.07).cos())
+        .collect();
+    let norm = v.iter().map(|x| x * x).sum::<f32>().sqrt();
+    if norm > 0.0 {
+        for x in &mut v {
+            *x /= norm;
+        }
+    }
+    v
+}
+
+/// Deterministic normalized query vector.
+fn query_vector() -> Vec<f32> {
+    let mut v: Vec<f32> = (0..DIM).map(|d| (d as f32 * 0.1).sin()).collect();
+    let norm = v.iter().map(|x| x * x).sum::<f32>().sqrt();
+    if norm > 0.0 {
+        for x in &mut v {
+            *x /= norm;
+        }
+    }
+    v
+}
+
+/// Builds a collection of `n` points, each carrying a `ts` field equal to its id
+/// (`0..n`). When `indexed`, a secondary index on `ts` is created so filtered
+/// search takes the bitmap-prefilter path; otherwise it falls back to O(n)
+/// post-filtering.
+fn setup_collection(dir: &std::path::Path, n: u64, indexed: bool) -> VectorCollection {
+    let collection = VectorCollection::create(
+        dir.join("bench_col"),
+        "bench_col",
+        DIM,
+        DistanceMetric::Cosine,
+        StorageMode::Full,
+    )
+    .expect("bench: create collection");
+
+    let points: Vec<Point> = (0..n)
+        .map(|id| Point::new(id, make_vector(id), Some(json!({ "ts": id }))))
+        .collect();
+    collection.upsert(points).expect("bench: upsert");
+
+    if indexed {
+        // Created after the bulk upsert to exercise the backfill path the agent
+        // hits on the first `recall_where` over an already-populated store.
+        collection
+            .create_index("ts")
+            .expect("bench: create secondary index");
+    }
+    collection
+}
+
+/// A range filter keeping the top `MATCHING_ROWS` ids: `ts >= n - MATCHING_ROWS`.
+fn selective_range_filter(n: u64) -> Filter {
+    Filter::new(Condition::gte("ts", n.saturating_sub(MATCHING_ROWS)))
+}
+
+/// Sweeps both strategies across [`SIZES`]; compare the two series' slopes.
+fn bench_recall_where_scaling(c: &mut Criterion) {
+    let query = query_vector();
+    let mut group = c.benchmark_group("recall_where_scaling");
+
+    for &n in SIZES {
+        let filter = selective_range_filter(n);
+
+        let dir_idx = tempfile::tempdir().expect("bench: temp dir");
+        let indexed = setup_collection(dir_idx.path(), n, true);
+        group.bench_with_input(BenchmarkId::new("indexed_prefilter", n), &n, |b, _| {
+            b.iter(|| {
+                let results = indexed
+                    .search_with_filter(black_box(&query), 10, black_box(&filter))
+                    .expect("bench: indexed search");
+                black_box(results)
+            });
+        });
+
+        let dir_post = tempfile::tempdir().expect("bench: temp dir");
+        let post = setup_collection(dir_post.path(), n, false);
+        group.bench_with_input(BenchmarkId::new("post_filter_on", n), &n, |b, _| {
+            b.iter(|| {
+                let results = post
+                    .search_with_filter(black_box(&query), 10, black_box(&filter))
+                    .expect("bench: post-filter search");
+                black_box(results)
+            });
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_recall_where_scaling);
+criterion_main!(benches);

--- a/crates/velesdb-core/src/agent/semantic_memory.rs
+++ b/crates/velesdb-core/src/agent/semantic_memory.rs
@@ -94,6 +94,29 @@ impl SemanticMemory {
         self.dimension
     }
 
+    /// Ensures a secondary index exists on `field` so filtered recall takes the
+    /// indexed bitmap prefilter instead of a linear post-filter scan.
+    ///
+    /// Idempotent and cheap to call on every filtered query: when the index is
+    /// already present this is a single `has_secondary_index` read. The first
+    /// call backfills existing payloads and records `field` in the persisted
+    /// `indexed_fields` authority (so the index is rebuilt on the next `open`,
+    /// not silently lost); subsequent upserts maintain it incrementally.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the collection is missing or persisting the index
+    /// authority fails.
+    pub fn ensure_index(&self, field: &str) -> Result<(), AgentMemoryError> {
+        let collection = memory_helpers::get_collection(&self.db, &self.collection_name)?;
+        if !collection.has_secondary_index(field) {
+            collection
+                .create_index(field)
+                .map_err(|e| AgentMemoryError::CollectionError(e.to_string()))?;
+        }
+        Ok(())
+    }
+
     /// Stores a semantic memory point.
     ///
     /// # Errors

--- a/crates/velesdb-core/src/agent/semantic_memory_tests.rs
+++ b/crates/velesdb-core/src/agent/semantic_memory_tests.rs
@@ -521,6 +521,38 @@ mod tests {
     }
 
     #[test]
+    fn test_ensure_index_creates_and_is_idempotent() {
+        let dir = tempdir().unwrap();
+        let db = Arc::new(Database::open(dir.path()).unwrap());
+        let sm = make_semantic(Arc::clone(&db));
+
+        let emb = vec![1.0_f32, 0.0, 0.0, 0.0];
+        let mut meta = serde_json::Map::new();
+        meta.insert("project".to_string(), serde_json::json!("veles"));
+        sm.store_with_metadata(1, "auth bug", &emb, &meta).unwrap();
+
+        let collection = db
+            .get_vector_collection(sm.collection_name())
+            .expect("semantic collection exists")
+            .inner;
+        assert!(
+            !collection.has_secondary_index("project"),
+            "no secondary index before ensure_index — recall would post-filter O(n)"
+        );
+
+        sm.ensure_index("project").expect("ensure_index");
+        assert!(
+            collection.has_secondary_index("project"),
+            "ensure_index activates the bitmap prefilter index on the field"
+        );
+
+        // Idempotent: a second call is a cheap no-op that still succeeds.
+        sm.ensure_index("project")
+            .expect("ensure_index is idempotent");
+        assert!(collection.has_secondary_index("project"));
+    }
+
+    #[test]
     fn test_query_filtered_skips_expired() {
         let dir = tempdir().unwrap();
         let db = Arc::new(Database::open(dir.path()).unwrap());

--- a/crates/velesdb-memory/src/service.rs
+++ b/crates/velesdb-memory/src/service.rs
@@ -475,6 +475,15 @@ impl<E: Embedder> MemoryService<E> {
         }
         let embedding = self.embedder.embed(query)?;
         let (sql, params) = self.build_fused_query(&embedding, k, filters)?;
+        // `build_fused_query` has validated every field name; ensure each one is
+        // indexed so the planner uses a bitmap prefilter instead of an O(n)
+        // post-filter scan. Idempotent and incrementally maintained thereafter.
+        for filter in filters {
+            self.memory
+                .semantic()
+                .ensure_index(&filter.field)
+                .map_err(MemoryError::from)?;
+        }
         let results = self
             .memory
             .query_semantic(&sql, &params)


### PR DESCRIPTION
## What

`recall_where` runs `vector NEAR $q AND <field> <op> $v`, but the agent's
`_semantic_memory` collection **never created a secondary index**, so the planner
always fell back to the post-filter path: oversample HNSW, then linearly scan
candidate payloads. Cost grew with the collection size even when the filter
pruned to a handful of rows — the O(n) cliff flagged in the pre-mortem (P3).

This activates the indexed prefilter that already existed in the engine but was
never reached from the agent layer:

- `SemanticMemory::ensure_index(field)` lazily creates + backfills the secondary
  B-tree index on first use. Idempotent (a cheap `has_secondary_index` read once
  present), persisted to `indexed_fields` (rebuilt on `open`), and maintained
  incrementally by subsequent upserts.
- `MemoryService::recall_where` calls it for each **validated** filter field
  before executing, so the planner resolves the predicate to an id bitmap and
  search cost tracks the *matching* set, not the collection size.

No new index type — reuses `SecondaryIndex` + `build_prefilter_bitmap`, already
wired into the `NEAR`+`WHERE` planner.

## Proof

New `recall_where_scaling_benchmark` (criterion) contrasts indexed-prefilter vs
post-filter as the collection grows under a fixed selective range filter:

| N | indexed_prefilter | post_filter (O(n)) |
|---|---|---|
| 2,000 | 10.4 µs | 53.8 µs |
| 10,000 | 11.4 µs | 56.2 µs |
| 50,000 | **9.9 µs** | **72.5 µs** |

Indexed stays ~flat as the collection ×25; post-filter starts ~5× slower and
climbs.

## Tests

- New unit test: `ensure_index` activates the index and is idempotent.
- Existing `recall_where` range/exact BDD tests pass unchanged → the indexed
  path returns identical results (it runs *before* the query in the same call).
- Full `velesdb-core` + `velesdb-memory` suites green; `fmt` clean; lizard
  CCN≤8/NLOC≤50 clean; clippy `-D warnings -D clippy::pedantic` clean on the
  changed targets.

Also syncs `Cargo.lock` (velesdb-python's `velesdb-memory` dep from #1242).