### PR TITLE
feat(wasm): observer read-gate parity on WASM (F-5.4, #1392)

### DIFF
--- a/crates/velesdb-wasm/src/database.rs
+++ b/crates/velesdb-wasm/src/database.rs
@@ -14,6 +14,7 @@ use std::rc::Rc;
 use wasm_bindgen::prelude::*;
 
 use crate::graph_store::WasmGraphStore;
+use crate::observer::{gate, WasmObserver, WasmQueryOperationKind};
 use crate::parsing;
 use crate::store_new;
 use crate::vector_store::VectorStore;
@@ -39,6 +40,14 @@ pub(crate) struct DatabaseInner {
     /// name. JS callers do not need to `CREATE COLLECTION` before running
     /// `INSERT EDGE` — the executor handles the auto-provision.
     graphs: HashMap<String, SharedGraph>,
+    /// Optional read-path control-plane hook (audit F-5.4, #1392).
+    ///
+    /// `None` on the open path (zero overhead — the gate is a single `Option`
+    /// check). When `Some`, every governed read (`search`, VelesQL `SELECT` /
+    /// `MATCH` / `SELECT EDGES`) consults it before touching the store. Held
+    /// as `Rc<dyn WasmObserver>` — deliberately non-`Send` to match the
+    /// single-threaded `Rc<RefCell<VectorStore>>` store graph.
+    observer: Option<Rc<dyn WasmObserver>>,
 }
 
 impl DatabaseInner {
@@ -46,7 +55,42 @@ impl DatabaseInner {
         Self {
             collections: HashMap::new(),
             graphs: HashMap::new(),
+            observer: None,
         }
+    }
+
+    /// Registers (or replaces) the read-path observer.
+    ///
+    /// Reads routed through the database after this call consult the observer.
+    /// Handles obtained via [`WasmDatabase::get_collection`] snapshot the
+    /// observer at hand-out time, so register the observer **before** handing
+    /// out handles you want governed (mirrors the existing DDL handle
+    /// semantics documented on `WasmCollectionHandle`).
+    pub(crate) fn register_observer(&mut self, observer: Rc<dyn WasmObserver>) {
+        self.observer = Some(observer);
+    }
+
+    /// Returns a cloned handle to the current observer, if any. Used to
+    /// snapshot the observer into a freshly minted `WasmCollectionHandle`.
+    pub(crate) fn observer_handle(&self) -> Option<Rc<dyn WasmObserver>> {
+        self.observer.clone()
+    }
+
+    /// Read-path gate for VelesQL / database-mediated reads.
+    ///
+    /// Zero-overhead when no observer is registered (single `Option` check).
+    /// Returns `Err(msg)` when the observer denies the read.
+    ///
+    /// # Errors
+    ///
+    /// Propagates the observer's denial message.
+    #[inline]
+    pub(crate) fn check_query_access(
+        &self,
+        collection: &str,
+        operation: WasmQueryOperationKind,
+    ) -> Result<(), String> {
+        gate(self.observer.as_ref(), collection, operation)
     }
 
     /// Returns a shared handle to the named graph store, creating it lazily
@@ -235,6 +279,20 @@ impl Default for WasmDatabase {
     }
 }
 
+impl WasmDatabase {
+    /// Registers a read-path observer (audit F-5.4, #1392).
+    ///
+    /// This is the internal Rust seam: `dyn WasmObserver` is not a
+    /// `wasm_bindgen`-compatible type, so JS registration would require a
+    /// concrete adapter wrapping a JS callback (documented follow-up). Reads
+    /// routed through the database after this call — `search` on handles
+    /// obtained afterwards, and every VelesQL `SELECT` / `MATCH` /
+    /// `SELECT EDGES` — consult the observer before touching the store.
+    pub fn register_observer(&mut self, observer: Rc<dyn WasmObserver>) {
+        self.inner.register_observer(observer);
+    }
+}
+
 #[wasm_bindgen]
 impl WasmDatabase {
     /// Creates an empty database with no collections.
@@ -328,7 +386,13 @@ impl WasmDatabase {
             .inner
             .get_shared_store(name)
             .map_err(|e| JsValue::from_str(&e))?;
-        Ok(WasmCollectionHandle { inner: store })
+        Ok(WasmCollectionHandle {
+            inner: store,
+            // Snapshot the observer registered at hand-out time so the handle
+            // can gate its own reads without a back-reference to the database.
+            observer: self.inner.observer_handle(),
+            name: name.to_owned(),
+        })
     }
 
     /// Returns the number of managed collections.
@@ -401,6 +465,11 @@ impl WasmDatabase {
 #[wasm_bindgen]
 pub struct WasmCollectionHandle {
     inner: SharedStore,
+    /// Observer snapshotted from the database at [`WasmDatabase::get_collection`]
+    /// time. `None` (the common case) makes [`Self::search`] gate a no-op.
+    observer: Option<Rc<dyn WasmObserver>>,
+    /// Collection name, carried for the read-path gate context.
+    name: String,
 }
 
 #[wasm_bindgen]
@@ -434,9 +503,20 @@ impl WasmCollectionHandle {
 
     /// k-NN search. Returns `[[id, score], ...]`.
     ///
+    /// When a read-path observer is registered on the owning database, it is
+    /// consulted before the store is touched: a `Deny` decision aborts with
+    /// the observer's message and produces no results (audit F-5.4, #1392).
+    ///
     /// # Errors
-    /// Returns an error if the query dimension does not match the collection.
+    /// Returns an error if the query dimension does not match the collection,
+    /// or if the read-path observer denies the query.
     pub fn search(&self, query: &[f32], k: usize) -> Result<JsValue, JsValue> {
+        gate(
+            self.observer.as_ref(),
+            &self.name,
+            WasmQueryOperationKind::VectorSearch,
+        )
+        .map_err(|e| JsValue::from_str(&e))?;
         let store = self.inner.borrow();
         store.search(query, k)
     }
@@ -463,6 +543,17 @@ impl WasmCollectionHandle {
     #[wasm_bindgen(getter)]
     pub fn dimension(&self) -> usize {
         self.inner.borrow().dimension()
+    }
+}
+
+impl WasmCollectionHandle {
+    /// Test-only: whether this handle snapshotted a read-path observer at
+    /// hand-out time. Used to assert the [`WasmDatabase::get_collection`]
+    /// observer-snapshot wiring without touching the `JsValue`-returning
+    /// `search` (which panics off `wasm32`).
+    #[cfg(test)]
+    pub(crate) fn has_observer(&self) -> bool {
+        self.observer.is_some()
     }
 }
 

--- a/crates/velesdb-wasm/src/lib.rs
+++ b/crates/velesdb-wasm/src/lib.rs
@@ -66,6 +66,9 @@ mod memory_service;
 /// The in-memory `MemoryStore` backend for `velesdb-memory`'s agent-memory
 /// wedge — see [`memory_store::WasmStore`].
 mod memory_store;
+/// Wasm-local read-path control-plane hook (audit F-5.4, #1392) — see
+/// [`observer::WasmObserver`].
+mod observer;
 mod parsing;
 mod persistence;
 mod serialization;
@@ -111,6 +114,9 @@ pub use agent::SemanticMemory;
 pub use database::{WasmCollectionHandle, WasmDatabase};
 pub use graph::{GraphEdge, GraphNode, GraphStore};
 pub use memory_service::WasmMemoryService;
+pub use observer::{
+    WasmAccessDecision, WasmObserver, WasmQueryAccessContext, WasmQueryOperationKind,
+};
 pub use vector_store::VectorStore;
 pub use velesdb_core::DistanceMetric;
 

--- a/crates/velesdb-wasm/src/observer.rs
+++ b/crates/velesdb-wasm/src/observer.rs
@@ -1,0 +1,130 @@
+//! `WasmObserver` — wasm-local read-path control-plane hook (audit F-5.4, #1392).
+//!
+//! # Why a wasm-dedicated trait (not core's `DatabaseObserver`)
+//!
+//! `velesdb-core`'s [`DatabaseObserver`](velesdb_core::DatabaseObserver) is
+//! bound by `Send + Sync` because the core `Database` is a multi-threaded
+//! server component. The WASM store graph is single-threaded and built on
+//! `Rc<RefCell<VectorStore>>` (see [`crate::database::DatabaseInner`]), which
+//! is neither `Send` nor `Sync`. A `Send + Sync` observer therefore cannot be
+//! wired into the WASM store, and requiring one would be a lie about the
+//! runtime. This module mirrors the core *contract* (borrowed context, an
+//! `AccessDecision` return, allow-by-default, zero cost when absent) with a
+//! trait that is deliberately **non-`Send`, non-`Sync`, and synchronous** —
+//! there is no async on the read hot path.
+//!
+//! # Contract (replicated from core)
+//!
+//! - `on_query_request` has a default `Allow` implementation, so an observer
+//!   overriding nothing behaves exactly as no observer at all.
+//! - Implementations MUST NOT panic.
+//! - Access denial flows through [`WasmAccessDecision::Deny`], **not** through
+//!   an out-of-band error channel: `Deny` carries the message surfaced to the
+//!   caller (empty result set + error string), `Allow` executes unmodified.
+//! - When no observer is registered the gate is a single `Option` check and an
+//!   early return — no context is built, nothing is allocated (zero overhead
+//!   on the hot path, matching the core contract).
+
+use std::rc::Rc;
+
+/// The read operation being gated (wasm-local mirror of core's
+/// `QueryOperationKind`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WasmQueryOperationKind {
+    /// Dense vector similarity search (`WasmCollectionHandle::search`).
+    VectorSearch,
+    /// Relational-style VelesQL `SELECT` (incl. JOIN / aggregation / FUSION /
+    /// `NEAR` / `similarity()` / set operations — they all funnel through
+    /// `velesql_select::execute`).
+    Select,
+    /// Graph traversal: VelesQL `MATCH` and `SELECT EDGES`.
+    GraphTraversal,
+}
+
+/// Read-time context handed to the wasm read-path hook.
+///
+/// A borrowed view over the resolved query — no allocation on the fast path.
+/// `principal` and `tenant_hint` are opaque, caller-supplied strings that the
+/// gate never interprets; they exist so a future JS-registered observer can
+/// carry identity/tenant hints through untouched (mirrors core's context).
+#[derive(Debug, Clone)]
+pub struct WasmQueryAccessContext<'a> {
+    /// Target collection (or graph) name. Best-effort for `MATCH`, where the
+    /// graph is inferred from the pattern; empty string when unresolved.
+    pub collection: &'a str,
+    /// Which read path is executing.
+    pub operation: WasmQueryOperationKind,
+    /// Opaque caller-supplied principal hint, forwarded untouched.
+    pub principal: Option<&'a str>,
+    /// Opaque caller-supplied tenant hint, forwarded untouched.
+    pub tenant_hint: Option<&'a str>,
+}
+
+/// The control-plane decision returned by the read-path hook.
+///
+/// Kept intentionally small for WASM: `Allow` executes the read unmodified,
+/// `Deny(msg)` aborts with `msg` and zero results. Scope narrowing
+/// (`AllowWithScope` in core) is deliberately **not** replicated here yet —
+/// see the module-level follow-up note; adding it later is additive.
+pub enum WasmAccessDecision {
+    /// Execute the read unmodified. Default decision.
+    Allow,
+    /// Abort the read and surface this message without producing results.
+    Deny(String),
+}
+
+/// Wasm-local, single-threaded read-path observer port.
+///
+/// Deliberately **not** `Send`/`Sync` (see module docs). Register an
+/// implementation via
+/// [`WasmDatabase::register_observer`](crate::WasmDatabase::register_observer);
+/// every read routed through the database (`search`, VelesQL `SELECT` /
+/// `MATCH` / `SELECT EDGES`) consults it before touching the store.
+pub trait WasmObserver {
+    /// Called immediately before a read executes. Returns [`WasmAccessDecision`].
+    ///
+    /// The default allows every read unmodified, so an observer that overrides
+    /// nothing is equivalent to no observer.
+    fn on_query_request(&self, ctx: &WasmQueryAccessContext<'_>) -> WasmAccessDecision {
+        let _ = ctx;
+        WasmAccessDecision::Allow
+    }
+}
+
+/// Read-path gate shared by every governed read.
+///
+/// Zero-overhead when `observer` is `None`: a single `Option` discriminant
+/// check and an early return — the context struct is not even constructed.
+/// Only when an observer is present do we build the borrowed context and
+/// dispatch. `Deny` is mapped to an `Err(String)` the caller renders as an
+/// empty result plus an error at the FFI boundary.
+///
+/// # Errors
+///
+/// Returns `Err(msg)` when the observer denies the read; `msg` is the
+/// observer-supplied denial reason.
+#[inline]
+pub(crate) fn gate(
+    observer: Option<&Rc<dyn WasmObserver>>,
+    collection: &str,
+    operation: WasmQueryOperationKind,
+) -> Result<(), String> {
+    // Fast path: no observer → nothing to build, nothing to check.
+    let Some(obs) = observer else {
+        return Ok(());
+    };
+    let ctx = WasmQueryAccessContext {
+        collection,
+        operation,
+        principal: None,
+        tenant_hint: None,
+    };
+    match obs.on_query_request(&ctx) {
+        WasmAccessDecision::Allow => Ok(()),
+        WasmAccessDecision::Deny(msg) => Err(msg),
+    }
+}
+
+#[cfg(test)]
+#[path = "observer_tests.rs"]
+mod tests;

--- a/crates/velesdb-wasm/src/observer_tests.rs
+++ b/crates/velesdb-wasm/src/observer_tests.rs
@@ -1,0 +1,236 @@
+//! Tests for the wasm-local read-path observer gate (audit F-5.4, #1392).
+//!
+//! Run on the native host target (like the other `velesdb-wasm` tests). They
+//! deliberately avoid the `JsValue`-returning `search`/`executeQuery` FFI
+//! methods (which panic off `wasm32`) and exercise the gate through the
+//! `String`-error seams: [`DatabaseInner::check_query_access`],
+//! [`crate::velesql_exec::execute`], and the shared [`gate`] helper the
+//! `WasmCollectionHandle::search` path uses.
+
+use std::rc::Rc;
+
+use super::{
+    gate, WasmAccessDecision, WasmObserver, WasmQueryAccessContext, WasmQueryOperationKind,
+};
+use crate::database::{DatabaseInner, WasmDatabase};
+
+/// Observer that denies a configured set of operations.
+struct DenyObserver {
+    deny: Vec<WasmQueryOperationKind>,
+}
+
+impl DenyObserver {
+    fn new(deny: Vec<WasmQueryOperationKind>) -> Rc<Self> {
+        Rc::new(Self { deny })
+    }
+}
+
+impl WasmObserver for DenyObserver {
+    fn on_query_request(&self, ctx: &WasmQueryAccessContext<'_>) -> WasmAccessDecision {
+        if self.deny.contains(&ctx.operation) {
+            WasmAccessDecision::Deny(format!(
+                "denied {:?} on '{}'",
+                ctx.operation, ctx.collection
+            ))
+        } else {
+            WasmAccessDecision::Allow
+        }
+    }
+}
+
+/// Observer using every default method — behaves as if absent (allow-all).
+struct DefaultObserver;
+impl WasmObserver for DefaultObserver {}
+
+fn seeded_metadata_db() -> DatabaseInner {
+    let mut inner = DatabaseInner::new();
+    inner
+        .create_metadata_collection("docs")
+        .expect("test: create metadata collection");
+    crate::velesql_exec::execute(
+        &mut inner,
+        "INSERT INTO docs (id, n) VALUES (1, 10), (2, 20), (3, 30)",
+        None,
+    )
+    .expect("test: seed rows");
+    inner
+}
+
+// --- gate helper: zero-overhead / allow-by-default ------------------------
+
+#[test]
+fn gate_without_observer_is_ok_for_every_op() {
+    for op in [
+        WasmQueryOperationKind::VectorSearch,
+        WasmQueryOperationKind::Select,
+        WasmQueryOperationKind::GraphTraversal,
+    ] {
+        assert!(gate(None, "docs", op).is_ok());
+    }
+}
+
+#[test]
+fn gate_with_default_observer_allows() {
+    let obs: Rc<dyn WasmObserver> = Rc::new(DefaultObserver);
+    assert!(gate(Some(&obs), "docs", WasmQueryOperationKind::VectorSearch).is_ok());
+}
+
+#[test]
+fn gate_deny_propagates_message() {
+    let obs: Rc<dyn WasmObserver> = DenyObserver::new(vec![WasmQueryOperationKind::VectorSearch]);
+    let err = gate(Some(&obs), "docs", WasmQueryOperationKind::VectorSearch)
+        .expect_err("test: should be denied");
+    assert!(err.contains("denied"));
+    assert!(err.contains("docs"));
+}
+
+// --- DatabaseInner::check_query_access ------------------------------------
+
+#[test]
+fn check_query_access_no_observer_allows_all() {
+    let inner = DatabaseInner::new();
+    assert!(inner
+        .check_query_access("docs", WasmQueryOperationKind::Select)
+        .is_ok());
+    assert!(inner
+        .check_query_access("docs", WasmQueryOperationKind::VectorSearch)
+        .is_ok());
+}
+
+#[test]
+fn check_query_access_denies_only_targeted_op() {
+    let mut inner = DatabaseInner::new();
+    inner.register_observer(DenyObserver::new(vec![
+        WasmQueryOperationKind::VectorSearch,
+    ]));
+    assert!(
+        inner
+            .check_query_access("docs", WasmQueryOperationKind::VectorSearch)
+            .is_err(),
+        "targeted op is denied"
+    );
+    assert!(
+        inner
+            .check_query_access("docs", WasmQueryOperationKind::Select)
+            .is_ok(),
+        "non-targeted op is allowed"
+    );
+}
+
+// --- VelesQL SELECT read path ---------------------------------------------
+
+#[test]
+fn select_denied_returns_error_and_no_rows() {
+    let mut inner = seeded_metadata_db();
+    inner.register_observer(DenyObserver::new(vec![WasmQueryOperationKind::Select]));
+    let err = crate::velesql_exec::execute(&mut inner, "SELECT * FROM docs", None)
+        .expect_err("test: select must be denied");
+    assert!(err.contains("denied"), "carries the denial message: {err}");
+}
+
+#[test]
+fn select_allowed_returns_rows() {
+    let mut inner = seeded_metadata_db();
+    inner.register_observer(Rc::new(DefaultObserver));
+    let r = crate::velesql_exec::execute(&mut inner, "SELECT * FROM docs", None)
+        .expect("test: select allowed");
+    assert_eq!(r.row_count(), 3);
+}
+
+#[test]
+fn select_without_observer_is_unchanged() {
+    // Zero-overhead path: identical behavior to pre-observer code.
+    let mut inner = seeded_metadata_db();
+    let r =
+        crate::velesql_exec::execute(&mut inner, "SELECT * FROM docs", None).expect("test: select");
+    assert_eq!(r.row_count(), 3);
+}
+
+#[test]
+fn set_operation_operands_are_each_gated() {
+    // UNION operands re-enter velesql_select::execute; a Select-deny must
+    // block the compound too.
+    let mut inner = seeded_metadata_db();
+    inner.register_observer(DenyObserver::new(vec![WasmQueryOperationKind::Select]));
+    let err = crate::velesql_exec::execute(
+        &mut inner,
+        "SELECT * FROM docs UNION SELECT * FROM docs",
+        None,
+    )
+    .expect_err("test: union must be denied");
+    assert!(err.contains("denied"));
+}
+
+// --- Graph read paths ------------------------------------------------------
+
+#[test]
+fn select_edges_denied_before_store_lookup() {
+    // Deny short-circuits ahead of the graph-store lookup: the error is the
+    // denial, not "Graph not found".
+    let mut inner = DatabaseInner::new();
+    inner.register_observer(DenyObserver::new(vec![
+        WasmQueryOperationKind::GraphTraversal,
+    ]));
+    let err = crate::velesql_exec::execute(&mut inner, "SELECT EDGES FROM social", None)
+        .expect_err("test: select edges denied");
+    assert!(err.contains("denied"), "denial wins over not-found: {err}");
+}
+
+#[test]
+fn select_edges_allowed_passes_gate_to_store_lookup() {
+    // With an allowing observer the gate is transparent: execution proceeds
+    // to the store lookup, which reports the missing graph (proving the gate
+    // did not short-circuit).
+    let mut inner = DatabaseInner::new();
+    inner.register_observer(Rc::new(DefaultObserver));
+    let err = crate::velesql_exec::execute(&mut inner, "SELECT EDGES FROM social", None)
+        .expect_err("test: missing graph");
+    assert!(err.contains("not found"), "gate is transparent: {err}");
+}
+
+// --- WasmCollectionHandle observer snapshot -------------------------------
+
+#[test]
+fn handle_snapshots_observer_registered_before_handout() {
+    let mut db = WasmDatabase::new();
+    db.create_collection("docs", 4, "cosine")
+        .expect("test: create");
+    db.register_observer(DenyObserver::new(vec![
+        WasmQueryOperationKind::VectorSearch,
+    ]));
+    let handle = db.get_collection("docs").expect("test: handle");
+    assert!(
+        handle.has_observer(),
+        "handle obtained after registration is governed"
+    );
+}
+
+#[test]
+fn handle_obtained_before_registration_has_no_observer() {
+    let mut db = WasmDatabase::new();
+    db.create_collection("docs", 4, "cosine")
+        .expect("test: create");
+    let handle = db.get_collection("docs").expect("test: handle");
+    db.register_observer(DenyObserver::new(vec![
+        WasmQueryOperationKind::VectorSearch,
+    ]));
+    assert!(
+        !handle.has_observer(),
+        "handle snapshots observer state at hand-out time"
+    );
+}
+
+// --- register replaces -----------------------------------------------------
+
+#[test]
+fn register_observer_replaces_previous() {
+    let mut inner = DatabaseInner::new();
+    inner.register_observer(Rc::new(DefaultObserver));
+    assert!(inner
+        .check_query_access("docs", WasmQueryOperationKind::Select)
+        .is_ok());
+    inner.register_observer(DenyObserver::new(vec![WasmQueryOperationKind::Select]));
+    assert!(inner
+        .check_query_access("docs", WasmQueryOperationKind::Select)
+        .is_err());
+}

--- a/crates/velesdb-wasm/src/velesql_graph.rs
+++ b/crates/velesdb-wasm/src/velesql_graph.rs
@@ -16,6 +16,7 @@ use velesdb_core::velesql::{
 
 use crate::database::DatabaseInner;
 use crate::graph_store::WasmEdge;
+use crate::observer::WasmQueryOperationKind;
 use crate::velesql_result::QueryResultRow;
 use crate::velesql_value::{resolve_value, Params};
 
@@ -25,7 +26,23 @@ pub(crate) fn execute_match(
     query: &Query,
     params: &Params,
 ) -> Result<Vec<QueryResultRow>, String> {
+    // Read-path gate (audit F-5.4, #1392). The graph store is inferred from
+    // the pattern, so the collection hint is best-effort: the first annotated
+    // pattern node's collection, else empty. Zero-overhead without an observer.
+    let collection = match_collection_hint(query);
+    db.check_query_access(collection, WasmQueryOperationKind::GraphTraversal)?;
     crate::velesql_match::execute_match(db, query, params)
+}
+
+/// Best-effort collection name for a MATCH read gate: the first pattern node
+/// carrying an `@collection` annotation, or `""` when none is present.
+fn match_collection_hint(query: &Query) -> &str {
+    query
+        .match_clause
+        .as_ref()
+        .and_then(|clause| clause.patterns.first())
+        .and_then(|pattern| pattern.nodes.iter().find_map(|n| n.collection.as_deref()))
+        .unwrap_or("")
 }
 
 // ---------------------------------------------------------------------------
@@ -139,6 +156,8 @@ pub(crate) fn select_edges(
     stmt: &SelectEdgesStatement,
     _params: &Params,
 ) -> Result<Vec<QueryResultRow>, String> {
+    // Read-path gate (audit F-5.4, #1392) — zero-overhead without an observer.
+    db.check_query_access(&stmt.collection, WasmQueryOperationKind::GraphTraversal)?;
     let store = db
         .get_graph_store(&stmt.collection)
         .ok_or_else(|| format!("Graph '{}' not found", stmt.collection))?;

--- a/crates/velesdb-wasm/src/velesql_select.rs
+++ b/crates/velesdb-wasm/src/velesql_select.rs
@@ -20,6 +20,7 @@ use std::collections::HashMap;
 use velesdb_core::velesql::{Condition, Query, SelectStatement, VectorSearch};
 
 use crate::database::DatabaseInner;
+use crate::observer::WasmQueryOperationKind;
 use crate::vector_ops;
 use crate::velesql_aggregate;
 use crate::velesql_fusion;
@@ -37,6 +38,13 @@ pub(crate) fn execute(
     query: &Query,
     params: &Params,
 ) -> Result<Vec<QueryResultRow>, String> {
+    // Read-path gate (audit F-5.4, #1392): consulted before any store access.
+    // Placed ahead of the JOIN early-return below so joined SELECTs are gated
+    // too. Set-operation operands re-enter here via `velesql_setops::run_select`,
+    // so each operand is gated with its own source collection. Zero-overhead
+    // when no observer is registered.
+    db.check_query_access(&query.select.from, WasmQueryOperationKind::Select)?;
+
     if !query.let_bindings.is_empty() {
         return Err("LET bindings are not supported in WASM".to_string());
     }


### PR DESCRIPTION
## Context (audit F-5.4, #1392, effort L)

Governance parity gap: the core read-path observer gate (`DatabaseObserver::on_query_request` → `AccessDecision`) had **no equivalent on the WASM store**. Core's trait is `Send + Sync`, which is incompatible with the WASM store's single-threaded `Rc<RefCell<VectorStore>>` graph (`DatabaseInner`). This PR adds a **wasm-dedicated observer port** — non-`Send`, synchronous — mirroring the core contract (borrowed context, allow-by-default, zero-overhead when absent).

## What changed

**New `observer` module**
- `WasmObserver` trait with allow-by-default `on_query_request`.
- Borrowed `WasmQueryAccessContext` (collection, operation, principal/tenant hints).
- `WasmAccessDecision::{Allow, Deny(String)}` (scope-narrowing intentionally deferred; additive later).
- Shared `gate(...)` helper: **zero-overhead when no observer** — a single `Option` check and early return, no context allocated.

**Wiring**
- `DatabaseInner` gains `Option<Rc<dyn WasmObserver>>`, `register_observer`, and `check_query_access`.
- `WasmDatabase::register_observer` is the Rust registration seam. `dyn` trait objects aren't `wasm_bindgen`-compatible, so a JS-callback adapter is a documented follow-up (mission: "l'API JS peut être minimale").

**Read paths gated (ahead of any store access)**
| Path | Entry point | Op |
|---|---|---|
| Vector search | `WasmCollectionHandle::search` (observer snapshotted at `get_collection`) | `VectorSearch` |
| VelesQL SELECT — plain, `NEAR`, `FUSION`, `similarity()`, JOIN, set-op operands | `velesql_select::execute` (gate before the JOIN early-return; set-op operands re-enter here) | `Select` |
| Graph MATCH | `velesql_graph::execute_match` | `GraphTraversal` |
| Graph SELECT EDGES | `velesql_graph::select_edges` | `GraphTraversal` |

`Deny` → error + zero results; `Allow` / no observer → normal read. Synchronous throughout (no async on the hot path).

## Tests
14 native tests (`observer_tests.rs`), run like the existing WASM tests on the host target, avoiding the `JsValue`-returning FFI methods that panic off `wasm32`:
- gate/`check_query_access`: deny, allow, absent, replace, per-op targeting;
- SELECT + UNION operands denied/allowed/unchanged;
- SELECT EDGES: deny short-circuits before the store lookup; allow is transparent;
- handle observer-snapshot semantics (before/after registration).

## Gates
- `cargo fmt --all -- --check` ✅
- `cargo test -p velesdb-wasm --lib -- --test-threads=1` → **624 passed** (610 prior + 14) ✅
- `cargo clippy -p velesdb-wasm --all-targets -- -D warnings -D clippy::pedantic` ✅
- `cargo check -p velesdb-wasm --target wasm32-unknown-unknown` ✅

## Known seam limitations (follow-up)
- Secondary JOIN tables are gated only via the query's **primary** collection, not per-joined-table.
- The standalone `VectorStore` JS primitive (direct `text_search`/`hybrid_search`/`multi_query_search`, etc.) is **not** database-governed — by design, consistent with core where the observer is a `Database`-level port, not a raw-store one.
- JS registration of an observer via a callback adapter.

Refs #1392.