### PR TITLE
ci: trigger CI on Dockerfile/docker-compose changes (unblocks Docker-only PRs)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,9 @@ on:
       - 'deny.toml'
       - 'sonar-project.properties'
       - '.github/workflows/**'
+      - 'Dockerfile'
+      - '.dockerignore'
+      - 'docker-compose.yml'
   pull_request:
     branches: [main, develop]
     paths:
@@ -46,6 +49,9 @@ on:
       - 'deny.toml'
       - 'sonar-project.properties'
       - '.github/workflows/**'
+      - 'Dockerfile'
+      - '.dockerignore'
+      - 'docker-compose.yml'
   # Manual trigger so coverage can be refreshed on demand (e.g. after a
   # config-only commit to main that skipped the path-filtered CI, leaving the
   # Codacy coverage badge stale).


### PR DESCRIPTION
## Problème

`ci.yml` filtre les déclencheurs par `paths:` et **n'y liste aucun fichier Docker**. Conséquence : un PR ne touchant que le `Dockerfile` (typiquement les bumps d'image de base dependabot, ex. #1362) ne déclenche jamais le workflow → le check requis **`CI Success`** ne se poste jamais → le PR reste `BLOCKED` pour le merge indéfiniment. En prime, tout changement Docker partait jusqu'ici **sans aucune CI**.

## Fix

Ajout de `Dockerfile`, `.dockerignore` et `docker-compose.yml` aux `paths` des déclencheurs `push` **et** `pull_request`. Les changements de build conteneur exécutent désormais la CI complète et peuvent satisfaire le check requis comme n'importe quel autre changement.

## Effet attendu

- #1362 (dependabot rust 1.96→1.97-bookworm) devient mergeable après `update-branch` (le filtre `paths` matche désormais son `Dockerfile`).
- Les futurs changements Docker sont couverts par la CI.