### PR TITLE
chore(core): SIMD dead re-exports, MmapStorage encapsulation (P3.11/P3.13)

### DIFF
--- a/crates/velesdb-core/src/simd_native/mod.rs
+++ b/crates/velesdb-core/src/simd_native/mod.rs
@@ -39,17 +39,9 @@ pub(crate) mod reduction;
 pub mod scalar;
 mod tail_unroll;
 
-// Re-export macros from tail_unroll for crate-wide use
-#[allow(unused_imports)]
-pub(crate) use tail_unroll::sum_remainder_unrolled_8;
-#[allow(unused_imports)]
-pub(crate) use tail_unroll::sum_squared_remainder_unrolled_8;
-
-// Re-export 4-accumulator loop macros from reduction for crate-wide use
-#[allow(unused_imports)]
-pub(crate) use reduction::simd_4acc_dot_loop;
-#[allow(unused_imports)]
-pub(crate) use reduction::simd_4acc_l2_loop;
+// NOTE: The `tail_unroll` and `reduction` unrolling macros are `#[macro_export]`,
+// so call-sites reach them via crate-root paths (`crate::sum_remainder_unrolled_8`,
+// `crate::simd_4acc_dot_loop`, …). No module-local re-export is needed here.
 
 // Re-export public API from scalar
 pub use scalar::{cosine_similarity_fast, fast_rsqrt};

--- a/crates/velesdb-core/src/storage/mmap.rs
+++ b/crates/velesdb-core/src/storage/mmap.rs
@@ -46,22 +46,26 @@ use tracing::error;
 #[allow(clippy::module_name_repetitions)]
 pub struct MmapStorage {
     /// Directory path for storage files
-    pub(super) path: PathBuf,
+    path: PathBuf,
     /// Vector dimension
-    pub(super) dimension: usize,
+    dimension: usize,
     /// In-memory index of ID -> file offset
     /// EPIC-033/US-004: Sharded for reduced lock contention on read-heavy workloads
-    pub(super) index: ShardedIndex,
+    index: ShardedIndex,
     /// Write-Ahead Log writer
-    pub(super) wal: RwLock<io::BufWriter<File>>,
-    /// File handle for the data file (kept open for resizing)
+    wal: RwLock<io::BufWriter<File>>,
+    /// File handle for the data file (kept open for resizing).
+    ///
+    /// Stays `pub(super)` because [`ensure_capacity`](Self::ensure_capacity)'s
+    /// sibling module (`mmap_capacity`) reopens (reassigns) this handle after a
+    /// compaction swap; a read-only getter cannot express that reassignment.
     pub(super) data_file: File,
     /// Memory mapped data file
-    pub(super) mmap: RwLock<MmapMut>,
+    mmap: RwLock<MmapMut>,
     /// Next available offset in the data file
-    pub(super) next_offset: AtomicUsize,
+    next_offset: AtomicUsize,
     /// P0 Audit: Metrics for monitoring `ensure_capacity` latency
-    pub(super) metrics: Arc<StorageMetrics>,
+    metrics: Arc<StorageMetrics>,
     /// Epoch counter incremented every time the mmap is remapped.
     ///
     /// # Overflow Safety
@@ -70,19 +74,19 @@ pub struct MmapStorage {
     /// remaps/second, overflow would take ~584 years. The worst-case scenario
     /// on wrap is a false-positive panic in `VectorSliceGuard::as_slice()`,
     /// which is acceptable given the astronomical time required.
-    pub(super) remap_epoch: AtomicU64,
+    remap_epoch: AtomicU64,
     /// Controls WAL write and sync behavior for vector storage.
     ///
     /// Issue #423 Component 4: `DurabilityMode::None` skips WAL writes
     /// entirely for bulk import scenarios where data can be re-derived.
     /// Default is `Fsync` (unchanged from pre-#423 behavior).
-    pub(super) durability: DurabilityMode,
+    durability: DurabilityMode,
     /// Ids touched by the WAL replay performed in [`MmapStorage::new`]
     /// (store + delete entries), deduplicated. The replay truncates the WAL,
     /// so these ids are the only remaining witness of writes the persisted
     /// HNSW index may not reflect; `Collection::open` drains them via
     /// [`MmapStorage::take_wal_replayed_ids`] for stale-entry reconciliation.
-    pub(super) wal_replayed_ids: Vec<u64>,
+    wal_replayed_ids: Vec<u64>,
     /// In-memory replication-consumer low-watermark registration state.
     ///
     /// Holds retention over the vector WAL: compaction consults its minimum
@@ -90,7 +94,7 @@ pub struct MmapStorage {
     /// loses a position it still needs (Requirement 6.3). Empty by default,
     /// so with no registered consumer truncation is unchanged from before this
     /// seam existed.
-    pub(super) watermarks: super::wal_cursor::WalWatermarkRegistry,
+    watermarks: super::wal_cursor::WalWatermarkRegistry,
 }
 
 impl MmapStorage {
@@ -232,6 +236,63 @@ impl MmapStorage {
     #[must_use]
     pub fn metrics(&self) -> &StorageMetrics {
         &self.metrics
+    }
+
+    // -------------------------------------------------------------------------
+    // Field accessors for sibling modules (`mmap_capacity`).
+    //
+    // Descendant modules (`mmap::vector_io`, `mmap::wal_replay`) and this module
+    // read the fields directly; these getters exist so the fields can stay
+    // private while `mmap_capacity` still borrows them (interior mutability via
+    // the returned reference preserves the original locking semantics).
+    // -------------------------------------------------------------------------
+
+    /// Storage directory path.
+    #[inline]
+    pub(super) fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Configured vector dimension.
+    #[inline]
+    pub(super) fn dimension(&self) -> usize {
+        self.dimension
+    }
+
+    /// Sharded ID -> offset index (interior-mutable).
+    #[inline]
+    pub(super) fn index(&self) -> &ShardedIndex {
+        &self.index
+    }
+
+    /// Write-Ahead Log writer lock.
+    #[inline]
+    pub(super) fn wal(&self) -> &RwLock<io::BufWriter<File>> {
+        &self.wal
+    }
+
+    /// Memory-mapped data file lock.
+    #[inline]
+    pub(super) fn mmap(&self) -> &RwLock<MmapMut> {
+        &self.mmap
+    }
+
+    /// Next-available data-file offset counter.
+    #[inline]
+    pub(super) fn next_offset(&self) -> &AtomicUsize {
+        &self.next_offset
+    }
+
+    /// Remap epoch counter, bumped on every mmap remap.
+    #[inline]
+    pub(super) fn remap_epoch(&self) -> &AtomicU64 {
+        &self.remap_epoch
+    }
+
+    /// Replication-consumer low-watermark registry.
+    #[inline]
+    pub(super) fn watermarks(&self) -> &super::wal_cursor::WalWatermarkRegistry {
+        &self.watermarks
     }
 
     /// Opens or creates the data file, ensuring it has at least `INITIAL_SIZE` bytes.

--- a/crates/velesdb-core/src/storage/mmap_capacity.rs
+++ b/crates/velesdb-core/src/storage/mmap_capacity.rs
@@ -23,7 +23,7 @@ impl MmapStorage {
         let mut did_resize = false;
         let mut bytes_resized = 0u64;
 
-        let mut mmap = self.mmap.write();
+        let mut mmap = self.mmap().write();
         if mmap.len() < required_len {
             mmap.flush()?;
 
@@ -45,14 +45,14 @@ impl MmapStorage {
             // - Condition 3: File remains open with read+write permissions.
             // SAFETY: Memory mapping requires unsafe; resizing ensures mapping doesn't exceed file bounds.
             *mmap = unsafe { MmapMut::map_mut(&self.data_file)? };
-            self.remap_epoch
+            self.remap_epoch()
                 .fetch_add(1, std::sync::atomic::Ordering::Release);
 
             did_resize = true;
             bytes_resized = new_len.saturating_sub(current_len);
         }
 
-        self.metrics
+        self.metrics()
             .record_ensure_capacity(start.elapsed(), did_resize, bytes_resized);
 
         Ok(())
@@ -64,10 +64,29 @@ impl MmapStorage {
     ///
     /// Returns an error if file operations fail.
     pub fn reserve_capacity(&mut self, vector_count: usize) -> io::Result<()> {
-        let vector_size = self.dimension * std::mem::size_of::<f32>();
+        let vector_size = self.dimension() * std::mem::size_of::<f32>();
         let required_len = vector_count.saturating_mul(vector_size);
         let with_headroom = required_len.saturating_add(required_len / 10);
         self.ensure_capacity(with_headroom)
+    }
+
+    /// Borrows this storage's live fields into a [`CompactionContext`].
+    ///
+    /// Shared by [`compact`](Self::compact) and
+    /// [`fragmentation_ratio`](Self::fragmentation_ratio) so the field wiring
+    /// lives in one place. The context borrows `self` immutably; interior
+    /// mutability on the borrowed locks/atomics preserves existing semantics.
+    fn compaction_ctx(&self) -> CompactionContext<'_> {
+        CompactionContext {
+            path: self.path(),
+            dimension: self.dimension(),
+            index: self.index(),
+            mmap: self.mmap(),
+            next_offset: self.next_offset(),
+            wal: self.wal(),
+            initial_size: Self::INITIAL_SIZE,
+            watermarks: self.watermarks(),
+        }
     }
 
     /// Compacts the storage by rewriting only active vectors.
@@ -80,21 +99,10 @@ impl MmapStorage {
     ///
     /// Returns an error if file operations fail.
     pub fn compact(&mut self) -> io::Result<usize> {
-        let ctx = CompactionContext {
-            path: &self.path,
-            dimension: self.dimension,
-            index: &self.index,
-            mmap: &self.mmap,
-            next_offset: &self.next_offset,
-            wal: &self.wal,
-            initial_size: Self::INITIAL_SIZE,
-            watermarks: &self.watermarks,
-        };
-
-        let bytes_reclaimed = ctx.compact()?;
+        let bytes_reclaimed = self.compaction_ctx().compact()?;
 
         if bytes_reclaimed > 0 {
-            let data_path = self.path.join("vectors.dat");
+            let data_path = self.path().join("vectors.dat");
             self.data_file = OpenOptions::new().read(true).write(true).open(&data_path)?;
             // No flush_full() here: `commit_compaction` already synced the
             // compacted data file before the swap, promoted an identical
@@ -111,17 +119,6 @@ impl MmapStorage {
     /// Returns the fragmentation ratio (0.0 = no fragmentation, 1.0 = 100% fragmented).
     #[must_use]
     pub fn fragmentation_ratio(&self) -> f64 {
-        let ctx = CompactionContext {
-            path: &self.path,
-            dimension: self.dimension,
-            index: &self.index,
-            mmap: &self.mmap,
-            next_offset: &self.next_offset,
-            wal: &self.wal,
-            initial_size: Self::INITIAL_SIZE,
-            watermarks: &self.watermarks,
-        };
-
-        ctx.fragmentation_ratio()
+        self.compaction_ctx().fragmentation_ratio()
     }
 }

--- a/crates/velesdb-core/src/storage/storage_reliability_tests.rs
+++ b/crates/velesdb-core/src/storage/storage_reliability_tests.rs
@@ -150,10 +150,10 @@ fn test_wal_replay_recovers_unflushed_stores() {
         storage.store(2, &[4.0, 5.0, 6.0]).unwrap();
 
         // Flush WAL to disk but do NOT call storage.flush() (which persists index)
-        storage.wal.write().flush().unwrap();
-        storage.wal.write().get_ref().sync_all().unwrap();
+        storage.wal().write().flush().unwrap();
+        storage.wal().write().get_ref().sync_all().unwrap();
         // Flush mmap too so vector bytes are on disk
-        storage.mmap.write().flush().unwrap();
+        storage.mmap().write().flush().unwrap();
 
         // Do NOT call storage.flush() — simulates crash before index persistence
     }
@@ -188,8 +188,8 @@ fn test_wal_replay_recovers_deletes() {
 
         // Now delete one — written to WAL but NOT flushed to index
         storage.delete(1).unwrap();
-        storage.wal.write().flush().unwrap();
-        storage.wal.write().get_ref().sync_all().unwrap();
+        storage.wal().write().flush().unwrap();
+        storage.wal().write().get_ref().sync_all().unwrap();
         // Do NOT call storage.flush() — crash
     }
 
@@ -260,9 +260,9 @@ fn test_wal_replay_truncates_after_success() {
     {
         let mut storage = MmapStorage::new(&path, dim).unwrap();
         storage.store(1, &[1.0, 2.0, 3.0]).unwrap();
-        storage.wal.write().flush().unwrap();
-        storage.wal.write().get_ref().sync_all().unwrap();
-        storage.mmap.write().flush().unwrap();
+        storage.wal().write().flush().unwrap();
+        storage.wal().write().get_ref().sync_all().unwrap();
+        storage.mmap().write().flush().unwrap();
     }
 
     // Reopen triggers replay
@@ -722,15 +722,15 @@ fn test_898b_store_offset_overflow_leaves_next_offset_unchanged() {
     // Force next_offset so close to usize::MAX that offset + vector_size wraps.
     let poisoned = usize::MAX - (vector_size - 1);
     storage
-        .next_offset
+        .next_offset()
         .store(poisoned, std::sync::atomic::Ordering::SeqCst);
 
     let before = storage
-        .next_offset
+        .next_offset()
         .load(std::sync::atomic::Ordering::SeqCst);
     let result = storage.store(999, &[1.0, 2.0, 3.0]);
     let after = storage
-        .next_offset
+        .next_offset()
         .load(std::sync::atomic::Ordering::SeqCst);
 
     assert!(result.is_err(), "overflowing store offset must be rejected");
@@ -752,16 +752,16 @@ fn test_898_store_batch_offset_overflow_leaves_next_offset_unchanged() {
     let mut storage = MmapStorage::new(&path, dim).unwrap();
     let poisoned = usize::MAX - (vector_size - 1);
     storage
-        .next_offset
+        .next_offset()
         .store(poisoned, std::sync::atomic::Ordering::SeqCst);
 
     let before = storage
-        .next_offset
+        .next_offset()
         .load(std::sync::atomic::Ordering::SeqCst);
     let v = [1.0_f32, 2.0, 3.0];
     let result = storage.store_batch(&[(999_u64, &v[..])]);
     let after = storage
-        .next_offset
+        .next_offset()
         .load(std::sync::atomic::Ordering::SeqCst);
 
     assert!(result.is_err(), "overflowing batch store must be rejected");

--- a/crates/velesdb-core/src/storage/tests.rs
+++ b/crates/velesdb-core/src/storage/tests.rs
@@ -82,7 +82,7 @@ fn test_drop_best_effort_mmap_lock_contention_non_blocking() {
     let mut storage = MmapStorage::new(dir.path(), 3).unwrap();
     storage.store(1, &[1.0, 2.0, 3.0]).unwrap();
 
-    let _mmap_guard = storage.mmap.read();
+    let _mmap_guard = storage.mmap().read();
     let start = std::time::Instant::now();
     storage.flush_on_shutdown_best_effort();
 
@@ -98,7 +98,7 @@ fn test_drop_best_effort_wal_lock_contention_non_blocking() {
     let mut storage = MmapStorage::new(dir.path(), 3).unwrap();
     storage.store(1, &[1.0, 2.0, 3.0]).unwrap();
 
-    let _wal_guard = storage.wal.write();
+    let _wal_guard = storage.wal().write();
     let start = std::time::Instant::now();
     storage.flush_on_shutdown_best_effort();
 
@@ -374,7 +374,7 @@ fn test_retrieve_ref_returns_invalid_data_on_misaligned_offset() {
     storage.store(1, &[1.0, 2.0, 3.0]).unwrap();
 
     // Inject a corrupted, non-f32-aligned offset to ensure retrieve_ref is fallible.
-    storage.index.insert(42, 1);
+    storage.index().insert(42, 1);
 
     let result = storage.retrieve_ref(42);
     match result {
@@ -393,7 +393,7 @@ fn test_retrieve_returns_invalid_data_on_overflowing_offset() {
     // `offset + vector_size` wraps, slipping past an unchecked bound check
     // and panicking on the subsequent slice. `retrieve` must return Err.
     let vector_size = 3 * std::mem::size_of::<f32>();
-    storage.index.insert(42, usize::MAX - vector_size + 1);
+    storage.index().insert(42, usize::MAX - vector_size + 1);
 
     let result = storage.retrieve(42);
     match result {


### PR DESCRIPTION
Three audit hygiene items (P3.11–P3.13).

## P3.11 — remove dead SIMD re-exports
`simd_native/mod.rs` carried four `pub(crate) use tail_unroll::… / reduction::…` re-exports under `#[allow(unused_imports)]`. Those unrolling macros are `#[macro_export]`, so every call-site reaches them via crate-root paths (`crate::sum_remainder_unrolled_8`, `crate::simd_4acc_dot_loop`, …) — grep confirms no `simd_native::` / `super::` call-site. Removed the four re-exports and both `#[allow]`s; left an explanatory NOTE.

## P3.12 — notify_* deprecation (already done)
`notify_upsert` / `notify_query` in `database/mod.rs` are **already** `#[deprecated(since = "3.9.0", …)]` on develop with accurate notes, and have no internal callers. No change needed — documented here for the audit trail.

## P3.13 — encapsulate MmapStorage fields
Made 11 `pub(super)` fields private and added `#[inline] pub(super)` getters for the 8 that the sibling module `mmap_capacity` borrows (`path`, `dimension`, `index`, `wal`, `mmap`, `next_offset`, `remap_epoch`, `watermarks`). `durability` / `wal_replayed_ids` became fully private (module-tree-only). `data_file` deliberately stays `pub(super)` — `mmap_capacity` reassigns it after a compaction swap, which a read-only getter can't express (documented inline). Locking / interior-mutability semantics unchanged. Migrated call-sites in `mmap_capacity.rs` + 2 test files.

## Verification (run in worktree)
- `cargo clippy -p velesdb-core --lib --bins --features persistence,gpu,update-check -- -D warnings` → clean
- `cargo test -p velesdb-core --lib` → **5266 passed; 0 failed**
- `cargo fmt --all -- --check` → clean

Audit refs: P3.11, P3.12, P3.13.