### PR TITLE
chore: clear latent clippy debt against the pinned 1.89 toolchain

### DIFF
--- a/crates/velesdb-core/src/collection/core/crud_read_delete.rs
+++ b/crates/velesdb-core/src/collection/core/crud_read_delete.rs
@@ -257,7 +257,7 @@ impl Collection {
         #[cfg(feature = "persistence")]
         {
             let indexes = self.sparse_indexes.read();
-            for (name, _) in indexes.iter() {
+            for name in indexes.keys() {
                 let wal_path =
                     crate::index::sparse::persistence::wal_path_for_name(&self.path, name);
                 for &id in ids {

--- a/crates/velesdb-core/src/collection/graph/label_index.rs
+++ b/crates/velesdb-core/src/collection/graph/label_index.rs
@@ -152,10 +152,9 @@ impl LabelIndex {
         let mut result = self.labels.get(first.as_str())?.clone();
 
         for label in iter {
-            match self.labels.get(label.as_str()) {
-                Some(bitmap) => result &= bitmap,
-                None => return None, // Label has no nodes → empty intersection
-            }
+            // A missing label means an empty intersection: `?` returns None.
+            let bitmap = self.labels.get(label.as_str())?;
+            result &= bitmap;
             if result.is_empty() {
                 return None;
             }

--- a/crates/velesdb-core/src/collection/stats/tests.rs
+++ b/crates/velesdb-core/src/collection/stats/tests.rs
@@ -407,8 +407,8 @@ fn test_builder_normal_distribution() {
     assert_eq!(h.buckets.len(), 10);
     // Each bucket should have ~10 values
     for bucket in &h.buckets {
-        assert!(bucket.count == 10);
-        assert!(bucket.distinct_count == 10);
+        assert_eq!(bucket.count, 10);
+        assert_eq!(bucket.distinct_count, 10);
     }
     assert_eq!(h.total_count, 100);
     assert!(!h.stale);

--- a/crates/velesdb-core/src/database/admin_executor.rs
+++ b/crates/velesdb-core/src/database/admin_executor.rs
@@ -90,13 +90,13 @@ impl Database {
     ///
     /// Returns the first flush error encountered.
     fn flush_all_collections(&self, full: bool) -> Result<()> {
-        for (_, vc) in self.vector_colls.read().iter() {
+        for vc in self.vector_colls.read().values() {
             flush_dispatch!(vc, full)?;
         }
-        for (_, gc) in self.graph_colls.read().iter() {
+        for gc in self.graph_colls.read().values() {
             flush_dispatch!(gc, full)?;
         }
-        for (_, mc) in self.metadata_colls.read().iter() {
+        for mc in self.metadata_colls.read().values() {
             flush_dispatch!(mc, full)?;
         }
         Ok(())

--- a/crates/velesdb-core/src/index/trigram/gpu.rs
+++ b/crates/velesdb-core/src/index/trigram/gpu.rs
@@ -285,9 +285,9 @@ mod gpu_tests {
             let mut bitmap = RoaringBitmap::new();
             bitmap.insert(0);
             bitmap.insert(1);
-            index.insert([b'h', b'e', b'l'], bitmap.clone());
-            index.insert([b'e', b'l', b'l'], bitmap.clone());
-            index.insert([b'l', b'l', b'o'], bitmap);
+            index.insert(*b"hel", bitmap.clone());
+            index.insert(*b"ell", bitmap.clone());
+            index.insert(*b"llo", bitmap);
 
             let patterns = vec!["hello"];
             let results = gpu.batch_search(&patterns, &index);

--- a/crates/velesdb-core/src/index/trigram/simd_tests.rs
+++ b/crates/velesdb-core/src/index/trigram/simd_tests.rs
@@ -81,16 +81,16 @@ fn test_extract_trigrams_simd_long_text() {
 #[test]
 fn test_count_matching_trigrams() {
     let query: Vec<[u8; 3]> = vec![
-        [b'h', b'e', b'l'],
-        [b'e', b'l', b'l'],
-        [b'l', b'l', b'o'],
-        [b'x', b'y', b'z'],
+        *b"hel",
+        *b"ell",
+        *b"llo",
+        *b"xyz",
     ];
 
     let mut doc_set = HashSet::new();
-    doc_set.insert([b'h', b'e', b'l']);
-    doc_set.insert([b'e', b'l', b'l']);
-    doc_set.insert([b'a', b'b', b'c']);
+    doc_set.insert(*b"hel");
+    doc_set.insert(*b"ell");
+    doc_set.insert(*b"abc");
 
     let count = count_matching_trigrams_simd(&query, &doc_set);
     assert_eq!(count, 2); // 'hel' and 'ell' match
@@ -190,19 +190,19 @@ fn test_count_matching_trigrams_empty_query() {
 
 #[test]
 fn test_count_matching_trigrams_no_match() {
-    let query: Vec<[u8; 3]> = vec![[b'a', b'b', b'c'], [b'd', b'e', b'f']];
+    let query: Vec<[u8; 3]> = vec![*b"abc", *b"def"];
     let mut doc_set = HashSet::new();
-    doc_set.insert([b'x', b'y', b'z']);
+    doc_set.insert(*b"xyz");
     let count = count_matching_trigrams_simd(&query, &doc_set);
     assert_eq!(count, 0);
 }
 
 #[test]
 fn test_count_matching_trigrams_all_match() {
-    let query: Vec<[u8; 3]> = vec![[b'a', b'b', b'c'], [b'd', b'e', b'f']];
+    let query: Vec<[u8; 3]> = vec![*b"abc", *b"def"];
     let mut doc_set = HashSet::new();
-    doc_set.insert([b'a', b'b', b'c']);
-    doc_set.insert([b'd', b'e', b'f']);
+    doc_set.insert(*b"abc");
+    doc_set.insert(*b"def");
     let count = count_matching_trigrams_simd(&query, &doc_set);
     assert_eq!(count, 2);
 }
@@ -213,9 +213,9 @@ fn test_count_matching_trigrams_large_query() {
     // Test with > 16 trigrams to trigger SIMD path
     let query: Vec<[u8; 3]> = (0..20).map(|i| [b'a' + i as u8, b'b', b'c']).collect();
     let mut doc_set = HashSet::new();
-    doc_set.insert([b'a', b'b', b'c']);
-    doc_set.insert([b'b', b'b', b'c']);
-    doc_set.insert([b'c', b'b', b'c']);
+    doc_set.insert(*b"abc");
+    doc_set.insert(*b"bbc");
+    doc_set.insert(*b"cbc");
     let count = count_matching_trigrams_simd(&query, &doc_set);
     assert_eq!(count, 3);
 }

--- a/crates/velesdb-core/src/simd_prefetch_x86_tests.rs
+++ b/crates/velesdb-core/src/simd_prefetch_x86_tests.rs
@@ -68,5 +68,5 @@ fn test_prefetch_distance_bounds() {
     // 32D = 128 bytes / 64 = 2 → clamped to 4
     assert_eq!(calculate_prefetch_distance(32), 4);
     // Maximum capped at 16
-    assert!(calculate_prefetch_distance(10000) == 16);
+    assert_eq!(calculate_prefetch_distance(10000), 16);
 }


### PR DESCRIPTION
## Contexte
La CI épingle clippy à Rust **1.89**, dont le jeu de lints diverge du stable actuel (ces lints ne se déclenchent pas en 1.95). Ces violations **préexistent** mais étaient masquées par le **fail-fast par-cible + le cache incrémental** de clippy : dès qu'une PR invalide ces cibles à la compilation, elles surgissent en erreurs `-D warnings` — et casseraient aussi **develop→main** sur un runner propre (cache froid). Découvert en débloquant les PRs WAL #1393/#1394.

## Corrections (lib + cibles test, mécaniques, comportement inchangé)
- `for_kv_map` : boucles map clés/valeurs seules → `.keys()`/`.values()` (crud_read_delete, admin_executor ×3)
- `question_mark` : match d'intersection de labels → `?` (label_index)
- assert sur égalité : `assert!(a == b)` → `assert_eq!` (stats/tests, simd_prefetch_x86_tests)
- `byte_char_slices` : `[b'x', b'y', b'z']` → `*b"xyz"` (trigram gpu.rs, simd_tests ×20)

## Note release
Non reproductible en local (le clippy 1.89 exige des deps ≤ son MSRV alors que le lock tire jusqu'à rustc 1.91 ; le clippy 1.95 ne flague pas ces lints). **Recommandation de suivi** : rendre le job lint déterministe (`CARGO_INCREMENTAL=0`) pour que la dette ne resurgisse pas au coup par coup, ou aligner le toolchain clippy sur ce que voient les contributeurs.