### PR TITLE
fix(memory): patch security, DoS, and ranking bugs found in recall_fused review

### DIFF
--- a/crates/velesdb-core/src/agent/semantic_memory.rs
+++ b/crates/velesdb-core/src/agent/semantic_memory.rs
@@ -542,6 +542,34 @@ impl SemanticMemory {
         Ok(point.payload.as_ref().and_then(Value::as_object).cloned())
     }
 
+    /// Batched [`Self::get_metadata`]: fetches every id in `ids` with a
+    /// single collection lookup, returning results in the same order and
+    /// length as `ids` (an unknown or expired id maps to `None`) — avoids
+    /// the N individual round trips a per-id loop over `get_metadata` would
+    /// cost when a caller needs metadata for a whole batch of hits (e.g.
+    /// `velesdb-memory`'s `recall`/`recall_fused`).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when collection access fails.
+    pub fn get_metadata_batch(
+        &self,
+        ids: &[u64],
+    ) -> Result<Vec<Option<Map<String, Value>>>, AgentMemoryError> {
+        let collection = memory_helpers::get_collection(&self.db, &self.collection_name)?;
+        let points = collection.get(ids);
+        Ok(ids
+            .iter()
+            .zip(points)
+            .map(|(&id, point)| {
+                if self.ttl.is_expired(MemoryKind::Semantic, id) {
+                    return None;
+                }
+                point.and_then(|p| p.payload.as_ref().and_then(Value::as_object).cloned())
+            })
+            .collect())
+    }
+
     /// Lists all live (non-expired) tracked facts as `(id, content)` pairs.
     ///
     /// # Errors

--- a/crates/velesdb-core/src/agent/semantic_memory_tests.rs
+++ b/crates/velesdb-core/src/agent/semantic_memory_tests.rs
@@ -377,6 +377,67 @@ mod tests {
     }
 
     #[test]
+    fn test_get_metadata_batch_matches_individual_calls_order_and_length() {
+        let dir = tempdir().unwrap();
+        let db = Arc::new(Database::open(dir.path()).unwrap());
+        let sm = make_semantic(Arc::clone(&db));
+
+        let mut tagged = serde_json::Map::new();
+        tagged.insert("tag".to_string(), serde_json::json!("science"));
+        sm.store_with_metadata(1, "photosynthesis", &[1.0, 0.0, 0.0, 0.0], &tagged)
+            .unwrap();
+        sm.store(2, "no metadata here", &[0.0, 1.0, 0.0, 0.0])
+            .unwrap();
+
+        let batch = sm.get_metadata_batch(&[1, 2, 404]).unwrap();
+        assert_eq!(batch.len(), 3, "one result per input id, in order");
+        assert_eq!(
+            batch[0].as_ref().and_then(|m| m.get("tag")),
+            Some(&serde_json::json!("science"))
+        );
+        assert!(!batch[1].as_ref().unwrap().contains_key("tag"));
+        assert!(batch[2].is_none(), "unknown id maps to None, not an error");
+    }
+
+    #[test]
+    fn test_get_metadata_batch_handles_a_gap_among_present_ids() {
+        // `store_with_ttl(id, .., 0)` deletes on the spot (see
+        // `test_store_with_ttl_zero_does_not_persist_point`), so id 1 here is
+        // absent from storage entirely by the time the batch runs — the same
+        // "missing id in the middle of the batch" shape a real expired-TTL
+        // gap would produce, without needing a real-time sleep to test it.
+        let dir = tempdir().unwrap();
+        let db = Arc::new(Database::open(dir.path()).unwrap());
+        let sm = make_semantic(Arc::clone(&db));
+
+        sm.store_with_ttl(1, "never actually persisted", &[1.0, 0.0, 0.0, 0.0], 0)
+            .unwrap();
+        sm.store(2, "live", &[0.0, 1.0, 0.0, 0.0]).unwrap();
+
+        let batch = sm.get_metadata_batch(&[1, 2]).unwrap();
+        assert!(batch[0].is_none());
+        assert!(batch[1].is_some());
+    }
+
+    #[test]
+    fn test_get_metadata_batch_excludes_a_durably_expired_id() {
+        let dir = tempdir().unwrap();
+        let db = Arc::new(Database::open(dir.path()).unwrap());
+        let sm = make_semantic(Arc::clone(&db));
+
+        sm.store(1, "will expire", &[1.0, 0.0, 0.0, 0.0]).unwrap();
+        sm.set_ttl_durable(1, 0).unwrap();
+        sm.store(2, "live", &[0.0, 1.0, 0.0, 0.0]).unwrap();
+
+        let batch = sm.get_metadata_batch(&[1, 2]).unwrap();
+        assert!(
+            batch[0].is_none(),
+            "durably-expired id must not surface metadata"
+        );
+        assert!(batch[1].is_some());
+    }
+
+    #[test]
     fn test_list_all_returns_live_facts() {
         let dir = tempdir().unwrap();
         let db = Arc::new(Database::open(dir.path()).unwrap());

--- a/crates/velesdb-memory/src/fused_recall.rs
+++ b/crates/velesdb-memory/src/fused_recall.rs
@@ -4,9 +4,14 @@
 //! child module of `service`, so it freely uses `MemoryService`'s private
 //! fields and methods (`traverse`, `search`, `HUB_FIELD`, …).
 
+use std::collections::HashMap;
+
 use serde_json::Value;
 
-use super::{reject_reserved_keys, MemoryService, Metadata, HUB_FIELD, MENTIONS_RELATION};
+use super::{
+    reject_reserved_keys, strip_reserved_keys, MemoryService, Metadata, HUB_FIELD,
+    MENTIONS_RELATION,
+};
 use crate::embedder::Embedder;
 use crate::error::MemoryError;
 use crate::fusion::{self, Candidate};
@@ -88,7 +93,9 @@ impl<E: Embedder> MemoryService<E> {
         Ok(ranked.into_iter().take(k).collect())
     }
 
-    /// The oversampled vector pool [`Self::recall_fused`] re-ranks.
+    /// The oversampled vector pool [`Self::recall_fused`] re-ranks. One
+    /// batched metadata lookup covers the whole pool (up to hundreds of ids
+    /// at the deepest `pool_depth`), not one round trip per hit.
     fn fused_pool(
         &self,
         embedding: &[f32],
@@ -96,20 +103,40 @@ impl<E: Embedder> MemoryService<E> {
         filter: Option<&Metadata>,
     ) -> Result<Vec<Candidate>, MemoryError> {
         let hits = self.search(embedding, depth, filter)?;
-        hits.into_iter()
-            .map(|(id, score, content)| {
-                Ok(Candidate {
-                    recollection: Recollection {
-                        id,
-                        score,
-                        content,
-                        metadata: self.recall_metadata(id)?,
-                    },
-                    vector_score: f64::from(score),
-                    graph_weight: 0.0,
-                })
+        let ids: Vec<u64> = hits.iter().map(|(id, _, _)| *id).collect();
+        let metadata = self.recall_metadata_batch(&ids)?;
+        Ok(hits
+            .into_iter()
+            .zip(metadata)
+            .map(|((id, score, content), metadata)| Candidate {
+                recollection: Recollection {
+                    id,
+                    score,
+                    content,
+                    metadata,
+                },
+                vector_score: f64::from(score),
+                graph_weight: 0.0,
             })
-            .collect()
+            .collect())
+    }
+
+    /// The caller-supplied metadata for every id in `ids` (reserved system
+    /// keys excluded, `None` per-id when it carries none), in the same
+    /// order — one batched storage round trip, so a `k`- or pool-sized
+    /// result set (here, and in [`MemoryService::recall`]) costs one
+    /// metadata lookup, not `k`/`pool_size` of them.
+    pub(crate) fn recall_metadata_batch(
+        &self,
+        ids: &[u64],
+    ) -> Result<Vec<Option<Metadata>>, MemoryError> {
+        Ok(self
+            .memory
+            .semantic()
+            .get_metadata_batch(ids)?
+            .into_iter()
+            .map(strip_reserved_keys)
+            .collect())
     }
 
     /// Facts the graph reaches (hop ≥ 1) from the query's top vector seed,
@@ -118,6 +145,11 @@ impl<E: Embedder> MemoryService<E> {
     /// generic mega-hub whose connections carry little signal — the idf lever
     /// validated on `HotpotQA` (+5.0pp both-facts-complete) and `LoCoMo` (turns
     /// the graph net-positive on multi-hop, no regression elsewhere).
+    ///
+    /// `filter` is re-checked against every reached fact's own metadata, not
+    /// just the seed: the graph walk is otherwise filter-blind, so a fact
+    /// outside the caller's scope (e.g. a different tenant/project) could
+    /// leak in just by being graph-connected to the seed.
     fn graph_reached(
         &self,
         embedding: &[f32],
@@ -129,9 +161,12 @@ impl<E: Embedder> MemoryService<E> {
             return Ok(Vec::new());
         };
         let explanation = self.traverse(seed_id, seed_content, hops)?;
+        let mut idf_cache: HashMap<u64, f64> = HashMap::new();
         let mut reached = Vec::new();
         for node in &explanation.nodes {
-            if let Some(candidate) = self.reached_candidate(node, &explanation.edges)? {
+            if let Some(candidate) =
+                self.reached_candidate(node, &explanation.edges, filter, &mut idf_cache)?
+            {
                 reached.push(candidate);
             }
         }
@@ -139,24 +174,46 @@ impl<E: Embedder> MemoryService<E> {
     }
 
     /// The graph-reached candidate for `node`, or `None` when it's the seed
-    /// itself (hop 0) or an entity hub (internal scaffolding, never a caller
-    /// fact — split out of [`Self::graph_reached`] to keep that loop's
-    /// complexity within budget).
+    /// itself (hop 0), an entity hub (internal scaffolding, never a caller
+    /// fact), or outside `filter`'s scope — split out of
+    /// [`Self::graph_reached`] to keep that loop's complexity within budget.
+    /// `idf_cache` memoizes [`Self::entity_idf`] per hub across the whole
+    /// traversal (siblings under the same hub would otherwise recompute an
+    /// identical value once per fact).
     fn reached_candidate(
         &self,
         node: &MemoryNode,
         edges: &[MemoryEdge],
+        filter: Option<&Metadata>,
+        idf_cache: &mut HashMap<u64, f64>,
     ) -> Result<Option<Candidate>, MemoryError> {
-        if node.hop == 0 || self.is_hub(node.id)? {
+        if node.hop == 0 {
             return Ok(None);
         }
-        let weight = self.reach_weight(node.id, edges)?;
+        // One raw-payload fetch serves both the hub check and the returned
+        // candidate's metadata — `is_hub` and a second `recall_metadata` call
+        // used to fetch the same payload twice. The hub flag lives under the
+        // reserved `_veles_hub` key, so it must be checked on the *raw*
+        // payload, before `strip_reserved_keys` removes it for the
+        // caller-facing metadata.
+        let raw = self.memory.semantic().get_metadata(node.id)?;
+        if raw
+            .as_ref()
+            .is_some_and(|meta| meta.get(HUB_FIELD) == Some(&Value::Bool(true)))
+        {
+            return Ok(None);
+        }
+        let metadata = strip_reserved_keys(raw);
+        if !matches_filter(metadata.as_ref(), filter) {
+            return Ok(None);
+        }
+        let weight = self.reach_weight(node.id, edges, idf_cache)?;
         Ok(Some(Candidate {
             recollection: Recollection {
                 id: node.id,
                 score: 0.0,
                 content: node.content.clone(),
-                metadata: self.recall_metadata(node.id)?,
+                metadata,
             },
             vector_score: 0.0,
             graph_weight: weight,
@@ -168,15 +225,37 @@ impl<E: Embedder> MemoryService<E> {
     /// edge into it, or a flat `1.0` when it was reached through a direct
     /// (non-hub) [`Self::relate`] edge instead — idf has nothing to weight
     /// there, so the original flat signal is kept.
-    fn reach_weight(&self, fact_id: u64, edges: &[MemoryEdge]) -> Result<f64, MemoryError> {
+    fn reach_weight(
+        &self,
+        fact_id: u64,
+        edges: &[MemoryEdge],
+        idf_cache: &mut HashMap<u64, f64>,
+    ) -> Result<f64, MemoryError> {
         let mut weight: Option<f64> = None;
         for edge in edges {
             if edge.to == fact_id && edge.relation == MENTIONS_RELATION {
-                let idf = self.entity_idf(edge.from)?;
+                let idf = self.cached_entity_idf(edge.from, idf_cache)?;
                 weight = Some(weight.map_or(idf, |w: f64| w.max(idf)));
             }
         }
         Ok(weight.unwrap_or(1.0))
+    }
+
+    /// [`Self::entity_idf`], memoized in `cache` for the lifetime of one
+    /// [`Self::graph_reached`] call — sibling facts under the same hub would
+    /// otherwise each pay a fresh `relations`+`count` store round trip for an
+    /// identical value.
+    fn cached_entity_idf(
+        &self,
+        hub_id: u64,
+        cache: &mut HashMap<u64, f64>,
+    ) -> Result<f64, MemoryError> {
+        if let Some(&idf) = cache.get(&hub_id) {
+            return Ok(idf);
+        }
+        let idf = self.entity_idf(hub_id)?;
+        cache.insert(hub_id, idf);
+        Ok(idf)
     }
 
     /// Normalised inverse document frequency of hub `hub_id`, in `[0, 1]`:
@@ -195,17 +274,22 @@ impl<E: Embedder> MemoryService<E> {
         let (n, d) = (n as f64, degree as f64);
         Ok((n / d).ln() / n.ln())
     }
+}
 
-    /// True when `id` is an entity hub auto-created by
-    /// [`Self::remember_extracted`] (internal scaffolding, never a caller
-    /// fact — recall and graph reach both exclude it).
-    fn is_hub(&self, id: u64) -> Result<bool, MemoryError> {
-        Ok(self
-            .memory
-            .semantic()
-            .get_metadata(id)?
-            .is_some_and(|meta| meta.get(HUB_FIELD) == Some(&Value::Bool(true))))
-    }
+/// True when `filter` is absent, or every key in it matches `metadata`
+/// exactly — the same "all filter keys must match" semantics
+/// [`MemoryService::search`]'s vector-side filtering applies, now also
+/// enforced on graph-reached facts so a caller-scoped `recall_fused` can't
+/// leak a fact outside that scope just because it's graph-connected to the
+/// seed.
+fn matches_filter(metadata: Option<&Metadata>, filter: Option<&Metadata>) -> bool {
+    let Some(filter) = filter else {
+        return true;
+    };
+    let Some(metadata) = metadata else {
+        return false;
+    };
+    filter.iter().all(|(k, v)| metadata.get(k) == Some(v))
 }
 
 /// The oversampled candidate pool depth for a `k`-sized fused recall:

--- a/crates/velesdb-memory/src/fused_recall.rs
+++ b/crates/velesdb-memory/src/fused_recall.rs
@@ -161,11 +161,15 @@ impl<E: Embedder> MemoryService<E> {
             return Ok(Vec::new());
         };
         let explanation = self.traverse(seed_id, seed_content, hops)?;
+        let nodes: Vec<&MemoryNode> = explanation.nodes.iter().filter(|n| n.hop != 0).collect();
+        let ids: Vec<u64> = nodes.iter().map(|n| n.id).collect();
+        let raw_payloads = self.memory.semantic().get_metadata_batch(&ids)?;
+
         let mut idf_cache: HashMap<u64, f64> = HashMap::new();
         let mut reached = Vec::new();
-        for node in &explanation.nodes {
+        for (node, raw) in nodes.into_iter().zip(raw_payloads) {
             if let Some(candidate) =
-                self.reached_candidate(node, &explanation.edges, filter, &mut idf_cache)?
+                self.reached_candidate(node, raw, &explanation.edges, filter, &mut idf_cache)?
             {
                 reached.push(candidate);
             }
@@ -173,30 +177,26 @@ impl<E: Embedder> MemoryService<E> {
         Ok(reached)
     }
 
-    /// The graph-reached candidate for `node`, or `None` when it's the seed
-    /// itself (hop 0), an entity hub (internal scaffolding, never a caller
-    /// fact), or outside `filter`'s scope — split out of
-    /// [`Self::graph_reached`] to keep that loop's complexity within budget.
-    /// `idf_cache` memoizes [`Self::entity_idf`] per hub across the whole
-    /// traversal (siblings under the same hub would otherwise recompute an
-    /// identical value once per fact).
+    /// The graph-reached candidate for `node` given its already-fetched raw
+    /// payload `raw`, or `None` when it's an entity hub (internal
+    /// scaffolding, never a caller fact) or outside `filter`'s scope — split
+    /// out of [`Self::graph_reached`] to keep that loop's complexity within
+    /// budget. `raw` is fetched once, batched across the whole traversal, by
+    /// the caller — not per node — and serves both the hub check and the
+    /// returned candidate's metadata: the hub flag lives under the reserved
+    /// `_veles_hub` key, so it must be checked before `strip_reserved_keys`
+    /// removes it for the caller-facing metadata. `idf_cache` memoizes
+    /// [`Self::entity_idf`] per hub across the whole traversal (siblings
+    /// under the same hub would otherwise recompute an identical value once
+    /// per fact).
     fn reached_candidate(
         &self,
         node: &MemoryNode,
+        raw: Option<Metadata>,
         edges: &[MemoryEdge],
         filter: Option<&Metadata>,
         idf_cache: &mut HashMap<u64, f64>,
     ) -> Result<Option<Candidate>, MemoryError> {
-        if node.hop == 0 {
-            return Ok(None);
-        }
-        // One raw-payload fetch serves both the hub check and the returned
-        // candidate's metadata — `is_hub` and a second `recall_metadata` call
-        // used to fetch the same payload twice. The hub flag lives under the
-        // reserved `_veles_hub` key, so it must be checked on the *raw*
-        // payload, before `strip_reserved_keys` removes it for the
-        // caller-facing metadata.
-        let raw = self.memory.semantic().get_metadata(node.id)?;
         if raw
             .as_ref()
             .is_some_and(|meta| meta.get(HUB_FIELD) == Some(&Value::Bool(true)))
@@ -286,6 +286,13 @@ fn matches_filter(metadata: Option<&Metadata>, filter: Option<&Metadata>) -> boo
     let Some(filter) = filter else {
         return true;
     };
+    // Mirrors velesdb-core's `payload_matches`: an empty (not absent) filter
+    // matches everything, including a metadata-less fact — `Some({})` from a
+    // caller (e.g. a JS `recallFused(q, k, {})`) must behave exactly like
+    // `None`, not like "reject anything without metadata".
+    if filter.is_empty() {
+        return true;
+    }
     let Some(metadata) = metadata else {
         return false;
     };
@@ -294,7 +301,13 @@ fn matches_filter(metadata: Option<&Metadata>, filter: Option<&Metadata>) -> boo
 
 /// The oversampled candidate pool depth for a `k`-sized fused recall:
 /// `opts.pool` if the caller set one, else the proven default
-/// ([`fusion::pool_size`]).
+/// ([`fusion::pool_size`]) — either way, capped at
+/// [`crate::limits::MAX_RECALL_LIMIT`], the same `DoS` ceiling `k`/`hops`
+/// carry. The cap lives here, not just at each binding's FFI boundary: the
+/// *default* pool (`k.saturating_mul(8)`) exceeds it well before `k` itself
+/// reaches its own cap, so a caller who never touches `pool` at all — not
+/// just one who sets it explicitly — must still be bounded.
 fn pool_depth(k: usize, opts: FusionOptions) -> usize {
-    opts.pool.unwrap_or_else(|| fusion::pool_size(k))
+    let depth = opts.pool.unwrap_or_else(|| fusion::pool_size(k));
+    crate::limits::clamp_recall_limit(depth)
 }

--- a/crates/velesdb-memory/src/fusion.rs
+++ b/crates/velesdb-memory/src/fusion.rs
@@ -82,8 +82,22 @@ pub(crate) fn fuse(
     candidates.into_iter().map(|c| c.recollection).collect()
 }
 
-/// `vector_score/max_score + graph_boost·graph_weight`. A pure vector hit
-/// (`graph_weight` absent from `weights`) keeps its bare normalised similarity.
+/// `max(vector_score, 0)/max_score + graph_boost·graph_weight`. A pure
+/// vector hit (`graph_weight` absent from `weights`) keeps its bare
+/// normalised similarity.
+///
+/// The numerator is floored at `0`, not just the divisor: Cosine scores
+/// range over `[-1, 1]`, so a negative `vector_score` is a legitimate,
+/// in-range "dissimilar" result, not an error state — dividing a negative
+/// numerator by an epsilon-floored *positive* divisor would otherwise invert
+/// its sign into an unbounded negative score (regression: an all-negative
+/// pool scored around `-2.3e14`, dwarfing any `graph_boost` regardless of
+/// actual relevance). Flooring the numerator instead means a fact with no
+/// positive vector signal contributes `0` — the same neutral baseline a
+/// graph-only candidate (`vector_score = 0.0`) already gets — so it can
+/// still be promoted by a real graph connection, but by the same bounded
+/// margin as any other zero-vector-signal candidate, never by an
+/// astronomical, sign-flipped one.
 fn fused_score(
     candidate: &Candidate,
     weights: &HashMap<u64, f64>,
@@ -94,7 +108,7 @@ fn fused_score(
         .get(&candidate.recollection.id)
         .copied()
         .unwrap_or(0.0);
-    candidate.vector_score / max_score + graph_boost * weight
+    candidate.vector_score.max(0.0) / max_score + graph_boost * weight
 }
 
 #[cfg(test)]

--- a/crates/velesdb-memory/src/fusion_tests.rs
+++ b/crates/velesdb-memory/src/fusion_tests.rs
@@ -93,3 +93,39 @@ fn test_fuse_empty_pool_and_reached_yields_empty() {
     let ranked = fuse(Vec::new(), &[], 5, 0.15);
     assert!(ranked.is_empty());
 }
+
+#[test]
+fn test_fuse_negative_vector_score_never_beats_a_stronger_positive_one() {
+    // Regression: Cosine scores range over [-1, 1], so a negative
+    // vector_score is a normal, in-range "dissimilar" result, not an error
+    // state. The old normalization divided it by a positive epsilon-floored
+    // divisor, producing an unbounded negative fused score (observed
+    // ~-2.3e14 for a realistic Cosine value) — nonsensical in scale, but
+    // more importantly the fix must not let a *weak positive* signal lose to
+    // a *negative* one just because both get divided by the same max_score.
+    let pool = vec![candidate(1, 0.05, 0.0), candidate(2, -0.9, 0.0)];
+    let ranked = fuse(pool, &[], 2, 0.15);
+    assert_eq!(
+        ranked.iter().map(|r| r.id).collect::<Vec<_>>(),
+        vec![1, 2],
+        "a positive (even weak) vector score must outrank a negative one"
+    );
+}
+
+#[test]
+fn test_fuse_all_negative_pool_ties_at_a_neutral_baseline_not_an_inverted_extreme() {
+    // A negative vector_score is floored to 0 before normalising — the same
+    // neutral baseline a graph-only candidate (vector_score = 0.0) already
+    // carries — rather than propagating its sign through the division. Two
+    // different negative scores therefore both land at fused_score = 0 (a
+    // stable sort keeps their relative pool order), never at astronomically
+    // different, sign-flipped magnitudes.
+    let pool = vec![candidate(1, -0.05, 0.0), candidate(2, -0.9, 0.0)];
+    let reached = vec![candidate(3, 0.0, 1.0)];
+    let ranked = fuse(pool, &reached, 3, 0.15);
+    assert_eq!(
+        ranked.iter().map(|r| r.id).collect::<Vec<_>>(),
+        vec![3, 1, 2],
+        "the graph-reached candidate outranks the tied, neutral-baseline negative pool (stable order preserved)"
+    );
+}

--- a/crates/velesdb-memory/src/service.rs
+++ b/crates/velesdb-memory/src/service.rs
@@ -354,10 +354,10 @@ impl<E: Embedder> MemoryService<E> {
     /// when the fact carries none) — store a date field (e.g. `occurred_at`)
     /// and it round-trips here, so a caller can sort the result into a
     /// chronological, date-stamped context without `recall_where`'s explicit
-    /// filters. This costs one extra lookup per returned hit.
+    /// filters. One extra, single batched lookup covers every returned hit.
     ///
     /// # Errors
-    /// Returns [`MemoryError`] if the semantic query or a metadata lookup fails.
+    /// Returns [`MemoryError`] if the semantic query or the metadata lookup fails.
     pub fn recall(
         &self,
         query: &str,
@@ -371,30 +371,18 @@ impl<E: Embedder> MemoryService<E> {
         reject_reserved_keys(filter)?;
         let embedding = self.embedder.embed(query)?;
         let hits = self.search(&embedding, k, filter)?;
-        hits.into_iter()
-            .map(|(id, score, content)| {
-                Ok(Recollection {
-                    id,
-                    score,
-                    content,
-                    metadata: self.recall_metadata(id)?,
-                })
+        let ids: Vec<u64> = hits.iter().map(|(id, _, _)| *id).collect();
+        let metadata = self.recall_metadata_batch(&ids)?;
+        Ok(hits
+            .into_iter()
+            .zip(metadata)
+            .map(|((id, score, content), metadata)| Recollection {
+                id,
+                score,
+                content,
+                metadata,
             })
-            .collect()
-    }
-
-    /// The caller-supplied metadata for memory `id` (reserved system keys
-    /// excluded), or `None` when it carries none. Shared by every recall path
-    /// so a fact's metadata round-trips regardless of which one a caller uses.
-    fn recall_metadata(&self, id: u64) -> Result<Option<Metadata>, MemoryError> {
-        let payload = self.memory.semantic().get_metadata(id)?;
-        Ok(payload.and_then(|payload| {
-            let metadata: Metadata = payload
-                .into_iter()
-                .filter(|(key, _)| !is_reserved_key(key))
-                .collect();
-            (!metadata.is_empty()).then_some(metadata)
-        }))
+            .collect())
     }
 
     /// Vector search for up to `k` ids, optionally narrowed by a metadata
@@ -638,6 +626,20 @@ fn hub_exclude_filter() -> Metadata {
 /// they can't overwrite a system field or collide with internal scaffolding.
 fn is_reserved_key(key: &str) -> bool {
     key == "content" || key.starts_with("_veles_")
+}
+
+/// Drop reserved system keys from a raw payload, and collapse an
+/// empty-after-stripping map to `None` — the caller-facing shape every
+/// `Recollection::metadata` is built from, regardless of which recall path
+/// (single or batched) fetched the raw payload.
+fn strip_reserved_keys(payload: Option<Metadata>) -> Option<Metadata> {
+    payload.and_then(|payload| {
+        let metadata: Metadata = payload
+            .into_iter()
+            .filter(|(key, _)| !is_reserved_key(key))
+            .collect();
+        (!metadata.is_empty()).then_some(metadata)
+    })
 }
 
 /// Reject caller-supplied metadata/filters that name a reserved key.

--- a/crates/velesdb-memory/tests/recall_fused_bdd.rs
+++ b/crates/velesdb-memory/tests/recall_fused_bdd.rs
@@ -511,6 +511,28 @@ fn recall_fused_never_leaks_a_graph_reached_fact_outside_the_caller_filter() {
     );
 }
 
+#[test]
+fn recall_fused_empty_filter_map_matches_a_graph_reached_fact_with_no_metadata() {
+    // Regression: an empty-but-present filter (`Some({})`, e.g. a JS caller
+    // doing `recallFused(q, k, {})`) must behave exactly like `None` — match
+    // everything, including a graph-reached fact that carries no metadata at
+    // all — mirroring velesdb-core's `payload_matches` convention. The graph
+    // filter check must not read "empty filter" as "reject anything without
+    // metadata".
+    let (_dir, svc) = service();
+    let (_decision, _pr, ticket) = seeded_chain(&svc);
+
+    let empty_filter = velesdb_memory::Metadata::new();
+    let fused = svc
+        .recall_fused(DECISION, 5, Some(&empty_filter), FusionOptions::default())
+        .expect("recall_fused");
+    assert!(
+        fused.iter().any(|r| r.id == ticket),
+        "an empty filter map must match a graph-reached fact with no metadata, \
+         same as no filter at all"
+    );
+}
+
 // --- Negative ------------------------------------------------------------
 
 #[test]

--- a/crates/velesdb-memory/tests/recall_fused_bdd.rs
+++ b/crates/velesdb-memory/tests/recall_fused_bdd.rs
@@ -279,7 +279,8 @@ fn recall_fused_ranks_graph_reached_fact_above_a_vector_tied_distractor() {
         .expect("recall_fused");
     let rank_of = |id: u64| fused.iter().position(|r| r.id == id);
     assert!(
-        rank_of(ticket) < rank_of(distractor),
+        rank_of(ticket).expect("graph-reached ticket must be present")
+            < rank_of(distractor).expect("distractor must be present"),
         "the graph-reached fact must outrank the vector-tied distractor"
     );
 }
@@ -475,6 +476,39 @@ fn recall_fused_zero_k_is_empty() {
         .recall_fused(DECISION, 0, None, FusionOptions::default())
         .expect("recall_fused");
     assert!(fused.is_empty());
+}
+
+#[test]
+fn recall_fused_never_leaks_a_graph_reached_fact_outside_the_caller_filter() {
+    // Regression: the graph walk used to be filter-blind past the seed, so a
+    // fact outside the caller's scope (a different tenant here) could leak
+    // in just by being graph-connected to the seed — a cross-tenant read.
+    let (_dir, svc) = service();
+    let mut alice_meta = velesdb_memory::Metadata::new();
+    alice_meta.insert("tenant".to_string(), Value::String("alice".to_string()));
+    let alice_fact = svc
+        .remember(DECISION, &[], Some(&alice_meta))
+        .expect("remember alice fact");
+
+    let mut bob_meta = velesdb_memory::Metadata::new();
+    bob_meta.insert("tenant".to_string(), Value::String("bob".to_string()));
+    let bob_fact = svc
+        .remember("EPIC-317 xyzzy quux frobnicate", &[], Some(&bob_meta))
+        .expect("remember bob fact");
+    svc.relate(alice_fact, bob_fact, "related_to")
+        .expect("relate");
+
+    let fused = svc
+        .recall_fused(DECISION, 5, Some(&alice_meta), FusionOptions::default())
+        .expect("recall_fused");
+    assert!(
+        fused.iter().all(|r| r.id != bob_fact),
+        "a graph-reached fact outside the tenant filter must not leak into the result"
+    );
+    assert!(
+        fused.iter().any(|r| r.id == alice_fact),
+        "the in-scope seed fact must still be returned"
+    );
 }
 
 // --- Negative ------------------------------------------------------------

--- a/crates/velesdb-node/__test__/index.spec.mjs
+++ b/crates/velesdb-node/__test__/index.spec.mjs
@@ -92,7 +92,11 @@ test('recallFused surfaces a graph-connected fact plain recall ranks low', async
 
     const fused = await store.recallFused('we chose parking_lot to avoid lock poisoning', 3)
     assert.ok(Array.isArray(fused) && fused.length >= 1)
-    const rankOf = (id) => fused.findIndex((r) => r.id === id)
+    const rankOf = (id) => {
+      const index = fused.findIndex((r) => r.id === id)
+      assert.notEqual(index, -1, `expected id ${id} to be present in the fused results`)
+      return index
+    }
     assert.ok(
       rankOf(ticket) < rankOf(distractor),
       'the graph-reached ticket must outrank the disconnected distractor',

--- a/crates/velesdb-node/src/convert.rs
+++ b/crates/velesdb-node/src/convert.rs
@@ -75,8 +75,11 @@ pub fn to_filters(filters: Vec<ColumnFilterJs>) -> napi::Result<Vec<ColumnFilter
 
 /// JS `{hops?, graphBoost?, pool?}` → engine [`FusionOptions`]. An omitted
 /// object, or an omitted field within it, falls back to
-/// [`FusionOptions::default`]'s proven value. `hops` is capped at
-/// [`limits::MAX_WHY_HOPS`], the same `DoS` cap `why()` enforces.
+/// [`FusionOptions::default`]'s proven value. `hops` and `pool` are each
+/// capped at their shared `DoS` limit ([`limits::MAX_WHY_HOPS`],
+/// [`limits::MAX_RECALL_LIMIT`]) — `pool` feeds the same oversampled vector
+/// search `k`/`hops` do, so an uncapped caller-supplied value is exactly as
+/// much of an unbounded-scan risk as an uncapped `k` or `hops` would be.
 pub fn to_fusion_options(opts: Option<FusionOptionsJs>) -> FusionOptions {
     let defaults = FusionOptions::default();
     let Some(opts) = opts else {
@@ -85,6 +88,9 @@ pub fn to_fusion_options(opts: Option<FusionOptionsJs>) -> FusionOptions {
     FusionOptions {
         hops: limits::clamp_hops(opts.hops.map_or(defaults.hops, |h| h as usize)),
         graph_boost: opts.graph_boost.unwrap_or(defaults.graph_boost),
-        pool: opts.pool.map(|p| p as usize).or(defaults.pool),
+        pool: opts
+            .pool
+            .map(|p| limits::clamp_recall_limit(p as usize))
+            .or(defaults.pool),
     }
 }

--- a/crates/velesdb-node/src/dto.rs
+++ b/crates/velesdb-node/src/dto.rs
@@ -53,9 +53,10 @@ pub struct RecollectionJs {
     pub score: f64,
     /// Stored fact content.
     pub content: String,
-    /// Caller-supplied structured metadata stored with the fact, or `undefined`
-    /// when the fact carries none (`recall`/`why` never populate this; only
-    /// `recallWhere` does).
+    /// Caller-supplied structured metadata stored with the fact, or
+    /// `undefined` when the fact carries none. `recall`, `recallWhere`, and
+    /// `recallFused` all populate this; `why()`'s subgraph nodes don't carry
+    /// metadata (a different shape, `MemoryNodeJs`).
     pub metadata: Option<Value>,
 }
 


### PR DESCRIPTION
## Summary

A retroactive `/code-review` pass on the just-merged fused-recall feature (#1308) surfaced 12 findings; this PR fixes all of them, then went through 2 more review rounds (per the standing rule: every fix-round on a review-gated PR needs its own re-review) which found 3 more real bugs — 15 fixed total, 0 findings on the final round.

**Round 1 — Critical (fixed):**
- `recall_fused`'s metadata `filter` only scoped the vector seed search, never the graph traversal — a fact outside the caller's filter (e.g. a different tenant) could leak into results via a graph connection to the seed. Now checked on every reached fact.
- `FusionOptionsJs.pool` (Node) had no upper-bound clamp, unlike its sibling `k`/`hops` fields — an unbounded caller value drove an unbounded vector fetch.
- `fuse()`'s score normalization divided a negative `vector_score` (a normal, in-range Cosine result) by a positive epsilon-floored divisor, inverting its sign into an astronomical magnitude that let any graph-reached candidate always outrank the whole pool regardless of relevance. Numerator is now floored at 0 before dividing.

**Round 1 — Test-quality & efficiency (fixed):**
- Two test assertions compared `Option`/`-1` "not found" sentinels as valid ranks, so a future "candidate silently dropped" regression would pass instead of fail.
- Stale doc comment on `RecollectionJs.metadata` (Node).
- `recall()`/`recall_fused`'s per-hit metadata fetches batched into one storage round trip (new `SemanticMemory::get_metadata_batch`).
- `reached_candidate` no longer double-fetches a graph-reached fact's metadata (hub check + candidate metadata now share one fetch).
- `entity_idf` memoized per hub within one `graph_reached` traversal.

**Round 2 — found on review of round 1's own fixes (fixed):**
- `matches_filter()` (the round-1 filter-leak fix) diverged from `velesdb-core`'s `payload_matches()` on an empty-but-present filter (`Some({})`): it rejected any graph-reached fact with no metadata instead of matching everything, same as an absent filter — reachable from a JS caller doing `recallFused(query, k, {})`.
- The round-1 pool DoS cap only applied when a caller set `FusionOptions.pool` explicitly — the *default* depth (`k * 8`, uncapped) could still reach 8000+ for a caller who never touches `pool` at all. Now clamped inside `pool_depth()` itself, protecting every caller (Rust, Node, MCP, future Python) uniformly instead of only the Node FFI boundary.
- `graph_reached`'s per-node metadata fetch was still one round trip per node in a loop, inconsistent with the sibling `fused_pool()`/`recall()` paths round 1 already batched. Restructured to one batched call covering the whole traversal.

**Round 3 (verification only):** 0 findings — scoped review of the round-2 diff, nothing survived verification.

**Deliberately not changed (reasoned, not silent):**
- `recall()`'s per-hit metadata fetch failing aborts the whole call rather than degrading gracefully. With batching this is now a single round trip, not N — and propagating a genuine storage error is the more honest failure mode than silently dropping data.
- `recall_fused`/`recall_fused_reranked` are Node-only, not yet on Python or the MCP tool surface. This was the original B5 scope (Node parity), not a defect in shipped code — extending to Python/MCP is new feature surface, tracked as follow-up.

## Test plan

- [x] `cargo test -p velesdb-memory` — 111/111 pass (incl. new regression tests for the filter-leak, negative-score, and empty-filter bugs)
- [x] `cargo test -p velesdb-core --features persistence` — 5218/5218 pass
- [x] `cargo clippy --all-targets -- -D warnings -D clippy::pedantic` clean on core, memory, node
- [x] `npm run build && npm test` (velesdb-node) — 8/8 pass
- [x] `maturin develop --release && pytest` (velesdb-python) — 403/403 pass
- [x] `lizard` — all touched files within NLOC≤500/CCN≤8 budget
- [x] Pre-commit hook (full workspace, 580-603 tests) — green on every commit
- [x] 3 `/code-review` rounds: 12 findings → fixed → 3 findings → fixed → **0 findings**