### PR TITLE
docs(core): soften recall guarantee + fix stale version pin (CORE-DOC)

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ docker run -d -p 8080:8080 -v velesdb_data:/data --name velesdb \
 curl http://localhost:8080/health
 ```
 Pin a specific version with `ghcr.io/cyberlife-coder/velesdb:3.9` (or a full
-`3.9.0`). To build the image yourself instead: `git clone` the repo and
+`3.9.1`). To build the image yourself instead: `git clone` the repo and
 `docker build -t velesdb .`.
 
 Data is stored in `/data` inside the container; the named volume `velesdb_data` persists across restarts.

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -177,7 +177,7 @@ The RRF fusion step is a simple score merge with no distance computation, so hyb
 
 *Recall values from recall_benchmark. Latencies measured March 19, 2026. ef_search values are base values (scaled with k).*
 
-Recall@10 >= 95% is guaranteed for Balanced mode and above. The new **Adaptive** mode starts with a low ef and escalates only for hard queries, achieving 2-4x faster median latency. Use `HnswParams::for_dataset_size()` for automatic parameter tuning.
+Recall@10 >= 95% is the design target for Balanced mode and above, and is what we measure on the benchmark sets below — it is a measured target, not a hard guarantee, since HNSW is an approximate index. The new **Adaptive** mode starts with a low ef and escalates only for hard queries, achieving 2-4x faster median latency. Use `HnswParams::for_dataset_size()` for automatic parameter tuning.
 
 ### Search Optimization Notes (v1.7.2)
 


### PR DESCRIPTION
## Why
Two honesty/accuracy nits flagged in the release audit (CORE-DOC):
- `docs/BENCHMARKS.md` claimed **"Recall@10 >= 95% is guaranteed"** — indefensible for an approximate HNSW index and a credibility crack for a compliance-minded audience.
- `README.md` Docker full-version example pinned `3.9.0` while the current release is `3.9.1`.

## What
- Reword the recall claim to a **measured design target** on the benchmark sets, explicitly *not* a hard guarantee (HNSW is approximate).
- Update the Docker pin example `3.9.0` → `3.9.1` (the `:3.9` minor tag already tracks the latest patch; the migration table's historical `v3.9.0` reference is intentionally left).

Docs-only, no code change.

## Not actioned (with rationale)
**CORE-POS** (README repositioning) was assessed and deliberately **not** changed: the README already leads with the governance / `why()` / EU-AI-Act angle as its first pillar; the recall benchmarks are a supporting "measured, not vibes" credibility pillar, not a "we win on recall" fight. The "split-brain" concern is overstated, and a rewrite of a high-visibility public artifact is subjective product-voice territory better left to a deliberate call.

⚠️ Awaiting nominative merge approval.