### PR TITLE
ci(memory): npm release pipeline for @wiscale/velesdb-memory-node (0.2.0)

### DIFF
--- a/.github/workflows/release-memory.yml
+++ b/.github/workflows/release-memory.yml
@@ -28,6 +28,10 @@ on:
         description: 'Publish to crates.io'
         type: boolean
         default: true
+      publish_npm:
+        description: 'Publish @wiscale/velesdb-memory-node to npm'
+        type: boolean
+        default: true
 
 concurrency:
   group: release-memory-${{ github.ref }}
@@ -167,3 +171,144 @@ jobs:
         run: |
           chmod +x scripts/check-crates-io-versions.sh
           scripts/check-crates-io-versions.sh "${{ needs.validate.outputs.version }}" velesdb-memory
+
+  # ===========================================================================
+  # 3. Build the native Node addon for every supported target
+  # ===========================================================================
+  #
+  # @wiscale/velesdb-memory-node is a napi-rs addon: a thin per-platform `.node`
+  # binary plus a pure-JS loader. We cross-build all five targets declared in
+  # crates/velesdb-node/package.json `napi.targets`, upload each as an artifact,
+  # then the publish-npm job assembles them into the per-platform npm packages.
+  #
+  # The npm package version is decoupled from the crate but rides the SAME
+  # velesdb-memory-vX.Y.Z tag (one release event for the whole memory product),
+  # so the first build step fails loudly if package.json drifts from the tag.
+  build-node:
+    name: Build node (${{ matrix.target }})
+    needs: validate
+    if: |
+      needs.validate.outputs.is_prerelease == 'false' &&
+      (github.event_name == 'push' || inputs.publish_npm)
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: aarch64-apple-darwin
+            host: macos-latest
+          - target: x86_64-apple-darwin
+            host: macos-latest
+          - target: x86_64-unknown-linux-gnu
+            host: ubuntu-latest
+          - target: aarch64-unknown-linux-gnu
+            host: ubuntu-latest
+            cross: true
+          - target: x86_64-pc-windows-msvc
+            host: windows-latest
+    runs-on: ${{ matrix.host }}
+    defaults:
+      run:
+        working-directory: crates/velesdb-node
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '20'
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+          targets: ${{ matrix.target }}
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          shared-key: "release-memory-node-${{ matrix.target }}"
+          workspaces: ". -> target"
+
+      - name: Verify package.json version matches tag
+        shell: bash
+        env:
+          TAG_VERSION: ${{ needs.validate.outputs.version }}
+        run: |
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          if [ "$PKG_VERSION" != "$TAG_VERSION" ]; then
+            echo "::error::crates/velesdb-node/package.json version ($PKG_VERSION) does not match tag ($TAG_VERSION). Bump it alongside the crate and re-tag."
+            exit 1
+          fi
+          echo "✅ node package version: $PKG_VERSION"
+
+      - name: Install build deps (@napi-rs/cli)
+        run: npm install
+
+      - name: Build addon
+        # napi reads the profile from package.json's build script; pass the
+        # target explicitly for cross/host builds. --use-napi-cross supplies the
+        # zig-based sysroot for the one cross target (no Docker needed).
+        run: npx napi build --platform --release --profile release-node --target ${{ matrix.target }} ${{ matrix.cross && '--use-napi-cross' || '' }}
+
+      - name: Smoke-test the addon (native targets only)
+        if: ${{ !matrix.cross && matrix.target != 'x86_64-apple-darwin' }}
+        run: node --test __test__/
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: bindings-${{ matrix.target }}
+          path: crates/velesdb-node/*.node
+          if-no-files-found: error
+
+  # ===========================================================================
+  # 4. Assemble per-platform packages and publish to npm
+  # ===========================================================================
+  publish-npm:
+    name: Publish npm
+    runs-on: ubuntu-latest
+    needs: [validate, build-node]
+    if: |
+      needs.validate.outputs.is_prerelease == 'false' &&
+      (github.event_name == 'push' || inputs.publish_npm)
+    environment: npm
+    permissions:
+      contents: read
+      id-token: write # required by `npm publish --provenance`
+    defaults:
+      run:
+        working-directory: crates/velesdb-node
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install deps
+        run: npm install
+
+      - name: Download all addon artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: crates/velesdb-node/artifacts
+          pattern: bindings-*
+          merge-multiple: true
+
+      - name: Stage native binaries into per-platform npm dirs
+        run: |
+          npx napi create-npm-dirs
+          npx napi artifacts --output-dir ./artifacts
+          ls -R ./npm
+
+      - name: Publish to npm
+        # `prepublishOnly` (napi prepublish -t npm) publishes the per-platform
+        # @wiscale/velesdb-memory-node-<triple> packages and injects them as
+        # optionalDependencies before the root package is published here. The
+        # already-published guard mirrors release.yml so a re-run is idempotent.
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          VERSION: ${{ needs.validate.outputs.version }}
+        run: |
+          set -euo pipefail
+          if npm publish --access public --provenance; then
+            echo "✅ published @wiscale/velesdb-memory-node@$VERSION"
+          elif npm view "@wiscale/velesdb-memory-node@$VERSION" version >/dev/null 2>&1; then
+            echo "⏭️ @wiscale/velesdb-memory-node@$VERSION already on npm — skipping"
+          else
+            echo "❌ npm publish FAILED for @wiscale/velesdb-memory-node@$VERSION (auth/registry error, NOT already-published)"
+            exit 1
+          fi

--- a/.github/workflows/release-memory.yml
+++ b/.github/workflows/release-memory.yml
@@ -289,9 +289,14 @@ jobs:
           merge-multiple: true
 
       - name: Stage native binaries into per-platform npm dirs
+        # Each per-platform package is published separately, so it must carry the
+        # VelesDB Core License text itself — `create-npm-dirs` does not copy it.
+        # npm always includes a top-level LICENSE file regardless of `files`, so
+        # dropping it (and the README) into each dir is enough.
         run: |
           npx napi create-npm-dirs
           npx napi artifacts --output-dir ./artifacts
+          for d in npm/*/; do cp LICENSE README.md "$d"; done
           ls -R ./npm
 
       - name: Publish to npm

--- a/crates/velesdb-node/package.json
+++ b/crates/velesdb-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wiscale/velesdb-memory-node",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Local-first agent memory for Node.js (napi-rs): remember/recall/relate/forget/why with the why() knowledge-graph wedge, plus auto-extraction.",
   "license": "SEE LICENSE IN LICENSE",
   "author": "Julien Lange <contact@wiscale.fr>",


### PR DESCRIPTION
## What
Adds the missing npm side of `release-memory.yml`: `velesdb-memory` shipped only to crates.io; the Node binding had no release path. Now the same `velesdb-memory-vX.Y.Z` tag also builds and publishes `@wiscale/velesdb-memory-node`.

- **`build-node`** — napi build matrix over the 5 `napi.targets` (aarch64-linux via `--use-napi-cross`, no Docker); uploads each `.node`.
- **`publish-npm`** — assembles per-platform packages (`napi create-npm-dirs`/`artifacts`), publishes with the same already-published idempotence guard as `release.yml`. `id-token: write` for provenance.
- Rides the existing tag; **fails loudly if `crates/velesdb-node/package.json` version ≠ tag**.
- **License hygiene**: copies `LICENSE` + `README.md` into every `npm/<triple>` dir so each standalone per-platform package carries the VelesDB Core License text.
- Bumps `velesdb-node` → **0.2.0** to match the release tag.

## Before first use (maintainer)
1. Create an **`npm`** GitHub environment with an **`NPM_TOKEN`** secret (@wiscale org publish rights).
2. One CI validation run (cross targets only compile on CI).
3. Then tag `velesdb-memory-v0.2.0` → publishes crate + npm together.

## Verified
- crate packaging includes `LICENSE` (`cargo package --list`).
- workflow YAML + package.json parse clean.