### PR TITLE
fix(ci): stop the nightly 100K Rust recall gate from timing out

### DIFF
--- a/.github/workflows/perf-gate-e2e.yml
+++ b/.github/workflows/perf-gate-e2e.yml
@@ -277,9 +277,12 @@ jobs:
           shared-key: "velesdb-perf-gate"
 
       - name: Run 100K multi-mode recall gate (brute-force ground truth)
-        # The four tests assert their per-mode thresholds internally, so a
+        # The test asserts all four per-mode thresholds internally, so a
         # recall regression at scale fails the job. Single-threaded: the suite
-        # shares filesystem state (CLAUDE.md).
+        # shares filesystem state (CLAUDE.md). --release is mandatory here —
+        # debug-mode HNSW insert/search at 100K vectors is an order of
+        # magnitude slower and blows the job's timeout budget (see the
+        # sibling Python 100K job's rationale above).
         run: |
-          cargo test -p velesdb-core --test scale_recall_100k \
+          cargo test -p velesdb-core --release --test scale_recall_100k \
             --features persistence -- --ignored --nocapture --test-threads=1

--- a/crates/velesdb-core/tests/scale_recall_100k.rs
+++ b/crates/velesdb-core/tests/scale_recall_100k.rs
@@ -102,66 +102,39 @@ fn build_100k_fixture() -> (HnswIndex, Vec<Vec<f32>>, Vec<Vec<f32>>) {
     (index, vectors, queries)
 }
 
+/// Validates recall@10 for all four quality modes against one shared 100K
+/// index/query fixture.
+///
+/// Building the 100K-vector HNSW index dominates this gate's runtime, so the
+/// four modes are asserted here instead of in separate `#[test]` fns — one
+/// fixture build instead of four keeps the nightly CI job (60 min budget,
+/// `--test-threads=1`) inside its timeout.
 #[test]
 #[ignore = "Long-running 100K recall gate — run with --ignored"]
-fn scale_100k_recall_balanced() {
+fn scale_100k_recall_all_qualities() {
     let (index, vectors, queries) = build_100k_fixture();
-    let recall = measure_recall(&index, &vectors, &queries, SearchQuality::Balanced);
+    let mut failures = Vec::new();
 
     println!();
-    println!("=== 100K Recall Gate: Balanced ===");
-    println!("  recall@{K} = {recall:.4} (threshold: 0.95)");
+    println!("=== 100K Recall Gate ===");
+    for (label, quality, threshold) in [
+        ("Fast", SearchQuality::Fast, 0.90),
+        ("Balanced", SearchQuality::Balanced, 0.95),
+        ("Accurate", SearchQuality::Accurate, 0.98),
+        ("Perfect", SearchQuality::Perfect, 1.00),
+    ] {
+        let recall = measure_recall(&index, &vectors, &queries, quality);
+        println!("  {label}: recall@{K} = {recall:.4} (threshold: {threshold})");
+        if recall < threshold {
+            failures.push(format!(
+                "{label} recall@{K} = {recall:.4} is below {threshold} threshold"
+            ));
+        }
+    }
 
     assert!(
-        recall >= 0.95,
-        "Balanced recall@{K} = {recall:.4} is below 0.95 threshold at 100K scale"
-    );
-}
-
-#[test]
-#[ignore = "Long-running 100K recall gate — run with --ignored"]
-fn scale_100k_recall_fast() {
-    let (index, vectors, queries) = build_100k_fixture();
-    let recall = measure_recall(&index, &vectors, &queries, SearchQuality::Fast);
-
-    println!();
-    println!("=== 100K Recall Gate: Fast ===");
-    println!("  recall@{K} = {recall:.4} (threshold: 0.90)");
-
-    assert!(
-        recall >= 0.90,
-        "Fast recall@{K} = {recall:.4} is below 0.90 threshold at 100K scale"
-    );
-}
-
-#[test]
-#[ignore = "Long-running 100K recall gate — run with --ignored"]
-fn scale_100k_recall_accurate() {
-    let (index, vectors, queries) = build_100k_fixture();
-    let recall = measure_recall(&index, &vectors, &queries, SearchQuality::Accurate);
-
-    println!();
-    println!("=== 100K Recall Gate: Accurate ===");
-    println!("  recall@{K} = {recall:.4} (threshold: 0.98)");
-
-    assert!(
-        recall >= 0.98,
-        "Accurate recall@{K} = {recall:.4} is below 0.98 threshold at 100K scale"
-    );
-}
-
-#[test]
-#[ignore = "Long-running 100K recall gate — run with --ignored"]
-fn scale_100k_recall_perfect() {
-    let (index, vectors, queries) = build_100k_fixture();
-    let recall = measure_recall(&index, &vectors, &queries, SearchQuality::Perfect);
-
-    println!();
-    println!("=== 100K Recall Gate: Perfect ===");
-    println!("  recall@{K} = {recall:.4} (threshold: 1.00)");
-
-    assert!(
-        (recall - 1.0).abs() < f64::EPSILON,
-        "Perfect recall@{K} = {recall:.4} must be 1.00 at any scale"
+        failures.is_empty(),
+        "100K recall gate failed at scale:\n  {}",
+        failures.join("\n  ")
     );
 }


### PR DESCRIPTION
## ⚠️ Target branch note

This session's branch is platform-assigned as `claude/admiring-fermi-vp1ou7`, which doesn't match this repo's Git-Flow prefix allow-list (`fix/*`, `ci/*`, etc.) enforced by `pr-governance.yml`, and the commit's author identity (`noreply@anthropic.com`, fixed by the execution environment) will trip the "Reject AI-attributed commits" check. Both gates will likely fail automatically — flagging this now so you can cherry-pick the two-file diff onto a compliant branch/identity if you want it merged as-is, same as with #1289.

## Description

No open PRs or open issues existed in the repo at the start of this run, so I audited CI health on `develop` and found: **every run of the nightly "Scheduled Rust 100K recall (Fast/Balanced/Accurate/Perfect)" job has been cancelled at its 60-minute timeout since it was added on 2026-06-24** — 8 consecutive nightly failures (runs #307–#351), confirmed via the Actions API. This gate exists to validate HNSW recall@10 across all four quality modes at 100K scale; it has never once produced a pass/fail signal.

Fixes # (no tracking issue existed for this — found via CI audit)

## Root cause (two compounding issues)

1. **4x redundant fixture build.** `scale_recall_100k.rs` built a fresh 100K-vector HNSW index from scratch in each of 4 separate `#[test]` fns (one per quality mode), despite the fixture helper's own doc comment claiming it was "shared across tests" — it was only a shared *function*, never shared *state*. Index construction dominates the gate's runtime, so this alone was a 4x cost multiplier.
2. **Debug-mode perf test.** The CI step ran `cargo test` without `--release`. Debug-mode HNSW insert/search at 100K vectors is an order of magnitude slower, and it's the only perf-sensitive job in this workflow that made that mistake — its sibling Python 100K job's own comment already states "Release build is mandatory for a perf gate."

## Changes

- `crates/velesdb-core/tests/scale_recall_100k.rs`: merged the four `#[test]` fns into one (`scale_100k_recall_all_qualities`) that builds the fixture once and asserts all four per-mode thresholds, collecting failures instead of stopping at the first.
- `.github/workflows/perf-gate-e2e.yml`: added `--release` to the `cargo test` invocation for this job.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🔧 Refactoring (no functional changes to what's being validated)
- [x] ⚡ Performance improvement

## How Has This Been Tested?

- [x] Ran the refactored test locally in release mode: **112s total** (previously never completed within the 60-minute CI budget). All four thresholds still pass at the same values: Fast 0.9440 (≥0.90), Balanced 0.9740 (≥0.95), Accurate 0.9970 (≥0.98), Perfect 1.0000 (=1.00).
- [x] `cargo fmt --check -p velesdb-core` — clean
- [x] `cargo clippy -p velesdb-core --test scale_recall_100k --release --features persistence -- -D warnings -D clippy::pedantic` — clean
- [x] `cargo check -p velesdb-core --tests --features persistence` (dev profile) — compiles
- [x] Workflow YAML re-validated with `yaml.safe_load`

**Test Configuration:**
- OS: Linux (Ubuntu, containerized)
- Rust version: stable (workspace default)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published — n/a, no dependent changes

## Additional Notes

No functional/behavioral change to what's validated — same four thresholds, same brute-force ground truth, same single-threaded execution constraint (shared filesystem state per CLAUDE.md). Purely a runtime-efficiency and CI-config fix so the gate can actually run to completion.
