### PR TITLE
test(node): rememberExtracted success-path coverage + document release hardening

### DIFF
--- a/.github/workflows/release-memory.yml
+++ b/.github/workflows/release-memory.yml
@@ -193,6 +193,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # HARDENING (tracked, not yet enabled): no *-unknown-linux-musl target, so
+        # Alpine / musl Node users (the default `node` Docker base) get no prebuilt
+        # binary and `require` fails. Add `x86_64-unknown-linux-musl` (and arm64
+        # musl) here + in package.json `napi.targets` + the root optionalDependencies.
+        # Deferred because a misconfigured musl leg would block this whole job
+        # (publish-npm `needs` every build leg green) — enable with a CI dry-run.
         include:
           - target: aarch64-apple-darwin
             host: macos-latest
@@ -245,6 +251,10 @@ jobs:
         run: npx napi build --platform --release --profile release-node --target ${{ matrix.target }} ${{ matrix.cross && '--use-napi-cross' || '' }}
 
       - name: Smoke-test the addon (native targets only)
+        # HARDENING (tracked): this skips x86_64-apple-darwin (Rosetta on the arm
+        # runner) and the aarch64 cross target, so two binaries publish without a
+        # load test. To close: run the smoke test under an emulator (QEMU for arm64,
+        # or a native x86 mac runner) so every shipped .node is load-verified.
         if: ${{ !matrix.cross && matrix.target != 'x86_64-apple-darwin' }}
         run: node --test __test__/
 
@@ -303,7 +313,18 @@ jobs:
         # `prepublishOnly` (napi prepublish -t npm) publishes the per-platform
         # @wiscale/velesdb-memory-node-<triple> packages and injects them as
         # optionalDependencies before the root package is published here. The
-        # already-published guard mirrors release.yml so a re-run is idempotent.
+        # already-published guard below mirrors release.yml so a re-run is idempotent
+        # for the ROOT package.
+        #
+        # HARDENING (tracked): the per-platform sub-packages are published by
+        # prepublishOnly with NO skip-if-exists guard. If a run dies after some
+        # sub-packages publish but before the root, a re-run hits "cannot overwrite
+        # version" on the published sub-packages and cannot cleanly recover. To close:
+        # change prepublishOnly to `napi prepublish -t npm --skip-optional-publish`
+        # (napi >=3.7 keeps the optionalDependencies injection, only skips the publish)
+        # and publish each `npm/*/` here in an explicit loop with the same
+        # publish-or-skip-if-already-on-npm guard used for the root. Verify with a
+        # `--dry-run` first.
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           VERSION: ${{ needs.validate.outputs.version }}

--- a/crates/velesdb-node/__test__/remember_extracted.integration.spec.mjs
+++ b/crates/velesdb-node/__test__/remember_extracted.integration.spec.mjs
@@ -1,0 +1,53 @@
+// Success-path coverage for rememberExtracted — the auto-extraction feature.
+//
+// Real extraction needs a local Ollama generative model, which offline CI does
+// not have, so this is OPT-IN: set VELESDB_OLLAMA_TESTS=1 (and have `ollama serve`
+// running with the model below) to exercise it. Without the env var it is skipped,
+// so the default `node --test` stays offline. The failure path (no backend →
+// throws) is covered unconditionally in index.spec.mjs.
+//
+//   VELESDB_OLLAMA_TESTS=1 node --test __test__/remember_extracted.integration.spec.mjs
+
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { MemoryService } from '../index.js'
+
+const RUN = !!process.env.VELESDB_OLLAMA_TESTS
+const MODEL = process.env.VELESDB_OLLAMA_EXTRACT_MODEL ?? 'qwen3.6:27b-mlx'
+
+test(
+  'rememberExtracted: a local model extracts facts and auto-wires a graph why() can walk',
+  { skip: RUN ? false : 'set VELESDB_OLLAMA_TESTS=1 (and run ollama) to enable' },
+  async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'velesdb-node-extract-'))
+    const store = MemoryService.open(dir, 'ollama', null, 'all-minilm')
+    try {
+      const transcript =
+        'Standup: we moved the analytics export to 3am because it kept colliding ' +
+        'with the database backup, which caused the Sunday slowdown. The backup ' +
+        'cannot move because the storage vendor only gives a midnight window.'
+
+      // Success path: returns the stored fact ids — no relate()/links by hand.
+      const ids = await store.rememberExtracted(transcript, MODEL)
+      assert.ok(Array.isArray(ids), 'returns an array of ids')
+      assert.ok(ids.length >= 2, `extracted multiple facts (got ${ids.length})`)
+      for (const id of ids) assert.match(id, /^\d+$/, 'each id is a decimal string')
+
+      // The auto-built graph is traversable: why() reaches a connected fact that
+      // shares no words with the question's surface.
+      const { nodes } = await store.why('why did the analytics export move to 3am?', 4)
+      assert.ok(nodes.length >= 2, 'why() returns a connected subgraph')
+      const reached = nodes.map((n) => n.content).join(' ').toLowerCase()
+      assert.ok(
+        reached.includes('backup') || reached.includes('vendor') || reached.includes('collid'),
+        'why() walked the self-built graph to the root cause',
+      )
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  },
+)


### PR DESCRIPTION
## Node: rememberExtracted success-path coverage + documented release hardening

### Verified change
- Adds an **opt-in integration test** for `rememberExtracted`'s success path (a local model extracts facts and auto-wires a graph that `why()` can walk). Gated on `VELESDB_OLLAMA_TESTS` so offline CI skips it — the prior suite only covered the no-backend failure path, so the marquee auto-extraction feature could have broken silently.
- Verified locally: passes with `qwen3.6` (48s); the default offline `node --test` run skips it (6 pass / 1 skip).

### Documented (not changed) — three tracked release-pipeline gaps
Captured inline in `release-memory.yml` with the exact fix for each, deferred because they need a CI dry-run to verify and a bad change would block the publish job:
1. **No musl/Alpine target** — Alpine `node` Docker users get no prebuilt binary; add `*-linux-musl` to the matrix + `package.json` `napi.targets` + root `optionalDependencies`.
2. **Two binaries publish without a load test** — the smoke test skips `x86_64-apple-darwin` and the arm64 cross target; run them under emulation/native runners.
3. **Non-idempotent per-platform sub-package publish** — a partial-failure re-run hits "cannot overwrite version"; switch `prepublishOnly` to `--skip-optional-publish` and publish each `npm/*/` in an explicit publish-or-skip loop.

These were surfaced by a launch premortem; this PR ships the verifiable fix and makes the rest actionable without risking the release pipeline.
