### PR TITLE
fix(server): u64 IDs precision-safe on the REST spec + bulk-delete input

### DIFF
--- a/crates/velesdb-core/src/api_types/responses.rs
+++ b/crates/velesdb-core/src/api_types/responses.rs
@@ -323,6 +323,24 @@ pub struct ListIndexesResponse {
 // Scroll Responses
 // ============================================================================
 
+/// `OpenAPI` schema for the scroll `cursor` input: an integer-or-string ID
+/// (precision-safe) that keeps the cursor-specific "resume after" semantics
+/// rather than the generic point-ID description.
+#[cfg(feature = "openapi")]
+fn scroll_cursor_schema() -> utoipa::openapi::schema::OneOfBuilder {
+    use utoipa::openapi::schema::{ObjectBuilder, Type};
+    // `cursor` is `Option<u64>`: the deserializer accepts an integer, a
+    // precision-safe string, or `null` (= start from the beginning). The
+    // `null` branch keeps the spec in step with that leniency.
+    serde_id::id_oneof()
+        .item(ObjectBuilder::new().schema_type(Type::Null))
+        .description(Some(
+            "Resume after this point ID (exclusive). Omit or send null to \
+             start from the beginning. Accepts a JSON integer or a \
+             precision-safe string.",
+        ))
+}
+
 /// Request body for the scroll endpoint.
 #[derive(Debug, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
@@ -332,6 +350,7 @@ pub struct ScrollRequest {
         default,
         deserialize_with = "serde_id::deserialize_option_id_from_string_or_number"
     )]
+    #[cfg_attr(feature = "openapi", schema(schema_with = scroll_cursor_schema))]
     pub cursor: Option<u64>,
     /// Maximum points per batch (1–10 000, default 100).
     #[serde(default = "default_scroll_batch_size")]
@@ -357,6 +376,7 @@ pub struct ScrollResponse {
         serialize_with = "serde_id::serialize_option_id_as_string",
         deserialize_with = "serde_id::deserialize_option_id_from_string_or_number"
     )]
+    #[cfg_attr(feature = "openapi", schema(value_type = Option<String>))]
     pub next_cursor: Option<u64>,
 }
 

--- a/crates/velesdb-core/src/api_types/serde_id.rs
+++ b/crates/velesdb-core/src/api_types/serde_id.rs
@@ -74,16 +74,32 @@ pub fn id_input_schema() -> utoipa::openapi::schema::OneOfBuilder {
 ///
 /// An ID is emitted as a string on the wire (precision-safe) but accepted as
 /// either an integer or a string on input.
+///
+/// `u64` has no exact `OpenAPI` primitive, so the two branches are deliberately
+/// asymmetric and the exact bound is enforced server-side (`parse::<u64>`):
+/// the integer branch is `int64`/`minimum: 0` (the JS-safe native form; values
+/// above `i64::MAX` must use the string branch, which is precisely why the
+/// string form exists), and the string branch is `^[0-9]+$` — permissive at
+/// the very top of the range (a >`u64::MAX` digit string is rejected at
+/// runtime) rather than an unreadable exact-max regex. This mirrors the
+/// protobuf/Google-JSON convention of carrying 64-bit ints as strings.
 #[cfg(feature = "openapi")]
-fn id_oneof() -> utoipa::openapi::schema::OneOfBuilder {
+pub(crate) fn id_oneof() -> utoipa::openapi::schema::OneOfBuilder {
     use utoipa::openapi::schema::{KnownFormat, ObjectBuilder, OneOfBuilder, SchemaFormat, Type};
     OneOfBuilder::new()
         .item(
             ObjectBuilder::new()
                 .schema_type(Type::Integer)
-                .format(Some(SchemaFormat::KnownFormat(KnownFormat::Int64))),
+                .format(Some(SchemaFormat::KnownFormat(KnownFormat::Int64)))
+                // IDs are `u64`; the native-integer branch is non-negative.
+                .minimum(Some(0.0)),
         )
-        .item(ObjectBuilder::new().schema_type(Type::String))
+        .item(
+            ObjectBuilder::new()
+                .schema_type(Type::String)
+                // The string branch carries the decimal digits of a `u64`.
+                .pattern(Some("^[0-9]+$")),
+        )
 }
 
 /// `OpenAPI` schema for an array of IDs whose elements accept an integer or a
@@ -94,7 +110,13 @@ fn id_oneof() -> utoipa::openapi::schema::OneOfBuilder {
 #[cfg(feature = "openapi")]
 #[must_use]
 pub fn ids_array_schema() -> utoipa::openapi::schema::ArrayBuilder {
-    utoipa::openapi::schema::ArrayBuilder::new().items(id_oneof())
+    utoipa::openapi::schema::ArrayBuilder::new()
+        .items(id_oneof())
+        .description(Some(
+            "Point IDs. Each accepts a JSON integer (native form) or a string; \
+             use a string for u64 values above 2^53-1 to avoid JavaScript \
+             precision loss.",
+        ))
 }
 
 /// `OpenAPI` schema for a map whose values are IDs accepting an integer or a

--- a/crates/velesdb-server/src/handlers/graph/handlers.rs
+++ b/crates/velesdb-server/src/handlers/graph/handlers.rs
@@ -322,7 +322,7 @@ pub async fn traverse_graph(
     path = "/collections/{name}/graph/nodes/{node_id}/degree",
     params(
         ("name" = String, Path, description = "Collection name"),
-        ("node_id" = u64, Path, description = "Node ID")
+        ("node_id" = String, Path, description = "Node ID (u64 as a string; precision-safe above 2^53-1)", pattern = "^[0-9]+$")
     ),
     responses(
         (status = 200, description = "Degree retrieved successfully", body = DegreeResponse),

--- a/crates/velesdb-server/src/handlers/graph/handlers_extended.rs
+++ b/crates/velesdb-server/src/handlers/graph/handlers_extended.rs
@@ -28,7 +28,7 @@ use super::types::{
     path = "/collections/{name}/graph/edges/{edge_id}",
     params(
         ("name" = String, Path, description = "Collection name"),
-        ("edge_id" = u64, Path, description = "Edge ID to remove")
+        ("edge_id" = String, Path, description = "Edge ID to remove (u64 as a string; precision-safe above 2^53-1)", pattern = "^[0-9]+$")
     ),
     responses(
         (status = 204, description = "Edge removed successfully"),
@@ -113,7 +113,7 @@ pub async fn list_nodes(
     path = "/collections/{name}/graph/nodes/{node_id}/edges",
     params(
         ("name" = String, Path, description = "Collection name"),
-        ("node_id" = u64, Path, description = "Node ID"),
+        ("node_id" = String, Path, description = "Node ID (u64 as a string; precision-safe above 2^53-1)", pattern = "^[0-9]+$"),
         NodeEdgeQueryParams
     ),
     responses(
@@ -166,7 +166,7 @@ pub async fn get_node_edges(
     path = "/collections/{name}/graph/nodes/{node_id}/payload",
     params(
         ("name" = String, Path, description = "Collection name"),
-        ("node_id" = u64, Path, description = "Node ID")
+        ("node_id" = String, Path, description = "Node ID (u64 as a string; precision-safe above 2^53-1)", pattern = "^[0-9]+$")
     ),
     request_body = UpsertNodePayloadRequest,
     responses(
@@ -201,7 +201,7 @@ pub async fn upsert_node_payload(
     path = "/collections/{name}/graph/nodes/{node_id}/payload",
     params(
         ("name" = String, Path, description = "Collection name"),
-        ("node_id" = u64, Path, description = "Node ID")
+        ("node_id" = String, Path, description = "Node ID (u64 as a string; precision-safe above 2^53-1)", pattern = "^[0-9]+$")
     ),
     responses(
         (status = 200, description = "Payload retrieved", body = NodePayloadResponse),

--- a/crates/velesdb-server/src/handlers/graph/types.rs
+++ b/crates/velesdb-server/src/handlers/graph/types.rs
@@ -277,7 +277,7 @@ pub struct GraphSearchResultItem {
 pub struct StreamTraverseParams {
     /// Source node ID to start traversal from.
     #[serde(deserialize_with = "serde_id::deserialize_id_from_string_or_number")]
-    #[param(example = 123)]
+    #[param(value_type = String, example = "123", pattern = "^[0-9]+$")]
     pub start_node: u64,
     /// Traversal algorithm: "bfs" or "dfs".
     #[serde(default = "default_algorithm")]

--- a/crates/velesdb-server/src/handlers/points/mod.rs
+++ b/crates/velesdb-server/src/handlers/points/mod.rs
@@ -24,6 +24,7 @@ use crate::types::{
     UpsertPointsRequest,
 };
 use crate::AppState;
+use velesdb_core::api_types::serde_id;
 use velesdb_core::Point;
 
 use crate::handlers::helpers::{
@@ -190,7 +191,7 @@ fn build_points_from_request(req: UpsertPointsRequest) -> Result<Vec<Point>, Str
     tag = "points",
     params(
         ("name" = String, Path, description = "Collection name"),
-        ("id" = u64, Path, description = "Point ID")
+        ("id" = String, Path, description = "Point ID (u64 as a string; precision-safe above 2^53-1)", pattern = "^[0-9]+$")
     ),
     responses(
         (status = 200, description = "Point found", body = Object),
@@ -229,7 +230,7 @@ pub async fn get_point(
     tag = "points",
     params(
         ("name" = String, Path, description = "Collection name"),
-        ("id" = u64, Path, description = "Point ID")
+        ("id" = String, Path, description = "Point ID (u64 as a string; precision-safe above 2^53-1)", pattern = "^[0-9]+$")
     ),
     responses(
         (status = 200, description = "Point deleted", body = Object),
@@ -350,6 +351,8 @@ const MAX_BULK_DELETE_SIZE: usize = 10_000;
 #[derive(serde::Deserialize, utoipa::ToSchema)]
 pub struct BulkDeleteRequest {
     /// List of point IDs to delete.
+    #[serde(deserialize_with = "serde_id::deserialize_ids_from_string_or_number")]
+    #[cfg_attr(feature = "openapi", schema(schema_with = serde_id::ids_array_schema))]
     pub ids: Vec<u64>,
 }
 

--- a/crates/velesdb-server/src/handlers/points/relations.rs
+++ b/crates/velesdb-server/src/handlers/points/relations.rs
@@ -194,7 +194,7 @@ fn insert_edge_with_retry(
     path = "/collections/{name}/relations/{edge_id}",
     params(
         ("name" = String, Path, description = "Collection name"),
-        ("edge_id" = u64, Path, description = "Edge ID to remove")
+        ("edge_id" = String, Path, description = "Edge ID to remove (u64 as a string; precision-safe above 2^53-1)", pattern = "^[0-9]+$")
     ),
     responses(
         (status = 204, description = "Relation removed"),
@@ -233,7 +233,7 @@ pub async fn unrelate_points(
     path = "/collections/{name}/points/{id}/relations",
     params(
         ("name" = String, Path, description = "Collection name"),
-        ("id" = u64, Path, description = "Point ID")
+        ("id" = String, Path, description = "Point ID (u64 as a string; precision-safe above 2^53-1)", pattern = "^[0-9]+$")
     ),
     responses(
         (status = 200, description = "Outgoing relations", body = RelationsResponse),
@@ -278,7 +278,7 @@ pub async fn get_point_relations(
     path = "/collections/{name}/points/{id}/ttl",
     params(
         ("name" = String, Path, description = "Collection name"),
-        ("id" = u64, Path, description = "Point ID")
+        ("id" = String, Path, description = "Point ID (u64 as a string; precision-safe above 2^53-1)", pattern = "^[0-9]+$")
     ),
     request_body = SetTtlRequest,
     responses(

--- a/crates/velesdb-server/tests/admin_endpoints_bdd_tests.rs
+++ b/crates/velesdb-server/tests/admin_endpoints_bdd_tests.rs
@@ -127,6 +127,32 @@ async fn bulk_delete_nominal_returns_200_with_deleted_count() {
 }
 
 #[tokio::test]
+async fn bulk_delete_accepts_string_ids_for_js_precision_safety() {
+    // IDs are emitted as JSON strings on every read surface (precision-safe
+    // above 2^53-1); bulk delete must therefore accept the string form a JS
+    // client echoes back — not just native integers. See `serde_id`.
+    let temp_dir = TempDir::new().expect("test: temp dir");
+    let app = create_test_app(&temp_dir);
+    seed_collection(app.clone(), 5).await;
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/collections/{TEST_COLLECTION}/points/delete"))
+                .header("Content-Type", "application/json")
+                .body(Body::from(json!({ "ids": ["1", "2", "3"] }).to_string()))
+                .expect("test: build delete request"),
+        )
+        .await
+        .expect("test: delete request");
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let json = read_json(response).await;
+    assert_eq!(json["deleted_count"], 3);
+}
+
+#[tokio::test]
 async fn bulk_delete_empty_payload_returns_200_noop() {
     // Documented behaviour: empty `ids: []` is a no-op (200, count=0).
     // See `bulk_delete_points` rustdoc — idempotent batch semantics.

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -777,12 +777,11 @@
           {
             "name": "edge_id",
             "in": "path",
-            "description": "Edge ID to remove",
+            "description": "Edge ID to remove (u64 as a string; precision-safe above 2^53-1)",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int64",
-              "minimum": 0
+              "type": "string",
+              "pattern": "^[0-9]+$"
             }
           }
         ],
@@ -875,12 +874,11 @@
           {
             "name": "node_id",
             "in": "path",
-            "description": "Node ID",
+            "description": "Node ID (u64 as a string; precision-safe above 2^53-1)",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int64",
-              "minimum": 0
+              "type": "string",
+              "pattern": "^[0-9]+$"
             }
           }
         ],
@@ -938,12 +936,11 @@
           {
             "name": "node_id",
             "in": "path",
-            "description": "Node ID",
+            "description": "Node ID (u64 as a string; precision-safe above 2^53-1)",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int64",
-              "minimum": 0
+              "type": "string",
+              "pattern": "^[0-9]+$"
             }
           },
           {
@@ -1014,12 +1011,11 @@
           {
             "name": "node_id",
             "in": "path",
-            "description": "Node ID",
+            "description": "Node ID (u64 as a string; precision-safe above 2^53-1)",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int64",
-              "minimum": 0
+              "type": "string",
+              "pattern": "^[0-9]+$"
             }
           }
         ],
@@ -1075,12 +1071,11 @@
           {
             "name": "node_id",
             "in": "path",
-            "description": "Node ID",
+            "description": "Node ID (u64 as a string; precision-safe above 2^53-1)",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int64",
-              "minimum": 0
+              "type": "string",
+              "pattern": "^[0-9]+$"
             }
           }
         ],
@@ -1348,11 +1343,10 @@
             "description": "Source node ID to start traversal from.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int64",
-              "minimum": 0
+              "type": "string",
+              "pattern": "^[0-9]+$"
             },
-            "example": 123
+            "example": "123"
           },
           {
             "name": "algorithm",
@@ -2084,12 +2078,11 @@
           {
             "name": "id",
             "in": "path",
-            "description": "Point ID",
+            "description": "Point ID (u64 as a string; precision-safe above 2^53-1)",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int64",
-              "minimum": 0
+              "type": "string",
+              "pattern": "^[0-9]+$"
             }
           }
         ],
@@ -2135,12 +2128,11 @@
           {
             "name": "id",
             "in": "path",
-            "description": "Point ID",
+            "description": "Point ID (u64 as a string; precision-safe above 2^53-1)",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int64",
-              "minimum": 0
+              "type": "string",
+              "pattern": "^[0-9]+$"
             }
           }
         ],
@@ -2188,12 +2180,11 @@
           {
             "name": "id",
             "in": "path",
-            "description": "Point ID",
+            "description": "Point ID (u64 as a string; precision-safe above 2^53-1)",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int64",
-              "minimum": 0
+              "type": "string",
+              "pattern": "^[0-9]+$"
             }
           }
         ],
@@ -2252,12 +2243,11 @@
           {
             "name": "id",
             "in": "path",
-            "description": "Point ID",
+            "description": "Point ID (u64 as a string; precision-safe above 2^53-1)",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int64",
-              "minimum": 0
+              "type": "string",
+              "pattern": "^[0-9]+$"
             }
           }
         ],
@@ -2401,12 +2391,11 @@
           {
             "name": "edge_id",
             "in": "path",
-            "description": "Edge ID to remove",
+            "description": "Edge ID to remove (u64 as a string; precision-safe above 2^53-1)",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int64",
-              "minimum": 0
+              "type": "string",
+              "pattern": "^[0-9]+$"
             }
           }
         ],
@@ -3451,10 +3440,12 @@
             "oneOf": [
               {
                 "type": "integer",
-                "format": "int64"
+                "format": "int64",
+                "minimum": 0
               },
               {
-                "type": "string"
+                "type": "string",
+                "pattern": "^[0-9]+$"
               }
             ],
             "description": "Point ID. Accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss."
@@ -3470,10 +3461,12 @@
             "oneOf": [
               {
                 "type": "integer",
-                "format": "int64"
+                "format": "int64",
+                "minimum": 0
               },
               {
-                "type": "string"
+                "type": "string",
+                "pattern": "^[0-9]+$"
               }
             ],
             "description": "Point ID. Accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss."
@@ -3482,10 +3475,12 @@
             "oneOf": [
               {
                 "type": "integer",
-                "format": "int64"
+                "format": "int64",
+                "minimum": 0
               },
               {
-                "type": "string"
+                "type": "string",
+                "pattern": "^[0-9]+$"
               }
             ],
             "description": "Point ID. Accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss."
@@ -3593,11 +3588,19 @@
           "ids": {
             "type": "array",
             "items": {
-              "type": "integer",
-              "format": "int64",
-              "minimum": 0
+              "oneOf": [
+                {
+                  "type": "integer",
+                  "format": "int64",
+                  "minimum": 0
+                },
+                {
+                  "type": "string",
+                  "pattern": "^[0-9]+$"
+                }
+              ]
             },
-            "description": "List of point IDs to delete."
+            "description": "Point IDs. Each accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss."
           }
         }
       },
@@ -4912,10 +4915,12 @@
               "oneOf": [
                 {
                   "type": "integer",
-                  "format": "int64"
+                  "format": "int64",
+                  "minimum": 0
                 },
                 {
-                  "type": "string"
+                  "type": "string",
+                  "pattern": "^[0-9]+$"
                 }
               ]
             }
@@ -5042,13 +5047,16 @@
               "oneOf": [
                 {
                   "type": "integer",
-                  "format": "int64"
+                  "format": "int64",
+                  "minimum": 0
                 },
                 {
-                  "type": "string"
+                  "type": "string",
+                  "pattern": "^[0-9]+$"
                 }
               ]
-            }
+            },
+            "description": "Point IDs. Each accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss."
           }
         }
       },
@@ -5144,13 +5152,16 @@
               "oneOf": [
                 {
                   "type": "integer",
-                  "format": "int64"
+                  "format": "int64",
+                  "minimum": 0
                 },
                 {
-                  "type": "string"
+                  "type": "string",
+                  "pattern": "^[0-9]+$"
                 }
               ]
-            }
+            },
+            "description": "Point IDs. Each accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss."
           }
         }
       },
@@ -5166,10 +5177,12 @@
             "oneOf": [
               {
                 "type": "integer",
-                "format": "int64"
+                "format": "int64",
+                "minimum": 0
               },
               {
-                "type": "string"
+                "type": "string",
+                "pattern": "^[0-9]+$"
               }
             ],
             "description": "Point ID. Accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss."
@@ -5358,10 +5371,12 @@
             "oneOf": [
               {
                 "type": "integer",
-                "format": "int64"
+                "format": "int64",
+                "minimum": 0
               },
               {
-                "type": "string"
+                "type": "string",
+                "pattern": "^[0-9]+$"
               }
             ],
             "description": "Point ID. Accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss."
@@ -5370,10 +5385,12 @@
             "oneOf": [
               {
                 "type": "integer",
-                "format": "int64"
+                "format": "int64",
+                "minimum": 0
               },
               {
-                "type": "string"
+                "type": "string",
+                "pattern": "^[0-9]+$"
               }
             ],
             "description": "Point ID. Accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss."
@@ -5483,13 +5500,21 @@
             "minimum": 0
           },
           "cursor": {
-            "type": [
-              "integer",
-              "null"
+            "oneOf": [
+              {
+                "type": "integer",
+                "format": "int64",
+                "minimum": 0
+              },
+              {
+                "type": "string",
+                "pattern": "^[0-9]+$"
+              },
+              {
+                "type": "null"
+              }
             ],
-            "format": "int64",
-            "description": "Resume after this point ID (exclusive). Omit to start from beginning.",
-            "minimum": 0
+            "description": "Resume after this point ID (exclusive). Omit or send null to start from the beginning. Accepts a JSON integer or a precision-safe string."
           },
           "filter": {
             "description": "Optional filter expression."
@@ -5505,12 +5530,10 @@
         "properties": {
           "next_cursor": {
             "type": [
-              "integer",
+              "string",
               "null"
             ],
-            "format": "int64",
-            "description": "Cursor for the next batch. Null when iteration is complete.",
-            "minimum": 0
+            "description": "Cursor for the next batch. Null when iteration is complete."
           },
           "points": {
             "type": "array",
@@ -5772,10 +5795,12 @@
             "oneOf": [
               {
                 "type": "integer",
-                "format": "int64"
+                "format": "int64",
+                "minimum": 0
               },
               {
-                "type": "string"
+                "type": "string",
+                "pattern": "^[0-9]+$"
               }
             ],
             "description": "Point ID. Accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss."
@@ -5818,13 +5843,16 @@
               "oneOf": [
                 {
                   "type": "integer",
-                  "format": "int64"
+                  "format": "int64",
+                  "minimum": 0
                 },
                 {
-                  "type": "string"
+                  "type": "string",
+                  "pattern": "^[0-9]+$"
                 }
               ]
-            }
+            },
+            "description": "Point IDs. Each accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss."
           }
         }
       },
@@ -5901,13 +5929,16 @@
               "oneOf": [
                 {
                   "type": "integer",
-                  "format": "int64"
+                  "format": "int64",
+                  "minimum": 0
                 },
                 {
-                  "type": "string"
+                  "type": "string",
+                  "pattern": "^[0-9]+$"
                 }
               ]
-            }
+            },
+            "description": "Point IDs. Each accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss."
           },
           "target_id": {
             "type": "string",
@@ -5965,10 +5996,12 @@
             "oneOf": [
               {
                 "type": "integer",
-                "format": "int64"
+                "format": "int64",
+                "minimum": 0
               },
               {
-                "type": "string"
+                "type": "string",
+                "pattern": "^[0-9]+$"
               }
             ],
             "description": "Point ID. Accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss."

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -487,12 +487,11 @@ paths:
           type: string
       - name: edge_id
         in: path
-        description: Edge ID to remove
+        description: Edge ID to remove (u64 as a string; precision-safe above 2^53-1)
         required: true
         schema:
-          type: integer
-          format: int64
-          minimum: 0
+          type: string
+          pattern: ^[0-9]+$
       responses:
         '204':
           description: Edge removed successfully
@@ -549,12 +548,11 @@ paths:
           type: string
       - name: node_id
         in: path
-        description: Node ID
+        description: Node ID (u64 as a string; precision-safe above 2^53-1)
         required: true
         schema:
-          type: integer
-          format: int64
-          minimum: 0
+          type: string
+          pattern: ^[0-9]+$
       responses:
         '200':
           description: Degree retrieved successfully
@@ -589,12 +587,11 @@ paths:
           type: string
       - name: node_id
         in: path
-        description: Node ID
+        description: Node ID (u64 as a string; precision-safe above 2^53-1)
         required: true
         schema:
-          type: integer
-          format: int64
-          minimum: 0
+          type: string
+          pattern: ^[0-9]+$
       - name: direction
         in: query
         description: 'Filter by direction: "in", "out", or "both".'
@@ -639,12 +636,11 @@ paths:
           type: string
       - name: node_id
         in: path
-        description: Node ID
+        description: Node ID (u64 as a string; precision-safe above 2^53-1)
         required: true
         schema:
-          type: integer
-          format: int64
-          minimum: 0
+          type: string
+          pattern: ^[0-9]+$
       responses:
         '200':
           description: Payload retrieved
@@ -678,12 +674,11 @@ paths:
           type: string
       - name: node_id
         in: path
-        description: Node ID
+        description: Node ID (u64 as a string; precision-safe above 2^53-1)
         required: true
         schema:
-          type: integer
-          format: int64
-          minimum: 0
+          type: string
+          pattern: ^[0-9]+$
       requestBody:
         content:
           application/json:
@@ -852,10 +847,9 @@ paths:
         description: Source node ID to start traversal from.
         required: true
         schema:
-          type: integer
-          format: int64
-          minimum: 0
-        example: 123
+          type: string
+          pattern: ^[0-9]+$
+        example: '123'
       - name: algorithm
         in: query
         description: 'Traversal algorithm: "bfs" or "dfs".'
@@ -1379,12 +1373,11 @@ paths:
           type: string
       - name: id
         in: path
-        description: Point ID
+        description: Point ID (u64 as a string; precision-safe above 2^53-1)
         required: true
         schema:
-          type: integer
-          format: int64
-          minimum: 0
+          type: string
+          pattern: ^[0-9]+$
       responses:
         '200':
           description: Point found
@@ -1412,12 +1405,11 @@ paths:
           type: string
       - name: id
         in: path
-        description: Point ID
+        description: Point ID (u64 as a string; precision-safe above 2^53-1)
         required: true
         schema:
-          type: integer
-          format: int64
-          minimum: 0
+          type: string
+          pattern: ^[0-9]+$
       responses:
         '200':
           description: Point deleted
@@ -1446,12 +1438,11 @@ paths:
           type: string
       - name: id
         in: path
-        description: Point ID
+        description: Point ID (u64 as a string; precision-safe above 2^53-1)
         required: true
         schema:
-          type: integer
-          format: int64
-          minimum: 0
+          type: string
+          pattern: ^[0-9]+$
       responses:
         '200':
           description: Outgoing relations
@@ -1491,12 +1482,11 @@ paths:
           type: string
       - name: id
         in: path
-        description: Point ID
+        description: Point ID (u64 as a string; precision-safe above 2^53-1)
         required: true
         schema:
-          type: integer
-          format: int64
-          minimum: 0
+          type: string
+          pattern: ^[0-9]+$
       requestBody:
         content:
           application/json:
@@ -1586,12 +1576,11 @@ paths:
           type: string
       - name: edge_id
         in: path
-        description: Edge ID to remove
+        description: Edge ID to remove (u64 as a string; precision-safe above 2^53-1)
         required: true
         schema:
-          type: integer
-          format: int64
-          minimum: 0
+          type: string
+          pattern: ^[0-9]+$
       responses:
         '204':
           description: Relation removed
@@ -2301,7 +2290,9 @@ components:
           oneOf:
           - type: integer
             format: int64
+            minimum: 0
           - type: string
+            pattern: ^[0-9]+$
           description: Point ID. Accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss.
         label:
           type: string
@@ -2312,13 +2303,17 @@ components:
           oneOf:
           - type: integer
             format: int64
+            minimum: 0
           - type: string
+            pattern: ^[0-9]+$
           description: Point ID. Accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss.
         target:
           oneOf:
           - type: integer
             format: int64
+            minimum: 0
           - type: string
+            pattern: ^[0-9]+$
           description: Point ID. Accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss.
     AddEdgesBatchRequest:
       type: object
@@ -2397,10 +2392,13 @@ components:
         ids:
           type: array
           items:
-            type: integer
-            format: int64
-            minimum: 0
-          description: List of point IDs to delete.
+            oneOf:
+            - type: integer
+              format: int64
+              minimum: 0
+            - type: string
+              pattern: ^[0-9]+$
+          description: Point IDs. Each accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss.
     CollectionConfigResponse:
       type: object
       description: Response with detailed collection configuration.
@@ -3455,7 +3453,9 @@ components:
             oneOf:
             - type: integer
               format: int64
+              minimum: 0
             - type: string
+              pattern: ^[0-9]+$
         depth:
           type: integer
           format: int32
@@ -3552,7 +3552,10 @@ components:
             oneOf:
             - type: integer
               format: int64
+              minimum: 0
             - type: string
+              pattern: ^[0-9]+$
+          description: Point IDs. Each accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss.
     NodePayloadResponse:
       type: object
       description: Response for a node payload retrieval.
@@ -3640,7 +3643,10 @@ components:
             oneOf:
             - type: integer
               format: int64
+              minimum: 0
             - type: string
+              pattern: ^[0-9]+$
+          description: Point IDs. Each accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss.
     PointRequest:
       type: object
       description: A point in an upsert request.
@@ -3652,7 +3658,9 @@ components:
           oneOf:
           - type: integer
             format: int64
+            minimum: 0
           - type: string
+            pattern: ^[0-9]+$
           description: Point ID. Accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss.
         payload:
           description: Optional payload.
@@ -3807,13 +3815,17 @@ components:
           oneOf:
           - type: integer
             format: int64
+            minimum: 0
           - type: string
+            pattern: ^[0-9]+$
           description: Point ID. Accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss.
         target:
           oneOf:
           - type: integer
             format: int64
+            minimum: 0
           - type: string
+            pattern: ^[0-9]+$
           description: Point ID. Accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss.
     RelateResponse:
       type: object
@@ -3892,12 +3904,14 @@ components:
           description: Maximum points per batch (1–10 000, default 100).
           minimum: 0
         cursor:
-          type:
-          - integer
-          - 'null'
-          format: int64
-          description: Resume after this point ID (exclusive). Omit to start from beginning.
-          minimum: 0
+          oneOf:
+          - type: integer
+            format: int64
+            minimum: 0
+          - type: string
+            pattern: ^[0-9]+$
+          - type: 'null'
+          description: Resume after this point ID (exclusive). Omit or send null to start from the beginning. Accepts a JSON integer or a precision-safe string.
         filter:
           description: Optional filter expression.
     ScrollResponse:
@@ -3908,11 +3922,9 @@ components:
       properties:
         next_cursor:
           type:
-          - integer
+          - string
           - 'null'
-          format: int64
           description: Cursor for the next batch. Null when iteration is complete.
-          minimum: 0
         points:
           type: array
           items:
@@ -4102,7 +4114,9 @@ components:
           oneOf:
           - type: integer
             format: int64
+            minimum: 0
           - type: string
+            pattern: ^[0-9]+$
           description: Point ID. Accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss.
         payload:
           description: Optional JSON payload (metadata).
@@ -4134,7 +4148,10 @@ components:
             oneOf:
             - type: integer
               format: int64
+              minimum: 0
             - type: string
+              pattern: ^[0-9]+$
+          description: Point IDs. Each accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss.
     StreamStatsEvent:
       type: object
       description: 'SSE event: Periodic statistics update.'
@@ -4193,7 +4210,10 @@ components:
             oneOf:
             - type: integer
               format: int64
+              minimum: 0
             - type: string
+              pattern: ^[0-9]+$
+          description: Point IDs. Each accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss.
         target_id:
           type: string
           description: Target node ID reached.
@@ -4237,7 +4257,9 @@ components:
           oneOf:
           - type: integer
             format: int64
+            minimum: 0
           - type: string
+            pattern: ^[0-9]+$
           description: Point ID. Accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss.
         strategy:
           type: string

--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -442,7 +442,7 @@ Cursor-based pagination over all points of a collection (ascending ID order).
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | batch_size | integer | No | Points per batch (1–10 000, default: 100) |
-| cursor | integer/null | No | Resume **after** this point ID (exclusive); omit to start from the beginning |
+| cursor | string \| integer \| null | No | Resume **after** this point ID (exclusive); echo back the `next_cursor` string. Omit or send `null` to start from the beginning. The integer form is also accepted |
 | filter | object | No | Optional canonical filter expression |
 
 **Response:**
@@ -451,12 +451,13 @@ Cursor-based pagination over all points of a collection (ascending ID order).
   "points": [
     {"id": "1", "vector": [0.1, 0.2, ...], "payload": {"title": "Doc 1"}}
   ],
-  "next_cursor": 1
+  "next_cursor": "1"
 }
 ```
 
-`next_cursor` is `null` once iteration is complete. Point IDs are serialized as
-strings (see the Point ID encoding note in [Search](#search)).
+`next_cursor` is `null` once iteration is complete. Point IDs (including the
+cursor) are serialized as strings (see the Point ID encoding note in
+[Search](#search)).
 
 ### POST /collections/:name/points/stream
 


### PR DESCRIPTION
## What

The REST response bodies already emit u64 IDs as JSON **strings** (precision-safe above 2^53-1, via `serde_id`), but several parts of the REST surface still described or accepted only the native-integer form — so a client generated from `docs/openapi.{json,yaml}` types those IDs as `number` and loses precision round-tripping large IDs.

This closes that gap **without any wire change** (spec-only + additive input leniency).

### Spec-only (runtime already emits/accepts these)
- **Path/query ID params** (`point id`, `node_id`, `edge_id`, `start_node`) were `integer/int64`; a URL segment is always text → now `string` with `pattern: ^[0-9]+$` (accurate + codegen-safe, numeric constraint kept).
- **`ScrollRequest.cursor` / `ScrollResponse.next_cursor`** carried the `serde_id` string helpers but no schema override. `next_cursor` → `string | null`; `cursor` → `oneOf(integer | string | null)`, matching the deserializer (int / precision-safe string / null / absent) and the `id_input_schema` convention used by every other string-or-number input.

### Additive (backward compatible)
- **`BulkDeleteRequest.ids`** accepted only integers; now accepts the string form every read surface emits (`oneOf integer|string`), so a JS client can delete the exact IDs it received. New end-to-end test.

### Hardening
- Shared `id_oneof` gains `minimum: 0` (integer branch) + `pattern: ^[0-9]+$` (string branch); restored the field descriptions the `schema_with` overrides had dropped. `u64` has no exact OpenAPI primitive → the integer branch stays `int64` (native/JS-safe range) while the string branch carries the full range with the exact bound enforced server-side — documented on `id_oneof`.

### Docs
- Fixed the `scroll` example (`next_cursor` was shown as a number, contradicting its own adjacent "IDs serialize as strings" note).

## Review
Two adversarial `/code-review high` passes (4 + 3 findings, all addressed) plus a focused verifier on the `cursor` null-branch delta (CLEAN). Clippy pedantic clean; api_types + admin + api_integration suites green; OpenAPI drift check passes (spec regenerated from code).

## Deferred (separate, wire-breaking)
`get`/`delete`/`/query` still emit numeric IDs via raw `json!` responses. Completing the string-ID migration there is a wire change → its own versioned follow-up.