### PR TITLE
docs: refresh version callouts for 3.7.0 / memory 0.5.0

### DIFF
--- a/crates/velesdb-memory/README.md
+++ b/crates/velesdb-memory/README.md
@@ -12,13 +12,13 @@ agent durable memory that never leaves your machine: it remembers decisions,
 recalls them semantically, and — the differentiator — **connects** them so it
 can answer *why* a decision was made, not just retrieve look-alike text.
 
-> **Release 0.4.0 — 2026-07-03.** `velesdb-memory` **0.4.0** ships on
+> **Release 0.5.0 — 2026-07-06.** `velesdb-memory` **0.5.0** ships on
 > [crates.io](https://crates.io/crates/velesdb-memory) and on the
 > [official MCP registry](https://registry.modelcontextprotocol.io)
 > (`io.github.cyberlife-coder/velesdb-memory`, with **5 prebuilt `.mcpb` bundles**:
 > macOS arm64/x64, Linux arm64/x64, Windows x64). Bindings: Node
-> [`@wiscale/velesdb-memory-node`](https://www.npmjs.com/package/@wiscale/velesdb-memory-node) **0.4.0**
-> and Python in [`velesdb`](https://pypi.org/project/velesdb/) **3.6.0**.
+> [`@wiscale/velesdb-memory-node`](https://www.npmjs.com/package/@wiscale/velesdb-memory-node) **0.5.0**
+> and Python in [`velesdb`](https://pypi.org/project/velesdb/) **3.7.0**.
 > **`cargo install velesdb-memory` installs the latest published release.**
 
 Built on [VelesDB](https://velesdb.com)'s in-core Agent Memory SDK, which fuses

--- a/docs/reference/ECOSYSTEM_PARITY.md
+++ b/docs/reference/ECOSYSTEM_PARITY.md
@@ -1,6 +1,6 @@
 # VelesQL Ecosystem Parity Matrix
 
-Last updated: 2026-07-06 (v3.7.0; velesdb-memory 0.4.0)
+Last updated: 2026-07-06 (v3.7.0; velesdb-memory 0.5.0)
 
 This matrix tracks runtime contract and feature parity across the VelesDB ecosystem.
 

--- a/docs/reference/VELESQL_CONTRACT.md
+++ b/docs/reference/VELESQL_CONTRACT.md
@@ -2,8 +2,8 @@
 
 Canonical contract for VelesQL server endpoints and payloads.
 
-- Contract version: `3.6.0`
-- Last updated: `2026-06-12`
+- Contract version: `3.7.0`
+- Last updated: `2026-07-06`
 
 This document is the normative REST contract baseline for VelesQL.
 When behavior differs between docs and runtime, runtime must be fixed or this


### PR DESCRIPTION
Fast-follow to #1322: refresh the hand-written version callouts that sit **outside** `scripts/bump_version.py`'s policed set and still advertised the previous release. Ship-blocker for a clean tag — a 0.5.0 package README should not say "Release 0.4.0".

- `crates/velesdb-memory/README.md` — "Release 0.4.0" banner, Node binding version, and the `velesdb` (PyPI) cross-reference → **0.5.0 / 3.7.0**.
- `docs/reference/ECOSYSTEM_PARITY.md` — `velesdb-memory 0.4.0` → **0.5.0** (the bumper had refreshed the workspace `v3.7.0` part).
- `docs/reference/VELESQL_CONTRACT.md` — contract version `3.6.0` → **3.7.0** + date, since the u64 ID typing in the REST OpenAPI contract changed in 3.7.0 (#1321).

Docs-only. Merge this before tagging `v3.7.0` / `velesdb-memory-v0.5.0`.