### PR TITLE
feat(server)!: string point IDs from GET/DELETE points

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **BREAKING (REST server):** `GET` and `DELETE /collections/{name}/points/{id}`
+  now return the point `id` as a JSON **string** (e.g. `"42"`) instead of a
+  number, completing the u64 precision-safety migration on the point-object
+  endpoints so they match `search`/`scroll`/`relations` (which already emit
+  string IDs). JS clients parsing these two responses as numbers must read the
+  `id` as a string. The VelesQL `/query` endpoint still emits numeric `id`
+  columns (general query results — a separate, tracked follow-up).
+
+### Fixed
+- CI: exclude `**/__test__/**` and `**/__tests__/**` from Sonar analysis (the
+  Node napi test suite was counted as uncovered production code, failing the
+  coverage Quality Gate).
+
 ## [3.7.0] — 2026-07-06
 
 ### Added

--- a/crates/velesdb-server/src/handlers/points/mod.rs
+++ b/crates/velesdb-server/src/handlers/points/mod.rs
@@ -210,8 +210,10 @@ pub async fn get_point(
     let points = collection.get(&[id]);
 
     match points.into_iter().next().flatten() {
+        // ID as a string for JS precision-safety above 2^53-1, consistent with
+        // every other read surface (search/scroll/relations, see `serde_id`).
         Some(point) => Json(serde_json::json!({
-            "id": point.id,
+            "id": point.id.to_string(),
             "vector": point.vector,
             "payload": point.payload
         }))
@@ -247,9 +249,11 @@ pub async fn delete_point(
     };
 
     match collection.delete(&[id]) {
+        // ID as a string for JS precision-safety (see `serde_id`), consistent
+        // with the string ID accepted in the path and returned by reads.
         Ok(()) => Json(serde_json::json!({
             "message": "Point deleted",
-            "id": id
+            "id": id.to_string()
         }))
         .into_response(),
         Err(e) => auto_core_error_response(&e),

--- a/crates/velesdb-server/tests/api_integration.rs
+++ b/crates/velesdb-server/tests/api_integration.rs
@@ -3632,7 +3632,7 @@ async fn test_get_point_by_id() {
         .unwrap();
     let json: Value = serde_json::from_slice(&body).unwrap();
 
-    assert_eq!(json["id"], 42);
+    assert_eq!(json["id"], "42"); // ID emitted as a string (JS precision-safety)
     assert_eq!(json["vector"], json!([1.0, 0.0, 0.0]));
     assert_eq!(json["payload"]["color"], "red");
 
@@ -3736,7 +3736,7 @@ async fn test_delete_point_by_id() {
         .await
         .unwrap();
     let json: Value = serde_json::from_slice(&body).unwrap();
-    assert_eq!(json["id"], 7);
+    assert_eq!(json["id"], "7"); // ID emitted as a string (JS precision-safety)
 
     // GET after delete returns 404
     let response = app

--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -401,7 +401,7 @@ Get a single point by ID.
 **Response:**
 ```json
 {
-  "id": 1,
+  "id": "1",
   "vector": [0.1, 0.2, 0.3, ...],
   "payload": {"title": "Hello World"}
 }
@@ -415,7 +415,7 @@ Delete a point by ID.
 ```json
 {
   "message": "Point deleted",
-  "id": 1
+  "id": "1"
 }
 ```
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -10,7 +10,7 @@ sonar.sourceEncoding=UTF-8
 # e.g. index/hnsw/native/tests.rs); `**/scripts/**` (crate-level dev/release
 # tooling — top-level `scripts/**` was already excluded); `**/e2e/**` (the WASM
 # end-to-end browser harness, not shipped product code).
-sonar.exclusions=**/tests/**,**/*_tests.rs,**/*_test.rs,**/tests.rs,**/benches/**,**/examples/**,.claude/**,conformance/**,scripts/**,**/scripts/**,**/e2e/**,docs/**,demos/**,sdks/**/tests/**,sdks/**/__tests__/**
+sonar.exclusions=**/tests/**,**/*_tests.rs,**/*_test.rs,**/tests.rs,**/benches/**,**/examples/**,.claude/**,conformance/**,scripts/**,**/scripts/**,**/e2e/**,docs/**,demos/**,sdks/**/tests/**,sdks/**/__tests__/**,**/__test__/**,**/__tests__/**
 
 # Rule-specific suppressions (false positives / non-product scope).
 # - S8570/S8565 ("lock file missing") are false positives in a Cargo workspace:


### PR DESCRIPTION
Completes the u64 precision-safety migration on the **point-object** REST endpoints.

## What
`GET` and `DELETE /collections/{name}/points/{id}` built their JSON response with a raw `serde_json::json!` that emitted `id` as a native **number**, while every other read surface (`search`/`scroll`/`relations`) already emits IDs as **strings** via `serde_id`. So a JS client lost precision for IDs above 2^53-1 on these two endpoints, and the REST surface was internally inconsistent. Both now emit `id.to_string()`.

## ⚠️ BREAKING (REST server)
The `id` field of these two responses changes from `1` (number) to `"1"` (string). Clients parsing them as numbers must read `id` as a string. This aligns them with search/scroll/relations, which already return string IDs.

## Scope / deferred
The VelesQL **`/query`** endpoint still emits numeric `id` columns — those come from the core query engine's generic row serialization (id is just one column in a general query language), a deeper and semantically distinct change. Tracked as a separate follow-up.

## Also
Folds in the Sonar Quality-Gate fix (exclude `**/__test__/**` & `**/__tests__/**` — the Node napi test dir was counted as uncovered production code) so this branch's coverage gate is clean on develop.

## Verification
Tests updated (`test_get_point_by_id` / `test_delete_point_by_id` → string ids) and pass; api-reference examples updated; clippy pedantic clean; adversarial review confirmed no other numeric-id emitter on the point-object endpoints. CHANGELOG `[Unreleased]` carries the BREAKING note. No version bump (release step bumps to 3.8.0 when cut).