### PR TITLE
feat(python): read-path veto for the SDK observer (CORE-5)

### DIFF
--- a/crates/velesdb-python/src/database.rs
+++ b/crates/velesdb-python/src/database.rs
@@ -111,21 +111,28 @@ impl Database {
     ///     config: Optional typed configuration (limits, etc.) applied
     ///         at open time. See :class:`VelesConfigOptions`.
     ///     observer: Optional callable invoked on collection lifecycle
-    ///         events. Called as ``observer(event, **fields)`` where
-    ///         ``event`` is one of ``"collection_created"``,
-    ///         ``"collection_deleted"``, ``"upsert"``, or ``"query"``:
+    ///         events and before every gated read. Called as
+    ///         ``observer(event, **fields)`` where ``event`` is one of
+    ///         ``"collection_created"``, ``"collection_deleted"``,
+    ///         ``"upsert"``, ``"query"``, or ``"query_request"``:
     ///
     ///         - ``collection_created`` → ``name``, ``kind``
     ///           (``"vector"``/``"metadata"``/``"graph"``/``"unknown"``)
     ///         - ``collection_deleted`` → ``name``
     ///         - ``upsert`` → ``collection``, ``point_count``
-    ///         - ``query`` → ``collection``, ``duration_us``
+    ///         - ``query`` → ``collection``, ``duration_us`` (after execution)
+    ///         - ``query_request`` → ``collection``, ``operation``,
+    ///           ``principal``, ``tenant`` (before execution — **veto point**)
     ///
     ///         The observer is immutable once the database is opened
-    ///         (there is no post-open setter). Exceptions raised inside
-    ///         the callback are swallowed so they never break a core
-    ///         operation. This is a notify-only hook — it cannot veto
-    ///         operations.
+    ///         (there is no post-open setter). For the *notify* events the
+    ///         return value is ignored and a raised exception is swallowed so
+    ///         it never breaks a core operation. For ``"query_request"`` the
+    ///         callback governs the read: return ``False`` or a string reason to
+    ///         **deny** it (raising a query error), or ``None``/``True`` to
+    ///         allow. A callback that ignores ``query_request`` (returns
+    ///         ``None``) allows every read, so existing notify-only observers
+    ///         are unaffected.
     ///
     /// Returns:
     ///     Database instance

--- a/crates/velesdb-python/src/observer.rs
+++ b/crates/velesdb-python/src/observer.rs
@@ -1,22 +1,28 @@
 //! `PyObserver` — bridges core [`DatabaseObserver`] lifecycle hooks to a single
 //! Python callable.
 //!
-//! The Python SDK exposes only the four *notify* callbacks (create/delete/
-//! upsert/query). The two veto hooks (`on_ddl_request` / `on_dml_mutation_request`)
-//! keep the trait's default-allow behavior and are intentionally **not** exposed —
-//! policy/RBAC enforcement is out of scope for the open SDK.
+//! The Python SDK exposes the four *notify* callbacks (create/delete/upsert/
+//! query) plus the read-path **veto** hook (`query_request`): the callback may
+//! refuse a read by returning `False` or a string reason, so an SDK embedder can
+//! enforce governance on every gated read (VelesQL `SELECT`/`MATCH`). The DDL/DML
+//! veto hooks (`on_ddl_request` / `on_dml_mutation_request`) keep the trait's
+//! default-allow behavior and remain unexposed.
 //!
 //! # GIL safety
 //!
 //! Core fires every callback *after* dropping the collection write guard, so
 //! re-acquiring the GIL here cannot deadlock the core-lock against the GIL.
-//! Each callback still swallows any [`PyErr`] (logged, never propagated) and
-//! never panics — the [`DatabaseObserver`] contract forbids panicking.
+//! Notify callbacks swallow any [`PyErr`] (logged, never propagated) and never
+//! panic — the [`DatabaseObserver`] contract forbids panicking. The
+//! `query_request` veto also never panics: a raised callback error is logged and
+//! treated as *allow* (fail-open on observer error, never break a read on a bug
+//! in user policy code — an explicit `False`/reason is the only way to deny).
 
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 use velesdb_core::collection::CollectionType;
-use velesdb_core::DatabaseObserver;
+use velesdb_core::observer::{AccessDecision, QueryAccessContext, QueryOperationKind};
+use velesdb_core::{DatabaseObserver, Error};
 
 /// A [`DatabaseObserver`] that forwards lifecycle events to one Python callable.
 ///
@@ -68,6 +74,45 @@ fn collection_kind(kind: &CollectionType) -> &'static str {
     }
 }
 
+/// Maps a [`QueryOperationKind`] to a stable operation string for the callback.
+/// The `_` arm keeps this total against the `#[non_exhaustive]` enum.
+fn operation_str(op: QueryOperationKind) -> &'static str {
+    match op {
+        QueryOperationKind::VectorSearch => "vector_search",
+        QueryOperationKind::TextSearch => "text_search",
+        QueryOperationKind::HybridSearch => "hybrid_search",
+        QueryOperationKind::GraphTraversal => "graph_traversal",
+        QueryOperationKind::Select => "select",
+        _ => "unknown",
+    }
+}
+
+/// Interprets a `query_request` callback return value as an [`AccessDecision`]:
+///
+/// * `None` or `True` (or any other truthy object) → [`AccessDecision::Allow`]
+///   — so an existing notify-only callback that ignores the event and returns
+///   `None` keeps allowing every read (backward compatible);
+/// * `False` → [`AccessDecision::Deny`] with a default reason;
+/// * a `str` → `Deny` carrying that string as the human-readable reason.
+fn interpret_decision(ret: &Bound<'_, PyAny>) -> AccessDecision {
+    if ret.is_none() {
+        return AccessDecision::Allow;
+    }
+    // A string is a deny *reason*. Check before bool so `""`—an empty reason—
+    // still denies rather than being coerced to a falsey bool.
+    if let Ok(reason) = ret.extract::<String>() {
+        return AccessDecision::Deny(Error::Query(format!("read denied by observer: {reason}")));
+    }
+    if let Ok(allow) = ret.extract::<bool>() {
+        return if allow {
+            AccessDecision::Allow
+        } else {
+            AccessDecision::Deny(Error::Query("read denied by observer policy".to_string()))
+        };
+    }
+    AccessDecision::Allow
+}
+
 impl DatabaseObserver for PyObserver {
     fn on_collection_created(&self, name: &str, kind: &CollectionType) {
         let kind = collection_kind(kind);
@@ -112,5 +157,38 @@ impl DatabaseObserver for PyObserver {
             }
             self.dispatch(py, "query", &fields);
         });
+    }
+
+    /// Read-path veto. Invokes the callback as
+    /// `callback("query_request", collection=…, operation=…, principal=…, tenant=…)`
+    /// and maps its return value through [`interpret_decision`]: `None`/`True`
+    /// allow, `False`/str deny. A callback that raises, or a field-population
+    /// failure, allows the read (fail-open on error so a bug in user policy code
+    /// never breaks a query — only an explicit refusal denies). Fires on every
+    /// gated read (VelesQL `SELECT`/`MATCH`) so an SDK embedder can enforce
+    /// governance, closing the "notify-only" gap (CORE-5).
+    fn on_query_request(&self, ctx: &QueryAccessContext) -> velesdb_core::Result<AccessDecision> {
+        let decision = Python::attach(|py| {
+            let fields = PyDict::new(py);
+            if fields.set_item("collection", ctx.collection).is_err()
+                || fields
+                    .set_item("operation", operation_str(ctx.operation))
+                    .is_err()
+                || fields.set_item("principal", ctx.principal).is_err()
+                || fields.set_item("tenant", ctx.tenant_hint).is_err()
+            {
+                return AccessDecision::Allow;
+            }
+            match self.cb.bind(py).call(("query_request",), Some(&fields)) {
+                Ok(ret) => interpret_decision(&ret),
+                Err(err) => {
+                    eprintln!(
+                        "[velesdb] observer callback 'query_request' raised; allowing: {err}"
+                    );
+                    AccessDecision::Allow
+                }
+            }
+        });
+        Ok(decision)
     }
 }

--- a/crates/velesdb-python/tests/test_observer.py
+++ b/crates/velesdb-python/tests/test_observer.py
@@ -112,3 +112,85 @@ def test_no_observer_is_optional():
         assert "docs" in db.list_collections()
     finally:
         shutil.rmtree(temp_dir, ignore_errors=True)
+
+
+# ---------------------------------------------------------------------------
+# CORE-5: read-path veto via the ``query_request`` event. A VelesQL SELECT is a
+# gated read, so it fires ``query_request`` before execution; returning
+# ``False`` / a reason denies it, ``None`` / ``True`` allows it.
+# ---------------------------------------------------------------------------
+
+
+def test_query_request_veto_denies_read():
+    """Returning ``False`` from ``query_request`` refuses the gated read."""
+    temp_dir = tempfile.mkdtemp()
+    try:
+
+        def deny_reads(event, **fields):
+            if event == "query_request":
+                return False
+            return None
+
+        db = Database(temp_dir, observer=deny_reads)
+        db.create_collection("docs", dimension=DIM)
+        with pytest.raises(Exception):
+            db.execute_query("SELECT * FROM docs")
+    finally:
+        shutil.rmtree(temp_dir, ignore_errors=True)
+
+
+def test_query_request_allow_permits_read():
+    """A notify-only observer (returns ``None``) allows every read unchanged."""
+    temp_dir = tempfile.mkdtemp()
+    try:
+
+        def notify_only(event, **fields):
+            return None
+
+        db = Database(temp_dir, observer=notify_only)
+        db.create_collection("docs", dimension=DIM)
+        rows = db.execute_query("SELECT * FROM docs")
+        assert isinstance(rows, list)
+    finally:
+        shutil.rmtree(temp_dir, ignore_errors=True)
+
+
+def test_query_request_reason_string_surfaces_in_error():
+    """Returning a string reason denies and carries the reason to the caller."""
+    temp_dir = tempfile.mkdtemp()
+    try:
+
+        def deny_with_reason(event, **fields):
+            if event == "query_request":
+                return "tenant mismatch"
+            return None
+
+        db = Database(temp_dir, observer=deny_with_reason)
+        db.create_collection("docs", dimension=DIM)
+        with pytest.raises(Exception) as exc:
+            db.execute_query("SELECT * FROM docs")
+        assert "tenant mismatch" in str(exc.value)
+    finally:
+        shutil.rmtree(temp_dir, ignore_errors=True)
+
+
+def test_query_request_fields_carry_collection_and_operation():
+    """The veto callback receives the collection name and operation kind."""
+    temp_dir = tempfile.mkdtemp()
+    try:
+        recorder = Recorder()
+
+        def observe(event, **fields):
+            recorder.events.append((event, fields))
+            return None
+
+        db = Database(temp_dir, observer=observe)
+        db.create_collection("docs", dimension=DIM)
+        db.execute_query("SELECT * FROM docs")
+
+        requests = recorder.events_of("query_request")
+        assert len(requests) >= 1
+        assert requests[0]["collection"] == "docs"
+        assert requests[0]["operation"] == "select"
+    finally:
+        shutil.rmtree(temp_dir, ignore_errors=True)


### PR DESCRIPTION
## Why
The Python SDK observer was **notify-only** — it received lifecycle events but could not enforce governance, so an SDK embedder had no way to refuse a read. This is the CORE-5 gap flagged in the release audit.

## What
Add `PyObserver::on_query_request`: before every gated read (VelesQL `SELECT`/`MATCH` via `execute_query`), the callback is invoked as `callback("query_request", collection=…, operation=…, principal=…, tenant=…)`. Its return governs the read:
- `False` or a `str` reason → **deny** (raises a query error; the reason surfaces in the message)
- `None` / `True` → **allow**

Backward compatible: a callback that ignores the event (returns `None`) allows every read, so existing notify-only observers are unchanged. Fail-open on error — a raised callback or field-population failure allows the read (a bug in user policy must never break a query; only an explicit refusal denies).

## Verification
- `test_observer.py` (run under `maturin develop`): deny-via-`False`, deny-via-reason-string (reason in error), allow-via-`None`, and callback receives `collection` + `operation`.
- **Full Python SDK suite: 441 passed, 0 regressions.**
- `cargo clippy -p velesdb-python --all-targets -D warnings -D clippy::pedantic` clean; `cargo fmt` clean.

## Follow-up (tracked)
The SDK's direct `.search()` / `.search_with_filter()` methods still call the ungated `VectorCollection` path. Routing them through `Database::gated_search` (as the REST server now does after #1369) will extend veto coverage beyond VelesQL to the direct-search API.

⚠️ Awaiting nominative merge approval.