### PR TITLE
feat(memory): durable TTL on remember + 0.3.0 (MCP + Node parity, docs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,8 @@ mem.remember("Booked the aisle seat on Robert's flight", links=[(reason, "becaus
 mem.why("why the aisle seat on Robert's flight?")   # walks booking → reason — recall() can't
 ```
 
+Memories are permanent by default; `forget(id)` deletes one, and `remember(…, ttl_seconds=…)` (or a server-wide `VELESDB_MEMORY_DEFAULT_TTL`) gives a fact a durable, restart-surviving expiry.
+
 The same wedge ships in **Python** (`pip install velesdb`), **Node** (`npm i @wiscale/velesdb-memory-node`), and as a local **[MCP server](crates/velesdb-memory)**.
 
 **Four runnable ways to see it** — each shows what plain vector recall misses and `why()` recovers:

--- a/crates/velesdb-memory/CHANGELOG.md
+++ b/crates/velesdb-memory/CHANGELOG.md
@@ -7,6 +7,23 @@ released on its own `velesdb-memory-vX.Y.Z` tag.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2026-06-30
+
+### Added
+
+- **Durable TTL on `remember`.** Facts can now expire. `remember` (MCP tool) and
+  `MemoryService::remember_with_ttl` take an optional `ttl_seconds`; the expiry is
+  persisted with the fact (`_veles_expires_at`), so it survives a restart, and
+  expired facts stop being recalled. Metadata and a TTL combine. Set a server-wide
+  default with `VELESDB_MEMORY_DEFAULT_TTL` (seconds); `0` means permanent. The
+  Node binding's `remember` gains the matching `ttlSeconds` argument.
+
+### Fixed
+
+- **Cleaner MCP tool schemas.** Stripped `schemars`' non-standard integer `format`
+  keywords (`uint64`/`uint`) from the generated tool schemas, so strict MCP clients
+  no longer log `unknown format "uint64" ignored` for every id field.
+
 ## [0.2.0] - 2026-06-29
 
 Benchmark milestone: the tri-engine is no longer just *wired* — each leg is
@@ -69,5 +86,6 @@ First release of the local-first MCP memory server for AI agents.
 - License boundary by construction: memory semantics only, never raw database
   capabilities.
 
+[0.3.0]: https://github.com/cyberlife-coder/VelesDB/releases/tag/velesdb-memory-v0.3.0
 [0.2.0]: https://github.com/cyberlife-coder/VelesDB/releases/tag/velesdb-memory-v0.2.0
 [0.1.0]: https://github.com/cyberlife-coder/VelesDB/releases/tag/velesdb-memory-v0.1.0

--- a/crates/velesdb-memory/Cargo.toml
+++ b/crates/velesdb-memory/Cargo.toml
@@ -2,7 +2,7 @@
 name = "velesdb-memory"
 # Independent of the workspace version: velesdb-memory is a young MCP wrapper
 # with its own release cadence, decoupled from the core engine's 3.x line.
-version = "0.2.0"
+version = "0.3.0"
 edition.workspace = true
 rust-version.workspace = true
 license-file = "../../LICENSE"

--- a/crates/velesdb-memory/README.md
+++ b/crates/velesdb-memory/README.md
@@ -10,7 +10,7 @@ three engines behind its memory tools:
 
 | Tool       | What it does                                               | Engines |
 |------------|------------------------------------------------------------|---------|
-| `remember` | store a fact, optionally linked + tagged with metadata     | Vector + Graph + ColumnStore |
+| `remember` | store a fact, optionally linked + tagged with metadata, with an optional expiry (`ttl_seconds`) | Vector + Graph + ColumnStore |
 | `recall`   | semantic retrieval, optional exact-match metadata filter   | Vector + ColumnStore |
 | `relate`   | create a typed edge between two memories                   | Graph |
 | `forget`   | delete a memory                                            | — |
@@ -249,7 +249,8 @@ Once configured, your agent discovers the tools automatically (via MCP
 //            (re-remembering identical text is idempotent — same id, updated in place)
 remember { "fact": "we chose parking_lot to avoid lock poisoning",
            "metadata": { "project": "checkout" },                  // optional → enables filtering
-           "links":   [ { "target": 1234, "relation": "decided_in" } ] }  // optional typed edges
+           "links":   [ { "target": 1234, "relation": "decided_in" } ],  // optional typed edges
+           "ttl_seconds": 604800 }                                 // optional → expires in 7 days
 → { "id": 9876543210 }
 
 // relate — add a typed edge between two existing memories
@@ -286,6 +287,13 @@ content. Pass it to `relate` / `forget`, or as a `links[].target` on a later
 `metadata` (project, author, status) and a `link` to the PR or ticket. Days
 later, `why("…")` recovers not just the decision but the PR, ticket, and
 benchmark linked to it — where `recall` alone returns only look-alike text.
+
+**Forgetting & expiry.** Facts are permanent by default. Delete one explicitly
+with `forget { "id": … }`. To make a fact self-expire, pass `ttl_seconds` to
+`remember` (a durable TTL persisted with the fact, so it survives a restart;
+expired facts stop being recalled). Set `VELESDB_MEMORY_DEFAULT_TTL` (seconds) to
+apply a default expiry to every fact that doesn't set its own. To wipe everything,
+delete the store directory at `VELESDB_MEMORY_PATH`.
 
 > **Embedding the library directly?** The same wedge is available without the
 > MCP server: as a **Rust** API (`MemoryService::remember/recall/relate/forget/why`,

--- a/crates/velesdb-memory/src/main.rs
+++ b/crates/velesdb-memory/src/main.rs
@@ -5,7 +5,8 @@
 //! Configure the store directory with `VELESDB_MEMORY_PATH` and the embedding
 //! backend with `VELESDB_MEMORY_EMBEDDER` (`hash` | `ollama`). When built with
 //! `--features extract`, set `VELESDB_MEMORY_EXTRACTOR=ollama` to enable the
-//! `remember_extracted` tool (auto text → fact↔topic graph).
+//! `remember_extracted` tool (auto text → fact↔topic graph). Set
+//! `VELESDB_MEMORY_DEFAULT_TTL` (seconds) to expire remembered facts by default.
 
 use rmcp::ServiceExt;
 use velesdb_memory::mcp::McpServer;
@@ -20,7 +21,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // worker thread on a synchronous operation.
     let embedder = build_embedder()?;
     let service = MemoryService::open(&store_path, embedder)?;
-    let server = build_server(service)?;
+    let server = apply_default_ttl(build_server(service)?)?;
 
     tokio::runtime::Runtime::new()?.block_on(async move {
         let running = server
@@ -29,6 +30,22 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         running.waiting().await?;
         Ok::<(), Box<dyn std::error::Error>>(())
     })
+}
+
+/// Apply `VELESDB_MEMORY_DEFAULT_TTL` (seconds) as the default expiry for facts
+/// stored without their own `ttl_seconds`. Unset means facts are permanent.
+fn apply_default_ttl(server: McpServer) -> Result<McpServer, Box<dyn std::error::Error>> {
+    match std::env::var("VELESDB_MEMORY_DEFAULT_TTL") {
+        Ok(raw) => {
+            let ttl_seconds: u64 = raw.trim().parse().map_err(|_| {
+                format!(
+                    "VELESDB_MEMORY_DEFAULT_TTL must be a non-negative integer (seconds), got '{raw}'"
+                )
+            })?;
+            Ok(server.with_default_ttl(ttl_seconds))
+        }
+        Err(_) => Ok(server),
+    }
 }
 
 /// Build the MCP server, attaching an extraction backend from

--- a/crates/velesdb-memory/src/mcp.rs
+++ b/crates/velesdb-memory/src/mcp.rs
@@ -46,6 +46,10 @@ pub struct McpServer {
     /// a backend is attached via [`Self::with_extractor`]; the tool then reports
     /// extraction as unconfigured.
     extractor: Option<DynExtractor>,
+    /// Default time-to-live (seconds) applied to `remember`d facts that don't
+    /// specify their own `ttl_seconds`. `None` (the default) stores permanently.
+    /// Set from `VELESDB_MEMORY_DEFAULT_TTL` by the binary.
+    default_ttl: Option<u64>,
     tool_router: ToolRouter<McpServer>,
 }
 
@@ -57,6 +61,7 @@ impl McpServer {
         Self {
             service: Arc::new(service),
             extractor: None,
+            default_ttl: None,
             tool_router: Self::tool_router(),
         }
     }
@@ -69,9 +74,17 @@ impl McpServer {
         self
     }
 
+    /// Apply a default TTL (seconds) to `remember`d facts that don't carry their
+    /// own `ttl_seconds`. `0` is treated as "no default" (permanent).
+    #[must_use]
+    pub fn with_default_ttl(mut self, ttl_seconds: u64) -> Self {
+        self.default_ttl = (ttl_seconds > 0).then_some(ttl_seconds);
+        self
+    }
+
     #[tool(
         name = "remember",
-        description = "Store a fact in durable local memory. Optionally link it to existing memories (graph) and tag it with structured metadata like project/author/type/status/date (ColumnStore) for later filtering. Returns the fact's stable id."
+        description = "Store a fact in durable local memory. Optionally link it to existing memories (graph) and tag it with structured metadata like project/author/type/status/date (ColumnStore) for later filtering. Set `ttl_seconds` to make the fact expire after a delay (a durable TTL that survives restarts); omit it for a permanent memory. Returns the fact's stable id."
     )]
     async fn remember(
         &self,
@@ -89,12 +102,15 @@ impl McpServer {
             fact,
             links,
             metadata,
+            ttl_seconds,
         } = params;
-        let id =
-            tokio::task::spawn_blocking(move || service.remember(&fact, &links, metadata.as_ref()))
-                .await
-                .map_err(join_error)?
-                .map_err(to_error)?;
+        let ttl = ttl_seconds.or(self.default_ttl);
+        let id = tokio::task::spawn_blocking(move || {
+            service.remember_with_ttl(&fact, &links, metadata.as_ref(), ttl)
+        })
+        .await
+        .map_err(join_error)?
+        .map_err(to_error)?;
         Ok(Json(RememberResult { id }))
     }
 

--- a/crates/velesdb-memory/src/mcp/dto.rs
+++ b/crates/velesdb-memory/src/mcp/dto.rs
@@ -23,6 +23,12 @@ pub(super) struct RememberParams {
     /// Optional structured metadata for later filtering (e.g.
     /// `{"project": "veles", "author": "julien", "status": "open"}`).
     pub(super) metadata: Option<Metadata>,
+    /// Optional time-to-live in seconds. When set, the fact expires (and stops
+    /// being recalled) after this many seconds — a durable TTL that survives a
+    /// restart. Omit for a permanent memory. Falls back to the server's
+    /// `VELESDB_MEMORY_DEFAULT_TTL` when unset.
+    #[serde(default)]
+    pub(super) ttl_seconds: Option<u64>,
 }
 
 /// Result of the `remember` tool.

--- a/crates/velesdb-memory/src/mcp/server_tests.rs
+++ b/crates/velesdb-memory/src/mcp/server_tests.rs
@@ -40,6 +40,7 @@ async fn remember_then_recall_roundtrips_through_the_server() {
             fact: DECISION.to_owned(),
             links: Vec::new(),
             metadata: None,
+            ttl_seconds: None,
         }))
         .await
         .expect("remember");
@@ -63,6 +64,7 @@ async fn why_returns_the_connected_subgraph() {
             fact: DECISION.to_owned(),
             links: Vec::new(),
             metadata: None,
+            ttl_seconds: None,
         }))
         .await
         .expect("remember decision");
@@ -71,6 +73,7 @@ async fn why_returns_the_connected_subgraph() {
             fact: "PR #42 swaps the mutex".to_owned(),
             links: Vec::new(),
             metadata: None,
+            ttl_seconds: None,
         }))
         .await
         .expect("remember pr");
@@ -95,6 +98,7 @@ async fn forget_removes_a_memory_through_the_server() {
             fact: "ephemeral note about France".to_owned(),
             links: Vec::new(),
             metadata: None,
+            ttl_seconds: None,
         }))
         .await
         .expect("remember");
@@ -122,6 +126,7 @@ async fn remember_links_are_traversable_by_why() {
             fact: "PR #99 refactors locks".to_owned(),
             links: Vec::new(),
             metadata: None,
+            ttl_seconds: None,
         }))
         .await
         .expect("remember pr");
@@ -133,6 +138,7 @@ async fn remember_links_are_traversable_by_why() {
                 relation: "decided_in".to_owned(),
             }],
             metadata: None,
+            ttl_seconds: None,
         }))
         .await
         .expect("remember decision with link");
@@ -154,6 +160,7 @@ async fn metadata_and_filter_flow_through_the_server() {
             fact: "auth bug in login".to_owned(),
             links: Vec::new(),
             metadata: Some(veles_meta.clone()),
+            ttl_seconds: None,
         }))
         .await
         .expect("remember veles");
@@ -162,6 +169,7 @@ async fn metadata_and_filter_flow_through_the_server() {
             fact: "auth bug in login too".to_owned(),
             links: Vec::new(),
             metadata: Some(acme_meta),
+            ttl_seconds: None,
         }))
         .await
         .expect("remember acme");
@@ -177,6 +185,46 @@ async fn metadata_and_filter_flow_through_the_server() {
 
     assert!(recalled.memories.iter().any(|m| m.id == kept.id));
     assert!(recalled.memories.iter().all(|m| m.id != dropped.id));
+}
+
+#[tokio::test]
+async fn remember_accepts_explicit_and_default_ttl() {
+    let (_dir, srv) = server();
+    let srv = srv.with_default_ttl(3_600);
+
+    // Per-fact ttl_seconds flows through the tool.
+    let Json(explicit) = srv
+        .remember(Parameters(RememberParams {
+            fact: "explicit ttl fact".to_owned(),
+            links: Vec::new(),
+            metadata: None,
+            ttl_seconds: Some(3_600),
+        }))
+        .await
+        .expect("remember with explicit ttl");
+
+    // No per-fact ttl → the server's default_ttl applies.
+    let Json(defaulted) = srv
+        .remember(Parameters(RememberParams {
+            fact: "default ttl fact".to_owned(),
+            links: Vec::new(),
+            metadata: None,
+            ttl_seconds: None,
+        }))
+        .await
+        .expect("remember with default ttl");
+
+    // Both have a future expiry, so both are still recallable now.
+    let Json(recalled) = srv
+        .recall(Parameters(RecallParams {
+            query: "ttl fact".to_owned(),
+            limit: None,
+            filter: None,
+        }))
+        .await
+        .expect("recall");
+    assert!(recalled.memories.iter().any(|m| m.id == explicit.id));
+    assert!(recalled.memories.iter().any(|m| m.id == defaulted.id));
 }
 
 /// Build a `{"ts": <n>}` metadata map.
@@ -197,6 +245,7 @@ async fn recall_where_filters_by_range_through_the_server() {
             fact: fact.to_owned(),
             links: Vec::new(),
             metadata: Some(ts_meta(ts)),
+            ttl_seconds: None,
         }))
         .await
         .expect("remember");
@@ -254,6 +303,7 @@ async fn empty_fact_returns_invalid_params_not_internal_error() {
             fact: "   ".to_owned(),
             links: Vec::new(),
             metadata: None,
+            ttl_seconds: None,
         }))
         .await
         .map(|_| ())
@@ -276,6 +326,7 @@ async fn unknown_link_target_returns_invalid_params_not_internal_error() {
                 relation: "x".to_owned(),
             }],
             metadata: None,
+            ttl_seconds: None,
         }))
         .await
         .map(|_| ())
@@ -295,6 +346,7 @@ async fn relate_to_unknown_endpoint_returns_invalid_params_not_internal_error() 
             fact: "an existing memory".to_owned(),
             links: Vec::new(),
             metadata: None,
+            ttl_seconds: None,
         }))
         .await
         .expect("remember");
@@ -329,6 +381,7 @@ async fn oversized_fact_returns_invalid_params() {
             fact: huge,
             links: Vec::new(),
             metadata: None,
+            ttl_seconds: None,
         }))
         .await
         .map(|_| ())
@@ -363,6 +416,7 @@ async fn why_hop_depth_is_capped_at_max() {
         fact: DECISION.to_owned(),
         links: Vec::new(),
         metadata: None,
+        ttl_seconds: None,
     }))
     .await
     .expect("remember");
@@ -437,6 +491,7 @@ async fn reserved_metadata_key_returns_invalid_params() {
             fact: "a fact".to_owned(),
             links: Vec::new(),
             metadata: Some(bad_meta),
+            ttl_seconds: None,
         }))
         .await
         .map(|_| ())
@@ -479,6 +534,7 @@ async fn relate_with_empty_relation_returns_invalid_params() {
             fact: "fact A".to_owned(),
             links: Vec::new(),
             metadata: None,
+            ttl_seconds: None,
         }))
         .await
         .expect("remember A");
@@ -487,6 +543,7 @@ async fn relate_with_empty_relation_returns_invalid_params() {
             fact: "fact B".to_owned(),
             links: Vec::new(),
             metadata: None,
+            ttl_seconds: None,
         }))
         .await
         .expect("remember B");

--- a/crates/velesdb-memory/src/service.rs
+++ b/crates/velesdb-memory/src/service.rs
@@ -100,8 +100,13 @@ impl<E: Embedder> MemoryService<E> {
         self.ensure_link_targets_exist(links)?;
         let fact_id = id::stable_id(fact);
         let embedding = self.embedder.embed(fact)?;
-        let ttl_seconds = ttl_seconds.filter(|&seconds| seconds > 0);
-        self.store(fact_id, fact, &embedding, metadata, ttl_seconds)?;
+        self.store(
+            fact_id,
+            fact,
+            &embedding,
+            metadata,
+            positive_ttl(ttl_seconds),
+        )?;
         for link in links {
             validate_relation(&link.relation)?;
             self.memory
@@ -600,6 +605,12 @@ fn reject_reserved_keys(metadata: Option<&Metadata>) -> Result<(), MemoryError> 
         }
     }
     Ok(())
+}
+
+/// Normalise a requested TTL: `Some(0)` (and `None`) mean "no expiry" — the fact
+/// is stored permanently. Any positive value is kept as-is.
+fn positive_ttl(ttl_seconds: Option<u64>) -> Option<u64> {
+    ttl_seconds.filter(|&seconds| seconds > 0)
 }
 
 /// Map a core search result to a [`Recollection`], lifting the fact text out of

--- a/crates/velesdb-memory/src/service.rs
+++ b/crates/velesdb-memory/src/service.rs
@@ -72,6 +72,26 @@ impl<E: Embedder> MemoryService<E> {
         links: &[Link],
         metadata: Option<&Metadata>,
     ) -> Result<u64, MemoryError> {
+        self.remember_with_ttl(fact, links, metadata, None)
+    }
+
+    /// Like [`Self::remember`], but the fact **expires after `ttl_seconds`**.
+    ///
+    /// The expiry is a durable TTL — persisted with the fact (reserved
+    /// `_veles_expires_at` payload field), so it survives a process restart, and
+    /// expired facts stop being recalled. `None` (or `Some(0)`) stores the fact
+    /// permanently, exactly like [`Self::remember`]. Metadata and a TTL combine:
+    /// the metadata is written and the expiry preserved.
+    ///
+    /// # Errors
+    /// Same as [`Self::remember`].
+    pub fn remember_with_ttl(
+        &self,
+        fact: &str,
+        links: &[Link],
+        metadata: Option<&Metadata>,
+        ttl_seconds: Option<u64>,
+    ) -> Result<u64, MemoryError> {
         let fact = fact.trim();
         if fact.is_empty() {
             return Err(MemoryError::EmptyFact);
@@ -80,7 +100,8 @@ impl<E: Embedder> MemoryService<E> {
         self.ensure_link_targets_exist(links)?;
         let fact_id = id::stable_id(fact);
         let embedding = self.embedder.embed(fact)?;
-        self.store(fact_id, fact, &embedding, metadata)?;
+        let ttl_seconds = ttl_seconds.filter(|&seconds| seconds > 0);
+        self.store(fact_id, fact, &embedding, metadata, ttl_seconds)?;
         for link in links {
             validate_relation(&link.relation)?;
             self.memory
@@ -249,7 +270,8 @@ impl<E: Embedder> MemoryService<E> {
         let embedding = self.embedder.embed(&content)?;
         let mut meta = Map::new();
         meta.insert(HUB_FIELD.to_string(), Value::Bool(true));
-        self.store(id, &content, &embedding, Some(&meta))?;
+        // Topic hubs are graph anchors — they never expire.
+        self.store(id, &content, &embedding, Some(&meta), None)?;
         Ok(id)
     }
 
@@ -269,26 +291,28 @@ impl<E: Embedder> MemoryService<E> {
         Ok(())
     }
 
-    /// Store a fact with or without metadata.
+    /// Store a fact with any combination of metadata and a durable TTL.
     fn store(
         &self,
         id: u64,
         fact: &str,
         embedding: &[f32],
         metadata: Option<&Metadata>,
+        ttl_seconds: Option<u64>,
     ) -> Result<(), MemoryError> {
-        match metadata {
-            Some(meta) => self
-                .memory
-                .semantic()
-                .store_with_metadata(id, fact, embedding, meta)
-                .map_err(MemoryError::from),
-            None => self
-                .memory
-                .semantic()
-                .store(id, fact, embedding)
-                .map_err(MemoryError::from),
+        let semantic = self.memory.semantic();
+        match (metadata, ttl_seconds) {
+            (Some(meta), Some(ttl)) => {
+                // store_with_ttl writes the fact + the durable expiry; update_metadata
+                // then merges the metadata while preserving `_veles_expires_at`.
+                semantic.store_with_ttl(id, fact, embedding, ttl)?;
+                semantic.update_metadata(id, meta)?;
+            }
+            (Some(meta), None) => semantic.store_with_metadata(id, fact, embedding, meta)?,
+            (None, Some(ttl)) => semantic.store_with_ttl(id, fact, embedding, ttl)?,
+            (None, None) => semantic.store(id, fact, embedding)?,
         }
+        Ok(())
     }
 
     /// Recall up to `k` memories semantically similar to `query` (vector facet),

--- a/crates/velesdb-memory/tests/ttl_bdd.rs
+++ b/crates/velesdb-memory/tests/ttl_bdd.rs
@@ -1,0 +1,99 @@
+//! BDD integration tests for the durable TTL on `remember_with_ttl`.
+//!
+//! Categories: Nominal (≥60%), Edge (~20%), Negative (≥20%).
+
+mod common;
+
+use std::thread::sleep;
+use std::time::Duration;
+
+use common::{meta, service};
+use serde_json::Value;
+
+// --- Nominal ---------------------------------------------------------------
+
+#[test]
+fn remember_with_ttl_stays_recallable_before_expiry() {
+    let (_dir, svc) = service();
+    let fact = "the staging token rotates nightly";
+    let id = svc
+        .remember_with_ttl(fact, &[], None, Some(3_600))
+        .expect("remember with ttl");
+
+    let hits = svc.recall("staging token", 5, None).expect("recall");
+
+    assert!(
+        hits.iter().any(|h| h.id == id),
+        "a fact with a future TTL must still be recallable"
+    );
+}
+
+#[test]
+fn remember_with_ttl_combines_with_metadata() {
+    let (_dir, svc) = service();
+    let filter = meta(&[("project", Value::String("veles".into()))]);
+    let id = svc
+        .remember_with_ttl("ephemeral note", &[], Some(&filter), Some(3_600))
+        .expect("remember with metadata + ttl");
+
+    let hits = svc
+        .recall("ephemeral note", 5, Some(&filter))
+        .expect("recall with filter");
+
+    assert!(
+        hits.iter().any(|h| h.id == id),
+        "metadata and TTL must combine: the fact keeps its filterable metadata"
+    );
+}
+
+// --- Edge ------------------------------------------------------------------
+
+#[test]
+fn zero_ttl_stores_permanently() {
+    let (_dir, svc) = service();
+    // Some(0) is normalised to "no TTL" (permanent) — it must NOT delete the fact.
+    let id = svc
+        .remember_with_ttl("permanent fact", &[], None, Some(0))
+        .expect("remember with zero ttl");
+
+    let hits = svc.recall("permanent fact", 5, None).expect("recall");
+
+    assert!(
+        hits.iter().any(|h| h.id == id),
+        "ttl_seconds = 0 must store permanently, not expire immediately"
+    );
+}
+
+#[test]
+fn none_ttl_matches_plain_remember() {
+    let (_dir, svc) = service();
+    let with_none = svc
+        .remember_with_ttl("same content", &[], None, None)
+        .expect("remember_with_ttl(None)");
+    let plain = svc.remember("same content", &[], None).expect("remember");
+
+    assert_eq!(
+        with_none, plain,
+        "remember_with_ttl(None) must behave exactly like remember"
+    );
+}
+
+// --- Negative --------------------------------------------------------------
+
+#[test]
+fn expired_fact_is_no_longer_recalled() {
+    let (_dir, svc) = service();
+    let id = svc
+        .remember_with_ttl("short-lived secret", &[], None, Some(1))
+        .expect("remember with 1s ttl");
+
+    // Past the TTL window: the durable expiry must drop the fact from recall.
+    sleep(Duration::from_millis(1_500));
+
+    let hits = svc.recall("short-lived secret", 5, None).expect("recall");
+
+    assert!(
+        !hits.iter().any(|h| h.id == id),
+        "a fact past its TTL must not be recalled"
+    );
+}

--- a/crates/velesdb-node/Cargo.toml
+++ b/crates/velesdb-node/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "velesdb-node"
-# Tracks velesdb-memory's independent 0.1.0 cadence (the npm package version),
+# Tracks velesdb-memory's independent cadence (the npm package version),
 # not the workspace 3.x engine line. Never crates.io-published (publish=false).
-version = "0.1.0"
+version = "0.3.0"
 # Never cargo-published: this cdylib ships to npm as @wiscale/velesdb-memory-node
 # per-platform prebuilds, not to crates.io.
 publish = false

--- a/crates/velesdb-node/package.json
+++ b/crates/velesdb-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wiscale/velesdb-memory-node",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Local-first agent memory for Node.js (napi-rs): remember/recall/relate/forget/why with the why() knowledge-graph wedge, plus auto-extraction.",
   "license": "SEE LICENSE IN LICENSE",
   "author": "Julien Lange <contact@wiscale.fr>",

--- a/crates/velesdb-node/src/lib.rs
+++ b/crates/velesdb-node/src/lib.rs
@@ -121,20 +121,23 @@ impl MemoryStore {
 
     /// Store a fact; resolves to its decimal-string id. `links` are
     /// `{target, relation}` edges to existing memories; `metadata` is an optional
-    /// object for later filtering.
+    /// object for later filtering. `ttlSeconds` makes the fact expire after that
+    /// many seconds (a durable TTL that survives restarts); omit it (or `0`) for
+    /// a permanent memory.
     #[napi(ts_return_type = "Promise<string>")]
     pub fn remember(
         &self,
         fact: String,
         links: Option<Vec<LinkJs>>,
         metadata: Option<Value>,
+        ttl_seconds: Option<u32>,
     ) -> AsyncTask<Job<String>> {
         let svc = Arc::clone(&self.inner);
         AsyncTask::new(Job::new(move || {
             guards::check_fact(&fact)?;
             let links = convert::to_links(links)?;
             let metadata = convert::to_metadata(metadata)?;
-            svc.remember(&fact, &links, metadata.as_ref())
+            svc.remember_with_ttl(&fact, &links, metadata.as_ref(), ttl_seconds.map(u64::from))
                 .map(convert::id_to_string)
                 .map_err(to_napi_err)
         }))


### PR DESCRIPTION
## What

Wires the engine's durable semantic-memory TTL into the velesdb-memory wedge, bumps to **0.3.0**, and documents it.

### Feature: durable TTL on `remember`
- **MCP `remember` tool** + `MemoryService::remember_with_ttl` take optional **`ttl_seconds`**. The expiry is persisted with the fact (`_veles_expires_at`), so it **survives a restart**, and expired facts stop being recalled. Metadata + TTL combine (`store_with_ttl` then `update_metadata`, which preserves the expiry).
- **`VELESDB_MEMORY_DEFAULT_TTL`** (seconds) + `McpServer::with_default_ttl` apply a server-wide default. `ttl_seconds = 0` = permanent.
- **Node binding** `remember()` gains the matching `ttlSeconds` arg (parity).
- No core change (composes existing public core methods) → no workspace release, only velesdb-memory bumps.

### Also
- **Feature audit**: all 7 tools (`remember/recall/recall_where/relate/forget/why/remember_extracted`) are at parity across MCP, Node, and Python. TTL: MCP ✅, Node ✅; **Python TTL deferred** (it would force a whole-workspace 3.x release for one param — rides the next core release).
- **Bumps**: velesdb-memory `0.2.0 → 0.3.0`, `@wiscale/velesdb-memory-node` `0.2.0 → 0.3.0` (released together on the `velesdb-memory-v*` tag).
- **Docs**: crate README (tools table, remember example, "Forgetting & expiry" note covering `forget` + `ttl_seconds` + default + wiping the store), root README lifecycle line, CHANGELOG `[0.3.0]` (TTL + the prior MCP schema-format fix).

## Verified
- `cargo test -p velesdb-memory`: **71 passed, 0 failed** (incl. a real-expiry test). Node + memory `clippy -D warnings -D clippy::pedantic` clean, `fmt --check` clean.

## Release (after merge)
Tagging `velesdb-memory-v0.3.0` triggers `release-memory.yml` (crates.io + npm) **and** `release-mcpb.yml` (official MCP registry, mcpb bundles) — fully automated.
