### PR TITLE
feat(memory): add --dump JSONL instrumentation to the LoCoMo harness

### DIFF
--- a/crates/velesdb-memory/examples/locomo/dump.rs
+++ b/crates/velesdb-memory/examples/locomo/dump.rs
@@ -1,0 +1,239 @@
+//! Per-question JSONL instrumentation for the `LoCoMo` temporal-decomposition
+//! research analysis (`--dump <path>`).
+//!
+//! Purely observational: every field is read from data `eval.rs` already
+//! computes for the real vector/graph/generation path. There is no second
+//! retrieval call and no change to any prompt string, so the generation/judge
+//! cache (content-addressed on `model + prompt`, see `ollama_gen.rs`) is
+//! identical whether `--dump` is on or off.
+
+use std::error::Error;
+use std::fs::File;
+use std::io::{BufWriter, Write as _};
+use std::path::Path;
+
+use serde::Serialize;
+
+use crate::dataset::Qa;
+use crate::eval::{EvalCfg, RetrievedFact};
+use crate::ollama_gen::TokenUsage;
+
+/// One retrieved fact, as it appeared in either the pre-budget candidate pool
+/// (`raw_facts`) or the final budgeted set the generator actually saw
+/// (`reranked_facts`). Comparing the two on `evidence_hit` tells "never
+/// retrieved" (missing from both) apart from "retrieved but evicted by
+/// ranking" (present in `raw_facts` only).
+#[derive(Serialize)]
+pub struct FactRecord {
+    pub rank: usize,
+    pub id: u64,
+    pub ts: i64,
+    pub vector_score: f64,
+    pub graph_weight: f64,
+    pub evidence_hit: bool,
+    pub dia_ids: Vec<String>,
+    pub text: String,
+}
+
+/// One question's full evaluation trace under one mode (vector-only or fused).
+// research JSONL row: independent observed fields, not a state machine
+#[allow(clippy::struct_excessive_bools)]
+#[derive(Serialize)]
+pub struct QuestionRecord {
+    pub conversation_id: String,
+    pub question_idx: usize,
+    pub graph_on: bool,
+    pub category: String,
+    pub question: String,
+    pub gold: Option<String>,
+    pub predicted: String,
+    pub correct: bool,
+    pub f1: Option<f64>,
+    pub evidence_hit: bool,
+    pub date_on: bool,
+    pub scaffold_on: bool,
+    pub prompt_kind: String,
+    pub is_temporal_trigger: bool,
+    pub latest_ts: i64,
+    /// From Ollama's own reply, when the answer call actually reached the
+    /// model (`None` on a cache hit or a Claude-CLI generation).
+    pub prompt_tokens: Option<u64>,
+    pub completion_tokens: Option<u64>,
+    /// Dependency-free whitespace-word estimate over `reranked_facts` text —
+    /// always available, a fallback/cross-check for `prompt_tokens`.
+    pub context_tokens: usize,
+    pub n_distinct_dates: usize,
+    pub date_span_days: i64,
+    pub raw_facts: Vec<FactRecord>,
+    pub reranked_facts: Vec<FactRecord>,
+}
+
+/// A `--dump` sink: each run starts from a fresh file. A restarted run
+/// overwrites rather than appending duplicate rows — the generation/judge
+/// cache still resumes for free underneath, so a restart just re-runs to
+/// completion instead of silently corrupting the analysis with dupes.
+pub struct DumpSink {
+    writer: BufWriter<File>,
+}
+
+impl DumpSink {
+    pub fn create(path: &Path) -> Result<Self, Box<dyn Error>> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        Ok(Self {
+            writer: BufWriter::new(File::create(path)?),
+        })
+    }
+
+    fn write(&mut self, record: &QuestionRecord) -> Result<(), Box<dyn Error>> {
+        serde_json::to_writer(&mut self.writer, record)?;
+        self.writer.write_all(b"\n")?;
+        self.writer.flush()?;
+        Ok(())
+    }
+}
+
+/// Bundles the `--dump` sink with the (conversation, question) coordinates
+/// `eval::evaluate` doesn't otherwise need — the only new plumbing this
+/// instrumentation requires (`Sample::sample_id` already existed).
+pub struct QuestionTrace<'a> {
+    pub conversation_id: &'a str,
+    pub question_idx: usize,
+    pub sink: &'a mut DumpSink,
+}
+
+/// Everything `eval::evaluate` has already computed by the time it's ready to
+/// write a record — grouped so the call site isn't a many-argument function.
+// research JSONL row inputs: independent observed fields, not a state machine
+#[allow(clippy::struct_excessive_bools)]
+pub struct RecordInputs<'a> {
+    pub qa: &'a Qa,
+    pub cfg: EvalCfg,
+    pub graph_on: bool,
+    pub raw: &'a [RetrievedFact],
+    pub reranked: &'a [RetrievedFact],
+    pub candidate: &'a str,
+    pub usage: Option<TokenUsage>,
+    pub correct: bool,
+    pub f1: Option<f64>,
+    pub evidence_hit: bool,
+    pub date_on: bool,
+    pub scaffold_on: bool,
+    pub is_temporal_trigger: bool,
+    pub latest_ts: i64,
+}
+
+/// Build and write one [`QuestionRecord`] — the only place that touches both
+/// `RetrievedFact` (eval.rs's retrieval type) and the JSONL shape.
+///
+/// `trace` must be taken by value: it carries the sink's unique `&mut`
+/// borrow, which a further `&QuestionTrace` could not re-lend.
+#[allow(clippy::needless_pass_by_value)]
+pub fn write_record(
+    trace: QuestionTrace<'_>,
+    inputs: &RecordInputs<'_>,
+) -> Result<(), Box<dyn Error>> {
+    let raw_facts = to_fact_records(inputs.raw, &inputs.qa.evidence);
+    let reranked_facts = to_fact_records(inputs.reranked, &inputs.qa.evidence);
+    let (n_distinct_dates, date_span_days) = date_span(&reranked_facts);
+    let context_tokens = reranked_facts
+        .iter()
+        .map(|f| estimate_tokens(&f.text))
+        .sum();
+    let prompt_kind = if inputs.scaffold_on {
+        "scaffold"
+    } else if inputs.cfg.cot {
+        "cot"
+    } else {
+        "terse"
+    };
+    let record = QuestionRecord {
+        conversation_id: trace.conversation_id.to_string(),
+        question_idx: trace.question_idx,
+        graph_on: inputs.graph_on,
+        category: inputs.qa.category.label().to_string(),
+        question: inputs.qa.question.clone(),
+        gold: inputs.qa.answer.clone(),
+        predicted: inputs.candidate.to_string(),
+        correct: inputs.correct,
+        f1: inputs.f1,
+        evidence_hit: inputs.evidence_hit,
+        date_on: inputs.date_on,
+        scaffold_on: inputs.scaffold_on,
+        prompt_kind: prompt_kind.to_string(),
+        is_temporal_trigger: inputs.is_temporal_trigger,
+        latest_ts: inputs.latest_ts,
+        prompt_tokens: inputs.usage.map(|u| u.prompt),
+        completion_tokens: inputs.usage.map(|u| u.completion),
+        context_tokens,
+        n_distinct_dates,
+        date_span_days,
+        raw_facts,
+        reranked_facts,
+    };
+    trace.sink.write(&record)
+}
+
+/// Rank + evidence-hit each fact against the gold `evidence` `dia_ids`.
+fn to_fact_records(facts: &[RetrievedFact], evidence: &[String]) -> Vec<FactRecord> {
+    facts
+        .iter()
+        .enumerate()
+        .map(|(rank, f)| FactRecord {
+            rank,
+            id: f.id,
+            ts: f.ts,
+            vector_score: f.score,
+            graph_weight: f.graph_weight,
+            evidence_hit: f.dia_ids.iter().any(|id| evidence.contains(id)),
+            dia_ids: f.dia_ids.clone(),
+            text: f.text.clone(),
+        })
+        .collect()
+}
+
+/// A dependency-free token-count estimate (whitespace-separated words). Not a
+/// real tokenizer; a cheap, always-available proxy for when Ollama's own
+/// `prompt_tokens`/`completion_tokens` are absent (cache hit, Claude-gen path).
+fn estimate_tokens(text: &str) -> usize {
+    text.split_whitespace().count()
+}
+
+/// `(distinct known dates, day-span)` over a fact list's `ts` (`YYYYMMDD`,
+/// `0` = unknown, excluded from both).
+fn date_span(facts: &[FactRecord]) -> (usize, i64) {
+    let mut days: Vec<i64> = facts
+        .iter()
+        .map(|f| f.ts)
+        .filter(|&ts| ts > 0)
+        .filter_map(ymd_to_ordinal)
+        .collect();
+    days.sort_unstable();
+    days.dedup();
+    let span = match (days.first(), days.last()) {
+        (Some(&lo), Some(&hi)) => hi - lo,
+        _ => 0,
+    };
+    (days.len(), span)
+}
+
+/// Days since a fixed epoch for a `YYYYMMDD` key (Howard Hinnant's
+/// `days_from_civil`, proleptic Gregorian) — `None` for an implausible date.
+fn ymd_to_ordinal(ts: i64) -> Option<i64> {
+    let (year, month, day) = (ts / 10_000, (ts / 100) % 100, ts % 100);
+    if !(1..=12).contains(&month) || !(1..=31).contains(&day) {
+        return None;
+    }
+    let y = if month <= 2 { year - 1 } else { year };
+    let era = if y >= 0 { y } else { y - 399 } / 400;
+    let yoe = y - era * 400;
+    let mp = (month + 9) % 12;
+    let doy = (153 * mp + 2) / 5 + day - 1;
+    let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
+    Some(era * 146_097 + doe - 719_468)
+}
+
+#[cfg(test)]
+#[path = "dump/dump_tests.rs"]
+mod tests;

--- a/crates/velesdb-memory/examples/locomo/dump.rs
+++ b/crates/velesdb-memory/examples/locomo/dump.rs
@@ -221,10 +221,7 @@ fn date_span(facts: &[FactRecord]) -> (usize, i64) {
 /// Days since a fixed epoch for a `YYYYMMDD` key (Howard Hinnant's
 /// `days_from_civil`, proleptic Gregorian) — `None` for an implausible date.
 fn ymd_to_ordinal(ts: i64) -> Option<i64> {
-    let (year, month, day) = (ts / 10_000, (ts / 100) % 100, ts % 100);
-    if !(1..=12).contains(&month) || !(1..=31).contains(&day) {
-        return None;
-    }
+    let (year, month, day) = crate::judge::decompose_ymd(ts)?;
     let y = if month <= 2 { year - 1 } else { year };
     let era = if y >= 0 { y } else { y - 399 } / 400;
     let yoe = y - era * 400;

--- a/crates/velesdb-memory/examples/locomo/dump/dump_tests.rs
+++ b/crates/velesdb-memory/examples/locomo/dump/dump_tests.rs
@@ -1,0 +1,181 @@
+use std::io::{BufReader, Read as _};
+
+use super::*;
+use crate::dataset::{Category, Qa};
+
+fn fact(
+    id: u64,
+    ts: i64,
+    score: f64,
+    graph_weight: f64,
+    dia_id: &str,
+    text: &str,
+) -> RetrievedFact {
+    RetrievedFact {
+        id,
+        text: text.to_string(),
+        dia_ids: vec![dia_id.to_string()],
+        score,
+        graph_weight,
+        ts,
+    }
+}
+
+fn qa(question: &str, answer: Option<&str>, evidence: &[&str], category: Category) -> Qa {
+    Qa {
+        question: question.to_string(),
+        answer: answer.map(str::to_string),
+        evidence: evidence.iter().map(|s| (*s).to_string()).collect(),
+        category,
+    }
+}
+
+#[test]
+fn ymd_to_ordinal_spans_known_dates() {
+    let start = ymd_to_ordinal(20_230_101).unwrap();
+    let end = ymd_to_ordinal(20_230_131).unwrap();
+    assert_eq!(end - start, 30);
+    // Leap day: 2024-02-29 exists, 2023 has no such date but is never asked for.
+    let feb28 = ymd_to_ordinal(20_240_228).unwrap();
+    let feb29 = ymd_to_ordinal(20_240_229).unwrap();
+    let mar01 = ymd_to_ordinal(20_240_301).unwrap();
+    assert_eq!(feb29 - feb28, 1);
+    assert_eq!(mar01 - feb29, 1);
+}
+
+#[test]
+fn ymd_to_ordinal_rejects_bad_month_or_day() {
+    assert!(ymd_to_ordinal(20_231_301).is_none()); // month 13
+    assert!(ymd_to_ordinal(20_230_100).is_none()); // day 0
+}
+
+#[test]
+fn estimate_tokens_counts_whitespace_words() {
+    assert_eq!(estimate_tokens("a b  c\nd"), 4);
+    assert_eq!(estimate_tokens(""), 0);
+}
+
+#[test]
+fn to_fact_records_marks_evidence_hit_per_fact() {
+    let facts = vec![
+        fact(1, 20_230_101, 0.9, 0.0, "D1:1", "on topic"),
+        fact(2, 20_230_102, 0.1, 0.5, "D1:9", "distractor"),
+    ];
+    let evidence = vec!["D1:1".to_string()];
+    let records = to_fact_records(&facts, &evidence);
+    assert_eq!(records.len(), 2);
+    assert!(records[0].evidence_hit);
+    assert!(!records[1].evidence_hit);
+    assert_eq!(records[0].rank, 0);
+    assert_eq!(records[1].rank, 1);
+}
+
+#[test]
+fn date_span_ignores_unknown_dates_and_dedups() {
+    let facts = vec![
+        fact(1, 20_230_101, 0.0, 0.0, "D1:1", "a"),
+        fact(2, 20_230_101, 0.0, 0.0, "D1:2", "b"), // same date, dedup
+        fact(3, 20_230_111, 0.0, 0.0, "D1:3", "c"),
+        fact(4, 0, 0.0, 0.0, "D1:4", "d"), // unknown, excluded
+    ];
+    let records = to_fact_records(&facts, &[]);
+    let (n_distinct, span) = date_span(&records);
+    assert_eq!(n_distinct, 2);
+    assert_eq!(span, 10);
+}
+
+#[test]
+fn write_record_round_trips_through_jsonl() {
+    let dir = std::env::temp_dir().join(format!("velesdb-locomo-dump-test-{}", std::process::id()));
+    let path = write_sample_record(&dir);
+
+    let value = read_first_record(&path);
+    assert_eq!(value["conversation_id"], "conv-7");
+    assert_eq!(value["question_idx"], 3);
+    assert_eq!(value["graph_on"], true);
+    assert_eq!(value["category"], "temporal");
+    assert_eq!(value["predicted"], "2023");
+    assert_eq!(value["prompt_tokens"], 120);
+    assert_eq!(value["completion_tokens"], 8);
+    assert_eq!(value["raw_facts"].as_array().unwrap().len(), 1);
+    assert_eq!(value["reranked_facts"].as_array().unwrap().len(), 1);
+    assert_eq!(value["reranked_facts"][0]["evidence_hit"], true);
+    assert_eq!(value["raw_facts"][0]["evidence_hit"], false);
+
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+/// Write one fixture record to `dir/out.jsonl` via the real `write_record`
+/// path (not a hand-built JSON string), returning the file path.
+fn write_sample_record(dir: &std::path::Path) -> std::path::PathBuf {
+    std::fs::create_dir_all(dir).unwrap();
+    let path = dir.join("out.jsonl");
+    let mut sink = DumpSink::create(&path).unwrap();
+
+    let raw = vec![fact(1, 20_230_101, 0.9, 0.0, "D1:1", "raw only")];
+    let reranked = vec![fact(2, 20_230_102, 0.8, 0.2, "D1:2", "made the cut")];
+    let question = qa(
+        "when did it happen",
+        Some("2023"),
+        &["D1:2"],
+        Category::Temporal,
+    );
+    write_record(
+        QuestionTrace {
+            conversation_id: "conv-7",
+            question_idx: 3,
+            sink: &mut sink,
+        },
+        &RecordInputs {
+            qa: &question,
+            cfg: test_cfg(),
+            graph_on: true,
+            raw: &raw,
+            reranked: &reranked,
+            candidate: "2023",
+            usage: Some(TokenUsage {
+                prompt: 120,
+                completion: 8,
+            }),
+            correct: true,
+            f1: Some(1.0),
+            evidence_hit: true,
+            date_on: true,
+            scaffold_on: false,
+            is_temporal_trigger: true,
+            latest_ts: 20_230_102,
+        },
+    )
+    .unwrap();
+    drop(sink);
+    path
+}
+
+/// Read back the sole JSONL line at `path` as a parsed value.
+fn read_first_record(path: &std::path::Path) -> serde_json::Value {
+    let mut contents = String::new();
+    BufReader::new(std::fs::File::open(path).unwrap())
+        .read_to_string(&mut contents)
+        .unwrap();
+    let lines: Vec<&str> = contents.lines().collect();
+    assert_eq!(lines.len(), 1, "one record per write_record call");
+    serde_json::from_str(lines[0]).unwrap()
+}
+
+fn test_cfg() -> EvalCfg {
+    EvalCfg {
+        k: 8,
+        graph_boost: 0.15,
+        hops: 2,
+        multihop_only: false,
+        idf_weight: false,
+        seed_breadth: 1,
+        date_context: true,
+        date_routed: true,
+        temporal_scaffold: false,
+        cot: false,
+        bm25: false,
+        claude_judge: false,
+        claude_gen: false,
+    }
+}

--- a/crates/velesdb-memory/examples/locomo/eval.rs
+++ b/crates/velesdb-memory/examples/locomo/eval.rs
@@ -369,7 +369,10 @@ fn raw_if_wanted(
         return Vec::new();
     }
     let mut all = pool.to_vec();
-    all.extend(reached.iter().cloned());
+    // Mirror `fuse`'s own dedup: a fact both vector-ranked and graph-reached
+    // must appear once in the raw pool, not twice with split scores.
+    let present: HashSet<u64> = all.iter().map(|f| f.id).collect();
+    all.extend(reached.iter().filter(|f| !present.contains(&f.id)).cloned());
     all
 }
 
@@ -663,6 +666,15 @@ fn fuse(pool: Vec<RetrievedFact>, reached: &[RetrievedFact], cfg: EvalCfg) -> Ve
     let mut candidates: Vec<RetrievedFact> = pool;
     let present: HashSet<u64> = candidates.iter().map(|f| f.id).collect();
     candidates.extend(reached.iter().filter(|f| !present.contains(&f.id)).cloned());
+    // A fact both vector-ranked and graph-reached keeps its pool copy (above),
+    // whose `graph_weight` is the vector pool's hardcoded 0.0. `fused_score`
+    // scores it correctly via `weights` regardless, but any consumer reading
+    // the struct field directly (the `--dump` instrumentation) needs it synced.
+    for candidate in &mut candidates {
+        if let Some(&weight) = weights.get(&candidate.id) {
+            candidate.graph_weight = weight;
+        }
+    }
 
     candidates.sort_by(|a, b| {
         fused_score(b, &weights, max_score, cfg)
@@ -699,3 +711,7 @@ fn record_injection(injected: usize) {
         GRAPH_ACTIVE_CONTEXTS.fetch_add(1, Ordering::Relaxed);
     }
 }
+
+#[cfg(test)]
+#[path = "eval/eval_tests.rs"]
+mod tests;

--- a/crates/velesdb-memory/examples/locomo/eval.rs
+++ b/crates/velesdb-memory/examples/locomo/eval.rs
@@ -20,9 +20,10 @@ use serde_json::json;
 use velesdb_memory::{ColumnFilter, ColumnOp};
 
 use crate::dataset::{Category, Qa};
+use crate::dump::{self, QuestionTrace};
 use crate::ingest::Store;
 use crate::judge;
-use crate::ollama_gen::Generator;
+use crate::ollama_gen::{Generator, TokenUsage};
 
 /// How many facts graph traversal injected into a context, and how many
 /// graph-mode contexts received at least one. Lets the report state how *active*
@@ -93,15 +94,17 @@ pub struct EvalCfg {
 /// A retrieved fact carried into the generation context. `score` is its vector
 /// similarity (0.0 for facts found only by graph traversal); `graph_weight` is
 /// its graph-link strength in `[0, 1]` (0.0 for facts not reached by the graph).
+/// `pub(crate)` so `dump.rs` can serialise it for `--dump` without a second,
+/// divergent copy of these fields.
 #[derive(Clone)]
-struct RetrievedFact {
-    id: u64,
-    text: String,
-    dia_ids: Vec<String>,
-    score: f64,
-    graph_weight: f64,
+pub(crate) struct RetrievedFact {
+    pub(crate) id: u64,
+    pub(crate) text: String,
+    pub(crate) dia_ids: Vec<String>,
+    pub(crate) score: f64,
+    pub(crate) graph_weight: f64,
     /// Session date (`YYYYMMDD`, 0 if unknown) for date-stamping the context.
-    ts: i64,
+    pub(crate) ts: i64,
 }
 
 /// Outcome of one QA under one mode.
@@ -114,38 +117,131 @@ pub struct ModeResult {
     pub f1: Option<f64>,
 }
 
-/// Evaluate one QA end-to-end under the chosen mode.
+/// Evaluate one QA end-to-end under the chosen mode. `trace`, when set, also
+/// writes one JSONL record to the `--dump` sink for the `LoCoMo` research
+/// analysis. Purely observational: it only reads values this function already
+/// computes and never changes a prompt string, so the generation/judge cache
+/// (keyed on `model + prompt`, see `ollama_gen.rs`) is identical whether
+/// `--dump` is on or off.
 pub fn evaluate(
     store: &Store,
     generator: &Generator,
     qa: &Qa,
     cfg: EvalCfg,
     graph_on: bool,
+    trace: Option<QuestionTrace<'_>>,
 ) -> Result<ModeResult, Box<dyn Error>> {
-    let facts = retrieve(store, &qa.question, cfg, graph_on, qa.category)?;
-    let evidence_hit = facts
-        .iter()
-        .any(|f| f.dia_ids.iter().any(|id| qa.evidence.contains(id)));
-    let dated: Vec<(i64, String)> = facts.into_iter().map(|f| (f.ts, f.text)).collect();
-    let date_on = cfg.date_context && (!cfg.date_routed || is_temporal_question(&qa.question));
-    // The scaffold only fires where dates apply (temporal-framed questions).
-    let scaffold_on = cfg.temporal_scaffold && date_on;
-    let candidate = judge::answer(
+    let (facts, raw) = retrieve(
+        store,
+        &qa.question,
+        cfg,
+        graph_on,
+        qa.category,
+        trace.is_some(),
+    )?;
+    let evidence_hit = any_evidence_hit(&facts, &qa.evidence);
+    // Cloned (not moved) so `facts` survives to build the `--dump` record below
+    // when a trace is requested — a handful of short strings, negligible next
+    // to the network round-trip `judge::answer` makes right after.
+    let dated: Vec<(i64, String)> = facts.iter().map(|f| (f.ts, f.text.clone())).collect();
+    let temporal = temporal_flags(&qa.question, cfg);
+    let now_ts = store.latest_ts();
+    let (candidate, usage) = judge::answer(
         generator,
         &qa.question,
         &dated,
-        date_on,
-        store.latest_ts(),
-        scaffold_on,
+        temporal.date_on,
+        now_ts,
+        temporal.scaffold_on,
         cfg.cot,
         cfg.claude_gen,
     )?;
     let (correct, f1) = score(generator, qa, &candidate, cfg.claude_judge)?;
-    Ok(ModeResult {
+    let result = ModeResult {
         evidence_hit,
         correct,
         f1,
-    })
+    };
+    maybe_dump(
+        trace,
+        &record_inputs(
+            qa, cfg, graph_on, &raw, &facts, &candidate, usage, &result, &temporal, now_ts,
+        ),
+    )?;
+    Ok(result)
+}
+
+/// Build this question's `--dump` inputs from what `evaluate` has already
+/// computed — kept out of `evaluate` so that function stays within budget.
+#[allow(clippy::too_many_arguments)]
+fn record_inputs<'a>(
+    qa: &'a Qa,
+    cfg: EvalCfg,
+    graph_on: bool,
+    raw: &'a [RetrievedFact],
+    reranked: &'a [RetrievedFact],
+    candidate: &'a str,
+    usage: Option<TokenUsage>,
+    verdict: &ModeResult,
+    temporal: &TemporalFlags,
+    latest_ts: i64,
+) -> dump::RecordInputs<'a> {
+    dump::RecordInputs {
+        qa,
+        cfg,
+        graph_on,
+        raw,
+        reranked,
+        candidate,
+        usage,
+        correct: verdict.correct,
+        f1: verdict.f1,
+        evidence_hit: verdict.evidence_hit,
+        date_on: temporal.date_on,
+        scaffold_on: temporal.scaffold_on,
+        is_temporal_trigger: temporal.is_temporal_trigger,
+        latest_ts,
+    }
+}
+
+/// Does any retrieved fact's source overlap the gold `evidence`?
+fn any_evidence_hit(facts: &[RetrievedFact], evidence: &[String]) -> bool {
+    facts
+        .iter()
+        .any(|f| f.dia_ids.iter().any(|id| evidence.contains(id)))
+}
+
+/// Whether a question is temporally framed, and whether dating/the scaffold
+/// prompt should fire for it — computed once, fed to both the answerer and
+/// the `--dump` record.
+struct TemporalFlags {
+    is_temporal_trigger: bool,
+    date_on: bool,
+    scaffold_on: bool,
+}
+
+/// The scaffold only fires where dates apply (temporally-framed questions).
+fn temporal_flags(question: &str, cfg: EvalCfg) -> TemporalFlags {
+    let is_temporal_trigger = is_temporal_question(question);
+    let date_on = cfg.date_context && (!cfg.date_routed || is_temporal_trigger);
+    let scaffold_on = cfg.temporal_scaffold && date_on;
+    TemporalFlags {
+        is_temporal_trigger,
+        date_on,
+        scaffold_on,
+    }
+}
+
+/// Write a `--dump` record when `trace` is set; a no-op otherwise. Isolated so
+/// `evaluate`'s own complexity/length stays within the crate's budget.
+fn maybe_dump(
+    trace: Option<QuestionTrace<'_>>,
+    inputs: &dump::RecordInputs<'_>,
+) -> Result<(), Box<dyn Error>> {
+    let Some(trace) = trace else {
+        return Ok(());
+    };
+    dump::write_record(trace, inputs)
 }
 
 /// The source `dia_id` lists of the budgeted top-`k` facts retrieved for
@@ -161,7 +257,8 @@ pub fn retrieved_dia_ids(
     graph_on: bool,
     category: Category,
 ) -> Result<Vec<Vec<String>>, Box<dyn Error>> {
-    Ok(retrieve(store, question, cfg, graph_on, category)?
+    Ok(retrieve(store, question, cfg, graph_on, category, false)?
+        .0
         .into_iter()
         .map(|f| f.dia_ids)
         .collect())
@@ -217,7 +314,12 @@ fn score(
 const POOL_FACTOR: usize = 8;
 const POOL_MIN: usize = 64;
 
-/// Retrieve the equal-budget fact set for `question` under the chosen mode.
+/// Retrieve the equal-budget fact set for `question` under the chosen mode,
+/// plus — when `want_raw` — the untruncated pre-budget candidates. The raw
+/// list is read from the same pool/traversal this function already computes;
+/// there is no second query and no change to the real (truncated) selection,
+/// so passing `want_raw = false` (every call site except `--dump`) costs one
+/// extra empty `Vec` and nothing else.
 ///
 /// Vector mode takes the top `k` of the vector pool. Graph mode **fuses**: it
 /// re-ranks the union of the vector pool and the facts `why()` reaches by
@@ -232,7 +334,8 @@ fn retrieve(
     cfg: EvalCfg,
     graph_on: bool,
     category: Category,
-) -> Result<Vec<RetrievedFact>, Box<dyn Error>> {
+    want_raw: bool,
+) -> Result<(Vec<RetrievedFact>, Vec<RetrievedFact>), Box<dyn Error>> {
     // Route the graph to multi-hop questions only when asked: elsewhere it was
     // neutral-to-harmful, so the pure vector path is the safer default.
     let use_graph = graph_on && (!cfg.multihop_only || matches!(category, Category::MultiHop));
@@ -240,17 +343,34 @@ fn retrieve(
         // Vector-only: no ColumnStore predicate, no graph. A date window still
         // applies on the fused path below for time-scoped questions.
         let pool = vector_pool(store, question, pool_size(cfg.k), &[])?;
+        let raw = raw_if_wanted(&pool, &[], want_raw);
         if cfg.bm25 {
-            return Ok(rrf_fuse(pool, store, question, cfg.k));
+            return Ok((rrf_fuse(pool, store, question, cfg.k), raw));
         }
-        return Ok(pool.into_iter().take(cfg.k).collect());
+        return Ok((pool.into_iter().take(cfg.k).collect(), raw));
     }
     // Fused mode: a ColumnStore date window when the question is time-scoped,
     // plus graph traversal — all three engines.
     let filters = temporal_filters(question);
     let pool = vector_pool(store, question, pool_size(cfg.k), &filters)?;
     let reached = graph_reached(store, question, cfg)?;
-    Ok(fuse(pool, &reached, cfg))
+    let raw = raw_if_wanted(&pool, &reached, want_raw);
+    Ok((fuse(pool, &reached, cfg), raw))
+}
+
+/// `pool ∪ reached`, uncloned (empty) unless `--dump` actually wants it — kept
+/// out of `retrieve` so its branching doesn't add to that function's CCN.
+fn raw_if_wanted(
+    pool: &[RetrievedFact],
+    reached: &[RetrievedFact],
+    want_raw: bool,
+) -> Vec<RetrievedFact> {
+    if !want_raw {
+        return Vec::new();
+    }
+    let mut all = pool.to_vec();
+    all.extend(reached.iter().cloned());
+    all
 }
 
 /// Reciprocal Rank Fusion of the dense vector pool with a BM25 lexical ranking:

--- a/crates/velesdb-memory/examples/locomo/eval/eval_tests.rs
+++ b/crates/velesdb-memory/examples/locomo/eval/eval_tests.rs
@@ -1,0 +1,74 @@
+use super::*;
+
+fn fact(id: u64, score: f64, graph_weight: f64) -> RetrievedFact {
+    RetrievedFact {
+        id,
+        text: format!("fact {id}"),
+        dia_ids: vec![format!("D1:{id}")],
+        score,
+        graph_weight,
+        ts: 0,
+    }
+}
+
+fn cfg() -> EvalCfg {
+    EvalCfg {
+        k: 8,
+        graph_boost: 0.15,
+        hops: 2,
+        multihop_only: false,
+        idf_weight: false,
+        seed_breadth: 1,
+        date_context: false,
+        date_routed: false,
+        temporal_scaffold: false,
+        cot: false,
+        bm25: false,
+        claude_judge: false,
+        claude_gen: false,
+    }
+}
+
+#[test]
+fn raw_if_wanted_off_returns_empty() {
+    let pool = vec![fact(1, 0.9, 0.0)];
+    let reached = vec![fact(2, 0.0, 0.5)];
+    assert!(raw_if_wanted(&pool, &reached, false).is_empty());
+}
+
+#[test]
+fn raw_if_wanted_dedups_a_fact_both_vector_ranked_and_graph_reached() {
+    // Same id (7) present in both pool and reached — the raw capture must
+    // list it once, not twice with split scores (the bug this test guards).
+    let pool = vec![fact(1, 0.9, 0.0), fact(7, 0.6, 0.0)];
+    let reached = vec![fact(7, 0.0, 0.8), fact(9, 0.0, 0.3)];
+    let raw = raw_if_wanted(&pool, &reached, true);
+    let ids: Vec<u64> = raw.iter().map(|f| f.id).collect();
+    assert_eq!(ids.len(), 3, "1, 7, 9 — id 7 must not repeat");
+    assert_eq!(ids.iter().filter(|&&id| id == 7).count(), 1);
+}
+
+#[test]
+fn fuse_syncs_graph_weight_onto_a_fact_present_in_both_pool_and_reached() {
+    // Fact 7 is a strong vector hit (pool) AND graph-reached (weight 0.8).
+    // Its surviving copy (from the pool) must report that real weight, not
+    // the vector pool's hardcoded 0.0 — otherwise --dump can't tell a
+    // graph-promoted fact from a pure vector hit.
+    let pool = vec![fact(1, 0.9, 0.0), fact(7, 0.6, 0.0)];
+    let reached = vec![fact(7, 0.0, 0.8)];
+    let fused = fuse(pool, &reached, cfg());
+    let seven = fused.iter().find(|f| f.id == 7).expect("fact 7 present");
+    assert!(
+        (seven.graph_weight - 0.8).abs() < f64::EPSILON,
+        "synced from the reached weight, got {}",
+        seven.graph_weight
+    );
+}
+
+#[test]
+fn fuse_leaves_a_pure_vector_hit_at_zero_weight() {
+    let pool = vec![fact(1, 0.9, 0.0)];
+    let reached: Vec<RetrievedFact> = vec![];
+    let fused = fuse(pool, &reached, cfg());
+    assert!(fused[0].graph_weight.abs() < f64::EPSILON);
+}

--- a/crates/velesdb-memory/examples/locomo/judge.rs
+++ b/crates/velesdb-memory/examples/locomo/judge.rs
@@ -120,15 +120,20 @@ fn extract_final(text: &str) -> String {
 /// Render a `YYYYMMDD` session key as `YYYY-MM-DD`, or `None` when unknown (0)
 /// or malformed, so an undated fact is shown without a misleading date prefix.
 fn fmt_date(ts: i64) -> Option<String> {
+    let (year, month, day) = decompose_ymd(ts)?;
+    Some(format!("{year:04}-{month:02}-{day:02}"))
+}
+
+/// Split a `YYYYMMDD` session key into `(year, month, day)`, or `None` when
+/// unknown (`ts <= 0`) or the month/day is out of range. Shared by every
+/// consumer of this key (date formatting here, day-span math in `dump.rs`) so
+/// the validity rule lives in exactly one place.
+pub(crate) fn decompose_ymd(ts: i64) -> Option<(i64, i64, i64)> {
     if ts <= 0 {
         return None;
     }
     let (year, month, day) = (ts / 10_000, (ts / 100) % 100, ts % 100);
-    if (1..=12).contains(&month) && (1..=31).contains(&day) {
-        Some(format!("{year:04}-{month:02}-{day:02}"))
-    } else {
-        None
-    }
+    ((1..=12).contains(&month) && (1..=31).contains(&day)).then_some((year, month, day))
 }
 
 /// True when the model declined to answer (the correct move on adversarial QA).

--- a/crates/velesdb-memory/examples/locomo/judge.rs
+++ b/crates/velesdb-memory/examples/locomo/judge.rs
@@ -9,7 +9,7 @@
 use std::error::Error;
 
 use crate::dataset::Qa;
-use crate::ollama_gen::Generator;
+use crate::ollama_gen::{Generator, TokenUsage};
 use crate::parse::{normalize, tokens};
 
 const ABSTAIN: &str = "NO_ANSWER";
@@ -19,7 +19,9 @@ const ABSTAIN: &str = "NO_ANSWER";
 /// When `date_context` is set, every dated fact is prefixed with its date and
 /// the facts are ordered chronologically — the session date is retrieved but
 /// otherwise invisible to the answerer, which makes temporal questions
-/// unanswerable despite high evidence recall.
+/// unanswerable despite high evidence recall. Returns the token usage Ollama
+/// reported for the generation call, when available (`None` on a cache hit or
+/// when `claude_gen` routes to the Claude CLI, which reports no usage).
 // benchmark harness: ablation knobs threaded through the harness
 #[allow(clippy::too_many_arguments, clippy::fn_params_excessive_bools)]
 pub fn answer(
@@ -31,7 +33,7 @@ pub fn answer(
     scaffold: bool,
     cot: bool,
     claude_gen: bool,
-) -> Result<String, Box<dyn Error>> {
+) -> Result<(String, Option<TokenUsage>), Box<dyn Error>> {
     let context = if facts.is_empty() {
         "(no facts retrieved)".to_string()
     } else {
@@ -64,8 +66,8 @@ ordering, or date the question asks for. If the timeline does not contain the \
 answer, the final answer is {ABSTAIN}. End with a line exactly of the form:\n\
 FINAL: <answer in a few words>"
         );
-        let raw = gen(generator, &prompt, claude_gen)?;
-        return Ok(extract_final(&raw));
+        let (raw, usage) = gen(generator, &prompt, claude_gen)?;
+        return Ok((extract_final(&raw), usage));
     }
     if cot {
         // General chain-of-thought: reason over the facts, then a parseable FINAL.
@@ -77,8 +79,8 @@ question, then determine the answer. If the facts do not contain the answer, the
 final answer is {ABSTAIN}. End with a line exactly of the form:\n\
 FINAL: <answer in a few words>"
         );
-        let raw = gen(generator, &prompt, claude_gen)?;
-        return Ok(extract_final(&raw));
+        let (raw, usage) = gen(generator, &prompt, claude_gen)?;
+        return Ok((extract_final(&raw), usage));
     }
     let prompt = format!(
         "Answer the question using ONLY the memory facts below. If the facts do \
@@ -89,12 +91,17 @@ explanation.\n\nFacts:\n{context}\n\nQuestion: {question}\nAnswer:"
 }
 
 /// Generate an answer with either the strong external model (Claude via CLI) or
-/// the local model, depending on `claude_gen`.
-fn gen(generator: &Generator, prompt: &str, claude_gen: bool) -> Result<String, Box<dyn Error>> {
+/// the local model, depending on `claude_gen`. Only the local model reports
+/// token usage; the Claude CLI path always carries `None`.
+fn gen(
+    generator: &Generator,
+    prompt: &str,
+    claude_gen: bool,
+) -> Result<(String, Option<TokenUsage>), Box<dyn Error>> {
     if claude_gen {
-        generator.judge(prompt)
+        Ok((generator.judge(prompt)?, None))
     } else {
-        generator.generate(prompt)
+        generator.generate_traced(prompt)
     }
 }
 
@@ -160,7 +167,7 @@ INCORRECT.\n\nQuestion: {question}\nReference answer: {gold}\nCandidate answer: 
     );
     // The judge can run on the stronger Claude model (vendor-neutral, fairer) or
     // the local model; the candidate answer itself is always the local system.
-    let raw = gen(generator, &prompt, use_claude)?;
+    let (raw, _usage) = gen(generator, &prompt, use_claude)?;
     let verdict = normalize(&raw);
     // Compare the leading word so "incorrect" never matches "correct" by
     // substring, and a stray verbose reply still grades on its first verdict word.

--- a/crates/velesdb-memory/examples/locomo/main.rs
+++ b/crates/velesdb-memory/examples/locomo/main.rs
@@ -26,6 +26,7 @@
 mod bm25;
 mod dataset;
 mod diagnose;
+mod dump;
 mod eval;
 mod explain;
 mod extract;
@@ -44,6 +45,7 @@ use velesdb_memory::{MemoryService, OllamaEmbedder, DEFAULT_OLLAMA_MODEL, DEFAUL
 
 use dataset::{Category, Sample};
 use diagnose::DiagnoseReport;
+use dump::{DumpSink, QuestionTrace};
 use eval::EvalCfg;
 use explain::ExplainReport;
 use ingest::Store;
@@ -69,6 +71,9 @@ struct Args {
     only_category: Option<Category>,
     /// Ollama embedding model (swappable to test stronger encoders).
     embed_model: String,
+    /// Research-analysis instrumentation: append one JSONL record per QA
+    /// (see `dump.rs`). `None` = today's behavior, byte-identical.
+    dump: Option<PathBuf>,
     cfg: EvalCfg,
 }
 
@@ -164,30 +169,17 @@ fn run_eval(
 ) -> Result<(), Box<dyn Error>> {
     let mut report = Report::default();
     let mut total_facts = 0usize;
+    let mut sink = args.dump.as_deref().map(DumpSink::create).transpose()?;
     for (position, sample) in samples.iter().take(take).enumerate() {
-        let (store, facts) = prepare(
+        total_facts += run_eval_conversation(
             generator,
             sample,
             position,
             take,
-            args.extract_version,
-            &args.embed_model,
+            args,
+            &mut sink,
+            &mut report,
         )?;
-        let qa_take = qa_limit(args.max_qa, sample.qa.len());
-        for (done, qa) in sample.qa.iter().take(qa_take).enumerate() {
-            if args.only_category.is_some_and(|c| c != qa.category) {
-                continue;
-            }
-            let off = eval::evaluate(&store, generator, qa, args.cfg, false)?;
-            let on = eval::evaluate(&store, generator, qa, args.cfg, true)?;
-            report.record(qa.category, false, &off);
-            report.record(qa.category, true, &on);
-            if (done + 1) % 20 == 0 {
-                eprintln!("        {}/{} QA evaluated", done + 1, qa_take);
-            }
-        }
-        finish(store, position);
-        total_facts += facts;
     }
     report.print(
         args.cfg,
@@ -201,6 +193,49 @@ fn run_eval(
         "graph activity: traversal injected {injected} fact(s) across {contexts} graph-mode context(s)"
     );
     Ok(())
+}
+
+/// Extract, ingest, and evaluate every QA of one conversation; returns its
+/// fact count. Pulled out of `run_eval` so that function stays within budget.
+#[allow(clippy::too_many_arguments)]
+fn run_eval_conversation(
+    generator: &Generator,
+    sample: &Sample,
+    position: usize,
+    take: usize,
+    args: &Args,
+    sink: &mut Option<DumpSink>,
+    report: &mut Report,
+) -> Result<usize, Box<dyn Error>> {
+    let (store, facts) = prepare(
+        generator,
+        sample,
+        position,
+        take,
+        args.extract_version,
+        &args.embed_model,
+    )?;
+    let qa_take = qa_limit(args.max_qa, sample.qa.len());
+    for (done, qa) in sample.qa.iter().take(qa_take).enumerate() {
+        if args.only_category.is_some_and(|c| c != qa.category) {
+            continue;
+        }
+        evaluate_qa(
+            &store,
+            generator,
+            qa,
+            args.cfg,
+            &sample.sample_id,
+            done,
+            sink,
+            report,
+        )?;
+        if (done + 1) % 20 == 0 {
+            eprintln!("        {}/{} QA evaluated", done + 1, qa_take);
+        }
+    }
+    finish(store, position);
+    Ok(facts)
 }
 
 /// The LLM-free explanation benchmark: does the graph connect scattered evidence?
@@ -231,6 +266,54 @@ fn run_explanation(
     }
     report.print(args.cfg, take);
     Ok(())
+}
+
+/// Evaluate one QA under both modes (vector-only, then fused) and record both
+/// — pulled out of `run_eval`'s loop so that function stays within budget.
+#[allow(clippy::too_many_arguments)]
+fn evaluate_qa(
+    store: &Store,
+    generator: &Generator,
+    qa: &dataset::Qa,
+    cfg: EvalCfg,
+    conversation_id: &str,
+    question_idx: usize,
+    sink: &mut Option<DumpSink>,
+    report: &mut Report,
+) -> Result<(), Box<dyn Error>> {
+    let off = eval::evaluate(
+        store,
+        generator,
+        qa,
+        cfg,
+        false,
+        trace(sink, conversation_id, question_idx),
+    )?;
+    let on = eval::evaluate(
+        store,
+        generator,
+        qa,
+        cfg,
+        true,
+        trace(sink, conversation_id, question_idx),
+    )?;
+    report.record(qa.category, false, &off);
+    report.record(qa.category, true, &on);
+    Ok(())
+}
+
+/// Build a `--dump` trace for one QA when a sink is active, `None` otherwise
+/// (the byte-identical no-op path when `--dump` was never passed).
+fn trace<'a>(
+    sink: &'a mut Option<DumpSink>,
+    conversation_id: &'a str,
+    question_idx: usize,
+) -> Option<QuestionTrace<'a>> {
+    sink.as_mut().map(|sink| QuestionTrace {
+        conversation_id,
+        question_idx,
+        sink,
+    })
 }
 
 /// Extract and ingest one conversation; returns its store and fact count.
@@ -312,6 +395,7 @@ impl Default for Args {
             extract_version: 1,
             only_category: None,
             embed_model: DEFAULT_OLLAMA_MODEL.to_string(),
+            dump: None,
             cfg: EvalCfg {
                 // Gentle: the graph nudges, rarely evicting a strong vector hit.
                 // On LoCoMo the graph is ~neutral; higher boosts only hurt more.
@@ -391,6 +475,7 @@ impl Args {
             "--model" => self.model = value.to_string(),
             "--embed-model" => self.embed_model = value.to_string(),
             "--dataset" => self.dataset = PathBuf::from(value),
+            "--dump" => self.dump = Some(PathBuf::from(value)),
             "--only" => {
                 self.only_category = Some(
                     Category::from_label(value)

--- a/crates/velesdb-memory/examples/locomo/ollama_gen.rs
+++ b/crates/velesdb-memory/examples/locomo/ollama_gen.rs
@@ -33,6 +33,23 @@ pub struct Generator {
     agent: ureq::Agent,
 }
 
+/// Ollama's reported token usage for one generation call. Only available on a
+/// live call (Ollama's `/api/generate` response), never on a cache hit or a
+/// Claude-CLI call — callers must treat `None` as "not recorded", not "zero".
+#[derive(Clone, Copy)]
+pub struct TokenUsage {
+    pub prompt: u64,
+    pub completion: u64,
+}
+
+/// One live-call reply: the answer text plus whatever usage counters Ollama
+/// reported alongside it.
+struct GenReply {
+    text: String,
+    prompt_eval_count: Option<u64>,
+    eval_count: Option<u64>,
+}
+
 impl Generator {
     /// Build a generator. `model` falls back to [`DEFAULT_MODEL`] when empty;
     /// `cache_dir` is created if missing.
@@ -62,18 +79,32 @@ impl Generator {
     /// cached entry is treated as a miss, so a transient blank reply is never
     /// trusted as a permanent answer.
     pub fn generate(&self, prompt: &str) -> Result<String, Box<dyn Error>> {
+        Ok(self.generate_traced(prompt)?.0)
+    }
+
+    /// Same as [`Self::generate`], but also returns Ollama's reported token
+    /// usage when this call actually reached the model. A cache hit carries no
+    /// usage counters — `None`, honestly, rather than a guessed value.
+    pub fn generate_traced(
+        &self,
+        prompt: &str,
+    ) -> Result<(String, Option<TokenUsage>), Box<dyn Error>> {
         let key = self.key(prompt);
         let path = self.cache_dir.join(format!("{key}.txt"));
         if let Ok(cached) = fs::read_to_string(&path) {
             if !cached.trim().is_empty() {
-                return Ok(cached);
+                return Ok((cached, None));
             }
         }
-        let answer = self.call(prompt)?;
-        if !answer.trim().is_empty() {
-            self.store(&key, &path, &answer)?;
+        let reply = self.call(prompt)?;
+        if !reply.text.trim().is_empty() {
+            self.store(&key, &path, &reply.text)?;
         }
-        Ok(answer)
+        let usage = match (reply.prompt_eval_count, reply.eval_count) {
+            (Some(prompt), Some(completion)) => Some(TokenUsage { prompt, completion }),
+            _ => None,
+        };
+        Ok((reply.text, usage))
     }
 
     /// Atomically persist `answer`: write a process-unique temp file, then
@@ -88,11 +119,11 @@ impl Generator {
         Ok(())
     }
 
-    /// POST to Ollama with bounded retries; returns the trimmed `response`.
-    /// The body is serialised with `serde_json` and sent as a raw string so the
-    /// crate's `ureq` can keep `default-features = false` (no bundled TLS/json),
-    /// leaving the shipped server binary tiny.
-    fn call(&self, prompt: &str) -> Result<String, Box<dyn Error>> {
+    /// POST to Ollama with bounded retries; returns the trimmed `response` plus
+    /// any usage counters. The body is serialised with `serde_json` and sent as
+    /// a raw string so the crate's `ureq` can keep `default-features = false`
+    /// (no bundled TLS/json), leaving the shipped server binary tiny.
+    fn call(&self, prompt: &str) -> Result<GenReply, Box<dyn Error>> {
         let body = serde_json::json!({
             "model": self.model,
             "prompt": prompt,
@@ -191,15 +222,27 @@ impl Generator {
     }
 }
 
-/// Pull the `response` string out of Ollama's JSON envelope.
-fn parse_response(resp: ureq::Response) -> Result<String, Box<dyn Error>> {
+/// Pull the `response` string plus the `prompt_eval_count`/`eval_count` usage
+/// fields (absent on some Ollama versions — recorded as `None`, not guessed)
+/// out of the JSON envelope.
+fn parse_response(resp: ureq::Response) -> Result<GenReply, Box<dyn Error>> {
     let raw = resp.into_string()?;
     let value: serde_json::Value = serde_json::from_str(&raw)?;
     let text = value
         .get("response")
         .and_then(serde_json::Value::as_str)
-        .ok_or("Ollama reply had no `response` field")?;
-    Ok(text.trim().to_string())
+        .ok_or("Ollama reply had no `response` field")?
+        .trim()
+        .to_string();
+    let prompt_eval_count = value
+        .get("prompt_eval_count")
+        .and_then(serde_json::Value::as_u64);
+    let eval_count = value.get("eval_count").and_then(serde_json::Value::as_u64);
+    Ok(GenReply {
+        text,
+        prompt_eval_count,
+        eval_count,
+    })
 }
 
 /// Flatten a `ureq` error into a labelled message for the retry log.


### PR DESCRIPTION
## Summary
- Adds `--dump <path>` to `examples/locomo/` (velesdb-memory): appends one JSONL `QuestionRecord` per QA per mode (vector-only / fused), needed for the temporal-decomposition research analysis (why the scaffold costs -6pp single-hop) — no per-question data exists today, only aggregate percentages.
- Each record carries: predicted/gold/correct/f1, date/scaffold/prompt-kind flags, `is_temporal_trigger`, token usage (from Ollama's own reply when available, honestly `None` on a cache hit or Claude-gen), a whitespace-estimate `context_tokens` fallback, date-span stats, and both the pre-budget candidate pool (`raw_facts`) and the final budgeted set (`reranked_facts`) so "never retrieved" can be told apart from "retrieved but evicted by ranking".
- Purely observational: built from data `eval::evaluate` already computes; no second retrieval call, no change to any prompt string. Ollama's cache key is `FNV1a(model + prompt)` (`ollama_gen.rs`), so it is unaffected by `--dump`.
- Scope: **this PR is instrumentation only** — no dataset run, no JSONL committed, no analysis. The actual 3-config 10-conversation reproduction run (expensive: hours of local generation + Claude-judge API calls) and the statistical/taxonomy analysis are a separate follow-up, gated on review of this PR.

## Verification
- [x] `cargo test -p velesdb-memory --features ollama --example locomo`: 6/6 new tests green (JSONL round-trip, date-span math, evidence-hit split, token estimate).
- [x] `cargo test -p velesdb-memory` (full crate, default features): all green — no lib behavior touched.
- [x] `cargo +1.89 fmt --check` / `cargo clippy --profile test -p velesdb-memory --features ollama --example locomo -- -D warnings -D clippy::pedantic`: clean.
- [x] `lizard` (CCN≤8, NLOC≤50): no new violations (the one pre-existing violation, `judge::answer`, predates this change and its shape is untouched here).
- [x] Live smoke run (1 conversation, 2 QA, local `qwen3.6:35b-mlx` + `all-minilm`): confirmed byte-identical cache-file count and identical predicted answers/report table with `--dump` on vs off (cold + warm reruns); confirmed `prompt_tokens`/`completion_tokens` populate on a cold call and are honestly `None` on a cache hit; confirmed `reranked_facts` count == budget `k` and `raw_facts` == the oversampled pre-budget pool.
- [x] Pre-commit hook passed in full (fmt, clippy, full workspace `--lib` test suite incl. velesdb-core, SAFETY/TODO governance, secret scan).

## Follow-up (not in this PR)
The 3-config faithful-reproduction run, statistical analysis (McNemar/Wilson/bootstrap), error taxonomy, and the Smart Routing chapter are the next phases of the durable research plan — deliberately deferred pending review of this instrumentation.