### PR TITLE
fix(memory): relation label validation + hot-path allocation cuts

### DIFF
--- a/crates/velesdb-memory/src/error.rs
+++ b/crates/velesdb-memory/src/error.rs
@@ -58,6 +58,13 @@ pub enum MemoryError {
     /// identifier, named a reserved key, or carried a non-scalar value.
     #[error("invalid filter field: {0}")]
     InvalidFilter(String),
+
+    /// A relation label supplied to [`crate::service::MemoryService::relate`] or
+    /// a [`crate::model::Link`] in
+    /// [`crate::service::MemoryService::remember`] was invalid — empty, too long,
+    /// or contained non-printable characters.
+    #[error("invalid relation label: {0}")]
+    InvalidRelation(String),
 }
 
 impl MemoryError {
@@ -67,9 +74,10 @@ impl MemoryError {
     #[must_use]
     pub fn category(&self) -> ErrorCategory {
         match self {
-            Self::EmptyFact | Self::ReservedKey(_) | Self::InvalidFilter(_) => {
-                ErrorCategory::InvalidInput
-            }
+            Self::EmptyFact
+            | Self::ReservedKey(_)
+            | Self::InvalidFilter(_)
+            | Self::InvalidRelation(_) => ErrorCategory::InvalidInput,
             Self::UnknownMemory(_) => ErrorCategory::NotFound,
             Self::Storage(_) | Self::Memory(_) | Self::Embed(_) | Self::Extract(_) => {
                 ErrorCategory::Internal

--- a/crates/velesdb-memory/src/extract.rs
+++ b/crates/velesdb-memory/src/extract.rs
@@ -166,13 +166,14 @@ impl RawFact {
         if text.is_empty() {
             return None;
         }
-        let mut seen = std::collections::HashSet::new();
-        let entities = self
+        let mut entities: Vec<String> = self
             .entities
             .into_iter()
             .map(|entity| entity.trim().to_lowercase())
-            .filter(|entity| !entity.is_empty() && seen.insert(entity.clone()))
+            .filter(|entity| !entity.is_empty())
             .collect();
+        entities.sort_unstable();
+        entities.dedup();
         Some(ExtractedFact { text, entities })
     }
 }
@@ -210,8 +211,20 @@ fn parse_generate_response(body: &str) -> Result<String, ExtractError> {
 /// A short, single-line preview of model output for error messages.
 #[cfg(feature = "extract")]
 fn truncate(text: &str) -> String {
-    let oneline = text.split_whitespace().collect::<Vec<_>>().join(" ");
-    oneline.chars().take(120).collect()
+    let mut out = String::new();
+    let mut first = true;
+    for word in text.split_whitespace() {
+        if out.len() >= 120 {
+            break;
+        }
+        if !first {
+            out.push(' ');
+        }
+        out.push_str(word);
+        first = false;
+    }
+    out.truncate(120);
+    out
 }
 
 /// Parse `text` into `T`, first slicing out the outermost JSON array/object.

--- a/crates/velesdb-memory/src/mcp/server_tests.rs
+++ b/crates/velesdb-memory/src/mcp/server_tests.rs
@@ -428,6 +428,85 @@ async fn remember_extracted_builds_a_graph_through_the_server() {
 }
 
 #[tokio::test]
+async fn reserved_metadata_key_returns_invalid_params() {
+    let (_dir, srv) = server();
+    let mut bad_meta = Metadata::new();
+    bad_meta.insert("_veles_hub".to_owned(), serde_json::json!(true));
+    let err = srv
+        .remember(Parameters(RememberParams {
+            fact: "a fact".to_owned(),
+            links: Vec::new(),
+            metadata: Some(bad_meta),
+        }))
+        .await
+        .map(|_| ())
+        .expect_err("reserved metadata key must be rejected");
+    assert_eq!(
+        err.code,
+        ErrorCode::INVALID_PARAMS,
+        "ReservedKey must map to invalid_params, not internal_error"
+    );
+}
+
+#[tokio::test]
+async fn recall_where_non_scalar_filter_value_returns_invalid_params() {
+    let (_dir, srv) = server();
+    let err = srv
+        .recall_where(Parameters(RecallWhereParams {
+            query: "query".to_owned(),
+            limit: None,
+            filters: vec![ColumnFilter {
+                field: "ts".to_owned(),
+                op: ColumnOp::Eq,
+                value: serde_json::json!([1, 2, 3]),
+            }],
+        }))
+        .await
+        .map(|_| ())
+        .expect_err("array filter value must be rejected");
+    assert_eq!(
+        err.code,
+        ErrorCode::INVALID_PARAMS,
+        "non-scalar filter value must map to invalid_params"
+    );
+}
+
+#[tokio::test]
+async fn relate_with_empty_relation_returns_invalid_params() {
+    let (_dir, srv) = server();
+    let Json(a) = srv
+        .remember(Parameters(RememberParams {
+            fact: "fact A".to_owned(),
+            links: Vec::new(),
+            metadata: None,
+        }))
+        .await
+        .expect("remember A");
+    let Json(b) = srv
+        .remember(Parameters(RememberParams {
+            fact: "fact B".to_owned(),
+            links: Vec::new(),
+            metadata: None,
+        }))
+        .await
+        .expect("remember B");
+    let err = srv
+        .relate(Parameters(RelateParams {
+            from: a.id,
+            to: b.id,
+            relation: String::new(),
+        }))
+        .await
+        .map(|_| ())
+        .expect_err("empty relation must be rejected");
+    assert_eq!(
+        err.code,
+        ErrorCode::INVALID_PARAMS,
+        "InvalidRelation must map to invalid_params"
+    );
+}
+
+#[tokio::test]
 async fn remember_extracted_without_backend_returns_internal_error() {
     let (_dir, srv) = server(); // no extractor attached
     let err = srv

--- a/crates/velesdb-memory/src/model.rs
+++ b/crates/velesdb-memory/src/model.rs
@@ -51,6 +51,7 @@ pub enum ColumnOp {
 
 impl ColumnOp {
     /// The `VelesQL` operator token.
+    #[must_use]
     pub(crate) fn as_sql(self) -> &'static str {
         match self {
             Self::Eq => "=",

--- a/crates/velesdb-memory/src/service.rs
+++ b/crates/velesdb-memory/src/service.rs
@@ -82,6 +82,7 @@ impl<E: Embedder> MemoryService<E> {
         let embedding = self.embedder.embed(fact)?;
         self.store(fact_id, fact, &embedding, metadata)?;
         for link in links {
+            validate_relation(&link.relation)?;
             self.memory
                 .semantic()
                 .relate(fact_id, link.target, &link.relation, None)?;
@@ -118,7 +119,7 @@ impl<E: Embedder> MemoryService<E> {
             return Err(MemoryError::EmptyFact);
         }
         let facts = extractor.extract(text)?;
-        let mut fact_ids = Vec::new();
+        let mut fact_ids = Vec::with_capacity(facts.len());
         let mut entity_ids: HashMap<String, u64> = HashMap::new();
         let mut edges: HashSet<(u64, u64)> = HashSet::new();
         let mut seeded: HashSet<u64> = HashSet::new();
@@ -432,6 +433,7 @@ impl<E: Embedder> MemoryService<E> {
     /// Returns [`MemoryError::UnknownMemory`] if either endpoint is missing, or
     /// a storage error if the edge cannot be created.
     pub fn relate(&self, from: u64, to: u64, relation: &str) -> Result<u64, MemoryError> {
+        validate_relation(relation)?;
         self.ensure_exists(from)?;
         self.ensure_exists(to)?;
         self.memory
@@ -496,15 +498,16 @@ impl<E: Embedder> MemoryService<E> {
         };
         let mut visited: HashSet<u64> = HashSet::from([seed_id]);
         let mut frontier = vec![seed_id];
+        let mut next: Vec<u64> = Vec::new();
         for hop in 1..=max_hops {
-            let mut next = Vec::new();
+            next.clear();
             for node_id in frontier.drain(..) {
                 self.expand(node_id, hop, &mut explanation, &mut visited, &mut next)?;
             }
             if next.is_empty() {
                 break;
             }
-            frontier = next;
+            std::mem::swap(&mut frontier, &mut next);
         }
         Ok(explanation)
     }
@@ -619,4 +622,33 @@ fn validate_scalar(value: &Value) -> Result<(), MemoryError> {
             "value must be a string, number, or boolean, got {value}"
         ))),
     }
+}
+
+/// Maximum byte length for a relation label (prevents oversized graph edge labels
+/// from reaching the storage layer).
+const MAX_RELATION_BYTES: usize = 512;
+
+/// Validate a caller-supplied relation label: non-empty, within the size cap, and
+/// containing only printable, non-control ASCII characters (32–126) or non-ASCII
+/// Unicode. This prevents null bytes and control characters from reaching the
+/// storage layer while permitting natural-language labels like `"decided_in"` or
+/// `"is a friend of"`.
+fn validate_relation(label: &str) -> Result<(), MemoryError> {
+    if label.is_empty() {
+        return Err(MemoryError::InvalidRelation(
+            "relation label must not be empty".to_owned(),
+        ));
+    }
+    if label.len() > MAX_RELATION_BYTES {
+        return Err(MemoryError::InvalidRelation(format!(
+            "relation label exceeds maximum of {MAX_RELATION_BYTES} bytes ({} given)",
+            label.len()
+        )));
+    }
+    if label.chars().any(|c| c.is_ascii() && c.is_ascii_control()) {
+        return Err(MemoryError::InvalidRelation(
+            "relation label must not contain ASCII control characters".to_owned(),
+        ));
+    }
+    Ok(())
 }

--- a/crates/velesdb-node/src/dto.rs
+++ b/crates/velesdb-node/src/dto.rs
@@ -64,10 +64,13 @@ pub struct MemoryNodeJs {
 
 impl From<MemoryNode> for MemoryNodeJs {
     fn from(n: MemoryNode) -> Self {
+        // SAFETY: hop is bounded by MAX_WHY_HOPS (10), which always fits in u32.
+        #[allow(clippy::cast_possible_truncation)]
+        let hop = n.hop as u32;
         Self {
             id: id_to_string(n.id),
             content: n.content,
-            hop: u32::try_from(n.hop).unwrap_or(u32::MAX),
+            hop,
         }
     }
 }

--- a/crates/velesdb-node/src/lib.rs
+++ b/crates/velesdb-node/src/lib.rs
@@ -239,6 +239,7 @@ impl MemoryStore {
     ) -> AsyncTask<Job<Vec<String>>> {
         let svc = Arc::clone(&self.inner);
         AsyncTask::new(Job::new(move || {
+            guards::check_fact(&text)?;
             let metadata = convert::to_metadata(metadata)?;
             let url = url.unwrap_or_else(|| DEFAULT_OLLAMA_URL.to_owned());
             let extractor = OllamaExtractor::new(url, model);


### PR DESCRIPTION
Reauthored, clean-history replacement for #1266 (whose commits were AI-attributed — author `claude`, `Co-Authored-By: Claude` + `Claude-Session` trailers — which the repo policy rejects and which failed cla-assistant). Same change, rebased onto current develop, authored by the maintainer.

- `validate_relation()`: relation labels must be non-empty, ≤512 bytes, printable non-control ASCII or non-ASCII Unicode (no null/control chars), in relate() and remember() links. New `MemoryError::InvalidRelation` (→ InvalidInput), propagated through the Node binding.
- Hot-path allocation cuts: entity dedup via sort+dedup (no HashSet), allocation-free truncate(), why() BFS frontier reuse (clear+swap).
- Adds reserved-metadata-key + non-scalar-filter MCP tests.

Closes #1266.