### PR TITLE
fix(storage): recover CRC WAL with corrupt first record + fsync data-file growth before index persist

### DIFF
--- a/crates/velesdb-core/src/storage/mmap.rs
+++ b/crates/velesdb-core/src/storage/mmap.rs
@@ -425,8 +425,20 @@ impl MmapStorage {
             &mut touched_ids,
         )?;
         if replayed > 0 {
-            // 1. Make the recovered vector bytes durable.
+            // 1. Make the recovered vector bytes durable (msync of dirty pages).
             mmap.flush()?;
+            // 1b. fsync the data file so any file GROWTH performed during replay
+            //     (ReplayTarget::ensure_capacity -> set_len) is durably recorded
+            //     BEFORE we persist the index (whose offsets reference the grown
+            //     region) and truncate the WAL. `msync` flushes page contents but
+            //     does not guarantee the inode size is journaled; on such a
+            //     filesystem a crash after the WAL truncation could leave the data
+            //     file at its pre-growth length while vectors.idx points past EOF
+            //     -> next open, load_index rejects "offset exceeds data file size"
+            //     and open fails with the WAL already gone. Ordering the sync here
+            //     closes that window; the WAL is only cleared once both the data
+            //     file (size + bytes) and the index are durable.
+            data_file.sync_all()?;
             // 2. Persist the rebuilt index so the recovered state survives even
             //    after the WAL is cleared.
             Self::persist_index_file(index_path, index)?;

--- a/crates/velesdb-core/src/storage/mmap/wal_replay.rs
+++ b/crates/velesdb-core/src/storage/mmap/wal_replay.rs
@@ -13,9 +13,13 @@
 //!
 //! # Legacy WAL Format (pre-#317, no CRC)
 //!
-//! Detected by validating the CRC of the first entry. If validation fails,
-//! the file is legacy format and replay is skipped (the persisted index is
-//! authoritative for legacy data).
+//! Distinguished from CRC-framed by scanning for at least one CRC-valid record
+//! (see [`is_crc_framed_wal`]). A file with no CRC-valid record anywhere is
+//! treated as legacy and replay is skipped (the persisted index is
+//! authoritative for legacy data). Keying detection off the FIRST record alone
+//! used to discard the ENTIRE WAL when only that record was corrupt — losing
+//! every valid write behind it — even though the writer always emits CRC frames
+//! (#317), so a "legacy-looking" first record is really a damaged recent write.
 //!
 //! # Corruption policy (#898)
 //!
@@ -203,6 +207,21 @@ fn drain_wal_entries(
 // ---------------------------------------------------------------------------
 
 /// Returns `true` if the WAL uses CRC32-framed entries.
+///
+/// Scans records forward as CRC frames and returns `true` as soon as ANY record
+/// validates its CRC. A genuine legacy (pre-#317) WAL carries no CRC, so —
+/// barring a ~2^-32 spurious collision — no record validates and it is correctly
+/// classified as legacy.
+///
+/// This deliberately does NOT key off the first record alone. The writer always
+/// emits CRC frames (#317), so a first record that fails its CRC is a damaged
+/// recent write, not a legacy file. Classifying such a file as legacy discarded
+/// the whole WAL — and every valid record behind the damaged one — silently.
+/// With a forward scan, that file is detected as CRC-framed and the drain path
+/// handles the damaged record as mid-stream corruption (skip + metric + warn +
+/// continue), recovering the later valid records. A file whose only records are
+/// corrupt/torn still yields `false` (nothing valid to recover), matching the
+/// prior legacy-skip behavior.
 fn is_crc_framed_wal(wal_path: &Path, file_len: u64) -> io::Result<bool> {
     let min_size = MIN_STORE_ENTRY.min(DELETE_ENTRY_SIZE);
     if file_len < min_size {
@@ -210,65 +229,38 @@ fn is_crc_framed_wal(wal_path: &Path, file_len: u64) -> io::Result<bool> {
     }
 
     let mut reader = BufReader::new(File::open(wal_path)?);
-    let mut op = [0u8; 1];
-    // Skip leading legacy compaction markers (bare 0x04 bytes) so a WAL whose
-    // first real record sits behind a marker is still detected as CRC-framed.
     loop {
+        if reader.stream_position()? >= file_len {
+            return Ok(false);
+        }
+
+        let mut op = [0u8; 1];
         if reader.read_exact(&mut op).is_err() {
             return Ok(false);
         }
-        if op[0] != 4 {
-            break;
+
+        match op[0] {
+            1 => match read_store_entry(&mut reader, file_len)? {
+                // A CRC-valid store frame proves the file is CRC-framed.
+                Some((_, _, true)) => return Ok(true),
+                // Framed but CRC-failing: possible mid-stream corruption inside a
+                // CRC-framed file — keep scanning for a valid frame behind it.
+                Some((_, _, false)) => {}
+                // Torn/short tail with nothing validated before it: not CRC.
+                None => return Ok(false),
+            },
+            2 => match read_delete_entry(&mut reader, file_len)? {
+                Some((_, true)) => return Ok(true),
+                Some((_, false)) => {}
+                None => return Ok(false),
+            },
+            // Bare legacy compaction marker (no payload): skip and keep scanning
+            // so a WAL whose first real record sits behind a marker is detected.
+            4 => {}
+            // Unknown opcode: this is not a CRC-framed record boundary.
+            _ => return Ok(false),
         }
     }
-
-    match op[0] {
-        1 => validate_first_store_crc(&mut reader, file_len),
-        2 => Ok(validate_first_delete_crc(&mut reader)),
-        _ => Ok(false),
-    }
-}
-
-/// Validates the CRC of the first store entry.
-fn validate_first_store_crc(reader: &mut BufReader<File>, file_len: u64) -> io::Result<bool> {
-    let mut id_bytes = [0u8; 8];
-    let mut len_bytes = [0u8; 4];
-    if reader.read_exact(&mut id_bytes).is_err() || reader.read_exact(&mut len_bytes).is_err() {
-        return Ok(false);
-    }
-
-    // OOM guard (#897/#898): cap the declared length against the bytes that can
-    // actually follow in the file before allocating.
-    let Some(data_len) = checked_store_data_len(len_bytes, reader, file_len)? else {
-        return Ok(false);
-    };
-
-    let mut data = vec![0u8; data_len];
-    if reader.read_exact(&mut data).is_err() {
-        return Ok(false);
-    }
-
-    let mut stored_crc = [0u8; 4];
-    if reader.read_exact(&mut stored_crc).is_err() {
-        return Ok(false);
-    }
-
-    Ok(store_crc_matches(id_bytes, len_bytes, &data, stored_crc))
-}
-
-/// Validates the CRC of the first delete entry.
-fn validate_first_delete_crc(reader: &mut BufReader<File>) -> bool {
-    let mut id_bytes = [0u8; 8];
-    if reader.read_exact(&mut id_bytes).is_err() {
-        return false;
-    }
-
-    let mut stored_crc = [0u8; 4];
-    if reader.read_exact(&mut stored_crc).is_err() {
-        return false;
-    }
-
-    delete_frame_crc(id_bytes) == u32::from_le_bytes(stored_crc)
 }
 
 // ---------------------------------------------------------------------------
@@ -356,6 +348,33 @@ fn read_store_entry(
 
     let crc_ok = store_crc_matches(id_bytes, len_bytes, &data, stored_crc);
     Ok(Some((u64::from_le_bytes(id_bytes), data, crc_ok)))
+}
+
+/// Reads a delete entry (`op=2` already consumed), returning `None` for a torn
+/// tail (fewer than `id(8) + crc(4)` bytes remain) and `Some((id, crc_ok))` for
+/// a fully-framed record. Mirrors [`read_store_entry`] so both the format
+/// detection scan and [`replay_delete`] share one framing path.
+fn read_delete_entry(
+    reader: &mut BufReader<File>,
+    file_len: u64,
+) -> io::Result<Option<(u64, bool)>> {
+    let pos = reader.stream_position()?;
+    if file_len.saturating_sub(pos) < 8 + 4 {
+        return Ok(None);
+    }
+
+    let mut id_bytes = [0u8; 8];
+    if reader.read_exact(&mut id_bytes).is_err() {
+        return Ok(None);
+    }
+
+    let mut stored_crc = [0u8; 4];
+    if reader.read_exact(&mut stored_crc).is_err() {
+        return Ok(None);
+    }
+
+    let crc_ok = delete_frame_crc(id_bytes) == u32::from_le_bytes(stored_crc);
+    Ok(Some((u64::from_le_bytes(id_bytes), crc_ok)))
 }
 
 /// Validates a store entry's declared payload length against the bytes that can
@@ -494,23 +513,12 @@ fn replay_delete(
     touched_ids: &mut Vec<u64>,
 ) -> io::Result<EntryOutcome> {
     // op(1) already consumed; a delete needs id(8) + crc(4) to follow.
-    let pos = reader.stream_position()?;
-    if file_len.saturating_sub(pos) < 8 + 4 {
+    let Some((id, crc_ok)) = read_delete_entry(reader, file_len)? else {
+        // Torn tail: stop cleanly, keeping prior entries.
         return Ok(EntryOutcome::Stop);
-    }
+    };
 
-    let mut id_bytes = [0u8; 8];
-    if reader.read_exact(&mut id_bytes).is_err() {
-        return Ok(EntryOutcome::Stop);
-    }
-
-    let mut stored_crc = [0u8; 4];
-    if reader.read_exact(&mut stored_crc).is_err() {
-        return Ok(EntryOutcome::Stop);
-    }
-
-    if delete_frame_crc(id_bytes) == u32::from_le_bytes(stored_crc) {
-        let id = u64::from_le_bytes(id_bytes);
+    if crc_ok {
         index.remove(id);
         touched_ids.push(id);
         return Ok(EntryOutcome::Applied);

--- a/crates/velesdb-core/src/storage/mmap_capacity.rs
+++ b/crates/velesdb-core/src/storage/mmap_capacity.rs
@@ -38,6 +38,16 @@ impl MmapStorage {
 
             self.data_file.set_len(new_len)?;
 
+            // No `data_file.sync_all()` here (unlike the replay growth path in
+            // `replay_wal`): live growth is protected by the WAL. A store writes
+            // (and, under Fsync, syncs) its record to the WAL *before* reaching
+            // here, and the WAL is not truncated during normal operation. So a
+            // crash that loses this `set_len` growth is recovered on reopen by
+            // replaying the WAL, which re-grows the file. The acute case — where
+            // the index is persisted against grown offsets AND the WAL is then
+            // cleared, removing the recovery source — happens only in the replay
+            // and compaction paths, which fsync the data file explicitly.
+
             // SAFETY: data_file has been resized with set_len(new_len) above,
             // ensuring the new mapping range is fully allocated.
             // - Condition 1: File was resized to new_len before remapping.

--- a/crates/velesdb-core/src/storage/storage_reliability_tests.rs
+++ b/crates/velesdb-core/src/storage/storage_reliability_tests.rs
@@ -542,6 +542,106 @@ fn test_898_replay_grows_mmap_no_silent_gap() {
 }
 
 #[test]
+// Reads/writes the process-global corrupt-entry metric; serialize with the rest
+// of the metric-asserting group.
+#[serial(wal_corrupt_metric)]
+fn test_replay_corrupt_first_record_recovers_following_entries() {
+    // Regression: a CRC-framed WAL whose FIRST record is corrupt must NOT be
+    // misclassified as legacy (which silently discarded the ENTIRE WAL). Format
+    // detection now scans for any CRC-valid record, so the corrupt first record
+    // is treated as mid-stream corruption (skip + metric) and every valid record
+    // behind it is still recovered.
+    let dir = tempdir().unwrap();
+    let path = dir.path().to_path_buf();
+    let dim = 3;
+
+    // First record: fully framed but with a broken CRC.
+    let mut bad = crc_store_entry(1, &vec3_bytes([1.0, 2.0, 3.0]));
+    let last = bad.len() - 1;
+    bad[last] ^= 0xFF;
+
+    let mut wal = bad;
+    wal.extend_from_slice(&crc_store_entry(2, &vec3_bytes([4.0, 5.0, 6.0])));
+    wal.extend_from_slice(&crc_store_entry(3, &vec3_bytes([7.0, 8.0, 9.0])));
+    std::fs::write(path.join("vectors.wal"), &wal).unwrap();
+
+    let before = crate::metrics::global_guardrails_metrics()
+        .wal_replay_corrupt_entries
+        .load(std::sync::atomic::Ordering::Relaxed);
+
+    let storage = MmapStorage::new(&path, dim).unwrap();
+    assert!(
+        storage.retrieve(1).unwrap().is_none(),
+        "corrupt first record must be skipped, not applied"
+    );
+    assert_eq!(
+        storage.retrieve(2).unwrap(),
+        Some(vec![4.0, 5.0, 6.0]),
+        "records after a corrupt first record must be recovered, not discarded with the whole WAL"
+    );
+    assert_eq!(storage.retrieve(3).unwrap(), Some(vec![7.0, 8.0, 9.0]));
+
+    let after = crate::metrics::global_guardrails_metrics()
+        .wal_replay_corrupt_entries
+        .load(std::sync::atomic::Ordering::Relaxed);
+    assert!(
+        after > before,
+        "a corrupt first record must be counted as mid-stream corruption"
+    );
+}
+
+#[test]
+fn test_replay_growth_persists_data_file_size_for_reopen() {
+    // FIX (fsync ordering): after a replay that GROWS the data file, the grown
+    // size and rebuilt index must be mutually consistent so a subsequent reopen's
+    // load_index bound check (offset <= data file size) passes. Exercises the
+    // sync_all-before-persist-index ordering added to `replay_wal`. (A true crash
+    // between truncation and data-file durability cannot be injected here without
+    // a fault harness; this guards the open -> replay+grow -> reopen round-trip.)
+    let dir = tempdir().unwrap();
+    let path = dir.path().to_path_buf();
+    let dim = 3;
+    let vec_size = dim * 4;
+
+    // Index whose highest offset is the last slot of the 16 MB initial map.
+    let near_cap = 16 * 1024 * 1024 - vec_size;
+    let mut index: FxHashMap<u64, usize> = FxHashMap::default();
+    index.insert(1, near_cap);
+    std::fs::write(
+        path.join("vectors.idx"),
+        postcard::to_allocvec(&index).unwrap(),
+    )
+    .unwrap();
+
+    let mut data = vec![0u8; 16 * 1024 * 1024];
+    data[near_cap..near_cap + vec_size].copy_from_slice(&vec3_bytes([1.0, 2.0, 3.0]));
+    std::fs::write(path.join("vectors.dat"), &data).unwrap();
+
+    // A NEW vector lands at next_offset (== 16 MB), beyond the initial mapping,
+    // forcing replay to grow the data file.
+    let wal = crc_store_entry(2, &vec3_bytes([4.0, 5.0, 6.0]));
+    std::fs::write(path.join("vectors.wal"), &wal).unwrap();
+
+    // First open replays, grows, persists the index, then truncates the WAL.
+    {
+        let storage = MmapStorage::new(&path, dim).unwrap();
+        assert_eq!(storage.retrieve(2).unwrap(), Some(vec![4.0, 5.0, 6.0]));
+        assert_eq!(
+            std::fs::metadata(path.join("vectors.wal")).unwrap().len(),
+            0,
+            "WAL truncated only after data file + index made durable"
+        );
+    }
+
+    // The persisted index now references an offset in the GROWN region; a reopen
+    // must load it without load_index rejecting the offset as past the data file,
+    // proving the grown size persisted consistently with the index.
+    let reopened = MmapStorage::new(&path, dim).unwrap();
+    assert_eq!(reopened.retrieve(1).unwrap(), Some(vec![1.0, 2.0, 3.0]));
+    assert_eq!(reopened.retrieve(2).unwrap(), Some(vec![4.0, 5.0, 6.0]));
+}
+
+#[test]
 fn test_898_load_index_rejects_out_of_bounds_offset() {
     // A corrupt index offset that points past the data file must be rejected,
     // not silently accepted (which would wrap into an OOB read later).


### PR DESCRIPTION
## Summary

Two confirmed findings in the mmap vector WAL replay path (`crates/velesdb-core/src/storage/mmap/wal_replay.rs` + `mmap.rs`). Same zone, one PR.

### FIX 1 (MED — silent data loss): corrupt first record → whole vector WAL discarded

`is_crc_framed_wal` classified the entire file as *legacy* — and skipped replay entirely, **with no metric or warning** — whenever the **first** record failed its CRC (broken CRC, or a corrupt length that made `checked_store_data_len` return `None`). `open_crc_wal` then returned `None`, `replay_wal_to_index` returned `Ok(0)`, and the WAL was left untruncated.

Because the writer **always** emits CRC frames (#317, `vector_io.rs`), there is no genuine recent legacy WAL: a "legacy-looking" first record is really a damaged recent write. So every valid record behind it was thrown away silently and lost at the next compaction (`set_len(0)`). This contradicted the module's own mid-stream corruption policy (record N>1: `record_wal_replay_corrupt_entry()` + `tracing::warn!` + continue).

**Fix:** detection now **scans records forward** and returns CRC-framed as soon as **any** record validates its CRC. The damaged first record is then handled by the existing mid-stream corruption path (skip + metric + warn + continue), recovering the later valid records. A file whose only records are corrupt/torn still yields "legacy" (nothing valid to recover), so genuine legacy WALs (no CRC anywhere, ~2⁻³² spurious-match risk) keep the prior skip behavior. Refactored `replay_delete` to share a new `read_delete_entry` framing helper with the scan.

### FIX 2 (MED — fsync ordering): data-file growth not fsynced before index persist + WAL truncate

During replay, `ReplayTarget::ensure_capacity` grew the data file via `set_len` + `mmap.flush()` (msync) but never `data_file.sync_all()`. Then `replay_wal` persisted `vectors.idx` (offsets referencing the grown region) and truncated the WAL. On a filesystem where msync does not journal the inode size, a crash after the truncation could leave the data file at its pre-growth length while `vectors.idx` points past EOF → next open, `load_index` rejects "offset exceeds data file size", open fails with the WAL already gone.

**Fix:** `data_file.sync_all()` after the mmap flush and **before** `persist_index_file` / `truncate_wal`. The **live** growth path (`mmap_capacity.rs::ensure_capacity`) is left without a sync and documented why: live growth is WAL-protected (the store's WAL record is written/synced before growth and the WAL is not truncated during normal operation, so replay re-grows on recovery); only the replay/compaction paths persist the index *and* drop the WAL, and they fsync explicitly.

## Tests

- `test_replay_corrupt_first_record_recovers_following_entries`: CRC-framed WAL, corrupt first record + 2 valid records → valid records recovered (not the whole WAL discarded), corrupt-entry metric incremented.
- `test_replay_growth_persists_data_file_size_for_reopen`: replay that grows the data file, then a second reopen whose persisted index references the grown region loads cleanly (open → replay+grow → reopen round-trip; a true crash between truncate and durability can't be injected without a fault harness).

## Gates

- `cargo test -p velesdb-core --lib --features persistence storage::` → **265 passed, 0 failed** (`--test-threads=1`).
- `cargo fmt --all --check` clean.
- `cargo clippy -p velesdb-core --all-targets --features persistence,gpu,update-check -- -D warnings -D clippy::pedantic` clean.
- `python3 scripts/check_prod_unwraps.py` PASSED.

## Residual doubt

`flush_full()` (persists `vectors.idx` but does **not** truncate the WAL) also lacks a `data_file.sync_all()` after live growth. That is out of scope here (lower severity — the WAL survives as recovery source, though `load_index` could still reject a past-EOF offset on reopen after a crash that lost the growth) and is worth a separate follow-up.