### PR TITLE
ci(dependabot): stop tracking example/demo npm deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,54 +38,11 @@ updates:
         applies-to: security-updates
         patterns: ["*"]
 
-  - package-ecosystem: "npm"
-    directory: "/examples/react-wasm-search"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-    labels: ["dependencies", "javascript"]
-    open-pull-requests-limit: 3
-    target-branch: "develop"
-    groups:
-      npm-react-example-non-major:
-        applies-to: version-updates
-        update-types: ["minor", "patch"]
-      security-npm-react-example:
-        applies-to: security-updates
-        patterns: ["*"]
-
-  - package-ecosystem: "npm"
-    directory: "/examples/node-express-rag"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-    labels: ["dependencies", "javascript"]
-    open-pull-requests-limit: 3
-    target-branch: "develop"
-    groups:
-      npm-node-example-non-major:
-        applies-to: version-updates
-        update-types: ["minor", "patch"]
-      security-npm-node-example:
-        applies-to: security-updates
-        patterns: ["*"]
-
-  - package-ecosystem: "npm"
-    directory: "/demos/tauri-rag-app"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-    labels: ["dependencies", "javascript"]
-    open-pull-requests-limit: 3
-    target-branch: "develop"
-    groups:
-      npm-tauri-demo-non-major:
-        applies-to: version-updates
-        update-types: ["minor", "patch"]
-      security-npm-tauri-demo:
-        applies-to: security-updates
-        patterns: ["*"]
-
+  # Example/demo npm packages (examples/*, demos/*) are intentionally NOT tracked:
+  # they ship nothing, so keeping their deps current has ~zero value, and ci.yml is
+  # path-filtered to skip examples/** — so their bumps can never satisfy the required
+  # "CI Success" check and pile up as unmergeable PRs. The shipped SDK
+  # (/sdks/typescript) and the product python wheel ARE tracked, above/below.
   - package-ecosystem: "pip"
     directory: "/crates/velesdb-python"
     schedule:


### PR DESCRIPTION
Per the CI-study finding: example/demo npm packages (examples/react-wasm-search, examples/node-express-rag, demos/tauri-rag-app) ship nothing, and ci.yml is path-filtered to skip examples/** — so their dependabot bumps can never satisfy the required `CI Success` check and pile up as unmergeable PRs (#1257/#1259/#1264). Untrack them; keep the shipped SDK (/sdks/typescript) + product python wheel. Config-only, path-filtered (admin-merged).