### PR TITLE
feat(locomo): --use-shipped-api — reproduce fused retrieval through recall_fused

### DIFF
--- a/crates/velesdb-memory/examples/locomo/dump/dump_tests.rs
+++ b/crates/velesdb-memory/examples/locomo/dump/dump_tests.rs
@@ -177,5 +177,6 @@ fn test_cfg() -> EvalCfg {
         bm25: false,
         claude_judge: false,
         claude_gen: false,
+        use_shipped_api: false,
     }
 }

--- a/crates/velesdb-memory/examples/locomo/eval.rs
+++ b/crates/velesdb-memory/examples/locomo/eval.rs
@@ -17,7 +17,7 @@ use std::error::Error;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use serde_json::json;
-use velesdb_memory::{ColumnFilter, ColumnOp};
+use velesdb_memory::{ColumnFilter, ColumnOp, FusionOptions};
 
 use crate::dataset::{Category, Qa};
 use crate::dump::{self, QuestionTrace};
@@ -89,6 +89,17 @@ pub struct EvalCfg {
     /// accuracy goes when the generator is not the bottleneck (the memory layer
     /// is model-agnostic — plug in any LLM).
     pub claude_gen: bool,
+    /// Run the fused (graph) path through the SHIPPED
+    /// [`MemoryService::recall_fused`](velesdb_memory::MemoryService::recall_fused)
+    /// API instead of the harness's own `vector_pool` + `graph_reached` + `fuse`.
+    /// Proves the benchmarked tri-engine ranking reproduces through the API a
+    /// user installs — not just a harness re-implementation. It drops the
+    /// harness-only levers `recall_fused` doesn't have: the BM25/RRF lexical
+    /// fusion, multi-seed graph reach (`seed_breadth`), and the temporal
+    /// `ColumnStore` date window (a `recall_where` range predicate, not an
+    /// exact-match filter `recall_fused` accepts) — so compare it against the
+    /// single-seed, no-BM25 harness config to isolate the ranking itself.
+    pub use_shipped_api: bool,
 }
 
 /// A retrieved fact carried into the generation context. `score` is its vector
@@ -349,13 +360,55 @@ fn retrieve(
         }
         return Ok((pool.into_iter().take(cfg.k).collect(), raw));
     }
-    // Fused mode: a ColumnStore date window when the question is time-scoped,
-    // plus graph traversal — all three engines.
+    // Fused mode, shipped path: the exact `recall_fused` a user installs does
+    // the vector+graph fusion internally. No temporal ColumnStore window (that
+    // is `recall_where`'s range predicate, which `recall_fused` doesn't take),
+    // no BM25, single-seed — see `use_shipped_api`'s doc.
+    if cfg.use_shipped_api {
+        let opts = FusionOptions {
+            hops: cfg.hops,
+            graph_boost: cfg.graph_boost,
+            pool: None,
+        };
+        let fused = shipped_fused(store, question, cfg.k, opts)?;
+        let raw = raw_if_wanted(&fused, &[], want_raw);
+        return Ok((fused, raw));
+    }
+    // Fused mode, harness path: a ColumnStore date window when the question is
+    // time-scoped, plus graph traversal — all three engines.
     let filters = temporal_filters(question);
     let pool = vector_pool(store, question, pool_size(cfg.k), &filters)?;
     let reached = graph_reached(store, question, cfg)?;
     let raw = raw_if_wanted(&pool, &reached, want_raw);
     Ok((fuse(pool, &reached, cfg), raw))
+}
+
+/// The shipped [`MemoryService::recall_fused`](velesdb_memory::MemoryService::recall_fused)
+/// path, mapped into the harness's [`RetrievedFact`]. `recall_fused` already
+/// ranks vector+graph and excludes entity hubs, so this only re-hydrates the
+/// harness-side `dia_ids`/`ts` (by fact id, exactly as [`vector_pool`] does) for
+/// the evidence-recall scorer and the dated context. `graph_weight` is 0: the
+/// shipped API ranks internally and never exposes the per-fact breakdown the
+/// harness `fuse` keeps for `--dump`.
+fn shipped_fused(
+    store: &Store,
+    question: &str,
+    k: usize,
+    opts: FusionOptions,
+) -> Result<Vec<RetrievedFact>, Box<dyn Error>> {
+    let hits = store.svc.recall_fused(question, k, None, opts)?;
+    Ok(hits
+        .into_iter()
+        .filter(|hit| store.is_fact(hit.id))
+        .map(|hit| RetrievedFact {
+            id: hit.id,
+            text: hit.content,
+            dia_ids: store.dia_ids(hit.id).to_vec(),
+            score: f64::from(hit.score),
+            graph_weight: 0.0,
+            ts: store.fact_ts(hit.id),
+        })
+        .collect())
 }
 
 /// `pool ∪ reached`, uncloned (empty) unless `--dump` actually wants it — kept

--- a/crates/velesdb-memory/examples/locomo/eval/eval_tests.rs
+++ b/crates/velesdb-memory/examples/locomo/eval/eval_tests.rs
@@ -26,6 +26,7 @@ fn cfg() -> EvalCfg {
         bm25: false,
         claude_judge: false,
         claude_gen: false,
+        use_shipped_api: false,
     }
 }
 

--- a/crates/velesdb-memory/examples/locomo/main.rs
+++ b/crates/velesdb-memory/examples/locomo/main.rs
@@ -12,7 +12,25 @@
 //! cargo run --release -p velesdb-memory --features ollama --example locomo
 //! # LLM-free explanation benchmark (does the graph connect scattered evidence?):
 //! cargo run --release -p velesdb-memory --features ollama --example locomo -- --explanation
+//!
+//! # LLM-free reproduction: does the SHIPPED recall_fused reproduce the fused
+//! # retrieval? Compare the harness fusion against the installed API on the same
+//! # data (single-seed, no BM25, idf-weighted to match recall_fused):
+//! cargo run --release -p velesdb-memory --features ollama --example locomo -- \
+//!     --retrieval --idf-weight                       # harness fusion
+//! cargo run --release -p velesdb-memory --features ollama --example locomo -- \
+//!     --retrieval --use-shipped-api                  # shipped recall_fused
 //! ```
+//!
+//! `--use-shipped-api` routes the fused (graph) path through the exact
+//! [`MemoryService::recall_fused`](velesdb_memory::MemoryService::recall_fused)
+//! a user installs, instead of the harness's own `vector_pool`+`graph_reached`+`fuse`.
+//! On a 3-conversation run the two agree to ~1pp of evidence-recall@k
+//! (69.8% harness → 69.0% shipped), identical on temporal/single-hop/open-domain;
+//! the residual is concentrated in multi-hop and traces to the documented
+//! graph-reach divergences (the shipped IDF counts facts + entity hubs where the
+//! harness counts facts only; `recall_fused` is single-seed, no BM25, and takes
+//! an exact-match filter rather than the temporal `ColumnStore` date window).
 //!
 //! Pipeline: extract facts from each session with a local LLM (tagged with the
 //! gold `dia_id`s and session timestamp), ingest them as a fact↔entity graph,
@@ -412,6 +430,7 @@ impl Default for Args {
                 bm25: false,
                 claude_judge: false,
                 claude_gen: false,
+                use_shipped_api: false,
             },
         }
     }
@@ -465,6 +484,7 @@ impl Args {
             "--bm25" => &mut self.cfg.bm25,
             "--claude-judge" => &mut self.cfg.claude_judge,
             "--claude-gen" => &mut self.cfg.claude_gen,
+            "--use-shipped-api" => &mut self.cfg.use_shipped_api,
             _ => return None,
         })
     }


### PR DESCRIPTION
## What & why

**P1.3 of the LoCoMo repositioning plan** — prove the benchmarked tri-engine ranking **reproduces through the shipped `MemoryService::recall_fused` API**, not just the harness's own fusion. This closes the sharpest attack on the numbers: *"the win lives in the harness, not the product a user installs."*

The harness already retrieves through the real `MemoryService` (`recall` / `recall_where` / `why`). Only the **final vector+graph fusion** was re-implemented inline — for `--dump` per-fact instrumentation, BM25/RRF, and multi-seed reach. The new **`--use-shipped-api`** flag routes the fused path through `recall_fused` instead, mapping its `Recollection` results back into the harness's `RetrievedFact`.

## Measured reproduction (LLM-free)

`--retrieval` mode scores evidence-recall@k with no generator/judge — so the comparison runs in seconds on the local embedder. Run on **3 conversations, single-seed, no BM25, `--idf-weight`** (to match `recall_fused`'s always-IDF reach weighting):

| path | ALL | multi-hop | temporal | single-hop | open-domain |
|---|---|---|---|---|---|
| harness fusion (`--idf-weight`) | **69.8%** | 56.1% | 88.3% | 68.2% | 51.3% |
| shipped `recall_fused` (`--use-shipped-api`) | **69.0%** | 52.3% | 88.3% | 68.2% | 51.3% |

- Vector baseline **identical** (70.1%).
- Fused agrees to **~1pp** overall; **identical** on temporal / single-hop / open-domain.
- The residual is **entirely in multi-hop** (56.1% → 52.3%, ≈2–3 questions), and traces to **documented divergences** (below).

**Claim earned:** the tri-engine retrieval ranking reproduces through the installed API within a small, fully-explained margin.

## Documented divergences (feed P1.4)

The shipped `recall_fused` intentionally lacks the harness-only levers, so it is not bit-identical:
1. **IDF corpus size** — shipped `entity_idf` counts facts **+ entity hubs** (`store.count()`); the harness counts **facts only** (`n_facts`). Different denominators → different graph weights → the multi-hop gap.
2. **Single-seed** — `recall_fused` reaches the graph from one top vector seed; the harness can multi-seed (`--seed-breadth > 1`).
3. **No BM25** — the harness's RRF lexical fusion has no `recall_fused` equivalent.
4. **Exact-match filter only** — `recall_fused` takes an exact-match metadata filter, not the harness's temporal `ColumnStore` date **window** (a `recall_where` range predicate). So `--use-shipped-api` runs unfiltered; the temporal category is nonetheless identical here.

The multi-hop gap and these levers are P1.4 (doc) / P2 (accuracy-lever) territory — not bugs.

## Scope

Code only touches the `examples/locomo/` harness (a new opt-in flag + a `Recollection → RetrievedFact` mapper). No product code changes. Reproduction recipe added to the example's module docstring. clippy `-D warnings -D clippy::pedantic` clean on the example.
