### PR TITLE
docs(memory): README registry badges + dated published status

### DIFF
--- a/crates/velesdb-memory/README.md
+++ b/crates/velesdb-memory/README.md
@@ -1,9 +1,25 @@
 # velesdb-memory
 
+[![crates.io](https://img.shields.io/crates/v/velesdb-memory?logo=rust&label=crates.io)](https://crates.io/crates/velesdb-memory)
+[![docs.rs](https://img.shields.io/docsrs/velesdb-memory?logo=docsdotrs&label=docs.rs)](https://docs.rs/velesdb-memory)
+[![npm](https://img.shields.io/npm/v/%40wiscale%2Fvelesdb-memory-node?logo=npm&label=npm)](https://www.npmjs.com/package/@wiscale/velesdb-memory-node)
+[![PyPI](https://img.shields.io/pypi/v/velesdb?logo=pypi&logoColor=white&label=PyPI)](https://pypi.org/project/velesdb/)
+[![MCP registry](https://img.shields.io/badge/MCP_registry-io.github.cyberlife--coder%2Fvelesdb--memory-1f6feb?logo=modelcontextprotocol&logoColor=white)](https://registry.modelcontextprotocol.io)
+[![license: VelesDB Core 1.0](https://img.shields.io/badge/license-VelesDB_Core_1.0_(source--available)-e8702a)](https://github.com/cyberlife-coder/VelesDB/blob/main/LICENSE)
+
 **Local-first memory for AI agents — a single MCP server.** Give your coding
 agent durable memory that never leaves your machine: it remembers decisions,
 recalls them semantically, and — the differentiator — **connects** them so it
 can answer *why* a decision was made, not just retrieve look-alike text.
+
+> **Shipped & published — as of 2026-06-30.** `velesdb-memory` **0.3.1** is live on
+> [crates.io](https://crates.io/crates/velesdb-memory) and on the
+> [official MCP registry](https://registry.modelcontextprotocol.io)
+> (`io.github.cyberlife-coder/velesdb-memory`, with **5 prebuilt `.mcpb` bundles**:
+> macOS arm64/x64, Linux arm64/x64, Windows x64). Bindings: Node
+> [`@wiscale/velesdb-memory-node`](https://www.npmjs.com/package/@wiscale/velesdb-memory-node) **0.3.1**
+> and Python in [`velesdb`](https://pypi.org/project/velesdb/) **3.5.0**.
+> **`cargo install velesdb-memory` works today.**
 
 Built on [VelesDB](https://velesdb.com)'s in-core Agent Memory SDK, which fuses
 three engines behind its memory tools:


### PR DESCRIPTION
## What

Adds to `crates/velesdb-memory/README.md`:
- a badge row (crates.io, docs.rs, npm, PyPI, MCP registry, license)
- a dated **"Shipped & published — as of 2026-06-30"** note with the live versions and that `cargo install velesdb-memory` works today.

## Why

Make the crates.io/MCP-registry shop window coherent, factual and time-stamped now that 0.3.1 is fully published.

## Verified (not asserted)

- crates.io sparse index: `velesdb-memory` → 0.2.0, 0.3.0, **0.3.1** (none yanked).
- Published `.crate` artifact downloads (HTTP 200) from static.crates.io; its `Cargo.toml` carries `[[bin]] velesdb-memory`.
- MCP registry: `io.github.cyberlife-coder/velesdb-memory` + 5 `.mcpb` bundles on the v0.3.1 release.
- PyPI `velesdb` 3.5.0; npm `@wiscale/velesdb-memory-node` 0.3.1; docs.rs resolves.

Docs-only; no code touched.