### PR TITLE
feat(mobile): observer read-gate parity on mobile (audit F-5.4, #1392)

### DIFF
--- a/crates/velesdb-mobile/src/collection.rs
+++ b/crates/velesdb-mobile/src/collection.rs
@@ -1,6 +1,11 @@
 //! `VelesCollection` — UniFFI-exported collection operations for mobile.
 
-use velesdb_core::VectorCollection as CoreCollection;
+use std::sync::Arc;
+
+use velesdb_core::{
+    Database as CoreDatabase, Filter, GatedRead, QueryOperationKind,
+    VectorCollection as CoreCollection,
+};
 
 use crate::types::{
     IndividualSearchRequest, MobileAdvancedConfig, MobileCollectionDiagnostics,
@@ -13,9 +18,63 @@ use crate::types::{
 // ============================================================================
 
 /// A collection of vectors with associated metadata.
+///
+/// `inner` is a *detached* core collection leaf with no observer reference, so
+/// every governed read is routed back through the owning database's
+/// control-plane gate (`db.gated_search` / `db.authorize_read`) rather than
+/// hitting the leaf directly — restoring observer governance for the mobile
+/// direct-search API (audit F-5.4, #1392). Reads with no observer registered
+/// take a single `Option` check and then the same leaf call as before
+/// (zero-overhead contract).
 #[derive(uniffi::Object)]
 pub struct VelesCollection {
     pub(crate) inner: CoreCollection,
+    /// Shared handle to the owning database, carrying the read gate.
+    pub(crate) db: Arc<CoreDatabase>,
+    /// Collection name, used to address the gate.
+    pub(crate) name: String,
+}
+
+/// Maps a batch of core search results into the UniFFI `SearchResult` shape
+/// (id + score, payload dropped — the mobile direct-search API is id/score
+/// oriented). Shared by every gated read leaf.
+fn to_mobile_results(results: Vec<velesdb_core::SearchResult>) -> Vec<SearchResult> {
+    results
+        .into_iter()
+        .map(|r| SearchResult {
+            id: r.point.id,
+            score: r.score,
+            payload: None,
+        })
+        .collect()
+}
+
+/// AND-composes a caller filter with an observer scope filter. The result
+/// matches only rows satisfying both, so composing a scope can only narrow.
+pub(crate) fn and_scope(caller: Option<Filter>, scope: Option<Filter>) -> Option<Filter> {
+    use velesdb_core::Condition;
+    match (caller, scope) {
+        (None, None) => None,
+        (Some(c), None) => Some(c),
+        (None, Some(s)) => Some(s),
+        (Some(c), Some(s)) => Some(Filter::new(Condition::And {
+            conditions: vec![c.condition, s.condition],
+        })),
+    }
+}
+
+/// Fails a non-`GatedRead` read closed when the observer returned a scope
+/// filter the leaf cannot apply (id/score-only leaves with no metadata-filtered
+/// twin). Refusing to run unscoped is the safe default — never widen past the
+/// observer's narrowing.
+pub(crate) fn deny_if_scoped(scope: Option<Filter>, context: &str) -> Result<(), VelesError> {
+    if scope.is_some() {
+        return Err(VelesError::database(format!(
+            "{context} cannot honor the governance scope filter returned by the observer \
+             (this entry point has no metadata-filtered leaf); refusing to run unscoped"
+        )));
+    }
+    Ok(())
 }
 
 #[uniffi::export]
@@ -31,18 +90,20 @@ impl VelesCollection {
     ///
     /// Vector of search results sorted by similarity.
     pub fn search(&self, vector: Vec<f32>, limit: u32) -> Result<Vec<SearchResult>, VelesError> {
-        let results = self
-            .inner
-            .search_ids(&vector, usize::try_from(limit).unwrap_or(usize::MAX))?;
+        let results = self.db.gated_search(
+            &self.name,
+            None,
+            None,
+            GatedRead::Dense {
+                query: &vector,
+                k: usize::try_from(limit).unwrap_or(usize::MAX),
+                ef: None,
+                quality: None,
+                filter: None,
+            },
+        )?;
 
-        Ok(results
-            .into_iter()
-            .map(|sr| SearchResult {
-                id: sr.id,
-                score: sr.score,
-                payload: None,
-            })
-            .collect())
+        Ok(to_mobile_results(results))
     }
 
     /// Searches with a specific quality profile controlling recall/latency.
@@ -62,21 +123,20 @@ impl VelesCollection {
         limit: u32,
         quality: SearchQuality,
     ) -> Result<Vec<SearchResult>, VelesError> {
-        let core_quality: velesdb_core::SearchQuality = quality.into();
-        let results = self.inner.search_with_quality(
-            &vector,
-            usize::try_from(limit).unwrap_or(usize::MAX),
-            core_quality,
+        let results = self.db.gated_search(
+            &self.name,
+            None,
+            None,
+            GatedRead::Dense {
+                query: &vector,
+                k: usize::try_from(limit).unwrap_or(usize::MAX),
+                ef: None,
+                quality: Some(quality.into()),
+                filter: None,
+            },
         )?;
 
-        Ok(results
-            .into_iter()
-            .map(|sr| SearchResult {
-                id: sr.point.id,
-                score: sr.score,
-                payload: None,
-            })
-            .collect())
+        Ok(to_mobile_results(results))
     }
 
     /// Inserts or updates a single point.
@@ -181,19 +241,18 @@ impl VelesCollection {
     ///
     /// Vector of search results sorted by BM25 score.
     pub fn text_search(&self, query: String, limit: u32) -> Result<Vec<SearchResult>, VelesError> {
-        let results = self
-            .inner
-            .text_search(&query, usize::try_from(limit).unwrap_or(usize::MAX))
-            .map_err(|e| VelesError::database(format!("Text search failed: {e}")))?;
+        let results = self.db.gated_search(
+            &self.name,
+            None,
+            None,
+            GatedRead::Text {
+                query: &query,
+                k: usize::try_from(limit).unwrap_or(usize::MAX),
+                filter: None,
+            },
+        )?;
 
-        Ok(results
-            .into_iter()
-            .map(|r| SearchResult {
-                id: r.point.id,
-                score: r.score,
-                payload: None,
-            })
-            .collect())
+        Ok(to_mobile_results(results))
     }
 
     /// Performs hybrid search combining vector similarity and BM25 text search.
@@ -215,21 +274,20 @@ impl VelesCollection {
         limit: u32,
         vector_weight: f32,
     ) -> Result<Vec<SearchResult>, VelesError> {
-        let results = self.inner.hybrid_search(
-            &vector,
-            &text_query,
-            usize::try_from(limit).unwrap_or(usize::MAX),
-            Some(vector_weight),
+        let results = self.db.gated_search(
+            &self.name,
+            None,
+            None,
+            GatedRead::Hybrid {
+                vector: &vector,
+                text: &text_query,
+                k: usize::try_from(limit).unwrap_or(usize::MAX),
+                alpha: Some(vector_weight),
+                filter: None,
+            },
         )?;
 
-        Ok(results
-            .into_iter()
-            .map(|r| SearchResult {
-                id: r.point.id,
-                score: r.score,
-                payload: None,
-            })
-            .collect())
+        Ok(to_mobile_results(results))
     }
 
     /// Searches with metadata filtering.
@@ -250,23 +308,23 @@ impl VelesCollection {
         filter_json: String,
     ) -> Result<Vec<SearchResult>, VelesError> {
         // Parse filter JSON
-        let filter: velesdb_core::Filter = serde_json::from_str(&filter_json)
+        let filter: Filter = serde_json::from_str(&filter_json)
             .map_err(|e| VelesError::database(format!("Invalid filter JSON: {e}")))?;
 
-        let results = self.inner.search_with_filter(
-            &vector,
-            usize::try_from(limit).unwrap_or(usize::MAX),
-            &filter,
+        let results = self.db.gated_search(
+            &self.name,
+            None,
+            None,
+            GatedRead::Dense {
+                query: &vector,
+                k: usize::try_from(limit).unwrap_or(usize::MAX),
+                ef: None,
+                quality: None,
+                filter: Some(&filter),
+            },
         )?;
 
-        Ok(results
-            .into_iter()
-            .map(|r| SearchResult {
-                id: r.point.id,
-                score: r.score,
-                payload: None,
-            })
-            .collect())
+        Ok(to_mobile_results(results))
     }
 
     /// Performs batch search for multiple query vectors in parallel.
@@ -284,7 +342,7 @@ impl VelesCollection {
     ) -> Result<Vec<Vec<SearchResult>>, VelesError> {
         let query_refs: Vec<&[f32]> = searches.iter().map(|s| s.vector.as_slice()).collect();
 
-        let filters: Result<Vec<Option<velesdb_core::Filter>>, VelesError> = searches
+        let filters: Result<Vec<Option<Filter>>, VelesError> = searches
             .iter()
             .map(|s| {
                 s.filter
@@ -298,7 +356,16 @@ impl VelesCollection {
             })
             .collect();
 
-        let filters = filters?;
+        // Authorize the batch as a whole through the read gate, then AND any
+        // observer scope filter into every per-query filter so the filtered
+        // leaf enforces the narrowing (Deny propagates as an error).
+        let scope =
+            self.db
+                .authorize_read(&self.name, QueryOperationKind::VectorSearch, None, None)?;
+        let filters: Vec<Option<Filter>> = filters?
+            .into_iter()
+            .map(|f| and_scope(f, scope.clone()))
+            .collect();
         let max_top_k = searches.iter().map(|s| s.top_k).max().unwrap_or(10);
 
         let all_results = self.inner.search_batch_with_filters(
@@ -339,26 +406,21 @@ impl VelesCollection {
         limit: u32,
         filter_json: String,
     ) -> Result<Vec<SearchResult>, VelesError> {
-        let filter: velesdb_core::Filter = serde_json::from_str(&filter_json)
+        let filter: Filter = serde_json::from_str(&filter_json)
             .map_err(|e| VelesError::database(format!("Invalid filter JSON: {e}")))?;
 
-        let results = self
-            .inner
-            .text_search_with_filter(
-                &query,
-                usize::try_from(limit).unwrap_or(usize::MAX),
-                &filter,
-            )
-            .map_err(|e| VelesError::database(format!("Text search with filter failed: {e}")))?;
+        let results = self.db.gated_search(
+            &self.name,
+            None,
+            None,
+            GatedRead::Text {
+                query: &query,
+                k: usize::try_from(limit).unwrap_or(usize::MAX),
+                filter: Some(&filter),
+            },
+        )?;
 
-        Ok(results
-            .into_iter()
-            .map(|r| SearchResult {
-                id: r.point.id,
-                score: r.score,
-                payload: None,
-            })
-            .collect())
+        Ok(to_mobile_results(results))
     }
 
     /// Performs hybrid search with metadata filtering.
@@ -378,25 +440,23 @@ impl VelesCollection {
         vector_weight: f32,
         filter_json: String,
     ) -> Result<Vec<SearchResult>, VelesError> {
-        let filter: velesdb_core::Filter = serde_json::from_str(&filter_json)
+        let filter: Filter = serde_json::from_str(&filter_json)
             .map_err(|e| VelesError::database(format!("Invalid filter JSON: {e}")))?;
 
-        let results = self.inner.hybrid_search_with_filter(
-            &vector,
-            &text_query,
-            usize::try_from(limit).unwrap_or(usize::MAX),
-            Some(vector_weight),
-            &filter,
+        let results = self.db.gated_search(
+            &self.name,
+            None,
+            None,
+            GatedRead::Hybrid {
+                vector: &vector,
+                text: &text_query,
+                k: usize::try_from(limit).unwrap_or(usize::MAX),
+                alpha: Some(vector_weight),
+                filter: Some(&filter),
+            },
         )?;
 
-        Ok(results
-            .into_iter()
-            .map(|r| SearchResult {
-                id: r.point.id,
-                score: r.score,
-                payload: None,
-            })
-            .collect())
+        Ok(to_mobile_results(results))
     }
 
     /// Executes a VelesQL query.
@@ -434,9 +494,12 @@ impl VelesCollection {
             .map_err(|e| VelesError::database(format!("Invalid params JSON: {e}")))?
             .unwrap_or_default();
 
-        // Execute the query
+        // Execute through the owning database (not the detached collection
+        // leaf) so the VelesQL read path passes the control-plane observer gate
+        // — the detached `VectorCollection::execute_query` has no observer
+        // reference and would bypass governance (audit F-5.4, #1392).
         let results = self
-            .inner
+            .db
             .execute_query(&parsed, &params)
             .map_err(|e| VelesError::database(format!("Query execution failed: {e}")))?;
 

--- a/crates/velesdb-mobile/src/collection_sparse.rs
+++ b/crates/velesdb-mobile/src/collection_sparse.rs
@@ -2,8 +2,9 @@
 //!
 //! Extracted from `collection.rs` to reduce NLOC below the 500 threshold.
 
-use velesdb_core::FusionStrategy as CoreFusionStrategy;
+use velesdb_core::{Filter, FusionStrategy as CoreFusionStrategy, QueryOperationKind};
 
+use crate::collection::{and_scope, deny_if_scoped};
 use crate::types::{FusionStrategy, SearchResult, VelesError, VelesPoint, VelesSparseVector};
 use crate::VelesCollection;
 
@@ -28,6 +29,14 @@ impl VelesCollection {
     ) -> Result<Vec<SearchResult>, VelesError> {
         let core_sv = Self::to_core_sparse_vector(&sparse_vector);
         let idx_name = index_name.unwrap_or_default();
+
+        // Sparse search has no `GatedRead` leaf and no metadata-filtered twin,
+        // so it consults the read gate directly and fails closed if the
+        // observer asks for a scope filter it cannot apply (audit F-5.4, #1392).
+        let scope =
+            self.db
+                .authorize_read(&self.name, QueryOperationKind::VectorSearch, None, None)?;
+        deny_if_scoped(scope, "sparse_search")?;
 
         let results = self
             .inner
@@ -74,6 +83,13 @@ impl VelesCollection {
         let strategy = velesdb_core::fusion::FusionStrategy::RRF { k: 60 };
         let idx_name = index_name.unwrap_or_default();
 
+        // Fused dense+sparse leaf takes no metadata filter, so consult the gate
+        // and fail closed on an unappliable observer scope (audit F-5.4, #1392).
+        let scope =
+            self.db
+                .authorize_read(&self.name, QueryOperationKind::HybridSearch, None, None)?;
+        deny_if_scoped(scope, "hybrid_sparse_search")?;
+
         let results = self
             .inner
             .hybrid_sparse_search(
@@ -111,13 +127,21 @@ impl VelesCollection {
         let query_refs: Vec<&[f32]> = vectors.iter().map(|v| v.as_slice()).collect();
         let core_strategy: CoreFusionStrategy = strategy.into();
 
+        // Consult the read gate, then AND any observer scope filter into the
+        // fusion leaf (which accepts a metadata filter) so narrowing is
+        // enforced (Deny propagates as an error) (audit F-5.4, #1392).
+        let scope =
+            self.db
+                .authorize_read(&self.name, QueryOperationKind::VectorSearch, None, None)?;
+        let effective: Option<Filter> = and_scope(None, scope);
+
         let results = self
             .inner
             .multi_query_search(
                 &query_refs,
                 usize::try_from(limit).unwrap_or(usize::MAX),
                 core_strategy,
-                None,
+                effective.as_ref(),
             )
             .map_err(|e| VelesError::database(format!("Multi-query search failed: {e}")))?;
 
@@ -149,6 +173,14 @@ impl VelesCollection {
 
         let query_refs: Vec<&[f32]> = vectors.iter().map(|v| v.as_slice()).collect();
         let core_strategy: CoreFusionStrategy = strategy.into();
+
+        // Ids/scores-only results carry no payload, so an observer scope filter
+        // cannot be enforced on them: consult the gate and fail closed rather
+        // than return unscoped ids (audit F-5.4, #1392).
+        let scope =
+            self.db
+                .authorize_read(&self.name, QueryOperationKind::VectorSearch, None, None)?;
+        deny_if_scoped(scope, "multi_query_search_ids")?;
 
         let results = self
             .inner
@@ -183,11 +215,18 @@ impl VelesCollection {
             ));
         }
 
-        let filter: velesdb_core::Filter = serde_json::from_str(&filter_json)
+        let filter: Filter = serde_json::from_str(&filter_json)
             .map_err(|e| VelesError::database(format!("Invalid filter JSON: {e}")))?;
 
         let query_refs: Vec<&[f32]> = vectors.iter().map(|v| v.as_slice()).collect();
         let core_strategy: CoreFusionStrategy = strategy.into();
+
+        // Consult the read gate and AND any observer scope filter into the
+        // caller filter (narrow-only) before running (audit F-5.4, #1392).
+        let scope =
+            self.db
+                .authorize_read(&self.name, QueryOperationKind::VectorSearch, None, None)?;
+        let effective = and_scope(Some(filter), scope);
 
         let results = self
             .inner
@@ -195,7 +234,7 @@ impl VelesCollection {
                 &query_refs,
                 usize::try_from(limit).unwrap_or(usize::MAX),
                 core_strategy,
-                Some(&filter),
+                effective.as_ref(),
             )
             .map_err(|e| VelesError::database(format!("Multi-query search failed: {e}")))?;
 

--- a/crates/velesdb-mobile/src/lib.rs
+++ b/crates/velesdb-mobile/src/lib.rs
@@ -51,6 +51,7 @@ mod agent;
 mod collection;
 mod collection_sparse;
 mod graph;
+mod observer;
 mod query;
 mod streaming_runtime;
 mod types;
@@ -58,6 +59,9 @@ mod types;
 pub use agent::{SemanticResult, VelesSemanticMemory};
 pub use collection::VelesCollection;
 pub use graph::{MobileGraphEdge, MobileGraphNode, MobileGraphStore, TraversalResult};
+pub use observer::{
+    MobileAccessDecision, MobileObserver, MobileQueryContext, MobileQueryOperationKind,
+};
 pub use query::{QueryResult, QueryResultKind, QueryResultRow};
 pub use types::{
     DistanceMetric, FusionStrategy, IndividualSearchRequest, MobileAdvancedConfig,
@@ -68,7 +72,9 @@ pub use types::{
 };
 
 use std::sync::Arc;
-use velesdb_core::Database as CoreDatabase;
+use velesdb_core::{Database as CoreDatabase, DatabaseObserver};
+
+use crate::observer::ForeignObserver;
 
 #[cfg(test)]
 use velesdb_core::DistanceMetric as CoreDistanceMetric;
@@ -90,7 +96,13 @@ use velesdb_core::SearchQuality as CoreSearchQuality;
 /// Thread-safe handle to a VelesDB database. Can be shared across threads.
 #[derive(uniffi::Object)]
 pub struct VelesDatabase {
-    inner: CoreDatabase,
+    /// Shared handle to the core database. Held behind an `Arc` so each
+    /// [`VelesCollection`] minted from it can carry a clone and route its reads
+    /// back through this database's control-plane gate (`gated_search` /
+    /// `authorize_read`) rather than hitting its detached collection leaf
+    /// directly — the read gate that observer governance depends on
+    /// (audit F-5.4, #1392).
+    inner: Arc<CoreDatabase>,
 }
 
 #[uniffi::export]
@@ -107,7 +119,38 @@ impl VelesDatabase {
     #[uniffi::constructor]
     pub fn open(path: String) -> Result<Arc<Self>, VelesError> {
         let db = CoreDatabase::open(&path)?;
-        Ok(Arc::new(Self { inner: db }))
+        Ok(Arc::new(Self {
+            inner: Arc::new(db),
+        }))
+    }
+
+    /// Opens or creates a database with a read-path [`MobileObserver`] attached.
+    ///
+    /// The observer is consulted before every governed read (dense / text /
+    /// hybrid / sparse / multi-query search and `VelesQL` `SELECT` / `MATCH`):
+    /// returning [`MobileAccessDecision::Deny`] aborts the read with that
+    /// message and zero results, [`MobileAccessDecision::Allow`] runs it
+    /// unmodified. This is the mobile counterpart of the observer gate already
+    /// wired on server and Python (audit F-5.4, #1392).
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - Path to the database directory (will be created if needed)
+    /// * `observer` - A Kotlin/Swift implementation of [`MobileObserver`]
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the path is invalid or cannot be accessed.
+    #[uniffi::constructor]
+    pub fn open_with_observer(
+        path: String,
+        observer: Arc<dyn MobileObserver>,
+    ) -> Result<Arc<Self>, VelesError> {
+        let core_observer: Arc<dyn DatabaseObserver> = Arc::new(ForeignObserver::new(observer));
+        let db = CoreDatabase::open_with_observer(&path, core_observer)?;
+        Ok(Arc::new(Self {
+            inner: Arc::new(db),
+        }))
     }
 
     /// Updates query guardrail limits for every collection in this database.
@@ -234,7 +277,11 @@ impl VelesDatabase {
     pub fn get_collection(&self, name: String) -> Result<Option<Arc<VelesCollection>>, VelesError> {
         match self.inner.get_any_collection(&name) {
             Some(any_coll) => match any_coll.into_vector() {
-                Ok(vc) => Ok(Some(Arc::new(VelesCollection { inner: vc }))),
+                Ok(vc) => Ok(Some(Arc::new(VelesCollection {
+                    inner: vc,
+                    db: self.inner.clone(),
+                    name,
+                }))),
                 Err(_other_variant) => Err(VelesError::Collection {
                     message: format!(
                         "Collection '{name}' is not a vector collection. \

--- a/crates/velesdb-mobile/src/lib_tests.rs
+++ b/crates/velesdb-mobile/src/lib_tests.rs
@@ -1220,3 +1220,174 @@ fn test_streaming_enable_and_insert_roundtrip() {
         .unwrap();
     assert_eq!(queued, 2);
 }
+
+// =========================================================================
+// Observer read-gate tests (audit F-5.4, #1392)
+// =========================================================================
+
+/// Test observer that denies every read with a fixed reason.
+struct DenyAllObserver;
+
+impl MobileObserver for DenyAllObserver {
+    fn on_query_request(&self, _context: MobileQueryContext) -> MobileAccessDecision {
+        MobileAccessDecision::Deny {
+            reason: "test policy".to_string(),
+        }
+    }
+}
+
+/// Test observer that allows every read and records the contexts it saw, so a
+/// test can assert the read actually passed through the gate.
+#[derive(Default)]
+struct RecordingObserver {
+    seen: std::sync::Mutex<Vec<(String, MobileQueryOperationKind)>>,
+}
+
+impl MobileObserver for RecordingObserver {
+    fn on_query_request(&self, context: MobileQueryContext) -> MobileAccessDecision {
+        self.seen
+            .lock()
+            .unwrap()
+            .push((context.collection, context.operation));
+        MobileAccessDecision::Allow
+    }
+}
+
+/// Opens a database with `observer`, creates a 4-dim `vectors` collection and
+/// seeds one point. Writes are not gated, so this succeeds even under a denying
+/// observer (only reads pass through `on_query_request`).
+fn seed_gated_db(
+    path: String,
+    observer: std::sync::Arc<dyn MobileObserver>,
+) -> std::sync::Arc<VelesDatabase> {
+    let db = VelesDatabase::open_with_observer(path, observer).unwrap();
+    db.create_collection("vectors".to_string(), 4, DistanceMetric::Cosine)
+        .unwrap();
+    let col = db.get_collection("vectors".to_string()).unwrap().unwrap();
+    col.upsert(VelesPoint {
+        id: 1,
+        vector: vec![1.0, 0.0, 0.0, 0.0],
+        payload: Some(r#"{"cat":"a"}"#.to_string()),
+    })
+    .unwrap();
+    db
+}
+
+#[test]
+fn test_observer_allow_read_returns_results_and_sees_context() {
+    let tmp = TempDir::new().unwrap();
+    let path = tmp.path().to_str().unwrap().to_string();
+
+    let obs = std::sync::Arc::new(RecordingObserver::default());
+    let db = seed_gated_db(path, obs.clone());
+    let col = db.get_collection("vectors".to_string()).unwrap().unwrap();
+
+    let results = col.search(vec![1.0, 0.0, 0.0, 0.0], 1).unwrap();
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].id, 1);
+
+    // The read passed through the gate: the observer saw a VectorSearch on
+    // the `vectors` collection.
+    let seen = obs.seen.lock().unwrap();
+    assert!(
+        seen.iter()
+            .any(|(c, op)| c == "vectors" && *op == MobileQueryOperationKind::VectorSearch),
+        "observer should have seen a VectorSearch on 'vectors', saw: {seen:?}"
+    );
+}
+
+#[test]
+fn test_observer_deny_blocks_vector_search() {
+    let tmp = TempDir::new().unwrap();
+    let path = tmp.path().to_str().unwrap().to_string();
+
+    let db = seed_gated_db(path, std::sync::Arc::new(DenyAllObserver));
+    let col = db.get_collection("vectors".to_string()).unwrap().unwrap();
+
+    let err = col.search(vec![1.0, 0.0, 0.0, 0.0], 1).unwrap_err();
+    let VelesError::Database { message, .. } = err else {
+        panic!("expected VelesError::Database, got {err:?}");
+    };
+    assert!(
+        message.contains("denied by observer"),
+        "denial should surface the observer reason, got: {message}"
+    );
+}
+
+#[test]
+fn test_observer_deny_blocks_text_hybrid_and_velesql() {
+    let tmp = TempDir::new().unwrap();
+    let path = tmp.path().to_str().unwrap().to_string();
+
+    let db = seed_gated_db(path, std::sync::Arc::new(DenyAllObserver));
+    let col = db.get_collection("vectors".to_string()).unwrap().unwrap();
+
+    assert!(
+        col.text_search("hello".to_string(), 5).is_err(),
+        "text_search must be gated"
+    );
+    assert!(
+        col.hybrid_search(vec![1.0, 0.0, 0.0, 0.0], "hello".to_string(), 5, 0.5)
+            .is_err(),
+        "hybrid_search must be gated"
+    );
+    // VelesQL collection query is routed through the gated database facade, so
+    // it is denied too.
+    assert!(
+        col.query("SELECT * FROM vectors LIMIT 10".to_string(), None)
+            .is_err(),
+        "VelesQL query must be gated"
+    );
+}
+
+#[test]
+fn test_observer_deny_blocks_sparse_and_multi_query() {
+    let tmp = TempDir::new().unwrap();
+    let path = tmp.path().to_str().unwrap().to_string();
+
+    let db = seed_gated_db(path, std::sync::Arc::new(DenyAllObserver));
+    let col = db.get_collection("vectors".to_string()).unwrap().unwrap();
+
+    // The gate is consulted before the leaf, so denial short-circuits even the
+    // sparse path (whether or not a sparse index is configured).
+    let sparse = VelesSparseVector {
+        indices: vec![0],
+        values: vec![1.0],
+    };
+    assert!(
+        col.sparse_search(sparse, 5, None).is_err(),
+        "sparse_search must be gated"
+    );
+    assert!(
+        col.multi_query_search(
+            vec![vec![1.0, 0.0, 0.0, 0.0]],
+            5,
+            FusionStrategy::Rrf { k: 60 }
+        )
+        .is_err(),
+        "multi_query_search must be gated"
+    );
+}
+
+#[test]
+fn test_open_without_observer_reads_unchanged() {
+    let tmp = TempDir::new().unwrap();
+    let path = tmp.path().to_str().unwrap().to_string();
+
+    // Baseline: the plain open() path registers no observer, so the gate is a
+    // no-op and reads behave exactly as before.
+    let db = VelesDatabase::open(path).unwrap();
+    db.create_collection("vectors".to_string(), 4, DistanceMetric::Cosine)
+        .unwrap();
+    let col = db.get_collection("vectors".to_string()).unwrap().unwrap();
+    col.upsert(VelesPoint {
+        id: 7,
+        vector: vec![1.0, 0.0, 0.0, 0.0],
+        payload: None,
+    })
+    .unwrap();
+
+    let results = col.search(vec![1.0, 0.0, 0.0, 0.0], 1).unwrap();
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].id, 7);
+}

--- a/crates/velesdb-mobile/src/observer.rs
+++ b/crates/velesdb-mobile/src/observer.rs
@@ -1,0 +1,180 @@
+//! `MobileObserver` — mobile read-path control-plane hook (audit F-5.4, #1392).
+//!
+//! # Governance parity on mobile
+//!
+//! The core read gate (`Database::open_with_observer` +
+//! [`Database::gated_search`](velesdb_core::Database::gated_search) /
+//! [`Database::authorize_read`](velesdb_core::Database::authorize_read)) is
+//! already wired on `server` and `python`, and notify-only on `tauri`, but was
+//! historically **absent** on mobile: [`crate::VelesDatabase`] opened via
+//! `Database::open` and every read went through a *detached*
+//! [`VectorCollection`](velesdb_core::VectorCollection) leaf that has no
+//! observer reference. This module restores parity.
+//!
+//! Unlike the WASM sibling — whose single-threaded `Rc<RefCell<…>>` store
+//! cannot satisfy core's `Send + Sync` observer bound and therefore mirrors the
+//! contract with a wasm-local trait — mobile's [`crate::VelesDatabase`] is a
+//! `Send + Sync` UniFFI object. It can (and does) wire the **real** core
+//! [`DatabaseObserver`](velesdb_core::DatabaseObserver) seam directly, so a
+//! denying observer actually fails the read closed and an
+//! `AllowWithScope` observer narrows results — this is a genuine gate, not
+//! notify-only.
+//!
+//! # Foreign (Kotlin / Swift) observers
+//!
+//! [`MobileObserver`] is a UniFFI **foreign-implementable** trait
+//! (`with_foreign`): a Kotlin or Swift class can implement it and register it
+//! through
+//! [`VelesDatabase::open_with_observer`](crate::VelesDatabase::open_with_observer).
+//! [`ForeignObserver`] adapts such an instance to core's `DatabaseObserver` so
+//! every governed read consults it before touching the store.
+//!
+//! # Contract (inherited from core)
+//!
+//! - [`MobileObserver::on_query_request`] defaults to [`MobileAccessDecision::Allow`],
+//!   so an observer overriding nothing behaves exactly as no observer at all.
+//! - Implementations MUST NOT panic.
+//! - Denial flows through [`MobileAccessDecision::Deny`], **not** an error
+//!   channel: `Deny` carries the message surfaced to the caller (the read
+//!   returns that error and zero results), `Allow` executes unmodified.
+//! - With no observer registered the gate is a single `Option` check (the
+//!   zero-overhead contract of the core gate).
+//!
+//! # Follow-up
+//!
+//! Scope narrowing (`AccessDecision::AllowWithScope`) is honoured end-to-end for
+//! observers wired at the Rust level, but is **not** yet expressible from the
+//! foreign `MobileAccessDecision` enum (which carries only `Allow` / `Deny`),
+//! mirroring the WASM decision surface. Surfacing a foreign scope filter is an
+//! additive follow-up; adding a variant to `MobileAccessDecision` is
+//! non-breaking.
+
+use std::sync::Arc;
+
+use velesdb_core::{
+    AccessDecision as CoreAccessDecision, DatabaseObserver, Error as CoreError,
+    QueryAccessContext as CoreQueryAccessContext, QueryOperationKind as CoreQueryOperationKind,
+};
+
+/// The read operation being gated (UniFFI mirror of core's `QueryOperationKind`).
+#[derive(uniffi::Enum, Clone, Copy, Debug, PartialEq, Eq)]
+pub enum MobileQueryOperationKind {
+    /// Dense vector similarity search.
+    VectorSearch,
+    /// Full-text / BM25 search.
+    TextSearch,
+    /// Hybrid (dense + text/sparse) fused search.
+    HybridSearch,
+    /// Graph traversal (`VelesQL` MATCH).
+    GraphTraversal,
+    /// Relational-style `VelesQL` SELECT (incl. JOIN / aggregation).
+    Select,
+}
+
+impl From<CoreQueryOperationKind> for MobileQueryOperationKind {
+    fn from(kind: CoreQueryOperationKind) -> Self {
+        match kind {
+            CoreQueryOperationKind::VectorSearch => Self::VectorSearch,
+            CoreQueryOperationKind::TextSearch => Self::TextSearch,
+            CoreQueryOperationKind::HybridSearch => Self::HybridSearch,
+            CoreQueryOperationKind::GraphTraversal => Self::GraphTraversal,
+            CoreQueryOperationKind::Select => Self::Select,
+            // `QueryOperationKind` is `#[non_exhaustive]`; a future kind is
+            // reported to foreign observers as the generic relational read so
+            // the callback still fires and the gate still runs (advisory hint).
+            _ => Self::Select,
+        }
+    }
+}
+
+/// Read-time context handed to a foreign [`MobileObserver`].
+///
+/// Owned (not borrowed) because it crosses the UniFFI boundary. `principal` and
+/// `tenant_hint` are opaque, caller-supplied identity/tenant hints forwarded
+/// untouched — the gate never interprets them (they are only meaningful when a
+/// trusted embedder forwards a verified identity: the local-SDK trust boundary).
+#[derive(uniffi::Record, Clone, Debug)]
+pub struct MobileQueryContext {
+    /// Target collection name.
+    pub collection: String,
+    /// Which read path is executing.
+    pub operation: MobileQueryOperationKind,
+    /// Opaque caller-supplied principal hint, forwarded untouched.
+    pub principal: Option<String>,
+    /// Opaque caller-supplied tenant hint, forwarded untouched.
+    pub tenant_hint: Option<String>,
+}
+
+/// The control-plane decision returned by a foreign [`MobileObserver`].
+///
+/// Kept intentionally small for the FFI boundary: `Allow` executes the read
+/// unmodified, `Deny { reason }` aborts with `reason` and zero results. Scope
+/// narrowing (`AllowWithScope` in core) is deliberately **not** replicated at
+/// the foreign boundary yet — see the module-level follow-up note; adding a
+/// variant later is additive.
+#[derive(uniffi::Enum, Clone, Debug)]
+pub enum MobileAccessDecision {
+    /// Execute the read unmodified. Default decision.
+    Allow,
+    /// Abort the read and surface `reason` without producing results.
+    Deny {
+        /// Human-readable denial reason surfaced to the caller.
+        reason: String,
+    },
+}
+
+/// Foreign-implementable read-path observer (UniFFI callback interface).
+///
+/// A Kotlin/Swift class implements this trait and registers it via
+/// [`VelesDatabase::open_with_observer`](crate::VelesDatabase::open_with_observer).
+/// Every governed read routed through the database (dense / text / hybrid /
+/// sparse / multi-query search, `VelesQL` `SELECT` / `MATCH`) consults it before
+/// touching the store.
+#[uniffi::export(with_foreign)]
+pub trait MobileObserver: Send + Sync {
+    /// Called immediately before a read executes. Returns a
+    /// [`MobileAccessDecision`].
+    ///
+    /// Implementations MUST NOT panic. Denial is expressed through
+    /// [`MobileAccessDecision::Deny`], never by throwing.
+    fn on_query_request(&self, context: MobileQueryContext) -> MobileAccessDecision;
+}
+
+/// Adapts a foreign [`MobileObserver`] to core's [`DatabaseObserver`] so it can
+/// be injected through
+/// [`Database::open_with_observer`](velesdb_core::Database::open_with_observer).
+///
+/// Only the read-path hook (`on_query_request`) is bridged; the lifecycle hooks
+/// keep their no-op defaults (mobile has no event stream to forward them to).
+pub(crate) struct ForeignObserver {
+    inner: Arc<dyn MobileObserver>,
+}
+
+impl ForeignObserver {
+    /// Wraps a foreign observer as a core-compatible `DatabaseObserver`.
+    pub(crate) fn new(inner: Arc<dyn MobileObserver>) -> Self {
+        Self { inner }
+    }
+}
+
+impl DatabaseObserver for ForeignObserver {
+    fn on_query_request(
+        &self,
+        ctx: &CoreQueryAccessContext,
+    ) -> velesdb_core::Result<CoreAccessDecision> {
+        let context = MobileQueryContext {
+            collection: ctx.collection.to_string(),
+            operation: ctx.operation.into(),
+            principal: ctx.principal.map(str::to_string),
+            tenant_hint: ctx.tenant_hint.map(str::to_string),
+        };
+        // Denial is a decision value, not an internal-failure `Err`: map the
+        // foreign `Deny` to `AccessDecision::Deny` (mirrors `PyObserver`).
+        Ok(match self.inner.on_query_request(context) {
+            MobileAccessDecision::Allow => CoreAccessDecision::Allow,
+            MobileAccessDecision::Deny { reason } => CoreAccessDecision::Deny(CoreError::Query(
+                format!("read denied by observer: {reason}"),
+            )),
+        })
+    }
+}


### PR DESCRIPTION
## Summary

Closes the last gap in observer read-gate parity (audit **F-5.4**, #1392). The gate is wired on `server` + `python` and notify-only on `tauri`; the just-merged sibling PR added it to `wasm`. Mobile was the remaining hole: `crates/velesdb-mobile` opened via `Database::open` and read through a **detached** `VectorCollection` leaf with no observer reference, so no read passed through governance.

## Approach — real core gate (not notify-only)

Unlike the WASM sibling — whose single-threaded `Rc<RefCell<…>>` store cannot satisfy core's `Send + Sync` observer bound, forcing a wasm-local mirror trait — mobile's `VelesDatabase` **is** `Send + Sync`, so it wires the **real** core seam directly (same architecture as Python):

- `VelesDatabase.inner` is now `Arc<CoreDatabase>`. Each `VelesCollection` carries a clone of that handle + its name and routes every read back through the database gate instead of its detached leaf.
- New `VelesDatabase::open_with_observer` constructor.
- Dense / text / hybrid reads (incl. `*_with_filter`) route through `Database::gated_search`; sparse / multi-query / batch route through `Database::authorize_read`, AND-composing any observer scope filter where a filtered leaf exists and **failing closed** on id/score-only leaves. Collection `query()` now executes through the gated database facade, so the VelesQL read path is governed too (the detached `VectorCollection::execute_query` had no observer — same latent gap still present in the Python `Collection.query`, worth a follow-up there).

## Foreign (Kotlin / Swift) parity

`MobileObserver` is a UniFFI **foreign-implementable** trait (`#[uniffi::export(with_foreign)]`): Kotlin/Swift apps implement it and register it at open time. `MobileAccessDecision::Deny { reason }` fails the read closed with zero results; `Allow` runs unmodified. `ForeignObserver` adapts it to core's `DatabaseObserver`.

Both **Kotlin and Swift** bindings generate cleanly (`uniffi-bindgen generate --language {kotlin,swift}`), exposing `openWithObserver`, the `MobileObserver` interface, and the `MobileQueryContext` / `MobileAccessDecision` / `MobileQueryOperationKind` types.

## Follow-up (documented, additive)

Scope narrowing (`AccessDecision::AllowWithScope`) is honoured end-to-end for Rust-level observers, but the foreign `MobileAccessDecision` carries only `Allow`/`Deny` (mirrors the WASM decision surface). Surfacing a foreign scope filter is a non-breaking additive follow-up.

## Tests / gates

- New tests: allow (results returned + context observed), deny across vector / text / hybrid / VelesQL / sparse / multi-query, and the zero-overhead no-observer baseline.
- `cargo test -p velesdb-mobile -- --test-threads=1`: green (115 lib tests + integration).
- `cargo build -p velesdb-mobile` + Kotlin & Swift bindgen: green.
- `cargo clippy -p velesdb-mobile --all-targets -- -D warnings -D clippy::pedantic`: clean.
- `cargo fmt --all -- --check`: clean.