### PR TITLE
docs(memory): MCP registry manifests + published install/license FAQ

### DIFF
--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -1,0 +1,43 @@
+name: Publish to MCP Registry
+
+# Registers the velesdb-memory MCP server (server.json at repo root) on the
+# official MCP registry (registry.modelcontextprotocol.io).
+#
+# Auth = GitHub OIDC: the io.github.cyberlife-coder/* namespace is proven by the
+# repository's own OIDC identity, so there is NO interactive login and NO secret
+# to manage. The underlying cargo package (velesdb-memory) is published
+# separately by release-memory.yml; this job only registers the server manifest.
+#
+# Triggers:
+#   - push of a velesdb-memory-vX.Y.Z tag (registers each memory release), and
+#   - manual workflow_dispatch (to (re)publish the current server.json on demand,
+#     e.g. to register 0.2.0 which was tagged before this workflow existed).
+#
+# Prereq: server.json `version` must match a velesdb-memory version already live
+# on crates.io (the registry validates the package exists). Bump it alongside the
+# crate on each memory release.
+
+on:
+  push:
+    tags: ["velesdb-memory-v*"]
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # required for GitHub OIDC authentication
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Install mcp-publisher
+        run: |
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+
+      - name: Authenticate to MCP Registry (GitHub OIDC)
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish server.json to MCP Registry
+        run: ./mcp-publisher publish

--- a/crates/velesdb-memory/README.md
+++ b/crates/velesdb-memory/README.md
@@ -155,14 +155,26 @@ has none of these — it ranks by similarity and stops.
 
 ## Install
 
+**One command (recommended, with a Rust toolchain present):**
+
 ```bash
-# Default build: tiny, zero-dependency, fully offline.
-cargo build --release -p velesdb-memory
-# → target/release/velesdb-memory
+cargo install velesdb-memory
+# → installs the `velesdb-memory` MCP server binary onto your PATH
 ```
 
-The binary speaks MCP over **stdio**, so client and server run on the same
-machine and the memory never leaves it.
+The binary is tiny, zero-dependency, and fully offline. It speaks MCP over
+**stdio**, so client and server run on the same machine and the memory never
+leaves it.
+
+**From the workspace (for hacking on the server itself):**
+
+```bash
+cargo build --release -p velesdb-memory   # → target/release/velesdb-memory
+```
+
+> Prebuilt, no-Rust binaries (GitHub Releases + `curl | sh` + Homebrew) are a
+> tracked follow-up — until then, `cargo install velesdb-memory` is the
+> supported one-liner.
 
 ## Configure your client
 
@@ -340,3 +352,31 @@ raw database capabilities (`query`, `create_collection`, `upsert`, `traverse`).
 Run locally over stdio, you operate the software for yourself: this is the
 license's expressly-permitted **embedded, local-first use** — not a hosted
 service to third parties.
+
+### License FAQ
+
+**Is this open source?** It is **source-available**: the full source is
+readable, modifiable, and redistributable under the **VelesDB Core License 1.0**
+(a derivative of the Elastic License 2.0). It is not an OSI-approved license.
+
+**Can I use it at work / in a commercial product?** **Yes.** Running the server
+locally, or embedding the library inside your own application where *your* users
+only ever receive results (a memory, a `why()` subgraph), is expressly permitted
+— the license's **embedded, local-first use** clause.
+
+**What's actually forbidden?** Re-hosting VelesDB as a multi-tenant *service*
+where third parties drive the database (run arbitrary queries, manage
+collections/indexes/graph nodes). This server makes that impossible by design:
+it exposes **memory semantics only** (`remember/recall/relate/forget/why`),
+never raw `query` / `create_collection` / `upsert` / `traverse`.
+
+**Why this license?** So that *you* can embed agent memory locally and freely,
+while a third party cannot turn *our* engine into a memory-as-a-service and
+resell it. The moat protects the project, not your usage.
+
+**What do I owe when I redistribute?** Keep the LICENSE file and copyright
+notices, and add a [velesdb.com](https://velesdb.com) attribution in any public
+app that ships the binary. Internal, dev, and test use need no attribution.
+
+> Full terms and the canonical FAQ: [LICENSE](https://github.com/cyberlife-coder/VelesDB/blob/main/LICENSE).
+> Questions: contact@wiscale.fr.

--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": [
+    "cyberlife-coder"
+  ]
+}

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.cyberlife-coder/velesdb-memory",
   "title": "VelesDB Memory",
-  "description": "Local-first memory for AI agents: remember/recall/relate/forget/why over a fused vector+graph+columnar engine. why() connects decisions across sessions, offline, in one tiny binary.",
+  "description": "Agentic memory for AI agents in one tiny offline binary. remember/recall/relate/forget/why over a tri-engine that fuses vector search, a knowledge graph, and a columnar store — why() walks the graph to reconnect a decision with its context across sessions, surfacing linked facts that share no words with the query.",
   "version": "0.2.0",
   "repository": {
     "url": "https://github.com/cyberlife-coder/VelesDB",

--- a/server.json
+++ b/server.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.cyberlife-coder/velesdb-memory",
+  "title": "VelesDB Memory",
+  "description": "Local-first memory for AI agents: remember/recall/relate/forget/why over a fused vector+graph+columnar engine. why() connects decisions across sessions, offline, in one tiny binary.",
+  "version": "0.2.0",
+  "repository": {
+    "url": "https://github.com/cyberlife-coder/VelesDB",
+    "source": "github"
+  },
+  "packages": [
+    {
+      "registryType": "cargo",
+      "registryBaseUrl": "https://crates.io",
+      "identifier": "velesdb-memory",
+      "version": "0.2.0",
+      "transport": {
+        "type": "stdio"
+      },
+      "environmentVariables": [
+        {
+          "name": "VELESDB_MEMORY_PATH",
+          "description": "Directory where the local memory store lives (the memory never leaves this machine).",
+          "isRequired": false,
+          "default": "~/.velesdb-memory"
+        },
+        {
+          "name": "VELESDB_MEMORY_EMBEDDER",
+          "description": "Embedding backend: 'hash' (default, offline, zero-dep) or 'ollama' (real semantic recall via a local model; binary must be built --features ollama).",
+          "isRequired": false,
+          "default": "hash"
+        }
+      ]
+    }
+  ]
+}

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,0 +1,42 @@
+# Smithery listing for velesdb-memory — a LOCAL stdio MCP server.
+# The server is a single Rust binary (`velesdb-memory`) installed with
+# `cargo install velesdb-memory`. It runs on the user's own machine over stdio,
+# so the memory store never leaves the host — this is a local server, not a
+# hosted/container deployment (which the VelesDB Core License forbids exposing
+# to third parties anyway).
+startCommand:
+  type: stdio
+  configSchema:
+    type: object
+    required: []
+    properties:
+      memoryPath:
+        type: string
+        description: Directory where the local memory store lives. Defaults to ~/.velesdb-memory.
+      embedder:
+        type: string
+        enum: [hash, ollama]
+        default: hash
+        description: >-
+          Embedding backend. 'hash' is offline and zero-dependency (default).
+          'ollama' gives real semantic recall via a local model and requires a
+          binary built with --features ollama plus a running Ollama.
+      ollamaModel:
+        type: string
+        default: all-minilm
+        description: Ollama model name, used only when embedder is 'ollama'.
+  commandFunction: |
+    (config) => ({
+      command: 'velesdb-memory',
+      args: [],
+      env: {
+        ...(config.memoryPath ? { VELESDB_MEMORY_PATH: config.memoryPath } : {}),
+        ...(config.embedder ? { VELESDB_MEMORY_EMBEDDER: config.embedder } : {}),
+        ...(config.embedder === 'ollama' && config.ollamaModel
+          ? { VELESDB_MEMORY_OLLAMA_MODEL: config.ollamaModel }
+          : {})
+      }
+    })
+  exampleConfig:
+    memoryPath: ~/.velesdb-memory
+    embedder: hash


### PR DESCRIPTION
## Why

0.2.0 is fully published (`velesdb-memory` on **crates.io** + `@wiscale/velesdb-memory-node` on **npm**, core `v3.4.0`). The last step to get the MCP server out of the shadows is **registry discoverability** — this PR lands the distribution manifests and turns the README into something a new user (and a registry crawler) can act on.

## What

- **`server.json`** — MCP official registry manifest. Cargo stdio package `velesdb-memory@0.2.0`; env vars (`VELESDB_MEMORY_PATH`, `VELESDB_MEMORY_EMBEDDER`, `VELESDB_MEMORY_OLLAMA_MODEL`) verified against the actual binary. Published via `mcp-publisher` (namespace `io.github.cyberlife-coder/*`, proven by GitHub auth).
- **`smithery.yaml`** — Smithery local-stdio launch config; `command: velesdb-memory` (the cargo-installed binary), explicitly a **local** server (no hosted deployment — license + sovereignty).
- **`glama.json`** — Glama maintainer claim (`cyberlife-coder`).
- **`crates/velesdb-memory/README.md`** — `## Install` now leads with the real one-liner `cargo install velesdb-memory` (was workspace-only build); `## License` gets a skimmable **License FAQ** (source-available; embedded local-first use permitted; memory-semantics-only surface). Links target `main`.

## Accuracy / scope notes

- The License FAQ makes **no MIT claim** — the crate ships `license-file = "../../LICENSE"` (VelesDB Core License 1.0), and the FAQ states exactly that. DECISIONS.md's intent to make the *wrapper source* permissive is a separate relicensing call (Licensor's), not actuated here.
- `server.json`'s `0.2.0` is not yet wired into the version-sync system (memory crate is independently versioned); bump it on the next memory release — small follow-up to add to `release-memory.yml`.
- Prebuilt no-Rust binaries (GitHub Releases + `curl|sh` + Homebrew) deferred; `cargo install` is the supported one-liner.

## Follow-up (account-gated, not in this PR)

`mcp-publisher publish` (MCP registry), Smithery "Add Server", Glama claim, and the `awesome-mcp-servers` PR — all require maintainer accounts.


## Update — also wires CI publishing to the MCP registry

Added `.github/workflows/publish-mcp-registry.yml`: registers `server.json` on registry.modelcontextprotocol.io via **GitHub OIDC** (the repo's own identity proves the `io.github.cyberlife-coder/*` namespace — no interactive `mcp-publisher login`, no secret). Triggers on `velesdb-memory-v*` tags and on `workflow_dispatch`, so 0.2.0 (already tagged) can be registered on demand from the Actions tab. This removes the only manual-OAuth step from the distribution path.
