### PR TITLE
fix(ci): add deny.toml to the CI path filter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ on:
       - 'demos/**'
       - 'Cargo.toml'
       - 'Cargo.lock'
+      - 'deny.toml'
       - 'sonar-project.properties'
       - '.github/workflows/**'
   pull_request:
@@ -42,6 +43,7 @@ on:
       - 'demos/**'
       - 'Cargo.toml'
       - 'Cargo.lock'
+      - 'deny.toml'
       - 'sonar-project.properties'
       - '.github/workflows/**'
   # Manual trigger so coverage can be refreshed on demand (e.g. after a

--- a/deny.toml
+++ b/deny.toml
@@ -33,6 +33,19 @@ ignore = [
     { id = "RUSTSEC-2025-0098", reason = "unic-ucd-version: tauri transitive, unmaintained" },
     { id = "RUSTSEC-2025-0100", reason = "unic-ucd-ident: tauri transitive, unmaintained" },
 
+    # ── quick-xml / plist transitive (tauri Info.plist tooling) ────────
+    # quick-xml 0.38.4 comes in via plist 1.8.0 (tauri's Info.plist reader/
+    # writer, tauri-codegen/tauri-utils/tauri-build all depend on it too).
+    # Both advisories are XML-parsing DoS only (quadratic attribute scan /
+    # unbounded namespace allocation) — not memory-unsafety, and only
+    # reachable if this stack parses untrusted XML, which it doesn't (local
+    # Info.plist files only). No fix yet: plist's latest release (1.9.0,
+    # 2026-04-26) still requires quick-xml ^0.39.2; the advisories need
+    # >=0.41.0. Revisit when plist ships a release depending on quick-xml
+    # >=0.41 (tracked upstream: https://github.com/ebarnard/rust-plist).
+    { id = "RUSTSEC-2026-0194", reason = "quick-xml: tauri/plist transitive, DoS-only, no fix yet (plist 1.9.0 caps at quick-xml 0.39)" },
+    { id = "RUSTSEC-2026-0195", reason = "quick-xml: tauri/plist transitive, DoS-only, no fix yet (plist 1.9.0 caps at quick-xml 0.39)" },
+
     # ── velesdb-cli transitive ────────────────────────────────────────
     { id = "RUSTSEC-2024-0384", reason = "instant: velesdb-cli transitive (clap/indicatif chain), unmaintained" },
 


### PR DESCRIPTION
## Summary
- `deny.toml` directly controls `cargo-deny`'s pass/fail behavior (the Security Audit job in `ci.yml`), but was missing from `ci.yml`'s `paths:` filter (both `push` and `pull_request` triggers).
- Found while trying to merge #1304 (a deny.toml-only advisory-ignore fix): the PR never triggered the CI workflow at all, so the branch-protection-required `CI Success` status never posted — the PR was stuck `BLOCKED` (not failed, just permanently pending), with no red check to fix and no way to merge through normal review.
- One-line addition: `deny.toml` alongside the existing `Cargo.toml`/`Cargo.lock` entries in both path lists.

**Update:** bundled #1304's actual deny.toml fix (RUSTSEC-2026-0194/0195 ignore entries, cherry-picked here) into this PR too — chicken-and-egg problem: this PR's own CI, once triggered by the path-filter fix, would otherwise hit the exact same pre-existing Security Audit failure #1304 exists to resolve, since it branches off the same pre-fix `develop`. Bundling both changes here breaks the deadlock. **#1304 will be closed as superseded once this merges** — its content is included here.

## Test plan
- [x] `ruby -ryaml` parse check on the workflow file — valid YAML
- [x] `cargo deny check advisories` locally — `advisories ok`
- [x] Touches `.github/workflows/**`, already in the path filter, so this PR's own CI triggers normally — and now has the deny.toml fix needed for Security Audit to actually pass