### PR TITLE
chore(hnsw): fix misleading brute-force lock comment + assert normalization invariant

### DIFF
--- a/crates/velesdb-core/src/index/hnsw/native/graph/insert.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/graph/insert.rs
@@ -272,7 +272,16 @@ impl<D: DistanceEngine> NativeHnsw<D> {
             && self.distance.metric() == crate::DistanceMetric::Cosine
         {
             for i in first..storage.len() {
-                if let Some(stored) = storage.get_mut(i) {
+                // `i` is in `first..storage.len()`, i.e. a slot we just pushed,
+                // so `get_mut` is always `Some`. Assert it: a `None` here would
+                // leave a raw (un-normalized) cosine vector in storage and
+                // silently corrupt every distance computed against it.
+                let stored = storage.get_mut(i);
+                debug_assert!(
+                    stored.is_some(),
+                    "just-pushed vector slot {i} missing during in-place normalization"
+                );
+                if let Some(stored) = stored {
                     crate::simd_native::normalize_inplace_native(stored);
                 }
             }

--- a/crates/velesdb-core/src/index/hnsw/native_index.rs
+++ b/crates/velesdb-core/src/index/hnsw/native_index.rs
@@ -353,12 +353,14 @@ impl NativeHnswIndex {
 
         let inner = self.inner.read();
 
-        // Snapshot the contiguous slab under a brief vectors read lock (one
-        // memcpy), releasing it BEFORE the rayon scan: parallel inserts
-        // acquire `vectors.write()` from inside rayon tasks, so parallel
-        // work under the vectors lock could park every worker on that write
-        // and deadlock the pool. Tombstoned slots (deleted/upserted vectors)
-        // have no reverse mapping and are skipped.
+        // Snapshot the contiguous slab into an owned buffer (one memcpy) so the
+        // rayon scan below iterates a private copy. The `inner` read lock is
+        // held for the whole scan (the closure calls `inner.compute_distance`),
+        // which is safe here: native inserts also run under `inner.read()` and
+        // mutate the graph through interior mutability, so there is no
+        // exclusive `inner.write()` this shared read could deadlock a rayon
+        // worker against. Tombstoned slots (deleted/upserted vectors) have no
+        // reverse mapping and are skipped by `mappings.get_id`.
         let (flat, dimension) = inner.with_contiguous_vectors(|vectors| {
             (vectors.as_flat_slice().to_vec(), vectors.dimension())
         });


### PR DESCRIPTION
## Quoi

Deux follow-ups **zéro-impact-runtime** issus de la revue de code haute intensité pré-release (delta develop vs main, Vague D). Aucun n'est un bug de correctness ; ce sont des clarifications d'invariants que la revue a signalées.

1. **`native_index.rs` `brute_force_search_parallel`** — le commentaire de concurrence était copié du sibling `HnswIndex::brute_force_search_rayon` : il affirmait relâcher le read-lock **avant** le scan rayon et référençait un verrou `vectors.write()` supprimé par la suppression du sidecar (PERF1, #1409). Le code tient en réalité `inner.read()` pendant tout le scan (`inner.compute_distance` dans la closure), ce qui est **sûr** ici car les inserts natifs opèrent aussi sous `inner.read()` via interior mutability — aucun writer exclusif contre lequel se bloquer. Commentaire réécrit pour décrire ce que le code fait vraiment.

2. **`insert.rs` `bulk_push_vectors`** — rend explicite l'invariant PERF2 « chaque slot fraîchement poussé se résout » via `debug_assert!`. Un `None` de `get_mut` laisserait silencieusement un vecteur cosine brut (non normalisé) en storage et corromprait toutes les distances calculées contre lui ; l'assert transforme cet invariant latent en invariant vérifié (debug).

## Pourquoi

§2.3 du programme pré-release : tout finding de la revue d'intégration devient une remédiation immédiate (pas de report). Le 3ᵉ finding (garde `debug_assert` sur `add_column` public) est un choix de design délibéré et documenté de la PR #1410, laissé tel quel.

## Vérifications

- `cargo fmt --all --check` PASS
- `cargo clippy -p velesdb-core --all-targets --features persistence,gpu,update-check -- -D warnings -D clippy::pedantic` PASS (toolchain 1.90, `cargo clean -p` avant)
- `check_prod_unwraps.py` PASS
- Aucun changement de comportement en release.