### PR TITLE
feat(memory): expose recall_fused on MCP and Python bindings

### DIFF
--- a/crates/velesdb-memory/src/fused_recall.rs
+++ b/crates/velesdb-memory/src/fused_recall.rs
@@ -50,6 +50,7 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
         if query.is_empty() || k == 0 {
             return Ok(Vec::new());
         }
+        let opts = opts.sanitized();
         reject_reserved_keys(filter)?;
         let embedding = self.embedder.embed(query)?;
         let pool = self.fused_pool(&embedding, pool_depth(k, opts), filter)?;
@@ -84,6 +85,7 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
         if query.is_empty() || k == 0 {
             return Ok(Vec::new());
         }
+        let opts = opts.sanitized();
         reject_reserved_keys(filter)?;
         let embedding = self.embedder.embed(query)?;
         let depth = pool_depth(k, opts);

--- a/crates/velesdb-memory/src/fusion_tests.rs
+++ b/crates/velesdb-memory/src/fusion_tests.rs
@@ -1,7 +1,7 @@
 //! Unit tests for the fusion ranking layer.
 
 use super::*;
-use crate::model::Recollection;
+use crate::model::{FusionOptions, Recollection};
 
 #[allow(clippy::cast_possible_truncation)] // test fixture scores are small, exact literals
 fn candidate(id: u64, vector_score: f64, graph_weight: f64) -> Candidate {
@@ -128,4 +128,79 @@ fn test_fuse_all_negative_pool_ties_at_a_neutral_baseline_not_an_inverted_extrem
         vec![3, 1, 2],
         "the graph-reached candidate outranks the tied, neutral-baseline negative pool (stable order preserved)"
     );
+}
+
+#[test]
+fn test_non_finite_graph_boost_collapses_fusion_without_sanitizing() {
+    // Guards the reason FusionOptions::sanitized exists: a non-finite boost
+    // makes `graph_boost · weight` NaN for EVERY candidate (even a pool-only
+    // one, since NaN·0.0 == NaN), so total_cmp sees all scores equal, the sort
+    // is a no-op, and the graph-reached fact — appended after the pool — is
+    // truncated away. A strong pool hit (id 1) plus a weak one (id 2) that the
+    // default boost is enough to outrank; the graph fact (id 3) should take the
+    // second slot at k=2.
+    let build = || {
+        (
+            vec![candidate(1, 0.5, 0.0), candidate(2, 0.01, 0.0)],
+            vec![candidate(3, 0.0, 1.0)],
+        )
+    };
+
+    let (pool, reached) = build();
+    let ranked = fuse(pool, &reached, 2, f64::NAN);
+    assert!(
+        !ranked.iter().any(|r| r.id == 3),
+        "with a raw NaN boost the graph fact is silently dropped — this is the failure sanitized() prevents"
+    );
+
+    // Sanitizing the boost restores correct fusion: the default 0.15 outranks
+    // the weak pool hit, so the graph fact takes the second slot.
+    let boost = FusionOptions {
+        graph_boost: f64::NAN,
+        ..FusionOptions::default()
+    }
+    .sanitized()
+    .graph_boost;
+    let (pool, reached) = build();
+    let ranked = fuse(pool, &reached, 2, boost);
+    assert!(
+        ranked.iter().any(|r| r.id == 3),
+        "after sanitizing the boost, the graph fact ranks in again"
+    );
+}
+
+#[test]
+#[allow(clippy::float_cmp)] // asserting exact propagation of literal boosts, no arithmetic
+fn test_fusion_options_sanitized_only_touches_non_finite_boost() {
+    let default_boost = FusionOptions::default().graph_boost;
+    for bad in [f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
+        let opts = FusionOptions {
+            graph_boost: bad,
+            ..FusionOptions::default()
+        }
+        .sanitized();
+        assert_eq!(opts.graph_boost, default_boost);
+    }
+    // A finite (even negative) boost is a valid demote-the-graph choice, left as is.
+    let kept = FusionOptions {
+        graph_boost: -0.5,
+        ..FusionOptions::default()
+    }
+    .sanitized();
+    assert_eq!(kept.graph_boost, -0.5);
+}
+
+#[test]
+#[allow(clippy::float_cmp)] // asserting exact propagation of literal boosts, no arithmetic
+fn test_fusion_options_from_knobs_defaults_and_clamps_hops() {
+    let d = FusionOptions::default();
+    let none = FusionOptions::from_knobs(None, None);
+    assert_eq!(none.hops, d.hops);
+    assert_eq!(none.graph_boost, d.graph_boost);
+    assert_eq!(none.pool, d.pool);
+
+    let clamped = FusionOptions::from_knobs(Some(usize::MAX), Some(0.42));
+    assert_eq!(clamped.hops, crate::limits::clamp_hops(usize::MAX));
+    assert_eq!(clamped.graph_boost, 0.42);
+    assert_eq!(clamped.pool, d.pool);
 }

--- a/crates/velesdb-memory/src/mcp.rs
+++ b/crates/velesdb-memory/src/mcp.rs
@@ -11,8 +11,8 @@ use rmcp::handler::server::wrapper::{Json, Parameters};
 use rmcp::model::{ErrorCode, Implementation, ServerCapabilities, ServerInfo};
 use rmcp::{tool, tool_handler, tool_router, ErrorData, ServerHandler};
 
-use crate::limits::{DEFAULT_WHY_HOPS, MAX_FACT_BYTES, MAX_RECALL_LIMIT, MAX_WHY_HOPS};
-use crate::model::Explanation;
+use crate::limits::{clamp_hops, DEFAULT_WHY_HOPS, MAX_FACT_BYTES, MAX_RECALL_LIMIT, MAX_WHY_HOPS};
+use crate::model::{Explanation, FusionOptions};
 use crate::service::MemoryService;
 
 /// Default number of memories returned by `recall`.
@@ -31,9 +31,9 @@ use crate::extract::DynExtractor;
 // domain types from `crate::model` directly (no duplicate wire/domain struct).
 mod dto;
 use dto::{
-    ForgetParams, ForgetResult, RecallParams, RecallResult, RecallWhereParams, RelateParams,
-    RelateResult, RememberExtractedParams, RememberExtractedResult, RememberParams, RememberResult,
-    WhyParams,
+    ForgetParams, ForgetResult, RecallFusedParams, RecallParams, RecallResult, RecallWhereParams,
+    RelateParams, RelateResult, RememberExtractedParams, RememberExtractedResult, RememberParams,
+    RememberResult, WhyParams,
 };
 
 // --- The server ------------------------------------------------------------
@@ -155,6 +155,35 @@ impl McpServer {
                 .await
                 .map_err(join_error)?
                 .map_err(to_error)?;
+        Ok(Json(RecallResult { memories }))
+    }
+
+    #[tool(
+        name = "recall_fused",
+        description = "Fused vector + graph recall: like `recall`, but also walks the graph from the top vector hit and folds any connected fact into the ranking — the tri-engine ranking (vector similarity + ColumnStore filter + graph reach) measured on multi-hop and temporal benchmarks. Reach for this when an answer needs a fact the query doesn't mention directly but a stored `relate`/extracted link connects (multi-hop reasoning, temporal chains). `hops`/`graph_boost` tune the graph reach; omit them for the proven defaults. Optionally narrow with an exact-match `filter`. Most relevant first."
+    )]
+    async fn recall_fused(
+        &self,
+        Parameters(params): Parameters<RecallFusedParams>,
+    ) -> Result<Json<RecallResult>, ErrorData> {
+        let k = params
+            .limit
+            .unwrap_or(DEFAULT_RECALL_LIMIT)
+            .min(MAX_RECALL_LIMIT);
+        let defaults = FusionOptions::default();
+        let opts = FusionOptions {
+            hops: clamp_hops(params.hops.unwrap_or(defaults.hops)),
+            graph_boost: params.graph_boost.unwrap_or(defaults.graph_boost),
+            pool: defaults.pool,
+        };
+        let service = Arc::clone(&self.service);
+        let RecallFusedParams { query, filter, .. } = params;
+        let memories = tokio::task::spawn_blocking(move || {
+            service.recall_fused(&query, k, filter.as_ref(), opts)
+        })
+        .await
+        .map_err(join_error)?
+        .map_err(to_error)?;
         Ok(Json(RecallResult { memories }))
     }
 

--- a/crates/velesdb-memory/src/mcp.rs
+++ b/crates/velesdb-memory/src/mcp.rs
@@ -11,7 +11,7 @@ use rmcp::handler::server::wrapper::{Json, Parameters};
 use rmcp::model::{ErrorCode, Implementation, ServerCapabilities, ServerInfo};
 use rmcp::{tool, tool_handler, tool_router, ErrorData, ServerHandler};
 
-use crate::limits::{clamp_hops, DEFAULT_WHY_HOPS, MAX_FACT_BYTES, MAX_RECALL_LIMIT, MAX_WHY_HOPS};
+use crate::limits::{DEFAULT_WHY_HOPS, MAX_FACT_BYTES, MAX_RECALL_LIMIT, MAX_WHY_HOPS};
 use crate::model::{Explanation, FusionOptions};
 use crate::service::MemoryService;
 
@@ -170,12 +170,7 @@ impl McpServer {
             .limit
             .unwrap_or(DEFAULT_RECALL_LIMIT)
             .min(MAX_RECALL_LIMIT);
-        let defaults = FusionOptions::default();
-        let opts = FusionOptions {
-            hops: clamp_hops(params.hops.unwrap_or(defaults.hops)),
-            graph_boost: params.graph_boost.unwrap_or(defaults.graph_boost),
-            pool: defaults.pool,
-        };
+        let opts = FusionOptions::from_knobs(params.hops, params.graph_boost);
         let service = Arc::clone(&self.service);
         let RecallFusedParams { query, filter, .. } = params;
         let memories = tokio::task::spawn_blocking(move || {

--- a/crates/velesdb-memory/src/mcp/dto.rs
+++ b/crates/velesdb-memory/src/mcp/dto.rs
@@ -75,6 +75,26 @@ pub(super) struct RecallWhereParams {
     pub(super) filters: Vec<ColumnFilter>,
 }
 
+/// Parameters for the `recall_fused` tool.
+#[derive(Deserialize, JsonSchema)]
+#[schemars(transform = crate::schema::strip_int_formats)]
+pub(super) struct RecallFusedParams {
+    /// Natural-language query to match semantically.
+    pub(super) query: String,
+    /// Maximum number of memories to return (default 10).
+    pub(super) limit: Option<usize>,
+    /// Optional exact-match metadata filter (e.g.
+    /// `{"project": "veles", "status": "resolved"}`).
+    pub(super) filter: Option<Metadata>,
+    /// Graph hops walked from the top vector hit (default 2). Higher reaches
+    /// further but adds noise; capped at the `why` hop ceiling.
+    pub(super) hops: Option<usize>,
+    /// Weight added to a graph-reached fact's normalised vector score
+    /// (default 0.15). Raise to trust the graph more, lower to trust vector
+    /// similarity more.
+    pub(super) graph_boost: Option<f64>,
+}
+
 /// Parameters for the `relate` tool.
 #[derive(Deserialize, JsonSchema)]
 #[schemars(transform = crate::schema::strip_int_formats)]

--- a/crates/velesdb-memory/src/mcp/server_tests.rs
+++ b/crates/velesdb-memory/src/mcp/server_tests.rs
@@ -454,6 +454,51 @@ async fn recall_fused_folds_in_a_graph_reached_fact() {
 }
 
 #[tokio::test]
+async fn recall_fused_survives_a_non_finite_graph_boost() {
+    // A NaN graph_boost reaches the pyo3/native-float bindings unfiltered; if it
+    // hit fusion it would collapse the ranking (NaN scores compare Equal) and
+    // silently drop the graph-reached facts. The service sanitizes it, so the
+    // linked fact is still surfaced — proving the guard holds on the real path.
+    let (_dir, srv) = server();
+    let Json(anchor) = srv
+        .remember(Parameters(RememberParams {
+            fact: DECISION.to_owned(),
+            links: Vec::new(),
+            metadata: None,
+            ttl_seconds: None,
+        }))
+        .await
+        .expect("remember anchor");
+    let Json(linked) = srv
+        .remember(Parameters(RememberParams {
+            fact: "the on-call rotation moved to Tuesdays".to_owned(),
+            links: vec![Link {
+                target: anchor.id,
+                relation: "context".to_owned(),
+            }],
+            metadata: None,
+            ttl_seconds: None,
+        }))
+        .await
+        .expect("remember linked");
+
+    let Json(fused) = srv
+        .recall_fused(Parameters(RecallFusedParams {
+            query: DECISION.to_owned(),
+            limit: Some(10),
+            filter: None,
+            hops: None,
+            graph_boost: Some(f64::NAN),
+        }))
+        .await
+        .expect("recall_fused");
+    assert!(
+        fused.memories.iter().any(|m| m.id == linked.id),
+        "graph-reached fact must still surface despite a non-finite graph_boost"
+    );
+}
+
+#[tokio::test]
 async fn recall_fused_limit_is_capped_at_max() {
     let (_dir, srv) = server();
     // The call must succeed (capped, not rejected) even with an absurd limit.

--- a/crates/velesdb-memory/src/mcp/server_tests.rs
+++ b/crates/velesdb-memory/src/mcp/server_tests.rs
@@ -394,6 +394,83 @@ async fn oversized_fact_returns_invalid_params() {
 }
 
 #[tokio::test]
+async fn recall_fused_folds_in_a_graph_reached_fact() {
+    let (_dir, srv) = server();
+    // Anchor: an exact vector hit for the query.
+    let Json(anchor) = srv
+        .remember(Parameters(RememberParams {
+            fact: DECISION.to_owned(),
+            links: Vec::new(),
+            metadata: None,
+            ttl_seconds: None,
+        }))
+        .await
+        .expect("remember anchor");
+    // Linked: unrelated text (so it is not a vector hit for the query), but
+    // graph-connected to the anchor — only the graph reach can surface it.
+    let Json(linked) = srv
+        .remember(Parameters(RememberParams {
+            fact: "the on-call rotation moved to Tuesdays".to_owned(),
+            links: vec![Link {
+                target: anchor.id,
+                relation: "context".to_owned(),
+            }],
+            metadata: None,
+            ttl_seconds: None,
+        }))
+        .await
+        .expect("remember linked");
+
+    // Plain top-1 vector recall for the query finds the anchor, not the linked fact.
+    let Json(plain) = srv
+        .recall(Parameters(RecallParams {
+            query: DECISION.to_owned(),
+            limit: Some(1),
+            filter: None,
+        }))
+        .await
+        .expect("recall");
+    assert!(!plain.memories.iter().any(|m| m.id == linked.id));
+
+    // Fused recall walks the graph from the anchor seed and folds the linked fact in.
+    let Json(fused) = srv
+        .recall_fused(Parameters(RecallFusedParams {
+            query: DECISION.to_owned(),
+            limit: Some(10),
+            filter: None,
+            hops: None,
+            graph_boost: None,
+        }))
+        .await
+        .expect("recall_fused");
+    assert!(
+        fused.memories.iter().any(|m| m.id == anchor.id),
+        "anchor present in fused recall"
+    );
+    assert!(
+        fused.memories.iter().any(|m| m.id == linked.id),
+        "graph-reached fact folded into fused recall"
+    );
+}
+
+#[tokio::test]
+async fn recall_fused_limit_is_capped_at_max() {
+    let (_dir, srv) = server();
+    // The call must succeed (capped, not rejected) even with an absurd limit.
+    let Json(result) = srv
+        .recall_fused(Parameters(RecallFusedParams {
+            query: "anything".to_owned(),
+            limit: Some(usize::MAX),
+            filter: None,
+            hops: Some(usize::MAX),
+            graph_boost: None,
+        }))
+        .await
+        .expect("recall_fused with huge limit/hops must succeed (silently capped)");
+    let _ = result;
+}
+
+#[tokio::test]
 async fn recall_limit_is_capped_at_max() {
     let (_dir, srv) = server();
     // The call must succeed (capped, not rejected).

--- a/crates/velesdb-memory/src/model.rs
+++ b/crates/velesdb-memory/src/model.rs
@@ -128,6 +128,47 @@ impl Default for FusionOptions {
     }
 }
 
+impl FusionOptions {
+    /// Build options from optional, untrusted tuning knobs, applying the
+    /// defaults and hop clamp every binding that takes raw `hops`/`graph_boost`
+    /// must enforce identically: `hops` clamped to the graph-traversal ceiling
+    /// ([`clamp_hops`](crate::limits::clamp_hops)), `graph_boost` defaulted when
+    /// absent, and `pool` left at the proven default. The MCP `recall_fused`
+    /// tool and the Python `recall_fused` binding both build their options here
+    /// so the two transports can't drift on what they accept. A non-finite
+    /// `graph_boost` is not filtered here — that guard lives in
+    /// [`Self::sanitized`], applied by fusion itself so *every* caller is
+    /// covered, not just this constructor.
+    #[must_use]
+    pub fn from_knobs(hops: Option<usize>, graph_boost: Option<f64>) -> Self {
+        let defaults = Self::default();
+        Self {
+            hops: crate::limits::clamp_hops(hops.unwrap_or(defaults.hops)),
+            graph_boost: graph_boost.unwrap_or(defaults.graph_boost),
+            pool: defaults.pool,
+        }
+    }
+
+    /// A copy with any non-finite `graph_boost` (NaN or ±∞) reset to the
+    /// default. A non-finite boost poisons fusion catastrophically: the score
+    /// term `graph_boost · weight` is `NaN` for *every* candidate — even a
+    /// pool-only one, since `NaN · 0.0 == NaN` — so [`crate::fusion::fuse`]'s
+    /// `total_cmp` sort sees all scores as equal, degenerates to a no-op, and
+    /// then truncates away the graph-reached facts fusion exists to surface
+    /// (they are appended after the vector pool). The result is silently worse
+    /// than a plain `recall`. Applied inside
+    /// [`recall_fused`](crate::service::MemoryService::recall_fused) so no
+    /// caller — any binding, or a direct Rust user who filled the struct — can
+    /// trip it, however the options were built.
+    #[must_use]
+    pub fn sanitized(mut self) -> Self {
+        if !self.graph_boost.is_finite() {
+            self.graph_boost = Self::default().graph_boost;
+        }
+        self
+    }
+}
+
 /// A node in an [`Explanation`] subgraph.
 #[derive(Debug, Clone, Serialize, JsonSchema)]
 #[schemars(transform = crate::schema::strip_int_formats)]

--- a/crates/velesdb-python/python/velesdb/__init__.pyi
+++ b/crates/velesdb-python/python/velesdb/__init__.pyi
@@ -2344,6 +2344,38 @@ class MemoryService:
         """
         ...
 
+    def recall_fused(
+        self,
+        query: str,
+        k: int = 10,
+        filter: Optional[Dict[str, Any]] = None,
+        hops: Optional[int] = None,
+        graph_boost: Optional[float] = None,
+    ) -> List[Dict[str, Any]]:
+        """Fused vector + graph recall (the tri-engine ranking).
+
+        Like :meth:`recall`, but also walks the graph from the top vector hit
+        and folds any connected fact into the ranking. Best when an answer
+        needs a fact the ``query`` doesn't mention directly but a stored
+        :meth:`relate` / :meth:`remember_extracted` link connects (multi-hop
+        or temporal reasoning).
+
+        Args:
+            query: Free-text query.
+            k: Maximum number of results (default: 10).
+            filter: Optional exact-match metadata filter dict.
+            hops: Graph hops from the top vector hit (default: 2).
+            graph_boost: Weight added to a graph-reached fact's score
+                (default: 0.15).
+
+        Returns:
+            List of ``{"id": int, "score": float, "content": str,
+            "metadata": Optional[Dict[str, Any]]}`` dicts, most relevant
+            first. ``metadata`` is the fact's stored dict, or ``None`` if it
+            carried none.
+        """
+        ...
+
     def relate(self, from_id: int, to_id: int, relation: str) -> int:
         """Create a typed edge ``from_id → to_id``.
 

--- a/crates/velesdb-python/src/agent_memory_service.rs
+++ b/crates/velesdb-python/src/agent_memory_service.rs
@@ -272,12 +272,7 @@ impl PyMemoryService {
     ) -> PyResult<Py<PyAny>> {
         let k = limits::clamp_recall_limit(k);
         let filter = to_metadata(py, filter)?;
-        let defaults = FusionOptions::default();
-        let opts = FusionOptions {
-            hops: limits::clamp_hops(hops.unwrap_or(defaults.hops)),
-            graph_boost: graph_boost.unwrap_or(defaults.graph_boost),
-            pool: defaults.pool,
-        };
+        let opts = FusionOptions::from_knobs(hops, graph_boost);
         let hits = py.detach(|| {
             self.svc
                 .recall_fused(query, k, filter.as_ref(), opts)

--- a/crates/velesdb-python/src/agent_memory_service.rs
+++ b/crates/velesdb-python/src/agent_memory_service.rs
@@ -13,9 +13,9 @@ use pyo3::types::{PyDict, PyList, PyString};
 use std::collections::HashMap;
 
 use velesdb_memory::{
-    limits, ColumnFilter, ColumnOp, DynEmbedder, ErrorCategory, Explanation, HashEmbedder, Link,
-    MemoryError, MemoryService, Metadata, OllamaEmbedder, OllamaExtractor, Recollection,
-    DEFAULT_DIMENSION, DEFAULT_OLLAMA_MODEL, DEFAULT_OLLAMA_URL,
+    limits, ColumnFilter, ColumnOp, DynEmbedder, ErrorCategory, Explanation, FusionOptions,
+    HashEmbedder, Link, MemoryError, MemoryService, Metadata, OllamaEmbedder, OllamaExtractor,
+    Recollection, DEFAULT_DIMENSION, DEFAULT_OLLAMA_MODEL, DEFAULT_OLLAMA_URL,
 };
 
 use crate::collection::query::convert_params;
@@ -245,6 +245,44 @@ impl PyMemoryService {
             })
             .collect::<PyResult<Vec<_>>>()?;
         let hits = py.detach(|| self.svc.recall_where(query, k, &filters).map_err(to_py_err))?;
+        let list = PyList::empty(py);
+        for hit in hits {
+            list.append(recollection_to_dict(py, hit)?)?;
+        }
+        Ok(list.into())
+    }
+
+    /// Fused vector + graph recall: like [`recall`](Self::recall), but also
+    /// walks the graph from the top vector hit and folds any connected fact
+    /// into the ranking — the tri-engine ranking measured on multi-hop and
+    /// temporal benchmarks. Best when an answer needs a fact the query doesn't
+    /// mention directly but a stored `relate`/`remember_extracted` link
+    /// connects. `hops`/`graph_boost` tune the graph reach; omit them for the
+    /// proven defaults. Returns `{id, score, content, metadata}` (`metadata`
+    /// is the fact's stored dict, or `None` if it carried none).
+    #[pyo3(signature = (query, k = 10, filter = None, hops = None, graph_boost = None))]
+    fn recall_fused(
+        &self,
+        py: Python<'_>,
+        query: &str,
+        k: usize,
+        filter: Option<HashMap<String, Py<PyAny>>>,
+        hops: Option<usize>,
+        graph_boost: Option<f64>,
+    ) -> PyResult<Py<PyAny>> {
+        let k = limits::clamp_recall_limit(k);
+        let filter = to_metadata(py, filter)?;
+        let defaults = FusionOptions::default();
+        let opts = FusionOptions {
+            hops: limits::clamp_hops(hops.unwrap_or(defaults.hops)),
+            graph_boost: graph_boost.unwrap_or(defaults.graph_boost),
+            pool: defaults.pool,
+        };
+        let hits = py.detach(|| {
+            self.svc
+                .recall_fused(query, k, filter.as_ref(), opts)
+                .map_err(to_py_err)
+        })?;
         let list = PyList::empty(py);
         for hit in hits {
             list.append(recollection_to_dict(py, hit)?)?;

--- a/crates/velesdb-python/tests/test_memory_service.py
+++ b/crates/velesdb-python/tests/test_memory_service.py
@@ -131,6 +131,38 @@ def test_recall_metadata_is_none_when_the_fact_carries_none(mem):
     assert all(h["metadata"] is None for h in hits)
 
 
+def test_recall_fused_folds_in_a_graph_reached_fact(mem):
+    # Fused recall walks the graph from the top vector hit and folds in a fact
+    # the query never mentions but a stored link connects — the shipped
+    # tri-engine ranking, not a harness-only prompt trick.
+    anchor = mem.remember("we chose parking_lot to avoid lock poisoning")
+    linked = mem.remember(
+        "the on-call rotation moved to Tuesdays",
+        links=[(anchor, "context")],
+    )
+    # Plain top-1 vector recall finds the anchor, not the unrelated linked fact.
+    plain = mem.recall("parking_lot poisoning", k=1)
+    assert all(h["id"] != linked for h in plain)
+    # Fused recall reaches it through the graph.
+    fused = mem.recall_fused("parking_lot poisoning", k=10)
+    ids = {h["id"] for h in fused}
+    assert anchor in ids and linked in ids
+
+
+def test_recall_fused_respects_exact_match_filter(mem):
+    keep = mem.remember("auth bug in login", metadata={"project": "veles"})
+    mem.remember("auth bug in login too", metadata={"project": "acme"})
+    hits = mem.recall_fused("auth bug", k=5, filter={"project": "veles"})
+    assert all(h["id"] == keep for h in hits)
+
+
+def test_recall_fused_accepts_tuning_knobs(mem):
+    # hops/graph_boost are optional and clamped, not rejected.
+    mem.remember("a decision about locks")
+    hits = mem.recall_fused("locks", k=5, hops=1, graph_boost=0.3)
+    assert isinstance(hits, list)
+
+
 def test_oversized_fact_raises_value_error(mem):
     # Facts above the shared 1 MiB cap are rejected before any embedding work.
     with pytest.raises(ValueError):

--- a/crates/velesdb-python/tests/test_memory_service.py
+++ b/crates/velesdb-python/tests/test_memory_service.py
@@ -163,6 +163,20 @@ def test_recall_fused_accepts_tuning_knobs(mem):
     assert isinstance(hits, list)
 
 
+def test_recall_fused_survives_non_finite_graph_boost(mem):
+    # A native Python float bypasses JSON's NaN rejection, so the binding must
+    # not let a NaN graph_boost poison fusion (it would collapse the ranking and
+    # silently drop exactly the graph-reached facts recall_fused exists to find).
+    anchor = mem.remember("we chose parking_lot to avoid lock poisoning")
+    linked = mem.remember(
+        "the on-call rotation moved to Tuesdays",
+        links=[(anchor, "context")],
+    )
+    hits = mem.recall_fused("parking_lot poisoning", k=10, graph_boost=float("nan"))
+    ids = {h["id"] for h in hits}
+    assert linked in ids
+
+
 def test_oversized_fact_raises_value_error(mem):
     # Facts above the shared 1 MiB cap are rejected before any embedding work.
     with pytest.raises(ValueError):


### PR DESCRIPTION
## What & why

**P1.1 of the LoCoMo repositioning plan** — close the most-cited product↔harness gap: the benchmarked *fused* ranking (vector similarity + ColumnStore filter + graph reach) was reachable from **Node** and **WASM** but **absent from the MCP server and the Python `MemoryService`**. So the tri-engine path measured on the multi-hop and temporal benchmarks could not be run through the two surfaces users actually install and integrate against. The strongest attack line against us was "the benchmark win lives in the harness, not the shipped product." This closes the MCP + Python half of that gap.

(REST server stays deferred by prior CTO decision — memory-only surface.)

## Changes

- **MCP** — new `recall_fused` tool + `RecallFusedParams` DTO, mirroring the flat `query`/`limit`/`filter` style of `recall`/`recall_where`, plus optional `hops` and `graph_boost` knobs mapped to `FusionOptions` (engine defaults when omitted). `hops`/`limit` clamped to the same DoS ceilings as `recall`/`why`.
- **Python** — `MemoryService.recall_fused(query, k=10, filter=None, hops=None, graph_boost=None)`, with a matching `.pyi` stub kept in sync (`test_stub_parity` guards it).

## Design note — `pool` stays Node/WASM-only

The advanced `pool` (oversample-depth) knob that Node/WASM expose is **not** added to MCP/Python:
- it mainly matters paired with a reranker, which neither MCP nor Python exposes;
- omitting it keeps both new surfaces symmetric and lean for LLM/agent callers;
- on Python it would also push the method past the repo's 7-arg clippy budget.

This binding-surface divergence will be documented in P1.4.

## Tests

- MCP: `recall_fused_folds_in_a_graph_reached_fact` (proves a graph-only fact the query never mentions is surfaced — the actual value prop, not just wiring), `recall_fused_limit_is_capped_at_max`.
- Python: graph-reach behavioral test, exact-match filter, tuning-knobs acceptance.
- Full `velesdb-memory` suite + `velesdb-python` pytest green; clippy `-D warnings -D clippy::pedantic` clean on both crates.

## Review gate

A high-effort `/code-review` workflow surfaced **one real correctness bug** (plus a duplication cleanup), both fixed in `4c44ac45`:

- **Bug (confirmed):** the new `graph_boost` knob, reachable via the native-float bindings (pyo3 here, and pre-existing Node/WASM), accepted `NaN`/`±inf` — which the JSON boundary rejects but a native float does not. A non-finite boost poisons fusion (`graph_boost·weight` is `NaN` even for pool-only candidates, so `total_cmp` sees all scores equal, the sort no-ops, and the graph-reached facts get truncated away). `recall_fused` would then return an unranked vector-only result and *silently drop the graph-connected facts it exists to surface* — worse than plain `recall`.
- **Fix:** `FusionOptions::sanitized()` resets a non-finite boost to the default, applied inside `recall_fused`/`recall_fused_reranked` so the guard covers **every** caller (all bindings + direct Rust), not just this PR's surfaces. A finite *negative* boost is intentionally kept. `FusionOptions::from_knobs()` centralizes the MCP/Python knob mapping (the cleanup finding).

A follow-up adversarial review of the fix commit confirmed no defects and full path coverage.
