### PR TITLE
feat(locomo): --full-context baseline (whole-conversation ceiling)

### DIFF
--- a/crates/velesdb-memory/examples/locomo/full_context.rs
+++ b/crates/velesdb-memory/examples/locomo/full_context.rs
@@ -1,0 +1,273 @@
+//! Full-context baseline: feed the ENTIRE conversation to the generator — no
+//! retrieval, no memory system, no budget — and score the answers exactly as
+//! the retrieval eval does. This is the reporting-standard local ceiling: the
+//! accuracy a long-context model reaches when nothing is dropped, and the
+//! token cost our budgeted retrieval trades that ceiling against.
+//!
+//! The whole conversation overflows Ollama's small default context window, so
+//! generation pins `num_ctx` (see [`FULL_CTX_TOKENS`]); a silent truncation
+//! there would quietly cap the very ceiling this baseline exists to measure.
+
+use std::error::Error;
+
+use crate::dataset::{Category, Sample};
+use crate::judge;
+use crate::ollama_gen::Generator;
+use crate::report::pct;
+
+/// Ollama context window for the whole-conversation prompt. Measured on the 10
+/// `LoCoMo` conversations: the dated `- [YYYY-MM-DD] Speaker: text` lines run
+/// ~2.9 chars/token (denser than a naive chars/4 estimate), so the prompt
+/// averages ~29k tokens and the largest conversation reaches the low-30k range;
+/// 49152 seats every one with comfortable headroom (verified: no prompt fills
+/// the window), far under the model's 262144 limit. `run` refuses upfront (see
+/// [`estimated_tokens`]) any conversation that would not fit.
+const FULL_CTX_TOKENS: u64 = 49_152;
+
+/// Tokens held back from [`FULL_CTX_TOKENS`] for the question, prompt scaffolding
+/// and the generated answer when checking a conversation fits — Ollama shares
+/// `num_ctx` between prompt and response, so the context alone must leave room.
+const RESPONSE_RESERVE_TOKENS: u64 = 1_024;
+
+/// Which stages route to the stronger Claude CLI instead of the local model:
+/// `gen` for answer generation, `judge` for the correctness verdict. Both
+/// default to the local model, matching the retrieval eval's flags.
+#[derive(Clone, Copy)]
+pub struct ClaudeFlags {
+    pub gen: bool,
+    pub judge: bool,
+}
+
+/// One category's running tally: correct / total, plus the prompt-token sum
+/// (and its sample count) so the report can show the mean context cost paid.
+#[derive(Default)]
+struct Cell {
+    n: u32,
+    correct: u32,
+    prompt_tokens: u64,
+    token_samples: u32,
+}
+
+impl Cell {
+    fn add(&mut self, correct: bool, prompt_tokens: Option<u64>) {
+        self.n += 1;
+        self.correct += u32::from(correct);
+        if let Some(tokens) = prompt_tokens {
+            self.prompt_tokens += tokens;
+            self.token_samples += 1;
+        }
+    }
+
+    fn accuracy(&self) -> f64 {
+        pct(self.correct, self.n)
+    }
+
+    fn mean_prompt_tokens(&self) -> Option<u64> {
+        (self.token_samples > 0).then(|| self.prompt_tokens / u64::from(self.token_samples))
+    }
+}
+
+/// Per-category accuracy report for the full-context baseline.
+#[derive(Default)]
+pub struct FullContextReport {
+    cells: [Cell; Category::COUNT],
+}
+
+impl FullContextReport {
+    /// Answer one question from the whole conversation and fold the verdict in.
+    /// Adversarial items are graded by abstention (the model should decline);
+    /// answerable items by the LLM judge, mirroring the retrieval eval so the
+    /// two numbers sit on the same scale.
+    fn record(
+        &mut self,
+        generator: &Generator,
+        context: &str,
+        qa: &crate::dataset::Qa,
+        claude: ClaudeFlags,
+    ) -> Result<(), Box<dyn Error>> {
+        let (candidate, usage) = answer(generator, context, &qa.question, claude.gen)?;
+        let correct = if qa.category.is_adversarial() {
+            judge::abstained(&candidate)
+        } else if let Some(gold) = judge::gold_answer(qa) {
+            judge::judge_correct(generator, &qa.question, gold, &candidate, claude.judge)?
+        } else {
+            false
+        };
+        self.cells[qa.category.index()].add(correct, usage.map(|u| u.prompt));
+        Ok(())
+    }
+
+    /// Print the per-category accuracy table plus the answerable headline and
+    /// the mean prompt-token cost the baseline paid to reach it. The provenance
+    /// line reflects the *actual* answerer: with `--claude-gen` the pinned local
+    /// `num_ctx` never applies (the Claude CLI answers), so it is not claimed.
+    fn print(&self, generator: &Generator, samples: usize, gen_claude: bool) {
+        println!(
+            "\nVelesDB-memory — LoCoMo full-context baseline (no retrieval, whole conversation)"
+        );
+        let provenance = if gen_claude {
+            "generator: claude (CLI)".to_string()
+        } else {
+            format!(
+                "generator: {}   ·   num_ctx={FULL_CTX_TOKENS}",
+                generator.model()
+            )
+        };
+        println!("{provenance}   ·   {samples} conversation(s)\n");
+        println!("  category         n      acc    mean-prompt-tokens");
+        let mut answerable = Cell::default();
+        for category in Category::ALL {
+            let cell = &self.cells[category.index()];
+            if cell.n == 0 {
+                continue;
+            }
+            println!(
+                "  {:<12} {:>4}    {:>4.0}%    {}",
+                category.label(),
+                cell.n,
+                cell.accuracy(),
+                cell.mean_prompt_tokens()
+                    .map_or_else(|| "       —".to_string(), |t| format!("{t:>8}")),
+            );
+            if !category.is_adversarial() {
+                answerable.n += cell.n;
+                answerable.correct += cell.correct;
+                answerable.prompt_tokens += cell.prompt_tokens;
+                answerable.token_samples += cell.token_samples;
+            }
+        }
+        println!(
+            "  {:<12} {:>4}    {:>4.0}%    {}",
+            "answerable",
+            answerable.n,
+            answerable.accuracy(),
+            answerable
+                .mean_prompt_tokens()
+                .map_or_else(|| "       —".to_string(), |t| format!("{t:>8}")),
+        );
+        println!(
+            "  (acc = LLM-judge accuracy; adversarial acc = abstention rate, excluded from the\n   \
+answerable total; mean-prompt-tokens = Ollama's reported context size per live call, '—' when\n   \
+every answer in the row was served from cache, which carries no usage counters.)"
+        );
+    }
+}
+
+/// Build the full-context prompt and generate a concise answer. Uses the same
+/// [`judge::plain_answer_prompt`] the retrieval eval uses, so the baseline and
+/// the eval grade like-for-like — only the "facts" differ: here the entire
+/// dated conversation, not a budgeted pool.
+fn answer(
+    generator: &Generator,
+    context: &str,
+    question: &str,
+    claude: bool,
+) -> Result<(String, Option<crate::ollama_gen::TokenUsage>), Box<dyn Error>> {
+    let prompt = judge::plain_answer_prompt(context, question);
+    if claude {
+        Ok((generator.judge(&prompt)?, None))
+    } else {
+        generator.generate_full_ctx(&prompt, FULL_CTX_TOKENS)
+    }
+}
+
+/// Render the whole conversation as dated, speaker-attributed lines, oldest
+/// first — the "memory" the baseline answers from. Each line carries its
+/// session date so temporal questions are answerable in principle.
+fn conversation_context(sample: &Sample) -> String {
+    let mut lines = Vec::new();
+    for session in &sample.sessions {
+        let date = judge::fmt_date(session.date_key());
+        for turn in &session.turns {
+            match &date {
+                Some(date) => lines.push(format!("- [{date}] {}: {}", turn.speaker, turn.text)),
+                None => lines.push(format!("- {}: {}", turn.speaker, turn.text)),
+            }
+        }
+    }
+    lines.join("\n")
+}
+
+/// Conservative token estimate for the fit check, calibrated for the
+/// Latin-script `LoCoMo` corpus this harness targets: its dated lines measured
+/// ~2.9 chars/token, so dividing by a smaller 2.5 deliberately over-counts,
+/// biasing the guard toward refusing a borderline conversation rather than
+/// letting Ollama silently truncate it. Deterministic (no model call), so it
+/// holds on a fully-cached rerun that reports no usage. Note the char-based
+/// ratio would *under*-count heavily non-Latin text (CJK/emoji tokenize to
+/// more than one token per char); the guard is a safety net for this dataset,
+/// not a general cross-script bound.
+fn estimated_tokens(text: &str) -> u64 {
+    u64::try_from(text.chars().count()).unwrap_or(u64::MAX) * 2 / 5
+}
+
+/// Run the full-context baseline over the first `take` conversations. `only`
+/// restricts scoring to a single category (a cheap, targeted A/B run), matching
+/// the `--only` flag the retrieval eval honors.
+pub fn run(
+    generator: &Generator,
+    samples: &[Sample],
+    take: usize,
+    claude: ClaudeFlags,
+    max_qa: usize,
+    only: Option<Category>,
+) -> Result<(), Box<dyn Error>> {
+    let contexts: Vec<(&Sample, String)> = samples
+        .iter()
+        .take(take)
+        .map(|sample| (sample, conversation_context(sample)))
+        .collect();
+    // Pre-flight, before ANY generation: a conversation whose prompt would
+    // overflow the pinned window is silently truncated by Ollama, corrupting the
+    // ceiling. Catch every oversized conversation up front — deterministically,
+    // independent of the answer cache — so the run aborts before spending
+    // minutes generating the ones ahead of it, never folding a clipped answer
+    // into a table that still looks clean. Skipped under `--claude-gen`, where
+    // the Claude CLI answers and the local `num_ctx` never applies.
+    if !claude.gen {
+        ensure_all_fit(&contexts)?;
+    }
+    let mut report = FullContextReport::default();
+    for (position, (sample, context)) in contexts.iter().enumerate() {
+        let qa_take = crate::qa_limit(max_qa, sample.qa.len());
+        println!(
+            "[{}/{take}] {} — {} turns, {} QA (full context)",
+            position + 1,
+            sample.sample_id,
+            sample.turn_count(),
+            qa_take,
+        );
+        for qa in sample.qa.iter().take(qa_take) {
+            if only.is_some_and(|category| category != qa.category) {
+                continue;
+            }
+            report.record(generator, context, qa, claude)?;
+        }
+    }
+    report.print(generator, take, claude.gen);
+    Ok(())
+}
+
+/// Verify every conversation's whole-context prompt fits the pinned window
+/// before any generation runs, so an oversized conversation aborts the run up
+/// front instead of after the earlier conversations were already (expensively)
+/// generated. Deterministic, so it holds on a fully-cached rerun.
+fn ensure_all_fit(contexts: &[(&Sample, String)]) -> Result<(), Box<dyn Error>> {
+    for (sample, context) in contexts {
+        let needed = estimated_tokens(context) + RESPONSE_RESERVE_TOKENS;
+        if needed > FULL_CTX_TOKENS {
+            return Err(format!(
+                "conversation {} needs ~{needed} context tokens but num_ctx is \
+{FULL_CTX_TOKENS}; raise FULL_CTX_TOKENS (up to 262144) — note this rebinds the \
+generation cache key, so cached full-context answers will be regenerated",
+                sample.sample_id,
+            )
+            .into());
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+#[path = "full_context/full_context_tests.rs"]
+mod tests;

--- a/crates/velesdb-memory/examples/locomo/full_context/full_context_tests.rs
+++ b/crates/velesdb-memory/examples/locomo/full_context/full_context_tests.rs
@@ -1,0 +1,117 @@
+//! Unit tests for the full-context baseline's pure helpers (context assembly,
+//! tallying, percentage). The generation/judging paths need a live Ollama and
+//! are exercised by the benchmark run itself, not here.
+
+use super::{conversation_context, estimated_tokens, pct, Cell, FULL_CTX_TOKENS};
+use crate::dataset::{Sample, Session, Turn};
+
+fn turn(speaker: &str, text: &str) -> Turn {
+    Turn {
+        speaker: speaker.to_string(),
+        dia_id: "D1:1".to_string(),
+        text: text.to_string(),
+    }
+}
+
+fn sample_with(sessions: Vec<Session>) -> Sample {
+    Sample {
+        sample_id: "conv-test".to_string(),
+        sessions,
+        qa: Vec::new(),
+    }
+}
+
+#[test]
+fn conversation_context_dates_and_attributes_every_turn_in_order() {
+    let sample = sample_with(vec![
+        Session {
+            index: 0,
+            date_time: "1:56 pm on 8 May, 2023".to_string(),
+            turns: vec![turn("Alice", "hi"), turn("Bob", "hello")],
+        },
+        Session {
+            index: 1,
+            date_time: "9:00 am on 10 June, 2023".to_string(),
+            turns: vec![turn("Alice", "back")],
+        },
+    ]);
+    let context = conversation_context(&sample);
+    assert_eq!(
+        context,
+        "- [2023-05-08] Alice: hi\n\
+         - [2023-05-08] Bob: hello\n\
+         - [2023-06-10] Alice: back"
+    );
+}
+
+#[test]
+fn conversation_context_omits_the_date_prefix_when_the_session_date_is_unparseable() {
+    let sample = sample_with(vec![Session {
+        index: 0,
+        date_time: "sometime".to_string(),
+        turns: vec![turn("Alice", "hi")],
+    }]);
+    assert_eq!(conversation_context(&sample), "- Alice: hi");
+}
+
+#[test]
+fn pct_guards_a_zero_denominator() {
+    assert!((pct(0, 0) - 0.0).abs() < f64::EPSILON);
+    assert!((pct(3, 4) - 75.0).abs() < f64::EPSILON);
+}
+
+#[test]
+fn cell_accuracy_and_mean_tokens_track_recorded_answers() {
+    let mut cell = Cell::default();
+    cell.add(true, Some(1000));
+    cell.add(false, Some(2000));
+    cell.add(true, None); // a cache hit: no usage counters
+    assert_eq!(cell.n, 3);
+    assert_eq!(cell.correct, 2);
+    assert!((cell.accuracy() - (200.0 / 3.0)).abs() < 1e-9);
+    // Mean over the two live calls only; the cached one is not counted.
+    assert_eq!(cell.mean_prompt_tokens(), Some(1500));
+}
+
+#[test]
+fn cell_mean_tokens_is_none_when_every_answer_was_cached() {
+    let mut cell = Cell::default();
+    cell.add(true, None);
+    assert_eq!(cell.mean_prompt_tokens(), None);
+}
+
+#[test]
+fn estimated_tokens_over_counts_relative_to_length() {
+    assert_eq!(estimated_tokens(""), 0);
+    // ~2.5 chars/token: 100 chars -> 40 estimated tokens.
+    assert_eq!(estimated_tokens(&"x".repeat(100)), 40);
+}
+
+#[test]
+fn the_largest_expected_conversation_fits_the_pinned_window() {
+    // The biggest LoCoMo conversation is ~92.7k characters; the guard must
+    // admit it (estimate + response reserve stays under the window), so a
+    // real run never spuriously aborts on the shipped dataset.
+    let biggest_chars = "x".repeat(92_716);
+    assert!(estimated_tokens(&biggest_chars) + super::RESPONSE_RESERVE_TOKENS < FULL_CTX_TOKENS);
+}
+
+#[test]
+fn ensure_all_fit_accepts_a_normal_conversation_and_rejects_an_overflowing_one() {
+    let small = sample_with(vec![Session {
+        index: 0,
+        date_time: "1:56 pm on 8 May, 2023".to_string(),
+        turns: vec![turn("Alice", "hi")],
+    }]);
+    let small_ctx = conversation_context(&small);
+    assert!(super::ensure_all_fit(&[(&small, small_ctx)]).is_ok());
+
+    // A single turn far larger than the window must be refused up front.
+    let huge = sample_with(vec![Session {
+        index: 0,
+        date_time: "1:56 pm on 8 May, 2023".to_string(),
+        turns: vec![turn("Alice", &"word ".repeat(60_000))],
+    }]);
+    let huge_ctx = conversation_context(&huge);
+    assert!(super::ensure_all_fit(&[(&huge, huge_ctx)]).is_err());
+}

--- a/crates/velesdb-memory/examples/locomo/judge.rs
+++ b/crates/velesdb-memory/examples/locomo/judge.rs
@@ -12,7 +12,7 @@ use crate::dataset::Qa;
 use crate::ollama_gen::{Generator, TokenUsage};
 use crate::parse::{normalize, tokens};
 
-const ABSTAIN: &str = "NO_ANSWER";
+pub(crate) const ABSTAIN: &str = "NO_ANSWER";
 
 /// Generate a concise answer from the retrieved facts (each a `(YYYYMMDD ts,
 /// text)` pair), or the abstain token when the facts don't contain the answer.
@@ -82,12 +82,23 @@ FINAL: <answer in a few words>"
         let (raw, usage) = gen(generator, &prompt, claude_gen)?;
         return Ok((extract_final(&raw), usage));
     }
-    let prompt = format!(
+    gen(
+        generator,
+        &plain_answer_prompt(&context, question),
+        claude_gen,
+    )
+}
+
+/// The plain (no-scaffold, no-CoT) answer prompt: answer from the given facts,
+/// or emit [`ABSTAIN`]. Shared so the full-context baseline
+/// ([`crate::full_context`]) grades like-for-like with this retrieval eval —
+/// one prompt, so the two answerers cannot silently diverge.
+pub(crate) fn plain_answer_prompt(context: &str, question: &str) -> String {
+    format!(
         "Answer the question using ONLY the memory facts below. If the facts do \
 not contain the answer, reply exactly {ABSTAIN}. Be concise: a few words, no \
 explanation.\n\nFacts:\n{context}\n\nQuestion: {question}\nAnswer:"
-    );
-    gen(generator, &prompt, claude_gen)
+    )
 }
 
 /// Generate an answer with either the strong external model (Claude via CLI) or
@@ -119,7 +130,7 @@ fn extract_final(text: &str) -> String {
 
 /// Render a `YYYYMMDD` session key as `YYYY-MM-DD`, or `None` when unknown (0)
 /// or malformed, so an undated fact is shown without a misleading date prefix.
-fn fmt_date(ts: i64) -> Option<String> {
+pub(crate) fn fmt_date(ts: i64) -> Option<String> {
     let (year, month, day) = decompose_ymd(ts)?;
     Some(format!("{year:04}-{month:02}-{day:02}"))
 }

--- a/crates/velesdb-memory/examples/locomo/main.rs
+++ b/crates/velesdb-memory/examples/locomo/main.rs
@@ -13,6 +13,10 @@
 //! # LLM-free explanation benchmark (does the graph connect scattered evidence?):
 //! cargo run --release -p velesdb-memory --features ollama --example locomo -- --explanation
 //!
+//! # Full-context baseline (whole conversation, no retrieval) — the local
+//! # ceiling our budgeted retrieval trades tokens against:
+//! cargo run --release -p velesdb-memory --features ollama --example locomo -- --full-context
+//!
 //! # LLM-free reproduction: does the SHIPPED recall_fused reproduce the fused
 //! # retrieval? Compare the harness fusion against the installed API on the same
 //! # data (single-seed, no BM25, idf-weighted to match recall_fused):
@@ -48,6 +52,7 @@ mod dump;
 mod eval;
 mod explain;
 mod extract;
+mod full_context;
 mod ingest;
 mod judge;
 mod ollama_gen;
@@ -72,6 +77,9 @@ use report::Report;
 use retrieval::RetrievalReport;
 
 /// Parsed command-line configuration.
+// The flags are independent CLI switches (run modes + ablation knobs), not a
+// state machine — the same reason `EvalCfg` carries this allow.
+#[allow(clippy::struct_excessive_bools)]
 struct Args {
     dataset: PathBuf,
     conversations: usize,
@@ -83,6 +91,9 @@ struct Args {
     retrieval: bool,
     /// Run the LLM-free extraction-vs-retrieval coverage diagnosis.
     diagnose: bool,
+    /// Run the full-context baseline (whole conversation, no retrieval) — the
+    /// reporting-standard local ceiling.
+    full_context: bool,
     /// Extraction prompt version: 1 (topics) or 2 (specific referents).
     extract_version: u8,
     /// Restrict the QA eval to one category (cheap, targeted A/B runs).
@@ -107,6 +118,19 @@ fn main() -> Result<(), Box<dyn Error>> {
         run_retrieval(&generator, &samples, take, &args)
     } else if args.explanation {
         run_explanation(&generator, &samples, take, &args)
+    } else if args.full_context {
+        let claude = full_context::ClaudeFlags {
+            gen: args.cfg.claude_gen,
+            judge: args.cfg.claude_judge,
+        };
+        full_context::run(
+            &generator,
+            &samples,
+            take,
+            claude,
+            args.max_qa,
+            args.only_category,
+        )
     } else {
         run_eval(&generator, &samples, take, &args)
     }
@@ -410,6 +434,7 @@ impl Default for Args {
             explanation: false,
             retrieval: false,
             diagnose: false,
+            full_context: false,
             extract_version: 1,
             only_category: None,
             embed_model: DEFAULT_OLLAMA_MODEL.to_string(),
@@ -475,6 +500,7 @@ impl Args {
             "--explanation" => &mut self.explanation,
             "--retrieval" => &mut self.retrieval,
             "--diagnose" => &mut self.diagnose,
+            "--full-context" => &mut self.full_context,
             "--multihop-only" => &mut self.cfg.multihop_only,
             "--idf-weight" => &mut self.cfg.idf_weight,
             "--date-context" => &mut self.cfg.date_context,

--- a/crates/velesdb-memory/examples/locomo/ollama_gen.rs
+++ b/crates/velesdb-memory/examples/locomo/ollama_gen.rs
@@ -89,14 +89,35 @@ impl Generator {
         &self,
         prompt: &str,
     ) -> Result<(String, Option<TokenUsage>), Box<dyn Error>> {
-        let key = self.key(prompt);
+        self.generate_ctx(prompt, None)
+    }
+
+    /// Like [`Self::generate_traced`], but pins Ollama's context window to
+    /// `num_ctx` tokens for this call — needed by the full-context baseline,
+    /// whose whole-conversation prompt overflows Ollama's small default window
+    /// (a silent truncation there would invalidate the ceiling it measures).
+    pub fn generate_full_ctx(
+        &self,
+        prompt: &str,
+        num_ctx: u64,
+    ) -> Result<(String, Option<TokenUsage>), Box<dyn Error>> {
+        self.generate_ctx(prompt, Some(num_ctx))
+    }
+
+    /// Cache-then-call core shared by the default and pinned-context entries.
+    fn generate_ctx(
+        &self,
+        prompt: &str,
+        num_ctx: Option<u64>,
+    ) -> Result<(String, Option<TokenUsage>), Box<dyn Error>> {
+        let key = self.key_ctx(prompt, num_ctx);
         let path = self.cache_dir.join(format!("{key}.txt"));
         if let Ok(cached) = fs::read_to_string(&path) {
             if !cached.trim().is_empty() {
                 return Ok((cached, None));
             }
         }
-        let reply = self.call(prompt)?;
+        let reply = self.call(prompt, num_ctx)?;
         if !reply.text.trim().is_empty() {
             self.store(&key, &path, &reply.text)?;
         }
@@ -123,13 +144,17 @@ impl Generator {
     /// any usage counters. The body is serialised with `serde_json` and sent as
     /// a raw string so the crate's `ureq` can keep `default-features = false`
     /// (no bundled TLS/json), leaving the shipped server binary tiny.
-    fn call(&self, prompt: &str) -> Result<GenReply, Box<dyn Error>> {
+    fn call(&self, prompt: &str, num_ctx: Option<u64>) -> Result<GenReply, Box<dyn Error>> {
+        let mut options = serde_json::json!({ "temperature": 0 });
+        if let Some(tokens) = num_ctx {
+            options["num_ctx"] = serde_json::json!(tokens);
+        }
         let body = serde_json::json!({
             "model": self.model,
             "prompt": prompt,
             "stream": false,
             "think": false,
-            "options": { "temperature": 0 },
+            "options": options,
         })
         .to_string();
         let mut last: Box<dyn Error> = "no attempt made".into();
@@ -209,6 +234,23 @@ impl Generator {
     /// Content-addressed cache key over the local model + prompt.
     fn key(&self, prompt: &str) -> String {
         self.key_for(&self.model, prompt)
+    }
+
+    /// Cache key that also binds the pinned context window, so a prompt
+    /// generated at one `num_ctx` is never served to a call that asked for a
+    /// different one (a smaller window silently truncates — exactly what the
+    /// full-context baseline must not do). `None` keeps the plain model+prompt
+    /// key, leaving every existing default-window cache entry valid.
+    fn key_ctx(&self, prompt: &str, num_ctx: Option<u64>) -> String {
+        let Some(tokens) = num_ctx else {
+            return self.key(prompt);
+        };
+        let mut hash = fnv1a(self.model.as_bytes());
+        hash = fnv1a_continue(hash, b"\0num_ctx\0");
+        hash = fnv1a_continue(hash, &tokens.to_le_bytes());
+        hash = fnv1a_continue(hash, b"\0");
+        hash = fnv1a_continue(hash, prompt.as_bytes());
+        format!("{hash:016x}")
     }
 
     /// Content-addressed cache key over an explicit `model` + prompt, so callers

--- a/crates/velesdb-memory/examples/locomo/report.rs
+++ b/crates/velesdb-memory/examples/locomo/report.rs
@@ -157,7 +157,7 @@ fn answerable(cells: &[Cell; 5]) -> Cell {
 }
 
 /// Percentage with a guarded zero denominator.
-fn pct(num: u32, den: u32) -> f64 {
+pub(crate) fn pct(num: u32, den: u32) -> f64 {
     if den == 0 {
         return 0.0;
     }


### PR DESCRIPTION
## What

Adds a `--full-context` mode to the LoCoMo benchmark harness. For each
question it feeds the **entire dated conversation** to the generator — no
retrieval, no budget, nothing dropped — and scores answers with the exact same
LLM-judge / abstention path the retrieval eval uses, so the two numbers land on
one scale.

This is the reporting-standard **local ceiling**: the accuracy a long-context
model reaches when it has everything, and the token cost that budgeted
retrieval trades that ceiling against. Publishing it is table stakes for an
honest benchmark — omitting the full-context baseline reads as cherry-picking.

## Result (10 conversations, qwen3.6:35b-mlx generator + local judge, `num_ctx=49152`)

| category | n | acc |
|---|---|---|
| multi-hop | 282 | 61% |
| temporal | 321 | 37% |
| open-domain | 96 | 27% |
| single-hop | 841 | 85% |
| adversarial | 446 | 76% (abstention) |
| **answerable** | **1540** | **67%** |

Mean prompt size ≈ **29k tokens/question**.

**The honest reading:** full-context (67%) sits above our budgeted retrieval
(45–53% answerable on the shipped path) — but it pays ~29k tokens *per question*
versus ~1–2k for a `recall_fused` top-k. That is the accuracy-vs-cost trade the
memory layer exists to make (≈15–30× fewer tokens for a bounded accuracy give-up),
now measured rather than asserted. Note temporal is low here (37%) because this
run uses the local judge and no dated-context scaffold; the dated-context lever
(already shipped) is what lifts temporal, and is a separate axis from this
ceiling.

## Implementation notes

- **`num_ctx` pinning** (`ollama_gen`): the whole-conversation prompt overflows
  Ollama's small default window, so the full-context call pins `num_ctx`. The
  on-disk generation cache key now **binds `num_ctx`**, so a pinned-context call
  can never be served an answer that was produced at a different (truncated)
  window. Default-window callers keep their existing cache keys.
- **`num_ctx = 49152`**: the dated `- [YYYY-MM-DD] Speaker: text` lines run
  ~2.9 chars/token, so prompts average ~29k and the largest conversation
  reaches the low-30k range; 49152 seats every one with headroom (verified: no
  prompt fills the window).
- **Deterministic pre-flight truncation guard** (`run`): before scoring a
  conversation, an estimated token count (`chars × 2/5`, conservative vs the
  measured ~2.9 chars/token) plus a response reserve is checked against the
  window; if it would not fit, the run **aborts with an actionable message**
  rather than let Ollama silently clip the context and report a ceiling that
  looks clean. Being deterministic, the guard holds on a fully-cached rerun
  (where Ollama reports no usage).
- Reuses `judge::ABSTAIN` and `report::pct` instead of re-declaring them; a
  live call with no reported usage prints `—` (not a misleading `(cached)`);
  the provenance header does not claim `num_ctx` when `--claude-gen` answers.
- `--only <category>` works for cheap targeted A/B runs.

## Verification

- clippy `-D warnings -D clippy::pedantic` clean; 7 unit tests (separate file).
- **4 adversarial `/code-review` passes** to 0 findings (~11 real defects fixed
  cumulatively — cache-key/`num_ctx` binding, a mislabeled token column, a
  dropped `--only` filter, and the truncation-guard rework that motivated the
  final deterministic pre-flight design).
- Full 10-conversation run completed end-to-end; `num_ctx=49152` confirmed
  sufficient (zero truncation warnings).

Example/benchmark harness code only — no shipped library surface changes.
