### PR TITLE
ci(dependabot): pin cache-apt-pkgs-action to 1.6.1 (v1.6.2 breaks CI on cache-hit)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -119,6 +119,15 @@ updates:
     labels: ["ci", "dependencies"]
     open-pull-requests-limit: 3
     target-branch: "develop"
+    ignore:
+      # cache-apt-pkgs-action v1.6.2 added `empty_packages_behavior: error`, which
+      # fails (exit 3) on an apt cache-HIT — every job that caches glib/gtk/webkit
+      # hits this once the shared cache is warm, breaking Lint/Tests/Bench. It's a
+      # CI-speed action with no value to us in v1.6.2+, and adapting all ~15 call
+      # sites isn't worth the ROI. Pin v1.6.1; revisit if a later release fixes the
+      # cache-hit regression. (Security updates still flow via the security-gha group.)
+      - dependency-name: "awalsh128/cache-apt-pkgs-action"
+        versions: [">=1.6.2"]
     groups:
       gha-non-major:
         applies-to: version-updates


### PR DESCRIPTION
**Root-caused #1261's CI break.** `awalsh128/cache-apt-pkgs-action` **v1.6.2** added a `empty_packages_behavior: error` default that exits 3 on an apt **cache-hit** (0 packages to install). Every job caching glib/gtk/webkit hits this once the shared cache is warm → Lint/Tests/Bench all fail.

**ROI decision (CTO):** it's a CI-speed action with no value to us in v1.6.2+, and adapting all ~15 call sites (adding `empty_packages_behavior: ignore`) isn't worth it. Pin v1.6.1 via a dependabot ignore on `>=1.6.2`. Security updates still flow through the `security-gha` group. Supersedes the cache-apt portion of #1261 (closed); the other 3 safe GHA bumps will re-propose.