### PR TITLE
chore(release): 3.8.0 + velesdb-memory 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **BREAKING (REST server):** `GET` and `DELETE /collections/{name}/points/{id}`
+  now return the point `id` as a JSON **string** (e.g. `"42"`) instead of a
+  number, completing the u64 precision-safety migration on the point-object
+  endpoints so they match `search`/`scroll`/`relations` (which already emit
+  string IDs). JS clients parsing these two responses as numbers must read the
+  `id` as a string. The VelesQL `/query` endpoint still emits numeric `id`
+  columns (general query results — a separate, tracked follow-up).
+
+### Fixed
+- CI: exclude `**/__test__/**` and `**/__tests__/**` from Sonar analysis (the
+  Node napi test suite was counted as uncovered production code, failing the
+  coverage Quality Gate).
+
 ## [3.7.0] — 2026-07-06
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.8.0] — 2026-07-06
+
 ### Changed
 - **BREAKING (REST server):** `GET` and `DELETE /collections/{name}/points/{id}`
   now return the point `id` as a JSON **string** (e.g. `"42"`) instead of a

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5668,7 +5668,7 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-velesdb"
-version = "3.7.0"
+version = "3.8.0"
 dependencies = [
  "dirs",
  "parking_lot",
@@ -6678,7 +6678,7 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "velesdb-cli"
-version = "3.7.0"
+version = "3.8.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -6703,7 +6703,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-core"
-version = "3.7.0"
+version = "3.8.0"
 dependencies = [
  "arc-swap",
  "bytemuck",
@@ -6758,7 +6758,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-memory"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "rmcp",
  "schemars 1.2.1",
@@ -6773,7 +6773,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-migrate"
-version = "3.7.0"
+version = "3.8.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6801,7 +6801,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-mobile"
-version = "3.7.0"
+version = "3.8.0"
 dependencies = [
  "parking_lot",
  "serde_json",
@@ -6815,7 +6815,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-node"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "napi",
  "napi-build",
@@ -6826,7 +6826,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-python"
-version = "3.7.0"
+version = "3.8.0"
 dependencies = [
  "numpy",
  "parking_lot",
@@ -6840,7 +6840,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-server"
-version = "3.7.0"
+version = "3.8.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -6873,7 +6873,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-wasm"
-version = "3.7.0"
+version = "3.8.0"
 dependencies = [
  "getrandom 0.3.4",
  "getrandom 0.4.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "3.7.0"
+version = "3.8.0"
 edition = "2021"
 rust-version = "1.89"
 license-file = "LICENSE"
@@ -79,7 +79,7 @@ base64 = "0.22"
 smallvec = { version = "1", features = ["serde"] }
 
 # Internal workspace crates
-velesdb-core = { path = "crates/velesdb-core", version = "3.7.0", default-features = false }
+velesdb-core = { path = "crates/velesdb-core", version = "3.8.0", default-features = false }
 
 [profile.release]
 lto = true

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM rust:1.96-bookworm AS builder
 
 LABEL maintainer="VelesDB Team <contact@wiscale.fr>"
-LABEL version="3.7.0"
+LABEL version="3.8.0"
 
 WORKDIR /app
 
@@ -25,7 +25,7 @@ RUN cargo build --release --bin velesdb-server
 FROM debian:bookworm-slim
 
 LABEL maintainer="VelesDB Team <contact@wiscale.fr>"
-LABEL version="3.7.0"
+LABEL version="3.8.0"
 
 WORKDIR /app
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,7 +4,7 @@ This roadmap commits to **what we are building**, **why**, and **when**. It is u
 
 It is intentionally narrow. Items not on this roadmap are tracked as `roadmap` issues but **not committed** until they reach a milestone here.
 
-> **Last updated:** 2026-06-21 — covers v3.7.0 (current). The horizon framing below predates the v2.0→v3.x line and is being re-baselined.
+> **Last updated:** 2026-06-21 — covers v3.8.0 (current). The horizon framing below predates the v2.0→v3.x line and is being re-baselined.
 
 ---
 

--- a/benchmarks/Dockerfile.bench
+++ b/benchmarks/Dockerfile.bench
@@ -6,7 +6,7 @@
 FROM debian:bookworm-slim
 
 LABEL maintainer="VelesDB Team <contact@wiscale.fr>"
-LABEL version="3.7.0"
+LABEL version="3.8.0"
 
 WORKDIR /app
 

--- a/benchmarks/Dockerfile.nightly
+++ b/benchmarks/Dockerfile.nightly
@@ -4,7 +4,7 @@
 FROM rust:slim-bookworm AS builder
 
 LABEL maintainer="VelesDB Team <contact@wiscale.fr>"
-LABEL version="3.7.0"
+LABEL version="3.8.0"
 
 WORKDIR /app
 
@@ -29,7 +29,7 @@ RUN cargo build --release --bin velesdb-server
 FROM debian:bookworm-slim
 
 LABEL maintainer="VelesDB Team <contact@wiscale.fr>"
-LABEL version="3.7.0"
+LABEL version="3.8.0"
 
 WORKDIR /app
 

--- a/benchmarks/Dockerfile.optimized
+++ b/benchmarks/Dockerfile.optimized
@@ -7,7 +7,7 @@
 FROM rust:slim-bookworm AS builder
 
 LABEL maintainer="VelesDB Team <contact@wiscale.fr>"
-LABEL version="3.7.0"
+LABEL version="3.8.0"
 
 WORKDIR /app
 
@@ -49,7 +49,7 @@ RUN cargo build --release --bin velesdb-server \
 FROM debian:bookworm-slim
 
 LABEL maintainer="VelesDB Team <contact@wiscale.fr>"
-LABEL version="3.7.0"
+LABEL version="3.8.0"
 
 WORKDIR /app
 

--- a/crates/tauri-plugin-velesdb/guest-js/package.json
+++ b/crates/tauri-plugin-velesdb/guest-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wiscale/tauri-plugin-velesdb",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "TypeScript bindings for the VelesDB Tauri plugin - Vector search in desktop apps",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/crates/velesdb-memory/CHANGELOG.md
+++ b/crates/velesdb-memory/CHANGELOG.md
@@ -7,6 +7,14 @@ released on its own `velesdb-memory-vX.Y.Z` tag.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Richer MCP tool descriptions and parameter docs for `relate` and `forget`
+  (when to use them, directionality, examples, durability) — improves the
+  schema quality MCP clients and directories surface.
+
 ## [0.5.0] - 2026-07-06
 
 ### Added

--- a/crates/velesdb-memory/CHANGELOG.md
+++ b/crates/velesdb-memory/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-07-06
+
 ### Changed
 
 - Richer MCP tool descriptions and parameter docs for `relate` and `forget`

--- a/crates/velesdb-memory/Cargo.toml
+++ b/crates/velesdb-memory/Cargo.toml
@@ -2,7 +2,7 @@
 name = "velesdb-memory"
 # Independent of the workspace version: velesdb-memory is a young MCP wrapper
 # with its own release cadence, decoupled from the core engine's 3.x line.
-version = "0.5.0"
+version = "0.6.0"
 edition.workspace = true
 rust-version.workspace = true
 license-file = "../../LICENSE"

--- a/crates/velesdb-memory/README.md
+++ b/crates/velesdb-memory/README.md
@@ -12,13 +12,13 @@ agent durable memory that never leaves your machine: it remembers decisions,
 recalls them semantically, and — the differentiator — **connects** them so it
 can answer *why* a decision was made, not just retrieve look-alike text.
 
-> **Release 0.5.0 — 2026-07-06.** `velesdb-memory` **0.5.0** ships on
+> **Release 0.6.0 — 2026-07-06.** `velesdb-memory` **0.6.0** ships on
 > [crates.io](https://crates.io/crates/velesdb-memory) and on the
 > [official MCP registry](https://registry.modelcontextprotocol.io)
 > (`io.github.cyberlife-coder/velesdb-memory`, with **5 prebuilt `.mcpb` bundles**:
 > macOS arm64/x64, Linux arm64/x64, Windows x64). Bindings: Node
-> [`@wiscale/velesdb-memory-node`](https://www.npmjs.com/package/@wiscale/velesdb-memory-node) **0.5.0**
-> and Python in [`velesdb`](https://pypi.org/project/velesdb/) **3.7.0**.
+> [`@wiscale/velesdb-memory-node`](https://www.npmjs.com/package/@wiscale/velesdb-memory-node) **0.6.0**
+> and Python in [`velesdb`](https://pypi.org/project/velesdb/) **3.8.0**.
 > **`cargo install velesdb-memory` installs the latest published release.**
 
 Built on [VelesDB](https://velesdb.com)'s in-core Agent Memory SDK, which fuses

--- a/crates/velesdb-memory/src/mcp.rs
+++ b/crates/velesdb-memory/src/mcp.rs
@@ -207,7 +207,7 @@ impl McpServer {
 
     #[tool(
         name = "relate",
-        description = "Create a typed link from one memory to another. Returns the edge id."
+        description = "Create a typed, directional link between two memories (`from` → `to`) labeled by `relation`. These links are the graph edges that `why` and `recall_fused` later traverse to surface connected facts that share no words with the query — build the graph with `relate` so multi-hop reasoning works (e.g. link a decision to its cause, a fact to its source, a task to the person it concerns). Idempotent per (from, relation, to). Returns the new edge id."
     )]
     async fn relate(
         &self,
@@ -222,7 +222,10 @@ impl McpServer {
         Ok(Json(RelateResult { edge_id }))
     }
 
-    #[tool(name = "forget", description = "Delete a memory by id.")]
+    #[tool(
+        name = "forget",
+        description = "Permanently delete a memory by its `id` (as returned by `remember` or `recall`), removing the fact and its graph links. The deletion is durable and cannot be undone — use it to retract or correct stored knowledge. For automatic time-based expiry instead, set a TTL when calling `remember`. Returns the deleted id."
+    )]
     async fn forget(
         &self,
         Parameters(params): Parameters<ForgetParams>,

--- a/crates/velesdb-memory/src/mcp/dto.rs
+++ b/crates/velesdb-memory/src/mcp/dto.rs
@@ -124,11 +124,12 @@ pub(super) struct RecallFusedResult {
 #[derive(Deserialize, JsonSchema)]
 #[schemars(transform = crate::schema::strip_int_formats)]
 pub(super) struct RelateParams {
-    /// Source memory id.
+    /// Source memory id — the link points FROM here (as returned by `remember`/`recall`).
     pub(super) from: u64,
-    /// Target memory id.
+    /// Target memory id — the link points TO here (as returned by `remember`/`recall`).
     pub(super) to: u64,
-    /// Relationship label.
+    /// Directional relationship label, read as `from` <relation> `to`.
+    /// Examples: `caused_by`, `depends_on`, `authored_by`, `supersedes`.
     pub(super) relation: String,
 }
 
@@ -144,7 +145,7 @@ pub(super) struct RelateResult {
 #[derive(Deserialize, JsonSchema)]
 #[schemars(transform = crate::schema::strip_int_formats)]
 pub(super) struct ForgetParams {
-    /// Id of the memory to forget.
+    /// Id of the memory to permanently delete (as returned by `remember` or `recall`).
     pub(super) id: u64,
 }
 

--- a/crates/velesdb-node/Cargo.toml
+++ b/crates/velesdb-node/Cargo.toml
@@ -2,7 +2,7 @@
 name = "velesdb-node"
 # Tracks velesdb-memory's independent cadence (the npm package version),
 # not the workspace 3.x engine line. Never crates.io-published (publish=false).
-version = "0.5.0"
+version = "0.6.0"
 # Never cargo-published: this cdylib ships to npm as @wiscale/velesdb-memory-node
 # per-platform prebuilds, not to crates.io.
 publish = false

--- a/crates/velesdb-node/package.json
+++ b/crates/velesdb-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wiscale/velesdb-memory-node",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Local-first agent memory for Node.js (napi-rs): remember/recall/relate/forget/why with the why() knowledge-graph wedge, plus auto-extraction.",
   "license": "SEE LICENSE IN LICENSE",
   "author": "Julien Lange <contact@wiscale.fr>",

--- a/crates/velesdb-python/README.md
+++ b/crates/velesdb-python/README.md
@@ -3,7 +3,7 @@
 [![PyPI](https://img.shields.io/pypi/v/velesdb)](https://pypi.org/project/velesdb/)
 [![Python](https://img.shields.io/pypi/pyversions/velesdb)](https://pypi.org/project/velesdb/)
 [![License](https://img.shields.io/badge/license-VelesDB_Core_1.0-blue)](./LICENSE)
-[![Version](https://img.shields.io/badge/version-3.7.0-blue)](https://github.com/cyberlife-coder/VelesDB/releases)
+[![Version](https://img.shields.io/badge/version-3.8.0-blue)](https://github.com/cyberlife-coder/VelesDB/releases)
 
 Python bindings for [VelesDB](https://github.com/cyberlife-coder/VelesDB) — a high-performance vector database for AI applications. `numpy>=1.20` ships as a hard runtime dependency since v1.13.8, so a single `pip install velesdb` is sufficient.
 

--- a/crates/velesdb-python/pyproject.toml
+++ b/crates/velesdb-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "velesdb"
-version = "3.7.0"
+version = "3.8.0"
 description = "VelesDB: The Local Vector Database for Python & AI. Microsecond semantic search, zero network latency."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/crates/velesdb-server/README.md
+++ b/crates/velesdb-server/README.md
@@ -659,7 +659,7 @@ curl http://localhost:8080/health
 Response:
 
 ```json
-{"status": "ok", "version": "3.7.0"}
+{"status": "ok", "version": "3.8.0"}
 ```
 
 ### `GET /ready` -- Readiness Probe
@@ -673,13 +673,13 @@ curl http://localhost:8080/ready
 Response (ready):
 
 ```json
-{"status": "ready", "version": "3.7.0"}
+{"status": "ready", "version": "3.8.0"}
 ```
 
 Response (not ready):
 
 ```json
-{"status": "not_ready", "version": "3.7.0"}
+{"status": "not_ready", "version": "3.8.0"}
 ```
 
 ### Kubernetes Example

--- a/crates/velesdb-server/src/handlers/points/mod.rs
+++ b/crates/velesdb-server/src/handlers/points/mod.rs
@@ -210,8 +210,10 @@ pub async fn get_point(
     let points = collection.get(&[id]);
 
     match points.into_iter().next().flatten() {
+        // ID as a string for JS precision-safety above 2^53-1, consistent with
+        // every other read surface (search/scroll/relations, see `serde_id`).
         Some(point) => Json(serde_json::json!({
-            "id": point.id,
+            "id": point.id.to_string(),
             "vector": point.vector,
             "payload": point.payload
         }))
@@ -247,9 +249,11 @@ pub async fn delete_point(
     };
 
     match collection.delete(&[id]) {
+        // ID as a string for JS precision-safety (see `serde_id`), consistent
+        // with the string ID accepted in the path and returned by reads.
         Ok(()) => Json(serde_json::json!({
             "message": "Point deleted",
-            "id": id
+            "id": id.to_string()
         }))
         .into_response(),
         Err(e) => auto_core_error_response(&e),

--- a/crates/velesdb-server/tests/api_integration.rs
+++ b/crates/velesdb-server/tests/api_integration.rs
@@ -3632,7 +3632,7 @@ async fn test_get_point_by_id() {
         .unwrap();
     let json: Value = serde_json::from_slice(&body).unwrap();
 
-    assert_eq!(json["id"], 42);
+    assert_eq!(json["id"], "42"); // ID emitted as a string (JS precision-safety)
     assert_eq!(json["vector"], json!([1.0, 0.0, 0.0]));
     assert_eq!(json["payload"]["color"], "red");
 
@@ -3736,7 +3736,7 @@ async fn test_delete_point_by_id() {
         .await
         .unwrap();
     let json: Value = serde_json::from_slice(&body).unwrap();
-    assert_eq!(json["id"], 7);
+    assert_eq!(json["id"], "7"); // ID emitted as a string (JS precision-safety)
 
     // GET after delete returns 404
     let response = app

--- a/demos/rag-pdf-demo/pyproject.toml
+++ b/demos/rag-pdf-demo/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "velesdb-rag-demo"
-version = "3.7.0"
+version = "3.8.0"
 description = "RAG Demo with PDF ingestion using VelesDB for vector storage"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/demos/rag-pdf-demo/src/__init__.py
+++ b/demos/rag-pdf-demo/src/__init__.py
@@ -1,3 +1,3 @@
 """VelesDB RAG Demo - PDF Question Answering System."""
 
-__version__ = "3.7.0"
+__version__ = "3.8.0"

--- a/demos/rag-pdf-demo/src/main.py
+++ b/demos/rag-pdf-demo/src/main.py
@@ -46,7 +46,7 @@ async def lifespan(app: FastAPI):
 app = FastAPI(
     title="VelesDB RAG Demo",
     description="PDF Question Answering with VelesDB vector search",
-    version="3.7.0",
+    version="3.8.0",
     lifespan=lifespan
 )
 

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -1,6 +1,6 @@
 # VelesDB Performance Benchmarks
 
-*Last updated: July 6, 2026 (VelesDB v3.7.0). Figures are re-validated at each release only when re-measured — each section carries its own measurement date and machine; this stamp tracks the document revision, not a fresh measurement.*
+*Last updated: July 6, 2026 (VelesDB v3.8.0). Figures are re-validated at each release only when re-measured — each section carries its own measurement date and machine; this stamp tracks the document revision, not a fresh measurement.*
 
 ---
 

--- a/docs/VELESQL_SPEC.md
+++ b/docs/VELESQL_SPEC.md
@@ -2,7 +2,7 @@
 
 > SQL-like query language for vector + graph + column-store search in VelesDB.
 
-**Version**: 3.10.0 | **Last Updated**: 2026-07-06 (VelesDB v3.7.0)
+**Version**: 3.10.0 | **Last Updated**: 2026-07-06 (VelesDB v3.8.0)
 
 ---
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -96,7 +96,7 @@ Expected response:
 ```json
 {
   "status": "ok",
-  "version": "3.7.0"
+  "version": "3.8.0"
 }
 ```
 

--- a/docs/guides/CLI_REPL.md
+++ b/docs/guides/CLI_REPL.md
@@ -1,6 +1,6 @@
 # 💻 CLI & REPL Reference
 
-*Version 3.7.0 — 2026-06-12*
+*Version 3.8.0 — 2026-06-12*
 
 Complete guide to the VelesDB command-line interface and the interactive REPL.
 
@@ -36,7 +36,7 @@ cargo build --release -p velesdb-cli
 
 ```bash
 velesdb --version
-# velesdb 3.7.0
+# velesdb 3.8.0
 ```
 
 ---
@@ -269,7 +269,7 @@ velesdb> \info
 ┌─────────────────────┬────────────────────┐
 │ Property            │ Value              │
 ├─────────────────────┼────────────────────┤
-│ Version             │ 3.7.0              │
+│ Version             │ 3.8.0              │
 │ Data directory      │ ./data             │
 │ Collections         │ 3                  │
 │ Total vectors       │ 125,000            │
@@ -342,7 +342,7 @@ Session settings are **not persisted** across REPL sessions. To persist them, us
 ```
 $ velesdb repl ./my_db
 
-VelesDB v3.7.0 - Interactive REPL
+VelesDB v3.8.0 - Interactive REPL
 Type \help for help, \quit to exit.
 
 velesdb> \show

--- a/docs/guides/CONFIGURATION.md
+++ b/docs/guides/CONFIGURATION.md
@@ -1,6 +1,6 @@
 # ⚙️ VelesDB Configuration
 
-*Version 3.7.0 — May 2026*
+*Version 3.8.0 — May 2026*
 
 Complete guide for configuring VelesDB via configuration file, environment variables, and runtime parameters.
 
@@ -62,7 +62,7 @@ data_dir = "./data"
 ```toml
 # =============================================================================
 # VelesDB Configuration File
-# Version: 3.7.0
+# Version: 3.8.0
 # =============================================================================
 
 # -----------------------------------------------------------------------------

--- a/docs/guides/GRAPH_PATTERNS.md
+++ b/docs/guides/GRAPH_PATTERNS.md
@@ -1,6 +1,6 @@
 # Graph Patterns Guide
 
-*Version 3.7.0 -- May 2026*
+*Version 3.8.0 -- May 2026*
 
 Practical guide for using VelesQL `MATCH` graph patterns in VelesDB.
 

--- a/docs/guides/INSTALLATION.md
+++ b/docs/guides/INSTALLATION.md
@@ -60,10 +60,10 @@ entry.
 
 ```bash
 # Download
-wget https://github.com/cyberlife-coder/VelesDB/releases/download/v3.7.0/velesdb-3.7.0-amd64.deb
+wget https://github.com/cyberlife-coder/VelesDB/releases/download/v3.8.0/velesdb-3.8.0-amd64.deb
 
 # Install
-sudo dpkg -i velesdb-3.7.0-amd64.deb
+sudo dpkg -i velesdb-3.8.0-amd64.deb
 
 # Verify
 velesdb --version
@@ -160,13 +160,13 @@ GitHub Container Registry, so you don't need to build locally:
 
 ```bash
 # Pull a specific release (recommended for reproducibility)
-docker pull ghcr.io/cyberlife-coder/velesdb:3.7.0
+docker pull ghcr.io/cyberlife-coder/velesdb:3.8.0
 
 # ...or the latest stable release
 docker pull ghcr.io/cyberlife-coder/velesdb:latest
 
 docker run -d --name velesdb -p 8080:8080 -v velesdb_data:/data \
-  ghcr.io/cyberlife-coder/velesdb:3.7.0
+  ghcr.io/cyberlife-coder/velesdb:3.8.0
 ```
 
 ### Build locally

--- a/docs/guides/SEARCH_MODES.md
+++ b/docs/guides/SEARCH_MODES.md
@@ -1,6 +1,6 @@
 # 🎯 Search Modes - Recall Configuration Guide
 
-*Version 3.7.0 -- 2026-06-12*
+*Version 3.8.0 -- 2026-06-12*
 
 Complete guide to configuring the **recall vs latency** trade-off in VelesDB. Covers dense search (HNSW), sparse search (SPLADE/BM42), and hybrid search (dense+sparse with fusion). Includes a comparison with Milvus, OpenSearch, and Qdrant practices.
 

--- a/docs/guides/SERVER_SECURITY.md
+++ b/docs/guides/SERVER_SECURITY.md
@@ -299,7 +299,7 @@ curl http://localhost:8080/health
 ```json
 {
   "status": "ok",
-  "version": "3.7.0"
+  "version": "3.8.0"
 }
 ```
 
@@ -318,7 +318,7 @@ curl http://localhost:8080/ready
 ```json
 {
   "status": "ready",
-  "version": "3.7.0"
+  "version": "3.8.0"
 }
 ```
 
@@ -327,7 +327,7 @@ curl http://localhost:8080/ready
 ```json
 {
   "status": "not_ready",
-  "version": "3.7.0"
+  "version": "3.8.0"
 }
 ```
 

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -11,7 +11,7 @@
       "name": "VelesDB Core License 1.0",
       "url": "https://github.com/cyberlife-coder/VelesDB/blob/main/LICENSE"
     },
-    "version": "3.7.0"
+    "version": "3.8.0"
   },
   "servers": [
     {

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -8,7 +8,7 @@ info:
   license:
     name: VelesDB Core License 1.0
     url: https://github.com/cyberlife-coder/VelesDB/blob/main/LICENSE
-  version: 3.7.0
+  version: 3.8.0
 servers:
 - url: /
   description: Local server

--- a/docs/reference/ARCHITECTURE_DIAGRAMS.md
+++ b/docs/reference/ARCHITECTURE_DIAGRAMS.md
@@ -1,4 +1,4 @@
-# VelesDB Architecture Diagrams — v3.7.0
+# VelesDB Architecture Diagrams — v3.8.0
 
 ## 1. Workspace Dependency Graph
 

--- a/docs/reference/ECOSYSTEM_PARITY.md
+++ b/docs/reference/ECOSYSTEM_PARITY.md
@@ -1,6 +1,6 @@
 # VelesQL Ecosystem Parity Matrix
 
-Last updated: 2026-07-06 (v3.7.0; velesdb-memory 0.5.0)
+Last updated: 2026-07-06 (v3.8.0; velesdb-memory 0.6.0)
 
 This matrix tracks runtime contract and feature parity across the VelesDB ecosystem.
 

--- a/docs/reference/VELESQL_CHEATSHEET.md
+++ b/docs/reference/VELESQL_CHEATSHEET.md
@@ -1,7 +1,7 @@
 # VelesQL Cheat Sheet
 
 > **Date:** 2026-06-03
-> **VelesDB version:** 3.7.0
+> **VelesDB version:** 3.8.0
 > See the full specification in [`docs/VELESQL_SPEC.md`](../VELESQL_SPEC.md).
 
 > Every `sql` block below is **parsed** against the real grammar by an automated

--- a/docs/reference/VELESQL_CONFORMANCE_MATRIX.md
+++ b/docs/reference/VELESQL_CONFORMANCE_MATRIX.md
@@ -4,7 +4,7 @@ This document lists every VelesQL feature with its parser and executor status.
 A feature can be **Parsed** (the grammar + AST accept it) without being
 **Executed** (the query engine acts on it at runtime).
 
-> Last updated: 2026-07-06 (VelesDB v3.7.0)
+> Last updated: 2026-07-06 (VelesDB v3.8.0)
 
 ## Fully Supported (Parsed AND Executed)
 

--- a/docs/reference/VELESQL_CONTRACT.md
+++ b/docs/reference/VELESQL_CONTRACT.md
@@ -2,7 +2,7 @@
 
 Canonical contract for VelesQL server endpoints and payloads.
 
-- Contract version: `3.7.0`
+- Contract version: `3.8.0`
 - Last updated: `2026-07-06`
 
 This document is the normative REST contract baseline for VelesQL.

--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -401,7 +401,7 @@ Get a single point by ID.
 **Response:**
 ```json
 {
-  "id": 1,
+  "id": "1",
   "vector": [0.1, 0.2, 0.3, ...],
   "payload": {"title": "Hello World"}
 }
@@ -415,7 +415,7 @@ Delete a point by ID.
 ```json
 {
   "message": "Point deleted",
-  "id": 1
+  "id": "1"
 }
 ```
 

--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -57,7 +57,7 @@ Check server health status.
 ```json
 {
   "status": "ok",
-  "version": "3.7.0"
+  "version": "3.8.0"
 }
 ```
 

--- a/examples/wasm-browser-demo/README.md
+++ b/examples/wasm-browser-demo/README.md
@@ -22,7 +22,7 @@ cd crates/velesdb-wasm
 wasm-pack build --target web --out-dir ../../examples/wasm-browser-demo/pkg
 
 # Then update index.html to use the local path instead of CDN:
-# Change: import init from 'https://unpkg.com/@wiscale/velesdb-wasm@3.7.0/velesdb_wasm.js'
+# Change: import init from 'https://unpkg.com/@wiscale/velesdb-wasm@3.8.0/velesdb_wasm.js'
 # To:     import init from './pkg/velesdb_wasm.js'
 ```
 
@@ -80,7 +80,7 @@ Typical results on modern hardware:
 ```html
 <script type="module">
   // If published on npm:
-  // import init, { VectorStore } from 'https://unpkg.com/@wiscale/velesdb-wasm@3.7.0/velesdb_wasm.js';
+  // import init, { VectorStore } from 'https://unpkg.com/@wiscale/velesdb-wasm@3.8.0/velesdb_wasm.js';
   // If built locally with wasm-pack:
   import init, { VectorStore } from './pkg/velesdb_wasm.js';
 

--- a/examples/wasm-browser-demo/index.html
+++ b/examples/wasm-browser-demo/index.html
@@ -171,8 +171,8 @@
         // WASM module - tracks @wiscale/velesdb-wasm@<workspace> with CDN fallback.
         // Bumped by scripts/bump-version.ps1 on every release; if you copy this
         // demo, update the version below to match `@wiscale/velesdb-wasm` on npm.
-        const WASM_CDN_PRIMARY = 'https://unpkg.com/@wiscale/velesdb-wasm@3.7.0/velesdb_wasm.js';
-        const WASM_CDN_FALLBACK = 'https://cdn.jsdelivr.net/npm/@wiscale/velesdb-wasm@3.7.0/velesdb_wasm.js';
+        const WASM_CDN_PRIMARY = 'https://unpkg.com/@wiscale/velesdb-wasm@3.8.0/velesdb_wasm.js';
+        const WASM_CDN_FALLBACK = 'https://cdn.jsdelivr.net/npm/@wiscale/velesdb-wasm@3.8.0/velesdb_wasm.js';
         
         let init, VectorStore;
         

--- a/integrations/common/pyproject.toml
+++ b/integrations/common/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "velesdb-common"
-version = "3.7.0"
+version = "3.8.0"
 description = "Shared utilities for VelesDB Python integrations (internal use)"
 readme = "README.md"
 license = {text = "MIT"}

--- a/integrations/haystack/pyproject.toml
+++ b/integrations/haystack/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "haystack-velesdb"
-version = "3.7.0"
+version = "3.8.0"
 description = "Haystack 2.x DocumentStore for VelesDB: The Local AI Memory Database."
 readme = "README.md"
 license = {text = "MIT"}

--- a/integrations/haystack/src/haystack_velesdb/__init__.py
+++ b/integrations/haystack/src/haystack_velesdb/__init__.py
@@ -3,4 +3,4 @@
 from haystack_velesdb.document_store import VelesDBDocumentStore
 
 __all__ = ["VelesDBDocumentStore"]
-__version__ = "3.7.0"
+__version__ = "3.8.0"

--- a/integrations/langchain/pyproject.toml
+++ b/integrations/langchain/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "langchain-velesdb"
-version = "3.7.0"
+version = "3.8.0"
 description = "LangChain VectorStore for VelesDB: The Local AI Memory Database. Microsecond RAG retrieval."
 readme = "README.md"
 license = {text = "MIT"}

--- a/integrations/langchain/src/langchain_velesdb/__init__.py
+++ b/integrations/langchain/src/langchain_velesdb/__init__.py
@@ -53,4 +53,4 @@ if _HAS_MEMORY:
         "VelesDBSemanticMemory",
         "VelesDBProceduralMemory",
     ])
-__version__ = "3.7.0"
+__version__ = "3.8.0"

--- a/integrations/langgraph/pyproject.toml
+++ b/integrations/langgraph/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "langgraph-velesdb"
-version = "3.7.0"
+version = "3.8.0"
 description = "LangGraph memory tools for VelesDB: drop the why() knowledge-graph memory wedge into any LangGraph agent."
 readme = "README.md"
 license = {text = "MIT"}

--- a/integrations/langgraph/src/langgraph_velesdb/__init__.py
+++ b/integrations/langgraph/src/langgraph_velesdb/__init__.py
@@ -16,4 +16,4 @@ across agent runs.
 from langgraph_velesdb.tools import make_memory_tools
 
 __all__ = ["make_memory_tools"]
-__version__ = "3.7.0"
+__version__ = "3.8.0"

--- a/integrations/llamaindex/pyproject.toml
+++ b/integrations/llamaindex/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "llama-index-vector-stores-velesdb"
-version = "3.7.0"
+version = "3.8.0"
 description = "LlamaIndex VectorStore for VelesDB: The Local AI Memory Database. Microsecond RAG retrieval."
 readme = "README.md"
 license = "MIT"

--- a/integrations/llamaindex/src/llamaindex_velesdb/__init__.py
+++ b/integrations/llamaindex/src/llamaindex_velesdb/__init__.py
@@ -57,4 +57,4 @@ if _HAS_MEMORY:
         "VelesDBChatMemory",
         "VelesDBProceduralMemory",
     ])
-__version__ = "3.7.0"
+__version__ = "3.8.0"

--- a/scripts/dx-timing/scenario_rust.sh
+++ b/scripts/dx-timing/scenario_rust.sh
@@ -41,7 +41,7 @@ RS
 # Pin to the latest released version on crates.io. Bump alongside each
 # workspace release; the timing measurement is meant to track the path a
 # fresh dev hits when they `cargo add velesdb-core` today.
-cargo add --quiet velesdb-core@3.7.0
+cargo add --quiet velesdb-core@3.8.0
 cargo add --quiet serde_json@1
 cargo run --quiet --release
 

--- a/scripts/dx-timing/scenario_server.sh
+++ b/scripts/dx-timing/scenario_server.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 
 START=$(date +%s.%N)
 
-cargo install --quiet --locked velesdb-server@3.7.0
+cargo install --quiet --locked velesdb-server@3.8.0
 
 DATA_DIR=$(mktemp -d -t velesdb_dx_server_XXXX)
 trap 'rm -rf "$DATA_DIR"' EXIT

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -2,7 +2,7 @@
 
 Official TypeScript SDK for [VelesDB](https://github.com/cyberlife-coder/VelesDB) -- the local-first vector database for AI and RAG. Sub-millisecond semantic search in Browser and Node.js.
 
-**v3.7.0** | Node.js >= 18 | Browser (WASM) | VelesDB Core License 1.0
+**v3.8.0** | Node.js >= 18 | Browser (WASM) | VelesDB Core License 1.0
 
 ## What's New in v3.6.0
 

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wiscale/velesdb-sdk",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wiscale/velesdb-sdk",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@wiscale/velesdb-wasm": "^3.0.0"

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wiscale/velesdb-sdk",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "VelesDB TypeScript SDK: The Local Vector Database for AI & RAG. Microsecond semantic search in Browser & Node.js.",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -10,7 +10,7 @@ sonar.sourceEncoding=UTF-8
 # e.g. index/hnsw/native/tests.rs); `**/scripts/**` (crate-level dev/release
 # tooling — top-level `scripts/**` was already excluded); `**/e2e/**` (the WASM
 # end-to-end browser harness, not shipped product code).
-sonar.exclusions=**/tests/**,**/*_tests.rs,**/*_test.rs,**/tests.rs,**/benches/**,**/examples/**,.claude/**,conformance/**,scripts/**,**/scripts/**,**/e2e/**,docs/**,demos/**,sdks/**/tests/**,sdks/**/__tests__/**
+sonar.exclusions=**/tests/**,**/*_tests.rs,**/*_test.rs,**/tests.rs,**/benches/**,**/examples/**,.claude/**,conformance/**,scripts/**,**/scripts/**,**/e2e/**,docs/**,demos/**,sdks/**/tests/**,sdks/**/__tests__/**,**/__test__/**,**/__tests__/**
 
 # Rule-specific suppressions (false positives / non-product scope).
 # - S8570/S8565 ("lock file missing") are false positives in a Cargo workspace:


### PR DESCRIPTION
Release train for **VelesDB 3.8.0** (workspace) and **velesdb-memory / @wiscale/velesdb-memory-node 0.6.0**.

## Headline since 3.7.0
- **BREAKING (REST server):** `GET`/`DELETE /collections/{name}/points/{id}` now return the point `id` as a JSON **string** (not a number), completing the u64 precision-safety migration on the point-object endpoints (#1335). VelesQL `/query` still emits numeric `id` columns — separate follow-up.
- **velesdb-memory:** richer `relate`/`forget` MCP tool descriptions + param docs (#1336) — better tool-definition quality for MCP clients/directories.
- **CI:** exclude `__test__`/`__tests__` dirs from Sonar coverage (#1333).

## Mechanics
- Workspace 3.7.0→3.8.0 via `scripts/bump_version.py`; memory + node 0.5.0→0.6.0.
- OpenAPI regenerated; `check-version-sync.py` passes; CHANGELOGs + hand-written version callouts refreshed.

## After merge
Tags `v3.8.0` (→ crates.io + PyPI + binaries) then `velesdb-memory-v0.6.0` (→ crates.io + npm + MCP registry), core-before-memory per the dependency ordering.