### PR TITLE
fix(security): patch crossbeam-epoch (RUSTSEC-2026-0204) + drop stale audit ignores

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -986,9 +986,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -22,11 +22,9 @@ ignore = [
     { id = "RUSTSEC-2024-0418", reason = "gdk-sys: tauri Linux GTK3 — no fix; Tauri 3 migration tracked" },
     { id = "RUSTSEC-2024-0419", reason = "gtk3-macros: tauri Linux GTK3 — no fix; Tauri 3 migration tracked" },
     { id = "RUSTSEC-2024-0420", reason = "gtk-sys: tauri Linux GTK3 — no fix; Tauri 3 migration tracked" },
-    { id = "RUSTSEC-2024-0429", reason = "glib unsound: tauri Linux GTK3 — no fix; Tauri 3 migration tracked" },
 
     # ── Tauri non-GTK3 transitives ────────────────────────────────────
     { id = "RUSTSEC-2024-0370", reason = "proc-macro-error: tauri build-time transitive, unmaintained" },
-    { id = "RUSTSEC-2025-0057", reason = "fxhash: tauri transitive, unmaintained" },
     { id = "RUSTSEC-2025-0075", reason = "unic-char-range: tauri transitive, unmaintained" },
     { id = "RUSTSEC-2025-0080", reason = "unic-common: tauri transitive, unmaintained" },
     { id = "RUSTSEC-2025-0081", reason = "unic-char-property: tauri transitive, unmaintained" },
@@ -49,8 +47,6 @@ ignore = [
     # ── velesdb-cli transitive ────────────────────────────────────────
     { id = "RUSTSEC-2024-0384", reason = "instant: velesdb-cli transitive (clap/indicatif chain), unmaintained" },
 
-    # ── SIMD / quantization transitive ────────────────────────────────
-    { id = "RUSTSEC-2024-0436", reason = "paste: simdeez transitive, unmaintained" },
 
     # ── Embedded / heapless transitive (postcard 1.x) ─────────────────
     # postcard 1.x is a load-bearing serializer in velesdb-core; postcard 2.x


### PR DESCRIPTION
The **Security Audit (cargo-deny) has been failing repo-wide** — including on released `main` and every open PR. Root cause + fix:

## 1. Stale ignore entries (the visible failure)
Three `deny.toml` ignores no longer matched any crate in the tree (`advisory-not-detected`, which cargo-deny treats as an error): `RUSTSEC-2024-0429` (glib), `RUSTSEC-2024-0436` (paste), `RUSTSEC-2025-0057` (fxhash) — those versions left the graph while gdk/atk/gtk stayed. Removed them.

## 2. The real advisory they masked
Removing them surfaced **`RUSTSEC-2026-0204`** — `crossbeam-epoch 0.9.18` dereferences an invalid pointer in its `fmt::Pointer` impl. Fixed via `cargo update -p crossbeam-epoch` → **0.9.20** (semver-compatible transitive patch).

## Result
`cargo deny check advisories` → **ok**. Greens the Security Audit gate on develop and unblocks the dependabot PRs (#1329, #1323, …) that only failed on it. Minimal diff: deny.toml −3 lines, Cargo.lock crossbeam-epoch bump.