### PR TITLE
feat(python): opt-in fail-closed observer strict mode (F-5.3)

### DIFF
--- a/crates/velesdb-python/python/velesdb/__init__.py
+++ b/crates/velesdb-python/python/velesdb/__init__.py
@@ -600,6 +600,7 @@ class Database:
         path: str,
         config: VelesConfigOptions | None = None,
         observer: Any | None = None,
+        observer_strict: bool = False,
     ) -> None:
         """Open or create a database.
 
@@ -611,19 +612,31 @@ class Database:
                 ``"collection_created"`` (fields ``name``, ``kind``, where
                 ``kind`` is ``"vector"``/``"metadata"``/``"graph"``/``"unknown"``),
                 ``"collection_deleted"`` (``name``), ``"upsert"``
-                (``collection``, ``point_count``), or ``"query"``
-                (``collection``, ``duration_us``). The observer is immutable
-                once the database is opened and cannot veto operations;
-                exceptions it raises are swallowed.
+                (``collection``, ``point_count``), ``"query"``
+                (``collection``, ``duration_us``), or the read-path veto
+                ``"query_request"`` (``collection``, ``operation``,
+                ``principal``, ``tenant``). For ``"query_request"`` the return
+                value decides the read: ``None``/``True`` allow, ``False``/a
+                reason string deny, and a ``{"filter": "<VelesQL predicate>"}``
+                dict allow-with-scope (narrowing the read). The observer is
+                immutable once the database is opened.
+            observer_strict: Read-path failure policy for the
+                ``"query_request"`` veto. Default ``False`` (fail-open): if the
+                policy callback raises or returns an uninterpretable value, the
+                read is **allowed** so a bug in policy code never breaks reads.
+                Set ``True`` (fail-closed) for governance / RBAC deployments:
+                the same error cases then **deny** the read. Explicit decisions
+                (``None``/``True``/``False``/str/dict) are unaffected by this
+                flag.
 
-                Caveat: in the embedded Python SDK only
-                ``collection_created`` / ``collection_deleted`` fire, as they
-                originate in the core engine. ``upsert`` / ``query`` are
-                emitted only by callers that explicitly call
-                ``notify_upsert`` / ``notify_query`` — in this ecosystem that
-                is the REST server, not embedded usage.
+                Caveat: in the embedded Python SDK the lifecycle
+                ``collection_created`` / ``collection_deleted`` events and the
+                ``query_request`` read gate fire from the core engine.
+                ``upsert`` / ``query`` are emitted only by callers that
+                explicitly call ``notify_upsert`` / ``notify_query`` — in this
+                ecosystem that is the REST server, not embedded usage.
         """
-        self._inner = _RawDatabase(path, config, observer)
+        self._inner = _RawDatabase(path, config, observer, observer_strict)
 
     def __getattr__(self, name: str) -> Any:
         return getattr(self._inner, name)

--- a/crates/velesdb-python/src/database.rs
+++ b/crates/velesdb-python/src/database.rs
@@ -161,12 +161,13 @@ impl Database {
     ///     ...     observer=lambda event, **f: events.append((event, f)),
     ///     ... )
     #[new]
-    #[pyo3(signature = (path, config = None, observer = None))]
+    #[pyo3(signature = (path, config = None, observer = None, observer_strict = false))]
     fn new(
         py: Python<'_>,
         path: &str,
         config: Option<VelesConfigOptions>,
         observer: Option<Py<PyAny>>,
+        observer_strict: bool,
     ) -> PyResult<Self> {
         // Open the database off the GIL. Opening walks the WAL, rebuilds
         // any in-memory state, and mmaps vector/edge files — on a multi-
@@ -181,8 +182,8 @@ impl Database {
         let path_buf = PathBuf::from(path);
         let path_clone = path_buf.clone();
         let core_config = config.map(|cfg| cfg.to_core());
-        let core_observer: Option<Arc<dyn DatabaseObserver>> =
-            observer.map(|cb| Arc::new(PyObserver::new(cb)) as Arc<dyn DatabaseObserver>);
+        let core_observer: Option<Arc<dyn DatabaseObserver>> = observer
+            .map(|cb| Arc::new(PyObserver::new(cb, observer_strict)) as Arc<dyn DatabaseObserver>);
         let db = py
             .detach(move || open_core(&path_clone, core_config, core_observer))
             .map_err(core_err)?;

--- a/crates/velesdb-python/src/observer.rs
+++ b/crates/velesdb-python/src/observer.rs
@@ -17,6 +17,16 @@
 //! `query_request` veto also never panics: a raised callback error is logged and
 //! treated as *allow* (fail-open on observer error, never break a read on a bug
 //! in user policy code — an explicit `False`/reason is the only way to deny).
+//!
+//! # Strict (fail-closed) mode
+//!
+//! Fail-open is the default so a bug in user policy never breaks reads. Governance
+//! / RBAC deployments can opt into **strict mode** (`Database(..., observer_strict=True)`):
+//! then any *error* while consulting the policy — the callback raising, a
+//! field-population failure, or an uninterpretable return value (e.g. a list) —
+//! resolves to **deny** instead of allow, so a broken policy fails closed rather
+//! than silently disabling governance. Explicit decisions (`None`/`True`/`False`/
+//! str/`dict`) are unaffected by the mode.
 
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
@@ -44,12 +54,37 @@ pub struct PyObserver {
     /// User-supplied Python callable. `Py<PyAny>` is `Send + Sync`, satisfying
     /// the `DatabaseObserver: Send + Sync` bound.
     cb: Py<PyAny>,
+    /// Read-path failure policy. When `false` (default), an *error* while
+    /// consulting the policy — the callback raising, a field-population
+    /// failure, or an uninterpretable return value — resolves to **allow**
+    /// (fail-open: a bug in user policy never breaks a read). When `true`
+    /// (opt-in, for RBAC / governance deployments), those same error cases
+    /// resolve to **deny** (fail-closed), so a broken policy denies rather
+    /// than silently disabling governance. Explicit decisions
+    /// (`None`/`True`/`False`/str/`dict`) behave identically in both modes.
+    strict: bool,
 }
 
 impl PyObserver {
     /// Wraps a Python callable as a core observer.
-    pub fn new(cb: Py<PyAny>) -> Self {
-        Self { cb }
+    ///
+    /// `strict` selects the read-path failure policy: `false` = fail-open
+    /// (default, backward compatible), `true` = fail-closed on any error while
+    /// consulting the policy. See [`PyObserver::strict`].
+    pub fn new(cb: Py<PyAny>, strict: bool) -> Self {
+        Self { cb, strict }
+    }
+
+    /// The [`AccessDecision`] to use when consulting the policy errors out:
+    /// `Deny` under strict mode, `Allow` otherwise.
+    fn on_error_decision(&self, what: &str) -> AccessDecision {
+        if self.strict {
+            AccessDecision::Deny(Error::Query(format!(
+                "read denied by observer strict mode: {what}"
+            )))
+        } else {
+            AccessDecision::Allow
+        }
     }
 
     /// Invokes the callback as `callback(event, **fields)`, swallowing any
@@ -101,7 +136,7 @@ fn operation_str(op: QueryOperationKind) -> &'static str {
 ///   `"tenant"` is an optional audit hint OSS does not itself narrow by. A dict
 ///   with a missing/empty/tenant-only or unparseable `"filter"` **denies**
 ///   (fail closed) rather than allowing an unscoped read.
-fn interpret_decision(ret: &Bound<'_, PyAny>) -> AccessDecision {
+fn interpret_decision(ret: &Bound<'_, PyAny>, strict: bool) -> AccessDecision {
     if ret.is_none() {
         return AccessDecision::Allow;
     }
@@ -120,6 +155,17 @@ fn interpret_decision(ret: &Bound<'_, PyAny>) -> AccessDecision {
     // A dict expresses an allow-with-scope narrowing.
     if let Ok(dict) = ret.cast::<PyDict>() {
         return interpret_scope(dict);
+    }
+    // Any other return type (e.g. a list, an int, an object) is not a valid
+    // decision. Fail-open by default (treat as no-opinion allow); fail-closed
+    // under strict mode so a policy bug that returns the wrong type denies
+    // rather than silently allowing.
+    if strict {
+        return AccessDecision::Deny(Error::Query(
+            "read denied by observer strict mode: policy returned an \
+             uninterpretable value (expected None/bool/str/dict)"
+                .to_string(),
+        ));
     }
     AccessDecision::Allow
 }
@@ -261,15 +307,14 @@ impl DatabaseObserver for PyObserver {
                 || fields.set_item("principal", ctx.principal).is_err()
                 || fields.set_item("tenant", ctx.tenant_hint).is_err()
             {
-                return AccessDecision::Allow;
+                return self.on_error_decision("could not populate query_request fields");
             }
             match self.cb.bind(py).call(("query_request",), Some(&fields)) {
-                Ok(ret) => interpret_decision(&ret),
+                Ok(ret) => interpret_decision(&ret, self.strict),
                 Err(err) => {
-                    eprintln!(
-                        "[velesdb] observer callback 'query_request' raised; allowing: {err}"
-                    );
-                    AccessDecision::Allow
+                    let verb = if self.strict { "denying" } else { "allowing" };
+                    eprintln!("[velesdb] observer callback 'query_request' raised; {verb}: {err}");
+                    self.on_error_decision("query_request callback raised")
                 }
             }
         });

--- a/crates/velesdb-python/tests/test_search_gate.py
+++ b/crates/velesdb-python/tests/test_search_gate.py
@@ -58,15 +58,34 @@ def _scope_to_acme(event, **fields):
     return None
 
 
+def _raise_on_read(event, **fields):
+    """A buggy policy that raises while deciding a gated read."""
+    if event == "query_request":
+        raise RuntimeError("policy bug")
+    return None
+
+
+def _return_bad_type(event, **fields):
+    """A buggy policy that returns an uninterpretable value (a list)."""
+    if event == "query_request":
+        return ["not", "a", "decision"]
+    return None
+
+
 class _Db:
     """Context-managed temp database, optionally with an observer."""
 
-    def __init__(self, observer=None):
+    def __init__(self, observer=None, observer_strict=False):
         self.observer = observer
+        self.observer_strict = observer_strict
 
     def __enter__(self):
         self.dir = tempfile.mkdtemp()
-        self.db = Database(self.dir, observer=self.observer)
+        self.db = Database(
+            self.dir,
+            observer=self.observer,
+            observer_strict=self.observer_strict,
+        )
         return self.db
 
     def __exit__(self, *exc):
@@ -145,6 +164,54 @@ def test_search_ids_deny_fails_closed():
         collection = _seed(db)
         with pytest.raises(Exception):
             collection.search_ids(QUERY, top_k=2)
+
+
+# ---------------------------------------------------------------------------
+# Strict (fail-closed) mode, audit F-5.3: a policy *error* denies under strict
+# and allows (fail-open) by default. Explicit decisions are unaffected.
+# ---------------------------------------------------------------------------
+
+
+def test_policy_exception_fails_open_by_default():
+    """A raising policy must NOT break the read in the default (fail-open) mode."""
+    with _Db(observer=_raise_on_read) as db:
+        collection = _seed(db)
+        results = collection.search_request(SearchOptions(vector=QUERY, top_k=2))
+        assert _ids(results) == {1, 2}
+
+
+def test_policy_exception_fails_closed_under_strict():
+    """The same raising policy denies the read when observer_strict=True."""
+    with _Db(observer=_raise_on_read, observer_strict=True) as db:
+        collection = _seed(db)
+        with pytest.raises(Exception):
+            collection.search_request(SearchOptions(vector=QUERY, top_k=2))
+
+
+def test_bad_return_type_fails_open_by_default():
+    """An uninterpretable return value is treated as allow by default."""
+    with _Db(observer=_return_bad_type) as db:
+        collection = _seed(db)
+        results = collection.search_request(SearchOptions(vector=QUERY, top_k=2))
+        assert _ids(results) == {1, 2}
+
+
+def test_bad_return_type_fails_closed_under_strict():
+    """An uninterpretable return value denies the read under strict mode."""
+    with _Db(observer=_return_bad_type, observer_strict=True) as db:
+        collection = _seed(db)
+        with pytest.raises(Exception):
+            collection.search_request(SearchOptions(vector=QUERY, top_k=2))
+
+
+def test_explicit_allow_unaffected_by_strict():
+    """None/allow from the policy still allows even under strict mode."""
+    with _Db(observer=_scope_to_acme, observer_strict=True) as db:
+        collection = _seed(db)
+        results = collection.search_request(SearchOptions(vector=QUERY, top_k=10))
+        # Scope still narrows to tenant 'acme' (id 1), proving strict didn't
+        # turn an explicit allow-with-scope into a denial.
+        assert _ids(results) == {1}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Adds an opt-in **fail-closed** mode to the Python read-path observer gate (audit **F-5.3**).

## Problem
The `query_request` veto is fail-open on *error*: a raising callback, a field-population failure, or an uninterpretable return value (e.g. a `list`) all resolve to **Allow** — a bug in user policy never breaks a read. For governance/RBAC, that silent fail-open means a broken policy disables the gate with only an `eprintln`.

## Change
New `observer_strict` flag on `Database(...)`, default `False` (unchanged fail-open). When `True`, those same *error* cases resolve to **Deny** (fail-closed). Explicit decisions (`None`/`True`/`False`/str/`dict`) are unaffected in both modes.

- `observer.rs`: `PyObserver.strict`; `on_error_decision()` centralizes Allow-vs-Deny; `interpret_decision(ret, strict)` denies on uninterpretable return under strict; the raise / field-population branches route through it.
- `database.rs`: `Database(path, config, observer, observer_strict=False)`.
- `python/velesdb/__init__.py`: thread `observer_strict` through the compatibility adapter; refresh the stale docstring (it still claimed the observer "cannot veto operations" — pre-3.10 read-gate).
- `tests/test_search_gate.py`: 5 new cases.

## Verification (run locally)
`maturin develop` + `pytest tests/test_search_gate.py tests/test_observer.py` → **43 passed**. `cargo fmt` + `cargo clippy -p velesdb-python` clean.

Audit ref: F-5.3.