### PR TITLE
perf(hnsw): remove per-vector allocations from the batch insert path (WO-D4, PERF2+PERF3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **HNSW batch-insert path allocates less.** `allocate_batch` no longer
+  materializes one prepared-query buffer per vector: raw slices are pushed
+  directly into the contiguous storage, and (for the pre-normalized cosine
+  configuration) the pushed range is normalized in place under the same write
+  lock. Phase B (graph connection) re-derives the normalized query per node
+  from a per-thread scratch buffer, keeping at most one owned buffer alive per
+  rayon worker instead of one per batch element. Stored bytes are unchanged
+  for every metric (verbatim in production; normalized for pre-normalized
+  cosine), so recovery byte-comparisons and search scores are unaffected.
+  `DeltaBuffer::extend` now materializes incoming entries **before** taking
+  the write lock, so deferred-indexing batch copies no longer stall concurrent
+  brute-force searches. (WO-D4, PERF2+PERF3.)
+
 ### Added
 
 - **GraphFirst full-scan truncation is now observable.** The filtered-vector

--- a/crates/velesdb-core/src/collection/core/crud_indexing.rs
+++ b/crates/velesdb-core/src/collection/core/crud_indexing.rs
@@ -302,6 +302,14 @@ impl Collection {
         let count = vector_refs.len();
         #[cfg(feature = "persistence")]
         if let Some(ref di) = self.deferred_indexer {
+            // PERF3: the per-vector `to_vec()` copy is intrinsic to the
+            // deferred contract — `vector_refs` borrows the caller's data and
+            // does not outlive this call, while the deferred buffer must own
+            // the vectors until the next merge. `DeltaBuffer` stores one
+            // exact-sized `Vec<f32>` per entry (its per-entry ownership is
+            // what makes upsert-replace/remove O(1) data-move); the copies
+            // run OUTSIDE the buffer's write lock (see `DeltaBuffer::extend`)
+            // and the buffer is bounded by `merge_threshold` entries.
             di.extend(vector_refs.iter().map(|(id, v)| (*id, v.to_vec())));
             if di.should_merge() {
                 self.merge_deferred_batch(di);

--- a/crates/velesdb-core/src/collection/streaming/delta.rs
+++ b/crates/velesdb-core/src/collection/streaming/delta.rs
@@ -184,11 +184,25 @@ impl DeltaBuffer {
     /// No-op if the buffer is not in `ACTIVE` state. The check is performed
     /// **inside** the write lock to close the TOCTOU window between `is_active()`
     /// and the actual write.
+    ///
+    /// # Lock scope (PERF3)
+    ///
+    /// The iterator is materialized **before** taking the write lock: callers
+    /// pass lazy iterators whose items perform `O(N×D)` vector copies
+    /// (e.g. `to_vec()` in `bulk_index_or_defer`), and running those copies
+    /// under the write lock would stall every concurrent brute-force search
+    /// (read lock) for the duration of the batch copy. If the buffer turns
+    /// out to be inactive the materialized entries are dropped — a rare,
+    /// benign waste (the deferred path activates the buffer just before
+    /// extending).
     pub fn extend(&self, entries: impl IntoIterator<Item = (u64, Vec<f32>)>) {
+        let new_entries: Vec<(u64, Vec<f32>)> = entries.into_iter().collect();
+        if new_entries.is_empty() {
+            return;
+        }
+        let new_ids: HashSet<u64> = new_entries.iter().map(|(id, _)| *id).collect();
         let mut points = self.points.write();
         if self.state.load(Ordering::Acquire) == ACTIVE {
-            let new_entries: Vec<(u64, Vec<f32>)> = entries.into_iter().collect();
-            let new_ids: HashSet<u64> = new_entries.iter().map(|(id, _)| *id).collect();
             points.retain(|(existing_id, _)| !new_ids.contains(existing_id));
             points.extend(new_entries);
         }

--- a/crates/velesdb-core/src/index/hnsw/native/backend_adapter.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/backend_adapter.rs
@@ -142,7 +142,7 @@ impl<D: DistanceEngine + Send + Sync> NativeHnsw<D> {
 
         // Phase A: Batch allocate — stores vectors, assigns layers (single lock scopes)
         let vectors: Vec<&[f32]> = data.iter().map(|(v, _)| *v).collect();
-        let (assignments, processed) = self.allocate_batch(&vectors)?;
+        let assignments = self.allocate_batch(&vectors)?;
         if assignments.is_empty() {
             return Ok(Vec::new());
         }
@@ -150,7 +150,7 @@ impl<D: DistanceEngine + Send + Sync> NativeHnsw<D> {
         let first_node = assignments[0].0;
         let connect_start = self.bootstrap_entry_point(&assignments);
 
-        self.connect_batch_chunked(&assignments[connect_start..], &processed, first_node)?;
+        self.connect_batch_chunked(&assignments[connect_start..], &vectors, first_node)?;
         self.finalize_batch(&assignments, connect_start);
 
         // Invalidate GPU caches — topology and vectors both changed.
@@ -282,10 +282,15 @@ impl<D: DistanceEngine + Send + Sync> NativeHnsw<D> {
     /// - **Phase 1** (first 10%): full ef — builds a quality scaffold
     /// - **Phase 2** (10%-90%): reduced ef (0.5x) — graph is dense enough
     /// - **Phase 3** (last 10%): moderate ef (0.75x) — finalizes connections
+    ///
+    /// Takes the **raw** input vectors; each worker derives the prepared
+    /// (cosine-normalized) query on demand via `with_prepared_query`, which
+    /// reuses one thread-local scratch buffer per rayon worker instead of
+    /// holding one owned normalized buffer per batch element alive (PERF2).
     fn connect_batch_chunked(
         &self,
         assignments: &[(NodeId, usize)],
-        processed: &[std::borrow::Cow<'_, [f32]>],
+        vectors: &[&[f32]],
         first_node: NodeId,
     ) -> crate::error::Result<()> {
         let chunk_size = Self::compute_chunk_size(assignments.len());
@@ -309,11 +314,14 @@ impl<D: DistanceEngine + Send + Sync> NativeHnsw<D> {
             chunk.par_iter().enumerate().try_for_each(
                 |(i, (node_id, layer))| -> crate::error::Result<()> {
                     let batch_idx = node_id - first_node;
-                    let query: &[f32] = &processed[batch_idx];
-                    let current_ep = self.greedy_descent_upper_layers(query, *layer, ep_id);
-                    let ef = schedule.ef_for_position(chunk_offset + i);
-                    let stagnation = ef / 2;
-                    self.connect_node_with_ef(*node_id, query, *layer, current_ep, ef, stagnation);
+                    self.with_prepared_query(vectors[batch_idx], |query| {
+                        let current_ep = self.greedy_descent_upper_layers(query, *layer, ep_id);
+                        let ef = schedule.ef_for_position(chunk_offset + i);
+                        let stagnation = ef / 2;
+                        self.connect_node_with_ef(
+                            *node_id, query, *layer, current_ep, ef, stagnation,
+                        );
+                    });
                     Ok(())
                 },
             )?;

--- a/crates/velesdb-core/src/index/hnsw/native/backend_adapter_tests.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/backend_adapter_tests.rs
@@ -1043,3 +1043,222 @@ fn test_i2_batch_exceeding_initial_capacity() {
         "nearest neighbor of vector 0 should be itself"
     );
 }
+
+// =========================================================================
+// PERF2 (WO-D4): unit-insert vs batch-insert score parity + storage invariants
+//
+// The batch insert path must produce the same search scores as the unit
+// insert path and must preserve the stored-vector invariants:
+// - non-pre-normalized engines (production): vectors stored VERBATIM;
+// - pre-normalized cosine engine: vectors stored NORMALIZED.
+// These tests pin the behavior before and after the allocation refactor.
+// =========================================================================
+
+/// Deterministic pseudo-random vectors (no external RNG dependency).
+fn parity_vectors(n: usize, dim: usize) -> Vec<Vec<f32>> {
+    (0..n)
+        .map(|i| {
+            (0..dim)
+                .map(|j| ((i * dim + j) as f32).mul_add(0.37, 1.0).sin())
+                .collect()
+        })
+        .collect()
+}
+
+/// Asserts unit-insert and batch-insert indexes agree on search scores.
+///
+/// HNSW construction is order/concurrency sensitive, so result SETS may
+/// differ slightly between the two indexes. Scores for common ids must be
+/// exact (same engine, same stored bytes), the best distance must align,
+/// and top-k overlap must stay high.
+fn assert_unit_batch_parity<D: DistanceEngine + Send + Sync>(
+    unit: &NativeHnsw<D>,
+    batch: &NativeHnsw<D>,
+    queries: &[Vec<f32>],
+    k: usize,
+    ef: usize,
+) {
+    for (q_idx, query) in queries.iter().enumerate() {
+        let unit_results = unit.search(query, k, ef);
+        let batch_results = batch.search(query, k, ef);
+        assert_eq!(
+            unit_results.len(),
+            k,
+            "unit search must return k (q={q_idx})"
+        );
+        assert_eq!(
+            batch_results.len(),
+            k,
+            "batch search must return k (q={q_idx})"
+        );
+
+        assert!(
+            (unit_results[0].1 - batch_results[0].1).abs() < 1e-6,
+            "best distance must match between unit and batch insert (q={q_idx}): {} vs {}",
+            unit_results[0].1,
+            batch_results[0].1
+        );
+
+        // Scores for ids returned by both must be bit-comparable (same
+        // engine over the same stored bytes) — tolerance 1e-6.
+        let mut overlap = 0;
+        for &(id, d_batch) in &batch_results {
+            if let Some(&(_, d_unit)) = unit_results.iter().find(|(uid, _)| *uid == id) {
+                overlap += 1;
+                assert!(
+                    (d_unit - d_batch).abs() < 1e-6,
+                    "score mismatch for id {id} (q={q_idx}): unit={d_unit} batch={d_batch}"
+                );
+            }
+        }
+        assert!(
+            overlap * 10 >= k * 8,
+            "top-{k} overlap too low (q={q_idx}): {overlap}/{k}"
+        );
+    }
+}
+
+/// Returns the vector stored in the graph for `node_id`.
+fn stored_vector<D: DistanceEngine>(hnsw: &NativeHnsw<D>, node_id: usize) -> Vec<f32> {
+    let guard = hnsw.vectors.read();
+    let storage = guard.as_ref().expect("storage initialized");
+    storage.get(node_id).expect("node stored").to_vec()
+}
+
+#[test]
+fn test_unit_vs_batch_parity_euclidean() {
+    let dim = 32;
+    let n = 300; // > 100: exercises the batch (allocate_batch) path
+    let vectors = parity_vectors(n, dim);
+
+    let unit = NativeHnsw::new(
+        CachedSimdDistance::new(DistanceMetric::Euclidean, dim),
+        16,
+        100,
+        n,
+    );
+    for v in &vectors {
+        unit.insert(v).expect("unit insert");
+    }
+
+    let batch = NativeHnsw::new(
+        CachedSimdDistance::new(DistanceMetric::Euclidean, dim),
+        16,
+        100,
+        n,
+    );
+    let data: Vec<(&[f32], usize)> = vectors
+        .iter()
+        .enumerate()
+        .map(|(i, v)| (v.as_slice(), i))
+        .collect();
+    batch.parallel_insert(&data).expect("batch insert");
+    assert_eq!(batch.len(), n);
+
+    // Non-cosine: stored bytes must be VERBATIM input bytes.
+    for id in [0, n / 2, n - 1] {
+        assert_eq!(
+            stored_vector(&batch, id),
+            vectors[id],
+            "euclidean batch path must store vectors verbatim (id={id})"
+        );
+    }
+
+    let queries: Vec<Vec<f32>> = (0..5).map(|q| vectors[q * 37].clone()).collect();
+    assert_unit_batch_parity(&unit, &batch, &queries, 10, n);
+}
+
+#[test]
+fn test_unit_vs_batch_parity_cosine_production_engine() {
+    let dim = 32;
+    let n = 300;
+    let vectors = parity_vectors(n, dim);
+
+    // Production configuration: CachedSimdDistance::new — NOT pre-normalized.
+    let unit = NativeHnsw::new(
+        CachedSimdDistance::new(DistanceMetric::Cosine, dim),
+        16,
+        100,
+        n,
+    );
+    for v in &vectors {
+        unit.insert(v).expect("unit insert");
+    }
+
+    let batch = NativeHnsw::new(
+        CachedSimdDistance::new(DistanceMetric::Cosine, dim),
+        16,
+        100,
+        n,
+    );
+    let data: Vec<(&[f32], usize)> = vectors
+        .iter()
+        .enumerate()
+        .map(|(i, v)| (v.as_slice(), i))
+        .collect();
+    batch.parallel_insert(&data).expect("batch insert");
+    assert_eq!(batch.len(), n);
+
+    // Production cosine stores vectors VERBATIM (recovery pass 3 relies on
+    // byte-exact equality between graph storage and vector storage).
+    for id in [0, n / 2, n - 1] {
+        assert_eq!(
+            stored_vector(&batch, id),
+            vectors[id],
+            "production cosine batch path must store vectors verbatim (id={id})"
+        );
+    }
+
+    let queries: Vec<Vec<f32>> = (0..5).map(|q| vectors[q * 37].clone()).collect();
+    assert_unit_batch_parity(&unit, &batch, &queries, 10, n);
+}
+
+#[test]
+fn test_unit_vs_batch_parity_cosine_prenormalized_engine() {
+    let dim = 32;
+    let n = 300;
+    let vectors = parity_vectors(n, dim);
+
+    let unit = NativeHnsw::new(
+        CachedSimdDistance::new_prenormalized(DistanceMetric::Cosine, dim),
+        16,
+        100,
+        n,
+    );
+    for v in &vectors {
+        unit.insert(v).expect("unit insert");
+    }
+
+    let batch = NativeHnsw::new(
+        CachedSimdDistance::new_prenormalized(DistanceMetric::Cosine, dim),
+        16,
+        100,
+        n,
+    );
+    let data: Vec<(&[f32], usize)> = vectors
+        .iter()
+        .enumerate()
+        .map(|(i, v)| (v.as_slice(), i))
+        .collect();
+    batch.parallel_insert(&data).expect("batch insert");
+    assert_eq!(batch.len(), n);
+
+    // Pre-normalized cosine: the STORED vectors must be the normalized
+    // form (unit norm), byte-identical to what the unit-insert path stores.
+    for id in [0, n / 2, n - 1] {
+        let stored = stored_vector(&batch, id);
+        let norm: f32 = stored.iter().map(|x| x * x).sum::<f32>().sqrt();
+        assert!(
+            (norm - 1.0).abs() < 1e-5,
+            "pre-normalized cosine batch path must store unit-norm vectors (id={id}, norm={norm})"
+        );
+        assert_eq!(
+            stored,
+            stored_vector(&unit, id),
+            "batch and unit insert must store byte-identical normalized vectors (id={id})"
+        );
+    }
+
+    let queries: Vec<Vec<f32>> = (0..5).map(|q| vectors[q * 37].clone()).collect();
+    assert_unit_batch_parity(&unit, &batch, &queries, 10, n);
+}

--- a/crates/velesdb-core/src/index/hnsw/native/graph/insert.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/graph/insert.rs
@@ -4,12 +4,7 @@ use super::super::distance::DistanceEngine;
 use super::super::layer::{Layer, NodeId};
 use super::{NativeHnsw, NO_ENTRY_POINT};
 use crate::perf_optimizations::ContiguousVectors;
-use std::borrow::Cow;
 use std::sync::atomic::Ordering;
-
-/// Result of [`NativeHnsw::allocate_batch`]: `(NodeId, layer)` pairs and
-/// the pre-processed query vectors (normalized for cosine, borrowed otherwise).
-type BatchAllocation<'a> = (Vec<(NodeId, usize)>, Vec<Cow<'a, [f32]>>);
 
 impl<D: DistanceEngine> NativeHnsw<D> {
     /// Allocates vector storage if needed and pushes the vector, returning its node ID.
@@ -174,35 +169,44 @@ impl<D: DistanceEngine> NativeHnsw<D> {
 
     /// Batch-allocates vectors and assigns random layers.
     ///
-    /// Returns `(assignments, processed_queries)` where:
-    /// - `assignments`: `(NodeId, layer)` pairs for each vector
-    /// - `processed_queries`: normalized query vectors (reusable in Phase B)
+    /// Returns the `(NodeId, layer)` assignments for each vector, in input
+    /// order (`assignments[i]` corresponds to `vectors[i]`).
     ///
     /// This is Phase A of the two-phase batch insertion: all vectors are stored
     /// and layers expanded in single lock scopes. The caller is responsible for
     /// connecting nodes (Phase B) and updating `entry_point`/`count` (Phase C).
+    ///
+    /// # Allocation strategy (PERF2)
+    ///
+    /// Raw input slices are pushed directly into [`ContiguousVectors`]; for
+    /// the pre-normalized cosine configuration the pushed range is then
+    /// normalized **in place** inside the storage, under the same write lock
+    /// (see [`Self::bulk_push_vectors`]). This avoids materializing one owned
+    /// normalized buffer per vector (`Vec<Cow>` of N owned buffers held alive
+    /// for the whole batch). Phase B re-derives the normalized query per node
+    /// from a thread-local scratch (`with_prepared_query`), which is
+    /// bit-identical to the stored form (same `normalize_inplace_native`
+    /// kernel on the same input bits).
     ///
     /// # Lock Strategy (I2 optimization)
     ///
     /// The vector write lock is acquired in two separate scopes:
     /// 1. **Capacity reservation** — initializes storage and pre-grows the buffer
     ///    if needed. May trigger an expensive realloc+copy on the cold path.
-    /// 2. **Bulk push** — copies vectors into pre-reserved space. Guaranteed
-    ///    fast memcpy with no reallocation.
+    /// 2. **Bulk push** — copies vectors into pre-reserved space (guaranteed
+    ///    fast memcpy with no reallocation), then normalizes the pushed range
+    ///    in place for pre-normalized cosine.
     ///
     /// # Errors
     ///
     /// Returns an error if vector storage allocation fails.
-    pub(in crate::index::hnsw::native) fn allocate_batch<'a>(
+    pub(in crate::index::hnsw::native) fn allocate_batch(
         &self,
-        vectors: &[&'a [f32]],
-    ) -> crate::error::Result<BatchAllocation<'a>> {
+        vectors: &[&[f32]],
+    ) -> crate::error::Result<Vec<(NodeId, usize)>> {
         if vectors.is_empty() {
-            return Ok((Vec::new(), Vec::new()));
+            return Ok(Vec::new());
         }
-
-        let processed: Vec<Cow<'a, [f32]>> =
-            vectors.iter().map(|v| self.prepare_query(v)).collect();
 
         // Pre-expand layers before vectors (lock ordering safe: layers only)
         let current_len = self
@@ -213,16 +217,16 @@ impl<D: DistanceEngine> NativeHnsw<D> {
         self.pre_expand_layers(current_len + vectors.len());
 
         // Scope 1: Initialize storage and reserve capacity (may resize — cold path)
-        self.reserve_vector_capacity(&processed, vectors.len())?;
+        self.reserve_vector_capacity(vectors[0].len(), vectors.len())?;
 
         // Scope 2: Bulk push into pre-reserved space (fast memcpy — no resize)
-        let first_id = self.bulk_push_vectors(&processed)?;
+        let first_id = self.bulk_push_vectors(vectors)?;
 
         let assignments: Vec<(NodeId, usize)> = (0..vectors.len())
             .map(|i| (first_id + i, self.random_layer()))
             .collect();
 
-        Ok((assignments, processed))
+        Ok(assignments)
     }
 
     /// Initializes vector storage if needed and pre-reserves capacity.
@@ -230,15 +234,12 @@ impl<D: DistanceEngine> NativeHnsw<D> {
     /// Cold path: the write lock may be held during a buffer resize.
     fn reserve_vector_capacity(
         &self,
-        processed: &[Cow<'_, [f32]>],
+        dimension: usize,
         batch_size: usize,
     ) -> crate::error::Result<()> {
         let mut guard = self.vectors.write();
         if guard.is_none() {
-            *guard = Some(ContiguousVectors::new(
-                processed[0].len(),
-                batch_size.max(16),
-            )?);
+            *guard = Some(ContiguousVectors::new(dimension, batch_size.max(16))?);
         }
         let storage = guard.as_mut().ok_or_else(|| {
             crate::error::Error::Internal("Vector storage missing after init".to_string())
@@ -247,17 +248,35 @@ impl<D: DistanceEngine> NativeHnsw<D> {
         Ok(())
     }
 
-    /// Pushes all processed vectors into pre-reserved storage.
+    /// Pushes all raw vectors into pre-reserved storage, then normalizes the
+    /// pushed range in place for the pre-normalized cosine configuration.
     ///
-    /// Fast path: write lock held only for bulk memcpy, no reallocation.
-    fn bulk_push_vectors(&self, processed: &[Cow<'_, [f32]>]) -> crate::error::Result<NodeId> {
+    /// Fast path: write lock held only for bulk memcpy (plus, for cosine
+    /// pre-normalized, one in-place normalization pass), no reallocation.
+    ///
+    /// # Ordering invariant (PERF2)
+    ///
+    /// The in-place normalization runs under the **same** write lock as the
+    /// push, so no reader can ever observe a raw (un-normalized) cosine
+    /// vector: graph construction (Phase B) only starts after this method
+    /// returns, and any concurrent search takes the vectors read lock, which
+    /// is excluded while this write lock is held.
+    fn bulk_push_vectors(&self, vectors: &[&[f32]]) -> crate::error::Result<NodeId> {
         let mut guard = self.vectors.write();
         let storage = guard.as_mut().ok_or_else(|| {
             crate::error::Error::Internal("Vector storage missing after reserve".to_string())
         })?;
         let first = storage.len();
-        let slices: Vec<&[f32]> = processed.iter().map(AsRef::as_ref).collect();
-        storage.push_batch(&slices)?;
+        storage.push_batch(vectors)?;
+        if self.distance.is_pre_normalized()
+            && self.distance.metric() == crate::DistanceMetric::Cosine
+        {
+            for i in first..storage.len() {
+                if let Some(stored) = storage.get_mut(i) {
+                    crate::simd_native::normalize_inplace_native(stored);
+                }
+            }
+        }
         Ok(first)
     }
 

--- a/crates/velesdb-core/src/index/hnsw/native/graph/search.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/graph/search.rs
@@ -566,6 +566,33 @@ impl<D: DistanceEngine> NativeHnsw<D> {
         }
     }
 
+    /// Runs `f` on a prepared (cosine-normalized) view of `query`, recycling
+    /// the thread-local scratch buffer afterwards.
+    ///
+    /// For non-cosine (or non-pre-normalized) engines this is a zero-cost
+    /// pass-through of the raw slice. For the pre-normalized cosine engine
+    /// the query is normalized into the `QUERY_BUF` thread-local scratch,
+    /// which is returned to the pool after `f` completes — so a batch loop
+    /// calling this per element keeps at most **one** owned buffer alive per
+    /// thread, instead of one per element (PERF2).
+    ///
+    /// The normalized bits are identical to those produced by
+    /// [`Self::prepare_query`] and by the in-place storage normalization in
+    /// the batch insert path: `normalize_inplace_native` dispatches on the
+    /// global SIMD level and slice length only (unaligned loads), so the
+    /// same input bits always yield the same output bits.
+    #[inline]
+    pub(in crate::index::hnsw::native) fn with_prepared_query<R>(
+        &self,
+        query: &[f32],
+        f: impl FnOnce(&[f32]) -> R,
+    ) -> R {
+        let prepared = self.prepare_query(query);
+        let result = f(&prepared);
+        Self::recycle_cow(prepared);
+        result
+    }
+
     /// Returns a query buffer to the thread-local pool for reuse.
     ///
     /// Called after the prepared query is no longer needed. This avoids

--- a/crates/velesdb-core/src/perf_optimizations.rs
+++ b/crates/velesdb-core/src/perf_optimizations.rs
@@ -397,6 +397,35 @@ impl ContiguousVectors {
         Some(unsafe { std::slice::from_raw_parts(self.data.as_ptr().add(offset), self.dimension) })
     }
 
+    /// Gets a mutable vector by index.
+    ///
+    /// Used by the HNSW batch-insert path to normalize cosine vectors
+    /// in place after a raw `push_batch`, avoiding one owned intermediate
+    /// buffer per vector (PERF2). Requires `&mut self`, so callers must
+    /// hold the exclusive storage lock — no concurrent reader can observe
+    /// a partially normalized vector.
+    ///
+    /// # Returns
+    ///
+    /// Mutable slice to the vector data, or `None` if index is out of bounds.
+    #[inline]
+    #[must_use]
+    pub fn get_mut(&mut self, index: usize) -> Option<&mut [f32]> {
+        if index >= self.count {
+            return None;
+        }
+
+        let offset = index * self.dimension;
+        // SAFETY: Index is within bounds (checked against count, which is <= capacity)
+        // - Condition 1: index < count ensures access is within initialized range.
+        // - Condition 2: data is non-null per NonNull invariant.
+        // - Condition 3: `&mut self` guarantees exclusive access — no aliasing.
+        // SAFETY: In-place mutation of one vector slot in contiguous storage.
+        Some(unsafe {
+            std::slice::from_raw_parts_mut(self.data.as_ptr().add(offset), self.dimension)
+        })
+    }
+
     /// Gets a vector by index (unchecked).
     ///
     /// # Safety


### PR DESCRIPTION
## Summary

Reduces allocations on the HNSW batch-insert path (PERF2) and fixes the deferred-indexer copy scope (PERF3). No behavior change: stored bytes, search scores, and graph-construction distances are identical (parity tests added and verified green on base AND on this branch).

## PERF2 — `allocate_batch` / Phase B (`insert.rs`, `backend_adapter.rs`, `search.rs`, `perf_optimizations.rs`)

**Before:** `allocate_batch` collected `vectors.iter().map(prepare_query).collect::<Vec<Cow<[f32]>>>()`. For the **pre-normalized cosine** engine this materializes one owned normalized buffer per vector, all held alive across the whole Phase B (`n x dim x 4` bytes transient — e.g. ~600 MB for 100k x 1536), defeating the `QUERY_BUF` thread-local pool. `bulk_push_vectors` then collected a second `Vec<&[f32]>`.

**After:**
- Raw input slices are pushed directly via `push_batch` (no `Vec<Cow>`, no `Vec<&[f32]>` re-collect).
- For pre-normalized cosine only, the pushed range is normalized **in place** in `ContiguousVectors` (new `get_mut`) under the **same write lock** as the push.
- Phase B (`connect_batch_chunked`) takes the raw slices and derives the prepared query per node via the new `with_prepared_query` (= `prepare_query` + `recycle_cow`): at most **one** scratch buffer per rayon worker, reused across all nodes that worker connects.

### Invariant proof (as requested by the WO)

1. **No reader between push and normalization.** The in-place normalization runs under the same exclusive `vectors.write()` guard as `push_batch`. Phase B (construction distances) starts only after `allocate_batch` returns; concurrent searches take the vectors **read** lock, excluded while the write guard is held. The normalize-before-connection ordering is therefore strictly preserved.
2. **Engine expectations** (`native/distance.rs:141-147`): `is_pre_normalized()` is true only for `CachedSimdDistance::new_prenormalized` with `Cosine`. The **production** engine is `CachedSimdDistance::new` (non-pre-normalized — `new_prenormalized` has zero non-test callers), so in production `prepare_query` was already `Cow::Borrowed` for every metric and the graph stores vectors **verbatim** — this PR changes nothing for non-cosine metrics nor for production cosine storage.
3. **Stored bytes unchanged.** Production: verbatim before and after — recovery pass 3 (`collection/core/recovery.rs`, byte-exact compare) and `sidecar_removal_tests.rs` untouched and green (they run in the persistence lib suite). Pre-normalized cosine: stored vectors remain the **normalized** form; `normalize_inplace_native` dispatches on the global SIMD level and slice length only and uses unaligned loads, so normalizing in 64-byte-aligned storage produces bits identical to the scratch normalization used by Phase B and by the unit `insert()` path (pinned by the new byte-identity test).

### Honest sizing of the win

The pathological case (N owned buffers) only occurs with the pre-normalized cosine engine, which today has **no production callers** — production merely sheds the `Vec<Cow>` + `Vec<&[f32]>` intermediates (~48 B/vector, measured ~96-128 KiB per 2000-batch). The full fix (not just the pool/chunk fallback) was still cheap and low-risk, and it protects the pre-normalization path if it is ever wired into production.

### Measured (counting global allocator, `parallel_insert`, n=2000, dim=768, idle machine, release)

| Config | allocs before → after | transient bytes before → after | wall |
|---|---|---|---|
| cosine pre-normalized | 27 757 → 25 833 (−~n) | 20.4 MiB → 14.6 MiB (**−5.8 MiB = n·dim·4**) | 26 ms → 25 ms |
| cosine production | ~25 250 → ~25 250 | 14.1 MiB → 14.0 MiB (−~100 KiB) | 22 ms → 22 ms |
| euclidean | ~25 230 → ~25 260 | 14.1 MiB → 14.1 MiB | 19 ms → 19 ms |

No throughput regression; the win is allocation count (−n on the pre-normalized path) and peak transient memory (−n·dim·4 B held across Phase B).

## PERF3 — deferred indexer (`crud_indexing.rs:305`, `streaming/delta.rs`)

**Analysis:** the per-vector `to_vec()` is **intrinsic to the contract** — `vector_refs` borrows the caller's data and does not outlive the call, while `DeltaBuffer` must own the vectors until the next merge and stores one exact-sized `Vec<f32>` per entry (per-entry ownership is what keeps upsert-replace/`remove` free of data moves; the entry type is shared by the rebuild drain, ingester, brute-force search, and `types.rs` paths). Collapsing to a single contiguous block would require re-plumbing the entry type across all of those for a buffer bounded by `merge_threshold` (1024-4096 entries) — disproportionate, documented at the call site instead.

**What was fixed:** `DeltaBuffer::extend` used to materialize the caller's lazy iterator **inside** the points write lock — i.e. all O(N x D) `to_vec` copies ran while blocking every concurrent brute-force search (read lock). The iterator is now materialized (and the dedup id-set built) **before** the lock; the ACTIVE check stays inside the lock, so the documented TOCTOU contract is unchanged.

## Tests

- New: `test_unit_vs_batch_parity_{euclidean, cosine_production_engine, cosine_prenormalized_engine}` — unit-insert vs `parallel_insert` (n=300 > batch threshold): score parity ≤1e-6 on common ids, best-distance parity, ≥80% top-k overlap, **verbatim stored bytes** for non-pre-normalized engines, **unit-norm + byte-identical-to-unit-path stored bytes** for pre-normalized cosine. Verified green on `origin/develop` before the refactor, and green after.
- `cargo test -p velesdb-core --lib --features persistence -- --test-threads=1`: **5273 passed, 0 failed** (14 ignored).
- `cargo test -p velesdb-core --lib --no-default-features -- --test-threads=1`: **2174 passed, 0 failed** (13 ignored).
- Gates: `cargo fmt --check` OK; CI-exact clippy (`cargo clean -p velesdb-core` + `--workspace --all-targets --features persistence,gpu,update-check -D warnings -D clippy::pedantic`, toolchain 1.90) **exit 0**; `scripts/check_prod_unwraps.py` PASSED.