### PR TITLE
fix(memory): server.json description <=100 chars (MCP registry validation)

### DIFF
--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.cyberlife-coder/velesdb-memory",
   "title": "VelesDB Memory",
-  "description": "Agentic memory for AI agents in one tiny offline binary. remember/recall/relate/forget/why over a tri-engine that fuses vector search, a knowledge graph, and a columnar store — why() walks the graph to reconnect a decision with its context across sessions, surfacing linked facts that share no words with the query.",
+  "description": "Offline agentic memory: remember/recall/relate/forget/why over a fused vector+graph+columnar engine",
   "version": "0.2.0",
   "repository": {
     "url": "https://github.com/cyberlife-coder/VelesDB",


### PR DESCRIPTION
The MCP registry rejects `description` > 100 chars (HTTP 422 on publish). Shortens server.json description to 99 chars while still leading with **agentic memory** + the **tri-engine** (vector+graph+columnar). Unblocks the publish-mcp-registry workflow added in #1279.

Tested: the OIDC auth + namespace resolution already succeed (the failed run got to validation); only the length was rejected.