### PR TITLE
feat(core): make GraphFirst SCAN_CAP truncation observable (WO-D2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **GraphFirst full-scan truncation is now observable.** The filtered-vector
+  `GraphFirst` executor caps how many metadata matches it rescores at
+  `SCAN_CAP = 100_000` per query (#901 pathological-query guard). The cap is
+  unchanged, but when it actually bites (matches were still unvisited when the
+  scan stopped) the query now emits **one** structured `tracing::warn!` with
+  the collection name, the cap, the matches scored, and an upper bound on the
+  unvisited remainder — instead of silently degrading recall. Documented in
+  `docs/reference/KNOWN_LIMITATIONS.md` with symptoms and workarounds. (WO-D2.)
+
 ## [3.11.0] — 2026-07-14
 
 Chief-engineer audit resolution: closes every actionable finding from the

--- a/crates/velesdb-core/src/collection/search/query/mod.rs
+++ b/crates/velesdb-core/src/collection/search/query/mod.rs
@@ -77,6 +77,8 @@ pub mod pushdown;
 #[cfg(test)]
 mod pushdown_tests;
 mod query_pipeline;
+#[cfg(test)]
+mod scan_cap_observability_tests;
 pub mod score_fusion;
 #[cfg(test)]
 mod score_fusion_tests;

--- a/crates/velesdb-core/src/collection/search/query/scan_cap_observability_tests.rs
+++ b/crates/velesdb-core/src/collection/search/query/scan_cap_observability_tests.rs
@@ -1,0 +1,288 @@
+//! WO-D2: observability of the `SCAN_CAP` truncation in
+//! `scan_and_score_by_vector` (GraphFirst full-scan + exact rescoring).
+//!
+//! The cap itself (100 000, #901 pathological-query guard) is intentional and
+//! unchanged; these tests prove that when the cap actually bites (the scan
+//! stopped while candidate ids were still unvisited) a single structured
+//! `tracing::warn!` is emitted per query, and that the returned results stay
+//! correct and ordered. The cap is exercised at a small test value through
+//! `scan_and_score_by_vector_capped` instead of inserting 100k points.
+
+#![cfg(all(test, feature = "persistence"))]
+
+use crate::point::Point;
+use crate::test_fixtures::fixtures::{make_point_with_payload, setup_collection};
+use std::sync::{Arc, Mutex};
+
+// ============================================================================
+// Minimal warn-capturing tracing subscriber (no extra dev-dependency).
+// ============================================================================
+
+/// Captures WARN-and-worse events as flat `field=value` strings.
+#[derive(Default)]
+struct WarnSink {
+    events: Mutex<Vec<String>>,
+}
+
+struct FlattenVisitor<'a>(&'a mut String);
+
+impl tracing::field::Visit for FlattenVisitor<'_> {
+    fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+        use std::fmt::Write;
+        let _ = write!(self.0, "{}={:?} ", field.name(), value);
+    }
+}
+
+struct WarnCapture {
+    sink: Arc<WarnSink>,
+}
+
+impl tracing::Subscriber for WarnCapture {
+    fn enabled(&self, metadata: &tracing::Metadata<'_>) -> bool {
+        // In `tracing`, more severe levels compare LESS (ERROR < WARN < INFO).
+        *metadata.level() <= tracing::Level::WARN
+    }
+
+    fn new_span(&self, _: &tracing::span::Attributes<'_>) -> tracing::span::Id {
+        tracing::span::Id::from_u64(1)
+    }
+
+    fn record(&self, _: &tracing::span::Id, _: &tracing::span::Record<'_>) {}
+
+    fn record_follows_from(&self, _: &tracing::span::Id, _: &tracing::span::Id) {}
+
+    fn event(&self, event: &tracing::Event<'_>) {
+        let mut line = String::new();
+        event.record(&mut FlattenVisitor(&mut line));
+        self.sink
+            .events
+            .lock()
+            .expect("test: warn sink lock")
+            .push(line);
+    }
+
+    fn enter(&self, _: &tracing::span::Id) {}
+
+    fn exit(&self, _: &tracing::span::Id) {}
+}
+
+/// Runs `f` with a warn-capturing subscriber installed (thread-local) and
+/// returns the captured WARN+ events.
+fn capture_warns<T>(f: impl FnOnce() -> T) -> (T, Vec<String>) {
+    let sink = Arc::new(WarnSink::default());
+    let subscriber = WarnCapture { sink: sink.clone() };
+    let out = tracing::subscriber::with_default(subscriber, f);
+    let events = sink.events.lock().expect("test: warn sink lock").clone();
+    (out, events)
+}
+
+// ============================================================================
+// Fixture
+// ============================================================================
+
+/// 20 points, all matching `category = "tech"`. The second vector component
+/// DEcreases with the id, so cosine similarity to `[1,0,0,0]` strictly
+/// INcreases with the id: the globally best matches are the LAST inserted
+/// points. A truncating scan that only visits an id-ordered prefix therefore
+/// returns visibly different (worse) top-k than an exhaustive scan —
+/// making silent truncation detectable from the results themselves.
+fn setup_truncatable_fixture() -> (tempfile::TempDir, crate::collection::Collection) {
+    let (dir, col) = setup_collection(4);
+    let points: Vec<Point> = (1..=20u64)
+        .map(|i| {
+            #[allow(clippy::cast_precision_loss)]
+            let v = vec![1.0, (21 - i) as f32 * 0.05, 0.0, 0.0];
+            make_point_with_payload(i, v, serde_json::json!({"category": "tech"}))
+        })
+        .collect();
+    col.upsert(points).expect("test: upsert");
+    (dir, col)
+}
+
+fn tech_filter() -> crate::filter::Filter {
+    crate::filter::Filter::new(crate::filter::Condition::Eq {
+        field: "category".into(),
+        value: serde_json::json!("tech"),
+    })
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+/// GIVEN 20 matching points and a scan cap of 8
+/// WHEN scan_and_score_by_vector runs with the cap biting
+/// THEN exactly ONE structured warn is emitted for the whole query,
+///      carrying the collection name, the cap, and the unscanned estimate.
+#[test]
+fn test_scan_cap_truncation_emits_single_structured_warn() {
+    let (_dir, col) = setup_truncatable_fixture();
+    let filter = tech_filter();
+    let query = [1.0, 0.0, 0.0, 0.0];
+
+    let (results, warns) =
+        capture_warns(|| col.scan_and_score_by_vector_capped(&filter, &query, 5, 8));
+
+    assert_eq!(results.len(), 5, "limit must still be respected");
+    let cap_warns: Vec<&String> = warns.iter().filter(|w| w.contains("scan_cap=8")).collect();
+    assert_eq!(
+        cap_warns.len(),
+        1,
+        "exactly one truncation warn per query (not per candidate), got: {warns:?}"
+    );
+    let warn = cap_warns[0];
+    assert!(
+        warn.contains("collection="),
+        "warn must identify the collection: {warn}"
+    );
+    assert!(
+        warn.contains("matches_scored=8"),
+        "warn must report how many matches were scored: {warn}"
+    );
+    assert!(
+        warn.contains("unscanned_points=12"),
+        "warn must estimate the unvisited remainder (20 total - 8 visited): {warn}"
+    );
+}
+
+/// GIVEN the cap bites (only the first 8 of 20 matches are scored)
+/// THEN the results are exactly the correctly-ordered top-k of the points the
+///      scan actually visited — truncated, but never wrong or mis-ordered.
+#[test]
+fn test_scan_cap_truncated_results_stay_correct_and_ordered() {
+    let (_dir, col) = setup_truncatable_fixture();
+    let filter = tech_filter();
+    let query = [1.0f32, 0.0, 0.0, 0.0];
+    let (limit, cap) = (5usize, 8usize);
+
+    let (results, _warns) =
+        capture_warns(|| col.scan_and_score_by_vector_capped(&filter, &query, limit, cap));
+
+    // Ground truth: the exact same first-`cap` matches the scan visits,
+    // rescored by exact cosine and sorted best-first.
+    let visited = col.execute_scan_query(&filter, cap, None);
+    assert_eq!(visited.len(), cap, "fixture must saturate the cap");
+    let mut expected: Vec<(u64, f32)> = visited
+        .iter()
+        .map(|r| {
+            let score = crate::distance::DistanceMetric::Cosine
+                .calculate(&r.point.vector, &query)
+                .clamp(-1.0, 1.0);
+            (r.point.id, score)
+        })
+        .collect();
+    expected.sort_by(|a, b| b.1.total_cmp(&a.1));
+    expected.truncate(limit);
+
+    let got: Vec<(u64, f32)> = results.iter().map(|r| (r.point.id, r.score)).collect();
+    assert_eq!(
+        got.iter().map(|(id, _)| *id).collect::<Vec<_>>(),
+        expected.iter().map(|(id, _)| *id).collect::<Vec<_>>(),
+        "top-k must be the correctly ordered best of the scanned prefix"
+    );
+    for (g, e) in got.iter().zip(expected.iter()) {
+        assert!(
+            (g.1 - e.1).abs() < f32::EPSILON,
+            "scores must be the exact rescored similarity: got {g:?}, want {e:?}"
+        );
+    }
+    for w in results.windows(2) {
+        assert!(
+            w[0].score >= w[1].score,
+            "descending similarity order even under truncation"
+        );
+    }
+}
+
+/// GIVEN fewer matches than the cap (scan exhausts the collection)
+/// THEN no truncation warn is emitted — the guard only fires when it bites.
+#[test]
+fn test_scan_cap_not_hit_emits_no_warn() {
+    let (_dir, col) = setup_truncatable_fixture();
+    let filter = tech_filter();
+    let query = [1.0f32, 0.0, 0.0, 0.0];
+
+    // Cap (32) far above the 20 available matches: nothing is truncated.
+    let (results, warns) =
+        capture_warns(|| col.scan_and_score_by_vector_capped(&filter, &query, 5, 32));
+
+    assert_eq!(results.len(), 5);
+    // Global best matches: ids 20, 19, 18, 17, 16 (similarity increases with id).
+    assert_eq!(
+        results.iter().map(|r| r.point.id).collect::<Vec<_>>(),
+        vec![20, 19, 18, 17, 16],
+        "without truncation the global top-k is returned"
+    );
+    assert!(
+        !warns.iter().any(|w| w.contains("scan_cap=")),
+        "no truncation warn when the cap does not bite, got: {warns:?}"
+    );
+}
+
+/// GIVEN a filter matching NOTHING alongside a small cap
+/// THEN the exhausted (empty) scan emits no warn — an empty result set is
+///      not a truncation.
+#[test]
+fn test_scan_cap_no_matches_emits_no_warn() {
+    let (_dir, col) = setup_truncatable_fixture();
+    let filter = crate::filter::Filter::new(crate::filter::Condition::Eq {
+        field: "category".into(),
+        value: serde_json::json!("absent"),
+    });
+    let query = [1.0f32, 0.0, 0.0, 0.0];
+
+    let (results, warns) =
+        capture_warns(|| col.scan_and_score_by_vector_capped(&filter, &query, 5, 8));
+
+    assert!(results.is_empty());
+    assert!(
+        !warns.iter().any(|w| w.contains("scan_cap=")),
+        "no warn on an exhausted empty scan, got: {warns:?}"
+    );
+}
+
+/// The production wrapper keeps the documented 100_000 cap: on a small
+/// collection it never truncates and returns the exhaustive global top-k.
+#[test]
+fn test_public_wrapper_unchanged_no_warn_on_small_collection() {
+    let (_dir, col) = setup_truncatable_fixture();
+    let filter = tech_filter();
+    let query = [1.0f32, 0.0, 0.0, 0.0];
+
+    let (results, warns) = capture_warns(|| col.scan_and_score_by_vector(&filter, &query, 3));
+
+    assert_eq!(
+        results.iter().map(|r| r.point.id).collect::<Vec<_>>(),
+        vec![20, 19, 18],
+        "public path returns the exhaustive top-k"
+    );
+    assert!(
+        !warns.iter().any(|w| w.contains("scan_cap=")),
+        "public path must not warn below the cap, got: {warns:?}"
+    );
+}
+
+/// `execute_scan_query_tracked` primitive: reports the exact number of
+/// candidate ids left unvisited when the scan stops at `limit`, and zero
+/// when the scan exhausts the id set.
+#[test]
+fn test_execute_scan_query_tracked_reports_unscanned_ids() {
+    let (_dir, col) = setup_truncatable_fixture();
+    let filter = tech_filter();
+
+    // Stops after 8 matches: ids 9..=20 (12 points) were never visited.
+    let truncated = col.execute_scan_query_tracked(&filter, 8, None);
+    assert_eq!(truncated.results.len(), 8);
+    assert_eq!(
+        truncated.unscanned_ids, 12,
+        "12 of 20 ids must be reported unvisited"
+    );
+
+    // Limit above the match count: the scan exhausts every id.
+    let exhaustive = col.execute_scan_query_tracked(&filter, 64, None);
+    assert_eq!(exhaustive.results.len(), 20);
+    assert_eq!(
+        exhaustive.unscanned_ids, 0,
+        "exhausted scan leaves no remainder"
+    );
+}

--- a/crates/velesdb-core/src/collection/search/query/similarity_filter.rs
+++ b/crates/velesdb-core/src/collection/search/query/similarity_filter.rs
@@ -11,6 +11,22 @@ use crate::error::Result;
 use crate::point::{Point, SearchResult};
 use crate::storage::{PayloadStorage, VectorStorage};
 
+/// Outcome of a tracked metadata scan (WO-D2): the collected matches plus
+/// how many candidate ids were never visited because the scan already
+/// reached `limit`.
+///
+/// `unscanned_ids > 0` means the scan stopped early; the unvisited ids are
+/// an upper bound on the matches missed. Callers that use `limit` as a hard
+/// scan cap (e.g. [`Collection::scan_and_score_by_vector`]) rely on it to
+/// detect and report silent truncation.
+pub(crate) struct TrackedScan {
+    /// Matches collected before the scan stopped (`len() <= limit`).
+    pub(crate) results: Vec<SearchResult>,
+    /// Candidate ids left unvisited when the scan stopped at `limit`;
+    /// `0` when the scan exhausted the candidate set.
+    pub(crate) unscanned_ids: usize,
+}
+
 /// Inverted-similarity threshold bundle for the NOT-similarity scan.
 struct NotSimilarityThreshold {
     op: crate::velesql::CompareOp,
@@ -307,6 +323,22 @@ impl Collection {
         limit: usize,
         cond: Option<&crate::velesql::Condition>,
     ) -> Vec<SearchResult> {
+        self.execute_scan_query_tracked(filter, limit, cond).results
+    }
+
+    /// Like [`Self::execute_scan_query`], but also reports how many candidate
+    /// ids were left unvisited when the scan stopped at `limit` (WO-D2).
+    ///
+    /// Callers that use `limit` as a hard *scan cap* rather than a user limit
+    /// (e.g. [`Self::scan_and_score_by_vector`]) need `unscanned_ids` to
+    /// detect — and surface — silent truncation. Behavior and results are
+    /// byte-identical to `execute_scan_query`.
+    pub(crate) fn execute_scan_query_tracked(
+        &self,
+        filter: &crate::filter::Filter,
+        limit: usize,
+        cond: Option<&crate::velesql::Condition>,
+    ) -> TrackedScan {
         // Try index-accelerated scan: extract the first Eq condition and use
         // the secondary index to get candidate IDs, then post-filter.
         // The cost model (audit F-4.7, issue #1391) decides whether hydrating
@@ -330,6 +362,7 @@ impl Collection {
         } else {
             vector_ids
         };
+        let total_ids = ids.len();
 
         // Record rows actually visited as payload-mirror scan debt: once the
         // debt exceeds one full-scan-equivalent, the next metadata query
@@ -344,7 +377,13 @@ impl Collection {
             limit,
         );
         self.payload_mirror.add_scan_debt(scanned);
-        results
+        // `scanned` counts visited ids out of `total_ids`; on 64-bit targets
+        // the conversion is lossless (falls back to "all visited" otherwise).
+        let visited = usize::try_from(scanned).unwrap_or(total_ids);
+        TrackedScan {
+            results,
+            unscanned_ids: total_ids.saturating_sub(visited),
+        }
     }
 
     /// Shared scan body: iterates `ids`, hydrates each matching point, and
@@ -430,22 +469,28 @@ impl Collection {
         }
     }
 
-    /// Scans a pre-filtered set of candidate IDs with the full filter.
+    /// Scans a pre-filtered set of candidate IDs with the full filter,
+    /// tracking how many candidate ids were left unvisited at `limit`.
     fn scan_candidate_ids(
         &self,
         candidate_ids: &[u64],
         filter: &crate::filter::Filter,
         limit: usize,
-    ) -> Vec<SearchResult> {
+    ) -> TrackedScan {
         let payload_storage = self.payload_storage.read();
         let vector_storage = self.vector_storage.read();
-        Self::collect_filtered_scan(
+        let mut scanned: usize = 0;
+        let results = Self::collect_filtered_scan(
             &*payload_storage,
             &*vector_storage,
-            candidate_ids.iter().copied(),
+            candidate_ids.iter().copied().inspect(|_| scanned += 1),
             filter,
             limit,
-        )
+        );
+        TrackedScan {
+            results,
+            unscanned_ids: candidate_ids.len().saturating_sub(scanned),
+        }
     }
 
     /// Scans all metadata-matching points and rescores them by exact vector similarity.
@@ -482,13 +527,46 @@ impl Collection {
         // heap caps retained memory to O(limit). Results and ordering are
         // identical to the previous full sort + truncate.
         const SCAN_CAP: usize = 100_000;
+        self.scan_and_score_by_vector_capped(metadata_filter, query, limit, SCAN_CAP)
+    }
 
-        let metric = self.config().metric;
+    /// Cap-parameterized body of [`Self::scan_and_score_by_vector`] (WO-D2).
+    ///
+    /// Split out so tests can prove the truncation warning and result
+    /// correctness with a small cap instead of inserting 100k points.
+    /// Production callers always go through the public wrapper
+    /// (`SCAN_CAP = 100_000`); the truncation behavior itself is unchanged.
+    pub(crate) fn scan_and_score_by_vector_capped(
+        &self,
+        metadata_filter: &crate::filter::Filter,
+        query: &[f32],
+        limit: usize,
+        scan_cap: usize,
+    ) -> Vec<SearchResult> {
+        let config = self.config();
+        let metric = config.metric;
         let higher_is_better = metric.higher_is_better();
 
-        let candidates = self.execute_scan_query(metadata_filter, SCAN_CAP, None);
+        let scan = self.execute_scan_query_tracked(metadata_filter, scan_cap, None);
+        if scan.results.len() >= scan_cap && scan.unscanned_ids > 0 {
+            // Observability (WO-D2): the #901 pathological-query guard
+            // otherwise degrades recall silently once a collection outgrows
+            // the cap. Emitted ONCE per query — never per candidate. The
+            // remainder is an upper bound: unvisited ids may not all match.
+            tracing::warn!(
+                collection = %config.name,
+                scan_cap,
+                matches_scored = scan.results.len(),
+                unscanned_points = scan.unscanned_ids,
+                "vector full-scan truncated at scan cap: up to `unscanned_points` \
+                 remaining points were never scored, so recall may be degraded. \
+                 Narrow the metadata filter (ideally on an indexed field) so it \
+                 matches fewer points, or split the query."
+            );
+        }
+
         let mut topk = super::bounded_top_k::BoundedTopK::new(limit, higher_is_better);
-        for mut r in candidates {
+        for mut r in scan.results {
             // Exact distance computation using the stored vector.
             // Clamp is mandatory (SecDev) to guard against NaN from zero-norm vectors.
             r.score = metric.calculate(&r.point.vector, query).clamp(-1.0, 1.0);

--- a/docs/reference/KNOWN_LIMITATIONS.md
+++ b/docs/reference/KNOWN_LIMITATIONS.md
@@ -156,6 +156,37 @@ collection holds more than **5,000,000** vectors the query is **rejected** with
 guidance to add a selective metadata filter or use a positive `similarity()`
 predicate (which is index-accelerated).
 
+### GraphFirst full-scan cap (`SCAN_CAP = 100_000`) — truncation is now warned
+
+**Status**: intentional guard-rail, observable since WO-D2. Source:
+`crates/velesdb-core/src/collection/search/query/similarity_filter.rs`
+(`scan_and_score_by_vector`, `SCAN_CAP = 100_000`, #901).
+
+When the planner picks the `GraphFirst` strategy for a filtered vector query
+(highly selective metadata filter), the executor full-scans the metadata
+matches and rescores them by exact vector similarity. To bound the work of a
+pathological query, at most **100,000** metadata matches are scored per query.
+
+**When it bites**: the metadata filter matches more than 100,000 points (or the
+scan reaches 100,000 matches while unvisited points remain). Matches beyond the
+cap are never scored.
+
+**Symptom**: silently degraded recall — the returned top-k is the best of the
+first 100,000 scanned matches, not of all matches. Results stay correctly
+ordered and deduplicated; they may just miss better matches that live past the
+cap. Since WO-D2 the truncation is no longer silent: one structured
+`tracing::warn!` is emitted **per affected query** (never per candidate) with
+the collection name, the cap, the number of matches scored, and an upper bound
+on the unvisited remainder (`unscanned_points`).
+
+**Workaround**: narrow the metadata filter so it matches fewer points —
+ideally on a field with a secondary index (`create_index`), which lets the
+executor scan only the indexed candidate set — or split the query into more
+selective partitions at the application level. A broad filter with low
+selectivity is better served by the `VectorFirst` (ANN) strategy, which the
+cost-based optimizer picks automatically when statistics are available
+(`ANALYZE`).
+
 ### 9. Bounded query-result materialization
 
 **Status**: resolved (bounded memory). Source: `crates/velesdb-core/src/collection/search/query/` (set_operations, parallel_traversal, similarity_filter), `database/query_engine.rs`, `database/query_join.rs`.


### PR DESCRIPTION
## Problem

`scan_and_score_by_vector` (GraphFirst strategy for filtered vector queries) bounds its full scan at `SCAN_CAP = 100_000` metadata matches per query (#901 pathological-query guard). On a collection whose filter matches more points, recall was **silently** degraded: the top-k came from the first 100k scanned matches with no signal to the operator.

## Change (observability only — the cap itself is unchanged)

- **`execute_scan_query_tracked` / `TrackedScan`** — the scan now reports how many candidate ids were left unvisited when it stopped at `limit`, on **both** the full-scan path (reusing the existing scan-debt counter, zero extra iterator work) and the index-accelerated candidate path. `execute_scan_query` remains a thin wrapper; results and scan-debt accounting are byte-identical.
- **One structured `tracing::warn!` per affected query** (never per candidate) from `scan_and_score_by_vector`, with `collection`, `scan_cap`, `matches_scored`, and `unscanned_points` (upper bound on the unvisited remainder). The read path has no per-collection metrics family in-core (`OperationalMetrics` lives server-side), so per the work order a structured warn is used instead of new metrics infra.
- **Test seam** `scan_and_score_by_vector_capped(…, scan_cap)`: production callers keep the `SCAN_CAP = 100_000` wrapper; tests exercise cap=8 instead of inserting 100k points.
- **Docs**: new `KNOWN_LIMITATIONS.md` entry (when it bites, symptom, workarounds: indexed filter via `create_index`, query splitting, `ANALYZE` so the CBO picks VectorFirst) + CHANGELOG (Unreleased).

## Tests (TDD red → green)

The warn-assertion test was written first and verified failing before the warn was added. Warn capture uses a minimal in-test `tracing::Subscriber` (no new dev-dependency). 6 new tests:

- exactly ONE structured warn per query when the cap bites (fields asserted: collection, cap, matches_scored=8, unscanned_points=12)
- truncated results remain the exactly-ordered top-k of the scanned prefix (rescored cosine ground truth)
- no warn when the cap does not bite / on an exhausted empty scan
- public wrapper unchanged below the cap (global top-k, no warn)
- `execute_scan_query_tracked` reports the exact unvisited remainder and 0 on exhaustion

## Gates

- `cargo fmt --all --check` PASS
- `cargo clippy -p velesdb-core --all-targets --features persistence,gpu,update-check -- -D warnings -D clippy::pedantic` PASS
- `python3 scripts/check_prod_unwraps.py` PASS
- `python3 scripts/check-feature-claims.py` PASS (docs touched)
- `cargo test -p velesdb-core --lib --features persistence -- --test-threads=1`: **5288 passed, 0 failed, 14 ignored**

## Non-goals

- The cap value and truncation behavior are untouched.
- No other silent-truncation site exists for this pattern: `SCAN_CAP` has a single occurrence; `NOT_SIMILARITY_MAX_SCAN` already rejects loudly; `MAX_LIMIT`/`JOIN_ROW_CEILING`/group caps are documented limit clamps, not recall-degrading scan caps.