### PR TITLE
perf(search): cost-model-driven metadata fallback threshold (F-4.7, #1391)

### DIFF
--- a/crates/velesdb-core/src/collection/search/query/execution_paths.rs
+++ b/crates/velesdb-core/src/collection/search/query/execution_paths.rs
@@ -264,12 +264,12 @@ impl Collection {
         let empty_filter =
             || crate::filter::Filter::new(crate::filter::Condition::And { conditions: vec![] });
         if skip_metadata_prefilter_for_graph_or {
-            return Ok(self.execute_scan_query(&empty_filter(), execution_limit));
+            return Ok(self.execute_scan_query(&empty_filter(), execution_limit, None));
         }
         let Some(metadata_cond) = Self::extract_metadata_filter(cond) else {
-            return Ok(self.execute_scan_query(&empty_filter(), execution_limit));
+            return Ok(self.execute_scan_query(&empty_filter(), execution_limit, None));
         };
-        Ok(self.dispatch_metadata_filter(cond, metadata_cond, execution_limit))
+        Ok(self.dispatch_metadata_filter(cond, &metadata_cond, execution_limit))
     }
 
     /// Resolves a metadata filter by probing bitmap → indexed → BM25 → scan paths.
@@ -278,7 +278,7 @@ impl Collection {
     fn dispatch_metadata_filter(
         &self,
         cond: &crate::velesql::Condition,
-        metadata_cond: crate::velesql::Condition,
+        metadata_cond: &crate::velesql::Condition,
         execution_limit: usize,
     ) -> Vec<SearchResult> {
         // Fast path: use bitmap from secondary indexes (same mechanism as
@@ -286,13 +286,14 @@ impl Collection {
         // range queries via the bitmap infrastructure.
         let filter =
             crate::filter::Filter::new(crate::filter::Condition::from(metadata_cond.clone()));
-        if let Some(bitmap_results) = self.try_bitmap_prefilter(&filter, execution_limit) {
+        if let Some(bitmap_results) =
+            self.try_bitmap_prefilter(&filter, metadata_cond, execution_limit)
+        {
             return bitmap_results;
         }
 
         tracing::debug!("dispatch_metadata_only: trying indexed path");
-        if let Some(indexed) = self.execute_indexed_metadata_query(&metadata_cond, execution_limit)
-        {
+        if let Some(indexed) = self.execute_indexed_metadata_query(metadata_cond, execution_limit) {
             tracing::debug!("dispatch_metadata_only: indexed path succeeded");
             return indexed;
         }
@@ -312,18 +313,114 @@ impl Collection {
             return like_results;
         }
 
-        let filter = crate::filter::Filter::new(crate::filter::Condition::from(metadata_cond));
-        self.execute_scan_query(&filter, execution_limit)
+        let filter =
+            crate::filter::Filter::new(crate::filter::Condition::from(metadata_cond.clone()));
+        self.execute_scan_query(&filter, execution_limit, Some(metadata_cond))
+    }
+
+    /// Cost-model-driven fallback decision (audit F-4.7, issue #1391).
+    ///
+    /// Replaces the arbitrary `execution_limit * 50 .max(1000)` candidate budget
+    /// that decided "too many index/bitmap candidates → sequential full scan".
+    /// Compares the estimated cost of hydrating `candidate_count` index/bitmap
+    /// candidates against a full sequential scan that early-exits once
+    /// `exec_limit` matches are produced, using the same [`CostEstimator`](crate::velesql::CostEstimator)
+    /// the ORDER BY router (`ordered_index_scan.rs`) already relies on.
+    ///
+    /// Returns `true` when the candidate scan is the cheaper (or equal) path.
+    ///
+    /// # Guardrails
+    /// - `.max(1000)` floor: candidate sets of ≤ 1000 always take the candidate
+    ///   path — a noisy estimate must never penalise a trivially small set.
+    /// - `cond == None` (SELECT * / empty filter — no indexed Eq exists on those
+    ///   paths anyway): falls back to the historical
+    ///   `execution_limit * 50 .max(1000)` budget.
+    /// - Empty / un-analysed collection (`total == 0`): candidate path.
+    ///
+    /// The choice **never** affects the result set — both branches post-filter
+    /// the same predicate and yield identical rows; only the physical path
+    /// differs, so switching paths is functionally safe.
+    pub(super) fn prefer_candidate_scan(
+        &self,
+        candidate_count: usize,
+        exec_limit: usize,
+        cond: Option<&crate::velesql::Condition>,
+    ) -> bool {
+        Self::candidate_scan_preferred(&self.get_stats(), candidate_count, exec_limit, cond)
+    }
+
+    /// Pure cost comparison behind [`Self::prefer_candidate_scan`], split out so
+    /// the routing decision can be unit-tested against hand-built
+    /// [`CollectionStats`](crate::collection::stats::CollectionStats) without a
+    /// live collection.
+    // Reason: usize/u64 → f64 for cardinality ratios; ±1 ULP has no operational
+    // impact on a routing decision that is guarded by a `.max(1000)` floor.
+    #[allow(clippy::cast_precision_loss)]
+    pub(super) fn candidate_scan_preferred(
+        stats: &crate::collection::stats::CollectionStats,
+        candidate_count: usize,
+        exec_limit: usize,
+        cond: Option<&crate::velesql::Condition>,
+    ) -> bool {
+        /// Floor guard: tiny candidate sets are always cheaper to hydrate
+        /// directly than to scan the whole collection.
+        const CANDIDATE_SCAN_FLOOR: usize = 1000;
+
+        if candidate_count <= CANDIDATE_SCAN_FLOOR {
+            return true;
+        }
+
+        // No condition tree available (SELECT * / empty filter): preserve the
+        // historical budget so behaviour on those paths is unchanged.
+        let Some(cond) = cond else {
+            return candidate_count <= exec_limit.saturating_mul(50).max(CANDIDATE_SCAN_FLOOR);
+        };
+
+        let total = stats.total_points.max(stats.row_count);
+        if total == 0 {
+            return true;
+        }
+        let total_f = total as f64;
+
+        let estimator = crate::velesql::CostEstimator::new(stats);
+        // Clamp selectivity away from 0 so the early-exit row estimate stays
+        // finite; a single-row lower bound is the tightest meaningful floor.
+        let selectivity = estimator
+            .estimate_condition_selectivity(cond)
+            .clamp(1.0 / total_f, 1.0);
+
+        // A full sequential scan with early exit visits ≈ exec_limit /
+        // selectivity rows before it collects `exec_limit` matches (bounded by
+        // the collection size).
+        let full_scan_rows = ((exec_limit.max(1) as f64) / selectivity)
+            .min(total_f)
+            .max(1.0);
+
+        // Cost both paths through the calibrated filter-cost model. Expressing
+        // each cardinality as a selectivity (`rows / total`) reuses
+        // `estimate_filter_cost_from_selectivity`, so calibrated I/O and CPU
+        // factors weight both sides identically; the decision is driven by the
+        // histogram-/cardinality-calibrated selectivity feeding `full_scan_rows`.
+        let candidate_cost = estimator
+            .estimate_filter_cost_from_selectivity(candidate_count as f64 / total_f)
+            .total();
+        let full_scan_cost = estimator
+            .estimate_filter_cost_from_selectivity(full_scan_rows / total_f)
+            .total();
+
+        candidate_cost <= full_scan_cost
     }
 
     /// Attempts a bitmap-prefiltered scan when the candidate set is bounded.
     ///
     /// Returns `Some(results)` when the bitmap path is viable (empty result or
-    /// candidate count within a reasonable multiple of `execution_limit`).
-    /// Returns `None` to let the caller fall through to indexed/scan paths.
+    /// a candidate count the cost model deems cheaper to scan than the full
+    /// collection). Returns `None` to let the caller fall through to
+    /// indexed/scan paths.
     fn try_bitmap_prefilter(
         &self,
         filter: &crate::filter::Filter,
+        cond: &crate::velesql::Condition,
         execution_limit: usize,
     ) -> Option<Vec<SearchResult>> {
         let bitmap = self.build_prefilter_bitmap(filter)?;
@@ -331,8 +428,7 @@ impl Collection {
             return Some(Vec::new());
         }
         let candidate_ids: Vec<u64> = bitmap.iter().map(u64::from).collect();
-        let candidate_budget = execution_limit.saturating_mul(50).max(1000);
-        if candidate_ids.len() <= candidate_budget {
+        if self.prefer_candidate_scan(candidate_ids.len(), execution_limit, Some(cond)) {
             return Some(self.scan_ids_with_filter(&candidate_ids, filter, execution_limit));
         }
         // Too many bitmap hits — fall through to scan with early exit
@@ -508,6 +604,7 @@ impl Collection {
             (None, None, None) => Ok(self.execute_scan_query(
                 &crate::filter::Filter::new(crate::filter::Condition::And { conditions: vec![] }),
                 execution_limit,
+                None,
             )),
         }
     }

--- a/crates/velesdb-core/src/collection/search/query/execution_paths_tests.rs
+++ b/crates/velesdb-core/src/collection/search/query/execution_paths_tests.rs
@@ -129,3 +129,231 @@ fn test_parallel_strategy_returns_best_score_union_of_both_branches() {
         assert!(w[0].score >= w[1].score, "descending similarity order");
     }
 }
+
+// ============================================================================
+// B. Cost-model-driven metadata fallback (audit F-4.7, issue #1391)
+// ============================================================================
+
+use crate::collection::stats::{CollectionStats, ColumnStats};
+use crate::collection::Collection;
+use crate::velesql::{CompareOp, Comparison, Condition, Value};
+
+/// Builds a velesql `col = "value"` string-equality condition.
+fn eq_string_cond(column: &str, value: &str) -> Condition {
+    Condition::Comparison(Comparison {
+        column: column.to_string(),
+        operator: CompareOp::Eq,
+        value: Value::String(value.to_string()),
+    })
+}
+
+/// Hand-builds `CollectionStats` whose `estimate_selectivity(column)` resolves
+/// to `1 / distinct_values` (no histogram → cardinality fallback).
+fn stats_with_cardinality(total: u64, column: &str, distinct_values: u64) -> CollectionStats {
+    let mut field_stats = std::collections::HashMap::new();
+    field_stats.insert(
+        column.to_string(),
+        ColumnStats {
+            name: column.to_string(),
+            distinct_values,
+            distinct_count: distinct_values,
+            ..Default::default()
+        },
+    );
+    CollectionStats {
+        total_points: total,
+        row_count: total,
+        field_stats,
+        ..Default::default()
+    }
+}
+
+/// The fallback bascule is driven by the cost model: for an *identical*
+/// candidate count and execution limit, a high-selectivity predicate (few
+/// matches → cheap full scan with early exit) declines the candidate path,
+/// while a low-selectivity predicate (many matches → expensive full scan)
+/// prefers it. Only the stats differ between the two calls.
+#[test]
+fn test_candidate_scan_switch_is_cost_driven() {
+    let cond = eq_string_cond("cat", "x");
+    let (candidate_count, exec_limit, total) = (5_000, 10, 100_000);
+
+    // distinct_values = 2 → selectivity 0.5 → a full scan finds `exec_limit`
+    // matches after ~20 rows, far cheaper than hydrating 5_000 candidates.
+    let high_sel = stats_with_cardinality(total, "cat", 2);
+    assert!(
+        !Collection::candidate_scan_preferred(&high_sel, candidate_count, exec_limit, Some(&cond)),
+        "high selectivity → full scan is cheaper, candidate path declined"
+    );
+
+    // distinct_values = total → selectivity ~1/total → a full scan must visit
+    // (nearly) the whole collection, so hydrating 5_000 candidates wins.
+    let low_sel = stats_with_cardinality(total, "cat", total);
+    assert!(
+        Collection::candidate_scan_preferred(&low_sel, candidate_count, exec_limit, Some(&cond)),
+        "low selectivity → candidate scan is cheaper"
+    );
+}
+
+/// Guardrails and edge cases: the `.max(1000)` floor, empty candidate sets,
+/// un-analysed stats, and a zero execution limit must all resolve safely
+/// without panicking or dividing by zero.
+#[test]
+fn test_candidate_scan_floor_and_edge_cases() {
+    let cond = eq_string_cond("cat", "x");
+    // High-selectivity stats that would otherwise decline the candidate path.
+    let high_sel = stats_with_cardinality(100_000, "cat", 2);
+
+    // Floor: candidate sets ≤ 1000 always take the candidate path, regardless
+    // of how cheap the full scan looks.
+    assert!(Collection::candidate_scan_preferred(
+        &high_sel,
+        1_000,
+        10,
+        Some(&cond)
+    ));
+    // Empty candidate set is trivially below the floor.
+    assert!(Collection::candidate_scan_preferred(
+        &high_sel,
+        0,
+        10,
+        Some(&cond)
+    ));
+    // Empty / un-analysed collection (total == 0) → candidate path, no panic.
+    let empty = CollectionStats::default();
+    assert!(Collection::candidate_scan_preferred(
+        &empty,
+        5_000,
+        10,
+        Some(&cond)
+    ));
+    // exec_limit == 0 must not divide by zero; low selectivity still prefers
+    // the candidate path.
+    let low_sel = stats_with_cardinality(100_000, "cat", 100_000);
+    assert!(Collection::candidate_scan_preferred(
+        &low_sel,
+        5_000,
+        0,
+        Some(&cond)
+    ));
+}
+
+/// When no condition tree is available (SELECT * / empty filter) the helper
+/// falls back to the historical `exec_limit * 50 .max(1000)` budget so those
+/// paths keep their previous behaviour unchanged.
+#[test]
+fn test_candidate_scan_none_cond_uses_legacy_budget() {
+    let stats = stats_with_cardinality(100_000, "cat", 2);
+    // exec_limit 10 → budget max(500, 1000) = 1000; 5_000 > 1000 → full scan.
+    assert!(!Collection::candidate_scan_preferred(
+        &stats, 5_000, 10, None
+    ));
+    // exec_limit 100 → budget 5_000; 1_500 ≤ 5_000 → candidate path.
+    assert!(Collection::candidate_scan_preferred(
+        &stats, 1_500, 100, None
+    ));
+}
+
+/// Result equivalence: whichever physical path the cost model selects, a
+/// metadata scan returns exactly the rows matching the predicate. Uses an
+/// indexed field and a large limit (no truncation) so the full matching set is
+/// compared against an independent brute-force reference.
+#[test]
+fn test_metadata_scan_matches_bruteforce_across_paths() {
+    let (_dir, col) = setup_collection(4);
+    col.create_index("cat")
+        .expect("test: create secondary index");
+
+    // 1_200 "hot" (> 1000 floor → cost model decides), 5 "cold" (< floor →
+    // candidate path), remainder "other".
+    let total: u64 = 2_000;
+    let points: Vec<Point> = (0..total)
+        .map(|id| {
+            let cat = if id < 1_200 {
+                "hot"
+            } else if id < 1_205 {
+                "cold"
+            } else {
+                "other"
+            };
+            make_point_with_payload(
+                id,
+                vec![1.0, 0.0, 0.0, 0.0],
+                serde_json::json!({ "cat": cat }),
+            )
+        })
+        .collect();
+    col.upsert(points).expect("test: upsert");
+
+    for target in ["hot", "cold", "other"] {
+        let expected: std::collections::BTreeSet<u64> = (0..total)
+            .filter(|&id| {
+                let cat = if id < 1_200 {
+                    "hot"
+                } else if id < 1_205 {
+                    "cold"
+                } else {
+                    "other"
+                };
+                cat == target
+            })
+            .collect();
+
+        let filter = crate::filter::Filter::new(crate::filter::Condition::eq("cat", target));
+        let cond = eq_string_cond("cat", target);
+        let got = col.execute_scan_query(&filter, 10_000, Some(&cond));
+        let got_ids: std::collections::BTreeSet<u64> = got.iter().map(|r| r.point.id).collect();
+
+        assert_eq!(
+            got_ids, expected,
+            "metadata scan for cat={target} must return exactly the matching rows"
+        );
+    }
+}
+
+/// Under a small limit the full-scan branch (or the candidate branch) may be
+/// selected; either way every returned row satisfies the predicate and the
+/// limit is respected — the routing never leaks non-matching rows.
+#[test]
+fn test_metadata_scan_small_limit_is_correct() {
+    let (_dir, col) = setup_collection(4);
+    col.create_index("cat")
+        .expect("test: create secondary index");
+
+    let total: u64 = 2_000;
+    let points: Vec<Point> = (0..total)
+        .map(|id| {
+            let cat = if id < 1_500 { "hot" } else { "other" };
+            make_point_with_payload(
+                id,
+                vec![1.0, 0.0, 0.0, 0.0],
+                serde_json::json!({ "cat": cat }),
+            )
+        })
+        .collect();
+    col.upsert(points).expect("test: upsert");
+
+    let filter = crate::filter::Filter::new(crate::filter::Condition::eq("cat", "hot"));
+    let cond = eq_string_cond("cat", "hot");
+    let limit = 300;
+    let got = col.execute_scan_query(&filter, limit, Some(&cond));
+
+    assert_eq!(
+        got.len(),
+        limit,
+        "limit must be respected (1_500 matches available)"
+    );
+    for r in &got {
+        let cat = r
+            .point
+            .payload
+            .as_ref()
+            .and_then(|p| p.get("cat"))
+            .and_then(serde_json::Value::as_str);
+        assert_eq!(
+            cat,
+            Some("hot"),
+            "every returned row must match the predicate"
+        );
+    }
+}

--- a/crates/velesdb-core/src/collection/search/query/metadata_query.rs
+++ b/crates/velesdb-core/src/collection/search/query/metadata_query.rs
@@ -21,9 +21,11 @@ impl Collection {
                 limit = execution_limit,
                 "indexed metadata query: Eq lookup"
             );
-            // Skip index path when too many hits — sequential scan with early
-            // exit is faster than hydrating thousands of index results.
-            if ids.len() > execution_limit.saturating_mul(50).max(1000) {
+            // Skip index path when the cost model (audit F-4.7, issue #1391)
+            // deems a sequential scan with early exit cheaper than hydrating the
+            // index hits. Both paths yield identical results — only the physical
+            // path differs.
+            if !self.prefer_candidate_scan(ids.len(), execution_limit, Some(cond)) {
                 tracing::debug!("indexed metadata query: too many hits, falling through to scan");
                 return None; // Fall through to scan
             }

--- a/crates/velesdb-core/src/collection/search/query/similarity_filter.rs
+++ b/crates/velesdb-core/src/collection/search/query/similarity_filter.rs
@@ -305,17 +305,19 @@ impl Collection {
         &self,
         filter: &crate::filter::Filter,
         limit: usize,
+        cond: Option<&crate::velesql::Condition>,
     ) -> Vec<SearchResult> {
         // Try index-accelerated scan: extract the first Eq condition and use
         // the secondary index to get candidate IDs, then post-filter.
-        // Skip when the index returns too many candidates relative to the limit —
-        // sequential scan with early exit is faster than hydrating thousands of
-        // index hits (e.g., IsMobile=1 matching 20% of rows).
+        // The cost model (audit F-4.7, issue #1391) decides whether hydrating
+        // the candidate set beats a sequential scan with early exit — the former
+        // wins for narrow candidate sets, the latter for broad ones (e.g.
+        // IsMobile=1 matching 20% of rows). Both paths return identical results.
         if let Some(candidate_ids) = self.try_index_accelerated_ids(filter) {
-            if candidate_ids.len() <= limit.saturating_mul(50).max(1000) {
+            if self.prefer_candidate_scan(candidate_ids.len(), limit, cond) {
                 return self.scan_candidate_ids(&candidate_ids, filter, limit);
             }
-            // Fall through to sequential scan — index has too many hits
+            // Fall through to sequential scan — cost model prefers full scan
         }
 
         // Full sequential scan (slow fallback for non-indexed conditions).
@@ -484,7 +486,7 @@ impl Collection {
         let metric = self.config().metric;
         let higher_is_better = metric.higher_is_better();
 
-        let candidates = self.execute_scan_query(metadata_filter, SCAN_CAP);
+        let candidates = self.execute_scan_query(metadata_filter, SCAN_CAP, None);
         let mut topk = super::bounded_top_k::BoundedTopK::new(limit, higher_is_better);
         for mut r in candidates {
             // Exact distance computation using the stored vector.

--- a/crates/velesdb-core/src/collection/search/query/union_query.rs
+++ b/crates/velesdb-core/src/collection/search/query/union_query.rs
@@ -125,8 +125,9 @@ impl Collection {
             }
             None => meta_cond,
         };
-        let filter = crate::filter::Filter::new(crate::filter::Condition::from(combined_cond));
-        let metadata_results = self.execute_scan_query(&filter, limit);
+        let filter =
+            crate::filter::Filter::new(crate::filter::Condition::from(combined_cond.clone()));
+        let metadata_results = self.execute_scan_query(&filter, limit, Some(&combined_cond));
 
         for result in metadata_results {
             // Only add if not already found by similarity search


### PR DESCRIPTION
## Summary

Closes the audit finding **F-4.7** (issue #1391): the arbitrary magic number `execution_limit.saturating_mul(50).max(1000)` decided "too many index/bitmap candidates → full scan" identically in **three** places. It is now replaced by a single cost-model-driven routing helper.

`Collection::prefer_candidate_scan` (backed by the pure, unit-testable `candidate_scan_preferred`) reuses the existing `CostEstimator` — the same one the ORDER BY router (`ordered_index_scan.rs`) already relies on — to compare:

- **candidate scan**: hydrate `candidate_count` index/bitmap candidates, vs
- **full sequential scan** with early exit: visits ≈ `execution_limit / selectivity` rows before collecting `execution_limit` matches (bounded by collection size).

Selectivity is drawn from the histogram-/cardinality-calibrated estimator, so the fallback decision follows the data instead of a fixed constant.

### Guardrails
- `.max(1000)` floor: candidate sets ≤ 1000 always take the candidate path (a noisy estimate must never penalise a trivially small set).
- `None` condition (SELECT * / empty filter — no indexed Eq exists there anyway): falls back to the historical `execution_limit * 50 .max(1000)` budget, unchanged behaviour.
- Empty / un-analysed collection (`total == 0`): candidate path; no divide-by-zero when `execution_limit == 0`.

### Sites routed through the helper
- `collection/search/query/metadata_query.rs` — indexed Eq lookup
- `collection/search/query/execution_paths.rs` — bitmap prefilter
- `collection/search/query/similarity_filter.rs` — index-accelerated scan

## Safety

Public API unchanged. Both branches post-filter the **same** predicate and yield **identical result sets** (when the limit does not truncate); under truncation both return `limit` valid matching rows — the pre-existing contract for metadata scans without ORDER BY. Switching paths only changes the physical plan, never correctness.

## Tests

- `test_candidate_scan_switch_is_cost_driven` — for an identical candidate count and limit, a high-selectivity predicate declines the candidate path while a low-selectivity one prefers it; **only the stats differ**, proving the bascule is cost-driven.
- `test_candidate_scan_floor_and_edge_cases` — floor, `candidate_count = 0`, `exec_limit = 0`, absent stats.
- `test_candidate_scan_none_cond_uses_legacy_budget` — `None` condition preserves the historical budget.
- `test_metadata_scan_matches_bruteforce_across_paths` — query-level result equivalence vs an independent brute-force reference.
- `test_metadata_scan_small_limit_is_correct` — truncating path only ever returns valid, limited rows.

## Gates

- `cargo fmt --all -- --check` ✅
- `cargo test -p velesdb-core --lib --features persistence` (search/query + column_store: 605 passed; new tests: 9 passed) ✅
- integration: `bitmap_prefilter_integration`, `ordered_index_order_by_equivalence`, bdd `secondary_index_bitmap_in` ✅
- `cargo clippy -p velesdb-core --all-targets --features persistence,gpu,update-check -- -D warnings -D clippy::pedantic` ✅

Refs #1391