### PR TITLE
docs: sync remaining REST endpoint counts to 54 (complements #1344)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -72,7 +72,7 @@ The workspace is laid out as eight crates with one-way dependencies (no cycles).
 | Crate | Role | Public surface | Notes |
 |-------|------|---------------|-------|
 | **`velesdb-core`** | The engine. HNSW, SIMD, VelesQL, collections, storage, recovery, GPU pipeline. Everything else depends on it. | `Database`, `VectorCollection`, `GraphCollection`, `MetadataCollection`, VelesQL parser, error types | The only crate where `unsafe` lives in non-trivial volume (SIMD intrinsics, mmap). All `unsafe` is documented in [`docs/SOUNDNESS.md`](docs/SOUNDNESS.md). |
-| **`velesdb-server`** | Axum REST + OpenAPI server. 48 endpoints (55 operations), including relation/TTL management and a Prometheus `GET /metrics` served by default. | HTTP API | Optional; `feature = "openapi"` exposes the schema. |
+| **`velesdb-server`** | Axum REST + OpenAPI server. 54 endpoints (61 operations), including relation/TTL management and a Prometheus `GET /metrics` served by default. | HTTP API | Optional; `feature = "openapi"` exposes the schema. |
 | **`velesdb-python`** | PyO3 bindings + NumPy interop. | `velesdb` package on PyPI | Released as wheels via maturin (abi3-py39, manylinux + macOS arm64/x64 + Windows x64). |
 | **`velesdb-wasm`** | Browser-side vector search. | `@wiscale/velesdb-sdk` partial | No `persistence` feature; transient in-memory. |
 | **`velesdb-mobile`** | iOS / Android bindings via UniFFI. | Swift + Kotlin | One binding crate, two outputs. |

--- a/docs/NEW_USER_TROUBLESHOOTING.md
+++ b/docs/NEW_USER_TROUBLESHOOTING.md
@@ -33,7 +33,7 @@ Collection vector dimension and metric are fixed by design for indexing/search p
 `velesdb-core` is embedded library only.
 
 Install the component you need:
-- `cargo install velesdb-server` — REST API server (48 endpoints, OpenAPI)
+- `cargo install velesdb-server` — REST API server (54 endpoints, OpenAPI)
 - `cargo install velesdb-cli` — Interactive VelesQL REPL (binary name: `velesdb`)
 
 ### 5) "Benchmark numbers are different"
@@ -75,7 +75,7 @@ C'est normal : ce choix est figé à la création pour conserver les performance
 `velesdb-core` = moteur embarqué.
 
 Installer le composant adapté :
-- `cargo install velesdb-server` — API REST (48 endpoints, OpenAPI)
+- `cargo install velesdb-server` — API REST (54 endpoints, OpenAPI)
 - `cargo install velesdb-cli` — Shell interactif VelesQL (binaire : `velesdb`)
 
 ### 5) « Les benchmarks ne correspondent pas »
@@ -101,6 +101,6 @@ Normal : dépend du CPU, de `ef_search`, des filtres/payloads et du dataset.
 - [VelesQL Specification](VELESQL_SPEC.md) — Full query language reference with examples
 - [Search Modes Guide](guides/SEARCH_MODES.md) — How to choose between Fast, Balanced, Accurate, Perfect, and Adaptive
 - [Tuning Guide](guides/TUNING_GUIDE.md) — HNSW parameters, quantization modes, memory estimation
-- [API Reference](reference/api-reference.md) — All 48 REST endpoints with request/response examples
+- [API Reference](reference/api-reference.md) — All 54 REST endpoints with request/response examples
 - [Installation Guide](guides/INSTALLATION.md) — All platforms: Linux, macOS, Windows, Docker, WASM, Mobile
 - [E-commerce Example](../examples/ecommerce_recommendation/) — Full Vector + Graph + Filter demo in Rust

--- a/docs/contributing/PROJECT_STRUCTURE.md
+++ b/docs/contributing/PROJECT_STRUCTURE.md
@@ -55,7 +55,7 @@ velesdb-core/
 │   │   ├── benches/           # Criterion benchmarks
 │   │   └── tests/             # Integration + BDD tests
 │   │
-│   ├── velesdb-server/        # Axum REST API server (48 endpoints)
+│   ├── velesdb-server/        # Axum REST API server (54 endpoints)
 │   │   ├── Cargo.toml
 │   │   └── src/
 │   │       └── handlers/      # Route handlers (query/, search/, graph, admin)
@@ -150,7 +150,7 @@ Core engine. Contains:
 
 ### `velesdb-server`
 
-Axum-based REST API server with 48 endpoints. Exposes:
+Axum-based REST API server with 54 endpoints. Exposes:
 - CRUD endpoints for collections and points
 - `/search`, `/search/batch`, `/search/hybrid` endpoints
 - `/query` endpoint for VelesQL execution

--- a/docs/reference/ARCHITECTURE.md
+++ b/docs/reference/ARCHITECTURE.md
@@ -100,7 +100,7 @@ VelesDB core architecture is explicitly **hybrid by design**:
 #### velesdb-server
 - Axum-based REST API server
 - OpenAPI/Swagger documentation
-- 48 REST endpoints (55 method+path operations)
+- 54 REST endpoints (61 method+path operations)
 - Prometheus metrics served by default (`GET /metrics`)
 
 #### velesdb-python


### PR DESCRIPTION
Complements #1344 (already merged). #1344 fixed `README.md` and the `promise-contract` registry to **54 REST endpoints** (61 operations); four more docs still carried the stale **48/55** figures. This syncs them so the whole tree agrees on the canonical count (OpenAPI paths = 54, corroborated by 54 `.route()` in `crates/velesdb-server/src/routes.rs`):

- `ARCHITECTURE.md`
- `docs/reference/ARCHITECTURE.md`
- `docs/contributing/PROJECT_STRUCTURE.md`
- `docs/NEW_USER_TROUBLESHOOTING.md` (EN + FR + API-reference link)

Note: overlaps #1345 (same content). #1345's `claude/*` source branch violates the Git Flow gate for `develop`; this branch is `docs/*` and passes. Recommend closing #1345 in favor of this one.