### PR TITLE
feat(query): execute SELECT/MATCH Parallel strategy concurrently (#1390)

### DIFF
--- a/crates/velesdb-core/src/collection/search/query/execution_paths.rs
+++ b/crates/velesdb-core/src/collection/search/query/execution_paths.rs
@@ -236,9 +236,26 @@ impl Collection {
                 Ok(self.scan_and_score_by_vector(filter, vector, execution_limit))
             }
             crate::velesql::ExecutionStrategy::Parallel => {
-                let graph_results = self.scan_and_score_by_vector(filter, vector, execution_limit);
-                let vector_results =
-                    self.search_with_filter_and_opts(vector, cbo_search_k, filter, search_opts)?;
+                // R2 (#1390): run the GraphFirst scan and the VectorFirst HNSW
+                // branch CONCURRENTLY via `rayon::join`. Both legs are read-only
+                // over immutable collection data and the merge below is a
+                // best-score-by-id union (order-insensitive), so the concurrent
+                // result set is byte-for-byte identical to the former sequential
+                // execution — only wall-clock latency changes. The two closures
+                // each take read locks only (no writer during a query), so there
+                // is no lock-ordering hazard, mirroring the concurrent hybrid
+                // dense/sparse path in `hybrid_sparse::execute_both_branches`.
+                #[cfg(feature = "persistence")]
+                let (graph_results, vector_results) = rayon::join(
+                    || self.scan_and_score_by_vector(filter, vector, execution_limit),
+                    || self.search_with_filter_and_opts(vector, cbo_search_k, filter, search_opts),
+                );
+                #[cfg(not(feature = "persistence"))]
+                let (graph_results, vector_results) = (
+                    self.scan_and_score_by_vector(filter, vector, execution_limit),
+                    self.search_with_filter_and_opts(vector, cbo_search_k, filter, search_opts),
+                );
+                let vector_results = vector_results?;
                 let higher = self.config.read().metric.higher_is_better();
                 Ok(merge_select_parallel_results(
                     graph_results,
@@ -569,8 +586,20 @@ impl Collection {
         cbo_strategy: crate::velesql::ExecutionStrategy,
         cbo_over_fetch: usize,
     ) -> Result<Vec<SearchResult>> {
+        // `cbo_strategy` (VectorFirst / GraphFirst / Parallel) only has a
+        // physically distinct realization on the NEAR + metadata-filter arm
+        // below, which routes through `dispatch_vector_with_strategy`. Every
+        // other arm has exactly one sensible physical plan, so it deliberately
+        // ignores `cbo_strategy` (documented per-arm). This is intentional, not
+        // an oversight: forcing a graph/parallel shape onto these arms would add
+        // machinery with no cost benefit (audit F-2.15, #1390).
         match (vector_search, first_similarity, filter_condition) {
-            // similarity() with optional NEAR vector and optional metadata filter
+            // similarity() with optional NEAR vector and optional metadata filter.
+            // Strategy IGNORED (deliberate): a similarity() threshold is
+            // intrinsically VectorFirst — it must score vector candidates before
+            // it can apply the threshold, so GraphFirst/Parallel have no
+            // meaningful realization here. The optional metadata filter is
+            // applied as a post-filter over the scored candidates.
             (search_vec, Some(sim), filter_cond) => self.dispatch_similarity_query(
                 search_vec.map(Vec::as_slice),
                 sim,
@@ -580,7 +609,10 @@ impl Collection {
                 skip_metadata_prefilter_for_graph_or,
                 search_opts,
             ),
-            // NEAR + metadata filter (no similarity threshold)
+            // NEAR + metadata filter (no similarity threshold). This is the ONLY
+            // arm that HONORS `cbo_strategy`: it dispatches to
+            // `dispatch_vector_with_strategy`, which realizes VectorFirst,
+            // GraphFirst, and Parallel as three physically distinct plans.
             (Some(vector), None, Some(cond)) => self.dispatch_near_with_filter(
                 vector,
                 cond,
@@ -590,17 +622,25 @@ impl Collection {
                 cbo_strategy,
                 cbo_over_fetch,
             ),
-            // Pure NEAR (no filter, no similarity threshold)
+            // Pure NEAR (no filter, no similarity threshold).
+            // Strategy IGNORED (deliberate): with no metadata/graph predicate
+            // there is no second leg to run first or in parallel — only the
+            // VectorFirst HNSW search exists, so the strategy is moot.
             (Some(vector), None, None) => {
                 self.dispatch_pure_near(vector, execution_limit, search_opts)
             }
-            // Metadata-only
+            // Metadata-only (no vector query at all).
+            // Strategy IGNORED (deliberate): `ExecutionStrategy` orders a vector
+            // search relative to a filter; with no vector query there is nothing
+            // to order — the path is a pure index/bitmap/scan resolution.
             (None, None, Some(cond)) => self.dispatch_metadata_only(
                 cond,
                 execution_limit,
                 skip_metadata_prefilter_for_graph_or,
             ),
-            // SELECT * (no WHERE)
+            // SELECT * (no WHERE, no vector).
+            // Strategy IGNORED (deliberate): no predicate and no vector query —
+            // a full sequential scan is the only possible plan.
             (None, None, None) => Ok(self.execute_scan_query(
                 &crate::filter::Filter::new(crate::filter::Condition::And { conditions: vec![] }),
                 execution_limit,

--- a/crates/velesdb-core/src/collection/search/query/execution_paths_tests.rs
+++ b/crates/velesdb-core/src/collection/search/query/execution_paths_tests.rs
@@ -130,6 +130,213 @@ fn test_parallel_strategy_returns_best_score_union_of_both_branches() {
     }
 }
 
+/// Shared fixture: 20 `category="tech"` points whose second vector component
+/// increases with the id, so cosine similarity to `[1,0,0,0]` is strictly
+/// monotone in the id (id 1 = closest). Distinct scores make every strategy's
+/// output fully ordered and deterministic.
+fn setup_parallel_fixture() -> (tempfile::TempDir, crate::collection::Collection) {
+    let (dir, col) = setup_collection(4);
+    let points: Vec<Point> = (1..=20u64)
+        .map(|i| {
+            #[allow(clippy::cast_precision_loss)]
+            let v = vec![1.0, i as f32 * 0.05, 0.0, 0.0];
+            make_point_with_payload(i, v, serde_json::json!({"category": "tech"}))
+        })
+        .collect();
+    col.upsert(points).expect("test: upsert");
+    (dir, col)
+}
+
+fn tech_filter() -> crate::filter::Filter {
+    crate::filter::Filter::new(crate::filter::Condition::Eq {
+        field: "category".into(),
+        value: serde_json::json!("tech"),
+    })
+}
+
+/// GIVEN a filtered collection
+/// WHEN dispatching with a FORCED `ExecutionStrategy::GraphFirst`
+/// THEN the result equals the exhaustive `scan_and_score_by_vector`
+///      realization (a full metadata scan scored by vector similarity),
+///      physically distinct from the HNSW path.
+#[test]
+fn test_graph_first_strategy_matches_exhaustive_scan_reference() {
+    let (_dir, col) = setup_parallel_fixture();
+    let filter = tech_filter();
+    let query = [1.0, 0.0, 0.0, 0.0];
+    let opts = QuerySearchOptions::default();
+    let (k, limit) = (10, 3);
+
+    let graph_first = col
+        .dispatch_vector_with_strategy(
+            &query,
+            &filter,
+            ExecutionStrategy::GraphFirst,
+            k,
+            limit,
+            &opts,
+        )
+        .expect("test: graph-first dispatch");
+
+    let expected = col.scan_and_score_by_vector(&filter, &query, limit);
+
+    assert_eq!(
+        ids_of(&graph_first),
+        ids_of(&expected),
+        "GraphFirst must equal the exhaustive scan-and-score realization"
+    );
+    assert_eq!(graph_first.len(), limit, "GraphFirst returns top-`limit`");
+    assert_eq!(graph_first[0].point.id, 1, "closest point ranks first");
+}
+
+/// GIVEN a filtered collection
+/// WHEN dispatching with a FORCED `ExecutionStrategy::VectorFirst`
+/// THEN the result equals the filtered-HNSW `search_with_filter_and_opts`
+///      realization (up to `k` candidates), distinct from the GraphFirst scan.
+#[test]
+fn test_vector_first_strategy_matches_hnsw_filtered_reference() {
+    let (_dir, col) = setup_parallel_fixture();
+    let filter = tech_filter();
+    let query = [1.0, 0.0, 0.0, 0.0];
+    let opts = QuerySearchOptions::default();
+    let (k, limit) = (10, 3);
+
+    let vector_first = col
+        .dispatch_vector_with_strategy(
+            &query,
+            &filter,
+            ExecutionStrategy::VectorFirst,
+            k,
+            limit,
+            &opts,
+        )
+        .expect("test: vector-first dispatch");
+
+    let expected = col
+        .search_with_filter_and_opts(&query, k, &filter, &opts)
+        .expect("test: vector reference");
+
+    assert_eq!(
+        ids_of(&vector_first),
+        ids_of(&expected),
+        "VectorFirst must equal the filtered-HNSW realization"
+    );
+}
+
+/// GIVEN the same data, filter, query, k, and limit
+/// WHEN dispatched under GraphFirst, VectorFirst, and Parallel
+/// THEN the three strategies are observably distinct physical plans: the
+///      VectorFirst set (up to `k` HNSW candidates) differs from the
+///      GraphFirst set (top-`limit` exhaustive), and Parallel is the
+///      best-score-per-id merge of both.
+#[test]
+fn test_three_strategies_yield_distinct_result_sets() {
+    let (_dir, col) = setup_parallel_fixture();
+    let filter = tech_filter();
+    let query = [1.0, 0.0, 0.0, 0.0];
+    let opts = QuerySearchOptions::default();
+    let (k, limit) = (10, 3);
+
+    let graph_first = col
+        .dispatch_vector_with_strategy(
+            &query,
+            &filter,
+            ExecutionStrategy::GraphFirst,
+            k,
+            limit,
+            &opts,
+        )
+        .expect("test: graph-first");
+    let vector_first = col
+        .dispatch_vector_with_strategy(
+            &query,
+            &filter,
+            ExecutionStrategy::VectorFirst,
+            k,
+            limit,
+            &opts,
+        )
+        .expect("test: vector-first");
+    let parallel = col
+        .dispatch_vector_with_strategy(
+            &query,
+            &filter,
+            ExecutionStrategy::Parallel,
+            k,
+            limit,
+            &opts,
+        )
+        .expect("test: parallel");
+
+    // GraphFirst (top-3 exhaustive) is not the VectorFirst set (10 candidates):
+    // three physically distinct realizations, not one collapsed path.
+    assert_ne!(
+        ids_of(&graph_first),
+        ids_of(&vector_first),
+        "GraphFirst and VectorFirst must produce distinct result-sets"
+    );
+
+    // Parallel equals the documented best-score-per-id merge of both legs.
+    let graph_ref = col.scan_and_score_by_vector(&filter, &query, limit);
+    let vector_ref = col
+        .search_with_filter_and_opts(&query, k, &filter, &opts)
+        .expect("test: vector ref");
+    let expected = merge_select_parallel_results(graph_ref, vector_ref, true, limit);
+    assert_eq!(
+        ids_of(&parallel),
+        ids_of(&expected),
+        "Parallel must equal the best-score-per-id union of both legs"
+    );
+}
+
+/// The concurrent (`rayon::join`) Parallel realization is DETERMINISTIC: the
+/// same forced dispatch, repeated, returns byte-identical ids AND scores,
+/// proving the switch from sequential to concurrent execution changed nothing
+/// observable (the merge is order-insensitive over immutable data).
+#[test]
+fn test_parallel_concurrent_dispatch_is_deterministic() {
+    let (_dir, col) = setup_parallel_fixture();
+    let filter = tech_filter();
+    let query = [1.0, 0.0, 0.0, 0.0];
+    let opts = QuerySearchOptions::default();
+    let (k, limit) = (10, 5);
+
+    let first = col
+        .dispatch_vector_with_strategy(
+            &query,
+            &filter,
+            ExecutionStrategy::Parallel,
+            k,
+            limit,
+            &opts,
+        )
+        .expect("test: parallel run 1");
+
+    for run in 0..8 {
+        let again = col
+            .dispatch_vector_with_strategy(
+                &query,
+                &filter,
+                ExecutionStrategy::Parallel,
+                k,
+                limit,
+                &opts,
+            )
+            .expect("test: parallel repeat");
+        assert_eq!(
+            ids_of(&first),
+            ids_of(&again),
+            "Parallel ids must be identical across runs (run {run})"
+        );
+        let scores_first: Vec<f32> = first.iter().map(|r| r.score).collect();
+        let scores_again: Vec<f32> = again.iter().map(|r| r.score).collect();
+        assert_eq!(
+            scores_first, scores_again,
+            "Parallel scores must be identical across runs (run {run})"
+        );
+    }
+}
+
 // ============================================================================
 // B. Cost-model-driven metadata fallback (audit F-4.7, issue #1391)
 // ============================================================================

--- a/crates/velesdb-core/src/collection/search/query/match_dispatch.rs
+++ b/crates/velesdb-core/src/collection/search/query/match_dispatch.rs
@@ -198,12 +198,20 @@ impl Collection {
 
     /// Executes the Parallel MATCH strategy (Wave 6 Phase D).
     ///
-    /// Runs GraphFirst and VectorFirst sequentially, then merges the result
-    /// sets by `node_id` (union semantics -- best score wins for duplicates).
+    /// Runs the GraphFirst and VectorFirst legs CONCURRENTLY via `rayon::join`
+    /// (R2, #1390), then merges the result sets by `node_id` (union semantics --
+    /// best score wins for duplicates).
     ///
-    /// True parallel execution (rayon/tokio) is a future optimisation; the
-    /// sequential approach is correct and avoids concurrency complexity for
-    /// typical MATCH query sizes.
+    /// # Determinism & counter invariant
+    ///
+    /// Both legs are read-only over immutable collection data, so the merged
+    /// result set is identical to the former sequential execution — only
+    /// wall-clock latency changes. Both legs share the same [`QueryContext`],
+    /// whose EXPLAIN counters (`traversal_nodes_visited` /
+    /// `traversal_edges_traversed`) are `AtomicU64` updated with `fetch_add`;
+    /// concurrent `fetch_add` is commutative, so the "Parallel = sum of both
+    /// legs" contract asserted by `parallel_counters_sum_both_legs` is
+    /// preserved regardless of interleaving.
     fn execute_match_parallel(
         &self,
         match_clause: &crate::velesql::MatchClause,
@@ -211,34 +219,43 @@ impl Collection {
         ctx: &crate::guardrails::QueryContext,
         vector_hint: &crate::velesql::match_planner::MatchExecutionStrategy,
     ) -> Result<Vec<super::match_exec::MatchResult>> {
-        // Phase 1: GraphFirst path.
-        let graph_results = self.execute_match_with_context(match_clause, params, Some(ctx))?;
-
-        // Phase 2: VectorFirst path (extract hint parameters).
-        let vector_results =
+        // Extract the VectorFirst hint parameters once, before the join.
+        let vector_first =
             if let crate::velesql::match_planner::MatchExecutionStrategy::VectorFirst {
                 similarity_alias,
                 top_k,
                 threshold,
             } = vector_hint
             {
-                self.execute_match_vector_first(
-                    match_clause,
-                    params,
-                    ctx,
-                    similarity_alias,
-                    *top_k,
-                    *threshold,
-                )?
+                Some((similarity_alias.as_str(), *top_k, *threshold))
             } else {
                 tracing::warn!(
                     "Parallel strategy vector_hint is not VectorFirst; \
                      skipping vector path"
                 );
-                Vec::new()
+                None
             };
 
-        // Phase 3: Merge by node_id (union, best score wins per metric polarity).
+        // GraphFirst leg + VectorFirst leg run concurrently. The shared `ctx`
+        // is `Sync` (all counters are atomics), so both closures may accumulate
+        // traversal metrics into it in parallel.
+        let graph_leg = || self.execute_match_with_context(match_clause, params, Some(ctx));
+        let vector_leg = || match vector_first {
+            Some((alias, top_k, threshold)) => {
+                self.execute_match_vector_first(match_clause, params, ctx, alias, top_k, threshold)
+            }
+            None => Ok(Vec::new()),
+        };
+
+        #[cfg(feature = "persistence")]
+        let (graph_results, vector_results) = rayon::join(graph_leg, vector_leg);
+        #[cfg(not(feature = "persistence"))]
+        let (graph_results, vector_results) = (graph_leg(), vector_leg());
+
+        let graph_results = graph_results?;
+        let vector_results = vector_results?;
+
+        // Merge by node_id (union, best score wins per metric polarity).
         let config = self.config.read();
         let higher_is_better = config.metric.higher_is_better();
         drop(config);

--- a/crates/velesdb-core/src/velesql/planner.rs
+++ b/crates/velesdb-core/src/velesql/planner.rs
@@ -36,31 +36,37 @@ pub use crate::velesql::query_stats::QueryStats;
 
 /// Execution strategy for hybrid queries.
 ///
-/// This is the planner's *intent*; the executor realizes it only partially:
-/// on the SELECT path (`execution_paths.rs`), `GraphFirst` selects a
-/// full-scan-then-score realization for metadata filters and every other
-/// variant (including `Parallel`) is executed as `VectorFirst`. Graph
-/// predicates in SELECT WHERE that are AND-required take the GraphFirst
-/// anchored fetch (`graph_prefilter.rs`) independently of this strategy —
-/// anchor sets are evaluated first and retrieval is exhaustive within them;
-/// only OR/NOT-wrapped predicates remain post-filters over the fetch
-/// window. On the top-level MATCH path (`match_dispatch.rs`),
-/// `Parallel` runs `GraphFirst` and `VectorFirst` **sequentially** and merges
-/// the result sets (true parallelism is a future optimization).
+/// On the NEAR + metadata-filter SELECT path (`execution_paths.rs`,
+/// `dispatch_vector_with_strategy`) all three variants are realized as
+/// **physically distinct** plans: `VectorFirst` runs the filtered HNSW search,
+/// `GraphFirst` runs a full metadata scan scored by vector similarity, and
+/// `Parallel` runs both concurrently (`rayon::join`) and merges them by
+/// best-score-per-id. Other SELECT arms (similarity() threshold, pure NEAR,
+/// metadata-only, SELECT *) each have a single sensible physical plan and
+/// deliberately ignore the strategy — see the `dispatch_vector_query` match
+/// arms for the per-arm rationale. Graph predicates in SELECT WHERE that are
+/// AND-required take the GraphFirst anchored fetch (`graph_prefilter.rs`)
+/// independently of this strategy — anchor sets are evaluated first and
+/// retrieval is exhaustive within them; only OR/NOT-wrapped predicates remain
+/// post-filters over the fetch window.
+///
+/// On the top-level MATCH path (`match_dispatch.rs`), `Parallel` runs
+/// `GraphFirst` and `VectorFirst` **concurrently** (`rayon::join`) and merges
+/// the result sets by `node_id`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum ExecutionStrategy {
-    /// Execute vector search first, then filter by graph pattern.
-    /// Best when graph filter is not very selective (>10% of data).
+    /// Execute the vector search first (filtered HNSW), then filter/merge.
+    /// Best when the metadata/graph filter is not very selective (>50% of data).
     VectorFirst,
-    /// Intended: execute graph pattern first, then vector search on
-    /// candidates (selective filters, <1% of data). Realized on the SELECT
-    /// path as a full scan scored by vector similarity for metadata filters;
-    /// not realized for SELECT graph predicates (post-filter applies).
+    /// Execute the filter first: a full metadata scan scored by vector
+    /// similarity (selective filters, <1% of data). Realized distinctly on the
+    /// SELECT NEAR+filter path via `scan_and_score_by_vector`. Not applied to
+    /// SELECT graph predicates, which use their own anchored pre-filter.
     GraphFirst,
-    /// Intended: execute both sides in parallel and merge (medium
-    /// selectivity, 1-10%). Realized as `VectorFirst` on the SELECT path and
-    /// as sequential GraphFirst + VectorFirst with a merge on the MATCH path.
+    /// Execute both sides concurrently and merge by best-score-per-id (medium
+    /// selectivity, 1-50%). Realized via `rayon::join` on BOTH the SELECT
+    /// NEAR+filter path and the top-level MATCH path.
     Parallel,
 }
 

--- a/docs/reference/KNOWN_LIMITATIONS.md
+++ b/docs/reference/KNOWN_LIMITATIONS.md
@@ -41,13 +41,13 @@ Both branches feed into the same `dispatch_vector_query` executor through the `(
 
 **What remains open**: the deeper `PlanGenerator::CandidatePlan` enumeration (SeqScan, IndexScan, VectorSearch, GraphTraversal, hybrid combinations) is still not consumed by `execute_query`. The current two-path routing covers the operationally common cases — full multi-candidate enumeration would only change the decision when the cost landscape is non-trivially multimodal.
 
-**Strategy realization on SELECT (audit F-2.15)**: the `ExecutionStrategy` the planner selects is not executed as three physically distinct engines on the SELECT path. As documented in `velesql/planner.rs`:
+**Strategy realization on SELECT (audit F-2.15 — RESOLVED, #1390)**: on the NEAR + metadata-filter SELECT path (`execution_paths.rs`, `dispatch_vector_with_strategy`), the `ExecutionStrategy` the planner selects is executed as three **physically distinct** plans:
 
-- `VectorFirst` — executed natively (HNSW-first, then filter).
-- `GraphFirst` — realized as an **anchor pre-filter** (compute the candidate id set, then run the vector search constrained to it), not a graph-driven scan.
-- `Parallel` — **collapses to `VectorFirst`** on SELECT; it is not run as concurrent branches. On `MATCH`, `Parallel` executes sequentially.
+- `VectorFirst` — filtered HNSW search (`search_with_filter_and_opts`).
+- `GraphFirst` — a full metadata scan scored by vector similarity (`scan_and_score_by_vector`), physically distinct from the HNSW path.
+- `Parallel` — the GraphFirst scan and the VectorFirst HNSW branch run **concurrently** via `rayon::join`, then merge by best-score-per-id. On `MATCH` (`match_dispatch.rs`, `execute_match_parallel`), `Parallel` likewise runs its GraphFirst and VectorFirst legs concurrently via `rayon::join` and merges by `node_id`.
 
-This is a deliberate, assumed limitation (the planner's cost model still picks the cheapest strategy; the executor just realizes `GraphFirst`/`Parallel` conservatively), not a hidden bug. Hybrid-query optimization that executes these strategies distinctly is a future item.
+The concurrent Parallel result set is identical to the former sequential one (both legs are read-only; the merge is order-insensitive); the shared EXPLAIN counters remain the sum of both legs (atomic `fetch_add`). The other SELECT arms (similarity() threshold, pure NEAR, metadata-only, SELECT *) each have a single sensible physical plan and deliberately ignore the strategy — see the `dispatch_vector_query` match arms for the per-arm rationale. SELECT graph predicates still use their own anchored pre-filter (`graph_prefilter.rs`) independently of `ExecutionStrategy`. Covered by `test_parallel_strategy_returns_best_score_union_of_both_branches`, the forced-`GraphFirst`/`VectorFirst` dispatch tests, and `parallel_counters_sum_both_legs`.
 
 **User impact**: `MATCH` queries use the full CBO via `MatchQueryPlanner::plan`. SELECT queries (including ORDER BY similarity + filter) now use calibrated strategy and over-fetch selection. Covered by `test_cbo_forces_vector_first_for_order_by_similarity_with_selective_filter` + `test_cbo_calibrated_path_still_works_without_order_by_similarity` + `test_filter_strategy_switches_on_selectivity`.
 


### PR DESCRIPTION
## Context

Audit finding **F-2.15** / issue #1390 (R2): SELECT execution strategies should be genuinely distinct, and the `Parallel` strategy should not run its two legs sequentially.

The finding was partially obsolete — the SELECT path already realized `GraphFirst` and `Parallel` distinctly (`dispatch_vector_with_strategy`). This PR closes the real remaining gaps.

## Changes

### 1. Parallel is now concurrent (`rayon::join`)
- **SELECT** (`execution_paths.rs`, `dispatch_vector_with_strategy`): the GraphFirst scan (`scan_and_score_by_vector`) and the VectorFirst HNSW branch (`search_with_filter_and_opts`) now run concurrently.
- **MATCH** (`match_dispatch.rs`, `execute_match_parallel`): the GraphFirst and VectorFirst legs now run concurrently.
- Both legs are read-only over immutable data and the merges are best-score-per-id (order-insensitive) → the concurrent result set is **identical** to the former sequential one.
- **Counter invariant preserved**: the MATCH legs share one `QueryContext` whose EXPLAIN counters are `AtomicU64` updated with `fetch_add` (commutative), so "Parallel = sum of both legs" holds regardless of interleaving.
- Mirrors the existing concurrent hybrid dense/sparse pattern (`hybrid_sparse::execute_both_branches`), including the `#[cfg(not(feature = "persistence"))]` sequential fallback.

### 2. `cbo_strategy` consumption documented
`dispatch_vector_query` computes the strategy but only one of its five arms has a physically distinct realization for it (NEAR + metadata filter). The other four arms (similarity() threshold, pure NEAR, metadata-only, SELECT *) each have a single sensible plan and **deliberately ignore** the strategy — now documented per-arm with rationale.

### 3. Docs corrected
- `ExecutionStrategy` enum docstring (`velesql/planner.rs`) and the `KNOWN_LIMITATIONS.md` F-2.15 entry falsely claimed `Parallel` collapses to `VectorFirst` on SELECT and runs sequentially on MATCH. Rewritten to reflect the real (now concurrent) behavior.

## Tests
- `test_graph_first_strategy_matches_exhaustive_scan_reference`
- `test_vector_first_strategy_matches_hnsw_filtered_reference`
- `test_three_strategies_yield_distinct_result_sets`
- `test_parallel_concurrent_dispatch_is_deterministic` (8 repeats, ids + scores identical)
- existing `test_parallel_strategy_returns_best_score_union_of_both_branches` (concurrent == sequential reference)
- existing `parallel_counters_sum_both_legs` now exercises the concurrent MATCH path

## Gates
- `cargo fmt --all -- --check` ✅
- `cargo test -p velesdb-core --lib --features persistence` (search/query + planner + cbo suites): 501 + 6 targeted, 0 failed ✅
- `cargo clippy -p velesdb-core --all-targets --features persistence,gpu,update-check -- -D warnings -D clippy::pedantic` ✅
- `cargo check --no-default-features` (non-persistence fallback) ✅