### PR TITLE
fix(ci): exclude __test__/__tests__ dirs from Sonar (fixes Quality Gate)

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -10,7 +10,7 @@ sonar.sourceEncoding=UTF-8
 # e.g. index/hnsw/native/tests.rs); `**/scripts/**` (crate-level dev/release
 # tooling — top-level `scripts/**` was already excluded); `**/e2e/**` (the WASM
 # end-to-end browser harness, not shipped product code).
-sonar.exclusions=**/tests/**,**/*_tests.rs,**/*_test.rs,**/tests.rs,**/benches/**,**/examples/**,.claude/**,conformance/**,scripts/**,**/scripts/**,**/e2e/**,docs/**,demos/**,sdks/**/tests/**,sdks/**/__tests__/**
+sonar.exclusions=**/tests/**,**/*_tests.rs,**/*_test.rs,**/tests.rs,**/benches/**,**/examples/**,.claude/**,conformance/**,scripts/**,**/scripts/**,**/e2e/**,docs/**,demos/**,sdks/**/tests/**,sdks/**/__tests__/**,**/__test__/**,**/__tests__/**
 
 # Rule-specific suppressions (false positives / non-product scope).
 # - S8570/S8565 ("lock file missing") are false positives in a Cargo workspace:


### PR DESCRIPTION
The SonarCloud Quality Gate has been failing on every release — **"75.2% Coverage on New Code (required ≥ 80%)"**. Root cause is a config gap, not missing tests: the Node binding's napi test suite lives in `crates/velesdb-node/__test__/`, a directory matched by **no** existing `sonar.exclusions` pattern. Sonar scanned its 118 JS test lines as production code needing coverage, but the coverage job is Rust-only (`cargo llvm-cov`) and never covers them → counted as uncovered new code.

Fix: exclude `**/__test__/**` and `**/__tests__/**` globally, consistent with how `**/tests/**`, `**/*_tests.rs`, and `sdks/**/__tests__/**` are already treated. Test files are not production code.

Config-only. Targets `main` via `hotfix/*` (Git Flow) to green the gate on main; will sync to develop.