### PR TITLE
chore: sync main into develop (Sonar __test__ exclusion)

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -10,7 +10,7 @@ sonar.sourceEncoding=UTF-8
 # e.g. index/hnsw/native/tests.rs); `**/scripts/**` (crate-level dev/release
 # tooling — top-level `scripts/**` was already excluded); `**/e2e/**` (the WASM
 # end-to-end browser harness, not shipped product code).
-sonar.exclusions=**/tests/**,**/*_tests.rs,**/*_test.rs,**/tests.rs,**/benches/**,**/examples/**,.claude/**,conformance/**,scripts/**,**/scripts/**,**/e2e/**,docs/**,demos/**,sdks/**/tests/**,sdks/**/__tests__/**
+sonar.exclusions=**/tests/**,**/*_tests.rs,**/*_test.rs,**/tests.rs,**/benches/**,**/examples/**,.claude/**,conformance/**,scripts/**,**/scripts/**,**/e2e/**,docs/**,demos/**,sdks/**/tests/**,sdks/**/__tests__/**,**/__test__/**,**/__tests__/**
 
 # Rule-specific suppressions (false positives / non-product scope).
 # - S8570/S8565 ("lock file missing") are false positives in a Cargo workspace:


### PR DESCRIPTION
Back-merge of the Sonar Quality-Gate fix (#1333) from main into develop so develop's analyses also exclude `**/__test__/**` / `**/__tests__/**`. Config-only, no code.