### PR TITLE
fix(storage): fsync data file before persisting index in flush_full (BUG3-bis)

### DIFF
--- a/crates/velesdb-core/src/storage/mmap.rs
+++ b/crates/velesdb-core/src/storage/mmap.rs
@@ -569,6 +569,18 @@ impl MmapStorage {
     /// Returns an error if any I/O operation fails.
     pub fn flush_full(&mut self) -> io::Result<()> {
         self.flush()?;
+        // fsync the data file BEFORE persisting the index (mirrors the replay
+        // growth path in `replay_wal`). `flush()` msyncs the mmap and fsyncs the
+        // WAL, but neither guarantees a live `set_len` growth (from
+        // `ensure_capacity`) has its inode size journaled. `flush_index()` then
+        // persists `vectors.idx` with offsets that reference the grown region.
+        // On a filesystem where the size update is not durable, a crash could
+        // leave the data file at its pre-growth length while the persisted index
+        // points past EOF -> next open, `load_index` rejects it ("index offset
+        // exceeds data file size") and open fails before `replay_wal` can rebuild
+        // from the (still-intact) WAL. Syncing the size here keeps the data file
+        // and the index we persist next mutually consistent.
+        self.data_file.sync_all()?;
         self.flush_index()
     }
 

--- a/crates/velesdb-core/src/storage/storage_reliability_tests.rs
+++ b/crates/velesdb-core/src/storage/storage_reliability_tests.rs
@@ -642,6 +642,58 @@ fn test_replay_growth_persists_data_file_size_for_reopen() {
 }
 
 #[test]
+fn test_flush_full_after_live_growth_persists_data_file_size_for_reopen() {
+    // FIX (fsync ordering): flush_full() persists vectors.idx after a LIVE growth
+    // (ensure_capacity -> set_len during a store). The grown data-file size must be
+    // fsync'd BEFORE the index is persisted so a subsequent reopen's load_index
+    // bound check (offset <= data file size) passes. Guards the
+    // sync_all-before-persist-index ordering added to `flush_full`, mirroring the
+    // replay path. (A true crash between growth and data-file durability cannot be
+    // injected here without a fault harness; this guards the
+    // open -> store+grow -> flush_full -> reopen round-trip.)
+    let dir = tempdir().unwrap();
+    let path = dir.path().to_path_buf();
+    let dim = 3;
+    let vec_size = dim * 4;
+
+    // Seed an index whose highest offset is the last slot of the 16 MB initial
+    // map, so next_offset lands exactly at the map boundary and the next store
+    // forces a live growth.
+    let near_cap = 16 * 1024 * 1024 - vec_size;
+    let mut index: FxHashMap<u64, usize> = FxHashMap::default();
+    index.insert(1, near_cap);
+    std::fs::write(
+        path.join("vectors.idx"),
+        postcard::to_allocvec(&index).unwrap(),
+    )
+    .unwrap();
+
+    let mut data = vec![0u8; 16 * 1024 * 1024];
+    data[near_cap..near_cap + vec_size].copy_from_slice(&vec3_bytes([1.0, 2.0, 3.0]));
+    std::fs::write(path.join("vectors.dat"), &data).unwrap();
+
+    // Open (no WAL to replay), then store a NEW vector at next_offset (== 16 MB),
+    // forcing ensure_capacity to grow the data file live. flush_full then persists
+    // the index referencing the grown offset.
+    {
+        let mut storage = MmapStorage::new(&path, dim).unwrap();
+        storage.store(2, &[4.0, 5.0, 6.0]).unwrap();
+        assert!(
+            std::fs::metadata(path.join("vectors.dat")).unwrap().len() > 16 * 1024 * 1024,
+            "storing past the initial map must have grown the data file live"
+        );
+        storage.flush_full().unwrap();
+    }
+
+    // The persisted index now references an offset in the GROWN region; a reopen
+    // must load it without load_index rejecting the offset as past the data file,
+    // proving flush_full made the grown size durable consistently with the index.
+    let reopened = MmapStorage::new(&path, dim).unwrap();
+    assert_eq!(reopened.retrieve(1).unwrap(), Some(vec![1.0, 2.0, 3.0]));
+    assert_eq!(reopened.retrieve(2).unwrap(), Some(vec![4.0, 5.0, 6.0]));
+}
+
+#[test]
 fn test_898_load_index_rejects_out_of_bounds_offset() {
     // A corrupt index offset that points past the data file must be rejected,
     // not silently accepted (which would wrap into an OOB read later).


### PR DESCRIPTION
## Contexte

Follow-up de #1393, qui a corrigé l'ordering fsync du chemin **REPLAY** (`replay_wal` fait `mmap.flush()` -> `data_file.sync_all()` -> `persist_index_file` -> `truncate_wal`).

Gap restant signalé : **`flush_full()` persiste `vectors.idx` après une croissance LIVE sans `data_file.sync_all()`** et ne tronque pas le WAL.

## Le gap est réel

`flush_full()` = `flush()` (msync mmap + fsync WAL, **pas** de `data_file.sync_all()`) puis `flush_index()` (persiste `vectors.idx`). Entre une croissance live (`ensure_capacity` -> `set_len`, sans sync) et la persistance de l'index référençant la région agrandie, la **taille** du data file n'est jamais fsync'd.

Sur un FS où la mise à jour de taille de l'inode n'est pas durable, un crash peut laisser `vectors.dat` à sa longueur pré-croissance alors que l'index persisté pointe au-delà d'EOF. À la réouverture, `load_index` s'exécute **avant** `replay_wal` et rejette durement l'index (« index offset exceeds data file size ») : l'open échoue **même si le WAL non tronqué contient encore les records** nécessaires — car l'erreur `load_index` remonte avant que `replay_wal` puisse reconstruire.

Le commentaire de `mmap_capacity.rs::ensure_capacity` (ajouté par #1393) justifie l'absence de sync sur la croissance live par la protection du WAL, en réservant le cas aigu « index persisté contre offsets agrandis » aux chemins replay/compaction. `flush_full` est précisément un troisième chemin qui persiste l'index — il lui faut donc le même sync.

## Fix

`data_file.sync_all()` entre `flush()` et `flush_index()`, exactement comme `replay_wal`. Rend la taille du data file durable avant que l'index ne la référence.

## Test

`test_flush_full_after_live_growth_persists_data_file_size_for_reopen` : round-trip open -> store forçant une croissance live -> `flush_full` -> reopen où `load_index` doit passer. Garde d'ordering (un vrai crash entre croissance et durabilité n'est pas injectable sans harnais de fault-injection ; même limite documentée que le test replay de #1393).

## Gates
- `cargo fmt --all -- --check` : OK
- `cargo test -p velesdb-core --lib --features persistence storage::` : **269 passed, 0 failed**
- `cargo clippy -p velesdb-core --all-targets --features persistence,gpu,update-check -- -D warnings -D clippy::pedantic` : OK (clippy local moderne ; la CI 1.89 tranche)