### PR TITLE
perf(search): drop redundant payload clone + reorder hydrate-then-filter (PERF8)

### DIFF
--- a/crates/velesdb-core/src/collection/search/query/metadata_query.rs
+++ b/crates/velesdb-core/src/collection/search/query/metadata_query.rs
@@ -83,8 +83,11 @@ impl Collection {
     ) -> Vec<SearchResult> {
         let mut results = Vec::new();
         for point in self.get(ids).into_iter().flatten() {
-            let payload = point.payload.clone().unwrap_or(serde_json::Value::Null);
-            if filter.matches(&payload) {
+            // `matches` only borrows the payload; pass a reference instead of
+            // deep-cloning the JSON per candidate. A missing payload is treated
+            // as `Null` (unchanged semantics). The borrow ends before `point`
+            // is moved into the result below.
+            if filter.matches(point.payload.as_ref().unwrap_or(&serde_json::Value::Null)) {
                 results.push(SearchResult::new(point, 1.0));
                 if results.len() >= execution_limit {
                     break;

--- a/crates/velesdb-core/src/collection/search/text.rs
+++ b/crates/velesdb-core/src/collection/search/text.rs
@@ -154,7 +154,6 @@ impl Collection {
         Ok(bm25_results
             .into_iter()
             .filter_map(|(id, score)| {
-                let vector = vector_storage.retrieve(id).ok().flatten()?;
                 let payload = payload_storage.retrieve(id).ok().flatten();
                 if is_payload_expired(payload.as_ref(), now_secs) {
                     return None;
@@ -165,6 +164,13 @@ impl Collection {
                 if !filter.matches(payload_ref) {
                     return None;
                 }
+
+                // Retrieve the vector only for candidates that pass the filter;
+                // fetching it before filtering copies a dim-D vector that is
+                // discarded for every non-match. Result-set membership is
+                // unchanged: inclusion still requires a present vector AND a
+                // non-expired payload passing the filter (a conjunction).
+                let vector = vector_storage.retrieve(id).ok().flatten()?;
 
                 let point = Point {
                     id,

--- a/crates/velesdb-core/src/collection/search/text_tests.rs
+++ b/crates/velesdb-core/src/collection/search/text_tests.rs
@@ -134,6 +134,33 @@ fn test_text_search_with_filter_includes_matching_category() {
     assert!(!results.is_empty(), "should find tech rust docs");
 }
 
+#[test]
+fn test_text_search_with_filter_exact_result_set_preserved() {
+    // Regression guard for the hydrate-order optimization: retrieving the
+    // vector only for post-filter matches must not change the result set.
+    // "programming" matches docs 1 and 2 (both category=tech); doc 4 (rust
+    // web framework) has no "programming" token and doc 3 is sports.
+    let (_dir, col) = setup_text_collection();
+
+    let filter = Filter::new(Condition::eq("category", "tech"));
+    let results = col
+        .text_search_with_filter("programming", 10, &filter)
+        .expect("filtered text search");
+
+    let mut ids: Vec<u64> = results.iter().map(|r| r.point.id).collect();
+    ids.sort_unstable();
+    assert_eq!(ids, vec![1, 2], "exact match set must be {{1, 2}}");
+
+    // Every returned point is fully hydrated (vector fetched for matches only).
+    for r in &results {
+        assert_eq!(
+            r.point.vector.len(),
+            4,
+            "matched point must carry its vector"
+        );
+    }
+}
+
 // -----------------------------------------------------------------------
 // Hybrid search (vector + text)
 // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Two low-risk allocation/copy micro-optimizations on the read path. **Result-set is strictly identical** in both cases (proven by the full suite + an added regression test).

### 1. `scan_ids_with_filter` (metadata_query.rs)
Was deep-cloning `point.payload` (a JSON `Value`) per candidate just to hand a `&Value` to `filter.matches`. Now passes `point.payload.as_ref().unwrap_or(&Value::Null)` — no clone. The immutable borrow ends before `point` is moved into the result. Missing payload still treated as `Null` (unchanged semantics).

### 2. `text_search_with_filter` (text.rs)
Was calling `vector_storage.retrieve()` (copies a dim-D vector) **before** the metadata filter, so the vector was fetched then thrown away for every non-match. Reordered: fetch payload, check expiry, check filter, and **only then** retrieve the vector for surviving matches. Inclusion still requires `(vector present) ∧ (payload present, non-expired) ∧ (filter matches)` — same conjunction, same set, same BM25 order. A regression test pins the exact `{1, 2}` result set.

## Not done: #3 (filter_and_hydrate re-match skip) — intentionally skipped

The third proposed item (skip the `filter.matches()` re-match in `filter_and_hydrate` when a prefilter bitmap already guarantees the match) was **deliberately not implemented** for correctness reasons:

- `bitmap_from_and` silently **skips** non-indexable children, so for a partially-indexable `AND` the prefilter bitmap is a **superset** of true matches — the re-match is load-bearing.
- `filter_and_hydrate` receives only `Vec<ScoredResult>` (id + score); `merge_delta` mixes in delta-buffer and deferred-indexer points that were **never** passed through the bitmap and must be re-matched.
- The function is shared by 3 callers, only one of which builds a bitmap. Safely skipping would require threading a bitmap + an exactness analysis through the shared signature — high blast radius for a low/medium-impact micro-opt. Per the fail-safe mandate, correctness wins.

## Gates
- `cargo fmt --all -- --check` ✅
- `cargo test -p velesdb-core --lib --features persistence -- --test-threads=1` → **5276 passed, 0 failed** ✅
- `cargo clippy -p velesdb-core --all-targets --features persistence,gpu,update-check -- -D warnings -D clippy::pedantic` ✅