### PR TITLE
feat: zero-friction DX — ghcr docker run, public-bind security warning, non-semantic embedder notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,16 +246,16 @@ cargo install velesdb-server velesdb-cli
 
 **Docker (REST server):**
 ```bash
-# Build the image locally
-git clone https://github.com/cyberlife-coder/VelesDB.git && cd VelesDB
-docker build -t velesdb .
-
-# Run with persistent data (named volume)
-docker run -d -p 8080:8080 -v velesdb_data:/data --name velesdb velesdb
+# Run the published image (multi-arch: linux/amd64 + linux/arm64)
+docker run -d -p 8080:8080 -v velesdb_data:/data --name velesdb \
+  ghcr.io/cyberlife-coder/velesdb:latest
 
 # Verify it's running
 curl http://localhost:8080/health
 ```
+Pin a specific version with `ghcr.io/cyberlife-coder/velesdb:3.9` (or a full
+`3.9.1`). To build the image yourself instead: `git clone` the repo and
+`docker build -t velesdb .`.
 
 Data is stored in `/data` inside the container; the named volume `velesdb_data` persists across restarts.
 
@@ -593,13 +593,13 @@ INSERT                      INDEX                       SEARCH
 <summary>Docker deployment</summary>
 
 ```bash
-# Build and run locally
-docker build -t velesdb .
-docker run -d -p 8080:8080 -v velesdb_data:/data --name velesdb velesdb
+# Run the published multi-arch image
+docker run -d -p 8080:8080 -v velesdb_data:/data --name velesdb \
+  ghcr.io/cyberlife-coder/velesdb:latest
 curl http://localhost:8080/health
 
-# Or with docker-compose (builds + auto-restart)
-docker-compose up -d
+# Or build locally / use docker-compose (builds + auto-restart)
+docker build -t velesdb . && docker-compose up -d
 ```
 
 | Variable | Default | Description |

--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ docker run -d -p 8080:8080 -v velesdb_data:/data --name velesdb \
 curl http://localhost:8080/health
 ```
 Pin a specific version with `ghcr.io/cyberlife-coder/velesdb:3.9` (or a full
-`3.9.1`). To build the image yourself instead: `git clone` the repo and
+`3.9.0`). To build the image yourself instead: `git clone` the repo and
 `docker build -t velesdb .`.
 
 Data is stored in `/data` inside the container; the named volume `velesdb_data` persists across restarts.

--- a/crates/velesdb-memory/src/main.rs
+++ b/crates/velesdb-memory/src/main.rs
@@ -113,9 +113,8 @@ fn build_embedder() -> Result<DynEmbedder, Box<dyn std::error::Error>> {
 /// that the default `hash` embedder is deterministic but **not semantic**:
 /// `recall` matches on lexical/hash proximity, not meaning. This is the single
 /// most common "why is recall bad?" surprise, so make the trade-off explicit
-/// and point to the opt-in. Suppress with `VELESDB_MEMORY_EMBEDDER=hash` set
-/// intentionally? No — the value is identical; instead honor an explicit
-/// opt-out for scripted/offline runs via `VELESDB_MEMORY_QUIET=1`.
+/// and point to the opt-in. Silence it for scripted/offline runs with
+/// `VELESDB_MEMORY_QUIET=1`.
 fn warn_hash_embedder_not_semantic() {
     if std::env::var_os("VELESDB_MEMORY_QUIET").is_some() {
         return;

--- a/crates/velesdb-memory/src/main.rs
+++ b/crates/velesdb-memory/src/main.rs
@@ -98,12 +98,35 @@ fn build_ollama_extractor() -> Result<velesdb_memory::DynExtractor, Box<dyn std:
 fn build_embedder() -> Result<DynEmbedder, Box<dyn std::error::Error>> {
     match std::env::var("VELESDB_MEMORY_EMBEDDER").as_deref() {
         Ok("ollama") => build_ollama_embedder(),
-        Ok("hash") | Err(_) => Ok(Box::new(HashEmbedder::new(DEFAULT_DIMENSION))),
+        Ok("hash") | Err(_) => {
+            warn_hash_embedder_not_semantic();
+            Ok(Box::new(HashEmbedder::new(DEFAULT_DIMENSION)))
+        }
         Ok(other) => Err(format!(
             "unknown VELESDB_MEMORY_EMBEDDER '{other}' (expected 'hash' or 'ollama')"
         )
         .into()),
     }
+}
+
+/// Warn (on **stderr**, never stdout — that carries the MCP JSON-RPC stream)
+/// that the default `hash` embedder is deterministic but **not semantic**:
+/// `recall` matches on lexical/hash proximity, not meaning. This is the single
+/// most common "why is recall bad?" surprise, so make the trade-off explicit
+/// and point to the opt-in. Suppress with `VELESDB_MEMORY_EMBEDDER=hash` set
+/// intentionally? No — the value is identical; instead honor an explicit
+/// opt-out for scripted/offline runs via `VELESDB_MEMORY_QUIET=1`.
+fn warn_hash_embedder_not_semantic() {
+    if std::env::var_os("VELESDB_MEMORY_QUIET").is_some() {
+        return;
+    }
+    eprintln!(
+        "[velesdb-memory] Using the default 'hash' embedder: deterministic and \
+         fully offline, but NOT semantic — recall matches surface form, not meaning. \
+         For real semantic recall, run an Ollama build with \
+         VELESDB_MEMORY_EMBEDDER=ollama (see crates/velesdb-memory/README.md). \
+         Set VELESDB_MEMORY_QUIET=1 to silence this notice."
+    );
 }
 
 #[cfg(feature = "ollama")]

--- a/crates/velesdb-server/src/config.rs
+++ b/crates/velesdb-server/src/config.rs
@@ -264,15 +264,31 @@ impl ServerConfig {
 
     /// Returns `true` when the bind host is reachable beyond the local machine.
     ///
-    /// A loopback host (`127.0.0.1`, `::1`, `localhost`) is treated as private;
-    /// anything else — including the wildcard `0.0.0.0`/`::` — is considered
-    /// publicly reachable. Used to warn when the server is exposed without
-    /// authentication.
+    /// A loopback host is treated as private: `localhost`, any `127.0.0.0/8`
+    /// address (`127.0.0.1`, `127.0.0.5`, …), IPv6 loopback `::1`, and the
+    /// IPv4-mapped form `::ffff:127.0.0.1`. Matching is case-insensitive and
+    /// tolerates surrounding whitespace and `[...]` brackets. Anything else —
+    /// including the wildcards `0.0.0.0`/`::` and any routable address or
+    /// hostname — is considered publicly reachable. Errs toward *over*-warning
+    /// (an unrecognised host is treated as public), never under-warning.
     pub fn binds_publicly(&self) -> bool {
-        let host = self.host.trim();
-        // Bracketed IPv6 literals may appear as `[::1]`.
-        let host = host.trim_start_matches('[').trim_end_matches(']');
-        !matches!(host, "127.0.0.1" | "::1" | "localhost") && !host.starts_with("127.")
+        // Case-insensitive, whitespace- and bracket-tolerant (`[::1]`).
+        let host = self
+            .host
+            .trim()
+            .trim_start_matches('[')
+            .trim_end_matches(']')
+            .to_ascii_lowercase();
+        if matches!(host.as_str(), "localhost" | "::1") || host.starts_with("127.") {
+            return false;
+        }
+        // IPv4-mapped IPv6 loopback, e.g. `::ffff:127.0.0.1`.
+        if let Some(v4) = host.strip_prefix("::ffff:") {
+            if v4.starts_with("127.") {
+                return false;
+            }
+        }
+        true
     }
 }
 
@@ -445,13 +461,23 @@ mod tests {
     #[test]
     fn test_binds_publicly() {
         let mut cfg = ServerConfig::default();
-        // Loopback hosts are private.
-        for host in ["127.0.0.1", "::1", "[::1]", "localhost", "127.0.0.5"] {
+        // Loopback hosts are private — including case variants, brackets,
+        // whitespace, 127.0.0.0/8, and the IPv4-mapped IPv6 loopback.
+        for host in [
+            "127.0.0.1",
+            "::1",
+            "[::1]",
+            "localhost",
+            "LOCALHOST",
+            " localhost ",
+            "127.0.0.5",
+            "::ffff:127.0.0.1",
+        ] {
             cfg.host = host.to_string();
             assert!(!cfg.binds_publicly(), "{host} should be private");
         }
         // Wildcard and routable addresses are public.
-        for host in ["0.0.0.0", "::", "192.168.1.10", "10.0.0.1"] {
+        for host in ["0.0.0.0", "::", "192.168.1.10", "10.0.0.1", ""] {
             cfg.host = host.to_string();
             assert!(cfg.binds_publicly(), "{host} should be public");
         }

--- a/crates/velesdb-server/src/config.rs
+++ b/crates/velesdb-server/src/config.rs
@@ -261,6 +261,19 @@ impl ServerConfig {
     pub fn rate_limit_enabled(&self) -> bool {
         self.rate_limit > 0
     }
+
+    /// Returns `true` when the bind host is reachable beyond the local machine.
+    ///
+    /// A loopback host (`127.0.0.1`, `::1`, `localhost`) is treated as private;
+    /// anything else — including the wildcard `0.0.0.0`/`::` — is considered
+    /// publicly reachable. Used to warn when the server is exposed without
+    /// authentication.
+    pub fn binds_publicly(&self) -> bool {
+        let host = self.host.trim();
+        // Bracketed IPv6 literals may appear as `[::1]`.
+        let host = host.trim_start_matches('[').trim_end_matches(']');
+        !matches!(host, "127.0.0.1" | "::1" | "localhost") && !host.starts_with("127.")
+    }
 }
 
 // ============================================================================
@@ -428,6 +441,21 @@ pub fn parse_api_keys_env() -> Option<Vec<String>> {
 mod tests {
     use super::*;
     use std::io::Write;
+
+    #[test]
+    fn test_binds_publicly() {
+        let mut cfg = ServerConfig::default();
+        // Loopback hosts are private.
+        for host in ["127.0.0.1", "::1", "[::1]", "localhost", "127.0.0.5"] {
+            cfg.host = host.to_string();
+            assert!(!cfg.binds_publicly(), "{host} should be private");
+        }
+        // Wildcard and routable addresses are public.
+        for host in ["0.0.0.0", "::", "192.168.1.10", "10.0.0.1"] {
+            cfg.host = host.to_string();
+            assert!(cfg.binds_publicly(), "{host} should be public");
+        }
+    }
 
     #[test]
     fn test_defaults() {

--- a/crates/velesdb-server/src/main.rs
+++ b/crates/velesdb-server/src/main.rs
@@ -196,15 +196,6 @@ fn build_router(
     }
 }
 
-fn warn_if_exposed(host: &str) {
-    if host != "127.0.0.1" && host != "localhost" {
-        tracing::warn!(
-            "VelesDB server exposed on network ({host}). \
-             Consider using 127.0.0.1 for local-first usage."
-        );
-    }
-}
-
 /// Returns a future that resolves when SIGTERM is received (Unix) or never (non-Unix).
 async fn sigterm() {
     #[cfg(unix)]
@@ -234,7 +225,6 @@ async fn serve(
     state: Arc<AppState>,
     shutdown_timeout_secs: u64,
 ) -> anyhow::Result<()> {
-    warn_if_exposed(host);
     let addr = format!("{host}:{port}");
     let listener = tokio::net::TcpListener::bind(&addr).await?;
     tracing::info!("VelesDB server listening on http://{}", addr);
@@ -360,8 +350,6 @@ async fn serve_tls(
     state: Arc<AppState>,
     shutdown_timeout_secs: u64,
 ) -> anyhow::Result<()> {
-    warn_if_exposed(host);
-
     let tls_acceptor = velesdb_server::tls::load_tls_config(cert_path, key_path)?;
     let addr = format!("{host}:{port}");
     let listener = tokio::net::TcpListener::bind(&addr).await?;

--- a/crates/velesdb-server/src/main.rs
+++ b/crates/velesdb-server/src/main.rs
@@ -78,8 +78,20 @@ fn log_startup(cfg: &ServerConfig) {
             "API key authentication enabled ({} key(s))",
             cfg.api_keys.len()
         );
+    } else if cfg.binds_publicly() {
+        tracing::warn!(
+            "API key authentication is DISABLED while binding a publicly reachable \
+             address ({}). Every endpoint — including /metrics and all data — is open \
+             to anyone who can reach this host. Set VELESDB_API_KEYS (and preferably \
+             TLS via VELESDB_TLS_CERT/VELESDB_TLS_KEY) before exposing this server, or \
+             bind 127.0.0.1 for local development. See docs/guides/SERVER_SECURITY.md.",
+            cfg.host
+        );
     } else {
-        tracing::info!("API key authentication disabled (local dev mode)");
+        tracing::info!(
+            "API key authentication disabled (local dev mode, bound to {})",
+            cfg.host
+        );
     }
     if cfg.tls_enabled() {
         tracing::info!("TLS enabled");


### PR DESCRIPTION
## Phase 1 — zéro-friction utilisateur final (core)

Trois frictions de découverte identifiées par l'audit « œil utilisateur final », corrigées sans changer aucun défaut :

### 1. `docker run` one-liner (README)
`docker-publish.yml` publie déjà l'image multi-arch sur `ghcr.io/cyberlife-coder/velesdb` à chaque tag. Le README pointait encore sur un build local. Désormais le quickstart Docker mène avec :
```bash
docker run -d -p 8080:8080 -v velesdb_data:/data --name velesdb ghcr.io/cyberlife-coder/velesdb:latest
```
**Smoke-testé** : l'image `:latest` répond `{"status":"ok","version":"3.9.0"}` sur `/health`.

### 2. Warning sécurité au boot (durcissement)
`ServerConfig::binds_publicly()` détecte une écoute non-loopback. Quand l'auth est désactivée **et** l'adresse est publiquement joignable, le serveur émet un `WARN` explicite (`/metrics` et toutes les données seraient ouverts), pointant vers `SERVER_SECURITY.md`. Aucun défaut affaibli ; couvert par `test_binds_publicly`.

### 3. Notice embedder non-sémantique (MCP memory)
L'embedder `hash` par défaut est déterministe mais non sémantique — surprise n°1 sur la qualité du recall. Notice **stderr** (jamais stdout, qui porte le flux JSON-RPC MCP) au démarrage, expliquant l'opt-in `VELESDB_MEMORY_EMBEDDER=ollama`, silençable via `VELESDB_MEMORY_QUIET=1`.

## Sécurité / gates
Aucune nouvelle dépendance. `cargo fmt` OK, tests config verts. Va dans le sens du durcissement (défauts sûrs, transparence).