### PR TITLE
fix(lint): resolve clippy for_kv_map/question_mark lints blocking CI

### DIFF
--- a/crates/velesdb-core/src/collection/core/crud_read_delete.rs
+++ b/crates/velesdb-core/src/collection/core/crud_read_delete.rs
@@ -257,7 +257,7 @@ impl Collection {
         #[cfg(feature = "persistence")]
         {
             let indexes = self.sparse_indexes.read();
-            for (name, _) in indexes.iter() {
+            for name in indexes.keys() {
                 let wal_path =
                     crate::index::sparse::persistence::wal_path_for_name(&self.path, name);
                 for &id in ids {

--- a/crates/velesdb-core/src/collection/graph/label_index.rs
+++ b/crates/velesdb-core/src/collection/graph/label_index.rs
@@ -152,10 +152,9 @@ impl LabelIndex {
         let mut result = self.labels.get(first.as_str())?.clone();
 
         for label in iter {
-            match self.labels.get(label.as_str()) {
-                Some(bitmap) => result &= bitmap,
-                None => return None, // Label has no nodes → empty intersection
-            }
+            // Label has no nodes → empty intersection
+            let bitmap = self.labels.get(label.as_str())?;
+            result &= bitmap;
             if result.is_empty() {
                 return None;
             }

--- a/crates/velesdb-core/src/database/admin_executor.rs
+++ b/crates/velesdb-core/src/database/admin_executor.rs
@@ -90,13 +90,13 @@ impl Database {
     ///
     /// Returns the first flush error encountered.
     fn flush_all_collections(&self, full: bool) -> Result<()> {
-        for (_, vc) in self.vector_colls.read().iter() {
+        for vc in self.vector_colls.read().values() {
             flush_dispatch!(vc, full)?;
         }
-        for (_, gc) in self.graph_colls.read().iter() {
+        for gc in self.graph_colls.read().values() {
             flush_dispatch!(gc, full)?;
         }
-        for (_, mc) in self.metadata_colls.read().iter() {
+        for mc in self.metadata_colls.read().values() {
             flush_dispatch!(mc, full)?;
         }
         Ok(())


### PR DESCRIPTION
## ⚠️ Target branch (Git Flow)

`fix/*` → targets `develop`. Compliant.

## Description

PR #1394's "Lint & Format" check started failing with 5 `clippy` errors in three files it never touched: `crud_read_delete.rs`, `label_index.rs`, `admin_executor.rs`. I verified these lints (`clippy::for_kv_map`, `clippy::question_mark`) already fire against `develop`'s current tip (`e214295`) — they are unrelated to any pending PR's diff, and every open/future PR based on this `develop` tip will hit the same "Lint & Format" failure until fixed here directly.

Root cause: `map.iter()` destructured as `(k, v)` where only one side is used, and a `match { Some(..) => .., None => return None }` that's equivalent to `?`. Both are default-enabled clippy lints; something in the CI toolchain (the concurrent Rust 1.96→1.97 bump in #1362) newly surfaces them.

Fixes # (no tracked issue — discovered as a CI-blocking side effect while triaging PR #1394)

## Type of Change

- [x] 🔧 Refactoring (no functional changes)

## How Has This Been Tested?

- [x] Unit tests
- `cargo test -p velesdb-core --lib --features persistence label_index` — 23 passed
- `cargo test -p velesdb-core --lib --features persistence sparse_indexes` — 1 passed
- `cargo clippy -p velesdb-core --all-targets --features persistence,gpu,update-check -- -D warnings -D clippy::pedantic` — clean
- `cargo fmt --all --check` — clean
- `python3 scripts/check_prod_unwraps.py` — PASSED

**Test Configuration:**
- OS: Linux
- Rust version: 1.94.1 (local); CI additionally validated against the 1.97 toolchain that originally surfaced the lints

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

Purely mechanical: `for (k, _) in map.iter()` → `for k in map.keys()`, `for (_, v) in map.iter()` → `for v in map.values()`, and a `match`+`return None` collapsed to `?` — exactly clippy's own suggested rewrites. No behavior change; each rewritten call site's existing tests all still pass.

Once merged, PR #1394 will need a rebase to pick this up and go green on Lint & Format.
