### PR TITLE
chore(release): bump version to 3.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.8.1] — 2026-07-10
+
+Maintenance release: a full crate + integration health audit closed with a
+security patch and a batch of correctness fixes. No API breaks.
+
+### Security
+- Patched `crossbeam-epoch` to 0.9.20 (**RUSTSEC-2026-0204**) and dropped the now-stale audit ignores.
+
+### Fixed
+- **storage/compaction:** compaction now works on Windows — the data file's memory map is released before the atomic rename, and the WAL is truncated through a write handle (previously `ACCESS_DENIED`). A durable rename barrier orders the swap before WAL truncation, and the live index is kept consistent with the mmap if a commit fails mid-compaction.
+- **cli:** `export` and `collection show --samples` iterate the collection's actual point IDs (including points with no payload) instead of an assumed contiguous `1..=n` range — no more silent data loss on sparse IDs.
+- **python:** vector search on a graph/metadata collection now raises instead of silently returning `[]`; `CONDITION_TYPES` is re-exported at the package top level.
+- **wasm:** persistence preserves the storage mode, quantized buffers and payloads (versioned v2 format); export no longer panics or drops data in SQ8/Binary modes.
+- **server:** batch search is offloaded to a blocking worker so it no longer stalls the async runtime.
+- **migrate:** graph relation edges are streamed instead of accumulated, avoiding OOM on large relations.
+- **langchain:** `from_texts(ids=...)` is honored instead of dropped.
+- **llamaindex:** distance scores are mapped to similarity; `delete()` binds its parameters.
+
+### Added
+- **ts-sdk:** retry on 429/503 with exponential backoff (503 retried only for idempotent methods, `Retry-After` capped); `bulkDelete`.
+- **haystack:** `VelesDBEmbeddingRetriever` component.
+- **common:** O(1) cursor scroll via `Collection.scroll_batch`.
+- **mobile:** `MobileGraphStore` save/load persistence.
+
+### Changed
+- **docs:** roadmap refreshed through v3.8.x with a forward-looking "Next" line; REST endpoint count corrected **48 → 54** across the tree and the promise-contract guardrail; stale version strings realigned.
+- **deps:** wgpu 30.0.0, uniffi 0.32.0, plus routine cargo/npm and CI-action group bumps.
+
 ## [3.8.0] — 2026-07-06
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5715,7 +5715,7 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-velesdb"
-version = "3.8.0"
+version = "3.8.1"
 dependencies = [
  "dirs",
  "parking_lot",
@@ -6725,7 +6725,7 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "velesdb-cli"
-version = "3.8.0"
+version = "3.8.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -6750,7 +6750,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-core"
-version = "3.8.0"
+version = "3.8.1"
 dependencies = [
  "arc-swap",
  "bytemuck",
@@ -6820,7 +6820,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-migrate"
-version = "3.8.0"
+version = "3.8.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6848,7 +6848,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-mobile"
-version = "3.8.0"
+version = "3.8.1"
 dependencies = [
  "parking_lot",
  "serde",
@@ -6874,7 +6874,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-python"
-version = "3.8.0"
+version = "3.8.1"
 dependencies = [
  "numpy",
  "parking_lot",
@@ -6888,7 +6888,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-server"
-version = "3.8.0"
+version = "3.8.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -6921,7 +6921,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-wasm"
-version = "3.8.0"
+version = "3.8.1"
 dependencies = [
  "getrandom 0.3.4",
  "getrandom 0.4.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "3.8.0"
+version = "3.8.1"
 edition = "2021"
 rust-version = "1.89"
 license-file = "LICENSE"
@@ -79,7 +79,7 @@ base64 = "0.22"
 smallvec = { version = "1", features = ["serde"] }
 
 # Internal workspace crates
-velesdb-core = { path = "crates/velesdb-core", version = "3.8.0", default-features = false }
+velesdb-core = { path = "crates/velesdb-core", version = "3.8.1", default-features = false }
 
 [profile.release]
 lto = true

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM rust:1.96-bookworm AS builder
 
 LABEL maintainer="VelesDB Team <contact@wiscale.fr>"
-LABEL version="3.8.0"
+LABEL version="3.8.1"
 
 WORKDIR /app
 
@@ -25,7 +25,7 @@ RUN cargo build --release --bin velesdb-server
 FROM debian:bookworm-slim
 
 LABEL maintainer="VelesDB Team <contact@wiscale.fr>"
-LABEL version="3.8.0"
+LABEL version="3.8.1"
 
 WORKDIR /app
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,7 +4,7 @@ This roadmap commits to **what we are building**, **why**, and **when**. It is u
 
 It is intentionally narrow. Items not on this roadmap are tracked as `roadmap` issues but **not committed** until they reach a milestone here.
 
-> **Last updated:** 2026-06-21 — covers v3.8.0 (current). The horizon framing below predates the v2.0→v3.x line and is being re-baselined.
+> **Last updated:** 2026-06-21 — covers v3.8.1 (current). The horizon framing below predates the v2.0→v3.x line and is being re-baselined.
 
 ---
 

--- a/benchmarks/Dockerfile.bench
+++ b/benchmarks/Dockerfile.bench
@@ -6,7 +6,7 @@
 FROM debian:bookworm-slim
 
 LABEL maintainer="VelesDB Team <contact@wiscale.fr>"
-LABEL version="3.8.0"
+LABEL version="3.8.1"
 
 WORKDIR /app
 

--- a/benchmarks/Dockerfile.nightly
+++ b/benchmarks/Dockerfile.nightly
@@ -4,7 +4,7 @@
 FROM rust:slim-bookworm AS builder
 
 LABEL maintainer="VelesDB Team <contact@wiscale.fr>"
-LABEL version="3.8.0"
+LABEL version="3.8.1"
 
 WORKDIR /app
 
@@ -29,7 +29,7 @@ RUN cargo build --release --bin velesdb-server
 FROM debian:bookworm-slim
 
 LABEL maintainer="VelesDB Team <contact@wiscale.fr>"
-LABEL version="3.8.0"
+LABEL version="3.8.1"
 
 WORKDIR /app
 

--- a/benchmarks/Dockerfile.optimized
+++ b/benchmarks/Dockerfile.optimized
@@ -7,7 +7,7 @@
 FROM rust:slim-bookworm AS builder
 
 LABEL maintainer="VelesDB Team <contact@wiscale.fr>"
-LABEL version="3.8.0"
+LABEL version="3.8.1"
 
 WORKDIR /app
 
@@ -49,7 +49,7 @@ RUN cargo build --release --bin velesdb-server \
 FROM debian:bookworm-slim
 
 LABEL maintainer="VelesDB Team <contact@wiscale.fr>"
-LABEL version="3.8.0"
+LABEL version="3.8.1"
 
 WORKDIR /app
 

--- a/crates/tauri-plugin-velesdb/guest-js/package.json
+++ b/crates/tauri-plugin-velesdb/guest-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wiscale/tauri-plugin-velesdb",
-  "version": "3.8.0",
+  "version": "3.8.1",
   "description": "TypeScript bindings for the VelesDB Tauri plugin - Vector search in desktop apps",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/crates/velesdb-python/README.md
+++ b/crates/velesdb-python/README.md
@@ -3,7 +3,7 @@
 [![PyPI](https://img.shields.io/pypi/v/velesdb)](https://pypi.org/project/velesdb/)
 [![Python](https://img.shields.io/pypi/pyversions/velesdb)](https://pypi.org/project/velesdb/)
 [![License](https://img.shields.io/badge/license-VelesDB_Core_1.0-blue)](./LICENSE)
-[![Version](https://img.shields.io/badge/version-3.8.0-blue)](https://github.com/cyberlife-coder/VelesDB/releases)
+[![Version](https://img.shields.io/badge/version-3.8.1-blue)](https://github.com/cyberlife-coder/VelesDB/releases)
 
 Python bindings for [VelesDB](https://github.com/cyberlife-coder/VelesDB) — a high-performance vector database for AI applications. `numpy>=1.20` ships as a hard runtime dependency since v1.13.8, so a single `pip install velesdb` is sufficient.
 

--- a/crates/velesdb-python/pyproject.toml
+++ b/crates/velesdb-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "velesdb"
-version = "3.8.0"
+version = "3.8.1"
 description = "VelesDB: The Local Vector Database for Python & AI. Microsecond semantic search, zero network latency."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/crates/velesdb-server/README.md
+++ b/crates/velesdb-server/README.md
@@ -659,7 +659,7 @@ curl http://localhost:8080/health
 Response:
 
 ```json
-{"status": "ok", "version": "3.8.0"}
+{"status": "ok", "version": "3.8.1"}
 ```
 
 ### `GET /ready` -- Readiness Probe
@@ -673,13 +673,13 @@ curl http://localhost:8080/ready
 Response (ready):
 
 ```json
-{"status": "ready", "version": "3.8.0"}
+{"status": "ready", "version": "3.8.1"}
 ```
 
 Response (not ready):
 
 ```json
-{"status": "not_ready", "version": "3.8.0"}
+{"status": "not_ready", "version": "3.8.1"}
 ```
 
 ### Kubernetes Example

--- a/demos/rag-pdf-demo/pyproject.toml
+++ b/demos/rag-pdf-demo/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "velesdb-rag-demo"
-version = "3.8.0"
+version = "3.8.1"
 description = "RAG Demo with PDF ingestion using VelesDB for vector storage"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/demos/rag-pdf-demo/src/__init__.py
+++ b/demos/rag-pdf-demo/src/__init__.py
@@ -1,3 +1,3 @@
 """VelesDB RAG Demo - PDF Question Answering System."""
 
-__version__ = "3.8.0"
+__version__ = "3.8.1"

--- a/demos/rag-pdf-demo/src/main.py
+++ b/demos/rag-pdf-demo/src/main.py
@@ -46,7 +46,7 @@ async def lifespan(app: FastAPI):
 app = FastAPI(
     title="VelesDB RAG Demo",
     description="PDF Question Answering with VelesDB vector search",
-    version="3.8.0",
+    version="3.8.1",
     lifespan=lifespan
 )
 

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -1,6 +1,6 @@
 # VelesDB Performance Benchmarks
 
-*Last updated: July 6, 2026 (VelesDB v3.8.0). Figures are re-validated at each release only when re-measured — each section carries its own measurement date and machine; this stamp tracks the document revision, not a fresh measurement.*
+*Last updated: July 10, 2026 (VelesDB v3.8.1). Figures are re-validated at each release only when re-measured — each section carries its own measurement date and machine; this stamp tracks the document revision, not a fresh measurement.*
 
 ---
 

--- a/docs/VELESQL_SPEC.md
+++ b/docs/VELESQL_SPEC.md
@@ -2,7 +2,7 @@
 
 > SQL-like query language for vector + graph + column-store search in VelesDB.
 
-**Version**: 3.10.0 | **Last Updated**: 2026-07-06 (VelesDB v3.8.0)
+**Version**: 3.10.0 | **Last Updated**: 2026-07-10 (VelesDB v3.8.1)
 
 ---
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -96,7 +96,7 @@ Expected response:
 ```json
 {
   "status": "ok",
-  "version": "3.8.0"
+  "version": "3.8.1"
 }
 ```
 

--- a/docs/guides/CLI_REPL.md
+++ b/docs/guides/CLI_REPL.md
@@ -1,6 +1,6 @@
 # 💻 CLI & REPL Reference
 
-*Version 3.8.0 — 2026-06-12*
+*Version 3.8.1 — 2026-06-12*
 
 Complete guide to the VelesDB command-line interface and the interactive REPL.
 
@@ -36,7 +36,7 @@ cargo build --release -p velesdb-cli
 
 ```bash
 velesdb --version
-# velesdb 3.8.0
+# velesdb 3.8.1
 ```
 
 ---
@@ -269,7 +269,7 @@ velesdb> \info
 ┌─────────────────────┬────────────────────┐
 │ Property            │ Value              │
 ├─────────────────────┼────────────────────┤
-│ Version             │ 3.8.0              │
+│ Version             │ 3.8.1              │
 │ Data directory      │ ./data             │
 │ Collections         │ 3                  │
 │ Total vectors       │ 125,000            │
@@ -342,7 +342,7 @@ Session settings are **not persisted** across REPL sessions. To persist them, us
 ```
 $ velesdb repl ./my_db
 
-VelesDB v3.8.0 - Interactive REPL
+VelesDB v3.8.1 - Interactive REPL
 Type \help for help, \quit to exit.
 
 velesdb> \show

--- a/docs/guides/CONFIGURATION.md
+++ b/docs/guides/CONFIGURATION.md
@@ -1,6 +1,6 @@
 # ⚙️ VelesDB Configuration
 
-*Version 3.8.0 — May 2026*
+*Version 3.8.1 — May 2026*
 
 Complete guide for configuring VelesDB via configuration file, environment variables, and runtime parameters.
 
@@ -62,7 +62,7 @@ data_dir = "./data"
 ```toml
 # =============================================================================
 # VelesDB Configuration File
-# Version: 3.8.0
+# Version: 3.8.1
 # =============================================================================
 
 # -----------------------------------------------------------------------------

--- a/docs/guides/GRAPH_PATTERNS.md
+++ b/docs/guides/GRAPH_PATTERNS.md
@@ -1,6 +1,6 @@
 # Graph Patterns Guide
 
-*Version 3.8.0 -- May 2026*
+*Version 3.8.1 -- May 2026*
 
 Practical guide for using VelesQL `MATCH` graph patterns in VelesDB.
 

--- a/docs/guides/INSTALLATION.md
+++ b/docs/guides/INSTALLATION.md
@@ -60,10 +60,10 @@ entry.
 
 ```bash
 # Download
-wget https://github.com/cyberlife-coder/VelesDB/releases/download/v3.8.0/velesdb-3.8.0-amd64.deb
+wget https://github.com/cyberlife-coder/VelesDB/releases/download/v3.8.1/velesdb-3.8.1-amd64.deb
 
 # Install
-sudo dpkg -i velesdb-3.8.0-amd64.deb
+sudo dpkg -i velesdb-3.8.1-amd64.deb
 
 # Verify
 velesdb --version
@@ -160,13 +160,13 @@ GitHub Container Registry, so you don't need to build locally:
 
 ```bash
 # Pull a specific release (recommended for reproducibility)
-docker pull ghcr.io/cyberlife-coder/velesdb:3.8.0
+docker pull ghcr.io/cyberlife-coder/velesdb:3.8.1
 
 # ...or the latest stable release
 docker pull ghcr.io/cyberlife-coder/velesdb:latest
 
 docker run -d --name velesdb -p 8080:8080 -v velesdb_data:/data \
-  ghcr.io/cyberlife-coder/velesdb:3.8.0
+  ghcr.io/cyberlife-coder/velesdb:3.8.1
 ```
 
 ### Build locally

--- a/docs/guides/SEARCH_MODES.md
+++ b/docs/guides/SEARCH_MODES.md
@@ -1,6 +1,6 @@
 # 🎯 Search Modes - Recall Configuration Guide
 
-*Version 3.8.0 -- 2026-06-12*
+*Version 3.8.1 -- 2026-06-12*
 
 Complete guide to configuring the **recall vs latency** trade-off in VelesDB. Covers dense search (HNSW), sparse search (SPLADE/BM42), and hybrid search (dense+sparse with fusion). Includes a comparison with Milvus, OpenSearch, and Qdrant practices.
 

--- a/docs/guides/SERVER_SECURITY.md
+++ b/docs/guides/SERVER_SECURITY.md
@@ -299,7 +299,7 @@ curl http://localhost:8080/health
 ```json
 {
   "status": "ok",
-  "version": "3.8.0"
+  "version": "3.8.1"
 }
 ```
 
@@ -318,7 +318,7 @@ curl http://localhost:8080/ready
 ```json
 {
   "status": "ready",
-  "version": "3.8.0"
+  "version": "3.8.1"
 }
 ```
 
@@ -327,7 +327,7 @@ curl http://localhost:8080/ready
 ```json
 {
   "status": "not_ready",
-  "version": "3.8.0"
+  "version": "3.8.1"
 }
 ```
 

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -11,7 +11,7 @@
       "name": "VelesDB Core License 1.0",
       "url": "https://github.com/cyberlife-coder/VelesDB/blob/main/LICENSE"
     },
-    "version": "3.8.0"
+    "version": "3.8.1"
   },
   "servers": [
     {

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -8,7 +8,7 @@ info:
   license:
     name: VelesDB Core License 1.0
     url: https://github.com/cyberlife-coder/VelesDB/blob/main/LICENSE
-  version: 3.8.0
+  version: 3.8.1
 servers:
 - url: /
   description: Local server

--- a/docs/reference/ARCHITECTURE_DIAGRAMS.md
+++ b/docs/reference/ARCHITECTURE_DIAGRAMS.md
@@ -1,4 +1,4 @@
-# VelesDB Architecture Diagrams — v3.8.0
+# VelesDB Architecture Diagrams — v3.8.1
 
 ## 1. Workspace Dependency Graph
 

--- a/docs/reference/ECOSYSTEM_PARITY.md
+++ b/docs/reference/ECOSYSTEM_PARITY.md
@@ -1,6 +1,6 @@
 # VelesQL Ecosystem Parity Matrix
 
-Last updated: 2026-07-06 (v3.8.0; velesdb-memory 0.6.0)
+Last updated: 2026-07-10 (v3.8.1; velesdb-memory 0.6.0)
 
 This matrix tracks runtime contract and feature parity across the VelesDB ecosystem.
 

--- a/docs/reference/VELESQL_CHEATSHEET.md
+++ b/docs/reference/VELESQL_CHEATSHEET.md
@@ -1,7 +1,7 @@
 # VelesQL Cheat Sheet
 
 > **Date:** 2026-06-03
-> **VelesDB version:** 3.8.0
+> **VelesDB version:** 3.8.1
 > See the full specification in [`docs/VELESQL_SPEC.md`](../VELESQL_SPEC.md).
 
 > Every `sql` block below is **parsed** against the real grammar by an automated

--- a/docs/reference/VELESQL_CONFORMANCE_MATRIX.md
+++ b/docs/reference/VELESQL_CONFORMANCE_MATRIX.md
@@ -4,7 +4,7 @@ This document lists every VelesQL feature with its parser and executor status.
 A feature can be **Parsed** (the grammar + AST accept it) without being
 **Executed** (the query engine acts on it at runtime).
 
-> Last updated: 2026-07-06 (VelesDB v3.8.0)
+> Last updated: 2026-07-10 (VelesDB v3.8.1)
 
 ## Fully Supported (Parsed AND Executed)
 

--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -57,7 +57,7 @@ Check server health status.
 ```json
 {
   "status": "ok",
-  "version": "3.8.0"
+  "version": "3.8.1"
 }
 ```
 

--- a/examples/wasm-browser-demo/README.md
+++ b/examples/wasm-browser-demo/README.md
@@ -22,7 +22,7 @@ cd crates/velesdb-wasm
 wasm-pack build --target web --out-dir ../../examples/wasm-browser-demo/pkg
 
 # Then update index.html to use the local path instead of CDN:
-# Change: import init from 'https://unpkg.com/@wiscale/velesdb-wasm@3.8.0/velesdb_wasm.js'
+# Change: import init from 'https://unpkg.com/@wiscale/velesdb-wasm@3.8.1/velesdb_wasm.js'
 # To:     import init from './pkg/velesdb_wasm.js'
 ```
 
@@ -80,7 +80,7 @@ Typical results on modern hardware:
 ```html
 <script type="module">
   // If published on npm:
-  // import init, { VectorStore } from 'https://unpkg.com/@wiscale/velesdb-wasm@3.8.0/velesdb_wasm.js';
+  // import init, { VectorStore } from 'https://unpkg.com/@wiscale/velesdb-wasm@3.8.1/velesdb_wasm.js';
   // If built locally with wasm-pack:
   import init, { VectorStore } from './pkg/velesdb_wasm.js';
 

--- a/examples/wasm-browser-demo/index.html
+++ b/examples/wasm-browser-demo/index.html
@@ -171,8 +171,8 @@
         // WASM module - tracks @wiscale/velesdb-wasm@<workspace> with CDN fallback.
         // Bumped by scripts/bump-version.ps1 on every release; if you copy this
         // demo, update the version below to match `@wiscale/velesdb-wasm` on npm.
-        const WASM_CDN_PRIMARY = 'https://unpkg.com/@wiscale/velesdb-wasm@3.8.0/velesdb_wasm.js';
-        const WASM_CDN_FALLBACK = 'https://cdn.jsdelivr.net/npm/@wiscale/velesdb-wasm@3.8.0/velesdb_wasm.js';
+        const WASM_CDN_PRIMARY = 'https://unpkg.com/@wiscale/velesdb-wasm@3.8.1/velesdb_wasm.js';
+        const WASM_CDN_FALLBACK = 'https://cdn.jsdelivr.net/npm/@wiscale/velesdb-wasm@3.8.1/velesdb_wasm.js';
         
         let init, VectorStore;
         

--- a/integrations/common/pyproject.toml
+++ b/integrations/common/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "velesdb-common"
-version = "3.8.0"
+version = "3.8.1"
 description = "Shared utilities for VelesDB Python integrations (internal use)"
 readme = "README.md"
 license = {text = "MIT"}

--- a/integrations/haystack/pyproject.toml
+++ b/integrations/haystack/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "haystack-velesdb"
-version = "3.8.0"
+version = "3.8.1"
 description = "Haystack 2.x DocumentStore for VelesDB: The Local AI Memory Database."
 readme = "README.md"
 license = {text = "MIT"}

--- a/integrations/haystack/src/haystack_velesdb/__init__.py
+++ b/integrations/haystack/src/haystack_velesdb/__init__.py
@@ -4,4 +4,4 @@ from haystack_velesdb.document_store import VelesDBDocumentStore
 from haystack_velesdb.retriever import VelesDBEmbeddingRetriever
 
 __all__ = ["VelesDBDocumentStore", "VelesDBEmbeddingRetriever"]
-__version__ = "3.8.0"
+__version__ = "3.8.1"

--- a/integrations/langchain/pyproject.toml
+++ b/integrations/langchain/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "langchain-velesdb"
-version = "3.8.0"
+version = "3.8.1"
 description = "LangChain VectorStore for VelesDB: The Local AI Memory Database. Microsecond RAG retrieval."
 readme = "README.md"
 license = {text = "MIT"}

--- a/integrations/langchain/src/langchain_velesdb/__init__.py
+++ b/integrations/langchain/src/langchain_velesdb/__init__.py
@@ -53,4 +53,4 @@ if _HAS_MEMORY:
         "VelesDBSemanticMemory",
         "VelesDBProceduralMemory",
     ])
-__version__ = "3.8.0"
+__version__ = "3.8.1"

--- a/integrations/langgraph/pyproject.toml
+++ b/integrations/langgraph/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "langgraph-velesdb"
-version = "3.8.0"
+version = "3.8.1"
 description = "LangGraph memory tools for VelesDB: drop the why() knowledge-graph memory wedge into any LangGraph agent."
 readme = "README.md"
 license = {text = "MIT"}

--- a/integrations/langgraph/src/langgraph_velesdb/__init__.py
+++ b/integrations/langgraph/src/langgraph_velesdb/__init__.py
@@ -16,4 +16,4 @@ across agent runs.
 from langgraph_velesdb.tools import make_memory_tools
 
 __all__ = ["make_memory_tools"]
-__version__ = "3.8.0"
+__version__ = "3.8.1"

--- a/integrations/llamaindex/pyproject.toml
+++ b/integrations/llamaindex/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "llama-index-vector-stores-velesdb"
-version = "3.8.0"
+version = "3.8.1"
 description = "LlamaIndex VectorStore for VelesDB: The Local AI Memory Database. Microsecond RAG retrieval."
 readme = "README.md"
 license = "MIT"

--- a/integrations/llamaindex/src/llamaindex_velesdb/__init__.py
+++ b/integrations/llamaindex/src/llamaindex_velesdb/__init__.py
@@ -57,4 +57,4 @@ if _HAS_MEMORY:
         "VelesDBChatMemory",
         "VelesDBProceduralMemory",
     ])
-__version__ = "3.8.0"
+__version__ = "3.8.1"

--- a/scripts/dx-timing/scenario_rust.sh
+++ b/scripts/dx-timing/scenario_rust.sh
@@ -41,7 +41,7 @@ RS
 # Pin to the latest released version on crates.io. Bump alongside each
 # workspace release; the timing measurement is meant to track the path a
 # fresh dev hits when they `cargo add velesdb-core` today.
-cargo add --quiet velesdb-core@3.8.0
+cargo add --quiet velesdb-core@3.8.1
 cargo add --quiet serde_json@1
 cargo run --quiet --release
 

--- a/scripts/dx-timing/scenario_server.sh
+++ b/scripts/dx-timing/scenario_server.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 
 START=$(date +%s.%N)
 
-cargo install --quiet --locked velesdb-server@3.8.0
+cargo install --quiet --locked velesdb-server@3.8.1
 
 DATA_DIR=$(mktemp -d -t velesdb_dx_server_XXXX)
 trap 'rm -rf "$DATA_DIR"' EXIT

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -2,7 +2,7 @@
 
 Official TypeScript SDK for [VelesDB](https://github.com/cyberlife-coder/VelesDB) -- the local-first vector database for AI and RAG. Sub-millisecond semantic search in Browser and Node.js.
 
-**v3.8.0** | Node.js >= 18 | Browser (WASM) | VelesDB Core License 1.0
+**v3.8.1** | Node.js >= 18 | Browser (WASM) | VelesDB Core License 1.0
 
 ## What's New in v3.6.0
 

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wiscale/velesdb-sdk",
-  "version": "3.8.0",
+  "version": "3.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wiscale/velesdb-sdk",
-      "version": "3.8.0",
+      "version": "3.8.1",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@wiscale/velesdb-wasm": "^3.8.0"

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wiscale/velesdb-sdk",
-  "version": "3.8.0",
+  "version": "3.8.1",
   "description": "VelesDB TypeScript SDK: The Local Vector Database for AI & RAG. Microsecond semantic search in Browser & Node.js.",
   "main": "dist/index.js",
   "module": "dist/index.mjs",


### PR DESCRIPTION
## v3.8.1 — release prep

Bumps the workspace to **3.8.1** and adds the CHANGELOG entry, so the audit-remediation work already on `develop` ships as a real patch release (a security fix only reaches users once published, not merely merged).

Applied strictly via the documented process (`docs/contributing/RELEASE.md`):
- `python3 scripts/bump_version.py 3.8.1` — 62 policed locations, 0 MISS
- OpenAPI specs regenerated from the crate version (`docs/openapi.{yaml,json}` → 3.8.1)
- `Cargo.lock` refreshed (`cargo build` green)
- `scripts/check-version-sync.py` → **All versions match**
- `CHANGELOG.md` `[3.8.1]` added (Security / Fixed / Added / Changed)

`velesdb-memory` and `velesdb-node` are intentionally **not** bumped — they track an independent 0.x cadence.

### Headline
- 🔒 **Security:** crossbeam-epoch 0.9.20 (RUSTSEC-2026-0204)
- 🐛 compaction works on Windows; CLI export no longer loses data on sparse IDs; python fails loud on wrong collection type; wasm persistence lossless; server/migrate/integration fixes

After merge to `develop` → `develop → main` (#1347 already open, will include this bump) → tag `v3.8.1` triggers `release.yml` (crates.io / PyPI / npm / GitHub Release).