### PR TITLE
feat(memory): ship dated-context (recall_fused date_field) on MCP + Python

### DIFF
--- a/crates/velesdb-memory/src/dated_context.rs
+++ b/crates/velesdb-memory/src/dated_context.rs
@@ -38,29 +38,25 @@ pub struct DatedContext {
 /// latest date seen. An empty `facts` yields an empty timeline and `now: None`.
 #[must_use]
 pub fn format_dated_context(facts: &[Recollection], date_field: &str) -> DatedContext {
-    // (date, content) for dated facts; content only for undated ones.
-    let mut dated: Vec<(i64, &str)> = Vec::new();
+    // (sort key, pre-formatted `YYYY-MM-DD`, content) for dated facts; content
+    // only for undated ones. The date is formatted once here, so nothing
+    // downstream re-parses it.
+    let mut dated: Vec<(i64, String, &str)> = Vec::new();
     let mut undated: Vec<&str> = Vec::new();
     for fact in facts {
         match fact_date(fact, date_field) {
-            Some(date) => dated.push((date, &fact.content)),
+            Some((key, formatted)) => dated.push((key, formatted, &fact.content)),
             None => undated.push(&fact.content),
         }
     }
     // Ascending chronological order; a stable sort keeps same-date facts in
     // their original relevance order.
-    dated.sort_by_key(|(date, _)| *date);
-    let now = dated.last().and_then(|(date, _)| fmt_date(*date));
+    dated.sort_by_key(|(key, _, _)| *key);
+    let now = dated.last().map(|(_, formatted, _)| formatted.clone());
 
     let lines = dated
         .iter()
-        .map(|(date, content)| match fmt_date(*date) {
-            Some(date) => format!("- [{date}] {content}"),
-            // Unreachable in practice: a value is only in `dated` because
-            // `fact_date` (via `decompose_ymd`) already validated it. Kept total
-            // rather than `unwrap` so a future change can't panic here.
-            None => format!("- {content}"),
-        })
+        .map(|(_, date, content)| format!("- [{date}] {content}"))
         .chain(undated.iter().map(|content| format!("- {content}")))
         .collect::<Vec<_>>()
         .join("\n");
@@ -71,32 +67,57 @@ pub fn format_dated_context(facts: &[Recollection], date_field: &str) -> DatedCo
     }
 }
 
-/// A fact's date from its `date_field` metadata, or `None` when the field is
-/// absent, non-integer, or not a valid `YYYYMMDD`.
-fn fact_date(fact: &Recollection, date_field: &str) -> Option<i64> {
+/// A fact's `(sort key, formatted "YYYY-MM-DD")` from its `date_field`
+/// metadata, or `None` when the field is absent, non-integer, or not a valid
+/// calendar date — so a plain counter (or an impossible date like `20260231`)
+/// living under the date field is treated as undated, not rendered as a
+/// nonsense timeline anchor. Formats the date here so the caller never parses
+/// the integer twice.
+fn fact_date(fact: &Recollection, date_field: &str) -> Option<(i64, String)> {
     let raw = fact.metadata.as_ref()?.get(date_field)?.as_i64()?;
-    // Validate the calendar shape so an out-of-range integer (e.g. a plain
-    // counter that happens to live under the date field) is treated as undated,
-    // not rendered as a nonsense date.
-    decompose_ymd(raw).map(|_| raw)
+    Some((raw, fmt_date(raw)?))
 }
 
 /// Render a `YYYYMMDD` integer as `YYYY-MM-DD`, or `None` when it is not a valid
-/// calendar date (`<= 0`, or month/day out of range).
+/// calendar date.
 fn fmt_date(ts: i64) -> Option<String> {
     let (year, month, day) = decompose_ymd(ts)?;
     Some(format!("{year:04}-{month:02}-{day:02}"))
 }
 
 /// Split a `YYYYMMDD` integer into `(year, month, day)`, or `None` when it is
-/// `<= 0` or the month/day is out of range. The single validity rule for the
-/// date convention, mirroring the `examples/locomo` harness.
+/// `<= 0`, the month is out of range, or the day exceeds that month's real
+/// length (leap years included) — the single validity rule for the date
+/// convention, stricter than the harness's `1..=31` so no impossible date ever
+/// reaches the timeline.
 fn decompose_ymd(ts: i64) -> Option<(i64, i64, i64)> {
     if ts <= 0 {
         return None;
     }
     let (year, month, day) = (ts / 10_000, (ts / 100) % 100, ts % 100);
-    ((1..=12).contains(&month) && (1..=31).contains(&day)).then_some((year, month, day))
+    if !(1..=12).contains(&month) {
+        return None;
+    }
+    (1..=days_in_month(year, month))
+        .contains(&day)
+        .then_some((year, month, day))
+}
+
+/// Days in `month` (1..=12) of `year` in the proleptic Gregorian calendar
+/// (February is 29 in a leap year). Only ever called with a validated month.
+fn days_in_month(year: i64, month: i64) -> i64 {
+    match month {
+        1 | 3 | 5 | 7 | 8 | 10 | 12 => 31,
+        4 | 6 | 9 | 11 => 30,
+        2 if is_leap_year(year) => 29,
+        2 => 28,
+        _ => 0,
+    }
+}
+
+/// Whether `year` is a leap year (Gregorian rule).
+fn is_leap_year(year: i64) -> bool {
+    year % 4 == 0 && (year % 100 != 0 || year % 400 == 0)
 }
 
 #[cfg(test)]

--- a/crates/velesdb-memory/src/dated_context.rs
+++ b/crates/velesdb-memory/src/dated_context.rs
@@ -1,0 +1,104 @@
+//! Dated context: turn recalled facts into a chronological, date-prefixed
+//! timeline with a "now" anchor — the representation measured to lift temporal
+//! question answering (the `examples/locomo` temporal ablation: +33.6pp,
+//! McNemar p=1.8e-28). This ships that representation as product behavior so a
+//! caller reproduces it through the installed API instead of re-implementing
+//! the formatting in a prompt.
+//!
+//! The date lives in caller-supplied metadata under a field the caller names
+//! (e.g. `ts`, `occurred_at`), holding a `YYYYMMDD` integer — the same key
+//! shape `recall_where` filters on. A fact whose named field is missing or not
+//! a valid `YYYYMMDD` date is treated as undated: it still appears, just without
+//! a date prefix and after the dated timeline, so an unlabeled fact never
+//! invents a misleading date.
+//!
+//! Only the *formatting* ships here — not the LLM reasoning prompt the harness
+//! wraps around it. Presenting retrieved facts is a memory-store concern;
+//! prompt engineering is the caller's.
+
+use crate::model::Recollection;
+
+/// A chronological, date-prefixed rendering of recalled facts.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DatedContext {
+    /// One line per fact: `- [YYYY-MM-DD] content` for a dated fact, `- content`
+    /// for an undated one. Dated facts come first in ascending date order; any
+    /// undated facts follow in their original (relevance) order.
+    pub timeline: String,
+    /// The most recent date across the facts (`YYYY-MM-DD`), the natural "now"
+    /// anchor for temporal reasoning. `None` when no fact carries a valid date.
+    pub now: Option<String>,
+}
+
+/// Render `facts` as a [`DatedContext`], reading each fact's date from the
+/// `date_field` metadata key (a `YYYYMMDD` integer).
+///
+/// Facts are split into dated (sorted oldest-first) and undated (kept in the
+/// order given, i.e. by relevance), then rendered one per line. `now` is the
+/// latest date seen. An empty `facts` yields an empty timeline and `now: None`.
+#[must_use]
+pub fn format_dated_context(facts: &[Recollection], date_field: &str) -> DatedContext {
+    // (date, content) for dated facts; content only for undated ones.
+    let mut dated: Vec<(i64, &str)> = Vec::new();
+    let mut undated: Vec<&str> = Vec::new();
+    for fact in facts {
+        match fact_date(fact, date_field) {
+            Some(date) => dated.push((date, &fact.content)),
+            None => undated.push(&fact.content),
+        }
+    }
+    // Ascending chronological order; a stable sort keeps same-date facts in
+    // their original relevance order.
+    dated.sort_by_key(|(date, _)| *date);
+    let now = dated.last().and_then(|(date, _)| fmt_date(*date));
+
+    let lines = dated
+        .iter()
+        .map(|(date, content)| match fmt_date(*date) {
+            Some(date) => format!("- [{date}] {content}"),
+            // Unreachable in practice: a value is only in `dated` because
+            // `fact_date` (via `decompose_ymd`) already validated it. Kept total
+            // rather than `unwrap` so a future change can't panic here.
+            None => format!("- {content}"),
+        })
+        .chain(undated.iter().map(|content| format!("- {content}")))
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    DatedContext {
+        timeline: lines,
+        now,
+    }
+}
+
+/// A fact's date from its `date_field` metadata, or `None` when the field is
+/// absent, non-integer, or not a valid `YYYYMMDD`.
+fn fact_date(fact: &Recollection, date_field: &str) -> Option<i64> {
+    let raw = fact.metadata.as_ref()?.get(date_field)?.as_i64()?;
+    // Validate the calendar shape so an out-of-range integer (e.g. a plain
+    // counter that happens to live under the date field) is treated as undated,
+    // not rendered as a nonsense date.
+    decompose_ymd(raw).map(|_| raw)
+}
+
+/// Render a `YYYYMMDD` integer as `YYYY-MM-DD`, or `None` when it is not a valid
+/// calendar date (`<= 0`, or month/day out of range).
+fn fmt_date(ts: i64) -> Option<String> {
+    let (year, month, day) = decompose_ymd(ts)?;
+    Some(format!("{year:04}-{month:02}-{day:02}"))
+}
+
+/// Split a `YYYYMMDD` integer into `(year, month, day)`, or `None` when it is
+/// `<= 0` or the month/day is out of range. The single validity rule for the
+/// date convention, mirroring the `examples/locomo` harness.
+fn decompose_ymd(ts: i64) -> Option<(i64, i64, i64)> {
+    if ts <= 0 {
+        return None;
+    }
+    let (year, month, day) = (ts / 10_000, (ts / 100) % 100, ts % 100);
+    ((1..=12).contains(&month) && (1..=31).contains(&day)).then_some((year, month, day))
+}
+
+#[cfg(test)]
+#[path = "dated_context_tests.rs"]
+mod tests;

--- a/crates/velesdb-memory/src/dated_context_tests.rs
+++ b/crates/velesdb-memory/src/dated_context_tests.rs
@@ -1,0 +1,104 @@
+//! Unit tests for the dated-context formatter.
+
+use super::*;
+use crate::model::Recollection;
+use serde_json::json;
+
+/// A recollection with `content` and an optional `date_field` metadata date.
+fn fact(id: u64, content: &str, date_field: &str, date: Option<i64>) -> Recollection {
+    let metadata = date.map(|d| {
+        let mut m = serde_json::Map::new();
+        m.insert(date_field.to_string(), json!(d));
+        m
+    });
+    Recollection {
+        id,
+        score: 0.0,
+        content: content.to_string(),
+        metadata,
+    }
+}
+
+#[test]
+fn empty_facts_yield_empty_timeline_and_no_now() {
+    let ctx = format_dated_context(&[], "ts");
+    assert_eq!(ctx.timeline, "");
+    assert_eq!(ctx.now, None);
+}
+
+#[test]
+fn dated_facts_are_sorted_ascending_and_prefixed() {
+    // Given out of order; must render oldest-first with date prefixes.
+    let facts = vec![
+        fact(1, "release shipped", "ts", Some(20_260_701)),
+        fact(2, "kickoff meeting", "ts", Some(20_260_103)),
+    ];
+    let ctx = format_dated_context(&facts, "ts");
+    assert_eq!(
+        ctx.timeline,
+        "- [2026-01-03] kickoff meeting\n- [2026-07-01] release shipped"
+    );
+    // "now" anchors on the latest date.
+    assert_eq!(ctx.now.as_deref(), Some("2026-07-01"));
+}
+
+#[test]
+fn undated_facts_follow_the_timeline_without_a_prefix() {
+    let facts = vec![
+        fact(1, "dated one", "ts", Some(20_260_101)),
+        fact(2, "no date here", "ts", None),
+    ];
+    let ctx = format_dated_context(&facts, "ts");
+    assert_eq!(ctx.timeline, "- [2026-01-01] dated one\n- no date here");
+    assert_eq!(ctx.now.as_deref(), Some("2026-01-01"));
+}
+
+#[test]
+fn all_undated_facts_have_no_now_anchor() {
+    let facts = vec![fact(1, "a", "ts", None), fact(2, "b", "ts", None)];
+    let ctx = format_dated_context(&facts, "ts");
+    assert_eq!(ctx.timeline, "- a\n- b");
+    assert_eq!(ctx.now, None);
+}
+
+#[test]
+fn the_date_field_name_is_honored() {
+    // Same fact, a caller-chosen field name other than `ts`.
+    let facts = vec![fact(1, "hired", "occurred_at", Some(20_250_615))];
+    let ctx = format_dated_context(&facts, "occurred_at");
+    assert_eq!(ctx.timeline, "- [2025-06-15] hired");
+    // A different field name sees no date → treated as undated.
+    let ctx_wrong = format_dated_context(&facts, "ts");
+    assert_eq!(ctx_wrong.timeline, "- hired");
+    assert_eq!(ctx_wrong.now, None);
+}
+
+#[test]
+fn out_of_range_or_non_integer_dates_are_treated_as_undated() {
+    // 20261301 = month 13 (invalid); 0 and negatives rejected; a string is not
+    // an integer date.
+    let bad_month = fact(1, "bad month", "ts", Some(20_261_301));
+    let zero = fact(2, "zero", "ts", Some(0));
+    let mut string_date = fact(3, "string date", "ts", None);
+    let mut m = serde_json::Map::new();
+    m.insert("ts".to_string(), json!("2026-07-01"));
+    string_date.metadata = Some(m);
+
+    let ctx = format_dated_context(&[bad_month, zero, string_date], "ts");
+    assert_eq!(ctx.timeline, "- bad month\n- zero\n- string date");
+    assert_eq!(ctx.now, None);
+}
+
+#[test]
+fn same_date_facts_keep_relevance_order() {
+    // A stable sort must not reorder facts sharing a date.
+    let facts = vec![
+        fact(1, "first by relevance", "ts", Some(20_260_101)),
+        fact(2, "second by relevance", "ts", Some(20_260_101)),
+    ];
+    let ctx = format_dated_context(&facts, "ts");
+    assert_eq!(
+        ctx.timeline,
+        "- [2026-01-01] first by relevance\n- [2026-01-01] second by relevance"
+    );
+}

--- a/crates/velesdb-memory/src/dated_context_tests.rs
+++ b/crates/velesdb-memory/src/dated_context_tests.rs
@@ -75,18 +75,40 @@ fn the_date_field_name_is_honored() {
 
 #[test]
 fn out_of_range_or_non_integer_dates_are_treated_as_undated() {
-    // 20261301 = month 13 (invalid); 0 and negatives rejected; a string is not
-    // an integer date.
+    // 20261301 = month 13; 20260231 = Feb 31 (impossible day for the month);
+    // 20260229 = Feb 29 in a non-leap year; 0 and negatives rejected; a string
+    // is not an integer date. None must render a date prefix or a `now` anchor.
     let bad_month = fact(1, "bad month", "ts", Some(20_261_301));
-    let zero = fact(2, "zero", "ts", Some(0));
-    let mut string_date = fact(3, "string date", "ts", None);
+    let feb31 = fact(2, "feb 31", "ts", Some(20_260_231));
+    let feb29_non_leap = fact(3, "feb 29 non-leap", "ts", Some(20_260_229));
+    let zero = fact(4, "zero", "ts", Some(0));
+    let mut string_date = fact(5, "string date", "ts", None);
     let mut m = serde_json::Map::new();
     m.insert("ts".to_string(), json!("2026-07-01"));
     string_date.metadata = Some(m);
 
-    let ctx = format_dated_context(&[bad_month, zero, string_date], "ts");
-    assert_eq!(ctx.timeline, "- bad month\n- zero\n- string date");
+    let ctx = format_dated_context(&[bad_month, feb31, feb29_non_leap, zero, string_date], "ts");
+    assert_eq!(
+        ctx.timeline,
+        "- bad month\n- feb 31\n- feb 29 non-leap\n- zero\n- string date"
+    );
     assert_eq!(ctx.now, None);
+}
+
+#[test]
+fn valid_end_of_month_and_leap_day_dates_are_kept() {
+    // Real edge dates must still render: Feb 29 in a leap year, 30/31-day ends.
+    let facts = vec![
+        fact(1, "leap day", "ts", Some(20_240_229)),
+        fact(2, "april end", "ts", Some(20_260_430)),
+        fact(3, "december end", "ts", Some(20_261_231)),
+    ];
+    let ctx = format_dated_context(&facts, "ts");
+    assert_eq!(
+        ctx.timeline,
+        "- [2024-02-29] leap day\n- [2026-04-30] april end\n- [2026-12-31] december end"
+    );
+    assert_eq!(ctx.now.as_deref(), Some("2026-12-31"));
 }
 
 #[test]

--- a/crates/velesdb-memory/src/fused_recall.rs
+++ b/crates/velesdb-memory/src/fused_recall.rs
@@ -302,14 +302,20 @@ fn matches_filter(metadata: Option<&Metadata>, filter: Option<&Metadata>) -> boo
 }
 
 /// The oversampled candidate pool depth for a `k`-sized fused recall:
-/// `opts.pool` if the caller set one, else the proven default
+/// `opts.pool` if the caller set one (floored at 1), else the proven default
 /// ([`fusion::pool_size`]) — either way, capped at
 /// [`crate::limits::MAX_RECALL_LIMIT`], the same `DoS` ceiling `k`/`hops`
-/// carry. The cap lives here, not just at each binding's FFI boundary: the
-/// *default* pool (`k.saturating_mul(8)`) exceeds it well before `k` itself
-/// reaches its own cap, so a caller who never touches `pool` at all — not
-/// just one who sets it explicitly — must still be bounded.
+/// carry. Both bounds live here, not at each binding's FFI boundary:
+/// - the floor of 1 stops an explicit `pool` of 0 (a binding now exposes the
+///   knob: `options={"pool": 0}` in Python) from oversampling *zero* candidates
+///   and returning nothing. A caller can still deliberately narrow the pool
+///   below the default (e.g. `pool: 1` to admit only the top vector hit — the
+///   documented behavior fusion's tests pin); the floor only rules out the
+///   degenerate empty-set case, it does not force a minimum recall depth.
+/// - the cap bounds the default too: `k.saturating_mul(8)` exceeds the limit
+///   well before `k` itself does, so even a caller who never touches `pool` is
+///   bounded.
 fn pool_depth(k: usize, opts: FusionOptions) -> usize {
-    let depth = opts.pool.unwrap_or_else(|| fusion::pool_size(k));
+    let depth = opts.pool.map_or_else(|| fusion::pool_size(k), |p| p.max(1));
     crate::limits::clamp_recall_limit(depth)
 }

--- a/crates/velesdb-memory/src/fusion_tests.rs
+++ b/crates/velesdb-memory/src/fusion_tests.rs
@@ -194,13 +194,16 @@ fn test_fusion_options_sanitized_only_touches_non_finite_boost() {
 #[allow(clippy::float_cmp)] // asserting exact propagation of literal boosts, no arithmetic
 fn test_fusion_options_from_knobs_defaults_and_clamps_hops() {
     let d = FusionOptions::default();
-    let none = FusionOptions::from_knobs(None, None);
+    let none = FusionOptions::from_knobs(None, None, None);
     assert_eq!(none.hops, d.hops);
     assert_eq!(none.graph_boost, d.graph_boost);
     assert_eq!(none.pool, d.pool);
 
-    let clamped = FusionOptions::from_knobs(Some(usize::MAX), Some(0.42));
+    let clamped = FusionOptions::from_knobs(Some(usize::MAX), Some(0.42), Some(usize::MAX));
     assert_eq!(clamped.hops, crate::limits::clamp_hops(usize::MAX));
     assert_eq!(clamped.graph_boost, 0.42);
-    assert_eq!(clamped.pool, d.pool);
+    assert_eq!(
+        clamped.pool,
+        Some(crate::limits::clamp_recall_limit(usize::MAX))
+    );
 }

--- a/crates/velesdb-memory/src/lib.rs
+++ b/crates/velesdb-memory/src/lib.rs
@@ -21,6 +21,10 @@
 //! Set" of the Software's features and breach the `VelesDB` Core License 1.0
 //! (§1, No Hosted or Managed Service). See `VISION.md` §5 and `PLAN.md` Phase 4A.
 
+/// Format recalled facts as a chronological, date-prefixed timeline with a
+/// "now" anchor — the dated-context representation measured to lift temporal
+/// question answering, shipped as product behavior rather than a harness prompt.
+pub mod dated_context;
 pub mod embedder;
 pub mod error;
 pub mod extract;
@@ -77,6 +81,7 @@ const _: () = assert!(
     "update FALLBACK_DIMENSION to match velesdb_core::agent::DEFAULT_DIMENSION"
 );
 
+pub use dated_context::{format_dated_context, DatedContext};
 pub use embedder::{DynEmbedder, EmbedError, Embedder, HashEmbedder};
 #[cfg(feature = "ollama")]
 pub use embedder::{OllamaEmbedder, DEFAULT_OLLAMA_MODEL, DEFAULT_OLLAMA_URL};

--- a/crates/velesdb-memory/src/mcp.rs
+++ b/crates/velesdb-memory/src/mcp.rs
@@ -31,9 +31,9 @@ use crate::extract::DynExtractor;
 // domain types from `crate::model` directly (no duplicate wire/domain struct).
 mod dto;
 use dto::{
-    ForgetParams, ForgetResult, RecallFusedParams, RecallParams, RecallResult, RecallWhereParams,
-    RelateParams, RelateResult, RememberExtractedParams, RememberExtractedResult, RememberParams,
-    RememberResult, WhyParams,
+    ForgetParams, ForgetResult, RecallFusedParams, RecallFusedResult, RecallParams, RecallResult,
+    RecallWhereParams, RelateParams, RelateResult, RememberExtractedParams,
+    RememberExtractedResult, RememberParams, RememberResult, WhyParams,
 };
 
 // --- The server ------------------------------------------------------------
@@ -160,26 +160,44 @@ impl McpServer {
 
     #[tool(
         name = "recall_fused",
-        description = "Fused vector + graph recall: like `recall`, but also walks the graph from the top vector hit and folds any connected fact into the ranking — the tri-engine ranking (vector similarity + ColumnStore filter + graph reach) measured on multi-hop and temporal benchmarks. Reach for this when an answer needs a fact the query doesn't mention directly but a stored `relate`/extracted link connects (multi-hop reasoning, temporal chains). `hops`/`graph_boost` tune the graph reach; omit them for the proven defaults. Optionally narrow with an exact-match `filter`. Most relevant first."
+        description = "Fused vector + graph recall: like `recall`, but also walks the graph from the top vector hit and folds any connected fact into the ranking — the tri-engine ranking (vector similarity + ColumnStore filter + graph reach) measured on multi-hop and temporal benchmarks. Reach for this when an answer needs a fact the query doesn't mention directly but a stored `relate`/extracted link connects (multi-hop reasoning, temporal chains). `hops`/`graph_boost` tune the graph reach; omit them for the proven defaults. Optionally narrow with an exact-match `filter`. Set `date_field` (the metadata key holding a YYYYMMDD date) to also get a `dated_context` timeline and a `now` anchor for temporal questions. Most relevant first."
     )]
     async fn recall_fused(
         &self,
         Parameters(params): Parameters<RecallFusedParams>,
-    ) -> Result<Json<RecallResult>, ErrorData> {
+    ) -> Result<Json<RecallFusedResult>, ErrorData> {
         let k = params
             .limit
             .unwrap_or(DEFAULT_RECALL_LIMIT)
             .min(MAX_RECALL_LIMIT);
-        let opts = FusionOptions::from_knobs(params.hops, params.graph_boost);
+        let opts = FusionOptions::from_knobs(params.hops, params.graph_boost, None);
         let service = Arc::clone(&self.service);
-        let RecallFusedParams { query, filter, .. } = params;
+        let RecallFusedParams {
+            query,
+            filter,
+            date_field,
+            ..
+        } = params;
         let memories = tokio::task::spawn_blocking(move || {
             service.recall_fused(&query, k, filter.as_ref(), opts)
         })
         .await
         .map_err(join_error)?
         .map_err(to_error)?;
-        Ok(Json(RecallResult { memories }))
+        // When the caller names a date field, also ship the dated timeline it
+        // would otherwise have to format itself in a prompt.
+        let (dated_context, now) = match date_field {
+            Some(field) => {
+                let ctx = crate::dated_context::format_dated_context(&memories, &field);
+                (Some(ctx.timeline), ctx.now)
+            }
+            None => (None, None),
+        };
+        Ok(Json(RecallFusedResult {
+            memories,
+            dated_context,
+            now,
+        }))
     }
 
     #[tool(

--- a/crates/velesdb-memory/src/mcp/dto.rs
+++ b/crates/velesdb-memory/src/mcp/dto.rs
@@ -93,6 +93,29 @@ pub(super) struct RecallFusedParams {
     /// (default 0.15). Raise to trust the graph more, lower to trust vector
     /// similarity more.
     pub(super) graph_boost: Option<f64>,
+    /// Name of the metadata field holding each fact's date as a `YYYYMMDD`
+    /// integer (e.g. `"ts"`, `"occurred_at"`). When set, the result adds a
+    /// `dated_context` timeline (facts date-prefixed and ordered oldest-first)
+    /// plus a `now` anchor — the representation that lifts temporal reasoning.
+    /// Omit for plain results.
+    pub(super) date_field: Option<String>,
+}
+
+/// Result of the `recall_fused` tool: the recalled memories, plus a dated
+/// timeline when `date_field` was given.
+#[derive(Serialize, JsonSchema)]
+pub(super) struct RecallFusedResult {
+    /// Recalled memories, most relevant first.
+    pub(super) memories: Vec<Recollection>,
+    /// Chronological, date-prefixed rendering of `memories` (`- [YYYY-MM-DD]
+    /// content` per line, oldest first, undated facts last). Present only when
+    /// `date_field` was set.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) dated_context: Option<String>,
+    /// The most recent date across `memories` (`YYYY-MM-DD`), the "now" anchor.
+    /// Present only when `date_field` was set and at least one fact is dated.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) now: Option<String>,
 }
 
 /// Parameters for the `relate` tool.

--- a/crates/velesdb-memory/src/mcp/server_tests.rs
+++ b/crates/velesdb-memory/src/mcp/server_tests.rs
@@ -440,6 +440,7 @@ async fn recall_fused_folds_in_a_graph_reached_fact() {
             filter: None,
             hops: None,
             graph_boost: None,
+            date_field: None,
         }))
         .await
         .expect("recall_fused");
@@ -451,6 +452,75 @@ async fn recall_fused_folds_in_a_graph_reached_fact() {
         fused.memories.iter().any(|m| m.id == linked.id),
         "graph-reached fact folded into fused recall"
     );
+}
+
+#[tokio::test]
+async fn recall_fused_with_date_field_returns_a_dated_timeline() {
+    let (_dir, srv) = server();
+    // Two dated facts, stored newest-first so ordering is actually exercised.
+    for (fact, ts) in [
+        ("the release shipped", 20_260_701_i64),
+        ("the project kicked off", 20_260_103),
+    ] {
+        srv.remember(Parameters(RememberParams {
+            fact: fact.to_owned(),
+            links: Vec::new(),
+            metadata: Some(ts_meta(ts)),
+            ttl_seconds: None,
+        }))
+        .await
+        .expect("remember dated fact");
+    }
+
+    let Json(res) = srv
+        .recall_fused(Parameters(RecallFusedParams {
+            query: "project release timeline".to_owned(),
+            limit: Some(10),
+            filter: None,
+            hops: None,
+            graph_boost: None,
+            date_field: Some("ts".to_owned()),
+        }))
+        .await
+        .expect("recall_fused dated");
+
+    let timeline = res
+        .dated_context
+        .expect("dated_context present when date_field set");
+    // Chronological: kickoff (Jan) before release (Jul), each date-prefixed.
+    assert!(timeline.contains("- [2026-01-03] the project kicked off"));
+    assert!(timeline.contains("- [2026-07-01] the release shipped"));
+    assert!(
+        timeline.find("2026-01-03").unwrap() < timeline.find("2026-07-01").unwrap(),
+        "facts must be ordered oldest-first"
+    );
+    assert_eq!(res.now.as_deref(), Some("2026-07-01"));
+}
+
+#[tokio::test]
+async fn recall_fused_without_date_field_omits_the_timeline() {
+    let (_dir, srv) = server();
+    srv.remember(Parameters(RememberParams {
+        fact: DECISION.to_owned(),
+        links: Vec::new(),
+        metadata: None,
+        ttl_seconds: None,
+    }))
+    .await
+    .expect("remember");
+    let Json(res) = srv
+        .recall_fused(Parameters(RecallFusedParams {
+            query: DECISION.to_owned(),
+            limit: Some(5),
+            filter: None,
+            hops: None,
+            graph_boost: None,
+            date_field: None,
+        }))
+        .await
+        .expect("recall_fused");
+    assert!(res.dated_context.is_none());
+    assert!(res.now.is_none());
 }
 
 #[tokio::test]
@@ -489,6 +559,7 @@ async fn recall_fused_survives_a_non_finite_graph_boost() {
             filter: None,
             hops: None,
             graph_boost: Some(f64::NAN),
+            date_field: None,
         }))
         .await
         .expect("recall_fused");
@@ -509,6 +580,7 @@ async fn recall_fused_limit_is_capped_at_max() {
             filter: None,
             hops: Some(usize::MAX),
             graph_boost: None,
+            date_field: None,
         }))
         .await
         .expect("recall_fused with huge limit/hops must succeed (silently capped)");

--- a/crates/velesdb-memory/src/model.rs
+++ b/crates/velesdb-memory/src/model.rs
@@ -130,22 +130,26 @@ impl Default for FusionOptions {
 
 impl FusionOptions {
     /// Build options from optional, untrusted tuning knobs, applying the
-    /// defaults and hop clamp every binding that takes raw `hops`/`graph_boost`
-    /// must enforce identically: `hops` clamped to the graph-traversal ceiling
+    /// defaults and clamps every binding must enforce identically: `hops`
+    /// clamped to the graph-traversal ceiling
     /// ([`clamp_hops`](crate::limits::clamp_hops)), `graph_boost` defaulted when
-    /// absent, and `pool` left at the proven default. The MCP `recall_fused`
-    /// tool and the Python `recall_fused` binding both build their options here
-    /// so the two transports can't drift on what they accept. A non-finite
-    /// `graph_boost` is not filtered here — that guard lives in
+    /// absent, and `pool` clamped to the recall ceiling
+    /// ([`clamp_recall_limit`](crate::limits::clamp_recall_limit)) or left at the
+    /// proven default. The MCP `recall_fused` tool (which exposes no `pool`, so
+    /// passes `None`) and the Python `recall_fused` binding both build their
+    /// options here so the transports can't drift on what they accept. A
+    /// non-finite `graph_boost` is not filtered here — that guard lives in
     /// [`Self::sanitized`], applied by fusion itself so *every* caller is
     /// covered, not just this constructor.
     #[must_use]
-    pub fn from_knobs(hops: Option<usize>, graph_boost: Option<f64>) -> Self {
+    pub fn from_knobs(hops: Option<usize>, graph_boost: Option<f64>, pool: Option<usize>) -> Self {
         let defaults = Self::default();
         Self {
             hops: crate::limits::clamp_hops(hops.unwrap_or(defaults.hops)),
             graph_boost: graph_boost.unwrap_or(defaults.graph_boost),
-            pool: defaults.pool,
+            pool: pool
+                .map(crate::limits::clamp_recall_limit)
+                .or(defaults.pool),
         }
     }
 

--- a/crates/velesdb-python/python/velesdb/__init__.pyi
+++ b/crates/velesdb-python/python/velesdb/__init__.pyi
@@ -2344,14 +2344,33 @@ class MemoryService:
         """
         ...
 
+    @overload
     def recall_fused(
         self,
         query: str,
         k: int = 10,
         filter: Optional[Dict[str, Any]] = None,
-        hops: Optional[int] = None,
-        graph_boost: Optional[float] = None,
-    ) -> List[Dict[str, Any]]:
+        date_field: None = None,
+        options: Optional[Dict[str, Any]] = None,
+    ) -> List[Dict[str, Any]]: ...
+    @overload
+    def recall_fused(
+        self,
+        query: str,
+        k: int = 10,
+        filter: Optional[Dict[str, Any]] = None,
+        *,
+        date_field: str,
+        options: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]: ...
+    def recall_fused(
+        self,
+        query: str,
+        k: int = 10,
+        filter: Optional[Dict[str, Any]] = None,
+        date_field: Optional[str] = None,
+        options: Optional[Dict[str, Any]] = None,
+    ) -> Union[List[Dict[str, Any]], Dict[str, Any]]:
         """Fused vector + graph recall (the tri-engine ranking).
 
         Like :meth:`recall`, but also walks the graph from the top vector hit
@@ -2364,15 +2383,19 @@ class MemoryService:
             query: Free-text query.
             k: Maximum number of results (default: 10).
             filter: Optional exact-match metadata filter dict.
-            hops: Graph hops from the top vector hit (default: 2).
-            graph_boost: Weight added to a graph-reached fact's score
-                (default: 0.15).
+            date_field: Metadata key holding each fact's ``YYYYMMDD`` date. When
+                given, the result is a dict with a dated timeline (see below);
+                when ``None`` (default), a plain list is returned.
+            options: Optional advanced fusion tuning
+                ``{"hops": int, "graph_boost": float, "pool": int}`` (all keys
+                optional). Omit for the proven defaults.
 
         Returns:
-            List of ``{"id": int, "score": float, "content": str,
-            "metadata": Optional[Dict[str, Any]]}`` dicts, most relevant
-            first. ``metadata`` is the fact's stored dict, or ``None`` if it
-            carried none.
+            Without ``date_field``: a list of ``{"id": int, "score": float,
+            "content": str, "metadata": Optional[Dict[str, Any]]}`` dicts, most
+            relevant first. With ``date_field``: a dict ``{"memories": [...],
+            "dated_context": str, "now": Optional[str]}`` — the same memories
+            plus a chronological, date-prefixed timeline and a "now" anchor.
         """
         ...
 

--- a/crates/velesdb-python/python/velesdb/__init__.pyi
+++ b/crates/velesdb-python/python/velesdb/__init__.pyi
@@ -2350,6 +2350,7 @@ class MemoryService:
         query: str,
         k: int = 10,
         filter: Optional[Dict[str, Any]] = None,
+        *,
         date_field: None = None,
         options: Optional[Dict[str, Any]] = None,
     ) -> List[Dict[str, Any]]: ...
@@ -2368,6 +2369,7 @@ class MemoryService:
         query: str,
         k: int = 10,
         filter: Optional[Dict[str, Any]] = None,
+        *,
         date_field: Optional[str] = None,
         options: Optional[Dict[str, Any]] = None,
     ) -> Union[List[Dict[str, Any]], Dict[str, Any]]:

--- a/crates/velesdb-python/src/agent_memory_service.rs
+++ b/crates/velesdb-python/src/agent_memory_service.rs
@@ -13,9 +13,9 @@ use pyo3::types::{PyDict, PyList, PyString};
 use std::collections::HashMap;
 
 use velesdb_memory::{
-    limits, ColumnFilter, ColumnOp, DynEmbedder, ErrorCategory, Explanation, FusionOptions,
-    HashEmbedder, Link, MemoryError, MemoryService, Metadata, OllamaEmbedder, OllamaExtractor,
-    Recollection, DEFAULT_DIMENSION, DEFAULT_OLLAMA_MODEL, DEFAULT_OLLAMA_URL,
+    format_dated_context, limits, ColumnFilter, ColumnOp, DynEmbedder, ErrorCategory, Explanation,
+    FusionOptions, HashEmbedder, Link, MemoryError, MemoryService, Metadata, OllamaEmbedder,
+    OllamaExtractor, Recollection, DEFAULT_DIMENSION, DEFAULT_OLLAMA_MODEL, DEFAULT_OLLAMA_URL,
 };
 
 use crate::collection::query::convert_params;
@@ -124,6 +124,34 @@ fn explanation_to_dict(py: Python<'_>, e: &Explanation) -> PyResult<Py<PyAny>> {
     out.set_item(PyString::intern(py, "nodes"), nodes)?;
     out.set_item(PyString::intern(py, "edges"), edges)?;
     Ok(out.into())
+}
+
+/// Extract an optional typed value for `key` from `dict`, `None` when the key
+/// is absent or holds Python `None` — the same three-state read the collection
+/// binding's `opt_field` uses, so `{}`, a missing key, and an explicit `None`
+/// all mean "unset".
+fn opt_item<'py, T: FromPyObjectOwned<'py>>(
+    dict: &Bound<'py, PyDict>,
+    key: &str,
+) -> PyResult<Option<T>> {
+    match dict.get_item(key)? {
+        Some(v) if !v.is_none() => Ok(Some(v.extract().map_err(Into::into)?)),
+        _ => Ok(None),
+    }
+}
+
+/// Build [`FusionOptions`] from an optional Python `{hops?, graph_boost?, pool?}`
+/// dict, routed through [`FusionOptions::from_knobs`] so the defaults and clamps
+/// stay identical to the MCP tool. An absent dict (or one omitting a key) uses
+/// the proven defaults.
+fn fusion_options_from_dict(options: Option<&Bound<'_, PyDict>>) -> PyResult<FusionOptions> {
+    let Some(dict) = options else {
+        return Ok(FusionOptions::from_knobs(None, None, None));
+    };
+    let hops = opt_item(dict, "hops")?;
+    let graph_boost = opt_item(dict, "graph_boost")?;
+    let pool = opt_item(dict, "pool")?;
+    Ok(FusionOptions::from_knobs(hops, graph_boost, pool))
 }
 
 /// Local-first agent memory with the `why()` graph wedge.
@@ -257,32 +285,53 @@ impl PyMemoryService {
     /// into the ranking — the tri-engine ranking measured on multi-hop and
     /// temporal benchmarks. Best when an answer needs a fact the query doesn't
     /// mention directly but a stored `relate`/`remember_extracted` link
-    /// connects. `hops`/`graph_boost` tune the graph reach; omit them for the
-    /// proven defaults. Returns `{id, score, content, metadata}` (`metadata`
-    /// is the fact's stored dict, or `None` if it carried none).
-    #[pyo3(signature = (query, k = 10, filter = None, hops = None, graph_boost = None))]
+    /// connects. Advanced fusion tuning goes in `options`
+    /// (`{"hops": int, "graph_boost": float, "pool": int}`, all optional — same
+    /// shape as the Node/WASM binding); omit it for the proven defaults.
+    ///
+    /// Without `date_field`, returns a list of `{id, score, content, metadata}`
+    /// (`metadata` is the fact's stored dict, or `None` if it carried none).
+    /// With `date_field` set to the metadata key holding each fact's `YYYYMMDD`
+    /// date, returns a dict `{"memories": [...], "dated_context": str, "now":
+    /// str | None}` — the memories plus a chronological, date-prefixed timeline
+    /// and a "now" anchor for temporal reasoning.
+    #[pyo3(signature = (query, k = 10, filter = None, date_field = None, options = None))]
     fn recall_fused(
         &self,
         py: Python<'_>,
         query: &str,
         k: usize,
         filter: Option<HashMap<String, Py<PyAny>>>,
-        hops: Option<usize>,
-        graph_boost: Option<f64>,
+        date_field: Option<String>,
+        options: Option<Bound<'_, PyDict>>,
     ) -> PyResult<Py<PyAny>> {
         let k = limits::clamp_recall_limit(k);
         let filter = to_metadata(py, filter)?;
-        let opts = FusionOptions::from_knobs(hops, graph_boost);
+        let opts = fusion_options_from_dict(options.as_ref())?;
         let hits = py.detach(|| {
             self.svc
                 .recall_fused(query, k, filter.as_ref(), opts)
                 .map_err(to_py_err)
         })?;
-        let list = PyList::empty(py);
+        // Format the dated timeline before the hits are consumed into the list.
+        let dated = date_field
+            .as_ref()
+            .map(|field| format_dated_context(&hits, field));
+
+        let memories = PyList::empty(py);
         for hit in hits {
-            list.append(recollection_to_dict(py, hit)?)?;
+            memories.append(recollection_to_dict(py, hit)?)?;
         }
-        Ok(list.into())
+        match dated {
+            None => Ok(memories.into()),
+            Some(ctx) => {
+                let out = PyDict::new(py);
+                out.set_item(PyString::intern(py, "memories"), memories)?;
+                out.set_item(PyString::intern(py, "dated_context"), ctx.timeline)?;
+                out.set_item(PyString::intern(py, "now"), ctx.now)?;
+                Ok(out.into())
+            }
+        }
     }
 
     /// Create a typed edge `from_id -> to_id`. Returns the edge id.

--- a/crates/velesdb-python/src/agent_memory_service.rs
+++ b/crates/velesdb-python/src/agent_memory_service.rs
@@ -19,7 +19,7 @@ use velesdb_memory::{
 };
 
 use crate::collection::query::convert_params;
-use crate::utils::{json_to_python, python_to_json};
+use crate::utils::{json_to_python, opt_field, python_to_json};
 
 /// Map a [`MemoryError`] to the most specific Python exception, driven by its
 /// transport-neutral [`ErrorCategory`] so the taxonomy stays identical to the
@@ -126,20 +126,6 @@ fn explanation_to_dict(py: Python<'_>, e: &Explanation) -> PyResult<Py<PyAny>> {
     Ok(out.into())
 }
 
-/// Extract an optional typed value for `key` from `dict`, `None` when the key
-/// is absent or holds Python `None` — the same three-state read the collection
-/// binding's `opt_field` uses, so `{}`, a missing key, and an explicit `None`
-/// all mean "unset".
-fn opt_item<'py, T: FromPyObjectOwned<'py>>(
-    dict: &Bound<'py, PyDict>,
-    key: &str,
-) -> PyResult<Option<T>> {
-    match dict.get_item(key)? {
-        Some(v) if !v.is_none() => Ok(Some(v.extract().map_err(Into::into)?)),
-        _ => Ok(None),
-    }
-}
-
 /// Build [`FusionOptions`] from an optional Python `{hops?, graph_boost?, pool?}`
 /// dict, routed through [`FusionOptions::from_knobs`] so the defaults and clamps
 /// stay identical to the MCP tool. An absent dict (or one omitting a key) uses
@@ -148,9 +134,9 @@ fn fusion_options_from_dict(options: Option<&Bound<'_, PyDict>>) -> PyResult<Fus
     let Some(dict) = options else {
         return Ok(FusionOptions::from_knobs(None, None, None));
     };
-    let hops = opt_item(dict, "hops")?;
-    let graph_boost = opt_item(dict, "graph_boost")?;
-    let pool = opt_item(dict, "pool")?;
+    let hops = opt_field(dict, "hops")?;
+    let graph_boost = opt_field(dict, "graph_boost")?;
+    let pool = opt_field(dict, "pool")?;
     Ok(FusionOptions::from_knobs(hops, graph_boost, pool))
 }
 
@@ -295,7 +281,7 @@ impl PyMemoryService {
     /// date, returns a dict `{"memories": [...], "dated_context": str, "now":
     /// str | None}` — the memories plus a chronological, date-prefixed timeline
     /// and a "now" anchor for temporal reasoning.
-    #[pyo3(signature = (query, k = 10, filter = None, date_field = None, options = None))]
+    #[pyo3(signature = (query, k = 10, filter = None, *, date_field = None, options = None))]
     fn recall_fused(
         &self,
         py: Python<'_>,

--- a/crates/velesdb-python/src/collection/mod.rs
+++ b/crates/velesdb-python/src/collection/mod.rs
@@ -29,17 +29,7 @@ const DEFAULT_FUSION: CoreFusionStrategy = CoreFusionStrategy::RRF { k: 60 };
 
 use velesdb_core::collection::streaming::{AsyncIndexBuilderConfig, DeferredIndexerConfig};
 
-/// Extract an optional typed value for `key`, returning `None` when the
-/// key is absent or holds Python `None`.
-fn opt_field<'py, T: FromPyObjectOwned<'py>>(
-    dict: &Bound<'py, PyDict>,
-    key: &str,
-) -> PyResult<Option<T>> {
-    match dict.get_item(key)? {
-        Some(v) if !v.is_none() => Ok(Some(v.extract().map_err(Into::into)?)),
-        _ => Ok(None),
-    }
-}
+use crate::utils::opt_field;
 
 /// Resolve a three-state override for `key`: an absent key leaves the field
 /// unchanged (`None`), an explicit Python `None` clears it (`Some(None)`),

--- a/crates/velesdb-python/src/utils.rs
+++ b/crates/velesdb-python/src/utils.rs
@@ -5,9 +5,28 @@
 
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
+use pyo3::types::PyDict;
 use pyo3::IntoPyObjectExt;
 use std::collections::HashMap;
 use velesdb_core::{DistanceMetric, StorageMode};
+
+/// Extract an optional typed value for `key` from `dict`, returning `None` when
+/// the key is absent or holds Python `None` — so `{}`, a missing key, and an
+/// explicit `None` all read as "unset". Shared by every binding that takes an
+/// options dict (collection config, `recall_fused` fusion options).
+///
+/// # Errors
+///
+/// Propagates any error from extracting the value as `T` (e.g. a wrong type).
+pub fn opt_field<'py, T: FromPyObjectOwned<'py>>(
+    dict: &Bound<'py, PyDict>,
+    key: &str,
+) -> PyResult<Option<T>> {
+    match dict.get_item(key)? {
+        Some(v) if !v.is_none() => Ok(Some(v.extract().map_err(Into::into)?)),
+        _ => Ok(None),
+    }
+}
 
 /// Rejects vectors that contain non-finite values (NaN or Infinity).
 ///

--- a/crates/velesdb-python/tests/test_memory_service.py
+++ b/crates/velesdb-python/tests/test_memory_service.py
@@ -204,6 +204,15 @@ def test_recall_fused_without_date_field_returns_a_plain_list(mem):
     assert isinstance(res, list)
 
 
+def test_recall_fused_zero_pool_is_floored_not_emptied(mem):
+    # pool=0 must not oversample zero candidates and return nothing; it is
+    # floored to 1 (a deliberate small pool is still honored, just never empty).
+    for i in range(3):
+        mem.remember(f"a fact number {i} about locks")
+    hits = mem.recall_fused("locks", k=5, options={"pool": 0})
+    assert len(hits) > 0
+
+
 def test_oversized_fact_raises_value_error(mem):
     # Facts above the shared 1 MiB cap are rejected before any embedding work.
     with pytest.raises(ValueError):

--- a/crates/velesdb-python/tests/test_memory_service.py
+++ b/crates/velesdb-python/tests/test_memory_service.py
@@ -157,9 +157,10 @@ def test_recall_fused_respects_exact_match_filter(mem):
 
 
 def test_recall_fused_accepts_tuning_knobs(mem):
-    # hops/graph_boost are optional and clamped, not rejected.
+    # Advanced fusion knobs go in `options` (same shape as Node/WASM); optional
+    # and clamped, not rejected.
     mem.remember("a decision about locks")
-    hits = mem.recall_fused("locks", k=5, hops=1, graph_boost=0.3)
+    hits = mem.recall_fused("locks", k=5, options={"hops": 1, "graph_boost": 0.3, "pool": 64})
     assert isinstance(hits, list)
 
 
@@ -172,9 +173,35 @@ def test_recall_fused_survives_non_finite_graph_boost(mem):
         "the on-call rotation moved to Tuesdays",
         links=[(anchor, "context")],
     )
-    hits = mem.recall_fused("parking_lot poisoning", k=10, graph_boost=float("nan"))
+    hits = mem.recall_fused(
+        "parking_lot poisoning", k=10, options={"graph_boost": float("nan")}
+    )
     ids = {h["id"] for h in hits}
     assert linked in ids
+
+
+def test_recall_fused_dated_returns_timeline_and_now(mem):
+    # With date_field, recall_fused returns a dict carrying a chronological,
+    # date-prefixed timeline + a "now" anchor — the temporal representation
+    # shipped as product behavior, not left to the caller's prompt.
+    mem.remember("the release shipped", metadata={"ts": 20260701})
+    mem.remember("the project kicked off", metadata={"ts": 20260103})
+    res = mem.recall_fused("project release timeline", k=10, date_field="ts")
+    assert isinstance(res, dict)
+    assert set(res) == {"memories", "dated_context", "now"}
+    timeline = res["dated_context"]
+    assert "- [2026-01-03] the project kicked off" in timeline
+    assert "- [2026-07-01] the release shipped" in timeline
+    # Oldest first.
+    assert timeline.index("2026-01-03") < timeline.index("2026-07-01")
+    assert res["now"] == "2026-07-01"
+
+
+def test_recall_fused_without_date_field_returns_a_plain_list(mem):
+    # Backward-compatible: no date_field -> a list, exactly like before.
+    mem.remember("a plain fact")
+    res = mem.recall_fused("plain fact", k=5)
+    assert isinstance(res, list)
 
 
 def test_oversized_fact_raises_value_error(mem):


### PR DESCRIPTION
## What & why

**P1.2 of the LoCoMo repositioning plan** — productize the **dated-context** representation. The temporal win measured on `examples/locomo` (+33.6pp, McNemar p=1.8e-28) came from presenting retrieved facts as a chronological, date-prefixed timeline with a "now" anchor. Until now that formatting lived only in the harness (`judge.rs`), so the lift was a *harness prompt*, not shipped product behavior. This ships it, closing another piece of the "the win is in the harness, not the installed product" attack.

## API decision (aligned with @cyberlife-coder)

- **`dated` flag on `recall_fused`** — one call returns the facts *and* the dated timeline (chosen over a standalone formatter / a new `recall_dated` verb).
- **Only the formatting ships** — the LLM temporal-reasoning scaffold (`step-by-step … FINAL:`) stays a caller/harness concern. A memory store presents retrieved facts; prompt engineering is the caller's.

The flag is expressed as an optional **`date_field`** (the metadata key holding each fact's date) rather than a bare boolean, because the formatter must know *which* field holds the date — and that field is caller-chosen (`ts`, `occurred_at`, …), holding a `YYYYMMDD` integer (the same key shape `recall_where` filters on).

## Changes

- **Core** — `velesdb_memory::format_dated_context(facts, date_field) -> DatedContext { timeline, now }`. Dated facts render `- [YYYY-MM-DD] content` oldest-first; undated facts (missing/out-of-range date) are kept, unprefixed, after the timeline (never given a misleading date); `now` anchors on the latest date. Pure, fully unit-tested.
- **MCP** — `recall_fused` gains an optional `date_field`; the result adds `dated_context` + `now` when set (omitted otherwise).
- **Python** — `recall_fused` gains `date_field` (returns a dict `{memories, dated_context, now}` when set, else the plain list — typed via `@overload`). Its advanced fusion knobs now live in an **`options` dict** (`{hops, graph_boost, pool}`), which:
  - keeps the method within the repo's 7-arg clippy budget once `date_field` is added (no `#[allow]`),
  - **aligns Python with the Node/WASM opts-object convention**, and
  - **restores `pool` parity** (Python was the only library surface missing it).
  `FusionOptions::from_knobs` grew a `pool` arg (MCP passes `None`).

## Scope / follow-up

**Node + WASM `date_field` is a deliberate fast-follow PR**, not omitted: their `recall_fused` is already published (npm 0.4.0/3.6.0), so adding the flag needs a *non-breaking* change handled with care. The core primitive they'll build on ships here.

## Tests

- Core formatter units: chronological ordering, undated handling, caller-named field, out-of-range/non-integer dates → undated, `now` anchor, stable same-date order.
- MCP: dated timeline returned + `now`; omitted when no `date_field`.
- Python: dated dict shape + values; plain-list backward-compat; `options` knobs accepted.
- Full `velesdb-memory` suite + `velesdb-python` pytest green; clippy `-D warnings -D clippy::pedantic` clean; Node/WASM crates compile against the changed core.
