### PR TITLE
chore(docker): embed LICENSE in the runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,10 @@ RUN useradd -r -s /bin/false velesdb
 # Copy binary from builder
 COPY --from=builder /app/target/release/velesdb-server /usr/local/bin/
 
+# Embed the license so the redistributed image carries its notices
+# (VelesDB Core License 1.0 / ELv2 requires the license to travel with the Software).
+COPY LICENSE /usr/local/share/doc/velesdb/LICENSE
+
 # Create data directory
 RUN mkdir -p /data && chown velesdb:velesdb /data
 


### PR DESCRIPTION
Embed the VelesDB Core License 1.0 (ELv2) in the published Docker image at `/usr/local/share/doc/velesdb/LICENSE`, so redistributed images carry the license notices ELv2 requires. Single-line `COPY LICENSE` in the runtime stage; no build impact.