### PR TITLE
fix(python): complete SAFETY template on into_vector_unchecked (F-3.2)

### DIFF
--- a/crates/velesdb-python/src/database.rs
+++ b/crates/velesdb-python/src/database.rs
@@ -368,9 +368,15 @@ impl Database {
                     CollectionKind::Vector
                 };
                 // SAFETY: `any_coll` came from `get_any_collection` (Some), so the
-                // underlying `AnyCollection` is registered and valid. The coerced
-                // vector facade only exercises the shared surface for non-Vector
-                // kinds; `Collection::ensure_vector` rejects vector-only ops.
+                // underlying `AnyCollection` is registered and valid.
+                // - any_coll is a valid, registered handle returned by
+                //   `get_any_collection`; it is never a disconnected copy.
+                // - The coerced vector facade only exercises the shared surface
+                //   for non-Vector kinds; `kind` is captured above and
+                //   `Collection::ensure_vector` rejects vector-only ops on
+                //   graph/metadata collections (fails loud, not UB).
+                // Reason: single-Collection Python ergonomic facade (mirrors the
+                // conforming block in `create_metadata_collection` below).
                 let vc = unsafe { any_coll.into_vector_unchecked() };
                 Ok(Some(Collection::new_with_kind(
                     vc,


### PR DESCRIPTION
## What

Completes the `// SAFETY:` template on the `unsafe { any_coll.into_vector_unchecked() }` block in `crates/velesdb-python/src/database.rs` (`get_collection`). It carried a prose comment but lacked the canonical `// - condition` bullets and a `// Reason:` line.

## Why

`scripts/verify_unsafe_safety_template.py --strict` flagged this as the **single Gate-4 violation across all 669 production Rust files** in the workspace (audit finding **F-3.2**, Haute). The sibling block in `create_metadata_collection` (added in 3.10.0) already uses the complete template; this brings the older call-site in line.

## Change

Comment-only. No behavior change.

## Verification

- `python3 scripts/verify_unsafe_safety_template.py --files crates/velesdb-python/src/database.rs --strict` → PASSED
- Full-workspace re-challenge (`find crates -path '*/src/*.rs' … | xargs verify_unsafe_safety_template.py`) → **0 violations** across all batches.

Audit ref: F-3.2. Part of the audit-resolution program (`velesdb-audit-report-61b5e8`).
