### PR TITLE
fix(memory): panic-safe truncate + DRY validate_relation + rmcp 2.0.0 security upgrade

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4551,9 +4551,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "1.8.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1f571c72940a19d9532fe52dbea8bc9912bf1d766c2970bb824056b86f3f59"
+checksum = "d52d21e5b342699bc4de690e6104fc4e43255e4e8420ff0f2cbb963aac09da6f"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4573,9 +4573,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "1.8.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aad0035b69380782d78ea95b508327e6deaa2235909053e596eea8f27b5e1d5"
+checksum = "6c68cec74c5b3ac73ff46375ae49e161637bda80bba70f0d5db641583bb308ee"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -6758,7 +6758,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-memory"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "rmcp",
  "schemars 1.2.1",
@@ -6815,7 +6815,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-node"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "napi",
  "napi-build",

--- a/crates/velesdb-memory/Cargo.toml
+++ b/crates/velesdb-memory/Cargo.toml
@@ -29,7 +29,7 @@ schemars = "1"
 # The MCP server stack — optional, behind the (default) `mcp` feature. Library
 # consumers (e.g. the language bindings) build with `default-features = false`
 # to get the memory core without the `rmcp`/`tokio` server dependencies.
-rmcp = { version = "1.8.0", features = ["server", "macros", "transport-io"], optional = true }
+rmcp = { version = "2.0.0", features = ["server", "macros", "transport-io"], optional = true }
 tokio = { workspace = true, optional = true }
 # Optional real-recall backend (off by default). HTTP-only to a local Ollama;
 # `default-features = false` drops TLS to keep the binary small.

--- a/crates/velesdb-memory/src/extract.rs
+++ b/crates/velesdb-memory/src/extract.rs
@@ -211,19 +211,18 @@ fn parse_generate_response(body: &str) -> Result<String, ExtractError> {
 /// A short, single-line preview of model output for error messages.
 #[cfg(feature = "extract")]
 fn truncate(text: &str) -> String {
+    const LIMIT: usize = 120;
     let mut out = String::new();
-    let mut first = true;
     for word in text.split_whitespace() {
-        if out.len() >= 120 {
+        let sep_len = if out.is_empty() { 0 } else { 1 };
+        if out.len() + sep_len + word.len() > LIMIT {
             break;
         }
-        if !first {
+        if sep_len > 0 {
             out.push(' ');
         }
         out.push_str(word);
-        first = false;
     }
-    out.truncate(120);
     out
 }
 

--- a/crates/velesdb-memory/src/extract.rs
+++ b/crates/velesdb-memory/src/extract.rs
@@ -214,11 +214,11 @@ fn truncate(text: &str) -> String {
     const LIMIT: usize = 120;
     let mut out = String::new();
     for word in text.split_whitespace() {
-        let sep_len = if out.is_empty() { 0 } else { 1 };
+        let sep_len = usize::from(!out.is_empty());
         if out.len() + sep_len + word.len() > LIMIT {
             break;
         }
-        if sep_len > 0 {
+        if !out.is_empty() {
             out.push(' ');
         }
         out.push_str(word);

--- a/crates/velesdb-memory/src/service.rs
+++ b/crates/velesdb-memory/src/service.rs
@@ -680,7 +680,7 @@ fn validate_relation(label: &str) -> Result<(), MemoryError> {
             label.len()
         )));
     }
-    if label.chars().any(|c| c.is_ascii() && c.is_ascii_control()) {
+    if label.chars().any(|c| c.is_ascii_control()) {
         return Err(MemoryError::InvalidRelation(
             "relation label must not contain ASCII control characters".to_owned(),
         ));


### PR DESCRIPTION
## Description

Three atomic fixes to `velesdb-memory`, each addressing a distinct code-quality issue found during a review of open PRs (PR #1278 — rmcp upgrade) and the code landed in develop.

---

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🔧 Refactoring (no functional changes)

---

## Changes

### 1. `fix(memory): prevent panic in truncate() when UTF-8 straddles byte 120`

**File:** `crates/velesdb-memory/src/extract.rs`

The previous implementation added words until `out.len() >= 120`, then called `out.truncate(120)`. If the last word pushed a multi-byte UTF-8 character (e.g. a 3-byte kanji at bytes 118–120), `String::truncate()` would panic — it requires a valid char boundary, and continuation bytes (`0x80–0xBF`) are never one.

**Fix:** Check *before* pushing a word whether adding it would push the output past 120 bytes. If it would, break without touching `out`. This preserves the `<= 120-byte` invariant at all times, making `out.truncate()` unnecessary and the panic impossible.

The function is an internal error-message preview (used in the `extract` feature). Stopping at a word boundary is the correct semantic here.

### 2. `refactor(memory): remove redundant is_ascii() guard in validate_relation`

**File:** `crates/velesdb-memory/src/service.rs`

```rust
// Before
if label.chars().any(|c| c.is_ascii() && c.is_ascii_control()) {

// After
if label.chars().any(|c| c.is_ascii_control()) {
```

`char::is_ascii_control()` returns `false` for all non-ASCII codepoints (U+0080+), so the `c.is_ascii()` guard is always redundant — it adds no filter and no protection. DRY simplification; semantics are identical.

### 3. `chore(deps): upgrade rmcp 1.8.0 → 2.0.0 (security fixes)`

**Files:** `crates/velesdb-memory/Cargo.toml`, `Cargo.lock`

rmcp 2.0.0 ships three security patches:
- Prevent OAuth resource spoofing ([rust-sdk#937](https://github.com/modelcontextprotocol/rust-sdk/pull/937))
- Block OAuth metadata SSRF ([rust-sdk#935](https://github.com/modelcontextprotocol/rust-sdk/pull/935))
- Prevent streamable HTTP session leak ([rust-sdk#934](https://github.com/modelcontextprotocol/rust-sdk/pull/934))

The breaking API changes in 2.0.0 (new `Audio` variant in `PromptMessageContent`, MCP 2025-11-25 spec alignment) do not affect `velesdb-memory`: the server only uses the tool-call surface (`tool_router` / `tool` macros / `transport-io`), not the prompt-message types that changed.

This supersedes dependabot PR #1278, which was blocked by the freshness check because `develop` had advanced after the bot opened it.

---

## How Has This Been Tested?

- [x] Unit tests — `cargo test -p velesdb-memory` — all 56 tests pass (service BDD, TTL BDD, why BDD, schema tests, MCP server integration tests)
- [x] Compile check — `cargo check -p velesdb-memory` — no warnings

**Test Configuration:**
- OS: Linux (Ubuntu 24.04)
- Rust version: stable (1.89)

---

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

The `truncate` panic (fix #1) could only be triggered in production when:
1. The `extract` feature is compiled in
2. Ollama returns output containing non-ASCII characters (CJK, emoji, etc.)
3. The content happens to have a multi-byte character straddling byte position 120

Low probability but deterministic once conditions align — classified as a correctness bug.

Date: 2026-06-30
