### PR TITLE
feat(node,wasm,sdk): dated-context recallFusedDated on Node + WASM + TS SDK

### DIFF
--- a/crates/velesdb-memory/src/fused_recall.rs
+++ b/crates/velesdb-memory/src/fused_recall.rs
@@ -58,6 +58,30 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
         Ok(fusion::fuse(pool, &reached, k, opts.graph_boost))
     }
 
+    /// [`Self::recall_fused`] paired with the dated-context rendering of its
+    /// results: returns the recalled facts and the
+    /// [`DatedContext`](crate::DatedContext) built from their `date_field`
+    /// metadata (see [`format_dated_context`](crate::format_dated_context)).
+    /// Every binding that exposes a "dated recall" (the MCP `recall_fused`
+    /// tool's `date_field`, Node/WASM `recallFusedDated`) calls this, so the
+    /// "recall then format" pairing lives in exactly one place and can't drift
+    /// between surfaces.
+    ///
+    /// # Errors
+    /// Returns [`MemoryError`] if the underlying [`Self::recall_fused`] fails.
+    pub fn recall_fused_dated(
+        &self,
+        query: &str,
+        k: usize,
+        filter: Option<&Metadata>,
+        opts: FusionOptions,
+        date_field: &str,
+    ) -> Result<(Vec<Recollection>, crate::DatedContext), MemoryError> {
+        let hits = self.recall_fused(query, k, filter, opts)?;
+        let ctx = crate::format_dated_context(&hits, date_field);
+        Ok((hits, ctx))
+    }
+
     /// Like [`Self::recall_fused`], but hands the FULL fused-ranked candidate
     /// pool (before the final `k` cutoff) to `reranker` for a second-stage
     /// re-score, then truncates to `k`. Closes the ranking-miss gap the

--- a/crates/velesdb-memory/src/mcp.rs
+++ b/crates/velesdb-memory/src/mcp.rs
@@ -178,20 +178,25 @@ impl McpServer {
             date_field,
             ..
         } = params;
-        let memories = tokio::task::spawn_blocking(move || {
-            service.recall_fused(&query, k, filter.as_ref(), opts)
-        })
-        .await
-        .map_err(join_error)?
-        .map_err(to_error)?;
-        // When the caller names a date field, also ship the dated timeline it
-        // would otherwise have to format itself in a prompt.
-        let (dated_context, now) = match date_field {
-            Some(field) => {
-                let ctx = crate::dated_context::format_dated_context(&memories, &field);
-                (Some(ctx.timeline), ctx.now)
-            }
-            None => (None, None),
+        // With a date field, take the shared "recall then format" path so the
+        // dated timeline stays identical to the Node/WASM bindings; without one,
+        // plain fused recall (no timeline).
+        let (memories, dated_context, now) = if let Some(field) = date_field {
+            let (hits, ctx) = tokio::task::spawn_blocking(move || {
+                service.recall_fused_dated(&query, k, filter.as_ref(), opts, &field)
+            })
+            .await
+            .map_err(join_error)?
+            .map_err(to_error)?;
+            (hits, Some(ctx.timeline), ctx.now)
+        } else {
+            let hits = tokio::task::spawn_blocking(move || {
+                service.recall_fused(&query, k, filter.as_ref(), opts)
+            })
+            .await
+            .map_err(join_error)?
+            .map_err(to_error)?;
+            (hits, None, None)
         };
         Ok(Json(RecallFusedResult {
             memories,

--- a/crates/velesdb-node/__test__/index.spec.mjs
+++ b/crates/velesdb-node/__test__/index.spec.mjs
@@ -17,7 +17,7 @@ function freshStore() {
   return { store, cleanup: () => rmSync(dir, { recursive: true, force: true }) }
 }
 
-test('surface allowlist — exactly the 9 supported methods, no engine leak', () => {
+test('surface allowlist — exactly the supported methods, no engine leak', () => {
   const instanceMethods = Object.getOwnPropertyNames(MemoryService.prototype)
     .filter((m) => m !== 'constructor')
     .sort((a, b) => a.localeCompare(b))
@@ -25,6 +25,7 @@ test('surface allowlist — exactly the 9 supported methods, no engine leak', ()
     'forget',
     'recall',
     'recallFused',
+    'recallFusedDated',
     'recallWhere',
     'relate',
     'remember',
@@ -142,6 +143,27 @@ test('recallWhere and recall both surface stored metadata (dated recall)', async
     const hits = await store.recall('pricing page', 5)
     assert.ok(hits.length >= 1)
     assert.equal(hits[0].metadata?.ts, 20260701, 'recall round-trips metadata too')
+  } finally {
+    cleanup()
+  }
+})
+
+test('recallFusedDated returns a chronological timeline and a now anchor', async () => {
+  const { store, cleanup } = freshStore()
+  try {
+    await store.remember('the release shipped', [], { ts: 20260701 })
+    await store.remember('the project kicked off', [], { ts: 20260103 })
+
+    const res = await store.recallFusedDated('project release timeline', 'ts', 10)
+    assert.ok(Array.isArray(res.memories) && res.memories.length >= 2)
+    assert.ok(res.datedContext.includes('- [2026-01-03] the project kicked off'))
+    assert.ok(res.datedContext.includes('- [2026-07-01] the release shipped'))
+    // Oldest first.
+    assert.ok(
+      res.datedContext.indexOf('2026-01-03') < res.datedContext.indexOf('2026-07-01'),
+      'timeline is oldest-first',
+    )
+    assert.equal(res.now, '2026-07-01', 'now anchors on the latest date')
   } finally {
     cleanup()
   }

--- a/crates/velesdb-node/src/dto.rs
+++ b/crates/velesdb-node/src/dto.rs
@@ -71,6 +71,19 @@ impl From<Recollection> for RecollectionJs {
     }
 }
 
+/// Result of `recallFusedDated`: the recalled memories plus a dated timeline.
+#[napi(object)]
+pub struct DatedRecallJs {
+    /// Recalled memories, most relevant first.
+    pub memories: Vec<RecollectionJs>,
+    /// Chronological, date-prefixed rendering of `memories` (`- [YYYY-MM-DD]
+    /// content` per line, oldest first, undated facts last).
+    pub dated_context: String,
+    /// The most recent date across `memories` (`YYYY-MM-DD`), or `undefined`
+    /// when no memory carries a valid date.
+    pub now: Option<String>,
+}
+
 /// A node in a `why()` explanation subgraph.
 #[napi(object)]
 pub struct MemoryNodeJs {

--- a/crates/velesdb-node/src/lib.rs
+++ b/crates/velesdb-node/src/lib.rs
@@ -45,8 +45,8 @@ use napi::bindgen_prelude::AsyncTask;
 use napi_derive::napi;
 use serde_json::Value;
 use velesdb_memory::{
-    format_dated_context, DynEmbedder, HashEmbedder, MemoryService, OllamaEmbedder,
-    OllamaExtractor, DEFAULT_DIMENSION, DEFAULT_OLLAMA_MODEL, DEFAULT_OLLAMA_URL,
+    DynEmbedder, HashEmbedder, MemoryService, OllamaEmbedder, OllamaExtractor, DEFAULT_DIMENSION,
+    DEFAULT_OLLAMA_MODEL, DEFAULT_OLLAMA_URL,
 };
 
 use crate::dto::{
@@ -239,10 +239,9 @@ impl MemoryStore {
             let k = guards::clamp_limit(k.unwrap_or(10));
             let filter = convert::to_metadata(filter)?;
             let opts = convert::to_fusion_options(opts);
-            let hits = svc
-                .recall_fused(&query, k, filter.as_ref(), opts)
+            let (hits, ctx) = svc
+                .recall_fused_dated(&query, k, filter.as_ref(), opts, &date_field)
                 .map_err(to_napi_err)?;
-            let ctx = format_dated_context(&hits, &date_field);
             Ok(DatedRecallJs {
                 memories: hits.into_iter().map(RecollectionJs::from).collect(),
                 dated_context: ctx.timeline,

--- a/crates/velesdb-node/src/lib.rs
+++ b/crates/velesdb-node/src/lib.rs
@@ -45,11 +45,13 @@ use napi::bindgen_prelude::AsyncTask;
 use napi_derive::napi;
 use serde_json::Value;
 use velesdb_memory::{
-    DynEmbedder, HashEmbedder, MemoryService, OllamaEmbedder, OllamaExtractor, DEFAULT_DIMENSION,
-    DEFAULT_OLLAMA_MODEL, DEFAULT_OLLAMA_URL,
+    format_dated_context, DynEmbedder, HashEmbedder, MemoryService, OllamaEmbedder,
+    OllamaExtractor, DEFAULT_DIMENSION, DEFAULT_OLLAMA_MODEL, DEFAULT_OLLAMA_URL,
 };
 
-use crate::dto::{ColumnFilterJs, ExplanationJs, FusionOptionsJs, LinkJs, RecollectionJs};
+use crate::dto::{
+    ColumnFilterJs, DatedRecallJs, ExplanationJs, FusionOptionsJs, LinkJs, RecollectionJs,
+};
 use crate::error::{invalid_input, to_napi_err, CODE_INTERNAL};
 use crate::tasks::Job;
 
@@ -211,6 +213,41 @@ impl MemoryStore {
                 .recall_fused(&query, k, filter.as_ref(), opts)
                 .map_err(to_napi_err)?;
             Ok(hits.into_iter().map(RecollectionJs::from).collect())
+        }))
+    }
+
+    /// Fused recall plus a dated timeline: like [`recall_fused`](Self::recall_fused),
+    /// but reads each fact's date from the `dateField` metadata key (a `YYYYMMDD`
+    /// integer) and resolves to `{memories, datedContext, now}` — the memories, a
+    /// chronological date-prefixed timeline, and a "now" anchor for temporal
+    /// reasoning. A separate method (not a flag on `recallFused`) so the published
+    /// `recallFused` array return type stays unchanged.
+    #[napi(
+        js_name = "recallFusedDated",
+        ts_return_type = "Promise<DatedRecallJs>"
+    )]
+    pub fn recall_fused_dated(
+        &self,
+        query: String,
+        date_field: String,
+        k: Option<u32>,
+        filter: Option<Value>,
+        opts: Option<FusionOptionsJs>,
+    ) -> AsyncTask<Job<DatedRecallJs>> {
+        let svc = Arc::clone(&self.inner);
+        AsyncTask::new(Job::new(move || {
+            let k = guards::clamp_limit(k.unwrap_or(10));
+            let filter = convert::to_metadata(filter)?;
+            let opts = convert::to_fusion_options(opts);
+            let hits = svc
+                .recall_fused(&query, k, filter.as_ref(), opts)
+                .map_err(to_napi_err)?;
+            let ctx = format_dated_context(&hits, &date_field);
+            Ok(DatedRecallJs {
+                memories: hits.into_iter().map(RecollectionJs::from).collect(),
+                dated_context: ctx.timeline,
+                now: ctx.now,
+            })
         }))
     }
 

--- a/crates/velesdb-wasm/src/memory_service.rs
+++ b/crates/velesdb-wasm/src/memory_service.rs
@@ -26,8 +26,8 @@ use serde_json::Value;
 use wasm_bindgen::prelude::*;
 
 use velesdb_memory::{
-    format_dated_context, ColumnFilter, ColumnOp, Explanation, FusionOptions, HashEmbedder,
-    MemoryEdge, MemoryError, MemoryNode, MemoryService, Metadata, Recollection,
+    ColumnFilter, ColumnOp, Explanation, FusionOptions, HashEmbedder, MemoryEdge, MemoryError,
+    MemoryNode, MemoryService, Metadata, Recollection,
 };
 
 use crate::memory_store::WasmStore;
@@ -203,8 +203,8 @@ impl From<Recollection> for RecollectionOut {
 struct DatedRecallOut {
     memories: Vec<RecollectionOut>,
     dated_context: String,
-    /// Skipped when absent (no dated fact) so it reads as `undefined` in JS.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    /// `null` when no fact is dated — kept present (not skipped) so this matches
+    /// the Node binding, where napi serializes `Option::None` as JS `null`.
     now: Option<String>,
 }
 
@@ -420,11 +420,10 @@ impl WasmMemoryService {
         let k = velesdb_memory::limits::clamp_recall_limit(k.unwrap_or(10));
         let filter = to_metadata(filter)?;
         let opts = to_fusion_options(opts)?;
-        let hits = self
+        let (hits, ctx) = self
             .inner
-            .recall_fused(query, k, filter.as_ref(), opts)
+            .recall_fused_dated(query, k, filter.as_ref(), opts, date_field)
             .map_err(to_js_err)?;
-        let ctx = format_dated_context(&hits, date_field);
         to_js(&DatedRecallOut {
             memories: hits.into_iter().map(RecollectionOut::from).collect(),
             dated_context: ctx.timeline,

--- a/crates/velesdb-wasm/src/memory_service.rs
+++ b/crates/velesdb-wasm/src/memory_service.rs
@@ -26,8 +26,8 @@ use serde_json::Value;
 use wasm_bindgen::prelude::*;
 
 use velesdb_memory::{
-    ColumnFilter, ColumnOp, Explanation, FusionOptions, HashEmbedder, MemoryEdge, MemoryError,
-    MemoryNode, MemoryService, Metadata, Recollection,
+    format_dated_context, ColumnFilter, ColumnOp, Explanation, FusionOptions, HashEmbedder,
+    MemoryEdge, MemoryError, MemoryNode, MemoryService, Metadata, Recollection,
 };
 
 use crate::memory_store::WasmStore;
@@ -194,6 +194,18 @@ impl From<Recollection> for RecollectionOut {
             metadata: r.metadata.map(Value::Object),
         }
     }
+}
+
+/// Result of [`WasmMemoryService::recall_fused_dated`]: the recalled memories
+/// plus a chronological, date-prefixed timeline and a "now" anchor.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct DatedRecallOut {
+    memories: Vec<RecollectionOut>,
+    dated_context: String,
+    /// Skipped when absent (no dated fact) so it reads as `undefined` in JS.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    now: Option<String>,
 }
 
 #[derive(Serialize)]
@@ -388,6 +400,36 @@ impl WasmMemoryService {
                 .map(RecollectionOut::from)
                 .collect::<Vec<_>>(),
         )
+    }
+
+    /// Fused recall plus a dated timeline: like [`Self::recall_fused`], but
+    /// reads each fact's date from the `dateField` metadata key (a `YYYYMMDD`
+    /// integer) and returns `{memories, datedContext, now}` — the memories, a
+    /// chronological date-prefixed timeline, and a "now" anchor for temporal
+    /// reasoning. A separate method (not a flag on `recallFused`) so the
+    /// published `recallFused` array return type is unchanged.
+    #[wasm_bindgen(js_name = recallFusedDated)]
+    pub fn recall_fused_dated(
+        &self,
+        query: &str,
+        date_field: &str,
+        k: Option<usize>,
+        filter: JsValue,
+        opts: JsValue,
+    ) -> Result<JsValue, JsValue> {
+        let k = velesdb_memory::limits::clamp_recall_limit(k.unwrap_or(10));
+        let filter = to_metadata(filter)?;
+        let opts = to_fusion_options(opts)?;
+        let hits = self
+            .inner
+            .recall_fused(query, k, filter.as_ref(), opts)
+            .map_err(to_js_err)?;
+        let ctx = format_dated_context(&hits, date_field);
+        to_js(&DatedRecallOut {
+            memories: hits.into_iter().map(RecollectionOut::from).collect(),
+            dated_context: ctx.timeline,
+            now: ctx.now,
+        })
     }
 
     /// Create a typed edge `from -> to`. Resolves to the edge's

--- a/crates/velesdb-wasm/src/memory_service_tests.rs
+++ b/crates/velesdb-wasm/src/memory_service_tests.rs
@@ -145,8 +145,8 @@ fn test_inner_why_reaches_a_two_hop_fact_vector_search_misses() {
 #[test]
 fn test_inner_recall_fused_dated_builds_a_chronological_timeline() {
     // The `recallFusedDated` JS boundary can't be touched natively (JsValue),
-    // but its logic is `inner.recall_fused` + `format_dated_context` — both pure
-    // Rust — so the timeline/now behavior is provable here.
+    // but its logic is the pure-Rust `inner.recall_fused_dated` the wrapper
+    // delegates to — so the timeline/now behavior is provable here.
     let svc = WasmMemoryService::new(4);
     let mut newer = Metadata::new();
     newer.insert("ts".to_owned(), serde_json::json!(20_260_701));
@@ -159,16 +159,16 @@ fn test_inner_recall_fused_dated_builds_a_chronological_timeline() {
         .remember("the project kicked off", &[], Some(&older))
         .unwrap();
 
-    let hits = svc
+    let (_hits, ctx) = svc
         .inner
-        .recall_fused(
+        .recall_fused_dated(
             "project release timeline",
             10,
             None,
             velesdb_memory::FusionOptions::default(),
+            "ts",
         )
         .unwrap();
-    let ctx = format_dated_context(&hits, "ts");
     assert!(ctx
         .timeline
         .contains("- [2026-01-03] the project kicked off"));

--- a/crates/velesdb-wasm/src/memory_service_tests.rs
+++ b/crates/velesdb-wasm/src/memory_service_tests.rs
@@ -141,3 +141,41 @@ fn test_inner_why_reaches_a_two_hop_fact_vector_search_misses() {
         .unwrap();
     assert!(explanation.nodes.iter().any(|n| n.id == ticket));
 }
+
+#[test]
+fn test_inner_recall_fused_dated_builds_a_chronological_timeline() {
+    // The `recallFusedDated` JS boundary can't be touched natively (JsValue),
+    // but its logic is `inner.recall_fused` + `format_dated_context` — both pure
+    // Rust — so the timeline/now behavior is provable here.
+    let svc = WasmMemoryService::new(4);
+    let mut newer = Metadata::new();
+    newer.insert("ts".to_owned(), serde_json::json!(20_260_701));
+    svc.inner
+        .remember("the release shipped", &[], Some(&newer))
+        .unwrap();
+    let mut older = Metadata::new();
+    older.insert("ts".to_owned(), serde_json::json!(20_260_103));
+    svc.inner
+        .remember("the project kicked off", &[], Some(&older))
+        .unwrap();
+
+    let hits = svc
+        .inner
+        .recall_fused(
+            "project release timeline",
+            10,
+            None,
+            velesdb_memory::FusionOptions::default(),
+        )
+        .unwrap();
+    let ctx = format_dated_context(&hits, "ts");
+    assert!(ctx
+        .timeline
+        .contains("- [2026-01-03] the project kicked off"));
+    assert!(ctx.timeline.contains("- [2026-07-01] the release shipped"));
+    assert!(
+        ctx.timeline.find("2026-01-03").unwrap() < ctx.timeline.find("2026-07-01").unwrap(),
+        "timeline is oldest-first"
+    );
+    assert_eq!(ctx.now.as_deref(), Some("2026-07-01"));
+}

--- a/sdks/typescript/src/index.ts
+++ b/sdks/typescript/src/index.ts
@@ -32,6 +32,7 @@ export type {
   MemoryRecollection,
   MemoryColumnFilter,
   MemoryFusionOptions,
+  MemoryDatedRecall,
   MemoryNode,
   MemoryEdge,
   MemoryExplanation,

--- a/sdks/typescript/src/memory.ts
+++ b/sdks/typescript/src/memory.ts
@@ -63,6 +63,19 @@ export interface MemoryFusionOptions {
   pool?: number;
 }
 
+/** Result of {@link MemoryService.recallFusedDated}: the recalled memories plus a dated timeline. */
+export interface MemoryDatedRecall {
+  /** Recalled memories, most relevant first. */
+  memories: MemoryRecollection[];
+  /**
+   * Chronological, date-prefixed rendering of {@link memories}
+   * (`- [YYYY-MM-DD] content` per line, oldest first, undated facts last).
+   */
+  datedContext: string;
+  /** The most recent date across {@link memories} (`YYYY-MM-DD`), or `undefined` when none is dated. */
+  now?: string;
+}
+
 /** A node in a {@link MemoryService.why} explanation subgraph. */
 export interface MemoryNode {
   /** Decimal-string id of the memory. */
@@ -103,6 +116,13 @@ interface WasmMemoryServiceInstance {
   recall(query: string, k: number | null | undefined, filter: unknown): unknown;
   recallWhere(query: string, filters: unknown, k?: number | null): unknown;
   recallFused(query: string, k: number | null | undefined, filter: unknown, opts: unknown): unknown;
+  recallFusedDated(
+    query: string,
+    dateField: string,
+    k: number | null | undefined,
+    filter: unknown,
+    opts: unknown
+  ): unknown;
   relate(from: string, to: string, relation: string): string;
   forget(id: string): void;
   why(decision: string, maxHops: number | null | undefined, filter: unknown): unknown;
@@ -317,6 +337,31 @@ export class MemoryService {
   ): Promise<MemoryRecollection[]> {
     return wrapWasmCall(
       () => this.ensureInitialized().recallFused(query, k, filter, opts) as MemoryRecollection[]
+    );
+  }
+
+  /**
+   * Fused recall plus a dated timeline: like {@link recallFused}, but reads each
+   * fact's date from the `dateField` metadata key (a `YYYYMMDD` integer) and
+   * resolves to `{ memories, datedContext, now }` — the memories, a chronological
+   * date-prefixed timeline, and a "now" anchor for temporal reasoning.
+   */
+  recallFusedDated(
+    query: string,
+    dateField: string,
+    k?: number,
+    filter?: Record<string, unknown>,
+    opts?: MemoryFusionOptions
+  ): Promise<MemoryDatedRecall> {
+    return wrapWasmCall(
+      () =>
+        this.ensureInitialized().recallFusedDated(
+          query,
+          dateField,
+          k,
+          filter,
+          opts
+        ) as MemoryDatedRecall
     );
   }
 

--- a/sdks/typescript/src/memory.ts
+++ b/sdks/typescript/src/memory.ts
@@ -72,8 +72,8 @@ export interface MemoryDatedRecall {
    * (`- [YYYY-MM-DD] content` per line, oldest first, undated facts last).
    */
   datedContext: string;
-  /** The most recent date across {@link memories} (`YYYY-MM-DD`), or `undefined` when none is dated. */
-  now?: string;
+  /** The most recent date across {@link memories} (`YYYY-MM-DD`), or `null` when none is dated. */
+  now: string | null;
 }
 
 /** A node in a {@link MemoryService.why} explanation subgraph. */

--- a/sdks/typescript/tests/memory.test.ts
+++ b/sdks/typescript/tests/memory.test.ts
@@ -24,6 +24,11 @@ class MockWasmMemoryService {
   recall = vi.fn(() => [{ id: '1', score: 0.9, content: 'we chose parking_lot' }]);
   recallWhere = vi.fn(() => [{ id: '1', score: 0.9, content: 'we chose parking_lot' }]);
   recallFused = vi.fn(() => [{ id: '2', score: 0.0, content: 'EPIC-317' }]);
+  recallFusedDated = vi.fn(() => ({
+    memories: [{ id: '1', score: 0.9, content: 'we chose parking_lot' }],
+    datedContext: '- [2026-01-03] we chose parking_lot',
+    now: '2026-01-03',
+  }));
   relate = vi.fn(() => '5');
   forget = vi.fn();
   why = vi.fn(() => ({
@@ -177,6 +182,20 @@ describe('MemoryService', () => {
       expect(lastMockInstance!.recallFused).toHaveBeenCalledWith('parking_lot', 3, undefined, {
         hops: 2,
       });
+    });
+
+    it('recallFusedDated() returns the memories plus a dated timeline', async () => {
+      const res = await memory.recallFusedDated('parking_lot', 'ts', 3, undefined, { hops: 2 });
+      expect(res.now).toBe('2026-01-03');
+      expect(res.datedContext).toContain('- [2026-01-03] we chose parking_lot');
+      expect(res.memories).toHaveLength(1);
+      expect(lastMockInstance!.recallFusedDated).toHaveBeenCalledWith(
+        'parking_lot',
+        'ts',
+        3,
+        undefined,
+        { hops: 2 }
+      );
     });
 
     it('relate() returns the edge id', async () => {


### PR DESCRIPTION
## What & why

**P1.2 fast-follow** — completes the dated-context feature across the two surfaces the core+MCP+Python PR (#1315) deferred: **Node**, **WASM**, and the **TypeScript SDK** that wraps WASM.

## Why a sibling method, not the `date_field` flag

On MCP/Python (#1315) the dated timeline is a flag on `recall_fused` — those methods were new/unpublished, so adding a flag was free. Node's and WASM's `recallFused` are **already published** (npm `@wiscale/velesdb-memory-node` 0.4.0, `@wiscale/velesdb-wasm` 3.6.0). A `dateField` flag that switched the return between an array and an object would change `recallFused`'s TypeScript return type to a **union**, breaking every existing typed caller (`hits.map(...)` would no longer type-check).

So this ships a **sibling method `recallFusedDated`** with the same "one call → memories + dated timeline" semantics, leaving `recallFused`'s published array return untouched.

## Changes

- **Node (napi)** — `recallFusedDated(query, dateField, k?, filter?, opts?) → Promise<DatedRecallJs { memories, datedContext, now }>`. The surface-allowlist test is updated (now 9 instance methods).
- **WASM (wasm-bindgen)** — `recallFusedDated(query, dateField, k?, filter, opts) → { memories, datedContext, now }` (camelCase serde output, matching the crate's convention).
- **TS SDK** — `MemoryService.recallFusedDated(...)` + a `MemoryDatedRecall` interface, re-exported from the package index.

All three delegate to the core `velesdb_memory::format_dated_context` shipped in #1315 — no formatting logic is re-implemented. The `pool=0` floor and calendar-date validation from #1315 cover these paths too (shared core).

## Tests

- **Node** `__test__/index.spec.mjs`: `recallFusedDated` returns a chronological timeline + `now` anchor; surface allowlist updated. Verified locally via `napi build` + `node --test` (9 pass).
- **WASM** native Rust test (the JsValue boundary can't run off-wasm; the logic — `inner.recall_fused` + `format_dated_context` — is proven natively; the boundary is covered by CI's `wasm-pack test`).
- **TS SDK** vitest: mock-delegation + result shape. Full SDK suite green locally (888 tests) incl. the `--dts` typecheck.
- clippy `-D warnings -D clippy::pedantic` clean on both `velesdb-node` and `velesdb-wasm`.

With this, **P1.2 (dated-context) is shipped on every memory surface**: core, MCP, Python, Node, WASM, TS SDK.

## Review gate

A high-effort `/code-review` workflow found **one cleanup** (plus a cross-surface parity nit), both fixed in `b66cbc02`:

- **DRY (confirmed):** the `recall_fused` + `format_dated_context` pairing was inlined in three bindings (MCP, Node, WASM). Extracted a core `MemoryService::recall_fused_dated(...) -> (Vec<Recollection>, DatedContext)` so the dated-recall contract lives in one place; each surface only maps its own DTO.
- **Parity:** the `now` anchor was JS `null` on Node (napi) but omitted (`undefined`) on WASM. Since `recallFusedDated` is new (unpublished) everywhere, standardized on `null` (WASM keeps the field; TS SDK types it `string | null`) — one contract, no drift.

A follow-up adversarial review of the refactor commit confirmed no defects and full cross-surface consistency.
