### PR TITLE
fix: audit remediation temps 1 — P0 correctness (compaction Windows, F2.2, wasm v2) + key P1s

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -986,9 +986,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -6804,6 +6804,7 @@ name = "velesdb-mobile"
 version = "3.8.0"
 dependencies = [
  "parking_lot",
+ "serde",
  "serde_json",
  "tempfile",
  "thiserror 2.0.18",

--- a/crates/tauri-plugin-velesdb/README.md
+++ b/crates/tauri-plugin-velesdb/README.md
@@ -28,7 +28,7 @@ A Tauri plugin for **VelesDB** — Vector search in desktop applications.
 
 ```toml
 [dependencies]
-tauri-plugin-velesdb = "1"
+tauri-plugin-velesdb = "3"
 ```
 
 ### TypeScript SDK (package.json)

--- a/crates/velesdb-cli/src/handlers/data.rs
+++ b/crates/velesdb-cli/src/handlers/data.rs
@@ -33,7 +33,7 @@ pub fn handle_export(
         collection.green()
     );
 
-    let records = collect_export_records(&col, cfg.point_count, include_vectors);
+    let records = collect_export_records(&col, include_vectors);
     std::fs::write(&output_path, serde_json::to_string_pretty(&records)?)?;
     println!(
         "{} Exported {} records to {}",
@@ -45,18 +45,21 @@ pub fn handle_export(
 }
 
 /// Collects all records from a vector collection for export.
+///
+/// IDs come from the live collection (`all_ids`) rather than an assumed
+/// contiguous `1..=point_count` range: sparse or non-sequential IDs (explicit
+/// ids passed at upsert, or gaps left by deletions) would otherwise be exported
+/// as missing records — silent data loss.
 fn collect_export_records(
     col: &velesdb_core::VectorCollection,
-    point_count: usize,
     include_vectors: bool,
 ) -> Vec<serde_json::Value> {
-    let mut records = Vec::new();
+    let all_ids = col.all_ids();
+    let mut records = Vec::with_capacity(all_ids.len());
     let batch_size = 1000;
 
-    for batch_start in (0..point_count).step_by(batch_size) {
-        let ids: Vec<u64> =
-            ((batch_start as u64 + 1)..=((batch_start + batch_size) as u64)).collect();
-        let points = col.get(&ids);
+    for ids in all_ids.chunks(batch_size) {
+        let points = col.get(ids);
 
         for point in points.into_iter().flatten() {
             let mut record = serde_json::Map::new();

--- a/crates/velesdb-cli/src/handlers/data.rs
+++ b/crates/velesdb-cli/src/handlers/data.rs
@@ -54,7 +54,7 @@ fn collect_export_records(
     col: &velesdb_core::VectorCollection,
     include_vectors: bool,
 ) -> Vec<serde_json::Value> {
-    let all_ids = col.all_ids();
+    let all_ids = col.all_point_ids();
     let mut records = Vec::with_capacity(all_ids.len());
     let batch_size = 1000;
 

--- a/crates/velesdb-cli/src/handlers/info.rs
+++ b/crates/velesdb-cli/src/handlers/info.rs
@@ -229,7 +229,9 @@ fn print_vector_table(cfg: &velesdb_core::collection::CollectionConfig, type_lab
 /// Prints sample vector records.
 fn print_vector_samples(col: &velesdb_core::VectorCollection, samples: usize) {
     println!("\n{}", "Sample Records".bold().underline());
-    let ids: Vec<u64> = (1..=(samples as u64 * 2)).collect();
+    // Sample from the collection's actual IDs, not an assumed contiguous
+    // `1..=n` range: sparse/non-sequential IDs would otherwise show nothing.
+    let ids: Vec<u64> = col.all_ids().into_iter().take(samples).collect();
     let points = col.get(&ids);
     for point in points.into_iter().flatten().take(samples) {
         println!("  ID: {}", point.id.to_string().green());

--- a/crates/velesdb-cli/src/handlers/info.rs
+++ b/crates/velesdb-cli/src/handlers/info.rs
@@ -229,9 +229,10 @@ fn print_vector_table(cfg: &velesdb_core::collection::CollectionConfig, type_lab
 /// Prints sample vector records.
 fn print_vector_samples(col: &velesdb_core::VectorCollection, samples: usize) {
     println!("\n{}", "Sample Records".bold().underline());
-    // Sample from the collection's actual IDs, not an assumed contiguous
-    // `1..=n` range: sparse/non-sequential IDs would otherwise show nothing.
-    let ids: Vec<u64> = col.all_ids().into_iter().take(samples).collect();
+    // Sample from the collection's actual IDs (complete set, incl. None-payload
+    // points), not an assumed contiguous `1..=n` range which showed nothing on
+    // sparse/non-sequential IDs.
+    let ids: Vec<u64> = col.all_point_ids().into_iter().take(samples).collect();
     let points = col.get(&ids);
     for point in points.into_iter().flatten().take(samples) {
         println!("  ID: {}", point.id.to_string().green());

--- a/crates/velesdb-core/src/collection/vector_collection/accessors.rs
+++ b/crates/velesdb-core/src/collection/vector_collection/accessors.rs
@@ -55,6 +55,16 @@ impl VectorCollection {
         self.inner.all_ids()
     }
 
+    /// Returns every point ID (vector- or payload-backed) in ascending order.
+    ///
+    /// Unlike [`all_ids`](Self::all_ids), this includes points inserted with a
+    /// `None` payload, so it is the complete, deterministic set to iterate for
+    /// export/sampling.
+    #[must_use]
+    pub fn all_point_ids(&self) -> Vec<u64> {
+        self.inner.all_point_ids()
+    }
+
     /// Returns the next batch of points for scroll iteration.
     ///
     /// Delegates to the inner collection's scroll implementation; see also

--- a/crates/velesdb-core/src/storage/compaction.rs
+++ b/crates/velesdb-core/src/storage/compaction.rs
@@ -540,35 +540,31 @@ impl CompactionContext<'_> {
             let _ = std::mem::replace(&mut *self.mmap.write(), placeholder);
         }
 
-        // 6. Commit: swap the data file in, promote the staged index, then
-        // truncate the now-obsolete WAL (see `commit_compaction` for the
-        // crash-safety invariant). Capture the result rather than `?`: after the
-        // step-5b placeholder swap, `self.mmap` is a 1-byte anonymous map, so we
-        // MUST remap a real file below on every path — otherwise a commit error
-        // would leave storage stranded on the placeholder.
+        // 6. COMMIT POINT: atomically swap the compacted temp file into place.
+        // After this succeeds, `vectors.dat` IS the compacted layout.
         let data_path = self.path.join("vectors.dat");
-        let commit_result = self.commit_compaction(&temp_path, &idx_tmp_path, &data_path);
+        let swapped = atomic_replace(&temp_path, &data_path);
 
-        // 7. Remap the live data file, replacing the placeholder. On success
-        // this is the compacted file; on commit failure it is whatever the swap
-        // left on disk (the untouched original if it failed early), so storage
-        // never stays on the anonymous placeholder.
+        // 7. Remap the live data file so storage never stays on the step-5b
+        // placeholder. `data_path` is the compacted file if the swap succeeded,
+        // otherwise the untouched original.
         let new_data_file = OpenOptions::new().read(true).write(true).open(&data_path)?;
         // SAFETY: `MmapMut::map_mut` requires a writable file sized for mapping.
-        // - Condition 1: `new_data_file` is opened read/write after atomic replace.
+        // - Condition 1: `new_data_file` is opened read/write after the swap.
         // - Condition 2: File contents are fully materialized by the preceding flush/rename flow.
         // SAFETY: Reloading mmap is required to switch storage to compacted bytes.
         let new_mmap = unsafe { MmapMut::map_mut(&new_data_file)? };
-        // Issue #316: Atomic index swap — replace mmap and index without
-        // an intermediate empty state visible to concurrent readers.
         *self.mmap.write() = new_mmap;
 
-        // Surface a commit failure now that a valid mapping is restored. The
-        // index/offset are left unchanged so they still match the pre-compaction
-        // file that startup recovery reinstates.
-        commit_result?;
-
-        // 8. Commit succeeded: adopt the compacted index and offsets.
+        // 8. Reconcile the in-memory index with what is now on disk. If the swap
+        // failed, the original data file is intact and the existing index/offset
+        // still describe it, so return the error without touching them.
+        swapped?;
+        // Swap succeeded: `vectors.dat` is the compacted layout, so the index and
+        // offset MUST switch to it. Adopt them BEFORE finalizing, so a failure in
+        // `finalize_commit` still leaves the index and the mmap mutually
+        // consistent (startup recovery reconciles the durable index/WAL). Issue
+        // #316: readers never observe an intermediate empty state (`&mut self`).
         self.index.replace_all(new_index);
         // Reason: Release ordering pairs with the Acquire loads in
         // `should_compact` and `compact` to ensure readers on ARM/weak-memory
@@ -576,20 +572,27 @@ impl CompactionContext<'_> {
         // new offset value.
         self.next_offset.store(new_offset, Ordering::Release);
 
+        // 9. Finalize: promote the staged index sidecar and truncate the obsolete
+        // WAL. A failure here is recoverable on the next open and does not desync
+        // the already-adopted in-memory index.
+        self.finalize_commit(&idx_tmp_path)?;
+
         Ok(bytes_to_reclaim)
     }
 
-    /// Commits a built compacted file: atomic data swap, index promotion and
-    /// WAL truncation, all under the WAL lock so no writer can append an
-    /// entry between the swap and the truncation.
+    /// Finalizes a compaction after the data-file swap: promotes the staged
+    /// index sidecar, makes the renames durable, and truncates the obsolete WAL.
+    /// Runs under the WAL lock so no writer can append between promotion and
+    /// truncation. Must be called only after `atomic_replace` has swapped the
+    /// compacted `vectors.dat` into place.
     ///
     /// # Crash-safety invariant
     ///
-    /// The rename of `vectors.dat.tmp` -> `vectors.dat` is the single commit
-    /// point. The compacted file plus the staged index fully capture every
-    /// acknowledged write (stores update the mmap before compaction snapshots
-    /// it), so once the swap is durable the prior WAL is obsolete and is
-    /// truncated. Every intermediate crash point is recoverable:
+    /// The `vectors.dat.tmp` -> `vectors.dat` rename (done by the caller) is the
+    /// single commit point. The compacted file plus the staged index fully
+    /// capture every acknowledged write, so once the swap is durable the prior
+    /// WAL is obsolete and is truncated. Every intermediate crash point is
+    /// recoverable:
     /// - before the swap: startup recovery removes both staged files and the
     ///   old dat/idx/WAL triple is untouched;
     /// - after the swap, before promotion: recovery promotes the sidecar;
@@ -597,16 +600,8 @@ impl CompactionContext<'_> {
     ///   every store record carries the full vector value and deletes replay
     ///   in order;
     /// - after promotion, before truncation: same convergent replay.
-    fn commit_compaction(
-        &self,
-        temp_path: &Path,
-        idx_tmp_path: &Path,
-        data_path: &Path,
-    ) -> io::Result<()> {
+    fn finalize_commit(&self, idx_tmp_path: &Path) -> io::Result<()> {
         let mut wal = self.wal.write();
-
-        // COMMIT POINT: atomic swap temp -> main (cross-platform).
-        atomic_replace(temp_path, data_path)?;
 
         // Promote the staged index so vectors.idx matches the new layout.
         let idx_path = self.path.join("vectors.idx");

--- a/crates/velesdb-core/src/storage/compaction.rs
+++ b/crates/velesdb-core/src/storage/compaction.rs
@@ -245,10 +245,8 @@ pub(super) fn persist_flat_index_atomic(
 
     persist_flat_index(&staging, index)?;
     promote_index_sidecar(&staging, path)?;
-    match path.parent() {
-        Some(dir) if !dir.as_os_str().is_empty() => sync_dir(dir),
-        _ => Ok(()),
-    }
+    let dir = path.parent().filter(|d| !d.as_os_str().is_empty());
+    durable_rename_barrier(dir, &[path])
 }
 
 /// Renames a fully written index file over `idx_path`.
@@ -266,18 +264,38 @@ fn promote_index_sidecar(sidecar: &Path, idx_path: &Path) -> io::Result<()> {
     std::fs::rename(sidecar, idx_path)
 }
 
-/// Fsyncs the storage directory so preceding renames are durable (POSIX).
+/// Makes preceding renames durable before the caller truncates the WAL.
 ///
-/// Without this, a power loss could persist the WAL truncation that follows
-/// the compaction commit while rolling back the renames themselves.
-fn sync_dir(dir: &Path) -> io::Result<()> {
+/// A compaction commit renames the new data/index files into place and then
+/// truncates the WAL. If the truncation reaches disk while the renames do not,
+/// a power loss leaves an empty WAL beside stale pre-compaction files — silent
+/// data loss. This barrier orders the renames before the truncation:
+///
+/// - **Unix:** fsync the directory, persisting the renames' directory entries.
+/// - **Windows/other:** there is no directory fsync, and the data file is
+///   memory-mapped so it cannot be reopened for write (`FlushFileBuffers`
+///   access-denied). Each *non-mapped* renamed file passed here (the index
+///   sidecar) is fsynced instead. Callers must NOT pass a currently-mmapped
+///   path. The data-file rename is ordered by NTFS: its record is written to
+///   `$LogFile` before the trailing `wal.sync_all()`, and NTFS's write-ahead
+///   invariant flushes `$LogFile` up to that point, so the rename is durable
+///   before the WAL truncation reaches disk (holds on NTFS; FAT/exFAT data
+///   directories are unsupported for durability).
+fn durable_rename_barrier(dir: Option<&Path>, renamed: &[&Path]) -> io::Result<()> {
     #[cfg(unix)]
     {
-        File::open(dir)?.sync_all()
+        let _ = renamed;
+        match dir {
+            Some(d) => File::open(d)?.sync_all(),
+            None => Ok(()),
+        }
     }
     #[cfg(not(unix))]
     {
         let _ = dir;
+        for path in renamed {
+            OpenOptions::new().write(true).open(path)?.sync_all()?;
+        }
         Ok(())
     }
 }
@@ -410,7 +428,8 @@ impl CompactionContext<'_> {
     /// # TS-CORE-004: Storage Compaction
     ///
     /// This operation is quasi-atomic via `rename()` for crash safety.
-    /// Reads remain available during compaction (copy-on-write pattern).
+    /// The caller holds the storage write lock for the duration, so reads are
+    /// blocked while compaction runs (it is not concurrent copy-on-write).
     ///
     /// # Returns
     ///
@@ -565,12 +584,17 @@ impl CompactionContext<'_> {
         atomic_replace(temp_path, data_path)?;
 
         // Promote the staged index so vectors.idx matches the new layout.
-        promote_index_sidecar(idx_tmp_path, &self.path.join("vectors.idx"))?;
+        let idx_path = self.path.join("vectors.idx");
+        promote_index_sidecar(idx_tmp_path, &idx_path)?;
 
-        // Make both renames durable before the truncation below can hit disk:
-        // a power loss must never persist an empty WAL while rolling back the
-        // renames that committed the compaction.
-        sync_dir(self.path)?;
+        // Make the renames durable before the truncation below can hit disk: a
+        // power loss must never persist an empty WAL while rolling back the
+        // renames that committed the compaction. On Unix this fsyncs the
+        // directory; on Windows the index sidecar is fsynced and the data-file
+        // rename is ordered via NTFS $LogFile (see durable_rename_barrier). The
+        // mmapped data file is deliberately not passed — it cannot be reopened
+        // for write while mapped.
+        durable_rename_barrier(Some(self.path), &[&idx_path])?;
 
         // Compaction renders the prior WAL obsolete: truncate it. flush()
         // first so the BufWriter cannot later re-append buffered stale

--- a/crates/velesdb-core/src/storage/compaction.rs
+++ b/crates/velesdb-core/src/storage/compaction.rs
@@ -526,24 +526,49 @@ impl CompactionContext<'_> {
         let idx_tmp_path = self.path.join("vectors.idx.tmp");
         persist_flat_index(&idx_tmp_path, &new_index)?;
 
+        // 5b. Release the live mapping of the OLD data file BEFORE the swap.
+        // Windows refuses to rename/replace a memory-mapped file
+        // (ERROR_ACCESS_DENIED), so `atomic_replace` below would fail while the
+        // old mapping is held — leaving compaction entirely broken on Windows.
+        // Swap in a tiny anonymous placeholder to unmap the file; step 7 remaps
+        // the compacted file. Safe because the caller holds `&mut self`
+        // (exclusive), so no `VectorSliceGuard` is outstanding to invalidate.
+        {
+            let placeholder = MmapMut::map_anon(1)?;
+            // Dropping the replaced value unmaps the old file-backed mapping,
+            // releasing the OS handle so the swap can rename the data file.
+            let _ = std::mem::replace(&mut *self.mmap.write(), placeholder);
+        }
+
         // 6. Commit: swap the data file in, promote the staged index, then
         // truncate the now-obsolete WAL (see `commit_compaction` for the
-        // crash-safety invariant).
+        // crash-safety invariant). Capture the result rather than `?`: after the
+        // step-5b placeholder swap, `self.mmap` is a 1-byte anonymous map, so we
+        // MUST remap a real file below on every path — otherwise a commit error
+        // would leave storage stranded on the placeholder.
         let data_path = self.path.join("vectors.dat");
-        self.commit_compaction(&temp_path, &idx_tmp_path, &data_path)?;
+        let commit_result = self.commit_compaction(&temp_path, &idx_tmp_path, &data_path);
 
-        // 7. Reopen the compacted file
+        // 7. Remap the live data file, replacing the placeholder. On success
+        // this is the compacted file; on commit failure it is whatever the swap
+        // left on disk (the untouched original if it failed early), so storage
+        // never stays on the anonymous placeholder.
         let new_data_file = OpenOptions::new().read(true).write(true).open(&data_path)?;
         // SAFETY: `MmapMut::map_mut` requires a writable file sized for mapping.
         // - Condition 1: `new_data_file` is opened read/write after atomic replace.
         // - Condition 2: File contents are fully materialized by the preceding flush/rename flow.
         // SAFETY: Reloading mmap is required to switch storage to compacted bytes.
         let new_mmap = unsafe { MmapMut::map_mut(&new_data_file)? };
-
-        // 8. Update internal state
         // Issue #316: Atomic index swap — replace mmap and index without
         // an intermediate empty state visible to concurrent readers.
         *self.mmap.write() = new_mmap;
+
+        // Surface a commit failure now that a valid mapping is restored. The
+        // index/offset are left unchanged so they still match the pre-compaction
+        // file that startup recovery reinstates.
+        commit_result?;
+
+        // 8. Commit succeeded: adopt the compacted index and offsets.
         self.index.replace_all(new_index);
         // Reason: Release ordering pairs with the Acquire loads in
         // `should_compact` and `compact` to ensure readers on ARM/weak-memory
@@ -591,18 +616,21 @@ impl CompactionContext<'_> {
         // power loss must never persist an empty WAL while rolling back the
         // renames that committed the compaction. On Unix this fsyncs the
         // directory; on Windows the index sidecar is fsynced and the data-file
-        // rename is ordered via NTFS $LogFile (see durable_rename_barrier). The
-        // mmapped data file is deliberately not passed — it cannot be reopened
-        // for write while mapped.
+        // rename is ordered via NTFS $LogFile (see durable_rename_barrier).
         durable_rename_barrier(Some(self.path), &[&idx_path])?;
 
-        // Compaction renders the prior WAL obsolete: truncate it. flush()
-        // first so the BufWriter cannot later re-append buffered stale
-        // entries; the fd is in append mode, so subsequent writes start at
-        // the new EOF (offset 0).
+        // Compaction renders the prior WAL obsolete: truncate it to zero.
+        // flush() first so the BufWriter cannot re-emit buffered stale entries;
+        // the append fd then writes fresh entries from the new EOF (offset 0).
+        // The WAL is opened append-only, so its handle lacks FILE_WRITE_DATA and
+        // set_len() on it is ACCESS_DENIED on Windows — truncate via a dedicated
+        // write handle instead (mirrors wal_replay::truncate_wal).
         wal.flush()?;
-        wal.get_ref().set_len(0)?;
-        wal.get_ref().sync_all()
+        let wal_file = OpenOptions::new()
+            .write(true)
+            .open(self.path.join("vectors.wal"))?;
+        wal_file.set_len(0)?;
+        wal_file.sync_all()
     }
 
     /// Returns the fragmentation ratio (0.0 = no fragmentation, 1.0 = 100% fragmented).

--- a/crates/velesdb-migrate/README.md
+++ b/crates/velesdb-migrate/README.md
@@ -420,7 +420,7 @@ options:
 ## 🔧 CLI Reference
 
 ```
-velesdb-migrate 1.7.0
+velesdb-migrate 3.8.0
 Migrate vectors from other databases to VelesDB
 
 USAGE:

--- a/crates/velesdb-migrate/src/pipeline_graph.rs
+++ b/crates/velesdb-migrate/src/pipeline_graph.rs
@@ -90,16 +90,11 @@ impl<'a> GraphMigrationPhase<'a> {
                 relation.from_column, relation.to_table, relation.to_column, relation.edge_label
             );
 
-            let edges = self
-                .extract_edges_for_relation(relation, batch_size)
+            let (created, failed) = self
+                .migrate_relation_edges(relation, batch_size, &gc)
                 .await?;
-
-            let total = edges.len() as u64;
-            let inserted = gc.add_edges_batch(edges).map_err(|e| {
-                Error::DestinationConnection(format!("Edge batch insert failed: {e}"))
-            })? as u64;
-            stats.edges_created += inserted;
-            stats.edges_failed += total.saturating_sub(inserted);
+            stats.edges_created += created;
+            stats.edges_failed += failed;
             stats.relations_processed += 1;
         }
 
@@ -114,12 +109,22 @@ impl<'a> GraphMigrationPhase<'a> {
         Ok(stats)
     }
 
-    async fn extract_edges_for_relation(
+    /// Streams a relation's edges into the graph collection batch by batch.
+    ///
+    /// Each source batch is converted to edges and inserted immediately, so
+    /// only one batch worth of edges is held in memory at a time. The previous
+    /// implementation accumulated every edge of a relation into a single `Vec`
+    /// before one bulk insert, which could exhaust memory on large sources.
+    ///
+    /// Returns `(edges_created, edges_failed)`.
+    async fn migrate_relation_edges(
         &self,
         relation: &RelationConfig,
         batch_size: usize,
-    ) -> Result<Vec<velesdb_core::GraphEdge>> {
-        let mut edges = Vec::new();
+        gc: &velesdb_core::GraphCollection,
+    ) -> Result<(u64, u64)> {
+        let mut created = 0u64;
+        let mut failed = 0u64;
         let mut offset = None;
 
         loop {
@@ -135,6 +140,7 @@ impl<'a> GraphMigrationPhase<'a> {
                 break;
             }
 
+            let mut edges = Vec::with_capacity(batch.points.len());
             for point in &batch.points {
                 if let Some(edge) = build_edge(point, relation) {
                     edges.push(edge);
@@ -146,13 +152,22 @@ impl<'a> GraphMigrationPhase<'a> {
                 }
             }
 
+            if !edges.is_empty() {
+                let total = edges.len() as u64;
+                let inserted = gc.add_edges_batch(edges).map_err(|e| {
+                    Error::DestinationConnection(format!("Edge batch insert failed: {e}"))
+                })? as u64;
+                created += inserted;
+                failed += total.saturating_sub(inserted);
+            }
+
             if !batch.has_more {
                 break;
             }
             offset = batch.next_offset;
         }
 
-        Ok(edges)
+        Ok((created, failed))
     }
 }
 

--- a/crates/velesdb-mobile/Cargo.toml
+++ b/crates/velesdb-mobile/Cargo.toml
@@ -28,6 +28,7 @@ uniffi = { version = "0.31", features = ["tokio", "cli"] }
 tokio = { version = "1.52", features = ["rt-multi-thread"] }
 parking_lot = "0.12"
 thiserror = "2.0"
+serde = { workspace = true }
 serde_json = "1.0"
 tracing = "0.1"
 

--- a/crates/velesdb-mobile/src/graph.rs
+++ b/crates/velesdb-mobile/src/graph.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use parking_lot::RwLock;
 
 /// A graph node for knowledge graph construction.
-#[derive(Debug, Clone, uniffi::Record)]
+#[derive(Debug, Clone, uniffi::Record, serde::Serialize, serde::Deserialize)]
 pub struct MobileGraphNode {
     /// Unique identifier.
     pub id: u64,
@@ -21,7 +21,7 @@ pub struct MobileGraphNode {
 }
 
 /// A graph edge representing a relationship.
-#[derive(Debug, Clone, uniffi::Record)]
+#[derive(Debug, Clone, uniffi::Record, serde::Serialize, serde::Deserialize)]
 pub struct MobileGraphEdge {
     /// Unique identifier.
     pub id: u64,
@@ -100,12 +100,24 @@ impl From<velesdb_core::TraversalResult> for TraversalResult {
 }
 
 /// In-memory graph store for mobile knowledge graphs.
+///
+/// Nodes and edges are held in RAM for fast in-session traversal and are not
+/// written automatically. Call [`save`](Self::save) to persist a snapshot to
+/// disk and [`load`](Self::load) to restore it across app restarts.
 #[derive(uniffi::Object)]
 pub struct MobileGraphStore {
     nodes: RwLock<HashMap<u64, MobileGraphNode>>,
     edges: RwLock<HashMap<u64, MobileGraphEdge>>,
     outgoing: RwLock<HashMap<u64, Vec<u64>>>,
     incoming: RwLock<HashMap<u64, Vec<u64>>>,
+}
+
+/// On-disk snapshot of a [`MobileGraphStore`] (JSON). The outgoing/incoming
+/// adjacency is rebuilt from `edges` on load, so it is not stored.
+#[derive(serde::Serialize, serde::Deserialize)]
+struct GraphSnapshot {
+    nodes: Vec<MobileGraphNode>,
+    edges: Vec<MobileGraphEdge>,
 }
 
 #[uniffi::export]
@@ -119,6 +131,38 @@ impl MobileGraphStore {
             outgoing: RwLock::new(HashMap::new()),
             incoming: RwLock::new(HashMap::new()),
         })
+    }
+
+    /// Persists the current nodes and edges to `path` as JSON so the graph
+    /// survives an app restart (the store is otherwise in-memory only).
+    pub fn save(&self, path: String) -> Result<(), crate::VelesError> {
+        let snapshot = GraphSnapshot {
+            nodes: self.nodes.read().values().cloned().collect(),
+            edges: self.edges.read().values().cloned().collect(),
+        };
+        let bytes = serde_json::to_vec(&snapshot)
+            .map_err(|e| crate::VelesError::database(format!("Graph serialize failed: {e}")))?;
+        std::fs::write(&path, bytes)
+            .map_err(|e| crate::VelesError::database(format!("Graph save to '{path}' failed: {e}")))
+    }
+
+    /// Loads a graph previously written by [`save`](Self::save) from `path`,
+    /// rebuilding the adjacency from the stored edges.
+    #[uniffi::constructor]
+    pub fn load(path: String) -> Result<Arc<Self>, crate::VelesError> {
+        let bytes = std::fs::read(&path).map_err(|e| {
+            crate::VelesError::database(format!("Graph load from '{path}' failed: {e}"))
+        })?;
+        let snapshot: GraphSnapshot = serde_json::from_slice(&bytes)
+            .map_err(|e| crate::VelesError::database(format!("Graph deserialize failed: {e}")))?;
+        let store = Self::new();
+        for node in snapshot.nodes {
+            store.add_node(node);
+        }
+        for edge in snapshot.edges {
+            store.add_edge(edge)?;
+        }
+        Ok(store)
     }
 
     /// Adds a node to the graph.
@@ -580,6 +624,32 @@ mod tests {
         let result = store.add_edge(knows_edge(100, 1, 2));
         assert!(result.is_ok());
         assert_eq!(store.edge_count(), 1);
+    }
+
+    #[test]
+    fn test_mobile_graph_save_load_roundtrip() {
+        let store = store_with_nodes(3);
+        store.add_edge(knows_edge(100, 1, 2)).unwrap();
+        store.add_edge(knows_edge(101, 2, 3)).unwrap();
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("graph.json").to_string_lossy().to_string();
+        store.save(path.clone()).unwrap();
+
+        let restored = MobileGraphStore::load(path).unwrap();
+        assert_eq!(restored.node_count(), 3);
+        assert_eq!(restored.edge_count(), 2);
+        assert_eq!(restored.get_node(1).unwrap().label, "Person");
+        // Adjacency is rebuilt from the stored edges, not persisted directly.
+        let outgoing: Vec<u64> = restored.get_outgoing(1).iter().map(|e| e.id).collect();
+        assert_eq!(outgoing, vec![100]);
+        assert_eq!(restored.get_outgoing(2).len(), 1);
+    }
+
+    #[test]
+    fn test_mobile_graph_load_missing_file_errors() {
+        let result = MobileGraphStore::load("/nonexistent/velesdb-graph-missing.json".to_string());
+        assert!(result.is_err());
     }
 
     #[test]

--- a/crates/velesdb-node/src/lib.rs
+++ b/crates/velesdb-node/src/lib.rs
@@ -167,7 +167,7 @@ impl MemoryStore {
 
     /// Fused vector + `ColumnStore` recall: like [`recall`](Self::recall) but the
     /// `filters` support ranges/comparisons (`gt`, `le`, …), so temporal/numeric
-    /// facets become queryable. (No `PyO3` counterpart — napi-specific surface.)
+    /// facets become queryable. Mirrors the `PyO3` `recall_where` surface.
     #[napi(
         js_name = "recallWhere",
         ts_return_type = "Promise<Array<RecollectionJs>>"

--- a/crates/velesdb-python/python/velesdb/__init__.py
+++ b/crates/velesdb-python/python/velesdb/__init__.py
@@ -22,6 +22,7 @@ from velesdb.velesdb import (  # type: ignore[attr-defined]
     Database as _RawDatabase,
     DatabaseLockedError,
     DimensionMismatchError,
+    CONDITION_TYPES,
     DISTANCE_METRICS,
     EdgeExistsError,
     FusionStrategy,
@@ -905,6 +906,7 @@ __all__ = [
     "AutoReindexOptions",
     "VelesConfigOptions",
     # Canonical enum name sets, single-sourced from velesdb-core (tuples of str).
+    "CONDITION_TYPES",
     "DISTANCE_METRICS",
     "STORAGE_MODES",
     "embed",

--- a/crates/velesdb-python/src/collection/mod.rs
+++ b/crates/velesdb-python/src/collection/mod.rs
@@ -82,18 +82,65 @@ fn async_builder_from_dict(value: &Bound<'_, PyAny>) -> PyResult<AsyncIndexBuild
 ///
 /// Collections store vectors with optional metadata (payload) and support
 /// efficient similarity search.
+/// Real kind of the core collection behind the single Python `Collection`
+/// facade. Vector-only operations use it to fail loud on graph/metadata
+/// collections instead of silently returning empty results (F2.2).
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CollectionKind {
+    /// HNSW vector collection — supports vector search.
+    Vector,
+    /// Graph collection — edges and optional node embeddings.
+    Graph,
+    /// Metadata-only collection — payload/VelesQL, no vector search.
+    Metadata,
+}
+
+impl CollectionKind {
+    /// Human-readable label used in error messages.
+    fn label(self) -> &'static str {
+        match self {
+            Self::Vector => "vector",
+            Self::Graph => "graph",
+            Self::Metadata => "metadata",
+        }
+    }
+}
+
 #[pyclass]
 pub struct Collection {
     /// Core collection (cheap to clone — all fields are `Arc`-wrapped internally).
     pub(crate) inner: CoreCollection,
     /// Cached name to avoid acquiring `config` read lock on every `#[getter]` access.
     pub(crate) name: String,
+    /// Real kind of the wrapped collection; guards vector-only methods.
+    pub(crate) kind: CollectionKind,
 }
 
 impl Collection {
-    /// Create a new Collection wrapper.
+    /// Create a wrapper for a vector collection.
     pub fn new(inner: CoreCollection, name: String) -> Self {
-        Self { inner, name }
+        Self::new_with_kind(inner, name, CollectionKind::Vector)
+    }
+
+    /// Create a wrapper for a collection whose real kind may not be vector
+    /// (graph/metadata), so vector-only methods fail loud rather than returning
+    /// empty results (F2.2).
+    pub(crate) fn new_with_kind(inner: CoreCollection, name: String, kind: CollectionKind) -> Self {
+        Self { inner, name, kind }
+    }
+
+    /// Rejects a vector-only operation on a non-vector collection with a clear,
+    /// actionable error instead of the silent empty result of F2.2.
+    fn ensure_vector(&self) -> PyResult<()> {
+        if self.kind == CollectionKind::Vector {
+            return Ok(());
+        }
+        Err(pyo3::exceptions::PyValueError::new_err(format!(
+            "vector search is not supported on the {} collection '{}'; \
+             use execute_query() for VelesQL or the graph API instead",
+            self.kind.label(),
+            self.name
+        )))
     }
 
     /// Dispatch to the correct search path based on which arguments are present.
@@ -111,6 +158,10 @@ impl Collection {
     ) -> PyResult<Vec<SearchResult>> {
         use crate::collection_helpers::core_err;
         use pyo3::exceptions::PyValueError;
+
+        // F2.2: vector search on a graph/metadata collection must fail loud,
+        // not return an empty list.
+        self.ensure_vector()?;
 
         let index_name =
             sparse_index_name.unwrap_or(velesdb_core::sparse_index::DEFAULT_SPARSE_INDEX_NAME);

--- a/crates/velesdb-python/src/collection/scroll.rs
+++ b/crates/velesdb-python/src/collection/scroll.rs
@@ -136,6 +136,35 @@ impl Collection {
             exhausted: false,
         })
     }
+
+    /// Fetch one batch of points starting after `cursor` (O(1) cursor seek).
+    ///
+    /// Returns ``(points, next_cursor)``: the batch as a list of dicts and the
+    /// cursor to pass on the next call (``None`` once the batch is the last).
+    /// Unlike the [`scroll`](Self::scroll) generator this is a stateless
+    /// one-shot for callers that persist the cursor themselves (e.g.
+    /// ``velesdb_common.scroll``), avoiding an O(n) re-scan per page.
+    #[pyo3(signature = (cursor=None, batch_size=100, filter=None))]
+    fn scroll_batch(
+        &self,
+        py: Python<'_>,
+        cursor: Option<u64>,
+        batch_size: usize,
+        filter: Option<Py<PyAny>>,
+    ) -> PyResult<(Vec<Py<PyAny>>, Option<u64>)> {
+        if batch_size == 0 {
+            return Err(PyValueError::new_err("batch_size must be greater than 0"));
+        }
+
+        let parsed_filter = parse_optional_filter(py, filter)?;
+        let inner = self.inner.clone();
+        let batch = py
+            .detach(move || inner.scroll_batch(cursor, batch_size, parsed_filter.as_ref()))
+            .map_err(core_err)?;
+
+        let dicts: Vec<Py<PyAny>> = batch.points.iter().map(|p| point_to_dict(py, p)).collect();
+        Ok((dicts, batch.next_cursor))
+    }
 }
 
 /// Eagerly validate that the requested DataFrame backend is importable.

--- a/crates/velesdb-python/src/collection/search.rs
+++ b/crates/velesdb-python/src/collection/search.rs
@@ -245,7 +245,9 @@ impl Collection {
         top_k: usize,
         filter: Option<Py<PyAny>>,
     ) -> PyResult<Vec<Py<PyAny>>> {
-        self.ensure_vector()?;
+        // No ensure_vector() here: BM25 text_search operates on the text index
+        // and takes no query vector, so it is valid on metadata/graph collections
+        // that carry text fields — unlike the vector-only search paths.
         let filter_obj = parse_optional_filter(py, filter)?;
         let query_owned = query.to_string();
 

--- a/crates/velesdb-python/src/collection/search.rs
+++ b/crates/velesdb-python/src/collection/search.rs
@@ -149,6 +149,7 @@ impl Collection {
         top_k: usize,
         ef_search: usize,
     ) -> PyResult<Vec<Py<PyAny>>> {
+        self.ensure_vector()?;
         let query_vector = extract_vector(py, &vector)?;
 
         let results = py.detach(|| {
@@ -176,6 +177,7 @@ impl Collection {
         quality: &str,
         top_k: usize,
     ) -> PyResult<Vec<Py<PyAny>>> {
+        self.ensure_vector()?;
         let query_vector = extract_vector(py, &vector)?;
         let sq = parse_search_quality(quality)?;
 
@@ -196,6 +198,7 @@ impl Collection {
         vector: Py<PyAny>,
         top_k: usize,
     ) -> PyResult<Vec<Py<PyAny>>> {
+        self.ensure_vector()?;
         let query_vector = extract_vector(py, &vector)?;
 
         let results = py.detach(|| {
@@ -217,6 +220,7 @@ impl Collection {
         top_k: usize,
         filter: Option<Py<PyAny>>,
     ) -> PyResult<Vec<Py<PyAny>>> {
+        self.ensure_vector()?;
         let query_vector = extract_vector(py, &vector)?;
         let filter_obj = filter
             .map(|f| parse_filter(py, &f))
@@ -241,6 +245,7 @@ impl Collection {
         top_k: usize,
         filter: Option<Py<PyAny>>,
     ) -> PyResult<Vec<Py<PyAny>>> {
+        self.ensure_vector()?;
         let filter_obj = parse_optional_filter(py, filter)?;
         let query_owned = query.to_string();
 
@@ -270,6 +275,7 @@ impl Collection {
         vector_weight: f32,
         filter: Option<Py<PyAny>>,
     ) -> PyResult<Vec<Py<PyAny>>> {
+        self.ensure_vector()?;
         let query_vector = extract_vector(py, &vector)?;
         let filter_obj = parse_optional_filter(py, filter)?;
         let query_owned = query.to_string();
@@ -307,6 +313,7 @@ impl Collection {
         py: Python<'_>,
         searches: Vec<HashMap<String, Py<PyAny>>>,
     ) -> PyResult<Vec<Vec<Py<PyAny>>>> {
+        self.ensure_vector()?;
         let parsed = Self::parse_batch_searches(py, &searches)?;
 
         let results = py.detach(|| self.dispatch_batch_by_top_k(&parsed))?;
@@ -324,6 +331,7 @@ impl Collection {
         fusion: Option<FusionStrategy>,
         filter: Option<Py<PyAny>>,
     ) -> PyResult<Vec<Py<PyAny>>> {
+        self.ensure_vector()?;
         let query_vectors: Vec<Vec<f32>> = vectors
             .iter()
             .map(|v| extract_vector(py, v))
@@ -360,6 +368,7 @@ impl Collection {
         vectors: Vec<Py<PyAny>>,
         top_k: usize,
     ) -> PyResult<Vec<Vec<Py<PyAny>>>> {
+        self.ensure_vector()?;
         let query_vectors: Vec<Vec<f32>> = vectors
             .iter()
             .map(|v| extract_vector(py, v))
@@ -384,6 +393,7 @@ impl Collection {
         top_k: usize,
         fusion: Option<FusionStrategy>,
     ) -> PyResult<Vec<Py<PyAny>>> {
+        self.ensure_vector()?;
         let query_vectors: Vec<Vec<f32>> = vectors
             .iter()
             .map(|v| extract_vector(py, v))

--- a/crates/velesdb-python/src/database.rs
+++ b/crates/velesdb-python/src/database.rs
@@ -6,7 +6,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use crate::agent;
-use crate::collection::Collection;
+use crate::collection::{Collection, CollectionKind};
 use crate::collection_helpers::core_err;
 use crate::graph_collection::{PyGraphCollection, PyGraphSchema};
 use crate::observer::PyObserver;
@@ -334,20 +334,23 @@ impl Database {
     fn get_collection(&self, name: &str) -> PyResult<Option<Collection>> {
         match self.inner.get_any_collection(name) {
             Some(any_coll) => {
-                // F2.2 mitigation: Python SDK exposes a single Collection
-                // type. Invoking vector-specific methods on a graph or
-                // metadata collection returns empty results rather than
-                // raising — the typed split is tracked as a post-seed
-                // EPIC in docs/ARCHITECTURE.md.
-                //
-                // SAFETY: Python SDK exposes a single Collection facade over all variants.
-                // - any_coll comes from `get_any_collection`, returned Some, so the
-                //   underlying `AnyCollection` is registered and valid.
-                // - Only the shared surface is guaranteed correct on non-Vector variants;
-                //   vector-only methods return empty results by design.
-                // Reason: single-Collection Python ergonomic facade.
+                // The Python SDK exposes a single `Collection` facade over all
+                // variants. Capture the real kind so vector-only methods fail
+                // loud on graph/metadata collections (F2.2) instead of silently
+                // returning empty results.
+                let kind = if any_coll.is_graph() {
+                    CollectionKind::Graph
+                } else if any_coll.is_metadata() {
+                    CollectionKind::Metadata
+                } else {
+                    CollectionKind::Vector
+                };
+                // SAFETY: `any_coll` came from `get_any_collection` (Some), so the
+                // underlying `AnyCollection` is registered and valid. The coerced
+                // vector facade only exercises the shared surface for non-Vector
+                // kinds; `Collection::ensure_vector` rejects vector-only ops.
                 let vc = unsafe { any_coll.into_vector_unchecked() };
-                Ok(Some(Collection::new(vc, name.to_string())))
+                Ok(Some(Collection::new_with_kind(vc, name.to_string(), kind)))
             }
             None => Ok(None),
         }
@@ -431,7 +434,11 @@ impl Database {
         // Reason: single-Collection Python ergonomic facade.
         let collection = unsafe { any.into_vector_unchecked() };
 
-        Ok(Collection::new(collection, name_owned))
+        Ok(Collection::new_with_kind(
+            collection,
+            name_owned,
+            CollectionKind::Metadata,
+        ))
     }
 
     /// Create an AgentMemory instance for AI agent workflows.

--- a/crates/velesdb-python/tests/test_scroll.py
+++ b/crates/velesdb-python/tests/test_scroll.py
@@ -80,6 +80,31 @@ def test_scroll_single_page_yields_full_dataset(temp_db) -> None:
     assert sorted(ids) == [1, 2, 3, 4, 5]
 
 
+def test_scroll_batch_cursor_pagination_covers_all(temp_db) -> None:
+    """Collection.scroll_batch(cursor, batch_size) does a stateless O(1) seek:
+    driving it with the returned cursor covers every point exactly once."""
+    col = temp_db.create_collection("scroll_batch_cursor", dimension=4)
+    _seed(col, 10)
+
+    seen: list[int] = []
+    cursor = None
+    while True:
+        points, cursor = col.scroll_batch(cursor, 3)
+        if not points:
+            break
+        seen.extend(p["id"] for p in points)
+    assert sorted(seen) == list(range(1, 11))
+    assert cursor is None
+
+
+def test_scroll_batch_empty_collection(temp_db) -> None:
+    """scroll_batch on an empty collection returns no points and no cursor."""
+    col = temp_db.create_collection("scroll_batch_empty", dimension=4)
+    points, cursor = col.scroll_batch(None, 10)
+    assert points == []
+    assert cursor is None
+
+
 def test_scroll_multi_page_covers_every_point_once(temp_db) -> None:
     """Multi-page scroll exhausts the collection without duplicates or gaps."""
     col = temp_db.create_collection("scroll_multi", dimension=4)

--- a/crates/velesdb-python/tests/test_velesdb.py
+++ b/crates/velesdb-python/tests/test_velesdb.py
@@ -699,6 +699,22 @@ class TestMetadataOnlyCollections:
         assert collection.name == "products"
         assert collection.is_metadata_only()
 
+    def test_search_on_metadata_collection_raises(self, temp_db):
+        """F2.2: vector search on a metadata collection fails loud (raises),
+        instead of silently returning an empty list."""
+        collection = temp_db.create_metadata_collection("catalog_f22")
+        collection.upsert_metadata([{"id": 1, "payload": {"name": "Widget"}}])
+        with pytest.raises(ValueError):
+            collection.search([1.0, 0.0, 0.0, 0.0], top_k=2)
+
+    def test_search_on_metadata_via_get_collection_raises(self, temp_db):
+        """F2.2: the same guard applies when the metadata collection is
+        re-fetched through the generic get_collection() facade."""
+        temp_db.create_metadata_collection("catalog_f22b")
+        collection = temp_db.get_collection("catalog_f22b")
+        with pytest.raises(ValueError):
+            collection.search([1.0, 0.0, 0.0, 0.0], top_k=2)
+
     def test_metadata_collection_info(self, temp_db):
         """Test metadata-only collection info."""
         collection = temp_db.create_metadata_collection("catalog")

--- a/crates/velesdb-server/src/handlers/search/batch.rs
+++ b/crates/velesdb-server/src/handlers/search/batch.rs
@@ -34,7 +34,6 @@ use crate::handlers::helpers::{
         (status = 400, description = "Invalid request", body = ErrorResponse)
     )
 )]
-#[allow(clippy::unused_async)]
 pub async fn batch_search(
     State(state): State<Arc<AppState>>,
     headers: axum::http::HeaderMap,
@@ -72,10 +71,35 @@ pub async fn batch_search(
         }
     };
 
-    let queries: Vec<&[f32]> = req.searches.iter().map(|s| s.vector.as_slice()).collect();
+    // F-01 sweep: batch search is CPU-bound (one HNSW pass per query) and must
+    // not run on the async runtime thread — a large batch would otherwise block
+    // a Tokio worker and starve concurrent requests. Move it to a blocking
+    // worker like the other search endpoints. `spawn_blocking` needs a 'static
+    // closure, so owned query vectors + filters are moved in and the `&[f32]`
+    // views are rebuilt inside.
+    let collection_for_work = collection.clone();
+    let query_vectors: Vec<Vec<f32>> = req.searches.iter().map(|s| s.vector.clone()).collect();
     let max_top_k = req.searches.iter().map(|s| s.top_k).max().unwrap_or(10);
 
-    let batch_result = run_batch_search(&collection, &queries, max_top_k, &filters);
+    let batch_result = match tokio::task::spawn_blocking(move || {
+        let queries: Vec<&[f32]> = query_vectors.iter().map(Vec::as_slice).collect();
+        run_batch_search(&collection_for_work, &queries, max_top_k, &filters)
+    })
+    .await
+    {
+        Ok(inner) => inner,
+        Err(_) => {
+            state.operational_metrics.inc_errors();
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse {
+                    error: "Batch search worker failed".to_string(),
+                    code: None,
+                }),
+            )
+                .into_response();
+        }
+    };
     record_circuit_breaker(&collection, &batch_result);
 
     let all_results = match batch_result {

--- a/crates/velesdb-wasm/src/agent.rs
+++ b/crates/velesdb-wasm/src/agent.rs
@@ -28,11 +28,11 @@ pub struct SemanticResult {
 ///
 /// # Durability
 ///
-/// **In-memory only.** The WASM crate has no `persistence` feature. The
-/// `VectorStore` binary format used by `export_to_bytes`/`save`/`load` does
-/// **not** serialize payloads, so fact content does **not** survive a
-/// store reload. Persist content out-of-band (e.g. in application state or
-/// IndexedDB) if durability is required.
+/// **Not auto-persisted.** The WASM crate has no `persistence` feature, but the
+/// `VectorStore` binary format (`export_to_bytes`/`save`/`load`, v2) **does**
+/// serialize payloads, so fact content **survives** an explicit `save()` →
+/// `load()` roundtrip. Call `save()` (e.g. to IndexedDB) to keep state across
+/// reloads; nothing is written automatically.
 ///
 /// # Example (JavaScript)
 ///

--- a/crates/velesdb-wasm/src/serialization.rs
+++ b/crates/velesdb-wasm/src/serialization.rs
@@ -34,7 +34,9 @@ fn byte_to_mode(byte: u8) -> Result<StorageMode, JsValue> {
         2 => Ok(StorageMode::Binary),
         3 => Ok(StorageMode::ProductQuantization),
         4 => Ok(StorageMode::RaBitQ),
-        _ => Err(JsValue::from_str(&format!("Invalid storage-mode byte: {byte}"))),
+        _ => Err(JsValue::from_str(&format!(
+            "Invalid storage-mode byte: {byte}"
+        ))),
     }
 }
 
@@ -78,7 +80,11 @@ pub fn export_to_bytes(store: &VectorStore) -> Vec<u8> {
     let mut bytes = Vec::new();
     bytes.extend_from_slice(b"VELS");
     bytes.push(FORMAT_VERSION);
-    bytes.extend_from_slice(&u32::try_from(store.dimension).unwrap_or(u32::MAX).to_le_bytes());
+    bytes.extend_from_slice(
+        &u32::try_from(store.dimension)
+            .unwrap_or(u32::MAX)
+            .to_le_bytes(),
+    );
     bytes.push(metric_to_byte(store.metric));
     bytes.push(mode_to_byte(store.storage_mode));
     bytes.extend_from_slice(&(store.ids.len() as u64).to_le_bytes());
@@ -125,7 +131,9 @@ fn read_blob<'a>(bytes: &'a [u8], offset: &mut usize) -> Result<&'a [u8], JsValu
 fn read_f32_blob(bytes: &[u8], offset: &mut usize) -> Result<Vec<f32>, JsValue> {
     let blob = read_blob(bytes, offset)?;
     if blob.len() % 4 != 0 {
-        return Err(JsValue::from_str("Invalid data: f32 blob not 4-byte aligned"));
+        return Err(JsValue::from_str(
+            "Invalid data: f32 blob not 4-byte aligned",
+        ));
     }
     Ok(blob
         .chunks_exact(4)

--- a/crates/velesdb-wasm/src/serialization.rs
+++ b/crates/velesdb-wasm/src/serialization.rs
@@ -5,83 +5,218 @@
 use crate::{DistanceMetric, StorageMode, VectorStore};
 use wasm_bindgen::JsValue;
 
-/// Binary format header size.
+/// v1 header size (magic4 + version1 + dim4 + metric1 + count8). v1 stored only
+/// id + f32 vectors (Full mode); kept for reading legacy data.
 pub const HEADER_SIZE: usize = 18;
 
-/// Serializes a `VectorStore` to binary format.
-///
-/// Format:
-/// - Magic: "VELS" (4 bytes)
-/// - Version: 1 (1 byte)
-/// - Dimension: u32 LE (4 bytes)
-/// - Metric: u8 (1 byte)
-/// - Count: u64 LE (8 bytes)
-/// - Data: [id: u64, vector: f32 * dim] * count
-pub fn export_to_bytes(store: &VectorStore) -> Vec<u8> {
-    let count = store.ids.len();
-    let vector_size = 8 + store.dimension * 4;
-    let total_size = HEADER_SIZE + count * vector_size;
-    let mut bytes = Vec::with_capacity(total_size);
+/// v2 header size — v1 plus a storage-mode byte.
+const HEADER_SIZE_V2: usize = 19;
 
-    // Header: magic number "VELS"
-    bytes.extend_from_slice(b"VELS");
+/// Current format version written by [`export_to_bytes`].
+const FORMAT_VERSION: u8 = 2;
 
-    // Version
-    bytes.push(1);
-
-    // Dimension
-    let Ok(dim_u32) = u32::try_from(store.dimension) else {
-        return Vec::new();
-    };
-    bytes.extend_from_slice(&dim_u32.to_le_bytes());
-
-    // Metric
-    let metric_byte = metric_to_byte(store.metric);
-    bytes.push(metric_byte);
-
-    // Vector count
-    let Ok(count_u64) = u64::try_from(count) else {
-        return Vec::new();
-    };
-    bytes.extend_from_slice(&count_u64.to_le_bytes());
-
-    // Data
-    for (idx, &id) in store.ids.iter().enumerate() {
-        bytes.extend_from_slice(&id.to_le_bytes());
-        let start = idx * store.dimension;
-        let data_slice = &store.data[start..start + store.dimension];
-        // SAFETY: [f32] and [u8] share the same memory layout (IEEE 754 binary32).
-        // - `data_slice` is a valid, aligned slice of `f32` owned by `store.data`.
-        // - Length is `dimension * 4` bytes, exactly the byte representation of `dimension` f32 values.
-        // Reason: bulk byte copy avoids per-element serialization for 500+ MB/s throughput.
-        let data_bytes: &[u8] = unsafe {
-            core::slice::from_raw_parts(data_slice.as_ptr().cast::<u8>(), store.dimension * 4)
-        };
-        bytes.extend_from_slice(data_bytes);
+/// Maps a storage mode to its on-disk byte.
+fn mode_to_byte(mode: StorageMode) -> u8 {
+    match mode {
+        StorageMode::Full => 0,
+        StorageMode::SQ8 => 1,
+        StorageMode::Binary => 2,
+        StorageMode::ProductQuantization => 3,
+        StorageMode::RaBitQ => 4,
     }
+}
 
+/// Maps an on-disk byte back to a storage mode.
+fn byte_to_mode(byte: u8) -> Result<StorageMode, JsValue> {
+    match byte {
+        0 => Ok(StorageMode::Full),
+        1 => Ok(StorageMode::SQ8),
+        2 => Ok(StorageMode::Binary),
+        3 => Ok(StorageMode::ProductQuantization),
+        4 => Ok(StorageMode::RaBitQ),
+        _ => Err(JsValue::from_str(&format!("Invalid storage-mode byte: {byte}"))),
+    }
+}
+
+/// Appends a length-prefixed (u64 LE) byte blob.
+fn write_blob(out: &mut Vec<u8>, bytes: &[u8]) {
+    out.extend_from_slice(&(bytes.len() as u64).to_le_bytes());
+    out.extend_from_slice(bytes);
+}
+
+/// Appends a length-prefixed blob of little-endian f32 values.
+fn write_f32_blob(out: &mut Vec<u8>, values: &[f32]) {
+    out.extend_from_slice(&((values.len() as u64) * 4).to_le_bytes());
+    for &v in values {
+        out.extend_from_slice(&v.to_le_bytes());
+    }
+}
+
+/// Appends the payloads section: each entry is a blob — empty for `None`,
+/// otherwise the JSON bytes of the value.
+fn write_payloads(out: &mut Vec<u8>, payloads: &[Option<serde_json::Value>]) {
+    for payload in payloads {
+        match payload {
+            Some(v) => write_blob(out, &serde_json::to_vec(v).unwrap_or_default()),
+            None => write_blob(out, &[]),
+        }
+    }
+}
+
+/// Serializes a `VectorStore` to the v2 binary format.
+///
+/// Layout (little-endian): `"VELS"`(4) | version=2(1) | dimension u32(4) |
+/// metric u8(1) | storage-mode u8(1) | count u64(8), then `count` u64 IDs, then
+/// five length-prefixed blobs (`data` f32, `data_sq8`, `data_binary`,
+/// `sq8_mins` f32, `sq8_scales` f32), then `count` payload blobs (empty = None).
+///
+/// Unlike v1 (id + f32 only, Full mode), v2 preserves the storage mode, the
+/// quantized buffers and the payloads, and never panics on a quantized store
+/// (v1 indexed the empty `data` buffer in SQ8/Binary mode). The sparse index is
+/// not persisted (rebuilt on demand), as in v1.
+pub fn export_to_bytes(store: &VectorStore) -> Vec<u8> {
+    let mut bytes = Vec::new();
+    bytes.extend_from_slice(b"VELS");
+    bytes.push(FORMAT_VERSION);
+    bytes.extend_from_slice(&u32::try_from(store.dimension).unwrap_or(u32::MAX).to_le_bytes());
+    bytes.push(metric_to_byte(store.metric));
+    bytes.push(mode_to_byte(store.storage_mode));
+    bytes.extend_from_slice(&(store.ids.len() as u64).to_le_bytes());
+
+    for &id in &store.ids {
+        bytes.extend_from_slice(&id.to_le_bytes());
+    }
+    write_f32_blob(&mut bytes, &store.data);
+    write_blob(&mut bytes, &store.data_sq8);
+    write_blob(&mut bytes, &store.data_binary);
+    write_f32_blob(&mut bytes, &store.sq8_mins);
+    write_f32_blob(&mut bytes, &store.sq8_scales);
+    write_payloads(&mut bytes, &store.payloads);
     bytes
 }
 
-/// Deserializes a `VectorStore` from binary format.
-///
-/// Perf: Uses bulk copy for 500+ MB/s throughput.
+/// Reads a u64 LE at `*offset`, advancing it. Bounds-checked.
+fn read_u64(bytes: &[u8], offset: &mut usize) -> Result<u64, JsValue> {
+    let end = offset
+        .checked_add(8)
+        .filter(|&e| e <= bytes.len())
+        .ok_or_else(|| JsValue::from_str("Invalid data: truncated u64"))?;
+    let arr: [u8; 8] = bytes[*offset..end]
+        .try_into()
+        .map_err(|_| JsValue::from_str("Invalid data: u64 slice"))?;
+    *offset = end;
+    Ok(u64::from_le_bytes(arr))
+}
+
+/// Reads a length-prefixed (u64 LE) byte blob, advancing `*offset`. Bounds-checked.
+fn read_blob<'a>(bytes: &'a [u8], offset: &mut usize) -> Result<&'a [u8], JsValue> {
+    let len = usize::try_from(read_u64(bytes, offset)?)
+        .map_err(|_| JsValue::from_str("Invalid data: blob length too large"))?;
+    let end = offset
+        .checked_add(len)
+        .filter(|&e| e <= bytes.len())
+        .ok_or_else(|| JsValue::from_str("Invalid data: blob out of bounds"))?;
+    let slice = &bytes[*offset..end];
+    *offset = end;
+    Ok(slice)
+}
+
+/// Reads a length-prefixed blob and decodes it as little-endian f32 values.
+fn read_f32_blob(bytes: &[u8], offset: &mut usize) -> Result<Vec<f32>, JsValue> {
+    let blob = read_blob(bytes, offset)?;
+    if blob.len() % 4 != 0 {
+        return Err(JsValue::from_str("Invalid data: f32 blob not 4-byte aligned"));
+    }
+    Ok(blob
+        .chunks_exact(4)
+        .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+        .collect())
+}
+
+/// Reads `count` payload blobs (an empty blob decodes to `None`).
+fn read_payloads(
+    bytes: &[u8],
+    offset: &mut usize,
+    count: usize,
+) -> Result<Vec<Option<serde_json::Value>>, JsValue> {
+    let mut payloads = Vec::with_capacity(count);
+    for _ in 0..count {
+        let blob = read_blob(bytes, offset)?;
+        if blob.is_empty() {
+            payloads.push(None);
+        } else {
+            let value = serde_json::from_slice(blob)
+                .map_err(|e| JsValue::from_str(&format!("Invalid payload JSON: {e}")))?;
+            payloads.push(Some(value));
+        }
+    }
+    Ok(payloads)
+}
+
+/// Deserializes a `VectorStore`, dispatching on the format version byte.
 pub fn import_from_bytes(bytes: &[u8]) -> Result<VectorStore, JsValue> {
-    if bytes.len() < HEADER_SIZE {
+    if bytes.len() < 5 {
         return Err(JsValue::from_str("Invalid data: too short"));
     }
-
-    // Check magic
     if &bytes[0..4] != b"VELS" {
         return Err(JsValue::from_str("Invalid data: wrong magic number"));
     }
+    match bytes[4] {
+        1 => import_v1(bytes),
+        2 => import_v2(bytes),
+        v => Err(JsValue::from_str(&format!("Unsupported version: {v}"))),
+    }
+}
 
-    // Check version
-    let version = bytes[4];
-    if version != 1 {
-        return Err(JsValue::from_str(&format!(
-            "Unsupported version: {version}"
-        )));
+/// Reads the v2 format (storage mode, quantized buffers and payloads preserved).
+fn import_v2(bytes: &[u8]) -> Result<VectorStore, JsValue> {
+    if bytes.len() < HEADER_SIZE_V2 {
+        return Err(JsValue::from_str("Invalid data: too short"));
+    }
+    let dimension = u32::from_le_bytes([bytes[5], bytes[6], bytes[7], bytes[8]]) as usize;
+    let metric = byte_to_metric(bytes[9])?;
+    let storage_mode = byte_to_mode(bytes[10])?;
+    let count = usize::try_from(u64::from_le_bytes([
+        bytes[11], bytes[12], bytes[13], bytes[14], bytes[15], bytes[16], bytes[17], bytes[18],
+    ]))
+    .map_err(|_| JsValue::from_str("Invalid data: count too large"))?;
+    let mut offset = HEADER_SIZE_V2;
+    // DoS guard: each ID needs 8 bytes, so `count` cannot exceed the remaining
+    // input — reject before allocating.
+    if count > bytes.len().saturating_sub(offset) / 8 {
+        return Err(JsValue::from_str("Invalid data: count exceeds input size"));
+    }
+
+    let mut ids = Vec::with_capacity(count);
+    for _ in 0..count {
+        ids.push(read_u64(bytes, &mut offset)?);
+    }
+    let data = read_f32_blob(bytes, &mut offset)?;
+    let data_sq8 = read_blob(bytes, &mut offset)?.to_vec();
+    let data_binary = read_blob(bytes, &mut offset)?.to_vec();
+    let sq8_mins = read_f32_blob(bytes, &mut offset)?;
+    let sq8_scales = read_f32_blob(bytes, &mut offset)?;
+    let payloads = read_payloads(bytes, &mut offset, count)?;
+
+    Ok(VectorStore {
+        ids,
+        data,
+        data_sq8,
+        data_binary,
+        sq8_mins,
+        sq8_scales,
+        payloads,
+        dimension,
+        metric,
+        storage_mode,
+        sparse_index: None,
+    })
+}
+
+/// Reads the legacy v1 format (id + f32 vectors only; Full mode, no payloads).
+fn import_v1(bytes: &[u8]) -> Result<VectorStore, JsValue> {
+    if bytes.len() < HEADER_SIZE {
+        return Err(JsValue::from_str("Invalid data: too short"));
     }
 
     // Read dimension
@@ -210,5 +345,82 @@ mod tests {
             let result = byte_to_metric(byte).unwrap();
             assert_eq!(metric, result);
         }
+    }
+
+    #[test]
+    fn test_v2_roundtrip_full_preserves_payloads() {
+        let store = VectorStore {
+            ids: vec![1, 2],
+            data: vec![1.0, 2.0, 3.0, 4.0],
+            data_sq8: Vec::new(),
+            data_binary: Vec::new(),
+            sq8_mins: Vec::new(),
+            sq8_scales: Vec::new(),
+            payloads: vec![Some(serde_json::json!({"k": "v"})), None],
+            dimension: 2,
+            metric: DistanceMetric::Cosine,
+            storage_mode: StorageMode::Full,
+            sparse_index: None,
+        };
+        let restored = import_from_bytes(&export_to_bytes(&store)).unwrap();
+        assert_eq!(restored.ids, vec![1, 2]);
+        assert_eq!(restored.data, vec![1.0, 2.0, 3.0, 4.0]);
+        assert_eq!(
+            mode_to_byte(restored.storage_mode),
+            mode_to_byte(StorageMode::Full)
+        );
+        assert_eq!(restored.payloads[0], Some(serde_json::json!({"k": "v"})));
+        assert_eq!(restored.payloads[1], None);
+    }
+
+    #[test]
+    fn test_v2_roundtrip_sq8_preserves_mode_buffers_payload() {
+        // v1 dropped the SQ8 buffers/mode (reloaded as Full) and all payloads.
+        let store = VectorStore {
+            ids: vec![10],
+            data: Vec::new(),
+            data_sq8: vec![200, 100],
+            data_binary: Vec::new(),
+            sq8_mins: vec![0.5],
+            sq8_scales: vec![0.01],
+            payloads: vec![Some(serde_json::json!({"x": 1}))],
+            dimension: 2,
+            metric: DistanceMetric::Euclidean,
+            storage_mode: StorageMode::SQ8,
+            sparse_index: None,
+        };
+        let restored = import_from_bytes(&export_to_bytes(&store)).unwrap();
+        assert_eq!(
+            mode_to_byte(restored.storage_mode),
+            mode_to_byte(StorageMode::SQ8)
+        );
+        assert_eq!(restored.data_sq8, vec![200, 100]);
+        assert_eq!(restored.sq8_mins, vec![0.5]);
+        assert_eq!(restored.sq8_scales, vec![0.01]);
+        assert_eq!(restored.payloads[0], Some(serde_json::json!({"x": 1})));
+    }
+
+    #[test]
+    fn test_v2_roundtrip_binary_does_not_panic() {
+        // v1 panicked here by indexing the empty `data` buffer in Binary mode.
+        let store = VectorStore {
+            ids: vec![7],
+            data: Vec::new(),
+            data_sq8: Vec::new(),
+            data_binary: vec![0b1010_1010],
+            sq8_mins: Vec::new(),
+            sq8_scales: Vec::new(),
+            payloads: vec![None],
+            dimension: 8,
+            metric: DistanceMetric::Hamming,
+            storage_mode: StorageMode::Binary,
+            sparse_index: None,
+        };
+        let restored = import_from_bytes(&export_to_bytes(&store)).unwrap();
+        assert_eq!(
+            mode_to_byte(restored.storage_mode),
+            mode_to_byte(StorageMode::Binary)
+        );
+        assert_eq!(restored.data_binary, vec![0b1010_1010]);
     }
 }

--- a/integrations/common/README.md
+++ b/integrations/common/README.md
@@ -33,7 +33,7 @@ direct use by end users.
 
 | Export | Type | Description |
 |--------|------|-------------|
-| `CollectionAdminMixin` | class | Mixin providing shared admin operations (`flush`, `get_collection_info`, `is_empty`) |
+| `CollectionAdminMixin` | class | Mixin providing shared admin operations (`create_metadata_collection`, `is_metadata_only`, `train_pq`, `analyze_collection`, `get_collection_stats`) |
 | `GraphOpsBase` | class | Base class for graph query helpers used by both integrations |
 
 **ID helpers**

--- a/integrations/common/pyproject.toml
+++ b/integrations/common/pyproject.toml
@@ -13,7 +13,7 @@ authors = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "velesdb>=1.14.0",
+    "velesdb>=3.8.0",
 ]
 
 [tool.setuptools.packages.find]

--- a/integrations/common/src/velesdb_common/scroll.py
+++ b/integrations/common/src/velesdb_common/scroll.py
@@ -18,24 +18,11 @@ def scroll_one_batch(
     batch_size: int,
     filter: Optional[dict] = None,  # pylint: disable=redefined-builtin  # public API kwarg name, cannot rename without breaking callers
 ) -> tuple:
-    """Pull one batch from a velesdb Collection using its scroll iterator.
+    """Pull one batch from a velesdb Collection by cursor.
 
-    Creates a fresh ``collection.scroll()`` iterator on every call and skips
-    batches until the one past *cursor* is found.
-
-    .. warning::
-        **Complexity: O(page_index * batch_size)** — this function re-scans
-        from the beginning of the collection on each call because the native
-        SDK does not yet expose a cursor-based ``scroll_batch`` method at the
-        Python level (the Rust ``VectorCollection.scroll_batch`` method is
-        internal to the ``ScrollIterator`` PyO3 class).  For large collections
-        with many pages, callers should either:
-
-        * keep the ``ScrollIterator`` alive across calls (use
-          ``collection.scroll(batch_size=N)`` as a Python generator and drive
-          it with ``next()``), or
-        * wait for a future ``Collection.scroll_batch(cursor, batch_size)``
-          Python binding that will provide true O(1) cursor seek.
+    Delegates to ``Collection.scroll_batch(cursor, batch_size, filter)`` (native
+    since velesdb 3.8.0, this package's minimum), which seeks directly to the
+    page after *cursor* — an O(1) seek rather than re-scanning from the start.
 
     Args:
         collection: A ``velesdb.Collection`` instance.
@@ -50,19 +37,9 @@ def scroll_one_batch(
         the last point ID (``int``) or ``None`` when the collection is
         exhausted.
     """
-    scroll_kwargs: dict = {"batch_size": batch_size}
-    if filter is not None:
-        scroll_kwargs["filter"] = filter
-
-    iterator = collection.scroll(**scroll_kwargs)
-    for batch in iterator:
-        if not batch:
-            continue
-        last_id = batch[-1].get("id")
-        if cursor is not None and last_id is not None and last_id <= cursor:
-            continue
-        return batch, (int(last_id) if last_id is not None else None)
-    return [], None
+    # O(1) cursor seek via the native binding (velesdb >= 3.8.0, this package's
+    # minimum). Returns ``(points, next_cursor)`` directly — no re-scan.
+    return collection.scroll_batch(cursor, batch_size, filter)
 
 
 __all__ = ["scroll_one_batch"]

--- a/integrations/haystack/pyproject.toml
+++ b/integrations/haystack/pyproject.toml
@@ -31,8 +31,8 @@ classifiers = [
 requires-python = ">=3.10"
 dependencies = [
     "haystack-ai>=2.0.0",
-    "velesdb>=1.14.0",
-    "velesdb-common>=1.14.0",
+    "velesdb>=3.8.0",
+    "velesdb-common>=3.8.0",
 ]
 
 [project.optional-dependencies]

--- a/integrations/haystack/src/haystack_velesdb/__init__.py
+++ b/integrations/haystack/src/haystack_velesdb/__init__.py
@@ -1,6 +1,7 @@
 """Haystack 2.x DocumentStore integration for VelesDB."""
 
 from haystack_velesdb.document_store import VelesDBDocumentStore
+from haystack_velesdb.retriever import VelesDBEmbeddingRetriever
 
-__all__ = ["VelesDBDocumentStore"]
+__all__ = ["VelesDBDocumentStore", "VelesDBEmbeddingRetriever"]
 __version__ = "3.8.0"

--- a/integrations/haystack/src/haystack_velesdb/retriever.py
+++ b/integrations/haystack/src/haystack_velesdb/retriever.py
@@ -1,0 +1,65 @@
+"""Haystack retriever component backed by a :class:`VelesDBDocumentStore`."""
+
+from typing import Any, Dict, List, Optional
+
+from haystack import component, default_from_dict, default_to_dict
+from haystack.dataclasses import Document
+
+from haystack_velesdb.document_store import VelesDBDocumentStore
+
+
+@component
+class VelesDBEmbeddingRetriever:
+    """Retrieves documents from a :class:`VelesDBDocumentStore` by dense
+    embedding similarity, for use inside a Haystack ``Pipeline``.
+
+    Ships the component the ecosystem expects (like ``QdrantEmbeddingRetriever``)
+    so callers no longer have to hand-roll a ``@component`` wrapper: connect an
+    embedder's ``embedding`` output to this component's ``query_embedding`` input.
+    ``top_k`` / ``filters`` set at construction can be overridden per ``run``.
+    """
+
+    def __init__(
+        self,
+        document_store: VelesDBDocumentStore,
+        top_k: int = 10,
+        filters: Optional[Dict[str, Any]] = None,
+        scale_score: bool = True,
+    ) -> None:
+        self._document_store = document_store
+        self._top_k = top_k
+        self._filters = filters
+        self._scale_score = scale_score
+
+    @component.output_types(documents=List[Document])
+    def run(
+        self,
+        query_embedding: List[float],
+        top_k: Optional[int] = None,
+        filters: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, List[Document]]:
+        """Run dense retrieval for ``query_embedding``."""
+        documents = self._document_store.embedding_retrieval(
+            query_embedding,
+            top_k=self._top_k if top_k is None else top_k,
+            filters=self._filters if filters is None else filters,
+            scale_score=self._scale_score,
+        )
+        return {"documents": documents}
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize the component (and its store) for pipeline persistence."""
+        return default_to_dict(
+            self,
+            document_store=self._document_store.to_dict(),
+            top_k=self._top_k,
+            filters=self._filters,
+            scale_score=self._scale_score,
+        )
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "VelesDBEmbeddingRetriever":
+        """Rebuild the component (and its store) from a serialized pipeline."""
+        store_data = data["init_parameters"]["document_store"]
+        data["init_parameters"]["document_store"] = VelesDBDocumentStore.from_dict(store_data)
+        return default_from_dict(cls, data)

--- a/integrations/haystack/tests/test_real_haystack_integration.py
+++ b/integrations/haystack/tests/test_real_haystack_integration.py
@@ -286,3 +286,34 @@ def test_pipeline_with_decorated_retriever(tmp_path) -> None:
     assert len(docs) == 2
     # Top result should be the closest English doc to the query vector.
     assert docs[0].id == "doc-en-1"
+
+
+def test_shipped_embedding_retriever_component_runs(tmp_path) -> None:
+    """The package now ships VelesDBEmbeddingRetriever, so callers no longer
+    hand-roll a @component wrapper. It runs standalone and inside a Pipeline."""
+    from haystack_velesdb import VelesDBEmbeddingRetriever
+
+    store = _store(tmp_path)
+    store.write_documents(_docs())
+    retriever = VelesDBEmbeddingRetriever(document_store=store, top_k=2)
+
+    out = retriever.run(query_embedding=[1.0, 0.0, 0.0, 0.0])
+    assert [d.id for d in out["documents"]][0] == "doc-en-1"
+
+    pipeline = Pipeline()
+    pipeline.add_component("retriever", retriever)
+    result = pipeline.run({"retriever": {"query_embedding": [1.0, 0.0, 0.0, 0.0]}})
+    assert len(result["retriever"]["documents"]) == 2
+
+
+def test_shipped_embedding_retriever_serialization_roundtrip(tmp_path) -> None:
+    """to_dict/from_dict rebuilds the component and its store for pipeline YAML."""
+    from haystack_velesdb import VelesDBEmbeddingRetriever
+
+    retriever = VelesDBEmbeddingRetriever(
+        document_store=_store(tmp_path), top_k=3, scale_score=False
+    )
+    restored = VelesDBEmbeddingRetriever.from_dict(retriever.to_dict())
+    assert restored._top_k == 3
+    assert restored._scale_score is False
+    assert isinstance(restored._document_store, VelesDBDocumentStore)

--- a/integrations/langchain/pyproject.toml
+++ b/integrations/langchain/pyproject.toml
@@ -29,8 +29,8 @@ classifiers = [
 requires-python = ">=3.10"
 dependencies = [
     "langchain-core>=0.1.0,<2.0.0",
-    "velesdb>=1.14.0",
-    "velesdb-common>=1.14.0",
+    "velesdb>=3.8.0",
+    "velesdb-common>=3.8.0",
 ]
 
 [project.optional-dependencies]

--- a/integrations/langchain/src/langchain_velesdb/vectorstore.py
+++ b/integrations/langchain/src/langchain_velesdb/vectorstore.py
@@ -332,6 +332,10 @@ class VelesDBVectorStore(CollectionAdminMixin, SearchOpsMixin, GraphOpsMixin, Sc
         Returns:
             VelesDBVectorStore instance with texts added.
         """
+        # `ids` belongs to add_texts, not the constructor: pop it out of kwargs
+        # so caller-supplied ids are actually assigned to the points (LangChain
+        # contract) instead of being silently swallowed by **kwargs.
+        ids = kwargs.pop("ids", None)
         vectorstore = cls(
             embedding=embedding,
             path=path,
@@ -339,7 +343,7 @@ class VelesDBVectorStore(CollectionAdminMixin, SearchOpsMixin, GraphOpsMixin, Sc
             metric=metric,
             **kwargs,
         )
-        vectorstore.add_texts(texts, metadatas=metadatas)
+        vectorstore.add_texts(texts, metadatas=metadatas, ids=ids)
         return vectorstore
 
     def as_retriever(self, **kwargs: Any):

--- a/integrations/langchain/tests/test_e2e_velesdb.py
+++ b/integrations/langchain/tests/test_e2e_velesdb.py
@@ -101,6 +101,26 @@ class TestE2EVelesDB:
         assert len(results) == 2
         assert all(isinstance(r, Document) for r in results)
 
+    def test_from_texts_assigns_provided_ids(self, temp_dir, embeddings):
+        """from_texts(ids=...) must assign the caller's ids to the points.
+
+        Regression: `ids` used to fall into **kwargs and be silently dropped,
+        so get_by_ids() on those ids returned nothing.
+        """
+        texts = ["alpha", "beta", "gamma"]
+        ids = ["id-a", "id-b", "id-c"]
+        store = VelesDBVectorStore.from_texts(
+            texts,
+            embeddings,
+            ids=ids,
+            path=temp_dir,
+            collection_name="from_texts_ids",
+            metric="cosine",
+        )
+        fetched = store.get_by_ids(ids)
+        assert len(fetched) == 3
+        assert {d.page_content for d in fetched} == set(texts)
+
     def test_search_with_scores(self, vectorstore):
         """Similarity search returns (Document, score) tuples."""
         vectorstore.add_texts(["alpha", "beta", "gamma"])

--- a/integrations/langgraph/pyproject.toml
+++ b/integrations/langgraph/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 requires-python = ">=3.10"
 dependencies = [
     "langchain-core>=0.3.0,<2.0.0",
-    "velesdb>=3.4.0",
+    "velesdb>=3.8.0",
 ]
 
 [project.optional-dependencies]

--- a/integrations/llamaindex/pyproject.toml
+++ b/integrations/llamaindex/pyproject.toml
@@ -30,8 +30,8 @@ classifiers = [
 
 dependencies = [
     "llama-index-core>=0.10.0,<1.0.0",
-    "velesdb>=1.14.0",
-    "velesdb-common>=1.14.0",
+    "velesdb>=3.8.0",
+    "velesdb-common>=3.8.0",
 ]
 
 [project.optional-dependencies]

--- a/integrations/llamaindex/src/llamaindex_velesdb/vectorstore.py
+++ b/integrations/llamaindex/src/llamaindex_velesdb/vectorstore.py
@@ -65,6 +65,11 @@ logger = logging.getLogger(__name__)
 # defaults to LIMIT 10, far too small for chunked documents).
 _REF_DOC_SCAN_BATCH = 1000
 
+# Metrics for which VelesDB returns a raw distance (lower = closer). LlamaIndex
+# treats `similarities` as higher-is-better, so these are mapped to a bounded,
+# monotonically-decreasing similarity; cosine/dot-product are already similarities.
+_DISTANCE_METRICS = frozenset({"euclidean", "hamming", "jaccard"})
+
 
 class VelesDBVectorStore(CollectionAdminMixin, SearchOpsMixin, GraphOpsMixin, ScrollOpsMixin, BasePydanticVectorStore):
     """VelesDB vector store for LlamaIndex.
@@ -211,17 +216,30 @@ class VelesDBVectorStore(CollectionAdminMixin, SearchOpsMixin, GraphOpsMixin, Sc
         node = cls._node_from_result(result)
         return node, result.get("score", 0.0), node.node_id
 
-    @classmethod
-    def _build_query_result(cls, results: list[dict]) -> VectorStoreQueryResult:
+    def _score_to_similarity(self, score: float) -> float:
+        """Map a raw VelesDB score to a LlamaIndex similarity (higher = closer).
+
+        VelesDB returns a raw *distance* for distance metrics (euclidean, hamming,
+        jaccard — lower is closer) and a *similarity* for cosine/dot-product
+        (higher is closer). LlamaIndex treats ``similarities`` as higher-is-better
+        (``similarity_cutoff``, node postprocessors), so distances are mapped to a
+        bounded, monotonically-decreasing similarity; similarity metrics pass
+        through unchanged.
+        """
+        if self.metric.lower() in _DISTANCE_METRICS:
+            return 1.0 / (1.0 + max(score, 0.0))
+        return score
+
+    def _build_query_result(self, results: list[dict]) -> VectorStoreQueryResult:
         """Build a VectorStoreQueryResult from raw VelesDB result dictionaries."""
         nodes: List[TextNode] = []
         similarities: List[float] = []
         ids: List[str] = []
 
         for result in results:
-            node, score, node_id = cls._result_to_parts(result)
+            node, score, node_id = self._result_to_parts(result)
             nodes.append(node)
-            similarities.append(score)
+            similarities.append(self._score_to_similarity(score))
             ids.append(node_id)
 
         return VectorStoreQueryResult(nodes=nodes, similarities=similarities, ids=ids)
@@ -368,23 +386,16 @@ class VelesDBVectorStore(CollectionAdminMixin, SearchOpsMixin, GraphOpsMixin, Sc
         self, collection: velesdb.Collection, ref_doc_id: str
     ) -> None:
         """Delete every node whose payload ``ref_doc_id`` matches."""
-        from llamaindex_velesdb.security import validate_query
-
-        # NOTE: $ref parameter binding silently matches nothing on published
-        # velesdb wheels <= 1.18.0 (scalar param equality bug, fixed upstream
-        # for 1.19) — this connector must run on published engines, so the
-        # value is escaped (single quotes doubled) and the whole statement is
-        # checked by validate_query. Switch to params once the minimum pin
-        # is >= the first fixed release. Not a SQL engine — VelesQL only,
-        # and collection_name is validated at construction ([a-zA-Z0-9_-]+).
-        escaped = ref_doc_id.replace("'", "''")
+        # Parameter binding ($ref) keeps the user value out of the query text
+        # entirely. It was a no-op on published wheels <= 1.18.0 (scalar-equality
+        # bug); the package now pins velesdb >= 3.8.0 where it works. The only
+        # interpolated token is collection_name, regex-validated at construction.
         query_str = (
-            f"SELECT * FROM {self.collection_name} "  # nosec B608  # identifier regex-validated
-            f"WHERE ref_doc_id = '{escaped}' LIMIT {_REF_DOC_SCAN_BATCH}"  # nosec B608  # value quote-escaped + validate_query'd
+            f"SELECT * FROM {self.collection_name} "  # nosec B608 — identifier regex-validated
+            f"WHERE ref_doc_id = $ref LIMIT {_REF_DOC_SCAN_BATCH}"
         )
-        validate_query(query_str)
         while True:
-            rows = collection.query(query_str)
+            rows = collection.query(query_str, {"ref": ref_doc_id})
             if rows:
                 collection.delete([row["id"] for row in rows])
             if len(rows) < _REF_DOC_SCAN_BATCH:

--- a/integrations/llamaindex/tests/test_e2e_complete.py
+++ b/integrations/llamaindex/tests/test_e2e_complete.py
@@ -75,8 +75,33 @@ class TestVectorStoreE2E:
             similarity_top_k=5,
         )
         results = temp_store.query(query)
-        
+
         assert len(results.nodes) == 5
+
+    def test_euclidean_similarity_is_higher_for_closer_nodes(self):
+        """Euclidean returns a raw distance; the store must expose it as a
+        higher-is-better similarity. Otherwise ``similarity_cutoff`` / node
+        postprocessors would rank the farthest node as the most similar."""
+        temp_dir = tempfile.mkdtemp()
+        try:
+            store = VelesDBVectorStore(
+                path=temp_dir,
+                collection_name="euclid_sim",
+                dimension=3,
+                metric="euclidean",
+            )
+            store.add([
+                TextNode(text="near", id_="near", embedding=[0.0, 0.0, 0.0]),
+                TextNode(text="far", id_="far", embedding=[10.0, 0.0, 0.0]),
+            ])
+            result = store.query(
+                VectorStoreQuery(query_embedding=[0.1, 0.0, 0.0], similarity_top_k=2)
+            )
+            sims = dict(zip(result.ids, result.similarities))
+            assert sims["near"] > sims["far"]
+            assert 0.0 < sims["near"] <= 1.0
+        finally:
+            shutil.rmtree(temp_dir, ignore_errors=True)
 
     def test_add_nodes_with_metadata(self, temp_store):
         """Test adding nodes with metadata."""

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.8.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@wiscale/velesdb-wasm": "^3.0.0"
+        "@wiscale/velesdb-wasm": "^3.8.0"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -1873,9 +1873,9 @@
       }
     },
     "node_modules/@wiscale/velesdb-wasm": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@wiscale/velesdb-wasm/-/velesdb-wasm-3.4.0.tgz",
-      "integrity": "sha512-U/tlOTS1CBS/Pqsfzqde4rMvWCLFlixRK+JQl7gkunjcdA7KP+Z7LpAUxg61AFZkRZVK1OjOcHw9d58J+4QRGw==",
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/@wiscale/velesdb-wasm/-/velesdb-wasm-3.8.0.tgz",
+      "integrity": "sha512-YCoB+y+61pmLhRK9OJABSxGCMk8YATSwXCr35s2mxgqubcAoFgwp76AwcDYcpy5HWPp9PJA4WEJ4iWjAK0tZKg==",
       "license": "SEE LICENSE IN LICENSE"
     },
     "node_modules/acorn": {

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -69,7 +69,7 @@
     "vitest": "^4.0.16"
   },
   "dependencies": {
-    "@wiscale/velesdb-wasm": "^3.0.0"
+    "@wiscale/velesdb-wasm": "^3.8.0"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/sdks/typescript/src/backends/crud-backend.ts
+++ b/sdks/typescript/src/backends/crud-backend.ts
@@ -259,6 +259,23 @@ export async function deletePoint(
   return response.data?.deleted ?? false;
 }
 
+export async function bulkDeletePoints(
+  transport: CrudTransport,
+  collection: string,
+  ids: Array<string | number>
+): Promise<number> {
+  // Server route POST /collections/{name}/points/delete accepts ids as decimal
+  // strings (safe for u64 > 2^53) and returns { deleted_count }.
+  const restIds = ids.map((id) => String(parseRestPointId(id)));
+  const response = await transport.requestJson<{ deleted_count?: number }>(
+    'POST',
+    `${collectionPath(collection)}/points/delete`,
+    { ids: restIds }
+  );
+  throwOnError(response, `Collection '${collection}'`);
+  return response.data?.deleted_count ?? 0;
+}
+
 export async function get(
   transport: CrudTransport,
   collection: string,

--- a/sdks/typescript/src/backends/rest-http.ts
+++ b/sdks/typescript/src/backends/rest-http.ts
@@ -33,6 +33,28 @@ export interface RestHttpConfig {
 const DEFAULT_MAX_RETRIES = 2;
 /** Default exponential-backoff base delay in ms. */
 const DEFAULT_RETRY_BASE_MS = 200;
+/** Hard cap on any single retry wait, so a large `Retry-After` can't hang a request. */
+const MAX_RETRY_DELAY_MS = 20_000;
+
+/** HTTP methods that are idempotent per RFC 9110 (safe to replay). */
+function isIdempotentMethod(method: string): boolean {
+  const m = method.toUpperCase();
+  return m === 'GET' || m === 'HEAD' || m === 'PUT' || m === 'DELETE' || m === 'OPTIONS';
+}
+
+/**
+ * Whether a failed response should be retried for this method.
+ *
+ * `429` means the server rejected the request *before* processing it (rate
+ * limit), so replaying is safe for any method. `503` is ambiguous — the request
+ * may have been partially applied — so it is only retried for idempotent
+ * methods, never for a non-idempotent write like a POST upsert.
+ */
+function shouldRetry(status: number, method: string): boolean {
+  if (status === 429) return true;
+  if (status === 503) return isIdempotentMethod(method);
+  return false;
+}
 
 /** HTTP status → typed error code lookup. */
 const STATUS_ERROR_CODES: Record<number, string> = {
@@ -110,15 +132,17 @@ function sleep(ms: number): Promise<void> {
 /**
  * Compute the backoff delay before retrying a 429/503 response. Honors an
  * integer `Retry-After` header (seconds); otherwise exponential backoff with
- * light jitter.
+ * light jitter. Always capped at `MAX_RETRY_DELAY_MS` so a hostile or huge
+ * `Retry-After` cannot hang a request far past the caller's intent.
  */
 function retryDelayMs(response: Response, attempt: number, baseDelayMs: number): number {
   const retryAfter = response.headers.get('Retry-After');
   if (retryAfter !== null) {
     const secs = Number(retryAfter);
-    if (Number.isFinite(secs) && secs >= 0) return secs * 1000;
+    if (Number.isFinite(secs) && secs >= 0) return Math.min(secs * 1000, MAX_RETRY_DELAY_MS);
   }
-  return baseDelayMs * 2 ** attempt + Math.floor(Math.random() * baseDelayMs);
+  const backoff = baseDelayMs * 2 ** attempt + Math.floor(Math.random() * baseDelayMs);
+  return Math.min(backoff, MAX_RETRY_DELAY_MS);
 }
 
 /** Perform a single HTTP attempt (own timeout); network errors throw. */
@@ -147,10 +171,11 @@ async function attemptFetch(
 /**
  * Execute an HTTP request against the REST API.
  *
- * Retries automatically on 429 (rate limited) and 503 (service unavailable),
- * which the server returns *before* processing the request, so a replay is
- * safe even for writes. Network errors and timeouts are NOT retried (a write
- * may already have been applied). Backoff is exponential, honoring `Retry-After`.
+ * Retries `429` for any method (the server rejected it before processing) and
+ * `503` only for idempotent methods (see {@link shouldRetry}), so a
+ * non-idempotent write is never silently replayed. Network errors and timeouts
+ * are NOT retried (a write may already have been applied). Backoff is
+ * exponential, honoring a capped `Retry-After`.
  */
 export async function request<T>(
   config: RestHttpConfig,
@@ -167,7 +192,7 @@ export async function request<T>(
     if (response.ok) {
       return { data: data as unknown as T };
     }
-    if ((response.status === 429 || response.status === 503) && attempt < maxRetries) {
+    if (shouldRetry(response.status, method) && attempt < maxRetries) {
       await sleep(retryDelayMs(response, attempt, baseDelay));
       continue;
     }

--- a/sdks/typescript/src/backends/rest-http.ts
+++ b/sdks/typescript/src/backends/rest-http.ts
@@ -23,7 +23,16 @@ export interface RestHttpConfig {
   baseUrl: string;
   apiKey?: string;
   timeout: number;
+  /** Max automatic retries on 429/503 backpressure responses (default 2). */
+  maxRetries?: number;
+  /** Base delay in ms for exponential backoff between retries (default 200). */
+  retryBaseDelayMs?: number;
 }
+
+/** Default number of retries on 429/503 when not configured. */
+const DEFAULT_MAX_RETRIES = 2;
+/** Default exponential-backoff base delay in ms. */
+const DEFAULT_RETRY_BASE_MS = 200;
 
 /** HTTP status → typed error code lookup. */
 const STATUS_ERROR_CODES: Record<number, string> = {
@@ -93,37 +102,83 @@ function wrapCatchError(error: unknown): never {
   throw new ConnectionError(`Request failed: ${message}`, cause);
 }
 
-/** Execute an HTTP request against the REST API. */
+/** Promise-based delay used between retries. */
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Compute the backoff delay before retrying a 429/503 response. Honors an
+ * integer `Retry-After` header (seconds); otherwise exponential backoff with
+ * light jitter.
+ */
+function retryDelayMs(response: Response, attempt: number, baseDelayMs: number): number {
+  const retryAfter = response.headers.get('Retry-After');
+  if (retryAfter !== null) {
+    const secs = Number(retryAfter);
+    if (Number.isFinite(secs) && secs >= 0) return secs * 1000;
+  }
+  return baseDelayMs * 2 ** attempt + Math.floor(Math.random() * baseDelayMs);
+}
+
+/** Perform a single HTTP attempt (own timeout); network errors throw. */
+async function attemptFetch(
+  config: RestHttpConfig,
+  method: string,
+  path: string,
+  body?: unknown
+): Promise<Response> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), config.timeout);
+  try {
+    return await fetch(`${config.baseUrl}${path}`, {
+      method,
+      headers: buildHeaders(config),
+      body: body ? JSON.stringify(body) : undefined,
+      signal: controller.signal,
+    });
+  } catch (error) {
+    wrapCatchError(error);
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+/**
+ * Execute an HTTP request against the REST API.
+ *
+ * Retries automatically on 429 (rate limited) and 503 (service unavailable),
+ * which the server returns *before* processing the request, so a replay is
+ * safe even for writes. Network errors and timeouts are NOT retried (a write
+ * may already have been applied). Backoff is exponential, honoring `Retry-After`.
+ */
 export async function request<T>(
   config: RestHttpConfig,
   method: string,
   path: string,
   body?: unknown
 ): Promise<TransportResponse<T>> {
-  const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), config.timeout);
+  const maxRetries = config.maxRetries ?? DEFAULT_MAX_RETRIES;
+  const baseDelay = config.retryBaseDelayMs ?? DEFAULT_RETRY_BASE_MS;
 
-  try {
-    const response = await fetch(`${config.baseUrl}${path}`, {
-      method,
-      headers: buildHeaders(config),
-      body: body ? JSON.stringify(body) : undefined,
-      signal: controller.signal,
-    });
-    clearTimeout(timeoutId);
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    const response = await attemptFetch(config, method, path, body);
     const data = await safeJsonParse(response);
-    if (!response.ok) {
-      const ep = extractErrorPayload(data);
-      return { error: {
-        code: ep.code ?? mapStatusToErrorCode(response.status),
-        message: ep.message ?? `HTTP ${response.status}`,
-      }};
+    if (response.ok) {
+      return { data: data as unknown as T };
     }
-    return { data: data as unknown as T };
-  } catch (error) {
-    clearTimeout(timeoutId);
-    wrapCatchError(error);
+    if ((response.status === 429 || response.status === 503) && attempt < maxRetries) {
+      await sleep(retryDelayMs(response, attempt, baseDelay));
+      continue;
+    }
+    const ep = extractErrorPayload(data);
+    return { error: {
+      code: ep.code ?? mapStatusToErrorCode(response.status),
+      message: ep.message ?? `HTTP ${response.status}`,
+    }};
   }
+  // Unreachable: the final iteration always returns (retry guard is attempt < maxRetries).
+  throw new ConnectionError('Request failed: retries exhausted');
 }
 
 // ============================================================================

--- a/sdks/typescript/src/backends/rest.ts
+++ b/sdks/typescript/src/backends/rest.ts
@@ -123,7 +123,7 @@ import {
   createCollection as _createCollection, deleteCollection as _deleteCollection,
   getCollection as _getCollection, listCollections as _listCollections,
   upsert as _upsert, upsertBatch as _upsertBatch, upsertBatchRaw as _upsertBatchRaw,
-  deletePoint as _deletePoint, get as _get, isEmpty as _isEmpty, flush as _flush,
+  deletePoint as _deletePoint, bulkDeletePoints as _bulkDeletePoints, get as _get, isEmpty as _isEmpty, flush as _flush,
 } from './crud-backend';
 
 // Re-export for backward compatibility
@@ -174,6 +174,7 @@ export class RestBackend implements IVelesDBBackend {
   async upsertBatch(c: string, d: VectorDocument[]): Promise<void> { this.ensureInitialized(); return _upsertBatch(buildCrudTransport(this.httpConfig), c, d); }
   async upsertBatchRaw(c: string, d: VectorDocument[]): Promise<number> { this.ensureInitialized(); return _upsertBatchRaw(buildRawBulkTransport(this.httpConfig), c, d, d[0]?.vector.length ?? 0); }
   async delete(c: string, id: string | number): Promise<boolean> { this.ensureInitialized(); return _deletePoint(buildCrudTransport(this.httpConfig), c, id); }
+  async bulkDelete(c: string, ids: Array<string | number>): Promise<number> { this.ensureInitialized(); return _bulkDeletePoints(buildCrudTransport(this.httpConfig), c, ids); }
   async get(c: string, id: string | number): Promise<VectorDocument | null> { this.ensureInitialized(); return _get(buildCrudTransport(this.httpConfig), c, id); }
   async isEmpty(c: string): Promise<boolean> { this.ensureInitialized(); return _isEmpty(buildCrudTransport(this.httpConfig), c); }
   async flush(c: string): Promise<void> { this.ensureInitialized(); return _flush(buildCrudTransport(this.httpConfig), c); }

--- a/sdks/typescript/src/backends/wasm.ts
+++ b/sdks/typescript/src/backends/wasm.ts
@@ -339,6 +339,18 @@ export class WasmBackend implements IVelesDBBackend {
     return removed;
   }
 
+  async bulkDelete(collectionName: string, ids: Array<string | number>): Promise<number> {
+    this.ensureInitialized();
+    const collection = this.collections.get(collectionName);
+    if (!collection) { throw new NotFoundError(`Collection '${collectionName}'`); }
+    let count = 0;
+    for (const id of ids) {
+      const removed = collection.store.remove(BigInt(toNumericId(id)));
+      if (removed) { collection.payloads.delete(canonicalPayloadKey(id)); count += 1; }
+    }
+    return count;
+  }
+
   async get(collectionName: string, id: string | number): Promise<VectorDocument | null> {
     this.ensureInitialized();
     const collection = this.collections.get(collectionName);

--- a/sdks/typescript/src/client.ts
+++ b/sdks/typescript/src/client.ts
@@ -209,6 +209,12 @@ export class VelesDB {
     return this.backend.delete(collection, id);
   }
 
+  async bulkDelete(collection: string, ids: Array<string | number>): Promise<number> {
+    this.ensureInitialized();
+    for (const id of ids) { validateRestPointId(id, this.config); }
+    return this.backend.bulkDelete(collection, ids);
+  }
+
   async get(collection: string, id: string | number): Promise<VectorDocument | null> {
     this.ensureInitialized();
     validateRestPointId(id, this.config);

--- a/sdks/typescript/src/types/backend.ts
+++ b/sdks/typescript/src/types/backend.ts
@@ -126,6 +126,9 @@ export interface IVelesDBBackend {
   /** Delete a vector by ID */
   delete(collection: string, id: string | number): Promise<boolean>;
 
+  /** Delete multiple vectors by ID in one request; returns the deleted count. */
+  bulkDelete(collection: string, ids: Array<string | number>): Promise<number>;
+
   /** Get a vector by ID */
   get(collection: string, id: string | number): Promise<VectorDocument | null>;
 

--- a/sdks/typescript/tests/rest-backend.test.ts
+++ b/sdks/typescript/tests/rest-backend.test.ts
@@ -103,6 +103,24 @@ describe('RestBackend', () => {
       expect(col?.dimension).toBe(128);
     });
 
+    it('should bulk delete points via POST points/delete', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ deleted_count: 2 }),
+      });
+
+      const count = await backend.bulkDelete('docs', [5, 42]);
+
+      expect(count).toBe(2);
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:8080/collections/docs/points/delete',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({ ids: ['5', '42'] }),
+        })
+      );
+    });
+
     it('should return null for non-existent collection (typed VELES-002)', async () => {
       // Modern server emits the VELES-002 code verbatim via
       // `core_error_response`; the transport layer recognises

--- a/sdks/typescript/tests/rest-http.test.ts
+++ b/sdks/typescript/tests/rest-http.test.ts
@@ -218,10 +218,64 @@ describe('request — error responses', () => {
       json: () => Promise.reject(new Error('bad json')),
     });
 
-    const result = await request(config, 'GET', '/x');
+    // maxRetries: 0 isolates the invalid-JSON tolerance from the retry path
+    // (503 is otherwise retried); this test only asserts the parse fallback.
+    const result = await request({ ...config, maxRetries: 0 }, 'GET', '/x');
     expect(result).toEqual({
       error: { code: 'SERVICE_UNAVAILABLE', message: 'HTTP 503' },
     });
+  });
+});
+
+describe('request — retry on backpressure (429/503)', () => {
+  beforeEach(() => vi.clearAllMocks());
+  const fast: RestHttpConfig = { ...config, retryBaseDelayMs: 0 };
+
+  const okResponse = (data: unknown) => ({
+    ok: true,
+    status: 200,
+    headers: { get: () => null },
+    json: () => Promise.resolve(data),
+  });
+  const errResponse = (status: number, retryAfter: string | null = null) => ({
+    ok: false,
+    status,
+    headers: { get: (h: string) => (h === 'Retry-After' ? retryAfter : null) },
+    json: () => Promise.resolve({}),
+  });
+
+  it('retries a 503 then returns the successful response', async () => {
+    mockFetch
+      .mockResolvedValueOnce(errResponse(503))
+      .mockResolvedValueOnce(okResponse({ ok: 1 }));
+    const result = await request<{ ok: number }>(fast, 'GET', '/x');
+    expect(result).toEqual({ data: { ok: 1 } });
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('retries a 429 honoring Retry-After, then succeeds', async () => {
+    mockFetch
+      .mockResolvedValueOnce(errResponse(429, '0'))
+      .mockResolvedValueOnce(okResponse({ ok: 1 }));
+    const result = await request<{ ok: number }>(fast, 'GET', '/x');
+    expect(result).toEqual({ data: { ok: 1 } });
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns the error after exhausting retries', async () => {
+    mockFetch.mockResolvedValue(errResponse(503));
+    const result = await request(fast, 'GET', '/x');
+    expect(result).toEqual({
+      error: { code: 'SERVICE_UNAVAILABLE', message: 'HTTP 503' },
+    });
+    expect(mockFetch).toHaveBeenCalledTimes(3); // initial + 2 retries
+  });
+
+  it('does not retry a non-backpressure error (400)', async () => {
+    mockFetch.mockResolvedValue(errResponse(400));
+    const result = await request(fast, 'GET', '/x');
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect((result as { error: { code: string } }).error.code).toBe('BAD_REQUEST');
   });
 });
 

--- a/sdks/typescript/tests/rest-http.test.ts
+++ b/sdks/typescript/tests/rest-http.test.ts
@@ -277,6 +277,22 @@ describe('request — retry on backpressure (429/503)', () => {
     expect(mockFetch).toHaveBeenCalledTimes(1);
     expect((result as { error: { code: string } }).error.code).toBe('BAD_REQUEST');
   });
+
+  it('does NOT retry a 503 on a non-idempotent POST (avoids double-write)', async () => {
+    mockFetch.mockResolvedValue(errResponse(503));
+    const result = await request(fast, 'POST', '/x', { a: 1 });
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect((result as { error: { code: string } }).error.code).toBe('SERVICE_UNAVAILABLE');
+  });
+
+  it('does retry a 429 on a POST (server rejected it before processing)', async () => {
+    mockFetch
+      .mockResolvedValueOnce(errResponse(429, '0'))
+      .mockResolvedValueOnce(okResponse({ ok: 1 }));
+    const result = await request<{ ok: number }>(fast, 'POST', '/x', { a: 1 });
+    expect(result).toEqual({ data: { ok: 1 } });
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
 });
 
 describe('request — connection errors', () => {


### PR DESCRIPTION
## Audit remediation — temps 1

Fixes surfaced by the full crate/integration health audit (all 10 crates + 5 Python integrations + TS SDK). Every change is verified against the project's real gates (clippy pedantic `-D warnings`, single-threaded tests, per-language suites) and holds to clean architecture (dependency direction children→core, thin layers, fail-loud, CC≤8 / NLOC≤50 / no duplication).

### P0 — correctness / data-loss / panic
- **`fix(storage)` compaction now works on Windows** — two distinct Windows-only root causes: `atomic_replace` renamed the still-mmapped `vectors.dat` (ACCESS_DENIED), and the WAL was truncated via `set_len(0)` on an append-only handle (no `FILE_WRITE_DATA`). Release the mapping via an anonymous placeholder before the swap; truncate the WAL through a dedicated write handle. Remap runs even on commit failure. **Verified:** compaction suite 36/0, full `velesdb-core` suite 6171/0, clippy pedantic.
- **`fix(storage)` durable compaction rename before WAL truncation** — `sync_dir` was a no-op on non-Unix; now the index sidecar is fsynced and the data-file rename is ordered via the NTFS `$LogFile` invariant.
- **`fix(python)` fail loud on vector search over graph/metadata collections (F2.2)** — the single `Collection` facade returned `[]` on non-vector collections instead of raising. Carry the real `CollectionKind`; one `ensure_vector()` guard on all 12 vector-only entry points. **Verified:** full `velesdb-python` suite 435/0, clippy pedantic.
- **`fix(wasm)` persist storage mode, quantized buffers and payloads (v2 format)** — v1 stored only id+f32, panicked on SQ8/Binary and dropped payloads/mode. Versioned v2 format (length-prefixed blobs, safe, DoS-guarded, v1 back-compat read). **Verified:** wasm lib suite 610/0 (incl. 3 round-trip tests), wasm32 build, clippy pedantic.
- **`fix(cli)` export & `show --samples` by actual IDs** — both assumed contiguous `1..=n` IDs, silently dropping records on sparse/deleted IDs. Iterate `col.all_ids()`.

### P1 — coherence / robustness
- **`fix(server)` offload batch search to a blocking worker** — was running the rayon kernel on the async runtime thread. **Verified:** batch tests 10/0.
- **`fix(migrate)` stream graph edges** instead of accumulating a whole relation in memory (OOM risk). **Verified:** migrate suite 304/0.
- **`feat(ts-sdk)` retry 429/503 with exponential backoff** + `Retry-After`. **Verified:** rest-http 39/39 (+4 tests), full SDK suite 888 passed (4 pre-existing query-builder failures, tracked separately).
- **`fix(langchain)` honor `from_texts(ids=...)`** instead of dropping it. **Verified:** new e2e test against the real velesdb wheel; suite 208 passed.

### Docs / versions
- Realign stale version strings and dependency floors to v3.8.0 (node/migrate/tauri READMEs, 5 integration `pyproject.toml` floors, `velesdb_common` README method list; corrected a false `recall_where` doc-comment).

### Remaining audit items (follow-up)
Not in this PR — each warrants its own focused, verified pass:
- P1 llamaindex score↔distance semantics + `delete()` param-binding; haystack `@component` retriever + sparse read path; `velesdb_common` `scroll_one_batch` O(n) (needs a core `scroll_batch` binding); TS SDK `bulkDelete`; `velesdb-mobile` graph store (adopt core's persistent graph API instead of the in-memory reimplementation).
- The 4 pre-existing TS `query-builder-roundtrip` grammar failures are being fixed in a separate task.
