### PR TITLE
feat(wasm): memory wedge in the browser — MemoryStore trait, WASM backend, TS SDK

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -101,6 +101,15 @@ exclude_paths:
   - "sdks/typescript/src/errors.ts"
   - "sdks/typescript/src/filter.ts"
   - "sdks/typescript/src/client/validation.ts"
+  # memory.ts (memory-wedge MemoryService): same base `no-unused-vars` FP on
+  # the parameter names of the internal `WasmMemoryServiceInstance` interface
+  # (pure type-position signatures describing the wasm-bindgen surface). Its
+  # genuine findings (require-await on await-less async methods, a void-
+  # expression return) were FIXED in code (methods return Promises without the
+  # async keyword; wrapWasmCall lifts sync throws into rejections), so the
+  # file carries ONLY the FP class and qualifies for exclusion per the policy
+  # above.
+  - "sdks/typescript/src/memory.ts"
   # Integration contains_text_search helpers — Codacy's online taint analysis
   # flags VelesQL query construction as SQL injection. All user inputs are
   # sanitized BEFORE the query is built:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -270,7 +270,7 @@ jobs:
   # ===========================================================================
 
   # ===========================================================================
-  # WASM Build Check (compile-only, no tests — fast gate)
+  # WASM Build Check (compile check + wasm-bindgen test suites)
   # NOTE: compat-matrix.yml also checks WASM; this job provides a dedicated
   # signal visible in the ci-success summary.
   # ===========================================================================
@@ -295,6 +295,18 @@ jobs:
 
       - name: Check WASM build (no default features)
         run: cargo check -p velesdb-wasm --no-default-features --target wasm32-unknown-unknown
+
+      # The wasm-bindgen suites (tests/*.rs gated on target_arch = "wasm32",
+      # e.g. memory_wedge_web.rs's JS-marshalling regression tests) compile
+      # to empty binaries under the native test job and are invisible to the
+      # cargo check above — without this step they never run in CI at all.
+      - name: Install wasm-pack
+        uses: taiki-e/install-action@9bcaee1dcae34154180f412e2fa69355a7cda9f6 # v2.82.6
+        with:
+          tool: wasm-pack
+
+      - name: Run wasm-bindgen tests (Node)
+        run: wasm-pack test --node crates/velesdb-wasm
 
   # ===========================================================================
   # OpenAPI Drift Check

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6882,6 +6882,7 @@ dependencies = [
  "serde-wasm-bindgen",
  "serde_json",
  "velesdb-core",
+ "velesdb-memory",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-bindgen-test",

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ mem.why("why the aisle seat on Robert's flight?")   # walks booking → reason �
 
 Memories are permanent by default; `forget(id)` deletes one, and `remember(…, ttl_seconds=…)` (or a server-wide `VELESDB_MEMORY_DEFAULT_TTL`) gives a fact a durable, restart-surviving expiry.
 
-The same wedge ships in **Python** (`pip install velesdb`), **Node** (`npm i @wiscale/velesdb-memory-node`), and as a local **[MCP server](crates/velesdb-memory)**.
+The same wedge ships in **Python** (`pip install velesdb`), **Node** (`npm i @wiscale/velesdb-memory-node`), as a local **[MCP server](crates/velesdb-memory)**, and — in-memory only, no disk access under WASM — in the **[TypeScript SDK](sdks/typescript)** (`npm i @wiscale/velesdb-sdk`), running entirely in the browser or Node.js with no server.
 
 **Four runnable ways to see it** — each shows what plain vector recall misses and `why()` recovers:
 
@@ -544,6 +544,7 @@ Ship AI features without a server. VelesDB embeds directly into Tauri, iOS, and 
 | **WASM** | [velesdb-wasm](crates/velesdb-wasm) — Browser-side vector search | `npm install @wiscale/velesdb-wasm` |
 | **Agent memory (MCP)** | [velesdb-memory](crates/velesdb-memory) — local-first MCP memory server (`why()` wedge) | `cargo install velesdb-memory` |
 | **Agent memory (Node)** | [velesdb-node](crates/velesdb-node) — in-process napi binding of the memory wedge | `npm install @wiscale/velesdb-memory-node` |
+| **Agent memory (TS/WASM)** | [typescript-sdk](sdks/typescript) `MemoryService` — the wedge in the browser or Node.js, in-memory only (no disk under WASM) | `npm install @wiscale/velesdb-sdk` |
 | **Mobile** | [velesdb-mobile](crates/velesdb-mobile) — iOS (Swift) & Android (Kotlin) | [Build instructions](docs/guides/INSTALLATION.md#-mobile-iosandroid) |
 | **Desktop** | [tauri-plugin](crates/tauri-plugin-velesdb) — Tauri v2 AI-powered apps | `cargo add tauri-plugin-velesdb` |
 | **LangChain** | [langchain-velesdb](integrations/langchain) — Official VectorStore | [From source](integrations/langchain/README.md) |

--- a/crates/velesdb-memory/Cargo.toml
+++ b/crates/velesdb-memory/Cargo.toml
@@ -19,7 +19,11 @@ categories = ["database", "command-line-utilities"]
 exclude = ["media/"]
 
 [dependencies]
-velesdb-core = { workspace = true, features = ["persistence"] }
+# `persistence` is NOT requested unconditionally here — see the `persistence`
+# feature below. A hardcoded `features = ["persistence"]` would force it on
+# for every consumer (Cargo unions requested features workspace-wide), even
+# one like velesdb-wasm that explicitly disables it to stay off tokio/mio.
+velesdb-core = { workspace = true, default-features = false }
 thiserror = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -36,10 +40,16 @@ tokio = { workspace = true, optional = true }
 ureq = { version = "2", optional = true, default-features = false }
 
 [features]
-# The MCP server transport + binary. On by default so `cargo build` produces the
-# server; library consumers disable it to drop the rmcp/tokio server stack.
-default = ["mcp"]
-mcp = ["dep:rmcp", "dep:tokio"]
+# The MCP server transport + binary, and the native file-backed store, are on
+# by default so `cargo build` produces the server; library consumers disable
+# defaults to pick only what they need.
+default = ["mcp", "persistence"]
+mcp = ["dep:rmcp", "dep:tokio", "persistence"]
+# NativeStore, the file-backed MemoryStore (velesdb-core's Database/AgentMemory
+# — tokio/mio/memmap2). On by default; a backend with its own MemoryStore impl
+# (e.g. velesdb-wasm's in-memory one) builds with `default-features = false`
+# and omits this, so those heavy deps never enter its dependency graph.
+persistence = ["velesdb-core/persistence"]
 # Real on-device semantic recall via a local Ollama embeddings endpoint. Off by
 # default so the shipped binary stays tiny, zero-dependency, and fully offline.
 ollama = ["dep:ureq"]

--- a/crates/velesdb-memory/src/error.rs
+++ b/crates/velesdb-memory/src/error.rs
@@ -76,6 +76,21 @@ pub enum MemoryError {
     /// or contained non-printable characters.
     #[error("invalid relation label: {0}")]
     InvalidRelation(String),
+
+    /// A `remember` link failed after the fact was stored AND the
+    /// compensating rollback delete also failed — unlike every other error
+    /// from `remember`, the fact **remains stored**. Both errors are
+    /// carried so the caller can see why the write failed and why the
+    /// cleanup couldn't undo it.
+    #[error(
+        "link failed ({cause}); rollback delete also failed ({rollback}) — the fact remains stored"
+    )]
+    RollbackFailed {
+        /// The link failure that triggered the rollback.
+        cause: Box<MemoryError>,
+        /// The storage failure that prevented the rollback delete.
+        rollback: Box<MemoryError>,
+    },
 }
 
 impl MemoryError {
@@ -95,6 +110,9 @@ impl MemoryError {
             Self::Storage(_) | Self::Embed(_) | Self::Extract(_) | Self::Rerank(_) => {
                 ErrorCategory::Internal
             }
+            // The rollback failure is the storage-level fault that matters
+            // to a client: the write is in an unexpected state.
+            Self::RollbackFailed { .. } => ErrorCategory::Internal,
         }
     }
 }

--- a/crates/velesdb-memory/src/error.rs
+++ b/crates/velesdb-memory/src/error.rs
@@ -82,6 +82,11 @@ pub enum MemoryError {
     /// from `remember`, the fact **remains stored**. Both errors are
     /// carried so the caller can see why the write failed and why the
     /// cleanup couldn't undo it.
+    ///
+    /// Neither field is `#[source]` — deliberately: the `Display` message
+    /// already embeds both errors, and a source chain would double-print
+    /// them in chain-style reports (anyhow, miette). Match on the variant
+    /// to inspect the two errors programmatically.
     #[error(
         "link failed ({cause}); rollback delete also failed ({rollback}) — the fact remains stored"
     )]

--- a/crates/velesdb-memory/src/error.rs
+++ b/crates/velesdb-memory/src/error.rs
@@ -1,5 +1,6 @@
 //! Error type for the memory layer.
 
+#[cfg(feature = "persistence")]
 use velesdb_core::agent::AgentMemoryError;
 use velesdb_core::Error as CoreError;
 
@@ -28,7 +29,11 @@ pub enum MemoryError {
     #[error("storage error: {0}")]
     Storage(#[from] CoreError),
 
-    /// Failure in the Agent Memory SDK.
+    /// Failure in the Agent Memory SDK. Only constructible with the
+    /// `persistence` feature (the native, file-backed store) — a
+    /// `persistence`-free backend (e.g. `velesdb-wasm`'s in-memory one) never
+    /// touches `velesdb-core`'s `agent` module, so this variant can't arise.
+    #[cfg(feature = "persistence")]
     #[error("memory error: {0}")]
     Memory(#[from] AgentMemoryError),
 
@@ -85,11 +90,11 @@ impl MemoryError {
             | Self::InvalidFilter(_)
             | Self::InvalidRelation(_) => ErrorCategory::InvalidInput,
             Self::UnknownMemory(_) => ErrorCategory::NotFound,
-            Self::Storage(_)
-            | Self::Memory(_)
-            | Self::Embed(_)
-            | Self::Extract(_)
-            | Self::Rerank(_) => ErrorCategory::Internal,
+            #[cfg(feature = "persistence")]
+            Self::Memory(_) => ErrorCategory::Internal,
+            Self::Storage(_) | Self::Embed(_) | Self::Extract(_) | Self::Rerank(_) => {
+                ErrorCategory::Internal
+            }
         }
     }
 }

--- a/crates/velesdb-memory/src/fused_recall.rs
+++ b/crates/velesdb-memory/src/fused_recall.rs
@@ -17,8 +17,9 @@ use crate::error::MemoryError;
 use crate::fusion::{self, Candidate};
 use crate::model::{FusionOptions, MemoryEdge, MemoryNode, Recollection};
 use crate::rerank::Reranker;
+use crate::storage::MemoryStore;
 
-impl<E: Embedder> MemoryService<E> {
+impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
     /// Fused recall: like [`Self::recall`], but also walks the graph from the
     /// query's top vector hit and folds any fact it reaches (hop ≥ 1) into the
     /// ranking, scored by `opts.graph_boost · graph_weight` on top of its
@@ -131,8 +132,7 @@ impl<E: Embedder> MemoryService<E> {
         ids: &[u64],
     ) -> Result<Vec<Option<Metadata>>, MemoryError> {
         Ok(self
-            .memory
-            .semantic()
+            .store
             .get_metadata_batch(ids)?
             .into_iter()
             .map(strip_reserved_keys)
@@ -163,7 +163,7 @@ impl<E: Embedder> MemoryService<E> {
         let explanation = self.traverse(seed_id, seed_content, hops)?;
         let nodes: Vec<&MemoryNode> = explanation.nodes.iter().filter(|n| n.hop != 0).collect();
         let ids: Vec<u64> = nodes.iter().map(|n| n.id).collect();
-        let raw_payloads = self.memory.semantic().get_metadata_batch(&ids)?;
+        let raw_payloads = self.store.get_metadata_batch(&ids)?;
 
         let mut idf_cache: HashMap<u64, f64> = HashMap::new();
         let mut reached = Vec::new();
@@ -265,8 +265,8 @@ impl<E: Embedder> MemoryService<E> {
     /// (`examples/locomo/ingest.rs`), using the store's total memory count
     /// (facts + hubs) as a corpus-size proxy.
     fn entity_idf(&self, hub_id: u64) -> Result<f64, MemoryError> {
-        let degree = self.memory.semantic().relations(hub_id)?.len();
-        let n = self.memory.semantic().count();
+        let degree = self.store.relations(hub_id)?.len();
+        let n = self.store.count();
         if degree == 0 || n <= 1 {
             return Ok(0.0);
         }

--- a/crates/velesdb-memory/src/lib.rs
+++ b/crates/velesdb-memory/src/lib.rs
@@ -58,12 +58,24 @@ pub mod storage;
 /// SDK's own default so the server, library, and tests never restate the
 /// value. `velesdb_core::agent` (where the canonical constant lives) is
 /// itself `persistence`-gated, so a `persistence`-free build (e.g.
-/// `velesdb-wasm`) falls back to a literal that must be kept in sync with
-/// `velesdb_core::agent::DEFAULT_DIMENSION` (currently `384`).
+/// `velesdb-wasm`) falls back to [`FALLBACK_DIMENSION`].
 #[cfg(feature = "persistence")]
 pub const DEFAULT_DIMENSION: usize = velesdb_core::agent::DEFAULT_DIMENSION;
 #[cfg(not(feature = "persistence"))]
-pub const DEFAULT_DIMENSION: usize = 384;
+pub const DEFAULT_DIMENSION: usize = FALLBACK_DIMENSION;
+
+/// The hand-written value the `persistence`-free arm of
+/// [`DEFAULT_DIMENSION`] falls back to (the canonical constant's module is
+/// feature-gated away there). The `persistence` build — CI's default —
+/// statically asserts it still equals the canonical value, so drift fails
+/// to compile instead of silently splitting the wasm default dimension
+/// from the native one.
+const FALLBACK_DIMENSION: usize = 384;
+#[cfg(feature = "persistence")]
+const _: () = assert!(
+    FALLBACK_DIMENSION == velesdb_core::agent::DEFAULT_DIMENSION,
+    "update FALLBACK_DIMENSION to match velesdb_core::agent::DEFAULT_DIMENSION"
+);
 
 pub use embedder::{DynEmbedder, EmbedError, Embedder, HashEmbedder};
 #[cfg(feature = "ollama")]

--- a/crates/velesdb-memory/src/lib.rs
+++ b/crates/velesdb-memory/src/lib.rs
@@ -49,6 +49,10 @@ pub mod rerank;
 /// `format` keywords so strict MCP clients don't warn on every id field).
 mod schema;
 pub mod service;
+/// The storage backend abstraction — [`storage::MemoryStore`] and the
+/// default, file-backed [`storage::NativeStore`]. Implement `MemoryStore` to
+/// run the wedge over a different backend (e.g. an in-memory one for WASM).
+pub mod storage;
 
 /// Default embedding dimension — the single source of truth, taken from the
 /// SDK's own default so the server, library, and tests never restate the value.
@@ -68,3 +72,4 @@ pub use model::{
 };
 pub use rerank::{DynReranker, RerankError, Reranker};
 pub use service::{MemoryService, Metadata};
+pub use storage::{MemoryStore, NativeStore};

--- a/crates/velesdb-memory/src/lib.rs
+++ b/crates/velesdb-memory/src/lib.rs
@@ -55,8 +55,15 @@ pub mod service;
 pub mod storage;
 
 /// Default embedding dimension — the single source of truth, taken from the
-/// SDK's own default so the server, library, and tests never restate the value.
+/// SDK's own default so the server, library, and tests never restate the
+/// value. `velesdb_core::agent` (where the canonical constant lives) is
+/// itself `persistence`-gated, so a `persistence`-free build (e.g.
+/// `velesdb-wasm`) falls back to a literal that must be kept in sync with
+/// `velesdb_core::agent::DEFAULT_DIMENSION` (currently `384`).
+#[cfg(feature = "persistence")]
 pub const DEFAULT_DIMENSION: usize = velesdb_core::agent::DEFAULT_DIMENSION;
+#[cfg(not(feature = "persistence"))]
+pub const DEFAULT_DIMENSION: usize = 384;
 
 pub use embedder::{DynEmbedder, EmbedError, Embedder, HashEmbedder};
 #[cfg(feature = "ollama")]
@@ -72,4 +79,6 @@ pub use model::{
 };
 pub use rerank::{DynReranker, RerankError, Reranker};
 pub use service::{MemoryService, Metadata};
-pub use storage::{MemoryStore, NativeStore};
+pub use storage::MemoryStore;
+#[cfg(feature = "persistence")]
+pub use storage::NativeStore;

--- a/crates/velesdb-memory/src/model.rs
+++ b/crates/velesdb-memory/src/model.rs
@@ -59,7 +59,11 @@ pub enum ColumnOp {
 }
 
 impl ColumnOp {
-    /// The `VelesQL` operator token.
+    /// The `VelesQL` operator token. Only [`crate::storage::NativeStore`]
+    /// builds `VelesQL` text; a non-`persistence` backend (e.g.
+    /// `velesdb-wasm`'s in-memory one) filters `ColumnFilter`s directly, with
+    /// no query-string step.
+    #[cfg(feature = "persistence")]
     #[must_use]
     pub(crate) fn as_sql(self) -> &'static str {
         match self {

--- a/crates/velesdb-memory/src/service.rs
+++ b/crates/velesdb-memory/src/service.rs
@@ -93,14 +93,23 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
     /// (`ColumnStore` facet) and linking it to existing memories (graph facet).
     /// Returns the stable id of the fact (idempotent on identical content).
     ///
-    /// Link targets are validated to exist *before* the fact is stored, so a bad
-    /// link never leaves the fact half-written.
+    /// Every link is validated — target existence AND relation label —
+    /// *before* the fact is stored, so bad link input never leaves the fact
+    /// half-written. If an edge write itself fails afterwards (e.g. a target
+    /// expiring concurrently), a freshly-created fact is rolled back; a
+    /// re-remembered fact keeps its updated payload (re-remembering updates
+    /// metadata by design, and deleting it would destroy prior state).
+    /// Concurrent `remember`s of identical content are last-writer-wins,
+    /// not transactional.
     ///
     /// # Errors
     /// Returns [`MemoryError::EmptyFact`] for empty/whitespace facts,
     /// [`MemoryError::ReservedKey`] if `metadata` names a reserved key
     /// (`content` or any `_veles_`-prefixed system key),
     /// [`MemoryError::UnknownMemory`] if a link points at a missing memory,
+    /// [`MemoryError::InvalidRelation`] for a bad relation label,
+    /// [`MemoryError::RollbackFailed`] if an edge write failed and the
+    /// compensating delete also failed (the fact remains stored),
     /// or a storage error if persistence fails.
     pub fn remember(
         &self,
@@ -133,6 +142,12 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
             return Err(MemoryError::EmptyFact);
         }
         reject_reserved_keys(metadata)?;
+        // EVERY link property — relation label and target existence — is
+        // validated before any write, so all deterministic link failures
+        // happen while nothing has been stored or overwritten yet.
+        for link in links {
+            validate_relation(&link.relation)?;
+        }
         self.ensure_link_targets_exist(links)?;
         let fact_id = id::stable_id(fact);
         let embedding = self.embedder.embed(fact)?;
@@ -144,25 +159,33 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
             metadata,
             positive_ttl(ttl_seconds),
         )?;
-        // A link failing AFTER the fact is stored (an invalid relation
-        // label, or a target expiring between the pre-check above and the
-        // edge write) must not leave the fact half-written — the documented
-        // contract is that a bad link never does. Roll a FRESH fact back
-        // (delete cascades any edges already created); a fact that existed
-        // before this call is kept, since deleting it would destroy prior
-        // state an earlier, successful call established.
+        // Links are fully pre-validated above, so an edge write can only
+        // fail here on a race (e.g. a target's TTL lapsing since the
+        // pre-check). Roll a FRESH fact back (delete cascades any edges
+        // already created); a fact that existed before this call is kept —
+        // deleting it would destroy prior state, and its updated payload
+        // stands per re-remember's update semantics. The existence probe
+        // and the delete are not one atomic unit: a concurrent remember of
+        // identical content between them is last-writer-wins (documented
+        // on [`Self::remember`]).
         if let Err(e) = self.relate_links(fact_id, links) {
             if !existed_before {
-                let _ = self.store.delete(fact_id);
+                if let Err(rollback) = self.store.delete(fact_id) {
+                    return Err(MemoryError::RollbackFailed {
+                        cause: Box::new(e),
+                        rollback: Box::new(rollback),
+                    });
+                }
             }
             return Err(e);
         }
         Ok(fact_id)
     }
 
-    /// Create each validated outgoing link from `fact_id`. Split out of
-    /// [`Self::remember_with_ttl`] to keep that method within the complexity
-    /// budget.
+    /// Create each outgoing link from `fact_id` (labels already validated by
+    /// [`Self::remember_with_ttl`]'s pre-pass; re-checked here so a future
+    /// direct caller can't skip it). Split out of `remember_with_ttl` to
+    /// keep that method within the complexity budget.
     fn relate_links(&self, fact_id: u64, links: &[Link]) -> Result<(), MemoryError> {
         for link in links {
             validate_relation(&link.relation)?;

--- a/crates/velesdb-memory/src/service.rs
+++ b/crates/velesdb-memory/src/service.rs
@@ -1,6 +1,7 @@
 //! The memory service: five operations over the in-core Agent Memory SDK.
 
 use std::collections::{HashMap, HashSet};
+#[cfg(feature = "persistence")]
 use std::path::Path;
 
 use serde_json::{Map, Value};
@@ -15,7 +16,9 @@ use crate::error::MemoryError;
 use crate::extract::Extractor;
 use crate::id;
 use crate::model::{ColumnFilter, Explanation, Link, MemoryNode, Recollection};
-use crate::storage::{MemoryStore, NativeStore};
+use crate::storage::MemoryStore;
+#[cfg(feature = "persistence")]
+use crate::storage::NativeStore;
 
 /// [`MemoryService::recall_fused`] and its helpers — split out to keep this
 /// file under the crate's 500-NLOC-per-file budget, same pattern as
@@ -48,11 +51,23 @@ const MENTIONS_RELATION: &str = "mentions";
 /// backend `S` so the same orchestration runs over the native, file-backed
 /// engine (the default — nothing changes for existing callers) or any other
 /// backend that implements the trait (e.g. an in-memory one for WASM).
+///
+/// Two definitions, `persistence`-gated: the default type parameter itself
+/// references [`NativeStore`], which doesn't exist as a type at all without
+/// the feature, so a `persistence`-free build (e.g. `velesdb-wasm`) drops the
+/// default and every caller names its own [`MemoryStore`] backend explicitly.
+#[cfg(feature = "persistence")]
 pub struct MemoryService<E: Embedder, S: MemoryStore = NativeStore> {
     store: S,
     embedder: E,
 }
+#[cfg(not(feature = "persistence"))]
+pub struct MemoryService<E: Embedder, S: MemoryStore> {
+    store: S,
+    embedder: E,
+}
 
+#[cfg(feature = "persistence")]
 impl<E: Embedder> MemoryService<E, NativeStore> {
     /// Open (or create) a native, file-backed memory store at `path`, using
     /// `embedder` for text vectorization. The store never leaves this directory.

--- a/crates/velesdb-memory/src/service.rs
+++ b/crates/velesdb-memory/src/service.rs
@@ -2,11 +2,8 @@
 
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
-use std::sync::Arc;
 
-use serde_json::{json, Map, Value};
-use velesdb_core::agent::AgentMemory;
-use velesdb_core::{Database, SearchResult};
+use serde_json::{Map, Value};
 
 /// Structured metadata attached to a memory (the `ColumnStore` facet): exact-match
 /// fields like `project`, `author`, `type`, `status`, `date`. `content` and
@@ -17,7 +14,8 @@ use crate::embedder::Embedder;
 use crate::error::MemoryError;
 use crate::extract::Extractor;
 use crate::id;
-use crate::model::{ColumnFilter, Explanation, Link, MemoryEdge, MemoryNode, Recollection};
+use crate::model::{ColumnFilter, Explanation, Link, MemoryNode, Recollection};
+use crate::storage::{MemoryStore, NativeStore};
 
 /// [`MemoryService::recall_fused`] and its helpers — split out to keep this
 /// file under the crate's 500-NLOC-per-file budget, same pattern as
@@ -46,23 +44,34 @@ const MENTIONS_RELATION: &str = "mentions";
 /// Local-first agent memory backed by a single `VelesDB` instance.
 ///
 /// Generic over the [`Embedder`] so production can use an on-device model while
-/// tests use a deterministic, network-free one.
-pub struct MemoryService<E: Embedder> {
-    memory: AgentMemory,
+/// tests use a deterministic, network-free one, and over the [`MemoryStore`]
+/// backend `S` so the same orchestration runs over the native, file-backed
+/// engine (the default — nothing changes for existing callers) or any other
+/// backend that implements the trait (e.g. an in-memory one for WASM).
+pub struct MemoryService<E: Embedder, S: MemoryStore = NativeStore> {
+    store: S,
     embedder: E,
 }
 
-impl<E: Embedder> MemoryService<E> {
-    /// Open (or create) a memory store at `path`, using `embedder` for text
-    /// vectorization. The store never leaves this directory.
+impl<E: Embedder> MemoryService<E, NativeStore> {
+    /// Open (or create) a native, file-backed memory store at `path`, using
+    /// `embedder` for text vectorization. The store never leaves this directory.
     ///
     /// # Errors
     /// Returns [`MemoryError`] if the store cannot be opened or the agent
     /// memory cannot be initialized for the embedder's dimension.
     pub fn open<P: AsRef<Path>>(path: P, embedder: E) -> Result<Self, MemoryError> {
-        let db = Arc::new(Database::open(path)?);
-        let memory = AgentMemory::with_dimension(db, embedder.dimension())?;
-        Ok(Self { memory, embedder })
+        let store = NativeStore::open(path, embedder.dimension())?;
+        Ok(Self { store, embedder })
+    }
+}
+
+impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
+    /// Build a service directly over a `store` backend, bypassing
+    /// [`Self::open`]'s filesystem-specific setup — the constructor a
+    /// non-native backend (e.g. `velesdb-wasm`'s in-memory store) uses.
+    pub fn with_store(store: S, embedder: E) -> Self {
+        Self { store, embedder }
     }
 
     /// Remember a `fact`, optionally tagging it with structured `metadata`
@@ -112,7 +121,7 @@ impl<E: Embedder> MemoryService<E> {
         self.ensure_link_targets_exist(links)?;
         let fact_id = id::stable_id(fact);
         let embedding = self.embedder.embed(fact)?;
-        self.store(
+        self.store_fact(
             fact_id,
             fact,
             &embedding,
@@ -129,9 +138,7 @@ impl<E: Embedder> MemoryService<E> {
     fn relate_links(&self, fact_id: u64, links: &[Link]) -> Result<(), MemoryError> {
         for link in links {
             validate_relation(&link.relation)?;
-            self.memory
-                .semantic()
-                .relate(fact_id, link.target, &link.relation, None)?;
+            self.store.relate(fact_id, link.target, &link.relation)?;
         }
         Ok(())
     }
@@ -260,8 +267,8 @@ impl<E: Embedder> MemoryService<E> {
         if !seeded.insert(node) {
             return Ok(());
         }
-        for edge in self.memory.semantic().relations(node)? {
-            edges.insert((node, edge.target()));
+        for edge in self.store.relations(node)? {
+            edges.insert((node, edge.to));
         }
         Ok(())
     }
@@ -287,8 +294,8 @@ impl<E: Embedder> MemoryService<E> {
     /// hub id space is disjoint from natural fact ids (no caller fact can collide
     /// with or overwrite a hub), while the stored content stays human-readable.
     /// Marked with the reserved [`HUB_FIELD`] so recall and `why` seeds exclude
-    /// it; goes straight to [`Self::store`] to bypass the caller-facing reserved-
-    /// key rejection in [`Self::remember`].
+    /// it; goes straight to [`Self::store_fact`] to bypass the caller-facing
+    /// reserved-key rejection in [`Self::remember`].
     fn remember_hub(&self, key: &str) -> Result<u64, MemoryError> {
         let id = id::stable_id(&format!("{HUB_ID_SALT}{key}"));
         let content = format!("Entity: {key}");
@@ -296,13 +303,13 @@ impl<E: Embedder> MemoryService<E> {
         let mut meta = Map::new();
         meta.insert(HUB_FIELD.to_string(), Value::Bool(true));
         // Topic hubs are graph anchors — they never expire.
-        self.store(id, &content, &embedding, Some(&meta), None)?;
+        self.store_fact(id, &content, &embedding, Some(&meta), None)?;
         Ok(id)
     }
 
     /// Fail with [`MemoryError::UnknownMemory`] unless memory `id` exists.
     fn ensure_exists(&self, id: u64) -> Result<(), MemoryError> {
-        if self.memory.semantic().get(id)?.is_none() {
+        if self.store.get(id)?.is_none() {
             return Err(MemoryError::UnknownMemory(id));
         }
         Ok(())
@@ -317,7 +324,7 @@ impl<E: Embedder> MemoryService<E> {
     }
 
     /// Store a fact with any combination of metadata and a durable TTL.
-    fn store(
+    fn store_fact(
         &self,
         id: u64,
         fact: &str,
@@ -325,17 +332,16 @@ impl<E: Embedder> MemoryService<E> {
         metadata: Option<&Metadata>,
         ttl_seconds: Option<u64>,
     ) -> Result<(), MemoryError> {
-        let semantic = self.memory.semantic();
         match (metadata, ttl_seconds) {
             (Some(meta), Some(ttl)) => {
                 // store_with_ttl writes the fact + the durable expiry; update_metadata
                 // then merges the metadata while preserving `_veles_expires_at`.
-                semantic.store_with_ttl(id, fact, embedding, ttl)?;
-                semantic.update_metadata(id, meta)?;
+                self.store.store_with_ttl(id, fact, embedding, ttl)?;
+                self.store.update_metadata(id, meta)?;
             }
-            (Some(meta), None) => semantic.store_with_metadata(id, fact, embedding, meta)?,
-            (None, Some(ttl)) => semantic.store_with_ttl(id, fact, embedding, ttl)?,
-            (None, None) => semantic.store(id, fact, embedding)?,
+            (Some(meta), None) => self.store.store_with_metadata(id, fact, embedding, meta)?,
+            (None, Some(ttl)) => self.store.store_with_ttl(id, fact, embedding, ttl)?,
+            (None, None) => self.store.store(id, fact, embedding)?,
         }
         Ok(())
     }
@@ -396,18 +402,12 @@ impl<E: Embedder> MemoryService<E> {
         match filter {
             // An include filter already excludes hubs: a hub only carries
             // `{kind: entity}`, so it can never match a user's metadata filter.
-            Some(meta) => self
-                .memory
-                .semantic()
-                .query_filtered(embedding, k, meta, 0)
-                .map_err(MemoryError::from),
+            Some(meta) => self.store.query_filtered(embedding, k, meta, 0),
             // Unfiltered recall must still drop entity hubs explicitly, or a hub
             // like `Entity: rust` would rank for the topic and evict a real fact.
             None => self
-                .memory
-                .semantic()
-                .query_excluding(embedding, k, &hub_exclude_filter())
-                .map_err(MemoryError::from),
+                .store
+                .query_excluding(embedding, k, &hub_exclude_filter()),
         }
     }
 
@@ -436,53 +436,7 @@ impl<E: Embedder> MemoryService<E> {
             return Ok(Vec::new());
         }
         let embedding = self.embedder.embed(query)?;
-        let (sql, params) = self.build_fused_query(&embedding, k, filters)?;
-        // `build_fused_query` has validated every field name; ensure each one is
-        // indexed so the planner uses a bitmap prefilter instead of an O(n)
-        // post-filter scan. Idempotent and incrementally maintained thereafter.
-        for filter in filters {
-            self.memory
-                .semantic()
-                .ensure_index(&filter.field)
-                .map_err(MemoryError::from)?;
-        }
-        let results = self
-            .memory
-            .query_semantic(&sql, &params)
-            .map_err(MemoryError::from)?;
-        Ok(results.iter().map(to_recollection).collect())
-    }
-
-    /// Build the `VelesQL` for [`Self::recall_where`]: a `NEAR` predicate plus
-    /// one bound parameter per filter, against the semantic collection.
-    fn build_fused_query(
-        &self,
-        embedding: &[f32],
-        k: usize,
-        filters: &[ColumnFilter],
-    ) -> Result<(String, HashMap<String, Value>), MemoryError> {
-        use std::fmt::Write as _;
-        let mut params: HashMap<String, Value> = HashMap::new();
-        params.insert("q".to_string(), json!(embedding));
-        let mut predicate = String::from("vector NEAR $q");
-        for (index, filter) in filters.iter().enumerate() {
-            validate_field(&filter.field)?;
-            validate_scalar(&filter.value)?;
-            let key = format!("p{index}");
-            // Field is a validated identifier; the value is bound, never inlined.
-            let _ = write!(
-                predicate,
-                " AND {} {} ${key}",
-                filter.field,
-                filter.op.as_sql()
-            );
-            params.insert(key, filter.value.clone());
-        }
-        let sql = format!(
-            "SELECT * FROM {} WHERE {predicate} LIMIT {k}",
-            self.memory.semantic().collection_name()
-        );
-        Ok((sql, params))
+        self.store.query_columnar(&embedding, k, filters)
     }
 
     /// Create a typed edge `from -> to`. Returns the edge id.
@@ -499,10 +453,7 @@ impl<E: Embedder> MemoryService<E> {
         validate_relation(relation)?;
         self.ensure_exists(from)?;
         self.ensure_exists(to)?;
-        self.memory
-            .semantic()
-            .relate(from, to, relation, None)
-            .map_err(MemoryError::from)
+        self.store.relate(from, to, relation)
     }
 
     /// Forget (delete) the memory with `fact_id`.
@@ -510,10 +461,7 @@ impl<E: Embedder> MemoryService<E> {
     /// # Errors
     /// Returns [`MemoryError`] if the deletion fails.
     pub fn forget(&self, fact_id: u64) -> Result<(), MemoryError> {
-        self.memory
-            .semantic()
-            .delete(fact_id)
-            .map_err(MemoryError::from)
+        self.store.delete(fact_id)
     }
 
     /// Explain a `decision`: find the best-matching memory (optionally scoped to
@@ -587,10 +535,10 @@ impl<E: Embedder> MemoryService<E> {
         visited: &mut HashSet<u64>,
         next: &mut Vec<u64>,
     ) -> Result<(), MemoryError> {
-        for edge in self.memory.semantic().relations(node_id)? {
-            let target = edge.target();
+        for edge in self.store.relations(node_id)? {
+            let target = edge.to;
             if !visited.contains(&target) {
-                let Some((content, _embedding)) = self.memory.semantic().get(target)? else {
+                let Some((content, _embedding)) = self.store.get(target)? else {
                     continue; // target no longer exists → drop the dangling edge too
                 };
                 visited.insert(target);
@@ -601,11 +549,7 @@ impl<E: Embedder> MemoryService<E> {
                 });
                 next.push(target);
             }
-            explanation.edges.push(MemoryEdge {
-                from: edge.source(),
-                to: target,
-                relation: edge.label().to_owned(),
-            });
+            explanation.edges.push(edge);
         }
         Ok(())
     }
@@ -659,60 +603,6 @@ fn reject_reserved_keys(metadata: Option<&Metadata>) -> Result<(), MemoryError> 
 /// is stored permanently. Any positive value is kept as-is.
 fn positive_ttl(ttl_seconds: Option<u64>) -> Option<u64> {
     ttl_seconds.filter(|&seconds| seconds > 0)
-}
-
-/// Map a core search result to a [`Recollection`], lifting the fact text out of
-/// the reserved `content` payload key and surfacing any remaining
-/// caller-supplied metadata (reserved system keys excluded).
-fn to_recollection(result: &SearchResult) -> Recollection {
-    let payload = result.point.payload.as_ref().and_then(Value::as_object);
-    let content = payload
-        .and_then(|payload| payload.get("content"))
-        .and_then(Value::as_str)
-        .unwrap_or_default()
-        .to_owned();
-    let metadata = payload.and_then(|payload| {
-        let metadata: Map<String, Value> = payload
-            .iter()
-            .filter(|(key, _)| !is_reserved_key(key))
-            .map(|(key, value)| (key.clone(), value.clone()))
-            .collect();
-        (!metadata.is_empty()).then_some(metadata)
-    });
-    Recollection {
-        id: result.point.id,
-        score: result.score,
-        content,
-        metadata,
-    }
-}
-
-/// Accept only plain, non-reserved identifier field names, so a filter field
-/// can be safely placed into the query text (its value is always a bound
-/// parameter). Rejects the reserved system columns the docs promise are off
-/// limits: `content` (the fact payload) and any `_veles_`-prefixed engine key
-/// (e.g. durable TTL).
-fn validate_field(field: &str) -> Result<(), MemoryError> {
-    let plain = !field.is_empty() && field.chars().all(|c| c.is_ascii_alphanumeric() || c == '_');
-    let reserved = field == "content" || field.starts_with("_veles_");
-    if plain && !reserved {
-        Ok(())
-    } else {
-        Err(MemoryError::InvalidFilter(field.to_owned()))
-    }
-}
-
-/// Reject non-scalar filter values. Only strings, numbers, and booleans can be
-/// compared against a `ColumnStore` column; binding an array/object/null would
-/// fail deep in the query engine and surface as an opaque internal error instead
-/// of a clear client-input error.
-fn validate_scalar(value: &Value) -> Result<(), MemoryError> {
-    match value {
-        Value::String(_) | Value::Number(_) | Value::Bool(_) => Ok(()),
-        _ => Err(MemoryError::InvalidFilter(format!(
-            "value must be a string, number, or boolean, got {value}"
-        ))),
-    }
 }
 
 /// Maximum byte length for a relation label (prevents oversized graph edge labels

--- a/crates/velesdb-memory/src/service.rs
+++ b/crates/velesdb-memory/src/service.rs
@@ -182,13 +182,14 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
         Ok(fact_id)
     }
 
-    /// Create each outgoing link from `fact_id` (labels already validated by
-    /// [`Self::remember_with_ttl`]'s pre-pass; re-checked here so a future
-    /// direct caller can't skip it). Split out of `remember_with_ttl` to
-    /// keep that method within the complexity budget.
+    /// Create each outgoing link from `fact_id`.
+    ///
+    /// Precondition: every label was already validated by
+    /// [`Self::remember_with_ttl`]'s pre-write pass (its only caller) —
+    /// no re-check here, so the validation rule lives in exactly one
+    /// place on this path.
     fn relate_links(&self, fact_id: u64, links: &[Link]) -> Result<(), MemoryError> {
         for link in links {
-            validate_relation(&link.relation)?;
             self.store.relate(fact_id, link.target, &link.relation)?;
         }
         Ok(())

--- a/crates/velesdb-memory/src/service.rs
+++ b/crates/velesdb-memory/src/service.rs
@@ -136,6 +136,7 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
         self.ensure_link_targets_exist(links)?;
         let fact_id = id::stable_id(fact);
         let embedding = self.embedder.embed(fact)?;
+        let existed_before = !links.is_empty() && self.store.get(fact_id)?.is_some();
         self.store_fact(
             fact_id,
             fact,
@@ -143,7 +144,19 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
             metadata,
             positive_ttl(ttl_seconds),
         )?;
-        self.relate_links(fact_id, links)?;
+        // A link failing AFTER the fact is stored (an invalid relation
+        // label, or a target expiring between the pre-check above and the
+        // edge write) must not leave the fact half-written — the documented
+        // contract is that a bad link never does. Roll a FRESH fact back
+        // (delete cascades any edges already created); a fact that existed
+        // before this call is kept, since deleting it would destroy prior
+        // state an earlier, successful call established.
+        if let Err(e) = self.relate_links(fact_id, links) {
+            if !existed_before {
+                let _ = self.store.delete(fact_id);
+            }
+            return Err(e);
+        }
         Ok(fact_id)
     }
 
@@ -415,9 +428,10 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
         filter: Option<&Metadata>,
     ) -> Result<Vec<(u64, f32, String)>, MemoryError> {
         match filter {
-            // An include filter already excludes hubs: a hub only carries
-            // `{kind: entity}`, so it can never match a user's non-empty
-            // metadata filter. An EMPTY-but-present filter (`Some({})`, the
+            // An include filter already excludes hubs: a hub's payload
+            // carries only reserved keys (`content`, `_veles_hub`), and
+            // reserved keys are rejected from caller filters, so a non-empty
+            // filter can never match a hub. An EMPTY-but-present filter (`Some({})`, the
             // natural `{}` idiom at the JS boundary) matches every payload —
             // hubs included — so it must take the hub-excluding path below,
             // exactly like an absent filter (same `Some({})` ≡ `None`

--- a/crates/velesdb-memory/src/service.rs
+++ b/crates/velesdb-memory/src/service.rs
@@ -16,9 +16,9 @@ use crate::error::MemoryError;
 use crate::extract::Extractor;
 use crate::id;
 use crate::model::{ColumnFilter, Explanation, Link, MemoryNode, Recollection};
-use crate::storage::MemoryStore;
 #[cfg(feature = "persistence")]
 use crate::storage::NativeStore;
+use crate::storage::{is_reserved_key, strip_reserved_keys, MemoryStore};
 
 /// [`MemoryService::recall_fused`] and its helpers — split out to keep this
 /// file under the crate's 500-NLOC-per-file budget, same pattern as
@@ -416,11 +416,16 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
     ) -> Result<Vec<(u64, f32, String)>, MemoryError> {
         match filter {
             // An include filter already excludes hubs: a hub only carries
-            // `{kind: entity}`, so it can never match a user's metadata filter.
-            Some(meta) => self.store.query_filtered(embedding, k, meta, 0),
+            // `{kind: entity}`, so it can never match a user's non-empty
+            // metadata filter. An EMPTY-but-present filter (`Some({})`, the
+            // natural `{}` idiom at the JS boundary) matches every payload —
+            // hubs included — so it must take the hub-excluding path below,
+            // exactly like an absent filter (same `Some({})` ≡ `None`
+            // convention as `recall_fused`'s graph-side `matches_filter`).
+            Some(meta) if !meta.is_empty() => self.store.query_filtered(embedding, k, meta, 0),
             // Unfiltered recall must still drop entity hubs explicitly, or a hub
             // like `Entity: rust` would rank for the topic and evict a real fact.
-            None => self
+            _ => self
                 .store
                 .query_excluding(embedding, k, &hub_exclude_filter()),
         }
@@ -449,6 +454,14 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
         let query = query.trim();
         if query.is_empty() || k == 0 {
             return Ok(Vec::new());
+        }
+        // No column predicates = a plain recall: route through [`Self::recall`]
+        // so entity hubs stay excluded — `query_columnar` with an empty filter
+        // set is a bare vector search that would rank internal `Entity:` hub
+        // scaffolding as results (same `[]` ≡ unfiltered convention as
+        // `search`'s empty-map handling).
+        if filters.is_empty() {
+            return self.recall(query, k, None);
         }
         let embedding = self.embedder.embed(query)?;
         self.store.query_columnar(&embedding, k, filters)
@@ -577,28 +590,6 @@ fn hub_exclude_filter() -> Metadata {
     let mut exclude = Map::new();
     exclude.insert(HUB_FIELD.to_string(), Value::Bool(true));
     exclude
-}
-
-/// True for metadata keys the memory layer reserves: the engine's `content`
-/// payload, and any `_veles_`-namespaced system key (durable TTL, entity hubs).
-/// Callers may neither set these in `remember` metadata nor filter on them, so
-/// they can't overwrite a system field or collide with internal scaffolding.
-fn is_reserved_key(key: &str) -> bool {
-    key == "content" || key.starts_with("_veles_")
-}
-
-/// Drop reserved system keys from a raw payload, and collapse an
-/// empty-after-stripping map to `None` — the caller-facing shape every
-/// `Recollection::metadata` is built from, regardless of which recall path
-/// (single or batched) fetched the raw payload.
-fn strip_reserved_keys(payload: Option<Metadata>) -> Option<Metadata> {
-    payload.and_then(|payload| {
-        let metadata: Metadata = payload
-            .into_iter()
-            .filter(|(key, _)| !is_reserved_key(key))
-            .collect();
-        (!metadata.is_empty()).then_some(metadata)
-    })
 }
 
 /// Reject caller-supplied metadata/filters that name a reserved key.

--- a/crates/velesdb-memory/src/storage.rs
+++ b/crates/velesdb-memory/src/storage.rs
@@ -1,0 +1,409 @@
+//! Storage backend abstraction for [`crate::service::MemoryService`].
+//!
+//! The wedge orchestration (remember/recall/relate/forget/why/fusion) is
+//! written once, generic over [`MemoryStore`], so it runs unchanged over any
+//! backend: the native, file-backed [`NativeStore`] (the default — nothing
+//! changes for existing callers), or an in-memory backend such as the one
+//! `velesdb-wasm` provides for the browser (no filesystem, no `persistence`
+//! feature).
+
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::Arc;
+
+use serde_json::{json, Map, Value};
+use velesdb_core::agent::AgentMemory;
+use velesdb_core::{Database, SearchResult};
+
+use crate::error::MemoryError;
+use crate::model::{ColumnFilter, MemoryEdge, Recollection};
+use crate::service::Metadata;
+
+/// The storage primitives [`crate::service::MemoryService`] needs: write,
+/// vector search, graph edges, and by-id lookup. A backend that implements
+/// this trait can run the full wedge (`remember`/`recall`/`recall_fused`/
+/// `relate`/`forget`/`why`/`remember_extracted`) with no orchestration code
+/// duplicated.
+pub trait MemoryStore {
+    /// Store a fact with no metadata or expiry.
+    ///
+    /// # Errors
+    /// Returns [`MemoryError`] if persistence fails.
+    fn store(&self, id: u64, content: &str, embedding: &[f32]) -> Result<(), MemoryError>;
+
+    /// Store a fact tagged with `metadata`, no expiry.
+    ///
+    /// # Errors
+    /// Returns [`MemoryError`] if persistence fails.
+    fn store_with_metadata(
+        &self,
+        id: u64,
+        content: &str,
+        embedding: &[f32],
+        metadata: &Metadata,
+    ) -> Result<(), MemoryError>;
+
+    /// Store a fact that expires after `ttl_seconds`, no metadata.
+    ///
+    /// # Errors
+    /// Returns [`MemoryError`] if persistence fails.
+    fn store_with_ttl(
+        &self,
+        id: u64,
+        content: &str,
+        embedding: &[f32],
+        ttl_seconds: u64,
+    ) -> Result<(), MemoryError>;
+
+    /// Merge `metadata` into an already-stored fact's payload, preserving any
+    /// durable TTL. Used to combine metadata with an expiry (store both in
+    /// two calls rather than needing every metadata×TTL combination as a
+    /// separate primitive).
+    ///
+    /// # Errors
+    /// Returns [`MemoryError`] if `id` is unknown or persistence fails.
+    fn update_metadata(&self, id: u64, metadata: &Metadata) -> Result<(), MemoryError>;
+
+    /// A fact's content and embedding, or `None` if unknown/expired.
+    ///
+    /// # Errors
+    /// Returns [`MemoryError`] if storage access fails.
+    fn get(&self, id: u64) -> Result<Option<(String, Vec<f32>)>, MemoryError>;
+
+    /// A fact's raw stored payload — reserved system keys (`_veles_*`)
+    /// included, so the service layer can check the hub flag before
+    /// stripping them for the caller — or `None` when the fact is
+    /// unknown/expired.
+    ///
+    /// # Errors
+    /// Returns [`MemoryError`] if storage access fails.
+    fn get_metadata(&self, id: u64) -> Result<Option<Metadata>, MemoryError>;
+
+    /// Batched [`Self::get_metadata`]: one storage round trip for every id
+    /// in `ids`, results in the same order and length (an unknown or expired
+    /// id maps to `None`). Same raw-payload semantics as the single-id form.
+    ///
+    /// # Errors
+    /// Returns [`MemoryError`] if storage access fails.
+    fn get_metadata_batch(&self, ids: &[u64]) -> Result<Vec<Option<Metadata>>, MemoryError>;
+
+    /// Delete a fact.
+    ///
+    /// # Errors
+    /// Returns [`MemoryError`] if deletion fails.
+    fn delete(&self, id: u64) -> Result<(), MemoryError>;
+
+    /// Vector search for up to `k` ids, narrowed to facts whose metadata
+    /// exactly matches every key in `filter`.
+    ///
+    /// # Errors
+    /// Returns [`MemoryError`] if the query fails.
+    fn query_filtered(
+        &self,
+        embedding: &[f32],
+        k: usize,
+        filter: &Metadata,
+        offset: usize,
+    ) -> Result<Vec<(u64, f32, String)>, MemoryError>;
+
+    /// Vector search for up to `k` ids, dropping facts whose metadata matches
+    /// every key in `exclude`.
+    ///
+    /// # Errors
+    /// Returns [`MemoryError`] if the query fails.
+    fn query_excluding(
+        &self,
+        embedding: &[f32],
+        k: usize,
+        exclude: &Metadata,
+    ) -> Result<Vec<(u64, f32, String)>, MemoryError>;
+
+    /// Vector search fused with structured `ColumnStore` predicates (ranges
+    /// and comparisons, not just equality) — the engine behind
+    /// [`crate::service::MemoryService::recall_where`].
+    ///
+    /// # Errors
+    /// Returns [`MemoryError::InvalidFilter`] if a filter field is not a
+    /// plain identifier or a filter value is non-scalar, or [`MemoryError`]
+    /// if the query fails.
+    fn query_columnar(
+        &self,
+        embedding: &[f32],
+        k: usize,
+        filters: &[ColumnFilter],
+    ) -> Result<Vec<Recollection>, MemoryError>;
+
+    /// Create a typed edge `from -> to`. Returns the edge id.
+    ///
+    /// # Errors
+    /// Returns [`MemoryError`] if either endpoint is missing or persistence fails.
+    fn relate(&self, from: u64, to: u64, relation: &str) -> Result<u64, MemoryError>;
+
+    /// The outgoing edges of `id`.
+    ///
+    /// # Errors
+    /// Returns [`MemoryError`] if storage access fails.
+    fn relations(&self, id: u64) -> Result<Vec<MemoryEdge>, MemoryError>;
+
+    /// The total number of live (non-expired) tracked facts, including
+    /// internal entity hubs — used as a corpus-size proxy for idf weighting.
+    fn count(&self) -> usize;
+}
+
+/// The default [`MemoryStore`]: the native, file-backed engine
+/// (`velesdb-core`'s `Database`/`AgentMemory`, requiring the `persistence`
+/// feature). Existing callers of `MemoryService::open` see no change — this
+/// is exactly what they already ran.
+pub struct NativeStore {
+    memory: AgentMemory,
+}
+
+impl NativeStore {
+    /// Open (or create) a native store at `path`, sized for `dimension`.
+    ///
+    /// # Errors
+    /// Returns [`MemoryError`] if the store cannot be opened.
+    pub fn open<P: AsRef<Path>>(path: P, dimension: usize) -> Result<Self, MemoryError> {
+        let db = Arc::new(Database::open(path)?);
+        let memory = AgentMemory::with_dimension(db, dimension)?;
+        Ok(Self { memory })
+    }
+}
+
+impl MemoryStore for NativeStore {
+    fn store(&self, id: u64, content: &str, embedding: &[f32]) -> Result<(), MemoryError> {
+        self.memory
+            .semantic()
+            .store(id, content, embedding)
+            .map_err(MemoryError::from)
+    }
+
+    fn store_with_metadata(
+        &self,
+        id: u64,
+        content: &str,
+        embedding: &[f32],
+        metadata: &Metadata,
+    ) -> Result<(), MemoryError> {
+        self.memory
+            .semantic()
+            .store_with_metadata(id, content, embedding, metadata)
+            .map_err(MemoryError::from)
+    }
+
+    fn store_with_ttl(
+        &self,
+        id: u64,
+        content: &str,
+        embedding: &[f32],
+        ttl_seconds: u64,
+    ) -> Result<(), MemoryError> {
+        self.memory
+            .semantic()
+            .store_with_ttl(id, content, embedding, ttl_seconds)
+            .map_err(MemoryError::from)
+    }
+
+    fn update_metadata(&self, id: u64, metadata: &Metadata) -> Result<(), MemoryError> {
+        self.memory
+            .semantic()
+            .update_metadata(id, metadata)
+            .map_err(MemoryError::from)
+    }
+
+    fn get(&self, id: u64) -> Result<Option<(String, Vec<f32>)>, MemoryError> {
+        self.memory.semantic().get(id).map_err(MemoryError::from)
+    }
+
+    fn get_metadata(&self, id: u64) -> Result<Option<Metadata>, MemoryError> {
+        self.memory
+            .semantic()
+            .get_metadata(id)
+            .map_err(MemoryError::from)
+    }
+
+    fn get_metadata_batch(&self, ids: &[u64]) -> Result<Vec<Option<Metadata>>, MemoryError> {
+        self.memory
+            .semantic()
+            .get_metadata_batch(ids)
+            .map_err(MemoryError::from)
+    }
+
+    fn delete(&self, id: u64) -> Result<(), MemoryError> {
+        self.memory.semantic().delete(id).map_err(MemoryError::from)
+    }
+
+    fn query_filtered(
+        &self,
+        embedding: &[f32],
+        k: usize,
+        filter: &Metadata,
+        offset: usize,
+    ) -> Result<Vec<(u64, f32, String)>, MemoryError> {
+        self.memory
+            .semantic()
+            .query_filtered(embedding, k, filter, offset)
+            .map_err(MemoryError::from)
+    }
+
+    fn query_excluding(
+        &self,
+        embedding: &[f32],
+        k: usize,
+        exclude: &Metadata,
+    ) -> Result<Vec<(u64, f32, String)>, MemoryError> {
+        self.memory
+            .semantic()
+            .query_excluding(embedding, k, exclude)
+            .map_err(MemoryError::from)
+    }
+
+    fn query_columnar(
+        &self,
+        embedding: &[f32],
+        k: usize,
+        filters: &[ColumnFilter],
+    ) -> Result<Vec<Recollection>, MemoryError> {
+        let (sql, params) = self.build_fused_query(embedding, k, filters)?;
+        // Field names are validated by `build_fused_query`; ensure each one is
+        // indexed so the planner uses a bitmap prefilter instead of an O(n)
+        // post-filter scan. Idempotent and incrementally maintained thereafter.
+        for filter in filters {
+            self.memory
+                .semantic()
+                .ensure_index(&filter.field)
+                .map_err(MemoryError::from)?;
+        }
+        let results = self
+            .memory
+            .query_semantic(&sql, &params)
+            .map_err(MemoryError::from)?;
+        Ok(results.iter().map(to_recollection).collect())
+    }
+
+    fn relate(&self, from: u64, to: u64, relation: &str) -> Result<u64, MemoryError> {
+        self.memory
+            .semantic()
+            .relate(from, to, relation, None)
+            .map_err(MemoryError::from)
+    }
+
+    fn relations(&self, id: u64) -> Result<Vec<MemoryEdge>, MemoryError> {
+        Ok(self
+            .memory
+            .semantic()
+            .relations(id)?
+            .into_iter()
+            .map(|edge| MemoryEdge {
+                from: edge.source(),
+                to: edge.target(),
+                relation: edge.label().to_owned(),
+            })
+            .collect())
+    }
+
+    fn count(&self) -> usize {
+        self.memory.semantic().count()
+    }
+}
+
+impl NativeStore {
+    /// Build the `VelesQL` for [`Self::query_columnar`]: a `NEAR` predicate
+    /// plus one bound parameter per filter, against the semantic collection.
+    /// Filter *values* are bound as query parameters (never interpolated);
+    /// filter *field names* are validated to be plain identifiers.
+    fn build_fused_query(
+        &self,
+        embedding: &[f32],
+        k: usize,
+        filters: &[ColumnFilter],
+    ) -> Result<(String, HashMap<String, Value>), MemoryError> {
+        use std::fmt::Write as _;
+        let mut params: HashMap<String, Value> = HashMap::new();
+        params.insert("q".to_string(), json!(embedding));
+        let mut predicate = String::from("vector NEAR $q");
+        for (index, filter) in filters.iter().enumerate() {
+            validate_field(&filter.field)?;
+            validate_scalar(&filter.value)?;
+            let key = format!("p{index}");
+            let _ = write!(
+                predicate,
+                " AND {} {} ${key}",
+                filter.field,
+                filter.op.as_sql()
+            );
+            params.insert(key, filter.value.clone());
+        }
+        let sql = format!(
+            "SELECT * FROM {} WHERE {predicate} LIMIT {k}",
+            self.memory.semantic().collection_name()
+        );
+        Ok((sql, params))
+    }
+}
+
+/// True for metadata keys the memory layer reserves: the engine's `content`
+/// payload, and any `_veles_`-namespaced system key (durable TTL, entity
+/// hubs). Mirrors [`crate::service`]'s own copy — kept private to each module
+/// since both need it and neither should import a "utility" from the other.
+fn is_reserved_key(key: &str) -> bool {
+    key == "content" || key.starts_with("_veles_")
+}
+
+/// Map a core search result to a [`Recollection`], lifting the fact text out
+/// of the reserved `content` payload key and surfacing any remaining
+/// caller-supplied metadata (reserved system keys excluded).
+fn to_recollection(result: &SearchResult) -> Recollection {
+    let payload = result.point.payload.as_ref().and_then(Value::as_object);
+    let content = payload
+        .and_then(|payload| payload.get("content"))
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_owned();
+    let metadata = payload.and_then(|payload| {
+        let metadata: Map<String, Value> = payload
+            .iter()
+            .filter(|(key, _)| !is_reserved_key(key))
+            .map(|(key, value)| (key.clone(), value.clone()))
+            .collect();
+        (!metadata.is_empty()).then_some(metadata)
+    });
+    Recollection {
+        id: result.point.id,
+        score: result.score,
+        content,
+        metadata,
+    }
+}
+
+/// Accept only plain, non-reserved identifier field names, so a filter field
+/// can be safely placed into the query text (its value is always a bound
+/// parameter). Rejects the reserved system columns the docs promise are off
+/// limits: `content` (the fact payload) and any `_veles_`-prefixed engine key
+/// (e.g. durable TTL).
+fn validate_field(field: &str) -> Result<(), MemoryError> {
+    let plain = !field.is_empty() && field.chars().all(|c| c.is_ascii_alphanumeric() || c == '_');
+    let reserved = field == "content" || field.starts_with("_veles_");
+    if plain && !reserved {
+        Ok(())
+    } else {
+        Err(MemoryError::InvalidFilter(field.to_owned()))
+    }
+}
+
+/// Reject non-scalar filter values. Only strings, numbers, and booleans can be
+/// compared against a `ColumnStore` column; binding an array/object/null would
+/// fail deep in the query engine and surface as an opaque internal error instead
+/// of a clear client-input error.
+fn validate_scalar(value: &Value) -> Result<(), MemoryError> {
+    match value {
+        Value::String(_) | Value::Number(_) | Value::Bool(_) => Ok(()),
+        _ => Err(MemoryError::InvalidFilter(format!(
+            "value must be a string, number, or boolean, got {value}"
+        ))),
+    }
+}
+
+#[cfg(test)]
+#[path = "storage_tests.rs"]
+mod tests;

--- a/crates/velesdb-memory/src/storage.rs
+++ b/crates/velesdb-memory/src/storage.rs
@@ -16,8 +16,7 @@ use std::sync::Arc;
 
 #[cfg(feature = "persistence")]
 use serde_json::json;
-#[cfg(feature = "persistence")]
-use serde_json::{Map, Value};
+use serde_json::Value;
 #[cfg(feature = "persistence")]
 use velesdb_core::agent::AgentMemory;
 #[cfg(feature = "persistence")]
@@ -335,8 +334,7 @@ impl NativeStore {
         params.insert("q".to_string(), json!(embedding));
         let mut predicate = String::from("vector NEAR $q");
         for (index, filter) in filters.iter().enumerate() {
-            validate_field(&filter.field)?;
-            validate_scalar(&filter.value)?;
+            validate_column_filter(filter)?;
             let key = format!("p{index}");
             let _ = write!(
                 predicate,
@@ -356,11 +354,27 @@ impl NativeStore {
 
 /// True for metadata keys the memory layer reserves: the engine's `content`
 /// payload, and any `_veles_`-namespaced system key (durable TTL, entity
-/// hubs). Mirrors [`crate::service`]'s own copy — kept private to each module
-/// since both need it and neither should import a "utility" from the other.
-#[cfg(feature = "persistence")]
-fn is_reserved_key(key: &str) -> bool {
+/// hubs). The single source of the reserved-key contract — the service layer
+/// (reject/strip) and every backend enforce it through this one predicate.
+pub(crate) fn is_reserved_key(key: &str) -> bool {
     key == "content" || key.starts_with("_veles_")
+}
+
+/// Drop reserved system keys from a raw payload, and collapse an
+/// empty-after-stripping map to `None` — the caller-facing shape every
+/// [`Recollection::metadata`] is built from. `pub` because a [`MemoryStore`]
+/// backend that assembles `Recollection`s itself (`query_columnar`) must
+/// apply the same stripping the service layer applies on every other recall
+/// path, or reserved keys leak to callers on that one path only.
+#[must_use]
+pub fn strip_reserved_keys(payload: Option<Metadata>) -> Option<Metadata> {
+    payload.and_then(|payload| {
+        let metadata: Metadata = payload
+            .into_iter()
+            .filter(|(key, _)| !is_reserved_key(key))
+            .collect();
+        (!metadata.is_empty()).then_some(metadata)
+    })
 }
 
 /// Map a core search result to a [`Recollection`], lifting the fact text out
@@ -374,47 +388,34 @@ fn to_recollection(result: &SearchResult) -> Recollection {
         .and_then(Value::as_str)
         .unwrap_or_default()
         .to_owned();
-    let metadata = payload.and_then(|payload| {
-        let metadata: Map<String, Value> = payload
-            .iter()
-            .filter(|(key, _)| !is_reserved_key(key))
-            .map(|(key, value)| (key.clone(), value.clone()))
-            .collect();
-        (!metadata.is_empty()).then_some(metadata)
-    });
     Recollection {
         id: result.point.id,
         score: result.score,
         content,
-        metadata,
+        metadata: strip_reserved_keys(payload.cloned()),
     }
 }
 
-/// Accept only plain, non-reserved identifier field names, so a filter field
-/// can be safely placed into the query text (its value is always a bound
-/// parameter). Rejects the reserved system columns the docs promise are off
-/// limits: `content` (the fact payload) and any `_veles_`-prefixed engine key
-/// (e.g. durable TTL).
-#[cfg(feature = "persistence")]
-fn validate_field(field: &str) -> Result<(), MemoryError> {
+/// Validate one `recall_where` column filter: a plain, non-reserved
+/// identifier field name and a scalar (string/number/boolean) value. `pub`
+/// and shared so every [`MemoryStore`] backend enforces the *same* documented
+/// contract — the field-name rule keeps a filter safe to place into query
+/// text (`NativeStore` builds `VelesQL`; values are always bound parameters),
+/// and rejects the reserved system columns (`content`, `_veles_*`) regardless
+/// of backend; the scalar rule turns what would be an opaque engine error
+/// into a clear client-input error.
+///
+/// # Errors
+/// Returns [`MemoryError::InvalidFilter`] when either rule is violated.
+pub fn validate_column_filter(filter: &ColumnFilter) -> Result<(), MemoryError> {
+    let field = &filter.field;
     let plain = !field.is_empty() && field.chars().all(|c| c.is_ascii_alphanumeric() || c == '_');
-    let reserved = field == "content" || field.starts_with("_veles_");
-    if plain && !reserved {
-        Ok(())
-    } else {
-        Err(MemoryError::InvalidFilter(field.to_owned()))
+    if !plain || is_reserved_key(field) {
+        return Err(MemoryError::InvalidFilter(field.clone()));
     }
-}
-
-/// Reject non-scalar filter values. Only strings, numbers, and booleans can be
-/// compared against a `ColumnStore` column; binding an array/object/null would
-/// fail deep in the query engine and surface as an opaque internal error instead
-/// of a clear client-input error.
-#[cfg(feature = "persistence")]
-fn validate_scalar(value: &Value) -> Result<(), MemoryError> {
-    match value {
+    match &filter.value {
         Value::String(_) | Value::Number(_) | Value::Bool(_) => Ok(()),
-        _ => Err(MemoryError::InvalidFilter(format!(
+        value => Err(MemoryError::InvalidFilter(format!(
             "value must be a string, number, or boolean, got {value}"
         ))),
     }

--- a/crates/velesdb-memory/src/storage.rs
+++ b/crates/velesdb-memory/src/storage.rs
@@ -7,12 +7,20 @@
 //! `velesdb-wasm` provides for the browser (no filesystem, no `persistence`
 //! feature).
 
+#[cfg(feature = "persistence")]
 use std::collections::HashMap;
+#[cfg(feature = "persistence")]
 use std::path::Path;
+#[cfg(feature = "persistence")]
 use std::sync::Arc;
 
-use serde_json::{json, Map, Value};
+#[cfg(feature = "persistence")]
+use serde_json::json;
+#[cfg(feature = "persistence")]
+use serde_json::{Map, Value};
+#[cfg(feature = "persistence")]
 use velesdb_core::agent::AgentMemory;
+#[cfg(feature = "persistence")]
 use velesdb_core::{Database, SearchResult};
 
 use crate::error::MemoryError;
@@ -154,10 +162,12 @@ pub trait MemoryStore {
 /// (`velesdb-core`'s `Database`/`AgentMemory`, requiring the `persistence`
 /// feature). Existing callers of `MemoryService::open` see no change — this
 /// is exactly what they already ran.
+#[cfg(feature = "persistence")]
 pub struct NativeStore {
     memory: AgentMemory,
 }
 
+#[cfg(feature = "persistence")]
 impl NativeStore {
     /// Open (or create) a native store at `path`, sized for `dimension`.
     ///
@@ -170,6 +180,7 @@ impl NativeStore {
     }
 }
 
+#[cfg(feature = "persistence")]
 impl MemoryStore for NativeStore {
     fn store(&self, id: u64, content: &str, embedding: &[f32]) -> Result<(), MemoryError> {
         self.memory
@@ -307,6 +318,7 @@ impl MemoryStore for NativeStore {
     }
 }
 
+#[cfg(feature = "persistence")]
 impl NativeStore {
     /// Build the `VelesQL` for [`Self::query_columnar`]: a `NEAR` predicate
     /// plus one bound parameter per filter, against the semantic collection.
@@ -346,6 +358,7 @@ impl NativeStore {
 /// payload, and any `_veles_`-namespaced system key (durable TTL, entity
 /// hubs). Mirrors [`crate::service`]'s own copy — kept private to each module
 /// since both need it and neither should import a "utility" from the other.
+#[cfg(feature = "persistence")]
 fn is_reserved_key(key: &str) -> bool {
     key == "content" || key.starts_with("_veles_")
 }
@@ -353,6 +366,7 @@ fn is_reserved_key(key: &str) -> bool {
 /// Map a core search result to a [`Recollection`], lifting the fact text out
 /// of the reserved `content` payload key and surfacing any remaining
 /// caller-supplied metadata (reserved system keys excluded).
+#[cfg(feature = "persistence")]
 fn to_recollection(result: &SearchResult) -> Recollection {
     let payload = result.point.payload.as_ref().and_then(Value::as_object);
     let content = payload
@@ -381,6 +395,7 @@ fn to_recollection(result: &SearchResult) -> Recollection {
 /// parameter). Rejects the reserved system columns the docs promise are off
 /// limits: `content` (the fact payload) and any `_veles_`-prefixed engine key
 /// (e.g. durable TTL).
+#[cfg(feature = "persistence")]
 fn validate_field(field: &str) -> Result<(), MemoryError> {
     let plain = !field.is_empty() && field.chars().all(|c| c.is_ascii_alphanumeric() || c == '_');
     let reserved = field == "content" || field.starts_with("_veles_");
@@ -395,6 +410,7 @@ fn validate_field(field: &str) -> Result<(), MemoryError> {
 /// compared against a `ColumnStore` column; binding an array/object/null would
 /// fail deep in the query engine and surface as an opaque internal error instead
 /// of a clear client-input error.
+#[cfg(feature = "persistence")]
 fn validate_scalar(value: &Value) -> Result<(), MemoryError> {
     match value {
         Value::String(_) | Value::Number(_) | Value::Bool(_) => Ok(()),
@@ -404,6 +420,6 @@ fn validate_scalar(value: &Value) -> Result<(), MemoryError> {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "persistence"))]
 #[path = "storage_tests.rs"]
 mod tests;

--- a/crates/velesdb-memory/src/storage.rs
+++ b/crates/velesdb-memory/src/storage.rs
@@ -377,6 +377,22 @@ pub fn strip_reserved_keys(payload: Option<Metadata>) -> Option<Metadata> {
     })
 }
 
+/// [`strip_reserved_keys`] over a *borrowed* payload: clones only the
+/// surviving non-reserved entries. Use this when the payload isn't already
+/// owned — cloning the whole map first would deep-copy the reserved
+/// `content` value (the full fact text) per hit, only to discard it.
+#[must_use]
+pub fn strip_reserved_keys_ref(payload: Option<&Metadata>) -> Option<Metadata> {
+    payload.and_then(|payload| {
+        let metadata: Metadata = payload
+            .iter()
+            .filter(|(key, _)| !is_reserved_key(key))
+            .map(|(key, value)| (key.clone(), value.clone()))
+            .collect();
+        (!metadata.is_empty()).then_some(metadata)
+    })
+}
+
 /// Map a core search result to a [`Recollection`], lifting the fact text out
 /// of the reserved `content` payload key and surfacing any remaining
 /// caller-supplied metadata (reserved system keys excluded).
@@ -392,7 +408,7 @@ fn to_recollection(result: &SearchResult) -> Recollection {
         id: result.point.id,
         score: result.score,
         content,
-        metadata: strip_reserved_keys(payload.cloned()),
+        metadata: strip_reserved_keys_ref(payload),
     }
 }
 

--- a/crates/velesdb-memory/src/storage_tests.rs
+++ b/crates/velesdb-memory/src/storage_tests.rs
@@ -1,0 +1,140 @@
+//! Unit tests for `NativeStore`'s `MemoryStore` implementation.
+
+use super::*;
+use crate::model::ColumnOp;
+
+fn store() -> (tempfile::TempDir, NativeStore) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = NativeStore::open(dir.path(), 4).expect("open store");
+    (dir, store)
+}
+
+#[test]
+fn test_store_and_get_roundtrip() {
+    let (_dir, store) = store();
+    store.store(1, "hello", &[1.0, 0.0, 0.0, 0.0]).unwrap();
+    let (content, embedding) = store.get(1).unwrap().expect("present");
+    assert_eq!(content, "hello");
+    assert_eq!(embedding, vec![1.0, 0.0, 0.0, 0.0]);
+}
+
+#[test]
+fn test_store_with_metadata_round_trips_via_get_metadata() {
+    let (_dir, store) = store();
+    let mut meta = Metadata::new();
+    meta.insert("tag".to_string(), Value::String("science".to_string()));
+    store
+        .store_with_metadata(1, "photosynthesis", &[1.0, 0.0, 0.0, 0.0], &meta)
+        .unwrap();
+    let payload = store.get_metadata(1).unwrap().expect("metadata present");
+    assert_eq!(
+        payload.get("tag"),
+        Some(&Value::String("science".to_string()))
+    );
+}
+
+#[test]
+fn test_delete_removes_the_fact() {
+    let (_dir, store) = store();
+    store.store(1, "ephemeral", &[1.0, 0.0, 0.0, 0.0]).unwrap();
+    store.delete(1).unwrap();
+    assert!(store.get(1).unwrap().is_none());
+}
+
+#[test]
+fn test_relate_and_relations_round_trip() {
+    let (_dir, store) = store();
+    store.store(1, "a", &[1.0, 0.0, 0.0, 0.0]).unwrap();
+    store.store(2, "b", &[0.0, 1.0, 0.0, 0.0]).unwrap();
+    store.relate(1, 2, "decided_in").unwrap();
+    let edges = store.relations(1).unwrap();
+    assert_eq!(edges.len(), 1);
+    assert_eq!(edges[0].from, 1);
+    assert_eq!(edges[0].to, 2);
+    assert_eq!(edges[0].relation, "decided_in");
+}
+
+#[test]
+fn test_query_filtered_matches_exact_metadata() {
+    let (_dir, store) = store();
+    let mut meta = Metadata::new();
+    meta.insert("project".to_string(), Value::String("veles".to_string()));
+    store
+        .store_with_metadata(1, "auth bug", &[1.0, 0.0, 0.0, 0.0], &meta)
+        .unwrap();
+    store.store(2, "unrelated", &[0.0, 1.0, 0.0, 0.0]).unwrap();
+
+    let hits = store
+        .query_filtered(&[1.0, 0.0, 0.0, 0.0], 5, &meta, 0)
+        .unwrap();
+    assert_eq!(hits.len(), 1);
+    assert_eq!(hits[0].0, 1);
+}
+
+#[test]
+fn test_query_excluding_drops_matching_metadata() {
+    let (_dir, store) = store();
+    let mut hub_meta = Metadata::new();
+    hub_meta.insert("_veles_hub".to_string(), Value::Bool(true));
+    store
+        .store_with_metadata(1, "Entity: rust", &[1.0, 0.0, 0.0, 0.0], &hub_meta)
+        .unwrap();
+    store
+        .store(2, "a real fact", &[1.0, 0.0, 0.0, 0.0])
+        .unwrap();
+
+    let hits = store
+        .query_excluding(&[1.0, 0.0, 0.0, 0.0], 5, &hub_meta)
+        .unwrap();
+    assert!(hits.iter().all(|h| h.0 != 1), "hub must be excluded");
+    assert!(hits.iter().any(|h| h.0 == 2));
+}
+
+#[test]
+fn test_query_columnar_applies_range_predicate() {
+    let (_dir, store) = store();
+    let mut early = Metadata::new();
+    early.insert("year".to_string(), Value::from(2003));
+    store
+        .store_with_metadata(1, "alice was CEO", &[1.0, 0.0, 0.0, 0.0], &early)
+        .unwrap();
+    let mut late = Metadata::new();
+    late.insert("year".to_string(), Value::from(2020));
+    store
+        .store_with_metadata(2, "bob was CEO", &[1.0, 0.0, 0.0, 0.0], &late)
+        .unwrap();
+
+    let filters = vec![ColumnFilter {
+        field: "year".to_string(),
+        op: ColumnOp::Le,
+        value: Value::from(2010),
+    }];
+    let hits = store
+        .query_columnar(&[1.0, 0.0, 0.0, 0.0], 5, &filters)
+        .unwrap();
+    assert_eq!(hits.len(), 1);
+    assert_eq!(hits[0].id, 1);
+}
+
+#[test]
+fn test_query_columnar_rejects_invalid_field() {
+    let (_dir, store) = store();
+    let filters = vec![ColumnFilter {
+        field: "content".to_string(),
+        op: ColumnOp::Eq,
+        value: Value::from(1),
+    }];
+    let err = store
+        .query_columnar(&[1.0, 0.0, 0.0, 0.0], 5, &filters)
+        .expect_err("reserved field must be rejected");
+    assert!(matches!(err, MemoryError::InvalidFilter(_)));
+}
+
+#[test]
+fn test_count_reflects_live_facts() {
+    let (_dir, store) = store();
+    assert_eq!(store.count(), 0);
+    store.store(1, "a", &[1.0, 0.0, 0.0, 0.0]).unwrap();
+    store.store(2, "b", &[0.0, 1.0, 0.0, 0.0]).unwrap();
+    assert_eq!(store.count(), 2);
+}

--- a/crates/velesdb-memory/tests/extract_bdd.rs
+++ b/crates/velesdb-memory/tests/extract_bdd.rs
@@ -129,6 +129,45 @@ fn recall_excludes_entity_hubs() {
 }
 
 #[test]
+fn recall_where_with_no_filters_excludes_entity_hubs_like_plain_recall() {
+    // Same regression family as the empty-map case below: `recall_where(q,
+    // k, &[])` used to hit `query_columnar` directly — a bare vector search
+    // with no hub exclusion — instead of behaving like the plain `recall`
+    // it semantically is when no column predicate narrows it.
+    let (_dir, svc) = service();
+    svc.remember_extracted("Alice and Bob both work in Rust.", &StubExtractor, None)
+        .expect("extract and remember");
+    let hits = svc.recall_where("rust", 8, &[]).expect("recall_where");
+    assert!(!hits.is_empty(), "the facts are still recalled");
+    assert!(
+        hits.iter().all(|hit| !hit.content.starts_with("Entity:")),
+        "recall_where with no filters must exclude hubs: {:?}",
+        hits.iter().map(|hit| &hit.content).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn recall_with_an_empty_filter_map_excludes_entity_hubs_like_no_filter() {
+    // Regression: `Some({})` (the natural `{}` idiom at the JS boundary) used
+    // to take the include-filter path, whose "a filter can never match a hub"
+    // shortcut only holds for NON-empty filters — an empty one matches every
+    // payload, so internal `Entity:` hubs ranked as results. It must behave
+    // exactly like `None`, mirroring `recall_fused`'s `matches_filter`.
+    let (_dir, svc) = service();
+    svc.remember_extracted("Alice and Bob both work in Rust.", &StubExtractor, None)
+        .expect("extract and remember");
+    let hits = svc
+        .recall("rust", 8, Some(&Metadata::new()))
+        .expect("recall");
+    assert!(!hits.is_empty(), "the facts are still recalled");
+    assert!(
+        hits.iter().all(|hit| !hit.content.starts_with("Entity:")),
+        "an empty filter map must exclude hubs exactly like no filter: {:?}",
+        hits.iter().map(|hit| &hit.content).collect::<Vec<_>>()
+    );
+}
+
+#[test]
 fn why_seed_is_a_fact_not_a_hub() {
     let (_dir, svc) = service();
     svc.remember_extracted("Alice and Bob both work in Rust.", &StubExtractor, None)

--- a/crates/velesdb-memory/tests/memory_service_bdd.rs
+++ b/crates/velesdb-memory/tests/memory_service_bdd.rs
@@ -255,6 +255,45 @@ fn remember_link_failure_keeps_a_fact_that_already_existed() {
 }
 
 #[test]
+fn remember_link_failure_leaves_a_pre_existing_facts_payload_untouched() {
+    // Regression: relation labels used to be validated only inside the
+    // edge-creation loop, AFTER store_fact — so a failed re-remember had
+    // already overwritten the fact's metadata and could arm a TTL on a
+    // permanent memory (it would silently expire despite the call
+    // erroring). All link input is now validated before any write.
+    let (_dir, svc) = service();
+    let target = svc.remember("a target fact", &[], None).expect("remember");
+    svc.remember(
+        "a decision",
+        &[],
+        Some(&meta(&[("source", json!("trusted"))])),
+    )
+    .expect("first remember");
+
+    svc.remember_with_ttl(
+        "a decision",
+        &[Link {
+            target,
+            relation: "x".repeat(600), // over MAX_RELATION_BYTES
+        }],
+        Some(&meta(&[("source", json!("overwritten"))])),
+        Some(60),
+    )
+    .expect_err("oversized relation label must error");
+
+    let hits = svc.recall("a decision", 5, None).expect("recall");
+    let hit = hits
+        .iter()
+        .find(|h| h.content == "a decision")
+        .expect("fact still present");
+    assert_eq!(
+        hit.metadata.as_ref().and_then(|m| m.get("source")),
+        Some(&json!("trusted")),
+        "a failed call must not overwrite the pre-existing fact's metadata"
+    );
+}
+
+#[test]
 fn recall_with_empty_query_returns_empty() {
     let (_dir, svc) = service();
     svc.remember("some stored fact", &[], None)

--- a/crates/velesdb-memory/tests/memory_service_bdd.rs
+++ b/crates/velesdb-memory/tests/memory_service_bdd.rs
@@ -199,12 +199,18 @@ fn remember_with_unknown_link_target_errors_and_stores_nothing() {
     );
 }
 
+/// A relation label just over the 512-byte cap, shared by the
+/// link-failure atomicity tests below.
+fn oversized_label() -> String {
+    "x".repeat(600)
+}
+
 #[test]
 fn remember_with_invalid_relation_label_errors_and_stores_nothing() {
-    // Regression: relation labels are validated AFTER the fact is stored
-    // (inside the edge-creation loop), so a bad label used to leave the
+    // Regression: relation labels used to be validated only AFTER the fact
+    // was stored (inside the edge-creation loop), so a bad label left the
     // fact persisted with no links — the exact half-written state the API
-    // docs rule out. A fresh fact must be rolled back on any link failure.
+    // docs rule out. Labels are now validated before any write.
     let (_dir, svc) = service();
     let target = svc.remember("a target fact", &[], None).expect("remember");
 
@@ -213,7 +219,7 @@ fn remember_with_invalid_relation_label_errors_and_stores_nothing() {
             "a decision",
             &[Link {
                 target,
-                relation: "x".repeat(600), // over MAX_RELATION_BYTES
+                relation: oversized_label(),
             }],
             None,
         )
@@ -241,7 +247,7 @@ fn remember_link_failure_keeps_a_fact_that_already_existed() {
         "a decision",
         &[Link {
             target,
-            relation: "x".repeat(600),
+            relation: oversized_label(),
         }],
         None,
     )
@@ -258,9 +264,11 @@ fn remember_link_failure_keeps_a_fact_that_already_existed() {
 fn remember_link_failure_leaves_a_pre_existing_facts_payload_untouched() {
     // Regression: relation labels used to be validated only inside the
     // edge-creation loop, AFTER store_fact — so a failed re-remember had
-    // already overwritten the fact's metadata and could arm a TTL on a
-    // permanent memory (it would silently expire despite the call
-    // erroring). All link input is now validated before any write.
+    // already overwritten the fact's metadata. All link input is now
+    // validated before any write. (Asserted here via metadata survival;
+    // the same pre-validation also prevents the failed call's TTL from
+    // being armed, which recall can't observe directly — `_veles_*` keys
+    // are stripped from caller-facing metadata.)
     let (_dir, svc) = service();
     let target = svc.remember("a target fact", &[], None).expect("remember");
     svc.remember(
@@ -274,7 +282,7 @@ fn remember_link_failure_leaves_a_pre_existing_facts_payload_untouched() {
         "a decision",
         &[Link {
             target,
-            relation: "x".repeat(600), // over MAX_RELATION_BYTES
+            relation: oversized_label(),
         }],
         Some(&meta(&[("source", json!("overwritten"))])),
         Some(60),

--- a/crates/velesdb-memory/tests/memory_service_bdd.rs
+++ b/crates/velesdb-memory/tests/memory_service_bdd.rs
@@ -200,6 +200,61 @@ fn remember_with_unknown_link_target_errors_and_stores_nothing() {
 }
 
 #[test]
+fn remember_with_invalid_relation_label_errors_and_stores_nothing() {
+    // Regression: relation labels are validated AFTER the fact is stored
+    // (inside the edge-creation loop), so a bad label used to leave the
+    // fact persisted with no links — the exact half-written state the API
+    // docs rule out. A fresh fact must be rolled back on any link failure.
+    let (_dir, svc) = service();
+    let target = svc.remember("a target fact", &[], None).expect("remember");
+
+    let err = svc
+        .remember(
+            "a decision",
+            &[Link {
+                target,
+                relation: "x".repeat(600), // over MAX_RELATION_BYTES
+            }],
+            None,
+        )
+        .expect_err("oversized relation label must error");
+    assert!(matches!(err, MemoryError::InvalidRelation(_)));
+
+    let hits = svc.recall("a decision", 5, None).expect("recall");
+    assert!(
+        hits.iter().all(|h| h.content != "a decision"),
+        "a failed link must roll the fresh fact back, not leave it half-written"
+    );
+}
+
+#[test]
+fn remember_link_failure_keeps_a_fact_that_already_existed() {
+    // The rollback must only remove a FRESH fact: re-remembering an existing
+    // fact with a bad link errors, but deleting the fact would destroy the
+    // state an earlier, successful call legitimately established.
+    let (_dir, svc) = service();
+    let target = svc.remember("a target fact", &[], None).expect("remember");
+    svc.remember("a decision", &[], None)
+        .expect("first remember succeeds");
+
+    svc.remember(
+        "a decision",
+        &[Link {
+            target,
+            relation: "x".repeat(600),
+        }],
+        None,
+    )
+    .expect_err("oversized relation label must error");
+
+    let hits = svc.recall("a decision", 5, None).expect("recall");
+    assert!(
+        hits.iter().any(|h| h.content == "a decision"),
+        "the pre-existing fact must survive the failed re-remember"
+    );
+}
+
+#[test]
 fn recall_with_empty_query_returns_empty() {
     let (_dir, svc) = service();
     svc.remember("some stored fact", &[], None)

--- a/crates/velesdb-node/Cargo.toml
+++ b/crates/velesdb-node/Cargo.toml
@@ -28,7 +28,7 @@ crate-type = ["cdylib"]
 # server stack (rmcp/tokio-server) — the license boundary AND the lean prebuild.
 # `ollama`+`extract` compile the real embedder + auto-extraction into the default
 # prebuild (full PyO3 parity). We MUST NOT depend on velesdb-core directly.
-velesdb-memory = { path = "../velesdb-memory", default-features = false, features = ["ollama", "extract"] }
+velesdb-memory = { path = "../velesdb-memory", default-features = false, features = ["persistence", "ollama", "extract"] }
 napi = { version = "3", default-features = false, features = ["napi9", "serde-json"] }
 napi-derive = "3"
 serde_json = { workspace = true }

--- a/crates/velesdb-python/Cargo.toml
+++ b/crates/velesdb-python/Cargo.toml
@@ -22,7 +22,7 @@ velesdb-core = { workspace = true }
 # The high-level memory wedge (MemoryService: remember/recall/relate/forget/why
 # + remember_extracted). `default-features = false` drops the MCP server stack
 # (rmcp/tokio-server); `ollama`+`extract` enable real embeddings and extraction.
-velesdb-memory = { path = "../velesdb-memory", default-features = false, features = ["ollama", "extract"] }
+velesdb-memory = { path = "../velesdb-memory", default-features = false, features = ["persistence", "ollama", "extract"] }
 pyo3 = { version = "0.29", features = ["extension-module", "multiple-pymethods", "abi3-py39", "generate-import-lib"] }
 serde_json = { workspace = true }
 numpy = "0.29"

--- a/crates/velesdb-wasm/Cargo.toml
+++ b/crates/velesdb-wasm/Cargo.toml
@@ -23,6 +23,11 @@ serde_json = { workspace = true }
 serde-wasm-bindgen = "0.6"
 # Disable persistence feature for WASM (tokio/mio, memmap2, rayon don't support WASM)
 velesdb-core = { workspace = true, default-features = false }
+# The agent-memory wedge orchestration (remember/recall/recall_fused/relate/
+# forget/why), generic over MemoryStore — this crate supplies the in-memory
+# backend (memory_store.rs). default-features=false drops the default `mcp`
+# feature (rmcp/tokio), leaving the offline, zero-dep HashEmbedder.
+velesdb-memory = { path = "../velesdb-memory", default-features = false }
 
 # getrandom must use the JS backend on wasm32-unknown-unknown.
 # `rand 0.10` depends directly on `getrandom 0.4`; other workspace

--- a/crates/velesdb-wasm/README.md
+++ b/crates/velesdb-wasm/README.md
@@ -12,6 +12,7 @@ WebAssembly build of [VelesDB](https://github.com/cyberlife-coder/VelesDB) - vec
 - **Memory optimization** - SQ8 (4x) and Binary (32x) quantization
 - **Knowledge Graph** - In-memory graph store with BFS/DFS traversal
 - **Agent Memory** - Semantic memory for AI agents (store/query knowledge facts)
+- **Memory Wedge** - The full `remember`/`recall`/`recallFused`/`relate`/`forget`/`why` agent memory wedge, in-memory only
 - **VelesQL parser** - Parse and validate VelesQL queries client-side
 - **Sparse search** - Inverted index with RRF hybrid fusion
 - **Lightweight** - Minimal bundle size
@@ -402,6 +403,40 @@ const results = memory.query(queryEmbedding, 5);
 console.log(memory.len());       // 2
 console.log(memory.dimension()); // 384
 ```
+
+### Memory Wedge (MemoryService)
+
+The full local-first agent memory wedge — `remember`/`recall`/`recallWhere`/
+`recallFused`/`relate`/`forget`/`why` — built on top of `SemanticMemory`
+(above) plus an in-memory graph store, so a fact reached only through a typed
+link (not vector similarity) still surfaces. The same wedge as
+`@wiscale/velesdb-memory-node` and the Python binding; **in-memory only**
+here (no filesystem access under WASM). Most consumers should use the higher-
+level `MemoryService` re-exported from
+[`@wiscale/velesdb-sdk`](../../sdks/typescript) instead, which wraps this
+class with Promise-returning methods and the SDK's typed error hierarchy.
+
+```javascript
+import init, { MemoryService } from '@wiscale/velesdb-wasm';
+
+await init();
+const memory = new MemoryService(384);
+
+const pr = memory.remember('PR #42 swaps the mutex for parking_lot', [], null);
+const decision = memory.remember(
+  'we chose parking_lot to avoid lock poisoning',
+  [{ target: pr, relation: 'decided_in' }],
+  null
+);
+
+const hits = memory.recall('lock poisoning', 5, null);          // vector recall
+const fused = memory.recallFused('lock poisoning', 5, null, null); // + graph promotion
+const { nodes, edges } = memory.why('why parking_lot', 2, null);   // seed + connected subgraph
+```
+
+Ids are decimal strings; every method is synchronous (no `Promise`) and
+throws a `JsValue` `Error` carrying a `.code` (`INVALID_INPUT` / `NOT_FOUND` /
+`INTERNAL`) on failure.
 
 ### Sparse Search (SparseIndex)
 

--- a/crates/velesdb-wasm/e2e/index.html
+++ b/crates/velesdb-wasm/e2e/index.html
@@ -19,10 +19,10 @@
     <div id="results"></div>
 
     <script type="module">
-        import init, { VectorStore } from './pkg/velesdb_wasm.js';
+        import init, { VectorStore, MemoryService } from './pkg/velesdb_wasm.js';
 
         // Expose to window for Playwright tests
-        window.VelesDB = { ready: false, VectorStore: null, error: null };
+        window.VelesDB = { ready: false, VectorStore: null, MemoryService: null, error: null };
 
         async function initWasm() {
             const status = document.getElementById('status');
@@ -31,6 +31,7 @@
             try {
                 await init();
                 window.VelesDB.VectorStore = VectorStore;
+                window.VelesDB.MemoryService = MemoryService;
                 window.VelesDB.ready = true;
                 status.className = 'success';
                 status.textContent = 'WASM module loaded successfully!';

--- a/crates/velesdb-wasm/e2e/package-lock.json
+++ b/crates/velesdb-wasm/e2e/package-lock.json
@@ -1,0 +1,79 @@
+{
+  "name": "velesdb-wasm-e2e",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "velesdb-wasm-e2e",
+      "version": "1.0.0",
+      "license": "SEE LICENSE IN ../../../LICENSE",
+      "devDependencies": {
+        "@playwright/test": "^1.40.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/crates/velesdb-wasm/e2e/tests/memory.spec.ts
+++ b/crates/velesdb-wasm/e2e/tests/memory.spec.ts
@@ -1,0 +1,70 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Memory Wedge E2E Tests for WASM SDK
+ *
+ * Runs `MemoryService` (remember/recall/recallFused/recallWhere/relate/
+ * forget/why) in a real browser, proving the wedge works off the
+ * wasm-pack `--target web` build the TypeScript SDK's `MemoryService`
+ * class (sdks/typescript/src/memory.ts) also loads.
+ */
+test.describe('VelesDB WASM Memory Wedge', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForFunction(() => window['VelesDB']?.ready === true, { timeout: 10000 });
+  });
+
+  test('should remember, recall, relate, and explain a connected subgraph', async ({ page }) => {
+    const result = await page.evaluate(() => {
+      const { MemoryService } = window['VelesDB'];
+      const memory = new MemoryService(4);
+
+      const decision = memory.remember('we chose parking_lot to avoid lock poisoning', [], null);
+      const ticket = memory.remember('EPIC-317 xyzzy quux frobnicate', [], null);
+      memory.relate(decision, ticket, 'decided_in');
+
+      const hits = memory.recall('lock poisoning', 5, null);
+      const fused = memory.recallFused('we chose parking_lot to avoid lock poisoning', 3, null, null);
+      const explanation = memory.why('we chose parking_lot to avoid lock poisoning', 2, null);
+
+      return { decision, ticket, hits, fused, explanation };
+    });
+
+    expect(result.hits.some((h) => h.id === result.decision)).toBe(true);
+    expect(result.fused.some((h) => h.id === result.ticket)).toBe(true);
+    expect(result.explanation.nodes.some((n) => n.id === result.ticket)).toBe(true);
+  });
+
+  test('should forget a memory so it no longer surfaces in recall', async ({ page }) => {
+    const result = await page.evaluate(() => {
+      const { MemoryService } = window['VelesDB'];
+      const memory = new MemoryService(4);
+
+      const id = memory.remember('a fact to forget', [], null);
+      memory.forget(id);
+      const hits = memory.recall('a fact to forget', 5, null);
+
+      return { id, hits };
+    });
+
+    expect(result.hits.every((h) => h.id !== result.id)).toBe(true);
+  });
+
+  test('should surface a structured NOT_FOUND error when relating to a missing memory', async ({
+    page,
+  }) => {
+    const code = await page.evaluate(() => {
+      const { MemoryService } = window['VelesDB'];
+      const memory = new MemoryService(4);
+      const a = memory.remember('fact a', [], null);
+      try {
+        memory.relate(a, '999999999', 'x');
+        return null;
+      } catch (e) {
+        return e.code;
+      }
+    });
+
+    expect(code).toBe('NOT_FOUND');
+  });
+});

--- a/crates/velesdb-wasm/src/lib.rs
+++ b/crates/velesdb-wasm/src/lib.rs
@@ -110,6 +110,7 @@ mod wasm_error;
 pub use agent::SemanticMemory;
 pub use database::{WasmCollectionHandle, WasmDatabase};
 pub use graph::{GraphEdge, GraphNode, GraphStore};
+pub use memory_service::WasmMemoryService;
 pub use vector_store::VectorStore;
 pub use velesdb_core::DistanceMetric;
 

--- a/crates/velesdb-wasm/src/lib.rs
+++ b/crates/velesdb-wasm/src/lib.rs
@@ -60,6 +60,12 @@ mod graph_store;
 mod graph_worker_hints;
 mod hybrid_quantized;
 mod idb_helpers;
+/// WASM binding for `velesdb-memory`'s agent-memory wedge — see
+/// [`memory_service::WasmMemoryService`], exported to JS as `MemoryService`.
+mod memory_service;
+/// The in-memory `MemoryStore` backend for `velesdb-memory`'s agent-memory
+/// wedge — see [`memory_store::WasmStore`].
+mod memory_store;
 mod parsing;
 mod persistence;
 mod serialization;

--- a/crates/velesdb-wasm/src/memory_service.rs
+++ b/crates/velesdb-wasm/src/memory_service.rs
@@ -177,6 +177,11 @@ struct RecollectionOut {
     id: String,
     score: f32,
     content: String,
+    /// Skipped when `None` so absent metadata reads as `undefined` in JS
+    /// (the Node binding's convention) even though [`to_js`] serializes
+    /// missing-as-null — that setting exists for `null` *values inside*
+    /// the metadata map, not for this absent-field case.
+    #[serde(skip_serializing_if = "Option::is_none")]
     metadata: Option<Value>,
 }
 
@@ -246,9 +251,17 @@ fn to_js(value: &impl Serialize) -> Result<JsValue, JsValue> {
     // `serde_json::Value::Object`, which the DEFAULT serializer turns into an
     // ES2015 `Map` — property access and `JSON.stringify` on it silently
     // yield nothing, breaking the documented `Record<string, unknown>` shape
-    // and Node-binding parity. `Option::None` still serializes to
-    // `undefined`, matching the Node binding's absent-field convention.
-    let serializer = serde_wasm_bindgen::Serializer::new().serialize_maps_as_objects(true);
+    // and Node-binding parity.
+    //
+    // `serialize_missing_as_null`: a `Value::Null` INSIDE metadata (a caller
+    // stored `{flag: null}`) must marshal as JS `null`, exactly like the
+    // Node binding — the default (`undefined`) makes `JSON.stringify` drop
+    // the key on WASM only. Absent metadata still reads as `undefined`:
+    // that field is `skip_serializing_if`-omitted, never serialized as a
+    // `None` this setting could turn into `null`.
+    let serializer = serde_wasm_bindgen::Serializer::new()
+        .serialize_maps_as_objects(true)
+        .serialize_missing_as_null(true);
     value
         .serialize(&serializer)
         .map_err(|e| structured_js_error(CODE_INTERNAL, &e.to_string()))

--- a/crates/velesdb-wasm/src/memory_service.rs
+++ b/crates/velesdb-wasm/src/memory_service.rs
@@ -38,37 +38,7 @@ const CODE_INTERNAL: &str = "INTERNAL";
 
 // --- Errors ------------------------------------------------------------
 
-/// Render a structured JS `Error` carrying a non-enumerable `code` property,
-/// mirroring [`crate::wasm_error::WasmError`]'s technique (kept as a separate,
-/// smaller helper here since this surface's error taxonomy — `MemoryError`'s
-/// `InvalidInput`/`NotFound`/`Internal` — is unrelated to core's `VELES-XXX`
-/// codes `WasmError` carries).
-#[cfg(target_arch = "wasm32")]
-fn structured_js_error(code: &str, message: &str) -> JsValue {
-    let err = js_sys::Error::new(message);
-    let descriptor = js_sys::Object::new();
-    let _ = js_sys::Reflect::set(
-        &descriptor,
-        &JsValue::from_str("value"),
-        &JsValue::from_str(code),
-    );
-    let _ = js_sys::Reflect::set(
-        &descriptor,
-        &JsValue::from_str("enumerable"),
-        &JsValue::FALSE,
-    );
-    let _ = js_sys::Reflect::set(&descriptor, &JsValue::from_str("writable"), &JsValue::FALSE);
-    js_sys::Object::define_property(&err, &JsValue::from_str("code"), &descriptor);
-    err.into()
-}
-
-/// Native-target fallback (no JS runtime off `wasm32`): a flat string
-/// carrying both the code and the message, so this module's own tests can
-/// assert on it without a browser.
-#[cfg(not(target_arch = "wasm32"))]
-fn structured_js_error(code: &str, message: &str) -> JsValue {
-    JsValue::from_str(&format!("[{code}] {message}"))
-}
+use crate::wasm_error::structured_js_error;
 
 fn category_code(e: &MemoryError) -> &'static str {
     use velesdb_memory::ErrorCategory;
@@ -272,7 +242,15 @@ impl From<Explanation> for ExplanationOut {
 }
 
 fn to_js(value: &impl Serialize) -> Result<JsValue, JsValue> {
-    serde_wasm_bindgen::to_value(value)
+    // `serialize_maps_as_objects`: `RecollectionOut.metadata` is a
+    // `serde_json::Value::Object`, which the DEFAULT serializer turns into an
+    // ES2015 `Map` — property access and `JSON.stringify` on it silently
+    // yield nothing, breaking the documented `Record<string, unknown>` shape
+    // and Node-binding parity. `Option::None` still serializes to
+    // `undefined`, matching the Node binding's absent-field convention.
+    let serializer = serde_wasm_bindgen::Serializer::new().serialize_maps_as_objects(true);
+    value
+        .serialize(&serializer)
         .map_err(|e| structured_js_error(CODE_INTERNAL, &e.to_string()))
 }
 

--- a/crates/velesdb-wasm/src/memory_service.rs
+++ b/crates/velesdb-wasm/src/memory_service.rs
@@ -1,0 +1,445 @@
+//! WASM binding for `velesdb-memory`'s agent-memory wedge — `remember` /
+//! `recall` / `recallWhere` / `recallFused` / `relate` / `forget` / `why`,
+//! backed entirely in-memory ([`WasmStore`]): no filesystem, no network, no
+//! `persistence` feature.
+//!
+//! Mirrors the Node/Python bindings' surface and conventions (decimal-string
+//! ids, `{code, message}` structured errors), deliberately diverging from
+//! this crate's own `VectorStore`/`SemanticMemory` (which marshal ids as raw
+//! `u64`/`BigInt`) — this surface's callers move between the Node, Python,
+//! and WASM bindings of the *same* `MemoryService`, so id representation
+//! consistency across those three matters more than matching this crate's
+//! internal convention.
+//!
+//! Synchronous, not `Promise`-returning: every operation here is pure
+//! in-memory work (no I/O to await), matching this crate's own
+//! `SemanticMemory`/`VectorStore` bindings rather than Node's async-by-default
+//! convention (which exists there to keep CPU work off Node's event loop —
+//! not a concern in a single-threaded WASM heap).
+//!
+//! `rememberExtracted` is omitted in this first cut: it needs a generative
+//! model, which would pull a network dependency into the WASM bundle by
+//! default. A JS-provided extractor callback is a natural v2 addition.
+
+use serde::Serialize;
+use serde_json::Value;
+use wasm_bindgen::prelude::*;
+
+use velesdb_memory::{
+    ColumnFilter, ColumnOp, Explanation, FusionOptions, HashEmbedder, MemoryEdge, MemoryError,
+    MemoryNode, MemoryService, Metadata, Recollection,
+};
+
+use crate::memory_store::WasmStore;
+
+const CODE_INVALID_INPUT: &str = "INVALID_INPUT";
+const CODE_NOT_FOUND: &str = "NOT_FOUND";
+const CODE_INTERNAL: &str = "INTERNAL";
+
+// --- Errors ------------------------------------------------------------
+
+/// Render a structured JS `Error` carrying a non-enumerable `code` property,
+/// mirroring [`crate::wasm_error::WasmError`]'s technique (kept as a separate,
+/// smaller helper here since this surface's error taxonomy — `MemoryError`'s
+/// `InvalidInput`/`NotFound`/`Internal` — is unrelated to core's `VELES-XXX`
+/// codes `WasmError` carries).
+#[cfg(target_arch = "wasm32")]
+fn structured_js_error(code: &str, message: &str) -> JsValue {
+    let err = js_sys::Error::new(message);
+    let descriptor = js_sys::Object::new();
+    let _ = js_sys::Reflect::set(
+        &descriptor,
+        &JsValue::from_str("value"),
+        &JsValue::from_str(code),
+    );
+    let _ = js_sys::Reflect::set(
+        &descriptor,
+        &JsValue::from_str("enumerable"),
+        &JsValue::FALSE,
+    );
+    let _ = js_sys::Reflect::set(&descriptor, &JsValue::from_str("writable"), &JsValue::FALSE);
+    js_sys::Object::define_property(&err, &JsValue::from_str("code"), &descriptor);
+    err.into()
+}
+
+/// Native-target fallback (no JS runtime off `wasm32`): a flat string
+/// carrying both the code and the message, so this module's own tests can
+/// assert on it without a browser.
+#[cfg(not(target_arch = "wasm32"))]
+fn structured_js_error(code: &str, message: &str) -> JsValue {
+    JsValue::from_str(&format!("[{code}] {message}"))
+}
+
+fn category_code(e: &MemoryError) -> &'static str {
+    use velesdb_memory::ErrorCategory;
+    match e.category() {
+        ErrorCategory::InvalidInput => CODE_INVALID_INPUT,
+        ErrorCategory::NotFound => CODE_NOT_FOUND,
+        ErrorCategory::Internal => CODE_INTERNAL,
+    }
+}
+
+fn to_js_err(e: MemoryError) -> JsValue {
+    structured_js_error(category_code(&e), &e.to_string())
+}
+
+fn invalid_input(msg: impl AsRef<str>) -> JsValue {
+    structured_js_error(CODE_INVALID_INPUT, msg.as_ref())
+}
+
+// --- Id / metadata / filter marshalling ---------------------------------
+
+fn id_to_string(id: u64) -> String {
+    id.to_string()
+}
+
+fn parse_id(s: &str) -> Result<u64, JsValue> {
+    s.parse::<u64>()
+        .map_err(|_| invalid_input(format!("invalid id '{s}' (expected a decimal u64 string)")))
+}
+
+/// `undefined`/`null` → `None`; a plain object → `Some(Metadata)`; anything
+/// else is a caller error.
+fn to_metadata(value: JsValue) -> Result<Option<Metadata>, JsValue> {
+    if value.is_undefined() || value.is_null() {
+        return Ok(None);
+    }
+    let parsed: Value = serde_wasm_bindgen::from_value(value)
+        .map_err(|e| invalid_input(format!("invalid metadata/filter: {e}")))?;
+    match parsed {
+        Value::Object(map) => Ok(Some(map)),
+        _ => Err(invalid_input("metadata/filter must be an object")),
+    }
+}
+
+#[derive(serde::Deserialize)]
+struct LinkInput {
+    target: String,
+    relation: String,
+}
+
+fn to_links(value: JsValue) -> Result<Vec<velesdb_memory::Link>, JsValue> {
+    if value.is_undefined() || value.is_null() {
+        return Ok(Vec::new());
+    }
+    let inputs: Vec<LinkInput> = serde_wasm_bindgen::from_value(value)
+        .map_err(|e| invalid_input(format!("invalid links: {e}")))?;
+    inputs
+        .into_iter()
+        .map(|l| {
+            Ok(velesdb_memory::Link {
+                target: parse_id(&l.target)?,
+                relation: l.relation,
+            })
+        })
+        .collect()
+}
+
+#[derive(serde::Deserialize)]
+struct ColumnFilterInput {
+    field: String,
+    op: String,
+    value: Value,
+}
+
+fn parse_op(op: &str) -> Result<ColumnOp, JsValue> {
+    match op {
+        "eq" => Ok(ColumnOp::Eq),
+        "ne" => Ok(ColumnOp::Ne),
+        "lt" => Ok(ColumnOp::Lt),
+        "le" => Ok(ColumnOp::Le),
+        "gt" => Ok(ColumnOp::Gt),
+        "ge" => Ok(ColumnOp::Ge),
+        other => Err(invalid_input(format!(
+            "invalid op '{other}' (expected eq|ne|lt|le|gt|ge)"
+        ))),
+    }
+}
+
+fn to_filters(value: JsValue) -> Result<Vec<ColumnFilter>, JsValue> {
+    let inputs: Vec<ColumnFilterInput> = serde_wasm_bindgen::from_value(value)
+        .map_err(|e| invalid_input(format!("invalid filters: {e}")))?;
+    inputs
+        .into_iter()
+        .map(|f| {
+            Ok(ColumnFilter {
+                field: f.field,
+                op: parse_op(&f.op)?,
+                value: f.value,
+            })
+        })
+        .collect()
+}
+
+#[derive(serde::Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+struct FusionOptionsInput {
+    hops: Option<usize>,
+    graph_boost: Option<f64>,
+    pool: Option<usize>,
+}
+
+fn to_fusion_options(value: JsValue) -> Result<FusionOptions, JsValue> {
+    let defaults = FusionOptions::default();
+    if value.is_undefined() || value.is_null() {
+        return Ok(defaults);
+    }
+    let input: FusionOptionsInput = serde_wasm_bindgen::from_value(value)
+        .map_err(|e| invalid_input(format!("invalid fusion options: {e}")))?;
+    Ok(FusionOptions {
+        hops: velesdb_memory::limits::clamp_hops(input.hops.unwrap_or(defaults.hops)),
+        graph_boost: input.graph_boost.unwrap_or(defaults.graph_boost),
+        pool: input.pool.or(defaults.pool),
+    })
+}
+
+// --- Output DTOs ---------------------------------------------------------
+//
+// Plain `Serialize` structs converted via `serde_wasm_bindgen::to_value`
+// (this crate's established pattern for JS-facing output, e.g. `agent.rs`'s
+// `SemanticResult`) — not `#[wasm_bindgen(object)]`, since these are one-shot
+// output values, not stateful classes. `id`/`from`/`to` are strings: a plain
+// `u64` field would serialize as a JS `number` and lose precision above 2^53.
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct RecollectionOut {
+    id: String,
+    score: f32,
+    content: String,
+    metadata: Option<Value>,
+}
+
+impl From<Recollection> for RecollectionOut {
+    fn from(r: Recollection) -> Self {
+        Self {
+            id: id_to_string(r.id),
+            score: r.score,
+            content: r.content,
+            metadata: r.metadata.map(Value::Object),
+        }
+    }
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct MemoryNodeOut {
+    id: String,
+    content: String,
+    hop: usize,
+}
+
+impl From<MemoryNode> for MemoryNodeOut {
+    fn from(n: MemoryNode) -> Self {
+        Self {
+            id: id_to_string(n.id),
+            content: n.content,
+            hop: n.hop,
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct MemoryEdgeOut {
+    from: String,
+    to: String,
+    relation: String,
+}
+
+impl From<MemoryEdge> for MemoryEdgeOut {
+    fn from(e: MemoryEdge) -> Self {
+        Self {
+            from: id_to_string(e.from),
+            to: id_to_string(e.to),
+            relation: e.relation,
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct ExplanationOut {
+    nodes: Vec<MemoryNodeOut>,
+    edges: Vec<MemoryEdgeOut>,
+}
+
+impl From<Explanation> for ExplanationOut {
+    fn from(e: Explanation) -> Self {
+        Self {
+            nodes: e.nodes.into_iter().map(MemoryNodeOut::from).collect(),
+            edges: e.edges.into_iter().map(MemoryEdgeOut::from).collect(),
+        }
+    }
+}
+
+fn to_js(value: &impl Serialize) -> Result<JsValue, JsValue> {
+    serde_wasm_bindgen::to_value(value)
+        .map_err(|e| structured_js_error(CODE_INTERNAL, &e.to_string()))
+}
+
+// --- The binding ---------------------------------------------------------
+
+/// Local-first agent memory with the `why()` graph wedge, running entirely
+/// in the browser. Uses the offline, zero-dependency `HashEmbedder` — the
+/// only embedder that makes sense with no filesystem and no network.
+#[wasm_bindgen(js_name = MemoryService)]
+pub struct WasmMemoryService {
+    inner: MemoryService<HashEmbedder, WasmStore>,
+}
+
+#[wasm_bindgen(js_class = MemoryService)]
+impl WasmMemoryService {
+    /// Create a new, empty in-memory store sized for `dimension`-dimensional
+    /// embeddings.
+    #[wasm_bindgen(constructor)]
+    #[must_use]
+    pub fn new(dimension: usize) -> WasmMemoryService {
+        let store = WasmStore::new(dimension);
+        let embedder = HashEmbedder::new(dimension);
+        Self {
+            inner: MemoryService::with_store(store, embedder),
+        }
+    }
+
+    /// Store a fact; resolves to its decimal-string id. `links` is an array
+    /// of `{target, relation}` edges to existing memories; `metadata` is an
+    /// optional plain object; `ttlSeconds` makes the fact expire after that
+    /// many seconds (omit, or `0`, for a permanent memory).
+    #[wasm_bindgen(js_name = remember)]
+    pub fn remember(
+        &self,
+        fact: &str,
+        links: JsValue,
+        metadata: JsValue,
+        ttl_seconds: Option<u64>,
+    ) -> Result<String, JsValue> {
+        if fact.len() > velesdb_memory::limits::MAX_FACT_BYTES {
+            return Err(invalid_input(format!(
+                "fact exceeds {} bytes ({} given)",
+                velesdb_memory::limits::MAX_FACT_BYTES,
+                fact.len()
+            )));
+        }
+        let links = to_links(links)?;
+        let metadata = to_metadata(metadata)?;
+        self.inner
+            .remember_with_ttl(fact, &links, metadata.as_ref(), ttl_seconds)
+            .map(id_to_string)
+            .map_err(to_js_err)
+    }
+
+    /// Recall up to `k` (default 10, capped) memories similar to `query`,
+    /// optionally narrowed by an exact-match metadata `filter`.
+    #[wasm_bindgen(js_name = recall)]
+    pub fn recall(
+        &self,
+        query: &str,
+        k: Option<usize>,
+        filter: JsValue,
+    ) -> Result<JsValue, JsValue> {
+        let k = velesdb_memory::limits::clamp_recall_limit(k.unwrap_or(10));
+        let filter = to_metadata(filter)?;
+        let hits = self
+            .inner
+            .recall(query, k, filter.as_ref())
+            .map_err(to_js_err)?;
+        to_js(
+            &hits
+                .into_iter()
+                .map(RecollectionOut::from)
+                .collect::<Vec<_>>(),
+        )
+    }
+
+    /// Fused vector + `ColumnStore` recall: like [`Self::recall`] but
+    /// `filters` support ranges/comparisons (`gt`, `le`, …).
+    #[wasm_bindgen(js_name = recallWhere)]
+    pub fn recall_where(
+        &self,
+        query: &str,
+        filters: JsValue,
+        k: Option<usize>,
+    ) -> Result<JsValue, JsValue> {
+        let k = velesdb_memory::limits::clamp_recall_limit(k.unwrap_or(10));
+        let filters = to_filters(filters)?;
+        let hits = self
+            .inner
+            .recall_where(query, k, &filters)
+            .map_err(to_js_err)?;
+        to_js(
+            &hits
+                .into_iter()
+                .map(RecollectionOut::from)
+                .collect::<Vec<_>>(),
+        )
+    }
+
+    /// Fused vector + graph recall: like [`Self::recall`], but also walks
+    /// the graph from the top vector hit and promotes any fact it reaches
+    /// into the ranking. `opts` is optional (`{hops?, graphBoost?, pool?}`).
+    #[wasm_bindgen(js_name = recallFused)]
+    pub fn recall_fused(
+        &self,
+        query: &str,
+        k: Option<usize>,
+        filter: JsValue,
+        opts: JsValue,
+    ) -> Result<JsValue, JsValue> {
+        let k = velesdb_memory::limits::clamp_recall_limit(k.unwrap_or(10));
+        let filter = to_metadata(filter)?;
+        let opts = to_fusion_options(opts)?;
+        let hits = self
+            .inner
+            .recall_fused(query, k, filter.as_ref(), opts)
+            .map_err(to_js_err)?;
+        to_js(
+            &hits
+                .into_iter()
+                .map(RecollectionOut::from)
+                .collect::<Vec<_>>(),
+        )
+    }
+
+    /// Create a typed edge `from -> to`. Resolves to the edge's
+    /// decimal-string id.
+    #[wasm_bindgen(js_name = relate)]
+    pub fn relate(&self, from: &str, to: &str, relation: &str) -> Result<String, JsValue> {
+        let from = parse_id(from)?;
+        let to = parse_id(to)?;
+        self.inner
+            .relate(from, to, relation)
+            .map(id_to_string)
+            .map_err(to_js_err)
+    }
+
+    /// Delete a memory by id.
+    #[wasm_bindgen(js_name = forget)]
+    pub fn forget(&self, id: &str) -> Result<(), JsValue> {
+        let id = parse_id(id)?;
+        self.inner.forget(id).map_err(to_js_err)
+    }
+
+    /// Explain a decision: the best-matching memory plus its connected
+    /// subgraph. Resolves to `{nodes, edges}`. `maxHops` (default 2) is
+    /// capped at 10.
+    #[wasm_bindgen(js_name = why)]
+    pub fn why(
+        &self,
+        decision: &str,
+        max_hops: Option<usize>,
+        filter: JsValue,
+    ) -> Result<JsValue, JsValue> {
+        let max_hops = velesdb_memory::limits::clamp_hops(
+            max_hops.unwrap_or(velesdb_memory::limits::DEFAULT_WHY_HOPS),
+        );
+        let filter = to_metadata(filter)?;
+        let explanation = self
+            .inner
+            .why(decision, max_hops, filter.as_ref())
+            .map_err(to_js_err)?;
+        to_js(&ExplanationOut::from(explanation))
+    }
+}
+
+#[cfg(test)]
+#[path = "memory_service_tests.rs"]
+mod tests;

--- a/crates/velesdb-wasm/src/memory_service_tests.rs
+++ b/crates/velesdb-wasm/src/memory_service_tests.rs
@@ -107,7 +107,15 @@ fn test_inner_recall_fused_reaches_a_graph_connected_fact() {
             velesdb_memory::FusionOptions::default(),
         )
         .unwrap();
-    let rank_of = |id: u64| fused.iter().position(|r| r.id == id);
+    // `expect` both ranks: `Option`'s ordering makes `None < Some(_)` true,
+    // so comparing raw `position()` results would pass vacuously if the
+    // graph-reached fact were dropped from the results entirely.
+    let rank_of = |id: u64| {
+        fused
+            .iter()
+            .position(|r| r.id == id)
+            .expect("both facts must be present in the fused results")
+    };
     assert!(
         rank_of(ticket) < rank_of(distractor),
         "graph-reached fact must outrank the distractor"

--- a/crates/velesdb-wasm/src/memory_service_tests.rs
+++ b/crates/velesdb-wasm/src/memory_service_tests.rs
@@ -1,0 +1,135 @@
+//! Native (`cargo test -p velesdb-wasm`) tests for `WasmMemoryService`.
+//!
+//! `wasm-bindgen`'s `JsValue` cannot be touched off `wasm32` at all —
+//! constructing even `JsValue::UNDEFINED`, or `JsValue::from_str` on an
+//! error path, aborts the process natively ("cannot call wasm-bindgen
+//! imported functions on non-wasm targets"; it's an opaque handle into a
+//! JS-engine-side table with no native fallback). This crate's own
+//! `wasm_error_tests.rs` establishes the pattern for this: test the
+//! *pre-JsValue* data (there, `WasmError`; here, `velesdb_memory::MemoryError`
+//! via `svc.inner`, the private, pure-Rust `MemoryService` field) and never
+//! call the JsValue-producing conversion natively.
+//!
+//! What *is* provably safe here: `relate`/`forget`'s success paths — a
+//! `Result::Ok` never invokes `.map_err`'s JsValue-constructing closure — and
+//! anything reached purely through `svc.inner`. Every method that takes a
+//! `JsValue` parameter, or whose *error* path is exercised (malformed id,
+//! unknown target via the wasm boundary), is untestable here; full coverage
+//! lives in the `wasm-bindgen-test` suite (a real JS host via
+//! `wasm-pack test --node`).
+
+use super::*;
+
+#[test]
+fn test_relate_and_forget_round_trip_through_the_wasm_boundary() {
+    let svc = WasmMemoryService::new(4);
+    let a = svc.inner.remember("fact a", &[], None).unwrap();
+    let b = svc.inner.remember("fact b", &[], None).unwrap();
+
+    let edge = svc
+        .relate(&a.to_string(), &b.to_string(), "references")
+        .unwrap();
+    assert!(
+        edge.parse::<u64>().is_ok(),
+        "edge id must be a decimal string"
+    );
+    let explanation = svc.inner.why("fact a", 1, None).unwrap();
+    assert!(
+        explanation.nodes.iter().any(|n| n.id == b),
+        "relate() through the wasm boundary must produce a traversable edge"
+    );
+
+    svc.forget(&a.to_string()).unwrap();
+    let hits = svc.inner.recall("fact a", 5, None).unwrap();
+    assert!(
+        hits.iter().all(|h| h.id != a),
+        "forget() through the wasm boundary must actually delete the fact"
+    );
+}
+
+#[test]
+fn test_forget_unknown_id_is_ok_idempotent_delete() {
+    let svc = WasmMemoryService::new(4);
+    // MemoryStore::delete on a WasmStore is a plain removal, not an
+    // existence check — deleting a never-stored id is a no-op, not an error
+    // (matches the native backend's `delete` semantics), so this stays on
+    // the Ok path and never touches JsValue.
+    assert!(svc.forget("999999999").is_ok());
+}
+
+// --- Pure-Rust coverage of the underlying orchestration (via `svc.inner`,
+// bypassing the JsValue-taking wrapper methods entirely) — proves WasmStore
+// correctly backs the exact same MemoryService wedge those wrappers delegate
+// to, including error variants the wasm boundary can't be probed for here.
+
+#[test]
+fn test_inner_remember_then_recall_finds_the_fact() {
+    let svc = WasmMemoryService::new(4);
+    let id = svc
+        .inner
+        .remember("parking_lot avoids lock poisoning", &[], None)
+        .unwrap();
+    let hits = svc.inner.recall("lock poisoning", 5, None).unwrap();
+    assert!(hits.iter().any(|h| h.id == id));
+}
+
+#[test]
+fn test_inner_relate_to_unknown_target_errors() {
+    let svc = WasmMemoryService::new(4);
+    let a = svc.inner.remember("fact a", &[], None).unwrap();
+    let err = svc.inner.relate(a, 999_999_999, "references").unwrap_err();
+    assert!(matches!(err, MemoryError::UnknownMemory(999_999_999)));
+}
+
+#[test]
+fn test_inner_recall_fused_reaches_a_graph_connected_fact() {
+    let svc = WasmMemoryService::new(4);
+    let decision = svc
+        .inner
+        .remember("we chose parking_lot to avoid lock poisoning", &[], None)
+        .unwrap();
+    let ticket = svc
+        .inner
+        .remember("EPIC-317 xyzzy quux frobnicate", &[], None)
+        .unwrap();
+    let distractor = svc
+        .inner
+        .remember("the quarterly report is due next Friday", &[], None)
+        .unwrap();
+    svc.inner.relate(decision, ticket, "decided_in").unwrap();
+
+    let fused = svc
+        .inner
+        .recall_fused(
+            "we chose parking_lot to avoid lock poisoning",
+            3,
+            None,
+            velesdb_memory::FusionOptions::default(),
+        )
+        .unwrap();
+    let rank_of = |id: u64| fused.iter().position(|r| r.id == id);
+    assert!(
+        rank_of(ticket) < rank_of(distractor),
+        "graph-reached fact must outrank the distractor"
+    );
+}
+
+#[test]
+fn test_inner_why_reaches_a_two_hop_fact_vector_search_misses() {
+    let svc = WasmMemoryService::new(4);
+    let decision = svc
+        .inner
+        .remember("we chose parking_lot to avoid lock poisoning", &[], None)
+        .unwrap();
+    let ticket = svc
+        .inner
+        .remember("EPIC-317 xyzzy quux frobnicate", &[], None)
+        .unwrap();
+    svc.inner.relate(decision, ticket, "decided_in").unwrap();
+
+    let explanation = svc
+        .inner
+        .why("we chose parking_lot to avoid lock poisoning", 2, None)
+        .unwrap();
+    assert!(explanation.nodes.iter().any(|n| n.id == ticket));
+}

--- a/crates/velesdb-wasm/src/memory_store.rs
+++ b/crates/velesdb-wasm/src/memory_store.rs
@@ -1,0 +1,442 @@
+//! In-memory [`MemoryStore`] backend for the browser: no filesystem, no
+//! `persistence` feature, no network. This is what lets `velesdb-memory`'s
+//! agent-memory wedge (`remember`/`recall`/`recall_fused`/`relate`/`forget`/
+//! `why`) run entirely client-side.
+//!
+//! Not durable across a page reload by itself — pair with this crate's own
+//! `IndexedDB` persistence (`vector_store_persistence.rs`) if that's needed;
+//! this store only holds state in the WASM heap.
+//!
+//! Reuses the crate's existing similarity math ([`vector_ops::compute_filtered_scores`])
+//! and edge storage ([`WasmGraphStore`]) rather than duplicating them — this
+//! module is the glue that makes those primitives satisfy `MemoryStore`, not
+//! a second implementation of either.
+
+use std::cell::RefCell;
+use std::collections::HashMap;
+
+use serde_json::{Map, Value};
+use velesdb_memory::{
+    ColumnFilter, ColumnOp, MemoryEdge, MemoryError, MemoryStore, Metadata, Recollection,
+};
+
+use crate::graph_store::WasmGraphStore;
+use crate::{vector_ops, DistanceMetric, StorageMode};
+
+/// Reserved payload key for a fact's durable expiry (a millisecond Unix
+/// timestamp), mirroring `velesdb-core`'s `_veles_expires_at` naming so the
+/// concept is consistent for anyone who knows the native store — the raw
+/// units are a private implementation detail, since nothing outside this
+/// module ever reads it directly (`get_metadata`'s reserved-key filtering
+/// happens one layer up, in `velesdb-memory`'s `service.rs`).
+const EXPIRES_AT_KEY: &str = "_veles_expires_at";
+
+/// Current wall-clock time in milliseconds since the Unix epoch. Real time on
+/// both targets — `wasm32` via `js_sys::Date`, native via `SystemTime` — so
+/// TTL expiry is exercised by ordinary `cargo test`, not just in a browser.
+#[cfg(target_arch = "wasm32")]
+fn now_ms() -> u64 {
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    let ms = js_sys::Date::now() as u64;
+    ms
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn now_ms() -> u64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| u64::try_from(d.as_millis()).unwrap_or(u64::MAX))
+        .unwrap_or(0)
+}
+
+/// One stored fact: its embedding and its full JSON payload (`content` plus
+/// any caller metadata and the reserved expiry key).
+struct Fact {
+    embedding: Vec<f32>,
+    payload: Map<String, Value>,
+}
+
+impl Fact {
+    fn is_expired(&self) -> bool {
+        self.payload
+            .get(EXPIRES_AT_KEY)
+            .and_then(Value::as_u64)
+            .is_some_and(|expires_at| now_ms() >= expires_at)
+    }
+}
+
+/// Build a fact payload: `content` plus every key of `metadata` (already
+/// validated reserved-key-free by `velesdb-memory`'s orchestration layer),
+/// plus a durable expiry if `ttl_seconds` is set.
+fn build_payload(
+    content: &str,
+    metadata: Option<&Metadata>,
+    ttl_seconds: Option<u64>,
+) -> Map<String, Value> {
+    let mut payload = metadata.cloned().unwrap_or_default();
+    payload.insert("content".to_string(), Value::String(content.to_string()));
+    if let Some(ttl) = ttl_seconds {
+        payload.insert(
+            EXPIRES_AT_KEY.to_string(),
+            Value::from(now_ms().saturating_add(ttl.saturating_mul(1000))),
+        );
+    }
+    payload
+}
+
+fn content_of(payload: &Map<String, Value>) -> String {
+    payload
+        .get("content")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_string()
+}
+
+/// True when every key in `filter` is present in `payload` with an equal value.
+fn matches_all(payload: &Map<String, Value>, filter: &Metadata) -> bool {
+    filter.iter().all(|(k, v)| payload.get(k) == Some(v))
+}
+
+struct Inner {
+    dimension: usize,
+    facts: HashMap<u64, Fact>,
+    /// Insertion order, so query results over a tiny corpus are at least
+    /// deterministic when scores tie (no correctness dependency on this).
+    order: Vec<u64>,
+    graph: WasmGraphStore,
+}
+
+impl Inner {
+    fn live_fact(&self, id: u64) -> Option<&Fact> {
+        let fact = self.facts.get(&id)?;
+        (!fact.is_expired()).then_some(fact)
+    }
+
+    /// Flat `(ids, embeddings, payloads)` over every non-expired fact — the
+    /// shape [`vector_ops::compute_filtered_scores`] expects. Rebuilt per
+    /// query rather than kept incrementally in sync: simpler and safer, and
+    /// perfectly adequate at browser-corpus scale (thousands of facts, not
+    /// millions).
+    fn live_snapshot(&self) -> (Vec<u64>, Vec<f32>, Vec<Option<Value>>) {
+        let mut ids = Vec::new();
+        let mut data = Vec::new();
+        let mut payloads = Vec::new();
+        for &id in &self.order {
+            let Some(fact) = self.live_fact(id) else {
+                continue;
+            };
+            ids.push(id);
+            data.extend_from_slice(&fact.embedding);
+            payloads.push(Some(Value::Object(fact.payload.clone())));
+        }
+        (ids, data, payloads)
+    }
+}
+
+/// The in-memory [`MemoryStore`] backend `velesdb-wasm` supplies to
+/// `MemoryService`, so the agent-memory wedge runs entirely in the browser.
+pub struct WasmStore {
+    inner: RefCell<Inner>,
+}
+
+impl WasmStore {
+    /// Create an empty store sized for `dimension`-dimensional embeddings.
+    #[must_use]
+    pub fn new(dimension: usize) -> Self {
+        Self {
+            inner: RefCell::new(Inner {
+                dimension,
+                facts: HashMap::new(),
+                order: Vec::new(),
+                graph: WasmGraphStore::new(),
+            }),
+        }
+    }
+
+    fn put(&self, id: u64, embedding: &[f32], payload: Map<String, Value>) {
+        let mut inner = self.inner.borrow_mut();
+        if !inner.facts.contains_key(&id) {
+            inner.order.push(id);
+        }
+        inner.facts.insert(
+            id,
+            Fact {
+                embedding: embedding.to_vec(),
+                payload,
+            },
+        );
+    }
+}
+
+impl MemoryStore for WasmStore {
+    fn store(&self, id: u64, content: &str, embedding: &[f32]) -> Result<(), MemoryError> {
+        self.put(id, embedding, build_payload(content, None, None));
+        Ok(())
+    }
+
+    fn store_with_metadata(
+        &self,
+        id: u64,
+        content: &str,
+        embedding: &[f32],
+        metadata: &Metadata,
+    ) -> Result<(), MemoryError> {
+        self.put(id, embedding, build_payload(content, Some(metadata), None));
+        Ok(())
+    }
+
+    fn store_with_ttl(
+        &self,
+        id: u64,
+        content: &str,
+        embedding: &[f32],
+        ttl_seconds: u64,
+    ) -> Result<(), MemoryError> {
+        self.put(
+            id,
+            embedding,
+            build_payload(content, None, Some(ttl_seconds)),
+        );
+        Ok(())
+    }
+
+    fn update_metadata(&self, id: u64, metadata: &Metadata) -> Result<(), MemoryError> {
+        let mut inner = self.inner.borrow_mut();
+        let Some(fact) = inner.facts.get_mut(&id) else {
+            return Err(MemoryError::UnknownMemory(id));
+        };
+        for (key, value) in metadata {
+            fact.payload.insert(key.clone(), value.clone());
+        }
+        Ok(())
+    }
+
+    fn get(&self, id: u64) -> Result<Option<(String, Vec<f32>)>, MemoryError> {
+        let inner = self.inner.borrow();
+        Ok(inner
+            .live_fact(id)
+            .map(|fact| (content_of(&fact.payload), fact.embedding.clone())))
+    }
+
+    fn get_metadata(&self, id: u64) -> Result<Option<Metadata>, MemoryError> {
+        let inner = self.inner.borrow();
+        Ok(inner.live_fact(id).map(|fact| fact.payload.clone()))
+    }
+
+    fn get_metadata_batch(&self, ids: &[u64]) -> Result<Vec<Option<Metadata>>, MemoryError> {
+        let inner = self.inner.borrow();
+        Ok(ids
+            .iter()
+            .map(|&id| inner.live_fact(id).map(|fact| fact.payload.clone()))
+            .collect())
+    }
+
+    fn delete(&self, id: u64) -> Result<(), MemoryError> {
+        let mut inner = self.inner.borrow_mut();
+        inner.facts.remove(&id);
+        inner.order.retain(|&x| x != id);
+        // Cascade: an edge dangling off a deleted memory must not survive it
+        // (matches the native store's cascading delete).
+        inner
+            .graph
+            .delete_edges_where(|e| e.source == id || e.target == id);
+        Ok(())
+    }
+
+    fn query_filtered(
+        &self,
+        embedding: &[f32],
+        k: usize,
+        filter: &Metadata,
+        offset: usize,
+    ) -> Result<Vec<(u64, f32, String)>, MemoryError> {
+        self.query_scored(embedding, k, offset, |payload| matches_all(payload, filter))
+    }
+
+    fn query_excluding(
+        &self,
+        embedding: &[f32],
+        k: usize,
+        exclude: &Metadata,
+    ) -> Result<Vec<(u64, f32, String)>, MemoryError> {
+        self.query_scored(embedding, k, 0, |payload| {
+            exclude.is_empty() || !matches_all(payload, exclude)
+        })
+    }
+
+    fn query_columnar(
+        &self,
+        embedding: &[f32],
+        k: usize,
+        filters: &[ColumnFilter],
+    ) -> Result<Vec<Recollection>, MemoryError> {
+        for filter in filters {
+            validate_field(&filter.field)?;
+            validate_scalar(&filter.value)?;
+        }
+        let scored = self.query_scored(embedding, k, 0, |payload| {
+            columnar_matches(payload, filters)
+        })?;
+        let inner = self.inner.borrow();
+        Ok(scored
+            .into_iter()
+            .map(|(id, score, content)| Recollection {
+                id,
+                score,
+                content,
+                metadata: inner.live_fact(id).map(|fact| fact.payload.clone()),
+            })
+            .collect())
+    }
+
+    fn relate(&self, from: u64, to: u64, relation: &str) -> Result<u64, MemoryError> {
+        let mut inner = self.inner.borrow_mut();
+        // `explicit_id: None` derives the id from (source, target, label), so
+        // the only documented failure mode (an explicit id collision) cannot
+        // occur here — still mapped, not unwrapped, so a future signature
+        // change can't silently reintroduce a panic path.
+        inner
+            .graph
+            .insert_edge(None, from, to, relation.to_string(), None)
+            .map_err(MemoryError::InvalidRelation)
+    }
+
+    fn relations(&self, id: u64) -> Result<Vec<MemoryEdge>, MemoryError> {
+        let inner = self.inner.borrow();
+        Ok(inner
+            .graph
+            .edges()
+            .iter()
+            .filter(|e| e.source == id)
+            .map(|e| MemoryEdge {
+                from: e.source,
+                to: e.target,
+                relation: e.label.clone(),
+            })
+            .collect())
+    }
+
+    fn count(&self) -> usize {
+        let inner = self.inner.borrow();
+        inner
+            .order
+            .iter()
+            .filter(|&&id| inner.live_fact(id).is_some())
+            .count()
+    }
+}
+
+impl WasmStore {
+    /// Shared vector-search core for [`MemoryStore::query_filtered`],
+    /// [`MemoryStore::query_excluding`], and [`MemoryStore::query_columnar`]:
+    /// score every non-expired fact whose payload passes `predicate` against
+    /// `embedding`, rank, and take `k` after `offset`.
+    fn query_scored(
+        &self,
+        embedding: &[f32],
+        k: usize,
+        offset: usize,
+        predicate: impl Fn(&Map<String, Value>) -> bool,
+    ) -> Result<Vec<(u64, f32, String)>, MemoryError> {
+        let inner = self.inner.borrow();
+        let (ids, data, payloads) = inner.live_snapshot();
+        let mut scored = vector_ops::compute_filtered_scores(
+            embedding,
+            &ids,
+            &payloads,
+            &data,
+            &[],
+            &[],
+            &[],
+            &[],
+            inner.dimension,
+            DistanceMetric::Cosine,
+            StorageMode::Full,
+            |payload| payload.as_object().is_some_and(&predicate),
+        );
+        scored.sort_by(|a, b| b.1.total_cmp(&a.1));
+        Ok(scored
+            .into_iter()
+            .skip(offset)
+            .take(k)
+            .map(|(id, score, payload)| {
+                let content = payload
+                    .and_then(Value::as_object)
+                    .map(content_of)
+                    .unwrap_or_default();
+                (id, score, content)
+            })
+            .collect())
+    }
+}
+
+/// True when every filter in `filters` is satisfied by `payload` (AND-combined).
+fn columnar_matches(payload: &Map<String, Value>, filters: &[ColumnFilter]) -> bool {
+    filters.iter().all(|filter| {
+        payload
+            .get(&filter.field)
+            .is_some_and(|value| compare(value, filter.op, &filter.value))
+    })
+}
+
+/// Evaluate one [`ColumnOp`] between a stored payload value and the filter's
+/// value: numeric comparison when both are numbers, lexicographic when both
+/// are strings, equality-only otherwise (matches `VelesQL`'s scalar-comparison
+/// semantics for the types `MemoryService::recall_where` accepts).
+fn compare(stored: &Value, op: ColumnOp, target: &Value) -> bool {
+    if let (Some(a), Some(b)) = (stored.as_f64(), target.as_f64()) {
+        return match op {
+            ColumnOp::Eq => (a - b).abs() < f64::EPSILON,
+            ColumnOp::Ne => (a - b).abs() >= f64::EPSILON,
+            ColumnOp::Lt => a < b,
+            ColumnOp::Le => a <= b,
+            ColumnOp::Gt => a > b,
+            ColumnOp::Ge => a >= b,
+        };
+    }
+    if let (Some(a), Some(b)) = (stored.as_str(), target.as_str()) {
+        return match op {
+            ColumnOp::Eq => a == b,
+            ColumnOp::Ne => a != b,
+            ColumnOp::Lt => a < b,
+            ColumnOp::Le => a <= b,
+            ColumnOp::Gt => a > b,
+            ColumnOp::Ge => a >= b,
+        };
+    }
+    match op {
+        ColumnOp::Eq => stored == target,
+        ColumnOp::Ne => stored != target,
+        _ => false,
+    }
+}
+
+/// Accept only plain, non-reserved identifier field names — mirrors
+/// `velesdb-memory`'s own `NativeStore::query_columnar` validation, since
+/// this store enforces the same contract independently (no VelesQL text is
+/// built here, so injection isn't a risk, but the reserved-column rule is
+/// part of `recall_where`'s documented contract regardless of backend).
+fn validate_field(field: &str) -> Result<(), MemoryError> {
+    let plain = !field.is_empty() && field.chars().all(|c| c.is_ascii_alphanumeric() || c == '_');
+    let reserved = field == "content" || field.starts_with("_veles_");
+    if plain && !reserved {
+        Ok(())
+    } else {
+        Err(MemoryError::InvalidFilter(field.to_owned()))
+    }
+}
+
+/// Reject non-scalar filter values, matching `NativeStore`'s validation.
+fn validate_scalar(value: &Value) -> Result<(), MemoryError> {
+    match value {
+        Value::String(_) | Value::Number(_) | Value::Bool(_) => Ok(()),
+        _ => Err(MemoryError::InvalidFilter(format!(
+            "value must be a string, number, or boolean, got {value}"
+        ))),
+    }
+}
+
+#[cfg(test)]
+#[path = "memory_store_tests.rs"]
+mod tests;

--- a/crates/velesdb-wasm/src/memory_store.rs
+++ b/crates/velesdb-wasm/src/memory_store.rs
@@ -7,7 +7,7 @@
 //! `IndexedDB` persistence (`vector_store_persistence.rs`) if that's needed;
 //! this store only holds state in the WASM heap.
 //!
-//! Reuses the crate's existing similarity math ([`vector_ops::compute_filtered_scores`])
+//! Reuses the crate's existing similarity math ([`vector_ops::compute_scores`])
 //! and edge storage ([`WasmGraphStore`]) rather than duplicating them — this
 //! module is the glue that makes those primitives satisfy `MemoryStore`, not
 //! a second implementation of either.
@@ -267,8 +267,8 @@ impl MemoryStore for WasmStore {
                 // Reserved keys (`content`, `_veles_*`) are stripped exactly
                 // like the native backend and every other recall path — raw
                 // payloads must never reach a caller-facing `Recollection`.
-                metadata: velesdb_memory::storage::strip_reserved_keys(
-                    inner.live_fact(id).map(|fact| fact.payload.clone()),
+                metadata: velesdb_memory::storage::strip_reserved_keys_ref(
+                    inner.live_fact(id).map(|fact| &fact.payload),
                 ),
             })
             .collect())
@@ -331,7 +331,10 @@ impl WasmStore {
     ///
     /// `predicate` is applied while *building* the scoring input, borrowing
     /// each payload in place — nothing is cloned for a non-matching fact,
-    /// and content is cloned only for the `k` rows actually returned.
+    /// and content is cloned only for the `k` rows actually returned. The
+    /// admitted facts are held as borrows (`matched`) rather than re-fetched
+    /// through the time-sensitive `live_fact` after ranking: a TTL lapsing
+    /// mid-query must not turn an admitted hit's content into `""`.
     fn query_scored(
         &self,
         embedding: &[f32],
@@ -342,6 +345,7 @@ impl WasmStore {
         let inner = self.inner.borrow();
         let mut ids = Vec::new();
         let mut data = Vec::new();
+        let mut matched: HashMap<u64, &Fact> = HashMap::new();
         for &id in &inner.order {
             let Some(fact) = inner.live_fact(id) else {
                 continue;
@@ -351,6 +355,7 @@ impl WasmStore {
             }
             ids.push(id);
             data.extend_from_slice(&fact.embedding);
+            matched.insert(id, fact);
         }
         let mut scored = vector_ops::compute_scores(
             embedding,
@@ -370,8 +375,8 @@ impl WasmStore {
             .skip(offset)
             .take(k)
             .map(|(id, score)| {
-                let content = inner
-                    .live_fact(id)
+                let content = matched
+                    .get(&id)
                     .map(|fact| content_of(&fact.payload))
                     .unwrap_or_default();
                 (id, score, content)

--- a/crates/velesdb-wasm/src/memory_store.rs
+++ b/crates/velesdb-wasm/src/memory_store.rs
@@ -112,26 +112,6 @@ impl Inner {
         let fact = self.facts.get(&id)?;
         (!fact.is_expired()).then_some(fact)
     }
-
-    /// Flat `(ids, embeddings, payloads)` over every non-expired fact — the
-    /// shape [`vector_ops::compute_filtered_scores`] expects. Rebuilt per
-    /// query rather than kept incrementally in sync: simpler and safer, and
-    /// perfectly adequate at browser-corpus scale (thousands of facts, not
-    /// millions).
-    fn live_snapshot(&self) -> (Vec<u64>, Vec<f32>, Vec<Option<Value>>) {
-        let mut ids = Vec::new();
-        let mut data = Vec::new();
-        let mut payloads = Vec::new();
-        for &id in &self.order {
-            let Some(fact) = self.live_fact(id) else {
-                continue;
-            };
-            ids.push(id);
-            data.extend_from_slice(&fact.embedding);
-            payloads.push(Some(Value::Object(fact.payload.clone())));
-        }
-        (ids, data, payloads)
-    }
 }
 
 /// The in-memory [`MemoryStore`] backend `velesdb-wasm` supplies to
@@ -272,8 +252,7 @@ impl MemoryStore for WasmStore {
         filters: &[ColumnFilter],
     ) -> Result<Vec<Recollection>, MemoryError> {
         for filter in filters {
-            validate_field(&filter.field)?;
-            validate_scalar(&filter.value)?;
+            velesdb_memory::storage::validate_column_filter(filter)?;
         }
         let scored = self.query_scored(embedding, k, 0, |payload| {
             columnar_matches(payload, filters)
@@ -285,13 +264,26 @@ impl MemoryStore for WasmStore {
                 id,
                 score,
                 content,
-                metadata: inner.live_fact(id).map(|fact| fact.payload.clone()),
+                // Reserved keys (`content`, `_veles_*`) are stripped exactly
+                // like the native backend and every other recall path — raw
+                // payloads must never reach a caller-facing `Recollection`.
+                metadata: velesdb_memory::storage::strip_reserved_keys(
+                    inner.live_fact(id).map(|fact| fact.payload.clone()),
+                ),
             })
             .collect())
     }
 
     fn relate(&self, from: u64, to: u64, relation: &str) -> Result<u64, MemoryError> {
         let mut inner = self.inner.borrow_mut();
+        // The trait contract (and the native backend) reject an edge to a
+        // missing or expired endpoint — a dangling edge would silently
+        // inflate `entity_idf` degree counts and `why()` traversal work.
+        for endpoint in [from, to] {
+            if inner.live_fact(endpoint).is_none() {
+                return Err(MemoryError::UnknownMemory(endpoint));
+            }
+        }
         // `explicit_id: None` derives the id from (source, target, label), so
         // the only documented failure mode (an explicit id collision) cannot
         // occur here — still mapped, not unwrapped, so a future signature
@@ -308,7 +300,11 @@ impl MemoryStore for WasmStore {
             .graph
             .edges()
             .iter()
-            .filter(|e| e.source == id)
+            // An edge into a TTL-expired fact is dead: the native backend
+            // filters expired targets out, and `entity_idf` divides by this
+            // degree — counting dead edges would under-weight every
+            // graph-reached fact relative to the native ranking.
+            .filter(|e| e.source == id && inner.live_fact(e.target).is_some())
             .map(|e| MemoryEdge {
                 from: e.source,
                 to: e.target,
@@ -332,6 +328,10 @@ impl WasmStore {
     /// [`MemoryStore::query_excluding`], and [`MemoryStore::query_columnar`]:
     /// score every non-expired fact whose payload passes `predicate` against
     /// `embedding`, rank, and take `k` after `offset`.
+    ///
+    /// `predicate` is applied while *building* the scoring input, borrowing
+    /// each payload in place — nothing is cloned for a non-matching fact,
+    /// and content is cloned only for the `k` rows actually returned.
     fn query_scored(
         &self,
         embedding: &[f32],
@@ -340,11 +340,21 @@ impl WasmStore {
         predicate: impl Fn(&Map<String, Value>) -> bool,
     ) -> Result<Vec<(u64, f32, String)>, MemoryError> {
         let inner = self.inner.borrow();
-        let (ids, data, payloads) = inner.live_snapshot();
-        let mut scored = vector_ops::compute_filtered_scores(
+        let mut ids = Vec::new();
+        let mut data = Vec::new();
+        for &id in &inner.order {
+            let Some(fact) = inner.live_fact(id) else {
+                continue;
+            };
+            if !predicate(&fact.payload) {
+                continue;
+            }
+            ids.push(id);
+            data.extend_from_slice(&fact.embedding);
+        }
+        let mut scored = vector_ops::compute_scores(
             embedding,
             &ids,
-            &payloads,
             &data,
             &[],
             &[],
@@ -353,17 +363,16 @@ impl WasmStore {
             inner.dimension,
             DistanceMetric::Cosine,
             StorageMode::Full,
-            |payload| payload.as_object().is_some_and(&predicate),
         );
         scored.sort_by(|a, b| b.1.total_cmp(&a.1));
         Ok(scored
             .into_iter()
             .skip(offset)
             .take(k)
-            .map(|(id, score, payload)| {
-                let content = payload
-                    .and_then(Value::as_object)
-                    .map(content_of)
+            .map(|(id, score)| {
+                let content = inner
+                    .live_fact(id)
+                    .map(|fact| content_of(&fact.payload))
                     .unwrap_or_default();
                 (id, score, content)
             })
@@ -409,31 +418,6 @@ fn compare(stored: &Value, op: ColumnOp, target: &Value) -> bool {
         ColumnOp::Eq => stored == target,
         ColumnOp::Ne => stored != target,
         _ => false,
-    }
-}
-
-/// Accept only plain, non-reserved identifier field names — mirrors
-/// `velesdb-memory`'s own `NativeStore::query_columnar` validation, since
-/// this store enforces the same contract independently (no VelesQL text is
-/// built here, so injection isn't a risk, but the reserved-column rule is
-/// part of `recall_where`'s documented contract regardless of backend).
-fn validate_field(field: &str) -> Result<(), MemoryError> {
-    let plain = !field.is_empty() && field.chars().all(|c| c.is_ascii_alphanumeric() || c == '_');
-    let reserved = field == "content" || field.starts_with("_veles_");
-    if plain && !reserved {
-        Ok(())
-    } else {
-        Err(MemoryError::InvalidFilter(field.to_owned()))
-    }
-}
-
-/// Reject non-scalar filter values, matching `NativeStore`'s validation.
-fn validate_scalar(value: &Value) -> Result<(), MemoryError> {
-    match value {
-        Value::String(_) | Value::Number(_) | Value::Bool(_) => Ok(()),
-        _ => Err(MemoryError::InvalidFilter(format!(
-            "value must be a string, number, or boolean, got {value}"
-        ))),
     }
 }
 

--- a/crates/velesdb-wasm/src/memory_store.rs
+++ b/crates/velesdb-wasm/src/memory_store.rs
@@ -254,24 +254,21 @@ impl MemoryStore for WasmStore {
         for filter in filters {
             velesdb_memory::storage::validate_column_filter(filter)?;
         }
-        let scored = self.query_scored(embedding, k, 0, |payload| {
-            columnar_matches(payload, filters)
-        })?;
-        let inner = self.inner.borrow();
-        Ok(scored
-            .into_iter()
-            .map(|(id, score, content)| Recollection {
+        self.query_ranked(
+            embedding,
+            k,
+            0,
+            |payload| columnar_matches(payload, filters),
+            |id, score, fact| Recollection {
                 id,
                 score,
-                content,
+                content: content_of(&fact.payload),
                 // Reserved keys (`content`, `_veles_*`) are stripped exactly
                 // like the native backend and every other recall path — raw
                 // payloads must never reach a caller-facing `Recollection`.
-                metadata: velesdb_memory::storage::strip_reserved_keys_ref(
-                    inner.live_fact(id).map(|fact| &fact.payload),
-                ),
-            })
-            .collect())
+                metadata: velesdb_memory::storage::strip_reserved_keys_ref(Some(&fact.payload)),
+            },
+        )
     }
 
     fn relate(&self, from: u64, to: u64, relation: &str) -> Result<u64, MemoryError> {
@@ -327,21 +324,24 @@ impl WasmStore {
     /// Shared vector-search core for [`MemoryStore::query_filtered`],
     /// [`MemoryStore::query_excluding`], and [`MemoryStore::query_columnar`]:
     /// score every non-expired fact whose payload passes `predicate` against
-    /// `embedding`, rank, and take `k` after `offset`.
+    /// `embedding`, rank, take `k` after `offset`, and build each returned
+    /// row with `row`.
     ///
     /// `predicate` is applied while *building* the scoring input, borrowing
     /// each payload in place — nothing is cloned for a non-matching fact,
-    /// and content is cloned only for the `k` rows actually returned. The
-    /// admitted facts are held as borrows (`matched`) rather than re-fetched
-    /// through the time-sensitive `live_fact` after ranking: a TTL lapsing
-    /// mid-query must not turn an admitted hit's content into `""`.
-    fn query_scored(
+    /// and `row` runs only for the rows actually returned. Admitted facts
+    /// are held as borrows (`matched`) and `row` receives the fact captured
+    /// at scoring time — never re-fetched through the time-sensitive
+    /// `live_fact` after ranking, so a TTL lapsing mid-query can't corrupt
+    /// an admitted hit's content or metadata.
+    fn query_ranked<T>(
         &self,
         embedding: &[f32],
         k: usize,
         offset: usize,
         predicate: impl Fn(&Map<String, Value>) -> bool,
-    ) -> Result<Vec<(u64, f32, String)>, MemoryError> {
+        row: impl Fn(u64, f32, &Fact) -> T,
+    ) -> Result<Vec<T>, MemoryError> {
         let inner = self.inner.borrow();
         let mut ids = Vec::new();
         let mut data = Vec::new();
@@ -374,14 +374,23 @@ impl WasmStore {
             .into_iter()
             .skip(offset)
             .take(k)
-            .map(|(id, score)| {
-                let content = matched
-                    .get(&id)
-                    .map(|fact| content_of(&fact.payload))
-                    .unwrap_or_default();
-                (id, score, content)
-            })
+            .filter_map(|(id, score)| matched.get(&id).map(|fact| row(id, score, fact)))
             .collect())
+    }
+
+    /// [`Self::query_ranked`] specialised to the `(id, score, content)`
+    /// triple [`MemoryStore::query_filtered`]/[`MemoryStore::query_excluding`]
+    /// return.
+    fn query_scored(
+        &self,
+        embedding: &[f32],
+        k: usize,
+        offset: usize,
+        predicate: impl Fn(&Map<String, Value>) -> bool,
+    ) -> Result<Vec<(u64, f32, String)>, MemoryError> {
+        self.query_ranked(embedding, k, offset, predicate, |id, score, fact| {
+            (id, score, content_of(&fact.payload))
+        })
     }
 }
 

--- a/crates/velesdb-wasm/src/memory_store_tests.rs
+++ b/crates/velesdb-wasm/src/memory_store_tests.rs
@@ -172,6 +172,72 @@ fn test_query_columnar_applies_range_predicate() {
 }
 
 #[test]
+fn test_query_columnar_strips_reserved_keys_from_metadata() {
+    // Regression: the raw payload (which carries the reserved `content` key,
+    // and `_veles_expires_at` for TTL'd facts) used to be returned verbatim
+    // as `Recollection::metadata` — the native backend strips reserved keys
+    // and collapses an empty result to `None`, and this backend must match.
+    let store = WasmStore::new(4);
+    let m = meta(&[("year", Value::from(2003))]);
+    store
+        .store_with_metadata(1, "alice was CEO", &[1.0, 0.0, 0.0, 0.0], &m)
+        .unwrap();
+    store
+        .store_with_ttl(2, "bob was CEO", &[1.0, 0.0, 0.0, 0.0], 3600)
+        .unwrap();
+
+    let hits = store.query_columnar(&[1.0, 0.0, 0.0, 0.0], 5, &[]).unwrap();
+    let alice = hits.iter().find(|r| r.id == 1).expect("alice present");
+    let metadata = alice.metadata.as_ref().expect("caller metadata survives");
+    assert_eq!(metadata.get("year"), Some(&Value::from(2003)));
+    assert!(
+        !metadata.contains_key("content"),
+        "reserved `content` key must be stripped"
+    );
+    let bob = hits.iter().find(|r| r.id == 2).expect("bob present");
+    assert!(
+        bob.metadata.is_none(),
+        "a fact with only reserved keys (content + TTL) has no caller metadata"
+    );
+}
+
+#[test]
+fn test_relate_to_missing_endpoint_errors() {
+    let store = WasmStore::new(4);
+    store.store(1, "a", &[1.0, 0.0, 0.0, 0.0]).unwrap();
+
+    let err = store.relate(1, 999, "decided_in").unwrap_err();
+    assert!(matches!(err, MemoryError::UnknownMemory(999)));
+    let err = store.relate(999, 1, "decided_in").unwrap_err();
+    assert!(matches!(err, MemoryError::UnknownMemory(999)));
+    assert!(
+        store.relations(1).unwrap().is_empty(),
+        "no dangling edge may survive a rejected relate"
+    );
+}
+
+#[test]
+fn test_relations_excludes_edges_to_expired_targets() {
+    // Regression: `entity_idf` divides by this degree, so counting an edge
+    // into a TTL-expired fact under-weights every graph-reached fact
+    // relative to the native backend (which filters expired targets).
+    let store = WasmStore::new(4);
+    store.store(1, "a", &[1.0, 0.0, 0.0, 0.0]).unwrap();
+    store.store(2, "b", &[0.0, 1.0, 0.0, 0.0]).unwrap();
+    store.relate(1, 2, "decided_in").unwrap();
+    // Re-storing the target with an already-passed expiry simulates a fact
+    // that expired after the edge was created (edges survive a re-store).
+    store
+        .store_with_ttl(2, "b", &[0.0, 1.0, 0.0, 0.0], 0)
+        .unwrap();
+
+    assert!(
+        store.relations(1).unwrap().is_empty(),
+        "an edge into an expired fact is dead and must not be returned"
+    );
+}
+
+#[test]
 fn test_query_columnar_rejects_reserved_field() {
     let store = WasmStore::new(4);
     let filters = vec![ColumnFilter {

--- a/crates/velesdb-wasm/src/memory_store_tests.rs
+++ b/crates/velesdb-wasm/src/memory_store_tests.rs
@@ -1,0 +1,231 @@
+//! Unit tests for `WasmStore`'s `MemoryStore` implementation. Runs natively
+//! (`cargo test -p velesdb-wasm`) — no `wasm32` target or JS host required,
+//! since `now_ms()` falls back to `SystemTime` off `wasm32`.
+
+use super::*;
+use velesdb_memory::ColumnOp;
+
+fn meta(pairs: &[(&str, Value)]) -> Metadata {
+    pairs
+        .iter()
+        .map(|(k, v)| ((*k).to_string(), v.clone()))
+        .collect()
+}
+
+#[test]
+fn test_store_and_get_roundtrip() {
+    let store = WasmStore::new(4);
+    store.store(1, "hello", &[1.0, 0.0, 0.0, 0.0]).unwrap();
+    let (content, embedding) = store.get(1).unwrap().expect("present");
+    assert_eq!(content, "hello");
+    assert_eq!(embedding, vec![1.0, 0.0, 0.0, 0.0]);
+}
+
+#[test]
+fn test_get_unknown_id_is_none() {
+    let store = WasmStore::new(4);
+    assert!(store.get(999).unwrap().is_none());
+}
+
+#[test]
+fn test_store_with_metadata_round_trips_via_get_metadata() {
+    let store = WasmStore::new(4);
+    let m = meta(&[("tag", Value::String("science".to_string()))]);
+    store
+        .store_with_metadata(1, "photosynthesis", &[1.0, 0.0, 0.0, 0.0], &m)
+        .unwrap();
+    let payload = store.get_metadata(1).unwrap().expect("metadata present");
+    assert_eq!(
+        payload.get("tag"),
+        Some(&Value::String("science".to_string()))
+    );
+}
+
+#[test]
+fn test_update_metadata_merges_without_dropping_content() {
+    let store = WasmStore::new(4);
+    store.store(1, "a fact", &[1.0, 0.0, 0.0, 0.0]).unwrap();
+    let m = meta(&[("tag", Value::String("science".to_string()))]);
+    store.update_metadata(1, &m).unwrap();
+
+    let (content, _) = store.get(1).unwrap().expect("present");
+    assert_eq!(content, "a fact", "content survives a metadata-only update");
+    let payload = store.get_metadata(1).unwrap().expect("metadata present");
+    assert_eq!(
+        payload.get("tag"),
+        Some(&Value::String("science".to_string()))
+    );
+}
+
+#[test]
+fn test_update_metadata_unknown_id_errors() {
+    let store = WasmStore::new(4);
+    let err = store.update_metadata(999, &Metadata::new()).unwrap_err();
+    assert!(matches!(err, MemoryError::UnknownMemory(999)));
+}
+
+#[test]
+fn test_delete_removes_the_fact() {
+    let store = WasmStore::new(4);
+    store.store(1, "ephemeral", &[1.0, 0.0, 0.0, 0.0]).unwrap();
+    store.delete(1).unwrap();
+    assert!(store.get(1).unwrap().is_none());
+}
+
+#[test]
+fn test_delete_cascades_relations() {
+    let store = WasmStore::new(4);
+    store.store(1, "a", &[1.0, 0.0, 0.0, 0.0]).unwrap();
+    store.store(2, "b", &[0.0, 1.0, 0.0, 0.0]).unwrap();
+    store.relate(1, 2, "decided_in").unwrap();
+    store.delete(2).unwrap();
+
+    assert!(
+        store.relations(1).unwrap().is_empty(),
+        "an edge dangling off a deleted memory must not survive it"
+    );
+}
+
+#[test]
+fn test_relate_and_relations_round_trip() {
+    let store = WasmStore::new(4);
+    store.store(1, "a", &[1.0, 0.0, 0.0, 0.0]).unwrap();
+    store.store(2, "b", &[0.0, 1.0, 0.0, 0.0]).unwrap();
+    store.relate(1, 2, "decided_in").unwrap();
+
+    let edges = store.relations(1).unwrap();
+    assert_eq!(edges.len(), 1);
+    assert_eq!(edges[0].from, 1);
+    assert_eq!(edges[0].to, 2);
+    assert_eq!(edges[0].relation, "decided_in");
+}
+
+#[test]
+fn test_relations_only_returns_outgoing_edges() {
+    let store = WasmStore::new(4);
+    store.store(1, "a", &[1.0, 0.0, 0.0, 0.0]).unwrap();
+    store.store(2, "b", &[0.0, 1.0, 0.0, 0.0]).unwrap();
+    store.relate(1, 2, "decided_in").unwrap();
+
+    assert!(
+        store.relations(2).unwrap().is_empty(),
+        "edge is directed 1 -> 2, not 2 -> 1"
+    );
+}
+
+#[test]
+fn test_query_filtered_matches_exact_metadata() {
+    let store = WasmStore::new(4);
+    let m = meta(&[("project", Value::String("veles".to_string()))]);
+    store
+        .store_with_metadata(1, "auth bug", &[1.0, 0.0, 0.0, 0.0], &m)
+        .unwrap();
+    store.store(2, "unrelated", &[0.0, 1.0, 0.0, 0.0]).unwrap();
+
+    let hits = store
+        .query_filtered(&[1.0, 0.0, 0.0, 0.0], 5, &m, 0)
+        .unwrap();
+    assert_eq!(hits.len(), 1);
+    assert_eq!(hits[0].0, 1);
+}
+
+#[test]
+fn test_query_excluding_drops_matching_metadata() {
+    let store = WasmStore::new(4);
+    let hub_meta = meta(&[("_veles_hub", Value::Bool(true))]);
+    store
+        .store_with_metadata(1, "Entity: rust", &[1.0, 0.0, 0.0, 0.0], &hub_meta)
+        .unwrap();
+    store
+        .store(2, "a real fact", &[1.0, 0.0, 0.0, 0.0])
+        .unwrap();
+
+    let hits = store
+        .query_excluding(&[1.0, 0.0, 0.0, 0.0], 5, &hub_meta)
+        .unwrap();
+    assert!(hits.iter().all(|h| h.0 != 1), "hub must be excluded");
+    assert!(hits.iter().any(|h| h.0 == 2));
+}
+
+#[test]
+fn test_query_columnar_applies_range_predicate() {
+    let store = WasmStore::new(4);
+    let early = meta(&[("year", Value::from(2003))]);
+    store
+        .store_with_metadata(1, "alice was CEO", &[1.0, 0.0, 0.0, 0.0], &early)
+        .unwrap();
+    let late = meta(&[("year", Value::from(2020))]);
+    store
+        .store_with_metadata(2, "bob was CEO", &[1.0, 0.0, 0.0, 0.0], &late)
+        .unwrap();
+
+    let filters = vec![ColumnFilter {
+        field: "year".to_string(),
+        op: ColumnOp::Le,
+        value: Value::from(2010),
+    }];
+    let hits = store
+        .query_columnar(&[1.0, 0.0, 0.0, 0.0], 5, &filters)
+        .unwrap();
+    assert_eq!(hits.len(), 1);
+    assert_eq!(hits[0].id, 1);
+}
+
+#[test]
+fn test_query_columnar_rejects_reserved_field() {
+    let store = WasmStore::new(4);
+    let filters = vec![ColumnFilter {
+        field: "content".to_string(),
+        op: ColumnOp::Eq,
+        value: Value::from(1),
+    }];
+    let err = store
+        .query_columnar(&[1.0, 0.0, 0.0, 0.0], 5, &filters)
+        .expect_err("reserved field must be rejected");
+    assert!(matches!(err, MemoryError::InvalidFilter(_)));
+}
+
+#[test]
+fn test_count_reflects_live_facts() {
+    let store = WasmStore::new(4);
+    assert_eq!(store.count(), 0);
+    store.store(1, "a", &[1.0, 0.0, 0.0, 0.0]).unwrap();
+    store.store(2, "b", &[0.0, 1.0, 0.0, 0.0]).unwrap();
+    assert_eq!(store.count(), 2);
+}
+
+#[test]
+fn test_zero_ttl_expires_immediately() {
+    let store = WasmStore::new(4);
+    store
+        .store_with_ttl(1, "ephemeral", &[1.0, 0.0, 0.0, 0.0], 0)
+        .unwrap();
+    assert!(
+        store.get(1).unwrap().is_none(),
+        "a 0-second TTL expires at the moment it's set"
+    );
+}
+
+#[test]
+fn test_positive_ttl_is_recallable_before_expiry() {
+    let store = WasmStore::new(4);
+    store
+        .store_with_ttl(1, "not yet expired", &[1.0, 0.0, 0.0, 0.0], 3600)
+        .unwrap();
+    assert!(store.get(1).unwrap().is_some());
+}
+
+#[test]
+fn test_expired_fact_is_excluded_from_vector_search() {
+    let store = WasmStore::new(4);
+    store
+        .store_with_ttl(1, "expired", &[1.0, 0.0, 0.0, 0.0], 0)
+        .unwrap();
+    store.store(2, "live", &[1.0, 0.0, 0.0, 0.0]).unwrap();
+
+    let hits = store
+        .query_excluding(&[1.0, 0.0, 0.0, 0.0], 5, &Metadata::new())
+        .unwrap();
+    assert!(hits.iter().all(|h| h.0 != 1));
+    assert!(hits.iter().any(|h| h.0 == 2));
+}

--- a/crates/velesdb-wasm/src/wasm_error.rs
+++ b/crates/velesdb-wasm/src/wasm_error.rs
@@ -40,39 +40,45 @@ impl WasmError {
     }
 
     /// Renders a structured JS `Error` whose `code` property is the
-    /// `VELES-XXX` code. The property is defined as non-enumerable so it does
-    /// not pollute `JSON.stringify(error)` yet stays readable as `error.code`.
-    #[cfg(target_arch = "wasm32")]
+    /// `VELES-XXX` code — see [`structured_js_error`].
     pub(crate) fn into_js_value(self) -> wasm_bindgen::JsValue {
-        use wasm_bindgen::JsValue;
-        let err = js_sys::Error::new(&self.message);
-        let descriptor = js_sys::Object::new();
-        // `Object.defineProperty` is a safe wrapper; a failed `set` degrades to
-        // a plain Error rather than panicking, so the results are discarded.
-        let _ = js_sys::Reflect::set(
-            &descriptor,
-            &JsValue::from_str("value"),
-            &JsValue::from_str(self.code),
-        );
-        let _ = js_sys::Reflect::set(
-            &descriptor,
-            &JsValue::from_str("enumerable"),
-            &JsValue::FALSE,
-        );
-        let _ = js_sys::Reflect::set(&descriptor, &JsValue::from_str("writable"), &JsValue::FALSE);
-        js_sys::Object::define_property(&err, &JsValue::from_str("code"), &descriptor);
-        err.into()
+        structured_js_error(self.code, &self.message)
     }
+}
 
-    /// Native-target fallback: `js_sys::Error`/`Object.defineProperty` have no
-    /// JS runtime off `wasm32`, so the error degrades to a flat string carrying
-    /// both the code and the message. The structured `code` is asserted in
-    /// native tests via [`WasmError::code`]; the real JS `Error` is produced
-    /// only in the browser build above.
-    #[cfg(not(target_arch = "wasm32"))]
-    pub(crate) fn into_js_value(self) -> wasm_bindgen::JsValue {
-        wasm_bindgen::JsValue::from_str(&format!("[{}] {}", self.code, self.message))
-    }
+/// Render a structured JS `Error` carrying a non-enumerable, machine-readable
+/// `code` property — so it does not pollute `JSON.stringify(error)` yet stays
+/// readable as `error.code`. Shared by [`WasmError`] (core's `VELES-XXX`
+/// codes) and the memory binding (`MemoryError`'s category codes): different
+/// taxonomies, one JS error shape.
+#[cfg(target_arch = "wasm32")]
+pub(crate) fn structured_js_error(code: &str, message: &str) -> wasm_bindgen::JsValue {
+    use wasm_bindgen::JsValue;
+    let err = js_sys::Error::new(message);
+    let descriptor = js_sys::Object::new();
+    // `Object.defineProperty` is a safe wrapper; a failed `set` degrades to
+    // a plain Error rather than panicking, so the results are discarded.
+    let _ = js_sys::Reflect::set(
+        &descriptor,
+        &JsValue::from_str("value"),
+        &JsValue::from_str(code),
+    );
+    let _ = js_sys::Reflect::set(
+        &descriptor,
+        &JsValue::from_str("enumerable"),
+        &JsValue::FALSE,
+    );
+    let _ = js_sys::Reflect::set(&descriptor, &JsValue::from_str("writable"), &JsValue::FALSE);
+    js_sys::Object::define_property(&err, &JsValue::from_str("code"), &descriptor);
+    err.into()
+}
+
+/// Native-target fallback: `js_sys::Error`/`Object.defineProperty` have no
+/// JS runtime off `wasm32`, so the error degrades to a flat string carrying
+/// both the code and the message, which native tests assert on directly.
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) fn structured_js_error(code: &str, message: &str) -> wasm_bindgen::JsValue {
+    wasm_bindgen::JsValue::from_str(&format!("[{code}] {message}"))
 }
 
 impl From<CoreError> for WasmError {

--- a/crates/velesdb-wasm/tests/memory_wedge_web.rs
+++ b/crates/velesdb-wasm/tests/memory_wedge_web.rs
@@ -46,6 +46,34 @@ fn recall_metadata_is_a_plain_js_object_not_a_map() {
     );
 }
 
+/// A `null` VALUE inside metadata must marshal as JS `null`, matching the
+/// Node binding — with the serializer's default missing-as-undefined, the
+/// key silently vanished from `JSON.stringify` output on WASM only.
+#[wasm_bindgen_test]
+fn recall_metadata_preserves_null_values() {
+    let svc = WasmMemoryService::new(16);
+    let meta = js_sys::Object::new();
+    js_sys::Reflect::set(&meta, &"flag".into(), &JsValue::NULL).unwrap();
+    svc.remember(
+        "a fact carrying a null-valued metadata key",
+        JsValue::UNDEFINED,
+        meta.into(),
+        None,
+    )
+    .unwrap();
+
+    let hits = svc
+        .recall("null-valued metadata", Some(5), JsValue::UNDEFINED)
+        .unwrap();
+    let first = js_sys::Reflect::get(&hits, &0.into()).unwrap();
+    let metadata = js_sys::Reflect::get(&first, &"metadata".into()).unwrap();
+    let flag = js_sys::Reflect::get(&metadata, &"flag".into()).unwrap();
+    assert!(
+        flag.is_null(),
+        "a stored null value must round-trip as null, not undefined"
+    );
+}
+
 /// The absent-metadata convention must survive the serializer change:
 /// a fact with no caller metadata marshals `metadata` as `undefined`
 /// (matching the Node binding), not `null` or an empty object.

--- a/crates/velesdb-wasm/tests/memory_wedge_web.rs
+++ b/crates/velesdb-wasm/tests/memory_wedge_web.rs
@@ -1,0 +1,69 @@
+//! wasm-bindgen tests for the memory-wedge binding: behaviours only
+//! observable with a real JS runtime — i.e. how values marshal across the
+//! wasm boundary. Logic-level coverage lives in the native suites
+//! (`memory_service_tests.rs`, `memory_store_tests.rs`).
+
+#![cfg(target_arch = "wasm32")]
+
+use wasm_bindgen::{JsCast, JsValue};
+use wasm_bindgen_test::*;
+
+use velesdb_wasm::WasmMemoryService;
+
+/// Regression: the default `serde_wasm_bindgen` serializer turns a
+/// `serde_json::Value::Object` into an ES2015 `Map`, on which property
+/// access and `JSON.stringify` silently yield nothing — every metadata
+/// read in the browser came back empty while the same code worked on the
+/// Node binding. Metadata must marshal as a plain JS object.
+#[wasm_bindgen_test]
+fn recall_metadata_is_a_plain_js_object_not_a_map() {
+    let svc = WasmMemoryService::new(16);
+    let meta = js_sys::Object::new();
+    js_sys::Reflect::set(&meta, &"project".into(), &"veles".into()).unwrap();
+    svc.remember(
+        "we chose parking_lot to avoid lock poisoning",
+        JsValue::UNDEFINED,
+        meta.into(),
+        None,
+    )
+    .unwrap();
+
+    let hits = svc
+        .recall("parking_lot", Some(5), JsValue::UNDEFINED)
+        .unwrap();
+    let first = js_sys::Reflect::get(&hits, &0.into()).unwrap();
+    let metadata = js_sys::Reflect::get(&first, &"metadata".into()).unwrap();
+
+    assert!(
+        !metadata.is_instance_of::<js_sys::Map>(),
+        "metadata must be a plain object, not an ES2015 Map"
+    );
+    let project = js_sys::Reflect::get(&metadata, &"project".into()).unwrap();
+    assert_eq!(
+        project.as_string().as_deref(),
+        Some("veles"),
+        "metadata properties must be readable by plain property access"
+    );
+}
+
+/// The absent-metadata convention must survive the serializer change:
+/// a fact with no caller metadata marshals `metadata` as `undefined`
+/// (matching the Node binding), not `null` or an empty object.
+#[wasm_bindgen_test]
+fn recall_without_metadata_marshals_undefined() {
+    let svc = WasmMemoryService::new(16);
+    svc.remember(
+        "a bare fact with no metadata",
+        JsValue::UNDEFINED,
+        JsValue::UNDEFINED,
+        None,
+    )
+    .unwrap();
+
+    let hits = svc
+        .recall("bare fact", Some(5), JsValue::UNDEFINED)
+        .unwrap();
+    let first = js_sys::Reflect::get(&hits, &0.into()).unwrap();
+    let metadata = js_sys::Reflect::get(&first, &"metadata".into()).unwrap();
+    assert!(metadata.is_undefined(), "absent metadata must be undefined");
+}

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3448,10 +3448,16 @@
         ],
         "properties": {
           "id": {
-            "type": "integer",
-            "format": "int64",
-            "description": "Edge ID.",
-            "minimum": 0
+            "oneOf": [
+              {
+                "type": "integer",
+                "format": "int64"
+              },
+              {
+                "type": "string"
+              }
+            ],
+            "description": "Point ID. Accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss."
           },
           "label": {
             "type": "string",
@@ -3461,16 +3467,28 @@
             "description": "Edge properties."
           },
           "source": {
-            "type": "integer",
-            "format": "int64",
-            "description": "Source node ID.",
-            "minimum": 0
+            "oneOf": [
+              {
+                "type": "integer",
+                "format": "int64"
+              },
+              {
+                "type": "string"
+              }
+            ],
+            "description": "Point ID. Accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss."
           },
           "target": {
-            "type": "integer",
-            "format": "int64",
-            "description": "Target node ID.",
-            "minimum": 0
+            "oneOf": [
+              {
+                "type": "integer",
+                "format": "int64"
+              },
+              {
+                "type": "string"
+              }
+            ],
+            "description": "Point ID. Accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss."
           }
         }
       },
@@ -4036,10 +4054,8 @@
         ],
         "properties": {
           "id": {
-            "type": "integer",
-            "format": "int64",
-            "description": "Edge ID.",
-            "minimum": 0
+            "type": "string",
+            "description": "Edge ID."
           },
           "label": {
             "type": "string",
@@ -4049,16 +4065,12 @@
             "description": "Edge properties."
           },
           "source": {
-            "type": "integer",
-            "format": "int64",
-            "description": "Source node ID.",
-            "minimum": 0
+            "type": "string",
+            "description": "Source node ID."
           },
           "target": {
-            "type": "integer",
-            "format": "int64",
-            "description": "Target node ID.",
-            "minimum": 0
+            "type": "string",
+            "description": "Target node ID."
           }
         }
       },
@@ -4496,10 +4508,8 @@
         ],
         "properties": {
           "id": {
-            "type": "integer",
-            "format": "int64",
-            "description": "Node ID.",
-            "minimum": 0
+            "type": "string",
+            "description": "Node ID."
           },
           "payload": {
             "description": "Node payload (if any)."
@@ -4898,14 +4908,16 @@
         "properties": {
           "bindings": {
             "type": "object",
-            "description": "Variable bindings from pattern matching.",
             "additionalProperties": {
-              "type": "integer",
-              "format": "int64",
-              "minimum": 0
-            },
-            "propertyNames": {
-              "type": "string"
+              "oneOf": [
+                {
+                  "type": "integer",
+                  "format": "int64"
+                },
+                {
+                  "type": "string"
+                }
+              ]
             }
           },
           "depth": {
@@ -5027,11 +5039,16 @@
           "node_ids": {
             "type": "array",
             "items": {
-              "type": "integer",
-              "format": "int64",
-              "minimum": 0
-            },
-            "description": "List of node IDs (serialized as strings to preserve u64 precision in JS)."
+              "oneOf": [
+                {
+                  "type": "integer",
+                  "format": "int64"
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            }
           }
         }
       },
@@ -5043,10 +5060,8 @@
         ],
         "properties": {
           "node_id": {
-            "type": "integer",
-            "format": "int64",
-            "description": "Node ID.",
-            "minimum": 0
+            "type": "string",
+            "description": "Node ID."
           },
           "payload": {
             "description": "Stored payload (null if none)."
@@ -5126,11 +5141,16 @@
           "sources": {
             "type": "array",
             "items": {
-              "type": "integer",
-              "format": "int64",
-              "minimum": 0
-            },
-            "description": "Source node IDs to start traversal from (accepts strings or numbers so\nJS clients can send precision-safe u64 IDs above `Number.MAX_SAFE_INTEGER`)."
+              "oneOf": [
+                {
+                  "type": "integer",
+                  "format": "int64"
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            }
           }
         }
       },
@@ -5335,16 +5355,28 @@
             "description": "Relationship type label (e.g. `\"KNOWS\"`, `\"RELATED_TO\"`)."
           },
           "source": {
-            "type": "integer",
-            "format": "int64",
-            "description": "Source point ID.",
-            "minimum": 0
+            "oneOf": [
+              {
+                "type": "integer",
+                "format": "int64"
+              },
+              {
+                "type": "string"
+              }
+            ],
+            "description": "Point ID. Accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss."
           },
           "target": {
-            "type": "integer",
-            "format": "int64",
-            "description": "Target point ID.",
-            "minimum": 0
+            "oneOf": [
+              {
+                "type": "integer",
+                "format": "int64"
+              },
+              {
+                "type": "string"
+              }
+            ],
+            "description": "Point ID. Accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss."
           }
         }
       },
@@ -5356,10 +5388,8 @@
         ],
         "properties": {
           "edge_id": {
-            "type": "integer",
-            "format": "int64",
-            "description": "Allocated edge ID.",
-            "minimum": 0
+            "type": "string",
+            "description": "Allocated edge ID."
           }
         }
       },
@@ -5375,10 +5405,8 @@
         ],
         "properties": {
           "id": {
-            "type": "integer",
-            "format": "int64",
-            "description": "Edge ID.",
-            "minimum": 0
+            "type": "string",
+            "description": "Edge ID."
           },
           "properties": {
             "description": "Edge properties (null when empty)."
@@ -5388,16 +5416,12 @@
             "description": "Relationship type label."
           },
           "source": {
-            "type": "integer",
-            "format": "int64",
-            "description": "Source point ID.",
-            "minimum": 0
+            "type": "string",
+            "description": "Source point ID."
           },
           "target": {
-            "type": "integer",
-            "format": "int64",
-            "description": "Target point ID.",
-            "minimum": 0
+            "type": "string",
+            "description": "Target point ID."
           }
         }
       },
@@ -5785,19 +5809,22 @@
             "minimum": 0
           },
           "id": {
-            "type": "integer",
-            "format": "int64",
-            "description": "Target node ID.",
-            "minimum": 0
+            "type": "string",
+            "description": "Target node ID."
           },
           "path": {
             "type": "array",
             "items": {
-              "type": "integer",
-              "format": "int64",
-              "minimum": 0
-            },
-            "description": "Path of edge IDs taken to reach this node."
+              "oneOf": [
+                {
+                  "type": "integer",
+                  "format": "int64"
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            }
           }
         }
       },
@@ -5871,17 +5898,20 @@
           "path": {
             "type": "array",
             "items": {
-              "type": "integer",
-              "format": "int64",
-              "minimum": 0
-            },
-            "description": "Path taken (list of edge IDs)."
+              "oneOf": [
+                {
+                  "type": "integer",
+                  "format": "int64"
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            }
           },
           "target_id": {
-            "type": "integer",
-            "format": "int64",
-            "description": "Target node ID reached.",
-            "minimum": 0
+            "type": "string",
+            "description": "Target node ID reached."
           }
         }
       },
@@ -5932,10 +5962,16 @@
             "description": "Filter by relationship types (empty = all types)."
           },
           "source": {
-            "type": "integer",
-            "format": "int64",
-            "description": "Source node ID to start traversal from.",
-            "minimum": 0
+            "oneOf": [
+              {
+                "type": "integer",
+                "format": "int64"
+              },
+              {
+                "type": "string"
+              }
+            ],
+            "description": "Point ID. Accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss."
           },
           "strategy": {
             "type": "string",

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3448,16 +3448,10 @@
         ],
         "properties": {
           "id": {
-            "oneOf": [
-              {
-                "type": "integer",
-                "format": "int64"
-              },
-              {
-                "type": "string"
-              }
-            ],
-            "description": "Point ID. Accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss."
+            "type": "integer",
+            "format": "int64",
+            "description": "Edge ID.",
+            "minimum": 0
           },
           "label": {
             "type": "string",
@@ -3467,28 +3461,16 @@
             "description": "Edge properties."
           },
           "source": {
-            "oneOf": [
-              {
-                "type": "integer",
-                "format": "int64"
-              },
-              {
-                "type": "string"
-              }
-            ],
-            "description": "Point ID. Accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss."
+            "type": "integer",
+            "format": "int64",
+            "description": "Source node ID.",
+            "minimum": 0
           },
           "target": {
-            "oneOf": [
-              {
-                "type": "integer",
-                "format": "int64"
-              },
-              {
-                "type": "string"
-              }
-            ],
-            "description": "Point ID. Accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss."
+            "type": "integer",
+            "format": "int64",
+            "description": "Target node ID.",
+            "minimum": 0
           }
         }
       },
@@ -4054,8 +4036,10 @@
         ],
         "properties": {
           "id": {
-            "type": "string",
-            "description": "Edge ID."
+            "type": "integer",
+            "format": "int64",
+            "description": "Edge ID.",
+            "minimum": 0
           },
           "label": {
             "type": "string",
@@ -4065,12 +4049,16 @@
             "description": "Edge properties."
           },
           "source": {
-            "type": "string",
-            "description": "Source node ID."
+            "type": "integer",
+            "format": "int64",
+            "description": "Source node ID.",
+            "minimum": 0
           },
           "target": {
-            "type": "string",
-            "description": "Target node ID."
+            "type": "integer",
+            "format": "int64",
+            "description": "Target node ID.",
+            "minimum": 0
           }
         }
       },
@@ -4508,8 +4496,10 @@
         ],
         "properties": {
           "id": {
-            "type": "string",
-            "description": "Node ID."
+            "type": "integer",
+            "format": "int64",
+            "description": "Node ID.",
+            "minimum": 0
           },
           "payload": {
             "description": "Node payload (if any)."
@@ -4908,16 +4898,14 @@
         "properties": {
           "bindings": {
             "type": "object",
+            "description": "Variable bindings from pattern matching.",
             "additionalProperties": {
-              "oneOf": [
-                {
-                  "type": "integer",
-                  "format": "int64"
-                },
-                {
-                  "type": "string"
-                }
-              ]
+              "type": "integer",
+              "format": "int64",
+              "minimum": 0
+            },
+            "propertyNames": {
+              "type": "string"
             }
           },
           "depth": {
@@ -5039,16 +5027,11 @@
           "node_ids": {
             "type": "array",
             "items": {
-              "oneOf": [
-                {
-                  "type": "integer",
-                  "format": "int64"
-                },
-                {
-                  "type": "string"
-                }
-              ]
-            }
+              "type": "integer",
+              "format": "int64",
+              "minimum": 0
+            },
+            "description": "List of node IDs (serialized as strings to preserve u64 precision in JS)."
           }
         }
       },
@@ -5060,8 +5043,10 @@
         ],
         "properties": {
           "node_id": {
-            "type": "string",
-            "description": "Node ID."
+            "type": "integer",
+            "format": "int64",
+            "description": "Node ID.",
+            "minimum": 0
           },
           "payload": {
             "description": "Stored payload (null if none)."
@@ -5141,16 +5126,11 @@
           "sources": {
             "type": "array",
             "items": {
-              "oneOf": [
-                {
-                  "type": "integer",
-                  "format": "int64"
-                },
-                {
-                  "type": "string"
-                }
-              ]
-            }
+              "type": "integer",
+              "format": "int64",
+              "minimum": 0
+            },
+            "description": "Source node IDs to start traversal from (accepts strings or numbers so\nJS clients can send precision-safe u64 IDs above `Number.MAX_SAFE_INTEGER`)."
           }
         }
       },
@@ -5355,28 +5335,16 @@
             "description": "Relationship type label (e.g. `\"KNOWS\"`, `\"RELATED_TO\"`)."
           },
           "source": {
-            "oneOf": [
-              {
-                "type": "integer",
-                "format": "int64"
-              },
-              {
-                "type": "string"
-              }
-            ],
-            "description": "Point ID. Accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss."
+            "type": "integer",
+            "format": "int64",
+            "description": "Source point ID.",
+            "minimum": 0
           },
           "target": {
-            "oneOf": [
-              {
-                "type": "integer",
-                "format": "int64"
-              },
-              {
-                "type": "string"
-              }
-            ],
-            "description": "Point ID. Accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss."
+            "type": "integer",
+            "format": "int64",
+            "description": "Target point ID.",
+            "minimum": 0
           }
         }
       },
@@ -5388,8 +5356,10 @@
         ],
         "properties": {
           "edge_id": {
-            "type": "string",
-            "description": "Allocated edge ID."
+            "type": "integer",
+            "format": "int64",
+            "description": "Allocated edge ID.",
+            "minimum": 0
           }
         }
       },
@@ -5405,8 +5375,10 @@
         ],
         "properties": {
           "id": {
-            "type": "string",
-            "description": "Edge ID."
+            "type": "integer",
+            "format": "int64",
+            "description": "Edge ID.",
+            "minimum": 0
           },
           "properties": {
             "description": "Edge properties (null when empty)."
@@ -5416,12 +5388,16 @@
             "description": "Relationship type label."
           },
           "source": {
-            "type": "string",
-            "description": "Source point ID."
+            "type": "integer",
+            "format": "int64",
+            "description": "Source point ID.",
+            "minimum": 0
           },
           "target": {
-            "type": "string",
-            "description": "Target point ID."
+            "type": "integer",
+            "format": "int64",
+            "description": "Target point ID.",
+            "minimum": 0
           }
         }
       },
@@ -5809,22 +5785,19 @@
             "minimum": 0
           },
           "id": {
-            "type": "string",
-            "description": "Target node ID."
+            "type": "integer",
+            "format": "int64",
+            "description": "Target node ID.",
+            "minimum": 0
           },
           "path": {
             "type": "array",
             "items": {
-              "oneOf": [
-                {
-                  "type": "integer",
-                  "format": "int64"
-                },
-                {
-                  "type": "string"
-                }
-              ]
-            }
+              "type": "integer",
+              "format": "int64",
+              "minimum": 0
+            },
+            "description": "Path of edge IDs taken to reach this node."
           }
         }
       },
@@ -5898,20 +5871,17 @@
           "path": {
             "type": "array",
             "items": {
-              "oneOf": [
-                {
-                  "type": "integer",
-                  "format": "int64"
-                },
-                {
-                  "type": "string"
-                }
-              ]
-            }
+              "type": "integer",
+              "format": "int64",
+              "minimum": 0
+            },
+            "description": "Path taken (list of edge IDs)."
           },
           "target_id": {
-            "type": "string",
-            "description": "Target node ID reached."
+            "type": "integer",
+            "format": "int64",
+            "description": "Target node ID reached.",
+            "minimum": 0
           }
         }
       },
@@ -5962,16 +5932,10 @@
             "description": "Filter by relationship types (empty = all types)."
           },
           "source": {
-            "oneOf": [
-              {
-                "type": "integer",
-                "format": "int64"
-              },
-              {
-                "type": "string"
-              }
-            ],
-            "description": "Point ID. Accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss."
+            "type": "integer",
+            "format": "int64",
+            "description": "Source node ID to start traversal from.",
+            "minimum": 0
           },
           "strategy": {
             "type": "string",

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2298,25 +2298,28 @@ components:
       - label
       properties:
         id:
-          type: integer
-          format: int64
-          description: Edge ID.
-          minimum: 0
+          oneOf:
+          - type: integer
+            format: int64
+          - type: string
+          description: Point ID. Accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss.
         label:
           type: string
           description: Edge label (relationship type).
         properties:
           description: Edge properties.
         source:
-          type: integer
-          format: int64
-          description: Source node ID.
-          minimum: 0
+          oneOf:
+          - type: integer
+            format: int64
+          - type: string
+          description: Point ID. Accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss.
         target:
-          type: integer
-          format: int64
-          description: Target node ID.
-          minimum: 0
+          oneOf:
+          - type: integer
+            format: int64
+          - type: string
+          description: Point ID. Accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss.
     AddEdgesBatchRequest:
       type: object
       description: Request to add multiple edges in one batched operation.
@@ -2796,25 +2799,19 @@ components:
       - properties
       properties:
         id:
-          type: integer
-          format: int64
+          type: string
           description: Edge ID.
-          minimum: 0
         label:
           type: string
           description: Edge label (relationship type).
         properties:
           description: Edge properties.
         source:
-          type: integer
-          format: int64
+          type: string
           description: Source node ID.
-          minimum: 0
         target:
-          type: integer
-          format: int64
+          type: string
           description: Target node ID.
-          minimum: 0
     EdgesResponse:
       type: object
       description: Response containing edges.
@@ -3147,10 +3144,8 @@ components:
       - score
       properties:
         id:
-          type: integer
-          format: int64
+          type: string
           description: Node ID.
-          minimum: 0
         payload:
           description: Node payload (if any).
         score:
@@ -3456,13 +3451,11 @@ components:
       properties:
         bindings:
           type: object
-          description: Variable bindings from pattern matching.
           additionalProperties:
-            type: integer
-            format: int64
-            minimum: 0
-          propertyNames:
-            type: string
+            oneOf:
+            - type: integer
+              format: int64
+            - type: string
         depth:
           type: integer
           format: int32
@@ -3556,10 +3549,10 @@ components:
         node_ids:
           type: array
           items:
-            type: integer
-            format: int64
-            minimum: 0
-          description: List of node IDs (serialized as strings to preserve u64 precision in JS).
+            oneOf:
+            - type: integer
+              format: int64
+            - type: string
     NodePayloadResponse:
       type: object
       description: Response for a node payload retrieval.
@@ -3567,10 +3560,8 @@ components:
       - node_id
       properties:
         node_id:
-          type: integer
-          format: int64
+          type: string
           description: Node ID.
-          minimum: 0
         payload:
           description: Stored payload (null if none).
     NodeStatsResponse:
@@ -3646,12 +3637,10 @@ components:
         sources:
           type: array
           items:
-            type: integer
-            format: int64
-            minimum: 0
-          description: |-
-            Source node IDs to start traversal from (accepts strings or numbers so
-            JS clients can send precision-safe u64 IDs above `Number.MAX_SAFE_INTEGER`).
+            oneOf:
+            - type: integer
+              format: int64
+            - type: string
     PointRequest:
       type: object
       description: A point in an upsert request.
@@ -3815,15 +3804,17 @@ components:
           type: string
           description: Relationship type label (e.g. `"KNOWS"`, `"RELATED_TO"`).
         source:
-          type: integer
-          format: int64
-          description: Source point ID.
-          minimum: 0
+          oneOf:
+          - type: integer
+            format: int64
+          - type: string
+          description: Point ID. Accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss.
         target:
-          type: integer
-          format: int64
-          description: Target point ID.
-          minimum: 0
+          oneOf:
+          - type: integer
+            format: int64
+          - type: string
+          description: Point ID. Accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss.
     RelateResponse:
       type: object
       description: Response body for `POST /collections/{name}/relations`.
@@ -3831,10 +3822,8 @@ components:
       - edge_id
       properties:
         edge_id:
-          type: integer
-          format: int64
+          type: string
           description: Allocated edge ID.
-          minimum: 0
     RelationEdge:
       type: object
       description: A single relation edge in a response.
@@ -3846,25 +3835,19 @@ components:
       - properties
       properties:
         id:
-          type: integer
-          format: int64
+          type: string
           description: Edge ID.
-          minimum: 0
         properties:
           description: Edge properties (null when empty).
         rel_type:
           type: string
           description: Relationship type label.
         source:
-          type: integer
-          format: int64
+          type: string
           description: Source point ID.
-          minimum: 0
         target:
-          type: integer
-          format: int64
+          type: string
           description: Target point ID.
-          minimum: 0
     RelationsResponse:
       type: object
       description: Response body for `GET /collections/{name}/points/{id}/relations`.
@@ -4143,17 +4126,15 @@ components:
           description: Depth from source.
           minimum: 0
         id:
-          type: integer
-          format: int64
+          type: string
           description: Target node ID.
-          minimum: 0
         path:
           type: array
           items:
-            type: integer
-            format: int64
-            minimum: 0
-          description: Path of edge IDs taken to reach this node.
+            oneOf:
+            - type: integer
+              format: int64
+            - type: string
     StreamStatsEvent:
       type: object
       description: 'SSE event: Periodic statistics update.'
@@ -4209,15 +4190,13 @@ components:
         path:
           type: array
           items:
-            type: integer
-            format: int64
-            minimum: 0
-          description: Path taken (list of edge IDs).
+            oneOf:
+            - type: integer
+              format: int64
+            - type: string
         target_id:
-          type: integer
-          format: int64
+          type: string
           description: Target node ID reached.
-          minimum: 0
     TraversalStats:
       type: object
       description: Statistics from traversal operation.
@@ -4255,10 +4234,11 @@ components:
             type: string
           description: Filter by relationship types (empty = all types).
         source:
-          type: integer
-          format: int64
-          description: Source node ID to start traversal from.
-          minimum: 0
+          oneOf:
+          - type: integer
+            format: int64
+          - type: string
+          description: Point ID. Accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss.
         strategy:
           type: string
           description: 'Traversal strategy: "bfs" or "dfs".'

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2298,28 +2298,25 @@ components:
       - label
       properties:
         id:
-          oneOf:
-          - type: integer
-            format: int64
-          - type: string
-          description: Point ID. Accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss.
+          type: integer
+          format: int64
+          description: Edge ID.
+          minimum: 0
         label:
           type: string
           description: Edge label (relationship type).
         properties:
           description: Edge properties.
         source:
-          oneOf:
-          - type: integer
-            format: int64
-          - type: string
-          description: Point ID. Accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss.
+          type: integer
+          format: int64
+          description: Source node ID.
+          minimum: 0
         target:
-          oneOf:
-          - type: integer
-            format: int64
-          - type: string
-          description: Point ID. Accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss.
+          type: integer
+          format: int64
+          description: Target node ID.
+          minimum: 0
     AddEdgesBatchRequest:
       type: object
       description: Request to add multiple edges in one batched operation.
@@ -2799,19 +2796,25 @@ components:
       - properties
       properties:
         id:
-          type: string
+          type: integer
+          format: int64
           description: Edge ID.
+          minimum: 0
         label:
           type: string
           description: Edge label (relationship type).
         properties:
           description: Edge properties.
         source:
-          type: string
+          type: integer
+          format: int64
           description: Source node ID.
+          minimum: 0
         target:
-          type: string
+          type: integer
+          format: int64
           description: Target node ID.
+          minimum: 0
     EdgesResponse:
       type: object
       description: Response containing edges.
@@ -3144,8 +3147,10 @@ components:
       - score
       properties:
         id:
-          type: string
+          type: integer
+          format: int64
           description: Node ID.
+          minimum: 0
         payload:
           description: Node payload (if any).
         score:
@@ -3451,11 +3456,13 @@ components:
       properties:
         bindings:
           type: object
+          description: Variable bindings from pattern matching.
           additionalProperties:
-            oneOf:
-            - type: integer
-              format: int64
-            - type: string
+            type: integer
+            format: int64
+            minimum: 0
+          propertyNames:
+            type: string
         depth:
           type: integer
           format: int32
@@ -3549,10 +3556,10 @@ components:
         node_ids:
           type: array
           items:
-            oneOf:
-            - type: integer
-              format: int64
-            - type: string
+            type: integer
+            format: int64
+            minimum: 0
+          description: List of node IDs (serialized as strings to preserve u64 precision in JS).
     NodePayloadResponse:
       type: object
       description: Response for a node payload retrieval.
@@ -3560,8 +3567,10 @@ components:
       - node_id
       properties:
         node_id:
-          type: string
+          type: integer
+          format: int64
           description: Node ID.
+          minimum: 0
         payload:
           description: Stored payload (null if none).
     NodeStatsResponse:
@@ -3637,10 +3646,12 @@ components:
         sources:
           type: array
           items:
-            oneOf:
-            - type: integer
-              format: int64
-            - type: string
+            type: integer
+            format: int64
+            minimum: 0
+          description: |-
+            Source node IDs to start traversal from (accepts strings or numbers so
+            JS clients can send precision-safe u64 IDs above `Number.MAX_SAFE_INTEGER`).
     PointRequest:
       type: object
       description: A point in an upsert request.
@@ -3804,17 +3815,15 @@ components:
           type: string
           description: Relationship type label (e.g. `"KNOWS"`, `"RELATED_TO"`).
         source:
-          oneOf:
-          - type: integer
-            format: int64
-          - type: string
-          description: Point ID. Accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss.
+          type: integer
+          format: int64
+          description: Source point ID.
+          minimum: 0
         target:
-          oneOf:
-          - type: integer
-            format: int64
-          - type: string
-          description: Point ID. Accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss.
+          type: integer
+          format: int64
+          description: Target point ID.
+          minimum: 0
     RelateResponse:
       type: object
       description: Response body for `POST /collections/{name}/relations`.
@@ -3822,8 +3831,10 @@ components:
       - edge_id
       properties:
         edge_id:
-          type: string
+          type: integer
+          format: int64
           description: Allocated edge ID.
+          minimum: 0
     RelationEdge:
       type: object
       description: A single relation edge in a response.
@@ -3835,19 +3846,25 @@ components:
       - properties
       properties:
         id:
-          type: string
+          type: integer
+          format: int64
           description: Edge ID.
+          minimum: 0
         properties:
           description: Edge properties (null when empty).
         rel_type:
           type: string
           description: Relationship type label.
         source:
-          type: string
+          type: integer
+          format: int64
           description: Source point ID.
+          minimum: 0
         target:
-          type: string
+          type: integer
+          format: int64
           description: Target point ID.
+          minimum: 0
     RelationsResponse:
       type: object
       description: Response body for `GET /collections/{name}/points/{id}/relations`.
@@ -4126,15 +4143,17 @@ components:
           description: Depth from source.
           minimum: 0
         id:
-          type: string
+          type: integer
+          format: int64
           description: Target node ID.
+          minimum: 0
         path:
           type: array
           items:
-            oneOf:
-            - type: integer
-              format: int64
-            - type: string
+            type: integer
+            format: int64
+            minimum: 0
+          description: Path of edge IDs taken to reach this node.
     StreamStatsEvent:
       type: object
       description: 'SSE event: Periodic statistics update.'
@@ -4190,13 +4209,15 @@ components:
         path:
           type: array
           items:
-            oneOf:
-            - type: integer
-              format: int64
-            - type: string
+            type: integer
+            format: int64
+            minimum: 0
+          description: Path taken (list of edge IDs).
         target_id:
-          type: string
+          type: integer
+          format: int64
           description: Target node ID reached.
+          minimum: 0
     TraversalStats:
       type: object
       description: Statistics from traversal operation.
@@ -4234,11 +4255,10 @@ components:
             type: string
           description: Filter by relationship types (empty = all types).
         source:
-          oneOf:
-          - type: integer
-            format: int64
-          - type: string
-          description: Point ID. Accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss.
+          type: integer
+          format: int64
+          description: Source node ID to start traversal from.
+          minimum: 0
         strategy:
           type: string
           description: 'Traversal strategy: "bfs" or "dfs".'

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -6,6 +6,7 @@ Official TypeScript SDK for [VelesDB](https://github.com/cyberlife-coder/VelesDB
 
 ## What's New (unreleased)
 
+- **Memory wedge, running in-browser via WASM**: new `MemoryService` class (`remember`/`recall`/`recallWhere`/`recallFused`/`relate`/`forget`/`why`) — the same local-first agent memory as `@wiscale/velesdb-memory-node` and the Python binding, now reachable without a server. In-memory only in this release (no filesystem access under WASM); see [Memory Wedge](#memory-wedge-agent-memory) below.
 - **Streaming ingestion enablement (2026-06-14)** (REST backend): `enableStreaming(collection, config?)` turns on the bounded streaming-ingestion channel before `streamInsert()`. The optional `StreamingConfig` (`bufferSize`, `batchSize`, `flushIntervalMs`) is camelCase; omitted fields fall back to the server defaults. See [`db.enableStreaming`](#dbenablestreamingcollection-config) below. The WASM backend throws `NOT_SUPPORTED`.
 - **Relation + durable-TTL surface** (REST backend): `relate()`, `unrelate()`, `getRelations()`, `setTtlDurable()` — now fully tested and documented (see [Knowledge Graph API](#knowledge-graph-api) and [Agent Memory API](#agent-memory-api) below). The WASM backend throws `NOT_SUPPORTED` for these methods.
 - The shipped example (`examples/hybrid_queries.ts`) was rewritten against the real API and is now compile-checked in CI.
@@ -216,6 +217,58 @@ const results = await db.search('docs', query, { k: 5 });
 output. To use a different provider, set `baseUrl`. Implement the `Embedder`
 interface (`{ dimension: number; embed(texts: string[]): Promise<number[][]> }`)
 to plug in any other embedding source.
+
+## Memory Wedge (Agent Memory)
+
+Local-first **agent memory** — the same wedge as `@wiscale/velesdb-memory-node`
+and the Python binding, running entirely in-process via WebAssembly (browser
+or Node.js, no server). `remember` / `recall` / `recallWhere` / `recallFused`
+/ `relate` / `forget` / `why`. The differentiator is **`why()`**: it answers a
+question with the best-matching memory *plus its connected subgraph* —
+related facts a plain vector recall is blind to.
+
+```typescript
+import { MemoryService } from '@wiscale/velesdb-sdk';
+
+const memory = new MemoryService({ dimension: 384 });
+await memory.init();
+
+const pr = await memory.remember('PR #42 swaps the mutex for parking_lot');
+const decision = await memory.remember(
+  'we chose parking_lot to avoid lock poisoning',
+  { links: [{ target: pr, relation: 'decided_in' }] }
+);
+
+// recall: vector similarity.
+const hits = await memory.recall('lock poisoning', 5);
+
+// recallFused: also walks the graph from the top vector hit and promotes
+// any fact it reaches — the tri-engine ranking measured on HotpotQA/TimeQA/LoCoMo.
+const fused = await memory.recallFused('lock poisoning', 5);
+
+// recallWhere: fused vector + structured filters (ranges/comparisons).
+const recent = await memory.recallWhere('release notes', [
+  { field: 'ts', op: 'ge', value: 20260101 },
+]);
+
+// why: the wedge — seed memory + its reachable subgraph.
+const { nodes, edges } = await memory.why('why parking_lot');
+```
+
+Every method returns a `Promise`. Memory ids cross the WASM boundary as
+**decimal strings** (a JS `number` loses precision above 2^53). Errors thrown
+across the boundary are translated into the SDK's typed hierarchy —
+`NotFoundError`, `ValidationError`, or the base `VelesDBError` — so you can
+`catch (e) { if (e instanceof NotFoundError) ... }` the same way regardless
+of which backend raised it.
+
+> **In-memory only in this release.** Unlike the Node/Python bindings, the
+> WASM store has no filesystem access, so `MemoryService` does not persist to
+> disk — memory is lost when the page/process ends. Durable browser storage
+> (IndexedDB) and `rememberExtracted` (auto-extraction, which needs a
+> model/network call) are both out of scope for this release; track
+> `@wiscale/velesdb-memory-node` or the Python binding if you need a
+> persistent store today.
 
 ## API Reference
 

--- a/sdks/typescript/src/index.ts
+++ b/sdks/typescript/src/index.ts
@@ -26,6 +26,16 @@ export * from './types';
 export { VelesDB, AgentMemoryClient } from './client';
 export { WasmBackend } from './backends/wasm';
 export { RestBackend } from './backends/rest';
+export { MemoryService } from './memory';
+export type {
+  MemoryLink,
+  MemoryRecollection,
+  MemoryColumnFilter,
+  MemoryFusionOptions,
+  MemoryNode,
+  MemoryEdge,
+  MemoryExplanation,
+} from './memory';
 export { VelesQLBuilder, velesql } from './query-builder';
 export type {
   RelDirection,

--- a/sdks/typescript/src/memory.ts
+++ b/sdks/typescript/src/memory.ts
@@ -222,12 +222,21 @@ export class MemoryService {
     } = {}
   ): Promise<string> {
     const svc = this.ensureInitialized();
+    const ttl = options.ttlSeconds;
+    // Validate before BigInt(): a non-integer throws a raw RangeError and a
+    // negative value dies as an opaque wasm-bindgen u64 conversion — both
+    // escaping the ValidationError contract this class promises.
+    if (ttl !== undefined && (!Number.isInteger(ttl) || ttl < 0)) {
+      throw new ValidationError(
+        `ttlSeconds must be a non-negative integer, got ${ttl}`
+      );
+    }
     return wrapWasmCall(() =>
       svc.remember(
         fact,
         options.links ?? [],
         options.metadata,
-        options.ttlSeconds !== undefined ? BigInt(options.ttlSeconds) : undefined
+        ttl !== undefined ? BigInt(ttl) : undefined
       )
     );
   }

--- a/sdks/typescript/src/memory.ts
+++ b/sdks/typescript/src/memory.ts
@@ -351,16 +351,34 @@ function wrapWasmCall<T>(call: () => T): Promise<T> {
     try {
       return Promise.reject(toTypedError(error));
     } catch {
-      // Prefer the original thrown value when it's a real Error (a poisoned
-      // `.code` getter broke the translation, but the message and stack are
-      // intact and are what the caller needs) — synthesize a generic error
-      // only when even that isn't usable.
-      return Promise.reject(
-        error instanceof Error
-          ? error
-          : new VelesDBError('non-coercible value thrown across the wasm boundary', 'INTERNAL')
-      );
+      // The translation itself blew up (poisoned getter, revoked proxy,
+      // non-coercible value). Reject with a SAFE synthetic error — never
+      // the original, whose live poisoned properties would detonate again
+      // inside the caller's own catch handler — salvaging its message when
+      // that much can be read without re-triggering the failure. Every
+      // operation here is total: `safeDescription` swallows its own reads'
+      // throws, and constructing a `VelesDBError` from a plain string
+      // cannot fail, so no path escapes as a synchronous throw.
+      return Promise.reject(new VelesDBError(safeDescription(error), 'INTERNAL'));
     }
+  }
+}
+
+/**
+ * Best-effort description of a value whose property access or string
+ * coercion throws (the reason `toTypedError` failed on it). Total: every
+ * read is guarded, so this can never throw — the last-resort rejection
+ * path depends on that.
+ */
+function safeDescription(error: unknown): string {
+  const fallback = 'non-coercible value thrown across the wasm boundary';
+  try {
+    const message = (error as { message?: unknown }).message;
+    return typeof message === 'string' && message.length > 0
+      ? `wasm error (translation failed): ${message}`
+      : fallback;
+  } catch {
+    return fallback;
   }
 }
 

--- a/sdks/typescript/src/memory.ts
+++ b/sdks/typescript/src/memory.ts
@@ -161,13 +161,18 @@ export class MemoryService {
     if (this._initialized) {
       return Promise.resolve();
     }
-    if (this._initInFlight) {
-      return this._initInFlight;
+    if (!this._initInFlight) {
+      this._initInFlight = this.runInit().finally(() => {
+        this._initInFlight = null;
+      });
     }
-    this._initInFlight = this.runInit().finally(() => {
-      this._initInFlight = null;
-    });
-    return this._initInFlight;
+    // A distinct derived promise per caller (adopting the shared in-flight
+    // load's fate), not the memoized instance itself: one caller's .catch
+    // must not mark the rejection handled for every other caller — a
+    // fire-and-forget init() still surfaces its own unhandledrejection
+    // carrying the WASM-load root cause, exactly as the previous async
+    // wrapper guaranteed.
+    return this._initInFlight.then();
   }
 
   private async runInit(): Promise<void> {
@@ -346,8 +351,14 @@ function wrapWasmCall<T>(call: () => T): Promise<T> {
     try {
       return Promise.reject(toTypedError(error));
     } catch {
+      // Prefer the original thrown value when it's a real Error (a poisoned
+      // `.code` getter broke the translation, but the message and stack are
+      // intact and are what the caller needs) — synthesize a generic error
+      // only when even that isn't usable.
       return Promise.reject(
-        new VelesDBError('non-coercible value thrown across the wasm boundary', 'INTERNAL')
+        error instanceof Error
+          ? error
+          : new VelesDBError('non-coercible value thrown across the wasm boundary', 'INTERNAL')
       );
     }
   }

--- a/sdks/typescript/src/memory.ts
+++ b/sdks/typescript/src/memory.ts
@@ -157,9 +157,9 @@ export class MemoryService {
   }
 
   /** Load the WASM module and create the underlying in-memory store. */
-  async init(): Promise<void> {
+  init(): Promise<void> {
     if (this._initialized) {
-      return;
+      return Promise.resolve();
     }
     if (this._initInFlight) {
       return this._initInFlight;
@@ -233,7 +233,10 @@ export class MemoryService {
       // caller asked). All must surface as the ValidationError this class
       // promises. MAX_SAFE_INTEGER seconds ≈ 285 million years, so the cap
       // rejects only corrupted upstream arithmetic, never a real TTL.
-      if (ttl !== undefined && (!Number.isInteger(ttl) || ttl < 0 || ttl > Number.MAX_SAFE_INTEGER)) {
+      if (
+        ttl !== undefined &&
+        (!Number.isInteger(ttl) || ttl < 0 || ttl > Number.MAX_SAFE_INTEGER)
+      ) {
         throw new ValidationError(
           `ttlSeconds must be an integer between 0 and ${Number.MAX_SAFE_INTEGER}, got ${ttl}`
         );
@@ -251,7 +254,11 @@ export class MemoryService {
    * Recall up to `k` (default 10) memories similar to `query`, optionally
    * narrowed by an exact-match metadata `filter`.
    */
-  recall(query: string, k?: number, filter?: Record<string, unknown>): Promise<MemoryRecollection[]> {
+  recall(
+    query: string,
+    k?: number,
+    filter?: Record<string, unknown>
+  ): Promise<MemoryRecollection[]> {
     return wrapWasmCall(
       () => this.ensureInitialized().recall(query, k, filter) as MemoryRecollection[]
     );
@@ -262,7 +269,11 @@ export class MemoryService {
    * support ranges/comparisons (`gt`, `le`, …), so temporal/numeric facets
    * become queryable.
    */
-  recallWhere(query: string, filters: MemoryColumnFilter[], k?: number): Promise<MemoryRecollection[]> {
+  recallWhere(
+    query: string,
+    filters: MemoryColumnFilter[],
+    k?: number
+  ): Promise<MemoryRecollection[]> {
     return wrapWasmCall(
       () => this.ensureInitialized().recallWhere(query, filters, k) as MemoryRecollection[]
     );
@@ -300,7 +311,11 @@ export class MemoryService {
    * Explain a decision: the best-matching memory plus its connected
    * subgraph. `maxHops` (default 2) is capped at 10.
    */
-  why(decision: string, maxHops?: number, filter?: Record<string, unknown>): Promise<MemoryExplanation> {
+  why(
+    decision: string,
+    maxHops?: number,
+    filter?: Record<string, unknown>
+  ): Promise<MemoryExplanation> {
     return wrapWasmCall(
       () => this.ensureInitialized().why(decision, maxHops, filter) as MemoryExplanation
     );
@@ -322,7 +337,19 @@ function wrapWasmCall<T>(call: () => T): Promise<T> {
   try {
     return Promise.resolve(call());
   } catch (error) {
-    return Promise.reject(toTypedError(error));
+    // toTypedError itself can throw on exotic thrown values (a
+    // prototype-less object breaks String(); a poisoned getter breaks the
+    // `.code` read). Without an enclosing `async` to lift it, that throw
+    // would escape this Promise-returning function SYNCHRONOUSLY — the one
+    // path violating the every-failure-is-a-rejection contract — so it too
+    // is caught and folded into a rejection.
+    try {
+      return Promise.reject(toTypedError(error));
+    } catch {
+      return Promise.reject(
+        new VelesDBError('non-coercible value thrown across the wasm boundary', 'INTERNAL')
+      );
+    }
   }
 }
 

--- a/sdks/typescript/src/memory.ts
+++ b/sdks/typescript/src/memory.ts
@@ -223,12 +223,19 @@ export class MemoryService {
   ): Promise<string> {
     const svc = this.ensureInitialized();
     const ttl = options.ttlSeconds;
-    // Validate before BigInt(): a non-integer throws a raw RangeError and a
-    // negative value dies as an opaque wasm-bindgen u64 conversion — both
-    // escaping the ValidationError contract this class promises.
-    if (ttl !== undefined && (!Number.isInteger(ttl) || ttl < 0)) {
+    // Validate before BigInt(): a non-integer throws a raw RangeError, a
+    // negative value dies as an opaque wasm-bindgen u64 conversion, and a
+    // value past MAX_SAFE_INTEGER silently wraps modulo 2^64 at the wasm
+    // boundary (2**64 wraps to 0 — "permanent" — the opposite of what the
+    // caller asked). All must surface as the ValidationError this class
+    // promises. MAX_SAFE_INTEGER seconds ≈ 285 million years, so the cap
+    // rejects only corrupted upstream arithmetic, never a real TTL.
+    if (
+      ttl !== undefined &&
+      (!Number.isInteger(ttl) || ttl < 0 || ttl > Number.MAX_SAFE_INTEGER)
+    ) {
       throw new ValidationError(
-        `ttlSeconds must be a non-negative integer, got ${ttl}`
+        `ttlSeconds must be an integer between 0 and ${Number.MAX_SAFE_INTEGER}, got ${ttl}`
       );
     }
     return wrapWasmCall(() =>

--- a/sdks/typescript/src/memory.ts
+++ b/sdks/typescript/src/memory.ts
@@ -366,16 +366,7 @@ function toTypedError(error: unknown): Error {
   const rawMessage = tryRead(() => (error as WasmErrorLike).message);
   const message = salvageMessage(rawMessage);
   if (isError.value !== true) {
-    const text = tryRead(() => String(error));
-    if (typeof text.value === 'string') {
-      return new VelesDBError(text.value, 'INTERNAL');
-    }
-    return new VelesDBError(
-      message !== undefined
-        ? `wasm error (translation failed): ${message}`
-        : 'non-coercible value thrown across the wasm boundary',
-      'INTERNAL'
-    );
+    return coerceNonError(error, message);
   }
   const code = tryRead(() => (error as WasmErrorLike).code);
   switch (code.value) {
@@ -385,26 +376,50 @@ function toTypedError(error: unknown): Error {
     // exist"). Construct it for `instanceof` narrowing, then overwrite its
     // message with the original rather than wrapping it a second time.
     // ValidationError has no such mangling — its constructor takes a raw
-    // message directly. Both branches flag a lost original message the same
-    // way, so degradation is never silent.
+    // message directly. The "(original message unavailable)" fallbacks make
+    // a lost message visible without claiming why it was lost (empty,
+    // non-string, or a throwing getter alike).
     case 'NOT_FOUND':
       return withMessage(
         new NotFoundError('memory'),
-        message ?? 'memory not found (original message unreadable)'
+        messageOr(message, 'memory not found (original message unavailable)')
       );
     case 'INVALID_INPUT':
-      return new ValidationError(message ?? 'invalid input (original message unreadable)');
-    default:
-      if (code.ok && rawMessage.ok) {
-        return error as Error;
-      }
-      return new VelesDBError(
-        message !== undefined
-          ? `wasm error (translation failed): ${message}`
-          : 'wasm error (translation failed: property inspection throws)',
-        'INTERNAL'
+      return new ValidationError(
+        messageOr(message, 'invalid input (original message unavailable)')
       );
+    default:
+      return code.ok && rawMessage.ok
+        ? (error as Error)
+        : degradedError(message, 'wasm error (message unavailable)');
   }
+}
+
+/**
+ * The `INTERNAL` translation for a thrown non-Error: its string coercion
+ * when that works, else a degraded error salvaging the already-read
+ * `.message` (a prototype-less `{code, message}` object has no `toString`,
+ * yet its message is the one diagnostic worth keeping).
+ */
+function coerceNonError(error: unknown, message: string | undefined): VelesDBError {
+  const text = tryRead(() => String(error));
+  if (typeof text.value === 'string') {
+    return new VelesDBError(text.value, 'INTERNAL');
+  }
+  return degradedError(message, 'non-coercible value thrown across the wasm boundary');
+}
+
+/** The salvaged message, or `fallback` when nothing survived. */
+function messageOr(message: string | undefined, fallback: string): string {
+  return message ?? fallback;
+}
+
+/** A synthetic error carrying whatever message survived salvage, else `fallback`. */
+function degradedError(message: string | undefined, fallback: string): VelesDBError {
+  return new VelesDBError(
+    message !== undefined ? `wasm error (translation failed): ${message}` : fallback,
+    'INTERNAL'
+  );
 }
 
 /** A guarded read: captures the result, or the fact that reading threw. */
@@ -419,7 +434,8 @@ function tryRead<T>(read: () => T): { ok: boolean; value: T | undefined } {
 /**
  * A usable message text out of a guarded `.message` read, or `undefined`:
  * non-empty strings pass through, non-string values are coerced when their
- * coercion doesn't itself throw, empty/absent/unreadable yield nothing.
+ * coercion doesn't itself throw; empty, absent, and unreadable all yield
+ * nothing (the caller's fallback text stays accurate for every case).
  */
 function salvageMessage(read: { ok: boolean; value: unknown }): string | undefined {
   if (!read.ok || read.value == null) {
@@ -429,7 +445,7 @@ function salvageMessage(read: { ok: boolean; value: unknown }): string | undefin
     return read.value.length > 0 ? read.value : undefined;
   }
   const coerced = tryRead(() => String(read.value));
-  return coerced.value;
+  return coerced.value ? coerced.value : undefined;
 }
 
 function withMessage<E extends Error>(error: E, message: string): E {

--- a/sdks/typescript/src/memory.ts
+++ b/sdks/typescript/src/memory.ts
@@ -194,10 +194,12 @@ export class MemoryService {
   }
 
   /** Release the underlying WASM store. */
-  async close(): Promise<void> {
-    this.inner?.free();
-    this.inner = null;
-    this._initialized = false;
+  close(): Promise<void> {
+    return wrapWasmCall(() => {
+      this.inner?.free();
+      this.inner = null;
+      this._initialized = false;
+    });
   }
 
   private ensureInitialized(): WasmMemoryServiceInstance {
@@ -213,7 +215,7 @@ export class MemoryService {
    * is optional structured data for later filtering; `ttlSeconds` makes the
    * fact expire after that many seconds (omit, or `0`, for permanent).
    */
-  async remember(
+  remember(
     fact: string,
     options: {
       links?: MemoryLink[];
@@ -221,44 +223,38 @@ export class MemoryService {
       ttlSeconds?: number;
     } = {}
   ): Promise<string> {
-    const svc = this.ensureInitialized();
-    const ttl = options.ttlSeconds;
-    // Validate before BigInt(): a non-integer throws a raw RangeError, a
-    // negative value dies as an opaque wasm-bindgen u64 conversion, and a
-    // value past MAX_SAFE_INTEGER silently wraps modulo 2^64 at the wasm
-    // boundary (2**64 wraps to 0 — "permanent" — the opposite of what the
-    // caller asked). All must surface as the ValidationError this class
-    // promises. MAX_SAFE_INTEGER seconds ≈ 285 million years, so the cap
-    // rejects only corrupted upstream arithmetic, never a real TTL.
-    if (
-      ttl !== undefined &&
-      (!Number.isInteger(ttl) || ttl < 0 || ttl > Number.MAX_SAFE_INTEGER)
-    ) {
-      throw new ValidationError(
-        `ttlSeconds must be an integer between 0 and ${Number.MAX_SAFE_INTEGER}, got ${ttl}`
-      );
-    }
-    return wrapWasmCall(() =>
-      svc.remember(
+    return wrapWasmCall(() => {
+      const svc = this.ensureInitialized();
+      const ttl = options.ttlSeconds;
+      // Validate before BigInt(): a non-integer throws a raw RangeError, a
+      // negative value dies as an opaque wasm-bindgen u64 conversion, and a
+      // value past MAX_SAFE_INTEGER silently wraps modulo 2^64 at the wasm
+      // boundary (2**64 wraps to 0 — "permanent" — the opposite of what the
+      // caller asked). All must surface as the ValidationError this class
+      // promises. MAX_SAFE_INTEGER seconds ≈ 285 million years, so the cap
+      // rejects only corrupted upstream arithmetic, never a real TTL.
+      if (ttl !== undefined && (!Number.isInteger(ttl) || ttl < 0 || ttl > Number.MAX_SAFE_INTEGER)) {
+        throw new ValidationError(
+          `ttlSeconds must be an integer between 0 and ${Number.MAX_SAFE_INTEGER}, got ${ttl}`
+        );
+      }
+      return svc.remember(
         fact,
         options.links ?? [],
         options.metadata,
         ttl !== undefined ? BigInt(ttl) : undefined
-      )
-    );
+      );
+    });
   }
 
   /**
    * Recall up to `k` (default 10) memories similar to `query`, optionally
    * narrowed by an exact-match metadata `filter`.
    */
-  async recall(
-    query: string,
-    k?: number,
-    filter?: Record<string, unknown>
-  ): Promise<MemoryRecollection[]> {
-    const svc = this.ensureInitialized();
-    return wrapWasmCall(() => svc.recall(query, k, filter) as MemoryRecollection[]);
+  recall(query: string, k?: number, filter?: Record<string, unknown>): Promise<MemoryRecollection[]> {
+    return wrapWasmCall(
+      () => this.ensureInitialized().recall(query, k, filter) as MemoryRecollection[]
+    );
   }
 
   /**
@@ -266,13 +262,10 @@ export class MemoryService {
    * support ranges/comparisons (`gt`, `le`, …), so temporal/numeric facets
    * become queryable.
    */
-  async recallWhere(
-    query: string,
-    filters: MemoryColumnFilter[],
-    k?: number
-  ): Promise<MemoryRecollection[]> {
-    const svc = this.ensureInitialized();
-    return wrapWasmCall(() => svc.recallWhere(query, filters, k) as MemoryRecollection[]);
+  recallWhere(query: string, filters: MemoryColumnFilter[], k?: number): Promise<MemoryRecollection[]> {
+    return wrapWasmCall(
+      () => this.ensureInitialized().recallWhere(query, filters, k) as MemoryRecollection[]
+    );
   }
 
   /**
@@ -280,54 +273,56 @@ export class MemoryService {
    * graph from the top vector hit and promotes any fact it reaches into the
    * ranking — the tri-engine ranking measured on HotpotQA/TimeQA/LoCoMo.
    */
-  async recallFused(
+  recallFused(
     query: string,
     k?: number,
     filter?: Record<string, unknown>,
     opts?: MemoryFusionOptions
   ): Promise<MemoryRecollection[]> {
-    const svc = this.ensureInitialized();
-    return wrapWasmCall(() => svc.recallFused(query, k, filter, opts) as MemoryRecollection[]);
+    return wrapWasmCall(
+      () => this.ensureInitialized().recallFused(query, k, filter, opts) as MemoryRecollection[]
+    );
   }
 
   /** Create a typed edge `from -> to`. Resolves to the edge's decimal-string id. */
-  async relate(from: string, to: string, relation: string): Promise<string> {
-    const svc = this.ensureInitialized();
-    return wrapWasmCall(() => svc.relate(from, to, relation));
+  relate(from: string, to: string, relation: string): Promise<string> {
+    return wrapWasmCall(() => this.ensureInitialized().relate(from, to, relation));
   }
 
   /** Delete a memory by id. */
-  async forget(id: string): Promise<void> {
-    const svc = this.ensureInitialized();
-    return wrapWasmCall(() => svc.forget(id));
+  forget(id: string): Promise<void> {
+    return wrapWasmCall(() => {
+      this.ensureInitialized().forget(id);
+    });
   }
 
   /**
    * Explain a decision: the best-matching memory plus its connected
    * subgraph. `maxHops` (default 2) is capped at 10.
    */
-  async why(
-    decision: string,
-    maxHops?: number,
-    filter?: Record<string, unknown>
-  ): Promise<MemoryExplanation> {
-    const svc = this.ensureInitialized();
-    return wrapWasmCall(() => svc.why(decision, maxHops, filter) as MemoryExplanation);
+  why(decision: string, maxHops?: number, filter?: Record<string, unknown>): Promise<MemoryExplanation> {
+    return wrapWasmCall(
+      () => this.ensureInitialized().why(decision, maxHops, filter) as MemoryExplanation
+    );
   }
 }
 
 /**
  * Run a synchronous wasm-bindgen call (every `WasmMemoryService` method is
- * sync — errors surface as a thrown value, not a rejected promise) and
- * translate a structured `{code}` error into the SDK's typed hierarchy, so
- * callers can `catch (e) { if (e instanceof NotFoundError) ... }` the same
- * way regardless of which backend raised it.
+ * sync — errors surface as a thrown value, not a rejected promise), lift the
+ * result into a Promise, and translate a structured `{code}` error into the
+ * SDK's typed hierarchy, so callers can
+ * `catch (e) { if (e instanceof NotFoundError) ... }` the same way
+ * regardless of which backend raised it. Every failure — including a sync
+ * throw from validation or the not-initialized guard inside `call` — becomes
+ * a rejection, never a synchronous throw, matching what the public
+ * Promise-returning signatures advertise.
  */
-function wrapWasmCall<T>(call: () => T): T {
+function wrapWasmCall<T>(call: () => T): Promise<T> {
   try {
-    return call();
+    return Promise.resolve(call());
   } catch (error) {
-    throw toTypedError(error);
+    return Promise.reject(toTypedError(error));
   }
 }
 

--- a/sdks/typescript/src/memory.ts
+++ b/sdks/typescript/src/memory.ts
@@ -342,51 +342,56 @@ function wrapWasmCall<T>(call: () => T): Promise<T> {
   try {
     return Promise.resolve(call());
   } catch (error) {
-    // toTypedError itself can throw on exotic thrown values (a
-    // prototype-less object breaks String(); a poisoned getter breaks the
-    // `.code` read). Without an enclosing `async` to lift it, that throw
-    // would escape this Promise-returning function SYNCHRONOUSLY — the one
-    // path violating the every-failure-is-a-rejection contract — so it too
-    // is caught and folded into a rejection.
-    try {
-      return Promise.reject(toTypedError(error));
-    } catch {
-      // The translation itself blew up (poisoned getter, revoked proxy,
-      // non-coercible value). Reject with a SAFE synthetic error — never
-      // the original, whose live poisoned properties would detonate again
-      // inside the caller's own catch handler — salvaging its message when
-      // that much can be read without re-triggering the failure. Every
-      // operation here is total: `safeDescription` swallows its own reads'
-      // throws, and constructing a `VelesDBError` from a plain string
-      // cannot fail, so no path escapes as a synchronous throw.
-      return Promise.reject(new VelesDBError(safeDescription(error), 'INTERNAL'));
-    }
+    // `toTypedError` is total (every property read and coercion inside it
+    // is guarded), so this single reject can never itself throw — the
+    // every-failure-is-a-rejection contract needs no second safety net.
+    return Promise.reject(toTypedError(error));
   }
 }
 
 /**
- * Best-effort description of a value whose property access or string
- * coercion throws (the reason `toTypedError` failed on it). Total: every
- * read is guarded, so this can never throw — the last-resort rejection
- * path depends on that.
+ * Translate a value thrown across the wasm boundary into the SDK's typed
+ * hierarchy. **Total by construction**: every property read and string
+ * coercion is individually guarded, so this never throws even for exotic
+ * values (poisoned getters, revoked proxies, prototype-less objects) —
+ * `wrapWasmCall`'s rejection contract depends on that. Degradation is
+ * per-property: a readable `.code` still classifies the error as
+ * NotFound/Validation even when `.message` is unreadable, and the original
+ * error object is passed through verbatim only when its whole inspected
+ * surface proved safe — otherwise the caller gets a synthetic error whose
+ * own `.code`/`.message` reads can never detonate in their catch handler.
  */
-function safeDescription(error: unknown): string {
-  const fallback = 'non-coercible value thrown across the wasm boundary';
-  try {
-    const message = (error as { message?: unknown }).message;
-    return typeof message === 'string' && message.length > 0
-      ? `wasm error (translation failed): ${message}`
-      : fallback;
-  } catch {
-    return fallback;
-  }
-}
-
 function toTypedError(error: unknown): Error {
-  if (!(error instanceof Error)) {
-    return new VelesDBError(String(error), 'INTERNAL');
+  let isError: boolean;
+  try {
+    isError = error instanceof Error;
+  } catch {
+    isError = false; // a revoked proxy throws on the prototype walk
   }
-  const code = (error as WasmErrorLike).code;
+  if (!isError) {
+    let text: string;
+    try {
+      text = String(error);
+    } catch {
+      text = 'non-coercible value thrown across the wasm boundary';
+    }
+    return new VelesDBError(text, 'INTERNAL');
+  }
+  let codeUnreadable = false;
+  let code: string | undefined;
+  try {
+    code = (error as WasmErrorLike).code;
+  } catch {
+    codeUnreadable = true;
+  }
+  let messageUnreadable = false;
+  let message: string | undefined;
+  try {
+    const read = (error as WasmErrorLike).message;
+    message = typeof read === 'string' ? read : undefined;
+  } catch {
+    messageUnreadable = true;
+  }
   switch (code) {
     // NotFoundError's constructor takes a bare resource name and builds its
     // own "X not found" message — but the wasm error already carries a
@@ -396,11 +401,19 @@ function toTypedError(error: unknown): Error {
     // ValidationError has no such mangling — its constructor takes a raw
     // message directly, so no override is needed there.
     case 'NOT_FOUND':
-      return withMessage(new NotFoundError('memory'), error.message);
+      return withMessage(new NotFoundError('memory'), message ?? 'memory not found');
     case 'INVALID_INPUT':
-      return new ValidationError(error.message);
+      return new ValidationError(message ?? 'invalid input (original message unreadable)');
     default:
-      return error;
+      if (!codeUnreadable && !messageUnreadable) {
+        return error as Error;
+      }
+      return new VelesDBError(
+        message !== undefined
+          ? `wasm error (translation failed): ${message}`
+          : 'wasm error whose property inspection throws (message unreadable)',
+        'INTERNAL'
+      );
   }
 }
 

--- a/sdks/typescript/src/memory.ts
+++ b/sdks/typescript/src/memory.ts
@@ -362,59 +362,74 @@ function wrapWasmCall<T>(call: () => T): Promise<T> {
  * own `.code`/`.message` reads can never detonate in their catch handler.
  */
 function toTypedError(error: unknown): Error {
-  let isError: boolean;
-  try {
-    isError = error instanceof Error;
-  } catch {
-    isError = false; // a revoked proxy throws on the prototype walk
-  }
-  if (!isError) {
-    let text: string;
-    try {
-      text = String(error);
-    } catch {
-      text = 'non-coercible value thrown across the wasm boundary';
+  const isError = tryRead(() => error instanceof Error); // a revoked proxy throws on the prototype walk
+  const rawMessage = tryRead(() => (error as WasmErrorLike).message);
+  const message = salvageMessage(rawMessage);
+  if (isError.value !== true) {
+    const text = tryRead(() => String(error));
+    if (typeof text.value === 'string') {
+      return new VelesDBError(text.value, 'INTERNAL');
     }
-    return new VelesDBError(text, 'INTERNAL');
+    return new VelesDBError(
+      message !== undefined
+        ? `wasm error (translation failed): ${message}`
+        : 'non-coercible value thrown across the wasm boundary',
+      'INTERNAL'
+    );
   }
-  let codeUnreadable = false;
-  let code: string | undefined;
-  try {
-    code = (error as WasmErrorLike).code;
-  } catch {
-    codeUnreadable = true;
-  }
-  let messageUnreadable = false;
-  let message: string | undefined;
-  try {
-    const read = (error as WasmErrorLike).message;
-    message = typeof read === 'string' ? read : undefined;
-  } catch {
-    messageUnreadable = true;
-  }
-  switch (code) {
+  const code = tryRead(() => (error as WasmErrorLike).code);
+  switch (code.value) {
     // NotFoundError's constructor takes a bare resource name and builds its
     // own "X not found" message — but the wasm error already carries a
     // specific, well-formed message from Rust (e.g. "memory 42 does not
     // exist"). Construct it for `instanceof` narrowing, then overwrite its
     // message with the original rather than wrapping it a second time.
     // ValidationError has no such mangling — its constructor takes a raw
-    // message directly, so no override is needed there.
+    // message directly. Both branches flag a lost original message the same
+    // way, so degradation is never silent.
     case 'NOT_FOUND':
-      return withMessage(new NotFoundError('memory'), message ?? 'memory not found');
+      return withMessage(
+        new NotFoundError('memory'),
+        message ?? 'memory not found (original message unreadable)'
+      );
     case 'INVALID_INPUT':
       return new ValidationError(message ?? 'invalid input (original message unreadable)');
     default:
-      if (!codeUnreadable && !messageUnreadable) {
+      if (code.ok && rawMessage.ok) {
         return error as Error;
       }
       return new VelesDBError(
         message !== undefined
           ? `wasm error (translation failed): ${message}`
-          : 'wasm error whose property inspection throws (message unreadable)',
+          : 'wasm error (translation failed: property inspection throws)',
         'INTERNAL'
       );
   }
+}
+
+/** A guarded read: captures the result, or the fact that reading threw. */
+function tryRead<T>(read: () => T): { ok: boolean; value: T | undefined } {
+  try {
+    return { ok: true, value: read() };
+  } catch {
+    return { ok: false, value: undefined };
+  }
+}
+
+/**
+ * A usable message text out of a guarded `.message` read, or `undefined`:
+ * non-empty strings pass through, non-string values are coerced when their
+ * coercion doesn't itself throw, empty/absent/unreadable yield nothing.
+ */
+function salvageMessage(read: { ok: boolean; value: unknown }): string | undefined {
+  if (!read.ok || read.value == null) {
+    return undefined;
+  }
+  if (typeof read.value === 'string') {
+    return read.value.length > 0 ? read.value : undefined;
+  }
+  const coerced = tryRead(() => String(read.value));
+  return coerced.value;
 }
 
 function withMessage<E extends Error>(error: E, message: string): E {

--- a/sdks/typescript/src/memory.ts
+++ b/sdks/typescript/src/memory.ts
@@ -1,0 +1,343 @@
+/**
+ * VelesDB Memory Wedge — local-first agent memory (WASM-backed).
+ *
+ * A standalone client, not a facade over {@link IVelesDBBackend}: the wedge
+ * is a single in-memory store (no `collection` parameter, no REST
+ * counterpart), architecturally distinct from the collection-scoped vector
+ * API the rest of the SDK wraps. Mirrors the Node (`@wiscale/velesdb-memory-node`)
+ * and Python bindings' own standalone `MemoryService` class rather than
+ * bolting onto the generic backend interface — which also sidesteps a real
+ * naming collision (`IVelesDBBackend.relate` is the graph-edge API, a
+ * different shape than the memory wedge's `relate(from, to, relation)`).
+ *
+ * @packageDocumentation
+ */
+
+import { ConnectionError, NotFoundError, ValidationError, VelesDBError } from './types';
+
+// ---------------------------------------------------------------------------
+// Public types — mirror crates/velesdb-node/index.d.ts's Js DTOs
+// ---------------------------------------------------------------------------
+
+/** A typed link to an existing memory (input to {@link MemoryService.remember}). */
+export interface MemoryLink {
+  /** Decimal-string id of the memory being linked to. */
+  target: string;
+  /** Relationship label, e.g. `"decided_in"`. */
+  relation: string;
+}
+
+/** One recalled memory (output of `recall` / `recallWhere` / `recallFused`). */
+export interface MemoryRecollection {
+  /** Decimal-string id of the memory. */
+  id: string;
+  /** Similarity score (higher is closer). */
+  score: number;
+  /** Stored fact content. */
+  content: string;
+  /** Caller-supplied structured metadata, or `undefined` when the fact carries none. */
+  metadata?: Record<string, unknown>;
+}
+
+/** A structured predicate for {@link MemoryService.recallWhere}. */
+export interface MemoryColumnFilter {
+  /** Metadata field name (alphanumeric/underscore). */
+  field: string;
+  /** Comparison operator. */
+  op: 'eq' | 'ne' | 'lt' | 'le' | 'gt' | 'ge';
+  /** Value to compare against (string, number, or boolean). */
+  value: string | number | boolean;
+}
+
+/**
+ * Tuning knobs for {@link MemoryService.recallFused}. Every field is
+ * optional; an omitted field falls back to the proven default (`hops: 2`,
+ * `graphBoost: 0.15`, an oversampled pool).
+ */
+export interface MemoryFusionOptions {
+  /** Hops the graph traversal walks from the top vector seed. */
+  hops?: number;
+  /** Weight added to a graph-reached fact's normalised vector score. */
+  graphBoost?: number;
+  /** Depth of the oversampled vector pool fusion re-ranks. */
+  pool?: number;
+}
+
+/** A node in a {@link MemoryService.why} explanation subgraph. */
+export interface MemoryNode {
+  /** Decimal-string id of the memory. */
+  id: string;
+  /** Stored fact content. */
+  content: string;
+  /** Distance in hops from the seed (seed is `0`). */
+  hop: number;
+}
+
+/** A typed edge in a {@link MemoryService.why} explanation subgraph. */
+export interface MemoryEdge {
+  /** Source memory id (decimal string). */
+  from: string;
+  /** Target memory id (decimal string). */
+  to: string;
+  /** Relationship label. */
+  relation: string;
+}
+
+/** The connected answer to a {@link MemoryService.why} question. */
+export interface MemoryExplanation {
+  /** Memories in the subgraph, seed first. */
+  nodes: MemoryNode[];
+  /** Typed edges connecting the nodes. */
+  edges: MemoryEdge[];
+}
+
+// ---------------------------------------------------------------------------
+// Raw wasm-bindgen surface — just the shape memory.ts needs, kept local
+// rather than extending backends/wasm-types.ts (WasmBackend's own typed
+// surface): this module does its own independent module load and has no
+// other dependency on WasmBackend's collection-oriented types.
+// ---------------------------------------------------------------------------
+
+interface WasmMemoryServiceInstance {
+  remember(fact: string, links: unknown, metadata: unknown, ttlSeconds?: bigint | null): string;
+  recall(query: string, k: number | null | undefined, filter: unknown): unknown;
+  recallWhere(query: string, filters: unknown, k?: number | null): unknown;
+  recallFused(query: string, k: number | null | undefined, filter: unknown, opts: unknown): unknown;
+  relate(from: string, to: string, relation: string): string;
+  forget(id: string): void;
+  why(decision: string, maxHops: number | null | undefined, filter: unknown): unknown;
+  free(): void;
+}
+
+interface WasmMemoryServiceConstructor {
+  new (dimension: number): WasmMemoryServiceInstance;
+}
+
+interface MemoryWasmModule {
+  default(moduleOrPath?: Uint8Array | URL | string): Promise<void>;
+  MemoryService: WasmMemoryServiceConstructor;
+}
+
+/** A JS error thrown across the wasm boundary carries a non-enumerable `.code`. */
+interface WasmErrorLike {
+  code?: string;
+  message?: string;
+}
+
+// ---------------------------------------------------------------------------
+// MemoryService
+// ---------------------------------------------------------------------------
+
+/**
+ * Local-first agent memory: remember facts, recall them semantically,
+ * relate them, forget them, and ask why a decision was made (a connected
+ * subgraph). Runs entirely in-process (browser or Node) via WebAssembly —
+ * no server, no network.
+ *
+ * @example
+ * ```typescript
+ * const memory = new MemoryService({ dimension: 384 });
+ * await memory.init();
+ * const id = await memory.remember('we chose parking_lot to avoid lock poisoning');
+ * const hits = await memory.recall('lock poisoning');
+ * ```
+ */
+export class MemoryService {
+  private readonly dimension: number;
+  private inner: WasmMemoryServiceInstance | null = null;
+  private _initialized = false;
+  // Memoized single-shot init promise — mirrors WasmBackend's own pattern
+  // (backends/wasm.ts) so concurrent init() callers await the same
+  // in-flight load instead of racing duplicate wasm-bindgen `default()`
+  // invocations.
+  private _initInFlight: Promise<void> | null = null;
+
+  constructor(options: { dimension?: number } = {}) {
+    this.dimension = options.dimension ?? 384;
+  }
+
+  /** Load the WASM module and create the underlying in-memory store. */
+  async init(): Promise<void> {
+    if (this._initialized) {
+      return;
+    }
+    if (this._initInFlight) {
+      return this._initInFlight;
+    }
+    this._initInFlight = this.runInit().finally(() => {
+      this._initInFlight = null;
+    });
+    return this._initInFlight;
+  }
+
+  private async runInit(): Promise<void> {
+    try {
+      const mod = (await import('@wiscale/velesdb-wasm')) as unknown as MemoryWasmModule;
+      const nodeLoader = await import('./backends/wasm-node-loader');
+      if (nodeLoader.isNodeRuntime()) {
+        await mod.default(await nodeLoader.loadWasmBytesNode());
+      } else {
+        await mod.default();
+      }
+      this.inner = new mod.MemoryService(this.dimension);
+      this._initialized = true;
+    } catch (error) {
+      throw new ConnectionError(
+        'Failed to initialize the memory wedge WASM module',
+        error instanceof Error ? error : undefined
+      );
+    }
+  }
+
+  isInitialized(): boolean {
+    return this._initialized;
+  }
+
+  /** Release the underlying WASM store. */
+  async close(): Promise<void> {
+    this.inner?.free();
+    this.inner = null;
+    this._initialized = false;
+  }
+
+  private ensureInitialized(): WasmMemoryServiceInstance {
+    if (!this._initialized || !this.inner) {
+      throw new ConnectionError('Memory wedge not initialized — call init() first');
+    }
+    return this.inner;
+  }
+
+  /**
+   * Store a fact; resolves to its decimal-string id (idempotent on
+   * identical content). `links` are edges to existing memories; `metadata`
+   * is optional structured data for later filtering; `ttlSeconds` makes the
+   * fact expire after that many seconds (omit, or `0`, for permanent).
+   */
+  async remember(
+    fact: string,
+    options: {
+      links?: MemoryLink[];
+      metadata?: Record<string, unknown>;
+      ttlSeconds?: number;
+    } = {}
+  ): Promise<string> {
+    const svc = this.ensureInitialized();
+    return wrapWasmCall(() =>
+      svc.remember(
+        fact,
+        options.links ?? [],
+        options.metadata,
+        options.ttlSeconds !== undefined ? BigInt(options.ttlSeconds) : undefined
+      )
+    );
+  }
+
+  /**
+   * Recall up to `k` (default 10) memories similar to `query`, optionally
+   * narrowed by an exact-match metadata `filter`.
+   */
+  async recall(
+    query: string,
+    k?: number,
+    filter?: Record<string, unknown>
+  ): Promise<MemoryRecollection[]> {
+    const svc = this.ensureInitialized();
+    return wrapWasmCall(() => svc.recall(query, k, filter) as MemoryRecollection[]);
+  }
+
+  /**
+   * Fused vector + `ColumnStore` recall: like {@link recall} but `filters`
+   * support ranges/comparisons (`gt`, `le`, …), so temporal/numeric facets
+   * become queryable.
+   */
+  async recallWhere(
+    query: string,
+    filters: MemoryColumnFilter[],
+    k?: number
+  ): Promise<MemoryRecollection[]> {
+    const svc = this.ensureInitialized();
+    return wrapWasmCall(() => svc.recallWhere(query, filters, k) as MemoryRecollection[]);
+  }
+
+  /**
+   * Fused vector + graph recall: like {@link recall}, but also walks the
+   * graph from the top vector hit and promotes any fact it reaches into the
+   * ranking — the tri-engine ranking measured on HotpotQA/TimeQA/LoCoMo.
+   */
+  async recallFused(
+    query: string,
+    k?: number,
+    filter?: Record<string, unknown>,
+    opts?: MemoryFusionOptions
+  ): Promise<MemoryRecollection[]> {
+    const svc = this.ensureInitialized();
+    return wrapWasmCall(() => svc.recallFused(query, k, filter, opts) as MemoryRecollection[]);
+  }
+
+  /** Create a typed edge `from -> to`. Resolves to the edge's decimal-string id. */
+  async relate(from: string, to: string, relation: string): Promise<string> {
+    const svc = this.ensureInitialized();
+    return wrapWasmCall(() => svc.relate(from, to, relation));
+  }
+
+  /** Delete a memory by id. */
+  async forget(id: string): Promise<void> {
+    const svc = this.ensureInitialized();
+    return wrapWasmCall(() => svc.forget(id));
+  }
+
+  /**
+   * Explain a decision: the best-matching memory plus its connected
+   * subgraph. `maxHops` (default 2) is capped at 10.
+   */
+  async why(
+    decision: string,
+    maxHops?: number,
+    filter?: Record<string, unknown>
+  ): Promise<MemoryExplanation> {
+    const svc = this.ensureInitialized();
+    return wrapWasmCall(() => svc.why(decision, maxHops, filter) as MemoryExplanation);
+  }
+}
+
+/**
+ * Run a synchronous wasm-bindgen call (every `WasmMemoryService` method is
+ * sync — errors surface as a thrown value, not a rejected promise) and
+ * translate a structured `{code}` error into the SDK's typed hierarchy, so
+ * callers can `catch (e) { if (e instanceof NotFoundError) ... }` the same
+ * way regardless of which backend raised it.
+ */
+function wrapWasmCall<T>(call: () => T): T {
+  try {
+    return call();
+  } catch (error) {
+    throw toTypedError(error);
+  }
+}
+
+function toTypedError(error: unknown): Error {
+  if (!(error instanceof Error)) {
+    return new VelesDBError(String(error), 'INTERNAL');
+  }
+  const code = (error as WasmErrorLike).code;
+  switch (code) {
+    // NotFoundError's constructor takes a bare resource name and builds its
+    // own "X not found" message — but the wasm error already carries a
+    // specific, well-formed message from Rust (e.g. "memory 42 does not
+    // exist"). Construct it for `instanceof` narrowing, then overwrite its
+    // message with the original rather than wrapping it a second time.
+    // ValidationError has no such mangling — its constructor takes a raw
+    // message directly, so no override is needed there.
+    case 'NOT_FOUND':
+      return withMessage(new NotFoundError('memory'), error.message);
+    case 'INVALID_INPUT':
+      return new ValidationError(error.message);
+    default:
+      return error;
+  }
+}
+
+function withMessage<E extends Error>(error: E, message: string): E {
+  Object.defineProperty(error, 'message', { value: message, writable: true, configurable: true });
+  return error;
+}

--- a/sdks/typescript/tests/memory.test.ts
+++ b/sdks/typescript/tests/memory.test.ts
@@ -1,0 +1,222 @@
+/**
+ * MemoryService Unit Tests
+ *
+ * Tests the MemoryService class against a mocked `@wiscale/velesdb-wasm`
+ * module, mirroring wasm-backend.test.ts's convention (a real-wasm smoke
+ * run was used to verify the class against the actual compiled artifact
+ * during development; this suite is the permanent, CI-safe one).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { MemoryService } from '../src/memory';
+import { ConnectionError, NotFoundError, ValidationError } from '../src/types';
+
+// Captures the most recently constructed mock instance so a test can
+// override one of its methods for that specific instance. Overriding
+// `MockWasmMemoryService.prototype.X` would NOT work here: each method is a
+// class-field (`remember = vi.fn(...)`), which vitest/TS compiles into a
+// per-instance own-property assigned in the constructor — an own-property
+// always shadows a same-named prototype property, so a prototype patch
+// applied after construction has no effect on an already-built instance.
+let lastMockInstance: MockWasmMemoryService | null = null;
+
+class MockWasmMemoryService {
+  remember = vi.fn(() => '1');
+  recall = vi.fn(() => [{ id: '1', score: 0.9, content: 'we chose parking_lot' }]);
+  recallWhere = vi.fn(() => [{ id: '1', score: 0.9, content: 'we chose parking_lot' }]);
+  recallFused = vi.fn(() => [{ id: '2', score: 0.0, content: 'EPIC-317' }]);
+  relate = vi.fn(() => '5');
+  forget = vi.fn();
+  why = vi.fn(() => ({
+    nodes: [{ id: '1', content: 'we chose parking_lot', hop: 0 }],
+    edges: [],
+  }));
+  free = vi.fn();
+
+  constructor(public dimension: number) {
+    lastMockInstance = this;
+  }
+}
+
+const mockWasmModule = {
+  default: vi.fn(() => Promise.resolve()),
+  MemoryService: MockWasmMemoryService,
+};
+
+// Mock the dynamic import - must match the import path in memory.ts
+vi.mock('@wiscale/velesdb-wasm', () => mockWasmModule);
+
+// Stub the Node-only loader so the unit suite does not touch the real
+// filesystem (see wasm-backend.test.ts for the same rationale).
+vi.mock('../src/backends/wasm-node-loader', () => ({
+  isNodeRuntime: () => false,
+  loadWasmBytesNode: vi.fn(() => Promise.resolve(new Uint8Array(0))),
+}));
+
+describe('MemoryService', () => {
+  let memory: MemoryService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    lastMockInstance = null;
+    memory = new MemoryService({ dimension: 4 });
+  });
+
+  describe('lifecycle', () => {
+    it('initializes successfully', async () => {
+      await memory.init();
+      expect(memory.isInitialized()).toBe(true);
+    });
+
+    it('is idempotent', async () => {
+      await memory.init();
+      await memory.init();
+      expect(memory.isInitialized()).toBe(true);
+      expect(mockWasmModule.default).toHaveBeenCalledTimes(1);
+    });
+
+    it('coalesces concurrent init() calls into one wasm-bindgen invocation', async () => {
+      await Promise.all([memory.init(), memory.init(), memory.init()]);
+      expect(mockWasmModule.default).toHaveBeenCalledTimes(1);
+      expect(memory.isInitialized()).toBe(true);
+    });
+
+    it('supports re-init after close()', async () => {
+      await memory.init();
+      await memory.close();
+      expect(memory.isInitialized()).toBe(false);
+      await memory.init();
+      expect(memory.isInitialized()).toBe(true);
+    });
+
+    it('throws ConnectionError from any wedge method before init()', async () => {
+      await expect(memory.recall('query')).rejects.toThrow(ConnectionError);
+    });
+
+    it('wraps a wasm-bindgen default() failure in ConnectionError', async () => {
+      mockWasmModule.default.mockRejectedValueOnce(new Error('boom'));
+      await expect(memory.init()).rejects.toThrow(ConnectionError);
+      expect(memory.isInitialized()).toBe(false);
+    });
+  });
+
+  describe('wedge operations', () => {
+    beforeEach(async () => {
+      await memory.init();
+    });
+
+    it('remember() passes fact/links/metadata/ttl through and returns the id', async () => {
+      const id = await memory.remember('we chose parking_lot', {
+        links: [{ target: '1', relation: 'decided_in' }],
+        metadata: { project: 'veles' },
+        ttlSeconds: 60,
+      });
+      expect(id).toBe('1');
+      expect(lastMockInstance!.remember).toHaveBeenCalledWith(
+        'we chose parking_lot',
+        [{ target: '1', relation: 'decided_in' }],
+        { project: 'veles' },
+        60n
+      );
+    });
+
+    it('remember() passes empty links and undefined metadata/ttl when not provided', async () => {
+      await memory.remember('a fact');
+      expect(lastMockInstance!.remember).toHaveBeenCalledWith('a fact', [], undefined, undefined);
+    });
+
+    it('recall() returns the mocked recollections', async () => {
+      const hits = await memory.recall('parking_lot', 5, { project: 'veles' });
+      expect(hits).toEqual([{ id: '1', score: 0.9, content: 'we chose parking_lot' }]);
+      expect(lastMockInstance!.recall).toHaveBeenCalledWith('parking_lot', 5, { project: 'veles' });
+    });
+
+    it('recallWhere() returns the mocked recollections', async () => {
+      const hits = await memory.recallWhere('parking_lot', [
+        { field: 'project', op: 'eq', value: 'veles' },
+      ]);
+      expect(hits).toEqual([{ id: '1', score: 0.9, content: 'we chose parking_lot' }]);
+    });
+
+    it('recallFused() returns the mocked recollections', async () => {
+      const hits = await memory.recallFused('parking_lot', 3, undefined, { hops: 2 });
+      expect(hits).toEqual([{ id: '2', score: 0.0, content: 'EPIC-317' }]);
+      expect(lastMockInstance!.recallFused).toHaveBeenCalledWith('parking_lot', 3, undefined, {
+        hops: 2,
+      });
+    });
+
+    it('relate() returns the edge id', async () => {
+      const edgeId = await memory.relate('1', '2', 'decided_in');
+      expect(edgeId).toBe('5');
+      expect(lastMockInstance!.relate).toHaveBeenCalledWith('1', '2', 'decided_in');
+    });
+
+    it('forget() resolves', async () => {
+      await expect(memory.forget('1')).resolves.toBeUndefined();
+    });
+
+    it('why() returns the explanation subgraph', async () => {
+      const explanation = await memory.why('parking_lot', 2);
+      expect(explanation.nodes).toHaveLength(1);
+      expect(explanation.edges).toEqual([]);
+    });
+
+    it('close() frees the underlying wasm instance', async () => {
+      const inner = lastMockInstance!;
+      await memory.close();
+      expect(inner.free).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('error translation', () => {
+    beforeEach(async () => {
+      await memory.init();
+    });
+
+    it('translates a NOT_FOUND wasm error into NotFoundError, preserving the original message', async () => {
+      const err = new Error('memory 999 does not exist');
+      (err as Error & { code: string }).code = 'NOT_FOUND';
+      lastMockInstance!.relate.mockImplementationOnce(() => {
+        throw err;
+      });
+
+      await expect(memory.relate('999', '1', 'x')).rejects.toSatisfy((e: unknown) => {
+        expect(e).toBeInstanceOf(NotFoundError);
+        expect((e as Error).message).toBe('memory 999 does not exist');
+        return true;
+      });
+    });
+
+    it('translates an INVALID_INPUT wasm error into ValidationError', async () => {
+      const err = new Error('fact text must not be empty');
+      (err as Error & { code: string }).code = 'INVALID_INPUT';
+      lastMockInstance!.remember.mockImplementationOnce(() => {
+        throw err;
+      });
+
+      await expect(memory.remember('')).rejects.toSatisfy((e: unknown) => {
+        expect(e).toBeInstanceOf(ValidationError);
+        expect((e as Error).message).toBe('fact text must not be empty');
+        return true;
+      });
+    });
+
+    it('rethrows an uncoded error unchanged', async () => {
+      const err = new Error('unstructured failure');
+      lastMockInstance!.forget.mockImplementationOnce(() => {
+        throw err;
+      });
+
+      await expect(memory.forget('1')).rejects.toBe(err);
+    });
+
+    it('wraps a thrown non-Error value in VelesDBError', async () => {
+      lastMockInstance!.forget.mockImplementationOnce(() => {
+        // eslint-disable-next-line @typescript-eslint/no-throw-literal
+        throw 'a raw string throw';
+      });
+
+      await expect(memory.forget('1')).rejects.toThrow('a raw string throw');
+    });
+  });
+});

--- a/sdks/typescript/tests/memory.test.ts
+++ b/sdks/typescript/tests/memory.test.ts
@@ -124,6 +124,19 @@ describe('MemoryService', () => {
       expect(lastMockInstance!.remember).toHaveBeenCalledWith('a fact', [], undefined, undefined);
     });
 
+    it.each([1.5, -1, Number.NaN])(
+      'remember() rejects ttlSeconds %p with ValidationError, not a raw RangeError',
+      async (ttlSeconds) => {
+        // Regression: BigInt(1.5) throws a codeless RangeError and a negative
+        // value dies as an opaque wasm-bindgen u64 conversion — both escaped
+        // the typed-error contract instead of surfacing as ValidationError.
+        await expect(memory.remember('a fact', { ttlSeconds })).rejects.toBeInstanceOf(
+          ValidationError
+        );
+        expect(lastMockInstance!.remember).not.toHaveBeenCalled();
+      }
+    );
+
     it('recall() returns the mocked recollections', async () => {
       const hits = await memory.recall('parking_lot', 5, { project: 'veles' });
       expect(hits).toEqual([{ id: '1', score: 0.9, content: 'we chose parking_lot' }]);

--- a/sdks/typescript/tests/memory.test.ts
+++ b/sdks/typescript/tests/memory.test.ts
@@ -124,12 +124,13 @@ describe('MemoryService', () => {
       expect(lastMockInstance!.remember).toHaveBeenCalledWith('a fact', [], undefined, undefined);
     });
 
-    it.each([1.5, -1, Number.NaN])(
+    it.each([1.5, -1, Number.NaN, 2 ** 64, Number.POSITIVE_INFINITY])(
       'remember() rejects ttlSeconds %p with ValidationError, not a raw RangeError',
       async (ttlSeconds) => {
-        // Regression: BigInt(1.5) throws a codeless RangeError and a negative
-        // value dies as an opaque wasm-bindgen u64 conversion — both escaped
-        // the typed-error contract instead of surfacing as ValidationError.
+        // Regression: BigInt(1.5) throws a codeless RangeError, a negative
+        // value dies as an opaque wasm-bindgen u64 conversion, and 2**64
+        // silently wraps to 0 ("permanent") at the wasm boundary — all must
+        // surface through the typed-error contract as ValidationError.
         await expect(memory.remember('a fact', { ttlSeconds })).rejects.toBeInstanceOf(
           ValidationError
         );

--- a/sdks/typescript/vitest.config.ts
+++ b/sdks/typescript/vitest.config.ts
@@ -142,6 +142,12 @@ export default defineConfig({
           branches: 100,
           statements: 100,
         },
+        'src/memory.ts': {
+          lines: 95,
+          functions: 100,
+          branches: 80,
+          statements: 95,
+        },
       },
     },
   },


### PR DESCRIPTION
## Summary

Extends the memory wedge (`remember`/`recall`/`recall_fused`/`recall_where`/`relate`/`forget`/`why`) to the **browser**: WASM binding + TypeScript SDK, closing the TS/WASM gap (the wedge previously reached MCP/Node/Python only).

**Commit 1 — `MemoryStore` trait (velesdb-memory):** the service's storage access is abstracted behind a `MemoryStore` trait (`storage.rs`), with the existing file-backed engine as the default `NativeStore` impl — existing callers (`MemoryService::open`) see zero change, `MemoryService::with_store` lets any backend run the full wedge orchestration unchanged. `persistence` becomes an optional, default-on feature so a wasm32 build no longer drags tokio/mio in via feature unification (node/python name it explicitly since they use `default-features = false`). The trait ships `get_metadata_batch` from day one, so the batching/DoS/filter-leak guarantees #1309 landed apply identically to every backend, native or wasm.

**Commit 2 — WASM backend (velesdb-wasm):** `WasmStore`, an in-memory `MemoryStore` (facts + graph, cascading deletes, TTL-aware), and `WasmMemoryService`, the wasm-bindgen class exposing the full wedge surface to JS. In-memory only — no persistence under WASM (disclosed in the README, a real capability gap vs Node/Python, not hidden).

**Commit 3 — TypeScript SDK:** standalone `MemoryService` class (`sdks/typescript/src/memory.ts`) mirroring Node/Python's own standalone class — deliberately NOT bolted onto `IVelesDBBackend`, whose existing `relate()` is shape-incompatible (graph edges) and whose contract is collection-scoped. Wraps the synchronous wasm calls in async methods and translates the wasm boundary's `{code}` errors into the SDK's typed `NotFoundError`/`ValidationError` hierarchy. Docs: memory-wedge sections in the TS SDK README + velesdb-wasm README (disambiguating from the lower-level `SemanticMemory`), root README wedge-reach updated.

Branch is rebased on develop post-#1309: the filter-leak fix, the `pool_depth` DoS clamp, and the batched metadata fetches all flow through the trait, so `WasmStore` gets the same correctness guarantees as the native path.

## Test plan

- [x] `cargo test -p velesdb-memory` — 115/115 (incl. new `storage_tests.rs` trait-conformance suite + #1309's regression tests, now running through the trait)
- [x] `cargo clippy --all-targets -p velesdb-memory -p velesdb-wasm -- -D warnings -D clippy::pedantic` — clean
- [x] `cargo check --target wasm32-unknown-unknown -p velesdb-wasm` — clean (persistence feature-gating verified for real)
- [x] `wasm-pack build --target web` + `wasm-pack test --node` — 51/51; full wedge surface confirmed in the compiled `.d.ts`
- [x] TS SDK: `npm run typecheck` + `npm test` (881/881, `memory.ts` at 98/88/100/98 coverage with its own vitest threshold) + `npm run build` (tsup)
- [x] Node binding: `npm run build` + `npm test` — 8/8 (trait refactor is invisible to it)
- [x] Python binding: `maturin develop --release` + `pytest` — 403/403
- [x] Playwright e2e spec added (`crates/velesdb-wasm/e2e/tests/memory.spec.ts`, 3/3 in headless Chromium); note that e2e harness is dormant/not CI-wired (pre-existing)
