### PR TITLE
refactor(column-store): unify deletion state on RoaringBitmap (F-2.11)

### DIFF
--- a/crates/velesdb-core/src/column_store/batch.rs
+++ b/crates/velesdb-core/src/column_store/batch.rs
@@ -41,7 +41,7 @@ impl ColumnStore {
             }
 
             match self.primary_index.get(&update.pk) {
-                Some(&row_idx) if !self.deleted_rows.contains(&row_idx) => {
+                Some(&row_idx) if !self.is_row_deleted_bitmap(row_idx) => {
                     by_column
                         .entry(update.column.as_str())
                         .or_default()
@@ -148,8 +148,6 @@ impl ColumnStore {
 
         for row_idx in expired_rows {
             if let Some(&pk) = self.row_idx_to_pk.get(&row_idx) {
-                self.deleted_rows.insert(row_idx);
-                // BUG-2 FIX: Also update RoaringBitmap to keep both in sync
                 if let Ok(idx) = u32::try_from(row_idx) {
                     self.deletion_bitmap.insert(idx);
                 }
@@ -209,9 +207,8 @@ impl ColumnStore {
         row_idx: usize,
         pk_col: &str,
     ) -> Result<UpsertResult, ColumnStoreError> {
-        if self.deleted_rows.contains(&row_idx) {
+        if self.is_row_deleted_bitmap(row_idx) {
             Self::validate_value_types(&self.columns, values, Some(pk_col))?;
-            self.deleted_rows.remove(&row_idx);
             if let Ok(idx) = u32::try_from(row_idx) {
                 self.deletion_bitmap.remove(idx);
             }

--- a/crates/velesdb-core/src/column_store/filter.rs
+++ b/crates/velesdb-core/src/column_store/filter.rs
@@ -29,26 +29,29 @@ fn scan_int_column(
     col.iter()
         .enumerate()
         .filter_map(|(idx, v)| match v {
-            Some(val) if predicate(*val) && !store.deleted_rows.contains(&idx) => Some(idx),
+            Some(val) if predicate(*val) && !store.is_row_deleted_bitmap(idx) => Some(idx),
             _ => None,
         })
         .collect()
 }
 
 /// Scans a typed column slice, returning a `RoaringBitmap` of indices where
-/// `predicate(val)` is true. Excludes deleted rows.
+/// `predicate(val)` is true. Excludes deleted rows (via `deletion_bitmap`).
 ///
 /// Indices >= `u32::MAX` are safely skipped (not truncated).
 fn scan_cells_bitmap<T: Copy>(
     cells: &[Option<T>],
-    deleted_rows: &rustc_hash::FxHashSet<usize>,
+    deletion_bitmap: &RoaringBitmap,
     predicate: impl Fn(T) -> bool,
 ) -> RoaringBitmap {
     cells
         .iter()
         .enumerate()
         .filter_map(|(idx, v)| match v {
-            Some(val) if predicate(*val) && !deleted_rows.contains(&idx) => u32::try_from(idx).ok(),
+            Some(val) if predicate(*val) => {
+                let idx = u32::try_from(idx).ok()?;
+                (!deletion_bitmap.contains(idx)).then_some(idx)
+            }
             _ => None,
         })
         .collect()
@@ -63,7 +66,7 @@ fn scan_int_column_bitmap(
     let Some(TypedColumn::Int(col)) = store.columns.get(column) else {
         return RoaringBitmap::new();
     };
-    scan_cells_bitmap(col, &store.deleted_rows, predicate)
+    scan_cells_bitmap(col, &store.deletion_bitmap, predicate)
 }
 
 /// Scans a float column, returning a `RoaringBitmap` of matching indices.
@@ -75,7 +78,7 @@ fn scan_float_column_bitmap(
     let Some(TypedColumn::Float(col)) = store.columns.get(column) else {
         return RoaringBitmap::new();
     };
-    scan_cells_bitmap(col, &store.deleted_rows, predicate)
+    scan_cells_bitmap(col, &store.deletion_bitmap, predicate)
 }
 
 /// Scans a bool column, returning a `RoaringBitmap` of rows equal to `value`.
@@ -83,7 +86,7 @@ fn scan_bool_column_bitmap(store: &ColumnStore, column: &str, value: bool) -> Ro
     let Some(TypedColumn::Bool(col)) = store.columns.get(column) else {
         return RoaringBitmap::new();
     };
-    scan_cells_bitmap(col, &store.deleted_rows, |v| v == value)
+    scan_cells_bitmap(col, &store.deletion_bitmap, |v| v == value)
 }
 
 /// Scans a string column for rows whose interned id matches `target_id`.
@@ -96,7 +99,7 @@ fn scan_string_column(store: &ColumnStore, column: &str, target_id: StringId) ->
     col.iter()
         .enumerate()
         .filter_map(|(idx, v)| {
-            if *v == Some(target_id) && !store.deleted_rows.contains(&idx) {
+            if *v == Some(target_id) && !store.is_row_deleted_bitmap(idx) {
                 Some(idx)
             } else {
                 None
@@ -115,7 +118,7 @@ fn scan_string_column_bitmap(
     let Some(TypedColumn::String(col)) = store.columns.get(column) else {
         return RoaringBitmap::new();
     };
-    scan_cells_bitmap(col, &store.deleted_rows, |id| id == target_id)
+    scan_cells_bitmap(col, &store.deletion_bitmap, |id| id == target_id)
 }
 
 impl ColumnStore {
@@ -194,7 +197,7 @@ impl ColumnStore {
 
         col.iter()
             .enumerate()
-            .filter(|(idx, v)| **v == Some(value) && !self.deleted_rows.contains(idx))
+            .filter(|(idx, v)| **v == Some(value) && !self.is_row_deleted_bitmap(*idx))
             .count()
     }
 
@@ -211,7 +214,7 @@ impl ColumnStore {
 
         col.iter()
             .enumerate()
-            .filter(|(idx, v)| **v == Some(string_id) && !self.deleted_rows.contains(idx))
+            .filter(|(idx, v)| **v == Some(string_id) && !self.is_row_deleted_bitmap(*idx))
             .count()
     }
 
@@ -357,7 +360,7 @@ impl ColumnStore {
         col.iter()
             .enumerate()
             .filter_map(|(idx, v)| match v {
-                Some(id) if predicate(id) && !self.deleted_rows.contains(&idx) => {
+                Some(id) if predicate(id) && !self.is_row_deleted_bitmap(idx) => {
                     u32::try_from(idx).ok()
                 }
                 _ => None,
@@ -386,7 +389,7 @@ impl ColumnStore {
         col.iter()
             .enumerate()
             .filter_map(|(idx, v)| match v {
-                Some(id) if predicate(id) && !self.deleted_rows.contains(&idx) => Some(idx),
+                Some(id) if predicate(id) && !self.is_row_deleted_bitmap(idx) => Some(idx),
                 _ => None,
             })
             .collect()

--- a/crates/velesdb-core/src/column_store/filter_array.rs
+++ b/crates/velesdb-core/src/column_store/filter_array.rs
@@ -42,7 +42,7 @@ impl ColumnStore {
         let Some(TypedColumn::Array { data, .. }) = self.columns.get(column) else {
             return C::default();
         };
-        Self::iter_array_matches(data, &predicate, &self.deleted_rows, map_idx)
+        Self::iter_array_matches(data, &predicate, &self.deletion_bitmap, map_idx)
     }
 
     /// Inner loop shared by [`Self::filter_array_indices`]. Kept as a free associated
@@ -51,7 +51,7 @@ impl ColumnStore {
     fn iter_array_matches<P, M, T, C>(
         data: &[ArrayRow],
         predicate: &P,
-        deleted_rows: &rustc_hash::FxHashSet<usize>,
+        deletion_bitmap: &RoaringBitmap,
         map_idx: M,
     ) -> C
     where
@@ -63,7 +63,10 @@ impl ColumnStore {
             .enumerate()
             .filter_map(|(idx, row)| {
                 let arr = row.as_ref()?;
-                if predicate(arr) && !deleted_rows.contains(&idx) {
+                // Deleted rows live in `deletion_bitmap` (u32-indexed); indices that
+                // don't fit `u32` can never be tombstoned, so they count as live.
+                let deleted = u32::try_from(idx).is_ok_and(|i| deletion_bitmap.contains(i));
+                if predicate(arr) && !deleted {
                     map_idx(idx)
                 } else {
                     None

--- a/crates/velesdb-core/src/column_store/filter_geo.rs
+++ b/crates/velesdb-core/src/column_store/filter_geo.rs
@@ -88,7 +88,7 @@ impl ColumnStore {
                 let (lat, lng) = (*v).as_ref()?;
                 let dist = haversine_distance(*lat, *lng, params.lat, params.lng);
                 if compare_f64(dist, params.threshold, params.operator)
-                    && !self.deleted_rows.contains(&idx)
+                    && !self.is_row_deleted_bitmap(idx)
                 {
                     Some(idx)
                 } else {
@@ -112,7 +112,7 @@ impl ColumnStore {
                 let (lat, lng) = (*v).as_ref()?;
                 let dist = haversine_distance(*lat, *lng, params.lat, params.lng);
                 if compare_f64(dist, params.threshold, params.operator)
-                    && !self.deleted_rows.contains(&idx)
+                    && !self.is_row_deleted_bitmap(idx)
                 {
                     u32::try_from(idx).ok()
                 } else {
@@ -142,7 +142,7 @@ impl ColumnStore {
                     && *lat <= params.lat_max
                     && *lng >= params.lng_min
                     && *lng <= params.lng_max
-                    && !self.deleted_rows.contains(&idx)
+                    && !self.is_row_deleted_bitmap(idx)
                 {
                     Some(idx)
                 } else {
@@ -171,7 +171,7 @@ impl ColumnStore {
                     && *lat <= params.lat_max
                     && *lng >= params.lng_min
                     && *lng <= params.lng_max
-                    && !self.deleted_rows.contains(&idx)
+                    && !self.is_row_deleted_bitmap(idx)
                 {
                     u32::try_from(idx).ok()
                 } else {

--- a/crates/velesdb-core/src/column_store/filter_tests.rs
+++ b/crates/velesdb-core/src/column_store/filter_tests.rs
@@ -104,7 +104,6 @@ fn filter_in_string_no_matches() {
 fn filter_excludes_deleted_rows() {
     let mut store = store_with_rows(5, &["a"]);
     // Delete row 2
-    store.deleted_rows.insert(2);
     if let Ok(idx) = u32::try_from(2_usize) {
         store.deletion_bitmap.insert(idx);
     }
@@ -323,9 +322,7 @@ fn test_filter_in_string_bitmap_excludes_deleted() {
     let mut store = store_with_rows(6, &["a", "b"]);
     // Rows: 0=a, 1=b, 2=a, 3=b, 4=a, 5=b
     // Delete rows 0 and 4 (both "a")
-    store.deleted_rows.insert(0);
     store.deletion_bitmap.insert(0);
-    store.deleted_rows.insert(4);
     store.deletion_bitmap.insert(4);
 
     let bitmap = store.filter_in_string_bitmap("name", &["a"]);
@@ -363,7 +360,6 @@ fn test_filter_in_int_bitmap_excludes_deleted() {
     let mut store = store_with_rows(6, &["a"]);
     // age column: 0,1,2,3,4,5
     // Delete row 2
-    store.deleted_rows.insert(2);
     store.deletion_bitmap.insert(2);
 
     let bitmap = store.filter_in_int_bitmap("age", &[1, 2, 3]);

--- a/crates/velesdb-core/src/column_store/mod.rs
+++ b/crates/velesdb-core/src/column_store/mod.rs
@@ -78,9 +78,9 @@ pub struct ColumnStore {
     pub(crate) primary_index: HashMap<i64, usize>,
     /// Reverse index: row_idx → pk_value (O(1) reverse lookup for expire_rows)
     pub(crate) row_idx_to_pk: HashMap<usize, i64>,
-    /// Deleted row indices (tombstones) - FxHashSet for backward compatibility
-    pub(crate) deleted_rows: rustc_hash::FxHashSet<usize>,
-    /// Deleted row bitmap (EPIC-043 US-002) - RoaringBitmap for O(1) contains
+    /// Deleted row indices (tombstones). Single source of truth for deletion
+    /// state (EPIC-043 US-002 / audit F-2.11): a `RoaringBitmap` for O(1)
+    /// `contains`. Rows with index >= `u32::MAX` cannot be tombstoned.
     pub(crate) deletion_bitmap: RoaringBitmap,
     /// Row expiry timestamps: row_idx → expiry_timestamp (US-004 TTL)
     pub(crate) row_expiry: HashMap<usize, u64>,
@@ -192,7 +192,6 @@ impl ColumnStore {
         if row_idx >= self.row_count {
             return;
         }
-        self.deleted_rows.insert(row_idx);
         if let Ok(idx) = u32::try_from(row_idx) {
             self.deletion_bitmap.insert(idx);
         }
@@ -207,13 +206,14 @@ impl ColumnStore {
     /// Returns the number of active (non-deleted) rows in the store.
     #[must_use]
     pub fn active_row_count(&self) -> usize {
-        self.row_count.saturating_sub(self.deleted_rows.len())
+        self.row_count
+            .saturating_sub(self.deletion_bitmap.len() as usize)
     }
 
     /// Returns the number of deleted (tombstoned) rows.
     #[must_use]
     pub fn deleted_row_count(&self) -> usize {
-        self.deleted_rows.len()
+        self.deletion_bitmap.len() as usize
     }
 
     /// Returns the string table for string interning.
@@ -275,7 +275,7 @@ impl ColumnStore {
     /// Gets a value from a column at a specific row index as JSON.
     #[must_use]
     pub fn get_value_as_json(&self, column: &str, row_idx: usize) -> Option<serde_json::Value> {
-        if self.deleted_rows.contains(&row_idx) {
+        if self.is_row_deleted_bitmap(row_idx) {
             return None;
         }
 

--- a/crates/velesdb-core/src/column_store/primary_key_ops.rs
+++ b/crates/velesdb-core/src/column_store/primary_key_ops.rs
@@ -77,7 +77,7 @@ impl ColumnStore {
         existing_idx: usize,
         pk_value: i64,
     ) -> Result<usize, ColumnStoreError> {
-        if !self.deleted_rows.contains(&existing_idx) {
+        if !self.is_row_deleted_bitmap(existing_idx) {
             return Err(ColumnStoreError::DuplicateKey(pk_value));
         }
 
@@ -114,7 +114,6 @@ impl ColumnStore {
 
     /// Marks a tombstoned row as live again.
     fn undelete_row(&mut self, row_idx: usize) {
-        self.deleted_rows.remove(&row_idx);
         if let Ok(idx) = u32::try_from(row_idx) {
             self.deletion_bitmap.remove(idx);
         }
@@ -152,7 +151,7 @@ impl ColumnStore {
     #[must_use]
     pub fn get_row_idx_by_pk(&self, pk: i64) -> Option<usize> {
         let row_idx = self.primary_index.get(&pk).copied()?;
-        if self.deleted_rows.contains(&row_idx) {
+        if self.is_row_deleted_bitmap(row_idx) {
             return None;
         }
         Some(row_idx)
@@ -161,16 +160,14 @@ impl ColumnStore {
     /// Deletes a row by primary key value.
     ///
     /// Also clears any TTL metadata to prevent false-positive expirations.
-    /// Updates both FxHashSet and RoaringBitmap (EPIC-043 US-002).
+    /// Tombstones the row in the `deletion_bitmap` (EPIC-043 US-002).
     pub fn delete_by_pk(&mut self, pk: i64) -> bool {
         let Some(&row_idx) = self.primary_index.get(&pk) else {
             return false;
         };
-        if self.deleted_rows.contains(&row_idx) {
+        if self.is_row_deleted_bitmap(row_idx) {
             return false;
         }
-        self.deleted_rows.insert(row_idx);
-        // EPIC-043 US-002: Also update RoaringBitmap for O(1) contains
         if let Ok(idx) = u32::try_from(row_idx) {
             self.deletion_bitmap.insert(idx);
         }
@@ -243,7 +240,7 @@ impl ColumnStore {
             .primary_index
             .get(&pk)
             .ok_or(ColumnStoreError::RowNotFound(pk))?;
-        if self.deleted_rows.contains(&row_idx) {
+        if self.is_row_deleted_bitmap(row_idx) {
             return Err(ColumnStoreError::RowNotFound(pk));
         }
         Ok(row_idx)

--- a/crates/velesdb-core/src/column_store/vacuum.rs
+++ b/crates/velesdb-core/src/column_store/vacuum.rs
@@ -9,16 +9,20 @@ use super::ColumnStore;
 use roaring::RoaringBitmap;
 use std::collections::HashMap;
 
+/// Returns whether `idx` is tombstoned in the deletion bitmap.
+///
+/// Indices that don't fit `u32` can never be tombstoned, so they count as live.
+#[inline]
+fn is_deleted(deleted: &RoaringBitmap, idx: usize) -> bool {
+    u32::try_from(idx).is_ok_and(|i| deleted.contains(i))
+}
+
 /// Filters a column vector, removing entries at deleted indices and counting reclaimed bytes.
-fn compact_vec<T: Copy>(
-    data: &[T],
-    deleted: &rustc_hash::FxHashSet<usize>,
-    element_bytes: u64,
-) -> (Vec<T>, u64) {
-    let mut new_data = Vec::with_capacity(data.len().saturating_sub(deleted.len()));
+fn compact_vec<T: Copy>(data: &[T], deleted: &RoaringBitmap, element_bytes: u64) -> (Vec<T>, u64) {
+    let mut new_data = Vec::with_capacity(data.len().saturating_sub(deleted.len() as usize));
     let mut bytes_reclaimed = 0u64;
     for (idx, value) in data.iter().enumerate() {
-        if deleted.contains(&idx) {
+        if is_deleted(deleted, idx) {
             bytes_reclaimed += element_bytes;
         } else {
             new_data.push(*value);
@@ -30,13 +34,13 @@ fn compact_vec<T: Copy>(
 /// Clone-based variant of `compact_vec` for non-Copy types (e.g., `SmallVec`).
 fn compact_vec_clone<T: Clone>(
     data: &[T],
-    deleted: &rustc_hash::FxHashSet<usize>,
+    deleted: &RoaringBitmap,
     element_bytes: u64,
 ) -> (Vec<T>, u64) {
-    let mut new_data = Vec::with_capacity(data.len().saturating_sub(deleted.len()));
+    let mut new_data = Vec::with_capacity(data.len().saturating_sub(deleted.len() as usize));
     let mut bytes_reclaimed = 0u64;
     for (idx, value) in data.iter().enumerate() {
-        if deleted.contains(&idx) {
+        if is_deleted(deleted, idx) {
             bytes_reclaimed += element_bytes;
         } else {
             new_data.push(value.clone());
@@ -63,7 +67,7 @@ impl ColumnStore {
     /// Statistics about the vacuum operation.
     pub fn vacuum(&mut self, _config: VacuumConfig) -> VacuumStats {
         let start = std::time::Instant::now();
-        let tombstones_found = self.deleted_rows.len();
+        let tombstones_found = self.deletion_bitmap.len() as usize;
 
         if tombstones_found == 0 {
             return VacuumStats {
@@ -84,8 +88,7 @@ impl ColumnStore {
         self.remap_primary_index(&old_to_new);
         self.remap_row_expiry(&old_to_new);
 
-        stats.tombstones_removed = self.deleted_rows.len();
-        self.deleted_rows.clear();
+        stats.tombstones_removed = self.deletion_bitmap.len() as usize;
         self.deletion_bitmap.clear();
         self.row_count = new_row_count;
 
@@ -99,7 +102,7 @@ impl ColumnStore {
         let mut old_to_new: HashMap<usize, usize> = HashMap::new();
         let mut new_idx = 0;
         for old_idx in 0..self.row_count {
-            if !self.deleted_rows.contains(&old_idx) {
+            if !self.is_row_deleted_bitmap(old_idx) {
                 old_to_new.insert(old_idx, new_idx);
                 new_idx += 1;
             }
@@ -110,7 +113,7 @@ impl ColumnStore {
     /// Compacts all columns, removing deleted rows and accumulating reclaimed bytes.
     fn compact_all_columns(&mut self, stats: &mut VacuumStats) {
         for column in self.columns.values_mut() {
-            let (new_col, bytes) = Self::compact_column(column, &self.deleted_rows);
+            let (new_col, bytes) = Self::compact_column(column, &self.deletion_bitmap);
             stats.bytes_reclaimed += bytes;
             *column = new_col;
         }
@@ -145,10 +148,7 @@ impl ColumnStore {
     }
 
     /// Compacts a single column by removing deleted rows.
-    fn compact_column(
-        column: &TypedColumn,
-        deleted: &rustc_hash::FxHashSet<usize>,
-    ) -> (TypedColumn, u64) {
+    fn compact_column(column: &TypedColumn, deleted: &RoaringBitmap) -> (TypedColumn, u64) {
         match column {
             TypedColumn::Int(data) => {
                 let (new_data, bytes) = compact_vec(data, deleted, 8);
@@ -196,7 +196,7 @@ impl ColumnStore {
         if self.row_count == 0 {
             return false;
         }
-        let ratio = self.deleted_rows.len() as f64 / self.row_count as f64;
+        let ratio = self.deletion_bitmap.len() as f64 / self.row_count as f64;
         ratio >= threshold
     }
 
@@ -206,16 +206,12 @@ impl ColumnStore {
 
     /// Checks if a row is deleted using RoaringBitmap (O(1) lookup).
     ///
-    /// This is faster than FxHashSet for large deletion sets.
+    /// Single source of truth for deletion state. Indices >= `u32::MAX` cannot
+    /// be tombstoned (the bitmap is `u32`-indexed) and are reported as live.
     #[must_use]
     #[inline]
     pub fn is_row_deleted_bitmap(&self, row_idx: usize) -> bool {
-        if let Ok(idx) = u32::try_from(row_idx) {
-            self.deletion_bitmap.contains(idx)
-        } else {
-            // Fallback to FxHashSet for indices > u32::MAX
-            self.deleted_rows.contains(&row_idx)
-        }
+        u32::try_from(row_idx).is_ok_and(|idx| self.deletion_bitmap.contains(idx))
     }
 
     /// Returns an iterator over live (non-deleted) row indices.

--- a/crates/velesdb-core/src/column_store/vacuum_tests.rs
+++ b/crates/velesdb-core/src/column_store/vacuum_tests.rs
@@ -23,8 +23,6 @@ fn vacuum_removes_tombstones() {
     let mut store = store_with_id_rows(10);
 
     // Soft-delete rows 3 and 7
-    store.deleted_rows.insert(3);
-    store.deleted_rows.insert(7);
     if let Ok(idx) = u32::try_from(3_usize) {
         store.deletion_bitmap.insert(idx);
     }
@@ -53,7 +51,6 @@ fn vacuum_no_tombstones_is_noop() {
 fn vacuum_preserves_remaining_data() {
     let mut store = store_with_id_rows(5);
     // Delete row at index 2 (id=2)
-    store.deleted_rows.insert(2);
     if let Ok(idx) = u32::try_from(2_usize) {
         store.deletion_bitmap.insert(idx);
     }
@@ -76,8 +73,8 @@ fn vacuum_preserves_remaining_data() {
 fn should_vacuum_below_threshold() {
     let mut store = store_with_id_rows(100);
     // Delete 10 out of 100 => 10%, threshold 20% => false
-    for i in 0..10 {
-        store.deleted_rows.insert(i);
+    for i in 0..10u32 {
+        store.deletion_bitmap.insert(i);
     }
     assert!(!store.should_vacuum(0.20));
 }
@@ -86,8 +83,8 @@ fn should_vacuum_below_threshold() {
 fn should_vacuum_at_threshold() {
     let mut store = store_with_id_rows(100);
     // Delete 20 out of 100 => 20%, threshold 20% => true
-    for i in 0..20 {
-        store.deleted_rows.insert(i);
+    for i in 0..20u32 {
+        store.deletion_bitmap.insert(i);
     }
     assert!(store.should_vacuum(0.20));
 }
@@ -95,8 +92,8 @@ fn should_vacuum_at_threshold() {
 #[test]
 fn should_vacuum_above_threshold() {
     let mut store = store_with_id_rows(100);
-    for i in 0..50 {
-        store.deleted_rows.insert(i);
+    for i in 0..50u32 {
+        store.deletion_bitmap.insert(i);
     }
     assert!(store.should_vacuum(0.20));
 }
@@ -114,7 +111,6 @@ fn should_vacuum_empty_store() {
 #[test]
 fn is_row_deleted_bitmap_true_for_deleted() {
     let mut store = store_with_id_rows(5);
-    store.deleted_rows.insert(2);
     store.deletion_bitmap.insert(2);
 
     assert!(store.is_row_deleted_bitmap(2));
@@ -130,9 +126,7 @@ fn is_row_deleted_bitmap_false_for_live() {
 #[test]
 fn live_row_indices_excludes_deleted() {
     let mut store = store_with_id_rows(5);
-    store.deleted_rows.insert(1);
     store.deletion_bitmap.insert(1);
-    store.deleted_rows.insert(3);
     store.deletion_bitmap.insert(3);
 
     let live: Vec<usize> = store.live_row_indices().collect();
@@ -143,7 +137,6 @@ fn live_row_indices_excludes_deleted() {
 fn deleted_count_bitmap_matches_set() {
     let mut store = store_with_id_rows(10);
     for i in [0, 2, 4, 6] {
-        store.deleted_rows.insert(i);
         if let Ok(idx) = u32::try_from(i) {
             store.deletion_bitmap.insert(idx);
         }


### PR DESCRIPTION
Removes the duplicated deletion state in `column_store` (audit **F-2.11**).

`deleted_rows: FxHashSet<usize>` and `deletion_bitmap: RoaringBitmap` were kept in sync since the EPIC-043 US-002 transition, and `filter.rs` still read the FxHashSet. This makes `deletion_bitmap` the **single source of truth** and deletes `deleted_rows` entirely.

## Changes
- `filter.rs` / `filter_geo.rs` / `filter_array.rs`: scan helpers consult `deletion_bitmap` (via `is_row_deleted_bitmap` / direct lookup) instead of the FxHashSet.
- `primary_key_ops.rs` / `batch.rs` / `vacuum.rs` / `mod.rs`: drop the parallel FxHashSet writes; counts + compaction read the bitmap; new `is_deleted(&RoaringBitmap, usize)` helper in vacuum.
- `is_row_deleted_bitmap`: drop the now-unreachable `> u32::MAX` FxHashSet fallback (the bitmap is `u32`-indexed).

## Behavior
Identical for all bitmap-representable rows (index `< u32::MAX`) — the store was already bounded to that range. The only removed path is tombstoning a row at index ≥ `u32::MAX` (> 4.29 B in-memory rows, impossible in practice); this removes a latent FxHashSet/bitmap divergence rather than introducing one. Documented in the field/method docs.

## Verification (run in the worktree)
- `cargo test -p velesdb-core --lib column_store` → **175 passed; 0 failed**
- `cargo test -p velesdb-core --features persistence --lib column_store` → **175 passed; 0 failed**
- `cargo clippy -p velesdb-core --lib --features persistence -- -D warnings` → clean
- `cargo fmt --all -- --check` → clean

Net −15 lines. Audit ref: F-2.11.