### PR TITLE
ci(quality): close scan-coverage gaps in prod-unwrap & SAFETY gates (F-3.10/11/12)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,19 +128,24 @@ jobs:
             BASE_SHA="$(git rev-list --max-parents=0 HEAD)"
           fi
 
-          mapfile -t CORE_RS_FILES < <(
+          # F-3.12: validate SAFETY templates in EVERY production crate, not
+          # just velesdb-core. Bindings (velesdb-python, velesdb-wasm,
+          # velesdb-mobile, tauri-plugin-velesdb) contain unsafe blocks too and
+          # were previously unchecked, which let one incomplete template slip
+          # through (F-3.2).
+          mapfile -t PROD_RS_FILES < <(
             git diff --name-only "$BASE_SHA" "${{ github.sha }}" \
               | grep '\.rs$' \
-              | grep '^crates/velesdb-core/src/' \
+              | grep -E '^crates/[^/]+/src/' \
               | grep -v '/tests/' \
               | grep -v '/benches/' \
               | grep -Ev '_tests?\.rs$'
           )
-          if [[ ${#CORE_RS_FILES[@]} -eq 0 ]]; then
+          if [[ ${#PROD_RS_FILES[@]} -eq 0 ]]; then
             echo "No changed production Rust files to validate."
             exit 0
           fi
-          python3 scripts/verify_unsafe_safety_template.py --files "${CORE_RS_FILES[@]}" --strict
+          python3 scripts/verify_unsafe_safety_template.py --files "${PROD_RS_FILES[@]}" --strict
 
       - name: Check TODO/FIXME/HACK governance (production code)
         run: |
@@ -172,6 +177,9 @@ jobs:
 
       - name: Test feature-claims audit script
         run: python3 -m unittest scripts.tests.test_check_feature_claims
+
+      - name: Test prod-unwraps audit script
+        run: python3 -m unittest scripts.tests.test_check_prod_unwraps
 
       - name: Audit feature claims vs exports
         run: python3 scripts/check-feature-claims.py

--- a/QUALITY_BAR.md
+++ b/QUALITY_BAR.md
@@ -102,6 +102,7 @@ These are **not the same number** as the canonical 450 µs. The README explicitl
 **Enforcement:**
 
 - **CI script:** `scripts/check_prod_unwraps.py` — runs on every push, blocks merge if non-zero.
+- **Crate coverage:** every production crate's `src/` — `velesdb-core`, `velesdb-server`, `velesdb-cli`, `velesdb-migrate`, `velesdb-mobile`, `velesdb-wasm`, `tauri-plugin-velesdb`, `velesdb-memory`, `velesdb-node`, `velesdb-python` (the last three were added per audit F-3.10). The scan set lives in `SCAN_DIRS`; add any new production crate there. Test modules gated by `#[cfg(test)]` **and** composite forms like `#[cfg(all(test, feature = "..."))]` are excluded (audit F-3.11).
 - **Status:** **PASSED** — re-verified per push; the script exits 0 on the current workspace.
 
 **Approved alternatives** (in order of preference):
@@ -126,6 +127,7 @@ These are **not the same number** as the canonical 450 µs. The README explicitl
 **Enforcement:**
 
 - **CI script:** `scripts/verify_unsafe_safety_template.py` — runs on every push, blocks merge if any `unsafe { … }` / `unsafe impl …` site is not preceded by a `// SAFETY:` comment.
+- **Crate coverage:** the CI `Verify SAFETY template` job validates changed production `.rs` files under **any** `crates/*/src/` — core and every binding (`velesdb-python`, `velesdb-wasm`, `velesdb-mobile`, `tauri-plugin-velesdb`, …). It was previously scoped to `velesdb-core` only, which let one incomplete template in `velesdb-python` slip past CI (audit F-3.12 / F-3.2).
 - **Coverage:** every unsafe site in the workspace is annotated; live counts (unsafe sites and `// SAFETY:` comments) are reported by the script in CI logs and tracked release-over-release in `CHANGELOG.md`.
 - **Audit trail:** [`docs/SOUNDNESS.md`](docs/SOUNDNESS.md) documents invariants for every unsafe pattern in the codebase.
 

--- a/scripts/check_prod_unwraps.py
+++ b/scripts/check_prod_unwraps.py
@@ -24,7 +24,35 @@ SCAN_DIRS = [
     Path("crates/velesdb-mobile/src"),
     Path("crates/velesdb-wasm/src"),
     Path("crates/tauri-plugin-velesdb/src"),
+    # Bindings/adapters were previously outside the gate (audit F-3.10): they
+    # ship production Rust too, so scan them as well. velesdb-node forbids
+    # unwrap/expect via its [lints] table, but scanning here makes the gate
+    # explicit and uniform across every production crate.
+    Path("crates/velesdb-memory/src"),
+    Path("crates/velesdb-node/src"),
+    Path("crates/velesdb-python/src"),
 ]
+
+
+def is_cfg_test_gate(stripped: str) -> bool:
+    """True if a line is a `#[cfg(...)]` attribute that gates a test module.
+
+    Recognises the bare `#[cfg(test)]` form *and* the composite forms the
+    codebase actually uses to gate test modules behind a feature, e.g.
+    `#[cfg(all(test, feature = "persistence"))]` or `#[cfg(any(test, ...))]`
+    (audit F-3.11 — the old exact-string match let those fall through and
+    flagged `.expect()` inside test modules as false positives).
+
+    Quoted strings are stripped first so `#[cfg(feature = "test-utils")]`
+    does not match, and `not(test)` is excluded so we never stop scanning at
+    an attribute that gates *production* (non-test) code.
+    """
+    if not stripped.startswith("#[cfg("):
+        return False
+    without_strings = re.sub(r'"[^"]*"', "", stripped)
+    if "not(" in without_strings:
+        return False
+    return re.search(r"\btest\b", without_strings) is not None
 
 
 def is_production_file(path: Path) -> bool:
@@ -52,8 +80,11 @@ def scan_file(path: Path) -> list[tuple[int, str]]:
     for line_no, line in enumerate(lines, start=1):
         stripped = line.strip()
 
-        # Stop scanning after #[cfg(test)] module
-        if stripped == "#[cfg(test)]":
+        # Stop scanning once we reach a test module gate (bare #[cfg(test)] or
+        # a composite like #[cfg(all(test, feature = "..."))]). Test modules
+        # live at the end of a file by convention, so everything after is test
+        # code.
+        if is_cfg_test_gate(stripped):
             break
 
         # Track block comments

--- a/scripts/tests/test_check_prod_unwraps.py
+++ b/scripts/tests/test_check_prod_unwraps.py
@@ -1,0 +1,126 @@
+"""Tests for scripts/check_prod_unwraps.py.
+
+Pins two audit contracts:
+
+* F-3.10 — every production crate's `src/` is in the scan set (bindings and
+  adapters were historically excluded, leaving an unwrap/expect blind spot).
+* F-3.11 — a test module gated by a composite attribute such as
+  `#[cfg(all(test, feature = "persistence"))]` must be recognised as a test
+  gate. The old exact-string match only handled bare `#[cfg(test)]`, so
+  `.expect()` calls inside those gated test modules were reported as false
+  positives (e.g. velesdb-memory/src/reinforce.rs).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+
+SCRIPT_PATH = Path(__file__).resolve().parent.parent / "check_prod_unwraps.py"
+
+
+def _load_script() -> types.ModuleType:
+    spec = importlib.util.spec_from_file_location("check_prod_unwraps", SCRIPT_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load {SCRIPT_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["check_prod_unwraps"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+cpu = _load_script()
+
+
+class TestCfgTestGate(unittest.TestCase):
+    def test_bare_cfg_test_is_a_gate(self) -> None:
+        self.assertTrue(cpu.is_cfg_test_gate("#[cfg(test)]"))
+
+    def test_composite_all_test_feature_is_a_gate(self) -> None:
+        # The exact form used in velesdb-memory/src/reinforce.rs (F-3.11).
+        self.assertTrue(
+            cpu.is_cfg_test_gate('#[cfg(all(test, feature = "persistence"))]')
+        )
+
+    def test_any_test_is_a_gate(self) -> None:
+        self.assertTrue(cpu.is_cfg_test_gate('#[cfg(any(test, feature = "x"))]'))
+
+    def test_test_not_first_is_a_gate(self) -> None:
+        self.assertTrue(
+            cpu.is_cfg_test_gate('#[cfg(all(feature = "persistence", test))]')
+        )
+
+    def test_feature_named_test_something_is_not_a_gate(self) -> None:
+        # `test` inside a quoted feature name must not trip the matcher.
+        self.assertFalse(cpu.is_cfg_test_gate('#[cfg(feature = "test-utils")]'))
+
+    def test_not_test_is_not_a_gate(self) -> None:
+        # #[cfg(not(test))] gates *production* code — never stop scanning here.
+        self.assertFalse(cpu.is_cfg_test_gate("#[cfg(not(test))]"))
+
+    def test_plain_feature_is_not_a_gate(self) -> None:
+        self.assertFalse(cpu.is_cfg_test_gate('#[cfg(feature = "persistence")]'))
+
+
+class TestScanFileStopsAtCompositeTestGate(unittest.TestCase):
+    def test_expect_inside_composite_gated_test_module_is_ignored(self) -> None:
+        content = (
+            "pub fn prod() -> u32 {\n"
+            "    compute()\n"
+            "}\n"
+            "\n"
+            '#[cfg(all(test, feature = "persistence"))]\n'
+            "mod tests {\n"
+            "    #[test]\n"
+            "    fn t() {\n"
+            '        let v = maybe().expect("test only");\n'
+            "        assert_eq!(v, 1);\n"
+            "    }\n"
+            "}\n"
+        )
+        tmp = Path(self._tmpdir.name) / "reinforce_like.rs"
+        tmp.write_text(content, encoding="utf-8")
+        self.assertEqual(cpu.scan_file(tmp), [])
+
+    def test_real_production_unwrap_before_gate_is_flagged(self) -> None:
+        content = (
+            "pub fn prod() -> u32 {\n"
+            "    maybe().unwrap()\n"
+            "}\n"
+            "\n"
+            '#[cfg(all(test, feature = "persistence"))]\n'
+            "mod tests {\n"
+            '    fn t() { let _ = x().expect(\"ok\"); }\n'
+            "}\n"
+        )
+        tmp = Path(self._tmpdir.name) / "has_prod_unwrap.rs"
+        tmp.write_text(content, encoding="utf-8")
+        hits = cpu.scan_file(tmp)
+        self.assertEqual(len(hits), 1)
+        self.assertEqual(hits[0][0], 2)  # line number of the production unwrap
+
+    def setUp(self) -> None:
+        import tempfile
+
+        self._tmpdir = tempfile.TemporaryDirectory()
+
+    def tearDown(self) -> None:
+        self._tmpdir.cleanup()
+
+
+class TestScanDirsCoverage(unittest.TestCase):
+    def test_bindings_are_in_scan_set(self) -> None:
+        scanned = {str(p) for p in cpu.SCAN_DIRS}
+        for required in (
+            "crates/velesdb-memory/src",
+            "crates/velesdb-node/src",
+            "crates/velesdb-python/src",
+        ):
+            self.assertIn(required, scanned, f"{required} must be scanned (F-3.10)")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes three audit findings on the quality-gate **tooling** (the gates themselves, not code violations).

## F-3.10 — `check_prod_unwraps.py` blind spots
`SCAN_DIRS` omitted `velesdb-memory`, `velesdb-node`, `velesdb-python`, leaving those production crates outside the no-`unwrap`/`expect` gate. Added all three.

## F-3.11 — false positives on composite test gates
The test-module cutoff matched only the exact string `#[cfg(test)]`, so `#[cfg(all(test, feature = "persistence"))]` (used in `velesdb-memory/src/reinforce.rs`) fell through and `.expect()` inside those test modules was reported as a production violation. Added `is_cfg_test_gate()` recognizing the bare, `all(..)` and `any(..)` forms, while excluding quoted feature names (`"test-utils"`) and `not(test)`.

## F-3.12 — CI SAFETY-template job scoped to core only
The `Verify SAFETY template` job filtered `^crates/velesdb-core/src/`, so unsafe blocks in bindings never got validated — exactly how F-3.2 slipped past CI. Broadened to any `crates/*/src/` production file.

## Also
- New `scripts/tests/test_check_prod_unwraps.py` (10 cases) pinning both the F-3.11 matcher contract and the F-3.10 scan set, wired into CI next to the existing feature-claims test.
- `QUALITY_BAR.md` now documents the exact crate coverage of both gates (audit rec #5).

## Verification
- `python3 scripts/check_prod_unwraps.py` → **PASSED** with the extended 10-crate scan set (the F-3.11 fix removes the `reinforce.rs` false positives).
- `python3 -m unittest scripts.tests.test_check_prod_unwraps` → **10/10 OK**.

Audit refs: F-3.10, F-3.11, F-3.12 + rec #5. Program `velesdb-audit-report-61b5e8`.