### PR TITLE
docs(memory): date 0.2.0 changelog + MCP registry discovery in README

### DIFF
--- a/crates/velesdb-memory/CHANGELOG.md
+++ b/crates/velesdb-memory/CHANGELOG.md
@@ -7,7 +7,7 @@ released on its own `velesdb-memory-vX.Y.Z` tag.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.2.0] - Unreleased
+## [0.2.0] - 2026-06-29
 
 Benchmark milestone: the tri-engine is no longer just *wired* — each leg is
 *measured* to beat pure-vector retrieval on its specialty, generation-free, on

--- a/crates/velesdb-memory/README.md
+++ b/crates/velesdb-memory/README.md
@@ -172,9 +172,13 @@ leaves it.
 cargo build --release -p velesdb-memory   # → target/release/velesdb-memory
 ```
 
-> Prebuilt, no-Rust binaries (GitHub Releases + `curl | sh` + Homebrew) are a
-> tracked follow-up — until then, `cargo install velesdb-memory` is the
-> supported one-liner.
+> **In an MCP client (no Rust toolchain needed):** velesdb-memory is listed on the
+> [official MCP registry](https://registry.modelcontextprotocol.io) as
+> `io.github.cyberlife-coder/velesdb-memory`. Registry-aware clients can install it
+> straight from the per-platform `.mcpb` bundles attached to each
+> [GitHub release](https://github.com/cyberlife-coder/VelesDB/releases). A
+> `curl | sh` / Homebrew installer is a tracked follow-up; with a Rust toolchain,
+> `cargo install velesdb-memory` is the supported one-liner.
 
 ## Configure your client
 


### PR DESCRIPTION
Small launch-polish on develop now that velesdb-memory 0.2.0 is live on crates.io, npm, and the official MCP registry:
- CHANGELOG: `[0.2.0] - Unreleased` → `2026-06-29`.
- README Install: replaced the stale 'prebuilt binaries are a follow-up' note with a real **no-Rust discovery path** — the official MCP registry listing (`io.github.cyberlife-coder/velesdb-memory`) + the per-platform `.mcpb` bundles on each GitHub release.