### PR TITLE
Release: develop → main (audit remediation + security + docs)

### DIFF
--- a/.github/workflows/bench-arm64.yml
+++ b/.github/workflows/bench-arm64.yml
@@ -61,7 +61,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Rust toolchain
-        uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # stable
+        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # stable
         with:
           toolchain: stable
           components: rustfmt

--- a/.github/workflows/bench-scalability.yml
+++ b/.github/workflows/bench-scalability.yml
@@ -39,7 +39,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # stable
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # stable
         with:
           toolchain: ${{ env.RUST_VERSION }}
 

--- a/.github/workflows/bench-sift1m-nightly.yml
+++ b/.github/workflows/bench-sift1m-nightly.yml
@@ -40,7 +40,7 @@ jobs:
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # stable
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # stable
         with:
           toolchain: ${{ env.RUST_VERSION }}
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0

--- a/.github/workflows/binary-size.yml
+++ b/.github/workflows/binary-size.yml
@@ -53,7 +53,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # stable
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # stable
         with:
           toolchain: "1.89"
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -301,7 +301,7 @@ jobs:
       # to empty binaries under the native test job and are invisible to the
       # cargo check above — without this step they never run in CI at all.
       - name: Install wasm-pack
-        uses: taiki-e/install-action@9bcaee1dcae34154180f412e2fa69355a7cda9f6 # v2.82.6
+        uses: taiki-e/install-action@50414676f9f5d50a65992c6dd2ed02641263226c # v2.82.10
         with:
           tool: wasm-pack
 
@@ -570,7 +570,7 @@ jobs:
       # `cargo install` from source — faster and avoids the compile/network
       # flakes that lost the runner mid-job on earlier release runs.
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@9bcaee1dcae34154180f412e2fa69355a7cda9f6 # v2.82.6
+        uses: taiki-e/install-action@50414676f9f5d50a65992c6dd2ed02641263226c # v2.82.10
         with:
           tool: cargo-llvm-cov
 

--- a/.github/workflows/compat-matrix.yml
+++ b/.github/workflows/compat-matrix.yml
@@ -46,7 +46,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # stable
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # stable
         with:
           toolchain: stable
 
@@ -71,7 +71,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # stable
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # stable
         with:
           toolchain: stable
           targets: wasm32-unknown-unknown
@@ -93,7 +93,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # nightly
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # nightly
         with:
           toolchain: nightly
 

--- a/.github/workflows/perf-gate-e2e.yml
+++ b/.github/workflows/perf-gate-e2e.yml
@@ -70,7 +70,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # stable
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # stable
         with:
           toolchain: "1.86"
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
@@ -177,7 +177,7 @@ jobs:
     timeout-minutes: 90
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # stable
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # stable
         with:
           toolchain: "1.86"
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
@@ -269,7 +269,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # stable
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # stable
         with:
           toolchain: "1.89"
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1

--- a/.github/workflows/production-gates.yml
+++ b/.github/workflows/production-gates.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # stable
+        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # stable
         with:
           toolchain: stable
       - name: Run production gates

--- a/.github/workflows/propagation-guard.yml
+++ b/.github/workflows/propagation-guard.yml
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # stable
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # stable
         with:
           toolchain: "1.86"
       - name: Install Linux build deps
@@ -74,7 +74,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # stable
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # stable
         with:
           toolchain: "1.86"
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
@@ -200,7 +200,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # stable
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # stable
         with:
           toolchain: "1.86"
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
@@ -267,7 +267,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # stable
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # stable
         with:
           toolchain: "1.86"
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1

--- a/.github/workflows/quality-deep.yml
+++ b/.github/workflows/quality-deep.yml
@@ -103,7 +103,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # nightly
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # nightly
         with:
           toolchain: nightly
 
@@ -150,7 +150,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # nightly
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # nightly
         with:
           toolchain: nightly
 
@@ -207,7 +207,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # nightly
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # nightly
         with:
           toolchain: nightly
           components: rust-src

--- a/.github/workflows/release-mcpb.yml
+++ b/.github/workflows/release-mcpb.yml
@@ -172,8 +172,13 @@ jobs:
         run: |
           set -euo pipefail
           # Ensure a release exists for the tag, then upload (clobber) the bundles.
+          # --latest=false: the velesdb-memory release must never become the
+          # repo's "Latest release" (that belongs to the VelesDB vX.Y.Z release,
+          # which carries the binaries the README download link points at). Left
+          # unset, `gh release create` marks it latest-by-date and steals the
+          # flag, breaking releases/latest/download/velesdb-*.
           if ! gh release view "$TAG" >/dev/null 2>&1; then
-            gh release create "$TAG" --title "$TAG" --notes "velesdb-memory $TAG — MCPB bundles for the MCP registry." || true
+            gh release create "$TAG" --title "$TAG" --latest=false --notes "velesdb-memory $TAG — MCPB bundles for the MCP registry." || true
           fi
           gh release upload "$TAG" bundles/*.mcpb --clobber
 

--- a/.github/workflows/release-mcpb.yml
+++ b/.github/workflows/release-mcpb.yml
@@ -65,7 +65,7 @@ jobs:
           - { target: aarch64-unknown-linux-gnu, host: ubuntu-latest,  os: linux,   arch: arm64 }
           - { target: x86_64-pc-windows-msvc,    host: windows-latest, os: win32,   arch: amd64 }
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -157,7 +157,7 @@ jobs:
     needs: [version, build]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Download all bundles
         uses: actions/download-artifact@v4

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -72,7 +72,7 @@ The workspace is laid out as eight crates with one-way dependencies (no cycles).
 | Crate | Role | Public surface | Notes |
 |-------|------|---------------|-------|
 | **`velesdb-core`** | The engine. HNSW, SIMD, VelesQL, collections, storage, recovery, GPU pipeline. Everything else depends on it. | `Database`, `VectorCollection`, `GraphCollection`, `MetadataCollection`, VelesQL parser, error types | The only crate where `unsafe` lives in non-trivial volume (SIMD intrinsics, mmap). All `unsafe` is documented in [`docs/SOUNDNESS.md`](docs/SOUNDNESS.md). |
-| **`velesdb-server`** | Axum REST + OpenAPI server. 48 endpoints (55 operations), including relation/TTL management and a Prometheus `GET /metrics` served by default. | HTTP API | Optional; `feature = "openapi"` exposes the schema. |
+| **`velesdb-server`** | Axum REST + OpenAPI server. 54 endpoints (61 operations), including relation/TTL management and a Prometheus `GET /metrics` served by default. | HTTP API | Optional; `feature = "openapi"` exposes the schema. |
 | **`velesdb-python`** | PyO3 bindings + NumPy interop. | `velesdb` package on PyPI | Released as wheels via maturin (abi3-py39, manylinux + macOS arm64/x64 + Windows x64). |
 | **`velesdb-wasm`** | Browser-side vector search. | `@wiscale/velesdb-sdk` partial | No `persistence` feature; transient in-memory. |
 | **`velesdb-mobile`** | iOS / Android bindings via UniFFI. | Swift + Kotlin | One binding crate, two outputs. |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.8.1] — 2026-07-10
+
+Maintenance release: a full crate + integration health audit closed with a
+security patch and a batch of correctness fixes. No API breaks.
+
+### Security
+- Patched `crossbeam-epoch` to 0.9.20 (**RUSTSEC-2026-0204**) and dropped the now-stale audit ignores.
+
+### Fixed
+- **storage/compaction:** compaction now works on Windows — the data file's memory map is released before the atomic rename, and the WAL is truncated through a write handle (previously `ACCESS_DENIED`). A durable rename barrier orders the swap before WAL truncation, and the live index is kept consistent with the mmap if a commit fails mid-compaction.
+- **cli:** `export` and `collection show --samples` iterate the collection's actual point IDs (including points with no payload) instead of an assumed contiguous `1..=n` range — no more silent data loss on sparse IDs.
+- **python:** vector search on a graph/metadata collection now raises instead of silently returning `[]`; `CONDITION_TYPES` is re-exported at the package top level.
+- **wasm:** persistence preserves the storage mode, quantized buffers and payloads (versioned v2 format); export no longer panics or drops data in SQ8/Binary modes.
+- **server:** batch search is offloaded to a blocking worker so it no longer stalls the async runtime.
+- **migrate:** graph relation edges are streamed instead of accumulated, avoiding OOM on large relations.
+- **langchain:** `from_texts(ids=...)` is honored instead of dropped.
+- **llamaindex:** distance scores are mapped to similarity; `delete()` binds its parameters.
+
+### Added
+- **ts-sdk:** retry on 429/503 with exponential backoff (503 retried only for idempotent methods, `Retry-After` capped); `bulkDelete`.
+- **haystack:** `VelesDBEmbeddingRetriever` component.
+- **common:** O(1) cursor scroll via `Collection.scroll_batch`.
+- **mobile:** `MobileGraphStore` save/load persistence.
+
+### Changed
+- **docs:** roadmap refreshed through v3.8.x with a forward-looking "Next" line; REST endpoint count corrected **48 → 54** across the tree and the promise-contract guardrail; stale version strings realigned.
+- **deps:** wgpu 30.0.0, uniffi 0.32.0, plus routine cargo/npm and CI-action group bumps.
+
 ## [3.8.0] — 2026-07-06
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -986,9 +986,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -135,11 +135,11 @@ dependencies = [
 
 [[package]]
 name = "askama"
-version = "0.14.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f75363874b771be265f4ffe307ca705ef6f3baa19011c149da8674a87f1b75c4"
+checksum = "f1bf825125edd887a019d0a3a837dcc5499a68b0d034cc3eb594070c3e18addc"
 dependencies = [
- "askama_derive",
+ "askama_macros",
  "itoa",
  "percent-encoding",
  "serde",
@@ -148,12 +148,13 @@ dependencies = [
 
 [[package]]
 name = "askama_derive"
-version = "0.14.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "129397200fe83088e8a68407a8e2b1f826cf0086b21ccdb866a722c8bcd3a94f"
+checksum = "e1c7065972a130eafa84215f21352ae15b4a7393da48c1f5e103904490736738"
 dependencies = [
  "askama_parser",
  "basic-toml",
+ "glob",
  "memchr",
  "proc-macro2",
  "quote",
@@ -164,15 +165,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "askama_parser"
-version = "0.14.0"
+name = "askama_macros"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6ab5630b3d5eaf232620167977f95eb51f3432fc76852328774afbd242d4358"
+checksum = "0e23b1d2c4bd39a41971f6124cef4cc6fd0540913ecb90919b69ab3bbe44ae1a"
 dependencies = [
- "memchr",
+ "askama_derive",
+]
+
+[[package]]
+name = "askama_parser"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7db09fde9143e7ac4513358fb32ee32847125b63b18ea715afd487956da715da"
+dependencies = [
+ "rustc-hash 2.1.2",
  "serde",
  "serde_derive",
- "winnow 0.7.15",
+ "unicode-ident",
+ "winnow 1.0.0",
 ]
 
 [[package]]
@@ -557,13 +568,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "cargo-platform"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd0061da739915fae12ea00e16397555ed4371a6bb285431aab930f61b0aa4ba"
+dependencies = [
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "cargo_metadata"
 version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba"
 dependencies = [
  "camino",
- "cargo-platform",
+ "cargo-platform 0.1.9",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef987d17b0a113becdd19d3d0022d04d7ef41f9efe4f3fb63ac44ba61df3ade9"
+dependencies = [
+ "camino",
+ "cargo-platform 0.3.3",
  "semver",
  "serde",
  "serde_json",
@@ -1697,9 +1732,9 @@ dependencies = [
 
 [[package]]
 name = "fs-err"
-version = "2.11.0"
+version = "3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88a41f105fe1d5b6b34b2055e3dc59bb79b46b48b2040b9e6c7b4b5de097aa41"
+checksum = "b91aa448ca50d7e79433bdf3ee8d99215430d2ec02ade5aefab2a073a1822e8a"
 dependencies = [
  "autocfg",
 ]
@@ -5715,7 +5750,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e176a18e67764923c4f1ce66f25ae4abe5f688384d5eb1a0fa6c77f3d90f887"
 dependencies = [
  "anyhow",
- "cargo_metadata",
+ "cargo_metadata 0.19.2",
  "ctor 0.8.0",
  "dom_query",
  "dunce",
@@ -6413,13 +6448,13 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "uniffi"
-version = "0.31.2"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46eefd5468602930da46b1f49d3448c6dfc2e81295f93120f23f8174fd70267f"
+checksum = "a782a48d72cfd7a2d65cfc7c691dbf5375c43104b3c195f7eccc716dcc3540c8"
 dependencies = [
  "anyhow",
  "camino",
- "cargo_metadata",
+ "cargo_metadata 0.23.1",
  "clap",
  "uniffi_bindgen",
  "uniffi_core",
@@ -6429,14 +6464,14 @@ dependencies = [
 
 [[package]]
 name = "uniffi_bindgen"
-version = "0.31.2"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4a0c9b375d32e1365cdb2bdd7cb495eecf6fac851ddbad077412b4ee1888514"
+checksum = "533b0312c73e3b54eb78a4b257ceae390962dd4767995778309a74644643f9ac"
 dependencies = [
  "anyhow",
  "askama",
  "camino",
- "cargo_metadata",
+ "cargo_metadata 0.23.1",
  "fs-err",
  "glob",
  "goblin",
@@ -6446,7 +6481,7 @@ dependencies = [
  "serde",
  "tempfile",
  "textwrap",
- "toml 0.9.12+spec-1.1.0",
+ "toml 1.1.2+spec-1.1.0",
  "uniffi_internal_macros",
  "uniffi_meta",
  "uniffi_pipeline",
@@ -6455,9 +6490,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_core"
-version = "0.31.2"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eec017b112701681f6fbbe5d92014b5c468eb0b177a94389de03ceec40665095"
+checksum = "8e32e261c5b0dfaba6488f536e71957dddd6b1a498ac7eb791bee56b60a086be"
 dependencies = [
  "anyhow",
  "async-compat",
@@ -6468,9 +6503,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_internal_macros"
-version = "0.31.2"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4641669b48fefbc5e80ff08c5004d9c7617fb91232131a6734ab6712779cb04c"
+checksum = "84ae78069a5e6772ef694fd5bdb628532c88d2c2f0e7142bf6a384636eadb1af"
 dependencies = [
  "anyhow",
  "indexmap 2.14.0",
@@ -6481,9 +6516,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_macros"
-version = "0.31.2"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeb8617ee814de22caf7417bf514715ba0b3f46bd9d5a5d794413fd8282cb737"
+checksum = "330be6770532e86320df31f54c70bb0be67588594e8e77fa56e9083a3fed5d0d"
 dependencies = [
  "camino",
  "fs-err",
@@ -6492,15 +6527,15 @@ dependencies = [
  "quote",
  "serde",
  "syn 2.0.117",
- "toml 0.9.12+spec-1.1.0",
+ "toml 1.1.2+spec-1.1.0",
  "uniffi_meta",
 ]
 
 [[package]]
 name = "uniffi_meta"
-version = "0.31.2"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58d5b94fc92803d21b2928bd15c6f06e57609b95caf98ea561c99cda1b6d2a25"
+checksum = "78de021f5547e56ab16c665a49d67d4fd3d31e77422f7739a2e9359d328cd9e7"
 dependencies = [
  "anyhow",
  "siphasher",
@@ -6510,9 +6545,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_pipeline"
-version = "0.31.2"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "032739b3ec725576914c15899dedaf080163ced86b6934566c20ec2b20ce90ca"
+checksum = "3f8201bb1907ed8a42d80e11cbc25c8a033e7a31c3cff1d911f56eedb81d4948"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
@@ -6523,9 +6558,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_udl"
-version = "0.31.2"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0a1d0a0252ce1af9e8ce78ba67ac0d8937fb2bedaf10cbddd43d3614d06ec6"
+checksum = "a6e57996bc58009cc29bf04845d627ae313c2547b87171c1c349d6c51a1656c0"
 dependencies = [
  "anyhow",
  "textwrap",
@@ -7904,6 +7939,9 @@ name = "winnow"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winreg"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -411,9 +411,9 @@ dependencies = [
 
 [[package]]
 name = "bit-set"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ddef2995421ab6a5c779542c81ee77c115206f4ad9d5a8e05f4ff49716a3dd"
+checksum = "09ec2f926cc3060f09db9ebc5b52823d85268d24bb917e472c0c4bea35780a7d"
 dependencies = [
  "bit-vec 0.9.1",
 ]
@@ -2161,26 +2161,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gpu-descriptor"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b89c83349105e3732062a895becfc71a8f921bb71ecbbdd8ff99263e3b53a0ca"
-dependencies = [
- "bitflags 2.11.0",
- "gpu-descriptor-types",
- "hashbrown 0.15.5",
-]
-
-[[package]]
-name = "gpu-descriptor-types"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdf242682df893b86f33a73828fb09ca4b2d3bb6cc95249707fc684d27484b91"
-dependencies = [
- "bitflags 2.11.0",
-]
-
-[[package]]
 name = "gtk"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2310,6 +2290,9 @@ name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+dependencies = [
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "heapless"
@@ -2348,12 +2331,6 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
-name = "hexf-parse"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
 
 [[package]]
 name = "home"
@@ -3169,28 +3146,40 @@ dependencies = [
 
 [[package]]
 name = "naga"
-version = "29.0.3"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dd91265cc2454558f659b3b4b9640f0ddb8cc6521277f166b8a8c181c898079"
+checksum = "23bf0a141a9ab6f07dbb492db53245e464bc9db42f407772d9ae03d83a2c1033"
 dependencies = [
  "arrayvec",
- "bit-set 0.9.1",
+ "bit-set 0.10.0",
  "bitflags 2.11.0",
  "cfg-if",
  "cfg_aliases",
  "codespan-reporting",
  "half",
- "hashbrown 0.16.1",
- "hexf-parse",
+ "hashbrown 0.17.0",
  "indexmap 2.14.0",
  "libm",
  "log",
+ "naga-types",
  "num-traits",
  "once_cell",
  "rustc-hash 1.1.0",
  "spirv",
  "thiserror 2.0.18",
  "unicode-ident",
+]
+
+[[package]]
+name = "naga-types"
+version = "30.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "658200ddc25c6c7b860747516d132d1b284c0fafb7a380233acee9a72fb30e11"
+dependencies = [
+ "hashbrown 0.17.0",
+ "indexmap 2.14.0",
+ "rustc-hash 1.1.0",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3466,6 +3455,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-graphics"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
+dependencies = [
+ "dispatch2",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-io-surface",
+]
+
+[[package]]
 name = "objc2-encode"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3476,6 +3477,17 @@ name = "objc2-foundation"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-io-surface"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
 dependencies = [
  "bitflags 2.11.0",
  "objc2",
@@ -3503,6 +3515,7 @@ dependencies = [
  "bitflags 2.11.0",
  "objc2",
  "objc2-core-foundation",
+ "objc2-core-graphics",
  "objc2-foundation",
  "objc2-metal",
 ]
@@ -7316,9 +7329,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu"
-version = "29.0.3"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb3feacc458f7bee8bc1737149b42b6c731aa461039a4264a67bb6681646b250"
+checksum = "6d8f4bd44d92da5270f03409dba9f952dab24f128e05d6a554926101d1bf9114"
 dependencies = [
  "arrayvec",
  "bitflags 2.11.0",
@@ -7326,7 +7339,7 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "document-features",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "js-sys",
  "log",
  "naga",
@@ -7346,21 +7359,22 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "29.0.3"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02da3ad1b568337f25513b317870960ef87073ea0945502e44b864b67a8c77b7"
+checksum = "08763620e76fc980bca7bf84de82568614487a53172dd968d89187282eb87fa2"
 dependencies = [
  "arrayvec",
- "bit-set 0.9.1",
+ "bit-set 0.10.0",
  "bit-vec 0.9.1",
  "bitflags 2.11.0",
  "bytemuck",
  "cfg_aliases",
  "document-features",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "indexmap 2.14.0",
  "log",
  "naga",
+ "naga-types",
  "once_cell",
  "parking_lot",
  "portable-atomic",
@@ -7379,41 +7393,41 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core-deps-apple"
-version = "29.0.3"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62e51b5447e144b3dbba4feb01f80f4fa21696fa0cd99afb2c3df1affd6fdb28"
+checksum = "3283b6da70d7fc892de95840215aa36381b5d0cbc479e88ee2b173c7b992b225"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-core-deps-emscripten"
-version = "29.0.3"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3487cd6293a963bc5c0c0396f6a2192043c50003c07f4efdccbad3d90ec9d819"
+checksum = "85dcf2b2e5c2afb9eda64c570a87a4e570304bf39e52eddbaaf222d655b656ad"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-core-deps-windows-linux-android"
-version = "29.0.3"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb01076d0aa08b0ba9bd741e178b5cc440f5abe99d9581323a4c8b5d1a1916"
+checksum = "f76bc9c1c186ff3d9054e0d224c93c8c1c79d6653907c5249a5c1ea1a2cb1e43"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-hal"
-version = "29.0.3"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31f8e1a9e7a8512f276f7c62e018c7fa8d60954303fed2e5750114332049193f"
+checksum = "cf765132d8d5f50e192e7880464890c13f4e7457aafe8e5466e8174586e9f101"
 dependencies = [
  "android_system_properties",
  "arrayvec",
  "ash",
- "bit-set 0.9.1",
+ "bit-set 0.10.0",
  "bitflags 2.11.0",
  "block2",
  "bytemuck",
@@ -7422,17 +7436,18 @@ dependencies = [
  "glow",
  "glutin_wgl_sys",
  "gpu-allocator",
- "gpu-descriptor",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "js-sys",
  "khronos-egl",
  "libc",
  "libloading 0.8.9",
  "log",
  "naga",
+ "naga-types",
  "ndk-sys",
  "objc2",
  "objc2-core-foundation",
+ "objc2-core-graphics",
  "objc2-foundation",
  "objc2-metal",
  "objc2-quartz-core",
@@ -7447,6 +7462,7 @@ dependencies = [
  "raw-window-metal",
  "renderdoc-sys",
  "smallvec",
+ "static_assertions",
  "thiserror 2.0.18",
  "wasm-bindgen",
  "wayland-sys",
@@ -7460,9 +7476,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu-naga-bridge"
-version = "29.0.3"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59c654c483f058800972c3645e95388a7eca31bf9fe1933bc20e036588a0be02"
+checksum = "c9eaac644e5008925c78567d272b9d66ef83da55a53cc17fc7daade7bb6e66e5"
 dependencies = [
  "naga",
  "wgpu-types",
@@ -7470,15 +7486,17 @@ dependencies = [
 
 [[package]]
 name = "wgpu-types"
-version = "29.0.3"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9bcc31518a0e9735aefebedb5f7a9ef3ed1c42549c9f4c882fa9060ceaac639"
+checksum = "1a9c93c2b35edde326df60ffdee4c0f5864eac3011d6768b70d43f028ad93565"
 dependencies = [
  "bitflags 2.11.0",
  "bytemuck",
  "js-sys",
  "log",
+ "naga-types",
  "raw-window-handle",
+ "static_assertions",
  "web-sys",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5715,7 +5715,7 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-velesdb"
-version = "3.8.0"
+version = "3.8.1"
 dependencies = [
  "dirs",
  "parking_lot",
@@ -6725,7 +6725,7 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "velesdb-cli"
-version = "3.8.0"
+version = "3.8.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -6750,7 +6750,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-core"
-version = "3.8.0"
+version = "3.8.1"
 dependencies = [
  "arc-swap",
  "bytemuck",
@@ -6820,7 +6820,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-migrate"
-version = "3.8.0"
+version = "3.8.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6848,7 +6848,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-mobile"
-version = "3.8.0"
+version = "3.8.1"
 dependencies = [
  "parking_lot",
  "serde",
@@ -6874,7 +6874,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-python"
-version = "3.8.0"
+version = "3.8.1"
 dependencies = [
  "numpy",
  "parking_lot",
@@ -6888,7 +6888,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-server"
-version = "3.8.0"
+version = "3.8.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -6921,7 +6921,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-wasm"
-version = "3.8.0"
+version = "3.8.1"
 dependencies = [
  "getrandom 0.3.4",
  "getrandom 0.4.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,7 +158,7 @@ dependencies = [
  "memchr",
  "proc-macro2",
  "quote",
- "rustc-hash 2.1.2",
+ "rustc-hash 2.1.3",
  "serde",
  "serde_derive",
  "syn 2.0.117",
@@ -179,7 +179,7 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7db09fde9143e7ac4513358fb32ee32847125b63b18ea715afd487956da715da"
 dependencies = [
- "rustc-hash 2.1.2",
+ "rustc-hash 2.1.3",
  "serde",
  "serde_derive",
  "unicode-ident",
@@ -748,9 +748,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.6.5"
+version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a7a9bfdb35811f9e59832f0f05975114d2251b415fb534108e6f34060fd772"
+checksum = "db8b397918185f0161ff3d6fcaa9e4bfc09b8367caf6e1d4a2848e5477ed027b"
 dependencies = [
  "clap",
 ]
@@ -862,9 +862,9 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.16.3"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
+checksum = "4fe5f465a4f6fee88fad41b85d990f84c835335e85b5d9e6e63e0d06d28cba7c"
 dependencies = [
  "encode_unicode",
  "libc",
@@ -2704,9 +2704,9 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.18.5"
+version = "0.18.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "993f007684f2e9727160da8b960ec161264703bfd1af084fd2e34d040c9a0dd4"
+checksum = "9433806cd6b4ec1aba79c021c7e4c58fb4c3b9977c085062e611ac929998fb0c"
 dependencies = [
  "console",
  "portable-atomic",
@@ -3195,9 +3195,9 @@ dependencies = [
 
 [[package]]
 name = "napi"
-version = "3.9.4"
+version = "3.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b41bda2ac390efb5e8d22025d925ccc3f3807d8c1bea6d19b36127247c4b8f83"
+checksum = "0c71997d6f7ad4a756966e452426848ac27d3b37a295302d63afbbcce0270f93"
 dependencies = [
  "bitflags 2.11.0",
  "ctor 1.0.7",
@@ -3205,7 +3205,7 @@ dependencies = [
  "napi-build",
  "napi-sys",
  "nohash-hasher",
- "rustc-hash 2.1.2",
+ "rustc-hash 2.1.3",
  "serde",
  "serde_json",
 ]
@@ -3218,9 +3218,9 @@ checksum = "c9c366d2c8c60b86fa632df75f745509b52f9128f91a6bad4c796e44abb505e1"
 
 [[package]]
 name = "napi-derive"
-version = "3.5.7"
+version = "3.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61d66f70256ad5aef58659966064471d0ad90e2897bc36a5a5e0389c85aabc1e"
+checksum = "d4ba572deef53e2c386759a8c2014175a62679d74ff83adc205c8bc0e0285727"
 dependencies = [
  "convert_case",
  "ctor 1.0.7",
@@ -3232,9 +3232,9 @@ dependencies = [
 
 [[package]]
 name = "napi-derive-backend"
-version = "5.0.5"
+version = "5.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81b4b08f15eed7a2a20c3f4c6314013fc3ac890a3afa9892b594485299ebdb2d"
+checksum = "ddd961eb2aa8965e3f29722d754f3a86907eb1984e2fbcbe3fe87b9a02d6bfba"
 dependencies = [
  "convert_case",
  "proc-macro2",
@@ -3430,7 +3430,7 @@ dependencies = [
  "num-traits",
  "pyo3",
  "pyo3-build-config",
- "rustc-hash 2.1.2",
+ "rustc-hash 2.1.3",
 ]
 
 [[package]]
@@ -3697,9 +3697,9 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"
-version = "2.8.6"
+version = "2.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
+checksum = "47627dd7305c6a2d6c8c6bcd24c5a4c17dbbf425f4f9c5313e724b38fc9782e9"
 dependencies = [
  "memchr",
  "ucd-trie",
@@ -3707,9 +3707,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.8.6"
+version = "2.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
+checksum = "4b4254325ecad416ab689e27ba51da03ba01a9632bc6e108f5fe7c3c4ad29d58"
 dependencies = [
  "pest",
  "pest_generator",
@@ -3717,9 +3717,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.8.6"
+version = "2.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
+checksum = "6c4c0e91ead7a8f7acecbca6f003fc2e8282b1dbe2dd9c9d2f16aba42995e0a7"
 dependencies = [
  "pest",
  "pest_meta",
@@ -3730,12 +3730,11 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.8.6"
+version = "2.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
+checksum = "f9744bc48116fee06334924bb5f2bad41eed5e89bd26e29b0b799f9a3f82c210"
 dependencies = [
  "pest",
- "sha2 0.10.9",
 ]
 
 [[package]]
@@ -4205,7 +4204,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash 2.1.2",
+ "rustc-hash 2.1.3",
  "rustls",
  "socket2",
  "thiserror 2.0.18",
@@ -4226,7 +4225,7 @@ dependencies = [
  "lru-slab",
  "rand 0.9.3",
  "ring",
- "rustc-hash 2.1.2",
+ "rustc-hash 2.1.3",
  "rustls",
  "rustls-pki-types",
  "slab",
@@ -4293,9 +4292,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
  "chacha20",
  "getrandom 0.4.2",
@@ -4343,7 +4342,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d431c2703ccf129de4d45253c03f49ebb22b97d6ad79ee3ecfc7e3f4862c1d8"
 dependencies = [
  "num-traits",
- "rand 0.10.1",
+ "rand 0.10.2",
 ]
 
 [[package]]
@@ -4586,9 +4585,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52d21e5b342699bc4de690e6104fc4e43255e4e8420ff0f2cbb963aac09da6f"
+checksum = "f00a32c3b81b7b254076a65abd5ab2551209146713ba38f73818657e865e9433"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4608,9 +4607,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c68cec74c5b3ac73ff46375ae49e161637bda80bba70f0d5db641583bb308ee"
+checksum = "2ee70afb7956da9f30d5348a2539b5eb90d9038f834463657ab717076ac3b1ad"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -4672,9 +4671,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustc_version"
@@ -4993,7 +4992,7 @@ dependencies = [
  "phf",
  "phf_codegen",
  "precomputed-hash",
- "rustc-hash 2.1.2",
+ "rustc-hash 2.1.3",
  "servo_arc",
  "smallvec",
 ]
@@ -5579,9 +5578,9 @@ checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tauri"
-version = "2.11.3"
+version = "2.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2616f96cb644bf2c5c456d9de4d5d5100e592d7424c74d8b55c5cb96e359e93"
+checksum = "667b20e2726d572dea2de7370da16e188eb06008faf9a92fab7cdc46791190b5"
 dependencies = [
  "anyhow",
  "bytes",
@@ -6765,12 +6764,12 @@ dependencies = [
  "pollster",
  "postcard",
  "proptest",
- "rand 0.10.1",
+ "rand 0.10.2",
  "rand_distr",
  "rayon",
  "reqwest",
  "roaring",
- "rustc-hash 2.1.2",
+ "rustc-hash 2.1.3",
  "serde",
  "serde_json",
  "serial_test",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -986,9 +986,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -6804,6 +6804,7 @@ name = "velesdb-mobile"
 version = "3.8.0"
 dependencies = [
  "parking_lot",
+ "serde",
  "serde_json",
  "tempfile",
  "thiserror 2.0.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "3.8.0"
+version = "3.8.1"
 edition = "2021"
 rust-version = "1.89"
 license-file = "LICENSE"
@@ -79,7 +79,7 @@ base64 = "0.22"
 smallvec = { version = "1", features = ["serde"] }
 
 # Internal workspace crates
-velesdb-core = { path = "crates/velesdb-core", version = "3.8.0", default-features = false }
+velesdb-core = { path = "crates/velesdb-core", version = "3.8.1", default-features = false }
 
 [profile.release]
 lto = true

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM rust:1.96-bookworm AS builder
 
 LABEL maintainer="VelesDB Team <contact@wiscale.fr>"
-LABEL version="3.8.0"
+LABEL version="3.8.1"
 
 WORKDIR /app
 
@@ -25,7 +25,7 @@ RUN cargo build --release --bin velesdb-server
 FROM debian:bookworm-slim
 
 LABEL maintainer="VelesDB Team <contact@wiscale.fr>"
-LABEL version="3.8.0"
+LABEL version="3.8.1"
 
 WORKDIR /app
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <img src="velesdb_icon_pack/favicon/android-chrome-512x512.png" alt="VelesDB Logo" width="200"/>
 </p>
 <h1 align="center">
-  <img src="velesdb_icon_pack/favicon/favicon-32x32.png" alt="VelesDB" width="32" height="32" style="vertical-align: middle;"/>
+  <img src="velesdb_icon_pack/favicon/favicon-32x32.png" alt="" width="32" height="32" style="vertical-align: middle;"/> VelesDB
 </h1>
 <h3 align="center">
   Your AI agents forget everything. VelesDB fixes that.
@@ -521,24 +521,21 @@ VelesDB removes the US provider from the chain entirely. One Rust binary, local-
 
 ## Roadmap
 
-| Milestone | Status |
-|-----------|--------|
-| v1.0 — Core engine (vector + graph + VelesQL) | ✅ Shipped |
-| v1.5 — Python SDK, WASM, Mobile bindings | ✅ Shipped |
-| v1.10 — Agent Memory SDK, hybrid search, quantization | ✅ Shipped |
-| v1.11 — Cross-collection MATCH, bitmap pre-filter, CSR graph | ✅ Shipped |
-| v1.12 — Cross-collection MATCH (graph/BM25/HNSW hybrids), Sprint 4 Phase B (TS SDK stability) | ✅ Shipped |
-| v1.13 — Pre-seed remediation: BM25 O(1) cold-start, sparse search 16× speedup, HNSW prefetch, EXPLAIN/CBO routing, VelesQL window functions, SIFT1M standardized harness | ✅ Shipped |
-| v1.14 — DX correctness: MSRV 1.89 alignment, Dockerfile auto-sync; **Haystack 2.x DocumentStore** completes the LangChain + LlamaIndex + Haystack Python RAG trio | ✅ Shipped |
-| v1.15 — ACT-R Phase 1 procedural learning, CBO calibration in `EXPLAIN ANALYZE`, Python auto-dimension + `SearchOptions` builder | ✅ Shipped |
-| v1.16 — `audit-2026q2` security-hardening wave (9 PRs), first-party embedding adapters (Python + TypeScript), multi-arch GHCR image | ✅ Shipped |
-| v1.17 — VelesQL error hints with did-you-mean suggestions, payload-WAL torn-tail crash recovery, OpenAPI id-type accuracy | ✅ Shipped |
-| v1.18 — Engine artifacts realigned to VelesDB Core License 1.0, agent-memory parity (Python/Tauri bindings, TS procedural recall) | ✅ Shipped |
-| v2.0.0 — Agent-memory graph dimension (`relate()` API + the NEAR + MATCH flagship query verbatim), GraphFirst anchored retrieval, PQ/RaBitQ quantization wired end-to-end across restarts, durable TTL on every read path, `GET /metrics` by default | ✅ Shipped |
+We ship weekly. This is the arc; the committed, dated plan lives in [ROADMAP.md](ROADMAP.md) and the [GitHub Milestones](https://github.com/cyberlife-coder/VelesDB/milestones).
+
+| Line | Highlights | Status |
+|------|-----------|--------|
+| **v1.0 → v1.18** | Core engine (vector + graph + VelesQL); Python / WASM / Mobile bindings; Agent Memory SDK; hybrid search + quantization; cross-collection MATCH; BM25 16× speedup; EXPLAIN / CBO routing; SIFT1M harness; the LangChain + LlamaIndex + **Haystack** Python RAG trio | ✅ Shipped |
+| **v2.0** | Agent-memory **graph dimension** — `relate()` + the NEAR + MATCH flagship query; GraphFirst anchored retrieval; PQ/RaBitQ wired end-to-end across restarts; durable TTL; `GET /metrics` by default | ✅ Shipped |
+| **v3.0 → v3.2** | Major release + API cleanup; canonical cross-SDK wire primitives (`hash_edge_id`, shared enum-name sets); `EXPLAIN` parity across REST / CLI / Python | ✅ Shipped |
+| **v3.3** | VelesQL correctness + cross-surface parity — silent-wrong-result sweep, canonical `VELES-XXX` error codes with correct HTTP statuses, executable scalar subqueries, request hard-limits | ✅ Shipped |
+| **v3.4 → v3.7** | The `why()` wedge **everywhere** — Node binding (`velesdb-memory-node`), Python `MemoryService`, MCP `recall_fused`, browser / WASM + TypeScript-SDK `MemoryService`, durable TTL, dated-context recall, indexed prefilter for filtered recall | ✅ Shipped |
+| **v3.8** *(current)* | u64 point-id precision-safety completed across the REST surface + OpenAPI spec | ✅ Shipped |
+| **Next** | Concurrent WAL writer & Raft replication (Enterprise); WASM SIMD128 kernels + 3+ hop `MATCH`; Dual-Precision (VSAG) engine integration; side-by-side Docker-Compose ANN benchmark vs Qdrant / Chroma / FAISS | 🔜 Tracked |
 
 > VelesDB Core is source-available (readable, modifiable, redistributable under the VelesDB Core License 1.0 — not an OSI-approved license; see [docs/LICENSING.md](docs/LICENSING.md)). Enterprise features (distributed replication, managed cloud, RBAC) are available separately via [VelesDB Premium](https://velesdb.com).
 
-> We ship weekly. [Full changelog](CHANGELOG.md) | [Contributing guide](CONTRIBUTING.md)
+> [Full changelog](CHANGELOG.md) · [Contributing guide](CONTRIBUTING.md)
 
 ---
 
@@ -547,7 +544,7 @@ VelesDB removes the US provider from the chain entirely. One Rust binary, local-
 | Domain | Component | Install |
 |--------|-----------|---------|
 | **Core** | [velesdb-core](crates/velesdb-core) — Vector + Graph + ColumnStore + VelesQL | `cargo add velesdb-core` |
-| **Server** | [velesdb-server](crates/velesdb-server) — REST API (48 endpoints, OpenAPI) | `cargo install velesdb-server` |
+| **Server** | [velesdb-server](crates/velesdb-server) — REST API (54 endpoints, OpenAPI) | `cargo install velesdb-server` |
 | **CLI** | [velesdb-cli](crates/velesdb-cli) — Interactive VelesQL REPL | `cargo install velesdb-cli` |
 | **Python** | [velesdb-python](crates/velesdb-python) — PyO3 bindings + NumPy | `pip install velesdb` |
 | **TypeScript** | [typescript-sdk](sdks/typescript) — Node.js & Browser SDK | `npm install @wiscale/velesdb-sdk` |
@@ -617,7 +614,7 @@ The container runs as a non-root `velesdb` user. Data persists via the named vol
 </details>
 
 <details>
-<summary>API Reference (48 REST endpoints)</summary>
+<summary>API Reference (54 REST endpoints)</summary>
 
 | Category | Key Endpoints |
 |----------|--------------|

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,7 +4,7 @@ This roadmap commits to **what we are building**, **why**, and **when**. It is u
 
 It is intentionally narrow. Items not on this roadmap are tracked as `roadmap` issues but **not committed** until they reach a milestone here.
 
-> **Last updated:** 2026-06-21 — covers v3.8.0 (current). The horizon framing below predates the v2.0→v3.x line and is being re-baselined.
+> **Last updated:** 2026-06-21 — covers v3.8.1 (current). The horizon framing below predates the v2.0→v3.x line and is being re-baselined.
 
 ---
 

--- a/benchmarks/Dockerfile.bench
+++ b/benchmarks/Dockerfile.bench
@@ -6,7 +6,7 @@
 FROM debian:bookworm-slim
 
 LABEL maintainer="VelesDB Team <contact@wiscale.fr>"
-LABEL version="3.8.0"
+LABEL version="3.8.1"
 
 WORKDIR /app
 

--- a/benchmarks/Dockerfile.nightly
+++ b/benchmarks/Dockerfile.nightly
@@ -4,7 +4,7 @@
 FROM rust:slim-bookworm AS builder
 
 LABEL maintainer="VelesDB Team <contact@wiscale.fr>"
-LABEL version="3.8.0"
+LABEL version="3.8.1"
 
 WORKDIR /app
 
@@ -29,7 +29,7 @@ RUN cargo build --release --bin velesdb-server
 FROM debian:bookworm-slim
 
 LABEL maintainer="VelesDB Team <contact@wiscale.fr>"
-LABEL version="3.8.0"
+LABEL version="3.8.1"
 
 WORKDIR /app
 

--- a/benchmarks/Dockerfile.optimized
+++ b/benchmarks/Dockerfile.optimized
@@ -7,7 +7,7 @@
 FROM rust:slim-bookworm AS builder
 
 LABEL maintainer="VelesDB Team <contact@wiscale.fr>"
-LABEL version="3.8.0"
+LABEL version="3.8.1"
 
 WORKDIR /app
 
@@ -49,7 +49,7 @@ RUN cargo build --release --bin velesdb-server \
 FROM debian:bookworm-slim
 
 LABEL maintainer="VelesDB Team <contact@wiscale.fr>"
-LABEL version="3.8.0"
+LABEL version="3.8.1"
 
 WORKDIR /app
 

--- a/crates/tauri-plugin-velesdb/README.md
+++ b/crates/tauri-plugin-velesdb/README.md
@@ -28,7 +28,7 @@ A Tauri plugin for **VelesDB** — Vector search in desktop applications.
 
 ```toml
 [dependencies]
-tauri-plugin-velesdb = "1"
+tauri-plugin-velesdb = "3"
 ```
 
 ### TypeScript SDK (package.json)

--- a/crates/tauri-plugin-velesdb/guest-js/package.json
+++ b/crates/tauri-plugin-velesdb/guest-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wiscale/tauri-plugin-velesdb",
-  "version": "3.8.0",
+  "version": "3.8.1",
   "description": "TypeScript bindings for the VelesDB Tauri plugin - Vector search in desktop apps",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/crates/velesdb-cli/src/handlers/data.rs
+++ b/crates/velesdb-cli/src/handlers/data.rs
@@ -33,7 +33,7 @@ pub fn handle_export(
         collection.green()
     );
 
-    let records = collect_export_records(&col, cfg.point_count, include_vectors);
+    let records = collect_export_records(&col, include_vectors);
     std::fs::write(&output_path, serde_json::to_string_pretty(&records)?)?;
     println!(
         "{} Exported {} records to {}",
@@ -45,18 +45,21 @@ pub fn handle_export(
 }
 
 /// Collects all records from a vector collection for export.
+///
+/// IDs come from the live collection (`all_ids`) rather than an assumed
+/// contiguous `1..=point_count` range: sparse or non-sequential IDs (explicit
+/// ids passed at upsert, or gaps left by deletions) would otherwise be exported
+/// as missing records — silent data loss.
 fn collect_export_records(
     col: &velesdb_core::VectorCollection,
-    point_count: usize,
     include_vectors: bool,
 ) -> Vec<serde_json::Value> {
-    let mut records = Vec::new();
+    let all_ids = col.all_ids();
+    let mut records = Vec::with_capacity(all_ids.len());
     let batch_size = 1000;
 
-    for batch_start in (0..point_count).step_by(batch_size) {
-        let ids: Vec<u64> =
-            ((batch_start as u64 + 1)..=((batch_start + batch_size) as u64)).collect();
-        let points = col.get(&ids);
+    for ids in all_ids.chunks(batch_size) {
+        let points = col.get(ids);
 
         for point in points.into_iter().flatten() {
             let mut record = serde_json::Map::new();

--- a/crates/velesdb-cli/src/handlers/data.rs
+++ b/crates/velesdb-cli/src/handlers/data.rs
@@ -54,7 +54,7 @@ fn collect_export_records(
     col: &velesdb_core::VectorCollection,
     include_vectors: bool,
 ) -> Vec<serde_json::Value> {
-    let all_ids = col.all_ids();
+    let all_ids = col.all_point_ids();
     let mut records = Vec::with_capacity(all_ids.len());
     let batch_size = 1000;
 

--- a/crates/velesdb-cli/src/handlers/info.rs
+++ b/crates/velesdb-cli/src/handlers/info.rs
@@ -229,7 +229,9 @@ fn print_vector_table(cfg: &velesdb_core::collection::CollectionConfig, type_lab
 /// Prints sample vector records.
 fn print_vector_samples(col: &velesdb_core::VectorCollection, samples: usize) {
     println!("\n{}", "Sample Records".bold().underline());
-    let ids: Vec<u64> = (1..=(samples as u64 * 2)).collect();
+    // Sample from the collection's actual IDs, not an assumed contiguous
+    // `1..=n` range: sparse/non-sequential IDs would otherwise show nothing.
+    let ids: Vec<u64> = col.all_ids().into_iter().take(samples).collect();
     let points = col.get(&ids);
     for point in points.into_iter().flatten().take(samples) {
         println!("  ID: {}", point.id.to_string().green());

--- a/crates/velesdb-cli/src/handlers/info.rs
+++ b/crates/velesdb-cli/src/handlers/info.rs
@@ -229,9 +229,10 @@ fn print_vector_table(cfg: &velesdb_core::collection::CollectionConfig, type_lab
 /// Prints sample vector records.
 fn print_vector_samples(col: &velesdb_core::VectorCollection, samples: usize) {
     println!("\n{}", "Sample Records".bold().underline());
-    // Sample from the collection's actual IDs, not an assumed contiguous
-    // `1..=n` range: sparse/non-sequential IDs would otherwise show nothing.
-    let ids: Vec<u64> = col.all_ids().into_iter().take(samples).collect();
+    // Sample from the collection's actual IDs (complete set, incl. None-payload
+    // points), not an assumed contiguous `1..=n` range which showed nothing on
+    // sparse/non-sequential IDs.
+    let ids: Vec<u64> = col.all_point_ids().into_iter().take(samples).collect();
     let points = col.get(&ids);
     for point in points.into_iter().flatten().take(samples) {
         println!("  ID: {}", point.id.to_string().green());

--- a/crates/velesdb-core/Cargo.toml
+++ b/crates/velesdb-core/Cargo.toml
@@ -62,7 +62,7 @@ version = "6.2"
 
 # GPU acceleration (optional)
 [dependencies.wgpu]
-version = "29"
+version = "30"
 optional = true
 
 [dependencies.pollster]

--- a/crates/velesdb-core/src/collection/vector_collection/accessors.rs
+++ b/crates/velesdb-core/src/collection/vector_collection/accessors.rs
@@ -55,6 +55,16 @@ impl VectorCollection {
         self.inner.all_ids()
     }
 
+    /// Returns every point ID (vector- or payload-backed) in ascending order.
+    ///
+    /// Unlike [`all_ids`](Self::all_ids), this includes points inserted with a
+    /// `None` payload, so it is the complete, deterministic set to iterate for
+    /// export/sampling.
+    #[must_use]
+    pub fn all_point_ids(&self) -> Vec<u64> {
+        self.inner.all_point_ids()
+    }
+
     /// Returns the next batch of points for scroll iteration.
     ///
     /// Delegates to the inner collection's scroll implementation; see also

--- a/crates/velesdb-core/src/gpu/gpu_backend.rs
+++ b/crates/velesdb-core/src/gpu/gpu_backend.rs
@@ -123,6 +123,7 @@ impl GpuAccelerator {
             power_preference: wgpu::PowerPreference::HighPerformance,
             compatible_surface: None,
             force_fallback_adapter: false,
+            apply_limit_buckets: false,
         }))
         .ok()?;
 

--- a/crates/velesdb-core/src/gpu/helpers.rs
+++ b/crates/velesdb-core/src/gpu/helpers.rs
@@ -86,7 +86,7 @@ pub(super) fn readback_buffer<T: bytemuck::Pod>(
 
     rx.recv().ok().and_then(Result::ok)?;
 
-    let data = buffer_slice.get_mapped_range();
+    let data = buffer_slice.get_mapped_range().ok()?;
     let typed: &[T] = bytemuck::cast_slice(&data);
     let result = typed[..count].to_vec();
     drop(data);

--- a/crates/velesdb-core/src/storage/compaction.rs
+++ b/crates/velesdb-core/src/storage/compaction.rs
@@ -540,35 +540,31 @@ impl CompactionContext<'_> {
             let _ = std::mem::replace(&mut *self.mmap.write(), placeholder);
         }
 
-        // 6. Commit: swap the data file in, promote the staged index, then
-        // truncate the now-obsolete WAL (see `commit_compaction` for the
-        // crash-safety invariant). Capture the result rather than `?`: after the
-        // step-5b placeholder swap, `self.mmap` is a 1-byte anonymous map, so we
-        // MUST remap a real file below on every path — otherwise a commit error
-        // would leave storage stranded on the placeholder.
+        // 6. COMMIT POINT: atomically swap the compacted temp file into place.
+        // After this succeeds, `vectors.dat` IS the compacted layout.
         let data_path = self.path.join("vectors.dat");
-        let commit_result = self.commit_compaction(&temp_path, &idx_tmp_path, &data_path);
+        let swapped = atomic_replace(&temp_path, &data_path);
 
-        // 7. Remap the live data file, replacing the placeholder. On success
-        // this is the compacted file; on commit failure it is whatever the swap
-        // left on disk (the untouched original if it failed early), so storage
-        // never stays on the anonymous placeholder.
+        // 7. Remap the live data file so storage never stays on the step-5b
+        // placeholder. `data_path` is the compacted file if the swap succeeded,
+        // otherwise the untouched original.
         let new_data_file = OpenOptions::new().read(true).write(true).open(&data_path)?;
         // SAFETY: `MmapMut::map_mut` requires a writable file sized for mapping.
-        // - Condition 1: `new_data_file` is opened read/write after atomic replace.
+        // - Condition 1: `new_data_file` is opened read/write after the swap.
         // - Condition 2: File contents are fully materialized by the preceding flush/rename flow.
         // SAFETY: Reloading mmap is required to switch storage to compacted bytes.
         let new_mmap = unsafe { MmapMut::map_mut(&new_data_file)? };
-        // Issue #316: Atomic index swap — replace mmap and index without
-        // an intermediate empty state visible to concurrent readers.
         *self.mmap.write() = new_mmap;
 
-        // Surface a commit failure now that a valid mapping is restored. The
-        // index/offset are left unchanged so they still match the pre-compaction
-        // file that startup recovery reinstates.
-        commit_result?;
-
-        // 8. Commit succeeded: adopt the compacted index and offsets.
+        // 8. Reconcile the in-memory index with what is now on disk. If the swap
+        // failed, the original data file is intact and the existing index/offset
+        // still describe it, so return the error without touching them.
+        swapped?;
+        // Swap succeeded: `vectors.dat` is the compacted layout, so the index and
+        // offset MUST switch to it. Adopt them BEFORE finalizing, so a failure in
+        // `finalize_commit` still leaves the index and the mmap mutually
+        // consistent (startup recovery reconciles the durable index/WAL). Issue
+        // #316: readers never observe an intermediate empty state (`&mut self`).
         self.index.replace_all(new_index);
         // Reason: Release ordering pairs with the Acquire loads in
         // `should_compact` and `compact` to ensure readers on ARM/weak-memory
@@ -576,20 +572,27 @@ impl CompactionContext<'_> {
         // new offset value.
         self.next_offset.store(new_offset, Ordering::Release);
 
+        // 9. Finalize: promote the staged index sidecar and truncate the obsolete
+        // WAL. A failure here is recoverable on the next open and does not desync
+        // the already-adopted in-memory index.
+        self.finalize_commit(&idx_tmp_path)?;
+
         Ok(bytes_to_reclaim)
     }
 
-    /// Commits a built compacted file: atomic data swap, index promotion and
-    /// WAL truncation, all under the WAL lock so no writer can append an
-    /// entry between the swap and the truncation.
+    /// Finalizes a compaction after the data-file swap: promotes the staged
+    /// index sidecar, makes the renames durable, and truncates the obsolete WAL.
+    /// Runs under the WAL lock so no writer can append between promotion and
+    /// truncation. Must be called only after `atomic_replace` has swapped the
+    /// compacted `vectors.dat` into place.
     ///
     /// # Crash-safety invariant
     ///
-    /// The rename of `vectors.dat.tmp` -> `vectors.dat` is the single commit
-    /// point. The compacted file plus the staged index fully capture every
-    /// acknowledged write (stores update the mmap before compaction snapshots
-    /// it), so once the swap is durable the prior WAL is obsolete and is
-    /// truncated. Every intermediate crash point is recoverable:
+    /// The `vectors.dat.tmp` -> `vectors.dat` rename (done by the caller) is the
+    /// single commit point. The compacted file plus the staged index fully
+    /// capture every acknowledged write, so once the swap is durable the prior
+    /// WAL is obsolete and is truncated. Every intermediate crash point is
+    /// recoverable:
     /// - before the swap: startup recovery removes both staged files and the
     ///   old dat/idx/WAL triple is untouched;
     /// - after the swap, before promotion: recovery promotes the sidecar;
@@ -597,16 +600,8 @@ impl CompactionContext<'_> {
     ///   every store record carries the full vector value and deletes replay
     ///   in order;
     /// - after promotion, before truncation: same convergent replay.
-    fn commit_compaction(
-        &self,
-        temp_path: &Path,
-        idx_tmp_path: &Path,
-        data_path: &Path,
-    ) -> io::Result<()> {
+    fn finalize_commit(&self, idx_tmp_path: &Path) -> io::Result<()> {
         let mut wal = self.wal.write();
-
-        // COMMIT POINT: atomic swap temp -> main (cross-platform).
-        atomic_replace(temp_path, data_path)?;
 
         // Promote the staged index so vectors.idx matches the new layout.
         let idx_path = self.path.join("vectors.idx");

--- a/crates/velesdb-core/src/storage/compaction.rs
+++ b/crates/velesdb-core/src/storage/compaction.rs
@@ -245,10 +245,8 @@ pub(super) fn persist_flat_index_atomic(
 
     persist_flat_index(&staging, index)?;
     promote_index_sidecar(&staging, path)?;
-    match path.parent() {
-        Some(dir) if !dir.as_os_str().is_empty() => sync_dir(dir),
-        _ => Ok(()),
-    }
+    let dir = path.parent().filter(|d| !d.as_os_str().is_empty());
+    durable_rename_barrier(dir, &[path])
 }
 
 /// Renames a fully written index file over `idx_path`.
@@ -266,18 +264,38 @@ fn promote_index_sidecar(sidecar: &Path, idx_path: &Path) -> io::Result<()> {
     std::fs::rename(sidecar, idx_path)
 }
 
-/// Fsyncs the storage directory so preceding renames are durable (POSIX).
+/// Makes preceding renames durable before the caller truncates the WAL.
 ///
-/// Without this, a power loss could persist the WAL truncation that follows
-/// the compaction commit while rolling back the renames themselves.
-fn sync_dir(dir: &Path) -> io::Result<()> {
+/// A compaction commit renames the new data/index files into place and then
+/// truncates the WAL. If the truncation reaches disk while the renames do not,
+/// a power loss leaves an empty WAL beside stale pre-compaction files — silent
+/// data loss. This barrier orders the renames before the truncation:
+///
+/// - **Unix:** fsync the directory, persisting the renames' directory entries.
+/// - **Windows/other:** there is no directory fsync, and the data file is
+///   memory-mapped so it cannot be reopened for write (`FlushFileBuffers`
+///   access-denied). Each *non-mapped* renamed file passed here (the index
+///   sidecar) is fsynced instead. Callers must NOT pass a currently-mmapped
+///   path. The data-file rename is ordered by NTFS: its record is written to
+///   `$LogFile` before the trailing `wal.sync_all()`, and NTFS's write-ahead
+///   invariant flushes `$LogFile` up to that point, so the rename is durable
+///   before the WAL truncation reaches disk (holds on NTFS; FAT/exFAT data
+///   directories are unsupported for durability).
+fn durable_rename_barrier(dir: Option<&Path>, renamed: &[&Path]) -> io::Result<()> {
     #[cfg(unix)]
     {
-        File::open(dir)?.sync_all()
+        let _ = renamed;
+        match dir {
+            Some(d) => File::open(d)?.sync_all(),
+            None => Ok(()),
+        }
     }
     #[cfg(not(unix))]
     {
         let _ = dir;
+        for path in renamed {
+            OpenOptions::new().write(true).open(path)?.sync_all()?;
+        }
         Ok(())
     }
 }
@@ -410,7 +428,8 @@ impl CompactionContext<'_> {
     /// # TS-CORE-004: Storage Compaction
     ///
     /// This operation is quasi-atomic via `rename()` for crash safety.
-    /// Reads remain available during compaction (copy-on-write pattern).
+    /// The caller holds the storage write lock for the duration, so reads are
+    /// blocked while compaction runs (it is not concurrent copy-on-write).
     ///
     /// # Returns
     ///
@@ -565,12 +584,17 @@ impl CompactionContext<'_> {
         atomic_replace(temp_path, data_path)?;
 
         // Promote the staged index so vectors.idx matches the new layout.
-        promote_index_sidecar(idx_tmp_path, &self.path.join("vectors.idx"))?;
+        let idx_path = self.path.join("vectors.idx");
+        promote_index_sidecar(idx_tmp_path, &idx_path)?;
 
-        // Make both renames durable before the truncation below can hit disk:
-        // a power loss must never persist an empty WAL while rolling back the
-        // renames that committed the compaction.
-        sync_dir(self.path)?;
+        // Make the renames durable before the truncation below can hit disk: a
+        // power loss must never persist an empty WAL while rolling back the
+        // renames that committed the compaction. On Unix this fsyncs the
+        // directory; on Windows the index sidecar is fsynced and the data-file
+        // rename is ordered via NTFS $LogFile (see durable_rename_barrier). The
+        // mmapped data file is deliberately not passed — it cannot be reopened
+        // for write while mapped.
+        durable_rename_barrier(Some(self.path), &[&idx_path])?;
 
         // Compaction renders the prior WAL obsolete: truncate it. flush()
         // first so the BufWriter cannot later re-append buffered stale

--- a/crates/velesdb-core/src/storage/compaction.rs
+++ b/crates/velesdb-core/src/storage/compaction.rs
@@ -526,24 +526,49 @@ impl CompactionContext<'_> {
         let idx_tmp_path = self.path.join("vectors.idx.tmp");
         persist_flat_index(&idx_tmp_path, &new_index)?;
 
+        // 5b. Release the live mapping of the OLD data file BEFORE the swap.
+        // Windows refuses to rename/replace a memory-mapped file
+        // (ERROR_ACCESS_DENIED), so `atomic_replace` below would fail while the
+        // old mapping is held — leaving compaction entirely broken on Windows.
+        // Swap in a tiny anonymous placeholder to unmap the file; step 7 remaps
+        // the compacted file. Safe because the caller holds `&mut self`
+        // (exclusive), so no `VectorSliceGuard` is outstanding to invalidate.
+        {
+            let placeholder = MmapMut::map_anon(1)?;
+            // Dropping the replaced value unmaps the old file-backed mapping,
+            // releasing the OS handle so the swap can rename the data file.
+            let _ = std::mem::replace(&mut *self.mmap.write(), placeholder);
+        }
+
         // 6. Commit: swap the data file in, promote the staged index, then
         // truncate the now-obsolete WAL (see `commit_compaction` for the
-        // crash-safety invariant).
+        // crash-safety invariant). Capture the result rather than `?`: after the
+        // step-5b placeholder swap, `self.mmap` is a 1-byte anonymous map, so we
+        // MUST remap a real file below on every path — otherwise a commit error
+        // would leave storage stranded on the placeholder.
         let data_path = self.path.join("vectors.dat");
-        self.commit_compaction(&temp_path, &idx_tmp_path, &data_path)?;
+        let commit_result = self.commit_compaction(&temp_path, &idx_tmp_path, &data_path);
 
-        // 7. Reopen the compacted file
+        // 7. Remap the live data file, replacing the placeholder. On success
+        // this is the compacted file; on commit failure it is whatever the swap
+        // left on disk (the untouched original if it failed early), so storage
+        // never stays on the anonymous placeholder.
         let new_data_file = OpenOptions::new().read(true).write(true).open(&data_path)?;
         // SAFETY: `MmapMut::map_mut` requires a writable file sized for mapping.
         // - Condition 1: `new_data_file` is opened read/write after atomic replace.
         // - Condition 2: File contents are fully materialized by the preceding flush/rename flow.
         // SAFETY: Reloading mmap is required to switch storage to compacted bytes.
         let new_mmap = unsafe { MmapMut::map_mut(&new_data_file)? };
-
-        // 8. Update internal state
         // Issue #316: Atomic index swap — replace mmap and index without
         // an intermediate empty state visible to concurrent readers.
         *self.mmap.write() = new_mmap;
+
+        // Surface a commit failure now that a valid mapping is restored. The
+        // index/offset are left unchanged so they still match the pre-compaction
+        // file that startup recovery reinstates.
+        commit_result?;
+
+        // 8. Commit succeeded: adopt the compacted index and offsets.
         self.index.replace_all(new_index);
         // Reason: Release ordering pairs with the Acquire loads in
         // `should_compact` and `compact` to ensure readers on ARM/weak-memory
@@ -591,18 +616,21 @@ impl CompactionContext<'_> {
         // power loss must never persist an empty WAL while rolling back the
         // renames that committed the compaction. On Unix this fsyncs the
         // directory; on Windows the index sidecar is fsynced and the data-file
-        // rename is ordered via NTFS $LogFile (see durable_rename_barrier). The
-        // mmapped data file is deliberately not passed — it cannot be reopened
-        // for write while mapped.
+        // rename is ordered via NTFS $LogFile (see durable_rename_barrier).
         durable_rename_barrier(Some(self.path), &[&idx_path])?;
 
-        // Compaction renders the prior WAL obsolete: truncate it. flush()
-        // first so the BufWriter cannot later re-append buffered stale
-        // entries; the fd is in append mode, so subsequent writes start at
-        // the new EOF (offset 0).
+        // Compaction renders the prior WAL obsolete: truncate it to zero.
+        // flush() first so the BufWriter cannot re-emit buffered stale entries;
+        // the append fd then writes fresh entries from the new EOF (offset 0).
+        // The WAL is opened append-only, so its handle lacks FILE_WRITE_DATA and
+        // set_len() on it is ACCESS_DENIED on Windows — truncate via a dedicated
+        // write handle instead (mirrors wal_replay::truncate_wal).
         wal.flush()?;
-        wal.get_ref().set_len(0)?;
-        wal.get_ref().sync_all()
+        let wal_file = OpenOptions::new()
+            .write(true)
+            .open(self.path.join("vectors.wal"))?;
+        wal_file.set_len(0)?;
+        wal_file.sync_all()
     }
 
     /// Returns the fragmentation ratio (0.0 = no fragmentation, 1.0 = 100% fragmented).

--- a/crates/velesdb-migrate/README.md
+++ b/crates/velesdb-migrate/README.md
@@ -420,7 +420,7 @@ options:
 ## 🔧 CLI Reference
 
 ```
-velesdb-migrate 1.7.0
+velesdb-migrate 3.8.0
 Migrate vectors from other databases to VelesDB
 
 USAGE:

--- a/crates/velesdb-migrate/src/pipeline_graph.rs
+++ b/crates/velesdb-migrate/src/pipeline_graph.rs
@@ -90,16 +90,11 @@ impl<'a> GraphMigrationPhase<'a> {
                 relation.from_column, relation.to_table, relation.to_column, relation.edge_label
             );
 
-            let edges = self
-                .extract_edges_for_relation(relation, batch_size)
+            let (created, failed) = self
+                .migrate_relation_edges(relation, batch_size, &gc)
                 .await?;
-
-            let total = edges.len() as u64;
-            let inserted = gc.add_edges_batch(edges).map_err(|e| {
-                Error::DestinationConnection(format!("Edge batch insert failed: {e}"))
-            })? as u64;
-            stats.edges_created += inserted;
-            stats.edges_failed += total.saturating_sub(inserted);
+            stats.edges_created += created;
+            stats.edges_failed += failed;
             stats.relations_processed += 1;
         }
 
@@ -114,12 +109,22 @@ impl<'a> GraphMigrationPhase<'a> {
         Ok(stats)
     }
 
-    async fn extract_edges_for_relation(
+    /// Streams a relation's edges into the graph collection batch by batch.
+    ///
+    /// Each source batch is converted to edges and inserted immediately, so
+    /// only one batch worth of edges is held in memory at a time. The previous
+    /// implementation accumulated every edge of a relation into a single `Vec`
+    /// before one bulk insert, which could exhaust memory on large sources.
+    ///
+    /// Returns `(edges_created, edges_failed)`.
+    async fn migrate_relation_edges(
         &self,
         relation: &RelationConfig,
         batch_size: usize,
-    ) -> Result<Vec<velesdb_core::GraphEdge>> {
-        let mut edges = Vec::new();
+        gc: &velesdb_core::GraphCollection,
+    ) -> Result<(u64, u64)> {
+        let mut created = 0u64;
+        let mut failed = 0u64;
         let mut offset = None;
 
         loop {
@@ -135,6 +140,7 @@ impl<'a> GraphMigrationPhase<'a> {
                 break;
             }
 
+            let mut edges = Vec::with_capacity(batch.points.len());
             for point in &batch.points {
                 if let Some(edge) = build_edge(point, relation) {
                     edges.push(edge);
@@ -146,13 +152,22 @@ impl<'a> GraphMigrationPhase<'a> {
                 }
             }
 
+            if !edges.is_empty() {
+                let total = edges.len() as u64;
+                let inserted = gc.add_edges_batch(edges).map_err(|e| {
+                    Error::DestinationConnection(format!("Edge batch insert failed: {e}"))
+                })? as u64;
+                created += inserted;
+                failed += total.saturating_sub(inserted);
+            }
+
             if !batch.has_more {
                 break;
             }
             offset = batch.next_offset;
         }
 
-        Ok(edges)
+        Ok((created, failed))
     }
 }
 

--- a/crates/velesdb-mobile/Cargo.toml
+++ b/crates/velesdb-mobile/Cargo.toml
@@ -28,6 +28,7 @@ uniffi = { version = "0.31", features = ["tokio", "cli"] }
 tokio = { version = "1.52", features = ["rt-multi-thread"] }
 parking_lot = "0.12"
 thiserror = "2.0"
+serde = { workspace = true }
 serde_json = "1.0"
 tracing = "0.1"
 

--- a/crates/velesdb-mobile/Cargo.toml
+++ b/crates/velesdb-mobile/Cargo.toml
@@ -24,7 +24,7 @@ path = "src/bin/uniffi-bindgen.rs"
 
 [dependencies]
 velesdb-core = { workspace = true }
-uniffi = { version = "0.31", features = ["tokio", "cli"] }
+uniffi = { version = "0.32", features = ["tokio", "cli"] }
 tokio = { version = "1.52", features = ["rt-multi-thread"] }
 parking_lot = "0.12"
 thiserror = "2.0"

--- a/crates/velesdb-mobile/src/graph.rs
+++ b/crates/velesdb-mobile/src/graph.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use parking_lot::RwLock;
 
 /// A graph node for knowledge graph construction.
-#[derive(Debug, Clone, uniffi::Record)]
+#[derive(Debug, Clone, uniffi::Record, serde::Serialize, serde::Deserialize)]
 pub struct MobileGraphNode {
     /// Unique identifier.
     pub id: u64,
@@ -21,7 +21,7 @@ pub struct MobileGraphNode {
 }
 
 /// A graph edge representing a relationship.
-#[derive(Debug, Clone, uniffi::Record)]
+#[derive(Debug, Clone, uniffi::Record, serde::Serialize, serde::Deserialize)]
 pub struct MobileGraphEdge {
     /// Unique identifier.
     pub id: u64,
@@ -100,12 +100,24 @@ impl From<velesdb_core::TraversalResult> for TraversalResult {
 }
 
 /// In-memory graph store for mobile knowledge graphs.
+///
+/// Nodes and edges are held in RAM for fast in-session traversal and are not
+/// written automatically. Call [`save`](Self::save) to persist a snapshot to
+/// disk and [`load`](Self::load) to restore it across app restarts.
 #[derive(uniffi::Object)]
 pub struct MobileGraphStore {
     nodes: RwLock<HashMap<u64, MobileGraphNode>>,
     edges: RwLock<HashMap<u64, MobileGraphEdge>>,
     outgoing: RwLock<HashMap<u64, Vec<u64>>>,
     incoming: RwLock<HashMap<u64, Vec<u64>>>,
+}
+
+/// On-disk snapshot of a [`MobileGraphStore`] (JSON). The outgoing/incoming
+/// adjacency is rebuilt from `edges` on load, so it is not stored.
+#[derive(serde::Serialize, serde::Deserialize)]
+struct GraphSnapshot {
+    nodes: Vec<MobileGraphNode>,
+    edges: Vec<MobileGraphEdge>,
 }
 
 #[uniffi::export]
@@ -119,6 +131,38 @@ impl MobileGraphStore {
             outgoing: RwLock::new(HashMap::new()),
             incoming: RwLock::new(HashMap::new()),
         })
+    }
+
+    /// Persists the current nodes and edges to `path` as JSON so the graph
+    /// survives an app restart (the store is otherwise in-memory only).
+    pub fn save(&self, path: String) -> Result<(), crate::VelesError> {
+        let snapshot = GraphSnapshot {
+            nodes: self.nodes.read().values().cloned().collect(),
+            edges: self.edges.read().values().cloned().collect(),
+        };
+        let bytes = serde_json::to_vec(&snapshot)
+            .map_err(|e| crate::VelesError::database(format!("Graph serialize failed: {e}")))?;
+        std::fs::write(&path, bytes)
+            .map_err(|e| crate::VelesError::database(format!("Graph save to '{path}' failed: {e}")))
+    }
+
+    /// Loads a graph previously written by [`save`](Self::save) from `path`,
+    /// rebuilding the adjacency from the stored edges.
+    #[uniffi::constructor]
+    pub fn load(path: String) -> Result<Arc<Self>, crate::VelesError> {
+        let bytes = std::fs::read(&path).map_err(|e| {
+            crate::VelesError::database(format!("Graph load from '{path}' failed: {e}"))
+        })?;
+        let snapshot: GraphSnapshot = serde_json::from_slice(&bytes)
+            .map_err(|e| crate::VelesError::database(format!("Graph deserialize failed: {e}")))?;
+        let store = Self::new();
+        for node in snapshot.nodes {
+            store.add_node(node);
+        }
+        for edge in snapshot.edges {
+            store.add_edge(edge)?;
+        }
+        Ok(store)
     }
 
     /// Adds a node to the graph.
@@ -580,6 +624,32 @@ mod tests {
         let result = store.add_edge(knows_edge(100, 1, 2));
         assert!(result.is_ok());
         assert_eq!(store.edge_count(), 1);
+    }
+
+    #[test]
+    fn test_mobile_graph_save_load_roundtrip() {
+        let store = store_with_nodes(3);
+        store.add_edge(knows_edge(100, 1, 2)).unwrap();
+        store.add_edge(knows_edge(101, 2, 3)).unwrap();
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("graph.json").to_string_lossy().to_string();
+        store.save(path.clone()).unwrap();
+
+        let restored = MobileGraphStore::load(path).unwrap();
+        assert_eq!(restored.node_count(), 3);
+        assert_eq!(restored.edge_count(), 2);
+        assert_eq!(restored.get_node(1).unwrap().label, "Person");
+        // Adjacency is rebuilt from the stored edges, not persisted directly.
+        let outgoing: Vec<u64> = restored.get_outgoing(1).iter().map(|e| e.id).collect();
+        assert_eq!(outgoing, vec![100]);
+        assert_eq!(restored.get_outgoing(2).len(), 1);
+    }
+
+    #[test]
+    fn test_mobile_graph_load_missing_file_errors() {
+        let result = MobileGraphStore::load("/nonexistent/velesdb-graph-missing.json".to_string());
+        assert!(result.is_err());
     }
 
     #[test]

--- a/crates/velesdb-node/src/lib.rs
+++ b/crates/velesdb-node/src/lib.rs
@@ -167,7 +167,7 @@ impl MemoryStore {
 
     /// Fused vector + `ColumnStore` recall: like [`recall`](Self::recall) but the
     /// `filters` support ranges/comparisons (`gt`, `le`, …), so temporal/numeric
-    /// facets become queryable. (No `PyO3` counterpart — napi-specific surface.)
+    /// facets become queryable. Mirrors the `PyO3` `recall_where` surface.
     #[napi(
         js_name = "recallWhere",
         ts_return_type = "Promise<Array<RecollectionJs>>"

--- a/crates/velesdb-python/README.md
+++ b/crates/velesdb-python/README.md
@@ -3,7 +3,7 @@
 [![PyPI](https://img.shields.io/pypi/v/velesdb)](https://pypi.org/project/velesdb/)
 [![Python](https://img.shields.io/pypi/pyversions/velesdb)](https://pypi.org/project/velesdb/)
 [![License](https://img.shields.io/badge/license-VelesDB_Core_1.0-blue)](./LICENSE)
-[![Version](https://img.shields.io/badge/version-3.8.0-blue)](https://github.com/cyberlife-coder/VelesDB/releases)
+[![Version](https://img.shields.io/badge/version-3.8.1-blue)](https://github.com/cyberlife-coder/VelesDB/releases)
 
 Python bindings for [VelesDB](https://github.com/cyberlife-coder/VelesDB) — a high-performance vector database for AI applications. `numpy>=1.20` ships as a hard runtime dependency since v1.13.8, so a single `pip install velesdb` is sufficient.
 

--- a/crates/velesdb-python/pyproject.toml
+++ b/crates/velesdb-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "velesdb"
-version = "3.8.0"
+version = "3.8.1"
 description = "VelesDB: The Local Vector Database for Python & AI. Microsecond semantic search, zero network latency."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/crates/velesdb-python/python/velesdb/__init__.py
+++ b/crates/velesdb-python/python/velesdb/__init__.py
@@ -22,6 +22,7 @@ from velesdb.velesdb import (  # type: ignore[attr-defined]
     Database as _RawDatabase,
     DatabaseLockedError,
     DimensionMismatchError,
+    CONDITION_TYPES,
     DISTANCE_METRICS,
     EdgeExistsError,
     FusionStrategy,
@@ -905,6 +906,7 @@ __all__ = [
     "AutoReindexOptions",
     "VelesConfigOptions",
     # Canonical enum name sets, single-sourced from velesdb-core (tuples of str).
+    "CONDITION_TYPES",
     "DISTANCE_METRICS",
     "STORAGE_MODES",
     "embed",

--- a/crates/velesdb-python/src/collection/mod.rs
+++ b/crates/velesdb-python/src/collection/mod.rs
@@ -82,18 +82,65 @@ fn async_builder_from_dict(value: &Bound<'_, PyAny>) -> PyResult<AsyncIndexBuild
 ///
 /// Collections store vectors with optional metadata (payload) and support
 /// efficient similarity search.
+/// Real kind of the core collection behind the single Python `Collection`
+/// facade. Vector-only operations use it to fail loud on graph/metadata
+/// collections instead of silently returning empty results (F2.2).
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CollectionKind {
+    /// HNSW vector collection — supports vector search.
+    Vector,
+    /// Graph collection — edges and optional node embeddings.
+    Graph,
+    /// Metadata-only collection — payload/VelesQL, no vector search.
+    Metadata,
+}
+
+impl CollectionKind {
+    /// Human-readable label used in error messages.
+    fn label(self) -> &'static str {
+        match self {
+            Self::Vector => "vector",
+            Self::Graph => "graph",
+            Self::Metadata => "metadata",
+        }
+    }
+}
+
 #[pyclass]
 pub struct Collection {
     /// Core collection (cheap to clone — all fields are `Arc`-wrapped internally).
     pub(crate) inner: CoreCollection,
     /// Cached name to avoid acquiring `config` read lock on every `#[getter]` access.
     pub(crate) name: String,
+    /// Real kind of the wrapped collection; guards vector-only methods.
+    pub(crate) kind: CollectionKind,
 }
 
 impl Collection {
-    /// Create a new Collection wrapper.
+    /// Create a wrapper for a vector collection.
     pub fn new(inner: CoreCollection, name: String) -> Self {
-        Self { inner, name }
+        Self::new_with_kind(inner, name, CollectionKind::Vector)
+    }
+
+    /// Create a wrapper for a collection whose real kind may not be vector
+    /// (graph/metadata), so vector-only methods fail loud rather than returning
+    /// empty results (F2.2).
+    pub(crate) fn new_with_kind(inner: CoreCollection, name: String, kind: CollectionKind) -> Self {
+        Self { inner, name, kind }
+    }
+
+    /// Rejects a vector-only operation on a non-vector collection with a clear,
+    /// actionable error instead of the silent empty result of F2.2.
+    fn ensure_vector(&self) -> PyResult<()> {
+        if self.kind == CollectionKind::Vector {
+            return Ok(());
+        }
+        Err(pyo3::exceptions::PyValueError::new_err(format!(
+            "vector search is not supported on the {} collection '{}'; \
+             use execute_query() for VelesQL or the graph API instead",
+            self.kind.label(),
+            self.name
+        )))
     }
 
     /// Dispatch to the correct search path based on which arguments are present.
@@ -111,6 +158,10 @@ impl Collection {
     ) -> PyResult<Vec<SearchResult>> {
         use crate::collection_helpers::core_err;
         use pyo3::exceptions::PyValueError;
+
+        // F2.2: vector search on a graph/metadata collection must fail loud,
+        // not return an empty list.
+        self.ensure_vector()?;
 
         let index_name =
             sparse_index_name.unwrap_or(velesdb_core::sparse_index::DEFAULT_SPARSE_INDEX_NAME);

--- a/crates/velesdb-python/src/collection/scroll.rs
+++ b/crates/velesdb-python/src/collection/scroll.rs
@@ -136,6 +136,35 @@ impl Collection {
             exhausted: false,
         })
     }
+
+    /// Fetch one batch of points starting after `cursor` (O(1) cursor seek).
+    ///
+    /// Returns ``(points, next_cursor)``: the batch as a list of dicts and the
+    /// cursor to pass on the next call (``None`` once the batch is the last).
+    /// Unlike the [`scroll`](Self::scroll) generator this is a stateless
+    /// one-shot for callers that persist the cursor themselves (e.g.
+    /// ``velesdb_common.scroll``), avoiding an O(n) re-scan per page.
+    #[pyo3(signature = (cursor=None, batch_size=100, filter=None))]
+    fn scroll_batch(
+        &self,
+        py: Python<'_>,
+        cursor: Option<u64>,
+        batch_size: usize,
+        filter: Option<Py<PyAny>>,
+    ) -> PyResult<(Vec<Py<PyAny>>, Option<u64>)> {
+        if batch_size == 0 {
+            return Err(PyValueError::new_err("batch_size must be greater than 0"));
+        }
+
+        let parsed_filter = parse_optional_filter(py, filter)?;
+        let inner = self.inner.clone();
+        let batch = py
+            .detach(move || inner.scroll_batch(cursor, batch_size, parsed_filter.as_ref()))
+            .map_err(core_err)?;
+
+        let dicts: Vec<Py<PyAny>> = batch.points.iter().map(|p| point_to_dict(py, p)).collect();
+        Ok((dicts, batch.next_cursor))
+    }
 }
 
 /// Eagerly validate that the requested DataFrame backend is importable.

--- a/crates/velesdb-python/src/collection/search.rs
+++ b/crates/velesdb-python/src/collection/search.rs
@@ -245,7 +245,9 @@ impl Collection {
         top_k: usize,
         filter: Option<Py<PyAny>>,
     ) -> PyResult<Vec<Py<PyAny>>> {
-        self.ensure_vector()?;
+        // No ensure_vector() here: BM25 text_search operates on the text index
+        // and takes no query vector, so it is valid on metadata/graph collections
+        // that carry text fields — unlike the vector-only search paths.
         let filter_obj = parse_optional_filter(py, filter)?;
         let query_owned = query.to_string();
 

--- a/crates/velesdb-python/src/collection/search.rs
+++ b/crates/velesdb-python/src/collection/search.rs
@@ -149,6 +149,7 @@ impl Collection {
         top_k: usize,
         ef_search: usize,
     ) -> PyResult<Vec<Py<PyAny>>> {
+        self.ensure_vector()?;
         let query_vector = extract_vector(py, &vector)?;
 
         let results = py.detach(|| {
@@ -176,6 +177,7 @@ impl Collection {
         quality: &str,
         top_k: usize,
     ) -> PyResult<Vec<Py<PyAny>>> {
+        self.ensure_vector()?;
         let query_vector = extract_vector(py, &vector)?;
         let sq = parse_search_quality(quality)?;
 
@@ -196,6 +198,7 @@ impl Collection {
         vector: Py<PyAny>,
         top_k: usize,
     ) -> PyResult<Vec<Py<PyAny>>> {
+        self.ensure_vector()?;
         let query_vector = extract_vector(py, &vector)?;
 
         let results = py.detach(|| {
@@ -217,6 +220,7 @@ impl Collection {
         top_k: usize,
         filter: Option<Py<PyAny>>,
     ) -> PyResult<Vec<Py<PyAny>>> {
+        self.ensure_vector()?;
         let query_vector = extract_vector(py, &vector)?;
         let filter_obj = filter
             .map(|f| parse_filter(py, &f))
@@ -241,6 +245,7 @@ impl Collection {
         top_k: usize,
         filter: Option<Py<PyAny>>,
     ) -> PyResult<Vec<Py<PyAny>>> {
+        self.ensure_vector()?;
         let filter_obj = parse_optional_filter(py, filter)?;
         let query_owned = query.to_string();
 
@@ -270,6 +275,7 @@ impl Collection {
         vector_weight: f32,
         filter: Option<Py<PyAny>>,
     ) -> PyResult<Vec<Py<PyAny>>> {
+        self.ensure_vector()?;
         let query_vector = extract_vector(py, &vector)?;
         let filter_obj = parse_optional_filter(py, filter)?;
         let query_owned = query.to_string();
@@ -307,6 +313,7 @@ impl Collection {
         py: Python<'_>,
         searches: Vec<HashMap<String, Py<PyAny>>>,
     ) -> PyResult<Vec<Vec<Py<PyAny>>>> {
+        self.ensure_vector()?;
         let parsed = Self::parse_batch_searches(py, &searches)?;
 
         let results = py.detach(|| self.dispatch_batch_by_top_k(&parsed))?;
@@ -324,6 +331,7 @@ impl Collection {
         fusion: Option<FusionStrategy>,
         filter: Option<Py<PyAny>>,
     ) -> PyResult<Vec<Py<PyAny>>> {
+        self.ensure_vector()?;
         let query_vectors: Vec<Vec<f32>> = vectors
             .iter()
             .map(|v| extract_vector(py, v))
@@ -360,6 +368,7 @@ impl Collection {
         vectors: Vec<Py<PyAny>>,
         top_k: usize,
     ) -> PyResult<Vec<Vec<Py<PyAny>>>> {
+        self.ensure_vector()?;
         let query_vectors: Vec<Vec<f32>> = vectors
             .iter()
             .map(|v| extract_vector(py, v))
@@ -384,6 +393,7 @@ impl Collection {
         top_k: usize,
         fusion: Option<FusionStrategy>,
     ) -> PyResult<Vec<Py<PyAny>>> {
+        self.ensure_vector()?;
         let query_vectors: Vec<Vec<f32>> = vectors
             .iter()
             .map(|v| extract_vector(py, v))

--- a/crates/velesdb-python/src/database.rs
+++ b/crates/velesdb-python/src/database.rs
@@ -6,7 +6,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use crate::agent;
-use crate::collection::Collection;
+use crate::collection::{Collection, CollectionKind};
 use crate::collection_helpers::core_err;
 use crate::graph_collection::{PyGraphCollection, PyGraphSchema};
 use crate::observer::PyObserver;
@@ -334,20 +334,23 @@ impl Database {
     fn get_collection(&self, name: &str) -> PyResult<Option<Collection>> {
         match self.inner.get_any_collection(name) {
             Some(any_coll) => {
-                // F2.2 mitigation: Python SDK exposes a single Collection
-                // type. Invoking vector-specific methods on a graph or
-                // metadata collection returns empty results rather than
-                // raising — the typed split is tracked as a post-seed
-                // EPIC in docs/ARCHITECTURE.md.
-                //
-                // SAFETY: Python SDK exposes a single Collection facade over all variants.
-                // - any_coll comes from `get_any_collection`, returned Some, so the
-                //   underlying `AnyCollection` is registered and valid.
-                // - Only the shared surface is guaranteed correct on non-Vector variants;
-                //   vector-only methods return empty results by design.
-                // Reason: single-Collection Python ergonomic facade.
+                // The Python SDK exposes a single `Collection` facade over all
+                // variants. Capture the real kind so vector-only methods fail
+                // loud on graph/metadata collections (F2.2) instead of silently
+                // returning empty results.
+                let kind = if any_coll.is_graph() {
+                    CollectionKind::Graph
+                } else if any_coll.is_metadata() {
+                    CollectionKind::Metadata
+                } else {
+                    CollectionKind::Vector
+                };
+                // SAFETY: `any_coll` came from `get_any_collection` (Some), so the
+                // underlying `AnyCollection` is registered and valid. The coerced
+                // vector facade only exercises the shared surface for non-Vector
+                // kinds; `Collection::ensure_vector` rejects vector-only ops.
                 let vc = unsafe { any_coll.into_vector_unchecked() };
-                Ok(Some(Collection::new(vc, name.to_string())))
+                Ok(Some(Collection::new_with_kind(vc, name.to_string(), kind)))
             }
             None => Ok(None),
         }
@@ -431,7 +434,11 @@ impl Database {
         // Reason: single-Collection Python ergonomic facade.
         let collection = unsafe { any.into_vector_unchecked() };
 
-        Ok(Collection::new(collection, name_owned))
+        Ok(Collection::new_with_kind(
+            collection,
+            name_owned,
+            CollectionKind::Metadata,
+        ))
     }
 
     /// Create an AgentMemory instance for AI agent workflows.

--- a/crates/velesdb-python/tests/test_scroll.py
+++ b/crates/velesdb-python/tests/test_scroll.py
@@ -80,6 +80,31 @@ def test_scroll_single_page_yields_full_dataset(temp_db) -> None:
     assert sorted(ids) == [1, 2, 3, 4, 5]
 
 
+def test_scroll_batch_cursor_pagination_covers_all(temp_db) -> None:
+    """Collection.scroll_batch(cursor, batch_size) does a stateless O(1) seek:
+    driving it with the returned cursor covers every point exactly once."""
+    col = temp_db.create_collection("scroll_batch_cursor", dimension=4)
+    _seed(col, 10)
+
+    seen: list[int] = []
+    cursor = None
+    while True:
+        points, cursor = col.scroll_batch(cursor, 3)
+        if not points:
+            break
+        seen.extend(p["id"] for p in points)
+    assert sorted(seen) == list(range(1, 11))
+    assert cursor is None
+
+
+def test_scroll_batch_empty_collection(temp_db) -> None:
+    """scroll_batch on an empty collection returns no points and no cursor."""
+    col = temp_db.create_collection("scroll_batch_empty", dimension=4)
+    points, cursor = col.scroll_batch(None, 10)
+    assert points == []
+    assert cursor is None
+
+
 def test_scroll_multi_page_covers_every_point_once(temp_db) -> None:
     """Multi-page scroll exhausts the collection without duplicates or gaps."""
     col = temp_db.create_collection("scroll_multi", dimension=4)

--- a/crates/velesdb-python/tests/test_velesdb.py
+++ b/crates/velesdb-python/tests/test_velesdb.py
@@ -699,6 +699,22 @@ class TestMetadataOnlyCollections:
         assert collection.name == "products"
         assert collection.is_metadata_only()
 
+    def test_search_on_metadata_collection_raises(self, temp_db):
+        """F2.2: vector search on a metadata collection fails loud (raises),
+        instead of silently returning an empty list."""
+        collection = temp_db.create_metadata_collection("catalog_f22")
+        collection.upsert_metadata([{"id": 1, "payload": {"name": "Widget"}}])
+        with pytest.raises(ValueError):
+            collection.search([1.0, 0.0, 0.0, 0.0], top_k=2)
+
+    def test_search_on_metadata_via_get_collection_raises(self, temp_db):
+        """F2.2: the same guard applies when the metadata collection is
+        re-fetched through the generic get_collection() facade."""
+        temp_db.create_metadata_collection("catalog_f22b")
+        collection = temp_db.get_collection("catalog_f22b")
+        with pytest.raises(ValueError):
+            collection.search([1.0, 0.0, 0.0, 0.0], top_k=2)
+
     def test_metadata_collection_info(self, temp_db):
         """Test metadata-only collection info."""
         collection = temp_db.create_metadata_collection("catalog")

--- a/crates/velesdb-server/README.md
+++ b/crates/velesdb-server/README.md
@@ -659,7 +659,7 @@ curl http://localhost:8080/health
 Response:
 
 ```json
-{"status": "ok", "version": "3.8.0"}
+{"status": "ok", "version": "3.8.1"}
 ```
 
 ### `GET /ready` -- Readiness Probe
@@ -673,13 +673,13 @@ curl http://localhost:8080/ready
 Response (ready):
 
 ```json
-{"status": "ready", "version": "3.8.0"}
+{"status": "ready", "version": "3.8.1"}
 ```
 
 Response (not ready):
 
 ```json
-{"status": "not_ready", "version": "3.8.0"}
+{"status": "not_ready", "version": "3.8.1"}
 ```
 
 ### Kubernetes Example

--- a/crates/velesdb-server/src/handlers/search/batch.rs
+++ b/crates/velesdb-server/src/handlers/search/batch.rs
@@ -34,7 +34,6 @@ use crate::handlers::helpers::{
         (status = 400, description = "Invalid request", body = ErrorResponse)
     )
 )]
-#[allow(clippy::unused_async)]
 pub async fn batch_search(
     State(state): State<Arc<AppState>>,
     headers: axum::http::HeaderMap,
@@ -72,10 +71,35 @@ pub async fn batch_search(
         }
     };
 
-    let queries: Vec<&[f32]> = req.searches.iter().map(|s| s.vector.as_slice()).collect();
+    // F-01 sweep: batch search is CPU-bound (one HNSW pass per query) and must
+    // not run on the async runtime thread — a large batch would otherwise block
+    // a Tokio worker and starve concurrent requests. Move it to a blocking
+    // worker like the other search endpoints. `spawn_blocking` needs a 'static
+    // closure, so owned query vectors + filters are moved in and the `&[f32]`
+    // views are rebuilt inside.
+    let collection_for_work = collection.clone();
+    let query_vectors: Vec<Vec<f32>> = req.searches.iter().map(|s| s.vector.clone()).collect();
     let max_top_k = req.searches.iter().map(|s| s.top_k).max().unwrap_or(10);
 
-    let batch_result = run_batch_search(&collection, &queries, max_top_k, &filters);
+    let batch_result = match tokio::task::spawn_blocking(move || {
+        let queries: Vec<&[f32]> = query_vectors.iter().map(Vec::as_slice).collect();
+        run_batch_search(&collection_for_work, &queries, max_top_k, &filters)
+    })
+    .await
+    {
+        Ok(inner) => inner,
+        Err(_) => {
+            state.operational_metrics.inc_errors();
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse {
+                    error: "Batch search worker failed".to_string(),
+                    code: None,
+                }),
+            )
+                .into_response();
+        }
+    };
     record_circuit_breaker(&collection, &batch_result);
 
     let all_results = match batch_result {

--- a/crates/velesdb-wasm/src/agent.rs
+++ b/crates/velesdb-wasm/src/agent.rs
@@ -28,11 +28,11 @@ pub struct SemanticResult {
 ///
 /// # Durability
 ///
-/// **In-memory only.** The WASM crate has no `persistence` feature. The
-/// `VectorStore` binary format used by `export_to_bytes`/`save`/`load` does
-/// **not** serialize payloads, so fact content does **not** survive a
-/// store reload. Persist content out-of-band (e.g. in application state or
-/// IndexedDB) if durability is required.
+/// **Not auto-persisted.** The WASM crate has no `persistence` feature, but the
+/// `VectorStore` binary format (`export_to_bytes`/`save`/`load`, v2) **does**
+/// serialize payloads, so fact content **survives** an explicit `save()` →
+/// `load()` roundtrip. Call `save()` (e.g. to IndexedDB) to keep state across
+/// reloads; nothing is written automatically.
 ///
 /// # Example (JavaScript)
 ///

--- a/crates/velesdb-wasm/src/serialization.rs
+++ b/crates/velesdb-wasm/src/serialization.rs
@@ -34,7 +34,9 @@ fn byte_to_mode(byte: u8) -> Result<StorageMode, JsValue> {
         2 => Ok(StorageMode::Binary),
         3 => Ok(StorageMode::ProductQuantization),
         4 => Ok(StorageMode::RaBitQ),
-        _ => Err(JsValue::from_str(&format!("Invalid storage-mode byte: {byte}"))),
+        _ => Err(JsValue::from_str(&format!(
+            "Invalid storage-mode byte: {byte}"
+        ))),
     }
 }
 
@@ -78,7 +80,11 @@ pub fn export_to_bytes(store: &VectorStore) -> Vec<u8> {
     let mut bytes = Vec::new();
     bytes.extend_from_slice(b"VELS");
     bytes.push(FORMAT_VERSION);
-    bytes.extend_from_slice(&u32::try_from(store.dimension).unwrap_or(u32::MAX).to_le_bytes());
+    bytes.extend_from_slice(
+        &u32::try_from(store.dimension)
+            .unwrap_or(u32::MAX)
+            .to_le_bytes(),
+    );
     bytes.push(metric_to_byte(store.metric));
     bytes.push(mode_to_byte(store.storage_mode));
     bytes.extend_from_slice(&(store.ids.len() as u64).to_le_bytes());
@@ -125,7 +131,9 @@ fn read_blob<'a>(bytes: &'a [u8], offset: &mut usize) -> Result<&'a [u8], JsValu
 fn read_f32_blob(bytes: &[u8], offset: &mut usize) -> Result<Vec<f32>, JsValue> {
     let blob = read_blob(bytes, offset)?;
     if blob.len() % 4 != 0 {
-        return Err(JsValue::from_str("Invalid data: f32 blob not 4-byte aligned"));
+        return Err(JsValue::from_str(
+            "Invalid data: f32 blob not 4-byte aligned",
+        ));
     }
     Ok(blob
         .chunks_exact(4)

--- a/crates/velesdb-wasm/src/serialization.rs
+++ b/crates/velesdb-wasm/src/serialization.rs
@@ -5,83 +5,218 @@
 use crate::{DistanceMetric, StorageMode, VectorStore};
 use wasm_bindgen::JsValue;
 
-/// Binary format header size.
+/// v1 header size (magic4 + version1 + dim4 + metric1 + count8). v1 stored only
+/// id + f32 vectors (Full mode); kept for reading legacy data.
 pub const HEADER_SIZE: usize = 18;
 
-/// Serializes a `VectorStore` to binary format.
-///
-/// Format:
-/// - Magic: "VELS" (4 bytes)
-/// - Version: 1 (1 byte)
-/// - Dimension: u32 LE (4 bytes)
-/// - Metric: u8 (1 byte)
-/// - Count: u64 LE (8 bytes)
-/// - Data: [id: u64, vector: f32 * dim] * count
-pub fn export_to_bytes(store: &VectorStore) -> Vec<u8> {
-    let count = store.ids.len();
-    let vector_size = 8 + store.dimension * 4;
-    let total_size = HEADER_SIZE + count * vector_size;
-    let mut bytes = Vec::with_capacity(total_size);
+/// v2 header size — v1 plus a storage-mode byte.
+const HEADER_SIZE_V2: usize = 19;
 
-    // Header: magic number "VELS"
-    bytes.extend_from_slice(b"VELS");
+/// Current format version written by [`export_to_bytes`].
+const FORMAT_VERSION: u8 = 2;
 
-    // Version
-    bytes.push(1);
-
-    // Dimension
-    let Ok(dim_u32) = u32::try_from(store.dimension) else {
-        return Vec::new();
-    };
-    bytes.extend_from_slice(&dim_u32.to_le_bytes());
-
-    // Metric
-    let metric_byte = metric_to_byte(store.metric);
-    bytes.push(metric_byte);
-
-    // Vector count
-    let Ok(count_u64) = u64::try_from(count) else {
-        return Vec::new();
-    };
-    bytes.extend_from_slice(&count_u64.to_le_bytes());
-
-    // Data
-    for (idx, &id) in store.ids.iter().enumerate() {
-        bytes.extend_from_slice(&id.to_le_bytes());
-        let start = idx * store.dimension;
-        let data_slice = &store.data[start..start + store.dimension];
-        // SAFETY: [f32] and [u8] share the same memory layout (IEEE 754 binary32).
-        // - `data_slice` is a valid, aligned slice of `f32` owned by `store.data`.
-        // - Length is `dimension * 4` bytes, exactly the byte representation of `dimension` f32 values.
-        // Reason: bulk byte copy avoids per-element serialization for 500+ MB/s throughput.
-        let data_bytes: &[u8] = unsafe {
-            core::slice::from_raw_parts(data_slice.as_ptr().cast::<u8>(), store.dimension * 4)
-        };
-        bytes.extend_from_slice(data_bytes);
+/// Maps a storage mode to its on-disk byte.
+fn mode_to_byte(mode: StorageMode) -> u8 {
+    match mode {
+        StorageMode::Full => 0,
+        StorageMode::SQ8 => 1,
+        StorageMode::Binary => 2,
+        StorageMode::ProductQuantization => 3,
+        StorageMode::RaBitQ => 4,
     }
+}
 
+/// Maps an on-disk byte back to a storage mode.
+fn byte_to_mode(byte: u8) -> Result<StorageMode, JsValue> {
+    match byte {
+        0 => Ok(StorageMode::Full),
+        1 => Ok(StorageMode::SQ8),
+        2 => Ok(StorageMode::Binary),
+        3 => Ok(StorageMode::ProductQuantization),
+        4 => Ok(StorageMode::RaBitQ),
+        _ => Err(JsValue::from_str(&format!("Invalid storage-mode byte: {byte}"))),
+    }
+}
+
+/// Appends a length-prefixed (u64 LE) byte blob.
+fn write_blob(out: &mut Vec<u8>, bytes: &[u8]) {
+    out.extend_from_slice(&(bytes.len() as u64).to_le_bytes());
+    out.extend_from_slice(bytes);
+}
+
+/// Appends a length-prefixed blob of little-endian f32 values.
+fn write_f32_blob(out: &mut Vec<u8>, values: &[f32]) {
+    out.extend_from_slice(&((values.len() as u64) * 4).to_le_bytes());
+    for &v in values {
+        out.extend_from_slice(&v.to_le_bytes());
+    }
+}
+
+/// Appends the payloads section: each entry is a blob — empty for `None`,
+/// otherwise the JSON bytes of the value.
+fn write_payloads(out: &mut Vec<u8>, payloads: &[Option<serde_json::Value>]) {
+    for payload in payloads {
+        match payload {
+            Some(v) => write_blob(out, &serde_json::to_vec(v).unwrap_or_default()),
+            None => write_blob(out, &[]),
+        }
+    }
+}
+
+/// Serializes a `VectorStore` to the v2 binary format.
+///
+/// Layout (little-endian): `"VELS"`(4) | version=2(1) | dimension u32(4) |
+/// metric u8(1) | storage-mode u8(1) | count u64(8), then `count` u64 IDs, then
+/// five length-prefixed blobs (`data` f32, `data_sq8`, `data_binary`,
+/// `sq8_mins` f32, `sq8_scales` f32), then `count` payload blobs (empty = None).
+///
+/// Unlike v1 (id + f32 only, Full mode), v2 preserves the storage mode, the
+/// quantized buffers and the payloads, and never panics on a quantized store
+/// (v1 indexed the empty `data` buffer in SQ8/Binary mode). The sparse index is
+/// not persisted (rebuilt on demand), as in v1.
+pub fn export_to_bytes(store: &VectorStore) -> Vec<u8> {
+    let mut bytes = Vec::new();
+    bytes.extend_from_slice(b"VELS");
+    bytes.push(FORMAT_VERSION);
+    bytes.extend_from_slice(&u32::try_from(store.dimension).unwrap_or(u32::MAX).to_le_bytes());
+    bytes.push(metric_to_byte(store.metric));
+    bytes.push(mode_to_byte(store.storage_mode));
+    bytes.extend_from_slice(&(store.ids.len() as u64).to_le_bytes());
+
+    for &id in &store.ids {
+        bytes.extend_from_slice(&id.to_le_bytes());
+    }
+    write_f32_blob(&mut bytes, &store.data);
+    write_blob(&mut bytes, &store.data_sq8);
+    write_blob(&mut bytes, &store.data_binary);
+    write_f32_blob(&mut bytes, &store.sq8_mins);
+    write_f32_blob(&mut bytes, &store.sq8_scales);
+    write_payloads(&mut bytes, &store.payloads);
     bytes
 }
 
-/// Deserializes a `VectorStore` from binary format.
-///
-/// Perf: Uses bulk copy for 500+ MB/s throughput.
+/// Reads a u64 LE at `*offset`, advancing it. Bounds-checked.
+fn read_u64(bytes: &[u8], offset: &mut usize) -> Result<u64, JsValue> {
+    let end = offset
+        .checked_add(8)
+        .filter(|&e| e <= bytes.len())
+        .ok_or_else(|| JsValue::from_str("Invalid data: truncated u64"))?;
+    let arr: [u8; 8] = bytes[*offset..end]
+        .try_into()
+        .map_err(|_| JsValue::from_str("Invalid data: u64 slice"))?;
+    *offset = end;
+    Ok(u64::from_le_bytes(arr))
+}
+
+/// Reads a length-prefixed (u64 LE) byte blob, advancing `*offset`. Bounds-checked.
+fn read_blob<'a>(bytes: &'a [u8], offset: &mut usize) -> Result<&'a [u8], JsValue> {
+    let len = usize::try_from(read_u64(bytes, offset)?)
+        .map_err(|_| JsValue::from_str("Invalid data: blob length too large"))?;
+    let end = offset
+        .checked_add(len)
+        .filter(|&e| e <= bytes.len())
+        .ok_or_else(|| JsValue::from_str("Invalid data: blob out of bounds"))?;
+    let slice = &bytes[*offset..end];
+    *offset = end;
+    Ok(slice)
+}
+
+/// Reads a length-prefixed blob and decodes it as little-endian f32 values.
+fn read_f32_blob(bytes: &[u8], offset: &mut usize) -> Result<Vec<f32>, JsValue> {
+    let blob = read_blob(bytes, offset)?;
+    if blob.len() % 4 != 0 {
+        return Err(JsValue::from_str("Invalid data: f32 blob not 4-byte aligned"));
+    }
+    Ok(blob
+        .chunks_exact(4)
+        .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+        .collect())
+}
+
+/// Reads `count` payload blobs (an empty blob decodes to `None`).
+fn read_payloads(
+    bytes: &[u8],
+    offset: &mut usize,
+    count: usize,
+) -> Result<Vec<Option<serde_json::Value>>, JsValue> {
+    let mut payloads = Vec::with_capacity(count);
+    for _ in 0..count {
+        let blob = read_blob(bytes, offset)?;
+        if blob.is_empty() {
+            payloads.push(None);
+        } else {
+            let value = serde_json::from_slice(blob)
+                .map_err(|e| JsValue::from_str(&format!("Invalid payload JSON: {e}")))?;
+            payloads.push(Some(value));
+        }
+    }
+    Ok(payloads)
+}
+
+/// Deserializes a `VectorStore`, dispatching on the format version byte.
 pub fn import_from_bytes(bytes: &[u8]) -> Result<VectorStore, JsValue> {
-    if bytes.len() < HEADER_SIZE {
+    if bytes.len() < 5 {
         return Err(JsValue::from_str("Invalid data: too short"));
     }
-
-    // Check magic
     if &bytes[0..4] != b"VELS" {
         return Err(JsValue::from_str("Invalid data: wrong magic number"));
     }
+    match bytes[4] {
+        1 => import_v1(bytes),
+        2 => import_v2(bytes),
+        v => Err(JsValue::from_str(&format!("Unsupported version: {v}"))),
+    }
+}
 
-    // Check version
-    let version = bytes[4];
-    if version != 1 {
-        return Err(JsValue::from_str(&format!(
-            "Unsupported version: {version}"
-        )));
+/// Reads the v2 format (storage mode, quantized buffers and payloads preserved).
+fn import_v2(bytes: &[u8]) -> Result<VectorStore, JsValue> {
+    if bytes.len() < HEADER_SIZE_V2 {
+        return Err(JsValue::from_str("Invalid data: too short"));
+    }
+    let dimension = u32::from_le_bytes([bytes[5], bytes[6], bytes[7], bytes[8]]) as usize;
+    let metric = byte_to_metric(bytes[9])?;
+    let storage_mode = byte_to_mode(bytes[10])?;
+    let count = usize::try_from(u64::from_le_bytes([
+        bytes[11], bytes[12], bytes[13], bytes[14], bytes[15], bytes[16], bytes[17], bytes[18],
+    ]))
+    .map_err(|_| JsValue::from_str("Invalid data: count too large"))?;
+    let mut offset = HEADER_SIZE_V2;
+    // DoS guard: each ID needs 8 bytes, so `count` cannot exceed the remaining
+    // input — reject before allocating.
+    if count > bytes.len().saturating_sub(offset) / 8 {
+        return Err(JsValue::from_str("Invalid data: count exceeds input size"));
+    }
+
+    let mut ids = Vec::with_capacity(count);
+    for _ in 0..count {
+        ids.push(read_u64(bytes, &mut offset)?);
+    }
+    let data = read_f32_blob(bytes, &mut offset)?;
+    let data_sq8 = read_blob(bytes, &mut offset)?.to_vec();
+    let data_binary = read_blob(bytes, &mut offset)?.to_vec();
+    let sq8_mins = read_f32_blob(bytes, &mut offset)?;
+    let sq8_scales = read_f32_blob(bytes, &mut offset)?;
+    let payloads = read_payloads(bytes, &mut offset, count)?;
+
+    Ok(VectorStore {
+        ids,
+        data,
+        data_sq8,
+        data_binary,
+        sq8_mins,
+        sq8_scales,
+        payloads,
+        dimension,
+        metric,
+        storage_mode,
+        sparse_index: None,
+    })
+}
+
+/// Reads the legacy v1 format (id + f32 vectors only; Full mode, no payloads).
+fn import_v1(bytes: &[u8]) -> Result<VectorStore, JsValue> {
+    if bytes.len() < HEADER_SIZE {
+        return Err(JsValue::from_str("Invalid data: too short"));
     }
 
     // Read dimension
@@ -210,5 +345,82 @@ mod tests {
             let result = byte_to_metric(byte).unwrap();
             assert_eq!(metric, result);
         }
+    }
+
+    #[test]
+    fn test_v2_roundtrip_full_preserves_payloads() {
+        let store = VectorStore {
+            ids: vec![1, 2],
+            data: vec![1.0, 2.0, 3.0, 4.0],
+            data_sq8: Vec::new(),
+            data_binary: Vec::new(),
+            sq8_mins: Vec::new(),
+            sq8_scales: Vec::new(),
+            payloads: vec![Some(serde_json::json!({"k": "v"})), None],
+            dimension: 2,
+            metric: DistanceMetric::Cosine,
+            storage_mode: StorageMode::Full,
+            sparse_index: None,
+        };
+        let restored = import_from_bytes(&export_to_bytes(&store)).unwrap();
+        assert_eq!(restored.ids, vec![1, 2]);
+        assert_eq!(restored.data, vec![1.0, 2.0, 3.0, 4.0]);
+        assert_eq!(
+            mode_to_byte(restored.storage_mode),
+            mode_to_byte(StorageMode::Full)
+        );
+        assert_eq!(restored.payloads[0], Some(serde_json::json!({"k": "v"})));
+        assert_eq!(restored.payloads[1], None);
+    }
+
+    #[test]
+    fn test_v2_roundtrip_sq8_preserves_mode_buffers_payload() {
+        // v1 dropped the SQ8 buffers/mode (reloaded as Full) and all payloads.
+        let store = VectorStore {
+            ids: vec![10],
+            data: Vec::new(),
+            data_sq8: vec![200, 100],
+            data_binary: Vec::new(),
+            sq8_mins: vec![0.5],
+            sq8_scales: vec![0.01],
+            payloads: vec![Some(serde_json::json!({"x": 1}))],
+            dimension: 2,
+            metric: DistanceMetric::Euclidean,
+            storage_mode: StorageMode::SQ8,
+            sparse_index: None,
+        };
+        let restored = import_from_bytes(&export_to_bytes(&store)).unwrap();
+        assert_eq!(
+            mode_to_byte(restored.storage_mode),
+            mode_to_byte(StorageMode::SQ8)
+        );
+        assert_eq!(restored.data_sq8, vec![200, 100]);
+        assert_eq!(restored.sq8_mins, vec![0.5]);
+        assert_eq!(restored.sq8_scales, vec![0.01]);
+        assert_eq!(restored.payloads[0], Some(serde_json::json!({"x": 1})));
+    }
+
+    #[test]
+    fn test_v2_roundtrip_binary_does_not_panic() {
+        // v1 panicked here by indexing the empty `data` buffer in Binary mode.
+        let store = VectorStore {
+            ids: vec![7],
+            data: Vec::new(),
+            data_sq8: Vec::new(),
+            data_binary: vec![0b1010_1010],
+            sq8_mins: Vec::new(),
+            sq8_scales: Vec::new(),
+            payloads: vec![None],
+            dimension: 8,
+            metric: DistanceMetric::Hamming,
+            storage_mode: StorageMode::Binary,
+            sparse_index: None,
+        };
+        let restored = import_from_bytes(&export_to_bytes(&store)).unwrap();
+        assert_eq!(
+            mode_to_byte(restored.storage_mode),
+            mode_to_byte(StorageMode::Binary)
+        );
+        assert_eq!(restored.data_binary, vec![0b1010_1010]);
     }
 }

--- a/demos/rag-pdf-demo/pyproject.toml
+++ b/demos/rag-pdf-demo/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "velesdb-rag-demo"
-version = "3.8.0"
+version = "3.8.1"
 description = "RAG Demo with PDF ingestion using VelesDB for vector storage"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/demos/rag-pdf-demo/src/__init__.py
+++ b/demos/rag-pdf-demo/src/__init__.py
@@ -1,3 +1,3 @@
 """VelesDB RAG Demo - PDF Question Answering System."""
 
-__version__ = "3.8.0"
+__version__ = "3.8.1"

--- a/demos/rag-pdf-demo/src/main.py
+++ b/demos/rag-pdf-demo/src/main.py
@@ -46,7 +46,7 @@ async def lifespan(app: FastAPI):
 app = FastAPI(
     title="VelesDB RAG Demo",
     description="PDF Question Answering with VelesDB vector search",
-    version="3.8.0",
+    version="3.8.1",
     lifespan=lifespan
 )
 

--- a/deny.toml
+++ b/deny.toml
@@ -22,11 +22,9 @@ ignore = [
     { id = "RUSTSEC-2024-0418", reason = "gdk-sys: tauri Linux GTK3 — no fix; Tauri 3 migration tracked" },
     { id = "RUSTSEC-2024-0419", reason = "gtk3-macros: tauri Linux GTK3 — no fix; Tauri 3 migration tracked" },
     { id = "RUSTSEC-2024-0420", reason = "gtk-sys: tauri Linux GTK3 — no fix; Tauri 3 migration tracked" },
-    { id = "RUSTSEC-2024-0429", reason = "glib unsound: tauri Linux GTK3 — no fix; Tauri 3 migration tracked" },
 
     # ── Tauri non-GTK3 transitives ────────────────────────────────────
     { id = "RUSTSEC-2024-0370", reason = "proc-macro-error: tauri build-time transitive, unmaintained" },
-    { id = "RUSTSEC-2025-0057", reason = "fxhash: tauri transitive, unmaintained" },
     { id = "RUSTSEC-2025-0075", reason = "unic-char-range: tauri transitive, unmaintained" },
     { id = "RUSTSEC-2025-0080", reason = "unic-common: tauri transitive, unmaintained" },
     { id = "RUSTSEC-2025-0081", reason = "unic-char-property: tauri transitive, unmaintained" },
@@ -49,8 +47,6 @@ ignore = [
     # ── velesdb-cli transitive ────────────────────────────────────────
     { id = "RUSTSEC-2024-0384", reason = "instant: velesdb-cli transitive (clap/indicatif chain), unmaintained" },
 
-    # ── SIMD / quantization transitive ────────────────────────────────
-    { id = "RUSTSEC-2024-0436", reason = "paste: simdeez transitive, unmaintained" },
 
     # ── Embedded / heapless transitive (postcard 1.x) ─────────────────
     # postcard 1.x is a load-bearing serializer in velesdb-core; postcard 2.x

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -1,6 +1,6 @@
 # VelesDB Performance Benchmarks
 
-*Last updated: July 6, 2026 (VelesDB v3.8.0). Figures are re-validated at each release only when re-measured — each section carries its own measurement date and machine; this stamp tracks the document revision, not a fresh measurement.*
+*Last updated: July 10, 2026 (VelesDB v3.8.1). Figures are re-validated at each release only when re-measured — each section carries its own measurement date and machine; this stamp tracks the document revision, not a fresh measurement.*
 
 ---
 

--- a/docs/NEW_USER_TROUBLESHOOTING.md
+++ b/docs/NEW_USER_TROUBLESHOOTING.md
@@ -33,7 +33,7 @@ Collection vector dimension and metric are fixed by design for indexing/search p
 `velesdb-core` is embedded library only.
 
 Install the component you need:
-- `cargo install velesdb-server` — REST API server (48 endpoints, OpenAPI)
+- `cargo install velesdb-server` — REST API server (54 endpoints, OpenAPI)
 - `cargo install velesdb-cli` — Interactive VelesQL REPL (binary name: `velesdb`)
 
 ### 5) "Benchmark numbers are different"
@@ -75,7 +75,7 @@ C'est normal : ce choix est figé à la création pour conserver les performance
 `velesdb-core` = moteur embarqué.
 
 Installer le composant adapté :
-- `cargo install velesdb-server` — API REST (48 endpoints, OpenAPI)
+- `cargo install velesdb-server` — API REST (54 endpoints, OpenAPI)
 - `cargo install velesdb-cli` — Shell interactif VelesQL (binaire : `velesdb`)
 
 ### 5) « Les benchmarks ne correspondent pas »
@@ -101,6 +101,6 @@ Normal : dépend du CPU, de `ef_search`, des filtres/payloads et du dataset.
 - [VelesQL Specification](VELESQL_SPEC.md) — Full query language reference with examples
 - [Search Modes Guide](guides/SEARCH_MODES.md) — How to choose between Fast, Balanced, Accurate, Perfect, and Adaptive
 - [Tuning Guide](guides/TUNING_GUIDE.md) — HNSW parameters, quantization modes, memory estimation
-- [API Reference](reference/api-reference.md) — All 48 REST endpoints with request/response examples
+- [API Reference](reference/api-reference.md) — All 54 REST endpoints with request/response examples
 - [Installation Guide](guides/INSTALLATION.md) — All platforms: Linux, macOS, Windows, Docker, WASM, Mobile
 - [E-commerce Example](../examples/ecommerce_recommendation/) — Full Vector + Graph + Filter demo in Rust

--- a/docs/VELESQL_SPEC.md
+++ b/docs/VELESQL_SPEC.md
@@ -2,7 +2,7 @@
 
 > SQL-like query language for vector + graph + column-store search in VelesDB.
 
-**Version**: 3.10.0 | **Last Updated**: 2026-07-06 (VelesDB v3.8.0)
+**Version**: 3.10.0 | **Last Updated**: 2026-07-10 (VelesDB v3.8.1)
 
 ---
 

--- a/docs/contributing/PROJECT_STRUCTURE.md
+++ b/docs/contributing/PROJECT_STRUCTURE.md
@@ -55,7 +55,7 @@ velesdb-core/
 │   │   ├── benches/           # Criterion benchmarks
 │   │   └── tests/             # Integration + BDD tests
 │   │
-│   ├── velesdb-server/        # Axum REST API server (48 endpoints)
+│   ├── velesdb-server/        # Axum REST API server (54 endpoints)
 │   │   ├── Cargo.toml
 │   │   └── src/
 │   │       └── handlers/      # Route handlers (query/, search/, graph, admin)
@@ -150,7 +150,7 @@ Core engine. Contains:
 
 ### `velesdb-server`
 
-Axum-based REST API server with 48 endpoints. Exposes:
+Axum-based REST API server with 54 endpoints. Exposes:
 - CRUD endpoints for collections and points
 - `/search`, `/search/batch`, `/search/hybrid` endpoints
 - `/query` endpoint for VelesQL execution

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -96,7 +96,7 @@ Expected response:
 ```json
 {
   "status": "ok",
-  "version": "3.8.0"
+  "version": "3.8.1"
 }
 ```
 

--- a/docs/guides/CLI_REPL.md
+++ b/docs/guides/CLI_REPL.md
@@ -1,6 +1,6 @@
 # 💻 CLI & REPL Reference
 
-*Version 3.8.0 — 2026-06-12*
+*Version 3.8.1 — 2026-06-12*
 
 Complete guide to the VelesDB command-line interface and the interactive REPL.
 
@@ -36,7 +36,7 @@ cargo build --release -p velesdb-cli
 
 ```bash
 velesdb --version
-# velesdb 3.8.0
+# velesdb 3.8.1
 ```
 
 ---
@@ -269,7 +269,7 @@ velesdb> \info
 ┌─────────────────────┬────────────────────┐
 │ Property            │ Value              │
 ├─────────────────────┼────────────────────┤
-│ Version             │ 3.8.0              │
+│ Version             │ 3.8.1              │
 │ Data directory      │ ./data             │
 │ Collections         │ 3                  │
 │ Total vectors       │ 125,000            │
@@ -342,7 +342,7 @@ Session settings are **not persisted** across REPL sessions. To persist them, us
 ```
 $ velesdb repl ./my_db
 
-VelesDB v3.8.0 - Interactive REPL
+VelesDB v3.8.1 - Interactive REPL
 Type \help for help, \quit to exit.
 
 velesdb> \show

--- a/docs/guides/CONFIGURATION.md
+++ b/docs/guides/CONFIGURATION.md
@@ -1,6 +1,6 @@
 # ⚙️ VelesDB Configuration
 
-*Version 3.8.0 — May 2026*
+*Version 3.8.1 — May 2026*
 
 Complete guide for configuring VelesDB via configuration file, environment variables, and runtime parameters.
 
@@ -62,7 +62,7 @@ data_dir = "./data"
 ```toml
 # =============================================================================
 # VelesDB Configuration File
-# Version: 3.8.0
+# Version: 3.8.1
 # =============================================================================
 
 # -----------------------------------------------------------------------------

--- a/docs/guides/GRAPH_PATTERNS.md
+++ b/docs/guides/GRAPH_PATTERNS.md
@@ -1,6 +1,6 @@
 # Graph Patterns Guide
 
-*Version 3.8.0 -- May 2026*
+*Version 3.8.1 -- May 2026*
 
 Practical guide for using VelesQL `MATCH` graph patterns in VelesDB.
 

--- a/docs/guides/INSTALLATION.md
+++ b/docs/guides/INSTALLATION.md
@@ -60,10 +60,10 @@ entry.
 
 ```bash
 # Download
-wget https://github.com/cyberlife-coder/VelesDB/releases/download/v3.8.0/velesdb-3.8.0-amd64.deb
+wget https://github.com/cyberlife-coder/VelesDB/releases/download/v3.8.1/velesdb-3.8.1-amd64.deb
 
 # Install
-sudo dpkg -i velesdb-3.8.0-amd64.deb
+sudo dpkg -i velesdb-3.8.1-amd64.deb
 
 # Verify
 velesdb --version
@@ -160,13 +160,13 @@ GitHub Container Registry, so you don't need to build locally:
 
 ```bash
 # Pull a specific release (recommended for reproducibility)
-docker pull ghcr.io/cyberlife-coder/velesdb:3.8.0
+docker pull ghcr.io/cyberlife-coder/velesdb:3.8.1
 
 # ...or the latest stable release
 docker pull ghcr.io/cyberlife-coder/velesdb:latest
 
 docker run -d --name velesdb -p 8080:8080 -v velesdb_data:/data \
-  ghcr.io/cyberlife-coder/velesdb:3.8.0
+  ghcr.io/cyberlife-coder/velesdb:3.8.1
 ```
 
 ### Build locally

--- a/docs/guides/SEARCH_MODES.md
+++ b/docs/guides/SEARCH_MODES.md
@@ -1,6 +1,6 @@
 # 🎯 Search Modes - Recall Configuration Guide
 
-*Version 3.8.0 -- 2026-06-12*
+*Version 3.8.1 -- 2026-06-12*
 
 Complete guide to configuring the **recall vs latency** trade-off in VelesDB. Covers dense search (HNSW), sparse search (SPLADE/BM42), and hybrid search (dense+sparse with fusion). Includes a comparison with Milvus, OpenSearch, and Qdrant practices.
 

--- a/docs/guides/SERVER_SECURITY.md
+++ b/docs/guides/SERVER_SECURITY.md
@@ -299,7 +299,7 @@ curl http://localhost:8080/health
 ```json
 {
   "status": "ok",
-  "version": "3.8.0"
+  "version": "3.8.1"
 }
 ```
 
@@ -318,7 +318,7 @@ curl http://localhost:8080/ready
 ```json
 {
   "status": "ready",
-  "version": "3.8.0"
+  "version": "3.8.1"
 }
 ```
 
@@ -327,7 +327,7 @@ curl http://localhost:8080/ready
 ```json
 {
   "status": "not_ready",
-  "version": "3.8.0"
+  "version": "3.8.1"
 }
 ```
 

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -11,7 +11,7 @@
       "name": "VelesDB Core License 1.0",
       "url": "https://github.com/cyberlife-coder/VelesDB/blob/main/LICENSE"
     },
-    "version": "3.8.0"
+    "version": "3.8.1"
   },
   "servers": [
     {

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -8,7 +8,7 @@ info:
   license:
     name: VelesDB Core License 1.0
     url: https://github.com/cyberlife-coder/VelesDB/blob/main/LICENSE
-  version: 3.8.0
+  version: 3.8.1
 servers:
 - url: /
   description: Local server

--- a/docs/reference/ARCHITECTURE.md
+++ b/docs/reference/ARCHITECTURE.md
@@ -100,7 +100,7 @@ VelesDB core architecture is explicitly **hybrid by design**:
 #### velesdb-server
 - Axum-based REST API server
 - OpenAPI/Swagger documentation
-- 48 REST endpoints (55 method+path operations)
+- 54 REST endpoints (61 method+path operations)
 - Prometheus metrics served by default (`GET /metrics`)
 
 #### velesdb-python

--- a/docs/reference/ARCHITECTURE_DIAGRAMS.md
+++ b/docs/reference/ARCHITECTURE_DIAGRAMS.md
@@ -1,4 +1,4 @@
-# VelesDB Architecture Diagrams — v3.8.0
+# VelesDB Architecture Diagrams — v3.8.1
 
 ## 1. Workspace Dependency Graph
 

--- a/docs/reference/ECOSYSTEM_PARITY.md
+++ b/docs/reference/ECOSYSTEM_PARITY.md
@@ -1,6 +1,6 @@
 # VelesQL Ecosystem Parity Matrix
 
-Last updated: 2026-07-06 (v3.8.0; velesdb-memory 0.6.0)
+Last updated: 2026-07-10 (v3.8.1; velesdb-memory 0.6.0)
 
 This matrix tracks runtime contract and feature parity across the VelesDB ecosystem.
 

--- a/docs/reference/VELESQL_CHEATSHEET.md
+++ b/docs/reference/VELESQL_CHEATSHEET.md
@@ -1,7 +1,7 @@
 # VelesQL Cheat Sheet
 
 > **Date:** 2026-06-03
-> **VelesDB version:** 3.8.0
+> **VelesDB version:** 3.8.1
 > See the full specification in [`docs/VELESQL_SPEC.md`](../VELESQL_SPEC.md).
 
 > Every `sql` block below is **parsed** against the real grammar by an automated

--- a/docs/reference/VELESQL_CONFORMANCE_MATRIX.md
+++ b/docs/reference/VELESQL_CONFORMANCE_MATRIX.md
@@ -4,7 +4,7 @@ This document lists every VelesQL feature with its parser and executor status.
 A feature can be **Parsed** (the grammar + AST accept it) without being
 **Executed** (the query engine acts on it at runtime).
 
-> Last updated: 2026-07-06 (VelesDB v3.8.0)
+> Last updated: 2026-07-10 (VelesDB v3.8.1)
 
 ## Fully Supported (Parsed AND Executed)
 

--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -57,7 +57,7 @@ Check server health status.
 ```json
 {
   "status": "ok",
-  "version": "3.8.0"
+  "version": "3.8.1"
 }
 ```
 

--- a/docs/reference/promise-contract.json
+++ b/docs/reference/promise-contract.json
@@ -1,5 +1,5 @@
 {
-  "last_updated": "2026-06-12",
+  "last_updated": "2026-07-10",
   "claims": [
     {
       "id": "root_readme_hnsw_latency_microseconds",
@@ -166,10 +166,10 @@
     {
       "id": "readme_rest_endpoint_count",
       "file": "README.md",
-      "must_contain": "48 REST endpoints",
-      "validation_command": "grep -cE \"^  /\" docs/openapi.yaml  # 48 paths (55 operations counting per-verb)",
-      "source": "docs/openapi.yaml on this branch: 48 paths / 55 operations, including the relations + TTL endpoints and GET /metrics. Endpoint count convention = OpenAPI paths.",
-      "last_updated": "2026-06-12"
+      "must_contain": "54 REST endpoints",
+      "validation_command": "grep -cE \"^  /\" docs/openapi.yaml  # 54 paths (61 operations counting per-verb)",
+      "source": "docs/openapi.yaml on this branch: 54 paths / 61 operations, including the relations + TTL endpoints and GET /metrics. Corroborated by crates/velesdb-server/src/routes.rs (54 .route() registrations). Endpoint count convention = OpenAPI paths.",
+      "last_updated": "2026-07-10"
     }
   ]
 }

--- a/examples/wasm-browser-demo/README.md
+++ b/examples/wasm-browser-demo/README.md
@@ -22,7 +22,7 @@ cd crates/velesdb-wasm
 wasm-pack build --target web --out-dir ../../examples/wasm-browser-demo/pkg
 
 # Then update index.html to use the local path instead of CDN:
-# Change: import init from 'https://unpkg.com/@wiscale/velesdb-wasm@3.8.0/velesdb_wasm.js'
+# Change: import init from 'https://unpkg.com/@wiscale/velesdb-wasm@3.8.1/velesdb_wasm.js'
 # To:     import init from './pkg/velesdb_wasm.js'
 ```
 
@@ -80,7 +80,7 @@ Typical results on modern hardware:
 ```html
 <script type="module">
   // If published on npm:
-  // import init, { VectorStore } from 'https://unpkg.com/@wiscale/velesdb-wasm@3.8.0/velesdb_wasm.js';
+  // import init, { VectorStore } from 'https://unpkg.com/@wiscale/velesdb-wasm@3.8.1/velesdb_wasm.js';
   // If built locally with wasm-pack:
   import init, { VectorStore } from './pkg/velesdb_wasm.js';
 

--- a/examples/wasm-browser-demo/index.html
+++ b/examples/wasm-browser-demo/index.html
@@ -171,8 +171,8 @@
         // WASM module - tracks @wiscale/velesdb-wasm@<workspace> with CDN fallback.
         // Bumped by scripts/bump-version.ps1 on every release; if you copy this
         // demo, update the version below to match `@wiscale/velesdb-wasm` on npm.
-        const WASM_CDN_PRIMARY = 'https://unpkg.com/@wiscale/velesdb-wasm@3.8.0/velesdb_wasm.js';
-        const WASM_CDN_FALLBACK = 'https://cdn.jsdelivr.net/npm/@wiscale/velesdb-wasm@3.8.0/velesdb_wasm.js';
+        const WASM_CDN_PRIMARY = 'https://unpkg.com/@wiscale/velesdb-wasm@3.8.1/velesdb_wasm.js';
+        const WASM_CDN_FALLBACK = 'https://cdn.jsdelivr.net/npm/@wiscale/velesdb-wasm@3.8.1/velesdb_wasm.js';
         
         let init, VectorStore;
         

--- a/integrations/common/README.md
+++ b/integrations/common/README.md
@@ -33,7 +33,7 @@ direct use by end users.
 
 | Export | Type | Description |
 |--------|------|-------------|
-| `CollectionAdminMixin` | class | Mixin providing shared admin operations (`flush`, `get_collection_info`, `is_empty`) |
+| `CollectionAdminMixin` | class | Mixin providing shared admin operations (`create_metadata_collection`, `is_metadata_only`, `train_pq`, `analyze_collection`, `get_collection_stats`) |
 | `GraphOpsBase` | class | Base class for graph query helpers used by both integrations |
 
 **ID helpers**

--- a/integrations/common/pyproject.toml
+++ b/integrations/common/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "velesdb-common"
-version = "3.8.0"
+version = "3.8.1"
 description = "Shared utilities for VelesDB Python integrations (internal use)"
 readme = "README.md"
 license = {text = "MIT"}

--- a/integrations/common/pyproject.toml
+++ b/integrations/common/pyproject.toml
@@ -13,7 +13,7 @@ authors = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "velesdb>=1.14.0",
+    "velesdb>=3.8.0",
 ]
 
 [tool.setuptools.packages.find]

--- a/integrations/common/src/velesdb_common/scroll.py
+++ b/integrations/common/src/velesdb_common/scroll.py
@@ -18,24 +18,11 @@ def scroll_one_batch(
     batch_size: int,
     filter: Optional[dict] = None,  # pylint: disable=redefined-builtin  # public API kwarg name, cannot rename without breaking callers
 ) -> tuple:
-    """Pull one batch from a velesdb Collection using its scroll iterator.
+    """Pull one batch from a velesdb Collection by cursor.
 
-    Creates a fresh ``collection.scroll()`` iterator on every call and skips
-    batches until the one past *cursor* is found.
-
-    .. warning::
-        **Complexity: O(page_index * batch_size)** — this function re-scans
-        from the beginning of the collection on each call because the native
-        SDK does not yet expose a cursor-based ``scroll_batch`` method at the
-        Python level (the Rust ``VectorCollection.scroll_batch`` method is
-        internal to the ``ScrollIterator`` PyO3 class).  For large collections
-        with many pages, callers should either:
-
-        * keep the ``ScrollIterator`` alive across calls (use
-          ``collection.scroll(batch_size=N)`` as a Python generator and drive
-          it with ``next()``), or
-        * wait for a future ``Collection.scroll_batch(cursor, batch_size)``
-          Python binding that will provide true O(1) cursor seek.
+    Delegates to ``Collection.scroll_batch(cursor, batch_size, filter)`` (native
+    since velesdb 3.8.0, this package's minimum), which seeks directly to the
+    page after *cursor* — an O(1) seek rather than re-scanning from the start.
 
     Args:
         collection: A ``velesdb.Collection`` instance.
@@ -50,19 +37,9 @@ def scroll_one_batch(
         the last point ID (``int``) or ``None`` when the collection is
         exhausted.
     """
-    scroll_kwargs: dict = {"batch_size": batch_size}
-    if filter is not None:
-        scroll_kwargs["filter"] = filter
-
-    iterator = collection.scroll(**scroll_kwargs)
-    for batch in iterator:
-        if not batch:
-            continue
-        last_id = batch[-1].get("id")
-        if cursor is not None and last_id is not None and last_id <= cursor:
-            continue
-        return batch, (int(last_id) if last_id is not None else None)
-    return [], None
+    # O(1) cursor seek via the native binding (velesdb >= 3.8.0, this package's
+    # minimum). Returns ``(points, next_cursor)`` directly — no re-scan.
+    return collection.scroll_batch(cursor, batch_size, filter)
 
 
 __all__ = ["scroll_one_batch"]

--- a/integrations/haystack/pyproject.toml
+++ b/integrations/haystack/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "haystack-velesdb"
-version = "3.8.0"
+version = "3.8.1"
 description = "Haystack 2.x DocumentStore for VelesDB: The Local AI Memory Database."
 readme = "README.md"
 license = {text = "MIT"}

--- a/integrations/haystack/pyproject.toml
+++ b/integrations/haystack/pyproject.toml
@@ -31,8 +31,8 @@ classifiers = [
 requires-python = ">=3.10"
 dependencies = [
     "haystack-ai>=2.0.0",
-    "velesdb>=1.14.0",
-    "velesdb-common>=1.14.0",
+    "velesdb>=3.8.0",
+    "velesdb-common>=3.8.0",
 ]
 
 [project.optional-dependencies]

--- a/integrations/haystack/src/haystack_velesdb/__init__.py
+++ b/integrations/haystack/src/haystack_velesdb/__init__.py
@@ -4,4 +4,4 @@ from haystack_velesdb.document_store import VelesDBDocumentStore
 from haystack_velesdb.retriever import VelesDBEmbeddingRetriever
 
 __all__ = ["VelesDBDocumentStore", "VelesDBEmbeddingRetriever"]
-__version__ = "3.8.0"
+__version__ = "3.8.1"

--- a/integrations/haystack/src/haystack_velesdb/__init__.py
+++ b/integrations/haystack/src/haystack_velesdb/__init__.py
@@ -1,6 +1,7 @@
 """Haystack 2.x DocumentStore integration for VelesDB."""
 
 from haystack_velesdb.document_store import VelesDBDocumentStore
+from haystack_velesdb.retriever import VelesDBEmbeddingRetriever
 
-__all__ = ["VelesDBDocumentStore"]
+__all__ = ["VelesDBDocumentStore", "VelesDBEmbeddingRetriever"]
 __version__ = "3.8.0"

--- a/integrations/haystack/src/haystack_velesdb/retriever.py
+++ b/integrations/haystack/src/haystack_velesdb/retriever.py
@@ -1,0 +1,65 @@
+"""Haystack retriever component backed by a :class:`VelesDBDocumentStore`."""
+
+from typing import Any, Dict, List, Optional
+
+from haystack import component, default_from_dict, default_to_dict
+from haystack.dataclasses import Document
+
+from haystack_velesdb.document_store import VelesDBDocumentStore
+
+
+@component
+class VelesDBEmbeddingRetriever:
+    """Retrieves documents from a :class:`VelesDBDocumentStore` by dense
+    embedding similarity, for use inside a Haystack ``Pipeline``.
+
+    Ships the component the ecosystem expects (like ``QdrantEmbeddingRetriever``)
+    so callers no longer have to hand-roll a ``@component`` wrapper: connect an
+    embedder's ``embedding`` output to this component's ``query_embedding`` input.
+    ``top_k`` / ``filters`` set at construction can be overridden per ``run``.
+    """
+
+    def __init__(
+        self,
+        document_store: VelesDBDocumentStore,
+        top_k: int = 10,
+        filters: Optional[Dict[str, Any]] = None,
+        scale_score: bool = True,
+    ) -> None:
+        self._document_store = document_store
+        self._top_k = top_k
+        self._filters = filters
+        self._scale_score = scale_score
+
+    @component.output_types(documents=List[Document])
+    def run(
+        self,
+        query_embedding: List[float],
+        top_k: Optional[int] = None,
+        filters: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, List[Document]]:
+        """Run dense retrieval for ``query_embedding``."""
+        documents = self._document_store.embedding_retrieval(
+            query_embedding,
+            top_k=self._top_k if top_k is None else top_k,
+            filters=self._filters if filters is None else filters,
+            scale_score=self._scale_score,
+        )
+        return {"documents": documents}
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize the component (and its store) for pipeline persistence."""
+        return default_to_dict(
+            self,
+            document_store=self._document_store.to_dict(),
+            top_k=self._top_k,
+            filters=self._filters,
+            scale_score=self._scale_score,
+        )
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "VelesDBEmbeddingRetriever":
+        """Rebuild the component (and its store) from a serialized pipeline."""
+        store_data = data["init_parameters"]["document_store"]
+        data["init_parameters"]["document_store"] = VelesDBDocumentStore.from_dict(store_data)
+        return default_from_dict(cls, data)

--- a/integrations/haystack/tests/test_real_haystack_integration.py
+++ b/integrations/haystack/tests/test_real_haystack_integration.py
@@ -286,3 +286,34 @@ def test_pipeline_with_decorated_retriever(tmp_path) -> None:
     assert len(docs) == 2
     # Top result should be the closest English doc to the query vector.
     assert docs[0].id == "doc-en-1"
+
+
+def test_shipped_embedding_retriever_component_runs(tmp_path) -> None:
+    """The package now ships VelesDBEmbeddingRetriever, so callers no longer
+    hand-roll a @component wrapper. It runs standalone and inside a Pipeline."""
+    from haystack_velesdb import VelesDBEmbeddingRetriever
+
+    store = _store(tmp_path)
+    store.write_documents(_docs())
+    retriever = VelesDBEmbeddingRetriever(document_store=store, top_k=2)
+
+    out = retriever.run(query_embedding=[1.0, 0.0, 0.0, 0.0])
+    assert [d.id for d in out["documents"]][0] == "doc-en-1"
+
+    pipeline = Pipeline()
+    pipeline.add_component("retriever", retriever)
+    result = pipeline.run({"retriever": {"query_embedding": [1.0, 0.0, 0.0, 0.0]}})
+    assert len(result["retriever"]["documents"]) == 2
+
+
+def test_shipped_embedding_retriever_serialization_roundtrip(tmp_path) -> None:
+    """to_dict/from_dict rebuilds the component and its store for pipeline YAML."""
+    from haystack_velesdb import VelesDBEmbeddingRetriever
+
+    retriever = VelesDBEmbeddingRetriever(
+        document_store=_store(tmp_path), top_k=3, scale_score=False
+    )
+    restored = VelesDBEmbeddingRetriever.from_dict(retriever.to_dict())
+    assert restored._top_k == 3
+    assert restored._scale_score is False
+    assert isinstance(restored._document_store, VelesDBDocumentStore)

--- a/integrations/langchain/pyproject.toml
+++ b/integrations/langchain/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "langchain-velesdb"
-version = "3.8.0"
+version = "3.8.1"
 description = "LangChain VectorStore for VelesDB: The Local AI Memory Database. Microsecond RAG retrieval."
 readme = "README.md"
 license = {text = "MIT"}

--- a/integrations/langchain/pyproject.toml
+++ b/integrations/langchain/pyproject.toml
@@ -29,8 +29,8 @@ classifiers = [
 requires-python = ">=3.10"
 dependencies = [
     "langchain-core>=0.1.0,<2.0.0",
-    "velesdb>=1.14.0",
-    "velesdb-common>=1.14.0",
+    "velesdb>=3.8.0",
+    "velesdb-common>=3.8.0",
 ]
 
 [project.optional-dependencies]

--- a/integrations/langchain/src/langchain_velesdb/__init__.py
+++ b/integrations/langchain/src/langchain_velesdb/__init__.py
@@ -53,4 +53,4 @@ if _HAS_MEMORY:
         "VelesDBSemanticMemory",
         "VelesDBProceduralMemory",
     ])
-__version__ = "3.8.0"
+__version__ = "3.8.1"

--- a/integrations/langchain/src/langchain_velesdb/vectorstore.py
+++ b/integrations/langchain/src/langchain_velesdb/vectorstore.py
@@ -332,6 +332,10 @@ class VelesDBVectorStore(CollectionAdminMixin, SearchOpsMixin, GraphOpsMixin, Sc
         Returns:
             VelesDBVectorStore instance with texts added.
         """
+        # `ids` belongs to add_texts, not the constructor: pop it out of kwargs
+        # so caller-supplied ids are actually assigned to the points (LangChain
+        # contract) instead of being silently swallowed by **kwargs.
+        ids = kwargs.pop("ids", None)
         vectorstore = cls(
             embedding=embedding,
             path=path,
@@ -339,7 +343,7 @@ class VelesDBVectorStore(CollectionAdminMixin, SearchOpsMixin, GraphOpsMixin, Sc
             metric=metric,
             **kwargs,
         )
-        vectorstore.add_texts(texts, metadatas=metadatas)
+        vectorstore.add_texts(texts, metadatas=metadatas, ids=ids)
         return vectorstore
 
     def as_retriever(self, **kwargs: Any):

--- a/integrations/langchain/tests/test_e2e_velesdb.py
+++ b/integrations/langchain/tests/test_e2e_velesdb.py
@@ -101,6 +101,26 @@ class TestE2EVelesDB:
         assert len(results) == 2
         assert all(isinstance(r, Document) for r in results)
 
+    def test_from_texts_assigns_provided_ids(self, temp_dir, embeddings):
+        """from_texts(ids=...) must assign the caller's ids to the points.
+
+        Regression: `ids` used to fall into **kwargs and be silently dropped,
+        so get_by_ids() on those ids returned nothing.
+        """
+        texts = ["alpha", "beta", "gamma"]
+        ids = ["id-a", "id-b", "id-c"]
+        store = VelesDBVectorStore.from_texts(
+            texts,
+            embeddings,
+            ids=ids,
+            path=temp_dir,
+            collection_name="from_texts_ids",
+            metric="cosine",
+        )
+        fetched = store.get_by_ids(ids)
+        assert len(fetched) == 3
+        assert {d.page_content for d in fetched} == set(texts)
+
     def test_search_with_scores(self, vectorstore):
         """Similarity search returns (Document, score) tuples."""
         vectorstore.add_texts(["alpha", "beta", "gamma"])

--- a/integrations/langgraph/pyproject.toml
+++ b/integrations/langgraph/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 requires-python = ">=3.10"
 dependencies = [
     "langchain-core>=0.3.0,<2.0.0",
-    "velesdb>=3.4.0",
+    "velesdb>=3.8.0",
 ]
 
 [project.optional-dependencies]

--- a/integrations/langgraph/pyproject.toml
+++ b/integrations/langgraph/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "langgraph-velesdb"
-version = "3.8.0"
+version = "3.8.1"
 description = "LangGraph memory tools for VelesDB: drop the why() knowledge-graph memory wedge into any LangGraph agent."
 readme = "README.md"
 license = {text = "MIT"}

--- a/integrations/langgraph/src/langgraph_velesdb/__init__.py
+++ b/integrations/langgraph/src/langgraph_velesdb/__init__.py
@@ -16,4 +16,4 @@ across agent runs.
 from langgraph_velesdb.tools import make_memory_tools
 
 __all__ = ["make_memory_tools"]
-__version__ = "3.8.0"
+__version__ = "3.8.1"

--- a/integrations/llamaindex/pyproject.toml
+++ b/integrations/llamaindex/pyproject.toml
@@ -30,8 +30,8 @@ classifiers = [
 
 dependencies = [
     "llama-index-core>=0.10.0,<1.0.0",
-    "velesdb>=1.14.0",
-    "velesdb-common>=1.14.0",
+    "velesdb>=3.8.0",
+    "velesdb-common>=3.8.0",
 ]
 
 [project.optional-dependencies]

--- a/integrations/llamaindex/pyproject.toml
+++ b/integrations/llamaindex/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "llama-index-vector-stores-velesdb"
-version = "3.8.0"
+version = "3.8.1"
 description = "LlamaIndex VectorStore for VelesDB: The Local AI Memory Database. Microsecond RAG retrieval."
 readme = "README.md"
 license = "MIT"

--- a/integrations/llamaindex/src/llamaindex_velesdb/__init__.py
+++ b/integrations/llamaindex/src/llamaindex_velesdb/__init__.py
@@ -57,4 +57,4 @@ if _HAS_MEMORY:
         "VelesDBChatMemory",
         "VelesDBProceduralMemory",
     ])
-__version__ = "3.8.0"
+__version__ = "3.8.1"

--- a/integrations/llamaindex/src/llamaindex_velesdb/vectorstore.py
+++ b/integrations/llamaindex/src/llamaindex_velesdb/vectorstore.py
@@ -65,6 +65,11 @@ logger = logging.getLogger(__name__)
 # defaults to LIMIT 10, far too small for chunked documents).
 _REF_DOC_SCAN_BATCH = 1000
 
+# Metrics for which VelesDB returns a raw distance (lower = closer). LlamaIndex
+# treats `similarities` as higher-is-better, so these are mapped to a bounded,
+# monotonically-decreasing similarity; cosine/dot-product are already similarities.
+_DISTANCE_METRICS = frozenset({"euclidean", "hamming", "jaccard"})
+
 
 class VelesDBVectorStore(CollectionAdminMixin, SearchOpsMixin, GraphOpsMixin, ScrollOpsMixin, BasePydanticVectorStore):
     """VelesDB vector store for LlamaIndex.
@@ -211,17 +216,30 @@ class VelesDBVectorStore(CollectionAdminMixin, SearchOpsMixin, GraphOpsMixin, Sc
         node = cls._node_from_result(result)
         return node, result.get("score", 0.0), node.node_id
 
-    @classmethod
-    def _build_query_result(cls, results: list[dict]) -> VectorStoreQueryResult:
+    def _score_to_similarity(self, score: float) -> float:
+        """Map a raw VelesDB score to a LlamaIndex similarity (higher = closer).
+
+        VelesDB returns a raw *distance* for distance metrics (euclidean, hamming,
+        jaccard — lower is closer) and a *similarity* for cosine/dot-product
+        (higher is closer). LlamaIndex treats ``similarities`` as higher-is-better
+        (``similarity_cutoff``, node postprocessors), so distances are mapped to a
+        bounded, monotonically-decreasing similarity; similarity metrics pass
+        through unchanged.
+        """
+        if self.metric.lower() in _DISTANCE_METRICS:
+            return 1.0 / (1.0 + max(score, 0.0))
+        return score
+
+    def _build_query_result(self, results: list[dict]) -> VectorStoreQueryResult:
         """Build a VectorStoreQueryResult from raw VelesDB result dictionaries."""
         nodes: List[TextNode] = []
         similarities: List[float] = []
         ids: List[str] = []
 
         for result in results:
-            node, score, node_id = cls._result_to_parts(result)
+            node, score, node_id = self._result_to_parts(result)
             nodes.append(node)
-            similarities.append(score)
+            similarities.append(self._score_to_similarity(score))
             ids.append(node_id)
 
         return VectorStoreQueryResult(nodes=nodes, similarities=similarities, ids=ids)
@@ -368,23 +386,16 @@ class VelesDBVectorStore(CollectionAdminMixin, SearchOpsMixin, GraphOpsMixin, Sc
         self, collection: velesdb.Collection, ref_doc_id: str
     ) -> None:
         """Delete every node whose payload ``ref_doc_id`` matches."""
-        from llamaindex_velesdb.security import validate_query
-
-        # NOTE: $ref parameter binding silently matches nothing on published
-        # velesdb wheels <= 1.18.0 (scalar param equality bug, fixed upstream
-        # for 1.19) — this connector must run on published engines, so the
-        # value is escaped (single quotes doubled) and the whole statement is
-        # checked by validate_query. Switch to params once the minimum pin
-        # is >= the first fixed release. Not a SQL engine — VelesQL only,
-        # and collection_name is validated at construction ([a-zA-Z0-9_-]+).
-        escaped = ref_doc_id.replace("'", "''")
+        # Parameter binding ($ref) keeps the user value out of the query text
+        # entirely. It was a no-op on published wheels <= 1.18.0 (scalar-equality
+        # bug); the package now pins velesdb >= 3.8.0 where it works. The only
+        # interpolated token is collection_name, regex-validated at construction.
         query_str = (
-            f"SELECT * FROM {self.collection_name} "  # nosec B608  # identifier regex-validated
-            f"WHERE ref_doc_id = '{escaped}' LIMIT {_REF_DOC_SCAN_BATCH}"  # nosec B608  # value quote-escaped + validate_query'd
+            f"SELECT * FROM {self.collection_name} "  # nosec B608 — identifier regex-validated
+            f"WHERE ref_doc_id = $ref LIMIT {_REF_DOC_SCAN_BATCH}"
         )
-        validate_query(query_str)
         while True:
-            rows = collection.query(query_str)
+            rows = collection.query(query_str, {"ref": ref_doc_id})
             if rows:
                 collection.delete([row["id"] for row in rows])
             if len(rows) < _REF_DOC_SCAN_BATCH:

--- a/integrations/llamaindex/tests/test_e2e_complete.py
+++ b/integrations/llamaindex/tests/test_e2e_complete.py
@@ -75,8 +75,33 @@ class TestVectorStoreE2E:
             similarity_top_k=5,
         )
         results = temp_store.query(query)
-        
+
         assert len(results.nodes) == 5
+
+    def test_euclidean_similarity_is_higher_for_closer_nodes(self):
+        """Euclidean returns a raw distance; the store must expose it as a
+        higher-is-better similarity. Otherwise ``similarity_cutoff`` / node
+        postprocessors would rank the farthest node as the most similar."""
+        temp_dir = tempfile.mkdtemp()
+        try:
+            store = VelesDBVectorStore(
+                path=temp_dir,
+                collection_name="euclid_sim",
+                dimension=3,
+                metric="euclidean",
+            )
+            store.add([
+                TextNode(text="near", id_="near", embedding=[0.0, 0.0, 0.0]),
+                TextNode(text="far", id_="far", embedding=[10.0, 0.0, 0.0]),
+            ])
+            result = store.query(
+                VectorStoreQuery(query_embedding=[0.1, 0.0, 0.0], similarity_top_k=2)
+            )
+            sims = dict(zip(result.ids, result.similarities))
+            assert sims["near"] > sims["far"]
+            assert 0.0 < sims["near"] <= 1.0
+        finally:
+            shutil.rmtree(temp_dir, ignore_errors=True)
 
     def test_add_nodes_with_metadata(self, temp_store):
         """Test adding nodes with metadata."""

--- a/scripts/dx-timing/scenario_rust.sh
+++ b/scripts/dx-timing/scenario_rust.sh
@@ -41,7 +41,7 @@ RS
 # Pin to the latest released version on crates.io. Bump alongside each
 # workspace release; the timing measurement is meant to track the path a
 # fresh dev hits when they `cargo add velesdb-core` today.
-cargo add --quiet velesdb-core@3.8.0
+cargo add --quiet velesdb-core@3.8.1
 cargo add --quiet serde_json@1
 cargo run --quiet --release
 

--- a/scripts/dx-timing/scenario_server.sh
+++ b/scripts/dx-timing/scenario_server.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 
 START=$(date +%s.%N)
 
-cargo install --quiet --locked velesdb-server@3.8.0
+cargo install --quiet --locked velesdb-server@3.8.1
 
 DATA_DIR=$(mktemp -d -t velesdb_dx_server_XXXX)
 trap 'rm -rf "$DATA_DIR"' EXIT

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -2,7 +2,7 @@
 
 Official TypeScript SDK for [VelesDB](https://github.com/cyberlife-coder/VelesDB) -- the local-first vector database for AI and RAG. Sub-millisecond semantic search in Browser and Node.js.
 
-**v3.8.0** | Node.js >= 18 | Browser (WASM) | VelesDB Core License 1.0
+**v3.8.1** | Node.js >= 18 | Browser (WASM) | VelesDB Core License 1.0
 
 ## What's New in v3.6.0
 

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -90,21 +90,21 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
+        "@emnapi/wasi-threads": "1.2.2",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -113,9 +113,9 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -786,14 +786,14 @@
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
-      "integrity": "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@tybys/wasm-util": "^0.10.2"
+        "@tybys/wasm-util": "^0.10.3"
       },
       "funding": {
         "type": "github",
@@ -805,9 +805,9 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.133.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
-      "integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
+      "version": "0.138.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.138.0.tgz",
+      "integrity": "sha512-1a7ZKmrRTCoN1XMZ4L0PyyqrMnrNlLyPuOkdSX2MZg7IiIGRUyurNhAm73ptDOraoBcIordsIGKNPKUzy3ZmfA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -815,9 +815,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
-      "integrity": "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.4.tgz",
+      "integrity": "sha512-EZLpf/8y7GXkkra90ML47kzik/GMP3EMcE9bPyHmRfxLC6z9+aW5A8poCsoxjrT5GfEcNAAvWwUHjvP1pUQkfw==",
       "cpu": [
         "arm64"
       ],
@@ -832,9 +832,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz",
-      "integrity": "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.4.tgz",
+      "integrity": "sha512-aUi+HBvmYb7j8krl1+qJgkG8C17fO79gk3c+jPw4S8glRFc1DTija9S3EyaTSQUm5GJXYKDAsugBEhFHH2vYiQ==",
       "cpu": [
         "arm64"
       ],
@@ -849,9 +849,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz",
-      "integrity": "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.4.tgz",
+      "integrity": "sha512-F7hHC3gwY11+vByKPRWqwGbeXWVgKmL+pTGCinaEhdihzBV2aQ0fvZOch9cXYUOKuKKq429HeYXOqQLc7wFCEg==",
       "cpu": [
         "x64"
       ],
@@ -866,9 +866,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz",
-      "integrity": "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.4.tgz",
+      "integrity": "sha512-sI5yw+7s92SK6odiEhD5lKCBlWcpjHS5qyqpVQbZAJ0fIzEUXrmbl3DH2ybR3PZogulNJF+COLtmA8hUfvkCCQ==",
       "cpu": [
         "x64"
       ],
@@ -883,9 +883,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz",
-      "integrity": "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.4.tgz",
+      "integrity": "sha512-mCi0OKgEieFircrtVYmQAFGszRtMnZ6fpZAXrxanXAu7lqZcsK1E1RAaZNG0uKAnxox3B1f4EyQNnoyMfN1vAA==",
       "cpu": [
         "arm"
       ],
@@ -900,13 +900,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz",
-      "integrity": "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.4.tgz",
+      "integrity": "sha512-B9Ial3Kv5sh0SHnB1g/QWcUQCEvCF6QKGAl4zXypYj65mVI+B4AhFBwPtSN7pDrJeIx8Z7zdy4ntx+wQABom7w==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -917,13 +920,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz",
-      "integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.4.tgz",
+      "integrity": "sha512-lZVym0PuHE1KZ22gmFTC15lAkrg9iTszR617oYRB/iPY1A56ywoJzVKOJBKaot5RiikCObmur6pogpse3gRcng==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -934,13 +940,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz",
-      "integrity": "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.4.tgz",
+      "integrity": "sha512-t2DNiLJWNTbnEHyUzTumldML6ET4/g16467LZoDDJ3tSxGvguL5/NyC2lCsNKuyRycg9XeDQF5SSv+TNOhQEXg==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -951,13 +960,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz",
-      "integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.4.tgz",
+      "integrity": "sha512-0WIRnL1Uw4BvTZRLQt+PVgo6ZKTJadlC2btP+/EOXv2f/DWbY0rEgl+y834mIVwP1FkTlWVTrGGJXf12lru7EQ==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -968,13 +980,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz",
-      "integrity": "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.4.tgz",
+      "integrity": "sha512-JWtGshGfX+oENAKonoNkqEJX+7hC8yfhi9GUyPX1VX4mdh1y5r+ZiJLR5XzAB0aoP6s/PcILsGjKq8O0mm24bw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -985,13 +1000,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz",
-      "integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.4.tgz",
+      "integrity": "sha512-rT6yQcxUuXs4CnbofqwHRRV0iem349rLMYpTjkgQGLjrY4ado/eDzwPZPTCgTOlF6Nkp8NEv70yLMTn6qkWxsQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1002,9 +1020,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz",
-      "integrity": "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.4.tgz",
+      "integrity": "sha512-KXMGoboq5cyaCQjDA4GLuRiOwBQ0EyFnJoVViLeZ45/3rFItRODEr+NdsBcVpll40hhNArlm/speWGRvj08LzA==",
       "cpu": [
         "arm64"
       ],
@@ -1019,9 +1037,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz",
-      "integrity": "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.4.tgz",
+      "integrity": "sha512-5K83rb36oJiY7BCyE9zLZtGcPV4g5wvq+xwdO0XPIwDVZI8cyB/AUjkNXGb92/rnmezEkjMOpgY61rtwjQtFwg==",
       "cpu": [
         "wasm32"
       ],
@@ -1029,18 +1047,18 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/core": "1.10.0",
-        "@emnapi/runtime": "1.10.0",
-        "@napi-rs/wasm-runtime": "^1.1.4"
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
-      "integrity": "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.4.tgz",
+      "integrity": "sha512-PnWBtw3TV5KOg69HQQDR0mnQuyCmSGR2pAB4DC1rPF808fgKeTUMj2EOEyKATpgiuxuR5APQmiDO7PDgEjTFSA==",
       "cpu": [
         "arm64"
       ],
@@ -1055,9 +1073,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz",
-      "integrity": "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.4.tgz",
+      "integrity": "sha512-M1lpniBePobTfsa7Ks9a199e1akxsXn+GYBUKsEzv3YFzOm1HJAMNwKI3qr0Zq+mxwx9gOZoTdP1yXRYsZUocQ==",
       "cpu": [
         "x64"
       ],
@@ -1436,9 +1454,9 @@
       "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
-      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1486,9 +1504,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "26.0.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.0.1.tgz",
-      "integrity": "sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw==",
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.0.tgz",
+      "integrity": "sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1496,17 +1514,17 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.62.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.62.0.tgz",
-      "integrity": "sha512-o+mpz7EYiMzXoySXiKmzlabIvTVqUuK5yLrAedRPRDA0IpPFMUV1IXt6OqljIxX/kumN6EjUYp41Hqelh6p/Dw==",
+      "version": "8.63.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.63.0.tgz",
+      "integrity": "sha512-rvwSgqT+DHpWdzfSzPatRLm02a0GlESt++9iy3hLCDY4BgkaLcl8LBi9Yh7XGFBpwcBE/K3024QuXWTpbz4FfQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.62.0",
-        "@typescript-eslint/type-utils": "8.62.0",
-        "@typescript-eslint/utils": "8.62.0",
-        "@typescript-eslint/visitor-keys": "8.62.0",
+        "@typescript-eslint/scope-manager": "8.63.0",
+        "@typescript-eslint/type-utils": "8.63.0",
+        "@typescript-eslint/utils": "8.63.0",
+        "@typescript-eslint/visitor-keys": "8.63.0",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -1525,16 +1543,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.62.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.62.0.tgz",
-      "integrity": "sha512-dzHeT2gySzZtLDsuqxU9AkYgIsQoHAHtRBpOqM+Ofzx1Bwrd2RcCjQJ+6iQbsHOIR6NS33bF2W1k3blN1zLDrA==",
+      "version": "8.63.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.63.0.tgz",
+      "integrity": "sha512-gwh4gvvlaVDKKxyfxMG+Gnu1u9X0OQBwyGLkbwB65dIzBKnxeRiJlNFqlI3zwVhNXJIs6qV7mlFCn/BIajlVig==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.62.0",
-        "@typescript-eslint/types": "8.62.0",
-        "@typescript-eslint/typescript-estree": "8.62.0",
-        "@typescript-eslint/visitor-keys": "8.62.0",
+        "@typescript-eslint/scope-manager": "8.63.0",
+        "@typescript-eslint/types": "8.63.0",
+        "@typescript-eslint/typescript-estree": "8.63.0",
+        "@typescript-eslint/visitor-keys": "8.63.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -1550,14 +1568,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.62.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.62.0.tgz",
-      "integrity": "sha512-wexnCqiTg7BOGtbLDftYpRWlmLq4xfoMd7BKFR6Y75sZS3QmRKLdN3yWLhmIYgqMmP/OXWpj3H8odkb5nGURCQ==",
+      "version": "8.63.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.63.0.tgz",
+      "integrity": "sha512-e5dh0/UI0ok53AlZ5wRkXCB32z/f2jUZqPR/ygAw5WYaSw8j9EoJWlS7wQjr/dmOaqWjnPIn2m+HhVPCMWGZVQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.62.0",
-        "@typescript-eslint/types": "^8.62.0",
+        "@typescript-eslint/tsconfig-utils": "^8.63.0",
+        "@typescript-eslint/types": "^8.63.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -1572,14 +1590,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.62.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.62.0.tgz",
-      "integrity": "sha512-1lX38kNxXIRb8mEc3lbq5mdHq1Pf2+U0nFU65KfT18mtPxxl0fvjuEE92mHuXPuCtElJhOrddOpyMlM3Z0umEA==",
+      "version": "8.63.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.63.0.tgz",
+      "integrity": "sha512-uUyfMWCnDSN8bCpcrY8nGP2BLkQ9Xn0GsipcONcpIDWhwhO4ZSyHvyS14U3X75mzxWxL3I2UZIrenTzdzcJO8A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.62.0",
-        "@typescript-eslint/visitor-keys": "8.62.0"
+        "@typescript-eslint/types": "8.63.0",
+        "@typescript-eslint/visitor-keys": "8.63.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1590,9 +1608,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.62.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.62.0.tgz",
-      "integrity": "sha512-y2GAdB6ykaXUvuspbYnizQc4oDDz0Tz/Yc7iWrXf9mx8vm/L/0vLHCe0tS2boG96Zy+DivnVDQ9ZUEWoHqqx1g==",
+      "version": "8.63.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.63.0.tgz",
+      "integrity": "sha512-sUAbkulqBAsncKnbRP3+7CtQFRKicexnj7ZwNC6ddCR7EmrXvjvdCYMJbUIqMd6lwoEriZjwLo08aS5tSjVMHg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1607,15 +1625,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.62.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.62.0.tgz",
-      "integrity": "sha512-+g5O3j0w2ldzC86Pv6fvbO/xhAonbJFIdf/MKQ1d30gndlsVzUOE83ldfSE15Qrl9fhFjK6AovHs5Wpp6vx86w==",
+      "version": "8.63.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.63.0.tgz",
+      "integrity": "sha512-Nzzh/OGxVCOjObjaj1CQF2RUasyYy2Jfuh+zZ3PjLzG2fYRriAiZLib9UKtO+CpQAS3YHiAS+ckZDclwqI1TPA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.62.0",
-        "@typescript-eslint/typescript-estree": "8.62.0",
-        "@typescript-eslint/utils": "8.62.0",
+        "@typescript-eslint/types": "8.63.0",
+        "@typescript-eslint/typescript-estree": "8.63.0",
+        "@typescript-eslint/utils": "8.63.0",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -1632,9 +1650,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.62.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.62.0.tgz",
-      "integrity": "sha512-KvAclkktORPvM54TgLgA4z9HIV1M8zOgw9ZVNXl9f/8dLYfXYX1wkMXP7qmabpijQRV5bHJLOmoyGQbLMaUYeg==",
+      "version": "8.63.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.63.0.tgz",
+      "integrity": "sha512-xyLtl9DUBBFrcJS4x2pIqGLH68/tC2uOa4Z7pUteW09D3bXnnXUom4dyPikzWgB7llmIc1zoeI3aoUdC4rPK/Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1646,16 +1664,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.62.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.62.0.tgz",
-      "integrity": "sha512-+hVbNxtW64pIcZWDPGbyaKF7vp2IBTVY5ma1blwwksrjdsbdqqEKvJWMGbBofei4F6Dovx1M0RJgoFeNu2279A==",
+      "version": "8.63.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.63.0.tgz",
+      "integrity": "sha512-ygBkU+B7ex5UI/gKhaqexWev79uISfIv7XQCRNYO/jmD8rGLPyWLAb3KMRT6nd8Gt9bmUBi9+iX6tBdYfOY81Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.62.0",
-        "@typescript-eslint/tsconfig-utils": "8.62.0",
-        "@typescript-eslint/types": "8.62.0",
-        "@typescript-eslint/visitor-keys": "8.62.0",
+        "@typescript-eslint/project-service": "8.63.0",
+        "@typescript-eslint/tsconfig-utils": "8.63.0",
+        "@typescript-eslint/types": "8.63.0",
+        "@typescript-eslint/visitor-keys": "8.63.0",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -1674,16 +1692,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.62.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.62.0.tgz",
-      "integrity": "sha512-82r66fi9zYwZ+mTq3vKgwjbZ1PVk/DJzrXFLpG6RnBbdvH8TEGVHIs9H4d2drhkOzf0syZuD/OZvvlu6GDbP4g==",
+      "version": "8.63.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.63.0.tgz",
+      "integrity": "sha512-fUKaeAvrTuQg/Tgt3nliAUSZHJM6DlCcfyEmxCvlX8kieWSStBX+5O5Fnidtc3i2JrH+9c/GL4RY2iasd/GPTA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.62.0",
-        "@typescript-eslint/types": "8.62.0",
-        "@typescript-eslint/typescript-estree": "8.62.0"
+        "@typescript-eslint/scope-manager": "8.63.0",
+        "@typescript-eslint/types": "8.63.0",
+        "@typescript-eslint/typescript-estree": "8.63.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1698,13 +1716,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.62.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.62.0.tgz",
-      "integrity": "sha512-CY3uyFSRbcQv3nnSv8S0+lDftMVz6P963PoRlxrV7ew/Md564g9ut60PYzdLM5qW4jFn93GBF+Soi90ISAN+GQ==",
+      "version": "8.63.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.63.0.tgz",
+      "integrity": "sha512-UexrHGnGTpbuQHct2ExOc2ZcFbGUS9FOesCxxqdBGcpI1BxYu/LZ6U8Aq6/72XtF/qRBk9nhuGHFJIXXMhPMdw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.62.0",
+        "@typescript-eslint/types": "8.63.0",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -1729,14 +1747,14 @@
       }
     },
     "node_modules/@vitest/coverage-v8": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.9.tgz",
-      "integrity": "sha512-G9/lgqibheLVBDRuya45EbsEXTYcWoSG+TLg7i2axuzx0Eq62eXn+aWXyaVdV5vKvFSWd6ywcX8hA7la9Pvu8g==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.10.tgz",
+      "integrity": "sha512-IM49HmthevbgAO4anp1hwtoT9wYe59w0LR00gr+eagHE+ZJ5lK4sLPeO0ubgoJcwLk6dehU3R24N+FbEEKDc8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
-        "@vitest/utils": "4.1.9",
+        "@vitest/utils": "4.1.10",
         "ast-v8-to-istanbul": "^1.0.0",
         "istanbul-lib-coverage": "^3.2.2",
         "istanbul-lib-report": "^3.0.1",
@@ -1750,8 +1768,8 @@
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "@vitest/browser": "4.1.9",
-        "vitest": "4.1.9"
+        "@vitest/browser": "4.1.10",
+        "vitest": "4.1.10"
       },
       "peerDependenciesMeta": {
         "@vitest/browser": {
@@ -1760,16 +1778,16 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.9.tgz",
-      "integrity": "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.9",
-        "@vitest/utils": "4.1.9",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
         "chai": "^6.2.2",
         "tinyrainbow": "^3.1.0"
       },
@@ -1778,13 +1796,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.9.tgz",
-      "integrity": "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.1.9",
+        "@vitest/spy": "4.1.10",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -1805,9 +1823,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
-      "integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1818,13 +1836,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.9.tgz",
-      "integrity": "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.9",
+        "@vitest/utils": "4.1.10",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -1832,14 +1850,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.9.tgz",
-      "integrity": "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.9",
-        "@vitest/utils": "4.1.9",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -1848,9 +1866,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.9.tgz",
-      "integrity": "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -1858,13 +1876,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
-      "integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.9",
+        "@vitest/pretty-format": "4.1.10",
         "convert-source-map": "^2.0.0",
         "tinyrainbow": "^3.1.0"
       },
@@ -1873,9 +1891,9 @@
       }
     },
     "node_modules/@wiscale/velesdb-wasm": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@wiscale/velesdb-wasm/-/velesdb-wasm-3.4.0.tgz",
-      "integrity": "sha512-U/tlOTS1CBS/Pqsfzqde4rMvWCLFlixRK+JQl7gkunjcdA7KP+Z7LpAUxg61AFZkRZVK1OjOcHw9d58J+4QRGw==",
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/@wiscale/velesdb-wasm/-/velesdb-wasm-3.8.0.tgz",
+      "integrity": "sha512-YCoB+y+61pmLhRK9OJABSxGCMk8YATSwXCr35s2mxgqubcAoFgwp76AwcDYcpy5HWPp9PJA4WEJ4iWjAK0tZKg==",
       "license": "SEE LICENSE IN LICENSE"
     },
     "node_modules/acorn": {
@@ -2830,6 +2848,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2851,6 +2872,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2872,6 +2896,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2893,6 +2920,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3247,9 +3277,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.16",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
+      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
       "dev": true,
       "funding": [
         {
@@ -3329,9 +3359,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.9.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.3.tgz",
-      "integrity": "sha512-HWmu+K+zvHNpaMfSnYeqdqrDbR16cuIXaPx8WoHaviQkDJh1/0BNtOZmHVQI5jc3wXv0H1yXc9wjvFdXh+n3hQ==",
+      "version": "3.9.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.4.tgz",
+      "integrity": "sha512-yWG/o/4oJfo036EKAfK6ACAoDOfHeRHx4tuxkfBZiauURiaSmYwlpOr5LQqKtIkRD2z1PLteme2WoxEnj4tHTg==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -3379,13 +3409,13 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
-      "integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.4.tgz",
+      "integrity": "sha512-IjZYiLxZwpnhwhdBH2ugdTGVSdhCQUmLxLoqyjiL0JxYjyRst+5a0P3xfrTxJ5F638j4Mvvw5FAX5XE6eHpXbA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.133.0",
+        "@oxc-project/types": "=0.138.0",
         "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
@@ -3395,21 +3425,21 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.3",
-        "@rolldown/binding-darwin-arm64": "1.0.3",
-        "@rolldown/binding-darwin-x64": "1.0.3",
-        "@rolldown/binding-freebsd-x64": "1.0.3",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.3",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.3",
-        "@rolldown/binding-linux-arm64-musl": "1.0.3",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.3",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.3",
-        "@rolldown/binding-linux-x64-gnu": "1.0.3",
-        "@rolldown/binding-linux-x64-musl": "1.0.3",
-        "@rolldown/binding-openharmony-arm64": "1.0.3",
-        "@rolldown/binding-wasm32-wasi": "1.0.3",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.3",
-        "@rolldown/binding-win32-x64-msvc": "1.0.3"
+        "@rolldown/binding-android-arm64": "1.1.4",
+        "@rolldown/binding-darwin-arm64": "1.1.4",
+        "@rolldown/binding-darwin-x64": "1.1.4",
+        "@rolldown/binding-freebsd-x64": "1.1.4",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.4",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.4",
+        "@rolldown/binding-linux-arm64-musl": "1.1.4",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.4",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.4",
+        "@rolldown/binding-linux-x64-gnu": "1.1.4",
+        "@rolldown/binding-linux-x64-musl": "1.1.4",
+        "@rolldown/binding-openharmony-arm64": "1.1.4",
+        "@rolldown/binding-wasm32-wasi": "1.1.4",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.4",
+        "@rolldown/binding-win32-x64-msvc": "1.1.4"
       }
     },
     "node_modules/rollup": {
@@ -3760,16 +3790,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.62.0",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.62.0.tgz",
-      "integrity": "sha512-8QxXi+ZACKX0kaqO4gY8kn0RSD9gFfaHDWwjqtEN48aWCBkX4MJaufWN+c3BzlrXLOxfywDL8CaoqUwcRq4j4Q==",
+      "version": "8.63.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.63.0.tgz",
+      "integrity": "sha512-xgwXyzG4sK9ALkBxbyGkTMMOS+imnW65iPhxCQMK83KhxyoDNW7l+IDqEf9vMdoUidHpOoS967RCq4eMiTexwQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.62.0",
-        "@typescript-eslint/parser": "8.62.0",
-        "@typescript-eslint/typescript-estree": "8.62.0",
-        "@typescript-eslint/utils": "8.62.0"
+        "@typescript-eslint/eslint-plugin": "8.63.0",
+        "@typescript-eslint/parser": "8.63.0",
+        "@typescript-eslint/typescript-estree": "8.63.0",
+        "@typescript-eslint/utils": "8.63.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3808,16 +3838,16 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.0.16",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
-      "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.3.tgz",
+      "integrity": "sha512-Ds+gBRbj0lwRO2Y5hwnUBdxSwlAve9LeRyU4sNnAr0ewW0gWF0n5bgXgUzbgZ49MV9BVUAQUFYVcDUcilUExMA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
-        "postcss": "^8.5.15",
-        "rolldown": "1.0.3",
+        "postcss": "^8.5.16",
+        "rolldown": "~1.1.3",
         "tinyglobby": "^0.2.17"
       },
       "bin": {
@@ -3834,7 +3864,7 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.1.18",
+        "@vitejs/devtools": "^0.3.0",
         "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",
@@ -3886,19 +3916,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.9.tgz",
-      "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.9",
-        "@vitest/mocker": "4.1.9",
-        "@vitest/pretty-format": "4.1.9",
-        "@vitest/runner": "4.1.9",
-        "@vitest/snapshot": "4.1.9",
-        "@vitest/spy": "4.1.9",
-        "@vitest/utils": "4.1.9",
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
         "es-module-lexer": "^2.0.0",
         "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
@@ -3926,12 +3956,12 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.9",
-        "@vitest/browser-preview": "4.1.9",
-        "@vitest/browser-webdriverio": "4.1.9",
-        "@vitest/coverage-istanbul": "4.1.9",
-        "@vitest/coverage-v8": "4.1.9",
-        "@vitest/ui": "4.1.9",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
         "happy-dom": "*",
         "jsdom": "*",
         "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.8.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@wiscale/velesdb-wasm": "^3.0.0"
+        "@wiscale/velesdb-wasm": "^3.8.0"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -1873,9 +1873,9 @@
       }
     },
     "node_modules/@wiscale/velesdb-wasm": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@wiscale/velesdb-wasm/-/velesdb-wasm-3.4.0.tgz",
-      "integrity": "sha512-U/tlOTS1CBS/Pqsfzqde4rMvWCLFlixRK+JQl7gkunjcdA7KP+Z7LpAUxg61AFZkRZVK1OjOcHw9d58J+4QRGw==",
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/@wiscale/velesdb-wasm/-/velesdb-wasm-3.8.0.tgz",
+      "integrity": "sha512-YCoB+y+61pmLhRK9OJABSxGCMk8YATSwXCr35s2mxgqubcAoFgwp76AwcDYcpy5HWPp9PJA4WEJ4iWjAK0tZKg==",
       "license": "SEE LICENSE IN LICENSE"
     },
     "node_modules/acorn": {

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wiscale/velesdb-sdk",
-  "version": "3.8.0",
+  "version": "3.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wiscale/velesdb-sdk",
-      "version": "3.8.0",
+      "version": "3.8.1",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@wiscale/velesdb-wasm": "^3.8.0"

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -69,7 +69,7 @@
     "vitest": "^4.0.16"
   },
   "dependencies": {
-    "@wiscale/velesdb-wasm": "^3.0.0"
+    "@wiscale/velesdb-wasm": "^3.8.0"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wiscale/velesdb-sdk",
-  "version": "3.8.0",
+  "version": "3.8.1",
   "description": "VelesDB TypeScript SDK: The Local Vector Database for AI & RAG. Microsecond semantic search in Browser & Node.js.",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/sdks/typescript/src/backends/crud-backend.ts
+++ b/sdks/typescript/src/backends/crud-backend.ts
@@ -259,6 +259,23 @@ export async function deletePoint(
   return response.data?.deleted ?? false;
 }
 
+export async function bulkDeletePoints(
+  transport: CrudTransport,
+  collection: string,
+  ids: Array<string | number>
+): Promise<number> {
+  // Server route POST /collections/{name}/points/delete accepts ids as decimal
+  // strings (safe for u64 > 2^53) and returns { deleted_count }.
+  const restIds = ids.map((id) => String(parseRestPointId(id)));
+  const response = await transport.requestJson<{ deleted_count?: number }>(
+    'POST',
+    `${collectionPath(collection)}/points/delete`,
+    { ids: restIds }
+  );
+  throwOnError(response, `Collection '${collection}'`);
+  return response.data?.deleted_count ?? 0;
+}
+
 export async function get(
   transport: CrudTransport,
   collection: string,

--- a/sdks/typescript/src/backends/rest-http.ts
+++ b/sdks/typescript/src/backends/rest-http.ts
@@ -33,6 +33,28 @@ export interface RestHttpConfig {
 const DEFAULT_MAX_RETRIES = 2;
 /** Default exponential-backoff base delay in ms. */
 const DEFAULT_RETRY_BASE_MS = 200;
+/** Hard cap on any single retry wait, so a large `Retry-After` can't hang a request. */
+const MAX_RETRY_DELAY_MS = 20_000;
+
+/** HTTP methods that are idempotent per RFC 9110 (safe to replay). */
+function isIdempotentMethod(method: string): boolean {
+  const m = method.toUpperCase();
+  return m === 'GET' || m === 'HEAD' || m === 'PUT' || m === 'DELETE' || m === 'OPTIONS';
+}
+
+/**
+ * Whether a failed response should be retried for this method.
+ *
+ * `429` means the server rejected the request *before* processing it (rate
+ * limit), so replaying is safe for any method. `503` is ambiguous — the request
+ * may have been partially applied — so it is only retried for idempotent
+ * methods, never for a non-idempotent write like a POST upsert.
+ */
+function shouldRetry(status: number, method: string): boolean {
+  if (status === 429) return true;
+  if (status === 503) return isIdempotentMethod(method);
+  return false;
+}
 
 /** HTTP status → typed error code lookup. */
 const STATUS_ERROR_CODES: Record<number, string> = {
@@ -110,15 +132,17 @@ function sleep(ms: number): Promise<void> {
 /**
  * Compute the backoff delay before retrying a 429/503 response. Honors an
  * integer `Retry-After` header (seconds); otherwise exponential backoff with
- * light jitter.
+ * light jitter. Always capped at `MAX_RETRY_DELAY_MS` so a hostile or huge
+ * `Retry-After` cannot hang a request far past the caller's intent.
  */
 function retryDelayMs(response: Response, attempt: number, baseDelayMs: number): number {
   const retryAfter = response.headers.get('Retry-After');
   if (retryAfter !== null) {
     const secs = Number(retryAfter);
-    if (Number.isFinite(secs) && secs >= 0) return secs * 1000;
+    if (Number.isFinite(secs) && secs >= 0) return Math.min(secs * 1000, MAX_RETRY_DELAY_MS);
   }
-  return baseDelayMs * 2 ** attempt + Math.floor(Math.random() * baseDelayMs);
+  const backoff = baseDelayMs * 2 ** attempt + Math.floor(Math.random() * baseDelayMs);
+  return Math.min(backoff, MAX_RETRY_DELAY_MS);
 }
 
 /** Perform a single HTTP attempt (own timeout); network errors throw. */
@@ -147,10 +171,11 @@ async function attemptFetch(
 /**
  * Execute an HTTP request against the REST API.
  *
- * Retries automatically on 429 (rate limited) and 503 (service unavailable),
- * which the server returns *before* processing the request, so a replay is
- * safe even for writes. Network errors and timeouts are NOT retried (a write
- * may already have been applied). Backoff is exponential, honoring `Retry-After`.
+ * Retries `429` for any method (the server rejected it before processing) and
+ * `503` only for idempotent methods (see {@link shouldRetry}), so a
+ * non-idempotent write is never silently replayed. Network errors and timeouts
+ * are NOT retried (a write may already have been applied). Backoff is
+ * exponential, honoring a capped `Retry-After`.
  */
 export async function request<T>(
   config: RestHttpConfig,
@@ -167,7 +192,7 @@ export async function request<T>(
     if (response.ok) {
       return { data: data as unknown as T };
     }
-    if ((response.status === 429 || response.status === 503) && attempt < maxRetries) {
+    if (shouldRetry(response.status, method) && attempt < maxRetries) {
       await sleep(retryDelayMs(response, attempt, baseDelay));
       continue;
     }

--- a/sdks/typescript/src/backends/rest-http.ts
+++ b/sdks/typescript/src/backends/rest-http.ts
@@ -23,7 +23,16 @@ export interface RestHttpConfig {
   baseUrl: string;
   apiKey?: string;
   timeout: number;
+  /** Max automatic retries on 429/503 backpressure responses (default 2). */
+  maxRetries?: number;
+  /** Base delay in ms for exponential backoff between retries (default 200). */
+  retryBaseDelayMs?: number;
 }
+
+/** Default number of retries on 429/503 when not configured. */
+const DEFAULT_MAX_RETRIES = 2;
+/** Default exponential-backoff base delay in ms. */
+const DEFAULT_RETRY_BASE_MS = 200;
 
 /** HTTP status → typed error code lookup. */
 const STATUS_ERROR_CODES: Record<number, string> = {
@@ -93,37 +102,83 @@ function wrapCatchError(error: unknown): never {
   throw new ConnectionError(`Request failed: ${message}`, cause);
 }
 
-/** Execute an HTTP request against the REST API. */
+/** Promise-based delay used between retries. */
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Compute the backoff delay before retrying a 429/503 response. Honors an
+ * integer `Retry-After` header (seconds); otherwise exponential backoff with
+ * light jitter.
+ */
+function retryDelayMs(response: Response, attempt: number, baseDelayMs: number): number {
+  const retryAfter = response.headers.get('Retry-After');
+  if (retryAfter !== null) {
+    const secs = Number(retryAfter);
+    if (Number.isFinite(secs) && secs >= 0) return secs * 1000;
+  }
+  return baseDelayMs * 2 ** attempt + Math.floor(Math.random() * baseDelayMs);
+}
+
+/** Perform a single HTTP attempt (own timeout); network errors throw. */
+async function attemptFetch(
+  config: RestHttpConfig,
+  method: string,
+  path: string,
+  body?: unknown
+): Promise<Response> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), config.timeout);
+  try {
+    return await fetch(`${config.baseUrl}${path}`, {
+      method,
+      headers: buildHeaders(config),
+      body: body ? JSON.stringify(body) : undefined,
+      signal: controller.signal,
+    });
+  } catch (error) {
+    wrapCatchError(error);
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+/**
+ * Execute an HTTP request against the REST API.
+ *
+ * Retries automatically on 429 (rate limited) and 503 (service unavailable),
+ * which the server returns *before* processing the request, so a replay is
+ * safe even for writes. Network errors and timeouts are NOT retried (a write
+ * may already have been applied). Backoff is exponential, honoring `Retry-After`.
+ */
 export async function request<T>(
   config: RestHttpConfig,
   method: string,
   path: string,
   body?: unknown
 ): Promise<TransportResponse<T>> {
-  const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), config.timeout);
+  const maxRetries = config.maxRetries ?? DEFAULT_MAX_RETRIES;
+  const baseDelay = config.retryBaseDelayMs ?? DEFAULT_RETRY_BASE_MS;
 
-  try {
-    const response = await fetch(`${config.baseUrl}${path}`, {
-      method,
-      headers: buildHeaders(config),
-      body: body ? JSON.stringify(body) : undefined,
-      signal: controller.signal,
-    });
-    clearTimeout(timeoutId);
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    const response = await attemptFetch(config, method, path, body);
     const data = await safeJsonParse(response);
-    if (!response.ok) {
-      const ep = extractErrorPayload(data);
-      return { error: {
-        code: ep.code ?? mapStatusToErrorCode(response.status),
-        message: ep.message ?? `HTTP ${response.status}`,
-      }};
+    if (response.ok) {
+      return { data: data as unknown as T };
     }
-    return { data: data as unknown as T };
-  } catch (error) {
-    clearTimeout(timeoutId);
-    wrapCatchError(error);
+    if ((response.status === 429 || response.status === 503) && attempt < maxRetries) {
+      await sleep(retryDelayMs(response, attempt, baseDelay));
+      continue;
+    }
+    const ep = extractErrorPayload(data);
+    return { error: {
+      code: ep.code ?? mapStatusToErrorCode(response.status),
+      message: ep.message ?? `HTTP ${response.status}`,
+    }};
   }
+  // Unreachable: the final iteration always returns (retry guard is attempt < maxRetries).
+  throw new ConnectionError('Request failed: retries exhausted');
 }
 
 // ============================================================================

--- a/sdks/typescript/src/backends/rest.ts
+++ b/sdks/typescript/src/backends/rest.ts
@@ -123,7 +123,7 @@ import {
   createCollection as _createCollection, deleteCollection as _deleteCollection,
   getCollection as _getCollection, listCollections as _listCollections,
   upsert as _upsert, upsertBatch as _upsertBatch, upsertBatchRaw as _upsertBatchRaw,
-  deletePoint as _deletePoint, get as _get, isEmpty as _isEmpty, flush as _flush,
+  deletePoint as _deletePoint, bulkDeletePoints as _bulkDeletePoints, get as _get, isEmpty as _isEmpty, flush as _flush,
 } from './crud-backend';
 
 // Re-export for backward compatibility
@@ -174,6 +174,7 @@ export class RestBackend implements IVelesDBBackend {
   async upsertBatch(c: string, d: VectorDocument[]): Promise<void> { this.ensureInitialized(); return _upsertBatch(buildCrudTransport(this.httpConfig), c, d); }
   async upsertBatchRaw(c: string, d: VectorDocument[]): Promise<number> { this.ensureInitialized(); return _upsertBatchRaw(buildRawBulkTransport(this.httpConfig), c, d, d[0]?.vector.length ?? 0); }
   async delete(c: string, id: string | number): Promise<boolean> { this.ensureInitialized(); return _deletePoint(buildCrudTransport(this.httpConfig), c, id); }
+  async bulkDelete(c: string, ids: Array<string | number>): Promise<number> { this.ensureInitialized(); return _bulkDeletePoints(buildCrudTransport(this.httpConfig), c, ids); }
   async get(c: string, id: string | number): Promise<VectorDocument | null> { this.ensureInitialized(); return _get(buildCrudTransport(this.httpConfig), c, id); }
   async isEmpty(c: string): Promise<boolean> { this.ensureInitialized(); return _isEmpty(buildCrudTransport(this.httpConfig), c); }
   async flush(c: string): Promise<void> { this.ensureInitialized(); return _flush(buildCrudTransport(this.httpConfig), c); }

--- a/sdks/typescript/src/backends/wasm.ts
+++ b/sdks/typescript/src/backends/wasm.ts
@@ -339,6 +339,18 @@ export class WasmBackend implements IVelesDBBackend {
     return removed;
   }
 
+  async bulkDelete(collectionName: string, ids: Array<string | number>): Promise<number> {
+    this.ensureInitialized();
+    const collection = this.collections.get(collectionName);
+    if (!collection) { throw new NotFoundError(`Collection '${collectionName}'`); }
+    let count = 0;
+    for (const id of ids) {
+      const removed = collection.store.remove(BigInt(toNumericId(id)));
+      if (removed) { collection.payloads.delete(canonicalPayloadKey(id)); count += 1; }
+    }
+    return count;
+  }
+
   async get(collectionName: string, id: string | number): Promise<VectorDocument | null> {
     this.ensureInitialized();
     const collection = this.collections.get(collectionName);

--- a/sdks/typescript/src/client.ts
+++ b/sdks/typescript/src/client.ts
@@ -209,6 +209,12 @@ export class VelesDB {
     return this.backend.delete(collection, id);
   }
 
+  async bulkDelete(collection: string, ids: Array<string | number>): Promise<number> {
+    this.ensureInitialized();
+    for (const id of ids) { validateRestPointId(id, this.config); }
+    return this.backend.bulkDelete(collection, ids);
+  }
+
   async get(collection: string, id: string | number): Promise<VectorDocument | null> {
     this.ensureInitialized();
     validateRestPointId(id, this.config);

--- a/sdks/typescript/src/types/backend.ts
+++ b/sdks/typescript/src/types/backend.ts
@@ -126,6 +126,9 @@ export interface IVelesDBBackend {
   /** Delete a vector by ID */
   delete(collection: string, id: string | number): Promise<boolean>;
 
+  /** Delete multiple vectors by ID in one request; returns the deleted count. */
+  bulkDelete(collection: string, ids: Array<string | number>): Promise<number>;
+
   /** Get a vector by ID */
   get(collection: string, id: string | number): Promise<VectorDocument | null>;
 

--- a/sdks/typescript/tests/rest-backend.test.ts
+++ b/sdks/typescript/tests/rest-backend.test.ts
@@ -103,6 +103,24 @@ describe('RestBackend', () => {
       expect(col?.dimension).toBe(128);
     });
 
+    it('should bulk delete points via POST points/delete', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ deleted_count: 2 }),
+      });
+
+      const count = await backend.bulkDelete('docs', [5, 42]);
+
+      expect(count).toBe(2);
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:8080/collections/docs/points/delete',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({ ids: ['5', '42'] }),
+        })
+      );
+    });
+
     it('should return null for non-existent collection (typed VELES-002)', async () => {
       // Modern server emits the VELES-002 code verbatim via
       // `core_error_response`; the transport layer recognises

--- a/sdks/typescript/tests/rest-http.test.ts
+++ b/sdks/typescript/tests/rest-http.test.ts
@@ -218,10 +218,64 @@ describe('request — error responses', () => {
       json: () => Promise.reject(new Error('bad json')),
     });
 
-    const result = await request(config, 'GET', '/x');
+    // maxRetries: 0 isolates the invalid-JSON tolerance from the retry path
+    // (503 is otherwise retried); this test only asserts the parse fallback.
+    const result = await request({ ...config, maxRetries: 0 }, 'GET', '/x');
     expect(result).toEqual({
       error: { code: 'SERVICE_UNAVAILABLE', message: 'HTTP 503' },
     });
+  });
+});
+
+describe('request — retry on backpressure (429/503)', () => {
+  beforeEach(() => vi.clearAllMocks());
+  const fast: RestHttpConfig = { ...config, retryBaseDelayMs: 0 };
+
+  const okResponse = (data: unknown) => ({
+    ok: true,
+    status: 200,
+    headers: { get: () => null },
+    json: () => Promise.resolve(data),
+  });
+  const errResponse = (status: number, retryAfter: string | null = null) => ({
+    ok: false,
+    status,
+    headers: { get: (h: string) => (h === 'Retry-After' ? retryAfter : null) },
+    json: () => Promise.resolve({}),
+  });
+
+  it('retries a 503 then returns the successful response', async () => {
+    mockFetch
+      .mockResolvedValueOnce(errResponse(503))
+      .mockResolvedValueOnce(okResponse({ ok: 1 }));
+    const result = await request<{ ok: number }>(fast, 'GET', '/x');
+    expect(result).toEqual({ data: { ok: 1 } });
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('retries a 429 honoring Retry-After, then succeeds', async () => {
+    mockFetch
+      .mockResolvedValueOnce(errResponse(429, '0'))
+      .mockResolvedValueOnce(okResponse({ ok: 1 }));
+    const result = await request<{ ok: number }>(fast, 'GET', '/x');
+    expect(result).toEqual({ data: { ok: 1 } });
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns the error after exhausting retries', async () => {
+    mockFetch.mockResolvedValue(errResponse(503));
+    const result = await request(fast, 'GET', '/x');
+    expect(result).toEqual({
+      error: { code: 'SERVICE_UNAVAILABLE', message: 'HTTP 503' },
+    });
+    expect(mockFetch).toHaveBeenCalledTimes(3); // initial + 2 retries
+  });
+
+  it('does not retry a non-backpressure error (400)', async () => {
+    mockFetch.mockResolvedValue(errResponse(400));
+    const result = await request(fast, 'GET', '/x');
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect((result as { error: { code: string } }).error.code).toBe('BAD_REQUEST');
   });
 });
 

--- a/sdks/typescript/tests/rest-http.test.ts
+++ b/sdks/typescript/tests/rest-http.test.ts
@@ -277,6 +277,22 @@ describe('request — retry on backpressure (429/503)', () => {
     expect(mockFetch).toHaveBeenCalledTimes(1);
     expect((result as { error: { code: string } }).error.code).toBe('BAD_REQUEST');
   });
+
+  it('does NOT retry a 503 on a non-idempotent POST (avoids double-write)', async () => {
+    mockFetch.mockResolvedValue(errResponse(503));
+    const result = await request(fast, 'POST', '/x', { a: 1 });
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect((result as { error: { code: string } }).error.code).toBe('SERVICE_UNAVAILABLE');
+  });
+
+  it('does retry a 429 on a POST (server rejected it before processing)', async () => {
+    mockFetch
+      .mockResolvedValueOnce(errResponse(429, '0'))
+      .mockResolvedValueOnce(okResponse({ ok: 1 }));
+    const result = await request<{ ok: number }>(fast, 'POST', '/x', { a: 1 });
+    expect(result).toEqual({ data: { ok: 1 } });
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
 });
 
 describe('request — connection errors', () => {


### PR DESCRIPTION
## Release: develop → main

Promotes 41 commits accumulated on `develop` since the last `main` sync. Grouped:

### Audit remediation (temps 1 — all P0 + P1, #1343)
- **storage**: compaction now works on Windows (mmap released + WAL truncated via write handle); durable rename barrier before WAL truncation; index kept consistent with mmap on partial-commit.
- **wasm**: v2 serialization format — persists storage mode, quantized buffers and payloads (was lossy/panicking on SQ8/Binary).
- **python**: fail loud on vector search over graph/metadata collections (F2.2); re-export `CONDITION_TYPES`.
- **cli**: export/samples use actual collection IDs (incl. None-payload), not an assumed `1..=n` range.
- **server**: offload batch search to a blocking worker. **migrate**: stream graph edges (no OOM).
- **ts-sdk**: retry 429/503 with backoff (idempotent-only 503, capped Retry-After); `bulkDelete`.
- **integrations**: langchain `from_texts(ids=)`; llamaindex distance→similarity + bound delete params; haystack `VelesDBEmbeddingRetriever`; common O(1) `scroll_batch`.
- **mobile**: `MobileGraphStore` save/load persistence.

### Security & deps
- **fix(security)**: crossbeam-epoch → 0.9.20 (RUSTSEC-2026-0204) + drop stale audit ignores.
- wgpu 30.0.0, uniffi 0.32, cargo/npm non-major groups, CI action bumps.

### Docs
- README roadmap refreshed through v3.8.0 + forward-looking "Next"; REST endpoint count corrected **48 → 54** across the whole tree (README, ARCHITECTURE ×2, PROJECT_STRUCTURE, NEW_USER_TROUBLESHOOTING) and the promise-contract guardrail; accessible h1; stale version strings realigned to v3.8.0.

### CI
- keep velesdb-memory releases off the "Latest" flag (#1342).

All items merged to `develop` with green CI (real checks). Note: `cla-assistant` reports failure for the `bot-ralph` commit author (not a GitHub user, structurally unsignable) — same condition under which the constituent PRs merged.