### PR TITLE
chore(release): 3.7.0 + velesdb-memory 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.7.0] — 2026-07-06
+
+### Added
+- **`recall_fused` on the MCP and Python bindings** — fused vector+graph recall
+  (previously Node/WASM-only) is now available to MCP clients (Claude Code,
+  Codex, OpenCode…) and the Python `MemoryService`, with flat `hops`/`graph_boost`
+  knobs. (#1314)
+- **Dated-context recall on every surface** — `recall_fused` gains a `date_field`
+  option (MCP, Python) and a sibling `recallFusedDated` (Node, WASM, TypeScript
+  SDK) returning a chronological, "now"-anchored timeline. Powered by the new
+  `velesdb-memory::format_dated_context` primitive. (#1315, #1316)
+
+### Fixed
+- **u64 IDs are precision-safe across the whole REST OpenAPI spec.** Path/query
+  ID parameters, the scroll `cursor`, and `BulkDeleteRequest.ids` were typed or
+  accepted as integers only; a client generated from `docs/openapi.{json,yaml}`
+  therefore typed IDs above 2^53-1 as a JavaScript `number` and lost precision.
+  IDs are now `string` (path/query, `^[0-9]+$`) or `oneOf(integer|string)`
+  (bodies), matching the string form every read surface already emits. No wire
+  change. (#1321)
+
+### Changed
+- LoCoMo positioning and benchmark docs (sourced citations, reproduction through
+  the shipped `recall_fused`, the k-budget lever) and the bench harness gains
+  `--use-shipped-api` plus a `--full-context` ceiling baseline. (#1313, #1317,
+  #1318, #1319, #1320)
+
 ## [3.6.0] — 2026-07-03
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5668,7 +5668,7 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-velesdb"
-version = "3.6.0"
+version = "3.7.0"
 dependencies = [
  "dirs",
  "parking_lot",
@@ -6678,7 +6678,7 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "velesdb-cli"
-version = "3.6.0"
+version = "3.7.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -6703,7 +6703,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-core"
-version = "3.6.0"
+version = "3.7.0"
 dependencies = [
  "arc-swap",
  "bytemuck",
@@ -6758,7 +6758,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-memory"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "rmcp",
  "schemars 1.2.1",
@@ -6773,7 +6773,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-migrate"
-version = "3.6.0"
+version = "3.7.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6801,7 +6801,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-mobile"
-version = "3.6.0"
+version = "3.7.0"
 dependencies = [
  "parking_lot",
  "serde_json",
@@ -6815,7 +6815,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-node"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "napi",
  "napi-build",
@@ -6826,7 +6826,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-python"
-version = "3.6.0"
+version = "3.7.0"
 dependencies = [
  "numpy",
  "parking_lot",
@@ -6840,7 +6840,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-server"
-version = "3.6.0"
+version = "3.7.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -6873,7 +6873,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-wasm"
-version = "3.6.0"
+version = "3.7.0"
 dependencies = [
  "getrandom 0.3.4",
  "getrandom 0.4.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "3.6.0"
+version = "3.7.0"
 edition = "2021"
 rust-version = "1.89"
 license-file = "LICENSE"
@@ -79,7 +79,7 @@ base64 = "0.22"
 smallvec = { version = "1", features = ["serde"] }
 
 # Internal workspace crates
-velesdb-core = { path = "crates/velesdb-core", version = "3.6.0", default-features = false }
+velesdb-core = { path = "crates/velesdb-core", version = "3.7.0", default-features = false }
 
 [profile.release]
 lto = true

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM rust:1.96-bookworm AS builder
 
 LABEL maintainer="VelesDB Team <contact@wiscale.fr>"
-LABEL version="3.6.0"
+LABEL version="3.7.0"
 
 WORKDIR /app
 
@@ -25,7 +25,7 @@ RUN cargo build --release --bin velesdb-server
 FROM debian:bookworm-slim
 
 LABEL maintainer="VelesDB Team <contact@wiscale.fr>"
-LABEL version="3.6.0"
+LABEL version="3.7.0"
 
 WORKDIR /app
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@
 </h3>
 <p align="center">
   <strong>One ~9 MB binary. Three engines. One query language. Zero cloud dependency.</strong><br/>
-  <em>Vector + Graph + ColumnStore — unified under <a href="docs/VELESQL_SPEC.md">VelesQL</a></em>
+  <em>Vector + Graph + ColumnStore — unified under <a href="docs/VELESQL_SPEC.md">VelesQL</a></em><br/><br/>
+  The <strong>explainable</strong> agent memory: <code>why()</code> returns the evidence path behind every recall —<br/>
+  <a href="crates/velesdb-memory/BENCHMARK.md"><strong>measured on public benchmarks</strong></a>, not vibes.
 </p>
 <p align="center">
   <a href="https://github.com/cyberlife-coder/VelesDB/actions/workflows/ci.yml"><img src="https://github.com/cyberlife-coder/VelesDB/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
@@ -42,17 +44,11 @@
 
 ---
 
-## The Story Behind VelesDB
+## Three things no competitor counters
 
-VelesDB was born in France out of a simple observation: **EU data sovereignty is an architectural problem, not a legal one.**
-
-The US Cloud Act, FISA 702, and PATRIOT Act give US authorities multiple legal paths to reach data held by any US company — regardless of where the servers are. Hosting on AWS `eu-west-1` is a latency decision, not a sovereignty decision. The EU's Data Privacy Framework has been invalidated twice (Schrems I, Schrems II), and a third challenge is pending.
-
-For European developers building AI agents that handle health data, legal documents, or financial records, the typical 2026 stack sends embeddings to Pinecone (US), graphs to Neo4j Aura (US), and metadata to PostgreSQL on AWS (US provider). Every one of these is reachable by a FISA warrant.
-
-VelesDB removes the US provider from the chain entirely. One Rust binary, local-first by design. No API key, no cloud account, no data processor. Your data stays in a directory you control — on your laptop, your server, your jurisdiction.
-
-> [Read the full story: "I built a database in France because the Cloud Act makes EU data sovereignty impossible"](https://dev.to/wiscale-fr/i-built-a-database-in-france-because-the-cloud-act-makes-eu-data-sovereignty-impossible-5325)
+| 🔍 It shows its work | 🔑 No cloud bill per memory | 📊 Measured, not vibes |
+|---|---|---|
+| Ask `why()` and the memory returns the **evidence trail** behind every answer — which facts it used and how they connect, not just the answer itself. That's a built-in audit trail, exactly what regulations like the [EU AI Act (enforceable Aug 2026)](https://artificialintelligenceact.eu/implementation-timeline/) will ask of AI systems. | With the leading alternatives, **every single memory saved runs 2–3 AI-model calls** — by default, paid cloud calls with an API key. VelesDB stores memories with **zero AI calls and zero keys**: one small program (~9 MB) on your machine, no extra databases to install or operate. | We publish how often the memory **finds the right information** — measured with no AI grader in the loop that could flatter the score. On public test sets: **+7.2 pts** on multi-hop (HotpotQA) and **+9.7 pts** on time-scoped recall (TimeQA); on a controlled task needing both engines at once, **+29 pts**. [Anyone can re-run the tests](crates/velesdb-memory/BENCHMARK.md). |
 
 ---
 
@@ -107,7 +103,7 @@ Built-in memory for AI agents — semantic, episodic, and procedural. No externa
 
 Most "agent memory" is vector recall: it finds text that *looks like* your query. VelesDB's high-level `MemoryService` adds the part that's missing — it **connects** memories with typed links, so it can answer *why* something happened by walking the graph to context that shares **no words** with your question. The store is on disk, so it works across sessions. Offline, deterministic, no API key, no model download:
 
-Where Mem0 and Zep are cloud-coupled orchestrators (a service mesh over Qdrant + Postgres, with a cloud LLM in the loop), this is **one local binary** — same tier as Mem0 on LoCoMo QA (~56% vs ~55%, neutral basis, full 10-conversation set), ahead of Zep, but fully offline with an auditable `why()` evidence path. Pick it when your data can't leave the box.
+Where Mem0 and Zep are cloud-coupled orchestrators (several backing services plus AI-model calls — cloud by default — on every memory write), this is **one local binary** — fully offline, zero AI calls to store a memory, and an auditable `why()` evidence trail. On the standard LoCoMo memory test, our fully-local setup answers 56% of the *answerable* questions (the benchmark's unanswerable "adversarial" category is excluded, as is standard practice — every configuration detail is disclosed) and **55–61% of time-related questions** ("when did X happen?") — spanning both configurations the leading vendor's own paper reports for itself in that category, on powerful cloud AI models, while we run on a model on your own machine. Scores from different labs can't be fairly compared (the same product's score can swing ~21 points with the test setup alone), so instead of a bar chart we publish the [full sourced landscape, method, and statistics](crates/velesdb-memory/BENCHMARK.md). Pick it when your data can't leave the box.
 
 ![recall() finds the booking but misses the reason; why() reaches it through typed links, across a session restart](examples/agent_memory/why_across_sessions.gif)
 
@@ -506,6 +502,20 @@ Ship AI features without a server. VelesDB embeds directly into Tauri, iOS, and 
 | iOS (Swift) | UniFFI bindings | ~4 MB |
 | Android (Kotlin) | UniFFI bindings | ~4 MB |
 | Browser | WASM module | ~430 KB gzipped |
+
+---
+
+## The Story Behind VelesDB
+
+VelesDB was born in France out of a simple observation: **EU data sovereignty is an architectural problem, not a legal one.**
+
+The US Cloud Act, FISA 702, and PATRIOT Act give US authorities multiple legal paths to reach data held by any US company — regardless of where the servers are. Hosting on AWS `eu-west-1` is a latency decision, not a sovereignty decision. The EU's Data Privacy Framework has been invalidated twice (Schrems I, Schrems II), and a third challenge is pending.
+
+For European developers building AI agents that handle health data, legal documents, or financial records, the typical 2026 stack sends embeddings to Pinecone (US), graphs to Neo4j Aura (US), and metadata to PostgreSQL on AWS (US provider). Every one of these is reachable by a FISA warrant.
+
+VelesDB removes the US provider from the chain entirely. One Rust binary, local-first by design. No API key, no cloud account, no data processor. Your data stays in a directory you control — on your laptop, your server, your jurisdiction.
+
+> [Read the full story: "I built a database in France because the Cloud Act makes EU data sovereignty impossible"](https://dev.to/wiscale-fr/i-built-a-database-in-france-because-the-cloud-act-makes-eu-data-sovereignty-impossible-5325)
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,7 +4,7 @@ This roadmap commits to **what we are building**, **why**, and **when**. It is u
 
 It is intentionally narrow. Items not on this roadmap are tracked as `roadmap` issues but **not committed** until they reach a milestone here.
 
-> **Last updated:** 2026-06-21 — covers v3.6.0 (current). The horizon framing below predates the v2.0→v3.x line and is being re-baselined.
+> **Last updated:** 2026-06-21 — covers v3.7.0 (current). The horizon framing below predates the v2.0→v3.x line and is being re-baselined.
 
 ---
 

--- a/benchmarks/Dockerfile.bench
+++ b/benchmarks/Dockerfile.bench
@@ -6,7 +6,7 @@
 FROM debian:bookworm-slim
 
 LABEL maintainer="VelesDB Team <contact@wiscale.fr>"
-LABEL version="3.6.0"
+LABEL version="3.7.0"
 
 WORKDIR /app
 

--- a/benchmarks/Dockerfile.nightly
+++ b/benchmarks/Dockerfile.nightly
@@ -4,7 +4,7 @@
 FROM rust:slim-bookworm AS builder
 
 LABEL maintainer="VelesDB Team <contact@wiscale.fr>"
-LABEL version="3.6.0"
+LABEL version="3.7.0"
 
 WORKDIR /app
 
@@ -29,7 +29,7 @@ RUN cargo build --release --bin velesdb-server
 FROM debian:bookworm-slim
 
 LABEL maintainer="VelesDB Team <contact@wiscale.fr>"
-LABEL version="3.6.0"
+LABEL version="3.7.0"
 
 WORKDIR /app
 

--- a/benchmarks/Dockerfile.optimized
+++ b/benchmarks/Dockerfile.optimized
@@ -7,7 +7,7 @@
 FROM rust:slim-bookworm AS builder
 
 LABEL maintainer="VelesDB Team <contact@wiscale.fr>"
-LABEL version="3.6.0"
+LABEL version="3.7.0"
 
 WORKDIR /app
 
@@ -49,7 +49,7 @@ RUN cargo build --release --bin velesdb-server \
 FROM debian:bookworm-slim
 
 LABEL maintainer="VelesDB Team <contact@wiscale.fr>"
-LABEL version="3.6.0"
+LABEL version="3.7.0"
 
 WORKDIR /app
 

--- a/crates/tauri-plugin-velesdb/guest-js/package.json
+++ b/crates/tauri-plugin-velesdb/guest-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wiscale/tauri-plugin-velesdb",
-  "version": "3.6.0",
+  "version": "3.7.0",
   "description": "TypeScript bindings for the VelesDB Tauri plugin - Vector search in desktop apps",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/crates/velesdb-core/src/api_types/responses.rs
+++ b/crates/velesdb-core/src/api_types/responses.rs
@@ -323,6 +323,24 @@ pub struct ListIndexesResponse {
 // Scroll Responses
 // ============================================================================
 
+/// `OpenAPI` schema for the scroll `cursor` input: an integer-or-string ID
+/// (precision-safe) that keeps the cursor-specific "resume after" semantics
+/// rather than the generic point-ID description.
+#[cfg(feature = "openapi")]
+fn scroll_cursor_schema() -> utoipa::openapi::schema::OneOfBuilder {
+    use utoipa::openapi::schema::{ObjectBuilder, Type};
+    // `cursor` is `Option<u64>`: the deserializer accepts an integer, a
+    // precision-safe string, or `null` (= start from the beginning). The
+    // `null` branch keeps the spec in step with that leniency.
+    serde_id::id_oneof()
+        .item(ObjectBuilder::new().schema_type(Type::Null))
+        .description(Some(
+            "Resume after this point ID (exclusive). Omit or send null to \
+             start from the beginning. Accepts a JSON integer or a \
+             precision-safe string.",
+        ))
+}
+
 /// Request body for the scroll endpoint.
 #[derive(Debug, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
@@ -332,6 +350,7 @@ pub struct ScrollRequest {
         default,
         deserialize_with = "serde_id::deserialize_option_id_from_string_or_number"
     )]
+    #[cfg_attr(feature = "openapi", schema(schema_with = scroll_cursor_schema))]
     pub cursor: Option<u64>,
     /// Maximum points per batch (1–10 000, default 100).
     #[serde(default = "default_scroll_batch_size")]
@@ -357,6 +376,7 @@ pub struct ScrollResponse {
         serialize_with = "serde_id::serialize_option_id_as_string",
         deserialize_with = "serde_id::deserialize_option_id_from_string_or_number"
     )]
+    #[cfg_attr(feature = "openapi", schema(value_type = Option<String>))]
     pub next_cursor: Option<u64>,
 }
 

--- a/crates/velesdb-core/src/api_types/serde_id.rs
+++ b/crates/velesdb-core/src/api_types/serde_id.rs
@@ -74,16 +74,32 @@ pub fn id_input_schema() -> utoipa::openapi::schema::OneOfBuilder {
 ///
 /// An ID is emitted as a string on the wire (precision-safe) but accepted as
 /// either an integer or a string on input.
+///
+/// `u64` has no exact `OpenAPI` primitive, so the two branches are deliberately
+/// asymmetric and the exact bound is enforced server-side (`parse::<u64>`):
+/// the integer branch is `int64`/`minimum: 0` (the JS-safe native form; values
+/// above `i64::MAX` must use the string branch, which is precisely why the
+/// string form exists), and the string branch is `^[0-9]+$` — permissive at
+/// the very top of the range (a >`u64::MAX` digit string is rejected at
+/// runtime) rather than an unreadable exact-max regex. This mirrors the
+/// protobuf/Google-JSON convention of carrying 64-bit ints as strings.
 #[cfg(feature = "openapi")]
-fn id_oneof() -> utoipa::openapi::schema::OneOfBuilder {
+pub(crate) fn id_oneof() -> utoipa::openapi::schema::OneOfBuilder {
     use utoipa::openapi::schema::{KnownFormat, ObjectBuilder, OneOfBuilder, SchemaFormat, Type};
     OneOfBuilder::new()
         .item(
             ObjectBuilder::new()
                 .schema_type(Type::Integer)
-                .format(Some(SchemaFormat::KnownFormat(KnownFormat::Int64))),
+                .format(Some(SchemaFormat::KnownFormat(KnownFormat::Int64)))
+                // IDs are `u64`; the native-integer branch is non-negative.
+                .minimum(Some(0.0)),
         )
-        .item(ObjectBuilder::new().schema_type(Type::String))
+        .item(
+            ObjectBuilder::new()
+                .schema_type(Type::String)
+                // The string branch carries the decimal digits of a `u64`.
+                .pattern(Some("^[0-9]+$")),
+        )
 }
 
 /// `OpenAPI` schema for an array of IDs whose elements accept an integer or a
@@ -94,7 +110,13 @@ fn id_oneof() -> utoipa::openapi::schema::OneOfBuilder {
 #[cfg(feature = "openapi")]
 #[must_use]
 pub fn ids_array_schema() -> utoipa::openapi::schema::ArrayBuilder {
-    utoipa::openapi::schema::ArrayBuilder::new().items(id_oneof())
+    utoipa::openapi::schema::ArrayBuilder::new()
+        .items(id_oneof())
+        .description(Some(
+            "Point IDs. Each accepts a JSON integer (native form) or a string; \
+             use a string for u64 values above 2^53-1 to avoid JavaScript \
+             precision loss.",
+        ))
 }
 
 /// `OpenAPI` schema for a map whose values are IDs accepting an integer or a

--- a/crates/velesdb-memory/BENCHMARK.md
+++ b/crates/velesdb-memory/BENCHMARK.md
@@ -332,13 +332,65 @@ cargo run --release -p velesdb-memory --features ollama --example locomo -- \
 # 3. full answer-accuracy run (date-routed context, Claude judge):
 cargo run --release -p velesdb-memory --features ollama --example locomo -- \
   --embed-model mxbai-embed-large --date-context --date-route --k 32 --claude-judge
+
+# 4. does the fused ranking reproduce through the SHIPPED recall_fused API?
+#    compare these two on identical data (LLM-free, seconds each):
+cargo run --release -p velesdb-memory --features ollama --example locomo -- \
+  --retrieval --idf-weight        # the harness's own fusion
+cargo run --release -p velesdb-memory --features ollama --example locomo -- \
+  --retrieval --use-shipped-api   # the installed MemoryService::recall_fused
 ```
 
 Flags: `--conversations N`, `--only <category>` (targeted A/B), `--model
 <ollama-chat-model>` (answerer), `--graph-boost`, `--idf-weight`,
-`--multihop-only`, `--temporal-scaffold`. The Claude judge runs through the
-authenticated `claude` CLI; the harness caches every LLM call, so re-runs are
-free and any judge can be substituted.
+`--multihop-only`, `--temporal-scaffold`, `--use-shipped-api` (below). The
+Claude judge runs through the authenticated `claude` CLI; the harness caches
+every LLM call, so re-runs are free and any judge can be substituted.
+
+## Does the win ship? Reproducing through the installed API
+
+A fair challenge to any benchmark: is the result a property of the *harness*, or
+of the product you install? Our harness always retrieves through the real
+`MemoryService` (`recall` / `recall_where` / `why`), but it historically did the
+final vector+graph **fusion** in its own code. The `--use-shipped-api` flag
+routes that fusion through the exact
+[`MemoryService::recall_fused`](https://docs.rs/velesdb-memory) a caller
+installs, so the two can be compared on identical data — LLM-free, in the fast
+`--retrieval` mode.
+
+On a 3-conversation run (default `all-minilm` embedder; single-seed, no BM25,
+`--idf-weight` to match `recall_fused`'s always-IDF reach weighting), evidence
+recall@k:
+
+| retrieval path | ALL | multi-hop | temporal | single-hop | open-domain |
+|---|---|---|---|---|---|
+| harness fusion | 69.8% | 56.1% | 88.3% | 68.2% | 51.3% |
+| shipped `recall_fused` | 69.0% | 52.3% | 88.3% | 68.2% | 51.3% |
+
+The vector baseline is identical (70.1%), and the fused numbers agree to ~1pp —
+**identical on temporal, single-hop, and open-domain.** What this measures is the
+harness-vs-shipped *delta*, which is embedder-independent (both paths share one
+store). The residual sits entirely in multi-hop, and it is not noise: it traces
+to deliberate differences between the shipped API and the harness's research
+levers, documented here so no comparison is misread —
+
+- **IDF corpus size.** `recall_fused` weights a graph link by the
+  inverse-document-frequency of the connecting entity over *all* memories (facts
+  + entity hubs); the harness counts facts only. Different denominators →
+  slightly different graph weights → the multi-hop gap.
+- **Single-seed.** `recall_fused` reaches the graph from one top vector seed; the
+  harness can seed from the top-N (`--seed-breadth`), an unshipped research lever.
+- **No BM25.** The harness's RRF lexical fusion has no `recall_fused` equivalent.
+- **Exact-match filter, not a range window.** `recall_fused` takes an exact-match
+  metadata filter; the harness's temporal date *window* is a `recall_where` range
+  predicate, so the shipped path runs unfiltered — yet the temporal category
+  still matches, because date grounding rides on the retrieved facts, not the
+  pre-filter.
+
+Net: the tri-engine *ranking* reproduces through the installed API within a
+small, fully-explained margin. The harness-only levers (multi-seed, BM25) and
+the IDF-corpus choice are tracked accuracy-lever work — not the source of the
+headline.
 
 ## Comparative context — read before comparing any two LoCoMo numbers
 

--- a/crates/velesdb-memory/BENCHMARK.md
+++ b/crates/velesdb-memory/BENCHMARK.md
@@ -1,15 +1,236 @@
-# velesdb-memory on LoCoMo
+# velesdb-memory — Benchmarks
 
-> Draft results page. Numbers are **our measurement** on the full 10-conversation
-> LoCoMo set, statistically validated with paired tests (McNemar, cluster bootstrap
-> over conversations) — see
+> Every number on this page is **our measurement**, reproducible from the bundled
+> examples, with the full configuration disclosed (embedder, generator, judge,
+> judge prompt, `k`, flags). We lead with **generation-free retrieval metrics** —
+> in plain terms: we check whether the memory surfaced the officially annotated
+> right pieces of evidence, with **no AI model involved in the scoring**, so the
+> number measures the *memory* itself and nothing can flatter it. The end-to-end
+> LoCoMo section follows, validated with paired statistical tests (McNemar,
+> cluster bootstrap — i.e. checks that a gain is a real effect, not a lucky
+> run) — see
 > [`docs/planning/LOCOMO_TEMPORAL_DECOMP_RESEARCH.md`](../../docs/planning/LOCOMO_TEMPORAL_DECOMP_RESEARCH.md)
-> for the full methodology and caveats. Reproducible from the bundled example
-> (`examples/locomo/`).
+> for full methodology and caveats.
+>
+> *Reading the numbers: "pp" = percentage points, the absolute gap between two
+> percentages (36.3% → 46.0% is +9.7pp). "k" = the retrieval budget — how many
+> memories the system is allowed to hand to the model answering the question.*
+
+## The scoreboard — each engine, measured, generation-free
+
+To our knowledge, no other agent-memory project publishes retrieval-level
+metrics — numbers for how often the memory actually *finds* the right
+information. These isolate each
+of our three engines against a pure vector-search baseline (what a standard
+RAG/memory product does) on **public, third-party datasets**:
+
+| Engine | Benchmark | Metric | Vector → fused |
+|---|---|---|---|
+| **Graph** (`why()` BFS) | [HotpotQA](https://hotpotqa.github.io/) 3,000 dev | both bridge facts retrieved (bridge questions) | 41.3% → 48.5% = **+7.2pp** |
+| **Graph** — *replicated* | [2WikiMultiHopQA](https://github.com/Alab-NII/2wikimultihop) 1,000 dev | supporting-fact recall — same harness, second independently built dataset | **+2.6 to +3.1pp** on its three bridged question types (+2.1pp overall) |
+| **ColumnStore** (`recall_where`) | [TimeQA](https://huggingface.co/datasets/hugosousa/TimeQA) real bios | gold-sentence recall, time-scoped questions | 36.3% → 46.0% = **+9.7pp** |
+| **Both engines together** | tri-engine capstone (synthetic) | answer-bearing recall, multi-hop **and** time-scoped | 21% → 50% = **+29pp — super-additive** |
+
+Details for each row are below; every figure reproduces from `examples/`.
+
+---
+
+# Part 1 — Retrieval benchmarks (generation-free)
+
+## HotpotQA — where the graph earns its keep
+
+LoCoMo's headline metric is generation-capped (a small local model is the
+ceiling). To measure the *memory* itself — independent of any generator — we
+evaluate on **[HotpotQA](https://hotpotqa.github.io/)** (distractor setting), the
+standard multi-hop benchmark with **sentence-level supporting-fact annotations**.
+The metric is purely retrieval: of a question's two gold supporting-fact
+sentences, how many does the system surface? No LLM answers, no judge — so this
+isolates the tri-engine's multi-hop retrieval, exactly where the graph is
+supposed to help.
+
+**Setup.** Each question carries 10 paragraphs (2 gold + 8 distractors) split
+into sentences. We ingest every sentence as a memory, build an entity graph from
+the paragraph **titles** (each sentence links to its own title and to any other
+title it mentions — that mention is the multi-hop *bridge*), then retrieve a
+top-`k` budget two ways: pure **vector** similarity vs the **fused** vector +
+graph (`why()`), where a graph bridge is weighted by the inverse-document-
+frequency of the connecting title (a rare, specific bridge counts; a common one
+is downweighted). Embedder: `mxbai-embed-large`, local. Fully generation-free.
+
+**Result (3,000 questions, k=5):**
+
+| Question type | Retrieval | Supporting-fact recall | Both gold facts retrieved |
+|---|---|---|---|
+| **bridge** (true multi-hop, n=2,400) | Vector only | 68.7% | 41.3% |
+| | **+ tri-engine graph (idf)** | **73.0% (+4.3pp)** | **48.5% (+7.2pp)** |
+| comparison (n=600) | Vector only | 85.5% | 70.3% |
+| | + graph | 84.6% (−0.9) | 69.2% (−1.1) |
+| **All** | Vector only | 72.1% | 47.1% |
+| | **+ tri-engine graph (idf)** | **75.3% (+3.2pp)** | **52.7% (+5.6pp)** |
+
+The split is the story. On **bridge** questions — the genuine multi-hop, 80% of
+the set, where the answer requires following a bridge entity to a second-hop
+fact a vector store ranks *low by construction* — the graph delivers a large,
+clean win. On **comparison** questions (both entities are named in the question,
+so there is no bridge to follow), pure vector already finds everything and the
+graph only adds noise — so a one-line router (apply the graph to bridge-style
+questions only) keeps the best of both. The win is robust across budgets
+(k=3/4/5) and holds from the 1,000-question sample (+6.9pp) to 3,000 (+7.2pp).
+
+A naive flat-boost graph *hurts* at tight budgets; the **idf weighting** (a rare
+bridge title is a real connection, a common one is noise) is what turns it into
+a net gain — the same lever that works on LoCoMo.
+
+This aligns with independent research: [HippoRAG 2](https://arxiv.org/abs/2502.14802)
+reports the same shape of result (+7% on multi-hop associativity from graph
+search over a dense-retrieval baseline) — graph retrieval specifically fixes the
+second hop that cosine similarity misses by construction.
+
+**Why this matters.** Pure RAG (and orchestrator-style memory layers) rank by
+vector similarity, which by construction misses the second-hop fact (it's
+*dissimilar* to the question — that's what makes it multi-hop). Our graph pulls
+it in, and **`why()` returns the scored evidence path** — the actual bridging
+sentences and the title that connects them — not just an answer.
+
+```sh
+ollama pull mxbai-embed-large
+# fetch HotpotQA dev (distractor) into examples/multihop/data/
+cargo run --release -p velesdb-memory --features ollama --example multihop -- \
+  --questions 3000 --k 5 --idf --embed-model mxbai-embed-large
+```
+
+Limitations: entity graph is title-mention based (a learned relation extractor
+could go further); supporting-fact recall measures *retrieval*, the upstream
+half of QA.
+
+## Corroboration: the same harness on 2WikiMultiHopQA
+
+A single dataset can flatter a method. To check the graph win is not a HotpotQA
+artifact we ran the **identical, unmodified harness** — same fusion, same
+idf-weighted bridge, same metric — on
+**[2WikiMultiHopQA](https://github.com/Alab-NII/2wikimultihop)** (Ho et al.,
+2020), an independently constructed multi-hop benchmark built over Wikipedia +
+Wikidata with the same supporting-fact annotation. Only the data changed.
+
+| 2Wiki dev — 1,000 questions, k=5 | n | Vector | Vector + graph | Δ |
+|---|---|---|---|---|
+| compositional | 430 | 59.0% | 62.1% | **+3.1pp** |
+| inference | 98 | 49.5% | 52.6% | **+3.1pp** |
+| bridge_comparison | 231 | 57.3% | 59.9% | **+2.6pp** |
+| comparison | 241 | 91.5% | 90.9% | −0.6pp |
+| **ALL** | **1,000** | **65.5%** | **67.6%** | **+2.1pp** |
+
+The win **replicates**: the graph lifts exactly the question types that require
+a genuine second hop, and only nudges down the `comparison` type, where both
+entities are already named in the question and saturated vector recall (91.5%)
+leaves nothing to gain. Stated plainly: the lift is **real but more modest than
+on HotpotQA** — on the same supporting-fact-recall metric, HotpotQA bridge
+questions gain +4.3pp vs +2.6 to +3.1pp on 2Wiki's bridged types (2Wiki's many
+comparison/short-fact questions give the graph less to do). What matters for
+the architectural claim is that the directional result
+— *the graph earns its keep on multi-hop retrieval* — holds across two
+independently built datasets, not one.
+
+```sh
+# convert 2Wiki dev (voidful/2WikiMultihopQA) into the column-oriented schema,
+# then run the SAME example used for HotpotQA — only --dataset changes:
+cargo run --release -p velesdb-memory --features ollama --example multihop -- \
+  --dataset examples/multihop/data/twowiki_dev_1000.json --questions 1000 --k 5 --idf
+```
+
+## TimeQA — the ColumnStore earns its keep (time-scoped retrieval)
+
+The **ColumnStore** is the engine a vector store cannot emulate at all. When the
+answer depends on a *time scope* — "who held the role between 2009 and 2015?" —
+every candidate is near-identical in embedding space and differs only by a
+number. Cosine similarity literally cannot disambiguate the year; a numeric
+range predicate can. This benchmarks the `recall_where(year ≥ lo AND year ≤ hi)`
+path end-to-end.
+
+**Real data — [TimeQA](https://huggingface.co/datasets/hugosousa/TimeQA)** asks
+time-scoped questions ("what position did X hold from 1997 to 2001?") over a
+person's bio, which lists their many positions across the years. We split the
+bio into sentences, forward-fill a `year` column along the (roughly
+chronological) timeline, parse the question's window, and score retrieval of the
+sentence(s) containing the gold answer — vector-only vs vector +
+`recall_where(year ≥ lo AND year ≤ hi)`. Generation-free.
+
+| TimeQA (405 answerable time-scoped questions, k=5) | Gold-sentence recall@k |
+|---|---|
+| Vector only | 36.3% |
+| **+ ColumnStore `recall_where`** | **46.0% (+9.7pp, +27% relative)** |
+
+**Controlled pilot (synthetic — 108 time-scoped probes, k=5):** on
+`(person, role, org, year)` tuples where every candidate for a role is
+embedding-near-identical and differs only by its `year` column, with
+out-of-window distractors built in:
+
+| Subset | Vector only | + ColumnStore `recall_where` |
+|---|---|---|
+| **Hard (≥2 in-window answers — range predicate required)** | 69.2% | **87.8% (+18.6pp)** |
+| Single (1 in-window answer) | 100% | 100% |
+| All | 79.4% | **91.9% (+12.5pp)** |
+
+On real data the lift is smaller than the pilot (noisier prose, approximate year
+imputation, some answer sentences carry no year) but clear and substantial — a
+*predicate*, not a learned ranking, doing what cosine alone cannot.
+
+## The engines *compound* (tri-engine capstone)
+
+The benchmarks above prove each leg beats vector on *its own* specialty. The
+remaining question is whether the legs **stack** when a single question needs
+more than one of them. We construct a task that is multi-hop **and** time-scoped
+at once: ten companies with **opaque names** (decoupled from their cities), each
+with dated office-holder facts (a `year` column) plus one location fact
+`"{company} is headquartered in {city}"`. The probe names a **city**, a
+**role**, and a **year window** — "Who was the {role} of the company
+headquartered in {city} from {lo} to {hi}?"
+
+To answer it you must resolve two independent axes that vector similarity owns
+neither of: **which company** (the role-facts never mention the city — only the
+graph location-edge connects them) and **which period** (the candidates differ
+only by a number — a `recall_where(year ∈ [lo,hi])` predicate, not cosine).
+Generation-free; answer-bearing recall@5 under four arms:
+
+| Arm | answer-bearing recall@5 | vs vector |
+|---|---|---|
+| Vector only | 21.0% | — |
+| + ColumnStore (`year ∈ [lo,hi]`) | 26.0% | +5.0pp |
+| + Graph (`why()`: city → company) | 37.0% | +16.0pp |
+| **+ both engines** | **50.0%** | **+29.0pp** |
+
+The ladder is monotone and, crucially, **super-additive**: the two engines
+together lift recall **+29pp**, more than the **+21pp** (= +5 + +16) they would
+give if their contributions were merely independent. Each engine fixes one axis
+the other can't — Graph resolves *which* company via the location-edge bridge,
+ColumnStore resolves *which* period via the numeric range — and only with both
+does the system find the right person in the right company in the right window.
+That is the architectural claim made literal: one embedded engine, three
+retrieval modes, fused in a single collection, doing together what no single
+mode can. (Synthetic by necessity — no public benchmark isolates "multi-hop AND
+time-scoped" — but every number reproduces from `examples/triengine`.)
+
+---
+
+# Part 2 — End-to-end QA: LoCoMo
 
 ## What this measures
 
-[LoCoMo](https://github.com/snap-research/locomo) (Snap Research, ACL 2024) is a long-term conversational-memory benchmark: each conversation runs ~300 turns across up to 35 sessions, and the system must answer questions spanning five categories — multi-hop, temporal, open-domain, single-hop, and adversarial. It stresses exactly what an agent memory layer is for: recalling and reasoning over facts stated dozens of sessions ago.
+[LoCoMo](https://github.com/snap-research/locomo) (Snap Research, ACL 2024) is a
+long-term conversational-memory benchmark: each conversation runs ~300 turns
+across up to 35 sessions, and the system must answer questions spanning five
+categories — multi-hop, temporal, open-domain, single-hop, and adversarial. It
+stresses exactly what an agent memory layer is for: recalling and reasoning over
+facts stated dozens of sessions ago.
+
+**Read this section knowing the field's caveats.** LoCoMo scores are extremely
+harness-sensitive — the same system scores 58.4 or 79.1 depending on whose
+harness runs it, and swapping only the generator model moves scores ~10pp
+([Continua's controlled rerun](https://blog.continua.ai/p/the-locomo-fair-fight)).
+An [independent audit](https://dev.to/penfieldlabs/we-audited-locomo-64-of-the-answer-key-is-wrong-and-the-judge-accepts-up-to-63-of-intentionally-33lg)
+found 6.4% of the answer key is wrong and that a gpt-4o-mini judge accepts 62.8%
+of intentionally wrong answers. That is why Part 1 (generation-free) leads this
+page, and why every config detail below is disclosed.
 
 ## Setup
 
@@ -20,7 +241,11 @@
 
 ## Headline results
 
-*Claude-Opus-4.8-judged · full 10-conversation set · n = 1,540 answerable questions · best config (mxbai embedder + date-routed context + temporal scaffold + k=32 budget, tri-engine fusion on).*
+*Claude-Opus-4.8-judged · full 10-conversation set · n = 1,540 answerable
+questions (adversarial excluded, as is standard practice since the Mem0 paper —
+stated explicitly so the denominator is unambiguous) · best config (mxbai
+embedder + date-routed context + temporal scaffold + k=32 budget, tri-engine
+fusion on).*
 
 | Category | Answer accuracy | Evidence recall @k=32 |
 |---|---|---|
@@ -30,21 +255,30 @@
 | Open-domain | 24% | 76% |
 | **Aggregate (answerable)** | **56%** | **89%** |
 
-**Statistically validated, not just measured once**: paired McNemar tests + a cluster
-bootstrap over the 10 conversations confirm the temporal lift from dated recall alone is
-real and large (+33.6pp over baseline, 95% CI [27.1, 41.0]). The temporal scaffold's
-*additional* gain on top of dated recall (+5.6pp here) and the aggregate answerable gain
-(+1.1pp) are both directionally positive but **not statistically distinguishable from
-zero at this sample size** (CIs cross zero) — treat the scaffold's marginal benefit as
-unproven, not confirmed. Full numbers, tests, and charts:
+Without the optional temporal scaffold (dated recall only, same pipeline) the
+same 10-conversation set gives **54% answerable / 55% temporal** — that is the
+statistically proven configuration; the scaffold's additional gain to the 56%/61%
+headline is directionally positive but not statistically proven (next
+paragraph). Both runs, with confidence intervals, are in the
+[research report](../../docs/planning/LOCOMO_TEMPORAL_DECOMP_RESEARCH.md).
+
+**Statistically validated, not just measured once**: paired McNemar tests + a
+cluster bootstrap over the 10 conversations confirm the temporal lift from dated
+recall alone is real and large (+33.6pp over baseline, 95% CI [27.1, 41.0]). The
+temporal scaffold's *additional* gain on top of dated recall (+5.6pp here) and
+the aggregate answerable gain (+1.1pp) are both directionally positive but **not
+statistically distinguishable from zero at this sample size** (CIs cross zero) —
+treat the scaffold's marginal benefit as unproven, not confirmed. Full numbers,
+tests, and charts:
 [`docs/planning/LOCOMO_TEMPORAL_DECOMP_RESEARCH.md`](../../docs/planning/LOCOMO_TEMPORAL_DECOMP_RESEARCH.md).
 
 ## The tuning trajectory
 
 The honest engineering story from early development — what each change bought,
-Claude-judged on a small 2-conversation exploratory subset at the time. **Superseded by
-the statistically-validated 10-conversation headline above**; kept here for the
-methodological trace of which levers mattered, not as a current accuracy claim:
+Claude-judged on a small 2-conversation exploratory subset at the time.
+**Superseded by the statistically-validated 10-conversation headline above**;
+kept here for the methodological trace of which levers mattered, not as a
+current accuracy claim:
 
 | Step | Aggregate (2-conv, historical) | What it fixed |
 |---|---|---|
@@ -54,15 +288,34 @@ methodological trace of which levers mattered, not as a current accuracy claim:
 | + Budget routing (k=32) | ~55% | gives multi-hop room to reason — multi-hop 40% → 58% |
 | + Temporal scaffold | ~57–58% (2-conv) | timeline + "now" anchor + date-arithmetic |
 
-The 2-conv run's apparent single-hop cost of the temporal scaffold (a −6pp drop) did
-**not** reproduce at 10-conversation scale with paired statistics (see the research
-report) — it was a small-sample artifact, not a real trade-off. The lesson that did
-hold up: most of the gain came not from a bigger model but from *grounding the answerer
-in time* and *budgeting retrieved evidence* — both cheap, both local.
+The 2-conv run's apparent single-hop cost of the temporal scaffold (a −6pp drop)
+did **not** reproduce at 10-conversation scale with paired statistics (see the
+research report) — it was a small-sample artifact, not a real trade-off. The
+lesson that did hold up: most of the gain came not from a bigger model but from
+*grounding the answerer in time* and *budgeting retrieved evidence* — both
+cheap, both local.
 
 ## Retrieval vs reasoning
 
-We report **evidence recall** (did retrieval surface the gold facts?) separately from **answer accuracy**, because they are different failure modes. The remaining gap is not the generator: swapping the local answerer for a GPT-4-class model (Claude Opus 4.8) did **not** lift multi-hop accuracy — it landed at the same ~50–58%. The cap is the benchmark's inherent difficulty (incomplete multi-hop evidence chains, and open-domain questions whose answer was never stated in the conversation), which is exactly why independently-measured systems cluster around ~55%. Our ~56% sits in that cluster — running fully local.
+We report **evidence recall** (did retrieval surface the gold facts?) separately
+from **answer accuracy**, because they are different failure modes. Within our
+harness, the remaining gap is not the generator: swapping the local answerer
+for a GPT-4-class model (Claude Opus 4.8), everything else held fixed, did
+**not** lift multi-hop accuracy — it landed at the same ~50–58%. The cap is the
+benchmark's inherent difficulty (incomplete multi-hop evidence chains, and
+open-domain questions whose answer was never stated in the conversation). This
+is a statement about the *multi-hop category under our fixed retrieval* — it
+does not contradict the observation below that a stronger generator lifts
+*aggregate* scores ~10pp in a controlled swap: multi-hop specifically is capped
+by evidence completeness, which no generator can fix.
+Bonus finding, disclosed as exploratory (2-conversation subset, Claude-judged —
+not part of the statistically-validated 10-conversation headline above, and
+not yet backed by a published table on this page): the fused tri-engine at
+k=32 reached about the same multi-hop accuracy as brute-force vector retrieval
+at k=64 in that smaller run — suggestive that **the graph can reach similar
+accuracy on half the context budget**, which would roughly halve the answering
+token bill. Treat this as a lead worth confirming at full scale, not a proven
+claim.
 
 ## How to reproduce
 
@@ -81,13 +334,48 @@ cargo run --release -p velesdb-memory --features ollama --example locomo -- \
   --embed-model mxbai-embed-large --date-context --date-route --k 32 --claude-judge
 ```
 
-Flags: `--conversations N`, `--only <category>` (targeted A/B), `--model <ollama-chat-model>` (answerer), `--graph-boost`, `--idf-weight`, `--multihop-only`, `--temporal-scaffold`. The Claude judge runs through the authenticated `claude` CLI; the harness caches every LLM call, so re-runs are free and any judge can be substituted.
+Flags: `--conversations N`, `--only <category>` (targeted A/B), `--model
+<ollama-chat-model>` (answerer), `--graph-boost`, `--idf-weight`,
+`--multihop-only`, `--temporal-scaffold`. The Claude judge runs through the
+authenticated `claude` CLI; the harness caches every LLM call, so re-runs are
+free and any judge can be substituted.
 
-## Comparative context
+## Comparative context — read before comparing any two LoCoMo numbers
 
-On a sober, third-party basis, the [PISA paper](https://arxiv.org/pdf/2510.15966) reports **Mem0 ~55%** and **Zep ~34%** on LoCoMo. Our ~56% puts velesdb-memory at **Mem0-tier accuracy — running fully local.**
+**Cross-harness LoCoMo scores are not comparable.** The same system swings by
+~21 points depending on whose harness measures it, and generator choice alone
+moves scores ~10pp. So instead of one misleading bar chart, here is the honest
+landscape, every figure sourced:
 
-Be skeptical of vendor headlines: Mem0's own ~92% and Zep's (later retracted, [corrected to ~58%](https://github.com/getzep/zep-papers/issues/5)) ~84% use cloud GPT-4o and methodology that has been contested. We do **not** claim to beat those; we claim sober parity with the independently-measured numbers, plus full locality and a reproducible harness.
+| System | Vendor-claimed | Measured outside the vendor's own eval | Harness of that measurement |
+|---|---|---|---|
+| Mem0 | 66.9–68.4 ([paper](https://arxiv.org/abs/2504.19413)); 91.6+ ([2026 README](https://github.com/mem0ai/mem0)) | **62.5** / **64.2** | [MIRIX](https://arxiv.org/abs/2507.07957) (gpt-4.1-mini) / [PISA](https://arxiv.org/abs/2510.15966) (generator not stated) |
+| Zep | 84 → [corrected 75.1](https://blog.getzep.com/lies-damn-lies-statistics-is-mem0-really-sota-in-agent-memory/) | **58.4** (by competitor Mem0 — disputed by Zep) / **79.1** (neutral) | [Mem0's run](https://github.com/getzep/zep-papers/issues/5) (gpt-4o-mini) / [MIRIX](https://arxiv.org/abs/2507.07957) (gpt-4.1-mini) |
+| Full-context (no memory system) | — | **72.9** (gpt-4o-mini) / **87.5** (gpt-4.1-mini) | [Mem0 paper](https://arxiv.org/abs/2504.19413) / [MIRIX](https://arxiv.org/abs/2507.07957) |
+| Filesystem agent (no memory system) | — | **74.0** | [Letta](https://www.letta.com/blog/benchmarking-ai-agent-memory/) (gpt-4o-mini) |
+| **velesdb-memory** | — | **56 aggregate / 55–61 temporal** — *self-measured, not independent*; the only fully-local entry on this table | ours (local qwen-35b generator, Opus 4.8 judge, config above) |
+
+What we actually claim from this table:
+
+1. **Every other row runs a frontier cloud generator; ours is a local 35B —
+   and, per the swing above, the eval stack moves the number as much as the
+   product does.** Even the full-context ceiling (no memory system at all)
+   moves from 72.9 to 87.5 depending on the generator. Our fully-local 56 sits
+   within a few points of the lowest cloud measurements in this table and well
+   under the strongest-stack ones — the honest statement is that it is in the
+   field's measured span, achieved with no cloud at all.
+2. **Our temporal category (55–61%; the floor is the configuration without the
+   optional scaffold) spans both rows Mem0's own paper reports for itself in
+   that category** ([source, Table 1](https://arxiv.org/abs/2504.19413)):
+   roughly level with base Mem0 (55.5%) at our floor, and above even Mem0's
+   graph-enhanced variant (**Mem0g, 58.1% — the paper's own best score in that
+   column**) at our ceiling — while Zep sits at 49.3% in that same evaluation
+   (a measurement by competitor Mem0, which Zep disputes). This is also the one
+   category with a statistically validated within-harness ablation behind it
+   (+33.6pp).
+3. **We do not claim to beat anyone's vendor headline.** We claim disclosed
+   config, paired statistics, a bundled harness, and retrieval metrics (Part 1)
+   nobody else publishes.
 
 ## Limitations & next
 
@@ -95,117 +383,5 @@ Be skeptical of vendor headlines: Mem0's own ~92% and Zep's (later retracted, [c
 - **The temporal scaffold's marginal benefit over dated-recall-alone is unproven at this sample size** (its point-estimate gain has a confidence interval crossing zero) — dated recall alone already captures nearly all of the temporal lift.
 - **Open-domain is the weak spot** (24%) — questions needing world knowledge beyond what the conversation stated; the next tuning target.
 - **Temporal is hard industry-wide**; date-grounding is exactly where we invested, and it's the proven, statistically robust win (+33.6pp over baseline).
-- Numbers are **our measurement** under the config above, not a leaderboard submission. The point is that you can re-run it yourself.
-
----
-
-# velesdb-memory on HotpotQA — where the graph earns its keep
-
-LoCoMo's headline metric is generation-capped (everyone clusters ~55% because a small local model is the ceiling). To measure the *memory* itself — independent of any generator — we evaluate on **[HotpotQA](https://hotpotqa.github.io/)** (distractor setting), the standard multi-hop benchmark with **sentence-level supporting-fact annotations**. The metric is purely retrieval: of a question's two gold supporting-fact sentences, how many does the system surface? No LLM answers, no judge — so this isolates the tri-engine's multi-hop retrieval, which is exactly where the graph is supposed to help.
-
-## Setup (HotpotQA)
-
-Each question carries 10 paragraphs (2 gold + 8 distractors) split into sentences. We ingest every sentence as a memory, build an entity graph from the paragraph **titles** (each sentence links to its own title and to any other title it mentions — that mention is the multi-hop *bridge*), then retrieve a top-`k` budget two ways: pure **vector** similarity vs the **fused** vector + graph (`why()`), where a graph bridge is weighted by the inverse-document-frequency of the connecting title (a rare, specific bridge counts; a common one is downweighted). Embedder: `mxbai-embed-large`, local. Fully generation-free.
-
-## Result (3 000 questions, k=5)
-
-| Question type | Retrieval | Supporting-fact recall | Both gold facts retrieved |
-|---|---|---|---|
-| **bridge** (true multi-hop, n=2 400) | Vector only | 68.7% | 41.3% |
-| | **+ tri-engine graph (idf)** | **73.0% (+4.3pp)** | **48.5% (+7.2pp)** |
-| comparison (n=600) | Vector only | 85.5% | 70.3% |
-| | + graph | 84.6% (−0.9) | 69.2% (−1.1) |
-| **All** | Vector only | 72.1% | 47.1% |
-| | **+ tri-engine graph (idf)** | **75.3% (+3.3pp)** | **52.7% (+5.6pp)** |
-
-(The win holds and slightly grows from the 1 000-question sample — bridge both-facts +6.9pp → +7.2pp — and the comparison drag shrinks; statistically robust at 3 000-question scale.)
-
-The split is the story. On **bridge** questions — the genuine multi-hop, 81% of the set, where the answer requires following a bridge entity to a second-hop fact a vector store ranks *low by construction* — the graph delivers a large, clean win: **+4.0pp recall, +6.9pp on retrieving both facts.** On **comparison** questions (both entities are named in the question, so there is no bridge to follow), pure vector already finds everything and the graph only adds noise — so a one-line router (apply the graph to bridge-style questions only) keeps the best of both. The win is robust across budgets (k=3/4/5) and holds at 1 000-question scale.
-
-A naive flat-boost graph *hurts* at tight budgets; the **idf weighting** (a rare bridge title is a real connection, a common one is noise) is what turns it into a net gain — the same lever that works on LoCoMo.
-
-## Why this matters
-
-This is the differentiator competitors don't report: pure RAG (and orchestrator-style memory layers) rank by vector similarity, which by construction misses the second-hop fact (it's *dissimilar* to the question — that's what makes it multi-hop). Our graph pulls it in, and **`why()` returns the scored evidence path** — the actual bridging sentences and the title that connects them — not just an answer. Same-basis, generation-free, on a public benchmark: the tri-engine adds retrieval quality a vector store cannot.
-
-## Reproduce
-
-```sh
-ollama pull mxbai-embed-large
-# fetch HotpotQA dev (distractor) into examples/multihop/data/
-cargo run --release -p velesdb-memory --features ollama --example multihop -- \
-  --questions 300 --k 4 --idf --embed-model mxbai-embed-large
-```
-
-Limitations: entity graph is title-mention based (a learned relation extractor could go further); supporting-fact recall measures *retrieval*, the upstream half of QA.
-
-## Corroboration: the same harness on 2WikiMultiHopQA
-
-A single dataset can flatter a method. To check the graph win is not a HotpotQA artifact we ran the **identical, unmodified harness** — same fusion, same idf-weighted bridge, same metric — on **[2WikiMultiHopQA](https://github.com/Alab-NII/2wikimultihop)** (Ho et al., 2020), an independently constructed multi-hop benchmark built over Wikipedia + Wikidata with the same supporting-fact annotation. Only the data changed.
-
-| 2Wiki dev — 1 000 questions, k=5 | n | Vector | Vector + graph | Δ |
-|---|---|---|---|---|
-| compositional | 430 | 59.0% | 62.1% | **+3.1pp** |
-| inference | 98 | 49.5% | 52.6% | **+3.1pp** |
-| bridge_comparison | 231 | 57.3% | 59.9% | **+2.6pp** |
-| comparison | 241 | 91.5% | 90.9% | −0.6pp |
-| **ALL** | **1 000** | **65.5%** | **67.6%** | **+2.1pp** |
-
-The win **replicates**: the graph lifts exactly the question types that require a genuine second hop (compositional and inference, both **+3.1pp**; bridge_comparison +2.6pp), and only nudges *down* the `comparison` type (−0.6pp), where both entities are already named in the question so there is no bridge for the graph to recover and the saturated vector recall (91.5%) leaves nothing to gain.
-
-Stated plainly: the lift is **real but more modest than on HotpotQA** (+2.1pp overall here vs +3.3pp there; 2Wiki's many comparison/short-fact questions give the graph less to do). What matters for the architectural claim is that the directional result — *the graph earns its keep on multi-hop retrieval* — holds across two independently built datasets, not one.
-
-```sh
-# convert 2Wiki dev (voidful/2WikiMultihopQA) into the column-oriented schema,
-# then run the SAME example used for HotpotQA — only --dataset changes:
-cargo run --release -p velesdb-memory --features ollama --example multihop -- \
-  --dataset examples/multihop/data/twowiki_dev_1000.json --questions 1000 --k 5 --idf
-```
-
----
-
-# velesdb-memory — the ColumnStore earns its keep (time-scoped retrieval)
-
-The graph is one of three engines; the **ColumnStore** is the one a vector store cannot emulate at all. When the answer depends on a *time scope* — "who held the role between 2009 and 2015?" — every candidate is near-identical in embedding space and differs only by a number. Cosine similarity literally cannot disambiguate the year; a numeric range predicate can. This pilot benchmarks the `recall_where(year ≥ lo AND year ≤ hi)` path end-to-end (it was unit-tested but never run as a benchmark).
-
-**Setup (synthetic, generation-free — a wiring + metric sanity check):** mint `(person, role, org, year)` tuples — each `(org, role)` has a succession of holders across the years, so every tuple for a role is embedding-near-identical and differs only by its `year` metadata column. A question scopes a year window; gold = the in-window holders. Out-of-window holders (same role, different year) are built-in distractors a time-blind retriever can't reject. Embedder `mxbai-embed-large`, local.
-
-**Result (108 time-scoped probes, k=5):**
-
-| Subset | Vector only | + ColumnStore `recall_where` |
-|---|---|---|
-| **Hard (≥2 in-window answers — range predicate required)** | 69.2% | **87.8% (+18.6pp)** |
-| Single (1 in-window answer) | 100% | 100% |
-| All | 79.4% | **91.9% (+12.5pp)** |
-
-On the hard subset where a range filter is genuinely required, the ColumnStore lifts answer-bearing recall by **+18.6pp** — a step change, because it is a *predicate*, not a learned ranking. On single-answer probes vector already saturates, so the filter costs nothing.
-
-## Real data: TimeQA
-
-The same `recall_where` arm, on real Wikipedia bios. **[TimeQA](https://huggingface.co/datasets/hugosousa/TimeQA)** asks time-scoped questions ("what position did X hold from 1997 to 2001?") over a person's bio, which lists their many positions across the years. We split the bio into sentences, forward-fill a `year` column along the (roughly chronological) timeline, parse the question's window, and score retrieval of the sentence(s) containing the gold answer — vector-only vs vector + `recall_where(year ≥ lo AND year ≤ hi)`. Generation-free.
-
-| TimeQA (405 answerable time-scoped questions, k=5) | Gold-sentence recall@k |
-|---|---|
-| Vector only | 36.3% |
-| **+ ColumnStore `recall_where`** | **46.0% (+9.7pp, +27% relative)** |
-
-On real data the lift is smaller than the synthetic pilot (noisier prose, approximate year imputation, some answer sentences carry no year) but **clear and substantial** — the `recall_where(Ge/Le)` path, unit-tested but never benchmarked end-to-end, demonstrably improves time-scoped retrieval that cosine alone cannot.
-
-**Together, all three engines show a measured advantage over vector-only retrieval, generation-free, on public/real data:** Graph (`why()` BFS) **+7.2pp** on retrieving both bridge facts of a multi-hop question (HotpotQA, 3 000 dev) — and the win **replicates on a second independent dataset, 2WikiMultiHopQA** (+2.1pp overall, +3.1pp on the genuinely-bridged types); ColumnStore (`recall_where`) **+9.7pp** on time-scoped questions (TimeQA real data; +18.6pp on the controlled synthetic pilot). That is the tri-engine, *demonstrated* — not just wired. The honest limit of each is disclosed (HotpotQA/2Wiki comparison questions, TimeQA year imputation, and the more modest 2Wiki magnitude stated as measured), and every number is reproducible from the bundled examples.
-
----
-
-# velesdb-memory — the engines *compound* (tri-engine capstone)
-
-The three benchmarks above prove each leg beats vector on *its own* specialty. The remaining question is whether the legs **stack** when a single question needs more than one of them. We construct a task that is multi-hop **and** time-scoped at once: ten companies with **opaque names** (decoupled from their cities), each with dated office-holder facts (a `year` column) plus one location fact `"{company} is headquartered in {city}"`. The probe names a **city**, a **role**, and a **year window** — "Who was the {role} of the company headquartered in {city} from {lo} to {hi}?"
-
-To answer it you must resolve two independent axes that vector similarity owns neither of: **which company** (the role-facts never mention the city — only the graph location-edge connects them) and **which period** (the candidates differ only by a number — a `recall_where(year ∈ [lo,hi])` predicate, not cosine). Generation-free; we score answer-bearing recall@k under four arms.
-
-| Arm | answer-bearing recall@5 | vs vector |
-|---|---|---|
-| Vector only | 21.0% | — |
-| + ColumnStore (`year ∈ [lo,hi]`) | 26.0% | +5.0pp |
-| + Graph (`why()`: city → company) | 37.0% | +16.0pp |
-| **+ both engines** | **50.0%** | **+29.0pp** |
-
-The ladder is monotone and, crucially, **super-additive**: the two engines together lift recall **+29pp**, more than the **+21pp** (= +5 + +16) they would give if their contributions were merely independent. Each engine fixes one axis the other can't — Graph resolves *which* company via the location-edge bridge, ColumnStore resolves *which* period via the numeric range — and only with both does the system find the right person in the right company in the right window. That is the architectural claim made literal: one embedded engine, three retrieval modes, fused in a single collection, doing together what no single mode can. (Synthetic by necessity — no public benchmark isolates "multi-hop AND time-scoped" — but every number reproduces from `examples/triengine`.)
+- **The headline uses the best config found on these same 10 conversations** (LoCoMo has no held-out split); the without-scaffold number (54% answerable / 55% temporal) is published alongside it above.
+- Not a leaderboard submission — a self-run harness. A LongMemEval run, the benchmark serious actors are moving to, is the tracked next step.

--- a/crates/velesdb-memory/BENCHMARK.md
+++ b/crates/velesdb-memory/BENCHMARK.md
@@ -308,14 +308,38 @@ is a statement about the *multi-hop category under our fixed retrieval* — it
 does not contradict the observation below that a stronger generator lifts
 *aggregate* scores ~10pp in a controlled swap: multi-hop specifically is capped
 by evidence completeness, which no generator can fix.
-Bonus finding, disclosed as exploratory (2-conversation subset, Claude-judged —
-not part of the statistically-validated 10-conversation headline above, and
-not yet backed by a published table on this page): the fused tri-engine at
-k=32 reached about the same multi-hop accuracy as brute-force vector retrieval
-at k=64 in that smaller run — suggestive that **the graph can reach similar
-accuracy on half the context budget**, which would roughly halve the answering
-token bill. Treat this as a lead worth confirming at full scale, not a proven
-claim.
+An earlier exploratory note here suggested the graph might reach the same
+multi-hop accuracy on *half* the context budget (fused at k=32 ≈ brute-force
+vector at k=64), which would roughly halve the answering token bill. We measured
+that lead at fuller scale (10-conversation set, local `all-minilm` embedder +
+local qwen judge — a self-consistent A/B, not the mxbai + Claude-judge headline
+config above) and **it did not hold**, so we retract it:
+
+- **The graph is retrieval-neutral here.** With the budget held fixed,
+  vector+graph and vector-only land within ~1pp of each other on every category
+  (graph contribution: temporal −1.2…+0.9pp over 321 questions, single-hop
+  +0.1…+0.6pp over 624, multi-hop −0.4…+0.0pp over 282 paired). The graph does
+  not measurably move retrieval accuracy on LoCoMo. The bar it would clear —
+  surfacing *at least one* gold fact — is already saturated: vector recall hits
+  it ~85–97% of the time (93–97% on multi-hop and temporal), so the graph rarely
+  rescues a question vector missed outright.
+- **The graph does not buy back a smaller budget.** Fused at k=32 lands ~4pp
+  *below* brute-force vector at k=64 on multi-hop (56% vs 60%) — the opposite of
+  the retracted lead. Budget helps where the graph doesn't because a multi-hop
+  answer needs a *chain* of facts, not one: the ≥1-fact bar is saturated, but
+  the full chain is not. Going from k=32 to k=64 raises the mean gold-evidence
+  facts retrieved per multi-hop question from 2.6 to 3.1 (37% of questions gain
+  at least one more), and that added chain coverage is what lifts accuracy.
+  Those facts sit at vector ranks 33–64 — a wider vector budget captures them;
+  graph traversal does not. The already-saturated categories, meanwhile, stay
+  flat (temporal +0.3pp, single-hop +1.3pp) and only pay extra tokens.
+
+So the honest decomposition of the tri-engine on LoCoMo: **date grounding
+(ColumnStore) and retrieval budget carry the accuracy; graph traversal does
+not.** The graph earns its place elsewhere in velesdb — as the substrate `why()`
+walks for auditable provenance — not as a retrieval-accuracy lever on this
+benchmark. Reproduce the budget contrast with `--only multi-hop --k 32` vs
+`--k 64`, both `--use-shipped-api --date-context`.
 
 ## How to reproduce
 

--- a/crates/velesdb-memory/CHANGELOG.md
+++ b/crates/velesdb-memory/CHANGELOG.md
@@ -7,6 +7,17 @@ released on its own `velesdb-memory-vX.Y.Z` tag.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2026-07-06
+
+### Added
+
+- **`format_dated_context` / `DatedContext` (new `dated_context` module)** —
+  formats recalled facts into a chronological, "now"-anchored timeline for dated
+  recall; the primitive behind `recall_fused`'s `date_field` (MCP/Python) and
+  `recallFusedDated` (Node/WASM/TypeScript SDK). (#1315, #1316)
+- **Node binding `recallFusedDated`** — fused recall returning the dated timeline
+  plus a `now` anchor in a single call. (#1316)
+
 ## [0.4.0] - 2026-07-03
 
 ### Added

--- a/crates/velesdb-memory/Cargo.toml
+++ b/crates/velesdb-memory/Cargo.toml
@@ -2,7 +2,7 @@
 name = "velesdb-memory"
 # Independent of the workspace version: velesdb-memory is a young MCP wrapper
 # with its own release cadence, decoupled from the core engine's 3.x line.
-version = "0.4.0"
+version = "0.5.0"
 edition.workspace = true
 rust-version.workspace = true
 license-file = "../../LICENSE"

--- a/crates/velesdb-memory/POSITIONING.md
+++ b/crates/velesdb-memory/POSITIONING.md
@@ -1,51 +1,179 @@
-# velesdb-memory — Positioning (draft)
+# velesdb-memory — Positioning
 
-> Draft marketing/positioning, grounded in honest LoCoMo measurements (local stack,
-> Opus-4.8-judged). Not committed. See `examples/locomo/` for the benchmark.
+> Marketing/positioning reference, grounded in our own measurements (local stack,
+> Opus-4.8-judged, methodology and stats in [`BENCHMARK.md`](BENCHMARK.md)) and in
+> **sourced** third-party numbers — every external figure below links to where it
+> comes from. See `examples/locomo/` for the reproducible harness.
 
 ## 1. Positioning statement
 
-**velesdb-memory is the agent-memory layer that IS the database: a single embedded Rust engine fusing vector, graph, and column storage in one WAL — running 100% local, returning the evidence path behind every recall, not just an answer.**
+**velesdb-memory is the explainable local memory for AI agents — one embedded
+binary, zero API keys, and we publish our retrieval numbers.** In plain terms:
+it's the memory layer that runs entirely on your own machine as a single small
+program, never sends data (or money) to a cloud AI service just to store a
+memory, can show the evidence trail behind every answer (`why()`), and backs its
+quality claims with numbers measured on public test sets that anyone can re-run.
 
-## 2. The category insight
+## 2. The three claims no competitor counters
 
-Today's leading agent-memory tools are not databases — they are orchestrators. Mem0 coordinates a separate Qdrant (vectors) plus Postgres (state) plus, for graph mode, Neptune; Zep/Graphiti are shaped the same way. That works fine when memory is a hosted SaaS call. But it is the wrong shape for a fast-growing class of users: anyone who has to *self-host*. Self-hosting Mem0 doesn't mean running Mem0 — it means standing up and operating a service mesh, and wiring it to a cloud LLM that every memory write and query depends on. For teams under data-residency, air-gap, or cost constraints, "a memory layer that requires three backing services and a per-token cloud bill" is operational and compliance debt disguised as a feature. The right shape for these users is one binary, on your hardware, with no token outbound.
+**1. Explainable, *measured* recall.** `why()` returns the actual evidence
+trail — which facts an answer came from and how they connect, with scores —
+where every competitor returns only an answer. And we are — to our knowledge —
+the only agent-memory project that publishes **how often the memory finds the
+right information**,
+measured on public test sets with no AI grader in the loop (so no model can
+flatter the score): the graph engine finds the two linked facts a multi-step
+question needs **+7.2 percentage points more often on HotpotQA** (3,000
+questions), a result replicated on a second independent test set
+(2WikiMultiHopQA: **+2.6 to +3.1 points on its three bridged question types**,
++2.1 overall); the column engine finds date-scoped
+answers **+9.7 points more often on TimeQA**. Nobody else in this market
+reports retrieval quality at all — you can't be out-benchmarked on a number
+only you publish. (All tables: [`BENCHMARK.md`](BENCHMARK.md).)
 
-## 3. Key messages
+**2. One binary, zero API keys.** The single most-repeated complaint about the
+incumbent memory layers is that **saving one memory triggers 2–3 AI-model calls
+— by default, paid cloud calls with an API key** (local-model setups exist but
+keep the per-write AI calls) — on top of the stack of separate services you
+must install and operate (Qdrant + Postgres for Mem0; Neo4j/FalkorDB for
+Graphiti — and Zep's self-hosted edition was
+[discontinued in 2025](https://blog.getzep.com/announcing-a-new-direction-for-zeps-open-source-strategy/)).
+velesdb-memory is one small embedded program: no Qdrant, no Postgres, no Neo4j —
+and storing or recalling a memory requires **no AI call at all** (AI-based fact
+extraction exists as an *option*, and it runs on a model on your own machine).
 
-- **It's a database, not a service mesh.** velesdb-memory ships as one embedded Rust binary (published 3.3.0 on crates.io / PyPI / npm) — no Qdrant, no Postgres, no Neptune to operate.
-- **100% local-first.** It runs on a local stack (ollama embedder + local chat model), so data never leaves the box — air-gappable, sovereign, and free of per-token API cost.
-- **Tri-engine fused in one collection/WAL.** Vector + Graph + ColumnStore live in a single write-ahead log, enabling fused vector + graph + date-window retrieval instead of stitching across systems.
-- **Explainable recall via `why()`.** It returns the actual evidence path — which facts, connected through which entities — where competitors return only an answer.
-- **The tri-engine earns its keep — all three legs, measured.** Each engine beats pure vector retrieval on its specialty, generation-free: the **graph** (`why()` BFS) **+7.2pp** on retrieving both bridging facts of a true multi-hop question (HotpotQA, 3 000 dev) — and the win **replicates on a second independent dataset** (2WikiMultiHopQA, same harness, +3.1pp on the genuinely-bridged question types), so it is not a one-dataset artifact; the **ColumnStore** (`recall_where`, numeric range) **+9.7pp on real time-scoped questions** (TimeQA; +18.6pp on a controlled pilot) that a vector store *cannot* disambiguate (the candidates differ only by a number); and the fused engines reach the same LoCoMo accuracy at **half the context budget**. A pure RAG / orchestrator-over-Qdrant has none of these — it ranks by cosine and stops.
-- **And the engines *compound*, not just coexist.** On a task that is multi-hop *and* time-scoped at once (find the right person, in the right company, in the right year-window), Graph alone adds +16pp and ColumnStore alone +5pp — but **both together add +29pp**, more than the sum of their parts. Each resolves an axis the other can't; fused in one collection they do together what no single retrieval mode can. (Generation-free; `examples/triengine`.)
-- **Quality in the same tier, soberly measured.** On our honest LoCoMo measurements (local qwen-35b + mxbai-embed-large, Opus-4.8-judged, full 10-conversation set, statistically validated with paired tests) we see ~56% aggregate, ~55% multi-hop, and **~61% temporal** — the category every memory system is weakest on, and the one lever we can prove moves the needle: +33.6pp over baseline (95% CI [27.1, 41.0]). Retrieval recall is ~89%, so the remaining gap is the local *answerer*, not the memory.
+**3. Time-aware memory, statistically validated.** Answering "when did X
+happen?" questions is the weakest category for every memory system. Our fix —
+storing each fact with its date and presenting recalled facts in dated,
+chronological order — lifts accuracy on those questions by **+33.6 percentage
+points over baseline**, and that gain is confirmed by paired statistical tests
+(meaning: it's a real effect, not a lucky run — 95% confidence interval
+[27.1, 41.0], measured across the full 10-conversation test set). Independent
+research reached the same conclusion — time-aware retrieval is one of the most
+effective memory techniques ([LongMemEval paper](https://arxiv.org/abs/2410.10813)).
+Our time-question score lands at **55–61%** (the floor is the statistically
+proven configuration; the ceiling adds an optional prompt scaffold whose extra
+gain is directionally positive but not yet statistically proven) — spanning
+both rows the [Mem0 paper's own evaluation](https://arxiv.org/abs/2504.19413)
+reports for that category: roughly level with base Mem0 (55.5%) at our floor,
+and above even Mem0's graph-enhanced variant (**Mem0g, 58.1% — the paper's own
+best score in that column**) at our ceiling. Zep scores 49.3% in that same
+evaluation (a measurement by competitor Mem0, which Zep disputes) — both run
+**on powerful cloud AI models**, ours on a model on your own machine.
+
+## 3. The category insight
+
+Today's leading agent-memory tools are not databases — they are orchestrators.
+Mem0 coordinates a separate Qdrant (vectors) plus Postgres (state) plus, for
+graph mode, a graph database; Zep/Graphiti are shaped the same way. That works
+when memory is a hosted SaaS call. It is the wrong shape for a fast-growing
+class of users: anyone who has to *self-host*. Self-hosting an orchestrator
+means standing up and operating a service mesh, and wiring it to a cloud LLM
+that every memory write depends on. For teams under data-residency, air-gap, or
+cost constraints, that is operational and compliance debt disguised as a
+feature. The right shape is one binary, on your hardware, with no token
+outbound.
 
 ## 4. Honest comparison
 
 | | **velesdb-memory** | **Mem0** | **Zep / Graphiti** |
 |---|---|---|---|
-| **Nature** | Database (embedded tri-engine) | Orchestrator over Qdrant + Postgres (+ Neptune) | Orchestrator (graph-centric) |
-| **Deployment** | Single Rust binary | Service mesh to self-host | Service mesh to self-host |
-| **LLM dependency** | Local model stack, no cloud | Cloud LLM in the loop | Cloud LLM in the loop |
-| **Explainability** | `why()` returns evidence path | Returns an answer | Returns an answer |
-| **LoCoMo (sober/local)** | ~56% agg, **61% temporal** (local stack, our measurement, full 10-conv) | ~55% (PISA, neutral 3rd-party) | ~34% (PISA, neutral 3rd-party) |
-| **License/distribution** | Open, crates.io / PyPI / npm | Open core + hosted | Open core + hosted |
+| **Nature** | Database (embedded tri-engine) | Orchestrator over Qdrant + Postgres (+ graph DB) | Orchestrator (graph-centric, Neo4j/FalkorDB) |
+| **Deployment** | Single Rust binary | Service mesh to self-host | Zep CE [deprecated](https://blog.getzep.com/announcing-a-new-direction-for-zeps-open-source-strategy/); Graphiti needs a graph DB |
+| **LLM calls per memory write** | **Zero required** (opt-in local extraction) | Cloud LLM in the write path | Cloud LLM in the write path |
+| **Explainability** | `why()` returns the scored evidence path | Returns an answer | Graph inside, but no evidence-path API or metric |
+| **Retrieval metrics published** | **Yes — generation-free, public datasets** | No | No |
+| **LoCoMo** | 56% aggregate / **55–61% temporal** (floor = without the optional scaffold) — fully local stack, config + stats disclosed, reproducible harness | 66.9% in its own paper ([source](https://arxiv.org/abs/2504.19413)); neutral labs measure it lower — [sourced landscape](BENCHMARK.md) | 75.1% in its own corrected run ([source](https://blog.getzep.com/lies-damn-lies-statistics-is-mem0-really-sota-in-agent-memory/)); measurements by others — including one by competitor Mem0 that Zep disputes — span ~21 points — [sourced landscape](BENCHMARK.md) |
+| **License / distribution** | Source-available, crates.io / PyPI / npm / MCP registry | Open core + hosted | Graphiti OSS + hosted cloud |
 
-*Note: Mem0's own ~92% and Zep's retracted ~84% headlines use cloud GPT-4o and contested methodology. On the neutral PISA basis, the field — including us — sits far lower and much closer together.*
+*Reading the LoCoMo row honestly: benchmark scores from different labs are
+**not comparable** — the same product's score swings by ~21 points between
+labs' test setups ([sourced landscape](BENCHMARK.md)), and merely changing
+which AI model writes the answers moves scores by ~10 points
+([controlled rerun](https://blog.continua.ai/p/the-locomo-fair-fight)). Every
+number in the Mem0/Zep cells was produced with a powerful **cloud** AI model;
+ours runs on a model **on your own machine**. So we do not claim to beat
+anyone's overall score. What we do claim: on **time-related questions**
+(55–61%) our range spans both configurations the
+[Mem0 paper's evaluation](https://arxiv.org/abs/2504.19413) reports for
+itself — roughly level with base Mem0 (55.5%) at our floor, above its
+graph-enhanced Mem0g variant (58.1%, the paper's own best score there) at our
+ceiling — and clears Zep's 49.3% in that category throughout (a measurement by
+competitor Mem0, which Zep disputes); our full method and statistics are
+disclosed, and the test harness ships with the product so you can re-run it.*
 
-## 5. Why choose us (the close)
+## 5. Why we don't play the aggregate-score game (and you shouldn't trust it)
 
-"It's Mem0-tier recall quality, but it's *one binary that runs entirely on our own hardware* — no Qdrant/Postgres to operate, no cloud LLM bill, nothing leaving the box. And when it recalls something, `why()` shows us the exact facts and entities it reasoned over, so we can actually audit it."
+The LoCoMo aggregate has become a marketing number, not a measurement:
+
+- **The benchmark itself is flawed**: an [independent audit](https://dev.to/penfieldlabs/we-audited-locomo-64-of-the-answer-key-is-wrong-and-the-judge-accepts-up-to-63-of-intentionally-33lg)
+  found **6.4% of the answer key is wrong**, and a gpt-4o-mini judge **accepts
+  62.8% of intentionally wrong** but topically related answers.
+- **Vendor numbers don't reproduce**: Mem0's LongMemEval claim of 93.4% came out
+  at **73.8%** under a neutral judge ([independent reproduction](https://www.maximem.ai/blog/state-of-ai-memory-2026-claimed-vs-observed));
+  Zep's original 84% LoCoMo claim was corrected downward after a
+  [public methodology dispute](https://github.com/getzep/zep-papers/issues/5).
+- **A plain filesystem agent scores 74%** — beating most memory products —
+  which says more about the benchmark than about memory systems
+  ([Letta](https://www.letta.com/blog/benchmarking-ai-agent-memory/)).
+
+Our stance: publish the test harness, the exact configuration, the grader, the
+raw outputs, and the statistics; lead with **retrieval numbers measured without
+any AI grader** (so nothing can inflate them); and only compare categories
+measured under the same conditions. If you want to check us — the harness ships
+with the product, in `examples/locomo/`.
 
 ## 6. Hardest objection
 
-**"Mem0 reports 92% on LoCoMo — you're only ~55%. That's a big gap."**
+**"Mem0's README says 91.6% on LoCoMo — you report 56%. That's a huge gap."**
 
-It isn't a real gap — it's apples to oranges. Mem0's 92% headline runs on **cloud GPT-4o**; our numbers run on a **fully local** qwen-35b. The honest comparison is same-basis: the neutral PISA paper puts Mem0 at ~55% and Zep at ~34% on LoCoMo, and our local measurement lands at ~56% (best config, full 10-conversation set, statistically validated) — i.e. the same tier as Mem0, *measured soberly*. (Mem0's own 92% and Zep's ~84% are vendor headlines on contested methodology; Zep's was retracted.) So the real trade is: you give up roughly nothing on quality, and in return you get full locality, a single embedded engine instead of a service mesh, no per-token cloud bill, and an explainable evidence path. We will not claim a higher score — we claim the same quality on radically better architecture.
+Those two numbers are not on the same scale. The 91.6% is a vendor headline
+([their README](https://github.com/mem0ai/mem0)) on a contested, evolving eval
+stack — their own *paper* number was 66.9%, and neutral labs measure them lower
+still (sourced figures in [`BENCHMARK.md`](BENCHMARK.md)); it runs on cloud
+frontier generators, on a benchmark
+where the judge [accepts most wrong answers](https://dev.to/penfieldlabs/we-audited-locomo-64-of-the-answer-key-is-wrong-and-the-judge-accepts-up-to-63-of-intentionally-33lg)
+and [a filesystem agent scores 74%](https://www.letta.com/blog/benchmarking-ai-agent-memory/).
+Our 56% runs on a **fully local** 35B generator with the config, judge, paired
+statistics, and raw dumps disclosed — and the *category we invest in* holds up:
+temporal 55–61%, spanning both rows the
+[Mem0 paper's evaluation](https://arxiv.org/abs/2504.19413) reports for
+itself — roughly level with base Mem0 (55.5%) at our floor, above its
+graph-enhanced Mem0g variant (58.1%, the paper's own best score there) at our
+ceiling. So the real trade is explicit: on the *aggregate* score, our 56 sits
+roughly 6 to 8 points behind Mem0's neutral-lab measurements (62.5–64.2) and
+about 23 points behind Zep's neutral-lab measurement (79.1) — with the
+strongest cloud-generator eval stacks pulling the full-context ceiling itself
+up to 87.5, a ~31-point gap ([exact figures, sourced](BENCHMARK.md)) — nothing
+like the 35-point gap the vendor headline suggests — in exchange for full
+locality,
+one embedded engine instead of a service mesh, zero per-write AI cost, and an
+evidence path you can audit. We will not inflate a score to win a bar chart; we
+publish what you can reproduce.
 
 ## 7. Where local-first is a hard requirement
 
-1. **Regulated / sovereign data — healthcare, legal, defense, finance.** Patient notes, case files, and classified context cannot transit a third-party LLM API; local-first + `why()` gives both residency and an auditable recall trail for compliance.
-2. **Air-gapped / on-prem environments.** Networks with no outbound internet can't call a cloud LLM or stand up a managed Qdrant/Neptune — a single self-contained binary running against a local model stack is the only shape that deploys at all.
-3. **Cost-sensitive, high-volume agents.** When every memory write and query would otherwise be a per-token cloud call, moving extraction and recall onto a local stack removes the API bill entirely — economics that flip at scale.
+1. **Regulated / sovereign data — healthcare, legal, defense, finance.** Patient
+   notes, case files, and classified context cannot transit a third-party LLM
+   API; local-first + `why()` gives both residency and an auditable recall trail.
+   With the [EU AI Act's obligations enforceable from August 2, 2026](https://artificialintelligenceact.eu/implementation-timeline/),
+   "can you show why the agent recalled that?" becomes a compliance question —
+   `why()` is the audit trail, built in.
+2. **Air-gapped / on-prem environments.** Networks with no outbound internet
+   can't call a cloud LLM or operate a managed vector/graph service — a single
+   self-contained binary against a local model stack is the only shape that
+   deploys at all.
+3. **Cost-sensitive, high-volume agents.** When every memory write is 2–3
+   cloud-LLM calls, economics flip at scale: local extraction and recall remove
+   the per-token bill entirely. Early, exploratory signal (2-conversation
+   subset, not yet confirmed at full scale): the graph may reach similar
+   LoCoMo accuracy at **half the context budget** (fused k=32 vs brute-force
+   vector k=64 — see [`BENCHMARK.md`](BENCHMARK.md)), which would halve the
+   *answering* token bill too.
+
+## 8. The close
+
+"When it recalls something, `why()` shows us the exact facts and entities it
+reasoned over, so we can actually audit it. It's one binary on our own hardware —
+no Qdrant, no Neo4j, no OpenAI key per write, nothing leaving the box. And
+they're the only ones who publish retrieval numbers you can re-run yourself."

--- a/crates/velesdb-memory/README.md
+++ b/crates/velesdb-memory/README.md
@@ -84,20 +84,31 @@ Each is a real run that shows what plain recall misses and `why()` recovers:
 
 ## How it compares — and who it's for
 
-velesdb-memory is **embedded memory, not a cloud memory service.** On the LoCoMo QA
-benchmark it sits in the **same tier as Mem0** and well ahead of Zep on a sober,
-neutral-judge basis — but the real difference is the *architecture*, not the score:
+velesdb-memory is **embedded memory, not a cloud memory service.** The
+difference isn't a benchmark bar chart — it's three things no competitor
+counters: an **evidence trail you can audit** (`why()` shows which facts an
+answer came from), **zero AI calls to store a memory** (the incumbents run 2–3
+AI-model calls per save — by default, paid cloud calls), and **published
+retrieval numbers** — we measure, with no AI grader in the loop, how often the
+memory finds the right information; to our knowledge, nobody else in this
+market publishes that at all:
 
 | | **velesdb-memory** | Mem0 | Zep / Graphiti |
 |---|---|---|---|
-| Shape | one embedded binary (vector + graph + column) | orchestrator over Qdrant + Postgres | orchestrator (graph-centric) |
-| Runs | **100% local / offline** | cloud LLM in the loop | cloud LLM in the loop |
-| Explains | **`why()` returns the evidence path** | returns an answer | returns an answer |
-| LoCoMo (neutral PISA basis) | ~56% | ~55% | ~34% |
+| What it is | one embedded binary (vector + graph + column engines) | coordinator over separate services (Qdrant + Postgres) | coordinator, graph-centric (needs Neo4j/FalkorDB) |
+| AI calls to store a memory | **zero required** (optional extraction runs on your local model) | AI-model calls on every write (cloud by default) | AI-model calls on every write (cloud by default) |
+| Runs | **100% local / offline** | self-host still needs an AI service in the write path | Zep's self-hosted edition was discontinued; Graphiti needs a graph database + an AI service |
+| Explains its answers | **yes** — `why()` returns the evidence trail | no — returns an answer only | no — returns an answer only |
+| Publishes retrieval accuracy | **yes** — [+7.2pts multi-hop, +9.7pts time-scoped, no AI grader](BENCHMARK.md) | no | no |
+| Time-related questions on LoCoMo | **55–61%** on a fully local model — floor = without the optional scaffold ([method + stats](BENCHMARK.md)) | 55.5% base / 58.1% graph-enhanced "Mem0g" (its own best score), both on cloud AI ([own paper](https://arxiv.org/abs/2504.19413)) | 49.3% on cloud AI — [as measured in Mem0's evaluation](https://arxiv.org/abs/2504.19413), which Zep disputes |
 
-*Mem0's ~92% / Zep's ~84% headlines run on cloud GPT-4o with contested methodology; on
-the neutral basis the whole field sits far lower and close together — we do **not** claim
-to beat those headlines, we claim the same tier on radically better architecture.*
+*Why no single "overall score" comparison row? Because overall scores from
+different labs can't be fairly compared: the same product's score can swing
+~21 points between two test setups, and vendor headlines often diverge widely
+from what other labs measure. Our fully-local 56% aggregate comes with the
+full method and statistics disclosed, and instead of a bar chart we publish
+the complete sourced landscape — who measured what, with which AI models, and
+which figures are disputed: [`BENCHMARK.md`](BENCHMARK.md).*
 
 **Choose velesdb-memory when local-first is a requirement, not a preference:**
 - **Regulated / sovereign data** (health, legal, finance, defense) — context can't transit a third-party LLM API; `why()` gives both data residency and an auditable recall trail.
@@ -158,7 +169,7 @@ every figure reproduces from the bundled examples.
 | Engine | Public benchmark | What it measures | Vector → fused |
 |---|---|---|---|
 | **Graph** (`why()` BFS) | HotpotQA (3 000 dev, distractor) | retrieving *both* bridge facts of a multi-hop question | **+7.2pp** both-facts on bridge questions (+5.6pp all types) |
-| **Graph** — *replicated* | 2WikiMultiHopQA (1 000 dev) | same metric, second independent dataset | **+3.1pp** on bridged types (+2.1pp overall) |
+| **Graph** — *replicated* | 2WikiMultiHopQA (1 000 dev) | supporting-fact recall, second independently built dataset | **+2.6 to +3.1pp** on its three bridged types (+2.1pp overall) |
 | **ColumnStore** (`recall_where`) | TimeQA (real Wikipedia bios) | time-scoped recall a year-range filter can do and cosine can't | **+9.7pp** gold-sentence recall |
 | **Tri-engine** (compound) | synthetic, multi-hop **and** time-scoped | do the engines *stack*? | **+29pp** together — more than the sum of each alone |
 

--- a/crates/velesdb-memory/examples/locomo/dump/dump_tests.rs
+++ b/crates/velesdb-memory/examples/locomo/dump/dump_tests.rs
@@ -177,5 +177,6 @@ fn test_cfg() -> EvalCfg {
         bm25: false,
         claude_judge: false,
         claude_gen: false,
+        use_shipped_api: false,
     }
 }

--- a/crates/velesdb-memory/examples/locomo/eval.rs
+++ b/crates/velesdb-memory/examples/locomo/eval.rs
@@ -17,7 +17,7 @@ use std::error::Error;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use serde_json::json;
-use velesdb_memory::{ColumnFilter, ColumnOp};
+use velesdb_memory::{ColumnFilter, ColumnOp, FusionOptions};
 
 use crate::dataset::{Category, Qa};
 use crate::dump::{self, QuestionTrace};
@@ -89,6 +89,17 @@ pub struct EvalCfg {
     /// accuracy goes when the generator is not the bottleneck (the memory layer
     /// is model-agnostic — plug in any LLM).
     pub claude_gen: bool,
+    /// Run the fused (graph) path through the SHIPPED
+    /// [`MemoryService::recall_fused`](velesdb_memory::MemoryService::recall_fused)
+    /// API instead of the harness's own `vector_pool` + `graph_reached` + `fuse`.
+    /// Proves the benchmarked tri-engine ranking reproduces through the API a
+    /// user installs — not just a harness re-implementation. It drops the
+    /// harness-only levers `recall_fused` doesn't have: the BM25/RRF lexical
+    /// fusion, multi-seed graph reach (`seed_breadth`), and the temporal
+    /// `ColumnStore` date window (a `recall_where` range predicate, not an
+    /// exact-match filter `recall_fused` accepts) — so compare it against the
+    /// single-seed, no-BM25 harness config to isolate the ranking itself.
+    pub use_shipped_api: bool,
 }
 
 /// A retrieved fact carried into the generation context. `score` is its vector
@@ -349,13 +360,55 @@ fn retrieve(
         }
         return Ok((pool.into_iter().take(cfg.k).collect(), raw));
     }
-    // Fused mode: a ColumnStore date window when the question is time-scoped,
-    // plus graph traversal — all three engines.
+    // Fused mode, shipped path: the exact `recall_fused` a user installs does
+    // the vector+graph fusion internally. No temporal ColumnStore window (that
+    // is `recall_where`'s range predicate, which `recall_fused` doesn't take),
+    // no BM25, single-seed — see `use_shipped_api`'s doc.
+    if cfg.use_shipped_api {
+        let opts = FusionOptions {
+            hops: cfg.hops,
+            graph_boost: cfg.graph_boost,
+            pool: None,
+        };
+        let fused = shipped_fused(store, question, cfg.k, opts)?;
+        let raw = raw_if_wanted(&fused, &[], want_raw);
+        return Ok((fused, raw));
+    }
+    // Fused mode, harness path: a ColumnStore date window when the question is
+    // time-scoped, plus graph traversal — all three engines.
     let filters = temporal_filters(question);
     let pool = vector_pool(store, question, pool_size(cfg.k), &filters)?;
     let reached = graph_reached(store, question, cfg)?;
     let raw = raw_if_wanted(&pool, &reached, want_raw);
     Ok((fuse(pool, &reached, cfg), raw))
+}
+
+/// The shipped [`MemoryService::recall_fused`](velesdb_memory::MemoryService::recall_fused)
+/// path, mapped into the harness's [`RetrievedFact`]. `recall_fused` already
+/// ranks vector+graph and excludes entity hubs, so this only re-hydrates the
+/// harness-side `dia_ids`/`ts` (by fact id, exactly as [`vector_pool`] does) for
+/// the evidence-recall scorer and the dated context. `graph_weight` is 0: the
+/// shipped API ranks internally and never exposes the per-fact breakdown the
+/// harness `fuse` keeps for `--dump`.
+fn shipped_fused(
+    store: &Store,
+    question: &str,
+    k: usize,
+    opts: FusionOptions,
+) -> Result<Vec<RetrievedFact>, Box<dyn Error>> {
+    let hits = store.svc.recall_fused(question, k, None, opts)?;
+    Ok(hits
+        .into_iter()
+        .filter(|hit| store.is_fact(hit.id))
+        .map(|hit| RetrievedFact {
+            id: hit.id,
+            text: hit.content,
+            dia_ids: store.dia_ids(hit.id).to_vec(),
+            score: f64::from(hit.score),
+            graph_weight: 0.0,
+            ts: store.fact_ts(hit.id),
+        })
+        .collect())
 }
 
 /// `pool ∪ reached`, uncloned (empty) unless `--dump` actually wants it — kept

--- a/crates/velesdb-memory/examples/locomo/eval/eval_tests.rs
+++ b/crates/velesdb-memory/examples/locomo/eval/eval_tests.rs
@@ -26,6 +26,7 @@ fn cfg() -> EvalCfg {
         bm25: false,
         claude_judge: false,
         claude_gen: false,
+        use_shipped_api: false,
     }
 }
 

--- a/crates/velesdb-memory/examples/locomo/full_context.rs
+++ b/crates/velesdb-memory/examples/locomo/full_context.rs
@@ -1,0 +1,273 @@
+//! Full-context baseline: feed the ENTIRE conversation to the generator — no
+//! retrieval, no memory system, no budget — and score the answers exactly as
+//! the retrieval eval does. This is the reporting-standard local ceiling: the
+//! accuracy a long-context model reaches when nothing is dropped, and the
+//! token cost our budgeted retrieval trades that ceiling against.
+//!
+//! The whole conversation overflows Ollama's small default context window, so
+//! generation pins `num_ctx` (see [`FULL_CTX_TOKENS`]); a silent truncation
+//! there would quietly cap the very ceiling this baseline exists to measure.
+
+use std::error::Error;
+
+use crate::dataset::{Category, Sample};
+use crate::judge;
+use crate::ollama_gen::Generator;
+use crate::report::pct;
+
+/// Ollama context window for the whole-conversation prompt. Measured on the 10
+/// `LoCoMo` conversations: the dated `- [YYYY-MM-DD] Speaker: text` lines run
+/// ~2.9 chars/token (denser than a naive chars/4 estimate), so the prompt
+/// averages ~29k tokens and the largest conversation reaches the low-30k range;
+/// 49152 seats every one with comfortable headroom (verified: no prompt fills
+/// the window), far under the model's 262144 limit. `run` refuses upfront (see
+/// [`estimated_tokens`]) any conversation that would not fit.
+const FULL_CTX_TOKENS: u64 = 49_152;
+
+/// Tokens held back from [`FULL_CTX_TOKENS`] for the question, prompt scaffolding
+/// and the generated answer when checking a conversation fits — Ollama shares
+/// `num_ctx` between prompt and response, so the context alone must leave room.
+const RESPONSE_RESERVE_TOKENS: u64 = 1_024;
+
+/// Which stages route to the stronger Claude CLI instead of the local model:
+/// `gen` for answer generation, `judge` for the correctness verdict. Both
+/// default to the local model, matching the retrieval eval's flags.
+#[derive(Clone, Copy)]
+pub struct ClaudeFlags {
+    pub gen: bool,
+    pub judge: bool,
+}
+
+/// One category's running tally: correct / total, plus the prompt-token sum
+/// (and its sample count) so the report can show the mean context cost paid.
+#[derive(Default)]
+struct Cell {
+    n: u32,
+    correct: u32,
+    prompt_tokens: u64,
+    token_samples: u32,
+}
+
+impl Cell {
+    fn add(&mut self, correct: bool, prompt_tokens: Option<u64>) {
+        self.n += 1;
+        self.correct += u32::from(correct);
+        if let Some(tokens) = prompt_tokens {
+            self.prompt_tokens += tokens;
+            self.token_samples += 1;
+        }
+    }
+
+    fn accuracy(&self) -> f64 {
+        pct(self.correct, self.n)
+    }
+
+    fn mean_prompt_tokens(&self) -> Option<u64> {
+        (self.token_samples > 0).then(|| self.prompt_tokens / u64::from(self.token_samples))
+    }
+}
+
+/// Per-category accuracy report for the full-context baseline.
+#[derive(Default)]
+pub struct FullContextReport {
+    cells: [Cell; Category::COUNT],
+}
+
+impl FullContextReport {
+    /// Answer one question from the whole conversation and fold the verdict in.
+    /// Adversarial items are graded by abstention (the model should decline);
+    /// answerable items by the LLM judge, mirroring the retrieval eval so the
+    /// two numbers sit on the same scale.
+    fn record(
+        &mut self,
+        generator: &Generator,
+        context: &str,
+        qa: &crate::dataset::Qa,
+        claude: ClaudeFlags,
+    ) -> Result<(), Box<dyn Error>> {
+        let (candidate, usage) = answer(generator, context, &qa.question, claude.gen)?;
+        let correct = if qa.category.is_adversarial() {
+            judge::abstained(&candidate)
+        } else if let Some(gold) = judge::gold_answer(qa) {
+            judge::judge_correct(generator, &qa.question, gold, &candidate, claude.judge)?
+        } else {
+            false
+        };
+        self.cells[qa.category.index()].add(correct, usage.map(|u| u.prompt));
+        Ok(())
+    }
+
+    /// Print the per-category accuracy table plus the answerable headline and
+    /// the mean prompt-token cost the baseline paid to reach it. The provenance
+    /// line reflects the *actual* answerer: with `--claude-gen` the pinned local
+    /// `num_ctx` never applies (the Claude CLI answers), so it is not claimed.
+    fn print(&self, generator: &Generator, samples: usize, gen_claude: bool) {
+        println!(
+            "\nVelesDB-memory — LoCoMo full-context baseline (no retrieval, whole conversation)"
+        );
+        let provenance = if gen_claude {
+            "generator: claude (CLI)".to_string()
+        } else {
+            format!(
+                "generator: {}   ·   num_ctx={FULL_CTX_TOKENS}",
+                generator.model()
+            )
+        };
+        println!("{provenance}   ·   {samples} conversation(s)\n");
+        println!("  category         n      acc    mean-prompt-tokens");
+        let mut answerable = Cell::default();
+        for category in Category::ALL {
+            let cell = &self.cells[category.index()];
+            if cell.n == 0 {
+                continue;
+            }
+            println!(
+                "  {:<12} {:>4}    {:>4.0}%    {}",
+                category.label(),
+                cell.n,
+                cell.accuracy(),
+                cell.mean_prompt_tokens()
+                    .map_or_else(|| "       —".to_string(), |t| format!("{t:>8}")),
+            );
+            if !category.is_adversarial() {
+                answerable.n += cell.n;
+                answerable.correct += cell.correct;
+                answerable.prompt_tokens += cell.prompt_tokens;
+                answerable.token_samples += cell.token_samples;
+            }
+        }
+        println!(
+            "  {:<12} {:>4}    {:>4.0}%    {}",
+            "answerable",
+            answerable.n,
+            answerable.accuracy(),
+            answerable
+                .mean_prompt_tokens()
+                .map_or_else(|| "       —".to_string(), |t| format!("{t:>8}")),
+        );
+        println!(
+            "  (acc = LLM-judge accuracy; adversarial acc = abstention rate, excluded from the\n   \
+answerable total; mean-prompt-tokens = Ollama's reported context size per live call, '—' when\n   \
+every answer in the row was served from cache, which carries no usage counters.)"
+        );
+    }
+}
+
+/// Build the full-context prompt and generate a concise answer. Uses the same
+/// [`judge::plain_answer_prompt`] the retrieval eval uses, so the baseline and
+/// the eval grade like-for-like — only the "facts" differ: here the entire
+/// dated conversation, not a budgeted pool.
+fn answer(
+    generator: &Generator,
+    context: &str,
+    question: &str,
+    claude: bool,
+) -> Result<(String, Option<crate::ollama_gen::TokenUsage>), Box<dyn Error>> {
+    let prompt = judge::plain_answer_prompt(context, question);
+    if claude {
+        Ok((generator.judge(&prompt)?, None))
+    } else {
+        generator.generate_full_ctx(&prompt, FULL_CTX_TOKENS)
+    }
+}
+
+/// Render the whole conversation as dated, speaker-attributed lines, oldest
+/// first — the "memory" the baseline answers from. Each line carries its
+/// session date so temporal questions are answerable in principle.
+fn conversation_context(sample: &Sample) -> String {
+    let mut lines = Vec::new();
+    for session in &sample.sessions {
+        let date = judge::fmt_date(session.date_key());
+        for turn in &session.turns {
+            match &date {
+                Some(date) => lines.push(format!("- [{date}] {}: {}", turn.speaker, turn.text)),
+                None => lines.push(format!("- {}: {}", turn.speaker, turn.text)),
+            }
+        }
+    }
+    lines.join("\n")
+}
+
+/// Conservative token estimate for the fit check, calibrated for the
+/// Latin-script `LoCoMo` corpus this harness targets: its dated lines measured
+/// ~2.9 chars/token, so dividing by a smaller 2.5 deliberately over-counts,
+/// biasing the guard toward refusing a borderline conversation rather than
+/// letting Ollama silently truncate it. Deterministic (no model call), so it
+/// holds on a fully-cached rerun that reports no usage. Note the char-based
+/// ratio would *under*-count heavily non-Latin text (CJK/emoji tokenize to
+/// more than one token per char); the guard is a safety net for this dataset,
+/// not a general cross-script bound.
+fn estimated_tokens(text: &str) -> u64 {
+    u64::try_from(text.chars().count()).unwrap_or(u64::MAX) * 2 / 5
+}
+
+/// Run the full-context baseline over the first `take` conversations. `only`
+/// restricts scoring to a single category (a cheap, targeted A/B run), matching
+/// the `--only` flag the retrieval eval honors.
+pub fn run(
+    generator: &Generator,
+    samples: &[Sample],
+    take: usize,
+    claude: ClaudeFlags,
+    max_qa: usize,
+    only: Option<Category>,
+) -> Result<(), Box<dyn Error>> {
+    let contexts: Vec<(&Sample, String)> = samples
+        .iter()
+        .take(take)
+        .map(|sample| (sample, conversation_context(sample)))
+        .collect();
+    // Pre-flight, before ANY generation: a conversation whose prompt would
+    // overflow the pinned window is silently truncated by Ollama, corrupting the
+    // ceiling. Catch every oversized conversation up front — deterministically,
+    // independent of the answer cache — so the run aborts before spending
+    // minutes generating the ones ahead of it, never folding a clipped answer
+    // into a table that still looks clean. Skipped under `--claude-gen`, where
+    // the Claude CLI answers and the local `num_ctx` never applies.
+    if !claude.gen {
+        ensure_all_fit(&contexts)?;
+    }
+    let mut report = FullContextReport::default();
+    for (position, (sample, context)) in contexts.iter().enumerate() {
+        let qa_take = crate::qa_limit(max_qa, sample.qa.len());
+        println!(
+            "[{}/{take}] {} — {} turns, {} QA (full context)",
+            position + 1,
+            sample.sample_id,
+            sample.turn_count(),
+            qa_take,
+        );
+        for qa in sample.qa.iter().take(qa_take) {
+            if only.is_some_and(|category| category != qa.category) {
+                continue;
+            }
+            report.record(generator, context, qa, claude)?;
+        }
+    }
+    report.print(generator, take, claude.gen);
+    Ok(())
+}
+
+/// Verify every conversation's whole-context prompt fits the pinned window
+/// before any generation runs, so an oversized conversation aborts the run up
+/// front instead of after the earlier conversations were already (expensively)
+/// generated. Deterministic, so it holds on a fully-cached rerun.
+fn ensure_all_fit(contexts: &[(&Sample, String)]) -> Result<(), Box<dyn Error>> {
+    for (sample, context) in contexts {
+        let needed = estimated_tokens(context) + RESPONSE_RESERVE_TOKENS;
+        if needed > FULL_CTX_TOKENS {
+            return Err(format!(
+                "conversation {} needs ~{needed} context tokens but num_ctx is \
+{FULL_CTX_TOKENS}; raise FULL_CTX_TOKENS (up to 262144) — note this rebinds the \
+generation cache key, so cached full-context answers will be regenerated",
+                sample.sample_id,
+            )
+            .into());
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+#[path = "full_context/full_context_tests.rs"]
+mod tests;

--- a/crates/velesdb-memory/examples/locomo/full_context/full_context_tests.rs
+++ b/crates/velesdb-memory/examples/locomo/full_context/full_context_tests.rs
@@ -1,0 +1,117 @@
+//! Unit tests for the full-context baseline's pure helpers (context assembly,
+//! tallying, percentage). The generation/judging paths need a live Ollama and
+//! are exercised by the benchmark run itself, not here.
+
+use super::{conversation_context, estimated_tokens, pct, Cell, FULL_CTX_TOKENS};
+use crate::dataset::{Sample, Session, Turn};
+
+fn turn(speaker: &str, text: &str) -> Turn {
+    Turn {
+        speaker: speaker.to_string(),
+        dia_id: "D1:1".to_string(),
+        text: text.to_string(),
+    }
+}
+
+fn sample_with(sessions: Vec<Session>) -> Sample {
+    Sample {
+        sample_id: "conv-test".to_string(),
+        sessions,
+        qa: Vec::new(),
+    }
+}
+
+#[test]
+fn conversation_context_dates_and_attributes_every_turn_in_order() {
+    let sample = sample_with(vec![
+        Session {
+            index: 0,
+            date_time: "1:56 pm on 8 May, 2023".to_string(),
+            turns: vec![turn("Alice", "hi"), turn("Bob", "hello")],
+        },
+        Session {
+            index: 1,
+            date_time: "9:00 am on 10 June, 2023".to_string(),
+            turns: vec![turn("Alice", "back")],
+        },
+    ]);
+    let context = conversation_context(&sample);
+    assert_eq!(
+        context,
+        "- [2023-05-08] Alice: hi\n\
+         - [2023-05-08] Bob: hello\n\
+         - [2023-06-10] Alice: back"
+    );
+}
+
+#[test]
+fn conversation_context_omits_the_date_prefix_when_the_session_date_is_unparseable() {
+    let sample = sample_with(vec![Session {
+        index: 0,
+        date_time: "sometime".to_string(),
+        turns: vec![turn("Alice", "hi")],
+    }]);
+    assert_eq!(conversation_context(&sample), "- Alice: hi");
+}
+
+#[test]
+fn pct_guards_a_zero_denominator() {
+    assert!((pct(0, 0) - 0.0).abs() < f64::EPSILON);
+    assert!((pct(3, 4) - 75.0).abs() < f64::EPSILON);
+}
+
+#[test]
+fn cell_accuracy_and_mean_tokens_track_recorded_answers() {
+    let mut cell = Cell::default();
+    cell.add(true, Some(1000));
+    cell.add(false, Some(2000));
+    cell.add(true, None); // a cache hit: no usage counters
+    assert_eq!(cell.n, 3);
+    assert_eq!(cell.correct, 2);
+    assert!((cell.accuracy() - (200.0 / 3.0)).abs() < 1e-9);
+    // Mean over the two live calls only; the cached one is not counted.
+    assert_eq!(cell.mean_prompt_tokens(), Some(1500));
+}
+
+#[test]
+fn cell_mean_tokens_is_none_when_every_answer_was_cached() {
+    let mut cell = Cell::default();
+    cell.add(true, None);
+    assert_eq!(cell.mean_prompt_tokens(), None);
+}
+
+#[test]
+fn estimated_tokens_over_counts_relative_to_length() {
+    assert_eq!(estimated_tokens(""), 0);
+    // ~2.5 chars/token: 100 chars -> 40 estimated tokens.
+    assert_eq!(estimated_tokens(&"x".repeat(100)), 40);
+}
+
+#[test]
+fn the_largest_expected_conversation_fits_the_pinned_window() {
+    // The biggest LoCoMo conversation is ~92.7k characters; the guard must
+    // admit it (estimate + response reserve stays under the window), so a
+    // real run never spuriously aborts on the shipped dataset.
+    let biggest_chars = "x".repeat(92_716);
+    assert!(estimated_tokens(&biggest_chars) + super::RESPONSE_RESERVE_TOKENS < FULL_CTX_TOKENS);
+}
+
+#[test]
+fn ensure_all_fit_accepts_a_normal_conversation_and_rejects_an_overflowing_one() {
+    let small = sample_with(vec![Session {
+        index: 0,
+        date_time: "1:56 pm on 8 May, 2023".to_string(),
+        turns: vec![turn("Alice", "hi")],
+    }]);
+    let small_ctx = conversation_context(&small);
+    assert!(super::ensure_all_fit(&[(&small, small_ctx)]).is_ok());
+
+    // A single turn far larger than the window must be refused up front.
+    let huge = sample_with(vec![Session {
+        index: 0,
+        date_time: "1:56 pm on 8 May, 2023".to_string(),
+        turns: vec![turn("Alice", &"word ".repeat(60_000))],
+    }]);
+    let huge_ctx = conversation_context(&huge);
+    assert!(super::ensure_all_fit(&[(&huge, huge_ctx)]).is_err());
+}

--- a/crates/velesdb-memory/examples/locomo/judge.rs
+++ b/crates/velesdb-memory/examples/locomo/judge.rs
@@ -12,7 +12,7 @@ use crate::dataset::Qa;
 use crate::ollama_gen::{Generator, TokenUsage};
 use crate::parse::{normalize, tokens};
 
-const ABSTAIN: &str = "NO_ANSWER";
+pub(crate) const ABSTAIN: &str = "NO_ANSWER";
 
 /// Generate a concise answer from the retrieved facts (each a `(YYYYMMDD ts,
 /// text)` pair), or the abstain token when the facts don't contain the answer.
@@ -82,12 +82,23 @@ FINAL: <answer in a few words>"
         let (raw, usage) = gen(generator, &prompt, claude_gen)?;
         return Ok((extract_final(&raw), usage));
     }
-    let prompt = format!(
+    gen(
+        generator,
+        &plain_answer_prompt(&context, question),
+        claude_gen,
+    )
+}
+
+/// The plain (no-scaffold, no-CoT) answer prompt: answer from the given facts,
+/// or emit [`ABSTAIN`]. Shared so the full-context baseline
+/// ([`crate::full_context`]) grades like-for-like with this retrieval eval —
+/// one prompt, so the two answerers cannot silently diverge.
+pub(crate) fn plain_answer_prompt(context: &str, question: &str) -> String {
+    format!(
         "Answer the question using ONLY the memory facts below. If the facts do \
 not contain the answer, reply exactly {ABSTAIN}. Be concise: a few words, no \
 explanation.\n\nFacts:\n{context}\n\nQuestion: {question}\nAnswer:"
-    );
-    gen(generator, &prompt, claude_gen)
+    )
 }
 
 /// Generate an answer with either the strong external model (Claude via CLI) or
@@ -119,7 +130,7 @@ fn extract_final(text: &str) -> String {
 
 /// Render a `YYYYMMDD` session key as `YYYY-MM-DD`, or `None` when unknown (0)
 /// or malformed, so an undated fact is shown without a misleading date prefix.
-fn fmt_date(ts: i64) -> Option<String> {
+pub(crate) fn fmt_date(ts: i64) -> Option<String> {
     let (year, month, day) = decompose_ymd(ts)?;
     Some(format!("{year:04}-{month:02}-{day:02}"))
 }

--- a/crates/velesdb-memory/examples/locomo/main.rs
+++ b/crates/velesdb-memory/examples/locomo/main.rs
@@ -13,6 +13,10 @@
 //! # LLM-free explanation benchmark (does the graph connect scattered evidence?):
 //! cargo run --release -p velesdb-memory --features ollama --example locomo -- --explanation
 //!
+//! # Full-context baseline (whole conversation, no retrieval) — the local
+//! # ceiling our budgeted retrieval trades tokens against:
+//! cargo run --release -p velesdb-memory --features ollama --example locomo -- --full-context
+//!
 //! # LLM-free reproduction: does the SHIPPED recall_fused reproduce the fused
 //! # retrieval? Compare the harness fusion against the installed API on the same
 //! # data (single-seed, no BM25, idf-weighted to match recall_fused):
@@ -48,6 +52,7 @@ mod dump;
 mod eval;
 mod explain;
 mod extract;
+mod full_context;
 mod ingest;
 mod judge;
 mod ollama_gen;
@@ -72,6 +77,9 @@ use report::Report;
 use retrieval::RetrievalReport;
 
 /// Parsed command-line configuration.
+// The flags are independent CLI switches (run modes + ablation knobs), not a
+// state machine — the same reason `EvalCfg` carries this allow.
+#[allow(clippy::struct_excessive_bools)]
 struct Args {
     dataset: PathBuf,
     conversations: usize,
@@ -83,6 +91,9 @@ struct Args {
     retrieval: bool,
     /// Run the LLM-free extraction-vs-retrieval coverage diagnosis.
     diagnose: bool,
+    /// Run the full-context baseline (whole conversation, no retrieval) — the
+    /// reporting-standard local ceiling.
+    full_context: bool,
     /// Extraction prompt version: 1 (topics) or 2 (specific referents).
     extract_version: u8,
     /// Restrict the QA eval to one category (cheap, targeted A/B runs).
@@ -107,6 +118,19 @@ fn main() -> Result<(), Box<dyn Error>> {
         run_retrieval(&generator, &samples, take, &args)
     } else if args.explanation {
         run_explanation(&generator, &samples, take, &args)
+    } else if args.full_context {
+        let claude = full_context::ClaudeFlags {
+            gen: args.cfg.claude_gen,
+            judge: args.cfg.claude_judge,
+        };
+        full_context::run(
+            &generator,
+            &samples,
+            take,
+            claude,
+            args.max_qa,
+            args.only_category,
+        )
     } else {
         run_eval(&generator, &samples, take, &args)
     }
@@ -410,6 +434,7 @@ impl Default for Args {
             explanation: false,
             retrieval: false,
             diagnose: false,
+            full_context: false,
             extract_version: 1,
             only_category: None,
             embed_model: DEFAULT_OLLAMA_MODEL.to_string(),
@@ -475,6 +500,7 @@ impl Args {
             "--explanation" => &mut self.explanation,
             "--retrieval" => &mut self.retrieval,
             "--diagnose" => &mut self.diagnose,
+            "--full-context" => &mut self.full_context,
             "--multihop-only" => &mut self.cfg.multihop_only,
             "--idf-weight" => &mut self.cfg.idf_weight,
             "--date-context" => &mut self.cfg.date_context,

--- a/crates/velesdb-memory/examples/locomo/main.rs
+++ b/crates/velesdb-memory/examples/locomo/main.rs
@@ -12,7 +12,25 @@
 //! cargo run --release -p velesdb-memory --features ollama --example locomo
 //! # LLM-free explanation benchmark (does the graph connect scattered evidence?):
 //! cargo run --release -p velesdb-memory --features ollama --example locomo -- --explanation
+//!
+//! # LLM-free reproduction: does the SHIPPED recall_fused reproduce the fused
+//! # retrieval? Compare the harness fusion against the installed API on the same
+//! # data (single-seed, no BM25, idf-weighted to match recall_fused):
+//! cargo run --release -p velesdb-memory --features ollama --example locomo -- \
+//!     --retrieval --idf-weight                       # harness fusion
+//! cargo run --release -p velesdb-memory --features ollama --example locomo -- \
+//!     --retrieval --use-shipped-api                  # shipped recall_fused
 //! ```
+//!
+//! `--use-shipped-api` routes the fused (graph) path through the exact
+//! [`MemoryService::recall_fused`](velesdb_memory::MemoryService::recall_fused)
+//! a user installs, instead of the harness's own `vector_pool`+`graph_reached`+`fuse`.
+//! On a 3-conversation run the two agree to ~1pp of evidence-recall@k
+//! (69.8% harness → 69.0% shipped), identical on temporal/single-hop/open-domain;
+//! the residual is concentrated in multi-hop and traces to the documented
+//! graph-reach divergences (the shipped IDF counts facts + entity hubs where the
+//! harness counts facts only; `recall_fused` is single-seed, no BM25, and takes
+//! an exact-match filter rather than the temporal `ColumnStore` date window).
 //!
 //! Pipeline: extract facts from each session with a local LLM (tagged with the
 //! gold `dia_id`s and session timestamp), ingest them as a fact↔entity graph,
@@ -412,6 +430,7 @@ impl Default for Args {
                 bm25: false,
                 claude_judge: false,
                 claude_gen: false,
+                use_shipped_api: false,
             },
         }
     }
@@ -465,6 +484,7 @@ impl Args {
             "--bm25" => &mut self.cfg.bm25,
             "--claude-judge" => &mut self.cfg.claude_judge,
             "--claude-gen" => &mut self.cfg.claude_gen,
+            "--use-shipped-api" => &mut self.cfg.use_shipped_api,
             _ => return None,
         })
     }

--- a/crates/velesdb-memory/examples/locomo/ollama_gen.rs
+++ b/crates/velesdb-memory/examples/locomo/ollama_gen.rs
@@ -89,14 +89,35 @@ impl Generator {
         &self,
         prompt: &str,
     ) -> Result<(String, Option<TokenUsage>), Box<dyn Error>> {
-        let key = self.key(prompt);
+        self.generate_ctx(prompt, None)
+    }
+
+    /// Like [`Self::generate_traced`], but pins Ollama's context window to
+    /// `num_ctx` tokens for this call — needed by the full-context baseline,
+    /// whose whole-conversation prompt overflows Ollama's small default window
+    /// (a silent truncation there would invalidate the ceiling it measures).
+    pub fn generate_full_ctx(
+        &self,
+        prompt: &str,
+        num_ctx: u64,
+    ) -> Result<(String, Option<TokenUsage>), Box<dyn Error>> {
+        self.generate_ctx(prompt, Some(num_ctx))
+    }
+
+    /// Cache-then-call core shared by the default and pinned-context entries.
+    fn generate_ctx(
+        &self,
+        prompt: &str,
+        num_ctx: Option<u64>,
+    ) -> Result<(String, Option<TokenUsage>), Box<dyn Error>> {
+        let key = self.key_ctx(prompt, num_ctx);
         let path = self.cache_dir.join(format!("{key}.txt"));
         if let Ok(cached) = fs::read_to_string(&path) {
             if !cached.trim().is_empty() {
                 return Ok((cached, None));
             }
         }
-        let reply = self.call(prompt)?;
+        let reply = self.call(prompt, num_ctx)?;
         if !reply.text.trim().is_empty() {
             self.store(&key, &path, &reply.text)?;
         }
@@ -123,13 +144,17 @@ impl Generator {
     /// any usage counters. The body is serialised with `serde_json` and sent as
     /// a raw string so the crate's `ureq` can keep `default-features = false`
     /// (no bundled TLS/json), leaving the shipped server binary tiny.
-    fn call(&self, prompt: &str) -> Result<GenReply, Box<dyn Error>> {
+    fn call(&self, prompt: &str, num_ctx: Option<u64>) -> Result<GenReply, Box<dyn Error>> {
+        let mut options = serde_json::json!({ "temperature": 0 });
+        if let Some(tokens) = num_ctx {
+            options["num_ctx"] = serde_json::json!(tokens);
+        }
         let body = serde_json::json!({
             "model": self.model,
             "prompt": prompt,
             "stream": false,
             "think": false,
-            "options": { "temperature": 0 },
+            "options": options,
         })
         .to_string();
         let mut last: Box<dyn Error> = "no attempt made".into();
@@ -209,6 +234,23 @@ impl Generator {
     /// Content-addressed cache key over the local model + prompt.
     fn key(&self, prompt: &str) -> String {
         self.key_for(&self.model, prompt)
+    }
+
+    /// Cache key that also binds the pinned context window, so a prompt
+    /// generated at one `num_ctx` is never served to a call that asked for a
+    /// different one (a smaller window silently truncates — exactly what the
+    /// full-context baseline must not do). `None` keeps the plain model+prompt
+    /// key, leaving every existing default-window cache entry valid.
+    fn key_ctx(&self, prompt: &str, num_ctx: Option<u64>) -> String {
+        let Some(tokens) = num_ctx else {
+            return self.key(prompt);
+        };
+        let mut hash = fnv1a(self.model.as_bytes());
+        hash = fnv1a_continue(hash, b"\0num_ctx\0");
+        hash = fnv1a_continue(hash, &tokens.to_le_bytes());
+        hash = fnv1a_continue(hash, b"\0");
+        hash = fnv1a_continue(hash, prompt.as_bytes());
+        format!("{hash:016x}")
     }
 
     /// Content-addressed cache key over an explicit `model` + prompt, so callers

--- a/crates/velesdb-memory/examples/locomo/report.rs
+++ b/crates/velesdb-memory/examples/locomo/report.rs
@@ -157,7 +157,7 @@ fn answerable(cells: &[Cell; 5]) -> Cell {
 }
 
 /// Percentage with a guarded zero denominator.
-fn pct(num: u32, den: u32) -> f64 {
+pub(crate) fn pct(num: u32, den: u32) -> f64 {
     if den == 0 {
         return 0.0;
     }

--- a/crates/velesdb-memory/src/dated_context.rs
+++ b/crates/velesdb-memory/src/dated_context.rs
@@ -1,0 +1,125 @@
+//! Dated context: turn recalled facts into a chronological, date-prefixed
+//! timeline with a "now" anchor — the representation measured to lift temporal
+//! question answering (the `examples/locomo` temporal ablation: +33.6pp,
+//! McNemar p=1.8e-28). This ships that representation as product behavior so a
+//! caller reproduces it through the installed API instead of re-implementing
+//! the formatting in a prompt.
+//!
+//! The date lives in caller-supplied metadata under a field the caller names
+//! (e.g. `ts`, `occurred_at`), holding a `YYYYMMDD` integer — the same key
+//! shape `recall_where` filters on. A fact whose named field is missing or not
+//! a valid `YYYYMMDD` date is treated as undated: it still appears, just without
+//! a date prefix and after the dated timeline, so an unlabeled fact never
+//! invents a misleading date.
+//!
+//! Only the *formatting* ships here — not the LLM reasoning prompt the harness
+//! wraps around it. Presenting retrieved facts is a memory-store concern;
+//! prompt engineering is the caller's.
+
+use crate::model::Recollection;
+
+/// A chronological, date-prefixed rendering of recalled facts.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DatedContext {
+    /// One line per fact: `- [YYYY-MM-DD] content` for a dated fact, `- content`
+    /// for an undated one. Dated facts come first in ascending date order; any
+    /// undated facts follow in their original (relevance) order.
+    pub timeline: String,
+    /// The most recent date across the facts (`YYYY-MM-DD`), the natural "now"
+    /// anchor for temporal reasoning. `None` when no fact carries a valid date.
+    pub now: Option<String>,
+}
+
+/// Render `facts` as a [`DatedContext`], reading each fact's date from the
+/// `date_field` metadata key (a `YYYYMMDD` integer).
+///
+/// Facts are split into dated (sorted oldest-first) and undated (kept in the
+/// order given, i.e. by relevance), then rendered one per line. `now` is the
+/// latest date seen. An empty `facts` yields an empty timeline and `now: None`.
+#[must_use]
+pub fn format_dated_context(facts: &[Recollection], date_field: &str) -> DatedContext {
+    // (sort key, pre-formatted `YYYY-MM-DD`, content) for dated facts; content
+    // only for undated ones. The date is formatted once here, so nothing
+    // downstream re-parses it.
+    let mut dated: Vec<(i64, String, &str)> = Vec::new();
+    let mut undated: Vec<&str> = Vec::new();
+    for fact in facts {
+        match fact_date(fact, date_field) {
+            Some((key, formatted)) => dated.push((key, formatted, &fact.content)),
+            None => undated.push(&fact.content),
+        }
+    }
+    // Ascending chronological order; a stable sort keeps same-date facts in
+    // their original relevance order.
+    dated.sort_by_key(|(key, _, _)| *key);
+    let now = dated.last().map(|(_, formatted, _)| formatted.clone());
+
+    let lines = dated
+        .iter()
+        .map(|(_, date, content)| format!("- [{date}] {content}"))
+        .chain(undated.iter().map(|content| format!("- {content}")))
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    DatedContext {
+        timeline: lines,
+        now,
+    }
+}
+
+/// A fact's `(sort key, formatted "YYYY-MM-DD")` from its `date_field`
+/// metadata, or `None` when the field is absent, non-integer, or not a valid
+/// calendar date — so a plain counter (or an impossible date like `20260231`)
+/// living under the date field is treated as undated, not rendered as a
+/// nonsense timeline anchor. Formats the date here so the caller never parses
+/// the integer twice.
+fn fact_date(fact: &Recollection, date_field: &str) -> Option<(i64, String)> {
+    let raw = fact.metadata.as_ref()?.get(date_field)?.as_i64()?;
+    Some((raw, fmt_date(raw)?))
+}
+
+/// Render a `YYYYMMDD` integer as `YYYY-MM-DD`, or `None` when it is not a valid
+/// calendar date.
+fn fmt_date(ts: i64) -> Option<String> {
+    let (year, month, day) = decompose_ymd(ts)?;
+    Some(format!("{year:04}-{month:02}-{day:02}"))
+}
+
+/// Split a `YYYYMMDD` integer into `(year, month, day)`, or `None` when it is
+/// `<= 0`, the month is out of range, or the day exceeds that month's real
+/// length (leap years included) — the single validity rule for the date
+/// convention, stricter than the harness's `1..=31` so no impossible date ever
+/// reaches the timeline.
+fn decompose_ymd(ts: i64) -> Option<(i64, i64, i64)> {
+    if ts <= 0 {
+        return None;
+    }
+    let (year, month, day) = (ts / 10_000, (ts / 100) % 100, ts % 100);
+    if !(1..=12).contains(&month) {
+        return None;
+    }
+    (1..=days_in_month(year, month))
+        .contains(&day)
+        .then_some((year, month, day))
+}
+
+/// Days in `month` (1..=12) of `year` in the proleptic Gregorian calendar
+/// (February is 29 in a leap year). Only ever called with a validated month.
+fn days_in_month(year: i64, month: i64) -> i64 {
+    match month {
+        1 | 3 | 5 | 7 | 8 | 10 | 12 => 31,
+        4 | 6 | 9 | 11 => 30,
+        2 if is_leap_year(year) => 29,
+        2 => 28,
+        _ => 0,
+    }
+}
+
+/// Whether `year` is a leap year (Gregorian rule).
+fn is_leap_year(year: i64) -> bool {
+    year % 4 == 0 && (year % 100 != 0 || year % 400 == 0)
+}
+
+#[cfg(test)]
+#[path = "dated_context_tests.rs"]
+mod tests;

--- a/crates/velesdb-memory/src/dated_context_tests.rs
+++ b/crates/velesdb-memory/src/dated_context_tests.rs
@@ -1,0 +1,126 @@
+//! Unit tests for the dated-context formatter.
+
+use super::*;
+use crate::model::Recollection;
+use serde_json::json;
+
+/// A recollection with `content` and an optional `date_field` metadata date.
+fn fact(id: u64, content: &str, date_field: &str, date: Option<i64>) -> Recollection {
+    let metadata = date.map(|d| {
+        let mut m = serde_json::Map::new();
+        m.insert(date_field.to_string(), json!(d));
+        m
+    });
+    Recollection {
+        id,
+        score: 0.0,
+        content: content.to_string(),
+        metadata,
+    }
+}
+
+#[test]
+fn empty_facts_yield_empty_timeline_and_no_now() {
+    let ctx = format_dated_context(&[], "ts");
+    assert_eq!(ctx.timeline, "");
+    assert_eq!(ctx.now, None);
+}
+
+#[test]
+fn dated_facts_are_sorted_ascending_and_prefixed() {
+    // Given out of order; must render oldest-first with date prefixes.
+    let facts = vec![
+        fact(1, "release shipped", "ts", Some(20_260_701)),
+        fact(2, "kickoff meeting", "ts", Some(20_260_103)),
+    ];
+    let ctx = format_dated_context(&facts, "ts");
+    assert_eq!(
+        ctx.timeline,
+        "- [2026-01-03] kickoff meeting\n- [2026-07-01] release shipped"
+    );
+    // "now" anchors on the latest date.
+    assert_eq!(ctx.now.as_deref(), Some("2026-07-01"));
+}
+
+#[test]
+fn undated_facts_follow_the_timeline_without_a_prefix() {
+    let facts = vec![
+        fact(1, "dated one", "ts", Some(20_260_101)),
+        fact(2, "no date here", "ts", None),
+    ];
+    let ctx = format_dated_context(&facts, "ts");
+    assert_eq!(ctx.timeline, "- [2026-01-01] dated one\n- no date here");
+    assert_eq!(ctx.now.as_deref(), Some("2026-01-01"));
+}
+
+#[test]
+fn all_undated_facts_have_no_now_anchor() {
+    let facts = vec![fact(1, "a", "ts", None), fact(2, "b", "ts", None)];
+    let ctx = format_dated_context(&facts, "ts");
+    assert_eq!(ctx.timeline, "- a\n- b");
+    assert_eq!(ctx.now, None);
+}
+
+#[test]
+fn the_date_field_name_is_honored() {
+    // Same fact, a caller-chosen field name other than `ts`.
+    let facts = vec![fact(1, "hired", "occurred_at", Some(20_250_615))];
+    let ctx = format_dated_context(&facts, "occurred_at");
+    assert_eq!(ctx.timeline, "- [2025-06-15] hired");
+    // A different field name sees no date → treated as undated.
+    let ctx_wrong = format_dated_context(&facts, "ts");
+    assert_eq!(ctx_wrong.timeline, "- hired");
+    assert_eq!(ctx_wrong.now, None);
+}
+
+#[test]
+fn out_of_range_or_non_integer_dates_are_treated_as_undated() {
+    // 20261301 = month 13; 20260231 = Feb 31 (impossible day for the month);
+    // 20260229 = Feb 29 in a non-leap year; 0 and negatives rejected; a string
+    // is not an integer date. None must render a date prefix or a `now` anchor.
+    let bad_month = fact(1, "bad month", "ts", Some(20_261_301));
+    let feb31 = fact(2, "feb 31", "ts", Some(20_260_231));
+    let feb29_non_leap = fact(3, "feb 29 non-leap", "ts", Some(20_260_229));
+    let zero = fact(4, "zero", "ts", Some(0));
+    let mut string_date = fact(5, "string date", "ts", None);
+    let mut m = serde_json::Map::new();
+    m.insert("ts".to_string(), json!("2026-07-01"));
+    string_date.metadata = Some(m);
+
+    let ctx = format_dated_context(&[bad_month, feb31, feb29_non_leap, zero, string_date], "ts");
+    assert_eq!(
+        ctx.timeline,
+        "- bad month\n- feb 31\n- feb 29 non-leap\n- zero\n- string date"
+    );
+    assert_eq!(ctx.now, None);
+}
+
+#[test]
+fn valid_end_of_month_and_leap_day_dates_are_kept() {
+    // Real edge dates must still render: Feb 29 in a leap year, 30/31-day ends.
+    let facts = vec![
+        fact(1, "leap day", "ts", Some(20_240_229)),
+        fact(2, "april end", "ts", Some(20_260_430)),
+        fact(3, "december end", "ts", Some(20_261_231)),
+    ];
+    let ctx = format_dated_context(&facts, "ts");
+    assert_eq!(
+        ctx.timeline,
+        "- [2024-02-29] leap day\n- [2026-04-30] april end\n- [2026-12-31] december end"
+    );
+    assert_eq!(ctx.now.as_deref(), Some("2026-12-31"));
+}
+
+#[test]
+fn same_date_facts_keep_relevance_order() {
+    // A stable sort must not reorder facts sharing a date.
+    let facts = vec![
+        fact(1, "first by relevance", "ts", Some(20_260_101)),
+        fact(2, "second by relevance", "ts", Some(20_260_101)),
+    ];
+    let ctx = format_dated_context(&facts, "ts");
+    assert_eq!(
+        ctx.timeline,
+        "- [2026-01-01] first by relevance\n- [2026-01-01] second by relevance"
+    );
+}

--- a/crates/velesdb-memory/src/fused_recall.rs
+++ b/crates/velesdb-memory/src/fused_recall.rs
@@ -302,14 +302,20 @@ fn matches_filter(metadata: Option<&Metadata>, filter: Option<&Metadata>) -> boo
 }
 
 /// The oversampled candidate pool depth for a `k`-sized fused recall:
-/// `opts.pool` if the caller set one, else the proven default
+/// `opts.pool` if the caller set one (floored at 1), else the proven default
 /// ([`fusion::pool_size`]) — either way, capped at
 /// [`crate::limits::MAX_RECALL_LIMIT`], the same `DoS` ceiling `k`/`hops`
-/// carry. The cap lives here, not just at each binding's FFI boundary: the
-/// *default* pool (`k.saturating_mul(8)`) exceeds it well before `k` itself
-/// reaches its own cap, so a caller who never touches `pool` at all — not
-/// just one who sets it explicitly — must still be bounded.
+/// carry. Both bounds live here, not at each binding's FFI boundary:
+/// - the floor of 1 stops an explicit `pool` of 0 (a binding now exposes the
+///   knob: `options={"pool": 0}` in Python) from oversampling *zero* candidates
+///   and returning nothing. A caller can still deliberately narrow the pool
+///   below the default (e.g. `pool: 1` to admit only the top vector hit — the
+///   documented behavior fusion's tests pin); the floor only rules out the
+///   degenerate empty-set case, it does not force a minimum recall depth.
+/// - the cap bounds the default too: `k.saturating_mul(8)` exceeds the limit
+///   well before `k` itself does, so even a caller who never touches `pool` is
+///   bounded.
 fn pool_depth(k: usize, opts: FusionOptions) -> usize {
-    let depth = opts.pool.unwrap_or_else(|| fusion::pool_size(k));
+    let depth = opts.pool.map_or_else(|| fusion::pool_size(k), |p| p.max(1));
     crate::limits::clamp_recall_limit(depth)
 }

--- a/crates/velesdb-memory/src/fused_recall.rs
+++ b/crates/velesdb-memory/src/fused_recall.rs
@@ -58,6 +58,30 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
         Ok(fusion::fuse(pool, &reached, k, opts.graph_boost))
     }
 
+    /// [`Self::recall_fused`] paired with the dated-context rendering of its
+    /// results: returns the recalled facts and the
+    /// [`DatedContext`](crate::DatedContext) built from their `date_field`
+    /// metadata (see [`format_dated_context`](crate::format_dated_context)).
+    /// Every binding that exposes a "dated recall" (the MCP `recall_fused`
+    /// tool's `date_field`, Node/WASM `recallFusedDated`) calls this, so the
+    /// "recall then format" pairing lives in exactly one place and can't drift
+    /// between surfaces.
+    ///
+    /// # Errors
+    /// Returns [`MemoryError`] if the underlying [`Self::recall_fused`] fails.
+    pub fn recall_fused_dated(
+        &self,
+        query: &str,
+        k: usize,
+        filter: Option<&Metadata>,
+        opts: FusionOptions,
+        date_field: &str,
+    ) -> Result<(Vec<Recollection>, crate::DatedContext), MemoryError> {
+        let hits = self.recall_fused(query, k, filter, opts)?;
+        let ctx = crate::format_dated_context(&hits, date_field);
+        Ok((hits, ctx))
+    }
+
     /// Like [`Self::recall_fused`], but hands the FULL fused-ranked candidate
     /// pool (before the final `k` cutoff) to `reranker` for a second-stage
     /// re-score, then truncates to `k`. Closes the ranking-miss gap the

--- a/crates/velesdb-memory/src/fused_recall.rs
+++ b/crates/velesdb-memory/src/fused_recall.rs
@@ -50,6 +50,7 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
         if query.is_empty() || k == 0 {
             return Ok(Vec::new());
         }
+        let opts = opts.sanitized();
         reject_reserved_keys(filter)?;
         let embedding = self.embedder.embed(query)?;
         let pool = self.fused_pool(&embedding, pool_depth(k, opts), filter)?;
@@ -84,6 +85,7 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
         if query.is_empty() || k == 0 {
             return Ok(Vec::new());
         }
+        let opts = opts.sanitized();
         reject_reserved_keys(filter)?;
         let embedding = self.embedder.embed(query)?;
         let depth = pool_depth(k, opts);

--- a/crates/velesdb-memory/src/fusion_tests.rs
+++ b/crates/velesdb-memory/src/fusion_tests.rs
@@ -1,7 +1,7 @@
 //! Unit tests for the fusion ranking layer.
 
 use super::*;
-use crate::model::Recollection;
+use crate::model::{FusionOptions, Recollection};
 
 #[allow(clippy::cast_possible_truncation)] // test fixture scores are small, exact literals
 fn candidate(id: u64, vector_score: f64, graph_weight: f64) -> Candidate {
@@ -128,4 +128,79 @@ fn test_fuse_all_negative_pool_ties_at_a_neutral_baseline_not_an_inverted_extrem
         vec![3, 1, 2],
         "the graph-reached candidate outranks the tied, neutral-baseline negative pool (stable order preserved)"
     );
+}
+
+#[test]
+fn test_non_finite_graph_boost_collapses_fusion_without_sanitizing() {
+    // Guards the reason FusionOptions::sanitized exists: a non-finite boost
+    // makes `graph_boost · weight` NaN for EVERY candidate (even a pool-only
+    // one, since NaN·0.0 == NaN), so total_cmp sees all scores equal, the sort
+    // is a no-op, and the graph-reached fact — appended after the pool — is
+    // truncated away. A strong pool hit (id 1) plus a weak one (id 2) that the
+    // default boost is enough to outrank; the graph fact (id 3) should take the
+    // second slot at k=2.
+    let build = || {
+        (
+            vec![candidate(1, 0.5, 0.0), candidate(2, 0.01, 0.0)],
+            vec![candidate(3, 0.0, 1.0)],
+        )
+    };
+
+    let (pool, reached) = build();
+    let ranked = fuse(pool, &reached, 2, f64::NAN);
+    assert!(
+        !ranked.iter().any(|r| r.id == 3),
+        "with a raw NaN boost the graph fact is silently dropped — this is the failure sanitized() prevents"
+    );
+
+    // Sanitizing the boost restores correct fusion: the default 0.15 outranks
+    // the weak pool hit, so the graph fact takes the second slot.
+    let boost = FusionOptions {
+        graph_boost: f64::NAN,
+        ..FusionOptions::default()
+    }
+    .sanitized()
+    .graph_boost;
+    let (pool, reached) = build();
+    let ranked = fuse(pool, &reached, 2, boost);
+    assert!(
+        ranked.iter().any(|r| r.id == 3),
+        "after sanitizing the boost, the graph fact ranks in again"
+    );
+}
+
+#[test]
+#[allow(clippy::float_cmp)] // asserting exact propagation of literal boosts, no arithmetic
+fn test_fusion_options_sanitized_only_touches_non_finite_boost() {
+    let default_boost = FusionOptions::default().graph_boost;
+    for bad in [f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
+        let opts = FusionOptions {
+            graph_boost: bad,
+            ..FusionOptions::default()
+        }
+        .sanitized();
+        assert_eq!(opts.graph_boost, default_boost);
+    }
+    // A finite (even negative) boost is a valid demote-the-graph choice, left as is.
+    let kept = FusionOptions {
+        graph_boost: -0.5,
+        ..FusionOptions::default()
+    }
+    .sanitized();
+    assert_eq!(kept.graph_boost, -0.5);
+}
+
+#[test]
+#[allow(clippy::float_cmp)] // asserting exact propagation of literal boosts, no arithmetic
+fn test_fusion_options_from_knobs_defaults_and_clamps_hops() {
+    let d = FusionOptions::default();
+    let none = FusionOptions::from_knobs(None, None);
+    assert_eq!(none.hops, d.hops);
+    assert_eq!(none.graph_boost, d.graph_boost);
+    assert_eq!(none.pool, d.pool);
+
+    let clamped = FusionOptions::from_knobs(Some(usize::MAX), Some(0.42));
+    assert_eq!(clamped.hops, crate::limits::clamp_hops(usize::MAX));
+    assert_eq!(clamped.graph_boost, 0.42);
+    assert_eq!(clamped.pool, d.pool);
 }

--- a/crates/velesdb-memory/src/fusion_tests.rs
+++ b/crates/velesdb-memory/src/fusion_tests.rs
@@ -194,13 +194,16 @@ fn test_fusion_options_sanitized_only_touches_non_finite_boost() {
 #[allow(clippy::float_cmp)] // asserting exact propagation of literal boosts, no arithmetic
 fn test_fusion_options_from_knobs_defaults_and_clamps_hops() {
     let d = FusionOptions::default();
-    let none = FusionOptions::from_knobs(None, None);
+    let none = FusionOptions::from_knobs(None, None, None);
     assert_eq!(none.hops, d.hops);
     assert_eq!(none.graph_boost, d.graph_boost);
     assert_eq!(none.pool, d.pool);
 
-    let clamped = FusionOptions::from_knobs(Some(usize::MAX), Some(0.42));
+    let clamped = FusionOptions::from_knobs(Some(usize::MAX), Some(0.42), Some(usize::MAX));
     assert_eq!(clamped.hops, crate::limits::clamp_hops(usize::MAX));
     assert_eq!(clamped.graph_boost, 0.42);
-    assert_eq!(clamped.pool, d.pool);
+    assert_eq!(
+        clamped.pool,
+        Some(crate::limits::clamp_recall_limit(usize::MAX))
+    );
 }

--- a/crates/velesdb-memory/src/lib.rs
+++ b/crates/velesdb-memory/src/lib.rs
@@ -21,6 +21,10 @@
 //! Set" of the Software's features and breach the `VelesDB` Core License 1.0
 //! (§1, No Hosted or Managed Service). See `VISION.md` §5 and `PLAN.md` Phase 4A.
 
+/// Format recalled facts as a chronological, date-prefixed timeline with a
+/// "now" anchor — the dated-context representation measured to lift temporal
+/// question answering, shipped as product behavior rather than a harness prompt.
+pub mod dated_context;
 pub mod embedder;
 pub mod error;
 pub mod extract;
@@ -77,6 +81,7 @@ const _: () = assert!(
     "update FALLBACK_DIMENSION to match velesdb_core::agent::DEFAULT_DIMENSION"
 );
 
+pub use dated_context::{format_dated_context, DatedContext};
 pub use embedder::{DynEmbedder, EmbedError, Embedder, HashEmbedder};
 #[cfg(feature = "ollama")]
 pub use embedder::{OllamaEmbedder, DEFAULT_OLLAMA_MODEL, DEFAULT_OLLAMA_URL};

--- a/crates/velesdb-memory/src/mcp.rs
+++ b/crates/velesdb-memory/src/mcp.rs
@@ -12,7 +12,7 @@ use rmcp::model::{ErrorCode, Implementation, ServerCapabilities, ServerInfo};
 use rmcp::{tool, tool_handler, tool_router, ErrorData, ServerHandler};
 
 use crate::limits::{DEFAULT_WHY_HOPS, MAX_FACT_BYTES, MAX_RECALL_LIMIT, MAX_WHY_HOPS};
-use crate::model::Explanation;
+use crate::model::{Explanation, FusionOptions};
 use crate::service::MemoryService;
 
 /// Default number of memories returned by `recall`.
@@ -31,9 +31,9 @@ use crate::extract::DynExtractor;
 // domain types from `crate::model` directly (no duplicate wire/domain struct).
 mod dto;
 use dto::{
-    ForgetParams, ForgetResult, RecallParams, RecallResult, RecallWhereParams, RelateParams,
-    RelateResult, RememberExtractedParams, RememberExtractedResult, RememberParams, RememberResult,
-    WhyParams,
+    ForgetParams, ForgetResult, RecallFusedParams, RecallParams, RecallResult, RecallWhereParams,
+    RelateParams, RelateResult, RememberExtractedParams, RememberExtractedResult, RememberParams,
+    RememberResult, WhyParams,
 };
 
 // --- The server ------------------------------------------------------------
@@ -155,6 +155,30 @@ impl McpServer {
                 .await
                 .map_err(join_error)?
                 .map_err(to_error)?;
+        Ok(Json(RecallResult { memories }))
+    }
+
+    #[tool(
+        name = "recall_fused",
+        description = "Fused vector + graph recall: like `recall`, but also walks the graph from the top vector hit and folds any connected fact into the ranking — the tri-engine ranking (vector similarity + ColumnStore filter + graph reach) measured on multi-hop and temporal benchmarks. Reach for this when an answer needs a fact the query doesn't mention directly but a stored `relate`/extracted link connects (multi-hop reasoning, temporal chains). `hops`/`graph_boost` tune the graph reach; omit them for the proven defaults. Optionally narrow with an exact-match `filter`. Most relevant first."
+    )]
+    async fn recall_fused(
+        &self,
+        Parameters(params): Parameters<RecallFusedParams>,
+    ) -> Result<Json<RecallResult>, ErrorData> {
+        let k = params
+            .limit
+            .unwrap_or(DEFAULT_RECALL_LIMIT)
+            .min(MAX_RECALL_LIMIT);
+        let opts = FusionOptions::from_knobs(params.hops, params.graph_boost);
+        let service = Arc::clone(&self.service);
+        let RecallFusedParams { query, filter, .. } = params;
+        let memories = tokio::task::spawn_blocking(move || {
+            service.recall_fused(&query, k, filter.as_ref(), opts)
+        })
+        .await
+        .map_err(join_error)?
+        .map_err(to_error)?;
         Ok(Json(RecallResult { memories }))
     }
 

--- a/crates/velesdb-memory/src/mcp.rs
+++ b/crates/velesdb-memory/src/mcp.rs
@@ -178,20 +178,25 @@ impl McpServer {
             date_field,
             ..
         } = params;
-        let memories = tokio::task::spawn_blocking(move || {
-            service.recall_fused(&query, k, filter.as_ref(), opts)
-        })
-        .await
-        .map_err(join_error)?
-        .map_err(to_error)?;
-        // When the caller names a date field, also ship the dated timeline it
-        // would otherwise have to format itself in a prompt.
-        let (dated_context, now) = match date_field {
-            Some(field) => {
-                let ctx = crate::dated_context::format_dated_context(&memories, &field);
-                (Some(ctx.timeline), ctx.now)
-            }
-            None => (None, None),
+        // With a date field, take the shared "recall then format" path so the
+        // dated timeline stays identical to the Node/WASM bindings; without one,
+        // plain fused recall (no timeline).
+        let (memories, dated_context, now) = if let Some(field) = date_field {
+            let (hits, ctx) = tokio::task::spawn_blocking(move || {
+                service.recall_fused_dated(&query, k, filter.as_ref(), opts, &field)
+            })
+            .await
+            .map_err(join_error)?
+            .map_err(to_error)?;
+            (hits, Some(ctx.timeline), ctx.now)
+        } else {
+            let hits = tokio::task::spawn_blocking(move || {
+                service.recall_fused(&query, k, filter.as_ref(), opts)
+            })
+            .await
+            .map_err(join_error)?
+            .map_err(to_error)?;
+            (hits, None, None)
         };
         Ok(Json(RecallFusedResult {
             memories,

--- a/crates/velesdb-memory/src/mcp.rs
+++ b/crates/velesdb-memory/src/mcp.rs
@@ -31,9 +31,9 @@ use crate::extract::DynExtractor;
 // domain types from `crate::model` directly (no duplicate wire/domain struct).
 mod dto;
 use dto::{
-    ForgetParams, ForgetResult, RecallFusedParams, RecallParams, RecallResult, RecallWhereParams,
-    RelateParams, RelateResult, RememberExtractedParams, RememberExtractedResult, RememberParams,
-    RememberResult, WhyParams,
+    ForgetParams, ForgetResult, RecallFusedParams, RecallFusedResult, RecallParams, RecallResult,
+    RecallWhereParams, RelateParams, RelateResult, RememberExtractedParams,
+    RememberExtractedResult, RememberParams, RememberResult, WhyParams,
 };
 
 // --- The server ------------------------------------------------------------
@@ -160,26 +160,44 @@ impl McpServer {
 
     #[tool(
         name = "recall_fused",
-        description = "Fused vector + graph recall: like `recall`, but also walks the graph from the top vector hit and folds any connected fact into the ranking — the tri-engine ranking (vector similarity + ColumnStore filter + graph reach) measured on multi-hop and temporal benchmarks. Reach for this when an answer needs a fact the query doesn't mention directly but a stored `relate`/extracted link connects (multi-hop reasoning, temporal chains). `hops`/`graph_boost` tune the graph reach; omit them for the proven defaults. Optionally narrow with an exact-match `filter`. Most relevant first."
+        description = "Fused vector + graph recall: like `recall`, but also walks the graph from the top vector hit and folds any connected fact into the ranking — the tri-engine ranking (vector similarity + ColumnStore filter + graph reach) measured on multi-hop and temporal benchmarks. Reach for this when an answer needs a fact the query doesn't mention directly but a stored `relate`/extracted link connects (multi-hop reasoning, temporal chains). `hops`/`graph_boost` tune the graph reach; omit them for the proven defaults. Optionally narrow with an exact-match `filter`. Set `date_field` (the metadata key holding a YYYYMMDD date) to also get a `dated_context` timeline and a `now` anchor for temporal questions. Most relevant first."
     )]
     async fn recall_fused(
         &self,
         Parameters(params): Parameters<RecallFusedParams>,
-    ) -> Result<Json<RecallResult>, ErrorData> {
+    ) -> Result<Json<RecallFusedResult>, ErrorData> {
         let k = params
             .limit
             .unwrap_or(DEFAULT_RECALL_LIMIT)
             .min(MAX_RECALL_LIMIT);
-        let opts = FusionOptions::from_knobs(params.hops, params.graph_boost);
+        let opts = FusionOptions::from_knobs(params.hops, params.graph_boost, None);
         let service = Arc::clone(&self.service);
-        let RecallFusedParams { query, filter, .. } = params;
+        let RecallFusedParams {
+            query,
+            filter,
+            date_field,
+            ..
+        } = params;
         let memories = tokio::task::spawn_blocking(move || {
             service.recall_fused(&query, k, filter.as_ref(), opts)
         })
         .await
         .map_err(join_error)?
         .map_err(to_error)?;
-        Ok(Json(RecallResult { memories }))
+        // When the caller names a date field, also ship the dated timeline it
+        // would otherwise have to format itself in a prompt.
+        let (dated_context, now) = match date_field {
+            Some(field) => {
+                let ctx = crate::dated_context::format_dated_context(&memories, &field);
+                (Some(ctx.timeline), ctx.now)
+            }
+            None => (None, None),
+        };
+        Ok(Json(RecallFusedResult {
+            memories,
+            dated_context,
+            now,
+        }))
     }
 
     #[tool(

--- a/crates/velesdb-memory/src/mcp/dto.rs
+++ b/crates/velesdb-memory/src/mcp/dto.rs
@@ -81,7 +81,9 @@ pub(super) struct RecallWhereParams {
 pub(super) struct RecallFusedParams {
     /// Natural-language query to match semantically.
     pub(super) query: String,
-    /// Maximum number of memories to return (default 10).
+    /// Maximum number of memories to return (default 10). Multi-hop reasoning
+    /// benefits from a larger budget (~32-64); simple and temporal recall
+    /// saturate early, where a larger budget only adds tokens.
     pub(super) limit: Option<usize>,
     /// Optional exact-match metadata filter (e.g.
     /// `{"project": "veles", "status": "resolved"}`).

--- a/crates/velesdb-memory/src/mcp/dto.rs
+++ b/crates/velesdb-memory/src/mcp/dto.rs
@@ -75,6 +75,26 @@ pub(super) struct RecallWhereParams {
     pub(super) filters: Vec<ColumnFilter>,
 }
 
+/// Parameters for the `recall_fused` tool.
+#[derive(Deserialize, JsonSchema)]
+#[schemars(transform = crate::schema::strip_int_formats)]
+pub(super) struct RecallFusedParams {
+    /// Natural-language query to match semantically.
+    pub(super) query: String,
+    /// Maximum number of memories to return (default 10).
+    pub(super) limit: Option<usize>,
+    /// Optional exact-match metadata filter (e.g.
+    /// `{"project": "veles", "status": "resolved"}`).
+    pub(super) filter: Option<Metadata>,
+    /// Graph hops walked from the top vector hit (default 2). Higher reaches
+    /// further but adds noise; capped at the `why` hop ceiling.
+    pub(super) hops: Option<usize>,
+    /// Weight added to a graph-reached fact's normalised vector score
+    /// (default 0.15). Raise to trust the graph more, lower to trust vector
+    /// similarity more.
+    pub(super) graph_boost: Option<f64>,
+}
+
 /// Parameters for the `relate` tool.
 #[derive(Deserialize, JsonSchema)]
 #[schemars(transform = crate::schema::strip_int_formats)]

--- a/crates/velesdb-memory/src/mcp/dto.rs
+++ b/crates/velesdb-memory/src/mcp/dto.rs
@@ -93,6 +93,29 @@ pub(super) struct RecallFusedParams {
     /// (default 0.15). Raise to trust the graph more, lower to trust vector
     /// similarity more.
     pub(super) graph_boost: Option<f64>,
+    /// Name of the metadata field holding each fact's date as a `YYYYMMDD`
+    /// integer (e.g. `"ts"`, `"occurred_at"`). When set, the result adds a
+    /// `dated_context` timeline (facts date-prefixed and ordered oldest-first)
+    /// plus a `now` anchor — the representation that lifts temporal reasoning.
+    /// Omit for plain results.
+    pub(super) date_field: Option<String>,
+}
+
+/// Result of the `recall_fused` tool: the recalled memories, plus a dated
+/// timeline when `date_field` was given.
+#[derive(Serialize, JsonSchema)]
+pub(super) struct RecallFusedResult {
+    /// Recalled memories, most relevant first.
+    pub(super) memories: Vec<Recollection>,
+    /// Chronological, date-prefixed rendering of `memories` (`- [YYYY-MM-DD]
+    /// content` per line, oldest first, undated facts last). Present only when
+    /// `date_field` was set.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) dated_context: Option<String>,
+    /// The most recent date across `memories` (`YYYY-MM-DD`), the "now" anchor.
+    /// Present only when `date_field` was set and at least one fact is dated.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) now: Option<String>,
 }
 
 /// Parameters for the `relate` tool.

--- a/crates/velesdb-memory/src/mcp/server_tests.rs
+++ b/crates/velesdb-memory/src/mcp/server_tests.rs
@@ -394,6 +394,128 @@ async fn oversized_fact_returns_invalid_params() {
 }
 
 #[tokio::test]
+async fn recall_fused_folds_in_a_graph_reached_fact() {
+    let (_dir, srv) = server();
+    // Anchor: an exact vector hit for the query.
+    let Json(anchor) = srv
+        .remember(Parameters(RememberParams {
+            fact: DECISION.to_owned(),
+            links: Vec::new(),
+            metadata: None,
+            ttl_seconds: None,
+        }))
+        .await
+        .expect("remember anchor");
+    // Linked: unrelated text (so it is not a vector hit for the query), but
+    // graph-connected to the anchor — only the graph reach can surface it.
+    let Json(linked) = srv
+        .remember(Parameters(RememberParams {
+            fact: "the on-call rotation moved to Tuesdays".to_owned(),
+            links: vec![Link {
+                target: anchor.id,
+                relation: "context".to_owned(),
+            }],
+            metadata: None,
+            ttl_seconds: None,
+        }))
+        .await
+        .expect("remember linked");
+
+    // Plain top-1 vector recall for the query finds the anchor, not the linked fact.
+    let Json(plain) = srv
+        .recall(Parameters(RecallParams {
+            query: DECISION.to_owned(),
+            limit: Some(1),
+            filter: None,
+        }))
+        .await
+        .expect("recall");
+    assert!(!plain.memories.iter().any(|m| m.id == linked.id));
+
+    // Fused recall walks the graph from the anchor seed and folds the linked fact in.
+    let Json(fused) = srv
+        .recall_fused(Parameters(RecallFusedParams {
+            query: DECISION.to_owned(),
+            limit: Some(10),
+            filter: None,
+            hops: None,
+            graph_boost: None,
+        }))
+        .await
+        .expect("recall_fused");
+    assert!(
+        fused.memories.iter().any(|m| m.id == anchor.id),
+        "anchor present in fused recall"
+    );
+    assert!(
+        fused.memories.iter().any(|m| m.id == linked.id),
+        "graph-reached fact folded into fused recall"
+    );
+}
+
+#[tokio::test]
+async fn recall_fused_survives_a_non_finite_graph_boost() {
+    // A NaN graph_boost reaches the pyo3/native-float bindings unfiltered; if it
+    // hit fusion it would collapse the ranking (NaN scores compare Equal) and
+    // silently drop the graph-reached facts. The service sanitizes it, so the
+    // linked fact is still surfaced — proving the guard holds on the real path.
+    let (_dir, srv) = server();
+    let Json(anchor) = srv
+        .remember(Parameters(RememberParams {
+            fact: DECISION.to_owned(),
+            links: Vec::new(),
+            metadata: None,
+            ttl_seconds: None,
+        }))
+        .await
+        .expect("remember anchor");
+    let Json(linked) = srv
+        .remember(Parameters(RememberParams {
+            fact: "the on-call rotation moved to Tuesdays".to_owned(),
+            links: vec![Link {
+                target: anchor.id,
+                relation: "context".to_owned(),
+            }],
+            metadata: None,
+            ttl_seconds: None,
+        }))
+        .await
+        .expect("remember linked");
+
+    let Json(fused) = srv
+        .recall_fused(Parameters(RecallFusedParams {
+            query: DECISION.to_owned(),
+            limit: Some(10),
+            filter: None,
+            hops: None,
+            graph_boost: Some(f64::NAN),
+        }))
+        .await
+        .expect("recall_fused");
+    assert!(
+        fused.memories.iter().any(|m| m.id == linked.id),
+        "graph-reached fact must still surface despite a non-finite graph_boost"
+    );
+}
+
+#[tokio::test]
+async fn recall_fused_limit_is_capped_at_max() {
+    let (_dir, srv) = server();
+    // The call must succeed (capped, not rejected) even with an absurd limit.
+    let Json(result) = srv
+        .recall_fused(Parameters(RecallFusedParams {
+            query: "anything".to_owned(),
+            limit: Some(usize::MAX),
+            filter: None,
+            hops: Some(usize::MAX),
+            graph_boost: None,
+        }))
+        .await
+        .expect("recall_fused with huge limit/hops must succeed (silently capped)");
+    let _ = result;
+}
+
+#[tokio::test]
 async fn recall_limit_is_capped_at_max() {
     let (_dir, srv) = server();
     // The call must succeed (capped, not rejected).

--- a/crates/velesdb-memory/src/mcp/server_tests.rs
+++ b/crates/velesdb-memory/src/mcp/server_tests.rs
@@ -440,6 +440,7 @@ async fn recall_fused_folds_in_a_graph_reached_fact() {
             filter: None,
             hops: None,
             graph_boost: None,
+            date_field: None,
         }))
         .await
         .expect("recall_fused");
@@ -451,6 +452,75 @@ async fn recall_fused_folds_in_a_graph_reached_fact() {
         fused.memories.iter().any(|m| m.id == linked.id),
         "graph-reached fact folded into fused recall"
     );
+}
+
+#[tokio::test]
+async fn recall_fused_with_date_field_returns_a_dated_timeline() {
+    let (_dir, srv) = server();
+    // Two dated facts, stored newest-first so ordering is actually exercised.
+    for (fact, ts) in [
+        ("the release shipped", 20_260_701_i64),
+        ("the project kicked off", 20_260_103),
+    ] {
+        srv.remember(Parameters(RememberParams {
+            fact: fact.to_owned(),
+            links: Vec::new(),
+            metadata: Some(ts_meta(ts)),
+            ttl_seconds: None,
+        }))
+        .await
+        .expect("remember dated fact");
+    }
+
+    let Json(res) = srv
+        .recall_fused(Parameters(RecallFusedParams {
+            query: "project release timeline".to_owned(),
+            limit: Some(10),
+            filter: None,
+            hops: None,
+            graph_boost: None,
+            date_field: Some("ts".to_owned()),
+        }))
+        .await
+        .expect("recall_fused dated");
+
+    let timeline = res
+        .dated_context
+        .expect("dated_context present when date_field set");
+    // Chronological: kickoff (Jan) before release (Jul), each date-prefixed.
+    assert!(timeline.contains("- [2026-01-03] the project kicked off"));
+    assert!(timeline.contains("- [2026-07-01] the release shipped"));
+    assert!(
+        timeline.find("2026-01-03").unwrap() < timeline.find("2026-07-01").unwrap(),
+        "facts must be ordered oldest-first"
+    );
+    assert_eq!(res.now.as_deref(), Some("2026-07-01"));
+}
+
+#[tokio::test]
+async fn recall_fused_without_date_field_omits_the_timeline() {
+    let (_dir, srv) = server();
+    srv.remember(Parameters(RememberParams {
+        fact: DECISION.to_owned(),
+        links: Vec::new(),
+        metadata: None,
+        ttl_seconds: None,
+    }))
+    .await
+    .expect("remember");
+    let Json(res) = srv
+        .recall_fused(Parameters(RecallFusedParams {
+            query: DECISION.to_owned(),
+            limit: Some(5),
+            filter: None,
+            hops: None,
+            graph_boost: None,
+            date_field: None,
+        }))
+        .await
+        .expect("recall_fused");
+    assert!(res.dated_context.is_none());
+    assert!(res.now.is_none());
 }
 
 #[tokio::test]
@@ -489,6 +559,7 @@ async fn recall_fused_survives_a_non_finite_graph_boost() {
             filter: None,
             hops: None,
             graph_boost: Some(f64::NAN),
+            date_field: None,
         }))
         .await
         .expect("recall_fused");
@@ -509,6 +580,7 @@ async fn recall_fused_limit_is_capped_at_max() {
             filter: None,
             hops: Some(usize::MAX),
             graph_boost: None,
+            date_field: None,
         }))
         .await
         .expect("recall_fused with huge limit/hops must succeed (silently capped)");

--- a/crates/velesdb-memory/src/model.rs
+++ b/crates/velesdb-memory/src/model.rs
@@ -128,6 +128,47 @@ impl Default for FusionOptions {
     }
 }
 
+impl FusionOptions {
+    /// Build options from optional, untrusted tuning knobs, applying the
+    /// defaults and hop clamp every binding that takes raw `hops`/`graph_boost`
+    /// must enforce identically: `hops` clamped to the graph-traversal ceiling
+    /// ([`clamp_hops`](crate::limits::clamp_hops)), `graph_boost` defaulted when
+    /// absent, and `pool` left at the proven default. The MCP `recall_fused`
+    /// tool and the Python `recall_fused` binding both build their options here
+    /// so the two transports can't drift on what they accept. A non-finite
+    /// `graph_boost` is not filtered here — that guard lives in
+    /// [`Self::sanitized`], applied by fusion itself so *every* caller is
+    /// covered, not just this constructor.
+    #[must_use]
+    pub fn from_knobs(hops: Option<usize>, graph_boost: Option<f64>) -> Self {
+        let defaults = Self::default();
+        Self {
+            hops: crate::limits::clamp_hops(hops.unwrap_or(defaults.hops)),
+            graph_boost: graph_boost.unwrap_or(defaults.graph_boost),
+            pool: defaults.pool,
+        }
+    }
+
+    /// A copy with any non-finite `graph_boost` (NaN or ±∞) reset to the
+    /// default. A non-finite boost poisons fusion catastrophically: the score
+    /// term `graph_boost · weight` is `NaN` for *every* candidate — even a
+    /// pool-only one, since `NaN · 0.0 == NaN` — so [`crate::fusion::fuse`]'s
+    /// `total_cmp` sort sees all scores as equal, degenerates to a no-op, and
+    /// then truncates away the graph-reached facts fusion exists to surface
+    /// (they are appended after the vector pool). The result is silently worse
+    /// than a plain `recall`. Applied inside
+    /// [`recall_fused`](crate::service::MemoryService::recall_fused) so no
+    /// caller — any binding, or a direct Rust user who filled the struct — can
+    /// trip it, however the options were built.
+    #[must_use]
+    pub fn sanitized(mut self) -> Self {
+        if !self.graph_boost.is_finite() {
+            self.graph_boost = Self::default().graph_boost;
+        }
+        self
+    }
+}
+
 /// A node in an [`Explanation`] subgraph.
 #[derive(Debug, Clone, Serialize, JsonSchema)]
 #[schemars(transform = crate::schema::strip_int_formats)]

--- a/crates/velesdb-memory/src/model.rs
+++ b/crates/velesdb-memory/src/model.rs
@@ -130,22 +130,26 @@ impl Default for FusionOptions {
 
 impl FusionOptions {
     /// Build options from optional, untrusted tuning knobs, applying the
-    /// defaults and hop clamp every binding that takes raw `hops`/`graph_boost`
-    /// must enforce identically: `hops` clamped to the graph-traversal ceiling
+    /// defaults and clamps every binding must enforce identically: `hops`
+    /// clamped to the graph-traversal ceiling
     /// ([`clamp_hops`](crate::limits::clamp_hops)), `graph_boost` defaulted when
-    /// absent, and `pool` left at the proven default. The MCP `recall_fused`
-    /// tool and the Python `recall_fused` binding both build their options here
-    /// so the two transports can't drift on what they accept. A non-finite
-    /// `graph_boost` is not filtered here — that guard lives in
+    /// absent, and `pool` clamped to the recall ceiling
+    /// ([`clamp_recall_limit`](crate::limits::clamp_recall_limit)) or left at the
+    /// proven default. The MCP `recall_fused` tool (which exposes no `pool`, so
+    /// passes `None`) and the Python `recall_fused` binding both build their
+    /// options here so the transports can't drift on what they accept. A
+    /// non-finite `graph_boost` is not filtered here — that guard lives in
     /// [`Self::sanitized`], applied by fusion itself so *every* caller is
     /// covered, not just this constructor.
     #[must_use]
-    pub fn from_knobs(hops: Option<usize>, graph_boost: Option<f64>) -> Self {
+    pub fn from_knobs(hops: Option<usize>, graph_boost: Option<f64>, pool: Option<usize>) -> Self {
         let defaults = Self::default();
         Self {
             hops: crate::limits::clamp_hops(hops.unwrap_or(defaults.hops)),
             graph_boost: graph_boost.unwrap_or(defaults.graph_boost),
-            pool: defaults.pool,
+            pool: pool
+                .map(crate::limits::clamp_recall_limit)
+                .or(defaults.pool),
         }
     }
 

--- a/crates/velesdb-node/Cargo.toml
+++ b/crates/velesdb-node/Cargo.toml
@@ -2,7 +2,7 @@
 name = "velesdb-node"
 # Tracks velesdb-memory's independent cadence (the npm package version),
 # not the workspace 3.x engine line. Never crates.io-published (publish=false).
-version = "0.4.0"
+version = "0.5.0"
 # Never cargo-published: this cdylib ships to npm as @wiscale/velesdb-memory-node
 # per-platform prebuilds, not to crates.io.
 publish = false

--- a/crates/velesdb-node/__test__/index.spec.mjs
+++ b/crates/velesdb-node/__test__/index.spec.mjs
@@ -17,7 +17,7 @@ function freshStore() {
   return { store, cleanup: () => rmSync(dir, { recursive: true, force: true }) }
 }
 
-test('surface allowlist — exactly the 9 supported methods, no engine leak', () => {
+test('surface allowlist — exactly the supported methods, no engine leak', () => {
   const instanceMethods = Object.getOwnPropertyNames(MemoryService.prototype)
     .filter((m) => m !== 'constructor')
     .sort((a, b) => a.localeCompare(b))
@@ -25,6 +25,7 @@ test('surface allowlist — exactly the 9 supported methods, no engine leak', ()
     'forget',
     'recall',
     'recallFused',
+    'recallFusedDated',
     'recallWhere',
     'relate',
     'remember',
@@ -142,6 +143,27 @@ test('recallWhere and recall both surface stored metadata (dated recall)', async
     const hits = await store.recall('pricing page', 5)
     assert.ok(hits.length >= 1)
     assert.equal(hits[0].metadata?.ts, 20260701, 'recall round-trips metadata too')
+  } finally {
+    cleanup()
+  }
+})
+
+test('recallFusedDated returns a chronological timeline and a now anchor', async () => {
+  const { store, cleanup } = freshStore()
+  try {
+    await store.remember('the release shipped', [], { ts: 20260701 })
+    await store.remember('the project kicked off', [], { ts: 20260103 })
+
+    const res = await store.recallFusedDated('project release timeline', 'ts', 10)
+    assert.ok(Array.isArray(res.memories) && res.memories.length >= 2)
+    assert.ok(res.datedContext.includes('- [2026-01-03] the project kicked off'))
+    assert.ok(res.datedContext.includes('- [2026-07-01] the release shipped'))
+    // Oldest first.
+    assert.ok(
+      res.datedContext.indexOf('2026-01-03') < res.datedContext.indexOf('2026-07-01'),
+      'timeline is oldest-first',
+    )
+    assert.equal(res.now, '2026-07-01', 'now anchors on the latest date')
   } finally {
     cleanup()
   }

--- a/crates/velesdb-node/package.json
+++ b/crates/velesdb-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wiscale/velesdb-memory-node",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Local-first agent memory for Node.js (napi-rs): remember/recall/relate/forget/why with the why() knowledge-graph wedge, plus auto-extraction.",
   "license": "SEE LICENSE IN LICENSE",
   "author": "Julien Lange <contact@wiscale.fr>",

--- a/crates/velesdb-node/src/dto.rs
+++ b/crates/velesdb-node/src/dto.rs
@@ -71,6 +71,19 @@ impl From<Recollection> for RecollectionJs {
     }
 }
 
+/// Result of `recallFusedDated`: the recalled memories plus a dated timeline.
+#[napi(object)]
+pub struct DatedRecallJs {
+    /// Recalled memories, most relevant first.
+    pub memories: Vec<RecollectionJs>,
+    /// Chronological, date-prefixed rendering of `memories` (`- [YYYY-MM-DD]
+    /// content` per line, oldest first, undated facts last).
+    pub dated_context: String,
+    /// The most recent date across `memories` (`YYYY-MM-DD`), or `undefined`
+    /// when no memory carries a valid date.
+    pub now: Option<String>,
+}
+
 /// A node in a `why()` explanation subgraph.
 #[napi(object)]
 pub struct MemoryNodeJs {

--- a/crates/velesdb-node/src/lib.rs
+++ b/crates/velesdb-node/src/lib.rs
@@ -49,7 +49,9 @@ use velesdb_memory::{
     DEFAULT_OLLAMA_MODEL, DEFAULT_OLLAMA_URL,
 };
 
-use crate::dto::{ColumnFilterJs, ExplanationJs, FusionOptionsJs, LinkJs, RecollectionJs};
+use crate::dto::{
+    ColumnFilterJs, DatedRecallJs, ExplanationJs, FusionOptionsJs, LinkJs, RecollectionJs,
+};
 use crate::error::{invalid_input, to_napi_err, CODE_INTERNAL};
 use crate::tasks::Job;
 
@@ -211,6 +213,40 @@ impl MemoryStore {
                 .recall_fused(&query, k, filter.as_ref(), opts)
                 .map_err(to_napi_err)?;
             Ok(hits.into_iter().map(RecollectionJs::from).collect())
+        }))
+    }
+
+    /// Fused recall plus a dated timeline: like [`recall_fused`](Self::recall_fused),
+    /// but reads each fact's date from the `dateField` metadata key (a `YYYYMMDD`
+    /// integer) and resolves to `{memories, datedContext, now}` — the memories, a
+    /// chronological date-prefixed timeline, and a "now" anchor for temporal
+    /// reasoning. A separate method (not a flag on `recallFused`) so the published
+    /// `recallFused` array return type stays unchanged.
+    #[napi(
+        js_name = "recallFusedDated",
+        ts_return_type = "Promise<DatedRecallJs>"
+    )]
+    pub fn recall_fused_dated(
+        &self,
+        query: String,
+        date_field: String,
+        k: Option<u32>,
+        filter: Option<Value>,
+        opts: Option<FusionOptionsJs>,
+    ) -> AsyncTask<Job<DatedRecallJs>> {
+        let svc = Arc::clone(&self.inner);
+        AsyncTask::new(Job::new(move || {
+            let k = guards::clamp_limit(k.unwrap_or(10));
+            let filter = convert::to_metadata(filter)?;
+            let opts = convert::to_fusion_options(opts);
+            let (hits, ctx) = svc
+                .recall_fused_dated(&query, k, filter.as_ref(), opts, &date_field)
+                .map_err(to_napi_err)?;
+            Ok(DatedRecallJs {
+                memories: hits.into_iter().map(RecollectionJs::from).collect(),
+                dated_context: ctx.timeline,
+                now: ctx.now,
+            })
         }))
     }
 

--- a/crates/velesdb-python/README.md
+++ b/crates/velesdb-python/README.md
@@ -3,7 +3,7 @@
 [![PyPI](https://img.shields.io/pypi/v/velesdb)](https://pypi.org/project/velesdb/)
 [![Python](https://img.shields.io/pypi/pyversions/velesdb)](https://pypi.org/project/velesdb/)
 [![License](https://img.shields.io/badge/license-VelesDB_Core_1.0-blue)](./LICENSE)
-[![Version](https://img.shields.io/badge/version-3.6.0-blue)](https://github.com/cyberlife-coder/VelesDB/releases)
+[![Version](https://img.shields.io/badge/version-3.7.0-blue)](https://github.com/cyberlife-coder/VelesDB/releases)
 
 Python bindings for [VelesDB](https://github.com/cyberlife-coder/VelesDB) — a high-performance vector database for AI applications. `numpy>=1.20` ships as a hard runtime dependency since v1.13.8, so a single `pip install velesdb` is sufficient.
 

--- a/crates/velesdb-python/pyproject.toml
+++ b/crates/velesdb-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "velesdb"
-version = "3.6.0"
+version = "3.7.0"
 description = "VelesDB: The Local Vector Database for Python & AI. Microsecond semantic search, zero network latency."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/crates/velesdb-python/python/velesdb/__init__.pyi
+++ b/crates/velesdb-python/python/velesdb/__init__.pyi
@@ -2344,6 +2344,38 @@ class MemoryService:
         """
         ...
 
+    def recall_fused(
+        self,
+        query: str,
+        k: int = 10,
+        filter: Optional[Dict[str, Any]] = None,
+        hops: Optional[int] = None,
+        graph_boost: Optional[float] = None,
+    ) -> List[Dict[str, Any]]:
+        """Fused vector + graph recall (the tri-engine ranking).
+
+        Like :meth:`recall`, but also walks the graph from the top vector hit
+        and folds any connected fact into the ranking. Best when an answer
+        needs a fact the ``query`` doesn't mention directly but a stored
+        :meth:`relate` / :meth:`remember_extracted` link connects (multi-hop
+        or temporal reasoning).
+
+        Args:
+            query: Free-text query.
+            k: Maximum number of results (default: 10).
+            filter: Optional exact-match metadata filter dict.
+            hops: Graph hops from the top vector hit (default: 2).
+            graph_boost: Weight added to a graph-reached fact's score
+                (default: 0.15).
+
+        Returns:
+            List of ``{"id": int, "score": float, "content": str,
+            "metadata": Optional[Dict[str, Any]]}`` dicts, most relevant
+            first. ``metadata`` is the fact's stored dict, or ``None`` if it
+            carried none.
+        """
+        ...
+
     def relate(self, from_id: int, to_id: int, relation: str) -> int:
         """Create a typed edge ``from_id → to_id``.
 

--- a/crates/velesdb-python/python/velesdb/__init__.pyi
+++ b/crates/velesdb-python/python/velesdb/__init__.pyi
@@ -2344,14 +2344,35 @@ class MemoryService:
         """
         ...
 
+    @overload
     def recall_fused(
         self,
         query: str,
         k: int = 10,
         filter: Optional[Dict[str, Any]] = None,
-        hops: Optional[int] = None,
-        graph_boost: Optional[float] = None,
-    ) -> List[Dict[str, Any]]:
+        *,
+        date_field: None = None,
+        options: Optional[Dict[str, Any]] = None,
+    ) -> List[Dict[str, Any]]: ...
+    @overload
+    def recall_fused(
+        self,
+        query: str,
+        k: int = 10,
+        filter: Optional[Dict[str, Any]] = None,
+        *,
+        date_field: str,
+        options: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]: ...
+    def recall_fused(
+        self,
+        query: str,
+        k: int = 10,
+        filter: Optional[Dict[str, Any]] = None,
+        *,
+        date_field: Optional[str] = None,
+        options: Optional[Dict[str, Any]] = None,
+    ) -> Union[List[Dict[str, Any]], Dict[str, Any]]:
         """Fused vector + graph recall (the tri-engine ranking).
 
         Like :meth:`recall`, but also walks the graph from the top vector hit
@@ -2364,15 +2385,19 @@ class MemoryService:
             query: Free-text query.
             k: Maximum number of results (default: 10).
             filter: Optional exact-match metadata filter dict.
-            hops: Graph hops from the top vector hit (default: 2).
-            graph_boost: Weight added to a graph-reached fact's score
-                (default: 0.15).
+            date_field: Metadata key holding each fact's ``YYYYMMDD`` date. When
+                given, the result is a dict with a dated timeline (see below);
+                when ``None`` (default), a plain list is returned.
+            options: Optional advanced fusion tuning
+                ``{"hops": int, "graph_boost": float, "pool": int}`` (all keys
+                optional). Omit for the proven defaults.
 
         Returns:
-            List of ``{"id": int, "score": float, "content": str,
-            "metadata": Optional[Dict[str, Any]]}`` dicts, most relevant
-            first. ``metadata`` is the fact's stored dict, or ``None`` if it
-            carried none.
+            Without ``date_field``: a list of ``{"id": int, "score": float,
+            "content": str, "metadata": Optional[Dict[str, Any]]}`` dicts, most
+            relevant first. With ``date_field``: a dict ``{"memories": [...],
+            "dated_context": str, "now": Optional[str]}`` — the same memories
+            plus a chronological, date-prefixed timeline and a "now" anchor.
         """
         ...
 

--- a/crates/velesdb-python/src/agent_memory_service.rs
+++ b/crates/velesdb-python/src/agent_memory_service.rs
@@ -13,9 +13,9 @@ use pyo3::types::{PyDict, PyList, PyString};
 use std::collections::HashMap;
 
 use velesdb_memory::{
-    limits, ColumnFilter, ColumnOp, DynEmbedder, ErrorCategory, Explanation, HashEmbedder, Link,
-    MemoryError, MemoryService, Metadata, OllamaEmbedder, OllamaExtractor, Recollection,
-    DEFAULT_DIMENSION, DEFAULT_OLLAMA_MODEL, DEFAULT_OLLAMA_URL,
+    limits, ColumnFilter, ColumnOp, DynEmbedder, ErrorCategory, Explanation, FusionOptions,
+    HashEmbedder, Link, MemoryError, MemoryService, Metadata, OllamaEmbedder, OllamaExtractor,
+    Recollection, DEFAULT_DIMENSION, DEFAULT_OLLAMA_MODEL, DEFAULT_OLLAMA_URL,
 };
 
 use crate::collection::query::convert_params;
@@ -245,6 +245,39 @@ impl PyMemoryService {
             })
             .collect::<PyResult<Vec<_>>>()?;
         let hits = py.detach(|| self.svc.recall_where(query, k, &filters).map_err(to_py_err))?;
+        let list = PyList::empty(py);
+        for hit in hits {
+            list.append(recollection_to_dict(py, hit)?)?;
+        }
+        Ok(list.into())
+    }
+
+    /// Fused vector + graph recall: like [`recall`](Self::recall), but also
+    /// walks the graph from the top vector hit and folds any connected fact
+    /// into the ranking — the tri-engine ranking measured on multi-hop and
+    /// temporal benchmarks. Best when an answer needs a fact the query doesn't
+    /// mention directly but a stored `relate`/`remember_extracted` link
+    /// connects. `hops`/`graph_boost` tune the graph reach; omit them for the
+    /// proven defaults. Returns `{id, score, content, metadata}` (`metadata`
+    /// is the fact's stored dict, or `None` if it carried none).
+    #[pyo3(signature = (query, k = 10, filter = None, hops = None, graph_boost = None))]
+    fn recall_fused(
+        &self,
+        py: Python<'_>,
+        query: &str,
+        k: usize,
+        filter: Option<HashMap<String, Py<PyAny>>>,
+        hops: Option<usize>,
+        graph_boost: Option<f64>,
+    ) -> PyResult<Py<PyAny>> {
+        let k = limits::clamp_recall_limit(k);
+        let filter = to_metadata(py, filter)?;
+        let opts = FusionOptions::from_knobs(hops, graph_boost);
+        let hits = py.detach(|| {
+            self.svc
+                .recall_fused(query, k, filter.as_ref(), opts)
+                .map_err(to_py_err)
+        })?;
         let list = PyList::empty(py);
         for hit in hits {
             list.append(recollection_to_dict(py, hit)?)?;

--- a/crates/velesdb-python/src/agent_memory_service.rs
+++ b/crates/velesdb-python/src/agent_memory_service.rs
@@ -13,13 +13,13 @@ use pyo3::types::{PyDict, PyList, PyString};
 use std::collections::HashMap;
 
 use velesdb_memory::{
-    limits, ColumnFilter, ColumnOp, DynEmbedder, ErrorCategory, Explanation, FusionOptions,
-    HashEmbedder, Link, MemoryError, MemoryService, Metadata, OllamaEmbedder, OllamaExtractor,
-    Recollection, DEFAULT_DIMENSION, DEFAULT_OLLAMA_MODEL, DEFAULT_OLLAMA_URL,
+    format_dated_context, limits, ColumnFilter, ColumnOp, DynEmbedder, ErrorCategory, Explanation,
+    FusionOptions, HashEmbedder, Link, MemoryError, MemoryService, Metadata, OllamaEmbedder,
+    OllamaExtractor, Recollection, DEFAULT_DIMENSION, DEFAULT_OLLAMA_MODEL, DEFAULT_OLLAMA_URL,
 };
 
 use crate::collection::query::convert_params;
-use crate::utils::{json_to_python, python_to_json};
+use crate::utils::{json_to_python, opt_field, python_to_json};
 
 /// Map a [`MemoryError`] to the most specific Python exception, driven by its
 /// transport-neutral [`ErrorCategory`] so the taxonomy stays identical to the
@@ -124,6 +124,20 @@ fn explanation_to_dict(py: Python<'_>, e: &Explanation) -> PyResult<Py<PyAny>> {
     out.set_item(PyString::intern(py, "nodes"), nodes)?;
     out.set_item(PyString::intern(py, "edges"), edges)?;
     Ok(out.into())
+}
+
+/// Build [`FusionOptions`] from an optional Python `{hops?, graph_boost?, pool?}`
+/// dict, routed through [`FusionOptions::from_knobs`] so the defaults and clamps
+/// stay identical to the MCP tool. An absent dict (or one omitting a key) uses
+/// the proven defaults.
+fn fusion_options_from_dict(options: Option<&Bound<'_, PyDict>>) -> PyResult<FusionOptions> {
+    let Some(dict) = options else {
+        return Ok(FusionOptions::from_knobs(None, None, None));
+    };
+    let hops = opt_field(dict, "hops")?;
+    let graph_boost = opt_field(dict, "graph_boost")?;
+    let pool = opt_field(dict, "pool")?;
+    Ok(FusionOptions::from_knobs(hops, graph_boost, pool))
 }
 
 /// Local-first agent memory with the `why()` graph wedge.
@@ -257,32 +271,53 @@ impl PyMemoryService {
     /// into the ranking — the tri-engine ranking measured on multi-hop and
     /// temporal benchmarks. Best when an answer needs a fact the query doesn't
     /// mention directly but a stored `relate`/`remember_extracted` link
-    /// connects. `hops`/`graph_boost` tune the graph reach; omit them for the
-    /// proven defaults. Returns `{id, score, content, metadata}` (`metadata`
-    /// is the fact's stored dict, or `None` if it carried none).
-    #[pyo3(signature = (query, k = 10, filter = None, hops = None, graph_boost = None))]
+    /// connects. Advanced fusion tuning goes in `options`
+    /// (`{"hops": int, "graph_boost": float, "pool": int}`, all optional — same
+    /// shape as the Node/WASM binding); omit it for the proven defaults.
+    ///
+    /// Without `date_field`, returns a list of `{id, score, content, metadata}`
+    /// (`metadata` is the fact's stored dict, or `None` if it carried none).
+    /// With `date_field` set to the metadata key holding each fact's `YYYYMMDD`
+    /// date, returns a dict `{"memories": [...], "dated_context": str, "now":
+    /// str | None}` — the memories plus a chronological, date-prefixed timeline
+    /// and a "now" anchor for temporal reasoning.
+    #[pyo3(signature = (query, k = 10, filter = None, *, date_field = None, options = None))]
     fn recall_fused(
         &self,
         py: Python<'_>,
         query: &str,
         k: usize,
         filter: Option<HashMap<String, Py<PyAny>>>,
-        hops: Option<usize>,
-        graph_boost: Option<f64>,
+        date_field: Option<String>,
+        options: Option<Bound<'_, PyDict>>,
     ) -> PyResult<Py<PyAny>> {
         let k = limits::clamp_recall_limit(k);
         let filter = to_metadata(py, filter)?;
-        let opts = FusionOptions::from_knobs(hops, graph_boost);
+        let opts = fusion_options_from_dict(options.as_ref())?;
         let hits = py.detach(|| {
             self.svc
                 .recall_fused(query, k, filter.as_ref(), opts)
                 .map_err(to_py_err)
         })?;
-        let list = PyList::empty(py);
+        // Format the dated timeline before the hits are consumed into the list.
+        let dated = date_field
+            .as_ref()
+            .map(|field| format_dated_context(&hits, field));
+
+        let memories = PyList::empty(py);
         for hit in hits {
-            list.append(recollection_to_dict(py, hit)?)?;
+            memories.append(recollection_to_dict(py, hit)?)?;
         }
-        Ok(list.into())
+        match dated {
+            None => Ok(memories.into()),
+            Some(ctx) => {
+                let out = PyDict::new(py);
+                out.set_item(PyString::intern(py, "memories"), memories)?;
+                out.set_item(PyString::intern(py, "dated_context"), ctx.timeline)?;
+                out.set_item(PyString::intern(py, "now"), ctx.now)?;
+                Ok(out.into())
+            }
+        }
     }
 
     /// Create a typed edge `from_id -> to_id`. Returns the edge id.

--- a/crates/velesdb-python/src/collection/mod.rs
+++ b/crates/velesdb-python/src/collection/mod.rs
@@ -29,17 +29,7 @@ const DEFAULT_FUSION: CoreFusionStrategy = CoreFusionStrategy::RRF { k: 60 };
 
 use velesdb_core::collection::streaming::{AsyncIndexBuilderConfig, DeferredIndexerConfig};
 
-/// Extract an optional typed value for `key`, returning `None` when the
-/// key is absent or holds Python `None`.
-fn opt_field<'py, T: FromPyObjectOwned<'py>>(
-    dict: &Bound<'py, PyDict>,
-    key: &str,
-) -> PyResult<Option<T>> {
-    match dict.get_item(key)? {
-        Some(v) if !v.is_none() => Ok(Some(v.extract().map_err(Into::into)?)),
-        _ => Ok(None),
-    }
-}
+use crate::utils::opt_field;
 
 /// Resolve a three-state override for `key`: an absent key leaves the field
 /// unchanged (`None`), an explicit Python `None` clears it (`Some(None)`),

--- a/crates/velesdb-python/src/utils.rs
+++ b/crates/velesdb-python/src/utils.rs
@@ -5,9 +5,28 @@
 
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
+use pyo3::types::PyDict;
 use pyo3::IntoPyObjectExt;
 use std::collections::HashMap;
 use velesdb_core::{DistanceMetric, StorageMode};
+
+/// Extract an optional typed value for `key` from `dict`, returning `None` when
+/// the key is absent or holds Python `None` — so `{}`, a missing key, and an
+/// explicit `None` all read as "unset". Shared by every binding that takes an
+/// options dict (collection config, `recall_fused` fusion options).
+///
+/// # Errors
+///
+/// Propagates any error from extracting the value as `T` (e.g. a wrong type).
+pub fn opt_field<'py, T: FromPyObjectOwned<'py>>(
+    dict: &Bound<'py, PyDict>,
+    key: &str,
+) -> PyResult<Option<T>> {
+    match dict.get_item(key)? {
+        Some(v) if !v.is_none() => Ok(Some(v.extract().map_err(Into::into)?)),
+        _ => Ok(None),
+    }
+}
 
 /// Rejects vectors that contain non-finite values (NaN or Infinity).
 ///

--- a/crates/velesdb-python/tests/test_memory_service.py
+++ b/crates/velesdb-python/tests/test_memory_service.py
@@ -157,9 +157,10 @@ def test_recall_fused_respects_exact_match_filter(mem):
 
 
 def test_recall_fused_accepts_tuning_knobs(mem):
-    # hops/graph_boost are optional and clamped, not rejected.
+    # Advanced fusion knobs go in `options` (same shape as Node/WASM); optional
+    # and clamped, not rejected.
     mem.remember("a decision about locks")
-    hits = mem.recall_fused("locks", k=5, hops=1, graph_boost=0.3)
+    hits = mem.recall_fused("locks", k=5, options={"hops": 1, "graph_boost": 0.3, "pool": 64})
     assert isinstance(hits, list)
 
 
@@ -172,9 +173,44 @@ def test_recall_fused_survives_non_finite_graph_boost(mem):
         "the on-call rotation moved to Tuesdays",
         links=[(anchor, "context")],
     )
-    hits = mem.recall_fused("parking_lot poisoning", k=10, graph_boost=float("nan"))
+    hits = mem.recall_fused(
+        "parking_lot poisoning", k=10, options={"graph_boost": float("nan")}
+    )
     ids = {h["id"] for h in hits}
     assert linked in ids
+
+
+def test_recall_fused_dated_returns_timeline_and_now(mem):
+    # With date_field, recall_fused returns a dict carrying a chronological,
+    # date-prefixed timeline + a "now" anchor — the temporal representation
+    # shipped as product behavior, not left to the caller's prompt.
+    mem.remember("the release shipped", metadata={"ts": 20260701})
+    mem.remember("the project kicked off", metadata={"ts": 20260103})
+    res = mem.recall_fused("project release timeline", k=10, date_field="ts")
+    assert isinstance(res, dict)
+    assert set(res) == {"memories", "dated_context", "now"}
+    timeline = res["dated_context"]
+    assert "- [2026-01-03] the project kicked off" in timeline
+    assert "- [2026-07-01] the release shipped" in timeline
+    # Oldest first.
+    assert timeline.index("2026-01-03") < timeline.index("2026-07-01")
+    assert res["now"] == "2026-07-01"
+
+
+def test_recall_fused_without_date_field_returns_a_plain_list(mem):
+    # Backward-compatible: no date_field -> a list, exactly like before.
+    mem.remember("a plain fact")
+    res = mem.recall_fused("plain fact", k=5)
+    assert isinstance(res, list)
+
+
+def test_recall_fused_zero_pool_is_floored_not_emptied(mem):
+    # pool=0 must not oversample zero candidates and return nothing; it is
+    # floored to 1 (a deliberate small pool is still honored, just never empty).
+    for i in range(3):
+        mem.remember(f"a fact number {i} about locks")
+    hits = mem.recall_fused("locks", k=5, options={"pool": 0})
+    assert len(hits) > 0
 
 
 def test_oversized_fact_raises_value_error(mem):

--- a/crates/velesdb-python/tests/test_memory_service.py
+++ b/crates/velesdb-python/tests/test_memory_service.py
@@ -131,6 +131,52 @@ def test_recall_metadata_is_none_when_the_fact_carries_none(mem):
     assert all(h["metadata"] is None for h in hits)
 
 
+def test_recall_fused_folds_in_a_graph_reached_fact(mem):
+    # Fused recall walks the graph from the top vector hit and folds in a fact
+    # the query never mentions but a stored link connects — the shipped
+    # tri-engine ranking, not a harness-only prompt trick.
+    anchor = mem.remember("we chose parking_lot to avoid lock poisoning")
+    linked = mem.remember(
+        "the on-call rotation moved to Tuesdays",
+        links=[(anchor, "context")],
+    )
+    # Plain top-1 vector recall finds the anchor, not the unrelated linked fact.
+    plain = mem.recall("parking_lot poisoning", k=1)
+    assert all(h["id"] != linked for h in plain)
+    # Fused recall reaches it through the graph.
+    fused = mem.recall_fused("parking_lot poisoning", k=10)
+    ids = {h["id"] for h in fused}
+    assert anchor in ids and linked in ids
+
+
+def test_recall_fused_respects_exact_match_filter(mem):
+    keep = mem.remember("auth bug in login", metadata={"project": "veles"})
+    mem.remember("auth bug in login too", metadata={"project": "acme"})
+    hits = mem.recall_fused("auth bug", k=5, filter={"project": "veles"})
+    assert all(h["id"] == keep for h in hits)
+
+
+def test_recall_fused_accepts_tuning_knobs(mem):
+    # hops/graph_boost are optional and clamped, not rejected.
+    mem.remember("a decision about locks")
+    hits = mem.recall_fused("locks", k=5, hops=1, graph_boost=0.3)
+    assert isinstance(hits, list)
+
+
+def test_recall_fused_survives_non_finite_graph_boost(mem):
+    # A native Python float bypasses JSON's NaN rejection, so the binding must
+    # not let a NaN graph_boost poison fusion (it would collapse the ranking and
+    # silently drop exactly the graph-reached facts recall_fused exists to find).
+    anchor = mem.remember("we chose parking_lot to avoid lock poisoning")
+    linked = mem.remember(
+        "the on-call rotation moved to Tuesdays",
+        links=[(anchor, "context")],
+    )
+    hits = mem.recall_fused("parking_lot poisoning", k=10, graph_boost=float("nan"))
+    ids = {h["id"] for h in hits}
+    assert linked in ids
+
+
 def test_oversized_fact_raises_value_error(mem):
     # Facts above the shared 1 MiB cap are rejected before any embedding work.
     with pytest.raises(ValueError):

--- a/crates/velesdb-server/README.md
+++ b/crates/velesdb-server/README.md
@@ -659,7 +659,7 @@ curl http://localhost:8080/health
 Response:
 
 ```json
-{"status": "ok", "version": "3.6.0"}
+{"status": "ok", "version": "3.7.0"}
 ```
 
 ### `GET /ready` -- Readiness Probe
@@ -673,13 +673,13 @@ curl http://localhost:8080/ready
 Response (ready):
 
 ```json
-{"status": "ready", "version": "3.6.0"}
+{"status": "ready", "version": "3.7.0"}
 ```
 
 Response (not ready):
 
 ```json
-{"status": "not_ready", "version": "3.6.0"}
+{"status": "not_ready", "version": "3.7.0"}
 ```
 
 ### Kubernetes Example

--- a/crates/velesdb-server/src/handlers/graph/handlers.rs
+++ b/crates/velesdb-server/src/handlers/graph/handlers.rs
@@ -322,7 +322,7 @@ pub async fn traverse_graph(
     path = "/collections/{name}/graph/nodes/{node_id}/degree",
     params(
         ("name" = String, Path, description = "Collection name"),
-        ("node_id" = u64, Path, description = "Node ID")
+        ("node_id" = String, Path, description = "Node ID (u64 as a string; precision-safe above 2^53-1)", pattern = "^[0-9]+$")
     ),
     responses(
         (status = 200, description = "Degree retrieved successfully", body = DegreeResponse),

--- a/crates/velesdb-server/src/handlers/graph/handlers_extended.rs
+++ b/crates/velesdb-server/src/handlers/graph/handlers_extended.rs
@@ -28,7 +28,7 @@ use super::types::{
     path = "/collections/{name}/graph/edges/{edge_id}",
     params(
         ("name" = String, Path, description = "Collection name"),
-        ("edge_id" = u64, Path, description = "Edge ID to remove")
+        ("edge_id" = String, Path, description = "Edge ID to remove (u64 as a string; precision-safe above 2^53-1)", pattern = "^[0-9]+$")
     ),
     responses(
         (status = 204, description = "Edge removed successfully"),
@@ -113,7 +113,7 @@ pub async fn list_nodes(
     path = "/collections/{name}/graph/nodes/{node_id}/edges",
     params(
         ("name" = String, Path, description = "Collection name"),
-        ("node_id" = u64, Path, description = "Node ID"),
+        ("node_id" = String, Path, description = "Node ID (u64 as a string; precision-safe above 2^53-1)", pattern = "^[0-9]+$"),
         NodeEdgeQueryParams
     ),
     responses(
@@ -166,7 +166,7 @@ pub async fn get_node_edges(
     path = "/collections/{name}/graph/nodes/{node_id}/payload",
     params(
         ("name" = String, Path, description = "Collection name"),
-        ("node_id" = u64, Path, description = "Node ID")
+        ("node_id" = String, Path, description = "Node ID (u64 as a string; precision-safe above 2^53-1)", pattern = "^[0-9]+$")
     ),
     request_body = UpsertNodePayloadRequest,
     responses(
@@ -201,7 +201,7 @@ pub async fn upsert_node_payload(
     path = "/collections/{name}/graph/nodes/{node_id}/payload",
     params(
         ("name" = String, Path, description = "Collection name"),
-        ("node_id" = u64, Path, description = "Node ID")
+        ("node_id" = String, Path, description = "Node ID (u64 as a string; precision-safe above 2^53-1)", pattern = "^[0-9]+$")
     ),
     responses(
         (status = 200, description = "Payload retrieved", body = NodePayloadResponse),

--- a/crates/velesdb-server/src/handlers/graph/types.rs
+++ b/crates/velesdb-server/src/handlers/graph/types.rs
@@ -277,7 +277,7 @@ pub struct GraphSearchResultItem {
 pub struct StreamTraverseParams {
     /// Source node ID to start traversal from.
     #[serde(deserialize_with = "serde_id::deserialize_id_from_string_or_number")]
-    #[param(example = 123)]
+    #[param(value_type = String, example = "123", pattern = "^[0-9]+$")]
     pub start_node: u64,
     /// Traversal algorithm: "bfs" or "dfs".
     #[serde(default = "default_algorithm")]

--- a/crates/velesdb-server/src/handlers/points/mod.rs
+++ b/crates/velesdb-server/src/handlers/points/mod.rs
@@ -24,6 +24,7 @@ use crate::types::{
     UpsertPointsRequest,
 };
 use crate::AppState;
+use velesdb_core::api_types::serde_id;
 use velesdb_core::Point;
 
 use crate::handlers::helpers::{
@@ -190,7 +191,7 @@ fn build_points_from_request(req: UpsertPointsRequest) -> Result<Vec<Point>, Str
     tag = "points",
     params(
         ("name" = String, Path, description = "Collection name"),
-        ("id" = u64, Path, description = "Point ID")
+        ("id" = String, Path, description = "Point ID (u64 as a string; precision-safe above 2^53-1)", pattern = "^[0-9]+$")
     ),
     responses(
         (status = 200, description = "Point found", body = Object),
@@ -229,7 +230,7 @@ pub async fn get_point(
     tag = "points",
     params(
         ("name" = String, Path, description = "Collection name"),
-        ("id" = u64, Path, description = "Point ID")
+        ("id" = String, Path, description = "Point ID (u64 as a string; precision-safe above 2^53-1)", pattern = "^[0-9]+$")
     ),
     responses(
         (status = 200, description = "Point deleted", body = Object),
@@ -350,6 +351,8 @@ const MAX_BULK_DELETE_SIZE: usize = 10_000;
 #[derive(serde::Deserialize, utoipa::ToSchema)]
 pub struct BulkDeleteRequest {
     /// List of point IDs to delete.
+    #[serde(deserialize_with = "serde_id::deserialize_ids_from_string_or_number")]
+    #[cfg_attr(feature = "openapi", schema(schema_with = serde_id::ids_array_schema))]
     pub ids: Vec<u64>,
 }
 

--- a/crates/velesdb-server/src/handlers/points/relations.rs
+++ b/crates/velesdb-server/src/handlers/points/relations.rs
@@ -194,7 +194,7 @@ fn insert_edge_with_retry(
     path = "/collections/{name}/relations/{edge_id}",
     params(
         ("name" = String, Path, description = "Collection name"),
-        ("edge_id" = u64, Path, description = "Edge ID to remove")
+        ("edge_id" = String, Path, description = "Edge ID to remove (u64 as a string; precision-safe above 2^53-1)", pattern = "^[0-9]+$")
     ),
     responses(
         (status = 204, description = "Relation removed"),
@@ -233,7 +233,7 @@ pub async fn unrelate_points(
     path = "/collections/{name}/points/{id}/relations",
     params(
         ("name" = String, Path, description = "Collection name"),
-        ("id" = u64, Path, description = "Point ID")
+        ("id" = String, Path, description = "Point ID (u64 as a string; precision-safe above 2^53-1)", pattern = "^[0-9]+$")
     ),
     responses(
         (status = 200, description = "Outgoing relations", body = RelationsResponse),
@@ -278,7 +278,7 @@ pub async fn get_point_relations(
     path = "/collections/{name}/points/{id}/ttl",
     params(
         ("name" = String, Path, description = "Collection name"),
-        ("id" = u64, Path, description = "Point ID")
+        ("id" = String, Path, description = "Point ID (u64 as a string; precision-safe above 2^53-1)", pattern = "^[0-9]+$")
     ),
     request_body = SetTtlRequest,
     responses(

--- a/crates/velesdb-server/tests/admin_endpoints_bdd_tests.rs
+++ b/crates/velesdb-server/tests/admin_endpoints_bdd_tests.rs
@@ -127,6 +127,32 @@ async fn bulk_delete_nominal_returns_200_with_deleted_count() {
 }
 
 #[tokio::test]
+async fn bulk_delete_accepts_string_ids_for_js_precision_safety() {
+    // IDs are emitted as JSON strings on every read surface (precision-safe
+    // above 2^53-1); bulk delete must therefore accept the string form a JS
+    // client echoes back — not just native integers. See `serde_id`.
+    let temp_dir = TempDir::new().expect("test: temp dir");
+    let app = create_test_app(&temp_dir);
+    seed_collection(app.clone(), 5).await;
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/collections/{TEST_COLLECTION}/points/delete"))
+                .header("Content-Type", "application/json")
+                .body(Body::from(json!({ "ids": ["1", "2", "3"] }).to_string()))
+                .expect("test: build delete request"),
+        )
+        .await
+        .expect("test: delete request");
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let json = read_json(response).await;
+    assert_eq!(json["deleted_count"], 3);
+}
+
+#[tokio::test]
 async fn bulk_delete_empty_payload_returns_200_noop() {
     // Documented behaviour: empty `ids: []` is a no-op (200, count=0).
     // See `bulk_delete_points` rustdoc — idempotent batch semantics.

--- a/crates/velesdb-wasm/src/memory_service.rs
+++ b/crates/velesdb-wasm/src/memory_service.rs
@@ -196,6 +196,18 @@ impl From<Recollection> for RecollectionOut {
     }
 }
 
+/// Result of [`WasmMemoryService::recall_fused_dated`]: the recalled memories
+/// plus a chronological, date-prefixed timeline and a "now" anchor.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct DatedRecallOut {
+    memories: Vec<RecollectionOut>,
+    dated_context: String,
+    /// `null` when no fact is dated — kept present (not skipped) so this matches
+    /// the Node binding, where napi serializes `Option::None` as JS `null`.
+    now: Option<String>,
+}
+
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 struct MemoryNodeOut {
@@ -388,6 +400,35 @@ impl WasmMemoryService {
                 .map(RecollectionOut::from)
                 .collect::<Vec<_>>(),
         )
+    }
+
+    /// Fused recall plus a dated timeline: like [`Self::recall_fused`], but
+    /// reads each fact's date from the `dateField` metadata key (a `YYYYMMDD`
+    /// integer) and returns `{memories, datedContext, now}` — the memories, a
+    /// chronological date-prefixed timeline, and a "now" anchor for temporal
+    /// reasoning. A separate method (not a flag on `recallFused`) so the
+    /// published `recallFused` array return type is unchanged.
+    #[wasm_bindgen(js_name = recallFusedDated)]
+    pub fn recall_fused_dated(
+        &self,
+        query: &str,
+        date_field: &str,
+        k: Option<usize>,
+        filter: JsValue,
+        opts: JsValue,
+    ) -> Result<JsValue, JsValue> {
+        let k = velesdb_memory::limits::clamp_recall_limit(k.unwrap_or(10));
+        let filter = to_metadata(filter)?;
+        let opts = to_fusion_options(opts)?;
+        let (hits, ctx) = self
+            .inner
+            .recall_fused_dated(query, k, filter.as_ref(), opts, date_field)
+            .map_err(to_js_err)?;
+        to_js(&DatedRecallOut {
+            memories: hits.into_iter().map(RecollectionOut::from).collect(),
+            dated_context: ctx.timeline,
+            now: ctx.now,
+        })
     }
 
     /// Create a typed edge `from -> to`. Resolves to the edge's

--- a/crates/velesdb-wasm/src/memory_service_tests.rs
+++ b/crates/velesdb-wasm/src/memory_service_tests.rs
@@ -141,3 +141,41 @@ fn test_inner_why_reaches_a_two_hop_fact_vector_search_misses() {
         .unwrap();
     assert!(explanation.nodes.iter().any(|n| n.id == ticket));
 }
+
+#[test]
+fn test_inner_recall_fused_dated_builds_a_chronological_timeline() {
+    // The `recallFusedDated` JS boundary can't be touched natively (JsValue),
+    // but its logic is the pure-Rust `inner.recall_fused_dated` the wrapper
+    // delegates to — so the timeline/now behavior is provable here.
+    let svc = WasmMemoryService::new(4);
+    let mut newer = Metadata::new();
+    newer.insert("ts".to_owned(), serde_json::json!(20_260_701));
+    svc.inner
+        .remember("the release shipped", &[], Some(&newer))
+        .unwrap();
+    let mut older = Metadata::new();
+    older.insert("ts".to_owned(), serde_json::json!(20_260_103));
+    svc.inner
+        .remember("the project kicked off", &[], Some(&older))
+        .unwrap();
+
+    let (_hits, ctx) = svc
+        .inner
+        .recall_fused_dated(
+            "project release timeline",
+            10,
+            None,
+            velesdb_memory::FusionOptions::default(),
+            "ts",
+        )
+        .unwrap();
+    assert!(ctx
+        .timeline
+        .contains("- [2026-01-03] the project kicked off"));
+    assert!(ctx.timeline.contains("- [2026-07-01] the release shipped"));
+    assert!(
+        ctx.timeline.find("2026-01-03").unwrap() < ctx.timeline.find("2026-07-01").unwrap(),
+        "timeline is oldest-first"
+    );
+    assert_eq!(ctx.now.as_deref(), Some("2026-07-01"));
+}

--- a/demos/rag-pdf-demo/pyproject.toml
+++ b/demos/rag-pdf-demo/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "velesdb-rag-demo"
-version = "3.6.0"
+version = "3.7.0"
 description = "RAG Demo with PDF ingestion using VelesDB for vector storage"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/demos/rag-pdf-demo/src/__init__.py
+++ b/demos/rag-pdf-demo/src/__init__.py
@@ -1,3 +1,3 @@
 """VelesDB RAG Demo - PDF Question Answering System."""
 
-__version__ = "3.6.0"
+__version__ = "3.7.0"

--- a/demos/rag-pdf-demo/src/main.py
+++ b/demos/rag-pdf-demo/src/main.py
@@ -46,7 +46,7 @@ async def lifespan(app: FastAPI):
 app = FastAPI(
     title="VelesDB RAG Demo",
     description="PDF Question Answering with VelesDB vector search",
-    version="3.6.0",
+    version="3.7.0",
     lifespan=lifespan
 )
 

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -1,6 +1,6 @@
 # VelesDB Performance Benchmarks
 
-*Last updated: July 3, 2026 (VelesDB v3.6.0). Figures are re-validated at each release only when re-measured — each section carries its own measurement date and machine; this stamp tracks the document revision, not a fresh measurement.*
+*Last updated: July 6, 2026 (VelesDB v3.7.0). Figures are re-validated at each release only when re-measured — each section carries its own measurement date and machine; this stamp tracks the document revision, not a fresh measurement.*
 
 ---
 

--- a/docs/VELESQL_SPEC.md
+++ b/docs/VELESQL_SPEC.md
@@ -2,7 +2,7 @@
 
 > SQL-like query language for vector + graph + column-store search in VelesDB.
 
-**Version**: 3.10.0 | **Last Updated**: 2026-07-03 (VelesDB v3.6.0)
+**Version**: 3.10.0 | **Last Updated**: 2026-07-06 (VelesDB v3.7.0)
 
 ---
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -96,7 +96,7 @@ Expected response:
 ```json
 {
   "status": "ok",
-  "version": "3.6.0"
+  "version": "3.7.0"
 }
 ```
 

--- a/docs/guides/CLI_REPL.md
+++ b/docs/guides/CLI_REPL.md
@@ -1,6 +1,6 @@
 # 💻 CLI & REPL Reference
 
-*Version 3.6.0 — 2026-06-12*
+*Version 3.7.0 — 2026-06-12*
 
 Complete guide to the VelesDB command-line interface and the interactive REPL.
 
@@ -36,7 +36,7 @@ cargo build --release -p velesdb-cli
 
 ```bash
 velesdb --version
-# velesdb 3.6.0
+# velesdb 3.7.0
 ```
 
 ---
@@ -269,7 +269,7 @@ velesdb> \info
 ┌─────────────────────┬────────────────────┐
 │ Property            │ Value              │
 ├─────────────────────┼────────────────────┤
-│ Version             │ 3.6.0              │
+│ Version             │ 3.7.0              │
 │ Data directory      │ ./data             │
 │ Collections         │ 3                  │
 │ Total vectors       │ 125,000            │
@@ -342,7 +342,7 @@ Session settings are **not persisted** across REPL sessions. To persist them, us
 ```
 $ velesdb repl ./my_db
 
-VelesDB v3.6.0 - Interactive REPL
+VelesDB v3.7.0 - Interactive REPL
 Type \help for help, \quit to exit.
 
 velesdb> \show

--- a/docs/guides/CONFIGURATION.md
+++ b/docs/guides/CONFIGURATION.md
@@ -1,6 +1,6 @@
 # ⚙️ VelesDB Configuration
 
-*Version 3.6.0 — May 2026*
+*Version 3.7.0 — May 2026*
 
 Complete guide for configuring VelesDB via configuration file, environment variables, and runtime parameters.
 
@@ -62,7 +62,7 @@ data_dir = "./data"
 ```toml
 # =============================================================================
 # VelesDB Configuration File
-# Version: 3.6.0
+# Version: 3.7.0
 # =============================================================================
 
 # -----------------------------------------------------------------------------

--- a/docs/guides/GRAPH_PATTERNS.md
+++ b/docs/guides/GRAPH_PATTERNS.md
@@ -1,6 +1,6 @@
 # Graph Patterns Guide
 
-*Version 3.6.0 -- May 2026*
+*Version 3.7.0 -- May 2026*
 
 Practical guide for using VelesQL `MATCH` graph patterns in VelesDB.
 

--- a/docs/guides/INSTALLATION.md
+++ b/docs/guides/INSTALLATION.md
@@ -60,10 +60,10 @@ entry.
 
 ```bash
 # Download
-wget https://github.com/cyberlife-coder/VelesDB/releases/download/v3.6.0/velesdb-3.6.0-amd64.deb
+wget https://github.com/cyberlife-coder/VelesDB/releases/download/v3.7.0/velesdb-3.7.0-amd64.deb
 
 # Install
-sudo dpkg -i velesdb-3.6.0-amd64.deb
+sudo dpkg -i velesdb-3.7.0-amd64.deb
 
 # Verify
 velesdb --version
@@ -160,13 +160,13 @@ GitHub Container Registry, so you don't need to build locally:
 
 ```bash
 # Pull a specific release (recommended for reproducibility)
-docker pull ghcr.io/cyberlife-coder/velesdb:3.6.0
+docker pull ghcr.io/cyberlife-coder/velesdb:3.7.0
 
 # ...or the latest stable release
 docker pull ghcr.io/cyberlife-coder/velesdb:latest
 
 docker run -d --name velesdb -p 8080:8080 -v velesdb_data:/data \
-  ghcr.io/cyberlife-coder/velesdb:3.6.0
+  ghcr.io/cyberlife-coder/velesdb:3.7.0
 ```
 
 ### Build locally

--- a/docs/guides/SEARCH_MODES.md
+++ b/docs/guides/SEARCH_MODES.md
@@ -1,6 +1,6 @@
 # 🎯 Search Modes - Recall Configuration Guide
 
-*Version 3.6.0 -- 2026-06-12*
+*Version 3.7.0 -- 2026-06-12*
 
 Complete guide to configuring the **recall vs latency** trade-off in VelesDB. Covers dense search (HNSW), sparse search (SPLADE/BM42), and hybrid search (dense+sparse with fusion). Includes a comparison with Milvus, OpenSearch, and Qdrant practices.
 

--- a/docs/guides/SERVER_SECURITY.md
+++ b/docs/guides/SERVER_SECURITY.md
@@ -299,7 +299,7 @@ curl http://localhost:8080/health
 ```json
 {
   "status": "ok",
-  "version": "3.6.0"
+  "version": "3.7.0"
 }
 ```
 
@@ -318,7 +318,7 @@ curl http://localhost:8080/ready
 ```json
 {
   "status": "ready",
-  "version": "3.6.0"
+  "version": "3.7.0"
 }
 ```
 
@@ -327,7 +327,7 @@ curl http://localhost:8080/ready
 ```json
 {
   "status": "not_ready",
-  "version": "3.6.0"
+  "version": "3.7.0"
 }
 ```
 

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -777,12 +777,11 @@
           {
             "name": "edge_id",
             "in": "path",
-            "description": "Edge ID to remove",
+            "description": "Edge ID to remove (u64 as a string; precision-safe above 2^53-1)",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int64",
-              "minimum": 0
+              "type": "string",
+              "pattern": "^[0-9]+$"
             }
           }
         ],
@@ -875,12 +874,11 @@
           {
             "name": "node_id",
             "in": "path",
-            "description": "Node ID",
+            "description": "Node ID (u64 as a string; precision-safe above 2^53-1)",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int64",
-              "minimum": 0
+              "type": "string",
+              "pattern": "^[0-9]+$"
             }
           }
         ],
@@ -938,12 +936,11 @@
           {
             "name": "node_id",
             "in": "path",
-            "description": "Node ID",
+            "description": "Node ID (u64 as a string; precision-safe above 2^53-1)",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int64",
-              "minimum": 0
+              "type": "string",
+              "pattern": "^[0-9]+$"
             }
           },
           {
@@ -1014,12 +1011,11 @@
           {
             "name": "node_id",
             "in": "path",
-            "description": "Node ID",
+            "description": "Node ID (u64 as a string; precision-safe above 2^53-1)",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int64",
-              "minimum": 0
+              "type": "string",
+              "pattern": "^[0-9]+$"
             }
           }
         ],
@@ -1075,12 +1071,11 @@
           {
             "name": "node_id",
             "in": "path",
-            "description": "Node ID",
+            "description": "Node ID (u64 as a string; precision-safe above 2^53-1)",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int64",
-              "minimum": 0
+              "type": "string",
+              "pattern": "^[0-9]+$"
             }
           }
         ],
@@ -1348,11 +1343,10 @@
             "description": "Source node ID to start traversal from.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int64",
-              "minimum": 0
+              "type": "string",
+              "pattern": "^[0-9]+$"
             },
-            "example": 123
+            "example": "123"
           },
           {
             "name": "algorithm",
@@ -2084,12 +2078,11 @@
           {
             "name": "id",
             "in": "path",
-            "description": "Point ID",
+            "description": "Point ID (u64 as a string; precision-safe above 2^53-1)",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int64",
-              "minimum": 0
+              "type": "string",
+              "pattern": "^[0-9]+$"
             }
           }
         ],
@@ -2135,12 +2128,11 @@
           {
             "name": "id",
             "in": "path",
-            "description": "Point ID",
+            "description": "Point ID (u64 as a string; precision-safe above 2^53-1)",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int64",
-              "minimum": 0
+              "type": "string",
+              "pattern": "^[0-9]+$"
             }
           }
         ],
@@ -2188,12 +2180,11 @@
           {
             "name": "id",
             "in": "path",
-            "description": "Point ID",
+            "description": "Point ID (u64 as a string; precision-safe above 2^53-1)",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int64",
-              "minimum": 0
+              "type": "string",
+              "pattern": "^[0-9]+$"
             }
           }
         ],
@@ -2252,12 +2243,11 @@
           {
             "name": "id",
             "in": "path",
-            "description": "Point ID",
+            "description": "Point ID (u64 as a string; precision-safe above 2^53-1)",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int64",
-              "minimum": 0
+              "type": "string",
+              "pattern": "^[0-9]+$"
             }
           }
         ],
@@ -2401,12 +2391,11 @@
           {
             "name": "edge_id",
             "in": "path",
-            "description": "Edge ID to remove",
+            "description": "Edge ID to remove (u64 as a string; precision-safe above 2^53-1)",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int64",
-              "minimum": 0
+              "type": "string",
+              "pattern": "^[0-9]+$"
             }
           }
         ],
@@ -3451,10 +3440,12 @@
             "oneOf": [
               {
                 "type": "integer",
-                "format": "int64"
+                "format": "int64",
+                "minimum": 0
               },
               {
-                "type": "string"
+                "type": "string",
+                "pattern": "^[0-9]+$"
               }
             ],
             "description": "Point ID. Accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss."
@@ -3470,10 +3461,12 @@
             "oneOf": [
               {
                 "type": "integer",
-                "format": "int64"
+                "format": "int64",
+                "minimum": 0
               },
               {
-                "type": "string"
+                "type": "string",
+                "pattern": "^[0-9]+$"
               }
             ],
             "description": "Point ID. Accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss."
@@ -3482,10 +3475,12 @@
             "oneOf": [
               {
                 "type": "integer",
-                "format": "int64"
+                "format": "int64",
+                "minimum": 0
               },
               {
-                "type": "string"
+                "type": "string",
+                "pattern": "^[0-9]+$"
               }
             ],
             "description": "Point ID. Accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss."
@@ -3593,11 +3588,19 @@
           "ids": {
             "type": "array",
             "items": {
-              "type": "integer",
-              "format": "int64",
-              "minimum": 0
+              "oneOf": [
+                {
+                  "type": "integer",
+                  "format": "int64",
+                  "minimum": 0
+                },
+                {
+                  "type": "string",
+                  "pattern": "^[0-9]+$"
+                }
+              ]
             },
-            "description": "List of point IDs to delete."
+            "description": "Point IDs. Each accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss."
           }
         }
       },
@@ -4912,10 +4915,12 @@
               "oneOf": [
                 {
                   "type": "integer",
-                  "format": "int64"
+                  "format": "int64",
+                  "minimum": 0
                 },
                 {
-                  "type": "string"
+                  "type": "string",
+                  "pattern": "^[0-9]+$"
                 }
               ]
             }
@@ -5042,13 +5047,16 @@
               "oneOf": [
                 {
                   "type": "integer",
-                  "format": "int64"
+                  "format": "int64",
+                  "minimum": 0
                 },
                 {
-                  "type": "string"
+                  "type": "string",
+                  "pattern": "^[0-9]+$"
                 }
               ]
-            }
+            },
+            "description": "Point IDs. Each accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss."
           }
         }
       },
@@ -5144,13 +5152,16 @@
               "oneOf": [
                 {
                   "type": "integer",
-                  "format": "int64"
+                  "format": "int64",
+                  "minimum": 0
                 },
                 {
-                  "type": "string"
+                  "type": "string",
+                  "pattern": "^[0-9]+$"
                 }
               ]
-            }
+            },
+            "description": "Point IDs. Each accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss."
           }
         }
       },
@@ -5166,10 +5177,12 @@
             "oneOf": [
               {
                 "type": "integer",
-                "format": "int64"
+                "format": "int64",
+                "minimum": 0
               },
               {
-                "type": "string"
+                "type": "string",
+                "pattern": "^[0-9]+$"
               }
             ],
             "description": "Point ID. Accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss."
@@ -5358,10 +5371,12 @@
             "oneOf": [
               {
                 "type": "integer",
-                "format": "int64"
+                "format": "int64",
+                "minimum": 0
               },
               {
-                "type": "string"
+                "type": "string",
+                "pattern": "^[0-9]+$"
               }
             ],
             "description": "Point ID. Accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss."
@@ -5370,10 +5385,12 @@
             "oneOf": [
               {
                 "type": "integer",
-                "format": "int64"
+                "format": "int64",
+                "minimum": 0
               },
               {
-                "type": "string"
+                "type": "string",
+                "pattern": "^[0-9]+$"
               }
             ],
             "description": "Point ID. Accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss."
@@ -5483,13 +5500,21 @@
             "minimum": 0
           },
           "cursor": {
-            "type": [
-              "integer",
-              "null"
+            "oneOf": [
+              {
+                "type": "integer",
+                "format": "int64",
+                "minimum": 0
+              },
+              {
+                "type": "string",
+                "pattern": "^[0-9]+$"
+              },
+              {
+                "type": "null"
+              }
             ],
-            "format": "int64",
-            "description": "Resume after this point ID (exclusive). Omit to start from beginning.",
-            "minimum": 0
+            "description": "Resume after this point ID (exclusive). Omit or send null to start from the beginning. Accepts a JSON integer or a precision-safe string."
           },
           "filter": {
             "description": "Optional filter expression."
@@ -5505,12 +5530,10 @@
         "properties": {
           "next_cursor": {
             "type": [
-              "integer",
+              "string",
               "null"
             ],
-            "format": "int64",
-            "description": "Cursor for the next batch. Null when iteration is complete.",
-            "minimum": 0
+            "description": "Cursor for the next batch. Null when iteration is complete."
           },
           "points": {
             "type": "array",
@@ -5772,10 +5795,12 @@
             "oneOf": [
               {
                 "type": "integer",
-                "format": "int64"
+                "format": "int64",
+                "minimum": 0
               },
               {
-                "type": "string"
+                "type": "string",
+                "pattern": "^[0-9]+$"
               }
             ],
             "description": "Point ID. Accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss."
@@ -5818,13 +5843,16 @@
               "oneOf": [
                 {
                   "type": "integer",
-                  "format": "int64"
+                  "format": "int64",
+                  "minimum": 0
                 },
                 {
-                  "type": "string"
+                  "type": "string",
+                  "pattern": "^[0-9]+$"
                 }
               ]
-            }
+            },
+            "description": "Point IDs. Each accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss."
           }
         }
       },
@@ -5901,13 +5929,16 @@
               "oneOf": [
                 {
                   "type": "integer",
-                  "format": "int64"
+                  "format": "int64",
+                  "minimum": 0
                 },
                 {
-                  "type": "string"
+                  "type": "string",
+                  "pattern": "^[0-9]+$"
                 }
               ]
-            }
+            },
+            "description": "Point IDs. Each accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss."
           },
           "target_id": {
             "type": "string",
@@ -5965,10 +5996,12 @@
             "oneOf": [
               {
                 "type": "integer",
-                "format": "int64"
+                "format": "int64",
+                "minimum": 0
               },
               {
-                "type": "string"
+                "type": "string",
+                "pattern": "^[0-9]+$"
               }
             ],
             "description": "Point ID. Accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss."

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -11,7 +11,7 @@
       "name": "VelesDB Core License 1.0",
       "url": "https://github.com/cyberlife-coder/VelesDB/blob/main/LICENSE"
     },
-    "version": "3.6.0"
+    "version": "3.7.0"
   },
   "servers": [
     {

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -487,12 +487,11 @@ paths:
           type: string
       - name: edge_id
         in: path
-        description: Edge ID to remove
+        description: Edge ID to remove (u64 as a string; precision-safe above 2^53-1)
         required: true
         schema:
-          type: integer
-          format: int64
-          minimum: 0
+          type: string
+          pattern: ^[0-9]+$
       responses:
         '204':
           description: Edge removed successfully
@@ -549,12 +548,11 @@ paths:
           type: string
       - name: node_id
         in: path
-        description: Node ID
+        description: Node ID (u64 as a string; precision-safe above 2^53-1)
         required: true
         schema:
-          type: integer
-          format: int64
-          minimum: 0
+          type: string
+          pattern: ^[0-9]+$
       responses:
         '200':
           description: Degree retrieved successfully
@@ -589,12 +587,11 @@ paths:
           type: string
       - name: node_id
         in: path
-        description: Node ID
+        description: Node ID (u64 as a string; precision-safe above 2^53-1)
         required: true
         schema:
-          type: integer
-          format: int64
-          minimum: 0
+          type: string
+          pattern: ^[0-9]+$
       - name: direction
         in: query
         description: 'Filter by direction: "in", "out", or "both".'
@@ -639,12 +636,11 @@ paths:
           type: string
       - name: node_id
         in: path
-        description: Node ID
+        description: Node ID (u64 as a string; precision-safe above 2^53-1)
         required: true
         schema:
-          type: integer
-          format: int64
-          minimum: 0
+          type: string
+          pattern: ^[0-9]+$
       responses:
         '200':
           description: Payload retrieved
@@ -678,12 +674,11 @@ paths:
           type: string
       - name: node_id
         in: path
-        description: Node ID
+        description: Node ID (u64 as a string; precision-safe above 2^53-1)
         required: true
         schema:
-          type: integer
-          format: int64
-          minimum: 0
+          type: string
+          pattern: ^[0-9]+$
       requestBody:
         content:
           application/json:
@@ -852,10 +847,9 @@ paths:
         description: Source node ID to start traversal from.
         required: true
         schema:
-          type: integer
-          format: int64
-          minimum: 0
-        example: 123
+          type: string
+          pattern: ^[0-9]+$
+        example: '123'
       - name: algorithm
         in: query
         description: 'Traversal algorithm: "bfs" or "dfs".'
@@ -1379,12 +1373,11 @@ paths:
           type: string
       - name: id
         in: path
-        description: Point ID
+        description: Point ID (u64 as a string; precision-safe above 2^53-1)
         required: true
         schema:
-          type: integer
-          format: int64
-          minimum: 0
+          type: string
+          pattern: ^[0-9]+$
       responses:
         '200':
           description: Point found
@@ -1412,12 +1405,11 @@ paths:
           type: string
       - name: id
         in: path
-        description: Point ID
+        description: Point ID (u64 as a string; precision-safe above 2^53-1)
         required: true
         schema:
-          type: integer
-          format: int64
-          minimum: 0
+          type: string
+          pattern: ^[0-9]+$
       responses:
         '200':
           description: Point deleted
@@ -1446,12 +1438,11 @@ paths:
           type: string
       - name: id
         in: path
-        description: Point ID
+        description: Point ID (u64 as a string; precision-safe above 2^53-1)
         required: true
         schema:
-          type: integer
-          format: int64
-          minimum: 0
+          type: string
+          pattern: ^[0-9]+$
       responses:
         '200':
           description: Outgoing relations
@@ -1491,12 +1482,11 @@ paths:
           type: string
       - name: id
         in: path
-        description: Point ID
+        description: Point ID (u64 as a string; precision-safe above 2^53-1)
         required: true
         schema:
-          type: integer
-          format: int64
-          minimum: 0
+          type: string
+          pattern: ^[0-9]+$
       requestBody:
         content:
           application/json:
@@ -1586,12 +1576,11 @@ paths:
           type: string
       - name: edge_id
         in: path
-        description: Edge ID to remove
+        description: Edge ID to remove (u64 as a string; precision-safe above 2^53-1)
         required: true
         schema:
-          type: integer
-          format: int64
-          minimum: 0
+          type: string
+          pattern: ^[0-9]+$
       responses:
         '204':
           description: Relation removed
@@ -2301,7 +2290,9 @@ components:
           oneOf:
           - type: integer
             format: int64
+            minimum: 0
           - type: string
+            pattern: ^[0-9]+$
           description: Point ID. Accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss.
         label:
           type: string
@@ -2312,13 +2303,17 @@ components:
           oneOf:
           - type: integer
             format: int64
+            minimum: 0
           - type: string
+            pattern: ^[0-9]+$
           description: Point ID. Accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss.
         target:
           oneOf:
           - type: integer
             format: int64
+            minimum: 0
           - type: string
+            pattern: ^[0-9]+$
           description: Point ID. Accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss.
     AddEdgesBatchRequest:
       type: object
@@ -2397,10 +2392,13 @@ components:
         ids:
           type: array
           items:
-            type: integer
-            format: int64
-            minimum: 0
-          description: List of point IDs to delete.
+            oneOf:
+            - type: integer
+              format: int64
+              minimum: 0
+            - type: string
+              pattern: ^[0-9]+$
+          description: Point IDs. Each accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss.
     CollectionConfigResponse:
       type: object
       description: Response with detailed collection configuration.
@@ -3455,7 +3453,9 @@ components:
             oneOf:
             - type: integer
               format: int64
+              minimum: 0
             - type: string
+              pattern: ^[0-9]+$
         depth:
           type: integer
           format: int32
@@ -3552,7 +3552,10 @@ components:
             oneOf:
             - type: integer
               format: int64
+              minimum: 0
             - type: string
+              pattern: ^[0-9]+$
+          description: Point IDs. Each accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss.
     NodePayloadResponse:
       type: object
       description: Response for a node payload retrieval.
@@ -3640,7 +3643,10 @@ components:
             oneOf:
             - type: integer
               format: int64
+              minimum: 0
             - type: string
+              pattern: ^[0-9]+$
+          description: Point IDs. Each accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss.
     PointRequest:
       type: object
       description: A point in an upsert request.
@@ -3652,7 +3658,9 @@ components:
           oneOf:
           - type: integer
             format: int64
+            minimum: 0
           - type: string
+            pattern: ^[0-9]+$
           description: Point ID. Accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss.
         payload:
           description: Optional payload.
@@ -3807,13 +3815,17 @@ components:
           oneOf:
           - type: integer
             format: int64
+            minimum: 0
           - type: string
+            pattern: ^[0-9]+$
           description: Point ID. Accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss.
         target:
           oneOf:
           - type: integer
             format: int64
+            minimum: 0
           - type: string
+            pattern: ^[0-9]+$
           description: Point ID. Accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss.
     RelateResponse:
       type: object
@@ -3892,12 +3904,14 @@ components:
           description: Maximum points per batch (1–10 000, default 100).
           minimum: 0
         cursor:
-          type:
-          - integer
-          - 'null'
-          format: int64
-          description: Resume after this point ID (exclusive). Omit to start from beginning.
-          minimum: 0
+          oneOf:
+          - type: integer
+            format: int64
+            minimum: 0
+          - type: string
+            pattern: ^[0-9]+$
+          - type: 'null'
+          description: Resume after this point ID (exclusive). Omit or send null to start from the beginning. Accepts a JSON integer or a precision-safe string.
         filter:
           description: Optional filter expression.
     ScrollResponse:
@@ -3908,11 +3922,9 @@ components:
       properties:
         next_cursor:
           type:
-          - integer
+          - string
           - 'null'
-          format: int64
           description: Cursor for the next batch. Null when iteration is complete.
-          minimum: 0
         points:
           type: array
           items:
@@ -4102,7 +4114,9 @@ components:
           oneOf:
           - type: integer
             format: int64
+            minimum: 0
           - type: string
+            pattern: ^[0-9]+$
           description: Point ID. Accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss.
         payload:
           description: Optional JSON payload (metadata).
@@ -4134,7 +4148,10 @@ components:
             oneOf:
             - type: integer
               format: int64
+              minimum: 0
             - type: string
+              pattern: ^[0-9]+$
+          description: Point IDs. Each accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss.
     StreamStatsEvent:
       type: object
       description: 'SSE event: Periodic statistics update.'
@@ -4193,7 +4210,10 @@ components:
             oneOf:
             - type: integer
               format: int64
+              minimum: 0
             - type: string
+              pattern: ^[0-9]+$
+          description: Point IDs. Each accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss.
         target_id:
           type: string
           description: Target node ID reached.
@@ -4237,7 +4257,9 @@ components:
           oneOf:
           - type: integer
             format: int64
+            minimum: 0
           - type: string
+            pattern: ^[0-9]+$
           description: Point ID. Accepts a JSON integer (native form) or a string; use a string for u64 values above 2^53-1 to avoid JavaScript precision loss.
         strategy:
           type: string

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -8,7 +8,7 @@ info:
   license:
     name: VelesDB Core License 1.0
     url: https://github.com/cyberlife-coder/VelesDB/blob/main/LICENSE
-  version: 3.6.0
+  version: 3.7.0
 servers:
 - url: /
   description: Local server

--- a/docs/reference/ARCHITECTURE_DIAGRAMS.md
+++ b/docs/reference/ARCHITECTURE_DIAGRAMS.md
@@ -1,4 +1,4 @@
-# VelesDB Architecture Diagrams — v3.6.0
+# VelesDB Architecture Diagrams — v3.7.0
 
 ## 1. Workspace Dependency Graph
 

--- a/docs/reference/ECOSYSTEM_PARITY.md
+++ b/docs/reference/ECOSYSTEM_PARITY.md
@@ -1,6 +1,6 @@
 # VelesQL Ecosystem Parity Matrix
 
-Last updated: 2026-07-03 (v3.6.0; velesdb-memory 0.4.0)
+Last updated: 2026-07-06 (v3.7.0; velesdb-memory 0.4.0)
 
 This matrix tracks runtime contract and feature parity across the VelesDB ecosystem.
 

--- a/docs/reference/VELESQL_CHEATSHEET.md
+++ b/docs/reference/VELESQL_CHEATSHEET.md
@@ -1,7 +1,7 @@
 # VelesQL Cheat Sheet
 
 > **Date:** 2026-06-03
-> **VelesDB version:** 3.6.0
+> **VelesDB version:** 3.7.0
 > See the full specification in [`docs/VELESQL_SPEC.md`](../VELESQL_SPEC.md).
 
 > Every `sql` block below is **parsed** against the real grammar by an automated

--- a/docs/reference/VELESQL_CONFORMANCE_MATRIX.md
+++ b/docs/reference/VELESQL_CONFORMANCE_MATRIX.md
@@ -4,7 +4,7 @@ This document lists every VelesQL feature with its parser and executor status.
 A feature can be **Parsed** (the grammar + AST accept it) without being
 **Executed** (the query engine acts on it at runtime).
 
-> Last updated: 2026-07-03 (VelesDB v3.6.0)
+> Last updated: 2026-07-06 (VelesDB v3.7.0)
 
 ## Fully Supported (Parsed AND Executed)
 

--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -442,7 +442,7 @@ Cursor-based pagination over all points of a collection (ascending ID order).
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | batch_size | integer | No | Points per batch (1–10 000, default: 100) |
-| cursor | integer/null | No | Resume **after** this point ID (exclusive); omit to start from the beginning |
+| cursor | string \| integer \| null | No | Resume **after** this point ID (exclusive); echo back the `next_cursor` string. Omit or send `null` to start from the beginning. The integer form is also accepted |
 | filter | object | No | Optional canonical filter expression |
 
 **Response:**
@@ -451,12 +451,13 @@ Cursor-based pagination over all points of a collection (ascending ID order).
   "points": [
     {"id": "1", "vector": [0.1, 0.2, ...], "payload": {"title": "Doc 1"}}
   ],
-  "next_cursor": 1
+  "next_cursor": "1"
 }
 ```
 
-`next_cursor` is `null` once iteration is complete. Point IDs are serialized as
-strings (see the Point ID encoding note in [Search](#search)).
+`next_cursor` is `null` once iteration is complete. Point IDs (including the
+cursor) are serialized as strings (see the Point ID encoding note in
+[Search](#search)).
 
 ### POST /collections/:name/points/stream
 

--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -57,7 +57,7 @@ Check server health status.
 ```json
 {
   "status": "ok",
-  "version": "3.6.0"
+  "version": "3.7.0"
 }
 ```
 

--- a/examples/wasm-browser-demo/README.md
+++ b/examples/wasm-browser-demo/README.md
@@ -22,7 +22,7 @@ cd crates/velesdb-wasm
 wasm-pack build --target web --out-dir ../../examples/wasm-browser-demo/pkg
 
 # Then update index.html to use the local path instead of CDN:
-# Change: import init from 'https://unpkg.com/@wiscale/velesdb-wasm@3.6.0/velesdb_wasm.js'
+# Change: import init from 'https://unpkg.com/@wiscale/velesdb-wasm@3.7.0/velesdb_wasm.js'
 # To:     import init from './pkg/velesdb_wasm.js'
 ```
 
@@ -80,7 +80,7 @@ Typical results on modern hardware:
 ```html
 <script type="module">
   // If published on npm:
-  // import init, { VectorStore } from 'https://unpkg.com/@wiscale/velesdb-wasm@3.6.0/velesdb_wasm.js';
+  // import init, { VectorStore } from 'https://unpkg.com/@wiscale/velesdb-wasm@3.7.0/velesdb_wasm.js';
   // If built locally with wasm-pack:
   import init, { VectorStore } from './pkg/velesdb_wasm.js';
 

--- a/examples/wasm-browser-demo/index.html
+++ b/examples/wasm-browser-demo/index.html
@@ -171,8 +171,8 @@
         // WASM module - tracks @wiscale/velesdb-wasm@<workspace> with CDN fallback.
         // Bumped by scripts/bump-version.ps1 on every release; if you copy this
         // demo, update the version below to match `@wiscale/velesdb-wasm` on npm.
-        const WASM_CDN_PRIMARY = 'https://unpkg.com/@wiscale/velesdb-wasm@3.6.0/velesdb_wasm.js';
-        const WASM_CDN_FALLBACK = 'https://cdn.jsdelivr.net/npm/@wiscale/velesdb-wasm@3.6.0/velesdb_wasm.js';
+        const WASM_CDN_PRIMARY = 'https://unpkg.com/@wiscale/velesdb-wasm@3.7.0/velesdb_wasm.js';
+        const WASM_CDN_FALLBACK = 'https://cdn.jsdelivr.net/npm/@wiscale/velesdb-wasm@3.7.0/velesdb_wasm.js';
         
         let init, VectorStore;
         

--- a/integrations/common/pyproject.toml
+++ b/integrations/common/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "velesdb-common"
-version = "3.6.0"
+version = "3.7.0"
 description = "Shared utilities for VelesDB Python integrations (internal use)"
 readme = "README.md"
 license = {text = "MIT"}

--- a/integrations/haystack/pyproject.toml
+++ b/integrations/haystack/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "haystack-velesdb"
-version = "3.6.0"
+version = "3.7.0"
 description = "Haystack 2.x DocumentStore for VelesDB: The Local AI Memory Database."
 readme = "README.md"
 license = {text = "MIT"}

--- a/integrations/haystack/src/haystack_velesdb/__init__.py
+++ b/integrations/haystack/src/haystack_velesdb/__init__.py
@@ -3,4 +3,4 @@
 from haystack_velesdb.document_store import VelesDBDocumentStore
 
 __all__ = ["VelesDBDocumentStore"]
-__version__ = "3.6.0"
+__version__ = "3.7.0"

--- a/integrations/langchain/pyproject.toml
+++ b/integrations/langchain/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "langchain-velesdb"
-version = "3.6.0"
+version = "3.7.0"
 description = "LangChain VectorStore for VelesDB: The Local AI Memory Database. Microsecond RAG retrieval."
 readme = "README.md"
 license = {text = "MIT"}

--- a/integrations/langchain/src/langchain_velesdb/__init__.py
+++ b/integrations/langchain/src/langchain_velesdb/__init__.py
@@ -53,4 +53,4 @@ if _HAS_MEMORY:
         "VelesDBSemanticMemory",
         "VelesDBProceduralMemory",
     ])
-__version__ = "3.6.0"
+__version__ = "3.7.0"

--- a/integrations/langgraph/pyproject.toml
+++ b/integrations/langgraph/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "langgraph-velesdb"
-version = "3.6.0"
+version = "3.7.0"
 description = "LangGraph memory tools for VelesDB: drop the why() knowledge-graph memory wedge into any LangGraph agent."
 readme = "README.md"
 license = {text = "MIT"}

--- a/integrations/langgraph/src/langgraph_velesdb/__init__.py
+++ b/integrations/langgraph/src/langgraph_velesdb/__init__.py
@@ -16,4 +16,4 @@ across agent runs.
 from langgraph_velesdb.tools import make_memory_tools
 
 __all__ = ["make_memory_tools"]
-__version__ = "3.6.0"
+__version__ = "3.7.0"

--- a/integrations/llamaindex/pyproject.toml
+++ b/integrations/llamaindex/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "llama-index-vector-stores-velesdb"
-version = "3.6.0"
+version = "3.7.0"
 description = "LlamaIndex VectorStore for VelesDB: The Local AI Memory Database. Microsecond RAG retrieval."
 readme = "README.md"
 license = "MIT"

--- a/integrations/llamaindex/src/llamaindex_velesdb/__init__.py
+++ b/integrations/llamaindex/src/llamaindex_velesdb/__init__.py
@@ -57,4 +57,4 @@ if _HAS_MEMORY:
         "VelesDBChatMemory",
         "VelesDBProceduralMemory",
     ])
-__version__ = "3.6.0"
+__version__ = "3.7.0"

--- a/scripts/dx-timing/scenario_rust.sh
+++ b/scripts/dx-timing/scenario_rust.sh
@@ -41,7 +41,7 @@ RS
 # Pin to the latest released version on crates.io. Bump alongside each
 # workspace release; the timing measurement is meant to track the path a
 # fresh dev hits when they `cargo add velesdb-core` today.
-cargo add --quiet velesdb-core@3.6.0
+cargo add --quiet velesdb-core@3.7.0
 cargo add --quiet serde_json@1
 cargo run --quiet --release
 

--- a/scripts/dx-timing/scenario_server.sh
+++ b/scripts/dx-timing/scenario_server.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 
 START=$(date +%s.%N)
 
-cargo install --quiet --locked velesdb-server@3.6.0
+cargo install --quiet --locked velesdb-server@3.7.0
 
 DATA_DIR=$(mktemp -d -t velesdb_dx_server_XXXX)
 trap 'rm -rf "$DATA_DIR"' EXIT

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -2,7 +2,7 @@
 
 Official TypeScript SDK for [VelesDB](https://github.com/cyberlife-coder/VelesDB) -- the local-first vector database for AI and RAG. Sub-millisecond semantic search in Browser and Node.js.
 
-**v3.6.0** | Node.js >= 18 | Browser (WASM) | VelesDB Core License 1.0
+**v3.7.0** | Node.js >= 18 | Browser (WASM) | VelesDB Core License 1.0
 
 ## What's New in v3.6.0
 

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wiscale/velesdb-sdk",
-  "version": "3.6.0",
+  "version": "3.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wiscale/velesdb-sdk",
-      "version": "3.6.0",
+      "version": "3.7.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@wiscale/velesdb-wasm": "^3.0.0"

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wiscale/velesdb-sdk",
-  "version": "3.6.0",
+  "version": "3.7.0",
   "description": "VelesDB TypeScript SDK: The Local Vector Database for AI & RAG. Microsecond semantic search in Browser & Node.js.",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/sdks/typescript/src/index.ts
+++ b/sdks/typescript/src/index.ts
@@ -32,6 +32,7 @@ export type {
   MemoryRecollection,
   MemoryColumnFilter,
   MemoryFusionOptions,
+  MemoryDatedRecall,
   MemoryNode,
   MemoryEdge,
   MemoryExplanation,

--- a/sdks/typescript/src/memory.ts
+++ b/sdks/typescript/src/memory.ts
@@ -63,6 +63,19 @@ export interface MemoryFusionOptions {
   pool?: number;
 }
 
+/** Result of {@link MemoryService.recallFusedDated}: the recalled memories plus a dated timeline. */
+export interface MemoryDatedRecall {
+  /** Recalled memories, most relevant first. */
+  memories: MemoryRecollection[];
+  /**
+   * Chronological, date-prefixed rendering of {@link memories}
+   * (`- [YYYY-MM-DD] content` per line, oldest first, undated facts last).
+   */
+  datedContext: string;
+  /** The most recent date across {@link memories} (`YYYY-MM-DD`), or `null` when none is dated. */
+  now: string | null;
+}
+
 /** A node in a {@link MemoryService.why} explanation subgraph. */
 export interface MemoryNode {
   /** Decimal-string id of the memory. */
@@ -103,6 +116,13 @@ interface WasmMemoryServiceInstance {
   recall(query: string, k: number | null | undefined, filter: unknown): unknown;
   recallWhere(query: string, filters: unknown, k?: number | null): unknown;
   recallFused(query: string, k: number | null | undefined, filter: unknown, opts: unknown): unknown;
+  recallFusedDated(
+    query: string,
+    dateField: string,
+    k: number | null | undefined,
+    filter: unknown,
+    opts: unknown
+  ): unknown;
   relate(from: string, to: string, relation: string): string;
   forget(id: string): void;
   why(decision: string, maxHops: number | null | undefined, filter: unknown): unknown;
@@ -317,6 +337,31 @@ export class MemoryService {
   ): Promise<MemoryRecollection[]> {
     return wrapWasmCall(
       () => this.ensureInitialized().recallFused(query, k, filter, opts) as MemoryRecollection[]
+    );
+  }
+
+  /**
+   * Fused recall plus a dated timeline: like {@link recallFused}, but reads each
+   * fact's date from the `dateField` metadata key (a `YYYYMMDD` integer) and
+   * resolves to `{ memories, datedContext, now }` — the memories, a chronological
+   * date-prefixed timeline, and a "now" anchor for temporal reasoning.
+   */
+  recallFusedDated(
+    query: string,
+    dateField: string,
+    k?: number,
+    filter?: Record<string, unknown>,
+    opts?: MemoryFusionOptions
+  ): Promise<MemoryDatedRecall> {
+    return wrapWasmCall(
+      () =>
+        this.ensureInitialized().recallFusedDated(
+          query,
+          dateField,
+          k,
+          filter,
+          opts
+        ) as MemoryDatedRecall
     );
   }
 

--- a/sdks/typescript/tests/memory.test.ts
+++ b/sdks/typescript/tests/memory.test.ts
@@ -24,6 +24,11 @@ class MockWasmMemoryService {
   recall = vi.fn(() => [{ id: '1', score: 0.9, content: 'we chose parking_lot' }]);
   recallWhere = vi.fn(() => [{ id: '1', score: 0.9, content: 'we chose parking_lot' }]);
   recallFused = vi.fn(() => [{ id: '2', score: 0.0, content: 'EPIC-317' }]);
+  recallFusedDated = vi.fn(() => ({
+    memories: [{ id: '1', score: 0.9, content: 'we chose parking_lot' }],
+    datedContext: '- [2026-01-03] we chose parking_lot',
+    now: '2026-01-03',
+  }));
   relate = vi.fn(() => '5');
   forget = vi.fn();
   why = vi.fn(() => ({
@@ -177,6 +182,20 @@ describe('MemoryService', () => {
       expect(lastMockInstance!.recallFused).toHaveBeenCalledWith('parking_lot', 3, undefined, {
         hops: 2,
       });
+    });
+
+    it('recallFusedDated() returns the memories plus a dated timeline', async () => {
+      const res = await memory.recallFusedDated('parking_lot', 'ts', 3, undefined, { hops: 2 });
+      expect(res.now).toBe('2026-01-03');
+      expect(res.datedContext).toContain('- [2026-01-03] we chose parking_lot');
+      expect(res.memories).toHaveLength(1);
+      expect(lastMockInstance!.recallFusedDated).toHaveBeenCalledWith(
+        'parking_lot',
+        'ts',
+        3,
+        undefined,
+        { hops: 2 }
+      );
     });
 
     it('relate() returns the edge id', async () => {


### PR DESCRIPTION
Release train for **VelesDB 3.7.0** (workspace) and **velesdb-memory / @wiscale/velesdb-memory-node 0.5.0**.

## Headline changes since 3.6.0
- **`recall_fused` on MCP + Python** — fused vector+graph recall, previously Node/WASM-only, now on MCP clients and the Python `MemoryService`. (#1314)
- **Dated-context recall on every surface** — `recall_fused` `date_field` (MCP, Python) + `recallFusedDated` (Node, WASM, TS SDK), on the new `velesdb-memory::format_dated_context` primitive. (#1315, #1316)
- **u64 IDs precision-safe across the REST OpenAPI spec** — path/query params, scroll cursor, bulk-delete ids; no wire change. (#1321)

## Mechanics
- Workspace 3.6.0→3.7.0 via `scripts/bump_version.py` (62 policed locations); memory + node 0.4.0→0.5.0 (independent cadence).
- OpenAPI snapshots regenerated from code; `check-version-sync.py` passes.
- CHANGELOG updated (root + `crates/velesdb-memory`).

## After merge
Tags `v3.7.0` (→ crates.io + PyPI + binaries) and `velesdb-memory-v0.5.0` (→ crates.io + npm) will be pushed on the merge commit; both release workflows verify tag==Cargo.toml version and that CI passed on the tagged commit.