### PR TITLE
docs: document the Node agent-memory binding + update wedge-reach/license listings

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -78,9 +78,11 @@ The workspace is laid out as eight crates with one-way dependencies (no cycles).
 | **`velesdb-mobile`** | iOS / Android bindings via UniFFI. | Swift + Kotlin | One binding crate, two outputs. |
 | **`velesdb-cli`** | Interactive REPL for VelesQL. | Single binary | Wraps `velesdb-core`. |
 | **`velesdb-migrate`** | Migration tooling: import from Pinecone / Qdrant / Milvus / Weaviate / Chroma / Elasticsearch / Redis. | CLI tool | Strategic candidate to extract to a separate repo (see ROADMAP.md Horizon 4). |
+| **`velesdb-memory`** | Local-first MCP agent-memory server: the high-level `MemoryService` wedge (remember/recall/recall_where/relate/forget/why/remember_extracted). | MCP server + Rust/Python/Node API | Independent `0.1.0` cadence. Depends on `velesdb-core` (not the engine's `3.x` line). |
+| **`velesdb-node`** | Node.js (napi-rs) binding of the memory wedge. | `@wiscale/velesdb-memory-node` (npm) | Depends on `velesdb-memory` only (never `velesdb-core` directly) — the license boundary. |
 | **`tauri-plugin-velesdb`** | Tauri desktop integration. | Plugin | Used by `demos/tauri-rag-app`. |
 
-The dependency graph is strictly downward: `server`, `python`, `wasm`, `mobile`, `cli`, `migrate`, `tauri-plugin` all depend on `velesdb-core` and never on each other.
+The dependency graph is strictly downward: `server`, `python`, `wasm`, `mobile`, `cli`, `migrate`, `memory`, `tauri-plugin` all depend on `velesdb-core` and never on each other. `velesdb-node` is the one exception by design — it depends only on `velesdb-memory` (which re-exposes memory semantics), keeping the raw engine behind the license boundary.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Node.js binding for the agent-memory wedge (`@wiscale/velesdb-memory-node`).**
+  A new `crates/velesdb-node` napi-rs addon exposes the high-level `MemoryService`
+  in-process to Node (remember/recall/recallWhere/relate/forget/why/
+  rememberExtracted), mirroring the Python binding. Depends on `velesdb-memory`
+  only (never `velesdb-core`) — the license boundary; in-process, not a service.
+  All ops are async; `u64` ids cross as decimal strings (JS 2^53). (#1245)
+- **`MemoryService` wedge exposed in the Python SDK.** `from velesdb import
+  MemoryService` brings remember/recall/relate/forget/why/remember_extracted to
+  Python, reusing the same hardened Rust as the MCP server. (#1242)
+- **Indexed prefilter for filtered semantic recall (`recall_where`).** Filtered
+  recall now activates a secondary bitmap-prefilter index on first use instead of
+  an O(n) post-filter scan, so latency stays flat as the collection grows. (#1244)
 - **VelesQL conformance fixture pins the full `VelesqlErrorResponse` shape.**
   Conformance cases C002 (`VELESQL_MISSING_COLLECTION`), C003
   (`VELESQL_COLLECTION_NOT_FOUND`), and C007 (`VELESQL_AGGREGATION_ERROR`) now

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,6 +86,8 @@ New to the codebase? Start with these documents (in order):
 | `velesdb-wasm` | Browser-side vector search (no `persistence` feature) |
 | `velesdb-mobile` | iOS/Android bindings via UniFFI |
 | `velesdb-migrate` | Schema/data migration tooling |
+| `velesdb-memory` | MCP agent-memory server (`MemoryService` wedge: remember/recall/why) |
+| `velesdb-node` | Node.js binding of the memory wedge (napi-rs; `@wiscale/velesdb-memory-node`) |
 | `tauri-plugin-velesdb` | Tauri desktop integration |
 
 ## Quality Gates

--- a/README.md
+++ b/README.md
@@ -504,6 +504,8 @@ Ship AI features without a server. VelesDB embeds directly into Tauri, iOS, and 
 | **Python** | [velesdb-python](crates/velesdb-python) — PyO3 bindings + NumPy | `pip install velesdb` |
 | **TypeScript** | [typescript-sdk](sdks/typescript) — Node.js & Browser SDK | `npm install @wiscale/velesdb-sdk` |
 | **WASM** | [velesdb-wasm](crates/velesdb-wasm) — Browser-side vector search | `npm install @wiscale/velesdb-wasm` |
+| **Agent memory (MCP)** | [velesdb-memory](crates/velesdb-memory) — local-first MCP memory server (`why()` wedge) | `cargo install velesdb-memory` |
+| **Agent memory (Node)** | [velesdb-node](crates/velesdb-node) — in-process napi binding of the memory wedge | `npm install @wiscale/velesdb-memory-node` |
 | **Mobile** | [velesdb-mobile](crates/velesdb-mobile) — iOS (Swift) & Android (Kotlin) | [Build instructions](docs/guides/INSTALLATION.md#-mobile-iosandroid) |
 | **Desktop** | [tauri-plugin](crates/tauri-plugin-velesdb) — Tauri v2 AI-powered apps | `cargo add tauri-plugin-velesdb` |
 | **LangChain** | [langchain-velesdb](integrations/langchain) — Official VectorStore | [From source](integrations/langchain/README.md) |

--- a/crates/velesdb-memory/ARCHITECTURE.md
+++ b/crates/velesdb-memory/ARCHITECTURE.md
@@ -85,11 +85,12 @@ There are **two distinct memory layers**, exposed by different surfaces:
 | Layer | Type | Operations | Exposed by |
 |---|---|---|---|
 | **Primitive** | `SemanticMemory` / `EpisodicMemory` / `ProceduralMemory` | store / query / record / learn / `relate` / `query_excluding` | Python SDK, TS SDK, WASM, core |
-| **High-level** | `MemoryService` | remember / recall / relate / forget / **why** / **remember_extracted** | **velesdb-memory MCP server only** |
+| **High-level** | `MemoryService` | remember / recall / recall_where / relate / forget / **why** / **remember_extracted** | MCP server, Python (PyO3), Node (napi) |
 
-The high-level service maps five (now six) intent-level operations onto the
-primitive SDK. The wedge (`why`) and auto-extraction live **only** in the MCP
-layer today — surfacing them in Python/npm is the planned next step (P2).
+The high-level service maps these intent-level operations onto the primitive
+SDK. The wedge (`why`) and auto-extraction ship in all three bindings: the MCP
+server, the Python SDK (`velesdb-python`, `MemoryService` pyclass), and the
+Node.js binding (`velesdb-node`, npm `@wiscale/velesdb-memory-node`).
 
 ---
 
@@ -192,9 +193,9 @@ scaffolding: marked with the reserved `_veles_hub` key and **excluded from
 
 ## 8. Roadmap edges (not yet built)
 
-- **P2** — expose the high-level `MemoryService` (remember/recall/why/
-  remember_extracted) in the **Python and npm SDKs**; today they expose only the
-  primitive layer.
+- ~~**P2** — expose the high-level `MemoryService` in the Python and npm SDKs.~~
+  **DONE:** Python (`velesdb-python`, #1242) and Node (`velesdb-node` /
+  `@wiscale/velesdb-memory-node`, #1245) both ship the full wedge surface.
 - The `why` subgraph still includes intermediate topic-hub *nodes* (the
   connecting topic); collapsing them to direct fact→fact links is an optional
   presentation refinement.

--- a/crates/velesdb-memory/CHANGELOG.md
+++ b/crates/velesdb-memory/CHANGELOG.md
@@ -12,9 +12,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 First release of the local-first MCP memory server for AI agents.
 
 ### Added
-- Five MCP tools over stdio mapping onto VelesDB's in-core Agent Memory SDK:
-  `remember`, `recall`, `relate`, `forget`, and `why` (vector recall + multi-hop
-  graph traversal — the connected-subgraph differentiator).
+- MCP tools over stdio mapping onto VelesDB's in-core Agent Memory SDK:
+  `remember`, `recall`, `recall_where` (fused vector + ColumnStore range/filter
+  recall), `relate`, `forget`, `why` (vector recall + multi-hop graph traversal —
+  the connected-subgraph differentiator), and `remember_extracted` (auto text →
+  fact↔topic graph via an `Extractor`).
+- The same high-level `MemoryService` is consumed beyond the MCP server by the
+  Python binding (`velesdb-python`) and the Node.js binding (`velesdb-node` /
+  `@wiscale/velesdb-memory-node`); the library is feature-gated (`default-features
+  = false` drops the rmcp/tokio MCP stack) so bindings link a lean core.
+- `recall_where` activates a secondary bitmap-prefilter index on first use, so
+  filtered recall stays flat as the collection grows (instead of an O(n) scan).
 - Pluggable embeddings: a deterministic, offline `HashEmbedder` by default and an
   optional on-device `OllamaEmbedder` (`--features ollama`).
 - Structured metadata (ColumnStore facet) with exact-match filtering on `recall`

--- a/crates/velesdb-memory/README.md
+++ b/crates/velesdb-memory/README.md
@@ -206,9 +206,11 @@ content. Pass it to `relate` / `forget`, or as a `links[].target` on a later
 later, `why("…")` recovers not just the decision but the PR, ticket, and
 benchmark linked to it — where `recall` alone returns only look-alike text.
 
-> **Embedding the library directly?** The same operations are available as a
-> Rust API (`MemoryService::remember/recall/relate/forget/why`) — see the
-> rustdoc on [docs.rs](https://docs.rs/velesdb-memory).
+> **Embedding the library directly?** The same wedge is available without the
+> MCP server: as a **Rust** API (`MemoryService::remember/recall/relate/forget/why`,
+> see the rustdoc on [docs.rs](https://docs.rs/velesdb-memory)), in **Python**
+> (`from velesdb import MemoryService`), and in **Node.js**
+> (`npm install @wiscale/velesdb-memory-node`).
 
 ## Embedding backend
 

--- a/docs/LICENSING.md
+++ b/docs/LICENSING.md
@@ -27,6 +27,8 @@ the Core-licensed `velesdb-core` crate and does not redistribute the engine.
 | `velesdb-mobile` (iOS/Android libs) | yes | **Core License 1.0** |
 | `velesdb-cli` (binary) | yes | **Core License 1.0** |
 | `velesdb-migrate` (binary) | yes | **Core License 1.0** |
+| `velesdb-memory` (MCP memory server; embeds engine) | yes | **Core License 1.0** |
+| `velesdb-node` / `@wiscale/velesdb-memory-node` (napi addon; statically links engine) | yes (engine in `.node`) | **Core License 1.0** |
 | `tauri-plugin-velesdb` (Rust) | yes | **Core License 1.0** |
 | `@wiscale/velesdb-sdk` (TS, bundles WASM) | yes | **Core License 1.0** |
 | `@wiscale/tauri-plugin-velesdb` (guest-js) | no (IPC glue) — kept Core as first-party product SDK | **Core License 1.0** |

--- a/docs/README.md
+++ b/docs/README.md
@@ -93,6 +93,8 @@ VelesDB provides a complete ecosystem of SDKs and integrations:
 | [velesdb-python](../crates/velesdb-python/README.md) | SDK | Python bindings (PyO3) |
 | [velesdb-mobile](../crates/velesdb-mobile/README.md) | SDK | iOS/Android (UniFFI) |
 | [TypeScript SDK](../sdks/typescript/README.md) | SDK | TypeScript/JavaScript client |
+| [velesdb-memory](../crates/velesdb-memory/README.md) | Server | MCP agent-memory server (`why()` wedge) |
+| [velesdb-node](../crates/velesdb-node/README.md) | SDK | Node.js agent-memory binding (napi-rs) |
 | [tauri-plugin-velesdb](../crates/tauri-plugin-velesdb/README.md) | Plugin | Tauri desktop integration |
 | [LangChain](../integrations/langchain/README.md) | Integration | LangChain VectorStore |
 | [LlamaIndex](../integrations/llamaindex/README.md) | Integration | LlamaIndex VectorStore |

--- a/docs/contributing/PROJECT_STRUCTURE.md
+++ b/docs/contributing/PROJECT_STRUCTURE.md
@@ -96,6 +96,14 @@ velesdb-core/
 │   │   ├── Cargo.toml
 │   │   └── src/
 │   │
+│   ├── velesdb-memory/        # MCP agent-memory server (MemoryService why() wedge)
+│   │   ├── Cargo.toml
+│   │   └── src/
+│   │
+│   ├── velesdb-node/          # Node.js napi binding of the memory wedge
+│   │   ├── Cargo.toml         # @wiscale/velesdb-memory-node (depends on velesdb-memory only)
+│   │   └── src/
+│   │
 │   └── tauri-plugin-velesdb/  # Tauri v2 desktop integration
 │       ├── Cargo.toml
 │       └── src/

--- a/docs/contributing/RELEASE.md
+++ b/docs/contributing/RELEASE.md
@@ -73,8 +73,9 @@ git push origin vX.Y.Z
 |-------------|---------|
 | **GitHub Release** | Binaries Linux/Windows/macOS + .deb |
 | **crates.io** | velesdb-core, velesdb-cli, velesdb-server, velesdb-migrate, velesdb-mobile, tauri-plugin-velesdb |
+| **crates.io (independent `velesdb-memory-v*` tag)** | velesdb-memory (0.1.0 cadence, via `release-memory.yml`) |
 | **PyPI** | velesdb |
-| **npm** | @wiscale/velesdb-wasm, @wiscale/velesdb-sdk |
+| **npm** | @wiscale/velesdb-wasm, @wiscale/velesdb-sdk, @wiscale/velesdb-memory-node (napi prebuilds; publish job TBD, see note) |
 
 ### 7. Vérifier le déploiement
 

--- a/docs/guides/INSTALLATION.md
+++ b/docs/guides/INSTALLATION.md
@@ -13,7 +13,7 @@ Complete installation instructions for all platforms and deployment methods.
 | **macOS (Apple Silicon)** | `.tar.gz` portable (`velesdb-aarch64-apple-darwin.tar.gz`) | [GitHub Releases](https://github.com/cyberlife-coder/VelesDB/releases) ✅ |
 | **Python** | `pip` | [PyPI](https://pypi.org/project/velesdb/) ✅ |
 | **Rust** | `cargo` | [crates.io](https://crates.io/crates/velesdb-core) ✅ |
-| **npm** | WASM/SDK | [npm @wiscale](https://www.npmjs.com/org/wiscale) ✅ |
+| **npm** | WASM/SDK (`@wiscale/velesdb-sdk`, `@wiscale/velesdb-wasm`) + agent memory (`@wiscale/velesdb-memory-node`) | [npm @wiscale](https://www.npmjs.com/org/wiscale) ✅ |
 | **Docker** | Container | [Build from source](#-docker-installation) |
 | **iOS** | XCFramework | [Build from source](#-mobile-iosandroid) |
 | **Android** | AAR/SO | [Build from source](#-mobile-iosandroid) |

--- a/docs/reference/ECOSYSTEM_PARITY.md
+++ b/docs/reference/ECOSYSTEM_PARITY.md
@@ -1,6 +1,6 @@
 # VelesQL Ecosystem Parity Matrix
 
-Last updated: 2026-06-24 (v3.3.0)
+Last updated: 2026-06-27 (v3.3.0; velesdb-memory 0.1.0)
 
 This matrix tracks runtime contract and feature parity across the VelesDB ecosystem.
 
@@ -83,7 +83,7 @@ Legend: ✅ full support | ⚠️ partial / limited | ❌ not supported | N/A no
   | Durable TTL set/refresh | ✅ `PATCH .../points/{id}/ttl` | ✅ `client.setTtlDurable()` | ❌ (throws `NOT_SUPPORTED`) | ✅ `set_semantic/episodic/procedural_ttl_durable`, `store_with_ttl`, `record_with_ttl`, `learn_with_ttl` |
   | Temporal recall facades | n/a (use `/query`) | ✅ `recallRecent` / `recallOlderThan` | ❌ (throws `NOT_SUPPORTED`) | ✅ `episodic.recent` / `episodic.older_than` |
 - **Agent Memory (WASM / Mobile)**: ⚠️ semantic-only surface (`SemanticMemory` in WASM, `VelesSemanticMemory` on mobile); episodic/procedural memory, TTL helpers, and snapshots are not exposed on these bindings.
-- **Auto-extraction (text → graph)**: lives in the high-level `velesdb-memory` **MCP server**, not in this core-feature matrix. `MemoryService::remember_extracted` (and the `remember_extracted` MCP tool) run an `Extractor` over raw text and auto-wire the fact↔topic graph; the reusable core primitive it builds on is `SemanticMemory::query_excluding` (negative-filter vector search, used to keep internal entity hubs out of recall/why). The MCP `recall`/`why` tools inherit hub-exclusion transparently. Python/TS SDKs do **not** yet expose the high-level `MemoryService`; surfacing remember/recall/why/remember_extracted there is the Python+npm wedge follow-up.
+- **Auto-extraction (text → graph)**: lives in the high-level `velesdb-memory` **MCP server**, not in this core-feature matrix. `MemoryService::remember_extracted` (and the `remember_extracted` MCP tool) run an `Extractor` over raw text and auto-wire the fact↔topic graph; the reusable core primitive it builds on is `SemanticMemory::query_excluding` (negative-filter vector search, used to keep internal entity hubs out of recall/why). The MCP `recall`/`why` tools inherit hub-exclusion transparently. The high-level `MemoryService` wedge (remember/recall/recall_where/relate/forget/why/remember_extracted) is now exposed beyond the MCP server in **Python** (`velesdb-python`, #1242) and **Node.js** (`velesdb-node` / npm `@wiscale/velesdb-memory-node`, #1245); the TS/WASM SDK still exposes only the primitive agent-memory layer.
 - **Persistence (WASM)**: Disabled by design — `persistence` feature flag is excluded for `wasm32-unknown-unknown` targets.
 - **GPU**: Requires `gpu` feature flag; only available in crates that link `wgpu` (core, server, Python bindings).
 


### PR DESCRIPTION
Docs-only follow-up to #1245 (Node napi binding), #1242 (Python MemoryService), #1244 (recall_where indexed prefilter). The doc + license **enumerations** still described the wedge as MCP-only and omitted `velesdb-node` / `velesdb-memory`.

## Changes (13 files, docs only)
- **Wedge reach flipped** (was "MCP-server-only / Python+npm planned"): `crates/velesdb-memory/ARCHITECTURE.md`, `docs/reference/ECOSYSTEM_PARITY.md` — now ships in Python (PyO3) + Node (napi); P2 marked done.
- **License matrix**: `docs/LICENSING.md` — added Core-License rows for `velesdb-memory` and `@wiscale/velesdb-memory-node` (the `.node` statically links the engine).
- **Crate/SDK listings** (both `velesdb-memory` and `velesdb-node` were missing): root `README.md` Full Ecosystem, `docs/README.md`, `CONTRIBUTING.md`, root `ARCHITECTURE.md`, `docs/contributing/PROJECT_STRUCTURE.md`.
- **Install/release**: `docs/guides/INSTALLATION.md`, `docs/contributing/RELEASE.md` — added the `@wiscale/velesdb-memory-node` npm target + velesdb-memory's independent crates.io cadence.
- **Changelogs**: root `CHANGELOG.md` + `crates/velesdb-memory/CHANGELOG.md` — recorded #1245/#1244/#1242 and corrected the crate tool list (`recall_where` + `remember_extracted`).

The license **files** themselves were already correct (local `LICENSE`, `package.json` `SEE LICENSE IN LICENSE`, `deny.toml` clarify) — this only fixes the enumerations referencing them.

No code or behaviour changed.