### PR TITLE
fix(ci): keep velesdb-memory releases off the "Latest" flag

### DIFF
--- a/.github/workflows/release-mcpb.yml
+++ b/.github/workflows/release-mcpb.yml
@@ -172,8 +172,13 @@ jobs:
         run: |
           set -euo pipefail
           # Ensure a release exists for the tag, then upload (clobber) the bundles.
+          # --latest=false: the velesdb-memory release must never become the
+          # repo's "Latest release" (that belongs to the VelesDB vX.Y.Z release,
+          # which carries the binaries the README download link points at). Left
+          # unset, `gh release create` marks it latest-by-date and steals the
+          # flag, breaking releases/latest/download/velesdb-*.
           if ! gh release view "$TAG" >/dev/null 2>&1; then
-            gh release create "$TAG" --title "$TAG" --notes "velesdb-memory $TAG — MCPB bundles for the MCP registry." || true
+            gh release create "$TAG" --title "$TAG" --latest=false --notes "velesdb-memory $TAG — MCPB bundles for the MCP registry." || true
           fi
           gh release upload "$TAG" bundles/*.mcpb --clobber
 


### PR DESCRIPTION
**Why the repo's "Latest release" was wrong** (v1.9.1 in a cached badge, then `velesdb-memory-v0.6.0`): GitHub picks "Latest" by **publish date**, not semver. `release-mcpb.yml` creates the `velesdb-memory-vX.Y.Z` GitHub release with `gh release create` and **no `--latest` flag**, so each memory tag — pushed right after the workspace `vX.Y.Z` tag — becomes "Latest". But the memory release only holds `.mcpb` bundles, not the VelesDB binaries, so:

- the README **"Download latest release"** link and the `releases/latest/download/velesdb-*` install commands resolve to a release with no `velesdb-*` assets → **broken downloads**;
- any `github/v/release` badge points at the memory release.

**Fix:** pass `--latest=false` when creating the memory release, so the VelesDB `vX.Y.Z` release keeps the Latest flag. One line.

I've already **re-pinned v3.8.0 as Latest manually** so `releases/latest` is correct now; this prevents the regression on the next `velesdb-memory-v*` tag.