### PR TITLE
fix(security): patch glib unsoundness (dependabot #3/#6)

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -22,6 +22,20 @@ ignore = [
     { id = "RUSTSEC-2024-0418", reason = "gdk-sys: tauri Linux GTK3 — no fix; Tauri 3 migration tracked" },
     { id = "RUSTSEC-2024-0419", reason = "gtk3-macros: tauri Linux GTK3 — no fix; Tauri 3 migration tracked" },
     { id = "RUSTSEC-2024-0420", reason = "gtk-sys: tauri Linux GTK3 — no fix; Tauri 3 migration tracked" },
+    # glib (RUSTSEC-2024-0429 / GHSA-wrw7-89jp-8q8g, Dependabot alerts #3 &
+    # #6): unsoundness in the `glib::VariantStrIter` Iterator impls, patched
+    # in glib 0.20.0. The fix is UNREACHABLE from this dependency tree: the
+    # GTK3 bindings (gtk3-rs, archived upstream) ended at 0.18.x and pin
+    # glib =0.18, and Tauri 2.x (incl. latest 2.11.5) depends on gtk 0.18
+    # via muda/tao/webkit2gtk on Linux. `cargo update -p glib` is a no-op in
+    # both lockfiles (root + demos/tauri-rag-app/src-tauri). No ignore entry
+    # is needed: the advisory is informational ("unsound") and cargo-deny
+    # does not flag it — an ignore would trip the unmatched-ignore warning.
+    # VelesDB code never constructs `VariantStrIter` (verified: no direct
+    # glib usage in crates/ or demos/); exposure is limited to the Tauri
+    # Linux GTK3 backend and goes away with the same Tauri 3 / GTK4
+    # migration as the ignores above. If cargo-deny starts erroring on
+    # unsound advisories, add: { id = "RUSTSEC-2024-0429", ... } here.
 
     # ── Tauri non-GTK3 transitives ────────────────────────────────────
     { id = "RUSTSEC-2024-0370", reason = "proc-macro-error: tauri build-time transitive, unmaintained" },


### PR DESCRIPTION
## Context

Dependabot alerts **#3** (root `Cargo.lock`) and **#6** (`demos/tauri-rag-app/src-tauri/Cargo.lock`) flag **glib 0.18.5** for [GHSA-wrw7-89jp-8q8g](https://github.com/advisories/GHSA-wrw7-89jp-8q8g) / [RUSTSEC-2024-0429](https://rustsec.org/advisories/RUSTSEC-2024-0429): unsoundness in the `Iterator`/`DoubleEndedIterator` impls of `glib::VariantStrIter`, patched in glib **0.20.0**.

## Investigation

**Who pulls glib** (both lockfiles, Linux targets only):
`tauri 2.11.x → muda / tao / tauri-runtime / webkit2gtk → gtk 0.18.2 → glib 0.18.5`

**Why the fix is unreachable without code changes:**
- The GTK3 bindings (**gtk3-rs**) are archived upstream; their final release line is **0.18.x**, which pins `glib = 0.18`. There is no gtk3 binding release compatible with glib 0.20.
- Tauri 2.x — including the latest **2.11.5** already used at the root — still depends on gtk 0.18 for its Linux backend. No patch/minor bump of tauri or wry changes this.
- `cargo update -p glib` is a **no-op** in both projects (0.18.5 is the max compatible version).
- The exit is the Tauri 3 / GTK4 + webkit2gtk-6 migration, already tracked in `deny.toml` for the 7 sibling GTK3 advisories (RUSTSEC-2024-0412/0413/0415/0416/0418/0419/0420).

**Exposure:** VelesDB code never constructs `VariantStrIter` (no direct glib usage in `crates/` or `demos/`); the affected functions live only in the Tauri Linux GTK3 backend.

## Change

- `deny.toml`: documentation block in the GTK3 advisories section recording the accepted risk, the reasoning, and the exit path. **No ignore entry** is added: the advisory is informational (`unsound`) and `cargo deny check advisories` already passes — an ignore entry trips cargo-deny's unmatched-ignore warning (verified both ways).

## Gates

- `cargo check --workspace` (root): **pass** (2m32s)
- `cargo deny check` (root): **advisories ok, bans ok, licenses ok, sources ok**
- `cargo check` in `demos/tauri-rag-app/src-tauri`: fails on a **pre-existing** environment requirement (`frontendDist ../dist` needs the frontend built first), not on Rust code. Note: on macOS the glib code path isn't compiled anyway (Linux-only dependency), so no local check can exercise it.

## Remediation for the alerts

This PR cannot auto-close #3/#6 (the vulnerable version stays in the lockfiles — that's the point). Recommended: **dismiss both alerts as "Risk is tolerable"** referencing this PR, mirroring the existing deny.toml treatment of the sibling GTK3 advisories. They will auto-resolve for real with the Tauri 3 / GTK4 migration (tracked, not before 2026 Q4).
