### PR TITLE
release: velesdb-memory 0.3.1 → main (rmcp 2.0 security patch)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4551,9 +4551,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "1.8.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1f571c72940a19d9532fe52dbea8bc9912bf1d766c2970bb824056b86f3f59"
+checksum = "d52d21e5b342699bc4de690e6104fc4e43255e4e8420ff0f2cbb963aac09da6f"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4573,9 +4573,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "1.8.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aad0035b69380782d78ea95b508327e6deaa2235909053e596eea8f27b5e1d5"
+checksum = "6c68cec74c5b3ac73ff46375ae49e161637bda80bba70f0d5db641583bb308ee"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -6758,7 +6758,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-memory"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "rmcp",
  "schemars 1.2.1",
@@ -6815,7 +6815,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-node"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "napi",
  "napi-build",

--- a/crates/velesdb-memory/CHANGELOG.md
+++ b/crates/velesdb-memory/CHANGELOG.md
@@ -7,6 +7,22 @@ released on its own `velesdb-memory-vX.Y.Z` tag.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.1] - 2026-06-30
+
+### Security
+
+- **Upgraded `rmcp` 1.8.0 → 2.0.0**, which patches three advisories: OAuth token
+  spoofing, SSRF via crafted MCP URLs, and a session-id leak in error responses.
+  No code changes were needed — the MCP server/macros API stayed compatible.
+
+### Fixed
+
+- **`truncate()` UTF-8 panic** (extract error previews): the budget is now checked
+  *before* appending a word, dropping the post-hoc `String::truncate` that could
+  panic when the 120-byte limit fell mid-multibyte-character.
+- **Dead code in `validate_relation`**: removed the redundant `is_ascii()` guard
+  (`char::is_ascii_control()` is already `false` for non-ASCII code points).
+
 ## [0.3.0] - 2026-06-30
 
 ### Added
@@ -86,6 +102,7 @@ First release of the local-first MCP memory server for AI agents.
 - License boundary by construction: memory semantics only, never raw database
   capabilities.
 
+[0.3.1]: https://github.com/cyberlife-coder/VelesDB/releases/tag/velesdb-memory-v0.3.1
 [0.3.0]: https://github.com/cyberlife-coder/VelesDB/releases/tag/velesdb-memory-v0.3.0
 [0.2.0]: https://github.com/cyberlife-coder/VelesDB/releases/tag/velesdb-memory-v0.2.0
 [0.1.0]: https://github.com/cyberlife-coder/VelesDB/releases/tag/velesdb-memory-v0.1.0

--- a/crates/velesdb-memory/Cargo.toml
+++ b/crates/velesdb-memory/Cargo.toml
@@ -2,7 +2,7 @@
 name = "velesdb-memory"
 # Independent of the workspace version: velesdb-memory is a young MCP wrapper
 # with its own release cadence, decoupled from the core engine's 3.x line.
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 rust-version.workspace = true
 license-file = "../../LICENSE"
@@ -29,7 +29,7 @@ schemars = "1"
 # The MCP server stack — optional, behind the (default) `mcp` feature. Library
 # consumers (e.g. the language bindings) build with `default-features = false`
 # to get the memory core without the `rmcp`/`tokio` server dependencies.
-rmcp = { version = "1.8.0", features = ["server", "macros", "transport-io"], optional = true }
+rmcp = { version = "2.0.0", features = ["server", "macros", "transport-io"], optional = true }
 tokio = { workspace = true, optional = true }
 # Optional real-recall backend (off by default). HTTP-only to a local Ollama;
 # `default-features = false` drops TLS to keep the binary small.

--- a/crates/velesdb-memory/src/extract.rs
+++ b/crates/velesdb-memory/src/extract.rs
@@ -211,19 +211,20 @@ fn parse_generate_response(body: &str) -> Result<String, ExtractError> {
 /// A short, single-line preview of model output for error messages.
 #[cfg(feature = "extract")]
 fn truncate(text: &str) -> String {
+    const LIMIT: usize = 120;
     let mut out = String::new();
-    let mut first = true;
     for word in text.split_whitespace() {
-        if out.len() >= 120 {
+        // Check the budget *before* pushing so we never need a post-hoc
+        // `String::truncate`, which would panic if the limit fell mid-UTF-8 char.
+        let sep_len = usize::from(!out.is_empty());
+        if out.len() + sep_len + word.len() > LIMIT {
             break;
         }
-        if !first {
+        if !out.is_empty() {
             out.push(' ');
         }
         out.push_str(word);
-        first = false;
     }
-    out.truncate(120);
     out
 }
 

--- a/crates/velesdb-memory/src/service.rs
+++ b/crates/velesdb-memory/src/service.rs
@@ -688,7 +688,7 @@ fn validate_relation(label: &str) -> Result<(), MemoryError> {
             label.len()
         )));
     }
-    if label.chars().any(|c| c.is_ascii() && c.is_ascii_control()) {
+    if label.chars().any(|c| c.is_ascii_control()) {
         return Err(MemoryError::InvalidRelation(
             "relation label must not contain ASCII control characters".to_owned(),
         ));

--- a/crates/velesdb-node/Cargo.toml
+++ b/crates/velesdb-node/Cargo.toml
@@ -2,7 +2,7 @@
 name = "velesdb-node"
 # Tracks velesdb-memory's independent cadence (the npm package version),
 # not the workspace 3.x engine line. Never crates.io-published (publish=false).
-version = "0.3.0"
+version = "0.3.1"
 # Never cargo-published: this cdylib ships to npm as @wiscale/velesdb-memory-node
 # per-platform prebuilds, not to crates.io.
 publish = false

--- a/crates/velesdb-node/package.json
+++ b/crates/velesdb-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wiscale/velesdb-memory-node",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Local-first agent memory for Node.js (napi-rs): remember/recall/relate/forget/why with the why() knowledge-graph wedge, plus auto-extraction.",
   "license": "SEE LICENSE IN LICENSE",
   "author": "Julien Lange <contact@wiscale.fr>",


### PR DESCRIPTION
Promotes the **velesdb-memory 0.3.1** security patch to main: rmcp 1.8 → 2.0 (3 CVEs), truncate() UTF-8 panic fix, validate_relation cleanup. Merge-commit so main's ancestry stays clean. Release runs on the `velesdb-memory-v0.3.1` tag (memory + node + MCP registry; uses the already-published core 3.5.0).