### PR TITLE
fix(deps): ignore RUSTSEC-2026-0194/0195 (quick-xml DoS, no fix yet)

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -33,6 +33,19 @@ ignore = [
     { id = "RUSTSEC-2025-0098", reason = "unic-ucd-version: tauri transitive, unmaintained" },
     { id = "RUSTSEC-2025-0100", reason = "unic-ucd-ident: tauri transitive, unmaintained" },
 
+    # ── quick-xml / plist transitive (tauri Info.plist tooling) ────────
+    # quick-xml 0.38.4 comes in via plist 1.8.0 (tauri's Info.plist reader/
+    # writer, tauri-codegen/tauri-utils/tauri-build all depend on it too).
+    # Both advisories are XML-parsing DoS only (quadratic attribute scan /
+    # unbounded namespace allocation) — not memory-unsafety, and only
+    # reachable if this stack parses untrusted XML, which it doesn't (local
+    # Info.plist files only). No fix yet: plist's latest release (1.9.0,
+    # 2026-04-26) still requires quick-xml ^0.39.2; the advisories need
+    # >=0.41.0. Revisit when plist ships a release depending on quick-xml
+    # >=0.41 (tracked upstream: https://github.com/ebarnard/rust-plist).
+    { id = "RUSTSEC-2026-0194", reason = "quick-xml: tauri/plist transitive, DoS-only, no fix yet (plist 1.9.0 caps at quick-xml 0.39)" },
+    { id = "RUSTSEC-2026-0195", reason = "quick-xml: tauri/plist transitive, DoS-only, no fix yet (plist 1.9.0 caps at quick-xml 0.39)" },
+
     # ── velesdb-cli transitive ────────────────────────────────────────
     { id = "RUSTSEC-2024-0384", reason = "instant: velesdb-cli transitive (clap/indicatif chain), unmaintained" },
 


### PR DESCRIPTION
## Summary
- **Unblocks the Security Audit gate for every open/future PR.** Two new RUSTSEC advisories (2026-0194, 2026-0195) were published against `quick-xml 0.38.4` between develop's last green CI run (2026-07-01 20:38) and now — `cargo-deny` now hard-fails on every PR regardless of what it touches.
- `quick-xml` is a transitive dep via `plist 1.8.0` (tauri's Info.plist reader/writer, pulled by `tauri-plugin-velesdb`/tauri-codegen/tauri-utils/tauri-build). Both advisories are DoS-only (quadratic attribute scan / unbounded namespace allocation while parsing XML) — not memory-unsafety, and only reachable by parsing untrusted XML, which this stack never does (local Info.plist files only, build time).
- No upstream fix available: `plist`'s latest release (1.9.0, 2026-04-26) still requires `quick-xml ^0.39.2`; the advisories need `>=0.41.0`. Nothing to bump on our side yet.
- Adds both IDs to `deny.toml`'s ignore list with a documented reason, mirroring the existing pattern already used for 15+ other tauri-transitive advisories in the same file (reviewed on a 90-day cadence per the file's own header comment).

## Test plan
- [x] `cargo deny check advisories` → `advisories ok` locally
- [x] Scoped to `deny.toml` only, no code changes — isolated from other in-flight PRs (#1303, quick-xml fix) intentionally, for a fast independent review