### PR TITLE
fix(server): stop double-firing on_query telemetry on /query endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,19 @@ security patch and a batch of correctness fixes. No API breaks.
   promise-contract CI guard rejects any doc that claims search throughput for
   `sq8`/`binary`.
 
+### Fixed
+- **server:** the `/query` VelesQL endpoint no longer double-fires `on_query`
+  telemetry. `Database::execute_query` already invokes the observer's
+  `on_query` hook exactly once internally (see "Telemetry is now
+  core-invoked" above); the REST handler was additionally calling the
+  deprecated `notify_query` shim after every `execute_query` dispatch, so any
+  registered `DatabaseObserver` (RBAC/audit/usage billing) counted every
+  `/query` request twice. The redundant call — and the per-statement
+  collection-name extraction helpers that existed only to feed it — were
+  removed; a regression test
+  (`query_endpoint_fires_on_query_exactly_once_per_dispatch_branch`) pins the
+  exactly-once contract for both `/query` dispatch branches.
+
 ### Deprecated
 - **`Database::notify_upsert` / `Database::notify_query`** are deprecated (since
   3.9.0). Telemetry is now invoked inside the core use-case layer; callers should

--- a/crates/velesdb-server/src/handlers/query/mod.rs
+++ b/crates/velesdb-server/src/handlers/query/mod.rs
@@ -13,11 +13,8 @@ use std::sync::Arc;
 use velesdb_core::collection::search::query::projection;
 #[cfg(test)]
 use velesdb_core::velesql;
-use velesdb_core::velesql::{
-    DdlStatement, DmlStatement, IntrospectionStatement, Query, SelectColumns,
-};
+use velesdb_core::velesql::{DmlStatement, Query, SelectColumns};
 
-use crate::handlers::helpers::notify_query_timing;
 use crate::types::{
     QueryRequest, QueryResponse, QueryResponseMeta, QueryType, VELESQL_CONTRACT_VERSION,
 };
@@ -121,118 +118,7 @@ pub async fn query(
         }
     };
 
-    build_query_response(
-        &state,
-        &collection_name,
-        start,
-        results,
-        &parsed.select.columns,
-    )
-}
-
-/// Extract the collection name targeted by a mutation/DDL/introspection query.
-///
-/// Returns `"_system"` for global operations that do not target a specific
-/// collection (SHOW COLLECTIONS, EXPLAIN, FLUSH without collection). This
-/// function is used exclusively for telemetry tagging — it is NOT on the
-/// HTTP routing path. The actual query execution goes through
-/// [`Database::execute_query`] which enforces its own dispatch rules.
-///
-/// # Forward compatibility
-///
-/// The four VelesQL statement enums (`IntrospectionStatement`,
-/// `AdminStatement`, `DdlStatement`, `DmlStatement`) are annotated
-/// `#[non_exhaustive]` so a wildcard `_` arm is mandatory here. To prevent
-/// silent telemetry degradation when a new core variant is added without
-/// an accompanying handler update, every wildcard arm now logs a
-/// `tracing::warn!` with a stable target so it is visible in CI logs and
-/// production observability.
-fn extract_mutation_collection_name(parsed: &Query) -> String {
-    extract_ddl_collection(parsed)
-        .or_else(|| extract_dml_collection(parsed))
-        .or_else(|| extract_introspection_collection(parsed))
-        .or_else(|| extract_admin_collection(parsed))
-        .or_else(|| parsed.train.as_ref().map(|train| train.collection.clone()))
-        .unwrap_or_else(|| "_system".to_string())
-}
-
-/// Extract collection name from an introspection statement.
-fn extract_introspection_collection(parsed: &Query) -> Option<String> {
-    parsed.introspection.as_ref().map(|intro| match intro {
-        IntrospectionStatement::DescribeCollection(d) => d.name.clone(),
-        IntrospectionStatement::ShowCollections | IntrospectionStatement::Explain(_) => {
-            "_system".to_string()
-        }
-        other => warn_unknown_velesql_variant("IntrospectionStatement", other),
-    })
-}
-
-/// Extract collection name from an admin statement.
-fn extract_admin_collection(parsed: &Query) -> Option<String> {
-    parsed.admin.as_ref().map(|admin| match admin {
-        velesdb_core::velesql::AdminStatement::Flush(f) => f
-            .collection
-            .clone()
-            .unwrap_or_else(|| "_system".to_string()),
-        other => warn_unknown_velesql_variant("AdminStatement", other),
-    })
-}
-
-/// Extract collection name from a DDL statement.
-fn extract_ddl_collection(parsed: &Query) -> Option<String> {
-    parsed.ddl.as_ref().and_then(|ddl| match ddl {
-        DdlStatement::CreateCollection(s) => Some(s.name.clone()),
-        DdlStatement::DropCollection(s) => Some(s.name.clone()),
-        DdlStatement::CreateIndex(s) => Some(s.collection.clone()),
-        DdlStatement::DropIndex(s) => Some(s.collection.clone()),
-        DdlStatement::Analyze(s) => Some(s.collection.clone()),
-        DdlStatement::Truncate(s) => Some(s.collection.clone()),
-        DdlStatement::AlterCollection(s) => Some(s.collection.clone()),
-        other => {
-            warn_unknown_velesql_variant("DdlStatement", other);
-            None
-        }
-    })
-}
-
-/// Extract collection name from a DML statement.
-fn extract_dml_collection(parsed: &Query) -> Option<String> {
-    parsed.dml.as_ref().and_then(|dml| match dml {
-        DmlStatement::Insert(s) | DmlStatement::Upsert(s) => Some(s.table.clone()),
-        DmlStatement::Update(s) => Some(s.table.clone()),
-        DmlStatement::InsertEdge(s) => Some(s.collection.clone()),
-        DmlStatement::Delete(s) => Some(s.table.clone()),
-        DmlStatement::DeleteEdge(s) => Some(s.collection.clone()),
-        DmlStatement::SelectEdges(s) => Some(s.collection.clone()),
-        DmlStatement::InsertNode(s) => Some(s.collection.clone()),
-        other => {
-            warn_unknown_velesql_variant("DmlStatement", other);
-            None
-        }
-    })
-}
-
-/// Logs a structured warning when an unknown VelesQL statement variant is
-/// encountered on the telemetry extraction path and returns the
-/// `"_system"` sentinel string. The structured `target` `velesql.dispatch`
-/// is stable so CI log aggregators and production observability can alert
-/// when a new core variant slips past the handler mapper without an
-/// accompanying update.
-///
-/// Note: this fallback only affects the collection-name tag attached to
-/// request telemetry. The HTTP response is still produced by the
-/// downstream `Database::execute_query` call which rejects truly
-/// unsupported statements with a proper error.
-fn warn_unknown_velesql_variant<T: std::fmt::Debug>(kind: &'static str, variant: &T) -> String {
-    tracing::warn!(
-        target: "velesql.dispatch",
-        enum_kind = kind,
-        variant = ?variant,
-        "unknown VelesQL statement variant on telemetry extraction path; \
-         routing collection tag to _system — add the new variant to \
-         extract_mutation_collection_name in handlers/query/mod.rs"
-    );
-    "_system".to_string()
+    build_query_response(&state, start, results, &parsed.select.columns)
 }
 
 /// Execute a DDL, graph/delete DML, introspection, admin, or TRAIN query.
@@ -253,10 +139,7 @@ fn execute_mutation_query(
     start: std::time::Instant,
 ) -> axum::response::Response {
     match state.db.execute_query(parsed, params) {
-        Ok(results) => {
-            let coll_name = extract_mutation_collection_name(parsed);
-            build_query_response(state, &coll_name, start, results, &parsed.select.columns)
-        }
+        Ok(results) => build_query_response(state, start, results, &parsed.select.columns),
         Err(e) => {
             state.operational_metrics.inc_errors();
             velesql_error(
@@ -330,9 +213,17 @@ fn execute_standard_query(
 }
 
 /// Build the final query response with timing metrics and SQL projection.
+///
+/// Both callers ([`execute_standard_query`] and [`execute_mutation_query`])
+/// dispatch through [`Database::execute_query`](velesdb_core::Database::execute_query),
+/// which already fires the observer's `on_query` telemetry exactly once
+/// internally. This function must therefore NOT also call the deprecated
+/// `notify_query_timing`/`notify_query` shim — doing so would double-count
+/// every `/query` request for any registered `DatabaseObserver` (RBAC/audit/
+/// usage billing). Only the Prometheus histogram, which is unrelated to the
+/// observer, is recorded here.
 fn build_query_response(
     state: &Arc<AppState>,
-    collection_name: &str,
     start: std::time::Instant,
     results: Vec<velesdb_core::SearchResult>,
     select_columns: &SelectColumns,
@@ -342,7 +233,6 @@ fn build_query_response(
     #[allow(clippy::cast_possible_truncation)]
     // Reason: timing_ms is always < u64::MAX (query durations < 585 millennia)
     let took_ms = timing_ms.round() as u64;
-    notify_query_timing(state, collection_name, start);
     state
         .query_duration_histogram
         .observe(elapsed.as_secs_f64());

--- a/crates/velesdb-server/tests/observer_lifecycle_tests.rs
+++ b/crates/velesdb-server/tests/observer_lifecycle_tests.rs
@@ -131,3 +131,54 @@ async fn observer_receives_full_lifecycle() {
         "on_collection_deleted"
     );
 }
+
+/// Regression test for a double-count bug: `Database::execute_query` fires
+/// `on_query` once internally (core-invoked telemetry). The `/query` REST
+/// handler must not *also* invoke the deprecated `notify_query` shim after
+/// calling `execute_query`, or every VelesQL request would tally twice for
+/// any registered `DatabaseObserver` (RBAC/audit/usage billing). Unlike
+/// `observer_receives_full_lifecycle` above (which asserts `>= 1` for the
+/// `/search` REST pipeline, a path that never routes through
+/// `execute_query`), this test asserts an exact count for both `/query`
+/// dispatch branches so a reintroduced double-fire fails the test.
+#[tokio::test]
+async fn query_endpoint_fires_on_query_exactly_once_per_dispatch_branch() {
+    let dir = TempDir::new().expect("test: dir");
+    let observer = Arc::new(CountingObserver::default());
+    let app = create_test_app_with_observer(&dir, observer.clone());
+
+    let status = post(
+        &app,
+        "/collections",
+        json!({"name": COLLECTION, "dimension": DIM, "metric": "cosine"}),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED, "create");
+
+    // SELECT via /query exercises `execute_standard_query`.
+    let status = post(
+        &app,
+        "/query",
+        json!({
+            "query": format!("SELECT * FROM {COLLECTION} WHERE vector NEAR $v LIMIT 1"),
+            "params": {"v": QUERY}
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "select via /query");
+    assert_eq!(
+        observer.query.load(Ordering::SeqCst),
+        1,
+        "on_query must fire exactly once for a SELECT dispatched via /query"
+    );
+
+    // SHOW COLLECTIONS via /query exercises the AST-routed
+    // `execute_mutation_query` branch (introspection).
+    let status = post(&app, "/query", json!({"query": "SHOW COLLECTIONS"})).await;
+    assert_eq!(status, StatusCode::OK, "show collections via /query");
+    assert_eq!(
+        observer.query.load(Ordering::SeqCst),
+        2,
+        "on_query must fire exactly once more for an introspection query dispatched via /query"
+    );
+}

--- a/crates/velesdb-server/tests/observer_lifecycle_tests.rs
+++ b/crates/velesdb-server/tests/observer_lifecycle_tests.rs
@@ -135,7 +135,7 @@ async fn observer_receives_full_lifecycle() {
 /// Regression test for a double-count bug: `Database::execute_query` fires
 /// `on_query` once internally (core-invoked telemetry). The `/query` REST
 /// handler must not *also* invoke the deprecated `notify_query` shim after
-/// calling `execute_query`, or every VelesQL request would tally twice for
+/// calling `execute_query`, or every `VelesQL` request would tally twice for
 /// any registered `DatabaseObserver` (RBAC/audit/usage billing). Unlike
 /// `observer_receives_full_lifecycle` above (which asserts `>= 1` for the
 /// `/search` REST pipeline, a path that never routes through

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -11,7 +11,7 @@
       "name": "VelesDB Core License 1.0",
       "url": "https://github.com/cyberlife-coder/VelesDB/blob/main/LICENSE"
     },
-    "version": "3.8.1"
+    "version": "3.9.0"
   },
   "servers": [
     {

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -8,7 +8,7 @@ info:
   license:
     name: VelesDB Core License 1.0
     url: https://github.com/cyberlife-coder/VelesDB/blob/main/LICENSE
-  version: 3.8.1
+  version: 3.9.0
 servers:
 - url: /
   description: Local server


### PR DESCRIPTION
## Description

This branch carries the unreleased `control-plane-boundary` feature (core-invoked `on_upsert`/`on_query` telemetry, the read-path `on_query_request` RBAC/tenant gate, `LockRank`, the shippable `WalCursor`, and the stable cross-engine `hash_id`/`hash_edge_id` hasher — see the `[3.9.0]` CHANGELOG entry). It had been pushed to `origin` with no open PR, so per the review workflow I audited the diff (Clean Code / Fowler refactor practices, DRY, KISS, performance, and vulnerability review) before opening one.

That audit found one real correctness bug, which this PR fixes:

**`/query` double-counted `on_query` telemetry.** `Database::execute_query` now fires the observer's `on_query` hook exactly once internally (that's the whole point of "telemetry is core-invoked" in 3.9.0). But `crates/velesdb-server/src/handlers/query/mod.rs`'s `build_query_response` — shared by both the standard SELECT/MATCH dispatch and the AST-routed DDL/introspection/admin/TRAIN/graph-DML dispatch, both of which already call `Database::execute_query` — was *also* calling the deprecated `notify_query` shim afterward. Every request to `/query` therefore counted twice for any registered `DatabaseObserver` (RBAC/audit/usage billing in `velesdb-premium`). Every other REST caller of the shim (`points/mod.rs`, `streaming.rs`, `search/pipeline.rs`, `search/batch.rs`, `aggregation.rs`) had already been correctly left alone because none of them route through `execute_query` — this one call site was the miss.

## Changes

- Removed the redundant `notify_query_timing` call from `build_query_response`, and the `collection_name` parameter that only existed to feed it.
- Removed `extract_mutation_collection_name` and its four AST-walking helpers (`extract_ddl_collection`, `extract_dml_collection`, `extract_introspection_collection`, `extract_admin_collection`) plus `warn_unknown_velesql_variant` — this whole cluster existed solely to compute the collection tag for the now-removed duplicate `notify_query` call, so it became dead code once that call was removed.
- Added a regression test, `query_endpoint_fires_on_query_exactly_once_per_dispatch_branch`, asserting an **exact** `on_query` count (not `>= 1`) across both `/query` dispatch branches (a `SELECT` and a `SHOW COLLECTIONS`), so a reintroduced double-fire fails CI.
- Documented the fix under the still-unreleased `[3.9.0]` CHANGELOG entry (dated 2026-07-11).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🔧 Refactoring (no functional changes) — dead-code removal

## How Has This Been Tested?

- [x] Unit tests
- [x] Integration tests

`cargo build` / `cargo clippy --all-targets -- -D warnings` clean for `velesdb-core` + `velesdb-server`. `cargo test -p velesdb-server --test observer_lifecycle_tests` and `cargo test -p velesdb-core --features persistence --test telemetry_exactly_once` pass, including the new regression test. A broader `cargo test --workspace` run (excluding the Tauri/GTK-linked crates, which can't build in this sandbox for unrelated system-library reasons) was still in flight at PR time; I'm watching this PR and will report back if it surfaces anything.

**Test Configuration:**
- OS: Linux (container)
- Rust version: workspace-pinned toolchain

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation (CHANGELOG)
- [x] My changes generate no new warnings (clippy `-D warnings` clean)
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

I reviewed the rest of the `control-plane-boundary` diff (the `DatabaseObserver` read-gate seam, `LockRank`, `WalCursor`/retention-aware compaction, `stable_hash`) and found it well-designed, well-tested, and correctly scoped — no other correctness, security, or DRY issues surfaced. One minor design note for awareness, not blocking: the new public `LockRank` newtype (`crates/velesdb-core/src/lock_rank.rs`, reserved premium range `[40, 59]`) is a distinct type from the pre-existing private `locking::LockRank` enum that already gates real HNSW/GPU lock acquisition in `graph/mod.rs`/`gpu_csr.rs`; the two aren't unified, so today the new type is exercised only by its own tests and is the seam premium is expected to build against, not (yet) core's own internal enforcement. Flagging in case that divergence wasn't intentional.
