### PR TITLE
test(node): localeCompare comparator for Array.sort (SonarCloud reliability)

### DIFF
--- a/crates/velesdb-node/__test__/index.spec.mjs
+++ b/crates/velesdb-node/__test__/index.spec.mjs
@@ -20,7 +20,7 @@ function freshStore() {
 test('surface allowlist — exactly the 8 supported methods, no engine leak', () => {
   const instanceMethods = Object.getOwnPropertyNames(MemoryService.prototype)
     .filter((m) => m !== 'constructor')
-    .sort()
+    .sort((a, b) => a.localeCompare(b))
   assert.deepEqual(instanceMethods, [
     'forget',
     'recall',


### PR DESCRIPTION
SonarCloud's only new-code finding (Quality Gate failed on Reliability D) — a bare `.sort()` in the node surface-allowlist test. Add an explicit `.sort((a, b) => a.localeCompare(b))`. Test-only file (not in the npm `files`); 6/6 node tests pass.