### PR TITLE
hotfix(release): prebuilt wasm-pack to unblock npm publish (3.12.0)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -530,7 +530,12 @@ jobs:
 
       - name: Install wasm-pack
         if: matrix.package == 'wasm'
-        run: cargo install wasm-pack --locked
+        # Prebuilt binary — NOT `cargo install wasm-pack --locked`, whose own
+        # lockfile pins cargo-platform 0.3.3 (MSRV 1.91) and fails to compile
+        # under the pinned RUST_VERSION (1.90). Matches ci.yml's wasm job.
+        uses: taiki-e/install-action@43aecc8d72668fbcfe75c31400bc4f890f1c5853 # v2.83.2
+        with:
+          tool: wasm-pack
 
       - name: Build & Publish WASM
         if: matrix.package == 'wasm'


### PR DESCRIPTION
## Contexte

La release **3.12.0** est publiée sur crates.io, PyPI (tous wheels + intégrations), binaires 4 plateformes et GitHub Release. **Seuls 2 jobs npm ont échoué** : `Publish npm wasm` puis `Publish npm typescript-sdk` (cascade — il attend la publication du wasm).

## Cause racine

Régression exposée par le pin toolchain 1.90 (WO-D9) : le job wasm faisait `cargo install wasm-pack --locked`. Le lockfile **de wasm-pack** épingle `cargo-platform 0.3.3` (MSRV **1.91**) → échec de compilation sous `RUST_VERSION=1.90`. (Notre propre `Cargo.lock` épingle 0.3.2, mais `--locked` sur wasm-pack ignore le nôtre.)

## Fix

Installer wasm-pack depuis un **binaire pré-compilé** via `taiki-e/install-action` (SHA pinné v2.83.2), exactement comme le job wasm de `ci.yml`. Zéro compilation, insensible à la toolchain. La compilation du crate `velesdb-wasm` reste sous 1.90 avec notre `Cargo.lock` (cargo-platform 0.3.2) — inchangée.

## Suite

Une fois mergé sur main : re-déclenchement de `release.yml` en `workflow_dispatch` **npm uniquement** (version 3.12.0) pour publier les 2 paquets manquants, puis backmerge main→develop.