### PR TITLE
docs(memory): enrich relate/forget MCP tool descriptions

### DIFF
--- a/crates/velesdb-memory/CHANGELOG.md
+++ b/crates/velesdb-memory/CHANGELOG.md
@@ -7,6 +7,14 @@ released on its own `velesdb-memory-vX.Y.Z` tag.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Richer MCP tool descriptions and parameter docs for `relate` and `forget`
+  (when to use them, directionality, examples, durability) — improves the
+  schema quality MCP clients and directories surface.
+
 ## [0.5.0] - 2026-07-06
 
 ### Added

--- a/crates/velesdb-memory/src/mcp.rs
+++ b/crates/velesdb-memory/src/mcp.rs
@@ -207,7 +207,7 @@ impl McpServer {
 
     #[tool(
         name = "relate",
-        description = "Create a typed link from one memory to another. Returns the edge id."
+        description = "Create a typed, directional link between two memories (`from` → `to`) labeled by `relation`. These links are the graph edges that `why` and `recall_fused` later traverse to surface connected facts that share no words with the query — build the graph with `relate` so multi-hop reasoning works (e.g. link a decision to its cause, a fact to its source, a task to the person it concerns). Idempotent per (from, relation, to). Returns the new edge id."
     )]
     async fn relate(
         &self,
@@ -222,7 +222,10 @@ impl McpServer {
         Ok(Json(RelateResult { edge_id }))
     }
 
-    #[tool(name = "forget", description = "Delete a memory by id.")]
+    #[tool(
+        name = "forget",
+        description = "Permanently delete a memory by its `id` (as returned by `remember` or `recall`), removing the fact and its graph links. The deletion is durable and cannot be undone — use it to retract or correct stored knowledge. For automatic time-based expiry instead, set a TTL when calling `remember`. Returns the deleted id."
+    )]
     async fn forget(
         &self,
         Parameters(params): Parameters<ForgetParams>,

--- a/crates/velesdb-memory/src/mcp/dto.rs
+++ b/crates/velesdb-memory/src/mcp/dto.rs
@@ -124,11 +124,12 @@ pub(super) struct RecallFusedResult {
 #[derive(Deserialize, JsonSchema)]
 #[schemars(transform = crate::schema::strip_int_formats)]
 pub(super) struct RelateParams {
-    /// Source memory id.
+    /// Source memory id — the link points FROM here (as returned by `remember`/`recall`).
     pub(super) from: u64,
-    /// Target memory id.
+    /// Target memory id — the link points TO here (as returned by `remember`/`recall`).
     pub(super) to: u64,
-    /// Relationship label.
+    /// Directional relationship label, read as `from` <relation> `to`.
+    /// Examples: `caused_by`, `depends_on`, `authored_by`, `supersedes`.
     pub(super) relation: String,
 }
 
@@ -144,7 +145,7 @@ pub(super) struct RelateResult {
 #[derive(Deserialize, JsonSchema)]
 #[schemars(transform = crate::schema::strip_int_formats)]
 pub(super) struct ForgetParams {
-    /// Id of the memory to forget.
+    /// Id of the memory to permanently delete (as returned by `remember` or `recall`).
     pub(super) id: u64,
 }
 


### PR DESCRIPTION
`relate` and `forget` were the two thinnest MCP tool definitions ("Create a typed link…", "Delete a memory by id.") next to the rich `why`/`recall_fused` ones — which surfaces as weaker **Tool Definition Quality** in MCP clients and directories that grade schemas (Glama scored both 3.3/5 vs `recall_fused` 4.9).

Enriches both tool descriptions (when to use, link directionality, how the edges power `why`/`recall_fused`, durability + the TTL alternative for `forget`) and their parameter docs (`from`/`to` direction, `relation` examples, `id` source).

Text-only; clippy pedantic clean; 24 mcp tests pass. Improves the schema for every MCP client, not just Glama's re-scan.