### PR TITLE
chore(release): 3.11.0 — chief-engineer audit resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,71 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.11.0] — 2026-07-14
+
+Chief-engineer audit resolution: closes every actionable finding from the
+line-by-line `velesdb-core` audit (soundness, quality-gate coverage,
+feature-gating, and documentation). No user-facing behavior changes except one
+new opt-in feature. The one large item — splitting the `Collection` god-object
+backing store — is deliberately deferred as a tracked EPIC (#1384) rather than
+rushed on a released core.
+
+### Added
+
+- **Opt-in fail-closed observer mode.** `Database(..., observer_strict=True)`
+  (Python) makes an *error* while consulting a `query_request` read policy — the
+  callback raising or returning an uninterpretable value — resolve to **deny**
+  instead of the default fail-open **allow**. Default is unchanged (fail-open, so
+  a bug in policy code never breaks a read); strict mode is for governance / RBAC
+  deployments. Explicit decisions (`None`/`True`/`False`/str/dict) are unaffected.
+  (Audit F-5.3.)
+- **VelesQL query planner is available without the `persistence` feature.**
+  `velesql::{planner, explain, cost_estimator, query_stats}` no longer require
+  `persistence`; they and their `collection::{stats, query_cost}` /
+  `match_planner` dependencies now compile with `--no-default-features`, so
+  no-persistence builds (the WASM path) can reach the core planner instead of
+  reimplementing it. The persistence build is unchanged. (Audit P1.4.)
+
+### Changed
+
+- **`AnyCollection::into_vector_unchecked` (`unsafe`) → `into_vector_facade`
+  (safe).** The method was never memory-unsafe — its body is a plain value move
+  between three newtypes that wrap the identical inner `Collection` — so the
+  `unsafe` marker (which flagged a *logical* contract) has been removed. The two
+  internal Python call-sites drop their `unsafe {}` blocks; the real contract is
+  still enforced by the captured `CollectionKind` + `Collection::ensure_vector`.
+  Removes the workspace's last logically-unsound `unsafe`. *Migration:* if you
+  called `into_vector_unchecked` directly, rename to `into_vector_facade` and
+  drop the `unsafe` block (no behavior change). (Audit P0.)
+- **Uniform `AnyCollection` dispatch** via a single private `inner()` accessor —
+  the shared, identical-across-kinds methods no longer mix `c.method()` /
+  `c.inner.method()` forwarding. No behavior change. (Audit P2.6.)
+- **`column_store` deletion state unified on `RoaringBitmap`.** Removed the
+  redundant parallel `deleted_rows` FxHashSet tombstone set; the bitmap is now the
+  single source of truth. (Audit F-2.11.)
+- **Quality-gate coverage extended.** `scripts/check_prod_unwraps.py` now scans
+  every production crate (adds `velesdb-memory`, `velesdb-node`, `velesdb-python`)
+  and recognizes composite test gates like `#[cfg(all(test, feature = "…"))]`;
+  the CI `Verify SAFETY template` job now validates unsafe blocks in **all**
+  crates, not just `velesdb-core`. (Audit F-3.10 / F-3.11 / F-3.12.)
+
+### Fixed
+
+- Encapsulated `MmapStorage`'s `pub(super)` fields behind accessors and removed
+  dead `simd_native` re-exports. (Audit P3.11 / P3.13.)
+- Completed the SAFETY template on the Python binding's unsafe block
+  (Audit F-3.2) — now superseded by the `into_vector_facade` removal above.
+
+### Documentation
+
+- Clarified `Point::is_metadata_only` semantics (P2.7), disambiguated
+  `SearchMode::Perfect` (bruteforce engine) from `SearchQuality::Perfect` (HNSW
+  graph effort) (P2.9), and documented the planner strategy realization on SELECT
+  (F-2.15), the indexed-metadata scan fallback (F-4.7), read-path-gate ecosystem
+  parity (F-5.4), and the per-function NLOC governance model (F-5.13).
+- Refreshed the `docs/ARCHITECTURE.md` F2.2 tech-debt entry to reflect the safe
+  `into_vector_facade` and link the `Collection` split EPIC (#1384). (P2.10.)
+
 ## [3.10.0] — 2026-07-14
 
 Delivery release: closes the P0 flagged by the 7-auditor review — the OSS

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5669,7 +5669,7 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-velesdb"
-version = "3.10.0"
+version = "3.11.0"
 dependencies = [
  "dirs",
  "parking_lot",
@@ -6668,7 +6668,7 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "velesdb-cli"
-version = "3.10.0"
+version = "3.11.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -6693,7 +6693,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-core"
-version = "3.10.0"
+version = "3.11.0"
 dependencies = [
  "arc-swap",
  "bytemuck",
@@ -6760,7 +6760,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-migrate"
-version = "3.10.0"
+version = "3.11.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6787,7 +6787,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-mobile"
-version = "3.10.0"
+version = "3.11.0"
 dependencies = [
  "parking_lot",
  "serde",
@@ -6813,7 +6813,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-python"
-version = "3.10.0"
+version = "3.11.0"
 dependencies = [
  "numpy",
  "parking_lot",
@@ -6827,7 +6827,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-server"
-version = "3.10.0"
+version = "3.11.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -6859,7 +6859,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-wasm"
-version = "3.10.0"
+version = "3.11.0"
 dependencies = [
  "getrandom 0.3.4",
  "getrandom 0.4.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "3.10.0"
+version = "3.11.0"
 edition = "2021"
 rust-version = "1.89"
 license-file = "LICENSE"
@@ -79,7 +79,7 @@ base64 = "0.22"
 smallvec = { version = "1", features = ["serde"] }
 
 # Internal workspace crates
-velesdb-core = { path = "crates/velesdb-core", version = "3.10.0", default-features = false }
+velesdb-core = { path = "crates/velesdb-core", version = "3.11.0", default-features = false }
 
 [profile.release]
 lto = true

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM rust:1.96-bookworm AS builder
 
 LABEL maintainer="VelesDB Team <contact@wiscale.fr>"
-LABEL version="3.10.0"
+LABEL version="3.11.0"
 
 WORKDIR /app
 
@@ -25,7 +25,7 @@ RUN cargo build --release --bin velesdb-server
 FROM debian:bookworm-slim
 
 LABEL maintainer="VelesDB Team <contact@wiscale.fr>"
-LABEL version="3.10.0"
+LABEL version="3.11.0"
 
 WORKDIR /app
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,7 +4,7 @@ This roadmap commits to **what we are building**, **why**, and **when**. It is u
 
 It is intentionally narrow. Items not on this roadmap are tracked as `roadmap` issues but **not committed** until they reach a milestone here.
 
-> **Last updated:** 2026-06-21 — covers v3.10.0 (current). The horizon framing below predates the v2.0→v3.x line and is being re-baselined.
+> **Last updated:** 2026-06-21 — covers v3.11.0 (current). The horizon framing below predates the v2.0→v3.x line and is being re-baselined.
 
 ---
 

--- a/benchmarks/Dockerfile.bench
+++ b/benchmarks/Dockerfile.bench
@@ -6,7 +6,7 @@
 FROM debian:bookworm-slim
 
 LABEL maintainer="VelesDB Team <contact@wiscale.fr>"
-LABEL version="3.10.0"
+LABEL version="3.11.0"
 
 WORKDIR /app
 

--- a/benchmarks/Dockerfile.nightly
+++ b/benchmarks/Dockerfile.nightly
@@ -4,7 +4,7 @@
 FROM rust:slim-bookworm AS builder
 
 LABEL maintainer="VelesDB Team <contact@wiscale.fr>"
-LABEL version="3.10.0"
+LABEL version="3.11.0"
 
 WORKDIR /app
 
@@ -29,7 +29,7 @@ RUN cargo build --release --bin velesdb-server
 FROM debian:bookworm-slim
 
 LABEL maintainer="VelesDB Team <contact@wiscale.fr>"
-LABEL version="3.10.0"
+LABEL version="3.11.0"
 
 WORKDIR /app
 

--- a/benchmarks/Dockerfile.optimized
+++ b/benchmarks/Dockerfile.optimized
@@ -7,7 +7,7 @@
 FROM rust:slim-bookworm AS builder
 
 LABEL maintainer="VelesDB Team <contact@wiscale.fr>"
-LABEL version="3.10.0"
+LABEL version="3.11.0"
 
 WORKDIR /app
 
@@ -49,7 +49,7 @@ RUN cargo build --release --bin velesdb-server \
 FROM debian:bookworm-slim
 
 LABEL maintainer="VelesDB Team <contact@wiscale.fr>"
-LABEL version="3.10.0"
+LABEL version="3.11.0"
 
 WORKDIR /app
 

--- a/crates/tauri-plugin-velesdb/guest-js/package.json
+++ b/crates/tauri-plugin-velesdb/guest-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wiscale/tauri-plugin-velesdb",
-  "version": "3.10.0",
+  "version": "3.11.0",
   "description": "TypeScript bindings for the VelesDB Tauri plugin - Vector search in desktop apps",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/crates/velesdb-python/README.md
+++ b/crates/velesdb-python/README.md
@@ -3,7 +3,7 @@
 [![PyPI](https://img.shields.io/pypi/v/velesdb)](https://pypi.org/project/velesdb/)
 [![Python](https://img.shields.io/pypi/pyversions/velesdb)](https://pypi.org/project/velesdb/)
 [![License](https://img.shields.io/badge/license-VelesDB_Core_1.0-blue)](./LICENSE)
-[![Version](https://img.shields.io/badge/version-3.10.0-blue)](https://github.com/cyberlife-coder/VelesDB/releases)
+[![Version](https://img.shields.io/badge/version-3.11.0-blue)](https://github.com/cyberlife-coder/VelesDB/releases)
 
 Python bindings for [VelesDB](https://github.com/cyberlife-coder/VelesDB) — a high-performance vector database for AI applications. `numpy>=1.20` ships as a hard runtime dependency since v1.13.8, so a single `pip install velesdb` is sufficient.
 

--- a/crates/velesdb-python/pyproject.toml
+++ b/crates/velesdb-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "velesdb"
-version = "3.10.0"
+version = "3.11.0"
 description = "VelesDB: The Local Vector Database for Python & AI. Microsecond semantic search, zero network latency."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/crates/velesdb-server/README.md
+++ b/crates/velesdb-server/README.md
@@ -659,7 +659,7 @@ curl http://localhost:8080/health
 Response:
 
 ```json
-{"status": "ok", "version": "3.10.0"}
+{"status": "ok", "version": "3.11.0"}
 ```
 
 ### `GET /ready` -- Readiness Probe
@@ -673,13 +673,13 @@ curl http://localhost:8080/ready
 Response (ready):
 
 ```json
-{"status": "ready", "version": "3.10.0"}
+{"status": "ready", "version": "3.11.0"}
 ```
 
 Response (not ready):
 
 ```json
-{"status": "not_ready", "version": "3.10.0"}
+{"status": "not_ready", "version": "3.11.0"}
 ```
 
 ### Kubernetes Example

--- a/demos/rag-pdf-demo/pyproject.toml
+++ b/demos/rag-pdf-demo/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "velesdb-rag-demo"
-version = "3.10.0"
+version = "3.11.0"
 description = "RAG Demo with PDF ingestion using VelesDB for vector storage"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/demos/rag-pdf-demo/src/__init__.py
+++ b/demos/rag-pdf-demo/src/__init__.py
@@ -1,3 +1,3 @@
 """VelesDB RAG Demo - PDF Question Answering System."""
 
-__version__ = "3.10.0"
+__version__ = "3.11.0"

--- a/demos/rag-pdf-demo/src/main.py
+++ b/demos/rag-pdf-demo/src/main.py
@@ -46,7 +46,7 @@ async def lifespan(app: FastAPI):
 app = FastAPI(
     title="VelesDB RAG Demo",
     description="PDF Question Answering with VelesDB vector search",
-    version="3.10.0",
+    version="3.11.0",
     lifespan=lifespan
 )
 

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -1,6 +1,6 @@
 # VelesDB Performance Benchmarks
 
-*Last updated: July 14, 2026 (VelesDB v3.10.0). Figures are re-validated at each release only when re-measured — each section carries its own measurement date and machine; this stamp tracks the document revision, not a fresh measurement.*
+*Last updated: July 14, 2026 (VelesDB v3.11.0). Figures are re-validated at each release only when re-measured — each section carries its own measurement date and machine; this stamp tracks the document revision, not a fresh measurement.*
 
 ---
 

--- a/docs/VELESQL_SPEC.md
+++ b/docs/VELESQL_SPEC.md
@@ -2,7 +2,7 @@
 
 > SQL-like query language for vector + graph + column-store search in VelesDB.
 
-**Version**: 3.10.0 | **Last Updated**: 2026-07-14 (VelesDB v3.10.0)
+**Version**: 3.10.0 | **Last Updated**: 2026-07-14 (VelesDB v3.11.0)
 
 ---
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -96,7 +96,7 @@ Expected response:
 ```json
 {
   "status": "ok",
-  "version": "3.10.0"
+  "version": "3.11.0"
 }
 ```
 

--- a/docs/guides/CLI_REPL.md
+++ b/docs/guides/CLI_REPL.md
@@ -1,6 +1,6 @@
 # 💻 CLI & REPL Reference
 
-*Version 3.10.0 — 2026-06-12*
+*Version 3.11.0 — 2026-06-12*
 
 Complete guide to the VelesDB command-line interface and the interactive REPL.
 
@@ -36,7 +36,7 @@ cargo build --release -p velesdb-cli
 
 ```bash
 velesdb --version
-# velesdb 3.10.0
+# velesdb 3.11.0
 ```
 
 ---
@@ -269,7 +269,7 @@ velesdb> \info
 ┌─────────────────────┬────────────────────┐
 │ Property            │ Value              │
 ├─────────────────────┼────────────────────┤
-│ Version             │ 3.10.0              │
+│ Version             │ 3.11.0              │
 │ Data directory      │ ./data             │
 │ Collections         │ 3                  │
 │ Total vectors       │ 125,000            │
@@ -342,7 +342,7 @@ Session settings are **not persisted** across REPL sessions. To persist them, us
 ```
 $ velesdb repl ./my_db
 
-VelesDB v3.10.0 - Interactive REPL
+VelesDB v3.11.0 - Interactive REPL
 Type \help for help, \quit to exit.
 
 velesdb> \show

--- a/docs/guides/CONFIGURATION.md
+++ b/docs/guides/CONFIGURATION.md
@@ -1,6 +1,6 @@
 # ⚙️ VelesDB Configuration
 
-*Version 3.10.0 — May 2026*
+*Version 3.11.0 — May 2026*
 
 Complete guide for configuring VelesDB via configuration file, environment variables, and runtime parameters.
 
@@ -62,7 +62,7 @@ data_dir = "./data"
 ```toml
 # =============================================================================
 # VelesDB Configuration File
-# Version: 3.10.0
+# Version: 3.11.0
 # =============================================================================
 
 # -----------------------------------------------------------------------------

--- a/docs/guides/GRAPH_PATTERNS.md
+++ b/docs/guides/GRAPH_PATTERNS.md
@@ -1,6 +1,6 @@
 # Graph Patterns Guide
 
-*Version 3.10.0 -- May 2026*
+*Version 3.11.0 -- May 2026*
 
 Practical guide for using VelesQL `MATCH` graph patterns in VelesDB.
 

--- a/docs/guides/INSTALLATION.md
+++ b/docs/guides/INSTALLATION.md
@@ -60,10 +60,10 @@ entry.
 
 ```bash
 # Download
-wget https://github.com/cyberlife-coder/VelesDB/releases/download/v3.10.0/velesdb-3.10.0-amd64.deb
+wget https://github.com/cyberlife-coder/VelesDB/releases/download/v3.11.0/velesdb-3.11.0-amd64.deb
 
 # Install
-sudo dpkg -i velesdb-3.10.0-amd64.deb
+sudo dpkg -i velesdb-3.11.0-amd64.deb
 
 # Verify
 velesdb --version
@@ -160,13 +160,13 @@ GitHub Container Registry, so you don't need to build locally:
 
 ```bash
 # Pull a specific release (recommended for reproducibility)
-docker pull ghcr.io/cyberlife-coder/velesdb:3.10.0
+docker pull ghcr.io/cyberlife-coder/velesdb:3.11.0
 
 # ...or the latest stable release
 docker pull ghcr.io/cyberlife-coder/velesdb:latest
 
 docker run -d --name velesdb -p 8080:8080 -v velesdb_data:/data \
-  ghcr.io/cyberlife-coder/velesdb:3.10.0
+  ghcr.io/cyberlife-coder/velesdb:3.11.0
 ```
 
 ### Build locally

--- a/docs/guides/SEARCH_MODES.md
+++ b/docs/guides/SEARCH_MODES.md
@@ -1,6 +1,6 @@
 # 🎯 Search Modes - Recall Configuration Guide
 
-*Version 3.10.0 -- 2026-06-12*
+*Version 3.11.0 -- 2026-06-12*
 
 Complete guide to configuring the **recall vs latency** trade-off in VelesDB. Covers dense search (HNSW), sparse search (SPLADE/BM42), and hybrid search (dense+sparse with fusion). Includes a comparison with Milvus, OpenSearch, and Qdrant practices.
 

--- a/docs/guides/SERVER_SECURITY.md
+++ b/docs/guides/SERVER_SECURITY.md
@@ -299,7 +299,7 @@ curl http://localhost:8080/health
 ```json
 {
   "status": "ok",
-  "version": "3.10.0"
+  "version": "3.11.0"
 }
 ```
 
@@ -318,7 +318,7 @@ curl http://localhost:8080/ready
 ```json
 {
   "status": "ready",
-  "version": "3.10.0"
+  "version": "3.11.0"
 }
 ```
 
@@ -327,7 +327,7 @@ curl http://localhost:8080/ready
 ```json
 {
   "status": "not_ready",
-  "version": "3.10.0"
+  "version": "3.11.0"
 }
 ```
 

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -11,7 +11,7 @@
       "name": "VelesDB Core License 1.0",
       "url": "https://github.com/cyberlife-coder/VelesDB/blob/main/LICENSE"
     },
-    "version": "3.10.0"
+    "version": "3.11.0"
   },
   "servers": [
     {

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -8,7 +8,7 @@ info:
   license:
     name: VelesDB Core License 1.0
     url: https://github.com/cyberlife-coder/VelesDB/blob/main/LICENSE
-  version: 3.10.0
+  version: 3.11.0
 servers:
 - url: /
   description: Local server

--- a/docs/reference/ARCHITECTURE_DIAGRAMS.md
+++ b/docs/reference/ARCHITECTURE_DIAGRAMS.md
@@ -1,4 +1,4 @@
-# VelesDB Architecture Diagrams — v3.10.0
+# VelesDB Architecture Diagrams — v3.11.0
 
 ## 1. Workspace Dependency Graph
 

--- a/docs/reference/ECOSYSTEM_PARITY.md
+++ b/docs/reference/ECOSYSTEM_PARITY.md
@@ -1,6 +1,6 @@
 # VelesQL Ecosystem Parity Matrix
 
-Last updated: 2026-07-14 (v3.10.0; velesdb-memory 0.7.0)
+Last updated: 2026-07-14 (v3.11.0; velesdb-memory 0.7.0)
 
 This matrix tracks runtime contract and feature parity across the VelesDB ecosystem.
 

--- a/docs/reference/VELESQL_CHEATSHEET.md
+++ b/docs/reference/VELESQL_CHEATSHEET.md
@@ -1,7 +1,7 @@
 # VelesQL Cheat Sheet
 
 > **Date:** 2026-06-03
-> **VelesDB version:** 3.10.0
+> **VelesDB version:** 3.11.0
 > See the full specification in [`docs/VELESQL_SPEC.md`](../VELESQL_SPEC.md).
 
 > Every `sql` block below is **parsed** against the real grammar by an automated

--- a/docs/reference/VELESQL_CONFORMANCE_MATRIX.md
+++ b/docs/reference/VELESQL_CONFORMANCE_MATRIX.md
@@ -4,7 +4,7 @@ This document lists every VelesQL feature with its parser and executor status.
 A feature can be **Parsed** (the grammar + AST accept it) without being
 **Executed** (the query engine acts on it at runtime).
 
-> Last updated: 2026-07-14 (VelesDB v3.10.0)
+> Last updated: 2026-07-14 (VelesDB v3.11.0)
 
 ## Fully Supported (Parsed AND Executed)
 

--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -57,7 +57,7 @@ Check server health status.
 ```json
 {
   "status": "ok",
-  "version": "3.10.0"
+  "version": "3.11.0"
 }
 ```
 

--- a/examples/wasm-browser-demo/README.md
+++ b/examples/wasm-browser-demo/README.md
@@ -22,7 +22,7 @@ cd crates/velesdb-wasm
 wasm-pack build --target web --out-dir ../../examples/wasm-browser-demo/pkg
 
 # Then update index.html to use the local path instead of CDN:
-# Change: import init from 'https://unpkg.com/@wiscale/velesdb-wasm@3.10.0/velesdb_wasm.js'
+# Change: import init from 'https://unpkg.com/@wiscale/velesdb-wasm@3.11.0/velesdb_wasm.js'
 # To:     import init from './pkg/velesdb_wasm.js'
 ```
 
@@ -80,7 +80,7 @@ Typical results on modern hardware:
 ```html
 <script type="module">
   // If published on npm:
-  // import init, { VectorStore } from 'https://unpkg.com/@wiscale/velesdb-wasm@3.10.0/velesdb_wasm.js';
+  // import init, { VectorStore } from 'https://unpkg.com/@wiscale/velesdb-wasm@3.11.0/velesdb_wasm.js';
   // If built locally with wasm-pack:
   import init, { VectorStore } from './pkg/velesdb_wasm.js';
 

--- a/examples/wasm-browser-demo/index.html
+++ b/examples/wasm-browser-demo/index.html
@@ -171,8 +171,8 @@
         // WASM module - tracks @wiscale/velesdb-wasm@<workspace> with CDN fallback.
         // Bumped by scripts/bump-version.ps1 on every release; if you copy this
         // demo, update the version below to match `@wiscale/velesdb-wasm` on npm.
-        const WASM_CDN_PRIMARY = 'https://unpkg.com/@wiscale/velesdb-wasm@3.10.0/velesdb_wasm.js';
-        const WASM_CDN_FALLBACK = 'https://cdn.jsdelivr.net/npm/@wiscale/velesdb-wasm@3.10.0/velesdb_wasm.js';
+        const WASM_CDN_PRIMARY = 'https://unpkg.com/@wiscale/velesdb-wasm@3.11.0/velesdb_wasm.js';
+        const WASM_CDN_FALLBACK = 'https://cdn.jsdelivr.net/npm/@wiscale/velesdb-wasm@3.11.0/velesdb_wasm.js';
         
         let init, VectorStore;
         

--- a/integrations/common/pyproject.toml
+++ b/integrations/common/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "velesdb-common"
-version = "3.10.0"
+version = "3.11.0"
 description = "Shared utilities for VelesDB Python integrations (internal use)"
 readme = "README.md"
 license = {text = "MIT"}

--- a/integrations/haystack/pyproject.toml
+++ b/integrations/haystack/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "haystack-velesdb"
-version = "3.10.0"
+version = "3.11.0"
 description = "Haystack 2.x DocumentStore for VelesDB: The Local AI Memory Database."
 readme = "README.md"
 license = {text = "MIT"}

--- a/integrations/haystack/src/haystack_velesdb/__init__.py
+++ b/integrations/haystack/src/haystack_velesdb/__init__.py
@@ -4,4 +4,4 @@ from haystack_velesdb.document_store import VelesDBDocumentStore
 from haystack_velesdb.retriever import VelesDBEmbeddingRetriever
 
 __all__ = ["VelesDBDocumentStore", "VelesDBEmbeddingRetriever"]
-__version__ = "3.10.0"
+__version__ = "3.11.0"

--- a/integrations/langchain/pyproject.toml
+++ b/integrations/langchain/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "langchain-velesdb"
-version = "3.10.0"
+version = "3.11.0"
 description = "LangChain VectorStore for VelesDB: The Local AI Memory Database. Microsecond RAG retrieval."
 readme = "README.md"
 license = {text = "MIT"}

--- a/integrations/langchain/src/langchain_velesdb/__init__.py
+++ b/integrations/langchain/src/langchain_velesdb/__init__.py
@@ -53,4 +53,4 @@ if _HAS_MEMORY:
         "VelesDBSemanticMemory",
         "VelesDBProceduralMemory",
     ])
-__version__ = "3.10.0"
+__version__ = "3.11.0"

--- a/integrations/langgraph/pyproject.toml
+++ b/integrations/langgraph/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "langgraph-velesdb"
-version = "3.10.0"
+version = "3.11.0"
 description = "LangGraph memory tools for VelesDB: drop the why() knowledge-graph memory wedge into any LangGraph agent."
 readme = "README.md"
 license = {text = "MIT"}

--- a/integrations/langgraph/src/langgraph_velesdb/__init__.py
+++ b/integrations/langgraph/src/langgraph_velesdb/__init__.py
@@ -16,4 +16,4 @@ across agent runs.
 from langgraph_velesdb.tools import make_memory_tools
 
 __all__ = ["make_memory_tools"]
-__version__ = "3.10.0"
+__version__ = "3.11.0"

--- a/integrations/llamaindex/pyproject.toml
+++ b/integrations/llamaindex/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "llama-index-vector-stores-velesdb"
-version = "3.10.0"
+version = "3.11.0"
 description = "LlamaIndex VectorStore for VelesDB: The Local AI Memory Database. Microsecond RAG retrieval."
 readme = "README.md"
 license = "MIT"

--- a/integrations/llamaindex/src/llamaindex_velesdb/__init__.py
+++ b/integrations/llamaindex/src/llamaindex_velesdb/__init__.py
@@ -57,4 +57,4 @@ if _HAS_MEMORY:
         "VelesDBChatMemory",
         "VelesDBProceduralMemory",
     ])
-__version__ = "3.10.0"
+__version__ = "3.11.0"

--- a/scripts/dx-timing/scenario_rust.sh
+++ b/scripts/dx-timing/scenario_rust.sh
@@ -41,7 +41,7 @@ RS
 # Pin to the latest released version on crates.io. Bump alongside each
 # workspace release; the timing measurement is meant to track the path a
 # fresh dev hits when they `cargo add velesdb-core` today.
-cargo add --quiet velesdb-core@3.10.0
+cargo add --quiet velesdb-core@3.11.0
 cargo add --quiet serde_json@1
 cargo run --quiet --release
 

--- a/scripts/dx-timing/scenario_server.sh
+++ b/scripts/dx-timing/scenario_server.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 
 START=$(date +%s.%N)
 
-cargo install --quiet --locked velesdb-server@3.10.0
+cargo install --quiet --locked velesdb-server@3.11.0
 
 DATA_DIR=$(mktemp -d -t velesdb_dx_server_XXXX)
 trap 'rm -rf "$DATA_DIR"' EXIT

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -2,7 +2,7 @@
 
 Official TypeScript SDK for [VelesDB](https://github.com/cyberlife-coder/VelesDB) -- the local-first vector database for AI and RAG. Sub-millisecond semantic search in Browser and Node.js.
 
-**v3.10.0** | Node.js >= 18 | Browser (WASM) | VelesDB Core License 1.0
+**v3.11.0** | Node.js >= 18 | Browser (WASM) | VelesDB Core License 1.0
 
 ## What's New in v3.6.0
 

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wiscale/velesdb-sdk",
-  "version": "3.10.0",
+  "version": "3.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wiscale/velesdb-sdk",
-      "version": "3.10.0",
+      "version": "3.11.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@wiscale/velesdb-wasm": "^3.8.0"

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wiscale/velesdb-sdk",
-  "version": "3.10.0",
+  "version": "3.11.0",
   "description": "VelesDB TypeScript SDK: The Local Vector Database for AI & RAG. Microsecond semantic search in Browser & Node.js.",
   "main": "dist/index.js",
   "module": "dist/index.mjs",


### PR DESCRIPTION
Release prep for **3.11.0**, bundling the resolution of the line-by-line `velesdb-core` audit (plan 61b5e8). Prep PR into `develop` (mirrors the 3.10.0 flow); a `develop → main` PR follows.

## Version
`3.10.0 → 3.11.0` (minor). Per this project's convention (removals/changes ship in minors — see 3.9.0's `### Removed`): adds the opt-in `observer_strict` feature + the no-persistence planner (P1.4), with the `into_vector_unchecked → into_vector_facade` rename documented as an internal-API migration. `velesdb-memory`/`velesdb-node` stay at `0.7.0`.

## Mechanics (project tooling)
- `scripts/bump_version.py 3.11.0 2026-07-14` → 62 policed manifests.
- OpenAPI regenerated — diff is **version-only**, no drift.
- `Cargo.lock` refreshed; CHANGELOG `3.11.0` section added.

## Validation (local)
- `check-version-sync.py` → All versions match · `check-feature-claims.py` → PASSED · `check-perf-claims.py --no-criterion` → PASSED.
- Re-challenge on develop already green: prod-unwrap scan PASS (all crates), SAFETY 0 violations, `velesdb-python` unsafe count 0, 5266 (persistence) + 2172 (no-default-features) tests pass.

Contents = the 9 merged audit PRs (#1376–#1383, #1385). P1.3 god-object split deferred → EPIC #1384.

_Note: the local jscpd pre-push hook flags pre-existing duplication in `filter_geo.rs` (an existing `.codacy.yml` lizard exclusion) and the legacy Python compat adapters — neither is touched by this version-bump commit; PR-level Codacy already accepted them on their source PRs._