### PR TITLE
fix(memory): strip non-standard integer formats from MCP tool schemas

### DIFF
--- a/crates/velesdb-memory/src/lib.rs
+++ b/crates/velesdb-memory/src/lib.rs
@@ -38,6 +38,9 @@ pub mod mcp;
 /// (`Link`, `Recollection`, `ColumnFilter`, `Explanation`, …), separate from the
 /// service that computes them.
 pub mod model;
+/// Shared JSON Schema post-processing (strips `schemars`' non-standard integer
+/// `format` keywords so strict MCP clients don't warn on every id field).
+mod schema;
 pub mod service;
 
 /// Default embedding dimension — the single source of truth, taken from the

--- a/crates/velesdb-memory/src/mcp/dto.rs
+++ b/crates/velesdb-memory/src/mcp/dto.rs
@@ -27,6 +27,7 @@ pub(super) struct RememberParams {
 
 /// Result of the `remember` tool.
 #[derive(Serialize, JsonSchema)]
+#[schemars(transform = crate::schema::strip_int_formats)]
 pub(super) struct RememberResult {
     /// Stable id assigned to the remembered fact.
     pub(super) id: u64,
@@ -34,6 +35,7 @@ pub(super) struct RememberResult {
 
 /// Parameters for the `recall` tool.
 #[derive(Deserialize, JsonSchema)]
+#[schemars(transform = crate::schema::strip_int_formats)]
 pub(super) struct RecallParams {
     /// Natural-language query to match semantically.
     pub(super) query: String,
@@ -53,6 +55,7 @@ pub(super) struct RecallResult {
 
 /// Parameters for the `recall_where` tool.
 #[derive(Deserialize, JsonSchema)]
+#[schemars(transform = crate::schema::strip_int_formats)]
 pub(super) struct RecallWhereParams {
     /// Natural-language query to match semantically.
     pub(super) query: String,
@@ -68,6 +71,7 @@ pub(super) struct RecallWhereParams {
 
 /// Parameters for the `relate` tool.
 #[derive(Deserialize, JsonSchema)]
+#[schemars(transform = crate::schema::strip_int_formats)]
 pub(super) struct RelateParams {
     /// Source memory id.
     pub(super) from: u64,
@@ -79,6 +83,7 @@ pub(super) struct RelateParams {
 
 /// Result of the `relate` tool.
 #[derive(Serialize, JsonSchema)]
+#[schemars(transform = crate::schema::strip_int_formats)]
 pub(super) struct RelateResult {
     /// Id of the created edge.
     pub(super) edge_id: u64,
@@ -86,6 +91,7 @@ pub(super) struct RelateResult {
 
 /// Parameters for the `forget` tool.
 #[derive(Deserialize, JsonSchema)]
+#[schemars(transform = crate::schema::strip_int_formats)]
 pub(super) struct ForgetParams {
     /// Id of the memory to forget.
     pub(super) id: u64,
@@ -93,6 +99,7 @@ pub(super) struct ForgetParams {
 
 /// Result of the `forget` tool.
 #[derive(Serialize, JsonSchema)]
+#[schemars(transform = crate::schema::strip_int_formats)]
 pub(super) struct ForgetResult {
     /// Id of the forgotten memory.
     pub(super) id: u64,
@@ -100,6 +107,7 @@ pub(super) struct ForgetResult {
 
 /// Parameters for the `why` tool.
 #[derive(Deserialize, JsonSchema)]
+#[schemars(transform = crate::schema::strip_int_formats)]
 pub(super) struct WhyParams {
     /// The decision (or fact) to explain.
     pub(super) decision: String,
@@ -121,6 +129,7 @@ pub(super) struct RememberExtractedParams {
 
 /// Result of the `remember_extracted` tool.
 #[derive(Serialize, JsonSchema)]
+#[schemars(transform = crate::schema::strip_int_formats)]
 pub(super) struct RememberExtractedResult {
     /// Stable ids of the stored facts, in extraction order.
     pub(super) ids: Vec<u64>,

--- a/crates/velesdb-memory/src/model.rs
+++ b/crates/velesdb-memory/src/model.rs
@@ -12,6 +12,7 @@ use serde_json::Value;
 
 /// A typed link from a freshly remembered fact to an existing memory.
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[schemars(transform = crate::schema::strip_int_formats)]
 pub struct Link {
     /// Id of the memory being linked to.
     pub target: u64,
@@ -21,6 +22,7 @@ pub struct Link {
 
 /// One semantically recalled memory.
 #[derive(Debug, Clone, Serialize, JsonSchema)]
+#[schemars(transform = crate::schema::strip_int_formats)]
 pub struct Recollection {
     /// Stable id of the memory.
     pub id: u64,
@@ -83,6 +85,7 @@ pub struct ColumnFilter {
 
 /// A node in an [`Explanation`] subgraph.
 #[derive(Debug, Clone, Serialize, JsonSchema)]
+#[schemars(transform = crate::schema::strip_int_formats)]
 pub struct MemoryNode {
     /// Stable id of the memory.
     pub id: u64,
@@ -94,6 +97,7 @@ pub struct MemoryNode {
 
 /// A typed edge in an [`Explanation`] subgraph.
 #[derive(Debug, Clone, Serialize, JsonSchema)]
+#[schemars(transform = crate::schema::strip_int_formats)]
 pub struct MemoryEdge {
     /// Source memory id.
     pub from: u64,

--- a/crates/velesdb-memory/src/schema.rs
+++ b/crates/velesdb-memory/src/schema.rs
@@ -1,0 +1,60 @@
+//! JSON Schema post-processing shared by the domain model and the MCP DTOs.
+//!
+//! `schemars` annotates Rust integer types with a `format` keyword (`"uint64"`
+//! for `u64`, `"uint"` for `usize`, …). Those values are not standard JSON
+//! Schema formats, so strict MCP clients log `unknown format "uint64" ignored`
+//! for every integer field. The `type: integer` (plus the `minimum: 0` schemars
+//! already emits for unsigned types) carries the constraint on its own, so the
+//! non-standard `format` is pure noise — this transform strips it.
+
+use schemars::Schema;
+use serde_json::{Map, Value};
+
+/// A `schemars` container transform that recursively removes Rust integer
+/// `format` keywords from a generated schema. Apply with
+/// `#[schemars(transform = crate::schema::strip_int_formats)]`.
+pub(crate) fn strip_int_formats(schema: &mut Schema) {
+    if let Some(object) = schema.as_object_mut() {
+        strip_in_map(object);
+    }
+}
+
+fn strip_in_map(map: &mut Map<String, Value>) {
+    let drop_format = matches!(map.get("format"), Some(Value::String(f)) if is_rust_int_format(f));
+    if drop_format {
+        map.remove("format");
+    }
+    for value in map.values_mut() {
+        strip_in_value(value);
+    }
+}
+
+fn strip_in_value(value: &mut Value) {
+    match value {
+        Value::Object(map) => strip_in_map(map),
+        Value::Array(items) => items.iter_mut().for_each(strip_in_value),
+        _ => {}
+    }
+}
+
+fn is_rust_int_format(format: &str) -> bool {
+    matches!(
+        format,
+        "uint"
+            | "uint8"
+            | "uint16"
+            | "uint32"
+            | "uint64"
+            | "uint128"
+            | "int"
+            | "int8"
+            | "int16"
+            | "int32"
+            | "int64"
+            | "int128"
+    )
+}
+
+#[cfg(test)]
+#[path = "schema_tests.rs"]
+mod tests;

--- a/crates/velesdb-memory/src/schema_tests.rs
+++ b/crates/velesdb-memory/src/schema_tests.rs
@@ -1,0 +1,48 @@
+//! Tests for [`strip_int_formats`](super::strip_int_formats).
+
+use schemars::{schema_for, JsonSchema};
+use serde_json::json;
+
+use super::strip_int_formats;
+
+#[test]
+fn removes_rust_int_formats_but_keeps_standard_ones() {
+    let mut schema: schemars::Schema = serde_json::from_value(json!({
+        "type": "object",
+        "properties": {
+            "id": { "type": "integer", "format": "uint64", "minimum": 0 },
+            "ids": { "type": "array", "items": { "type": "integer", "format": "uint" } },
+            "when": { "type": "string", "format": "date-time" }
+        }
+    }))
+    .expect("valid schema");
+
+    strip_int_formats(&mut schema);
+
+    let value = serde_json::to_value(&schema).expect("serializable");
+    assert!(value["properties"]["id"].get("format").is_none());
+    assert!(value["properties"]["ids"]["items"].get("format").is_none());
+    // The integer constraint survives; only the non-standard format is dropped.
+    assert_eq!(value["properties"]["id"]["type"], "integer");
+    assert_eq!(value["properties"]["id"]["minimum"], 0);
+    // Standard formats are preserved.
+    assert_eq!(value["properties"]["when"]["format"], "date-time");
+}
+
+#[derive(JsonSchema)]
+#[schemars(transform = strip_int_formats)]
+#[allow(dead_code)]
+struct Sample {
+    id: u64,
+    hop: usize,
+}
+
+#[test]
+fn derived_schema_has_no_int_format() {
+    let schema = schema_for!(Sample);
+    let text = serde_json::to_string(&schema).expect("serializable");
+    assert!(
+        !text.contains("\"format\""),
+        "derived schema still carries an int format: {text}"
+    );
+}


### PR DESCRIPTION
## Why

Adding `velesdb-memory` to an MCP client (e.g. `claude mcp get velesdb-memory`) logged ~20 lines of:
```
unknown format "uint64" ignored in schema at path "#/properties/id"
unknown format "uint" ignored in schema at path "#/$defs/MemoryNode/properties/hop"
```
`schemars` annotates Rust integers with `format: "uint64"` / `"uint"`, which are **not** standard JSON Schema formats, so strict MCP clients warn on every id/hop field. Pure noise — the server still connected and worked, but it looks broken.

## What

- New shared `schema::strip_int_formats` — a `schemars` container transform that recursively removes the non-standard integer `format` keywords. `type: integer` (+ the `minimum: 0` schemars emits for unsigned) keeps the constraint intact; only the bogus `format` is dropped, and standard formats (e.g. `date-time`) are preserved.
- Applied via `#[schemars(transform = …)]` to the 13 model + DTO types that carry ids/hops (`Link`, `Recollection`, `MemoryNode`, `MemoryEdge`, and the `*Params`/`*Result` DTOs).
- Tests in a separate file (`schema_tests.rs`): a unit test on the transform + a derive-integration test asserting the generated schema has no int `format`.

## Verified

- `cargo test -p velesdb-memory`: schema 2/2, **mcp server 18/18**, full suite green.
- `cargo clippy -- -D warnings -D clippy::pedantic` clean; `cargo fmt --check` clean.
- **End-to-end in Claude Code**: reinstalled the binary and `claude mcp get velesdb-memory` now shows **0 `unknown format` warnings** and `Status: ✔ Connected`.
