### PR TITLE
feat(python): gate direct .search() through governance read-path gate

### DIFF
--- a/crates/velesdb-python/python/velesdb/__init__.pyi
+++ b/crates/velesdb-python/python/velesdb/__init__.pyi
@@ -211,6 +211,8 @@ class SearchOptions:
     sparse_index_name: Optional[str]
     include_vectors: bool
     fusion: Optional["FusionStrategy"]
+    principal: Optional[str]
+    tenant: Optional[str]
 
     def __init__(
         self,
@@ -222,6 +224,8 @@ class SearchOptions:
         sparse_index_name: Optional[str] = None,
         include_vectors: bool = False,
         fusion: Optional["FusionStrategy"] = None,
+        principal: Optional[str] = None,
+        tenant: Optional[str] = None,
     ) -> None: ...
     def with_vector(
         self, vector: Optional[Union[List[float], "np.ndarray"]]
@@ -234,6 +238,8 @@ class SearchOptions:
     def with_sparse_index_name(self, name: Optional[str]) -> "SearchOptions": ...
     def with_include_vectors(self, include: bool) -> "SearchOptions": ...
     def with_fusion(self, fusion: Optional["FusionStrategy"]) -> "SearchOptions": ...
+    def with_principal(self, principal: Optional[str]) -> "SearchOptions": ...
+    def with_tenant(self, tenant: Optional[str]) -> "SearchOptions": ...
 
 
 class SearchResult:
@@ -462,6 +468,8 @@ class Collection:
         top_k: int = 10,
         filter: Optional[Dict[str, Any]] = None,
         sparse_index_name: Optional[str] = None,
+        principal: Optional[str] = None,
+        tenant: Optional[str] = None,
     ) -> List[Dict[str, Any]]:
         """Search for similar vectors (dense, sparse, or hybrid).
 
@@ -511,6 +519,9 @@ class Collection:
         vector: Union[List[float], "np.ndarray"],
         top_k: int = 10,
         ef_search: int = 128,
+        *,
+        principal: Optional[str] = None,
+        tenant: Optional[str] = None,
     ) -> List[Dict[str, Any]]:
         """Search with custom HNSW ef_search parameter."""
         ...
@@ -519,8 +530,16 @@ class Collection:
         self,
         vector: Union[List[float], "np.ndarray"],
         top_k: int = 10,
+        *,
+        principal: Optional[str] = None,
+        tenant: Optional[str] = None,
     ) -> List[Dict[str, Any]]:
-        """Search returning only IDs and scores."""
+        """Search returning only IDs and scores.
+
+        Note: this entry point returns no payload, so it cannot apply an
+        observer scope filter; a scoped read fails closed. Use ``search`` /
+        ``search_request`` when governance scoping may be in effect.
+        """
         ...
 
     def search_with_filter(
@@ -528,6 +547,9 @@ class Collection:
         vector: Union[List[float], "np.ndarray"],
         top_k: int = 10,
         filter: Optional[Dict[str, Any]] = None,
+        *,
+        principal: Optional[str] = None,
+        tenant: Optional[str] = None,
     ) -> List[Dict[str, Any]]:
         """Search with metadata filtering."""
         ...
@@ -537,6 +559,9 @@ class Collection:
         query: str,
         top_k: int = 10,
         filter: Optional[Dict[str, Any]] = None,
+        *,
+        principal: Optional[str] = None,
+        tenant: Optional[str] = None,
     ) -> List[Dict[str, Any]]:
         """Full-text search using BM25 ranking."""
         ...
@@ -548,6 +573,9 @@ class Collection:
         top_k: int = 10,
         vector_weight: float = 0.5,
         filter: Optional[Dict[str, Any]] = None,
+        *,
+        principal: Optional[str] = None,
+        tenant: Optional[str] = None,
     ) -> List[Dict[str, Any]]:
         """Hybrid search combining vector similarity and text search."""
         ...
@@ -555,6 +583,9 @@ class Collection:
     def batch_search(
         self,
         searches: List[Dict[str, Any]],
+        *,
+        principal: Optional[str] = None,
+        tenant: Optional[str] = None,
     ) -> List[List[Dict[str, Any]]]:
         """Batch search for multiple query vectors in parallel.
 
@@ -568,6 +599,9 @@ class Collection:
         top_k: int = 10,
         fusion: Optional["FusionStrategy"] = None,
         filter: Optional[Dict[str, Any]] = None,
+        *,
+        principal: Optional[str] = None,
+        tenant: Optional[str] = None,
     ) -> List[Dict[str, Any]]:
         """Multi-query search with result fusion.
 
@@ -587,8 +621,14 @@ class Collection:
         vectors: List[Union[List[float], "np.ndarray"]],
         top_k: int = 10,
         fusion: Optional[FusionStrategy] = None,
+        *,
+        principal: Optional[str] = None,
+        tenant: Optional[str] = None,
     ) -> List[Dict[str, Any]]:
-        """Multi-query search returning only IDs and fused scores."""
+        """Multi-query search returning only IDs and fused scores.
+
+        Note: returns no payload, so a scoped observer read fails closed.
+        """
         ...
 
     def get(self, ids: List[int]) -> List[Optional[Dict[str, Any]]]:
@@ -662,6 +702,9 @@ class Collection:
         self,
         vectors: List[Union[List[float], "np.ndarray"]],
         top_k: int = 10,
+        *,
+        principal: Optional[str] = None,
+        tenant: Optional[str] = None,
     ) -> List[List[Dict[str, Any]]]:
         """Parallel batch search for multiple query vectors.
 
@@ -679,6 +722,9 @@ class Collection:
         vector: Union[List[float], "np.ndarray"],
         quality: str,
         top_k: int = 10,
+        *,
+        principal: Optional[str] = None,
+        tenant: Optional[str] = None,
     ) -> List[Dict[str, Any]]:
         """Search with a named quality mode.
 

--- a/crates/velesdb-python/src/collection/mod.rs
+++ b/crates/velesdb-python/src/collection/mod.rs
@@ -18,10 +18,13 @@ pub(crate) mod scroll;
 mod search;
 pub(crate) mod search_options;
 
+use std::sync::Arc;
+
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyString};
 use velesdb_core::{
-    Filter, FusionStrategy as CoreFusionStrategy, SearchResult, VectorCollection as CoreCollection,
+    Condition, Database as CoreDatabase, Filter, FusionStrategy as CoreFusionStrategy, GatedRead,
+    QueryOperationKind, SearchResult, VectorCollection as CoreCollection,
 };
 
 /// Default fusion strategy when none is specified by the caller.
@@ -110,6 +113,12 @@ impl CollectionKind {
 pub struct Collection {
     /// Core collection (cheap to clone — all fields are `Arc`-wrapped internally).
     pub(crate) inner: CoreCollection,
+    /// Shared handle to the owning database. `inner` is a *detached* collection
+    /// leaf with no observer reference, so every search is routed back through
+    /// this handle's control-plane read gate (`gated_search` / `authorize_read`)
+    /// rather than hitting the leaf directly — restoring governance for the
+    /// Python direct-search API (OSS direct-search gate).
+    pub(crate) db: Arc<CoreDatabase>,
     /// Cached name to avoid acquiring `config` read lock on every `#[getter]` access.
     pub(crate) name: String,
     /// Real kind of the wrapped collection; guards vector-only methods.
@@ -118,15 +127,25 @@ pub struct Collection {
 
 impl Collection {
     /// Create a wrapper for a vector collection.
-    pub fn new(inner: CoreCollection, name: String) -> Self {
-        Self::new_with_kind(inner, name, CollectionKind::Vector)
+    pub fn new(inner: CoreCollection, db: Arc<CoreDatabase>, name: String) -> Self {
+        Self::new_with_kind(inner, db, name, CollectionKind::Vector)
     }
 
     /// Create a wrapper for a collection whose real kind may not be vector
     /// (graph/metadata), so vector-only methods fail loud rather than returning
     /// empty results (F2.2).
-    pub(crate) fn new_with_kind(inner: CoreCollection, name: String, kind: CollectionKind) -> Self {
-        Self { inner, name, kind }
+    pub(crate) fn new_with_kind(
+        inner: CoreCollection,
+        db: Arc<CoreDatabase>,
+        name: String,
+        kind: CollectionKind,
+    ) -> Self {
+        Self {
+            inner,
+            db,
+            name,
+            kind,
+        }
     }
 
     /// Rejects a vector-only operation on a non-vector collection with a clear,
@@ -145,8 +164,13 @@ impl Collection {
 
     /// Dispatch to the correct search path based on which arguments are present.
     ///
-    /// Handles all combinations of dense/sparse with optional filter and
-    /// optional named sparse index selection.
+    /// Every path is routed through the owning database's control-plane read
+    /// gate first: dense-only / dense+filter reads map directly onto
+    /// [`GatedRead::Dense`] and run via [`gated_search`](CoreDatabase::gated_search);
+    /// sparse and hybrid-sparse reads have no `GatedRead` leaf, so they consult
+    /// [`authorize_read`](CoreDatabase::authorize_read) and AND any observer
+    /// scope filter into a post-filter (fail closed on deny, narrow on scope).
+    #[allow(clippy::too_many_arguments)] // gate identity (principal/tenant) threads through
     fn dispatch_search(
         &self,
         dense: Option<Vec<f32>>,
@@ -155,6 +179,8 @@ impl Collection {
         filter: Option<&Filter>,
         sparse_index_name: Option<&str>,
         fusion: Option<&CoreFusionStrategy>,
+        principal: Option<&str>,
+        tenant: Option<&str>,
     ) -> PyResult<Vec<SearchResult>> {
         use crate::collection_helpers::core_err;
         use pyo3::exceptions::PyValueError;
@@ -169,42 +195,160 @@ impl Collection {
         // (backlog #24); other paths ignore it. Default preserves RRF k=60.
         let fusion = fusion.unwrap_or(&DEFAULT_FUSION);
 
-        match (dense, sparse, filter) {
-            (Some(d), Some(s), Some(f)) => {
-                // No native hybrid_sparse_search_with_filter — run unfiltered then post-filter
-                let mut results = self
-                    .inner
-                    .hybrid_sparse_search(&d, &s, top_k, index_name, fusion)
+        match (dense, sparse) {
+            // Dense-only / dense+filter: expressible as a governed `GatedRead`.
+            (Some(d), None) => self
+                .db
+                .gated_search(
+                    &self.name,
+                    principal,
+                    tenant,
+                    GatedRead::Dense {
+                        query: &d,
+                        k: top_k,
+                        ef: None,
+                        quality: None,
+                        filter,
+                    },
+                )
+                .map_err(core_err),
+            // Any path carrying a sparse vector: the gate has no sparse leaf, so
+            // authorize the read (deny ⇒ Err, fail closed) then AND the observer
+            // scope filter into a post-filter so a scoped read only narrows.
+            (dense_opt, Some(s)) => {
+                let scope = self
+                    .db
+                    .authorize_read(
+                        &self.name,
+                        QueryOperationKind::VectorSearch,
+                        principal,
+                        tenant,
+                    )
                     .map_err(core_err)?;
-                results.retain(|r| {
-                    r.point
-                        .payload
-                        .as_ref()
-                        .is_some_and(|p| f.matches(p))
-                });
-                Ok(results)
+                self.run_sparse_gated(
+                    dense_opt.as_deref(),
+                    &s,
+                    top_k,
+                    filter,
+                    scope.as_ref(),
+                    index_name,
+                    fusion,
+                )
             }
-            (Some(d), Some(s), None) => self
-                .inner
-                .hybrid_sparse_search(&d, &s, top_k, index_name, fusion)
-                .map_err(core_err),
-            (Some(d), None, Some(f)) => self
-                .inner
-                .search_with_filter(&d, top_k, f)
-                .map_err(core_err),
-            (Some(d), None, None) => self.inner.search(&d, top_k).map_err(core_err),
-            (None, Some(_), Some(_)) => Err(PyValueError::new_err(
-                "Filter is not supported with sparse-only search; provide 'vector' for hybrid search",
-            )),
-            (None, Some(s), None) => self
-                .inner
-                .sparse_search(&s, top_k, index_name)
-                .map_err(core_err),
-            (None, None, _) => Err(PyValueError::new_err(
+            (None, None) => Err(PyValueError::new_err(
                 "At least one of 'vector' or 'sparse_vector' must be provided",
             )),
         }
     }
+
+    /// Runs a sparse-only or hybrid dense+sparse search after the read gate has
+    /// authorized it, applying the caller filter and any observer scope filter
+    /// via post-filtering (neither leaf accepts a metadata filter natively).
+    #[allow(clippy::too_many_arguments)] // scope threading is intrinsic to the gate
+    fn run_sparse_gated(
+        &self,
+        dense: Option<&[f32]>,
+        sparse: &velesdb_core::sparse_index::SparseVector,
+        top_k: usize,
+        caller_filter: Option<&Filter>,
+        scope_filter: Option<&Filter>,
+        index_name: &str,
+        fusion: &CoreFusionStrategy,
+    ) -> PyResult<Vec<SearchResult>> {
+        use crate::collection_helpers::core_err;
+        use pyo3::exceptions::PyValueError;
+
+        match dense {
+            // Hybrid dense+sparse: no filtered leaf — run unfiltered then
+            // post-filter by the caller filter AND the observer scope filter.
+            Some(d) => {
+                let mut results = self
+                    .inner
+                    .hybrid_sparse_search(d, sparse, top_k, index_name, fusion)
+                    .map_err(core_err)?;
+                retain_by_filters(&mut results, caller_filter, scope_filter);
+                Ok(results)
+            }
+            // Sparse-only: a caller filter was never supported here (preserved
+            // error). A governance scope filter still applies via post-filter,
+            // so a scoped observer narrows rather than being silently bypassed.
+            None => {
+                if caller_filter.is_some() {
+                    return Err(PyValueError::new_err(
+                        "Filter is not supported with sparse-only search; provide 'vector' for hybrid search",
+                    ));
+                }
+                let mut results = self
+                    .inner
+                    .sparse_search(sparse, top_k, index_name)
+                    .map_err(core_err)?;
+                retain_by_filters(&mut results, None, scope_filter);
+                Ok(results)
+            }
+        }
+    }
+
+    /// Consults the read gate for a non-`GatedRead` search path (sparse, text on
+    /// a non-vector collection, batch, multi-query). Returns the observer scope
+    /// filter to AND into the query, `Ok(None)` to allow unmodified, or an
+    /// `Err` when the read is denied (fail closed).
+    fn authorize(
+        &self,
+        operation: QueryOperationKind,
+        principal: Option<&str>,
+        tenant: Option<&str>,
+    ) -> PyResult<Option<Filter>> {
+        self.db
+            .authorize_read(&self.name, operation, principal, tenant)
+            .map_err(crate::collection_helpers::core_err)
+    }
+}
+
+/// AND-composes a caller filter with an observer scope filter. The result
+/// matches only rows satisfying both, so composing a scope can only narrow.
+fn and_scope(caller: Option<Filter>, scope: Option<Filter>) -> Option<Filter> {
+    match (caller, scope) {
+        (None, None) => None,
+        (Some(c), None) => Some(c),
+        (None, Some(s)) => Some(s),
+        (Some(c), Some(s)) => Some(Filter::new(Condition::And {
+            conditions: vec![c.condition, s.condition],
+        })),
+    }
+}
+
+/// Post-filters search results in place, dropping any row failing the caller
+/// filter or the observer scope filter (either may be absent). A row with no
+/// payload is dropped whenever a filter is active, matching the pre-existing
+/// hybrid-sparse post-filter semantics.
+fn retain_by_filters(
+    results: &mut Vec<SearchResult>,
+    caller: Option<&Filter>,
+    scope: Option<&Filter>,
+) {
+    if caller.is_none() && scope.is_none() {
+        return;
+    }
+    results.retain(|r| {
+        r.point.payload.as_ref().is_some_and(|p| {
+            caller.is_none_or(|f| f.matches(p)) && scope.is_none_or(|f| f.matches(p))
+        })
+    });
+}
+
+/// Refuses a search whose return shape (IDs and scores only, no payload) cannot
+/// carry an observer scope filter. Rather than silently returning unscoped
+/// rows, the read fails closed and the caller is pointed at a filterable entry
+/// point. A `None` scope (plain allow) is a no-op.
+fn deny_if_scoped(scope: Option<Filter>, context: &str) -> PyResult<()> {
+    if scope.is_some() {
+        return Err(pyo3::exceptions::PyPermissionError::new_err(format!(
+            "{context} cannot honor the governance scope filter returned by the observer \
+             (this entry point returns only ids/scores and has no metadata-filtered leaf); \
+             refusing to run unscoped. Use search()/search_request() with the same query instead."
+        )));
+    }
+    Ok(())
 }
 
 #[pymethods]

--- a/crates/velesdb-python/src/collection/mod.rs
+++ b/crates/velesdb-python/src/collection/mod.rs
@@ -292,6 +292,10 @@ impl Collection {
     /// a non-vector collection, batch, multi-query). Returns the observer scope
     /// filter to AND into the query, `Ok(None)` to allow unmodified, or an
     /// `Err` when the read is denied (fail closed).
+    ///
+    /// `principal`/`tenant` are caller-supplied and only meaningful when a
+    /// trusted embedder forwards a verified identity (local-SDK trust boundary):
+    /// the gate authorizes against them but cannot itself authenticate the caller.
     fn authorize(
         &self,
         operation: QueryOperationKind,
@@ -321,7 +325,11 @@ fn and_scope(caller: Option<Filter>, scope: Option<Filter>) -> Option<Filter> {
 /// filter or the observer scope filter (either may be absent). A row with no
 /// payload is dropped whenever a filter is active, matching the pre-existing
 /// hybrid-sparse post-filter semantics.
-fn retain_by_filters(
+///
+/// Exposed `pub(crate)` so leaf-only search paths that take no metadata filter
+/// (sparse, parallel batch, graph embedding search) can apply an observer scope
+/// filter as a post-filter (narrow-only) after the gate authorizes the read.
+pub(crate) fn retain_by_filters(
     results: &mut Vec<SearchResult>,
     caller: Option<&Filter>,
     scope: Option<&Filter>,

--- a/crates/velesdb-python/src/collection/search.rs
+++ b/crates/velesdb-python/src/collection/search.rs
@@ -5,7 +5,9 @@ use std::collections::HashMap;
 use pyo3::exceptions::{PyDeprecationWarning, PyValueError};
 use pyo3::prelude::*;
 use velesdb_core::FusionStrategy as CoreFusionStrategy;
-use velesdb_core::SearchResult;
+use velesdb_core::{GatedRead, QueryOperationKind, SearchResult};
+
+use super::{and_scope, deny_if_scoped, retain_by_filters};
 
 use crate::collection_helpers::{
     core_err, id_score_pairs_to_dicts, parse_filter, parse_optional_filter, parse_sparse_vector,
@@ -56,7 +58,7 @@ impl Collection {
     // v2.0.  New callers should use search_request(SearchOptions) instead
     // (issue #717 v1.15 path).
     #[allow(clippy::too_many_arguments)]
-    #[pyo3(signature = (vector=None, *, sparse_vector=None, top_k=10, filter=None, sparse_index_name=None, include_vectors=false))]
+    #[pyo3(signature = (vector=None, *, sparse_vector=None, top_k=10, filter=None, sparse_index_name=None, include_vectors=false, principal=None, tenant=None))]
     fn search(
         &self,
         py: Python<'_>,
@@ -66,6 +68,8 @@ impl Collection {
         filter: Option<Py<PyAny>>,
         sparse_index_name: Option<String>,
         include_vectors: bool,
+        principal: Option<String>,
+        tenant: Option<String>,
     ) -> PyResult<Vec<Py<PyAny>>> {
         PyErr::warn(
             py,
@@ -84,6 +88,8 @@ impl Collection {
             sparse_index_name,
             include_vectors,
             None,
+            principal,
+            tenant,
         );
         self.search_request(py, &opts)
     }
@@ -123,6 +129,8 @@ impl Collection {
         let sparse_index_name = opts.sparse_index_name.clone();
         let include_vectors = opts.include_vectors;
         let fusion = opts.fusion.as_ref().map(FusionStrategy::inner);
+        let principal = opts.principal.clone();
+        let tenant = opts.tenant.clone();
 
         // Phase 2: Release GIL during Rust computation
         let results = py.detach(|| {
@@ -133,6 +141,8 @@ impl Collection {
                 filter_obj.as_ref(),
                 sparse_index_name.as_deref(),
                 fusion.as_ref(),
+                principal.as_deref(),
+                tenant.as_deref(),
             )
         })?;
 
@@ -141,20 +151,34 @@ impl Collection {
     }
 
     /// Search for similar vectors with custom HNSW ef_search parameter.
-    #[pyo3(signature = (vector, top_k = 10, ef_search = 128))]
+    #[pyo3(signature = (vector, top_k = 10, ef_search = 128, *, principal = None, tenant = None))]
     fn search_with_ef(
         &self,
         py: Python<'_>,
         vector: Py<PyAny>,
         top_k: usize,
         ef_search: usize,
+        principal: Option<String>,
+        tenant: Option<String>,
     ) -> PyResult<Vec<Py<PyAny>>> {
         self.ensure_vector()?;
         let query_vector = extract_vector(py, &vector)?;
 
+        // Routed through the read gate as a dense read carrying the ef override.
         let results = py.detach(|| {
-            self.inner
-                .search_with_ef(&query_vector, top_k, ef_search)
+            self.db
+                .gated_search(
+                    &self.name,
+                    principal.as_deref(),
+                    tenant.as_deref(),
+                    GatedRead::Dense {
+                        query: &query_vector,
+                        k: top_k,
+                        ef: Some(ef_search),
+                        quality: None,
+                        filter: None,
+                    },
+                )
                 .map_err(core_err)
         })?;
 
@@ -169,21 +193,35 @@ impl Collection {
     ///     vector: Dense query vector (list or numpy array).
     ///     quality: Search quality mode string.
     ///     top_k: Number of results (default: 10).
-    #[pyo3(signature = (vector, quality, top_k = 10))]
+    #[pyo3(signature = (vector, quality, top_k = 10, *, principal = None, tenant = None))]
     fn search_with_quality(
         &self,
         py: Python<'_>,
         vector: Py<PyAny>,
         quality: &str,
         top_k: usize,
+        principal: Option<String>,
+        tenant: Option<String>,
     ) -> PyResult<Vec<Py<PyAny>>> {
         self.ensure_vector()?;
         let query_vector = extract_vector(py, &vector)?;
         let sq = parse_search_quality(quality)?;
 
+        // Routed through the read gate as a dense read carrying the quality profile.
         let results = py.detach(|| {
-            self.inner
-                .search_with_quality(&query_vector, top_k, sq)
+            self.db
+                .gated_search(
+                    &self.name,
+                    principal.as_deref(),
+                    tenant.as_deref(),
+                    GatedRead::Dense {
+                        query: &query_vector,
+                        k: top_k,
+                        ef: None,
+                        quality: Some(sq),
+                        filter: None,
+                    },
+                )
                 .map_err(core_err)
         })?;
 
@@ -191,17 +229,28 @@ impl Collection {
     }
 
     /// Search returning only IDs and scores.
-    #[pyo3(signature = (vector, top_k = 10))]
+    #[pyo3(signature = (vector, top_k = 10, *, principal = None, tenant = None))]
     fn search_ids(
         &self,
         py: Python<'_>,
         vector: Py<PyAny>,
         top_k: usize,
+        principal: Option<String>,
+        tenant: Option<String>,
     ) -> PyResult<Vec<Py<PyAny>>> {
         self.ensure_vector()?;
         let query_vector = extract_vector(py, &vector)?;
 
         let results = py.detach(|| {
+            // IDs-only results carry no payload, so an observer scope filter
+            // cannot be applied — fail closed if one is returned (never leak
+            // unscoped ids). Deny propagates as an Err from authorize().
+            let scope = self.authorize(
+                QueryOperationKind::VectorSearch,
+                principal.as_deref(),
+                tenant.as_deref(),
+            )?;
+            deny_if_scoped(scope, "search_ids")?;
             self.inner
                 .search_ids(&query_vector, top_k)
                 .map_err(core_err)
@@ -212,13 +261,15 @@ impl Collection {
     }
 
     /// Search with metadata filtering.
-    #[pyo3(signature = (vector, top_k = 10, filter = None))]
+    #[pyo3(signature = (vector, top_k = 10, filter = None, *, principal = None, tenant = None))]
     fn search_with_filter(
         &self,
         py: Python<'_>,
         vector: Py<PyAny>,
         top_k: usize,
         filter: Option<Py<PyAny>>,
+        principal: Option<String>,
+        tenant: Option<String>,
     ) -> PyResult<Vec<Py<PyAny>>> {
         self.ensure_vector()?;
         let query_vector = extract_vector(py, &vector)?;
@@ -227,9 +278,22 @@ impl Collection {
             .transpose()?
             .ok_or_else(|| PyValueError::new_err("Filter is required for search_with_filter"))?;
 
+        // Routed through the read gate as a dense read; the gate AND-composes any
+        // observer scope filter with this caller filter (narrow-only).
         let results = py.detach(|| {
-            self.inner
-                .search_with_filter(&query_vector, top_k, &filter_obj)
+            self.db
+                .gated_search(
+                    &self.name,
+                    principal.as_deref(),
+                    tenant.as_deref(),
+                    GatedRead::Dense {
+                        query: &query_vector,
+                        k: top_k,
+                        ef: None,
+                        quality: None,
+                        filter: Some(&filter_obj),
+                    },
+                )
                 .map_err(core_err)
         })?;
 
@@ -237,29 +301,41 @@ impl Collection {
     }
 
     /// Full-text search using BM25 ranking.
-    #[pyo3(signature = (query, top_k = 10, filter = None))]
+    #[pyo3(signature = (query, top_k = 10, filter = None, *, principal = None, tenant = None))]
     fn text_search(
         &self,
         py: Python<'_>,
         query: &str,
         top_k: usize,
         filter: Option<Py<PyAny>>,
+        principal: Option<String>,
+        tenant: Option<String>,
     ) -> PyResult<Vec<Py<PyAny>>> {
         // No ensure_vector() here: BM25 text_search operates on the text index
         // and takes no query vector, so it is valid on metadata/graph collections
-        // that carry text fields — unlike the vector-only search paths.
-        let filter_obj = parse_optional_filter(py, filter)?;
+        // that carry text fields — unlike the vector-only search paths. Because
+        // `gated_search` resolves a *vector* collection leaf it cannot serve
+        // metadata/graph text search, so text search consults `authorize_read`
+        // (kind-agnostic) and AND-composes any observer scope filter into the
+        // text-search filter instead — same governance, no leaf mismatch.
+        let caller_filter = parse_optional_filter(py, filter)?;
         let query_owned = query.to_string();
 
         let results = py.detach(|| {
-            if let Some(f) = filter_obj {
-                self.inner
+            let scope = self.authorize(
+                QueryOperationKind::TextSearch,
+                principal.as_deref(),
+                tenant.as_deref(),
+            )?;
+            match and_scope(caller_filter, scope) {
+                Some(f) => self
+                    .inner
                     .text_search_with_filter(&query_owned, top_k, &f)
-                    .map_err(core_err)
-            } else {
-                self.inner
+                    .map_err(core_err),
+                None => self
+                    .inner
                     .text_search(&query_owned, top_k)
-                    .map_err(core_err)
+                    .map_err(core_err),
             }
         })?;
 
@@ -267,7 +343,8 @@ impl Collection {
     }
 
     /// Hybrid search combining vector similarity and text search.
-    #[pyo3(signature = (vector, query, top_k = 10, vector_weight = 0.5, filter = None))]
+    #[allow(clippy::too_many_arguments)] // gate identity kwargs on top of the existing signature
+    #[pyo3(signature = (vector, query, top_k = 10, vector_weight = 0.5, filter = None, *, principal = None, tenant = None))]
     fn hybrid_search(
         &self,
         py: Python<'_>,
@@ -276,26 +353,31 @@ impl Collection {
         top_k: usize,
         vector_weight: f32,
         filter: Option<Py<PyAny>>,
+        principal: Option<String>,
+        tenant: Option<String>,
     ) -> PyResult<Vec<Py<PyAny>>> {
         self.ensure_vector()?;
         let query_vector = extract_vector(py, &vector)?;
         let filter_obj = parse_optional_filter(py, filter)?;
         let query_owned = query.to_string();
 
+        // Routed through the read gate as a hybrid dense+text read; the gate
+        // AND-composes any observer scope filter with this caller filter.
         let results = py.detach(|| {
-            if let Some(f) = filter_obj {
-                self.inner.hybrid_search_with_filter(
-                    &query_vector,
-                    &query_owned,
-                    top_k,
-                    Some(vector_weight),
-                    &f,
+            self.db
+                .gated_search(
+                    &self.name,
+                    principal.as_deref(),
+                    tenant.as_deref(),
+                    GatedRead::Hybrid {
+                        vector: &query_vector,
+                        text: &query_owned,
+                        k: top_k,
+                        alpha: Some(vector_weight),
+                        filter: filter_obj.as_ref(),
+                    },
                 )
-            } else {
-                self.inner
-                    .hybrid_search(&query_vector, &query_owned, top_k, Some(vector_weight))
-            }
-            .map_err(core_err)
+                .map_err(core_err)
         })?;
 
         Ok(search_results_to_dicts(py, results, false))
@@ -309,22 +391,39 @@ impl Collection {
     /// Queries are partitioned by `top_k` so each group searches with the
     /// correct candidate count, avoiding wasted HNSW traversal when queries
     /// request different result sizes (issue #419).
-    #[pyo3(signature = (searches))]
+    #[pyo3(signature = (searches, *, principal = None, tenant = None))]
     fn batch_search(
         &self,
         py: Python<'_>,
         searches: Vec<HashMap<String, Py<PyAny>>>,
+        principal: Option<String>,
+        tenant: Option<String>,
     ) -> PyResult<Vec<Vec<Py<PyAny>>>> {
         self.ensure_vector()?;
-        let parsed = Self::parse_batch_searches(py, &searches)?;
+        let mut parsed = Self::parse_batch_searches(py, &searches)?;
 
-        let results = py.detach(|| self.dispatch_batch_by_top_k(&parsed))?;
+        // Authorize the batch as a whole, then AND any observer scope filter
+        // into every per-query filter so the filtered leaf enforces narrowing.
+        let results = py.detach(move || {
+            let scope = self.authorize(
+                QueryOperationKind::VectorSearch,
+                principal.as_deref(),
+                tenant.as_deref(),
+            )?;
+            if let Some(s) = scope {
+                for p in &mut parsed {
+                    p.filter = and_scope(p.filter.take(), Some(s.clone()));
+                }
+            }
+            self.dispatch_batch_by_top_k(&parsed)
+        })?;
 
         Ok(Self::convert_batch_results(py, results))
     }
 
     /// Multi-query search with result fusion.
-    #[pyo3(signature = (vectors, top_k = 10, fusion = None, filter = None))]
+    #[allow(clippy::too_many_arguments)] // gate identity kwargs on top of the existing signature
+    #[pyo3(signature = (vectors, top_k = 10, fusion = None, filter = None, *, principal = None, tenant = None))]
     fn multi_query_search(
         &self,
         py: Python<'_>,
@@ -332,6 +431,8 @@ impl Collection {
         top_k: usize,
         fusion: Option<FusionStrategy>,
         filter: Option<Py<PyAny>>,
+        principal: Option<String>,
+        tenant: Option<String>,
     ) -> PyResult<Vec<Py<PyAny>>> {
         self.ensure_vector()?;
         let query_vectors: Vec<Vec<f32>> = vectors
@@ -341,10 +442,18 @@ impl Collection {
         let fusion_strategy = fusion.map_or(DEFAULT_FUSION, |f| f.inner());
         let filter_obj = parse_optional_filter(py, filter)?;
 
-        let results = py.detach(|| {
+        // Authorize, then AND any observer scope filter into the caller filter so
+        // the filtered leaf enforces narrowing (deny propagates as Err).
+        let results = py.detach(move || {
+            let scope = self.authorize(
+                QueryOperationKind::VectorSearch,
+                principal.as_deref(),
+                tenant.as_deref(),
+            )?;
+            let effective = and_scope(filter_obj, scope);
             let query_refs: Vec<&[f32]> = query_vectors.iter().map(|v| v.as_slice()).collect();
             self.inner
-                .multi_query_search(&query_refs, top_k, fusion_strategy, filter_obj.as_ref())
+                .multi_query_search(&query_refs, top_k, fusion_strategy, effective.as_ref())
                 .map_err(core_err)
         })?;
 
@@ -363,12 +472,14 @@ impl Collection {
     ///
     /// Returns:
     ///     List of result lists, one per query vector.
-    #[pyo3(signature = (vectors, top_k = 10))]
+    #[pyo3(signature = (vectors, top_k = 10, *, principal = None, tenant = None))]
     fn search_batch_parallel(
         &self,
         py: Python<'_>,
         vectors: Vec<Py<PyAny>>,
         top_k: usize,
+        principal: Option<String>,
+        tenant: Option<String>,
     ) -> PyResult<Vec<Vec<Py<PyAny>>>> {
         self.ensure_vector()?;
         let query_vectors: Vec<Vec<f32>> = vectors
@@ -376,24 +487,40 @@ impl Collection {
             .map(|v| extract_vector(py, v))
             .collect::<PyResult<_>>()?;
 
-        let results = py.detach(|| {
+        // The parallel leaf takes no metadata filter, so an observer scope
+        // filter is applied by post-filtering each result list (narrow-only).
+        let results = py.detach(move || {
+            let scope = self.authorize(
+                QueryOperationKind::VectorSearch,
+                principal.as_deref(),
+                tenant.as_deref(),
+            )?;
             let query_refs: Vec<&[f32]> = query_vectors.iter().map(|v| v.as_slice()).collect();
-            self.inner
+            let mut results = self
+                .inner
                 .search_batch_parallel(&query_refs, top_k)
-                .map_err(core_err)
+                .map_err(core_err)?;
+            if let Some(s) = scope {
+                for group in &mut results {
+                    retain_by_filters(group, None, Some(&s));
+                }
+            }
+            Ok::<_, PyErr>(results)
         })?;
 
         Ok(Self::convert_batch_results(py, results))
     }
 
     /// Multi-query search returning only IDs and fused scores.
-    #[pyo3(signature = (vectors, top_k = 10, fusion = None))]
+    #[pyo3(signature = (vectors, top_k = 10, fusion = None, *, principal = None, tenant = None))]
     fn multi_query_search_ids(
         &self,
         py: Python<'_>,
         vectors: Vec<Py<PyAny>>,
         top_k: usize,
         fusion: Option<FusionStrategy>,
+        principal: Option<String>,
+        tenant: Option<String>,
     ) -> PyResult<Vec<Py<PyAny>>> {
         self.ensure_vector()?;
         let query_vectors: Vec<Vec<f32>> = vectors
@@ -402,7 +529,15 @@ impl Collection {
             .collect::<PyResult<_>>()?;
         let fusion_strategy = fusion.map_or(DEFAULT_FUSION, |f| f.inner());
 
-        let results = py.detach(|| {
+        let results = py.detach(move || {
+            // IDs-only results carry no payload, so an observer scope filter
+            // cannot be applied — fail closed if one is returned.
+            let scope = self.authorize(
+                QueryOperationKind::VectorSearch,
+                principal.as_deref(),
+                tenant.as_deref(),
+            )?;
+            deny_if_scoped(scope, "multi_query_search_ids")?;
             let query_refs: Vec<&[f32]> = query_vectors.iter().map(|v| v.as_slice()).collect();
             self.inner
                 .multi_query_search_ids(&query_refs, top_k, fusion_strategy)

--- a/crates/velesdb-python/src/collection/search_options.rs
+++ b/crates/velesdb-python/src/collection/search_options.rs
@@ -77,6 +77,15 @@ pub struct SearchOptions {
     /// sparse-only searches.
     #[pyo3(get, set)]
     pub fusion: Option<FusionStrategy>,
+    /// Optional principal (caller identity) forwarded to the control-plane read
+    /// gate. When ``None`` (default) and no observer is registered the gate is a
+    /// zero-overhead allow, preserving pre-governance behavior.
+    #[pyo3(get, set)]
+    pub principal: Option<String>,
+    /// Optional tenant hint forwarded to the control-plane read gate alongside
+    /// ``principal`` for multi-tenant scoping. ``None`` by default.
+    #[pyo3(get, set)]
+    pub tenant: Option<String>,
 }
 
 #[pymethods]
@@ -96,7 +105,10 @@ impl SearchOptions {
     ///     include_vectors: Include raw vectors in results (default: False).
     ///     fusion: Optional :py:class:`FusionStrategy` for hybrid dense+sparse
     ///         fusion (default: RRF k=60).
+    ///     principal: Optional caller identity forwarded to the read gate.
+    ///     tenant: Optional tenant hint forwarded to the read gate.
     #[new]
+    #[allow(clippy::too_many_arguments)] // additive governance kwargs on an existing builder
     #[pyo3(signature = (
         vector = None,
         *,
@@ -106,6 +118,8 @@ impl SearchOptions {
         sparse_index_name = None,
         include_vectors = false,
         fusion = None,
+        principal = None,
+        tenant = None,
     ))]
     pub fn new(
         vector: Option<Py<PyAny>>,
@@ -115,6 +129,8 @@ impl SearchOptions {
         sparse_index_name: Option<String>,
         include_vectors: bool,
         fusion: Option<FusionStrategy>,
+        principal: Option<String>,
+        tenant: Option<String>,
     ) -> Self {
         Self {
             vector,
@@ -124,6 +140,8 @@ impl SearchOptions {
             sparse_index_name,
             include_vectors,
             fusion,
+            principal,
+            tenant,
         }
     }
 
@@ -192,6 +210,18 @@ impl SearchOptions {
     /// Pass ``None`` to fall back to the default RRF (k=60).
     pub fn with_fusion(slf: Py<Self>, py: Python<'_>, fusion: Option<FusionStrategy>) -> Py<Self> {
         slf.bind(py).borrow_mut().fusion = fusion;
+        slf
+    }
+
+    /// Sets the read-gate principal (caller identity) and returns `self`.
+    pub fn with_principal(slf: Py<Self>, py: Python<'_>, principal: Option<String>) -> Py<Self> {
+        slf.bind(py).borrow_mut().principal = principal;
+        slf
+    }
+
+    /// Sets the read-gate tenant hint and returns `self`.
+    pub fn with_tenant(slf: Py<Self>, py: Python<'_>, tenant: Option<String>) -> Py<Self> {
+        slf.bind(py).borrow_mut().tenant = tenant;
         slf
     }
 }

--- a/crates/velesdb-python/src/database.rs
+++ b/crates/velesdb-python/src/database.rs
@@ -129,10 +129,19 @@ impl Database {
     ///         return value is ignored and a raised exception is swallowed so
     ///         it never breaks a core operation. For ``"query_request"`` the
     ///         callback governs the read: return ``False`` or a string reason to
-    ///         **deny** it (raising a query error), or ``None``/``True`` to
-    ///         allow. A callback that ignores ``query_request`` (returns
-    ///         ``None``) allows every read, so existing notify-only observers
-    ///         are unaffected.
+    ///         **deny** it (raising a query error), ``None``/``True`` to allow,
+    ///         or a ``dict`` to **allow with a narrowing scope** — recognized
+    ///         keys are ``"filter"`` (a VelesQL WHERE-predicate string such as
+    ///         ``"tenant = 'acme'"``, AND-composed into the read) and
+    ///         ``"tenant"`` (an opaque tenant hint). A malformed ``"filter"``
+    ///         denies (fail closed). ``query_request`` fires for VelesQL
+    ///         ``SELECT``/``MATCH`` and for the Python direct-search API
+    ///         (``search``/``search_request``/``text_search``/``hybrid_search``
+    ///         and their variants), with ``operation`` one of ``"select"``,
+    ///         ``"vector_search"``, ``"text_search"``, ``"hybrid_search"``,
+    ///         ``"graph_traversal"``. A callback that ignores ``query_request``
+    ///         (returns ``None``) allows every read, so existing notify-only
+    ///         observers are unaffected.
     ///
     /// Returns:
     ///     Database instance
@@ -320,7 +329,11 @@ impl Database {
             collection.attach_auto_reindex(manager);
         }
 
-        Ok(Collection::new(collection, name_owned))
+        Ok(Collection::new(
+            collection,
+            Arc::clone(&self.inner),
+            name_owned,
+        ))
     }
 
     /// Get an existing collection by name.
@@ -357,7 +370,12 @@ impl Database {
                 // vector facade only exercises the shared surface for non-Vector
                 // kinds; `Collection::ensure_vector` rejects vector-only ops.
                 let vc = unsafe { any_coll.into_vector_unchecked() };
-                Ok(Some(Collection::new_with_kind(vc, name.to_string(), kind)))
+                Ok(Some(Collection::new_with_kind(
+                    vc,
+                    Arc::clone(&self.inner),
+                    name.to_string(),
+                    kind,
+                )))
             }
             None => Ok(None),
         }
@@ -443,6 +461,7 @@ impl Database {
 
         Ok(Collection::new_with_kind(
             collection,
+            Arc::clone(&self.inner),
             name_owned,
             CollectionKind::Metadata,
         ))

--- a/crates/velesdb-python/src/database.rs
+++ b/crates/velesdb-python/src/database.rs
@@ -130,11 +130,13 @@ impl Database {
     ///         it never breaks a core operation. For ``"query_request"`` the
     ///         callback governs the read: return ``False`` or a string reason to
     ///         **deny** it (raising a query error), ``None``/``True`` to allow,
-    ///         or a ``dict`` to **allow with a narrowing scope** — recognized
-    ///         keys are ``"filter"`` (a VelesQL WHERE-predicate string such as
-    ///         ``"tenant = 'acme'"``, AND-composed into the read) and
-    ///         ``"tenant"`` (an opaque tenant hint). A malformed ``"filter"``
-    ///         denies (fail closed). ``query_request`` fires for VelesQL
+    ///         or a ``dict`` to **allow with a narrowing scope**. The dict MUST
+    ///         carry an enforceable ``"filter"`` (a VelesQL WHERE-predicate
+    ///         string such as ``"tenant = 'acme'"``, AND-composed into the
+    ///         read); ``"tenant"`` is an optional audit hint OSS does not narrow
+    ///         by. A dict with a missing/empty/tenant-only or unparseable
+    ///         ``"filter"`` denies (fail closed), so a ``{"tenant": t}`` return
+    ///         can never masquerade as scoping. ``query_request`` fires for VelesQL
     ///         ``SELECT``/``MATCH`` and for the Python direct-search API
     ///         (``search``/``search_request``/``text_search``/``hybrid_search``
     ///         and their variants), with ``operation`` one of ``"select"``,
@@ -593,7 +595,11 @@ impl Database {
             .get_graph_collection(&name_owned)
             .ok_or_else(|| PyRuntimeError::new_err("Graph collection not found after creation"))?;
 
-        Ok(PyGraphCollection::new(coll, name_owned))
+        Ok(PyGraphCollection::new(
+            coll,
+            Arc::clone(&self.inner),
+            name_owned,
+        ))
     }
 
     /// Execute a VelesQL query string (SELECT, DDL, or DML).
@@ -723,7 +729,7 @@ impl Database {
         Ok(self
             .inner
             .get_graph_collection(name)
-            .map(|c| PyGraphCollection::new(c, name.to_string())))
+            .map(|c| PyGraphCollection::new(c, Arc::clone(&self.inner), name.to_string())))
     }
 
     /// Analyze a collection, computing and persisting statistics.

--- a/crates/velesdb-python/src/graph_collection.rs
+++ b/crates/velesdb-python/src/graph_collection.rs
@@ -6,12 +6,14 @@
 
 use pyo3::prelude::*;
 use std::collections::HashMap;
+use std::sync::Arc;
 
+use crate::collection::retain_by_filters;
 use crate::collection_helpers::{core_err, point_to_dict, search_result_to_dict};
 use crate::graph::{dict_to_edge, edge_to_dict, traversal_to_dict};
 use crate::utils::{extract_vector, json_to_python, python_to_json};
 use velesdb_core::collection::graph::TraversalConfig;
-use velesdb_core::{GraphCollection, GraphSchema};
+use velesdb_core::{Database as CoreDatabase, GraphCollection, GraphSchema, QueryOperationKind};
 
 // ---------------------------------------------------------------------------
 // PyGraphSchema
@@ -103,13 +105,18 @@ impl PyGraphSchema {
 #[pyclass(name = "GraphCollection")]
 pub struct PyGraphCollection {
     pub(crate) inner: GraphCollection,
+    /// Shared handle to the owning database. Like `Collection`, `inner` is a
+    /// detached leaf with no observer reference, so `search_by_embedding` routes
+    /// its vector read through this handle's control-plane gate rather than
+    /// hitting the leaf directly.
+    pub(crate) db: Arc<CoreDatabase>,
     name: String,
 }
 
 impl PyGraphCollection {
     /// Creates a new `PyGraphCollection` wrapper.
-    pub fn new(inner: GraphCollection, name: String) -> Self {
-        Self { inner, name }
+    pub fn new(inner: GraphCollection, db: Arc<CoreDatabase>, name: String) -> Self {
+        Self { inner, db, name }
     }
 }
 
@@ -452,20 +459,45 @@ impl PyGraphCollection {
     ///
     /// Raises:
     ///     RuntimeError: If the collection has no embeddings
-    #[pyo3(signature = (query, k=None))]
+    ///     PermissionError / RuntimeError: If the read gate denies the read.
+    ///
+    /// The `principal` argument is caller-supplied and only meaningful when a
+    /// trusted embedder forwards a verified identity (local-SDK trust boundary):
+    /// the gate cannot itself authenticate the caller.
+    #[pyo3(signature = (query, k=None, *, principal=None, tenant=None))]
     fn search_by_embedding(
         &self,
         py: Python<'_>,
         query: Py<PyAny>,
         k: Option<usize>,
+        principal: Option<String>,
+        tenant: Option<String>,
     ) -> PyResult<Vec<Py<PyAny>>> {
         let vec = extract_vector(py, &query)?;
         let top_k = k.unwrap_or(10);
 
+        // Route the vector read through the control-plane gate. The graph leaf
+        // takes no metadata filter, so authorize first (Deny ⇒ Err, fail closed)
+        // then apply any observer scope filter as a post-filter (narrow-only),
+        // mirroring the sparse / parallel-batch paths on `Collection`.
         let results = py.detach(|| {
-            self.inner
+            let scope = self
+                .db
+                .authorize_read(
+                    &self.name,
+                    QueryOperationKind::VectorSearch,
+                    principal.as_deref(),
+                    tenant.as_deref(),
+                )
+                .map_err(core_err)?;
+            let mut results = self
+                .inner
                 .search_by_embedding(&vec, top_k)
-                .map_err(core_err)
+                .map_err(core_err)?;
+            if let Some(scope_filter) = scope {
+                retain_by_filters(&mut results, None, Some(&scope_filter));
+            }
+            Ok::<_, PyErr>(results)
         })?;
 
         Ok(results

--- a/crates/velesdb-python/src/observer.rs
+++ b/crates/velesdb-python/src/observer.rs
@@ -96,10 +96,11 @@ fn operation_str(op: QueryOperationKind) -> &'static str {
 /// * `False` → [`AccessDecision::Deny`] with a default reason;
 /// * a `str` → `Deny` carrying that string as the human-readable reason;
 /// * a `dict` → [`AccessDecision::AllowWithScope`] — the read is allowed but
-///   *narrowed*. Recognized keys: `"filter"` (a `VelesQL` WHERE predicate string,
-///   e.g. `"tenant = 'acme'"`, AND-composed into the query) and `"tenant"`
-///   (an opaque tenant hint). A malformed `"filter"` **denies** (fail closed)
-///   rather than allowing an unscoped read.
+///   *narrowed*. It MUST carry an enforceable `"filter"` (a `VelesQL` WHERE
+///   predicate string, e.g. `"tenant = 'acme'"`, AND-composed into the query);
+///   `"tenant"` is an optional audit hint OSS does not itself narrow by. A dict
+///   with a missing/empty/tenant-only or unparseable `"filter"` **denies**
+///   (fail closed) rather than allowing an unscoped read.
 fn interpret_decision(ret: &Bound<'_, PyAny>) -> AccessDecision {
     if ret.is_none() {
         return AccessDecision::Allow;
@@ -124,8 +125,15 @@ fn interpret_decision(ret: &Bound<'_, PyAny>) -> AccessDecision {
 }
 
 /// Builds an [`AccessDecision::AllowWithScope`] from a callback-returned dict.
-/// A present-but-invalid `"filter"` fails closed (denies) so a policy typo can
-/// never silently widen access to an unscoped read.
+///
+/// A scope dict **must** yield an enforceable `"filter"` predicate. Because OSS
+/// enforces narrowing only through the `filter` (it forwards `tenant` for audit
+/// but does not itself narrow by it), a dict with no parseable `filter` —
+/// empty (`{}`), `tenant`-only (`{"tenant": …}`), or a `filter` that fails to
+/// parse — is treated as **DENY** (fail closed). Otherwise a policy author who
+/// writes `return {"tenant": t}` believing they scoped the read would instead
+/// receive every tenant's rows. A proper `{"filter": "<predicate>"}` narrows;
+/// bare `True`/`None` stays Allow and `False`/str stays Deny (handled upstream).
 fn interpret_scope(dict: &Bound<'_, PyDict>) -> AccessDecision {
     let tenant = dict
         .get_item("tenant")
@@ -133,23 +141,34 @@ fn interpret_scope(dict: &Bound<'_, PyDict>) -> AccessDecision {
         .flatten()
         .and_then(|v| v.extract::<String>().ok());
 
-    let filter = match dict.get_item("filter") {
+    // An enforceable filter predicate is mandatory — its absence fails closed.
+    let predicate = match dict.get_item("filter") {
         Ok(Some(v)) if !v.is_none() => match v.extract::<String>() {
-            Ok(predicate) => match parse_scope_predicate(&predicate) {
-                Ok(condition) => Some(condition),
-                Err(err) => {
-                    return AccessDecision::Deny(Error::Query(format!(
-                        "invalid observer scope filter: {err}"
-                    )))
-                }
-            },
+            Ok(predicate) => predicate,
             Err(_) => {
                 return AccessDecision::Deny(Error::Query(
                     "observer scope 'filter' must be a VelesQL predicate string".to_string(),
                 ))
             }
         },
-        _ => None,
+        _ => {
+            return AccessDecision::Deny(Error::Query(
+                "observer returned an allow-with-scope dict without an enforceable 'filter' \
+                 predicate; OSS does not narrow by 'tenant' alone, so the read is denied \
+                 (fail closed). Return a {\"filter\": \"<VelesQL predicate>\"} dict to scope, \
+                 or None/True to allow."
+                    .to_string(),
+            ))
+        }
+    };
+
+    let condition = match parse_scope_predicate(&predicate) {
+        Ok(condition) => condition,
+        Err(err) => {
+            return AccessDecision::Deny(Error::Query(format!(
+                "invalid observer scope filter: {err}"
+            )))
+        }
     };
 
     // `AccessScope` is `#[non_exhaustive]`, so struct-literal construction is
@@ -158,7 +177,7 @@ fn interpret_scope(dict: &Bound<'_, PyDict>) -> AccessDecision {
     let scope = {
         let mut scope = AccessScope::default();
         scope.tenant = tenant;
-        scope.filter = filter;
+        scope.filter = Some(condition);
         scope
     };
     AccessDecision::AllowWithScope(scope)

--- a/crates/velesdb-python/src/observer.rs
+++ b/crates/velesdb-python/src/observer.rs
@@ -21,7 +21,8 @@
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 use velesdb_core::collection::CollectionType;
-use velesdb_core::observer::{AccessDecision, QueryAccessContext, QueryOperationKind};
+use velesdb_core::observer::{AccessDecision, AccessScope, QueryAccessContext, QueryOperationKind};
+use velesdb_core::velesql::{Condition, Parser};
 use velesdb_core::{DatabaseObserver, Error};
 
 /// A [`DatabaseObserver`] that forwards lifecycle events to one Python callable.
@@ -93,7 +94,12 @@ fn operation_str(op: QueryOperationKind) -> &'static str {
 ///   — so an existing notify-only callback that ignores the event and returns
 ///   `None` keeps allowing every read (backward compatible);
 /// * `False` → [`AccessDecision::Deny`] with a default reason;
-/// * a `str` → `Deny` carrying that string as the human-readable reason.
+/// * a `str` → `Deny` carrying that string as the human-readable reason;
+/// * a `dict` → [`AccessDecision::AllowWithScope`] — the read is allowed but
+///   *narrowed*. Recognized keys: `"filter"` (a `VelesQL` WHERE predicate string,
+///   e.g. `"tenant = 'acme'"`, AND-composed into the query) and `"tenant"`
+///   (an opaque tenant hint). A malformed `"filter"` **denies** (fail closed)
+///   rather than allowing an unscoped read.
 fn interpret_decision(ret: &Bound<'_, PyAny>) -> AccessDecision {
     if ret.is_none() {
         return AccessDecision::Allow;
@@ -110,7 +116,64 @@ fn interpret_decision(ret: &Bound<'_, PyAny>) -> AccessDecision {
             AccessDecision::Deny(Error::Query("read denied by observer policy".to_string()))
         };
     }
+    // A dict expresses an allow-with-scope narrowing.
+    if let Ok(dict) = ret.cast::<PyDict>() {
+        return interpret_scope(dict);
+    }
     AccessDecision::Allow
+}
+
+/// Builds an [`AccessDecision::AllowWithScope`] from a callback-returned dict.
+/// A present-but-invalid `"filter"` fails closed (denies) so a policy typo can
+/// never silently widen access to an unscoped read.
+fn interpret_scope(dict: &Bound<'_, PyDict>) -> AccessDecision {
+    let tenant = dict
+        .get_item("tenant")
+        .ok()
+        .flatten()
+        .and_then(|v| v.extract::<String>().ok());
+
+    let filter = match dict.get_item("filter") {
+        Ok(Some(v)) if !v.is_none() => match v.extract::<String>() {
+            Ok(predicate) => match parse_scope_predicate(&predicate) {
+                Ok(condition) => Some(condition),
+                Err(err) => {
+                    return AccessDecision::Deny(Error::Query(format!(
+                        "invalid observer scope filter: {err}"
+                    )))
+                }
+            },
+            Err(_) => {
+                return AccessDecision::Deny(Error::Query(
+                    "observer scope 'filter' must be a VelesQL predicate string".to_string(),
+                ))
+            }
+        },
+        _ => None,
+    };
+
+    // `AccessScope` is `#[non_exhaustive]`, so struct-literal construction is
+    // not available to this crate — build via `Default` then assign fields.
+    #[allow(clippy::field_reassign_with_default)]
+    let scope = {
+        let mut scope = AccessScope::default();
+        scope.tenant = tenant;
+        scope.filter = filter;
+        scope
+    };
+    AccessDecision::AllowWithScope(scope)
+}
+
+/// Parses a bare `VelesQL` WHERE predicate (e.g. `"tenant = 'acme'"`) into a
+/// [`Condition`] by wrapping it in a throwaway `SELECT` and reusing the real
+/// parser — no parallel filter grammar is introduced.
+fn parse_scope_predicate(predicate: &str) -> Result<Condition, String> {
+    let sql = format!("SELECT * FROM _scope WHERE {predicate}");
+    let query = Parser::parse(&sql).map_err(|e| e.message)?;
+    query
+        .select
+        .where_clause
+        .ok_or_else(|| "scope predicate produced no WHERE condition".to_string())
 }
 
 impl DatabaseObserver for PyObserver {
@@ -162,11 +225,13 @@ impl DatabaseObserver for PyObserver {
     /// Read-path veto. Invokes the callback as
     /// `callback("query_request", collection=…, operation=…, principal=…, tenant=…)`
     /// and maps its return value through [`interpret_decision`]: `None`/`True`
-    /// allow, `False`/str deny. A callback that raises, or a field-population
-    /// failure, allows the read (fail-open on error so a bug in user policy code
-    /// never breaks a query — only an explicit refusal denies). Fires on every
-    /// gated read (VelesQL `SELECT`/`MATCH`) so an SDK embedder can enforce
-    /// governance, closing the "notify-only" gap (CORE-5).
+    /// allow, `False`/str deny, `dict` allow-with-scope (a `"filter"` VelesQL
+    /// predicate string and/or `"tenant"` hint narrowing the read). A callback
+    /// that raises, or a field-population failure, allows the read (fail-open on
+    /// error so a bug in user policy code never breaks a query — only an explicit
+    /// refusal denies). Fires on every gated read: VelesQL `SELECT`/`MATCH` and,
+    /// via the Python SDK's direct-search gate, `vector_search` / `text_search` /
+    /// `hybrid_search` (closing the "notify-only" gap, CORE-5).
     fn on_query_request(&self, ctx: &QueryAccessContext) -> velesdb_core::Result<AccessDecision> {
         let decision = Python::attach(|py| {
             let fields = PyDict::new(py);

--- a/crates/velesdb-python/tests/test_search_gate.py
+++ b/crates/velesdb-python/tests/test_search_gate.py
@@ -1,0 +1,271 @@
+"""Tests for the OSS direct-search governance gate.
+
+The Python SDK's direct-search API (``Collection.search`` /
+``search_request`` / ``text_search`` / ``hybrid_search`` and their variants)
+routes every read through the control-plane read gate (the same
+``query_request`` observer hook that VelesQL ``SELECT``/``MATCH`` use). This
+module proves three properties for those paths:
+
+* **Deny fails closed** — an observer that vetoes ``query_request`` makes the
+  matching search raise, so no results leak (mirrors the core
+  ``test_gated_search_deny_fails_closed_with_zero_results``). Before the gate
+  the Python ``.search()`` bypassed the observer entirely, so a deny had no
+  effect — these tests are the regression guard.
+* **Scope narrows** — an observer returning a scope ``dict`` narrows results
+  versus the ungated run.
+* **Backward compatible** — with no observer, results are unchanged and the
+  ``.search()`` deprecation warning still fires (zero-overhead allow).
+"""
+
+import shutil
+import tempfile
+import warnings
+
+import pytest
+
+try:
+    from velesdb import Database, SearchOptions
+
+    VELESDB_AVAILABLE = True
+except (ImportError, AttributeError):
+    VELESDB_AVAILABLE = False
+    Database = None  # type: ignore[assignment,misc]
+    SearchOptions = None  # type: ignore[assignment,misc]
+
+pytestmark = pytest.mark.skipif(
+    not VELESDB_AVAILABLE,
+    reason="VelesDB Python bindings not installed. Run: maturin develop",
+)
+
+DIM = 4
+QUERY = [1.0, 0.0, 0.0, 0.0]
+
+# Search operations emitted by the direct-search gate (per GatedRead variant).
+READ_OPS = {"vector_search", "text_search", "hybrid_search"}
+
+
+def _deny_reads(event, **fields):
+    """Veto every gated *read*; allow lifecycle/notify events through."""
+    if event == "query_request":
+        return False
+    return None
+
+
+def _scope_to_acme(event, **fields):
+    """Allow reads but narrow them to ``tenant == 'acme'``."""
+    if event == "query_request":
+        return {"filter": "tenant = 'acme'"}
+    return None
+
+
+class _Db:
+    """Context-managed temp database, optionally with an observer."""
+
+    def __init__(self, observer=None):
+        self.observer = observer
+
+    def __enter__(self):
+        self.dir = tempfile.mkdtemp()
+        self.db = Database(self.dir, observer=self.observer)
+        return self.db
+
+    def __exit__(self, *exc):
+        shutil.rmtree(self.dir, ignore_errors=True)
+
+
+def _seed(db, name="docs"):
+    """Create ``name`` and upsert two tenant-tagged, text-bearing points."""
+    collection = db.create_collection(name, dimension=DIM)
+    collection.upsert(
+        [
+            {
+                "id": 1,
+                "vector": [1.0, 0.0, 0.0, 0.0],
+                "payload": {"tenant": "acme", "text": "alpha machine learning"},
+            },
+            {
+                "id": 2,
+                "vector": [0.9, 0.1, 0.0, 0.0],
+                "payload": {"tenant": "other", "text": "beta machine learning"},
+            },
+        ]
+    )
+    return collection
+
+
+def _ids(results):
+    return {r["id"] for r in results}
+
+
+# ---------------------------------------------------------------------------
+# Deny fails closed (mirrors core test_gated_search_deny_fails_closed_*).
+# ---------------------------------------------------------------------------
+
+
+def test_search_deny_fails_closed():
+    with _Db(observer=_deny_reads) as db:
+        collection = _seed(db)
+        with pytest.raises(Exception):
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", DeprecationWarning)
+                collection.search(QUERY, top_k=2)
+
+
+def test_search_request_deny_fails_closed():
+    with _Db(observer=_deny_reads) as db:
+        collection = _seed(db)
+        with pytest.raises(Exception):
+            collection.search_request(SearchOptions(vector=QUERY, top_k=2))
+
+
+def test_text_search_deny_fails_closed():
+    with _Db(observer=_deny_reads) as db:
+        collection = _seed(db)
+        with pytest.raises(Exception):
+            collection.text_search("learning", top_k=2)
+
+
+def test_hybrid_search_deny_fails_closed():
+    with _Db(observer=_deny_reads) as db:
+        collection = _seed(db)
+        with pytest.raises(Exception):
+            collection.hybrid_search(QUERY, "learning", top_k=2)
+
+
+def test_batch_search_deny_fails_closed():
+    """A non-GatedRead path (batch) is gated via authorize_read → deny raises."""
+    with _Db(observer=_deny_reads) as db:
+        collection = _seed(db)
+        with pytest.raises(Exception):
+            collection.batch_search([{"vector": QUERY, "top_k": 2}])
+
+
+def test_search_ids_deny_fails_closed():
+    with _Db(observer=_deny_reads) as db:
+        collection = _seed(db)
+        with pytest.raises(Exception):
+            collection.search_ids(QUERY, top_k=2)
+
+
+# ---------------------------------------------------------------------------
+# Scope narrows results versus the ungated run.
+# ---------------------------------------------------------------------------
+
+
+def test_search_scope_narrows_results():
+    # Ungated: both points are returned.
+    with _Db() as db:
+        collection = _seed(db)
+        ungated = collection.search_request(SearchOptions(vector=QUERY, top_k=10))
+    assert _ids(ungated) == {1, 2}
+
+    # Scoped to tenant == 'acme': only point 1 survives.
+    with _Db(observer=_scope_to_acme) as db:
+        collection = _seed(db)
+        scoped = collection.search_request(SearchOptions(vector=QUERY, top_k=10))
+    assert _ids(scoped) == {1}
+
+
+def test_search_with_filter_scope_narrows_results():
+    with _Db(observer=_scope_to_acme) as db:
+        collection = _seed(db)
+        # Caller filter is AND-composed with the observer scope; both allow id 1.
+        scoped = collection.search_with_filter(
+            QUERY,
+            top_k=10,
+            filter={"condition": {"type": "eq", "field": "tenant", "value": "acme"}},
+        )
+    assert _ids(scoped) == {1}
+
+
+def test_text_search_scope_narrows_results():
+    with _Db() as db:
+        collection = _seed(db)
+        ungated = collection.text_search("learning", top_k=10)
+    assert _ids(ungated) == {1, 2}
+
+    with _Db(observer=_scope_to_acme) as db:
+        collection = _seed(db)
+        scoped = collection.text_search("learning", top_k=10)
+    assert _ids(scoped) == {1}
+
+
+def test_batch_search_scope_narrows_results():
+    with _Db(observer=_scope_to_acme) as db:
+        collection = _seed(db)
+        scoped = collection.batch_search([{"vector": QUERY, "top_k": 10}])
+    assert len(scoped) == 1
+    assert _ids(scoped[0]) == {1}
+
+
+def test_search_ids_scope_fails_closed():
+    """IDs-only results carry no payload, so a scope filter cannot be applied:
+    the read must fail closed rather than return unscoped ids."""
+    with _Db(observer=_scope_to_acme) as db:
+        collection = _seed(db)
+        with pytest.raises(Exception):
+            collection.search_ids(QUERY, top_k=10)
+
+
+def test_malformed_scope_filter_denies():
+    """A scope dict whose VelesQL predicate does not parse fails closed."""
+
+    def bad_scope(event, **fields):
+        if event == "query_request":
+            return {"filter": "this is not valid velesql !!!"}
+        return None
+
+    with _Db(observer=bad_scope) as db:
+        collection = _seed(db)
+        with pytest.raises(Exception):
+            collection.search_request(SearchOptions(vector=QUERY, top_k=10))
+
+
+# ---------------------------------------------------------------------------
+# Backward compatibility: no observer ⇒ unchanged results + deprecation warning.
+# ---------------------------------------------------------------------------
+
+
+def test_no_observer_returns_all_results():
+    with _Db() as db:
+        collection = _seed(db)
+        results = collection.search_request(SearchOptions(vector=QUERY, top_k=10))
+    assert _ids(results) == {1, 2}
+    # Nearest neighbour to QUERY is point 1 (exact match).
+    assert results[0]["id"] == 1
+
+
+def test_deprecated_search_still_warns_and_works():
+    with _Db() as db:
+        collection = _seed(db)
+        with pytest.warns(DeprecationWarning):
+            results = collection.search(QUERY, top_k=10)
+    assert _ids(results) == {1, 2}
+
+
+def test_allow_observer_permits_read():
+    def notify_only(event, **fields):
+        return None
+
+    with _Db(observer=notify_only) as db:
+        collection = _seed(db)
+        results = collection.search_request(SearchOptions(vector=QUERY, top_k=10))
+    assert _ids(results) == {1, 2}
+
+
+def test_query_request_fields_carry_search_operation():
+    """The veto callback sees the correct operation label per search kind."""
+    seen = []
+
+    def observe(event, **fields):
+        if event == "query_request":
+            seen.append(fields["operation"])
+        return None
+
+    with _Db(observer=observe) as db:
+        collection = _seed(db)
+        collection.search_request(SearchOptions(vector=QUERY, top_k=2))
+        collection.text_search("learning", top_k=2)
+        collection.hybrid_search(QUERY, "learning", top_k=2)
+
+    assert READ_OPS.issubset(set(seen))

--- a/crates/velesdb-python/tests/test_search_gate.py
+++ b/crates/velesdb-python/tests/test_search_gate.py
@@ -222,6 +222,147 @@ def test_malformed_scope_filter_denies():
 
 
 # ---------------------------------------------------------------------------
+# Fail closed on a scope dict that carries no enforceable filter. A dict MUST
+# yield a real predicate; OSS does not narrow by "tenant" alone, so an
+# empty/tenant-only dict must NOT masquerade as scoping.
+# ---------------------------------------------------------------------------
+
+
+def test_empty_scope_dict_denies():
+    """An empty ``{}`` scope dict fails closed, not allow-unscoped."""
+
+    def empty_scope(event, **fields):
+        if event == "query_request":
+            return {}
+        return None
+
+    with _Db(observer=empty_scope) as db:
+        collection = _seed(db)
+        with pytest.raises(Exception):
+            collection.search_request(SearchOptions(vector=QUERY, top_k=10))
+
+
+def test_tenant_only_scope_dict_denies():
+    """A ``{"tenant": ...}``-only dict fails closed (OSS ignores tenant)."""
+
+    def tenant_only(event, **fields):
+        if event == "query_request":
+            return {"tenant": "acme"}
+        return None
+
+    with _Db(observer=tenant_only) as db:
+        collection = _seed(db)
+        with pytest.raises(Exception):
+            collection.search_request(SearchOptions(vector=QUERY, top_k=10))
+
+
+def test_tenant_plus_filter_scope_narrows():
+    """A dict with both tenant hint and a real filter still narrows correctly."""
+
+    def scoped(event, **fields):
+        if event == "query_request":
+            return {"tenant": "acme", "filter": "tenant = 'acme'"}
+        return None
+
+    with _Db(observer=scoped) as db:
+        collection = _seed(db)
+        results = collection.search_request(SearchOptions(vector=QUERY, top_k=10))
+    assert _ids(results) == {1}
+
+
+# ---------------------------------------------------------------------------
+# Additional non-GatedRead coverage: sparse deny, and dense-backed parallel /
+# multi-query deny + scope (multi_query_search_ids fails closed on scope).
+# ---------------------------------------------------------------------------
+
+
+def test_sparse_search_deny_fails_closed():
+    with _Db(observer=_deny_reads) as db:
+        collection = _seed(db)
+        with pytest.raises(Exception):
+            collection.search_request(
+                SearchOptions(sparse_vector={0: 1.0}, top_k=2)
+            )
+
+
+def test_search_batch_parallel_deny_fails_closed():
+    with _Db(observer=_deny_reads) as db:
+        collection = _seed(db)
+        with pytest.raises(Exception):
+            collection.search_batch_parallel([QUERY], top_k=2)
+
+
+def test_search_batch_parallel_scope_narrows():
+    with _Db(observer=_scope_to_acme) as db:
+        collection = _seed(db)
+        scoped = collection.search_batch_parallel([QUERY], top_k=10)
+    assert len(scoped) == 1
+    assert _ids(scoped[0]) == {1}
+
+
+def test_multi_query_search_deny_fails_closed():
+    with _Db(observer=_deny_reads) as db:
+        collection = _seed(db)
+        with pytest.raises(Exception):
+            collection.multi_query_search([QUERY], top_k=2)
+
+
+def test_multi_query_search_scope_narrows():
+    with _Db(observer=_scope_to_acme) as db:
+        collection = _seed(db)
+        scoped = collection.multi_query_search([QUERY], top_k=10)
+    assert _ids(scoped) == {1}
+
+
+def test_multi_query_search_ids_deny_fails_closed():
+    with _Db(observer=_deny_reads) as db:
+        collection = _seed(db)
+        with pytest.raises(Exception):
+            collection.multi_query_search_ids([QUERY], top_k=2)
+
+
+def test_multi_query_search_ids_scope_fails_closed():
+    """IDs-only fused results carry no payload → scope fails closed."""
+    with _Db(observer=_scope_to_acme) as db:
+        collection = _seed(db)
+        with pytest.raises(Exception):
+            collection.multi_query_search_ids([QUERY], top_k=10)
+
+
+# ---------------------------------------------------------------------------
+# Graph collection: PyGraphCollection.search_by_embedding is now gated too.
+# ---------------------------------------------------------------------------
+
+
+def _seed_graph(db, name="kg"):
+    graph = db.create_graph_collection(name, dimension=DIM)
+    graph.upsert_node(1, {"tenant": "acme"}, [1.0, 0.0, 0.0, 0.0])
+    graph.upsert_node(2, {"tenant": "other"}, [0.9, 0.1, 0.0, 0.0])
+    return graph
+
+
+def test_graph_search_by_embedding_no_observer_unchanged():
+    with _Db() as db:
+        graph = _seed_graph(db)
+        results = graph.search_by_embedding(QUERY, 10)
+    assert _ids(results) == {1, 2}
+
+
+def test_graph_search_by_embedding_deny_fails_closed():
+    with _Db(observer=_deny_reads) as db:
+        graph = _seed_graph(db)
+        with pytest.raises(Exception):
+            graph.search_by_embedding(QUERY, 10)
+
+
+def test_graph_search_by_embedding_scope_narrows():
+    with _Db(observer=_scope_to_acme) as db:
+        graph = _seed_graph(db)
+        scoped = graph.search_by_embedding(QUERY, 10)
+    assert _ids(scoped) == {1}
+
+
+# ---------------------------------------------------------------------------
 # Backward compatibility: no observer ⇒ unchanged results + deprecation warning.
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

The Python SDK's direct-search API bypassed the merged control-plane read gate.
`PyCollection` wrapped a **detached** `VectorCollection` leaf with no observer
reference, so the `query_request` veto that VelesQL `SELECT`/`MATCH` already
honor never fired for `Collection.search()` and friends. This PR routes every
Python direct-search read back through the owning database's gate
(`Database::gated_search` / `Database::authorize_read`) **without duplicating
gate logic** (approach "b").

## What changed

- **`Collection` holds `Arc<CoreDatabase>`** (`collection/mod.rs`), threaded
  through `new` / `new_with_kind` and all three construction sites in
  `database.rs`.
- **GatedRead paths → `gated_search`**: dense (`search_request` dense +
  `search_with_ef` + `search_with_quality` + `search_with_filter`) and hybrid
  dense+text (`hybrid_search`).
- **authorize_read paths** (no `GatedRead` leaf): `text_search`
  (kind-agnostic, keeps working on metadata/graph text indexes), sparse /
  hybrid-sparse (`search_request`), `batch_search`, `multi_query_search`,
  `search_batch_parallel`. The observer scope filter is AND-composed into the
  query (pre-filter where the leaf supports it, post-filter otherwise).
- **IDs-only paths fail closed**: `search_ids` / `multi_query_search_ids` carry
  no payload to narrow, so a returned scope filter refuses the read
  (`PermissionError`) rather than leaking unscoped ids.
- **principal/tenant plumbing**: optional kwargs on every search entry plus
  `SearchOptions.principal` / `.tenant` fields + builders. Both `None` + no
  observer = zero-overhead allow (backward compatible).
- **Observer scope emission**: `query_request` may now return a `dict`
  (`{"filter": <VelesQL predicate>, "tenant": <hint>}`) → allow-with-scope; a
  malformed filter fails closed. Previously Python observers could only
  Allow/Deny, leaving the scope path unreachable from Python.

## Tests

`tests/test_search_gate.py` — 16 new tests: deny-fails-closed (search,
search_request, text_search, hybrid_search, batch_search, search_ids), scope
narrowing (dense, search_with_filter, text_search, batch), IDs-only
fail-closed, malformed-scope deny, and no-observer backward compat +
deprecation warning. Full suite: **457 passed** (441 baseline + 16).

`cargo fmt --all --check` clean; `cargo clippy -p velesdb-python --all-targets
-- -D warnings -D clippy::pedantic` clean.

## Residual gaps (explicit)

- `PyGraphCollection.search_by_embedding` (graph API, separate class) still
  hits its leaf directly and is **not** gated — out of scope for this PR
  (which targets `PyCollection`); flagged for a follow-up.
- Rust `#[cfg(test)]` unit tests in this crate cannot run under `cargo test`
  (pyo3 `extension-module` + `cdylib` cannot link a standalone test binary; CI
  excludes `velesdb-python` from cargo test). Behavior is verified via pytest.

## Post-review fixes (commit 21ffc16)

- **Graph embedding search now gated**: `PyGraphCollection` holds
  `Arc<CoreDatabase>`; `search_by_embedding` routes through `authorize_read`
  (deny → Err, scope → `retain_by_filters` post-filter) + principal/tenant
  kwargs. The earlier residual bypass is closed.
- **Filterless scope dict now fails closed**: an empty `{}` or tenant-only
  `{"tenant": t}` observer return previously became an unscoped allow; it now
  DENIES (OSS narrows only via `filter`; `tenant` is an audit hint). Proper
  `{"filter": "<predicate>"}` still narrows.

Both the graph path and the empty/tenant-only-dict path now fail closed.
Test count: 29 in `test_search_gate.py`; full suite 470 passed.
