### PR TITLE
feat(memory): productize vector+graph fusion in recall_fused

### DIFF
--- a/crates/velesdb-core/src/agent/semantic_memory.rs
+++ b/crates/velesdb-core/src/agent/semantic_memory.rs
@@ -522,6 +522,26 @@ impl SemanticMemory {
         Ok(Some((extract_content(&point), point.vector.clone())))
     }
 
+    /// Retrieves a fact's raw payload as a metadata map, or `None` when the id
+    /// is unknown, expired, or carries no payload. Unlike [`Self::get`], this
+    /// skips the embedding entirely, so a caller that only needs to inspect a
+    /// fact's tags (e.g. to distinguish internal scaffolding from user data)
+    /// doesn't pay for a vector copy.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when collection access fails.
+    pub fn get_metadata(&self, id: u64) -> Result<Option<Map<String, Value>>, AgentMemoryError> {
+        if self.ttl.is_expired(MemoryKind::Semantic, id) {
+            return Ok(None);
+        }
+        let collection = memory_helpers::get_collection(&self.db, &self.collection_name)?;
+        let Some(point) = collection.get(&[id]).into_iter().flatten().next() else {
+            return Ok(None);
+        };
+        Ok(point.payload.as_ref().and_then(Value::as_object).cloned())
+    }
+
     /// Lists all live (non-expired) tracked facts as `(id, content)` pairs.
     ///
     /// # Errors

--- a/crates/velesdb-core/src/agent/semantic_memory_tests.rs
+++ b/crates/velesdb-core/src/agent/semantic_memory_tests.rs
@@ -345,6 +345,38 @@ mod tests {
     }
 
     #[test]
+    fn test_get_metadata_returns_payload_excluding_none_for_unknown() {
+        let dir = tempdir().unwrap();
+        let db = Arc::new(Database::open(dir.path()).unwrap());
+        let sm = make_semantic(Arc::clone(&db));
+
+        let emb = vec![1.0_f32, 0.0, 0.0, 0.0];
+        let mut meta = serde_json::Map::new();
+        meta.insert("tag".to_string(), serde_json::json!("science"));
+        sm.store_with_metadata(1, "Photosynthesis", &emb, &meta)
+            .unwrap();
+
+        let payload = sm.get_metadata(1).unwrap().expect("payload present");
+        assert_eq!(payload.get("tag"), Some(&serde_json::json!("science")));
+        assert!(sm.get_metadata(404).unwrap().is_none());
+    }
+
+    #[test]
+    fn test_get_metadata_bare_store_has_no_extra_fields() {
+        let dir = tempdir().unwrap();
+        let db = Arc::new(Database::open(dir.path()).unwrap());
+        let sm = make_semantic(Arc::clone(&db));
+
+        sm.store(1, "no metadata here", &[1.0, 0.0, 0.0, 0.0])
+            .unwrap();
+
+        // `store()` still writes a payload (the reserved `content` key), so the
+        // map is Some, just without any caller-supplied field.
+        let payload = sm.get_metadata(1).unwrap().expect("payload present");
+        assert!(!payload.contains_key("tag"));
+    }
+
+    #[test]
     fn test_list_all_returns_live_facts() {
         let dir = tempdir().unwrap();
         let db = Arc::new(Database::open(dir.path()).unwrap());

--- a/crates/velesdb-memory/src/error.rs
+++ b/crates/velesdb-memory/src/error.rs
@@ -5,6 +5,7 @@ use velesdb_core::Error as CoreError;
 
 use crate::embedder::EmbedError;
 use crate::extract::ExtractError;
+use crate::rerank::RerankError;
 
 /// The transport-neutral class of a [`MemoryError`] — the single source of
 /// truth every adapter maps onto its own error channel (JSON-RPC code, napi
@@ -54,6 +55,11 @@ pub enum MemoryError {
     #[error("extraction error: {0}")]
     Extract(#[from] ExtractError),
 
+    /// Failure reranking a fused-recall candidate pool in
+    /// [`crate::service::MemoryService::recall_fused_reranked`].
+    #[error("rerank error: {0}")]
+    Rerank(#[from] RerankError),
+
     /// A fused-recall filter referenced a field name that is not a plain
     /// identifier, named a reserved key, or carried a non-scalar value.
     #[error("invalid filter field: {0}")]
@@ -79,9 +85,11 @@ impl MemoryError {
             | Self::InvalidFilter(_)
             | Self::InvalidRelation(_) => ErrorCategory::InvalidInput,
             Self::UnknownMemory(_) => ErrorCategory::NotFound,
-            Self::Storage(_) | Self::Memory(_) | Self::Embed(_) | Self::Extract(_) => {
-                ErrorCategory::Internal
-            }
+            Self::Storage(_)
+            | Self::Memory(_)
+            | Self::Embed(_)
+            | Self::Extract(_)
+            | Self::Rerank(_) => ErrorCategory::Internal,
         }
     }
 }

--- a/crates/velesdb-memory/src/fused_recall.rs
+++ b/crates/velesdb-memory/src/fused_recall.rs
@@ -1,0 +1,216 @@
+//! [`MemoryService::recall_fused`]: vector recall combined with the graph
+//! reach `why()` already walks, re-ranked by [`crate::fusion::fuse`]. Split
+//! out of `service.rs` to keep that file under the crate's NLOC budget; a
+//! child module of `service`, so it freely uses `MemoryService`'s private
+//! fields and methods (`traverse`, `search`, `HUB_FIELD`, …).
+
+use serde_json::Value;
+
+use super::{reject_reserved_keys, MemoryService, Metadata, HUB_FIELD, MENTIONS_RELATION};
+use crate::embedder::Embedder;
+use crate::error::MemoryError;
+use crate::fusion::{self, Candidate};
+use crate::model::{FusionOptions, MemoryEdge, MemoryNode, Recollection};
+use crate::rerank::Reranker;
+
+impl<E: Embedder> MemoryService<E> {
+    /// Fused recall: like [`Self::recall`], but also walks the graph from the
+    /// query's top vector hit and folds any fact it reaches (hop ≥ 1) into the
+    /// ranking, scored by `opts.graph_boost · graph_weight` on top of its
+    /// normalised vector similarity. A fact the graph reaches never displaces
+    /// a strong vector hit unless the boosted score genuinely outranks it; a
+    /// fact the vector pool ranked low (or missed) can still surface if the
+    /// graph connects it. This is the tri-engine ranking measured on
+    /// HotpotQA/TimeQA/LoCoMo (`examples/multihop`, `examples/timeqa`,
+    /// `examples/locomo`) — [`Self::recall`] stays pure-vector and unchanged,
+    /// so existing callers see no behavior shift.
+    ///
+    /// The graph reach requires a wired graph to find anything: it walks
+    /// edges from [`Self::relate`] or the entity hubs
+    /// [`Self::remember_extracted`] auto-wires. Entity hubs themselves are
+    /// never returned, exactly like [`Self::recall`].
+    ///
+    /// # Errors
+    /// Returns [`MemoryError`] if embedding, vector search, or graph
+    /// traversal fails.
+    pub fn recall_fused(
+        &self,
+        query: &str,
+        k: usize,
+        filter: Option<&Metadata>,
+        opts: FusionOptions,
+    ) -> Result<Vec<Recollection>, MemoryError> {
+        let query = query.trim();
+        if query.is_empty() || k == 0 {
+            return Ok(Vec::new());
+        }
+        reject_reserved_keys(filter)?;
+        let embedding = self.embedder.embed(query)?;
+        let pool = self.fused_pool(&embedding, pool_depth(k, opts), filter)?;
+        let reached = self.graph_reached(&embedding, filter, opts.hops)?;
+        Ok(fusion::fuse(pool, &reached, k, opts.graph_boost))
+    }
+
+    /// Like [`Self::recall_fused`], but hands the FULL fused-ranked candidate
+    /// pool (before the final `k` cutoff) to `reranker` for a second-stage
+    /// re-score, then truncates to `k`. Closes the ranking-miss gap the
+    /// `LoCoMo` ceiling diagnostic found: a relevant fact can be IN the pool
+    /// (recall@64 ≈ 89% on multi-hop) yet outranked out of a tight `k`
+    /// (recall@8 ≈ 50%) — a reranker recovers it without widening `k` itself.
+    ///
+    /// No built-in reranker ships: bring your own (cross-encoder, LLM judge,
+    /// …) via [`Reranker`]. Never call this as a default — a reranker can
+    /// also *hurt* out-of-distribution conversational queries (measured on
+    /// `LoCoMo`), so it is opt-in, one call at a time.
+    ///
+    /// # Errors
+    /// Returns [`MemoryError`] if embedding, vector search, graph traversal,
+    /// or `reranker` itself fails.
+    pub fn recall_fused_reranked<R: Reranker>(
+        &self,
+        query: &str,
+        k: usize,
+        filter: Option<&Metadata>,
+        opts: FusionOptions,
+        reranker: &R,
+    ) -> Result<Vec<Recollection>, MemoryError> {
+        let query = query.trim();
+        if query.is_empty() || k == 0 {
+            return Ok(Vec::new());
+        }
+        reject_reserved_keys(filter)?;
+        let embedding = self.embedder.embed(query)?;
+        let depth = pool_depth(k, opts);
+        let pool = self.fused_pool(&embedding, depth, filter)?;
+        let reached = self.graph_reached(&embedding, filter, opts.hops)?;
+        let fused = fusion::fuse(pool, &reached, depth, opts.graph_boost);
+        let ranked = reranker.rerank(query, fused)?;
+        Ok(ranked.into_iter().take(k).collect())
+    }
+
+    /// The oversampled vector pool [`Self::recall_fused`] re-ranks.
+    fn fused_pool(
+        &self,
+        embedding: &[f32],
+        depth: usize,
+        filter: Option<&Metadata>,
+    ) -> Result<Vec<Candidate>, MemoryError> {
+        let hits = self.search(embedding, depth, filter)?;
+        hits.into_iter()
+            .map(|(id, score, content)| {
+                Ok(Candidate {
+                    recollection: Recollection {
+                        id,
+                        score,
+                        content,
+                        metadata: self.recall_metadata(id)?,
+                    },
+                    vector_score: f64::from(score),
+                    graph_weight: 0.0,
+                })
+            })
+            .collect()
+    }
+
+    /// Facts the graph reaches (hop ≥ 1) from the query's top vector seed,
+    /// entity hubs excluded, each weighted by [`Self::reach_weight`]: a link
+    /// through a rare, specific entity hub promotes harder than one through a
+    /// generic mega-hub whose connections carry little signal — the idf lever
+    /// validated on `HotpotQA` (+5.0pp both-facts-complete) and `LoCoMo` (turns
+    /// the graph net-positive on multi-hop, no regression elsewhere).
+    fn graph_reached(
+        &self,
+        embedding: &[f32],
+        filter: Option<&Metadata>,
+        hops: usize,
+    ) -> Result<Vec<Candidate>, MemoryError> {
+        let seeds = self.search(embedding, 1, filter)?;
+        let Some((seed_id, _score, seed_content)) = seeds.into_iter().next() else {
+            return Ok(Vec::new());
+        };
+        let explanation = self.traverse(seed_id, seed_content, hops)?;
+        let mut reached = Vec::new();
+        for node in &explanation.nodes {
+            if let Some(candidate) = self.reached_candidate(node, &explanation.edges)? {
+                reached.push(candidate);
+            }
+        }
+        Ok(reached)
+    }
+
+    /// The graph-reached candidate for `node`, or `None` when it's the seed
+    /// itself (hop 0) or an entity hub (internal scaffolding, never a caller
+    /// fact — split out of [`Self::graph_reached`] to keep that loop's
+    /// complexity within budget).
+    fn reached_candidate(
+        &self,
+        node: &MemoryNode,
+        edges: &[MemoryEdge],
+    ) -> Result<Option<Candidate>, MemoryError> {
+        if node.hop == 0 || self.is_hub(node.id)? {
+            return Ok(None);
+        }
+        let weight = self.reach_weight(node.id, edges)?;
+        Ok(Some(Candidate {
+            recollection: Recollection {
+                id: node.id,
+                score: 0.0,
+                content: node.content.clone(),
+                metadata: self.recall_metadata(node.id)?,
+            },
+            vector_score: 0.0,
+            graph_weight: weight,
+        }))
+    }
+
+    /// The strength of the link(s) that reached `fact_id`: the maximum
+    /// entity-idf ([`Self::entity_idf`]) over every hub with a `mentions`
+    /// edge into it, or a flat `1.0` when it was reached through a direct
+    /// (non-hub) [`Self::relate`] edge instead — idf has nothing to weight
+    /// there, so the original flat signal is kept.
+    fn reach_weight(&self, fact_id: u64, edges: &[MemoryEdge]) -> Result<f64, MemoryError> {
+        let mut weight: Option<f64> = None;
+        for edge in edges {
+            if edge.to == fact_id && edge.relation == MENTIONS_RELATION {
+                let idf = self.entity_idf(edge.from)?;
+                weight = Some(weight.map_or(idf, |w: f64| w.max(idf)));
+            }
+        }
+        Ok(weight.unwrap_or(1.0))
+    }
+
+    /// Normalised inverse document frequency of hub `hub_id`, in `[0, 1]`:
+    /// `1` when it links a single fact (maximally specific), trending to `0`
+    /// as it links ever more (a generic mega-hub whose links carry little
+    /// answer signal). Mirrors the `LoCoMo` harness formula
+    /// (`examples/locomo/ingest.rs`), using the store's total memory count
+    /// (facts + hubs) as a corpus-size proxy.
+    fn entity_idf(&self, hub_id: u64) -> Result<f64, MemoryError> {
+        let degree = self.memory.semantic().relations(hub_id)?.len();
+        let n = self.memory.semantic().count();
+        if degree == 0 || n <= 1 {
+            return Ok(0.0);
+        }
+        #[allow(clippy::cast_precision_loss)] // corpus/degree sizes are far below f64's exact range
+        let (n, d) = (n as f64, degree as f64);
+        Ok((n / d).ln() / n.ln())
+    }
+
+    /// True when `id` is an entity hub auto-created by
+    /// [`Self::remember_extracted`] (internal scaffolding, never a caller
+    /// fact — recall and graph reach both exclude it).
+    fn is_hub(&self, id: u64) -> Result<bool, MemoryError> {
+        Ok(self
+            .memory
+            .semantic()
+            .get_metadata(id)?
+            .is_some_and(|meta| meta.get(HUB_FIELD) == Some(&Value::Bool(true))))
+    }
+}
+
+/// The oversampled candidate pool depth for a `k`-sized fused recall:
+/// `opts.pool` if the caller set one, else the proven default
+/// ([`fusion::pool_size`]).
+fn pool_depth(k: usize, opts: FusionOptions) -> usize {
+    opts.pool.unwrap_or_else(|| fusion::pool_size(k))
+}

--- a/crates/velesdb-memory/src/fusion.rs
+++ b/crates/velesdb-memory/src/fusion.rs
@@ -1,0 +1,102 @@
+//! Vector+graph score fusion — the ranking layer behind
+//! [`MemoryService::recall_fused`](crate::service::MemoryService::recall_fused).
+//!
+//! Ported from the LoCoMo benchmark harness (`examples/locomo/eval.rs`), where
+//! this exact re-ranking measured a generation-free lift on public multi-hop
+//! benchmarks (+6.9pp both-facts recall, HotpotQA 3000-Q; +9.7pp gold-sentence
+//! recall, TimeQA) that the shipped `recall()` — pure vector search — never
+//! captured, because it never combined the vector and graph facets.
+
+use std::collections::{HashMap, HashSet};
+
+use crate::model::Recollection;
+
+/// Depth of the oversampled vector pool a fused recall re-ranks, and its floor
+/// regardless of `k`: deep enough that a graph-promoted fact has room to
+/// surface without evicting a genuinely stronger vector hit. Values proven on
+/// HotpotQA/TimeQA/LoCoMo.
+pub(crate) const POOL_FACTOR: usize = 8;
+pub(crate) const POOL_MIN: usize = 64;
+
+/// Oversampled candidate pool depth for a `k`-sized fused recall.
+pub(crate) fn pool_size(k: usize) -> usize {
+    k.saturating_mul(POOL_FACTOR).max(POOL_MIN)
+}
+
+/// A recall candidate carrying its raw vector score and (if graph-reached) a
+/// graph promotion weight. Internal fusion currency — distinct from
+/// [`Recollection`], the public return shape.
+#[derive(Debug, Clone)]
+pub(crate) struct Candidate {
+    pub recollection: Recollection,
+    /// Raw vector similarity, `0.0` for a fact the vector pool never ranked
+    /// (it entered only via graph traversal).
+    pub vector_score: f64,
+    /// Graph promotion weight: `0.0` for a pool-only hit, `> 0.0` for a fact
+    /// the graph traversal reached (a flat `1.0`, or an idf-based weight).
+    pub graph_weight: f64,
+}
+
+/// Re-rank `pool ∪ reached` by `vector_score/max_score + graph_boost·graph_weight`,
+/// take the top `k`. A fact both vector-ranked and graph-reached keeps its pool
+/// copy (its real vector score, plus the reached weight folded in by
+/// [`fused_score`]); a fact the graph reaches but the pool never ranked
+/// carries `vector_score = 0.0` and rides on its `graph_weight` alone.
+///
+/// Equal-budget promotion, not blind eviction: a strong vector fact keeps its
+/// place unless a graph-connected fact's boosted score outranks it.
+pub(crate) fn fuse(
+    pool: Vec<Candidate>,
+    reached: &[Candidate],
+    k: usize,
+    graph_boost: f64,
+) -> Vec<Recollection> {
+    let weights: HashMap<u64, f64> = reached
+        .iter()
+        .map(|c| (c.recollection.id, c.graph_weight))
+        .collect();
+    let max_score = pool
+        .iter()
+        .map(|c| c.vector_score)
+        .fold(f64::MIN, f64::max)
+        .max(f64::EPSILON);
+
+    let mut candidates = pool;
+    let present: HashSet<u64> = candidates.iter().map(|c| c.recollection.id).collect();
+    candidates.extend(
+        reached
+            .iter()
+            .filter(|c| !present.contains(&c.recollection.id))
+            .cloned(),
+    );
+
+    candidates.sort_by(|a, b| {
+        fused_score(b, &weights, max_score, graph_boost).total_cmp(&fused_score(
+            a,
+            &weights,
+            max_score,
+            graph_boost,
+        ))
+    });
+    candidates.truncate(k);
+    candidates.into_iter().map(|c| c.recollection).collect()
+}
+
+/// `vector_score/max_score + graph_boost·graph_weight`. A pure vector hit
+/// (`graph_weight` absent from `weights`) keeps its bare normalised similarity.
+fn fused_score(
+    candidate: &Candidate,
+    weights: &HashMap<u64, f64>,
+    max_score: f64,
+    graph_boost: f64,
+) -> f64 {
+    let weight = weights
+        .get(&candidate.recollection.id)
+        .copied()
+        .unwrap_or(0.0);
+    candidate.vector_score / max_score + graph_boost * weight
+}
+
+#[cfg(test)]
+#[path = "fusion_tests.rs"]
+mod tests;

--- a/crates/velesdb-memory/src/fusion_tests.rs
+++ b/crates/velesdb-memory/src/fusion_tests.rs
@@ -1,0 +1,95 @@
+//! Unit tests for the fusion ranking layer.
+
+use super::*;
+use crate::model::Recollection;
+
+#[allow(clippy::cast_possible_truncation)] // test fixture scores are small, exact literals
+fn candidate(id: u64, vector_score: f64, graph_weight: f64) -> Candidate {
+    Candidate {
+        recollection: Recollection {
+            id,
+            score: vector_score as f32,
+            content: format!("fact-{id}"),
+            metadata: None,
+        },
+        vector_score,
+        graph_weight,
+    }
+}
+
+#[test]
+fn test_pool_size_floors_at_pool_min() {
+    assert_eq!(pool_size(1), POOL_MIN);
+    assert_eq!(pool_size(4), POOL_MIN);
+}
+
+#[test]
+fn test_pool_size_scales_with_k_above_floor() {
+    assert_eq!(pool_size(100), 800);
+}
+
+#[test]
+fn test_fuse_pure_vector_pool_keeps_score_order() {
+    let pool = vec![candidate(1, 0.9, 0.0), candidate(2, 0.5, 0.0)];
+    let ranked = fuse(pool, &[], 2, 0.15);
+    assert_eq!(ranked.iter().map(|r| r.id).collect::<Vec<_>>(), vec![1, 2]);
+}
+
+#[test]
+fn test_fuse_promotes_graph_reached_fact_not_in_pool() {
+    // Pool has two vector hits, the 2nd clearly weaker; the graph reaches
+    // a 3rd fact with a strong weight. It must be able to outrank the
+    // weaker pool member, not just get appended.
+    let pool = vec![candidate(1, 0.5, 0.0), candidate(2, 0.3, 0.0)];
+    let reached = vec![candidate(3, 0.0, 1.0)];
+    let ranked = fuse(pool, &reached, 2, 0.8);
+    assert_eq!(ranked.len(), 2);
+    assert!(
+        ranked.iter().any(|r| r.id == 3),
+        "graph fact should surface"
+    );
+    assert!(
+        !ranked.iter().any(|r| r.id == 2),
+        "weaker vector hit should be displaced"
+    );
+}
+
+#[test]
+fn test_fuse_never_evicts_strong_vector_hit_with_weak_boost() {
+    // A small graph_boost must not let a graph-only fact beat a strong,
+    // well-ranked vector hit.
+    let pool = vec![candidate(1, 0.95, 0.0), candidate(2, 0.5, 0.0)];
+    let reached = vec![candidate(3, 0.0, 1.0)];
+    let ranked = fuse(pool, &reached, 1, 0.05);
+    assert_eq!(ranked.len(), 1);
+    assert_eq!(ranked[0].id, 1);
+}
+
+#[test]
+fn test_fuse_dedups_fact_both_vector_ranked_and_graph_reached() {
+    let pool = vec![candidate(1, 0.9, 0.0)];
+    let reached = vec![candidate(1, 0.0, 1.0)];
+    let ranked = fuse(pool, &reached, 5, 0.15);
+    assert_eq!(ranked.len(), 1);
+    // The pool copy's real vector score must win, boosted by the reached
+    // weight — not the reached copy's placeholder 0.0 vector score.
+    assert!(ranked[0].score > 0.0);
+}
+
+#[test]
+fn test_fuse_truncates_to_k() {
+    let pool = vec![
+        candidate(1, 0.9, 0.0),
+        candidate(2, 0.8, 0.0),
+        candidate(3, 0.7, 0.0),
+    ];
+    let ranked = fuse(pool, &[], 1, 0.15);
+    assert_eq!(ranked.len(), 1);
+    assert_eq!(ranked[0].id, 1);
+}
+
+#[test]
+fn test_fuse_empty_pool_and_reached_yields_empty() {
+    let ranked = fuse(Vec::new(), &[], 5, 0.15);
+    assert!(ranked.is_empty());
+}

--- a/crates/velesdb-memory/src/lib.rs
+++ b/crates/velesdb-memory/src/lib.rs
@@ -24,6 +24,10 @@
 pub mod embedder;
 pub mod error;
 pub mod extract;
+/// Vector+graph score fusion — the ranking layer behind
+/// [`service::MemoryService::recall_fused`]. Internal: callers reach it only
+/// through that method.
+mod fusion;
 /// Content-addressed memory ids — internal; ids surface through the service API.
 pub(crate) mod id;
 /// Resource caps (DoS limits) shared by every adapter — the single source of
@@ -38,6 +42,9 @@ pub mod mcp;
 /// (`Link`, `Recollection`, `ColumnFilter`, `Explanation`, …), separate from the
 /// service that computes them.
 pub mod model;
+/// Optional second-stage re-scoring of a fused recall pool (bring your own
+/// cross-encoder/LLM). Never wired in by default — see [`rerank::Reranker`].
+pub mod rerank;
 /// Shared JSON Schema post-processing (strips `schemars`' non-standard integer
 /// `format` keywords so strict MCP clients don't warn on every id field).
 mod schema;
@@ -56,5 +63,8 @@ pub use extract::OllamaExtractor;
 pub use extract::{DynExtractor, ExtractError, ExtractedFact, Extractor};
 #[cfg(feature = "mcp")]
 pub use mcp::McpServer;
-pub use model::{ColumnFilter, ColumnOp, Explanation, Link, MemoryEdge, MemoryNode, Recollection};
+pub use model::{
+    ColumnFilter, ColumnOp, Explanation, FusionOptions, Link, MemoryEdge, MemoryNode, Recollection,
+};
+pub use rerank::{DynReranker, RerankError, Reranker};
 pub use service::{MemoryService, Metadata};

--- a/crates/velesdb-memory/src/model.rs
+++ b/crates/velesdb-memory/src/model.rs
@@ -90,6 +90,40 @@ pub struct ColumnFilter {
     pub value: Value,
 }
 
+/// Tuning knobs for
+/// [`MemoryService::recall_fused`](crate::service::MemoryService::recall_fused).
+///
+/// `Default` matches the values validated on the LoCoMo/HotpotQA/TimeQA
+/// benchmarks (`examples/locomo`, `examples/multihop`, `examples/timeqa`):
+/// `graph_boost = 0.15` was the optimum of a sweep (0.30/0.50/0.80 all
+/// degraded ranking quality), and `hops = 2` is the minimum depth at which a
+/// fact wired only through a shared topic (the `remember_extracted` hub
+/// scaffolding: fact → hub is hop 1, hub → sibling fact is hop 2) becomes
+/// reachable at all.
+#[derive(Debug, Clone, Copy)]
+pub struct FusionOptions {
+    /// Hops the graph traversal walks from the top vector seed.
+    pub hops: usize,
+    /// Weight added to a graph-reached fact's normalised vector score.
+    pub graph_boost: f64,
+    /// Depth of the oversampled vector pool fusion re-ranks. `None` uses the
+    /// proven default (`k` scaled up, floored at 64 — see
+    /// `crate::fusion::pool_size`). Widen this to give
+    /// [`MemoryService::recall_fused_reranked`](crate::service::MemoryService::recall_fused_reranked)'s
+    /// reranker more candidates to work with.
+    pub pool: Option<usize>,
+}
+
+impl Default for FusionOptions {
+    fn default() -> Self {
+        Self {
+            hops: 2,
+            graph_boost: 0.15,
+            pool: None,
+        }
+    }
+}
+
 /// A node in an [`Explanation`] subgraph.
 #[derive(Debug, Clone, Serialize, JsonSchema)]
 #[schemars(transform = crate::schema::strip_int_formats)]

--- a/crates/velesdb-memory/src/rerank.rs
+++ b/crates/velesdb-memory/src/rerank.rs
@@ -1,0 +1,73 @@
+//! Optional second-stage re-scoring of a [`MemoryService::recall_fused`]
+//! candidate pool, the layer that lifts a ranking miss (a relevant fact deep
+//! in the pool, below the fusion cutoff) into the final `k` — the lever
+//! validated on the LoCoMo ceiling diagnostic (multi-hop recall@8 = 50%,
+//! recall@64 = 89%: the gold fact is IN the pool, just outranked).
+//!
+//! Mirroring the [`crate::embedder`]/[`crate::extract`] pattern, the
+//! plug-point is dependency-free (bring your own cross-encoder or LLM by
+//! implementing [`Reranker`]) and never wired in by default: a reranker
+//! measurably helps ranking-bound corpora but can hurt on out-of-distribution
+//! conversational queries (the LoCoMo panel's own finding) — opt-in only,
+//! never a silent default.
+//!
+//! [`MemoryService::recall_fused`]: crate::service::MemoryService::recall_fused
+
+use crate::model::Recollection;
+
+/// Failure produced by a [`Reranker`] backend (e.g. a network-backed model
+/// that cannot be reached, or output that cannot be mapped back to
+/// candidates).
+#[derive(Debug, thiserror::Error)]
+pub enum RerankError {
+    /// The reranking backend (network, subprocess, …) returned an error.
+    #[error("rerank backend error: {0}")]
+    Backend(String),
+}
+
+/// Re-scores or reorders a fused candidate pool against `query`.
+///
+/// Implement this to plug in a cross-encoder, an LLM judge, or any other
+/// second-stage ranker, and pass it to
+/// [`MemoryService::recall_fused_reranked`](crate::service::MemoryService::recall_fused_reranked).
+/// A well-behaved implementation returns the same candidates (by id), just
+/// reordered or re-scored — it should not invent or drop ids.
+pub trait Reranker {
+    /// Re-score or reorder `candidates` for relevance to `query`.
+    ///
+    /// # Errors
+    /// Returns [`RerankError`] if the backend fails.
+    fn rerank(
+        &self,
+        query: &str,
+        candidates: Vec<Recollection>,
+    ) -> Result<Vec<Recollection>, RerankError>;
+}
+
+/// Forward [`Reranker`] through an [`Arc`], so a shared `Arc<dyn Reranker>`
+/// (e.g. one held by the MCP server) satisfies the `R: Reranker` bound on
+/// [`crate::MemoryService::recall_fused_reranked`].
+impl<T: Reranker + ?Sized> Reranker for std::sync::Arc<T> {
+    fn rerank(
+        &self,
+        query: &str,
+        candidates: Vec<Recollection>,
+    ) -> Result<Vec<Recollection>, RerankError> {
+        (**self).rerank(query, candidates)
+    }
+}
+
+/// A boxed, object-safe reranker. Lets a non-generic caller (e.g. the Node
+/// binding, wrapping a JS callback) hold `Box<dyn Reranker + Send + Sync>`
+/// without threading a generic parameter through `MemoryService`.
+pub type DynReranker = Box<dyn Reranker + Send + Sync>;
+
+impl Reranker for DynReranker {
+    fn rerank(
+        &self,
+        query: &str,
+        candidates: Vec<Recollection>,
+    ) -> Result<Vec<Recollection>, RerankError> {
+        (**self).rerank(query, candidates)
+    }
+}

--- a/crates/velesdb-memory/src/service.rs
+++ b/crates/velesdb-memory/src/service.rs
@@ -19,6 +19,13 @@ use crate::extract::Extractor;
 use crate::id;
 use crate::model::{ColumnFilter, Explanation, Link, MemoryEdge, MemoryNode, Recollection};
 
+/// [`MemoryService::recall_fused`] and its helpers — split out to keep this
+/// file under the crate's 500-NLOC-per-file budget, same pattern as
+/// `velesdb-core`'s `database/*.rs` split. A child module of `service`, so it
+/// shares full access to `MemoryService`'s private fields and methods.
+#[path = "fused_recall.rs"]
+mod fused_recall;
+
 /// Reserved metadata key marking an entity hub auto-created by
 /// [`MemoryService::remember_extracted`] (value `true`). Namespaced under the
 /// system `_veles_` prefix so it can never collide with a caller's own metadata,
@@ -30,6 +37,11 @@ const HUB_FIELD: &str = "_veles_hub";
 /// natural fact ids: a caller fact whose text happens to equal a hub's display
 /// content (`Entity: rust`) can never collide with, or overwrite, the hub.
 const HUB_ID_SALT: &str = "\u{0}_veles_entity_hub\u{0}";
+/// Edge label a hub uses to point back at a fact it tags (the hub → fact
+/// direction). [`fused_recall`] reads this to recognise which edges in a
+/// `why()` walk crossed a hub, so it can weight the reached fact by that
+/// hub's specificity instead of a flat constant.
+const MENTIONS_RELATION: &str = "mentions";
 
 /// Local-first agent memory backed by a single `VelesDB` instance.
 ///
@@ -217,7 +229,7 @@ impl<E: Embedder> MemoryService<E> {
         self.seed_existing_edges(fact_id, edges, seeded)?;
         self.seed_existing_edges(entity_id, edges, seeded)?;
         self.add_edge(fact_id, entity_id, "about", edges)?;
-        self.add_edge(entity_id, fact_id, "mentions", edges)?;
+        self.add_edge(entity_id, fact_id, MENTIONS_RELATION, edges)?;
         Ok(())
     }
 
@@ -338,8 +350,14 @@ impl<E: Embedder> MemoryService<E> {
     /// Entity hubs created by [`Self::remember_extracted`] are never returned:
     /// they are internal graph scaffolding, not facts the caller stored.
     ///
+    /// Each hit carries its caller metadata (`Recollection::metadata`, `None`
+    /// when the fact carries none) — store a date field (e.g. `occurred_at`)
+    /// and it round-trips here, so a caller can sort the result into a
+    /// chronological, date-stamped context without `recall_where`'s explicit
+    /// filters. This costs one extra lookup per returned hit.
+    ///
     /// # Errors
-    /// Returns [`MemoryError`] if the semantic query fails.
+    /// Returns [`MemoryError`] if the semantic query or a metadata lookup fails.
     pub fn recall(
         &self,
         query: &str,
@@ -353,21 +371,30 @@ impl<E: Embedder> MemoryService<E> {
         reject_reserved_keys(filter)?;
         let embedding = self.embedder.embed(query)?;
         let hits = self.search(&embedding, k, filter)?;
-        // `self.search` (below) goes through core's `query_filtered`/
-        // `query_excluding`, which return only `(id, score, content)` — no
-        // payload/metadata access at that layer. Widening that would mean
-        // changing velesdb-core's public API, which is out of scope here.
-        // `recall_where` (via `to_recollection`) is the documented path for
-        // metadata-carrying, dated recall.
-        Ok(hits
-            .into_iter()
-            .map(|(id, score, content)| Recollection {
-                id,
-                score,
-                content,
-                metadata: None,
+        hits.into_iter()
+            .map(|(id, score, content)| {
+                Ok(Recollection {
+                    id,
+                    score,
+                    content,
+                    metadata: self.recall_metadata(id)?,
+                })
             })
-            .collect())
+            .collect()
+    }
+
+    /// The caller-supplied metadata for memory `id` (reserved system keys
+    /// excluded), or `None` when it carries none. Shared by every recall path
+    /// so a fact's metadata round-trips regardless of which one a caller uses.
+    fn recall_metadata(&self, id: u64) -> Result<Option<Metadata>, MemoryError> {
+        let payload = self.memory.semantic().get_metadata(id)?;
+        Ok(payload.and_then(|payload| {
+            let metadata: Metadata = payload
+                .into_iter()
+                .filter(|(key, _)| !is_reserved_key(key))
+                .collect();
+            (!metadata.is_empty()).then_some(metadata)
+        }))
     }
 
     /// Vector search for up to `k` ids, optionally narrowed by a metadata

--- a/crates/velesdb-memory/tests/memory_service_bdd.rs
+++ b/crates/velesdb-memory/tests/memory_service_bdd.rs
@@ -5,7 +5,8 @@
 
 mod common;
 
-use common::service;
+use common::{meta, service};
+use serde_json::json;
 use velesdb_memory::{Link, MemoryError};
 
 // --- Nominal ---------------------------------------------------------------
@@ -24,6 +25,43 @@ fn remember_then_recall_returns_the_fact() {
         hits.iter().any(|h| h.id == id),
         "recalled set should contain the stored fact"
     );
+}
+
+#[test]
+fn recall_round_trips_caller_metadata_for_dated_context() {
+    let (_dir, svc) = service();
+    let m = meta(&[("occurred_at", json!("2026-01-05"))]);
+    let id = svc
+        .remember(
+            "we chose parking_lot to avoid lock poisoning",
+            &[],
+            Some(&m),
+        )
+        .expect("remember with metadata");
+
+    let hits = svc
+        .recall("parking_lot lock poisoning", 5, None)
+        .expect("recall");
+    let hit = hits.iter().find(|h| h.id == id).expect("fact present");
+
+    assert_eq!(
+        hit.metadata.as_ref().and_then(|m| m.get("occurred_at")),
+        Some(&json!("2026-01-05")),
+        "recall() must round-trip caller metadata, not just recall_where()"
+    );
+}
+
+#[test]
+fn recall_metadata_is_none_when_the_fact_carries_none() {
+    let (_dir, svc) = service();
+    svc.remember("a fact with no metadata", &[], None)
+        .expect("remember");
+
+    let hits = svc
+        .recall("a fact with no metadata", 5, None)
+        .expect("recall");
+
+    assert_eq!(hits[0].metadata, None);
 }
 
 #[test]

--- a/crates/velesdb-memory/tests/recall_fused_bdd.rs
+++ b/crates/velesdb-memory/tests/recall_fused_bdd.rs
@@ -1,0 +1,521 @@
+//! BDD integration tests for `recall_fused` — vector+graph score fusion.
+//!
+//! This proves the tri-engine ranking measured on HotpotQA/TimeQA/LoCoMo
+//! (`examples/multihop`, `examples/timeqa`, `examples/locomo`) now lives in
+//! the shipped recall path: `recall_fused` surfaces a graph-connected fact
+//! that pure vector similarity misses, without evicting genuinely strong
+//! vector hits or leaking internal entity-hub scaffolding.
+//!
+//! Categories: Nominal (≥60%), Edge (~20%), Negative (≥20%).
+
+mod common;
+
+use common::service;
+use serde_json::Value;
+use velesdb_memory::{
+    ExtractError, ExtractedFact, Extractor, FusionOptions, HashEmbedder, Link, MemoryError,
+    MemoryService, RerankError, Reranker,
+};
+
+const DECISION: &str = "we chose parking_lot to avoid lock poisoning";
+
+/// Same chain as `why_bdd.rs`: decision -[`decided_in`]-> PR -[`tracked_by`]-> ticket,
+/// with the ticket wording dissimilar to the decision so only the graph reaches it.
+fn seeded_chain(svc: &MemoryService<HashEmbedder>) -> (u64, u64, u64) {
+    let decision = svc
+        .remember(DECISION, &[], None)
+        .expect("remember decision");
+    let pr = svc
+        .remember("PR #42 swaps the mutex implementation", &[], None)
+        .expect("remember pr");
+    let ticket = svc
+        .remember("EPIC-317 xyzzy quux frobnicate", &[], None)
+        .expect("remember ticket");
+    svc.relate(decision, pr, "decided_in")
+        .expect("relate decision->pr");
+    svc.relate(pr, ticket, "tracked_by")
+        .expect("relate pr->ticket");
+    (decision, pr, ticket)
+}
+
+/// A canned extractor: two facts sharing only the topic `rust`, so the sole
+/// path from one to the other is through the auto-wired entity hub — the
+/// same fixture `extract_bdd.rs` uses for `why()`.
+struct StubExtractor;
+
+impl Extractor for StubExtractor {
+    fn extract(&self, _text: &str) -> Result<Vec<ExtractedFact>, ExtractError> {
+        Ok(vec![
+            ExtractedFact {
+                text: "Alice ships the parser in Rust.".to_string(),
+                entities: vec!["rust".to_string(), "parser".to_string()],
+            },
+            ExtractedFact {
+                text: "Bob maintains the Rust toolchain.".to_string(),
+                entities: vec!["rust".to_string()],
+            },
+        ])
+    }
+}
+
+const SEED_TEXT: &str = "seed fact anchors the walk";
+
+/// One seed fact tagged with both a rare topic (linking only one sibling) and
+/// a common topic (linking three siblings) — isolates the idf weighting
+/// itself: every sibling is reached at the same hop, so only the connecting
+/// hub's specificity can differentiate their rank.
+struct WeightedExtractor;
+
+impl Extractor for WeightedExtractor {
+    fn extract(&self, _text: &str) -> Result<Vec<ExtractedFact>, ExtractError> {
+        Ok(vec![
+            ExtractedFact {
+                text: SEED_TEXT.to_string(),
+                entities: vec!["raretopic".to_string(), "commontopic".to_string()],
+            },
+            ExtractedFact {
+                text: "specific sibling via the rare topic".to_string(),
+                entities: vec!["raretopic".to_string()],
+            },
+            ExtractedFact {
+                text: "common sibling one via the common topic".to_string(),
+                entities: vec!["commontopic".to_string()],
+            },
+            ExtractedFact {
+                text: "common sibling two via the common topic".to_string(),
+                entities: vec!["commontopic".to_string()],
+            },
+            ExtractedFact {
+                text: "common sibling three via the common topic".to_string(),
+                entities: vec!["commontopic".to_string()],
+            },
+        ])
+    }
+}
+
+/// A reranker that reverses the candidate order — proof the pool actually
+/// reaches the caller's hook and its output order is honored, not ignored.
+struct ReverseReranker;
+
+impl Reranker for ReverseReranker {
+    fn rerank(
+        &self,
+        _query: &str,
+        mut candidates: Vec<velesdb_memory::Recollection>,
+    ) -> Result<Vec<velesdb_memory::Recollection>, RerankError> {
+        candidates.reverse();
+        Ok(candidates)
+    }
+}
+
+/// A reranker that always fails, to check the error path is surfaced.
+struct FailingReranker;
+
+impl Reranker for FailingReranker {
+    fn rerank(
+        &self,
+        _query: &str,
+        _candidates: Vec<velesdb_memory::Recollection>,
+    ) -> Result<Vec<velesdb_memory::Recollection>, RerankError> {
+        Err(RerankError::Backend("cross-encoder offline".to_string()))
+    }
+}
+
+// --- Nominal ---------------------------------------------------------------
+
+#[test]
+fn recall_fused_reranked_lets_reranker_reorder_results() {
+    let (_dir, svc) = service();
+    seeded_chain(&svc);
+
+    let plain = svc
+        .recall_fused(DECISION, 3, None, FusionOptions::default())
+        .expect("recall_fused");
+    let reranked = svc
+        .recall_fused_reranked(
+            DECISION,
+            3,
+            None,
+            FusionOptions::default(),
+            &ReverseReranker,
+        )
+        .expect("recall_fused_reranked");
+
+    assert_eq!(plain.len(), reranked.len());
+    let plain_ids: Vec<u64> = plain.iter().map(|r| r.id).collect();
+    let reranked_ids: Vec<u64> = reranked.iter().map(|r| r.id).collect();
+    assert_ne!(
+        plain_ids, reranked_ids,
+        "the reranker's reordering must be honored, not ignored"
+    );
+    assert_eq!(
+        reranked_ids,
+        plain_ids.into_iter().rev().collect::<Vec<_>>(),
+        "reversing reranker output must exactly reverse the fused order"
+    );
+}
+
+#[test]
+fn recall_fused_reranked_truncates_to_k_after_reranking_the_wider_pool() {
+    let (_dir, svc) = service();
+    seeded_chain(&svc);
+
+    let reranked = svc
+        .recall_fused_reranked(
+            DECISION,
+            1,
+            None,
+            FusionOptions::default(),
+            &ReverseReranker,
+        )
+        .expect("recall_fused_reranked");
+    assert_eq!(reranked.len(), 1);
+}
+
+#[test]
+fn recall_fused_pool_override_narrows_the_candidate_set() {
+    let (_dir, svc) = service();
+    let decision = svc
+        .remember(DECISION, &[], None)
+        .expect("remember decision");
+    svc.remember("PR #42 swaps the mutex implementation", &[], None)
+        .expect("remember pr");
+    svc.remember("EPIC-317 xyzzy quux frobnicate", &[], None)
+        .expect("remember ticket");
+
+    let default_pool = svc
+        .recall_fused(DECISION, 5, None, FusionOptions::default())
+        .expect("recall_fused");
+    assert_eq!(default_pool.len(), 3, "default pool oversamples past k");
+
+    let narrowed = svc
+        .recall_fused(
+            DECISION,
+            5,
+            None,
+            FusionOptions {
+                pool: Some(1),
+                ..FusionOptions::default()
+            },
+        )
+        .expect("recall_fused");
+    assert_eq!(
+        narrowed.len(),
+        1,
+        "pool: Some(1) caps the candidate set at 1, even though k=5"
+    );
+    assert_eq!(
+        narrowed[0].id, decision,
+        "the sole admitted candidate must be the top vector hit"
+    );
+}
+
+#[test]
+fn recall_fused_round_trips_caller_metadata_on_a_graph_reached_fact() {
+    let (_dir, svc) = service();
+    let decision = svc
+        .remember(DECISION, &[], None)
+        .expect("remember decision");
+    let mut ticket_meta = velesdb_memory::Metadata::new();
+    ticket_meta.insert(
+        "occurred_at".to_string(),
+        Value::String("2026-01-05".to_string()),
+    );
+    let ticket = svc
+        .remember("EPIC-317 xyzzy quux frobnicate", &[], Some(&ticket_meta))
+        .expect("remember ticket with metadata");
+    svc.relate(decision, ticket, "decided_in")
+        .expect("relate decision->ticket");
+
+    let fused = svc
+        .recall_fused(DECISION, 5, None, FusionOptions::default())
+        .expect("recall_fused");
+    let hit = fused
+        .iter()
+        .find(|r| r.id == ticket)
+        .expect("ticket present");
+
+    assert_eq!(
+        hit.metadata
+            .as_ref()
+            .and_then(|m| m.get("occurred_at"))
+            .cloned(),
+        Some(Value::String("2026-01-05".to_string())),
+        "a graph-reached fact's metadata must round-trip through recall_fused too"
+    );
+}
+
+#[test]
+fn recall_fused_ranks_graph_reached_fact_above_a_vector_tied_distractor() {
+    let (_dir, svc) = service();
+    let decision = svc
+        .remember(DECISION, &[], None)
+        .expect("remember decision");
+    let ticket = svc
+        .remember("EPIC-317 xyzzy quux frobnicate", &[], None)
+        .expect("remember ticket");
+    let distractor = svc
+        .remember("the quarterly report is due next Friday", &[], None)
+        .expect("remember distractor");
+    svc.relate(decision, ticket, "decided_in")
+        .expect("relate decision->ticket");
+
+    // Vector similarity alone cannot distinguish the graph-connected ticket
+    // from the unrelated distractor: neither shares wording with the query,
+    // so both score identically under recall().
+    let vector_only = svc.recall(DECISION, 3, None).expect("recall");
+    let score_of = |id: u64| vector_only.iter().find(|h| h.id == id).map(|h| h.score);
+    assert_eq!(
+        score_of(ticket),
+        score_of(distractor),
+        "vector recall alone ties the connected fact with the unrelated one"
+    );
+
+    // The graph breaks the tie: fused ranks the connected ticket strictly
+    // above the disconnected distractor — the promotion vector search alone
+    // cannot do.
+    let fused = svc
+        .recall_fused(DECISION, 3, None, FusionOptions::default())
+        .expect("recall_fused");
+    let rank_of = |id: u64| fused.iter().position(|r| r.id == id);
+    assert!(
+        rank_of(ticket) < rank_of(distractor),
+        "the graph-reached fact must outrank the vector-tied distractor"
+    );
+}
+
+#[test]
+fn recall_fused_keeps_the_top_vector_hit_first() {
+    let (_dir, svc) = service();
+    let (decision, _pr, _ticket) = seeded_chain(&svc);
+
+    let fused = svc
+        .recall_fused(DECISION, 3, None, FusionOptions::default())
+        .expect("recall_fused");
+    assert_eq!(
+        fused[0].id, decision,
+        "the exact-match seed keeps the top rank"
+    );
+}
+
+#[test]
+fn recall_fused_promotes_sibling_fact_via_shared_entity_hub() {
+    let (_dir, svc) = service();
+    svc.remember_extracted("Alice and Bob both work in Rust.", &StubExtractor, None)
+        .expect("extract and remember");
+
+    // Bob's fact shares no wording with Alice's — pure vector recall at k=1
+    // returns only Alice's fact.
+    let vector_only = svc
+        .recall("Alice ships the parser in Rust.", 1, None)
+        .expect("recall");
+    assert!(vector_only[0].content.contains("Alice"));
+
+    let fused = svc
+        .recall_fused(
+            "Alice ships the parser in Rust.",
+            2,
+            None,
+            FusionOptions::default(),
+        )
+        .expect("recall_fused");
+    assert!(
+        fused.iter().any(|r| r.content.contains("Bob")),
+        "the shared-topic sibling fact surfaces via the 2-hop hub bridge"
+    );
+}
+
+#[test]
+fn recall_fused_ranks_rare_hub_sibling_above_common_hub_sibling() {
+    let (_dir, svc) = service();
+    svc.remember_extracted(SEED_TEXT, &WeightedExtractor, None)
+        .expect("extract and remember");
+
+    // Every sibling shares no wording with the seed query, so vector
+    // similarity alone cannot rank one above another.
+    let vector_only = svc.recall(SEED_TEXT, 10, None).expect("recall");
+    let seed_score = vector_only[0].score;
+    assert!(
+        vector_only[1..].iter().all(|h| h.score < seed_score),
+        "only the exact-match seed should stand out under vector search alone"
+    );
+
+    // idf weighting must rank the sibling reached through the rare,
+    // single-fact hub above every sibling reached through the common hub
+    // that links three facts.
+    let fused = svc
+        .recall_fused(SEED_TEXT, 10, None, FusionOptions::default())
+        .expect("recall_fused");
+    let rank_of = |needle: &str| fused.iter().position(|r| r.content.contains(needle));
+    let rare_rank = rank_of("specific sibling").expect("rare-hub sibling present");
+    for common in [
+        "common sibling one",
+        "common sibling two",
+        "common sibling three",
+    ] {
+        let common_rank = rank_of(common).expect("common-hub sibling present");
+        assert!(
+            rare_rank < common_rank,
+            "the rare-hub sibling must outrank {common:?} (idf weighting)"
+        );
+    }
+}
+
+#[test]
+fn recall_fused_never_returns_entity_hubs() {
+    let (_dir, svc) = service();
+    svc.remember_extracted("Alice and Bob both work in Rust.", &StubExtractor, None)
+        .expect("extract and remember");
+
+    let fused = svc
+        .recall_fused(
+            "Alice ships the parser in Rust.",
+            10,
+            None,
+            FusionOptions::default(),
+        )
+        .expect("recall_fused");
+    assert!(
+        fused.iter().all(|r| !r.content.starts_with("Entity: ")),
+        "internal hub scaffolding is never returned, exactly like recall()"
+    );
+}
+
+#[test]
+fn recall_fused_via_links_argument_is_traversable() {
+    let (_dir, svc) = service();
+    let pr = svc
+        .remember("PR #99 refactors the lock layer", &[], None)
+        .expect("remember pr");
+    let decision = svc
+        .remember(
+            DECISION,
+            &[Link {
+                target: pr,
+                relation: "decided_in".to_owned(),
+            }],
+            None,
+        )
+        .expect("remember decision with link");
+
+    let fused = svc
+        .recall_fused(DECISION, 2, None, FusionOptions::default())
+        .expect("recall_fused");
+    let ids: Vec<u64> = fused.iter().map(|r| r.id).collect();
+    assert!(ids.contains(&decision) && ids.contains(&pr));
+}
+
+// --- Edge --------------------------------------------------------------
+
+#[test]
+fn recall_fused_on_isolated_memory_still_returns_it_via_vector() {
+    let (_dir, svc) = service();
+    let lone = svc
+        .remember("a fact with no relations", &[], None)
+        .expect("remember");
+
+    let fused = svc
+        .recall_fused(
+            "a fact with no relations",
+            5,
+            None,
+            FusionOptions::default(),
+        )
+        .expect("recall_fused");
+    assert_eq!(fused.len(), 1);
+    assert_eq!(fused[0].id, lone);
+}
+
+#[test]
+fn recall_fused_respects_k_truncation() {
+    let (_dir, svc) = service();
+    seeded_chain(&svc);
+
+    let fused = svc
+        .recall_fused(DECISION, 1, None, FusionOptions::default())
+        .expect("recall_fused");
+    assert_eq!(fused.len(), 1);
+}
+
+#[test]
+fn recall_fused_with_zero_hops_behaves_like_pure_vector_recall() {
+    let (_dir, svc) = service();
+    let (_decision, _pr, ticket) = seeded_chain(&svc);
+
+    let opts = FusionOptions {
+        hops: 0,
+        ..FusionOptions::default()
+    };
+    let fused = svc
+        .recall_fused(DECISION, 2, None, opts)
+        .expect("recall_fused");
+    assert!(
+        fused.iter().all(|r| r.id != ticket),
+        "zero hops means no graph reach, so the ticket cannot surface"
+    );
+}
+
+#[test]
+fn recall_fused_blank_query_is_empty() {
+    let (_dir, svc) = service();
+    seeded_chain(&svc);
+
+    let fused = svc
+        .recall_fused("   ", 5, None, FusionOptions::default())
+        .expect("recall_fused");
+    assert!(fused.is_empty());
+}
+
+#[test]
+fn recall_fused_zero_k_is_empty() {
+    let (_dir, svc) = service();
+    seeded_chain(&svc);
+
+    let fused = svc
+        .recall_fused(DECISION, 0, None, FusionOptions::default())
+        .expect("recall_fused");
+    assert!(fused.is_empty());
+}
+
+// --- Negative ------------------------------------------------------------
+
+#[test]
+fn recall_fused_on_empty_store_is_empty() {
+    let (_dir, svc) = service();
+
+    let fused = svc
+        .recall_fused("anything", 5, None, FusionOptions::default())
+        .expect("recall_fused on empty store");
+    assert!(fused.is_empty());
+}
+
+#[test]
+fn recall_fused_rejects_reserved_filter_key() {
+    let (_dir, svc) = service();
+    seeded_chain(&svc);
+
+    let mut filter = velesdb_memory::Metadata::new();
+    filter.insert("content".to_string(), Value::String("x".to_string()));
+
+    let err = svc
+        .recall_fused(DECISION, 5, Some(&filter), FusionOptions::default())
+        .expect_err("reserved key must be rejected");
+    assert!(matches!(err, MemoryError::ReservedKey(_)));
+}
+
+#[test]
+fn recall_fused_reranked_propagates_reranker_failure() {
+    let (_dir, svc) = service();
+    seeded_chain(&svc);
+
+    let err = svc
+        .recall_fused_reranked(
+            DECISION,
+            3,
+            None,
+            FusionOptions::default(),
+            &FailingReranker,
+        )
+        .expect_err("reranker failure must surface, not be swallowed");
+    assert!(matches!(err, MemoryError::Rerank(_)));
+}

--- a/crates/velesdb-node/__test__/index.spec.mjs
+++ b/crates/velesdb-node/__test__/index.spec.mjs
@@ -17,13 +17,14 @@ function freshStore() {
   return { store, cleanup: () => rmSync(dir, { recursive: true, force: true }) }
 }
 
-test('surface allowlist — exactly the 8 supported methods, no engine leak', () => {
+test('surface allowlist — exactly the 9 supported methods, no engine leak', () => {
   const instanceMethods = Object.getOwnPropertyNames(MemoryService.prototype)
     .filter((m) => m !== 'constructor')
     .sort((a, b) => a.localeCompare(b))
   assert.deepEqual(instanceMethods, [
     'forget',
     'recall',
+    'recallFused',
     'recallWhere',
     'relate',
     'remember',
@@ -81,6 +82,32 @@ test('relate + why returns a connected subgraph with string ids', async () => {
   }
 })
 
+test('recallFused surfaces a graph-connected fact plain recall ranks low', async () => {
+  const { store, cleanup } = freshStore()
+  try {
+    const decision = await store.remember('we chose parking_lot to avoid lock poisoning')
+    const ticket = await store.remember('EPIC-317 xyzzy quux frobnicate')
+    const distractor = await store.remember('the quarterly report is due next Friday')
+    await store.relate(decision, ticket, 'decided_in')
+
+    const fused = await store.recallFused('we chose parking_lot to avoid lock poisoning', 3)
+    assert.ok(Array.isArray(fused) && fused.length >= 1)
+    const rankOf = (id) => fused.findIndex((r) => r.id === id)
+    assert.ok(
+      rankOf(ticket) < rankOf(distractor),
+      'the graph-reached ticket must outrank the disconnected distractor',
+    )
+
+    const withOpts = await store.recallFused('we chose parking_lot to avoid lock poisoning', 1, null, {
+      pool: 1,
+    })
+    assert.equal(withOpts.length, 1, 'the pool override narrows the candidate set')
+    assert.equal(withOpts[0].id, decision, 'a pool of 1 admits only the top vector hit')
+  } finally {
+    cleanup()
+  }
+})
+
 test('recallWhere equals recall with the same exact-match filter', async () => {
   const { store, cleanup } = freshStore()
   try {
@@ -97,7 +124,7 @@ test('recallWhere equals recall with the same exact-match filter', async () => {
   }
 })
 
-test('recallWhere surfaces stored metadata; recall leaves it null', async () => {
+test('recallWhere and recall both surface stored metadata (dated recall)', async () => {
   const { store, cleanup } = freshStore()
   try {
     await store.remember('deployed the new pricing page', [], { ts: 20260701 })
@@ -110,7 +137,7 @@ test('recallWhere surfaces stored metadata; recall leaves it null', async () => 
 
     const hits = await store.recall('pricing page', 5)
     assert.ok(hits.length >= 1)
-    assert.equal(hits[0].metadata, undefined, 'recall does not carry metadata')
+    assert.equal(hits[0].metadata?.ts, 20260701, 'recall round-trips metadata too')
   } finally {
     cleanup()
   }

--- a/crates/velesdb-node/src/convert.rs
+++ b/crates/velesdb-node/src/convert.rs
@@ -3,9 +3,10 @@
 //! both worlds, so the dependency boundary is auditable by inspection.
 
 use serde_json::Value;
-use velesdb_memory::{ColumnFilter, ColumnOp, Link, Metadata};
+use velesdb_memory::limits;
+use velesdb_memory::{ColumnFilter, ColumnOp, FusionOptions, Link, Metadata};
 
-use crate::dto::{ColumnFilterJs, LinkJs};
+use crate::dto::{ColumnFilterJs, FusionOptionsJs, LinkJs};
 use crate::error::invalid_input;
 
 /// Format a `u64` id as a decimal string (JS `number` loses precision >2^53).
@@ -70,4 +71,20 @@ pub fn to_filters(filters: Vec<ColumnFilterJs>) -> napi::Result<Vec<ColumnFilter
             })
         })
         .collect()
+}
+
+/// JS `{hops?, graphBoost?, pool?}` → engine [`FusionOptions`]. An omitted
+/// object, or an omitted field within it, falls back to
+/// [`FusionOptions::default`]'s proven value. `hops` is capped at
+/// [`limits::MAX_WHY_HOPS`], the same `DoS` cap `why()` enforces.
+pub fn to_fusion_options(opts: Option<FusionOptionsJs>) -> FusionOptions {
+    let defaults = FusionOptions::default();
+    let Some(opts) = opts else {
+        return defaults;
+    };
+    FusionOptions {
+        hops: limits::clamp_hops(opts.hops.map_or(defaults.hops, |h| h as usize)),
+        graph_boost: opts.graph_boost.unwrap_or(defaults.graph_boost),
+        pool: opts.pool.map(|p| p as usize).or(defaults.pool),
+    }
 }

--- a/crates/velesdb-node/src/dto.rs
+++ b/crates/velesdb-node/src/dto.rs
@@ -30,6 +30,20 @@ pub struct ColumnFilterJs {
     pub value: Value,
 }
 
+/// Tuning knobs for `recallFused` (input). Every field is optional; an
+/// omitted field falls back to the proven default from
+/// [`velesdb_memory::FusionOptions::default`] (via
+/// [`crate::convert::to_fusion_options`]).
+#[napi(object)]
+pub struct FusionOptionsJs {
+    /// Hops the graph traversal walks from the top vector seed.
+    pub hops: Option<u32>,
+    /// Weight added to a graph-reached fact's normalised vector score.
+    pub graph_boost: Option<f64>,
+    /// Depth of the oversampled vector pool fusion re-ranks.
+    pub pool: Option<u32>,
+}
+
 /// One recalled memory (output of `recall` / `recallWhere`).
 #[napi(object)]
 pub struct RecollectionJs {

--- a/crates/velesdb-node/src/lib.rs
+++ b/crates/velesdb-node/src/lib.rs
@@ -49,7 +49,7 @@ use velesdb_memory::{
     DEFAULT_OLLAMA_MODEL, DEFAULT_OLLAMA_URL,
 };
 
-use crate::dto::{ColumnFilterJs, ExplanationJs, LinkJs, RecollectionJs};
+use crate::dto::{ColumnFilterJs, ExplanationJs, FusionOptionsJs, LinkJs, RecollectionJs};
 use crate::error::{invalid_input, to_napi_err, CODE_INTERNAL};
 use crate::tasks::Job;
 
@@ -181,6 +181,35 @@ impl MemoryStore {
             let k = guards::clamp_limit(k.unwrap_or(10));
             let filters = convert::to_filters(filters)?;
             let hits = svc.recall_where(&query, k, &filters).map_err(to_napi_err)?;
+            Ok(hits.into_iter().map(RecollectionJs::from).collect())
+        }))
+    }
+
+    /// Fused vector + graph recall: like [`recall`](Self::recall), but also
+    /// walks the graph from the top vector hit and promotes any fact it
+    /// reaches into the ranking — the tri-engine ranking measured on
+    /// HotpotQA/TimeQA/LoCoMo, now reachable from Node. `opts` is optional;
+    /// an omitted field falls back to the proven default (`hops: 2`,
+    /// `graphBoost: 0.15`, oversampled pool).
+    #[napi(
+        js_name = "recallFused",
+        ts_return_type = "Promise<Array<RecollectionJs>>"
+    )]
+    pub fn recall_fused(
+        &self,
+        query: String,
+        k: Option<u32>,
+        filter: Option<Value>,
+        opts: Option<FusionOptionsJs>,
+    ) -> AsyncTask<Job<Vec<RecollectionJs>>> {
+        let svc = Arc::clone(&self.inner);
+        AsyncTask::new(Job::new(move || {
+            let k = guards::clamp_limit(k.unwrap_or(10));
+            let filter = convert::to_metadata(filter)?;
+            let opts = convert::to_fusion_options(opts);
+            let hits = svc
+                .recall_fused(&query, k, filter.as_ref(), opts)
+                .map_err(to_napi_err)?;
             Ok(hits.into_iter().map(RecollectionJs::from).collect())
         }))
     }

--- a/crates/velesdb-python/src/agent_memory_service.rs
+++ b/crates/velesdb-python/src/agent_memory_service.rs
@@ -196,8 +196,8 @@ impl PyMemoryService {
 
     /// Recall up to `k` memories similar to `query`, optionally narrowed by an
     /// exact-match metadata `filter`. Returns a list of `{id, score, content, metadata}`
-    /// (`metadata` is always `None` here; only [`recall_where`](Self::recall_where)
-    /// populates it — matches the upstream `Recollection` contract).
+    /// (`metadata` is `None` when the fact carries none, matching the upstream
+    /// `Recollection` contract).
     #[pyo3(signature = (query, k = 10, filter = None))]
     fn recall(
         &self,

--- a/crates/velesdb-python/tests/test_memory_service.py
+++ b/crates/velesdb-python/tests/test_memory_service.py
@@ -108,18 +108,26 @@ def test_recall_where_unknown_op_raises_value_error(mem):
 
 
 def test_recall_where_returns_stored_metadata(mem):
-    # `recall_where` results carry the fact's caller-supplied metadata dict
-    # (unlike `recall`/`why`, which never populate it — see Recollection).
+    # `recall_where` results carry the fact's caller-supplied metadata dict.
     fid = mem.remember("we shipped the release", metadata={"ts": 20260701})
     hits = mem.recall_where("release", [("ts", "eq", 20260701)], k=5)
     hit = next(h for h in hits if h["id"] == fid)
     assert hit["metadata"] == {"ts": 20260701}
 
 
-def test_recall_and_why_never_populate_metadata(mem):
-    # Intentional asymmetry: only `recall_where` echoes stored metadata back.
-    mem.remember("paris is lovely in spring", metadata={"ts": 1})
+def test_recall_also_returns_stored_metadata(mem):
+    # `recall` round-trips caller metadata too (one extra by-id lookup per
+    # hit), not just `recall_where` — enables dated/sorted context from any
+    # recall path.
+    fid = mem.remember("paris is lovely in spring", metadata={"ts": 1})
     hits = mem.recall("paris", k=5)
+    hit = next(h for h in hits if h["id"] == fid)
+    assert hit["metadata"] == {"ts": 1}
+
+
+def test_recall_metadata_is_none_when_the_fact_carries_none(mem):
+    mem.remember("a fact with no metadata")
+    hits = mem.recall("a fact with no metadata", k=5)
     assert all(h["metadata"] is None for h in hits)
 
 


### PR DESCRIPTION
## Summary

The shipped `velesdb-memory`/`velesdb-memory-node` recall path has always been pure vector
search. Every tri-engine fusion win we've measured — vector+graph (+6.9pp both-facts recall,
HotpotQA 3000-Q), idf-weighting (net-positive on LoCoMo multi-hop), dated-recall (+33.6pp
temporal, LoCoMo Phase C, McNemar p=1.8e-28) — lived only in the `examples/locomo` benchmark
harness. `recall()` did vector-only search; `recall_where()` added metadata but no graph;
`why()`'s graph traversal never fed the ranking. Users of the library never got what our own
benchmarks show.

This PR productizes that fusion into the shipped recall path.

- **`MemoryService::recall_fused`** — re-ranks the vector pool against facts the graph reaches
  from the top hit (`fusion.rs`, pure/tested; `fused_recall.rs`, orchestration split out to keep
  `service.rs` under the crate's 500-NLOC budget). A graph-reached fact never evicts a genuinely
  stronger vector hit; it competes on `vector_score/max + graph_boost·weight`.
- **idf weighting** — a link through a rare, specific entity hub outranks one through a generic
  mega-hub, instead of every reached fact carrying the same flat weight.
- **`recall_fused_reranked`** — optional BYO second-stage reranker (`Reranker` trait, mirrors the
  existing `Embedder`/`Extractor` bring-your-own pattern). Never wired in by default — a reranker
  can also hurt out-of-distribution queries, so it's opt-in per call.
- **`FusionOptions`** (`hops`/`graph_boost`/`pool`) lets a caller override the proven defaults
  (`hops: 2`, `graph_boost: 0.15`, oversampled pool).
- **`recall()` and `recall_fused()` now round-trip caller metadata** (one extra by-id lookup via
  new core `SemanticMemory::get_metadata`), closing the gap where only `recall_where()` carried
  it — a caller can date-stamp/sort context from any recall path now, not just the filtered one.
- **Node parity**: `MemoryService.recallFused(query, k, filter, opts)` on
  `@wiscale/velesdb-memory-node`, same conventions (decimal-string ids, `to_napi_err` categories,
  hops clamped to the same DoS cap `why()` enforces).

`recall()`'s default behavior is unchanged — existing callers see no shift; `recall_fused` is a
new, additive method.

## Test plan

- [x] `cargo test -p velesdb-core --features persistence` — 5215 passed, 0 failed (full suite,
      since `semantic_memory.rs` was touched).
- [x] `cargo test -p velesdb-memory` — 32+14+10+13+18+5+10 = new tests include 8 pure fusion-math
      unit tests, 18 `recall_fused` integration tests, 2 `recall()` metadata tests. Nominal/Edge/
      Negative BDD coverage: graph promotion beating a vector-tied distractor, idf ranking a
      rare-hub sibling above a common-hub one, hub exclusion, pool narrowing, reranker reordering
      + error propagation, metadata round-tripping on plain and graph-reached hits.
- [x] `cargo clippy -p velesdb-core -p velesdb-memory -p velesdb-node --lib --tests -- -D warnings
      -D clippy::pedantic` — clean.
- [x] `cargo fmt --check` — clean. Lizard NLOC/CCN — all functions within budget (`service.rs`
      481 NLOC, `fused_recall.rs` 138 NLOC, both well under the 500 file cap).
- [x] Node: real `napi build:debug` + `node --test __test__/*.spec.mjs` — 8 passed, 1 skipped
      (Ollama-gated, unrelated). Updated the two tests whose assertions encoded now-outdated
      contracts (method-surface allowlist, `recall()`'s metadata field).
- [x] Full workspace pre-commit hook (fmt+clippy+undocumented-unsafe+full test suite+secrets) ran
      clean on all 3 commits.