### PR TITLE
fix(node): velesdb-node 0.7.0 + version-sync gate coverage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6858,7 +6858,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-node"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "napi",
  "napi-build",

--- a/crates/velesdb-node/Cargo.toml
+++ b/crates/velesdb-node/Cargo.toml
@@ -2,7 +2,7 @@
 name = "velesdb-node"
 # Tracks velesdb-memory's independent cadence (the npm package version),
 # not the workspace 3.x engine line. Never crates.io-published (publish=false).
-version = "0.6.0"
+version = "0.7.0"
 # Never cargo-published: this cdylib ships to npm as @wiscale/velesdb-memory-node
 # per-platform prebuilds, not to crates.io.
 publish = false

--- a/crates/velesdb-node/package-lock.json
+++ b/crates/velesdb-node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wiscale/velesdb-memory-node",
-  "version": "0.4.0",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wiscale/velesdb-memory-node",
-      "version": "0.4.0",
+      "version": "0.7.0",
       "license": "SEE LICENSE IN LICENSE",
       "devDependencies": {
         "@napi-rs/cli": "^3.0.0"

--- a/crates/velesdb-node/package.json
+++ b/crates/velesdb-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wiscale/velesdb-memory-node",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Local-first agent memory for Node.js (napi-rs): remember/recall/relate/forget/why with the why() knowledge-graph wedge, plus auto-extraction.",
   "license": "SEE LICENSE IN LICENSE",
   "author": "Julien Lange <contact@wiscale.fr>",

--- a/scripts/check-version-sync.py
+++ b/scripts/check-version-sync.py
@@ -164,6 +164,15 @@ TARGETS: "list[tuple[str, str]]" = [
 # field, so there is nothing to police in them.
 MEMORY_TARGETS: "list[tuple[str, str]]" = [
     ("server.json", "mcp_server_json"),
+    # The napi-rs node binding of velesdb-memory versions in lock-step with
+    # the crate. Its package.json was found at 0.6.0 when the 0.7.0 tag was
+    # cut (release-memory.yml failed all five node builds on the
+    # version-vs-tag check and the npm publish was skipped), and its lockfile
+    # had silently drifted to 0.4.0 — neither was policed by anything before.
+    ("crates/velesdb-node/Cargo.toml", "toml"),
+    ("crates/velesdb-node/package.json", "json"),
+    ("crates/velesdb-node/package-lock.json", "json"),
+    ("crates/velesdb-node/package-lock.json", "npm_lock_pkg"),
 ]
 
 


### PR DESCRIPTION
Complète la release velesdb-memory 0.7.0 : le binding node était resté à 0.6.0 (lockfile à 0.4.0 !), les 5 builds node du run release-memory ont échoué et le publish npm a été sauté (crates.io, lui, est publié).

- Bump Cargo.toml / package.json / package-lock.json du binding à 0.7.0.
- `check-version-sync.py` : les 3 manifestes du binding rejoignent MEMORY_TARGETS (4 lecteurs) — ce drift ne peut plus se reproduire.
- Gate local : All versions match ; `cargo check -p velesdb-node` vert.

Après merge : `gh workflow run release-memory.yml -r main -f version=0.7.0` (publish_crate=false) pour rejouer les builds node + publish npm.
