### PR TITLE
release: 3.4.0 — SonarCloud reliability fix on top of the merged release

### DIFF
--- a/crates/velesdb-node/__test__/index.spec.mjs
+++ b/crates/velesdb-node/__test__/index.spec.mjs
@@ -20,7 +20,7 @@ function freshStore() {
 test('surface allowlist — exactly the 8 supported methods, no engine leak', () => {
   const instanceMethods = Object.getOwnPropertyNames(MemoryService.prototype)
     .filter((m) => m !== 'constructor')
-    .sort()
+    .sort((a, b) => a.localeCompare(b))
   assert.deepEqual(instanceMethods, [
     'forget',
     'recall',


### PR DESCRIPTION
Follow-up to #1255: brings the one SonarCloud Quality-Gate fix (bare `.sort()` → `localeCompare` comparator in a node test) onto main so the 3.4.0 tag HEAD is fully green across CI Success + Codacy + SonarCloud. Delta vs main = that single test-only commit.